### PR TITLE
fix: smooth terminal transition + UI polish from testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 spa/node_modules/
 spa/dist/
+.playwright-mcp/

--- a/spa/src/components/TerminalView.tsx
+++ b/spa/src/components/TerminalView.tsx
@@ -47,8 +47,8 @@ export default function TerminalView({ wsUrl }: Props) {
       wsUrl,
       (data) => {
         term.write(new Uint8Array(data))
-        // Reveal on first data — terminal has rendered
-        reveal()
+        // Reveal shortly after first data — give tmux time to finish rendering
+        if (!revealed) setTimeout(reveal, 300)
       },
       () => term.write('\r\n\x1b[31m[disconnected]\x1b[0m\r\n'),
       () => {


### PR DESCRIPTION
## Summary

Testing session fixes from live browser testing:

- Delay terminal reveal 300ms after first data received (prevents seeing tmux mid-resize)
- Loading overlay with breathing "connecting..." animation  
- URL-encode session names in WebSocket URL (fixes spaces, CJK characters)
- Auto-discover existing tmux sessions on API list
- Terminal fills full viewport height
- Session buttons use cursor pointer + auto-focus terminal on reveal
- Brighten sidebar text for readability
- Add `.playwright-mcp/` to `.gitignore`

## Test plan
- [ ] Click sessions with spaces in name (e.g. "Ark Tower") — should connect
- [ ] Click sessions with CJK characters (e.g. "客服中心") — should connect  
- [ ] Session switch shows smooth transition (no flash of small terminal)
- [ ] Terminal fills full height immediately after reveal
- [ ] `go test -race ./...` passes
- [ ] `cd spa && pnpm vitest run` passes