### PR TITLE
fix: reset stream handoff state on term handoff, ensure history loads

### DIFF
--- a/internal/server/handoff_handler.go
+++ b/internal/server/handoff_handler.go
@@ -314,16 +314,21 @@ func (s *Server) runHandoffToTerm(sess store.Session, handoffID string) {
 	}
 	sessionID := current.CCSessionID
 
-	// Step 1.5: Pre-update mode to "term" before shutting down relay.
+	// Pre-update mode to "term" before shutting down relay.
 	// This prevents revertModeOnRelayDisconnect from firing a spurious
 	// "failed:relay disconnected" event during an intentional handoff.
+	// If later steps fail, the deferred rollback restores the original mode.
+	origMode := current.Mode
 	termMode := "term"
 	if err := s.store.UpdateSession(sess.ID, store.SessionUpdate{Mode: &termMode}); err != nil {
 		broadcast("failed:db pre-update error: " + err.Error())
 		return
 	}
+	rollbackMode := func() {
+		s.store.UpdateSession(sess.ID, store.SessionUpdate{Mode: &origMode})
+	}
 
-	// Step 2: Shut down relay
+	// Shut down relay
 	if s.bridge.HasRelay(sess.Name) {
 		broadcast("stopping-relay")
 		s.bridge.SubscriberToRelay(sess.Name, []byte(`{"type":"shutdown"}`))
@@ -335,12 +340,13 @@ func (s *Server) runHandoffToTerm(sess store.Session, handoffID string) {
 			time.Sleep(500 * time.Millisecond)
 		}
 		if s.bridge.HasRelay(sess.Name) {
+			rollbackMode()
 			broadcast("failed:relay did not disconnect")
 			return
 		}
 	}
 
-	// Step 3: Wait for shell
+	// Wait for shell
 	broadcast("waiting-shell")
 	shellDeadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(shellDeadline) {
@@ -350,19 +356,21 @@ func (s *Server) runHandoffToTerm(sess store.Session, handoffID string) {
 		time.Sleep(500 * time.Millisecond)
 	}
 	if s.detector.Detect(sess.Name) != detect.StatusNormal {
+		rollbackMode()
 		broadcast("failed:shell did not recover")
 		return
 	}
 
-	// Step 4: Launch interactive CC with --resume
+	// Launch interactive CC with --resume
 	broadcast("launching-cc")
 	resumeCmd := fmt.Sprintf("claude --resume %s", sessionID)
 	if err := s.tmux.SendKeys(sess.Name, resumeCmd); err != nil {
+		rollbackMode()
 		broadcast("failed:send-keys error: " + err.Error())
 		return
 	}
 
-	// Step 5: Verify CC started
+	// Verify CC started
 	ccDeadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(ccDeadline) {
 		st := s.detector.Detect(sess.Name)
@@ -373,11 +381,12 @@ func (s *Server) runHandoffToTerm(sess store.Session, handoffID string) {
 	}
 	finalSt := s.detector.Detect(sess.Name)
 	if finalSt != detect.StatusCCIdle && finalSt != detect.StatusCCRunning && finalSt != detect.StatusCCWaiting {
+		rollbackMode()
 		broadcast("failed:CC did not start")
 		return
 	}
 
-	// Step 6: Update DB (clear cc_session_id; mode already set to "term" in step 1.5)
+	// Clear cc_session_id (mode already set to "term" above)
 	emptyID := ""
 	if err := s.store.UpdateSession(sess.ID, store.SessionUpdate{
 		CCSessionID: &emptyID,

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -89,17 +89,16 @@ export default function App() {
                 // Stream/JSONL handoff — mark connected and load conversation history
                 useStreamStore.getState().setHandoffState(event.session, 'connected')
                 fetchHistory(daemonBase, sess.id).then((msgs) => {
-                  if (msgs.length > 0) {
-                    useStreamStore.getState().loadHistory(event.session, msgs)
-                  }
+                  useStreamStore.getState().loadHistory(event.session, msgs)
                 }).catch(() => { /* history fetch failed — non-critical */ })
               } else {
-                // Term handoff — reset to idle so stream page shows HandoffButton
+                // Term handoff — clear stale per-session state and reset to idle
+                useStreamStore.getState().clearSession(event.session)
                 useStreamStore.getState().setHandoffState(event.session, 'idle')
               }
             }).catch(() => {
-              // fetchSessions failed — fall back to connected
-              useStreamStore.getState().setHandoffState(event.session, 'connected')
+              // fetchSessions failed — fall back to idle (safe default)
+              useStreamStore.getState().setHandoffState(event.session, 'idle')
             })
           } else if (event.value.startsWith('failed')) {
             store.setHandoffState(event.session, 'disconnected')


### PR DESCRIPTION
## Summary

- **Daemon**: `runHandoffToTerm` 在關閉 relay 前先更新 DB mode 為 `term`（Step 1.5），防止 `revertModeOnRelayDisconnect` 誤觸 `"failed:relay disconnected"` 事件
- **SPA**: `handoff:connected` 事件處理改為先 await `fetchSessions` 取得最新 session mode，根據 mode 決定行為：
  - stream/jsonl → `setHandoffState('connected')` + `fetchHistory` 載入完整對話歷史
  - term → `setHandoffState('idle')` 讓 stream 頁面恢復到 HandoffButton 等待狀態

## 修復的問題

1. **Term→Stream handoff 不載入對話歷史**：原本 `fetchSessions` 沒有 await，直接用 stale session data 去 fetch history，現改為等待 fresh data 後再取歷史
2. **Stream→Term handoff 後 stream 頁面狀態錯誤**：`runHandoffToTerm` 完成後廣播 `"connected"`，但 SPA 不區分 mode 一律設 `handoffState='connected'`，導致 stream 頁面顯示對話 UI 而不是 HandoffButton。此外 relay 斷開時 `revertModeOnRelayDisconnect` 會誤觸 `"failed:relay disconnected"`

## Test plan

- [x] Go handoff tests pass (10/10)
- [x] SPA vitest pass (131/131)
- [ ] 手動測試：term→stream handoff 後確認歷史訊息顯示
- [ ] 手動測試：stream→term handoff 後切回 stream tab 確認顯示 HandoffButton
- [ ] 手動測試：stream→term→stream 來回切換確認狀態正確