### PR TITLE
fix: exit tmux copy-mode before handoff

### DIFF
--- a/internal/server/handoff_handler.go
+++ b/internal/server/handoff_handler.go
@@ -175,9 +175,11 @@ func (s *Server) runHandoff(sess store.Session, mode, command, handoffID, token 
 	}
 
 	// Prepare pane — exit tmux copy-mode (if active) and clear any partial
-	// input. Escape exits copy-mode, closes CC dialogs, and may interrupt a
-	// running tool (Step 3 handles the idle check regardless). C-u clears
-	// the input line. Both are safe no-ops in normal idle state.
+	// input. "send-keys -X cancel" exits copy-mode without sending keys to
+	// the underlying application (safe no-op if not in copy-mode).
+	// Escape closes CC dialogs and may interrupt a running tool (Step 3
+	// handles the idle check regardless). C-u clears the input line.
+	s.tmux.SendKeysRaw(target, "-X", "cancel") // exit copy-mode; ignore error if not in a mode
 	if err := s.tmux.SendKeysRaw(target, "Escape"); err != nil {
 		broadcast("failed:send Escape: " + err.Error())
 		return

--- a/internal/server/handoff_handler_test.go
+++ b/internal/server/handoff_handler_test.go
@@ -499,16 +499,19 @@ func TestHandoffSendsEscapeAndCuBeforeDetect(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	// Verify the first two raw key calls are Escape and C-u (pane prep)
+	// Verify the first three raw key calls: -X cancel (exit copy-mode), Escape, C-u
 	rawKeys := fakeTmux.RawKeysSent()
-	if len(rawKeys) < 2 {
-		t.Fatalf("expected at least 2 raw key calls, got %d", len(rawKeys))
+	if len(rawKeys) < 3 {
+		t.Fatalf("expected at least 3 raw key calls, got %d", len(rawKeys))
 	}
-	if len(rawKeys[0].Keys) == 0 || rawKeys[0].Keys[0] != "Escape" {
-		t.Errorf("first raw key should be Escape, got %v", rawKeys[0].Keys)
+	if len(rawKeys[0].Keys) < 2 || rawKeys[0].Keys[0] != "-X" || rawKeys[0].Keys[1] != "cancel" {
+		t.Errorf("first raw key should be [-X cancel], got %v", rawKeys[0].Keys)
 	}
-	if len(rawKeys[1].Keys) == 0 || rawKeys[1].Keys[0] != "C-u" {
-		t.Errorf("second raw key should be C-u, got %v", rawKeys[1].Keys)
+	if len(rawKeys[1].Keys) == 0 || rawKeys[1].Keys[0] != "Escape" {
+		t.Errorf("second raw key should be Escape, got %v", rawKeys[1].Keys)
+	}
+	if len(rawKeys[2].Keys) == 0 || rawKeys[2].Keys[0] != "C-u" {
+		t.Errorf("third raw key should be C-u, got %v", rawKeys[2].Keys)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Terminal 處於 tmux copy-mode（捲動瀏覽歷史）時，handoff to stream 無法正確啟動
- 原因：`Escape` 在 vi copy-mode 下不會退出 copy-mode（只是切換 vi normal mode）
- 修復：在 `Escape` 前加 `tmux send-keys -X cancel`，直接取消 copy-mode，不受 vi/emacs mode 影響，不送任何按鍵到底層應用

### 變更

- `handoff_handler.go`：pane prep 階段加 `SendKeysRaw(target, "-X", "cancel")`
- `handoff_handler_test.go`：更新 assertion 順序驗證三步驟（`-X cancel` → `Escape` → `C-u`）

## Test plan

- [x] `go test ./internal/...` 全部通過
- [x] `tmux send-keys -X cancel` 不在 copy-mode 時安全回傳 exit 1
- [ ] 實際測試：term 進入 copy-mode → 點 stream handoff → 驗證正確啟動