### PR TITLE
fix: handoff pane prep C-u→C-c and staged /status send

### DIFF
--- a/internal/server/handoff_handler.go
+++ b/internal/server/handoff_handler.go
@@ -174,18 +174,16 @@ func (s *Server) runHandoff(sess store.Session, mode, command, handoffID, token 
 		}
 	}
 
-	// Prepare pane — exit tmux copy-mode (if active) and clear any partial
-	// input. "send-keys -X cancel" exits copy-mode without sending keys to
-	// the underlying application (safe no-op if not in copy-mode).
-	// Escape closes CC dialogs and may interrupt a running tool (Step 3
-	// handles the idle check regardless). C-u clears the input line.
-	s.tmux.SendKeysRaw(target, "-X", "cancel") // exit copy-mode; ignore error if not in a mode
-	if err := s.tmux.SendKeysRaw(target, "Escape"); err != nil {
-		broadcast("failed:send Escape: " + err.Error())
-		return
-	}
-	s.tmux.SendKeysRaw(target, "C-u") // best-effort; Escape success means target exists
-	time.Sleep(200 * time.Millisecond)
+	// Prepare pane:
+	// 1. Exit tmux copy-mode (safe no-op if not in copy-mode)
+	// 2. Escape — close CC dialogs / cancel current operation
+	// 3. C-c — clear CC input box (C-u is undo in CC and exits on empty prompt)
+	s.tmux.SendKeysRaw(target, "-X", "cancel")
+	time.Sleep(500 * time.Millisecond)
+	s.tmux.SendKeysRaw(target, "Escape")
+	time.Sleep(500 * time.Millisecond)
+	s.tmux.SendKeysRaw(target, "C-c")
+	time.Sleep(500 * time.Millisecond)
 
 	// Step 2: Prerequisite — CC must be running
 	broadcast("detecting")
@@ -235,19 +233,27 @@ func (s *Server) runHandoff(sess store.Session, mode, command, handoffID, token 
 	}
 
 	// Step 4: Extract session ID + cwd via /status
-	// Send "/status" in literal mode (-l) first, then Enter separately after
-	// a short delay. CC needs time to recognize the slash command before Enter
-	// is pressed — sending text+Enter in one call can cause the AI to treat
-	// it as a skill invocation instead of a built-in command.
+	// Staged send: "/" first to trigger CC's slash-command menu, wait for
+	// the TUI to switch mode, then "status" + delay + Enter. This mirrors
+	// ccbot's approach for mode-switching commands and prevents CC's AI
+	// from intercepting "/status" as a skill invocation.
 	broadcast("extracting-id")
-	if err := s.tmux.SendKeysRaw(target, "-l", "/status"); err != nil {
+	if err := s.tmux.SendKeysRaw(target, "-l", "/"); err != nil {
 		if didManualResize {
 			s.tmux.ResizeWindowAuto(target)
 		}
-		broadcast("failed:send /status: " + err.Error())
+		broadcast("failed:send /: " + err.Error())
 		return
 	}
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(1 * time.Second)
+	if err := s.tmux.SendKeysRaw(target, "-l", "status"); err != nil {
+		if didManualResize {
+			s.tmux.ResizeWindowAuto(target)
+		}
+		broadcast("failed:send status: " + err.Error())
+		return
+	}
+	time.Sleep(500 * time.Millisecond)
 	if err := s.tmux.SendKeysRaw(target, "Enter"); err != nil {
 		if didManualResize {
 			s.tmux.ResizeWindowAuto(target)


### PR DESCRIPTION
## Summary

- **C-u → C-c**：CC 的 C-u 是 undo 功能，空 prompt 時會退出 CC，導致後續 slash command 無法被正確攔截。改用 C-c 清除輸入框，三步驟（cancel copy-mode → Escape → C-c）各間隔 500ms 讓 TUI settle
- **staged /status send**：CC 2.1.78 會把一次送出的 `/status`+Enter 當作 regular message 傳給 AI（[已知 bug #25226](https://github.com/anthropics/claude-code/issues/25226)）。改為分段送出：`/` → 等 1s 觸發 slash menu → `status` → 等 500ms → Enter

## Test plan

- [x] 手動測試 handoff to stream 成功
- [x] 確認 `/status` dialog 正確顯示並可 capture session ID
- [x] 確認 C-c 不會破壞後續 slash command 攔截