### PR TITLE
fix: delay ResizeWindowAuto to after browser resize

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -90,7 +90,12 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 		relay.OnStart = func() {
 			// Clear any manual window size (e.g. set by handoff or user) so
 			// tmux auto-resizes to match the browser viewport.
-			s.tmux.ResizeWindowAuto(name)
+			// Delay to let: (1) tmux register the client, (2) WS I/O start,
+			// (3) browser send its viewport resize — so -A sees the real size.
+			go func() {
+				time.Sleep(1200 * time.Millisecond)
+				s.tmux.ResizeWindowAuto(name)
+			}()
 		}
 	}
 	relay.HandleWebSocket(w, r)


### PR DESCRIPTION
## Summary

- `OnStart` 在 `pty.StartWithSize` 後立即執行，此時 tmux client 尚未註冊、瀏覽器尚未送出 viewport resize，`resize-window -A` 只看到 80x24 預設值
- 改為 background goroutine 延遲 1200ms 執行，等待 tmux client 註冊 + WS I/O 啟動 + 瀏覽器 resize 到達後再清除手動旗標

## Test plan

- [x] 手動驗證：重新整理頁面後 terminal 正確 resize