### PR TITLE
feat: terminal WS auto-reconnect with reconnecting overlay

### DIFF
--- a/spa/src/components/TerminalView.test.tsx
+++ b/spa/src/components/TerminalView.test.tsx
@@ -121,20 +121,22 @@ describe('TerminalView', () => {
     expect(overlay?.textContent).toContain('reconnecting...')
   })
 
-  it('hides reconnecting overlay on reconnect', () => {
+  it('hides reconnecting overlay on reconnect', async () => {
     const { container } = render(
       <TerminalView wsUrl="ws://localhost:7860/ws/terminal/test" />
     )
+    // Simulate initial connect + first data → wait for reveal (300ms + margin)
     act(() => capturedCallbacks.onOpen?.())
-    act(() => capturedCallbacks.onClose?.())
+    act(() => capturedCallbacks.onData?.(new ArrayBuffer(1)))
+    await act(() => new Promise((r) => setTimeout(r, 400)))
 
-    // Overlay should be visible
+    // Disconnect
+    act(() => capturedCallbacks.onClose?.())
     let overlay = container.querySelector('[data-testid="terminal-overlay"]')
     expect(overlay?.getAttribute('style')).toContain('opacity: 1')
 
-    // Simulate reconnect
+    // Reconnect — revealed=true so onOpen sets ready=true
     act(() => capturedCallbacks.onOpen?.())
-
     overlay = container.querySelector('[data-testid="terminal-overlay"]')
     expect(overlay?.getAttribute('style')).toContain('opacity: 0')
   })

--- a/spa/src/components/TerminalView.tsx
+++ b/spa/src/components/TerminalView.tsx
@@ -65,7 +65,9 @@ export default function TerminalView({ wsUrl, visible = true }: Props) {
       () => setDisconnected(true),
       () => {
         setDisconnected(false)
-        setReady(true)
+        // On reconnect, show terminal immediately (buffer already has content).
+        // On initial connect, let reveal() handle it after first data + 300ms.
+        if (revealed) setReady(true)
         fitAddon.fit()
         conn.resize(term.cols, term.rows)
       },

--- a/spa/src/lib/ws.test.ts
+++ b/spa/src/lib/ws.test.ts
@@ -144,7 +144,7 @@ describe('connectTerminal auto-reconnect', () => {
     expect(onClose).not.toHaveBeenCalled() // onClose not called on manual close
   })
 
-  it('does not reconnect if WS never opened (initial connect failure)', () => {
+  it('retries even if WS never opened (initial connect failure)', () => {
     connectTerminal('ws://test', vi.fn(), vi.fn())
     wsInstances[0].simulateClose() // never opened
 

--- a/spa/src/lib/ws.ts
+++ b/spa/src/lib/ws.ts
@@ -29,12 +29,10 @@ export function connectTerminal(
     ws.onclose = () => {
       if (closed) return // manual close — don't notify or reconnect
       onClose()
-      if (!closed) {
-        setTimeout(() => {
-          if (!closed) connect()
-        }, retryMs)
-        retryMs = Math.min(retryMs * 2, 30000)
-      }
+      setTimeout(() => {
+        if (!closed) connect()
+      }, retryMs)
+      retryMs = Math.min(retryMs * 2, 30000)
     }
   }
 


### PR DESCRIPTION
## Summary

- **WS 自動重連**：斷線後指數退避重連（1s→2s→4s...→30s cap），成功後 reset。手動 `close()` 不重連
- **Reconnecting 遮罩**：斷線時顯示 50% 透明 "reconnecting..." 呼吸動畫，重連後自動隱藏
- **移除 `[disconnected]` 文字注入**：不再寫紅色文字到 terminal，改用視覺遮罩

### 變更檔案

| 檔案 | 變更 |
|------|------|
| `spa/src/lib/ws.ts` | `connectTerminal` 加入自動重連邏輯 |
| `spa/src/lib/ws.test.ts` | 8 個新測試（退避、reset、cap、manual close） |
| `spa/src/components/TerminalView.tsx` | `disconnected` state + 半透明遮罩 |
| `spa/src/components/TerminalView.test.tsx` | 2 個新測試（斷線顯示/重連隱藏遮罩） |

## Test plan

- [x] `npx vitest run` 162/162 通過
- [x] TDD：所有測試先 RED 再 GREEN
- [ ] 實際測試：停止 daemon → 遮罩出現 → 重啟 daemon → 自動重連 → 遮罩消失