### PR TITLE
feat: Shift+Enter newline and IME duplicate input guard

### DIFF
--- a/spa/src/components/TerminalView.tsx
+++ b/spa/src/components/TerminalView.tsx
@@ -115,6 +115,7 @@ export default function TerminalView({ wsUrl, visible = true }: Props) {
       const isComposed = data.length > 1 && data.charCodeAt(0) !== 0x1b
       if (isComposed && data === lastComposedSent) return
       if (isComposed) lastComposedSent = data
+      else lastComposedSent = '' // reset on non-composed input (fixes #21)
 
       conn.send(data)
     })


### PR DESCRIPTION
## Summary

兩個 xterm.js 輸入問題修正：

### 1. Shift+Enter 換行
- 傳統 terminal 無法區分 Shift+Enter 和 Enter（都送 `\r`）
- 在 container 上用 capture phase `keydown` 攔截 Shift+Enter，改送 `\n`（line feed，同 Ctrl+J）
- CC 接受 `\n` 作為換行插入
- onData 中有 `shiftEnterHandled` flag 防止殘留 `\r` 漏過

### 2. CJK IME 重複輸入
- macOS 上按 Cmd（切換輸入法）時 xterm.js `_finalizeComposition` 提前送出文字，compositionend 又送一次
- 滑鼠點擊也會從 textarea 殘留內容觸發重複送出
- 用 `compositionstart` 重置追蹤器，onData 中比對 suppress 相同的多字元資料
- Escape sequences（方向鍵等）排除在追蹤外

### 其他
- 所有事件 listener 在 unmount 時正確 cleanup

## Test plan

- [x] `npx vitest run` 162/162 通過
- [x] Shift+Enter 在 CC 中正確插入換行（不送出）
- [x] 中文 IME 用 Enter 確認不重複
- [x] 中文 IME 用 Cmd+Space 切換不重複
- [x] 滑鼠點擊不觸發 IME 重複
- [x] 方向鍵連按正常運作