### PR TITLE
fix: remove redundant MetaStore write, log migration errors

### DIFF
--- a/cmd/tbox/main.go
+++ b/cmd/tbox/main.go
@@ -111,7 +111,9 @@ func runServe(args []string) {
 
 	// 11. Migrate legacy session data → meta.db (once, on startup; errors are non-fatal)
 	if tmuxSessions, err := tx.ListSessions(); err == nil {
-		meta.MigrateFromLegacy(st.DB(), tmuxSessions)
+		if err := meta.MigrateFromLegacy(st.DB(), tmuxSessions); err != nil {
+			log.Printf("migration warning: %v", err)
+		}
 	}
 
 	// 12. Start modules (session module resets stale modes in MetaStore)

--- a/internal/server/handoff_handler.go
+++ b/internal/server/handoff_handler.go
@@ -379,14 +379,11 @@ func (s *Server) runHandoff(sess handoffSession, mode, command, handoffID, token
 		if statusInfo.Cwd != "" {
 			metaUpdate.Cwd = &statusInfo.Cwd
 		}
-		// Ensure meta record exists before partial update
-		s.meta.SetMeta(sess.TmuxID, store.SessionMeta{
-			TmuxID:      sess.TmuxID,
+		if err := s.meta.SetMeta(sess.TmuxID, store.SessionMeta{
 			Mode:        mode,
 			CCSessionID: ccID,
 			Cwd:         statusInfo.Cwd,
-		})
-		if err := s.meta.UpdateMeta(sess.TmuxID, metaUpdate); err != nil {
+		}); err != nil {
 			broadcast("failed:meta update: " + err.Error())
 			return
 		}


### PR DESCRIPTION
## Summary
- handoff Step 8：`SetMeta`（upsert）後的 `UpdateMeta` 寫相同資料，移除冗餘的第二次 DB write
- `MigrateFromLegacy` 錯誤現在會 log 而非靜默丟棄

## Test plan
- [x] handoff 測試全過（含 TestHandoffResizesPaneTooSmall、TestHandoffSendsEscapeAndCcBeforeDetect）
- [x] `go build ./cmd/tbox/` 成功