### PR TITLE
feat: add Cmd+W close-tab shortcut

### DIFF
--- a/electron/keybindings.ts
+++ b/electron/keybindings.ts
@@ -23,6 +23,7 @@ const DEFAULT_KEYBINDINGS: readonly KeybindingDef[] = [
   { action: 'prev-tab', accelerator: 'CommandOrControl+Alt+Left', label: 'Previous Tab', menuCategory: 'Tab', menuGroup: 'tab-nav' },
   { action: 'next-tab', accelerator: 'CommandOrControl+Alt+Right', label: 'Next Tab', menuCategory: 'Tab', menuGroup: 'tab-nav' },
   { action: 'new-tab', accelerator: 'CommandOrControl+T', label: 'New Tab', menuCategory: 'Tab', menuGroup: 'tab-action' },
+  { action: 'close-tab', accelerator: 'CommandOrControl+W', label: 'Close Tab', menuCategory: 'Tab', menuGroup: 'tab-action' },
   { action: 'reopen-closed-tab', accelerator: 'CommandOrControl+Shift+T', label: 'Reopen Closed Tab', menuCategory: 'Tab', menuGroup: 'tab-action' },
   { action: 'open-settings', accelerator: 'CommandOrControl+,', label: 'Settings', menuCategory: 'App', menuGroup: 'app' },
   { action: 'open-history', accelerator: 'CommandOrControl+Y', label: 'History', menuCategory: 'View', menuGroup: 'view' },

--- a/spa/src/hooks/useShortcuts.test.ts
+++ b/spa/src/hooks/useShortcuts.test.ts
@@ -165,6 +165,29 @@ describe('useShortcuts', () => {
     })
   })
 
+  describe('close-tab', () => {
+    it('closes the active tab', () => {
+      const { fire } = mockElectronAPI()
+      const tabs = seedTabs(3)
+      useTabStore.getState().setActiveTab(tabs[1].id)
+      renderHook(() => useShortcuts())
+
+      fire('close-tab')
+      expect(useTabStore.getState().tabs[tabs[1].id]).toBeUndefined()
+    })
+
+    it('does not close a locked tab', () => {
+      const { fire } = mockElectronAPI()
+      const tabs = seedTabs(2)
+      useTabStore.getState().toggleLock(tabs[0].id)
+      useTabStore.getState().setActiveTab(tabs[0].id)
+      renderHook(() => useShortcuts())
+
+      fire('close-tab')
+      expect(useTabStore.getState().tabs[tabs[0].id]).toBeDefined()
+    })
+  })
+
   describe('new-tab', () => {
     it('creates a new tab and activates it', () => {
       const { fire } = mockElectronAPI()

--- a/spa/src/hooks/useShortcuts.ts
+++ b/spa/src/hooks/useShortcuts.ts
@@ -68,6 +68,19 @@ export function useShortcuts(): void {
         return
       }
 
+      if (action === 'close-tab') {
+        const { activeTabId, tabs } = tabState
+        if (!activeTabId) return
+        const tab = tabs[activeTabId]
+        if (!tab || tab.locked) return
+        const wsStore = useWorkspaceStore.getState()
+        useHistoryStore.getState().recordClose(tab, wsStore.findWorkspaceByTab(activeTabId)?.id)
+        const ws = wsStore.findWorkspaceByTab(activeTabId)
+        if (ws) wsStore.removeTabFromWorkspace(ws.id, activeTabId)
+        tabState.closeTab(activeTabId)
+        return
+      }
+
       if (action === 'new-tab') {
         const tab = createTab({ kind: 'new-tab' })
         tabState.addTab(tab)


### PR DESCRIPTION
## Summary

- 新增 `Cmd+W` / `Ctrl+W` 關閉當前 tab 快捷鍵
- 尊重 locked tab（不關閉）
- 關閉時記錄 history（可 Cmd+Shift+T 重開）

## Test plan

- [x] 19 useShortcuts tests pass (2 new)
- [ ] Manual: Cmd+W 關閉當前 tab
- [ ] Manual: locked tab 按 Cmd+W 無反應