### PR TITLE
fix: disable asar packing for dev update

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "build": {
     "appId": "dev.wake.tmux-box",
     "productName": "tmux-box",
+    "asar": false,
     "directories": {
       "output": "dist"
     },


### PR DESCRIPTION
## Summary

- `asar: false` in electron-builder config
- Dev update 需要替換 `out/main/` 和 `out/preload/`，asar 是唯讀的

## Test plan

- [ ] Build app, verify `Contents/Resources/app/` exists (not app.asar)
- [ ] Dev update 成功下載並替換