### PR TITLE
fix: align settings page text colors

### DIFF
--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -89,26 +89,26 @@ export function DevEnvironmentSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-sm font-medium text-text-primary">{t('settings.dev.title')}</h3>
-        <p className="text-xs text-text-muted mt-1">{t('settings.dev.desc')}</p>
+        <h2 className="text-lg text-text-primary">{t('settings.dev.title')}</h2>
+        <p className="text-xs text-text-secondary mb-6">{t('settings.dev.desc')}</p>
       </div>
 
       <div className="space-y-3">
         <div className="flex items-center justify-between">
           <span className="text-sm text-text-primary">{t('settings.dev.app_version')}</span>
-          <span className="text-xs text-text-muted font-mono">{appInfo?.version ?? '...'}</span>
+          <span className="text-xs text-text-secondary font-mono">{appInfo?.version ?? '...'}</span>
         </div>
         <div className="flex items-center justify-between">
           <span className="text-sm text-text-primary">{t('settings.dev.spa_hash')}</span>
           <div className="flex items-center gap-2">
-            <span className="text-xs text-text-muted font-mono">{appInfo?.spaHash ?? '...'}</span>
+            <span className="text-xs text-text-secondary font-mono">{appInfo?.spaHash ?? '...'}</span>
             {hasSPAUpdate && <span className="text-xs text-status-warning font-mono">→ {remoteInfo.spaHash}</span>}
           </div>
         </div>
         <div className="flex items-center justify-between">
           <span className="text-sm text-text-primary">{t('settings.dev.electron_hash')}</span>
           <div className="flex items-center gap-2">
-            <span className="text-xs text-text-muted font-mono">{appInfo?.electronHash ?? '...'}</span>
+            <span className="text-xs text-text-secondary font-mono">{appInfo?.electronHash ?? '...'}</span>
             {hasElectronUpdate && <span className="text-xs text-status-warning font-mono">→ {remoteInfo.electronHash}</span>}
           </div>
         </div>

--- a/spa/src/components/settings/ElectronSection.tsx
+++ b/spa/src/components/settings/ElectronSection.tsx
@@ -6,44 +6,44 @@ export function ElectronSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-sm font-medium text-text-primary">{t('settings.electron.title')}</h3>
-        <p className="text-xs text-text-muted mt-1">{t('settings.electron.desc')}</p>
+        <h2 className="text-lg text-text-primary">{t('settings.electron.title')}</h2>
+        <p className="text-xs text-text-secondary mb-6">{t('settings.electron.desc')}</p>
       </div>
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <div>
             <div className="text-sm text-text-primary">{t('settings.electron.idle_timeout.label')}</div>
-            <div className="text-xs text-text-muted">{t('settings.electron.idle_timeout.desc')}</div>
+            <div className="text-xs text-text-secondary">{t('settings.electron.idle_timeout.desc')}</div>
           </div>
           <div className="flex items-center gap-2">
             <input type="number" defaultValue={5} min={1} max={60}
               aria-label={t('settings.electron.idle_timeout.aria')}
               className="w-16 bg-surface-input border border-border-default rounded-md text-text-primary text-xs px-2 py-1 text-center focus:border-border-active focus:outline-none" />
-            <span className="text-xs text-text-muted">min</span>
+            <span className="text-xs text-text-secondary">min</span>
           </div>
         </div>
         <div className="flex items-center justify-between">
           <div>
             <div className="text-sm text-text-primary">{t('settings.electron.memory_limit.label')}</div>
-            <div className="text-xs text-text-muted">{t('settings.electron.memory_limit.desc')}</div>
+            <div className="text-xs text-text-secondary">{t('settings.electron.memory_limit.desc')}</div>
           </div>
           <div className="flex items-center gap-2">
             <input type="number" defaultValue={512} min={128} max={4096} step={128}
               aria-label={t('settings.electron.memory_limit.aria')}
               className="w-16 bg-surface-input border border-border-default rounded-md text-text-primary text-xs px-2 py-1 text-center focus:border-border-active focus:outline-none" />
-            <span className="text-xs text-text-muted">MB</span>
+            <span className="text-xs text-text-secondary">MB</span>
           </div>
         </div>
         <div className="flex items-center justify-between">
           <div>
             <div className="text-sm text-text-primary">{t('settings.electron.max_bg.label')}</div>
-            <div className="text-xs text-text-muted">{t('settings.electron.max_bg.desc')}</div>
+            <div className="text-xs text-text-secondary">{t('settings.electron.max_bg.desc')}</div>
           </div>
           <div className="flex items-center gap-2">
             <input type="number" defaultValue={3} min={0} max={20}
               aria-label={t('settings.electron.max_bg.aria')}
               className="w-16 bg-surface-input border border-border-default rounded-md text-text-primary text-xs px-2 py-1 text-center focus:border-border-active focus:outline-none" />
-            <span className="text-xs text-text-muted">views</span>
+            <span className="text-xs text-text-secondary">views</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Electron / Development 頁面的文字顏色與 Appearance 頁面不一致。

- 頁面標題：`text-sm font-medium` → `text-lg`
- 描述文字：`text-text-muted` → `text-text-secondary`
- 值欄位（Dev）：`text-text-muted` → `text-text-secondary`

## Test plan

- [x] 554 tests pass
- [ ] Visual: 三頁 Settings 文字顏色一致