### PR TITLE
fix: preserve settings section when switching tabs

### DIFF
--- a/spa/src/components/SettingsPage.test.tsx
+++ b/spa/src/components/SettingsPage.test.tsx
@@ -1,8 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { createElement, type ReactNode } from 'react'
-import { Router } from 'wouter'
-import { memoryLocation } from 'wouter/memory-location'
 import { SettingsPage } from './SettingsPage'
 import { registerSettingsSection, clearSettingsSectionRegistry } from '../lib/settings-section-registry'
 import { AppearanceSection } from './settings/AppearanceSection'
@@ -12,12 +9,6 @@ import type { Pane } from '../types/tab'
 const settingsPane: Pane = {
   id: 'pane-set',
   content: { kind: 'settings', scope: 'global' },
-}
-
-function createWrapper(mem: ReturnType<typeof memoryLocation>) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return createElement(Router, { hook: mem.hook, children })
-  }
 }
 
 describe('SettingsPage', () => {
@@ -30,36 +21,24 @@ describe('SettingsPage', () => {
   })
 
   it('renders sidebar and default appearance section', () => {
-    const mem = memoryLocation({ path: '/settings', record: true })
-    render(<SettingsPage pane={settingsPane} isActive />, { wrapper: createWrapper(mem) })
+    render(<SettingsPage pane={settingsPane} isActive />)
     expect(screen.getAllByText('Appearance').length).toBeGreaterThan(0)
     expect(screen.getByText('Terminal')).toBeTruthy()
     expect(screen.getByText('Visual preferences for the application')).toBeTruthy()
   })
 
   it('switches to terminal section on sidebar click', () => {
-    const mem = memoryLocation({ path: '/settings', record: true })
-    render(<SettingsPage pane={settingsPane} isActive />, { wrapper: createWrapper(mem) })
+    render(<SettingsPage pane={settingsPane} isActive />)
     fireEvent.click(screen.getByText('Terminal'))
     expect(screen.getByText('Terminal rendering and connection settings')).toBeTruthy()
   })
 
-  it('reads section from URL', () => {
-    const mem = memoryLocation({ path: '/settings/terminal', record: true })
-    render(<SettingsPage pane={settingsPane} isActive />, { wrapper: createWrapper(mem) })
-    expect(screen.getByText('Terminal rendering and connection settings')).toBeTruthy()
-  })
-
-  it('updates URL on section switch', () => {
-    const mem = memoryLocation({ path: '/settings', record: true })
-    render(<SettingsPage pane={settingsPane} isActive />, { wrapper: createWrapper(mem) })
+  it('preserves section across re-renders', () => {
+    const { rerender } = render(<SettingsPage pane={settingsPane} isActive />)
     fireEvent.click(screen.getByText('Terminal'))
-    expect(mem.history).toContain('/settings/terminal')
-  })
-
-  it('falls back to appearance for invalid section', () => {
-    const mem = memoryLocation({ path: '/settings/nonexistent', record: true })
-    render(<SettingsPage pane={settingsPane} isActive />, { wrapper: createWrapper(mem) })
-    expect(screen.getByText('Visual preferences for the application')).toBeTruthy()
+    expect(screen.getByText('Terminal rendering and connection settings')).toBeTruthy()
+    // Re-render (simulates tab switch back)
+    rerender(<SettingsPage pane={settingsPane} isActive />)
+    expect(screen.getByText('Terminal rendering and connection settings')).toBeTruthy()
   })
 })

--- a/spa/src/components/SettingsPage.tsx
+++ b/spa/src/components/SettingsPage.tsx
@@ -1,30 +1,20 @@
-import { useLocation } from 'wouter'
+import { useState } from 'react'
 import type { PaneRendererProps } from '../lib/pane-registry'
 import { getSettingsSections } from '../lib/settings-section-registry'
 import { SettingsSidebar } from './settings/SettingsSidebar'
 
-function parseSectionFromPath(path: string): string {
-  const segment = path.replace(/^\/settings\/?/, '').split('/')[0]
-  const validIds = getSettingsSections().filter((s) => s.component).map((s) => s.id)
-  if (validIds.includes(segment)) return segment
-  return validIds[0] ?? ''
-}
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function SettingsPage(_props: PaneRendererProps) {
-  const [location, setLocation] = useLocation()
-  const activeSection = parseSectionFromPath(location)
   const sections = getSettingsSections()
-
-  const handleSelectSection = (section: string) => {
-    setLocation(`/settings/${section}`)
-  }
+  const [activeSection, setActiveSection] = useState(
+    () => sections.find((s) => s.component)?.id ?? '',
+  )
 
   const ActiveComponent = sections.find((s) => s.id === activeSection)?.component
 
   return (
     <div className="flex h-full">
-      <SettingsSidebar activeSection={activeSection} onSelectSection={handleSelectSection} />
+      <SettingsSidebar activeSection={activeSection} onSelectSection={setActiveSection} />
       <div className="flex-1 overflow-y-auto p-6">
         {ActiveComponent && <ActiveComponent />}
       </div>


### PR DESCRIPTION
切換 tab 再回到 Settings 時不再跳回第一個 section。改用 component state 取代 URL-based routing。