### PR TITLE
feat: dev update auto-build — check/download 一致性 + 自動建置

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'electron-vite'
 import { resolve } from 'path'
 import { execSync } from 'child_process'
-import { readFileSync } from 'fs'
+import { readFileSync, writeFileSync, mkdirSync } from 'fs'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
@@ -21,6 +21,23 @@ function readVersion(): string {
   }
 }
 
+function buildInfoPlugin() {
+  return {
+    name: 'write-build-info',
+    closeBundle() {
+      const info = {
+        version: readVersion(),
+        spaHash: gitHash('spa/'),
+        electronHash: gitHash('electron/', 'electron.vite.config.ts'),
+        builtAt: new Date().toISOString(),
+      }
+      const outDir = resolve(__dirname, 'out')
+      mkdirSync(outDir, { recursive: true })
+      writeFileSync(resolve(outDir, '.build-info.json'), JSON.stringify(info, null, 2) + '\n')
+    },
+  }
+}
+
 const buildDefines = {
   __APP_VERSION__: JSON.stringify(readVersion()),
   __ELECTRON_HASH__: JSON.stringify(gitHash('electron/', 'electron.vite.config.ts')),
@@ -29,6 +46,7 @@ const buildDefines = {
 
 export default defineConfig({
   main: {
+    plugins: [buildInfoPlugin()],
     build: {
       outDir: 'out/main',
       rollupOptions: {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -112,6 +112,7 @@ app.whenReady().then(() => {
   if (getAppInfo().devUpdateEnabled) {
     const daemonUrl = 'http://100.64.0.2:7860'
     checkUpdate(daemonUrl).then((remote) => {
+      if (remote.building) return // build in progress, SPA will poll
       const local = getAppInfo()
       if (remote.electronHash !== local.electronHash || remote.spaHash !== local.spaHash) {
         for (const win of windowManager.getAllWindows()) {

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -19,6 +19,9 @@ export interface RemoteVersionInfo {
   version: string
   spaHash: string
   electronHash: string
+  source: { spaHash: string; electronHash: string }
+  building: boolean
+  buildError: string
 }
 
 export function getAppInfo(): AppInfo {

--- a/internal/module/dev/handler.go
+++ b/internal/module/dev/handler.go
@@ -11,17 +11,68 @@ import (
 	"strings"
 )
 
-type UpdateCheckResponse struct {
-	Version      string `json:"version"`
+type SourceHashes struct {
 	SPAHash      string `json:"spaHash"`
 	ElectronHash string `json:"electronHash"`
 }
 
+type UpdateCheckResponse struct {
+	Version      string       `json:"version"`
+	SPAHash      string       `json:"spaHash"`
+	ElectronHash string       `json:"electronHash"`
+	Source       SourceHashes `json:"source"`
+	Building     bool         `json:"building"`
+	BuildError   string       `json:"buildError"`
+}
+
+type BuildInfo struct {
+	Version      string `json:"version"`
+	SPAHash      string `json:"spaHash"`
+	ElectronHash string `json:"electronHash"`
+	BuiltAt      string `json:"builtAt"`
+}
+
+func (m *DevModule) readBuildInfo() BuildInfo {
+	path := filepath.Join(m.repoRoot, "out", ".build-info.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return BuildInfo{SPAHash: "unknown", ElectronHash: "unknown"}
+	}
+	var info BuildInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return BuildInfo{SPAHash: "unknown", ElectronHash: "unknown"}
+	}
+	return info
+}
+
 func (m *DevModule) handleCheck(w http.ResponseWriter, r *http.Request) {
+	build := m.readBuildInfo()
+	spaSource := m.hashFn("spa/")
+	electronSource := m.hashFn("electron/", "electron.vite.config.ts")
+
+	// Determine if source differs from build
+	sourceChanged := build.SPAHash != spaSource || build.ElectronHash != electronSource
+
+	m.mu.Lock()
+	if sourceChanged && !m.building {
+		m.building = true
+		m.buildError = ""
+		go m.runBuild()
+	}
+	building := m.building
+	buildError := m.buildError
+	m.mu.Unlock()
+
 	resp := UpdateCheckResponse{
 		Version:      m.readVersion(),
-		SPAHash:      m.hashFn("spa/"),
-		ElectronHash: m.hashFn("electron/", "electron.vite.config.ts"),
+		SPAHash:      build.SPAHash,
+		ElectronHash: build.ElectronHash,
+		Source: SourceHashes{
+			SPAHash:      spaSource,
+			ElectronHash: electronSource,
+		},
+		Building:   building,
+		BuildError: buildError,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)

--- a/internal/module/dev/handler.go
+++ b/internal/module/dev/handler.go
@@ -54,9 +54,12 @@ func (m *DevModule) handleCheck(w http.ResponseWriter, r *http.Request) {
 	sourceChanged := build.SPAHash != spaSource || build.ElectronHash != electronSource
 
 	m.mu.Lock()
-	if sourceChanged && !m.building {
+	failedSameSource := m.buildError != "" && m.lastFailedSPA == spaSource && m.lastFailedElectron == electronSource
+	if sourceChanged && !m.building && !failedSameSource {
 		m.building = true
 		m.buildError = ""
+		m.lastFailedSPA = spaSource
+		m.lastFailedElectron = electronSource
 		go m.runBuild()
 	}
 	building := m.building
@@ -79,6 +82,14 @@ func (m *DevModule) handleCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func (m *DevModule) handleDownload(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	building := m.building
+	m.mu.Unlock()
+	if building {
+		http.Error(w, "build in progress", http.StatusConflict)
+		return
+	}
+
 	outDir := filepath.Join(m.repoRoot, "out")
 	if _, err := os.Stat(outDir); os.IsNotExist(err) {
 		http.Error(w, "out/ directory not found", http.StatusNotFound)

--- a/internal/module/dev/handler_test.go
+++ b/internal/module/dev/handler_test.go
@@ -51,15 +51,38 @@ func TestHandleDownloadMissingOut(t *testing.T) {
 	}
 }
 
-func TestHandleCheck(t *testing.T) {
+func TestHandleCheck_WithBuildInfo(t *testing.T) {
 	dir := t.TempDir()
 	versionFile := filepath.Join(dir, "VERSION")
-	os.WriteFile(versionFile, []byte("1.0.0-alpha.21\n"), 0644)
+	os.WriteFile(versionFile, []byte("1.0.0-alpha.24\n"), 0644)
+
+	// Create .build-info.json with matching hashes
+	outDir := filepath.Join(dir, "out")
+	os.MkdirAll(outDir, 0755)
+	buildInfo := BuildInfo{
+		Version:      "1.0.0-alpha.24",
+		SPAHash:      "abc1234",
+		ElectronHash: "def5678",
+		BuiltAt:      "2026-03-29T12:00:00Z",
+	}
+	data, _ := json.Marshal(buildInfo)
+	os.WriteFile(filepath.Join(outDir, ".build-info.json"), data, 0644)
 
 	m := &DevModule{
 		repoRoot:    dir,
 		versionFile: versionFile,
 		hashFn:      func(paths ...string) string { return "abc1234" },
+		buildCmd:    func() error { return nil },
+	}
+
+	// hashFn returns "abc1234" for all paths; SPA build hash is "abc1234" — matches SPA source
+	// Electron build hash is "def5678" but hashFn returns "abc1234" — mismatch, but let's
+	// use a smarter hashFn to make both match
+	m.hashFn = func(paths ...string) string {
+		if len(paths) > 0 && paths[0] == "spa/" {
+			return "abc1234"
+		}
+		return "def5678"
 	}
 
 	req := httptest.NewRequest("GET", "/api/dev/update/check", nil)
@@ -74,13 +97,131 @@ func TestHandleCheck(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Version != "1.0.0-alpha.21" {
-		t.Errorf("version: want 1.0.0-alpha.21, got %s", resp.Version)
-	}
-	if resp.ElectronHash != "abc1234" {
-		t.Errorf("electronHash: want abc1234, got %s", resp.ElectronHash)
+
+	// Top-level hashes come from build info
+	if resp.Version != "1.0.0-alpha.24" {
+		t.Errorf("version: want 1.0.0-alpha.24, got %s", resp.Version)
 	}
 	if resp.SPAHash != "abc1234" {
 		t.Errorf("spaHash: want abc1234, got %s", resp.SPAHash)
+	}
+	if resp.ElectronHash != "def5678" {
+		t.Errorf("electronHash: want def5678, got %s", resp.ElectronHash)
+	}
+
+	// Source hashes come from hashFn
+	if resp.Source.SPAHash != "abc1234" {
+		t.Errorf("source.spaHash: want abc1234, got %s", resp.Source.SPAHash)
+	}
+	if resp.Source.ElectronHash != "def5678" {
+		t.Errorf("source.electronHash: want def5678, got %s", resp.Source.ElectronHash)
+	}
+
+	// All match → no build triggered
+	if resp.Building {
+		t.Error("building: want false, got true")
+	}
+	if resp.BuildError != "" {
+		t.Errorf("buildError: want empty, got %s", resp.BuildError)
+	}
+}
+
+func TestHandleCheck_NoBuildInfo(t *testing.T) {
+	dir := t.TempDir()
+	versionFile := filepath.Join(dir, "VERSION")
+	os.WriteFile(versionFile, []byte("1.0.0-alpha.24\n"), 0644)
+
+	// No .build-info.json — no out/ directory at all
+
+	m := &DevModule{
+		repoRoot:    dir,
+		versionFile: versionFile,
+		hashFn:      func(paths ...string) string { return "abc1234" },
+		buildCmd:    func() error { return nil },
+	}
+
+	req := httptest.NewRequest("GET", "/api/dev/update/check", nil)
+	w := httptest.NewRecorder()
+	m.handleCheck(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", w.Code)
+	}
+
+	var resp UpdateCheckResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// No build info → hashes are "unknown"
+	if resp.SPAHash != "unknown" {
+		t.Errorf("spaHash: want unknown, got %s", resp.SPAHash)
+	}
+	if resp.ElectronHash != "unknown" {
+		t.Errorf("electronHash: want unknown, got %s", resp.ElectronHash)
+	}
+
+	// Source ≠ "unknown" → build triggered
+	if !resp.Building {
+		t.Error("building: want true, got false")
+	}
+}
+
+func TestHandleCheck_StaleTriggersAutoBuild(t *testing.T) {
+	dir := t.TempDir()
+	versionFile := filepath.Join(dir, "VERSION")
+	os.WriteFile(versionFile, []byte("1.0.0-alpha.24\n"), 0644)
+
+	// Create .build-info.json with OLD hashes
+	outDir := filepath.Join(dir, "out")
+	os.MkdirAll(outDir, 0755)
+	buildInfo := BuildInfo{
+		Version:      "1.0.0-alpha.23",
+		SPAHash:      "old1111",
+		ElectronHash: "old2222",
+		BuiltAt:      "2026-03-28T12:00:00Z",
+	}
+	data, _ := json.Marshal(buildInfo)
+	os.WriteFile(filepath.Join(outDir, ".build-info.json"), data, 0644)
+
+	m := &DevModule{
+		repoRoot:    dir,
+		versionFile: versionFile,
+		hashFn:      func(paths ...string) string { return "new3333" },
+		buildCmd:    func() error { return nil },
+	}
+
+	req := httptest.NewRequest("GET", "/api/dev/update/check", nil)
+	w := httptest.NewRecorder()
+	m.handleCheck(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", w.Code)
+	}
+
+	var resp UpdateCheckResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Top-level hashes from build info (stale)
+	if resp.SPAHash != "old1111" {
+		t.Errorf("spaHash: want old1111, got %s", resp.SPAHash)
+	}
+	if resp.ElectronHash != "old2222" {
+		t.Errorf("electronHash: want old2222, got %s", resp.ElectronHash)
+	}
+
+	// Source hashes are new
+	if resp.Source.SPAHash != "new3333" {
+		t.Errorf("source.spaHash: want new3333, got %s", resp.Source.SPAHash)
+	}
+	if resp.Source.ElectronHash != "new3333" {
+		t.Errorf("source.electronHash: want new3333, got %s", resp.Source.ElectronHash)
+	}
+
+	// Stale → build triggered
+	if !resp.Building {
+		t.Error("building: want true, got false")
 	}
 }

--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -14,14 +14,16 @@ import (
 )
 
 type DevModule struct {
-	core        *core.Core
-	repoRoot    string
-	versionFile string
-	hashFn      func(paths ...string) string
-	mu          sync.Mutex
-	building    bool
-	buildError  string
-	buildCmd    func() error
+	core               *core.Core
+	repoRoot           string
+	versionFile        string
+	hashFn             func(paths ...string) string
+	mu                 sync.Mutex
+	building           bool
+	buildError         string
+	buildCmd           func() error
+	lastFailedSPA      string
+	lastFailedElectron string
 }
 
 func New(repoRoot string) *DevModule {
@@ -47,6 +49,10 @@ func (m *DevModule) Init(c *core.Core) error {
 }
 
 func (m *DevModule) runBuild() {
+	// Remove stale build info so a partial build doesn't leave source hashes
+	// that prevent re-triggering on next check
+	os.Remove(filepath.Join(m.repoRoot, "out", ".build-info.json"))
+
 	err := m.buildCmd()
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -56,6 +62,8 @@ func (m *DevModule) runBuild() {
 		log.Printf("[dev] build failed: %v", err)
 	} else {
 		m.buildError = ""
+		m.lastFailedSPA = ""
+		m.lastFailedElectron = ""
 		log.Println("[dev] build completed successfully")
 	}
 }

--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -69,7 +69,7 @@ func (m *DevModule) runBuild() {
 }
 
 func (m *DevModule) defaultBuild() error {
-	cmd := exec.Command("npx", "electron-vite", "build")
+	cmd := exec.Command("pnpm", "exec", "electron-vite", "build")
 	cmd.Dir = m.repoRoot
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/wake/tmux-box/internal/core"
 )
@@ -17,6 +18,10 @@ type DevModule struct {
 	repoRoot    string
 	versionFile string
 	hashFn      func(paths ...string) string
+	mu          sync.Mutex
+	building    bool
+	buildError  string
+	buildCmd    func() error
 }
 
 func New(repoRoot string) *DevModule {
@@ -34,6 +39,34 @@ func (m *DevModule) Init(c *core.Core) error {
 	m.core = c
 	if m.hashFn == nil {
 		m.hashFn = m.gitHash
+	}
+	if m.buildCmd == nil {
+		m.buildCmd = m.defaultBuild
+	}
+	return nil
+}
+
+func (m *DevModule) runBuild() {
+	err := m.buildCmd()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.building = false
+	if err != nil {
+		m.buildError = err.Error()
+		log.Printf("[dev] build failed: %v", err)
+	} else {
+		m.buildError = ""
+		log.Println("[dev] build completed successfully")
+	}
+}
+
+func (m *DevModule) defaultBuild() error {
+	cmd := exec.Command("npx", "electron-vite", "build")
+	cmd.Dir = m.repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("[dev] build output: %s", string(out))
+		return err
 	}
 	return nil
 }

--- a/spa/src/components/settings/DevEnvironmentSection.test.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.test.tsx
@@ -93,7 +93,7 @@ describe('DevEnvironmentSection', () => {
 
     // After poll, building is done — should show update_available
     await waitFor(() => {
-      expect(screen.getByText(/Update available|有可用更新/)).toBeTruthy()
+      expect(screen.getByText(/Update available|有新版本/)).toBeTruthy()
     })
   })
 

--- a/spa/src/components/settings/DevEnvironmentSection.test.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import { DevEnvironmentSection } from './DevEnvironmentSection'
 
 const mockGetAppInfo = vi.fn().mockResolvedValue({
@@ -9,22 +9,110 @@ const mockGetAppInfo = vi.fn().mockResolvedValue({
   devUpdateEnabled: true,
 })
 
+const mockCheckUpdate = vi.fn()
+const mockApplyUpdate = vi.fn()
+
 beforeEach(() => {
   vi.clearAllMocks()
   window.electronAPI = {
     ...window.electronAPI!,
     getAppInfo: mockGetAppInfo,
+    checkUpdate: mockCheckUpdate,
+    applyUpdate: mockApplyUpdate,
   } as any
 })
 
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 describe('DevEnvironmentSection', () => {
-  it('renders section title', () => {
+  it('renders section title', async () => {
+    mockCheckUpdate.mockResolvedValue({
+      version: '1.0.0-alpha.21',
+      spaHash: 'def5678',
+      electronHash: 'abc1234',
+      source: { spaHash: 'src111', electronHash: 'src222' },
+      building: false,
+      buildError: '',
+    })
+
     render(<DevEnvironmentSection />)
     expect(screen.getByText(/Development|開發環境/)).toBeTruthy()
   })
 
   it('calls getAppInfo on mount', async () => {
+    mockCheckUpdate.mockResolvedValue({
+      version: '1.0.0-alpha.21',
+      spaHash: 'def5678',
+      electronHash: 'abc1234',
+      source: { spaHash: 'src111', electronHash: 'src222' },
+      building: false,
+      buildError: '',
+    })
+
     render(<DevEnvironmentSection />)
     expect(mockGetAppInfo).toHaveBeenCalledOnce()
+  })
+
+  it('shows building status and polls', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    // First call: building in progress
+    mockCheckUpdate.mockResolvedValueOnce({
+      version: '1.0.0-alpha.21',
+      spaHash: 'def5678',
+      electronHash: 'abc1234',
+      source: { spaHash: 'src111', electronHash: 'src222' },
+      building: true,
+      buildError: '',
+    })
+    // Second call (poll): build done, new hashes
+    mockCheckUpdate.mockResolvedValueOnce({
+      version: '1.0.0-alpha.21',
+      spaHash: 'new5678',
+      electronHash: 'newabc1',
+      source: { spaHash: 'src333', electronHash: 'src444' },
+      building: false,
+      buildError: '',
+    })
+
+    await act(async () => {
+      render(<DevEnvironmentSection />)
+    })
+
+    // Wait for initial check to complete and show building status
+    await waitFor(() => {
+      expect(screen.getByText(/Building|建置中/)).toBeTruthy()
+    })
+
+    // Advance timer to trigger poll
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    // After poll, building is done — should show update_available
+    await waitFor(() => {
+      expect(screen.getByText(/Update available|有可用更新/)).toBeTruthy()
+    })
+  })
+
+  it('shows build error', async () => {
+    mockCheckUpdate.mockResolvedValue({
+      version: '1.0.0-alpha.21',
+      spaHash: 'def5678',
+      electronHash: 'abc1234',
+      source: { spaHash: 'src111', electronHash: 'src222' },
+      building: false,
+      buildError: 'exit code 1',
+    })
+
+    await act(async () => {
+      render(<DevEnvironmentSection />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('exit code 1')).toBeTruthy()
+    })
   })
 })

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useI18nStore } from '../../stores/useI18nStore'
 import { useHostStore } from '../../stores/useHostStore'
 
-type UpdateStatus = 'idle' | 'checking' | 'up_to_date' | 'update_available' | 'error'
+type UpdateStatus = 'idle' | 'checking' | 'building' | 'up_to_date' | 'update_available' | 'error'
 
 interface AppInfo {
   version: string
@@ -14,6 +14,9 @@ interface RemoteInfo {
   version: string
   spaHash: string
   electronHash: string
+  source: { spaHash: string; electronHash: string }
+  building: boolean
+  buildError: string
 }
 
 export function DevEnvironmentSection() {
@@ -28,24 +31,67 @@ export function DevEnvironmentSection() {
   const [updateStep, setUpdateStep] = useState<string | null>(null)
   const [updateError, setUpdateError] = useState<string | null>(null)
 
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+  }, [])
+
+  useEffect(() => () => stopPolling(), [stopPolling])
+
   useEffect(() => {
     window.electronAPI?.getAppInfo().then(setAppInfo)
   }, [])
 
-  const checkUpdate = useCallback(async () => {
-    setStatus('checking')
-    try {
-      const remote = await window.electronAPI!.checkUpdate(daemonBase)
+  const processCheckResult = useCallback(
+    (remote: RemoteInfo) => {
       setRemoteInfo(remote)
+      if (remote.buildError) {
+        setUpdateError(remote.buildError)
+        setStatus('error')
+        return
+      }
       if (remote.electronHash !== appInfo?.electronHash || remote.spaHash !== appInfo?.spaHash) {
         setStatus('update_available')
       } else {
         setStatus('up_to_date')
       }
+    },
+    [appInfo],
+  )
+
+  const checkUpdate = useCallback(async () => {
+    setStatus('checking')
+    setUpdateError(null)
+    try {
+      const remote = await window.electronAPI!.checkUpdate(daemonBase)
+      if (remote.building) {
+        setStatus('building')
+        if (!pollRef.current) {
+          pollRef.current = setInterval(async () => {
+            try {
+              const r = await window.electronAPI!.checkUpdate(daemonBase)
+              if (!r.building) {
+                stopPolling()
+                processCheckResult(r)
+              }
+            } catch {
+              stopPolling()
+              setStatus('error')
+            }
+          }, 3000)
+        }
+      } else {
+        stopPolling()
+        processCheckResult(remote)
+      }
     } catch {
       setStatus('error')
     }
-  }, [daemonBase, appInfo])
+  }, [daemonBase, stopPolling, processCheckResult])
 
   useEffect(() => {
     if (appInfo) checkUpdate()
@@ -81,6 +127,7 @@ export function DevEnvironmentSection() {
   const statusText: Record<UpdateStatus, string> = {
     idle: '',
     checking: t('settings.dev.status.checking'),
+    building: t('settings.dev.status.building'),
     up_to_date: t('settings.dev.status.up_to_date'),
     update_available: t('settings.dev.status.update_available'),
     error: t('settings.dev.status.error'),
@@ -115,8 +162,8 @@ export function DevEnvironmentSection() {
       </div>
 
       {status !== 'idle' && (
-        <div className={`text-sm ${status === 'error' ? 'text-status-error' : status === 'update_available' ? 'text-status-warning' : 'text-text-secondary'}`}>
-          {statusText[status]}
+        <div className={`text-sm ${status === 'error' ? 'text-status-error' : status === 'building' ? 'text-accent' : status === 'update_available' ? 'text-status-warning' : 'text-text-secondary'}`}>
+          {status === 'error' && updateError ? updateError : statusText[status]}
         </div>
       )}
 
@@ -126,16 +173,10 @@ export function DevEnvironmentSection() {
         </div>
       )}
 
-      {updateError && (
-        <div className="text-sm text-status-error">
-          Error: {updateError}
-        </div>
-      )}
-
       <div className="flex gap-2">
         <button
           onClick={checkUpdate}
-          disabled={!appInfo || status === 'checking'}
+          disabled={!appInfo || status === 'checking' || status === 'building'}
           className="px-3 py-1.5 text-xs rounded-md bg-surface-input border border-border-default text-text-primary hover:bg-surface-hover disabled:opacity-50 cursor-pointer disabled:cursor-default"
         >
           {t('settings.dev.btn.check')}

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -10,14 +10,7 @@ interface AppInfo {
   spaHash: string
 }
 
-interface RemoteInfo {
-  version: string
-  spaHash: string
-  electronHash: string
-  source: { spaHash: string; electronHash: string }
-  building: boolean
-  buildError: string
-}
+type RemoteInfo = Awaited<ReturnType<NonNullable<typeof window.electronAPI>['checkUpdate']>>
 
 export function DevEnvironmentSection() {
   const t = useI18nStore((s) => s.t)

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -180,6 +180,7 @@
   "settings.dev.status.checking": "Checking...",
   "settings.dev.status.up_to_date": "Up to date",
   "settings.dev.status.update_available": "Update available",
+  "settings.dev.status.building": "Building…",
   "settings.dev.status.error": "Check failed",
   "settings.dev.btn.check": "Check for Updates",
   "settings.dev.btn.update_app": "Update App",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -180,6 +180,7 @@
   "settings.dev.status.checking": "檢查中...",
   "settings.dev.status.up_to_date": "已是最新",
   "settings.dev.status.update_available": "有新版本",
+  "settings.dev.status.building": "建置中…",
   "settings.dev.status.error": "檢查失敗",
   "settings.dev.btn.check": "檢查更新",
   "settings.dev.btn.update_app": "更新 App",

--- a/spa/src/types/electron.d.ts
+++ b/spa/src/types/electron.d.ts
@@ -32,6 +32,15 @@ interface ElectronUpdateResult {
   message: string
 }
 
+interface ElectronRemoteVersionInfo {
+  version: string
+  spaHash: string
+  electronHash: string
+  source: { spaHash: string; electronHash: string }
+  building: boolean
+  buildError: string
+}
+
 interface Window {
   electronAPI?: {
     tearOffTab: (tabJson: string) => Promise<void>
@@ -58,7 +67,7 @@ interface Window {
 
     // Dev Update
     getAppInfo: () => Promise<ElectronAppInfo>
-    checkUpdate: (daemonUrl: string) => Promise<{ version: string; spaHash: string; electronHash: string; source: { spaHash: string; electronHash: string }; building: boolean; buildError: string }>
+    checkUpdate: (daemonUrl: string) => Promise<ElectronRemoteVersionInfo>
     applyUpdate: (daemonUrl: string) => Promise<ElectronUpdateResult>
     onUpdateProgress: (callback: (step: string) => void) => () => void
   }

--- a/spa/src/types/electron.d.ts
+++ b/spa/src/types/electron.d.ts
@@ -58,7 +58,7 @@ interface Window {
 
     // Dev Update
     getAppInfo: () => Promise<ElectronAppInfo>
-    checkUpdate: (daemonUrl: string) => Promise<{ version: string; spaHash: string; electronHash: string }>
+    checkUpdate: (daemonUrl: string) => Promise<{ version: string; spaHash: string; electronHash: string; source: { spaHash: string; electronHash: string }; building: boolean; buildError: string }>
     applyUpdate: (daemonUrl: string) => Promise<ElectronUpdateResult>
     onUpdateProgress: (callback: (step: string) => void) => () => void
   }


### PR DESCRIPTION
## Summary

- `electron.vite.config.ts` build 完成後寫 `out/.build-info.json`（version + hash + timestamp）
- Daemon `check` 端點改讀 `.build-info.json` 作為 build hash（取代 git hash），消除 check/download 來源不對稱
- Source ≠ build 時 daemon 背景自動觸發 `electron-vite build`，回傳 `building: true`
- SPA DevEnvironmentSection 顯示 "Building…" 並每 3 秒 poll，完成後自動比對 + 顯示更新狀態
- 新增 `buildError` 欄位處理 build 失敗

Closes #78

## Test plan

- [ ] Go tests: `go test ./internal/module/dev/ -v` — 5/5 PASS
- [ ] SPA tests: `cd spa && npx vitest run` — 559/560 PASS（1 pre-existing #95）
- [ ] 在 Mini 修改 SPA 代碼 → daemon check 自動偵測 stale → 背景 build → Air 端顯示 "Building…" → 完成後顯示 "Update available"
- [ ] 點 Update App → 版本一致 → 不再無限循環