### PR TITLE
fix: agent hook 狀態依子類別正確判斷

### DIFF
--- a/cmd/tbox/setup.go
+++ b/cmd/tbox/setup.go
@@ -13,6 +13,7 @@ var hookEvents = []string{
 	"SessionStart",
 	"UserPromptSubmit",
 	"Stop",
+	"StopFailure",
 	"Notification",
 	"PermissionRequest",
 	"SessionEnd",

--- a/docs/cc-hook-event-reference.md
+++ b/docs/cc-hook-event-reference.md
@@ -1,0 +1,138 @@
+# CC Hook Event Reference
+
+> Claude Code hooks 事件與 tbox 狀態映射的完整參考。
+> 來源：[CC Hooks 文件](https://code.claude.com/docs/en/hooks)、[anthropics/claude-code#32634](https://github.com/anthropics/claude-code/issues/32634)
+
+---
+
+## tbox 註冊的 Hook 事件
+
+tbox 透過 `tbox setup` 在 `~/.claude/settings.json` 註冊以下 hook 事件：
+
+| 事件 | 觸發時機 |
+|------|---------|
+| `SessionStart` | CC session 開始（startup / resume / clear / compact） |
+| `UserPromptSubmit` | 使用者送出 prompt |
+| `Stop` | CC 完成回應，回到 idle prompt |
+| `StopFailure` | API 錯誤導致中斷（rate_limit / authentication_failed / billing_error 等） |
+| `Notification` | CC 發出通知（idle_prompt / permission_prompt / auth_success / elicitation_dialog） |
+| `PermissionRequest` | CC 等待工具權限核准 |
+| `SessionEnd` | CC session 結束 |
+
+---
+
+## 狀態映射（deriveStatus）
+
+`spa/src/stores/useAgentStore.ts` 的 `deriveStatus(eventName, rawEvent)` 將 hook 事件映射為 tab 狀態：
+
+### 基本映射
+
+| 事件 | 狀態 | Tab 顏色 |
+|------|------|---------|
+| `SessionStart` | running | 綠色（呼吸動畫） |
+| `UserPromptSubmit` | running | 綠色（呼吸動畫） |
+| `PermissionRequest` | waiting | 黃色 |
+| `Stop` | idle | 灰色 |
+| `StopFailure` | idle | 灰色 |
+| `SessionEnd` | clear（移除狀態） | 無 |
+
+### 需要子類別判斷的事件
+
+#### Notification（依 `notification_type`）
+
+| `notification_type` | 狀態 | 說明 |
+|---------------------|------|------|
+| `permission_prompt` | waiting | CC 需要權限核准 |
+| `elicitation_dialog` | waiting | MCP server 請求使用者輸入 |
+| `idle_prompt` | idle | CC 閒置提醒（見下方說明） |
+| `auth_success` | idle | 認證成功 |
+| 未知 / 缺少 | null（不變更） | console.warn 記錄 |
+
+#### SessionStart（依 `source`）
+
+| `source` | 狀態 | 說明 |
+|----------|------|------|
+| `startup` | running | 全新 session |
+| `resume` | running | 恢復 session |
+| `clear` | running | 使用者執行 /clear |
+| `compact` | null（不變更） | 背景 context 壓縮，CC 繼續執行中 |
+
+---
+
+## idle_prompt 設計決策
+
+### 機制
+
+`idle_prompt` 是 CC 內建的閒置通知，使用 **60 秒 timer heuristic**（非狀態機驅動）。
+
+- CC 停止輸出後等待 ~60 秒才觸發
+- 無法區分「CC 真的 idle」和「CC 長時間思考/工具執行中」
+- 參考：[anthropics/claude-code#32634](https://github.com/anthropics/claude-code/issues/32634)
+
+### 與 Stop 的關係
+
+典型事件順序：
+```
+UserPromptSubmit → running
+  ↓
+Stop → idle（立即）→ 觸發通知 + unread dot
+  ↓ (~60 秒後)
+Notification(idle_prompt) → idle（延遲）→ 不通知、不掛 unread
+```
+
+### tbox 的處理策略
+
+| 項目 | 處理 | 原因 |
+|------|------|------|
+| 狀態 | 設為 `idle` | 語意正確（CC 確實 idle） |
+| Desktop 通知 | 不發送 | `Stop` 已發過通知，60 秒後重複通知無意義 |
+| Unread dot | 不標記 | 同上，`Stop` 已標記過 |
+
+### auth_success
+
+認證完成後 CC 回到 prompt，會有 `SessionStart` 或 `Stop` 處理狀態轉換。`auth_success` 本身是資訊性通知，處理策略同 `idle_prompt`。
+
+---
+
+## Unread 標記邏輯
+
+`handleHookEvent` 中的 unread 標記規則：
+
+```
+unread = (derived === 'waiting') ||
+         (derived === 'idle' && event_name !== 'Notification')
+```
+
+| 條件 | unread | 說明 |
+|------|--------|------|
+| waiting（任何來源） | ✓ | 需要使用者注意 |
+| idle + Stop/StopFailure | ✓ | 任務完成或出錯 |
+| idle + Notification(idle_prompt) | ✗ | Stop 已處理，延遲提醒不重複 |
+| idle + Notification(auth_success) | ✗ | 資訊性通知 |
+
+---
+
+## StopFailure 錯誤類型
+
+| `error` 值 | 說明 |
+|------------|------|
+| `rate_limit` | API 速率限制 |
+| `authentication_failed` | 認證失敗 |
+| `billing_error` | 帳單問題 |
+| `invalid_request` | 無效請求 |
+| `server_error` | Anthropic 伺服器錯誤 |
+| `max_output_tokens` | 輸出 token 超限 |
+| `unknown` | 未知錯誤 |
+
+通知 body 優先序：`error_details` → `error` → fallback "Task stopped unexpectedly"
+
+---
+
+## hooksInstalled Fallback
+
+當 hooks 已安裝但 session 尚無任何事件時，tab 預設顯示 idle 狀態點（灰色）。
+
+- `hooksInstalled` 在 App mount 時從 `/api/agent/hook-status` 取得
+- `useHookStatus.runAction`（install/remove）後同步更新
+- 不持久化（每次啟動重新查詢）
+- SessionEnd 清除 statuses 後的短暫 fallback 是過渡態（session tab 會隨 tmux session 銷毀而消失）

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -104,7 +104,7 @@ func (m *Module) handleHookStatus(w http.ResponseWriter, r *http.Request) {
 	var issues []string
 	allInstalled := true
 
-	hookEvents := []string{"SessionStart", "UserPromptSubmit", "Stop", "Notification", "PermissionRequest", "SessionEnd"}
+	hookEvents := []string{"SessionStart", "UserPromptSubmit", "Stop", "StopFailure", "Notification", "PermissionRequest", "SessionEnd"}
 	for _, eventName := range hookEvents {
 		entries, ok := hooks[eventName]
 		if !ok {

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -170,7 +170,7 @@ func TestHandleHookStatus_WithHooks(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 
-	hookEvents := []string{"SessionStart", "UserPromptSubmit", "Stop", "Notification", "PermissionRequest", "SessionEnd"}
+	hookEvents := []string{"SessionStart", "UserPromptSubmit", "Stop", "StopFailure", "Notification", "PermissionRequest", "SessionEnd"}
 
 	// Build hooks map with a tbox hook entry for each event.
 	hooksMap := map[string]any{}
@@ -267,7 +267,7 @@ func TestHandleHookStatus_EmptyHooks(t *testing.T) {
 		t.Fatal("events field missing or wrong type")
 	}
 
-	hookEvents := []string{"SessionStart", "UserPromptSubmit", "Stop", "Notification", "PermissionRequest", "SessionEnd"}
+	hookEvents := []string{"SessionStart", "UserPromptSubmit", "Stop", "StopFailure", "Notification", "PermissionRequest", "SessionEnd"}
 	for _, ev := range hookEvents {
 		evData, ok := events[ev].(map[string]any)
 		if !ok {

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -15,6 +15,7 @@ import { useSessionEventWs } from './hooks/useSessionEventWs'
 import { useRouteSync } from './hooks/useRouteSync'
 import { useShortcuts } from './hooks/useShortcuts'
 import { useNotificationDispatcher } from './hooks/useNotificationDispatcher'
+import { useAgentStore } from './stores/useAgentStore'
 import { useTabWorkspaceActions } from './hooks/useTabWorkspaceActions'
 import { isStandaloneTab } from './types/tab'
 import { TabContextMenu } from './components/TabContextMenu'
@@ -50,6 +51,16 @@ export default function App() {
   useRouteSync()
   useShortcuts()
   useNotificationDispatcher()
+
+  // --- Fetch hook installation status on mount ---
+  useEffect(() => {
+    fetch(`${daemonBase}/api/agent/hook-status`)
+      .then((r) => r.json())
+      .then((data: { installed?: boolean }) => {
+        useAgentStore.getState().setHooksInstalled(!!data.installed)
+      })
+      .catch(() => { /* ignore */ })
+  }, [daemonBase])
 
   // --- Electron: signal SPA ready (replaces 500ms setTimeout) ---
   useEffect(() => {

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -53,13 +53,17 @@ export default function App() {
   useNotificationDispatcher()
 
   // --- Fetch hook installation status on mount ---
+  // Sets global hooksInstalled flag (used by SortableTab for idle fallback).
   useEffect(() => {
     fetch(`${daemonBase}/api/agent/hook-status`)
-      .then((r) => r.json())
-      .then((data: { installed?: boolean }) => {
-        useAgentStore.getState().setHooksInstalled(!!data.installed)
+      .then((r) => {
+        if (!r.ok) return
+        return r.json()
       })
-      .catch(() => { /* ignore */ })
+      .then((data: { installed?: boolean } | undefined) => {
+        if (data) useAgentStore.getState().setHooksInstalled(!!data.installed)
+      })
+      .catch(() => { /* daemon unreachable — hooksInstalled stays false */ })
   }, [daemonBase])
 
   // --- Electron: signal SPA ready (replaces 500ms setTimeout) ---

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -72,7 +72,10 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
   const workspaces = useWorkspaceStore((s) => s.workspaces)
 
   const sessionCode = primaryContent.kind === 'session' ? primaryContent.sessionCode : undefined
-  const agentStatus = useAgentStore((s) => sessionCode ? s.statuses[sessionCode] : undefined)
+  const agentStatus = useAgentStore((s) => {
+    if (!sessionCode) return undefined
+    return s.statuses[sessionCode] ?? (s.hooksInstalled ? 'idle' : undefined)
+  })
   const isUnread = useAgentStore((s) => sessionCode ? !!s.unread[sessionCode] : false)
   const tabIndicatorStyle = useAgentStore((s) => s.tabIndicatorStyle)
   const sessionLookup = { getByCode: (code: string) => sessions.find((s) => s.code === code) }

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -74,6 +74,10 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
   const sessionCode = primaryContent.kind === 'session' ? primaryContent.sessionCode : undefined
   const agentStatus = useAgentStore((s) => {
     if (!sessionCode) return undefined
+    // Fallback to idle only when hooks installed and session has never had events.
+    // After SessionEnd both statuses and events are cleared — fallback triggers
+    // again, but this is a brief transient state (session tab disappears shortly
+    // after tmux session is destroyed and session list refreshes).
     return s.statuses[sessionCode] ?? (s.hooksInstalled ? 'idle' : undefined)
   })
   const isUnread = useAgentStore((s) => sessionCode ? !!s.unread[sessionCode] : false)

--- a/spa/src/hooks/useHookStatus.ts
+++ b/spa/src/hooks/useHookStatus.ts
@@ -24,7 +24,11 @@ export function useHookStatus() {
   useEffect(() => {
     fetch(`${daemonBase}/api/agent/hook-status`)
       .then((r) => r.json())
-      .then((data) => setHookStatus(data as HookStatus))
+      .then((data) => {
+        const status = data as HookStatus
+        setHookStatus(status)
+        useAgentStore.getState().setHooksInstalled(!!status.installed)
+      })
       .catch(() => setHookStatus(null))
   }, [daemonBase])
 

--- a/spa/src/hooks/useHookStatus.ts
+++ b/spa/src/hooks/useHookStatus.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useHostStore } from '../stores/useHostStore'
+import { useAgentStore } from '../stores/useAgentStore'
 
 interface HookEventStatus {
   installed: boolean
@@ -39,8 +40,9 @@ export function useHookStatus() {
         setHookLoading(false)
         return
       }
-      const data = await res.json()
-      setHookStatus(data as HookStatus)
+      const data = await res.json() as HookStatus
+      setHookStatus(data)
+      useAgentStore.getState().setHooksInstalled(!!data.installed)
     } catch { /* ignore */ }
     setHookLoading(false)
   }

--- a/spa/src/hooks/useNotificationDispatcher.test.ts
+++ b/spa/src/hooks/useNotificationDispatcher.test.ts
@@ -34,4 +34,10 @@ describe('shouldNotify', () => {
   it('event defaults to true when not in events map', () => {
     expect(shouldNotify({ derived: 'idle', eventName: 'Stop', sessionCode: 'abc', focusedSession: null, hasTab: true, settings: { ...defaultSettings, events: {} } })).toBe(true)
   })
+  it('returns false for idle Notification (idle_prompt/auth_success are informational)', () => {
+    expect(shouldNotify({ derived: 'idle', eventName: 'Notification', sessionCode: 'abc', focusedSession: null, hasTab: true, settings: defaultSettings })).toBe(false)
+  })
+  it('returns true for waiting Notification (permission_prompt/elicitation_dialog)', () => {
+    expect(shouldNotify({ derived: 'waiting', eventName: 'Notification', sessionCode: 'abc', focusedSession: null, hasTab: true, settings: defaultSettings })).toBe(true)
+  })
 })

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -46,7 +46,7 @@ export function useNotificationDispatcher(): void {
         // (guards against DB fix edge cases and initial snapshot replays)
         if (notifiedRef.current.has(event.broadcast_ts)) continue
 
-        const derived = deriveStatus(event.event_name)
+        const derived = deriveStatus(event.event_name, event.raw_event)
         const tabs = useTabStore.getState().tabs
         const hasTab = findTabBySessionCode(tabs, sessionCode) !== undefined
         const settings = useNotificationSettingsStore.getState().getSettingsForAgent(event.agent_type || '')

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -23,6 +23,9 @@ interface ShouldNotifyParams {
 export function shouldNotify(params: ShouldNotifyParams): boolean {
   const { derived, eventName, sessionCode, focusedSession, hasTab, settings } = params
   if (derived !== 'waiting' && derived !== 'idle') return false
+  // Informational Notification subtypes (idle_prompt, auth_success) derive to 'idle'
+  // but should not trigger desktop notifications — consistent with unread marking logic.
+  if (derived === 'idle' && eventName === 'Notification') return false
   if (!settings.enabled) return false
   if (settings.events[eventName] === false) return false
   if (!hasTab && !settings.notifyWithoutTab) return false

--- a/spa/src/lib/notification-content.test.ts
+++ b/spa/src/lib/notification-content.test.ts
@@ -18,6 +18,18 @@ describe('buildNotificationContent', () => {
     const result = buildNotificationContent('Stop', {}, 'my-session')
     expect(result).toEqual({ title: 'my-session', body: 'Task completed' })
   })
+  it('StopFailure → uses error_details', () => {
+    const result = buildNotificationContent('StopFailure', { error: 'rate_limit', error_details: '429 Too Many Requests' }, 'my-session')
+    expect(result).toEqual({ title: 'my-session', body: '429 Too Many Requests' })
+  })
+  it('StopFailure without error_details → uses error', () => {
+    const result = buildNotificationContent('StopFailure', { error: 'rate_limit' }, 'my-session')
+    expect(result).toEqual({ title: 'my-session', body: 'rate_limit' })
+  })
+  it('StopFailure without any fields → fallback', () => {
+    const result = buildNotificationContent('StopFailure', {}, 'my-session')
+    expect(result).toEqual({ title: 'my-session', body: 'Task stopped unexpectedly' })
+  })
   it('unknown event → null', () => {
     expect(buildNotificationContent('SessionStart', {}, 'x')).toBeNull()
   })

--- a/spa/src/lib/notification-content.ts
+++ b/spa/src/lib/notification-content.ts
@@ -15,6 +15,8 @@ export function buildNotificationContent(
       return { title: sessionName, body: (rawEvent.tool_name as string) ? `Permission required: ${rawEvent.tool_name}` : (t?.('notification.fallback.permission') ?? 'Permission required: unknown tool') }
     case 'Stop':
       return { title: sessionName, body: (rawEvent.last_assistant_message as string) || (t?.('notification.fallback.stop') ?? 'Task completed') }
+    case 'StopFailure':
+      return { title: sessionName, body: (rawEvent.error_details as string) || (rawEvent.error as string) || (t?.('notification.fallback.stopFailure') ?? 'Task stopped unexpectedly') }
     default:
       return null
   }

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -268,6 +268,7 @@
   "notification.fallback.new": "New notification",
   "notification.fallback.permission": "Permission required: unknown tool",
   "notification.fallback.stop": "Task completed",
+  "notification.fallback.stopFailure": "Task stopped unexpectedly",
 
   "settings.agent.cc.name": "Claude Code"
 }

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -268,6 +268,7 @@
   "notification.fallback.new": "新通知",
   "notification.fallback.permission": "需要授權：未知工具",
   "notification.fallback.stop": "任務完成",
+  "notification.fallback.stopFailure": "任務異常中斷",
 
   "settings.agent.cc.name": "Claude Code"
 }

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -63,7 +63,7 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().statuses['dev']).toBe('idle')
   })
 
-  it('Notification(auth_success) → does not change status', () => {
+  it('Notification(auth_success) → status = idle', () => {
     useAgentStore.setState({ statuses: { dev: 'running' } })
     const event: AgentHookEvent = {
       tmux_session: 'dev',
@@ -73,7 +73,7 @@ describe('useAgentStore', () => {
       broadcast_ts: Date.now(),
     }
     useAgentStore.getState().handleHookEvent('dev', event)
-    expect(useAgentStore.getState().statuses['dev']).toBe('running')
+    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
   })
 
   it('Notification without notification_type → does not change status', () => {

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -25,7 +25,59 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().statuses['dev']).toBe('running')
   })
 
-  it('Notification → status = waiting', () => {
+  it('Notification(permission_prompt) → status = waiting', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Notification',
+      raw_event: { notification_type: 'permission_prompt' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('waiting')
+  })
+
+  it('Notification(elicitation_dialog) → status = waiting', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Notification',
+      raw_event: { notification_type: 'elicitation_dialog' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('waiting')
+  })
+
+  it('Notification(idle_prompt) → does not change status', () => {
+    // Pre-set to idle (as Stop would have done)
+    useAgentStore.setState({ statuses: { dev: 'idle' } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Notification',
+      raw_event: { notification_type: 'idle_prompt' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
+  })
+
+  it('Notification(auth_success) → does not change status', () => {
+    useAgentStore.setState({ statuses: { dev: 'running' } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Notification',
+      raw_event: { notification_type: 'auth_success' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('running')
+  })
+
+  it('Notification without notification_type → does not change status', () => {
+    useAgentStore.setState({ statuses: { dev: 'idle' } })
     const event: AgentHookEvent = {
       tmux_session: 'dev',
       event_name: 'Notification',
@@ -34,7 +86,57 @@ describe('useAgentStore', () => {
       broadcast_ts: Date.now(),
     }
     useAgentStore.getState().handleHookEvent('dev', event)
-    expect(useAgentStore.getState().statuses['dev']).toBe('waiting')
+    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
+  })
+
+  it('SessionStart(compact) → does not change status', () => {
+    useAgentStore.setState({ statuses: { dev: 'idle' } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SessionStart',
+      raw_event: { source: 'compact' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
+  })
+
+  it('SessionStart(startup) → status = running', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SessionStart',
+      raw_event: { source: 'startup' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('running')
+  })
+
+  it('SessionStart(resume) → status = running', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SessionStart',
+      raw_event: { source: 'resume' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('running')
+  })
+
+  it('StopFailure → status = idle', () => {
+    useAgentStore.setState({ statuses: { dev: 'running' } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'StopFailure',
+      raw_event: { error: 'rate_limit' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
   })
 
   it('Stop → status = idle', () => {

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -49,9 +49,8 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().statuses['dev']).toBe('waiting')
   })
 
-  it('Notification(idle_prompt) → does not change status', () => {
-    // Pre-set to idle (as Stop would have done)
-    useAgentStore.setState({ statuses: { dev: 'idle' } })
+  it('Notification(idle_prompt) → status = idle (from running)', () => {
+    useAgentStore.setState({ statuses: { dev: 'running' } })
     const event: AgentHookEvent = {
       tmux_session: 'dev',
       event_name: 'Notification',
@@ -156,6 +155,30 @@ describe('useAgentStore', () => {
       tmux_session: 'dev',
       event_name: 'Stop',
       raw_event: {},
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().unread['dev']).toBe(true)
+  })
+
+  it('Notification(idle_prompt) → does not mark unread', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Notification',
+      raw_event: { notification_type: 'idle_prompt' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().unread['dev']).toBeUndefined()
+  })
+
+  it('Notification(permission_prompt) → marks unread when not focused', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Notification',
+      raw_event: { notification_type: 'permission_prompt' },
       agent_type: 'cc',
       broadcast_ts: Date.now(),
     }

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -9,6 +9,7 @@ beforeEach(() => {
     statuses: {},
     unread: {},
     focusedSession: null,
+    hooksInstalled: false,
   })
 })
 
@@ -172,6 +173,30 @@ describe('useAgentStore', () => {
     }
     useAgentStore.getState().handleHookEvent('dev', event)
     expect(useAgentStore.getState().unread['dev']).toBeUndefined()
+  })
+
+  it('Notification(auth_success) → does not mark unread', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Notification',
+      raw_event: { notification_type: 'auth_success' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().unread['dev']).toBeUndefined()
+  })
+
+  it('StopFailure → marks unread when not focused', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'StopFailure',
+      raw_event: { error: 'rate_limit' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().unread['dev']).toBe(true)
   })
 
   it('Notification(permission_prompt) → marks unread when not focused', () => {

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -40,7 +40,8 @@ export function deriveStatus(eventName: string, rawEvent?: Record<string, unknow
       const nt = rawEvent?.notification_type
       if (nt === 'permission_prompt' || nt === 'elicitation_dialog') return 'waiting'
       if (nt === 'idle_prompt' || nt === 'auth_success') return 'idle'
-      // unknown notification_type → don't change status
+      // unrecognized or missing notification_type → don't change status
+      if (nt !== undefined) console.warn('[deriveStatus] unknown notification_type:', nt)
       return null
     }
     case 'PermissionRequest':
@@ -96,8 +97,9 @@ export const useAgentStore = create<AgentState>()(
           // Update status
           set((s) => ({ statuses: { ...s.statuses, [session]: derived } }))
 
-          // Mark unread on actionable events (waiting, Stop/StopFailure) when not focused.
-          // Informational notifications (idle_prompt, auth_success) are excluded.
+          // Mark unread when not focused: all 'waiting' statuses are actionable;
+          // 'idle' statuses are actionable only if they don't come from a Notification event
+          // (idle_prompt/auth_success are informational and should not trigger the red dot).
           const isActionable = derived === 'waiting' ||
             (derived === 'idle' && event.event_name !== 'Notification')
           if (isActionable && get().focusedSession !== session) {

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -19,11 +19,13 @@ interface AgentState {
   unread: Record<string, boolean>              // unread flag per session
   focusedSession: string | null
   tabIndicatorStyle: TabIndicatorStyle
+  hooksInstalled: boolean                      // whether CC hooks are installed
 
   handleHookEvent: (session: string, event: AgentHookEvent) => void
   markRead: (session: string) => void
   setFocusedSession: (session: string | null) => void
   setTabIndicatorStyle: (style: TabIndicatorStyle) => void
+  setHooksInstalled: (installed: boolean) => void
 }
 
 export function deriveStatus(eventName: string): AgentStatus | 'clear' | null {
@@ -58,6 +60,7 @@ export const useAgentStore = create<AgentState>()(
       unread: {},
       focusedSession: null,
       tabIndicatorStyle: 'overlay' as TabIndicatorStyle,
+      hooksInstalled: false,
 
       handleHookEvent: (session, event) => {
         const derived = deriveStatus(event.event_name)
@@ -105,6 +108,7 @@ export const useAgentStore = create<AgentState>()(
       },
 
       setTabIndicatorStyle: (style) => set({ tabIndicatorStyle: style }),
+      setHooksInstalled: (installed) => set({ hooksInstalled: installed }),
     }),
     {
       name: 'tbox-agent',

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -96,9 +96,11 @@ export const useAgentStore = create<AgentState>()(
           // Update status
           set((s) => ({ statuses: { ...s.statuses, [session]: derived } }))
 
-          // Mark unread on Stop or waiting events when not focused
-          const isWaitingOrIdle = derived === 'idle' || derived === 'waiting'
-          if (isWaitingOrIdle && get().focusedSession !== session) {
+          // Mark unread on actionable events (waiting, Stop/StopFailure) when not focused.
+          // Informational notifications (idle_prompt, auth_success) are excluded.
+          const isActionable = derived === 'waiting' ||
+            (derived === 'idle' && event.event_name !== 'Notification')
+          if (isActionable && get().focusedSession !== session) {
             set((s) => ({ unread: { ...s.unread, [session]: true } }))
           }
         }

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -39,7 +39,8 @@ export function deriveStatus(eventName: string, rawEvent?: Record<string, unknow
     case 'Notification': {
       const nt = rawEvent?.notification_type
       if (nt === 'permission_prompt' || nt === 'elicitation_dialog') return 'waiting'
-      // idle_prompt, auth_success, or unknown → don't change status
+      if (nt === 'idle_prompt' || nt === 'auth_success') return 'idle'
+      // unknown notification_type → don't change status
       return null
     }
     case 'PermissionRequest':

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -28,15 +28,24 @@ interface AgentState {
   setHooksInstalled: (installed: boolean) => void
 }
 
-export function deriveStatus(eventName: string): AgentStatus | 'clear' | null {
+export function deriveStatus(eventName: string, rawEvent?: Record<string, unknown>): AgentStatus | 'clear' | null {
   switch (eventName) {
     case 'SessionStart':
+      // compact is background auto-compaction, not user activity
+      if (rawEvent?.source === 'compact') return null
+      return 'running'
     case 'UserPromptSubmit':
       return 'running'
-    case 'Notification':
+    case 'Notification': {
+      const nt = rawEvent?.notification_type
+      if (nt === 'permission_prompt' || nt === 'elicitation_dialog') return 'waiting'
+      // idle_prompt, auth_success, or unknown → don't change status
+      return null
+    }
     case 'PermissionRequest':
       return 'waiting'
     case 'Stop':
+    case 'StopFailure':
       return 'idle'
     case 'SessionEnd':
       return 'clear'
@@ -63,7 +72,7 @@ export const useAgentStore = create<AgentState>()(
       hooksInstalled: false,
 
       handleHookEvent: (session, event) => {
-        const derived = deriveStatus(event.event_name)
+        const derived = deriveStatus(event.event_name, event.raw_event)
 
         if (derived === 'clear') {
           // SessionEnd: remove session from all maps


### PR DESCRIPTION
## Summary

- **deriveStatus 子類別判斷**：Notification、SessionStart 事件依 raw_event 子類別欄位決定狀態，避免 idle_prompt 覆蓋 idle 為 waiting
- **StopFailure 處理**：新增映射到 idle（原本未處理）
- **hooks 啟用後預設 idle**：hooks 已安裝但尚無事件的 session tab 顯示 idle 狀態點

### 修改對照

| 事件 | 子類別 | 修前 | 修後 |
|------|--------|------|------|
| Notification | permission_prompt / elicitation_dialog | waiting | waiting ✓ |
| Notification | idle_prompt / auth_success | waiting ❌ | idle ✓ |
| Notification | 未知 | waiting ❌ | 不變更 |
| SessionStart | compact | running ❌ | 不變更 |
| StopFailure | — | 未處理 ❌ | idle ✓ |
| hooks 已裝 + 無事件 | — | 無狀態點 ❌ | idle ✓ |

Fixes #106

## Test plan

- [x] 8 個新測試案例覆蓋所有子類別路徑（15/15 通過）
- [ ] 實機驗證：安裝 hooks 後 tab 預設顯示灰色 idle 點
- [ ] 實機驗證：CC 任務完成後 tab 顯示 idle 而非 waiting
- [ ] 實機驗證：CC 等待權限時 tab 顯示 waiting