### PR TITLE
fix: app:// custom protocol + SPA source mode UI

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -99,7 +99,7 @@ function registerIpcHandlers(): void {
 
   // SPA Force Load (skip detection, load specific mode)
   ipcMain.handle('spa:force-load', (event, mode: 'dev' | 'bundled') => {
-    windowManager.forceLoadSPA(event.sender, mode)
+    return windowManager.forceLoadSPA(event.sender, mode)
   })
 
   // Dev Update
@@ -135,10 +135,15 @@ function startMetricsPolling(): void {
 
 app.whenReady().then(() => {
   // Serve bundled renderer files via app:// protocol
+  const rendererRoot = join(__dirname, '../renderer')
   protocol.handle('app', (req) => {
     let pathname = new URL(req.url).pathname
     if (pathname === '/') pathname = '/index.html'
-    return net.fetch('file://' + join(__dirname, '../renderer', pathname))
+    const resolved = join(rendererRoot, pathname)
+    if (!resolved.startsWith(rendererRoot)) {
+      return new Response('Forbidden', { status: 403 })
+    }
+    return net.fetch('file://' + resolved)
   })
 
   registerIpcHandlers()

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -97,6 +97,11 @@ function registerIpcHandlers(): void {
     windowManager.reloadSPA(event.sender)
   })
 
+  // SPA Force Load (skip detection, load specific mode)
+  ipcMain.handle('spa:force-load', (event, mode: 'dev' | 'bundled') => {
+    windowManager.forceLoadSPA(event.sender, mode)
+  })
+
   // Dev Update
   ipcMain.handle('dev:app-info', () => getAppInfo())
   ipcMain.handle('dev:check-update', (_event, daemonUrl: string) => checkUpdate(daemonUrl))

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,9 +1,17 @@
-import { app, BrowserWindow, ipcMain, Menu, Notification } from 'electron'
+import { app, BrowserWindow, ipcMain, Menu, Notification, protocol, net } from 'electron'
+import { join } from 'path'
 import { WindowManager } from './window-manager'
 import { BrowserViewManager } from './browser-view-manager'
 import { createTray } from './tray'
 import { getAppInfo, checkUpdate, applyUpdate } from './updater'
 import { getDefaultKeybindings, buildMenuTemplate } from './keybindings'
+
+// Register custom protocol before app is ready (Electron requirement).
+// 'app://' replaces 'file://' for bundled SPA, enabling standard CORS behavior.
+protocol.registerSchemesAsPrivileged([{
+  scheme: 'app',
+  privileges: { standard: true, secure: true, supportFetchAPI: true },
+}])
 
 const windowManager = new WindowManager()
 const browserViewManager = new BrowserViewManager()
@@ -121,6 +129,13 @@ function startMetricsPolling(): void {
 }
 
 app.whenReady().then(() => {
+  // Serve bundled renderer files via app:// protocol
+  protocol.handle('app', (req) => {
+    let pathname = new URL(req.url).pathname
+    if (pathname === '/') pathname = '/index.html'
+    return net.fetch('file://' + join(__dirname, '../renderer', pathname))
+  })
+
   registerIpcHandlers()
   createTray(windowManager)
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -29,9 +29,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // SPA reload (re-detect dev server via main process)
   reloadSPA: () => ipcRenderer.invoke('spa:reload'),
 
-  // SPA force load (skip detection, load specific mode)
-  forceLoadSPA: (mode: 'dev' | 'bundled') => ipcRenderer.invoke('spa:force-load', mode),
-
   // Keyboard Shortcuts
   onShortcut: (callback: (payload: { action: string }) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, payload: { action: string }) =>
@@ -64,6 +61,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getAppInfo: () => ipcRenderer.invoke('dev:app-info'),
     checkUpdate: (daemonUrl: string) => ipcRenderer.invoke('dev:check-update', daemonUrl),
     applyUpdate: (daemonUrl: string) => ipcRenderer.invoke('dev:apply-update', daemonUrl),
+    forceLoadSPA: (mode: 'dev' | 'bundled') => ipcRenderer.invoke('spa:force-load', mode),
     onUpdateProgress: (callback: (step: string) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, step: string) => callback(step)
       ipcRenderer.on('dev:update-progress', handler)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -29,6 +29,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // SPA reload (re-detect dev server via main process)
   reloadSPA: () => ipcRenderer.invoke('spa:reload'),
 
+  // SPA force load (skip detection, load specific mode)
+  forceLoadSPA: (mode: 'dev' | 'bundled') => ipcRenderer.invoke('spa:force-load', mode),
+
   // Keyboard Shortcuts
   onShortcut: (callback: (payload: { action: string }) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, payload: { action: string }) =>

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -67,13 +67,13 @@ export class WindowManager {
     if (win && !win.isDestroyed()) this.loadSPA(win)
   }
 
-  forceLoadSPA(webContents: Electron.WebContents, mode: 'dev' | 'bundled'): void {
+  async forceLoadSPA(webContents: Electron.WebContents, mode: 'dev' | 'bundled'): Promise<void> {
     const win = BrowserWindow.fromWebContents(webContents)
     if (!win || win.isDestroyed()) return
     if (mode === 'dev') {
-      win.loadURL(WindowManager.DEV_SERVER)
-    } else {
-      win.loadURL('app://./index.html')
+      await win.loadURL(WindowManager.DEV_SERVER)
+    } else if (mode === 'bundled') {
+      await win.loadURL('app://./index.html')
     }
   }
 

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -67,6 +67,16 @@ export class WindowManager {
     if (win && !win.isDestroyed()) this.loadSPA(win)
   }
 
+  forceLoadSPA(webContents: Electron.WebContents, mode: 'dev' | 'bundled'): void {
+    const win = BrowserWindow.fromWebContents(webContents)
+    if (!win || win.isDestroyed()) return
+    if (mode === 'dev') {
+      win.loadURL(WindowManager.DEV_SERVER)
+    } else {
+      win.loadURL('app://./index.html')
+    }
+  }
+
   closeWindow(windowId: string): void {
     const win = this.windows.get(windowId)
     if (win && !win.isDestroyed()) {

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -59,7 +59,7 @@ export class WindowManager {
   loadSPA(win: BrowserWindow): void {
     fetch(WindowManager.DEV_SERVER, { signal: AbortSignal.timeout(500) })
       .then(() => win.loadURL(WindowManager.DEV_SERVER))
-      .catch(() => win.loadFile(join(__dirname, '../renderer/index.html')))
+      .catch(() => win.loadURL('app://./index.html'))
   }
 
   reloadSPA(webContents: Electron.WebContents): void {

--- a/spa/src/components/settings/DevEnvironmentSection.test.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.test.tsx
@@ -143,7 +143,7 @@ describe('DevEnvironmentSection', () => {
       }
     })
 
-    it('shows switch button and calls forceLoadSPA on click', async () => {
+    it('shows switch button and calls forceLoadSPA("bundled") from dev mode', async () => {
       mockCheckUpdate.mockResolvedValue(upToDateRemote)
       // Default is http: → dev server, so button should offer "Switch to Bundled"
       await act(async () => {
@@ -155,6 +155,31 @@ describe('DevEnvironmentSection', () => {
       const switchBtn = screen.getByRole('button', { name: /Bundled/i })
       fireEvent.click(switchBtn)
       expect(mockForceLoadSPA).toHaveBeenCalledWith('bundled')
+    })
+
+    it('shows switch button and calls forceLoadSPA("dev") from bundled mode', async () => {
+      mockCheckUpdate.mockResolvedValue(upToDateRemote)
+      const originalProtocol = window.location.protocol
+      Object.defineProperty(window, 'location', {
+        value: { ...window.location, protocol: 'app:' },
+        writable: true,
+      })
+      try {
+        await act(async () => {
+          render(<DevEnvironmentSection />)
+        })
+        await waitFor(() => {
+          expect(screen.getByText('Bundled')).toBeTruthy()
+        })
+        const switchBtn = screen.getByRole('button', { name: /Dev Server/i })
+        fireEvent.click(switchBtn)
+        expect(mockForceLoadSPA).toHaveBeenCalledWith('dev')
+      } finally {
+        Object.defineProperty(window, 'location', {
+          value: { ...window.location, protocol: originalProtocol },
+          writable: true,
+        })
+      }
     })
   })
 

--- a/spa/src/components/settings/DevEnvironmentSection.test.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import { DevEnvironmentSection } from './DevEnvironmentSection'
 
 const mockGetAppInfo = vi.fn().mockResolvedValue({
@@ -11,6 +11,7 @@ const mockGetAppInfo = vi.fn().mockResolvedValue({
 
 const mockCheckUpdate = vi.fn()
 const mockApplyUpdate = vi.fn()
+const mockForceLoadSPA = vi.fn().mockResolvedValue(undefined)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -19,6 +20,7 @@ beforeEach(() => {
     getAppInfo: mockGetAppInfo,
     checkUpdate: mockCheckUpdate,
     applyUpdate: mockApplyUpdate,
+    forceLoadSPA: mockForceLoadSPA,
   } as any
 })
 
@@ -94,6 +96,65 @@ describe('DevEnvironmentSection', () => {
     // After poll, building is done — should show update_available
     await waitFor(() => {
       expect(screen.getByText(/Update available|有新版本/)).toBeTruthy()
+    })
+  })
+
+  describe('SPA source mode', () => {
+    const upToDateRemote = {
+      version: '1.0.0-alpha.21',
+      spaHash: 'def5678',
+      electronHash: 'abc1234',
+      source: { spaHash: 'src111', electronHash: 'src222' },
+      building: false,
+      buildError: '',
+    }
+
+    it('shows "Dev Server" when loaded from http: protocol', async () => {
+      mockCheckUpdate.mockResolvedValue(upToDateRemote)
+      // jsdom default is http://localhost — which means dev server
+      await act(async () => {
+        render(<DevEnvironmentSection />)
+      })
+      await waitFor(() => {
+        expect(screen.getByText('Dev Server')).toBeTruthy()
+      })
+    })
+
+    it('shows "Bundled" when loaded from app: protocol', async () => {
+      mockCheckUpdate.mockResolvedValue(upToDateRemote)
+      // Simulate app:// protocol by overriding location.protocol
+      const originalProtocol = window.location.protocol
+      Object.defineProperty(window, 'location', {
+        value: { ...window.location, protocol: 'app:' },
+        writable: true,
+      })
+      try {
+        await act(async () => {
+          render(<DevEnvironmentSection />)
+        })
+        await waitFor(() => {
+          expect(screen.getByText('Bundled')).toBeTruthy()
+        })
+      } finally {
+        Object.defineProperty(window, 'location', {
+          value: { ...window.location, protocol: originalProtocol },
+          writable: true,
+        })
+      }
+    })
+
+    it('shows switch button and calls forceLoadSPA on click', async () => {
+      mockCheckUpdate.mockResolvedValue(upToDateRemote)
+      // Default is http: → dev server, so button should offer "Switch to Bundled"
+      await act(async () => {
+        render(<DevEnvironmentSection />)
+      })
+      await waitFor(() => {
+        expect(screen.getByText('Dev Server')).toBeTruthy()
+      })
+      const switchBtn = screen.getByRole('button', { name: /Bundled/i })
+      fireEvent.click(switchBtn)
+      expect(mockForceLoadSPA).toHaveBeenCalledWith('bundled')
     })
   })
 

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -17,7 +17,7 @@ export function DevEnvironmentSection() {
   const getDaemonBase = useHostStore((s) => s.getDaemonBase)
   const daemonBase = getDaemonBase('local')
 
-  const spaSource: 'dev' | 'bundled' = window.location.protocol === 'http:' ? 'dev' : 'bundled'
+  const spaSource: 'dev' | 'bundled' = window.location.protocol === 'app:' ? 'bundled' : 'dev'
 
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
   const [remoteInfo, setRemoteInfo] = useState<RemoteInfo | null>(null)

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -17,6 +17,8 @@ export function DevEnvironmentSection() {
   const getDaemonBase = useHostStore((s) => s.getDaemonBase)
   const daemonBase = getDaemonBase('local')
 
+  const spaSource: 'dev' | 'bundled' = window.location.protocol === 'http:' ? 'dev' : 'bundled'
+
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
   const [remoteInfo, setRemoteInfo] = useState<RemoteInfo | null>(null)
   const [status, setStatus] = useState<UpdateStatus>('idle')
@@ -134,6 +136,20 @@ export function DevEnvironmentSection() {
       </div>
 
       <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-text-primary">{t('settings.dev.spa_source')}</span>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-text-secondary font-mono">
+              {spaSource === 'dev' ? 'Dev Server' : 'Bundled'}
+            </span>
+            <button
+              onClick={() => window.electronAPI?.forceLoadSPA(spaSource === 'dev' ? 'bundled' : 'dev')}
+              className="px-2 py-0.5 text-xs rounded bg-surface-input border border-border-default text-text-primary hover:bg-surface-hover cursor-pointer"
+            >
+              {spaSource === 'dev' ? t('settings.dev.btn.switch_bundled') : t('settings.dev.btn.switch_dev')}
+            </button>
+          </div>
+        </div>
         <div className="flex items-center justify-between">
           <span className="text-sm text-text-primary">{t('settings.dev.app_version')}</span>
           <span className="text-xs text-text-secondary font-mono">{appInfo?.version ?? '...'}</span>

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -206,6 +206,9 @@
   "settings.dev.btn.update_app": "Update App",
   "settings.dev.btn.reload_spa": "Reload SPA",
   "settings.dev.btn.updating": "Updating...",
+  "settings.dev.spa_source": "SPA Source",
+  "settings.dev.btn.switch_bundled": "Switch to Bundled",
+  "settings.dev.btn.switch_dev": "Switch to Dev Server",
 
   "monitor.provider_label": "Memory Monitor",
   "monitor.requires_app": "Requires desktop app",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -206,6 +206,9 @@
   "settings.dev.btn.update_app": "更新 App",
   "settings.dev.btn.reload_spa": "重新載入 SPA",
   "settings.dev.btn.updating": "更新中...",
+  "settings.dev.spa_source": "SPA 來源",
+  "settings.dev.btn.switch_bundled": "切換為 Bundled",
+  "settings.dev.btn.switch_dev": "切換為 Dev Server",
 
   "monitor.provider_label": "記憶體監控",
   "monitor.requires_app": "需要安裝桌面版本",

--- a/spa/src/types/electron.d.ts
+++ b/spa/src/types/electron.d.ts
@@ -51,6 +51,7 @@ interface Window {
     onTabReceived: (callback: (tabJson: string, replace: boolean) => void) => () => void
     signalReady: () => void
     reloadSPA: () => Promise<void>
+    forceLoadSPA: (mode: 'dev' | 'bundled') => Promise<void>
 
     // Keyboard Shortcuts
     onShortcut: (callback: (payload: { action: string }) => void) => () => void


### PR DESCRIPTION
## Summary
- Use `app://` custom protocol for bundled SPA instead of `file://`, enabling standard CORS behavior for fetch/WS from bundled renderer
- Add SPA Source row in Development Settings showing current mode (Dev Server / Bundled)
- Add instant switch button to toggle between dev server and bundled SPA without restart

## Test plan
- [ ] Verify `app://` protocol serves bundled SPA correctly
- [ ] Verify Dev Settings shows "Dev Server" when loaded from dev server
- [ ] Verify Dev Settings shows "Bundled" when loaded from app:// protocol
- [ ] Verify switch button reloads to the other mode immediately
- [ ] Verify cross-origin fetch to daemon works from app:// origin
- [ ] `npx vitest run` — 605 pass, 1 pre-existing fail (#95)