### PR TITLE
fix: include renderer in dev update download and apply

### DIFF
--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -68,40 +68,37 @@ export async function applyUpdate(
 
   progress('applying')
 
-  // Replace out/main and out/preload in app directory
+  // Replace out/main, out/preload, and out/renderer in app directory
   // __dirname is out/main/ in the built output, so parent is out/
   const appOutDir = join(__dirname, '..')
-  const mainDst = join(appOutDir, 'main')
-  const preloadDst = join(appOutDir, 'preload')
-  const mainSrc = join(extractDir, 'main')
-  const preloadSrc = join(extractDir, 'preload')
+  const targets = ['main', 'preload', 'renderer'] as const
 
   // Backup current files before replacing
   const backupDir = join(tmpDir, 'backup')
   mkdirSync(backupDir, { recursive: true })
-  if (existsSync(mainDst)) cpSync(mainDst, join(backupDir, 'main'), { recursive: true })
-  if (existsSync(preloadDst)) cpSync(preloadDst, join(backupDir, 'preload'), { recursive: true })
+  for (const name of targets) {
+    const dst = join(appOutDir, name)
+    if (existsSync(dst)) cpSync(dst, join(backupDir, name), { recursive: true })
+  }
 
   try {
-    if (existsSync(mainSrc)) {
-      if (existsSync(mainDst)) rmSync(mainDst, { recursive: true })
-      renameSync(mainSrc, mainDst)
-    }
-    if (existsSync(preloadSrc)) {
-      if (existsSync(preloadDst)) rmSync(preloadDst, { recursive: true })
-      renameSync(preloadSrc, preloadDst)
+    for (const name of targets) {
+      const src = join(extractDir, name)
+      const dst = join(appOutDir, name)
+      if (existsSync(src)) {
+        if (existsSync(dst)) rmSync(dst, { recursive: true })
+        renameSync(src, dst)
+      }
     }
   } catch (err) {
     // Rollback: restore from backup
-    const mainBackup = join(backupDir, 'main')
-    const preloadBackup = join(backupDir, 'preload')
-    if (existsSync(mainBackup)) {
-      if (existsSync(mainDst)) rmSync(mainDst, { recursive: true })
-      renameSync(mainBackup, mainDst)
-    }
-    if (existsSync(preloadBackup)) {
-      if (existsSync(preloadDst)) rmSync(preloadDst, { recursive: true })
-      renameSync(preloadBackup, preloadDst)
+    for (const name of targets) {
+      const backup = join(backupDir, name)
+      const dst = join(appOutDir, name)
+      if (existsSync(backup)) {
+        if (existsSync(dst)) rmSync(dst, { recursive: true })
+        renameSync(backup, dst)
+      }
     }
     rmSync(tmpDir, { recursive: true })
     throw err

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -91,16 +91,21 @@ export async function applyUpdate(
       }
     }
   } catch (err) {
-    // Rollback: restore from backup
+    // Rollback: restore from backup — each target independently so one
+    // failure does not prevent restoring the others
     for (const name of targets) {
-      const backup = join(backupDir, name)
-      const dst = join(appOutDir, name)
-      if (existsSync(backup)) {
-        if (existsSync(dst)) rmSync(dst, { recursive: true })
-        renameSync(backup, dst)
+      try {
+        const backup = join(backupDir, name)
+        const dst = join(appOutDir, name)
+        if (existsSync(backup)) {
+          if (existsSync(dst)) rmSync(dst, { recursive: true })
+          renameSync(backup, dst)
+        }
+      } catch (rollbackErr) {
+        console.error(`[updater] rollback failed for ${name}:`, rollbackErr)
       }
     }
-    rmSync(tmpDir, { recursive: true })
+    try { rmSync(tmpDir, { recursive: true }) } catch { /* best effort */ }
     throw err
   }
 

--- a/internal/module/dev/handler.go
+++ b/internal/module/dev/handler.go
@@ -123,7 +123,7 @@ func (m *DevModule) handleDownload(w http.ResponseWriter, r *http.Request) {
 		// Top-level entries: only allow main/ and preload/ directories
 		parts := strings.SplitN(rel, string(filepath.Separator), 2)
 		topLevel := parts[0]
-		if topLevel != "main" && topLevel != "preload" {
+		if topLevel != "main" && topLevel != "preload" && topLevel != "renderer" {
 			if info.IsDir() {
 				return filepath.SkipDir
 			}

--- a/internal/module/dev/handler.go
+++ b/internal/module/dev/handler.go
@@ -120,7 +120,7 @@ func (m *DevModule) handleDownload(w http.ResponseWriter, r *http.Request) {
 			return nil
 		}
 
-		// Top-level entries: only allow main/ and preload/ directories
+		// Top-level entries: only allow main/, preload/, and renderer/ directories
 		parts := strings.SplitN(rel, string(filepath.Separator), 2)
 		topLevel := parts[0]
 		if topLevel != "main" && topLevel != "preload" && topLevel != "renderer" {

--- a/internal/module/dev/handler_test.go
+++ b/internal/module/dev/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -74,8 +75,11 @@ func TestHandleDownloadIncludesRenderer(t *testing.T) {
 	files := map[string]bool{}
 	for {
 		hdr, err := tr.Next()
-		if err != nil {
+		if err == io.EOF {
 			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected tar read error: %v", err)
 		}
 		files[hdr.Name] = true
 	}

--- a/internal/module/dev/handler_test.go
+++ b/internal/module/dev/handler_test.go
@@ -1,6 +1,8 @@
 package dev
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -34,6 +36,57 @@ func TestHandleDownload(t *testing.T) {
 	}
 	if w.Body.Len() == 0 {
 		t.Error("body is empty")
+	}
+}
+
+func TestHandleDownloadIncludesRenderer(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create fake out/ structure with main, preload, renderer
+	for _, sub := range []string{"main", "preload", "renderer"} {
+		p := filepath.Join(dir, "out", sub)
+		os.MkdirAll(p, 0755)
+		os.WriteFile(filepath.Join(p, "index.js"), []byte("// "+sub), 0644)
+	}
+	// Also create a directory that should be excluded
+	excluded := filepath.Join(dir, "out", "other")
+	os.MkdirAll(excluded, 0755)
+	os.WriteFile(filepath.Join(excluded, "skip.js"), []byte("// skip"), 0644)
+
+	m := &DevModule{repoRoot: dir}
+
+	req := httptest.NewRequest("GET", "/api/dev/update/download", nil)
+	w := httptest.NewRecorder()
+	m.handleDownload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", w.Code)
+	}
+
+	// Extract tar and collect file names
+	gr, err := gzip.NewReader(w.Body)
+	if err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	defer gr.Close()
+	tr := tar.NewReader(gr)
+
+	files := map[string]bool{}
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		files[hdr.Name] = true
+	}
+
+	for _, want := range []string{"main/index.js", "preload/index.js", "renderer/index.js"} {
+		if !files[want] {
+			t.Errorf("tar missing %s, got: %v", want, files)
+		}
+	}
+	if files["other/skip.js"] {
+		t.Error("tar should not contain other/skip.js")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Dev update previously only packaged `main/` and `preload/` from `out/`, skipping `renderer/`
- SPA changes (bundled renderer) were never delivered via dev update — stayed frozen at `.app` install time
- Now includes `renderer/` in tar download and applies it alongside main/preload with same backup/rollback logic

## Changes
- `handler.go`: add `"renderer"` to allowed top-level dirs filter
- `updater.ts`: refactor backup/replace/rollback to loop over `['main', 'preload', 'renderer']`
- `handler_test.go`: new test verifies tar includes renderer and excludes other dirs

## Test plan
- [ ] `go test ./internal/module/dev/` — 6 pass
- [ ] `npx vitest run` — 606 pass, 1 pre-existing (#95)
- [ ] Build on Mini, dev update on Air, verify bundled SPA is updated
- [ ] Verify rollback works if apply fails mid-renderer