### PR TITLE
fix: preflight check before switching to dev server

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -98,8 +98,12 @@ function registerIpcHandlers(): void {
   })
 
   // SPA Force Load (skip detection, load specific mode)
-  ipcMain.handle('spa:force-load', (event, mode: 'dev' | 'bundled') => {
-    return windowManager.forceLoadSPA(event.sender, mode)
+  ipcMain.handle('spa:force-load', async (event, mode: 'dev' | 'bundled') => {
+    try {
+      return await windowManager.forceLoadSPA(event.sender, mode)
+    } catch (err) {
+      throw String(err instanceof Error ? err.message : err)
+    }
   })
 
   // Dev Update

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -73,7 +73,9 @@ export class WindowManager {
     if (mode === 'dev') {
       // Verify dev server is reachable before navigating — loadURL navigates
       // immediately, so a failure would strand the user on an error page.
-      await fetch(WindowManager.DEV_SERVER, { signal: AbortSignal.timeout(2000) })
+      // Timeout is longer than loadSPA's 500ms because this is user-initiated.
+      const res = await fetch(WindowManager.DEV_SERVER, { signal: AbortSignal.timeout(2000) })
+      if (!res.ok) throw new Error(`Dev server responded with ${res.status}`)
       await win.loadURL(WindowManager.DEV_SERVER)
     } else if (mode === 'bundled') {
       await win.loadURL('app://./index.html')

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -71,6 +71,9 @@ export class WindowManager {
     const win = BrowserWindow.fromWebContents(webContents)
     if (!win || win.isDestroyed()) return
     if (mode === 'dev') {
+      // Verify dev server is reachable before navigating — loadURL navigates
+      // immediately, so a failure would strand the user on an error page.
+      await fetch(WindowManager.DEV_SERVER, { signal: AbortSignal.timeout(2000) })
       await win.loadURL(WindowManager.DEV_SERVER)
     } else if (mode === 'bundled') {
       await win.loadURL('app://./index.html')

--- a/spa/src/components/settings/DevEnvironmentSection.test.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.test.tsx
@@ -181,6 +181,24 @@ describe('DevEnvironmentSection', () => {
         })
       }
     })
+
+    it('shows error when forceLoadSPA rejects', async () => {
+      mockCheckUpdate.mockResolvedValue(upToDateRemote)
+      mockForceLoadSPA.mockRejectedValueOnce(new Error('ERR_CONNECTION_REFUSED'))
+      await act(async () => {
+        render(<DevEnvironmentSection />)
+      })
+      await waitFor(() => {
+        expect(screen.getByText('Dev Server')).toBeTruthy()
+      })
+      const switchBtn = screen.getByRole('button', { name: /Bundled/i })
+      await act(async () => {
+        fireEvent.click(switchBtn)
+      })
+      await waitFor(() => {
+        expect(screen.getByText(/Failed to load bundled SPA/)).toBeTruthy()
+      })
+    })
   })
 
   it('shows build error', async () => {

--- a/spa/src/components/settings/DevEnvironmentSection.test.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.test.tsx
@@ -182,9 +182,9 @@ describe('DevEnvironmentSection', () => {
       }
     })
 
-    it('shows error when forceLoadSPA rejects', async () => {
+    it('shows error when switching to bundled fails', async () => {
       mockCheckUpdate.mockResolvedValue(upToDateRemote)
-      mockForceLoadSPA.mockRejectedValueOnce(new Error('ERR_CONNECTION_REFUSED'))
+      mockForceLoadSPA.mockRejectedValueOnce('protocol error')
       await act(async () => {
         render(<DevEnvironmentSection />)
       })
@@ -196,8 +196,38 @@ describe('DevEnvironmentSection', () => {
         fireEvent.click(switchBtn)
       })
       await waitFor(() => {
-        expect(screen.getByText(/Failed to load bundled SPA/)).toBeTruthy()
+        expect(screen.getByText(/Failed to load bundled SPA.*protocol error/)).toBeTruthy()
       })
+    })
+
+    it('shows error when switching to dev server fails', async () => {
+      mockCheckUpdate.mockResolvedValue(upToDateRemote)
+      mockForceLoadSPA.mockRejectedValueOnce('ERR_CONNECTION_REFUSED')
+      const originalProtocol = window.location.protocol
+      Object.defineProperty(window, 'location', {
+        value: { ...window.location, protocol: 'app:' },
+        writable: true,
+      })
+      try {
+        await act(async () => {
+          render(<DevEnvironmentSection />)
+        })
+        await waitFor(() => {
+          expect(screen.getByText('Bundled')).toBeTruthy()
+        })
+        const switchBtn = screen.getByRole('button', { name: /Dev Server/i })
+        await act(async () => {
+          fireEvent.click(switchBtn)
+        })
+        await waitFor(() => {
+          expect(screen.getByText(/Dev server is not reachable.*ERR_CONNECTION_REFUSED/)).toBeTruthy()
+        })
+      } finally {
+        Object.defineProperty(window, 'location', {
+          value: { ...window.location, protocol: originalProtocol },
+          writable: true,
+        })
+      }
     })
   })
 

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -145,8 +145,11 @@ export function DevEnvironmentSection() {
             <button
               onClick={() => {
                 const target = spaSource === 'dev' ? 'bundled' : 'dev'
-                window.electronAPI?.forceLoadSPA(target)?.catch(() => {
-                  setUpdateError(target === 'dev' ? 'Dev server is not reachable' : 'Failed to load bundled SPA')
+                window.electronAPI?.forceLoadSPA(target)?.catch((err: unknown) => {
+                  const detail = typeof err === 'string' ? err : (err instanceof Error ? err.message : String(err))
+                  setUpdateError(target === 'dev'
+                    ? `${t('settings.dev.error.dev_unreachable')}: ${detail}`
+                    : `${t('settings.dev.error.bundled_failed')}: ${detail}`)
                   setStatus('error')
                 })
               }}

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -143,7 +143,13 @@ export function DevEnvironmentSection() {
               {spaSource === 'dev' ? 'Dev Server' : 'Bundled'}
             </span>
             <button
-              onClick={() => window.electronAPI?.forceLoadSPA(spaSource === 'dev' ? 'bundled' : 'dev')}
+              onClick={() => {
+                const target = spaSource === 'dev' ? 'bundled' : 'dev'
+                window.electronAPI?.forceLoadSPA(target)?.catch(() => {
+                  setUpdateError(target === 'dev' ? 'Dev server is not reachable' : 'Failed to load bundled SPA')
+                  setStatus('error')
+                })
+              }}
               className="px-2 py-0.5 text-xs rounded bg-surface-input border border-border-default text-text-primary hover:bg-surface-hover cursor-pointer"
             >
               {spaSource === 'dev' ? t('settings.dev.btn.switch_bundled') : t('settings.dev.btn.switch_dev')}

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -209,6 +209,8 @@
   "settings.dev.spa_source": "SPA Source",
   "settings.dev.btn.switch_bundled": "Switch to Bundled",
   "settings.dev.btn.switch_dev": "Switch to Dev Server",
+  "settings.dev.error.dev_unreachable": "Dev server is not reachable",
+  "settings.dev.error.bundled_failed": "Failed to load bundled SPA",
 
   "monitor.provider_label": "Memory Monitor",
   "monitor.requires_app": "Requires desktop app",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -209,6 +209,8 @@
   "settings.dev.spa_source": "SPA 來源",
   "settings.dev.btn.switch_bundled": "切換為 Bundled",
   "settings.dev.btn.switch_dev": "切換為 Dev Server",
+  "settings.dev.error.dev_unreachable": "Dev Server 無法連線",
+  "settings.dev.error.bundled_failed": "無法載入 Bundled SPA",
 
   "monitor.provider_label": "記憶體監控",
   "monitor.requires_app": "需要安裝桌面版本",


### PR DESCRIPTION
## Summary
- `forceLoadSPA('dev')` now fetches dev server (2s timeout) before calling `loadURL`, preventing the user from being stranded on an Electron error page when the dev server is not running
- SPA button catches IPC rejection and displays error inline via existing `setUpdateError` / `setStatus('error')` mechanism

## Test plan
- [ ] Click "Switch to Dev Server" when dev server is NOT running → error message appears, SPA stays intact
- [ ] Click "Switch to Dev Server" when dev server IS running → navigates correctly
- [ ] Click "Switch to Bundled" → navigates correctly (no preflight needed)
- [ ] `npx vitest run` — 607 pass, 1 pre-existing (#95)