### PR TITLE
fix: findTboxCommand matches quoted tbox paths

### DIFF
--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -151,7 +151,7 @@ func findTboxCommand(entries any) string {
 				continue
 			}
 			cmd, _ := hookMap["command"].(string)
-			if strings.Contains(cmd, "tbox hook") {
+			if strings.Contains(strings.ReplaceAll(cmd, `"`, ""), "tbox hook") {
 				return cmd
 			}
 		}

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -348,6 +348,17 @@ func TestFindTboxCommand(t *testing.T) {
 			want: "/usr/local/bin/tbox hook Notification",
 		},
 		{
+			name: "quoted tbox path",
+			entries: []any{
+				map[string]any{
+					"hooks": []any{
+						map[string]any{"type": "command", "command": `"/Users/wake/Workspace/tmux-box/tbox" hook --agent cc Stop`},
+					},
+				},
+			},
+			want: `"/Users/wake/Workspace/tmux-box/tbox" hook --agent cc Stop`,
+		},
+		{
 			name: "hook map has no command field",
 			entries: []any{
 				map[string]any{


### PR DESCRIPTION
## Summary
- `findTboxCommand` strips double quotes before matching `"tbox hook"` substring
- Fixes `hooksInstalled` returning `false` when hooks are installed with quoted paths (default from `tbox setup`)
- Root cause of idle fallback and unread badge not working

## Test plan
- [ ] `go test ./internal/module/agent/` — all pass
- [ ] `curl /api/agent/hook-status` returns `installed: true` with quoted-path hooks
- [ ] Tabs without events show idle indicator