### PR TITLE
fix: persistent notification dedup + window focus awareness

### DIFF
--- a/spa/src/hooks/useNotificationDispatcher.test.ts
+++ b/spa/src/hooks/useNotificationDispatcher.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { shouldNotify } from './useNotificationDispatcher'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { shouldNotify, shouldDispatch } from './useNotificationDispatcher'
 import type { NotificationSettings } from '../stores/useNotificationSettingsStore'
 
 const defaultSettings: NotificationSettings = {
@@ -16,8 +16,15 @@ describe('shouldNotify', () => {
   it('returns false for running event', () => {
     expect(shouldNotify({ derived: 'running', eventName: 'UserPromptSubmit', sessionCode: 'abc', focusedSession: null, hasTab: true, settings: defaultSettings })).toBe(false)
   })
-  it('returns false when focused on same session', () => {
+  it('returns false when focused on same session and window has focus', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
     expect(shouldNotify({ derived: 'waiting', eventName: 'Notification', sessionCode: 'abc', focusedSession: 'abc', hasTab: true, settings: defaultSettings })).toBe(false)
+    vi.restoreAllMocks()
+  })
+  it('returns true when focused on same session but window is in background', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+    expect(shouldNotify({ derived: 'waiting', eventName: 'Notification', sessionCode: 'abc', focusedSession: 'abc', hasTab: true, settings: defaultSettings })).toBe(true)
+    vi.restoreAllMocks()
   })
   it('returns false when no tab and notifyWithoutTab=false', () => {
     expect(shouldNotify({ derived: 'waiting', eventName: 'Notification', sessionCode: 'abc', focusedSession: null, hasTab: false, settings: defaultSettings })).toBe(false)
@@ -39,5 +46,51 @@ describe('shouldNotify', () => {
   })
   it('returns true for waiting Notification (permission_prompt/elicitation_dialog)', () => {
     expect(shouldNotify({ derived: 'waiting', eventName: 'Notification', sessionCode: 'abc', focusedSession: null, hasTab: true, settings: defaultSettings })).toBe(true)
+  })
+})
+
+describe('shouldDispatch', () => {
+  beforeEach(() => {
+    localStorage.removeItem('tbox-notification-seen')
+  })
+
+  it('returns false for new session (sentinel Infinity) but records ts', () => {
+    // First event for a session the client has never seen
+    expect(shouldDispatch('abc', 1000)).toBe(false)
+    // ts is now recorded, so a newer event should dispatch
+    expect(shouldDispatch('abc', 2000)).toBe(true)
+  })
+
+  it('returns false for duplicate broadcast_ts', () => {
+    shouldDispatch('abc', 1000) // sentinel → record
+    shouldDispatch('abc', 2000) // first real → dispatch
+    expect(shouldDispatch('abc', 2000)).toBe(false) // same ts → skip
+  })
+
+  it('returns false for older broadcast_ts', () => {
+    shouldDispatch('abc', 1000) // sentinel → record
+    shouldDispatch('abc', 2000) // dispatch
+    expect(shouldDispatch('abc', 1500)).toBe(false) // older → skip
+  })
+
+  it('returns true for newer broadcast_ts after recorded', () => {
+    shouldDispatch('abc', 1000) // sentinel → record
+    expect(shouldDispatch('abc', 2000)).toBe(true) // newer → dispatch
+    expect(shouldDispatch('abc', 3000)).toBe(true) // newer again → dispatch
+  })
+
+  it('isolates sessions', () => {
+    shouldDispatch('abc', 1000) // record abc
+    shouldDispatch('def', 5000) // record def
+    expect(shouldDispatch('abc', 2000)).toBe(true) // abc newer
+    expect(shouldDispatch('def', 3000)).toBe(false) // def older than 5000
+  })
+
+  it('persists across calls (simulates restart)', () => {
+    shouldDispatch('abc', 1000) // sentinel → record
+    shouldDispatch('abc', 2000) // dispatch + record
+    // Simulate restart: shouldDispatch is called fresh but localStorage persists
+    expect(shouldDispatch('abc', 2000)).toBe(false) // same ts
+    expect(shouldDispatch('abc', 3000)).toBe(true)  // newer
   })
 })

--- a/spa/src/hooks/useNotificationDispatcher.test.ts
+++ b/spa/src/hooks/useNotificationDispatcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { shouldNotify, shouldDispatch } from './useNotificationDispatcher'
+import { shouldNotify, shouldDispatch, clearSeenTs } from './useNotificationDispatcher'
 import type { NotificationSettings } from '../stores/useNotificationSettingsStore'
 
 const defaultSettings: NotificationSettings = {
@@ -92,5 +92,14 @@ describe('shouldDispatch', () => {
     // Simulate restart: shouldDispatch is called fresh but localStorage persists
     expect(shouldDispatch('abc', 2000)).toBe(false) // same ts
     expect(shouldDispatch('abc', 3000)).toBe(true)  // newer
+  })
+
+  it('clearSeenTs resets session so next event is sentinel again', () => {
+    shouldDispatch('abc', 1000) // sentinel → record
+    shouldDispatch('abc', 2000) // dispatch
+    clearSeenTs('abc')
+    // After clear, session is new again — sentinel behavior
+    expect(shouldDispatch('abc', 500)).toBe(false) // sentinel → record (even older ts)
+    expect(shouldDispatch('abc', 600)).toBe(true)  // newer than 500 → dispatch
   })
 })

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useAgentStore, deriveStatus } from '../stores/useAgentStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { useNotificationSettingsStore } from '../stores/useNotificationSettingsStore'
@@ -10,6 +10,28 @@ import { buildNotificationContent } from '../lib/notification-content'
 import { findTabBySessionCode } from '../lib/pane-tree'
 import { getPlatformCapabilities } from '../lib/platform'
 import { createTab } from '../types/tab'
+
+const SEEN_KEY = 'tbox-notification-seen'
+
+/** Check if a notification should be dispatched based on broadcast_ts dedup.
+ *  New sessions default to Infinity (sentinel), so their first event is recorded
+ *  but not dispatched — prevents snapshot flooding on new/restarted clients. */
+export function shouldDispatch(sessionCode: string, broadcastTs: number): boolean {
+  const data: Record<string, number> = JSON.parse(localStorage.getItem(SEEN_KEY) || '{}')
+  const stored = data[sessionCode] ?? Infinity
+
+  if (broadcastTs <= stored) {
+    if (stored === Infinity) {
+      data[sessionCode] = broadcastTs
+      localStorage.setItem(SEEN_KEY, JSON.stringify(data))
+    }
+    return false
+  }
+
+  data[sessionCode] = broadcastTs
+  localStorage.setItem(SEEN_KEY, JSON.stringify(data))
+  return true
+}
 
 interface ShouldNotifyParams {
   derived: string | null
@@ -29,13 +51,13 @@ export function shouldNotify(params: ShouldNotifyParams): boolean {
   if (!settings.enabled) return false
   if (settings.events[eventName] === false) return false
   if (!hasTab && !settings.notifyWithoutTab) return false
-  if (focusedSession === sessionCode) return false
+  // Only suppress when user is actively looking at this session:
+  // both the app window must be focused AND the session tab must be active.
+  if (focusedSession === sessionCode && document.hasFocus()) return false
   return true
 }
 
 export function useNotificationDispatcher(): void {
-  const notifiedRef = useRef(new Set<number>())
-
   useEffect(() => {
     const unsubscribe = useAgentStore.subscribe((state, prevState) => {
       const prevEvents = prevState.events
@@ -45,9 +67,9 @@ export function useNotificationDispatcher(): void {
         const prev = prevEvents[sessionCode]
         if (prev && prev.broadcast_ts === event.broadcast_ts) continue
 
-        // Double protection: skip if this broadcast_ts was already notified
-        // (guards against DB fix edge cases and initial snapshot replays)
-        if (notifiedRef.current.has(event.broadcast_ts)) continue
+        // Persistent dedup: skip already-seen events (handles restart/snapshot replay).
+        // New sessions use Infinity sentinel — first event is recorded but not dispatched.
+        if (!shouldDispatch(sessionCode, event.broadcast_ts)) continue
 
         const derived = deriveStatus(event.event_name, event.raw_event)
         const tabs = useTabStore.getState().tabs
@@ -63,8 +85,6 @@ export function useNotificationDispatcher(): void {
 
         const content = buildNotificationContent(event.event_name, event.raw_event, sessionName, useI18nStore.getState().t)
         if (!content) continue
-
-        notifiedRef.current.add(event.broadcast_ts)
 
         const capabilities = getPlatformCapabilities()
         if (capabilities.canNotification && window.electronAPI?.showNotification) {

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -33,6 +33,14 @@ export function shouldDispatch(sessionCode: string, broadcastTs: number): boolea
   return true
 }
 
+/** Remove a session's lastSeenTs entry (called on SessionEnd to prevent
+ *  stale timestamps from blocking notifications if the code is reused). */
+export function clearSeenTs(sessionCode: string): void {
+  const data: Record<string, number> = JSON.parse(localStorage.getItem(SEEN_KEY) || '{}')
+  delete data[sessionCode]
+  localStorage.setItem(SEEN_KEY, JSON.stringify(data))
+}
+
 interface ShouldNotifyParams {
   derived: string | null
   eventName: string
@@ -63,12 +71,22 @@ export function useNotificationDispatcher(): void {
       const prevEvents = prevState.events
       const currentEvents = state.events
 
+      // Clean up lastSeenTs for sessions that ended (prevents stale ts
+      // blocking notifications if the session code is reused).
+      for (const sessionCode of Object.keys(prevEvents)) {
+        if (!currentEvents[sessionCode]) {
+          clearSeenTs(sessionCode)
+        }
+      }
+
       for (const [sessionCode, event] of Object.entries(currentEvents)) {
         const prev = prevEvents[sessionCode]
         if (prev && prev.broadcast_ts === event.broadcast_ts) continue
 
-        // Persistent dedup: skip already-seen events (handles restart/snapshot replay).
+        // Dedup layer 1: localStorage-based persistent dedup (handles restart/snapshot).
         // New sessions use Infinity sentinel — first event is recorded but not dispatched.
+        // Layer 2: shouldNotify checks focusedSession + document.hasFocus().
+        // Layer 3: Electron main process recentBroadcasts dedup (5s window, multi-window).
         if (!shouldDispatch(sessionCode, event.broadcast_ts)) continue
 
         const derived = deriveStatus(event.event_name, event.raw_event)


### PR DESCRIPTION
## Summary
- Replace in-memory `notifiedRef` (Set) with localStorage-based `lastSeenTs` for persistent dedup across app restarts
- New sessions use `Infinity` sentinel — first event records ts but skips notification, preventing snapshot flooding on new/restarted clients
- Focused-tab notification suppression now checks `document.hasFocus()` — app in background still notifies even for the active tab

## Test plan
- [ ] Restart app → no duplicate notifications from snapshot
- [ ] New client first connect → no notification flood
- [ ] New live event on non-focused tab → notification fires
- [ ] New live event on focused tab, app focused → no notification
- [ ] New live event on focused tab, app in background → notification fires
- [ ] `npx vitest run` — 615 pass, 1 pre-existing (#95)