### PR TITLE
fix: remove tab indicator fallback when no snapshot

### DIFF
--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -74,11 +74,11 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
   const sessionCode = primaryContent.kind === 'session' ? primaryContent.sessionCode : undefined
   const agentStatus = useAgentStore((s) => {
     if (!sessionCode) return undefined
-    // Fallback to idle only when hooks installed and session has never had events.
-    // After SessionEnd both statuses and events are cleared — fallback triggers
-    // again, but this is a brief transient state (session tab disappears shortly
-    // after tmux session is destroyed and session list refreshes).
-    return s.statuses[sessionCode] ?? (s.hooksInstalled ? 'idle' : undefined)
+    // No fallback — only show indicator when we have an actual hook event.
+    // Previously fell back to 'idle' when hooksInstalled was true, but that
+    // made it impossible to distinguish "agent running, first event pending"
+    // from "no agent running at all".
+    return s.statuses[sessionCode]
   })
   const isUnread = useAgentStore((s) => sessionCode ? !!s.unread[sessionCode] : false)
   const tabIndicatorStyle = useAgentStore((s) => s.tabIndicatorStyle)


### PR DESCRIPTION
## Summary
- 移除沒有 snapshot 時 fallback 到 idle 的邏輯
- 原本 hooksInstalled 為 true 時會預設顯示灰色燈號，但無法分辨「agent 在跑但還沒送 event」跟「沒有在跑 agent」
- 現在只在實際收到 hook event 後才顯示燈號

## Test plan
- [ ] 開啟有 agent 的 session tab，確認燈號正常顯示
- [ ] 開啟沒有 agent 的 session tab，確認不顯示燈號
- [ ] agent SessionEnd 後確認燈號消失