### PR TITLE
fix: prevent duplicate tbox hook entries on setup

### DIFF
--- a/cmd/tbox/setup.go
+++ b/cmd/tbox/setup.go
@@ -140,30 +140,8 @@ func toEntrySlice(v any) []any {
 	return []any{}
 }
 
-// hasTboxEntry checks if any entry in the slice contains a tbox command.
-func hasTboxEntry(entries []any, tboxPath string) bool {
-	for _, e := range entries {
-		if entryMatchesTbox(e, tboxPath) {
-			return true
-		}
-	}
-	return false
-}
-
-// filterOutTbox returns entries with tbox entries for a specific path removed.
-// Always returns a non-nil slice (empty []any{} when all removed).
-func filterOutTbox(entries []any, tboxPath string) []any {
-	result := []any{}
-	for _, e := range entries {
-		if !entryMatchesTbox(e, tboxPath) {
-			result = append(result, e)
-		}
-	}
-	return result
-}
-
 // filterOutAnyTbox returns entries with ALL tbox hook entries removed,
-// regardless of binary path. Detects commands containing "tbox" + "hook".
+// regardless of binary path.
 func filterOutAnyTbox(entries []any) []any {
 	result := []any{}
 	for _, e := range entries {
@@ -175,6 +153,8 @@ func filterOutAnyTbox(entries []any) []any {
 }
 
 // entryIsTbox checks if an entry contains a tbox hook command (any path).
+// Requires "tbox" to be the exact binary basename — rejects substrings
+// like "tbox-extra" by checking for /tbox or ^tbox boundary.
 func entryIsTbox(entry any) bool {
 	m, ok := entry.(map[string]any)
 	if !ok {
@@ -197,43 +177,24 @@ func entryIsTbox(entry any) bool {
 		if !ok {
 			continue
 		}
-		if strings.Contains(cmd, "tbox") && strings.Contains(cmd, "hook") {
+		if isTboxCommand(cmd) {
 			return true
 		}
 	}
 	return false
 }
 
-// entryMatchesTbox checks if an entry's hooks[].command belongs to tboxPath.
-// It matches both quoted (`"path" hook Event`) and unquoted (`path hook Event`)
-// forms for backward compatibility with entries created before quoting was added.
-func entryMatchesTbox(entry any, tboxPath string) bool {
-	m, ok := entry.(map[string]any)
-	if !ok {
-		return false
+// isTboxCommand checks if cmd is a tbox hook invocation.
+// Matches quoted ("/path/tbox" hook ...) and unquoted (/path/tbox hook ...)
+// forms while rejecting similar names like "tbox-extra".
+func isTboxCommand(cmd string) bool {
+	// Quoted path: ..."/path/tbox" hook ... or "tbox" hook ...
+	if strings.Contains(cmd, `/tbox" hook`) || strings.HasPrefix(cmd, `"tbox" hook`) {
+		return true
 	}
-	innerHooks, ok := m["hooks"]
-	if !ok {
-		return false
-	}
-	arr, ok := innerHooks.([]any)
-	if !ok {
-		return false
-	}
-	quoted := `"` + tboxPath + `"`
-	for _, h := range arr {
-		hookObj, ok := h.(map[string]any)
-		if !ok {
-			continue
-		}
-		cmd, ok := hookObj["command"].(string)
-		if !ok {
-			continue
-		}
-		// Exact prefix match: unquoted "path hook ..." or quoted `"path" hook ...`
-		if strings.HasPrefix(cmd, tboxPath+" ") || strings.HasPrefix(cmd, quoted+" ") {
-			return true
-		}
+	// Unquoted path: .../path/tbox hook ... or tbox hook ...
+	if strings.Contains(cmd, `/tbox hook`) || strings.HasPrefix(cmd, `tbox hook`) {
+		return true
 	}
 	return false
 }

--- a/cmd/tbox/setup.go
+++ b/cmd/tbox/setup.go
@@ -88,12 +88,13 @@ func mergeHooks(path, tboxPath string, remove bool) error {
 	for _, event := range hookEvents {
 		entries := toEntrySlice(hooks[event])
 
-		if remove {
-			entries = filterOutTbox(entries, tboxPath)
-		} else {
-			if !hasTboxEntry(entries, tboxPath) {
-				entries = append(entries, makeTboxEntry(tboxPath, event))
-			}
+		// Always remove ALL existing tbox entries (any path) first.
+		// This prevents duplicates when setup is re-run from a different
+		// binary path (e.g. ./tbox vs ./bin/tbox).
+		entries = filterOutAnyTbox(entries)
+
+		if !remove {
+			entries = append(entries, makeTboxEntry(tboxPath, event))
 		}
 
 		hooks[event] = entries
@@ -149,7 +150,7 @@ func hasTboxEntry(entries []any, tboxPath string) bool {
 	return false
 }
 
-// filterOutTbox returns entries with tbox entries removed.
+// filterOutTbox returns entries with tbox entries for a specific path removed.
 // Always returns a non-nil slice (empty []any{} when all removed).
 func filterOutTbox(entries []any, tboxPath string) []any {
 	result := []any{}
@@ -159,6 +160,48 @@ func filterOutTbox(entries []any, tboxPath string) []any {
 		}
 	}
 	return result
+}
+
+// filterOutAnyTbox returns entries with ALL tbox hook entries removed,
+// regardless of binary path. Detects commands containing "tbox" + "hook".
+func filterOutAnyTbox(entries []any) []any {
+	result := []any{}
+	for _, e := range entries {
+		if !entryIsTbox(e) {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// entryIsTbox checks if an entry contains a tbox hook command (any path).
+func entryIsTbox(entry any) bool {
+	m, ok := entry.(map[string]any)
+	if !ok {
+		return false
+	}
+	innerHooks, ok := m["hooks"]
+	if !ok {
+		return false
+	}
+	arr, ok := innerHooks.([]any)
+	if !ok {
+		return false
+	}
+	for _, h := range arr {
+		hookObj, ok := h.(map[string]any)
+		if !ok {
+			continue
+		}
+		cmd, ok := hookObj["command"].(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(cmd, "tbox") && strings.Contains(cmd, "hook") {
+			return true
+		}
+	}
+	return false
 }
 
 // entryMatchesTbox checks if an entry's hooks[].command belongs to tboxPath.

--- a/cmd/tbox/setup_test.go
+++ b/cmd/tbox/setup_test.go
@@ -31,12 +31,7 @@ func TestMergeHooks_EmptyFile(t *testing.T) {
 		t.Fatal("hooks key missing or not object")
 	}
 
-	expectedEvents := []string{
-		"SessionStart", "UserPromptSubmit", "Stop",
-		"Notification", "PermissionRequest", "SessionEnd",
-	}
-
-	for _, event := range expectedEvents {
+	for _, event := range hookEvents {
 		entries, ok := hooks[event]
 		if !ok {
 			t.Errorf("event %q missing", event)
@@ -107,12 +102,7 @@ func TestMergeHooks_Idempotent(t *testing.T) {
 
 	hooks := settings["hooks"].(map[string]any)
 
-	expectedEvents := []string{
-		"SessionStart", "UserPromptSubmit", "Stop",
-		"Notification", "PermissionRequest", "SessionEnd",
-	}
-
-	for _, event := range expectedEvents {
+	for _, event := range hookEvents {
 		arr := hooks[event].([]any)
 		if len(arr) != 1 {
 			t.Errorf("event %q: got %d entries after double run, want 1", event, len(arr))
@@ -190,12 +180,8 @@ func TestMergeHooks_PreservesExisting(t *testing.T) {
 		t.Errorf("second entry command = %q, want %q", secondCmd, expectedCmd)
 	}
 
-	// All 6 events must be present
-	expectedEvents := []string{
-		"SessionStart", "UserPromptSubmit", "Stop",
-		"Notification", "PermissionRequest", "SessionEnd",
-	}
-	for _, event := range expectedEvents {
+	// All events must be present
+	for _, event := range hookEvents {
 		if _, ok := hooks[event]; !ok {
 			t.Errorf("event %q missing after merge", event)
 		}
@@ -275,46 +261,41 @@ func TestMergeHooks_Remove(t *testing.T) {
 	}
 }
 
-func TestEntryMatchesTbox_NoFalsePositive(t *testing.T) {
-	tboxPath := "/usr/local/bin/tbox"
-
-	// An entry from a different tool whose path merely contains tboxPath as a substring
-	otherEntry := map[string]any{
-		"hooks": []any{
-			map[string]any{
-				"type":    "command",
-				"command": "/usr/local/bin/tbox-extra hook Stop",
+func TestEntryIsTbox(t *testing.T) {
+	mkEntry := func(cmd string) map[string]any {
+		return map[string]any{
+			"hooks": []any{
+				map[string]any{"type": "command", "command": cmd},
 			},
-		},
-	}
-	if entryMatchesTbox(otherEntry, tboxPath) {
-		t.Error("entryMatchesTbox incorrectly matched a different tool with a similar path prefix")
+		}
 	}
 
-	// Quoted tbox entry (new format) should match
-	quotedEntry := map[string]any{
-		"hooks": []any{
-			map[string]any{
-				"type":    "command",
-				"command": `"/usr/local/bin/tbox" hook Stop`,
-			},
-		},
+	// Should match: various tbox command forms
+	shouldMatch := []string{
+		`"/usr/local/bin/tbox" hook --agent cc Stop`,           // quoted absolute
+		`/usr/local/bin/tbox hook --agent cc Stop`,             // unquoted absolute
+		`"/Users/wake/Workspace/wake/tmux-box/bin/tbox" hook --agent cc Notification`, // real-world path
+		`"tbox" hook --agent cc SessionStart`,                  // bare quoted
+		`tbox hook --agent cc SessionEnd`,                      // bare unquoted
+		`"/Users/my user/bin/tbox" hook --agent cc Stop`,       // path with spaces
 	}
-	if !entryMatchesTbox(quotedEntry, tboxPath) {
-		t.Error("entryMatchesTbox failed to match quoted tbox entry")
+	for _, cmd := range shouldMatch {
+		if !entryIsTbox(mkEntry(cmd)) {
+			t.Errorf("entryIsTbox should match %q", cmd)
+		}
 	}
 
-	// Unquoted tbox entry (legacy format) should still match
-	unquotedEntry := map[string]any{
-		"hooks": []any{
-			map[string]any{
-				"type":    "command",
-				"command": "/usr/local/bin/tbox hook Stop",
-			},
-		},
+	// Should NOT match: similar but different tools
+	shouldReject := []string{
+		`/usr/local/bin/tbox-extra hook Stop`,          // tbox-extra, not tbox
+		`/usr/local/bin/mytbox hook Stop`,              // mytbox
+		`/Users/wake/.config/tsm/hooks/tsm-hook.sh`,   // completely unrelated
+		`/usr/local/bin/toolbox hook-handler Stop`,     // toolbox contains "tbox"
 	}
-	if !entryMatchesTbox(unquotedEntry, tboxPath) {
-		t.Error("entryMatchesTbox failed to match unquoted (legacy) tbox entry")
+	for _, cmd := range shouldReject {
+		if entryIsTbox(mkEntry(cmd)) {
+			t.Errorf("entryIsTbox should NOT match %q", cmd)
+		}
 	}
 }
 

--- a/cmd/tbox/setup_test.go
+++ b/cmd/tbox/setup_test.go
@@ -318,6 +318,47 @@ func TestEntryMatchesTbox_NoFalsePositive(t *testing.T) {
 	}
 }
 
+func TestMergeHooks_DifferentPaths(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	// First setup with one path
+	if err := mergeHooks(settingsPath, "/project/tbox", false); err != nil {
+		t.Fatalf("first mergeHooks: %v", err)
+	}
+	// Second setup with a different path (simulates ./tbox vs ./bin/tbox)
+	if err := mergeHooks(settingsPath, "/project/bin/tbox", false); err != nil {
+		t.Fatalf("second mergeHooks: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	hooks := settings["hooks"].(map[string]any)
+
+	for _, event := range hookEvents {
+		arr := hooks[event].([]any)
+		if len(arr) != 1 {
+			t.Errorf("event %q: got %d entries, want 1 (old path should be replaced)", event, len(arr))
+		}
+		// Should be the second path
+		entry := arr[0].(map[string]any)
+		innerHooks := entry["hooks"].([]any)
+		cmd := innerHooks[0].(map[string]any)["command"].(string)
+		expectedCmd := `"/project/bin/tbox" hook --agent cc ` + event
+		if cmd != expectedCmd {
+			t.Errorf("event %q: command = %q, want %q", event, cmd, expectedCmd)
+		}
+	}
+}
+
 func TestMergeHooks_SpacePath(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.json")


### PR DESCRIPTION
## Summary
- 從不同路徑執行 `tbox setup`（如 `./tbox` vs `./bin/tbox`）會各自新增 hook entry，導致 CC 每次事件觸發兩次 `tbox hook`，產生不同 `broadcastTs` 繞過三層 notification dedup
- `mergeHooks` 改為先移除所有既有 tbox entries（任意路徑），再加入當前路徑的 entry
- 新增 `filterOutAnyTbox()` + `entryIsTbox()` 偵測任意路徑的 tbox hook command
- 新增 `TestMergeHooks_DifferentPaths` 驗證不同路徑 setup 後只保留一筆
- 已清理 `~/.claude/settings.json` 的重複 entries

## Test plan
- [x] `go test ./cmd/tbox/ -v` — 14 tests 全部通過
- [x] `tbox setup` 後確認 settings.json 每個事件只有一筆 tbox entry
- [ ] 觸發 Notification hook 確認不再出現重複通知