### PR TITLE
fix: derive focusedSession + tab switch auto-focus

### DIFF
--- a/spa/src/components/ConversationView.tsx
+++ b/spa/src/components/ConversationView.tsx
@@ -23,6 +23,7 @@ import { Prohibit, TerminalWindow } from '@phosphor-icons/react'
 
 interface Props {
   sessionCode: string
+  isActive?: boolean
   onHandoff?: () => void
   onHandoffToTerm?: () => void
 }
@@ -30,7 +31,7 @@ interface Props {
 const EMPTY_MESSAGES: StreamMessage[] = []
 const EMPTY_CONTROLS: ControlRequest[] = []
 
-export default function ConversationView({ sessionCode, onHandoff, onHandoffToTerm }: Props) {
+export default function ConversationView({ sessionCode, isActive = false, onHandoff, onHandoffToTerm }: Props) {
   const t = useI18nStore((s) => s.t)
   const scrollRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -342,7 +343,7 @@ export default function ConversationView({ sessionCode, onHandoff, onHandoffToTe
       <FileAttachment files={attachedFiles} onRemove={handleRemoveFile} />
 
       {/* Input area */}
-      <StreamInput onSend={handleSend} onAttach={handleAttach} onHandoffToTerm={onHandoffToTerm} disabled={isStreaming} />
+      <StreamInput onSend={handleSend} onAttach={handleAttach} onHandoffToTerm={onHandoffToTerm} disabled={isStreaming} focused={isActive} />
     </div>
   )
 }

--- a/spa/src/components/SessionPaneContent.tsx
+++ b/spa/src/components/SessionPaneContent.tsx
@@ -55,6 +55,7 @@ export function SessionPaneContent({ pane, isActive }: PaneRendererProps) {
     return (
       <ConversationView
         sessionCode={sessionCode}
+        isActive={isActive}
         onHandoff={handleHandoff}
         onHandoffToTerm={handleHandoffToTerm}
       />

--- a/spa/src/components/SessionPanel.test.tsx
+++ b/spa/src/components/SessionPanel.test.tsx
@@ -12,7 +12,7 @@ vi.mock('../lib/api', () => ({
 beforeEach(() => {
   cleanup()
   useSessionStore.setState({ sessions: [], activeId: null })
-  useAgentStore.setState({ statuses: {}, events: {}, unread: {}, focusedSession: null })
+  useAgentStore.setState({ statuses: {}, events: {}, unread: {} })
 })
 
 describe('SessionPanel', () => {

--- a/spa/src/components/StreamInput.test.tsx
+++ b/spa/src/components/StreamInput.test.tsx
@@ -73,4 +73,20 @@ describe('StreamInput', () => {
     render(<StreamInput onSend={vi.fn()} onHandoffToTerm={vi.fn()} disabled />)
     expect(screen.getByTitle('Handoff to Term')).toBeDisabled()
   })
+
+  it('focuses textarea when focused prop becomes true', async () => {
+    const { rerender } = render(<StreamInput onSend={vi.fn()} focused={false} />)
+    const textarea = screen.getByRole('textbox')
+    expect(document.activeElement).not.toBe(textarea)
+    rerender(<StreamInput onSend={vi.fn()} focused={true} />)
+    // requestAnimationFrame delay
+    await new Promise((r) => requestAnimationFrame(r))
+    expect(document.activeElement).toBe(textarea)
+  })
+
+  it('does not focus textarea when disabled even if focused=true', async () => {
+    render(<StreamInput onSend={vi.fn()} focused={true} disabled />)
+    await new Promise((r) => requestAnimationFrame(r))
+    expect(document.activeElement).not.toBe(screen.getByRole('textbox'))
+  })
 })

--- a/spa/src/components/StreamInput.tsx
+++ b/spa/src/components/StreamInput.tsx
@@ -1,5 +1,5 @@
 // spa/src/components/StreamInput.tsx
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { Plus, Terminal } from '@phosphor-icons/react'
 import { useI18nStore } from '../stores/useI18nStore'
 
@@ -9,13 +9,20 @@ interface Props {
   onHandoffToTerm?: () => void
   disabled?: boolean
   placeholder?: string
+  focused?: boolean
 }
 
-export default function StreamInput({ onSend, onAttach, onHandoffToTerm, disabled = false, placeholder }: Props) {
+export default function StreamInput({ onSend, onAttach, onHandoffToTerm, disabled = false, placeholder, focused = false }: Props) {
   const t = useI18nStore((s) => s.t)
   const resolvedPlaceholder = placeholder ?? t('stream.input.placeholder')
   const [value, setValue] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (focused && !disabled) {
+      requestAnimationFrame(() => textareaRef.current?.focus())
+    }
+  }, [focused, disabled])
 
   const autoGrow = useCallback(() => {
     const ta = textareaRef.current

--- a/spa/src/components/TabContent.test.tsx
+++ b/spa/src/components/TabContent.test.tsx
@@ -44,4 +44,25 @@ describe('TabContent', () => {
     render(<TabContent activeTab={null} allTabs={[]} />)
     expect(screen.getByText(/選擇或建立/)).toBeTruthy()
   })
+
+  it('sets inert on non-active keep-alive tabs', () => {
+    // First render with dashboard active to put it in the alive pool
+    const { container, rerender } = render(
+      <TabContent activeTab={dashboardTab} allTabs={[sessionTab, dashboardTab]} />,
+    )
+    // Switch to session tab — dashboard stays in pool but becomes inactive
+    rerender(
+      <TabContent activeTab={sessionTab} allTabs={[sessionTab, dashboardTab]} />,
+    )
+    const wrappers = container.querySelectorAll('[class*="absolute"]')
+    // Active tab (session) should NOT have inert
+    const activeWrapper = Array.from(wrappers).find((w) => w.querySelector('[data-testid="session-renderer"]'))
+    expect(activeWrapper).not.toBeNull()
+    expect(activeWrapper?.getAttribute('inert')).toBeNull()
+    // Inactive tab (dashboard) should have inert
+    const inactiveWrapper = Array.from(wrappers).find((w) => w.querySelector('[data-testid="dashboard-renderer"]'))
+    expect(inactiveWrapper).not.toBeNull()
+    // jsdom may not reflect `inert` as an HTML attribute; check the React prop via data attribute fallback
+    expect(inactiveWrapper?.getAttribute('inert')).not.toBeNull()
+  })
 })

--- a/spa/src/components/TabContent.tsx
+++ b/spa/src/components/TabContent.tsx
@@ -35,6 +35,7 @@ export function TabContent({ activeTab, allTabs }: Props) {
             key={`${id}-${poolVersion}`}
             className="absolute"
             style={isActive ? { inset: 0 } : { top: 0, left: '-9999em', width: '100%', height: '100%' }}
+            inert={!isActive || undefined}
           >
             <PaneLayoutRenderer layout={tab.layout} isActive={isActive} />
           </div>

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -141,7 +141,6 @@ function handleNotificationClick(sessionCode: string): void {
   let handled = false
   if (tabId) {
     useTabStore.getState().setActiveTab(tabId)
-    // markRead handled by cross-store subscription in active-session.ts
     handled = true
   } else if (agentSettings.reopenTabOnClick) {
     const newTab = createTab({ kind: 'session', sessionCode, mode: 'stream' })
@@ -153,6 +152,12 @@ function handleNotificationClick(sessionCode: string): void {
       useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, newTab.id)
     }
     handled = true
+  }
+
+  // Always markRead — cross-store subscription only fires on tab *change*,
+  // but notification click on the already-active tab still needs to clear unread.
+  if (handled) {
+    useAgentStore.getState().markRead(sessionCode)
   }
 
   if (handled && window.electronAPI?.focusMyWindow) {

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useAgentStore, deriveStatus } from '../stores/useAgentStore'
+import { getActiveSessionCode } from '../lib/active-session'
 import { useI18nStore } from '../stores/useI18nStore'
 import { useNotificationSettingsStore } from '../stores/useNotificationSettingsStore'
 import type { NotificationSettings } from '../stores/useNotificationSettingsStore'
@@ -85,7 +86,7 @@ export function useNotificationDispatcher(): void {
 
         // Dedup layer 1: localStorage-based persistent dedup (handles restart/snapshot).
         // New sessions use Infinity sentinel — first event is recorded but not dispatched.
-        // Layer 2: shouldNotify checks focusedSession + document.hasFocus().
+        // Layer 2: shouldNotify checks active session (derived from activeTabId) + document.hasFocus().
         // Layer 3: Electron main process recentBroadcasts dedup (5s window, multi-window).
         if (!shouldDispatch(sessionCode, event.broadcast_ts)) continue
 
@@ -93,7 +94,7 @@ export function useNotificationDispatcher(): void {
         const tabs = useTabStore.getState().tabs
         const hasTab = findTabBySessionCode(tabs, sessionCode) !== undefined
         const settings = useNotificationSettingsStore.getState().getSettingsForAgent(event.agent_type || '')
-        const focusedSession = state.focusedSession
+        const focusedSession = getActiveSessionCode()
 
         if (!shouldNotify({ derived, eventName: event.event_name, sessionCode, focusedSession, hasTab, settings })) continue
 
@@ -140,7 +141,7 @@ function handleNotificationClick(sessionCode: string): void {
   let handled = false
   if (tabId) {
     useTabStore.getState().setActiveTab(tabId)
-    useAgentStore.getState().setFocusedSession(sessionCode)
+    // markRead handled by cross-store subscription in active-session.ts
     handled = true
   } else if (agentSettings.reopenTabOnClick) {
     const newTab = createTab({ kind: 'session', sessionCode, mode: 'stream' })
@@ -151,7 +152,6 @@ function handleNotificationClick(sessionCode: string): void {
       useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, newTab.id)
       useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, newTab.id)
     }
-    useAgentStore.getState().setFocusedSession(sessionCode)
     handled = true
   }
 

--- a/spa/src/hooks/useTabWorkspaceActions.ts
+++ b/spa/src/hooks/useTabWorkspaceActions.ts
@@ -2,7 +2,6 @@ import { useState, useCallback } from 'react'
 import { useTabStore } from '../stores/useTabStore'
 import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { useHistoryStore } from '../stores/useHistoryStore'
-import { useAgentStore } from '../stores/useAgentStore'
 import { createTab } from '../types/tab'
 import { getPrimaryPane } from '../lib/pane-tree'
 import type { Tab } from '../types/tab'
@@ -42,16 +41,7 @@ export function useTabWorkspaceActions(displayTabs: Tab[]) {
       setWorkspaceActiveTab(ws.id, tabId)
     }
 
-    // Clear unread badge when user focuses a session tab
-    const tab = tabs[tabId]
-    if (tab) {
-      const primary = getPrimaryPane(tab.layout)
-      if (primary.content.kind === 'session') {
-        useAgentStore.getState().setFocusedSession(primary.content.sessionCode)
-      } else {
-        useAgentStore.getState().setFocusedSession(null)
-      }
-    }
+    // markRead is handled by the cross-store subscription in active-session.ts
   }, [tabs, setActiveTab, findWorkspaceByTab, setActiveWorkspace, setWorkspaceActiveTab])
 
   const handleCloseTab = useCallback((tabId: string) => {

--- a/spa/src/lib/active-session.test.ts
+++ b/spa/src/lib/active-session.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useTabStore } from '../stores/useTabStore'
+import { createTab } from '../types/tab'
+import { getActiveSessionCode } from './active-session'
+
+beforeEach(() => {
+  useTabStore.setState({ tabs: {}, activeTabId: null, tabOrder: [] })
+})
+
+describe('getActiveSessionCode', () => {
+  it('returns sessionCode when active tab is a session', () => {
+    const tab = { ...createTab({ kind: 'session', sessionCode: 'dev', mode: 'terminal' }), id: 't1' }
+    useTabStore.setState({ tabs: { t1: tab }, activeTabId: 't1' })
+    expect(getActiveSessionCode()).toBe('dev')
+  })
+
+  it('returns sessionCode for stream-mode session tab', () => {
+    const tab = { ...createTab({ kind: 'session', sessionCode: 'box', mode: 'stream' }), id: 't2' }
+    useTabStore.setState({ tabs: { t2: tab }, activeTabId: 't2' })
+    expect(getActiveSessionCode()).toBe('box')
+  })
+
+  it('returns null when active tab is not a session', () => {
+    const tab = { ...createTab({ kind: 'settings', scope: 'global' }), id: 't3' }
+    useTabStore.setState({ tabs: { t3: tab }, activeTabId: 't3' })
+    expect(getActiveSessionCode()).toBeNull()
+  })
+
+  it('returns null when no active tab', () => {
+    expect(getActiveSessionCode()).toBeNull()
+  })
+
+  it('returns null when activeTabId points to missing tab', () => {
+    useTabStore.setState({ tabs: {}, activeTabId: 'nonexistent' })
+    expect(getActiveSessionCode()).toBeNull()
+  })
+})

--- a/spa/src/lib/active-session.ts
+++ b/spa/src/lib/active-session.ts
@@ -1,5 +1,4 @@
 import { useTabStore } from '../stores/useTabStore'
-import { useAgentStore } from '../stores/useAgentStore'
 import { getPrimaryPane } from './pane-tree'
 
 /** Derive the active session code from the current active tab.
@@ -11,19 +10,4 @@ export function getActiveSessionCode(): string | null {
   if (!tab) return null
   const primary = getPrimaryPane(tab.layout)
   return primary.content.kind === 'session' ? primary.content.sessionCode : null
-}
-
-/** Cross-store subscription: auto-markRead when the active tab changes to a session.
- *  Call once at app init. Returns unsubscribe function. */
-export function subscribeActiveTabMarkRead(): () => void {
-  let prev = getActiveSessionCode()
-  return useTabStore.subscribe(() => {
-    const current = getActiveSessionCode()
-    if (current !== prev) {
-      prev = current
-      if (current !== null) {
-        useAgentStore.getState().markRead(current)
-      }
-    }
-  })
 }

--- a/spa/src/lib/active-session.ts
+++ b/spa/src/lib/active-session.ts
@@ -1,0 +1,29 @@
+import { useTabStore } from '../stores/useTabStore'
+import { useAgentStore } from '../stores/useAgentStore'
+import { getPrimaryPane } from './pane-tree'
+
+/** Derive the active session code from the current active tab.
+ *  Returns null if no tab is active or the active tab is not a session. */
+export function getActiveSessionCode(): string | null {
+  const { activeTabId, tabs } = useTabStore.getState()
+  if (!activeTabId) return null
+  const tab = tabs[activeTabId]
+  if (!tab) return null
+  const primary = getPrimaryPane(tab.layout)
+  return primary.content.kind === 'session' ? primary.content.sessionCode : null
+}
+
+/** Cross-store subscription: auto-markRead when the active tab changes to a session.
+ *  Call once at app init. Returns unsubscribe function. */
+export function subscribeActiveTabMarkRead(): () => void {
+  let prev = getActiveSessionCode()
+  return useTabStore.subscribe(() => {
+    const current = getActiveSessionCode()
+    if (current !== prev) {
+      prev = current
+      if (current !== null) {
+        useAgentStore.getState().markRead(current)
+      }
+    }
+  })
+}

--- a/spa/src/main.tsx
+++ b/spa/src/main.tsx
@@ -5,12 +5,26 @@ import App from './App.tsx'
 import { registerBuiltinLocales } from './lib/register-locales'
 import { registerBuiltinThemes } from './lib/register-themes'
 import { registerBuiltinPanes } from './lib/register-panes'
-import { subscribeActiveTabMarkRead } from './lib/active-session'
+import { getActiveSessionCode } from './lib/active-session'
+import { useTabStore } from './stores/useTabStore'
+import { useAgentStore } from './stores/useAgentStore'
 
 registerBuiltinLocales()
 registerBuiltinThemes()
 registerBuiltinPanes()
-subscribeActiveTabMarkRead()
+
+// Cross-store subscription: auto-markRead when active tab changes to a session.
+// Inlined here to avoid circular dependency between active-session.ts and useAgentStore.
+let prevSession = getActiveSessionCode()
+useTabStore.subscribe(() => {
+  const current = getActiveSessionCode()
+  if (current !== prevSession) {
+    prevSession = current
+    if (current !== null) {
+      useAgentStore.getState().markRead(current)
+    }
+  }
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/spa/src/main.tsx
+++ b/spa/src/main.tsx
@@ -5,10 +5,12 @@ import App from './App.tsx'
 import { registerBuiltinLocales } from './lib/register-locales'
 import { registerBuiltinThemes } from './lib/register-themes'
 import { registerBuiltinPanes } from './lib/register-panes'
+import { subscribeActiveTabMarkRead } from './lib/active-session'
 
 registerBuiltinLocales()
 registerBuiltinThemes()
 registerBuiltinPanes()
+subscribeActiveTabMarkRead()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -1,6 +1,8 @@
 // spa/src/stores/useAgentStore.test.ts
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useAgentStore } from './useAgentStore'
+import { useTabStore } from './useTabStore'
+import { createTab } from '../types/tab'
 import type { AgentHookEvent } from './useAgentStore'
 
 beforeEach(() => {
@@ -8,9 +10,9 @@ beforeEach(() => {
     events: {},
     statuses: {},
     unread: {},
-    focusedSession: null,
     hooksInstalled: false,
   })
+  useTabStore.setState({ tabs: {}, activeTabId: null, tabOrder: [] })
 })
 
 describe('useAgentStore', () => {
@@ -151,7 +153,7 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().statuses['dev']).toBe('idle')
   })
 
-  it('Stop → marks unread when focusedSession is null', () => {
+  it('Stop → marks unread when active tab is not this session', () => {
     const event: AgentHookEvent = {
       tmux_session: 'dev',
       event_name: 'Stop',
@@ -161,6 +163,20 @@ describe('useAgentStore', () => {
     }
     useAgentStore.getState().handleHookEvent('dev', event)
     expect(useAgentStore.getState().unread['dev']).toBe(true)
+  })
+
+  it('Stop → does NOT mark unread when active tab is this session', () => {
+    const tab = { ...createTab({ kind: 'session', sessionCode: 'dev', mode: 'terminal' }), id: 't1' }
+    useTabStore.setState({ tabs: { t1: tab }, activeTabId: 't1' })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Stop',
+      raw_event: {},
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().unread['dev']).toBeUndefined()
   })
 
   it('Notification(idle_prompt) → does not mark unread', () => {

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -64,7 +64,7 @@ export function getAgentLabel(event: AgentHookEvent | undefined): string | null 
 
 export const useAgentStore = create<AgentState>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       events: {},
       statuses: {},
       unread: {},

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -1,6 +1,7 @@
 // spa/src/stores/useAgentStore.ts
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { getActiveSessionCode } from '../lib/active-session'
 
 export type AgentStatus = 'running' | 'waiting' | 'idle'
 export type TabIndicatorStyle = 'overlay' | 'replace' | 'inline'
@@ -17,13 +18,11 @@ interface AgentState {
   events: Record<string, AgentHookEvent>       // latest event per session code
   statuses: Record<string, AgentStatus>        // derived status per session
   unread: Record<string, boolean>              // unread flag per session
-  focusedSession: string | null
   tabIndicatorStyle: TabIndicatorStyle
   hooksInstalled: boolean                      // whether CC hooks are installed
 
   handleHookEvent: (session: string, event: AgentHookEvent) => void
   markRead: (session: string) => void
-  setFocusedSession: (session: string | null) => void
   setTabIndicatorStyle: (style: TabIndicatorStyle) => void
   setHooksInstalled: (installed: boolean) => void
 }
@@ -69,7 +68,6 @@ export const useAgentStore = create<AgentState>()(
       events: {},
       statuses: {},
       unread: {},
-      focusedSession: null,
       tabIndicatorStyle: 'overlay' as TabIndicatorStyle,
       hooksInstalled: false,
 
@@ -102,7 +100,7 @@ export const useAgentStore = create<AgentState>()(
           // (idle_prompt/auth_success are informational and should not trigger the red dot).
           const isActionable = derived === 'waiting' ||
             (derived === 'idle' && event.event_name !== 'Notification')
-          if (isActionable && get().focusedSession !== session) {
+          if (isActionable && getActiveSessionCode() !== session) {
             set((s) => ({ unread: { ...s.unread, [session]: true } }))
           }
         }
@@ -113,13 +111,6 @@ export const useAgentStore = create<AgentState>()(
         const { [session]: _, ...rest } = s.unread
         return { unread: rest }
       }),
-
-      setFocusedSession: (session) => {
-        set({ focusedSession: session })
-        if (session !== null) {
-          get().markRead(session)
-        }
-      },
 
       setTabIndicatorStyle: (style) => set({ tabIndicatorStyle: style }),
       setHooksInstalled: (installed) => set({ hooksInstalled: installed }),


### PR DESCRIPTION
## Summary
- 將手動同步的 `focusedSession` 狀態改為從 `activeTabId` 即時衍生，修復鍵盤快捷鍵切 tab 時通知仍在 active tab 彈出的問題
- 非 active 的 keep-alive tab 加上 `inert` attribute，防止隱藏的 terminal 攔截鍵盤輸入
- Stream tab 切換後自動 focus textarea

### 改動明細
- **`lib/active-session.ts`** — `getActiveSessionCode()` 衍生函式 + `subscribeActiveTabMarkRead()` cross-store subscription
- **`useAgentStore`** — 移除 `focusedSession` / `setFocusedSession`，`handleHookEvent` 改用 `getActiveSessionCode()`
- **`useNotificationDispatcher`** — `shouldNotify` 的 focusedSession 改從 `getActiveSessionCode()` 取得
- **`TabContent`** — 非 active div 加 `inert`
- **`StreamInput`** — 加 `focused` prop
- **`ConversationView`** / **`SessionPaneContent`** — 傳遞 `isActive`

## Test plan
- [x] 625 tests pass（1 個 pre-existing failure in TerminalView.test.tsx）
- [x] `getActiveSessionCode` 5 tests
- [x] `useAgentStore` unread marking with active tab 20 tests
- [x] `TabContent` inert attribute test
- [x] `StreamInput` focused prop 2 tests
- [ ] 手動驗證：Cmd+1~9 切 tab 後通知不在 active tab 彈出
- [ ] 手動驗證：切到 stream tab 後 textarea 自動 focus
- [ ] 手動驗證：隱藏 tab 的 terminal 不再攔截鍵盤輸入