### PR TITLE
feat: agent hook enhancement — error status, subagent tracking, unread fix

### DIFF
--- a/cmd/tbox/setup.go
+++ b/cmd/tbox/setup.go
@@ -12,6 +12,8 @@ import (
 var hookEvents = []string{
 	"SessionStart",
 	"UserPromptSubmit",
+	"SubagentStart",
+	"SubagentStop",
 	"Stop",
 	"StopFailure",
 	"Notification",

--- a/docs/superpowers/specs/2026-03-30-agent-hook-enhancement-design.md
+++ b/docs/superpowers/specs/2026-03-30-agent-hook-enhancement-design.md
@@ -1,0 +1,230 @@
+# Agent Hook 狀態偵測增強
+
+## 背景
+
+現有 agent hook 狀態偵測（spec: `2026-03-29-agent-hook-status-design.md`）存在三個問題：
+
+### 問題 1：SessionStart 錯誤推導為 running
+
+`SessionStart` 的 `source` 有四種值，目前除 `compact` 外全部推導為 `running`，但 `startup`/`resume`/`clear` 實際上是 CC 等待使用者輸入（idle）。
+
+| source | 含義 | 現行推導 | 正確推導 |
+|--------|------|----------|----------|
+| `startup` | 全新啟動 | ❌ `running` | `idle` |
+| `resume` | 恢復舊 session | ❌ `running` | `idle` |
+| `clear` | `/clear` 後重新開始 | ❌ `running` | `idle` |
+| `compact` | 自動壓縮（工作中途） | ✅ `null` | `null` |
+
+### 問題 2：StopFailure 缺少 error 狀態
+
+`StopFailure` 目前推導為 `idle`，但實際上代表 API 錯誤（rate limit、認證失敗等），應顯示紅色錯誤燈號。
+
+`StopFailure` 的 `error` 欄位可能值：
+- `rate_limit` — 速率限制
+- `authentication_failed` — 認證失敗
+- `billing_error` — 帳單問題
+- `server_error` — 伺服器錯誤
+- `max_output_tokens` — 輸出上限
+- `invalid_request` — 請求無效
+- `unknown` — 未知錯誤
+
+### 問題 3：Stale running 問題
+
+已知 CC bug（[anthropics/claude-code#34713](https://github.com/anthropics/claude-code/issues/34713)）會導致 `UserPromptSubmit` hook 觸發後 CC 靜默丟棄 prompt，跳回輸入狀態。此時不會產生 `Stop`/`SessionEnd` 事件，DB 中 `UserPromptSubmit` 永遠不被覆蓋，snapshot 持續顯示 `running`。
+
+事件流程斷裂：
+```
+UserPromptSubmit → (hook 觸發，POST 到 daemon) → CC 靜默丟棄 prompt → 跳回輸入
+                                                    ↑
+                                            沒有 Stop / SessionEnd
+```
+
+## CC Hooks 完整參考
+
+以下是所有 CC hook 事件、tbox 目前使用狀態、及可用於狀態偵測的分析。
+
+### 目前 tbox 註冊的 hooks（7 個）
+
+定義在 `cmd/tbox/setup.go` 的 `hookEvents`：
+
+| Hook | 推導狀態 | 用途 |
+|------|----------|------|
+| `SessionStart` | `running`（應改 `idle`） | CC 啟動/恢復 |
+| `UserPromptSubmit` | `running` | 使用者送出 prompt |
+| `Notification` | `waiting` 或 `idle` | 通知（權限/idle/auth） |
+| `PermissionRequest` | `waiting` | 權限對話框 |
+| `Stop` | `idle` | CC 正常結束回應 |
+| `StopFailure` | `idle`（應改 `error`） | API 錯誤 |
+| `SessionEnd` | `clear` | Session 結束 |
+
+### 所有 CC hook 事件（完整清單）
+
+| 事件 | 觸發時機 | Matcher 欄位 | 可 Block | stdin 關鍵欄位 |
+|------|----------|-------------|----------|---------------|
+| `SessionStart` | session 啟動/恢復 | `source`: startup, resume, clear, compact | 否 | `source`, `model`, `session_id` |
+| `InstructionsLoaded` | CLAUDE.md 載入 | `load_reason` | 否 | `file_path`, `memory_type` |
+| `UserPromptSubmit` | 使用者送出 prompt | 無 | 是（exit 2） | `prompt`, `permission_mode` |
+| `PreToolUse` | 工具執行前 | `tool_name` (regex) | 是（exit 2） | `tool_name`, `tool_input`, `tool_use_id` |
+| `PermissionRequest` | 權限對話框出現 | `tool_name` (regex) | 是 | `tool_name`, `tool_input` |
+| `PostToolUse` | 工具成功執行後 | `tool_name` (regex) | 否 | `tool_name`, `tool_input`, `tool_response` |
+| `PostToolUseFailure` | 工具失敗後 | `tool_name` (regex) | 否 | `tool_name`, `tool_input`, `error` |
+| `Notification` | 通知發送 | `notification_type` | 否 | `message`, `notification_type` |
+| `SubagentStart` | subagent 啟動 | `agent_type` | 否 | `agent_id`, `agent_type` |
+| `SubagentStop` | subagent 結束 | `agent_type` | 是（exit 2） | `agent_id`, `agent_type`, `last_assistant_message`, `agent_transcript_path` |
+| `TaskCreated` | Task 建立 | 無 | 是（exit 2） | `task_id`, `task_subject` |
+| `TaskCompleted` | Task 完成 | 無 | 是（exit 2） | `task_id`, `task_subject` |
+| `Stop` | CC 正常結束回應 | 無 | 是（exit 2） | `last_assistant_message`, `stop_hook_active` |
+| `StopFailure` | API 錯誤 | `error` type | 否 | `error`, `error_details`, `last_assistant_message` |
+| `TeammateIdle` | Teammate 閒置 | 無 | 是 | `teammate_name`, `team_name` |
+| `ConfigChange` | 設定檔變更 | `source` | 是（exit 2） | `source`, `file_path` |
+| `CwdChanged` | 工作目錄改變 | 無 | 否 | `cwd` |
+| `FileChanged` | 監控檔案改變 | filename basename | 否 | `file_path` |
+| `PreCompact` | context 壓縮前 | `compaction_type` | 否 | `compaction_type`: manual, auto |
+| `PostCompact` | context 壓縮後 | `compaction_type` | 否 | `compaction_type`: manual, auto |
+| `Elicitation` | MCP server 要求輸入 | MCP server name | 是 | `mcp_server`, `form_schema` |
+| `ElicitationResult` | 使用者回應 MCP 輸入 | MCP server name | 是 | `mcp_server`, `user_response` |
+| `WorktreeCreate` | Worktree 建立 | 無 | 是 | — |
+| `WorktreeRemove` | Worktree 移除 | 無 | 否 | — |
+| `SessionEnd` | session 結束 | `source`: clear, resume, logout, prompt_input_exit, bypass_permissions_disabled, other | 否 | `source` |
+
+### SubagentStart / SubagentStop 配對
+
+兩個事件都帶 `agent_id` 欄位，可做精確配對：
+
+```json
+// SubagentStart stdin
+{
+  "hook_event_name": "SubagentStart",
+  "session_id": "abc123",
+  "agent_id": "agent-abc123",        // ← 配對 key
+  "agent_type": "Explore"            // Explore | Bash | Plan | 自定義
+}
+
+// SubagentStop stdin
+{
+  "hook_event_name": "SubagentStop",
+  "session_id": "abc123",
+  "agent_id": "agent-abc123",        // ← 同一個 ID
+  "agent_type": "Explore",
+  "agent_transcript_path": "...jsonl",
+  "last_assistant_message": "...",
+  "stop_hook_active": false
+}
+```
+
+**已知限制**（[anthropics/claude-code#14859](https://github.com/anthropics/claude-code/issues/14859)）：
+- 所有 hook 事件共用同一個 `session_id`，無法區分是主 agent 還是 subagent 產生的 PreToolUse
+- 沒有 `parent_agent_id` 欄位，無法建立 agent 樹狀結構
+- 只能做「這個 session 有 N 個 subagent 在跑」的粗略計數
+
+## 修改方案
+
+### 一、修改 AgentStatus 型別
+
+```typescript
+// spa/src/stores/useAgentStore.ts
+export type AgentStatus = 'running' | 'waiting' | 'idle' | 'error'
+```
+
+### 二、修改 deriveStatus
+
+`SubagentStart`/`SubagentStop` **不經過 deriveStatus**，在 `handleHookEvent` 中 early return，只更新 `activeSubagents` 追蹤，不影響主 agent 狀態。原因：subagent 是獨立的工作單元，主 agent 的 idle/running/error 應由自身事件決定。
+
+```typescript
+function deriveStatus(eventName: string, rawEvent?: Record<string, unknown>): AgentStatus | 'clear' | null {
+  switch (eventName) {
+    case 'SessionStart':
+      if (rawEvent?.source === 'compact') return null
+      return 'idle'                    // ← 修正：啟動 = 等待輸入
+    case 'UserPromptSubmit':
+      return 'running'
+    case 'Notification': {
+      const nt = rawEvent?.notification_type
+      if (nt === 'permission_prompt' || nt === 'elicitation_dialog') return 'waiting'
+      if (nt === 'idle_prompt' || nt === 'auth_success') return 'idle'
+      if (nt !== undefined) console.warn('[deriveStatus] unknown notification_type:', nt)
+      return null
+    }
+    case 'PermissionRequest':
+      return 'waiting'
+    case 'Stop':
+      return 'idle'
+    case 'StopFailure':
+      return 'error'                   // ← 修正：錯誤狀態
+    case 'SessionEnd':
+      return 'clear'
+    default:
+      return null
+  }
+}
+```
+
+### 三、新增 hook 註冊
+
+在 `cmd/tbox/setup.go` 的 `hookEvents` 新增：
+
+> **注意**：`PreToolUse` 延後實作（目前無 stale running 問題），待需要時再加。
+
+```go
+var hookEvents = []string{
+    "SessionStart",
+    "UserPromptSubmit",
+    "SubagentStart",        // ← 新增（ephemeral，不存 DB）
+    "SubagentStop",         // ← 新增（ephemeral，不存 DB）
+    "Stop",
+    "StopFailure",
+    "Notification",
+    "PermissionRequest",
+    "SessionEnd",
+}
+```
+
+### 四、PreToolUse 效能考量
+
+`PreToolUse` 觸發頻率極高（每個工具呼叫都觸發），需要在 daemon 端做優化：
+
+**方案 A — 只更新 timestamp，不存完整事件**
+- 收到 `PreToolUse` 時只更新 `agent_events` 表的 `updated_at` 欄位
+- 不廣播完整 hook event 到 WS
+- 前端用 `updated_at` 差異偵測 stale
+
+**方案 B — 節流廣播**
+- daemon 收到 `PreToolUse` 後標記 session 為 active
+- 每 N 秒檢查一次，如果 session active 且當前狀態非 running，才廣播 status change
+- 減少 WS 訊息量
+
+### 五、error 狀態 UI
+
+| 狀態 | 顏色 | 動畫 |
+|------|------|------|
+| running | `#4ade80` 綠 | 呼吸燈 |
+| waiting | `#facc15` 黃 | 無 |
+| idle | `#6b7280` 灰 | 無 |
+| **error** | **`#ef4444` 紅** | **無** |
+
+### 六、Stale running 偵測（前端輔助）
+
+即使新增 `PreToolUse`，仍需前端 stale timeout 作為最後防線：
+
+- `UserPromptSubmit` 後 N 秒內無後續事件 → 降級為 `idle`
+- N 的建議值：60 秒（CC 長思考 + API 延遲的合理上限）
+- 實作位置：`useAgentStore` 的 `handleHookEvent` 中啟動 timer
+
+## 涉及檔案
+
+| 檔案 | 修改內容 |
+|------|----------|
+| `cmd/tbox/setup.go` | `hookEvents` 新增 3 個事件 |
+| `cmd/tbox/hook.go` | 無需修改（通用處理） |
+| `internal/module/agent/handler.go` | PreToolUse 效能優化邏輯 |
+| `internal/store/agent_event.go` | 可能新增 `updated_at` 欄位 |
+| `spa/src/stores/useAgentStore.ts` | `AgentStatus` 加 `error`、`deriveStatus` 修正 |
+| `spa/src/components/TabBar/TabButton.tsx` | error 燈號顏色 |
+| `spa/src/components/SessionPanel/` | error 燈號顏色 |
+
+## 參考資料
+
+- [CC Hooks 官方文件](https://code.claude.com/docs/en/hooks)
+- [#34713 — False "Hook Error" labels](https://github.com/anthropics/claude-code/issues/34713)
+- [#13912 — UserPromptSubmit stdout error](https://github.com/anthropics/claude-code/issues/13912)
+- [#14859 — Agent Hierarchy in Hook Events](https://github.com/anthropics/claude-code/issues/14859)

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -31,10 +31,18 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// Store event (skip if no tmux session — can't map to anything useful).
 	if req.TmuxSession != "" {
 		broadcastTs := time.Now().UnixNano()
-		if err := m.events.Set(req.TmuxSession, req.EventName, req.RawEvent, req.AgentType, broadcastTs); err != nil {
-			log.Printf("[agent] store event: %v", err)
-			http.Error(w, `{"error":"store failed"}`, http.StatusInternalServerError)
-			return
+
+		// SubagentStart/SubagentStop are transient — broadcast only, do not
+		// overwrite the DB record.  This prevents sendSnapshot from replaying
+		// a SubagentStop instead of the real Stop/StopFailure on WS reconnect.
+		ephemeral := req.EventName == "SubagentStart" || req.EventName == "SubagentStop"
+
+		if !ephemeral {
+			if err := m.events.Set(req.TmuxSession, req.EventName, req.RawEvent, req.AgentType, broadcastTs); err != nil {
+				log.Printf("[agent] store event: %v", err)
+				http.Error(w, `{"error":"store failed"}`, http.StatusInternalServerError)
+				return
+			}
 		}
 
 		// Broadcast to WS subscribers if we can resolve session code.

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -104,7 +104,7 @@ func (m *Module) handleHookStatus(w http.ResponseWriter, r *http.Request) {
 	var issues []string
 	allInstalled := true
 
-	hookEvents := []string{"SessionStart", "UserPromptSubmit", "Stop", "StopFailure", "Notification", "PermissionRequest", "SessionEnd"}
+	hookEvents := []string{"SessionStart", "UserPromptSubmit", "SubagentStart", "SubagentStop", "Stop", "StopFailure", "Notification", "PermissionRequest", "SessionEnd"}
 	for _, eventName := range hookEvents {
 		entries, ok := hooks[eventName]
 		if !ok {

--- a/spa/src/components/HandoffButton.tsx
+++ b/spa/src/components/HandoffButton.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 function isAgentActive(status?: AgentStatus): boolean {
-  return status === 'idle' || status === 'running' || status === 'waiting'
+  return status === 'idle' || status === 'running' || status === 'waiting' || status === 'error'
 }
 
 export default function HandoffButton({ inProgress, progress = '', agentStatus, onHandoff }: Props) {

--- a/spa/src/components/SessionStatusBadge.test.tsx
+++ b/spa/src/components/SessionStatusBadge.test.tsx
@@ -9,6 +9,7 @@ describe('SessionStatusBadge', () => {
     ['running', 'bg-green-400'],
     ['waiting', 'bg-yellow-400'],
     ['idle', 'bg-gray-500'],
+    ['error', 'bg-red-500'],
   ]
 
   cases.forEach(([status, expectedClass]) => {

--- a/spa/src/components/SessionStatusBadge.tsx
+++ b/spa/src/components/SessionStatusBadge.tsx
@@ -5,6 +5,7 @@ const STATUS_COLORS: Record<AgentStatus, string> = {
   running: 'bg-green-400',
   waiting: 'bg-yellow-400',
   idle: 'bg-gray-500',
+  error: 'bg-red-500',
 }
 
 interface Props {

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -9,6 +9,7 @@ import { useI18nStore } from '../stores/useI18nStore'
 import { useAgentStore } from '../stores/useAgentStore'
 import type { AgentStatus, TabIndicatorStyle } from '../stores/useAgentStore'
 import { TabStatusDot } from './TabStatusDot'
+import { SubagentDots } from './SubagentDots'
 
 function renderTabIcon(
   IconComponent: React.ComponentType<{ size: number; className?: string }> | undefined,
@@ -16,22 +17,30 @@ function renderTabIcon(
   tabIndicatorStyle: TabIndicatorStyle,
   isActive: boolean,
   iconSize: number,
+  subagentCount: number,
 ) {
   if (tabIndicatorStyle === 'replace' && agentStatus) {
-    return <TabStatusDot status={agentStatus} style="replace" isActive={isActive} />
+    return (
+      <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
+        <TabStatusDot status={agentStatus} style="replace" isActive={isActive} />
+        {subagentCount > 0 && <SubagentDots count={subagentCount} isActive={isActive} />}
+      </span>
+    )
   }
   if (tabIndicatorStyle === 'inline') {
     return (
-      <>
+      <span className="relative inline-flex items-center justify-center flex-shrink-0" style={{ minWidth: 16 }}>
         {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
         <TabStatusDot status={agentStatus} style="inline" isActive={isActive} />
-      </>
+        {subagentCount > 0 && <SubagentDots count={subagentCount} isActive={isActive} />}
+      </span>
     )
   }
   return (
     <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
       {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
       <TabStatusDot status={agentStatus} style="overlay" isActive={isActive} />
+      {subagentCount > 0 && <SubagentDots count={subagentCount} isActive={isActive} />}
     </span>
   )
 }
@@ -81,6 +90,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
     return s.statuses[sessionCode]
   })
   const isUnread = useAgentStore((s) => sessionCode ? !!s.unread[sessionCode] : false)
+  const subagentCount = useAgentStore((s) => sessionCode ? (s.activeSubagents[sessionCode]?.length ?? 0) : 0)
   const tabIndicatorStyle = useAgentStore((s) => s.tabIndicatorStyle)
   const sessionLookup = { getByCode: (code: string) => sessions.find((s) => s.code === code) }
   const workspaceLookup = { getById: (id: string) => workspaces.find((w) => w.id === id) }
@@ -117,10 +127,10 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
         }`}
         title={label}
       >
-        {renderTabIcon(IconComponent, agentStatus, tabIndicatorStyle, isActive, 14)}
+        {renderTabIcon(IconComponent, agentStatus, tabIndicatorStyle, isActive, 14, subagentCount)}
         {tab.locked && <Lock size={10} className="absolute bottom-0.5 right-0.5" />}
         {!isActive && isUnread && (
-          <span className="absolute top-0.5 right-1 w-[5px] h-[5px] rounded-full"
+          <span className="absolute -top-[4px] -right-[4px] w-2 h-2 rounded-full z-20"
             style={{ backgroundColor: '#b91c1c' }} />
         )}
       </button>
@@ -147,17 +157,17 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onContextMenu={handleContextMenu}
-      className={`group relative flex items-center gap-1.5 pl-2 pr-1 text-xs whitespace-nowrap cursor-pointer transition-colors duration-150 ease-out rounded-[6px] overflow-hidden ${
+      className={`group relative flex items-center gap-1.5 pl-2 pr-1 text-xs whitespace-nowrap cursor-pointer transition-colors duration-150 ease-out rounded-[6px] ${
         isActive
           ? 'text-white bg-surface-active border border-accent-muted'
           : 'text-text-muted hover:text-text-primary bg-surface-secondary hover:bg-surface-hover border border-transparent'
       }`}
     >
-      {renderTabIcon(IconComponent, agentStatus, tabIndicatorStyle, isActive, 14)}
+      {renderTabIcon(IconComponent, agentStatus, tabIndicatorStyle, isActive, 14, subagentCount)}
       <span className="overflow-hidden flex-1 min-w-0 text-left">{label}</span>
       {tab.locked && <Lock size={10} className="ml-0.5 flex-shrink-0" />}
       {!isActive && isUnread && (
-        <span className="absolute top-0.5 right-1 w-[5px] h-[5px] rounded-full"
+        <span className="absolute -top-[4px] -right-[4px] w-2 h-2 rounded-full z-20"
           style={{ backgroundColor: '#b91c1c' }} />
       )}
       {showClose && (

--- a/spa/src/components/SubagentDots.tsx
+++ b/spa/src/components/SubagentDots.tsx
@@ -1,0 +1,49 @@
+// spa/src/components/SubagentDots.tsx
+
+interface Props {
+  count: number
+  isActive: boolean
+}
+
+const COLOR = '#60a5fa'
+const DOT_SIZES: Record<number, number> = { 1: 4, 2: 3.5, 3: 3 }
+
+// Vertical line positions to the left of the icon center.
+const ARC_POSITIONS: Record<number, [number, number][]> = {
+  1: [[-9, 0]],
+  2: [[-9, -4], [-9, 4]],
+  3: [[-9, -5.5], [-9, 0], [-9, 5.5]],
+}
+
+export function SubagentDots({ count, isActive }: Props) {
+  if (count <= 0) return null
+  const clamped = Math.min(count, 3)
+  const positions = ARC_POSITIONS[clamped]
+  const dotSize = DOT_SIZES[clamped]
+
+  const breatheBg = isActive
+    ? 'var(--surface-active)'
+    : 'var(--surface-secondary)'
+
+  return (
+    <>
+      {positions.map(([left, top], i) => (
+        <span
+          key={i}
+          className="absolute rounded-full animate-breathe"
+          style={{
+            width: dotSize,
+            height: dotSize,
+            backgroundColor: COLOR,
+            left: `calc(50% + ${left}px)`,
+            top: `calc(50% + ${top}px)`,
+            transform: 'translate(-50%, -50%)',
+            '--breathe-color': COLOR,
+            '--breathe-bg': breatheBg,
+            animationDelay: `${i * 0.3}s`,
+          } as React.CSSProperties}
+        />
+      ))}
+    </>
+  )
+}

--- a/spa/src/components/TabStatusDot.tsx
+++ b/spa/src/components/TabStatusDot.tsx
@@ -13,6 +13,7 @@ const STATUS_COLORS: Record<AgentStatus, string> = {
   running: '#4ade80',
   waiting: '#facc15',
   idle: '#6b7280',
+  error: '#ef4444',
 }
 
 export function TabStatusDot({ status, style, isActive }: Props) {

--- a/spa/src/hooks/useNotificationDispatcher.test.ts
+++ b/spa/src/hooks/useNotificationDispatcher.test.ts
@@ -47,6 +47,9 @@ describe('shouldNotify', () => {
   it('returns true for waiting Notification (permission_prompt/elicitation_dialog)', () => {
     expect(shouldNotify({ derived: 'waiting', eventName: 'Notification', sessionCode: 'abc', focusedSession: null, hasTab: true, settings: defaultSettings })).toBe(true)
   })
+  it('returns true for error event (StopFailure)', () => {
+    expect(shouldNotify({ derived: 'error', eventName: 'StopFailure', sessionCode: 'abc', focusedSession: null, hasTab: true, settings: defaultSettings })).toBe(true)
+  })
 })
 
 describe('shouldDispatch', () => {

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -53,7 +53,7 @@ interface ShouldNotifyParams {
 
 export function shouldNotify(params: ShouldNotifyParams): boolean {
   const { derived, eventName, sessionCode, focusedSession, hasTab, settings } = params
-  if (derived !== 'waiting' && derived !== 'idle') return false
+  if (derived !== 'waiting' && derived !== 'idle' && derived !== 'error') return false
   // Informational Notification subtypes (idle_prompt, auth_success) derive to 'idle'
   // but should not trigger desktop notifications — consistent with unread marking logic.
   if (derived === 'idle' && eventName === 'Notification') return false

--- a/spa/src/hooks/useSessionEventWs.ts
+++ b/spa/src/hooks/useSessionEventWs.ts
@@ -43,6 +43,10 @@ export function useSessionEventWs(wsBase: string, daemonBase: string) {
           }
         }
       },
+      undefined, // onClose
+      // onOpen (initial + reconnect): clear ephemeral subagent tracking —
+      // DB snapshot won't contain SubagentStart/Stop events.
+      () => { useAgentStore.getState().clearAllSubagents() },
     )
     return () => conn.close()
   }, [fetchSessions, daemonBase, wsBase])

--- a/spa/src/lib/notification-content.test.ts
+++ b/spa/src/lib/notification-content.test.ts
@@ -43,4 +43,8 @@ describe('buildNotificationContent', () => {
     const result = buildNotificationContent('Notification', {}, 'my-session', t)
     expect(result).toEqual({ title: 'my-session', body: '新通知' })
   })
+  it('collapses consecutive newlines in body', () => {
+    const result = buildNotificationContent('Stop', { last_assistant_message: 'Line 1\n\n\nLine 2\n\nLine 3' }, 'my-session')
+    expect(result).toEqual({ title: 'my-session', body: 'Line 1\nLine 2\nLine 3' })
+  })
 })

--- a/spa/src/lib/notification-content.ts
+++ b/spa/src/lib/notification-content.ts
@@ -2,22 +2,34 @@
 
 interface NotificationContent { title: string; body: string }
 
+/** Collapse consecutive newlines into a single newline. */
+function collapseNewlines(s: string): string {
+  return s.replace(/\n{2,}/g, '\n')
+}
+
 export function buildNotificationContent(
   eventName: string,
   rawEvent: Record<string, unknown>,
   sessionName: string,
   t?: (key: string) => string,
 ): NotificationContent | null {
+  let content: NotificationContent | null
   switch (eventName) {
     case 'Notification':
-      return { title: sessionName, body: (rawEvent.message as string) || (t?.('notification.fallback.new') ?? 'New notification') }
+      content = { title: sessionName, body: (rawEvent.message as string) || (t?.('notification.fallback.new') ?? 'New notification') }
+      break
     case 'PermissionRequest':
-      return { title: sessionName, body: (rawEvent.tool_name as string) ? `Permission required: ${rawEvent.tool_name}` : (t?.('notification.fallback.permission') ?? 'Permission required: unknown tool') }
+      content = { title: sessionName, body: (rawEvent.tool_name as string) ? `Permission required: ${rawEvent.tool_name}` : (t?.('notification.fallback.permission') ?? 'Permission required: unknown tool') }
+      break
     case 'Stop':
-      return { title: sessionName, body: (rawEvent.last_assistant_message as string) || (t?.('notification.fallback.stop') ?? 'Task completed') }
+      content = { title: sessionName, body: (rawEvent.last_assistant_message as string) || (t?.('notification.fallback.stop') ?? 'Task completed') }
+      break
     case 'StopFailure':
-      return { title: sessionName, body: (rawEvent.error_details as string) || (rawEvent.error as string) || (t?.('notification.fallback.stopFailure') ?? 'Task stopped unexpectedly') }
+      content = { title: sessionName, body: (rawEvent.error_details as string) || (rawEvent.error as string) || (t?.('notification.fallback.stopFailure') ?? 'Task stopped unexpectedly') }
+      break
     default:
       return null
   }
+  content.body = collapseNewlines(content.body)
+  return content
 }

--- a/spa/src/lib/session-events.ts
+++ b/spa/src/lib/session-events.ts
@@ -14,6 +14,7 @@ export function connectSessionEvents(
   url: string,
   onEvent: (event: SessionEvent) => void,
   onClose?: () => void,
+  onOpen?: () => void,
 ): EventConnection {
   let ws: WebSocket
   let retryMs = 1000
@@ -21,7 +22,7 @@ export function connectSessionEvents(
 
   function connect() {
     ws = new WebSocket(url)
-    ws.onopen = () => { retryMs = 1000 } // reset backoff on success
+    ws.onopen = () => { retryMs = 1000; onOpen?.() }
     ws.onmessage = (e) => {
       try {
         const event = JSON.parse(e.data) as SessionEvent

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -367,6 +367,19 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().activeSubagents['dev']).toBeUndefined()
   })
 
+  it('SessionStart(compact) → does NOT clear activeSubagents', () => {
+    useAgentStore.setState({ activeSubagents: { dev: ['agent-A'] } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SessionStart',
+      raw_event: { source: 'compact' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().activeSubagents['dev']).toEqual(['agent-A'])
+  })
+
   it('SubagentStart without agent_id → ignored', () => {
     const event: AgentHookEvent = {
       tmux_session: 'dev',

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -367,6 +367,72 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().activeSubagents['dev']).toBeUndefined()
   })
 
+  it('SubagentStart without agent_id → ignored', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SubagentStart',
+      raw_event: { agent_type: 'Explore' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().activeSubagents['dev']).toBeUndefined()
+    expect(useAgentStore.getState().events['dev']).toBeUndefined()
+  })
+
+  it('SubagentStop without agent_id → ignored', () => {
+    useAgentStore.setState({ activeSubagents: { dev: ['agent-A'] } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SubagentStop',
+      raw_event: { agent_type: 'Explore' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    // activeSubagents unchanged — agent-A still there
+    expect(useAgentStore.getState().activeSubagents['dev']).toEqual(['agent-A'])
+  })
+
+  it('error status is not downgraded by Notification(idle_prompt)', () => {
+    useAgentStore.setState({ statuses: { dev: 'error' } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Notification',
+      raw_event: { notification_type: 'idle_prompt' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('error')
+  })
+
+  it('error status is not downgraded by Notification(auth_success)', () => {
+    useAgentStore.setState({ statuses: { dev: 'error' } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'Notification',
+      raw_event: { notification_type: 'auth_success' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('error')
+  })
+
+  it('error status IS cleared by UserPromptSubmit', () => {
+    useAgentStore.setState({ statuses: { dev: 'error' } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'UserPromptSubmit',
+      raw_event: {},
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().statuses['dev']).toBe('running')
+  })
+
   it('stores raw_event data', () => {
     const rawEvent = { session_id: 'abc123', model: 'opus-4', extra: [1, 2, 3] }
     const event: AgentHookEvent = {

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -10,6 +10,7 @@ beforeEach(() => {
     events: {},
     statuses: {},
     unread: {},
+    activeSubagents: {},
     hooksInstalled: false,
   })
   useTabStore.setState({ tabs: {}, activeTabId: null, tabOrder: [] })
@@ -104,7 +105,7 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().statuses['dev']).toBe('idle')
   })
 
-  it('SessionStart(startup) → status = running', () => {
+  it('SessionStart(startup) → status = idle', () => {
     const event: AgentHookEvent = {
       tmux_session: 'dev',
       event_name: 'SessionStart',
@@ -113,10 +114,10 @@ describe('useAgentStore', () => {
       broadcast_ts: Date.now(),
     }
     useAgentStore.getState().handleHookEvent('dev', event)
-    expect(useAgentStore.getState().statuses['dev']).toBe('running')
+    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
   })
 
-  it('SessionStart(resume) → status = running', () => {
+  it('SessionStart(resume) → status = idle', () => {
     const event: AgentHookEvent = {
       tmux_session: 'dev',
       event_name: 'SessionStart',
@@ -125,10 +126,22 @@ describe('useAgentStore', () => {
       broadcast_ts: Date.now(),
     }
     useAgentStore.getState().handleHookEvent('dev', event)
-    expect(useAgentStore.getState().statuses['dev']).toBe('running')
+    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
   })
 
-  it('StopFailure → status = idle', () => {
+  it('SessionStart → marks unread when not focused', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SessionStart',
+      raw_event: { source: 'startup' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().unread['dev']).toBe(true)
+  })
+
+  it('StopFailure → status = error', () => {
     useAgentStore.setState({ statuses: { dev: 'running' } })
     const event: AgentHookEvent = {
       tmux_session: 'dev',
@@ -138,7 +151,7 @@ describe('useAgentStore', () => {
       broadcast_ts: Date.now(),
     }
     useAgentStore.getState().handleHookEvent('dev', event)
-    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
+    expect(useAgentStore.getState().statuses['dev']).toBe('error')
   })
 
   it('Stop → status = idle', () => {
@@ -252,6 +265,106 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().statuses['dev']).toBeUndefined()
     expect(useAgentStore.getState().events['dev']).toBeUndefined()
     expect(useAgentStore.getState().unread['dev']).toBeUndefined()
+  })
+
+  it('SessionEnd → clears activeSubagents', () => {
+    useAgentStore.setState({ activeSubagents: { dev: ['agent-A'] } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SessionEnd',
+      raw_event: {},
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().activeSubagents['dev']).toBeUndefined()
+  })
+
+  it('SubagentStart → adds agent_id to activeSubagents', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SubagentStart',
+      raw_event: { agent_id: 'agent-A', agent_type: 'Explore' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().activeSubagents['dev']).toEqual(['agent-A'])
+  })
+
+  it('SubagentStart → does not duplicate agent_id', () => {
+    useAgentStore.setState({ activeSubagents: { dev: ['agent-A'] } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SubagentStart',
+      raw_event: { agent_id: 'agent-A', agent_type: 'Explore' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().activeSubagents['dev']).toEqual(['agent-A'])
+  })
+
+  it('SubagentStop → removes agent_id from activeSubagents', () => {
+    useAgentStore.setState({ activeSubagents: { dev: ['agent-A', 'agent-B'] } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SubagentStop',
+      raw_event: { agent_id: 'agent-A', agent_type: 'Explore' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().activeSubagents['dev']).toEqual(['agent-B'])
+  })
+
+  it('SubagentStop → removes session key when last agent removed', () => {
+    useAgentStore.setState({ activeSubagents: { dev: ['agent-A'] } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SubagentStop',
+      raw_event: { agent_id: 'agent-A', agent_type: 'Explore' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().activeSubagents['dev']).toBeUndefined()
+  })
+
+  it('SubagentStart/Stop → does not change main status', () => {
+    useAgentStore.setState({ statuses: { dev: 'idle' } })
+    const start: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SubagentStart',
+      raw_event: { agent_id: 'agent-A', agent_type: 'Explore' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', start)
+    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
+
+    const stop: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SubagentStop',
+      raw_event: { agent_id: 'agent-A', agent_type: 'Explore' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', stop)
+    expect(useAgentStore.getState().statuses['dev']).toBe('idle')
+  })
+
+  it('SessionStart → clears stale activeSubagents', () => {
+    useAgentStore.setState({ activeSubagents: { dev: ['agent-A'] } })
+    const event: AgentHookEvent = {
+      tmux_session: 'dev',
+      event_name: 'SessionStart',
+      raw_event: { source: 'startup' },
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent('dev', event)
+    expect(useAgentStore.getState().activeSubagents['dev']).toBeUndefined()
   })
 
   it('stores raw_event data', () => {

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { getActiveSessionCode } from '../lib/active-session'
 
-export type AgentStatus = 'running' | 'waiting' | 'idle'
+export type AgentStatus = 'running' | 'waiting' | 'idle' | 'error'
 export type TabIndicatorStyle = 'overlay' | 'replace' | 'inline'
 
 export interface AgentHookEvent {
@@ -18,6 +18,7 @@ interface AgentState {
   events: Record<string, AgentHookEvent>       // latest event per session code
   statuses: Record<string, AgentStatus>        // derived status per session
   unread: Record<string, boolean>              // unread flag per session
+  activeSubagents: Record<string, string[]>    // active subagent IDs per session
   tabIndicatorStyle: TabIndicatorStyle
   hooksInstalled: boolean                      // whether CC hooks are installed
 
@@ -32,7 +33,8 @@ export function deriveStatus(eventName: string, rawEvent?: Record<string, unknow
     case 'SessionStart':
       // compact is background auto-compaction, not user activity
       if (rawEvent?.source === 'compact') return null
-      return 'running'
+      // startup/resume/clear = CC waiting for user input
+      return 'idle'
     case 'UserPromptSubmit':
       return 'running'
     case 'Notification': {
@@ -46,8 +48,9 @@ export function deriveStatus(eventName: string, rawEvent?: Record<string, unknow
     case 'PermissionRequest':
       return 'waiting'
     case 'Stop':
-    case 'StopFailure':
       return 'idle'
+    case 'StopFailure':
+      return 'error'
     case 'SessionEnd':
       return 'clear'
     default:
@@ -68,11 +71,44 @@ export const useAgentStore = create<AgentState>()(
       events: {},
       statuses: {},
       unread: {},
+      activeSubagents: {},
       tabIndicatorStyle: 'overlay' as TabIndicatorStyle,
       hooksInstalled: false,
 
       handleHookEvent: (session, event) => {
         const derived = deriveStatus(event.event_name, event.raw_event)
+
+        // Subagent tracking (before status derivation — does not affect main status)
+        if (event.event_name === 'SubagentStart') {
+          const agentId = event.raw_event?.agent_id as string | undefined
+          if (agentId) {
+            set((s) => {
+              const current = s.activeSubagents[session] || []
+              if (current.includes(agentId)) return s
+              return { activeSubagents: { ...s.activeSubagents, [session]: [...current, agentId] } }
+            })
+          }
+          // Store event but don't change main status
+          set((s) => ({ events: { ...s.events, [session]: event } }))
+          return
+        }
+        if (event.event_name === 'SubagentStop') {
+          const agentId = event.raw_event?.agent_id as string | undefined
+          if (agentId) {
+            set((s) => {
+              const current = s.activeSubagents[session] || []
+              const filtered = current.filter((id) => id !== agentId)
+              if (filtered.length === 0) {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { [session]: _, ...rest } = s.activeSubagents
+                return { activeSubagents: rest }
+              }
+              return { activeSubagents: { ...s.activeSubagents, [session]: filtered } }
+            })
+          }
+          set((s) => ({ events: { ...s.events, [session]: event } }))
+          return
+        }
 
         if (derived === 'clear') {
           // SessionEnd: remove session from all maps
@@ -83,9 +119,21 @@ export const useAgentStore = create<AgentState>()(
             const { [session]: _s, ...restStatuses } = s.statuses
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { [session]: _u, ...restUnread } = s.unread
-            return { events: restEvents, statuses: restStatuses, unread: restUnread }
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { [session]: _a, ...restSubagents } = s.activeSubagents
+            return { events: restEvents, statuses: restStatuses, unread: restUnread, activeSubagents: restSubagents }
           })
           return
+        }
+
+        // Safety net: clear subagents on SessionStart (fresh/resumed session)
+        if (event.event_name === 'SessionStart') {
+          set((s) => {
+            if (!s.activeSubagents[session]) return s
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { [session]: _, ...rest } = s.activeSubagents
+            return { activeSubagents: rest }
+          })
         }
 
         // Store the latest event
@@ -98,7 +146,7 @@ export const useAgentStore = create<AgentState>()(
           // Mark unread when not focused: all 'waiting' statuses are actionable;
           // 'idle' statuses are actionable only if they don't come from a Notification event
           // (idle_prompt/auth_success are informational and should not trigger the red dot).
-          const isActionable = derived === 'waiting' ||
+          const isActionable = derived === 'waiting' || derived === 'error' ||
             (derived === 'idle' && event.event_name !== 'Notification')
           if (isActionable && getActiveSessionCode() !== session) {
             set((s) => ({ unread: { ...s.unread, [session]: true } }))

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -78,35 +78,37 @@ export const useAgentStore = create<AgentState>()(
       handleHookEvent: (session, event) => {
         const derived = deriveStatus(event.event_name, event.raw_event)
 
-        // Subagent tracking (before status derivation — does not affect main status)
+        // Subagent tracking — does not affect main status.
+        // Ignore events without agent_id (malformed or future CC changes).
         if (event.event_name === 'SubagentStart') {
           const agentId = event.raw_event?.agent_id as string | undefined
-          if (agentId) {
-            set((s) => {
-              const current = s.activeSubagents[session] || []
-              if (current.includes(agentId)) return s
-              return { activeSubagents: { ...s.activeSubagents, [session]: [...current, agentId] } }
-            })
-          }
-          // Store event but don't change main status
-          set((s) => ({ events: { ...s.events, [session]: event } }))
+          if (!agentId) return
+          set((s) => {
+            const current = s.activeSubagents[session] || []
+            if (current.includes(agentId)) return { events: { ...s.events, [session]: event } }
+            return {
+              activeSubagents: { ...s.activeSubagents, [session]: [...current, agentId] },
+              events: { ...s.events, [session]: event },
+            }
+          })
           return
         }
         if (event.event_name === 'SubagentStop') {
           const agentId = event.raw_event?.agent_id as string | undefined
-          if (agentId) {
-            set((s) => {
-              const current = s.activeSubagents[session] || []
-              const filtered = current.filter((id) => id !== agentId)
-              if (filtered.length === 0) {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const { [session]: _, ...rest } = s.activeSubagents
-                return { activeSubagents: rest }
-              }
-              return { activeSubagents: { ...s.activeSubagents, [session]: filtered } }
-            })
-          }
-          set((s) => ({ events: { ...s.events, [session]: event } }))
+          if (!agentId) return
+          set((s) => {
+            const current = s.activeSubagents[session] || []
+            const filtered = current.filter((id) => id !== agentId)
+            if (filtered.length === 0) {
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              const { [session]: _, ...rest } = s.activeSubagents
+              return { activeSubagents: rest, events: { ...s.events, [session]: event } }
+            }
+            return {
+              activeSubagents: { ...s.activeSubagents, [session]: filtered },
+              events: { ...s.events, [session]: event },
+            }
+          })
           return
         }
 
@@ -140,8 +142,13 @@ export const useAgentStore = create<AgentState>()(
         set((s) => ({ events: { ...s.events, [session]: event } }))
 
         if (derived !== null) {
-          // Update status
-          set((s) => ({ statuses: { ...s.statuses, [session]: derived } }))
+          // Don't let informational Notification subtypes (idle_prompt, auth_success)
+          // downgrade an error status — the user should see the error until a real
+          // state change (UserPromptSubmit, SessionStart, Stop) clears it.
+          set((s) => {
+            if (s.statuses[session] === 'error' && derived === 'idle' && event.event_name === 'Notification') return s
+            return { statuses: { ...s.statuses, [session]: derived } }
+          })
 
           // Mark unread when not focused: all 'waiting' statuses are actionable;
           // 'idle' statuses are actionable only if they don't come from a Notification event

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -24,6 +24,7 @@ interface AgentState {
 
   handleHookEvent: (session: string, event: AgentHookEvent) => void
   markRead: (session: string) => void
+  clearAllSubagents: () => void
   setTabIndicatorStyle: (style: TabIndicatorStyle) => void
   setHooksInstalled: (installed: boolean) => void
 }
@@ -166,6 +167,8 @@ export const useAgentStore = create<AgentState>()(
         const { [session]: _, ...rest } = s.unread
         return { unread: rest }
       }),
+
+      clearAllSubagents: () => set({ activeSubagents: {} }),
 
       setTabIndicatorStyle: (style) => set({ tabIndicatorStyle: style }),
       setHooksInstalled: (installed) => set({ hooksInstalled: installed }),

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -129,8 +129,9 @@ export const useAgentStore = create<AgentState>()(
           return
         }
 
-        // Safety net: clear subagents on SessionStart (fresh/resumed session)
-        if (event.event_name === 'SessionStart') {
+        // Safety net: clear subagents on SessionStart (fresh/resumed session).
+        // Skip compact — that's mid-work auto-compaction, subagents may still be running.
+        if (event.event_name === 'SessionStart' && event.raw_event?.source !== 'compact') {
           set((s) => {
             if (!s.activeSubagents[session]) return s
             // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## Summary

- **Unread 紅點修正**：移除 `overflow-hidden`、重新定位到 tab 右上角框線上（`-top-[4px] -right-[4px]`、8px、`z-20`），解決被 close 按鈕 gradient 遮蔽問題
- **通知 newline 壓縮**：`buildNotificationContent` body 欄位連續換行壓成單個
- **deriveStatus 修正**：`SessionStart(startup/resume/clear)` → `idle`（等待輸入）、`StopFailure` → 新增 `error` 狀態（紅色燈號 `#ef4444`）
- **Unread 條件更新**：加入 `error` 為 actionable 狀態
- **Subagent 追蹤**：daemon 註冊 `SubagentStart`/`SubagentStop` hooks，SPA store 以 `agent_id` 追蹤 active subagents（safety net: SessionEnd/SessionStart 清空）
- **SubagentDots 元件**：1-3 顆藍色呼吸燈號（`#60a5fa`），依數量遞減尺寸，顯示在 tab icon 左側

## Test plan

- [ ] `cd spa && npx vitest run` — 28 store tests + 11 notification tests 通過
- [ ] 確認 unread 紅點在非 active tab 可見（不被 close 按鈕遮蔽）
- [ ] 確認 `StopFailure` 事件顯示紅色 error 燈號
- [ ] 確認 `SessionStart` 事件顯示灰色 idle 燈號（非綠色 running）
- [ ] 重新編譯 daemon + `tbox setup` 後確認新 hooks 註冊
- [ ] CC 派出 subagent 時確認藍色呼吸燈出現