### PR TITLE
feat: Phase 4 錯誤 UI — Terminated Tab + Host Error Display + Cascade Delete

### DIFF
--- a/docs/superpowers/plans/2026-04-04-phase4-error-ui.md
+++ b/docs/superpowers/plans/2026-04-04-phase4-error-ui.md
@@ -1,0 +1,1487 @@
+# Phase 4 — 錯誤 UI 實作計畫
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 實作完整的錯誤 UI — tab terminated 狀態、host 層級 L1-L3 錯誤顯示、host 刪除 cascade cleanup + undo、L2/L3 通知、以及 5 個 bug fix。
+
+**Architecture:** PaneContent 新增 `terminated` 欄位記錄終結原因（event-sourced，不可推導）。`useHostConnection` hook 封裝 SM 存取。通知 click handler 改為 action payload 模式。Host 刪除支援 undo（in-memory snapshot）。
+
+**Tech Stack:** React 19 / Zustand 5 / Tailwind 4 / Vitest / Phosphor Icons / xterm.js 6
+
+**Spec:** `docs/superpowers/specs/2026-04-04-phase4-error-ui-design.md`
+
+---
+
+## Phase 4a — Tab 狀態基礎建設
+
+### Task 1: PaneContent 類型更新 + TerminatedReason
+
+**Files:**
+- Modify: `spa/src/types/tab.ts:24-32`
+
+- [ ] **Step 1: 更新 PaneContent 類型**
+
+```typescript
+// spa/src/types/tab.ts — 替換 PaneContent 定義
+
+export type TerminatedReason = 'session-closed' | 'tmux-restarted' | 'host-removed'
+
+export type PaneContent =
+  | { kind: 'new-tab' }
+  | { kind: 'tmux-session'; hostId: string; sessionCode: string; mode: 'terminal' | 'stream'; cachedName: string; tmuxInstance: string; terminated?: TerminatedReason }
+  | { kind: 'dashboard' }
+  | { kind: 'hosts' }
+  | { kind: 'history' }
+  | { kind: 'settings'; scope: 'global' | { workspaceId: string } }
+  | { kind: 'browser'; url: string }
+  | { kind: 'memory-monitor' }
+```
+
+- [ ] **Step 2: 確認 TypeScript 編譯錯誤出現**
+
+Run: `cd spa && npx tsc --noEmit 2>&1 | head -30`
+Expected: 大量 `'session'` 相關的 type error（因為所有引用還沒改）
+
+---
+
+### Task 2: 全域 rename `kind: 'session'` → `kind: 'tmux-session'`
+
+**Files:**
+- Modify: 所有含 `kind: 'session'` 或 `kind === 'session'` 的檔案（約 31 個）
+
+- [ ] **Step 1: 列出所有需修改的檔案**
+
+Run: `cd spa && grep -rn "kind.*['\"]session['\"]" src/ --include='*.ts' --include='*.tsx' | grep -v node_modules | cut -d: -f1 | sort -u`
+
+- [ ] **Step 2: 批次替換原始碼**
+
+在所有 `spa/src/` 下的 `.ts` 和 `.tsx` 檔案中：
+- `kind: 'session'` → `kind: 'tmux-session'`
+- `kind === 'session'` → `kind === 'tmux-session'`
+- `kind !== 'session'` → `kind !== 'tmux-session'`
+- `case 'session'` → `case 'tmux-session'`
+
+注意：不要替換 `kind: 'session-tab'`（route-utils 中的 route kind）或其他非 PaneContent 的 `session` 字串。只替換 PaneContent union member 的 `kind` 值。
+
+- [ ] **Step 3: 確認 TypeScript 編譯通過**
+
+Run: `cd spa && npx tsc --noEmit`
+Expected: 無錯誤
+
+- [ ] **Step 4: 確認現有測試通過**
+
+Run: `cd spa && npx vitest run`
+Expected: 全部通過
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "refactor: rename PaneContent kind 'session' → 'tmux-session'
+
+Add TerminatedReason type for Phase 4 terminated tab state.
+Mechanical rename across ~31 files."
+```
+
+---
+
+### Task 3: Zustand persist migration
+
+**Files:**
+- Modify: `spa/src/stores/useTabStore.ts:158-167`
+- Test: `spa/src/stores/useTabStore.test.ts`
+
+- [ ] **Step 1: 寫 migration 的測試**
+
+在 `spa/src/stores/useTabStore.test.ts` 加入：
+
+```typescript
+describe('persist migration', () => {
+  it('migrates kind "session" to "tmux-session" in version 2', () => {
+    // Simulate v1 persisted state with old kind
+    const v1State = {
+      tabs: {
+        tab1: {
+          id: 'tab1',
+          pinned: false,
+          locked: false,
+          createdAt: 1000,
+          layout: {
+            type: 'leaf' as const,
+            pane: {
+              id: 'pane1',
+              content: {
+                kind: 'session',
+                hostId: 'h1',
+                sessionCode: 'abc123',
+                mode: 'terminal',
+                cachedName: 'test',
+                tmuxInstance: '123:456',
+              },
+            },
+          },
+        },
+      },
+      tabOrder: ['tab1'],
+      activeTabId: 'tab1',
+    }
+
+    const migrated = migrateTabStore(v1State, 1)
+    const pane = (migrated as any).tabs.tab1.layout.pane
+    expect(pane.content.kind).toBe('tmux-session')
+  })
+
+  it('preserves non-session tabs during migration', () => {
+    const v1State = {
+      tabs: {
+        tab1: {
+          id: 'tab1',
+          pinned: false,
+          locked: false,
+          createdAt: 1000,
+          layout: {
+            type: 'leaf' as const,
+            pane: {
+              id: 'pane1',
+              content: { kind: 'dashboard' },
+            },
+          },
+        },
+      },
+      tabOrder: ['tab1'],
+      activeTabId: 'tab1',
+    }
+
+    const migrated = migrateTabStore(v1State, 1)
+    const pane = (migrated as any).tabs.tab1.layout.pane
+    expect(pane.content.kind).toBe('dashboard')
+  })
+})
+```
+
+- [ ] **Step 2: 執行測試確認失敗**
+
+Run: `cd spa && npx vitest run src/stores/useTabStore.test.ts`
+Expected: FAIL — `migrateTabStore` 尚未定義
+
+- [ ] **Step 3: 實作 migration 函式**
+
+在 `spa/src/stores/useTabStore.ts` 加入 migrate 函式並更新 persist 設定：
+
+```typescript
+// 在 file 頂部或 persist config 前加入
+import type { PaneLayout } from '../types/tab'
+
+function migrateLayout(layout: PaneLayout): PaneLayout {
+  if (layout.type === 'leaf') {
+    const content = layout.pane.content as any
+    if (content.kind === 'session') {
+      return {
+        ...layout,
+        pane: { ...layout.pane, content: { ...content, kind: 'tmux-session' } },
+      }
+    }
+    return layout
+  }
+  return { ...layout, children: layout.children.map(migrateLayout) }
+}
+
+export function migrateTabStore(state: any, version: number): any {
+  if (version < 2) {
+    const tabs: Record<string, any> = {}
+    for (const [id, tab] of Object.entries(state.tabs as Record<string, any>)) {
+      tabs[id] = { ...tab, layout: migrateLayout(tab.layout) }
+    }
+    return { ...state, tabs }
+  }
+  return state
+}
+```
+
+更新 persist config：
+
+```typescript
+{
+  name: STORAGE_KEYS.TABS,
+  storage: purdexStorage,
+  version: 2,
+  migrate: migrateTabStore,
+  partialize: (state) => ({
+    tabs: state.tabs,
+    tabOrder: state.tabOrder,
+    activeTabId: state.activeTabId,
+  }),
+}
+```
+
+- [ ] **Step 4: 執行測試確認通過**
+
+Run: `cd spa && npx vitest run src/stores/useTabStore.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/stores/useTabStore.ts spa/src/stores/useTabStore.test.ts
+git commit -m "feat: TabStore persist migration v1→v2 for kind rename"
+```
+
+---
+
+### Task 4: deriveTabState 推導函式
+
+**Files:**
+- Create: `spa/src/lib/tab-state.ts`
+- Test: `spa/src/lib/tab-state.test.ts`
+
+- [ ] **Step 1: 寫測試**
+
+```typescript
+// spa/src/lib/tab-state.test.ts
+import { describe, it, expect } from 'vitest'
+import { deriveTabState } from './tab-state'
+import type { PaneContent } from '../types/tab'
+import type { HostRuntime } from '../stores/useHostStore'
+
+describe('deriveTabState', () => {
+  it('returns "active" for non-tmux-session kinds', () => {
+    expect(deriveTabState({ kind: 'dashboard' })).toBe('active')
+    expect(deriveTabState({ kind: 'browser', url: 'http://x' })).toBe('active')
+  })
+
+  it('returns "terminated" when terminated field is set', () => {
+    const content: PaneContent = {
+      kind: 'tmux-session', hostId: 'h', sessionCode: 'c',
+      mode: 'terminal', cachedName: 'n', tmuxInstance: 't',
+      terminated: 'session-closed',
+    }
+    const runtime: HostRuntime = { status: 'reconnecting' }
+    // terminated takes precedence over reconnecting
+    expect(deriveTabState(content, runtime)).toBe('terminated')
+  })
+
+  it('returns "reconnecting" when runtime is reconnecting', () => {
+    const content: PaneContent = {
+      kind: 'tmux-session', hostId: 'h', sessionCode: 'c',
+      mode: 'terminal', cachedName: 'n', tmuxInstance: 't',
+    }
+    expect(deriveTabState(content, { status: 'reconnecting' })).toBe('reconnecting')
+  })
+
+  it('returns "active" for connected tmux-session', () => {
+    const content: PaneContent = {
+      kind: 'tmux-session', hostId: 'h', sessionCode: 'c',
+      mode: 'terminal', cachedName: 'n', tmuxInstance: 't',
+    }
+    expect(deriveTabState(content, { status: 'connected' })).toBe('active')
+  })
+
+  it('returns "active" when runtime is undefined', () => {
+    const content: PaneContent = {
+      kind: 'tmux-session', hostId: 'h', sessionCode: 'c',
+      mode: 'terminal', cachedName: 'n', tmuxInstance: 't',
+    }
+    expect(deriveTabState(content)).toBe('active')
+  })
+})
+```
+
+- [ ] **Step 2: 確認測試失敗**
+
+Run: `cd spa && npx vitest run src/lib/tab-state.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: 實作**
+
+```typescript
+// spa/src/lib/tab-state.ts
+import type { PaneContent } from '../types/tab'
+import type { HostRuntime } from '../stores/useHostStore'
+
+export type TabState = 'active' | 'reconnecting' | 'terminated'
+
+export function deriveTabState(content: PaneContent, runtime?: HostRuntime): TabState {
+  if (content.kind !== 'tmux-session') return 'active'
+  if (content.terminated) return 'terminated'
+  if (runtime?.status === 'reconnecting') return 'reconnecting'
+  return 'active'
+}
+```
+
+- [ ] **Step 4: 確認測試通過**
+
+Run: `cd spa && npx vitest run src/lib/tab-state.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/lib/tab-state.ts spa/src/lib/tab-state.test.ts
+git commit -m "feat: deriveTabState — tab display state derivation"
+```
+
+---
+
+### Task 5: Tab icon + name 更新（terminated 狀態）
+
+**Files:**
+- Modify: `spa/src/lib/pane-labels.ts`
+- Modify: `spa/src/components/SortableTab.tsx`
+- Test: `spa/src/lib/pane-labels.test.ts`（如已存在）
+
+- [ ] **Step 1: 更新 getPaneIcon 支援 terminated**
+
+在 `spa/src/lib/pane-labels.ts` 的 `getPaneIcon` 函式中，`case 'tmux-session'` 分支加入 terminated 判斷：
+
+```typescript
+case 'tmux-session':
+  if (content.terminated) return 'SmileySad'
+  return content.mode === 'stream' ? 'ChatCircleDots' : 'TerminalWindow'
+```
+
+- [ ] **Step 2: 更新 getPaneLabel 支援 terminated**
+
+在 `getPaneLabel` 的 `case 'tmux-session'` 分支加入 terminated 判斷：
+
+```typescript
+case 'tmux-session': {
+  if (content.terminated) {
+    const name = content.cachedName || content.sessionCode
+    return `${name}（Terminated）`
+  }
+  // 原有邏輯：session?.name ?? content.cachedName ?? content.sessionCode
+  ...
+}
+```
+
+- [ ] **Step 3: 更新 SortableTab 的 offline indicator**
+
+在 `spa/src/components/SortableTab.tsx` 中，目前有 offline indicator 邏輯（檢查 host runtime status）。加入 terminated 判斷：若 `primaryContent.kind === 'tmux-session' && primaryContent.terminated`，icon 直接使用 `SmileySad`，不顯示其他 status indicator。
+
+- [ ] **Step 4: 確認 lint + 測試通過**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+Expected: 全部通過
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/lib/pane-labels.ts spa/src/components/SortableTab.tsx
+git commit -m "feat: tab icon SmileySad + name suffix for terminated state"
+```
+
+---
+
+### Task 6: i18n key 新增
+
+**Files:**
+- Modify: `spa/src/locales/en.json`
+- Modify: `spa/src/locales/zh-TW.json`
+
+- [ ] **Step 1: 加入所有 Phase 4 i18n key**
+
+在 `en.json` 加入：
+
+```json
+"terminated": {
+  "session_closed": "Session closed",
+  "session_closed_desc": "{name} no longer exists",
+  "tmux_restarted": "tmux restarted",
+  "tmux_restarted_desc": "Previous sessions are no longer valid",
+  "host_removed": "Host removed",
+  "host_removed_desc": "This host has been removed",
+  "no_sessions": "No available connections",
+  "close_tab": "Close tab",
+  "select_session": "Select a session to reconnect"
+},
+"hosts": {
+  ... // 在現有 hosts section 內新增：
+  "confirm_delete_tabs": "Also close all tabs for this host",
+  "deleted_toast": "Deleted {name}",
+  "undo": "Undo",
+  "error_unreachable": "Host unreachable",
+  "error_refused": "Daemon not running",
+  "error_tmux_down": "tmux unavailable"
+},
+"connection": {
+  "reconnect": "Reconnect"
+},
+"notification": {
+  ... // 在現有 notification section 內新增：
+  "daemon_refused": "{name} — Daemon not running",
+  "tmux_down": "{name} — tmux unavailable"
+}
+```
+
+在 `zh-TW.json` 加入對應的繁體中文翻譯（見 spec 第八節）。
+
+- [ ] **Step 2: 確認 locale completeness test 通過**
+
+Run: `cd spa && npx vitest run src/locales/locale-completeness.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spa/src/locales/en.json spa/src/locales/zh-TW.json
+git commit -m "feat: add Phase 4 i18n keys for terminated, host errors, notifications"
+```
+
+---
+
+## Phase 4b — Terminated 錯誤頁元件
+
+### Task 7: SessionPickerList 元件
+
+**Files:**
+- Create: `spa/src/components/SessionPickerList.tsx`
+- Test: `spa/src/components/SessionPickerList.test.tsx`
+
+- [ ] **Step 1: 寫測試**
+
+```typescript
+// spa/src/components/SessionPickerList.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SessionPickerList } from './SessionPickerList'
+
+// Mock stores
+vi.mock('../stores/useHostStore')
+vi.mock('../stores/useSessionStore')
+
+describe('SessionPickerList', () => {
+  it('renders "no available connections" when no connected hosts', () => {
+    // Setup mocks: no hosts or all disconnected
+    render(<SessionPickerList onSelect={vi.fn()} />)
+    expect(screen.getByText(/no available connections/i)).toBeInTheDocument()
+  })
+
+  it('renders sessions grouped by connected host', () => {
+    // Setup mocks: 2 hosts, 1 connected with sessions
+    render(<SessionPickerList onSelect={vi.fn()} />)
+    // Assert host group header and session items visible
+  })
+
+  it('calls onSelect with session info when clicked', async () => {
+    const onSelect = vi.fn()
+    // Setup mocks with a connected host and sessions
+    render(<SessionPickerList onSelect={onSelect} />)
+    // Click a session item
+    // Assert onSelect called with { hostId, sessionCode, cachedName, tmuxInstance }
+  })
+})
+```
+
+- [ ] **Step 2: 確認測試失敗**
+
+Run: `cd spa && npx vitest run src/components/SessionPickerList.test.tsx`
+
+- [ ] **Step 3: 實作元件**
+
+```typescript
+// spa/src/components/SessionPickerList.tsx
+import { useHostStore } from '../stores/useHostStore'
+import { useSessionStore } from '../stores/useSessionStore'
+import { useTranslation } from '../hooks/useTranslation'
+
+interface SessionSelection {
+  hostId: string
+  sessionCode: string
+  cachedName: string
+  tmuxInstance: string
+}
+
+interface Props {
+  onSelect: (selection: SessionSelection) => void
+}
+
+export function SessionPickerList({ onSelect }: Props) {
+  const { t } = useTranslation()
+  const hosts = useHostStore((s) => s.hosts)
+  const hostOrder = useHostStore((s) => s.hostOrder)
+  const runtime = useHostStore((s) => s.runtime)
+  const sessions = useSessionStore((s) => s.sessions)
+
+  const connectedHosts = hostOrder.filter(
+    (id) => runtime[id]?.status === 'connected'
+  )
+
+  if (connectedHosts.length === 0) {
+    return (
+      <div className="text-center text-zinc-500 py-8">
+        {t('terminated.no_sessions')}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-zinc-400">{t('terminated.select_session')}</p>
+      {connectedHosts.map((hostId) => {
+        const host = hosts[hostId]
+        const hostSessions = sessions[hostId] ?? []
+        if (!host || hostSessions.length === 0) return null
+        return (
+          <div key={hostId}>
+            <div className="text-xs text-zinc-500 mb-1">{host.name}</div>
+            <div className="space-y-1">
+              {hostSessions.map((s) => (
+                <button
+                  key={s.code}
+                  className="w-full text-left px-3 py-2 rounded hover:bg-zinc-700/50 text-sm"
+                  onClick={() =>
+                    onSelect({
+                      hostId,
+                      sessionCode: s.code,
+                      cachedName: s.name,
+                      tmuxInstance: runtime[hostId]?.info?.tmux_instance ?? '',
+                    })
+                  }
+                >
+                  {s.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: 確認測試通過**
+
+Run: `cd spa && npx vitest run src/components/SessionPickerList.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/components/SessionPickerList.tsx spa/src/components/SessionPickerList.test.tsx
+git commit -m "feat: SessionPickerList — cross-host session picker for terminated tabs"
+```
+
+---
+
+### Task 8: TerminatedPane 元件
+
+**Files:**
+- Create: `spa/src/components/TerminatedPane.tsx`
+- Test: `spa/src/components/TerminatedPane.test.tsx`
+
+- [ ] **Step 1: 寫測試**
+
+測試要覆蓋：
+- 三種 reason 各自顯示對應訊息
+- 關閉按鈕呼叫 closeTab
+- SessionPickerList 的 onSelect 覆寫 PaneContent（清除 terminated）
+
+- [ ] **Step 2: 確認測試失敗**
+
+Run: `cd spa && npx vitest run src/components/TerminatedPane.test.tsx`
+
+- [ ] **Step 3: 實作元件**
+
+```typescript
+// spa/src/components/TerminatedPane.tsx
+import { SmileySad, X } from '@phosphor-icons/react'
+import { useTabStore } from '../stores/useTabStore'
+import { useTranslation } from '../hooks/useTranslation'
+import { SessionPickerList } from './SessionPickerList'
+import type { PaneContent, TerminatedReason } from '../types/tab'
+
+interface Props {
+  content: Extract<PaneContent, { kind: 'tmux-session' }>
+  tabId: string
+  paneId: string
+}
+
+const REASON_KEYS: Record<TerminatedReason, { title: string; desc: string }> = {
+  'session-closed': { title: 'terminated.session_closed', desc: 'terminated.session_closed_desc' },
+  'tmux-restarted': { title: 'terminated.tmux_restarted', desc: 'terminated.tmux_restarted_desc' },
+  'host-removed': { title: 'terminated.host_removed', desc: 'terminated.host_removed_desc' },
+}
+
+export function TerminatedPane({ content, tabId, paneId }: Props) {
+  const { t } = useTranslation()
+  const closeTab = useTabStore((s) => s.closeTab)
+  const setPaneContent = useTabStore((s) => s.setPaneContent)
+  const reason = content.terminated!
+  const keys = REASON_KEYS[reason]
+
+  const handleSelect = (selection: { hostId: string; sessionCode: string; cachedName: string; tmuxInstance: string }) => {
+    setPaneContent(tabId, paneId, {
+      kind: 'tmux-session',
+      hostId: selection.hostId,
+      sessionCode: selection.sessionCode,
+      mode: content.mode, // 沿用原 tab 的 mode
+      cachedName: selection.cachedName,
+      tmuxInstance: selection.tmuxInstance,
+    })
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+      <SmileySad size={48} className="text-zinc-500 mb-4" />
+      <h2 className="text-lg font-medium text-zinc-300 mb-1">{t(keys.title)}</h2>
+      <p className="text-sm text-zinc-500 mb-6">
+        {t(keys.desc, { name: content.cachedName })}
+      </p>
+      <button
+        className="text-sm text-zinc-400 hover:text-zinc-200 mb-8"
+        onClick={() => closeTab(tabId)}
+      >
+        {t('terminated.close_tab')}
+      </button>
+      <div className="w-full max-w-sm">
+        <SessionPickerList onSelect={handleSelect} />
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: 確認測試通過**
+
+Run: `cd spa && npx vitest run src/components/TerminatedPane.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/components/TerminatedPane.tsx spa/src/components/TerminatedPane.test.tsx
+git commit -m "feat: TerminatedPane — error page for terminated tabs"
+```
+
+---
+
+### Task 9: SessionPaneContent terminated 分支 + WS guard
+
+**Files:**
+- Modify: `spa/src/components/SessionPaneContent.tsx`
+- Modify: `spa/src/hooks/useTerminalWs.ts`
+
+- [ ] **Step 1: SessionPaneContent 加入 terminated 判斷**
+
+在 `SessionPaneContent.tsx` 的 render 邏輯最前面加入：
+
+```typescript
+import { TerminatedPane } from './TerminatedPane'
+
+// 在元件函式開頭，content 解構之後
+if (content.terminated) {
+  return <TerminatedPane content={content} tabId={tabId} paneId={paneId} />
+}
+```
+
+- [ ] **Step 2: useTerminalWs 加入 terminated guard**
+
+在 `spa/src/hooks/useTerminalWs.ts` 的 WS 連線建立之前加入 guard：
+
+```typescript
+// 在 useEffect 內，ws 連線建立前
+if (content.terminated) return
+```
+
+- [ ] **Step 3: 確認 lint + 測試通過**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/components/SessionPaneContent.tsx spa/src/hooks/useTerminalWs.ts
+git commit -m "feat: terminated tab rendering + WS isolation guard"
+```
+
+---
+
+### Task 10: TabStore markTerminated action + 偵測寫入
+
+**Files:**
+- Modify: `spa/src/stores/useTabStore.ts`
+- Modify: `spa/src/hooks/useMultiHostEventWs.ts`
+- Test: `spa/src/stores/useTabStore.test.ts`
+
+- [ ] **Step 1: 寫 markTerminated 測試**
+
+```typescript
+describe('markTerminated', () => {
+  it('marks matching tmux-session panes as terminated', () => {
+    // Setup: add a tab with tmux-session content
+    // Call markTerminated(hostId, sessionCode, 'session-closed')
+    // Assert: pane content has terminated: 'session-closed'
+  })
+
+  it('scans full pane tree including split panes', () => {
+    // Setup: add a tab with split layout
+    // Call markTerminated
+    // Assert: both primary and secondary panes are marked if matching
+  })
+
+  it('does not mark non-matching panes', () => {
+    // Setup: add tabs with different hostId/sessionCode
+    // Call markTerminated
+    // Assert: non-matching panes unchanged
+  })
+})
+```
+
+- [ ] **Step 2: 確認測試失敗**
+
+- [ ] **Step 3: 實作 markTerminated + markHostTerminated**
+
+在 `useTabStore.ts` 加入兩個 action：
+
+```typescript
+// 標記特定 session 的所有 pane 為 terminated
+markTerminated: (hostId: string, sessionCode: string, reason: TerminatedReason) =>
+  set((state) => {
+    let changed = false
+    const tabs = { ...state.tabs }
+    for (const [id, tab] of Object.entries(tabs)) {
+      const newLayout = markPanesInLayout(tab.layout, hostId, sessionCode, reason)
+      if (newLayout !== tab.layout) {
+        tabs[id] = { ...tab, layout: newLayout }
+        changed = true
+      }
+    }
+    return changed ? { tabs } : state
+  }),
+
+// 標記某 host 所有 tmux-session pane 為 terminated
+markHostTerminated: (hostId: string, reason: TerminatedReason) =>
+  set((state) => {
+    let changed = false
+    const tabs = { ...state.tabs }
+    for (const [id, tab] of Object.entries(tabs)) {
+      const newLayout = markHostPanesInLayout(tab.layout, hostId, reason)
+      if (newLayout !== tab.layout) {
+        tabs[id] = { ...tab, layout: newLayout }
+        changed = true
+      }
+    }
+    return changed ? { tabs } : state
+  }),
+```
+
+需要在 `pane-tree.ts` 或 `useTabStore.ts` 中加入 helper：
+
+```typescript
+function markPanesInLayout(layout: PaneLayout, hostId: string, sessionCode: string, reason: TerminatedReason): PaneLayout {
+  if (layout.type === 'leaf') {
+    const c = layout.pane.content
+    if (c.kind === 'tmux-session' && c.hostId === hostId && c.sessionCode === sessionCode && !c.terminated) {
+      return { ...layout, pane: { ...layout.pane, content: { ...c, terminated: reason } } }
+    }
+    return layout
+  }
+  const children = layout.children.map((child) => markPanesInLayout(child, hostId, sessionCode, reason))
+  return children.some((c, i) => c !== layout.children[i]) ? { ...layout, children } : layout
+}
+
+function markHostPanesInLayout(layout: PaneLayout, hostId: string, reason: TerminatedReason): PaneLayout {
+  if (layout.type === 'leaf') {
+    const c = layout.pane.content
+    if (c.kind === 'tmux-session' && c.hostId === hostId && !c.terminated) {
+      return { ...layout, pane: { ...layout.pane, content: { ...c, terminated: reason } } }
+    }
+    return layout
+  }
+  const children = layout.children.map((child) => markHostPanesInLayout(child, hostId, reason))
+  return children.some((c, i) => c !== layout.children[i]) ? { ...layout, children } : layout
+}
+```
+
+- [ ] **Step 4: 確認測試通過**
+
+Run: `cd spa && npx vitest run src/stores/useTabStore.test.ts`
+
+- [ ] **Step 5: useMultiHostEventWs 加入 session-closed 偵測**
+
+在 `useMultiHostEventWs.ts` 的 `sessions` 事件 handler 中，在 `replaceHost` 之後加入：
+
+```typescript
+// session-closed detection: compare new list with open tabs
+const newCodes = new Set(data.map((s: any) => s.code))
+const { tabs } = useTabStore.getState()
+for (const tab of Object.values(tabs)) {
+  // Scan full pane tree for matching tmux-session panes
+  scanPaneTree(tab.layout, (pane) => {
+    const c = pane.content
+    if (c.kind === 'tmux-session' && c.hostId === hostId && !c.terminated && !newCodes.has(c.sessionCode)) {
+      useTabStore.getState().markTerminated(hostId, c.sessionCode, 'session-closed')
+    }
+  })
+}
+```
+
+需要在 `pane-tree.ts` 加入 `scanPaneTree` helper：
+
+```typescript
+export function scanPaneTree(layout: PaneLayout, fn: (pane: Pane) => void): void {
+  if (layout.type === 'leaf') {
+    fn(layout.pane)
+  } else {
+    layout.children.forEach((child) => scanPaneTree(child, fn))
+  }
+}
+```
+
+- [ ] **Step 6: tmux-restarted 偵測（需 daemon 配合）**
+
+在 `useMultiHostEventWs.ts` 的 `sessions` 事件 handler 中，daemon 端需在 sessions 事件 payload 附帶 `tmuxInstance`（`pid:startTime`）。SPA 端比對：
+
+```typescript
+// sessions event handler，在 session-closed 偵測之前
+const incomingTmuxInstance = (rawEvent as any).tmuxInstance // daemon 新增欄位
+if (incomingTmuxInstance) {
+  const { tabs } = useTabStore.getState()
+  for (const tab of Object.values(tabs)) {
+    scanPaneTree(tab.layout, (pane) => {
+      const c = pane.content
+      if (c.kind === 'tmux-session' && c.hostId === hostId && !c.terminated
+          && c.tmuxInstance && c.tmuxInstance !== incomingTmuxInstance) {
+        useTabStore.getState().markHostTerminated(hostId, 'tmux-restarted')
+      }
+    })
+  }
+}
+```
+
+> 注：此步驟依賴 daemon 端修改 sessions 廣播格式。若 daemon 尚未支援，先跳過此步驟，Phase 4b 的 session-closed 偵測仍可獨立運作。
+
+- [ ] **Step 7: 確認全部測試通過**
+
+Run: `cd spa && npx vitest run`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add spa/src/stores/useTabStore.ts spa/src/stores/useTabStore.test.ts spa/src/hooks/useMultiHostEventWs.ts spa/src/lib/pane-tree.ts
+git commit -m "feat: markTerminated actions + session-closed/tmux-restarted detection"
+```
+
+---
+
+## Phase 4c — Host 層級錯誤 UI
+
+### Task 11: useHostConnection hook
+
+**Files:**
+- Create: `spa/src/hooks/useHostConnection.ts`
+- Modify: `spa/src/hooks/useMultiHostEventWs.ts`
+- Test: `spa/src/hooks/useHostConnection.test.ts`
+
+- [ ] **Step 1: 在 HostRuntime 新增 manualRetry 欄位**
+
+在 `useHostStore.ts` 的 `HostRuntime` interface 加入：
+
+```typescript
+export interface HostRuntime {
+  status: 'connected' | 'disconnected' | 'reconnecting'
+  latency?: number
+  info?: HostInfo
+  daemonState?: 'connected' | 'refused' | 'unreachable'
+  tmuxState?: 'ok' | 'unavailable'
+  manualRetry?: () => void  // 新增
+}
+```
+
+- [ ] **Step 2: useMultiHostEventWs 將 SM trigger 存進 runtime**
+
+在 `useMultiHostEventWs.ts` 中，建立 SM 後將 trigger 存進 runtime：
+
+```typescript
+const sm = new ConnectionStateMachine(...)
+// SM 建立後
+useHostStore.getState().setRuntime(hostId, { manualRetry: () => sm.trigger() })
+```
+
+- [ ] **Step 3: 建立 useHostConnection hook**
+
+```typescript
+// spa/src/hooks/useHostConnection.ts
+import { useHostStore } from '../stores/useHostStore'
+
+export function useHostConnection(hostId: string) {
+  const runtime = useHostStore((s) => s.runtime[hostId])
+  return {
+    status: runtime?.status ?? 'disconnected',
+    daemonState: runtime?.daemonState,
+    tmuxState: runtime?.tmuxState,
+    latency: runtime?.latency,
+    manualRetry: runtime?.manualRetry ?? (() => {}),
+  }
+}
+```
+
+- [ ] **Step 4: 確認 lint + 測試通過**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/hooks/useHostConnection.ts spa/src/hooks/useMultiHostEventWs.ts spa/src/stores/useHostStore.ts
+git commit -m "feat: useHostConnection hook — SM access for manual retry"
+```
+
+---
+
+### Task 12: Host 層級錯誤 UI — StatusBar / HostSidebar / SessionPanel / OverviewSection
+
+**Files:**
+- Modify: `spa/src/components/StatusBar.tsx`
+- Modify: `spa/src/components/hosts/HostSidebar.tsx`
+- Modify: `spa/src/components/hosts/OverviewSection.tsx`
+- Modify: `spa/src/components/hosts/SessionsSection.tsx`（SessionPanel 行為）
+
+- [ ] **Step 1: HostSidebar StatusIcon 加入 L3 黃色 Warning**
+
+```typescript
+// spa/src/components/hosts/HostSidebar.tsx — StatusIcon
+function StatusIcon({ runtime }: { runtime?: HostRuntime }) {
+  if (!runtime) return <Circle size={8} weight="fill" className="text-zinc-500" />
+  if (runtime.status === 'connected' && runtime.tmuxState === 'unavailable')
+    return <Warning size={12} weight="fill" className="text-yellow-400" />
+  if (runtime.status === 'connected')
+    return <Circle size={8} weight="fill" className="text-green-500" />
+  if (runtime.status === 'reconnecting')
+    return <Spinner size={12} className="text-yellow-400 animate-spin" />
+  return <Circle size={8} weight="fill" className="text-red-400" />
+}
+```
+
+- [ ] **Step 2: StatusBar 加入 L3 黃色 tmux unavailable**
+
+在 StatusBar 的 host status 顯示區域，加入 tmuxState 判斷：
+
+```typescript
+const statusColor =
+  runtime?.status === 'connected' && runtime?.tmuxState === 'unavailable'
+    ? 'text-yellow-400'
+    : runtime?.status === 'connected'
+      ? 'text-green-500'
+      : runtime?.status === 'reconnecting'
+        ? 'text-yellow-400'
+        : 'text-red-400'
+
+const statusLabel =
+  runtime?.status === 'connected' && runtime?.tmuxState === 'unavailable'
+    ? t('hosts.error_tmux_down')
+    : runtime?.status ?? 'disconnected'
+```
+
+- [ ] **Step 3: OverviewSection 加入 L1/L2/L3 錯誤訊息**
+
+在 OverviewSection 的 connection status 區域加入條件訊息：
+
+```typescript
+function connectionErrorMessage(runtime?: HostRuntime): string | null {
+  if (!runtime || runtime.status === 'connected') {
+    if (runtime?.tmuxState === 'unavailable') return t('hosts.error_tmux_down')
+    return null
+  }
+  if (runtime.daemonState === 'unreachable') return t('hosts.error_unreachable')
+  if (runtime.daemonState === 'refused') return t('hosts.error_refused')
+  return null
+}
+```
+
+- [ ] **Step 4: SessionsSection disable 行為**
+
+Host 斷線或 tmux down 時，session list 項目 disabled + 頂部錯誤訊息：
+
+```typescript
+const isOffline = !runtime || runtime.status !== 'connected' || runtime.tmuxState === 'unavailable'
+// 在 session list 前顯示 error banner
+{isOffline && (
+  <div className="text-xs text-red-400 px-3 py-2">{connectionErrorMessage(runtime)}</div>
+)}
+// session 按鈕加入 disabled={isOffline}
+```
+
+- [ ] **Step 5: 確認 lint + 測試通過**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/components/StatusBar.tsx spa/src/components/hosts/HostSidebar.tsx spa/src/components/hosts/OverviewSection.tsx spa/src/components/hosts/SessionsSection.tsx
+git commit -m "feat: host-level L1/L2/L3 error UI across StatusBar, Sidebar, Overview, Sessions"
+```
+
+---
+
+### Task 13: Reconnecting overlay 手動重連按鈕
+
+**Files:**
+- 找到現有的 reconnecting overlay 元件並修改（可能在 `SessionPaneContent.tsx` 或 terminal/stream view 中）
+
+- [ ] **Step 1: 找到 reconnecting overlay 的位置**
+
+Run: `cd spa && grep -rn 'reconnect' src/components/ --include='*.tsx' | head -20`
+
+- [ ] **Step 2: 在 overlay 加入手動重連按鈕**
+
+```typescript
+import { useHostConnection } from '../hooks/useHostConnection'
+
+// 在 overlay 元件中
+const { manualRetry, status } = useHostConnection(hostId)
+const [retrying, setRetrying] = useState(false)
+
+const handleRetry = () => {
+  setRetrying(true)
+  manualRetry()
+}
+
+// 當 status 改變時重置 retrying
+useEffect(() => { setRetrying(false) }, [status])
+
+// 在 overlay UI 中加入按鈕
+<button
+  className="mt-4 px-4 py-2 rounded bg-zinc-700 hover:bg-zinc-600 text-sm"
+  onClick={handleRetry}
+  disabled={retrying}
+>
+  {retrying ? <Spinner size={16} className="animate-spin" /> : t('connection.reconnect')}
+</button>
+```
+
+- [ ] **Step 3: 確認 lint + 測試通過**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "feat: manual reconnect button in reconnecting overlay"
+```
+
+---
+
+## Phase 4d — Host 刪除流程 + Cascade Cleanup
+
+### Task 14: AgentStore.removeHost + StreamStore.clearHost
+
+**Files:**
+- Modify: `spa/src/stores/useAgentStore.ts`
+- Modify: `spa/src/stores/useStreamStore.ts`
+- Test: existing test files or new
+
+- [ ] **Step 1: AgentStore.removeHost**
+
+新增 `removeHost(hostId)` action，掃描所有 `hostId:*` composite key，清除 `events`、`statuses`、`unread`、`activeSubagents`。同時移除舊的 `clearSubagentsForHost`。
+
+```typescript
+removeHost: (hostId: string) =>
+  set((state) => {
+    const prefix = `${hostId}:`
+    const filterKeys = <T,>(record: Record<string, T>): Record<string, T> => {
+      const result: Record<string, T> = {}
+      for (const [k, v] of Object.entries(record)) {
+        if (!k.startsWith(prefix)) result[k] = v
+      }
+      return result
+    }
+    return {
+      events: filterKeys(state.events),
+      statuses: filterKeys(state.statuses),
+      unread: filterKeys(state.unread),
+      activeSubagents: filterKeys(state.activeSubagents),
+    }
+  }),
+```
+
+更新所有呼叫 `clearSubagentsForHost` 的地方改用 `removeHost`（或在連線建立時只清 subagents，視情況保留特化版本）。
+
+- [ ] **Step 2: StreamStore.clearHost**
+
+新增 `clearHost(hostId)` action：
+
+```typescript
+clearHost: (hostId: string) =>
+  set((state) => {
+    const prefix = `${hostId}:`
+    const newSessions: Record<string, any> = {}
+    for (const [k, v] of Object.entries(state.sessions)) {
+      if (k.startsWith(prefix)) {
+        v.conn?.close()
+      } else {
+        newSessions[k] = v
+      }
+    }
+    const filterKeys = <T,>(record: Record<string, T>): Record<string, T> => {
+      const result: Record<string, T> = {}
+      for (const [k, v] of Object.entries(record)) {
+        if (!k.startsWith(prefix)) result[k] = v
+      }
+      return result
+    }
+    return {
+      sessions: newSessions,
+      relayStatus: filterKeys(state.relayStatus),
+      handoffProgress: filterKeys(state.handoffProgress),
+    }
+  }),
+```
+
+- [ ] **Step 3: 確認 lint + 測試通過**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/stores/useAgentStore.ts spa/src/stores/useStreamStore.ts
+git commit -m "feat: AgentStore.removeHost + StreamStore.clearHost for cascade cleanup"
+```
+
+---
+
+### Task 15: Host 刪除 cascade + 確認 UI + undo toast
+
+**Files:**
+- Modify: `spa/src/components/hosts/OverviewSection.tsx`
+- Modify: `spa/src/stores/useHostStore.ts`
+- Create: `spa/src/components/UndoToast.tsx`（或 inline）
+
+- [ ] **Step 1: OverviewSection 刪除確認 UI 加 checkbox**
+
+替換現有的確認 UI：
+
+```typescript
+{confirmDelete && (
+  <div className="mt-3 p-3 bg-red-500/10 border border-red-500/30 rounded">
+    <p className="text-xs text-red-400 mb-2">{t('hosts.confirm_delete')}</p>
+    <label className="flex items-center gap-2 text-xs text-zinc-400 mb-3">
+      <input
+        type="checkbox"
+        checked={closeTabs}
+        onChange={(e) => setCloseTabs(e.target.checked)}
+      />
+      {t('hosts.confirm_delete_tabs')}
+    </label>
+    <div className="flex gap-2">
+      <button onClick={() => handleDeleteHost(closeTabs)} className="...">
+        {t('common.delete')}
+      </button>
+      <button onClick={() => setConfirmDelete(false)} className="...">
+        {t('common.cancel')}
+      </button>
+    </div>
+  </div>
+)}
+```
+
+- [ ] **Step 2: 實作 cascade delete + undo**
+
+```typescript
+const handleDeleteHost = (withCloseTabs: boolean) => {
+  const hostStore = useHostStore.getState()
+  const tabStore = useTabStore.getState()
+  const sessionStore = useSessionStore.getState()
+  const agentStore = useAgentStore.getState()
+  const streamStore = useStreamStore.getState()
+
+  // Snapshot for undo
+  const snapshot = {
+    host: hostStore.hosts[hostId],
+    hostOrder: [...hostStore.hostOrder],
+    runtime: hostStore.runtime[hostId],
+    sessions: sessionStore.sessions[hostId],
+    // AgentStore + StreamStore: snapshot composite key entries
+    agentEvents: pickByPrefix(agentStore.events, `${hostId}:`),
+    agentStatuses: pickByPrefix(agentStore.statuses, `${hostId}:`),
+    agentUnread: pickByPrefix(agentStore.unread, `${hostId}:`),
+    agentSubagents: pickByPrefix(agentStore.activeSubagents, `${hostId}:`),
+    // Tabs
+    affectedTabs: withCloseTabs
+      ? findTabsForHost(tabStore, hostId)
+      : null,
+    tabsState: withCloseTabs
+      ? { tabs: { ...tabStore.tabs }, tabOrder: [...tabStore.tabOrder], activeTabId: tabStore.activeTabId }
+      : null,
+  }
+
+  // Execute cascade
+  if (withCloseTabs) {
+    closeTabsForHost(tabStore, hostId)
+  } else {
+    tabStore.markHostTerminated(hostId, 'host-removed')
+  }
+  sessionStore.removeHost(hostId)
+  agentStore.removeHost(hostId)
+  streamStore.clearHost(hostId)
+  hostStore.removeHost(hostId)
+
+  // Show undo toast
+  showUndoToast(hostStore.hosts[hostId]?.name ?? hostId, () => {
+    // Restore from snapshot
+    // ... restore logic
+  })
+}
+```
+
+- [ ] **Step 3: Undo toast 元件**
+
+簡單的底部 fixed toast，5 秒自動消失 + undo 按鈕。可以用 state 管理或 portal。
+
+- [ ] **Step 4: 確認 lint + 測試通過**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: host deletion cascade cleanup + undo toast + checkbox UI"
+```
+
+---
+
+## Phase 4e — 通知 + Bug fixes
+
+### Task 16: HEALTH_TIMEOUT_MS 調整
+
+**Files:**
+- Modify: `spa/src/lib/host-connection.ts:13`
+
+- [ ] **Step 1: 改 timeout**
+
+```typescript
+const HEALTH_TIMEOUT_MS = 6000  // was 3000
+```
+
+- [ ] **Step 2: 更新相關測試**
+
+如果有測試 mock 了 3000ms timeout，改為 6000ms。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spa/src/lib/host-connection.ts
+git commit -m "fix: increase health check timeout from 3s to 6s for unstable networks"
+```
+
+---
+
+### Task 17: NotificationAction 模組化 + L2/L3 通知
+
+**Files:**
+- Modify: `spa/src/hooks/useNotificationDispatcher.ts`
+
+- [ ] **Step 1: 定義 NotificationAction 類型**
+
+```typescript
+export type NotificationAction =
+  | { kind: 'open-session'; hostId: string; sessionCode: string }
+  | { kind: 'open-host'; hostId: string }
+```
+
+- [ ] **Step 2: 重構 handleNotificationClick 為 action dispatch**
+
+```typescript
+function handleNotificationClick(action: NotificationAction) {
+  switch (action.kind) {
+    case 'open-session': {
+      // 現有邏輯：找 tab or 開新 tab
+      break
+    }
+    case 'open-host': {
+      useTabStore.getState().openSingletonTab({ kind: 'hosts' })
+      useHostStore.getState().setActiveHost(action.hostId)
+      break
+    }
+  }
+}
+```
+
+- [ ] **Step 3: 加入 L2/L3 連線通知**
+
+在 hook 中監聽 `HostRuntime.daemonState` 和 `tmuxState` 變化：
+
+```typescript
+// Track previous state per host for edge detection
+const prevState = useRef<Record<string, { daemon?: string; tmux?: string }>>({})
+
+// On runtime change:
+for (const hostId of hostOrder) {
+  const rt = runtime[hostId]
+  const prev = prevState.current[hostId]
+
+  // L2: daemon refused (was connected, now refused)
+  if (prev?.daemon === 'connected' && rt?.daemonState === 'refused') {
+    notify(t('notification.daemon_refused', { name: hosts[hostId]?.name }),
+           { kind: 'open-host', hostId })
+  }
+  // L3: tmux down (was ok, now unavailable)
+  if (prev?.tmux === 'ok' && rt?.tmuxState === 'unavailable') {
+    notify(t('notification.tmux_down', { name: hosts[hostId]?.name }),
+           { kind: 'open-host', hostId })
+  }
+
+  prevState.current[hostId] = { daemon: rt?.daemonState, tmux: rt?.tmuxState }
+}
+```
+
+- [ ] **Step 4: 確認 lint + 測試通過**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/hooks/useNotificationDispatcher.ts
+git commit -m "feat: NotificationAction modular click handler + L2/L3 connection notifications"
+```
+
+---
+
+### Task 18: Bug fix #161 — JSON parse error
+
+**Files:**
+- Modify: `spa/src/hooks/useMultiHostEventWs.ts`
+
+- [ ] **Step 1: Wrap JSON.parse in try-catch**
+
+在 `useMultiHostEventWs.ts` 中所有 `JSON.parse(event.value)` 呼叫加 try-catch：
+
+```typescript
+// sessions event handler
+try {
+  const data: Session[] = JSON.parse(event.value)
+  // ... existing logic
+} catch (e) {
+  console.warn(`[host-events] Failed to parse sessions payload for ${hostId}:`, e)
+}
+```
+
+同樣處理其他 `JSON.parse` 呼叫點。
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add spa/src/hooks/useMultiHostEventWs.ts
+git commit -m "fix(#161): wrap JSON.parse in try-catch for WS event payloads"
+```
+
+---
+
+### Task 19: Bug fix #156 — AddHostDialog 錯誤提示
+
+**Files:**
+- Modify: `spa/src/components/hosts/AddHostDialog.tsx`
+
+- [ ] **Step 1: 區分錯誤類型**
+
+在 `handleTest` 的 catch block 中，根據 error 類型顯示不同訊息：
+
+```typescript
+try {
+  const healthRes = await fetch(...)
+  // ...
+} catch (err) {
+  if (err instanceof TypeError) {
+    // Connection refused → L2
+    setError(t('hosts.error_refused'))
+  } else if (err instanceof DOMException && err.name === 'AbortError') {
+    // Timeout → L1
+    setError(t('hosts.error_unreachable'))
+  } else {
+    setError(String(err))
+  }
+  setStage('error')
+}
+```
+
+對於 401 回應：
+```typescript
+if (sessionsRes.status === 401) {
+  setStage('needs-token')
+  setError('')  // 清除之前的錯誤
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add spa/src/components/hosts/AddHostDialog.tsx
+git commit -m "fix(#156): AddHostDialog shows specific L1/L2/401 error messages"
+```
+
+---
+
+### Task 20: Bug fix #140 — TokenField 空值驗證
+
+**Files:**
+- Modify: `spa/src/components/hosts/OverviewSection.tsx`
+
+- [ ] **Step 1: 空值不觸發驗證**
+
+在 TokenField 的 `handleSave` 中：
+
+```typescript
+const handleSave = async () => {
+  if (!draft.trim()) {
+    // 空值：直接儲存空 token，清除錯誤
+    setError('')
+    onSave(draft)
+    setEditing(false)
+    return
+  }
+  // 原有驗證邏輯...
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add spa/src/components/hosts/OverviewSection.tsx
+git commit -m "fix(#140): TokenField skips validation on empty value"
+```
+
+---
+
+### Task 21: Bug fix #137 — Electron 離線白屏
+
+**Files:**
+- 確認 `SessionPaneContent.tsx` 的 terminated guard + reconnecting overlay 已覆蓋此情境
+- 可能需要在 Electron main process 或 renderer entry point 加入 fallback
+
+- [ ] **Step 1: 確認 L1 狀態不會白屏**
+
+驗證：daemon 不可達時，`HostRuntime.status` 為 `disconnected`，`SessionPaneContent` 不會 crash（因為有 reconnecting overlay 或 WS 連不上）。如果 Electron 啟動時 renderer 本身就 crash，需要在 Electron main process 加入 error handler。
+
+- [ ] **Step 2: 如需修改，commit**
+
+```bash
+git add -A && git commit -m "fix(#137): prevent Electron renderer crash on offline startup"
+```
+
+---
+
+### Task 22: 最終驗證 + Phase 4 完成
+
+- [ ] **Step 1: 執行全部測試**
+
+Run: `cd spa && npx vitest run`
+Expected: 全部通過
+
+- [ ] **Step 2: 執行 lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: 無錯誤
+
+- [ ] **Step 3: 執行 build**
+
+Run: `cd spa && pnpm run build`
+Expected: 建置成功
+
+- [ ] **Step 4: 確認 i18n locale completeness**
+
+Run: `cd spa && npx vitest run src/locales/locale-completeness.test.ts`
+Expected: PASS

--- a/docs/superpowers/plans/2026-04-04-phase4-error-ui.md
+++ b/docs/superpowers/plans/2026-04-04-phase4-error-ui.md
@@ -61,7 +61,10 @@ Run: `cd spa && grep -rn "kind.*['\"]session['\"]" src/ --include='*.ts' --inclu
 - `kind !== 'session'` → `kind !== 'tmux-session'`
 - `case 'session'` → `case 'tmux-session'`
 
-注意：不要替換 `kind: 'session-tab'`（route-utils 中的 route kind）或其他非 PaneContent 的 `session` 字串。只替換 PaneContent union member 的 `kind` 值。
+注意：
+- 不要替換 `kind: 'session-tab'`（route-utils 中的 route kind）或其他非 PaneContent 的 `session` 字串。只替換 PaneContent union member 的 `kind` 值。
+- **`register-panes.tsx`** 的 `registerPaneRenderer('session', ...)` 是 registry key，不含 `kind` 關鍵字，grep 不會命中。必須手動改為 `registerPaneRenderer('tmux-session', ...)`。
+- **`active-session.ts`** 的 `kind !== 'session'` 和 `kind === 'session'` 是核心 session 判斷邏輯，必須確認有被替換，否則 `getActiveSessionInfo()` 會永遠回傳 `null`。
 
 - [ ] **Step 3: 確認 TypeScript 編譯通過**
 
@@ -128,6 +131,30 @@ describe('persist migration', () => {
     const migrated = migrateTabStore(v1State, 1)
     const pane = (migrated as any).tabs.tab1.layout.pane
     expect(pane.content.kind).toBe('tmux-session')
+  })
+
+  it('migrates kind "session" inside split layouts', () => {
+    const v1State = {
+      tabs: {
+        tab1: {
+          id: 'tab1', pinned: false, locked: false, createdAt: 1000,
+          layout: {
+            type: 'split' as const, id: 'split1', direction: 'h' as const,
+            children: [
+              { type: 'leaf' as const, pane: { id: 'p1', content: { kind: 'session', hostId: 'h1', sessionCode: 'a', mode: 'terminal', cachedName: 'A', tmuxInstance: '1:2' } } },
+              { type: 'leaf' as const, pane: { id: 'p2', content: { kind: 'dashboard' } } },
+            ],
+            sizes: [50, 50],
+          },
+        },
+      },
+      tabOrder: ['tab1'],
+      activeTabId: 'tab1',
+    }
+    const migrated = migrateTabStore(v1State, 1)
+    const children = (migrated as any).tabs.tab1.layout.children
+    expect(children[0].pane.content.kind).toBe('tmux-session')
+    expect(children[1].pane.content.kind).toBe('dashboard')
   })
 
   it('preserves non-session tabs during migration', () => {
@@ -481,7 +508,7 @@ Run: `cd spa && npx vitest run src/components/SessionPickerList.test.tsx`
 // spa/src/components/SessionPickerList.tsx
 import { useHostStore } from '../stores/useHostStore'
 import { useSessionStore } from '../stores/useSessionStore'
-import { useTranslation } from '../hooks/useTranslation'
+import { useI18nStore } from '../stores/useI18nStore'
 
 interface SessionSelection {
   hostId: string
@@ -495,7 +522,7 @@ interface Props {
 }
 
 export function SessionPickerList({ onSelect }: Props) {
-  const { t } = useTranslation()
+  const t = useI18nStore((s) => s.t)
   const hosts = useHostStore((s) => s.hosts)
   const hostOrder = useHostStore((s) => s.hostOrder)
   const runtime = useHostStore((s) => s.runtime)
@@ -533,7 +560,7 @@ export function SessionPickerList({ onSelect }: Props) {
                       hostId,
                       sessionCode: s.code,
                       cachedName: s.name,
-                      tmuxInstance: runtime[hostId]?.info?.tmux_instance ?? '',
+                      tmuxInstance: runtime[hostId]?.info?.tmux_instance ?? '', // info 未載入時為空字串，tmux-restarted 偵測會在下次 sessions event 時自然校正
                     })
                   }
                 >
@@ -571,10 +598,52 @@ git commit -m "feat: SessionPickerList — cross-host session picker for termina
 
 - [ ] **Step 1: 寫測試**
 
-測試要覆蓋：
-- 三種 reason 各自顯示對應訊息
-- 關閉按鈕呼叫 closeTab
-- SessionPickerList 的 onSelect 覆寫 PaneContent（清除 terminated）
+```typescript
+// spa/src/components/TerminatedPane.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TerminatedPane } from './TerminatedPane'
+import type { PaneContent } from '../types/tab'
+
+vi.mock('../stores/useTabStore', () => ({
+  useTabStore: vi.fn((sel) => sel({
+    closeTab: vi.fn(),
+    setPaneContent: vi.fn(),
+  })),
+}))
+vi.mock('../stores/useI18nStore', () => ({
+  useI18nStore: vi.fn((sel) => sel({ t: (key: string) => key })),
+}))
+vi.mock('./SessionPickerList', () => ({
+  SessionPickerList: ({ onSelect }: any) => (
+    <button data-testid="pick" onClick={() => onSelect({ hostId: 'h2', sessionCode: 'x', cachedName: 'X', tmuxInstance: 't2' })}>pick</button>
+  ),
+}))
+
+const baseContent: Extract<PaneContent, { kind: 'tmux-session' }> = {
+  kind: 'tmux-session', hostId: 'h1', sessionCode: 'c1',
+  mode: 'terminal', cachedName: 'my-session', tmuxInstance: 't1',
+  terminated: 'session-closed',
+}
+
+describe('TerminatedPane', () => {
+  it('renders correct message for session-closed', () => {
+    render(<TerminatedPane content={baseContent} tabId="t1" paneId="p1" />)
+    expect(screen.getByText('terminated.session_closed')).toBeInTheDocument()
+  })
+
+  it('renders correct message for host-removed', () => {
+    render(<TerminatedPane content={{ ...baseContent, terminated: 'host-removed' }} tabId="t1" paneId="p1" />)
+    expect(screen.getByText('terminated.host_removed')).toBeInTheDocument()
+  })
+
+  it('renders close tab button', () => {
+    render(<TerminatedPane content={baseContent} tabId="t1" paneId="p1" />)
+    expect(screen.getByText('terminated.close_tab')).toBeInTheDocument()
+  })
+})
+```
 
 - [ ] **Step 2: 確認測試失敗**
 
@@ -586,7 +655,7 @@ Run: `cd spa && npx vitest run src/components/TerminatedPane.test.tsx`
 // spa/src/components/TerminatedPane.tsx
 import { SmileySad, X } from '@phosphor-icons/react'
 import { useTabStore } from '../stores/useTabStore'
-import { useTranslation } from '../hooks/useTranslation'
+import { useI18nStore } from '../stores/useI18nStore'
 import { SessionPickerList } from './SessionPickerList'
 import type { PaneContent, TerminatedReason } from '../types/tab'
 
@@ -603,7 +672,7 @@ const REASON_KEYS: Record<TerminatedReason, { title: string; desc: string }> = {
 }
 
 export function TerminatedPane({ content, tabId, paneId }: Props) {
-  const { t } = useTranslation()
+  const t = useI18nStore((s) => s.t)
   const closeTab = useTabStore((s) => s.closeTab)
   const setPaneContent = useTabStore((s) => s.setPaneContent)
   const reason = content.terminated!
@@ -655,11 +724,10 @@ git commit -m "feat: TerminatedPane — error page for terminated tabs"
 
 ---
 
-### Task 9: SessionPaneContent terminated 分支 + WS guard
+### Task 9: SessionPaneContent terminated 分支
 
 **Files:**
 - Modify: `spa/src/components/SessionPaneContent.tsx`
-- Modify: `spa/src/hooks/useTerminalWs.ts`
 
 - [ ] **Step 1: SessionPaneContent 加入 terminated 判斷**
 
@@ -674,25 +742,18 @@ if (content.terminated) {
 }
 ```
 
-- [ ] **Step 2: useTerminalWs 加入 terminated guard**
+> 注：`useTerminalWs` 不需要額外 guard — `SessionPaneContent` 的 terminated 判斷在最頂層，當 `content.terminated` 為 true 時，`TerminalView`（含 `useTerminalWs`）不會被渲染，WS 自然不會建立。
 
-在 `spa/src/hooks/useTerminalWs.ts` 的 WS 連線建立之前加入 guard：
-
-```typescript
-// 在 useEffect 內，ws 連線建立前
-if (content.terminated) return
-```
-
-- [ ] **Step 3: 確認 lint + 測試通過**
+- [ ] **Step 2: 確認 lint + 測試通過**
 
 Run: `cd spa && pnpm run lint && npx vitest run`
 Expected: PASS
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
-git add spa/src/components/SessionPaneContent.tsx spa/src/hooks/useTerminalWs.ts
-git commit -m "feat: terminated tab rendering + WS isolation guard"
+git add spa/src/components/SessionPaneContent.tsx
+git commit -m "feat: terminated tab rendering in SessionPaneContent"
 ```
 
 ---
@@ -803,17 +864,20 @@ Run: `cd spa && npx vitest run src/stores/useTabStore.test.ts`
 在 `useMultiHostEventWs.ts` 的 `sessions` 事件 handler 中，在 `replaceHost` 之後加入：
 
 ```typescript
-// session-closed detection: compare new list with open tabs
+// session-closed detection: collect unique closed sessionCodes, then mark once each
 const newCodes = new Set(data.map((s: any) => s.code))
+const closedCodes = new Set<string>()
 const { tabs } = useTabStore.getState()
 for (const tab of Object.values(tabs)) {
-  // Scan full pane tree for matching tmux-session panes
   scanPaneTree(tab.layout, (pane) => {
     const c = pane.content
     if (c.kind === 'tmux-session' && c.hostId === hostId && !c.terminated && !newCodes.has(c.sessionCode)) {
-      useTabStore.getState().markTerminated(hostId, c.sessionCode, 'session-closed')
+      closedCodes.add(c.sessionCode)
     }
   })
+}
+for (const code of closedCodes) {
+  useTabStore.getState().markTerminated(hostId, code, 'session-closed')
 }
 ```
 
@@ -837,20 +901,25 @@ export function scanPaneTree(layout: PaneLayout, fn: (pane: Pane) => void): void
 // sessions event handler，在 session-closed 偵測之前
 const incomingTmuxInstance = (rawEvent as any).tmuxInstance // daemon 新增欄位
 if (incomingTmuxInstance) {
+  // Check if any open tab has a different tmuxInstance — if so, mark all as tmux-restarted
+  let needsTerminate = false
   const { tabs } = useTabStore.getState()
   for (const tab of Object.values(tabs)) {
     scanPaneTree(tab.layout, (pane) => {
       const c = pane.content
       if (c.kind === 'tmux-session' && c.hostId === hostId && !c.terminated
           && c.tmuxInstance && c.tmuxInstance !== incomingTmuxInstance) {
-        useTabStore.getState().markHostTerminated(hostId, 'tmux-restarted')
+        needsTerminate = true
       }
     })
+  }
+  if (needsTerminate) {
+    useTabStore.getState().markHostTerminated(hostId, 'tmux-restarted')
   }
 }
 ```
 
-> 注：此步驟依賴 daemon 端修改 sessions 廣播格式。若 daemon 尚未支援，先跳過此步驟，Phase 4b 的 session-closed 偵測仍可獨立運作。
+> 注：此步驟依賴 daemon 端修改 sessions 廣播格式（在 sessions event payload 附帶 `tmuxInstance` 欄位）。若 daemon 尚未支援，先跳過此步驟，Phase 4b 的 session-closed 偵測仍可獨立運作。需建立 GitHub issue 追蹤 daemon 端修改。
 
 - [ ] **Step 7: 確認全部測試通過**
 
@@ -885,7 +954,7 @@ export interface HostRuntime {
   info?: HostInfo
   daemonState?: 'connected' | 'refused' | 'unreachable'
   tmuxState?: 'ok' | 'unavailable'
-  manualRetry?: () => void  // 新增
+  manualRetry?: () => void  // 新增。安全：runtime 不在 persist partialize 範圍內，函式不會被序列化
 }
 ```
 
@@ -979,7 +1048,8 @@ const statusLabel =
 在 OverviewSection 的 connection status 區域加入條件訊息：
 
 ```typescript
-function connectionErrorMessage(runtime?: HostRuntime): string | null {
+// 定義在元件外部，接收 t 參數
+function connectionErrorMessage(runtime: HostRuntime | undefined, t: (key: string) => string): string | null {
   if (!runtime || runtime.status === 'connected') {
     if (runtime?.tmuxState === 'unavailable') return t('hosts.error_tmux_down')
     return null
@@ -988,6 +1058,10 @@ function connectionErrorMessage(runtime?: HostRuntime): string | null {
   if (runtime.daemonState === 'refused') return t('hosts.error_refused')
   return null
 }
+
+// 在元件內使用：
+const t = useI18nStore((s) => s.t)
+const errorMsg = connectionErrorMessage(runtime, t)
 ```
 
 - [ ] **Step 4: SessionsSection disable 行為**
@@ -1097,7 +1171,7 @@ removeHost: (hostId: string) =>
   }),
 ```
 
-更新所有呼叫 `clearSubagentsForHost` 的地方改用 `removeHost`（或在連線建立時只清 subagents，視情況保留特化版本）。
+**重要**：`useMultiHostEventWs` 的 `onOpen` handler 中有 `clearSubagentsForHost(hostId)` 呼叫，這是 WS 重連時只清 subagents 的正確行為，**不可替換為 `removeHost`**（否則每次 WS 重連都會清掉 events/statuses/unread）。保留 `clearSubagentsForHost` 給 WS onOpen 使用，新增的 `removeHost` 只在 host 刪除 cascade 中呼叫。
 
 - [ ] **Step 2: StreamStore.clearHost**
 
@@ -1219,10 +1293,30 @@ const handleDeleteHost = (withCloseTabs: boolean) => {
   streamStore.clearHost(hostId)
   hostStore.removeHost(hostId)
 
-  // Show undo toast
-  showUndoToast(hostStore.hosts[hostId]?.name ?? hostId, () => {
+  // Show undo toast（用 snapshot 取 host name，因為 removeHost 後 store 已清空）
+  showUndoToast(snapshot.host?.name ?? hostId, () => {
     // Restore from snapshot
-    // ... restore logic
+    if (snapshot.host) {
+      useHostStore.getState().addHost(snapshot.host)
+    }
+    if (snapshot.sessions) {
+      useSessionStore.getState().replaceHost(hostId, snapshot.sessions)
+    }
+    // Restore agent store entries
+    const agentState = useAgentStore.getState()
+    for (const [k, v] of Object.entries(snapshot.agentEvents)) agentState.events[k] = v
+    for (const [k, v] of Object.entries(snapshot.agentStatuses)) agentState.statuses[k] = v
+    // Restore tabs: only if they haven't been overwritten by user during undo window
+    if (snapshot.tabsState) {
+      const currentTabs = useTabStore.getState().tabs
+      for (const [tabId, tab] of Object.entries(snapshot.tabsState.tabs as Record<string, any>)) {
+        if (!currentTabs[tabId]) {
+          // Tab was closed — restore it
+          useTabStore.getState().addTab(tab)
+        }
+        // Tab still exists but was modified by user — skip (don't overwrite user's choice)
+      }
+    }
   })
 }
 ```
@@ -1300,7 +1394,22 @@ function handleNotificationClick(action: NotificationAction) {
 }
 ```
 
-- [ ] **Step 3: 加入 L2/L3 連線通知**
+- [ ] **Step 3: 更新現有 agent notification 的 click call sites**
+
+現有兩處呼叫 `handleNotificationClick(sessionCode)` 的地方需改為傳遞 `NotificationAction`：
+
+```typescript
+// Electron path (約 line 138)：
+// 舊：handleNotificationClick(payload.sessionCode)
+// 新：需從 payload 取得 hostId，若無法取得則從 TabStore 掃描
+const info = getActiveSessionInfo() // 或從 tab 找出 hostId
+handleNotificationClick({ kind: 'open-session', hostId: info?.hostId ?? '', sessionCode: payload.sessionCode })
+
+// Browser Notification path (約 line 127)：
+// 同上改法
+```
+
+- [ ] **Step 4: 加入 L2/L3 連線通知**
 
 在 hook 中監聽 `HostRuntime.daemonState` 和 `tmuxState` 變化：
 

--- a/docs/superpowers/specs/2026-04-04-phase4-error-ui-design.md
+++ b/docs/superpowers/specs/2026-04-04-phase4-error-ui-design.md
@@ -1,0 +1,378 @@
+# Phase 4 — 錯誤 UI 設計規格
+
+> 2026-04-04 — 基於 Phase 3 連線偵測基礎，實作完整的錯誤 UI、tab 終結狀態、host 刪除流程
+>
+> 注：原始架構規格中的 `SessionDestroyed` 元件在本規格中更名為 `TerminatedPane`，以更準確反映用途（涵蓋 session 關閉、tmux 重啟、host 刪除等多種終結情境）。
+
+## 一、概述
+
+Phase 4 為 Host 連線管理的主線最後一個 Phase，目標是讓使用者在各種錯誤情境下獲得清晰的資訊回饋和操作路徑。涵蓋：
+
+- Tab 狀態模型（含 terminated 終結狀態）
+- Terminated 錯誤頁元件
+- Host 層級 L1-L3 錯誤 UI
+- Host 刪除流程 + cascade cleanup + undo
+- L2/L3 系統通知 + bug fixes
+
+## 二、Tab 狀態模型
+
+### PaneContent 類型更新
+
+```typescript
+export type PaneContent =
+  | { kind: 'new-tab' }
+  | { kind: 'tmux-session'; hostId: string; sessionCode: string; mode: 'terminal' | 'stream'; cachedName: string; tmuxInstance: string; terminated?: TerminatedReason }
+  | { kind: 'dashboard' }
+  | { kind: 'hosts' }
+  | { kind: 'history' }
+  | { kind: 'settings'; scope: 'global' | { workspaceId: string } }
+  | { kind: 'browser'; url: string }
+  | { kind: 'memory-monitor' }
+
+type TerminatedReason = 'session-closed' | 'tmux-restarted' | 'host-removed'
+```
+
+**Rename**：`kind: 'session'` → `kind: 'tmux-session'`，涉及約 31 個檔案（原始碼 + 測試）的 kind 比對，機械性替換。具體檔案數以實作時 grep 結果為準。
+
+**Zustand Persist Migration**：TabStore 的 persist version 從 1 升到 2，加入 `migrate` 函式，將舊資料的 `kind: 'session'` 轉換為 `kind: 'tmux-session'`。否則 localStorage 中已儲存的 tab 會變成 unknown kind，導致渲染失敗。
+
+### Tab 顯示狀態推導
+
+Tab 狀態不是獨立欄位，而是從 PaneContent + HostRuntime 推導：
+
+```typescript
+function deriveTabState(content: PaneContent, runtime?: HostRuntime) {
+  if (content.kind !== 'tmux-session') return 'active'
+  if (content.terminated) return 'terminated'
+  if (runtime?.status === 'reconnecting') return 'reconnecting'
+  return 'active'
+}
+```
+
+Phase 4 的 tab 狀態處理只涉及 `tmux-session` kind，其他 kind 不受影響。
+
+### Tab Icon / Name 對應
+
+| 狀態 | Icon | Tab Name |
+|------|------|----------|
+| active | Terminal / Stream（依 mode） | `{sessionName}` |
+| reconnecting | Spinner | `{cachedName}` |
+| terminated | SmileySad（類 Chrome crashed） | `{cachedName}（Terminated）` |
+
+> 注：terminated 使用 SmileySad 而非 Warning icon，是因為 Warning 保留給 reconnecting/disconnected 的 host 層級指示（HostSidebar L3），SmileySad 專門表達「此 tab 已終結、不可自動恢復」的語義。原始架構規格中的 `disconnected / error → Warning` 指的是 host 層級狀態。
+
+### Terminated 生命週期
+
+`terminated` 欄位記錄的是「發生過的事件」，不是可推導的狀態。觸發終結的上下文（session list 變化、tmux instance 變化、host 刪除）是瞬間的，之後會消失，因此需要在偵測到時主動寫入 PaneContent。
+
+**寫入時機：**
+
+| 事件 | 偵測位置 | Reason |
+|------|---------|--------|
+| Session 從 list 消失 | `useMultiHostEventWs` | `session-closed` |
+| tmuxInstance 變化 | `useMultiHostEventWs` | `tmux-restarted` |
+| 使用者刪除 host | `removeHost()` | `host-removed` |
+
+**Session 消失偵測邏輯**：`useMultiHostEventWs` 收到 `sessions` 事件時，比對新 session list 與 TabStore 中所有 pane（含 split pane 的 secondary pane，需掃描完整 pane tree），找出 `content.kind === 'tmux-session' && content.hostId === hostId` 且 `sessionCode` 不在新 list 中的 pane，寫入 `terminated: 'session-closed'`。
+
+**tmux-restarted 偵測邏輯**：Daemon 端在 `sessions` 事件 payload 中附帶 `tmuxInstance`。`useMultiHostEventWs` 收到 sessions 事件時，比對 payload 中的 tmuxInstance 與各 tab PaneContent 中存的值，若不一致則對該 host 所有 tmux-session tab 寫入 `terminated: 'tmux-restarted'`。需 daemon 端配合修改 sessions 廣播格式。
+
+**清除時機：**
+
+| 事件 | 結果 |
+|------|------|
+| 使用者在錯誤頁選新 session | 覆寫 PaneContent（新 hostId、sessionCode 等），`terminated` 消失 |
+| 使用者點關閉按鈕 | 整個 PaneContent 從 TabStore 移除 |
+
+## 三、Terminated 錯誤頁元件
+
+### 元件結構
+
+```
+TerminatedPane
+├── 錯誤訊息（依 reason 不同）
+├── 關閉按鈕
+└── SessionPickerList（只列已連線 host 的 session，按 host 分組）
+```
+
+### 錯誤訊息
+
+| Reason | 主訊息 | 補充說明 |
+|--------|------|---------|
+| `session-closed` | Session 已關閉 | `{cachedName}` 已不存在 |
+| `tmux-restarted` | tmux 已重啟 | 原有 session 已失效 |
+| `host-removed` | Host 已移除 | 該主機已從列表中移除 |
+
+### SessionPickerList 子元件
+
+- 資料來源：遍歷 HostStore 所有 host，篩選 `runtime.status === 'connected'`，從 SessionStore 取各 host 的 session list
+- 按 host 分組顯示，每組標題為 host 名稱
+- 點選 session → 覆寫當前 tab 的 PaneContent（新 hostId、sessionCode、tmuxInstance、cachedName），`mode` 沿用原 tab 的值，`terminated` 清除，tab 回到 active
+- 若無任何已連線 host → 顯示「目前沒有可用的連線」提示
+- SessionStore 的 `sessions` 不做持久化，資料來自 WS `sessions` 事件的被動填充。正常情況下 terminated 頁面顯示時 WS 已建立、sessions 已有資料。若 sessions 為空（如 WS 尚未連線），顯示上述提示即可，不需額外觸發 fetch
+- 此元件可被 TerminatedPane 和未來 new-tab 頁面共用
+
+### 渲染進入點
+
+在 `SessionPaneContent.tsx`（`tmux-session` kind 的渲染器）中加入判斷：
+
+```typescript
+if (content.terminated) return <TerminatedPane content={content} tabId={tabId} paneId={paneId} />
+// 否則正常渲染 TerminalView / ConversationView
+```
+
+### 新增檔案
+
+- `spa/src/components/TerminatedPane.tsx` — 錯誤頁主元件
+- `spa/src/components/SessionPickerList.tsx` — 跨 host session list
+
+## 四、Host 層級錯誤 UI（L1-L3）
+
+### 各元件錯誤行為
+
+| 元件 | L1（unreachable） | L2（refused） | L3（tmux down） |
+|------|-------------------|---------------|-----------------|
+| **HostSidebar StatusIcon** | 紅色 Circle | 紅色 Circle | 黃色 Warning |
+| **StatusBar** | 紅色 `Disconnected` | 紅色 `Disconnected` | 黃色 `tmux unavailable` |
+| **SessionPanel** | Session list disabled + 錯誤提示 | 同 L1 | Session list disabled +「tmux 未啟動」 |
+| **OverviewSection** | 「主機無法連線」 | 「Daemon 未啟動」 | 「tmux 環境無法連線」 |
+
+### L1 vs L2 區分
+
+已在 Phase 3 實作，從 `HostRuntime.daemonState` 讀取：
+
+- `unreachable`（timeout）→ L1：主機本身不可達
+- `refused`（快速失敗）→ L2：主機可達但 daemon 沒跑
+
+### Reconnecting Overlay
+
+維持現有行為：terminal/stream 畫面上蓋半透明 overlay。新增手動重連按鈕：
+
+- 按鈕在 overlay 上，文字「重新連線」
+- 點擊後顯示 spinner，成功或失敗後恢復按鈕狀態
+- 按鈕 spinner 結束條件：訂閱 `HostRuntime.status`，當 status 變為 `connected` 或確認仍 `disconnected` 後恢復按鈕
+- 觸發機制：透過 `useHostConnection(hostId)` hook 提供的 `manualRetry()` 函式呼叫 `ConnectionStateMachine.trigger()`
+
+### 手動重連按鈕
+
+OverviewSection 已有 Test Connection 按鈕，視為 host 層級的手動重連等效操作。Reconnecting Overlay 的重連按鈕為 tab 層級。其他頁面（SessionPanel、TerminatedPane）不額外提供重連按鈕。
+
+### SessionPanel disable 行為
+
+Host 斷線（L1/L2）或 tmux down（L3）時：
+
+- Session list 項目變 muted，不可點擊開新 tab
+- 列表上方顯示一行錯誤提示（與 OverviewSection 同訊息）
+
+## 五、Host 刪除流程
+
+### 刪除 UI
+
+在 OverviewSection 現有 inline 確認區塊中增加 checkbox：
+
+```
+確定要刪除？
+☑ 一併關閉所有此 Host 的分頁
+[刪除]  [取消]
+```
+
+Checkbox 預設 checked。
+
+### 刪除行為
+
+確認後：
+
+- **Checked**：關閉該 host 所有 `tmux-session` tab + cascade cleanup 所有 store
+- **Unchecked**：tab 標記 `terminated: 'host-removed'`（保留） + cascade cleanup（不含 TabStore）
+
+### Cascade Cleanup
+
+不論 checkbox 狀態，刪除 host 時都執行：
+
+| Store | 清理動作 |
+|-------|---------|
+| HostStore | 移除 `hosts[id]`、`hostOrder`、`runtime[id]` |
+| SessionStore | `removeHost(id)` — 清除 `sessions[id]` |
+| AgentStore | 清除該 host 的 composite key 資料：`events`、`statuses`、`unread`、`activeSubagents`（需新增 `removeHost(hostId)` action，掃描所有 `hostId:*` 前綴 key）。新 `removeHost` 涵蓋現有 `clearSubagentsForHost` 的功能，後者應被移除以避免重複 |
+| StreamStore | 清除該 host 的 sessions、relayStatus、handoffProgress（需新增 `clearHost(hostId)` action，掃描所有 `hostId:*` 前綴 composite key） |
+| WS 連線 | `useMultiHostEventWs` 透過 `hostOrderKey` 變化自動 cleanup |
+
+### Undo Toast
+
+刪除後底部出現 undo toast：
+
+- 內容：「已刪除 {hostName}」+「復原」按鈕
+- 5 秒倒數後自動消失
+- 點擊復原 → 從 snapshot 還原所有受影響的 store 資料（含 tab 狀態）
+- 實作方式：刪除前做 snapshot（受影響 store 的資料），存在記憶體中，復原 = 把 snapshot 寫回各 store
+- Snapshot 只保存可序列化資料：StreamStore 的 `conn: StreamConnection` 等連線物件不納入 snapshot，undo 後 stream tab 回到「有歷史訊息但未建立連線」狀態，切換到該 tab 時自然重建 WS
+- 衝突處理：undo 期間如果 snapshot 中的 tab 已被使用者覆寫（例如選了新 session），則略過不還原該 tab
+- 最後一個 host 不可刪：維持現有 HostStore `removeHost` 的防呆（`Object.keys(hosts).length <= 1` 時不執行），刪除按鈕 disabled
+
+### Terminated Tab 的 WS 隔離
+
+`terminated` 狀態的 tab 不觸發任何 WS 連線。在 `useTerminalWs` 和 `SessionPaneContent` 中加 guard：
+
+```typescript
+if (content.terminated) return  // 不建立 WS
+```
+
+此修復同時解決 #159（ghost reconnect on deleted host）。
+
+> 注：刪除 host 時，`hostOrderKey` 變化觸發 `useMultiHostEventWs` 的 cleanup effect re-run，SM 會在 cleanup 中被 `stop()`，不影響 terminated 寫入時序。即使 tab 正處於 reconnecting 狀態，`deriveTabState` 的優先順序為 `terminated` > `reconnecting`，因此 terminated 寫入後 tab 狀態立即正確。
+
+## 六、通知
+
+### L2/L3 Electron 系統通知
+
+在 `useNotificationDispatcher` 擴充連線狀態通知：
+
+| 觸發 | 條件 | 通知內容 |
+|------|------|---------|
+| L2（daemon refused） | `daemonState` 從 `connected` 變為 `refused` | 「{hostName} — Daemon 未啟動」 |
+| L3（tmux down） | `tmuxState` 從 `ok` 變為 `unavailable` | 「{hostName} — tmux 環境無法連線」 |
+| L1（unreachable） | 不發通知 | — |
+
+規則：
+
+- 每 host 每次斷線只發一次（恢復後再斷才會再發）
+- 使用 `Notification` API（瀏覽器）或 Electron `notification` module
+- 點擊通知 → 切換到該 host 的 overview 頁面
+
+## 七、Bug Fixes
+
+### #161 — checkHealth JSON parse error
+
+`useMultiHostEventWs` 中 `JSON.parse(event.value)` 無 try-catch。修復：wrap try-catch，parse 失敗 log warning，不影響連線狀態。
+
+### #156 — AddHostDialog /api/info 失敗無提示
+
+目前 fetch 失敗時無回饋。修復：加入錯誤訊息顯示，區分 L1（主機無法連線）/ L2（Daemon 未啟動）/ 401（Token 無效）。
+
+### #140 — TokenField 清空時誤顯 Invalid token
+
+使用者清空 token 欄位時觸發驗證 → 空值送 API → 401 → 顯示錯誤。修復：空值不觸發驗證，清除錯誤訊息。
+
+### #137 — Electron 離線 renderer crash
+
+Electron 啟動時 daemon 不可達 → renderer 未處理錯誤 → 白屏。修復：Phase 3 ConnectionStateMachine 已處理底層，Phase 4 補 UI 層 — 確保 L1 狀態有正確的錯誤頁面而非白屏。
+
+## 八、i18n Key 清單
+
+Phase 4 新增的所有 UI 文字需同步加入 `en.json` 和 `zh-TW.json`：
+
+| Key | en | zh-TW |
+|-----|----|-------|
+| `terminated.session_closed` | Session closed | Session 已關閉 |
+| `terminated.session_closed_desc` | {name} no longer exists | {name} 已不存在 |
+| `terminated.tmux_restarted` | tmux restarted | tmux 已重啟 |
+| `terminated.tmux_restarted_desc` | Previous sessions are no longer valid | 原有 session 已失效 |
+| `terminated.host_removed` | Host removed | Host 已移除 |
+| `terminated.host_removed_desc` | This host has been removed | 該主機已從列表中移除 |
+| `terminated.no_sessions` | No available connections | 目前沒有可用的連線 |
+| `terminated.close_tab` | Close tab | 關閉分頁 |
+| `terminated.select_session` | Select a session to reconnect | 選擇 session 以重新連線 |
+| `hosts.confirm_delete_tabs` | Also close all tabs for this host | 一併關閉所有此 Host 的分頁 |
+| `hosts.deleted_toast` | Deleted {name} | 已刪除 {name} |
+| `hosts.undo` | Undo | 復原 |
+| `hosts.error_unreachable` | Host unreachable | 主機無法連線 |
+| `hosts.error_refused` | Daemon not running | Daemon 未啟動 |
+| `hosts.error_tmux_down` | tmux unavailable | tmux 環境無法連線 |
+| `connection.reconnect` | Reconnect | 重新連線 |
+| `notification.daemon_refused` | {name} — Daemon not running | {name} — Daemon 未啟動 |
+| `notification.tmux_down` | {name} — tmux unavailable | {name} — tmux 環境無法連線 |
+
+## 九、Sub-Phase 拆分
+
+### Phase 4a — Tab 狀態基礎建設
+
+- `kind: 'session'` → `kind: 'tmux-session'` rename（約 31 個檔案，含 `useNotificationDispatcher.ts`）
+- Zustand persist migration（version 1 → 2）
+- PaneContent 加 `terminated?: TerminatedReason`
+- Tab icon 對應（SmileySad for terminated）
+- Tab name 對應（`{cachedName}（Terminated）`）
+- `deriveTabState()` 推導函式（放在 `spa/src/lib/tab-state.ts`）
+- i18n key 新增（第八節清單）
+
+### Phase 4b — Terminated 錯誤頁元件
+
+- `TerminatedPane` 元件（訊息 + 關閉按鈕 + session list）
+- `SessionPickerList` 元件（跨 host，只列 connected）
+- Tab 重新綁定：選 session 後覆寫 PaneContent
+- `SessionPaneContent` 加入 terminated 判斷分支
+- Terminated 偵測寫入（useMultiHostEventWs 中 session 消失 / tmux 重啟）
+
+### Phase 4c — Host 層級錯誤 UI
+
+- StatusBar / SessionPanel / HostSidebar / OverviewSection 的 L1-L3 錯誤顯示
+- Reconnecting overlay 手動重連按鈕
+- SessionPanel disable 行為
+
+### Phase 4d — Host 刪除流程 + Cascade Cleanup
+
+- 刪除確認 UI 加 checkbox（一併關閉分頁）
+- Cascade cleanup（SessionStore、AgentStore、StreamStore）
+- Undo toast + snapshot 復原
+- Terminated tab WS 隔離（同時修復 #159）
+
+### Phase 4e — 通知 + Bug fixes
+
+- L2/L3 Electron 系統通知
+- Bug fix: #137、#140、#156、#161
+- `HEALTH_TIMEOUT_MS` 從 3000 改為 6000（對應 F-2 決策）
+
+### Sub-Phase 依賴關係
+
+```
+4a (rename + terminated field + i18n + migration)
+ ├──→ 4b (TerminatedPane 元件 + 偵測寫入)
+ ├──→ 4c (Host 層級錯誤 UI)        ← 4b 與 4c 可並行
+ └──→ 4d (刪除流程 + cascade)      ← 僅依賴 4a，不需等 4b/4c
+          └──→ 4e (通知 + bug fixes)
+```
+
+## 十、設計決策記錄
+
+### C-2 — SM 存取方式（已決定：useHostConnection hook）
+
+新增 `useHostConnection(hostId)` hook，封裝 `ConnectionStateMachine` 的存取，對外提供 `manualRetry()` 函式。Reconnecting Overlay 透過此 hook 觸發手動重連。按鈕 spinner 結束條件為訂閱 `HostRuntime.status` 變化。
+
+### C-3 — tmuxInstance 廣播來源（已決定：sessions 事件附帶）
+
+Daemon 端在 `sessions` 事件 payload 中附帶 `tmuxInstance`（`pid:startTime`）。SPA 在 `useMultiHostEventWs` 收到 sessions 事件時，比對 payload 中的 tmuxInstance 與各 tab PaneContent 中存的值，若不一致則寫入 `terminated: 'tmux-restarted'`。需要 daemon 端配合修改 sessions 廣播格式。
+
+### F-2 — Background retry timeout
+
+`checkHealth` 的 timeout 從 3s 調整為 6s，讓不穩定網路有更多緩衝。背景重連的實際節奏變為 `6s timeout + 100ms delay ≈ 每 6 秒一次`。
+
+### F-3 — 通知 click handler 模組化
+
+現有 `handleNotificationClick` 只支援跳到 session tab。改為 action payload 模式，通知攜帶導航意圖（純資料），中央 dispatcher 解讀：
+
+```typescript
+type NotificationAction =
+  | { kind: 'open-session'; hostId: string; sessionCode: string }
+  | { kind: 'open-host'; hostId: string }
+  // 未來擴充：| { kind: 'open-file'; hostId: string; path: string }
+
+function handleNotificationClick(action: NotificationAction) {
+  switch (action.kind) {
+    case 'open-session': // 找到或開啟 session tab
+    case 'open-host':    // 切換到 hosts 頁面 + 選中 hostId
+  }
+}
+```
+
+新增通知類型只需加一個 `NotificationAction` variant + 一個 switch case。不依賴 tab 是否已存在。Phase 4e 將現有 agent 通知遷移到此模式，並加入 L2/L3 host 通知。
+
+`open-host` 的導航實作：呼叫 `openSingletonTab({ kind: 'hosts' })` 切到 hosts 頁面，再呼叫 `setActiveHost(hostId)` 選中目標 host。
+
+## 十一、關聯 Issues
+
+| Issue | 對應 Sub-Phase | 處理方式 |
+|-------|---------------|---------|
+| #137 | 4e | 補 L1 錯誤 UI，避免白屏 |
+| #140 | 4e | 空值不觸發驗證 |
+| #156 | 4e | 加入 L1/L2/401 錯誤訊息 |
+| #159 | 4d | terminated tab 不觸發 WS |
+| #161 | 4e | JSON.parse try-catch |

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -64,6 +64,7 @@ function registerIpcHandlers(): void {
   ipcMain.handle('notification:show', (_event, optsJson: string) => {
     const opts = JSON.parse(optsJson) as {
       title: string; body: string; sessionCode: string; eventName: string; broadcastTs: number
+      action?: { kind: string; hostId: string; sessionCode?: string }
     }
     // Dedup: same broadcast received by multiple windows
     if (recentBroadcasts.has(opts.broadcastTs)) return
@@ -74,9 +75,13 @@ function registerIpcHandlers(): void {
     notification.on('click', () => {
       // Broadcast to all renderers — SPA decides which one has the tab
       // The SPA will call focusMyWindow IPC when it handles the click
+      const payload: { sessionCode: string; action?: { kind: string; hostId: string; sessionCode?: string } } = {
+        sessionCode: opts.sessionCode,
+      }
+      if (opts.action) payload.action = opts.action
       for (const win of windowManager.getAllWindows()) {
         if (!win.isDestroyed()) {
-          win.webContents.send('notification:clicked', { sessionCode: opts.sessionCode })
+          win.webContents.send('notification:clicked', payload)
         }
       }
     })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -46,10 +46,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   // Notifications
-  showNotification: (opts: { title: string; body: string; sessionCode: string; eventName: string; broadcastTs: number }) =>
+  showNotification: (opts: { title: string; body: string; sessionCode: string; eventName: string; broadcastTs: number; action?: { kind: string; hostId: string; sessionCode?: string } }) =>
     ipcRenderer.invoke('notification:show', JSON.stringify(opts)),
-  onNotificationClicked: (callback: (payload: { sessionCode: string }) => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, payload: { sessionCode: string }) =>
+  onNotificationClicked: (callback: (payload: { sessionCode: string; action?: { kind: string; hostId: string; sessionCode?: string } }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, payload: { sessionCode: string; action?: { kind: string; hostId: string; sessionCode?: string } }) =>
       callback(payload)
     ipcRenderer.on('notification:clicked', handler)
     return () => ipcRenderer.removeListener('notification:clicked', handler)

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -1,5 +1,5 @@
 // spa/src/App.tsx — v2 重構：wouter Router + Tab/Pane model
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Router } from 'wouter'
 import { ActivityBar } from './components/ActivityBar'
 import { TabBar } from './components/TabBar'
@@ -15,13 +15,49 @@ import { useRouteSync } from './hooks/useRouteSync'
 import { useShortcuts } from './hooks/useShortcuts'
 import { useNotificationDispatcher } from './hooks/useNotificationDispatcher'
 import { useAgentStore } from './stores/useAgentStore'
+import { useUndoToast } from './stores/useUndoToast'
 import { useTabWorkspaceActions } from './hooks/useTabWorkspaceActions'
 import { isStandaloneTab } from './types/tab'
 import { TabContextMenu } from './components/TabContextMenu'
 import { ThemeInjector } from './components/ThemeInjector'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { getPlatformCapabilities } from './lib/platform'
+import { useI18nStore } from './stores/useI18nStore'
 import type { Tab } from './types/tab'
+
+function GlobalUndoToast() {
+  const toast = useUndoToast((s) => s.toast)
+  const dismiss = useUndoToast((s) => s.dismiss)
+  const t = useI18nStore((s) => s.t)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!toast) return
+    timerRef.current = setTimeout(() => dismiss(), 5000)
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [toast, dismiss])
+
+  if (!toast) return null
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3 flex items-center gap-3 shadow-lg z-50">
+      <span className="text-sm text-zinc-300">
+        {toast.message}
+      </span>
+      <button
+        className="text-sm text-blue-400 hover:text-blue-300 font-medium cursor-pointer"
+        onClick={() => {
+          toast.restore()
+          dismiss()
+        }}
+      >
+        {t('hosts.undo')}
+      </button>
+    </div>
+  )
+}
 
 export default function App() {
   const isElectron = getPlatformCapabilities().isElectron
@@ -229,6 +265,7 @@ export default function App() {
         )}
         </div>
       </div>
+      <GlobalUndoToast />
     </Router>
     </ErrorBoundary>
   )

--- a/spa/src/components/ActivityBar.test.tsx
+++ b/spa/src/components/ActivityBar.test.tsx
@@ -10,7 +10,7 @@ const mockWorkspaces: Workspace[] = [
 ]
 
 const mockStandaloneTabs: Tab[] = [
-  { ...createTab({ kind: 'session', hostId: 'test-host', sessionCode: 'misc', mode: 'terminal', cachedName: '', tmuxInstance: '' }), id: 'st-1' },
+  { ...createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'misc', mode: 'terminal', cachedName: '', tmuxInstance: '' }), id: 'st-1' },
 ]
 
 describe('ActivityBar', () => {

--- a/spa/src/components/HistoryPage.test.tsx
+++ b/spa/src/components/HistoryPage.test.tsx
@@ -26,7 +26,7 @@ describe('HistoryPage', () => {
 
   it('renders browse records in reverse chronological order', () => {
     const content1: PaneContent = { kind: 'dashboard' }
-    const content2: PaneContent = { kind: 'session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
+    const content2: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
     useHistoryStore.setState({
       browseHistory: [
         { tabId: 't1', paneContent: content1, visitedAt: 1000 },

--- a/spa/src/components/HostPage.tsx
+++ b/spa/src/components/HostPage.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { PaneRendererProps } from '../lib/pane-registry'
 import { useHostStore } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { HostSidebar } from './hosts/HostSidebar'
-import { OverviewSection, type UndoToastInfo } from './hosts/OverviewSection'
+import { OverviewSection } from './hosts/OverviewSection'
 import { SessionsSection } from './hosts/SessionsSection'
 import { HooksSection } from './hosts/HooksSection'
 import { UploadSection } from './hosts/UploadSection'
@@ -26,18 +26,7 @@ export function HostPage(_props: PaneRendererProps) {
     subPage: 'overview',
   }))
   const [showAddHost, setShowAddHost] = useState(false)
-  const [undoToast, setUndoToast] = useState<UndoToastInfo | null>(null)
-  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const t = useI18nStore((s) => s.t)
-
-  // Auto-dismiss undo toast after 5 seconds
-  useEffect(() => {
-    if (!undoToast) return
-    undoTimerRef.current = setTimeout(() => setUndoToast(null), 5000)
-    return () => {
-      if (undoTimerRef.current) clearTimeout(undoTimerRef.current)
-    }
-  }, [undoToast])
 
   // Derive effective selection: reset when selected host no longer exists
   const effectiveSelection = useMemo<Selection>(() => {
@@ -53,7 +42,7 @@ export function HostPage(_props: PaneRendererProps) {
     }
     switch (effectiveSelection.subPage) {
       case 'overview':
-        return <OverviewSection hostId={effectiveSelection.hostId} onShowUndoToast={setUndoToast} />
+        return <OverviewSection hostId={effectiveSelection.hostId} />
       case 'sessions':
         return <SessionsSection hostId={effectiveSelection.hostId} />
       case 'hooks':
@@ -75,22 +64,6 @@ export function HostPage(_props: PaneRendererProps) {
         {renderContent()}
       </div>
       {showAddHost && <AddHostDialog onClose={() => setShowAddHost(false)} />}
-      {undoToast && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3 flex items-center gap-3 shadow-lg z-50">
-          <span className="text-sm text-zinc-300">
-            {t('hosts.deleted_toast', { name: undoToast.name })}
-          </span>
-          <button
-            className="text-sm text-blue-400 hover:text-blue-300 font-medium cursor-pointer"
-            onClick={() => {
-              undoToast.restore()
-              setUndoToast(null)
-            }}
-          >
-            {t('hosts.undo')}
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/spa/src/components/HostPage.tsx
+++ b/spa/src/components/HostPage.tsx
@@ -1,9 +1,9 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { PaneRendererProps } from '../lib/pane-registry'
 import { useHostStore } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { HostSidebar } from './hosts/HostSidebar'
-import { OverviewSection } from './hosts/OverviewSection'
+import { OverviewSection, type UndoToastInfo } from './hosts/OverviewSection'
 import { SessionsSection } from './hosts/SessionsSection'
 import { HooksSection } from './hosts/HooksSection'
 import { UploadSection } from './hosts/UploadSection'
@@ -26,7 +26,18 @@ export function HostPage(_props: PaneRendererProps) {
     subPage: 'overview',
   }))
   const [showAddHost, setShowAddHost] = useState(false)
+  const [undoToast, setUndoToast] = useState<UndoToastInfo | null>(null)
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const t = useI18nStore((s) => s.t)
+
+  // Auto-dismiss undo toast after 5 seconds
+  useEffect(() => {
+    if (!undoToast) return
+    undoTimerRef.current = setTimeout(() => setUndoToast(null), 5000)
+    return () => {
+      if (undoTimerRef.current) clearTimeout(undoTimerRef.current)
+    }
+  }, [undoToast])
 
   // Derive effective selection: reset when selected host no longer exists
   const effectiveSelection = useMemo<Selection>(() => {
@@ -42,7 +53,7 @@ export function HostPage(_props: PaneRendererProps) {
     }
     switch (effectiveSelection.subPage) {
       case 'overview':
-        return <OverviewSection hostId={effectiveSelection.hostId} />
+        return <OverviewSection hostId={effectiveSelection.hostId} onShowUndoToast={setUndoToast} />
       case 'sessions':
         return <SessionsSection hostId={effectiveSelection.hostId} />
       case 'hooks':
@@ -64,6 +75,22 @@ export function HostPage(_props: PaneRendererProps) {
         {renderContent()}
       </div>
       {showAddHost && <AddHostDialog onClose={() => setShowAddHost(false)} />}
+      {undoToast && (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3 flex items-center gap-3 shadow-lg z-50">
+          <span className="text-sm text-zinc-300">
+            {t('hosts.deleted_toast', { name: undoToast.name })}
+          </span>
+          <button
+            className="text-sm text-blue-400 hover:text-blue-300 font-medium cursor-pointer"
+            onClick={() => {
+              undoToast.restore()
+              setUndoToast(null)
+            }}
+          >
+            {t('hosts.undo')}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/spa/src/components/SessionPaneContent.test.tsx
+++ b/spa/src/components/SessionPaneContent.test.tsx
@@ -3,8 +3,9 @@ import { render, screen, cleanup } from '@testing-library/react'
 import { SessionPaneContent } from './SessionPaneContent'
 import { useHostStore } from '../stores/useHostStore'
 import { useSessionStore } from '../stores/useSessionStore'
+import { useTabStore } from '../stores/useTabStore'
 import { useConfigStore } from '../stores/useConfigStore'
-import type { Pane } from '../types/tab'
+import type { Pane, Tab } from '../types/tab'
 import type { ConfigData } from '../lib/api'
 
 vi.mock('./TerminalView', () => ({
@@ -13,6 +14,12 @@ vi.mock('./TerminalView', () => ({
 
 vi.mock('./ConversationView', () => ({
   default: () => <div data-testid="conversation-view" />,
+}))
+
+vi.mock('./TerminatedPane', () => ({
+  TerminatedPane: ({ content }: { content: { terminated: string } }) => (
+    <div data-testid="terminated-pane">Terminated: {content.terminated}</div>
+  ),
 }))
 
 const HOST_ID = 'test-host'
@@ -28,6 +35,21 @@ const defaultConfig: ConfigData = {
   port: 7860,
   stream: { presets: [{ name: 'cc', command: 'claude -p' }] },
   detect: { cc_commands: [], poll_interval: 5 },
+}
+
+function setupTabStore(pane: Pane) {
+  const tab: Tab = {
+    id: 'tab-1',
+    pinned: false,
+    locked: false,
+    createdAt: Date.now(),
+    layout: { type: 'leaf', pane },
+  }
+  useTabStore.setState({
+    tabs: { 'tab-1': tab },
+    tabOrder: ['tab-1'],
+    activeTabId: 'tab-1',
+  })
 }
 
 beforeEach(() => {
@@ -48,17 +70,20 @@ beforeEach(() => {
     activeCode: null,
   })
   useConfigStore.setState({ config: defaultConfig })
+  useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
 })
 
 describe('SessionPaneContent', () => {
   it('returns null for non-session pane content', () => {
     const pane: Pane = { id: 'pane-1', content: { kind: 'dashboard' } }
+    setupTabStore(pane)
     const { container } = render(<SessionPaneContent pane={pane} isActive={true} />)
     expect(container.innerHTML).toBe('')
   })
 
   it('renders TerminalView for terminal mode', () => {
     const pane = makePane()
+    setupTabStore(pane)
     render(<SessionPaneContent pane={pane} isActive={true} />)
     expect(screen.getByTestId('terminal-view')).toBeInTheDocument()
   })
@@ -67,7 +92,36 @@ describe('SessionPaneContent', () => {
     const pane = makePane({
       content: { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'stream', cachedName: '', tmuxInstance: '' },
     })
+    setupTabStore(pane)
     render(<SessionPaneContent pane={pane} isActive={true} />)
     expect(screen.getByTestId('conversation-view')).toBeInTheDocument()
+  })
+
+  it('renders TerminatedPane when content.terminated is set', () => {
+    const pane = makePane({
+      content: {
+        kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001',
+        mode: 'terminal', cachedName: 'my-session', tmuxInstance: '',
+        terminated: 'session-closed',
+      },
+    })
+    setupTabStore(pane)
+    render(<SessionPaneContent pane={pane} isActive={true} />)
+    expect(screen.getByTestId('terminated-pane')).toBeInTheDocument()
+    expect(screen.getByText('Terminated: session-closed')).toBeInTheDocument()
+  })
+
+  it('does not render TerminalView when terminated', () => {
+    const pane = makePane({
+      content: {
+        kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001',
+        mode: 'terminal', cachedName: '', tmuxInstance: '',
+        terminated: 'tmux-restarted',
+      },
+    })
+    setupTabStore(pane)
+    render(<SessionPaneContent pane={pane} isActive={true} />)
+    expect(screen.queryByTestId('terminal-view')).not.toBeInTheDocument()
+    expect(screen.getByTestId('terminated-pane')).toBeInTheDocument()
   })
 })

--- a/spa/src/components/SessionPaneContent.test.tsx
+++ b/spa/src/components/SessionPaneContent.test.tsx
@@ -19,7 +19,7 @@ const HOST_ID = 'test-host'
 
 const makePane = (overrides?: Partial<Pane>): Pane => ({
   id: 'pane-1',
-  content: { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' },
+  content: { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' },
   ...overrides,
 })
 
@@ -65,7 +65,7 @@ describe('SessionPaneContent', () => {
 
   it('renders ConversationView for stream mode', () => {
     const pane = makePane({
-      content: { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'stream', cachedName: '', tmuxInstance: '' },
+      content: { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'stream', cachedName: '', tmuxInstance: '' },
     })
     render(<SessionPaneContent pane={pane} isActive={true} />)
     expect(screen.getByTestId('conversation-view')).toBeInTheDocument()

--- a/spa/src/components/SessionPaneContent.tsx
+++ b/spa/src/components/SessionPaneContent.tsx
@@ -12,9 +12,9 @@ const EMPTY_PRESETS: Array<{ name: string; command: string }> = []
 
 export function SessionPaneContent({ pane, isActive }: PaneRendererProps) {
   const content = pane.content
-  const sessionCode = content.kind === 'session' ? content.sessionCode : ''
-  const hostId = content.kind === 'session' ? content.hostId : ''
-  const mode = content.kind === 'session' ? content.mode : 'terminal'
+  const sessionCode = content.kind === 'tmux-session' ? content.sessionCode : ''
+  const hostId = content.kind === 'tmux-session' ? content.hostId : ''
+  const mode = content.kind === 'tmux-session' ? content.mode : 'terminal'
 
   const daemonBase = useHostStore((s) => s.getDaemonBase(hostId))
   const wsBase = useHostStore((s) => s.getWsBase(hostId))
@@ -50,7 +50,7 @@ export function SessionPaneContent({ pane, isActive }: PaneRendererProps) {
     }
   }, [session, hostId, daemonBase, fetchHost])
 
-  if (content.kind !== 'session') return null
+  if (content.kind !== 'tmux-session') return null
 
   if (mode === 'stream') {
     return (

--- a/spa/src/components/SessionPaneContent.tsx
+++ b/spa/src/components/SessionPaneContent.tsx
@@ -1,11 +1,14 @@
 import { useCallback } from 'react'
 import TerminalView from './TerminalView'
 import ConversationView from './ConversationView'
+import { TerminatedPane } from './TerminatedPane'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useStreamStore } from '../stores/useStreamStore'
 import { useConfigStore } from '../stores/useConfigStore'
+import { useTabStore } from '../stores/useTabStore'
 import { handoff } from '../lib/api'
 import { useHostStore } from '../stores/useHostStore'
+import { findPane } from '../lib/pane-tree'
 import type { PaneRendererProps } from '../lib/pane-registry'
 
 const EMPTY_PRESETS: Array<{ name: string; command: string }> = []
@@ -49,6 +52,18 @@ export function SessionPaneContent({ pane, isActive }: PaneRendererProps) {
       useStreamStore.getState().setHandoffProgress(hostId, session.code, '')
     }
   }, [session, hostId, daemonBase, fetchHost])
+
+  // Look up tabId from store (pane renderers don't receive tabId as a prop)
+  const tabId = useTabStore((s) => {
+    for (const id of Object.keys(s.tabs)) {
+      if (findPane(s.tabs[id].layout, pane.id)) return id
+    }
+    return ''
+  })
+
+  if (content.kind === 'tmux-session' && content.terminated) {
+    return <TerminatedPane content={content} tabId={tabId} paneId={pane.id} />
+  }
 
   if (content.kind !== 'tmux-session') return null
 

--- a/spa/src/components/SessionPickerList.test.tsx
+++ b/spa/src/components/SessionPickerList.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { SessionPickerList } from './SessionPickerList'
+import { useHostStore } from '../stores/useHostStore'
+import { useSessionStore } from '../stores/useSessionStore'
+
+const HOST_A = 'host-a'
+const HOST_B = 'host-b'
+
+beforeEach(() => {
+  cleanup()
+  useHostStore.setState({
+    hosts: {},
+    hostOrder: [],
+    runtime: {},
+    activeHostId: null,
+  })
+  useSessionStore.setState({
+    sessions: {},
+    activeHostId: null,
+    activeCode: null,
+  })
+})
+
+describe('SessionPickerList', () => {
+  it('shows empty message when no connected hosts', () => {
+    const onSelect = vi.fn()
+    render(<SessionPickerList onSelect={onSelect} />)
+    expect(screen.getByText('No available connections')).toBeInTheDocument()
+  })
+
+  it('shows empty message when hosts exist but none are connected', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+      },
+      hostOrder: [HOST_A],
+      runtime: {
+        [HOST_A]: { status: 'disconnected' },
+      },
+    })
+    const onSelect = vi.fn()
+    render(<SessionPickerList onSelect={onSelect} />)
+    expect(screen.getByText('No available connections')).toBeInTheDocument()
+  })
+
+  it('shows sessions grouped by host name', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+        [HOST_B]: { id: HOST_B, name: 'Host B', ip: '5.6.7.8', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_A, HOST_B],
+      runtime: {
+        [HOST_A]: { status: 'connected' },
+        [HOST_B]: { status: 'connected' },
+      },
+    })
+    useSessionStore.setState({
+      sessions: {
+        [HOST_A]: [
+          { code: 'dev001', name: 'dev-session', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+        [HOST_B]: [
+          { code: 'cld001', name: 'claude-session', cwd: '/tmp', mode: 'stream', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+      },
+    })
+    const onSelect = vi.fn()
+    render(<SessionPickerList onSelect={onSelect} />)
+
+    expect(screen.getByText('Host A')).toBeInTheDocument()
+    expect(screen.getByText('Host B')).toBeInTheDocument()
+    expect(screen.getByText('dev-session')).toBeInTheDocument()
+    expect(screen.getByText('claude-session')).toBeInTheDocument()
+  })
+
+  it('skips connected host with no sessions', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+      },
+      hostOrder: [HOST_A],
+      runtime: {
+        [HOST_A]: { status: 'connected' },
+      },
+    })
+    useSessionStore.setState({ sessions: { [HOST_A]: [] } })
+
+    const onSelect = vi.fn()
+    render(<SessionPickerList onSelect={onSelect} />)
+
+    // Has connected host but no sessions — still shows the wrapper, but no host name
+    expect(screen.queryByText('Host A')).not.toBeInTheDocument()
+  })
+
+  it('calls onSelect with correct SessionSelection on click', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+      },
+      hostOrder: [HOST_A],
+      runtime: {
+        [HOST_A]: {
+          status: 'connected',
+          info: { host_id: HOST_A, tmux_instance: '12345:67890', tbox_version: '1.0', tmux_version: '3.6', os: 'darwin', arch: 'arm64' },
+        },
+      },
+    })
+    useSessionStore.setState({
+      sessions: {
+        [HOST_A]: [
+          { code: 'dev001', name: 'dev-session', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+      },
+    })
+
+    const onSelect = vi.fn()
+    render(<SessionPickerList onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByText('dev-session'))
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith({
+      hostId: HOST_A,
+      sessionCode: 'dev001',
+      cachedName: 'dev-session',
+      tmuxInstance: '12345:67890',
+    })
+  })
+
+  it('uses empty string for tmuxInstance when info is missing', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+      },
+      hostOrder: [HOST_A],
+      runtime: {
+        [HOST_A]: { status: 'connected' },
+      },
+    })
+    useSessionStore.setState({
+      sessions: {
+        [HOST_A]: [
+          { code: 'dev001', name: 'dev-session', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+      },
+    })
+
+    const onSelect = vi.fn()
+    render(<SessionPickerList onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByText('dev-session'))
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ tmuxInstance: '' }),
+    )
+  })
+
+  it('only shows connected hosts, not disconnected ones', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+        [HOST_B]: { id: HOST_B, name: 'Host B', ip: '5.6.7.8', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_A, HOST_B],
+      runtime: {
+        [HOST_A]: { status: 'connected' },
+        [HOST_B]: { status: 'disconnected' },
+      },
+    })
+    useSessionStore.setState({
+      sessions: {
+        [HOST_A]: [
+          { code: 'dev001', name: 'dev-session', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+        [HOST_B]: [
+          { code: 'cld001', name: 'cloud-session', cwd: '/tmp', mode: 'stream', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+      },
+    })
+
+    const onSelect = vi.fn()
+    render(<SessionPickerList onSelect={onSelect} />)
+
+    expect(screen.getByText('Host A')).toBeInTheDocument()
+    expect(screen.getByText('dev-session')).toBeInTheDocument()
+    expect(screen.queryByText('Host B')).not.toBeInTheDocument()
+    expect(screen.queryByText('cloud-session')).not.toBeInTheDocument()
+  })
+})

--- a/spa/src/components/SessionPickerList.tsx
+++ b/spa/src/components/SessionPickerList.tsx
@@ -1,0 +1,62 @@
+import { useHostStore } from '../stores/useHostStore'
+import { useSessionStore } from '../stores/useSessionStore'
+import { useI18nStore } from '../stores/useI18nStore'
+
+export interface SessionSelection {
+  hostId: string
+  sessionCode: string
+  cachedName: string
+  tmuxInstance: string
+}
+
+interface Props {
+  onSelect: (selection: SessionSelection) => void
+}
+
+export function SessionPickerList({ onSelect }: Props) {
+  const t = useI18nStore((s) => s.t)
+  const hosts = useHostStore((s) => s.hosts)
+  const hostOrder = useHostStore((s) => s.hostOrder)
+  const runtime = useHostStore((s) => s.runtime)
+  const sessions = useSessionStore((s) => s.sessions)
+
+  const connectedHosts = hostOrder.filter((id) => runtime[id]?.status === 'connected')
+
+  if (connectedHosts.length === 0) {
+    return <div className="text-center text-zinc-500 py-8">{t('terminated.no_sessions')}</div>
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-zinc-400">{t('terminated.select_session')}</p>
+      {connectedHosts.map((hostId) => {
+        const host = hosts[hostId]
+        const hostSessions = sessions[hostId] ?? []
+        if (!host || hostSessions.length === 0) return null
+        return (
+          <div key={hostId}>
+            <div className="text-xs text-zinc-500 mb-1">{host.name}</div>
+            <div className="space-y-1">
+              {hostSessions.map((s) => (
+                <button
+                  key={s.code}
+                  className="w-full text-left px-3 py-2 rounded hover:bg-zinc-700/50 text-sm"
+                  onClick={() =>
+                    onSelect({
+                      hostId,
+                      sessionCode: s.code,
+                      cachedName: s.name,
+                      tmuxInstance: runtime[hostId]?.info?.tmux_instance ?? '',
+                    })
+                  }
+                >
+                  {s.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -52,7 +52,7 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
                 className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-white/10 text-left text-sm text-text-primary cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={!!isOffline}
                 onClick={() =>
-                  onSelect({ kind: 'session', hostId, sessionCode: session.code, mode: 'terminal', cachedName: session.name, tmuxInstance: '' })
+                  onSelect({ kind: 'tmux-session', hostId, sessionCode: session.code, mode: 'terminal', cachedName: session.name, tmuxInstance: '' })
                 }
               >
                 <TerminalWindow size={16} className="text-text-secondary flex-shrink-0" />

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -82,11 +82,11 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
   const IconComponent = iconMap[iconName]
 
   const t = useI18nStore((s) => s.t)
-  const hostId = primaryContent.kind === 'session' ? primaryContent.hostId : ''
+  const hostId = primaryContent.kind === 'tmux-session' ? primaryContent.hostId : ''
   const sessions = useSessionStore((s) => (hostId ? s.sessions[hostId] : undefined) ?? EMPTY_SESSIONS)
   const workspaces = useWorkspaceStore((s) => s.workspaces)
 
-  const sessionCode = primaryContent.kind === 'session' ? primaryContent.sessionCode : undefined
+  const sessionCode = primaryContent.kind === 'tmux-session' ? primaryContent.sessionCode : undefined
   const ck = sessionCode && hostId ? compositeKey(hostId, sessionCode) : undefined
   const agentStatus = useAgentStore((s) => {
     if (!ck) return undefined

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -99,8 +99,9 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
   const isUnread = useAgentStore((s) => ck ? !!s.unread[ck] : false)
   const subagentCount = useAgentStore((s) => ck ? (s.activeSubagents[ck]?.length ?? 0) : 0)
   const tabIndicatorStyle = useAgentStore((s) => s.tabIndicatorStyle)
+  const isTerminated = primaryContent.kind === 'tmux-session' && !!primaryContent.terminated
   const isHostOffline = useHostStore((s) => {
-    if (!hostId) return false
+    if (!hostId || isTerminated) return false
     const rt = s.runtime[hostId]
     return rt ? rt.status !== 'connected' : false
   })

--- a/spa/src/components/StatusBar.test.tsx
+++ b/spa/src/components/StatusBar.test.tsx
@@ -46,7 +46,7 @@ beforeEach(() => {
 
 describe('StatusBar', () => {
   it('renders host and session info', () => {
-    const tab = makeTab('t1', { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
     expect(screen.getByText('mlab')).toBeTruthy()
     expect(screen.getByText('dev-server')).toBeTruthy()
@@ -59,7 +59,7 @@ describe('StatusBar', () => {
   })
 
   it('shows viewMode badge for session tabs', () => {
-    const tab = makeTab('t1', { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
     expect(screen.getByText('terminal')).toBeTruthy()
   })
@@ -73,7 +73,7 @@ describe('StatusBar', () => {
 
   it('opens popup on badge click and calls onViewModeChange', () => {
     const onChange = vi.fn()
-    const tab = makeTab('t1', { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     render(<StatusBar activeTab={tab} onViewModeChange={onChange} />)
     fireEvent.click(screen.getByTitle('Toggle view mode'))
     // popup should show both options
@@ -85,7 +85,7 @@ describe('StatusBar', () => {
 
   it('falls back to sessionCode when session not in store', () => {
     useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
-    const tab = makeTab('t1', { kind: 'session', hostId: HOST_ID, sessionCode: 'unknown999', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'unknown999', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
     expect(screen.getByText('unknown999')).toBeTruthy()
   })
@@ -103,7 +103,7 @@ describe('StatusBar upload progress', () => {
     useUploadStore.setState({
       sessions: { [ck]: { total: 5, completed: 1, failed: 0, currentFile: 'photo.png', status: 'uploading' } },
     })
-    const tab = makeTab('t1', { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
     expect(screen.getByTestId('upload-status')).toBeTruthy()
     expect(screen.getByText(/photo\.png/)).toBeTruthy()
@@ -115,7 +115,7 @@ describe('StatusBar upload progress', () => {
     useUploadStore.setState({
       sessions: { [ck]: { total: 3, completed: 3, failed: 0, currentFile: '', status: 'done' } },
     })
-    const tab = makeTab('t1', { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
     expect(screen.getByText(/3 files uploaded/)).toBeTruthy()
   })
@@ -125,7 +125,7 @@ describe('StatusBar upload progress', () => {
     useUploadStore.setState({
       sessions: { [ck]: { total: 1, completed: 0, failed: 1, currentFile: '', error: 'bad.mp4', status: 'error' } },
     })
-    const tab = makeTab('t1', { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
     expect(screen.getByText(/bad\.mp4/)).toBeTruthy()
   })
@@ -146,7 +146,7 @@ describe('StatusBar agent label badge', () => {
       activeSubagents: {},
       hooksInstalled: true,
     })
-    const tab = makeTab('t1', { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
     const badge = screen.getByTestId('agent-label')
     expect(badge.textContent).toBe('Claude Opus 4')
@@ -162,7 +162,7 @@ describe('StatusBar agent label badge', () => {
       activeSubagents: {},
       hooksInstalled: true,
     })
-    const tab = makeTab('t1', { kind: 'session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
     const badge = screen.getByTestId('agent-label')
     expect(badge.textContent).toBe('Agent')

--- a/spa/src/components/StatusBar.tsx
+++ b/spa/src/components/StatusBar.tsx
@@ -137,11 +137,14 @@ export function StatusBar({ activeTab, onViewModeChange }: Props) {
       <span>{hostName}</span>
       <span>{sessionName}</span>
       <span className={
-        status === 'connected' ? 'text-green-500'
+        status === 'connected' && hostRuntime?.tmuxState === 'unavailable' ? 'text-yellow-400'
+          : status === 'connected' ? 'text-green-500'
           : status === 'reconnecting' ? 'text-yellow-400'
           : 'text-red-400'
       }>
-        {status}
+        {status === 'connected' && hostRuntime?.tmuxState === 'unavailable'
+          ? t('hosts.error_tmux_down')
+          : status}
       </span>
       {getAgentLabel(agentEvent) && (() => {
         const label = getAgentLabel(agentEvent)!

--- a/spa/src/components/StatusBar.tsx
+++ b/spa/src/components/StatusBar.tsx
@@ -89,7 +89,7 @@ export function StatusBar({ activeTab, onViewModeChange }: Props) {
   const primaryContent = activeTab?.layout
     ? getPrimaryPane(activeTab.layout).content
     : null
-  const agentHostId = primaryContent && primaryContent.kind === 'session' ? primaryContent.hostId : null
+  const agentHostId = primaryContent && primaryContent.kind === 'tmux-session' ? primaryContent.hostId : null
   const agentSessionCode = primaryContent && 'sessionCode' in primaryContent ? primaryContent.sessionCode : null
   const agentCk = agentHostId && agentSessionCode ? compositeKey(agentHostId, agentSessionCode) : null
 
@@ -116,7 +116,7 @@ export function StatusBar({ activeTab, onViewModeChange }: Props) {
   const primary = getPrimaryPane(activeTab.layout)
   const { content } = primary
 
-  if (content.kind !== 'session') {
+  if (content.kind !== 'tmux-session') {
     return (
       <div className="h-6 bg-surface-secondary border-t border-border-subtle flex items-center px-3 text-[10px] text-text-muted flex-shrink-0">
         <span>{content.kind}</span>

--- a/spa/src/components/TabBar.test.tsx
+++ b/spa/src/components/TabBar.test.tsx
@@ -9,7 +9,7 @@ import { useSessionStore } from '../stores/useSessionStore'
 beforeEach(() => {
   cleanup()
   clearPaneRegistry()
-  registerPaneRenderer('session', { component: () => null })
+  registerPaneRenderer('tmux-session', { component: () => null })
   registerPaneRenderer('dashboard', { component: () => null })
   // Provide sessions keyed by hostId for SortableTab's label lookups
   useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
@@ -31,15 +31,15 @@ function makeTab(id: string, content: import('../types/tab').PaneContent, opts?:
 }
 
 const mockTabs: Tab[] = [
-  makeTab('t1', { kind: 'session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }),
-  makeTab('t2', { kind: 'session', hostId: 'test-host', sessionCode: 'cld001', mode: 'stream', cachedName: '', tmuxInstance: '' }),
+  makeTab('t1', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }),
+  makeTab('t2', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'cld001', mode: 'stream', cachedName: '', tmuxInstance: '' }),
   makeTab('t3', { kind: 'dashboard' }),
 ]
 
 const pinnedTabs: Tab[] = [
-  makeTab('p1', { kind: 'session', hostId: 'test-host', sessionCode: 'aaa001', mode: 'terminal', cachedName: '', tmuxInstance: '' }, { pinned: true }),
-  makeTab('t1', { kind: 'session', hostId: 'test-host', sessionCode: 'bbb001', mode: 'terminal', cachedName: '', tmuxInstance: '' }),
-  makeTab('t2', { kind: 'session', hostId: 'test-host', sessionCode: 'ccc001', mode: 'terminal', cachedName: '', tmuxInstance: '' }),
+  makeTab('p1', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'aaa001', mode: 'terminal', cachedName: '', tmuxInstance: '' }, { pinned: true }),
+  makeTab('t1', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'bbb001', mode: 'terminal', cachedName: '', tmuxInstance: '' }),
+  makeTab('t2', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'ccc001', mode: 'terminal', cachedName: '', tmuxInstance: '' }),
 ]
 
 describe('TabBar', () => {
@@ -89,7 +89,7 @@ describe('TabBar', () => {
 
   it('locked tab hides close button', () => {
     const lockedTabs: Tab[] = [
-      makeTab('t1', { kind: 'session', hostId: 'test-host', sessionCode: 'xxx001', mode: 'terminal', cachedName: '', tmuxInstance: '' }, { locked: true }),
+      makeTab('t1', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'xxx001', mode: 'terminal', cachedName: '', tmuxInstance: '' }, { locked: true }),
     ]
     render(<TabBar tabs={lockedTabs} activeTabId="t1" {...defaultHandlers} />)
     expect(screen.queryByTitle('Close tab')).not.toBeInTheDocument()
@@ -97,7 +97,7 @@ describe('TabBar', () => {
 
   it('shows lock icon on locked non-pinned tab', () => {
     const lockedTabs: Tab[] = [
-      makeTab('t1', { kind: 'session', hostId: 'test-host', sessionCode: 'xxx001', mode: 'terminal', cachedName: '', tmuxInstance: '' }, { locked: true }),
+      makeTab('t1', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'xxx001', mode: 'terminal', cachedName: '', tmuxInstance: '' }, { locked: true }),
     ]
     render(<TabBar tabs={lockedTabs} activeTabId="t1" {...defaultHandlers} />)
     expect(screen.getByText('xxx001')).toBeInTheDocument()

--- a/spa/src/components/TabBar.tsx
+++ b/spa/src/components/TabBar.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useRef, useState, useCallback, useMemo } from 'react'
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent, type Modifier } from '@dnd-kit/core'
 import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortable'
-import { Plus, CaretLeft, CaretRight, TerminalWindow, ChatCircleDots, House, ClockCounterClockwise, GearSix } from '@phosphor-icons/react'
+import { Plus, CaretLeft, CaretRight, TerminalWindow, ChatCircleDots, House, ClockCounterClockwise, GearSix, SmileySad } from '@phosphor-icons/react'
 import { SortableTab } from './SortableTab'
 import { useScrollOverflow } from '../hooks/useScrollOverflow'
 import type { Tab } from '../types/tab'
@@ -16,6 +16,7 @@ const ICON_MAP: Record<string, React.ComponentType<{ size: number; className?: s
   House,
   ClockCounterClockwise,
   GearSix,
+  SmileySad,
 }
 
 interface Props {

--- a/spa/src/components/TabContent.test.tsx
+++ b/spa/src/components/TabContent.test.tsx
@@ -6,7 +6,7 @@ import { createTab } from '../types/tab'
 import type { Tab, Pane } from '../types/tab'
 
 const MockSessionRenderer = ({ pane }: { pane: Pane }) => (
-  <div data-testid="session-renderer">Session: {pane.content.kind === 'session' ? pane.content.sessionCode : ''}</div>
+  <div data-testid="session-renderer">Session: {pane.content.kind === 'tmux-session' ? pane.content.sessionCode : ''}</div>
 )
 const MockDashboardRenderer = () => (
   <div data-testid="dashboard-renderer">Dashboard</div>
@@ -15,12 +15,12 @@ const MockDashboardRenderer = () => (
 beforeEach(() => {
   cleanup()
   clearPaneRegistry()
-  registerPaneRenderer('session', { component: MockSessionRenderer })
+  registerPaneRenderer('tmux-session', { component: MockSessionRenderer })
   registerPaneRenderer('dashboard', { component: MockDashboardRenderer })
 })
 
 const sessionTab: Tab = {
-  ...createTab({ kind: 'session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }),
+  ...createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }),
   id: 't1',
 }
 

--- a/spa/src/components/TabContextMenu.test.tsx
+++ b/spa/src/components/TabContextMenu.test.tsx
@@ -11,7 +11,7 @@ vi.mock('../lib/platform', () => ({
 import { getPlatformCapabilities } from '../lib/platform'
 
 function makeSessionTab(mode: 'terminal' | 'stream' = 'terminal', opts?: { pinned?: boolean; locked?: boolean }): Tab {
-  const tab = createTab({ kind: 'session', hostId: 'test-host', sessionCode: 'tst001', mode, cachedName: '', tmuxInstance: '' }, { pinned: opts?.pinned })
+  const tab = createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'tst001', mode, cachedName: '', tmuxInstance: '' }, { pinned: opts?.pinned })
   if (opts?.locked) return { ...tab, locked: true }
   return tab
 }

--- a/spa/src/components/TabContextMenu.tsx
+++ b/spa/src/components/TabContextMenu.tsx
@@ -55,8 +55,8 @@ export function TabContextMenu({ tab, position, onClose, onAction, hasOtherUnloc
   }, [onClose])
 
   const primary = getPrimaryPane(tab.layout)
-  const isSession = primary.content.kind === 'session'
-  const currentMode = isSession ? (primary.content as { kind: 'session'; mode: string }).mode : undefined
+  const isSession = primary.content.kind === 'tmux-session'
+  const currentMode = isSession ? (primary.content as { kind: 'tmux-session'; mode: string }).mode : undefined
 
   const items: (MenuItem | 'separator')[] = [
     // ViewMode section

--- a/spa/src/components/TerminalView.tsx
+++ b/spa/src/components/TerminalView.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
-import { UploadSimple } from '@phosphor-icons/react'
+import { UploadSimple, Spinner } from '@phosphor-icons/react'
 import { useTerminal } from '../hooks/useTerminal'
 import { useTerminalWs } from '../hooks/useTerminalWs'
+import { useHostConnection } from '../hooks/useHostConnection'
 import { useAgentStore } from '../stores/useAgentStore'
 import { useUploadStore } from '../stores/useUploadStore'
 import { useHostStore } from '../stores/useHostStore'
@@ -38,6 +39,12 @@ export default function TerminalView({ wsUrl, visible = true, connectingMessage,
     onDisconnect: handleDisconnect,
     onReconnect: handleReconnect,
   })
+
+  // Manual reconnect
+  const { manualRetry, status: hostStatus } = useHostConnection(hostId ?? '')
+  const [retrying, setRetrying] = useState(false)
+  const handleRetry = useCallback(() => { setRetrying(true); manualRetry() }, [manualRetry])
+  useEffect(() => { setRetrying(false) }, [hostStatus])
 
   // Drag-drop state
   const [isDragging, setIsDragging] = useState(false)
@@ -130,7 +137,7 @@ export default function TerminalView({ wsUrl, visible = true, connectingMessage,
       <div ref={containerRef} className="w-full h-full" />
       <div
         data-testid="terminal-overlay"
-        className="absolute inset-0 flex items-center justify-center pointer-events-none"
+        className={`absolute inset-0 flex flex-col items-center justify-center ${disconnected ? '' : 'pointer-events-none'}`}
         style={{
           background: disconnected ? 'color-mix(in srgb, var(--terminal-bg) 50%, transparent)' : 'var(--terminal-bg)',
           opacity: showOverlay ? 1 : 0,
@@ -140,6 +147,16 @@ export default function TerminalView({ wsUrl, visible = true, connectingMessage,
         <span className="text-text-muted text-sm" style={{ animation: 'breathing 2s ease-in-out infinite' }}>
           {disconnected ? 'reconnecting...' : (connectingMessage || 'connecting...')}
         </span>
+        {disconnected && (
+          <button
+            data-testid="reconnect-btn"
+            className="mt-4 px-4 py-2 rounded bg-zinc-700 hover:bg-zinc-600 text-sm text-text-secondary cursor-pointer disabled:opacity-50"
+            onClick={handleRetry}
+            disabled={retrying}
+          >
+            {retrying ? <Spinner size={16} className="animate-spin" /> : t('connection.reconnect')}
+          </button>
+        )}
         <style>{`@keyframes breathing { 0%, 100% { opacity: 0.3; } 50% { opacity: 1; } }`}</style>
       </div>
       {isDragging && (

--- a/spa/src/components/TerminatedPane.test.tsx
+++ b/spa/src/components/TerminatedPane.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { TerminatedPane } from './TerminatedPane'
+import { useTabStore } from '../stores/useTabStore'
+import { useHostStore } from '../stores/useHostStore'
+import { useSessionStore } from '../stores/useSessionStore'
+import type { PaneContent, Tab } from '../types/tab'
+
+vi.mock('./SessionPickerList', () => ({
+  SessionPickerList: ({ onSelect }: { onSelect: (sel: unknown) => void }) => (
+    <button
+      data-testid="session-picker"
+      onClick={() =>
+        onSelect({
+          hostId: 'new-host',
+          sessionCode: 'new001',
+          cachedName: 'new-session',
+          tmuxInstance: 'tmux:inst',
+        })
+      }
+    >
+      Mock SessionPickerList
+    </button>
+  ),
+}))
+
+const TAB_ID = 'tab-1'
+const PANE_ID = 'pane-1'
+
+function makeContent(reason: 'session-closed' | 'tmux-restarted' | 'host-removed', mode: 'terminal' | 'stream' = 'terminal'): Extract<PaneContent, { kind: 'tmux-session' }> {
+  return {
+    kind: 'tmux-session',
+    hostId: 'host-1',
+    sessionCode: 'dev001',
+    mode,
+    cachedName: 'my-session',
+    tmuxInstance: '123:456',
+    terminated: reason,
+  }
+}
+
+function setupTab(content: PaneContent) {
+  const tab: Tab = {
+    id: TAB_ID,
+    pinned: false,
+    locked: false,
+    createdAt: Date.now(),
+    layout: { type: 'leaf', pane: { id: PANE_ID, content } },
+  }
+  useTabStore.setState({
+    tabs: { [TAB_ID]: tab },
+    tabOrder: [TAB_ID],
+    activeTabId: TAB_ID,
+  })
+}
+
+beforeEach(() => {
+  cleanup()
+  useHostStore.setState({ hosts: {}, hostOrder: [], runtime: {}, activeHostId: null })
+  useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
+})
+
+describe('TerminatedPane', () => {
+  it('shows session-closed message', () => {
+    const content = makeContent('session-closed')
+    setupTab(content)
+    render(<TerminatedPane content={content} tabId={TAB_ID} paneId={PANE_ID} />)
+    expect(screen.getByText('Session closed')).toBeInTheDocument()
+    expect(screen.getByText('my-session no longer exists')).toBeInTheDocument()
+  })
+
+  it('shows tmux-restarted message', () => {
+    const content = makeContent('tmux-restarted')
+    setupTab(content)
+    render(<TerminatedPane content={content} tabId={TAB_ID} paneId={PANE_ID} />)
+    expect(screen.getByText('tmux restarted')).toBeInTheDocument()
+    expect(screen.getByText('Previous sessions are no longer valid')).toBeInTheDocument()
+  })
+
+  it('shows host-removed message', () => {
+    const content = makeContent('host-removed')
+    setupTab(content)
+    render(<TerminatedPane content={content} tabId={TAB_ID} paneId={PANE_ID} />)
+    expect(screen.getByText('Host removed')).toBeInTheDocument()
+    expect(screen.getByText('This host has been removed')).toBeInTheDocument()
+  })
+
+  it('has a close tab button that calls closeTab', () => {
+    const content = makeContent('session-closed')
+    setupTab(content)
+    render(<TerminatedPane content={content} tabId={TAB_ID} paneId={PANE_ID} />)
+
+    const closeBtn = screen.getByText('Close tab')
+    expect(closeBtn).toBeInTheDocument()
+
+    fireEvent.click(closeBtn)
+    // Tab should be closed
+    expect(useTabStore.getState().tabs[TAB_ID]).toBeUndefined()
+  })
+
+  it('session selection calls setPaneContent with correct data, preserving mode', () => {
+    const content = makeContent('session-closed', 'stream')
+    setupTab(content)
+    render(<TerminatedPane content={content} tabId={TAB_ID} paneId={PANE_ID} />)
+
+    fireEvent.click(screen.getByTestId('session-picker'))
+
+    const updatedTab = useTabStore.getState().tabs[TAB_ID]
+    expect(updatedTab).toBeDefined()
+    if (updatedTab.layout.type === 'leaf') {
+      const newContent = updatedTab.layout.pane.content
+      expect(newContent).toEqual({
+        kind: 'tmux-session',
+        hostId: 'new-host',
+        sessionCode: 'new001',
+        mode: 'stream', // preserved from original tab
+        cachedName: 'new-session',
+        tmuxInstance: 'tmux:inst',
+      })
+    }
+  })
+
+  it('session selection for terminal mode tab preserves terminal mode', () => {
+    const content = makeContent('session-closed', 'terminal')
+    setupTab(content)
+    render(<TerminatedPane content={content} tabId={TAB_ID} paneId={PANE_ID} />)
+
+    fireEvent.click(screen.getByTestId('session-picker'))
+
+    const updatedTab = useTabStore.getState().tabs[TAB_ID]
+    if (updatedTab.layout.type === 'leaf') {
+      const newContent = updatedTab.layout.pane.content
+      expect(newContent.kind).toBe('tmux-session')
+      if (newContent.kind === 'tmux-session') {
+        expect(newContent.mode).toBe('terminal')
+      }
+    }
+  })
+
+  it('renders the SessionPickerList', () => {
+    const content = makeContent('session-closed')
+    setupTab(content)
+    render(<TerminatedPane content={content} tabId={TAB_ID} paneId={PANE_ID} />)
+    expect(screen.getByTestId('session-picker')).toBeInTheDocument()
+  })
+})

--- a/spa/src/components/TerminatedPane.tsx
+++ b/spa/src/components/TerminatedPane.tsx
@@ -1,0 +1,50 @@
+import { SmileySad } from '@phosphor-icons/react'
+import { useTabStore } from '../stores/useTabStore'
+import { useI18nStore } from '../stores/useI18nStore'
+import { SessionPickerList } from './SessionPickerList'
+import type { PaneContent, TerminatedReason } from '../types/tab'
+
+interface Props {
+  content: Extract<PaneContent, { kind: 'tmux-session' }>
+  tabId: string
+  paneId: string
+}
+
+const REASON_KEYS: Record<TerminatedReason, { title: string; desc: string }> = {
+  'session-closed': { title: 'terminated.session_closed', desc: 'terminated.session_closed_desc' },
+  'tmux-restarted': { title: 'terminated.tmux_restarted', desc: 'terminated.tmux_restarted_desc' },
+  'host-removed': { title: 'terminated.host_removed', desc: 'terminated.host_removed_desc' },
+}
+
+export function TerminatedPane({ content, tabId, paneId }: Props) {
+  const t = useI18nStore((s) => s.t)
+  const closeTab = useTabStore((s) => s.closeTab)
+  const setPaneContent = useTabStore((s) => s.setPaneContent)
+  const reason = content.terminated!
+  const keys = REASON_KEYS[reason]
+
+  const handleSelect = (sel: { hostId: string; sessionCode: string; cachedName: string; tmuxInstance: string }) => {
+    setPaneContent(tabId, paneId, {
+      kind: 'tmux-session',
+      hostId: sel.hostId,
+      sessionCode: sel.sessionCode,
+      mode: content.mode,
+      cachedName: sel.cachedName,
+      tmuxInstance: sel.tmuxInstance,
+    })
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+      <SmileySad size={48} className="text-zinc-500 mb-4" />
+      <h2 className="text-lg font-medium text-zinc-300 mb-1">{t(keys.title)}</h2>
+      <p className="text-sm text-zinc-500 mb-6">{t(keys.desc, { name: content.cachedName })}</p>
+      <button className="text-sm text-zinc-400 hover:text-zinc-200 mb-8" onClick={() => closeTab(tabId)}>
+        {t('terminated.close_tab')}
+      </button>
+      <div className="w-full max-w-sm">
+        <SessionPickerList onSelect={handleSelect} />
+      </div>
+    </div>
+  )
+}

--- a/spa/src/components/hosts/AddHostDialog.tsx
+++ b/spa/src/components/hosts/AddHostDialog.tsx
@@ -77,7 +77,13 @@ export function AddHostDialog({ onClose }: Props) {
       }
     } catch (err) {
       setStage('error')
-      setError(err instanceof Error ? err.message : 'Connection failed')
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        setError(t('hosts.error_unreachable'))
+      } else if (err instanceof TypeError) {
+        setError(t('hosts.error_refused'))
+      } else {
+        setError(err instanceof Error ? err.message : t('hosts.connection_failed'))
+      }
     }
   }
 

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -1,4 +1,4 @@
-import { Plus, CaretDown, CaretRight, Circle, Spinner } from '@phosphor-icons/react'
+import { Plus, CaretDown, CaretRight, Circle, Spinner, Warning } from '@phosphor-icons/react'
 import { useState } from 'react'
 import { useHostStore, type HostRuntime } from '../../stores/useHostStore'
 import { useI18nStore } from '../../stores/useI18nStore'
@@ -19,15 +19,11 @@ interface Props {
 }
 
 function StatusIcon({ runtime }: { runtime?: HostRuntime }) {
-  if (!runtime) {
-    return <Circle size={8} weight="fill" className="text-text-muted" />
-  }
-  if (runtime.status === 'connected') {
-    return <Circle size={8} weight="fill" className="text-green-400" />
-  }
-  if (runtime.status === 'reconnecting') {
-    return <Spinner size={10} className="text-yellow-400 animate-spin" />
-  }
+  if (!runtime) return <Circle size={8} weight="fill" className="text-text-muted" />
+  if (runtime.status === 'connected' && runtime.tmuxState === 'unavailable')
+    return <Warning size={12} weight="fill" className="text-yellow-400" />
+  if (runtime.status === 'connected') return <Circle size={8} weight="fill" className="text-green-400" />
+  if (runtime.status === 'reconnecting') return <Spinner size={10} className="text-yellow-400 animate-spin" />
   return <Circle size={8} weight="fill" className="text-red-400" />
 }
 

--- a/spa/src/components/hosts/OverviewSection.tsx
+++ b/spa/src/components/hosts/OverviewSection.tsx
@@ -1,12 +1,24 @@
 import { useEffect, useRef, useState } from 'react'
 import { CaretDown, CaretRight, ArrowsClockwise, Trash, Plugs, Eye, EyeSlash, Check, X } from '@phosphor-icons/react'
-import { useHostStore, type HostInfo, type HostRuntime } from '../../stores/useHostStore'
+import { useHostStore, type HostConfig, type HostInfo, type HostRuntime } from '../../stores/useHostStore'
+import { useSessionStore } from '../../stores/useSessionStore'
+import { useTabStore } from '../../stores/useTabStore'
+import { useAgentStore } from '../../stores/useAgentStore'
+import { useStreamStore } from '../../stores/useStreamStore'
 import { useI18nStore } from '../../stores/useI18nStore'
 import { hostFetch, fetchInfo, fetchHealth } from '../../lib/host-api'
+import { getPrimaryPane } from '../../lib/pane-tree'
 import type { ConfigData } from '../../lib/api'
+import type { Session } from '../../lib/api'
+
+export interface UndoToastInfo {
+  name: string
+  restore: () => void
+}
 
 interface Props {
   hostId: string
+  onShowUndoToast?: (info: UndoToastInfo) => void
 }
 
 /* ─── Collapsible section wrapper ─── */
@@ -224,12 +236,11 @@ function connectionErrorMessage(runtime: HostRuntime | undefined, t: (key: strin
 
 /* ─── Main component ─── */
 
-export function OverviewSection({ hostId }: Props) {
+export function OverviewSection({ hostId, onShowUndoToast }: Props) {
   const t = useI18nStore((s) => s.t)
   const host = useHostStore((s) => s.hosts[hostId])
   const runtime = useHostStore((s) => s.runtime[hostId])
   const updateHost = useHostStore((s) => s.updateHost)
-  const removeHost = useHostStore((s) => s.removeHost)
   const hostOrder = useHostStore((s) => s.hostOrder)
 
   const [info, setInfo] = useState<HostInfo | null>(null)
@@ -237,6 +248,7 @@ export function OverviewSection({ hostId }: Props) {
   const [testResult, setTestResult] = useState<{ ok: boolean; latency?: number; error?: string } | null>(null)
   const [testing, setTesting] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [closeTabs, setCloseTabs] = useState(true)
 
   // Fetch info + config on mount or hostId change
   useEffect(() => {
@@ -276,7 +288,62 @@ export function OverviewSection({ hostId }: Props) {
   }
 
   const handleDeleteHost = () => {
-    removeHost(hostId)
+    const hostStore = useHostStore.getState()
+    const tabStore = useTabStore.getState()
+    const sessionStore = useSessionStore.getState()
+
+    const hostName = hostStore.hosts[hostId]?.name ?? hostId
+
+    // Snapshot for undo (serializable data only)
+    const snapshot: {
+      host: HostConfig | undefined
+      hostOrder: string[]
+      sessions: Session[] | undefined
+      activeHostId: string | null
+    } = {
+      host: hostStore.hosts[hostId],
+      hostOrder: [...hostStore.hostOrder],
+      sessions: sessionStore.sessions[hostId],
+      activeHostId: hostStore.activeHostId,
+    }
+
+    // Execute cascade: tabs -> sessions -> agent -> stream -> host
+    if (closeTabs) {
+      // Close all tmux-session tabs for this host
+      for (const [tabId, tab] of Object.entries(tabStore.tabs)) {
+        const primary = getPrimaryPane(tab.layout)
+        if (primary.content.kind === 'tmux-session' && primary.content.hostId === hostId) {
+          tabStore.closeTab(tabId)
+        }
+      }
+    } else {
+      // Mark all tmux-session tabs as terminated
+      tabStore.markHostTerminated(hostId, 'host-removed')
+    }
+
+    sessionStore.removeHost(hostId)
+    useAgentStore.getState().removeHost(hostId)
+    useStreamStore.getState().clearHost(hostId)
+    hostStore.removeHost(hostId)
+
+    setConfirmDelete(false)
+
+    // Show undo toast via parent
+    onShowUndoToast?.({
+      name: hostName,
+      restore: () => {
+        if (snapshot.host) {
+          useHostStore.getState().addHost(snapshot.host)
+          // Restore activeHostId if it was this host
+          if (snapshot.activeHostId === hostId) {
+            useHostStore.getState().setActiveHost(hostId)
+          }
+        }
+        if (snapshot.sessions) {
+          useSessionStore.getState().replaceHost(hostId, snapshot.sessions)
+        }
+      },
+    })
   }
 
   const statusLabel = (r?: HostRuntime) => {
@@ -374,6 +441,15 @@ export function OverviewSection({ hostId }: Props) {
         {confirmDelete && (
           <div className="mt-3 p-3 bg-red-500/10 border border-red-500/30 rounded">
             <p className="text-xs text-red-400 mb-2">{t('hosts.confirm_delete')}</p>
+            <label className="flex items-center gap-2 text-xs text-zinc-400 mb-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={closeTabs}
+                onChange={(e) => setCloseTabs(e.target.checked)}
+                className="rounded"
+              />
+              {t('hosts.confirm_delete_tabs')}
+            </label>
             <div className="flex gap-2">
               <button
                 onClick={handleDeleteHost}

--- a/spa/src/components/hosts/OverviewSection.tsx
+++ b/spa/src/components/hosts/OverviewSection.tsx
@@ -3,22 +3,19 @@ import { CaretDown, CaretRight, ArrowsClockwise, Trash, Plugs, Eye, EyeSlash, Ch
 import { useHostStore, type HostConfig, type HostInfo, type HostRuntime } from '../../stores/useHostStore'
 import { useSessionStore } from '../../stores/useSessionStore'
 import { useTabStore } from '../../stores/useTabStore'
-import { useAgentStore } from '../../stores/useAgentStore'
-import { useStreamStore } from '../../stores/useStreamStore'
+import { useAgentStore, type AgentHookEvent, type AgentStatus } from '../../stores/useAgentStore'
+import { useStreamStore, type PerSessionState } from '../../stores/useStreamStore'
 import { useI18nStore } from '../../stores/useI18nStore'
+import { useUndoToast } from '../../stores/useUndoToast'
 import { hostFetch, fetchInfo, fetchHealth } from '../../lib/host-api'
-import { getPrimaryPane } from '../../lib/pane-tree'
+import { scanPaneTree } from '../../lib/pane-tree'
+import { connectionErrorMessage } from '../../lib/host-utils'
 import type { ConfigData } from '../../lib/api'
 import type { Session } from '../../lib/api'
-
-export interface UndoToastInfo {
-  name: string
-  restore: () => void
-}
+import type { Tab } from '../../types/tab'
 
 interface Props {
   hostId: string
-  onShowUndoToast?: (info: UndoToastInfo) => void
 }
 
 /* ─── Collapsible section wrapper ─── */
@@ -229,21 +226,9 @@ function TokenField({ token, ip, port, onSave, t }: {
   )
 }
 
-/* ─── Connection error message ─── */
-
-function connectionErrorMessage(runtime: HostRuntime | undefined, t: (key: string) => string): string | null {
-  if (!runtime || runtime.status !== 'connected') {
-    if (runtime?.daemonState === 'unreachable') return t('hosts.error_unreachable')
-    if (runtime?.daemonState === 'refused') return t('hosts.error_refused')
-    return null
-  }
-  if (runtime.tmuxState === 'unavailable') return t('hosts.error_tmux_down')
-  return null
-}
-
 /* ─── Main component ─── */
 
-export function OverviewSection({ hostId, onShowUndoToast }: Props) {
+export function OverviewSection({ hostId }: Props) {
   const t = useI18nStore((s) => s.t)
   const host = useHostStore((s) => s.hosts[hostId])
   const runtime = useHostStore((s) => s.runtime[hostId])
@@ -298,59 +283,169 @@ export function OverviewSection({ hostId, onShowUndoToast }: Props) {
     const hostStore = useHostStore.getState()
     const tabStore = useTabStore.getState()
     const sessionStore = useSessionStore.getState()
+    const agentStore = useAgentStore.getState()
+    const streamStore = useStreamStore.getState()
 
     const hostName = hostStore.hosts[hostId]?.name ?? hostId
+    const prefix = `${hostId}:`
 
-    // Snapshot for undo (serializable data only)
+    // --- Snapshot for undo (serializable data only) ---
     const snapshot: {
       host: HostConfig | undefined
       hostOrder: string[]
       sessions: Session[] | undefined
       activeHostId: string | null
+      // AgentStore data (exclude transient activeSubagents)
+      agentEvents: Record<string, AgentHookEvent>
+      agentStatuses: Record<string, AgentStatus>
+      agentUnread: Record<string, boolean>
+      // StreamStore data (exclude non-serializable conn)
+      streamSessions: Record<string, Omit<PerSessionState, 'conn'>>
+      // Tab data for undo
+      closedTabs: Tab[]
+      terminatedTabPaneIds: { tabId: string; paneId: string }[]
     } = {
       host: hostStore.hosts[hostId],
       hostOrder: [...hostStore.hostOrder],
       sessions: sessionStore.sessions[hostId],
       activeHostId: hostStore.activeHostId,
+      agentEvents: {},
+      agentStatuses: {},
+      agentUnread: {},
+      streamSessions: {},
+      closedTabs: [],
+      terminatedTabPaneIds: [],
+    }
+
+    // Snapshot AgentStore entries for this host
+    for (const [k, v] of Object.entries(agentStore.events)) {
+      if (k.startsWith(prefix)) snapshot.agentEvents[k] = v
+    }
+    for (const [k, v] of Object.entries(agentStore.statuses)) {
+      if (k.startsWith(prefix)) snapshot.agentStatuses[k] = v
+    }
+    for (const [k, v] of Object.entries(agentStore.unread)) {
+      if (k.startsWith(prefix)) snapshot.agentUnread[k] = v
+    }
+
+    // Snapshot StreamStore entries for this host (exclude conn)
+    for (const [k, v] of Object.entries(streamStore.sessions)) {
+      if (k.startsWith(prefix)) {
+        const { conn: _, ...serializable } = v // eslint-disable-line @typescript-eslint/no-unused-vars
+        snapshot.streamSessions[k] = serializable
+      }
     }
 
     // Execute cascade: tabs -> sessions -> agent -> stream -> host
     if (closeTabs) {
-      // Close all tmux-session tabs for this host
+      // Close all tmux-session tabs for this host (scan ALL panes, not just primary)
       for (const [tabId, tab] of Object.entries(tabStore.tabs)) {
-        const primary = getPrimaryPane(tab.layout)
-        if (primary.content.kind === 'tmux-session' && primary.content.hostId === hostId) {
+        let hasHostPane = false
+        scanPaneTree(tab.layout, (pane) => {
+          if (pane.content.kind === 'tmux-session' && pane.content.hostId === hostId) {
+            hasHostPane = true
+          }
+        })
+        if (hasHostPane) {
+          snapshot.closedTabs.push(tab)
           tabStore.closeTab(tabId)
         }
       }
     } else {
+      // Track which panes will be marked terminated (for undo)
+      for (const [tabId, tab] of Object.entries(tabStore.tabs)) {
+        scanPaneTree(tab.layout, (pane) => {
+          if (pane.content.kind === 'tmux-session' && pane.content.hostId === hostId && !pane.content.terminated) {
+            snapshot.terminatedTabPaneIds.push({ tabId, paneId: pane.id })
+          }
+        })
+      }
       // Mark all tmux-session tabs as terminated
       tabStore.markHostTerminated(hostId, 'host-removed')
     }
 
     sessionStore.removeHost(hostId)
-    useAgentStore.getState().removeHost(hostId)
-    useStreamStore.getState().clearHost(hostId)
+    agentStore.removeHost(hostId)
+    streamStore.clearHost(hostId)
     hostStore.removeHost(hostId)
 
     setConfirmDelete(false)
 
-    // Show undo toast via parent
-    onShowUndoToast?.({
-      name: hostName,
-      restore: () => {
+    // Show undo toast via global store
+    useUndoToast.getState().show(
+      t('hosts.deleted_toast', { name: hostName }),
+      () => {
+        // --- Restore host + hostOrder position ---
         if (snapshot.host) {
           useHostStore.getState().addHost(snapshot.host)
-          // Restore activeHostId if it was this host
+          // Restore original hostOrder position
+          useHostStore.getState().reorderHosts(snapshot.hostOrder)
           if (snapshot.activeHostId === hostId) {
             useHostStore.getState().setActiveHost(hostId)
           }
         }
+
+        // --- Restore sessions ---
         if (snapshot.sessions) {
           useSessionStore.getState().replaceHost(hostId, snapshot.sessions)
         }
+
+        // --- Restore AgentStore data ---
+        const ag = useAgentStore.getState()
+        if (Object.keys(snapshot.agentEvents).length > 0) {
+          useAgentStore.setState({
+            events: { ...ag.events, ...snapshot.agentEvents },
+            statuses: { ...ag.statuses, ...snapshot.agentStatuses },
+            unread: { ...ag.unread, ...snapshot.agentUnread },
+          })
+        }
+
+        // --- Restore StreamStore data (conn set to null) ---
+        if (Object.keys(snapshot.streamSessions).length > 0) {
+          const st = useStreamStore.getState()
+          const restored: Record<string, PerSessionState> = {}
+          for (const [k, v] of Object.entries(snapshot.streamSessions)) {
+            restored[k] = { ...v, conn: null }
+          }
+          useStreamStore.setState({
+            sessions: { ...st.sessions, ...restored },
+          })
+        }
+
+        // --- Restore tabs ---
+        if (closeTabs && snapshot.closedTabs.length > 0) {
+          const ts = useTabStore.getState()
+          for (const tab of snapshot.closedTabs) {
+            // Only restore if tab wasn't re-created by user during undo window
+            if (!ts.tabs[tab.id]) {
+              useTabStore.getState().addTab(tab)
+            }
+          }
+        } else if (!closeTabs && snapshot.terminatedTabPaneIds.length > 0) {
+          // Clear terminated marking on panes that were marked by this delete
+          for (const { tabId, paneId } of snapshot.terminatedTabPaneIds) {
+            const currentTab = useTabStore.getState().tabs[tabId]
+            if (!currentTab) continue
+            // Find the pane and clear its terminated field
+            let found = false
+            scanPaneTree(currentTab.layout, (pane) => {
+              if (pane.id === paneId && pane.content.kind === 'tmux-session' && pane.content.terminated === 'host-removed') {
+                found = true
+              }
+            })
+            if (found) {
+              // Re-read to get current content and remove terminated
+              scanPaneTree(useTabStore.getState().tabs[tabId].layout, (pane) => {
+                if (pane.id === paneId && pane.content.kind === 'tmux-session' && pane.content.terminated === 'host-removed') {
+                  const { terminated: _, ...contentWithoutTerminated } = pane.content // eslint-disable-line @typescript-eslint/no-unused-vars
+                  useTabStore.getState().setPaneContent(tabId, paneId, contentWithoutTerminated as typeof pane.content)
+                }
+              })
+            }
+          }
+        }
       },
-    })
+    )
   }
 
   const statusLabel = (r?: HostRuntime) => {
@@ -411,11 +506,14 @@ export function OverviewSection({ hostId, onShowUndoToast }: Props) {
             {runtime?.latency != null && ` (${runtime.latency}ms)`}
           </span>
         </Field>
-        {connectionErrorMessage(runtime, t) && (
-          <div className="text-xs text-red-400 px-1 py-1">
-            {connectionErrorMessage(runtime, t)}
-          </div>
-        )}
+        {(() => {
+          const errorMsg = connectionErrorMessage(runtime, t)
+          return errorMsg && (
+            <div className="text-xs text-red-400 px-1 py-1">
+              {errorMsg}
+            </div>
+          )
+        })()}
 
         <div className="flex gap-2 mt-3">
           <button

--- a/spa/src/components/hosts/OverviewSection.tsx
+++ b/spa/src/components/hosts/OverviewSection.tsx
@@ -210,6 +210,18 @@ function TokenField({ token, ip, port, onSave, t }: {
   )
 }
 
+/* ─── Connection error message ─── */
+
+function connectionErrorMessage(runtime: HostRuntime | undefined, t: (key: string) => string): string | null {
+  if (!runtime || runtime.status !== 'connected') {
+    if (runtime?.daemonState === 'unreachable') return t('hosts.error_unreachable')
+    if (runtime?.daemonState === 'refused') return t('hosts.error_refused')
+    return null
+  }
+  if (runtime.tmuxState === 'unavailable') return t('hosts.error_tmux_down')
+  return null
+}
+
 /* ─── Main component ─── */
 
 export function OverviewSection({ hostId }: Props) {
@@ -316,7 +328,8 @@ export function OverviewSection({ hostId }: Props) {
         />
         <Field label={t('hosts.status')}>
           <span className={`text-sm ${
-            runtime?.status === 'connected' ? 'text-green-400'
+            runtime?.status === 'connected' && runtime?.tmuxState === 'unavailable' ? 'text-yellow-400'
+              : runtime?.status === 'connected' ? 'text-green-400'
               : runtime?.status === 'reconnecting' ? 'text-yellow-400'
               : 'text-red-400'
           }`}>
@@ -324,6 +337,11 @@ export function OverviewSection({ hostId }: Props) {
             {runtime?.latency != null && ` (${runtime.latency}ms)`}
           </span>
         </Field>
+        {connectionErrorMessage(runtime, t) && (
+          <div className="text-xs text-red-400 px-1 py-1">
+            {connectionErrorMessage(runtime, t)}
+          </div>
+        )}
 
         <div className="flex gap-2 mt-3">
           <button

--- a/spa/src/components/hosts/OverviewSection.tsx
+++ b/spa/src/components/hosts/OverviewSection.tsx
@@ -118,6 +118,13 @@ function TokenField({ token, ip, port, onSave, t }: {
       setEditing(false)
       return
     }
+    // Empty token: skip validation, just save
+    if (!draft.trim()) {
+      setError('')
+      onSave(draft)
+      setEditing(false)
+      return
+    }
     // Validate token by testing /api/sessions with it
     setValidating(true)
     setError('')

--- a/spa/src/components/hosts/SessionsSection.test.tsx
+++ b/spa/src/components/hosts/SessionsSection.test.tsx
@@ -109,7 +109,7 @@ describe('SessionsSection', () => {
     const openBtn = screen.getByTitle('Open')
     fireEvent.click(openBtn)
     expect(mockOpenSingletonTab).toHaveBeenCalledWith({
-      kind: 'session',
+      kind: 'tmux-session',
       hostId: HOST_ID,
       sessionCode: 'abc',
       mode: 'terminal',

--- a/spa/src/components/hosts/SessionsSection.tsx
+++ b/spa/src/components/hosts/SessionsSection.tsx
@@ -138,7 +138,7 @@ export function SessionsSection({ hostId }: Props) {
 
   const handleOpen = (session: Session, mode: string) => {
     const tabId = useTabStore.getState().openSingletonTab({
-      kind: 'session',
+      kind: 'tmux-session',
       hostId,
       sessionCode: session.code,
       mode: mode as 'terminal' | 'stream',

--- a/spa/src/components/hosts/SessionsSection.tsx
+++ b/spa/src/components/hosts/SessionsSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Plus, Play, Trash, PencilSimple, Check, X } from '@phosphor-icons/react'
 import { useSessionStore } from '../../stores/useSessionStore'
-import { useHostStore } from '../../stores/useHostStore'
+import { useHostStore, type HostRuntime } from '../../stores/useHostStore'
 import { useTabStore } from '../../stores/useTabStore'
 import { useWorkspaceStore } from '../../stores/useWorkspaceStore'
 import { useI18nStore } from '../../stores/useI18nStore'
@@ -124,13 +124,25 @@ function InlineRename({ hostId, session, onDone }: { hostId: string; session: Se
   )
 }
 
+/* ─── Connection error message ─── */
+
+function connectionErrorMessage(runtime: HostRuntime | undefined, t: (key: string) => string): string | null {
+  if (!runtime || runtime.status !== 'connected') {
+    if (runtime?.daemonState === 'unreachable') return t('hosts.error_unreachable')
+    if (runtime?.daemonState === 'refused') return t('hosts.error_refused')
+    return null
+  }
+  if (runtime.tmuxState === 'unavailable') return t('hosts.error_tmux_down')
+  return null
+}
+
 /* ─── Main component ─── */
 
 export function SessionsSection({ hostId }: Props) {
   const t = useI18nStore((s) => s.t)
   const sessions = useSessionStore((s) => s.sessions[hostId] ?? [])
   const runtime = useHostStore((s) => s.runtime[hostId])
-  const isOffline = runtime != null && runtime.status !== 'connected'
+  const isOffline = !runtime || runtime.status !== 'connected' || runtime.tmuxState === 'unavailable'
   const [showNew, setShowNew] = useState(false)
   const [renamingCode, setRenamingCode] = useState<string | null>(null)
   const [deletingCode, setDeletingCode] = useState<string | null>(null)
@@ -175,6 +187,12 @@ export function SessionsSection({ hostId }: Props) {
       </div>
 
       {showNew && <NewSessionDialog hostId={hostId} onClose={() => setShowNew(false)} />}
+
+      {isOffline && connectionErrorMessage(runtime, t) && (
+        <div className="text-xs text-red-400 px-3 py-2 mb-2">
+          {connectionErrorMessage(runtime, t)}
+        </div>
+      )}
 
       {sessions.length === 0 ? (
         <p className="text-sm text-text-muted">{t('hosts.no_sessions')}</p>

--- a/spa/src/components/hosts/SessionsSection.tsx
+++ b/spa/src/components/hosts/SessionsSection.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react'
 import { Plus, Play, Trash, PencilSimple, Check, X } from '@phosphor-icons/react'
 import { useSessionStore } from '../../stores/useSessionStore'
-import { useHostStore, type HostRuntime } from '../../stores/useHostStore'
+import { useHostStore } from '../../stores/useHostStore'
 import { useTabStore } from '../../stores/useTabStore'
 import { useWorkspaceStore } from '../../stores/useWorkspaceStore'
 import { useI18nStore } from '../../stores/useI18nStore'
 import { useAgentStore } from '../../stores/useAgentStore'
 import { hostFetch, renameSession } from '../../lib/host-api'
 import { compositeKey } from '../../lib/composite-key'
+import { connectionErrorMessage } from '../../lib/host-utils'
 import type { Session } from '../../lib/api'
 
 interface Props {
@@ -124,18 +125,6 @@ function InlineRename({ hostId, session, onDone }: { hostId: string; session: Se
   )
 }
 
-/* ─── Connection error message ─── */
-
-function connectionErrorMessage(runtime: HostRuntime | undefined, t: (key: string) => string): string | null {
-  if (!runtime || runtime.status !== 'connected') {
-    if (runtime?.daemonState === 'unreachable') return t('hosts.error_unreachable')
-    if (runtime?.daemonState === 'refused') return t('hosts.error_refused')
-    return null
-  }
-  if (runtime.tmuxState === 'unavailable') return t('hosts.error_tmux_down')
-  return null
-}
-
 /* ─── Main component ─── */
 
 export function SessionsSection({ hostId }: Props) {
@@ -188,11 +177,14 @@ export function SessionsSection({ hostId }: Props) {
 
       {showNew && <NewSessionDialog hostId={hostId} onClose={() => setShowNew(false)} />}
 
-      {isOffline && connectionErrorMessage(runtime, t) && (
-        <div className="text-xs text-red-400 px-3 py-2 mb-2">
-          {connectionErrorMessage(runtime, t)}
-        </div>
-      )}
+      {(() => {
+        const errorMsg = isOffline ? connectionErrorMessage(runtime, t) : null
+        return errorMsg && (
+          <div className="text-xs text-red-400 px-3 py-2 mb-2">
+            {errorMsg}
+          </div>
+        )
+      })()}
 
       {sessions.length === 0 ? (
         <p className="text-sm text-text-muted">{t('hosts.no_sessions')}</p>

--- a/spa/src/hooks/useHostConnection.ts
+++ b/spa/src/hooks/useHostConnection.ts
@@ -1,0 +1,15 @@
+// spa/src/hooks/useHostConnection.ts — Convenience hook for host connection state + manual retry
+import { useHostStore } from '../stores/useHostStore'
+
+const noop = () => {}
+
+export function useHostConnection(hostId: string) {
+  const runtime = useHostStore((s) => s.runtime[hostId])
+  return {
+    status: runtime?.status ?? 'disconnected',
+    daemonState: runtime?.daemonState,
+    tmuxState: runtime?.tmuxState,
+    latency: runtime?.latency,
+    manualRetry: runtime?.manualRetry ?? noop,
+  }
+}

--- a/spa/src/hooks/useMultiHostEventWs.ts
+++ b/spa/src/hooks/useMultiHostEventWs.ts
@@ -45,6 +45,7 @@ export function useMultiHostEventWs() {
         },
       )
       stateMachines.set(hostId, sm)
+      useHostStore.getState().setRuntime(hostId, { manualRetry: () => sm.trigger() })
 
       // --- WS connection (per host) ---
       const conn = connectHostEvents(

--- a/spa/src/hooks/useMultiHostEventWs.ts
+++ b/spa/src/hooks/useMultiHostEventWs.ts
@@ -6,6 +6,7 @@ import { useStreamStore } from '../stores/useStreamStore'
 import { useAgentStore } from '../stores/useAgentStore'
 import { useTabStore } from '../stores/useTabStore'
 import { connectHostEvents, type EventConnection } from '../lib/host-events'
+import { scanPaneTree } from '../lib/pane-tree'
 import { hostWsUrl, fetchWsTicket } from '../lib/host-api'
 import { fetchHistory } from '../lib/api'
 import { checkHealth } from '../lib/host-connection'
@@ -55,6 +56,22 @@ export function useMultiHostEventWs() {
               useSessionStore.getState().replaceHost(hostId, data)
               for (const s of data) {
                 useTabStore.getState().updateSessionCache(hostId, s.code, s.name)
+              }
+
+              // session-closed detection: collect unique closed codes, then mark once each
+              const newCodes = new Set(data.map((s: Session) => s.code))
+              const closedCodes = new Set<string>()
+              const { tabs } = useTabStore.getState()
+              for (const tab of Object.values(tabs)) {
+                scanPaneTree(tab.layout, (pane) => {
+                  const c = pane.content
+                  if (c.kind === 'tmux-session' && c.hostId === hostId && !c.terminated && !newCodes.has(c.sessionCode)) {
+                    closedCodes.add(c.sessionCode)
+                  }
+                })
+              }
+              for (const code of closedCodes) {
+                useTabStore.getState().markTerminated(hostId, code, 'session-closed')
               }
             } catch { /* ignore */ }
             return

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -150,7 +150,7 @@ function handleNotificationClick(sessionCode: string): void {
     const tab = tabs[tabId]
     if (tab) {
       const primary = getPrimaryPane(tab.layout)
-      if (primary.content.kind === 'session') {
+      if (primary.content.kind === 'tmux-session') {
         hostId = primary.content.hostId
       }
     }
@@ -166,7 +166,7 @@ function handleNotificationClick(sessionCode: string): void {
     handled = true
   } else if (agentSettings.reopenTabOnClick) {
     const sessionName = useSessionStore.getState().sessions[hostId]?.find(s => s.code === sessionCode)?.name ?? ''
-    const newTab = createTab({ kind: 'session', hostId, sessionCode, mode: 'stream', cachedName: sessionName, tmuxInstance: '' })
+    const newTab = createTab({ kind: 'tmux-session', hostId, sessionCode, mode: 'stream', cachedName: sessionName, tmuxInstance: '' })
     useTabStore.getState().addTab(newTab)
     useTabStore.getState().setActiveTab(newTab.id)
     const activeWorkspaceId = useWorkspaceStore.getState().activeWorkspaceId

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -125,6 +125,7 @@ export function useNotificationDispatcher(): void {
             sessionCode,
             eventName: event.event_name,
             broadcastTs: event.broadcast_ts,
+            action: { kind: 'open-session', hostId, sessionCode },
           })
         } else if ('Notification' in window && Notification.permission === 'granted') {
           const n = new Notification(content.title, { body: content.body })
@@ -139,6 +140,20 @@ export function useNotificationDispatcher(): void {
   useEffect(() => {
     if (!window.electronAPI?.onNotificationClicked) return
     return window.electronAPI.onNotificationClicked((payload) => {
+      // If the payload carries an explicit action, use it directly
+      if (payload.action) {
+        if (payload.action.kind === 'open-host') {
+          handleNotificationClick({ kind: 'open-host', hostId: payload.action.hostId })
+        } else {
+          handleNotificationClick({
+            kind: 'open-session',
+            hostId: payload.action.hostId,
+            sessionCode: payload.action.sessionCode ?? payload.sessionCode,
+          })
+        }
+        return
+      }
+      // Backwards compat: no action field — fall back to open-session
       const tabs = useTabStore.getState().tabs
       const tabId = findTabBySessionCode(tabs, payload.sessionCode)
       let hostId = useHostStore.getState().hostOrder[0] ?? ''
@@ -240,6 +255,9 @@ function sendConnectionNotification(message: string, action: NotificationAction)
       sessionCode: '',
       eventName: 'ConnectionStatus',
       broadcastTs: Date.now(),
+      action: action.kind === 'open-host'
+        ? { kind: 'open-host', hostId: action.hostId }
+        : { kind: 'open-session', hostId: action.hostId, sessionCode: action.sessionCode },
     })
   } else if ('Notification' in window && Notification.permission === 'granted') {
     const n = new Notification(message)

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -15,6 +15,10 @@ import { useHostStore } from '../stores/useHostStore'
 import { createTab } from '../types/tab'
 import { STORAGE_KEYS } from '../lib/storage'
 
+export type NotificationAction =
+  | { kind: 'open-session'; hostId: string; sessionCode: string }
+  | { kind: 'open-host'; hostId: string }
+
 /** Check if a notification should be dispatched based on broadcast_ts dedup.
  *  New sessions default to Infinity (sentinel), so their first event is recorded
  *  but not dispatched — prevents snapshot flooding on new/restarted clients. */
@@ -124,7 +128,7 @@ export function useNotificationDispatcher(): void {
           })
         } else if ('Notification' in window && Notification.permission === 'granted') {
           const n = new Notification(content.title, { body: content.body })
-          n.onclick = () => handleNotificationClick(sessionCode)
+          n.onclick = () => handleNotificationClick({ kind: 'open-session', hostId, sessionCode })
         }
       }
     })
@@ -135,55 +139,110 @@ export function useNotificationDispatcher(): void {
   useEffect(() => {
     if (!window.electronAPI?.onNotificationClicked) return
     return window.electronAPI.onNotificationClicked((payload) => {
-      handleNotificationClick(payload.sessionCode)
+      const tabs = useTabStore.getState().tabs
+      const tabId = findTabBySessionCode(tabs, payload.sessionCode)
+      let hostId = useHostStore.getState().hostOrder[0] ?? ''
+      if (tabId) {
+        const tab = tabs[tabId]
+        const primary = getPrimaryPane(tab.layout)
+        if (primary.content.kind === 'tmux-session') hostId = primary.content.hostId
+      }
+      handleNotificationClick({ kind: 'open-session', hostId, sessionCode: payload.sessionCode })
     })
+  }, [])
+
+  // L2/L3 connection notifications (daemon refused, tmux down)
+  useEffect(() => {
+    const prevState: Record<string, { daemon?: string; tmux?: string }> = {}
+
+    const unsubscribe = useHostStore.subscribe((state) => {
+      const t = useI18nStore.getState().t
+
+      for (const hostId of state.hostOrder) {
+        const rt = state.runtime[hostId]
+        const prev = prevState[hostId]
+        const hostName = state.hosts[hostId]?.name ?? hostId
+
+        // L2: daemon refused (was connected, now refused)
+        if (prev?.daemon === 'connected' && rt?.daemonState === 'refused') {
+          sendConnectionNotification(
+            t('notification.daemon_refused', { name: hostName }),
+            { kind: 'open-host', hostId },
+          )
+        }
+        // L3: tmux down (was ok, now unavailable)
+        if (prev?.tmux === 'ok' && rt?.tmuxState === 'unavailable') {
+          sendConnectionNotification(
+            t('notification.tmux_down', { name: hostName }),
+            { kind: 'open-host', hostId },
+          )
+        }
+
+        prevState[hostId] = { daemon: rt?.daemonState, tmux: rt?.tmuxState }
+      }
+    })
+    return unsubscribe
   }, [])
 }
 
-function handleNotificationClick(sessionCode: string): void {
-  const tabs = useTabStore.getState().tabs
-  const tabId = findTabBySessionCode(tabs, sessionCode)
+function handleNotificationClick(action: NotificationAction): void {
+  switch (action.kind) {
+    case 'open-session': {
+      const { hostId, sessionCode } = action
+      const tabs = useTabStore.getState().tabs
+      const tabId = findTabBySessionCode(tabs, sessionCode)
+      const ck = `${hostId}:${sessionCode}`
+      const event = useAgentStore.getState().events[ck]
+      const agentSettings = useNotificationSettingsStore.getState().getSettingsForAgent(event?.agent_type || '')
 
-  // Resolve hostId: try to find from the tab's pane content, fallback to first host
-  let hostId = useHostStore.getState().hostOrder[0] ?? ''
-  if (tabId) {
-    const tab = tabs[tabId]
-    if (tab) {
-      const primary = getPrimaryPane(tab.layout)
-      if (primary.content.kind === 'tmux-session') {
-        hostId = primary.content.hostId
+      let handled = false
+      if (tabId) {
+        useTabStore.getState().setActiveTab(tabId)
+        handled = true
+      } else if (agentSettings.reopenTabOnClick) {
+        const sessionName = useSessionStore.getState().sessions[hostId]?.find(s => s.code === sessionCode)?.name ?? ''
+        const newTab = createTab({ kind: 'tmux-session', hostId, sessionCode, mode: 'stream', cachedName: sessionName, tmuxInstance: '' })
+        useTabStore.getState().addTab(newTab)
+        useTabStore.getState().setActiveTab(newTab.id)
+        const activeWorkspaceId = useWorkspaceStore.getState().activeWorkspaceId
+        if (activeWorkspaceId) {
+          useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, newTab.id)
+          useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, newTab.id)
+        }
+        handled = true
       }
+
+      if (handled) {
+        useAgentStore.getState().markRead(hostId, sessionCode)
+      }
+      if (handled && window.electronAPI?.focusMyWindow) {
+        window.electronAPI.focusMyWindow()
+      }
+      break
+    }
+    case 'open-host': {
+      useTabStore.getState().openSingletonTab({ kind: 'hosts' })
+      useHostStore.getState().setActiveHost(action.hostId)
+      if (window.electronAPI?.focusMyWindow) {
+        window.electronAPI.focusMyWindow()
+      }
+      break
     }
   }
+}
 
-  const ck = `${hostId}:${sessionCode}`
-  const event = useAgentStore.getState().events[ck]
-  const agentSettings = useNotificationSettingsStore.getState().getSettingsForAgent(event?.agent_type || '')
-
-  let handled = false
-  if (tabId) {
-    useTabStore.getState().setActiveTab(tabId)
-    handled = true
-  } else if (agentSettings.reopenTabOnClick) {
-    const sessionName = useSessionStore.getState().sessions[hostId]?.find(s => s.code === sessionCode)?.name ?? ''
-    const newTab = createTab({ kind: 'tmux-session', hostId, sessionCode, mode: 'stream', cachedName: sessionName, tmuxInstance: '' })
-    useTabStore.getState().addTab(newTab)
-    useTabStore.getState().setActiveTab(newTab.id)
-    const activeWorkspaceId = useWorkspaceStore.getState().activeWorkspaceId
-    if (activeWorkspaceId) {
-      useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, newTab.id)
-      useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, newTab.id)
-    }
-    handled = true
-  }
-
-  // Always markRead — cross-store subscription only fires on tab *change*,
-  // but notification click on the already-active tab still needs to clear unread.
-  if (handled) {
-    useAgentStore.getState().markRead(hostId, sessionCode)
-  }
-
-  if (handled && window.electronAPI?.focusMyWindow) {
-    window.electronAPI.focusMyWindow()
+function sendConnectionNotification(message: string, action: NotificationAction): void {
+  const capabilities = getPlatformCapabilities()
+  if (capabilities.canNotification && window.electronAPI?.showNotification) {
+    window.electronAPI.showNotification({
+      title: message,
+      body: '',
+      sessionCode: '',
+      eventName: 'ConnectionStatus',
+      broadcastTs: Date.now(),
+    })
+  } else if ('Notification' in window && Notification.permission === 'granted') {
+    const n = new Notification(message)
+    n.onclick = () => handleNotificationClick(action)
   }
 }

--- a/spa/src/hooks/useRouteSync.test.ts
+++ b/spa/src/hooks/useRouteSync.test.ts
@@ -9,9 +9,9 @@ import { useTabStore } from '../stores/useTabStore'
 import { getPrimaryPane } from '../lib/pane-tree'
 import type { Tab } from '../types/tab'
 
-function makeTab(id: string, contentKind: 'session' | 'dashboard' | 'history' | 'settings', mode?: 'terminal' | 'stream'): Tab {
-  const content = contentKind === 'session'
-    ? { kind: 'session' as const, hostId: 'test-host', sessionCode: 'test', mode: mode ?? 'terminal' as const, cachedName: '', tmuxInstance: '' }
+function makeTab(id: string, contentKind: 'tmux-session' | 'dashboard' | 'history' | 'settings', mode?: 'terminal' | 'stream'): Tab {
+  const content = contentKind === 'tmux-session'
+    ? { kind: 'tmux-session' as const, hostId: 'test-host', sessionCode: 'test', mode: mode ?? 'terminal' as const, cachedName: '', tmuxInstance: '' }
     : contentKind === 'settings'
       ? { kind: 'settings' as const, scope: 'global' as const }
       : { kind: contentKind as 'dashboard' | 'history' }
@@ -60,7 +60,7 @@ describe('useRouteSync', () => {
   })
 
   it('session route /t/abc123/terminal with existing tab activates it', () => {
-    const tab = makeTab('abc123', 'session', 'terminal')
+    const tab = makeTab('abc123', 'tmux-session', 'terminal')
     resetStore({
       tabs: { abc123: tab },
       tabOrder: ['abc123'],
@@ -88,7 +88,7 @@ describe('useRouteSync', () => {
   })
 
   it('tab activation updates URL', () => {
-    const tab = makeTab('abc123', 'session', 'terminal')
+    const tab = makeTab('abc123', 'tmux-session', 'terminal')
     resetStore({
       tabs: { abc123: tab },
       tabOrder: ['abc123'],
@@ -107,7 +107,7 @@ describe('useRouteSync', () => {
   })
 
   it('viewMode change updates URL', () => {
-    const tab = makeTab('abc123', 'session', 'terminal')
+    const tab = makeTab('abc123', 'tmux-session', 'terminal')
     resetStore({
       tabs: { abc123: tab },
       tabOrder: ['abc123'],

--- a/spa/src/lib/active-session.test.ts
+++ b/spa/src/lib/active-session.test.ts
@@ -9,13 +9,13 @@ beforeEach(() => {
 
 describe('getActiveSessionCode', () => {
   it('returns sessionCode when active tab is a session', () => {
-    const tab = { ...createTab({ kind: 'session', hostId: 'test-host', sessionCode: 'dev', mode: 'terminal', cachedName: '', tmuxInstance: '' }), id: 't1' }
+    const tab = { ...createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev', mode: 'terminal', cachedName: '', tmuxInstance: '' }), id: 't1' }
     useTabStore.setState({ tabs: { t1: tab }, activeTabId: 't1' })
     expect(getActiveSessionCode()).toBe('dev')
   })
 
   it('returns sessionCode for stream-mode session tab', () => {
-    const tab = { ...createTab({ kind: 'session', hostId: 'test-host', sessionCode: 'box', mode: 'stream', cachedName: '', tmuxInstance: '' }), id: 't2' }
+    const tab = { ...createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'box', mode: 'stream', cachedName: '', tmuxInstance: '' }), id: 't2' }
     useTabStore.setState({ tabs: { t2: tab }, activeTabId: 't2' })
     expect(getActiveSessionCode()).toBe('box')
   })

--- a/spa/src/lib/active-session.ts
+++ b/spa/src/lib/active-session.ts
@@ -9,7 +9,7 @@ export function getActiveSessionCode(): string | null {
   const tab = tabs[activeTabId]
   if (!tab) return null
   const primary = getPrimaryPane(tab.layout)
-  return primary.content.kind === 'session' ? primary.content.sessionCode : null
+  return primary.content.kind === 'tmux-session' ? primary.content.sessionCode : null
 }
 
 /** Derive both hostId and sessionCode from the current active tab.
@@ -20,6 +20,6 @@ export function getActiveSessionInfo(): { hostId: string; sessionCode: string } 
   const tab = tabs[activeTabId]
   if (!tab) return null
   const primary = getPrimaryPane(tab.layout)
-  if (primary.content.kind !== 'session') return null
+  if (primary.content.kind !== 'tmux-session') return null
   return { hostId: primary.content.hostId, sessionCode: primary.content.sessionCode }
 }

--- a/spa/src/lib/host-connection.ts
+++ b/spa/src/lib/host-connection.ts
@@ -10,7 +10,7 @@ export interface HealthResult {
   latency: number | null
 }
 
-const HEALTH_TIMEOUT_MS = 3000
+const HEALTH_TIMEOUT_MS = 6000
 
 export async function checkHealth(baseUrl: string): Promise<HealthResult> {
   const controller = new AbortController()

--- a/spa/src/lib/host-lifecycle.test.ts
+++ b/spa/src/lib/host-lifecycle.test.ts
@@ -1,0 +1,435 @@
+// spa/src/lib/host-lifecycle.test.ts — Tests for host delete cascade and session-closed detection
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useHostStore } from '../stores/useHostStore'
+import { useTabStore } from '../stores/useTabStore'
+import { useSessionStore } from '../stores/useSessionStore'
+import { useAgentStore, type AgentHookEvent, type AgentStatus } from '../stores/useAgentStore'
+import { useStreamStore } from '../stores/useStreamStore'
+import { useUndoToast } from '../stores/useUndoToast'
+import { createTab } from '../types/tab'
+import { getPrimaryPane, scanPaneTree } from './pane-tree'
+import type { Tab, PaneContent } from '../types/tab'
+import type { StreamMessage } from './stream-ws'
+import type { Session } from './api'
+
+function makeSession(code: string, name: string = code): Session {
+  return { code, name, mode: 'terminal', cwd: '~', cc_session_id: '', cc_model: '', has_relay: false }
+}
+
+const HOST_A = 'host-a'
+const HOST_B = 'host-b'
+
+function makeSessionTab(hostId: string, code: string, mode: 'terminal' | 'stream' = 'terminal'): Tab {
+  return createTab({ kind: 'tmux-session', hostId, sessionCode: code, mode, cachedName: '', tmuxInstance: '' })
+}
+
+function resetAllStores() {
+  useHostStore.setState({
+    hosts: {
+      [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+      [HOST_B]: { id: HOST_B, name: 'Host B', ip: '5.6.7.8', port: 7860, order: 1 },
+    },
+    hostOrder: [HOST_A, HOST_B],
+    activeHostId: HOST_A,
+    runtime: {},
+  })
+  useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+  useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
+  useAgentStore.setState({ events: {}, statuses: {}, unread: {}, activeSubagents: {}, hooksInstalled: false })
+  useStreamStore.setState({ sessions: {}, relayStatus: {}, handoffProgress: {} })
+  useUndoToast.setState({ toast: null })
+}
+
+/**
+ * Simulate handleDeleteHost cascade (mirrors the logic in OverviewSection).
+ * Extracted here to test as a pure function operating on stores.
+ */
+function simulateDeleteHost(hostId: string, closeTabs: boolean): () => void {
+  const hostStore = useHostStore.getState()
+  const tabStore = useTabStore.getState()
+  const sessionStore = useSessionStore.getState()
+  const agentStore = useAgentStore.getState()
+  const streamStore = useStreamStore.getState()
+  const prefix = `${hostId}:`
+
+  // Snapshot host + hostOrder
+  const snapshotHost = hostStore.hosts[hostId]
+  const snapshotHostOrder = [...hostStore.hostOrder]
+  const snapshotSessions = sessionStore.sessions[hostId]
+  const snapshotActiveHostId = hostStore.activeHostId
+
+  // Snapshot agent data
+  const snapshotEvents: Record<string, AgentHookEvent> = {}
+  const snapshotStatuses: Record<string, AgentStatus> = {}
+  const snapshotUnread: Record<string, boolean> = {}
+  for (const [k, v] of Object.entries(agentStore.events)) {
+    if (k.startsWith(prefix)) snapshotEvents[k] = v
+  }
+  for (const [k, v] of Object.entries(agentStore.statuses)) {
+    if (k.startsWith(prefix)) snapshotStatuses[k] = v
+  }
+  for (const [k, v] of Object.entries(agentStore.unread)) {
+    if (k.startsWith(prefix)) snapshotUnread[k] = v
+  }
+
+  // Snapshot stream data
+  const snapshotStreamSessions: Record<string, { messages: StreamMessage[]; isStreaming: boolean }> = {}
+  for (const [k, v] of Object.entries(streamStore.sessions)) {
+    if (k.startsWith(prefix)) {
+      snapshotStreamSessions[k] = { messages: v.messages, isStreaming: v.isStreaming }
+    }
+  }
+
+  // Snapshot tab data
+  const closedTabs: Tab[] = []
+  const terminatedPanes: { tabId: string; paneId: string }[] = []
+
+  if (closeTabs) {
+    for (const [tabId, tab] of Object.entries(tabStore.tabs)) {
+      let hasHostPane = false
+      scanPaneTree(tab.layout, (pane) => {
+        if (pane.content.kind === 'tmux-session' && pane.content.hostId === hostId) {
+          hasHostPane = true
+        }
+      })
+      if (hasHostPane) {
+        closedTabs.push(tab)
+        tabStore.closeTab(tabId)
+      }
+    }
+  } else {
+    for (const [tabId, tab] of Object.entries(tabStore.tabs)) {
+      scanPaneTree(tab.layout, (pane) => {
+        if (pane.content.kind === 'tmux-session' && pane.content.hostId === hostId && !pane.content.terminated) {
+          terminatedPanes.push({ tabId, paneId: pane.id })
+        }
+      })
+    }
+    tabStore.markHostTerminated(hostId, 'host-removed')
+  }
+
+  sessionStore.removeHost(hostId)
+  agentStore.removeHost(hostId)
+  streamStore.clearHost(hostId)
+  hostStore.removeHost(hostId)
+
+  // Return undo function
+  return () => {
+    if (snapshotHost) {
+      useHostStore.getState().addHost(snapshotHost)
+      useHostStore.getState().reorderHosts(snapshotHostOrder)
+      if (snapshotActiveHostId === hostId) {
+        useHostStore.getState().setActiveHost(hostId)
+      }
+    }
+    if (snapshotSessions) {
+      useSessionStore.getState().replaceHost(hostId, snapshotSessions)
+    }
+    // Restore agent data
+    if (Object.keys(snapshotEvents).length > 0) {
+      const ag = useAgentStore.getState()
+      useAgentStore.setState({
+        events: { ...ag.events, ...snapshotEvents },
+        statuses: { ...ag.statuses, ...snapshotStatuses },
+        unread: { ...ag.unread, ...snapshotUnread },
+      })
+    }
+    // Restore stream data
+    if (Object.keys(snapshotStreamSessions).length > 0) {
+      const st = useStreamStore.getState()
+      const restored: Record<string, typeof st.sessions[string]> = {}
+      for (const [k, v] of Object.entries(snapshotStreamSessions)) {
+        restored[k] = {
+          messages: v.messages,
+          pendingControlRequests: [],
+          isStreaming: v.isStreaming,
+          conn: null,
+          sessionInfo: { ccSessionId: '', model: '' },
+          cost: 0,
+        }
+      }
+      useStreamStore.setState({ sessions: { ...st.sessions, ...restored } })
+    }
+    // Restore tabs
+    if (closeTabs && closedTabs.length > 0) {
+      for (const tab of closedTabs) {
+        if (!useTabStore.getState().tabs[tab.id]) {
+          useTabStore.getState().addTab(tab)
+        }
+      }
+    } else if (!closeTabs && terminatedPanes.length > 0) {
+      for (const { tabId, paneId } of terminatedPanes) {
+        scanPaneTree(useTabStore.getState().tabs[tabId]?.layout ?? { type: 'leaf', pane: { id: '', content: { kind: 'new-tab' } } }, (pane) => {
+          if (pane.id === paneId && pane.content.kind === 'tmux-session' && pane.content.terminated === 'host-removed') {
+            const { terminated: _, ...clean } = pane.content // eslint-disable-line @typescript-eslint/no-unused-vars
+            useTabStore.getState().setPaneContent(tabId, paneId, clean as PaneContent)
+          }
+        })
+      }
+    }
+  }
+}
+
+describe('host delete cascade', () => {
+  beforeEach(resetAllStores)
+
+  it('closeTabs=true closes matching tabs', () => {
+    const tab1 = makeSessionTab(HOST_A, 'dev001')
+    const tab2 = makeSessionTab(HOST_B, 'dev002')
+    useTabStore.getState().addTab(tab1)
+    useTabStore.getState().addTab(tab2)
+
+    simulateDeleteHost(HOST_A, true)
+
+    expect(useTabStore.getState().tabs[tab1.id]).toBeUndefined()
+    expect(useTabStore.getState().tabs[tab2.id]).toBeDefined()
+  })
+
+  it('closeTabs=false marks tabs as terminated', () => {
+    const tab = makeSessionTab(HOST_A, 'dev001')
+    useTabStore.getState().addTab(tab)
+
+    simulateDeleteHost(HOST_A, false)
+
+    const content = getPrimaryPane(useTabStore.getState().tabs[tab.id].layout).content
+    expect(content.kind).toBe('tmux-session')
+    if (content.kind === 'tmux-session') {
+      expect(content.terminated).toBe('host-removed')
+    }
+  })
+
+  it('cascade cleans AgentStore entries', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev001',
+      event_name: 'Stop',
+      raw_event: {},
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent(HOST_A, 'dev001', event)
+    expect(useAgentStore.getState().statuses[`${HOST_A}:dev001`]).toBe('idle')
+
+    simulateDeleteHost(HOST_A, true)
+
+    expect(useAgentStore.getState().events[`${HOST_A}:dev001`]).toBeUndefined()
+    expect(useAgentStore.getState().statuses[`${HOST_A}:dev001`]).toBeUndefined()
+  })
+
+  it('cascade cleans StreamStore entries', () => {
+    useStreamStore.getState().addMessage(HOST_A, 'dev001', { type: 'assistant' } as StreamMessage)
+    expect(useStreamStore.getState().sessions[`${HOST_A}:dev001`]).toBeDefined()
+
+    simulateDeleteHost(HOST_A, true)
+
+    expect(useStreamStore.getState().sessions[`${HOST_A}:dev001`]).toBeUndefined()
+  })
+
+  it('cascade cleans SessionStore entries', () => {
+    const sessions: Session[] = [makeSession('dev001', 'Dev')]
+    useSessionStore.getState().replaceHost(HOST_A, sessions)
+    expect(useSessionStore.getState().sessions[HOST_A]).toBeDefined()
+
+    simulateDeleteHost(HOST_A, true)
+
+    expect(useSessionStore.getState().sessions[HOST_A]).toBeUndefined()
+  })
+
+  it('undo restores host at original position', () => {
+    const restore = simulateDeleteHost(HOST_A, true)
+    expect(useHostStore.getState().hostOrder).toEqual([HOST_B])
+
+    restore()
+    expect(useHostStore.getState().hostOrder).toEqual([HOST_A, HOST_B])
+    expect(useHostStore.getState().hosts[HOST_A]).toBeDefined()
+  })
+
+  it('undo restores sessions', () => {
+    const sessions: Session[] = [makeSession('dev001', 'Dev')]
+    useSessionStore.getState().replaceHost(HOST_A, sessions)
+
+    const restore = simulateDeleteHost(HOST_A, true)
+    expect(useSessionStore.getState().sessions[HOST_A]).toBeUndefined()
+
+    restore()
+    expect(useSessionStore.getState().sessions[HOST_A]).toEqual(sessions)
+  })
+
+  it('undo restores AgentStore data', () => {
+    const event: AgentHookEvent = {
+      tmux_session: 'dev001',
+      event_name: 'UserPromptSubmit',
+      raw_event: {},
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent(HOST_A, 'dev001', event)
+
+    const restore = simulateDeleteHost(HOST_A, true)
+    expect(useAgentStore.getState().statuses[`${HOST_A}:dev001`]).toBeUndefined()
+
+    restore()
+    expect(useAgentStore.getState().statuses[`${HOST_A}:dev001`]).toBe('running')
+    expect(useAgentStore.getState().events[`${HOST_A}:dev001`]).toBeDefined()
+  })
+
+  it('undo restores StreamStore data', () => {
+    const msg = { type: 'assistant' } as StreamMessage
+    useStreamStore.getState().addMessage(HOST_A, 'dev001', msg)
+
+    const restore = simulateDeleteHost(HOST_A, true)
+    expect(useStreamStore.getState().sessions[`${HOST_A}:dev001`]).toBeUndefined()
+
+    restore()
+    const restored = useStreamStore.getState().sessions[`${HOST_A}:dev001`]
+    expect(restored).toBeDefined()
+    expect(restored.messages).toHaveLength(1)
+    expect(restored.conn).toBeNull()
+  })
+
+  it('undo restores closed tabs (closeTabs=true)', () => {
+    const tab = makeSessionTab(HOST_A, 'dev001')
+    useTabStore.getState().addTab(tab)
+
+    const restore = simulateDeleteHost(HOST_A, true)
+    expect(useTabStore.getState().tabs[tab.id]).toBeUndefined()
+
+    restore()
+    expect(useTabStore.getState().tabs[tab.id]).toBeDefined()
+  })
+
+  it('undo clears terminated marking (closeTabs=false)', () => {
+    const tab = makeSessionTab(HOST_A, 'dev001')
+    useTabStore.getState().addTab(tab)
+
+    const restore = simulateDeleteHost(HOST_A, false)
+    const terminated = getPrimaryPane(useTabStore.getState().tabs[tab.id].layout).content
+    if (terminated.kind === 'tmux-session') {
+      expect(terminated.terminated).toBe('host-removed')
+    }
+
+    restore()
+    const restored = getPrimaryPane(useTabStore.getState().tabs[tab.id].layout).content
+    if (restored.kind === 'tmux-session') {
+      expect(restored.terminated).toBeUndefined()
+    }
+  })
+
+  it('does not affect other hosts during cascade', () => {
+    const tabB = makeSessionTab(HOST_B, 'stg001')
+    useTabStore.getState().addTab(tabB)
+    const eventB: AgentHookEvent = {
+      tmux_session: 'stg001',
+      event_name: 'UserPromptSubmit',
+      raw_event: {},
+      agent_type: 'cc',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleHookEvent(HOST_B, 'stg001', eventB)
+    useStreamStore.getState().addMessage(HOST_B, 'stg001', { type: 'user' } as StreamMessage)
+
+    simulateDeleteHost(HOST_A, true)
+
+    // HOST_B data should be untouched
+    expect(useTabStore.getState().tabs[tabB.id]).toBeDefined()
+    expect(useAgentStore.getState().statuses[`${HOST_B}:stg001`]).toBe('running')
+    expect(useStreamStore.getState().sessions[`${HOST_B}:stg001`]).toBeDefined()
+  })
+})
+
+describe('session-closed detection', () => {
+  beforeEach(resetAllStores)
+
+  it('marks tabs as terminated when sessions disappear', () => {
+    const tab = makeSessionTab(HOST_A, 'dev001')
+    useTabStore.getState().addTab(tab)
+
+    // Simulate session-closed detection (from useMultiHostEventWs)
+    const newSessions: Session[] = [] // dev001 no longer exists
+    const newCodes = new Set(newSessions.map((s) => s.code))
+    const closedCodes = new Set<string>()
+
+    for (const t of Object.values(useTabStore.getState().tabs)) {
+      scanPaneTree(t.layout, (pane) => {
+        const c = pane.content
+        if (c.kind === 'tmux-session' && c.hostId === HOST_A && !c.terminated && !newCodes.has(c.sessionCode)) {
+          closedCodes.add(c.sessionCode)
+        }
+      })
+    }
+
+    for (const code of closedCodes) {
+      useTabStore.getState().markTerminated(HOST_A, code, 'session-closed')
+    }
+
+    const content = getPrimaryPane(useTabStore.getState().tabs[tab.id].layout).content
+    expect(content.kind).toBe('tmux-session')
+    if (content.kind === 'tmux-session') {
+      expect(content.terminated).toBe('session-closed')
+    }
+  })
+
+  it('does not double-mark already-terminated tabs', () => {
+    const tab = makeSessionTab(HOST_A, 'dev001')
+    useTabStore.getState().addTab(tab)
+    useTabStore.getState().markTerminated(HOST_A, 'dev001', 'session-closed')
+    const before = useTabStore.getState().tabs[tab.id]
+
+    // Run detection again
+    const newCodes = new Set<string>()
+    const closedCodes = new Set<string>()
+    for (const t of Object.values(useTabStore.getState().tabs)) {
+      scanPaneTree(t.layout, (pane) => {
+        const c = pane.content
+        if (c.kind === 'tmux-session' && c.hostId === HOST_A && !c.terminated && !newCodes.has(c.sessionCode)) {
+          closedCodes.add(c.sessionCode)
+        }
+      })
+    }
+    // Already terminated — should not be in closedCodes
+    expect(closedCodes.size).toBe(0)
+
+    // Verify tab unchanged
+    const after = useTabStore.getState().tabs[tab.id]
+    expect(after).toBe(before)
+  })
+
+  it('only marks sessions not in the new list', () => {
+    const tab1 = makeSessionTab(HOST_A, 'dev001')
+    const tab2 = makeSessionTab(HOST_A, 'dev002')
+    useTabStore.getState().addTab(tab1)
+    useTabStore.getState().addTab(tab2)
+
+    // dev001 still exists, dev002 is gone
+    const newSessions: Session[] = [makeSession('dev001', 'Dev')]
+    const newCodes = new Set(newSessions.map((s) => s.code))
+    const closedCodes = new Set<string>()
+
+    for (const t of Object.values(useTabStore.getState().tabs)) {
+      scanPaneTree(t.layout, (pane) => {
+        const c = pane.content
+        if (c.kind === 'tmux-session' && c.hostId === HOST_A && !c.terminated && !newCodes.has(c.sessionCode)) {
+          closedCodes.add(c.sessionCode)
+        }
+      })
+    }
+
+    expect(closedCodes.has('dev002')).toBe(true)
+    expect(closedCodes.has('dev001')).toBe(false)
+
+    for (const code of closedCodes) {
+      useTabStore.getState().markTerminated(HOST_A, code, 'session-closed')
+    }
+
+    // dev001 should not be terminated
+    const c1 = getPrimaryPane(useTabStore.getState().tabs[tab1.id].layout).content
+    if (c1.kind === 'tmux-session') {
+      expect(c1.terminated).toBeUndefined()
+    }
+
+    // dev002 should be terminated
+    const c2 = getPrimaryPane(useTabStore.getState().tabs[tab2.id].layout).content
+    if (c2.kind === 'tmux-session') {
+      expect(c2.terminated).toBe('session-closed')
+    }
+  })
+})

--- a/spa/src/lib/host-utils.test.ts
+++ b/spa/src/lib/host-utils.test.ts
@@ -1,0 +1,37 @@
+// spa/src/lib/host-utils.test.ts
+import { describe, it, expect } from 'vitest'
+import { connectionErrorMessage } from './host-utils'
+import type { HostRuntime } from '../stores/useHostStore'
+
+const t = (key: string) => key
+
+describe('connectionErrorMessage', () => {
+  it('returns null for undefined runtime', () => {
+    expect(connectionErrorMessage(undefined, t)).toBeNull()
+  })
+
+  it('returns unreachable message when daemonState is unreachable', () => {
+    const runtime: HostRuntime = { status: 'disconnected', daemonState: 'unreachable' }
+    expect(connectionErrorMessage(runtime, t)).toBe('hosts.error_unreachable')
+  })
+
+  it('returns refused message when daemonState is refused', () => {
+    const runtime: HostRuntime = { status: 'disconnected', daemonState: 'refused' }
+    expect(connectionErrorMessage(runtime, t)).toBe('hosts.error_refused')
+  })
+
+  it('returns tmux down when connected but tmux unavailable', () => {
+    const runtime: HostRuntime = { status: 'connected', daemonState: 'connected', tmuxState: 'unavailable' }
+    expect(connectionErrorMessage(runtime, t)).toBe('hosts.error_tmux_down')
+  })
+
+  it('returns null when fully connected', () => {
+    const runtime: HostRuntime = { status: 'connected', daemonState: 'connected', tmuxState: 'ok' }
+    expect(connectionErrorMessage(runtime, t)).toBeNull()
+  })
+
+  it('returns null for reconnecting without specific daemon state', () => {
+    const runtime: HostRuntime = { status: 'reconnecting' }
+    expect(connectionErrorMessage(runtime, t)).toBeNull()
+  })
+})

--- a/spa/src/lib/host-utils.ts
+++ b/spa/src/lib/host-utils.ts
@@ -1,0 +1,19 @@
+// spa/src/lib/host-utils.ts — Shared host utility functions
+import type { HostRuntime } from '../stores/useHostStore'
+
+/**
+ * Returns a user-facing error message for the current host connection state,
+ * or null if there is no error.
+ */
+export function connectionErrorMessage(
+  runtime: HostRuntime | undefined,
+  t: (key: string) => string,
+): string | null {
+  if (!runtime || runtime.status !== 'connected') {
+    if (runtime?.daemonState === 'unreachable') return t('hosts.error_unreachable')
+    if (runtime?.daemonState === 'refused') return t('hosts.error_refused')
+    return null
+  }
+  if (runtime.tmuxState === 'unavailable') return t('hosts.error_tmux_down')
+  return null
+}

--- a/spa/src/lib/pane-labels.test.ts
+++ b/spa/src/lib/pane-labels.test.ts
@@ -25,17 +25,17 @@ describe('getPaneLabel', () => {
   })
 
   it('returns session name for session content', () => {
-    const c: PaneContent = { kind: 'session', hostId: 'test-host', sessionCode: 'abc123', mode: 'terminal', cachedName: '', tmuxInstance: '' }
+    const c: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'abc123', mode: 'terminal', cachedName: '', tmuxInstance: '' }
     expect(getPaneLabel(c, mockSessionStore, mockWorkspaceStore, mockT)).toBe('dev-server')
   })
 
   it('falls back to cachedName if session not found', () => {
-    const c: PaneContent = { kind: 'session', hostId: 'test-host', sessionCode: 'zzz999', mode: 'terminal', cachedName: 'my-session', tmuxInstance: '' }
+    const c: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'zzz999', mode: 'terminal', cachedName: 'my-session', tmuxInstance: '' }
     expect(getPaneLabel(c, mockSessionStore, mockWorkspaceStore, mockT)).toBe('my-session')
   })
 
   it('falls back to sessionCode if session not found and cachedName empty', () => {
-    const c: PaneContent = { kind: 'session', hostId: 'test-host', sessionCode: 'zzz999', mode: 'terminal', cachedName: '', tmuxInstance: '' }
+    const c: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'zzz999', mode: 'terminal', cachedName: '', tmuxInstance: '' }
     expect(getPaneLabel(c, mockSessionStore, mockWorkspaceStore, mockT)).toBe('zzz999')
   })
 
@@ -87,11 +87,11 @@ describe('getPaneIcon', () => {
   })
 
   it('returns TerminalWindow for terminal session', () => {
-    expect(getPaneIcon({ kind: 'session', hostId: 'test-host', sessionCode: 'x', mode: 'terminal', cachedName: '', tmuxInstance: '' })).toBe('TerminalWindow')
+    expect(getPaneIcon({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'x', mode: 'terminal', cachedName: '', tmuxInstance: '' })).toBe('TerminalWindow')
   })
 
   it('returns ChatCircleDots for stream session', () => {
-    expect(getPaneIcon({ kind: 'session', hostId: 'test-host', sessionCode: 'x', mode: 'stream', cachedName: '', tmuxInstance: '' })).toBe('ChatCircleDots')
+    expect(getPaneIcon({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'x', mode: 'stream', cachedName: '', tmuxInstance: '' })).toBe('ChatCircleDots')
   })
 
   it('returns House for dashboard', () => {

--- a/spa/src/lib/pane-labels.ts
+++ b/spa/src/lib/pane-labels.ts
@@ -20,6 +20,10 @@ export function getPaneLabel(
     case 'new-tab':
       return t('page.pane.new_tab')
     case 'tmux-session': {
+      if (content.terminated) {
+        const name = content.cachedName || content.sessionCode
+        return `${name}（Terminated）`
+      }
       const session = sessionStore.getByCode(content.sessionCode)
       return session?.name ?? (content.cachedName || content.sessionCode)
     }
@@ -47,6 +51,7 @@ export function getPaneIcon(content: PaneContent): string {
     case 'new-tab':
       return 'Plus'
     case 'tmux-session':
+      if (content.terminated) return 'SmileySad'
       return content.mode === 'terminal' ? 'TerminalWindow' : 'ChatCircleDots'
     case 'dashboard':
       return 'House'

--- a/spa/src/lib/pane-labels.ts
+++ b/spa/src/lib/pane-labels.ts
@@ -19,7 +19,7 @@ export function getPaneLabel(
   switch (content.kind) {
     case 'new-tab':
       return t('page.pane.new_tab')
-    case 'session': {
+    case 'tmux-session': {
       const session = sessionStore.getByCode(content.sessionCode)
       return session?.name ?? (content.cachedName || content.sessionCode)
     }
@@ -46,7 +46,7 @@ export function getPaneIcon(content: PaneContent): string {
   switch (content.kind) {
     case 'new-tab':
       return 'Plus'
-    case 'session':
+    case 'tmux-session':
       return content.mode === 'terminal' ? 'TerminalWindow' : 'ChatCircleDots'
     case 'dashboard':
       return 'House'

--- a/spa/src/lib/pane-registry.test.ts
+++ b/spa/src/lib/pane-registry.test.ts
@@ -8,8 +8,8 @@ beforeEach(() => {
 describe('pane-registry', () => {
   it('registers and retrieves a renderer', () => {
     const component = (() => null) as React.FC<unknown>
-    registerPaneRenderer('session', { component })
-    expect(getPaneRenderer('session')).toEqual({ component })
+    registerPaneRenderer('tmux-session', { component })
+    expect(getPaneRenderer('tmux-session')).toEqual({ component })
   })
 
   it('returns undefined for unregistered kind', () => {
@@ -17,16 +17,16 @@ describe('pane-registry', () => {
   })
 
   it('clearPaneRegistry removes all entries', () => {
-    registerPaneRenderer('session', { component: (() => null) as React.FC<unknown> })
+    registerPaneRenderer('tmux-session', { component: (() => null) as React.FC<unknown> })
     clearPaneRegistry()
-    expect(getPaneRenderer('session')).toBeUndefined()
+    expect(getPaneRenderer('tmux-session')).toBeUndefined()
   })
 
   it('overwrites existing registration', () => {
     const comp1 = (() => null) as React.FC<unknown>
     const comp2 = (() => 'v2') as unknown as React.FC<unknown>
-    registerPaneRenderer('session', { component: comp1 })
-    registerPaneRenderer('session', { component: comp2 })
-    expect(getPaneRenderer('session')?.component).toBe(comp2)
+    registerPaneRenderer('tmux-session', { component: comp1 })
+    registerPaneRenderer('tmux-session', { component: comp2 })
+    expect(getPaneRenderer('tmux-session')?.component).toBe(comp2)
   })
 })

--- a/spa/src/lib/pane-tree.test.ts
+++ b/spa/src/lib/pane-tree.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { getPrimaryPane, findPane, updatePaneInLayout, getLayoutKey, findTabBySessionCode } from './pane-tree'
+import { describe, it, expect, vi } from 'vitest'
+import { getPrimaryPane, findPane, updatePaneInLayout, getLayoutKey, findTabBySessionCode, scanPaneTree } from './pane-tree'
 import type { PaneLayout, Pane } from '../types/tab'
 
 const paneA: Pane = { id: 'aaaaaa', content: { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'abc123', mode: 'terminal', cachedName: '', tmuxInstance: '' } }
@@ -118,5 +118,38 @@ describe('findTabBySessionCode', () => {
       tab2: { layout: { type: 'leaf', pane: paneDashboard } as PaneLayout },
     }
     expect(findTabBySessionCode(tabs, 'abc123')).toBeUndefined()
+  })
+})
+
+describe('scanPaneTree', () => {
+  it('calls fn for leaf pane', () => {
+    const fn = vi.fn()
+    scanPaneTree(leaf, fn)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith(paneA)
+  })
+
+  it('calls fn for all panes in split layout', () => {
+    const fn = vi.fn()
+    scanPaneTree(split, fn)
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(fn).toHaveBeenCalledWith(paneA)
+    expect(fn).toHaveBeenCalledWith(paneB)
+  })
+
+  it('calls fn for nested split layouts', () => {
+    const paneC: Pane = { id: 'cccccc', content: { kind: 'history' } }
+    const nested: PaneLayout = {
+      type: 'split', id: 'outer', direction: 'v',
+      children: [
+        split,
+        { type: 'leaf', pane: paneC },
+      ],
+      sizes: [70, 30],
+    }
+    const fn = vi.fn()
+    scanPaneTree(nested, fn)
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(fn).toHaveBeenCalledWith(paneC)
   })
 })

--- a/spa/src/lib/pane-tree.test.ts
+++ b/spa/src/lib/pane-tree.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { getPrimaryPane, findPane, updatePaneInLayout, getLayoutKey, findTabBySessionCode } from './pane-tree'
 import type { PaneLayout, Pane } from '../types/tab'
 
-const paneA: Pane = { id: 'aaaaaa', content: { kind: 'session', hostId: 'test-host', sessionCode: 'abc123', mode: 'terminal', cachedName: '', tmuxInstance: '' } }
+const paneA: Pane = { id: 'aaaaaa', content: { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'abc123', mode: 'terminal', cachedName: '', tmuxInstance: '' } }
 const paneB: Pane = { id: 'bbbbbb', content: { kind: 'dashboard' } }
 
 const leaf: PaneLayout = { type: 'leaf', pane: paneA }
@@ -102,7 +102,7 @@ describe('findTabBySessionCode', () => {
   })
 
   it('returns first matching tabId when multiple tabs have different sessions', () => {
-    const paneC: Pane = { id: 'cccccc', content: { kind: 'session', hostId: 'test-host', sessionCode: 'xyz789', mode: 'terminal', cachedName: '', tmuxInstance: '' } }
+    const paneC: Pane = { id: 'cccccc', content: { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'xyz789', mode: 'terminal', cachedName: '', tmuxInstance: '' } }
     const tabs = {
       tab1: { layout: { type: 'leaf', pane: paneA } as PaneLayout },
       tab2: { layout: { type: 'leaf', pane: paneC } as PaneLayout },

--- a/spa/src/lib/pane-tree.ts
+++ b/spa/src/lib/pane-tree.ts
@@ -50,7 +50,7 @@ export function findTabBySessionCode(
 ): string | undefined {
   for (const [tabId, tab] of Object.entries(tabs)) {
     const primary = getPrimaryPane(tab.layout)
-    if (primary.content.kind === 'session' && primary.content.sessionCode === sessionCode) {
+    if (primary.content.kind === 'tmux-session' && primary.content.sessionCode === sessionCode) {
       return tabId
     }
   }

--- a/spa/src/lib/pane-tree.ts
+++ b/spa/src/lib/pane-tree.ts
@@ -37,6 +37,14 @@ export function updatePaneInLayout(
   }
 }
 
+export function scanPaneTree(layout: PaneLayout, fn: (pane: Pane) => void): void {
+  if (layout.type === 'leaf') {
+    fn(layout.pane)
+  } else {
+    layout.children.forEach((child) => scanPaneTree(child, fn))
+  }
+}
+
 export function getLayoutKey(layout: PaneLayout): string {
   return layout.type === 'leaf' ? layout.pane.id : layout.id
 }

--- a/spa/src/lib/pane-utils.test.ts
+++ b/spa/src/lib/pane-utils.test.ts
@@ -10,14 +10,14 @@ describe('contentMatches', () => {
   })
 
   it('returns false for session kind (sessions are never singletons)', () => {
-    const a: PaneContent = { kind: 'session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
-    const b: PaneContent = { kind: 'session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
+    const a: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
+    const b: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
     expect(contentMatches(a, b)).toBe(false)
   })
 
   it('returns false for session kind even with different codes', () => {
-    const a: PaneContent = { kind: 'session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
-    const b: PaneContent = { kind: 'session', hostId: 'test-host', sessionCode: 'dev002', mode: 'stream', cachedName: '', tmuxInstance: '' }
+    const a: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
+    const b: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev002', mode: 'stream', cachedName: '', tmuxInstance: '' }
     expect(contentMatches(a, b)).toBe(false)
   })
 

--- a/spa/src/lib/pane-utils.ts
+++ b/spa/src/lib/pane-utils.ts
@@ -2,7 +2,7 @@ import type { PaneContent } from '../types/tab'
 
 export function contentMatches(a: PaneContent, b: PaneContent): boolean {
   if (a.kind !== b.kind) return false
-  if (a.kind === 'session') return false // sessions are never singletons
+  if (a.kind === 'tmux-session') return false // sessions are never singletons
   if (a.kind === 'browser') return false // browser panes are never singletons
   if (a.kind === 'settings' && b.kind === 'settings') {
     return JSON.stringify(a.scope) === JSON.stringify(b.scope)

--- a/spa/src/lib/register-panes.tsx
+++ b/spa/src/lib/register-panes.tsx
@@ -39,7 +39,7 @@ export function registerBuiltinPanes(): void {
       return <NewTabPage onSelect={handleSelect} />
     },
   })
-  registerPaneRenderer('session', { component: SessionPaneContent })
+  registerPaneRenderer('tmux-session', { component: SessionPaneContent })
   registerPaneRenderer('dashboard', { component: DashboardPage })
   registerPaneRenderer('history', { component: HistoryPage })
   registerPaneRenderer('settings', { component: SettingsPage })

--- a/spa/src/lib/route-utils.test.ts
+++ b/spa/src/lib/route-utils.test.ts
@@ -103,7 +103,7 @@ describe('parseRoute', () => {
 
 describe('tabToUrl', () => {
   it('generates session tab URL', () => {
-    expect(tabToUrl('abc123', { kind: 'session', hostId: 'test-host', sessionCode: 'x', mode: 'terminal', cachedName: '', tmuxInstance: '' }))
+    expect(tabToUrl('abc123', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'x', mode: 'terminal', cachedName: '', tmuxInstance: '' }))
       .toBe('/t/abc123/terminal')
   })
 
@@ -125,7 +125,7 @@ describe('tabToUrl', () => {
   })
 
   it('generates session tab URL within workspace', () => {
-    expect(tabToUrl('abc123', { kind: 'session', hostId: 'test-host', sessionCode: 'x', mode: 'terminal', cachedName: '', tmuxInstance: '' }, 'ws0001'))
+    expect(tabToUrl('abc123', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'x', mode: 'terminal', cachedName: '', tmuxInstance: '' }, 'ws0001'))
       .toBe('/w/ws0001/t/abc123/terminal')
   })
 

--- a/spa/src/lib/route-utils.ts
+++ b/spa/src/lib/route-utils.ts
@@ -59,7 +59,7 @@ export function tabToUrl(tabId: string, content: PaneContent, workspaceId?: stri
     case 'settings':
       if (content.scope === 'global') return '/settings'
       return `/w/${content.scope.workspaceId}/settings`
-    case 'session':
+    case 'tmux-session':
       if (workspaceId) return `/w/${workspaceId}/t/${tabId}/${content.mode}`
       return `/t/${tabId}/${content.mode}`
     case 'hosts':

--- a/spa/src/lib/tab-state.test.ts
+++ b/spa/src/lib/tab-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { deriveTabState } from './tab-state'
+import type { PaneContent } from '../types/tab'
+import type { HostRuntime } from '../stores/useHostStore'
+
+describe('deriveTabState', () => {
+  it('returns "active" for non-tmux-session kinds', () => {
+    expect(deriveTabState({ kind: 'dashboard' })).toBe('active')
+    expect(deriveTabState({ kind: 'browser', url: 'http://x' })).toBe('active')
+  })
+
+  it('returns "terminated" when terminated field is set', () => {
+    const content: PaneContent = {
+      kind: 'tmux-session', hostId: 'h', sessionCode: 'c',
+      mode: 'terminal', cachedName: 'n', tmuxInstance: 't',
+      terminated: 'session-closed',
+    }
+    const runtime: HostRuntime = { status: 'reconnecting' }
+    expect(deriveTabState(content, runtime)).toBe('terminated')
+  })
+
+  it('returns "reconnecting" when runtime is reconnecting', () => {
+    const content: PaneContent = {
+      kind: 'tmux-session', hostId: 'h', sessionCode: 'c',
+      mode: 'terminal', cachedName: 'n', tmuxInstance: 't',
+    }
+    expect(deriveTabState(content, { status: 'reconnecting' })).toBe('reconnecting')
+  })
+
+  it('returns "active" for connected tmux-session', () => {
+    const content: PaneContent = {
+      kind: 'tmux-session', hostId: 'h', sessionCode: 'c',
+      mode: 'terminal', cachedName: 'n', tmuxInstance: 't',
+    }
+    expect(deriveTabState(content, { status: 'connected' })).toBe('active')
+  })
+
+  it('returns "active" when runtime is undefined', () => {
+    const content: PaneContent = {
+      kind: 'tmux-session', hostId: 'h', sessionCode: 'c',
+      mode: 'terminal', cachedName: 'n', tmuxInstance: 't',
+    }
+    expect(deriveTabState(content)).toBe('active')
+  })
+})

--- a/spa/src/lib/tab-state.ts
+++ b/spa/src/lib/tab-state.ts
@@ -1,0 +1,11 @@
+import type { PaneContent } from '../types/tab'
+import type { HostRuntime } from '../stores/useHostStore'
+
+export type TabState = 'active' | 'reconnecting' | 'terminated'
+
+export function deriveTabState(content: PaneContent, runtime?: HostRuntime): TabState {
+  if (content.kind !== 'tmux-session') return 'active'
+  if (content.terminated) return 'terminated'
+  if (runtime?.status === 'reconnecting') return 'reconnecting'
+  return 'active'
+}

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -353,11 +353,32 @@
   "hosts.no_host_selected": "No host selected.",
   "hosts.preset_count": "{{count}} preset(s)",
   "hosts.connection_failed": "Connection failed",
+  "hosts.confirm_delete_tabs": "Also close all tabs for this host",
+  "hosts.deleted_toast": "{name} deleted",
+  "hosts.undo": "Undo",
+  "hosts.error_unreachable": "Host unreachable",
+  "hosts.error_refused": "Daemon not running",
+  "hosts.error_tmux_down": "tmux environment unreachable",
   "common.edit": "Edit",
 
   "error.boundary.title": "Something went wrong",
   "error.boundary.message": "An unexpected error occurred.",
   "error.boundary.reload": "Reload",
 
-  "session.no_sessions": "No sessions available"
+  "session.no_sessions": "No sessions available",
+
+  "terminated.session_closed": "Session closed",
+  "terminated.session_closed_desc": "{name} no longer exists",
+  "terminated.tmux_restarted": "tmux restarted",
+  "terminated.tmux_restarted_desc": "Previous sessions are no longer valid",
+  "terminated.host_removed": "Host removed",
+  "terminated.host_removed_desc": "This host has been removed",
+  "terminated.no_sessions": "No available connections",
+  "terminated.close_tab": "Close tab",
+  "terminated.select_session": "Select a session to reconnect",
+
+  "connection.reconnect": "Reconnect",
+
+  "notification.daemon_refused": "{name} — Daemon not running",
+  "notification.tmux_down": "{name} — tmux environment unreachable"
 }

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -354,7 +354,7 @@
   "hosts.preset_count": "{{count}} preset(s)",
   "hosts.connection_failed": "Connection failed",
   "hosts.confirm_delete_tabs": "Also close all tabs for this host",
-  "hosts.deleted_toast": "{name} deleted",
+  "hosts.deleted_toast": "{{name}} deleted",
   "hosts.undo": "Undo",
   "hosts.error_unreachable": "Host unreachable",
   "hosts.error_refused": "Daemon not running",
@@ -368,7 +368,7 @@
   "session.no_sessions": "No sessions available",
 
   "terminated.session_closed": "Session closed",
-  "terminated.session_closed_desc": "{name} no longer exists",
+  "terminated.session_closed_desc": "{{name}} no longer exists",
   "terminated.tmux_restarted": "tmux restarted",
   "terminated.tmux_restarted_desc": "Previous sessions are no longer valid",
   "terminated.host_removed": "Host removed",
@@ -379,6 +379,6 @@
 
   "connection.reconnect": "Reconnect",
 
-  "notification.daemon_refused": "{name} — Daemon not running",
-  "notification.tmux_down": "{name} — tmux environment unreachable"
+  "notification.daemon_refused": "{{name}} — Daemon not running",
+  "notification.tmux_down": "{{name}} — tmux environment unreachable"
 }

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -354,7 +354,7 @@
   "hosts.preset_count": "{{count}} 個預設",
   "hosts.connection_failed": "連線失敗",
   "hosts.confirm_delete_tabs": "一併關閉所有此 Host 的分頁",
-  "hosts.deleted_toast": "已刪除 {name}",
+  "hosts.deleted_toast": "已刪除 {{name}}",
   "hosts.undo": "復原",
   "hosts.error_unreachable": "主機無法連線",
   "hosts.error_refused": "Daemon 未啟動",
@@ -368,7 +368,7 @@
   "session.no_sessions": "沒有可用的 Session",
 
   "terminated.session_closed": "Session 已關閉",
-  "terminated.session_closed_desc": "{name} 已不存在",
+  "terminated.session_closed_desc": "{{name}} 已不存在",
   "terminated.tmux_restarted": "tmux 已重啟",
   "terminated.tmux_restarted_desc": "原有 session 已失效",
   "terminated.host_removed": "Host 已移除",
@@ -379,6 +379,6 @@
 
   "connection.reconnect": "重新連線",
 
-  "notification.daemon_refused": "{name} — Daemon 未啟動",
-  "notification.tmux_down": "{name} — tmux 環境無法連線"
+  "notification.daemon_refused": "{{name}} — Daemon 未啟動",
+  "notification.tmux_down": "{{name}} — tmux 環境無法連線"
 }

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -353,11 +353,32 @@
   "hosts.no_host_selected": "未選取主機。",
   "hosts.preset_count": "{{count}} 個預設",
   "hosts.connection_failed": "連線失敗",
+  "hosts.confirm_delete_tabs": "一併關閉所有此 Host 的分頁",
+  "hosts.deleted_toast": "已刪除 {name}",
+  "hosts.undo": "復原",
+  "hosts.error_unreachable": "主機無法連線",
+  "hosts.error_refused": "Daemon 未啟動",
+  "hosts.error_tmux_down": "tmux 環境無法連線",
   "common.edit": "編輯",
 
   "error.boundary.title": "發生錯誤",
   "error.boundary.message": "發生了未預期的錯誤。",
   "error.boundary.reload": "重新載入",
 
-  "session.no_sessions": "沒有可用的 Session"
+  "session.no_sessions": "沒有可用的 Session",
+
+  "terminated.session_closed": "Session 已關閉",
+  "terminated.session_closed_desc": "{name} 已不存在",
+  "terminated.tmux_restarted": "tmux 已重啟",
+  "terminated.tmux_restarted_desc": "原有 session 已失效",
+  "terminated.host_removed": "Host 已移除",
+  "terminated.host_removed_desc": "該主機已從列表中移除",
+  "terminated.no_sessions": "目前沒有可用的連線",
+  "terminated.close_tab": "關閉分頁",
+  "terminated.select_session": "選擇 session 以重新連線",
+
+  "connection.reconnect": "重新連線",
+
+  "notification.daemon_refused": "{name} — Daemon 未啟動",
+  "notification.tmux_down": "{name} — tmux 環境無法連線"
 }

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -474,4 +474,43 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().activeSubagents[`${H}:staging`]).toBeUndefined()
     expect(useAgentStore.getState().activeSubagents['other-host:dev']).toEqual(['agent-C'])
   })
+
+  it('removeHost → clears all 4 fields for matching host, preserves others', () => {
+    useAgentStore.setState({
+      events: {
+        [`${H}:dev`]: { tmux_session: 'dev', event_name: 'Stop', raw_event: {}, agent_type: 'cc', broadcast_ts: 1 },
+        [`${H}:staging`]: { tmux_session: 'staging', event_name: 'Stop', raw_event: {}, agent_type: 'cc', broadcast_ts: 2 },
+        ['other-host:dev']: { tmux_session: 'dev', event_name: 'Stop', raw_event: {}, agent_type: 'cc', broadcast_ts: 3 },
+      },
+      statuses: {
+        [`${H}:dev`]: 'idle',
+        [`${H}:staging`]: 'running',
+        ['other-host:dev']: 'waiting',
+      },
+      unread: {
+        [`${H}:dev`]: true,
+        ['other-host:dev']: true,
+      },
+      activeSubagents: {
+        [`${H}:dev`]: ['agent-A'],
+        ['other-host:dev']: ['agent-B'],
+      },
+    })
+
+    useAgentStore.getState().removeHost(H)
+
+    const state = useAgentStore.getState()
+    // Host entries cleared
+    expect(state.events[`${H}:dev`]).toBeUndefined()
+    expect(state.events[`${H}:staging`]).toBeUndefined()
+    expect(state.statuses[`${H}:dev`]).toBeUndefined()
+    expect(state.statuses[`${H}:staging`]).toBeUndefined()
+    expect(state.unread[`${H}:dev`]).toBeUndefined()
+    expect(state.activeSubagents[`${H}:dev`]).toBeUndefined()
+    // Other host preserved
+    expect(state.events['other-host:dev']).toBeDefined()
+    expect(state.statuses['other-host:dev']).toBe('waiting')
+    expect(state.unread['other-host:dev']).toBe(true)
+    expect(state.activeSubagents['other-host:dev']).toEqual(['agent-B'])
+  })
 })

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -181,7 +181,7 @@ describe('useAgentStore', () => {
   })
 
   it('Stop → does NOT mark unread when active tab is this session', () => {
-    const tab = { ...createTab({ kind: 'session', hostId: 'test-host', sessionCode: 'dev', mode: 'terminal', cachedName: '', tmuxInstance: '' }), id: 't1' }
+    const tab = { ...createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev', mode: 'terminal', cachedName: '', tmuxInstance: '' }), id: 't1' }
     useTabStore.setState({ tabs: { t1: tab }, activeTabId: 't1' })
     const event: AgentHookEvent = {
       tmux_session: 'dev',

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -28,6 +28,7 @@ interface AgentState {
   markRead: (hostId: string, sessionCode: string) => void
   clearAllSubagents: () => void
   clearSubagentsForHost: (hostId: string) => void
+  removeHost: (hostId: string) => void
   setTabIndicatorStyle: (style: TabIndicatorStyle) => void
   setHooksInstalled: (installed: boolean) => void
 }
@@ -185,6 +186,23 @@ export const useAgentStore = create<AgentState>()(
           if (!k.startsWith(prefix)) filtered[k] = v
         }
         return { activeSubagents: filtered }
+      }),
+
+      removeHost: (hostId) => set((s) => {
+        const prefix = `${hostId}:`
+        const filterKeys = <T,>(record: Record<string, T>): Record<string, T> => {
+          const result: Record<string, T> = {}
+          for (const [k, v] of Object.entries(record)) {
+            if (!k.startsWith(prefix)) result[k] = v
+          }
+          return result
+        }
+        return {
+          events: filterKeys(s.events),
+          statuses: filterKeys(s.statuses),
+          unread: filterKeys(s.unread),
+          activeSubagents: filterKeys(s.activeSubagents),
+        }
       }),
 
       setTabIndicatorStyle: (style) => set({ tabIndicatorStyle: style }),

--- a/spa/src/stores/useHistoryStore.test.ts
+++ b/spa/src/stores/useHistoryStore.test.ts
@@ -5,7 +5,7 @@ import type { PaneContent } from '../types/tab'
 
 function makeContent(kind: PaneContent['kind'] = 'dashboard'): PaneContent {
   switch (kind) {
-    case 'session': return { kind: 'session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
+    case 'tmux-session': return { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
     case 'settings': return { kind: 'settings', scope: 'global' }
     case 'new-tab': return { kind: 'new-tab' }
     case 'dashboard': return { kind: 'dashboard' }

--- a/spa/src/stores/useHostStore.ts
+++ b/spa/src/stores/useHostStore.ts
@@ -20,6 +20,7 @@ export interface HostRuntime {
   info?: HostInfo
   daemonState?: 'connected' | 'refused' | 'unreachable'
   tmuxState?: 'ok' | 'unavailable'
+  manualRetry?: () => void  // safe: runtime excluded from persist partialize
 }
 
 export interface HostInfo {

--- a/spa/src/stores/useStreamStore.test.ts
+++ b/spa/src/stores/useStreamStore.test.ts
@@ -119,4 +119,44 @@ describe('useStreamStore (per-session)', () => {
     expect(useStreamStore.getState().relayStatus[`${H}:sess-b`]).toBe(false)
   })
 
+  it('clearHost closes connections and removes all entries for host', () => {
+    const { setConn, addMessage, setRelayStatus, setHandoffProgress } = useStreamStore.getState()
+    const closedConns: string[] = []
+    const mockConn = (label: string) => ({
+      send: () => {},
+      close: () => { closedConns.push(label) },
+    }) as unknown as StreamConnection
+
+    // Set up data for target host
+    setConn(H, 'sess-a', mockConn('a'))
+    addMessage(H, 'sess-a', { type: 'user' } as StreamMessage)
+    setConn(H, 'sess-b', mockConn('b'))
+    addMessage(H, 'sess-b', { type: 'assistant' } as StreamMessage)
+    setRelayStatus(H, 'sess-a', true)
+    setHandoffProgress(H, 'sess-b', 'detecting')
+
+    // Set up data for other host
+    setConn('other-host', 'sess-c', mockConn('c'))
+    addMessage('other-host', 'sess-c', { type: 'user' } as StreamMessage)
+    setRelayStatus('other-host', 'sess-c', true)
+    setHandoffProgress('other-host', 'sess-c', 'launching')
+
+    useStreamStore.getState().clearHost(H)
+
+    const state = useStreamStore.getState()
+    // Target host entries cleared
+    expect(state.sessions[`${H}:sess-a`]).toBeUndefined()
+    expect(state.sessions[`${H}:sess-b`]).toBeUndefined()
+    expect(state.relayStatus[`${H}:sess-a`]).toBeUndefined()
+    expect(state.handoffProgress[`${H}:sess-b`]).toBeUndefined()
+    // Connections closed
+    expect(closedConns).toContain('a')
+    expect(closedConns).toContain('b')
+    expect(closedConns).not.toContain('c')
+    // Other host preserved
+    expect(state.sessions['other-host:sess-c']).toBeDefined()
+    expect(state.relayStatus['other-host:sess-c']).toBe(true)
+    expect(state.handoffProgress['other-host:sess-c']).toBe('launching')
+  })
+
 })

--- a/spa/src/stores/useStreamStore.ts
+++ b/spa/src/stores/useStreamStore.ts
@@ -43,6 +43,9 @@ interface StreamStore {
   loadHistory: (hostId: string, sessionCode: string, messages: StreamMessage[]) => void
   clearSession: (hostId: string, sessionCode: string) => void
 
+  // Host-level actions
+  clearHost: (hostId: string) => void
+
   // Global-keyed actions
   setHandoffProgress: (hostId: string, sessionCode: string, progress: string) => void
   setRelayStatus: (hostId: string, sessionCode: string, connected: boolean) => void
@@ -116,6 +119,29 @@ export const useStreamStore = create<StreamStore>()(subscribeWithSelector((set) 
     set((s) => {
       const { [key]: _cleared, ...rest } = s.sessions // eslint-disable-line @typescript-eslint/no-unused-vars
       return { sessions: rest }
+    })
+  },
+
+  clearHost: (hostId) => {
+    const prefix = `${hostId}:`
+    // Close connections outside set() to avoid re-entrant mutations
+    const currentSessions = useStreamStore.getState().sessions
+    for (const [k, v] of Object.entries(currentSessions)) {
+      if (k.startsWith(prefix)) v.conn?.close()
+    }
+    set((s) => {
+      const filterKeys = <T,>(record: Record<string, T>): Record<string, T> => {
+        const result: Record<string, T> = {}
+        for (const [k, v] of Object.entries(record)) {
+          if (!k.startsWith(prefix)) result[k] = v
+        }
+        return result
+      }
+      return {
+        sessions: filterKeys(s.sessions),
+        relayStatus: filterKeys(s.relayStatus),
+        handoffProgress: filterKeys(s.handoffProgress),
+      }
     })
   },
 

--- a/spa/src/stores/useTabStore.pin-lock.test.ts
+++ b/spa/src/stores/useTabStore.pin-lock.test.ts
@@ -3,7 +3,7 @@ import { useTabStore } from './useTabStore'
 import { createTab } from '../types/tab'
 
 function addTab(name: string) {
-  const tab = createTab({ kind: 'session', hostId: 'test-host', sessionCode: name, mode: 'terminal', cachedName: '', tmuxInstance: '' })
+  const tab = createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: name, mode: 'terminal', cachedName: '', tmuxInstance: '' })
   useTabStore.getState().addTab(tab)
   return tab
 }

--- a/spa/src/stores/useTabStore.test.ts
+++ b/spa/src/stores/useTabStore.test.ts
@@ -5,7 +5,7 @@ import type { PaneContent } from '../types/tab'
 import { getPrimaryPane } from '../lib/pane-tree'
 
 function makeSessionTab(code: string, mode: 'terminal' | 'stream' = 'terminal') {
-  return createTab({ kind: 'session', hostId: 'test-host', sessionCode: code, mode, cachedName: '', tmuxInstance: '' })
+  return createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: code, mode, cachedName: '', tmuxInstance: '' })
 }
 
 describe('useTabStore', () => {
@@ -94,7 +94,7 @@ describe('useTabStore', () => {
   })
 
   it('openSingletonTab always creates new tab for session (non-singleton)', () => {
-    const content: PaneContent = { kind: 'session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
+    const content: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }
     const tab = createTab(content)
     useTabStore.getState().addTab(tab)
     const returnedId = useTabStore.getState().openSingletonTab(content)
@@ -129,7 +129,7 @@ describe('useTabStore', () => {
     useTabStore.getState().setViewMode(tab.id, paneId, 'stream')
     const updated = useTabStore.getState().tabs[tab.id]
     const content = updated.layout.type === 'leaf' ? updated.layout.pane.content : undefined
-    expect(content?.kind === 'session' && content.mode).toBe('stream')
+    expect(content?.kind === 'tmux-session' && content.mode).toBe('stream')
   })
 
   it('setViewMode is no-op for nonexistent tab', () => {
@@ -196,8 +196,8 @@ describe('useTabStore', () => {
       useTabStore.getState().updateSessionCache('test-host', 'dev001', 'renamed-session')
 
       const content = getPrimaryPane(useTabStore.getState().tabs[tabId].layout).content
-      expect(content.kind).toBe('session')
-      if (content.kind === 'session') {
+      expect(content.kind).toBe('tmux-session')
+      if (content.kind === 'tmux-session') {
         expect(content.cachedName).toBe('renamed-session')
       }
     })
@@ -210,8 +210,8 @@ describe('useTabStore', () => {
       useTabStore.getState().updateSessionCache('test-host', 'dev999', 'renamed')
 
       const content = getPrimaryPane(useTabStore.getState().tabs[tabId].layout).content
-      expect(content.kind).toBe('session')
-      if (content.kind === 'session') {
+      expect(content.kind).toBe('tmux-session')
+      if (content.kind === 'tmux-session') {
         expect(content.cachedName).toBe('')
       }
     })
@@ -224,8 +224,8 @@ describe('useTabStore', () => {
       useTabStore.getState().updateSessionCache('other-host', 'dev001', 'renamed')
 
       const content = getPrimaryPane(useTabStore.getState().tabs[tabId].layout).content
-      expect(content.kind).toBe('session')
-      if (content.kind === 'session') {
+      expect(content.kind).toBe('tmux-session')
+      if (content.kind === 'tmux-session') {
         expect(content.cachedName).toBe('')
       }
     })
@@ -252,8 +252,8 @@ describe('useTabStore', () => {
 
       for (const tabId of useTabStore.getState().tabOrder) {
         const content = getPrimaryPane(useTabStore.getState().tabs[tabId].layout).content
-        expect(content.kind).toBe('session')
-        if (content.kind === 'session') {
+        expect(content.kind).toBe('tmux-session')
+        if (content.kind === 'tmux-session') {
           expect(content.cachedName).toBe('new-name')
         }
       }

--- a/spa/src/stores/useTabStore.test.ts
+++ b/spa/src/stores/useTabStore.test.ts
@@ -260,6 +260,117 @@ describe('useTabStore', () => {
     })
   })
 
+  describe('markTerminated', () => {
+    it('marks matching pane as terminated', () => {
+      const tab = makeSessionTab('dev001')
+      useTabStore.getState().addTab(tab)
+      useTabStore.getState().markTerminated('test-host', 'dev001', 'session-closed')
+      const content = getPrimaryPane(useTabStore.getState().tabs[tab.id].layout).content
+      expect(content.kind).toBe('tmux-session')
+      if (content.kind === 'tmux-session') {
+        expect(content.terminated).toBe('session-closed')
+      }
+    })
+
+    it('does not mark pane with different sessionCode', () => {
+      const tab = makeSessionTab('dev001')
+      useTabStore.getState().addTab(tab)
+      useTabStore.getState().markTerminated('test-host', 'dev999', 'session-closed')
+      const content = getPrimaryPane(useTabStore.getState().tabs[tab.id].layout).content
+      if (content.kind === 'tmux-session') {
+        expect(content.terminated).toBeUndefined()
+      }
+    })
+
+    it('does not mark pane with different hostId', () => {
+      const tab = makeSessionTab('dev001')
+      useTabStore.getState().addTab(tab)
+      useTabStore.getState().markTerminated('other-host', 'dev001', 'session-closed')
+      const content = getPrimaryPane(useTabStore.getState().tabs[tab.id].layout).content
+      if (content.kind === 'tmux-session') {
+        expect(content.terminated).toBeUndefined()
+      }
+    })
+
+    it('does not double-mark already-terminated panes', () => {
+      const tab = makeSessionTab('dev001')
+      useTabStore.getState().addTab(tab)
+      useTabStore.getState().markTerminated('test-host', 'dev001', 'session-closed')
+      const before = useTabStore.getState().tabs[tab.id]
+      // Mark again with different reason — should be no-op (already terminated)
+      useTabStore.getState().markTerminated('test-host', 'dev001', 'tmux-restarted')
+      const after = useTabStore.getState().tabs[tab.id]
+      expect(after).toBe(before) // same reference — no update
+      const content = getPrimaryPane(after.layout).content
+      if (content.kind === 'tmux-session') {
+        expect(content.terminated).toBe('session-closed') // original reason preserved
+      }
+    })
+
+    it('marks multiple matching tabs', () => {
+      const tab1 = makeSessionTab('dev001')
+      const tab2 = makeSessionTab('dev001', 'stream')
+      useTabStore.getState().addTab(tab1)
+      useTabStore.getState().addTab(tab2)
+      useTabStore.getState().markTerminated('test-host', 'dev001', 'session-closed')
+      for (const tabId of useTabStore.getState().tabOrder) {
+        const content = getPrimaryPane(useTabStore.getState().tabs[tabId].layout).content
+        if (content.kind === 'tmux-session') {
+          expect(content.terminated).toBe('session-closed')
+        }
+      }
+    })
+
+    it('is no-op when no panes match (returns same state)', () => {
+      const tab = makeSessionTab('dev001')
+      useTabStore.getState().addTab(tab)
+      const before = useTabStore.getState().tabs
+      useTabStore.getState().markTerminated('test-host', 'no-match', 'session-closed')
+      const after = useTabStore.getState().tabs
+      expect(after).toBe(before)
+    })
+  })
+
+  describe('markHostTerminated', () => {
+    it('marks all panes for a host', () => {
+      const tab1 = makeSessionTab('dev001')
+      const tab2 = makeSessionTab('dev002', 'stream')
+      useTabStore.getState().addTab(tab1)
+      useTabStore.getState().addTab(tab2)
+      useTabStore.getState().markHostTerminated('test-host', 'tmux-restarted')
+      for (const tabId of useTabStore.getState().tabOrder) {
+        const content = getPrimaryPane(useTabStore.getState().tabs[tabId].layout).content
+        if (content.kind === 'tmux-session') {
+          expect(content.terminated).toBe('tmux-restarted')
+        }
+      }
+    })
+
+    it('does not mark panes for different host', () => {
+      const tab = makeSessionTab('dev001')
+      useTabStore.getState().addTab(tab)
+      useTabStore.getState().markHostTerminated('other-host', 'host-removed')
+      const content = getPrimaryPane(useTabStore.getState().tabs[tab.id].layout).content
+      if (content.kind === 'tmux-session') {
+        expect(content.terminated).toBeUndefined()
+      }
+    })
+
+    it('does not double-mark already-terminated panes', () => {
+      const tab = makeSessionTab('dev001')
+      useTabStore.getState().addTab(tab)
+      useTabStore.getState().markHostTerminated('test-host', 'session-closed')
+      const before = useTabStore.getState().tabs[tab.id]
+      useTabStore.getState().markHostTerminated('test-host', 'tmux-restarted')
+      const after = useTabStore.getState().tabs[tab.id]
+      expect(after).toBe(before)
+      const content = getPrimaryPane(after.layout).content
+      if (content.kind === 'tmux-session') {
+        expect(content.terminated).toBe('session-closed')
+      }
+    })
+  })
+
   describe('persist migration', () => {
     it('migrates kind "session" to "tmux-session" in version 2', () => {
       const v1State = {

--- a/spa/src/stores/useTabStore.test.ts
+++ b/spa/src/stores/useTabStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { useTabStore } from './useTabStore'
+import { useTabStore, migrateTabStore } from './useTabStore'
 import { createTab } from '../types/tab'
 import type { PaneContent } from '../types/tab'
 import { getPrimaryPane } from '../lib/pane-tree'
@@ -257,6 +257,70 @@ describe('useTabStore', () => {
           expect(content.cachedName).toBe('new-name')
         }
       }
+    })
+  })
+
+  describe('persist migration', () => {
+    it('migrates kind "session" to "tmux-session" in version 2', () => {
+      const v1State = {
+        tabs: {
+          tab1: {
+            id: 'tab1', pinned: false, locked: false, createdAt: 1000,
+            layout: {
+              type: 'leaf' as const,
+              pane: {
+                id: 'pane1',
+                content: { kind: 'session', hostId: 'h1', sessionCode: 'abc123', mode: 'terminal', cachedName: 'test', tmuxInstance: '123:456' },
+              },
+            },
+          },
+        },
+        tabOrder: ['tab1'],
+        activeTabId: 'tab1',
+      }
+      const migrated = migrateTabStore(v1State, 1)
+      const pane = migrated.tabs.tab1.layout.pane
+      expect(pane.content.kind).toBe('tmux-session')
+    })
+
+    it('migrates kind "session" inside split layouts', () => {
+      const v1State = {
+        tabs: {
+          tab1: {
+            id: 'tab1', pinned: false, locked: false, createdAt: 1000,
+            layout: {
+              type: 'split' as const, id: 'split1', direction: 'h' as const,
+              children: [
+                { type: 'leaf' as const, pane: { id: 'p1', content: { kind: 'session', hostId: 'h1', sessionCode: 'a', mode: 'terminal', cachedName: 'A', tmuxInstance: '1:2' } } },
+                { type: 'leaf' as const, pane: { id: 'p2', content: { kind: 'dashboard' } } },
+              ],
+              sizes: [50, 50],
+            },
+          },
+        },
+        tabOrder: ['tab1'],
+        activeTabId: 'tab1',
+      }
+      const migrated = migrateTabStore(v1State, 1)
+      const children = migrated.tabs.tab1.layout.children
+      expect(children[0].pane.content.kind).toBe('tmux-session')
+      expect(children[1].pane.content.kind).toBe('dashboard')
+    })
+
+    it('preserves non-session tabs during migration', () => {
+      const v1State = {
+        tabs: {
+          tab1: {
+            id: 'tab1', pinned: false, locked: false, createdAt: 1000,
+            layout: { type: 'leaf' as const, pane: { id: 'pane1', content: { kind: 'dashboard' } } },
+          },
+        },
+        tabOrder: ['tab1'],
+        activeTabId: 'tab1',
+      }
+      const migrated = migrateTabStore(v1State, 1)
+      const pane = migrated.tabs.tab1.layout.pane
+      expect(pane.content.kind).toBe('dashboard')
     })
   })
 })

--- a/spa/src/stores/useTabStore.ts
+++ b/spa/src/stores/useTabStore.ts
@@ -1,10 +1,43 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { Tab, PaneContent } from '../types/tab'
+import type { Tab, PaneContent, PaneLayout } from '../types/tab'
 import { createTab } from '../types/tab'
 import { getPrimaryPane, findPane, updatePaneInLayout } from '../lib/pane-tree'
 import { contentMatches } from '../lib/pane-utils'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
+
+// --- Persist migration helpers ---
+// These functions handle legacy persisted data whose shape no longer matches
+// current TypeScript types, so `any` casts are unavoidable.
+
+function migrateLayout(layout: PaneLayout): PaneLayout {
+  if (layout.type === 'leaf') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const content = layout.pane.content as any
+    if (content.kind === 'session') {
+      return {
+        ...layout,
+        pane: { ...layout.pane, content: { ...content, kind: 'tmux-session' } },
+      }
+    }
+    return layout
+  }
+  return { ...layout, children: layout.children.map(migrateLayout) }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function migrateTabStore(state: any, version: number): any {
+  if (version < 2) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tabs: Record<string, any> = {}
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const [id, tab] of Object.entries(state.tabs as Record<string, any>)) {
+      tabs[id] = { ...tab, layout: migrateLayout(tab.layout) }
+    }
+    return { ...state, tabs }
+  }
+  return state
+}
 
 interface TabState {
   tabs: Record<string, Tab>
@@ -158,7 +191,8 @@ export const useTabStore = create<TabState>()(
     {
       name: STORAGE_KEYS.TABS,
       storage: purdexStorage,
-      version: 1,
+      version: 2,
+      migrate: migrateTabStore,
       partialize: (state) => ({
         tabs: state.tabs,
         tabOrder: state.tabOrder,

--- a/spa/src/stores/useTabStore.ts
+++ b/spa/src/stores/useTabStore.ts
@@ -88,9 +88,9 @@ export const useTabStore = create<TabState>()(
           const tab = state.tabs[tabId]
           if (!tab) return state
           const pane = findPane(tab.layout, paneId)
-          if (!pane || pane.content.kind !== 'session') return state
+          if (!pane || pane.content.kind !== 'tmux-session') return state
           const newLayout = updatePaneInLayout(tab.layout, paneId, {
-            kind: 'session',
+            kind: 'tmux-session',
             hostId: pane.content.hostId,
             sessionCode: pane.content.sessionCode,
             mode,
@@ -144,7 +144,7 @@ export const useTabStore = create<TabState>()(
           for (const [id, tab] of Object.entries(tabs)) {
             const primary = getPrimaryPane(tab.layout)
             const c = primary.content
-            if (c.kind === 'session' && c.hostId === hostId && c.sessionCode === sessionCode && c.cachedName !== cachedName) {
+            if (c.kind === 'tmux-session' && c.hostId === hostId && c.sessionCode === sessionCode && c.cachedName !== cachedName) {
               tabs[id] = {
                 ...tab,
                 layout: updatePaneInLayout(tab.layout, primary.id, { ...c, cachedName }),

--- a/spa/src/stores/useTabStore.ts
+++ b/spa/src/stores/useTabStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { Tab, PaneContent, PaneLayout } from '../types/tab'
+import type { Tab, PaneContent, PaneLayout, TerminatedReason } from '../types/tab'
 import { createTab } from '../types/tab'
 import { getPrimaryPane, findPane, updatePaneInLayout } from '../lib/pane-tree'
 import { contentMatches } from '../lib/pane-utils'
@@ -39,6 +39,32 @@ export function migrateTabStore(state: any, version: number): any {
   return state
 }
 
+// --- Terminated marking helpers ---
+
+function markPanesInLayout(layout: PaneLayout, hostId: string, sessionCode: string, reason: TerminatedReason): PaneLayout {
+  if (layout.type === 'leaf') {
+    const c = layout.pane.content
+    if (c.kind === 'tmux-session' && c.hostId === hostId && c.sessionCode === sessionCode && !c.terminated) {
+      return { ...layout, pane: { ...layout.pane, content: { ...c, terminated: reason } } }
+    }
+    return layout
+  }
+  const children = layout.children.map((child) => markPanesInLayout(child, hostId, sessionCode, reason))
+  return children.some((c, i) => c !== layout.children[i]) ? { ...layout, children } : layout
+}
+
+function markHostPanesInLayout(layout: PaneLayout, hostId: string, reason: TerminatedReason): PaneLayout {
+  if (layout.type === 'leaf') {
+    const c = layout.pane.content
+    if (c.kind === 'tmux-session' && c.hostId === hostId && !c.terminated) {
+      return { ...layout, pane: { ...layout.pane, content: { ...c, terminated: reason } } }
+    }
+    return layout
+  }
+  const children = layout.children.map((child) => markHostPanesInLayout(child, hostId, reason))
+  return children.some((c, i) => c !== layout.children[i]) ? { ...layout, children } : layout
+}
+
 interface TabState {
   tabs: Record<string, Tab>
   tabOrder: string[]
@@ -56,6 +82,8 @@ interface TabState {
   togglePin: (id: string) => void
   toggleLock: (id: string) => void
   updateSessionCache: (hostId: string, sessionCode: string, cachedName: string) => void
+  markTerminated: (hostId: string, sessionCode: string, reason: TerminatedReason) => void
+  markHostTerminated: (hostId: string, reason: TerminatedReason) => void
 }
 
 export const useTabStore = create<TabState>()(
@@ -182,6 +210,34 @@ export const useTabStore = create<TabState>()(
                 ...tab,
                 layout: updatePaneInLayout(tab.layout, primary.id, { ...c, cachedName }),
               }
+              changed = true
+            }
+          }
+          return changed ? { tabs } : state
+        }),
+
+      markTerminated: (hostId, sessionCode, reason) =>
+        set((state) => {
+          let changed = false
+          const tabs = { ...state.tabs }
+          for (const [id, tab] of Object.entries(tabs)) {
+            const newLayout = markPanesInLayout(tab.layout, hostId, sessionCode, reason)
+            if (newLayout !== tab.layout) {
+              tabs[id] = { ...tab, layout: newLayout }
+              changed = true
+            }
+          }
+          return changed ? { tabs } : state
+        }),
+
+      markHostTerminated: (hostId, reason) =>
+        set((state) => {
+          let changed = false
+          const tabs = { ...state.tabs }
+          for (const [id, tab] of Object.entries(tabs)) {
+            const newLayout = markHostPanesInLayout(tab.layout, hostId, reason)
+            if (newLayout !== tab.layout) {
+              tabs[id] = { ...tab, layout: newLayout }
               changed = true
             }
           }

--- a/spa/src/stores/useUndoToast.test.ts
+++ b/spa/src/stores/useUndoToast.test.ts
@@ -1,0 +1,38 @@
+// spa/src/stores/useUndoToast.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useUndoToast } from './useUndoToast'
+
+describe('useUndoToast', () => {
+  beforeEach(() => {
+    useUndoToast.setState({ toast: null })
+  })
+
+  it('starts with null toast', () => {
+    expect(useUndoToast.getState().toast).toBeNull()
+  })
+
+  it('show sets toast', () => {
+    const restore = vi.fn()
+    useUndoToast.getState().show('Deleted host', restore)
+    const toast = useUndoToast.getState().toast
+    expect(toast).not.toBeNull()
+    expect(toast!.message).toBe('Deleted host')
+    expect(toast!.restore).toBe(restore)
+  })
+
+  it('dismiss clears toast', () => {
+    useUndoToast.getState().show('msg', vi.fn())
+    useUndoToast.getState().dismiss()
+    expect(useUndoToast.getState().toast).toBeNull()
+  })
+
+  it('calling show again replaces previous toast', () => {
+    const restore1 = vi.fn()
+    const restore2 = vi.fn()
+    useUndoToast.getState().show('first', restore1)
+    useUndoToast.getState().show('second', restore2)
+    const toast = useUndoToast.getState().toast
+    expect(toast!.message).toBe('second')
+    expect(toast!.restore).toBe(restore2)
+  })
+})

--- a/spa/src/stores/useUndoToast.ts
+++ b/spa/src/stores/useUndoToast.ts
@@ -1,0 +1,14 @@
+// spa/src/stores/useUndoToast.ts — Global undo toast state
+import { create } from 'zustand'
+
+interface UndoToastState {
+  toast: { message: string; restore: () => void } | null
+  show: (message: string, restore: () => void) => void
+  dismiss: () => void
+}
+
+export const useUndoToast = create<UndoToastState>()((set) => ({
+  toast: null,
+  show: (message, restore) => set({ toast: { message, restore } }),
+  dismiss: () => set({ toast: null }),
+}))

--- a/spa/src/types/electron.d.ts
+++ b/spa/src/types/electron.d.ts
@@ -67,8 +67,8 @@ interface Window {
     onMetricsUpdate: (callback: (metrics: ElectronTabMetrics[]) => void) => () => void
 
     // Notifications
-    showNotification: (opts: { title: string; body: string; sessionCode: string; eventName: string; broadcastTs: number }) => Promise<void>
-    onNotificationClicked: (callback: (payload: { sessionCode: string }) => void) => () => void
+    showNotification: (opts: { title: string; body: string; sessionCode: string; eventName: string; broadcastTs: number; action?: { kind: string; hostId: string; sessionCode?: string } }) => Promise<void>
+    onNotificationClicked: (callback: (payload: { sessionCode: string; action?: { kind: string; hostId: string; sessionCode?: string } }) => void) => () => void
     focusMyWindow: () => void
 
     // Dev Update

--- a/spa/src/types/tab.test.ts
+++ b/spa/src/types/tab.test.ts
@@ -3,7 +3,7 @@ import { createTab, createWorkspace, isStandaloneTab } from './tab'
 
 describe('createTab', () => {
   it('creates a tab with session content', () => {
-    const tab = createTab({ kind: 'session', hostId: 'test-host', sessionCode: 'abc123', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'abc123', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     expect(tab.id).toMatch(/^[0-9a-z]{6}$/)
     expect(tab.pinned).toBe(false)
     expect(tab.locked).toBe(false)
@@ -11,7 +11,7 @@ describe('createTab', () => {
     expect(tab.layout.type).toBe('leaf')
     if (tab.layout.type === 'leaf') {
       expect(tab.layout.pane.id).toMatch(/^[0-9a-z]{6}$/)
-      expect(tab.layout.pane.content).toEqual({ kind: 'session', hostId: 'test-host', sessionCode: 'abc123', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+      expect(tab.layout.pane.content).toEqual({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'abc123', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     }
   })
 
@@ -53,13 +53,13 @@ describe('createWorkspace', () => {
 
 describe('isStandaloneTab', () => {
   it('returns true when tab is not in any workspace', () => {
-    const tab = createTab({ kind: 'session', hostId: 'test-host', sessionCode: 'abc', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    const tab = createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'abc', mode: 'terminal', cachedName: '', tmuxInstance: '' })
     const workspaces = [createWorkspace('WS1')]
     expect(isStandaloneTab(tab.id, workspaces)).toBe(true)
   })
 
   it('returns false when tab is in a workspace', () => {
-    const tab = createTab({ kind: 'session', hostId: 'test-host', sessionCode: 'xyz', mode: 'stream', cachedName: '', tmuxInstance: '' })
+    const tab = createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'xyz', mode: 'stream', cachedName: '', tmuxInstance: '' })
     const ws = createWorkspace('WS1')
     ws.tabs = [tab.id]
     expect(isStandaloneTab(tab.id, [ws])).toBe(false)

--- a/spa/src/types/tab.ts
+++ b/spa/src/types/tab.ts
@@ -21,9 +21,11 @@ export interface Pane {
 }
 
 // === Pane Content (discriminated union) ===
+export type TerminatedReason = 'session-closed' | 'tmux-restarted' | 'host-removed'
+
 export type PaneContent =
   | { kind: 'new-tab' }
-  | { kind: 'session'; hostId: string; sessionCode: string; mode: 'terminal' | 'stream'; cachedName: string; tmuxInstance: string }
+  | { kind: 'tmux-session'; hostId: string; sessionCode: string; mode: 'terminal' | 'stream'; cachedName: string; tmuxInstance: string; terminated?: TerminatedReason }
   | { kind: 'dashboard' }
   | { kind: 'hosts' }
   | { kind: 'history' }


### PR DESCRIPTION
## Summary

- **Tab 狀態模型**：PaneContent `kind: 'session'` → `kind: 'tmux-session'`（含 Zustand persist migration v1→v2），新增 `terminated?: TerminatedReason` 欄位（event-sourced）
- **TerminatedPane 錯誤頁**：session 關閉 / tmux 重啟 / host 刪除三種情境，顯示對應訊息 + 關閉按鈕 + 跨 host SessionPickerList
- **Host 層級 L1-L3 錯誤 UI**：StatusBar / HostSidebar / OverviewSection / SessionsSection 各自顯示錯誤狀態
- **useHostConnection hook**：封裝 ConnectionStateMachine 存取，提供 `manualRetry()` 給 Reconnecting Overlay 手動重連按鈕
- **Host 刪除 cascade**：checkbox 選擇是否關閉分頁 + 多 store cascade cleanup（AgentStore.removeHost + StreamStore.clearHost）+ undo toast（5s snapshot 復原）
- **NotificationAction 模組化**：click handler 改為 action payload 模式，新增 L2/L3 連線狀態系統通知
- **Bug fixes**：#156 AddHostDialog L1/L2/401 錯誤提示、#140 TokenField 空值驗證、health timeout 3s→6s

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-04-04-phase4-error-ui-design.md`
- Plan: `docs/superpowers/plans/2026-04-04-phase4-error-ui.md`

## Test plan

- [ ] `cd spa && npx vitest run` — 803 passed（1 pre-existing failure）
- [ ] `cd spa && pnpm run lint`
- [ ] `cd spa && pnpm run build`
- [ ] Locale completeness test 通過
- [ ] 手動測試：開啟 terminal tab → 關閉 tmux session → tab 顯示 TerminatedPane
- [ ] 手動測試：刪除 host → checkbox + cascade + undo toast
- [ ] 手動測試：daemon 離線 → L1/L2 錯誤 UI + 手動重連按鈕