### PR TITLE
feat: Phase 5b — WS Ticket 統一 + Auth Error UI (#148, #167)

### DIFF
--- a/docs/superpowers/plans/2026-04-06-phase5b-ws-ticket-auth-error.md
+++ b/docs/superpowers/plans/2026-04-06-phase5b-ws-ticket-auth-error.md
@@ -1,0 +1,1245 @@
+# Phase 5b: WS Ticket 統一 + Auth Error UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 統一三條 WS 的 ticket auth、修正狀態機 auth 死循環、新增 auth-error UI、消費 health mode 欄位。
+
+**Architecture:** Negotiation-First — 狀態機的 checkFn 升級為兩階段 negotiation（health + ws-ticket），同時驗證 reachability + auth。connectHostEvents 以 lazy mode 啟動，由狀態機觸發首次連線。Terminal/Stream WS 各自取 ticket。
+
+**Tech Stack:** React 19 / Zustand 5 / Vitest / Go net/http middleware / Phosphor Icons
+
+**Spec:** `docs/superpowers/specs/2026-04-06-phase5b-ws-ticket-auth-error-design.md`
+
+---
+
+### Task 1: Go — 移除 `?token=` legacy fallback
+
+**Files:**
+- Modify: `internal/middleware/middleware.go:79-83`
+- Modify: `internal/middleware/middleware_test.go:80-88`
+
+- [ ] **Step 1: 修改 Go test 為驗證 401**
+
+```go
+// internal/middleware/middleware_test.go — 把 TestTokenAuthQueryParam 改為：
+func TestTokenAuthQueryParamRemoved(t *testing.T) {
+	h := middleware.TokenAuth(func() string { return "secret" }, nil)(ok)
+	req := httptest.NewRequest("GET", "/?token=secret", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 401 {
+		t.Errorf("want 401 for removed query param token, got %d", rec.Code)
+	}
+}
+```
+
+- [ ] **Step 2: 執行 test 確認失敗**
+
+Run: `cd /Users/wake/Workspace/wake/tmux-box && go test ./internal/middleware/ -run TestTokenAuthQueryParamRemoved -v`
+Expected: FAIL（目前 ?token= 仍生效，回傳 200）
+
+- [ ] **Step 3: 刪除 middleware.go 的 ?token= fallback**
+
+刪除 `internal/middleware/middleware.go` 第 79-83 行：
+```go
+// 刪除以下段落：
+// Fallback: ?token= query param (legacy, will be removed)
+if subtle.ConstantTimeCompare([]byte(r.URL.Query().Get("token")), []byte(token)) == 1 {
+    next.ServeHTTP(w, r)
+    return
+}
+```
+
+- [ ] **Step 4: 執行 test 確認通過**
+
+Run: `go test ./internal/middleware/ -v`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/middleware/middleware.go internal/middleware/middleware_test.go
+git commit -m "feat(middleware): remove legacy ?token= query param fallback"
+```
+
+---
+
+### Task 2: checkHealth 兩階段 + HealthResult 擴充
+
+**Files:**
+- Modify: `spa/src/lib/host-connection.ts`
+- Modify: `spa/src/lib/host-connection.test.ts`
+
+- [ ] **Step 1: 寫 10 個 failing tests**
+
+```typescript
+// spa/src/lib/host-connection.test.ts — 替換整個檔案內容
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { checkHealth } from './host-connection'
+
+function healthResponse(mode = 'normal') {
+  return new Response(JSON.stringify({ ok: true, mode }), { status: 200 })
+}
+function ticketResponse(ticket = 'tk_abc') {
+  return new Response(JSON.stringify({ ticket }), { status: 200 })
+}
+
+describe('checkHealth', () => {
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('Phase 1 only: no token, non-pairing → auth-error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(healthResponse('normal'))
+    const result = await checkHealth('http://localhost:7860')
+    expect(result.daemon).toBe('auth-error')
+    expect(result.mode).toBe('normal')
+    expect(fetch).toHaveBeenCalledTimes(1) // Phase 2 skipped
+  })
+
+  it('Phase 1 only: no token, pairing mode → connected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(healthResponse('pairing'))
+    const result = await checkHealth('http://localhost:7860')
+    expect(result.daemon).toBe('connected')
+    expect(result.mode).toBe('pairing')
+  })
+
+  it('Phase 2 success: connected + ticket', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(ticketResponse('tk_123'))
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('connected')
+    expect(result.ticket).toBe('tk_123')
+    expect(result.mode).toBe('normal')
+  })
+
+  it('Phase 2 returns 401 → auth-error', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(new Response('unauthorized', { status: 401 }))
+    const result = await checkHealth('http://localhost:7860', () => 'badtoken')
+    expect(result.daemon).toBe('auth-error')
+  })
+
+  it('Phase 2 returns 503 (PairingGuard) → auth-error', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(new Response('pairing_mode', { status: 503 }))
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('auth-error')
+  })
+
+  it('Phase 2 network error → fallback connected', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('connected')
+    expect(result.ticket).toBeUndefined()
+  })
+
+  it('Phase 1 timeout → unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      Object.assign(new Error('signal is aborted'), { name: 'AbortError' })
+    )
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('unreachable')
+    expect(result.latency).toBeNull()
+  })
+
+  it('Phase 1 network error → refused', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'))
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('refused')
+  })
+
+  it('mode field parsed from health response', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse('pending'))
+      .mockResolvedValueOnce(ticketResponse())
+    const result = await checkHealth('http://localhost:7860', () => 'tok')
+    expect(result.mode).toBe('pending')
+  })
+
+  it('latency measured from Phase 1', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(ticketResponse())
+    const result = await checkHealth('http://localhost:7860', () => 'tok')
+    expect(result.latency).toBeGreaterThanOrEqual(0)
+  })
+})
+```
+
+- [ ] **Step 2: 執行 test 確認失敗**
+
+Run: `cd spa && npx vitest run src/lib/host-connection.test.ts`
+Expected: FAIL（checkHealth 簽名不符 + 無 auth-error 等新值）
+
+- [ ] **Step 3: 實作 checkHealth 兩階段**
+
+將 `spa/src/lib/host-connection.ts` 替換為 spec 3.2 的完整實作：
+
+```typescript
+// spa/src/lib/host-connection.ts — Health check with two-phase negotiation
+
+export interface HealthResult {
+  daemon: 'connected' | 'refused' | 'unreachable' | 'auth-error'
+  tmux: 'ok' | 'unavailable'
+  latency: number | null
+  mode: 'pairing' | 'pending' | 'normal'
+  ticket?: string
+}
+
+const PHASE1_TIMEOUT_MS = 6000
+const PHASE2_TIMEOUT_MS = 5000
+
+export async function checkHealth(
+  baseUrl: string,
+  getToken?: () => string | undefined,
+): Promise<HealthResult> {
+  const ctrl1 = new AbortController()
+  const timer1 = setTimeout(() => ctrl1.abort(), PHASE1_TIMEOUT_MS)
+  try {
+    const start = performance.now()
+    const res = await fetch(`${baseUrl}/api/health`, { signal: ctrl1.signal })
+    const latency = Math.round(performance.now() - start)
+    const body = await res.json()
+    const mode = (body.mode ?? 'normal') as 'pairing' | 'pending' | 'normal'
+
+    const token = getToken?.()
+    if (!token) {
+      if (mode === 'pairing') {
+        return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+      }
+      return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
+    }
+
+    const ctrl2 = new AbortController()
+    const timer2 = setTimeout(() => ctrl2.abort(), PHASE2_TIMEOUT_MS)
+    try {
+      const ticketRes = await fetch(`${baseUrl}/api/ws-ticket`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        signal: ctrl2.signal,
+      })
+      if (ticketRes.status === 401) {
+        return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
+      }
+      if (ticketRes.status === 503) {
+        return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
+      }
+      if (!ticketRes.ok) {
+        return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+      }
+      const { ticket } = await ticketRes.json()
+      return { daemon: 'connected', tmux: 'unavailable', latency, mode, ticket }
+    } catch {
+      return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+    } finally {
+      clearTimeout(timer2)
+    }
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { daemon: 'unreachable', tmux: 'unavailable', latency: null, mode: 'normal' }
+    }
+    return { daemon: 'refused', tmux: 'unavailable', latency: null, mode: 'normal' }
+  } finally {
+    clearTimeout(timer1)
+  }
+}
+```
+
+- [ ] **Step 4: 執行 test 確認通過**
+
+Run: `cd spa && npx vitest run src/lib/host-connection.test.ts`
+Expected: 10 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/lib/host-connection.ts spa/src/lib/host-connection.test.ts
+git commit -m "feat: checkHealth two-phase negotiation (health + ws-ticket)"
+```
+
+---
+
+### Task 3: ConnectionStateMachine auth-error 分支
+
+**Files:**
+- Modify: `spa/src/lib/connection-state-machine.ts`
+- Modify: `spa/src/lib/connection-state-machine.test.ts`
+
+- [ ] **Step 1: 寫 3 個 failing tests**
+
+在 `connection-state-machine.test.ts` 末尾 `})` 前新增：
+
+```typescript
+  it('auth-error exits FAST_RETRY on first attempt', async () => {
+    checkFn.mockResolvedValue({ daemon: 'auth-error', tmux: 'unavailable', latency: 5, mode: 'normal' })
+    sm = new ConnectionStateMachine(checkFn, onStateChange)
+    await sm.trigger()
+    expect(checkFn).toHaveBeenCalledTimes(1) // not 3
+    expect(onStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({ daemon: 'auth-error' })
+    )
+  })
+
+  it('auth-error does not start background retry', async () => {
+    checkFn.mockResolvedValue({ daemon: 'auth-error', tmux: 'unavailable', latency: 5, mode: 'normal' })
+    sm = new ConnectionStateMachine(checkFn, onStateChange)
+    await sm.trigger()
+    const countAfter = checkFn.mock.calls.length
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(checkFn.mock.calls.length).toBe(countAfter) // no background retries
+  })
+
+  it('manual trigger recovers from auth-error', async () => {
+    checkFn.mockResolvedValue({ daemon: 'auth-error', tmux: 'unavailable', latency: 5, mode: 'normal' })
+    sm = new ConnectionStateMachine(checkFn, onStateChange)
+    await sm.trigger()
+    checkFn.mockResolvedValue({ daemon: 'connected', tmux: 'ok', latency: 3, mode: 'normal' })
+    await sm.trigger()
+    const lastCall = onStateChange.mock.calls[onStateChange.mock.calls.length - 1][0]
+    expect(lastCall.daemon).toBe('connected')
+  })
+```
+
+- [ ] **Step 2: 執行 test 確認失敗**
+
+Run: `cd spa && npx vitest run src/lib/connection-state-machine.test.ts`
+Expected: 新增的 3 個 test FAIL（auth-error 未被 FAST_RETRY 特殊處理）
+
+- [ ] **Step 3: 實作 auth-error 分支**
+
+修改 `spa/src/lib/connection-state-machine.ts` 的 `trigger()` 方法，在 FAST_RETRY 迴圈內加入 auth-error 短路：
+
+```typescript
+  // 在 FAST_RETRY 迴圈裡，connected return 的後面加：
+  if (lastResult.daemon === 'connected') {
+    return // recovered
+  }
+  if (lastResult.daemon === 'auth-error') {
+    return // permanent error, don't retry
+  }
+```
+
+- [ ] **Step 4: 執行全部 test 確認通過**
+
+Run: `cd spa && npx vitest run src/lib/connection-state-machine.test.ts`
+Expected: 全部 PASS（含原有 9 + 新增 3 = 12 tests）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/lib/connection-state-machine.ts spa/src/lib/connection-state-machine.test.ts
+git commit -m "feat: ConnectionStateMachine auth-error branch (no retry)"
+```
+
+---
+
+### Task 4: HostRuntime 型別 + host-utils + i18n
+
+**Files:**
+- Modify: `spa/src/stores/useHostStore.ts:17-24`
+- Modify: `spa/src/lib/host-utils.ts`
+- Modify: `spa/src/lib/host-utils.test.ts`
+- Modify: `spa/src/locales/zh-TW.json`
+- Modify: `spa/src/locales/en.json`
+
+- [ ] **Step 1: 寫 failing test**
+
+在 `spa/src/lib/host-utils.test.ts` 末尾 `})` 前新增：
+
+```typescript
+  it('returns auth error message for auth-error status', () => {
+    const runtime: HostRuntime = { status: 'auth-error', daemonState: 'auth-error' }
+    expect(connectionErrorMessage(runtime, t)).toBe('hosts.error_auth')
+  })
+```
+
+- [ ] **Step 2: 執行 test 確認失敗**
+
+Run: `cd spa && npx vitest run src/lib/host-utils.test.ts`
+Expected: FAIL（TypeScript: 'auth-error' 不在 status union type 中）
+
+- [ ] **Step 3: 擴充 HostRuntime 型別**
+
+修改 `spa/src/stores/useHostStore.ts`：
+
+```typescript
+export interface HostRuntime {
+  status: 'connected' | 'disconnected' | 'reconnecting' | 'auth-error'
+  latency?: number
+  info?: HostInfo
+  daemonState?: 'connected' | 'refused' | 'unreachable' | 'auth-error'
+  tmuxState?: 'ok' | 'unavailable'
+  manualRetry?: () => void
+}
+```
+
+- [ ] **Step 4: 擴充 connectionErrorMessage**
+
+修改 `spa/src/lib/host-utils.ts`，在函式開頭加入 auth-error 檢查：
+
+```typescript
+export function connectionErrorMessage(
+  runtime: HostRuntime | undefined,
+  t: (key: string) => string,
+): string | null {
+  if (runtime?.status === 'auth-error') return t('hosts.error_auth')
+  if (!runtime || runtime.status !== 'connected') {
+    if (runtime?.daemonState === 'unreachable') return t('hosts.error_unreachable')
+    if (runtime?.daemonState === 'refused') return t('hosts.error_refused')
+    return null
+  }
+  if (runtime.tmuxState === 'unavailable') return t('hosts.error_tmux_down')
+  return null
+}
+```
+
+- [ ] **Step 5: 新增 i18n keys**
+
+在 `spa/src/locales/zh-TW.json` 的 `hosts.error_tmux_down` 後新增：
+
+```json
+  "hosts.error_auth": "Token 無效，請確認 Token 與 daemon 設定一致",
+  "hosts.auth_error": "Token 無效",
+  "hosts.auth_error_hint": "請確認 Token 與 daemon 設定一致，修改後自動重新連線",
+  "status.auth_error": "Token 無效，點擊設定",
+```
+
+在 `spa/src/locales/en.json` 對應位置新增：
+
+```json
+  "hosts.error_auth": "Invalid token — check that the token matches the daemon config",
+  "hosts.auth_error": "Invalid token",
+  "hosts.auth_error_hint": "Verify the token matches the daemon config. Changes reconnect automatically.",
+  "status.auth_error": "Invalid token — click to configure",
+```
+
+- [ ] **Step 6: 執行 test 確認通過**
+
+Run: `cd spa && npx vitest run src/lib/host-utils.test.ts`
+Expected: 全部 PASS（含新增 1 case）
+
+- [ ] **Step 7: Lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: 無新增 error
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add spa/src/stores/useHostStore.ts spa/src/lib/host-utils.ts spa/src/lib/host-utils.test.ts spa/src/locales/zh-TW.json spa/src/locales/en.json
+git commit -m "feat: HostRuntime auth-error type + connectionErrorMessage + i18n keys"
+```
+
+---
+
+### Task 5: connectHostEvents — lazy mode + reconnectWithTicket
+
+**Files:**
+- Modify: `spa/src/lib/host-events.ts`
+- Create: `spa/src/lib/host-events.test.ts`
+
+- [ ] **Step 1: 寫 failing tests**
+
+```typescript
+// spa/src/lib/host-events.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { connectHostEvents } from './host-events'
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 3
+  readyState = MockWebSocket.CONNECTING
+  binaryType = ''
+  url: string
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onmessage: ((e: { data: unknown }) => void) | null = null
+  onerror: (() => void) | null = null
+  send = vi.fn()
+  close = vi.fn(() => { this.readyState = MockWebSocket.CLOSED; this.onclose?.() })
+  simulateOpen() { this.readyState = MockWebSocket.OPEN; this.onopen?.() }
+  constructor(url: string) { this.url = url; wsInstances.push(this) }
+}
+
+let wsInstances: MockWebSocket[] = []
+
+beforeEach(() => {
+  wsInstances = []
+  vi.stubGlobal('WebSocket', MockWebSocket)
+})
+afterEach(() => { vi.unstubAllGlobals() })
+
+describe('connectHostEvents', () => {
+  it('lazy mode does not connect immediately', () => {
+    connectHostEvents('ws://test/ws/host-events', vi.fn(), undefined, undefined, undefined, false, true)
+    expect(wsInstances).toHaveLength(0)
+  })
+
+  it('reconnectWithTicket creates WS with ticket in URL', async () => {
+    const conn = connectHostEvents('ws://test/ws/host-events', vi.fn(), undefined, undefined, undefined, false, true)
+    conn.reconnectWithTicket('tk_pre')
+    await vi.dynamicImportSettled?.() // flush microtasks
+    await new Promise((r) => setTimeout(r, 0))
+    expect(wsInstances).toHaveLength(1)
+    expect(wsInstances[0].url).toContain('ticket=tk_pre')
+  })
+
+  it('pendingTicket is consumed once, second connect falls back to getTicket', async () => {
+    const getTicket = vi.fn().mockResolvedValue('tk_callback')
+    const conn = connectHostEvents('ws://test/ws/host-events', vi.fn(), undefined, undefined, getTicket, false, true)
+    conn.reconnectWithTicket('tk_once')
+    await new Promise((r) => setTimeout(r, 0))
+    expect(wsInstances[0].url).toContain('ticket=tk_once')
+    // Simulate WS close → reconnect without pendingTicket
+    wsInstances[0].close()
+    conn.reconnect()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(getTicket).toHaveBeenCalled()
+    expect(wsInstances[1].url).toContain('ticket=tk_callback')
+  })
+
+  it('getTicket failure with no pendingTicket calls onClose', async () => {
+    const onClose = vi.fn()
+    const getTicket = vi.fn().mockRejectedValue(new Error('401'))
+    const conn = connectHostEvents('ws://test/ws/host-events', vi.fn(), onClose, undefined, getTicket, false, true)
+    conn.reconnect()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onClose).toHaveBeenCalled()
+    expect(wsInstances).toHaveLength(0) // no WS created
+  })
+
+  it('connecting flag prevents concurrent connect calls', async () => {
+    const getTicket = vi.fn().mockImplementation(() => new Promise((r) => setTimeout(() => r('tk'), 100)))
+    const conn = connectHostEvents('ws://test/ws/host-events', vi.fn(), undefined, undefined, getTicket, false, true)
+    conn.reconnect()
+    conn.reconnect() // second call while first is awaiting getTicket
+    await new Promise((r) => setTimeout(r, 150))
+    expect(getTicket).toHaveBeenCalledTimes(1) // only one connect ran
+  })
+})
+```
+
+- [ ] **Step 2: 執行 test 確認失敗**
+
+Run: `cd spa && npx vitest run src/lib/host-events.test.ts`
+Expected: FAIL（connectHostEvents 無 lazy 參數、無 reconnectWithTicket）
+
+- [ ] **Step 3: 實作 connectHostEvents 改動**
+
+修改 `spa/src/lib/host-events.ts`，按 spec 4.2 實作 lazy mode、connecting flag、pendingTicket、reconnectWithTicket。完整替換：
+
+```typescript
+// spa/src/lib/host-events.ts
+
+export interface HostEvent {
+  type: 'handoff' | 'relay' | 'hook' | 'sessions' | 'tmux'
+  session: string
+  value: string
+}
+
+export interface EventConnection {
+  close: () => void
+  reconnect: () => void
+  reconnectWithTicket: (ticket?: string) => void
+}
+
+export function connectHostEvents(
+  url: string,
+  onEvent: (event: HostEvent) => void,
+  onClose?: () => void,
+  onOpen?: () => void,
+  getTicket?: () => Promise<string>,
+  autoReconnect = true,
+  lazy = false,
+): EventConnection {
+  let ws: WebSocket
+  let retryMs = 1000
+  let closed = false
+  let connecting = false
+  let pendingTicket: string | undefined
+
+  async function connect() {
+    if (connecting) return
+    connecting = true
+    try {
+      let wsUrl = url
+      const ticket = pendingTicket ?? (getTicket ? await getTicket().catch(() => null) : null)
+      pendingTicket = undefined
+
+      if (ticket) {
+        const u = new URL(wsUrl)
+        u.searchParams.set('ticket', ticket)
+        wsUrl = u.toString()
+      } else if (getTicket) {
+        if (!closed) onClose?.()
+        return
+      }
+
+      ws = new WebSocket(wsUrl)
+      ws.onopen = () => { retryMs = 1000; onOpen?.() }
+      ws.onmessage = (e) => {
+        try {
+          const event = JSON.parse(e.data) as HostEvent
+          onEvent(event)
+        } catch { /* ignore parse errors */ }
+      }
+      ws.onerror = () => {}
+      ws.onclose = () => {
+        if (closed) return
+        onClose?.()
+        if (autoReconnect) {
+          setTimeout(() => { if (!closed) connect() }, retryMs)
+          retryMs = Math.min(retryMs * 2, 30000)
+        }
+      }
+    } finally {
+      connecting = false
+    }
+  }
+
+  if (!lazy) connect()
+  return {
+    close: () => { closed = true; ws?.close() },
+    reconnect: () => { if (!closed) { retryMs = 1000; ws?.close(); connect() } },
+    reconnectWithTicket: (ticket) => {
+      if (!closed) {
+        pendingTicket = ticket
+        retryMs = 1000
+        ws?.close()
+        connect()
+      }
+    },
+  }
+}
+```
+
+- [ ] **Step 4: 執行 test 確認通過**
+
+Run: `cd spa && npx vitest run src/lib/host-events.test.ts`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/lib/host-events.ts spa/src/lib/host-events.test.ts
+git commit -m "feat: connectHostEvents lazy mode + reconnectWithTicket"
+```
+
+---
+
+### Task 6: connectTerminal — getTicket 參數
+
+**Files:**
+- Modify: `spa/src/lib/ws.ts`
+- Modify: `spa/src/lib/ws.test.ts`
+
+- [ ] **Step 1: 修改 MockWebSocket 記錄 URL + 寫 3 個 failing tests**
+
+在 `ws.test.ts` 的 MockWebSocket constructor 加入 URL：
+```typescript
+// 改為：
+vi.stubGlobal('WebSocket', class extends MockWebSocket {
+  constructor(url: string) {
+    super()
+    this.url = url
+    wsInstances.push(this)
+  }
+})
+```
+
+MockWebSocket class 加入 `url = ''`。
+
+在檔案末尾新增測試：
+
+```typescript
+describe('connectTerminal with getTicket', () => {
+  it('appends ticket to WS URL on success', async () => {
+    const getTicket = vi.fn().mockResolvedValue('tk_term')
+    connectTerminal('ws://test/ws/terminal/abc', vi.fn(), vi.fn(), undefined, undefined, getTicket)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(wsInstances[0].url).toContain('ticket=tk_term')
+  })
+
+  it('retries with backoff on getTicket failure', async () => {
+    const getTicket = vi.fn().mockRejectedValue(new Error('401'))
+    const onClose = vi.fn()
+    connectTerminal('ws://test/ws/terminal/abc', vi.fn(), onClose, undefined, undefined, getTicket)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(wsInstances).toHaveLength(0) // no WS created
+    expect(onClose).not.toHaveBeenCalled() // no onClose — self backoff
+    // After 1s backoff, retry
+    getTicket.mockResolvedValueOnce('tk_retry')
+    await vi.advanceTimersByTimeAsync(1100)
+    expect(wsInstances).toHaveLength(1)
+    expect(wsInstances[0].url).toContain('ticket=tk_retry')
+  })
+
+  it('stops retrying when canReconnect returns false', async () => {
+    const getTicket = vi.fn().mockRejectedValue(new Error('401'))
+    connectTerminal('ws://test/ws/terminal/abc', vi.fn(), vi.fn(), undefined, () => false, getTicket)
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(1100)
+    expect(getTicket).toHaveBeenCalledTimes(1) // no retry
+  })
+})
+```
+
+- [ ] **Step 2: 執行 test 確認失敗**
+
+Run: `cd spa && npx vitest run src/lib/ws.test.ts`
+Expected: 新增的 3 個 test FAIL
+
+- [ ] **Step 3: 實作 connectTerminal getTicket**
+
+修改 `spa/src/lib/ws.ts`，`connectTerminal` 加入 `getTicket` 參數，`connect()` 改為 async，按 spec 4.3 實作。
+
+函式簽名改為：
+```typescript
+export function connectTerminal(
+  url: string,
+  onData: (data: ArrayBuffer) => void,
+  onClose: () => void,
+  onOpen?: () => void,
+  canReconnect?: () => boolean,
+  getTicket?: () => Promise<string>,
+): TerminalConnection {
+```
+
+`connect()` 改為 `async function connect()`，開頭加入：
+```typescript
+    let wsUrl = url
+    if (getTicket) {
+      try {
+        const ticket = await getTicket()
+        const u = new URL(wsUrl)
+        u.searchParams.set('ticket', ticket)
+        wsUrl = u.toString()
+      } catch {
+        setTimeout(() => {
+          if (closed) return
+          if (canReconnect && !canReconnect()) return
+          connect()
+        }, retryMs)
+        retryMs = Math.min(retryMs * 2, 30000)
+        return
+      }
+    }
+    ws = new WebSocket(wsUrl)
+```
+
+- [ ] **Step 4: 執行 test 確認通過**
+
+Run: `cd spa && npx vitest run src/lib/ws.test.ts`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/lib/ws.ts spa/src/lib/ws.test.ts
+git commit -m "feat: connectTerminal getTicket param for WS ticket auth"
+```
+
+---
+
+### Task 7: useMultiHostEventWs — 整合 negotiation + lazy connect
+
+**Files:**
+- Modify: `spa/src/hooks/useMultiHostEventWs.ts`
+
+- [ ] **Step 1: 修改 useMultiHostEventWs**
+
+核心改動：
+1. 狀態機 `checkFn` 傳入 `getToken` 動態 closure
+2. `connectHostEvents` 設 `lazy: true`
+3. `onStateChange` 用 statusMap 映射 + reconnectWithTicket/reconnect 分流
+4. 移除 `getTicket` 參數改由狀態機管理初始連線
+5. Effect 尾部加 `sm.trigger()`
+
+修改 `useMultiHostEventWs.ts` 中 per-host 迴圈內：
+
+```typescript
+      // --- Connection state machine (per host) ---
+      const connRef: { current: EventConnection | undefined } = { current: undefined }
+
+      const statusMap: Record<string, string> = {
+        connected: 'connected',
+        unreachable: 'disconnected',
+        refused: 'disconnected',
+        'auth-error': 'auth-error',
+      }
+
+      const sm = new ConnectionStateMachine(
+        () => checkHealth(baseUrl, () => useHostStore.getState().hosts[hostId]?.token),
+        (result) => {
+          useHostStore.getState().setRuntime(hostId, {
+            status: (statusMap[result.daemon] ?? 'disconnected') as HostRuntime['status'],
+            latency: result.latency ?? undefined,
+            daemonState: result.daemon,
+          })
+          // On recovery → reconnect WS with pre-fetched ticket
+          if (result.daemon === 'connected' && connRef.current) {
+            if (result.ticket) {
+              connRef.current.reconnectWithTicket(result.ticket)
+            } else {
+              connRef.current.reconnect()
+            }
+          }
+        },
+      )
+      stateMachines.set(hostId, sm)
+      useHostStore.getState().setRuntime(hostId, { manualRetry: () => sm.trigger() })
+
+      // --- WS connection (per host, lazy — waits for SM) ---
+      const conn = connectHostEvents(
+        wsUrl,
+        (event) => { /* ... 既有 event handler 不變 ... */ },
+        () => {
+          useHostStore.getState().setRuntime(hostId, { status: 'reconnecting' })
+          sm.trigger()
+        },
+        () => {
+          useHostStore.getState().setRuntime(hostId, {
+            status: 'connected',
+            daemonState: 'connected',
+          })
+          useAgentStore.getState().clearSubagentsForHost(hostId)
+          const daemonBase = useHostStore.getState().getDaemonBase(hostId)
+          useSessionStore.getState().fetchHost(hostId, daemonBase).catch(() => {})
+        },
+        () => fetchWsTicket(hostId),
+        false,  // autoReconnect = false
+        true,   // lazy = true
+      )
+      connRef.current = conn
+      connections.set(hostId, conn)
+
+      // Start negotiation — SM will trigger reconnectWithTicket on success
+      sm.trigger()
+```
+
+- [ ] **Step 2: 加入 HostRuntime type import**
+
+在 imports 區加入：`import type { HostRuntime } from '../stores/useHostStore'`
+
+- [ ] **Step 3: 執行 lint + test**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+Expected: lint 無 error，既有 test 全部 PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/hooks/useMultiHostEventWs.ts
+git commit -m "feat: useMultiHostEventWs negotiation-first + lazy connect"
+```
+
+---
+
+### Task 8: useRelayWsManager — 外層 ticket fetch
+
+**Files:**
+- Modify: `spa/src/hooks/useRelayWsManager.ts`
+
+- [ ] **Step 1: 修改 relay connected 分支**
+
+在 `useRelayWsManager.ts` 的 `if (connected && !wasConnected)` 分支內，把同步的 `connectStream` 改為先 await ticket。加入 `fetchWsTicket` import：
+
+```typescript
+import { fetchWsTicket } from '../lib/host-api'
+```
+
+改寫建立邏輯：
+
+```typescript
+          if (connected && !wasConnected) {
+            const wsBase = useHostStore.getState().getWsBase(hostId)
+
+            fetchWsTicket(hostId).then((ticket) => {
+              if (!useStreamStore.getState().relayStatus[ck]) return
+
+              const url = new URL(`${wsBase}/ws/cli-bridge-sub/${encodeURIComponent(sessionCode)}`)
+              url.searchParams.set('ticket', ticket)
+
+              const conn = connectStream(
+                url.toString(),
+                (msg: StreamMessage) => { /* ... 既有 onMessage 不變 ... */ },
+                () => {
+                  useStreamStore.getState().setConn(hostId, sessionCode, null)
+                  activeConns.delete(ck)
+                },
+              )
+              useStreamStore.getState().setConn(hostId, sessionCode, conn)
+              activeConns.set(ck, conn)
+            }).catch((err) => {
+              if (!(err instanceof Error && err.message.includes('ws-ticket'))) {
+                console.error('[useRelayWsManager] stream WS setup error', err)
+              }
+            })
+          }
+```
+
+- [ ] **Step 2: 執行 lint + test**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spa/src/hooks/useRelayWsManager.ts
+git commit -m "feat: useRelayWsManager ticket fetch before stream WS"
+```
+
+---
+
+### Task 9: SessionPaneContent — 傳入 getTicket
+
+**Files:**
+- Modify: `spa/src/components/SessionPaneContent.tsx`
+- Modify: `spa/src/hooks/useTerminalWs.ts`
+
+- [ ] **Step 1: useTerminalWs 加 getTicket prop**
+
+修改 `spa/src/hooks/useTerminalWs.ts`：
+
+介面加入 `getTicket?: () => Promise<string>`：
+```typescript
+interface UseTerminalWsOpts {
+  wsUrl: string
+  // ... 既有 props ...
+  hostId?: string
+  getTicket?: () => Promise<string>  // 新增
+  // ...
+}
+```
+
+解構時加入 `getTicket`，傳入 `connectTerminal`：
+```typescript
+    const conn = connectTerminal(
+      wsUrl,
+      (data) => { /* ... */ },
+      () => onDisconnectRef.current(),
+      () => { /* ... */ },
+      canReconnect,
+      getTicket,  // 新增
+    )
+```
+
+- [ ] **Step 2: SessionPaneContent 傳入 getTicket**
+
+修改 `spa/src/components/SessionPaneContent.tsx`，在 `<TerminalView>` 或直接傳給 `useTerminalWs`：
+
+加入 import：
+```typescript
+import { fetchWsTicket } from '../lib/host-api'
+```
+
+在呼叫 `useTerminalWs` 或傳給 `TerminalView` 的 props 中加入：
+```typescript
+getTicket={() => fetchWsTicket(hostId)}
+```
+
+- [ ] **Step 3: 執行 lint + test**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/hooks/useTerminalWs.ts spa/src/components/SessionPaneContent.tsx
+git commit -m "feat: terminal WS ticket auth via getTicket callback"
+```
+
+---
+
+### Task 10: HostSidebar — auth-error 圖示
+
+**Files:**
+- Modify: `spa/src/components/hosts/HostSidebar.tsx`
+
+- [ ] **Step 1: 加入 LockSimple import + auth-error 分支**
+
+修改 `HostSidebar.tsx`，import 加入 `LockSimple`：
+```typescript
+import { Plus, CaretDown, CaretRight, Circle, Spinner, Warning, LockSimple } from '@phosphor-icons/react'
+```
+
+`StatusIcon` 函式在 `reconnecting` 和 default 之間插入：
+```typescript
+  if (runtime.status === 'auth-error')
+    return <LockSimple size={12} weight="fill" className="text-red-400" />
+```
+
+Host 名稱在 auth-error 時改為紅色。在 button 的 className 邏輯中，加入：
+```typescript
+// 在 truncate flex-1 的 span 上加條件 class
+className={`truncate flex-1 ${runtime[hostId]?.status === 'auth-error' ? 'text-red-400' : ''}`}
+```
+
+- [ ] **Step 2: 執行 lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spa/src/components/hosts/HostSidebar.tsx
+git commit -m "feat: HostSidebar auth-error lock icon"
+```
+
+---
+
+### Task 11: StatusBar — auth-error 顯示 + 導航
+
+**Files:**
+- Modify: `spa/src/components/StatusBar.tsx`
+- Modify: `spa/src/App.tsx`（提供 onNavigateToHost callback）
+
+- [ ] **Step 1: StatusBar 加入 auth-error 狀態 + onNavigateToHost prop**
+
+修改 `StatusBar.tsx` Props：
+```typescript
+interface Props {
+  activeTab: Tab | null
+  onViewModeChange?: (tabId: string, paneId: string, mode: 'terminal' | 'stream') => void
+  onNavigateToHost?: (hostId: string) => void  // 新增
+}
+```
+
+import 加入 `LockSimple`：
+```typescript
+import { CaretUp, CircleNotch, CheckCircle, XCircle, LockSimple } from '@phosphor-icons/react'
+```
+
+狀態顯示邏輯（L139-148 區域）加入 auth-error 分支：
+```typescript
+      <span
+        className={
+          status === 'auth-error' ? 'text-red-400 cursor-pointer flex items-center gap-1'
+            : status === 'connected' && hostRuntime?.tmuxState === 'unavailable' ? 'text-yellow-400'
+            : status === 'connected' ? 'text-green-500'
+            : status === 'reconnecting' ? 'text-yellow-400'
+            : 'text-red-400'
+        }
+        onClick={status === 'auth-error' && agentHostId ? () => onNavigateToHost?.(agentHostId) : undefined}
+      >
+        {status === 'auth-error' && <LockSimple size={10} weight="fill" />}
+        {status === 'auth-error' ? t('hosts.auth_error')
+          : status === 'connected' && hostRuntime?.tmuxState === 'unavailable'
+            ? t('hosts.error_tmux_down')
+            : status}
+      </span>
+```
+
+- [ ] **Step 2: App.tsx 傳入 onNavigateToHost**
+
+在 `App.tsx` 中，`StatusBar` 的 props 加入 `onNavigateToHost` callback，觸發切換到 HostPage 的 OverviewSection。具體實作取決於 App 的路由/頁面切換機制（查看 App.tsx 既有的頁面切換 state）。
+
+- [ ] **Step 3: 執行 lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/components/StatusBar.tsx spa/src/App.tsx
+git commit -m "feat: StatusBar auth-error display + navigation"
+```
+
+---
+
+### Task 12: OverviewSection — auth-error banner + 自動重試
+
+**Files:**
+- Modify: `spa/src/components/hosts/OverviewSection.tsx`
+
+- [ ] **Step 1: 加入 auth-error banner**
+
+import 加入 `LockSimple`：
+```typescript
+import { CaretDown, CaretRight, ArrowsClockwise, Trash, Plugs, Eye, EyeSlash, Check, X, LockSimple } from '@phosphor-icons/react'
+```
+
+在 `<h2>` 標題下方、Connection Section 上方插入 auth-error banner：
+```tsx
+      {runtime?.status === 'auth-error' && (
+        <div className="flex items-start gap-3 px-3 py-2.5 rounded-md mb-4 bg-red-500/10 border border-red-500/20">
+          <LockSimple size={16} weight="fill" className="text-red-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm text-red-400 font-medium">{t('hosts.auth_error')}</p>
+            <p className="text-xs text-text-muted mt-0.5">{t('hosts.auth_error_hint')}</p>
+          </div>
+        </div>
+      )}
+```
+
+- [ ] **Step 2: Status 欄位加入 auth-error 顯示**
+
+修改 status className（L502-506 區域）加入 auth-error：
+```typescript
+            runtime?.status === 'auth-error' ? 'text-red-400'
+              : runtime?.status === 'connected' && runtime?.tmuxState === 'unavailable' ? 'text-yellow-400'
+              : ...
+```
+
+statusLabel 加入 auth-error 圖示：
+```typescript
+  const statusLabel = (r?: HostRuntime) => {
+    if (!r) return 'unknown'
+    if (r.status === 'auth-error') return 'auth-error'
+    return r.status
+  }
+```
+
+- [ ] **Step 3: TokenField onSave 觸發自動重試**
+
+修改 TokenField 的 `onSave` callback：
+```typescript
+        <TokenField
+          token={host.token}
+          ip={host.ip}
+          port={host.port}
+          onSave={(token) => {
+            updateHost(hostId, { token: token || undefined })
+            // Auto-retry: set reconnecting then trigger SM
+            useHostStore.getState().setRuntime(hostId, { status: 'reconnecting' })
+            const rt = useHostStore.getState().runtime[hostId]
+            if (rt?.manualRetry) rt.manualRetry()
+          }}
+          t={t}
+        />
+```
+
+- [ ] **Step 4: 執行 lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/components/hosts/OverviewSection.tsx
+git commit -m "feat: OverviewSection auth-error banner + token auto-retry"
+```
+
+---
+
+### Task 13: AddHostDialog — health mode 自動導流（#167）
+
+**Files:**
+- Modify: `spa/src/components/hosts/AddHostDialog.tsx`
+
+- [ ] **Step 1: 加入 debounced health check**
+
+在 `AddHostDialog` 元件內新增 state 和 effect：
+
+```typescript
+  const [healthMode, setHealthMode] = useState<'pairing' | 'pending' | 'normal' | null>(null)
+
+  // Debounced health check when in manual mode with IP+port filled
+  useEffect(() => {
+    if (!useToken || !ip || stage === 'saving' || stage === 'done') {
+      setHealthMode(null)
+      return
+    }
+    const portNum = port || '7860'
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`http://${ip}:${portNum}/api/health`)
+        const body = await res.json()
+        setHealthMode(body.mode ?? 'normal')
+      } catch {
+        setHealthMode(null)
+      }
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [useToken, ip, port, stage])
+```
+
+- [ ] **Step 2: auto-switch on pairing detection**
+
+在 `useEffect` 的 health mode 成功回呼後加入 auto-switch 邏輯（只在 token 欄位空白時）：
+
+```typescript
+      // After setHealthMode, check for auto-switch
+      if (body.mode === 'pairing' && !token) {
+        handleToggleToken(false) // switch to pairing route
+      }
+```
+
+- [ ] **Step 3: 顯示 mode badge**
+
+在 Host/Port/Token 欄位上方加入 mode 提示：
+
+```tsx
+          {healthMode && useToken && (
+            <div className={`flex items-start gap-2 px-2 py-2 rounded text-xs ${
+              healthMode === 'pairing' ? 'bg-yellow-500/10 border border-yellow-500/20 text-yellow-400'
+                : healthMode === 'pending' ? 'bg-blue-500/10 border border-blue-500/20 text-blue-400'
+                : 'bg-green-500/10 border border-green-500/20 text-green-400'
+            }`}>
+              {healthMode === 'pairing' && t('hosts.mode_pairing_hint')}
+              {healthMode === 'pending' && t('hosts.mode_pending_hint')}
+              {healthMode === 'normal' && t('hosts.mode_normal_hint')}
+            </div>
+          )}
+```
+
+- [ ] **Step 4: 加入 i18n keys**
+
+在 `zh-TW.json` 和 `en.json` 新增：
+```json
+  "hosts.mode_pairing_hint": "Daemon 等待配對中",
+  "hosts.mode_pending_hint": "請輸入 daemon 終端機顯示的 Token",
+  "hosts.mode_normal_hint": "Daemon 運作中，請輸入已設定的 Token"
+```
+
+- [ ] **Step 5: 執行 lint + test**
+
+Run: `cd spa && pnpm run lint && npx vitest run`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/components/hosts/AddHostDialog.tsx spa/src/locales/zh-TW.json spa/src/locales/en.json
+git commit -m "feat: AddHostDialog health mode auto-detect (#167)"
+```
+
+---
+
+### Task 14: 全面整合測試 + build 驗證
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: 執行全部 SPA 測試**
+
+Run: `cd spa && npx vitest run`
+Expected: 全部 PASS
+
+- [ ] **Step 2: 執行 SPA lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: 無 error
+
+- [ ] **Step 3: 執行 SPA build**
+
+Run: `cd spa && pnpm run build`
+Expected: 建置成功
+
+- [ ] **Step 4: 執行全部 Go 測試**
+
+Run: `go test ./...`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit 任何 fix**
+
+若前面步驟發現問題，修復後 commit。

--- a/docs/superpowers/plans/2026-04-06-phase5b-ws-ticket-auth-error.md
+++ b/docs/superpowers/plans/2026-04-06-phase5b-ws-ticket-auth-error.md
@@ -69,6 +69,7 @@ git commit -m "feat(middleware): remove legacy ?token= query param fallback"
 **Files:**
 - Modify: `spa/src/lib/host-connection.ts`
 - Modify: `spa/src/lib/host-connection.test.ts`
+- Modify: `spa/src/lib/connection-state-machine.test.ts`（補 `mode` 欄位避免 TS 型別錯誤）
 
 - [ ] **Step 1: 寫 10 個 failing tests**
 
@@ -254,10 +255,28 @@ export async function checkHealth(
 Run: `cd spa && npx vitest run src/lib/host-connection.test.ts`
 Expected: 10 tests PASS
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: 更新 SM test mocks 補 `mode` 欄位**
+
+`HealthResult.mode` 改為必填後，`connection-state-machine.test.ts` 的既有 mock 缺少 `mode` 會導致 TS 型別錯誤。在所有 `checkFn.mockResolvedValue(...)` 的回傳物件中加入 `mode: 'normal'`。例如：
+
+```typescript
+// 每個 mock 都補 mode，例：
+checkFn.mockResolvedValue({ daemon: 'connected', tmux: 'ok', latency: 10, mode: 'normal' })
+checkFn.mockResolvedValue({ daemon: 'unreachable', tmux: 'unavailable', latency: null, mode: 'normal' })
+checkFn.mockResolvedValue({ daemon: 'refused', tmux: 'unavailable', latency: null, mode: 'normal' })
+```
+
+共 9 個既有 test 的 mock 需更新（所有 `checkFn.mockResolvedValue` 和 `mockResolvedValueOnce` 呼叫）。
+
+- [ ] **Step 6: 執行全部 SPA test 確認無 breakage**
+
+Run: `cd spa && npx vitest run`
+Expected: 全部 PASS（含 SM 的 9 個既有 test）
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add spa/src/lib/host-connection.ts spa/src/lib/host-connection.test.ts
+git add spa/src/lib/host-connection.ts spa/src/lib/host-connection.test.ts spa/src/lib/connection-state-machine.test.ts
 git commit -m "feat: checkHealth two-phase negotiation (health + ws-ticket)"
 ```
 
@@ -605,12 +624,18 @@ export function connectHostEvents(
   if (!lazy) connect()
   return {
     close: () => { closed = true; ws?.close() },
-    reconnect: () => { if (!closed) { retryMs = 1000; ws?.close(); connect() } },
+    reconnect: () => {
+      if (!closed) {
+        retryMs = 1000
+        if (ws) { ws.onclose = null; ws.close() }  // 清除 onclose 防止 double-trigger
+        connect()
+      }
+    },
     reconnectWithTicket: (ticket) => {
       if (!closed) {
         pendingTicket = ticket
         retryMs = 1000
-        ws?.close()
+        if (ws) { ws.onclose = null; ws.close() }  // 清除 onclose 防止 double-trigger
         connect()
       }
     },
@@ -696,7 +721,9 @@ Expected: 新增的 3 個 test FAIL
 
 - [ ] **Step 3: 實作 connectTerminal getTicket**
 
-修改 `spa/src/lib/ws.ts`，`connectTerminal` 加入 `getTicket` 參數，`connect()` 改為 async，按 spec 4.3 實作。
+修改 `spa/src/lib/ws.ts`，`connectTerminal` 加入 `getTicket` 參數。
+
+**重要：`connect()` 必須保持同步**，否則既有 8 個 test 因 WebSocket 建立延遲一 microtask 而全部 crash。使用雙函式設計：
 
 函式簽名改為：
 ```typescript
@@ -710,27 +737,57 @@ export function connectTerminal(
 ): TerminalConnection {
 ```
 
-`connect()` 改為 `async function connect()`，開頭加入：
+在既有 `connect()` 函式前新增 async 版本，`connect()` 根據是否有 `getTicket` 分流：
+
 ```typescript
+  // Async ticket path — separate from sync connect to avoid breaking existing sync callers
+  async function connectWithTicket() {
     let wsUrl = url
-    if (getTicket) {
-      try {
-        const ticket = await getTicket()
-        const u = new URL(wsUrl)
-        u.searchParams.set('ticket', ticket)
-        wsUrl = u.toString()
-      } catch {
-        setTimeout(() => {
-          if (closed) return
-          if (canReconnect && !canReconnect()) return
-          connect()
-        }, retryMs)
-        retryMs = Math.min(retryMs * 2, 30000)
-        return
-      }
+    try {
+      const ticket = await getTicket!()
+      const u = new URL(wsUrl)
+      u.searchParams.set('ticket', ticket)
+      wsUrl = u.toString()
+    } catch {
+      setTimeout(() => {
+        if (closed) return
+        if (canReconnect && !canReconnect()) return
+        connect()
+      }, retryMs)
+      retryMs = Math.min(retryMs * 2, 30000)
+      return
     }
+    setupWs(wsUrl)
+  }
+
+  function setupWs(wsUrl: string) {
     ws = new WebSocket(wsUrl)
+    ws.binaryType = 'arraybuffer'
+    ws.onopen = () => { retryMs = 1000; onOpen?.() }
+    ws.onmessage = (e) => { if (e.data instanceof ArrayBuffer) onData(e.data) }
+    ws.onerror = () => {}
+    ws.onclose = () => {
+      if (closed) return
+      onClose()
+      setTimeout(() => {
+        if (closed) return
+        if (canReconnect && !canReconnect()) return
+        connect()
+      }, retryMs)
+      retryMs = Math.min(retryMs * 2, 30000)
+    }
+  }
+
+  function connect() {
+    if (getTicket) {
+      connectWithTicket()
+      return
+    }
+    setupWs(url)
+  }
 ```
+
+`connect()` 本身保持同步：無 `getTicket` → 直接 `setupWs(url)`（同步建立 WebSocket）。有 `getTicket` → 轉呼叫 async `connectWithTicket()`。既有 test 不傳 `getTicket`，走同步路徑，不受影響。
 
 - [ ] **Step 4: 執行 test 確認通過**
 
@@ -766,7 +823,7 @@ git commit -m "feat: connectTerminal getTicket param for WS ticket auth"
       // --- Connection state machine (per host) ---
       const connRef: { current: EventConnection | undefined } = { current: undefined }
 
-      const statusMap: Record<string, string> = {
+      const statusMap: Record<HealthResult['daemon'], HostRuntime['status']> = {
         connected: 'connected',
         unreachable: 'disconnected',
         refused: 'disconnected',
@@ -777,7 +834,7 @@ git commit -m "feat: connectTerminal getTicket param for WS ticket auth"
         () => checkHealth(baseUrl, () => useHostStore.getState().hosts[hostId]?.token),
         (result) => {
           useHostStore.getState().setRuntime(hostId, {
-            status: (statusMap[result.daemon] ?? 'disconnected') as HostRuntime['status'],
+            status: statusMap[result.daemon],
             latency: result.latency ?? undefined,
             daemonState: result.daemon,
           })
@@ -795,9 +852,11 @@ git commit -m "feat: connectTerminal getTicket param for WS ticket auth"
       useHostStore.getState().setRuntime(hostId, { manualRetry: () => sm.trigger() })
 
       // --- WS connection (per host, lazy — waits for SM) ---
+      // IMPORTANT: 完整保留現有 onEvent handler（L54-117 的 sessions/hook/relay/tmux/handoff 處理）。
+      // 只修改 connectHostEvents 的後三個參數（onClose/onOpen/getTicket）和新增 autoReconnect/lazy。
       const conn = connectHostEvents(
         wsUrl,
-        (event) => { /* ... 既有 event handler 不變 ... */ },
+        (event) => { /* 完整保留現有 L54-117 的 event handler，不做任何修改 */ },
         () => {
           useHostStore.getState().setRuntime(hostId, { status: 'reconnecting' })
           sm.trigger()
@@ -822,9 +881,13 @@ git commit -m "feat: connectTerminal getTicket param for WS ticket auth"
       sm.trigger()
 ```
 
-- [ ] **Step 2: 加入 HostRuntime type import**
+- [ ] **Step 2: 加入 type imports**
 
-在 imports 區加入：`import type { HostRuntime } from '../stores/useHostStore'`
+在 imports 區加入：
+```typescript
+import type { HostRuntime } from '../stores/useHostStore'
+import type { HealthResult } from '../lib/host-connection'
+```
 
 - [ ] **Step 3: 執行 lint + test**
 
@@ -859,6 +922,8 @@ import { fetchWsTicket } from '../lib/host-api'
           if (connected && !wasConnected) {
             const wsBase = useHostStore.getState().getWsBase(hostId)
 
+            // IMPORTANT: 完整保留現有 onMessage handler（L35-58 的 assistant/user/result/control_request/system 處理）。
+            // 只修改外層包裝（fetchWsTicket + guard）和 URL 構建。
             fetchWsTicket(hostId).then((ticket) => {
               if (!useStreamStore.getState().relayStatus[ck]) return
 
@@ -867,7 +932,7 @@ import { fetchWsTicket } from '../lib/host-api'
 
               const conn = connectStream(
                 url.toString(),
-                (msg: StreamMessage) => { /* ... 既有 onMessage 不變 ... */ },
+                (msg: StreamMessage) => { /* 完整保留現有 L35-58 的 onMessage handler，不做任何修改 */ },
                 () => {
                   useStreamStore.getState().setConn(hostId, sessionCode, null)
                   activeConns.delete(ck)
@@ -897,51 +962,67 @@ git commit -m "feat: useRelayWsManager ticket fetch before stream WS"
 
 ---
 
-### Task 9: SessionPaneContent — 傳入 getTicket
+### Task 9: Terminal WS ticket — 完整 prop chain
 
 **Files:**
-- Modify: `spa/src/components/SessionPaneContent.tsx`
 - Modify: `spa/src/hooks/useTerminalWs.ts`
+- Modify: `spa/src/components/TerminalView.tsx`
+- Modify: `spa/src/components/SessionPaneContent.tsx`
 
-- [ ] **Step 1: useTerminalWs 加 getTicket prop**
+Prop chain: `SessionPaneContent` → `TerminalView` (props) → `useTerminalWs` (opts) → `connectTerminal` (param)
+
+- [ ] **Step 1: useTerminalWs 加 getTicket**
 
 修改 `spa/src/hooks/useTerminalWs.ts`：
 
-介面加入 `getTicket?: () => Promise<string>`：
+`UseTerminalWsOpts` 介面加入：
 ```typescript
-interface UseTerminalWsOpts {
-  wsUrl: string
-  // ... 既有 props ...
-  hostId?: string
-  getTicket?: () => Promise<string>  // 新增
-  // ...
-}
+  getTicket?: () => Promise<string>
 ```
 
 解構時加入 `getTicket`，傳入 `connectTerminal`：
 ```typescript
     const conn = connectTerminal(
       wsUrl,
-      (data) => { /* ... */ },
+      (data) => { /* 既有 */ },
       () => onDisconnectRef.current(),
-      () => { /* ... */ },
+      () => { /* 既有 */ },
       canReconnect,
-      getTicket,  // 新增
+      getTicket,  // 新增：第六參數
     )
 ```
 
-- [ ] **Step 2: SessionPaneContent 傳入 getTicket**
+- [ ] **Step 2: TerminalView 加 getTicket prop**
 
-修改 `spa/src/components/SessionPaneContent.tsx`，在 `<TerminalView>` 或直接傳給 `useTerminalWs`：
+修改 `spa/src/components/TerminalView.tsx`：
+
+Props 介面加入：
+```typescript
+  getTicket?: () => Promise<string>
+```
+
+傳給 `useTerminalWs`：
+```typescript
+  useTerminalWs({ wsUrl, ..., getTicket })
+```
+
+- [ ] **Step 3: SessionPaneContent 傳入 getTicket**
+
+修改 `spa/src/components/SessionPaneContent.tsx`：
 
 加入 import：
 ```typescript
 import { fetchWsTicket } from '../lib/host-api'
 ```
 
-在呼叫 `useTerminalWs` 或傳給 `TerminalView` 的 props 中加入：
+在 `<TerminalView>` JSX 加入 prop：
 ```typescript
-getTicket={() => fetchWsTicket(hostId)}
+<TerminalView
+  wsUrl={`${wsBase}/ws/terminal/${encodeURIComponent(sessionCode)}`}
+  hostId={hostId}
+  getTicket={() => fetchWsTicket(hostId)}
+  // ... 其餘既有 props
+/>
 ```
 
 - [ ] **Step 3: 執行 lint + test**
@@ -1040,7 +1121,25 @@ import { CaretUp, CircleNotch, CheckCircle, XCircle, LockSimple } from '@phospho
 
 - [ ] **Step 2: App.tsx 傳入 onNavigateToHost**
 
-在 `App.tsx` 中，`StatusBar` 的 props 加入 `onNavigateToHost` callback，觸發切換到 HostPage 的 OverviewSection。具體實作取決於 App 的路由/頁面切換機制（查看 App.tsx 既有的頁面切換 state）。
+`App.tsx` 已有 `onOpenHosts` callback（使用 `openSingletonTab({ kind: 'hosts' })`）。`onNavigateToHost` 用相同機制：
+
+```typescript
+<StatusBar
+  activeTab={activeTab}
+  onViewModeChange={handleViewModeChange}
+  onNavigateToHost={(hostId) => {
+    // 開啟/切換到 hosts tab（singleton）
+    const tabId = useTabStore.getState().openSingletonTab({ kind: 'hosts' })
+    if (activeWorkspaceId) {
+      useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, tabId)
+      useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, tabId)
+    }
+    handleSelectTab(tabId)
+    // HostPage 會從 useHostStore.activeHostId 讀取初始選中的 host
+    useHostStore.getState().setActiveHost(hostId)
+  }}
+/>
+```
 
 - [ ] **Step 3: 執行 lint**
 

--- a/docs/superpowers/specs/2026-04-06-phase5b-ws-ticket-auth-error-design.md
+++ b/docs/superpowers/specs/2026-04-06-phase5b-ws-ticket-auth-error-design.md
@@ -75,10 +75,12 @@ interface HealthResult {
   daemon: 'connected' | 'refused' | 'unreachable' | 'auth-error'
   tmux: 'ok' | 'unavailable'
   latency: number | null
-  mode?: 'pairing' | 'pending' | 'normal'
+  mode: 'pairing' | 'pending' | 'normal'  // daemon 永遠回傳，非 optional
   ticket?: string  // Phase 2 成功時附帶
 }
 ```
+
+`mode` 為非 optional。`checkHealth` 解析時使用 `body.mode ?? 'normal'` fallback 保護。
 
 ### 3.2 checkHealth 兩階段
 
@@ -108,7 +110,7 @@ async function checkHealth(
     const res = await fetch(`${baseUrl}/api/health`, { signal: ctrl1.signal })
     const latency = Math.round(performance.now() - start)
     const body = await res.json()
-    const mode = body.mode as 'pairing' | 'pending' | 'normal' | undefined
+    const mode = (body.mode ?? 'normal') as 'pairing' | 'pending' | 'normal'
 
     // Phase 2: auth probe (獨立 timeout)
     const token = getToken?.()
@@ -230,7 +232,13 @@ interface HostRuntime {
   WS 連線
 ```
 
-**關鍵**：effect 建立後**立即呼叫 `sm.trigger()`**。這確保新 host 加入時狀態機主動跑一次 negotiation，即使 WS 從未建立也能偵測 auth-error。
+**關鍵設計**：
+
+1. `connectHostEvents` 以 `lazy: true` 建立 — **不立即呼叫 `connect()`**，等待 SM 指令
+2. Effect 建立後立即 `sm.trigger()` — SM 先跑完 negotiation
+3. SM 完成後透過 `onStateChange` → `reconnectWithTicket(ticket)` 啟動第一次 WS 連線
+
+這避免了 SM 與 `connectHostEvents` 初始 `connect()` 並行的 race condition（兩個 `connect()` 同時跑會建立兩個 WebSocket）。`connectHostEvents` 只有在 SM 明確說 connected 後才建立連線。
 
 ### 3.6 HostRuntime 狀態映射規則
 
@@ -269,7 +277,22 @@ setRuntime(hostId, {
 | UploadSection | `UploadSection.tsx` L35 | `!== 'connected'` | 同上 |
 | useTerminalWs | `useTerminalWs.ts` L50-54 | canReconnect gate | auth-error 時 `status !== 'connected'` → 不重連，正確 |
 
-前三個需主動加 `auth-error` 分支；後六個的 `!== 'connected'` 邏輯自然排除 auth-error，行為正確無需改動。
+| SessionSection | `SessionSection.tsx` L27,34,36 | `status === 'reconnecting'` / else | auth-error 落入 else → 紅色圓圈，行為同 disconnected，可接受 |
+| SessionPanel | `SessionPanel.tsx` L54,61-68 | `!== 'connected'` / `=== 'reconnecting'` | 同上 |
+
+前三個（HostSidebar、StatusBar、OverviewSection）需主動加 `auth-error` 分支。其餘八個的 `!== 'connected'` 邏輯自然排除 auth-error，行為正確無需改動。
+
+### 3.8 Terminal WS 在 auth-error 時的行為
+
+auth-error 只在 WS upgrade 時偵測。**已建立的 WS 連線不受影響**（WebSocket 協議在 upgrade 後不再驗 auth）。
+
+場景：使用者正在使用 terminal，daemon 端 token 變更：
+- Terminal WS **仍然連通**，使用者可繼續操作（預期行為）
+- Host-events WS 若因其他原因斷線 → SM 偵測 auth-error → status = 'auth-error'
+- Terminal 下次斷線時，`canReconnect()` 回傳 false → 暫停重連
+- 使用者修改 token → status 回到 connected → terminal 下次可重連
+
+此為 WebSocket 協議的本質限制，不強制中斷已建立的連線。
 
 ---
 
@@ -307,39 +330,47 @@ export function connectHostEvents(
   onOpen?: ...,
   getTicket?: () => Promise<string>,
   autoReconnect = true,
+  lazy = false,            // 新增：true 時不立即連線
 ): EventConnection {
   let ws: WebSocket
   let retryMs = 1000
   let closed = false
-  let pendingTicket: string | undefined  // 新增：一次性 pre-fetched ticket
+  let connecting = false   // 防止並發 connect()
+  let pendingTicket: string | undefined
 
   async function connect() {
-    let wsUrl = url
-    // 優先消費 pendingTicket（由 reconnectWithTicket 注入）
-    // 若無，回退到 getTicket callback
-    const ticket = pendingTicket ?? (getTicket ? await getTicket().catch(() => null) : null)
-    pendingTicket = undefined  // 一次性消費，用完清空
+    if (connecting) return  // 防止雙重 connect
+    connecting = true
+    try {
+      let wsUrl = url
+      // 優先消費 pendingTicket（由 reconnectWithTicket 注入）
+      // 若無，回退到 getTicket callback
+      const ticket = pendingTicket ?? (getTicket ? await getTicket().catch(() => null) : null)
+      pendingTicket = undefined
 
-    if (ticket) {
-      const u = new URL(wsUrl)
-      u.searchParams.set('ticket', ticket)
-      wsUrl = u.toString()
-    } else if (getTicket) {
-      // getTicket 失敗且無 pendingTicket → 通知上層
-      if (!closed) onClose?.()
-      return
+      if (ticket) {
+        const u = new URL(wsUrl)
+        u.searchParams.set('ticket', ticket)
+        wsUrl = u.toString()
+      } else if (getTicket) {
+        // getTicket 失敗且無 pendingTicket → 通知上層
+        if (!closed) onClose?.()
+        return
+      }
+      ws = new WebSocket(wsUrl)
+      // ... 其餘不變
+    } finally {
+      connecting = false
     }
-    ws = new WebSocket(wsUrl)
-    // ... 其餘不變
   }
 
-  connect()
+  if (!lazy) connect()     // lazy=true 時等 reconnectWithTicket 觸發
   return {
     close: () => { closed = true; ws?.close() },
     reconnect: () => { if (!closed) { retryMs = 1000; ws?.close(); connect() } },
     reconnectWithTicket: (ticket) => {
       if (!closed) {
-        pendingTicket = ticket    // 注入一次性 ticket
+        pendingTicket = ticket
         retryMs = 1000
         ws?.close()
         connect()
@@ -349,13 +380,40 @@ export function connectHostEvents(
 }
 ```
 
+**`connecting` flag**：防止 `reconnectWithTicket` 觸發的 `connect()` 與前一個仍在飛行的 `connect()` 並行。若前者仍在 `await getTicket()` 階段，後者直接 return。前者完成後，透過 ws.onclose → onClose → SM trigger → 下一輪 reconnectWithTicket 再啟動。
+
 #### useMultiHostEventWs 呼叫方式
 
 ```typescript
-// onStateChange callback:
+// SM onStateChange callback:
 if (result.daemon === 'connected' && connRef.current) {
-  connRef.current.reconnectWithTicket(result.ticket)
+  if (result.ticket) {
+    connRef.current.reconnectWithTicket(result.ticket)
+  } else {
+    // Phase 2 timeout 等情況 — ticket 不存在
+    // 用普通 reconnect，讓 getTicket callback 自行取 ticket
+    connRef.current.reconnect()
+  }
 }
+```
+
+**重要**：`reconnectWithTicket(undefined)` 會清空 `pendingTicket`，導致 `connect()` 呼叫 `getTicket()`，若 getTicket 也 timeout → `onClose` → SM trigger → Phase 2 再次 timeout → 無限循環。必須只在 `result.ticket` 有值時才用 `reconnectWithTicket`。
+
+#### useMultiHostEventWs 初始化流程
+
+```typescript
+// 1. 建立 connectHostEvents（lazy mode，不立即連線）
+const conn = connectHostEvents(
+  wsUrl, onEvent, onClose, onOpen,
+  () => fetchWsTicket(hostId),
+  false,  // autoReconnect = false（SM 管重連）
+  true,   // lazy = true（等 SM 指令）
+)
+
+// 2. 立即觸發 SM negotiation
+sm.trigger()
+
+// SM 完成後 onStateChange 自動呼叫 reconnectWithTicket 或 reconnect
 ```
 
 **一次性消費語意**：`pendingTicket` 在 `connect()` 內消費後清空。若 WS 在使用 pre-fetched ticket 後斷線再重連，`pendingTicket` 已空，回退到 `getTicket()` callback（觸發新的 `fetchWsTicket`）。若 `getTicket` 也失敗，通知 `onClose` → 狀態機重新 negotiate。
@@ -422,10 +480,12 @@ async function connect() {
 // useRelayWsManager.ts — relay connected 時
 if (connected && !wasConnected) {
   const wsBase = useHostStore.getState().getWsBase(hostId)
-  const baseUrl = `${wsBase.replace('ws:', 'http:')}`
 
   // 外層 await ticket，再帶入 URL
   fetchWsTicket(hostId).then((ticket) => {
+    // Guard: relay 可能在 ticket fetch 期間已斷線
+    if (!useStreamStore.getState().relayStatus[ck]) return
+
     const url = new URL(`${wsBase}/ws/cli-bridge-sub/${encodeURIComponent(sessionCode)}`)
     url.searchParams.set('ticket', ticket)
 
@@ -435,9 +495,14 @@ if (connected && !wasConnected) {
     )
     useStreamStore.getState().setConn(hostId, sessionCode, conn)
     activeConns.set(ck, conn)
-  }).catch(() => {
-    // ticket fetch 失敗 — 不建立 WS
-    // 狀態機會從 host-events 路徑偵測 auth-error
+  }).catch((err) => {
+    // 區分 ticket fetch 失敗（預期）與程式錯誤（非預期）
+    if (err instanceof Error && err.message.includes('ws-ticket')) {
+      // ticket fetch 失敗 — 不建立 WS
+      // 狀態機會從 host-events 路徑偵測 auth-error
+    } else {
+      console.error('[useRelayWsManager] stream WS setup error', err)
+    }
   })
 }
 ```
@@ -559,7 +624,7 @@ Phase 1 health check 解析 response body 的 `mode` 欄位，存入 `HealthResu
 | `normal` | 維持 Token 路線 + 提示「Daemon 運作中，請輸入已設定的 Token」 |
 | health 失敗 | 無提示，兩條路線都開放（使用者手動選） |
 
-使用者仍可手動覆蓋自動導流的結果（例如重新勾選/取消 Token checkbox）。
+**Auto-switch 保護**：只在 `stage === 'manual'` 且 token 欄位尚未填入時才自動切換。若使用者已填入 token（`token.length > 0`），不觸發自動切換，避免打斷已完成的配置。使用者仍可手動覆蓋。
 
 此為 UX 優化，不影響核心認證流程。
 

--- a/docs/superpowers/specs/2026-04-06-phase5b-ws-ticket-auth-error-design.md
+++ b/docs/superpowers/specs/2026-04-06-phase5b-ws-ticket-auth-error-design.md
@@ -82,62 +82,112 @@ interface HealthResult {
 
 ### 3.2 checkHealth 兩階段
 
+**重要**：`getToken` 必須是**動態 closure**，每次呼叫時從 store 讀取最新值。
+若寫成靜態快照，使用者修改 token 後狀態機仍用舊 token，Phase 2 永遠 401。
+
+呼叫端範例：
 ```typescript
+() => checkHealth(baseUrl, () => useHostStore.getState().hosts[hostId]?.token)
+```
+
+完整實作：
+
+```typescript
+const PHASE1_TIMEOUT_MS = 6000
+const PHASE2_TIMEOUT_MS = 5000
+
 async function checkHealth(
   baseUrl: string,
   getToken?: () => string | undefined,
 ): Promise<HealthResult> {
   // Phase 1: health (no auth, 6s timeout)
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), 6000)
+  const ctrl1 = new AbortController()
+  const timer1 = setTimeout(() => ctrl1.abort(), PHASE1_TIMEOUT_MS)
   try {
     const start = performance.now()
-    const res = await fetch(`${baseUrl}/api/health`, { signal: controller.signal })
+    const res = await fetch(`${baseUrl}/api/health`, { signal: ctrl1.signal })
     const latency = Math.round(performance.now() - start)
     const body = await res.json()
     const mode = body.mode as 'pairing' | 'pending' | 'normal' | undefined
 
-    // Phase 2: auth probe (only if token available)
+    // Phase 2: auth probe (獨立 timeout)
     const token = getToken?.()
     if (!token) {
-      return { daemon: 'connected', tmux: 'unavailable', latency, mode }
-    }
-    const ticketRes = await fetch(`${baseUrl}/api/ws-ticket`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}` },
-    })
-    if (ticketRes.status === 401) {
+      // SPA 無 token → 視為 auth-error（daemon 可能有 token，WS 會被拒）
+      // 除非 mode=pairing（daemon 尚未設定 token，不需要 auth）
+      if (mode === 'pairing') {
+        return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+      }
       return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
     }
-    if (!ticketRes.ok) {
-      // ws-ticket endpoint 異常但非 auth → 視為 connected
+
+    const ctrl2 = new AbortController()
+    const timer2 = setTimeout(() => ctrl2.abort(), PHASE2_TIMEOUT_MS)
+    try {
+      const ticketRes = await fetch(`${baseUrl}/api/ws-ticket`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        signal: ctrl2.signal,
+      })
+      if (ticketRes.status === 401) {
+        return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
+      }
+      if (ticketRes.status === 503) {
+        // PairingGuard 攔截 — daemon 處於 pairing mode，不重試
+        return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
+      }
+      if (!ticketRes.ok) {
+        // ws-ticket endpoint 異常但非 auth/pairing → 視為 connected
+        return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+      }
+      const { ticket } = await ticketRes.json()
+      return { daemon: 'connected', tmux: 'unavailable', latency, mode, ticket }
+    } catch {
+      // Phase 2 timeout 或 network error → 回退用 Phase 1 結果
       return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+    } finally {
+      clearTimeout(timer2)
     }
-    const { ticket } = await ticketRes.json()
-    return { daemon: 'connected', tmux: 'unavailable', latency, mode, ticket }
   } catch (err: unknown) {
     if (err instanceof Error && err.name === 'AbortError') {
       return { daemon: 'unreachable', tmux: 'unavailable', latency: null }
     }
     return { daemon: 'refused', tmux: 'unavailable', latency: null }
   } finally {
-    clearTimeout(timer)
+    clearTimeout(timer1)
   }
 }
 ```
 
+#### 設計決策說明
+
+- **無 token 時回傳 `auth-error`**（非 `connected`）：SPA 無 token 但 daemon 有 token 時，WS 會被 daemon 401 拒絕。只有 `mode=pairing` 例外（daemon 尚未設定 token）。
+- **503 → `auth-error`**：PairingGuard 回 503 代表 daemon 在 pairing mode，此時 token 認證不可用。UI 顯示與 401 相同（引導使用者設定）。
+- **Phase 2 獨立 timeout（5 秒）**：Phase 1 成功後 daemon 可能在 Phase 2 前掉線。獨立 AbortController 防止掛起。
+- **Phase 2 的非 401/503 錯誤回退**：ws-ticket endpoint 本身故障（500 等）不是 auth 問題，回退用 Phase 1 結果。
+
 ### 3.3 狀態機新增 auth-error 分支
 
-```typescript
-// connection-state-machine.ts — trigger() 分類邏輯
+FAST_RETRY 迴圈中，`auth-error` 在**第一次 checkFn 回傳時就跳出**（不跑滿 3 次），因為重試也不會改變結果（token 不會自己變對），且每次 Phase 2 成功會消耗一個 ticket。
 
-if (lastResult.daemon === 'connected') return    // recovered
-if (lastResult.daemon === 'auth-error') return   // 永久錯誤，不背景重試
+```typescript
+// connection-state-machine.ts — trigger() 的 FAST_RETRY 迴圈
+
+for (let i = 0; i < FAST_RETRY_COUNT; i++) {
+  if (this.stopped || this.epoch !== myEpoch) return
+  lastResult = await this.checkFn()
+  if (this.stopped || this.epoch !== myEpoch) return
+  this.onStateChange(lastResult)
+
+  if (lastResult.daemon === 'connected') return    // recovered
+  if (lastResult.daemon === 'auth-error') return   // 永久錯誤，立即跳出
+}
+
+// FAST_RETRY 結束後的分類（只有 unreachable / refused 會走到這）
 if (lastResult.daemon === 'unreachable') {       // L1: 不間斷重連
   this.backgroundDeadline = null
   this.startBackground(L1_RETRY_DELAY_MS)
-}
-if (lastResult.daemon === 'refused') {           // L2: 3s 間隔，3 分鐘停止
+} else if (lastResult.daemon === 'refused') {    // L2: 3s 間隔，3 分鐘停止
   this.backgroundDeadline = Date.now() + L2_RETRY_TIMEOUT_MS
   this.startBackground(L2_RETRY_DELAY_MS)
 }
@@ -162,7 +212,7 @@ interface HostRuntime {
                     ┌──────────────┐
                     │   (initial)  │
                     └──────┬───────┘
-                           │ effect 啟動
+                           │ effect 啟動 → 立即 sm.trigger()
                            ▼
                     ┌──────────────┐
            ┌───────│  negotiating  │◄──── 手動重試 / WS close
@@ -180,6 +230,47 @@ interface HostRuntime {
   WS 連線
 ```
 
+**關鍵**：effect 建立後**立即呼叫 `sm.trigger()`**。這確保新 host 加入時狀態機主動跑一次 negotiation，即使 WS 從未建立也能偵測 auth-error。
+
+### 3.6 HostRuntime 狀態映射規則
+
+狀態機 `onStateChange(result)` 的映射：
+
+```typescript
+const statusMap: Record<HealthResult['daemon'], HostRuntime['status']> = {
+  'connected': 'connected',
+  'unreachable': 'disconnected',
+  'refused': 'disconnected',
+  'auth-error': 'auth-error',
+}
+
+setRuntime(hostId, {
+  status: statusMap[result.daemon],
+  daemonState: result.daemon,
+  latency: result.latency ?? undefined,
+})
+```
+
+`status` 和 `daemonState` 都會反映 `auth-error`。
+
+### 3.7 所有 HostRuntime.status 消費者
+
+以下元件消費 `runtime.status`，必須處理新的 `'auth-error'` 值：
+
+| 元件 | 檔案 | 現有邏輯 | Phase 5b 調整 |
+|------|------|---------|--------------|
+| StatusIcon | `HostSidebar.tsx` L21-28 | switch on status | 加 `auth-error` → Lock 圖示 |
+| StatusBar | `StatusBar.tsx` L139-148 | status className | 加 `auth-error` → 紅色 + 鎖頭文字 |
+| OverviewSection | `OverviewSection.tsx` L502-506 | status className | 加 `auth-error` → 紅色 + banner |
+| SessionPickerList | `SessionPickerList.tsx` L23 | `=== 'connected'` | auth-error ≠ connected → 不顯示 session，行為正確 |
+| SessionPanel | `SessionPanel.tsx` L54 | `!== 'connected'` | auth-error 視為 offline → 行為正確，但可加提示 |
+| SortableTab | `SortableTab.tsx` L106 | `!== 'connected'` | 同上 |
+| HooksSection | `HooksSection.tsx` L31 | `!== 'connected'` | 同上 |
+| UploadSection | `UploadSection.tsx` L35 | `!== 'connected'` | 同上 |
+| useTerminalWs | `useTerminalWs.ts` L50-54 | canReconnect gate | auth-error 時 `status !== 'connected'` → 不重連，正確 |
+
+前三個需主動加 `auth-error` 分支；後六個的 `!== 'connected'` 邏輯自然排除 auth-error，行為正確無需改動。
+
 ---
 
 ## 四、WS Ticket 統一
@@ -194,15 +285,80 @@ interface HostRuntime {
 
 ### 4.2 host-events：pre-fetched ticket
 
-狀態機 Phase 2 成功時已拿到 ticket。`useMultiHostEventWs` 的 `onStateChange` callback 將 ticket 傳給 `connectHostEvents`：
+狀態機 Phase 2 成功時已拿到 ticket。`useMultiHostEventWs` 的 `onStateChange` 透過 `pendingTicket` 機制傳給 `connectHostEvents`。
+
+#### EventConnection 介面擴充
 
 ```typescript
+export interface EventConnection {
+  close: () => void
+  reconnect: () => void
+  reconnectWithTicket: (ticket?: string) => void  // 新增
+}
+```
+
+#### connectHostEvents 內部實作
+
+```typescript
+export function connectHostEvents(
+  url: string,
+  onEvent: ...,
+  onClose?: ...,
+  onOpen?: ...,
+  getTicket?: () => Promise<string>,
+  autoReconnect = true,
+): EventConnection {
+  let ws: WebSocket
+  let retryMs = 1000
+  let closed = false
+  let pendingTicket: string | undefined  // 新增：一次性 pre-fetched ticket
+
+  async function connect() {
+    let wsUrl = url
+    // 優先消費 pendingTicket（由 reconnectWithTicket 注入）
+    // 若無，回退到 getTicket callback
+    const ticket = pendingTicket ?? (getTicket ? await getTicket().catch(() => null) : null)
+    pendingTicket = undefined  // 一次性消費，用完清空
+
+    if (ticket) {
+      const u = new URL(wsUrl)
+      u.searchParams.set('ticket', ticket)
+      wsUrl = u.toString()
+    } else if (getTicket) {
+      // getTicket 失敗且無 pendingTicket → 通知上層
+      if (!closed) onClose?.()
+      return
+    }
+    ws = new WebSocket(wsUrl)
+    // ... 其餘不變
+  }
+
+  connect()
+  return {
+    close: () => { closed = true; ws?.close() },
+    reconnect: () => { if (!closed) { retryMs = 1000; ws?.close(); connect() } },
+    reconnectWithTicket: (ticket) => {
+      if (!closed) {
+        pendingTicket = ticket    // 注入一次性 ticket
+        retryMs = 1000
+        ws?.close()
+        connect()
+      }
+    },
+  }
+}
+```
+
+#### useMultiHostEventWs 呼叫方式
+
+```typescript
+// onStateChange callback:
 if (result.daemon === 'connected' && connRef.current) {
   connRef.current.reconnectWithTicket(result.ticket)
 }
 ```
 
-`connectHostEvents` 介面調整：接受 `ticket?: string` 直接使用（跳過 `getTicket` callback）。若 ticket 已過期（WS upgrade 失敗），觸發狀態機重新 negotiate。
+**一次性消費語意**：`pendingTicket` 在 `connect()` 內消費後清空。若 WS 在使用 pre-fetched ticket 後斷線再重連，`pendingTicket` 已空，回退到 `getTicket()` callback（觸發新的 `fetchWsTicket`）。若 `getTicket` 也失敗，通知 `onClose` → 狀態機重新 negotiate。
 
 ### 4.3 connectTerminal 加 getTicket
 
@@ -220,47 +376,96 @@ export function connectTerminal(
 
 連線流程：
 
-```
-connect() {
+```typescript
+async function connect() {
+  let wsUrl = url
   if (getTicket) {
-    try { ticket = await getTicket() → append ?ticket= to URL }
-    catch { onClose() → 通知上層 → 觸發狀態機; return }
+    try {
+      const ticket = await getTicket()
+      const u = new URL(wsUrl)
+      u.searchParams.set('ticket', ticket)
+      wsUrl = u.toString()
+    } catch {
+      // getTicket 失敗 → 沿用現有 backoff 自行重試，不呼叫 onClose
+      // （避免與 ws.onclose 的 retry timer 雙重觸發）
+      setTimeout(() => {
+        if (closed) return
+        if (canReconnect && !canReconnect()) return
+        connect()
+      }, retryMs)
+      retryMs = Math.min(retryMs * 2, 30000)
+      return
+    }
   }
   ws = new WebSocket(wsUrl)
-  ...
+  // ... 其餘不變
 }
 ```
 
+**設計決策**：`getTicket` 失敗時不呼叫 `onClose()`，而是沿用 `connectTerminal` 自身的 backoff 重試。原因：
+- Terminal 的 `onClose` → `TerminalView.setDisconnected(true)`，只更新 React 元件 state，不觸發狀態機
+- 如果同時呼叫 `onClose` + 排程 retry timer，會產生雙重觸發
+- Terminal WS 的 backoff 最終會因 `canReconnect()` gate 停止（當狀態機偵測到 auth-error，host status ≠ connected → canReconnect 回傳 false）
+
+**狀態機觸發路徑**（間接）：
+1. Terminal getTicket 401 → 自行 backoff 重試
+2. 同時，host-events WS 也在嘗試連線 → getTicket 也失敗 → 觸發 `onClose` → 狀態機 trigger
+3. 狀態機 negotiate → Phase 2 401 → `auth-error` → `canReconnect()` 回傳 false → terminal 停止重試
+
 `useTerminalWs` 和 `SessionPaneContent` 傳入 `() => fetchWsTicket(hostId)`。
 
-### 4.4 connectStream 加 getTicket
+### 4.4 connectStream：外層 await ticket
+
+`connectStream` 保持同步介面不變（內部直接 `new WebSocket(url)`）。Ticket 取得在 `useRelayWsManager` 外層完成：
 
 ```typescript
-// stream-ws.ts
-export function connectStream(
-  url: string,
-  onMessage: (msg: StreamMessage) => void,
-  onClose: () => void,
-  onOpen?: () => void,
-  getTicket?: () => Promise<string>,  // 新增
-): StreamConnection
+// useRelayWsManager.ts — relay connected 時
+if (connected && !wasConnected) {
+  const wsBase = useHostStore.getState().getWsBase(hostId)
+  const baseUrl = `${wsBase.replace('ws:', 'http:')}`
+
+  // 外層 await ticket，再帶入 URL
+  fetchWsTicket(hostId).then((ticket) => {
+    const url = new URL(`${wsBase}/ws/cli-bridge-sub/${encodeURIComponent(sessionCode)}`)
+    url.searchParams.set('ticket', ticket)
+
+    const conn = connectStream(
+      url.toString(),
+      onMessage, onClose, onOpen,
+    )
+    useStreamStore.getState().setConn(hostId, sessionCode, conn)
+    activeConns.set(ck, conn)
+  }).catch(() => {
+    // ticket fetch 失敗 — 不建立 WS
+    // 狀態機會從 host-events 路徑偵測 auth-error
+  })
+}
 ```
 
-`useRelayWsManager` 在建立 stream WS 前取 ticket：
+**設計決策**：不改 `connectStream` 簽名。原因：
+- `connectStream` 是同步函式，內部直接 `new WebSocket(url)`，塞 async getTicket 需要重構整個函式
+- Stream WS 的生命週期由 relay event 驅動（relay connected → 建立 WS），與 terminal 的長連線模式不同
+- 在外層 await 更清晰：ticket 取得是 `useRelayWsManager` 的職責，不應耦合到通用的 `connectStream`
 
-```typescript
-const conn = connectStream(
-  `${wsBase}/ws/cli-bridge-sub/${encodeURIComponent(sessionCode)}`,
-  onMessage, onClose, onOpen,
-  () => fetchWsTicket(hostId),
-)
-```
+**Race condition 防護**：如果 ticket fetch 還在進行中，relay 斷開了（`!connected && wasConnected`），cleanup 邏輯會執行 `existing?.close()`。但此時 conn 尚未建立（`then` 未執行），`activeConns.get(ck)` 為 undefined，安全。Ticket fetch 完成後的 `then` callback 會建立一個新的 conn，但此時 `relayStatus[ck]` 已為 false，下一輪 subscribe 會清理它。
 
 ### 4.5 Ticket fetch 401 處理
 
-Terminal / Stream 的 `getTicket` 失敗時呼叫 `onClose()`，通知上層。`useMultiHostEventWs` 的 WS close handler 觸發狀態機 → 狀態機重跑 negotiation → Phase 2 偵測 401 → 設 `auth-error`。
+**狀態機是唯一的 auth 狀態擁有者**。Terminal / Stream 不自行判斷 auth error。
 
-**狀態機是唯一的 auth 狀態擁有者**。Terminal / Stream 只回報失敗，不自行判斷 auth error。
+觸發路徑統一為：
+
+```
+任何 WS 的 ticket fetch 401
+  → host-events WS 也在 401（同一 host 的所有 WS 共用 token）
+  → host-events onClose 觸發狀態機（或 effect 初始 trigger）
+  → 狀態機 negotiate Phase 2 → 偵測 401 → 設 auth-error
+  → HostRuntime.status = 'auth-error'
+  → Terminal canReconnect() 回傳 false → 停止重試
+  → Stream 不建立新連線（ticket fetch 失敗直接 catch）
+```
+
+Terminal 和 Stream 不需要自己觸發狀態機，因為同一 host 的 host-events WS **一定也會遇到相同的 auth 問題**，而 host-events 的失敗路徑已與狀態機連結。
 
 ---
 
@@ -282,10 +487,12 @@ auth-error 用鎖頭圖示（Phosphor `LockSimple`）而非紅色圓圈，視覺
 ### 5.2 StatusBar
 
 ```
-auth-error → 紅色鎖頭 + "Token 無效" + "— 點擊設定 Token"
+auth-error → 紅色鎖頭 + "Token 無效" + "— 點擊設定 Token"（可點擊）
 ```
 
-不顯示「重新連線中」等暫時性語言。可點擊引導到 OverviewSection。
+不顯示「重新連線中」等暫時性語言。
+
+**導航機制**：StatusBar 新增 `onNavigateToHost?: (hostId: string) => void` prop，由外層 App/Layout 注入。點擊 auth-error 文字觸發 `onNavigateToHost(hostId)` → 切換到 HostPage → 選中該 host 的 OverviewSection。此 prop 模式與現有 `onViewModeChange` 一致。
 
 ### 5.3 OverviewSection
 
@@ -298,14 +505,15 @@ auth-error 時顯示：
 ### 5.4 Token 修改 → 自動重試
 
 ```
-使用者修改 token → updateHost(hostId, { token: newToken })
-  → onSave callback 呼叫 manualRetry()
-  → 狀態機重新 negotiate（Phase 1 + Phase 2）
+使���者修改 token → updateHost(hostId, { token: newToken })
+  → 先 setRuntime(hostId, { status: 'reconnecting' })  // 避免 auth-error 閃爍
+  → 再呼叫 manualRetry()
+  → 狀態機��新 negotiate（Phase 1 + Phase 2）
   → 成功 → 'connected'
   → 仍失敗 → 'auth-error'
 ```
 
-OverviewSection 的 TokenField `onSave` 後自動觸發 `manualRetry()`，使用者不需額外操作。
+OverviewSection 的 TokenField `onSave` 先設 `reconnecting`（讓 UI 立即從紅色鎖頭切換為黃色旋轉），再觸發 `manualRetry()`。避免舊的 auth-error 在新的 negotiate 完成前短暫閃現。
 
 ### 5.5 connectionErrorMessage 擴充
 
@@ -340,16 +548,20 @@ Phase 1 health check 解析 response body 的 `mode` 欄位，存入 `HealthResu
 
 ### 6.2 AddHostDialog 自動導流
 
-AddHostDialog 開啟時，若使用者已輸入 IP:port，可選擇先打 `GET /api/health`：
+**僅在 manual route（勾選 Token）時觸發**。Pairing route 不需要 health check — IP 從配對碼解碼而來，daemon 一定在 pairing mode。
+
+**觸發時機**：使用者在 IP + port 欄位都有值後，debounced（300ms）自動打 `GET http://{ip}:{port}/api/health`。欄位變更時重新觸發。
 
 | health mode | 行為 |
 |-------------|------|
-| `pairing` | 自動進入配對碼路線 + badge "daemon 等待配對中" |
-| `pending` | 自動進入 Token 路線 + 提示「請輸入 daemon 終端機顯示的 Token」 |
-| `normal` | Token 路線 + 提示「Daemon 運作中，請輸入已設定的 Token」 |
-| health 失敗 | 兩條路線都開放 |
+| `pairing` | 自動切換到配對碼路線（取消 Token 勾選）+ badge "daemon 等待配對中" |
+| `pending` | 維持 Token 路線 + 提示「請輸入 daemon 終端機顯示的 Token」 |
+| `normal` | 維持 Token 路線 + 提示「Daemon 運作中，請輸入已設定的 Token」 |
+| health 失敗 | 無提示，兩條路線都開放（使用者手動選） |
 
-此為 UX 優化，不影響核心流程。使用者仍可手動切換。
+使用者仍可手動覆蓋自動導流的結果（例如重新勾選/取消 Token checkbox）。
+
+此為 UX 優化，不影響核心認證流程。
 
 ---
 
@@ -359,16 +571,19 @@ AddHostDialog 開啟時，若使用者已輸入 IP:port，可選擇先打 `GET /
 
 `internal/middleware/middleware.go` L79-83 的 `?token=` fallback 移除。Phase 5b 後所有 WS 連線統一用 `?ticket=`，HTTP API 用 Bearer header。
 
+**Go 測試同步修改**：`internal/middleware/middleware_test.go` 的 `TestTokenAuthQueryParam` 目前驗證 `?token=secret` 回傳 200。移除 `?token=` 後此 test 必紅。改為驗證 `?token=` 回傳 **401**（確認 fallback 已移除）。
+
 ---
 
 ## 八、影響範圍
 
-### 8.1 Daemon（Go）— 極小
+### 8.1 Daemon（Go��— 極小
 
 | 項目 | 改動 |
 |------|------|
 | middleware.go | 刪除 `?token=` fallback（~5 行） |
-| 其他 | 無 — 不需新端點、不改 WS handler |
+| middleware_test.go | `TestTokenAuthQueryParam` 改為驗證 401 |
+| 其他 | 無 — 不需���端點、不改 WS handler |
 
 ### 8.2 SPA — 中等
 
@@ -397,11 +612,12 @@ AddHostDialog 開啟時，若使用者已輸入 IP:port，可選擇先打 `GET /
 | 檔案 | 改動 |
 |------|------|
 | `HostSidebar.tsx` | auth-error 圖示（LockSimple） |
-| `StatusBar.tsx` | auth-error 顯示 |
-| `OverviewSection.tsx` | auth-error banner + TokenField 標紅 + 自動 manualRetry |
+| `StatusBar.tsx` | auth-error 顯示 + `onNavigateToHost` prop |
+| `OverviewSection.tsx` | auth-error banner + TokenField 標紅 + 儲存後 setRuntime reconnecting + manualRetry |
 | `host-utils.ts` | `connectionErrorMessage` 加 auth-error |
-| `AddHostDialog.tsx` | health mode 自動導流 |
+| `AddHostDialog.tsx` | health mode debounced 自動導流 |
 | i18n JSON | 新增 keys |
+| App/Layout | 提供 `onNavigateToHost` callback 給 StatusBar |
 
 ### 8.3 不受影響
 
@@ -415,23 +631,79 @@ AddHostDialog 開啟時，若使用者已輸入 IP:port，可選擇先打 `GET /
 
 | 風險 | 緩解 |
 |------|------|
-| Phase 2 非 401 失敗（network error） | 只有 HTTP 401 判定 auth-error，其他回退用 Phase 1 結果 |
+| Phase 2 非 401/503 失敗 | 回退用 Phase 1 結果，不誤判為 auth-error |
 | 重連延遲（多一次 HTTP） | 僅在重連路徑，本地網路 < 10ms |
 | Pre-fetched ticket 過期 | TTL 30 秒，negotiate → WS 連線通常 < 1 秒 |
+| `stop()` 無法中止 mid-Phase-2 fetch | fetch 完成後 epoch 檢查 → 結果被丟棄，不影響正確性（殭屍 fetch 可接受） |
+| Stream ticket fetch 與 relay disconnect race | `then` callback 建立的 conn 會被下一輪 subscribe 清理（見 4.4 說明） |
 
 ---
 
-## 九、測試範圍
+## 九、��試範圍
 
-| 層面 | 測試項目 |
+### 9.1 SPA 測試
+
+**`host-connection.test.ts`**（現有，需擴充）：
+
+用 `vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce()` 鏈式 mock 序列呼叫。
+
+| 測試 case | Phase 1 | Phase 2 | 預期 daemon |
+|-----------|---------|---------|------------|
+| Phase 1 only（無 token） | 200 | 不呼叫 | `auth-error`（非 pairing 時無 token 視為 auth 問題） |
+| Phase 1 only（pairing mode 無 token） | 200 `mode:pairing` | 不呼叫 | `connected` |
+| Phase 2 成功 | 200 | 200 + ticket | `connected` + ticket |
+| Phase 2 返回 401 | 200 | 401 | `auth-error` |
+| Phase 2 返回 503（PairingGuard）| 200 | 503 | `auth-error` |
+| Phase 2 network error | 200 | throw | `connected`（回退 Phase 1） |
+| Phase 2 timeout | 200 | 掛起 >5s | `connected`（Phase 2 abort） |
+| Phase 1 timeout | 掛起 >6s | — | `unreachable` |
+| Phase 1 network error | throw TypeError | — | `refused` |
+| Mode 欄位解析 | 200 `mode:pending` | 200 | mode = `'pending'` |
+
+**`connection-state-machine.test.ts`**（現有，需擴充）：
+
+用 `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync()`。
+
+| 測試 case | 說明 |
+|-----------|------|
+| auth-error 第一次就跳出 FAST_RETRY | checkFn 只被呼叫 1 次（非 3 次） |
+| auth-error 不啟動背景重試 | advanceTimers 後 checkFn 不再被呼叫 |
+| 手動 trigger 從 auth-error 恢復 | checkFn 改回 connected → onStateChange 被呼叫 |
+
+**`ws.test.ts`**（現有，需擴充）：
+
+MockWebSocket 需補 `this.url = url` 以驗證 ticket 附加。
+
+| 測試 case | 說明 |
+|-----------|------|
+| getTicket 成功 → URL 含 `?ticket=` | 檢查 `wsInstances[0].url` |
+| getTicket 失敗 → backoff 重試 | 用 fake timer 確認 setTimeout 排程 |
+| getTicket 失敗 + canReconnect false → 停止 | 確認不再排程 |
+
+**`stream-ws.test.ts`**（現有只測 parseStreamMessage，需從零建立 WS 連線測試）：
+
+從 `ws.test.ts` 移植 MockWebSocket 基礎架構。但 `connectStream` 簽名不變（不加 getTicket），只需確認既有行為不被 Phase 5b 改動影響。
+
+**`host-events.test.ts`**（新建）：
+
+| 測試 case | 說明 |
+|-----------|------|
+| reconnectWithTicket(ticket) → URL 含 ticket | pendingTicket 一次性消費 |
+| reconnectWithTicket 後 WS 斷線 → 回退 getTicket | pendingTicket 已清空 |
+| getTicket 失敗 + 無 pendingTicket → 呼叫 onClose | 觸發狀態機路徑 |
+
+**`host-utils.test.ts`**（現有，需加 1 case）：
+
+| 測試 case | 說明 |
+|-----------|------|
+| `status: 'auth-error'` → `t('hosts.error_auth')` | 新狀態 |
+
+### 9.2 Go 測試
+
+| 檔案 | 測試項目 |
 |------|---------|
-| `checkHealth` | Phase 1 only（無 token）/ Phase 2 成功 / Phase 2 返回 401 / Phase 2 network error 回退 |
-| `ConnectionStateMachine` | auth-error 不進入 L1/L2 / 手動重試可從 auth-error 恢復到 connected |
-| `connectTerminal` | getTicket 成功帶 ticket / getTicket 失敗觸發 onClose |
-| `connectStream` | getTicket 成功帶 ticket / getTicket 失敗觸發 onClose |
-| `connectionErrorMessage` | auth-error 回傳正確 i18n key |
-| `host-utils` | 新狀態的 error message |
-| Daemon middleware | 移除 `?token=` 後既有 test 通過 |
+| `middleware_test.go` | `TestTokenAuthQueryParam` 改為：`?token=secret` → 401（確認 fallback 已移除） |
+| `middleware_test.go` | 確認 Bearer header + `?ticket=` 仍正常通過 |
 
 ---
 

--- a/docs/superpowers/specs/2026-04-06-phase5b-ws-ticket-auth-error-design.md
+++ b/docs/superpowers/specs/2026-04-06-phase5b-ws-ticket-auth-error-design.md
@@ -1,0 +1,449 @@
+# Phase 5b：WS Ticket 統一 + Auth Error UI
+
+> 前置：Phase 5a（PR #164, alpha.46）已完成配對系統 + Token 認證。
+> 本 Phase 解決 WS 連線缺乏 ticket auth、auth error 無 UI 回饋、以及 health mode 未消費三個問題。
+
+---
+
+## 一、問題陳述
+
+### 1.1 狀態機 + Auth 死循環
+
+`ConnectionStateMachine` 用 `GET /api/health`（無 auth）判斷 daemon 狀態。Health endpoint 在 outer mux、不經 TokenAuth middleware，因此 **token 失效時 health 仍回 200**。
+
+完整流程：
+
+```
+WS close → 狀態機 trigger → checkHealth(/api/health) → "connected"
+→ reconnect() → fetchWsTicket 401 → 靜默失敗（autoReconnect=false）
+→ 無人再觸發狀態機 → UI 顯示綠色 "connected" 但 WS 完全斷線
+```
+
+兩個場景：
+
+- **新 host token 錯**：WS 從未建立 → onClose 從未觸發 → 狀態機從未啟動 → HostRuntime 永遠 undefined → 灰色圓圈，無錯誤提示
+- **既有 host token 失效**：WS 斷線 → 狀態機 trigger → health ok → 設 "connected" → reconnect 失敗（ticket fetch 401）→ UI 綠色但 WS 死
+
+### 1.2 Terminal / Stream WS 無 auth
+
+| WS 端點 | 現狀 |
+|---------|------|
+| `/ws/host-events` | ✅ 有 ticket auth |
+| `/ws/terminal/{code}` | ❌ 無 auth（直接 URL 連線） |
+| `/ws/cli-bridge-sub/{code}` | ❌ 無 auth（直接 URL 連線） |
+
+三個端點都在 TokenAuth middleware 後面，daemon 會拒絕無 auth 的 WS upgrade。但 SPA 端 `connectTerminal` 和 `connectStream` 沒有取 ticket 的機制。
+
+### 1.3 Health mode 未消費（#167）
+
+`/api/health` 回傳 `mode: 'pairing' | 'pending' | 'normal'`，但 SPA 無消費者。AddHostDialog 靠 checkbox 手動切換配對碼/Token 路線。
+
+### 1.4 Legacy `?token=` 安全風險
+
+Middleware 仍有 `?token=` query param fallback（L79-83），token 出現在 URL/log/瀏覽器歷史。Phase 5b ticket 統一後無消費者。
+
+---
+
+## 二、設計方案：Negotiation-First
+
+### 核心概念
+
+狀態機的 `checkFn` 升級為兩階段 **connection negotiation**，同時驗證 reachability + auth：
+
+```
+Phase 1: GET /api/health (no auth) → daemon 是否活著 + mode
+Phase 2: POST /api/ws-ticket (Bearer token) → token 是否有效 + pre-fetch ticket
+```
+
+靈感來自 Slack Socket Mode 的 `connections.open` 模式：HTTP 端點負責所有 auth，回傳可直接使用的 WS 憑證。Auth 失敗在 HTTP 層就被偵測，不會進入 WS 層。
+
+### 為什麼用 ws-ticket 作為 auth probe
+
+- `POST /api/ws-ticket` 需要 Bearer token → 401 = token 錯誤
+- 成功時回傳 ticket → 直接給 host-events WS 使用，零浪費
+- 不需要新端點、不需要「借用」`/api/info` 驗 auth
+
+---
+
+## 三、狀態模型
+
+### 3.1 HealthResult 擴充
+
+```typescript
+// host-connection.ts
+interface HealthResult {
+  daemon: 'connected' | 'refused' | 'unreachable' | 'auth-error'
+  tmux: 'ok' | 'unavailable'
+  latency: number | null
+  mode?: 'pairing' | 'pending' | 'normal'
+  ticket?: string  // Phase 2 成功時附帶
+}
+```
+
+### 3.2 checkHealth 兩階段
+
+```typescript
+async function checkHealth(
+  baseUrl: string,
+  getToken?: () => string | undefined,
+): Promise<HealthResult> {
+  // Phase 1: health (no auth, 6s timeout)
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 6000)
+  try {
+    const start = performance.now()
+    const res = await fetch(`${baseUrl}/api/health`, { signal: controller.signal })
+    const latency = Math.round(performance.now() - start)
+    const body = await res.json()
+    const mode = body.mode as 'pairing' | 'pending' | 'normal' | undefined
+
+    // Phase 2: auth probe (only if token available)
+    const token = getToken?.()
+    if (!token) {
+      return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+    }
+    const ticketRes = await fetch(`${baseUrl}/api/ws-ticket`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (ticketRes.status === 401) {
+      return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
+    }
+    if (!ticketRes.ok) {
+      // ws-ticket endpoint 異常但非 auth → 視為 connected
+      return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+    }
+    const { ticket } = await ticketRes.json()
+    return { daemon: 'connected', tmux: 'unavailable', latency, mode, ticket }
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { daemon: 'unreachable', tmux: 'unavailable', latency: null }
+    }
+    return { daemon: 'refused', tmux: 'unavailable', latency: null }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+```
+
+### 3.3 狀態機新增 auth-error 分支
+
+```typescript
+// connection-state-machine.ts — trigger() 分類邏輯
+
+if (lastResult.daemon === 'connected') return    // recovered
+if (lastResult.daemon === 'auth-error') return   // 永久錯誤，不背景重試
+if (lastResult.daemon === 'unreachable') {       // L1: 不間斷重連
+  this.backgroundDeadline = null
+  this.startBackground(L1_RETRY_DELAY_MS)
+}
+if (lastResult.daemon === 'refused') {           // L2: 3s 間隔，3 分鐘停止
+  this.backgroundDeadline = Date.now() + L2_RETRY_TIMEOUT_MS
+  this.startBackground(L2_RETRY_DELAY_MS)
+}
+```
+
+### 3.4 HostRuntime 擴充
+
+```typescript
+interface HostRuntime {
+  status: 'connected' | 'disconnected' | 'reconnecting' | 'auth-error'
+  latency?: number
+  info?: HostInfo
+  daemonState?: 'connected' | 'refused' | 'unreachable' | 'auth-error'
+  tmuxState?: 'ok' | 'unavailable'
+  manualRetry?: () => void
+}
+```
+
+### 3.5 狀態流轉
+
+```
+                    ┌──────────────┐
+                    │   (initial)  │
+                    └──────┬───────┘
+                           │ effect 啟動
+                           ▼
+                    ┌──────────────┐
+           ┌───────│  negotiating  │◄──── 手動重試 / WS close
+           │       └──────┬───────┘
+           │              │ Phase 1 + Phase 2
+           │              ▼
+     ┌─────┴─────┬────────┴────────┬──────────────┐
+     ▼           ▼                 ▼              ▼
+ connected   unreachable       refused       auth-error
+ (綠色)      (L1 重試)        (L2 重試)      (鎖頭,不重試)
+     │           │                │
+     │      背景重連成功       背景重連成功
+     │           │                │
+     ▼           └───►connected◄──┘
+  WS 連線
+```
+
+---
+
+## 四、WS Ticket 統一
+
+### 4.1 三條 WS 的 ticket 來源
+
+| WS 端點 | 管理者 | Ticket 來源 |
+|---------|--------|------------|
+| `/ws/host-events` | `useMultiHostEventWs` | 狀態機 negotiation 的 pre-fetched ticket；後續重連由狀態機再次 negotiate |
+| `/ws/terminal/{code}` | `useTerminalWs` | 連線前呼叫 `fetchWsTicket(hostId)` |
+| `/ws/cli-bridge-sub/{code}` | `useRelayWsManager` | 連線前呼叫 `fetchWsTicket(hostId)` |
+
+### 4.2 host-events：pre-fetched ticket
+
+狀態機 Phase 2 成功時已拿到 ticket。`useMultiHostEventWs` 的 `onStateChange` callback 將 ticket 傳給 `connectHostEvents`：
+
+```typescript
+if (result.daemon === 'connected' && connRef.current) {
+  connRef.current.reconnectWithTicket(result.ticket)
+}
+```
+
+`connectHostEvents` 介面調整：接受 `ticket?: string` 直接使用（跳過 `getTicket` callback）。若 ticket 已過期（WS upgrade 失敗），觸發狀態機重新 negotiate。
+
+### 4.3 connectTerminal 加 getTicket
+
+```typescript
+// ws.ts
+export function connectTerminal(
+  url: string,
+  onData: (data: ArrayBuffer) => void,
+  onClose: () => void,
+  onOpen?: () => void,
+  canReconnect?: () => boolean,
+  getTicket?: () => Promise<string>,  // 新增
+): TerminalConnection
+```
+
+連線流程：
+
+```
+connect() {
+  if (getTicket) {
+    try { ticket = await getTicket() → append ?ticket= to URL }
+    catch { onClose() → 通知上層 → 觸發狀態機; return }
+  }
+  ws = new WebSocket(wsUrl)
+  ...
+}
+```
+
+`useTerminalWs` 和 `SessionPaneContent` 傳入 `() => fetchWsTicket(hostId)`。
+
+### 4.4 connectStream 加 getTicket
+
+```typescript
+// stream-ws.ts
+export function connectStream(
+  url: string,
+  onMessage: (msg: StreamMessage) => void,
+  onClose: () => void,
+  onOpen?: () => void,
+  getTicket?: () => Promise<string>,  // 新增
+): StreamConnection
+```
+
+`useRelayWsManager` 在建立 stream WS 前取 ticket：
+
+```typescript
+const conn = connectStream(
+  `${wsBase}/ws/cli-bridge-sub/${encodeURIComponent(sessionCode)}`,
+  onMessage, onClose, onOpen,
+  () => fetchWsTicket(hostId),
+)
+```
+
+### 4.5 Ticket fetch 401 處理
+
+Terminal / Stream 的 `getTicket` 失敗時呼叫 `onClose()`，通知上層。`useMultiHostEventWs` 的 WS close handler 觸發狀態機 → 狀態機重跑 negotiation → Phase 2 偵測 401 → 設 `auth-error`。
+
+**狀態機是唯一的 auth 狀態擁有者**。Terminal / Stream 只回報失敗，不自行判斷 auth error。
+
+---
+
+## 五、Auth Error UI
+
+### 5.1 HostSidebar 狀態圖示
+
+| 狀態 | 圖示 | 顏色 |
+|------|------|------|
+| connected | 實心圓 | green-400 |
+| connected + tmux ✗ | Warning | yellow-400 |
+| reconnecting | Spinner | yellow-400 animate-spin |
+| auth-error | Lock（鎖頭） | red-400 animate-pulse |
+| disconnected | 實心圓 | red-400 |
+| (no runtime) | 實心圓 | text-muted |
+
+auth-error 用鎖頭圖示（Phosphor `LockSimple`）而非紅色圓圈，視覺上與 disconnected 區分。Host 名稱文字也改為 red-400。
+
+### 5.2 StatusBar
+
+```
+auth-error → 紅色鎖頭 + "Token 無效" + "— 點擊設定 Token"
+```
+
+不顯示「重新連線中」等暫時性語言。可點擊引導到 OverviewSection。
+
+### 5.3 OverviewSection
+
+auth-error 時顯示：
+
+1. **Banner**（紅色背景）：鎖頭圖示 + "Token 無效" + "請確認 Token 與 daemon 設定一致，修改後自動重新連線"
+2. **TokenField**：label 標紅 + 外框紅色 border + 錯誤提示文字
+3. **Status 欄位**：鎖頭 + "auth-error"
+
+### 5.4 Token 修改 → 自動重試
+
+```
+使用者修改 token → updateHost(hostId, { token: newToken })
+  → onSave callback 呼叫 manualRetry()
+  → 狀態機重新 negotiate（Phase 1 + Phase 2）
+  → 成功 → 'connected'
+  → 仍失敗 → 'auth-error'
+```
+
+OverviewSection 的 TokenField `onSave` 後自動觸發 `manualRetry()`，使用者不需額外操作。
+
+### 5.5 connectionErrorMessage 擴充
+
+```typescript
+// host-utils.ts
+export function connectionErrorMessage(runtime, t): string | null {
+  if (runtime?.status === 'auth-error') return t('hosts.error_auth')
+  if (runtime?.daemonState === 'unreachable') return t('hosts.error_unreachable')
+  if (runtime?.daemonState === 'refused') return t('hosts.error_refused')
+  if (runtime?.status === 'connected' && runtime?.tmuxState === 'unavailable')
+    return t('hosts.error_tmux_down')
+  return null
+}
+```
+
+### 5.6 i18n keys 新增
+
+```
+hosts.error_auth        → "Token 無效，請確認 Token 與 daemon 設定一致"
+hosts.auth_error        → "Token 無效"
+hosts.auth_error_hint   → "請確認 Token 與 daemon 設定一致，修改後自動重新連線"
+status.auth_error       → "Token 無效，點擊設定"
+```
+
+---
+
+## 六、Health Mode 消費（#167）
+
+### 6.1 checkHealth 回傳 mode
+
+Phase 1 health check 解析 response body 的 `mode` 欄位，存入 `HealthResult.mode`。
+
+### 6.2 AddHostDialog 自動導流
+
+AddHostDialog 開啟時，若使用者已輸入 IP:port，可選擇先打 `GET /api/health`：
+
+| health mode | 行為 |
+|-------------|------|
+| `pairing` | 自動進入配對碼路線 + badge "daemon 等待配對中" |
+| `pending` | 自動進入 Token 路線 + 提示「請輸入 daemon 終端機顯示的 Token」 |
+| `normal` | Token 路線 + 提示「Daemon 運作中，請輸入已設定的 Token」 |
+| health 失敗 | 兩條路線都開放 |
+
+此為 UX 優化，不影響核心流程。使用者仍可手動切換。
+
+---
+
+## 七、Legacy 清理
+
+### 7.1 移除 `?token=` query param
+
+`internal/middleware/middleware.go` L79-83 的 `?token=` fallback 移除。Phase 5b 後所有 WS 連線統一用 `?ticket=`，HTTP API 用 Bearer header。
+
+---
+
+## 八、影響範圍
+
+### 8.1 Daemon（Go）— 極小
+
+| 項目 | 改動 |
+|------|------|
+| middleware.go | 刪除 `?token=` fallback（~5 行） |
+| 其他 | 無 — 不需新端點、不改 WS handler |
+
+### 8.2 SPA — 中等
+
+**核心架構**：
+
+| 檔案 | 改動 |
+|------|------|
+| `host-connection.ts` | `checkHealth` 兩階段 + `HealthResult` 擴充 |
+| `connection-state-machine.ts` | auth-error 分支（不進入 L1/L2） |
+| `useHostStore.ts` | `HostRuntime.status` 加 `'auth-error'` |
+
+**WS Ticket 統一**：
+
+| 檔案 | 改動 |
+|------|------|
+| `ws.ts` | `connectTerminal` 加 `getTicket` 參數 |
+| `stream-ws.ts` | `connectStream` 加 `getTicket` 參數 |
+| `host-events.ts` | `connectHostEvents` 支援 `reconnectWithTicket` |
+| `useTerminalWs.ts` | 傳入 `getTicket` |
+| `SessionPaneContent.tsx` | 提供 `getTicket` callback |
+| `useRelayWsManager.ts` | stream WS 前 fetch ticket |
+| `useMultiHostEventWs.ts` | 傳遞 pre-fetched ticket + auth-error 處理 |
+
+**UI**：
+
+| 檔案 | 改動 |
+|------|------|
+| `HostSidebar.tsx` | auth-error 圖示（LockSimple） |
+| `StatusBar.tsx` | auth-error 顯示 |
+| `OverviewSection.tsx` | auth-error banner + TokenField 標紅 + 自動 manualRetry |
+| `host-utils.ts` | `connectionErrorMessage` 加 auth-error |
+| `AddHostDialog.tsx` | health mode 自動導流 |
+| i18n JSON | 新增 keys |
+
+### 8.3 不受影響
+
+- Daemon 所有 API 端點（行為不變）
+- Daemon WS handler（已支援 ticket）
+- Host 資料持久化（HostConfig 型別不變）
+- Tab / Session / Stream / Agent store
+- 已建立的 WS 連線（auth 只在 upgrade 時驗）
+
+### 8.4 風險
+
+| 風險 | 緩解 |
+|------|------|
+| Phase 2 非 401 失敗（network error） | 只有 HTTP 401 判定 auth-error，其他回退用 Phase 1 結果 |
+| 重連延遲（多一次 HTTP） | 僅在重連路徑，本地網路 < 10ms |
+| Pre-fetched ticket 過期 | TTL 30 秒，negotiate → WS 連線通常 < 1 秒 |
+
+---
+
+## 九、測試範圍
+
+| 層面 | 測試項目 |
+|------|---------|
+| `checkHealth` | Phase 1 only（無 token）/ Phase 2 成功 / Phase 2 返回 401 / Phase 2 network error 回退 |
+| `ConnectionStateMachine` | auth-error 不進入 L1/L2 / 手動重試可從 auth-error 恢復到 connected |
+| `connectTerminal` | getTicket 成功帶 ticket / getTicket 失敗觸發 onClose |
+| `connectStream` | getTicket 成功帶 ticket / getTicket 失敗觸發 onClose |
+| `connectionErrorMessage` | auth-error 回傳正確 i18n key |
+| `host-utils` | 新狀態的 error message |
+| Daemon middleware | 移除 `?token=` 後既有 test 通過 |
+
+---
+
+## 十、關聯 Issues
+
+| Issue | 解決方式 |
+|-------|---------|
+| #148 pt.2 — Terminal/Stream WS 無 Bearer | 統一用 ticket |
+| #148 pt.3 — WS 401 無 auth error 提示 | 狀態機偵測 + UI 顯示 |
+| #167 — health mode SPA 未消費 | 狀態機 Phase 1 + AddHostDialog 導流 |
+| 死循環 — 狀態機誤判 connected | 兩階段 negotiation |
+| 靜默失敗 — 新 host token 錯無回饋 | 狀態機首次 negotiation 偵測 |
+| `?token=` 安全風險 | 移除 legacy fallback |
+
+不涵蓋（獨立處理）：#165 測試覆蓋率、#166 程式碼清理、#159 ghost reconnect、#160 WriteControl。

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -52,10 +52,10 @@ type TicketValidator interface {
 	Validate(ticket string) bool
 }
 
-// TokenAuth checks Bearer token, one-time ticket, or ?token= query param.
+// TokenAuth checks Bearer token or one-time ticket (?ticket=).
 // tokenFn is called on each request to support runtime token changes.
 // Bearer prefix is case-insensitive, token value is case-sensitive.
-// If tickets is non-nil, ?ticket= is checked before the legacy ?token= fallback.
+// If tickets is non-nil, ?ticket= is checked for WebSocket authentication.
 func TokenAuth(tokenFn func() string, tickets TicketValidator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -75,11 +75,6 @@ func TokenAuth(tokenFn func() string, tickets TicketValidator) func(http.Handler
 					next.ServeHTTP(w, r)
 					return
 				}
-			}
-			// Fallback: ?token= query param (legacy, will be removed)
-			if subtle.ConstantTimeCompare([]byte(r.URL.Query().Get("token")), []byte(token)) == 1 {
-				next.ServeHTTP(w, r)
-				return
 			}
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 		})

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -77,13 +77,13 @@ func TestTokenAuthCaseSensitive(t *testing.T) {
 	}
 }
 
-func TestTokenAuthQueryParam(t *testing.T) {
+func TestTokenAuthQueryParamRemoved(t *testing.T) {
 	h := middleware.TokenAuth(func() string { return "secret" }, nil)(ok)
 	req := httptest.NewRequest("GET", "/?token=secret", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
-	if rec.Code != 200 {
-		t.Errorf("want 200 for valid query param token, got %d", rec.Code)
+	if rec.Code != 401 {
+		t.Errorf("want 401 for removed query param token, got %d", rec.Code)
 	}
 }
 

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -251,6 +251,15 @@ export default function App() {
             onViewModeChange={(tabId, paneId, mode) => {
               useTabStore.getState().setViewMode(tabId, paneId, mode)
             }}
+            onNavigateToHost={(hostId) => {
+              const tabId = useTabStore.getState().openSingletonTab({ kind: 'hosts' })
+              if (activeWorkspaceId) {
+                useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, tabId)
+                useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, tabId)
+              }
+              handleSelectTab(tabId)
+              useHostStore.getState().setActiveHost(hostId)
+            }}
           />
         </div>
         {contextMenu && (

--- a/spa/src/components/SessionPaneContent.tsx
+++ b/spa/src/components/SessionPaneContent.tsx
@@ -7,6 +7,7 @@ import { useStreamStore } from '../stores/useStreamStore'
 import { useConfigStore } from '../stores/useConfigStore'
 import { useTabStore } from '../stores/useTabStore'
 import { handoff } from '../lib/api'
+import { fetchWsTicket } from '../lib/host-api'
 import { useHostStore } from '../stores/useHostStore'
 import { findPane } from '../lib/pane-tree'
 import type { PaneRendererProps } from '../lib/pane-registry'
@@ -86,6 +87,7 @@ export function SessionPaneContent({ pane, isActive }: PaneRendererProps) {
       visible={isActive}
       hostId={hostId}
       sessionCode={sessionCode}
+      getTicket={() => fetchWsTicket(hostId)}
     />
   )
 }

--- a/spa/src/components/StatusBar.tsx
+++ b/spa/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { CaretUp, CircleNotch, CheckCircle, XCircle } from '@phosphor-icons/react'
+import { CaretUp, CircleNotch, CheckCircle, XCircle, LockSimple } from '@phosphor-icons/react'
 import type { Tab } from '../types/tab'
 import { getPrimaryPane } from '../lib/pane-tree'
 import { useSessionStore } from '../stores/useSessionStore'
@@ -13,6 +13,7 @@ import { useI18nStore } from '../stores/useI18nStore'
 interface Props {
   activeTab: Tab | null
   onViewModeChange?: (tabId: string, paneId: string, mode: 'terminal' | 'stream') => void
+  onNavigateToHost?: (hostId: string) => void
 }
 
 const VIEW_MODE_COLORS: Record<string, string> = {
@@ -80,7 +81,7 @@ function UploadStatus({ hostId, sessionCode, t }: { hostId: string | null; sessi
   return null
 }
 
-export function StatusBar({ activeTab, onViewModeChange }: Props) {
+export function StatusBar({ activeTab, onViewModeChange, onNavigateToHost }: Props) {
   const t = useI18nStore((s) => s.t)
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -136,15 +137,21 @@ export function StatusBar({ activeTab, onViewModeChange }: Props) {
     <div className="h-6 bg-surface-secondary border-t border-border-subtle flex items-center px-3 text-[10px] text-text-muted gap-3 flex-shrink-0 relative z-10">
       <span>{hostName}</span>
       <span>{sessionName}</span>
-      <span className={
-        status === 'connected' && hostRuntime?.tmuxState === 'unavailable' ? 'text-yellow-400'
-          : status === 'connected' ? 'text-green-500'
-          : status === 'reconnecting' ? 'text-yellow-400'
-          : 'text-red-400'
-      }>
-        {status === 'connected' && hostRuntime?.tmuxState === 'unavailable'
-          ? t('hosts.error_tmux_down')
-          : status}
+      <span
+        className={
+          status === 'auth-error' ? 'text-red-400 cursor-pointer flex items-center gap-1'
+            : status === 'connected' && hostRuntime?.tmuxState === 'unavailable' ? 'text-yellow-400'
+            : status === 'connected' ? 'text-green-500'
+            : status === 'reconnecting' ? 'text-yellow-400'
+            : 'text-red-400'
+        }
+        onClick={status === 'auth-error' && agentHostId ? () => onNavigateToHost?.(agentHostId) : undefined}
+      >
+        {status === 'auth-error' && <LockSimple size={10} weight="fill" />}
+        {status === 'auth-error' ? t('hosts.auth_error')
+          : status === 'connected' && hostRuntime?.tmuxState === 'unavailable'
+            ? t('hosts.error_tmux_down')
+            : status}
       </span>
       {getAgentLabel(agentEvent) && (() => {
         const label = getAgentLabel(agentEvent)!

--- a/spa/src/components/TerminalView.tsx
+++ b/spa/src/components/TerminalView.tsx
@@ -17,9 +17,10 @@ interface Props {
   connectingMessage?: string
   hostId?: string
   sessionCode?: string
+  getTicket?: () => Promise<string>
 }
 
-export default function TerminalView({ wsUrl, visible = true, connectingMessage, hostId, sessionCode }: Props) {
+export default function TerminalView({ wsUrl, visible = true, connectingMessage, hostId, sessionCode, getTicket }: Props) {
   const { termRef, fitAddonRef, containerRef } = useTerminal()
   const [ready, setReady] = useState(false)
   const [disconnected, setDisconnected] = useState(false)
@@ -38,6 +39,7 @@ export default function TerminalView({ wsUrl, visible = true, connectingMessage,
     onReady: handleReady,
     onDisconnect: handleDisconnect,
     onReconnect: handleReconnect,
+    getTicket,
   })
 
   // Manual reconnect

--- a/spa/src/components/hosts/AddHostDialog.tsx
+++ b/spa/src/components/hosts/AddHostDialog.tsx
@@ -25,6 +25,32 @@ export function AddHostDialog({ onClose }: Props) {
   const [error, setError] = useState('')
   const [useToken, setUseToken] = useState(false)
   const [setupSecret, setSetupSecret] = useState('')
+  const [healthMode, setHealthMode] = useState<'pairing' | 'pending' | 'normal' | null>(null)
+
+  // Debounced health check in manual (token) mode
+  useEffect(() => {
+    if (!useToken || !ip || stage === 'saving' || stage === 'done') {
+      setHealthMode(null)
+      return
+    }
+    const portNum = port || '7860'
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`http://${ip}:${portNum}/api/health`)
+        const body = await res.json()
+        const mode = body.mode ?? 'normal'
+        setHealthMode(mode)
+        // Auto-switch to pairing route if daemon is in pairing mode and no token entered yet
+        if (mode === 'pairing' && !token) {
+          handleToggleToken(false)
+        }
+      } catch {
+        setHealthMode(null)
+      }
+    }, 300)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [useToken, ip, port, stage])
 
   // Escape to close
   useEffect(() => {
@@ -196,6 +222,19 @@ export function AddHostDialog({ onClose }: Props) {
             />
             {t('hosts.use_token')}
           </label>
+
+          {/* Mode badge */}
+          {healthMode && useToken && (
+            <div className={`flex items-start gap-2 px-2 py-2 rounded text-xs ${
+              healthMode === 'pairing' ? 'bg-yellow-500/10 border border-yellow-500/20 text-yellow-400'
+                : healthMode === 'pending' ? 'bg-blue-500/10 border border-blue-500/20 text-blue-400'
+                : 'bg-green-500/10 border border-green-500/20 text-green-400'
+            }`}>
+              {healthMode === 'pairing' && t('hosts.mode_pairing_hint')}
+              {healthMode === 'pending' && t('hosts.mode_pending_hint')}
+              {healthMode === 'normal' && t('hosts.mode_normal_hint')}
+            </div>
+          )}
 
           {/* Host / Port / Token fields */}
           <div className="grid grid-cols-3 gap-2">

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -1,4 +1,4 @@
-import { Plus, CaretDown, CaretRight, Circle, Spinner, Warning } from '@phosphor-icons/react'
+import { Plus, CaretDown, CaretRight, Circle, LockSimple, Spinner, Warning } from '@phosphor-icons/react'
 import { useState } from 'react'
 import { useHostStore, type HostRuntime } from '../../stores/useHostStore'
 import { useI18nStore } from '../../stores/useI18nStore'
@@ -24,6 +24,8 @@ function StatusIcon({ runtime }: { runtime?: HostRuntime }) {
     return <Warning size={12} weight="fill" className="text-yellow-400" />
   if (runtime.status === 'connected') return <Circle size={8} weight="fill" className="text-green-400" />
   if (runtime.status === 'reconnecting') return <Spinner size={10} className="text-yellow-400 animate-spin" />
+  if (runtime.status === 'auth-error')
+    return <LockSimple size={12} weight="fill" className="text-red-400" />
   return <Circle size={8} weight="fill" className="text-red-400" />
 }
 
@@ -65,7 +67,11 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
               >
                 {isExpanded ? <CaretDown size={10} /> : <CaretRight size={10} />}
                 <StatusIcon runtime={runtime[hostId]} />
-                <span className="truncate flex-1">{host.name}</span>
+                <span
+                  className={`truncate flex-1 ${runtime[hostId]?.status === 'auth-error' ? 'text-red-400' : ''}`}
+                >
+                  {host.name}
+                </span>
               </button>
               {isExpanded && (
                 <div className="ml-4 border-l-2 border-border-subtle pl-2 mt-1">

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -25,7 +25,7 @@ function StatusIcon({ runtime }: { runtime?: HostRuntime }) {
   if (runtime.status === 'connected') return <Circle size={8} weight="fill" className="text-green-400" />
   if (runtime.status === 'reconnecting') return <Spinner size={10} className="text-yellow-400 animate-spin" />
   if (runtime.status === 'auth-error')
-    return <LockSimple size={12} weight="fill" className="text-red-400" />
+    return <LockSimple size={12} weight="fill" className="text-red-400 animate-pulse" />
   return <Circle size={8} weight="fill" className="text-red-400" />
 }
 

--- a/spa/src/components/hosts/OverviewSection.tsx
+++ b/spa/src/components/hosts/OverviewSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { CaretDown, CaretRight, ArrowsClockwise, Trash, Plugs, Eye, EyeSlash, Check, X } from '@phosphor-icons/react'
+import { CaretDown, CaretRight, ArrowsClockwise, Trash, Plugs, Eye, EyeSlash, Check, X, LockSimple } from '@phosphor-icons/react'
 import { useHostStore, type HostConfig, type HostInfo, type HostRuntime } from '../../stores/useHostStore'
 import { useSessionStore } from '../../stores/useSessionStore'
 import { useTabStore } from '../../stores/useTabStore'
@@ -474,6 +474,16 @@ export function OverviewSection({ hostId }: Props) {
     <div className="max-w-2xl space-y-2">
       <h2 className="text-lg font-semibold mb-4">{host.name}</h2>
 
+      {runtime?.status === 'auth-error' && (
+        <div className="flex items-start gap-3 px-3 py-2.5 rounded-md mb-4 bg-red-500/10 border border-red-500/20">
+          <LockSimple size={16} weight="fill" className="text-red-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm text-red-400 font-medium">{t('hosts.auth_error')}</p>
+            <p className="text-xs text-text-muted mt-0.5">{t('hosts.auth_error_hint')}</p>
+          </div>
+        </div>
+      )}
+
       {/* ─── Connection ─── */}
       <Section title={t('hosts.connection')}>
         <EditableField
@@ -495,12 +505,19 @@ export function OverviewSection({ hostId }: Props) {
           token={host.token}
           ip={host.ip}
           port={host.port}
-          onSave={(token) => updateHost(hostId, { token: token || undefined })}
+          onSave={(token) => {
+            updateHost(hostId, { token: token || undefined })
+            // Auto-retry: set reconnecting then trigger SM
+            useHostStore.getState().setRuntime(hostId, { status: 'reconnecting' })
+            const rt = useHostStore.getState().runtime[hostId]
+            if (rt?.manualRetry) rt.manualRetry()
+          }}
           t={t}
         />
         <Field label={t('hosts.status')}>
           <span className={`text-sm ${
-            runtime?.status === 'connected' && runtime?.tmuxState === 'unavailable' ? 'text-yellow-400'
+            runtime?.status === 'auth-error' ? 'text-red-400'
+              : runtime?.status === 'connected' && runtime?.tmuxState === 'unavailable' ? 'text-yellow-400'
               : runtime?.status === 'connected' ? 'text-green-400'
               : runtime?.status === 'reconnecting' ? 'text-yellow-400'
               : 'text-red-400'

--- a/spa/src/hooks/useMultiHostEventWs.ts
+++ b/spa/src/hooks/useMultiHostEventWs.ts
@@ -1,6 +1,6 @@
 // spa/src/hooks/useMultiHostEventWs.ts — Multi-host event WS + connection state machine
 import { useEffect } from 'react'
-import { useHostStore } from '../stores/useHostStore'
+import { useHostStore, type HostRuntime } from '../stores/useHostStore'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useStreamStore } from '../stores/useStreamStore'
 import { useAgentStore } from '../stores/useAgentStore'
@@ -9,7 +9,7 @@ import { connectHostEvents, type EventConnection } from '../lib/host-events'
 import { scanPaneTree } from '../lib/pane-tree'
 import { hostWsUrl, fetchWsTicket } from '../lib/host-api'
 import { fetchHistory } from '../lib/api'
-import { checkHealth } from '../lib/host-connection'
+import { checkHealth, type HealthResult } from '../lib/host-connection'
 import { ConnectionStateMachine } from '../lib/connection-state-machine'
 import type { Session } from '../lib/api'
 
@@ -29,19 +29,28 @@ export function useMultiHostEventWs() {
       // --- Connection state machine (per host) ---
       const connRef: { current: EventConnection | undefined } = { current: undefined }
 
+      const statusMap: Record<HealthResult['daemon'], HostRuntime['status']> = {
+        connected: 'connected',
+        unreachable: 'disconnected',
+        refused: 'disconnected',
+        'auth-error': 'auth-error',
+      }
+
       const sm = new ConnectionStateMachine(
-        () => checkHealth(baseUrl),
+        () => checkHealth(baseUrl, () => useHostStore.getState().hosts[hostId]?.token),
         (result) => {
           useHostStore.getState().setRuntime(hostId, {
-            status: result.daemon === 'connected' ? 'connected' : 'disconnected',
+            status: statusMap[result.daemon],
             latency: result.latency ?? undefined,
             daemonState: result.daemon,
-            // tmuxState 不在此設定 — checkHealth 的 tmux 永遠是 'unavailable'（硬編碼），
-            // 真正的 tmux 狀態由 WS 'tmux' event 推送，在 onOpen/onMessage 中更新。
           })
-          // On recovery → reconnect WS
+          // On recovery → reconnect WS with pre-fetched ticket
           if (result.daemon === 'connected' && connRef.current) {
-            connRef.current.reconnect()
+            if (result.ticket) {
+              connRef.current.reconnectWithTicket(result.ticket)
+            } else {
+              connRef.current.reconnect()
+            }
           }
         },
       )
@@ -133,9 +142,13 @@ export function useMultiHostEventWs() {
         },
         () => fetchWsTicket(hostId),
         false, // autoReconnect disabled — SM manages reconnection
+        true,  // lazy — waits for SM to trigger first connection
       )
       connRef.current = conn
       connections.set(hostId, conn)
+
+      // Start negotiation — SM will trigger reconnectWithTicket on success
+      sm.trigger()
     }
 
     return () => {

--- a/spa/src/hooks/useMultiHostEventWs.ts
+++ b/spa/src/hooks/useMultiHostEventWs.ts
@@ -188,7 +188,13 @@ export function useMultiHostEventWs() {
       // Start negotiation — SM will trigger reconnectWithTicket on success
       sm.trigger()
     }
+    // No cleanup here — diff logic handles teardown of changed/removed hosts.
+    // Unmount cleanup is handled by the separate effect below.
+  }, [hostConfigKey])
 
+  // Unmount-only cleanup: close all entries when the component unmounts
+  useEffect(() => {
+    const entries = entriesRef.current
     return () => {
       entries.forEach((entry) => {
         entry.conn.close()
@@ -196,5 +202,5 @@ export function useMultiHostEventWs() {
       })
       entries.clear()
     }
-  }, [hostConfigKey])
+  }, [])
 }

--- a/spa/src/hooks/useMultiHostEventWs.ts
+++ b/spa/src/hooks/useMultiHostEventWs.ts
@@ -1,5 +1,5 @@
 // spa/src/hooks/useMultiHostEventWs.ts — Multi-host event WS + connection state machine
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useHostStore, type HostRuntime } from '../stores/useHostStore'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useStreamStore } from '../stores/useStreamStore'
@@ -13,20 +13,58 @@ import { checkHealth, type HealthResult } from '../lib/host-connection'
 import { ConnectionStateMachine } from '../lib/connection-state-machine'
 import type { Session } from '../lib/api'
 
+interface HostEntry {
+  conn: EventConnection
+  sm: ConnectionStateMachine
+  configKey: string // "ip:port"
+}
+
 export function useMultiHostEventWs() {
-  const hostOrderKey = useHostStore((s) => s.hostOrder.join(','))
+  const hostConfigKey = useHostStore((s) =>
+    s.hostOrder.map((id) => {
+      const h = s.hosts[id]
+      return h ? `${id}:${h.ip}:${h.port}` : id
+    }).join(',')
+  )
+
+  const entriesRef = useRef(new Map<string, HostEntry>())
 
   useEffect(() => {
     const { hosts, hostOrder } = useHostStore.getState()
-    const connections = new Map<string, EventConnection>()
-    const stateMachines = new Map<string, ConnectionStateMachine>()
+    const entries = entriesRef.current
+    const currentIds = new Set(hostOrder)
 
+    // 1. Remove hosts no longer in hostOrder
+    for (const [hostId, entry] of entries) {
+      if (!currentIds.has(hostId)) {
+        entry.conn.close()
+        entry.sm.stop()
+        entries.delete(hostId)
+      }
+    }
+
+    // 2. For each host, check if configKey changed; skip if same
     for (const hostId of hostOrder) {
-      if (!hosts[hostId]) continue
+      const host = hosts[hostId]
+      if (!host) continue
+
+      const configKey = `${host.ip}:${host.port}`
+      const existing = entries.get(hostId)
+
+      if (existing && existing.configKey === configKey) {
+        continue // no change — keep existing connection
+      }
+
+      // Teardown old entry if config changed
+      if (existing) {
+        existing.conn.close()
+        existing.sm.stop()
+      }
+
+      // Create new SM + WS for this host
       const wsUrl = hostWsUrl(hostId, '/ws/host-events')
       const baseUrl = useHostStore.getState().getDaemonBase(hostId)
 
-      // --- Connection state machine (per host) ---
       const connRef: { current: EventConnection | undefined } = { current: undefined }
 
       const statusMap: Record<HealthResult['daemon'], HostRuntime['status']> = {
@@ -54,7 +92,6 @@ export function useMultiHostEventWs() {
           }
         },
       )
-      stateMachines.set(hostId, sm)
       useHostStore.getState().setRuntime(hostId, { manualRetry: () => sm.trigger() })
 
       // --- WS connection (per host) ---
@@ -145,15 +182,19 @@ export function useMultiHostEventWs() {
         true,  // lazy — waits for SM to trigger first connection
       )
       connRef.current = conn
-      connections.set(hostId, conn)
+
+      entries.set(hostId, { conn, sm, configKey })
 
       // Start negotiation — SM will trigger reconnectWithTicket on success
       sm.trigger()
     }
 
     return () => {
-      connections.forEach((c) => c.close())
-      stateMachines.forEach((sm) => sm.stop())
+      entries.forEach((entry) => {
+        entry.conn.close()
+        entry.sm.stop()
+      })
+      entries.clear()
     }
-  }, [hostOrderKey])
+  }, [hostConfigKey])
 }

--- a/spa/src/hooks/useRelayWsManager.ts
+++ b/spa/src/hooks/useRelayWsManager.ts
@@ -15,6 +15,7 @@ export function useRelayWsManager() {
 
   useEffect(() => {
     const activeConns = new Map<string, { close: () => void }>()
+    const pendingFetches = new Set<string>()
 
     const unsub = useStreamStore.subscribe(
       (s) => s.relayStatus,
@@ -28,11 +29,15 @@ export function useRelayWsManager() {
           const sessionCode = colonIdx >= 0 ? ck.slice(colonIdx + 1) : ck
 
           if (connected && !wasConnected) {
+            if (pendingFetches.has(ck)) continue // ticket fetch already in flight
+
             // Derive wsBase for this specific host
             const wsBase = useHostStore.getState().getWsBase(hostId)
 
             // Fetch ticket before opening stream WS
+            pendingFetches.add(ck)
             fetchWsTicket(hostId).then((ticket) => {
+              pendingFetches.delete(ck)
               // Guard: relay may have disconnected during async ticket fetch
               if (!useStreamStore.getState().relayStatus[ck]) return
 
@@ -70,6 +75,7 @@ export function useRelayWsManager() {
               useStreamStore.getState().setConn(hostId, sessionCode, conn)
               activeConns.set(ck, conn)
             }).catch((err) => {
+              pendingFetches.delete(ck)
               if (!(err instanceof Error && err.message.includes('ws-ticket'))) {
                 console.error('[useRelayWsManager] stream WS setup error', err)
               }

--- a/spa/src/hooks/useRelayWsManager.ts
+++ b/spa/src/hooks/useRelayWsManager.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import { useHostStore } from '../stores/useHostStore'
 import { useStreamStore } from '../stores/useStreamStore'
 import { connectStream, type StreamMessage, type ControlRequest } from '../lib/stream-ws'
+import { fetchWsTicket } from '../lib/host-api'
 
 /**
  * Manages stream WS connections driven by relayStatus changes.
@@ -29,36 +30,50 @@ export function useRelayWsManager() {
           if (connected && !wasConnected) {
             // Derive wsBase for this specific host
             const wsBase = useHostStore.getState().getWsBase(hostId)
-            // Relay just connected — create stream WS
-            const conn = connectStream(
-              `${wsBase}/ws/cli-bridge-sub/${encodeURIComponent(sessionCode)}`,
-              (msg: StreamMessage) => {
-                const store = useStreamStore.getState()
-                if (msg.type === 'assistant' || msg.type === 'user') {
-                  store.addMessage(hostId, sessionCode, msg)
-                }
-                if (msg.type === 'result' && 'total_cost_usd' in msg) {
-                  store.addCost(hostId, sessionCode, (msg as { total_cost_usd?: number }).total_cost_usd || 0)
-                  store.setStreaming(hostId, sessionCode, false)
-                }
-                if (msg.type === 'control_request') {
-                  store.addControlRequest(hostId, sessionCode, msg as ControlRequest)
-                }
-                if (msg.type === 'system') {
-                  const sys = msg as { subtype?: string; session_id?: string; model?: string }
-                  if (sys.subtype === 'init') {
-                    store.setSessionInfo(hostId, sessionCode, sys.session_id ?? '', sys.model ?? '')
+
+            // Fetch ticket before opening stream WS
+            fetchWsTicket(hostId).then((ticket) => {
+              // Guard: relay may have disconnected during async ticket fetch
+              if (!useStreamStore.getState().relayStatus[ck]) return
+
+              const url = new URL(`${wsBase}/ws/cli-bridge-sub/${encodeURIComponent(sessionCode)}`)
+              url.searchParams.set('ticket', ticket)
+
+              // Relay just connected — create stream WS
+              const conn = connectStream(
+                url.toString(),
+                (msg: StreamMessage) => {
+                  const store = useStreamStore.getState()
+                  if (msg.type === 'assistant' || msg.type === 'user') {
+                    store.addMessage(hostId, sessionCode, msg)
                   }
-                }
-              },
-              () => {
-                // WS closed — clear conn (relay:disconnected event will handle UI state)
-                useStreamStore.getState().setConn(hostId, sessionCode, null)
-                activeConns.delete(ck)
-              },
-            )
-            useStreamStore.getState().setConn(hostId, sessionCode, conn)
-            activeConns.set(ck, conn)
+                  if (msg.type === 'result' && 'total_cost_usd' in msg) {
+                    store.addCost(hostId, sessionCode, (msg as { total_cost_usd?: number }).total_cost_usd || 0)
+                    store.setStreaming(hostId, sessionCode, false)
+                  }
+                  if (msg.type === 'control_request') {
+                    store.addControlRequest(hostId, sessionCode, msg as ControlRequest)
+                  }
+                  if (msg.type === 'system') {
+                    const sys = msg as { subtype?: string; session_id?: string; model?: string }
+                    if (sys.subtype === 'init') {
+                      store.setSessionInfo(hostId, sessionCode, sys.session_id ?? '', sys.model ?? '')
+                    }
+                  }
+                },
+                () => {
+                  // WS closed — clear conn (relay:disconnected event will handle UI state)
+                  useStreamStore.getState().setConn(hostId, sessionCode, null)
+                  activeConns.delete(ck)
+                },
+              )
+              useStreamStore.getState().setConn(hostId, sessionCode, conn)
+              activeConns.set(ck, conn)
+            }).catch((err) => {
+              if (!(err instanceof Error && err.message.includes('ws-ticket'))) {
+                console.error('[useRelayWsManager] stream WS setup error', err)
+              }
+            })
           }
 
           if (!connected && wasConnected) {

--- a/spa/src/hooks/useTerminalWs.ts
+++ b/spa/src/hooks/useTerminalWs.ts
@@ -14,9 +14,10 @@ interface UseTerminalWsOpts {
   onReady: () => void
   onDisconnect: () => void
   onReconnect: () => void
+  getTicket?: () => Promise<string>
 }
 
-export function useTerminalWs({ wsUrl, termRef, fitAddonRef, containerRef, hostId, onReady, onDisconnect, onReconnect }: UseTerminalWsOpts) {
+export function useTerminalWs({ wsUrl, termRef, fitAddonRef, containerRef, hostId, onReady, onDisconnect, onReconnect, getTicket }: UseTerminalWsOpts) {
   const connRef = useRef<ReturnType<typeof connectTerminal> | null>(null)
   const revealDelayRef = useRef(useUISettingsStore.getState().terminalRevealDelay)
 
@@ -70,6 +71,7 @@ export function useTerminalWs({ wsUrl, termRef, fitAddonRef, containerRef, hostI
         conn.resize(term.cols, term.rows)
       },
       canReconnect,
+      getTicket,
     )
     connRef.current = conn
 

--- a/spa/src/lib/connection-state-machine.test.ts
+++ b/spa/src/lib/connection-state-machine.test.ts
@@ -127,4 +127,33 @@ describe('ConnectionStateMachine', () => {
     const lastCall = onStateChange.mock.calls[onStateChange.mock.calls.length - 1][0]
     expect(lastCall.daemon).toBe('refused')
   })
+
+  it('auth-error exits FAST_RETRY on first attempt', async () => {
+    checkFn.mockResolvedValue({ daemon: 'auth-error', tmux: 'unavailable', latency: 5, mode: 'normal' })
+    sm = new ConnectionStateMachine(checkFn, onStateChange)
+    await sm.trigger()
+    expect(checkFn).toHaveBeenCalledTimes(1) // not 3
+    expect(onStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({ daemon: 'auth-error' })
+    )
+  })
+
+  it('auth-error does not start background retry', async () => {
+    checkFn.mockResolvedValue({ daemon: 'auth-error', tmux: 'unavailable', latency: 5, mode: 'normal' })
+    sm = new ConnectionStateMachine(checkFn, onStateChange)
+    await sm.trigger()
+    const countAfter = checkFn.mock.calls.length
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(checkFn.mock.calls.length).toBe(countAfter) // no background retries
+  })
+
+  it('manual trigger recovers from auth-error', async () => {
+    checkFn.mockResolvedValue({ daemon: 'auth-error', tmux: 'unavailable', latency: 5, mode: 'normal' })
+    sm = new ConnectionStateMachine(checkFn, onStateChange)
+    await sm.trigger()
+    checkFn.mockResolvedValue({ daemon: 'connected', tmux: 'ok', latency: 3, mode: 'normal' })
+    await sm.trigger()
+    const lastCall = onStateChange.mock.calls[onStateChange.mock.calls.length - 1][0]
+    expect(lastCall.daemon).toBe('connected')
+  })
 })

--- a/spa/src/lib/connection-state-machine.test.ts
+++ b/spa/src/lib/connection-state-machine.test.ts
@@ -19,7 +19,7 @@ describe('ConnectionStateMachine', () => {
   })
 
   it('transitions to connected on first successful check', async () => {
-    checkFn.mockResolvedValue({ daemon: 'connected', tmux: 'ok', latency: 10 })
+    checkFn.mockResolvedValue({ daemon: 'connected', tmux: 'ok', latency: 10, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
     expect(onStateChange).toHaveBeenCalledWith(
@@ -28,7 +28,7 @@ describe('ConnectionStateMachine', () => {
   })
 
   it('enters FAST_RETRY then L1 on 3 timeouts', async () => {
-    checkFn.mockResolvedValue({ daemon: 'unreachable', tmux: 'unavailable', latency: null })
+    checkFn.mockResolvedValue({ daemon: 'unreachable', tmux: 'unavailable', latency: null, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
 
@@ -38,7 +38,7 @@ describe('ConnectionStateMachine', () => {
   })
 
   it('enters FAST_RETRY then L2 on 3 refused', async () => {
-    checkFn.mockResolvedValue({ daemon: 'refused', tmux: 'unavailable', latency: null })
+    checkFn.mockResolvedValue({ daemon: 'refused', tmux: 'unavailable', latency: null, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
 
@@ -49,8 +49,8 @@ describe('ConnectionStateMachine', () => {
 
   it('recovers during FAST_RETRY if second attempt succeeds', async () => {
     checkFn
-      .mockResolvedValueOnce({ daemon: 'unreachable', tmux: 'unavailable', latency: null })
-      .mockResolvedValueOnce({ daemon: 'connected', tmux: 'ok', latency: 5 })
+      .mockResolvedValueOnce({ daemon: 'unreachable', tmux: 'unavailable', latency: null, mode: 'normal' })
+      .mockResolvedValueOnce({ daemon: 'connected', tmux: 'ok', latency: 5, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
 
@@ -60,20 +60,20 @@ describe('ConnectionStateMachine', () => {
   })
 
   it('L1 continues retrying in background', async () => {
-    checkFn.mockResolvedValue({ daemon: 'unreachable', tmux: 'unavailable', latency: null })
+    checkFn.mockResolvedValue({ daemon: 'unreachable', tmux: 'unavailable', latency: null, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
 
     const countAfterTrigger = checkFn.mock.calls.length
 
-    checkFn.mockResolvedValueOnce({ daemon: 'connected', tmux: 'ok', latency: 15 })
+    checkFn.mockResolvedValueOnce({ daemon: 'connected', tmux: 'ok', latency: 15, mode: 'normal' })
     await vi.advanceTimersByTimeAsync(3100)
 
     expect(checkFn.mock.calls.length).toBeGreaterThan(countAfterTrigger)
   })
 
   it('L2 retries every 3s in background', async () => {
-    checkFn.mockResolvedValue({ daemon: 'refused', tmux: 'unavailable', latency: null })
+    checkFn.mockResolvedValue({ daemon: 'refused', tmux: 'unavailable', latency: null, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
 
@@ -89,7 +89,7 @@ describe('ConnectionStateMachine', () => {
   })
 
   it('L2 stops retrying after 3 minutes', async () => {
-    checkFn.mockResolvedValue({ daemon: 'refused', tmux: 'unavailable', latency: null })
+    checkFn.mockResolvedValue({ daemon: 'refused', tmux: 'unavailable', latency: null, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
 
@@ -105,12 +105,12 @@ describe('ConnectionStateMachine', () => {
   })
 
   it('manual retry restarts FAST_RETRY for L2', async () => {
-    checkFn.mockResolvedValue({ daemon: 'refused', tmux: 'unavailable', latency: null })
+    checkFn.mockResolvedValue({ daemon: 'refused', tmux: 'unavailable', latency: null, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
 
     const countBefore = checkFn.mock.calls.length
-    checkFn.mockResolvedValue({ daemon: 'connected', tmux: 'ok', latency: 8 })
+    checkFn.mockResolvedValue({ daemon: 'connected', tmux: 'ok', latency: 8, mode: 'normal' })
     await sm.trigger()
 
     expect(checkFn.mock.calls.length).toBeGreaterThan(countBefore)
@@ -118,9 +118,9 @@ describe('ConnectionStateMachine', () => {
 
   it('uses last attempt result for classification', async () => {
     checkFn
-      .mockResolvedValueOnce({ daemon: 'unreachable', tmux: 'unavailable', latency: null })
-      .mockResolvedValueOnce({ daemon: 'unreachable', tmux: 'unavailable', latency: null })
-      .mockResolvedValueOnce({ daemon: 'refused', tmux: 'unavailable', latency: null })
+      .mockResolvedValueOnce({ daemon: 'unreachable', tmux: 'unavailable', latency: null, mode: 'normal' })
+      .mockResolvedValueOnce({ daemon: 'unreachable', tmux: 'unavailable', latency: null, mode: 'normal' })
+      .mockResolvedValueOnce({ daemon: 'refused', tmux: 'unavailable', latency: null, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
 

--- a/spa/src/lib/connection-state-machine.test.ts
+++ b/spa/src/lib/connection-state-machine.test.ts
@@ -145,6 +145,27 @@ describe('ConnectionStateMachine', () => {
     expect(checkFn.mock.calls.length).toBe(countAfter) // no background retries
   })
 
+  it('background retry stops on auth-error after initial unreachable', async () => {
+    // Start as unreachable → enters L1 background
+    checkFn.mockResolvedValue({ daemon: 'unreachable', tmux: 'unavailable', latency: null, mode: 'normal' })
+    sm = new ConnectionStateMachine(checkFn, onStateChange)
+    await sm.trigger()
+    const countAfterTrigger = checkFn.mock.calls.length
+
+    // Background retry returns auth-error → should stop
+    checkFn.mockResolvedValue({ daemon: 'auth-error', tmux: 'unavailable', latency: 5, mode: 'normal' })
+    await vi.advanceTimersByTimeAsync(200) // L1 delay is 100ms
+    const countAfterAuthError = checkFn.mock.calls.length
+    expect(countAfterAuthError).toBe(countAfterTrigger + 1)
+
+    // Verify no more retries after auth-error
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(checkFn.mock.calls.length).toBe(countAfterAuthError)
+    // Verify auth-error was reported
+    const lastCall = onStateChange.mock.calls[onStateChange.mock.calls.length - 1][0]
+    expect(lastCall.daemon).toBe('auth-error')
+  })
+
   it('manual trigger recovers from auth-error', async () => {
     checkFn.mockResolvedValue({ daemon: 'auth-error', tmux: 'unavailable', latency: 5, mode: 'normal' })
     sm = new ConnectionStateMachine(checkFn, onStateChange)

--- a/spa/src/lib/connection-state-machine.test.ts
+++ b/spa/src/lib/connection-state-machine.test.ts
@@ -93,8 +93,6 @@ describe('ConnectionStateMachine', () => {
     sm = new ConnectionStateMachine(checkFn, onStateChange)
     await sm.trigger()
 
-    const countAfterTrigger = checkFn.mock.calls.length
-
     // Advance past 3 minute deadline
     await vi.advanceTimersByTimeAsync(181_000)
     const countAfterDeadline = checkFn.mock.calls.length

--- a/spa/src/lib/connection-state-machine.ts
+++ b/spa/src/lib/connection-state-machine.ts
@@ -41,6 +41,9 @@ export class ConnectionStateMachine {
       if (lastResult.daemon === 'connected') {
         return // recovered
       }
+      if (lastResult.daemon === 'auth-error') {
+        return // permanent error, don't retry
+      }
     }
 
     if (!lastResult || this.stopped || this.epoch !== myEpoch) return

--- a/spa/src/lib/connection-state-machine.ts
+++ b/spa/src/lib/connection-state-machine.ts
@@ -79,6 +79,9 @@ export class ConnectionStateMachine {
       if (result.daemon === 'connected') {
         return // recovered
       }
+      if (result.daemon === 'auth-error') {
+        return // permanent error, stop background retry
+      }
       this.startBackground(delayMs)
     }, delayMs)
   }

--- a/spa/src/lib/host-connection.test.ts
+++ b/spa/src/lib/host-connection.test.ts
@@ -1,40 +1,94 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { checkHealth } from './host-connection'
 
+function healthResponse(mode = 'normal') {
+  return new Response(JSON.stringify({ ok: true, mode }), { status: 200 })
+}
+function ticketResponse(ticket = 'tk_abc') {
+  return new Response(JSON.stringify({ ticket }), { status: 200 })
+}
+
 describe('checkHealth', () => {
-  afterEach(() => {
-    vi.restoreAllMocks()
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('Phase 1 only: no token, non-pairing → auth-error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(healthResponse('normal'))
+    const result = await checkHealth('http://localhost:7860')
+    expect(result.daemon).toBe('auth-error')
+    expect(result.mode).toBe('normal')
+    expect(fetch).toHaveBeenCalledTimes(1) // Phase 2 skipped
   })
 
-  it('returns connected with latency on HTTP 200', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), { status: 200 })
-    )
-
+  it('Phase 1 only: no token, pairing mode → connected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(healthResponse('pairing'))
     const result = await checkHealth('http://localhost:7860')
     expect(result.daemon).toBe('connected')
-    // health is pure liveness — tmux status comes via WS or /api/ready
-    expect(result.tmux).toBe('unavailable')
-    expect(result.latency).toBeGreaterThanOrEqual(0)
+    expect(result.mode).toBe('pairing')
   })
 
-  it('returns refused on TypeError (connection refused)', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'))
-
-    const result = await checkHealth('http://localhost:7860')
-    expect(result.daemon).toBe('refused')
-    expect(result.tmux).toBe('unavailable')
-    expect(result.latency).toBeNull()
+  it('Phase 2 success: connected + ticket', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(ticketResponse('tk_123'))
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('connected')
+    expect(result.ticket).toBe('tk_123')
+    expect(result.mode).toBe('normal')
   })
 
-  it('returns unreachable on AbortError (timeout)', async () => {
+  it('Phase 2 returns 401 → auth-error', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(new Response('unauthorized', { status: 401 }))
+    const result = await checkHealth('http://localhost:7860', () => 'badtoken')
+    expect(result.daemon).toBe('auth-error')
+  })
+
+  it('Phase 2 returns 503 (PairingGuard) → auth-error', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(new Response('pairing_mode', { status: 503 }))
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('auth-error')
+  })
+
+  it('Phase 2 network error → fallback connected', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('connected')
+    expect(result.ticket).toBeUndefined()
+  })
+
+  it('Phase 1 timeout → unreachable', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(
       Object.assign(new Error('signal is aborted'), { name: 'AbortError' })
     )
-
-    const result = await checkHealth('http://localhost:7860')
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
     expect(result.daemon).toBe('unreachable')
-    expect(result.tmux).toBe('unavailable')
     expect(result.latency).toBeNull()
+  })
+
+  it('Phase 1 network error → refused', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'))
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('refused')
+  })
+
+  it('mode field parsed from health response', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse('pending'))
+      .mockResolvedValueOnce(ticketResponse())
+    const result = await checkHealth('http://localhost:7860', () => 'tok')
+    expect(result.mode).toBe('pending')
+  })
+
+  it('latency measured from Phase 1', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(ticketResponse())
+    const result = await checkHealth('http://localhost:7860', () => 'tok')
+    expect(result.latency).toBeGreaterThanOrEqual(0)
   })
 })

--- a/spa/src/lib/host-connection.ts
+++ b/spa/src/lib/host-connection.ts
@@ -1,38 +1,67 @@
-// spa/src/lib/host-connection.ts — Health check with L1/L2/L3 classification
-//
-// /api/health is a pure liveness endpoint (no auth, returns {"ok": true}).
-// tmux status is NOT included here — it comes via /api/ready (behind auth)
-// or via host-events WS "tmux" event during normal operation.
+// spa/src/lib/host-connection.ts — Health check with two-phase negotiation
 
 export interface HealthResult {
-  daemon: 'connected' | 'refused' | 'unreachable'
+  daemon: 'connected' | 'refused' | 'unreachable' | 'auth-error'
   tmux: 'ok' | 'unavailable'
   latency: number | null
+  mode: 'pairing' | 'pending' | 'normal'
+  ticket?: string
 }
 
-const HEALTH_TIMEOUT_MS = 6000
+const PHASE1_TIMEOUT_MS = 6000
+const PHASE2_TIMEOUT_MS = 5000
 
-export async function checkHealth(baseUrl: string): Promise<HealthResult> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS)
-
+export async function checkHealth(
+  baseUrl: string,
+  getToken?: () => string | undefined,
+): Promise<HealthResult> {
+  const ctrl1 = new AbortController()
+  const timer1 = setTimeout(() => ctrl1.abort(), PHASE1_TIMEOUT_MS)
   try {
     const start = performance.now()
-    const res = await fetch(`${baseUrl}/api/health`, { signal: controller.signal })
+    const res = await fetch(`${baseUrl}/api/health`, { signal: ctrl1.signal })
     const latency = Math.round(performance.now() - start)
-    await res.json() // consume body
-    return {
-      daemon: 'connected',
-      // tmux status unknown from health — will be updated via WS or /api/ready
-      tmux: 'unavailable',
-      latency,
+    const body = await res.json()
+    const mode = (body.mode ?? 'normal') as 'pairing' | 'pending' | 'normal'
+
+    const token = getToken?.()
+    if (!token) {
+      if (mode === 'pairing') {
+        return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+      }
+      return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
+    }
+
+    const ctrl2 = new AbortController()
+    const timer2 = setTimeout(() => ctrl2.abort(), PHASE2_TIMEOUT_MS)
+    try {
+      const ticketRes = await fetch(`${baseUrl}/api/ws-ticket`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        signal: ctrl2.signal,
+      })
+      if (ticketRes.status === 401) {
+        return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
+      }
+      if (ticketRes.status === 503) {
+        return { daemon: 'auth-error', tmux: 'unavailable', latency, mode }
+      }
+      if (!ticketRes.ok) {
+        return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+      }
+      const { ticket } = await ticketRes.json()
+      return { daemon: 'connected', tmux: 'unavailable', latency, mode, ticket }
+    } catch {
+      return { daemon: 'connected', tmux: 'unavailable', latency, mode }
+    } finally {
+      clearTimeout(timer2)
     }
   } catch (err: unknown) {
     if (err instanceof Error && err.name === 'AbortError') {
-      return { daemon: 'unreachable', tmux: 'unavailable', latency: null }
+      return { daemon: 'unreachable', tmux: 'unavailable', latency: null, mode: 'normal' }
     }
-    return { daemon: 'refused', tmux: 'unavailable', latency: null }
+    return { daemon: 'refused', tmux: 'unavailable', latency: null, mode: 'normal' }
   } finally {
-    clearTimeout(timer)
+    clearTimeout(timer1)
   }
 }

--- a/spa/src/lib/host-events.test.ts
+++ b/spa/src/lib/host-events.test.ts
@@ -1,0 +1,77 @@
+// spa/src/lib/host-events.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { connectHostEvents } from './host-events'
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 3
+  readyState = MockWebSocket.CONNECTING
+  binaryType = ''
+  url: string
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onmessage: ((e: { data: unknown }) => void) | null = null
+  onerror: (() => void) | null = null
+  send = vi.fn()
+  close = vi.fn(() => { this.readyState = MockWebSocket.CLOSED; this.onclose?.() })
+  simulateOpen() { this.readyState = MockWebSocket.OPEN; this.onopen?.() }
+  constructor(url: string) { this.url = url; wsInstances.push(this) }
+}
+
+let wsInstances: MockWebSocket[] = []
+
+beforeEach(() => {
+  wsInstances = []
+  vi.stubGlobal('WebSocket', MockWebSocket)
+})
+afterEach(() => { vi.unstubAllGlobals() })
+
+describe('connectHostEvents', () => {
+  it('lazy mode does not connect immediately', () => {
+    connectHostEvents('ws://test/ws/host-events', vi.fn(), undefined, undefined, undefined, false, true)
+    expect(wsInstances).toHaveLength(0)
+  })
+
+  it('reconnectWithTicket creates WS with ticket in URL', async () => {
+    const conn = connectHostEvents('ws://test/ws/host-events', vi.fn(), undefined, undefined, undefined, false, true)
+    conn.reconnectWithTicket('tk_pre')
+    await vi.dynamicImportSettled?.() // flush microtasks
+    await new Promise((r) => setTimeout(r, 0))
+    expect(wsInstances).toHaveLength(1)
+    expect(wsInstances[0].url).toContain('ticket=tk_pre')
+  })
+
+  it('pendingTicket is consumed once, second connect falls back to getTicket', async () => {
+    const getTicket = vi.fn().mockResolvedValue('tk_callback')
+    const conn = connectHostEvents('ws://test/ws/host-events', vi.fn(), undefined, undefined, getTicket, false, true)
+    conn.reconnectWithTicket('tk_once')
+    await new Promise((r) => setTimeout(r, 0))
+    expect(wsInstances[0].url).toContain('ticket=tk_once')
+    // Simulate WS close → reconnect without pendingTicket
+    wsInstances[0].close()
+    conn.reconnect()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(getTicket).toHaveBeenCalled()
+    expect(wsInstances[1].url).toContain('ticket=tk_callback')
+  })
+
+  it('getTicket failure with no pendingTicket calls onClose', async () => {
+    const onClose = vi.fn()
+    const getTicket = vi.fn().mockRejectedValue(new Error('401'))
+    const conn = connectHostEvents('ws://test/ws/host-events', vi.fn(), onClose, undefined, getTicket, false, true)
+    conn.reconnect()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onClose).toHaveBeenCalled()
+    expect(wsInstances).toHaveLength(0) // no WS created
+  })
+
+  it('connecting flag prevents concurrent connect calls', async () => {
+    const getTicket = vi.fn().mockImplementation(() => new Promise((r) => setTimeout(() => r('tk'), 100)))
+    const conn = connectHostEvents('ws://test/ws/host-events', vi.fn(), undefined, undefined, getTicket, false, true)
+    conn.reconnect()
+    conn.reconnect() // second call while first is awaiting getTicket
+    await new Promise((r) => setTimeout(r, 150))
+    expect(getTicket).toHaveBeenCalledTimes(1) // only one connect ran
+  })
+})

--- a/spa/src/lib/host-events.ts
+++ b/spa/src/lib/host-events.ts
@@ -9,6 +9,7 @@ export interface HostEvent {
 export interface EventConnection {
   close: () => void
   reconnect: () => void
+  reconnectWithTicket: (ticket?: string) => void
 }
 
 export function connectHostEvents(
@@ -18,53 +19,68 @@ export function connectHostEvents(
   onOpen?: () => void,
   getTicket?: () => Promise<string>,
   autoReconnect = true,
+  lazy = false,
 ): EventConnection {
   let ws: WebSocket
   let retryMs = 1000
   let closed = false
+  let connecting = false
+  let pendingTicket: string | undefined
 
   async function connect() {
-    let wsUrl = url
-    if (getTicket) {
-      try {
-        const ticket = await getTicket()
+    if (connecting) return
+    connecting = true
+    try {
+      let wsUrl = url
+      const ticket = pendingTicket ?? (getTicket ? await getTicket().catch(() => null) : null)
+      pendingTicket = undefined
+
+      if (ticket) {
         const u = new URL(wsUrl)
         u.searchParams.set('ticket', ticket)
         wsUrl = u.toString()
-      } catch {
-        if (!closed && autoReconnect) setTimeout(connect, retryMs)
-        retryMs = Math.min(retryMs * 2, 30000)
+      } else if (getTicket) {
+        if (!closed) onClose?.()
         return
       }
-    }
-    ws = new WebSocket(wsUrl)
-    ws.onopen = () => { retryMs = 1000; onOpen?.() }
-    ws.onmessage = (e) => {
-      try {
-        const event = JSON.parse(e.data) as HostEvent
-        onEvent(event)
-      } catch { /* ignore parse errors */ }
-    }
-    ws.onerror = () => { /* handled by onclose */ }
-    ws.onclose = () => {
-      if (closed) return
-      onClose?.()
-      if (autoReconnect) {
-        setTimeout(() => {
-          if (!closed) connect()
-        }, retryMs)
-        retryMs = Math.min(retryMs * 2, 30000)
+
+      ws = new WebSocket(wsUrl)
+      ws.onopen = () => { retryMs = 1000; onOpen?.() }
+      ws.onmessage = (e) => {
+        try {
+          const event = JSON.parse(e.data) as HostEvent
+          onEvent(event)
+        } catch { /* ignore parse errors */ }
       }
+      ws.onerror = () => {}
+      ws.onclose = () => {
+        if (closed) return
+        onClose?.()
+        if (autoReconnect) {
+          setTimeout(() => { if (!closed) connect() }, retryMs)
+          retryMs = Math.min(retryMs * 2, 30000)
+        }
+      }
+    } finally {
+      connecting = false
     }
   }
 
-  connect()
+  if (!lazy) connect()
   return {
     close: () => { closed = true; ws?.close() },
     reconnect: () => {
       if (!closed) {
         retryMs = 1000
-        ws?.close()
+        if (ws) { ws.onclose = null; ws.close() }  // 清除 onclose 防止 double-trigger
+        connect()
+      }
+    },
+    reconnectWithTicket: (ticket) => {
+      if (!closed) {
+        pendingTicket = ticket
+        retryMs = 1000
+        if (ws) { ws.onclose = null; ws.close() }  // 清除 onclose 防止 double-trigger
         connect()
       }
     },

--- a/spa/src/lib/host-utils.test.ts
+++ b/spa/src/lib/host-utils.test.ts
@@ -34,4 +34,9 @@ describe('connectionErrorMessage', () => {
     const runtime: HostRuntime = { status: 'reconnecting' }
     expect(connectionErrorMessage(runtime, t)).toBeNull()
   })
+
+  it('returns auth error message for auth-error status', () => {
+    const runtime: HostRuntime = { status: 'auth-error', daemonState: 'auth-error' }
+    expect(connectionErrorMessage(runtime, t)).toBe('hosts.error_auth')
+  })
 })

--- a/spa/src/lib/host-utils.ts
+++ b/spa/src/lib/host-utils.ts
@@ -9,6 +9,7 @@ export function connectionErrorMessage(
   runtime: HostRuntime | undefined,
   t: (key: string) => string,
 ): string | null {
+  if (runtime?.status === 'auth-error') return t('hosts.error_auth')
   if (!runtime || runtime.status !== 'connected') {
     if (runtime?.daemonState === 'unreachable') return t('hosts.error_unreachable')
     if (runtime?.daemonState === 'refused') return t('hosts.error_refused')

--- a/spa/src/lib/ws.test.ts
+++ b/spa/src/lib/ws.test.ts
@@ -8,6 +8,7 @@ class MockWebSocket {
   static CLOSING = 2
   static CLOSED = 3
 
+  url = ''
   readyState = MockWebSocket.CONNECTING
   binaryType = ''
   onopen: (() => void) | null = null
@@ -37,8 +38,9 @@ let wsInstances: MockWebSocket[] = []
 beforeEach(() => {
   wsInstances = []
   vi.stubGlobal('WebSocket', class extends MockWebSocket {
-    constructor() {
+    constructor(url: string) {
       super()
+      this.url = url
       wsInstances.push(this)
     }
   })
@@ -172,5 +174,36 @@ describe('connectTerminal gate', () => {
 
     vi.advanceTimersByTime(1000)
     expect(wsInstances).toHaveLength(2) // reconnected — gate allowed
+  })
+})
+
+describe('connectTerminal with getTicket', () => {
+  it('appends ticket to WS URL on success', async () => {
+    const getTicket = vi.fn().mockResolvedValue('tk_term')
+    connectTerminal('ws://test/ws/terminal/abc', vi.fn(), vi.fn(), undefined, undefined, getTicket)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(wsInstances[0].url).toContain('ticket=tk_term')
+  })
+
+  it('retries with backoff on getTicket failure', async () => {
+    const getTicket = vi.fn().mockRejectedValue(new Error('401'))
+    const onClose = vi.fn()
+    connectTerminal('ws://test/ws/terminal/abc', vi.fn(), onClose, undefined, undefined, getTicket)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(wsInstances).toHaveLength(0) // no WS created
+    expect(onClose).not.toHaveBeenCalled() // no onClose — self backoff
+    // After 1s backoff, retry
+    getTicket.mockResolvedValueOnce('tk_retry')
+    await vi.advanceTimersByTimeAsync(1100)
+    expect(wsInstances).toHaveLength(1)
+    expect(wsInstances[0].url).toContain('ticket=tk_retry')
+  })
+
+  it('stops retrying when canReconnect returns false', async () => {
+    const getTicket = vi.fn().mockRejectedValue(new Error('401'))
+    connectTerminal('ws://test/ws/terminal/abc', vi.fn(), vi.fn(), undefined, () => false, getTicket)
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(1100)
+    expect(getTicket).toHaveBeenCalledTimes(1) // no retry
   })
 })

--- a/spa/src/lib/ws.ts
+++ b/spa/src/lib/ws.ts
@@ -72,10 +72,10 @@ export function connectTerminal(
 
   return {
     send: (data) => {
-      if (ws.readyState === WebSocket.OPEN) ws.send(data)
+      if (ws?.readyState === WebSocket.OPEN) ws.send(data)
     },
     resize: (cols, rows) => {
-      if (ws.readyState === WebSocket.OPEN) {
+      if (ws?.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: 'resize', cols, rows }))
       }
     },

--- a/spa/src/lib/ws.ts
+++ b/spa/src/lib/ws.ts
@@ -81,7 +81,7 @@ export function connectTerminal(
     },
     close: () => {
       closed = true
-      ws.close()
+      ws?.close()
     },
   }
 }

--- a/spa/src/lib/ws.ts
+++ b/spa/src/lib/ws.ts
@@ -10,13 +10,34 @@ export function connectTerminal(
   onClose: () => void,
   onOpen?: () => void,
   canReconnect?: () => boolean,
+  getTicket?: () => Promise<string>,
 ): TerminalConnection {
   let closed = false
   let retryMs = 1000
   let ws: WebSocket
 
-  function connect() {
-    ws = new WebSocket(url)
+  // Async ticket path — separate from sync connect to avoid breaking existing sync callers
+  async function connectWithTicket() {
+    let wsUrl = url
+    try {
+      const ticket = await getTicket!()
+      const u = new URL(wsUrl)
+      u.searchParams.set('ticket', ticket)
+      wsUrl = u.toString()
+    } catch {
+      setTimeout(() => {
+        if (closed) return
+        if (canReconnect && !canReconnect()) return
+        connect()
+      }, retryMs)
+      retryMs = Math.min(retryMs * 2, 30000)
+      return
+    }
+    setupWs(wsUrl)
+  }
+
+  function setupWs(wsUrl: string) {
+    ws = new WebSocket(wsUrl)
     ws.binaryType = 'arraybuffer'
 
     ws.onopen = () => {
@@ -37,6 +58,14 @@ export function connectTerminal(
       }, retryMs)
       retryMs = Math.min(retryMs * 2, 30000)
     }
+  }
+
+  function connect() {
+    if (getTicket) {
+      connectWithTicket()
+      return
+    }
+    setupWs(url)
   }
 
   connect()

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -397,5 +397,8 @@
   "hosts.invalid_pairing_code": "Invalid pairing code",
   "hosts.token_too_short": "Token must be at least 20 characters",
   "hosts.saving": "Saving…",
-  "hosts.confirm": "Confirm"
+  "hosts.confirm": "Confirm",
+  "hosts.mode_pairing_hint": "Daemon is waiting for pairing",
+  "hosts.mode_pending_hint": "Enter the token shown in the daemon terminal",
+  "hosts.mode_normal_hint": "Daemon is running — enter the configured token"
 }

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -359,6 +359,10 @@
   "hosts.error_unreachable": "Host unreachable",
   "hosts.error_refused": "Daemon not running",
   "hosts.error_tmux_down": "tmux environment unreachable",
+  "hosts.error_auth": "Invalid token — check that the token matches the daemon config",
+  "hosts.auth_error": "Invalid token",
+  "hosts.auth_error_hint": "Verify the token matches the daemon config. Changes reconnect automatically.",
+  "status.auth_error": "Invalid token — click to configure",
   "common.edit": "Edit",
 
   "error.boundary.title": "Something went wrong",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -359,6 +359,10 @@
   "hosts.error_unreachable": "主機無法連線",
   "hosts.error_refused": "Daemon 未啟動",
   "hosts.error_tmux_down": "tmux 環境無法連線",
+  "hosts.error_auth": "Token 無效，請確認 Token 與 daemon 設定一致",
+  "hosts.auth_error": "Token 無效",
+  "hosts.auth_error_hint": "請確認 Token 與 daemon 設定一致，修改後自動重新連線",
+  "status.auth_error": "Token 無效，點擊設定",
   "common.edit": "編輯",
 
   "error.boundary.title": "發生錯誤",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -397,5 +397,8 @@
   "hosts.invalid_pairing_code": "無效的配對碼",
   "hosts.token_too_short": "Token 長度至少需要 20 字元",
   "hosts.saving": "儲存中…",
-  "hosts.confirm": "確認"
+  "hosts.confirm": "確認",
+  "hosts.mode_pairing_hint": "Daemon 等待配對中",
+  "hosts.mode_pending_hint": "請輸入 daemon 終端機顯示的 Token",
+  "hosts.mode_normal_hint": "Daemon 運作中，請輸入已設定的 Token"
 }

--- a/spa/src/stores/useHostStore.ts
+++ b/spa/src/stores/useHostStore.ts
@@ -15,10 +15,10 @@ export interface HostConfig {
 }
 
 export interface HostRuntime {
-  status: 'connected' | 'disconnected' | 'reconnecting'
+  status: 'connected' | 'disconnected' | 'reconnecting' | 'auth-error'
   latency?: number
   info?: HostInfo
-  daemonState?: 'connected' | 'refused' | 'unreachable'
+  daemonState?: 'connected' | 'refused' | 'unreachable' | 'auth-error'
   tmuxState?: 'ok' | 'unavailable'
   manualRetry?: () => void  // safe: runtime excluded from persist partialize
 }


### PR DESCRIPTION
## Summary

- **Negotiation-First 架構**：狀態機 checkFn 升級為兩階段（GET /api/health + POST /api/ws-ticket），同時驗證 daemon reachability 與 token auth
- **WS Ticket 統一**：terminal、stream、host-events 三條 WS 連線全面使用 ticket auth；移除 legacy `?token=` query param
- **Auth Error UI**：新增 `auth-error` 狀態，HostSidebar 鎖頭圖示、StatusBar 可點擊導航、OverviewSection banner + token 自動重試
- **Health Mode 消費**（#167）：AddHostDialog 根據 daemon mode 自動導流配對碼/Token 路線

### 解決問題
- 修正狀態機 + auth 死循環（health 不驗 auth → 誤判 connected）
- 修正新 host token 錯時的靜默失敗
- #148 pt.2/pt.3 — Terminal/Stream WS auth + error 提示
- #167 — health mode SPA 消費

### 架構改動
- `checkHealth` 兩階段 negotiation + `HealthResult` 擴充（`'auth-error'`、`mode`、`ticket`）
- `ConnectionStateMachine` auth-error 第一次就跳出 FAST_RETRY
- `connectHostEvents` lazy mode + `reconnectWithTicket` + `connecting` flag
- `connectTerminal` 雙函式設計（sync + async ticket path）
- `useMultiHostEventWs` 立即 `sm.trigger()` + lazy WS
- `useRelayWsManager` 外層 await ticket + relayStatus guard

## Test plan
- [ ] SPA vitest: 858 passed（+19 新增 tests）
- [ ] Go middleware: 15 passed（`TestTokenAuthQueryParamRemoved` 驗證 401）
- [ ] 手動測試：正確 token → 綠色 connected
- [ ] 手動測試：錯誤 token → 紅色鎖頭 auth-error
- [ ] 手動測試：修改 token → 自動重連
- [ ] 手動測試：AddHostDialog health mode 自動偵測