### PR TITLE
feat: Phase 10b — getVisibleTabIds + insertTab 收斂 + DeleteDialog (2/3)

### DIFF
--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -104,11 +104,7 @@ export default function App() {
           useTabStore.getState().addTab(tab)
           useTabStore.getState().setActiveTab(tab.id)
           // Restore workspace membership if receiving window has an active workspace
-          const wsId = useWorkspaceStore.getState().activeWorkspaceId
-          if (wsId) {
-            useWorkspaceStore.getState().addTabToWorkspace(wsId, tab.id)
-            useWorkspaceStore.getState().setWorkspaceActiveTab(wsId, tab.id)
-          }
+          useWorkspaceStore.getState().insertTab(tab.id)
         }
       } catch { /* ignore malformed tab JSON */ }
     })
@@ -195,18 +191,12 @@ export default function App() {
           onAddWorkspace={() => {}}
           onOpenHosts={() => {
             const tabId = useTabStore.getState().openSingletonTab({ kind: 'hosts' })
-            if (activeWorkspaceId) {
-              useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, tabId)
-              useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, tabId)
-            }
+            useWorkspaceStore.getState().insertTab(tabId)
             handleSelectTab(tabId)
           }}
           onOpenSettings={() => {
             const tabId = useTabStore.getState().openSingletonTab({ kind: 'settings', scope: 'global' })
-            if (activeWorkspaceId) {
-              useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, tabId)
-              useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, tabId)
-            }
+            useWorkspaceStore.getState().insertTab(tabId)
             handleSelectTab(tabId)
           }}
         />
@@ -237,10 +227,7 @@ export default function App() {
             }}
             onNavigateToHost={(hostId) => {
               const tabId = useTabStore.getState().openSingletonTab({ kind: 'hosts' })
-              if (activeWorkspaceId) {
-                useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, tabId)
-                useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, tabId)
-              }
+              useWorkspaceStore.getState().insertTab(tabId)
               handleSelectTab(tabId)
               useHostStore.getState().setActiveHost(hostId)
             }}

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -17,6 +17,7 @@ import { useNotificationDispatcher } from './hooks/useNotificationDispatcher'
 import { useUndoToast } from './stores/useUndoToast'
 import { useTabWorkspaceActions } from './hooks/useTabWorkspaceActions'
 import { isStandaloneTab } from './types/tab'
+import { getVisibleTabIds } from './features/workspace'
 import { TabContextMenu } from './components/TabContextMenu'
 import { ThemeInjector } from './components/ThemeInjector'
 import { ErrorBoundary } from './components/ErrorBoundary'
@@ -122,10 +123,14 @@ export default function App() {
   }, [fetchConfig, firstHostId])
 
   // --- Derive visible tabs for display ---
-  const activeWs = workspaces.find((w) => w.id === activeWorkspaceId)
-  const visibleTabs: Tab[] = activeWs
-    ? activeWs.tabs.map((id) => tabs[id]).filter(Boolean)
-    : []
+  const visibleTabIds = getVisibleTabIds({
+    tabs,
+    tabOrder,
+    activeTabId,
+    workspaces,
+    activeWorkspaceId,
+  })
+  const displayTabs: Tab[] = visibleTabIds.map((id) => tabs[id]).filter(Boolean)
 
   const standaloneTabs = tabOrder
     .filter((id) => isStandaloneTab(id, workspaces))
@@ -133,10 +138,6 @@ export default function App() {
     .filter(Boolean)
 
   const activeStandaloneTabId = activeTabId && isStandaloneTab(activeTabId, workspaces) ? activeTabId : null
-
-  const displayTabs = activeStandaloneTabId
-    ? [tabs[activeStandaloneTabId]].filter(Boolean)
-    : visibleTabs
 
   // --- Tab/Workspace action handlers ---
   const {

--- a/spa/src/components/hosts/SessionsSection.test.tsx
+++ b/spa/src/components/hosts/SessionsSection.test.tsx
@@ -9,8 +9,7 @@ import { compositeKey } from '../../lib/composite-key'
 
 const mockOpenSingletonTab = vi.fn(() => 'tab-1')
 const mockSetActiveTab = vi.fn()
-const mockAddTabToWorkspace = vi.fn()
-const mockSetWorkspaceActiveTab = vi.fn()
+const mockInsertTab = vi.fn()
 
 vi.mock('../../stores/useTabStore', () => ({
   useTabStore: {
@@ -24,9 +23,7 @@ vi.mock('../../stores/useTabStore', () => ({
 vi.mock('../../stores/useWorkspaceStore', () => ({
   useWorkspaceStore: {
     getState: () => ({
-      activeWorkspaceId: null,
-      addTabToWorkspace: mockAddTabToWorkspace,
-      setWorkspaceActiveTab: mockSetWorkspaceActiveTab,
+      insertTab: mockInsertTab,
     }),
   },
 }))
@@ -45,6 +42,7 @@ beforeEach(() => {
   cleanup()
   mockOpenSingletonTab.mockClear()
   mockSetActiveTab.mockClear()
+  mockInsertTab.mockClear()
   useSessionStore.setState({ sessions: { [HOST_ID]: SESSIONS } })
   useHostStore.setState({
     hosts: { [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '1.2.3.4', port: 7860, order: 0 } },

--- a/spa/src/components/hosts/SessionsSection.tsx
+++ b/spa/src/components/hosts/SessionsSection.tsx
@@ -146,11 +146,7 @@ export function SessionsSection({ hostId }: Props) {
       cachedName: session.name,
       tmuxInstance: '',
     })
-    const wsId = useWorkspaceStore.getState().activeWorkspaceId
-    if (wsId) {
-      useWorkspaceStore.getState().addTabToWorkspace(wsId, tabId)
-      useWorkspaceStore.getState().setWorkspaceActiveTab(wsId, tabId)
-    }
+    useWorkspaceStore.getState().insertTab(tabId)
     useTabStore.getState().setActiveTab(tabId)
   }
 

--- a/spa/src/features/workspace/components/WorkspaceDeleteDialog.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceDeleteDialog.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { WorkspaceDeleteDialog } from './WorkspaceDeleteDialog'
+
+const mockTabs = [
+  { id: 't1', label: 'dev session' },
+  { id: 't2', label: 'settings' },
+]
+
+describe('WorkspaceDeleteDialog', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('renders workspace name and tab list', () => {
+    render(
+      <WorkspaceDeleteDialog
+        workspaceName="My Workspace"
+        tabs={mockTabs}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/My Workspace/)).toBeInTheDocument()
+    expect(screen.getByText('dev session')).toBeInTheDocument()
+    expect(screen.getByText('settings')).toBeInTheDocument()
+  })
+
+  it('all tabs are checked by default', () => {
+    render(
+      <WorkspaceDeleteDialog
+        workspaceName="WS"
+        tabs={mockTabs}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(2)
+    checkboxes.forEach((cb) => expect(cb).toBeChecked())
+  })
+
+  it('unchecking a tab excludes it from closedTabIds', () => {
+    const onConfirm = vi.fn()
+    render(
+      <WorkspaceDeleteDialog
+        workspaceName="WS"
+        tabs={mockTabs}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    )
+    const checkboxes = screen.getAllByRole('checkbox')
+    fireEvent.click(checkboxes[0])
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }))
+    expect(onConfirm).toHaveBeenCalledWith(['t2'])
+  })
+
+  it('confirm with all checked sends all tab ids', () => {
+    const onConfirm = vi.fn()
+    render(
+      <WorkspaceDeleteDialog
+        workspaceName="WS"
+        tabs={mockTabs}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }))
+    expect(onConfirm).toHaveBeenCalledWith(['t1', 't2'])
+  })
+
+  it('cancel calls onCancel', () => {
+    const onCancel = vi.fn()
+    render(
+      <WorkspaceDeleteDialog
+        workspaceName="WS"
+        tabs={mockTabs}
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('renders empty tab list gracefully', () => {
+    const onConfirm = vi.fn()
+    render(
+      <WorkspaceDeleteDialog
+        workspaceName="WS"
+        tabs={[]}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }))
+    expect(onConfirm).toHaveBeenCalledWith([])
+  })
+})

--- a/spa/src/features/workspace/components/WorkspaceDeleteDialog.tsx
+++ b/spa/src/features/workspace/components/WorkspaceDeleteDialog.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { Trash, Warning } from '@phosphor-icons/react'
+import { useI18nStore } from '../../../stores/useI18nStore'
+
+interface TabItem {
+  id: string
+  label: string
+}
+
+interface Props {
+  workspaceName: string
+  tabs: TabItem[]
+  onConfirm: (closedTabIds: string[]) => void
+  onCancel: () => void
+}
+
+export function WorkspaceDeleteDialog({ workspaceName, tabs, onConfirm, onCancel }: Props) {
+  const t = useI18nStore((s) => s.t)
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(() => new Set(tabs.map((tab) => tab.id)))
+
+  const toggleTab = (tabId: string) => {
+    setCheckedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(tabId)) {
+        next.delete(tabId)
+      } else {
+        next.add(tabId)
+      }
+      return next
+    })
+  }
+
+  const handleConfirm = () => {
+    const closedTabIds = tabs.filter((tab) => checkedIds.has(tab.id)).map((tab) => tab.id)
+    onConfirm(closedTabIds)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-surface-secondary border border-border-default rounded-lg shadow-xl w-full max-w-md mx-4">
+        {/* Header */}
+        <div className="flex items-center gap-3 px-5 pt-5 pb-3">
+          <div className="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center flex-shrink-0">
+            <Warning size={20} className="text-red-400" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-primary">
+              {t('workspace.delete_title', { name: workspaceName })}
+            </h3>
+            {tabs.length > 0 && (
+              <p className="text-xs text-text-muted mt-0.5">
+                {t('workspace.delete_description')}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Tab list */}
+        {tabs.length > 0 && (
+          <div className="px-5 py-3 max-h-48 overflow-y-auto">
+            <div className="space-y-1.5">
+              {tabs.map((tab) => (
+                <label key={tab.id} className="flex items-center gap-2 cursor-pointer group">
+                  <input
+                    type="checkbox"
+                    checked={checkedIds.has(tab.id)}
+                    onChange={() => toggleTab(tab.id)}
+                    className="rounded border-border-default"
+                  />
+                  <span className="text-sm text-text-secondary group-hover:text-text-primary truncate">
+                    {tab.label}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex justify-end gap-2 px-5 py-4 border-t border-border-subtle">
+          <button
+            onClick={onCancel}
+            className="px-3 py-1.5 rounded text-xs bg-surface-tertiary text-text-secondary hover:text-text-primary cursor-pointer"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="px-3 py-1.5 rounded text-xs bg-red-600 text-white hover:bg-red-500 cursor-pointer flex items-center gap-1.5"
+          >
+            <Trash size={14} />
+            {t('workspace.delete_confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/spa/src/features/workspace/hooks.ts
+++ b/spa/src/features/workspace/hooks.ts
@@ -57,11 +57,8 @@ export function useTabWorkspaceActions(displayTabs: Tab[]) {
     const tab = createTab({ kind: 'new-tab' })
     addTab(tab)
     setActiveTab(tab.id)
-    if (activeWorkspaceId) {
-      useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, tab.id)
-      useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, tab.id)
-    }
-  }, [addTab, setActiveTab, activeWorkspaceId])
+    useWorkspaceStore.getState().insertTab(tab.id)
+  }, [addTab, setActiveTab])
 
   const handleReorderTabs = useCallback((order: string[]) => {
     if (activeWorkspaceId) {

--- a/spa/src/features/workspace/index.ts
+++ b/spa/src/features/workspace/index.ts
@@ -6,6 +6,7 @@ export { useTabWorkspaceActions } from './hooks'
 
 // Components
 export { ActivityBar } from './components/ActivityBar'
+export { WorkspaceDeleteDialog } from './components/WorkspaceDeleteDialog'
 
 // Lib
 export { getVisibleTabIds } from './lib/getVisibleTabIds'

--- a/spa/src/features/workspace/index.ts
+++ b/spa/src/features/workspace/index.ts
@@ -7,6 +7,9 @@ export { useTabWorkspaceActions } from './hooks'
 // Components
 export { ActivityBar } from './components/ActivityBar'
 
+// Lib
+export { getVisibleTabIds } from './lib/getVisibleTabIds'
+
 // Re-export shared types from types/tab.ts
 export type { Workspace } from '../../types/tab'
 export { createWorkspace, isStandaloneTab } from '../../types/tab'

--- a/spa/src/features/workspace/lib/getVisibleTabIds.test.ts
+++ b/spa/src/features/workspace/lib/getVisibleTabIds.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { getVisibleTabIds } from './getVisibleTabIds'
+import type { Workspace } from '../../../types/tab'
+
+describe('getVisibleTabIds', () => {
+  it('returns workspace tabs when active workspace exists', () => {
+    const workspaces: Workspace[] = [
+      { id: 'ws-1', name: 'WS1', color: '#aaa', tabs: ['t1', 't2'], activeTabId: 't1' },
+    ]
+    const tabs: Record<string, unknown> = { t1: {}, t2: {}, t3: {} }
+    const result = getVisibleTabIds({
+      tabs,
+      tabOrder: ['t1', 't2', 't3'],
+      activeTabId: 't1',
+      workspaces,
+      activeWorkspaceId: 'ws-1',
+    })
+    expect(result).toEqual(['t1', 't2'])
+  })
+
+  it('filters out tabs not in tab store', () => {
+    const workspaces: Workspace[] = [
+      { id: 'ws-1', name: 'WS1', color: '#aaa', tabs: ['t1', 't2', 't3'], activeTabId: 't1' },
+    ]
+    const tabs: Record<string, unknown> = { t1: {}, t3: {} }
+    const result = getVisibleTabIds({
+      tabs,
+      tabOrder: ['t1', 't3'],
+      activeTabId: 't1',
+      workspaces,
+      activeWorkspaceId: 'ws-1',
+    })
+    expect(result).toEqual(['t1', 't3'])
+  })
+
+  it('returns only standalone tab when active tab is standalone', () => {
+    const workspaces: Workspace[] = [
+      { id: 'ws-1', name: 'WS1', color: '#aaa', tabs: ['t1'], activeTabId: 't1' },
+    ]
+    const tabs: Record<string, unknown> = { t1: {}, t2: {} }
+    const result = getVisibleTabIds({
+      tabs,
+      tabOrder: ['t1', 't2'],
+      activeTabId: 't2',
+      workspaces,
+      activeWorkspaceId: 'ws-1',
+    })
+    expect(result).toEqual(['t2'])
+  })
+
+  it('returns all tabs from tabOrder when 0 workspaces', () => {
+    const result = getVisibleTabIds({
+      tabs: { t1: {}, t2: {}, t3: {} },
+      tabOrder: ['t1', 't2', 't3'],
+      activeTabId: 't1',
+      workspaces: [],
+      activeWorkspaceId: null,
+    })
+    expect(result).toEqual(['t1', 't2', 't3'])
+  })
+
+  it('returns all tabs from tabOrder when activeWorkspaceId is null', () => {
+    const workspaces: Workspace[] = [
+      { id: 'ws-1', name: 'WS1', color: '#aaa', tabs: ['t1'], activeTabId: 't1' },
+    ]
+    const result = getVisibleTabIds({
+      tabs: { t1: {}, t2: {} },
+      tabOrder: ['t1', 't2'],
+      activeTabId: null,
+      workspaces,
+      activeWorkspaceId: null,
+    })
+    expect(result).toEqual(['t1', 't2'])
+  })
+
+  it('returns empty array when no tabs exist', () => {
+    const result = getVisibleTabIds({
+      tabs: {},
+      tabOrder: [],
+      activeTabId: null,
+      workspaces: [],
+      activeWorkspaceId: null,
+    })
+    expect(result).toEqual([])
+  })
+})

--- a/spa/src/features/workspace/lib/getVisibleTabIds.ts
+++ b/spa/src/features/workspace/lib/getVisibleTabIds.ts
@@ -1,0 +1,38 @@
+import { isStandaloneTab, type Workspace } from '../../../types/tab'
+
+interface GetVisibleTabIdsParams {
+  tabs: Record<string, unknown>
+  tabOrder: string[]
+  activeTabId: string | null
+  workspaces: Workspace[]
+  activeWorkspaceId: string | null
+}
+
+/**
+ * Get the tab IDs currently visible in the TabBar (workspace-aware).
+ *
+ * Rules:
+ * 1. Active standalone tab selected → only that tab
+ * 2. Active workspace → that workspace's tabs (filtered by existence in tab store)
+ * 3. No workspace (0 workspaces or null activeWorkspaceId) → fallback to tabOrder
+ */
+export function getVisibleTabIds(params: GetVisibleTabIdsParams): string[] {
+  const { tabs, tabOrder, activeTabId, workspaces, activeWorkspaceId } = params
+
+  // Only apply workspace/standalone logic when the workspace system is active
+  if (workspaces.length > 0) {
+    // Standalone tab selected — only that tab is visible
+    if (activeTabId && isStandaloneTab(activeTabId, workspaces)) {
+      return [activeTabId]
+    }
+
+    // Active workspace — use its tab order
+    const activeWs = workspaces.find((w) => w.id === activeWorkspaceId)
+    if (activeWs) {
+      return activeWs.tabs.filter((id) => !!tabs[id])
+    }
+  }
+
+  // Fallback to global tabOrder (no workspaces, or no activeWorkspaceId)
+  return tabOrder
+}

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -219,11 +219,7 @@ function handleNotificationClick(action: NotificationAction): void {
         const newTab = createTab({ kind: 'tmux-session', hostId, sessionCode, mode: 'stream', cachedName: sessionName, tmuxInstance: '' })
         useTabStore.getState().addTab(newTab)
         useTabStore.getState().setActiveTab(newTab.id)
-        const activeWorkspaceId = useWorkspaceStore.getState().activeWorkspaceId
-        if (activeWorkspaceId) {
-          useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, newTab.id)
-          useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, newTab.id)
-        }
+        useWorkspaceStore.getState().insertTab(newTab.id)
         handled = true
       }
 

--- a/spa/src/hooks/useShortcuts.ts
+++ b/spa/src/hooks/useShortcuts.ts
@@ -2,35 +2,8 @@ import { useEffect } from 'react'
 import { useTabStore } from '../stores/useTabStore'
 import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { useHistoryStore } from '../stores/useHistoryStore'
-import { createTab, isStandaloneTab } from '../types/tab'
-
-/** Get the tab IDs currently visible in the TabBar (workspace-aware). */
-function getVisibleTabIds(): string[] {
-  const { tabs, tabOrder, activeTabId } = useTabStore.getState()
-  const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState()
-
-  // Standalone tab selected — only that tab is visible
-  if (activeTabId && isStandaloneTab(activeTabId, workspaces)) {
-    return [activeTabId]
-  }
-
-  // Active workspace — use its tab order
-  const activeWs = workspaces.find((w) => w.id === activeWorkspaceId)
-  if (activeWs) {
-    return activeWs.tabs.filter((id) => !!tabs[id])
-  }
-
-  // Fallback to global tabOrder
-  return tabOrder
-}
-
-function addToActiveWorkspace(tabId: string): void {
-  const wsId = useWorkspaceStore.getState().activeWorkspaceId
-  if (wsId) {
-    useWorkspaceStore.getState().addTabToWorkspace(wsId, tabId)
-    useWorkspaceStore.getState().setWorkspaceActiveTab(wsId, tabId)
-  }
-}
+import { createTab } from '../types/tab'
+import { getVisibleTabIds as getVisibleTabIdsShared } from '../features/workspace'
 
 export function useShortcuts(): void {
   useEffect(() => {
@@ -38,7 +11,13 @@ export function useShortcuts(): void {
 
     const cleanup = window.electronAPI.onShortcut(({ action }) => {
       const tabState = useTabStore.getState()
-      const visibleIds = getVisibleTabIds()
+      const visibleIds = getVisibleTabIdsShared({
+        tabs: tabState.tabs,
+        tabOrder: tabState.tabOrder,
+        activeTabId: tabState.activeTabId,
+        workspaces: useWorkspaceStore.getState().workspaces,
+        activeWorkspaceId: useWorkspaceStore.getState().activeWorkspaceId,
+      })
 
       if (action.startsWith('switch-tab-')) {
         if (action === 'switch-tab-last') {
@@ -85,19 +64,19 @@ export function useShortcuts(): void {
         const tab = createTab({ kind: 'new-tab' })
         tabState.addTab(tab)
         tabState.setActiveTab(tab.id)
-        addToActiveWorkspace(tab.id)
+        useWorkspaceStore.getState().insertTab(tab.id)
         return
       }
 
       if (action === 'open-settings') {
         const tabId = tabState.openSingletonTab({ kind: 'settings', scope: 'global' })
-        addToActiveWorkspace(tabId)
+        useWorkspaceStore.getState().insertTab(tabId)
         return
       }
 
       if (action === 'open-history') {
         const tabId = tabState.openSingletonTab({ kind: 'history' })
-        addToActiveWorkspace(tabId)
+        useWorkspaceStore.getState().insertTab(tabId)
         return
       }
 
@@ -106,7 +85,7 @@ export function useShortcuts(): void {
         if (tab) {
           tabState.addTab(tab)
           tabState.setActiveTab(tab.id)
-          addToActiveWorkspace(tab.id)
+          useWorkspaceStore.getState().insertTab(tab.id)
         }
         return
       }

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -407,5 +407,9 @@
   "hosts.confirm": "Confirm",
   "hosts.mode_pairing_hint": "Daemon is waiting for pairing",
   "hosts.mode_pending_hint": "Enter the token shown in the daemon terminal",
-  "hosts.mode_normal_hint": "Daemon is running — enter the configured token"
+  "hosts.mode_normal_hint": "Daemon is running — enter the configured token",
+
+  "workspace.delete_title": "Delete {{name}}",
+  "workspace.delete_description": "Select tabs to close with the workspace:",
+  "workspace.delete_confirm": "Delete"
 }

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -407,5 +407,9 @@
   "hosts.confirm": "確認",
   "hosts.mode_pairing_hint": "Daemon 等待配對中",
   "hosts.mode_pending_hint": "請輸入 daemon 終端機顯示的 Token",
-  "hosts.mode_normal_hint": "Daemon 運作中，請輸入已設定的 Token"
+  "hosts.mode_normal_hint": "Daemon 運作中，請輸入已設定的 Token",
+
+  "workspace.delete_title": "刪除 {{name}}",
+  "workspace.delete_description": "選擇要一併關閉的分頁：",
+  "workspace.delete_confirm": "刪除"
 }


### PR DESCRIPTION
## Summary

Phase 10 Workspace 強化的第二部分（共三個 PR）。依賴 PR #189。

- **Task 4**：提取 `getVisibleTabIds` 共用函式至 `features/workspace/lib/`，替換 App.tsx + useShortcuts.ts 的重複邏輯
- **Task 5**：收斂所有 `addTabToWorkspace + setWorkspaceActiveTab` 模式為 `insertTab`（App.tsx、hooks、useNotificationDispatcher、SessionsSection）
- **Task 6**：WorkspaceDeleteDialog — 刪除 workspace 確認 UI + tab 勾選清單

### 關鍵變更

| 變更 | 說明 |
|------|------|
| `features/workspace/lib/getVisibleTabIds.ts` | 共用 visible tabs 邏輯（純函式） |
| `App.tsx` | 改用 getVisibleTabIds + insertTab |
| `hooks/useShortcuts.ts` | 移除本地 helper，改用共用函式 |
| `hooks/useNotificationDispatcher.ts` | 改用 insertTab |
| `components/hosts/SessionsSection.tsx` | 改用 insertTab |
| `features/workspace/components/WorkspaceDeleteDialog.tsx` | 刪除確認對話框 |

### 測試

- getVisibleTabIds 6 test cases
- WorkspaceDeleteDialog 6 test cases
- SessionsSection mock 更新為 mockInsertTab
- 929 tests pass（Task 6 完成時）

## Test plan

- [ ] `cd spa && npx vitest run` — 全部通過
- [ ] `cd spa && pnpm run lint` — 無錯誤
- [ ] 搜尋確認無殘留 addTabToWorkspace 生產呼叫（store 內部除外）