### PR TITLE
feat: Phase 10c — 右鍵選單 + Chip + 設定 UI + 快捷鍵 + Migration (3/3)

### DIFF
--- a/electron/keybindings.ts
+++ b/electron/keybindings.ts
@@ -1,6 +1,6 @@
 import type { MenuItemConstructorOptions } from 'electron'
 
-export type MenuGroup = 'tab-index' | 'tab-nav' | 'tab-action' | 'app' | 'view' | 'file'
+export type MenuGroup = 'tab-index' | 'tab-nav' | 'tab-action' | 'workspace-nav' | 'app' | 'view' | 'file'
 
 export interface KeybindingDef {
   action: string
@@ -27,6 +27,18 @@ const DEFAULT_KEYBINDINGS: readonly KeybindingDef[] = [
   { action: 'reopen-closed-tab', accelerator: 'CommandOrControl+Shift+T', label: 'Reopen Closed Tab', menuCategory: 'Tab', menuGroup: 'tab-action' },
   { action: 'open-settings', accelerator: 'CommandOrControl+,', label: 'Settings', menuCategory: 'App', menuGroup: 'app' },
   { action: 'open-history', accelerator: 'CommandOrControl+Y', label: 'History', menuCategory: 'View', menuGroup: 'view' },
+  // Workspace navigation
+  { action: 'switch-workspace-1', accelerator: 'CommandOrControl+Alt+1', label: 'Workspace 1', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'switch-workspace-2', accelerator: 'CommandOrControl+Alt+2', label: 'Workspace 2', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'switch-workspace-3', accelerator: 'CommandOrControl+Alt+3', label: 'Workspace 3', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'switch-workspace-4', accelerator: 'CommandOrControl+Alt+4', label: 'Workspace 4', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'switch-workspace-5', accelerator: 'CommandOrControl+Alt+5', label: 'Workspace 5', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'switch-workspace-6', accelerator: 'CommandOrControl+Alt+6', label: 'Workspace 6', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'switch-workspace-7', accelerator: 'CommandOrControl+Alt+7', label: 'Workspace 7', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'switch-workspace-8', accelerator: 'CommandOrControl+Alt+8', label: 'Workspace 8', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'switch-workspace-9', accelerator: 'CommandOrControl+Alt+9', label: 'Workspace 9', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'prev-workspace', accelerator: 'CommandOrControl+Alt+Up', label: 'Previous Workspace', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
+  { action: 'next-workspace', accelerator: 'CommandOrControl+Alt+Down', label: 'Next Workspace', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
   // File
   { action: 'new-window', accelerator: 'CommandOrControl+N', label: 'New Window', menuCategory: 'File', menuGroup: 'file' },
 ]
@@ -87,6 +99,8 @@ export function buildMenuTemplate(
       ...(byGroup.get('tab-nav') ?? []),
       { type: 'separator' as const },
       ...(byGroup.get('tab-action') ?? []),
+      { type: 'separator' as const },
+      ...(byGroup.get('workspace-nav') ?? []),
     ],
   }
 

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -1,5 +1,5 @@
 // spa/src/App.tsx — v2 重構：wouter Router + Tab/Pane model
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Router } from 'wouter'
 import { ActivityBar } from './components/ActivityBar'
 import { TabBar } from './components/TabBar'
@@ -17,11 +17,21 @@ import { useNotificationDispatcher } from './hooks/useNotificationDispatcher'
 import { useUndoToast } from './stores/useUndoToast'
 import { useTabWorkspaceActions } from './hooks/useTabWorkspaceActions'
 import { isStandaloneTab } from './types/tab'
-import { getVisibleTabIds } from './features/workspace'
+import {
+  getVisibleTabIds,
+  WorkspaceChip,
+  WorkspaceContextMenu,
+  WorkspaceDeleteDialog,
+  WorkspaceRenameDialog,
+  WorkspaceColorPicker,
+  WorkspaceIconPicker,
+} from './features/workspace'
 import { TabContextMenu } from './components/TabContextMenu'
 import { ThemeInjector } from './components/ThemeInjector'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { getPlatformCapabilities } from './lib/platform'
+import { getPrimaryPane } from './lib/pane-tree'
+import { getPaneLabel } from './lib/pane-labels'
 import { useI18nStore } from './stores/useI18nStore'
 import type { Tab } from './types/tab'
 
@@ -150,6 +160,36 @@ export default function App() {
     handleContextAction,
   } = useTabWorkspaceActions(displayTabs)
 
+  // --- Workspace UI state ---
+  const [wsContextMenu, setWsContextMenu] = useState<{ wsId: string; position: { x: number; y: number } } | null>(null)
+  const [wsDeleteTarget, setWsDeleteTarget] = useState<string | null>(null)
+  const [wsRenameTarget, setWsRenameTarget] = useState<string | null>(null)
+  const [wsColorTarget, setWsColorTarget] = useState<string | null>(null)
+  const [wsIconTarget, setWsIconTarget] = useState<string | null>(null)
+
+  const activeWs = workspaces.find((w) => w.id === activeWorkspaceId)
+
+  const handleWsContextMenu = (e: React.MouseEvent, wsId: string) => {
+    setWsContextMenu({ wsId, position: { x: e.clientX, y: e.clientY } })
+  }
+
+  const handleWsDelete = (wsId: string) => {
+    const ws = workspaces.find((w) => w.id === wsId)
+    if (!ws) return
+    if (ws.tabs.length === 0) {
+      useWorkspaceStore.getState().removeWorkspace(wsId)
+    } else {
+      setWsDeleteTarget(wsId)
+    }
+  }
+
+  const handleWsDeleteConfirm = (closedTabIds: string[]) => {
+    if (!wsDeleteTarget) return
+    closedTabIds.forEach((tabId) => handleCloseTab(tabId))
+    useWorkspaceStore.getState().removeWorkspace(wsDeleteTarget)
+    setWsDeleteTarget(null)
+  }
+
   return (
     <ErrorBoundary>
     <Router>
@@ -164,7 +204,15 @@ export default function App() {
             {/* Traffic light safe zone (78px ≈ 3 buttons + padding) */}
             <div className="shrink-0" style={{ width: 78 }} />
             {/* Tabs — no-drag so clicks work */}
-            <div style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+            <div className="flex items-center" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+              {activeWs && !activeStandaloneTabId && (
+                <WorkspaceChip
+                  name={activeWs.name}
+                  color={activeWs.color}
+                  onClick={() => {}}
+                  onContextMenu={(e) => handleWsContextMenu(e, activeWs.id)}
+                />
+              )}
               <TabBar
                 tabs={displayTabs}
                 activeTabId={activeTabId}
@@ -189,6 +237,7 @@ export default function App() {
           onSelectWorkspace={handleSelectWorkspace}
           onSelectStandaloneTab={handleSelectTab}
           onAddWorkspace={() => {}}
+          onContextMenuWorkspace={handleWsContextMenu}
           onOpenHosts={() => {
             const tabId = useTabStore.getState().openSingletonTab({ kind: 'hosts' })
             useWorkspaceStore.getState().insertTab(tabId)
@@ -203,16 +252,28 @@ export default function App() {
         <div className="flex-1 flex flex-col min-w-0">
           {/* SPA: TabBar in normal position */}
           {!isElectron && (
-            <TabBar
-              tabs={displayTabs}
-              activeTabId={activeTabId}
-              onSelectTab={handleSelectTab}
-              onCloseTab={handleCloseTab}
-              onAddTab={handleAddTab}
-              onReorderTabs={handleReorderTabs}
-              onMiddleClick={handleMiddleClick}
-              onContextMenu={handleContextMenu}
-            />
+            <div className="flex items-center bg-surface-secondary border-b border-border-subtle">
+              {activeWs && !activeStandaloneTabId && (
+                <WorkspaceChip
+                  name={activeWs.name}
+                  color={activeWs.color}
+                  onClick={() => {}}
+                  onContextMenu={(e) => handleWsContextMenu(e, activeWs.id)}
+                />
+              )}
+              <div className="flex-1 min-w-0">
+                <TabBar
+                  tabs={displayTabs}
+                  activeTabId={activeTabId}
+                  onSelectTab={handleSelectTab}
+                  onCloseTab={handleCloseTab}
+                  onAddTab={handleAddTab}
+                  onReorderTabs={handleReorderTabs}
+                  onMiddleClick={handleMiddleClick}
+                  onContextMenu={handleContextMenu}
+                />
+              </div>
+            </div>
           )}
           <div className="flex-1 flex overflow-hidden">
             <TabContent
@@ -241,6 +302,60 @@ export default function App() {
             onAction={handleContextAction}
             hasOtherUnlocked={displayTabs.some((t) => t.id !== contextMenu.tab.id && !t.locked)}
             hasRightUnlocked={contextMenuHasRightUnlocked}
+          />
+        )}
+        {wsContextMenu && (
+          <WorkspaceContextMenu
+            position={wsContextMenu.position}
+            workspaceName={workspaces.find((w) => w.id === wsContextMenu.wsId)?.name ?? ''}
+            onRename={() => { setWsRenameTarget(wsContextMenu.wsId); setWsContextMenu(null) }}
+            onChangeColor={() => { setWsColorTarget(wsContextMenu.wsId); setWsContextMenu(null) }}
+            onChangeIcon={() => { setWsIconTarget(wsContextMenu.wsId); setWsContextMenu(null) }}
+            onDelete={() => { handleWsDelete(wsContextMenu.wsId); setWsContextMenu(null) }}
+            onClose={() => setWsContextMenu(null)}
+          />
+        )}
+        {wsDeleteTarget && (() => {
+          const ws = workspaces.find((w) => w.id === wsDeleteTarget)
+          if (!ws) return null
+          const t = useI18nStore.getState().t
+          const tabItems = ws.tabs
+            .map((tabId) => {
+              const tab = tabs[tabId]
+              if (!tab) return null
+              const content = getPrimaryPane(tab.layout).content
+              const label = getPaneLabel(content, { getByCode: () => undefined }, { getById: () => undefined }, t)
+              return { id: tabId, label }
+            })
+            .filter(Boolean) as { id: string; label: string }[]
+          return (
+            <WorkspaceDeleteDialog
+              workspaceName={ws.name}
+              tabs={tabItems}
+              onConfirm={handleWsDeleteConfirm}
+              onCancel={() => setWsDeleteTarget(null)}
+            />
+          )
+        })()}
+        {wsRenameTarget && (
+          <WorkspaceRenameDialog
+            currentName={workspaces.find((w) => w.id === wsRenameTarget)?.name ?? ''}
+            onConfirm={(name) => { useWorkspaceStore.getState().renameWorkspace(wsRenameTarget, name); setWsRenameTarget(null) }}
+            onCancel={() => setWsRenameTarget(null)}
+          />
+        )}
+        {wsColorTarget && (
+          <WorkspaceColorPicker
+            currentColor={workspaces.find((w) => w.id === wsColorTarget)?.color ?? '#888'}
+            onSelect={(color) => { useWorkspaceStore.getState().setWorkspaceColor(wsColorTarget, color); setWsColorTarget(null) }}
+            onCancel={() => setWsColorTarget(null)}
+          />
+        )}
+        {wsIconTarget && (
+          <WorkspaceIconPicker
+            currentIcon={workspaces.find((w) => w.id === wsIconTarget)?.icon}
+            onSelect={(icon) => { useWorkspaceStore.getState().setWorkspaceIcon(wsIconTarget, icon); setWsIconTarget(null) }}
+            onCancel={() => setWsIconTarget(null)}
           />
         )}
         </div>

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -175,11 +175,19 @@ export default function App() {
     setWsContextMenu({ wsId, position: { x: e.clientX, y: e.clientY } })
   }
 
+  const syncActiveTabAfterWsRemove = () => {
+    const { activeWorkspaceId: newWsId, workspaces: remaining } = useWorkspaceStore.getState()
+    const newWs = remaining.find((w) => w.id === newWsId)
+    const nextTab = newWs?.activeTabId ?? newWs?.tabs[0]
+    if (nextTab) useTabStore.getState().setActiveTab(nextTab)
+  }
+
   const handleWsDelete = (wsId: string) => {
     const ws = workspaces.find((w) => w.id === wsId)
     if (!ws) return
     if (ws.tabs.length === 0) {
       useWorkspaceStore.getState().removeWorkspace(wsId)
+      syncActiveTabAfterWsRemove()
     } else {
       setWsDeleteTarget(wsId)
     }
@@ -191,9 +199,10 @@ export default function App() {
     const hasPreservedTabs = ws && closedTabIds.length < ws.tabs.length
     closedTabIds.forEach((tabId) => handleCloseTab(tabId))
     useWorkspaceStore.getState().removeWorkspace(wsDeleteTarget)
-    // Switch to Home if some tabs were preserved (now standalone)
     if (hasPreservedTabs) {
       useWorkspaceStore.getState().setActiveWorkspace(null)
+    } else {
+      syncActiveTabAfterWsRemove()
     }
     setWsDeleteTarget(null)
   }
@@ -327,7 +336,6 @@ export default function App() {
         {wsContextMenu && (
           <WorkspaceContextMenu
             position={wsContextMenu.position}
-            workspaceName={workspaces.find((w) => w.id === wsContextMenu.wsId)?.name ?? ''}
             onRename={() => { setWsRenameTarget(wsContextMenu.wsId); setWsContextMenu(null) }}
             onChangeColor={() => { setWsColorTarget(wsContextMenu.wsId); setWsContextMenu(null) }}
             onChangeIcon={() => { setWsIconTarget(wsContextMenu.wsId); setWsContextMenu(null) }}
@@ -390,6 +398,7 @@ export default function App() {
             }}
             onSkip={() => {
               setMigrateDialog(null)
+              useWorkspaceStore.getState().setActiveWorkspace(null)
             }}
           />
         )}

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -187,8 +187,14 @@ export default function App() {
 
   const handleWsDeleteConfirm = (closedTabIds: string[]) => {
     if (!wsDeleteTarget) return
+    const ws = workspaces.find((w) => w.id === wsDeleteTarget)
+    const hasPreservedTabs = ws && closedTabIds.length < ws.tabs.length
     closedTabIds.forEach((tabId) => handleCloseTab(tabId))
     useWorkspaceStore.getState().removeWorkspace(wsDeleteTarget)
+    // Switch to Home if some tabs were preserved (now standalone)
+    if (hasPreservedTabs) {
+      useWorkspaceStore.getState().setActiveWorkspace(null)
+    }
     setWsDeleteTarget(null)
   }
 
@@ -233,11 +239,15 @@ export default function App() {
         <div className="flex-1 flex min-h-0">
         <ActivityBar
           workspaces={workspaces}
-          standaloneTabs={standaloneTabs}
           activeWorkspaceId={activeStandaloneTabId ? null : activeWorkspaceId}
           activeStandaloneTabId={activeStandaloneTabId}
           onSelectWorkspace={handleSelectWorkspace}
-          onSelectStandaloneTab={handleSelectTab}
+          onSelectHome={() => {
+            useWorkspaceStore.getState().setActiveWorkspace(null)
+            const firstStandalone = standaloneTabs[0]
+            if (firstStandalone) handleSelectTab(firstStandalone.id)
+          }}
+          standaloneTabCount={standaloneTabs.length}
           onAddWorkspace={() => {
             if (workspaces.length === 0 && tabOrder.length > 0) {
               const ws = useWorkspaceStore.getState().addWorkspace('Workspace 1')

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -25,6 +25,7 @@ import {
   WorkspaceRenameDialog,
   WorkspaceColorPicker,
   WorkspaceIconPicker,
+  MigrateTabsDialog,
 } from './features/workspace'
 import { TabContextMenu } from './components/TabContextMenu'
 import { ThemeInjector } from './components/ThemeInjector'
@@ -166,6 +167,7 @@ export default function App() {
   const [wsRenameTarget, setWsRenameTarget] = useState<string | null>(null)
   const [wsColorTarget, setWsColorTarget] = useState<string | null>(null)
   const [wsIconTarget, setWsIconTarget] = useState<string | null>(null)
+  const [migrateDialog, setMigrateDialog] = useState<{ wsId: string; wsName: string } | null>(null)
 
   const activeWs = workspaces.find((w) => w.id === activeWorkspaceId)
 
@@ -236,7 +238,15 @@ export default function App() {
           activeStandaloneTabId={activeStandaloneTabId}
           onSelectWorkspace={handleSelectWorkspace}
           onSelectStandaloneTab={handleSelectTab}
-          onAddWorkspace={() => {}}
+          onAddWorkspace={() => {
+            if (workspaces.length === 0 && tabOrder.length > 0) {
+              const ws = useWorkspaceStore.getState().addWorkspace('Workspace 1')
+              setMigrateDialog({ wsId: ws.id, wsName: ws.name })
+            } else {
+              const count = workspaces.length + 1
+              useWorkspaceStore.getState().addWorkspace(`Workspace ${count}`)
+            }
+          }}
           onContextMenuWorkspace={handleWsContextMenu}
           onOpenHosts={() => {
             const tabId = useTabStore.getState().openSingletonTab({ kind: 'hosts' })
@@ -356,6 +366,21 @@ export default function App() {
             currentIcon={workspaces.find((w) => w.id === wsIconTarget)?.icon}
             onSelect={(icon) => { useWorkspaceStore.getState().setWorkspaceIcon(wsIconTarget, icon); setWsIconTarget(null) }}
             onCancel={() => setWsIconTarget(null)}
+          />
+        )}
+        {migrateDialog && (
+          <MigrateTabsDialog
+            tabCount={tabOrder.length}
+            workspaceName={migrateDialog.wsName}
+            onMigrate={() => {
+              tabOrder.forEach((tabId) => {
+                useWorkspaceStore.getState().insertTab(tabId, migrateDialog.wsId)
+              })
+              setMigrateDialog(null)
+            }}
+            onSkip={() => {
+              setMigrateDialog(null)
+            }}
           />
         )}
         </div>

--- a/spa/src/features/workspace/components/ActivityBar.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.test.tsx
@@ -1,92 +1,78 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { ActivityBar } from './ActivityBar'
-import { createTab } from '../../../types/tab'
-import type { Tab, Workspace } from '../../../types/tab'
+import type { Workspace } from '../../../types/tab'
 
 const mockWorkspaces: Workspace[] = [
   { id: 'ws-1', name: 'Project A', color: '#7a6aaa', icon: '🔧', tabs: ['t1', 't2'], activeTabId: 't1' },
   { id: 'ws-2', name: 'Server', color: '#6aaa7a', icon: '🖥', tabs: ['t3'], activeTabId: 't3' },
 ]
 
-const mockStandaloneTabs: Tab[] = [
-  { ...createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'misc', mode: 'terminal', cachedName: '', tmuxInstance: '' }), id: 'st-1' },
-]
+const defaultProps = {
+  workspaces: mockWorkspaces,
+  activeWorkspaceId: 'ws-1' as string | null,
+  activeStandaloneTabId: null as string | null,
+  onSelectWorkspace: vi.fn(),
+  onSelectHome: vi.fn(),
+  standaloneTabCount: 0,
+  onAddWorkspace: vi.fn(),
+  onOpenHosts: vi.fn(),
+  onOpenSettings: vi.fn(),
+}
 
 describe('ActivityBar', () => {
-  it('renders workspace icons', () => {
+  beforeEach(() => {
     cleanup()
-    render(
-      <ActivityBar
-        workspaces={mockWorkspaces}
-        standaloneTabs={mockStandaloneTabs}
-        activeWorkspaceId="ws-1"
-        activeStandaloneTabId={null}
-        onSelectWorkspace={vi.fn()}
-        onSelectStandaloneTab={vi.fn()}
-        onAddWorkspace={vi.fn()}
-        onOpenHosts={vi.fn()}
-        onOpenSettings={vi.fn()}
-      />,
-    )
+    vi.clearAllMocks()
+  })
+
+  it('renders workspace icons', () => {
+    render(<ActivityBar {...defaultProps} />)
     expect(screen.getByTitle('Project A')).toBeTruthy()
     expect(screen.getByTitle('Server')).toBeTruthy()
   })
 
   it('highlights active workspace', () => {
-    cleanup()
-    render(
-      <ActivityBar
-        workspaces={mockWorkspaces}
-        standaloneTabs={mockStandaloneTabs}
-        activeWorkspaceId="ws-1"
-        activeStandaloneTabId={null}
-        onSelectWorkspace={vi.fn()}
-        onSelectStandaloneTab={vi.fn()}
-        onAddWorkspace={vi.fn()}
-        onOpenHosts={vi.fn()}
-        onOpenSettings={vi.fn()}
-      />,
-    )
+    render(<ActivityBar {...defaultProps} />)
     const activeBtn = screen.getByTitle('Project A')
     expect(activeBtn.className).toContain('ring')
   })
 
   it('calls onSelectWorkspace on click', () => {
-    cleanup()
     const onSelect = vi.fn()
-    render(
-      <ActivityBar
-        workspaces={mockWorkspaces}
-        standaloneTabs={mockStandaloneTabs}
-        activeWorkspaceId="ws-1"
-        activeStandaloneTabId={null}
-        onSelectWorkspace={onSelect}
-        onSelectStandaloneTab={vi.fn()}
-        onAddWorkspace={vi.fn()}
-        onOpenHosts={vi.fn()}
-        onOpenSettings={vi.fn()}
-      />,
-    )
+    render(<ActivityBar {...defaultProps} onSelectWorkspace={onSelect} />)
     fireEvent.click(screen.getByTitle('Server'))
     expect(onSelect).toHaveBeenCalledWith('ws-2')
   })
 
-  it('renders standalone tabs below separator', () => {
-    cleanup()
-    render(
-      <ActivityBar
-        workspaces={mockWorkspaces}
-        standaloneTabs={mockStandaloneTabs}
-        activeWorkspaceId="ws-1"
-        activeStandaloneTabId={null}
-        onSelectWorkspace={vi.fn()}
-        onSelectStandaloneTab={vi.fn()}
-        onAddWorkspace={vi.fn()}
-        onOpenHosts={vi.fn()}
-        onOpenSettings={vi.fn()}
-      />,
-    )
-    expect(screen.getByTitle('misc')).toBeTruthy()
+  it('renders Home button', () => {
+    render(<ActivityBar {...defaultProps} />)
+    expect(screen.getByTitle('Home')).toBeTruthy()
+  })
+
+  it('highlights Home when no active workspace', () => {
+    render(<ActivityBar {...defaultProps} activeWorkspaceId={null} />)
+    const homeBtn = screen.getByTitle('Home')
+    expect(homeBtn.className).toContain('bg-accent')
+  })
+
+  it('calls onSelectHome on Home click', () => {
+    const onSelectHome = vi.fn()
+    render(<ActivityBar {...defaultProps} onSelectHome={onSelectHome} />)
+    fireEvent.click(screen.getByTitle('Home'))
+    expect(onSelectHome).toHaveBeenCalled()
+  })
+
+  it('shows badge on Home when standalone tabs exist and workspace is active', () => {
+    const { container } = render(<ActivityBar {...defaultProps} standaloneTabCount={3} />)
+    const badge = container.querySelector('.bg-red-500')
+    expect(badge).toBeTruthy()
+    expect(badge!.textContent).toBe('3')
+  })
+
+  it('hides badge on Home when in Home mode', () => {
+    const { container } = render(<ActivityBar {...defaultProps} activeWorkspaceId={null} standaloneTabCount={3} />)
+    const badge = container.querySelector('.bg-red-500')
+    expect(badge).toBeNull()
   })
 })

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -1,19 +1,14 @@
-import { Plus, GearSix, HardDrives } from '@phosphor-icons/react'
-import type { Tab, Workspace } from '../../../types/tab'
-import { getPrimaryPane } from '../../../lib/pane-tree'
-import { getPaneLabel } from '../../../lib/pane-labels'
+import { Plus, GearSix, HardDrives, SquaresFour } from '@phosphor-icons/react'
+import type { Workspace } from '../../../types/tab'
 import { useI18nStore } from '../../../stores/useI18nStore'
-
-const emptySessionLookup = { getByCode: () => undefined }
-const emptyWorkspaceLookup = { getById: () => undefined }
 
 interface Props {
   workspaces: Workspace[]
-  standaloneTabs: Tab[]
   activeWorkspaceId: string | null
   activeStandaloneTabId: string | null
   onSelectWorkspace: (wsId: string) => void
-  onSelectStandaloneTab: (tabId: string) => void
+  onSelectHome: () => void
+  standaloneTabCount: number
   onAddWorkspace: () => void
   onContextMenuWorkspace?: (e: React.MouseEvent, wsId: string) => void
   onOpenHosts: () => void
@@ -22,11 +17,11 @@ interface Props {
 
 export function ActivityBar({
   workspaces,
-  standaloneTabs,
   activeWorkspaceId,
   activeStandaloneTabId,
   onSelectWorkspace,
-  onSelectStandaloneTab,
+  onSelectHome,
+  standaloneTabCount,
   onAddWorkspace,
   onContextMenuWorkspace,
   onOpenHosts,
@@ -35,6 +30,26 @@ export function ActivityBar({
   const t = useI18nStore((s) => s.t)
   return (
     <div className="hidden lg:flex w-11 flex-col items-center bg-surface-tertiary border-r border-border-subtle py-2 gap-2 flex-shrink-0">
+      {/* Home — standalone tabs */}
+      <button
+        title={t('nav.home')}
+        onClick={onSelectHome}
+        className={`relative w-8 h-8 rounded-lg flex items-center justify-center cursor-pointer transition-all ${
+          !activeWorkspaceId && !activeStandaloneTabId
+            ? 'bg-accent text-white'
+            : 'bg-surface-secondary text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
+        }`}
+      >
+        <SquaresFour size={18} weight={!activeWorkspaceId && !activeStandaloneTabId ? 'fill' : 'regular'} />
+        {activeWorkspaceId && standaloneTabCount > 0 && (
+          <span className="absolute -top-1 -right-1 min-w-[16px] h-4 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center px-0.5">
+            {standaloneTabCount}
+          </span>
+        )}
+      </button>
+
+      {workspaces.length > 0 && <div className="w-5 h-px bg-border-default my-0.5" />}
+
       {/* Workspaces */}
       {workspaces.map((ws) => (
         <button
@@ -55,35 +70,6 @@ export function ActivityBar({
           {ws.icon ?? ws.name.charAt(0)}
         </button>
       ))}
-
-      {/* Separator */}
-      {standaloneTabs.length > 0 && (
-        <div className="w-5 h-px bg-border-default my-1" />
-      )}
-
-      {/* Standalone tabs */}
-      {standaloneTabs.map((tab) => {
-        const label = getPaneLabel(
-          getPrimaryPane(tab.layout).content,
-          emptySessionLookup,
-          emptyWorkspaceLookup,
-          t,
-        )
-        return (
-          <button
-            key={tab.id}
-            title={label}
-            onClick={() => onSelectStandaloneTab(tab.id)}
-            className={`w-8 h-8 rounded-md flex items-center justify-center text-xs cursor-pointer transition-all ${
-              activeStandaloneTabId === tab.id
-                ? 'ring-2 ring-accent bg-surface-secondary'
-                : 'bg-surface-tertiary opacity-70 hover:opacity-100'
-            }`}
-          >
-            {label.charAt(0).toUpperCase()}
-          </button>
-        )
-      })}
 
       {/* Add + Settings */}
       <div className="mt-auto flex flex-col items-center gap-2 pb-1">

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -35,12 +35,12 @@ export function ActivityBar({
         title={t('nav.home')}
         onClick={onSelectHome}
         className={`relative w-8 h-8 rounded-lg flex items-center justify-center cursor-pointer transition-all ${
-          !activeWorkspaceId && !activeStandaloneTabId
+          !activeWorkspaceId
             ? 'bg-accent text-white'
             : 'bg-surface-secondary text-text-secondary hover:text-text-primary hover:bg-surface-tertiary'
         }`}
       >
-        <SquaresFour size={18} weight={!activeWorkspaceId && !activeStandaloneTabId ? 'fill' : 'regular'} />
+        <SquaresFour size={18} weight={!activeWorkspaceId ? 'fill' : 'regular'} />
         {activeWorkspaceId && standaloneTabCount > 0 && (
           <span className="absolute -top-1 -right-1 min-w-[16px] h-4 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center px-0.5">
             {standaloneTabCount}

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -15,6 +15,7 @@ interface Props {
   onSelectWorkspace: (wsId: string) => void
   onSelectStandaloneTab: (tabId: string) => void
   onAddWorkspace: () => void
+  onContextMenuWorkspace?: (e: React.MouseEvent, wsId: string) => void
   onOpenHosts: () => void
   onOpenSettings: () => void
 }
@@ -27,6 +28,7 @@ export function ActivityBar({
   onSelectWorkspace,
   onSelectStandaloneTab,
   onAddWorkspace,
+  onContextMenuWorkspace,
   onOpenHosts,
   onOpenSettings,
 }: Props) {
@@ -39,6 +41,10 @@ export function ActivityBar({
           key={ws.id}
           title={ws.name}
           onClick={() => onSelectWorkspace(ws.id)}
+          onContextMenu={(e) => {
+            e.preventDefault()
+            onContextMenuWorkspace?.(e, ws.id)
+          }}
           className={`w-8 h-8 rounded-md flex items-center justify-center text-xs cursor-pointer transition-all ${
             activeWorkspaceId === ws.id && !activeStandaloneTabId
               ? 'ring-2 ring-purple-400'

--- a/spa/src/features/workspace/components/MigrateTabsDialog.test.tsx
+++ b/spa/src/features/workspace/components/MigrateTabsDialog.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { MigrateTabsDialog } from './MigrateTabsDialog'
+
+describe('MigrateTabsDialog', () => {
+  beforeEach(() => { cleanup() })
+
+  it('renders dialog with tab count', () => {
+    render(<MigrateTabsDialog tabCount={3} workspaceName="New WS" onMigrate={vi.fn()} onSkip={vi.fn()} />)
+    expect(screen.getByText(/3/)).toBeInTheDocument()
+    expect(screen.getByText(/New WS/)).toBeInTheDocument()
+  })
+
+  it('calls onMigrate when user chooses to migrate', () => {
+    const onMigrate = vi.fn()
+    render(<MigrateTabsDialog tabCount={2} workspaceName="WS" onMigrate={onMigrate} onSkip={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /move/i }))
+    expect(onMigrate).toHaveBeenCalled()
+  })
+
+  it('calls onSkip when user chooses not to migrate', () => {
+    const onSkip = vi.fn()
+    render(<MigrateTabsDialog tabCount={2} workspaceName="WS" onMigrate={vi.fn()} onSkip={onSkip} />)
+    fireEvent.click(screen.getByRole('button', { name: /skip/i }))
+    expect(onSkip).toHaveBeenCalled()
+  })
+})

--- a/spa/src/features/workspace/components/MigrateTabsDialog.tsx
+++ b/spa/src/features/workspace/components/MigrateTabsDialog.tsx
@@ -1,0 +1,38 @@
+import { ArrowRight, SkipForward } from '@phosphor-icons/react'
+import { useI18nStore } from '../../../stores/useI18nStore'
+
+interface Props {
+  tabCount: number
+  workspaceName: string
+  onMigrate: () => void
+  onSkip: () => void
+}
+
+export function MigrateTabsDialog({ tabCount, workspaceName, onMigrate, onSkip }: Props) {
+  const t = useI18nStore((s) => s.t)
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-surface-secondary border border-border-default rounded-lg shadow-xl w-full max-w-sm mx-4 p-5">
+        <h3 className="text-sm font-semibold text-text-primary mb-2">
+          {t('workspace.migrate_title')}
+        </h3>
+        <p className="text-xs text-text-muted mb-4">
+          {t('workspace.migrate_description', { count: tabCount, name: workspaceName })}
+        </p>
+        <div className="flex justify-end gap-2">
+          <button onClick={onSkip}
+            className="px-3 py-1.5 rounded text-xs bg-surface-tertiary text-text-secondary hover:text-text-primary cursor-pointer flex items-center gap-1.5">
+            <SkipForward size={14} />
+            {t('workspace.migrate_skip')}
+          </button>
+          <button onClick={onMigrate}
+            className="px-3 py-1.5 rounded text-xs bg-accent text-white hover:bg-accent/80 cursor-pointer flex items-center gap-1.5">
+            <ArrowRight size={14} />
+            {t('workspace.migrate_move')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/spa/src/features/workspace/components/WorkspaceChip.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceChip.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { WorkspaceChip } from './WorkspaceChip'
+
+describe('WorkspaceChip', () => {
+  beforeEach(() => { cleanup() })
+
+  it('renders workspace name and color dot', () => {
+    render(<WorkspaceChip name="My Workspace" color="#7a6aaa" onClick={vi.fn()} onContextMenu={vi.fn()} />)
+    expect(screen.getByText('My Workspace')).toBeInTheDocument()
+    const dot = screen.getByTestId('workspace-color-dot')
+    expect(dot.style.backgroundColor).toBe('rgb(122, 106, 170)')
+  })
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn()
+    render(<WorkspaceChip name="WS" color="#aaa" onClick={onClick} onContextMenu={vi.fn()} />)
+    fireEvent.click(screen.getByText('WS'))
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('calls onContextMenu on right click', () => {
+    const onContextMenu = vi.fn()
+    render(<WorkspaceChip name="WS" color="#aaa" onClick={vi.fn()} onContextMenu={onContextMenu} />)
+    fireEvent.contextMenu(screen.getByText('WS'))
+    expect(onContextMenu).toHaveBeenCalled()
+  })
+
+  it('does not render when name is null', () => {
+    const { container } = render(<WorkspaceChip name={null} color={null} onClick={vi.fn()} onContextMenu={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/spa/src/features/workspace/components/WorkspaceChip.tsx
+++ b/spa/src/features/workspace/components/WorkspaceChip.tsx
@@ -1,0 +1,20 @@
+import { CaretDown } from '@phosphor-icons/react'
+
+interface Props {
+  name: string | null
+  color: string | null
+  onClick: () => void
+  onContextMenu: (e: React.MouseEvent) => void
+}
+
+export function WorkspaceChip({ name, color, onClick, onContextMenu }: Props) {
+  if (!name) return null
+  return (
+    <button onClick={onClick} onContextMenu={onContextMenu}
+      className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-text-secondary hover:text-text-primary hover:bg-surface-hover cursor-pointer transition-colors flex-shrink-0">
+      <span data-testid="workspace-color-dot" className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: color ?? '#888' }} />
+      <span className="truncate max-w-24">{name}</span>
+      <CaretDown size={10} className="flex-shrink-0 opacity-60" />
+    </button>
+  )
+}

--- a/spa/src/features/workspace/components/WorkspaceColorPicker.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceColorPicker.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { WorkspaceColorPicker } from './WorkspaceColorPicker'
+import { WORKSPACE_COLORS } from '../constants'
+
+describe('WorkspaceColorPicker', () => {
+  beforeEach(() => { cleanup() })
+
+  it('renders all color options', () => {
+    render(<WorkspaceColorPicker currentColor="#7a6aaa" onSelect={vi.fn()} onCancel={vi.fn()} />)
+    const buttons = screen.getAllByRole('button').filter((b) => b.getAttribute('data-color'))
+    expect(buttons.length).toBe(WORKSPACE_COLORS.length)
+  })
+
+  it('highlights current color', () => {
+    render(<WorkspaceColorPicker currentColor="#7a6aaa" onSelect={vi.fn()} onCancel={vi.fn()} />)
+    const activeBtn = screen.getByRole('button', { pressed: true })
+    expect(activeBtn.getAttribute('data-color')).toBe('#7a6aaa')
+  })
+
+  it('calls onSelect with chosen color', () => {
+    const onSelect = vi.fn()
+    render(<WorkspaceColorPicker currentColor="#7a6aaa" onSelect={onSelect} onCancel={vi.fn()} />)
+    const buttons = screen.getAllByRole('button').filter((b) => b.getAttribute('data-color'))
+    const different = buttons.find((b) => b.getAttribute('data-color') !== '#7a6aaa')!
+    fireEvent.click(different)
+    expect(onSelect).toHaveBeenCalledWith(different.getAttribute('data-color'))
+  })
+})

--- a/spa/src/features/workspace/components/WorkspaceColorPicker.tsx
+++ b/spa/src/features/workspace/components/WorkspaceColorPicker.tsx
@@ -1,0 +1,35 @@
+import { Check } from '@phosphor-icons/react'
+import { useI18nStore } from '../../../stores/useI18nStore'
+import { WORKSPACE_COLORS } from '../constants'
+
+interface Props {
+  currentColor: string
+  onSelect: (color: string) => void
+  onCancel: () => void
+}
+
+export function WorkspaceColorPicker({ currentColor, onSelect, onCancel }: Props) {
+  const t = useI18nStore((s) => s.t)
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-surface-secondary border border-border-default rounded-lg shadow-xl w-full max-w-xs mx-4 p-5">
+        <h3 className="text-sm font-semibold text-text-primary mb-3">{t('workspace.change_color')}</h3>
+        <div className="grid grid-cols-6 gap-2">
+          {WORKSPACE_COLORS.map((color) => (
+            <button key={color} data-color={color} aria-pressed={color === currentColor} onClick={() => onSelect(color)}
+              className={`w-8 h-8 rounded-full cursor-pointer flex items-center justify-center transition-transform hover:scale-110 ${
+                color === currentColor ? 'ring-2 ring-white ring-offset-2 ring-offset-surface-secondary' : ''
+              }`} style={{ backgroundColor: color }}>
+              {color === currentColor && <Check size={14} className="text-white" />}
+            </button>
+          ))}
+        </div>
+        <div className="flex justify-end mt-4">
+          <button onClick={onCancel} className="px-3 py-1.5 rounded text-xs bg-surface-tertiary text-text-secondary hover:text-text-primary cursor-pointer">
+            {t('common.cancel')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/spa/src/features/workspace/components/WorkspaceContextMenu.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceContextMenu.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { WorkspaceContextMenu } from './WorkspaceContextMenu'
+
+describe('WorkspaceContextMenu', () => {
+  beforeEach(() => { cleanup() })
+
+  it('renders all menu items', () => {
+    render(
+      <WorkspaceContextMenu
+        position={{ x: 100, y: 200 }}
+        workspaceName="My WS"
+        onRename={vi.fn()}
+        onChangeColor={vi.fn()}
+        onChangeIcon={vi.fn()}
+        onDelete={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/rename/i)).toBeInTheDocument()
+    expect(screen.getByText(/color/i)).toBeInTheDocument()
+    expect(screen.getByText(/icon/i)).toBeInTheDocument()
+    expect(screen.getByText(/delete/i)).toBeInTheDocument()
+  })
+
+  it('calls onRename when clicking rename', () => {
+    const onRename = vi.fn()
+    render(
+      <WorkspaceContextMenu position={{ x: 100, y: 200 }} workspaceName="WS"
+        onRename={onRename} onChangeColor={vi.fn()} onChangeIcon={vi.fn()} onDelete={vi.fn()} onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByText(/rename/i))
+    expect(onRename).toHaveBeenCalled()
+  })
+
+  it('calls onDelete when clicking delete', () => {
+    const onDelete = vi.fn()
+    render(
+      <WorkspaceContextMenu position={{ x: 100, y: 200 }} workspaceName="WS"
+        onRename={vi.fn()} onChangeColor={vi.fn()} onChangeIcon={vi.fn()} onDelete={onDelete} onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByText(/delete/i))
+    expect(onDelete).toHaveBeenCalled()
+  })
+
+  it('calls onClose on backdrop click', () => {
+    const onClose = vi.fn()
+    render(
+      <WorkspaceContextMenu position={{ x: 100, y: 200 }} workspaceName="WS"
+        onRename={vi.fn()} onChangeColor={vi.fn()} onChangeIcon={vi.fn()} onDelete={vi.fn()} onClose={onClose} />,
+    )
+    fireEvent.mouseDown(screen.getByTestId('context-menu-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
+++ b/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react'
+import { PencilSimple, Palette, Smiley, Trash } from '@phosphor-icons/react'
+import { useI18nStore } from '../../../stores/useI18nStore'
+
+interface Props {
+  position: { x: number; y: number }
+  workspaceName: string
+  onRename: () => void
+  onChangeColor: () => void
+  onChangeIcon: () => void
+  onDelete: () => void
+  onClose: () => void
+}
+
+export function WorkspaceContextMenu({ position, onRename, onChangeColor, onChangeIcon, onDelete, onClose }: Props) {
+  const t = useI18nStore((s) => s.t)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  const menuItems = [
+    { label: t('workspace.rename'), icon: PencilSimple, onClick: onRename },
+    { label: t('workspace.change_color'), icon: Palette, onClick: onChangeColor },
+    { label: t('workspace.change_icon'), icon: Smiley, onClick: onChangeIcon },
+    { type: 'separator' as const },
+    { label: t('workspace.delete'), icon: Trash, onClick: onDelete, danger: true },
+  ]
+
+  return (
+    <>
+      <div data-testid="context-menu-backdrop" className="fixed inset-0 z-40" onMouseDown={onClose} />
+      <div ref={menuRef} className="fixed z-50 min-w-44 bg-surface-secondary border border-border-default rounded-lg shadow-xl py-1"
+        style={{ left: position.x, top: position.y }}>
+        {menuItems.map((item, i) => {
+          if ('type' in item && item.type === 'separator') {
+            return <div key={i} className="h-px bg-border-subtle my-1 mx-2" />
+          }
+          const Icon = item.icon!
+          return (
+            <button key={i} onClick={() => { item.onClick!(); onClose() }}
+              className={`w-full flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer transition-colors ${
+                item.danger ? 'text-red-400 hover:bg-red-500/10' : 'text-text-secondary hover:text-text-primary hover:bg-surface-hover'
+              }`}>
+              <Icon size={14} />
+              {item.label}
+            </button>
+          )
+        })}
+      </div>
+    </>
+  )
+}

--- a/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
+++ b/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { PencilSimple, Palette, Smiley, Trash } from '@phosphor-icons/react'
 import { useI18nStore } from '../../../stores/useI18nStore'
 
 interface Props {
   position: { x: number; y: number }
-  workspaceName: string
   onRename: () => void
   onChangeColor: () => void
   onChangeIcon: () => void
@@ -14,8 +13,6 @@ interface Props {
 
 export function WorkspaceContextMenu({ position, onRename, onChangeColor, onChangeIcon, onDelete, onClose }: Props) {
   const t = useI18nStore((s) => s.t)
-  const menuRef = useRef<HTMLDivElement>(null)
-
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -35,7 +32,7 @@ export function WorkspaceContextMenu({ position, onRename, onChangeColor, onChan
   return (
     <>
       <div data-testid="context-menu-backdrop" className="fixed inset-0 z-40" onMouseDown={onClose} />
-      <div ref={menuRef} className="fixed z-50 min-w-44 bg-surface-secondary border border-border-default rounded-lg shadow-xl py-1"
+      <div className="fixed z-50 min-w-44 bg-surface-secondary border border-border-default rounded-lg shadow-xl py-1"
         style={{ left: position.x, top: position.y }}>
         {menuItems.map((item, i) => {
           if ('type' in item && item.type === 'separator') {

--- a/spa/src/features/workspace/components/WorkspaceIconPicker.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceIconPicker.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { WorkspaceIconPicker } from './WorkspaceIconPicker'
+import { WORKSPACE_ICONS } from '../constants'
+
+describe('WorkspaceIconPicker', () => {
+  beforeEach(() => { cleanup() })
+
+  it('renders all icon options', () => {
+    render(<WorkspaceIconPicker currentIcon={undefined} onSelect={vi.fn()} onCancel={vi.fn()} />)
+    const buttons = screen.getAllByRole('button').filter((b) => b.getAttribute('data-icon'))
+    expect(buttons.length).toBe(WORKSPACE_ICONS.length)
+  })
+
+  it('calls onSelect with chosen icon', () => {
+    const onSelect = vi.fn()
+    render(<WorkspaceIconPicker currentIcon={undefined} onSelect={onSelect} onCancel={vi.fn()} />)
+    const buttons = screen.getAllByRole('button').filter((b) => b.getAttribute('data-icon'))
+    fireEvent.click(buttons[0])
+    expect(onSelect).toHaveBeenCalledWith(buttons[0].getAttribute('data-icon'))
+  })
+
+  it('highlights current icon', () => {
+    render(<WorkspaceIconPicker currentIcon={WORKSPACE_ICONS[2]} onSelect={vi.fn()} onCancel={vi.fn()} />)
+    const activeBtn = screen.getByRole('button', { pressed: true })
+    expect(activeBtn.getAttribute('data-icon')).toBe(WORKSPACE_ICONS[2])
+  })
+})

--- a/spa/src/features/workspace/components/WorkspaceIconPicker.tsx
+++ b/spa/src/features/workspace/components/WorkspaceIconPicker.tsx
@@ -1,0 +1,34 @@
+import { useI18nStore } from '../../../stores/useI18nStore'
+import { WORKSPACE_ICONS } from '../constants'
+
+interface Props {
+  currentIcon: string | undefined
+  onSelect: (icon: string) => void
+  onCancel: () => void
+}
+
+export function WorkspaceIconPicker({ currentIcon, onSelect, onCancel }: Props) {
+  const t = useI18nStore((s) => s.t)
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-surface-secondary border border-border-default rounded-lg shadow-xl w-full max-w-xs mx-4 p-5">
+        <h3 className="text-sm font-semibold text-text-primary mb-3">{t('workspace.change_icon')}</h3>
+        <div className="grid grid-cols-7 gap-2">
+          {WORKSPACE_ICONS.map((icon) => (
+            <button key={icon} data-icon={icon} aria-pressed={icon === currentIcon} onClick={() => onSelect(icon)}
+              className={`w-8 h-8 rounded-md flex items-center justify-center text-sm cursor-pointer transition-colors ${
+                icon === currentIcon ? 'bg-accent/20 ring-2 ring-accent text-text-primary' : 'bg-surface-tertiary text-text-secondary hover:text-text-primary hover:bg-surface-hover'
+              }`}>
+              {icon}
+            </button>
+          ))}
+        </div>
+        <div className="flex justify-end mt-4">
+          <button onClick={onCancel} className="px-3 py-1.5 rounded text-xs bg-surface-tertiary text-text-secondary hover:text-text-primary cursor-pointer">
+            {t('common.cancel')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/spa/src/features/workspace/components/WorkspaceRenameDialog.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRenameDialog.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { WorkspaceRenameDialog } from './WorkspaceRenameDialog'
+
+describe('WorkspaceRenameDialog', () => {
+  beforeEach(() => { cleanup() })
+
+  it('renders with current name pre-filled', () => {
+    render(<WorkspaceRenameDialog currentName="Old Name" onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.value).toBe('Old Name')
+  })
+
+  it('calls onConfirm with new name', () => {
+    const onConfirm = vi.fn()
+    render(<WorkspaceRenameDialog currentName="Old" onConfirm={onConfirm} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'New Name' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onConfirm).toHaveBeenCalledWith('New Name')
+  })
+
+  it('calls onConfirm on Enter key', () => {
+    const onConfirm = vi.fn()
+    render(<WorkspaceRenameDialog currentName="Old" onConfirm={onConfirm} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Via Enter' } })
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' })
+    expect(onConfirm).toHaveBeenCalledWith('Via Enter')
+  })
+
+  it('calls onCancel on Escape key', () => {
+    const onCancel = vi.fn()
+    render(<WorkspaceRenameDialog currentName="Old" onConfirm={vi.fn()} onCancel={onCancel} />)
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('does not confirm with empty name', () => {
+    const onConfirm = vi.fn()
+    render(<WorkspaceRenameDialog currentName="Old" onConfirm={onConfirm} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '  ' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+})

--- a/spa/src/features/workspace/components/WorkspaceRenameDialog.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRenameDialog.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { useI18nStore } from '../../../stores/useI18nStore'
+
+interface Props {
+  currentName: string
+  onConfirm: (newName: string) => void
+  onCancel: () => void
+}
+
+export function WorkspaceRenameDialog({ currentName, onConfirm, onCancel }: Props) {
+  const t = useI18nStore((s) => s.t)
+  const [name, setName] = useState(currentName)
+
+  const handleConfirm = () => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    onConfirm(trimmed)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-surface-secondary border border-border-default rounded-lg shadow-xl w-full max-w-sm mx-4 p-5">
+        <h3 className="text-sm font-semibold text-text-primary mb-3">{t('workspace.rename')}</h3>
+        <input type="text" value={name} onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') handleConfirm(); if (e.key === 'Escape') onCancel() }}
+          className="w-full bg-surface-primary border border-border-default rounded px-3 py-2 text-sm text-text-primary" autoFocus />
+        <div className="flex justify-end gap-2 mt-4">
+          <button onClick={onCancel} className="px-3 py-1.5 rounded text-xs bg-surface-tertiary text-text-secondary hover:text-text-primary cursor-pointer">
+            {t('common.cancel')}
+          </button>
+          <button onClick={handleConfirm} className="px-3 py-1.5 rounded text-xs bg-accent text-white hover:bg-accent/80 cursor-pointer">
+            {t('common.save')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/spa/src/features/workspace/constants.ts
+++ b/spa/src/features/workspace/constants.ts
@@ -1,0 +1,11 @@
+export const WORKSPACE_COLORS = [
+  '#7a6aaa', '#6aaa7a', '#aa6a7a', '#6a8aaa', '#aa8a6a', '#8a6aaa',
+  '#5b8c5a', '#c75050', '#d4a843', '#5a7fbf', '#bf5a9d', '#4abfbf',
+]
+
+export const WORKSPACE_ICONS = [
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+  'P', 'R', 'S', 'T', 'W', 'X',
+  '🔧', '🖥', '📦', '🚀', '📝', '🎯',
+  '💡', '🔬', '🎨', '⚡', '🌐', '📊',
+]

--- a/spa/src/features/workspace/index.ts
+++ b/spa/src/features/workspace/index.ts
@@ -7,6 +7,11 @@ export { useTabWorkspaceActions } from './hooks'
 // Components
 export { ActivityBar } from './components/ActivityBar'
 export { WorkspaceDeleteDialog } from './components/WorkspaceDeleteDialog'
+export { WorkspaceContextMenu } from './components/WorkspaceContextMenu'
+export { WorkspaceChip } from './components/WorkspaceChip'
+export { WorkspaceRenameDialog } from './components/WorkspaceRenameDialog'
+export { WorkspaceColorPicker } from './components/WorkspaceColorPicker'
+export { WorkspaceIconPicker } from './components/WorkspaceIconPicker'
 
 // Lib
 export { getVisibleTabIds } from './lib/getVisibleTabIds'

--- a/spa/src/features/workspace/index.ts
+++ b/spa/src/features/workspace/index.ts
@@ -12,6 +12,7 @@ export { WorkspaceChip } from './components/WorkspaceChip'
 export { WorkspaceRenameDialog } from './components/WorkspaceRenameDialog'
 export { WorkspaceColorPicker } from './components/WorkspaceColorPicker'
 export { WorkspaceIconPicker } from './components/WorkspaceIconPicker'
+export { MigrateTabsDialog } from './components/MigrateTabsDialog'
 
 // Lib
 export { getVisibleTabIds } from './lib/getVisibleTabIds'

--- a/spa/src/features/workspace/lib/getVisibleTabIds.test.ts
+++ b/spa/src/features/workspace/lib/getVisibleTabIds.test.ts
@@ -59,7 +59,7 @@ describe('getVisibleTabIds', () => {
     expect(result).toEqual(['t1', 't2', 't3'])
   })
 
-  it('returns all tabs from tabOrder when activeWorkspaceId is null', () => {
+  it('returns only standalone tabs when activeWorkspaceId is null (Home mode)', () => {
     const workspaces: Workspace[] = [
       { id: 'ws-1', name: 'WS1', color: '#aaa', tabs: ['t1'], activeTabId: 't1' },
     ]
@@ -70,7 +70,24 @@ describe('getVisibleTabIds', () => {
       workspaces,
       activeWorkspaceId: null,
     })
-    expect(result).toEqual(['t1', 't2'])
+    // t1 belongs to ws-1, only t2 is standalone
+    expect(result).toEqual(['t2'])
+  })
+
+  it('returns all standalone tabs in Home mode with multiple workspaces', () => {
+    const workspaces: Workspace[] = [
+      { id: 'ws-1', name: 'WS1', color: '#aaa', tabs: ['t1', 't2'], activeTabId: 't1' },
+      { id: 'ws-2', name: 'WS2', color: '#bbb', tabs: ['t3'], activeTabId: 't3' },
+    ]
+    const result = getVisibleTabIds({
+      tabs: { t1: {}, t2: {}, t3: {}, t4: {}, t5: {} },
+      tabOrder: ['t1', 't2', 't3', 't4', 't5'],
+      activeTabId: 't4',
+      workspaces,
+      activeWorkspaceId: null,
+    })
+    // t1,t2 in ws-1; t3 in ws-2; t4,t5 are standalone
+    expect(result).toEqual(['t4', 't5'])
   })
 
   it('returns empty array when no tabs exist', () => {

--- a/spa/src/features/workspace/lib/getVisibleTabIds.ts
+++ b/spa/src/features/workspace/lib/getVisibleTabIds.ts
@@ -14,14 +14,20 @@ interface GetVisibleTabIdsParams {
  * Rules:
  * 1. Active standalone tab selected → only that tab
  * 2. Active workspace → that workspace's tabs (filtered by existence in tab store)
- * 3. No workspace (0 workspaces or null activeWorkspaceId) → fallback to tabOrder
+ * 3. Home mode (workspaces exist but activeWorkspaceId is null) → standalone tabs only
+ * 4. No workspace system (0 workspaces) → fallback to tabOrder
  */
 export function getVisibleTabIds(params: GetVisibleTabIdsParams): string[] {
   const { tabs, tabOrder, activeTabId, workspaces, activeWorkspaceId } = params
 
   // Only apply workspace/standalone logic when the workspace system is active
   if (workspaces.length > 0) {
-    // Standalone tab selected — only that tab is visible
+    // Home mode (no active workspace) — show all standalone tabs
+    if (!activeWorkspaceId) {
+      return tabOrder.filter((id) => isStandaloneTab(id, workspaces))
+    }
+
+    // Standalone tab selected while viewing a workspace — only that tab
     if (activeTabId && isStandaloneTab(activeTabId, workspaces)) {
       return [activeTabId]
     }
@@ -33,6 +39,6 @@ export function getVisibleTabIds(params: GetVisibleTabIdsParams): string[] {
     }
   }
 
-  // Fallback to global tabOrder (no workspaces, or no activeWorkspaceId)
+  // No workspace system — show all tabs
   return tabOrder
 }

--- a/spa/src/features/workspace/lib/workspace-shortcuts.test.ts
+++ b/spa/src/features/workspace/lib/workspace-shortcuts.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from '../store'
+
+describe('workspace shortcut handlers', () => {
+  beforeEach(() => {
+    useWorkspaceStore.getState().reset()
+  })
+
+  it('switch-workspace-N jumps to Nth workspace by position', () => {
+    const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
+    const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+    const ws3 = useWorkspaceStore.getState().addWorkspace('WS3')
+    const workspaces = useWorkspaceStore.getState().workspaces
+    const target = workspaces[1]
+    expect(target.id).toBe(ws2.id)
+    useWorkspaceStore.getState().setActiveWorkspace(target.id)
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ws2.id)
+  })
+
+  it('switch-workspace out of range is ignored', () => {
+    const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
+    const workspaces = useWorkspaceStore.getState().workspaces
+    const target = workspaces[5]
+    expect(target).toBeUndefined()
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ws1.id)
+  })
+
+  it('prev-workspace wraps from first to last', () => {
+    const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
+    const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+    const ws3 = useWorkspaceStore.getState().addWorkspace('WS3')
+    useWorkspaceStore.getState().setActiveWorkspace(ws1.id)
+    const workspaces = useWorkspaceStore.getState().workspaces
+    const currentIdx = workspaces.findIndex((w) => w.id === ws1.id)
+    const prevIdx = (currentIdx - 1 + workspaces.length) % workspaces.length
+    useWorkspaceStore.getState().setActiveWorkspace(workspaces[prevIdx].id)
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ws3.id)
+  })
+
+  it('next-workspace wraps from last to first', () => {
+    const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
+    const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+    const ws3 = useWorkspaceStore.getState().addWorkspace('WS3')
+    useWorkspaceStore.getState().setActiveWorkspace(ws3.id)
+    const workspaces = useWorkspaceStore.getState().workspaces
+    const currentIdx = workspaces.findIndex((w) => w.id === ws3.id)
+    const nextIdx = (currentIdx + 1) % workspaces.length
+    useWorkspaceStore.getState().setActiveWorkspace(workspaces[nextIdx].id)
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ws1.id)
+  })
+
+  it('workspace shortcuts with 0 workspaces do nothing', () => {
+    const workspaces = useWorkspaceStore.getState().workspaces
+    expect(workspaces).toHaveLength(0)
+    const target = workspaces[0]
+    expect(target).toBeUndefined()
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
+  })
+})

--- a/spa/src/features/workspace/lib/workspace-shortcuts.test.ts
+++ b/spa/src/features/workspace/lib/workspace-shortcuts.test.ts
@@ -7,9 +7,9 @@ describe('workspace shortcut handlers', () => {
   })
 
   it('switch-workspace-N jumps to Nth workspace by position', () => {
-    const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
+    useWorkspaceStore.getState().addWorkspace('WS1')
     const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
-    const ws3 = useWorkspaceStore.getState().addWorkspace('WS3')
+    useWorkspaceStore.getState().addWorkspace('WS3')
     const workspaces = useWorkspaceStore.getState().workspaces
     const target = workspaces[1]
     expect(target.id).toBe(ws2.id)
@@ -27,7 +27,7 @@ describe('workspace shortcut handlers', () => {
 
   it('prev-workspace wraps from first to last', () => {
     const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
-    const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+    useWorkspaceStore.getState().addWorkspace('WS2')
     const ws3 = useWorkspaceStore.getState().addWorkspace('WS3')
     useWorkspaceStore.getState().setActiveWorkspace(ws1.id)
     const workspaces = useWorkspaceStore.getState().workspaces
@@ -39,7 +39,7 @@ describe('workspace shortcut handlers', () => {
 
   it('next-workspace wraps from last to first', () => {
     const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
-    const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+    useWorkspaceStore.getState().addWorkspace('WS2')
     const ws3 = useWorkspaceStore.getState().addWorkspace('WS3')
     useWorkspaceStore.getState().setActiveWorkspace(ws3.id)
     const workspaces = useWorkspaceStore.getState().workspaces

--- a/spa/src/features/workspace/store.test.ts
+++ b/spa/src/features/workspace/store.test.ts
@@ -171,6 +171,26 @@ describe('useWorkspaceStore', () => {
     expect(ws.color).toBe('#ff0000')
   })
 
+  // === Workspace settings ===
+
+  it('renameWorkspace updates workspace name', () => {
+    const ws = useWorkspaceStore.getState().addWorkspace('Old Name')
+    useWorkspaceStore.getState().renameWorkspace(ws.id, 'New Name')
+    expect(useWorkspaceStore.getState().workspaces[0].name).toBe('New Name')
+  })
+
+  it('setWorkspaceColor updates workspace color', () => {
+    const ws = useWorkspaceStore.getState().addWorkspace('Test')
+    useWorkspaceStore.getState().setWorkspaceColor(ws.id, '#ff0000')
+    expect(useWorkspaceStore.getState().workspaces[0].color).toBe('#ff0000')
+  })
+
+  it('setWorkspaceIcon updates workspace icon', () => {
+    const ws = useWorkspaceStore.getState().addWorkspace('Test')
+    useWorkspaceStore.getState().setWorkspaceIcon(ws.id, 'R')
+    expect(useWorkspaceStore.getState().workspaces[0].icon).toBe('R')
+  })
+
   // === insertTab edge cases ===
 
   it('insertTab with nonexistent wsId is a no-op', () => {

--- a/spa/src/features/workspace/store.ts
+++ b/spa/src/features/workspace/store.ts
@@ -16,6 +16,9 @@ interface WorkspaceState {
   reorderWorkspaceTabs: (wsId: string, tabIds: string[]) => void
   findWorkspaceByTab: (tabId: string) => Workspace | null
   insertTab: (tabId: string, workspaceId?: string | null) => void
+  renameWorkspace: (wsId: string, name: string) => void
+  setWorkspaceColor: (wsId: string, color: string) => void
+  setWorkspaceIcon: (wsId: string, icon: string) => void
   reset: () => void
 }
 
@@ -116,6 +119,27 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           }),
         }))
       },
+
+      renameWorkspace: (wsId, name) =>
+        set((state) => ({
+          workspaces: state.workspaces.map((ws) =>
+            ws.id === wsId ? { ...ws, name } : ws,
+          ),
+        })),
+
+      setWorkspaceColor: (wsId, color) =>
+        set((state) => ({
+          workspaces: state.workspaces.map((ws) =>
+            ws.id === wsId ? { ...ws, color } : ws,
+          ),
+        })),
+
+      setWorkspaceIcon: (wsId, icon) =>
+        set((state) => ({
+          workspaces: state.workspaces.map((ws) =>
+            ws.id === wsId ? { ...ws, icon } : ws,
+          ),
+        })),
 
       reset: () => set(createDefaultState()),
     }),

--- a/spa/src/hooks/useShortcuts.test.ts
+++ b/spa/src/hooks/useShortcuts.test.ts
@@ -87,7 +87,7 @@ describe('useShortcuts', () => {
       const { fire } = mockElectronAPI()
       const tabs = seedTabs(4, { addToWorkspace: false })
       // Add only tabs[2] and tabs[0] to workspace (reversed vs global order)
-      const wsId = useWorkspaceStore.getState().activeWorkspaceId
+      const wsId = useWorkspaceStore.getState().activeWorkspaceId!
       useWorkspaceStore.getState().addTabToWorkspace(wsId, tabs[2].id)
       useWorkspaceStore.getState().addTabToWorkspace(wsId, tabs[0].id)
       useTabStore.getState().setActiveTab(tabs[2].id)
@@ -270,7 +270,7 @@ describe('useShortcuts', () => {
     it('adds reopened tab to active workspace', () => {
       const { fire } = mockElectronAPI()
       const tabs = seedTabs(2)
-      const wsId = useWorkspaceStore.getState().activeWorkspaceId
+      const wsId = useWorkspaceStore.getState().activeWorkspaceId!
       useWorkspaceStore.getState().addTabToWorkspace(wsId, tabs[0].id)
       useWorkspaceStore.getState().addTabToWorkspace(wsId, tabs[1].id)
 
@@ -321,7 +321,6 @@ describe('useShortcuts', () => {
     it('cycles to next workspace', () => {
       const { fire } = mockElectronAPI()
       seedTabs(1)
-      const ws1Id = useWorkspaceStore.getState().activeWorkspaceId
       const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
       renderHook(() => useShortcuts())
 

--- a/spa/src/hooks/useShortcuts.test.ts
+++ b/spa/src/hooks/useShortcuts.test.ts
@@ -284,4 +284,82 @@ describe('useShortcuts', () => {
       expect(ws?.tabs).toContain(closedTab.id)
     })
   })
+
+  describe('switch-workspace-{n}', () => {
+    it('switches to workspace by index', () => {
+      const { fire } = mockElectronAPI()
+      seedTabs(1)
+      const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+      useWorkspaceStore.getState().addTabToWorkspace(ws2.id, seedTabs(1, { addToWorkspace: false })[0].id)
+      renderHook(() => useShortcuts())
+
+      fire('switch-workspace-2')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ws2.id)
+    })
+
+    it('ignores out-of-range workspace index', () => {
+      const { fire } = mockElectronAPI()
+      seedTabs(1)
+      const currentWsId = useWorkspaceStore.getState().activeWorkspaceId
+      renderHook(() => useShortcuts())
+
+      fire('switch-workspace-5')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(currentWsId)
+    })
+
+    it('does nothing with 0 workspaces', () => {
+      const { fire } = mockElectronAPI()
+      useWorkspaceStore.getState().reset()
+      renderHook(() => useShortcuts())
+
+      fire('switch-workspace-1')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
+    })
+  })
+
+  describe('prev-workspace / next-workspace', () => {
+    it('cycles to next workspace', () => {
+      const { fire } = mockElectronAPI()
+      seedTabs(1)
+      const ws1Id = useWorkspaceStore.getState().activeWorkspaceId
+      const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+      renderHook(() => useShortcuts())
+
+      fire('next-workspace')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ws2.id)
+    })
+
+    it('wraps from last to first workspace', () => {
+      const { fire } = mockElectronAPI()
+      seedTabs(1)
+      const ws1Id = useWorkspaceStore.getState().activeWorkspaceId!
+      const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+      useWorkspaceStore.getState().setActiveWorkspace(ws2.id)
+      renderHook(() => useShortcuts())
+
+      fire('next-workspace')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ws1Id)
+    })
+
+    it('cycles to prev workspace', () => {
+      const { fire } = mockElectronAPI()
+      seedTabs(1)
+      const ws1Id = useWorkspaceStore.getState().activeWorkspaceId!
+      const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+      useWorkspaceStore.getState().setActiveWorkspace(ws2.id)
+      renderHook(() => useShortcuts())
+
+      fire('prev-workspace')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ws1Id)
+    })
+
+    it('does nothing with 0 workspaces', () => {
+      const { fire } = mockElectronAPI()
+      useWorkspaceStore.getState().reset()
+      renderHook(() => useShortcuts())
+
+      fire('next-workspace')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
+    })
+  })
 })

--- a/spa/src/hooks/useShortcuts.ts
+++ b/spa/src/hooks/useShortcuts.ts
@@ -109,7 +109,7 @@ export function useShortcuts(): void {
         const currentIdx = workspaces.findIndex((w) => w.id === currentWsId)
         const delta = action === 'next-workspace' ? 1 : -1
         const nextIdx = currentIdx === -1
-          ? 0
+          ? (delta > 0 ? 0 : workspaces.length - 1)
           : (currentIdx + delta + workspaces.length) % workspaces.length
         const targetWs = workspaces[nextIdx]
         useWorkspaceStore.getState().setActiveWorkspace(targetWs.id)

--- a/spa/src/hooks/useShortcuts.ts
+++ b/spa/src/hooks/useShortcuts.ts
@@ -90,6 +90,34 @@ export function useShortcuts(): void {
         return
       }
 
+      if (action.startsWith('switch-workspace-')) {
+        const workspaces = useWorkspaceStore.getState().workspaces
+        if (workspaces.length === 0) return
+        const index = parseInt(action.replace('switch-workspace-', ''), 10) - 1
+        const targetWs = workspaces[index]
+        if (!targetWs) return
+        useWorkspaceStore.getState().setActiveWorkspace(targetWs.id)
+        const activeTab = targetWs.activeTabId ?? targetWs.tabs[0]
+        if (activeTab) tabState.setActiveTab(activeTab)
+        return
+      }
+
+      if (action === 'prev-workspace' || action === 'next-workspace') {
+        const workspaces = useWorkspaceStore.getState().workspaces
+        if (workspaces.length === 0) return
+        const currentWsId = useWorkspaceStore.getState().activeWorkspaceId
+        const currentIdx = workspaces.findIndex((w) => w.id === currentWsId)
+        const delta = action === 'next-workspace' ? 1 : -1
+        const nextIdx = currentIdx === -1
+          ? 0
+          : (currentIdx + delta + workspaces.length) % workspaces.length
+        const targetWs = workspaces[nextIdx]
+        useWorkspaceStore.getState().setActiveWorkspace(targetWs.id)
+        const activeTab = targetWs.activeTabId ?? targetWs.tabs[0]
+        if (activeTab) tabState.setActiveTab(activeTab)
+        return
+      }
+
       if (import.meta.env.DEV) {
         console.warn(`[useShortcuts] unknown action: ${action}`)
       }

--- a/spa/src/lib/host-api.ts
+++ b/spa/src/lib/host-api.ts
@@ -248,10 +248,11 @@ export async function fetchTokenAuth(
 }
 
 export class PairingError extends Error {
-  constructor(
-    public status: number,
-    public body: string,
-  ) {
+  status: number
+  body: string
+  constructor(status: number, body: string) {
     super(`Pairing failed: HTTP ${status}`)
+    this.status = status
+    this.body = body
   }
 }

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -149,6 +149,7 @@
   "nav.scroll_left": "Scroll left",
   "nav.scroll_right": "Scroll right",
   "nav.new_tab": "New tab",
+  "nav.home": "Home",
   "nav.new_workspace": "New workspace",
   "nav.settings": "Settings",
   "nav.hosts": "Hosts",

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -415,5 +415,10 @@
   "workspace.rename": "Rename",
   "workspace.change_color": "Change Color",
   "workspace.change_icon": "Change Icon",
-  "workspace.delete": "Delete Workspace"
+  "workspace.delete": "Delete Workspace",
+
+  "workspace.migrate_title": "Move Existing Tabs?",
+  "workspace.migrate_description": "You have {{count}} open tab(s). Move them into \"{{name}}\"?",
+  "workspace.migrate_move": "Move",
+  "workspace.migrate_skip": "Skip"
 }

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -411,5 +411,9 @@
 
   "workspace.delete_title": "Delete {{name}}",
   "workspace.delete_description": "Select tabs to close with the workspace:",
-  "workspace.delete_confirm": "Delete"
+  "workspace.delete_confirm": "Delete",
+  "workspace.rename": "Rename",
+  "workspace.change_color": "Change Color",
+  "workspace.change_icon": "Change Icon",
+  "workspace.delete": "Delete Workspace"
 }

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -411,5 +411,9 @@
 
   "workspace.delete_title": "刪除 {{name}}",
   "workspace.delete_description": "選擇要一併關閉的分頁：",
-  "workspace.delete_confirm": "刪除"
+  "workspace.delete_confirm": "刪除",
+  "workspace.rename": "重新命名",
+  "workspace.change_color": "變更顏色",
+  "workspace.change_icon": "變更圖示",
+  "workspace.delete": "刪除工作區"
 }

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -415,5 +415,10 @@
   "workspace.rename": "重新命名",
   "workspace.change_color": "變更顏色",
   "workspace.change_icon": "變更圖示",
-  "workspace.delete": "刪除工作區"
+  "workspace.delete": "刪除工作區",
+
+  "workspace.migrate_title": "移動現有分頁？",
+  "workspace.migrate_description": "您有 {{count}} 個開啟的分頁。要移入「{{name}}」嗎？",
+  "workspace.migrate_move": "移入",
+  "workspace.migrate_skip": "跳過"
 }

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -149,6 +149,7 @@
   "nav.scroll_left": "向左捲動",
   "nav.scroll_right": "向右捲動",
   "nav.new_tab": "新增分頁",
+  "nav.home": "首頁",
   "nav.new_workspace": "新增工作區",
   "nav.settings": "設定",
   "nav.hosts": "主機管理",


### PR DESCRIPTION
## Summary

Phase 10 Workspace 強化的第三部分（共三個 PR）。依賴 PR #190。

- **Task 7 (10d)**：WorkspaceContextMenu + WorkspaceChip + RenameDialog + ColorPicker + IconPicker + store actions (rename/color/icon) + App.tsx 完整整合
- **Task 8 (10e)**：Electron keybindings ⌘⌥1-9 位置切換 + ⌘⌥↑/↓ 循環切換 + useShortcuts handler
- **Task 9 (10c)**：MigrateTabsDialog — 首個 workspace 建立時詢問遷移既有 tab

### 新增元件

| 元件 | 說明 |
|------|------|
| `WorkspaceContextMenu` | 右鍵選單（Rename/Color/Icon/Delete） |
| `WorkspaceChip` | Titlebar 色點 + 名稱 + 下拉箭頭 |
| `WorkspaceRenameDialog` | 重新命名對話框 |
| `WorkspaceColorPicker` | 12 色圓形選擇器 |
| `WorkspaceIconPicker` | 字母 + emoji 圖示選擇器 |
| `MigrateTabsDialog` | 首次 workspace 遷移詢問 |

### 其他變更

- `electron/keybindings.ts`：新增 `workspace-nav` menu group（11 個快捷鍵）
- `spa/src/App.tsx`：整合全部 workspace 對話框 + Electron/SPA Titlebar Chip
- `spa/src/locales/en.json` + `zh-TW.json`：新增 11 個 `workspace.*` i18n keys
- `features/workspace/constants.ts`：WORKSPACE_COLORS + WORKSPACE_ICONS

### 測試

- 7 個新元件測試檔案
- workspace-shortcuts 5 test cases
- useShortcuts workspace integration 7 test cases
- 966 tests pass（最終）

## Test plan

- [ ] `cd spa && npx vitest run` — 全部通過
- [ ] `cd spa && pnpm run lint` — 無錯誤
- [ ] `cd spa && pnpm run build` — 無錯誤
- [ ] locale-completeness 測試通過（en/zh-TW 鍵值一致）
- [ ] 驗證右鍵選單 rename/color/icon/delete 功能
- [ ] 驗證 ⌘⌥1-9 + ⌘⌥↑/↓ 快捷鍵