### PR TITLE
fix: Phase 7.4 — Daemon 品質改善 (#133, #130, #131, #121, #134)

### DIFF
--- a/cmd/tbox/setup.go
+++ b/cmd/tbox/setup.go
@@ -114,7 +114,16 @@ func mergeHooks(path, tboxPath string, remove bool) error {
 		return fmt.Errorf("marshal settings: %w", err)
 	}
 
-	return os.WriteFile(path, out, 0644)
+	// Write to a temp file in the same directory, then atomically rename.
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, out, 0644); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath) // Best-effort cleanup
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
 }
 
 // makeTboxEntry creates a hook entry for the given event.

--- a/cmd/tbox/setup_test.go
+++ b/cmd/tbox/setup_test.go
@@ -340,6 +340,39 @@ func TestMergeHooks_DifferentPaths(t *testing.T) {
 	}
 }
 
+func TestMergeHooks_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	tboxPath := "/usr/local/bin/tbox"
+
+	if err := mergeHooks(settingsPath, tboxPath, false); err != nil {
+		t.Fatalf("mergeHooks: %v", err)
+	}
+
+	// .tmp file must NOT exist after successful write
+	tmpPath := settingsPath + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("temp file %q should not exist after mergeHooks, got stat err: %v", tmpPath, err)
+	}
+
+	// settings.json must exist
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings file missing after mergeHooks: %v", err)
+	}
+
+	// Content must be valid JSON
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("settings.json is not valid JSON: %v", err)
+	}
+
+	// Sanity-check that hooks were written
+	if _, ok := settings["hooks"]; !ok {
+		t.Error("hooks key missing in written JSON")
+	}
+}
+
 func TestMergeHooks_SpacePath(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.json")

--- a/internal/module/agent/upload.go
+++ b/internal/module/agent/upload.go
@@ -11,19 +11,29 @@ import (
 	"strings"
 )
 
-// deduplicateFilename returns a filename that does not conflict with
-// existing files in dir. If "photo.png" exists it tries "photo-1.png",
-// "photo-2.png", etc.
-func deduplicateFilename(dir, name string) string {
-	if _, err := os.Stat(filepath.Join(dir, name)); os.IsNotExist(err) {
-		return name
+// createDedupFile atomically creates a file in dir using O_CREATE|O_EXCL to
+// avoid TOCTOU races. If "photo.png" already exists it tries "photo-1.png",
+// "photo-2.png", etc. Returns the open file and the chosen filename.
+func createDedupFile(dir, name string) (*os.File, string, error) {
+	path := filepath.Join(dir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err == nil {
+		return f, name, nil
+	}
+	if !os.IsExist(err) {
+		return nil, "", err
 	}
 	ext := filepath.Ext(name)
 	base := strings.TrimSuffix(name, ext)
 	for i := 1; ; i++ {
 		candidate := fmt.Sprintf("%s-%d%s", base, i, ext)
-		if _, err := os.Stat(filepath.Join(dir, candidate)); os.IsNotExist(err) {
-			return candidate
+		path = filepath.Join(dir, candidate)
+		f, err = os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err == nil {
+			return f, candidate, nil
+		}
+		if !os.IsExist(err) {
+			return nil, "", err
 		}
 	}
 }
@@ -64,18 +74,18 @@ func (m *Module) handleUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Save file with dedup. Strip directory components to prevent path traversal.
-	filename := deduplicateFilename(dir, filepath.Base(header.Filename))
-	destPath := filepath.Join(dir, filename)
-	dst, err := os.Create(destPath)
+	// Save file with atomic dedup. Strip directory components to prevent path traversal.
+	dst, filename, err := createDedupFile(dir, filepath.Base(header.Filename))
 	if err != nil {
 		log.Printf("[agent] create file: %v", err)
 		http.Error(w, `{"error":"cannot save file"}`, http.StatusInternalServerError)
 		return
 	}
 	defer dst.Close()
+	destPath := filepath.Join(dir, filename)
 
 	if _, err := io.Copy(dst, file); err != nil {
+		os.Remove(destPath) // Clean up atomically-created but partially-written file
 		log.Printf("[agent] write file: %v", err)
 		http.Error(w, `{"error":"write failed"}`, http.StatusInternalServerError)
 		return

--- a/internal/module/agent/upload.go
+++ b/internal/module/agent/upload.go
@@ -84,6 +84,7 @@ func (m *Module) handleUpload(w http.ResponseWriter, r *http.Request) {
 	// Inject path into tmux pane via send-keys (space prefix, quoted, literal mode).
 	// Quoting handles filenames with spaces so CC receives the full path as one token.
 	if err := m.core.Tmux.SendKeysRaw(tmuxName, "-l", ` "`+destPath+`"`); err != nil {
+		os.Remove(destPath) // Clean up orphaned file
 		log.Printf("[agent] send-keys: %v", err)
 		http.Error(w, `{"error":"inject failed"}`, http.StatusInternalServerError)
 		return

--- a/internal/module/agent/upload_mgmt.go
+++ b/internal/module/agent/upload_mgmt.go
@@ -115,13 +115,12 @@ func (m *Module) handleDeleteUploadFile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if _, err := os.Stat(target); os.IsNotExist(err) {
-		http.Error(w, "file not found", http.StatusNotFound)
-		return
-	}
-
 	if err := os.Remove(target); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		if os.IsNotExist(err) {
+			http.Error(w, "file not found", http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/module/agent/upload_mgmt_test.go
+++ b/internal/module/agent/upload_mgmt_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMgmtTestModule creates a Module with a temp uploadDir for management tests.
+func newMgmtTestModule(t *testing.T) *Module {
+	t.Helper()
+	m := &Module{}
+	m.uploadDir = t.TempDir()
+	return m
+}
+
+// TestHandleDeleteUploadFile_NotFound verifies that deleting a non-existent file
+// returns 404 without a TOCTOU race (os.Remove is called directly).
+func TestHandleDeleteUploadFile_NotFound(t *testing.T) {
+	m := newMgmtTestModule(t)
+
+	// Create the session subdirectory so path traversal check passes,
+	// but do NOT create the target file.
+	require.NoError(t, os.MkdirAll(filepath.Join(m.uploadDir, "sess1"), 0755))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/upload/files/{session}/{filename}", m.handleDeleteUploadFile)
+
+	req := httptest.NewRequest("DELETE", "/api/upload/files/sess1/ghost.txt", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "file not found")
+}
+
+// TestHandleDeleteUploadFile_Success verifies that deleting an existing file
+// returns 204 and removes the file from disk.
+func TestHandleDeleteUploadFile_Success(t *testing.T) {
+	m := newMgmtTestModule(t)
+
+	dir := filepath.Join(m.uploadDir, "sess1")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	target := filepath.Join(dir, "real.txt")
+	require.NoError(t, os.WriteFile(target, []byte("data"), 0644))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/upload/files/{session}/{filename}", m.handleDeleteUploadFile)
+
+	req := httptest.NewRequest("DELETE", "/api/upload/files/sess1/real.txt", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	_, err := os.Stat(target)
+	assert.True(t, os.IsNotExist(err), "file should have been deleted")
+}

--- a/internal/module/agent/upload_test.go
+++ b/internal/module/agent/upload_test.go
@@ -19,26 +19,32 @@ import (
 	"github.com/wake/tmux-box/internal/tmux"
 )
 
-func TestDeduplicateFilename(t *testing.T) {
+func TestCreateDedupFile(t *testing.T) {
 	dir := t.TempDir()
 
-	// No conflict — returns original name.
-	got := deduplicateFilename(dir, "photo.png")
+	// No conflict — returns original name and creates the file.
+	f, got, err := createDedupFile(dir, "photo.png")
+	require.NoError(t, err)
+	f.Close()
 	assert.Equal(t, "photo.png", got)
 
-	// Create file to trigger conflict.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "photo.png"), []byte("x"), 0644))
-	got = deduplicateFilename(dir, "photo.png")
+	// File already exists (created above) — should return "photo-1.png".
+	f, got, err = createDedupFile(dir, "photo.png")
+	require.NoError(t, err)
+	f.Close()
 	assert.Equal(t, "photo-1.png", got)
 
-	// Second conflict.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "photo-1.png"), []byte("x"), 0644))
-	got = deduplicateFilename(dir, "photo.png")
+	// Second conflict — "photo-1.png" now exists too, expect "photo-2.png".
+	f, got, err = createDedupFile(dir, "photo.png")
+	require.NoError(t, err)
+	f.Close()
 	assert.Equal(t, "photo-2.png", got)
 
 	// No extension.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "README"), []byte("x"), 0644))
-	got = deduplicateFilename(dir, "README")
+	f, got, err = createDedupFile(dir, "README")
+	require.NoError(t, err)
+	f.Close()
 	assert.Equal(t, "README-1", got)
 }
 

--- a/internal/module/agent/upload_test.go
+++ b/internal/module/agent/upload_test.go
@@ -173,3 +173,30 @@ func TestHandleUpload_SessionNotFound(t *testing.T) {
 	m.handleUpload(rec, req)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
+
+// TestHandleUpload_SendKeysFail verifies that when SendKeysRaw fails the
+// uploaded file is removed from disk (no orphaned files).
+func TestHandleUpload_SendKeysFail(t *testing.T) {
+	m, fake := newUploadTestModule(t)
+	fake.FailSendKeys = true
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	mw.WriteField("session", "my-sess")
+	fw, _ := mw.CreateFormFile("file", "inject.txt")
+	fw.Write([]byte("content"))
+	mw.Close()
+
+	req := httptest.NewRequest("POST", "/api/agent/upload", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	m.handleUpload(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "inject failed")
+
+	// The uploaded file must not remain on disk.
+	_, err := os.Stat(filepath.Join(m.uploadDir, "my-sess", "inject.txt"))
+	assert.True(t, os.IsNotExist(err), "orphaned file should have been removed")
+}

--- a/internal/module/session/watcher.go
+++ b/internal/module/session/watcher.go
@@ -13,9 +13,10 @@ import (
 
 // watcherState tracks the NORMAL / TMUX_DOWN state machine.
 type watcherState struct {
-	mu        sync.RWMutex
-	tmuxAlive bool
-	lastHash  string
+	mu            sync.RWMutex
+	tmuxAlive     bool
+	lastHash      string
+	lastBroadcast time.Time // debounce: tracks last broadcastSessions call time
 }
 
 func (ws *watcherState) getTmuxAlive() bool {
@@ -100,6 +101,18 @@ func (m *SessionModule) broadcastSessions() {
 	if !m.core.Events.HasSubscribers() {
 		return
 	}
+
+	// Debounce: skip if last broadcast was within 500ms to prevent duplicate
+	// broadcasts when goroutine A (wait-for) and goroutine B (5s ticker) fire
+	// nearly simultaneously.
+	m.wstate.mu.Lock()
+	if time.Since(m.wstate.lastBroadcast) < 500*time.Millisecond {
+		m.wstate.mu.Unlock()
+		return
+	}
+	m.wstate.lastBroadcast = time.Now()
+	m.wstate.mu.Unlock()
+
 	sessions, err := m.ListSessions()
 	if err != nil {
 		log.Printf("session: broadcast list error: %v", err)

--- a/internal/module/session/watcher_test.go
+++ b/internal/module/session/watcher_test.go
@@ -101,6 +101,79 @@ func TestWatcherNilSessionsWithTmuxAlive(t *testing.T) {
 	assert.True(t, mod.TmuxAlive())
 }
 
+// TestBroadcastSessionsDebounce verifies that rapid concurrent calls to
+// broadcastSessions() within the 500ms window result in only one broadcast.
+func TestBroadcastSessionsDebounce(t *testing.T) {
+	mod, fake, events := newWatcherTestModule(t)
+	sub := events.AddTestSubscriber()
+	defer events.RemoveTestSubscriber(sub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fake.AddSession("s1", "/tmp")
+	require.NoError(t, mod.Start(ctx))
+
+	// Call broadcastSessions twice back-to-back within the debounce window.
+	mod.broadcastSessions()
+	mod.broadcastSessions()
+
+	// Only one broadcast should have been sent.
+	count := 0
+	timeout := time.After(100 * time.Millisecond)
+drain:
+	for {
+		select {
+		case msg := <-sub.SendCh():
+			if len(msg) > 0 {
+				count++
+			}
+		case <-timeout:
+			break drain
+		}
+	}
+	assert.Equal(t, 1, count, "debounce should suppress second broadcast within 500ms window")
+}
+
+// TestBroadcastSessionsDebounceExpiry verifies that a second call after the
+// debounce window has passed DOES produce a broadcast.
+func TestBroadcastSessionsDebounceExpiry(t *testing.T) {
+	mod, fake, events := newWatcherTestModule(t)
+	sub := events.AddTestSubscriber()
+	defer events.RemoveTestSubscriber(sub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fake.AddSession("s1", "/tmp")
+	require.NoError(t, mod.Start(ctx))
+
+	// First call sets the lastBroadcast timestamp.
+	mod.broadcastSessions()
+
+	// Drain first broadcast.
+	select {
+	case <-sub.SendCh():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected first broadcast")
+	}
+
+	// Manually expire the debounce window by backdating lastBroadcast.
+	mod.wstate.mu.Lock()
+	mod.wstate.lastBroadcast = mod.wstate.lastBroadcast.Add(-600 * time.Millisecond)
+	mod.wstate.mu.Unlock()
+
+	// Second call after window expiry should go through.
+	mod.broadcastSessions()
+
+	select {
+	case msg := <-sub.SendCh():
+		assert.Contains(t, string(msg), `"type":"sessions"`, "second broadcast should contain sessions event")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected second broadcast after debounce expiry")
+	}
+}
+
 func TestWatcherNoRepeatBroadcastInTmuxDown(t *testing.T) {
 	mod, fake, events := newWatcherTestModule(t)
 	sub := events.AddTestSubscriber()

--- a/internal/tmux/fake_executor.go
+++ b/internal/tmux/fake_executor.go
@@ -39,6 +39,7 @@ type FakeExecutor struct {
 	setWindowOptionCalls []SetWindowOptionCall // calls to SetWindowOption
 	alive                bool                  // whether tmux server is "alive"
 	HooksOutput          string                // returned by ShowHooksGlobal
+	FailSendKeys         bool                  // if true, SendKeysRaw returns an error
 }
 
 func NewFakeExecutor() *FakeExecutor {
@@ -154,6 +155,9 @@ func (f *FakeExecutor) SendKeysRaw(target string, keys ...string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.rawKeysCalls = append(f.rawKeysCalls, RawKeysCall{Target: target, Keys: keys})
+	if f.FailSendKeys {
+		return fmt.Errorf("send-keys: simulated failure")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- **#133 + #130** — upload delete TOCTOU 修正（直接 `os.Remove` + `IsNotExist`）+ send-keys 失敗時清理孤立檔案
- **#131** — `deduplicateFilename` 改用 `os.OpenFile(O_CREATE|O_EXCL)` 原子佔檔名，消除並發 race condition
- **#121** — `mergeHooks` 寫入 `settings.json` 改為 atomic write（tmp + `os.Rename`）
- **#134** — session watcher `broadcastSessions()` 加 500ms debounce，防止 wait-for + ticker 重複廣播

## Changes

| File | Change |
|------|--------|
| `upload_mgmt.go` | `handleDeleteUploadFile` 移除 `os.Stat` TOCTOU |
| `upload.go` | `createDedupFile` 取代 `deduplicateFilename`，`handleUpload` cleanup on failure |
| `setup.go` | `mergeHooks` atomic write via tmp + rename |
| `watcher.go` | `broadcastSessions` debounce with `lastBroadcast` timestamp |
| `fake_executor.go` | 新增 `FailSendKeys` 測試支援 |

## Test plan

- [x] Go agent module: 22 tests pass（+3 new: delete 404, delete success, send-keys fail cleanup）
- [x] Go session module: 9 tests pass（+2 new: debounce, debounce expiry）
- [x] Go cmd/tbox: 15 tests pass（+1 new: atomic write）
- [ ] Smoke test: upload file via UI, verify inject + dedup

Closes #133, closes #130, closes #131, closes #121, closes #134