### PR TITLE
feat: browser tab toolbar + mini browser popup window

### DIFF
--- a/docs/superpowers/plans/2026-04-07-browser-tab-enhancement.md
+++ b/docs/superpowers/plans/2026-04-07-browser-tab-enhancement.md
@@ -1,0 +1,1906 @@
+# Browser Tab Enhancement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add toolbar controls to browser tabs and support mini browser popup windows via Shift+click.
+
+**Architecture:** Shared `BrowserToolbar` component (props-driven) used by both in-tab browser panes and standalone mini browser windows. Electron side extended with navigation IPC, state-update push, WebContentsView preload injection for shiftKey detection, and mini browser window lifecycle. Link handler unified as a factory function injected into terminal and browser pane contexts.
+
+**Tech Stack:** React 19, Zustand 5, Phosphor Icons, Electron (WebContentsView, BrowserWindow, contextBridge), xterm.js 6 (WebLinksAddon), Vite multi-entry, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-07-browser-tab-enhancement-design.md`
+
+---
+
+## File Map
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `spa/src/lib/url-utils.ts` | URL 正規化 + 驗證（shared utility） |
+| `spa/src/components/BrowserToolbar.tsx` | 共用 toolbar UI（純 props-driven） |
+| `spa/src/components/BrowserToolbarMenu.tsx` | ⋯ 更多選單下拉 |
+| `spa/src/hooks/useBrowserViewState.ts` | 訂閱 Electron state-update IPC |
+| `spa/src/lib/link-handler.ts` | `createLinkHandler` factory |
+| `spa/src/components/MiniBrowserApp.tsx` | Mini browser 視窗的 React 根元件 |
+| `spa/mini-browser.html` | Mini browser HTML entry |
+| `spa/src/mini-browser.tsx` | Mini browser React entry |
+| `electron/browser-view-ipc.ts` | 集中 browser-view IPC handler |
+| `electron/browser-view-preload.ts` | WebContentsView 注入 preload |
+| `electron/mini-browser-window.ts` | Mini browser BrowserWindow 管理 |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `spa/src/components/BrowserPane.tsx` | 整合 toolbar + 調整 ResizeObserver |
+| `spa/src/hooks/useTerminal.ts` | 接受 `linkHandler` 參數 |
+| `spa/src/components/TerminalView.tsx` | 傳入 linkHandler |
+| `spa/src/hooks/useTabWorkspaceActions.ts` | 新增 `openBrowserTab` |
+| `spa/src/components/TabBar.tsx` | ICON_MAP 加入 `Globe` |
+| `spa/src/lib/register-panes.tsx` | 更新 BrowserPane props（如需要） |
+| `electron/browser-view-manager.ts` | 導航 API + state push + destroy + getEntryByWebContents + preload 注入 |
+| `electron/preload.ts` | 暴露新 IPC 方法 |
+| `electron/main.ts` | 委派 IPC 到 browser-view-ipc.ts |
+| `electron.vite.config.ts` | 新增 preload + renderer entry |
+
+### Test Files
+
+| File | Covers |
+|------|--------|
+| `spa/src/lib/__tests__/url-utils.test.ts` | URL 正規化 + 驗證 |
+| `spa/src/components/__tests__/BrowserToolbar.test.tsx` | Toolbar 渲染、按鈕狀態、選單 |
+| `spa/src/hooks/__tests__/useBrowserViewState.test.ts` | State subscription + paneId 過濾 |
+| `spa/src/lib/__tests__/link-handler.test.ts` | 分派邏輯 |
+| `spa/src/hooks/__tests__/useTerminal.test.ts` | linkHandler 注入（更新現有測試） |
+
+---
+
+## Task 1: URL Utility
+
+**Files:**
+- Create: `spa/src/lib/url-utils.ts`
+- Create: `spa/src/lib/__tests__/url-utils.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// spa/src/lib/__tests__/url-utils.test.ts
+import { describe, it, expect } from 'vitest'
+import { normalizeUrl } from '../url-utils'
+
+describe('normalizeUrl', () => {
+  it('returns valid https URL as-is', () => {
+    expect(normalizeUrl('https://github.com')).toBe('https://github.com')
+  })
+
+  it('returns valid http URL as-is', () => {
+    expect(normalizeUrl('http://localhost:3000')).toBe('http://localhost:3000')
+  })
+
+  it('prepends https:// when no scheme', () => {
+    expect(normalizeUrl('github.com')).toBe('https://github.com')
+  })
+
+  it('prepends https:// for domain with path', () => {
+    expect(normalizeUrl('github.com/wake/tmux-box')).toBe('https://github.com/wake/tmux-box')
+  })
+
+  it('returns null for javascript: scheme', () => {
+    expect(normalizeUrl('javascript:alert(1)')).toBeNull()
+  })
+
+  it('returns null for file: scheme', () => {
+    expect(normalizeUrl('file:///etc/passwd')).toBeNull()
+  })
+
+  it('returns null for ftp: scheme', () => {
+    expect(normalizeUrl('ftp://example.com')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(normalizeUrl('')).toBeNull()
+  })
+
+  it('returns null for whitespace only', () => {
+    expect(normalizeUrl('   ')).toBeNull()
+  })
+
+  it('trims whitespace', () => {
+    expect(normalizeUrl('  https://github.com  ')).toBe('https://github.com')
+  })
+
+  it('returns null for malformed URL', () => {
+    expect(normalizeUrl('not a url at all')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd spa && npx vitest run src/lib/__tests__/url-utils.test.ts`
+Expected: FAIL — module `../url-utils` not found
+
+- [ ] **Step 3: Implement url-utils.ts**
+
+```typescript
+// spa/src/lib/url-utils.ts
+const ALLOWED_SCHEMES = ['http:', 'https:']
+
+export function normalizeUrl(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  let urlStr = trimmed
+  if (!trimmed.includes('://')) {
+    urlStr = `https://${trimmed}`
+  }
+
+  try {
+    const parsed = new URL(urlStr)
+    if (!ALLOWED_SCHEMES.includes(parsed.protocol)) return null
+    return parsed.href
+  } catch {
+    return null
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd spa && npx vitest run src/lib/__tests__/url-utils.test.ts`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/lib/url-utils.ts spa/src/lib/__tests__/url-utils.test.ts
+git commit -m "feat(spa): add url-utils with normalizeUrl"
+```
+
+---
+
+## Task 2: link-handler Factory
+
+**Files:**
+- Create: `spa/src/lib/link-handler.ts`
+- Create: `spa/src/lib/__tests__/link-handler.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// spa/src/lib/__tests__/link-handler.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { createLinkHandler } from '../link-handler'
+
+function makeMouseEvent(overrides: Partial<MouseEvent> = {}): MouseEvent {
+  return { shiftKey: false, ...overrides } as MouseEvent
+}
+
+describe('createLinkHandler', () => {
+  describe('Electron mode', () => {
+    it('calls openBrowserTab on normal click', () => {
+      const openBrowserTab = vi.fn()
+      const openMiniWindow = vi.fn()
+      const handler = createLinkHandler({
+        isElectron: true,
+        openBrowserTab,
+        openMiniWindow,
+      })
+
+      handler(makeMouseEvent(), 'https://github.com')
+
+      expect(openBrowserTab).toHaveBeenCalledWith('https://github.com')
+      expect(openMiniWindow).not.toHaveBeenCalled()
+    })
+
+    it('calls openMiniWindow on shift+click', () => {
+      const openBrowserTab = vi.fn()
+      const openMiniWindow = vi.fn()
+      const handler = createLinkHandler({
+        isElectron: true,
+        openBrowserTab,
+        openMiniWindow,
+      })
+
+      handler(makeMouseEvent({ shiftKey: true }), 'https://github.com')
+
+      expect(openMiniWindow).toHaveBeenCalledWith('https://github.com')
+      expect(openBrowserTab).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('SPA mode', () => {
+    it('calls window.open on any click', () => {
+      const openSpy = vi.fn()
+      vi.stubGlobal('open', openSpy)
+
+      const handler = createLinkHandler({
+        isElectron: false,
+        openBrowserTab: vi.fn(),
+        openMiniWindow: vi.fn(),
+      })
+
+      handler(makeMouseEvent(), 'https://github.com')
+
+      expect(openSpy).toHaveBeenCalledWith('https://github.com', '_blank')
+
+      vi.unstubAllGlobals()
+    })
+
+    it('calls window.open on shift+click too', () => {
+      const openSpy = vi.fn()
+      vi.stubGlobal('open', openSpy)
+
+      const handler = createLinkHandler({
+        isElectron: false,
+        openBrowserTab: vi.fn(),
+        openMiniWindow: vi.fn(),
+      })
+
+      handler(makeMouseEvent({ shiftKey: true }), 'https://github.com')
+
+      expect(openSpy).toHaveBeenCalledWith('https://github.com', '_blank')
+
+      vi.unstubAllGlobals()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd spa && npx vitest run src/lib/__tests__/link-handler.test.ts`
+Expected: FAIL — module `../link-handler` not found
+
+- [ ] **Step 3: Implement link-handler.ts**
+
+```typescript
+// spa/src/lib/link-handler.ts
+export interface LinkHandlerDeps {
+  isElectron: boolean
+  openBrowserTab: (url: string) => void
+  openMiniWindow: (url: string) => void
+}
+
+export function createLinkHandler(deps: LinkHandlerDeps) {
+  return (event: MouseEvent, uri: string): void => {
+    if (deps.isElectron) {
+      if (event.shiftKey) {
+        deps.openMiniWindow(uri)
+      } else {
+        deps.openBrowserTab(uri)
+      }
+    } else {
+      window.open(uri, '_blank')
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd spa && npx vitest run src/lib/__tests__/link-handler.test.ts`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/lib/link-handler.ts spa/src/lib/__tests__/link-handler.test.ts
+git commit -m "feat(spa): add createLinkHandler factory"
+```
+
+---
+
+## Task 3: BrowserToolbar Component
+
+**Files:**
+- Create: `spa/src/components/BrowserToolbar.tsx`
+- Create: `spa/src/components/BrowserToolbarMenu.tsx`
+- Create: `spa/src/components/__tests__/BrowserToolbar.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// spa/src/components/__tests__/BrowserToolbar.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BrowserToolbar } from '../BrowserToolbar'
+
+function makeProps(overrides = {}) {
+  return {
+    url: 'https://github.com',
+    title: 'GitHub',
+    canGoBack: true,
+    canGoForward: false,
+    isLoading: false,
+    context: 'tab' as const,
+    onGoBack: vi.fn(),
+    onGoForward: vi.fn(),
+    onReload: vi.fn(),
+    onStop: vi.fn(),
+    onNavigate: vi.fn(),
+    onOpenExternal: vi.fn(),
+    onCopyUrl: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('BrowserToolbar', () => {
+  it('renders back, forward, reload buttons', () => {
+    render(<BrowserToolbar {...makeProps()} />)
+    expect(screen.getByLabelText('Go back')).toBeInTheDocument()
+    expect(screen.getByLabelText('Go forward')).toBeInTheDocument()
+    expect(screen.getByLabelText('Reload')).toBeInTheDocument()
+  })
+
+  it('disables forward button when canGoForward is false', () => {
+    render(<BrowserToolbar {...makeProps({ canGoForward: false })} />)
+    expect(screen.getByLabelText('Go forward')).toBeDisabled()
+  })
+
+  it('disables back button when canGoBack is false', () => {
+    render(<BrowserToolbar {...makeProps({ canGoBack: false })} />)
+    expect(screen.getByLabelText('Go back')).toBeDisabled()
+  })
+
+  it('shows stop button when isLoading is true', () => {
+    render(<BrowserToolbar {...makeProps({ isLoading: true })} />)
+    expect(screen.getByLabelText('Stop')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Reload')).not.toBeInTheDocument()
+  })
+
+  it('calls onGoBack when back button clicked', () => {
+    const onGoBack = vi.fn()
+    render(<BrowserToolbar {...makeProps({ onGoBack })} />)
+    fireEvent.click(screen.getByLabelText('Go back'))
+    expect(onGoBack).toHaveBeenCalledOnce()
+  })
+
+  it('calls onNavigate with normalized URL on Enter', () => {
+    const onNavigate = vi.fn()
+    render(<BrowserToolbar {...makeProps({ onNavigate })} />)
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'example.com' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onNavigate).toHaveBeenCalledWith('https://example.com')
+  })
+
+  it('does not call onNavigate for invalid URL', () => {
+    const onNavigate = vi.fn()
+    render(<BrowserToolbar {...makeProps({ onNavigate })} />)
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'javascript:alert(1)' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+
+  it('displays current URL in input', () => {
+    render(<BrowserToolbar {...makeProps({ url: 'https://example.com/page' })} />)
+    expect(screen.getByRole('textbox')).toHaveValue('https://example.com/page')
+  })
+
+  it('shows popOut in menu for tab context', () => {
+    const onPopOut = vi.fn()
+    render(<BrowserToolbar {...makeProps({ onPopOut })} />)
+    fireEvent.click(screen.getByLabelText('More'))
+    expect(screen.getByText(/mini browser/i)).toBeInTheDocument()
+  })
+
+  it('shows moveToTab in menu for mini-window context', () => {
+    const onMoveToTab = vi.fn()
+    render(<BrowserToolbar {...makeProps({ context: 'mini-window', onMoveToTab })} />)
+    fireEvent.click(screen.getByLabelText('More'))
+    expect(screen.getByText(/主視窗/i)).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd spa && npx vitest run src/components/__tests__/BrowserToolbar.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement BrowserToolbarMenu.tsx**
+
+```typescript
+// spa/src/components/BrowserToolbarMenu.tsx
+import { useEffect, useRef } from 'react'
+import {
+  ArrowSquareOut,
+  Copy,
+  ArrowSquareUpRight,
+  ArrowLineRight,
+} from '@phosphor-icons/react'
+import { useTranslation } from 'react-i18next'
+
+interface MenuItem {
+  label: string
+  icon: React.ReactNode
+  onClick: () => void
+  show: boolean
+}
+
+interface BrowserToolbarMenuProps {
+  context: 'tab' | 'mini-window'
+  onOpenExternal: () => void
+  onCopyUrl: () => void
+  onPopOut?: () => void
+  onMoveToTab?: () => void
+  onClose: () => void
+}
+
+export function BrowserToolbarMenu({
+  context,
+  onOpenExternal,
+  onCopyUrl,
+  onPopOut,
+  onMoveToTab,
+  onClose,
+}: BrowserToolbarMenuProps) {
+  const { t } = useTranslation()
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [onClose])
+
+  const items: MenuItem[] = [
+    {
+      label: t('browser.open_external'),
+      icon: <ArrowSquareOut size={14} />,
+      onClick: () => { onOpenExternal(); onClose() },
+      show: true,
+    },
+    {
+      label: t('browser.copy_url'),
+      icon: <Copy size={14} />,
+      onClick: () => { onCopyUrl(); onClose() },
+      show: true,
+    },
+    {
+      label: t('browser.pop_out'),
+      icon: <ArrowSquareUpRight size={14} />,
+      onClick: () => { onPopOut?.(); onClose() },
+      show: context === 'tab' && !!onPopOut,
+    },
+    {
+      label: t('browser.move_to_tab'),
+      icon: <ArrowLineRight size={14} />,
+      onClick: () => { onMoveToTab?.(); onClose() },
+      show: context === 'mini-window' && !!onMoveToTab,
+    },
+  ]
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-0 top-full mt-1 z-50 min-w-48 rounded-md border border-border bg-popover py-1 shadow-lg"
+    >
+      {items.filter((i) => i.show).map((item) => (
+        <button
+          key={item.label}
+          className="flex w-full items-center gap-2 px-3 py-1.5 text-sm text-popover-foreground hover:bg-accent"
+          onClick={item.onClick}
+        >
+          {item.icon}
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Implement BrowserToolbar.tsx**
+
+```typescript
+// spa/src/components/BrowserToolbar.tsx
+import { useState, useRef, useEffect, useCallback } from 'react'
+import {
+  ArrowLeft,
+  ArrowRight,
+  ArrowClockwise,
+  X,
+  DotsThree,
+} from '@phosphor-icons/react'
+import { normalizeUrl } from '../lib/url-utils'
+import { BrowserToolbarMenu } from './BrowserToolbarMenu'
+
+export interface BrowserToolbarProps {
+  url: string
+  title: string
+  canGoBack: boolean
+  canGoForward: boolean
+  isLoading: boolean
+  context: 'tab' | 'mini-window'
+  onGoBack: () => void
+  onGoForward: () => void
+  onReload: () => void
+  onStop: () => void
+  onNavigate: (url: string) => void
+  onOpenExternal: () => void
+  onCopyUrl: () => void
+  onPopOut?: () => void
+  onMoveToTab?: () => void
+}
+
+export function BrowserToolbar({
+  url,
+  canGoBack,
+  canGoForward,
+  isLoading,
+  context,
+  onGoBack,
+  onGoForward,
+  onReload,
+  onStop,
+  onNavigate,
+  onOpenExternal,
+  onCopyUrl,
+  onPopOut,
+  onMoveToTab,
+}: BrowserToolbarProps) {
+  const [inputValue, setInputValue] = useState(url)
+  const [isEditing, setIsEditing] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Sync URL from prop when not editing
+  useEffect(() => {
+    if (!isEditing) setInputValue(url)
+  }, [url, isEditing])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        const normalized = normalizeUrl(inputValue)
+        if (normalized) {
+          onNavigate(normalized)
+          setIsEditing(false)
+          inputRef.current?.blur()
+        }
+      } else if (e.key === 'Escape') {
+        setInputValue(url)
+        setIsEditing(false)
+        inputRef.current?.blur()
+      }
+    },
+    [inputValue, url, onNavigate],
+  )
+
+  return (
+    <div className="flex items-center gap-1 px-2 py-1 border-b border-border bg-surface-1">
+      {/* Navigation buttons */}
+      <button
+        aria-label="Go back"
+        className="p-1 rounded hover:bg-accent disabled:opacity-30"
+        disabled={!canGoBack}
+        onClick={onGoBack}
+      >
+        <ArrowLeft size={16} />
+      </button>
+      <button
+        aria-label="Go forward"
+        className="p-1 rounded hover:bg-accent disabled:opacity-30"
+        disabled={!canGoForward}
+        onClick={onGoForward}
+      >
+        <ArrowRight size={16} />
+      </button>
+      {isLoading ? (
+        <button
+          aria-label="Stop"
+          className="p-1 rounded hover:bg-accent"
+          onClick={onStop}
+        >
+          <X size={16} />
+        </button>
+      ) : (
+        <button
+          aria-label="Reload"
+          className="p-1 rounded hover:bg-accent"
+          onClick={onReload}
+        >
+          <ArrowClockwise size={16} />
+        </button>
+      )}
+
+      {/* URL bar */}
+      <input
+        ref={inputRef}
+        role="textbox"
+        className="flex-1 mx-1 px-2 py-0.5 rounded bg-surface-2 text-xs font-mono text-foreground outline-none focus:ring-1 focus:ring-accent"
+        value={inputValue}
+        onChange={(e) => { setInputValue(e.target.value); setIsEditing(true) }}
+        onFocus={() => { setIsEditing(true); inputRef.current?.select() }}
+        onBlur={() => { setIsEditing(false); setInputValue(url) }}
+        onKeyDown={handleKeyDown}
+      />
+
+      {/* More menu */}
+      <div className="relative">
+        <button
+          aria-label="More"
+          className="p-1 rounded hover:bg-accent"
+          onClick={() => setMenuOpen((v) => !v)}
+        >
+          <DotsThree size={16} weight="bold" />
+        </button>
+        {menuOpen && (
+          <BrowserToolbarMenu
+            context={context}
+            onOpenExternal={onOpenExternal}
+            onCopyUrl={onCopyUrl}
+            onPopOut={onPopOut}
+            onMoveToTab={onMoveToTab}
+            onClose={() => setMenuOpen(false)}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd spa && npx vitest run src/components/__tests__/BrowserToolbar.test.tsx`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/components/BrowserToolbar.tsx spa/src/components/BrowserToolbarMenu.tsx spa/src/components/__tests__/BrowserToolbar.test.tsx
+git commit -m "feat(spa): add BrowserToolbar and BrowserToolbarMenu components"
+```
+
+---
+
+## Task 4: useBrowserViewState Hook
+
+**Files:**
+- Create: `spa/src/hooks/useBrowserViewState.ts`
+- Create: `spa/src/hooks/__tests__/useBrowserViewState.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// spa/src/hooks/__tests__/useBrowserViewState.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBrowserViewState } from '../useBrowserViewState'
+import type { BrowserViewState } from '../useBrowserViewState'
+
+describe('useBrowserViewState', () => {
+  let listeners: Array<(paneId: string, state: BrowserViewState) => void>
+  let mockUnsubscribe: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    listeners = []
+    mockUnsubscribe = vi.fn()
+    vi.stubGlobal('electronAPI', {
+      onBrowserViewStateUpdate: vi.fn((cb) => {
+        listeners.push(cb)
+        return mockUnsubscribe
+      }),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns initial empty state', () => {
+    const { result } = renderHook(() => useBrowserViewState('pane-1'))
+    expect(result.current).toEqual({
+      url: '',
+      title: '',
+      canGoBack: false,
+      canGoForward: false,
+      isLoading: false,
+    })
+  })
+
+  it('updates state when matching paneId received', () => {
+    const { result } = renderHook(() => useBrowserViewState('pane-1'))
+
+    act(() => {
+      listeners[0]('pane-1', {
+        url: 'https://github.com',
+        title: 'GitHub',
+        canGoBack: true,
+        canGoForward: false,
+        isLoading: false,
+      })
+    })
+
+    expect(result.current.url).toBe('https://github.com')
+    expect(result.current.title).toBe('GitHub')
+    expect(result.current.canGoBack).toBe(true)
+  })
+
+  it('ignores state for different paneId', () => {
+    const { result } = renderHook(() => useBrowserViewState('pane-1'))
+
+    act(() => {
+      listeners[0]('pane-OTHER', {
+        url: 'https://other.com',
+        title: 'Other',
+        canGoBack: true,
+        canGoForward: true,
+        isLoading: true,
+      })
+    })
+
+    expect(result.current.url).toBe('')
+  })
+
+  it('calls unsubscribe on unmount', () => {
+    const { unmount } = renderHook(() => useBrowserViewState('pane-1'))
+    unmount()
+    expect(mockUnsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('returns empty state when electronAPI not available', () => {
+    vi.stubGlobal('electronAPI', undefined)
+    const { result } = renderHook(() => useBrowserViewState('pane-1'))
+    expect(result.current.url).toBe('')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd spa && npx vitest run src/hooks/__tests__/useBrowserViewState.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement useBrowserViewState.ts**
+
+```typescript
+// spa/src/hooks/useBrowserViewState.ts
+import { useState, useEffect } from 'react'
+
+export interface BrowserViewState {
+  url: string
+  title: string
+  canGoBack: boolean
+  canGoForward: boolean
+  isLoading: boolean
+}
+
+const INITIAL_STATE: BrowserViewState = {
+  url: '',
+  title: '',
+  canGoBack: false,
+  canGoForward: false,
+  isLoading: false,
+}
+
+export function useBrowserViewState(paneId: string): BrowserViewState {
+  const [state, setState] = useState<BrowserViewState>(INITIAL_STATE)
+
+  useEffect(() => {
+    const api = window.electronAPI
+    if (!api?.onBrowserViewStateUpdate) return
+
+    const unsubscribe = api.onBrowserViewStateUpdate(
+      (id: string, update: BrowserViewState) => {
+        if (id === paneId) setState(update)
+      },
+    )
+
+    return unsubscribe
+  }, [paneId])
+
+  return state
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd spa && npx vitest run src/hooks/__tests__/useBrowserViewState.test.ts`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/hooks/useBrowserViewState.ts spa/src/hooks/__tests__/useBrowserViewState.test.ts
+git commit -m "feat(spa): add useBrowserViewState hook"
+```
+
+---
+
+## Task 5: BrowserViewManager Extensions
+
+**Files:**
+- Modify: `electron/browser-view-manager.ts`
+
+This task extends the existing manager with navigation methods, state-update push, `destroy()`, `getEntryByWebContents()`, and preload script injection. No unit tests (Electron integration); verified in Task 11 integration.
+
+- [ ] **Step 1: Add navigation methods to BrowserViewManager**
+
+In `electron/browser-view-manager.ts`, after the existing `resize()` method (around line 121), add:
+
+```typescript
+goBack(paneId: string): void {
+  const entry = this.views.get(paneId)
+  if (entry?.view.webContents.canGoBack()) {
+    entry.view.webContents.goBack()
+  }
+}
+
+goForward(paneId: string): void {
+  const entry = this.views.get(paneId)
+  if (entry?.view.webContents.canGoForward()) {
+    entry.view.webContents.goForward()
+  }
+}
+
+reload(paneId: string): void {
+  const entry = this.views.get(paneId)
+  entry?.view.webContents.reload()
+}
+
+stop(paneId: string): void {
+  const entry = this.views.get(paneId)
+  entry?.view.webContents.stop()
+}
+```
+
+- [ ] **Step 2: Add destroy() method**
+
+After the `discard()` method, add:
+
+```typescript
+destroy(paneId: string): void {
+  const entry = this.views.get(paneId)
+  if (!entry) return
+  try {
+    entry.window.contentView.removeChildView(entry.view)
+  } catch { /* already removed */ }
+  try {
+    entry.view.webContents.close()
+  } catch { /* already closed */ }
+  this.views.delete(paneId)
+}
+```
+
+- [ ] **Step 3: Add getEntryByWebContents() method**
+
+```typescript
+getEntryByWebContents(wc: WebContents): ViewEntry | undefined {
+  for (const entry of this.views.values()) {
+    if (entry.view.webContents === wc) return entry
+  }
+  return undefined
+}
+```
+
+Import `WebContents` from `electron` at the top of the file.
+
+- [ ] **Step 4: Add getCurrentState() method for snapshot retrieval**
+
+```typescript
+getCurrentState(paneId: string): { url: string; title: string } | undefined {
+  const entry = this.views.get(paneId)
+  if (!entry) return undefined
+  return {
+    url: entry.view.webContents.getURL(),
+    title: entry.view.webContents.getTitle(),
+  }
+}
+```
+
+- [ ] **Step 5: Add state-update push in open() method**
+
+In the `open()` method, after `entry.view.webContents.loadURL(url)` and before adding to `this.views`, add event listeners that push state to the SPA:
+
+```typescript
+const wc = entry.view.webContents
+
+const pushState = () => {
+  try {
+    entry.window.webContents.send('browser-view:state-update', paneId, {
+      url: wc.getURL(),
+      title: wc.getTitle(),
+      canGoBack: wc.canGoBack(),
+      canGoForward: wc.canGoForward(),
+      isLoading: wc.isLoading(),
+    })
+  } catch { /* window may be closed */ }
+}
+
+wc.on('did-navigate', pushState)
+wc.on('did-navigate-in-page', pushState)
+wc.on('did-start-loading', pushState)
+wc.on('did-stop-loading', pushState)
+wc.on('page-title-updated', pushState)
+```
+
+- [ ] **Step 6: Inject preload script in open() method**
+
+Modify the `WebContentsView` constructor in `open()` to include the preload path. Change:
+
+```typescript
+const view = new WebContentsView({
+  webPreferences: {
+    contextIsolation: true,
+    sandbox: true,
+  },
+})
+```
+
+To:
+
+```typescript
+import { join } from 'node:path'
+
+const view = new WebContentsView({
+  webPreferences: {
+    contextIsolation: true,
+    sandbox: true,
+    preload: join(__dirname, '../preload/browserViewPreload.js'),
+  },
+})
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add electron/browser-view-manager.ts
+git commit -m "feat(electron): extend BrowserViewManager with navigation, state push, destroy, preload"
+```
+
+---
+
+## Task 6: browser-view-preload.ts
+
+**Files:**
+- Create: `electron/browser-view-preload.ts`
+
+- [ ] **Step 1: Create preload script**
+
+```typescript
+// electron/browser-view-preload.ts
+import { ipcRenderer } from 'electron'
+
+document.addEventListener(
+  'click',
+  (e: MouseEvent) => {
+    const link = (e.target as HTMLElement).closest('a[href]') as HTMLAnchorElement | null
+    if (!link) return
+    const href = link.href
+    if (!href || href.startsWith('javascript:')) return
+
+    if (e.shiftKey || link.target === '_blank') {
+      e.preventDefault()
+      ipcRenderer.send('browser-view:link-click', {
+        url: href,
+        shiftKey: e.shiftKey,
+        targetBlank: link.target === '_blank',
+      })
+    }
+    // Normal links: don't intercept, let will-navigate handle
+  },
+  true,
+)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add electron/browser-view-preload.ts
+git commit -m "feat(electron): add browser-view-preload for link click interception"
+```
+
+---
+
+## Task 7: browser-view-ipc.ts + Main Integration
+
+**Files:**
+- Create: `electron/browser-view-ipc.ts`
+- Modify: `electron/main.ts`
+
+- [ ] **Step 1: Create browser-view-ipc.ts**
+
+```typescript
+// electron/browser-view-ipc.ts
+import { ipcMain, BrowserWindow, shell } from 'electron'
+import type { BrowserViewManager } from './browser-view-manager'
+import type { MiniWindowManager } from './mini-browser-window'
+
+export function registerBrowserViewIpc(
+  manager: BrowserViewManager,
+  miniWindowManager: MiniWindowManager,
+): void {
+  // Existing handlers (moved from main.ts)
+  ipcMain.handle('browser-view:open', (event, url: string, paneId: string) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (win) manager.open(win, url, paneId)
+  })
+
+  ipcMain.handle('browser-view:close', (_event, paneId: string) => {
+    manager.background(paneId)
+  })
+
+  ipcMain.handle('browser-view:navigate', (_event, paneId: string, url: string) => {
+    manager.navigate(paneId, url)
+  })
+
+  ipcMain.handle('browser-view:resize', (_event, paneId: string, boundsJson: string) => {
+    const raw = JSON.parse(boundsJson)
+    manager.resize(paneId, {
+      x: Math.round(raw.x),
+      y: Math.round(raw.y),
+      width: Math.round(raw.width),
+      height: Math.round(raw.height),
+    })
+  })
+
+  // New navigation handlers
+  ipcMain.handle('browser-view:go-back', (_event, paneId: string) => {
+    manager.goBack(paneId)
+  })
+
+  ipcMain.handle('browser-view:go-forward', (_event, paneId: string) => {
+    manager.goForward(paneId)
+  })
+
+  ipcMain.handle('browser-view:reload', (_event, paneId: string) => {
+    manager.reload(paneId)
+  })
+
+  ipcMain.handle('browser-view:stop', (_event, paneId: string) => {
+    manager.stop(paneId)
+  })
+
+  ipcMain.handle('browser-view:destroy', (_event, paneId: string) => {
+    manager.destroy(paneId)
+  })
+
+  // Mini browser window
+  ipcMain.handle('browser-view:open-mini-window', (event, url: string) => {
+    const parentWin = BrowserWindow.fromWebContents(event.sender)
+    if (parentWin) miniWindowManager.open(parentWin, url)
+  })
+
+  // Move to tab: mini window → parent window
+  ipcMain.handle('browser-view:move-to-tab', (_event, paneId: string) => {
+    miniWindowManager.moveToTab(paneId)
+  })
+
+  // Link click from WebContentsView preload
+  ipcMain.on('browser-view:link-click', (event, data: { url: string; shiftKey: boolean; targetBlank: boolean }) => {
+    const entry = manager.getEntryByWebContents(event.sender)
+    if (!entry) return
+
+    if (data.shiftKey) {
+      miniWindowManager.open(entry.window, data.url)
+    } else {
+      // Notify parent window SPA to open new browser tab
+      entry.window.webContents.send('browser-view:open-in-tab', data.url)
+    }
+  })
+}
+```
+
+- [ ] **Step 2: Update main.ts — remove old browser-view handlers and delegate**
+
+In `electron/main.ts`, replace the existing browser-view `ipcMain.handle(...)` blocks (around lines 34-55) with:
+
+```typescript
+import { registerBrowserViewIpc } from './browser-view-ipc'
+import { MiniWindowManager } from './mini-browser-window'
+
+// After browserViewManager and windowManager are created:
+const miniWindowManager = new MiniWindowManager(browserViewManager, windowManager)
+registerBrowserViewIpc(browserViewManager, miniWindowManager)
+```
+
+Remove the individual `ipcMain.handle('browser-view:open', ...)` etc. from main.ts since they are now in `browser-view-ipc.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add electron/browser-view-ipc.ts electron/main.ts
+git commit -m "feat(electron): centralize browser-view IPC in browser-view-ipc.ts"
+```
+
+---
+
+## Task 8: Preload API Extensions
+
+**Files:**
+- Modify: `electron/preload.ts`
+
+- [ ] **Step 1: Add new methods to preload contextBridge**
+
+Add these to the `electronAPI` object in `electron/preload.ts`:
+
+```typescript
+// Navigation
+browserViewGoBack: (paneId: string) =>
+  ipcRenderer.invoke('browser-view:go-back', paneId),
+browserViewGoForward: (paneId: string) =>
+  ipcRenderer.invoke('browser-view:go-forward', paneId),
+browserViewReload: (paneId: string) =>
+  ipcRenderer.invoke('browser-view:reload', paneId),
+browserViewStop: (paneId: string) =>
+  ipcRenderer.invoke('browser-view:stop', paneId),
+
+// Window operations
+browserViewOpenMiniWindow: (url: string) =>
+  ipcRenderer.invoke('browser-view:open-mini-window', url),
+destroyBrowserView: (paneId: string) =>
+  ipcRenderer.invoke('browser-view:destroy', paneId),
+browserViewMoveToTab: (paneId: string) =>
+  ipcRenderer.invoke('browser-view:move-to-tab', paneId),
+
+// State subscription (Electron → SPA)
+onBrowserViewStateUpdate: (
+  callback: (paneId: string, state: unknown) => void,
+) => {
+  const handler = (_event: unknown, paneId: string, state: unknown) =>
+    callback(paneId, state)
+  ipcRenderer.on('browser-view:state-update', handler)
+  return () => {
+    ipcRenderer.removeListener('browser-view:state-update', handler)
+  }
+},
+
+// Open in tab (from mini browser or WebContentsView link click)
+onBrowserViewOpenInTab: (callback: (url: string) => void) => {
+  const handler = (_event: unknown, url: string) => callback(url)
+  ipcRenderer.on('browser-view:open-in-tab', handler)
+  return () => {
+    ipcRenderer.removeListener('browser-view:open-in-tab', handler)
+  }
+},
+```
+
+- [ ] **Step 2: Update TypeScript declarations**
+
+Find the existing `electronAPI` type declaration (likely in `spa/src/types/electron.d.ts` or `spa/src/vite-env.d.ts`) and add the new methods. If there's no explicit type file, the SPA code uses `window.electronAPI?.` optional chaining pattern — verify that the new methods work with this pattern. The key is that each new method matches the preload's `contextBridge.exposeInMainWorld` definition exactly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add electron/preload.ts
+git commit -m "feat(electron): extend preload API with navigation, state-update, mini-window IPC"
+```
+
+---
+
+## Task 9: BrowserPane Integration
+
+**Files:**
+- Modify: `spa/src/components/BrowserPane.tsx`
+- Modify: `spa/src/lib/register-panes.tsx`
+
+- [ ] **Step 1: Update BrowserPane.tsx**
+
+Rewrite `BrowserPane.tsx` to include `BrowserToolbar` and adjust `ResizeObserver` to observe the content area (not the full container):
+
+```typescript
+// spa/src/components/BrowserPane.tsx
+import { useEffect, useRef, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { BrowserToolbar } from './BrowserToolbar'
+import { useBrowserViewState } from '../hooks/useBrowserViewState'
+
+interface Props {
+  paneId: string
+  url: string
+}
+
+export function BrowserPane({ paneId, url }: Props) {
+  const { t } = useTranslation()
+  const contentRef = useRef<HTMLDivElement>(null)
+  const mountedRef = useRef(false)
+  const state = useBrowserViewState(paneId)
+
+  // Display URL: prefer live state, fallback to initial url prop
+  const currentUrl = state.url || url
+
+  // Open/close lifecycle
+  useEffect(() => {
+    if (!window.electronAPI) return
+    window.electronAPI.openBrowserView(url, paneId)
+    mountedRef.current = true
+    return () => {
+      window.electronAPI.closeBrowserView(paneId)
+      mountedRef.current = false
+    }
+  }, [url, paneId])
+
+  // ResizeObserver on content area (below toolbar)
+  useEffect(() => {
+    const el = contentRef.current
+    if (!el || !window.electronAPI) return
+
+    let rafId = 0
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        const rect = el.getBoundingClientRect()
+        if (!rect.width || !rect.height) return
+        window.electronAPI.resizeBrowserView(
+          paneId,
+          JSON.stringify({
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+          }),
+        )
+      })
+    })
+    observer.observe(el)
+
+    return () => {
+      cancelAnimationFrame(rafId)
+      observer.disconnect()
+    }
+  }, [paneId])
+
+  // Toolbar callbacks
+  const handleGoBack = useCallback(() => window.electronAPI?.browserViewGoBack(paneId), [paneId])
+  const handleGoForward = useCallback(() => window.electronAPI?.browserViewGoForward(paneId), [paneId])
+  const handleReload = useCallback(() => window.electronAPI?.browserViewReload(paneId), [paneId])
+  const handleStop = useCallback(() => window.electronAPI?.browserViewStop(paneId), [paneId])
+  const handleNavigate = useCallback(
+    (newUrl: string) => window.electronAPI?.navigateBrowserView(paneId, newUrl),
+    [paneId],
+  )
+  const handleOpenExternal = useCallback(() => window.open(currentUrl, '_blank'), [currentUrl])
+  const handleCopyUrl = useCallback(() => navigator.clipboard.writeText(currentUrl), [currentUrl])
+  const handlePopOut = useCallback(
+    () => window.electronAPI?.browserViewOpenMiniWindow(currentUrl),
+    [currentUrl],
+  )
+
+  // SPA fallback
+  if (!window.electronAPI) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        {t('browser.requires_app')}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full" data-browser-pane={paneId}>
+      <BrowserToolbar
+        url={currentUrl}
+        title={state.title}
+        canGoBack={state.canGoBack}
+        canGoForward={state.canGoForward}
+        isLoading={state.isLoading}
+        context="tab"
+        onGoBack={handleGoBack}
+        onGoForward={handleGoForward}
+        onReload={handleReload}
+        onStop={handleStop}
+        onNavigate={handleNavigate}
+        onOpenExternal={handleOpenExternal}
+        onCopyUrl={handleCopyUrl}
+        onPopOut={handlePopOut}
+      />
+      {/* Content area: WebContentsView overlays this div */}
+      <div ref={contentRef} className="flex-1" />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify register-panes.tsx doesn't need changes**
+
+The browser pane registration in `register-panes.tsx` passes `paneId` and `url` props, which matches the updated `BrowserPane` interface. No changes needed.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd spa && npx vitest run`
+Expected: All existing tests pass (BrowserPane is Electron-dependent, may not have unit tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/components/BrowserPane.tsx
+git commit -m "feat(spa): integrate BrowserToolbar into BrowserPane with ResizeObserver adjustment"
+```
+
+---
+
+## Task 10: useTerminal linkHandler + TerminalView Wiring
+
+**Files:**
+- Modify: `spa/src/hooks/useTerminal.ts`
+- Modify: `spa/src/components/TerminalView.tsx`
+
+- [ ] **Step 1: Update useTerminal to accept linkHandler**
+
+Change the function signature and `WebLinksAddon` instantiation:
+
+```typescript
+// spa/src/hooks/useTerminal.ts — changes only
+
+export interface UseTerminalOptions {
+  linkHandler?: (event: MouseEvent, uri: string) => void
+}
+
+export function useTerminal(options: UseTerminalOptions = {}): UseTerminalResult {
+  // ... existing code ...
+
+  useEffect(() => {
+    // ... existing terminal creation ...
+
+    // Replace: try { term.loadAddon(new WebLinksAddon()) } catch { /* non-critical */ }
+    // With:
+    try {
+      const handler = options.linkHandler
+      term.loadAddon(handler ? new WebLinksAddon(handler) : new WebLinksAddon())
+    } catch { /* non-critical */ }
+
+    // ... rest of effect ...
+  }, []) // options.linkHandler is stable (created via useCallback in parent)
+```
+
+- [ ] **Step 2: Update TerminalView to create and pass linkHandler**
+
+In `spa/src/components/TerminalView.tsx`, add linkHandler creation:
+
+```typescript
+import { useMemo } from 'react'
+import { createLinkHandler } from '../lib/link-handler'
+import { getPlatformCapabilities } from '../lib/platform'
+import { useTabWorkspaceActions } from '../hooks/useTabWorkspaceActions'
+
+// Inside the component:
+const caps = useMemo(() => getPlatformCapabilities(), [])
+const { openBrowserTab } = useTabWorkspaceActions()
+
+const linkHandler = useMemo(
+  () =>
+    createLinkHandler({
+      isElectron: caps.isElectron,
+      openBrowserTab,
+      openMiniWindow: (url) => window.electronAPI?.browserViewOpenMiniWindow(url),
+    }),
+  [caps.isElectron, openBrowserTab],
+)
+
+// Pass to useTerminal:
+const { termRef, fitAddonRef, containerRef } = useTerminal({ linkHandler })
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd spa && npx vitest run`
+Expected: All pass. Existing useTerminal tests may need minor adjustments if they test the hook signature.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/hooks/useTerminal.ts spa/src/components/TerminalView.tsx
+git commit -m "feat(spa): wire link handler into useTerminal and TerminalView"
+```
+
+---
+
+## Task 11: TabBar ICON_MAP + openBrowserTab Action
+
+**Files:**
+- Modify: `spa/src/components/TabBar.tsx`
+- Modify: `spa/src/hooks/useTabWorkspaceActions.ts`
+
+- [ ] **Step 1: Add Globe to TabBar ICON_MAP**
+
+In `spa/src/components/TabBar.tsx`, add import and map entry:
+
+```typescript
+import { Globe } from '@phosphor-icons/react'
+
+// In ICON_MAP:
+const ICON_MAP: Record<string, React.ComponentType<{ size: number; className?: string }>> = {
+  Plus,
+  TerminalWindow: TerminalWindowFill,
+  ChatCircleDots,
+  House,
+  ClockCounterClockwise,
+  GearSix,
+  SmileySad,
+  Globe,  // ← add
+}
+```
+
+- [ ] **Step 2: Add openBrowserTab to useTabWorkspaceActions**
+
+In `spa/src/hooks/useTabWorkspaceActions.ts`, add:
+
+```typescript
+import { createTab } from '../lib/pane-tree'  // or wherever createTab is
+
+const openBrowserTab = useCallback(
+  (url: string) => {
+    const tab = createTab({ kind: 'browser', url })
+    addTab(tab)
+    setActiveTab(tab.id)
+    if (activeWorkspaceId) {
+      useWorkspaceStore.getState().addTabToWorkspace(activeWorkspaceId, tab.id)
+      useWorkspaceStore.getState().setWorkspaceActiveTab(activeWorkspaceId, tab.id)
+    }
+  },
+  [addTab, setActiveTab, activeWorkspaceId],
+)
+
+// Include in the return value:
+return { ..., openBrowserTab }
+```
+
+- [ ] **Step 3: Wire onBrowserViewOpenInTab in App.tsx**
+
+In `spa/src/App.tsx`, add an effect to listen for `browser-view:open-in-tab` events from mini browser windows or WebContentsView link clicks:
+
+```typescript
+// In App component, near other electronAPI effects:
+useEffect(() => {
+  if (!window.electronAPI?.onBrowserViewOpenInTab) return
+  return window.electronAPI.onBrowserViewOpenInTab((url: string) => {
+    // Reuse the same workspace-aware logic
+    const tab = createTab({ kind: 'browser', url })
+    useTabStore.getState().addTab(tab)
+    useTabStore.getState().setActiveTab(tab.id)
+    const wsId = useWorkspaceStore.getState().activeWorkspaceId
+    if (wsId) {
+      useWorkspaceStore.getState().addTabToWorkspace(wsId, tab.id)
+      useWorkspaceStore.getState().setWorkspaceActiveTab(wsId, tab.id)
+    }
+  })
+}, [])
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npx vitest run`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/components/TabBar.tsx spa/src/hooks/useTabWorkspaceActions.ts spa/src/App.tsx
+git commit -m "feat(spa): add Globe to ICON_MAP, openBrowserTab action, open-in-tab listener"
+```
+
+---
+
+## Task 12: mini-browser-window.ts
+
+**Files:**
+- Create: `electron/mini-browser-window.ts`
+
+- [ ] **Step 1: Create MiniWindowManager**
+
+```typescript
+// electron/mini-browser-window.ts
+import { BrowserWindow } from 'electron'
+import { join } from 'node:path'
+import type { BrowserViewManager } from './browser-view-manager'
+import type { WindowManager } from './window-manager'
+
+interface MiniWindowEntry {
+  window: BrowserWindow
+  paneId: string
+  parentWindow: BrowserWindow
+}
+
+export class MiniWindowManager {
+  private entries = new Map<string, MiniWindowEntry>()
+  private nextId = 0
+
+  constructor(
+    private viewManager: BrowserViewManager,
+    private windowManager: WindowManager,
+  ) {}
+
+  open(parentWindow: BrowserWindow, url: string): void {
+    const paneId = `mini-${++this.nextId}`
+
+    const win = new BrowserWindow({
+      width: 800,
+      height: 600,
+      titleBarStyle: 'hiddenInset',
+      trafficLightPosition: { x: 12, y: 12 },
+      webPreferences: {
+        contextIsolation: true,
+        sandbox: true,
+        nodeIntegration: false,
+        preload: join(__dirname, '../preload/index.js'),
+      },
+    })
+
+    this.entries.set(paneId, { window: win, paneId, parentWindow })
+
+    // Load mini browser SPA entry
+    const query = `?paneId=${encodeURIComponent(paneId)}`
+    const devServer = WindowManager.DEV_SERVER
+    fetch(devServer, { signal: AbortSignal.timeout(500) })
+      .then(() => win.loadURL(`${devServer}/mini-browser.html${query}`))
+      .catch(() => win.loadURL(`app://./mini-browser.html${query}`))
+
+    // Once SPA is ready, open the WebContentsView
+    win.webContents.once('did-finish-load', () => {
+      this.viewManager.open(win, url, paneId)
+    })
+
+    // Cleanup on window close
+    win.on('closed', () => {
+      this.viewManager.destroy(paneId)
+      this.entries.delete(paneId)
+    })
+  }
+
+  moveToTab(paneId: string): void {
+    const entry = this.entries.get(paneId)
+    if (!entry) return
+
+    // Get current URL from the view
+    const state = this.viewManager.getCurrentState(paneId)
+    const url = state?.url || ''
+
+    // Notify parent window SPA to open new tab
+    try {
+      entry.parentWindow.webContents.send('browser-view:open-in-tab', url)
+    } catch { /* parent window may be closed */ }
+
+    // Close mini window (triggers 'closed' event → cleanup)
+    entry.window.close()
+  }
+
+  closeAll(): void {
+    for (const entry of this.entries.values()) {
+      entry.window.close()
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add electron/mini-browser-window.ts
+git commit -m "feat(electron): add MiniWindowManager for standalone browser windows"
+```
+
+---
+
+## Task 13: Mini Browser SPA Entry
+
+**Files:**
+- Create: `spa/mini-browser.html`
+- Create: `spa/src/mini-browser.tsx`
+
+- [ ] **Step 1: Create mini-browser.html**
+
+```html
+<!-- spa/mini-browser.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mini Browser</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/mini-browser.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 2: Create mini-browser.tsx**
+
+```typescript
+// spa/src/mini-browser.tsx
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import { MiniBrowserApp } from './components/MiniBrowserApp'
+
+const params = new URLSearchParams(window.location.search)
+const paneId = params.get('paneId') || ''
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <MiniBrowserApp paneId={paneId} />
+  </StrictMode>,
+)
+```
+
+- [ ] **Step 3: Create MiniBrowserApp component**
+
+```typescript
+// spa/src/components/MiniBrowserApp.tsx
+import { useEffect, useRef, useCallback } from 'react'
+import { BrowserToolbar } from './BrowserToolbar'
+import { useBrowserViewState } from '../hooks/useBrowserViewState'
+
+interface Props {
+  paneId: string
+}
+
+export function MiniBrowserApp({ paneId }: Props) {
+  const contentRef = useRef<HTMLDivElement>(null)
+  const state = useBrowserViewState(paneId)
+
+  // ResizeObserver for content area
+  useEffect(() => {
+    const el = contentRef.current
+    if (!el || !window.electronAPI) return
+
+    let rafId = 0
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        const rect = el.getBoundingClientRect()
+        if (!rect.width || !rect.height) return
+        window.electronAPI.resizeBrowserView(
+          paneId,
+          JSON.stringify({
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+          }),
+        )
+      })
+    })
+    observer.observe(el)
+
+    return () => {
+      cancelAnimationFrame(rafId)
+      observer.disconnect()
+    }
+  }, [paneId])
+
+  const handleGoBack = useCallback(() => window.electronAPI?.browserViewGoBack(paneId), [paneId])
+  const handleGoForward = useCallback(() => window.electronAPI?.browserViewGoForward(paneId), [paneId])
+  const handleReload = useCallback(() => window.electronAPI?.browserViewReload(paneId), [paneId])
+  const handleStop = useCallback(() => window.electronAPI?.browserViewStop(paneId), [paneId])
+  const handleNavigate = useCallback(
+    (url: string) => window.electronAPI?.navigateBrowserView(paneId, url),
+    [paneId],
+  )
+  const handleOpenExternal = useCallback(() => window.open(state.url, '_blank'), [state.url])
+  const handleCopyUrl = useCallback(() => navigator.clipboard.writeText(state.url), [state.url])
+  const handleMoveToTab = useCallback(
+    () => window.electronAPI?.browserViewMoveToTab(paneId),
+    [paneId],
+  )
+
+  return (
+    <div className="flex flex-col h-screen bg-background text-foreground">
+      {/* Electron title bar drag region */}
+      <div
+        className="h-10 flex items-end"
+        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      />
+      <BrowserToolbar
+        url={state.url}
+        title={state.title}
+        canGoBack={state.canGoBack}
+        canGoForward={state.canGoForward}
+        isLoading={state.isLoading}
+        context="mini-window"
+        onGoBack={handleGoBack}
+        onGoForward={handleGoForward}
+        onReload={handleReload}
+        onStop={handleStop}
+        onNavigate={handleNavigate}
+        onOpenExternal={handleOpenExternal}
+        onCopyUrl={handleCopyUrl}
+        onMoveToTab={handleMoveToTab}
+      />
+      <div ref={contentRef} className="flex-1" />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/mini-browser.html spa/src/mini-browser.tsx spa/src/components/MiniBrowserApp.tsx
+git commit -m "feat(spa): add mini browser SPA entry point and MiniBrowserApp component"
+```
+
+---
+
+## Task 14: Build Config
+
+**Files:**
+- Modify: `electron.vite.config.ts`
+
+- [ ] **Step 1: Add preload entry for browser-view-preload**
+
+In `electron.vite.config.ts`, change the preload section from single entry to multi-entry:
+
+```typescript
+preload: {
+  build: {
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'electron/preload.ts'),
+        browserViewPreload: resolve(__dirname, 'electron/browser-view-preload.ts'),
+      },
+      output: { entryFileNames: '[name].js' },
+    },
+    outDir: 'out/preload',
+  },
+  // ... existing plugins
+},
+```
+
+- [ ] **Step 2: Add renderer entry for mini-browser**
+
+In the renderer section, change from single entry to multi-entry:
+
+```typescript
+renderer: {
+  root: 'spa',
+  build: {
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'spa/index.html'),
+        'mini-browser': resolve(__dirname, 'spa/mini-browser.html'),
+      },
+    },
+    outDir: 'out/renderer',
+  },
+  // ... existing plugins
+},
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd spa && pnpm run build` (or the electron-vite build command)
+Expected: Build succeeds, `out/preload/browserViewPreload.js` and `out/renderer/mini-browser.html` exist
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add electron.vite.config.ts
+git commit -m "build: add browser-view-preload and mini-browser entries to electron-vite config"
+```
+
+---
+
+## Task 15: i18n Keys
+
+**Files:**
+- Modify: `spa/src/locales/en.json` (and `zh-TW.json` if exists)
+
+- [ ] **Step 1: Add translation keys**
+
+Add these keys to the locale files:
+
+```json
+{
+  "browser": {
+    "open_external": "Open in browser",
+    "copy_url": "Copy URL",
+    "pop_out": "Open in mini browser",
+    "move_to_tab": "Open in main window"
+  }
+}
+```
+
+And for zh-TW:
+
+```json
+{
+  "browser": {
+    "open_external": "在瀏覽器中開啟",
+    "copy_url": "複製網址",
+    "pop_out": "在 Mini Browser 開啟",
+    "move_to_tab": "在主視窗重新開啟此網址"
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add spa/src/locales/
+git commit -m "feat(spa): add i18n keys for browser toolbar menu"
+```
+
+---
+
+## Task 16: Browser Tab Close → Destroy Path
+
+**Files:**
+- Modify: `spa/src/hooks/useTabWorkspaceActions.ts` (or wherever `closeTab` flow is handled)
+- Modify: `spa/src/components/BrowserPane.tsx`
+
+The spec requires that when a user **actively closes** a browser tab, it calls `destroyBrowserView()` (not `closeBrowserView()`). The current flow: user closes tab → tab removed from store → BrowserPane unmounts → `closeBrowserView()` → `background()`. We need to intercept before unmount.
+
+- [ ] **Step 1: Add destroy call before tab removal**
+
+In the tab close flow (in `useTabWorkspaceActions.ts` or `handleContextAction`), detect if the closing tab contains a browser pane and call `destroyBrowserView` before removing the tab:
+
+```typescript
+// In the close tab handler, before calling removeTab/closeTab:
+const tab = useTabStore.getState().tabs[tabId]
+if (tab) {
+  const primary = getPrimaryPane(tab.layout)
+  if (primary.content.kind === 'browser') {
+    window.electronAPI?.destroyBrowserView(primary.id)
+  }
+}
+// Then proceed with normal closeTab
+```
+
+This way, `destroy()` runs before the BrowserPane unmounts. The subsequent `closeBrowserView()` from unmount will be a no-op (view already removed from manager).
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd spa && npx vitest run`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spa/src/hooks/useTabWorkspaceActions.ts
+git commit -m "feat(spa): call destroyBrowserView on active browser tab close"
+```
+
+**Note:** The recently-closed store (snapshot + restore UI) is deferred — the destroy path is the critical piece for correct cleanup. Recently-closed can be added as a follow-up with a keyboard shortcut (Cmd+Shift+T) trigger.
+
+---
+
+## Task 17: Integration Verification
+
+- [ ] **Step 1: Run all tests**
+
+Run: `cd spa && npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 2: Run lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: No errors
+
+- [ ] **Step 3: Run build**
+
+Run: `cd spa && pnpm run build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Manual smoke test checklist (Electron)**
+
+- Open app → create browser tab → toolbar visible with ← → ↻ URL ⋯
+- Navigate to a URL → URL bar updates, back button enables
+- Click back → navigates back, forward enables
+- Click ↻ → page reloads, button switches to ✕ during load
+- Edit URL bar → Enter → navigates to new URL
+- ⋯ menu → "Open in browser" → opens system browser
+- ⋯ menu → "Copy URL" → clipboard has URL
+- ⋯ menu → "Open in mini browser" → new window with same toolbar
+- Mini browser → ⋯ → "Open in main window" → new tab in main, mini closes
+- Terminal → click link → opens new browser tab
+- Terminal → shift+click link → opens mini browser window
+- Close browser tab → close works properly
+
+- [ ] **Step 5: Final commit if any fixes needed**

--- a/docs/superpowers/specs/2026-04-07-browser-tab-enhancement-design.md
+++ b/docs/superpowers/specs/2026-04-07-browser-tab-enhancement-design.md
@@ -1,0 +1,407 @@
+# Browser Tab Enhancement 設計規格
+
+## 範圍
+
+兩個功能：
+
+1. **Browser tab 完整 toolbar** — 導航按鈕、可編輯 URL 欄位、更多選單
+2. **Mini browser 獨立視窗** — Shift+click 彈出，共用同一套 toolbar component
+
+**不在範圍內：**
+- 完整 tab tear-off（跨視窗拖曳、狀態同步）
+- WebContentsView 跨視窗搬移（V1 用重新載入取代）
+
+**已知取捨：**
+- 從 browser tab 彈出 mini browser 時，主視窗 tab 繼續存在（兩個 WebContentsView 並行，記憶體 double），V1 不處理此問題
+
+## 連結點擊行為
+
+統一規則，適用所有連結來源：
+
+| 環境 | 來源 | Click | Shift+Click |
+|------|------|-------|-------------|
+| Electron | Terminal 連結 | 開新 browser tab | 彈出 mini browser 視窗 |
+| Electron | Browser tab 內 `target=_blank` 連結 | 開新 browser tab | 彈出 mini browser 視窗 |
+| Electron | Browser tab 內一般連結 | 正常導航（不攔截） | 正常導航（不攔截） |
+| SPA | Terminal 連結 | `window.open(uri, '_blank')` | `window.open(uri, '_blank')` |
+
+SPA 環境下 browser tab 不可用，所有連結一律開系統瀏覽器新分頁。
+
+**Browser tab 內連結的攔截規則：** 只攔截 `target=_blank`（透過 Electron 的 `setWindowOpenHandler`）。一般頁面內導航走正常 `will-navigate` 流程，不攔截。
+
+## BrowserToolbar Component
+
+共用元件，同時用在 browser tab（inline）和 mini browser 視窗。純 props-driven，不直接呼叫 IPC。
+
+### Props 介面
+
+```typescript
+interface BrowserToolbarProps {
+  url: string
+  title: string
+  canGoBack: boolean
+  canGoForward: boolean
+  isLoading: boolean
+  context: 'tab' | 'mini-window'     // 控制選單項目顯示
+  onGoBack: () => void
+  onGoForward: () => void
+  onReload: () => void
+  onStop: () => void
+  onNavigate: (url: string) => void   // URL 欄位 Enter
+  onOpenExternal: () => void          // 系統瀏覽器開啟（直接用 url prop）
+  onCopyUrl: () => void
+  onPopOut?: () => void               // 彈出成 mini browser（僅 context='tab'）
+  onMoveToTab?: () => void            // 在主視窗重新開啟此網址（僅 context='mini-window'）
+}
+```
+
+### 組成
+
+| 區域 | 元素 | 功能 |
+|------|------|------|
+| 左側 | ← → ↻/✕ 按鈕 | goBack / goForward / reload（載入中切換為 stop） |
+| 中間 | URL 欄位 | 顯示當前 URL，可編輯 + Enter 導航（見 URL 正規化規則） |
+| 右側 | ⋯ 更多選單 | 下拉選單 |
+
+所有 icon 統一使用 Phosphor Icons。Reload 與 Stop 按鈕依 `isLoading` 狀態交替顯示，比照瀏覽器行為。
+
+### ⋯ 選單項目
+
+- 在系統瀏覽器開啟
+- 複製 URL
+- 彈出成 mini browser 視窗（僅 `context='tab'` 顯示）
+- 在主視窗重新開啟此網址（僅 `context='mini-window'` 顯示）
+
+### URL 正規化
+
+URL 欄位 Enter 觸發 `onNavigate(url)` 前，先做正規化：
+- 無 scheme 的字串（如 `github.com`）→ 自動補 `https://`
+- `javascript:` scheme → 拒絕（不觸發 onNavigate）
+- 非 `http:` / `https:` scheme → 拒絕（不觸發 onNavigate）
+
+此邏輯與現有 `BrowserNewTabSection.tsx` 的 URL 驗證一致，可抽為共用 utility。
+
+### 導航按鈕狀態
+
+- ← disabled 當 `canGoBack === false`
+- → disabled 當 `canGoForward === false`
+
+## BrowserPane 佈局變更
+
+現有 `BrowserPane.tsx` 的 `ResizeObserver` 把整個 div 的 bounds 推給 Electron。加入 toolbar 後需要調整：
+
+1. BrowserPane 頂部渲染 `BrowserToolbar`，下方為 `WebContentsView` 佔位區
+2. `ResizeObserver` 觀察的是**佔位區**（不含 toolbar），推送的 bounds 是佔位區的位置和大小
+3. toolbar 高度固定（不隨 WebContentsView 縮放），避免 WebContentsView 遮住 toolbar
+
+## Electron 架構變更
+
+### 新增 IPC 頻道
+
+IPC 頻道名稱（snake-case）與 preload 函式名稱（camelCase）一對一對應。
+
+| 方向 | IPC 頻道 | Preload 函式 | 用途 |
+|------|----------|-------------|------|
+| SPA → Electron | `browser-view:go-back` | `browserViewGoBack` | 上一頁 |
+| SPA → Electron | `browser-view:go-forward` | `browserViewGoForward` | 下一頁 |
+| SPA → Electron | `browser-view:reload` | `browserViewReload` | 重新整理 |
+| SPA → Electron | `browser-view:stop` | `browserViewStop` | 停止載入 |
+| SPA → Electron | `browser-view:open-mini-window` | `browserViewOpenMiniWindow` | 彈出 mini browser 視窗 |
+| SPA → Electron | `browser-view:destroy` | `destroyBrowserView` | 主動關閉 tab 時銷毀 view |
+| SPA → Electron | `browser-view:move-to-tab` | `browserViewMoveToTab` | mini browser「在主視窗重新開啟此網址」 |
+| Electron → SPA | `browser-view:state-update` | `onBrowserViewStateUpdate` | 回報導航狀態 |
+| Electron → SPA | `browser-view:open-in-tab` | `onBrowserViewOpenInTab` | 主視窗收到：開新 browser tab |
+| WebContentsView → Electron | `browser-view:link-click` | （preload 內部） | 頁面內連結點擊回報 shiftKey + URL |
+
+**不需要 IPC 的操作：**
+- **在系統瀏覽器開啟** — toolbar 已持有 URL，SPA 端直接 `window.open(url, '_blank')` 即可
+
+**`browser-view:close` vs `browser-view:destroy` 語意區分：**
+- `browser-view:close`（現有）→ `background()` — 用於 tab 切換時 BrowserPane unmount，view 保留在背景
+- `browser-view:destroy`（新增）→ `destroy()` — 用於使用者主動關閉 tab，真正銷毀 view
+
+### State Update 機制
+
+Electron 監聽 `WebContentsView` 事件（`did-navigate`、`did-start-loading`、`did-stop-loading`、`page-title-updated` 等），彙整為 `BrowserViewState` 透過 `viewEntry.window.webContents.send()` 推給**該 view 所屬 window** 的 SPA。
+
+```typescript
+interface BrowserViewState {
+  url: string
+  title: string
+  canGoBack: boolean
+  canGoForward: boolean
+  isLoading: boolean
+}
+```
+
+推送時帶 `paneId`，SPA 端的 `useBrowserViewState(paneId)` hook 過濾只處理自己的 paneId。
+
+### Browser Tab 內連結攔截（shiftKey 問題）
+
+Electron 的 `will-navigate` 和 `setWindowOpenHandler` 事件不包含 modifier keys。解決方案：
+
+為 `WebContentsView` 設定專用 preload script，在頁面層攔截 `click` 事件：
+
+```javascript
+// browser-view-preload.ts（注入到 WebContentsView，需在 electron-vite 打包為 CJS）
+const { ipcRenderer } = require('electron')
+
+document.addEventListener('click', (e) => {
+  const link = e.target.closest('a[href]')
+  if (!link) return
+  const href = link.href
+  if (!href || href.startsWith('javascript:')) return
+
+  if (e.shiftKey || link.target === '_blank') {
+    e.preventDefault()
+    ipcRenderer.send('browser-view:link-click', {
+      url: href,
+      shiftKey: e.shiftKey,
+      targetBlank: link.target === '_blank',
+    })
+  }
+  // 一般連結不攔截，走正常導航
+}, true)
+```
+
+**打包設定：** `electron.vite.config.ts` 的 preload section 需新增第二個 entry：
+
+```typescript
+preload: {
+  build: {
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'electron/preload.ts'),
+        browserViewPreload: resolve(__dirname, 'electron/browser-view-preload.ts'),
+      },
+    },
+  },
+},
+```
+
+`BrowserViewManager` 建立 `WebContentsView` 時，透過 `join(__dirname, '../preload/browserViewPreload.js')` 引用打包後的路徑設定 `webPreferences.preload`。
+
+**sender 反查機制：** Main process 收到 `browser-view:link-click` 時，`event.sender` 是 WebContentsView 的 webContents（不是 BrowserWindow 的）。`BrowserViewManager` 需新增反查方法：
+
+```typescript
+getEntryByWebContents(wc: WebContents): ViewEntry | undefined
+```
+
+透過遍歷 `views` Map 比對 `entry.view.webContents === wc` 實現。取得 entry 後即可知道 paneId 和所屬 window，進而通知正確的主視窗 SPA 開新 tab。
+
+### Mini Browser 視窗
+
+**建立方式：** 新建 Electron `BrowserWindow`，載入獨立的 SPA entry point。
+
+**SPA Entry Point：** 新增 `spa/src/mini-browser.tsx` 作為 mini browser 的獨立 entry（Vite multi-entry），搭配 `spa/mini-browser.html` 作為 HTML 入口。這個 entry 只渲染 `BrowserToolbar` + `WebContentsView` 佔位 div，不載入完整 App（無 tab bar、sidebar 等）。透過 URL query parameter 傳入 `paneId`（如 `mini-browser.html?paneId=xxx`）。
+
+**Vite 打包設定：** `electron.vite.config.ts` 的 renderer section 需擴充 `rollupOptions.input`：
+
+```typescript
+renderer: {
+  build: {
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'spa/index.html'),
+        miniBrowser: resolve(__dirname, 'spa/mini-browser.html'),
+      },
+    },
+  },
+},
+```
+
+**載入路徑：**
+- Dev 模式：`http://100.64.0.2:5174/mini-browser.html?paneId=xxx`
+- Bundled 模式：`app://./mini-browser.html?paneId=xxx`
+
+**生命週期：**
+- `mini-browser-window.ts` 建立 `BrowserWindow` + `WebContentsView`，記錄 parent window reference
+- 視窗關閉時 destroy `WebContentsView`，從 `BrowserViewManager` 移除
+- 「在主視窗重新開啟此網址」：見下方 IPC 路徑說明
+
+**Mini window SPA 如何知道自己的 paneId：** 從 `window.location.search` 的 `paneId` query parameter 讀取，由 `mini-browser-window.ts` 建立視窗時帶入 URL。
+
+**「在主視窗重新開啟此網址」IPC 路徑：**
+
+Mini window SPA 無法直接存取主視窗的 tab store，需要完整的 IPC 鏈：
+
+1. Mini window SPA → main process：`browserViewMoveToTab(paneId)` IPC（preload 暴露）
+2. Main process 從 `MiniWindowManager` 查詢 paneId 對應的 parent window 和當前 URL
+3. Main process → 主視窗 SPA：`parentWindow.webContents.send('browser-view:open-in-tab', url)`
+4. 主視窗 SPA 監聽 `browser-view:open-in-tab` 事件，呼叫 `openBrowserTab(url)`
+5. Main process 關閉 mini window + destroy WebContentsView
+
+## xterm.js 連結攔截
+
+### 變更
+
+`useTerminal.ts` 的 `WebLinksAddon` 改為傳入自訂 handler：
+
+```typescript
+new WebLinksAddon((event, uri) => {
+  linkHandler(event, uri)
+})
+```
+
+`linkHandler` 由上層傳入（`useTerminal` 接受 `linkHandler` 參數），不在 hook 內部處理。
+
+### link-handler.ts
+
+建立連結處理函式的 factory，接受 callback 參數，保持 `lib/` 模組不直接依賴 store：
+
+```typescript
+interface LinkHandlerDeps {
+  isElectron: boolean
+  openBrowserTab: (url: string) => void
+  openMiniWindow: (url: string) => void
+}
+
+function createLinkHandler(deps: LinkHandlerDeps) {
+  return (event: MouseEvent, uri: string) => {
+    if (deps.isElectron) {
+      if (event.shiftKey) deps.openMiniWindow(uri)
+      else deps.openBrowserTab(uri)
+    } else {
+      window.open(uri, '_blank')
+    }
+  }
+}
+```
+
+呼叫端（TerminalView 等）負責接線：將 `openBrowserTab` 綁到 tab store action，`openMiniWindow` 綁到 Electron IPC。
+
+## 模組劃分
+
+```
+spa/src/
+├── components/
+│   └── BrowserToolbar.tsx        # 共用 toolbar（純 UI，props-driven）
+│
+├── hooks/
+│   ├── useTerminal.ts            # 現有，改為接受 linkHandler 參數
+│   └── useBrowserViewState.ts    # 訂閱 Electron state-update，以 paneId 過濾
+│
+├── lib/
+│   └── link-handler.ts           # createLinkHandler factory（純函式，不依賴 store）
+│
+├── mini-browser.tsx              # Mini browser 獨立 entry point（Vite multi-entry）
+│
+electron/
+├── browser-view-manager.ts       # 現有，擴充導航 API + state 回報 + preload script 注入
+├── browser-view-ipc.ts           # 新增，集中註冊 browser-view IPC handler
+├── browser-view-preload.ts       # 新增，注入 WebContentsView 攔截連結 click（electron-vite 打包為 CJS）
+└── mini-browser-window.ts        # 新增，mini browser 視窗建立與生命週期
+```
+
+### 各模組職責
+
+| 模組 | 職責 | 依賴 |
+|------|------|------|
+| `BrowserToolbar` | 渲染 ← → ↻/✕ URL ⋯，觸發 callback | 無外部依賴，純 props |
+| `useBrowserViewState(paneId)` | 監聯 IPC state-update，以 paneId 過濾，回傳 `BrowserViewState`。IPC listener 必須在 `useEffect` cleanup 中透過 unsubscribe function 移除，避免 Strict Mode double-mount 殭屍 listener | Electron preload API |
+| `link-handler.ts` | `createLinkHandler(deps)` factory — 根據 platform + shiftKey 分派 | 無（deps 由呼叫端注入） |
+| `mini-browser.tsx` | Mini browser SPA entry，只渲染 toolbar + 佔位 div | BrowserToolbar、useBrowserViewState |
+| `browser-view-ipc.ts` | export `registerBrowserViewIpc(manager, miniWindowManager)` 由 `main.ts` 呼叫 | browser-view-manager、mini-browser-window |
+| `browser-view-preload.ts` | 注入 WebContentsView，攔截 click 事件回報 shiftKey + URL。需作為 electron-vite preload entry 打包（CJS） | Electron ipcRenderer |
+| `mini-browser-window.ts` | 建立/管理 mini browser BrowserWindow，記錄 parent window reference，URL 帶入 paneId | Electron BrowserWindow |
+| `browser-view-manager.ts` | 現有 + goBack/goForward/reload/stop + destroy() + 監聽 webContents 推 state + 注入 preload + `getEntryByWebContents()` 反查 | Electron WebContentsView |
+
+### 設計原則
+
+- `BrowserToolbar` 完全 props-driven，不直接呼叫 IPC，由使用端接線
+- `link-handler.ts` 是 factory，不依賴 store，由呼叫端注入 dependencies
+- Electron 端 IPC 集中在 `browser-view-ipc.ts`，`main.ts` 只呼叫 `registerBrowserViewIpc()`
+- `state-update` 推送到 view 所屬 window，hook 以 paneId 過濾
+
+## Preload API 擴充
+
+### 現有
+
+```typescript
+openBrowserView(url: string, paneId: string): void
+closeBrowserView(paneId: string): void
+navigateBrowserView(paneId: string, url: string): void
+resizeBrowserView(paneId: string, bounds: Bounds): void
+```
+
+### 新增
+
+```typescript
+// 導航控制
+browserViewGoBack(paneId: string): void
+browserViewGoForward(paneId: string): void
+browserViewReload(paneId: string): void
+browserViewStop(paneId: string): void
+
+// 視窗操作
+browserViewOpenMiniWindow(url: string): void
+destroyBrowserView(paneId: string): void          // 主動關閉 tab 時銷毀
+browserViewMoveToTab(paneId: string): void         // mini browser → 在主視窗重新開啟
+
+// 狀態訂閱（Electron → SPA）
+onBrowserViewStateUpdate(
+  callback: (paneId: string, state: BrowserViewState) => void
+): () => void   // 回傳 unsubscribe function
+
+// 主視窗接收（Electron → SPA）
+onBrowserViewOpenInTab(
+  callback: (url: string) => void
+): () => void   // 回傳 unsubscribe function
+```
+
+**「在系統瀏覽器開啟」** 不需要新 IPC — toolbar 已持有 URL，SPA 端直接 `window.open(url, '_blank')` 即可。
+
+## PaneContent 型別
+
+不需變更。現有 `{ kind: 'browser'; url: string }` 已足夠，`url` 為初始 URL。
+
+### Tab Store 新增 Action
+
+```typescript
+openBrowserTab(url: string): void
+```
+
+此 action 放在 hook 層（`useTabWorkspaceActions`），不放在 `useTabStore` store 層。原因：workspace 整合邏輯（`addTabToWorkspace`、`setWorkspaceActiveTab`）在現有架構中由 hook 層完成（參考 `handleAddTab`），store 層不直接跨 store 呼叫。
+
+`openBrowserTab` 內部流程：建立新 tab（content `{ kind: 'browser', url }`）→ 加入當前 workspace → 設為 active。
+
+### Tab Title 顯示
+
+- 來源：`BrowserViewState.title`（Electron 回報的頁面 title）
+- Fallback：URL 的 hostname（如 `github.com`）
+- Icon：Phosphor `Globe`（需確認 `TabBar.tsx` 的 ICON_MAP 包含 `Globe`）
+
+## Browser Tab 關閉復原
+
+### 關閉時 Snapshot
+
+Browser tab 關閉前，從 Electron 取得當前 URL 和 title：
+
+```typescript
+interface BrowserTabSnapshot {
+  url: string    // 當前 URL
+  title: string  // 頁面 title
+}
+```
+
+V1 不存導航歷史（`navigationHistory` API 可用性有版本風險，且目前無法注入歷史復原）。
+
+### 關閉路徑
+
+使用者主動關閉 browser tab 時：
+1. 從 `BrowserViewManager` 取得當前 `BrowserViewState`（url + title）
+2. 存入 recently-closed store
+3. 透過 `destroyBrowserView(paneId)` IPC 呼叫 `BrowserViewManager.destroy(paneId)`（真正銷毀 view）
+
+**與 tab 切換路徑的區分：**
+- Tab 切換（BrowserPane unmount）→ `closeBrowserView(paneId)` → `background()`（view 保留在背景）
+- 使用者主動關閉 tab → `destroyBrowserView(paneId)` → `destroy()`（view 銷毀）
+- Idle discard → `background()` → 超時 → `discard()`（快照 URL 後銷毀，可復原）
+
+### 儲存
+
+存在記憶體中的 recently-closed store。App 重啟後不保留（與瀏覽器行為一致）。
+
+### 復原
+
+建立新 browser tab，`url` 設為 snapshot 的 URL。頁面重新載入（不保留滾動位置等狀態）。

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -61,7 +61,10 @@ export default defineConfig({
       outDir: 'out/preload',
       // Preload must be CJS (.js) — Electron sandbox does not support ESM preloads
       rollupOptions: {
-        input: { index: resolve(__dirname, 'electron/preload.ts') },
+        input: {
+          index: resolve(__dirname, 'electron/preload.ts'),
+          browserViewPreload: resolve(__dirname, 'electron/browser-view-preload.ts'),
+        },
         external: ['electron'],
         output: { format: 'cjs', entryFileNames: '[name].js' },
       },
@@ -73,7 +76,10 @@ export default defineConfig({
     build: {
       outDir: resolve(__dirname, 'out/renderer'),
       rollupOptions: {
-        input: resolve(__dirname, 'spa/index.html'),
+        input: {
+          index: resolve(__dirname, 'spa/index.html'),
+          'mini-browser': resolve(__dirname, 'spa/mini-browser.html'),
+        },
       },
     },
   },

--- a/electron/browser-view-ipc.ts
+++ b/electron/browser-view-ipc.ts
@@ -1,0 +1,84 @@
+import { ipcMain, BrowserWindow } from 'electron'
+import type { BrowserViewManager } from './browser-view-manager'
+import type { MiniWindowManager } from './mini-browser-window'
+
+export function registerBrowserViewIpc(
+  manager: BrowserViewManager,
+  miniWindowManager: MiniWindowManager,
+): void {
+  // --- Existing handlers (moved from main.ts) ---
+
+  ipcMain.handle('browser-view:open', (event, url: string, paneId: string) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (win) manager.open(win, url, paneId)
+  })
+
+  ipcMain.handle('browser-view:close', (_event, paneId: string) => {
+    manager.background(paneId)
+  })
+
+  ipcMain.handle('browser-view:navigate', (_event, paneId: string, url: string) => {
+    manager.navigate(paneId, url)
+  })
+
+  ipcMain.handle('browser-view:resize', (_event, paneId: string, boundsJson: string) => {
+    try {
+      const raw = JSON.parse(boundsJson)
+      manager.resize(paneId, {
+        x: Math.round(Number(raw.x)) || 0,
+        y: Math.round(Number(raw.y)) || 0,
+        width: Math.max(1, Math.round(Number(raw.width)) || 1),
+        height: Math.max(1, Math.round(Number(raw.height)) || 1),
+      })
+    } catch { /* ignore malformed bounds JSON */ }
+  })
+
+  // --- New navigation handlers ---
+
+  ipcMain.handle('browser-view:go-back', (_event, paneId: string) => {
+    manager.goBack(paneId)
+  })
+
+  ipcMain.handle('browser-view:go-forward', (_event, paneId: string) => {
+    manager.goForward(paneId)
+  })
+
+  ipcMain.handle('browser-view:reload', (_event, paneId: string) => {
+    manager.reload(paneId)
+  })
+
+  ipcMain.handle('browser-view:stop', (_event, paneId: string) => {
+    manager.stop(paneId)
+  })
+
+  ipcMain.handle('browser-view:destroy', (_event, paneId: string) => {
+    manager.destroy(paneId)
+  })
+
+  // --- Mini browser window ---
+
+  ipcMain.handle('browser-view:open-mini-window', (event, url: string) => {
+    const parentWin = BrowserWindow.fromWebContents(event.sender)
+    if (parentWin) miniWindowManager.open(parentWin, url)
+  })
+
+  ipcMain.handle('browser-view:move-to-tab', (_event, paneId: string) => {
+    miniWindowManager.moveToTab(paneId)
+  })
+
+  // --- Link click from WebContentsView preload ---
+
+  ipcMain.on('browser-view:link-click', (event, data: { url: string; shiftKey: boolean; targetBlank: boolean }) => {
+    const entry = manager.getEntryByWebContents(event.sender)
+    if (!entry) return
+
+    if (data.shiftKey) {
+      miniWindowManager.open(entry.window, data.url)
+    } else {
+      // Notify parent window SPA to open new browser tab
+      try {
+        entry.window.webContents.send('browser-view:open-in-tab', data.url)
+      } catch { /* window may be closed */ }
+    }
+  })
+}

--- a/electron/browser-view-ipc.ts
+++ b/electron/browser-view-ipc.ts
@@ -1,4 +1,5 @@
 import { ipcMain, BrowserWindow } from 'electron'
+import { isAllowedUrl } from './browser-view-manager'
 import type { BrowserViewManager } from './browser-view-manager'
 import type { MiniWindowManager } from './mini-browser-window'
 
@@ -71,6 +72,7 @@ export function registerBrowserViewIpc(
   ipcMain.on('browser-view:link-click', (event, data: { url: string; shiftKey: boolean; targetBlank: boolean }) => {
     const entry = manager.getEntryByWebContents(event.sender)
     if (!entry) return
+    if (!isAllowedUrl(data.url)) return
 
     if (data.shiftKey) {
       miniWindowManager.open(entry.window, data.url)

--- a/electron/browser-view-manager.ts
+++ b/electron/browser-view-manager.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 
 const ALLOWED_SCHEMES = new Set(['http:', 'https:'])
 
-function isAllowedUrl(url: string): boolean {
+export function isAllowedUrl(url: string): boolean {
   try {
     return ALLOWED_SCHEMES.has(new URL(url).protocol)
   } catch {
@@ -25,6 +25,7 @@ interface ViewEntry {
   window: BrowserWindow
   state: 'active' | 'background'
   lastActiveAt: number
+  cleanupListeners?: () => void
 }
 
 interface Snapshot {
@@ -120,6 +121,14 @@ export class BrowserViewManager {
     wc.on('did-stop-loading', pushState)
     wc.on('page-title-updated', pushState)
 
+    entry.cleanupListeners = () => {
+      wc.off('did-navigate', pushState)
+      wc.off('did-navigate-in-page', pushState)
+      wc.off('did-start-loading', pushState)
+      wc.off('did-stop-loading', pushState)
+      wc.off('page-title-updated', pushState)
+    }
+
     this.clearTimer(paneId)
   }
 
@@ -171,6 +180,7 @@ export class BrowserViewManager {
     const entry = this.views.get(paneId)
     if (!entry) return
     this.clearTimer(paneId)
+    entry.cleanupListeners?.()
     try {
       entry.window.contentView.removeChildView(entry.view)
     } catch { /* already removed */ }
@@ -249,6 +259,8 @@ export class BrowserViewManager {
   private discard(paneId: string): void {
     const entry = this.views.get(paneId)
     if (!entry) return
+
+    entry.cleanupListeners?.()
 
     if (entry.window.isDestroyed()) {
       // Window already closed — just clean up our references

--- a/electron/browser-view-manager.ts
+++ b/electron/browser-view-manager.ts
@@ -1,4 +1,5 @@
-import { WebContentsView, BrowserWindow, app } from 'electron'
+import { WebContentsView, BrowserWindow, app, type WebContents } from 'electron'
+import { join } from 'node:path'
 
 const ALLOWED_SCHEMES = new Set(['http:', 'https:'])
 
@@ -76,6 +77,7 @@ export class BrowserViewManager {
         contextIsolation: true,
         sandbox: true,
         backgroundThrottling: false, // Active — no throttling
+        preload: join(__dirname, '../preload/browserViewPreload.js'),
       },
     })
 
@@ -88,14 +90,35 @@ export class BrowserViewManager {
     win.contentView.addChildView(view)
     view.webContents.loadURL(loadUrl)
 
-    this.views.set(paneId, {
+    const entry: ViewEntry = {
       view,
       paneId,
       url: loadUrl,
       window: win,
       state: 'active',
       lastActiveAt: Date.now(),
-    })
+    }
+    this.views.set(paneId, entry)
+
+    // Push state updates to the SPA in the owning window
+    const wc = view.webContents
+    const pushState = () => {
+      try {
+        if (entry.window.isDestroyed() || wc.isDestroyed()) return
+        entry.window.webContents.send('browser-view:state-update', paneId, {
+          url: wc.getURL(),
+          title: wc.getTitle(),
+          canGoBack: wc.canGoBack(),
+          canGoForward: wc.canGoForward(),
+          isLoading: wc.isLoading(),
+        })
+      } catch { /* window or webContents may be closed */ }
+    }
+    wc.on('did-navigate', pushState)
+    wc.on('did-navigate-in-page', pushState)
+    wc.on('did-start-loading', pushState)
+    wc.on('did-stop-loading', pushState)
+    wc.on('page-title-updated', pushState)
 
     this.clearTimer(paneId)
   }
@@ -117,6 +140,59 @@ export class BrowserViewManager {
     const entry = this.views.get(paneId)
     if (entry) {
       entry.view.setBounds(bounds)
+    }
+  }
+
+  goBack(paneId: string): void {
+    const entry = this.views.get(paneId)
+    if (entry?.view.webContents.canGoBack()) {
+      entry.view.webContents.goBack()
+    }
+  }
+
+  goForward(paneId: string): void {
+    const entry = this.views.get(paneId)
+    if (entry?.view.webContents.canGoForward()) {
+      entry.view.webContents.goForward()
+    }
+  }
+
+  reload(paneId: string): void {
+    const entry = this.views.get(paneId)
+    entry?.view.webContents.reload()
+  }
+
+  stop(paneId: string): void {
+    const entry = this.views.get(paneId)
+    entry?.view.webContents.stop()
+  }
+
+  destroy(paneId: string): void {
+    const entry = this.views.get(paneId)
+    if (!entry) return
+    this.clearTimer(paneId)
+    try {
+      entry.window.contentView.removeChildView(entry.view)
+    } catch { /* already removed */ }
+    try {
+      entry.view.webContents.close()
+    } catch { /* already closed */ }
+    this.views.delete(paneId)
+  }
+
+  getEntryByWebContents(wc: WebContents): ViewEntry | undefined {
+    for (const entry of this.views.values()) {
+      if (entry.view.webContents === wc) return entry
+    }
+    return undefined
+  }
+
+  getCurrentState(paneId: string): { url: string; title: string } | undefined {
+    const entry = this.views.get(paneId)
+    if (!entry || entry.view.webContents.isDestroyed()) return undefined
+    return {
+      url: entry.view.webContents.getURL(),
+      title: entry.view.webContents.getTitle(),
     }
   }
 

--- a/electron/browser-view-preload.ts
+++ b/electron/browser-view-preload.ts
@@ -1,0 +1,22 @@
+import { ipcRenderer } from 'electron'
+
+document.addEventListener(
+  'click',
+  (e: MouseEvent) => {
+    const link = (e.target as HTMLElement).closest('a[href]') as HTMLAnchorElement | null
+    if (!link) return
+    const href = link.href
+    if (!href || href.startsWith('javascript:')) return
+
+    if (e.shiftKey || link.target === '_blank') {
+      e.preventDefault()
+      ipcRenderer.send('browser-view:link-click', {
+        url: href,
+        shiftKey: e.shiftKey,
+        targetBlank: link.target === '_blank',
+      })
+    }
+    // Normal links: don't intercept, let will-navigate handle
+  },
+  true,
+)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,6 +2,8 @@ import { app, BrowserWindow, ipcMain, Menu, Notification, protocol, net } from '
 import { join } from 'path'
 import { WindowManager } from './window-manager'
 import { BrowserViewManager } from './browser-view-manager'
+import { MiniWindowManager } from './mini-browser-window'
+import { registerBrowserViewIpc } from './browser-view-ipc'
 import { createTray } from './tray'
 import { getAppInfo, checkUpdate, applyUpdate } from './updater'
 import { getDefaultKeybindings, buildMenuTemplate } from './keybindings'
@@ -15,6 +17,7 @@ protocol.registerSchemesAsPrivileged([{
 
 const windowManager = new WindowManager()
 const browserViewManager = new BrowserViewManager()
+const miniWindowManager = new MiniWindowManager(browserViewManager, windowManager)
 windowManager.setOnWindowClosed((win) => browserViewManager.cleanupForWindow(win))
 let metricsInterval: ReturnType<typeof setInterval> | null = null
 let updateInProgress = false
@@ -31,28 +34,8 @@ function registerIpcHandlers(): void {
     return windowManager.getAll()
   })
 
-  // Browser View
-  ipcMain.handle('browser-view:open', (event, url: string, paneId: string) => {
-    const win = BrowserWindow.fromWebContents(event.sender)
-    if (win) browserViewManager.open(win, url, paneId)
-  })
-  ipcMain.handle('browser-view:close', (_event, paneId: string) => {
-    browserViewManager.background(paneId)
-  })
-  ipcMain.handle('browser-view:navigate', (_event, paneId: string, url: string) => {
-    browserViewManager.navigate(paneId, url)
-  })
-  ipcMain.handle('browser-view:resize', (_event, paneId: string, boundsJson: string) => {
-    try {
-      const raw = JSON.parse(boundsJson)
-      browserViewManager.resize(paneId, {
-        x: Math.round(Number(raw.x)) || 0,
-        y: Math.round(Number(raw.y)) || 0,
-        width: Math.max(1, Math.round(Number(raw.width)) || 1),
-        height: Math.max(1, Math.round(Number(raw.height)) || 1),
-      })
-    } catch { /* ignore malformed bounds JSON */ }
-  })
+  // Browser View — delegated to browser-view-ipc.ts
+  registerBrowserViewIpc(browserViewManager, miniWindowManager)
 
   // Memory Monitor
   ipcMain.handle('metrics:get', () => {
@@ -187,5 +170,6 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   if (metricsInterval) clearInterval(metricsInterval)
+  miniWindowManager.closeAll()
   browserViewManager.destroyAll()
 })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,7 +17,7 @@ protocol.registerSchemesAsPrivileged([{
 
 const windowManager = new WindowManager()
 const browserViewManager = new BrowserViewManager()
-const miniWindowManager = new MiniWindowManager(browserViewManager, windowManager)
+const miniWindowManager = new MiniWindowManager(browserViewManager)
 windowManager.setOnWindowClosed((win) => browserViewManager.cleanupForWindow(win))
 let metricsInterval: ReturnType<typeof setInterval> | null = null
 let updateInProgress = false

--- a/electron/mini-browser-window.ts
+++ b/electron/mini-browser-window.ts
@@ -1,0 +1,85 @@
+import { BrowserWindow } from 'electron'
+import { join } from 'node:path'
+import type { BrowserViewManager } from './browser-view-manager'
+
+interface MiniWindowEntry {
+  window: BrowserWindow
+  paneId: string
+  parentWindow: BrowserWindow
+}
+
+const DEV_SERVER = 'http://100.64.0.2:5174'
+
+export class MiniWindowManager {
+  private entries = new Map<string, MiniWindowEntry>()
+  private nextId = 0
+
+  constructor(
+    private viewManager: BrowserViewManager,
+    // WindowManager type not imported to avoid circular — only need DEV_SERVER pattern
+  ) {}
+
+  open(parentWindow: BrowserWindow, url: string): void {
+    const paneId = `mini-${++this.nextId}`
+
+    const win = new BrowserWindow({
+      width: 800,
+      height: 600,
+      titleBarStyle: 'hiddenInset',
+      trafficLightPosition: { x: 12, y: 12 },
+      webPreferences: {
+        contextIsolation: true,
+        sandbox: true,
+        nodeIntegration: false,
+        preload: join(__dirname, '../preload/index.js'),
+      },
+    })
+
+    this.entries.set(paneId, { window: win, paneId, parentWindow })
+
+    // Load mini browser SPA entry
+    const query = `?paneId=${encodeURIComponent(paneId)}`
+    fetch(DEV_SERVER, { signal: AbortSignal.timeout(500) })
+      .then(() => win.loadURL(`${DEV_SERVER}/mini-browser.html${query}`))
+      .catch(() => win.loadURL(`app://./mini-browser.html${query}`))
+
+    // Once SPA is ready, open the WebContentsView
+    win.webContents.once('did-finish-load', () => {
+      this.viewManager.open(win, url, paneId)
+    })
+
+    // Cleanup on window close
+    win.on('closed', () => {
+      this.viewManager.destroy(paneId)
+      this.entries.delete(paneId)
+    })
+  }
+
+  moveToTab(paneId: string): void {
+    const entry = this.entries.get(paneId)
+    if (!entry) return
+
+    const state = this.viewManager.getCurrentState(paneId)
+    const url = state?.url || ''
+
+    // Notify parent window SPA to open new tab
+    try {
+      if (!entry.parentWindow.isDestroyed()) {
+        entry.parentWindow.webContents.send('browser-view:open-in-tab', url)
+      }
+    } catch { /* parent window may be closed */ }
+
+    // Close mini window (triggers 'closed' event → cleanup)
+    if (!entry.window.isDestroyed()) {
+      entry.window.close()
+    }
+  }
+
+  closeAll(): void {
+    for (const entry of this.entries.values()) {
+      if (!entry.window.isDestroyed()) {
+        entry.window.close()
+      }
+    }
+  }
+}

--- a/electron/mini-browser-window.ts
+++ b/electron/mini-browser-window.ts
@@ -45,6 +45,7 @@ export class MiniWindowManager {
 
     // Once SPA is ready, open the WebContentsView
     win.webContents.once('did-finish-load', () => {
+      if (win.isDestroyed()) return
       this.viewManager.open(win, url, paneId)
     })
 
@@ -60,7 +61,8 @@ export class MiniWindowManager {
     if (!entry) return
 
     const state = this.viewManager.getCurrentState(paneId)
-    const url = state?.url || ''
+    const url = state?.url
+    if (!url) return  // View not yet loaded — nothing to move
 
     // Notify parent window SPA to open new tab
     try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -13,7 +13,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('tab:received', handler)
   },
 
-  // Browser View
+  // Browser View — existing
   openBrowserView: (url: string, paneId: string) =>
     ipcRenderer.invoke('browser-view:open', url, paneId),
   closeBrowserView: (paneId: string) =>
@@ -22,6 +22,41 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('browser-view:navigate', paneId, url),
   resizeBrowserView: (paneId: string, bounds: { x: number; y: number; width: number; height: number }) =>
     ipcRenderer.invoke('browser-view:resize', paneId, JSON.stringify(bounds)),
+
+  // Browser View — navigation
+  browserViewGoBack: (paneId: string) =>
+    ipcRenderer.invoke('browser-view:go-back', paneId),
+  browserViewGoForward: (paneId: string) =>
+    ipcRenderer.invoke('browser-view:go-forward', paneId),
+  browserViewReload: (paneId: string) =>
+    ipcRenderer.invoke('browser-view:reload', paneId),
+  browserViewStop: (paneId: string) =>
+    ipcRenderer.invoke('browser-view:stop', paneId),
+
+  // Browser View — lifecycle
+  destroyBrowserView: (paneId: string) =>
+    ipcRenderer.invoke('browser-view:destroy', paneId),
+
+  // Browser View — mini window
+  browserViewOpenMiniWindow: (url: string) =>
+    ipcRenderer.invoke('browser-view:open-mini-window', url),
+  browserViewMoveToTab: (paneId: string) =>
+    ipcRenderer.invoke('browser-view:move-to-tab', paneId),
+
+  // Browser View — state subscription (Electron → SPA)
+  onBrowserViewStateUpdate: (callback: (paneId: string, state: unknown) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, paneId: string, state: unknown) =>
+      callback(paneId, state)
+    ipcRenderer.on('browser-view:state-update', handler)
+    return () => ipcRenderer.removeListener('browser-view:state-update', handler)
+  },
+
+  // Browser View — open in tab (from mini browser or WebContentsView link click)
+  onBrowserViewOpenInTab: (callback: (url: string) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, url: string) => callback(url)
+    ipcRenderer.on('browser-view:open-in-tab', handler)
+    return () => ipcRenderer.removeListener('browser-view:open-in-tab', handler)
+  },
 
   // SPA ready signal
   signalReady: () => ipcRenderer.send('spa:ready'),

--- a/spa/mini-browser.html
+++ b/spa/mini-browser.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mini Browser</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/mini-browser.tsx"></script>
+  </body>
+</html>

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -13,6 +13,7 @@ import { useRelayWsManager } from './hooks/useRelayWsManager'
 import { useMultiHostEventWs } from './hooks/useMultiHostEventWs'
 import { useRouteSync } from './hooks/useRouteSync'
 import { useShortcuts } from './hooks/useShortcuts'
+import { openBrowserTab } from './lib/open-browser-tab'
 import { useNotificationDispatcher } from './hooks/useNotificationDispatcher'
 import { useUndoToast } from './stores/useUndoToast'
 import { useTabWorkspaceActions } from './hooks/useTabWorkspaceActions'
@@ -118,6 +119,14 @@ export default function App() {
           useWorkspaceStore.getState().insertTab(tab.id)
         }
       } catch { /* ignore malformed tab JSON */ }
+    })
+  }, [])
+
+  // --- Electron IPC: open browser tab from mini browser / WebContentsView link click ---
+  useEffect(() => {
+    if (!window.electronAPI?.onBrowserViewOpenInTab) return
+    return window.electronAPI.onBrowserViewOpenInTab((url: string) => {
+      openBrowserTab(url)
     })
   }, [])
 

--- a/spa/src/components/BrowserPane.tsx
+++ b/spa/src/components/BrowserPane.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useCallback } from 'react'
 import { useI18nStore } from '../stores/useI18nStore'
+import { BrowserToolbar } from './BrowserToolbar'
+import { useBrowserViewState } from '../hooks/useBrowserViewState'
 
 interface BrowserPaneProps {
   paneId: string
@@ -8,8 +10,12 @@ interface BrowserPaneProps {
 
 export function BrowserPane({ paneId, url }: BrowserPaneProps) {
   const t = useI18nStore((s) => s.t)
-  const ref = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
   const initialUrlRef = useRef(url)
+  const state = useBrowserViewState(paneId)
+
+  // Display URL: prefer live state, fallback to initial url prop
+  const currentUrl = state.url || url
 
   // Open/close lifecycle — mount/unmount only
   useEffect(() => {
@@ -26,23 +32,48 @@ export function BrowserPane({ paneId, url }: BrowserPaneProps) {
     window.electronAPI.navigateBrowserView(paneId, url)
   }, [url, paneId])
 
-  // Bounds sync via ResizeObserver
+  // Bounds sync via ResizeObserver — observe content area (below toolbar)
   useEffect(() => {
-    if (!window.electronAPI || !ref.current) return
+    const el = contentRef.current
+    if (!window.electronAPI || !el) return
+
+    let rafId = 0
     const observer = new ResizeObserver(() => {
-      const el = ref.current
-      if (!el) return
-      const rect = el.getBoundingClientRect()
-      window.electronAPI!.resizeBrowserView(paneId, {
-        x: Math.round(rect.x),
-        y: Math.round(rect.y),
-        width: Math.round(rect.width),
-        height: Math.round(rect.height),
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        const rect = el.getBoundingClientRect()
+        if (!rect.width || !rect.height) return
+        window.electronAPI!.resizeBrowserView(paneId, {
+          x: Math.round(rect.x),
+          y: Math.round(rect.y),
+          width: Math.round(rect.width),
+          height: Math.round(rect.height),
+        })
       })
     })
-    observer.observe(ref.current)
-    return () => observer.disconnect()
-  }, [paneId, url])
+    observer.observe(el)
+
+    return () => {
+      cancelAnimationFrame(rafId)
+      observer.disconnect()
+    }
+  }, [paneId])
+
+  // Toolbar callbacks
+  const handleGoBack = useCallback(() => window.electronAPI?.browserViewGoBack(paneId), [paneId])
+  const handleGoForward = useCallback(() => window.electronAPI?.browserViewGoForward(paneId), [paneId])
+  const handleReload = useCallback(() => window.electronAPI?.browserViewReload(paneId), [paneId])
+  const handleStop = useCallback(() => window.electronAPI?.browserViewStop(paneId), [paneId])
+  const handleNavigate = useCallback(
+    (newUrl: string) => window.electronAPI?.navigateBrowserView(paneId, newUrl),
+    [paneId],
+  )
+  const handleOpenExternal = useCallback(() => window.open(currentUrl, '_blank'), [currentUrl])
+  const handleCopyUrl = useCallback(() => { navigator.clipboard.writeText(currentUrl) }, [currentUrl])
+  const handlePopOut = useCallback(
+    () => window.electronAPI?.browserViewOpenMiniWindow(currentUrl),
+    [currentUrl],
+  )
 
   // SPA fallback
   if (!window.electronAPI) {
@@ -53,5 +84,26 @@ export function BrowserPane({ paneId, url }: BrowserPaneProps) {
     )
   }
 
-  return <div ref={ref} className="w-full h-full" data-browser-pane={paneId} />
+  return (
+    <div className="flex flex-col h-full" data-browser-pane={paneId}>
+      <BrowserToolbar
+        url={currentUrl}
+        title={state.title}
+        canGoBack={state.canGoBack}
+        canGoForward={state.canGoForward}
+        isLoading={state.isLoading}
+        context="tab"
+        onGoBack={handleGoBack}
+        onGoForward={handleGoForward}
+        onReload={handleReload}
+        onStop={handleStop}
+        onNavigate={handleNavigate}
+        onOpenExternal={handleOpenExternal}
+        onCopyUrl={handleCopyUrl}
+        onPopOut={handlePopOut}
+      />
+      {/* Content area: WebContentsView overlays this div */}
+      <div ref={contentRef} className="flex-1" />
+    </div>
+  )
 }

--- a/spa/src/components/BrowserPane.tsx
+++ b/spa/src/components/BrowserPane.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react'
 import { useI18nStore } from '../stores/useI18nStore'
 import { BrowserToolbar } from './BrowserToolbar'
 import { useBrowserViewState } from '../hooks/useBrowserViewState'
+import { useBrowserViewResize } from '../hooks/useBrowserViewResize'
 
 interface BrowserPaneProps {
   paneId: string
@@ -33,31 +34,7 @@ export function BrowserPane({ paneId, url }: BrowserPaneProps) {
   }, [url, paneId])
 
   // Bounds sync via ResizeObserver — observe content area (below toolbar)
-  useEffect(() => {
-    const el = contentRef.current
-    if (!window.electronAPI || !el) return
-
-    let rafId = 0
-    const observer = new ResizeObserver(() => {
-      cancelAnimationFrame(rafId)
-      rafId = requestAnimationFrame(() => {
-        const rect = el.getBoundingClientRect()
-        if (!rect.width || !rect.height) return
-        window.electronAPI!.resizeBrowserView(paneId, {
-          x: Math.round(rect.x),
-          y: Math.round(rect.y),
-          width: Math.round(rect.width),
-          height: Math.round(rect.height),
-        })
-      })
-    })
-    observer.observe(el)
-
-    return () => {
-      cancelAnimationFrame(rafId)
-      observer.disconnect()
-    }
-  }, [paneId])
+  useBrowserViewResize(paneId, contentRef)
 
   // Toolbar callbacks
   const handleGoBack = useCallback(() => window.electronAPI?.browserViewGoBack(paneId), [paneId])
@@ -88,7 +65,6 @@ export function BrowserPane({ paneId, url }: BrowserPaneProps) {
     <div className="flex flex-col h-full" data-browser-pane={paneId}>
       <BrowserToolbar
         url={currentUrl}
-        title={state.title}
         canGoBack={state.canGoBack}
         canGoForward={state.canGoForward}
         isLoading={state.isLoading}

--- a/spa/src/components/BrowserToolbar.tsx
+++ b/spa/src/components/BrowserToolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useCallback } from 'react'
 import {
   ArrowLeft,
   ArrowRight,
@@ -43,31 +43,29 @@ export function BrowserToolbar({
   onPopOut,
   onMoveToTab,
 }: BrowserToolbarProps) {
-  const [inputValue, setInputValue] = useState(url)
+  const [editValue, setEditValue] = useState('')
   const [isEditing, setIsEditing] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  useEffect(() => {
-    if (!isEditing) setInputValue(url)
-  }, [url, isEditing])
+  // When not editing, display the prop URL directly. When editing, show editValue.
+  const displayValue = isEditing ? editValue : url
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter') {
-        const normalized = normalizeUrl(inputValue)
+        const normalized = normalizeUrl(editValue)
         if (normalized) {
           onNavigate(normalized)
           setIsEditing(false)
           inputRef.current?.blur()
         }
       } else if (e.key === 'Escape') {
-        setInputValue(url)
         setIsEditing(false)
         inputRef.current?.blur()
       }
     },
-    [inputValue, url, onNavigate],
+    [editValue, onNavigate],
   )
 
   const navBtnClass = 'p-1 rounded hover:bg-surface-hover disabled:opacity-30 transition-colors'
@@ -112,10 +110,10 @@ export function BrowserToolbar({
         ref={inputRef}
         role="textbox"
         className="flex-1 mx-1 px-2 py-0.5 rounded bg-surface-input text-xs font-mono text-text-primary outline-none focus:border-border-active focus:ring-1 focus:ring-border-active"
-        value={inputValue}
-        onChange={(e) => { setInputValue(e.target.value); setIsEditing(true) }}
-        onFocus={() => { setIsEditing(true); inputRef.current?.select() }}
-        onBlur={() => { setIsEditing(false); setInputValue(url) }}
+        value={displayValue}
+        onChange={(e) => { setEditValue(e.target.value); setIsEditing(true) }}
+        onFocus={() => { setEditValue(url); setIsEditing(true); inputRef.current?.select() }}
+        onBlur={() => setIsEditing(false)}
         onKeyDown={handleKeyDown}
       />
 

--- a/spa/src/components/BrowserToolbar.tsx
+++ b/spa/src/components/BrowserToolbar.tsx
@@ -1,0 +1,143 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import {
+  ArrowLeft,
+  ArrowRight,
+  ArrowClockwise,
+  X,
+  DotsThree,
+} from '@phosphor-icons/react'
+import { normalizeUrl } from '../lib/url-utils'
+import { BrowserToolbarMenu } from './BrowserToolbarMenu'
+
+export interface BrowserToolbarProps {
+  url: string
+  title: string
+  canGoBack: boolean
+  canGoForward: boolean
+  isLoading: boolean
+  context: 'tab' | 'mini-window'
+  onGoBack: () => void
+  onGoForward: () => void
+  onReload: () => void
+  onStop: () => void
+  onNavigate: (url: string) => void
+  onOpenExternal: () => void
+  onCopyUrl: () => void
+  onPopOut?: () => void
+  onMoveToTab?: () => void
+}
+
+export function BrowserToolbar({
+  url,
+  canGoBack,
+  canGoForward,
+  isLoading,
+  context,
+  onGoBack,
+  onGoForward,
+  onReload,
+  onStop,
+  onNavigate,
+  onOpenExternal,
+  onCopyUrl,
+  onPopOut,
+  onMoveToTab,
+}: BrowserToolbarProps) {
+  const [inputValue, setInputValue] = useState(url)
+  const [isEditing, setIsEditing] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!isEditing) setInputValue(url)
+  }, [url, isEditing])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        const normalized = normalizeUrl(inputValue)
+        if (normalized) {
+          onNavigate(normalized)
+          setIsEditing(false)
+          inputRef.current?.blur()
+        }
+      } else if (e.key === 'Escape') {
+        setInputValue(url)
+        setIsEditing(false)
+        inputRef.current?.blur()
+      }
+    },
+    [inputValue, url, onNavigate],
+  )
+
+  const navBtnClass = 'p-1 rounded hover:bg-surface-hover disabled:opacity-30 transition-colors'
+
+  return (
+    <div className="flex items-center gap-1 px-2 py-1 border-b border-border-subtle bg-surface-secondary">
+      <button
+        aria-label="Go back"
+        className={navBtnClass}
+        disabled={!canGoBack}
+        onClick={onGoBack}
+      >
+        <ArrowLeft size={16} />
+      </button>
+      <button
+        aria-label="Go forward"
+        className={navBtnClass}
+        disabled={!canGoForward}
+        onClick={onGoForward}
+      >
+        <ArrowRight size={16} />
+      </button>
+      {isLoading ? (
+        <button
+          aria-label="Stop"
+          className={navBtnClass}
+          onClick={onStop}
+        >
+          <X size={16} />
+        </button>
+      ) : (
+        <button
+          aria-label="Reload"
+          className={navBtnClass}
+          onClick={onReload}
+        >
+          <ArrowClockwise size={16} />
+        </button>
+      )}
+
+      <input
+        ref={inputRef}
+        role="textbox"
+        className="flex-1 mx-1 px-2 py-0.5 rounded bg-surface-input text-xs font-mono text-text-primary outline-none focus:border-border-active focus:ring-1 focus:ring-border-active"
+        value={inputValue}
+        onChange={(e) => { setInputValue(e.target.value); setIsEditing(true) }}
+        onFocus={() => { setIsEditing(true); inputRef.current?.select() }}
+        onBlur={() => { setIsEditing(false); setInputValue(url) }}
+        onKeyDown={handleKeyDown}
+      />
+
+      <div className="relative">
+        <button
+          aria-label="More"
+          className={navBtnClass}
+          onClick={() => setMenuOpen((v) => !v)}
+        >
+          <DotsThree size={16} weight="bold" />
+        </button>
+        {menuOpen && (
+          <BrowserToolbarMenu
+            context={context}
+            onOpenExternal={onOpenExternal}
+            onCopyUrl={onCopyUrl}
+            onPopOut={onPopOut}
+            onMoveToTab={onMoveToTab}
+            onClose={() => setMenuOpen(false)}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/spa/src/components/BrowserToolbar.tsx
+++ b/spa/src/components/BrowserToolbar.tsx
@@ -11,7 +11,6 @@ import { BrowserToolbarMenu } from './BrowserToolbarMenu'
 
 export interface BrowserToolbarProps {
   url: string
-  title: string
   canGoBack: boolean
   canGoForward: boolean
   isLoading: boolean

--- a/spa/src/components/BrowserToolbarMenu.tsx
+++ b/spa/src/components/BrowserToolbarMenu.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from 'react'
+import {
+  ArrowSquareOut,
+  Copy,
+  ArrowSquareUpRight,
+  ArrowLineRight,
+} from '@phosphor-icons/react'
+import { useI18nStore } from '../stores/useI18nStore'
+
+interface MenuItem {
+  label: string
+  icon: React.ReactNode
+  onClick: () => void
+  show: boolean
+}
+
+interface BrowserToolbarMenuProps {
+  context: 'tab' | 'mini-window'
+  onOpenExternal: () => void
+  onCopyUrl: () => void
+  onPopOut?: () => void
+  onMoveToTab?: () => void
+  onClose: () => void
+}
+
+export function BrowserToolbarMenu({
+  context,
+  onOpenExternal,
+  onCopyUrl,
+  onPopOut,
+  onMoveToTab,
+  onClose,
+}: BrowserToolbarMenuProps) {
+  const t = useI18nStore((s) => s.t)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [onClose])
+
+  const items: MenuItem[] = [
+    {
+      label: t('browser.open_external'),
+      icon: <ArrowSquareOut size={14} />,
+      onClick: () => { onOpenExternal(); onClose() },
+      show: true,
+    },
+    {
+      label: t('browser.copy_url'),
+      icon: <Copy size={14} />,
+      onClick: () => { onCopyUrl(); onClose() },
+      show: true,
+    },
+    {
+      label: t('browser.pop_out'),
+      icon: <ArrowSquareUpRight size={14} />,
+      onClick: () => { onPopOut?.(); onClose() },
+      show: context === 'tab' && !!onPopOut,
+    },
+    {
+      label: t('browser.move_to_tab'),
+      icon: <ArrowLineRight size={14} />,
+      onClick: () => { onMoveToTab?.(); onClose() },
+      show: context === 'mini-window' && !!onMoveToTab,
+    },
+  ]
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-0 top-full mt-1 z-50 min-w-48 bg-surface-elevated border border-border-default rounded-lg shadow-xl py-1 text-xs"
+    >
+      {items.filter((i) => i.show).map((item) => (
+        <button
+          key={item.label}
+          className="flex w-full items-center gap-2 px-3 py-1.5 text-text-primary cursor-pointer hover:bg-surface-hover transition-colors"
+          onClick={item.onClick}
+        >
+          {item.icon}
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/spa/src/components/MiniBrowserApp.tsx
+++ b/spa/src/components/MiniBrowserApp.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useCallback } from 'react'
+import { useRef, useCallback } from 'react'
 import { BrowserToolbar } from './BrowserToolbar'
 import { useBrowserViewState } from '../hooks/useBrowserViewState'
+import { useBrowserViewResize } from '../hooks/useBrowserViewResize'
 
 interface Props {
   paneId: string
@@ -10,32 +11,7 @@ export function MiniBrowserApp({ paneId }: Props) {
   const contentRef = useRef<HTMLDivElement>(null)
   const state = useBrowserViewState(paneId)
 
-  // ResizeObserver for content area
-  useEffect(() => {
-    const el = contentRef.current
-    if (!el || !window.electronAPI) return
-
-    let rafId = 0
-    const observer = new ResizeObserver(() => {
-      cancelAnimationFrame(rafId)
-      rafId = requestAnimationFrame(() => {
-        const rect = el.getBoundingClientRect()
-        if (!rect.width || !rect.height) return
-        window.electronAPI!.resizeBrowserView(paneId, {
-          x: Math.round(rect.x),
-          y: Math.round(rect.y),
-          width: Math.round(rect.width),
-          height: Math.round(rect.height),
-        })
-      })
-    })
-    observer.observe(el)
-
-    return () => {
-      cancelAnimationFrame(rafId)
-      observer.disconnect()
-    }
-  }, [paneId])
+  useBrowserViewResize(paneId, contentRef)
 
   const handleGoBack = useCallback(() => window.electronAPI?.browserViewGoBack(paneId), [paneId])
   const handleGoForward = useCallback(() => window.electronAPI?.browserViewGoForward(paneId), [paneId])
@@ -61,7 +37,6 @@ export function MiniBrowserApp({ paneId }: Props) {
       />
       <BrowserToolbar
         url={state.url}
-        title={state.title}
         canGoBack={state.canGoBack}
         canGoForward={state.canGoForward}
         isLoading={state.isLoading}

--- a/spa/src/components/MiniBrowserApp.tsx
+++ b/spa/src/components/MiniBrowserApp.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useCallback } from 'react'
+import { BrowserToolbar } from './BrowserToolbar'
+import { useBrowserViewState } from '../hooks/useBrowserViewState'
+
+interface Props {
+  paneId: string
+}
+
+export function MiniBrowserApp({ paneId }: Props) {
+  const contentRef = useRef<HTMLDivElement>(null)
+  const state = useBrowserViewState(paneId)
+
+  // ResizeObserver for content area
+  useEffect(() => {
+    const el = contentRef.current
+    if (!el || !window.electronAPI) return
+
+    let rafId = 0
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        const rect = el.getBoundingClientRect()
+        if (!rect.width || !rect.height) return
+        window.electronAPI!.resizeBrowserView(paneId, {
+          x: Math.round(rect.x),
+          y: Math.round(rect.y),
+          width: Math.round(rect.width),
+          height: Math.round(rect.height),
+        })
+      })
+    })
+    observer.observe(el)
+
+    return () => {
+      cancelAnimationFrame(rafId)
+      observer.disconnect()
+    }
+  }, [paneId])
+
+  const handleGoBack = useCallback(() => window.electronAPI?.browserViewGoBack(paneId), [paneId])
+  const handleGoForward = useCallback(() => window.electronAPI?.browserViewGoForward(paneId), [paneId])
+  const handleReload = useCallback(() => window.electronAPI?.browserViewReload(paneId), [paneId])
+  const handleStop = useCallback(() => window.electronAPI?.browserViewStop(paneId), [paneId])
+  const handleNavigate = useCallback(
+    (url: string) => window.electronAPI?.navigateBrowserView(paneId, url),
+    [paneId],
+  )
+  const handleOpenExternal = useCallback(() => window.open(state.url, '_blank'), [state.url])
+  const handleCopyUrl = useCallback(() => { navigator.clipboard.writeText(state.url) }, [state.url])
+  const handleMoveToTab = useCallback(
+    () => window.electronAPI?.browserViewMoveToTab(paneId),
+    [paneId],
+  )
+
+  return (
+    <div className="flex flex-col h-screen bg-surface-primary text-text-primary">
+      {/* Electron title bar drag region */}
+      <div
+        className="h-10 flex items-end flex-shrink-0"
+        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      />
+      <BrowserToolbar
+        url={state.url}
+        title={state.title}
+        canGoBack={state.canGoBack}
+        canGoForward={state.canGoForward}
+        isLoading={state.isLoading}
+        context="mini-window"
+        onGoBack={handleGoBack}
+        onGoForward={handleGoForward}
+        onReload={handleReload}
+        onStop={handleStop}
+        onNavigate={handleNavigate}
+        onOpenExternal={handleOpenExternal}
+        onCopyUrl={handleCopyUrl}
+        onMoveToTab={handleMoveToTab}
+      />
+      <div ref={contentRef} className="flex-1" />
+    </div>
+  )
+}

--- a/spa/src/components/TabBar.tsx
+++ b/spa/src/components/TabBar.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useRef, useState, useCallback, useMemo } from 'react'
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent, type Modifier } from '@dnd-kit/core'
 import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortable'
-import { Plus, CaretLeft, CaretRight, TerminalWindow, ChatCircleDots, House, ClockCounterClockwise, GearSix, SmileySad } from '@phosphor-icons/react'
+import { Plus, CaretLeft, CaretRight, TerminalWindow, ChatCircleDots, House, ClockCounterClockwise, GearSix, SmileySad, Globe } from '@phosphor-icons/react'
 import { SortableTab } from './SortableTab'
 import { useScrollOverflow } from '../hooks/useScrollOverflow'
 import type { Tab } from '../types/tab'
@@ -17,6 +17,7 @@ const ICON_MAP: Record<string, React.ComponentType<{ size: number; className?: s
   ClockCounterClockwise,
   GearSix,
   SmileySad,
+  Globe,
 }
 
 interface Props {

--- a/spa/src/components/TerminalView.tsx
+++ b/spa/src/components/TerminalView.tsx
@@ -31,7 +31,7 @@ export default function TerminalView({ wsUrl, visible = true, connectingMessage,
         openBrowserTab,
         openMiniWindow: (url) => window.electronAPI?.browserViewOpenMiniWindow(url),
       }),
-    [caps.isElectron, openBrowserTab],
+    [caps.isElectron],
   )
   const { termRef, fitAddonRef, containerRef } = useTerminal({ linkHandler })
   const [ready, setReady] = useState(false)

--- a/spa/src/components/TerminalView.tsx
+++ b/spa/src/components/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react'
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
 import { UploadSimple, Spinner } from '@phosphor-icons/react'
 import { useTerminal } from '../hooks/useTerminal'
 import { useTerminalWs } from '../hooks/useTerminalWs'
@@ -8,6 +8,9 @@ import { useUploadStore } from '../stores/useUploadStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { compositeKey } from '../lib/composite-key'
 import { agentUpload } from '../lib/host-api'
+import { createLinkHandler } from '../lib/link-handler'
+import { getPlatformCapabilities } from '../lib/platform'
+import { openBrowserTab } from '../lib/open-browser-tab'
 import '@xterm/xterm/css/xterm.css'
 
 interface Props {
@@ -20,7 +23,17 @@ interface Props {
 }
 
 export default function TerminalView({ wsUrl, visible = true, connectingMessage, hostId, sessionCode, getTicket }: Props) {
-  const { termRef, fitAddonRef, containerRef } = useTerminal()
+  const caps = useMemo(() => getPlatformCapabilities(), [])
+  const linkHandler = useMemo(
+    () =>
+      createLinkHandler({
+        isElectron: caps.isElectron,
+        openBrowserTab,
+        openMiniWindow: (url) => window.electronAPI?.browserViewOpenMiniWindow(url),
+      }),
+    [caps.isElectron, openBrowserTab],
+  )
+  const { termRef, fitAddonRef, containerRef } = useTerminal({ linkHandler })
   const [ready, setReady] = useState(false)
   const [disconnected, setDisconnected] = useState(false)
   const prevVisible = useRef(visible)

--- a/spa/src/components/__tests__/BrowserToolbar.test.tsx
+++ b/spa/src/components/__tests__/BrowserToolbar.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BrowserToolbar } from '../BrowserToolbar'
+
+function makeProps(overrides: Partial<Parameters<typeof BrowserToolbar>[0]> = {}) {
+  return {
+    url: 'https://github.com/',
+    title: 'GitHub',
+    canGoBack: true,
+    canGoForward: false,
+    isLoading: false,
+    context: 'tab' as const,
+    onGoBack: vi.fn(),
+    onGoForward: vi.fn(),
+    onReload: vi.fn(),
+    onStop: vi.fn(),
+    onNavigate: vi.fn(),
+    onOpenExternal: vi.fn(),
+    onCopyUrl: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('BrowserToolbar', () => {
+  it('renders back, forward, reload buttons', () => {
+    render(<BrowserToolbar {...makeProps()} />)
+    expect(screen.getByLabelText('Go back')).toBeInTheDocument()
+    expect(screen.getByLabelText('Go forward')).toBeInTheDocument()
+    expect(screen.getByLabelText('Reload')).toBeInTheDocument()
+  })
+
+  it('disables forward button when canGoForward is false', () => {
+    render(<BrowserToolbar {...makeProps({ canGoForward: false })} />)
+    expect(screen.getByLabelText('Go forward')).toBeDisabled()
+  })
+
+  it('disables back button when canGoBack is false', () => {
+    render(<BrowserToolbar {...makeProps({ canGoBack: false })} />)
+    expect(screen.getByLabelText('Go back')).toBeDisabled()
+  })
+
+  it('shows stop button when isLoading is true', () => {
+    render(<BrowserToolbar {...makeProps({ isLoading: true })} />)
+    expect(screen.getByLabelText('Stop')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Reload')).not.toBeInTheDocument()
+  })
+
+  it('calls onGoBack when back button clicked', () => {
+    const onGoBack = vi.fn()
+    render(<BrowserToolbar {...makeProps({ onGoBack })} />)
+    fireEvent.click(screen.getByLabelText('Go back'))
+    expect(onGoBack).toHaveBeenCalledOnce()
+  })
+
+  it('calls onNavigate with normalized URL on Enter', () => {
+    const onNavigate = vi.fn()
+    render(<BrowserToolbar {...makeProps({ onNavigate })} />)
+    const input = screen.getByRole('textbox')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'example.com' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onNavigate).toHaveBeenCalledWith('https://example.com/')
+  })
+
+  it('does not call onNavigate for invalid URL', () => {
+    const onNavigate = vi.fn()
+    render(<BrowserToolbar {...makeProps({ onNavigate })} />)
+    const input = screen.getByRole('textbox')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'javascript:alert(1)' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+
+  it('displays current URL in input', () => {
+    render(<BrowserToolbar {...makeProps({ url: 'https://example.com/page' })} />)
+    expect(screen.getByRole('textbox')).toHaveValue('https://example.com/page')
+  })
+
+  it('shows popOut in menu for tab context', () => {
+    const onPopOut = vi.fn()
+    render(<BrowserToolbar {...makeProps({ onPopOut })} />)
+    fireEvent.click(screen.getByLabelText('More'))
+    expect(screen.getByText('Open in mini browser')).toBeInTheDocument()
+  })
+
+  it('shows moveToTab in menu for mini-window context', () => {
+    const onMoveToTab = vi.fn()
+    render(<BrowserToolbar {...makeProps({ context: 'mini-window', onMoveToTab })} />)
+    fireEvent.click(screen.getByLabelText('More'))
+    expect(screen.getByText('Open in main window')).toBeInTheDocument()
+  })
+})

--- a/spa/src/components/__tests__/BrowserToolbar.test.tsx
+++ b/spa/src/components/__tests__/BrowserToolbar.test.tsx
@@ -5,7 +5,6 @@ import { BrowserToolbar } from '../BrowserToolbar'
 function makeProps(overrides: Partial<Parameters<typeof BrowserToolbar>[0]> = {}) {
   return {
     url: 'https://github.com/',
-    title: 'GitHub',
     canGoBack: true,
     canGoForward: false,
     isLoading: false,

--- a/spa/src/features/workspace/hooks.ts
+++ b/spa/src/features/workspace/hooks.ts
@@ -47,6 +47,14 @@ export function useTabWorkspaceActions(displayTabs: Tab[]) {
   const handleCloseTab = useCallback((tabId: string) => {
     const tab = tabs[tabId]
     if (!tab || tab.locked) return // locked guard
+
+    // Browser tabs: destroy the view before removing the tab.
+    // This calls destroy() (real cleanup) instead of background() (keep-alive).
+    const primary = getPrimaryPane(tab.layout)
+    if (primary.content.kind === 'browser') {
+      window.electronAPI?.destroyBrowserView(primary.id)
+    }
+
     useHistoryStore.getState().recordClose(tab, findWorkspaceByTab(tabId)?.id)
     const ws = findWorkspaceByTab(tabId)
     if (ws) removeTabFromWorkspace(ws.id, tabId)

--- a/spa/src/hooks/__tests__/useBrowserViewState.test.ts
+++ b/spa/src/hooks/__tests__/useBrowserViewState.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBrowserViewState } from '../useBrowserViewState'
+import type { BrowserViewState } from '../useBrowserViewState'
+
+describe('useBrowserViewState', () => {
+  let listeners: Array<(paneId: string, state: BrowserViewState) => void>
+  let mockUnsubscribe: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    listeners = []
+    mockUnsubscribe = vi.fn()
+    window.electronAPI = {
+      onBrowserViewStateUpdate: vi.fn((cb: (paneId: string, state: BrowserViewState) => void) => {
+        listeners.push(cb)
+        return mockUnsubscribe
+      }),
+    } as unknown as typeof window.electronAPI
+  })
+
+  afterEach(() => {
+    // @ts-expect-error cleanup
+    window.electronAPI = undefined
+  })
+
+  it('returns initial empty state', () => {
+    const { result } = renderHook(() => useBrowserViewState('pane-1'))
+    expect(result.current).toEqual({
+      url: '',
+      title: '',
+      canGoBack: false,
+      canGoForward: false,
+      isLoading: false,
+    })
+  })
+
+  it('updates state when matching paneId received', () => {
+    const { result } = renderHook(() => useBrowserViewState('pane-1'))
+
+    act(() => {
+      listeners[0]('pane-1', {
+        url: 'https://github.com',
+        title: 'GitHub',
+        canGoBack: true,
+        canGoForward: false,
+        isLoading: false,
+      })
+    })
+
+    expect(result.current.url).toBe('https://github.com')
+    expect(result.current.title).toBe('GitHub')
+    expect(result.current.canGoBack).toBe(true)
+  })
+
+  it('ignores state for different paneId', () => {
+    const { result } = renderHook(() => useBrowserViewState('pane-1'))
+
+    act(() => {
+      listeners[0]('pane-OTHER', {
+        url: 'https://other.com',
+        title: 'Other',
+        canGoBack: true,
+        canGoForward: true,
+        isLoading: true,
+      })
+    })
+
+    expect(result.current.url).toBe('')
+  })
+
+  it('calls unsubscribe on unmount', () => {
+    const { unmount } = renderHook(() => useBrowserViewState('pane-1'))
+    unmount()
+    expect(mockUnsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('returns empty state when electronAPI not available', () => {
+    // @ts-expect-error cleanup
+    window.electronAPI = undefined
+    const { result } = renderHook(() => useBrowserViewState('pane-1'))
+    expect(result.current.url).toBe('')
+  })
+})

--- a/spa/src/hooks/useBrowserViewResize.ts
+++ b/spa/src/hooks/useBrowserViewResize.ts
@@ -1,0 +1,33 @@
+import { useEffect, type RefObject } from 'react'
+
+/**
+ * Observes the given element and pushes its bounds to Electron's BrowserViewManager
+ * via the resizeBrowserView IPC. Used by both BrowserPane and MiniBrowserApp.
+ */
+export function useBrowserViewResize(paneId: string, ref: RefObject<HTMLDivElement | null>): void {
+  useEffect(() => {
+    const el = ref.current
+    if (!window.electronAPI || !el) return
+
+    let rafId = 0
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        const rect = el.getBoundingClientRect()
+        if (!rect.width || !rect.height) return
+        window.electronAPI!.resizeBrowserView(paneId, {
+          x: Math.round(rect.x),
+          y: Math.round(rect.y),
+          width: Math.round(rect.width),
+          height: Math.round(rect.height),
+        })
+      })
+    })
+    observer.observe(el)
+
+    return () => {
+      cancelAnimationFrame(rafId)
+      observer.disconnect()
+    }
+  }, [paneId, ref])
+}

--- a/spa/src/hooks/useBrowserViewState.ts
+++ b/spa/src/hooks/useBrowserViewState.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+
+export interface BrowserViewState {
+  url: string
+  title: string
+  canGoBack: boolean
+  canGoForward: boolean
+  isLoading: boolean
+}
+
+const INITIAL_STATE: BrowserViewState = {
+  url: '',
+  title: '',
+  canGoBack: false,
+  canGoForward: false,
+  isLoading: false,
+}
+
+export function useBrowserViewState(paneId: string): BrowserViewState {
+  const [state, setState] = useState<BrowserViewState>(INITIAL_STATE)
+
+  useEffect(() => {
+    const api = window.electronAPI
+    if (!api?.onBrowserViewStateUpdate) return
+
+    const unsubscribe = api.onBrowserViewStateUpdate(
+      (id: string, update: BrowserViewState) => {
+        if (id === paneId) setState(update)
+      },
+    )
+
+    return unsubscribe
+  }, [paneId])
+
+  return state
+}

--- a/spa/src/hooks/useTerminal.ts
+++ b/spa/src/hooks/useTerminal.ts
@@ -27,7 +27,11 @@ function getTerminalTheme() {
  * wsUrl 變更或 settings 變更導致的重建由 TabContent 的 pool key
  * (`key={id}-${poolVersion}`) 觸發 remount，不在此 hook 處理。
  */
-export function useTerminal(): UseTerminalResult {
+export interface UseTerminalOptions {
+  linkHandler?: (event: MouseEvent, uri: string) => void
+}
+
+export function useTerminal(options: UseTerminalOptions = {}): UseTerminalResult {
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
@@ -68,7 +72,10 @@ export function useTerminal(): UseTerminalResult {
       term.loadAddon(new Unicode11Addon())
       term.unicode.activeVersion = '11'
     } catch { /* fallback to unicode 6 */ }
-    try { term.loadAddon(new WebLinksAddon()) } catch { /* non-critical */ }
+    try {
+      const lh = options.linkHandler
+      term.loadAddon(lh ? new WebLinksAddon(lh) : new WebLinksAddon())
+    } catch { /* non-critical */ }
 
     // Guard: skip initial fit if container is hidden (visibility:hidden in keep-alive pool)
     requestAnimationFrame(() => {

--- a/spa/src/hooks/useTerminal.ts
+++ b/spa/src/hooks/useTerminal.ts
@@ -105,6 +105,7 @@ export function useTerminal(options: UseTerminalOptions = {}): UseTerminalResult
       fitAddonRef.current = null
       termRef.current = null
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- lifecycle bound to mount/unmount only
   }, [])
 
   useEffect(() => {

--- a/spa/src/lib/__tests__/link-handler.test.ts
+++ b/spa/src/lib/__tests__/link-handler.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createLinkHandler } from '../link-handler'
+
+function makeMouseEvent(overrides: Partial<MouseEvent> = {}): MouseEvent {
+  return { shiftKey: false, ...overrides } as MouseEvent
+}
+
+describe('createLinkHandler', () => {
+  describe('Electron mode', () => {
+    it('calls openBrowserTab on normal click', () => {
+      const openBrowserTab = vi.fn()
+      const openMiniWindow = vi.fn()
+      const handler = createLinkHandler({
+        isElectron: true,
+        openBrowserTab,
+        openMiniWindow,
+      })
+
+      handler(makeMouseEvent(), 'https://github.com')
+
+      expect(openBrowserTab).toHaveBeenCalledWith('https://github.com')
+      expect(openMiniWindow).not.toHaveBeenCalled()
+    })
+
+    it('calls openMiniWindow on shift+click', () => {
+      const openBrowserTab = vi.fn()
+      const openMiniWindow = vi.fn()
+      const handler = createLinkHandler({
+        isElectron: true,
+        openBrowserTab,
+        openMiniWindow,
+      })
+
+      handler(makeMouseEvent({ shiftKey: true }), 'https://github.com')
+
+      expect(openMiniWindow).toHaveBeenCalledWith('https://github.com')
+      expect(openBrowserTab).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('SPA mode', () => {
+    it('calls window.open on any click', () => {
+      const openSpy = vi.fn()
+      vi.stubGlobal('open', openSpy)
+
+      const handler = createLinkHandler({
+        isElectron: false,
+        openBrowserTab: vi.fn(),
+        openMiniWindow: vi.fn(),
+      })
+
+      handler(makeMouseEvent(), 'https://github.com')
+
+      expect(openSpy).toHaveBeenCalledWith('https://github.com', '_blank')
+
+      vi.unstubAllGlobals()
+    })
+
+    it('calls window.open on shift+click too', () => {
+      const openSpy = vi.fn()
+      vi.stubGlobal('open', openSpy)
+
+      const handler = createLinkHandler({
+        isElectron: false,
+        openBrowserTab: vi.fn(),
+        openMiniWindow: vi.fn(),
+      })
+
+      handler(makeMouseEvent({ shiftKey: true }), 'https://github.com')
+
+      expect(openSpy).toHaveBeenCalledWith('https://github.com', '_blank')
+
+      vi.unstubAllGlobals()
+    })
+  })
+})

--- a/spa/src/lib/__tests__/url-utils.test.ts
+++ b/spa/src/lib/__tests__/url-utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeUrl } from '../url-utils'
+
+describe('normalizeUrl', () => {
+  it('returns valid https URL as-is', () => {
+    expect(normalizeUrl('https://github.com')).toBe('https://github.com/')
+  })
+
+  it('returns valid http URL as-is', () => {
+    expect(normalizeUrl('http://localhost:3000')).toBe('http://localhost:3000/')
+  })
+
+  it('prepends https:// when no scheme', () => {
+    expect(normalizeUrl('github.com')).toBe('https://github.com/')
+  })
+
+  it('prepends https:// for domain with path', () => {
+    expect(normalizeUrl('github.com/wake/tmux-box')).toBe('https://github.com/wake/tmux-box')
+  })
+
+  it('returns null for javascript: scheme', () => {
+    expect(normalizeUrl('javascript:alert(1)')).toBeNull()
+  })
+
+  it('returns null for file: scheme', () => {
+    expect(normalizeUrl('file:///etc/passwd')).toBeNull()
+  })
+
+  it('returns null for ftp: scheme', () => {
+    expect(normalizeUrl('ftp://example.com')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(normalizeUrl('')).toBeNull()
+  })
+
+  it('returns null for whitespace only', () => {
+    expect(normalizeUrl('   ')).toBeNull()
+  })
+
+  it('trims whitespace', () => {
+    expect(normalizeUrl('  https://github.com  ')).toBe('https://github.com/')
+  })
+
+  it('returns null for malformed URL', () => {
+    expect(normalizeUrl('not a url at all')).toBeNull()
+  })
+})

--- a/spa/src/lib/link-handler.ts
+++ b/spa/src/lib/link-handler.ts
@@ -1,0 +1,19 @@
+export interface LinkHandlerDeps {
+  isElectron: boolean
+  openBrowserTab: (url: string) => void
+  openMiniWindow: (url: string) => void
+}
+
+export function createLinkHandler(deps: LinkHandlerDeps) {
+  return (event: MouseEvent, uri: string): void => {
+    if (deps.isElectron) {
+      if (event.shiftKey) {
+        deps.openMiniWindow(uri)
+      } else {
+        deps.openBrowserTab(uri)
+      }
+    } else {
+      window.open(uri, '_blank')
+    }
+  }
+}

--- a/spa/src/lib/open-browser-tab.ts
+++ b/spa/src/lib/open-browser-tab.ts
@@ -1,0 +1,20 @@
+import { useTabStore } from '../stores/useTabStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+import { createTab } from '../types/tab'
+
+/**
+ * Open a new browser tab with the given URL.
+ * Integrates with workspace: adds to active workspace and sets as active tab.
+ * Can be called from anywhere (not a hook — uses store.getState() directly).
+ */
+export function openBrowserTab(url: string): void {
+  const tab = createTab({ kind: 'browser', url })
+  useTabStore.getState().addTab(tab)
+  useTabStore.getState().setActiveTab(tab.id)
+
+  const wsId = useWorkspaceStore.getState().activeWorkspaceId
+  if (wsId) {
+    useWorkspaceStore.getState().addTabToWorkspace(wsId, tab.id)
+    useWorkspaceStore.getState().setWorkspaceActiveTab(wsId, tab.id)
+  }
+}

--- a/spa/src/lib/url-utils.ts
+++ b/spa/src/lib/url-utils.ts
@@ -1,0 +1,19 @@
+const ALLOWED_SCHEMES = ['http:', 'https:']
+
+export function normalizeUrl(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  let urlStr = trimmed
+  if (!trimmed.includes('://')) {
+    urlStr = `https://${trimmed}`
+  }
+
+  try {
+    const parsed = new URL(urlStr)
+    if (!ALLOWED_SCHEMES.includes(parsed.protocol)) return null
+    return parsed.href
+  } catch {
+    return null
+  }
+}

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -179,6 +179,10 @@
   "browser.provider_label": "Browser",
   "browser.requires_app": "Requires desktop app",
   "browser.url_placeholder": "Enter URL...",
+  "browser.open_external": "Open in browser",
+  "browser.copy_url": "Copy URL",
+  "browser.pop_out": "Open in mini browser",
+  "browser.move_to_tab": "Open in main window",
 
   "tray.show_window": "Show Window",
   "tray.quit": "Quit tmux-box",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -179,6 +179,10 @@
   "browser.provider_label": "瀏覽器",
   "browser.requires_app": "需要安裝桌面版本",
   "browser.url_placeholder": "輸入網址...",
+  "browser.open_external": "在瀏覽器中開啟",
+  "browser.copy_url": "複製網址",
+  "browser.pop_out": "在 Mini Browser 開啟",
+  "browser.move_to_tab": "在主視窗重新開啟此網址",
 
   "tray.show_window": "顯示視窗",
   "tray.quit": "結束 tmux-box",

--- a/spa/src/mini-browser.tsx
+++ b/spa/src/mini-browser.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import { MiniBrowserApp } from './components/MiniBrowserApp'
+
+const params = new URLSearchParams(window.location.search)
+const paneId = params.get('paneId') || ''
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <MiniBrowserApp paneId={paneId} />
+  </StrictMode>,
+)

--- a/spa/src/types/electron.d.ts
+++ b/spa/src/types/electron.d.ts
@@ -61,6 +61,15 @@ interface Window {
 
     // Browser View
     resizeBrowserView: (paneId: string, bounds: ElectronBounds) => Promise<void>
+    browserViewGoBack: (paneId: string) => Promise<void>
+    browserViewGoForward: (paneId: string) => Promise<void>
+    browserViewReload: (paneId: string) => Promise<void>
+    browserViewStop: (paneId: string) => Promise<void>
+    destroyBrowserView: (paneId: string) => Promise<void>
+    browserViewOpenMiniWindow: (url: string) => Promise<void>
+    browserViewMoveToTab: (paneId: string) => Promise<void>
+    onBrowserViewStateUpdate: (callback: (paneId: string, state: { url: string; title: string; canGoBack: boolean; canGoForward: boolean; isLoading: boolean }) => void) => () => void
+    onBrowserViewOpenInTab: (callback: (url: string) => void) => () => void
 
     // Memory Monitor
     getProcessMetrics: () => Promise<ElectronTabMetrics[]>


### PR DESCRIPTION
## Summary

- Browser tab 新增完整 toolbar（← → ↻/✕ | 可編輯 URL 欄位 | ⋯ 更多選單）
- Shift+click 連結彈出 mini browser 獨立視窗（共用同一套 BrowserToolbar）
- Terminal 連結統一處理：click 開新 browser tab、shift+click 開 mini browser（SPA fallback 為 window.open）
- Electron 端擴充：導航 IPC、state-update 推送、WebContentsView preload 注入、MiniWindowManager
- Browser tab 主動關閉走 destroy 路徑（而非 background）

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-04-07-browser-tab-enhancement-design.md`
- Plan: `docs/superpowers/plans/2026-04-07-browser-tab-enhancement.md`

## New Files

| File | Purpose |
|------|---------|
| `spa/src/lib/url-utils.ts` | URL 正規化 + 驗證 |
| `spa/src/lib/link-handler.ts` | createLinkHandler factory |
| `spa/src/lib/open-browser-tab.ts` | workspace-aware openBrowserTab |
| `spa/src/components/BrowserToolbar.tsx` | 共用 toolbar UI |
| `spa/src/components/BrowserToolbarMenu.tsx` | ⋯ 下拉選單 |
| `spa/src/components/MiniBrowserApp.tsx` | Mini browser 視窗根元件 |
| `spa/src/hooks/useBrowserViewState.ts` | Electron state-update 訂閱 |
| `spa/src/mini-browser.tsx` | Mini browser SPA entry |
| `spa/mini-browser.html` | Mini browser HTML entry |
| `electron/browser-view-ipc.ts` | 集中 browser-view IPC handler |
| `electron/browser-view-preload.ts` | WebContentsView 連結攔截 |
| `electron/mini-browser-window.ts` | MiniWindowManager |

## Test plan

- [x] `npx vitest run` — 102 files, 944 tests all pass
- [x] `pnpm run lint` — 0 errors, 0 warnings
- [ ] Electron smoke test: browser tab toolbar 功能
- [ ] Electron smoke test: mini browser 視窗開啟/關閉
- [ ] Electron smoke test: terminal 連結 click / shift+click
- [ ] Electron smoke test: move-to-tab 流程