### PR TITLE
fix: Home tab stale display + workspace icon tooltip

### DIFF
--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -302,7 +302,11 @@ export default function App() {
           onSelectHome={() => {
             useWorkspaceStore.getState().setActiveWorkspace(null)
             const firstStandalone = standaloneTabs[0]
-            if (firstStandalone) handleSelectTab(firstStandalone.id)
+            if (firstStandalone) {
+              handleSelectTab(firstStandalone.id)
+            } else {
+              useTabStore.getState().setActiveTab(null)
+            }
           }}
           standaloneTabCount={standaloneTabs.length}
           onAddWorkspace={() => {

--- a/spa/src/features/workspace/components/ActivityBar.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.test.tsx
@@ -34,20 +34,20 @@ describe('ActivityBar', () => {
 
   it('renders workspace icons', () => {
     render(<ActivityBar {...defaultProps} />)
-    expect(screen.getByTitle('Project A')).toBeTruthy()
-    expect(screen.getByTitle('Server')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Project A' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Server' })).toBeTruthy()
   })
 
   it('highlights active workspace', () => {
     render(<ActivityBar {...defaultProps} />)
-    const activeBtn = screen.getByTitle('Project A')
+    const activeBtn = screen.getByRole('button', { name: 'Project A' })
     expect(activeBtn.className).toContain('ring')
   })
 
   it('calls onSelectWorkspace on click', () => {
     const onSelect = vi.fn()
     render(<ActivityBar {...defaultProps} onSelectWorkspace={onSelect} />)
-    fireEvent.click(screen.getByTitle('Server'))
+    fireEvent.click(screen.getByRole('button', { name: 'Server' }))
     expect(onSelect).toHaveBeenCalledWith('ws-2')
   })
 

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -55,22 +55,26 @@ export function ActivityBar({
       {workspaces.map((ws) => {
         const isActive = activeWorkspaceId === ws.id && !activeStandaloneTabId
         return (
-          <button
-            key={ws.id}
-            title={ws.name}
-            onClick={() => onSelectWorkspace(ws.id)}
-            onContextMenu={(e) => {
-              e.preventDefault()
-              onContextMenuWorkspace?.(e, ws.id)
-            }}
-            className={`w-[30px] h-[30px] rounded-md flex items-center justify-center text-sm cursor-pointer transition-all ${
-              isActive
-                ? 'bg-[#8b5cf6]/35 text-text-primary ring-2 ring-purple-400'
-                : 'bg-surface-secondary text-text-secondary hover:bg-surface-hover hover:text-text-primary'
-            }`}
-          >
-            <WorkspaceIcon icon={ws.icon} name={ws.name} size={16} weight={ws.iconWeight} />
-          </button>
+          <div key={ws.id} className="relative group">
+            <button
+              title={ws.name}
+              onClick={() => onSelectWorkspace(ws.id)}
+              onContextMenu={(e) => {
+                e.preventDefault()
+                onContextMenuWorkspace?.(e, ws.id)
+              }}
+              className={`w-[30px] h-[30px] rounded-md flex items-center justify-center text-sm cursor-pointer transition-all ${
+                isActive
+                  ? 'bg-[#8b5cf6]/35 text-text-primary ring-2 ring-purple-400'
+                  : 'bg-surface-secondary text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+              }`}
+            >
+              <WorkspaceIcon icon={ws.icon} name={ws.name} size={16} weight={ws.iconWeight} />
+            </button>
+            <span className="pointer-events-none absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50">
+              {ws.name}
+            </span>
+          </div>
         )
       })}
 

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -57,7 +57,7 @@ export function ActivityBar({
         return (
           <div key={ws.id} className="relative group">
             <button
-              title={ws.name}
+              aria-label={ws.name}
               onClick={() => onSelectWorkspace(ws.id)}
               onContextMenu={(e) => {
                 e.preventDefault()


### PR DESCRIPTION
## Summary

- **Home tab 殘留修復**：切回 Home 時如果沒有 standalone tabs，`activeTabId` 未清除導致前一個 workspace 的 tab 繼續顯示。修正為 `setActiveTab(null)`
- **Workspace icon tooltip**：ActivityBar workspace icon 新增 CSS tooltip，hover 即時顯示名稱（取代原生 title 的 ~1s 延遲）

## Test plan
- [x] 1063/1063 tests passing
- [x] Lint clean
- [ ] 手動測試：建立 workspace → 切換到 Home → 確認不會殘留 workspace tab
- [ ] 手動測試：hover workspace icon → 確認 tooltip 即時顯示名稱