### PR TITLE
fix: tab drag, rename CORS, notification GC, tab overflow, upload typing

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -49,8 +49,15 @@ function registerIpcHandlers(): void {
     return browserViewManager.getMetrics()
   })
 
-  // Notifications
+  // Notifications — prevent GC from collecting Notification objects before
+  // the user clicks them. Without this Set, the local `notification` variable
+  // goes out of scope after show(), V8 can GC the JS wrapper, and the click
+  // handler is silently lost. Electron's C++ layer does NOT use SelfKeepAlive
+  // for Notification (unlike Tray), so userland must hold the reference.
+  // No TTL — notification frequency is low and each object is ~hundreds of
+  // bytes; a slow leak from missing close events is negligible.
   const recentBroadcasts = new Set<number>()
+  const activeNotifications = new Set<Notification>()
   ipcMain.handle('notification:show', (_event, optsJson: string) => {
     const opts = JSON.parse(optsJson) as {
       title: string; body: string; sessionCode: string; eventName: string; broadcastTs: number
@@ -62,7 +69,10 @@ function registerIpcHandlers(): void {
     setTimeout(() => recentBroadcasts.delete(opts.broadcastTs), 5000)
 
     const notification = new Notification({ title: opts.title, body: opts.body })
+    activeNotifications.add(notification)
+    const release = () => { activeNotifications.delete(notification) }
     notification.on('click', () => {
+      release()
       // Broadcast to all renderers — SPA decides which one has the tab
       // The SPA will call focusMyWindow IPC when it handles the click
       const payload: { sessionCode: string; action?: { kind: string; hostId: string; sessionCode?: string } } = {
@@ -75,6 +85,7 @@ function registerIpcHandlers(): void {
         }
       }
     })
+    notification.on('close', release)
     notification.show()
   })
 

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -85,7 +85,7 @@ func TokenAuth(tokenFn func() string, tickets TicketValidator) func(http.Handler
 func CORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(204)

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -4,6 +4,7 @@ package middleware_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/wake/tmux-box/internal/middleware"
@@ -164,5 +165,11 @@ func TestCORSHeaders(t *testing.T) {
 	}
 	if rec.Code != 204 {
 		t.Errorf("want 204 for OPTIONS, got %d", rec.Code)
+	}
+	methods := rec.Header().Get("Access-Control-Allow-Methods")
+	for _, m := range []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"} {
+		if !strings.Contains(methods, m) {
+			t.Errorf("want %s in Allow-Methods, got %s", m, methods)
+		}
 	}
 }

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -276,8 +276,8 @@ export default function App() {
           >
             {/* Traffic light safe zone (78px ≈ 3 buttons + padding) */}
             <div className="shrink-0" style={{ width: 78 }} />
-            {/* Tabs — no-drag so clicks work */}
-            <div className="flex items-center" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+            {/* Tabs — no-drag so clicks work; flex-1 min-w-0 constrains width to prevent app-wide overflow */}
+            <div className="flex-1 min-w-0 flex items-center" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
               <TabBar
                 tabs={displayTabs}
                 activeTabId={activeTabId}

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -112,10 +112,11 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
   // Prevent focus theft when clicking the already-active tab.
   // Must wrap dnd-kit's onPointerDown to avoid overriding it.
   const handlePointerDown = (e: React.PointerEvent) => {
-    if (isActive) e.preventDefault()
-    // Forward to dnd-kit's listener so drag still works
+    // Forward to dnd-kit FIRST — dnd-kit checks nativeEvent.defaultPrevented
+    // and silently aborts if true, so we must call it before preventDefault.
     const dndHandler = listeners?.onPointerDown as ((e: React.PointerEvent) => void) | undefined
     dndHandler?.(e)
+    if (isActive) e.preventDefault()
   }
 
   const handleMouseEnter = () => onHover?.(tab.id)

--- a/spa/src/components/StatusBar.test.tsx
+++ b/spa/src/components/StatusBar.test.tsx
@@ -110,6 +110,17 @@ describe('StatusBar upload progress', () => {
     expect(screen.getByText(/2\/5/)).toBeTruthy()
   })
 
+  it('shows typing status after upload completes', () => {
+    const ck = compositeKey(HOST_ID, 'dev001')
+    useUploadStore.setState({
+      sessions: { [ck]: { total: 2, completed: 2, failed: 0, currentFile: '', status: 'typing' } },
+    })
+    const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+    render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
+    expect(screen.getByTestId('upload-status')).toBeTruthy()
+    expect(screen.getByText('Typing into session...')).toBeTruthy()
+  })
+
   it('shows upload done', () => {
     const ck = compositeKey(HOST_ID, 'dev001')
     useUploadStore.setState({

--- a/spa/src/components/StatusBar.tsx
+++ b/spa/src/components/StatusBar.tsx
@@ -24,8 +24,16 @@ const VIEW_MODE_COLORS: Record<string, string> = {
 function UploadStatus({ hostId, sessionCode, t }: { hostId: string | null; sessionCode: string | null; t: (key: string, params?: Record<string, string | number>) => string }) {
   const ck = hostId && sessionCode ? compositeKey(hostId, sessionCode) : null
   const uploadState = useUploadStore((s) => ck ? s.sessions[ck] : undefined)
+  const setDone = useUploadStore((s) => s.setDone)
   const dismiss = useUploadStore((s) => s.dismiss)
   const uploadStatus = uploadState?.status
+
+  // Auto-transition "typing" → "done" after 1.5 seconds
+  useEffect(() => {
+    if (uploadStatus !== 'typing' || !hostId || !sessionCode) return
+    const timer = setTimeout(() => setDone(hostId, sessionCode), 1500)
+    return () => clearTimeout(timer)
+  }, [uploadStatus, hostId, sessionCode, setDone])
 
   // Auto-dismiss "done" after 3 seconds
   useEffect(() => {
@@ -48,6 +56,15 @@ function UploadStatus({ hostId, sessionCode, t }: { hostId: string | null; sessi
       <span className="flex items-center gap-1 text-yellow-400" data-testid="upload-status">
         <CircleNotch size={12} className="animate-spin" />
         <span>{t('upload.uploading', { file: uploadState.currentFile, current: uploadState.completed + 1, total: uploadState.total })}</span>
+      </span>
+    )
+  }
+
+  if (uploadState.status === 'typing') {
+    return (
+      <span className="flex items-center gap-1 text-blue-400" data-testid="upload-status">
+        <CircleNotch size={12} className="animate-spin" />
+        <span>{t('upload.typing')}</span>
       </span>
     )
   }

--- a/spa/src/components/TabBar.tsx
+++ b/spa/src/components/TabBar.tsx
@@ -99,7 +99,7 @@ export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, o
   }
 
   return (
-    <div className={`flex items-center px-1 flex-shrink-0 ${embedded ? 'h-full' : 'bg-surface-secondary border-b border-border-subtle'}`} style={embedded ? undefined : { height: 41 }}>
+    <div className={`flex items-center px-1 ${embedded ? 'h-full flex-1 min-w-0' : 'flex-shrink-0 bg-surface-secondary border-b border-border-subtle'}`} style={embedded ? undefined : { height: 41 }}>
       <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToTabZone]} onDragEnd={handleDragEnd}>
         {/* Pinned zone */}
         {pinnedTabs.length > 0 && (
@@ -140,7 +140,7 @@ export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, o
             </button>
           )}
           <div ref={normalZoneRef} className="flex items-center h-full overflow-x-auto scrollbar-hide">
-            <div ref={normalTabsRef} className="flex items-center h-full">
+            <div ref={normalTabsRef} className="flex items-center h-full flex-1" style={{ minWidth: 'min-content' }}>
               <SortableContext items={normalIds} strategy={horizontalListSortingStrategy}>
                 {normalTabs.map((tab, i) => (
                   <Fragment key={tab.id}>

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -293,6 +293,7 @@
 
   "upload.drop_files": "Drop files to upload",
   "upload.uploading": "Uploading {{file}} ({{current}}/{{total}})...",
+  "upload.typing": "Typing into session...",
   "upload.done_one": "{{count}} file uploaded",
   "upload.done_many": "{{count}} files uploaded",
   "upload.failed": "Upload failed: {{file}}",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -293,6 +293,7 @@
 
   "upload.drop_files": "拖放檔案以上傳",
   "upload.uploading": "上傳中 {{file}}（{{current}}/{{total}}）...",
+  "upload.typing": "輸入中…",
   "upload.done_one": "已上傳 {{count}} 個檔案",
   "upload.done_many": "已上傳 {{count}} 個檔案",
   "upload.failed": "上傳失敗：{{file}}",

--- a/spa/src/stores/useUploadStore.test.ts
+++ b/spa/src/stores/useUploadStore.test.ts
@@ -77,4 +77,13 @@ describe('useUploadStore', () => {
     expect(useUploadStore.getState().sessions[`${H}:dev`]).toBeDefined()
     expect(useUploadStore.getState().sessions[`${H}:dev`].status).toBe('uploading')
   })
+
+  it('dismiss does not clear typing state', () => {
+    useUploadStore.getState().startUpload(H, 'dev', 1, 'a.png')
+    useUploadStore.getState().fileCompleted(H, 'dev')
+    expect(useUploadStore.getState().sessions[`${H}:dev`].status).toBe('typing')
+    useUploadStore.getState().dismiss(H, 'dev')
+    expect(useUploadStore.getState().sessions[`${H}:dev`]).toBeDefined()
+    expect(useUploadStore.getState().sessions[`${H}:dev`].status).toBe('typing')
+  })
 })

--- a/spa/src/stores/useUploadStore.test.ts
+++ b/spa/src/stores/useUploadStore.test.ts
@@ -18,7 +18,7 @@ describe('useUploadStore', () => {
     expect(s.currentFile).toBe('a.png')
   })
 
-  it('fileCompleted increments count and sets done when all complete', () => {
+  it('fileCompleted increments count and sets typing when all complete', () => {
     useUploadStore.getState().startUpload(H, 'dev', 2, 'a.png')
     useUploadStore.getState().fileCompleted(H, 'dev')
     expect(useUploadStore.getState().sessions[`${H}:dev`].completed).toBe(1)
@@ -26,6 +26,14 @@ describe('useUploadStore', () => {
 
     useUploadStore.getState().fileCompleted(H, 'dev')
     expect(useUploadStore.getState().sessions[`${H}:dev`].completed).toBe(2)
+    expect(useUploadStore.getState().sessions[`${H}:dev`].status).toBe('typing')
+  })
+
+  it('setDone transitions typing to done', () => {
+    useUploadStore.getState().startUpload(H, 'dev', 1, 'a.png')
+    useUploadStore.getState().fileCompleted(H, 'dev')
+    expect(useUploadStore.getState().sessions[`${H}:dev`].status).toBe('typing')
+    useUploadStore.getState().setDone(H, 'dev')
     expect(useUploadStore.getState().sessions[`${H}:dev`].status).toBe('done')
   })
 
@@ -57,7 +65,8 @@ describe('useUploadStore', () => {
 
   it('dismiss clears done/error state', () => {
     useUploadStore.getState().startUpload(H, 'dev', 1, 'a.png')
-    useUploadStore.getState().fileCompleted(H, 'dev') // status → done
+    useUploadStore.getState().fileCompleted(H, 'dev') // status → typing
+    useUploadStore.getState().setDone(H, 'dev') // status → done
     useUploadStore.getState().dismiss(H, 'dev')
     expect(useUploadStore.getState().sessions[`${H}:dev`]).toBeUndefined()
   })

--- a/spa/src/stores/useUploadStore.ts
+++ b/spa/src/stores/useUploadStore.ts
@@ -100,8 +100,9 @@ export const useUploadStore = create<UploadState>((set) => ({
     const key = compositeKey(hostId, sessionCode)
     set((s) => {
       const prev = s.sessions[key]
-      // Don't dismiss while uploading — prevents concurrent drop from corrupting state.
-      if (prev?.status === 'uploading') return s
+      // Don't dismiss while uploading or typing — prevents concurrent drop from
+      // corrupting state and ensures the typing→done transition completes.
+      if (prev?.status === 'uploading' || prev?.status === 'typing') return s
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [key]: _, ...rest } = s.sessions
       return { sessions: rest }

--- a/spa/src/stores/useUploadStore.ts
+++ b/spa/src/stores/useUploadStore.ts
@@ -7,7 +7,7 @@ interface SessionUploadState {
   failed: number
   currentFile: string
   error?: string
-  status: 'uploading' | 'done' | 'error'
+  status: 'uploading' | 'typing' | 'done' | 'error'
 }
 
 interface UploadState {
@@ -16,6 +16,7 @@ interface UploadState {
   fileCompleted: (hostId: string, sessionCode: string) => void
   fileFailed: (hostId: string, sessionCode: string, filename: string) => void
   nextFile: (hostId: string, sessionCode: string, filename: string) => void
+  setDone: (hostId: string, sessionCode: string) => void
   dismiss: (hostId: string, sessionCode: string) => void
 }
 
@@ -45,7 +46,7 @@ export const useUploadStore = create<UploadState>((set) => ({
           [key]: {
             ...prev,
             completed,
-            status: allDone ? (prev.failed > 0 ? 'error' : 'done') : 'uploading',
+            status: allDone ? (prev.failed > 0 ? 'error' : 'typing') : 'uploading',
           },
         },
       }
@@ -80,6 +81,17 @@ export const useUploadStore = create<UploadState>((set) => ({
       if (!prev) return s
       return {
         sessions: { ...s.sessions, [key]: { ...prev, currentFile: filename } },
+      }
+    })
+  },
+
+  setDone: (hostId, sessionCode) => {
+    const key = compositeKey(hostId, sessionCode)
+    set((s) => {
+      const prev = s.sessions[key]
+      if (!prev || prev.status !== 'typing') return s
+      return {
+        sessions: { ...s.sessions, [key]: { ...prev, status: 'done' } },
       }
     })
   },


### PR DESCRIPTION
## Summary

- **Tab drag blocked on active tabs** — dnd-kit checks `nativeEvent.defaultPrevented`; reordered `handlePointerDown` to call dnd-kit handler before `preventDefault()`
- **Rename session "Failed to fetch"** — CORS middleware missing `PATCH` in allowed methods
- **Notification click silently lost** — Electron Notification JS wrapper GC'd after `show()` returns; hold refs in `Set<Notification>` with click/close cleanup
- **Tab overflow leaks to entire app** — Electron title bar tab container lacked width constraint; added `flex-1 min-w-0` + `normalTabsRef` uses `flex-1` with `min-content` so tabs shrink before scroll activates
- **Upload missing "typing" phase** — added `typing` status between `uploading` and `done` (1.5s → 3s → dismiss)

## Test plan

- [ ] 建立多個 tab，確認 active tab 可以拖曳排序
- [ ] 右鍵 tab → Rename Session，確認 PATCH 不再報 "Failed to fetch"
- [ ] 觸發 agent notification，點擊通知確認跳轉至正確 tab（同 workspace / 跨 workspace）
- [ ] 開 8+ 個 tab，確認 tab 自動縮減寬度而非整個 app 橫向捲動
- [ ] 拖放圖片到 terminal，確認顯示「上傳中 → 輸入中… → 上傳完成 → dismiss」