### PR TITLE
feat: workspace icon indicators (unread badge + status pill)

### DIFF
--- a/docs/superpowers/plans/2026-04-09-workspace-icon-indicators.md
+++ b/docs/superpowers/plans/2026-04-09-workspace-icon-indicators.md
@@ -1,0 +1,609 @@
+# Workspace Icon Indicators Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add unread badge and status pill indicators to workspace icons in the ActivityBar sidebar.
+
+**Architecture:** Extract a `WorkspaceButton` component from ActivityBar that uses a `useWorkspaceIndicators` hook to aggregate per-workspace unread counts and status from existing stores. Pure utility functions handle the tabId→compositeKey bridging and status priority logic, keeping the hook thin.
+
+**Tech Stack:** React 19, Zustand 5, Tailwind 4, Vitest, @testing-library/react
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `spa/src/features/workspace/workspace-indicators.ts` | Create | Pure utility functions: `getWorkspaceCompositeKeys`, `aggregateStatus` |
+| `spa/src/features/workspace/workspace-indicators.test.ts` | Create | Unit tests for utility functions |
+| `spa/src/features/workspace/useWorkspaceIndicators.ts` | Create | React hook: bridges stores → workspace-level indicators |
+| `spa/src/features/workspace/useWorkspaceIndicators.test.ts` | Create | Hook integration tests using `renderHook` |
+| `spa/src/features/workspace/components/ActivityBar.tsx` | Modify | Extract `WorkspaceButton` sub-component, add badge + pill rendering |
+| `spa/src/features/workspace/components/ActivityBar.test.tsx` | Modify | Add test cases for badge display, count, and aria-label |
+
+---
+
+### Task 1: Pure Utility Functions
+
+**Files:**
+- Create: `spa/src/features/workspace/workspace-indicators.ts`
+- Create: `spa/src/features/workspace/workspace-indicators.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// spa/src/features/workspace/workspace-indicators.test.ts
+import { describe, it, expect } from 'vitest'
+import type { Tab } from '../../types/tab'
+import { getWorkspaceCompositeKeys, aggregateStatus } from './workspace-indicators'
+
+function mockSessionTab(id: string, hostId: string, sessionCode: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: {
+      type: 'leaf',
+      pane: {
+        id: `pane-${id}`,
+        content: { kind: 'tmux-session', hostId, sessionCode, mode: 'terminal' as const, cachedName: '', tmuxInstance: '' },
+      },
+    },
+  }
+}
+
+function mockDashboardTab(id: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: { type: 'leaf', pane: { id: `pane-${id}`, content: { kind: 'dashboard' } } },
+  }
+}
+
+describe('getWorkspaceCompositeKeys', () => {
+  it('returns compositeKeys for tmux-session tabs', () => {
+    const tabs: Record<string, Tab> = {
+      t1: mockSessionTab('t1', 'h1', 's1'),
+      t2: mockSessionTab('t2', 'h1', 's2'),
+    }
+    expect(getWorkspaceCompositeKeys(['t1', 't2'], tabs)).toEqual(['h1:s1', 'h1:s2'])
+  })
+
+  it('skips non-session tabs', () => {
+    const tabs: Record<string, Tab> = {
+      t1: mockSessionTab('t1', 'h1', 's1'),
+      t2: mockDashboardTab('t2'),
+    }
+    expect(getWorkspaceCompositeKeys(['t1', 't2'], tabs)).toEqual(['h1:s1'])
+  })
+
+  it('skips missing tab IDs', () => {
+    const tabs: Record<string, Tab> = {
+      t1: mockSessionTab('t1', 'h1', 's1'),
+    }
+    expect(getWorkspaceCompositeKeys(['t1', 't999'], tabs)).toEqual(['h1:s1'])
+  })
+
+  it('returns empty array for empty workspace', () => {
+    expect(getWorkspaceCompositeKeys([], {})).toEqual([])
+  })
+})
+
+describe('aggregateStatus', () => {
+  it('returns undefined for empty array', () => {
+    expect(aggregateStatus([])).toBeUndefined()
+  })
+
+  it('returns undefined for all idle', () => {
+    expect(aggregateStatus(['idle', 'idle'])).toBeUndefined()
+  })
+
+  it('returns undefined for all undefined', () => {
+    expect(aggregateStatus([undefined, undefined])).toBeUndefined()
+  })
+
+  it('returns running when highest is running', () => {
+    expect(aggregateStatus(['running', 'idle'])).toBe('running')
+  })
+
+  it('returns waiting over running', () => {
+    expect(aggregateStatus(['running', 'waiting'])).toBe('waiting')
+  })
+
+  it('returns error over everything', () => {
+    expect(aggregateStatus(['running', 'waiting', 'error'])).toBe('error')
+  })
+
+  it('returns running when mixed with undefined', () => {
+    expect(aggregateStatus([undefined, 'running', undefined])).toBe('running')
+  })
+})
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+Run: `cd spa && npx vitest run src/features/workspace/workspace-indicators.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+// spa/src/features/workspace/workspace-indicators.ts
+import type { Tab } from '../../types/tab'
+import type { AgentStatus } from '../../stores/useAgentStore'
+import { getPrimaryPane } from '../../lib/pane-tree'
+import { compositeKey } from '../../lib/composite-key'
+
+/** Extract compositeKeys from a workspace's tab IDs. Skips non-session and missing tabs. */
+export function getWorkspaceCompositeKeys(tabIds: string[], tabs: Record<string, Tab>): string[] {
+  const keys: string[] = []
+  for (const id of tabIds) {
+    const tab = tabs[id]
+    if (!tab) continue
+    const { content } = getPrimaryPane(tab.layout)
+    if (content.kind !== 'tmux-session') continue
+    keys.push(compositeKey(content.hostId, content.sessionCode))
+  }
+  return keys
+}
+
+const STATUS_PRIORITY: Record<AgentStatus, number> = {
+  error: 3,
+  waiting: 2,
+  running: 1,
+  idle: 0,
+}
+
+/** Returns highest-priority status across tabs, or undefined if all idle/absent. */
+export function aggregateStatus(statuses: (AgentStatus | undefined)[]): AgentStatus | undefined {
+  let highest: AgentStatus | undefined
+  let highestPri = -1
+  for (const s of statuses) {
+    if (s === undefined) continue
+    const p = STATUS_PRIORITY[s]
+    if (p > highestPri) {
+      highest = s
+      highestPri = p
+    }
+  }
+  return highest === 'idle' ? undefined : highest
+}
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+Run: `cd spa && npx vitest run src/features/workspace/workspace-indicators.test.ts`
+Expected: All 9 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/features/workspace/workspace-indicators.ts spa/src/features/workspace/workspace-indicators.test.ts
+git commit -m "feat: add workspace indicator utility functions
+
+Pure functions for tabId→compositeKey bridging and status aggregation."
+```
+
+---
+
+### Task 2: useWorkspaceIndicators Hook
+
+**Files:**
+- Create: `spa/src/features/workspace/useWorkspaceIndicators.ts`
+- Create: `spa/src/features/workspace/useWorkspaceIndicators.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// spa/src/features/workspace/useWorkspaceIndicators.test.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTabStore } from '../../stores/useTabStore'
+import { useAgentStore } from '../../stores/useAgentStore'
+import { useWorkspaceIndicators } from './useWorkspaceIndicators'
+import type { Tab } from '../../types/tab'
+
+function mockSessionTab(id: string, hostId: string, sessionCode: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: {
+      type: 'leaf',
+      pane: {
+        id: `pane-${id}`,
+        content: { kind: 'tmux-session', hostId, sessionCode, mode: 'terminal' as const, cachedName: '', tmuxInstance: '' },
+      },
+    },
+  }
+}
+
+describe('useWorkspaceIndicators', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: {} })
+    useAgentStore.setState({ unread: {}, statuses: {} })
+  })
+
+  it('returns zero unread for empty workspace', () => {
+    const { result } = renderHook(() => useWorkspaceIndicators([]))
+    expect(result.current.unreadCount).toBe(0)
+    expect(result.current.aggregatedStatus).toBeUndefined()
+  })
+
+  it('counts unread tabs', () => {
+    useTabStore.setState({
+      tabs: {
+        t1: mockSessionTab('t1', 'h1', 's1'),
+        t2: mockSessionTab('t2', 'h1', 's2'),
+        t3: mockSessionTab('t3', 'h1', 's3'),
+      },
+    })
+    useAgentStore.setState({ unread: { 'h1:s1': true, 'h1:s2': false, 'h1:s3': true } })
+
+    const { result } = renderHook(() => useWorkspaceIndicators(['t1', 't2', 't3']))
+    expect(result.current.unreadCount).toBe(2)
+  })
+
+  it('aggregates status with priority', () => {
+    useTabStore.setState({
+      tabs: {
+        t1: mockSessionTab('t1', 'h1', 's1'),
+        t2: mockSessionTab('t2', 'h1', 's2'),
+      },
+    })
+    useAgentStore.setState({ statuses: { 'h1:s1': 'running', 'h1:s2': 'waiting' } })
+
+    const { result } = renderHook(() => useWorkspaceIndicators(['t1', 't2']))
+    expect(result.current.aggregatedStatus).toBe('waiting')
+  })
+
+  it('reacts to unread store updates', () => {
+    useTabStore.setState({ tabs: { t1: mockSessionTab('t1', 'h1', 's1') } })
+    const { result } = renderHook(() => useWorkspaceIndicators(['t1']))
+    expect(result.current.unreadCount).toBe(0)
+
+    act(() => {
+      useAgentStore.setState({ unread: { 'h1:s1': true } })
+    })
+    expect(result.current.unreadCount).toBe(1)
+  })
+
+  it('returns undefined status for all-idle workspace', () => {
+    useTabStore.setState({ tabs: { t1: mockSessionTab('t1', 'h1', 's1') } })
+    useAgentStore.setState({ statuses: { 'h1:s1': 'idle' } })
+
+    const { result } = renderHook(() => useWorkspaceIndicators(['t1']))
+    expect(result.current.aggregatedStatus).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+Run: `cd spa && npx vitest run src/features/workspace/useWorkspaceIndicators.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+// spa/src/features/workspace/useWorkspaceIndicators.ts
+import { useCallback, useMemo } from 'react'
+import { useTabStore } from '../../stores/useTabStore'
+import { useAgentStore } from '../../stores/useAgentStore'
+import type { AgentStatus } from '../../stores/useAgentStore'
+import { getWorkspaceCompositeKeys, aggregateStatus } from './workspace-indicators'
+
+interface WorkspaceIndicators {
+  unreadCount: number
+  aggregatedStatus: AgentStatus | undefined
+}
+
+export function useWorkspaceIndicators(tabIds: string[]): WorkspaceIndicators {
+  const tabs = useTabStore((s) => s.tabs)
+
+  const compositeKeys = useMemo(
+    () => getWorkspaceCompositeKeys(tabIds, tabs),
+    [tabIds, tabs],
+  )
+
+  const unreadCount = useAgentStore(
+    useCallback(
+      (s: { unread: Record<string, boolean> }) =>
+        compositeKeys.reduce((n, k) => n + (s.unread[k] ? 1 : 0), 0),
+      [compositeKeys],
+    ),
+  )
+
+  const aggregatedStatus = useAgentStore(
+    useCallback(
+      (s: { statuses: Record<string, AgentStatus> }) =>
+        aggregateStatus(compositeKeys.map((k) => s.statuses[k])),
+      [compositeKeys],
+    ),
+  )
+
+  return { unreadCount, aggregatedStatus }
+}
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+Run: `cd spa && npx vitest run src/features/workspace/useWorkspaceIndicators.test.ts`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/features/workspace/useWorkspaceIndicators.ts spa/src/features/workspace/useWorkspaceIndicators.test.ts
+git commit -m "feat: add useWorkspaceIndicators hook
+
+Zustand-based hook bridging tab/agent stores to workspace-level
+unread count and aggregated status."
+```
+
+---
+
+### Task 3: Extract WorkspaceButton + Unread Badge
+
+**Files:**
+- Modify: `spa/src/features/workspace/components/ActivityBar.tsx`
+- Modify: `spa/src/features/workspace/components/ActivityBar.test.tsx`
+
+- [ ] **Step 1: Extract WorkspaceButton and add badge in ActivityBar.tsx**
+
+Add imports at top of file:
+
+```typescript
+import { useWorkspaceIndicators } from '../useWorkspaceIndicators'
+```
+
+Add `WorkspaceButton` component before the `ActivityBar` export. This replaces the inline workspace button JSX in the `.map()`:
+
+```typescript
+interface WorkspaceButtonProps {
+  workspace: Workspace
+  isActive: boolean
+  onSelect: (wsId: string) => void
+  onContextMenu?: (e: React.MouseEvent, wsId: string) => void
+}
+
+function WorkspaceButton({ workspace: ws, isActive, onSelect, onContextMenu }: WorkspaceButtonProps) {
+  const { unreadCount } = useWorkspaceIndicators(ws.tabs)
+  const showBadge = !isActive && unreadCount > 0
+
+  return (
+    <button
+      title={ws.name}
+      aria-label={showBadge ? `${ws.name}, ${unreadCount} unread` : ws.name}
+      onClick={() => onSelect(ws.id)}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        onContextMenu?.(e, ws.id)
+      }}
+      className={`relative w-[30px] h-[30px] rounded-md flex items-center justify-center text-sm cursor-pointer transition-all ${
+        isActive
+          ? 'bg-[#8b5cf6]/35 text-text-primary ring-2 ring-purple-400'
+          : 'bg-surface-secondary text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+      }`}
+    >
+      <WorkspaceIcon icon={ws.icon} name={ws.name} size={16} weight={ws.iconWeight} />
+      {showBadge && (
+        <span
+          data-testid="ws-unread-badge"
+          className="absolute -top-[5px] -right-[6px] min-w-[15px] h-[15px] rounded-full flex items-center justify-center text-white text-[9px] font-bold px-[3px] leading-none"
+          style={{ backgroundColor: '#dc2626', boxShadow: '0 0 0 2px var(--surface-tertiary)' }}
+        >
+          {unreadCount}
+        </span>
+      )}
+    </button>
+  )
+}
+```
+
+Replace the workspace `.map()` block (lines 55-75) in ActivityBar with:
+
+```typescript
+{workspaces.map((ws) => (
+  <WorkspaceButton
+    key={ws.id}
+    workspace={ws}
+    isActive={activeWorkspaceId === ws.id && !activeStandaloneTabId}
+    onSelect={onSelectWorkspace}
+    onContextMenu={onContextMenuWorkspace}
+  />
+))}
+```
+
+- [ ] **Step 2: Run existing tests to verify no regression**
+
+Run: `cd spa && npx vitest run src/features/workspace/components/ActivityBar.test.tsx`
+Expected: All 8 existing tests PASS (stores default to empty → no badge renders → no interference)
+
+- [ ] **Step 3: Add badge test cases to ActivityBar.test.tsx**
+
+Add imports at top:
+
+```typescript
+import { useTabStore } from '../../../stores/useTabStore'
+import { useAgentStore } from '../../../stores/useAgentStore'
+import type { Tab } from '../../../types/tab'
+```
+
+Add helper inside test file:
+
+```typescript
+function mockSessionTab(id: string, hostId: string, sessionCode: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: {
+      type: 'leaf',
+      pane: {
+        id: `pane-${id}`,
+        content: { kind: 'tmux-session', hostId, sessionCode, mode: 'terminal' as const, cachedName: '', tmuxInstance: '' },
+      },
+    },
+  }
+}
+```
+
+Add to `beforeEach`:
+
+```typescript
+useTabStore.setState({ tabs: {} })
+useAgentStore.setState({ unread: {}, statuses: {} })
+```
+
+Add new test cases inside the `describe` block:
+
+```typescript
+it('shows unread badge on inactive workspace', () => {
+  useTabStore.setState({
+    tabs: {
+      t1: mockSessionTab('t1', 'h1', 's1'),
+      t2: mockSessionTab('t2', 'h1', 's2'),
+      t3: mockSessionTab('t3', 'h1', 's3'),
+    },
+  })
+  useAgentStore.setState({ unread: { 'h1:s3': true } })
+
+  render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
+
+  const badges = screen.getAllByTestId('ws-unread-badge')
+  expect(badges).toHaveLength(1)
+  expect(badges[0].textContent).toBe('1')
+})
+
+it('hides unread badge on active workspace', () => {
+  useTabStore.setState({
+    tabs: {
+      t1: mockSessionTab('t1', 'h1', 's1'),
+      t2: mockSessionTab('t2', 'h1', 's2'),
+    },
+  })
+  useAgentStore.setState({ unread: { 'h1:s1': true } })
+
+  render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
+
+  // ws-1 is active → no badge even though t1 is unread
+  expect(screen.queryAllByTestId('ws-unread-badge')).toHaveLength(0)
+})
+
+it('includes unread count in aria-label', () => {
+  useTabStore.setState({
+    tabs: { t3: mockSessionTab('t3', 'h1', 's3') },
+  })
+  useAgentStore.setState({ unread: { 'h1:s3': true } })
+
+  render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
+
+  expect(screen.getByLabelText('Server, 1 unread')).toBeTruthy()
+})
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `cd spa && npx vitest run src/features/workspace/`
+Expected: All tests PASS (utilities + hook + ActivityBar)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/features/workspace/components/ActivityBar.tsx spa/src/features/workspace/components/ActivityBar.test.tsx
+git commit -m "feat: add unread badge to workspace icons
+
+Extract WorkspaceButton component, integrate useWorkspaceIndicators
+hook, render red badge with count on inactive workspaces."
+```
+
+---
+
+### Task 4: Status Pill (Initial Implementation)
+
+**Files:**
+- Modify: `spa/src/features/workspace/components/ActivityBar.tsx`
+
+> **Note:** This task's visual output is subject to iteration. The initial implementation provides a working pill that can be adjusted visually.
+
+- [ ] **Step 1: Add status pill to WorkspaceButton**
+
+Add status color constant before `WorkspaceButton`:
+
+```typescript
+const PILL_COLORS: Record<string, string> = {
+  running: '#4ade80',
+  waiting: '#facc15',
+  error: '#ef4444',
+}
+```
+
+In `WorkspaceButton`, destructure `aggregatedStatus` from the hook (already called but not used):
+
+```typescript
+const { unreadCount, aggregatedStatus } = useWorkspaceIndicators(ws.tabs)
+```
+
+Add pill JSX inside the `<button>`, after the `WorkspaceIcon`:
+
+```typescript
+{aggregatedStatus && (
+  <span
+    className={`absolute rounded-r-sm ${aggregatedStatus === 'running' ? 'animate-breathe' : ''}`}
+    style={{
+      left: '-7px',
+      top: '50%',
+      transform: 'translateY(-50%)',
+      width: '3px',
+      height: aggregatedStatus === 'error' || aggregatedStatus === 'waiting' ? '60%' : '40%',
+      backgroundColor: PILL_COLORS[aggregatedStatus],
+      '--breathe-color': PILL_COLORS[aggregatedStatus],
+      '--breathe-bg': 'transparent',
+    } as React.CSSProperties}
+  />
+)}
+```
+
+- [ ] **Step 2: Run all tests to verify no regression**
+
+Run: `cd spa && npx vitest run src/features/workspace/`
+Expected: All tests PASS
+
+- [ ] **Step 3: Visual verification**
+
+Run: `cd spa && pnpm run dev`
+Open `http://100.64.0.2:5174` — verify:
+- Workspace with running agent shows green pill on left edge
+- Workspace with waiting agent shows yellow pill (taller)
+- Idle workspaces show no pill
+- Badge and pill coexist without overlap
+
+> Adjust pill position (`left`), height percentages, and active-workspace visibility based on visual feedback. This is expected to require iteration.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/features/workspace/components/ActivityBar.tsx
+git commit -m "feat: add status pill to workspace icons (initial)
+
+Discord-style left pill showing aggregated agent status.
+Position and active-workspace behavior subject to iteration."
+```
+
+---
+
+## Run All Tests
+
+After all tasks, verify the full test suite:
+
+```bash
+cd spa && npx vitest run
+```
+
+Expected: All tests PASS, no regressions.

--- a/docs/superpowers/plans/2026-04-09-workspace-icon-indicators.md
+++ b/docs/superpowers/plans/2026-04-09-workspace-icon-indicators.md
@@ -481,19 +481,23 @@ it('shows unread badge on inactive workspace', () => {
   expect(badges[0].textContent).toBe('1')
 })
 
-it('hides unread badge on active workspace', () => {
+it('hides unread badge on active workspace even when it has unread tabs', () => {
   useTabStore.setState({
     tabs: {
       t1: mockSessionTab('t1', 'h1', 's1'),
       t2: mockSessionTab('t2', 'h1', 's2'),
+      t3: mockSessionTab('t3', 'h1', 's3'),
     },
   })
-  useAgentStore.setState({ unread: { 'h1:s1': true } })
+  // ws-1 (active) has t1 unread, ws-2 (inactive) has t3 unread
+  useAgentStore.setState({ unread: { 'h1:s1': true, 'h1:s3': true } })
 
   render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
 
-  // ws-1 is active → no badge even though t1 is unread
-  expect(screen.queryAllByTestId('ws-unread-badge')).toHaveLength(0)
+  // Only ws-2's badge should show — ws-1 is active so its badge is suppressed
+  const badges = screen.getAllByTestId('ws-unread-badge')
+  expect(badges).toHaveLength(1)
+  expect(badges[0].textContent).toBe('1')
 })
 
 it('includes unread count in aria-label', () => {

--- a/docs/superpowers/specs/2026-04-09-workspace-icon-indicators-design.md
+++ b/docs/superpowers/specs/2026-04-09-workspace-icon-indicators-design.md
@@ -25,25 +25,30 @@
 - 外框：`box-shadow: 0 0 0 2px` sidebar 背景色，確保深色背景下可辨識
 - 數字 ≥ 10 時 badge 自動撐寬（`min-width` + `padding: 0 3px`）
 
+### tabId → compositeKey 橋接
+
+ActivityBar 只有 `workspace.tabs[]`（tab ID 陣列）。要取得 compositeKey 需要：
+
+1. 從 `useTabStore` 取得 `Tab` 物件
+2. 用 `getPrimaryPane(tab.layout)` 取得主要 pane
+3. 檢查 `content.kind === 'tmux-session'`（非 session 的 tab 如 dashboard/settings/hosts 直接跳過）
+4. 取 `content.hostId` + `content.sessionCode` → `compositeKey()`
+
+Split-pane tab 只取 primary pane 的 compositeKey，與 `SortableTab` 的現有做法一致。
+
 ### 資料流
 
 ```
-useAgentStore.unread (Record<compositeKey, boolean>)
+useTabStore.tabs (Tab[])
+  ↓ 過濾 workspace.tabs[] 中的 tabId
+  ↓ getPrimaryPane(tab.layout).content
+  ↓ guard: kind === 'tmux-session'
+  ↓ compositeKey(hostId, sessionCode)
   ↓
-ActivityBar 讀取 workspace.tabs[]
-  ↓ 對每個 tabId 取得 hostId:sessionCode → compositeKey
-  ↓ 計算 unread count
+useAgentStore.unread[ck] === true → 計數
   ↓
 條件渲染 badge（!isActive && count > 0）
 ```
-
-### 涉及檔案
-
-| 檔案 | 變更 |
-|------|------|
-| `spa/src/features/workspace/components/ActivityBar.tsx` | workspace button 內加入 badge 渲染邏輯 |
-| `spa/src/stores/useAgentStore.ts` | 可能新增 selector helper（依複雜度決定） |
-| `spa/src/types/tab.ts` | 無變更（Tab 已有 layout → hostId/sessionCode） |
 
 ## 功能二：狀態 Pill（方向定義，UI 實作階段迭代）
 
@@ -69,25 +74,27 @@ ActivityBar 讀取 workspace.tabs[]
 
 ### 資料流
 
-```
-useAgentStore.statuses (Record<compositeKey, AgentStatus>)
-  ↓
-ActivityBar 讀取 workspace.tabs[]
-  ↓ 對每個 tabId 取得 compositeKey → status
-  ↓ 取最高優先級狀態
-  ↓
-條件渲染 pill（status !== 'idle' && status !== undefined）
-```
+同未讀 badge 的 tabId → compositeKey 橋接流程，最後改為讀 `useAgentStore.statuses[ck]` 並取最高優先級。
 
-### 涉及檔案
+## 涉及檔案
 
 | 檔案 | 變更 |
 |------|------|
-| `spa/src/features/workspace/components/ActivityBar.tsx` | 加入 pill 渲染 + 狀態彙整邏輯 |
-| `spa/src/stores/useAgentStore.ts` | 可能新增 workspace-level status selector |
+| `spa/src/features/workspace/components/ActivityBar.tsx` | workspace button 內加入 badge + pill 渲染 |
+| `spa/src/features/workspace/hooks/useWorkspaceIndicators.ts` | **新增** — 封裝 tabId→compositeKey 橋接、unread 聚合、狀態優先級計算 |
+| `spa/src/stores/useTabStore.ts` | 讀取依賴（hook 內訂閱） |
+| `spa/src/stores/useAgentStore.ts` | 讀取依賴（hook 內訂閱） |
+| `spa/src/features/workspace/components/ActivityBar.test.tsx` | 補測 badge 顯示/隱藏、數字計算 |
+
+## 實作注意事項
+
+- **效能**：`useWorkspaceIndicators` hook 須用精準 selector 訂閱 store，避免整個 `unread` 物件變動觸發全量重算。用 `useMemo` 將 tabIds 轉為 compositeKeys，再逐 key 訂閱。
+- **元件職責**：聚合邏輯全部放在 `useWorkspaceIndicators` hook，ActivityBar 維持純渲染層。
+- **Accessibility**：workspace button 的 `aria-label` 需包含未讀數（如 `"Workspace Foo, 3 unread"`），與 commit `4c5661f6` 的 aria-label 方向一致。
 
 ## 不做的事
 
 - 不改變現有 tab 級別的 unread/status 行為
 - 不改變 `markRead()` 的觸發時機
 - Home 按鈕維持現有的 `standaloneTabCount` badge，不套用新的 unread 計算
+- 不處理斷線 host 的特殊視覺狀態（`clearHost()` 已清除狀態，行為合理）

--- a/docs/superpowers/specs/2026-04-09-workspace-icon-indicators-design.md
+++ b/docs/superpowers/specs/2026-04-09-workspace-icon-indicators-design.md
@@ -81,7 +81,8 @@ useAgentStore.unread[ck] === true → 計數
 | 檔案 | 變更 |
 |------|------|
 | `spa/src/features/workspace/components/ActivityBar.tsx` | workspace button 內加入 badge + pill 渲染 |
-| `spa/src/features/workspace/hooks/useWorkspaceIndicators.ts` | **新增** — 封裝 tabId→compositeKey 橋接、unread 聚合、狀態優先級計算 |
+| `spa/src/features/workspace/workspace-indicators.ts` | **新增** — 純函式：tabId→compositeKey 橋接、狀態優先級計算 |
+| `spa/src/features/workspace/useWorkspaceIndicators.ts` | **新增** — React hook：封裝 store 訂閱、unread 聚合 |
 | `spa/src/stores/useTabStore.ts` | 讀取依賴（hook 內訂閱） |
 | `spa/src/stores/useAgentStore.ts` | 讀取依賴（hook 內訂閱） |
 | `spa/src/features/workspace/components/ActivityBar.test.tsx` | 補測 badge 顯示/隱藏、數字計算 |

--- a/docs/superpowers/specs/2026-04-09-workspace-icon-indicators-design.md
+++ b/docs/superpowers/specs/2026-04-09-workspace-icon-indicators-design.md
@@ -1,0 +1,93 @@
+# Workspace Icon 指示器設計
+
+## 概述
+
+在 ActivityBar 的 workspace icon 上新增兩種指示器，讓使用者不切換 workspace 就能掌握各 workspace 的狀態：
+
+1. **未讀 badge** — 統計 workspace 內有幾個 unread tab，顯示紅色數字徽章
+2. **狀態 pill** — 彙整 workspace 內 tab 的 agent 狀態，以 Discord 風格左側 pill 呈現
+
+## 功能一：未讀 Badge（完整定義）
+
+### 行為規則
+
+- 計算方式：workspace 的 `tabs[]` 中，`useAgentStore.unread[compositeKey] === true` 的 tab 數量
+- 顯示條件：`workspace 不是 active` **且** `unread count > 0`
+- Active workspace 隱藏 badge，但不清除 unread 狀態；切走後若仍有未讀，badge 重新出現
+- 每個 tab 的 unread 清除時機不變：tab 被 activate 時呼叫 `markRead()`
+
+### 視覺規格
+
+- 位置：workspace button 右上角，`top: -5px; right: -6px`
+- 尺寸：`min-width: 15px; height: 15px; border-radius: 8px`
+- 顏色：`background: #dc2626`（紅），`color: #fff`
+- 字體：`font-size: 9px; font-weight: 700`
+- 外框：`box-shadow: 0 0 0 2px` sidebar 背景色，確保深色背景下可辨識
+- 數字 ≥ 10 時 badge 自動撐寬（`min-width` + `padding: 0 3px`）
+
+### 資料流
+
+```
+useAgentStore.unread (Record<compositeKey, boolean>)
+  ↓
+ActivityBar 讀取 workspace.tabs[]
+  ↓ 對每個 tabId 取得 hostId:sessionCode → compositeKey
+  ↓ 計算 unread count
+  ↓
+條件渲染 badge（!isActive && count > 0）
+```
+
+### 涉及檔案
+
+| 檔案 | 變更 |
+|------|------|
+| `spa/src/features/workspace/components/ActivityBar.tsx` | workspace button 內加入 badge 渲染邏輯 |
+| `spa/src/stores/useAgentStore.ts` | 可能新增 selector helper（依複雜度決定） |
+| `spa/src/types/tab.ts` | 無變更（Tab 已有 layout → hostId/sessionCode） |
+
+## 功能二：狀態 Pill（方向定義，UI 實作階段迭代）
+
+### 目標行為
+
+- 彙整 workspace 內所有 tab 的 agent 狀態，取最高優先級：`error > waiting > running > idle`
+- 優先級規則：任一 tab 為 `waiting` 或 `error` 即視為需關注；全部 `running` 則顯示 running；全部 `idle` 或無狀態則不顯示
+- `idle` 不顯示 pill（與 tab 上 idle 不顯示 dot 的行為一致）
+
+### UI 方向（待迭代）
+
+經過 brainstorming 比較了 7 種方案（A-G），初步偏向 **Discord 風格左側 pill**（方案 F1）：
+
+- Pill 定位在 sidebar container 的 `left: 0`，不佔 button 空間
+- Pill 顏色對應狀態：綠（running）、黃（waiting）、紅（error）
+- Running 狀態加 breathe 動畫
+
+**待解決**：active workspace 已有 purple ring，pill 如何共存。可能方案：
+1. Pill 統一負責 active + 狀態指示，移除 purple ring
+2. Active workspace 不顯示 pill（狀態已可在 tab bar 看到）
+
+此部分在實作階段邊做邊調整視覺呈現。
+
+### 資料流
+
+```
+useAgentStore.statuses (Record<compositeKey, AgentStatus>)
+  ↓
+ActivityBar 讀取 workspace.tabs[]
+  ↓ 對每個 tabId 取得 compositeKey → status
+  ↓ 取最高優先級狀態
+  ↓
+條件渲染 pill（status !== 'idle' && status !== undefined）
+```
+
+### 涉及檔案
+
+| 檔案 | 變更 |
+|------|------|
+| `spa/src/features/workspace/components/ActivityBar.tsx` | 加入 pill 渲染 + 狀態彙整邏輯 |
+| `spa/src/stores/useAgentStore.ts` | 可能新增 workspace-level status selector |
+
+## 不做的事
+
+- 不改變現有 tab 級別的 unread/status 行為
+- 不改變 `markRead()` 的觸發時機
+- Home 按鈕維持現有的 `standaloneTabCount` badge，不套用新的 unread 計算

--- a/spa/src/features/workspace/components/ActivityBar.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.test.tsx
@@ -8,6 +8,25 @@ vi.mock('../generated/icon-loader', () => ({
 
 import { ActivityBar } from './ActivityBar'
 import type { Workspace } from '../../../types/tab'
+import { useTabStore } from '../../../stores/useTabStore'
+import { useAgentStore } from '../../../stores/useAgentStore'
+import type { Tab } from '../../../types/tab'
+
+function mockSessionTab(id: string, hostId: string, sessionCode: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: {
+      type: 'leaf',
+      pane: {
+        id: `pane-${id}`,
+        content: { kind: 'tmux-session', hostId, sessionCode, mode: 'terminal' as const, cachedName: '', tmuxInstance: '' },
+      },
+    },
+  }
+}
 
 const mockWorkspaces: Workspace[] = [
   { id: 'ws-1', name: 'Project A', icon: '🔧', tabs: ['t1', 't2'], activeTabId: 't1' },
@@ -30,6 +49,8 @@ describe('ActivityBar', () => {
   beforeEach(() => {
     cleanup()
     vi.clearAllMocks()
+    useTabStore.setState({ tabs: {} })
+    useAgentStore.setState({ unread: {}, statuses: {} })
   })
 
   it('renders workspace icons', () => {
@@ -80,5 +101,52 @@ describe('ActivityBar', () => {
     const { container } = render(<ActivityBar {...defaultProps} activeWorkspaceId={null} standaloneTabCount={3} />)
     const badge = container.querySelector('.bg-red-500')
     expect(badge).toBeNull()
+  })
+
+  it('shows unread badge on inactive workspace', () => {
+    useTabStore.setState({
+      tabs: {
+        t1: mockSessionTab('t1', 'h1', 's1'),
+        t2: mockSessionTab('t2', 'h1', 's2'),
+        t3: mockSessionTab('t3', 'h1', 's3'),
+      },
+    })
+    useAgentStore.setState({ unread: { 'h1:s3': true } })
+
+    render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
+
+    const badges = screen.getAllByTestId('ws-unread-badge')
+    expect(badges).toHaveLength(1)
+    expect(badges[0].textContent).toBe('1')
+  })
+
+  it('hides unread badge on active workspace even when it has unread tabs', () => {
+    useTabStore.setState({
+      tabs: {
+        t1: mockSessionTab('t1', 'h1', 's1'),
+        t2: mockSessionTab('t2', 'h1', 's2'),
+        t3: mockSessionTab('t3', 'h1', 's3'),
+      },
+    })
+    // ws-1 (active) has t1 unread, ws-2 (inactive) has t3 unread
+    useAgentStore.setState({ unread: { 'h1:s1': true, 'h1:s3': true } })
+
+    render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
+
+    // Only ws-2's badge should show — ws-1 is active so its badge is suppressed
+    const badges = screen.getAllByTestId('ws-unread-badge')
+    expect(badges).toHaveLength(1)
+    expect(badges[0].textContent).toBe('1')
+  })
+
+  it('includes unread count in aria-label', () => {
+    useTabStore.setState({
+      tabs: { t3: mockSessionTab('t3', 'h1', 's3') },
+    })
+    useAgentStore.setState({ unread: { 'h1:s3': true } })
+
+    render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
+
+    expect(screen.getByLabelText('Server, 1 unread')).toBeTruthy()
   })
 })

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -3,6 +3,7 @@ import type { Workspace } from '../../../types/tab'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { WorkspaceIcon } from './WorkspaceIcon'
 import { useWorkspaceIndicators } from '../useWorkspaceIndicators'
+import type { ActiveStatus } from '../workspace-indicators'
 
 interface WorkspaceButtonProps {
   workspace: Workspace
@@ -11,7 +12,7 @@ interface WorkspaceButtonProps {
   onContextMenu?: (e: React.MouseEvent, wsId: string) => void
 }
 
-const PILL_COLORS: Record<string, string> = {
+const PILL_COLORS: Record<ActiveStatus, string> = {
   running: '#4ade80',
   waiting: '#facc15',
   error: '#ef4444',
@@ -49,7 +50,7 @@ function WorkspaceButton({ workspace: ws, isActive, onSelect, onContextMenu }: W
             height: aggregatedStatus === 'error' || aggregatedStatus === 'waiting' ? '60%' : '40%',
             backgroundColor: PILL_COLORS[aggregatedStatus],
             '--breathe-color': PILL_COLORS[aggregatedStatus],
-            '--breathe-bg': 'transparent',
+            '--breathe-bg': 'var(--surface-tertiary)',
           } as React.CSSProperties}
         />
       )}

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -2,6 +2,51 @@ import { Plus, GearSix, HardDrives, SquaresFour } from '@phosphor-icons/react'
 import type { Workspace } from '../../../types/tab'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { WorkspaceIcon } from './WorkspaceIcon'
+import { useWorkspaceIndicators } from '../useWorkspaceIndicators'
+
+interface WorkspaceButtonProps {
+  workspace: Workspace
+  isActive: boolean
+  onSelect: (wsId: string) => void
+  onContextMenu?: (e: React.MouseEvent, wsId: string) => void
+}
+
+function WorkspaceButton({ workspace: ws, isActive, onSelect, onContextMenu }: WorkspaceButtonProps) {
+  const { unreadCount } = useWorkspaceIndicators(ws.tabs)
+  const showBadge = !isActive && unreadCount > 0
+
+  return (
+    <div className="relative group">
+      <button
+        aria-label={showBadge ? `${ws.name}, ${unreadCount} unread` : ws.name}
+        onClick={() => onSelect(ws.id)}
+        onContextMenu={(e) => {
+          e.preventDefault()
+          onContextMenu?.(e, ws.id)
+        }}
+        className={`w-[30px] h-[30px] rounded-md flex items-center justify-center text-sm cursor-pointer transition-all ${
+          isActive
+            ? 'bg-[#8b5cf6]/35 text-text-primary ring-2 ring-purple-400'
+            : 'bg-surface-secondary text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+        }`}
+      >
+        <WorkspaceIcon icon={ws.icon} name={ws.name} size={16} weight={ws.iconWeight} />
+      </button>
+      {showBadge && (
+        <span
+          data-testid="ws-unread-badge"
+          className="absolute -top-[5px] -right-[6px] min-w-[15px] h-[15px] rounded-full flex items-center justify-center text-white text-[9px] font-bold px-[3px] leading-none z-10"
+          style={{ backgroundColor: '#dc2626', boxShadow: '0 0 0 2px var(--surface-tertiary)' }}
+        >
+          {unreadCount}
+        </span>
+      )}
+      <span className="pointer-events-none absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50">
+        {ws.name}
+      </span>
+    </div>
+  )
+}
 
 interface Props {
   workspaces: Workspace[]
@@ -52,31 +97,15 @@ export function ActivityBar({
       {workspaces.length > 0 && <div className="w-5 h-px bg-border-default my-0.5" />}
 
       {/* Workspaces */}
-      {workspaces.map((ws) => {
-        const isActive = activeWorkspaceId === ws.id && !activeStandaloneTabId
-        return (
-          <div key={ws.id} className="relative group">
-            <button
-              aria-label={ws.name}
-              onClick={() => onSelectWorkspace(ws.id)}
-              onContextMenu={(e) => {
-                e.preventDefault()
-                onContextMenuWorkspace?.(e, ws.id)
-              }}
-              className={`w-[30px] h-[30px] rounded-md flex items-center justify-center text-sm cursor-pointer transition-all ${
-                isActive
-                  ? 'bg-[#8b5cf6]/35 text-text-primary ring-2 ring-purple-400'
-                  : 'bg-surface-secondary text-text-secondary hover:bg-surface-hover hover:text-text-primary'
-              }`}
-            >
-              <WorkspaceIcon icon={ws.icon} name={ws.name} size={16} weight={ws.iconWeight} />
-            </button>
-            <span className="pointer-events-none absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50">
-              {ws.name}
-            </span>
-          </div>
-        )
-      })}
+      {workspaces.map((ws) => (
+        <WorkspaceButton
+          key={ws.id}
+          workspace={ws}
+          isActive={activeWorkspaceId === ws.id && !activeStandaloneTabId}
+          onSelect={onSelectWorkspace}
+          onContextMenu={onContextMenuWorkspace}
+        />
+      ))}
 
       {/* Add + Settings */}
       <div className="mt-auto flex flex-col items-center gap-2 pb-1">

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -11,8 +11,14 @@ interface WorkspaceButtonProps {
   onContextMenu?: (e: React.MouseEvent, wsId: string) => void
 }
 
+const PILL_COLORS: Record<string, string> = {
+  running: '#4ade80',
+  waiting: '#facc15',
+  error: '#ef4444',
+}
+
 function WorkspaceButton({ workspace: ws, isActive, onSelect, onContextMenu }: WorkspaceButtonProps) {
-  const { unreadCount } = useWorkspaceIndicators(ws.tabs)
+  const { unreadCount, aggregatedStatus } = useWorkspaceIndicators(ws.tabs)
   const showBadge = !isActive && unreadCount > 0
 
   return (
@@ -32,6 +38,21 @@ function WorkspaceButton({ workspace: ws, isActive, onSelect, onContextMenu }: W
       >
         <WorkspaceIcon icon={ws.icon} name={ws.name} size={16} weight={ws.iconWeight} />
       </button>
+      {aggregatedStatus && (
+        <span
+          className={`absolute rounded-r-sm ${aggregatedStatus === 'running' ? 'animate-breathe' : ''}`}
+          style={{
+            left: '-7px',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            width: '3px',
+            height: aggregatedStatus === 'error' || aggregatedStatus === 'waiting' ? '60%' : '40%',
+            backgroundColor: PILL_COLORS[aggregatedStatus],
+            '--breathe-color': PILL_COLORS[aggregatedStatus],
+            '--breathe-bg': 'transparent',
+          } as React.CSSProperties}
+        />
+      )}
       {showBadge && (
         <span
           data-testid="ws-unread-badge"

--- a/spa/src/features/workspace/useWorkspaceIndicators.test.ts
+++ b/spa/src/features/workspace/useWorkspaceIndicators.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTabStore } from '../../stores/useTabStore'
+import { useAgentStore } from '../../stores/useAgentStore'
+import { useWorkspaceIndicators } from './useWorkspaceIndicators'
+import type { Tab } from '../../types/tab'
+
+function mockSessionTab(id: string, hostId: string, sessionCode: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: {
+      type: 'leaf',
+      pane: {
+        id: `pane-${id}`,
+        content: { kind: 'tmux-session', hostId, sessionCode, mode: 'terminal' as const, cachedName: '', tmuxInstance: '' },
+      },
+    },
+  }
+}
+
+describe('useWorkspaceIndicators', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: {} })
+    useAgentStore.setState({ unread: {}, statuses: {} })
+  })
+
+  it('returns zero unread for empty workspace', () => {
+    const { result } = renderHook(() => useWorkspaceIndicators([]))
+    expect(result.current.unreadCount).toBe(0)
+    expect(result.current.aggregatedStatus).toBeUndefined()
+  })
+
+  it('counts unread tabs', () => {
+    useTabStore.setState({
+      tabs: {
+        t1: mockSessionTab('t1', 'h1', 's1'),
+        t2: mockSessionTab('t2', 'h1', 's2'),
+        t3: mockSessionTab('t3', 'h1', 's3'),
+      },
+    })
+    useAgentStore.setState({ unread: { 'h1:s1': true, 'h1:s2': false, 'h1:s3': true } })
+
+    const { result } = renderHook(() => useWorkspaceIndicators(['t1', 't2', 't3']))
+    expect(result.current.unreadCount).toBe(2)
+  })
+
+  it('aggregates status with priority', () => {
+    useTabStore.setState({
+      tabs: {
+        t1: mockSessionTab('t1', 'h1', 's1'),
+        t2: mockSessionTab('t2', 'h1', 's2'),
+      },
+    })
+    useAgentStore.setState({ statuses: { 'h1:s1': 'running', 'h1:s2': 'waiting' } })
+
+    const { result } = renderHook(() => useWorkspaceIndicators(['t1', 't2']))
+    expect(result.current.aggregatedStatus).toBe('waiting')
+  })
+
+  it('reacts to unread store updates', () => {
+    useTabStore.setState({ tabs: { t1: mockSessionTab('t1', 'h1', 's1') } })
+    const { result } = renderHook(() => useWorkspaceIndicators(['t1']))
+    expect(result.current.unreadCount).toBe(0)
+
+    act(() => {
+      useAgentStore.setState({ unread: { 'h1:s1': true } })
+    })
+    expect(result.current.unreadCount).toBe(1)
+  })
+
+  it('returns undefined status for all-idle workspace', () => {
+    useTabStore.setState({ tabs: { t1: mockSessionTab('t1', 'h1', 's1') } })
+    useAgentStore.setState({ statuses: { 'h1:s1': 'idle' } })
+
+    const { result } = renderHook(() => useWorkspaceIndicators(['t1']))
+    expect(result.current.aggregatedStatus).toBeUndefined()
+  })
+})

--- a/spa/src/features/workspace/useWorkspaceIndicators.ts
+++ b/spa/src/features/workspace/useWorkspaceIndicators.ts
@@ -2,11 +2,11 @@ import { useCallback, useMemo } from 'react'
 import { useTabStore } from '../../stores/useTabStore'
 import { useAgentStore } from '../../stores/useAgentStore'
 import type { AgentStatus } from '../../stores/useAgentStore'
-import { getWorkspaceCompositeKeys, aggregateStatus } from './workspace-indicators'
+import { getWorkspaceCompositeKeys, aggregateStatus, type ActiveStatus } from './workspace-indicators'
 
 interface WorkspaceIndicators {
   unreadCount: number
-  aggregatedStatus: AgentStatus | undefined
+  aggregatedStatus: ActiveStatus | undefined
 }
 
 export function useWorkspaceIndicators(tabIds: string[]): WorkspaceIndicators {

--- a/spa/src/features/workspace/useWorkspaceIndicators.ts
+++ b/spa/src/features/workspace/useWorkspaceIndicators.ts
@@ -1,0 +1,37 @@
+import { useCallback, useMemo } from 'react'
+import { useTabStore } from '../../stores/useTabStore'
+import { useAgentStore } from '../../stores/useAgentStore'
+import type { AgentStatus } from '../../stores/useAgentStore'
+import { getWorkspaceCompositeKeys, aggregateStatus } from './workspace-indicators'
+
+interface WorkspaceIndicators {
+  unreadCount: number
+  aggregatedStatus: AgentStatus | undefined
+}
+
+export function useWorkspaceIndicators(tabIds: string[]): WorkspaceIndicators {
+  const tabs = useTabStore((s) => s.tabs)
+
+  const compositeKeys = useMemo(
+    () => getWorkspaceCompositeKeys(tabIds, tabs),
+    [tabIds, tabs],
+  )
+
+  const unreadCount = useAgentStore(
+    useCallback(
+      (s: { unread: Record<string, boolean> }) =>
+        compositeKeys.reduce((n, k) => n + (s.unread[k] ? 1 : 0), 0),
+      [compositeKeys],
+    ),
+  )
+
+  const aggregatedStatus = useAgentStore(
+    useCallback(
+      (s: { statuses: Record<string, AgentStatus> }) =>
+        aggregateStatus(compositeKeys.map((k) => s.statuses[k])),
+      [compositeKeys],
+    ),
+  )
+
+  return { unreadCount, aggregatedStatus }
+}

--- a/spa/src/features/workspace/workspace-indicators.test.ts
+++ b/spa/src/features/workspace/workspace-indicators.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import type { Tab } from '../../types/tab'
+import { getWorkspaceCompositeKeys, aggregateStatus } from './workspace-indicators'
+
+function mockSessionTab(id: string, hostId: string, sessionCode: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: {
+      type: 'leaf',
+      pane: {
+        id: `pane-${id}`,
+        content: { kind: 'tmux-session', hostId, sessionCode, mode: 'terminal' as const, cachedName: '', tmuxInstance: '' },
+      },
+    },
+  }
+}
+
+function mockDashboardTab(id: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: { type: 'leaf', pane: { id: `pane-${id}`, content: { kind: 'dashboard' } } },
+  }
+}
+
+describe('getWorkspaceCompositeKeys', () => {
+  it('returns compositeKeys for tmux-session tabs', () => {
+    const tabs: Record<string, Tab> = {
+      t1: mockSessionTab('t1', 'h1', 's1'),
+      t2: mockSessionTab('t2', 'h1', 's2'),
+    }
+    expect(getWorkspaceCompositeKeys(['t1', 't2'], tabs)).toEqual(['h1:s1', 'h1:s2'])
+  })
+
+  it('skips non-session tabs', () => {
+    const tabs: Record<string, Tab> = {
+      t1: mockSessionTab('t1', 'h1', 's1'),
+      t2: mockDashboardTab('t2'),
+    }
+    expect(getWorkspaceCompositeKeys(['t1', 't2'], tabs)).toEqual(['h1:s1'])
+  })
+
+  it('skips missing tab IDs', () => {
+    const tabs: Record<string, Tab> = {
+      t1: mockSessionTab('t1', 'h1', 's1'),
+    }
+    expect(getWorkspaceCompositeKeys(['t1', 't999'], tabs)).toEqual(['h1:s1'])
+  })
+
+  it('returns empty array for empty workspace', () => {
+    expect(getWorkspaceCompositeKeys([], {})).toEqual([])
+  })
+})
+
+describe('aggregateStatus', () => {
+  it('returns undefined for empty array', () => {
+    expect(aggregateStatus([])).toBeUndefined()
+  })
+
+  it('returns undefined for all idle', () => {
+    expect(aggregateStatus(['idle', 'idle'])).toBeUndefined()
+  })
+
+  it('returns undefined for all undefined', () => {
+    expect(aggregateStatus([undefined, undefined])).toBeUndefined()
+  })
+
+  it('returns running when highest is running', () => {
+    expect(aggregateStatus(['running', 'idle'])).toBe('running')
+  })
+
+  it('returns waiting over running', () => {
+    expect(aggregateStatus(['running', 'waiting'])).toBe('waiting')
+  })
+
+  it('returns error over everything', () => {
+    expect(aggregateStatus(['running', 'waiting', 'error'])).toBe('error')
+  })
+
+  it('returns running when mixed with undefined', () => {
+    expect(aggregateStatus([undefined, 'running', undefined])).toBe('running')
+  })
+})

--- a/spa/src/features/workspace/workspace-indicators.ts
+++ b/spa/src/features/workspace/workspace-indicators.ts
@@ -1,0 +1,39 @@
+import type { Tab } from '../../types/tab'
+import type { AgentStatus } from '../../stores/useAgentStore'
+import { getPrimaryPane } from '../../lib/pane-tree'
+import { compositeKey } from '../../lib/composite-key'
+
+/** Extract compositeKeys from a workspace's tab IDs. Skips non-session and missing tabs. */
+export function getWorkspaceCompositeKeys(tabIds: string[], tabs: Record<string, Tab>): string[] {
+  const keys: string[] = []
+  for (const id of tabIds) {
+    const tab = tabs[id]
+    if (!tab) continue
+    const { content } = getPrimaryPane(tab.layout)
+    if (content.kind !== 'tmux-session') continue
+    keys.push(compositeKey(content.hostId, content.sessionCode))
+  }
+  return keys
+}
+
+const STATUS_PRIORITY: Record<AgentStatus, number> = {
+  error: 3,
+  waiting: 2,
+  running: 1,
+  idle: 0,
+}
+
+/** Returns highest-priority status across tabs, or undefined if all idle/absent. */
+export function aggregateStatus(statuses: (AgentStatus | undefined)[]): AgentStatus | undefined {
+  let highest: AgentStatus | undefined
+  let highestPri = -1
+  for (const s of statuses) {
+    if (s === undefined) continue
+    const p = STATUS_PRIORITY[s]
+    if (p > highestPri) {
+      highest = s
+      highestPri = p
+    }
+  }
+  return highest === 'idle' ? undefined : highest
+}

--- a/spa/src/features/workspace/workspace-indicators.ts
+++ b/spa/src/features/workspace/workspace-indicators.ts
@@ -23,8 +23,10 @@ const STATUS_PRIORITY: Record<AgentStatus, number> = {
   idle: 0,
 }
 
+export type ActiveStatus = Exclude<AgentStatus, 'idle'>
+
 /** Returns highest-priority status across tabs, or undefined if all idle/absent. */
-export function aggregateStatus(statuses: (AgentStatus | undefined)[]): AgentStatus | undefined {
+export function aggregateStatus(statuses: (AgentStatus | undefined)[]): ActiveStatus | undefined {
   let highest: AgentStatus | undefined
   let highestPri = -1
   for (const s of statuses) {


### PR DESCRIPTION
## Summary

- Add **unread badge** (red number) to workspace icons — shows count of unread tabs when workspace is inactive
- Add **status pill** (Discord-style left bar) — shows aggregated agent status (running/waiting/error) per workspace
- Extract `WorkspaceButton` component from `ActivityBar` for hook integration
- New `useWorkspaceIndicators` hook bridging `useTabStore` + `useAgentStore` to workspace-level indicators
- Pure utility functions for tabId→compositeKey bridging and status priority aggregation

## Design Decisions

- Badge hidden on active workspace (status visible directly in tab bar)
- Status pill position/active-workspace behavior subject to visual iteration
- Split-pane tabs use primary pane only (consistent with `SortableTab`)
- Non-session tabs (dashboard/settings/hosts) silently skipped

## Test plan

- [ ] 11 unit tests for utility functions (`workspace-indicators.test.ts`)
- [ ] 5 hook integration tests (`useWorkspaceIndicators.test.ts`)
- [ ] 11 ActivityBar tests including 3 new badge tests
- [ ] Full suite: 1100/1100 pass
- [ ] Visual verification: badge count, pill colors, breathe animation