### PR TITLE
fix: workspace split host state, sidebar drag reorder, empty window Cmd+W

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,14 +43,18 @@ function registerIpcHandlers(): void {
   ipcMain.handle('window:close', async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender)
     if (!win || win.isDestroyed()) return
-    const { response } = await dialog.showMessageBox(win, {
-      type: 'question',
-      buttons: ['Close', 'Cancel'],
-      defaultId: 0,
-      cancelId: 1,
-      message: 'Close this window?',
-    })
-    if (response === 0) win.close()
+    try {
+      const { response } = await dialog.showMessageBox(win, {
+        type: 'question',
+        buttons: ['Close', 'Cancel'],
+        defaultId: 0,
+        cancelId: 1,
+        message: 'Close this window?',
+      })
+      if (response === 0 && !win.isDestroyed()) win.close()
+    } catch {
+      // Window destroyed while dialog was showing — nothing to do
+    }
   })
 
   // Browser View — delegated to browser-view-ipc.ts

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, Menu, Notification, protocol, net } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, Menu, Notification, protocol, net } from 'electron'
 import { join } from 'path'
 import { WindowManager } from './window-manager'
 import { BrowserViewManager } from './browser-view-manager'
@@ -39,6 +39,18 @@ function registerIpcHandlers(): void {
   })
   ipcMain.handle('window:get-all', (event) => {
     return windowManager.getAll(event.sender)
+  })
+  ipcMain.handle('window:close', async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win || win.isDestroyed()) return
+    const { response } = await dialog.showMessageBox(win, {
+      type: 'question',
+      buttons: ['Close', 'Cancel'],
+      defaultId: 0,
+      cancelId: 1,
+      message: 'Close this window?',
+    })
+    if (response === 0) win.close()
   })
 
   // Browser View — delegated to browser-view-ipc.ts

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -71,6 +71,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('browser-view:open-in-tab', handler)
   },
 
+  // Window Management — close current window
+  closeWindow: () => ipcRenderer.invoke('window:close'),
+
   // SPA ready signal
   signalReady: () => ipcRenderer.send('spa:ready'),
 

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -30,6 +30,7 @@ import { RenamePopover } from './components/RenamePopover'
 import { ThemeInjector } from './components/ThemeInjector'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { getPlatformCapabilities } from './lib/platform'
+import { scanPaneTree } from './lib/pane-tree'
 import { useI18nStore } from './stores/useI18nStore'
 import type { Tab } from './types/tab'
 
@@ -233,13 +234,14 @@ export default function App() {
     if (!ws || ws.tabs.length === 0) return null
     const tabData = ws.tabs.map(id => tabs[id]).filter(Boolean)
     if (tabData.length === 0) return null
-    // Collect host configs referenced by tabs so the receiving window
-    // has them immediately (before localStorage hydration completes)
+    // Collect host configs referenced by tabs (including split-layout panes)
+    // so the receiving window has them immediately
     const hostState = useHostStore.getState()
     const hostIds = new Set<string>()
     for (const tab of tabData) {
-      const pane = tab.layout?.type === 'leaf' ? tab.layout.pane : null
-      if (pane?.content.kind === 'tmux-session') hostIds.add(pane.content.hostId)
+      scanPaneTree(tab.layout, (pane) => {
+        if (pane.content.kind === 'tmux-session') hostIds.add(pane.content.hostId)
+      })
     }
     const hostConfigs: Record<string, import('./stores/useHostStore').HostConfig> = {}
     for (const hid of hostIds) {

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -123,8 +123,17 @@ export default function App() {
     if (!window.electronAPI?.onWorkspaceReceived) return
     return window.electronAPI.onWorkspaceReceived((payload: string, replace: boolean) => {
       try {
-        const { workspace, tabData } = JSON.parse(payload)
+        const { workspace, tabData, hostConfigs } = JSON.parse(payload)
         if (!workspace?.id || !Array.isArray(tabData)) return
+
+        // Restore host configs so the receiving window can display
+        // host names and establish connections immediately
+        if (hostConfigs && typeof hostConfigs === 'object') {
+          const hs = useHostStore.getState()
+          for (const [hid, cfg] of Object.entries(hostConfigs)) {
+            if (!hs.hosts[hid]) hs.addHost(cfg as { id: string; name: string; ip: string; port: number; token?: string })
+          }
+        }
 
         // 校驗 tab ids
         const tabMap = new Map(tabData.map((t: Tab) => [t.id, t]))
@@ -224,7 +233,20 @@ export default function App() {
     if (!ws || ws.tabs.length === 0) return null
     const tabData = ws.tabs.map(id => tabs[id]).filter(Boolean)
     if (tabData.length === 0) return null
-    return { ws, payload: JSON.stringify({ workspace: ws, tabData }) }
+    // Collect host configs referenced by tabs so the receiving window
+    // has them immediately (before localStorage hydration completes)
+    const hostState = useHostStore.getState()
+    const hostIds = new Set<string>()
+    for (const tab of tabData) {
+      const pane = tab.layout?.type === 'leaf' ? tab.layout.pane : null
+      if (pane?.content.kind === 'tmux-session') hostIds.add(pane.content.hostId)
+    }
+    const hostConfigs: Record<string, import('./stores/useHostStore').HostConfig> = {}
+    for (const hid of hostIds) {
+      const cfg = hostState.hosts[hid]
+      if (cfg) hostConfigs[hid] = cfg
+    }
+    return { ws, payload: JSON.stringify({ workspace: ws, tabData, hostConfigs }) }
   }, [workspaces, tabs])
 
   const removeWorkspaceFromStore = useCallback((tabIds: string[], wsId: string) => {
@@ -300,6 +322,7 @@ export default function App() {
           activeWorkspaceId={activeStandaloneTabId ? null : activeWorkspaceId}
           activeStandaloneTabId={activeStandaloneTabId}
           onSelectWorkspace={handleSelectWorkspace}
+          onReorderWorkspaces={(orderedIds) => useWorkspaceStore.getState().reorderWorkspaces(orderedIds)}
           onSelectHome={() => {
             useWorkspaceStore.getState().setActiveWorkspace(null)
             const firstStandalone = standaloneTabs[0]

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -1,3 +1,6 @@
+import { useCallback, useMemo } from 'react'
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent, type Modifier } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable'
 import { Plus, GearSix, HardDrives, SquaresFour } from '@phosphor-icons/react'
 import type { Workspace } from '../../../types/tab'
 import { useI18nStore } from '../../../stores/useI18nStore'
@@ -11,9 +14,49 @@ interface Props {
   onSelectHome: () => void
   standaloneTabCount: number
   onAddWorkspace: () => void
+  onReorderWorkspaces?: (orderedIds: string[]) => void
   onContextMenuWorkspace?: (e: React.MouseEvent, wsId: string) => void
   onOpenHosts: () => void
   onOpenSettings: () => void
+}
+
+function SortableWorkspaceButton({ ws, isActive, onSelect, onContextMenu }: {
+  ws: Workspace
+  isActive: boolean
+  onSelect: (wsId: string) => void
+  onContextMenu?: (e: React.MouseEvent, wsId: string) => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: ws.id })
+
+  const style = {
+    transform: transform ? `translate3d(0, ${Math.round(transform.y)}px, 0)` : undefined,
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+    opacity: isDragging ? 0.8 : 1,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} className="relative group" {...attributes} {...listeners}>
+      <button
+        aria-label={ws.name}
+        onClick={() => onSelect(ws.id)}
+        onContextMenu={(e) => {
+          e.preventDefault()
+          onContextMenu?.(e, ws.id)
+        }}
+        className={`w-[30px] h-[30px] rounded-md flex items-center justify-center text-sm cursor-pointer transition-all ${
+          isActive
+            ? 'bg-[#8b5cf6]/35 text-text-primary ring-2 ring-purple-400'
+            : 'bg-surface-secondary text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+        }`}
+      >
+        <WorkspaceIcon icon={ws.icon} name={ws.name} size={16} weight={ws.iconWeight} />
+      </button>
+      <span className="pointer-events-none absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50">
+        {ws.name}
+      </span>
+    </div>
+  )
 }
 
 export function ActivityBar({
@@ -24,11 +67,31 @@ export function ActivityBar({
   onSelectHome,
   standaloneTabCount,
   onAddWorkspace,
+  onReorderWorkspaces,
   onContextMenuWorkspace,
   onOpenHosts,
   onOpenSettings,
 }: Props) {
   const t = useI18nStore((s) => s.t)
+  const wsIds = useMemo(() => workspaces.map((ws) => ws.id), [workspaces])
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }))
+
+  const restrictToVertical: Modifier = useCallback(({ transform }) => {
+    return { ...transform, x: 0 }
+  }, [])
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIdx = wsIds.indexOf(String(active.id))
+    const newIdx = wsIds.indexOf(String(over.id))
+    if (oldIdx === -1 || newIdx === -1) return
+    const newOrder = [...wsIds]
+    newOrder.splice(oldIdx, 1)
+    newOrder.splice(newIdx, 0, String(active.id))
+    onReorderWorkspaces?.(newOrder)
+  }, [wsIds, onReorderWorkspaces])
+
   return (
     <div className="hidden lg:flex w-11 flex-col items-center bg-surface-tertiary border-r border-border-subtle py-2 px-px gap-2.5 flex-shrink-0">
       {/* Home — standalone tabs */}
@@ -51,32 +114,20 @@ export function ActivityBar({
 
       {workspaces.length > 0 && <div className="w-5 h-px bg-border-default my-0.5" />}
 
-      {/* Workspaces */}
-      {workspaces.map((ws) => {
-        const isActive = activeWorkspaceId === ws.id && !activeStandaloneTabId
-        return (
-          <div key={ws.id} className="relative group">
-            <button
-              aria-label={ws.name}
-              onClick={() => onSelectWorkspace(ws.id)}
-              onContextMenu={(e) => {
-                e.preventDefault()
-                onContextMenuWorkspace?.(e, ws.id)
-              }}
-              className={`w-[30px] h-[30px] rounded-md flex items-center justify-center text-sm cursor-pointer transition-all ${
-                isActive
-                  ? 'bg-[#8b5cf6]/35 text-text-primary ring-2 ring-purple-400'
-                  : 'bg-surface-secondary text-text-secondary hover:bg-surface-hover hover:text-text-primary'
-              }`}
-            >
-              <WorkspaceIcon icon={ws.icon} name={ws.name} size={16} weight={ws.iconWeight} />
-            </button>
-            <span className="pointer-events-none absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50">
-              {ws.name}
-            </span>
-          </div>
-        )
-      })}
+      {/* Workspaces — sortable */}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVertical]} onDragEnd={handleDragEnd}>
+        <SortableContext items={wsIds} strategy={verticalListSortingStrategy}>
+          {workspaces.map((ws) => (
+            <SortableWorkspaceButton
+              key={ws.id}
+              ws={ws}
+              isActive={activeWorkspaceId === ws.id && !activeStandaloneTabId}
+              onSelect={onSelectWorkspace}
+              onContextMenu={onContextMenuWorkspace}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
 
       {/* Add + Settings */}
       <div className="mt-auto flex flex-col items-center gap-2 pb-1">

--- a/spa/src/features/workspace/store.test.ts
+++ b/spa/src/features/workspace/store.test.ts
@@ -464,6 +464,27 @@ describe('useWorkspaceStore', () => {
     })
   })
 
+  // === reorderWorkspaces ===
+
+  describe('reorderWorkspaces', () => {
+    it('reorders workspaces by given id array', () => {
+      const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
+      const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+      const ws3 = useWorkspaceStore.getState().addWorkspace('WS3')
+      useWorkspaceStore.getState().reorderWorkspaces([ws3.id, ws1.id, ws2.id])
+      const ids = useWorkspaceStore.getState().workspaces.map(w => w.id)
+      expect(ids).toEqual([ws3.id, ws1.id, ws2.id])
+    })
+
+    it('filters out unknown ids', () => {
+      const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
+      const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+      useWorkspaceStore.getState().reorderWorkspaces([ws2.id, 'nonexistent', ws1.id])
+      const ids = useWorkspaceStore.getState().workspaces.map(w => w.id)
+      expect(ids).toEqual([ws2.id, ws1.id])
+    })
+  })
+
   // === importWorkspace ===
 
   describe('importWorkspace', () => {

--- a/spa/src/features/workspace/store.test.ts
+++ b/spa/src/features/workspace/store.test.ts
@@ -483,6 +483,16 @@ describe('useWorkspaceStore', () => {
       const ids = useWorkspaceStore.getState().workspaces.map(w => w.id)
       expect(ids).toEqual([ws2.id, ws1.id])
     })
+
+    it('preserves workspaces missing from orderedIds', () => {
+      const ws1 = useWorkspaceStore.getState().addWorkspace('WS1')
+      const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+      const ws3 = useWorkspaceStore.getState().addWorkspace('WS3')
+      // Only pass 2 of 3 — ws1 should be appended at the end
+      useWorkspaceStore.getState().reorderWorkspaces([ws3.id, ws2.id])
+      const ids = useWorkspaceStore.getState().workspaces.map(w => w.id)
+      expect(ids).toEqual([ws3.id, ws2.id, ws1.id])
+    })
   })
 
   // === importWorkspace ===

--- a/spa/src/features/workspace/store.ts
+++ b/spa/src/features/workspace/store.ts
@@ -16,6 +16,7 @@ interface WorkspaceState {
   removeTabFromWorkspace: (wsId: string, tabId: string) => void
   setWorkspaceActiveTab: (wsId: string, tabId: string) => void
   reorderWorkspaceTabs: (wsId: string, tabIds: string[]) => void
+  reorderWorkspaces: (orderedIds: string[]) => void
   findWorkspaceByTab: (tabId: string) => Workspace | null
   insertTab: (tabId: string, workspaceId?: string | null) => void
   closeTabInWorkspace: (tabId: string, opts?: { skipHistory?: boolean }) => void
@@ -93,6 +94,13 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             ws.id === wsId ? { ...ws, tabs: tabIds } : ws,
           ),
         })),
+
+      reorderWorkspaces: (orderedIds) =>
+        set((state) => {
+          const byId = new Map(state.workspaces.map((ws) => [ws.id, ws]))
+          const reordered = orderedIds.map((id) => byId.get(id)).filter(Boolean) as Workspace[]
+          return { workspaces: reordered }
+        }),
 
       findWorkspaceByTab: (tabId) => {
         return get().workspaces.find((ws) => ws.tabs.includes(tabId)) ?? null

--- a/spa/src/features/workspace/store.ts
+++ b/spa/src/features/workspace/store.ts
@@ -98,7 +98,16 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       reorderWorkspaces: (orderedIds) =>
         set((state) => {
           const byId = new Map(state.workspaces.map((ws) => [ws.id, ws]))
-          const reordered = orderedIds.map((id) => byId.get(id)).filter(Boolean) as Workspace[]
+          const seen = new Set<string>()
+          const reordered: Workspace[] = []
+          for (const id of orderedIds) {
+            const ws = byId.get(id)
+            if (ws) { reordered.push(ws); seen.add(id) }
+          }
+          // Preserve workspaces not in orderedIds (defensive — prevents data loss)
+          for (const ws of state.workspaces) {
+            if (!seen.has(ws.id)) reordered.push(ws)
+          }
           return { workspaces: reordered }
         }),
 

--- a/spa/src/hooks/useShortcuts.test.ts
+++ b/spa/src/hooks/useShortcuts.test.ts
@@ -248,7 +248,7 @@ describe('useShortcuts', () => {
     })
 
     it('calls closeWindow when window is empty (no tabs)', () => {
-      const closeWindow = vi.fn()
+      const closeWindow = vi.fn().mockResolvedValue(undefined)
       ;(window as unknown as Record<string, unknown>).electronAPI = {
         ...(window as unknown as { electronAPI: Record<string, unknown> }).electronAPI,
         onShortcut: (cb: (payload: { action: string }) => void) => {

--- a/spa/src/hooks/useShortcuts.test.ts
+++ b/spa/src/hooks/useShortcuts.test.ts
@@ -246,6 +246,27 @@ describe('useShortcuts', () => {
       expect(useTabStore.getState().activeTabId).toBeNull()
       expect(useTabStore.getState().tabs[tabs[0].id]).toBeUndefined()
     })
+
+    it('calls closeWindow when window is empty (no tabs)', () => {
+      const closeWindow = vi.fn()
+      ;(window as unknown as Record<string, unknown>).electronAPI = {
+        ...(window as unknown as { electronAPI: Record<string, unknown> }).electronAPI,
+        onShortcut: (cb: (payload: { action: string }) => void) => {
+          const shortcutCb = cb
+          ;(window as unknown as { __fire: (a: string) => void }).__fire = (a: string) => shortcutCb({ action: a })
+          return vi.fn()
+        },
+        signalReady: () => {},
+        closeWindow,
+      }
+      // Reset: empty workspace, no tabs
+      useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+      useWorkspaceStore.getState().reset()
+      renderHook(() => useShortcuts())
+
+      ;(window as unknown as { __fire: (a: string) => void }).__fire('close-tab')
+      expect(closeWindow).toHaveBeenCalled()
+    })
   })
 
   describe('new-tab', () => {

--- a/spa/src/hooks/useShortcuts.ts
+++ b/spa/src/hooks/useShortcuts.ts
@@ -60,10 +60,10 @@ export function useShortcuts(): void {
       if (action === 'close-tab') {
         const { activeTabId, tabs } = tabState
         if (!activeTabId || !visibleIds.includes(activeTabId)) {
-          // No active/visible tab — ask to close the window if it's empty
-          const allEmpty = tabState.tabOrder.length === 0
-            || useWorkspaceStore.getState().workspaces.every((ws) => ws.tabs.length === 0)
-          if (allEmpty) window.electronAPI?.closeWindow()
+          // No active/visible tab — ask to close the window if truly empty
+          if (visibleIds.length === 0 && tabState.tabOrder.length === 0) {
+            window.electronAPI?.closeWindow().catch(() => {})
+          }
           return
         }
         const tab = tabs[activeTabId]

--- a/spa/src/hooks/useShortcuts.ts
+++ b/spa/src/hooks/useShortcuts.ts
@@ -59,7 +59,13 @@ export function useShortcuts(): void {
 
       if (action === 'close-tab') {
         const { activeTabId, tabs } = tabState
-        if (!activeTabId || !visibleIds.includes(activeTabId)) return
+        if (!activeTabId || !visibleIds.includes(activeTabId)) {
+          // No active/visible tab — ask to close the window if it's empty
+          const allEmpty = tabState.tabOrder.length === 0
+            || useWorkspaceStore.getState().workspaces.every((ws) => ws.tabs.length === 0)
+          if (allEmpty) window.electronAPI?.closeWindow()
+          return
+        }
         const tab = tabs[activeTabId]
         if (!tab || tab.locked) return
         destroyBrowserViewIfNeeded(tab)

--- a/spa/src/types/electron.d.ts
+++ b/spa/src/types/electron.d.ts
@@ -64,6 +64,7 @@ interface Window {
 
     // Window Management
     getWindows: () => Promise<ElectronWindowInfo[]>
+    closeWindow: () => Promise<void>
 
     // Browser View
     resizeBrowserView: (paneId: string, bounds: ElectronBounds) => Promise<void>


### PR DESCRIPTION
## Summary
- **Workspace split/merge host disconnected**: Include host configs in tear-off/merge payload so the receiving window displays correct host names and establishes connections immediately
- **Workspace icon drag reorder**: Implement drag-and-drop reordering in ActivityBar using `@dnd-kit/sortable` with new `reorderWorkspaces` store action
- **Empty window Cmd+W**: Show native confirmation dialog when pressing Cmd+W on a window with no tabs/workspaces, via new `window:close` IPC handler

## Test plan
- [ ] Tear off a workspace to a new window → verify host name and connection status display correctly
- [ ] Merge a workspace back → verify host state preserved
- [ ] Drag workspace icons in the sidebar to reorder → verify order persists
- [ ] Close all tabs in a standalone window, then press Cmd+W → verify confirmation dialog appears
- [ ] Cancel the dialog → window stays open; confirm → window closes
- [ ] `cd spa && npx vitest run` — 1084 tests pass
- [ ] `cd spa && pnpm run lint` — no errors