### PR TITLE
fix: topbar toggle 改為顯示/隱藏 + workspace module settings

### DIFF
--- a/spa/src/components/SidebarRegion.tsx
+++ b/spa/src/components/SidebarRegion.tsx
@@ -21,7 +21,7 @@ export function SidebarRegion({ region, resizeEdge }: Props) {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
   const activeHostId = useHostStore((s) => s.activeHostId ?? s.hostOrder[0] ?? '')
 
-  if (views.length === 0) return null
+  if (views.length === 0 || mode === 'hidden') return null
 
   // Fallback to first view if activeViewId is unset
   const resolvedActiveViewId = activeViewId ?? views[0]

--- a/spa/src/components/TitleBar.tsx
+++ b/spa/src/components/TitleBar.tsx
@@ -24,7 +24,7 @@ const regionToggles: { region: SidebarRegion; icon: typeof SidebarSimple; label:
 export function TitleBar({ title }: Props) {
   const activeTabId = useTabStore((s) => s.activeTabId)
   const regions = useLayoutStore((s) => s.regions)
-  const toggleRegion = useLayoutStore((s) => s.toggleRegion)
+  const toggleVisibility = useLayoutStore((s) => s.toggleVisibility)
 
   const handlePattern = (pattern: LayoutPattern) => {
     if (!activeTabId) return
@@ -47,17 +47,17 @@ export function TitleBar({ title }: Props) {
       >
         {/* Region toggles */}
         {visibleToggles.map(({ region, icon: Icon, label, mirror }) => {
-          const isPinned = regions[region].mode === 'pinned'
+          const isVisible = regions[region].mode !== 'hidden'
           return (
             <button
               key={region}
               className={`p-1 rounded transition-colors ${
-                isPinned
+                isVisible
                   ? 'text-accent-base bg-accent-base/10 hover:bg-accent-base/20'
                   : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
               }`}
               title={label}
-              onClick={() => toggleRegion(region)}
+              onClick={() => toggleVisibility(region)}
               style={mirror ? { transform: 'scaleX(-1)' } : undefined}
             >
               <Icon size={14} />

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
@@ -9,6 +9,7 @@ import { WorkspaceIcon } from './WorkspaceIcon'
 
 import { WorkspaceIconPicker } from './WorkspaceIconPicker'
 import { WorkspaceDeleteDialog } from './WorkspaceDeleteDialog'
+import { ModuleConfigSection } from '../../../components/settings/ModuleConfigSection'
 
 interface Props {
   workspaceId: string
@@ -113,8 +114,11 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
           />
         </section>
 
+        {/* Module Settings */}
+        <ModuleConfigSection scope={{ workspaceId }} />
+
         {/* Danger Zone */}
-        <section className="border-t border-border-subtle pt-6">
+        <section className="border-t border-border-subtle pt-6 mt-8">
           <h3 className="text-xs font-semibold text-red-400 uppercase tracking-wider mb-3">
             Danger Zone
           </h3>

--- a/spa/src/stores/useLayoutStore.test.ts
+++ b/spa/src/stores/useLayoutStore.test.ts
@@ -89,4 +89,26 @@ describe('useLayoutStore', () => {
       expect(useLayoutStore.getState().regions['primary-sidebar'].mode).toBe('collapsed')
     })
   })
+
+  describe('toggleVisibility', () => {
+    it('toggles between hidden and pinned', () => {
+      // Start from collapsed, toggle visibility → hidden
+      useLayoutStore.getState().toggleVisibility('primary-sidebar')
+      expect(useLayoutStore.getState().regions['primary-sidebar'].mode).toBe('hidden')
+
+      // Toggle again → pinned
+      useLayoutStore.getState().toggleVisibility('primary-sidebar')
+      expect(useLayoutStore.getState().regions['primary-sidebar'].mode).toBe('pinned')
+
+      // Toggle again → hidden
+      useLayoutStore.getState().toggleVisibility('primary-sidebar')
+      expect(useLayoutStore.getState().regions['primary-sidebar'].mode).toBe('hidden')
+    })
+
+    it('hides a pinned region', () => {
+      useLayoutStore.getState().setRegionMode('primary-sidebar', 'pinned')
+      useLayoutStore.getState().toggleVisibility('primary-sidebar')
+      expect(useLayoutStore.getState().regions['primary-sidebar'].mode).toBe('hidden')
+    })
+  })
 })

--- a/spa/src/stores/useLayoutStore.ts
+++ b/spa/src/stores/useLayoutStore.ts
@@ -10,7 +10,7 @@ interface RegionState {
   views: string[]
   activeViewId?: string
   width: number
-  mode: 'pinned' | 'collapsed'
+  mode: 'pinned' | 'collapsed' | 'hidden'
 }
 
 interface LayoutState {
@@ -21,6 +21,7 @@ interface LayoutState {
   setActiveView: (region: SidebarRegion, viewId: string | undefined) => void
   setRegionViews: (region: SidebarRegion, views: string[]) => void
   toggleRegion: (region: SidebarRegion) => void
+  toggleVisibility: (region: SidebarRegion) => void
 }
 
 function createDefaultRegions(): Record<SidebarRegion, RegionState> {
@@ -70,6 +71,13 @@ export const useLayoutStore = create<LayoutState>()(
         set((state) => {
           const current = state.regions[region].mode
           const next = current === 'collapsed' ? 'pinned' : 'collapsed'
+          return updateRegion(state, region, { mode: next })
+        }),
+
+      toggleVisibility: (region) =>
+        set((state) => {
+          const current = state.regions[region].mode
+          const next = current === 'hidden' ? 'pinned' : 'hidden'
           return updateRegion(state, region, { mode: next })
         }),
     }),


### PR DESCRIPTION
## Summary
- Topbar 的 region toggle 從展開/收合改為完全顯示/隱藏（新增 `toggleVisibility` action）
- WorkspaceSettingsPage 加入 `ModuleConfigSection`，workspace 範圍的模組設定現在可見
- Daemon binary 已重建（agent hooks 改版後首次），codex provider endpoint 已可用

## Changes
- `useLayoutStore.ts`: mode 型別加入 `'hidden'`，新增 `toggleVisibility` action
- `TitleBar.tsx`: 改用 `toggleVisibility`，按鈕狀態改判 `!== 'hidden'`
- `SidebarRegion.tsx`: `mode === 'hidden'` 時 return null
- `WorkspaceSettingsPage.tsx`: 加入 `<ModuleConfigSection scope={{ workspaceId }} />`
- `useLayoutStore.test.ts`: 新增 toggleVisibility 測試

## Test plan
- [ ] Topbar toggle 按鈕點擊後 region 完全消失/出現
- [ ] SidebarRegion 自身的收合箭頭仍可 pinned ↔ collapsed
- [ ] Workspace Settings 頁面顯示模組設定（如 Files 的 projectPath）
- [ ] `npx vitest run` 全部通過