### PR TITLE
fix: topbar 標題置中、cursor pointer、workspace 拖曳範圍

### DIFF
--- a/spa/src/components/TitleBar.tsx
+++ b/spa/src/components/TitleBar.tsx
@@ -35,11 +35,14 @@ export function TitleBar({ title }: Props) {
 
   return (
     <div
-      className="shrink-0 flex items-center bg-surface-secondary border-b border-border-subtle px-2"
+      className="shrink-0 relative flex items-center bg-surface-secondary border-b border-border-subtle px-2"
       style={{ height: 30, WebkitAppRegion: 'drag' } as React.CSSProperties}
     >
-      <div className="shrink-0" style={{ width: 70 }} />
-      <div className="flex-1 text-center text-xs text-text-muted truncate select-none">{title}</div>
+      {/* Title — absolute positioned for true center across full window width */}
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none select-none">
+        <span className="text-xs text-text-muted truncate px-20">{title}</span>
+      </div>
+      <div className="flex-1" />
       <div
         data-testid="layout-buttons"
         className="shrink-0 flex items-center gap-0.5"

--- a/spa/src/components/settings/AppearanceSection.tsx
+++ b/spa/src/components/settings/AppearanceSection.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react'
 import { DownloadSimple, Upload, Trash, PaintBrush, Translate } from '@phosphor-icons/react'
 import { SettingItem } from './SettingItem'
-import { useAgentStore } from '../../stores/useAgentStore'
-import type { TabIndicatorStyle } from '../../stores/useAgentStore'
 import { getAllThemes } from '../../lib/theme-registry'
 import type { ThemeDefinition } from '../../lib/theme-registry'
 import { useThemeStore } from '../../stores/useThemeStore'
@@ -51,9 +49,6 @@ export function AppearanceSection() {
   const [showImportModal, setShowImportModal] = useState(false)
   const [showLocaleEditor, setShowLocaleEditor] = useState(false)
   const [showLocaleImport, setShowLocaleImport] = useState(false)
-  const tabIndicatorStyle = useAgentStore((s) => s.tabIndicatorStyle)
-  const setTabIndicatorStyle = useAgentStore((s) => s.setTabIndicatorStyle)
-
   const allThemes = getAllThemes()
   const presetThemes = allThemes.filter((th) => th.builtin)
   const customThemeList = allThemes.filter((th) => !th.builtin)
@@ -226,20 +221,6 @@ export function AppearanceSection() {
             {t('common.import')}
           </button>
         </div>
-      </SettingItem>
-
-      {/* Tab indicator style */}
-      <SettingItem label={t('settings.appearance.tab_indicator.label')} description={t('settings.appearance.tab_indicator.desc')}>
-        <select
-          aria-label={t('settings.appearance.tab_indicator.aria')}
-          value={tabIndicatorStyle}
-          onChange={(e) => setTabIndicatorStyle(e.target.value as TabIndicatorStyle)}
-          className="bg-surface-input border border-border-default rounded-md text-text-primary text-xs px-3 py-1.5 w-40 hover:border-text-muted focus:border-border-active focus:outline-none"
-        >
-          <option value="overlay">{t('settings.appearance.tab_indicator.overlay')}</option>
-          <option value="replace">{t('settings.appearance.tab_indicator.replace')}</option>
-          <option value="inline">{t('settings.appearance.tab_indicator.inline')}</option>
-        </select>
       </SettingItem>
 
       {showEditor && (

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent, type Modifier } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable'
 import { Plus, GearSix, HardDrives, SquaresFour } from '@phosphor-icons/react'
@@ -114,9 +114,14 @@ export function ActivityBar({
   const t = useI18nStore((s) => s.t)
   const wsIds = useMemo(() => workspaces.map((ws) => ws.id), [workspaces])
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }))
+  const wsZoneRef = useRef<HTMLDivElement>(null)
 
-  const restrictToVertical: Modifier = useCallback(({ transform }) => {
-    return { ...transform, x: 0 }
+  const restrictToVertical: Modifier = useCallback(({ transform, activeNodeRect }) => {
+    if (!activeNodeRect || !wsZoneRef.current) return { ...transform, x: 0 }
+    const zoneRect = wsZoneRef.current.getBoundingClientRect()
+    const minY = zoneRect.top - activeNodeRect.top
+    const maxY = zoneRect.bottom - activeNodeRect.bottom
+    return { ...transform, x: 0, y: Math.min(Math.max(transform.y, minY), maxY) }
   }, [])
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
@@ -181,15 +186,17 @@ export function ActivityBar({
       {/* Workspaces — sortable */}
       <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVertical]} onDragEnd={handleDragEnd}>
         <SortableContext items={wsIds} strategy={verticalListSortingStrategy}>
-          {workspaces.map((ws) => (
-            <SortableWorkspaceButton
-              key={ws.id}
-              workspace={ws}
-              isActive={activeWorkspaceId === ws.id && !activeStandaloneTabId}
-              onSelect={onSelectWorkspace}
-              onContextMenu={onContextMenuWorkspace}
-            />
-          ))}
+          <div ref={wsZoneRef} className="flex flex-col items-center gap-2.5">
+            {workspaces.map((ws) => (
+              <SortableWorkspaceButton
+                key={ws.id}
+                workspace={ws}
+                isActive={activeWorkspaceId === ws.id && !activeStandaloneTabId}
+                onSelect={onSelectWorkspace}
+                onContextMenu={onContextMenuWorkspace}
+              />
+            ))}
+          </div>
         </SortableContext>
       </DndContext>
 

--- a/spa/src/index.css
+++ b/spa/src/index.css
@@ -6,6 +6,16 @@ body {
   background-color: var(--surface-primary);
 }
 
+/* All interactive elements default to pointer cursor */
+button,
+[role="tab"],
+[role="button"] {
+  cursor: pointer;
+}
+button:disabled {
+  cursor: default;
+}
+
 /* Hide scrollbar for tab overflow */
 .scrollbar-hide {
   -ms-overflow-style: none;

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -47,7 +47,7 @@ export const useAgentStore = create<AgentState>()(
       subagents: {},
       lastEvents: {},
       unread: {},
-      tabIndicatorStyle: 'overlay' as TabIndicatorStyle,
+      tabIndicatorStyle: 'replace' as TabIndicatorStyle,
 
       handleNormalizedEvent: (hostId, sessionCode, event) => {
         const key = compositeKey(hostId, sessionCode)


### PR DESCRIPTION
## Summary

- **Topbar 標題置中** (#262)：標題改用 `absolute inset-0` 定位，不受右側按鈕影響，以完整視窗寬度置中
- **全域 cursor: pointer** (#263)：在 `index.css` 加入全域規則，讓所有 `button`、`[role="tab"]`、`[role="button"]` 預設 `cursor: pointer`，disabled 時回 `default`
- **Workspace icon 拖曳範圍限制** (#264)：`restrictToVertical` modifier 增加 Y 軸 `minY/maxY` 邊界計算，拖曳不超出第一個到最後一個 icon 的範圍
- **Tab Indicator Style 設定隱藏**：從 Settings UI 移除選項，預設改為 `replace`，保留 store 架構供未來使用

Closes #262, closes #263, closes #264

## Test plan

- [ ] Electron 中確認 topbar 標題在各種按鈕組合下保持視窗置中
- [ ] 確認所有按鈕（TitleBar、Settings、FileTree、SessionPicker 等）hover 時顯示 pointer cursor
- [ ] 確認 disabled 按鈕不顯示 pointer cursor
- [ ] 拖曳 workspace icon 確認無法超出列表頂部/底部範圍
- [ ] Settings > Appearance 確認 Tab Indicator Style 選項已移除
- [ ] 確認 tab 上的 agent 狀態指示器以 replace 模式正常顯示