### PR TITLE
fix: topbar cursor pointer + host 子分頁切換保留

### DIFF
--- a/spa/src/components/TitleBar.test.tsx
+++ b/spa/src/components/TitleBar.test.tsx
@@ -56,4 +56,15 @@ describe('TitleBar', () => {
       expect(buttons[i]).toHaveProperty('disabled', true)
     }
   })
+
+  it('all enabled buttons have cursor-pointer class', () => {
+    const tab = createTab({ kind: 'dashboard' })
+    useTabStore.setState({ tabs: { [tab.id]: tab }, tabOrder: [tab.id], activeTabId: tab.id, visitHistory: [] })
+    render(<TitleBar title="test" />)
+    const buttons = screen.getByTestId('layout-buttons').querySelectorAll('button:not(:disabled)')
+    expect(buttons.length).toBeGreaterThan(0)
+    for (const btn of buttons) {
+      expect(btn.className).toContain('cursor-pointer')
+    }
+  })
 })

--- a/spa/src/components/TitleBar.tsx
+++ b/spa/src/components/TitleBar.tsx
@@ -54,7 +54,7 @@ export function TitleBar({ title }: Props) {
           return (
             <button
               key={region}
-              className={`p-1 rounded transition-colors ${
+              className={`p-1 rounded transition-colors cursor-pointer ${
                 isVisible
                   ? 'text-accent-base bg-accent-base/10 hover:bg-accent-base/20'
                   : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
@@ -74,7 +74,7 @@ export function TitleBar({ title }: Props) {
           <button
             key={pattern}
             disabled={!activeTabId}
-            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-hover disabled:opacity-40 disabled:pointer-events-none"
+            className="p-1 rounded cursor-pointer text-text-muted hover:text-text-primary hover:bg-surface-hover disabled:opacity-40 disabled:pointer-events-none"
             title={label}
             onClick={() => handlePattern(pattern)}
           >

--- a/spa/src/components/hosts/HostSidebar.test.tsx
+++ b/spa/src/components/hosts/HostSidebar.test.tsx
@@ -161,6 +161,23 @@ describe('HostSidebar', () => {
     expect(sessionsButtons.length).toBeGreaterThanOrEqual(1)
   })
 
+  it('preserves current subPage when expanding a collapsed host', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Test Host', ip: '1.2.3.4', port: 7860, order: 0 },
+        [HOST_B]: { id: HOST_B, name: 'Second Host', ip: '5.6.7.8', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, HOST_B],
+      runtime: {},
+    })
+    // Current selectedSubPage is 'hooks'
+    render(<HostSidebar {...defaultProps} selectedSubPage="hooks" />)
+
+    // Click collapsed HOST_B — should call onSelect with 'hooks', not 'overview'
+    fireEvent.click(screen.getByText('Second Host'))
+    expect(defaultProps.onSelect).toHaveBeenCalledWith(HOST_B, 'hooks')
+  })
+
   it('auto-expands new selectedHostId on prop change (e.g. host deletion fallback)', () => {
     useHostStore.setState({
       hosts: {

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -58,7 +58,7 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
               <button
                 onClick={() => {
                   toggleExpand(hostId)
-                  if (!isExpanded) onSelect(hostId, 'overview')
+                  if (!isExpanded) onSelect(hostId, selectedSubPage)
                 }}
                 className={`w-full text-left px-2 py-1.5 rounded text-sm cursor-pointer flex items-center gap-1.5 ${
                   selectedHostId === hostId


### PR DESCRIPTION
## Summary

- TitleBar 按鈕明確加 `cursor-pointer` class，修正 Electron `-webkit-app-region: drag` 覆蓋 cursor 樣式的問題
- HostSidebar 展開不同 host 時保留當前選中的 subPage（如 Hooks），不再 hardcode reset 到 overview

## Test plan

- [x] TitleBar: 新增測試驗證所有 enabled 按鈕包含 `cursor-pointer` class
- [x] HostSidebar: 新增測試驗證切換 host 時保留當前 subPage
- [x] 全量測試通過（129 files, 1198 tests, 0 failures）