### PR TITLE
fix: SubagentDots 相位同步 + terminal reconnect 自動恢復

### DIFF
--- a/spa/src/components/SubagentDots.tsx
+++ b/spa/src/components/SubagentDots.tsx
@@ -17,14 +17,15 @@ const ARC_POSITIONS: Record<number, [number, number][]> = {
 }
 
 export function SubagentDots({ count, isActive }: Props) {
-  // Capture phase offset once at mount time so the animation-delay stays
-  // deterministic across re-renders without calling impure performance.now()
-  // on every render.
-  // eslint-disable-next-line react-hooks/purity
-  const phaseOffset = useMemo(() => performance.now(), [])
+  const clamped = Math.min(Math.max(count, 0), 3)
 
-  if (count <= 0) return null
-  const clamped = Math.min(count, 3)
+  // Recalculate phase offset when dot count changes so all dots restart
+  // with correctly synchronized animation phases.  When count stays the
+  // same, useMemo keeps the value stable across re-renders.
+  // eslint-disable-next-line react-hooks/purity, react-hooks/exhaustive-deps
+  const phaseOffset = useMemo(() => performance.now(), [clamped])
+
+  if (clamped <= 0) return null
   const positions = ARC_POSITIONS[clamped]
   const dotSize = DOT_SIZES[clamped]
 
@@ -36,7 +37,7 @@ export function SubagentDots({ count, isActive }: Props) {
     <>
       {positions.map(([left, top], i) => (
         <span
-          key={i}
+          key={`${clamped}-${i}`}
           className="absolute rounded-full animate-breathe"
           style={{
             width: dotSize,

--- a/spa/src/lib/ws.test.ts
+++ b/spa/src/lib/ws.test.ts
@@ -183,13 +183,13 @@ describe('connectTerminal gate', () => {
     wsInstances[0].simulateOpen()
     wsInstances[0].simulateClose()
 
-    // 1st poll at 1s — gate closed, no WS created
+    // t=1s: 1st poll — gate closed, no WS created, polls again at same 1s interval
     vi.advanceTimersByTime(1000)
     expect(wsInstances).toHaveLength(1)
 
-    // Open the gate before 2nd poll fires at 2s
+    // Open gate; t=2s: 2nd poll — gate open, reconnects
     gateOpen = true
-    vi.advanceTimersByTime(2000)
+    vi.advanceTimersByTime(1000)
     expect(wsInstances).toHaveLength(2) // reconnected after gate opened
   })
 })
@@ -221,13 +221,13 @@ describe('connectTerminal with getTicket', () => {
     const getTicket = vi.fn().mockRejectedValueOnce(new Error('401')).mockResolvedValue('tk_ok')
     connectTerminal('ws://test/ws/terminal/abc', vi.fn(), vi.fn(), undefined, () => gateOpen, getTicket)
     await vi.advanceTimersByTimeAsync(0)
-    // 1st poll at 1s — gate closed, getTicket not called again
+    // t=1s: 1st poll — gate closed, getTicket not called again, polls at same 1s interval
     await vi.advanceTimersByTimeAsync(1100)
     expect(getTicket).toHaveBeenCalledTimes(1)
 
-    // Open gate before 2nd poll at 2s
+    // Open gate; t=2s: 2nd poll — gate open, retries getTicket
     gateOpen = true
-    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(1000)
     expect(getTicket).toHaveBeenCalledTimes(2) // retried after gate opened
     expect(wsInstances).toHaveLength(1)
     expect(wsInstances[0].url).toContain('ticket=tk_ok')

--- a/spa/src/lib/ws.test.ts
+++ b/spa/src/lib/ws.test.ts
@@ -156,7 +156,7 @@ describe('connectTerminal auto-reconnect', () => {
 })
 
 describe('connectTerminal gate', () => {
-  it('does not reconnect when gate returns false', () => {
+  it('does not reconnect while gate returns false', () => {
     const gate = vi.fn().mockReturnValue(false)
     connectTerminal('ws://test', vi.fn(), vi.fn(), undefined, gate)
     wsInstances[0].simulateOpen()
@@ -174,6 +174,23 @@ describe('connectTerminal gate', () => {
 
     vi.advanceTimersByTime(1000)
     expect(wsInstances).toHaveLength(2) // reconnected — gate allowed
+  })
+
+  it('resumes reconnect when gate changes from false to true', () => {
+    let gateOpen = false
+    const gate = () => gateOpen
+    connectTerminal('ws://test', vi.fn(), vi.fn(), undefined, gate)
+    wsInstances[0].simulateOpen()
+    wsInstances[0].simulateClose()
+
+    // 1st poll at 1s — gate closed, no WS created
+    vi.advanceTimersByTime(1000)
+    expect(wsInstances).toHaveLength(1)
+
+    // Open the gate before 2nd poll fires at 2s
+    gateOpen = true
+    vi.advanceTimersByTime(2000)
+    expect(wsInstances).toHaveLength(2) // reconnected after gate opened
   })
 })
 
@@ -199,11 +216,20 @@ describe('connectTerminal with getTicket', () => {
     expect(wsInstances[0].url).toContain('ticket=tk_retry')
   })
 
-  it('stops retrying when canReconnect returns false', async () => {
-    const getTicket = vi.fn().mockRejectedValue(new Error('401'))
-    connectTerminal('ws://test/ws/terminal/abc', vi.fn(), vi.fn(), undefined, () => false, getTicket)
+  it('keeps polling when canReconnect returns false, resumes when true', async () => {
+    let gateOpen = false
+    const getTicket = vi.fn().mockRejectedValueOnce(new Error('401')).mockResolvedValue('tk_ok')
+    connectTerminal('ws://test/ws/terminal/abc', vi.fn(), vi.fn(), undefined, () => gateOpen, getTicket)
     await vi.advanceTimersByTimeAsync(0)
+    // 1st poll at 1s — gate closed, getTicket not called again
     await vi.advanceTimersByTimeAsync(1100)
-    expect(getTicket).toHaveBeenCalledTimes(1) // no retry
+    expect(getTicket).toHaveBeenCalledTimes(1)
+
+    // Open gate before 2nd poll at 2s
+    gateOpen = true
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(getTicket).toHaveBeenCalledTimes(2) // retried after gate opened
+    expect(wsInstances).toHaveLength(1)
+    expect(wsInstances[0].url).toContain('ticket=tk_ok')
   })
 })

--- a/spa/src/lib/ws.ts
+++ b/spa/src/lib/ws.ts
@@ -28,21 +28,27 @@ export function connectTerminal(
       scheduleRetry()
       return
     }
+    if (closed) return
     setupWs(wsUrl)
   }
 
   function scheduleRetry() {
-    setTimeout(() => {
-      if (closed) return
-      if (canReconnect && !canReconnect()) {
-        // Gate closed — don't connect yet, but keep polling so we resume
-        // automatically once the host comes back online.
-        scheduleRetry()
-        return
-      }
-      connect()
-    }, retryMs)
+    const delay = retryMs
     retryMs = Math.min(retryMs * 2, 30000)
+    // Inner loop: poll at fixed `delay` while gate is closed, then connect
+    // once the gate opens.  backoff only advances on the next scheduleRetry
+    // call (i.e. after a real connection failure), not during gate polling.
+    function attempt() {
+      setTimeout(() => {
+        if (closed) return
+        if (canReconnect && !canReconnect()) {
+          attempt()
+          return
+        }
+        connect()
+      }, delay)
+    }
+    attempt()
   }
 
   function setupWs(wsUrl: string) {

--- a/spa/src/lib/ws.ts
+++ b/spa/src/lib/ws.ts
@@ -25,15 +25,24 @@ export function connectTerminal(
       u.searchParams.set('ticket', ticket)
       wsUrl = u.toString()
     } catch {
-      setTimeout(() => {
-        if (closed) return
-        if (canReconnect && !canReconnect()) return
-        connect()
-      }, retryMs)
-      retryMs = Math.min(retryMs * 2, 30000)
+      scheduleRetry()
       return
     }
     setupWs(wsUrl)
+  }
+
+  function scheduleRetry() {
+    setTimeout(() => {
+      if (closed) return
+      if (canReconnect && !canReconnect()) {
+        // Gate closed — don't connect yet, but keep polling so we resume
+        // automatically once the host comes back online.
+        scheduleRetry()
+        return
+      }
+      connect()
+    }, retryMs)
+    retryMs = Math.min(retryMs * 2, 30000)
   }
 
   function setupWs(wsUrl: string) {
@@ -51,12 +60,7 @@ export function connectTerminal(
     ws.onclose = () => {
       if (closed) return // manual close — don't notify or reconnect
       onClose()
-      setTimeout(() => {
-        if (closed) return
-        if (canReconnect && !canReconnect()) return // gate check
-        connect()
-      }, retryMs)
-      retryMs = Math.min(retryMs * 2, 30000)
+      scheduleRetry()
     }
   }
 


### PR DESCRIPTION
## Summary

- **SubagentDots 相位修正**：`useMemo` dependency `[]` → `[clamped]` + `key` 加入 `clamped`，count 變化時全部 dot remount 並重算 `animationDelay`，修正新 dot 與既有 dot 相位不同步的雜亂閃爍
- **Terminal reconnect gate 持續重試**：`ws.ts` 中 `canReconnect()` gate 回 `false` 時改為持續 backoff polling，host 恢復後自動重連，不再需要手動切換 tab

Closes #277

## Test plan

- [x] 全套 1209 tests 通過
- [x] Lint 乾淨
- [ ] 手動驗證：啟動 subagent 觀察 dots 波浪序列
- [ ] 手動驗證：斷線後 reconnect overlay 在 host 恢復時自動消失