### PR TITLE
refactor: App.tsx 拆分 — 提取 hooks + 具名 callback (#281)

### DIFF
--- a/docs/superpowers/plans/2026-04-11-app-tsx-split.md
+++ b/docs/superpowers/plans/2026-04-11-app-tsx-split.md
@@ -1,0 +1,661 @@
+# App.tsx 拆分 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 將 `spa/src/App.tsx` 從 409 行降至 ~180 行，消除混合職責，使其回歸純組裝層角色。
+
+**Architecture:** 提取 3 個獨立模組（GlobalUndoToast 元件、useElectronIpc hook、useWorkspaceWindowActions hook），在 useTabWorkspaceActions 新增 `openSingletonAndSelect` 統一 4 處重複的 singleton tab 開啟模式，最後將 App.tsx 殘留的 inline lambda 全部提為具名 callback。
+
+**Tech Stack:** React 19 / Zustand 5 / Vitest / @testing-library/react
+
+**Issue:** #281 — Closes #202, #219, #225, #231, #237, #243, #261
+
+**Baseline:** 131 test files, 1209 tests 全通過
+
+---
+
+### Task 1: 提取 GlobalUndoToast 元件
+
+**Files:**
+- Create: `spa/src/components/GlobalUndoToast.tsx`
+- Modify: `spa/src/App.tsx:1-70` (移除元件定義，加 import)
+
+- [ ] **Step 1: 建立 `spa/src/components/GlobalUndoToast.tsx`**
+
+```tsx
+import { useEffect, useRef } from 'react'
+import { useUndoToast } from '../stores/useUndoToast'
+import { useI18nStore } from '../stores/useI18nStore'
+
+export function GlobalUndoToast() {
+  const toast = useUndoToast((s) => s.toast)
+  const dismiss = useUndoToast((s) => s.dismiss)
+  const t = useI18nStore((s) => s.t)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!toast) return
+    timerRef.current = setTimeout(() => dismiss(), 5000)
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [toast, dismiss])
+
+  if (!toast) return null
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3 flex items-center gap-3 shadow-lg z-50">
+      <span className="text-sm text-zinc-300">
+        {toast.message}
+      </span>
+      <button
+        className="text-sm text-blue-400 hover:text-blue-300 font-medium cursor-pointer"
+        onClick={() => {
+          toast.restore()
+          dismiss()
+        }}
+      >
+        {t('hosts.undo')}
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 修改 App.tsx — 移除內嵌定義，改為 import**
+
+移除 App.tsx L1–L70 的 `GlobalUndoToast` function 定義和其相關 imports（`useUndoToast`, `useI18nStore`, `useRef` 只用於 GlobalUndoToast 的話也一併清理）。
+
+在 import 區加入：
+```tsx
+import { GlobalUndoToast } from './components/GlobalUndoToast'
+```
+
+注意 App.tsx 自身仍使用 `useRef` 嗎？否。App() 函式內無 useRef 呼叫，可從 React import 中移除。`useI18nStore` 也只被 GlobalUndoToast 使用，可移除。`useUndoToast` 也只被 GlobalUndoToast 使用，可移除。
+
+最終 App.tsx 的 React import 變為：
+```tsx
+import { useCallback, useEffect, useMemo, useState } from 'react'
+```
+
+- [ ] **Step 3: 執行測試確認無回歸**
+
+Run: `cd spa && npx vitest run`
+Expected: 131 test files, 1209 tests 全通過
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/components/GlobalUndoToast.tsx spa/src/App.tsx
+git commit -m "refactor: extract GlobalUndoToast from App.tsx"
+```
+
+---
+
+### Task 2: 新增 openSingletonAndSelect 到 useTabWorkspaceActions
+
+**Files:**
+- Modify: `spa/src/features/workspace/hooks.ts:195-213` (新增方法 + export)
+- Modify: `spa/src/features/workspace/hooks.test.ts` (新增測試)
+- Modify: `spa/src/features/workspace/index.ts` (無需改，hook 整體 re-export)
+
+- [ ] **Step 1: 寫失敗測試**
+
+在 `spa/src/features/workspace/hooks.test.ts` 新增：
+
+```ts
+describe('openSingletonAndSelect', () => {
+  beforeEach(() => {
+    useWorkspaceStore.getState().reset()
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+  })
+
+  it('creates singleton tab, inserts into active workspace, and selects it', () => {
+    const ws = useWorkspaceStore.getState().addWorkspace('WS1')
+    useWorkspaceStore.getState().setActiveWorkspace(ws.id)
+
+    const { result } = renderHook(() => useTabWorkspaceActions([]))
+
+    let tabId: string
+    act(() => {
+      tabId = result.current.openSingletonAndSelect({ kind: 'hosts' })
+    })
+
+    // Tab was created
+    expect(useTabStore.getState().tabs[tabId!]).toBeDefined()
+    // Tab is active
+    expect(useTabStore.getState().activeTabId).toBe(tabId!)
+    // Tab is in workspace
+    const updatedWs = useWorkspaceStore.getState().workspaces.find(w => w.id === ws.id)
+    expect(updatedWs!.tabs).toContain(tabId!)
+    // Workspace active tab is set
+    expect(updatedWs!.activeTabId).toBe(tabId!)
+  })
+
+  it('reuses existing singleton tab instead of creating duplicate', () => {
+    const ws = useWorkspaceStore.getState().addWorkspace('WS1')
+    useWorkspaceStore.getState().setActiveWorkspace(ws.id)
+
+    const { result } = renderHook(() => useTabWorkspaceActions([]))
+
+    let tabId1: string
+    let tabId2: string
+    act(() => {
+      tabId1 = result.current.openSingletonAndSelect({ kind: 'hosts' })
+    })
+    act(() => {
+      tabId2 = result.current.openSingletonAndSelect({ kind: 'hosts' })
+    })
+
+    expect(tabId1!).toBe(tabId2!)
+    expect(Object.keys(useTabStore.getState().tabs)).toHaveLength(1)
+  })
+
+  it('works without active workspace (standalone tabs)', () => {
+    const { result } = renderHook(() => useTabWorkspaceActions([]))
+
+    let tabId: string
+    act(() => {
+      tabId = result.current.openSingletonAndSelect({ kind: 'settings', scope: 'global' })
+    })
+
+    expect(useTabStore.getState().tabs[tabId!]).toBeDefined()
+    expect(useTabStore.getState().activeTabId).toBe(tabId!)
+  })
+})
+```
+
+- [ ] **Step 2: 執行測試確認失敗**
+
+Run: `cd spa && npx vitest run src/features/workspace/hooks.test.ts`
+Expected: FAIL — `openSingletonAndSelect` 不存在
+
+- [ ] **Step 3: 實作 openSingletonAndSelect**
+
+在 `spa/src/features/workspace/hooks.ts` 檔案頂部加入 import：
+```ts
+import type { PaneContent } from '../../types/tab'
+```
+
+在 `useTabWorkspaceActions` 函式內，`handleClearRenameError` 之後加入：
+```ts
+  const openSingletonAndSelect = useCallback((content: PaneContent) => {
+    const tabId = useTabStore.getState().openSingletonTab(content)
+    useWorkspaceStore.getState().insertTab(tabId)
+    handleSelectTab(tabId)
+    return tabId
+  }, [handleSelectTab])
+```
+
+在 return 物件中加入 `openSingletonAndSelect`：
+```ts
+  return {
+    contextMenu,
+    setContextMenu,
+    contextMenuHasRightUnlocked,
+    handleSelectWorkspace,
+    handleSelectTab,
+    handleCloseTab,
+    handleAddTab,
+    handleReorderTabs,
+    handleContextMenu,
+    handleMiddleClick,
+    handleContextAction,
+    renameTarget,
+    renameError,
+    handleRenameConfirm,
+    handleRenameCancel,
+    handleClearRenameError,
+    openSingletonAndSelect,
+  }
+```
+
+- [ ] **Step 4: 執行測試確認通過**
+
+Run: `cd spa && npx vitest run src/features/workspace/hooks.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: 執行全部測試確認無回歸**
+
+Run: `cd spa && npx vitest run`
+Expected: 131 test files, all passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/features/workspace/hooks.ts spa/src/features/workspace/hooks.test.ts
+git commit -m "feat: add openSingletonAndSelect to useTabWorkspaceActions"
+```
+
+---
+
+### Task 3: 提取 useElectronIpc hook
+
+**Files:**
+- Create: `spa/src/hooks/useElectronIpc.ts`
+- Modify: `spa/src/App.tsx:98-163` (移除 4 個 useEffect)
+
+此 hook 收納 4 個 Electron IPC side-effect：`signalReady`、`onTabReceived`、`onWorkspaceReceived`、`onBrowserViewOpenInTab`。同時修正 #231（`onWorkspaceReceived` 的 catch 範圍過大）。
+
+- [ ] **Step 1: 建立 `spa/src/hooks/useElectronIpc.ts`**
+
+```ts
+import { useEffect } from 'react'
+import { useTabStore } from '../stores/useTabStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+import { openBrowserTab } from '../lib/open-browser-tab'
+import type { Tab } from '../types/tab'
+
+/**
+ * Registers all Electron IPC listeners as React effects.
+ * No-op when window.electronAPI is absent (SPA-only mode).
+ */
+export function useElectronIpc() {
+  // Signal SPA ready
+  useEffect(() => {
+    window.electronAPI?.signalReady()
+  }, [])
+
+  // Receive single tab from tear-off/merge
+  useEffect(() => {
+    if (!window.electronAPI) return
+    return window.electronAPI.onTabReceived((tabJson: string, replace: boolean) => {
+      try {
+        const tab = JSON.parse(tabJson)
+        if (tab && tab.id && tab.layout) {
+          if (replace) {
+            useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+          }
+          useTabStore.getState().addTab(tab)
+          useTabStore.getState().setActiveTab(tab.id)
+          useWorkspaceStore.getState().insertTab(tab.id)
+        }
+      } catch { /* ignore malformed tab JSON */ }
+    })
+  }, [])
+
+  // Receive workspace from tear-off/merge
+  // Fix #231: narrow catch to JSON.parse only
+  useEffect(() => {
+    if (!window.electronAPI?.onWorkspaceReceived) return
+    return window.electronAPI.onWorkspaceReceived((payload: string, replace: boolean) => {
+      let parsed: { workspace: { id: string; tabs: string[]; activeTabId?: string }; tabData: Tab[] }
+      try {
+        parsed = JSON.parse(payload)
+      } catch {
+        return // malformed JSON — discard
+      }
+
+      const { workspace, tabData } = parsed
+      if (!workspace?.id || !Array.isArray(tabData)) return
+
+      const tabMap = new Map(tabData.map((t: Tab) => [t.id, t]))
+      workspace.tabs = workspace.tabs.filter((id: string) => tabMap.has(id))
+
+      if (replace) {
+        useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+        useWorkspaceStore.getState().reset()
+      }
+
+      for (const tab of tabData) {
+        if (tab?.id && tab?.layout) useTabStore.getState().addTab(tab)
+      }
+
+      useWorkspaceStore.getState().importWorkspace(workspace)
+      if (replace) {
+        useWorkspaceStore.getState().setActiveWorkspace(workspace.id)
+      }
+      const activeTab = (workspace.activeTabId && tabMap.has(workspace.activeTabId))
+        ? workspace.activeTabId
+        : workspace.tabs[0]
+      if (activeTab) useTabStore.getState().setActiveTab(activeTab)
+    })
+  }, [])
+
+  // Open browser tab from mini browser / WebContentsView link click
+  useEffect(() => {
+    if (!window.electronAPI?.onBrowserViewOpenInTab) return
+    return window.electronAPI.onBrowserViewOpenInTab((url: string) => {
+      openBrowserTab(url)
+    })
+  }, [])
+}
+```
+
+- [ ] **Step 2: 修改 App.tsx — 移除 4 個 effect，加 import**
+
+移除 App.tsx 中以下區塊：
+- L98–101: `signalReady` effect
+- L103–121: `onTabReceived` effect
+- L123–155: `onWorkspaceReceived` effect
+- L157–163: `onBrowserViewOpenInTab` effect
+
+加入 import 和 hook 呼叫：
+```tsx
+import { useElectronIpc } from './hooks/useElectronIpc'
+```
+
+在 `useNotificationDispatcher()` 之後加入：
+```tsx
+useElectronIpc()
+```
+
+清理不再需要的 App.tsx imports：
+- `openBrowserTab` — 只被 onBrowserViewOpenInTab 使用，移除
+- `type Tab` — 檢查是否還有其他用途。App.tsx 中 `displayTabs: Tab[]` 仍使用 → 保留
+
+- [ ] **Step 3: 執行測試確認無回歸**
+
+Run: `cd spa && npx vitest run`
+Expected: all passed
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/hooks/useElectronIpc.ts spa/src/App.tsx
+git commit -m "refactor: extract useElectronIpc hook from App.tsx
+
+Fixes #231 — narrow onWorkspaceReceived catch to JSON.parse only"
+```
+
+---
+
+### Task 4: 提取 useWorkspaceWindowActions hook
+
+**Files:**
+- Create: `spa/src/hooks/useWorkspaceWindowActions.ts`
+- Modify: `spa/src/App.tsx:226-269` (移除 4 個函式)
+
+- [ ] **Step 1: 建立 `spa/src/hooks/useWorkspaceWindowActions.ts`**
+
+```ts
+import { useCallback } from 'react'
+import { useTabStore } from '../stores/useTabStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+
+/**
+ * Workspace tear-off / merge handlers for Electron multi-window.
+ * Returns no-op-safe handlers — callers don't need to check electronAPI.
+ */
+export function useWorkspaceWindowActions() {
+  const workspaces = useWorkspaceStore((s) => s.workspaces)
+  const tabs = useTabStore((s) => s.tabs)
+
+  const prepareWorkspacePayload = useCallback((wsId: string) => {
+    const ws = workspaces.find(w => w.id === wsId)
+    if (!ws || ws.tabs.length === 0) return null
+    const tabData = ws.tabs.map(id => tabs[id]).filter(Boolean)
+    if (tabData.length === 0) return null
+    return { ws, payload: JSON.stringify({ workspace: ws, tabData }) }
+  }, [workspaces, tabs])
+
+  const removeWorkspaceFromStore = useCallback((tabIds: string[], wsId: string) => {
+    const { tabs: currentTabs, tabOrder: currentTabOrder } = useTabStore.getState()
+    const newTabs = { ...currentTabs }
+    const newTabOrder = currentTabOrder.filter(id => !tabIds.includes(id))
+    for (const id of tabIds) delete newTabs[id]
+    useTabStore.setState({ tabs: newTabs, tabOrder: newTabOrder, activeTabId: null })
+    useWorkspaceStore.getState().removeWorkspace(wsId)
+    const wsState = useWorkspaceStore.getState()
+    const newActiveWs = wsState.activeWorkspaceId
+      ? wsState.workspaces.find(w => w.id === wsState.activeWorkspaceId)
+      : null
+    const syncedTabId = newActiveWs?.activeTabId ?? newActiveWs?.tabs[0] ?? newTabOrder[0] ?? null
+    if (syncedTabId) useTabStore.getState().setActiveTab(syncedTabId)
+  }, [])
+
+  const handleWsTearOff = useCallback(async (wsId: string) => {
+    if (!window.electronAPI) return
+    const prepared = prepareWorkspacePayload(wsId)
+    if (!prepared) return
+    try {
+      await window.electronAPI.tearOffWorkspace(prepared.payload)
+      removeWorkspaceFromStore(prepared.ws.tabs, wsId)
+    } catch { /* IPC failed — keep data intact */ }
+  }, [prepareWorkspacePayload, removeWorkspaceFromStore])
+
+  const handleWsMergeTo = useCallback(async (wsId: string, targetWindowId: string) => {
+    if (!window.electronAPI) return
+    const prepared = prepareWorkspacePayload(wsId)
+    if (!prepared) return
+    try {
+      await window.electronAPI.mergeWorkspace(prepared.payload, targetWindowId)
+      removeWorkspaceFromStore(prepared.ws.tabs, wsId)
+    } catch { /* IPC failed — keep data intact */ }
+  }, [prepareWorkspacePayload, removeWorkspaceFromStore])
+
+  return { handleWsTearOff, handleWsMergeTo }
+}
+```
+
+- [ ] **Step 2: 修改 App.tsx — 移除函式，加 import + hook 呼叫**
+
+移除 App.tsx 中以下區塊：
+- `prepareWorkspacePayload` 的 useCallback（整個定義）
+- `removeWorkspaceFromStore` 的 useCallback（整個定義）
+- `handleWsTearOff` 的 useCallback（整個定義）
+- `handleWsMergeTo` 的 useCallback（整個定義）
+
+加入：
+```tsx
+import { useWorkspaceWindowActions } from './hooks/useWorkspaceWindowActions'
+```
+
+在 `useElectronIpc()` 之後加入：
+```tsx
+const { handleWsTearOff, handleWsMergeTo } = useWorkspaceWindowActions()
+```
+
+- [ ] **Step 3: 執行測試確認無回歸**
+
+Run: `cd spa && npx vitest run`
+Expected: all passed
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/hooks/useWorkspaceWindowActions.ts spa/src/App.tsx
+git commit -m "refactor: extract useWorkspaceWindowActions hook from App.tsx"
+```
+
+---
+
+### Task 5: 將 App.tsx inline lambda 提為具名 callback
+
+**Files:**
+- Modify: `spa/src/App.tsx` (將 JSX 內所有多行 inline lambda 提為具名 useCallback)
+
+此 task 消除 JSX 中散落的 store 操作，讓 render 區塊只剩 prop 傳遞。
+
+- [ ] **Step 1: 提取 ActivityBar 和 StatusBar 的 inline handlers**
+
+在 App.tsx 的 `openWsSettings` 定義之後、JSX return 之前，加入以下具名 callback：
+
+```tsx
+  const handleSelectHome = useCallback(() => {
+    useWorkspaceStore.getState().setActiveWorkspace(null)
+    const firstStandalone = standaloneTabIds[0]
+    if (firstStandalone) {
+      handleSelectTab(firstStandalone)
+    } else {
+      useTabStore.getState().setActiveTab(null)
+    }
+  }, [standaloneTabIds, handleSelectTab])
+
+  const handleAddWorkspace = useCallback(() => {
+    if (workspaces.length === 0 && tabOrder.length > 0) {
+      const ws = useWorkspaceStore.getState().addWorkspace('Workspace 1')
+      setMigrateDialog({ wsId: ws.id, wsName: ws.name })
+    } else {
+      const count = workspaces.length + 1
+      const ws = useWorkspaceStore.getState().addWorkspace(`Workspace ${count}`)
+      openWsSettings(ws.id)
+    }
+  }, [workspaces.length, tabOrder.length, openWsSettings])
+
+  const handleOpenHosts = useCallback(() => {
+    openSingletonAndSelect({ kind: 'hosts' })
+  }, [openSingletonAndSelect])
+
+  const handleOpenSettings = useCallback(() => {
+    openSingletonAndSelect({ kind: 'settings', scope: 'global' })
+  }, [openSingletonAndSelect])
+
+  const handleViewModeChange = useCallback((tabId: string, paneId: string, mode: 'terminal' | 'stream') => {
+    useTabStore.getState().setViewMode(tabId, paneId, mode)
+  }, [])
+
+  const handleNavigateToHost = useCallback((hostId: string) => {
+    openSingletonAndSelect({ kind: 'hosts' })
+    useHostStore.getState().setActiveHost(hostId)
+  }, [openSingletonAndSelect])
+
+  const handleMigrateConfirm = useCallback(() => {
+    if (!migrateDialog) return
+    tabOrder.forEach((tabId) => {
+      useWorkspaceStore.getState().insertTab(tabId, migrateDialog.wsId)
+    })
+    setMigrateDialog(null)
+    openWsSettings(migrateDialog.wsId)
+  }, [migrateDialog, tabOrder, openWsSettings])
+
+  const handleMigrateSkip = useCallback(() => {
+    setMigrateDialog(null)
+    useWorkspaceStore.getState().setActiveWorkspace(null)
+  }, [])
+```
+
+注意：`openSingletonAndSelect` 來自 Task 2 新增的 `useTabWorkspaceActions` 回傳值。需要在 App.tsx 的 destructuring 中加入它：
+
+```tsx
+  const {
+    contextMenu,
+    setContextMenu,
+    contextMenuHasRightUnlocked,
+    handleSelectWorkspace,
+    handleSelectTab,
+    handleCloseTab,
+    handleAddTab,
+    handleReorderTabs,
+    handleContextMenu,
+    handleMiddleClick,
+    handleContextAction,
+    renameTarget,
+    renameError,
+    handleRenameConfirm,
+    handleRenameCancel,
+    handleClearRenameError,
+    openSingletonAndSelect,
+  } = useTabWorkspaceActions(displayTabs)
+```
+
+同時 `openWsSettings` 可以簡化為使用 `openSingletonAndSelect`：
+```tsx
+  const openWsSettings = useCallback((wsId: string) => {
+    openSingletonAndSelect({ kind: 'settings', scope: { workspaceId: wsId } })
+  }, [openSingletonAndSelect])
+```
+
+- [ ] **Step 2: 簡化 JSX — 替換所有 inline lambda 為具名 reference**
+
+ActivityBar 區塊變為：
+```tsx
+          <ActivityBar
+            workspaces={workspaces}
+            activeWorkspaceId={activeStandaloneTabId ? null : activeWorkspaceId}
+            activeStandaloneTabId={activeStandaloneTabId}
+            onSelectWorkspace={handleSelectWorkspace}
+            onSelectHome={handleSelectHome}
+            standaloneTabIds={standaloneTabIds}
+            onAddWorkspace={handleAddWorkspace}
+            onReorderWorkspaces={(ids) => useWorkspaceStore.getState().reorderWorkspaces(ids)}
+            onContextMenuWorkspace={handleWsContextMenu}
+            onOpenHosts={handleOpenHosts}
+            onOpenSettings={handleOpenSettings}
+          />
+```
+
+StatusBar 區塊變為：
+```tsx
+            <StatusBar
+              activeTab={activeTab ?? null}
+              onViewModeChange={handleViewModeChange}
+              onNavigateToHost={handleNavigateToHost}
+            />
+```
+
+MigrateTabsDialog 區塊變為：
+```tsx
+        {migrateDialog && (
+          <MigrateTabsDialog
+            tabCount={tabOrder.length}
+            workspaceName={migrateDialog.wsName}
+            onMigrate={handleMigrateConfirm}
+            onSkip={handleMigrateSkip}
+          />
+        )}
+```
+
+- [ ] **Step 3: 清理不再需要的 imports**
+
+移除 App.tsx 中不再直接使用的 imports：
+- `useHostStore` — 檢查：`handleNavigateToHost` 用了 → 保留
+- `isStandaloneTab` — `standaloneTabIds` 計算用了 → 保留
+
+- [ ] **Step 4: 執行測試確認無回歸**
+
+Run: `cd spa && npx vitest run`
+Expected: all passed
+
+- [ ] **Step 5: 執行 lint 確認無警告**
+
+Run: `cd spa && pnpm run lint`
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/App.tsx
+git commit -m "refactor: extract inline handlers to named callbacks in App.tsx"
+```
+
+---
+
+### Task 6: 最終驗證 + 清理
+
+**Files:**
+- Verify: `spa/src/App.tsx` (確認行數 ≤ 200)
+- Verify: all tests pass
+- Verify: lint clean
+
+- [ ] **Step 1: 確認 App.tsx 行數**
+
+Run: `wc -l spa/src/App.tsx`
+Expected: ≤ 200 行
+
+- [ ] **Step 2: 確認所有測試通過**
+
+Run: `cd spa && npx vitest run`
+Expected: all passed（含 Task 2 新增的 3 個測試）
+
+- [ ] **Step 3: 確認 lint 無錯誤**
+
+Run: `cd spa && pnpm run lint`
+Expected: no errors
+
+- [ ] **Step 4: 確認 build 成功**
+
+Run: `cd spa && pnpm run build`
+Expected: 成功產出 dist/
+
+- [ ] **Step 5: 檢視最終 App.tsx 結構**
+
+確認 App.tsx 呈現以下結構：
+1. Imports
+2. `export default function App()` 
+3. Store subscriptions（5 行）
+4. Hook 呼叫（7 行：useRelayWsManager, useMultiHostEventWs, useRouteSync, useShortcuts, useNotificationDispatcher, useElectronIpc, useWorkspaceWindowActions）
+5. Derived state（visibleTabIds, displayTabs, standaloneTabIds, activeStandaloneTabId）
+6. useTabWorkspaceActions destructuring
+7. 具名 callback handlers
+8. JSX return — 純組裝，無 inline 業務邏輯

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -111,16 +111,28 @@ export default function App() {
   } = useTabWorkspaceActions(displayTabs)
 
   const openWsSettings = useCallback((wsId: string) => {
-    openSingletonAndSelect({ kind: 'settings', scope: { workspaceId: wsId } })
+    openSingletonAndSelect({ kind: 'settings', scope: { workspaceId: wsId } }, wsId)
   }, [openSingletonAndSelect])
 
   // --- Workspace UI state ---
   const [wsContextMenu, setWsContextMenu] = useState<{ wsId: string; position: { x: number; y: number } } | null>(null)
   const [migrateDialog, setMigrateDialog] = useState<{ wsId: string; wsName: string } | null>(null)
 
-  const handleWsContextMenu = (e: React.MouseEvent, wsId: string) => {
+  const handleWsContextMenu = useCallback((e: React.MouseEvent, wsId: string) => {
     setWsContextMenu({ wsId, position: { x: e.clientX, y: e.clientY } })
-  }
+  }, [])
+
+  const handleReorderWorkspaces = useCallback((ids: string[]) => {
+    useWorkspaceStore.getState().reorderWorkspaces(ids)
+  }, [])
+
+  const handleCloseTabContextMenu = useCallback(() => {
+    setContextMenu(null)
+  }, [setContextMenu])
+
+  const handleCloseWsContextMenu = useCallback(() => {
+    setWsContextMenu(null)
+  }, [])
 
   const handleSelectHome = useCallback(() => {
     useWorkspaceStore.getState().setActiveWorkspace(null)
@@ -189,7 +201,7 @@ export default function App() {
             onSelectHome={handleSelectHome}
             standaloneTabIds={standaloneTabIds}
             onAddWorkspace={handleAddWorkspace}
-            onReorderWorkspaces={(ids) => useWorkspaceStore.getState().reorderWorkspaces(ids)}
+            onReorderWorkspaces={handleReorderWorkspaces}
             onContextMenuWorkspace={handleWsContextMenu}
             onOpenHosts={handleOpenHosts}
             onOpenSettings={handleOpenSettings}
@@ -229,7 +241,7 @@ export default function App() {
           <TabContextMenu
             tab={contextMenu.tab}
             position={contextMenu.position}
-            onClose={() => setContextMenu(null)}
+            onClose={handleCloseTabContextMenu}
             onAction={handleContextAction}
             hasOtherUnlocked={displayTabs.some((t) => t.id !== contextMenu.tab.id && !t.locked)}
             hasRightUnlocked={contextMenuHasRightUnlocked}
@@ -254,7 +266,7 @@ export default function App() {
             onSettings={() => openWsSettings(wsContextMenu.wsId)}
             onTearOff={window.electronAPI ? () => handleWsTearOff(wsContextMenu.wsId) : undefined}
             onMergeTo={window.electronAPI ? (targetWindowId) => handleWsMergeTo(wsContextMenu.wsId, targetWindowId) : undefined}
-            onClose={() => setWsContextMenu(null)}
+            onClose={handleCloseWsContextMenu}
           />
         )}
         {migrateDialog && (

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -1,5 +1,5 @@
 // spa/src/App.tsx — v2 重構：wouter Router + Tab/Pane model
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Router } from 'wouter'
 import { ActivityBar } from './components/ActivityBar'
 import { TabBar } from './components/TabBar'
@@ -18,7 +18,6 @@ import { useShortcuts } from './hooks/useShortcuts'
 import { openBrowserTab } from './lib/open-browser-tab'
 import './lib/browser-shortcuts'
 import { useNotificationDispatcher } from './hooks/useNotificationDispatcher'
-import { useUndoToast } from './stores/useUndoToast'
 import { useTabWorkspaceActions } from './hooks/useTabWorkspaceActions'
 import { isStandaloneTab } from './types/tab'
 import {
@@ -32,42 +31,8 @@ import { RenamePopover } from './components/RenamePopover'
 import { ThemeInjector } from './components/ThemeInjector'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { getPlatformCapabilities } from './lib/platform'
-import { useI18nStore } from './stores/useI18nStore'
 import type { Tab } from './types/tab'
-
-function GlobalUndoToast() {
-  const toast = useUndoToast((s) => s.toast)
-  const dismiss = useUndoToast((s) => s.dismiss)
-  const t = useI18nStore((s) => s.t)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => {
-    if (!toast) return
-    timerRef.current = setTimeout(() => dismiss(), 5000)
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current)
-    }
-  }, [toast, dismiss])
-
-  if (!toast) return null
-
-  return (
-    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3 flex items-center gap-3 shadow-lg z-50">
-      <span className="text-sm text-zinc-300">
-        {toast.message}
-      </span>
-      <button
-        className="text-sm text-blue-400 hover:text-blue-300 font-medium cursor-pointer"
-        onClick={() => {
-          toast.restore()
-          dismiss()
-        }}
-      >
-        {t('hosts.undo')}
-      </button>
-    </div>
-  )
-}
+import { GlobalUndoToast } from './components/GlobalUndoToast'
 
 export default function App() {
   const isElectron = getPlatformCapabilities().isElectron

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -15,9 +15,9 @@ import { useRelayWsManager } from './hooks/useRelayWsManager'
 import { useMultiHostEventWs } from './hooks/useMultiHostEventWs'
 import { useRouteSync } from './hooks/useRouteSync'
 import { useShortcuts } from './hooks/useShortcuts'
-import { openBrowserTab } from './lib/open-browser-tab'
 import './lib/browser-shortcuts'
 import { useNotificationDispatcher } from './hooks/useNotificationDispatcher'
+import { useElectronIpc } from './hooks/useElectronIpc'
 import { useTabWorkspaceActions } from './hooks/useTabWorkspaceActions'
 import { isStandaloneTab } from './types/tab'
 import {
@@ -59,73 +59,7 @@ export default function App() {
   useRouteSync()
   useShortcuts()
   useNotificationDispatcher()
-
-  // --- Electron: signal SPA ready (replaces 500ms setTimeout) ---
-  useEffect(() => {
-    window.electronAPI?.signalReady()
-  }, [])
-
-  // --- Electron IPC: receive tab from tear-off/merge ---
-  useEffect(() => {
-    if (!window.electronAPI) return
-    return window.electronAPI.onTabReceived((tabJson: string, replace: boolean) => {
-      try {
-        const tab = JSON.parse(tabJson)
-        if (tab && tab.id && tab.layout) {
-          if (replace) {
-            // Tear-off: new window — clear persisted tabs, keep only the received one
-            useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
-          }
-          useTabStore.getState().addTab(tab)
-          useTabStore.getState().setActiveTab(tab.id)
-          // Restore workspace membership if receiving window has an active workspace
-          useWorkspaceStore.getState().insertTab(tab.id)
-        }
-      } catch { /* ignore malformed tab JSON */ }
-    })
-  }, [])
-
-  // --- Electron IPC: receive workspace from tear-off/merge ---
-  useEffect(() => {
-    if (!window.electronAPI?.onWorkspaceReceived) return
-    return window.electronAPI.onWorkspaceReceived((payload: string, replace: boolean) => {
-      try {
-        const { workspace, tabData } = JSON.parse(payload)
-        if (!workspace?.id || !Array.isArray(tabData)) return
-
-        // 校驗 tab ids
-        const tabMap = new Map(tabData.map((t: Tab) => [t.id, t]))
-        workspace.tabs = workspace.tabs.filter((id: string) => tabMap.has(id))
-
-        if (replace) {
-          useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
-          useWorkspaceStore.getState().reset()
-        }
-
-        for (const tab of tabData) {
-          if (tab?.id && tab?.layout) useTabStore.getState().addTab(tab)
-        }
-
-        useWorkspaceStore.getState().importWorkspace(workspace)
-        // Only force-switch workspace on tear-off (replace); merge adds silently
-        if (replace) {
-          useWorkspaceStore.getState().setActiveWorkspace(workspace.id)
-        }
-        const activeTab = (workspace.activeTabId && tabMap.has(workspace.activeTabId))
-          ? workspace.activeTabId
-          : workspace.tabs[0]
-        if (activeTab) useTabStore.getState().setActiveTab(activeTab)
-      } catch { /* ignore malformed payload */ }
-    })
-  }, [])
-
-  // --- Electron IPC: open browser tab from mini browser / WebContentsView link click ---
-  useEffect(() => {
-    if (!window.electronAPI?.onBrowserViewOpenInTab) return
-    return window.electronAPI.onBrowserViewOpenInTab((url: string) => {
-      openBrowserTab(url)
-    })
-  }, [])
+  useElectronIpc()
 
   // --- Derived state ---
   const activeTab = activeTabId ? tabs[activeTabId] : undefined

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -19,6 +19,7 @@ import './lib/browser-shortcuts'
 import { useNotificationDispatcher } from './hooks/useNotificationDispatcher'
 import { useElectronIpc } from './hooks/useElectronIpc'
 import { useTabWorkspaceActions } from './hooks/useTabWorkspaceActions'
+import { useWorkspaceWindowActions } from './hooks/useWorkspaceWindowActions'
 import { isStandaloneTab } from './types/tab'
 import {
   getVisibleTabIds,
@@ -60,6 +61,7 @@ export default function App() {
   useShortcuts()
   useNotificationDispatcher()
   useElectronIpc()
+  const { handleWsTearOff, handleWsMergeTo } = useWorkspaceWindowActions()
 
   // --- Derived state ---
   const activeTab = activeTabId ? tabs[activeTabId] : undefined
@@ -121,51 +123,6 @@ export default function App() {
   const handleWsContextMenu = (e: React.MouseEvent, wsId: string) => {
     setWsContextMenu({ wsId, position: { x: e.clientX, y: e.clientY } })
   }
-
-  const prepareWorkspacePayload = useCallback((wsId: string) => {
-    const ws = workspaces.find(w => w.id === wsId)
-    if (!ws || ws.tabs.length === 0) return null
-    const tabData = ws.tabs.map(id => tabs[id]).filter(Boolean)
-    if (tabData.length === 0) return null
-    return { ws, payload: JSON.stringify({ workspace: ws, tabData }) }
-  }, [workspaces, tabs])
-
-  const removeWorkspaceFromStore = useCallback((tabIds: string[], wsId: string) => {
-    // Read fresh state to avoid stale closure after async IPC
-    const { tabs: currentTabs, tabOrder: currentTabOrder } = useTabStore.getState()
-    const newTabs = { ...currentTabs }
-    const newTabOrder = currentTabOrder.filter(id => !tabIds.includes(id))
-    for (const id of tabIds) delete newTabs[id]
-    useTabStore.setState({ tabs: newTabs, tabOrder: newTabOrder, activeTabId: null })
-    useWorkspaceStore.getState().removeWorkspace(wsId)
-    // Sync activeTabId with the new active workspace's activeTabId
-    const wsState = useWorkspaceStore.getState()
-    const newActiveWs = wsState.activeWorkspaceId
-      ? wsState.workspaces.find(w => w.id === wsState.activeWorkspaceId)
-      : null
-    const syncedTabId = newActiveWs?.activeTabId ?? newActiveWs?.tabs[0] ?? newTabOrder[0] ?? null
-    if (syncedTabId) useTabStore.getState().setActiveTab(syncedTabId)
-  }, [])
-
-  const handleWsTearOff = useCallback(async (wsId: string) => {
-    if (!window.electronAPI) return
-    const prepared = prepareWorkspacePayload(wsId)
-    if (!prepared) return
-    try {
-      await window.electronAPI.tearOffWorkspace(prepared.payload)
-      removeWorkspaceFromStore(prepared.ws.tabs, wsId)
-    } catch { /* IPC failed — keep data intact */ }
-  }, [prepareWorkspacePayload, removeWorkspaceFromStore])
-
-  const handleWsMergeTo = useCallback(async (wsId: string, targetWindowId: string) => {
-    if (!window.electronAPI) return
-    const prepared = prepareWorkspacePayload(wsId)
-    if (!prepared) return
-    try {
-      await window.electronAPI.mergeWorkspace(prepared.payload, targetWindowId)
-      removeWorkspaceFromStore(prepared.ws.tabs, wsId)
-    } catch { /* IPC failed — keep data intact */ }
-  }, [prepareWorkspacePayload, removeWorkspaceFromStore])
 
   return (
     <ErrorBoundary>

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -86,7 +86,6 @@ export default function App() {
     () => tabOrder.filter((id) => isStandaloneTab(id, workspaces)),
     [tabOrder, workspaces],
   )
-  const standaloneTabs = standaloneTabIds.map((id) => tabs[id]).filter(Boolean)
 
   const activeStandaloneTabId = activeTabId && isStandaloneTab(activeTabId, workspaces) ? activeTabId : null
 
@@ -108,13 +107,12 @@ export default function App() {
     handleRenameConfirm,
     handleRenameCancel,
     handleClearRenameError,
+    openSingletonAndSelect,
   } = useTabWorkspaceActions(displayTabs)
 
   const openWsSettings = useCallback((wsId: string) => {
-    const tabId = useTabStore.getState().openSingletonTab({ kind: 'settings', scope: { workspaceId: wsId } })
-    useWorkspaceStore.getState().insertTab(tabId, wsId)
-    handleSelectTab(tabId)
-  }, [handleSelectTab])
+    openSingletonAndSelect({ kind: 'settings', scope: { workspaceId: wsId } })
+  }, [openSingletonAndSelect])
 
   // --- Workspace UI state ---
   const [wsContextMenu, setWsContextMenu] = useState<{ wsId: string; position: { x: number; y: number } } | null>(null)
@@ -123,6 +121,58 @@ export default function App() {
   const handleWsContextMenu = (e: React.MouseEvent, wsId: string) => {
     setWsContextMenu({ wsId, position: { x: e.clientX, y: e.clientY } })
   }
+
+  const handleSelectHome = useCallback(() => {
+    useWorkspaceStore.getState().setActiveWorkspace(null)
+    const firstStandalone = standaloneTabIds[0]
+    if (firstStandalone) {
+      handleSelectTab(firstStandalone)
+    } else {
+      useTabStore.getState().setActiveTab(null)
+    }
+  }, [standaloneTabIds, handleSelectTab])
+
+  const handleAddWorkspace = useCallback(() => {
+    if (workspaces.length === 0 && tabOrder.length > 0) {
+      const ws = useWorkspaceStore.getState().addWorkspace('Workspace 1')
+      setMigrateDialog({ wsId: ws.id, wsName: ws.name })
+    } else {
+      const count = workspaces.length + 1
+      const ws = useWorkspaceStore.getState().addWorkspace(`Workspace ${count}`)
+      openWsSettings(ws.id)
+    }
+  }, [workspaces.length, tabOrder.length, openWsSettings])
+
+  const handleOpenHosts = useCallback(() => {
+    openSingletonAndSelect({ kind: 'hosts' })
+  }, [openSingletonAndSelect])
+
+  const handleOpenSettings = useCallback(() => {
+    openSingletonAndSelect({ kind: 'settings', scope: 'global' })
+  }, [openSingletonAndSelect])
+
+  const handleViewModeChange = useCallback((tabId: string, paneId: string, mode: 'terminal' | 'stream') => {
+    useTabStore.getState().setViewMode(tabId, paneId, mode)
+  }, [])
+
+  const handleNavigateToHost = useCallback((hostId: string) => {
+    openSingletonAndSelect({ kind: 'hosts' })
+    useHostStore.getState().setActiveHost(hostId)
+  }, [openSingletonAndSelect])
+
+  const handleMigrateConfirm = useCallback(() => {
+    if (!migrateDialog) return
+    tabOrder.forEach((tabId) => {
+      useWorkspaceStore.getState().insertTab(tabId, migrateDialog.wsId)
+    })
+    setMigrateDialog(null)
+    openWsSettings(migrateDialog.wsId)
+  }, [migrateDialog, tabOrder, openWsSettings])
+
+  const handleMigrateSkip = useCallback(() => {
+    setMigrateDialog(null)
+    useWorkspaceStore.getState().setActiveWorkspace(null)
+  }, [])
 
   return (
     <ErrorBoundary>
@@ -136,38 +186,13 @@ export default function App() {
             activeWorkspaceId={activeStandaloneTabId ? null : activeWorkspaceId}
             activeStandaloneTabId={activeStandaloneTabId}
             onSelectWorkspace={handleSelectWorkspace}
-            onSelectHome={() => {
-              useWorkspaceStore.getState().setActiveWorkspace(null)
-              const firstStandalone = standaloneTabs[0]
-              if (firstStandalone) {
-                handleSelectTab(firstStandalone.id)
-              } else {
-                useTabStore.getState().setActiveTab(null)
-              }
-            }}
+            onSelectHome={handleSelectHome}
             standaloneTabIds={standaloneTabIds}
-            onAddWorkspace={() => {
-              if (workspaces.length === 0 && tabOrder.length > 0) {
-                const ws = useWorkspaceStore.getState().addWorkspace('Workspace 1')
-                setMigrateDialog({ wsId: ws.id, wsName: ws.name })
-              } else {
-                const count = workspaces.length + 1
-                const ws = useWorkspaceStore.getState().addWorkspace(`Workspace ${count}`)
-                openWsSettings(ws.id)
-              }
-            }}
+            onAddWorkspace={handleAddWorkspace}
             onReorderWorkspaces={(ids) => useWorkspaceStore.getState().reorderWorkspaces(ids)}
             onContextMenuWorkspace={handleWsContextMenu}
-            onOpenHosts={() => {
-              const tabId = useTabStore.getState().openSingletonTab({ kind: 'hosts' })
-              useWorkspaceStore.getState().insertTab(tabId)
-              handleSelectTab(tabId)
-            }}
-            onOpenSettings={() => {
-              const tabId = useTabStore.getState().openSingletonTab({ kind: 'settings', scope: 'global' })
-              useWorkspaceStore.getState().insertTab(tabId)
-              handleSelectTab(tabId)
-            }}
+            onOpenHosts={handleOpenHosts}
+            onOpenSettings={handleOpenSettings}
           />
           <SidebarRegion region="primary-sidebar" resizeEdge="right" />
           <div className="flex-1 flex flex-col min-w-0">
@@ -195,15 +220,8 @@ export default function App() {
             </div>
             <StatusBar
               activeTab={activeTab ?? null}
-              onViewModeChange={(tabId, paneId, mode) => {
-                useTabStore.getState().setViewMode(tabId, paneId, mode)
-              }}
-              onNavigateToHost={(hostId) => {
-                const tabId = useTabStore.getState().openSingletonTab({ kind: 'hosts' })
-                useWorkspaceStore.getState().insertTab(tabId)
-                handleSelectTab(tabId)
-                useHostStore.getState().setActiveHost(hostId)
-              }}
+              onViewModeChange={handleViewModeChange}
+              onNavigateToHost={handleNavigateToHost}
             />
           </div>
           <SidebarRegion region="secondary-sidebar" resizeEdge="left" />
@@ -243,17 +261,8 @@ export default function App() {
           <MigrateTabsDialog
             tabCount={tabOrder.length}
             workspaceName={migrateDialog.wsName}
-            onMigrate={() => {
-              tabOrder.forEach((tabId) => {
-                useWorkspaceStore.getState().insertTab(tabId, migrateDialog.wsId)
-              })
-              setMigrateDialog(null)
-              openWsSettings(migrateDialog.wsId)
-            }}
-            onSkip={() => {
-              setMigrateDialog(null)
-              useWorkspaceStore.getState().setActiveWorkspace(null)
-            }}
+            onMigrate={handleMigrateConfirm}
+            onSkip={handleMigrateSkip}
           />
         )}
         </div>

--- a/spa/src/components/GlobalUndoToast.tsx
+++ b/spa/src/components/GlobalUndoToast.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react'
+import { useUndoToast } from '../stores/useUndoToast'
+import { useI18nStore } from '../stores/useI18nStore'
+
+export function GlobalUndoToast() {
+  const toast = useUndoToast((s) => s.toast)
+  const dismiss = useUndoToast((s) => s.dismiss)
+  const t = useI18nStore((s) => s.t)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!toast) return
+    timerRef.current = setTimeout(() => dismiss(), 5000)
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [toast, dismiss])
+
+  if (!toast) return null
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3 flex items-center gap-3 shadow-lg z-50">
+      <span className="text-sm text-zinc-300">
+        {toast.message}
+      </span>
+      <button
+        className="text-sm text-blue-400 hover:text-blue-300 font-medium cursor-pointer"
+        onClick={() => {
+          toast.restore()
+          dismiss()
+        }}
+      >
+        {t('hosts.undo')}
+      </button>
+    </div>
+  )
+}

--- a/spa/src/features/workspace/hooks.test.ts
+++ b/spa/src/features/workspace/hooks.test.ts
@@ -57,3 +57,63 @@ describe('workspace tab recall', () => {
     expect(useTabStore.getState().activeTabId).toBe(tab2.id)
   })
 })
+
+describe('openSingletonAndSelect', () => {
+  beforeEach(() => {
+    useWorkspaceStore.getState().reset()
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+  })
+
+  it('creates singleton tab, inserts into active workspace, and selects it', () => {
+    const ws = useWorkspaceStore.getState().addWorkspace('WS1')
+    useWorkspaceStore.getState().setActiveWorkspace(ws.id)
+
+    const { result } = renderHook(() => useTabWorkspaceActions([]))
+
+    let tabId: string
+    act(() => {
+      tabId = result.current.openSingletonAndSelect({ kind: 'hosts' })
+    })
+
+    // Tab was created
+    expect(useTabStore.getState().tabs[tabId!]).toBeDefined()
+    // Tab is active
+    expect(useTabStore.getState().activeTabId).toBe(tabId!)
+    // Tab is in workspace
+    const updatedWs = useWorkspaceStore.getState().workspaces.find(w => w.id === ws.id)
+    expect(updatedWs!.tabs).toContain(tabId!)
+    // Workspace active tab is set
+    expect(updatedWs!.activeTabId).toBe(tabId!)
+  })
+
+  it('reuses existing singleton tab instead of creating duplicate', () => {
+    const ws = useWorkspaceStore.getState().addWorkspace('WS1')
+    useWorkspaceStore.getState().setActiveWorkspace(ws.id)
+
+    const { result } = renderHook(() => useTabWorkspaceActions([]))
+
+    let tabId1: string
+    let tabId2: string
+    act(() => {
+      tabId1 = result.current.openSingletonAndSelect({ kind: 'hosts' })
+    })
+    act(() => {
+      tabId2 = result.current.openSingletonAndSelect({ kind: 'hosts' })
+    })
+
+    expect(tabId1!).toBe(tabId2!)
+    expect(Object.keys(useTabStore.getState().tabs)).toHaveLength(1)
+  })
+
+  it('works without active workspace (standalone tabs)', () => {
+    const { result } = renderHook(() => useTabWorkspaceActions([]))
+
+    let tabId: string
+    act(() => {
+      tabId = result.current.openSingletonAndSelect({ kind: 'settings', scope: 'global' })
+    })
+
+    expect(useTabStore.getState().tabs[tabId!]).toBeDefined()
+    expect(useTabStore.getState().activeTabId).toBe(tabId!)
+  })
+})

--- a/spa/src/features/workspace/hooks.test.ts
+++ b/spa/src/features/workspace/hooks.test.ts
@@ -116,4 +116,26 @@ describe('openSingletonAndSelect', () => {
     expect(useTabStore.getState().tabs[tabId!]).toBeDefined()
     expect(useTabStore.getState().activeTabId).toBe(tabId!)
   })
+
+  it('inserts tab into explicit wsId even when a different workspace is active', () => {
+    const wsA = useWorkspaceStore.getState().addWorkspace('WS-A')
+    const wsB = useWorkspaceStore.getState().addWorkspace('WS-B')
+    useWorkspaceStore.getState().setActiveWorkspace(wsA.id)
+
+    const { result } = renderHook(() => useTabWorkspaceActions([]))
+
+    let tabId: string
+    act(() => {
+      tabId = result.current.openSingletonAndSelect(
+        { kind: 'settings', scope: { workspaceId: wsB.id } },
+        wsB.id,
+      )
+    })
+
+    // Tab should be inserted into wsB, NOT the active wsA
+    const updatedWsB = useWorkspaceStore.getState().workspaces.find(w => w.id === wsB.id)
+    const updatedWsA = useWorkspaceStore.getState().workspaces.find(w => w.id === wsA.id)
+    expect(updatedWsB!.tabs).toContain(tabId!)
+    expect(updatedWsA!.tabs).not.toContain(tabId!)
+  })
 })

--- a/spa/src/features/workspace/hooks.ts
+++ b/spa/src/features/workspace/hooks.ts
@@ -184,9 +184,9 @@ export function useTabWorkspaceActions(displayTabs: Tab[]) {
     setRenameError(undefined)
   }, [])
 
-  const openSingletonAndSelect = useCallback((content: PaneContent) => {
+  const openSingletonAndSelect = useCallback((content: PaneContent, wsId?: string) => {
     const tabId = useTabStore.getState().openSingletonTab(content)
-    useWorkspaceStore.getState().insertTab(tabId)
+    useWorkspaceStore.getState().insertTab(tabId, wsId)
     handleSelectTab(tabId)
     return tabId
   }, [handleSelectTab])

--- a/spa/src/features/workspace/hooks.ts
+++ b/spa/src/features/workspace/hooks.ts
@@ -5,7 +5,7 @@ import { createTab } from '../../types/tab'
 import { getPrimaryPane } from '../../lib/pane-tree'
 import { renameSession } from '../../lib/host-api'
 import { destroyBrowserViewIfNeeded } from '../../lib/browser-cleanup'
-import type { Tab } from '../../types/tab'
+import type { Tab, PaneContent } from '../../types/tab'
 import type { ContextMenuAction } from '../../components/TabContextMenu'
 
 export function useTabWorkspaceActions(displayTabs: Tab[]) {
@@ -184,6 +184,13 @@ export function useTabWorkspaceActions(displayTabs: Tab[]) {
     setRenameError(undefined)
   }, [])
 
+  const openSingletonAndSelect = useCallback((content: PaneContent) => {
+    const tabId = useTabStore.getState().openSingletonTab(content)
+    useWorkspaceStore.getState().insertTab(tabId)
+    handleSelectTab(tabId)
+    return tabId
+  }, [handleSelectTab])
+
   // Context menu derived state
   const contextMenuHasRightUnlocked = (() => {
     if (!contextMenu) return false
@@ -209,5 +216,6 @@ export function useTabWorkspaceActions(displayTabs: Tab[]) {
     handleRenameConfirm,
     handleRenameCancel,
     handleClearRenameError,
+    openSingletonAndSelect,
   }
 }

--- a/spa/src/hooks/useElectronIpc.ts
+++ b/spa/src/hooks/useElectronIpc.ts
@@ -1,0 +1,80 @@
+import { useEffect } from 'react'
+import { useTabStore } from '../stores/useTabStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+import { openBrowserTab } from '../lib/open-browser-tab'
+import type { Tab } from '../types/tab'
+
+/**
+ * Registers all Electron IPC listeners as React effects.
+ * No-op when window.electronAPI is absent (SPA-only mode).
+ */
+export function useElectronIpc() {
+  // Signal SPA ready
+  useEffect(() => {
+    window.electronAPI?.signalReady()
+  }, [])
+
+  // Receive single tab from tear-off/merge
+  useEffect(() => {
+    if (!window.electronAPI) return
+    return window.electronAPI.onTabReceived((tabJson: string, replace: boolean) => {
+      try {
+        const tab = JSON.parse(tabJson)
+        if (tab && tab.id && tab.layout) {
+          if (replace) {
+            useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+          }
+          useTabStore.getState().addTab(tab)
+          useTabStore.getState().setActiveTab(tab.id)
+          useWorkspaceStore.getState().insertTab(tab.id)
+        }
+      } catch { /* ignore malformed tab JSON */ }
+    })
+  }, [])
+
+  // Receive workspace from tear-off/merge
+  // Fix #231: narrow catch to JSON.parse only
+  useEffect(() => {
+    if (!window.electronAPI?.onWorkspaceReceived) return
+    return window.electronAPI.onWorkspaceReceived((payload: string, replace: boolean) => {
+      let parsed: { workspace: { id: string; tabs: string[]; activeTabId?: string }; tabData: Tab[] }
+      try {
+        parsed = JSON.parse(payload)
+      } catch {
+        return // malformed JSON — discard
+      }
+
+      const { workspace, tabData } = parsed
+      if (!workspace?.id || !Array.isArray(tabData)) return
+
+      const tabMap = new Map(tabData.map((t: Tab) => [t.id, t]))
+      workspace.tabs = workspace.tabs.filter((id: string) => tabMap.has(id))
+
+      if (replace) {
+        useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+        useWorkspaceStore.getState().reset()
+      }
+
+      for (const tab of tabData) {
+        if (tab?.id && tab?.layout) useTabStore.getState().addTab(tab)
+      }
+
+      useWorkspaceStore.getState().importWorkspace(workspace)
+      if (replace) {
+        useWorkspaceStore.getState().setActiveWorkspace(workspace.id)
+      }
+      const activeTab = (workspace.activeTabId && tabMap.has(workspace.activeTabId))
+        ? workspace.activeTabId
+        : workspace.tabs[0]
+      if (activeTab) useTabStore.getState().setActiveTab(activeTab)
+    })
+  }, [])
+
+  // Open browser tab from mini browser / WebContentsView link click
+  useEffect(() => {
+    if (!window.electronAPI?.onBrowserViewOpenInTab) return
+    return window.electronAPI.onBrowserViewOpenInTab((url: string) => {
+      openBrowserTab(url)
+    })
+  }, [])
+}

--- a/spa/src/hooks/useElectronIpc.ts
+++ b/spa/src/hooks/useElectronIpc.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useTabStore } from '../stores/useTabStore'
 import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { openBrowserTab } from '../lib/open-browser-tab'
-import type { Tab } from '../types/tab'
+import type { Tab, Workspace } from '../types/tab'
 
 /**
  * Registers all Electron IPC listeners as React effects.
@@ -37,7 +37,7 @@ export function useElectronIpc() {
   useEffect(() => {
     if (!window.electronAPI?.onWorkspaceReceived) return
     return window.electronAPI.onWorkspaceReceived((payload: string, replace: boolean) => {
-      let parsed: { workspace: { id: string; tabs: string[]; activeTabId?: string }; tabData: Tab[] }
+      let parsed: { workspace: Workspace; tabData: Tab[] }
       try {
         parsed = JSON.parse(payload)
       } catch {

--- a/spa/src/hooks/useWorkspaceWindowActions.ts
+++ b/spa/src/hooks/useWorkspaceWindowActions.ts
@@ -19,6 +19,9 @@ export function useWorkspaceWindowActions() {
   }, [workspaces, tabs])
 
   const removeWorkspaceFromStore = useCallback((tabIds: string[], wsId: string) => {
+    // Read fresh state via getState() to avoid stale closure after async IPC.
+    // The IPC await in handleWsTearOff/handleWsMergeTo may take long enough for
+    // store state to change; using closure values would cause lost updates.
     const { tabs: currentTabs, tabOrder: currentTabOrder } = useTabStore.getState()
     const newTabs = { ...currentTabs }
     const newTabOrder = currentTabOrder.filter(id => !tabIds.includes(id))

--- a/spa/src/hooks/useWorkspaceWindowActions.ts
+++ b/spa/src/hooks/useWorkspaceWindowActions.ts
@@ -1,0 +1,57 @@
+import { useCallback } from 'react'
+import { useTabStore } from '../stores/useTabStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+
+/**
+ * Workspace tear-off / merge handlers for Electron multi-window.
+ * Returns no-op-safe handlers — callers don't need to check electronAPI.
+ */
+export function useWorkspaceWindowActions() {
+  const workspaces = useWorkspaceStore((s) => s.workspaces)
+  const tabs = useTabStore((s) => s.tabs)
+
+  const prepareWorkspacePayload = useCallback((wsId: string) => {
+    const ws = workspaces.find(w => w.id === wsId)
+    if (!ws || ws.tabs.length === 0) return null
+    const tabData = ws.tabs.map(id => tabs[id]).filter(Boolean)
+    if (tabData.length === 0) return null
+    return { ws, payload: JSON.stringify({ workspace: ws, tabData }) }
+  }, [workspaces, tabs])
+
+  const removeWorkspaceFromStore = useCallback((tabIds: string[], wsId: string) => {
+    const { tabs: currentTabs, tabOrder: currentTabOrder } = useTabStore.getState()
+    const newTabs = { ...currentTabs }
+    const newTabOrder = currentTabOrder.filter(id => !tabIds.includes(id))
+    for (const id of tabIds) delete newTabs[id]
+    useTabStore.setState({ tabs: newTabs, tabOrder: newTabOrder, activeTabId: null })
+    useWorkspaceStore.getState().removeWorkspace(wsId)
+    const wsState = useWorkspaceStore.getState()
+    const newActiveWs = wsState.activeWorkspaceId
+      ? wsState.workspaces.find(w => w.id === wsState.activeWorkspaceId)
+      : null
+    const syncedTabId = newActiveWs?.activeTabId ?? newActiveWs?.tabs[0] ?? newTabOrder[0] ?? null
+    if (syncedTabId) useTabStore.getState().setActiveTab(syncedTabId)
+  }, [])
+
+  const handleWsTearOff = useCallback(async (wsId: string) => {
+    if (!window.electronAPI) return
+    const prepared = prepareWorkspacePayload(wsId)
+    if (!prepared) return
+    try {
+      await window.electronAPI.tearOffWorkspace(prepared.payload)
+      removeWorkspaceFromStore(prepared.ws.tabs, wsId)
+    } catch { /* IPC failed — keep data intact */ }
+  }, [prepareWorkspacePayload, removeWorkspaceFromStore])
+
+  const handleWsMergeTo = useCallback(async (wsId: string, targetWindowId: string) => {
+    if (!window.electronAPI) return
+    const prepared = prepareWorkspacePayload(wsId)
+    if (!prepared) return
+    try {
+      await window.electronAPI.mergeWorkspace(prepared.payload, targetWindowId)
+      removeWorkspaceFromStore(prepared.ws.tabs, wsId)
+    } catch { /* IPC failed — keep data intact */ }
+  }, [prepareWorkspacePayload, removeWorkspaceFromStore])
+
+  return { handleWsTearOff, handleWsMergeTo }
+}


### PR DESCRIPTION
## Summary

- 將 `App.tsx` 從 409 行降至 274 行，JSX 區塊不再包含業務邏輯
- 提取 `GlobalUndoToast` 為獨立元件
- 提取 `useElectronIpc` hook（收納 4 個 IPC effect），同時修正 #231（`onWorkspaceReceived` catch 範圍過大）
- 提取 `useWorkspaceWindowActions` hook（workspace tear-off/merge）
- 新增 `openSingletonAndSelect` 到 `useTabWorkspaceActions`，統一 4 處重複的 singleton tab 開啟模式
- 所有 inline lambda 提為具名 `useCallback`

## Test plan

- [x] 1212 tests 全通過（+3 新增 openSingletonAndSelect 測試）
- [x] ESLint clean
- [x] TypeScript build 無新增錯誤（PaneLayoutRenderer 既存 TS error 與本 PR 無關）
- [ ] Electron app 手動測試 workspace tear-off / merge
- [ ] SPA-only 模式確認 Electron IPC 無干擾

Closes #281, closes #202, closes #219, closes #225, closes #231, closes #237, closes #243, closes #261