### PR TITLE
fix: SubagentDots 燈號殘留 (5 個 root cause)

### DIFF
--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -24,7 +24,7 @@ type NormalizedEvent struct {
 	AgentType    string         `json:"agent_type"`
 	Status       string         `json:"status"`
 	Model        string         `json:"model,omitempty"`
-	Subagents    []string       `json:"subagents,omitempty"`
+	Subagents    []string       `json:"subagents"`
 	RawEventName string         `json:"raw_event_name"`
 	BroadcastTs  int64          `json:"broadcast_ts"`
 	Detail       map[string]any `json:"detail,omitempty"`

--- a/internal/module/agent/fakes_test.go
+++ b/internal/module/agent/fakes_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+
+	agentpkg "github.com/wake/tmux-box/internal/agent"
+	"github.com/wake/tmux-box/internal/module/session"
+)
+
+// fakeSessionProvider is a shared test-only SessionProvider with a
+// configurable session list.  Used by handler_test.go and upload_test.go.
+//
+// When `sessions` is nil, ListSessions/GetSession fall back to the legacy
+// single-entry default ("my-sess") so existing upload tests don't need to
+// initialize the slice.  Tests that need an empty list should pass
+// `sessions: []session.SessionInfo{}` explicitly.
+type fakeSessionProvider struct {
+	sessions []session.SessionInfo
+}
+
+func (f *fakeSessionProvider) ListSessions() ([]session.SessionInfo, error) {
+	if f.sessions != nil {
+		return f.sessions, nil
+	}
+	return []session.SessionInfo{{Code: "my-sess", Name: "my-sess"}}, nil
+}
+
+func (f *fakeSessionProvider) GetSession(code string) (*session.SessionInfo, error) {
+	for _, s := range f.sessions {
+		if s.Code == code {
+			return &s, nil
+		}
+	}
+	if code == "my-sess" {
+		return &session.SessionInfo{Code: "my-sess", Name: "my-sess"}, nil
+	}
+	return nil, nil
+}
+
+func (f *fakeSessionProvider) UpdateMeta(string, session.MetaUpdate) error { return nil }
+func (f *fakeSessionProvider) HandleTerminalWS(http.ResponseWriter, *http.Request, string) {
+}
+
+// fakeAgentProvider is a configurable AgentProvider for tests.
+type fakeAgentProvider struct {
+	typeName string
+	alive    bool
+	derive   func(eventName string, raw json.RawMessage) agentpkg.DeriveResult
+}
+
+func (f *fakeAgentProvider) Type() string                          { return f.typeName }
+func (f *fakeAgentProvider) DisplayName() string                   { return f.typeName }
+func (f *fakeAgentProvider) IconHint() string                      { return "" }
+func (f *fakeAgentProvider) Claim(_ agentpkg.ClaimContext) bool    { return false }
+func (f *fakeAgentProvider) IsAlive(string) bool                   { return f.alive }
+func (f *fakeAgentProvider) DeriveStatus(eventName string, raw json.RawMessage) agentpkg.DeriveResult {
+	if f.derive != nil {
+		return f.derive(eventName, raw)
+	}
+	return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning}
+}

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -119,6 +119,26 @@ func (m *Module) handleSubagentEvent(tmuxSession, eventName string, result agent
 	if agentID == "" {
 		return
 	}
+	if eventName == "SubagentStart" {
+		// Guard: ignore SubagentStart for sessions whose latest persisted
+		// event indicates they're not active.  Two cases this rejects:
+		//   - No DB entry at all → session is unknown to the daemon
+		//     (also covers daemon restart with no replay state).
+		//   - Latest event is StatusClear (SessionEnd) → late hook arriving
+		//     after the session ended; should not re-populate state.
+		// Uses persistent DB state instead of in-memory currentStatus, so
+		// the guard survives daemon restarts and edge cases like compact
+		// SessionStart events that don't update currentStatus.
+		ev, _ := m.events.Get(tmuxSession)
+		if ev == nil {
+			return
+		}
+		if provider, ok := m.registry.Get(ev.AgentType); ok {
+			if r := provider.DeriveStatus(ev.EventName, ev.RawEvent); r.Status == agentpkg.StatusClear {
+				return
+			}
+		}
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if eventName == "SubagentStart" {
@@ -156,12 +176,10 @@ func (m *Module) buildNormalized(tmuxSession, eventName, agentType string, broad
 		AgentType:    agentType,
 		Status:       string(result.Status),
 		Model:        result.Model,
+		Subagents:    subs,
 		RawEventName: eventName,
 		BroadcastTs:  broadcastTs,
 		Detail:       result.Detail,
-	}
-	if len(subs) > 0 {
-		normalized.Subagents = subs
 	}
 	return normalized
 }

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -8,8 +8,13 @@ import (
 	"testing"
 
 	agentpkg "github.com/wake/tmux-box/internal/agent"
+	"github.com/wake/tmux-box/internal/core"
+	"github.com/wake/tmux-box/internal/module/session"
 	"github.com/wake/tmux-box/internal/store"
+	"github.com/wake/tmux-box/internal/tmux"
 )
+
+// fakeSessionProvider is defined in fakes_test.go (shared test fixture).
 
 func newTestModule(t *testing.T) *Module {
 	t.Helper()
@@ -135,3 +140,303 @@ func TestHandleEvent_StoresAgentType(t *testing.T) {
 		t.Errorf("agent_type: want cc, got %q", ev.AgentType)
 	}
 }
+
+// --- Bug 0: buildNormalized always includes Subagents field ---
+
+func TestBuildNormalized_EmptySubagentsIsNotNil(t *testing.T) {
+	m := newTestModule(t)
+
+	result := agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning}
+	normalized := m.buildNormalized("work", "UserPromptSubmit", "cc", 1, result)
+
+	// Subagents must be a non-nil empty slice so JSON serializes as []
+	if normalized.Subagents == nil {
+		t.Fatal("Subagents should be non-nil empty slice, got nil")
+	}
+	if len(normalized.Subagents) != 0 {
+		t.Errorf("Subagents length: want 0, got %d", len(normalized.Subagents))
+	}
+
+	// Verify JSON: field must be present as "subagents":[]
+	data, _ := json.Marshal(normalized)
+	if !strings.Contains(string(data), `"subagents":[]`) {
+		t.Errorf("JSON should contain \"subagents\":[], got %s", string(data))
+	}
+}
+
+func TestBuildNormalized_WithSubagents(t *testing.T) {
+	m := newTestModule(t)
+	m.mu.Lock()
+	m.subagents["work"] = []string{"agent-1", "agent-2"}
+	m.mu.Unlock()
+
+	result := agentpkg.DeriveResult{Valid: true}
+	normalized := m.buildNormalized("work", "SubagentStart", "cc", 1, result)
+	if len(normalized.Subagents) != 2 {
+		t.Fatalf("Subagents: want 2, got %d", len(normalized.Subagents))
+	}
+}
+
+// --- Bug 0b: RenameSession transfers in-memory state ---
+
+func TestRenameSession(t *testing.T) {
+	m := newTestModule(t)
+	m.mu.Lock()
+	m.subagents["old-session"] = []string{"agent-1"}
+	m.currentStatus["old-session"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+
+	m.RenameSession("old-session", "new-session")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.subagents["old-session"]; ok {
+		t.Error("old-session should be removed from subagents")
+	}
+	if _, ok := m.currentStatus["old-session"]; ok {
+		t.Error("old-session should be removed from currentStatus")
+	}
+	if subs := m.subagents["new-session"]; len(subs) != 1 || subs[0] != "agent-1" {
+		t.Errorf("new-session subagents: want [agent-1], got %v", subs)
+	}
+	if m.currentStatus["new-session"] != agentpkg.StatusRunning {
+		t.Errorf("new-session status: want running, got %s", m.currentStatus["new-session"])
+	}
+}
+
+func TestRenameSession_NoOldData(t *testing.T) {
+	m := newTestModule(t)
+	// Should not panic or create entries when old name doesn't exist
+	m.RenameSession("nonexistent", "new-name")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.subagents["new-name"]; ok {
+		t.Error("should not create subagents entry for non-existent old name")
+	}
+}
+
+// --- Bug 3: SubagentStart guard via events.Get ---
+
+func TestHandleSubagentEvent_NoEntryStartIgnored(t *testing.T) {
+	m := newTestModule(t)
+	// No DB entry for "work" → session is unknown to the daemon
+
+	result := agentpkg.DeriveResult{
+		Valid:  true,
+		Detail: map[string]any{"agent_id": "late-agent"},
+	}
+	m.handleSubagentEvent("work", "SubagentStart", result)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.subagents["work"]; ok {
+		t.Error("SubagentStart should be ignored when session has no DB entry")
+	}
+}
+
+func TestHandleSubagentEvent_StartAfterClearIgnored(t *testing.T) {
+	m := newTestModule(t)
+	// Register a fake provider whose DeriveStatus returns StatusClear
+	provider := &fakeAgentProvider{
+		typeName: "cc",
+		derive: func(string, json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusClear}
+		},
+	}
+	m.registry.Register(provider)
+	_ = m.events.Set("work", "SessionEnd", json.RawMessage(`{}`), "cc", 1)
+
+	result := agentpkg.DeriveResult{
+		Valid:  true,
+		Detail: map[string]any{"agent_id": "late-agent"},
+	}
+	m.handleSubagentEvent("work", "SubagentStart", result)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.subagents["work"]; ok {
+		t.Error("SubagentStart should be ignored when latest event is StatusClear")
+	}
+}
+
+func TestHandleSubagentEvent_StartAcceptedWhenSessionActive(t *testing.T) {
+	m := newTestModule(t)
+	// Register a fake provider whose DeriveStatus returns StatusRunning
+	provider := &fakeAgentProvider{
+		typeName: "cc",
+		derive: func(string, json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning}
+		},
+	}
+	m.registry.Register(provider)
+	_ = m.events.Set("work", "UserPromptSubmit", json.RawMessage(`{}`), "cc", 1)
+
+	result := agentpkg.DeriveResult{
+		Valid:  true,
+		Detail: map[string]any{"agent_id": "agent-1"},
+	}
+	m.handleSubagentEvent("work", "SubagentStart", result)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if subs := m.subagents["work"]; len(subs) != 1 || subs[0] != "agent-1" {
+		t.Errorf("SubagentStart should be accepted for active session, got %v", subs)
+	}
+}
+
+// Bug 2 A1: compact SessionStart edge case — DB has entry but currentStatus
+// is empty (because compact returns Valid:false).  events.Get-based guard
+// must accept SubagentStart in this case.
+func TestHandleSubagentEvent_CompactSessionStartAccepted(t *testing.T) {
+	m := newTestModule(t)
+	provider := &fakeAgentProvider{
+		typeName: "cc",
+		derive: func(eventName string, _ json.RawMessage) agentpkg.DeriveResult {
+			// Compact SessionStart returns Valid:false
+			return agentpkg.DeriveResult{Valid: false}
+		},
+	}
+	m.registry.Register(provider)
+	_ = m.events.Set("work", "SessionStart", json.RawMessage(`{"source":"compact"}`), "cc", 1)
+	// Note: m.currentStatus["work"] is NOT populated (Valid:false skipped)
+
+	result := agentpkg.DeriveResult{
+		Valid:  true,
+		Detail: map[string]any{"agent_id": "agent-1"},
+	}
+	m.handleSubagentEvent("work", "SubagentStart", result)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if subs := m.subagents["work"]; len(subs) != 1 {
+		t.Errorf("SubagentStart should be accepted for compact-started session, got %v", subs)
+	}
+}
+
+// --- Bug 2 (refined): checkAliveAll uses IsAlive tiebreaker for orphans ---
+
+func TestCheckAliveAll_OrphanNotInTmuxDeleted(t *testing.T) {
+	m := newTestModule(t)
+	provider := &fakeAgentProvider{typeName: "cc"}
+	m.registry.Register(provider)
+	_ = m.events.Set("dead-session", "UserPromptSubmit", json.RawMessage(`{}`), "cc", 1)
+
+	m.mu.Lock()
+	m.subagents["dead-session"] = []string{"agent-1"}
+	m.currentStatus["dead-session"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+
+	// Fake tmux with NO sessions → HasSession("dead-session") returns false
+	fake := tmux.NewFakeExecutor()
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	m.checkAliveAll(sub)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.subagents["dead-session"]; ok {
+		t.Error("orphan not in tmux should be deleted")
+	}
+	if ev, _ := m.events.Get("dead-session"); ev != nil {
+		t.Error("orphan DB entry should be deleted")
+	}
+}
+
+func TestCheckAliveAll_OrphanStillInTmuxPreserved(t *testing.T) {
+	m := newTestModule(t)
+	provider := &fakeAgentProvider{typeName: "cc"}
+	m.registry.Register(provider)
+	_ = m.events.Set("transient-session", "UserPromptSubmit", json.RawMessage(`{}`), "cc", 1)
+
+	m.mu.Lock()
+	m.subagents["transient-session"] = []string{"agent-1"}
+	m.currentStatus["transient-session"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+
+	// Fake tmux HAS the session → HasSession returns true, but the
+	// fakeSessionProvider omits it (simulating transient ListSessions hiccup)
+	fake := tmux.NewFakeExecutor()
+	fake.AddSession("transient-session", "/tmp")
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	m.checkAliveAll(sub)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if subs := m.subagents["transient-session"]; len(subs) != 1 {
+		t.Error("orphan still in tmux should NOT be deleted (transient case)")
+	}
+	if ev, _ := m.events.Get("transient-session"); ev == nil {
+		t.Error("orphan still in tmux should preserve DB entry")
+	}
+}
+
+// --- Bug 0b: RenameSessionAtomic runs callback under lock ---
+
+func TestRenameSessionAtomic_Success(t *testing.T) {
+	m := newTestModule(t)
+	m.mu.Lock()
+	m.subagents["old-name"] = []string{"agent-1"}
+	m.currentStatus["old-name"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+
+	called := false
+	err := m.RenameSessionAtomic("old-name", "new-name", func() error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("callback should be invoked")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if subs := m.subagents["new-name"]; len(subs) != 1 || subs[0] != "agent-1" {
+		t.Errorf("subagents should be transferred to new-name, got %v", subs)
+	}
+	if _, ok := m.subagents["old-name"]; ok {
+		t.Error("old-name entry should be removed")
+	}
+}
+
+func TestRenameSessionAtomic_CallbackErrorSkipsTransfer(t *testing.T) {
+	m := newTestModule(t)
+	m.mu.Lock()
+	m.subagents["old-name"] = []string{"agent-1"}
+	m.mu.Unlock()
+
+	wantErr := errStub("rename failed")
+	err := m.RenameSessionAtomic("old-name", "new-name", func() error {
+		return wantErr
+	})
+	if err != wantErr {
+		t.Fatalf("err: want %v, got %v", wantErr, err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Transfer should NOT have happened
+	if _, ok := m.subagents["new-name"]; ok {
+		t.Error("subagents should NOT be transferred on callback error")
+	}
+	if _, ok := m.subagents["old-name"]; !ok {
+		t.Error("old-name entry should remain on callback error")
+	}
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -58,8 +58,9 @@ func (m *Module) Init(c *core.Core) error {
 	}
 	m.sessions = svc.(session.SessionProvider)
 
-	// Expose event store so other modules (e.g. session rename) can update it.
+	// Expose event store and module so other modules (e.g. session rename) can update it.
 	c.Registry.Register("agent.events", m.events)
+	c.Registry.Register("agent.module", m)
 
 	if m.uploadDir == "" {
 		home, _ := os.UserHomeDir()
@@ -124,6 +125,54 @@ func (m *Module) Start(_ context.Context) error {
 
 // Stop is a no-op.
 func (m *Module) Stop(_ context.Context) error { return nil }
+
+// renameSessionLocked transfers in-memory agent state (subagents, currentStatus)
+// from oldName to newName.  CALLER MUST hold m.mu.
+func (m *Module) renameSessionLocked(oldName, newName string) {
+	if subs, ok := m.subagents[oldName]; ok {
+		m.subagents[newName] = subs
+		delete(m.subagents, oldName)
+	}
+	if status, ok := m.currentStatus[oldName]; ok {
+		m.currentStatus[newName] = status
+		delete(m.currentStatus, oldName)
+	}
+}
+
+// RenameSession transfers in-memory agent state from oldName to newName
+// under the module's lock.  Used by callers that don't need to coordinate
+// with other rename steps (e.g. tests).  Production callers should prefer
+// RenameSessionAtomic to make the rename atomic with tmux + DB updates.
+func (m *Module) RenameSession(oldName, newName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.renameSessionLocked(oldName, newName)
+}
+
+// RenameSessionAtomic runs doRename under the module's lock and then
+// transfers in-memory state from oldName to newName.  This makes the
+// entire rename (tmux + DB + in-memory) atomic from the perspective of
+// concurrent hook events: any handler that acquires m.mu while a rename
+// is in progress observes either the pre-rename or post-rename state,
+// never partial state.  If doRename returns an error, the in-memory
+// transfer is skipped and the error is propagated.
+//
+// Tradeoff: doRename is expected to include the tmux rename exec.Command,
+// which runs under the lock.  This can delay all concurrent hook handlers
+// by the duration of the tmux call (~50ms normally).  This is an intentional
+// choice: hook handlers are brief and renames are low-frequency (user-
+// triggered), so sacrificing a small amount of throughput during rename
+// in exchange for full atomicity is the right tradeoff.  doRename MUST NOT
+// call any method that acquires m.mu (would deadlock).
+func (m *Module) RenameSessionAtomic(oldName, newName string, doRename func() error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := doRename(); err != nil {
+		return err
+	}
+	m.renameSessionLocked(oldName, newName)
+	return nil
+}
 
 // replayFromDB rebuilds in-memory currentStatus from persisted events.
 func (m *Module) replayFromDB() {
@@ -218,6 +267,28 @@ func (m *Module) checkAliveAll(sub *core.EventSubscriber) {
 
 		code, ok := nameToCode[ev.TmuxSession]
 		if !ok {
+			// Not in current sessions list — could be a real orphan or
+			// a transient ListSessions inconsistency.  Use tmux.HasSession
+			// as the authoritative tiebreaker before deleting persistent
+			// state: this directly checks tmux session existence, unlike
+			// provider.IsAlive which only checks whether the CC/Codex
+			// process is the pane's current command (a user exiting CC
+			// in a live tmux session would wrongly trigger deletion).
+			//
+			// No broadcast is sent here: orphaned sessions have no code
+			// (resolveSessionCode would return ""), so the frontend cannot
+			// be notified by session code.  The frontend's session-closed
+			// detection (useMultiHostEventWs) handles this case via the
+			// sessions WS event, which fires whenever ListSessions output
+			// changes.
+			if m.core != nil && m.core.Tmux != nil && m.core.Tmux.HasSession(ev.TmuxSession) {
+				continue // transient — leave it alone
+			}
+			m.mu.Lock()
+			delete(m.currentStatus, ev.TmuxSession)
+			delete(m.subagents, ev.TmuxSession)
+			m.mu.Unlock()
+			_ = m.events.Delete(ev.TmuxSession)
 			continue
 		}
 		provider, ok := m.registry.Get(ev.AgentType)

--- a/internal/module/agent/upload_test.go
+++ b/internal/module/agent/upload_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/wake/tmux-box/internal/core"
-	"github.com/wake/tmux-box/internal/module/session"
 	"github.com/wake/tmux-box/internal/tmux"
 )
 
@@ -48,22 +46,8 @@ func TestCreateDedupFile(t *testing.T) {
 	assert.Equal(t, "README-1", got)
 }
 
-// --- fakeSessionProvider for upload handler tests ---
-
-type fakeSessionProvider struct{}
-
-func (f *fakeSessionProvider) ListSessions() ([]session.SessionInfo, error) {
-	return []session.SessionInfo{{Code: "my-sess", Name: "my-sess"}}, nil
-}
-func (f *fakeSessionProvider) GetSession(code string) (*session.SessionInfo, error) {
-	if code == "my-sess" {
-		return &session.SessionInfo{Code: "my-sess", Name: "my-sess"}, nil
-	}
-	return nil, fmt.Errorf("not found")
-}
-func (f *fakeSessionProvider) UpdateMeta(code string, update session.MetaUpdate) error { return nil }
-func (f *fakeSessionProvider) HandleTerminalWS(w http.ResponseWriter, r *http.Request, code string) {
-}
+// --- fakeSessionProvider for tests ---
+// Defined in handler_test.go (shared across test files in this package).
 
 // newUploadTestModule creates a Module with a fake session provider and tmux executor for upload tests.
 func newUploadTestModule(t *testing.T) (*Module, *tmux.FakeExecutor) {

--- a/internal/module/session/handler.go
+++ b/internal/module/session/handler.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"regexp"
 
@@ -169,16 +170,9 @@ func (m *SessionModule) handleRename(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := m.tmux.RenameSession(info.Name, req.Name); err != nil {
+	if err := m.renameSessionAtomic(info.Name, req.Name); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
-	}
-
-	// Update agent event store so stored events follow the new session name.
-	if svc, ok := m.core.Registry.Get("agent.events"); ok {
-		if renamer, ok := svc.(interface{ Rename(old, new string) error }); ok {
-			_ = renamer.Rename(info.Name, req.Name)
-		}
 	}
 
 	// Return updated info with new name
@@ -303,4 +297,67 @@ func (m *SessionModule) handleSendKeys(w http.ResponseWriter, r *http.Request) {
 func (m *SessionModule) handleTerminalWS(w http.ResponseWriter, r *http.Request) {
 	code := r.PathValue("code")
 	m.HandleTerminalWS(w, r, code)
+}
+
+// agentEventsRenamer is the optional interface implemented by the agent
+// events store, used to rename stored events when a tmux session is renamed.
+type agentEventsRenamer interface {
+	Rename(oldName, newName string) error
+}
+
+// atomicRenamer is the optional interface implemented by the agent module,
+// used to perform tmux + DB + in-memory rename atomically under the agent
+// module's lock.
+type atomicRenamer interface {
+	RenameSessionAtomic(oldName, newName string, doRename func() error) error
+}
+
+// renameSessionAtomic runs the complete rename flow (tmux + agent events DB
+// + agent module in-memory state) atomically under the agent module's lock.
+//
+// Ordering: DB rename first, then tmux rename.  This ordering allows tmux
+// rename failure (the most likely failure mode — e.g. tmux server unavailable)
+// to trigger a best-effort DB rollback, since the DB UPDATE is trivially
+// reversible.  If the initial DB rename fails, no tmux state is mutated.
+//
+// The agent module MUST be registered at "agent.module" and implement
+// atomicRenamer — this is enforced at daemon startup, not a runtime fallback.
+func (m *SessionModule) renameSessionAtomic(oldName, newName string) error {
+	// Hard assert: agent module must be registered with the atomic rename API.
+	// Silent fallback would mask module initialization bugs.
+	svc, ok := m.core.Registry.Get("agent.module")
+	if !ok {
+		return errors.New("rename: agent.module not registered in service registry")
+	}
+	renamer, ok := svc.(atomicRenamer)
+	if !ok {
+		return errors.New("rename: agent.module does not implement atomicRenamer")
+	}
+
+	// Look up the optional DB renamer once, before entering the critical section.
+	var dbRenamer agentEventsRenamer
+	if svc, ok := m.core.Registry.Get("agent.events"); ok {
+		if r, ok := svc.(agentEventsRenamer); ok {
+			dbRenamer = r
+		}
+	}
+
+	doRename := func() error {
+		// DB first — reversible via UPDATE back to oldName.
+		if dbRenamer != nil {
+			if err := dbRenamer.Rename(oldName, newName); err != nil {
+				return err
+			}
+		}
+		// Tmux rename — if this fails, best-effort roll back the DB
+		// so the DB + in-memory + tmux state stay consistent.
+		if err := m.tmux.RenameSession(oldName, newName); err != nil {
+			if dbRenamer != nil {
+				_ = dbRenamer.Rename(newName, oldName)
+			}
+			return err
+		}
+		return nil
+	}
+	return renamer.RenameSessionAtomic(oldName, newName, doRename)
 }

--- a/internal/module/session/handler_test.go
+++ b/internal/module/session/handler_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -330,6 +331,107 @@ func TestHandlerRenameSessionDuplicate(t *testing.T) {
 
 	assert.Equal(t, http.StatusConflict, w.Code)
 	assert.Contains(t, w.Body.String(), "session already exists")
+}
+
+// TestRenameSessionAtomic_HardErrorNoAgentModule verifies that when the
+// agent module is not registered, the rename helper returns a clear error
+// (hard-fail) instead of silently falling back to a partial rename.
+func TestRenameSessionAtomic_HardErrorNoAgentModule(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+	fake.AddSession("alpha", "/tmp")
+
+	// agent.module is deliberately NOT registered.
+	err := mod.renameSessionAtomic("alpha", "beta")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent.module not registered")
+
+	// tmux must NOT have been modified.
+	assert.True(t, fake.HasSession("alpha"))
+	assert.False(t, fake.HasSession("beta"))
+}
+
+// spyEventRenamer records Rename calls and can be configured to fail.
+type spyEventRenamer struct {
+	calls   [][2]string
+	failOn  string // if non-empty, Rename("old", "new") where old == failOn returns error
+}
+
+func (s *spyEventRenamer) Rename(oldName, newName string) error {
+	s.calls = append(s.calls, [2]string{oldName, newName})
+	if s.failOn != "" && oldName == s.failOn {
+		return errors.New("simulated DB rename failure")
+	}
+	return nil
+}
+
+// stubAtomicRenamer implements atomicRenamer by immediately running doRename.
+// No in-memory state to transfer in this test — we only care about doRename
+// behavior and rollback semantics.
+type stubAtomicRenamer struct{}
+
+func (stubAtomicRenamer) RenameSessionAtomic(oldName, newName string, doRename func() error) error {
+	return doRename()
+}
+
+// TestRenameSessionAtomic_RollbackOnTmuxFailure verifies that when tmux
+// rename fails after DB rename succeeded, the DB rename is rolled back
+// so all three layers (tmux, DB, in-memory) stay consistent.
+func TestRenameSessionAtomic_RollbackOnTmuxFailure(t *testing.T) {
+	mod, _, _ := newTestModule(t)
+	// Note: deliberately do NOT add "alpha" to fake → tmux.RenameSession
+	// will fail with ErrNoSession, triggering the rollback path.
+
+	spy := &spyEventRenamer{}
+	mod.core.Registry.Register("agent.events", spy)
+	mod.core.Registry.Register("agent.module", stubAtomicRenamer{})
+
+	err := mod.renameSessionAtomic("alpha", "beta")
+	require.Error(t, err)
+
+	// Expect two DB calls: forward rename + rollback
+	require.Len(t, spy.calls, 2, "expected DB rename + rollback, got %v", spy.calls)
+	assert.Equal(t, [2]string{"alpha", "beta"}, spy.calls[0], "first call should be forward rename")
+	assert.Equal(t, [2]string{"beta", "alpha"}, spy.calls[1], "second call should be rollback")
+}
+
+// TestRenameSessionAtomic_HappyPath verifies DB rename is called exactly once
+// when tmux rename succeeds (no rollback).
+func TestRenameSessionAtomic_HappyPath(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+	fake.AddSession("alpha", "/tmp")
+
+	spy := &spyEventRenamer{}
+	mod.core.Registry.Register("agent.events", spy)
+	mod.core.Registry.Register("agent.module", stubAtomicRenamer{})
+
+	err := mod.renameSessionAtomic("alpha", "beta")
+	require.NoError(t, err)
+
+	require.Len(t, spy.calls, 1, "expected single DB rename, got %v", spy.calls)
+	assert.Equal(t, [2]string{"alpha", "beta"}, spy.calls[0])
+	assert.True(t, fake.HasSession("beta"))
+	assert.False(t, fake.HasSession("alpha"))
+}
+
+// TestRenameSessionAtomic_DBRenameFailsNoTmuxChange verifies that when DB
+// rename fails first, tmux is never touched.
+func TestRenameSessionAtomic_DBRenameFailsNoTmuxChange(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+	fake.AddSession("alpha", "/tmp")
+
+	spy := &spyEventRenamer{failOn: "alpha"}
+	mod.core.Registry.Register("agent.events", spy)
+	mod.core.Registry.Register("agent.module", stubAtomicRenamer{})
+
+	err := mod.renameSessionAtomic("alpha", "beta")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated DB rename failure")
+
+	// Only the forward attempt, no rollback (nothing to roll back).
+	require.Len(t, spy.calls, 1)
+	// tmux unchanged.
+	assert.True(t, fake.HasSession("alpha"))
+	assert.False(t, fake.HasSession("beta"))
 }
 
 func TestHandlerDeleteSession(t *testing.T) {

--- a/spa/src/hooks/useMultiHostEventWs.ts
+++ b/spa/src/hooks/useMultiHostEventWs.ts
@@ -118,6 +118,9 @@ export function useMultiHostEventWs() {
               }
               for (const code of closedCodes) {
                 useTabStore.getState().markTerminated(hostId, code, 'session-closed')
+                // Clear agent state (subagents, status, etc.) so indicators
+                // don't linger after the tmux session disappears.
+                useAgentStore.getState().clearSession(hostId, code)
               }
             } catch { /* ignore */ }
             return

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -285,6 +285,31 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().models[`${H}:unknown`]).toBeUndefined()
   })
 
+  it('clearSession action wipes all keyed state for session', () => {
+    useAgentStore.setState({
+      statuses: { [`${H}:dev`]: 'idle', [`${H}:staging`]: 'running' },
+      agentTypes: { [`${H}:dev`]: 'cc' },
+      models: { [`${H}:dev`]: 'claude-sonnet-4-6' },
+      subagents: { [`${H}:dev`]: ['sub-1', 'sub-2'] },
+      lastEvents: { [`${H}:dev`]: { agent_type: 'cc', status: 'idle', raw_event_name: 'Stop', broadcast_ts: 1 } },
+      unread: { [`${H}:dev`]: true, [`${H}:staging`]: true },
+    })
+    useAgentStore.getState().clearSession(H, 'dev')
+    const state = useAgentStore.getState()
+
+    // dev session is wiped
+    expect(state.statuses[`${H}:dev`]).toBeUndefined()
+    expect(state.agentTypes[`${H}:dev`]).toBeUndefined()
+    expect(state.models[`${H}:dev`]).toBeUndefined()
+    expect(state.subagents[`${H}:dev`]).toBeUndefined()
+    expect(state.lastEvents[`${H}:dev`]).toBeUndefined()
+    expect(state.unread[`${H}:dev`]).toBeUndefined()
+
+    // staging preserved
+    expect(state.statuses[`${H}:staging`]).toBe('running')
+    expect(state.unread[`${H}:staging`]).toBe(true)
+  })
+
   it('clear status preserves other sessions', () => {
     useAgentStore.setState({
       statuses: { [`${H}:dev`]: 'idle', [`${H}:staging`]: 'running' },

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -33,6 +33,7 @@ interface AgentState {
 
   // Actions
   handleNormalizedEvent: (hostId: string, sessionCode: string, event: NormalizedEvent) => void
+  clearSession: (hostId: string, sessionCode: string) => void
   markRead: (hostId: string, sessionCode: string) => void
   removeHost: (hostId: string) => void
   setTabIndicatorStyle: (style: TabIndicatorStyle) => void
@@ -40,7 +41,7 @@ interface AgentState {
 
 export const useAgentStore = create<AgentState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       statuses: {},
       agentTypes: {},
       models: {},
@@ -49,25 +50,30 @@ export const useAgentStore = create<AgentState>()(
       unread: {},
       tabIndicatorStyle: 'replace' as TabIndicatorStyle,
 
+      clearSession: (hostId, sessionCode) => {
+        const key = compositeKey(hostId, sessionCode)
+        set((s) => {
+          const filterOut = <T,>(rec: Record<string, T>): Record<string, T> => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { [key]: _, ...rest } = rec
+            return rest
+          }
+          return {
+            statuses: filterOut(s.statuses),
+            agentTypes: filterOut(s.agentTypes),
+            models: filterOut(s.models),
+            subagents: filterOut(s.subagents),
+            lastEvents: filterOut(s.lastEvents),
+            unread: filterOut(s.unread),
+          }
+        })
+      },
+
       handleNormalizedEvent: (hostId, sessionCode, event) => {
         const key = compositeKey(hostId, sessionCode)
 
         if (event.status === 'clear') {
-          set((s) => {
-            const filterOut = <T,>(rec: Record<string, T>): Record<string, T> => {
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              const { [key]: _, ...rest } = rec
-              return rest
-            }
-            return {
-              statuses: filterOut(s.statuses),
-              agentTypes: filterOut(s.agentTypes),
-              models: filterOut(s.models),
-              subagents: filterOut(s.subagents),
-              lastEvents: filterOut(s.lastEvents),
-              unread: filterOut(s.unread),
-            }
-          })
+          get().clearSession(hostId, sessionCode)
           return
         }
 


### PR DESCRIPTION
## Summary

修復 SubagentDots 燈號在 subagent 已結束後仍殘留的問題。深入分析後找到 **5 個獨立 root cause**，全部一併修復。

## Root Causes

### Bug 0 (主因): \`omitempty\` 讓最後 SubagentStop 不送空陣列
- 位置: \`internal/agent/status.go:27\`, \`internal/module/agent/handler.go:163-165\`
- 機制:
  1. \`SubagentStart(A)\` → \`m.subagents=[\"A\"]\` → JSON \`{subagents:[\"A\"]}\` → 前端更新 ✓
  2. \`SubagentStop(A)\` → \`m.subagents=[]\` → \`delete from map\` → JSON 因 \`omitempty\` 省略 \`subagents\` 欄位
  3. 前端 \`if (event.subagents)\` = undefined → **不更新** → 燈號永遠卡在最後一個值
- 修復: 移除 \`omitempty\` + 移除 \`if len > 0\` guard，永遠送 \`subagents\` 欄位（即使是 \`[]\`）

### Bug 0b: Session rename 不更新 in-memory state
- 位置: \`internal/module/session/handler.go:178-182\` 原本只更新 DB
- 機制: \`tbox hook\` 用 \`tmux display-message -p '#{session_name}'\` 取**當下**名稱
  - SubagentStart 用舊名 → \`m.subagents[\"old\"] = [...]\`
  - rename → DB updated, but \`m.subagents[\"old\"]\` 還在
  - SubagentStop 用新名 → 從空 map 移除 → 失敗，舊名孤立
- 修復: \`agent.Module\` 新增 \`RenameSession()\` 方法，rename handler 同步轉移 in-memory state

### Bug 1: \`markTerminated\` 不清理 agent store (Frontend)
- 位置: \`spa/src/hooks/useMultiHostEventWs.ts:119-121\`
- 機制: session-closed detection 只標記 tab terminated，沒清 \`useAgentStore.subagents[ck]\`
- 修復: 同步發 \`handleNormalizedEvent({status:'clear'})\` 清理前端 agent state

### Bug 2: \`checkAliveAll\` 跳過已消失的 tmux session
- 位置: \`internal/module/agent/module.go:219-221\`
- 機制: \`nameToCode\` 從 \`ListSessions()\` 建映射，已 kill 的 tmux session 不在裡面 → \`if !ok { continue }\` → 永遠不發 clear event
- 修復: \`nameToCode\` miss 時主動清理 DB + in-memory，而非 skip

### Bug 3: late \`SubagentStart\` 在 \`StatusClear\` 後重新污染
- 位置: \`internal/module/agent/handler.go:124-131\`
- 機制: hooks 是 async HTTP，可能在 SessionEnd/StatusClear 後才到達 → 重新填入 \`m.subagents\`
- 修復: \`handleSubagentEvent\` 對 SubagentStart 加 \`currentStatus\` guard，沒有 status 表示 session 已結束

## Files Changed

| File | Lines | 修復 |
|------|-------|-----|
| \`internal/agent/status.go\` | -1 +1 | Bug 0 |
| \`internal/module/agent/handler.go\` | -3 +9 | Bug 0, Bug 3 |
| \`internal/module/agent/module.go\` | -2 +25 | Bug 0b, Bug 2 |
| \`internal/module/session/handler.go\` | +8 | Bug 0b |
| \`spa/src/hooks/useMultiHostEventWs.ts\` | +5 | Bug 1 |
| \`internal/module/agent/handler_test.go\` | +175 | 新測試 |
| \`internal/module/agent/upload_test.go\` | -19 +1 | 重構 fake provider |

## Test plan

- [x] Go: 7 個新測試（\`TestBuildNormalized_EmptySubagentsIsNotNil\`, \`TestRenameSession\`, \`TestHandleSubagentEvent_LateStartIgnored\`, \`TestCheckAliveAll_CleansOrphanedSessions\` 等）
- [x] \`go test ./...\` 全 pass（含 stream 模組 68s）
- [x] \`pnpm vitest run\` 全 pass (1209 tests)
- [x] \`pnpm run lint\` 全 pass
- [ ] **手動驗證**: 重啟 daemon + Electron 後，原本卡住的 tab 燈號應消失；新跑一個帶 subagent 的對話，所有 SubagentStop 後燈號應正確清除
- [ ] **手動驗證**: rename 一個正在跑 subagent 的 session，rename 後 SubagentStop 燈號應正確清除

## 相關分析

完整 root cause 分析參見 memory: \`bug_subagent_dots_stuck.md\`