### PR TITLE
fix: lock CfgMu when reading sizing mode in HandleTerminalWS (#26)

### DIFF
--- a/docs/superpowers/plans/2026-04-12-issue-26-cfgmu-race-fix.md
+++ b/docs/superpowers/plans/2026-04-12-issue-26-cfgmu-race-fix.md
@@ -1,0 +1,102 @@
+# Plan: Issue #26 — handleTerminal cfgMu race 修復
+
+- **Spec**: `docs/superpowers/specs/2026-04-12-issue-26-cfgmu-race-fix.md`
+- **Issue**: #26
+- **Branch**: `worktree-issue-26-cfgmu-race`
+- **方法**: TDD（紅 → 綠 → refactor）
+
+## 任務分解
+
+### Step 1: 撰寫失敗的 race regression 測試 (Red)
+
+**檔案**: `internal/module/session/service_test.go`
+
+**動作**:
+1. 新增測試 `TestHandleTerminalWS_NoConfigRace`，依 spec §5.2 骨架
+2. 確認 import 包含 `httptest`, `sync`, `core`, `config`, `tmux`, `store`
+3. 執行 `go test -race ./internal/module/session/ -run TestHandleTerminalWS_NoConfigRace`
+4. **預期**: race detector 命中 (DATA RACE on `Cfg.Terminal.SizingMode`) → 測試 fail
+5. 若不命中，調整 reader/writer goroutine 數量或 inject `runtime.Gosched()` 提高碰撞機率
+
+**驗證標準**:
+- 測試在未修復的程式碼上**必須 fail**（race detector 命中）
+- 若直接 pass，代表沒測到實際 race，需重新檢查觸發路徑
+
+### Step 2: 套用修復 (Green)
+
+**檔案**: `internal/module/session/service.go`
+
+**動作**: 修改 `HandleTerminalWS` 第 134-138 行：
+
+```diff
+- // Determine sizing mode from config (default to "auto" if no config).
+- sizingMode := "auto"
+- if m.core != nil && m.core.Cfg != nil {
+-     sizingMode = m.core.Cfg.Terminal.GetSizingMode()
+- }
++ // Snapshot sizing mode under read lock to avoid race with handlePutConfig
++ // (config.go writes Terminal.SizingMode under CfgMu.Lock).
++ sizingMode := "auto"
++ if m.core != nil && m.core.Cfg != nil {
++     m.core.CfgMu.RLock()
++     sizingMode = m.core.Cfg.Terminal.GetSizingMode()
++     m.core.CfgMu.RUnlock()
++ }
+```
+
+**驗證標準**:
+- `go test -race ./internal/module/session/ -run TestHandleTerminalWS_NoConfigRace` **通過**
+- `go test ./internal/module/session/...` 全綠
+- `go test -race ./internal/module/session/...` 全綠
+
+### Step 3: 全套件 race + lint 驗證
+
+**動作**:
+1. `go build ./...` — 編譯通過
+2. `go vet ./...` — 無警告
+3. `gofmt -l internal/module/session/` — 無輸出
+4. `go test -race ./...` — 全綠
+
+**驗證標準**: 上述命令全部通過。任一 fail 必須回頭修。
+
+### Step 4: 提交
+
+- Commit subject: `fix: lock CfgMu when reading sizing mode in HandleTerminalWS`
+- Body 提到 `Closes #26`
+- 兩個檔案：`service.go` + `service_test.go`
+
+### Step 5: PR + 兩輪 review
+
+- 走標準 PR 流程
+- 第一輪：`code-review:code-review` skill
+- 第二輪：3 個 parallel agent（攻擊 / 防守 / 檔案大小）
+- 修高信心 / 低複雜度 / 測試相關問題
+
+### Step 6: Merge + bump
+
+- Merge PR
+- Update `VERSION` + `CHANGELOG.md`
+- Push
+
+## 風險與 Mitigation
+
+| 風險 | Mitigation |
+|------|------------|
+| Race test 在 CI 不穩定 | 增加 reader/writer 迭代次數確保 race 視窗夠大；race detector 對碰撞很敏感 |
+| `httptest.NewRecorder` 與 ws upgrade 互動產生 panic | 已驗證：upgrader 在非 Hijacker 上回 error，不 panic（relay.go:42-45） |
+| Cfg = nil 路徑被測試 dirty 觸發 | nil guard 保留，無破壞風險 |
+| 測試 leak goroutine | writer goroutine 用 `stop` channel 收斂，readers 都 wait 完才 close stop |
+
+## 不做的事 (Out of Scope)
+
+- 不改寫 writer 端 (`config_handler.go`)
+- 不抽 `snapshotSizingMode()` helper
+- 不改 `agent/module.go` Init() 那段（單執行緒初始化）
+- 不引入 atomic.Pointer
+- 不動 `BuildTerminalRelay` / `buildTerminalRelayArgs`（已純函式化）
+
+## 預估改動規模
+
+- `service.go`: +5 / -1 行
+- `service_test.go`: +60 行（含 imports）
+- 總計：~65 行

--- a/docs/superpowers/specs/2026-04-12-issue-26-cfgmu-race-fix.md
+++ b/docs/superpowers/specs/2026-04-12-issue-26-cfgmu-race-fix.md
@@ -1,0 +1,206 @@
+# Spec: Issue #26 — handleTerminal Cfg 讀取 race 修復
+
+- **Issue**: [#26 fix: handleTerminal reads s.cfg without cfgMu lock](https://github.com/wake/tmux-box/issues/26)
+- **日期**: 2026-04-12
+- **範圍**: 單一檔案 (`internal/module/session/service.go`) + 對應測試
+
+## 1. 背景
+
+Issue 原文指向已不存在的 `internal/server/server.go`。經過 Phase 1.6a 重構後，相關程式碼搬到 `internal/module/session/`：
+
+- `handleTerminal` → `HandleTerminalWS` (`service.go:123`)
+- `BuildTerminalRelay` → `buildTerminalRelayArgs` (`service.go:182`，純函式，無 race)
+
+但 race condition 仍然存在：`HandleTerminalWS` 在 `service.go:137` 讀取 `m.core.Cfg.Terminal.GetSizingMode()` 時**沒有取 `core.CfgMu.RLock()`**，而寫入端 `handlePutConfig` 在 `internal/core/config_handler.go:79` 仍然在 `CfgMu.Lock()` 下修改 `c.Cfg.Terminal.SizingMode`。
+
+並發場景：使用者打開 terminal WS 連線的同時，另一個 client 透過 `PUT /api/config` 修改 `terminal.sizing_mode` → data race。
+
+## 2. 問題定義
+
+### 2.1 受影響的程式碼
+
+```go
+// internal/module/session/service.go:134-138
+sizingMode := "auto"
+if m.core != nil && m.core.Cfg != nil {
+    sizingMode = m.core.Cfg.Terminal.GetSizingMode()  // ← 無鎖讀取
+}
+```
+
+### 2.2 寫入端 (對照組，已正確上鎖)
+
+```go
+// internal/core/config_handler.go:47, 78-80
+c.CfgMu.Lock()
+...
+if req.Terminal != nil && req.Terminal.SizingMode != "" {
+    c.Cfg.Terminal.SizingMode = req.Terminal.SizingMode  // ← 持寫鎖
+}
+```
+
+### 2.3 參考的正確 pattern
+
+```go
+// internal/module/stream/handler.go:177-182
+m.core.CfgMu.RLock()
+presets := m.core.Cfg.Stream.Presets
+token := m.core.Cfg.Token
+port := m.core.Cfg.Port
+bind := m.core.Cfg.Bind
+m.core.CfgMu.RUnlock()
+```
+
+## 3. 修復方案
+
+### 3.1 程式碼變更
+
+將 `HandleTerminalWS` 中的 config 讀取改為 snapshot pattern，仿照 stream/handler.go：
+
+```go
+// HandleTerminalWS attaches a WebSocket connection to the tmux session PTY relay.
+func (m *SessionModule) HandleTerminalWS(w http.ResponseWriter, r *http.Request, code string) {
+    info, err := m.GetSession(code)
+    if err != nil { ... }
+    if info == nil { ... }
+
+    // Snapshot sizing mode under read lock to avoid race with handlePutConfig.
+    sizingMode := "auto"
+    if m.core != nil && m.core.Cfg != nil {
+        m.core.CfgMu.RLock()
+        sizingMode = m.core.Cfg.Terminal.GetSizingMode()
+        m.core.CfgMu.RUnlock()
+    }
+
+    // ... rest unchanged
+}
+```
+
+### 3.2 為什麼是 snapshot
+
+`GetSizingMode()` 回傳 string（value type），複製即完成隔離；之後的 switch 邏輯不再需要持鎖。最小臨界區、無 lock 升級風險。
+
+### 3.3 nil 防護維持
+
+外層 `m.core != nil && m.core.Cfg != nil` 守衛保留。生產路徑透過 `Init()` 一定會把 `m.core = c` 設好且 `c.Cfg` 由 `config.Load` 載入（缺檔回 default），不會 nil；nil 保護是專為測試直接 `&SessionModule{}` 構造的情境（例如 `hooks_test.go`）所留。
+
+## 4. 不變條件 (Invariants)
+
+- **I1**: 任何讀取 `c.Cfg.*` 欄位的程式碼必須持有 `CfgMu` 的 read lock 或 write lock。本修復強化此 invariant。
+- **I2 (reader-only)**: Reader 端的 `CfgMu` 臨界區應盡可能短 — snapshot 後立即解鎖，避免延長 writer 等待。本修復符合。
+  - 註：writer 端 (`handlePutConfig`) 目前仍在持寫鎖期間呼叫 `config.WriteFile`（disk IO），這是 pre-existing 設計，out of scope。
+- **I3**: 修復後 `go test -race ./internal/module/session/...` 必須通過。
+
+## 5. 測試策略
+
+### 5.1 Race 回歸測試（直接打 `HandleTerminalWS`）
+
+新增測試 `TestHandleTerminalWS_NoConfigRace` (`service_test.go`)，**直接呼叫 `HandleTerminalWS` 而非抽 helper** — 否則 race regression 測到的是 helper 而不是真正的 bug 點。
+
+關鍵觀察：racy 讀取（`m.core.Cfg.Terminal.GetSizingMode()`）發生在 `relay.HandleWebSocket(w, r)` 之前。所以即使 WS upgrade 失敗、即使 fake tmux 立即 exit，racy 讀取也已經執行 — race detector 仍能命中。
+
+### 5.2 測試骨架
+
+利用既有 `newTestModule(t)` helper（或仿照其建構新 helper 帶 Cfg）。需要 `core.New(CoreDeps{Config: ...})` 才能讓 `m.core.Cfg` 非 nil（既有 helper 沒帶 Config，新測試需自建一份）。
+
+```go
+func TestHandleTerminalWS_NoConfigRace(t *testing.T) {
+    // 自建 Core，確保 Cfg 非 nil
+    meta, err := store.OpenMeta(":memory:")
+    require.NoError(t, err)
+    t.Cleanup(func() { meta.Close() })
+
+    fake := tmux.NewFakeExecutor()
+    fake.AddSession("test-session", "/tmp")  // 自動分配 $0
+
+    mod := NewSessionModule(meta)
+    c := core.New(core.CoreDeps{
+        Config:   &config.Config{Terminal: config.TerminalConfig{SizingMode: "auto"}},
+        Tmux:     fake,
+        Registry: core.NewServiceRegistry(),
+    })
+    require.NoError(t, mod.Init(c))
+
+    code, err := EncodeSessionID("$0")
+    require.NoError(t, err)
+
+    stop := make(chan struct{})
+
+    // Writer goroutine: 持續切換 SizingMode
+    var writerWg sync.WaitGroup
+    writerWg.Add(1)
+    go func() {
+        defer writerWg.Done()
+        modes := []string{"auto", "terminal-first", "minimal-first"}
+        for i := 0; ; i++ {
+            select {
+            case <-stop:
+                return
+            default:
+            }
+            c.CfgMu.Lock()
+            c.Cfg.Terminal.SizingMode = modes[i%len(modes)]
+            c.CfgMu.Unlock()
+        }
+    }()
+
+    // Reader goroutines: 並發呼叫 HandleTerminalWS
+    var readerWg sync.WaitGroup
+    for i := 0; i < 50; i++ {
+        readerWg.Add(1)
+        go func() {
+            defer readerWg.Done()
+            req := httptest.NewRequest("GET", "/ws/terminal/"+code, nil)
+            rec := httptest.NewRecorder()
+            // WS upgrade 會失敗（rec 非 Hijacker），但 racy 讀取早已執行
+            mod.HandleTerminalWS(rec, req, code)
+        }()
+    }
+
+    readerWg.Wait()
+    close(stop)
+    writerWg.Wait()
+}
+```
+
+執行：`go test -race ./internal/module/session/ -run TestHandleTerminalWS_NoConfigRace`。
+- 修復前：race detector 命中
+- 修復後：通過
+
+### 5.3 既有測試
+
+`TestBuildTerminalRelayArgs_*` (service_test.go:9-19) 純函式測試不受影響，繼續執行確保未破壞。
+
+`module_test.go` 中的 `newTestModule` 已示範 fake executor + 測試 module 的構造，可參考重用。
+
+### 5.4 注意
+
+- 若 `httptest.NewRecorder` 不支援的 hijack 路徑導致過早 panic，可改用 `httptest.NewServer` + real `http.Client`，並讓 client 不升級 WS（直接 GET）— racy 讀取仍會在 server handler 被觸發。
+- 不需也不應抽出 `snapshotSizingMode()` helper：那只會測到 helper 自己持鎖，無法保證 `HandleTerminalWS` 真的呼叫了它。
+
+### 5.3 不變的測試
+
+`TestBuildTerminalRelayArgs_*` 已存在（service_test.go:9-19）— 純函式測試不受影響，只需確認仍通過。
+
+## 6. 範圍邊界
+
+### 包含
+- `internal/module/session/service.go` — `HandleTerminalWS` 加鎖
+- `internal/module/session/service_test.go` — race regression test (`TestHandleTerminalWS_NoConfigRace`)
+
+### 不含
+- 不修 `agent/module.go:71` — 那是 `Init()` 階段在任何 request 進來之前的單執行緒初始化，無 race
+- 不重構 `core.Cfg` 為 atomic.Pointer — 改動範圍過大、out of scope
+- 不引入 typed config snapshot struct — out of scope
+
+## 7. 風險與回滾
+
+- **風險低**：純粹加鎖，行為等價於原本（讀取一個 string）
+- **回滾**：直接 revert commit 即可
+
+## 8. 驗收條件
+
+- [ ] `go test -race ./internal/module/session/...` 通過
+- [ ] `go test ./...` 全綠
+- [ ] `gofmt`、`go vet` 乾淨
+- [ ] PR 兩輪 review（標準 + 三方 parallel）通過
+- [ ] Issue #26 在 PR 描述中以 `Closes #26` 連結

--- a/internal/module/session/service.go
+++ b/internal/module/session/service.go
@@ -131,10 +131,13 @@ func (m *SessionModule) HandleTerminalWS(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	// Determine sizing mode from config (default to "auto" if no config).
+	// Snapshot sizing mode under read lock to avoid race with handlePutConfig
+	// (config_handler.go writes Terminal.SizingMode under CfgMu.Lock).
 	sizingMode := "auto"
 	if m.core != nil && m.core.Cfg != nil {
+		m.core.CfgMu.RLock()
 		sizingMode = m.core.Cfg.Terminal.GetSizingMode()
+		m.core.CfgMu.RUnlock()
 	}
 
 	// Build tmux attach-session command and args.

--- a/internal/module/session/service_test.go
+++ b/internal/module/session/service_test.go
@@ -1,9 +1,17 @@
 package session
 
 import (
+	"net/http/httptest"
+	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wake/tmux-box/internal/config"
+	"github.com/wake/tmux-box/internal/core"
+	"github.com/wake/tmux-box/internal/store"
+	"github.com/wake/tmux-box/internal/tmux"
 )
 
 func TestBuildTerminalRelayArgs_Auto(t *testing.T) {
@@ -27,4 +35,69 @@ func TestWindowSizeForMode(t *testing.T) {
 	assert.Equal(t, "smallest", windowSizeForMode("minimal-first"))
 	assert.Equal(t, "latest", windowSizeForMode("terminal-first"))
 	assert.Equal(t, "latest", windowSizeForMode(""))
+}
+
+// TestHandleTerminalWS_NoConfigRace is a race regression test for issue #26.
+// HandleTerminalWS used to read m.core.Cfg.Terminal.SizingMode without holding
+// CfgMu, while handlePutConfig writes that field under CfgMu.Lock. Running this
+// test with `go test -race` must not report a data race.
+func TestHandleTerminalWS_NoConfigRace(t *testing.T) {
+	meta, err := store.OpenMeta(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { meta.Close() })
+
+	fake := tmux.NewFakeExecutor()
+	fake.AddSession("test-session", "/tmp") // auto-assigns $0
+
+	mod := NewSessionModule(meta)
+	c := core.New(core.CoreDeps{
+		Config: &config.Config{
+			Terminal: config.TerminalConfig{SizingMode: "auto"},
+		},
+		Tmux:     fake,
+		Registry: core.NewServiceRegistry(),
+	})
+	require.NoError(t, mod.Init(c))
+
+	code, err := EncodeSessionID("$0")
+	require.NoError(t, err)
+
+	stop := make(chan struct{})
+
+	// Writer goroutine: continuously flips SizingMode under CfgMu.
+	var writerWg sync.WaitGroup
+	writerWg.Add(1)
+	go func() {
+		defer writerWg.Done()
+		modes := []string{"auto", "terminal-first", "minimal-first"}
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			c.CfgMu.Lock()
+			c.Cfg.Terminal.SizingMode = modes[i%len(modes)]
+			c.CfgMu.Unlock()
+			runtime.Gosched()
+		}
+	}()
+
+	// Reader goroutines: concurrently invoke HandleTerminalWS. The WS upgrade
+	// will fail because httptest.ResponseRecorder is not a Hijacker, but the
+	// racy read of Cfg.Terminal.SizingMode runs before the upgrade attempt.
+	var readerWg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		readerWg.Add(1)
+		go func() {
+			defer readerWg.Done()
+			req := httptest.NewRequest("GET", "/ws/terminal/"+code, nil)
+			rec := httptest.NewRecorder()
+			mod.HandleTerminalWS(rec, req, code)
+		}()
+	}
+
+	readerWg.Wait()
+	close(stop)
+	writerWg.Wait()
 }

--- a/internal/module/session/service_test.go
+++ b/internal/module/session/service_test.go
@@ -63,6 +63,8 @@ func TestHandleTerminalWS_NoConfigRace(t *testing.T) {
 	require.NoError(t, err)
 
 	stop := make(chan struct{})
+	var stopOnce sync.Once
+	closeStop := func() { stopOnce.Do(func() { close(stop) }) }
 
 	// Writer goroutine: continuously flips SizingMode under CfgMu.
 	var writerWg sync.WaitGroup
@@ -83,21 +85,33 @@ func TestHandleTerminalWS_NoConfigRace(t *testing.T) {
 		}
 	}()
 
+	// Cleanup must run even if the test body panics, to prevent the writer
+	// goroutine from leaking into subsequent tests in the same package run.
+	t.Cleanup(func() {
+		closeStop()
+		writerWg.Wait()
+	})
+
 	// Reader goroutines: concurrently invoke HandleTerminalWS. The WS upgrade
 	// will fail because httptest.ResponseRecorder is not a Hijacker, but the
-	// racy read of Cfg.Terminal.SizingMode runs before the upgrade attempt.
+	// read of Cfg.Terminal.SizingMode (the field protected by the fix) runs
+	// before the upgrade attempt. Each goroutine loops several times so total
+	// reader activity is large enough to keep race-detector firing reliable
+	// on busy CI hardware.
 	var readerWg sync.WaitGroup
 	for i := 0; i < 50; i++ {
 		readerWg.Add(1)
 		go func() {
 			defer readerWg.Done()
-			req := httptest.NewRequest("GET", "/ws/terminal/"+code, nil)
-			rec := httptest.NewRecorder()
-			mod.HandleTerminalWS(rec, req, code)
+			for j := 0; j < 20; j++ {
+				req := httptest.NewRequest("GET", "/ws/terminal/"+code, nil)
+				rec := httptest.NewRecorder()
+				mod.HandleTerminalWS(rec, req, code)
+			}
 		}()
 	}
 
 	readerWg.Wait()
-	close(stop)
+	closeStop()
 	writerWg.Wait()
 }


### PR DESCRIPTION
## Summary

- 修復 `HandleTerminalWS` 在讀取 `m.core.Cfg.Terminal.GetSizingMode()` 時未持 `CfgMu.RLock`，與 `handlePutConfig` 在 `CfgMu.Lock` 下寫入相同欄位產生的 data race
- 採用 snapshot pattern：於 read lock 內取值後立即解鎖，仿 `internal/module/stream/handler.go:177-182` 既有 pattern
- 新增 race regression test，於 `-race` 下並發 50 reader + 1 writer 驗證

## 變更檔案

- `internal/module/session/service.go`：`HandleTerminalWS` 加 `CfgMu.RLock`/`RUnlock`
- `internal/module/session/service_test.go`：新增 `TestHandleTerminalWS_NoConfigRace`
- `docs/superpowers/specs/2026-04-12-issue-26-cfgmu-race-fix.md`：spec
- `docs/superpowers/plans/2026-04-12-issue-26-cfgmu-race-fix.md`：plan

## Test plan

- [x] `go test -race ./internal/module/session/ -run TestHandleTerminalWS_NoConfigRace -count=3` 通過
- [x] `go test -race ./...` 全綠
- [x] `go vet ./...` 無警告
- [x] `gofmt -l` on changed files 無輸出
- [x] 修復前該測試會命中 DATA RACE 並 fail（已驗證）

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)