### PR TITLE
fix: rollback in-memory config on writeConfig failure (#28)

### DIFF
--- a/docs/superpowers/plans/2026-04-12-issue-28-config-rollback.md
+++ b/docs/superpowers/plans/2026-04-12-issue-28-config-rollback.md
@@ -1,0 +1,170 @@
+# Plan — Issue #28: handlePutConfig Rollback
+
+## Target Files
+
+1. `internal/core/config_handler.go` — add snapshot + rollback
+2. `internal/core/config_handler_test.go` — add `TestPutConfigRollsBackOnWriteFailure`
+
+## Implementation Steps
+
+### Step 1 (TDD RED) — Add failing test
+
+In `internal/core/config_handler_test.go`, append:
+
+```go
+func TestPutConfigRollsBackOnWriteFailure(t *testing.T) {
+    // Create a regular file to use as a "blocker" — any path under it
+    // triggers ENOTDIR on write, portable across macOS/Linux/CI.
+    tmpDir := t.TempDir()
+    blocker := filepath.Join(tmpDir, "blocker")
+    require.NoError(t, os.WriteFile(blocker, []byte("x"), 0644))
+
+    c := newTestCore()
+    c.CfgPath = filepath.Join(blocker, "config.toml") // parent is a file
+
+    // Snapshot expected original state
+    originalPresets := append([]config.Preset(nil), c.Cfg.Stream.Presets...)
+    originalCCCommands := append([]string(nil), c.Cfg.Detect.CCCommands...)
+    originalPollInterval := c.Cfg.Detect.PollInterval
+    originalSizingMode := c.Cfg.Terminal.SizingMode
+    originalCfgPtr := c.Cfg
+
+    var callbackCalled int
+    c.OnConfigChange(func() { callbackCalled++ })
+
+    body := `{
+      "stream":{"presets":[{"name":"new","command":"x"}]},
+      "detect":{"cc_commands":["aider"],"poll_interval":99},
+      "terminal":{"sizing_mode":"terminal-first"}
+    }`
+    req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+    rec := httptest.NewRecorder()
+    c.handlePutConfig(rec, req)
+
+    // 1. Status 500
+    assert.Equal(t, http.StatusInternalServerError, rec.Code)
+    assert.Contains(t, rec.Body.String(), "failed to save config")
+
+    // 2. In-memory state fully rolled back
+    c.CfgMu.RLock()
+    assert.Equal(t, originalPresets, c.Cfg.Stream.Presets, "Stream.Presets should be rolled back")
+    assert.Equal(t, originalCCCommands, c.Cfg.Detect.CCCommands, "Detect.CCCommands should be rolled back")
+    assert.Equal(t, originalPollInterval, c.Cfg.Detect.PollInterval, "Detect.PollInterval should be rolled back")
+    assert.Equal(t, originalSizingMode, c.Cfg.Terminal.SizingMode, "Terminal.SizingMode should be rolled back")
+    c.CfgMu.RUnlock()
+
+    // 3. Callback not called (no actual change)
+    assert.Equal(t, 0, callbackCalled, "OnConfigChange must not fire on rollback")
+
+    // 4. Pointer identity preserved (other goroutines hold c.Cfg)
+    assert.Same(t, originalCfgPtr, c.Cfg, "c.Cfg pointer must not be swapped")
+
+    // 5. Recovery: a successful PUT after rollback must still work
+    tmpDir2 := t.TempDir()
+    c.CfgPath = filepath.Join(tmpDir2, "config.toml")
+    body2 := `{"detect":{"cc_commands":["aider"]}}`
+    req2 := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body2))
+    rec2 := httptest.NewRecorder()
+    c.handlePutConfig(rec2, req2)
+    assert.Equal(t, http.StatusOK, rec2.Code)
+    c.CfgMu.RLock()
+    assert.Equal(t, []string{"aider"}, c.Cfg.Detect.CCCommands)
+    c.CfgMu.RUnlock()
+}
+```
+
+Run: `cd .../issue-28-config-rollback && go test ./internal/core -run TestPutConfigRollsBackOnWriteFailure` → expect **FAIL** (because rollback not yet implemented).
+
+### Step 2 (TDD GREEN) — Implement rollback
+
+Edit `internal/core/config_handler.go`. Place snapshot **after** the `sizing_mode` validation (validation early-returns should not waste a snapshot). Replace the current mutate + write block:
+
+```go
+// Snapshot BEFORE any mutation for rollback on writeConfig failure.
+// Shallow copy is sufficient because all mutations below replace slice
+// headers wholesale (never mutate in place); if a future field adds
+// in-place mutation (append/map update), rollback will silently break.
+snapshot := *c.Cfg
+
+detectChanged := false
+
+if req.Stream != nil {
+    c.Cfg.Stream = *req.Stream
+}
+if req.Detect != nil {
+    if req.Detect.CCCommands != nil {
+        c.Cfg.Detect.CCCommands = *req.Detect.CCCommands
+        detectChanged = true
+    }
+    if req.Detect.PollInterval != nil && *req.Detect.PollInterval > 0 {
+        c.Cfg.Detect.PollInterval = *req.Detect.PollInterval
+        detectChanged = true
+    }
+}
+if req.Terminal != nil && req.Terminal.SizingMode != "" {
+    c.Cfg.Terminal.SizingMode = req.Terminal.SizingMode
+}
+
+// Write back to config file
+if c.CfgPath != "" {
+    if err := config.WriteFile(c.CfgPath, *c.Cfg); err != nil {
+        *c.Cfg = snapshot // rollback in-memory state on write failure
+        c.CfgMu.Unlock()
+        http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+        return
+    }
+}
+```
+
+Key notes:
+- `snapshot` taken **before** any mutation
+- Rollback uses `*c.Cfg = snapshot` (not `c.Cfg = &snapshot`) to preserve pointer identity
+- `detectChanged` still only affects callback path, which is outside the lock and unchanged
+
+Run: `go test ./internal/core -run TestPutConfigRollsBackOnWriteFailure` → expect **PASS**.
+
+### Step 3 — Regression check
+
+Run package tests: `go test ./internal/core/...` → all existing tests must pass. Then run full module: `go test ./...` since this is a hot handler path.
+
+### Step 4 — Lint + vet
+
+```
+gofmt -w internal/core/config_handler.go internal/core/config_handler_test.go
+go vet ./internal/core/...
+```
+
+### Step 5 — Commit & push
+
+```
+git add internal/core/config_handler.go internal/core/config_handler_test.go docs/superpowers/specs/2026-04-12-issue-28-config-rollback.md docs/superpowers/plans/2026-04-12-issue-28-config-rollback.md
+git commit -m "fix: rollback in-memory config on writeConfig failure (#28)"
+git push -u origin worktree-issue-28-config-rollback
+```
+
+### Step 6 — Open PR
+
+```
+gh pr create --title "fix: rollback in-memory config on writeConfig failure (#28)" \
+  --body "Closes #28. Snapshots c.Cfg before mutating, restores on writeConfig error..."
+```
+
+### Step 7 — Three-dimension review
+
+Run in parallel:
+- Attack agent — look for race conditions, missed fields, aliasing bugs
+- Defense agent — verify invariants hold, architecture consistency
+- File-size / responsibility agent — check the diff is focused
+
+### Step 8 — Merge + close + bump
+
+- Address high-confidence / low-complexity / test-related findings
+- Merge PR
+- Bump `VERSION` + `package.json` + `spa/package.json` to next alpha
+- Update `CHANGELOG.md`
+- Close issue #28 (via "Closes #28" in PR body)
+
+## Out of Scope
+
+- Refactoring `config.WriteFile` atomicity
+- Other handlers' rollback patterns

--- a/docs/superpowers/specs/2026-04-12-issue-28-config-rollback.md
+++ b/docs/superpowers/specs/2026-04-12-issue-28-config-rollback.md
@@ -1,0 +1,90 @@
+# Spec — Issue #28: handlePutConfig Rollback on writeConfig Failure
+
+## Problem
+
+`internal/core/config_handler.go:handlePutConfig` 先將請求內容套用到 `c.Cfg`（記憶體），再呼叫 `config.WriteFile` 寫入磁碟。若寫檔失敗，記憶體已更新但磁碟未更新，產生不一致：
+- 目前執行的 daemon 使用新設定
+- 下次重啟 daemon 從磁碟讀回舊設定
+- 客戶端收到 500，不確定設定是否生效
+
+## Scope
+
+僅修改 `internal/core/config_handler.go` 的 `handlePutConfig` 函式與其測試。不觸及 config file format、callback 機制、其他 handler。
+
+## Invariants
+
+1. **原子性**：HTTP 請求完成後，記憶體 (`c.Cfg`) 與磁碟 (`c.CfgPath`) 必須一致。寫檔失敗時，記憶體狀態必須回復到請求前。
+2. **鎖保護**：整段 mutation + write + rollback 必須在 `c.CfgMu.Lock()` 保護範圍內，避免其他 reader/writer 觀察到中間狀態。
+3. **callback 不誤觸**：若寫檔失敗並 rollback，`NotifyConfigChange` 不得被呼叫（因為設定實際上沒變）。
+4. **回傳碼語意保持**：
+   - 400 — invalid JSON / invalid sizing_mode
+   - 500 — writeConfig 失敗（rollback 完成後回傳）
+   - 200 — 成功（記憶體與磁碟皆已更新）
+5. **指標身分保留**：`c.Cfg` 指標不可被換掉，rollback 必須透過 `*c.Cfg = snapshot` 寫回原本的 struct（其他 goroutine 持有該指標）。
+6. **Config 不得 in-place mutation**：codebase 不得對 `c.Cfg` 的子欄位做 in-place mutation（如 `append(c.Cfg.Stream.Presets, ...)` 或 map update）。shallow snapshot rollback 的正確性建立在此 invariant 之上；所有修改必須整個指派新值。
+
+## Approach
+
+在所有 mutation 之前拍 shallow snapshot：
+
+```go
+snapshot := *c.Cfg
+```
+
+Shallow copy 的安全性分析：
+- `c.Cfg.Stream = *req.Stream` — 整個 struct 取代，rollback 時 `c.Cfg.Stream = snapshot.Stream` 還原整個 slice header。✅
+- `c.Cfg.Detect.CCCommands = *req.Detect.CCCommands` — 整個 slice 取代。✅
+- `c.Cfg.Detect.PollInterval = *req.Detect.PollInterval` — scalar。✅
+- `c.Cfg.Terminal.SizingMode = req.Terminal.SizingMode` — scalar。✅
+- 沒有 `append(c.Cfg.X, ...)` 之類的 in-place 操作。
+- 沒有 map 欄位 mutation。
+
+因此 shallow copy `*c.Cfg` 即可完整 rollback，**不需要 deep copy**。
+
+寫檔失敗時：
+```go
+if err := config.WriteFile(c.CfgPath, *c.Cfg); err != nil {
+    *c.Cfg = snapshot  // rollback
+    c.CfgMu.Unlock()
+    http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+    return
+}
+```
+
+同時 `detectChanged` 變成「是否真的已 commit」的旗標，只有在寫檔成功後才會觸發 callback。
+
+## Test Plan
+
+新增測試 `TestPutConfigRollsBackOnWriteFailure`：
+
+**Setup**：
+- Core 初始配置帶入明確的 Stream.Presets、Detect.CCCommands、Terminal.SizingMode
+- `c.CfgPath` 指向一個不可能寫入的路徑：在 `t.TempDir()` 內建一個普通檔案 `blocker`，然後把 `CfgPath` 設為 `filepath.Join(blocker, "config.toml")`。父路徑是檔案而非目錄，任何寫檔嘗試（包含 tmp + rename）都會得到 `ENOTDIR`，100% 跨平台、不需 chmod cleanup。
+
+**Action**：
+- PUT 一個同時修改 stream、detect、terminal 的 body
+- 註冊 `OnConfigChange` callback 計數
+
+**Assertions**：
+1. `rec.Code == 500`
+2. Response body 包含 "failed to save config"
+3. `c.Cfg.Stream.Presets` 等於初始值（未被覆蓋）
+4. `c.Cfg.Detect.CCCommands` 等於初始值
+5. `c.Cfg.Detect.PollInterval` 等於初始值
+6. `c.Cfg.Terminal.SizingMode` 等於初始值
+7. callback 呼叫次數為 0
+8. `c.Cfg` 指標身分未變（不是被整個換掉）— 透過比對操作前後 `c.Cfg` 指標相等驗證
+9. **recovery 測試**：rollback 後，將 `c.CfgPath` 改為正常可寫路徑後再發一次 PUT，必須 200 且狀態正確套用（確認 state 沒被破壞）
+
+**Cleanup**：測試結尾將目錄權限還原為 0700（否則 `t.TempDir()` cleanup 會失敗）。`t.Cleanup` 負責。
+
+## Edge Cases
+
+- **既有測試**：`TestPutConfigUpdatesStreamAndPersists`、`TestPutConfigDetectCCCommandsTriggersOnConfigChange` 等必須仍然通過。
+- **鎖順序**：實作時保持現有手動 `Lock` / `Unlock` 模式（不改為 defer Unlock），因為 callback 呼叫發生在 Unlock 之後。
+
+## Out of Scope
+
+- writeConfig 本身的原子性（fsync、tmp + rename）— 由 `internal/config` 負責，不在本次修改範圍
+- 其他 handler（如 host-config 等）的 rollback — issue #28 僅針對 `handlePutConfig`
+- deep copy/reflection-based snapshot — 目前 mutation pattern 不需要

--- a/docs/superpowers/specs/2026-04-12-issue-28-config-rollback.md
+++ b/docs/superpowers/specs/2026-04-12-issue-28-config-rollback.md
@@ -76,7 +76,7 @@ if err := config.WriteFile(c.CfgPath, *c.Cfg); err != nil {
 8. `c.Cfg` 指標身分未變（不是被整個換掉）— 透過比對操作前後 `c.Cfg` 指標相等驗證
 9. **recovery 測試**：rollback 後，將 `c.CfgPath` 改為正常可寫路徑後再發一次 PUT，必須 200 且狀態正確套用（確認 state 沒被破壞）
 
-**Cleanup**：測試結尾將目錄權限還原為 0700（否則 `t.TempDir()` cleanup 會失敗）。`t.Cleanup` 負責。
+**Cleanup**：無需額外處理。`t.TempDir()` 的 auto-cleanup 會清掉整個目錄（包含 blocker 檔與其下的失敗 config path）。
 
 ## Edge Cases
 

--- a/internal/core/config_handler.go
+++ b/internal/core/config_handler.go
@@ -67,7 +67,9 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 
 	detectChanged := false
 
-	// Apply updates — only the allowed fields
+	// Invariant: every mutation below must replace the field wholesale.
+	// Do NOT append into c.Cfg slices or write into c.Cfg maps — rollback
+	// relies on whole-field assignment to restore `snapshot` correctly.
 	if req.Stream != nil {
 		c.Cfg.Stream = *req.Stream
 	}

--- a/internal/core/config_handler.go
+++ b/internal/core/config_handler.go
@@ -58,6 +58,13 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Snapshot before any mutation so writeConfig failure can roll back the
+	// in-memory state, keeping c.Cfg and disk consistent. Shallow copy is
+	// sufficient because every mutation below replaces fields wholesale
+	// (slice headers reassigned, never appended into). Future fields must
+	// follow the same whole-field-assignment rule or rollback will break.
+	snapshot := *c.Cfg
+
 	detectChanged := false
 
 	// Apply updates — only the allowed fields
@@ -82,6 +89,7 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	// Write back to config file
 	if c.CfgPath != "" {
 		if err := config.WriteFile(c.CfgPath, *c.Cfg); err != nil {
+			*c.Cfg = snapshot // rollback: preserve pointer identity for other goroutines
 			c.CfgMu.Unlock()
 			http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -102,4 +110,3 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(cfg)
 }
-

--- a/internal/core/config_handler_test.go
+++ b/internal/core/config_handler_test.go
@@ -254,3 +254,66 @@ func TestRegisterCoreRoutesIncludesConfigEndpoints(t *testing.T) {
 	mux.ServeHTTP(rec, req)
 	assert.NotEqual(t, http.StatusNotFound, rec.Code)
 }
+
+// TestPutConfigRollsBackOnWriteFailure verifies that when writeConfig fails,
+// in-memory state is restored so memory and disk stay consistent.
+func TestPutConfigRollsBackOnWriteFailure(t *testing.T) {
+	// Use a regular file as the parent of CfgPath. Any WriteFile attempt
+	// (including MkdirAll on the parent) returns ENOTDIR — portable across
+	// macOS/Linux/CI, no chmod cleanup required.
+	tmpDir := t.TempDir()
+	blocker := filepath.Join(tmpDir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0644))
+
+	c := newTestCore()
+	c.CfgPath = filepath.Join(blocker, "config.toml") // parent is a file → ENOTDIR
+
+	// Capture original state for rollback assertions.
+	originalPresets := append([]config.Preset(nil), c.Cfg.Stream.Presets...)
+	originalCCCommands := append([]string(nil), c.Cfg.Detect.CCCommands...)
+	originalPollInterval := c.Cfg.Detect.PollInterval
+	originalSizingMode := c.Cfg.Terminal.SizingMode
+	originalCfgPtr := c.Cfg
+
+	var callbackCalled int
+	c.OnConfigChange(func() { callbackCalled++ })
+
+	body := `{
+		"stream":{"presets":[{"name":"new","command":"new-cmd"}]},
+		"detect":{"cc_commands":["aider"],"poll_interval":99},
+		"terminal":{"sizing_mode":"terminal-first"}
+	}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+
+	// 1. 500 returned with error message
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "failed to save config")
+
+	// 2. In-memory state fully rolled back
+	c.CfgMu.RLock()
+	assert.Equal(t, originalPresets, c.Cfg.Stream.Presets, "Stream.Presets must be rolled back")
+	assert.Equal(t, originalCCCommands, c.Cfg.Detect.CCCommands, "Detect.CCCommands must be rolled back")
+	assert.Equal(t, originalPollInterval, c.Cfg.Detect.PollInterval, "Detect.PollInterval must be rolled back")
+	assert.Equal(t, originalSizingMode, c.Cfg.Terminal.SizingMode, "Terminal.SizingMode must be rolled back")
+	c.CfgMu.RUnlock()
+
+	// 3. OnConfigChange callback must NOT fire on failed write
+	assert.Equal(t, 0, callbackCalled, "OnConfigChange must not fire when rollback occurs")
+
+	// 4. c.Cfg pointer identity preserved (other goroutines hold this pointer)
+	assert.Same(t, originalCfgPtr, c.Cfg, "c.Cfg pointer must not be swapped")
+
+	// 5. Recovery: state is not corrupted — a subsequent successful PUT works.
+	tmpDir2 := t.TempDir()
+	c.CfgPath = filepath.Join(tmpDir2, "config.toml")
+	body2 := `{"detect":{"cc_commands":["aider"]}}`
+	req2 := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body2))
+	rec2 := httptest.NewRecorder()
+	c.handlePutConfig(rec2, req2)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	c.CfgMu.RLock()
+	assert.Equal(t, []string{"aider"}, c.Cfg.Detect.CCCommands)
+	c.CfgMu.RUnlock()
+}

--- a/internal/core/config_handler_test.go
+++ b/internal/core/config_handler_test.go
@@ -287,9 +287,12 @@ func TestPutConfigRollsBackOnWriteFailure(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c.handlePutConfig(rec, req)
 
-	// 1. 500 returned with error message
+	// 1. 500 returned, and the error must contain a filesystem-y message so
+	//    future refactors can't swallow the real write error and still pass.
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.Contains(t, rec.Body.String(), "failed to save config")
+	assert.Contains(t, rec.Body.String(), "not a directory",
+		"rollback must surface the underlying ENOTDIR, not a synthetic error")
 
 	// 2. In-memory state fully rolled back
 	c.CfgMu.RLock()


### PR DESCRIPTION
## Summary

- `handlePutConfig` 之前會先改 `c.Cfg`（記憶體）再寫檔，若寫檔失敗就回 500 但記憶體已變，造成 daemon 執行中設定與重啟後從磁碟讀回的設定不一致
- 在 mutation 之前 shallow snapshot `*c.Cfg`，寫檔失敗時 `*c.Cfg = snapshot` 還原；採 `*c.Cfg =` 而非換指標，避免破壞其他 goroutine 持有的 `c.Cfg` 指標
- Shallow copy 安全性的前提已於 snapshot 註解說明：所有 mutation 必須整個指派新值，不得 in-place mutation slice/map

## Test plan
- [x] `TestPutConfigRollsBackOnWriteFailure` 觸發 ENOTDIR 寫檔失敗（`CfgPath` 父路徑為普通檔案，跨平台可靠）
- [x] 驗證 500 status + 錯誤訊息
- [x] 驗證 `Stream.Presets`、`Detect.CCCommands`、`Detect.PollInterval`、`Terminal.SizingMode` 全數回到原值
- [x] 驗證 `OnConfigChange` callback 未觸發
- [x] 驗證 `c.Cfg` 指標身分未變
- [x] 驗證 rollback 後再發一次正常 PUT 仍然成功
- [x] `go test ./...` 全綠（`internal/core`、`internal/module/stream` 等全數通過）

Closes #28