### PR TITLE
fix(spa): restore cursor pointer on TitleBar buttons

### DIFF
--- a/spa/src/components/TitleBar.tsx
+++ b/spa/src/components/TitleBar.tsx
@@ -36,17 +36,19 @@ export function TitleBar({ title }: Props) {
   return (
     <div
       className="shrink-0 relative flex items-center bg-surface-secondary border-b border-border-subtle px-2"
-      style={{ height: 30, WebkitAppRegion: 'drag' } as React.CSSProperties}
+      style={{ height: 30 } as React.CSSProperties}
     >
       {/* Title — absolute positioned for true center across full window width */}
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none select-none">
         <span className="text-xs text-text-muted truncate px-20">{title}</span>
       </div>
-      <div className="flex-1" />
+      <div
+        className="flex-1 self-stretch"
+        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      />
       <div
         data-testid="layout-buttons"
         className="shrink-0 flex items-center gap-0.5"
-        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
         {/* Region toggles */}
         {visibleToggles.map(({ region, icon: Icon, label, mirror }) => {


### PR DESCRIPTION
## Summary
- Move `-webkit-app-region: drag` off the TitleBar container onto a dedicated `flex-1` spacer so button children are no longer descendants of a drag region
- Chromium forces the default cursor on all descendants of a drag region regardless of `no-drag` overrides, which was suppressing `cursor-pointer` on the right-side layout/region-toggle buttons

## Test plan
- [x] `cd spa && npx vitest run TitleBar` — 7 passed
- [ ] Manual: hover topbar right-side buttons in Electron, confirm pointer cursor
- [ ] Manual: confirm window drag still works on the title/spacer area