### PR TITLE
fix(spa): force cursor pointer on TitleBar buttons

### DIFF
--- a/spa/src/components/TitleBar.tsx
+++ b/spa/src/components/TitleBar.tsx
@@ -48,7 +48,8 @@ export function TitleBar({ title }: Props) {
       />
       <div
         data-testid="layout-buttons"
-        className="shrink-0 flex items-center gap-0.5"
+        className="relative z-10 shrink-0 flex items-center gap-0.5"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
         {/* Region toggles */}
         {visibleToggles.map(({ region, icon: Icon, label, mirror }) => {
@@ -56,7 +57,7 @@ export function TitleBar({ title }: Props) {
           return (
             <button
               key={region}
-              className={`p-1 rounded transition-colors cursor-pointer ${
+              className={`p-1 rounded transition-colors cursor-pointer! ${
                 isVisible
                   ? 'text-accent-base bg-accent-base/10 hover:bg-accent-base/20'
                   : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
@@ -76,7 +77,7 @@ export function TitleBar({ title }: Props) {
           <button
             key={pattern}
             disabled={!activeTabId}
-            className="p-1 rounded cursor-pointer text-text-muted hover:text-text-primary hover:bg-surface-hover disabled:opacity-40 disabled:pointer-events-none"
+            className="p-1 rounded cursor-pointer! text-text-muted hover:text-text-primary hover:bg-surface-hover disabled:opacity-40 disabled:pointer-events-none disabled:cursor-default!"
             title={label}
             onClick={() => handlePattern(pattern)}
           >


### PR DESCRIPTION
## Summary
- Follow-up to #296 — previous drag-region-only fix still left the buttons under the absolute `inset-0` title layer, where cursor fall-through was unreliable in Electron
- Lift the buttons container into the positioned stacking layer (`relative z-10`) so it paints above the absolute title div
- Reassert `WebkitAppRegion: 'no-drag'` as belt-and-suspenders
- Use Tailwind v4 `cursor-pointer!` (with `!important`) on each button, plus `disabled:cursor-default!` for the disabled state

## Test plan
- [x] `cd spa && npx vitest run TitleBar` — 7 passed
- [ ] Manual: hover topbar right-side buttons in Electron on Air, confirm pointer cursor
- [ ] Manual: confirm window drag still works via the center spacer