### PR TITLE
fix(electron): restore Toggle Developer Tools in View menu

### DIFF
--- a/electron/keybindings.ts
+++ b/electron/keybindings.ts
@@ -137,7 +137,11 @@ export function buildMenuTemplate(
 
   const viewMenu: MenuItemConstructorOptions = {
     label: 'View',
-    submenu: [...(byCategory.get('View') ?? [])],
+    submenu: [
+      ...(byCategory.get('View') ?? []),
+      { type: 'separator' as const },
+      { role: 'toggleDevTools' as const },
+    ],
   }
 
   const editMenu: MenuItemConstructorOptions = {


### PR DESCRIPTION
## Summary
- The custom application menu replaces Electron's default menu, which dropped the built-in `Cmd+Option+I` shortcut for Toggle Developer Tools
- Append a `toggleDevTools` role item to the View submenu so the default accelerator is re-registered

## Test plan
- [ ] Manual: in Electron app, View → Toggle Developer Tools opens DevTools
- [ ] Manual: `Cmd+Option+I` toggles DevTools