### PR TITLE
revert: undo ineffective TitleBar cursor-pointer attempts

### DIFF
--- a/spa/src/components/TitleBar.tsx
+++ b/spa/src/components/TitleBar.tsx
@@ -36,19 +36,16 @@ export function TitleBar({ title }: Props) {
   return (
     <div
       className="shrink-0 relative flex items-center bg-surface-secondary border-b border-border-subtle px-2"
-      style={{ height: 30 } as React.CSSProperties}
+      style={{ height: 30, WebkitAppRegion: 'drag' } as React.CSSProperties}
     >
       {/* Title — absolute positioned for true center across full window width */}
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none select-none">
         <span className="text-xs text-text-muted truncate px-20">{title}</span>
       </div>
-      <div
-        className="flex-1 self-stretch"
-        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-      />
+      <div className="flex-1" />
       <div
         data-testid="layout-buttons"
-        className="relative z-10 shrink-0 flex items-center gap-0.5"
+        className="shrink-0 flex items-center gap-0.5"
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
         {/* Region toggles */}
@@ -57,7 +54,7 @@ export function TitleBar({ title }: Props) {
           return (
             <button
               key={region}
-              className={`p-1 rounded transition-colors cursor-pointer! ${
+              className={`p-1 rounded transition-colors cursor-pointer ${
                 isVisible
                   ? 'text-accent-base bg-accent-base/10 hover:bg-accent-base/20'
                   : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
@@ -77,7 +74,7 @@ export function TitleBar({ title }: Props) {
           <button
             key={pattern}
             disabled={!activeTabId}
-            className="p-1 rounded cursor-pointer! text-text-muted hover:text-text-primary hover:bg-surface-hover disabled:opacity-40 disabled:pointer-events-none disabled:cursor-default!"
+            className="p-1 rounded cursor-pointer text-text-muted hover:text-text-primary hover:bg-surface-hover disabled:opacity-40 disabled:pointer-events-none"
             title={label}
             onClick={() => handlePattern(pattern)}
           >


### PR DESCRIPTION
## Summary
- PRs #296 and #297 tried to force pointer cursor on TitleBar right-side buttons via drag-region and CSS tweaks
- DevTools inspection confirms computed cursor is already `pointer !important` — the fixes were no-ops in the problematic scenario
- Root cause is upstream Electron/macOS: `titleBarStyle: 'hiddenInset'` leaves the NSWindow title-bar region active in the top ~38px, which swallows Chromium cursor updates ([electron/electron#5723](https://github.com/electron/electron/issues/5723), [#21632](https://github.com/electron/electron/issues/21632))
- No pure-CSS fix exists; proper fix requires restructuring (move buttons below the 38px tracking zone, VSCode-style)
- This PR restores `TitleBar.tsx` to the state before #296 to remove dead code and keep the diff honest; follow-up issue tracks the real fix

## Test plan
- [x] `cd spa && npx vitest run TitleBar` — 7 passed