### PR TITLE
fix(electron): restore renderer focus when backgrounding BrowserView

### DIFF
--- a/electron/browser-view-manager.ts
+++ b/electron/browser-view-manager.ts
@@ -260,8 +260,13 @@ export class BrowserViewManager {
     // the user clicked into the BrowserView, OS-level focus stays with that
     // WebContents even after it's moved off-screen, so the SPA's focus() calls
     // (e.g. TerminalView auto-focus on re-show) have no effect until the user
-    // clicks the main window.
-    if (!entry.window.isDestroyed() && !entry.window.webContents.isDestroyed()) {
+    // clicks the main window. Guarded on window.isFocused() so we never steal
+    // focus from another window — only return it within an already-active one.
+    if (
+      !entry.window.isDestroyed() &&
+      !entry.window.webContents.isDestroyed() &&
+      entry.window.isFocused()
+    ) {
       entry.window.webContents.focus()
     }
 

--- a/electron/browser-view-manager.ts
+++ b/electron/browser-view-manager.ts
@@ -256,6 +256,15 @@ export class BrowserViewManager {
     // Move off-screen
     entry.view.setBounds({ x: -10000, y: -10000, width: 1, height: 1 })
 
+    // Return keyboard focus to the host window's renderer. Without this, if
+    // the user clicked into the BrowserView, OS-level focus stays with that
+    // WebContents even after it's moved off-screen, so the SPA's focus() calls
+    // (e.g. TerminalView auto-focus on re-show) have no effect until the user
+    // clicks the main window.
+    if (!entry.window.isDestroyed() && !entry.window.webContents.isDestroyed()) {
+      entry.window.webContents.focus()
+    }
+
     // Start idle timer
     this.startIdleTimer(paneId)
 


### PR DESCRIPTION
## Summary
- 切回 Terminal tab 後 terminal 無法自動 focus（需手動點一下）的根因修復
- 點過 Browser 頁面內容後，OS 鍵盤 focus 會留在 `WebContentsView` 的 webContents
- `BrowserViewManager.deactivate()` 只把 view 移到 off-screen，沒把 focus 交回主視窗 → SPA 端 `termRef.focus()` 形同無效
- Fix：在 `deactivate()` 移 off-screen 後呼叫 `entry.window.webContents.focus()`

## Test plan
- [ ] Browser tab → 點頁面任一處 → 切回 Terminal tab → terminal 應立即可輸入，毋需手動點擊
- [ ] Browser tab → **不要**點頁面 → 切回 Terminal tab → 行為不變（regression check）
- [ ] 切到 Settings/History 等非 terminal tab 再切回不應壞掉
- [ ] 關閉 Browser tab（unmount → background → idle discard）流程不應 crash