### PR TITLE
feat: editors update custom entries in-place (#74)

### DIFF
--- a/spa/src/components/settings/LocaleEditor.test.tsx
+++ b/spa/src/components/settings/LocaleEditor.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { LocaleEditor } from './LocaleEditor'
+import { useI18nStore } from '../../stores/useI18nStore'
+import { registerLocale, clearLocaleRegistry } from '../../lib/locale-registry'
+import type { LocaleDef } from '../../lib/locale-registry'
+
+const en: LocaleDef = {
+  id: 'en', name: 'English',
+  translations: { 'common.save': 'Save', 'common.cancel': 'Cancel', 'common.reset': 'Reset',
+    'locale.editor.title': 'Locale Editor', 'locale.editor.close': 'Close',
+    'locale.editor.name_label': 'Name', 'locale.editor.name_aria': 'Locale name',
+    'locale.editor.search': 'Search', 'locale.editor.save': 'Save locale',
+    'locale.editor.filter.all': 'All ({{count}})', 'locale.editor.filter.modified': 'Modified ({{count}})',
+    'locale.editor.filter.missing': 'Missing ({{count}})' },
+  builtin: true,
+}
+
+describe('LocaleEditor', () => {
+  beforeEach(() => {
+    clearLocaleRegistry()
+    registerLocale(en)
+    useI18nStore.setState({ activeLocaleId: 'en', customLocales: {} })
+    useI18nStore.getState().setLocale('en')
+  })
+
+  it('save forks builtin locale into new custom entry', () => {
+    const onClose = vi.fn()
+    render(<LocaleEditor baseLocaleId="en" onClose={onClose} />)
+
+    // Change name
+    const nameInput = screen.getByLabelText('Locale name')
+    fireEvent.change(nameInput, { target: { value: 'My English' } })
+
+    // Save
+    fireEvent.click(screen.getByLabelText('Save locale'))
+
+    // Should have created a custom locale
+    const state = useI18nStore.getState()
+    const customIds = Object.keys(state.customLocales)
+    expect(customIds.length).toBe(1)
+    expect(customIds[0]).not.toBe('en')
+    expect(state.customLocales[customIds[0]].name).toBe('My English')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('save updates existing custom locale in-place', () => {
+    // Pre-create a custom locale
+    const customId = useI18nStore.getState().importLocale({
+      name: 'My Locale',
+      translations: { ...en.translations },
+    })
+    registerLocale(useI18nStore.getState().customLocales[customId])
+
+    const onClose = vi.fn()
+    render(<LocaleEditor baseLocaleId={customId} onClose={onClose} />)
+
+    // Change name
+    const nameInput = screen.getByLabelText('Locale name')
+    fireEvent.change(nameInput, { target: { value: 'Updated Locale' } })
+
+    // Save
+    fireEvent.click(screen.getByLabelText('Save locale'))
+
+    // Should have updated in-place, not created a new entry
+    const state = useI18nStore.getState()
+    const customIds = Object.keys(state.customLocales)
+    expect(customIds.length).toBe(1)
+    expect(customIds[0]).toBe(customId)
+    expect(state.customLocales[customId].name).toBe('Updated Locale')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('name initializes without (Custom) suffix when editing custom', () => {
+    // Pre-create a custom locale
+    const customId = useI18nStore.getState().importLocale({
+      name: 'My Locale',
+      translations: { ...en.translations },
+    })
+    registerLocale(useI18nStore.getState().customLocales[customId])
+
+    render(<LocaleEditor baseLocaleId={customId} onClose={() => {}} />)
+
+    const nameInput = screen.getByLabelText('Locale name')
+    expect(nameInput).toHaveValue('My Locale')
+  })
+})

--- a/spa/src/components/settings/LocaleEditor.tsx
+++ b/spa/src/components/settings/LocaleEditor.tsx
@@ -18,12 +18,14 @@ export function LocaleEditor({ baseLocaleId, onClose }: LocaleEditorProps) {
   const baseLocale = getLocale(baseLocaleId)
   const importLocale = useI18nStore((s) => s.importLocale)
   const setLocale = useI18nStore((s) => s.setLocale)
+  const isEditingCustom = useI18nStore((s) => baseLocaleId in s.customLocales)
+  const updateCustomLocale = useI18nStore((s) => s.updateCustomLocale)
   const t = useI18nStore((s) => s.t)
 
   const enTranslations = useMemo(() => getLocale('en')?.translations ?? {}, [])
   const allKeys = useMemo(() => Object.keys(enTranslations).sort(), [enTranslations])
 
-  const [name, setName] = useState(() => `${baseLocale?.name ?? 'Custom'} (Custom)`)
+  const [name, setName] = useState(() => isEditingCustom ? (baseLocale?.name ?? 'Custom') : `${baseLocale?.name ?? 'Custom'} (Custom)`)
   const [translations, setTranslations] = useState<Record<string, string>>(
     () => ({ ...enTranslations, ...baseLocale?.translations }),
   )
@@ -81,8 +83,13 @@ export function LocaleEditor({ baseLocaleId, onClose }: LocaleEditorProps) {
   }
 
   const handleSave = () => {
-    const newId = importLocale({ name, translations })
-    setLocale(newId)
+    if (isEditingCustom) {
+      updateCustomLocale(baseLocaleId, { name, translations })
+      setLocale(baseLocaleId)
+    } else {
+      const newId = importLocale({ name, translations })
+      setLocale(newId)
+    }
     onClose()
   }
 

--- a/spa/src/components/settings/ThemeEditor.test.tsx
+++ b/spa/src/components/settings/ThemeEditor.test.tsx
@@ -117,4 +117,29 @@ describe('ThemeEditor', () => {
     // Token label should now be hidden
     expect(screen.queryByText('Primary Background')).toBeNull()
   })
+
+  it('save updates existing custom theme in-place', () => {
+    // First create a custom theme
+    const customId = useThemeStore.getState().createCustomTheme('My Theme', 'dark', {})
+    useThemeStore.setState({ activeThemeId: customId })
+
+    const onClose = vi.fn()
+    render(<ThemeEditor baseThemeId={customId} onClose={onClose} />)
+
+    // Change name
+    const nameInput = screen.getByLabelText('Theme name')
+    fireEvent.change(nameInput, { target: { value: 'Updated Theme' } })
+
+    // Save
+    fireEvent.click(screen.getByLabelText('Save theme'))
+
+    // Should have updated in-place, not created a new entry
+    const state = useThemeStore.getState()
+    const customIds = Object.keys(state.customThemes)
+    expect(customIds.length).toBe(1)
+    expect(customIds[0]).toBe(customId)
+    expect(state.customThemes[customId].name).toBe('Updated Theme')
+    expect(state.activeThemeId).toBe(customId)
+    expect(onClose).toHaveBeenCalled()
+  })
 })

--- a/spa/src/components/settings/ThemeEditor.tsx
+++ b/spa/src/components/settings/ThemeEditor.tsx
@@ -56,9 +56,11 @@ export function ThemeEditor({ baseThemeId, onClose }: ThemeEditorProps) {
   const baseTheme = getTheme(baseThemeId)
   const createCustomTheme = useThemeStore((s) => s.createCustomTheme)
   const setActiveTheme = useThemeStore((s) => s.setActiveTheme)
+  const isEditingCustom = useThemeStore((s) => baseThemeId in s.customThemes)
+  const updateCustomTheme = useThemeStore((s) => s.updateCustomTheme)
   const t = useI18nStore((s) => s.t)
 
-  const [name, setName] = useState(() => `${baseTheme?.name ?? 'Custom'} (Custom)`)
+  const [name, setName] = useState(() => isEditingCustom ? (baseTheme?.name ?? 'Custom') : `${baseTheme?.name ?? 'Custom'} (Custom)`)
   const [tokens, setTokens] = useState<ThemeTokens>(() => ({ ...baseTheme!.tokens }))
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
   const styleRef = useRef<HTMLStyleElement | null>(null)
@@ -113,8 +115,13 @@ export function ThemeEditor({ baseThemeId, onClose }: ThemeEditorProps) {
       }
     }
 
-    const newId = createCustomTheme(name, baseThemeId, overrides)
-    setActiveTheme(newId)
+    if (isEditingCustom) {
+      updateCustomTheme(baseThemeId, { name, tokens })
+      setActiveTheme(baseThemeId)
+    } else {
+      const newId = createCustomTheme(name, baseThemeId, overrides)
+      setActiveTheme(newId)
+    }
     savedRef.current = true
     onClose()
   }


### PR DESCRIPTION
## Summary
- LocaleEditor / ThemeEditor 編輯 custom entry 時改用 `updateCustomLocale` / `updateCustomTheme` 就地更新，不再重複建立新項目
- Builtin entry 仍維持 fork 行為（建立新 custom entry）
- 編輯 custom entry 時 name 初始值直接使用現有名稱，不附加 "(Custom)" 後綴

Closes #74

## Test plan
- [x] 新增 `LocaleEditor.test.tsx`（3 tests: fork builtin / update custom / name init）
- [x] 擴充 `ThemeEditor.test.tsx`（1 test: update custom in-place）
- [x] 全部 1233 tests 通過
- [ ] 手動測試：開啟 Settings → Appearance → 自訂 theme/locale → 編輯 → Save → 確認無重複項