### PR TITLE
fix: dev update uses config repo_root instead of os.Getwd() (#79)

### DIFF
--- a/cmd/pdx/main.go
+++ b/cmd/pdx/main.go
@@ -153,8 +153,11 @@ func runServe(args []string) {
 	c.AddModule(files.New())
 	c.AddModule(logs.New())
 	if c.Cfg.Dev.Update {
-		wd, _ := os.Getwd()
-		c.AddModule(dev.New(wd))
+		repoRoot := c.Cfg.Dev.RepoRoot
+		if repoRoot == "" {
+			repoRoot, _ = os.Getwd()
+		}
+		c.AddModule(dev.New(repoRoot))
 	}
 
 	// 6. Init all modules

--- a/cmd/pdx/main.go
+++ b/cmd/pdx/main.go
@@ -155,7 +155,11 @@ func runServe(args []string) {
 	if c.Cfg.Dev.Update {
 		repoRoot := c.Cfg.Dev.RepoRoot
 		if repoRoot == "" {
-			repoRoot, _ = os.Getwd()
+			wd, err := os.Getwd()
+			if err != nil {
+				log.Fatalf("dev module: cannot determine repo root: %v", err)
+			}
+			repoRoot = wd
 		}
 		c.AddModule(dev.New(repoRoot))
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,7 +28,8 @@ type FeaturesConfig struct {
 }
 
 type DevConfig struct {
-	Update bool `toml:"update" json:"update"`
+	Update   bool   `toml:"update"    json:"update"`
+	RepoRoot string `toml:"repo_root" json:"repo_root"`
 }
 
 type TerminalConfig struct {


### PR DESCRIPTION
## Summary
- `DevConfig` 新增 `RepoRoot string` 欄位（`repo_root`），daemon 從非 repo 目錄啟動時可透過 config 指定正確的 repo 路徑
- `cmd/pdx/main.go` 改用 `c.Cfg.Dev.RepoRoot`，空值 fallback 到 `os.Getwd()`（向下相容）

Closes #79

## Test plan
- [x] `go build ./...` 通過
- [x] `go test ./internal/config/ ./internal/module/dev/` 通過
- [ ] 手動測試：config 設定 `repo_root`，從非 repo 目錄啟動 daemon，驗證 dev update 功能正常