### PR TITLE
fix: buffer tar.gz to prevent corrupted download on walk error (#82)

### DIFF
--- a/internal/module/dev/handler.go
+++ b/internal/module/dev/handler.go
@@ -2,6 +2,7 @@ package dev
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"io"
@@ -96,15 +97,12 @@ func (m *DevModule) handleDownload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/gzip")
-	w.Header().Set("Content-Disposition", "attachment; filename=\"out.tar.gz\"")
-
-	gw := gzip.NewWriter(w)
-	defer gw.Close()
+	// Buffer the tar.gz in memory so we can return an error status if Walk fails
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gw)
-	defer tw.Close()
 
-	err := filepath.Walk(outDir, func(path string, info os.FileInfo, err error) error {
+	walkErr := filepath.Walk(outDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -155,8 +153,15 @@ func (m *DevModule) handleDownload(w http.ResponseWriter, r *http.Request) {
 		return err
 	})
 
-	if err != nil {
-		// Headers already sent; nothing we can do about the status code
+	tw.Close()
+	gw.Close()
+
+	if walkErr != nil {
+		http.Error(w, "tar creation failed: "+walkErr.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", "attachment; filename=\"out.tar.gz\"")
+	w.Write(buf.Bytes())
 }

--- a/internal/module/dev/handler_test.go
+++ b/internal/module/dev/handler_test.go
@@ -94,6 +94,29 @@ func TestHandleDownloadIncludesRenderer(t *testing.T) {
 	}
 }
 
+func TestHandleDownloadWalkError(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create out/main/ but make a file unreadable to trigger walk error
+	outMain := filepath.Join(dir, "out", "main")
+	os.MkdirAll(outMain, 0755)
+	badFile := filepath.Join(outMain, "index.mjs")
+	os.WriteFile(badFile, []byte("// main"), 0644)
+	// Remove read permission to trigger an error during io.Copy
+	os.Chmod(badFile, 0000)
+	defer os.Chmod(badFile, 0644) // cleanup
+
+	m := &DevModule{repoRoot: dir}
+
+	req := httptest.NewRequest("GET", "/api/dev/update/download", nil)
+	w := httptest.NewRecorder()
+	m.handleDownload(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status: want 500, got %d", w.Code)
+	}
+}
+
 func TestHandleDownloadMissingOut(t *testing.T) {
 	dir := t.TempDir() // no out/ directory
 


### PR DESCRIPTION
## Summary
- `handleDownload` 改為先將 tar.gz 寫入 `bytes.Buffer`，Walk 成功才送出 HTTP 200
- Walk 失敗時回傳 HTTP 500（之前是靜默產出損壞的 tar.gz）
- 新增 `TestHandleDownloadWalkError` 測試

Closes #82

## Test plan
- [x] `go build ./...` 通過
- [x] `go test ./internal/module/dev/` — 7 tests 全部通過
- [x] 新增 walk error 測試驗證回傳 500