### PR TITLE
refactor: unify closeTab callers with centralized locked guard (#217)

### DIFF
--- a/spa/src/components/TerminatedPane.tsx
+++ b/spa/src/components/TerminatedPane.tsx
@@ -1,8 +1,7 @@
 import { SmileySad } from '@phosphor-icons/react'
 import { useTabStore } from '../stores/useTabStore'
-import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { useI18nStore } from '../stores/useI18nStore'
-import { destroyBrowserViewIfNeeded } from '../lib/browser-cleanup'
+import { closeTab } from '../lib/tab-lifecycle'
 import { SessionPickerList } from './SessionPickerList'
 import type { PaneContent, TerminatedReason } from '../types/tab'
 
@@ -20,7 +19,6 @@ const REASON_KEYS: Record<TerminatedReason, { title: string; desc: string }> = {
 
 export function TerminatedPane({ content, tabId, paneId }: Props) {
   const t = useI18nStore((s) => s.t)
-  const closeTabInWorkspace = useWorkspaceStore((s) => s.closeTabInWorkspace)
   const setPaneContent = useTabStore((s) => s.setPaneContent)
   const reason = content.terminated!
   const keys = REASON_KEYS[reason]
@@ -42,9 +40,7 @@ export function TerminatedPane({ content, tabId, paneId }: Props) {
       <h2 className="text-lg font-medium text-zinc-300 mb-1">{t(keys.title)}</h2>
       <p className="text-sm text-zinc-500 mb-6">{t(keys.desc, { name: content.cachedName })}</p>
       <button className="text-sm text-zinc-400 hover:text-zinc-200 mb-8" onClick={() => {
-        const tab = useTabStore.getState().tabs[tabId]
-        if (tab) destroyBrowserViewIfNeeded(tab)
-        closeTabInWorkspace(tabId)
+        closeTab(tabId)
       }}>
         {t('terminated.close_tab')}
       </button>

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
@@ -5,6 +5,7 @@ import { useTabStore } from '../../../stores/useTabStore'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { getPrimaryPane } from '../../../lib/pane-tree'
 import { getPaneLabel } from '../../../lib/pane-labels'
+import { closeTab } from '../../../lib/tab-lifecycle'
 import { WorkspaceIcon } from './WorkspaceIcon'
 
 import { WorkspaceIconPicker } from './WorkspaceIconPicker'
@@ -135,11 +136,10 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
               workspaceName={ws.name}
               tabs={tabItems}
               onConfirm={(closedTabIds) => {
-                const wsStore = useWorkspaceStore.getState()
                 closedTabIds.forEach((id) => {
-                  wsStore.closeTabInWorkspace(id)
+                  closeTab(id)
                 })
-                wsStore.removeWorkspace(workspaceId)
+                useWorkspaceStore.getState().removeWorkspace(workspaceId)
                 const hasPreservedTabs = closedTabIds.length < tabItems.length
                 if (hasPreservedTabs) {
                   useWorkspaceStore.getState().setActiveWorkspace(null)

--- a/spa/src/features/workspace/hooks.ts
+++ b/spa/src/features/workspace/hooks.ts
@@ -4,7 +4,7 @@ import { useWorkspaceStore } from './store'
 import { createTab } from '../../types/tab'
 import { getPrimaryPane } from '../../lib/pane-tree'
 import { renameSession } from '../../lib/host-api'
-import { destroyBrowserViewIfNeeded } from '../../lib/browser-cleanup'
+import { closeTab } from '../../lib/tab-lifecycle'
 import type { Tab, PaneContent } from '../../types/tab'
 import type { ContextMenuAction } from '../../components/TabContextMenu'
 
@@ -46,17 +46,14 @@ export function useTabWorkspaceActions(displayTabs: Tab[]) {
   }, [setActiveTab, findWorkspaceByTab, setActiveWorkspace, setWorkspaceActiveTab])
 
   const handleCloseTab = useCallback((tabId: string) => {
-    const tab = tabs[tabId]
-    if (!tab || tab.locked) return
-    destroyBrowserViewIfNeeded(tab)
-    useWorkspaceStore.getState().closeTabInWorkspace(tabId)
+    closeTab(tabId)
 
     // Clear rename popover if the renamed tab was closed
     if (renameTarget?.tabId === tabId) {
       setRenameTarget(null)
       setRenameError(undefined)
     }
-  }, [tabs, renameTarget])
+  }, [renameTarget])
 
   const handleAddTab = useCallback(() => {
     const tab = createTab({ kind: 'new-tab' })

--- a/spa/src/hooks/useShortcuts.ts
+++ b/spa/src/hooks/useShortcuts.ts
@@ -4,7 +4,7 @@ import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { useHistoryStore } from '../stores/useHistoryStore'
 import { createTab } from '../types/tab'
 import { getVisibleTabIds as getVisibleTabIdsShared } from '../features/workspace'
-import { destroyBrowserViewIfNeeded } from '../lib/browser-cleanup'
+import { closeTab } from '../lib/tab-lifecycle'
 import { getTabShortcutHandler } from '../lib/tab-shortcut-registry'
 import { getPrimaryPane } from '../lib/pane-tree'
 
@@ -58,12 +58,9 @@ export function useShortcuts(): void {
       }
 
       if (action === 'close-tab') {
-        const { activeTabId, tabs } = tabState
+        const { activeTabId } = tabState
         if (!activeTabId || !visibleIds.includes(activeTabId)) return
-        const tab = tabs[activeTabId]
-        if (!tab || tab.locked) return
-        destroyBrowserViewIfNeeded(tab)
-        useWorkspaceStore.getState().closeTabInWorkspace(activeTabId)
+        closeTab(activeTabId)
         return
       }
 

--- a/spa/src/lib/tab-lifecycle.test.ts
+++ b/spa/src/lib/tab-lifecycle.test.ts
@@ -1,0 +1,83 @@
+// spa/src/lib/tab-lifecycle.test.ts — Tests for unified closeTab helper
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useTabStore } from '../stores/useTabStore'
+import { useHistoryStore } from '../stores/useHistoryStore'
+import { useWorkspaceStore } from '../features/workspace/store'
+import { createTab } from '../types/tab'
+import { closeTab } from './tab-lifecycle'
+
+function resetStores() {
+  useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+  useHistoryStore.setState({ browseHistory: [], closedTabs: [] })
+  useWorkspaceStore.getState().reset()
+}
+
+describe('closeTab', () => {
+  beforeEach(() => {
+    resetStores()
+    // @ts-expect-error -- test-only partial mock
+    window.electronAPI = { destroyBrowserView: vi.fn() }
+  })
+
+  afterEach(() => {
+    // @ts-expect-error -- cleanup
+    delete window.electronAPI
+  })
+
+  it('closes an unlocked tab', () => {
+    const tab = createTab({ kind: 'new-tab' })
+    useTabStore.getState().addTab(tab)
+    expect(useTabStore.getState().tabs[tab.id]).toBeDefined()
+
+    closeTab(tab.id)
+
+    expect(useTabStore.getState().tabs[tab.id]).toBeUndefined()
+  })
+
+  it('calls destroyBrowserViewIfNeeded for browser tabs', () => {
+    const tab = createTab({ kind: 'browser', url: 'https://example.com' })
+    useTabStore.getState().addTab(tab)
+
+    closeTab(tab.id)
+
+    const paneId = tab.layout.type === 'leaf' ? tab.layout.pane.id : ''
+    expect(window.electronAPI?.destroyBrowserView).toHaveBeenCalledWith(paneId)
+  })
+
+  it('does not close a locked tab', () => {
+    const tab = createTab({ kind: 'new-tab' })
+    useTabStore.getState().addTab(tab)
+    useTabStore.getState().toggleLock(tab.id)
+    expect(useTabStore.getState().tabs[tab.id]?.locked).toBe(true)
+
+    closeTab(tab.id)
+
+    expect(useTabStore.getState().tabs[tab.id]).toBeDefined()
+  })
+
+  it('does nothing for nonexistent tabId', () => {
+    // Should not throw
+    expect(() => closeTab('nonexistent')).not.toThrow()
+  })
+
+  it('forwards skipHistory option', () => {
+    const tab = createTab({ kind: 'new-tab' })
+    useTabStore.getState().addTab(tab)
+
+    closeTab(tab.id, { skipHistory: true })
+
+    // Tab should be removed
+    expect(useTabStore.getState().tabs[tab.id]).toBeUndefined()
+    // History should NOT have a record
+    expect(useHistoryStore.getState().closedTabs).toHaveLength(0)
+  })
+
+  it('records to history by default', () => {
+    const tab = createTab({ kind: 'new-tab' })
+    useTabStore.getState().addTab(tab)
+
+    closeTab(tab.id)
+
+    expect(useHistoryStore.getState().closedTabs).toHaveLength(1)
+  })
+})

--- a/spa/src/lib/tab-lifecycle.ts
+++ b/spa/src/lib/tab-lifecycle.ts
@@ -1,0 +1,10 @@
+import { useTabStore } from '../stores/useTabStore'
+import { useWorkspaceStore } from '../features/workspace/store'
+import { destroyBrowserViewIfNeeded } from './browser-cleanup'
+
+export function closeTab(tabId: string, opts?: { skipHistory?: boolean }): void {
+  const tab = useTabStore.getState().tabs[tabId]
+  if (!tab || tab.locked) return
+  destroyBrowserViewIfNeeded(tab)
+  useWorkspaceStore.getState().closeTabInWorkspace(tabId, opts)
+}


### PR DESCRIPTION
## Summary

- 建立 `closeTab()` helper（`spa/src/lib/tab-lifecycle.ts`），統一 locked guard + `destroyBrowserViewIfNeeded` 呼叫
- 遷移 4 個 caller：`useShortcuts.ts`、`hooks.ts`、`TerminatedPane.tsx`、`WorkspaceSettingsPage.tsx`
- 修復 `WorkspaceSettingsPage` 刪除 workspace 時 browser tab 的 BrowserView 洩漏
- `host-lifecycle.ts` 刻意排除（只處理 tmux-session tab，destroyBrowserViewIfNeeded 為 no-op）

## Test plan

- [x] 新增 6 個單元測試（unlocked close、browser view cleanup、locked guard、nonexistent tab、skipHistory、default history）
- [x] 全部 1239 測試通過
- [x] Lint 無錯誤

Closes #217