### PR TITLE
fix: merge window list shows fallback when title is empty (#220)

### DIFF
--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -114,7 +114,7 @@ export class WindowManager {
     const excludeWin = excludeWebContents ? BrowserWindow.fromWebContents(excludeWebContents) : null
     return Array.from(this.windows.entries())
       .filter(([, win]) => !win.isDestroyed() && win !== excludeWin)
-      .map(([id, win]) => ({ id, title: win.getTitle() }))
+      .map(([id, win]) => ({ id, title: win.getTitle() || 'Purdex' }))
   }
 
   getAllWindows(): BrowserWindow[] {

--- a/spa/src/features/workspace/components/WorkspaceContextMenu.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceContextMenu.test.tsx
@@ -172,6 +172,29 @@ describe('WorkspaceContextMenu', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('shows fallback label when window title is empty', async () => {
+    Object.defineProperty(window, 'electronAPI', {
+      value: {
+        getWindows: vi.fn().mockResolvedValue([
+          { id: 'win-abc', title: '' },
+        ]),
+      },
+      writable: true,
+      configurable: true,
+    })
+    render(
+      <WorkspaceContextMenu
+        position={{ x: 100, y: 200 }}
+        onSettings={vi.fn()}
+        onClose={vi.fn()}
+        onMergeTo={vi.fn()}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('win-abc')).toBeInTheDocument()
+    })
+  })
+
   it('calls onMergeTo with windowId when merge target clicked', async () => {
     Object.defineProperty(window, 'electronAPI', {
       value: {

--- a/spa/src/features/workspace/components/WorkspaceContextMenu.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceContextMenu.test.tsx
@@ -191,7 +191,7 @@ describe('WorkspaceContextMenu', () => {
       />,
     )
     await waitFor(() => {
-      expect(screen.getByText('win-abc')).toBeInTheDocument()
+      expect(screen.getByText('Purdex')).toBeInTheDocument()
     })
   })
 

--- a/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
+++ b/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
@@ -92,7 +92,7 @@ export function WorkspaceContextMenu({ position, onSettings, onTearOff, onMergeT
                 onClick={() => { onMergeTo!(win.id); onClose() }}
                 className="w-full flex items-center gap-2 pl-8 pr-3 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-surface-hover cursor-pointer transition-colors"
               >
-                {win.title || win.id}
+                {win.title || 'Purdex'}
               </button>
             ))}
           </>

--- a/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
+++ b/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
@@ -92,7 +92,7 @@ export function WorkspaceContextMenu({ position, onSettings, onTearOff, onMergeT
                 onClick={() => { onMergeTo!(win.id); onClose() }}
                 className="w-full flex items-center gap-2 pl-8 pr-3 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-surface-hover cursor-pointer transition-colors"
               >
-                {win.title}
+                {win.title || win.id}
               </button>
             ))}
           </>


### PR DESCRIPTION
## Summary

- **Electron**: `window-manager.ts` `getAll()` 加 `'Purdex'` fallback，SPA 未載入完成時不再回傳空字串
- **SPA**: `WorkspaceContextMenu.tsx` 加防禦性 `win.id` fallback
- 新增 1 個測試驗證空 title 情境

## Test plan

- [x] 新增空 title fallback 測試
- [x] 全部 1240 測試通過
- [x] Lint 無錯誤

Closes #220