### PR TITLE
feat(daemon): add 5-minute timeout to dev auto-build (#97)

### DIFF
--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -2,6 +2,7 @@ package dev
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/wake/purdex/internal/core"
 )
@@ -69,10 +71,15 @@ func (m *DevModule) runBuild() {
 }
 
 func (m *DevModule) defaultBuild() error {
-	cmd := exec.Command("pnpm", "exec", "electron-vite", "build")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "pnpm", "exec", "electron-vite", "build")
 	cmd.Dir = m.repoRoot
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("build timed out after 5 minutes")
+		}
 		log.Printf("[dev] build output: %s", string(out))
 		return err
 	}

--- a/internal/module/dev/module_test.go
+++ b/internal/module/dev/module_test.go
@@ -1,0 +1,64 @@
+package dev
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunBuild_Success(t *testing.T) {
+	m := &DevModule{
+		repoRoot: t.TempDir(),
+		buildCmd: func() error { return nil },
+		building: true,
+	}
+	// Create out/ dir so .build-info.json removal doesn't fail
+	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
+
+	m.runBuild()
+
+	if m.building {
+		t.Error("building: want false after successful build")
+	}
+	if m.buildError != "" {
+		t.Errorf("buildError: want empty, got %q", m.buildError)
+	}
+}
+
+func TestRunBuild_Failure(t *testing.T) {
+	m := &DevModule{
+		repoRoot: t.TempDir(),
+		buildCmd: func() error { return fmt.Errorf("build timed out after 5 minutes") },
+		building: true,
+	}
+	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
+
+	m.runBuild()
+
+	if m.building {
+		t.Error("building: want false after failed build")
+	}
+	if m.buildError == "" {
+		t.Error("buildError: want non-empty after failed build")
+	}
+	if m.buildError != "build timed out after 5 minutes" {
+		t.Errorf("buildError: want timeout message, got %q", m.buildError)
+	}
+}
+
+func TestRunBuild_ClearsErrorOnSuccess(t *testing.T) {
+	m := &DevModule{
+		repoRoot:   t.TempDir(),
+		buildCmd:    func() error { return nil },
+		building:   true,
+		buildError: "previous error",
+	}
+	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
+
+	m.runBuild()
+
+	if m.buildError != "" {
+		t.Errorf("buildError: want empty after success, got %q", m.buildError)
+	}
+}


### PR DESCRIPTION
## Summary

- `defaultBuild()` 改用 `exec.CommandContext` + `context.WithTimeout(5min)`
- Timeout 觸發時回傳明確 error message `"build timed out after 5 minutes"`
- 新增 3 個 `runBuild` 單元測試（成功、失敗、清除舊 error）

## Test plan

- [x] 新增 3 個 Go 測試，全部通過
- [x] 全部 Go 測試通過（20 packages）
- [x] 不影響現有 `buildCmd` mock 測試

Closes #97