### PR TITLE
fix(daemon): Stop() cancels in-progress build goroutine (#99)

### DIFF
--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -26,6 +26,8 @@ type DevModule struct {
 	buildCmd           func() error
 	lastFailedSPA      string
 	lastFailedElectron string
+	stopCtx            context.Context
+	stopCancel         context.CancelFunc
 }
 
 func New(repoRoot string) *DevModule {
@@ -71,7 +73,11 @@ func (m *DevModule) runBuild() {
 }
 
 func (m *DevModule) defaultBuild() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	parent := m.stopCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, 5*time.Minute)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "pnpm", "exec", "electron-vite", "build")
 	cmd.Dir = m.repoRoot
@@ -92,11 +98,17 @@ func (m *DevModule) RegisterRoutes(mux *http.ServeMux) {
 }
 
 func (m *DevModule) Start(_ context.Context) error {
+	m.stopCtx, m.stopCancel = context.WithCancel(context.Background())
 	log.Println("[dev] update endpoints enabled")
 	return nil
 }
 
-func (m *DevModule) Stop(_ context.Context) error { return nil }
+func (m *DevModule) Stop(_ context.Context) error {
+	if m.stopCancel != nil {
+		m.stopCancel()
+	}
+	return nil
+}
 
 func (m *DevModule) gitHash(paths ...string) string {
 	args := append([]string{"log", "-1", "--format=%h", "--"}, paths...)

--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -43,6 +43,7 @@ func (m *DevModule) Dependencies() []string { return nil }
 
 func (m *DevModule) Init(c *core.Core) error {
 	m.core = c
+	m.stopCtx, m.stopCancel = context.WithCancel(context.Background())
 	if m.hashFn == nil {
 		m.hashFn = m.gitHash
 	}
@@ -98,7 +99,6 @@ func (m *DevModule) RegisterRoutes(mux *http.ServeMux) {
 }
 
 func (m *DevModule) Start(_ context.Context) error {
-	m.stopCtx, m.stopCancel = context.WithCancel(context.Background())
 	log.Println("[dev] update endpoints enabled")
 	return nil
 }

--- a/internal/module/dev/module_test.go
+++ b/internal/module/dev/module_test.go
@@ -1,10 +1,12 @@
 package dev
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestRunBuild_Success(t *testing.T) {
@@ -44,6 +46,50 @@ func TestRunBuild_Failure(t *testing.T) {
 	}
 	if m.buildError != "build timed out after 5 minutes" {
 		t.Errorf("buildError: want timeout message, got %q", m.buildError)
+	}
+}
+
+func TestStop_CancelsBuild(t *testing.T) {
+	buildStarted := make(chan struct{})
+	m := &DevModule{
+		repoRoot: t.TempDir(),
+		building: true,
+	}
+	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
+
+	// Start lifecycle
+	m.Start(context.Background())
+
+	// Mock buildCmd that blocks until stopCtx is cancelled
+	m.buildCmd = func() error {
+		close(buildStarted)
+		<-m.stopCtx.Done()
+		return m.stopCtx.Err()
+	}
+
+	// Run build in goroutine
+	done := make(chan struct{})
+	go func() {
+		m.runBuild()
+		close(done)
+	}()
+
+	// Wait for build to start
+	<-buildStarted
+
+	// Stop should cancel the build
+	m.Stop(context.Background())
+
+	// Build goroutine should finish quickly
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("build goroutine did not finish after Stop()")
+	}
+
+	if m.building {
+		t.Error("building: want false after Stop()")
 	}
 }
 

--- a/internal/module/dev/module_test.go
+++ b/internal/module/dev/module_test.go
@@ -57,8 +57,8 @@ func TestStop_CancelsBuild(t *testing.T) {
 	}
 	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
 
-	// Start lifecycle
-	m.Start(context.Background())
+	// Init lifecycle (creates stopCtx)
+	m.Init(nil)
 
 	// Mock buildCmd that blocks until stopCtx is cancelled
 	m.buildCmd = func() error {


### PR DESCRIPTION
## Summary

- DevModule 新增 `stopCtx` / `stopCancel` 生命週期
- `Start()` 建立 context，`Stop()` 取消 context
- `defaultBuild()` 的 timeout 從 `stopCtx` 衍生，daemon shutdown 會取消進行中的 build
- 新增 `TestStop_CancelsBuild` 驗證 Stop 取消行為

## Test plan

- [x] 新增 1 個 Go 測試（Stop 取消 build goroutine）
- [x] 全部 20 個 Go package 測試通過

Closes #99