### PR TITLE
test: add HandoffButton error/waiting status test cases (#125)

### DIFF
--- a/spa/src/components/HandoffButton.test.tsx
+++ b/spa/src/components/HandoffButton.test.tsx
@@ -61,6 +61,20 @@ describe('HandoffButton', () => {
     expect(screen.getByText('Exiting CC...')).toBeInTheDocument()
   })
 
+  it('enables button when agentStatus is error', () => {
+    const fn = vi.fn()
+    render(<HandoffButton inProgress={false} agentStatus="error" onHandoff={fn} />)
+    const button = screen.getByRole('button')
+    expect(button).not.toBeDisabled()
+    fireEvent.click(button)
+    expect(fn).toHaveBeenCalled()
+  })
+
+  it('enables button when agentStatus is waiting', () => {
+    render(<HandoffButton inProgress={false} agentStatus="waiting" onHandoff={() => {}} />)
+    expect(screen.getByRole('button')).not.toBeDisabled()
+  })
+
   it('falls back to Connecting... with empty progress', () => {
     render(<HandoffButton inProgress={true} progress="" agentStatus="idle" onHandoff={() => {}} />)
     expect(screen.getByText('Connecting...')).toBeInTheDocument()


### PR DESCRIPTION
## Summary

- 新增 `agentStatus='error'` 測試：驗證按鈕 enabled 且可點擊
- 新增 `agentStatus='waiting'` 測試：驗證按鈕 enabled
- 覆蓋 `isAgentActive` 所有 truthy 分支

## Test plan

- [x] 13/13 HandoffButton 測試通過
- [x] 純測試新增，無邏輯變更

Closes #125