### PR TITLE
feat: session list real-time sync with polling + debounce cache (#128)

### DIFF
--- a/internal/module/session/handler.go
+++ b/internal/module/session/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/wake/purdex/internal/store"
 )
@@ -14,7 +15,7 @@ var nameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // --- HTTP Handlers ---
 
 func (m *SessionModule) handleList(w http.ResponseWriter, r *http.Request) {
-	sessions, err := m.ListSessions()
+	sessions, err := m.cachedListSessions()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -25,6 +26,21 @@ func (m *SessionModule) handleList(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(sessions)
+}
+
+func (m *SessionModule) cachedListSessions() ([]SessionInfo, error) {
+	m.listCacheMu.Lock()
+	defer m.listCacheMu.Unlock()
+	if time.Since(m.listCacheAt) < listCacheTTL && m.listCacheData != nil {
+		return m.listCacheData, nil
+	}
+	sessions, err := m.ListSessions()
+	if err != nil {
+		return nil, err
+	}
+	m.listCacheData = sessions
+	m.listCacheAt = time.Now()
+	return sessions, nil
 }
 
 func (m *SessionModule) handleGet(w http.ResponseWriter, r *http.Request) {

--- a/internal/module/session/handler_test.go
+++ b/internal/module/session/handler_test.go
@@ -639,6 +639,42 @@ func TestHandlerSendKeysNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+func TestHandleList_CacheDebounce(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+
+	fake.AddSession("test", "/tmp")
+
+	handler := http.HandlerFunc(mod.handleList)
+
+	// First call — fetches from tmux
+	req1 := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first call: want 200, got %d", w1.Code)
+	}
+	// ListSessions is called once by handleList, but also internally by
+	// ListSessions → listSessions which may call tmux.ListSessions.
+	// We count tmux-level ListSessions calls via FakeExecutor.
+	firstCount := fake.ListCallCount()
+	if firstCount < 1 {
+		t.Fatalf("first call: want ≥1 tmux ListSessions calls, got %d", firstCount)
+	}
+
+	// Second call within TTL — should use cache (no additional tmux calls)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+	if fake.ListCallCount() != firstCount {
+		t.Fatalf("second call: want %d tmux calls (cached), got %d", firstCount, fake.ListCallCount())
+	}
+
+	// Verify both responses are identical
+	if w1.Body.String() != w2.Body.String() {
+		t.Error("cached response differs from original")
+	}
+}
+
 func TestHandlerTerminalWSNotFound(t *testing.T) {
 	// Setup module with no sessions
 	mod, _, _ := newTestModule(t)

--- a/internal/module/session/module.go
+++ b/internal/module/session/module.go
@@ -6,11 +6,14 @@ import (
 	"log"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/wake/purdex/internal/core"
 	"github.com/wake/purdex/internal/store"
 	"github.com/wake/purdex/internal/tmux"
 )
+
+const listCacheTTL = time.Second
 
 // SessionModule manages tmux sessions, meta cache, and HTTP API.
 type SessionModule struct {
@@ -24,6 +27,11 @@ type SessionModule struct {
 	// critical section so two concurrent POSTs with the same name can't
 	// both slip past the duplicate check. See #61.
 	createMu sync.Mutex
+
+	// listCache debounces rapid ListSessions calls (1s TTL). See #128.
+	listCacheMu   sync.Mutex
+	listCacheData []SessionInfo
+	listCacheAt   time.Time
 }
 
 // NewSessionModule creates a SessionModule with the given MetaStore.

--- a/internal/tmux/fake_executor.go
+++ b/internal/tmux/fake_executor.go
@@ -37,6 +37,7 @@ type FakeExecutor struct {
 	keysCalls            []KeysCall
 	autoResizeCalls      []string              // targets passed to ResizeWindowAuto
 	setWindowOptionCalls []SetWindowOptionCall // calls to SetWindowOption
+	listCallCount        int                   // how many times ListSessions was called
 	alive                bool                  // whether tmux server is "alive"
 	HooksOutput          string                // returned by ShowHooksGlobal
 	FailSendKeys         bool                  // if true, SendKeysRaw returns an error
@@ -75,6 +76,7 @@ func (f *FakeExecutor) AddSessionWithID(id, name, cwd string) {
 func (f *FakeExecutor) ListSessions() ([]TmuxSession, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.listCallCount++
 	out := make([]TmuxSession, 0, len(f.sessionOrder))
 	for _, name := range f.sessionOrder {
 		if s, ok := f.sessions[name]; ok {
@@ -82,6 +84,13 @@ func (f *FakeExecutor) ListSessions() ([]TmuxSession, error) {
 		}
 	}
 	return out, nil
+}
+
+// ListCallCount returns how many times ListSessions was called.
+func (f *FakeExecutor) ListCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.listCallCount
 }
 
 // NewSession creates a session with an auto-assigned ID.

--- a/spa/src/components/SessionPickerList.tsx
+++ b/spa/src/components/SessionPickerList.tsx
@@ -1,6 +1,7 @@
 import { useHostStore } from '../stores/useHostStore'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useI18nStore } from '../stores/useI18nStore'
+import { useSessionWatch } from '../hooks/useSessionWatch'
 
 export interface SessionSelection {
   hostId: string
@@ -14,6 +15,7 @@ interface Props {
 }
 
 export function SessionPickerList({ onSelect }: Props) {
+  useSessionWatch()
   const t = useI18nStore((s) => s.t)
   const hosts = useHostStore((s) => s.hosts)
   const hostOrder = useHostStore((s) => s.hostOrder)

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -1,10 +1,12 @@
 import { useSessionStore } from '../stores/useSessionStore'
 import { useHostStore } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
+import { useSessionWatch } from '../hooks/useSessionWatch'
 import type { NewTabProviderProps } from '../lib/new-tab-registry'
 import { TerminalWindow, Circle, Spinner } from '@phosphor-icons/react'
 
 export function SessionSection({ onSelect }: NewTabProviderProps) {
+  useSessionWatch()
   const sessionsMap = useSessionStore((s) => s.sessions)
   const hosts = useHostStore((s) => s.hosts)
   const hostOrder = useHostStore((s) => s.hostOrder)

--- a/spa/src/hooks/useSessionWatch.test.ts
+++ b/spa/src/hooks/useSessionWatch.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, cleanup } from '@testing-library/react'
+import { useHostStore } from '../stores/useHostStore'
+import { useSessionStore } from '../stores/useSessionStore'
+import { useSessionWatch, __resetSessionWatch } from './useSessionWatch'
+
+describe('useSessionWatch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    __resetSessionWatch()
+    useHostStore.setState({
+      hosts: { h1: { id: 'h1', name: 'Host 1', ip: '1.2.3.4', port: 7860, order: 0 } },
+      hostOrder: ['h1'],
+      runtime: { h1: { status: 'connected' } },
+    })
+    useSessionStore.setState({ sessions: {} })
+  })
+
+  afterEach(() => {
+    cleanup()
+    __resetSessionWatch()
+    vi.useRealTimers()
+  })
+
+  it('starts polling on mount and stops on unmount', () => {
+    const fetchHost = vi.spyOn(useSessionStore.getState(), 'fetchHost').mockResolvedValue(undefined)
+
+    const { unmount } = renderHook(() => useSessionWatch())
+
+    // Initial fetch on mount
+    expect(fetchHost).toHaveBeenCalledTimes(1)
+
+    // After 1s interval tick
+    vi.advanceTimersByTime(1000)
+    expect(fetchHost).toHaveBeenCalledTimes(2)
+
+    // After unmount, no more polling
+    unmount()
+    vi.advanceTimersByTime(2000)
+    expect(fetchHost).toHaveBeenCalledTimes(2)
+
+    fetchHost.mockRestore()
+  })
+
+  it('ref-counts multiple consumers', () => {
+    const fetchHost = vi.spyOn(useSessionStore.getState(), 'fetchHost').mockResolvedValue(undefined)
+
+    const h1 = renderHook(() => useSessionWatch())
+    const h2 = renderHook(() => useSessionWatch())
+
+    // Both mounted, but only one interval — initial fetch fires for first mount
+    expect(fetchHost).toHaveBeenCalledTimes(1)
+
+    // Unmount first — polling continues
+    h1.unmount()
+    vi.advanceTimersByTime(1000)
+    expect(fetchHost.mock.calls.length).toBeGreaterThan(1)
+
+    // Unmount second — polling stops
+    const countBefore = fetchHost.mock.calls.length
+    h2.unmount()
+    vi.advanceTimersByTime(2000)
+    expect(fetchHost).toHaveBeenCalledTimes(countBefore)
+
+    fetchHost.mockRestore()
+  })
+
+  it('skips disconnected hosts', () => {
+    useHostStore.setState({
+      hosts: {
+        h1: { id: 'h1', name: 'Host 1', ip: '1.2.3.4', port: 7860, order: 0 },
+        h2: { id: 'h2', name: 'Host 2', ip: '5.6.7.8', port: 7860, order: 1 },
+      },
+      hostOrder: ['h1', 'h2'],
+      runtime: {
+        h1: { status: 'connected' },
+        h2: { status: 'disconnected' },
+      },
+    })
+    const fetchHost = vi.spyOn(useSessionStore.getState(), 'fetchHost').mockResolvedValue(undefined)
+
+    renderHook(() => useSessionWatch())
+
+    // Only h1 (connected) should be fetched, not h2 (disconnected)
+    expect(fetchHost).toHaveBeenCalledWith('h1')
+    expect(fetchHost).not.toHaveBeenCalledWith('h2')
+
+    fetchHost.mockRestore()
+  })
+})

--- a/spa/src/hooks/useSessionWatch.ts
+++ b/spa/src/hooks/useSessionWatch.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react'
+import { useSessionStore } from '../stores/useSessionStore'
+import { useHostStore } from '../stores/useHostStore'
+
+let refCount = 0
+let intervalId: ReturnType<typeof setInterval> | null = null
+
+function start() {
+  if (intervalId !== null) return
+  // Fetch immediately on first mount
+  fetchAll()
+  intervalId = setInterval(fetchAll, 1000)
+}
+
+function stop() {
+  if (intervalId !== null) {
+    clearInterval(intervalId)
+    intervalId = null
+  }
+}
+
+function fetchAll() {
+  const { hostOrder } = useHostStore.getState()
+  const runtime = useHostStore.getState().runtime
+  const { fetchHost } = useSessionStore.getState()
+  for (const hostId of hostOrder) {
+    if (runtime[hostId]?.status === 'connected') {
+      fetchHost(hostId).catch(() => {})
+    }
+  }
+}
+
+export function useSessionWatch(): void {
+  useEffect(() => {
+    refCount++
+    if (refCount === 1) start()
+    return () => {
+      refCount--
+      if (refCount === 0) stop()
+    }
+  }, [])
+}
+
+// For testing: reset internal state
+export function __resetSessionWatch(): void {
+  stop()
+  refCount = 0
+}


### PR DESCRIPTION
## Summary

- **Daemon**: `handleList` 新增 1s TTL debounce cache，同秒內多次 poll 只執行一次 `tmux list-sessions`
- **SPA**: 新增 `useSessionWatch()` ref-counted polling hook（1s interval），僅 poll 已連線 host
- 整合到 `SessionSection` 和 `SessionPickerList`

## Test plan

- [x] Go: `TestHandleList_CacheDebounce` 驗證 TTL cache 命中
- [x] SPA: 3 個測試（mount/unmount lifecycle、ref counting、skip disconnected）
- [x] 全部 Go 測試通過（20 packages）
- [x] 全部 SPA 測試通過（137 files, 1245 tests）

Closes #128