### PR TITLE
feat(spa): add vertical viewport clamping to RenamePopover

### DIFF
--- a/spa/src/components/RenamePopover.test.tsx
+++ b/spa/src/components/RenamePopover.test.tsx
@@ -60,4 +60,73 @@ describe('RenamePopover', () => {
     render(<RenamePopover {...defaultProps} error="Rename failed" />)
     expect(screen.getByText('Rename failed')).toBeInTheDocument()
   })
+
+  describe('vertical viewport clamping', () => {
+    const PADDING = 4
+    let offsetHeightDescriptor: PropertyDescriptor | undefined
+    let innerHeightDescriptor: PropertyDescriptor | undefined
+
+    beforeEach(() => {
+      offsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')
+      innerHeightDescriptor = Object.getOwnPropertyDescriptor(window, 'innerHeight')
+    })
+
+    afterEach(() => {
+      if (offsetHeightDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', offsetHeightDescriptor)
+      }
+      if (innerHeightDescriptor) {
+        Object.defineProperty(window, 'innerHeight', innerHeightDescriptor)
+      }
+    })
+
+    it('positions popover below anchor when space is sufficient', () => {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 40 })
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 })
+      const anchor = { left: 100, top: 30, width: 120, height: 26, bottom: 56, right: 220 } as DOMRect
+      const { container } = render(<RenamePopover {...defaultProps} anchorRect={anchor} />)
+      const el = container.firstElementChild as HTMLElement
+      expect(el.style.top).toBe(`${anchor.bottom + PADDING}px`)
+    })
+
+    it('flips popover above anchor when below would overflow', () => {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 40 })
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 200 })
+      const anchor = { left: 100, top: 170, width: 120, height: 20, bottom: 190, right: 220 } as DOMRect
+      const { container } = render(<RenamePopover {...defaultProps} anchorRect={anchor} />)
+      const el = container.firstElementChild as HTMLElement
+      // anchorRect.top - PADDING - popoverHeight = 170 - 4 - 40 = 126
+      expect(el.style.top).toBe('126px')
+    })
+
+    it('clamps to PADDING when both above and below overflow', () => {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 40 })
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 50 })
+      const anchor = { left: 100, top: 10, width: 120, height: 20, bottom: 30, right: 220 } as DOMRect
+      const { container } = render(<RenamePopover {...defaultProps} anchorRect={anchor} />)
+      const el = container.firstElementChild as HTMLElement
+      // below: 30 + 4 = 34, 34 + 40 = 74 > 50 - 4 = 46 → flip
+      // above: 10 - 4 - 40 = -34 < 4 → clamp to PADDING
+      expect(el.style.top).toBe(`${PADDING}px`)
+    })
+
+    it('recalculates position when error changes popover height', () => {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 40 })
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 200 })
+      // Anchor near bottom but popover (height=40) fits below: 160 + 4 + 40 = 204 > 196 → actually flips
+      // Use anchor where height=40 fits below but height=70 does not
+      const anchor = { left: 100, top: 130, width: 120, height: 20, bottom: 150, right: 220 } as DOMRect
+      // below: 150 + 4 = 154, 154 + 40 = 194 < 200 - 4 = 196 → fits below
+      const { container, rerender } = render(<RenamePopover {...defaultProps} anchorRect={anchor} />)
+      const el = container.firstElementChild as HTMLElement
+      expect(el.style.top).toBe(`${anchor.bottom + PADDING}px`)
+
+      // Now error appears, popover grows taller
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 70 })
+      rerender(<RenamePopover {...defaultProps} anchorRect={anchor} error="Name taken" />)
+      // below: 150 + 4 = 154, 154 + 70 = 224 > 196 → flip above
+      // above: 130 - 4 - 70 = 56
+      expect(el.style.top).toBe('56px')
+    })
+  })
 })

--- a/spa/src/components/RenamePopover.test.tsx
+++ b/spa/src/components/RenamePopover.test.tsx
@@ -62,7 +62,6 @@ describe('RenamePopover', () => {
   })
 
   describe('vertical viewport clamping', () => {
-    const PADDING = 4
     let offsetHeightDescriptor: PropertyDescriptor | undefined
     let innerHeightDescriptor: PropertyDescriptor | undefined
 
@@ -86,7 +85,7 @@ describe('RenamePopover', () => {
       const anchor = { left: 100, top: 30, width: 120, height: 26, bottom: 56, right: 220 } as DOMRect
       const { container } = render(<RenamePopover {...defaultProps} anchorRect={anchor} />)
       const el = container.firstElementChild as HTMLElement
-      expect(el.style.top).toBe(`${anchor.bottom + PADDING}px`)
+      expect(el.style.top).toBe(`${anchor.bottom + 4}px`)
     })
 
     it('flips popover above anchor when below would overflow', () => {
@@ -107,7 +106,7 @@ describe('RenamePopover', () => {
       const el = container.firstElementChild as HTMLElement
       // below: 30 + 4 = 34, 34 + 40 = 74 > 50 - 4 = 46 → flip
       // above: 10 - 4 - 40 = -34 < 4 → clamp to PADDING
-      expect(el.style.top).toBe(`${PADDING}px`)
+      expect(el.style.top).toBe('4px')
     })
 
     it('recalculates position when error changes popover height', () => {
@@ -119,7 +118,7 @@ describe('RenamePopover', () => {
       // below: 150 + 4 = 154, 154 + 40 = 194 < 200 - 4 = 196 → fits below
       const { container, rerender } = render(<RenamePopover {...defaultProps} anchorRect={anchor} />)
       const el = container.firstElementChild as HTMLElement
-      expect(el.style.top).toBe(`${anchor.bottom + PADDING}px`)
+      expect(el.style.top).toBe(`${anchor.bottom + 4}px`)
 
       // Now error appears, popover grows taller
       Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 70 })

--- a/spa/src/components/RenamePopover.tsx
+++ b/spa/src/components/RenamePopover.tsx
@@ -36,12 +36,21 @@ export function RenamePopover({ anchorRect, currentName, onConfirm, onCancel, er
   useLayoutEffect(() => {
     const el = containerRef.current
     if (!el) return
+    // Horizontal clamping (existing)
     let left = anchorRect.left + anchorRect.width / 2 - POPOVER_WIDTH / 2
     left = Math.max(PADDING, Math.min(left, window.innerWidth - POPOVER_WIDTH - PADDING))
-    const top = anchorRect.bottom + PADDING
+    // Vertical clamping
+    const popoverHeight = el.offsetHeight
+    let top = anchorRect.bottom + PADDING
+    if (top + popoverHeight > window.innerHeight - PADDING) {
+      top = anchorRect.top - PADDING - popoverHeight
+    }
+    if (top < PADDING) {
+      top = PADDING
+    }
     el.style.left = `${left}px`
     el.style.top = `${top}px`
-  }, [anchorRect])
+  }, [anchorRect, error])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {


### PR DESCRIPTION
## Summary

- RenamePopover 新增垂直方向 viewport clamping，補完原本只有水平 clamping 的缺口
- 當 popover 下方空間不足時自動翻轉到 anchor 上方；上下都不夠時 clamp 到 viewport 頂部
- `error` prop 加入 `useLayoutEffect` 依賴陣列，確保 error 出現/消失引起的高度變化觸發位置重算

Closes #212

## Test plan

- [x] 新增 4 個測試案例（正常下方、翻轉上方、極端 clamp、error 重算）
- [x] 既有 7 個測試全部通過
- [x] Lint 無新增錯誤