### PR TITLE
feat(spa): show unread count in workspace tooltip

### DIFF
--- a/spa/src/features/workspace/components/ActivityBar.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.test.tsx
@@ -267,4 +267,28 @@ describe('ActivityBar', () => {
 
     expect(screen.getByLabelText('Server, running')).toBeTruthy()
   })
+
+  it('shows unread count in tooltip on inactive workspace', () => {
+    useTabStore.setState({
+      tabs: { t3: mockSessionTab('t3', 'h1', 's3') },
+    })
+    useAgentStore.setState({ unread: { 'h1:s3': true } })
+
+    render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
+
+    expect(screen.getByText('Server (1 unread)')).toBeTruthy()
+  })
+
+  it('tooltip shows only name when no unread and no status', () => {
+    useTabStore.setState({
+      tabs: { t3: mockSessionTab('t3', 'h1', 's3') },
+    })
+    useAgentStore.setState({ unread: {}, statuses: {} })
+
+    render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
+
+    const tooltips = screen.getAllByTestId('ws-tooltip')
+    const serverTooltip = tooltips.find(el => el.textContent === 'Server')
+    expect(serverTooltip).toBeTruthy()
+  })
 })

--- a/spa/src/features/workspace/components/ActivityBar.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.test.tsx
@@ -257,7 +257,7 @@ describe('ActivityBar', () => {
     expect(statusDot!.className).not.toContain('animate-breathe')
   })
 
-  it('includes status in aria-label', () => {
+  it('includes status in aria-label for inactive workspace', () => {
     useTabStore.setState({
       tabs: { t3: mockSessionTab('t3', 'h1', 's3') },
     })
@@ -266,6 +266,17 @@ describe('ActivityBar', () => {
     render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
 
     expect(screen.getByLabelText('Server, running')).toBeTruthy()
+  })
+
+  it('excludes status from aria-label for active workspace', () => {
+    useTabStore.setState({
+      tabs: { t1: mockSessionTab('t1', 'h1', 's1') },
+    })
+    useAgentStore.setState({ statuses: { 'h1:s1': 'running' } })
+
+    render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" />)
+
+    expect(screen.getByLabelText('Project A')).toBeTruthy()
   })
 
   it('shows unread count in tooltip on inactive workspace', () => {

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -58,7 +58,7 @@ function SortableWorkspaceButton({ workspace: ws, isActive, onSelect, onContextM
         aria-label={[
           ws.name,
           showBadge && `${unreadCount} unread`,
-          aggregatedStatus && aggregatedStatus,
+          aggregatedStatus && !isActive && aggregatedStatus,
         ].filter(Boolean).join(', ')}
         onClick={() => onSelect(ws.id)}
         onContextMenu={(e) => {

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -23,6 +23,11 @@ function SortableWorkspaceButton({ workspace: ws, isActive, onSelect, onContextM
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: ws.id })
   const { unreadCount, aggregatedStatus } = useWorkspaceIndicators(ws.tabs)
   const showBadge = !isActive && unreadCount > 0
+  const tooltipExtras = [
+    showBadge && `${unreadCount} unread`,
+    aggregatedStatus && !isActive && aggregatedStatus,
+  ].filter(Boolean)
+  const tooltipText = tooltipExtras.length > 0 ? `${ws.name} (${tooltipExtras.join(', ')})` : ws.name
 
   const style = {
     transform: transform ? `translate3d(0, ${Math.round(transform.y)}px, 0)` : undefined,
@@ -77,8 +82,8 @@ function SortableWorkspaceButton({ workspace: ws, isActive, onSelect, onContextM
           {unreadCount}
         </span>
       )}
-      <span className="pointer-events-none absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50">
-        {ws.name}
+      <span data-testid="ws-tooltip" className="pointer-events-none absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50">
+        {tooltipText}
       </span>
     </div>
   )


### PR DESCRIPTION
## Summary

- Workspace button tooltip 從只顯示名稱改為與 aria-label 一致，含 unread count 和 agent status
- 格式：`"Name (N unread, status)"`，無額外資訊時只顯示 `"Name"`
- 新增 `data-testid="ws-tooltip"` 方便測試選取

Closes #228

## Test plan

- [x] 新增 2 個測試（tooltip 含 unread、tooltip 只有名稱）
- [x] 既有 19 個測試全部通過
- [x] Lint 無新增錯誤