### PR TITLE
fix(spa): truncate ActivityBar badge to 99+

### DIFF
--- a/spa/src/features/workspace/components/ActivityBar.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.test.tsx
@@ -292,6 +292,44 @@ describe('ActivityBar', () => {
     expect(screen.getByText('Server (1 unread)')).toBeTruthy()
   })
 
+  it('truncates workspace badge to 99+ when unread count exceeds 99', () => {
+    // Create 100 tabs in ws-2 with unique sessions, all unread
+    const tabIds = Array.from({ length: 100 }, (_, i) => `t-${i}`)
+    const tabs: Record<string, Tab> = {}
+    const unread: Record<string, boolean> = {}
+    tabIds.forEach((id, i) => {
+      tabs[id] = mockSessionTab(id, 'h1', `s${i}`)
+      unread[`h1:s${i}`] = true
+    })
+    const workspaces: Workspace[] = [
+      { id: 'ws-1', name: 'Active', icon: '🔧', tabs: ['t1'], activeTabId: 't1' },
+      { id: 'ws-2', name: 'Big', icon: '🖥', tabs: tabIds, activeTabId: tabIds[0] },
+    ]
+    tabs.t1 = mockSessionTab('t1', 'h1', 'active-s')
+    useTabStore.setState({ tabs })
+    useAgentStore.setState({ unread })
+
+    render(<ActivityBar {...defaultProps} workspaces={workspaces} activeWorkspaceId="ws-1" />)
+    const badge = screen.getByTestId('ws-unread-badge')
+    expect(badge.textContent).toBe('99+')
+  })
+
+  it('truncates Home badge to 99+ when unread count exceeds 99', () => {
+    const tabIds = Array.from({ length: 100 }, (_, i) => `sh-${i}`)
+    const tabs: Record<string, Tab> = {}
+    const unread: Record<string, boolean> = {}
+    tabIds.forEach((id, i) => {
+      tabs[id] = mockSessionTab(id, 'h1', `hs${i}`)
+      unread[`h1:hs${i}`] = true
+    })
+    useTabStore.setState({ tabs })
+    useAgentStore.setState({ unread })
+
+    render(<ActivityBar {...defaultProps} activeWorkspaceId="ws-1" standaloneTabIds={tabIds} />)
+    const badge = screen.getByTestId('home-unread-badge')
+    expect(badge.textContent).toBe('99+')
+  })
+
   it('tooltip shows only name when no unread and no status', () => {
     useTabStore.setState({
       tabs: { t3: mockSessionTab('t3', 'h1', 's3') },

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -79,7 +79,7 @@ function SortableWorkspaceButton({ workspace: ws, isActive, onSelect, onContextM
           className="absolute -top-[5px] -right-[6px] min-w-[15px] h-[15px] rounded-full flex items-center justify-center text-white text-[9px] font-bold px-[3px] leading-none z-10"
           style={{ backgroundColor: '#dc2626', boxShadow: '0 0 0 2px var(--surface-tertiary)' }}
         >
-          {unreadCount}
+          {unreadCount > 99 ? '99+' : unreadCount}
         </span>
       )}
       <span data-testid="ws-tooltip" className="pointer-events-none absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50">
@@ -181,7 +181,7 @@ export function ActivityBar({
             className="absolute -top-[5px] -right-[6px] min-w-[15px] h-[15px] rounded-full flex items-center justify-center text-white text-[9px] font-bold px-[3px] leading-none z-10"
             style={{ backgroundColor: '#dc2626', boxShadow: '0 0 0 2px var(--surface-tertiary)' }}
           >
-            {homeUnreadCount}
+            {homeUnreadCount > 99 ? '99+' : homeUnreadCount}
           </span>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Cap workspace and Home badge display at `99+` when unread count exceeds 99
- Prevents badge from stretching into elongated oval on high counts
- Tooltip and aria-label retain exact count for accessibility

Closes #229

## Test plan
- [x] Workspace badge shows `99+` when 100 tabs are unread
- [x] Home badge shows `99+` when 100 standalone tabs are unread
- [x] Existing tests unchanged (all use small counts)
- [x] Full suite — 1298 tests passing