### PR TITLE
fix(spa): add maxLength to workspace name input

### DIFF
--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.test.tsx
@@ -33,6 +33,12 @@ describe('WorkspaceSettingsPage', () => {
     expect(useWorkspaceStore.getState().workspaces[0].name).toBe('Renamed')
   })
 
+  it('has maxLength on name input to prevent excessively long names', () => {
+    render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    const input = screen.getByDisplayValue('Test WS') as HTMLInputElement
+    expect(input.maxLength).toBe(64)
+  })
+
   it('renders delete button and shows confirm dialog', () => {
     render(<WorkspaceSettingsPage workspaceId={wsId} />)
     fireEvent.click(screen.getByTestId('delete-workspace-btn'))

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
@@ -79,6 +79,7 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
             onChange={(e) => setNameInput(e.target.value)}
             onBlur={handleNameBlur}
             onKeyDown={handleNameKeyDown}
+            maxLength={64}
             className="text-center text-lg font-semibold bg-transparent text-text-primary border-b border-transparent hover:border-border-default focus:border-accent focus:outline-none px-2 py-1 transition-colors"
           />
         </div>


### PR DESCRIPTION
## Summary
- Add `maxLength={64}` to workspace name input in `WorkspaceSettingsPage`
- `WorkspaceRenameDialog` no longer exists (removed in prior iteration)
- Prevents excessively long names from bloating localStorage persist

Closes #205

## Test plan
- [x] Input has `maxLength=64` attribute
- [x] Full suite — 1299 tests passing