### PR TITLE
feat(daemon+spa): make upload temp directory configurable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	Allow        []string       `toml:"allow"          json:"allow"`
 	DataDir      string         `toml:"data_dir"       json:"data_dir"`
 	AllowedPaths []string       `toml:"allowed_paths"  json:"allowed_paths"`
+	UploadDir    string         `toml:"upload_dir"     json:"upload_dir"`
 	Terminal     TerminalConfig `toml:"terminal"       json:"terminal"`
 	Stream       StreamConfig   `toml:"stream"         json:"stream"`
 	Detect       DetectConfig   `toml:"detect"         json:"detect"`
@@ -64,7 +65,8 @@ func defaults() Config {
 	return Config{
 		Bind:    "127.0.0.1",
 		Port:    7860,
-		DataDir: filepath.Join(home, ".config", "pdx"),
+		DataDir:   filepath.Join(home, ".config", "pdx"),
+		UploadDir: filepath.Join(home, "tmp", "purdex-upload"),
 		Stream: StreamConfig{
 			Presets: []Preset{{
 				Name:    "cc",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -118,6 +118,18 @@ func TestLoadInvalidTOML(t *testing.T) {
 	}
 }
 
+func TestDefaultsHaveUploadDir(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, "tmp", "purdex-upload")
+	if cfg.UploadDir != want {
+		t.Errorf("UploadDir = %q, want %q", cfg.UploadDir, want)
+	}
+}
+
 func TestGetSizingModeDefault(t *testing.T) {
 	tc := config.TerminalConfig{}
 	if tc.GetSizingMode() != "auto" {

--- a/internal/core/config_handler.go
+++ b/internal/core/config_handler.go
@@ -4,6 +4,7 @@ package core
 import (
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 
 	"github.com/wake/purdex/internal/config"
 )
@@ -24,9 +25,10 @@ func (c *Core) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 
 // configUpdateRequest defines the fields that can be updated via PUT /api/config.
 type configUpdateRequest struct {
-	Stream   *config.StreamConfig   `json:"stream,omitempty"`
-	Detect   *detectUpdateRequest   `json:"detect,omitempty"`
-	Terminal *config.TerminalConfig `json:"terminal,omitempty"`
+	Stream    *config.StreamConfig   `json:"stream,omitempty"`
+	Detect    *detectUpdateRequest   `json:"detect,omitempty"`
+	Terminal  *config.TerminalConfig `json:"terminal,omitempty"`
+	UploadDir *string                `json:"upload_dir,omitempty"`
 }
 
 // detectUpdateRequest allows partial updates to detect config.
@@ -54,6 +56,14 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		default:
 			c.CfgMu.Unlock()
 			http.Error(w, "invalid sizing_mode: must be auto, terminal-first, or minimal-first", http.StatusBadRequest)
+			return
+		}
+	}
+
+	if req.UploadDir != nil {
+		if *req.UploadDir == "" || !filepath.IsAbs(*req.UploadDir) {
+			c.CfgMu.Unlock()
+			http.Error(w, "upload_dir must be a non-empty absolute path", http.StatusBadRequest)
 			return
 		}
 	}
@@ -88,6 +98,10 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		c.Cfg.Terminal.SizingMode = req.Terminal.SizingMode
 	}
 
+	if req.UploadDir != nil {
+		c.Cfg.UploadDir = *req.UploadDir
+	}
+
 	// Write back to config file
 	if c.CfgPath != "" {
 		if err := config.WriteFile(c.CfgPath, *c.Cfg); err != nil {
@@ -103,7 +117,7 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	c.CfgMu.Unlock()
 
 	// Notify registered callbacks about config changes (outside lock)
-	if detectChanged {
+	if detectChanged || req.UploadDir != nil {
 		c.NotifyConfigChange()
 	}
 

--- a/internal/core/config_handler_test.go
+++ b/internal/core/config_handler_test.go
@@ -255,6 +255,45 @@ func TestRegisterCoreRoutesIncludesConfigEndpoints(t *testing.T) {
 	assert.NotEqual(t, http.StatusNotFound, rec.Code)
 }
 
+func TestPutConfigUpdatesUploadDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.toml")
+	err := os.WriteFile(cfgPath, []byte("bind = \"127.0.0.1\"\n"), 0644)
+	require.NoError(t, err)
+
+	c := newTestCore()
+	c.CfgPath = cfgPath
+
+	body := `{"upload_dir": "/tmp/custom-uploads"}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify in-memory config updated
+	c.CfgMu.RLock()
+	assert.Equal(t, "/tmp/custom-uploads", c.Cfg.UploadDir)
+	c.CfgMu.RUnlock()
+
+	// Verify file was written with the new path
+	data, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "/tmp/custom-uploads")
+}
+
+func TestPutConfigRejectsRelativeUploadDir(t *testing.T) {
+	c := newTestCore()
+
+	body := `{"upload_dir": "relative/path"}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "upload_dir must be a non-empty absolute path")
+}
+
 // TestPutConfigRollsBackOnWriteFailure verifies that when writeConfig fails,
 // in-memory state is restored so memory and disk stay consistent.
 func TestPutConfigRollsBackOnWriteFailure(t *testing.T) {

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -68,8 +66,9 @@ func (m *Module) Init(c *core.Core) error {
 	c.Registry.Register("agent.module", m)
 
 	if m.uploadDir == "" {
-		home, _ := os.UserHomeDir()
-		m.uploadDir = filepath.Join(home, "tmp", "purdex-upload")
+		c.CfgMu.RLock()
+		m.uploadDir = c.Cfg.UploadDir
+		c.CfgMu.RUnlock()
 	}
 
 	// Prober (shared across all providers)
@@ -90,8 +89,12 @@ func (m *Module) Init(c *core.Core) error {
 	c.OnConfigChange(func() {
 		c.CfgMu.RLock()
 		cmds := c.Cfg.Detect.CCCommands
+		newDir := c.Cfg.UploadDir
 		c.CfgMu.RUnlock()
 		m.prober.UpdateProcessNames("cc", cmds)
+		if newDir != "" {
+			m.uploadDir = newDir
+		}
 	})
 
 	// Codex provider

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -93,7 +93,9 @@ func (m *Module) Init(c *core.Core) error {
 		c.CfgMu.RUnlock()
 		m.prober.UpdateProcessNames("cc", cmds)
 		if newDir != "" {
+			m.mu.Lock()
 			m.uploadDir = newDir
+			m.mu.Unlock()
 		}
 	})
 
@@ -137,6 +139,13 @@ func (m *Module) Start(_ context.Context) error {
 
 	log.Println("[agent] hook event endpoint registered")
 	return nil
+}
+
+// getUploadDir returns the current upload directory under lock.
+func (m *Module) getUploadDir() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.uploadDir
 }
 
 // Stop cancels all active Activity watchers and resets transient state.

--- a/internal/module/agent/upload.go
+++ b/internal/module/agent/upload.go
@@ -67,7 +67,7 @@ func (m *Module) handleUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Ensure upload directory exists.
-	dir := filepath.Join(m.uploadDir, sessionCode)
+	dir := filepath.Join(m.getUploadDir(), sessionCode)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		log.Printf("[agent] mkdir upload dir: %v", err)
 		http.Error(w, `{"error":"cannot create upload directory"}`, http.StatusInternalServerError)

--- a/internal/module/agent/upload_mgmt.go
+++ b/internal/module/agent/upload_mgmt.go
@@ -24,9 +24,10 @@ type uploadFileInfo struct {
 
 // handleUploadStats returns aggregate stats for the upload directory.
 func (m *Module) handleUploadStats(w http.ResponseWriter, r *http.Request) {
-	stats := uploadStatsResponse{Path: m.uploadDir}
+	dir := m.getUploadDir()
+	stats := uploadStatsResponse{Path: dir}
 
-	_ = filepath.Walk(m.uploadDir, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil // skip inaccessible entries
 		}
@@ -44,8 +45,9 @@ func (m *Module) handleUploadStats(w http.ResponseWriter, r *http.Request) {
 // handleUploadFiles lists all uploaded files grouped by session.
 func (m *Module) handleUploadFiles(w http.ResponseWriter, r *http.Request) {
 	var files []uploadFileInfo
+	uploadDir := m.getUploadDir()
 
-	entries, err := os.ReadDir(m.uploadDir)
+	entries, err := os.ReadDir(uploadDir)
 	if err != nil {
 		// Directory doesn't exist or is unreadable — return empty array.
 		w.Header().Set("Content-Type", "application/json")
@@ -58,7 +60,7 @@ func (m *Module) handleUploadFiles(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		sessionDir := entry.Name()
-		sessionPath := filepath.Join(m.uploadDir, sessionDir)
+		sessionPath := filepath.Join(uploadDir, sessionDir)
 		fileEntries, err := os.ReadDir(sessionPath)
 		if err != nil {
 			continue
@@ -90,9 +92,10 @@ func (m *Module) handleUploadFiles(w http.ResponseWriter, r *http.Request) {
 // handleDeleteUploadSession removes an entire session upload directory.
 func (m *Module) handleDeleteUploadSession(w http.ResponseWriter, r *http.Request) {
 	session := r.PathValue("session")
-	target := filepath.Clean(filepath.Join(m.uploadDir, session))
+	uploadDir := m.getUploadDir()
+	target := filepath.Clean(filepath.Join(uploadDir, session))
 
-	if !strings.HasPrefix(target, filepath.Clean(m.uploadDir)+string(os.PathSeparator)) {
+	if !strings.HasPrefix(target, filepath.Clean(uploadDir)+string(os.PathSeparator)) {
 		http.Error(w, "invalid path", http.StatusBadRequest)
 		return
 	}
@@ -108,9 +111,10 @@ func (m *Module) handleDeleteUploadSession(w http.ResponseWriter, r *http.Reques
 func (m *Module) handleDeleteUploadFile(w http.ResponseWriter, r *http.Request) {
 	session := r.PathValue("session")
 	filename := r.PathValue("filename")
-	target := filepath.Clean(filepath.Join(m.uploadDir, session, filename))
+	uploadDir := m.getUploadDir()
+	target := filepath.Clean(filepath.Join(uploadDir, session, filename))
 
-	if !strings.HasPrefix(target, filepath.Clean(m.uploadDir)+string(os.PathSeparator)) {
+	if !strings.HasPrefix(target, filepath.Clean(uploadDir)+string(os.PathSeparator)) {
 		http.Error(w, "invalid path", http.StatusBadRequest)
 		return
 	}
@@ -128,7 +132,8 @@ func (m *Module) handleDeleteUploadFile(w http.ResponseWriter, r *http.Request) 
 
 // handleDeleteAllUploads removes all session subdirectories in the upload dir.
 func (m *Module) handleDeleteAllUploads(w http.ResponseWriter, r *http.Request) {
-	entries, err := os.ReadDir(m.uploadDir)
+	uploadDir := m.getUploadDir()
+	entries, err := os.ReadDir(uploadDir)
 	if err != nil {
 		// Nothing to delete.
 		w.WriteHeader(http.StatusNoContent)
@@ -136,7 +141,7 @@ func (m *Module) handleDeleteAllUploads(w http.ResponseWriter, r *http.Request) 
 	}
 
 	for _, entry := range entries {
-		path := filepath.Join(m.uploadDir, entry.Name())
+		path := filepath.Join(uploadDir, entry.Name())
 		_ = os.RemoveAll(path)
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/spa/src/components/hosts/UploadSection.test.tsx
+++ b/spa/src/components/hosts/UploadSection.test.tsx
@@ -11,8 +11,17 @@ const FILES = [
   { session: 'abc', name: 'file2.txt', size: 512, modified: '2025-01-01' },
 ]
 
+const CONFIG = {
+  upload_dir: '/tmp/purdex-upload',
+  bind: '0.0.0.0',
+  port: 7860,
+  stream: { presets: [] },
+  detect: { cc_commands: [], poll_interval: 5 },
+}
+
 // Mock the host-api module
 vi.mock('../../lib/host-api', () => ({
+  hostFetch: vi.fn(),
   fetchUploadStats: vi.fn(),
   fetchUploadFiles: vi.fn(),
   deleteUploadFile: vi.fn(),
@@ -21,11 +30,13 @@ vi.mock('../../lib/host-api', () => ({
 }))
 
 import {
+  hostFetch,
   fetchUploadStats,
   fetchUploadFiles,
   deleteAllUploads,
 } from '../../lib/host-api'
 
+const mockHostFetch = vi.mocked(hostFetch)
 const mockFetchUploadStats = vi.mocked(fetchUploadStats)
 const mockFetchUploadFiles = vi.mocked(fetchUploadFiles)
 const mockDeleteAllUploads = vi.mocked(deleteAllUploads)
@@ -41,6 +52,11 @@ beforeEach(() => {
     hostOrder: [HOST_ID],
     runtime: { [HOST_ID]: { status: 'connected' } },
   })
+  // Default: mock hostFetch for /api/config
+  mockHostFetch.mockImplementation((_hostId, path) => {
+    if (path === '/api/config') return Promise.resolve(mockOkResponse(CONFIG))
+    return Promise.resolve({ ok: false } as Response)
+  })
 })
 
 describe('UploadSection', () => {
@@ -51,8 +67,80 @@ describe('UploadSection', () => {
     render(<UploadSection hostId={HOST_ID} />)
 
     await waitFor(() => {
-      expect(screen.getByText('/tmp/uploads')).toBeInTheDocument()
+      // Should show config's upload_dir, not stats.dir
+      expect(screen.getByText('/tmp/purdex-upload')).toBeInTheDocument()
       expect(screen.getByText('2')).toBeInTheDocument()
+    })
+  })
+
+  it('renders EditableField with config upload_dir', async () => {
+    mockFetchUploadStats.mockResolvedValue(mockOkResponse(STATS))
+    mockFetchUploadFiles.mockResolvedValue(mockOkResponse(FILES))
+
+    render(<UploadSection hostId={HOST_ID} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('/tmp/purdex-upload')).toBeInTheDocument()
+    })
+
+    // Click to edit the dir
+    fireEvent.click(screen.getByText('/tmp/purdex-upload'))
+
+    // Should show an input with the current dir value
+    const input = screen.getByDisplayValue('/tmp/purdex-upload')
+    expect(input).toBeInTheDocument()
+  })
+
+  it('saves new upload dir via PUT /api/config', async () => {
+    mockFetchUploadStats.mockResolvedValue(mockOkResponse(STATS))
+    mockFetchUploadFiles.mockResolvedValue(mockOkResponse(FILES))
+
+    const updatedConfig = { ...CONFIG, upload_dir: '/new/upload/path' }
+    mockHostFetch.mockImplementation((_hostId, path, init) => {
+      if (path === '/api/config' && init?.method === 'PUT') {
+        return Promise.resolve(mockOkResponse(updatedConfig))
+      }
+      if (path === '/api/config') return Promise.resolve(mockOkResponse(CONFIG))
+      return Promise.resolve({ ok: false } as Response)
+    })
+
+    render(<UploadSection hostId={HOST_ID} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('/tmp/purdex-upload')).toBeInTheDocument()
+    })
+
+    // Click to edit
+    fireEvent.click(screen.getByText('/tmp/purdex-upload'))
+
+    const input = screen.getByDisplayValue('/tmp/purdex-upload')
+    fireEvent.change(input, { target: { value: '/new/upload/path' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(mockHostFetch).toHaveBeenCalledWith(
+        HOST_ID,
+        '/api/config',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ upload_dir: '/new/upload/path' }),
+        }),
+      )
+    })
+  })
+
+  it('falls back to stats.dir when config has no upload_dir', async () => {
+    mockHostFetch.mockImplementation((_hostId, path) => {
+      if (path === '/api/config') return Promise.resolve(mockOkResponse({ ...CONFIG, upload_dir: undefined }))
+      return Promise.resolve({ ok: false } as Response)
+    })
+    mockFetchUploadStats.mockResolvedValue(mockOkResponse(STATS))
+    mockFetchUploadFiles.mockResolvedValue(mockOkResponse(FILES))
+
+    render(<UploadSection hostId={HOST_ID} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('/tmp/uploads')).toBeInTheDocument()
     })
   })
 

--- a/spa/src/components/hosts/UploadSection.tsx
+++ b/spa/src/components/hosts/UploadSection.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react'
 import { ArrowsClockwise, Trash, File } from '@phosphor-icons/react'
 import { useHostStore } from '../../stores/useHostStore'
 import { useI18nStore } from '../../stores/useI18nStore'
-import { fetchUploadStats, fetchUploadFiles, deleteUploadFile, deleteUploadSession, deleteAllUploads } from '../../lib/host-api'
+import { hostFetch, fetchUploadStats, fetchUploadFiles, deleteUploadFile, deleteUploadSession, deleteAllUploads } from '../../lib/host-api'
+import { EditableField } from './form-fields'
 
 interface Props {
   hostId: string
@@ -37,6 +38,7 @@ export function UploadSection({ hostId }: Props) {
   const [files, setFiles] = useState<UploadFile[]>([])
   const [loading, setLoading] = useState(true)
   const [confirmClearAll, setConfirmClearAll] = useState(false)
+  const [configDir, setConfigDir] = useState<string | null>(null)
 
   const refresh = async () => {
     setLoading(true)
@@ -53,17 +55,23 @@ export function UploadSection({ hostId }: Props) {
 
   useEffect(() => {
     let cancelled = false
-    Promise.all([fetchUploadStats(hostId), fetchUploadFiles(hostId)])
-      .then(([statsRes, filesRes]) =>
+    Promise.all([
+      fetchUploadStats(hostId),
+      fetchUploadFiles(hostId),
+      hostFetch(hostId, '/api/config').then((r) => r.ok ? r.json() : null),
+    ])
+      .then(([statsRes, filesRes, configData]) =>
         Promise.all([
           statsRes.ok ? statsRes.json() : null,
           filesRes.ok ? filesRes.json() : null,
+          configData,
         ]),
       )
-      .then(([statsData, filesData]) => {
+      .then(([statsData, filesData, configData]) => {
         if (cancelled) return
         if (statsData) setStats(statsData)
         if (filesData) setFiles(filesData)
+        if (configData) setConfigDir(configData.upload_dir ?? null)
       })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
@@ -91,6 +99,21 @@ export function UploadSection({ hostId }: Props) {
     } catch { /* ignore */ }
     setConfirmClearAll(false)
     await refresh()
+  }
+
+  const handleDirSave = async (newDir: string) => {
+    try {
+      const res = await hostFetch(hostId, '/api/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ upload_dir: newDir }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setConfigDir(data.upload_dir ?? null)
+        await refresh()
+      }
+    } catch { /* ignore */ }
   }
 
   // Group files by session
@@ -147,12 +170,13 @@ export function UploadSection({ hostId }: Props) {
 
       {/* Stats overview */}
       {stats && (
-        <div className="p-4 bg-surface-secondary rounded-lg border border-border-subtle mb-4">
-          <div className="grid grid-cols-3 gap-4 text-center">
-            <div>
-              <p className="text-xs text-text-muted">{t('hosts.upload_dir')}</p>
-              <p className="text-sm text-text-primary font-mono truncate">{stats.dir}</p>
-            </div>
+        <div className="p-4 bg-surface-secondary rounded-lg border border-border-subtle mb-4 space-y-3">
+          <EditableField
+            label={t('hosts.upload_dir')}
+            value={configDir ?? stats.dir}
+            onSave={handleDirSave}
+          />
+          <div className="grid grid-cols-2 gap-4 text-center">
             <div>
               <p className="text-xs text-text-muted">{t('hosts.total_size')}</p>
               <p className="text-sm text-text-primary">{formatBytes(stats.total_size)}</p>

--- a/spa/src/lib/host-api.ts
+++ b/spa/src/lib/host-api.ts
@@ -18,6 +18,7 @@ export interface Session {
 export interface ConfigData {
   bind: string
   port: number
+  upload_dir?: string
   terminal?: { sizing_mode: string }
   stream: { presets: Array<{ name: string; command: string }> }
   detect: { cc_commands: string[]; poll_interval: number }


### PR DESCRIPTION
## Summary
- Add `UploadDir` field to daemon `Config` struct with default `~/tmp/purdex-upload/`
- `PUT /api/config` accepts `upload_dir` (validates absolute path, rejects relative)
- Agent module reads from config and syncs at runtime via `OnConfigChange`
- UploadSection UI replaces read-only dir display with `EditableField` for in-place editing

Closes #143

## Test plan
- [x] Go tests: `TestDefaultsHaveUploadDir`, `TestPutConfigUpdatesUploadDir`, `TestPutConfigRejectsRelativeUploadDir`
- [x] SPA tests: EditableField rendering, save via PUT, fallback to stats.dir
- [x] All 1302 SPA tests pass
- [x] All Go tests pass
- [ ] Manual: edit upload dir in Host page → verify daemon config updates