### PR TITLE
feat(spa): collapsible host headers in SessionPanel/SessionSection

### DIFF
--- a/spa/src/components/SessionPanel.test.tsx
+++ b/spa/src/components/SessionPanel.test.tsx
@@ -264,4 +264,39 @@ describe('SessionPanel', () => {
     expect(screen.getByText('dev')).toBeInTheDocument()
     expect(headerA).toHaveAttribute('aria-expanded', 'true')
   })
+
+  it('auto-expands new active host even if it was previously collapsed', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 },
+        [HOST_B]: { id: HOST_B, name: 'air', ip: '100.64.0.1', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, HOST_B],
+      activeHostId: HOST_ID,
+    })
+    useSessionStore.setState({
+      sessions: {
+        [HOST_ID]: [
+          { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+        [HOST_B]: [
+          { code: 'xyz001', name: 'air-dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+      },
+      activeHostId: HOST_ID,
+      activeCode: 'abc001',
+    })
+    const { rerender } = render(<SessionPanel />)
+    // Collapse HOST_B
+    fireEvent.click(screen.getByTestId(`host-header-${HOST_B}`))
+    expect(screen.queryByText('air-dev')).toBeNull()
+
+    // Switch activeHostId to HOST_B
+    useSessionStore.setState({ activeHostId: HOST_B, activeCode: 'xyz001' })
+    rerender(<SessionPanel />)
+
+    // HOST_B should auto-expand because it is now the active host
+    expect(screen.getByText('air-dev')).toBeInTheDocument()
+    expect(screen.getByTestId(`host-header-${HOST_B}`)).toHaveAttribute('aria-expanded', 'true')
+  })
 })

--- a/spa/src/components/SessionPanel.tsx
+++ b/spa/src/components/SessionPanel.tsx
@@ -1,8 +1,9 @@
 // spa/src/components/SessionPanel.tsx
+import { useState } from 'react'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useAgentStore } from '../stores/useAgentStore'
 import { useHostStore } from '../stores/useHostStore'
-import { Terminal, Lightning, GearSix, Circle, Spinner } from '@phosphor-icons/react'
+import { Terminal, Lightning, GearSix, Circle, Spinner, CaretDown, CaretRight } from '@phosphor-icons/react'
 import SessionStatusBadge from './SessionStatusBadge'
 import { useI18nStore } from '../stores/useI18nStore'
 import { compositeKey } from '../lib/composite-key'
@@ -37,6 +38,7 @@ export default function SessionPanel({ onSettingsOpen, onSelectSession, activeSe
   }
 
   const activeHostId = useSessionStore((s) => s.activeHostId)
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
   const isActiveSession = (hostId: string, s: { code: string }) =>
     activeSessionCode != null ? s.code === activeSessionCode : (activeHostId === hostId && activeCode === s.code)
@@ -52,12 +54,19 @@ export default function SessionPanel({ onSettingsOpen, onSelectSession, activeSe
             const sessions = sessionsMap[hostId] ?? []
             const hostRuntime = runtime[hostId]
             const isOffline = hostRuntime && hostRuntime.status !== 'connected'
+            const isExpanded = expanded[hostId] !== false || activeHostId === hostId
 
             return (
               <div key={hostId}>
                 {/* Host header — only show when multiple hosts */}
                 {hostOrder.length > 1 && (
-                  <div className="flex items-center gap-1.5 mb-1 px-1">
+                  <button
+                    data-testid={`host-header-${hostId}`}
+                    aria-expanded={isExpanded}
+                    onClick={() => setExpanded((prev) => ({ ...prev, [hostId]: !isExpanded }))}
+                    className="flex items-center gap-1.5 mb-1 px-1 w-full cursor-pointer"
+                  >
+                    {isExpanded ? <CaretDown size={10} className="text-text-muted" /> : <CaretRight size={10} className="text-text-muted" />}
                     {hostRuntime?.status === 'reconnecting' ? (
                       <Spinner size={8} className="text-yellow-400 animate-spin" />
                     ) : hostRuntime?.status === 'connected' ? (
@@ -68,36 +77,38 @@ export default function SessionPanel({ onSettingsOpen, onSelectSession, activeSe
                       <Circle size={8} weight="fill" className="text-text-muted" />
                     )}
                     <span className="text-xs text-text-muted font-semibold truncate">{host.name}</span>
-                  </div>
+                  </button>
                 )}
 
                 {/* Sessions */}
-                <div className="space-y-1">
-                  {sessions.length === 0 && (
-                    <p className="text-xs text-text-muted px-2">
-                      {isOffline ? t('session.reconnecting') : t('session.empty')}
-                    </p>
-                  )}
-                  {sessions.map((s) => {
-                    const ck = compositeKey(hostId, s.code)
-                    const status = agentStatuses[ck]
-                    return (
-                      <button
-                        key={ck}
-                        onClick={() => handleClick(hostId, s.code)}
-                        disabled={!!isOffline}
-                        className={`w-full text-left px-2 py-1.5 rounded text-sm cursor-pointer flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed ${
-                          isActiveSession(hostId, s) ? 'bg-surface-secondary text-text-primary' : 'text-text-secondary hover:bg-surface-secondary/50'
-                        }`}
-                      >
-                        <SessionIcon mode={s.mode} code={s.code} />
-                        <span className="flex-1 truncate">{s.name}</span>
-                        {status && <SessionStatusBadge status={status} />}
-                        <span className="text-xs text-text-muted">{s.mode}</span>
-                      </button>
-                    )
-                  })}
-                </div>
+                {isExpanded && (
+                  <div className="space-y-1">
+                    {sessions.length === 0 && (
+                      <p className="text-xs text-text-muted px-2">
+                        {isOffline ? t('session.reconnecting') : t('session.empty')}
+                      </p>
+                    )}
+                    {sessions.map((s) => {
+                      const ck = compositeKey(hostId, s.code)
+                      const status = agentStatuses[ck]
+                      return (
+                        <button
+                          key={ck}
+                          onClick={() => handleClick(hostId, s.code)}
+                          disabled={!!isOffline}
+                          className={`w-full text-left px-2 py-1.5 rounded text-sm cursor-pointer flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed ${
+                            isActiveSession(hostId, s) ? 'bg-surface-secondary text-text-primary' : 'text-text-secondary hover:bg-surface-secondary/50'
+                          }`}
+                        >
+                          <SessionIcon mode={s.mode} code={s.code} />
+                          <span className="flex-1 truncate">{s.name}</span>
+                          {status && <SessionStatusBadge status={status} />}
+                          <span className="text-xs text-text-muted">{s.mode}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
               </div>
             )
           })}

--- a/spa/src/components/SessionPanel.tsx
+++ b/spa/src/components/SessionPanel.tsx
@@ -63,7 +63,10 @@ export default function SessionPanel({ onSettingsOpen, onSelectSession, activeSe
                   <button
                     data-testid={`host-header-${hostId}`}
                     aria-expanded={isExpanded}
-                    onClick={() => setExpanded((prev) => ({ ...prev, [hostId]: !isExpanded }))}
+                    onClick={() => {
+                      if (activeHostId === hostId) return
+                      setExpanded((prev) => ({ ...prev, [hostId]: !isExpanded }))
+                    }}
                     className="flex items-center gap-1.5 mb-1 px-1 w-full cursor-pointer"
                   >
                     {isExpanded ? <CaretDown size={10} className="text-text-muted" /> : <CaretRight size={10} className="text-text-muted" />}

--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -1,24 +1,27 @@
-// spa/src/components/SessionPanel.test.tsx
+// spa/src/components/SessionSection.test.tsx
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
-import SessionPanel from './SessionPanel'
+import { SessionSection } from './SessionSection'
 import { useSessionStore } from '../stores/useSessionStore'
-import { useAgentStore } from '../stores/useAgentStore'
 import { useHostStore } from '../stores/useHostStore'
-import { compositeKey } from '../lib/composite-key'
+
+vi.mock('../hooks/useSessionWatch', () => ({
+  useSessionWatch: vi.fn(),
+}))
 
 vi.mock('../lib/host-api', async (importOriginal) => {
-  const actual = await importOriginal() as Record<string, unknown>
+  const actual = (await importOriginal()) as Record<string, unknown>
   return { ...actual, listSessions: vi.fn().mockResolvedValue([]) }
 })
 
 const HOST_ID = 'test-host'
 const HOST_B = 'host-b'
+const mockOnSelect = vi.fn()
 
 beforeEach(() => {
   cleanup()
+  mockOnSelect.mockClear()
   useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
-  useAgentStore.setState({ statuses: {}, lastEvents: {}, unread: {} })
   useHostStore.setState({
     hosts: { [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 } },
     hostOrder: [HOST_ID],
@@ -26,105 +29,42 @@ beforeEach(() => {
   })
 })
 
-describe('SessionPanel', () => {
-  it('shows empty state', () => {
-    render(<SessionPanel />)
-    expect(screen.getByText('No sessions')).toBeInTheDocument()
+describe('SessionSection', () => {
+  it('shows no sessions message when empty', () => {
+    render(<SessionSection onSelect={mockOnSelect} />)
+    expect(screen.getByText('No sessions available')).toBeInTheDocument()
   })
 
-  it('renders session list', () => {
+  it('renders session buttons', () => {
     useSessionStore.setState({
       sessions: {
         [HOST_ID]: [
           { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
-          { code: 'abc002', name: 'prod', cwd: '/tmp', mode: 'stream', cc_session_id: '', cc_model: '', has_relay: false },
         ],
       },
-      activeHostId: HOST_ID,
-      activeCode: null,
     })
-    render(<SessionPanel />)
+    render(<SessionSection onSelect={mockOnSelect} />)
     expect(screen.getByText('dev')).toBeInTheDocument()
-    expect(screen.getByText('prod')).toBeInTheDocument()
   })
 
-  it('highlights active session', () => {
+  it('calls onSelect when session is clicked', () => {
     useSessionStore.setState({
       sessions: {
         [HOST_ID]: [
           { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
         ],
       },
-      activeHostId: HOST_ID,
-      activeCode: 'abc001',
     })
-    render(<SessionPanel />)
-    const btn = screen.getByRole('button', { name: /dev/i })
-    expect(btn.className).toContain('bg-surface-secondary')
-  })
-
-  it('sets active on click', () => {
-    const setActive = vi.fn()
-    useSessionStore.setState({
-      sessions: {
-        [HOST_ID]: [
-          { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
-        ],
-      },
-      activeHostId: HOST_ID,
-      activeCode: null,
-      setActive,
+    render(<SessionSection onSelect={mockOnSelect} />)
+    fireEvent.click(screen.getByText('dev'))
+    expect(mockOnSelect).toHaveBeenCalledWith({
+      kind: 'tmux-session',
+      hostId: HOST_ID,
+      sessionCode: 'abc001',
+      mode: 'terminal',
+      cachedName: 'dev',
+      tmuxInstance: '',
     })
-    render(<SessionPanel />)
-    fireEvent.click(screen.getByRole('button', { name: /dev/i }))
-    expect(setActive).toHaveBeenCalledWith(HOST_ID, 'abc001')
-  })
-
-  it('shows terminal icon for term mode', () => {
-    useSessionStore.setState({
-      sessions: {
-        [HOST_ID]: [
-          { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
-        ],
-      },
-      activeHostId: HOST_ID,
-      activeCode: null,
-    })
-    render(<SessionPanel />)
-    // Terminal icon should be present (Phosphor Terminal icon)
-    expect(screen.getByTestId('session-icon-abc001')).toBeInTheDocument()
-  })
-
-  it('shows agent status badge when agent is active', () => {
-    useSessionStore.setState({
-      sessions: {
-        [HOST_ID]: [
-          { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
-        ],
-      },
-      activeHostId: HOST_ID,
-      activeCode: null,
-    })
-    // Set agent status with composite key
-    const ck = compositeKey(HOST_ID, 'abc001')
-    useAgentStore.setState({ statuses: { [ck]: 'idle' } })
-    render(<SessionPanel />)
-    expect(screen.getByTestId('status-badge')).toHaveAttribute('title', 'idle')
-  })
-
-  it('shows no badge when no agent status exists for session', () => {
-    useSessionStore.setState({
-      sessions: {
-        [HOST_ID]: [
-          { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'stream', cc_session_id: '', cc_model: '', has_relay: false },
-        ],
-      },
-      activeHostId: HOST_ID,
-      activeCode: null,
-    })
-    // No agent status set
-    render(<SessionPanel />)
-    expect(screen.queryByTestId('status-badge')).toBeNull()
   })
 
   it('does not show host header for single host', () => {
@@ -134,10 +74,8 @@ describe('SessionPanel', () => {
           { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
         ],
       },
-      activeHostId: HOST_ID,
-      activeCode: null,
     })
-    render(<SessionPanel />)
+    render(<SessionSection onSelect={mockOnSelect} />)
     expect(screen.queryByTestId(`host-header-${HOST_ID}`)).toBeNull()
   })
 
@@ -159,10 +97,8 @@ describe('SessionPanel', () => {
           { code: 'xyz001', name: 'air-dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
         ],
       },
-      activeHostId: HOST_ID,
-      activeCode: null,
     })
-    render(<SessionPanel />)
+    render(<SessionSection onSelect={mockOnSelect} />)
     const headerA = screen.getByTestId(`host-header-${HOST_ID}`)
     const headerB = screen.getByTestId(`host-header-${HOST_B}`)
     expect(headerA).toBeInTheDocument()
@@ -189,17 +125,11 @@ describe('SessionPanel', () => {
           { code: 'xyz001', name: 'air-dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
         ],
       },
-      activeHostId: HOST_ID,
-      activeCode: null,
     })
-    render(<SessionPanel />)
-    // Click HOST_B header to collapse it
+    render(<SessionSection onSelect={mockOnSelect} />)
     fireEvent.click(screen.getByTestId(`host-header-${HOST_B}`))
-    // HOST_B sessions should be hidden
     expect(screen.queryByText('air-dev')).toBeNull()
-    // HOST_B header should show collapsed state
     expect(screen.getByTestId(`host-header-${HOST_B}`)).toHaveAttribute('aria-expanded', 'false')
-    // HOST_ID sessions should still be visible
     expect(screen.getByText('dev')).toBeInTheDocument()
   })
 
@@ -221,21 +151,17 @@ describe('SessionPanel', () => {
           { code: 'xyz001', name: 'air-dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
         ],
       },
-      activeHostId: HOST_ID,
-      activeCode: null,
     })
-    render(<SessionPanel />)
+    render(<SessionSection onSelect={mockOnSelect} />)
     const headerB = screen.getByTestId(`host-header-${HOST_B}`)
-    // Click to collapse
     fireEvent.click(headerB)
     expect(screen.queryByText('air-dev')).toBeNull()
-    // Click again to expand
     fireEvent.click(headerB)
     expect(screen.getByText('air-dev')).toBeInTheDocument()
     expect(headerB).toHaveAttribute('aria-expanded', 'true')
   })
 
-  it('prevents collapsing the active host', () => {
+  it('allows collapsing any host including active', () => {
     useHostStore.setState({
       hosts: {
         [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 },
@@ -253,15 +179,40 @@ describe('SessionPanel', () => {
           { code: 'xyz001', name: 'air-dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
         ],
       },
-      activeHostId: HOST_ID,
-      activeCode: 'abc001',
     })
-    render(<SessionPanel />)
+    render(<SessionSection onSelect={mockOnSelect} />)
+    // SessionSection has no active host protection — any host can be collapsed
     const headerA = screen.getByTestId(`host-header-${HOST_ID}`)
-    // Try to collapse the active host
     fireEvent.click(headerA)
-    // Sessions should still be visible
-    expect(screen.getByText('dev')).toBeInTheDocument()
-    expect(headerA).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.queryByText('dev')).toBeNull()
+    expect(headerA).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('keyboard nav skips collapsed host sessions', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 },
+        [HOST_B]: { id: HOST_B, name: 'air', ip: '100.64.0.1', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, HOST_B],
+      activeHostId: HOST_ID,
+    })
+    useSessionStore.setState({
+      sessions: {
+        [HOST_ID]: [
+          { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+        [HOST_B]: [
+          { code: 'xyz001', name: 'air-dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+      },
+    })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    // Collapse HOST_B
+    fireEvent.click(screen.getByTestId(`host-header-${HOST_B}`))
+    // Only HOST_ID session buttons should be navigable
+    const sessionButtons = screen.getAllByRole('button').filter((btn) => btn.hasAttribute('data-session-btn'))
+    expect(sessionButtons).toHaveLength(1)
+    expect(sessionButtons[0]).toHaveTextContent('dev')
   })
 })

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -1,9 +1,10 @@
+import { useState } from 'react'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useHostStore } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { useSessionWatch } from '../hooks/useSessionWatch'
 import type { NewTabProviderProps } from '../lib/new-tab-registry'
-import { TerminalWindow, Circle, Spinner } from '@phosphor-icons/react'
+import { TerminalWindow, Circle, Spinner, CaretDown, CaretRight } from '@phosphor-icons/react'
 
 export function SessionSection({ onSelect }: NewTabProviderProps) {
   useSessionWatch()
@@ -12,6 +13,7 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
   const hostOrder = useHostStore((s) => s.hostOrder)
   const runtime = useHostStore((s) => s.runtime)
   const t = useI18nStore((s) => s.t)
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
   const hasAnySessions = hostOrder.some((hid) => (sessionsMap[hid] ?? []).length > 0)
 
@@ -27,12 +29,19 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
         const sessions = sessionsMap[hostId] ?? []
         const hostRuntime = runtime[hostId]
         const isOffline = hostRuntime && hostRuntime.status !== 'connected'
+        const isExpanded = expanded[hostId] !== false
 
         return (
           <div key={hostId}>
             {/* Host header — only show when multiple hosts */}
             {hostOrder.length > 1 && (
-              <div className="flex items-center gap-1.5 px-3 py-1 mt-1">
+              <button
+                data-testid={`host-header-${hostId}`}
+                aria-expanded={isExpanded}
+                onClick={() => setExpanded((prev) => ({ ...prev, [hostId]: !isExpanded }))}
+                className="flex items-center gap-1.5 px-3 py-1 mt-1 w-full cursor-pointer"
+              >
+                {isExpanded ? <CaretDown size={10} className="text-text-muted" /> : <CaretRight size={10} className="text-text-muted" />}
                 {hostRuntime?.status === 'reconnecting' ? (
                   <Spinner size={8} className="text-yellow-400 animate-spin" />
                 ) : hostRuntime?.status === 'connected' ? (
@@ -46,11 +55,12 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
                 {isOffline && (
                   <span className="text-xs text-text-muted ml-auto">{t('session.reconnecting')}</span>
                 )}
-              </div>
+              </button>
             )}
-            {sessions.map((session) => (
+            {isExpanded && sessions.map((session) => (
               <button
                 key={`${hostId}:${session.code}`}
+                data-session-btn
                 className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-white/10 text-left text-sm text-text-primary cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-1 focus:ring-accent-muted"
                 disabled={!!isOffline}
                 tabIndex={0}
@@ -60,7 +70,7 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
                 onKeyDown={(e) => {
                   const container = e.currentTarget.closest('[data-session-list]')
                   if (!container) return
-                  const buttons = Array.from(container.querySelectorAll('button:not(:disabled)')) as HTMLElement[]
+                  const buttons = Array.from(container.querySelectorAll('button[data-session-btn]:not(:disabled)')) as HTMLElement[]
                   const currentIndex = buttons.indexOf(e.currentTarget)
                   if (currentIndex === -1) return
                   switch (e.key) {


### PR DESCRIPTION
Closes #144

## Summary
- Host headers (multi-host mode) become clickable toggle buttons with `CaretDown`/`CaretRight` icons
- SessionPanel: active host is protected from collapsing (`isExpanded = expanded[id] !== false || activeHostId === id`)
- SessionSection: all hosts can be collapsed freely; keyboard nav (`j/k`) updated to use `data-session-btn` selector, excluding toggle buttons
- Added `aria-expanded` for accessibility

## Test plan
- [x] 1316 tests pass (19 new: SessionPanel 5 + SessionSection 9 + existing 5 updated)
- [ ] Manual: multi-host setup — verify toggle animation, active host protection
- [ ] Manual: single host — verify no header shown (regression check)
- [ ] Manual: SessionSection in NewTab dialog — verify collapse works and j/k nav skips collapsed sessions