### PR TITLE
perf(daemon): add 3s exec timeout to GetTmuxInstance/getTmuxVersion

### DIFF
--- a/internal/config/hostid.go
+++ b/internal/config/hostid.go
@@ -13,10 +13,14 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+// tmuxExecTimeout bounds lightweight tmux metadata queries (display-message, -V).
+// Shorter than TmuxAlive's 5s because these are read-only, single-process commands.
+const tmuxExecTimeout = 3 * time.Second
+
 // GetTmuxInstance returns the tmux server's "pid:startTime" identifier.
 // Returns empty string if tmux is not running or the command times out.
 func GetTmuxInstance() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxExecTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pid}:#{start_time}").Output()
 	if err != nil {

--- a/internal/config/hostid.go
+++ b/internal/config/hostid.go
@@ -1,20 +1,24 @@
 package config
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
 
 // GetTmuxInstance returns the tmux server's "pid:startTime" identifier.
-// Returns empty string if tmux is not running.
+// Returns empty string if tmux is not running or the command times out.
 func GetTmuxInstance() string {
-	out, err := exec.Command("tmux", "display-message", "-p", "#{pid}:#{start_time}").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "tmux", "display-message", "-p", "#{pid}:#{start_time}").Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/core/info_handler.go
+++ b/internal/core/info_handler.go
@@ -56,10 +56,14 @@ func (c *Core) handleInfo(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(info)
 }
 
+// tmuxExecTimeout bounds lightweight tmux metadata queries (display-message, -V).
+// Shorter than TmuxAlive's 5s because these are read-only, single-process commands.
+const tmuxExecTimeout = 3 * time.Second
+
 // getTmuxVersion runs `tmux -V` and returns the version string (e.g. "tmux 3.6a").
 // Returns "unknown" if tmux is not found, the command fails, or it times out.
 func getTmuxVersion() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxExecTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "tmux", "-V").Output()
 	if err != nil {

--- a/internal/core/info_handler.go
+++ b/internal/core/info_handler.go
@@ -2,11 +2,13 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/wake/purdex/internal/config"
 )
@@ -55,9 +57,11 @@ func (c *Core) handleInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 // getTmuxVersion runs `tmux -V` and returns the version string (e.g. "tmux 3.6a").
-// Returns "unknown" if tmux is not found or the command fails.
+// Returns "unknown" if tmux is not found, the command fails, or it times out.
 func getTmuxVersion() string {
-	out, err := exec.Command("tmux", "-V").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "tmux", "-V").Output()
 	if err != nil {
 		return "unknown"
 	}


### PR DESCRIPTION
Closes #154

## Summary
- `GetTmuxInstance()` and `getTmuxVersion()` now use `exec.CommandContext` with 3s timeout
- Prevents `/api/info` handler from blocking when tmux server is in abnormal state
- Matches existing `TmuxAlive()` pattern (which uses 5s for heavier `tmux info`)
- Error behavior unchanged: timeout returns empty string / "unknown"

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/config/ ./internal/core/` passes
- [x] SPA tests (1317) pass — no regression
- [ ] Manual: kill tmux server process while keeping socket → verify `/api/info` responds within 3s