### PR TITLE
fix(spa): prevent WS ghost reconnect on deleted host

### DIFF
--- a/spa/src/hooks/useTerminalWs.ts
+++ b/spa/src/hooks/useTerminalWs.ts
@@ -50,7 +50,9 @@ export function useTerminalWs({ wsUrl, termRef, fitAddonRef, containerRef, hostI
 
     const canReconnect = hostId
       ? () => {
-          const runtime = useHostStore.getState().runtime[hostId]
+          const state = useHostStore.getState()
+          if (!state.hosts[hostId]) return false // host deleted — stop reconnecting
+          const runtime = state.runtime[hostId]
           return !runtime || runtime.status === 'connected'
         }
       : undefined


### PR DESCRIPTION
Closes #159

## Summary
- `canReconnect` gate in `useTerminalWs.ts` now checks `state.hosts[hostId]` existence before allowing reconnection
- Previously `!runtime` evaluated to `true` when host was deleted (runtime entry removed), causing infinite reconnect attempts
- Single-line guard: `if (!state.hosts[hostId]) return false`

## Test plan
- [x] 1317 SPA tests pass — no regression
- [ ] Manual: delete a host with active terminal WS → verify no ghost reconnect attempts in console