### PR TITLE
feat(daemon): add WS ping/pong keep-alive to terminal relay

### DIFF
--- a/internal/terminal/relay.go
+++ b/internal/terminal/relay.go
@@ -30,7 +30,9 @@ type Relay struct {
 	cmd     string
 	args    []string
 	cwd     string
-	OnStart func() // called after PTY starts, before I/O goroutines
+	OnStart      func() // called after PTY starts, before I/O goroutines
+	PingInterval time.Duration // default: 30s
+	PongTimeout  time.Duration // default: 10s
 }
 
 func NewRelay(cmd string, args []string, cwd string) *Relay {
@@ -62,8 +64,37 @@ func (r *Relay) HandleWebSocket(w http.ResponseWriter, req *http.Request) {
 		c.Wait()
 	}()
 
+	// Resolve ping/pong durations with defaults
+	pingInterval := r.PingInterval
+	if pingInterval == 0 {
+		pingInterval = 30 * time.Second
+	}
+	pongTimeout := r.PongTimeout
+	if pongTimeout == 0 {
+		pongTimeout = 10 * time.Second
+	}
+
+	// Pong handling — reset read deadline on each pong received
+	conn.SetReadDeadline(time.Now().Add(pingInterval + pongTimeout))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(pingInterval + pongTimeout))
+		return nil
+	})
+
 	var wg sync.WaitGroup
 	var writeMu sync.Mutex
+
+	// Periodic ping to keep connection alive through proxies/firewalls.
+	// Not in WaitGroup — exits when conn.Close() causes WriteControl error.
+	go func() {
+		ticker := time.NewTicker(pingInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(pongTimeout)); err != nil {
+				return
+			}
+		}
+	}()
 
 	// PTY → WebSocket (batched, mutex-protected writes)
 	wg.Add(1)
@@ -98,6 +129,7 @@ func (r *Relay) HandleWebSocket(w http.ResponseWriter, req *http.Request) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer conn.Close() // wake PTY→WS goroutine on read-deadline/disconnect
 		defer ptmx.Close() // wake PTY read goroutine on WS disconnect
 		for {
 			_, msg, err := conn.ReadMessage()

--- a/internal/terminal/relay.go
+++ b/internal/terminal/relay.go
@@ -85,6 +85,9 @@ func (r *Relay) HandleWebSocket(w http.ResponseWriter, req *http.Request) {
 	var writeMu sync.Mutex
 
 	// Periodic ping to keep connection alive through proxies/firewalls.
+	// WriteControl is documented as concurrent-safe with WriteMessage
+	// (gorilla/websocket: "Close and WriteControl can be called concurrently
+	// with all other methods"), so no writeMu needed here.
 	// Not in WaitGroup — exits when conn.Close() causes WriteControl error.
 	go func() {
 		ticker := time.NewTicker(pingInterval)

--- a/internal/terminal/relay_test.go
+++ b/internal/terminal/relay_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
 	"github.com/wake/purdex/internal/terminal"
 )
 
@@ -75,5 +76,85 @@ func TestRelayResize(t *testing.T) {
 	err = ws.WriteMessage(websocket.TextMessage, []byte("ok\n"))
 	if err != nil {
 		t.Errorf("connection died after resize: %v", err)
+	}
+}
+
+func TestPingIsSentByRelay(t *testing.T) {
+	relay := terminal.NewRelay("cat", []string{}, "/tmp")
+	relay.PingInterval = 100 * time.Millisecond
+	relay.PongTimeout = 50 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		relay.HandleWebSocket(w, r)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer ws.Close()
+
+	pingReceived := make(chan struct{}, 1)
+	ws.SetPingHandler(func(msg string) error {
+		select {
+		case pingReceived <- struct{}{}:
+		default:
+		}
+		// Reply with pong to keep connection alive
+		return ws.WriteControl(websocket.PongMessage, []byte(msg), time.Now().Add(time.Second))
+	})
+
+	// Must drain read loop for control frames to be processed
+	go func() {
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-pingReceived:
+		// OK — relay sent a ping
+	case <-time.After(time.Second):
+		t.Fatal("expected ping from relay within 1s")
+	}
+}
+
+func TestPongTimeoutClosesRelayConnection(t *testing.T) {
+	relay := terminal.NewRelay("cat", []string{}, "/tmp")
+	relay.PingInterval = 100 * time.Millisecond
+	relay.PongTimeout = 50 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		relay.HandleWebSocket(w, r)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer ws.Close()
+
+	// Swallow pings without sending pong — server should close us
+	ws.SetPingHandler(func(string) error {
+		return nil // no pong reply
+	})
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-closed:
+		// OK — connection was closed by server after pong timeout
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected server to close connection after pong timeout")
 	}
 }


### PR DESCRIPTION
Closes #160

## Summary
- Terminal relay now sends periodic ping frames (30s default) via `WriteControl` (concurrent-safe)
- Pong handler resets read deadline; pong timeout (10s default) causes connection teardown
- `PingInterval`/`PongTimeout` are configurable on `Relay` struct (same pattern as `EventBroadcaster`)
- Added `defer conn.Close()` to WS→PTY goroutine to ensure prompt disconnect on read deadline expiry

## Test plan
- [x] `go test ./internal/terminal/` — 6 tests pass (2 new: `TestPingIsSentByRelay`, `TestPongTimeoutClosesRelayConnection`)
- [x] `go build ./...` passes
- [ ] Manual: connect terminal through proxy → verify connection survives idle period