### PR TITLE
fix(spa): show workspace prompt instead of silent form failure

### DIFF
--- a/spa/src/components/FileTreeView.test.tsx
+++ b/spa/src/components/FileTreeView.test.tsx
@@ -88,6 +88,12 @@ describe('FileTreeWorkspaceView', () => {
     expect(screen.getByText(/No host connected/)).toBeTruthy()
   })
 
+  it('shows workspace required message when workspaceId is undefined', () => {
+    render(<FileTreeWorkspaceView isActive={true} workspaceId={undefined} />)
+    expect(screen.getByText('請先選擇 Workspace')).toBeTruthy()
+    expect(screen.queryByPlaceholderText('/home/user/project')).toBeNull()
+  })
+
   it('shows setup prompt when projectPath is not configured', () => {
     useWorkspaceStore.setState({
       workspaces: [{

--- a/spa/src/components/FileTreeView.test.tsx
+++ b/spa/src/components/FileTreeView.test.tsx
@@ -89,9 +89,11 @@ describe('FileTreeWorkspaceView', () => {
   })
 
   it('shows workspace required message when workspaceId is undefined', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
     render(<FileTreeWorkspaceView isActive={true} workspaceId={undefined} />)
     expect(screen.getByText('請先選擇 Workspace')).toBeTruthy()
     expect(screen.queryByPlaceholderText('/home/user/project')).toBeNull()
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   it('shows setup prompt when projectPath is not configured', () => {

--- a/spa/src/components/FileTreeView.tsx
+++ b/spa/src/components/FileTreeView.tsx
@@ -71,6 +71,7 @@ export function FileTreeWorkspaceView({ isActive, workspaceId }: ViewProps) {
   }, [expandedDirs, fetchDir])
 
   if (!baseUrl) return <div className="p-3 text-xs text-text-muted">No host connected</div>
+  if (!workspaceId) return <div className="p-3 text-xs text-text-muted">請先選擇 Workspace</div>
 
   if (!projectPath) {
     const handleSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary

- **Fixes #257**: `FileTreeWorkspaceView` 在 `workspaceId` 為 `undefined`（standalone tab 模式）時，提交 projectPath 表單會靜默失敗
- 新增 `!workspaceId` early return guard，在 `!baseUrl` 之後、`!projectPath` 之前，顯示「請先選擇 Workspace」提示
- 新增測試覆蓋 workspaceId undefined 情境（正向：顯示提示；負向：不渲染表單）

## Test plan

- [x] 新測試：workspaceId undefined → 顯示「請先選擇 Workspace」
- [x] 新測試：workspaceId undefined → 不渲染 projectPath 表單
- [x] 所有 1318 個既有測試通過，零 regression