### PR TITLE
fix(spa): add a11y attributes to ModuleConfigSection toggle

### DIFF
--- a/spa/src/components/settings/ModuleConfigSection.test.tsx
+++ b/spa/src/components/settings/ModuleConfigSection.test.tsx
@@ -58,9 +58,10 @@ describe('ModuleConfigSection', () => {
       expect(screen.getByRole('switch').getAttribute('type')).toBe('button')
     })
 
-    it('does not use <label> element for boolean field', () => {
-      render(<ModuleConfigSection scope="global" />)
-      expect(screen.queryByLabelText('Enable Feature')).toBeTruthy() // aria-label on ToggleSwitch
+    it('uses aria-label instead of <label> element for boolean field', () => {
+      const { container } = render(<ModuleConfigSection scope="global" />)
+      expect(container.querySelector('label')).toBeNull()
+      expect(screen.getByRole('switch').getAttribute('aria-label')).toBe('Enable Feature')
     })
   })
 

--- a/spa/src/components/settings/ModuleConfigSection.test.tsx
+++ b/spa/src/components/settings/ModuleConfigSection.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ModuleConfigSection } from './ModuleConfigSection'
+
+// Mock module-registry
+vi.mock('../../lib/module-registry', () => ({
+  getModulesWithGlobalConfig: vi.fn(() => []),
+  getModulesWithWorkspaceConfig: vi.fn(() => []),
+}))
+
+// Mock stores
+vi.mock('../../stores/useModuleConfigStore', () => ({
+  useModuleConfigStore: Object.assign(vi.fn(() => undefined), {
+    getState: () => ({ setGlobalModuleConfig: vi.fn() }),
+  }),
+}))
+
+vi.mock('../../features/workspace/store', () => ({
+  useWorkspaceStore: Object.assign(vi.fn(() => undefined), {
+    getState: () => ({ setModuleConfig: vi.fn() }),
+  }),
+}))
+
+import { getModulesWithGlobalConfig } from '../../lib/module-registry'
+import type { ModuleDefinition } from '../../lib/module-registry'
+
+describe('ModuleConfigSection', () => {
+  beforeEach(() => {
+    vi.mocked(getModulesWithGlobalConfig).mockReturnValue([])
+  })
+
+  it('renders nothing when no modules have config', () => {
+    const { container } = render(<ModuleConfigSection scope="global" />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  describe('boolean config field', () => {
+    beforeEach(() => {
+      vi.mocked(getModulesWithGlobalConfig).mockReturnValue([{
+        id: 'test-mod',
+        name: 'Test Module',
+        globalConfig: [{ key: 'enabled', type: 'boolean', label: 'Enable Feature', defaultValue: false }],
+      }] as ModuleDefinition[])
+    })
+
+    it('renders toggle with role="switch"', () => {
+      render(<ModuleConfigSection scope="global" />)
+      expect(screen.getByRole('switch')).toBeTruthy()
+    })
+
+    it('has correct aria-checked reflecting value', () => {
+      render(<ModuleConfigSection scope="global" />)
+      expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('false')
+    })
+
+    it('has type="button"', () => {
+      render(<ModuleConfigSection scope="global" />)
+      expect(screen.getByRole('switch').getAttribute('type')).toBe('button')
+    })
+
+    it('does not use <label> element for boolean field', () => {
+      render(<ModuleConfigSection scope="global" />)
+      expect(screen.queryByLabelText('Enable Feature')).toBeTruthy() // aria-label on ToggleSwitch
+    })
+  })
+
+  describe('text config field', () => {
+    beforeEach(() => {
+      vi.mocked(getModulesWithGlobalConfig).mockReturnValue([{
+        id: 'test-mod',
+        name: 'Test Module',
+        globalConfig: [{ key: 'apiUrl', type: 'string', label: 'API URL', defaultValue: '' }],
+      }] as ModuleDefinition[])
+    })
+
+    it('associates label with input via htmlFor', () => {
+      render(<ModuleConfigSection scope="global" />)
+      const input = screen.getByRole('textbox')
+      const label = input.closest('div')?.querySelector('label')
+      expect(label).toBeTruthy()
+      expect(label!.getAttribute('for')).toBe(input.id)
+    })
+  })
+})

--- a/spa/src/components/settings/ModuleConfigSection.tsx
+++ b/spa/src/components/settings/ModuleConfigSection.tsx
@@ -1,8 +1,10 @@
 // spa/src/components/settings/ModuleConfigSection.tsx
+import { useId } from 'react'
 import { getModulesWithGlobalConfig, getModulesWithWorkspaceConfig } from '../../lib/module-registry'
 import type { ConfigDef } from '../../lib/module-registry'
 import { useModuleConfigStore } from '../../stores/useModuleConfigStore'
 import { useWorkspaceStore } from '../../features/workspace/store'
+import { ToggleSwitch } from './ToggleSwitch'
 
 interface Props {
   scope: 'global' | { workspaceId: string }
@@ -33,6 +35,9 @@ export function ModuleConfigSection({ scope }: Props) {
 }
 
 function ConfigField({ def, moduleId, scope }: { def: ConfigDef; moduleId: string; scope: Props['scope'] }) {
+  const id = useId()
+  const fieldId = id + '-' + def.key
+
   const globalValue = useModuleConfigStore((s) => s.globalConfig[moduleId]?.[def.key])
   const wsValue = useWorkspaceStore((s) => {
     if (scope === 'global') return undefined
@@ -53,21 +58,22 @@ function ConfigField({ def, moduleId, scope }: { def: ConfigDef; moduleId: strin
 
   return (
     <div className="flex items-center justify-between py-1">
-      <label className="text-xs text-text-secondary">{def.label}</label>
       {def.type === 'boolean' ? (
-        <button
-          className={`w-8 h-4 rounded-full transition-colors ${displayValue ? 'bg-accent-base' : 'bg-surface-hover'}`}
-          onClick={() => handleChange(!displayValue)}
-        >
-          <div className={`w-3 h-3 rounded-full bg-white transition-transform ${displayValue ? 'translate-x-4' : 'translate-x-0.5'}`} />
-        </button>
+        <>
+          <span className="text-xs text-text-secondary">{def.label}</span>
+          <ToggleSwitch label={def.label} checked={!!displayValue} onChange={(v) => handleChange(v)} />
+        </>
       ) : (
-        <input
-          className="w-48 px-2 py-0.5 rounded border border-border-default bg-surface-primary text-xs text-text-primary"
-          type={def.type === 'number' ? 'number' : 'text'}
-          value={String(displayValue)}
-          onChange={(e) => handleChange(def.type === 'number' ? Number(e.target.value) : e.target.value)}
-        />
+        <>
+          <label htmlFor={fieldId} className="text-xs text-text-secondary">{def.label}</label>
+          <input
+            id={fieldId}
+            className="w-48 px-2 py-0.5 rounded border border-border-default bg-surface-primary text-xs text-text-primary"
+            type={def.type === 'number' ? 'number' : 'text'}
+            value={String(displayValue)}
+            onChange={(e) => handleChange(def.type === 'number' ? Number(e.target.value) : e.target.value)}
+          />
+        </>
       )}
     </div>
   )

--- a/spa/src/components/settings/ToggleSwitch.test.tsx
+++ b/spa/src/components/settings/ToggleSwitch.test.tsx
@@ -25,6 +25,11 @@ describe('ToggleSwitch', () => {
     expect(screen.getByLabelText('My Toggle')).toBeTruthy()
   })
 
+  it('has type="button" to prevent form submission', () => {
+    render(<ToggleSwitch label="Test" checked={false} onChange={vi.fn()} />)
+    expect(screen.getByRole('switch').getAttribute('type')).toBe('button')
+  })
+
   it('applies active color when checked', () => {
     render(<ToggleSwitch label="Test" checked={true} onChange={vi.fn()} />)
     expect(screen.getByRole('switch').className).toContain('bg-accent')

--- a/spa/src/components/settings/ToggleSwitch.tsx
+++ b/spa/src/components/settings/ToggleSwitch.tsx
@@ -7,6 +7,7 @@ interface Props {
 export function ToggleSwitch({ label, checked, onChange }: Props) {
   return (
     <button
+      type="button"
       role="switch"
       aria-label={label}
       aria-checked={checked}


### PR DESCRIPTION
## Summary

- Reuse `ToggleSwitch` component for boolean config fields, replacing inline `<button>` that lacked `role="switch"`, `aria-checked`, `type="button"`
- Add `htmlFor`/`id` association for text/number config field `<label>` elements  
- Change boolean field outer `<label>` to `<span>` to avoid orphan label a11y warning

Closes #258

## Test plan

- [x] `ToggleSwitch.test.tsx`: 6 tests pass (including new `type="button"` test)
- [x] `ModuleConfigSection.test.tsx`: 6 new tests covering boolean a11y + text label association
- [x] Full suite: 1325 tests pass
- [x] Lint: no new errors