### PR TITLE
fix(spa): bump useAgentStore persist version for tabIndicatorStyle default

### DIFF
--- a/spa/src/components/SortableTab.test.tsx
+++ b/spa/src/components/SortableTab.test.tsx
@@ -57,7 +57,7 @@ beforeEach(() => {
   useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
   useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: null })
   useHostStore.setState({ runtime: {} })
-  useAgentStore.setState({ unread: {}, statuses: {}, subagents: {}, tabIndicatorStyle: 'overlay' })
+  useAgentStore.setState({ unread: {}, statuses: {}, subagents: {}, tabIndicatorStyle: 'replace' })
   useI18nStore.setState({ t: (k: string) => k })
 })
 

--- a/spa/src/hooks/useNotificationDispatcher.test.ts
+++ b/spa/src/hooks/useNotificationDispatcher.test.ts
@@ -122,7 +122,7 @@ describe('handleNotificationClick workspace switching', () => {
     // Reset all stores
     useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
     useWorkspaceStore.getState().reset()
-    useAgentStore.setState({ lastEvents: {}, statuses: {}, unread: {}, subagents: {}, models: {}, agentTypes: {}, tabIndicatorStyle: 'overlay' })
+    useAgentStore.setState({ lastEvents: {}, statuses: {}, unread: {}, subagents: {}, models: {}, agentTypes: {}, tabIndicatorStyle: 'replace' })
     useNotificationSettingsStore.setState({ agents: {} })
     useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
     // Mock window.electronAPI as undefined (not in Electron in tests)

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -147,7 +147,7 @@ export const useAgentStore = create<AgentState>()(
     {
       name: STORAGE_KEYS.AGENT,
       storage: purdexStorage,
-      version: 2,  // bumped from 1
+      version: 3,
       partialize: (state) => ({ tabIndicatorStyle: state.tabIndicatorStyle }),
     },
   ),


### PR DESCRIPTION
## Summary

- Bump `useAgentStore` persist version 2 → 3 to discard old persisted `tabIndicatorStyle: 'overlay'`
- Zustand automatically resets to the new default `'replace'` on version mismatch
- Update test fixtures to match the current default value

Closes #268

## Test plan

- [x] Full suite: 1326 tests pass
- [x] No migration needed (Alpha policy: Zustand auto-reset on version bump)