### PR TITLE
fix(daemon): add local fallback for pdx setup when daemon unreachable

### DIFF
--- a/cmd/pdx/setup.go
+++ b/cmd/pdx/setup.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"time"
 
+	agentcc "github.com/wake/purdex/internal/agent/cc"
+	"github.com/wake/purdex/internal/agent/codex"
 	"github.com/wake/purdex/internal/config"
 )
 
@@ -63,8 +65,17 @@ func runSetup(args []string) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "setup: cannot reach daemon: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "setup: daemon unreachable, installing hooks locally\n")
+		if err := localSetup(agentType, remove); err != nil {
+			fmt.Fprintf(os.Stderr, "setup: %v\n", err)
+			os.Exit(1)
+		}
+		if remove {
+			fmt.Printf("pdx hooks for %s removed\n", agentType)
+		} else {
+			fmt.Printf("pdx hooks for %s installed\n", agentType)
+		}
+		return
 	}
 	defer resp.Body.Close()
 
@@ -78,5 +89,32 @@ func runSetup(args []string) {
 		fmt.Printf("pdx hooks for %s removed\n", agentType)
 	} else {
 		fmt.Printf("pdx hooks for %s installed\n", agentType)
+	}
+}
+
+// localSetup installs or removes hooks directly without the daemon.
+// The hook methods on CC/Codex providers don't use any injected dependencies,
+// so we can construct providers with nil deps for local-only operation.
+func localSetup(agentType string, remove bool) error {
+	pdxPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("cannot find pdx binary: %w", err)
+	}
+
+	switch agentType {
+	case "cc":
+		p := agentcc.NewProvider(nil, nil, nil, nil)
+		if remove {
+			return p.RemoveHooks(pdxPath)
+		}
+		return p.InstallHooks(pdxPath)
+	case "codex":
+		p := codex.NewProvider()
+		if remove {
+			return p.RemoveHooks(pdxPath)
+		}
+		return p.InstallHooks(pdxPath)
+	default:
+		return fmt.Errorf("unknown agent type: %s (supported: cc, codex)", agentType)
 	}
 }

--- a/cmd/pdx/setup.go
+++ b/cmd/pdx/setup.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	agentcc "github.com/wake/purdex/internal/agent/cc"
@@ -62,7 +63,10 @@ func runSetup(args []string) {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	// Short timeout: daemon is local, responds instantly if running.
+	// Fallback only triggers on transport errors (connection refused, timeout),
+	// not on HTTP 4xx/5xx from a running daemon.
+	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "setup: daemon unreachable, installing hooks locally\n")
@@ -99,6 +103,9 @@ func localSetup(agentType string, remove bool) error {
 	pdxPath, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("cannot find pdx binary: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(pdxPath); err == nil {
+		pdxPath = resolved
 	}
 
 	switch agentType {

--- a/cmd/pdx/setup_test.go
+++ b/cmd/pdx/setup_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalSetup(t *testing.T) {
+	t.Run("cc install creates settings.json", func(t *testing.T) {
+		tmpHome := t.TempDir()
+		t.Setenv("HOME", tmpHome)
+
+		err := localSetup("cc", false)
+		if err != nil {
+			t.Fatalf("localSetup cc install: %v", err)
+		}
+
+		settingsPath := filepath.Join(tmpHome, ".claude", "settings.json")
+		data, err := os.ReadFile(settingsPath)
+		if err != nil {
+			t.Fatalf("read settings.json: %v", err)
+		}
+		if len(data) == 0 {
+			t.Fatal("settings.json is empty")
+		}
+
+		var settings map[string]any
+		if err := json.Unmarshal(data, &settings); err != nil {
+			t.Fatalf("parse settings.json: %v", err)
+		}
+		if _, ok := settings["hooks"]; !ok {
+			t.Fatal("settings.json missing 'hooks' key")
+		}
+	})
+
+	t.Run("codex install creates hooks.json", func(t *testing.T) {
+		tmpHome := t.TempDir()
+		t.Setenv("HOME", tmpHome)
+
+		err := localSetup("codex", false)
+		if err != nil {
+			t.Fatalf("localSetup codex install: %v", err)
+		}
+
+		hooksPath := filepath.Join(tmpHome, ".codex", "hooks.json")
+		data, err := os.ReadFile(hooksPath)
+		if err != nil {
+			t.Fatalf("read hooks.json: %v", err)
+		}
+		if len(data) == 0 {
+			t.Fatal("hooks.json is empty")
+		}
+
+		var hooksFile map[string]any
+		if err := json.Unmarshal(data, &hooksFile); err != nil {
+			t.Fatalf("parse hooks.json: %v", err)
+		}
+		if _, ok := hooksFile["hooks"]; !ok {
+			t.Fatal("hooks.json missing 'hooks' key")
+		}
+	})
+
+	t.Run("unknown agent returns error", func(t *testing.T) {
+		err := localSetup("unknown", false)
+		if err == nil {
+			t.Fatal("expected error for unknown agent")
+		}
+	})
+
+	t.Run("cc remove on empty dir succeeds", func(t *testing.T) {
+		tmpHome := t.TempDir()
+		t.Setenv("HOME", tmpHome)
+
+		err := localSetup("cc", true)
+		if err != nil {
+			t.Fatalf("localSetup cc remove: %v", err)
+		}
+	})
+
+	t.Run("codex remove on empty dir succeeds", func(t *testing.T) {
+		tmpHome := t.TempDir()
+		t.Setenv("HOME", tmpHome)
+
+		err := localSetup("codex", true)
+		if err != nil {
+			t.Fatalf("localSetup codex remove: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- When `pdx setup --agent cc` can't reach the daemon, fall back to local hook installation
- Uses provider `InstallHooks()`/`RemoveHooks()` methods directly (they don't need daemon)
- Prints `stderr` warning: `setup: daemon unreachable, installing hooks locally`
- Previous behavior: `os.Exit(1)` with "cannot reach daemon" error

Closes #255

## Test plan

- [x] 5 new tests for `localSetup` (cc install, codex install, unknown agent, cc remove, codex remove)
- [x] Full Go test suite passes
- [x] Build succeeds