### PR TITLE
fix(spa): browser tab insertion — workspace order + nearest browser position

### DIFF
--- a/spa/src/lib/__tests__/find-browser-insert-target.test.ts
+++ b/spa/src/lib/__tests__/find-browser-insert-target.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { findBrowserInsertTarget } from '../find-browser-insert-target'
+import type { Tab } from '../../types/tab'
+
+function makeTab(id: string, kind: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: { type: 'leaf', pane: { id: `p-${id}`, content: kind === 'browser' ? { kind: 'browser', url: 'https://example.com' } : { kind: 'tmux-session', hostId: 'h', sessionCode: 's', mode: 'terminal', cachedName: '', tmuxInstance: '' } } },
+  }
+}
+
+function makeTabs(...specs: [string, string][]): Record<string, Tab> {
+  const result: Record<string, Tab> = {}
+  for (const [id, kind] of specs) {
+    result[id] = makeTab(id, kind)
+  }
+  return result
+}
+
+describe('findBrowserInsertTarget', () => {
+  it('returns nearest browser tab to the right', () => {
+    const tabs = makeTabs(['t1', 'terminal'], ['t2', 'terminal'], ['b1', 'browser'], ['t3', 'terminal'])
+    const result = findBrowserInsertTarget(['t1', 't2', 'b1', 't3'], 't1', tabs)
+    expect(result).toBe('b1')
+  })
+
+  it('skips non-browser tabs when scanning right', () => {
+    const tabs = makeTabs(['t1', 'terminal'], ['t2', 'terminal'], ['t3', 'terminal'], ['b1', 'browser'])
+    const result = findBrowserInsertTarget(['t1', 't2', 't3', 'b1'], 't1', tabs)
+    expect(result).toBe('b1')
+  })
+
+  it('returns activeTabId when no browser tab to the right', () => {
+    const tabs = makeTabs(['b1', 'browser'], ['t1', 'terminal'], ['t2', 'terminal'])
+    const result = findBrowserInsertTarget(['b1', 't1', 't2'], 't1', tabs)
+    expect(result).toBe('t1')
+  })
+
+  it('returns activeTabId when active tab is last', () => {
+    const tabs = makeTabs(['t1', 'terminal'], ['t2', 'terminal'])
+    const result = findBrowserInsertTarget(['t1', 't2'], 't2', tabs)
+    expect(result).toBe('t2')
+  })
+
+  it('returns activeTabId when not found in order', () => {
+    const tabs = makeTabs(['t1', 'terminal'])
+    const result = findBrowserInsertTarget(['t1'], 'nonexistent', tabs)
+    expect(result).toBe('nonexistent')
+  })
+
+  it('picks the nearest (first) browser tab among multiple', () => {
+    const tabs = makeTabs(['t1', 'terminal'], ['b1', 'browser'], ['b2', 'browser'], ['t2', 'terminal'])
+    const result = findBrowserInsertTarget(['t1', 'b1', 'b2', 't2'], 't1', tabs)
+    expect(result).toBe('b1')
+  })
+
+  it('works when active tab is a browser tab — scans right for next browser', () => {
+    const tabs = makeTabs(['b1', 'browser'], ['t1', 'terminal'], ['b2', 'browser'])
+    const result = findBrowserInsertTarget(['b1', 't1', 'b2'], 'b1', tabs)
+    expect(result).toBe('b2')
+  })
+
+  it('works when active tab is a browser tab and no browser to the right', () => {
+    const tabs = makeTabs(['b1', 'browser'], ['t1', 'terminal'])
+    const result = findBrowserInsertTarget(['b1', 't1'], 'b1', tabs)
+    expect(result).toBe('b1')
+  })
+
+  it('handles empty order array', () => {
+    const result = findBrowserInsertTarget([], 't1', {})
+    expect(result).toBe('t1')
+  })
+})

--- a/spa/src/lib/__tests__/open-browser-tab.test.ts
+++ b/spa/src/lib/__tests__/open-browser-tab.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { openBrowserTab } from '../open-browser-tab'
+import { useTabStore } from '../../stores/useTabStore'
+import { useWorkspaceStore } from '../../features/workspace/store'
+import { createTab } from '../../types/tab'
+
+function addTerminalTab(id?: string) {
+  const tab = createTab({ kind: 'tmux-session', hostId: 'h', sessionCode: 's', mode: 'terminal', cachedName: '', tmuxInstance: '' })
+  if (id) (tab as { id: string }).id = id
+  useTabStore.getState().addTab(tab)
+  return tab
+}
+
+function addBrowserTab(id?: string, url = 'https://example.com') {
+  const tab = createTab({ kind: 'browser', url })
+  if (id) (tab as { id: string }).id = id
+  useTabStore.getState().addTab(tab)
+  return tab
+}
+
+describe('openBrowserTab — workspace tab insertion order', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useWorkspaceStore.getState().reset()
+  })
+
+  it('inserts after nearest browser tab to the right in workspace', () => {
+    // Setup: [T1*] [T2] [B1] [T3] in workspace
+    const ws = useWorkspaceStore.getState().addWorkspace('Test')
+    const t1 = addTerminalTab('t1')
+    const t2 = addTerminalTab('t2')
+    const b1 = addBrowserTab('b1')
+    const t3 = addTerminalTab('t3')
+    useWorkspaceStore.getState().addTabToWorkspace(ws.id, t1.id)
+    useWorkspaceStore.getState().addTabToWorkspace(ws.id, t2.id)
+    useWorkspaceStore.getState().addTabToWorkspace(ws.id, b1.id)
+    useWorkspaceStore.getState().addTabToWorkspace(ws.id, t3.id)
+    useTabStore.getState().setActiveTab(t1.id)
+
+    openBrowserTab('https://new.com')
+
+    const wsState = useWorkspaceStore.getState().workspaces[0]
+    const newTabId = wsState.tabs.find((id) => id !== t1.id && id !== t2.id && id !== b1.id && id !== t3.id)!
+    const b1Idx = wsState.tabs.indexOf(b1.id)
+    const newIdx = wsState.tabs.indexOf(newTabId)
+    // New tab should be right after B1
+    expect(newIdx).toBe(b1Idx + 1)
+  })
+
+  it('inserts after active tab when no browser tab to the right', () => {
+    // Setup: [B1] [T1*] [T2] in workspace
+    const ws = useWorkspaceStore.getState().addWorkspace('Test')
+    const b1 = addBrowserTab('b1')
+    const t1 = addTerminalTab('t1')
+    const t2 = addTerminalTab('t2')
+    useWorkspaceStore.getState().addTabToWorkspace(ws.id, b1.id)
+    useWorkspaceStore.getState().addTabToWorkspace(ws.id, t1.id)
+    useWorkspaceStore.getState().addTabToWorkspace(ws.id, t2.id)
+    useTabStore.getState().setActiveTab(t1.id)
+
+    openBrowserTab('https://new.com')
+
+    const wsState = useWorkspaceStore.getState().workspaces[0]
+    const newTabId = wsState.tabs.find((id) => id !== b1.id && id !== t1.id && id !== t2.id)!
+    const t1Idx = wsState.tabs.indexOf(t1.id)
+    const newIdx = wsState.tabs.indexOf(newTabId)
+    expect(newIdx).toBe(t1Idx + 1)
+  })
+
+  it('appends when no active tab', () => {
+    const ws = useWorkspaceStore.getState().addWorkspace('Test')
+    const t1 = addTerminalTab('t1')
+    useWorkspaceStore.getState().addTabToWorkspace(ws.id, t1.id)
+    // activeTabId is null
+
+    openBrowserTab('https://new.com')
+
+    const wsState = useWorkspaceStore.getState().workspaces[0]
+    expect(wsState.tabs).toHaveLength(2)
+    // New tab should be at the end
+    expect(wsState.tabs[1]).not.toBe(t1.id)
+  })
+
+  it('sets new tab as workspace active tab', () => {
+    const ws = useWorkspaceStore.getState().addWorkspace('Test')
+    const t1 = addTerminalTab('t1')
+    useWorkspaceStore.getState().addTabToWorkspace(ws.id, t1.id)
+    useTabStore.getState().setActiveTab(t1.id)
+
+    openBrowserTab('https://new.com')
+
+    const wsState = useWorkspaceStore.getState().workspaces[0]
+    const newTabId = wsState.tabs.find((id) => id !== t1.id)!
+    expect(wsState.activeTabId).toBe(newTabId)
+  })
+})
+
+describe('openBrowserTab — global tabOrder insertion (no workspace)', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useWorkspaceStore.getState().reset()
+  })
+
+  it('inserts after nearest browser tab to the right in tabOrder', () => {
+    // Setup: [T1*] [T2] [B1] [T3], no workspace
+    const t1 = addTerminalTab('t1')
+    const t2 = addTerminalTab('t2')
+    const b1 = addBrowserTab('b1')
+    const t3 = addTerminalTab('t3')
+    useTabStore.getState().setActiveTab(t1.id)
+
+    openBrowserTab('https://new.com')
+
+    const tabOrder = useTabStore.getState().tabOrder
+    const newTabId = tabOrder.find((id) => id !== t1.id && id !== t2.id && id !== b1.id && id !== t3.id)!
+    const b1Idx = tabOrder.indexOf(b1.id)
+    const newIdx = tabOrder.indexOf(newTabId)
+    expect(newIdx).toBe(b1Idx + 1)
+  })
+})

--- a/spa/src/lib/find-browser-insert-target.ts
+++ b/spa/src/lib/find-browser-insert-target.ts
@@ -1,0 +1,25 @@
+import type { Tab } from '../types/tab'
+import { getPrimaryPane } from './pane-tree'
+
+/**
+ * Find the insertion target for a new browser tab.
+ * Scans right from activeTabId to find the nearest browser tab.
+ * Returns that browser tab's ID (insert after it), or activeTabId if none found.
+ */
+export function findBrowserInsertTarget(
+  orderedTabIds: string[],
+  activeTabId: string,
+  tabs: Record<string, Tab>,
+): string {
+  const activeIdx = orderedTabIds.indexOf(activeTabId)
+  if (activeIdx === -1) return activeTabId
+
+  for (let i = activeIdx + 1; i < orderedTabIds.length; i++) {
+    const tab = tabs[orderedTabIds[i]]
+    if (tab && getPrimaryPane(tab.layout).content.kind === 'browser') {
+      return orderedTabIds[i]
+    }
+  }
+
+  return activeTabId
+}

--- a/spa/src/lib/open-browser-tab.ts
+++ b/spa/src/lib/open-browser-tab.ts
@@ -1,21 +1,31 @@
 import { useTabStore } from '../stores/useTabStore'
 import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { createTab } from '../types/tab'
+import { findBrowserInsertTarget } from './find-browser-insert-target'
 
 /**
  * Open a new browser tab with the given URL.
- * Integrates with workspace: adds to active workspace and sets as active tab.
- * Can be called from anywhere (not a hook — uses store.getState() directly).
+ * Inserts after the nearest browser tab to the right of the active tab.
+ * Falls back to inserting after the active tab if no browser tab is found.
  */
 export function openBrowserTab(url: string): void {
   const tab = createTab({ kind: 'browser', url })
-  const activeTabId = useTabStore.getState().activeTabId
-  useTabStore.getState().addTab(tab, activeTabId ?? undefined)
+  const tabState = useTabStore.getState()
+  const wsState = useWorkspaceStore.getState()
+  const activeTabId = tabState.activeTabId
+
+  const wsId = wsState.activeWorkspaceId
+  const ws = wsId ? wsState.workspaces.find((w) => w.id === wsId) : null
+  const visibleOrder = ws ? ws.tabs.filter((id) => !!tabState.tabs[id]) : tabState.tabOrder
+
+  const afterTabId = activeTabId
+    ? findBrowserInsertTarget(visibleOrder, activeTabId, tabState.tabs)
+    : undefined
+
+  useTabStore.getState().addTab(tab, afterTabId)
   useTabStore.getState().setActiveTab(tab.id)
 
-  const wsId = useWorkspaceStore.getState().activeWorkspaceId
   if (wsId) {
-    useWorkspaceStore.getState().addTabToWorkspace(wsId, tab.id)
-    useWorkspaceStore.getState().setWorkspaceActiveTab(wsId, tab.id)
+    wsState.insertTab(tab.id, wsId, afterTabId)
   }
 }


### PR DESCRIPTION
## Summary

- **修正 PR #233 regression**：`addTabToWorkspace` 沒有 `afterTabId` 支援，永遠 append 到末尾。UI 用 workspace tab order 顯示，導致 `addTab` 的 global `tabOrder` 修正無效
- **新插入邏輯**：從 active tab 往右掃描，找到最近的 browser tab 後插入其後方，讓 browser tabs 自然群聚
- **改用 `insertTab`**：workspace store 已有支援 `afterTabId` 的 `insertTab` 方法，取代 `addTabToWorkspace` + `setWorkspaceActiveTab`

## Changes

| 檔案 | 說明 |
|------|------|
| `spa/src/lib/find-browser-insert-target.ts` | 新增純函式，掃描右側最近 browser tab |
| `spa/src/lib/open-browser-tab.ts` | 計算 visible order → 找 browser 插入點 → 用 `insertTab` |
| `spa/src/lib/__tests__/find-browser-insert-target.test.ts` | 9 tests |
| `spa/src/lib/__tests__/open-browser-tab.test.ts` | 5 tests |

## Test plan

- [x] `findBrowserInsertTarget` 純函式 9 個邊界測試
- [x] `openBrowserTab` workspace + global tabOrder 整合測試 5 個
- [x] 全套 143 files / 1331 tests 通過
- [x] lint 無新增錯誤
- [ ] Electron app 中從 terminal 點擊 URL，確認新 tab 出現在右側最近 browser tab 之後
- [ ] 無 browser tab 時，確認新 tab 出現在 active tab 之後