### PR TITLE
fix(spa): show Home badge when standalone tab is focused

### DIFF
--- a/spa/src/features/workspace/components/ActivityBar.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.test.tsx
@@ -181,6 +181,20 @@ describe('ActivityBar', () => {
     expect(dots.length).toBeGreaterThanOrEqual(1)
   })
 
+  it('excludes focused standalone tab from Home badge unread count', () => {
+    useTabStore.setState({
+      tabs: {
+        s1: mockSessionTab('s1', 'h1', 'sa'),
+        s2: mockSessionTab('s2', 'h1', 'sb'),
+      },
+    })
+    // s1 (focused) has unread, s2 does not — badge should NOT show
+    useAgentStore.setState({ unread: { 'h1:sa': true } })
+
+    const { container } = render(<ActivityBar {...defaultProps} activeWorkspaceId={null} activeStandaloneTabId="s1" standaloneTabIds={['s1', 's2']} />)
+    expect(container.querySelector('[data-testid="home-unread-badge"]')).toBeNull()
+  })
+
   it('shows Home static dot for waiting status', () => {
     useTabStore.setState({
       tabs: { s1: mockSessionTab('s1', 'h1', 'sa') },

--- a/spa/src/features/workspace/components/ActivityBar.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.test.tsx
@@ -153,6 +153,34 @@ describe('ActivityBar', () => {
     expect(dots).toHaveLength(0)
   })
 
+  it('shows Home unread badge when standalone tab is focused and other standalone tabs have unreads', () => {
+    useTabStore.setState({
+      tabs: {
+        s1: mockSessionTab('s1', 'h1', 'sa'),
+        s2: mockSessionTab('s2', 'h1', 'sb'),
+      },
+    })
+    useAgentStore.setState({ unread: { 'h1:sb': true } })
+
+    render(<ActivityBar {...defaultProps} activeWorkspaceId={null} activeStandaloneTabId="s1" standaloneTabIds={['s1', 's2']} />)
+    const badge = screen.getByTestId('home-unread-badge')
+    expect(badge.textContent).toBe('1')
+  })
+
+  it('shows Home status dot when standalone tab is focused and other standalone tabs have running agent', () => {
+    useTabStore.setState({
+      tabs: {
+        s1: mockSessionTab('s1', 'h1', 'sa'),
+        s2: mockSessionTab('s2', 'h1', 'sb'),
+      },
+    })
+    useAgentStore.setState({ statuses: { 'h1:sb': 'running' } })
+
+    const { container } = render(<ActivityBar {...defaultProps} activeWorkspaceId={null} activeStandaloneTabId="s1" standaloneTabIds={['s1', 's2']} />)
+    const dots = container.querySelectorAll('.animate-breathe')
+    expect(dots.length).toBeGreaterThanOrEqual(1)
+  })
+
   it('shows Home static dot for waiting status', () => {
     useTabStore.setState({
       tabs: { s1: mockSessionTab('s1', 'h1', 'sa') },

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -143,12 +143,12 @@ export function ActivityBar({
 
   const { unreadCount: homeUnreadCount, aggregatedStatus: homeStatus } = useWorkspaceIndicators(standaloneTabIds)
   const isHomeActive = !activeWorkspaceId
-  const showHomeBadge = !isHomeActive && homeUnreadCount > 0
+  const showHomeBadge = (!isHomeActive || !!activeStandaloneTabId) && homeUnreadCount > 0
   return (
     <div className="hidden lg:flex w-11 flex-col items-center bg-surface-tertiary border-r border-border-subtle py-2 px-px gap-2.5 flex-shrink-0">
       {/* Home — standalone tabs */}
       <div className="relative group">
-        {homeStatus && !isHomeActive && (
+        {homeStatus && (!isHomeActive || !!activeStandaloneTabId) && (
           <span
             className={`absolute rounded-full ${homeStatus === 'running' ? 'animate-breathe' : ''}`}
             style={{

--- a/spa/src/features/workspace/components/ActivityBar.tsx
+++ b/spa/src/features/workspace/components/ActivityBar.tsx
@@ -141,7 +141,11 @@ export function ActivityBar({
     onReorderWorkspaces?.(newOrder)
   }, [wsIds, onReorderWorkspaces])
 
-  const { unreadCount: homeUnreadCount, aggregatedStatus: homeStatus } = useWorkspaceIndicators(standaloneTabIds)
+  const nonActiveStandaloneTabIds = useMemo(
+    () => activeStandaloneTabId ? standaloneTabIds.filter(id => id !== activeStandaloneTabId) : standaloneTabIds,
+    [standaloneTabIds, activeStandaloneTabId],
+  )
+  const { unreadCount: homeUnreadCount, aggregatedStatus: homeStatus } = useWorkspaceIndicators(nonActiveStandaloneTabIds)
   const isHomeActive = !activeWorkspaceId
   const showHomeBadge = (!isHomeActive || !!activeStandaloneTabId) && homeUnreadCount > 0
   return (


### PR DESCRIPTION
## Summary

- Decouple Home badge/status-dot from `isHomeActive` by checking `activeStandaloneTabId`
- Badge now shows when standalone tab is focused (other standalone tabs hidden, user needs notification)
- Badge stays hidden in genuine Home mode (all standalone tabs visible, badge redundant)
- Status dot follows same logic

Closes #253

## Test plan

- [x] 2 new tests: badge + status dot show when standalone tab focused
- [x] Existing tests pass: badge hidden in genuine Home mode, badge shown when workspace active
- [x] Full suite: 1342 tests pass (145 files)