### PR TITLE
fix: icon picker + upload paste injection

### DIFF
--- a/internal/module/agent/upload.go
+++ b/internal/module/agent/upload.go
@@ -91,11 +91,12 @@ func (m *Module) handleUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Inject path into tmux pane via send-keys (space prefix, quoted, literal mode).
-	// Quoting handles filenames with spaces so CC receives the full path as one token.
-	if err := m.core.Tmux.SendKeysRaw(tmuxName, "-l", ` "`+destPath+`"`); err != nil {
+	// Inject path into tmux pane via paste-buffer with bracketed paste markers.
+	// Using paste (not send-keys) so Claude Code's TUI recognises the event
+	// as a paste and auto-detects image file paths → [Image #N] chip.
+	if err := m.core.Tmux.PasteText(tmuxName, destPath); err != nil {
 		os.Remove(destPath) // Clean up orphaned file
-		log.Printf("[agent] send-keys: %v", err)
+		log.Printf("[agent] paste-text: %v", err)
 		http.Error(w, `{"error":"inject failed"}`, http.StatusInternalServerError)
 		return
 	}

--- a/internal/module/agent/upload_test.go
+++ b/internal/module/agent/upload_test.go
@@ -90,15 +90,11 @@ func TestHandleUpload_Success(t *testing.T) {
 	_, err := os.Stat(filepath.Join(m.uploadDir, "my-sess", "test.png"))
 	assert.NoError(t, err)
 
-	// send-keys should have been called with quoted path + literal flag.
-	calls := fake.RawKeysSent()
-	require.Len(t, calls, 1)
-	assert.Equal(t, "my-sess", calls[0].Target)
-	assert.Contains(t, calls[0].Keys, "-l")
-	// Path should be quoted and space-prefixed.
-	injected := calls[0].Keys[len(calls[0].Keys)-1]
-	assert.True(t, injected[0] == ' ', "should start with space")
-	assert.Contains(t, injected, `"`)
+	// PasteText should have been called with the file path.
+	pastes := fake.PastesSent()
+	require.Len(t, pastes, 1)
+	assert.Equal(t, "my-sess", pastes[0].Target)
+	assert.Contains(t, pastes[0].Text, "test.png")
 
 }
 
@@ -164,11 +160,11 @@ func TestHandleUpload_SessionNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-// TestHandleUpload_SendKeysFail verifies that when SendKeysRaw fails the
+// TestHandleUpload_PasteTextFail verifies that when PasteText fails the
 // uploaded file is removed from disk (no orphaned files).
-func TestHandleUpload_SendKeysFail(t *testing.T) {
+func TestHandleUpload_PasteTextFail(t *testing.T) {
 	m, fake := newUploadTestModule(t)
-	fake.FailSendKeys = true
+	fake.FailPasteText = true
 
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)

--- a/internal/tmux/executor.go
+++ b/internal/tmux/executor.go
@@ -27,6 +27,7 @@ type Executor interface {
 	HasSession(name string) bool
 	SendKeys(target, keys string) error
 	SendKeysRaw(target string, keys ...string) error
+	PasteText(target, text string) error
 	PaneCurrentCommand(target string) (string, error)
 	PanePID(target string) (string, error)
 	PaneChildCommands(target string) ([]string, error)
@@ -115,6 +116,24 @@ func (r *RealExecutor) SendKeysRaw(target string, keys ...string) error {
 	args := []string{"send-keys", "-t", target}
 	args = append(args, keys...)
 	return exec.Command("tmux", args...).Run()
+}
+
+func (r *RealExecutor) PasteText(target, text string) error {
+	// Use a named buffer to avoid races when multiple goroutines paste
+	// concurrently (the default anonymous buffer is shared globally).
+	bufName := fmt.Sprintf("pdx-%d", time.Now().UnixNano())
+
+	cmd := exec.Command("tmux", "load-buffer", "-b", bufName, "-")
+	cmd.Stdin = strings.NewReader(text)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("tmux load-buffer: %w", err)
+	}
+	// -d  deletes the named buffer after pasting.
+	// -p  wraps content in bracketed paste markers (\e[200~ … \e[201~)
+	//     so the receiving application (e.g. Claude Code) recognises it as
+	//     a paste event rather than typed input.
+	// -r  preserves LF as-is (default converts LF → CR).
+	return exec.Command("tmux", "paste-buffer", "-b", bufName, "-t", target, "-d", "-p", "-r").Run()
 }
 
 func (r *RealExecutor) PaneCurrentCommand(target string) (string, error) {

--- a/internal/tmux/executor_test.go
+++ b/internal/tmux/executor_test.go
@@ -195,3 +195,34 @@ func TestTmuxAliveSetFalse(t *testing.T) {
 		t.Error("TmuxAlive() = true after SetAlive(false), want false")
 	}
 }
+
+func TestPasteText(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	fake.AddSession("test", "/tmp")
+
+	err := fake.PasteText("test", "/path/to/image.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pastes := fake.PastesSent()
+	if len(pastes) != 1 {
+		t.Fatalf("want 1 paste call, got %d", len(pastes))
+	}
+	if pastes[0].Target != "test" {
+		t.Errorf("want target 'test', got %q", pastes[0].Target)
+	}
+	if pastes[0].Text != "/path/to/image.png" {
+		t.Errorf("want text '/path/to/image.png', got %q", pastes[0].Text)
+	}
+}
+
+func TestPasteTextFail(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	fake.FailPasteText = true
+
+	err := fake.PasteText("test", "anything")
+	if err == nil {
+		t.Error("want error when FailPasteText is true")
+	}
+}

--- a/internal/tmux/fake_executor.go
+++ b/internal/tmux/fake_executor.go
@@ -23,6 +23,11 @@ type SetWindowOptionCall struct {
 	Value  string
 }
 
+type PasteCall struct {
+	Target string
+	Text   string
+}
+
 type FakeExecutor struct {
 	mu                   sync.Mutex
 	sessions             map[string]TmuxSession // keyed by name for O(1) lookup
@@ -35,12 +40,14 @@ type FakeExecutor struct {
 	paneSizes            map[string][2]int      // target → [cols, rows]
 	rawKeysCalls         []RawKeysCall
 	keysCalls            []KeysCall
+	pasteCalls           []PasteCall
 	autoResizeCalls      []string              // targets passed to ResizeWindowAuto
 	setWindowOptionCalls []SetWindowOptionCall // calls to SetWindowOption
 	listCallCount        int                   // how many times ListSessions was called
 	alive                bool                  // whether tmux server is "alive"
 	HooksOutput          string                // returned by ShowHooksGlobal
 	FailSendKeys         bool                  // if true, SendKeysRaw returns an error
+	FailPasteText        bool                  // if true, PasteText returns an error
 }
 
 func NewFakeExecutor() *FakeExecutor {
@@ -168,6 +175,22 @@ func (f *FakeExecutor) SendKeysRaw(target string, keys ...string) error {
 		return fmt.Errorf("send-keys: simulated failure")
 	}
 	return nil
+}
+
+func (f *FakeExecutor) PasteText(target, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pasteCalls = append(f.pasteCalls, PasteCall{Target: target, Text: text})
+	if f.FailPasteText {
+		return fmt.Errorf("paste-buffer: simulated failure")
+	}
+	return nil
+}
+
+func (f *FakeExecutor) PastesSent() []PasteCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.pasteCalls
 }
 
 func (f *FakeExecutor) RawKeysSent() []RawKeysCall {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "out/main/index.mjs",
   "scripts": {
     "electron:dev": "electron-vite dev",
-    "electron:build": "electron-vite build && node scripts/build-electron.mjs",
+    "electron:build": "node spa/scripts/generate-icon-data.mjs && electron-vite build && node scripts/build-electron.mjs",
     "electron:preview": "electron-vite preview"
   },
   "build": {

--- a/spa/src/features/workspace/components/WorkspaceIconPicker.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceIconPicker.test.tsx
@@ -107,6 +107,15 @@ describe('WorkspaceIconPicker', () => {
     expect(boldBtn.className).not.toContain('bg-accent/20')
   })
 
+  it('calls onWeightChange when weight is switched', () => {
+    const onWeightChange = vi.fn()
+    render(<WorkspaceIconPicker currentIcon={undefined} onSelect={vi.fn()} onCancel={vi.fn()} onWeightChange={onWeightChange} />)
+    fireEvent.click(screen.getByTestId('weight-regular'))
+    expect(onWeightChange).toHaveBeenCalledWith('regular')
+    fireEvent.click(screen.getByTestId('weight-duotone'))
+    expect(onWeightChange).toHaveBeenCalledWith('duotone')
+  })
+
   it('shows empty state when search has no results', () => {
     render(<WorkspaceIconPicker currentIcon={undefined} onSelect={vi.fn()} onCancel={vi.fn()} />)
     const search = screen.getByPlaceholderText(/search/i)

--- a/spa/src/features/workspace/components/WorkspaceIconPicker.tsx
+++ b/spa/src/features/workspace/components/WorkspaceIconPicker.tsx
@@ -66,9 +66,10 @@ interface Props {
   onCancel: () => void
   inline?: boolean
   currentWeight?: IconWeight
+  onWeightChange?: (weight: IconWeight) => void
 }
 
-export function WorkspaceIconPicker({ currentIcon, onSelect, onCancel, inline, currentWeight = 'bold' }: Props) {
+export function WorkspaceIconPicker({ currentIcon, onSelect, onCancel, inline, currentWeight = 'bold', onWeightChange }: Props) {
   const t = useI18nStore((s) => s.t)
   const categories = Object.keys(CURATED_ICON_CATEGORIES)
   const [activeCategory, setActiveCategory] = useState(categories[0])
@@ -129,7 +130,7 @@ export function WorkspaceIconPicker({ currentIcon, onSelect, onCancel, inline, c
           <button
             key={w}
             data-testid={`weight-${w}`}
-            onClick={() => setWeight(w)}
+            onClick={() => { setWeight(w); onWeightChange?.(w) }}
             className={`px-2 py-0.5 rounded text-[11px] capitalize cursor-pointer transition-colors ${
               weight === w
                 ? 'bg-accent/20 text-accent font-semibold'

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
@@ -89,31 +89,13 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
           <h3 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-3">
             {t('workspace.change_icon') ?? 'Icon'}
           </h3>
-          {/* Weight toggle */}
-          {ws.icon && (
-            <div className="flex items-center gap-2 mb-3">
-              <span className="text-xs text-text-tertiary">Style</span>
-              {(['bold', 'regular', 'thin', 'light', 'fill', 'duotone'] as const).map((w) => (
-                <button
-                  key={w}
-                  onClick={() => setWorkspaceIconWeight(workspaceId, w)}
-                  className={`px-2.5 py-1 rounded text-xs capitalize cursor-pointer transition-colors ${
-                    (ws.iconWeight ?? 'bold') === w
-                      ? 'bg-accent/20 text-accent font-semibold'
-                      : 'text-text-secondary hover:text-text-primary hover:bg-surface-hover'
-                  }`}
-                >
-                  {w}
-                </button>
-              ))}
-            </div>
-          )}
           <WorkspaceIconPicker
             currentIcon={ws.icon}
             onSelect={handleIconSelect}
             onCancel={() => {}}
             inline
             currentWeight={ws.iconWeight}
+            onWeightChange={(w) => setWorkspaceIconWeight(workspaceId, w)}
           />
         </section>
 


### PR DESCRIPTION
## Summary

- **Icon 不顯示**：`electron:build` 加上 `generate-icon-data.mjs` 前置步驟，確保 bundled SPA 包含 icon weight JSON
- **重複 Style switcher**：移除 `WorkspaceSettingsPage` 的 weight toggle，改由 `WorkspaceIconPicker` 統一管理（新增 `onWeightChange` callback）
- **圖片注入失敗**：upload handler 從 `tmux send-keys -l` 改為 `tmux load-buffer` + `paste-buffer -p`，讓 CC 透過 bracketed paste 識別圖片路徑並 chip 化為 `[Image #N]`

## Test plan

- [ ] `pnpm run electron:build` 後確認 `out/renderer/icons/` 有 bold.json 等 weight JSON
- [ ] Workspace Settings 的 icon picker 只顯示一組 Style switcher，切換 weight 時 activity bar icon 同步更新
- [ ] 拖曳圖片到 terminal（agent active 時），確認 CC input 出現 `[Image #N]` chip