### PR TITLE
fix: block workspace arrow keys in Home, add Cmd+Alt+0 for Home

### DIFF
--- a/electron/keybindings.ts
+++ b/electron/keybindings.ts
@@ -35,6 +35,7 @@ const DEFAULT_KEYBINDINGS: readonly KeybindingDef[] = [
   { action: 'open-hosts', accelerator: 'CommandOrControl+Shift+H', label: 'Hosts', menuCategory: 'View', menuGroup: 'view' },
   { action: 'open-history', accelerator: 'CommandOrControl+Y', label: 'History', menuCategory: 'View', menuGroup: 'view' },
   // Workspace navigation
+  { action: 'switch-workspace-home', accelerator: 'CommandOrControl+Alt+0', label: 'Home', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
   { action: 'switch-workspace-1', accelerator: 'CommandOrControl+Alt+1', label: 'Workspace 1', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
   { action: 'switch-workspace-2', accelerator: 'CommandOrControl+Alt+2', label: 'Workspace 2', menuCategory: 'Tab', menuGroup: 'workspace-nav' },
   { action: 'switch-workspace-3', accelerator: 'CommandOrControl+Alt+3', label: 'Workspace 3', menuCategory: 'Tab', menuGroup: 'workspace-nav' },

--- a/spa/src/hooks/useShortcuts.test.ts
+++ b/spa/src/hooks/useShortcuts.test.ts
@@ -470,6 +470,68 @@ describe('useShortcuts', () => {
       fire('next-workspace')
       expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
     })
+
+    it('blocks next-workspace when in Home mode', () => {
+      const { fire } = mockElectronAPI()
+      seedTabs(1)
+      useWorkspaceStore.getState().addWorkspace('WS2')
+      useWorkspaceStore.getState().setActiveWorkspace(null)
+      renderHook(() => useShortcuts())
+
+      fire('next-workspace')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
+    })
+
+    it('blocks prev-workspace when in Home mode', () => {
+      const { fire } = mockElectronAPI()
+      seedTabs(1)
+      useWorkspaceStore.getState().addWorkspace('WS2')
+      useWorkspaceStore.getState().setActiveWorkspace(null)
+      renderHook(() => useShortcuts())
+
+      fire('prev-workspace')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
+    })
+  })
+
+  describe('switch-workspace-home', () => {
+    it('switches to Home (null activeWorkspaceId)', () => {
+      const { fire } = mockElectronAPI()
+      seedTabs(1)
+      const ws2 = useWorkspaceStore.getState().addWorkspace('WS2')
+      useWorkspaceStore.getState().setActiveWorkspace(ws2.id)
+      renderHook(() => useShortcuts())
+
+      fire('switch-workspace-home')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
+    })
+
+    it('activates first standalone tab when switching to Home', () => {
+      const { fire } = mockElectronAPI()
+      // Create a standalone tab (not added to any workspace)
+      const standaloneTab = createTab({ kind: 'new-tab' })
+      useTabStore.getState().addTab(standaloneTab)
+      // Create workspace and switch to it
+      const ws = useWorkspaceStore.getState().addWorkspace('WS1')
+      const wsTab = seedTabs(1, { addToWorkspace: false })[0]
+      useWorkspaceStore.getState().addTabToWorkspace(ws.id, wsTab.id)
+      useWorkspaceStore.getState().setActiveWorkspace(ws.id)
+      renderHook(() => useShortcuts())
+
+      fire('switch-workspace-home')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
+      expect(useTabStore.getState().activeTabId).toBe(standaloneTab.id)
+    })
+
+    it('sets activeTabId to null when no standalone tabs exist', () => {
+      const { fire } = mockElectronAPI()
+      seedTabs(1)
+      renderHook(() => useShortcuts())
+
+      fire('switch-workspace-home')
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBeNull()
+      expect(useTabStore.getState().activeTabId).toBeNull()
+    })
   })
 
   describe('tab shortcut registry dispatch', () => {

--- a/spa/src/hooks/useShortcuts.ts
+++ b/spa/src/hooks/useShortcuts.ts
@@ -100,6 +100,21 @@ export function useShortcuts(): void {
         return
       }
 
+      if (action === 'switch-workspace-home') {
+        useWorkspaceStore.getState().setActiveWorkspace(null)
+        const standaloneIds = getVisibleTabIdsShared({
+          tabs: tabState.tabs,
+          tabOrder: tabState.tabOrder,
+          activeTabId: tabState.activeTabId,
+          workspaces: useWorkspaceStore.getState().workspaces,
+          activeWorkspaceId: null,
+        })
+        const firstTab = standaloneIds[0]
+        if (firstTab) activateTab(firstTab)
+        else tabState.setActiveTab(null)
+        return
+      }
+
       if (action.startsWith('switch-workspace-')) {
         const workspaces = useWorkspaceStore.getState().workspaces
         if (workspaces.length === 0) return
@@ -113,14 +128,14 @@ export function useShortcuts(): void {
       }
 
       if (action === 'prev-workspace' || action === 'next-workspace') {
-        const workspaces = useWorkspaceStore.getState().workspaces
+        const wsStore = useWorkspaceStore.getState()
+        const workspaces = wsStore.workspaces
         if (workspaces.length === 0) return
-        const currentWsId = useWorkspaceStore.getState().activeWorkspaceId
-        const currentIdx = workspaces.findIndex((w) => w.id === currentWsId)
+        // Block navigation when in Home mode
+        if (wsStore.activeWorkspaceId === null) return
+        const currentIdx = workspaces.findIndex((w) => w.id === wsStore.activeWorkspaceId)
         const delta = action === 'next-workspace' ? 1 : -1
-        const nextIdx = currentIdx === -1
-          ? (delta > 0 ? 0 : workspaces.length - 1)
-          : (currentIdx + delta + workspaces.length) % workspaces.length
+        const nextIdx = (currentIdx + delta + workspaces.length) % workspaces.length
         const targetWs = workspaces[nextIdx]
         useWorkspaceStore.getState().setActiveWorkspace(targetWs.id)
         const activeTab = targetWs.activeTabId ?? targetWs.tabs[0]


### PR DESCRIPTION
## Summary
- Block `prev-workspace` / `next-workspace` (Cmd+Alt+Up/Down) when in Home mode — prevents accidental navigation out of Home
- Add `switch-workspace-home` action bound to `Cmd+Alt+0` to jump back to Home workspace, mirroring `Cmd+Alt+1-9` for numbered workspaces

## Test plan
- [x] 1349 tests pass (5 new tests added)
- [ ] In Home mode, press Cmd+Alt+Down — should not navigate away
- [ ] In a workspace, press Cmd+Alt+0 — should jump to Home
- [ ] Cmd+Alt+1-9 and Cmd+Alt+Up/Down still work normally between workspaces