### PR TITLE
fix(dev): install deps before auto build

### DIFF
--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -24,6 +24,7 @@ type DevModule struct {
 	building           bool
 	buildError         string
 	buildCmd           func() error
+	execCmd            func(ctx context.Context, dir string, name string, args ...string) ([]byte, error)
 	lastFailedSPA      string
 	lastFailedElectron string
 	stopCtx            context.Context
@@ -46,6 +47,9 @@ func (m *DevModule) Init(c *core.Core) error {
 	m.stopCtx, m.stopCancel = context.WithCancel(context.Background())
 	if m.hashFn == nil {
 		m.hashFn = m.gitHash
+	}
+	if m.execCmd == nil {
+		m.execCmd = runCombinedOutput
 	}
 	if m.buildCmd == nil {
 		m.buildCmd = m.defaultBuild
@@ -80,16 +84,43 @@ func (m *DevModule) defaultBuild() error {
 	}
 	ctx, cancel := context.WithTimeout(parent, 5*time.Minute)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "pnpm", "exec", "electron-vite", "build")
-	cmd.Dir = m.repoRoot
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("build timed out after 5 minutes")
-		}
-		log.Printf("[dev] build output: %s", string(out))
-		return err
+
+	steps := []struct {
+		label string
+		name  string
+		args  []string
+	}{
+		{
+			label: "dependency install",
+			name:  "pnpm",
+			args:  []string{"install", "--frozen-lockfile"},
+		},
+		{
+			label: "icon generation",
+			name:  "node",
+			args:  []string{"spa/scripts/generate-icon-data.mjs"},
+		},
+		{
+			label: "renderer/main build",
+			name:  "pnpm",
+			args:  []string{"exec", "electron-vite", "build"},
+		},
 	}
+
+	for _, step := range steps {
+		out, err := m.execCmd(ctx, m.repoRoot, step.name, step.args...)
+		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("build timed out after 5 minutes")
+			}
+			if len(out) > 0 {
+				log.Printf("[dev] %s output: %s", step.label, string(out))
+				return fmt.Errorf("%s failed: %w\n%s", step.label, err, strings.TrimSpace(string(out)))
+			}
+			return fmt.Errorf("%s failed: %w", step.label, err)
+		}
+	}
+
 	return nil
 }
 
@@ -127,4 +158,10 @@ func (m *DevModule) readVersion() string {
 		return "unknown"
 	}
 	return strings.TrimSpace(string(data))
+}
+
+func runCombinedOutput(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
 }

--- a/internal/module/dev/module_test.go
+++ b/internal/module/dev/module_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -96,7 +98,7 @@ func TestStop_CancelsBuild(t *testing.T) {
 func TestRunBuild_ClearsErrorOnSuccess(t *testing.T) {
 	m := &DevModule{
 		repoRoot:   t.TempDir(),
-		buildCmd:    func() error { return nil },
+		buildCmd:   func() error { return nil },
 		building:   true,
 		buildError: "previous error",
 	}
@@ -106,5 +108,61 @@ func TestRunBuild_ClearsErrorOnSuccess(t *testing.T) {
 
 	if m.buildError != "" {
 		t.Errorf("buildError: want empty after success, got %q", m.buildError)
+	}
+}
+
+func TestDefaultBuild_RunsInstallGenerateAndBuild(t *testing.T) {
+	repoRoot := t.TempDir()
+	m := &DevModule{
+		repoRoot: repoRoot,
+		stopCtx:  context.Background(),
+	}
+
+	var calls [][]string
+	m.execCmd = func(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+		if dir != repoRoot {
+			t.Fatalf("dir: want %s, got %s", repoRoot, dir)
+		}
+		calls = append(calls, append([]string{name}, args...))
+		return nil, nil
+	}
+
+	if err := m.defaultBuild(); err != nil {
+		t.Fatalf("defaultBuild: %v", err)
+	}
+
+	want := [][]string{
+		{"pnpm", "install", "--frozen-lockfile"},
+		{"node", "spa/scripts/generate-icon-data.mjs"},
+		{"pnpm", "exec", "electron-vite", "build"},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("commands:\nwant %#v\ngot  %#v", want, calls)
+	}
+}
+
+func TestDefaultBuild_ReturnsStepOutputOnFailure(t *testing.T) {
+	m := &DevModule{
+		repoRoot: t.TempDir(),
+		stopCtx:  context.Background(),
+	}
+
+	m.execCmd = func(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+		if name == "pnpm" && len(args) > 0 && args[0] == "install" {
+			return []byte("ERR_PNPM_OUTDATED_LOCKFILE"), fmt.Errorf("exit status 1")
+		}
+		return nil, nil
+	}
+
+	err := m.defaultBuild()
+	if err == nil {
+		t.Fatal("defaultBuild: want error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "dependency install failed") {
+		t.Fatalf("error: want dependency install context, got %q", msg)
+	}
+	if !strings.Contains(msg, "ERR_PNPM_OUTDATED_LOCKFILE") {
+		t.Fatalf("error: want command output, got %q", msg)
 	}
 }


### PR DESCRIPTION
## Summary
- add dependency install before dev auto-build runs
- generate icon data before electron-vite build
- include step-specific build errors and tests for the new sequence

## Verification
- go test ./internal/module/dev/...