### PR TITLE
refactor: add partialize + reconcileViews to useLayoutStore

### DIFF
--- a/spa/src/main.tsx
+++ b/spa/src/main.tsx
@@ -14,13 +14,7 @@ registerBuiltinLocales()
 registerBuiltinThemes()
 registerBuiltinModules()
 
-// Only set defaults if not already persisted (first install)
-const regions = useLayoutStore.getState().regions
-const hasAnyView = Object.values(regions).some((r) => r.views.length > 0)
-if (!hasAnyView) {
-  useLayoutStore.getState().setRegionViews('primary-sidebar', ['file-tree-workspace'])
-  useLayoutStore.getState().setActiveView('primary-sidebar', 'file-tree-workspace')
-}
+useLayoutStore.getState().reconcileViews()
 
 // Cross-store subscription: auto-markRead when active tab changes to a session.
 // Inlined here to avoid circular dependency between active-session.ts and useAgentStore.

--- a/spa/src/stores/useLayoutStore.test.ts
+++ b/spa/src/stores/useLayoutStore.test.ts
@@ -288,20 +288,63 @@ describe('reconcileViews', () => {
     expect(useLayoutStore.getState().regions['primary-sidebar'].activeViewId).toBe('view-b')
   })
 
-  it('sets defaults with activeViewId', () => {
+  it('no-ops when module registry is empty', () => {
+    useLayoutStore.getState().setRegionViews('primary-sidebar', ['some-view'])
+    useLayoutStore.getState().setActiveView('primary-sidebar', 'some-view')
+    // No registerModule — registry is empty
+    useLayoutStore.getState().reconcileViews()
+    expect(useLayoutStore.getState().regions['primary-sidebar'].views).toEqual(['some-view'])
+    expect(useLayoutStore.getState().regions['primary-sidebar'].activeViewId).toBe('some-view')
+  })
+
+  it('keeps allEmpty when file-tree-workspace is not registered', () => {
     registerModule({
       id: 'test-mod',
       name: 'Test',
       views: [{
-        id: 'file-tree-workspace',
-        label: 'File Tree',
+        id: 'other-view',
+        label: 'Other',
         icon: () => null,
         scope: 'workspace',
         component: () => null,
       }],
     })
     useLayoutStore.getState().reconcileViews()
-    expect(useLayoutStore.getState().regions['primary-sidebar'].views).toEqual(['file-tree-workspace'])
-    expect(useLayoutStore.getState().regions['primary-sidebar'].activeViewId).toBe('file-tree-workspace')
+    expect(useLayoutStore.getState().regions['primary-sidebar'].views).toEqual([])
+  })
+
+  it('removes stale views from non-primary-sidebar regions', () => {
+    useLayoutStore.getState().setRegionViews('secondary-sidebar', ['valid-view', 'stale-view'])
+    registerModule({
+      id: 'test-mod',
+      name: 'Test',
+      views: [{
+        id: 'valid-view',
+        label: 'Valid',
+        icon: () => null,
+        scope: 'workspace',
+        component: () => null,
+      }],
+    })
+    useLayoutStore.getState().reconcileViews()
+    expect(useLayoutStore.getState().regions['secondary-sidebar'].views).toEqual(['valid-view'])
+  })
+
+  it('preserves undefined activeViewId when no stale views', () => {
+    useLayoutStore.getState().setRegionViews('primary-sidebar', ['view-a'])
+    // activeViewId is undefined by default
+    registerModule({
+      id: 'test-mod',
+      name: 'Test',
+      views: [{
+        id: 'view-a',
+        label: 'A',
+        icon: () => null,
+        scope: 'workspace',
+        component: () => null,
+      }],
+    })
+    useLayoutStore.getState().reconcileViews()
+    expect(useLayoutStore.getState().regions['primary-sidebar'].activeViewId).toBeUndefined()
   })
 })

--- a/spa/src/stores/useLayoutStore.test.ts
+++ b/spa/src/stores/useLayoutStore.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useLayoutStore } from './useLayoutStore'
 import type { SidebarRegion } from '../types/layout'
+import { registerModule, clearModuleRegistry } from '../lib/module-registry'
 
 beforeEach(() => {
   useLayoutStore.setState(useLayoutStore.getInitialState())
+  clearModuleRegistry()
 })
 
 describe('useLayoutStore', () => {
@@ -177,5 +179,129 @@ describe('reorderViews', () => {
     useLayoutStore.getState().setRegionViews('primary-sidebar', ['a', 'b', 'c'])
     useLayoutStore.getState().reorderViews('primary-sidebar', ['b', 'x'])
     expect(useLayoutStore.getState().regions['primary-sidebar'].views).toEqual(['b', 'a', 'c'])
+  })
+})
+
+describe('reconcileViews', () => {
+  it('removes stale view IDs', () => {
+    useLayoutStore.getState().setRegionViews('primary-sidebar', ['valid-view', 'stale-view'])
+    registerModule({
+      id: 'test-mod',
+      name: 'Test',
+      views: [{
+        id: 'valid-view',
+        label: 'Valid',
+        icon: () => null,
+        scope: 'workspace',
+        component: () => null,
+      }],
+    })
+    useLayoutStore.getState().reconcileViews()
+    expect(useLayoutStore.getState().regions['primary-sidebar'].views).toEqual(['valid-view'])
+  })
+
+  it('fixes activeViewId when stale', () => {
+    useLayoutStore.getState().setRegionViews('primary-sidebar', ['valid-view', 'stale-view'])
+    useLayoutStore.getState().setActiveView('primary-sidebar', 'stale-view')
+    registerModule({
+      id: 'test-mod',
+      name: 'Test',
+      views: [{
+        id: 'valid-view',
+        label: 'Valid',
+        icon: () => null,
+        scope: 'workspace',
+        component: () => null,
+      }],
+    })
+    useLayoutStore.getState().reconcileViews()
+    expect(useLayoutStore.getState().regions['primary-sidebar'].activeViewId).toBe('valid-view')
+  })
+
+  it('sets defaults when all regions empty', () => {
+    registerModule({
+      id: 'test-mod',
+      name: 'Test',
+      views: [{
+        id: 'file-tree-workspace',
+        label: 'File Tree',
+        icon: () => null,
+        scope: 'workspace',
+        component: () => null,
+      }],
+    })
+    useLayoutStore.getState().reconcileViews()
+    expect(useLayoutStore.getState().regions['primary-sidebar'].views).toEqual(['file-tree-workspace'])
+    expect(useLayoutStore.getState().regions['primary-sidebar'].activeViewId).toBe('file-tree-workspace')
+  })
+
+  it('preserves valid views unchanged', () => {
+    useLayoutStore.getState().setRegionViews('primary-sidebar', ['view-a', 'view-b'])
+    registerModule({
+      id: 'test-mod',
+      name: 'Test',
+      views: [
+        {
+          id: 'view-a',
+          label: 'A',
+          icon: () => null,
+          scope: 'workspace',
+          component: () => null,
+        },
+        {
+          id: 'view-b',
+          label: 'B',
+          icon: () => null,
+          scope: 'workspace',
+          component: () => null,
+        },
+      ],
+    })
+    useLayoutStore.getState().reconcileViews()
+    expect(useLayoutStore.getState().regions['primary-sidebar'].views).toEqual(['view-a', 'view-b'])
+  })
+
+  it('preserves valid activeViewId', () => {
+    useLayoutStore.getState().setRegionViews('primary-sidebar', ['view-a', 'view-b'])
+    useLayoutStore.getState().setActiveView('primary-sidebar', 'view-b')
+    registerModule({
+      id: 'test-mod',
+      name: 'Test',
+      views: [
+        {
+          id: 'view-a',
+          label: 'A',
+          icon: () => null,
+          scope: 'workspace',
+          component: () => null,
+        },
+        {
+          id: 'view-b',
+          label: 'B',
+          icon: () => null,
+          scope: 'workspace',
+          component: () => null,
+        },
+      ],
+    })
+    useLayoutStore.getState().reconcileViews()
+    expect(useLayoutStore.getState().regions['primary-sidebar'].activeViewId).toBe('view-b')
+  })
+
+  it('sets defaults with activeViewId', () => {
+    registerModule({
+      id: 'test-mod',
+      name: 'Test',
+      views: [{
+        id: 'file-tree-workspace',
+        label: 'File Tree',
+        icon: () => null,
+        scope: 'workspace',
+        component: () => null,
+      }],
+    })
+    useLayoutStore.getState().reconcileViews()
+    expect(useLayoutStore.getState().regions['primary-sidebar'].views).toEqual(['file-tree-workspace'])
+    expect(useLayoutStore.getState().regions['primary-sidebar'].activeViewId).toBe('file-tree-workspace')
   })
 })

--- a/spa/src/stores/useLayoutStore.ts
+++ b/spa/src/stores/useLayoutStore.ts
@@ -128,6 +128,7 @@ export const useLayoutStore = create<LayoutState>()(
       reconcileViews: () =>
         set((state) => {
           const validIds = new Set(getAllViews().map((v) => v.id))
+          if (validIds.size === 0) return state
           const reconciled = { ...state.regions }
           for (const key of Object.keys(reconciled) as SidebarRegion[]) {
             const region = reconciled[key]
@@ -135,7 +136,9 @@ export const useLayoutStore = create<LayoutState>()(
             const activeViewId =
               region.activeViewId && filtered.includes(region.activeViewId)
                 ? region.activeViewId
-                : filtered[0]
+                : region.activeViewId !== undefined
+                  ? filtered[0]
+                  : undefined
             reconciled[key] = { ...region, views: filtered, activeViewId }
           }
           const allEmpty = Object.values(reconciled).every((r) => r.views.length === 0)

--- a/spa/src/stores/useLayoutStore.ts
+++ b/spa/src/stores/useLayoutStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { SidebarRegion } from '../types/layout'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
+import { getAllViews } from '../lib/module-registry'
 
 const MIN_WIDTH = 120
 const MAX_WIDTH = 600
@@ -26,6 +27,7 @@ interface LayoutState {
   addView: (region: SidebarRegion, viewId: string) => void
   removeView: (region: SidebarRegion, viewId: string) => void
   reorderViews: (region: SidebarRegion, views: string[]) => void
+  reconcileViews: () => void
 }
 
 function createDefaultRegions(): Record<SidebarRegion, RegionState> {
@@ -122,11 +124,36 @@ export const useLayoutStore = create<LayoutState>()(
           }
           return updateRegion(state, region, { views: reordered })
         }),
+
+      reconcileViews: () =>
+        set((state) => {
+          const validIds = new Set(getAllViews().map((v) => v.id))
+          const reconciled = { ...state.regions }
+          for (const key of Object.keys(reconciled) as SidebarRegion[]) {
+            const region = reconciled[key]
+            const filtered = region.views.filter((id) => validIds.has(id))
+            const activeViewId =
+              region.activeViewId && filtered.includes(region.activeViewId)
+                ? region.activeViewId
+                : filtered[0]
+            reconciled[key] = { ...region, views: filtered, activeViewId }
+          }
+          const allEmpty = Object.values(reconciled).every((r) => r.views.length === 0)
+          if (allEmpty && validIds.has('file-tree-workspace')) {
+            reconciled['primary-sidebar'] = {
+              ...reconciled['primary-sidebar'],
+              views: ['file-tree-workspace'],
+              activeViewId: 'file-tree-workspace',
+            }
+          }
+          return { regions: reconciled }
+        }),
     }),
     {
       name: STORAGE_KEYS.LAYOUT,
       storage: purdexStorage,
       version: 1,
+      partialize: (state) => ({ regions: state.regions }),
     },
   ),
 )


### PR DESCRIPTION
## Summary

- `useLayoutStore` 新增 `partialize` 設定，明確只持久化 `regions` state
- 新增 `reconcileViews()` action：啟動時驗證 views 是否仍對應已註冊模組，清除 stale ID、修正 activeViewId、首次安裝自動填入 defaults
- `main.tsx` 移除 ad-hoc `hasAnyView` 邏輯，改用 `reconcileViews()`

Closes #242

## Test plan

- [x] 新增 6 個 reconcileViews 測試（stale removal、activeViewId fix、default population、preservation）
- [x] 全量 1381 測試通過