### PR TITLE
fix(spa): checkHealth JSON parse error misclassified as refused

### DIFF
--- a/spa/src/lib/host-connection.test.ts
+++ b/spa/src/lib/host-connection.test.ts
@@ -101,6 +101,7 @@ describe('checkHealth', () => {
     )
     const result = await checkHealth('http://localhost:7860', () => 'mytoken')
     expect(result.daemon).toBe('connected')
+    expect(result.ticket).toBeUndefined()
     expect(result.latency).toBeGreaterThanOrEqual(0)
     expect(fetch).toHaveBeenCalledTimes(1) // Phase 2 not attempted
   })

--- a/spa/src/lib/host-connection.test.ts
+++ b/spa/src/lib/host-connection.test.ts
@@ -84,6 +84,27 @@ describe('checkHealth', () => {
     expect(result.mode).toBe('pending')
   })
 
+  it('Phase 1 JSON parse error (no token) → connected, not refused', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('not-json', { status: 200 })
+    )
+    const result = await checkHealth('http://localhost:7860')
+    expect(result.daemon).toBe('connected')
+    expect(result.latency).toBeGreaterThanOrEqual(0)
+    expect(result.mode).toBe('normal')
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('Phase 1 JSON parse error (with token) → connected, Phase 2 skipped', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('not-json', { status: 200 })
+    )
+    const result = await checkHealth('http://localhost:7860', () => 'mytoken')
+    expect(result.daemon).toBe('connected')
+    expect(result.latency).toBeGreaterThanOrEqual(0)
+    expect(fetch).toHaveBeenCalledTimes(1) // Phase 2 not attempted
+  })
+
   it('latency measured from Phase 1', async () => {
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(healthResponse())

--- a/spa/src/lib/host-connection.ts
+++ b/spa/src/lib/host-connection.ts
@@ -21,7 +21,12 @@ export async function checkHealth(
     const start = performance.now()
     const res = await fetch(`${baseUrl}/api/health`, { signal: ctrl1.signal })
     const latency = Math.round(performance.now() - start)
-    const body = await res.json()
+    let body: { mode?: string } = {}
+    try {
+      body = await res.json()
+    } catch {
+      return { daemon: 'connected', tmux: 'unavailable', latency, mode: 'normal' }
+    }
     const mode = (body.mode ?? 'normal') as 'pairing' | 'pending' | 'normal'
 
     const token = getToken?.()


### PR DESCRIPTION
## Summary
- `checkHealth` 在 HTTP 200 但 `res.json()` 拋出 SyntaxError 時，錯誤會跌入外層 catch 被歸類為 `refused`（L2），但此時 daemon 確實可達
- 用 inner try-catch 包住 `res.json()`，parse 失敗時回傳 `connected` + `mode: 'normal'`，不進入 Phase 2
- 新增兩個測試案例（無 token / 有 token + 無效 JSON），驗證分類正確且 Phase 2 不被觸發

Closes #161

## Design decisions
- **不新增 `degraded` 狀態**：`connected` 語義正確（daemon 可達），引入新 state 需連動修改 `ConnectionStateMachine`、`statusMap` 等，過度設計
- **Phase 1 JSON 失敗 → early return，不進 Phase 2**：無 mode 資訊就無法判斷是否需要 token 驗證
- **`res.ok` 檢查是獨立問題**，不在此 PR 範圍

## Test plan
- [x] 新增 `Phase 1 JSON parse error (no token) → connected` 測試
- [x] 新增 `Phase 1 JSON parse error (with token) → connected, Phase 2 skipped` 測試
- [x] 全套測試 149 files / 1386 tests 通過，零 regression