### PR TITLE
fix(spa): PaneHeader swap menu click-outside & Escape close (#249)

### DIFF
--- a/spa/src/components/PaneHeader.test.tsx
+++ b/spa/src/components/PaneHeader.test.tsx
@@ -25,4 +25,58 @@ describe('PaneHeader', () => {
     expect(screen.queryByTitle('Detach to tab')).toBeNull()
   })
 
+  describe('swap menu', () => {
+    const swapTargets = [
+      { id: 'pane-1', label: 'Terminal' },
+      { id: 'pane-2', label: 'Editor' },
+    ]
+
+    function renderWithSwap() {
+      const onSwap = vi.fn()
+      render(
+        <PaneHeader
+          title="Dashboard"
+          onClose={vi.fn()}
+          onSwap={onSwap}
+          swapTargets={swapTargets}
+        />,
+      )
+      return { onSwap }
+    }
+
+    it('shows swap targets when toggle button clicked', () => {
+      renderWithSwap()
+      fireEvent.click(screen.getByTitle('Swap with...'))
+      expect(screen.getByText('Terminal')).toBeTruthy()
+      expect(screen.getByText('Editor')).toBeTruthy()
+    })
+
+    it('closes swap menu on click outside', () => {
+      renderWithSwap()
+      fireEvent.click(screen.getByTitle('Swap with...'))
+      expect(screen.getByText('Terminal')).toBeTruthy()
+
+      // Click outside the menu
+      fireEvent.mouseDown(document.body)
+      expect(screen.queryByText('Terminal')).toBeNull()
+    })
+
+    it('closes swap menu on Escape key', () => {
+      renderWithSwap()
+      fireEvent.click(screen.getByTitle('Swap with...'))
+      expect(screen.getByText('Terminal')).toBeTruthy()
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(screen.queryByText('Terminal')).toBeNull()
+    })
+
+    it('calls onSwap and closes menu when target selected', () => {
+      const { onSwap } = renderWithSwap()
+      fireEvent.click(screen.getByTitle('Swap with...'))
+      fireEvent.click(screen.getByText('Terminal'))
+      expect(onSwap).toHaveBeenCalledWith('pane-1')
+      expect(screen.queryByText('Terminal')).toBeNull()
+    })
+  })
+
 })

--- a/spa/src/components/PaneHeader.tsx
+++ b/spa/src/components/PaneHeader.tsx
@@ -1,5 +1,6 @@
-import { useState, type ReactNode } from 'react'
+import { useState, useRef, useCallback, useEffect, type ReactNode } from 'react'
 import { X, ArrowSquareOut, ArrowsLeftRight } from '@phosphor-icons/react'
+import { useClickOutside } from '../hooks/useClickOutside'
 
 interface SwapTarget {
   id: string
@@ -17,6 +18,19 @@ interface Props {
 
 export function PaneHeader({ title, onClose, onDetach, onSwap, swapTargets, extraActions }: Props) {
   const [showSwapMenu, setShowSwapMenu] = useState(false)
+  const swapMenuRef = useRef<HTMLDivElement>(null)
+  const closeSwapMenu = useCallback(() => setShowSwapMenu(false), [])
+
+  useClickOutside(swapMenuRef, closeSwapMenu)
+
+  useEffect(() => {
+    if (!showSwapMenu) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeSwapMenu()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [showSwapMenu, closeSwapMenu])
 
   return (
     <div className="shrink-0 flex items-center h-7 px-2 bg-surface-secondary border-b border-border-default">
@@ -24,7 +38,7 @@ export function PaneHeader({ title, onClose, onDetach, onSwap, swapTargets, extr
       <div className="flex items-center gap-0.5">
         {extraActions}
         {onSwap && swapTargets && swapTargets.length > 0 && (
-          <div className="relative">
+          <div className="relative" ref={swapMenuRef}>
             <button
               className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-hover transition-colors"
               title="Swap with..."


### PR DESCRIPTION
## Summary
- PaneHeader swap menu 加入 `useClickOutside` hook，點擊外部自動關閉
- 加入 Escape 鍵監聽，按 Escape 關閉 swap menu
- 新增 4 個測試案例覆蓋 swap menu 開關行為

Closes #249

## Test plan
- [x] swap menu 點擊 toggle 按鈕正常開關
- [x] 點擊外部自動關閉 swap menu
- [x] 按 Escape 鍵關閉 swap menu
- [x] 選擇 target 後關閉 menu 並呼叫 onSwap
- [x] 全套 1390 測試通過，無回歸