### PR TITLE
fix(spa): workspace auto-naming avoids duplicate names (#199)

### DIFF
--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -24,6 +24,7 @@ import { useWorkspaceWindowActions } from './hooks/useWorkspaceWindowActions'
 import { isStandaloneTab } from './types/tab'
 import {
   getVisibleTabIds,
+  nextWorkspaceName,
   WorkspaceContextMenu,
   MigrateTabsDialog,
   WorkspaceEmptyState,
@@ -149,15 +150,15 @@ export default function App() {
   }, [standaloneTabIds, handleSelectTab])
 
   const handleAddWorkspace = useCallback(() => {
+    const names = workspaces.map(w => w.name)
     if (workspaces.length === 0 && tabOrder.length > 0) {
-      const ws = useWorkspaceStore.getState().addWorkspace('Workspace 1')
+      const ws = useWorkspaceStore.getState().addWorkspace(nextWorkspaceName(names))
       setMigrateDialog({ wsId: ws.id, wsName: ws.name })
     } else {
-      const count = workspaces.length + 1
-      const ws = useWorkspaceStore.getState().addWorkspace(`Workspace ${count}`)
+      const ws = useWorkspaceStore.getState().addWorkspace(nextWorkspaceName(names))
       openWsSettings(ws.id)
     }
-  }, [workspaces.length, tabOrder.length, openWsSettings])
+  }, [workspaces, tabOrder.length, openWsSettings])
 
   const handleOpenHosts = useCallback(() => {
     openSingletonAndSelect({ kind: 'hosts' })

--- a/spa/src/features/workspace/index.ts
+++ b/spa/src/features/workspace/index.ts
@@ -16,6 +16,7 @@ export { WorkspaceEmptyState } from './components/WorkspaceEmptyState'
 
 // Lib
 export { getVisibleTabIds } from './lib/getVisibleTabIds'
+export { nextWorkspaceName } from './lib/workspace-naming'
 
 // Re-export shared types from types/tab.ts
 export type { Workspace } from '../../types/tab'

--- a/spa/src/features/workspace/lib/workspace-naming.test.ts
+++ b/spa/src/features/workspace/lib/workspace-naming.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { nextWorkspaceName } from './workspace-naming'
+
+describe('nextWorkspaceName', () => {
+  it('returns "Workspace 1" when no workspaces exist', () => {
+    expect(nextWorkspaceName([])).toBe('Workspace 1')
+  })
+
+  it('returns next sequential name', () => {
+    expect(nextWorkspaceName(['Workspace 1'])).toBe('Workspace 2')
+  })
+
+  it('fills gap in numbering', () => {
+    expect(nextWorkspaceName(['Workspace 1', 'Workspace 3'])).toBe('Workspace 2')
+  })
+
+  it('starts from 1 even if only higher numbers exist', () => {
+    expect(nextWorkspaceName(['Workspace 2'])).toBe('Workspace 1')
+  })
+
+  it('ignores non-pattern names', () => {
+    expect(nextWorkspaceName(['Dev', 'Workspace 2'])).toBe('Workspace 1')
+  })
+})

--- a/spa/src/features/workspace/lib/workspace-naming.ts
+++ b/spa/src/features/workspace/lib/workspace-naming.ts
@@ -1,0 +1,7 @@
+export function nextWorkspaceName(existingNames: string[]): string {
+  const nameSet = new Set(existingNames)
+  for (let n = 1; ; n++) {
+    const candidate = `Workspace ${n}`
+    if (!nameSet.has(candidate)) return candidate
+  }
+}


### PR DESCRIPTION
## Summary
- 新增 `nextWorkspaceName()` 純函式，從 N=1 開始找第一個未使用的 `Workspace N` 名稱
- 替換 `App.tsx` 中 `workspaces.length + 1` 的命名邏輯，防止刪除 workspace 後產生重複名稱
- 修正 `useCallback` 依賴從 `workspaces.length` 改為 `workspaces` 避免 stale closure

Closes #199

## Test plan
- [x] 5 個單元測試涵蓋：空陣列、連續、跳號填補、非模式名稱忽略
- [x] 全部 1395 個測試通過
- [x] lint 無新增錯誤