### PR TITLE
fix(spa): prevent orphaned WS from in-flight fetch after cleanup (#173)

### DIFF
--- a/spa/src/hooks/useRelayWsManager.hook.test.ts
+++ b/spa/src/hooks/useRelayWsManager.hook.test.ts
@@ -1,0 +1,59 @@
+// spa/src/hooks/useRelayWsManager.hook.test.ts
+// Separate from store-level integration tests to allow module-level mocks.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useStreamStore } from '../stores/useStreamStore'
+import { useHostStore } from '../stores/useHostStore'
+
+// Must mock before import of the hook
+vi.mock('../lib/host-api', () => ({
+  fetchWsTicket: vi.fn(),
+}))
+vi.mock('../lib/stream-ws', () => ({
+  connectStream: vi.fn(() => ({ send: vi.fn(), close: vi.fn() })),
+}))
+
+import { fetchWsTicket } from '../lib/host-api'
+import { connectStream } from '../lib/stream-ws'
+import { useRelayWsManager } from './useRelayWsManager'
+
+describe('useRelayWsManager cancelled flag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useStreamStore.setState({ sessions: {}, relayStatus: {}, handoffProgress: {} })
+    // Ensure getWsBase returns a valid wsBase for any hostId
+    vi.spyOn(useHostStore.getState(), 'getWsBase').mockImplementation(
+      () => 'ws://localhost:7860',
+    )
+  })
+
+  it('does not create WS if unmount runs before fetchWsTicket resolves', async () => {
+    let resolveTicket!: (v: string) => void
+    const ticketPromise = new Promise<string>((r) => {
+      resolveTicket = r
+    })
+    vi.mocked(fetchWsTicket).mockReturnValue(ticketPromise)
+
+    const { unmount } = renderHook(() => useRelayWsManager())
+
+    // Trigger relay connect — this starts the fetchWsTicket call
+    act(() => {
+      useStreamStore.getState().setRelayStatus('local', 'sess1', true)
+    })
+
+    expect(fetchWsTicket).toHaveBeenCalledOnce()
+
+    // Unmount BEFORE the ticket resolves
+    unmount()
+
+    // Now resolve the ticket after unmount
+    resolveTicket('test-ticket')
+    await ticketPromise
+
+    // Flush microtasks so the .then() callback has a chance to run
+    await new Promise((r) => setTimeout(r, 0))
+
+    // connectStream should NOT have been called — cancelled flag prevents it
+    expect(connectStream).not.toHaveBeenCalled()
+  })
+})

--- a/spa/src/hooks/useRelayWsManager.ts
+++ b/spa/src/hooks/useRelayWsManager.ts
@@ -16,6 +16,7 @@ export function useRelayWsManager() {
   useEffect(() => {
     const activeConns = new Map<string, { close: () => void }>()
     const pendingFetches = new Set<string>()
+    let cancelled = false
 
     const unsub = useStreamStore.subscribe(
       (s) => s.relayStatus,
@@ -38,6 +39,7 @@ export function useRelayWsManager() {
             pendingFetches.add(ck)
             fetchWsTicket(hostId).then((ticket) => {
               pendingFetches.delete(ck)
+              if (cancelled) return
               // Guard: relay may have disconnected during async ticket fetch
               if (!useStreamStore.getState().relayStatus[ck]) return
 
@@ -109,6 +111,7 @@ export function useRelayWsManager() {
     )
 
     return () => {
+      cancelled = true
       unsub()
       activeConns.forEach((conn) => conn.close())
       activeConns.clear()


### PR DESCRIPTION
## Summary
- `useRelayWsManager` useEffect cleanup 後，in-flight `fetchWsTicket` promise 的 `.then()` 可能建立遊離 WS 連線
- 加入 `cancelled` flag：cleanup 時設為 true，`.then()` 開頭檢查後 early return
- 3 行修改 + 1 個新測試檔

Closes #173

## Test plan
- [x] 新增 hook-level 測試：unmount 後 resolve 不建立 WS
- [x] 全部 1397 個測試通過
- [x] Lint 無新增錯誤