### PR TITLE
feat(spa): add Escape key close to IconPicker and DeleteDialog (#195)

### DIFF
--- a/spa/src/features/workspace/components/WorkspaceDeleteDialog.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceDeleteDialog.test.tsx
@@ -97,4 +97,18 @@ describe('WorkspaceDeleteDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: /delete/i }))
     expect(onConfirm).toHaveBeenCalledWith([])
   })
+
+  it('calls onCancel on Escape key', () => {
+    const onCancel = vi.fn()
+    render(
+      <WorkspaceDeleteDialog
+        workspaceName="WS"
+        tabs={mockTabs}
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalled()
+  })
 })

--- a/spa/src/features/workspace/components/WorkspaceDeleteDialog.tsx
+++ b/spa/src/features/workspace/components/WorkspaceDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Trash, Warning } from '@phosphor-icons/react'
 import { useI18nStore } from '../../../stores/useI18nStore'
 
@@ -17,6 +17,15 @@ interface Props {
 export function WorkspaceDeleteDialog({ workspaceName, tabs, onConfirm, onCancel }: Props) {
   const t = useI18nStore((s) => s.t)
   const [checkedIds, setCheckedIds] = useState<Set<string>>(() => new Set(tabs.map((tab) => tab.id)))
+
+  // Close on Escape key
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onCancel])
 
   const toggleTab = (tabId: string) => {
     setCheckedIds((prev) => {

--- a/spa/src/features/workspace/components/WorkspaceIconPicker.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceIconPicker.test.tsx
@@ -122,4 +122,11 @@ describe('WorkspaceIconPicker', () => {
     fireEvent.change(search, { target: { value: 'xyznonexistent' } })
     expect(screen.getByText('No results found')).toBeInTheDocument()
   })
+
+  it('calls onCancel on Escape key', () => {
+    const onCancel = vi.fn()
+    render(<WorkspaceIconPicker currentIcon={undefined} onSelect={vi.fn()} onCancel={onCancel} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalled()
+  })
 })

--- a/spa/src/features/workspace/components/WorkspaceIconPicker.tsx
+++ b/spa/src/features/workspace/components/WorkspaceIconPicker.tsx
@@ -103,6 +103,15 @@ export function WorkspaceIconPicker({ currentIcon, onSelect, onCancel, inline, c
     }
   }, [weight])
 
+  // Close on Escape key
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onCancel])
+
   // Reset scroll position when category or search changes
   useEffect(() => {
     if (scrollRef.current) scrollRef.current.scrollTop = 0


### PR DESCRIPTION
## Summary
- `WorkspaceIconPicker` 和 `WorkspaceDeleteDialog` 加入 `useEffect` 監聽 Escape 鍵關閉
- 與 PaneHeader、RegionContextMenu 等既有 pattern 一致
- `WorkspaceColorPicker` 已不存在（色彩系統移除），跳過

Closes #195

## Test plan
- [x] 2 個新測試：Escape key 觸發 onCancel
- [x] 全部 1410 個測試通過
- [x] Lint 無新增錯誤