### PR TITLE
feat(sync): cross-device sync architecture

### DIFF
--- a/cmd/pdx/main.go
+++ b/cmd/pdx/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/wake/purdex/internal/module/dev"
 	fsmod "github.com/wake/purdex/internal/module/fs"
 	"github.com/wake/purdex/internal/module/logs"
+	syncmod "github.com/wake/purdex/internal/module/sync"
 	"github.com/wake/purdex/internal/module/session"
 	"github.com/wake/purdex/internal/module/stream"
 	"github.com/wake/purdex/internal/relay"
@@ -152,6 +153,7 @@ func runServe(args []string) {
 	c.AddModule(agent.New(agentEvents))
 	c.AddModule(fsmod.New())
 	c.AddModule(logs.New())
+	c.AddModule(syncmod.New())
 	if c.Cfg.Dev.Update {
 		repoRoot := c.Cfg.Dev.RepoRoot
 		if repoRoot == "" {

--- a/internal/module/sync/handler.go
+++ b/internal/module/sync/handler.go
@@ -80,7 +80,7 @@ func (m *SyncModule) handleHistory(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	entries, err := m.store.ListHistory(clientID, limit)
+	entries, err := m.store.ListHistorySummary(clientID, limit)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -88,7 +88,7 @@ func (m *SyncModule) handleHistory(w http.ResponseWriter, r *http.Request) {
 
 	// Return [] rather than null for an empty list.
 	if entries == nil {
-		entries = []HistoryEntry{}
+		entries = []HistorySummary{}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/module/sync/handler.go
+++ b/internal/module/sync/handler.go
@@ -1,0 +1,267 @@
+package sync
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+// handlePush accepts a raw JSON bundle from a client and stores it as the
+// canonical bundle for that client's group.
+//
+// Query param: clientId
+// Body:        raw JSON bundle (max 10 MB)
+// Response:    204 No Content on success
+func (m *SyncModule) handlePush(w http.ResponseWriter, r *http.Request) {
+	clientID := r.URL.Query().Get("clientId")
+	if clientID == "" {
+		http.Error(w, "clientId required", http.StatusBadRequest)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 10<<20))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	if err := m.store.PushBundle(clientID, string(body)); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handlePull returns the current canonical bundle for the client's group.
+//
+// Query param: clientId
+// Response:    JSON bundle, or null if no bundle has been pushed yet
+func (m *SyncModule) handlePull(w http.ResponseWriter, r *http.Request) {
+	clientID := r.URL.Query().Get("clientId")
+	if clientID == "" {
+		http.Error(w, "clientId required", http.StatusBadRequest)
+		return
+	}
+
+	bundle, err := m.store.PullCanonical(clientID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if bundle == "" {
+		w.Write([]byte("null"))
+		return
+	}
+	w.Write([]byte(bundle))
+}
+
+// handleHistory returns the push history for the client's group.
+//
+// Query params: clientId, limit (optional, default/max 100)
+// Response:    JSON array of history entries
+func (m *SyncModule) handleHistory(w http.ResponseWriter, r *http.Request) {
+	clientID := r.URL.Query().Get("clientId")
+	if clientID == "" {
+		http.Error(w, "clientId required", http.StatusBadRequest)
+		return
+	}
+
+	limit := 100
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > 100 {
+				n = 100
+			}
+			limit = n
+		}
+	}
+
+	entries, err := m.store.ListHistory(clientID, limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Return [] rather than null for an empty list.
+	if entries == nil {
+		entries = []HistoryEntry{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(entries)
+}
+
+// handleGroupCreate creates a new sync group and adds the requesting client.
+//
+// Body:     {"clientId": "...", "device": "..."}
+// Response: {"groupId": "..."}
+func (m *SyncModule) handleGroupCreate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClientID string `json:"clientId"`
+		Device   string `json:"device"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.ClientID == "" {
+		http.Error(w, "clientId required", http.StatusBadRequest)
+		return
+	}
+
+	groupID, err := generateGroupID()
+	if err != nil {
+		http.Error(w, "failed to generate group id", http.StatusInternalServerError)
+		return
+	}
+
+	if err := m.store.CreateGroup(groupID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := m.store.AddClientToGroup(groupID, req.ClientID, req.Device); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"groupId": groupID})
+}
+
+// handleGroupJoin adds a client to an existing group.
+//
+// Body:     {"groupId": "...", "clientId": "...", "device": "..."}
+// Response: 204 No Content
+func (m *SyncModule) handleGroupJoin(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		GroupID  string `json:"groupId"`
+		ClientID string `json:"clientId"`
+		Device   string `json:"device"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.GroupID == "" || req.ClientID == "" {
+		http.Error(w, "groupId and clientId required", http.StatusBadRequest)
+		return
+	}
+
+	if err := m.store.AddClientToGroup(req.GroupID, req.ClientID, req.Device); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handlePairCreate generates a pairing code for the client's group.
+//
+// Body:     {"clientId": "..."}
+// Response: {"code": "XXXXXXXX"}
+func (m *SyncModule) handlePairCreate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClientID string `json:"clientId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.ClientID == "" {
+		http.Error(w, "clientId required", http.StatusBadRequest)
+		return
+	}
+
+	code, err := m.store.CreatePairingCode(req.ClientID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"code": code})
+}
+
+// handlePairVerify validates a pairing code and adds the client to the group.
+//
+// Body:     {"code": "...", "clientId": "...", "device": "..."}
+// Response: {"groupId": "..."} on success, 403 on failure
+func (m *SyncModule) handlePairVerify(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Code     string `json:"code"`
+		ClientID string `json:"clientId"`
+		Device   string `json:"device"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.Code == "" || req.ClientID == "" {
+		http.Error(w, "code and clientId required", http.StatusBadRequest)
+		return
+	}
+
+	groupID, err := m.store.VerifyPairingCode(req.Code)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
+	if err := m.store.AddClientToGroup(groupID, req.ClientID, req.Device); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"groupId": groupID})
+}
+
+// handleGroupMembers returns the list of members in the client's group.
+//
+// Query param: clientId
+// Response:    JSON array of {clientId, device, lastSeen}
+func (m *SyncModule) handleGroupMembers(w http.ResponseWriter, r *http.Request) {
+	clientID := r.URL.Query().Get("clientId")
+	if clientID == "" {
+		http.Error(w, "clientId required", http.StatusBadRequest)
+		return
+	}
+
+	members, err := m.store.ListGroupMembers(clientID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Return [] rather than null for an empty group.
+	if members == nil {
+		members = []GroupMember{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(members)
+}
+
+// handleGroupRemoveMember removes a member from the requester's group.
+//
+// Query params: clientId (requester), targetId (member to remove)
+// Response:     204 No Content
+func (m *SyncModule) handleGroupRemoveMember(w http.ResponseWriter, r *http.Request) {
+	clientID := r.URL.Query().Get("clientId")
+	targetID := r.URL.Query().Get("targetId")
+	if clientID == "" || targetID == "" {
+		http.Error(w, "clientId and targetId required", http.StatusBadRequest)
+		return
+	}
+
+	if err := m.store.RemoveClientFromGroup(clientID, targetID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/module/sync/module.go
+++ b/internal/module/sync/module.go
@@ -1,0 +1,58 @@
+package sync
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"path/filepath"
+
+	"github.com/wake/purdex/internal/core"
+)
+
+// SyncModule provides settings-sync persistence and pairing over HTTP.
+type SyncModule struct {
+	core  *core.Core
+	store *SyncStore
+}
+
+// New returns a new SyncModule ready for registration.
+func New() *SyncModule { return &SyncModule{} }
+
+func (m *SyncModule) Name() string           { return "sync" }
+func (m *SyncModule) Dependencies() []string { return nil }
+
+// Init opens (or creates) the sync SQLite database inside DataDir.
+func (m *SyncModule) Init(c *core.Core) error {
+	m.core = c
+	dbPath := filepath.Join(c.Cfg.DataDir, "sync.db")
+	var err error
+	m.store, err = OpenSyncStore(dbPath)
+	return err
+}
+
+// RegisterRoutes wires up all /api/sync/* endpoints.
+func (m *SyncModule) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/sync/push", m.handlePush)
+	mux.HandleFunc("GET /api/sync/pull", m.handlePull)
+	mux.HandleFunc("GET /api/sync/history", m.handleHistory)
+	mux.HandleFunc("POST /api/sync/group/create", m.handleGroupCreate)
+	mux.HandleFunc("POST /api/sync/group/join", m.handleGroupJoin)
+	mux.HandleFunc("POST /api/sync/pair/create", m.handlePairCreate)
+	mux.HandleFunc("POST /api/sync/pair/verify", m.handlePairVerify)
+	mux.HandleFunc("GET /api/sync/group/members", m.handleGroupMembers)
+	mux.HandleFunc("DELETE /api/sync/group/member", m.handleGroupRemoveMember)
+}
+
+// Start logs a banner; no background work required.
+func (m *SyncModule) Start(_ context.Context) error {
+	log.Println("[sync] endpoints enabled")
+	return nil
+}
+
+// Stop closes the underlying SQLite database.
+func (m *SyncModule) Stop(_ context.Context) error {
+	if m.store != nil {
+		return m.store.Close()
+	}
+	return nil
+}

--- a/internal/module/sync/store.go
+++ b/internal/module/sync/store.go
@@ -1,0 +1,326 @@
+package sync
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// SyncStore is the SQLite-backed persistence layer for the sync module.
+type SyncStore struct{ db *sql.DB }
+
+// HistoryEntry represents a single bundle push recorded in sync_history.
+type HistoryEntry struct {
+	ID        int64
+	ClientID  string
+	Device    string
+	Bundle    string
+	Timestamp int64
+}
+
+// OpenSyncStore opens (or creates) a SyncStore at path and runs schema migration.
+// Use ":memory:" for tests.
+func OpenSyncStore(path string) (*SyncStore, error) {
+	dsn := path
+	if path != ":memory:" {
+		dsn = path + "?_pragma=journal_mode(wal)"
+	}
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open sync db: %w", err)
+	}
+	if path == ":memory:" {
+		db.SetMaxOpenConns(1)
+	}
+	s := &SyncStore{db: db}
+	if err := s.migrate(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate sync db: %w", err)
+	}
+	return s, nil
+}
+
+// Close closes the underlying DB connection.
+func (s *SyncStore) Close() error { return s.db.Close() }
+
+// migrate creates all sync tables if they don't already exist.
+func (s *SyncStore) migrate() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS sync_groups (
+			group_id  TEXT    NOT NULL,
+			client_id TEXT    NOT NULL,
+			device    TEXT    NOT NULL DEFAULT '',
+			last_seen INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (group_id, client_id)
+		);
+
+		CREATE TABLE IF NOT EXISTS sync_canonical (
+			group_id   TEXT    PRIMARY KEY,
+			updated_at INTEGER NOT NULL DEFAULT 0,
+			bundle     TEXT    NOT NULL DEFAULT ''
+		);
+
+		CREATE TABLE IF NOT EXISTS sync_history (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			group_id   TEXT    NOT NULL,
+			client_id  TEXT    NOT NULL,
+			device     TEXT    NOT NULL DEFAULT '',
+			bundle     TEXT    NOT NULL DEFAULT '',
+			timestamp  INTEGER NOT NULL DEFAULT 0
+		);
+
+		CREATE TABLE IF NOT EXISTS sync_pairing (
+			code       TEXT    PRIMARY KEY,
+			group_id   TEXT    NOT NULL,
+			created_at INTEGER NOT NULL DEFAULT 0,
+			expires_at INTEGER NOT NULL DEFAULT 0,
+			attempts   INTEGER NOT NULL DEFAULT 0
+		);
+	`)
+	return err
+}
+
+// clientGroupID resolves the group_id for a given clientID.
+// Returns an error if the client is not a member of any group.
+func (s *SyncStore) clientGroupID(clientID string) (string, error) {
+	var groupID string
+	err := s.db.QueryRow(
+		`SELECT group_id FROM sync_groups WHERE client_id = ? LIMIT 1`,
+		clientID,
+	).Scan(&groupID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("client %q not found in any group", clientID)
+	}
+	if err != nil {
+		return "", err
+	}
+	return groupID, nil
+}
+
+// updateLastSeen bumps the last_seen timestamp for clientID within its group.
+func (s *SyncStore) updateLastSeen(groupID, clientID string) error {
+	_, err := s.db.Exec(
+		`UPDATE sync_groups SET last_seen = ? WHERE group_id = ? AND client_id = ?`,
+		time.Now().Unix(), groupID, clientID,
+	)
+	return err
+}
+
+// CreateGroup inserts a new group record into sync_canonical (no-op if exists).
+func (s *SyncStore) CreateGroup(groupID string) error {
+	_, err := s.db.Exec(
+		`INSERT OR IGNORE INTO sync_canonical (group_id, updated_at, bundle) VALUES (?, 0, '')`,
+		groupID,
+	)
+	return err
+}
+
+// AddClientToGroup registers clientID as a member of groupID.
+func (s *SyncStore) AddClientToGroup(groupID, clientID, device string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO sync_groups (group_id, client_id, device, last_seen)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(group_id, client_id) DO UPDATE SET
+			device    = excluded.device,
+			last_seen = excluded.last_seen
+	`, groupID, clientID, device, time.Now().Unix())
+	return err
+}
+
+// PushBundle records a new canonical bundle for the group that clientID belongs
+// to, and appends an entry to sync_history.
+func (s *SyncStore) PushBundle(clientID, bundle string) error {
+	groupID, err := s.clientGroupID(clientID)
+	if err != nil {
+		return err
+	}
+
+	if err := s.updateLastSeen(groupID, clientID); err != nil {
+		return err
+	}
+
+	now := time.Now().Unix()
+
+	// Resolve the device label for the history entry.
+	var device string
+	_ = s.db.QueryRow(
+		`SELECT device FROM sync_groups WHERE group_id = ? AND client_id = ?`,
+		groupID, clientID,
+	).Scan(&device)
+
+	// Upsert canonical bundle.
+	_, err = s.db.Exec(`
+		INSERT INTO sync_canonical (group_id, updated_at, bundle)
+		VALUES (?, ?, ?)
+		ON CONFLICT(group_id) DO UPDATE SET
+			updated_at = excluded.updated_at,
+			bundle     = excluded.bundle
+	`, groupID, now, bundle)
+	if err != nil {
+		return err
+	}
+
+	// Append history record.
+	_, err = s.db.Exec(`
+		INSERT INTO sync_history (group_id, client_id, device, bundle, timestamp)
+		VALUES (?, ?, ?, ?, ?)
+	`, groupID, clientID, device, bundle, now)
+	return err
+}
+
+// PullCanonical returns the current canonical bundle for the group that
+// clientID belongs to.  Returns an empty string if no bundle has been pushed
+// yet (not an error).
+func (s *SyncStore) PullCanonical(clientID string) (string, error) {
+	groupID, err := s.clientGroupID(clientID)
+	if err != nil {
+		return "", err
+	}
+
+	if err := s.updateLastSeen(groupID, clientID); err != nil {
+		return "", err
+	}
+
+	var bundle string
+	err = s.db.QueryRow(
+		`SELECT bundle FROM sync_canonical WHERE group_id = ?`,
+		groupID,
+	).Scan(&bundle)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return bundle, err
+}
+
+// ListHistory returns up to limit history entries for the group that clientID
+// belongs to, ordered by most-recent first.
+func (s *SyncStore) ListHistory(clientID string, limit int) ([]HistoryEntry, error) {
+	groupID, err := s.clientGroupID(clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := s.db.Query(`
+		SELECT id, client_id, device, bundle, timestamp
+		FROM sync_history
+		WHERE group_id = ?
+		ORDER BY id DESC
+		LIMIT ?
+	`, groupID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []HistoryEntry
+	for rows.Next() {
+		var e HistoryEntry
+		if err := rows.Scan(&e.ID, &e.ClientID, &e.Device, &e.Bundle, &e.Timestamp); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// pairingCharset is the unambiguous alphanumeric charset used for pairing codes
+// (no 0/O/1/I to avoid visual confusion).
+const pairingCharset = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+// CreatePairingCode generates an 8-character pairing code for the group that
+// clientID belongs to.  Any existing codes for that group are replaced.
+func (s *SyncStore) CreatePairingCode(clientID string) (string, error) {
+	groupID, err := s.clientGroupID(clientID)
+	if err != nil {
+		return "", err
+	}
+
+	// Generate random code from charset.
+	code, err := randomCode(8)
+	if err != nil {
+		return "", fmt.Errorf("generate pairing code: %w", err)
+	}
+
+	now := time.Now().Unix()
+	expiresAt := now + 300 // 5 minutes
+
+	// Delete any existing codes for this group, then insert the new one.
+	_, err = s.db.Exec(`DELETE FROM sync_pairing WHERE group_id = ?`, groupID)
+	if err != nil {
+		return "", err
+	}
+	_, err = s.db.Exec(`
+		INSERT INTO sync_pairing (code, group_id, created_at, expires_at, attempts)
+		VALUES (?, ?, ?, ?, 0)
+	`, code, groupID, now, expiresAt)
+	if err != nil {
+		return "", err
+	}
+	return code, nil
+}
+
+// VerifyPairingCode validates code and returns the associated groupID on
+// success.  On success the code is deleted (single-use).  On failure the
+// attempts counter is incremented and an error is returned.
+func (s *SyncStore) VerifyPairingCode(code string) (string, error) {
+	var groupID string
+	var expiresAt int64
+	var attempts int
+
+	err := s.db.QueryRow(
+		`SELECT group_id, expires_at, attempts FROM sync_pairing WHERE code = ?`,
+		code,
+	).Scan(&groupID, &expiresAt, &attempts)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("pairing code not found")
+	}
+	if err != nil {
+		return "", err
+	}
+
+	if attempts >= 5 {
+		return "", fmt.Errorf("pairing code locked: too many attempts")
+	}
+
+	if time.Now().Unix() > expiresAt {
+		_, _ = s.db.Exec(`UPDATE sync_pairing SET attempts = attempts + 1 WHERE code = ?`, code)
+		return "", fmt.Errorf("pairing code expired")
+	}
+
+	// Success: delete code and return groupID.
+	_, err = s.db.Exec(`DELETE FROM sync_pairing WHERE code = ?`, code)
+	if err != nil {
+		return "", err
+	}
+	return groupID, nil
+}
+
+// generateGroupID returns a new unique group identifier prefixed with "g_"
+// followed by 16 random hex characters.
+func generateGroupID() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate group id: %w", err)
+	}
+	return "g_" + hex.EncodeToString(b), nil
+}
+
+// randomCode generates an n-character string sampled uniformly from
+// pairingCharset using crypto/rand.
+func randomCode(n int) (string, error) {
+	charset := []byte(pairingCharset)
+	buf := make([]byte, n)
+	random := make([]byte, n)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	for i, b := range random {
+		buf[i] = charset[int(b)%len(charset)]
+	}
+	return string(buf), nil
+}

--- a/internal/module/sync/store.go
+++ b/internal/module/sync/store.go
@@ -300,6 +300,66 @@ func (s *SyncStore) VerifyPairingCode(code string) (string, error) {
 	return groupID, nil
 }
 
+// GroupMember represents a single member of a sync group.
+type GroupMember struct {
+	ClientID string `json:"clientId"`
+	Device   string `json:"device"`
+	LastSeen int64  `json:"lastSeen"`
+}
+
+// ListGroupMembers returns all members of the group that clientID belongs to.
+func (s *SyncStore) ListGroupMembers(clientID string) ([]GroupMember, error) {
+	groupID, err := s.clientGroupID(clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := s.db.Query(`
+		SELECT client_id, device, last_seen
+		FROM sync_groups
+		WHERE group_id = ?
+		ORDER BY last_seen DESC
+	`, groupID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []GroupMember
+	for rows.Next() {
+		var m GroupMember
+		if err := rows.Scan(&m.ClientID, &m.Device, &m.LastSeen); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// RemoveClientFromGroup removes targetID from the group that requesterID belongs to.
+// Returns an error if either client is not in the same group.
+func (s *SyncStore) RemoveClientFromGroup(requesterID, targetID string) error {
+	groupID, err := s.clientGroupID(requesterID)
+	if err != nil {
+		return err
+	}
+
+	// Verify target is in the same group.
+	targetGroup, err := s.clientGroupID(targetID)
+	if err != nil {
+		return fmt.Errorf("target %q not found", targetID)
+	}
+	if targetGroup != groupID {
+		return fmt.Errorf("clients not in the same group")
+	}
+
+	_, err = s.db.Exec(
+		`DELETE FROM sync_groups WHERE group_id = ? AND client_id = ?`,
+		groupID, targetID,
+	)
+	return err
+}
+
 // generateGroupID returns a new unique group identifier prefixed with "g_"
 // followed by 16 random hex characters.
 func generateGroupID() (string, error) {

--- a/internal/module/sync/store.go
+++ b/internal/module/sync/store.go
@@ -23,6 +23,14 @@ type HistoryEntry struct {
 	Timestamp int64
 }
 
+// HistorySummary is a lightweight view of a history entry (no bundle payload).
+type HistorySummary struct {
+	ID        int64  `json:"id"`
+	ClientID  string `json:"clientId"`
+	Device    string `json:"device"`
+	Timestamp int64  `json:"timestamp"`
+}
+
 // OpenSyncStore opens (or creates) a SyncStore at path and runs schema migration.
 // Use ":memory:" for tests.
 func OpenSyncStore(path string) (*SyncStore, error) {
@@ -122,7 +130,19 @@ func (s *SyncStore) CreateGroup(groupID string) error {
 
 // AddClientToGroup registers clientID as a member of groupID.
 func (s *SyncStore) AddClientToGroup(groupID, clientID, device string) error {
-	_, err := s.db.Exec(`
+	// Verify group exists before adding a member.
+	var exists int
+	err := s.db.QueryRow(
+		`SELECT 1 FROM sync_canonical WHERE group_id = ?`, groupID,
+	).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("group %s does not exist", groupID)
+	}
+	if err != nil {
+		return err
+	}
+
+	_, err = s.db.Exec(`
 		INSERT INTO sync_groups (group_id, client_id, device, last_seen)
 		VALUES (?, ?, ?, ?)
 		ON CONFLICT(group_id, client_id) DO UPDATE SET
@@ -170,7 +190,18 @@ func (s *SyncStore) PushBundle(clientID, bundle string) error {
 		INSERT INTO sync_history (group_id, client_id, device, bundle, timestamp)
 		VALUES (?, ?, ?, ?, ?)
 	`, groupID, clientID, device, bundle, now)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Prune old history: keep only the most recent 100 entries per group.
+	_, _ = s.db.Exec(`
+		DELETE FROM sync_history
+		WHERE group_id = ? AND id NOT IN (
+			SELECT id FROM sync_history WHERE group_id = ? ORDER BY timestamp DESC LIMIT 100
+		)
+	`, groupID, groupID)
+	return nil
 }
 
 // PullCanonical returns the current canonical bundle for the group that
@@ -228,6 +259,36 @@ func (s *SyncStore) ListHistory(clientID string, limit int) ([]HistoryEntry, err
 	return out, rows.Err()
 }
 
+// ListHistorySummary returns lightweight history entries (without bundle payload).
+func (s *SyncStore) ListHistorySummary(clientID string, limit int) ([]HistorySummary, error) {
+	groupID, err := s.clientGroupID(clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := s.db.Query(`
+		SELECT id, client_id, device, timestamp
+		FROM sync_history
+		WHERE group_id = ?
+		ORDER BY id DESC
+		LIMIT ?
+	`, groupID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []HistorySummary
+	for rows.Next() {
+		var e HistorySummary
+		if err := rows.Scan(&e.ID, &e.ClientID, &e.Device, &e.Timestamp); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 // pairingCharset is the unambiguous alphanumeric charset used for pairing codes
 // (no 0/O/1/I to avoid visual confusion).
 const pairingCharset = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
@@ -265,8 +326,12 @@ func (s *SyncStore) CreatePairingCode(clientID string) (string, error) {
 }
 
 // VerifyPairingCode validates code and returns the associated groupID on
-// success.  On success the code is deleted (single-use).  On failure the
-// attempts counter is incremented and an error is returned.
+// success.  On success the code is deleted (single-use).
+//
+// Rate limiting: every failed attempt (wrong code, expired, or locked)
+// increments the attempts counter on ALL active pairing codes.  This prevents
+// brute-force enumeration — an attacker cannot try unlimited random codes
+// without exhausting the real code's attempt budget.
 func (s *SyncStore) VerifyPairingCode(code string) (string, error) {
 	var groupID string
 	var expiresAt int64
@@ -277,6 +342,8 @@ func (s *SyncStore) VerifyPairingCode(code string) (string, error) {
 		code,
 	).Scan(&groupID, &expiresAt, &attempts)
 	if errors.Is(err, sql.ErrNoRows) {
+		// Wrong code: increment ALL active codes' attempts (brute-force protection).
+		_, _ = s.db.Exec(`UPDATE sync_pairing SET attempts = attempts + 1`)
 		return "", fmt.Errorf("pairing code not found")
 	}
 	if err != nil {
@@ -284,11 +351,13 @@ func (s *SyncStore) VerifyPairingCode(code string) (string, error) {
 	}
 
 	if attempts >= 5 {
+		// Locked: delete the exhausted code.
+		_, _ = s.db.Exec(`DELETE FROM sync_pairing WHERE code = ?`, code)
 		return "", fmt.Errorf("pairing code locked: too many attempts")
 	}
 
 	if time.Now().Unix() > expiresAt {
-		_, _ = s.db.Exec(`UPDATE sync_pairing SET attempts = attempts + 1 WHERE code = ?`, code)
+		_, _ = s.db.Exec(`DELETE FROM sync_pairing WHERE code = ?`, code)
 		return "", fmt.Errorf("pairing code expired")
 	}
 

--- a/internal/module/sync/store_test.go
+++ b/internal/module/sync/store_test.go
@@ -1,0 +1,156 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func openTestStore(t *testing.T) *SyncStore {
+	t.Helper()
+	s, err := OpenSyncStore(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// TestSyncStorePushAndPullCanonical creates a group, adds a client, pushes a
+// bundle, and verifies PullCanonical returns that bundle.
+func TestSyncStorePushAndPullCanonical(t *testing.T) {
+	s := openTestStore(t)
+
+	groupID, err := generateGroupID()
+	require.NoError(t, err)
+
+	require.NoError(t, s.CreateGroup(groupID))
+	require.NoError(t, s.AddClientToGroup(groupID, "client-1", "MacBook"))
+	require.NoError(t, s.PushBundle("client-1", `{"theme":"dark","fontSize":14}`))
+
+	bundle, err := s.PullCanonical("client-1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, bundle)
+	assert.Equal(t, `{"theme":"dark","fontSize":14}`, bundle)
+}
+
+// TestSyncStoreGroupIsolation verifies that a client in group2 cannot see data
+// pushed by a client in group1.
+func TestSyncStoreGroupIsolation(t *testing.T) {
+	s := openTestStore(t)
+
+	gid1, err := generateGroupID()
+	require.NoError(t, err)
+	gid2, err := generateGroupID()
+	require.NoError(t, err)
+
+	require.NoError(t, s.CreateGroup(gid1))
+	require.NoError(t, s.CreateGroup(gid2))
+	require.NoError(t, s.AddClientToGroup(gid1, "client-a", "DevA"))
+	require.NoError(t, s.AddClientToGroup(gid2, "client-b", "DevB"))
+
+	require.NoError(t, s.PushBundle("client-a", `{"group":"one"}`))
+
+	bundle, err := s.PullCanonical("client-b")
+	require.NoError(t, err)
+	assert.Empty(t, bundle, "client-b must not see group1 data")
+}
+
+// TestSyncStorePairingCode creates a pairing code and verifies it returns the
+// correct groupID on successful verification.
+func TestSyncStorePairingCode(t *testing.T) {
+	s := openTestStore(t)
+
+	gid, err := generateGroupID()
+	require.NoError(t, err)
+	require.NoError(t, s.CreateGroup(gid))
+	require.NoError(t, s.AddClientToGroup(gid, "owner-1", "Owner"))
+
+	code, err := s.CreatePairingCode("owner-1")
+	require.NoError(t, err)
+	assert.Len(t, code, 8)
+
+	returnedGroupID, err := s.VerifyPairingCode(code)
+	require.NoError(t, err)
+	assert.Equal(t, gid, returnedGroupID)
+}
+
+// TestSyncStorePairingCodeRateLimit verifies that after 5 failed verification
+// attempts the pairing code is locked out and can no longer be verified.
+func TestSyncStorePairingCodeRateLimit(t *testing.T) {
+	s := openTestStore(t)
+
+	gid, err := generateGroupID()
+	require.NoError(t, err)
+	require.NoError(t, s.CreateGroup(gid))
+	require.NoError(t, s.AddClientToGroup(gid, "owner-rl", "RLDevice"))
+
+	code, err := s.CreatePairingCode("owner-rl")
+	require.NoError(t, err)
+
+	// Simulate 5 failed attempts by passing the real code but with a
+	// spoofed DB state — we can't do that through the API, so instead we
+	// insert a second code row directly via a helper.  Actually, the cleanest
+	// approach is to verify 5 times with a WRONG code that shares the same
+	// row (not possible from outside), so we test the publicly observable
+	// behaviour: each call to VerifyPairingCode with a non-existent or
+	// over-attempted code returns an error.
+	//
+	// To properly test rate-limit we need to set attempts=4 before the 5th
+	// call.  We do this by calling VerifyPairingCode(code) 4 times — but the
+	// first successful call will delete the code and return success, making
+	// further calls return "not found" (also an error, just a different one).
+	// That still verifies the observable contract: code is single-use.
+	//
+	// For a true rate-limit test we manipulate the DB directly via the
+	// exported db field — not available here.  Use a white-box approach:
+	// call the internal incrementAttempts path by using a known-bad code
+	// to exhaust attempts on a row we pre-seed via the public API, then
+	// try the real code.
+	//
+	// Simplest TDD-valid test: use CreatePairingCode to get a real code,
+	// then manually set its attempts to 4 via s.db (white-box).  The
+	// SyncStore.db field is unexported but we're in the same package (sync),
+	// so it IS accessible.
+	// Pre-seed attempts=5 so that the very next call is over the limit.
+	err = setAttempts(s, code, 5)
+	require.NoError(t, err, "pre-seed attempts=5 in same-package white-box test")
+
+	// attempts >= 5 → should be rejected immediately.
+	_, err = s.VerifyPairingCode(code)
+	assert.Error(t, err, "attempt with attempts=5 should be rejected")
+
+	// 6th attempt: attempts >= 5 → also rejected.
+	_, err = s.VerifyPairingCode(code)
+	assert.Error(t, err, "6th attempt should still be rejected")
+}
+
+// setAttempts is a white-box helper (same package) to pre-seed the attempts
+// counter for a pairing code row.
+func setAttempts(s *SyncStore, code string, n int) error {
+	_, err := s.db.Exec(`UPDATE sync_pairing SET attempts = ? WHERE code = ?`, n, code)
+	return err
+}
+
+// TestSyncStoreHistory pushes 5 bundles and verifies ListHistory with limit 3
+// returns exactly 3 entries with correct metadata.
+func TestSyncStoreHistory(t *testing.T) {
+	s := openTestStore(t)
+
+	gid, err := generateGroupID()
+	require.NoError(t, err)
+	require.NoError(t, s.CreateGroup(gid))
+	require.NoError(t, s.AddClientToGroup(gid, "client-h", "HistDevice"))
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, s.PushBundle("client-h", `{"n":`+string(rune('0'+i))+`}`))
+	}
+
+	entries, err := s.ListHistory("client-h", 3)
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+	for _, e := range entries {
+		assert.Equal(t, "client-h", e.ClientID)
+		assert.Equal(t, "HistDevice", e.Device)
+		assert.NotZero(t, e.Timestamp)
+	}
+}

--- a/spa/.gitignore
+++ b/spa/.gitignore
@@ -25,3 +25,4 @@ public/icons/*.json
 *.njsproj
 *.sln
 *.sw?
+pdx

--- a/spa/src/components/settings/SyncSection.tsx
+++ b/spa/src/components/settings/SyncSection.tsx
@@ -1,0 +1,214 @@
+import { useRef } from 'react'
+import { ArrowsClockwise, DownloadSimple, Upload } from '@phosphor-icons/react'
+import { SettingItem } from './SettingItem'
+import { SegmentControl } from './SegmentControl'
+import { useSyncStore } from '../../lib/sync/use-sync-store'
+import { syncEngine } from '../../lib/sync/register-sync'
+import { createManualProvider } from '../../lib/sync/providers/manual-provider'
+
+// ---------------------------------------------------------------------------
+// Provider selector type
+// ---------------------------------------------------------------------------
+
+type ProviderId = 'off' | 'daemon' | 'file'
+
+const PROVIDER_OPTIONS: { value: ProviderId; label: string }[] = [
+  { value: 'off', label: 'Off' },
+  { value: 'daemon', label: 'Daemon' },
+  { value: 'file', label: 'File' },
+]
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(ms: number): string {
+  const diffSec = Math.floor((Date.now() - ms) / 1000)
+  if (diffSec < 60) return `${diffSec}s ago`
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDay = Math.floor(diffHr / 24)
+  return `${diffDay}d ago`
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+// ---------------------------------------------------------------------------
+// SyncSection
+// ---------------------------------------------------------------------------
+
+export function SyncSection() {
+  const activeProviderId = useSyncStore((s) => s.activeProviderId)
+  const setActiveProvider = useSyncStore((s) => s.setActiveProvider)
+  const lastSyncedAt = useSyncStore((s) => s.lastSyncedAt)
+  const enabledModules = useSyncStore((s) => s.enabledModules)
+  const toggleModule = useSyncStore((s) => s.toggleModule)
+  const getClientId = useSyncStore((s) => s.getClientId)
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Normalise: null → 'off'
+  const currentProvider: ProviderId =
+    (activeProviderId as ProviderId | null) ?? 'off'
+
+  const handleProviderChange = (value: ProviderId) => {
+    setActiveProvider(value === 'off' ? null : value)
+  }
+
+  const contributors = syncEngine.getContributors()
+
+  // --------------------------------------------------------------------------
+  // Export
+  // --------------------------------------------------------------------------
+
+  const handleExportAll = () => {
+    const clientId = getClientId()
+    const bundle = syncEngine.serialize(clientId, enabledModules)
+    const provider = createManualProvider()
+    const blob = provider.exportToBlob(bundle)
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    triggerDownload(blob, `purdex-sync-${timestamp}.purdex-sync`)
+  }
+
+  // --------------------------------------------------------------------------
+  // Import
+  // --------------------------------------------------------------------------
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    try {
+      const text = await file.text()
+      const provider = createManualProvider()
+      const bundle = provider.importFromText(text)
+      // Full import flow will be wired in a future task
+      console.log('[SyncSection] Imported bundle:', bundle)
+    } catch (err) {
+      console.error('[SyncSection] Import failed:', err)
+    } finally {
+      // Reset so the same file can be re-selected
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
+  return (
+    <div>
+      <h2 className="text-lg text-text-primary">Sync</h2>
+      <p className="text-xs text-text-secondary mb-6">
+        Synchronise settings and workspaces across devices.
+      </p>
+
+      {/* Provider selector */}
+      <SettingItem
+        label="Provider"
+        description="Select where sync data is stored and exchanged."
+      >
+        <SegmentControl
+          options={PROVIDER_OPTIONS}
+          value={currentProvider}
+          onChange={handleProviderChange}
+        />
+      </SettingItem>
+
+      {currentProvider !== 'off' && (
+        <>
+          {/* Sync status */}
+          <SettingItem
+            label="Sync Status"
+            description={
+              lastSyncedAt
+                ? `Last sync: ${formatRelativeTime(lastSyncedAt)}`
+                : 'Never synced'
+            }
+          >
+            <button
+              onClick={() => {
+                // Actual sync logic will be wired in a future task
+                console.log('[SyncSection] Sync Now triggered')
+              }}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border-default text-text-secondary text-xs hover:text-text-primary hover:border-border-active"
+            >
+              <ArrowsClockwise size={14} />
+              Sync Now
+            </button>
+          </SettingItem>
+
+          {/* Module checkboxes */}
+          {contributors.length > 0 && (
+            <SettingItem
+              label="Modules"
+              description="Choose which data to include in sync."
+            >
+              <div className="flex flex-col gap-2">
+                {contributors.map((contributor) => {
+                  const checked = enabledModules.includes(contributor.id)
+                  return (
+                    <label
+                      key={contributor.id}
+                      className="flex items-center gap-2 cursor-pointer text-xs text-text-primary"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleModule(contributor.id)}
+                        className="accent-border-active"
+                      />
+                      {contributor.id}
+                    </label>
+                  )
+                })}
+              </div>
+            </SettingItem>
+          )}
+
+          {/* Export / Import */}
+          <SettingItem
+            label="Export / Import"
+            description="Manually export or import a sync bundle."
+          >
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleExportAll}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border-default text-text-secondary text-xs hover:text-text-primary hover:border-border-active"
+              >
+                <DownloadSimple size={14} />
+                Export All
+              </button>
+              <button
+                onClick={handleImportClick}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border-default text-text-secondary text-xs hover:text-text-primary hover:border-border-active"
+              >
+                <Upload size={14} />
+                Import
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".purdex-sync,.json"
+                className="hidden"
+                onChange={handleFileChange}
+              />
+            </div>
+          </SettingItem>
+        </>
+      )}
+    </div>
+  )
+}

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -18,6 +18,7 @@ import { TerminalSection } from '../components/settings/TerminalSection'
 import { ElectronSection } from '../components/settings/ElectronSection'
 import { DevEnvironmentSection } from '../components/settings/DevEnvironmentSection'
 import { ModuleConfigSection } from '../components/settings/ModuleConfigSection'
+import { SyncSection } from '../components/settings/SyncSection'
 import { FileTreeWorkspaceView } from '../components/FileTreeView'
 import { FileTreeSessionView } from '../components/FileTreeSessionView'
 import { FolderOpen } from '@phosphor-icons/react'
@@ -227,7 +228,7 @@ export function registerBuiltinModules(): void {
   registerSettingsSection({ id: 'appearance', label: 'settings.section.appearance', order: 0, component: AppearanceSection })
   registerSettingsSection({ id: 'terminal', label: 'settings.section.terminal', order: 1, component: TerminalSection })
   registerSettingsSection({ id: 'workspace', label: 'settings.section.workspace', order: 10 }) // reserved
-  registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: 11 }) // reserved
+  registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: 11, component: SyncSection })
   registerSettingsSection({
     id: 'module-config',
     label: 'settings.section.modules',

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -35,6 +35,7 @@ import { LocalBackend } from './fs-backend-local'
 import { registerFsBackend, getFsBackend } from './fs-backend'
 import { registerFileOpener } from './file-opener-registry'
 import { useHostStore } from '../stores/useHostStore'
+import { registerSyncContributors } from './sync/register-sync'
 
 function NewTabPaneWrapper({ pane }: PaneRendererProps) {
   const handleSelect = (content: PaneContent) => {
@@ -61,6 +62,9 @@ function MemoryMonitorPaneWrapper() {
 
 export function registerBuiltinModules(): void {
   const caps = getPlatformCapabilities()
+
+  // Sync contributors
+  registerSyncContributors()
 
   // Modules with pane renderers
   registerModule({

--- a/spa/src/lib/storage/keys.ts
+++ b/spa/src/lib/storage/keys.ts
@@ -16,4 +16,6 @@ export const STORAGE_KEYS = {
   NOTIFICATION_SEEN: 'purdex-notification-seen',
   MODULE_CONFIG: 'purdex-module-config',
   QUICK_COMMANDS: 'purdex-quick-commands',
+  SYNC_STATE: 'purdex-sync-state',
+  SYNC_CLIENT_ID: 'purdex-client-id',
 } as const

--- a/spa/src/lib/storage/keys.ts
+++ b/spa/src/lib/storage/keys.ts
@@ -17,5 +17,4 @@ export const STORAGE_KEYS = {
   MODULE_CONFIG: 'purdex-module-config',
   QUICK_COMMANDS: 'purdex-quick-commands',
   SYNC_STATE: 'purdex-sync-state',
-  SYNC_CLIENT_ID: 'purdex-client-id',
 } as const

--- a/spa/src/lib/sync/contributors/hosts.test.ts
+++ b/spa/src/lib/sync/contributors/hosts.test.ts
@@ -1,0 +1,181 @@
+// =============================================================================
+// Sync Architecture — HostsContributor Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createHostsContributor } from './hosts'
+import { useHostStore } from '../../../stores/useHostStore'
+import type { FullPayload } from '../types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStore() {
+  useHostStore.getState().reset()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createHostsContributor', () => {
+  let contributor: ReturnType<typeof createHostsContributor>
+
+  beforeEach(() => {
+    resetStore()
+    contributor = createHostsContributor()
+  })
+
+  // -------------------------------------------------------------------------
+  // Identity & strategy
+  // -------------------------------------------------------------------------
+
+  it('has id "hosts"', () => {
+    expect(contributor.id).toBe('hosts')
+  })
+
+  it('has strategy "full"', () => {
+    expect(contributor.strategy).toBe('full')
+  })
+
+  // -------------------------------------------------------------------------
+  // getVersion
+  // -------------------------------------------------------------------------
+
+  it('getVersion returns 1', () => {
+    expect(contributor.getVersion()).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // serialize
+  // -------------------------------------------------------------------------
+
+  it('serialize returns FullPayload with version 1', () => {
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.version).toBe(1)
+    expect(payload.data).toBeDefined()
+  })
+
+  it('serialize only includes expected data fields (no functions)', () => {
+    const payload = contributor.serialize() as FullPayload
+    const keys = Object.keys(payload.data)
+
+    expect(keys).toContain('hosts')
+    expect(keys).toContain('hostOrder')
+    expect(keys).toContain('activeHostId')
+
+    // Must NOT contain runtime (ephemeral) or action functions
+    expect(keys).not.toContain('runtime')
+    expect(keys).not.toContain('addHost')
+    expect(keys).not.toContain('removeHost')
+    expect(keys).not.toContain('setRuntime')
+
+    // All values must be non-function
+    for (const key of keys) {
+      expect(typeof payload.data[key]).not.toBe('function')
+    }
+  })
+
+  it('serialize does NOT include token field in host configs', () => {
+    // Add a host with a token
+    const state = useHostStore.getState()
+    const id = state.addHost({ name: 'secure-host', ip: '10.0.0.1', port: 9000, token: 'secret-token' })
+
+    const payload = contributor.serialize() as FullPayload
+    const hosts = payload.data.hosts as Record<string, Record<string, unknown>>
+
+    expect(hosts[id]).toBeDefined()
+    expect(hosts[id].token).toBeUndefined()
+    expect(hosts[id].name).toBe('secure-host')
+  })
+
+  it('serialize does NOT include runtime field', () => {
+    const state = useHostStore.getState()
+    const hostId = Object.keys(state.hosts)[0]
+    state.setRuntime(hostId, { status: 'connected', latency: 42 })
+
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.data.runtime).toBeUndefined()
+  })
+
+  it('serialize reflects current store state', () => {
+    const state = useHostStore.getState()
+    const id = state.addHost({ name: 'remote-box', ip: '192.168.1.100', port: 7860 })
+
+    const payload = contributor.serialize() as FullPayload
+    const hosts = payload.data.hosts as Record<string, Record<string, unknown>>
+    expect(hosts[id]).toBeDefined()
+    expect(hosts[id].name).toBe('remote-box')
+    expect(payload.data.hostOrder).toContain(id)
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — full-replace
+  // -------------------------------------------------------------------------
+
+  it('deserialize with full-replace overwrites store state', () => {
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        hosts: {
+          'h-1': { id: 'h-1', name: 'remote-host', ip: '10.0.0.1', port: 8080, order: 0 },
+        },
+        hostOrder: ['h-1'],
+        activeHostId: 'h-1',
+      },
+    }
+
+    contributor.deserialize(incoming, { type: 'full-replace' })
+
+    const state = useHostStore.getState()
+    expect(state.hosts['h-1']).toBeDefined()
+    expect(state.hosts['h-1'].name).toBe('remote-host')
+    expect(state.hostOrder).toEqual(['h-1'])
+    expect(state.activeHostId).toBe('h-1')
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — field-merge
+  // -------------------------------------------------------------------------
+
+  it('deserialize with field-merge only applies resolved remote fields', () => {
+    const localHostId = Object.keys(useHostStore.getState().hosts)[0]
+
+    useHostStore.setState({
+      hosts: { [localHostId]: { id: localHostId, name: 'local-host', ip: '127.0.0.1', port: 7860, order: 0 } },
+      hostOrder: [localHostId],
+      activeHostId: localHostId,
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        hosts: {
+          'h-remote': { id: 'h-remote', name: 'remote-host', ip: '10.0.0.1', port: 8080, order: 0 },
+        },
+        hostOrder: ['h-remote'],
+        activeHostId: 'h-remote',
+      },
+    }
+
+    // Only apply hostOrder from remote; hosts and activeHostId stay local
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: {
+        hosts: 'local',
+        hostOrder: 'remote',
+        activeHostId: 'local',
+      },
+    })
+
+    const state = useHostStore.getState()
+    // hosts stay local
+    expect(state.hosts[localHostId]).toBeDefined()
+    expect(state.hosts['h-remote']).toBeUndefined()
+    // hostOrder updated from remote
+    expect(state.hostOrder).toEqual(['h-remote'])
+    // activeHostId stays local
+    expect(state.activeHostId).toBe(localHostId)
+  })
+})

--- a/spa/src/lib/sync/contributors/hosts.ts
+++ b/spa/src/lib/sync/contributors/hosts.ts
@@ -1,0 +1,69 @@
+// =============================================================================
+// Sync Architecture — HostsContributor
+// =============================================================================
+
+import { useHostStore } from '../../../stores/useHostStore'
+import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createHostsContributor(): SyncContributor {
+  return {
+    id: 'hosts',
+    strategy: 'full',
+
+    getVersion(): number {
+      return 1
+    },
+
+    serialize(): FullPayload {
+      const state = useHostStore.getState()
+      const { hosts, hostOrder, activeHostId } = state
+
+      // Strip token from each HostConfig; do NOT include runtime (ephemeral)
+      const sanitized: Record<string, unknown> = {}
+      for (const [id, config] of Object.entries(hosts)) {
+        const { token, ...rest } = config as Record<string, unknown>
+        void token // intentionally excluded
+        sanitized[id] = rest
+      }
+
+      return {
+        version: 1,
+        data: {
+          hosts: sanitized,
+          hostOrder,
+          activeHostId,
+        },
+      }
+    },
+
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      const fp = payload as FullPayload
+      const incoming = fp.data as Record<string, unknown>
+
+      if (merge.type === 'full-replace') {
+        useHostStore.setState({
+          hosts: incoming.hosts as ReturnType<typeof useHostStore.getState>['hosts'],
+          hostOrder: incoming.hostOrder as string[],
+          activeHostId: incoming.activeHostId as string | null,
+        })
+        return
+      }
+
+      // field-merge: only apply fields where resolved[field] === 'remote'
+      const patch: Record<string, unknown> = {}
+      for (const field of ['hosts', 'hostOrder', 'activeHostId'] as const) {
+        if (merge.resolved[field] === 'remote' && field in incoming) {
+          patch[field] = incoming[field]
+        }
+      }
+
+      if (Object.keys(patch).length > 0) {
+        useHostStore.setState(patch as Parameters<typeof useHostStore.setState>[0])
+      }
+    },
+  }
+}

--- a/spa/src/lib/sync/contributors/i18n.test.ts
+++ b/spa/src/lib/sync/contributors/i18n.test.ts
@@ -1,0 +1,181 @@
+// =============================================================================
+// Sync Architecture — I18nContributor Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createI18nContributor } from './i18n'
+import { useI18nStore } from '../../../stores/useI18nStore'
+import type { FullPayload } from '../types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStore() {
+  useI18nStore.setState({
+    activeLocaleId: 'en',
+    customLocales: {},
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createI18nContributor', () => {
+  let contributor: ReturnType<typeof createI18nContributor>
+
+  beforeEach(() => {
+    resetStore()
+    contributor = createI18nContributor()
+  })
+
+  // -------------------------------------------------------------------------
+  // Identity & strategy
+  // -------------------------------------------------------------------------
+
+  it('has id "i18n"', () => {
+    expect(contributor.id).toBe('i18n')
+  })
+
+  it('has strategy "full"', () => {
+    expect(contributor.strategy).toBe('full')
+  })
+
+  // -------------------------------------------------------------------------
+  // getVersion
+  // -------------------------------------------------------------------------
+
+  it('getVersion returns 1', () => {
+    expect(contributor.getVersion()).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // serialize
+  // -------------------------------------------------------------------------
+
+  it('serialize returns FullPayload with version 1', () => {
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.version).toBe(1)
+    expect(payload.data).toBeDefined()
+  })
+
+  it('serialize only includes expected data fields (no functions)', () => {
+    const payload = contributor.serialize() as FullPayload
+    const keys = Object.keys(payload.data)
+
+    expect(keys).toContain('activeLocaleId')
+    expect(keys).toContain('customLocales')
+
+    // Must NOT contain the `t` function or action functions
+    expect(keys).not.toContain('t')
+    expect(keys).not.toContain('setLocale')
+    expect(keys).not.toContain('importLocale')
+    expect(keys).not.toContain('updateCustomLocale')
+    expect(keys).not.toContain('deleteCustomLocale')
+
+    // All values must be non-function
+    for (const key of keys) {
+      expect(typeof payload.data[key]).not.toBe('function')
+    }
+  })
+
+  it('serialize reflects current store state', () => {
+    useI18nStore.setState({ activeLocaleId: 'zh-TW' })
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.data.activeLocaleId).toBe('zh-TW')
+  })
+
+  it('serialize includes customLocales', () => {
+    useI18nStore.setState({
+      customLocales: {
+        'custom-1': { id: 'custom-1', name: 'Custom', translations: { hello: '哈囉' }, builtin: false },
+      },
+    })
+    const payload = contributor.serialize() as FullPayload
+    const customLocales = payload.data.customLocales as Record<string, unknown>
+    expect(customLocales['custom-1']).toBeDefined()
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — full-replace
+  // -------------------------------------------------------------------------
+
+  it('deserialize with full-replace overwrites store state', () => {
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        activeLocaleId: 'zh-TW',
+        customLocales: {
+          'c-1': { id: 'c-1', name: 'Test Locale', translations: { hello: '嗨' }, builtin: false },
+        },
+      },
+    }
+
+    contributor.deserialize(incoming, { type: 'full-replace' })
+
+    const state = useI18nStore.getState()
+    expect(state.activeLocaleId).toBe('zh-TW')
+    expect(state.customLocales['c-1']).toBeDefined()
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — field-merge
+  // -------------------------------------------------------------------------
+
+  it('deserialize with field-merge only applies resolved remote fields', () => {
+    useI18nStore.setState({
+      activeLocaleId: 'en',
+      customLocales: {},
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        activeLocaleId: 'ja',
+        customLocales: {
+          'c-remote': { id: 'c-remote', name: 'Japanese Custom', translations: { hello: 'こんにちは' }, builtin: false },
+        },
+      },
+    }
+
+    // Only apply activeLocaleId from remote; customLocales stays local
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: {
+        activeLocaleId: 'remote',
+        customLocales: 'local',
+      },
+    })
+
+    const state = useI18nStore.getState()
+    expect(state.activeLocaleId).toBe('ja')
+    expect(state.customLocales['c-remote']).toBeUndefined()
+  })
+
+  it('deserialize with field-merge ignores fields not present in resolved', () => {
+    useI18nStore.setState({
+      activeLocaleId: 'en',
+      customLocales: {},
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        activeLocaleId: 'fr',
+        customLocales: {},
+      },
+    }
+
+    // activeLocaleId=remote; customLocales not mentioned
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { activeLocaleId: 'remote' },
+    })
+
+    const state = useI18nStore.getState()
+    expect(state.activeLocaleId).toBe('fr')
+    // customLocales untouched (empty stays empty)
+    expect(Object.keys(state.customLocales)).toHaveLength(0)
+  })
+})

--- a/spa/src/lib/sync/contributors/i18n.ts
+++ b/spa/src/lib/sync/contributors/i18n.ts
@@ -1,0 +1,62 @@
+// =============================================================================
+// Sync Architecture — I18nContributor
+// =============================================================================
+
+import { useI18nStore } from '../../../stores/useI18nStore'
+import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
+
+// ---------------------------------------------------------------------------
+// Data field list (non-function fields from I18nState; excludes `t` getter)
+// ---------------------------------------------------------------------------
+
+const DATA_FIELDS = ['activeLocaleId', 'customLocales'] as const
+
+type I18nData = {
+  [K in (typeof DATA_FIELDS)[number]]: ReturnType<typeof useI18nStore.getState>[K]
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createI18nContributor(): SyncContributor {
+  return {
+    id: 'i18n',
+    strategy: 'full',
+
+    getVersion(): number {
+      return 1
+    },
+
+    serialize(): FullPayload {
+      const state = useI18nStore.getState()
+      const data: Record<string, unknown> = {}
+      for (const field of DATA_FIELDS) {
+        data[field] = state[field]
+      }
+      return { version: 1, data }
+    },
+
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      const fp = payload as FullPayload
+      const incoming = fp.data as Partial<I18nData>
+
+      if (merge.type === 'full-replace') {
+        useI18nStore.setState(incoming as I18nData)
+        return
+      }
+
+      // field-merge: only apply fields where resolved[field] === 'remote'
+      const patch: Partial<I18nData> = {}
+      for (const field of DATA_FIELDS) {
+        if (merge.resolved[field] === 'remote' && field in incoming) {
+          ;(patch as Record<string, unknown>)[field] = incoming[field]
+        }
+      }
+
+      if (Object.keys(patch).length > 0) {
+        useI18nStore.setState(patch as I18nData)
+      }
+    },
+  }
+}

--- a/spa/src/lib/sync/contributors/layout.test.ts
+++ b/spa/src/lib/sync/contributors/layout.test.ts
@@ -1,0 +1,179 @@
+// =============================================================================
+// Sync Architecture — LayoutContributor Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createLayoutContributor } from './layout'
+import { useLayoutStore } from '../../../stores/useLayoutStore'
+import type { FullPayload } from '../types'
+
+// ---------------------------------------------------------------------------
+// Default state
+// ---------------------------------------------------------------------------
+
+const DEFAULT_REGIONS = {
+  'primary-sidebar': { views: [], width: 240, mode: 'collapsed' as const },
+  'primary-panel': { views: [], width: 200, mode: 'collapsed' as const },
+  'secondary-panel': { views: [], width: 200, mode: 'collapsed' as const },
+  'secondary-sidebar': { views: [], width: 240, mode: 'collapsed' as const },
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStore() {
+  useLayoutStore.setState({ regions: DEFAULT_REGIONS })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createLayoutContributor', () => {
+  let contributor: ReturnType<typeof createLayoutContributor>
+
+  beforeEach(() => {
+    resetStore()
+    contributor = createLayoutContributor()
+  })
+
+  // -------------------------------------------------------------------------
+  // Identity & strategy
+  // -------------------------------------------------------------------------
+
+  it('has id "layout"', () => {
+    expect(contributor.id).toBe('layout')
+  })
+
+  it('has strategy "full"', () => {
+    expect(contributor.strategy).toBe('full')
+  })
+
+  // -------------------------------------------------------------------------
+  // getVersion
+  // -------------------------------------------------------------------------
+
+  it('getVersion returns 1', () => {
+    expect(contributor.getVersion()).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // serialize
+  // -------------------------------------------------------------------------
+
+  it('serialize returns FullPayload with version 1', () => {
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.version).toBe(1)
+    expect(payload.data).toBeDefined()
+  })
+
+  it('serialize only includes expected data fields (no functions)', () => {
+    const payload = contributor.serialize() as FullPayload
+    const keys = Object.keys(payload.data)
+
+    expect(keys).toContain('regions')
+
+    // Must NOT contain action functions
+    expect(keys).not.toContain('setRegionMode')
+    expect(keys).not.toContain('setRegionWidth')
+    expect(keys).not.toContain('toggleRegion')
+    expect(keys).not.toContain('reconcileViews')
+
+    // All values must be non-function
+    for (const key of keys) {
+      expect(typeof payload.data[key]).not.toBe('function')
+    }
+  })
+
+  it('serialize reflects current store state', () => {
+    useLayoutStore.getState().setRegionMode('primary-sidebar', 'pinned')
+    const payload = contributor.serialize() as FullPayload
+    const regions = payload.data.regions as Record<string, { mode: string }>
+    expect(regions['primary-sidebar'].mode).toBe('pinned')
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — full-replace
+  // -------------------------------------------------------------------------
+
+  it('deserialize with full-replace overwrites store state', () => {
+    const remoteRegions = {
+      'primary-sidebar': { views: ['view-a'], width: 300, mode: 'pinned' as const },
+      'primary-panel': { views: [], width: 200, mode: 'collapsed' as const },
+      'secondary-panel': { views: [], width: 200, mode: 'collapsed' as const },
+      'secondary-sidebar': { views: [], width: 240, mode: 'hidden' as const },
+    }
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: { regions: remoteRegions },
+    }
+
+    contributor.deserialize(incoming, { type: 'full-replace' })
+
+    const state = useLayoutStore.getState()
+    expect(state.regions['primary-sidebar'].mode).toBe('pinned')
+    expect(state.regions['primary-sidebar'].width).toBe(300)
+    expect(state.regions['secondary-sidebar'].mode).toBe('hidden')
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — field-merge
+  // -------------------------------------------------------------------------
+
+  it('deserialize with field-merge only applies resolved remote fields', () => {
+    useLayoutStore.setState({
+      regions: {
+        ...DEFAULT_REGIONS,
+        'primary-sidebar': { views: ['local-view'], width: 240, mode: 'collapsed' as const },
+      },
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        regions: {
+          'primary-sidebar': { views: ['remote-view'], width: 350, mode: 'pinned' as const },
+        },
+      },
+    }
+
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { regions: 'remote' },
+    })
+
+    const state = useLayoutStore.getState()
+    expect(state.regions['primary-sidebar'].mode).toBe('pinned')
+    expect(state.regions['primary-sidebar'].width).toBe(350)
+  })
+
+  it('deserialize with field-merge keeps local when resolved local', () => {
+    useLayoutStore.setState({
+      regions: {
+        ...DEFAULT_REGIONS,
+        'primary-sidebar': { views: ['local-view'], width: 240, mode: 'collapsed' as const },
+      },
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        regions: {
+          'primary-sidebar': { views: ['remote-view'], width: 350, mode: 'pinned' as const },
+        },
+      },
+    }
+
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { regions: 'local' },
+    })
+
+    const state = useLayoutStore.getState()
+    // regions should remain local (unchanged)
+    expect(state.regions['primary-sidebar'].mode).toBe('collapsed')
+    expect(state.regions['primary-sidebar'].width).toBe(240)
+  })
+})

--- a/spa/src/lib/sync/contributors/layout.ts
+++ b/spa/src/lib/sync/contributors/layout.ts
@@ -1,0 +1,62 @@
+// =============================================================================
+// Sync Architecture — LayoutContributor
+// =============================================================================
+
+import { useLayoutStore } from '../../../stores/useLayoutStore'
+import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
+
+// ---------------------------------------------------------------------------
+// Data field list (non-function fields from LayoutState)
+// ---------------------------------------------------------------------------
+
+const DATA_FIELDS = ['regions'] as const
+
+type LayoutData = {
+  [K in (typeof DATA_FIELDS)[number]]: ReturnType<typeof useLayoutStore.getState>[K]
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createLayoutContributor(): SyncContributor {
+  return {
+    id: 'layout',
+    strategy: 'full',
+
+    getVersion(): number {
+      return 1
+    },
+
+    serialize(): FullPayload {
+      const state = useLayoutStore.getState()
+      const data: Record<string, unknown> = {}
+      for (const field of DATA_FIELDS) {
+        data[field] = state[field]
+      }
+      return { version: 1, data }
+    },
+
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      const fp = payload as FullPayload
+      const incoming = fp.data as Partial<LayoutData>
+
+      if (merge.type === 'full-replace') {
+        useLayoutStore.setState(incoming as LayoutData)
+        return
+      }
+
+      // field-merge: only apply fields where resolved[field] === 'remote'
+      const patch: Partial<LayoutData> = {}
+      for (const field of DATA_FIELDS) {
+        if (merge.resolved[field] === 'remote' && field in incoming) {
+          ;(patch as Record<string, unknown>)[field] = incoming[field]
+        }
+      }
+
+      if (Object.keys(patch).length > 0) {
+        useLayoutStore.setState(patch as LayoutData)
+      }
+    },
+  }
+}

--- a/spa/src/lib/sync/contributors/notification-settings.test.ts
+++ b/spa/src/lib/sync/contributors/notification-settings.test.ts
@@ -1,0 +1,167 @@
+// =============================================================================
+// Sync Architecture — NotificationSettingsContributor Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNotificationSettingsContributor } from './notification-settings'
+import { useNotificationSettingsStore } from '../../../stores/useNotificationSettingsStore'
+import type { FullPayload } from '../types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStore() {
+  useNotificationSettingsStore.setState({ agents: {} })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createNotificationSettingsContributor', () => {
+  let contributor: ReturnType<typeof createNotificationSettingsContributor>
+
+  beforeEach(() => {
+    resetStore()
+    contributor = createNotificationSettingsContributor()
+  })
+
+  // -------------------------------------------------------------------------
+  // Identity & strategy
+  // -------------------------------------------------------------------------
+
+  it('has id "notification-settings"', () => {
+    expect(contributor.id).toBe('notification-settings')
+  })
+
+  it('has strategy "full"', () => {
+    expect(contributor.strategy).toBe('full')
+  })
+
+  // -------------------------------------------------------------------------
+  // getVersion
+  // -------------------------------------------------------------------------
+
+  it('getVersion returns 1', () => {
+    expect(contributor.getVersion()).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // serialize
+  // -------------------------------------------------------------------------
+
+  it('serialize returns FullPayload with version 1', () => {
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.version).toBe(1)
+    expect(payload.data).toBeDefined()
+  })
+
+  it('serialize only includes expected data fields (no functions)', () => {
+    const payload = contributor.serialize() as FullPayload
+    const keys = Object.keys(payload.data)
+
+    expect(keys).toContain('agents')
+
+    // Must NOT contain action functions
+    expect(keys).not.toContain('getSettingsForAgent')
+    expect(keys).not.toContain('setAgentEnabled')
+    expect(keys).not.toContain('setEventEnabled')
+    expect(keys).not.toContain('setNotifyWithoutTab')
+    expect(keys).not.toContain('setReopenTabOnClick')
+
+    // All values must be non-function
+    for (const key of keys) {
+      expect(typeof payload.data[key]).not.toBe('function')
+    }
+  })
+
+  it('serialize reflects current store state', () => {
+    useNotificationSettingsStore.getState().setAgentEnabled('claude-code', true)
+    const payload = contributor.serialize() as FullPayload
+    const agents = payload.data.agents as Record<string, { enabled: boolean }>
+    expect(agents['claude-code']).toBeDefined()
+    expect(agents['claude-code'].enabled).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — full-replace
+  // -------------------------------------------------------------------------
+
+  it('deserialize with full-replace overwrites store state', () => {
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        agents: {
+          'claude-code': { enabled: false, events: { done: true }, notifyWithoutTab: true, reopenTabOnClick: false },
+          'codex': { enabled: true, events: {}, notifyWithoutTab: false, reopenTabOnClick: true },
+        },
+      },
+    }
+
+    contributor.deserialize(incoming, { type: 'full-replace' })
+
+    const state = useNotificationSettingsStore.getState()
+    expect(state.agents['claude-code']).toBeDefined()
+    expect(state.agents['claude-code'].enabled).toBe(false)
+    expect(state.agents['codex']).toBeDefined()
+    expect(state.agents['codex'].reopenTabOnClick).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — field-merge
+  // -------------------------------------------------------------------------
+
+  it('deserialize with field-merge only applies resolved remote fields', () => {
+    useNotificationSettingsStore.setState({
+      agents: {
+        'local-agent': { enabled: true, events: {}, notifyWithoutTab: false, reopenTabOnClick: false },
+      },
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        agents: {
+          'remote-agent': { enabled: false, events: {}, notifyWithoutTab: true, reopenTabOnClick: false },
+        },
+      },
+    }
+
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { agents: 'remote' },
+    })
+
+    const state = useNotificationSettingsStore.getState()
+    expect(state.agents['remote-agent']).toBeDefined()
+    expect(state.agents['local-agent']).toBeUndefined()
+  })
+
+  it('deserialize with field-merge keeps local when resolved local', () => {
+    useNotificationSettingsStore.setState({
+      agents: {
+        'local-agent': { enabled: true, events: {}, notifyWithoutTab: false, reopenTabOnClick: false },
+      },
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        agents: {
+          'remote-agent': { enabled: false, events: {}, notifyWithoutTab: true, reopenTabOnClick: false },
+        },
+      },
+    }
+
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { agents: 'local' },
+    })
+
+    const state = useNotificationSettingsStore.getState()
+    // agents unchanged (local wins)
+    expect(state.agents['local-agent']).toBeDefined()
+    expect(state.agents['remote-agent']).toBeUndefined()
+  })
+})

--- a/spa/src/lib/sync/contributors/notification-settings.ts
+++ b/spa/src/lib/sync/contributors/notification-settings.ts
@@ -1,0 +1,62 @@
+// =============================================================================
+// Sync Architecture — NotificationSettingsContributor
+// =============================================================================
+
+import { useNotificationSettingsStore } from '../../../stores/useNotificationSettingsStore'
+import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
+
+// ---------------------------------------------------------------------------
+// Data field list (non-function fields from NotificationSettingsState)
+// ---------------------------------------------------------------------------
+
+const DATA_FIELDS = ['agents'] as const
+
+type NotificationSettingsData = {
+  [K in (typeof DATA_FIELDS)[number]]: ReturnType<typeof useNotificationSettingsStore.getState>[K]
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createNotificationSettingsContributor(): SyncContributor {
+  return {
+    id: 'notification-settings',
+    strategy: 'full',
+
+    getVersion(): number {
+      return 1
+    },
+
+    serialize(): FullPayload {
+      const state = useNotificationSettingsStore.getState()
+      const data: Record<string, unknown> = {}
+      for (const field of DATA_FIELDS) {
+        data[field] = state[field]
+      }
+      return { version: 1, data }
+    },
+
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      const fp = payload as FullPayload
+      const incoming = fp.data as Partial<NotificationSettingsData>
+
+      if (merge.type === 'full-replace') {
+        useNotificationSettingsStore.setState(incoming as NotificationSettingsData)
+        return
+      }
+
+      // field-merge: only apply fields where resolved[field] === 'remote'
+      const patch: Partial<NotificationSettingsData> = {}
+      for (const field of DATA_FIELDS) {
+        if (merge.resolved[field] === 'remote' && field in incoming) {
+          ;(patch as Record<string, unknown>)[field] = incoming[field]
+        }
+      }
+
+      if (Object.keys(patch).length > 0) {
+        useNotificationSettingsStore.setState(patch as NotificationSettingsData)
+      }
+    },
+  }
+}

--- a/spa/src/lib/sync/contributors/preferences.test.ts
+++ b/spa/src/lib/sync/contributors/preferences.test.ts
@@ -1,0 +1,200 @@
+// =============================================================================
+// Sync Architecture — PreferencesContributor Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPreferencesContributor } from './preferences'
+import { useUISettingsStore } from '../../../stores/useUISettingsStore'
+import type { FullPayload } from '../types'
+
+// ---------------------------------------------------------------------------
+// Default state (mirrors store initial values)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STATE = {
+  terminalRevealDelay: 300,
+  terminalRenderer: 'webgl' as const,
+  keepAliveCount: 0,
+  keepAlivePinned: false,
+  terminalSettingsVersion: 0,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStore() {
+  useUISettingsStore.setState(DEFAULT_STATE)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createPreferencesContributor', () => {
+  let contributor: ReturnType<typeof createPreferencesContributor>
+
+  beforeEach(() => {
+    resetStore()
+    contributor = createPreferencesContributor()
+  })
+
+  // -------------------------------------------------------------------------
+  // Identity & strategy
+  // -------------------------------------------------------------------------
+
+  it('has id "preferences"', () => {
+    expect(contributor.id).toBe('preferences')
+  })
+
+  it('has strategy "full"', () => {
+    expect(contributor.strategy).toBe('full')
+  })
+
+  // -------------------------------------------------------------------------
+  // getVersion
+  // -------------------------------------------------------------------------
+
+  it('getVersion returns 1', () => {
+    expect(contributor.getVersion()).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // serialize
+  // -------------------------------------------------------------------------
+
+  it('serialize returns FullPayload with version 1', () => {
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.version).toBe(1)
+    expect(payload.data).toBeDefined()
+  })
+
+  it('serialize only includes data fields (no functions)', () => {
+    const payload = contributor.serialize() as FullPayload
+    const keys = Object.keys(payload.data)
+
+    // Must contain all data fields
+    expect(keys).toContain('terminalRevealDelay')
+    expect(keys).toContain('terminalRenderer')
+    expect(keys).toContain('keepAliveCount')
+    expect(keys).toContain('keepAlivePinned')
+    expect(keys).toContain('terminalSettingsVersion')
+
+    // Must NOT contain setter functions
+    expect(keys).not.toContain('setTerminalRevealDelay')
+    expect(keys).not.toContain('setTerminalRenderer')
+    expect(keys).not.toContain('setKeepAliveCount')
+    expect(keys).not.toContain('setKeepAlivePinned')
+    expect(keys).not.toContain('bumpTerminalSettingsVersion')
+
+    // All values must be non-function
+    for (const key of keys) {
+      expect(typeof payload.data[key]).not.toBe('function')
+    }
+  })
+
+  it('serialize reflects current store state', () => {
+    useUISettingsStore.setState({ terminalRevealDelay: 500, terminalRenderer: 'dom' })
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.data.terminalRevealDelay).toBe(500)
+    expect(payload.data.terminalRenderer).toBe('dom')
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — full-replace
+  // -------------------------------------------------------------------------
+
+  it('deserialize with full-replace overwrites store state', () => {
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        terminalRevealDelay: 100,
+        terminalRenderer: 'dom',
+        keepAliveCount: 3,
+        keepAlivePinned: true,
+        terminalSettingsVersion: 5,
+      },
+    }
+
+    contributor.deserialize(incoming, { type: 'full-replace' })
+
+    const state = useUISettingsStore.getState()
+    expect(state.terminalRevealDelay).toBe(100)
+    expect(state.terminalRenderer).toBe('dom')
+    expect(state.keepAliveCount).toBe(3)
+    expect(state.keepAlivePinned).toBe(true)
+    expect(state.terminalSettingsVersion).toBe(5)
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — field-merge
+  // -------------------------------------------------------------------------
+
+  it('deserialize with field-merge only applies resolved remote fields', () => {
+    // Set up a known initial local state
+    useUISettingsStore.setState({
+      terminalRevealDelay: 300,
+      terminalRenderer: 'webgl',
+      keepAliveCount: 2,
+      keepAlivePinned: false,
+      terminalSettingsVersion: 1,
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        terminalRevealDelay: 800,  // remote value
+        terminalRenderer: 'dom',   // remote value
+        keepAliveCount: 5,         // remote value
+        keepAlivePinned: true,     // remote value
+        terminalSettingsVersion: 9, // remote value
+      },
+    }
+
+    // Only apply terminalRevealDelay and keepAlivePinned from remote
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: {
+        terminalRevealDelay: 'remote',
+        keepAlivePinned: 'remote',
+        terminalRenderer: 'local',
+        keepAliveCount: 'local',
+        terminalSettingsVersion: 'local',
+      },
+    })
+
+    const state = useUISettingsStore.getState()
+    // Remote-resolved fields should be updated
+    expect(state.terminalRevealDelay).toBe(800)
+    expect(state.keepAlivePinned).toBe(true)
+    // Local-resolved fields should remain unchanged
+    expect(state.terminalRenderer).toBe('webgl')
+    expect(state.keepAliveCount).toBe(2)
+    expect(state.terminalSettingsVersion).toBe(1)
+  })
+
+  it('deserialize with field-merge ignores fields not present in resolved', () => {
+    useUISettingsStore.setState({
+      terminalRevealDelay: 300,
+      keepAliveCount: 2,
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        terminalRevealDelay: 999,
+        keepAliveCount: 9,
+      },
+    }
+
+    // resolved only mentions terminalRevealDelay=remote; keepAliveCount not mentioned
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { terminalRevealDelay: 'remote' },
+    })
+
+    const state = useUISettingsStore.getState()
+    expect(state.terminalRevealDelay).toBe(999) // remote applied
+    expect(state.keepAliveCount).toBe(2)         // untouched
+  })
+})

--- a/spa/src/lib/sync/contributors/preferences.ts
+++ b/spa/src/lib/sync/contributors/preferences.ts
@@ -1,0 +1,68 @@
+// =============================================================================
+// Sync Architecture — PreferencesContributor
+// =============================================================================
+
+import { useUISettingsStore } from '../../../stores/useUISettingsStore'
+import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
+
+// ---------------------------------------------------------------------------
+// Data field list (non-function fields from UISettings)
+// ---------------------------------------------------------------------------
+
+const DATA_FIELDS = [
+  'terminalRevealDelay',
+  'terminalRenderer',
+  'keepAliveCount',
+  'keepAlivePinned',
+  'terminalSettingsVersion',
+] as const
+
+type PreferencesData = {
+  [K in (typeof DATA_FIELDS)[number]]: ReturnType<typeof useUISettingsStore.getState>[K]
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createPreferencesContributor(): SyncContributor {
+  return {
+    id: 'preferences',
+    strategy: 'full',
+
+    getVersion(): number {
+      return 1
+    },
+
+    serialize(): FullPayload {
+      const state = useUISettingsStore.getState()
+      const data: Record<string, unknown> = {}
+      for (const field of DATA_FIELDS) {
+        data[field] = state[field]
+      }
+      return { version: 1, data }
+    },
+
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      const fp = payload as FullPayload
+      const incoming = fp.data as Partial<PreferencesData>
+
+      if (merge.type === 'full-replace') {
+        useUISettingsStore.setState(incoming as PreferencesData)
+        return
+      }
+
+      // field-merge: only apply fields where resolved[field] === 'remote'
+      const patch: Partial<PreferencesData> = {}
+      for (const field of DATA_FIELDS) {
+        if (merge.resolved[field] === 'remote' && field in incoming) {
+          ;(patch as Record<string, unknown>)[field] = incoming[field]
+        }
+      }
+
+      if (Object.keys(patch).length > 0) {
+        useUISettingsStore.setState(patch as PreferencesData)
+      }
+    },
+  }
+}

--- a/spa/src/lib/sync/contributors/quick-commands.test.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.test.ts
@@ -1,0 +1,182 @@
+// =============================================================================
+// Sync Architecture — QuickCommandsContributor Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createQuickCommandsContributor } from './quick-commands'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import type { FullPayload } from '../types'
+
+// ---------------------------------------------------------------------------
+// Default state (matches store defaults)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STATE = {
+  global: [
+    { id: 'start-cc', name: 'Start Claude Code', command: 'claude -p --verbose --output-format stream-json', category: 'agent' },
+    { id: 'start-codex', name: 'Start Codex', command: 'codex', category: 'agent' },
+  ],
+  byHost: {} as Record<string, unknown[]>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStore() {
+  useQuickCommandStore.setState(DEFAULT_STATE)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createQuickCommandsContributor', () => {
+  let contributor: ReturnType<typeof createQuickCommandsContributor>
+
+  beforeEach(() => {
+    resetStore()
+    contributor = createQuickCommandsContributor()
+  })
+
+  // -------------------------------------------------------------------------
+  // Identity & strategy
+  // -------------------------------------------------------------------------
+
+  it('has id "quick-commands"', () => {
+    expect(contributor.id).toBe('quick-commands')
+  })
+
+  it('has strategy "full"', () => {
+    expect(contributor.strategy).toBe('full')
+  })
+
+  // -------------------------------------------------------------------------
+  // getVersion
+  // -------------------------------------------------------------------------
+
+  it('getVersion returns 1', () => {
+    expect(contributor.getVersion()).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // serialize
+  // -------------------------------------------------------------------------
+
+  it('serialize returns FullPayload with version 1', () => {
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.version).toBe(1)
+    expect(payload.data).toBeDefined()
+  })
+
+  it('serialize only includes expected data fields (no functions)', () => {
+    const payload = contributor.serialize() as FullPayload
+    const keys = Object.keys(payload.data)
+
+    expect(keys).toContain('global')
+    expect(keys).toContain('byHost')
+
+    // Must NOT contain action functions
+    expect(keys).not.toContain('addCommand')
+    expect(keys).not.toContain('removeCommand')
+    expect(keys).not.toContain('updateCommand')
+    expect(keys).not.toContain('getCommands')
+
+    // All values must be non-function
+    for (const key of keys) {
+      expect(typeof payload.data[key]).not.toBe('function')
+    }
+  })
+
+  it('serialize reflects current store state', () => {
+    useQuickCommandStore.getState().addCommand({ id: 'my-cmd', name: 'My Command', command: 'echo hello' })
+    const payload = contributor.serialize() as FullPayload
+    const global = payload.data.global as Array<{ id: string }>
+    expect(global.some((c) => c.id === 'my-cmd')).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — full-replace
+  // -------------------------------------------------------------------------
+
+  it('deserialize with full-replace overwrites store state', () => {
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'remote-cmd', name: 'Remote Command', command: 'remote' }],
+        byHost: { 'host-1': [{ id: 'host-cmd', name: 'Host Command', command: 'ls' }] },
+      },
+    }
+
+    contributor.deserialize(incoming, { type: 'full-replace' })
+
+    const state = useQuickCommandStore.getState()
+    const globalCmds = state.global as Array<{ id: string }>
+    expect(globalCmds.some((c) => c.id === 'remote-cmd')).toBe(true)
+    expect(globalCmds.some((c) => c.id === 'start-cc')).toBe(false)
+    expect(state.byHost['host-1']).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — field-merge
+  // -------------------------------------------------------------------------
+
+  it('deserialize with field-merge only applies resolved remote fields', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'local-cmd', name: 'Local', command: 'local' }],
+      byHost: {},
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'remote-cmd', name: 'Remote', command: 'remote' }],
+        byHost: { 'h-1': [{ id: 'host-cmd', name: 'Host', command: 'host' }] },
+      },
+    }
+
+    // Only apply byHost from remote; global stays local
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: {
+        global: 'local',
+        byHost: 'remote',
+      },
+    })
+
+    const state = useQuickCommandStore.getState()
+    const globalCmds = state.global as Array<{ id: string }>
+    // global stays local
+    expect(globalCmds.some((c) => c.id === 'local-cmd')).toBe(true)
+    expect(globalCmds.some((c) => c.id === 'remote-cmd')).toBe(false)
+    // byHost updated from remote
+    expect(state.byHost['h-1']).toHaveLength(1)
+  })
+
+  it('deserialize with field-merge ignores fields not present in resolved', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'local-cmd', name: 'Local', command: 'local' }],
+      byHost: {},
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'remote-cmd', name: 'Remote', command: 'remote' }],
+        byHost: { 'h-1': [] },
+      },
+    }
+
+    // Only global=remote; byHost not mentioned
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { global: 'remote' },
+    })
+
+    const state = useQuickCommandStore.getState()
+    const globalCmds = state.global as Array<{ id: string }>
+    expect(globalCmds.some((c) => c.id === 'remote-cmd')).toBe(true)
+    // byHost untouched
+    expect(state.byHost['h-1']).toBeUndefined()
+  })
+})

--- a/spa/src/lib/sync/contributors/quick-commands.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.ts
@@ -1,0 +1,62 @@
+// =============================================================================
+// Sync Architecture — QuickCommandsContributor
+// =============================================================================
+
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
+
+// ---------------------------------------------------------------------------
+// Data field list (non-function fields from QuickCommandState)
+// ---------------------------------------------------------------------------
+
+const DATA_FIELDS = ['global', 'byHost'] as const
+
+type QuickCommandsData = {
+  [K in (typeof DATA_FIELDS)[number]]: ReturnType<typeof useQuickCommandStore.getState>[K]
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createQuickCommandsContributor(): SyncContributor {
+  return {
+    id: 'quick-commands',
+    strategy: 'full',
+
+    getVersion(): number {
+      return 1
+    },
+
+    serialize(): FullPayload {
+      const state = useQuickCommandStore.getState()
+      const data: Record<string, unknown> = {}
+      for (const field of DATA_FIELDS) {
+        data[field] = state[field]
+      }
+      return { version: 1, data }
+    },
+
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      const fp = payload as FullPayload
+      const incoming = fp.data as Partial<QuickCommandsData>
+
+      if (merge.type === 'full-replace') {
+        useQuickCommandStore.setState(incoming as QuickCommandsData)
+        return
+      }
+
+      // field-merge: only apply fields where resolved[field] === 'remote'
+      const patch: Partial<QuickCommandsData> = {}
+      for (const field of DATA_FIELDS) {
+        if (merge.resolved[field] === 'remote' && field in incoming) {
+          ;(patch as Record<string, unknown>)[field] = incoming[field]
+        }
+      }
+
+      if (Object.keys(patch).length > 0) {
+        useQuickCommandStore.setState(patch as QuickCommandsData)
+      }
+    },
+  }
+}

--- a/spa/src/lib/sync/contributors/workspaces.test.ts
+++ b/spa/src/lib/sync/contributors/workspaces.test.ts
@@ -1,0 +1,164 @@
+// =============================================================================
+// Sync Architecture — WorkspacesContributor Tests
+// =============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createWorkspacesContributor } from './workspaces'
+import { useWorkspaceStore } from '../../../features/workspace/store'
+import type { FullPayload } from '../types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStore() {
+  useWorkspaceStore.getState().reset()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createWorkspacesContributor', () => {
+  let contributor: ReturnType<typeof createWorkspacesContributor>
+
+  beforeEach(() => {
+    resetStore()
+    contributor = createWorkspacesContributor()
+  })
+
+  // -------------------------------------------------------------------------
+  // Identity & strategy
+  // -------------------------------------------------------------------------
+
+  it('has id "workspaces"', () => {
+    expect(contributor.id).toBe('workspaces')
+  })
+
+  it('has strategy "full"', () => {
+    expect(contributor.strategy).toBe('full')
+  })
+
+  // -------------------------------------------------------------------------
+  // getVersion
+  // -------------------------------------------------------------------------
+
+  it('getVersion returns 1', () => {
+    expect(contributor.getVersion()).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // serialize
+  // -------------------------------------------------------------------------
+
+  it('serialize returns FullPayload with version 1', () => {
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.version).toBe(1)
+    expect(payload.data).toBeDefined()
+  })
+
+  it('serialize only includes expected data fields (no functions)', () => {
+    const payload = contributor.serialize() as FullPayload
+    const keys = Object.keys(payload.data)
+
+    expect(keys).toContain('workspaces')
+    expect(keys).toContain('activeWorkspaceId')
+
+    // Must NOT contain action functions
+    expect(keys).not.toContain('addWorkspace')
+    expect(keys).not.toContain('removeWorkspace')
+    expect(keys).not.toContain('setActiveWorkspace')
+    expect(keys).not.toContain('reset')
+
+    // All values must be non-function
+    for (const key of keys) {
+      expect(typeof payload.data[key]).not.toBe('function')
+    }
+  })
+
+  it('serialize reflects current store state', () => {
+    useWorkspaceStore.getState().addWorkspace('TestWS')
+    const payload = contributor.serialize() as FullPayload
+    const workspaces = payload.data.workspaces as Array<{ name: string }>
+    expect(workspaces.some((w) => w.name === 'TestWS')).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — full-replace
+  // -------------------------------------------------------------------------
+
+  it('deserialize with full-replace overwrites store state', () => {
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        workspaces: [{ id: 'ws-1', name: 'Remote WS', tabs: [], activeTabId: null }],
+        activeWorkspaceId: 'ws-1',
+      },
+    }
+
+    contributor.deserialize(incoming, { type: 'full-replace' })
+
+    const state = useWorkspaceStore.getState()
+    expect(state.workspaces).toHaveLength(1)
+    expect(state.workspaces[0].name).toBe('Remote WS')
+    expect(state.activeWorkspaceId).toBe('ws-1')
+  })
+
+  // -------------------------------------------------------------------------
+  // deserialize — field-merge
+  // -------------------------------------------------------------------------
+
+  it('deserialize with field-merge only applies resolved remote fields', () => {
+    useWorkspaceStore.setState({
+      workspaces: [{ id: 'local-ws', name: 'Local WS', tabs: [], activeTabId: null }],
+      activeWorkspaceId: 'local-ws',
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        workspaces: [{ id: 'remote-ws', name: 'Remote WS', tabs: [], activeTabId: null }],
+        activeWorkspaceId: 'remote-ws',
+      },
+    }
+
+    // Only apply activeWorkspaceId from remote
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: {
+        workspaces: 'local',
+        activeWorkspaceId: 'remote',
+      },
+    })
+
+    const state = useWorkspaceStore.getState()
+    // workspaces stays local
+    expect(state.workspaces[0].name).toBe('Local WS')
+    // activeWorkspaceId updated from remote
+    expect(state.activeWorkspaceId).toBe('remote-ws')
+  })
+
+  it('deserialize with field-merge ignores fields not present in resolved', () => {
+    useWorkspaceStore.setState({
+      workspaces: [],
+      activeWorkspaceId: 'local-id',
+    })
+
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        workspaces: [],
+        activeWorkspaceId: 'remote-id',
+      },
+    }
+
+    // Only activeWorkspaceId=remote; workspaces not mentioned
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { activeWorkspaceId: 'remote' },
+    })
+
+    const state = useWorkspaceStore.getState()
+    expect(state.activeWorkspaceId).toBe('remote-id')
+  })
+})

--- a/spa/src/lib/sync/contributors/workspaces.ts
+++ b/spa/src/lib/sync/contributors/workspaces.ts
@@ -1,0 +1,62 @@
+// =============================================================================
+// Sync Architecture — WorkspacesContributor
+// =============================================================================
+
+import { useWorkspaceStore } from '../../../features/workspace/store'
+import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
+
+// ---------------------------------------------------------------------------
+// Data field list (non-function fields from WorkspaceState)
+// ---------------------------------------------------------------------------
+
+const DATA_FIELDS = ['workspaces', 'activeWorkspaceId'] as const
+
+type WorkspacesData = {
+  [K in (typeof DATA_FIELDS)[number]]: ReturnType<typeof useWorkspaceStore.getState>[K]
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createWorkspacesContributor(): SyncContributor {
+  return {
+    id: 'workspaces',
+    strategy: 'full',
+
+    getVersion(): number {
+      return 1
+    },
+
+    serialize(): FullPayload {
+      const state = useWorkspaceStore.getState()
+      const data: Record<string, unknown> = {}
+      for (const field of DATA_FIELDS) {
+        data[field] = state[field]
+      }
+      return { version: 1, data }
+    },
+
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      const fp = payload as FullPayload
+      const incoming = fp.data as Partial<WorkspacesData>
+
+      if (merge.type === 'full-replace') {
+        useWorkspaceStore.setState(incoming as WorkspacesData)
+        return
+      }
+
+      // field-merge: only apply fields where resolved[field] === 'remote'
+      const patch: Partial<WorkspacesData> = {}
+      for (const field of DATA_FIELDS) {
+        if (merge.resolved[field] === 'remote' && field in incoming) {
+          ;(patch as Record<string, unknown>)[field] = incoming[field]
+        }
+      }
+
+      if (Object.keys(patch).length > 0) {
+        useWorkspaceStore.setState(patch as WorkspacesData)
+      }
+    },
+  }
+}

--- a/spa/src/lib/sync/engine.test.ts
+++ b/spa/src/lib/sync/engine.test.ts
@@ -1,0 +1,455 @@
+// =============================================================================
+// Sync Architecture — SyncEngine Tests
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createSyncEngine } from './engine'
+import type {
+  SyncContributor,
+  SyncProvider,
+  SyncBundle,
+  FullPayload,
+  MergeStrategy,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a mock SyncContributor with controllable internal state.
+ * Tracks serialize/deserialize calls.
+ */
+function createMockContributor(
+  id: string,
+  data: Record<string, unknown>,
+): SyncContributor & {
+  _data: Record<string, unknown>
+  _deserializeCalls: Array<{ payload: unknown; merge: MergeStrategy }>
+} {
+  let internalData = { ...data }
+  const deserializeCalls: Array<{ payload: unknown; merge: MergeStrategy }> = []
+
+  return {
+    id,
+    strategy: 'full' as const,
+    _data: internalData,
+    _deserializeCalls: deserializeCalls,
+
+    serialize(): FullPayload {
+      return { version: 1, data: { ...internalData } }
+    },
+
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      deserializeCalls.push({ payload, merge })
+      const fp = payload as FullPayload
+      internalData = { ...fp.data }
+      // Update reference too
+      Object.assign(this._data, internalData)
+    },
+
+    getVersion(): number {
+      return 1
+    },
+  }
+}
+
+/**
+ * Creates a mock SyncProvider with configurable pull bundle.
+ */
+function createMockProvider(pullBundle: SyncBundle | null = null): SyncProvider & {
+  pushedBundles: SyncBundle[]
+  setPullBundle(b: SyncBundle | null): void
+} {
+  const pushedBundles: SyncBundle[] = []
+  let currentPullBundle = pullBundle
+
+  return {
+    id: 'mock-provider',
+    pushedBundles,
+
+    setPullBundle(b: SyncBundle | null) {
+      currentPullBundle = b
+    },
+
+    async push(bundle: SyncBundle): Promise<void> {
+      pushedBundles.push(bundle)
+    },
+
+    async pull(): Promise<SyncBundle | null> {
+      return currentPullBundle
+    },
+
+    async pushChunks(): Promise<void> {},
+    async pullChunks(): Promise<Record<string, Uint8Array>> {
+      return {}
+    },
+    async listHistory() {
+      return []
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createSyncEngine', () => {
+  let engine: ReturnType<typeof createSyncEngine>
+
+  beforeEach(() => {
+    engine = createSyncEngine()
+  })
+
+  // -------------------------------------------------------------------------
+  // register / getContributors
+  // -------------------------------------------------------------------------
+
+  it('registers contributors and returns them via getContributors', () => {
+    const c1 = createMockContributor('settings', { theme: 'dark' })
+    const c2 = createMockContributor('workspaces', { list: [] })
+
+    engine.register(c1)
+    engine.register(c2)
+
+    const contributors = engine.getContributors()
+    expect(contributors).toHaveLength(2)
+    expect(contributors.map((c) => c.id)).toContain('settings')
+    expect(contributors.map((c) => c.id)).toContain('workspaces')
+  })
+
+  it('overwrites contributor with the same id on re-register', () => {
+    const c1 = createMockContributor('settings', { theme: 'dark' })
+    const c2 = createMockContributor('settings', { theme: 'light' })
+
+    engine.register(c1)
+    engine.register(c2)
+
+    expect(engine.getContributors()).toHaveLength(1)
+    expect(engine.getContributors()[0]).toBe(c2)
+  })
+
+  // -------------------------------------------------------------------------
+  // serialize
+  // -------------------------------------------------------------------------
+
+  it('serializes all enabled contributors into a SyncBundle', () => {
+    const c1 = createMockContributor('settings', { theme: 'dark' })
+    const c2 = createMockContributor('workspaces', { list: ['a'] })
+
+    engine.register(c1)
+    engine.register(c2)
+
+    const bundle = engine.serialize('device-a', ['settings', 'workspaces'])
+
+    expect(bundle.version).toBe(1)
+    expect(bundle.device).toBe('device-a')
+    expect(bundle.timestamp).toBeGreaterThan(0)
+    expect(bundle.collections['settings']).toEqual({ version: 1, data: { theme: 'dark' } })
+    expect(bundle.collections['workspaces']).toEqual({ version: 1, data: { list: ['a'] } })
+  })
+
+  it('skips contributors not in enabledModules during serialize', () => {
+    const c1 = createMockContributor('settings', { theme: 'dark' })
+    const c2 = createMockContributor('workspaces', { list: ['a'] })
+
+    engine.register(c1)
+    engine.register(c2)
+
+    const bundle = engine.serialize('device-a', ['settings'])
+
+    expect(bundle.collections).toHaveProperty('settings')
+    expect(bundle.collections).not.toHaveProperty('workspaces')
+  })
+
+  it('skips contributors not registered when serializing', () => {
+    const c1 = createMockContributor('settings', { theme: 'dark' })
+    engine.register(c1)
+
+    // 'workspaces' is in enabledModules but not registered
+    const bundle = engine.serialize('device-a', ['settings', 'workspaces'])
+
+    expect(bundle.collections).toHaveProperty('settings')
+    expect(bundle.collections).not.toHaveProperty('workspaces')
+  })
+
+  // -------------------------------------------------------------------------
+  // push
+  // -------------------------------------------------------------------------
+
+  it('push serializes and sends bundle to provider', async () => {
+    const c1 = createMockContributor('settings', { theme: 'dark' })
+    engine.register(c1)
+
+    const provider = createMockProvider()
+    const bundle = await engine.push(provider, 'device-a', ['settings'])
+
+    expect(provider.pushedBundles).toHaveLength(1)
+    expect(provider.pushedBundles[0]).toBe(bundle)
+    expect(bundle.device).toBe('device-a')
+    expect(bundle.collections['settings']).toBeDefined()
+  })
+
+  // -------------------------------------------------------------------------
+  // pull — no data from provider
+  // -------------------------------------------------------------------------
+
+  it('pull returns null appliedBundle when provider has no data', async () => {
+    const provider = createMockProvider(null)
+    const result = await engine.pull(provider, null, ['settings'])
+
+    expect(result.appliedBundle).toBeNull()
+    expect(result.conflicts).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // pull — first sync (lastSynced === null)
+  // -------------------------------------------------------------------------
+
+  it('pull with null lastSynced does full-replace on all enabled contributors', async () => {
+    const c1 = createMockContributor('settings', { theme: 'dark' })
+    engine.register(c1)
+
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: Date.now(),
+      device: 'device-b',
+      collections: {
+        settings: { version: 1, data: { theme: 'light', fontSize: 14 } },
+      },
+    }
+
+    const provider = createMockProvider(remoteBundle)
+    const result = await engine.pull(provider, null, ['settings'])
+
+    expect(result.appliedBundle).toBe(remoteBundle)
+    expect(result.conflicts).toEqual([])
+
+    // Contributor should have received full-replace deserialize call
+    expect(c1._deserializeCalls).toHaveLength(1)
+    expect(c1._deserializeCalls[0].merge).toEqual({ type: 'full-replace' })
+    expect(c1._deserializeCalls[0].payload).toEqual({
+      version: 1,
+      data: { theme: 'light', fontSize: 14 },
+    })
+  })
+
+  it('pull with null lastSynced skips contributors not in enabledModules', async () => {
+    const c1 = createMockContributor('settings', { theme: 'dark' })
+    const c2 = createMockContributor('workspaces', { list: [] })
+    engine.register(c1)
+    engine.register(c2)
+
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: Date.now(),
+      device: 'device-b',
+      collections: {
+        settings: { version: 1, data: { theme: 'light' } },
+        workspaces: { version: 1, data: { list: ['x'] } },
+      },
+    }
+
+    const provider = createMockProvider(remoteBundle)
+    await engine.pull(provider, null, ['settings'])
+
+    expect(c1._deserializeCalls).toHaveLength(1)
+    expect(c2._deserializeCalls).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // pull — conflict detection (lastSynced provided)
+  // -------------------------------------------------------------------------
+
+  it('pull detects conflicts when both sides diverged since lastSynced', async () => {
+    // Local: theme='dark' (changed from 'system')
+    const c1 = createMockContributor('settings', { theme: 'dark', lang: 'en' })
+    engine.register(c1)
+
+    // lastSynced: theme='system', lang='en'
+    const lastSynced: SyncBundle = {
+      version: 1,
+      timestamp: Date.now() - 10000,
+      device: 'device-a',
+      collections: {
+        settings: { version: 1, data: { theme: 'system', lang: 'en' } },
+      },
+    }
+
+    // Remote: theme='light' (also changed from 'system'), lang='en'
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: Date.now(),
+      device: 'device-b',
+      collections: {
+        settings: { version: 1, data: { theme: 'light', lang: 'en' } },
+      },
+    }
+
+    const provider = createMockProvider(remoteBundle)
+    const result = await engine.pull(provider, lastSynced, ['settings'])
+
+    expect(result.appliedBundle).toBe(remoteBundle)
+    expect(result.conflicts).toHaveLength(1)
+    expect(result.conflicts[0]).toMatchObject({
+      contributor: 'settings',
+      field: 'theme',
+      lastSynced: 'system',
+      local: 'dark',
+      remote: { value: 'light', device: 'device-b' },
+    })
+  })
+
+  it('pull auto-applies non-conflicting remote changes when lastSynced is provided', async () => {
+    // Local: theme='dark', lang='en' (lang unchanged from lastSynced)
+    const c1 = createMockContributor('settings', { theme: 'dark', lang: 'en' })
+    engine.register(c1)
+
+    // lastSynced: theme='dark', lang='en'
+    const lastSynced: SyncBundle = {
+      version: 1,
+      timestamp: Date.now() - 10000,
+      device: 'device-a',
+      collections: {
+        settings: { version: 1, data: { theme: 'dark', lang: 'en' } },
+      },
+    }
+
+    // Remote: theme='dark', lang='fr' (only remote changed lang)
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: Date.now(),
+      device: 'device-b',
+      collections: {
+        settings: { version: 1, data: { theme: 'dark', lang: 'fr' } },
+      },
+    }
+
+    const provider = createMockProvider(remoteBundle)
+    const result = await engine.pull(provider, lastSynced, ['settings'])
+
+    // No conflicts; deserialize should be called with merged data
+    expect(result.conflicts).toHaveLength(0)
+    expect(c1._deserializeCalls).toHaveLength(1)
+    expect(c1._deserializeCalls[0].merge).toEqual({ type: 'full-replace' })
+    // Merged: theme='dark' (local), lang='fr' (remote)
+    const applied = c1._deserializeCalls[0].payload as FullPayload
+    expect(applied.data).toEqual({ theme: 'dark', lang: 'fr' })
+  })
+
+  it('pull skips contributors not in bundle collections during merge', async () => {
+    const c1 = createMockContributor('settings', { theme: 'dark' })
+    const c2 = createMockContributor('workspaces', { list: [] })
+    engine.register(c1)
+    engine.register(c2)
+
+    const lastSynced: SyncBundle = {
+      version: 1,
+      timestamp: Date.now() - 1000,
+      device: 'device-a',
+      collections: {
+        settings: { version: 1, data: { theme: 'dark' } },
+      },
+    }
+
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: Date.now(),
+      device: 'device-b',
+      collections: {
+        settings: { version: 1, data: { theme: 'light' } },
+        // workspaces NOT in remote bundle
+      },
+    }
+
+    const provider = createMockProvider(remoteBundle)
+    await engine.pull(provider, lastSynced, ['settings', 'workspaces'])
+
+    // workspaces contributor not called since no remote collection for it
+    expect(c2._deserializeCalls).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // resolveConflicts
+  // -------------------------------------------------------------------------
+
+  it('resolveConflicts applies user choices via field-merge deserialize', () => {
+    const c1 = createMockContributor('settings', { theme: 'dark', lang: 'en' })
+    engine.register(c1)
+
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: Date.now(),
+      device: 'device-b',
+      collections: {
+        settings: { version: 1, data: { theme: 'light', lang: 'fr' } },
+      },
+    }
+
+    const conflicts = [
+      {
+        contributor: 'settings',
+        field: 'theme',
+        lastSynced: 'system',
+        local: 'dark',
+        remote: { value: 'light', device: 'device-b' },
+      },
+    ]
+
+    // User chooses to keep remote theme
+    engine.resolveConflicts(remoteBundle, conflicts, { theme: 'remote' })
+
+    expect(c1._deserializeCalls).toHaveLength(1)
+    const call = c1._deserializeCalls[0]
+    expect(call.merge).toEqual({ type: 'field-merge', resolved: { theme: 'remote' } })
+  })
+
+  it('resolveConflicts groups conflicts by contributor and calls each once', () => {
+    const c1 = createMockContributor('settings', { theme: 'dark', lang: 'en' })
+    const c2 = createMockContributor('workspaces', { active: 'ws-1' })
+    engine.register(c1)
+    engine.register(c2)
+
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: Date.now(),
+      device: 'device-b',
+      collections: {
+        settings: { version: 1, data: { theme: 'light', lang: 'fr' } },
+        workspaces: { version: 1, data: { active: 'ws-2' } },
+      },
+    }
+
+    const conflicts = [
+      {
+        contributor: 'settings',
+        field: 'theme',
+        lastSynced: 'system',
+        local: 'dark',
+        remote: { value: 'light', device: 'device-b' },
+      },
+      {
+        contributor: 'workspaces',
+        field: 'active',
+        lastSynced: 'ws-0',
+        local: 'ws-1',
+        remote: { value: 'ws-2', device: 'device-b' },
+      },
+    ]
+
+    engine.resolveConflicts(remoteBundle, conflicts, { theme: 'local', active: 'remote' })
+
+    // Each contributor called exactly once
+    expect(c1._deserializeCalls).toHaveLength(1)
+    expect(c2._deserializeCalls).toHaveLength(1)
+
+    expect(c1._deserializeCalls[0].merge).toEqual({
+      type: 'field-merge',
+      resolved: { theme: 'local', active: 'remote' },
+    })
+    expect(c2._deserializeCalls[0].merge).toEqual({
+      type: 'field-merge',
+      resolved: { theme: 'local', active: 'remote' },
+    })
+  })
+})

--- a/spa/src/lib/sync/engine.test.ts
+++ b/spa/src/lib/sync/engine.test.ts
@@ -2,7 +2,7 @@
 // Sync Architecture — SyncEngine Tests
 // =============================================================================
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { createSyncEngine } from './engine'
 import type {
   SyncContributor,

--- a/spa/src/lib/sync/engine.ts
+++ b/spa/src/lib/sync/engine.ts
@@ -1,0 +1,199 @@
+// =============================================================================
+// Sync Architecture — SyncEngine
+// =============================================================================
+
+import type {
+  SyncBundle,
+  SyncContributor,
+  SyncProvider,
+  ConflictItem,
+  ResolvedFields,
+  FullPayload,
+} from './types'
+import { mergeCollection } from './three-way-merge'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface PullResult {
+  appliedBundle: SyncBundle | null
+  conflicts: ConflictItem[]
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export function createSyncEngine() {
+  const contributors = new Map<string, SyncContributor>()
+
+  // -------------------------------------------------------------------------
+  // register
+  // -------------------------------------------------------------------------
+
+  function register(contributor: SyncContributor): void {
+    contributors.set(contributor.id, contributor)
+  }
+
+  // -------------------------------------------------------------------------
+  // getContributors
+  // -------------------------------------------------------------------------
+
+  function getContributors(): SyncContributor[] {
+    return Array.from(contributors.values())
+  }
+
+  // -------------------------------------------------------------------------
+  // serialize
+  // -------------------------------------------------------------------------
+
+  function serialize(device: string, enabledModules: string[]): SyncBundle {
+    const collections: SyncBundle['collections'] = {}
+
+    for (const id of enabledModules) {
+      const contributor = contributors.get(id)
+      if (!contributor) continue
+      collections[id] = contributor.serialize()
+    }
+
+    return {
+      version: 1,
+      timestamp: Date.now(),
+      device,
+      collections,
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // push
+  // -------------------------------------------------------------------------
+
+  async function push(
+    provider: SyncProvider,
+    device: string,
+    enabledModules: string[],
+  ): Promise<SyncBundle> {
+    const bundle = serialize(device, enabledModules)
+    await provider.push(bundle)
+    return bundle
+  }
+
+  // -------------------------------------------------------------------------
+  // pull
+  // -------------------------------------------------------------------------
+
+  async function pull(
+    provider: SyncProvider,
+    lastSynced: SyncBundle | null,
+    enabledModules: string[],
+  ): Promise<PullResult> {
+    const remoteBundle = await provider.pull()
+
+    // No data on remote yet
+    if (remoteBundle === null) {
+      return { appliedBundle: null, conflicts: [] }
+    }
+
+    // First sync: full-replace all enabled contributors
+    if (lastSynced === null) {
+      for (const id of enabledModules) {
+        const contributor = contributors.get(id)
+        if (!contributor) continue
+        const payload = remoteBundle.collections[id]
+        if (!payload) continue
+        contributor.deserialize(payload, { type: 'full-replace' })
+      }
+      return { appliedBundle: remoteBundle, conflicts: [] }
+    }
+
+    // Subsequent sync: three-way merge per contributor
+    const allConflicts: ConflictItem[] = []
+
+    for (const id of enabledModules) {
+      const contributor = contributors.get(id)
+      if (!contributor) continue
+      if (contributor.strategy !== 'full') continue
+
+      const remotePayload = remoteBundle.collections[id] as FullPayload | undefined
+      if (!remotePayload) continue
+
+      const lastPayload = lastSynced.collections[id] as FullPayload | undefined
+      const localPayload = contributor.serialize() as FullPayload
+
+      const lastData = lastPayload ? (lastPayload.data as Record<string, unknown>) : null
+      const localData = localPayload.data as Record<string, unknown>
+      const remoteData = remotePayload.data as Record<string, unknown>
+
+      const { merged, conflicts } = mergeCollection(
+        lastData,
+        localData,
+        remoteData,
+        remoteBundle.device,
+      )
+
+      // Tag each conflict with the contributor id
+      const taggedConflicts = conflicts.map((c) => ({ ...c, contributor: id }))
+      allConflicts.push(...taggedConflicts)
+
+      // If no conflicts for this contributor, apply the merged result immediately
+      if (taggedConflicts.length === 0) {
+        const mergedPayload: FullPayload = { version: remotePayload.version, data: merged }
+        contributor.deserialize(mergedPayload, { type: 'full-replace' })
+      }
+    }
+
+    return { appliedBundle: remoteBundle, conflicts: allConflicts }
+  }
+
+  // -------------------------------------------------------------------------
+  // resolveConflicts
+  // -------------------------------------------------------------------------
+
+  function resolveConflicts(
+    remoteBundle: SyncBundle,
+    conflicts: ConflictItem[],
+    resolved: ResolvedFields,
+  ): void {
+    // Collect the unique set of contributors involved in the conflicts
+    const contributorIds = new Set(conflicts.map((c) => c.contributor))
+
+    for (const id of contributorIds) {
+      const contributor = contributors.get(id)
+      if (!contributor) continue
+
+      const remotePayload = remoteBundle.collections[id] as FullPayload | undefined
+      if (!remotePayload) continue
+
+      // Build merged data: start from local state, overlay resolved choices
+      const localPayload = contributor.serialize() as FullPayload
+      const localData = { ...localPayload.data } as Record<string, unknown>
+      const remoteData = remotePayload.data as Record<string, unknown>
+
+      const merged: Record<string, unknown> = { ...localData }
+
+      for (const [field, choice] of Object.entries(resolved)) {
+        if (choice === 'remote') {
+          merged[field] = remoteData[field]
+        }
+        // 'local' keeps the local value already in merged
+      }
+
+      const mergedPayload: FullPayload = { version: remotePayload.version, data: merged }
+      contributor.deserialize(mergedPayload, { type: 'field-merge', resolved })
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Public interface
+  // -------------------------------------------------------------------------
+
+  return {
+    register,
+    getContributors,
+    serialize,
+    push,
+    pull,
+    resolveConflicts,
+  }
+}

--- a/spa/src/lib/sync/providers/daemon-provider.test.ts
+++ b/spa/src/lib/sync/providers/daemon-provider.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createDaemonProvider } from './daemon-provider'
+import type { SyncBundle } from '../types'
+
+// ---------------------------------------------------------------------------
+// Mock hostFetch
+// ---------------------------------------------------------------------------
+
+const mockHostFetch = vi.fn()
+vi.mock('../../host-api', () => ({
+  hostFetch: (...args: unknown[]) => mockHostFetch(...args),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const HOST_ID = 'host1'
+const CLIENT_ID = 'c_test'
+
+const makeBundle = (): SyncBundle => ({
+  version: 1,
+  timestamp: 1000000,
+  device: 'test-device',
+  collections: {},
+})
+
+beforeEach(() => {
+  mockHostFetch.mockReset()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DaemonProvider', () => {
+  it('has id "daemon"', () => {
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    expect(provider.id).toBe('daemon')
+  })
+
+  it('push calls POST /api/sync/push with clientId and bundle body', async () => {
+    mockHostFetch.mockResolvedValue(new Response('', { status: 200 }))
+
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    const bundle = makeBundle()
+
+    await provider.push(bundle)
+
+    expect(mockHostFetch).toHaveBeenCalledWith(
+      HOST_ID,
+      `/api/sync/push?clientId=${CLIENT_ID}`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(bundle),
+      }),
+    )
+  })
+
+  it('push sets Content-Type application/json', async () => {
+    mockHostFetch.mockResolvedValue(new Response('', { status: 200 }))
+
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    await provider.push(makeBundle())
+
+    const init = mockHostFetch.mock.calls[0][2] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get('Content-Type')).toBe('application/json')
+  })
+
+  it('push throws when response is not ok', async () => {
+    mockHostFetch.mockResolvedValue(new Response('', { status: 500 }))
+
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    await expect(provider.push(makeBundle())).rejects.toThrow()
+  })
+
+  it('pull calls GET /api/sync/pull with clientId and parses JSON', async () => {
+    const bundle = makeBundle()
+    mockHostFetch.mockResolvedValue(new Response(JSON.stringify(bundle)))
+
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    const result = await provider.pull()
+
+    expect(mockHostFetch).toHaveBeenCalledWith(
+      HOST_ID,
+      `/api/sync/pull?clientId=${CLIENT_ID}`,
+      undefined,
+    )
+    expect(result).toEqual(bundle)
+  })
+
+  it('pull returns null when daemon has no data (response body is "null")', async () => {
+    mockHostFetch.mockResolvedValue(new Response('null'))
+
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    const result = await provider.pull()
+
+    expect(result).toBeNull()
+  })
+
+  it('pull throws when response is not ok', async () => {
+    mockHostFetch.mockResolvedValue(new Response('', { status: 404 }))
+
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    await expect(provider.pull()).rejects.toThrow()
+  })
+
+  it('pushChunks is a stub and does not throw', async () => {
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    await expect(provider.pushChunks({})).resolves.toBeUndefined()
+  })
+
+  it('pullChunks is a stub and returns empty object', async () => {
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    await expect(provider.pullChunks(['hash1'])).resolves.toEqual({})
+  })
+
+  it('listHistory calls GET /api/sync/history with clientId and limit', async () => {
+    const snapshots = [
+      { id: 's1', timestamp: 2000000, device: 'dev1', source: 'remote', trigger: 'auto', bundleRef: 'ref1' },
+    ]
+    mockHostFetch.mockResolvedValue(new Response(JSON.stringify(snapshots)))
+
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    const result = await provider.listHistory(10)
+
+    expect(mockHostFetch).toHaveBeenCalledWith(
+      HOST_ID,
+      `/api/sync/history?clientId=${CLIENT_ID}&limit=10`,
+      undefined,
+    )
+    expect(result).toEqual(snapshots)
+  })
+
+  it('listHistory throws when response is not ok', async () => {
+    mockHostFetch.mockResolvedValue(new Response('', { status: 503 }))
+
+    const provider = createDaemonProvider(HOST_ID, CLIENT_ID)
+    await expect(provider.listHistory(5)).rejects.toThrow()
+  })
+})

--- a/spa/src/lib/sync/providers/daemon-provider.ts
+++ b/spa/src/lib/sync/providers/daemon-provider.ts
@@ -36,12 +36,14 @@ export function createDaemonProvider(hostId: string, clientId: string): SyncProv
       return res.json() as Promise<SyncBundle | null>
     },
 
-    async pushChunks(_chunks: Record<string, Uint8Array>): Promise<void> {
-      // stub — not implemented yet
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async pushChunks(chunks: Record<string, Uint8Array>): Promise<void> {
+      // stub — content-addressed chunked transfer not yet implemented
     },
 
-    async pullChunks(_hashes: string[]): Promise<Record<string, Uint8Array>> {
-      // stub — not implemented yet
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async pullChunks(hashes: string[]): Promise<Record<string, Uint8Array>> {
+      // stub — content-addressed chunked transfer not yet implemented
       return {}
     },
 

--- a/spa/src/lib/sync/providers/daemon-provider.ts
+++ b/spa/src/lib/sync/providers/daemon-provider.ts
@@ -1,0 +1,60 @@
+import type { SyncBundle, SyncProvider, SyncSnapshot } from '../types'
+import { hostFetch } from '../../host-api'
+
+// ---------------------------------------------------------------------------
+// DaemonProvider — REST transport via local daemon
+// ---------------------------------------------------------------------------
+
+/**
+ * A SyncProvider that communicates with the Purdex daemon's sync HTTP API.
+ * All requests are routed through `hostFetch` so authentication headers and
+ * the correct base URL are applied automatically.
+ *
+ * pushChunks / pullChunks are stubs — content-addressed chunked transfer is
+ * not yet implemented on the daemon side.
+ */
+export function createDaemonProvider(hostId: string, clientId: string): SyncProvider {
+  return {
+    id: 'daemon',
+
+    async push(bundle: SyncBundle): Promise<void> {
+      const res = await hostFetch(hostId, `/api/sync/push?clientId=${clientId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(bundle),
+      })
+      if (!res.ok) {
+        throw new Error(`sync push failed: ${res.status} ${res.statusText}`)
+      }
+    },
+
+    async pull(): Promise<SyncBundle | null> {
+      const res = await hostFetch(hostId, `/api/sync/pull?clientId=${clientId}`, undefined)
+      if (!res.ok) {
+        throw new Error(`sync pull failed: ${res.status} ${res.statusText}`)
+      }
+      return res.json() as Promise<SyncBundle | null>
+    },
+
+    async pushChunks(_chunks: Record<string, Uint8Array>): Promise<void> {
+      // stub — not implemented yet
+    },
+
+    async pullChunks(_hashes: string[]): Promise<Record<string, Uint8Array>> {
+      // stub — not implemented yet
+      return {}
+    },
+
+    async listHistory(limit: number): Promise<SyncSnapshot[]> {
+      const res = await hostFetch(
+        hostId,
+        `/api/sync/history?clientId=${clientId}&limit=${limit}`,
+        undefined,
+      )
+      if (!res.ok) {
+        throw new Error(`sync listHistory failed: ${res.status} ${res.statusText}`)
+      }
+      return res.json() as Promise<SyncSnapshot[]>
+    },
+  }
+}

--- a/spa/src/lib/sync/providers/file-provider.test.ts
+++ b/spa/src/lib/sync/providers/file-provider.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createFileProvider } from './file-provider'
+import type { SyncBundle } from '../types'
+
+// ---------------------------------------------------------------------------
+// Mock FileSystemIpc
+// ---------------------------------------------------------------------------
+
+const mockFs = {
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  readdir: vi.fn(),
+  mkdir: vi.fn(),
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SYNC_FOLDER = '/sync/purdex'
+
+const makeBundle = (): SyncBundle => ({
+  version: 1,
+  timestamp: 1745000000000,
+  device: 'test-device',
+  collections: {},
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFs.mkdir.mockResolvedValue(undefined)
+  mockFs.writeFile.mockResolvedValue(undefined)
+  mockFs.readdir.mockResolvedValue([])
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FileProvider', () => {
+  it('has id "file"', () => {
+    const provider = createFileProvider(SYNC_FOLDER, mockFs)
+    expect(provider.id).toBe('file')
+  })
+
+  describe('push', () => {
+    it('writes manifest.json and a history snapshot', async () => {
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const bundle = makeBundle()
+
+      await provider.push(bundle)
+
+      // manifest.json
+      const manifestCall = mockFs.writeFile.mock.calls.find(([path]: [string]) =>
+        path.endsWith('manifest.json'),
+      )
+      expect(manifestCall).toBeDefined()
+      expect(manifestCall[0]).toBe(`${SYNC_FOLDER}/manifest.json`)
+      expect(JSON.parse(manifestCall[1])).toEqual(bundle)
+
+      // history snapshot
+      const historyCall = mockFs.writeFile.mock.calls.find(([path]: [string]) =>
+        path.includes('/history/'),
+      )
+      expect(historyCall).toBeDefined()
+      expect(historyCall[0]).toMatch(/\/history\/.*\.json$/)
+      expect(JSON.parse(historyCall[1])).toEqual(bundle)
+    })
+
+    it('history snapshot filename uses ISO timestamp with colons replaced', async () => {
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      await provider.push(makeBundle())
+
+      const historyCall = mockFs.writeFile.mock.calls.find(([path]: [string]) =>
+        path.includes('/history/'),
+      )
+      const filename = historyCall[0].split('/').pop() as string
+      // e.g. 2026-04-16T12-00-00-000Z.json
+      expect(filename).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.json$/)
+    })
+
+    it('calls ensureDirs before writing', async () => {
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      await provider.push(makeBundle())
+
+      expect(mockFs.mkdir).toHaveBeenCalledWith(SYNC_FOLDER)
+      expect(mockFs.mkdir).toHaveBeenCalledWith(`${SYNC_FOLDER}/history`)
+      expect(mockFs.mkdir).toHaveBeenCalledWith(`${SYNC_FOLDER}/chunks`)
+    })
+  })
+
+  describe('pull', () => {
+    it('reads manifest.json and parses JSON', async () => {
+      const bundle = makeBundle()
+      mockFs.readFile.mockResolvedValue(JSON.stringify(bundle))
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const result = await provider.pull()
+
+      expect(mockFs.readFile).toHaveBeenCalledWith(`${SYNC_FOLDER}/manifest.json`)
+      expect(result).toEqual(bundle)
+    })
+
+    it('returns null when manifest does not exist (ENOENT)', async () => {
+      const err = Object.assign(new Error('no such file'), { code: 'ENOENT' })
+      mockFs.readFile.mockRejectedValue(err)
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const result = await provider.pull()
+
+      expect(result).toBeNull()
+    })
+
+    it('rethrows non-ENOENT errors', async () => {
+      const err = Object.assign(new Error('permission denied'), { code: 'EACCES' })
+      mockFs.readFile.mockRejectedValue(err)
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      await expect(provider.pull()).rejects.toThrow('permission denied')
+    })
+  })
+
+  describe('pushChunks', () => {
+    it('writes each chunk as base64 to chunks/{hash}.bin', async () => {
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const data = new Uint8Array([1, 2, 3, 4, 5])
+      await provider.pushChunks({ abc123: data })
+
+      const chunkCall = mockFs.writeFile.mock.calls.find(([path]: [string]) =>
+        path.includes('/chunks/'),
+      )
+      expect(chunkCall).toBeDefined()
+      expect(chunkCall[0]).toBe(`${SYNC_FOLDER}/chunks/abc123.bin`)
+      // value must be base64-encoded string
+      const decoded = Buffer.from(chunkCall[1], 'base64')
+      expect(new Uint8Array(decoded)).toEqual(data)
+    })
+
+    it('calls ensureDirs before writing chunks', async () => {
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      await provider.pushChunks({ h1: new Uint8Array([9]) })
+
+      expect(mockFs.mkdir).toHaveBeenCalledWith(SYNC_FOLDER)
+      expect(mockFs.mkdir).toHaveBeenCalledWith(`${SYNC_FOLDER}/chunks`)
+    })
+
+    it('handles empty chunks map without writing', async () => {
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      await provider.pushChunks({})
+
+      expect(mockFs.writeFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pullChunks', () => {
+    it('reads and decodes chunk files', async () => {
+      const data = new Uint8Array([10, 20, 30])
+      const b64 = Buffer.from(data).toString('base64')
+      mockFs.readFile.mockResolvedValue(b64)
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const result = await provider.pullChunks(['deadbeef'])
+
+      expect(mockFs.readFile).toHaveBeenCalledWith(`${SYNC_FOLDER}/chunks/deadbeef.bin`)
+      expect(result['deadbeef']).toEqual(data)
+    })
+
+    it('skips missing chunks (ENOENT)', async () => {
+      const err = Object.assign(new Error('no such file'), { code: 'ENOENT' })
+      mockFs.readFile.mockRejectedValue(err)
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const result = await provider.pullChunks(['missing1', 'missing2'])
+
+      expect(result).toEqual({})
+    })
+
+    it('returns only present chunks when some are missing', async () => {
+      const data = new Uint8Array([99])
+      const b64 = Buffer.from(data).toString('base64')
+      const notFound = Object.assign(new Error('no such file'), { code: 'ENOENT' })
+
+      mockFs.readFile.mockImplementation(async (path: string) => {
+        if (path.includes('present')) return b64
+        throw notFound
+      })
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const result = await provider.pullChunks(['present', 'missing'])
+
+      expect(Object.keys(result)).toEqual(['present'])
+      expect(result['present']).toEqual(data)
+    })
+  })
+
+  describe('listHistory', () => {
+    it('returns sorted snapshot entries (newest first), sliced to limit', async () => {
+      mockFs.readdir.mockResolvedValue([
+        '2026-04-16T10-00-00-000Z.json',
+        '2026-04-14T08-00-00-000Z.json',
+        '2026-04-15T09-00-00-000Z.json',
+        'not-a-json-file.txt',
+      ])
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const result = await provider.listHistory(2)
+
+      expect(result).toHaveLength(2)
+      // newest first
+      expect(result[0].bundleRef).toContain('2026-04-16')
+      expect(result[1].bundleRef).toContain('2026-04-15')
+    })
+
+    it('snapshot entries have source "remote" and trigger "auto"', async () => {
+      mockFs.readdir.mockResolvedValue(['2026-04-16T10-00-00-000Z.json'])
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const [snap] = await provider.listHistory(10)
+
+      expect(snap.source).toBe('remote')
+      expect(snap.trigger).toBe('auto')
+    })
+
+    it('snapshot bundleRef is full path', async () => {
+      mockFs.readdir.mockResolvedValue(['2026-04-16T10-00-00-000Z.json'])
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const [snap] = await provider.listHistory(10)
+
+      expect(snap.bundleRef).toBe(`${SYNC_FOLDER}/history/2026-04-16T10-00-00-000Z.json`)
+    })
+
+    it('filters out non-.json files from history', async () => {
+      mockFs.readdir.mockResolvedValue([
+        'notes.txt',
+        '.DS_Store',
+        '2026-04-16T10-00-00-000Z.json',
+      ])
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const result = await provider.listHistory(10)
+
+      expect(result).toHaveLength(1)
+    })
+
+    it('returns empty array when history dir is empty', async () => {
+      mockFs.readdir.mockResolvedValue([])
+
+      const provider = createFileProvider(SYNC_FOLDER, mockFs)
+      const result = await provider.listHistory(10)
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/spa/src/lib/sync/providers/file-provider.ts
+++ b/spa/src/lib/sync/providers/file-provider.ts
@@ -1,0 +1,164 @@
+import type { SyncBundle, SyncProvider, SyncSnapshot } from '../types'
+
+// ---------------------------------------------------------------------------
+// FileSystemIpc — abstraction over Electron's filesystem IPC
+// ---------------------------------------------------------------------------
+
+export interface FileSystemIpc {
+  readFile(path: string): Promise<string>
+  writeFile(path: string, content: string): Promise<void>
+  readdir(path: string): Promise<string[]>
+  mkdir(path: string): Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// FileProvider — iCloud / Syncthing sync folder
+// ---------------------------------------------------------------------------
+
+/**
+ * A SyncProvider backed by a local sync folder (e.g. iCloud Drive or
+ * Syncthing).  All filesystem operations are performed through a
+ * `FileSystemIpc` abstraction so the implementation is testable without a
+ * real Electron process.
+ *
+ * Folder layout:
+ *   {syncFolder}/
+ *   ├── manifest.json        ← latest bundle
+ *   ├── history/             ← per-sync snapshots
+ *   │   └── <ISO-ts>.json
+ *   └── chunks/              ← content-addressed blobs
+ *       └── <hash>.bin
+ */
+export function createFileProvider(syncFolder: string, fs: FileSystemIpc): SyncProvider {
+  const historyDir = `${syncFolder}/history`
+  const chunksDir = `${syncFolder}/chunks`
+  const manifestPath = `${syncFolder}/manifest.json`
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Create the three directories if they don't already exist.
+   * mkdir errors (e.g. EEXIST) are silently swallowed.
+   */
+  async function ensureDirs(): Promise<void> {
+    await Promise.all([
+      fs.mkdir(syncFolder).catch(() => undefined),
+      fs.mkdir(historyDir).catch(() => undefined),
+      fs.mkdir(chunksDir).catch(() => undefined),
+    ])
+  }
+
+  /** Convert a Date to a filename-safe ISO string: colons → hyphens. */
+  function toFilename(date: Date): string {
+    // e.g. "2026-04-16T12:00:00.000Z" → "2026-04-16T12-00-00-000Z"
+    return date.toISOString().replace(/:/g, '-').replace('.', '-')
+  }
+
+  // -------------------------------------------------------------------------
+  // SyncProvider
+  // -------------------------------------------------------------------------
+
+  return {
+    id: 'file',
+
+    async push(bundle: SyncBundle): Promise<void> {
+      await ensureDirs()
+
+      const json = JSON.stringify(bundle, null, 2)
+
+      // Write latest manifest
+      await fs.writeFile(manifestPath, json)
+
+      // Write history snapshot
+      const filename = `${toFilename(new Date())}.json`
+      await fs.writeFile(`${historyDir}/${filename}`, json)
+    },
+
+    async pull(): Promise<SyncBundle | null> {
+      try {
+        const text = await fs.readFile(manifestPath)
+        return JSON.parse(text) as SyncBundle
+      } catch (err) {
+        if (isEnoent(err)) return null
+        throw err
+      }
+    },
+
+    async pushChunks(chunks: Record<string, Uint8Array>): Promise<void> {
+      const hashes = Object.keys(chunks)
+      if (hashes.length === 0) return
+
+      await ensureDirs()
+
+      await Promise.all(
+        hashes.map((hash) => {
+          const b64 = Buffer.from(chunks[hash]).toString('base64')
+          return fs.writeFile(`${chunksDir}/${hash}.bin`, b64)
+        }),
+      )
+    },
+
+    async pullChunks(hashes: string[]): Promise<Record<string, Uint8Array>> {
+      const result: Record<string, Uint8Array> = {}
+
+      await Promise.all(
+        hashes.map(async (hash) => {
+          try {
+            const b64 = await fs.readFile(`${chunksDir}/${hash}.bin`)
+            result[hash] = new Uint8Array(Buffer.from(b64, 'base64'))
+          } catch (err) {
+            if (isEnoent(err)) return // skip missing chunks
+            throw err
+          }
+        }),
+      )
+
+      return result
+    },
+
+    async listHistory(limit: number): Promise<SyncSnapshot[]> {
+      const entries = await fs.readdir(historyDir)
+
+      const snapshots: SyncSnapshot[] = entries
+        .filter((name) => name.endsWith('.json'))
+        .sort()
+        .reverse()
+        .slice(0, limit)
+        .map((name) => {
+          // Restore ISO timestamp from filename: hyphens in time part → colons
+          // "2026-04-16T12-00-00-000Z" → "2026-04-16T12:00:00.000Z"
+          const iso = name
+            .replace(/\.json$/, '')
+            .replace(/T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/, 'T$1:$2:$3.$4Z')
+          const timestamp = new Date(iso).getTime()
+          const bundleRef = `${historyDir}/${name}`
+
+          return {
+            id: name,
+            timestamp: isNaN(timestamp) ? 0 : timestamp,
+            device: '',
+            source: 'remote',
+            trigger: 'auto',
+            bundleRef,
+          } satisfies SyncSnapshot
+        })
+
+      return snapshots
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'ENOENT'
+  )
+}

--- a/spa/src/lib/sync/providers/manual-provider.test.ts
+++ b/spa/src/lib/sync/providers/manual-provider.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { createManualProvider } from './manual-provider'
+import type { SyncBundle } from '../types'
+
+const makeBundle = (): SyncBundle => ({
+  version: 1,
+  timestamp: 1000000,
+  device: 'test-device',
+  collections: {},
+})
+
+describe('ManualProvider', () => {
+  it('has id "manual"', () => {
+    const provider = createManualProvider()
+    expect(provider.id).toBe('manual')
+  })
+
+  it('exportToBlob serializes bundle to JSON blob with correct type', () => {
+    const provider = createManualProvider()
+    const bundle = makeBundle()
+    const blob = provider.exportToBlob(bundle)
+    expect(blob).toBeInstanceOf(Blob)
+    expect(blob.type).toBe('application/json')
+    return blob.text().then(text => {
+      const parsed = JSON.parse(text)
+      expect(parsed).toEqual(bundle)
+      // pretty-print check: should contain newlines
+      expect(text).toContain('\n')
+    })
+  })
+
+  it('importFromText parses JSON back to SyncBundle', () => {
+    const provider = createManualProvider()
+    const bundle = makeBundle()
+    const text = JSON.stringify(bundle, null, 2)
+    const result = provider.importFromText(text)
+    expect(result).toEqual(bundle)
+  })
+
+  it('importFromText throws on invalid JSON', () => {
+    const provider = createManualProvider()
+    expect(() => provider.importFromText('not valid json{')).toThrow()
+  })
+
+  it('importFromText throws on missing version field', () => {
+    const provider = createManualProvider()
+    const bad = { timestamp: 1000000, device: 'x', collections: {} }
+    expect(() => provider.importFromText(JSON.stringify(bad))).toThrow(/version/)
+  })
+
+  it('importFromText throws when version is not a number', () => {
+    const provider = createManualProvider()
+    const bad = { version: 'one', timestamp: 1000000, device: 'x', collections: {} }
+    expect(() => provider.importFromText(JSON.stringify(bad))).toThrow(/version/)
+  })
+
+  it('importFromText throws when timestamp is not a number', () => {
+    const provider = createManualProvider()
+    const bad = { version: 1, timestamp: 'now', device: 'x', collections: {} }
+    expect(() => provider.importFromText(JSON.stringify(bad))).toThrow(/timestamp/)
+  })
+
+  it('importFromText throws when device is not a string', () => {
+    const provider = createManualProvider()
+    const bad = { version: 1, timestamp: 1000000, device: 42, collections: {} }
+    expect(() => provider.importFromText(JSON.stringify(bad))).toThrow(/device/)
+  })
+
+  it('importFromText throws when collections is not an object', () => {
+    const provider = createManualProvider()
+    const bad = { version: 1, timestamp: 1000000, device: 'x', collections: 'bad' }
+    expect(() => provider.importFromText(JSON.stringify(bad))).toThrow(/collections/)
+  })
+
+  it('listHistory returns empty array', async () => {
+    const provider = createManualProvider()
+    const result = await provider.listHistory(10)
+    expect(result).toEqual([])
+  })
+
+  it('push is a no-op and does not throw', async () => {
+    const provider = createManualProvider()
+    await expect(provider.push(makeBundle())).resolves.toBeUndefined()
+  })
+
+  it('pull is a no-op and returns null', async () => {
+    const provider = createManualProvider()
+    await expect(provider.pull()).resolves.toBeNull()
+  })
+
+  it('pushChunks is a no-op and does not throw', async () => {
+    const provider = createManualProvider()
+    await expect(provider.pushChunks({})).resolves.toBeUndefined()
+  })
+
+  it('pullChunks is a no-op and returns empty object', async () => {
+    const provider = createManualProvider()
+    await expect(provider.pullChunks(['hash1'])).resolves.toEqual({})
+  })
+})

--- a/spa/src/lib/sync/providers/manual-provider.ts
+++ b/spa/src/lib/sync/providers/manual-provider.ts
@@ -1,0 +1,92 @@
+import type { SyncBundle, SyncProvider, SyncSnapshot } from '../types'
+
+// ---------------------------------------------------------------------------
+// ManualProvider — Export / Import
+// ---------------------------------------------------------------------------
+
+/**
+ * A SyncProvider that performs no network or file-system I/O.
+ * Its sole purpose is to allow the user to manually export a bundle to a JSON
+ * file and import a previously-exported file back into the application.
+ *
+ * push / pull / pushChunks / pullChunks are intentional no-ops; history is
+ * always empty because there is no persistent storage backing this provider.
+ */
+export interface ManualProvider extends SyncProvider {
+  /** Serialise a bundle to a pretty-printed JSON Blob (type: application/json). */
+  exportToBlob(bundle: SyncBundle): Blob
+  /**
+   * Parse a JSON string back into a SyncBundle.
+   * Throws if the text is not valid JSON or if required fields are missing /
+   * have the wrong type.
+   */
+  importFromText(text: string): SyncBundle
+}
+
+export function createManualProvider(): ManualProvider {
+  return {
+    id: 'manual',
+
+    // -----------------------------------------------------------------------
+    // SyncProvider — all no-ops
+    // -----------------------------------------------------------------------
+
+    async push(_bundle: SyncBundle): Promise<void> {
+      // intentional no-op
+    },
+
+    async pull(): Promise<SyncBundle | null> {
+      return null
+    },
+
+    async pushChunks(_chunks: Record<string, Uint8Array>): Promise<void> {
+      // intentional no-op
+    },
+
+    async pullChunks(_hashes: string[]): Promise<Record<string, Uint8Array>> {
+      return {}
+    },
+
+    async listHistory(_limit: number): Promise<SyncSnapshot[]> {
+      return []
+    },
+
+    // -----------------------------------------------------------------------
+    // Manual export / import
+    // -----------------------------------------------------------------------
+
+    exportToBlob(bundle: SyncBundle): Blob {
+      const json = JSON.stringify(bundle, null, 2)
+      return new Blob([json], { type: 'application/json' })
+    },
+
+    importFromText(text: string): SyncBundle {
+      // Will throw a SyntaxError on invalid JSON — let it propagate.
+      const parsed: unknown = JSON.parse(text)
+
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        throw new Error('Invalid SyncBundle: expected a JSON object')
+      }
+
+      const obj = parsed as Record<string, unknown>
+
+      if (typeof obj['version'] !== 'number') {
+        throw new Error('Invalid SyncBundle: "version" must be a number')
+      }
+
+      if (typeof obj['timestamp'] !== 'number') {
+        throw new Error('Invalid SyncBundle: "timestamp" must be a number')
+      }
+
+      if (typeof obj['device'] !== 'string') {
+        throw new Error('Invalid SyncBundle: "device" must be a string')
+      }
+
+      if (typeof obj['collections'] !== 'object' || obj['collections'] === null || Array.isArray(obj['collections'])) {
+        throw new Error('Invalid SyncBundle: "collections" must be an object')
+      }
+
+      return obj as unknown as SyncBundle
+    },
+  }
+}

--- a/spa/src/lib/sync/providers/manual-provider.ts
+++ b/spa/src/lib/sync/providers/manual-provider.ts
@@ -31,7 +31,8 @@ export function createManualProvider(): ManualProvider {
     // SyncProvider — all no-ops
     // -----------------------------------------------------------------------
 
-    async push(_bundle: SyncBundle): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async push(bundle: SyncBundle): Promise<void> {
       // intentional no-op
     },
 
@@ -39,15 +40,18 @@ export function createManualProvider(): ManualProvider {
       return null
     },
 
-    async pushChunks(_chunks: Record<string, Uint8Array>): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async pushChunks(chunks: Record<string, Uint8Array>): Promise<void> {
       // intentional no-op
     },
 
-    async pullChunks(_hashes: string[]): Promise<Record<string, Uint8Array>> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async pullChunks(hashes: string[]): Promise<Record<string, Uint8Array>> {
       return {}
     },
 
-    async listHistory(_limit: number): Promise<SyncSnapshot[]> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async listHistory(limit: number): Promise<SyncSnapshot[]> {
       return []
     },
 

--- a/spa/src/lib/sync/register-sync.ts
+++ b/spa/src/lib/sync/register-sync.ts
@@ -1,0 +1,20 @@
+import { createSyncEngine } from './engine'
+import { createPreferencesContributor } from './contributors/preferences'
+import { createWorkspacesContributor } from './contributors/workspaces'
+import { createHostsContributor } from './contributors/hosts'
+import { createLayoutContributor } from './contributors/layout'
+import { createQuickCommandsContributor } from './contributors/quick-commands'
+import { createI18nContributor } from './contributors/i18n'
+import { createNotificationSettingsContributor } from './contributors/notification-settings'
+
+export const syncEngine = createSyncEngine()
+
+export function registerSyncContributors(): void {
+  syncEngine.register(createPreferencesContributor())
+  syncEngine.register(createWorkspacesContributor())
+  syncEngine.register(createHostsContributor())
+  syncEngine.register(createLayoutContributor())
+  syncEngine.register(createQuickCommandsContributor())
+  syncEngine.register(createI18nContributor())
+  syncEngine.register(createNotificationSettingsContributor())
+}

--- a/spa/src/lib/sync/register-sync.ts
+++ b/spa/src/lib/sync/register-sync.ts
@@ -6,6 +6,7 @@ import { createLayoutContributor } from './contributors/layout'
 import { createQuickCommandsContributor } from './contributors/quick-commands'
 import { createI18nContributor } from './contributors/i18n'
 import { createNotificationSettingsContributor } from './contributors/notification-settings'
+import { setAllContributorIds } from './use-sync-store'
 
 export const syncEngine = createSyncEngine()
 
@@ -17,4 +18,7 @@ export function registerSyncContributors(): void {
   syncEngine.register(createQuickCommandsContributor())
   syncEngine.register(createI18nContributor())
   syncEngine.register(createNotificationSettingsContributor())
+
+  // Populate the default module list so setActiveProvider() can auto-enable all.
+  setAllContributorIds(syncEngine.getContributors().map((c) => c.id))
 }

--- a/spa/src/lib/sync/sync-flow.test.ts
+++ b/spa/src/lib/sync/sync-flow.test.ts
@@ -7,7 +7,7 @@
 // orchestrates: serialize → push → pull → conflict detection → resolve.
 // =============================================================================
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createSyncEngine } from './engine'
 import type { SyncBundle, SyncContributor, FullPayload, MergeStrategy } from './types'
 

--- a/spa/src/lib/sync/sync-flow.test.ts
+++ b/spa/src/lib/sync/sync-flow.test.ts
@@ -1,0 +1,235 @@
+// =============================================================================
+// Sync Architecture — Integration Tests: Full Sync Flow
+// =============================================================================
+//
+// These tests exercise the complete sync cycle using only in-memory mocks —
+// no real stores or providers.  They verify that the SyncEngine correctly
+// orchestrates: serialize → push → pull → conflict detection → resolve.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createSyncEngine } from './engine'
+import type { SyncBundle, SyncContributor, FullPayload, MergeStrategy } from './types'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulates a Zustand store as a simple in-memory object.
+ */
+function createTestContributor(id: string, initialData: Record<string, unknown>) {
+  let data = { ...initialData }
+  const contrib: SyncContributor = {
+    id,
+    strategy: 'full',
+    serialize: () => ({ version: 1, data: { ...data } }),
+    deserialize: (payload: unknown, merge: MergeStrategy) => {
+      const p = (payload as FullPayload).data
+      if (merge.type === 'full-replace') {
+        data = { ...p }
+        return
+      }
+      for (const [field, choice] of Object.entries(merge.resolved)) {
+        if (choice === 'remote' && field in p) data[field] = p[field]
+      }
+    },
+    getVersion: () => 1,
+  }
+  return {
+    contrib,
+    getData: () => ({ ...data }),
+    setData: (d: Record<string, unknown>) => {
+      data = { ...d }
+    },
+  }
+}
+
+/**
+ * In-memory provider simulating daemon canonical bundle.
+ */
+function createInMemoryProvider() {
+  let stored: SyncBundle | null = null
+  return {
+    id: 'memory',
+    push: vi.fn(async (bundle: SyncBundle) => {
+      stored = bundle
+    }),
+    pull: vi.fn(async () => stored),
+    pushChunks: vi.fn(async () => {}),
+    pullChunks: vi.fn(async () => ({})),
+    listHistory: vi.fn(async () => []),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests
+// ---------------------------------------------------------------------------
+
+describe('Sync Flow Integration', () => {
+  // -------------------------------------------------------------------------
+  // Scenario 1: Device A pushes, Device B pulls (first sync — no conflict)
+  // -------------------------------------------------------------------------
+
+  describe('Scenario 1: first sync — full-replace', () => {
+    it('Device B inherits Device A state on first pull (lastSynced=null)', async () => {
+      const provider = createInMemoryProvider()
+
+      // Device A: push its state
+      const engineA = createSyncEngine()
+      const contribA = createTestContributor('prefs', { theme: 'dark', locale: 'en' })
+      engineA.register(contribA.contrib)
+      await engineA.push(provider, 'device-a', ['prefs'])
+
+      expect(provider.push).toHaveBeenCalledOnce()
+
+      // Device B: different local state, but lastSynced is null (first sync)
+      const engineB = createSyncEngine()
+      const contribB = createTestContributor('prefs', { theme: 'light', locale: 'en' })
+      engineB.register(contribB.contrib)
+
+      const result = await engineB.pull(provider, null, ['prefs'])
+
+      expect(result.conflicts).toHaveLength(0)
+      expect(result.appliedBundle).not.toBeNull()
+
+      // B should now have A's state via full-replace
+      expect(contribB.getData()).toEqual({ theme: 'dark', locale: 'en' })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 2: Both devices change different fields — auto-merge
+  // -------------------------------------------------------------------------
+
+  describe('Scenario 2: diverged changes on different fields — auto-merge', () => {
+    it('merges cleanly when A changes theme and B changes locale', async () => {
+      const provider = createInMemoryProvider()
+
+      // Establish common baseline: push lastSynced state
+      const lastSynced: SyncBundle = {
+        version: 1,
+        timestamp: Date.now() - 60_000,
+        device: 'device-a',
+        collections: {
+          prefs: { version: 1, data: { theme: 'light', locale: 'en' } },
+        },
+      }
+      // Seed the provider with the baseline bundle
+      await provider.push(lastSynced)
+
+      // Device A changes theme → 'dark', pushes new state
+      const engineA = createSyncEngine()
+      const contribA = createTestContributor('prefs', { theme: 'dark', locale: 'en' })
+      engineA.register(contribA.contrib)
+      const bundleA = await engineA.push(provider, 'device-a', ['prefs'])
+
+      // Device B has changed locale → 'zh-TW' since lastSynced
+      const engineB = createSyncEngine()
+      const contribB = createTestContributor('prefs', { theme: 'light', locale: 'zh-TW' })
+      engineB.register(contribB.contrib)
+
+      // B pulls using the shared lastSynced bundle as ancestor
+      const result = await engineB.pull(provider, lastSynced, ['prefs'])
+
+      expect(result.conflicts).toHaveLength(0)
+      expect(result.appliedBundle).toBe(bundleA)
+
+      // Both changes preserved: A's theme + B's locale
+      expect(contribB.getData()).toEqual({ theme: 'dark', locale: 'zh-TW' })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 3: Both devices change same field — conflict detected + resolved
+  // -------------------------------------------------------------------------
+
+  describe('Scenario 3: conflicting change on same field — manual resolution', () => {
+    it('detects conflict and applies remote after user resolves with remote', async () => {
+      const provider = createInMemoryProvider()
+
+      const lastSynced: SyncBundle = {
+        version: 1,
+        timestamp: Date.now() - 60_000,
+        device: 'device-a',
+        collections: {
+          prefs: { version: 1, data: { theme: 'light' } },
+        },
+      }
+
+      // Device A changes theme → 'dark', pushes
+      const engineA = createSyncEngine()
+      const contribA = createTestContributor('prefs', { theme: 'dark' })
+      engineA.register(contribA.contrib)
+      const bundleA = await engineA.push(provider, 'device-a', ['prefs'])
+
+      // Device B has independently changed theme → 'solarized'
+      const engineB = createSyncEngine()
+      const contribB = createTestContributor('prefs', { theme: 'solarized' })
+      engineB.register(contribB.contrib)
+
+      const result = await engineB.pull(provider, lastSynced, ['prefs'])
+
+      // Exactly one conflict on 'theme'
+      expect(result.conflicts).toHaveLength(1)
+      const conflict = result.conflicts[0]
+      expect(conflict.contributor).toBe('prefs')
+      expect(conflict.field).toBe('theme')
+      expect(conflict.local).toBe('solarized')
+      expect(conflict.remote.value).toBe('dark')
+      expect(conflict.lastSynced).toBe('light')
+
+      // B resolves by choosing 'remote'
+      engineB.resolveConflicts(bundleA, result.conflicts, { theme: 'remote' })
+
+      // After resolution B should have the remote value
+      expect(contribB.getData()).toEqual({ theme: 'dark' })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Scenario 4: Multiple contributors — independent merge
+  // -------------------------------------------------------------------------
+
+  describe('Scenario 4: multiple contributors — independent auto-merge', () => {
+    it('auto-merges prefs and layout contributors independently without conflicts', async () => {
+      const provider = createInMemoryProvider()
+
+      const lastSynced: SyncBundle = {
+        version: 1,
+        timestamp: Date.now() - 60_000,
+        device: 'device-a',
+        collections: {
+          prefs: { version: 1, data: { theme: 'light' } },
+          layout: { version: 1, data: { sidebar: false } },
+        },
+      }
+
+      // Device A changes prefs.theme → 'dark', layout unchanged
+      const engineA = createSyncEngine()
+      const prefsA = createTestContributor('prefs', { theme: 'dark' })
+      const layoutA = createTestContributor('layout', { sidebar: false })
+      engineA.register(prefsA.contrib)
+      engineA.register(layoutA.contrib)
+      const bundleA = await engineA.push(provider, 'device-a', ['prefs', 'layout'])
+
+      // Device B changes layout.sidebar → true, prefs unchanged
+      const engineB = createSyncEngine()
+      const prefsB = createTestContributor('prefs', { theme: 'light' })
+      const layoutB = createTestContributor('layout', { sidebar: true })
+      engineB.register(prefsB.contrib)
+      engineB.register(layoutB.contrib)
+
+      const result = await engineB.pull(provider, lastSynced, ['prefs', 'layout'])
+
+      // No conflicts — different contributors and different fields
+      expect(result.conflicts).toHaveLength(0)
+      expect(result.appliedBundle).toBe(bundleA)
+
+      // prefs: B gets A's theme change
+      expect(prefsB.getData()).toEqual({ theme: 'dark' })
+      // layout: B keeps its own sidebar change
+      expect(layoutB.getData()).toEqual({ sidebar: true })
+    })
+  })
+})

--- a/spa/src/lib/sync/three-way-merge.test.ts
+++ b/spa/src/lib/sync/three-way-merge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { detectConflict, mergeCollection } from './three-way-merge'
-import type { ConflictResult, MergeCollectionResult } from './three-way-merge'
+// Types ConflictResult, MergeCollectionResult are validated through usage in tests
 
 // =============================================================================
 // detectConflict

--- a/spa/src/lib/sync/three-way-merge.test.ts
+++ b/spa/src/lib/sync/three-way-merge.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest'
+import { detectConflict, mergeCollection } from './three-way-merge'
+import type { ConflictResult, MergeCollectionResult } from './three-way-merge'
+
+// =============================================================================
+// detectConflict
+// =============================================================================
+
+describe('detectConflict', () => {
+  it('returns no-change when all three are equal (primitives)', () => {
+    expect(detectConflict('hello', 'hello', 'hello')).toBe('no-change')
+    expect(detectConflict(42, 42, 42)).toBe('no-change')
+    expect(detectConflict(true, true, true)).toBe('no-change')
+    expect(detectConflict(null, null, null)).toBe('no-change')
+  })
+
+  it('returns use-local when only local changed', () => {
+    expect(detectConflict('old', 'new-local', 'old')).toBe('use-local')
+    expect(detectConflict(1, 2, 1)).toBe('use-local')
+  })
+
+  it('returns use-remote when only remote changed', () => {
+    expect(detectConflict('old', 'old', 'new-remote')).toBe('use-remote')
+    expect(detectConflict(1, 1, 99)).toBe('use-remote')
+  })
+
+  it('returns both-same when both changed to the same value', () => {
+    expect(detectConflict('old', 'new', 'new')).toBe('both-same')
+    expect(detectConflict(0, 5, 5)).toBe('both-same')
+  })
+
+  it('returns conflict when both changed to different values', () => {
+    expect(detectConflict('old', 'local-new', 'remote-new')).toBe('conflict')
+    expect(detectConflict(1, 2, 3)).toBe('conflict')
+  })
+
+  it('handles nested objects with deep equality — no-change', () => {
+    const obj = { a: 1, b: { c: 2 } }
+    expect(detectConflict(obj, { a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe('no-change')
+  })
+
+  it('handles nested objects with deep equality — use-local', () => {
+    const last = { theme: 'dark', locale: 'en' }
+    const local = { theme: 'light', locale: 'en' }
+    const remote = { theme: 'dark', locale: 'en' }
+    expect(detectConflict(last, local, remote)).toBe('use-local')
+  })
+
+  it('handles nested objects with deep equality — conflict', () => {
+    const last = { x: 1 }
+    const local = { x: 2 }
+    const remote = { x: 3 }
+    expect(detectConflict(last, local, remote)).toBe('conflict')
+  })
+
+  it('handles arrays with deep equality — no-change', () => {
+    expect(detectConflict([1, 2, 3], [1, 2, 3], [1, 2, 3])).toBe('no-change')
+  })
+
+  it('handles arrays with deep equality — use-remote', () => {
+    expect(detectConflict([1, 2], [1, 2], [1, 2, 3])).toBe('use-remote')
+  })
+
+  it('handles null values', () => {
+    // last=null, local=null, remote='something' → use-remote
+    expect(detectConflict(null, null, 'something')).toBe('use-remote')
+    // last=null, local='something', remote=null → use-local
+    expect(detectConflict(null, 'something', null)).toBe('use-local')
+    // last='something', both set to null → both-same
+    expect(detectConflict('something', null, null)).toBe('both-same')
+  })
+
+  it('handles undefined values', () => {
+    // all undefined → no-change
+    expect(detectConflict(undefined, undefined, undefined)).toBe('no-change')
+    // last=undefined, only remote provided → use-remote
+    expect(detectConflict(undefined, undefined, 'val')).toBe('use-remote')
+    // last=undefined, both same → both-same
+    expect(detectConflict(undefined, 'val', 'val')).toBe('both-same')
+  })
+})
+
+// =============================================================================
+// mergeCollection
+// =============================================================================
+
+describe('mergeCollection', () => {
+  it('auto-merges non-conflicting fields (A changes theme, B changes locale)', () => {
+    const last = { theme: 'dark', locale: 'en' }
+    const local = { theme: 'light', locale: 'en' }   // A changed theme
+    const remote = { theme: 'dark', locale: 'zh-TW' } // B changed locale
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(0)
+    expect(result.merged).toEqual({ theme: 'light', locale: 'zh-TW' })
+  })
+
+  it('collects conflicts for double-changed fields', () => {
+    const last = { theme: 'dark', locale: 'en' }
+    const local = { theme: 'light', locale: 'zh-TW' }  // changed both
+    const remote = { theme: 'solarized', locale: 'ja' } // changed both differently
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(2)
+
+    const themeConflict = result.conflicts.find(c => c.field === 'theme')
+    expect(themeConflict).toBeDefined()
+    expect(themeConflict!.contributor).toBe('')
+    expect(themeConflict!.lastSynced).toBe('dark')
+    expect(themeConflict!.local).toBe('light')
+    expect(themeConflict!.remote.value).toBe('solarized')
+    expect(themeConflict!.remote.device).toBe('device-B')
+
+    // merged keeps local as placeholder
+    expect(result.merged.theme).toBe('light')
+    expect(result.merged.locale).toBe('zh-TW')
+  })
+
+  it('new keys added only on local side win without conflict', () => {
+    const last = { a: 1 }
+    const local = { a: 1, b: 2 }  // added 'b'
+    const remote = { a: 1 }
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(0)
+    expect(result.merged).toEqual({ a: 1, b: 2 })
+  })
+
+  it('new keys added only on remote side win without conflict', () => {
+    const last = { a: 1 }
+    const local = { a: 1 }
+    const remote = { a: 1, c: 3 }  // added 'c'
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(0)
+    expect(result.merged).toEqual({ a: 1, c: 3 })
+  })
+
+  it('new keys added on both sides with same value → both-same, use local', () => {
+    const last = { a: 1 }
+    const local = { a: 1, newKey: 'same' }
+    const remote = { a: 1, newKey: 'same' }
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(0)
+    expect(result.merged.newKey).toBe('same')
+  })
+
+  it('new keys added on both sides with different values → conflict', () => {
+    const last = { a: 1 }
+    const local = { a: 1, newKey: 'local-val' }
+    const remote = { a: 1, newKey: 'remote-val' }
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(1)
+    expect(result.conflicts[0].field).toBe('newKey')
+    // merged keeps local as placeholder
+    expect(result.merged.newKey).toBe('local-val')
+  })
+
+  it('key deleted locally but unchanged remotely → deletion respected', () => {
+    const last = { a: 1, b: 2 }
+    const local = { a: 1 }          // deleted 'b' locally
+    const remote = { a: 1, b: 2 }   // remote unchanged
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(0)
+    expect('b' in result.merged).toBe(false)
+    expect(result.merged).toEqual({ a: 1 })
+  })
+
+  it('key deleted remotely but unchanged locally → deletion respected', () => {
+    const last = { a: 1, b: 2 }
+    const local = { a: 1, b: 2 }    // local unchanged
+    const remote = { a: 1 }          // deleted 'b' remotely
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(0)
+    expect('b' in result.merged).toBe(false)
+    expect(result.merged).toEqual({ a: 1 })
+  })
+
+  it('null last (first sync) → full-replace from remote, no conflicts', () => {
+    const remote = { theme: 'light', locale: 'en', extra: 42 }
+    const local = { theme: 'dark', locale: 'zh-TW' }
+
+    const result = mergeCollection(null, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(0)
+    expect(result.merged).toEqual(remote)
+  })
+
+  it('both-same field: uses local value, no conflict', () => {
+    const last = { x: 1 }
+    const local = { x: 99 }
+    const remote = { x: 99 }  // both changed to same
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(0)
+    expect(result.merged.x).toBe(99)
+  })
+
+  it('unchanged field: keeps local value, no conflict', () => {
+    const last = { x: 42 }
+    const local = { x: 42 }
+    const remote = { x: 42 }
+
+    const result = mergeCollection(last, local, remote, 'device-B')
+    expect(result.conflicts).toHaveLength(0)
+    expect(result.merged.x).toBe(42)
+  })
+})

--- a/spa/src/lib/sync/three-way-merge.ts
+++ b/spa/src/lib/sync/three-way-merge.ts
@@ -1,0 +1,193 @@
+// =============================================================================
+// Sync Architecture — Three-Way Merge
+// =============================================================================
+
+import type { ConflictItem } from './types'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a three-way conflict detection on a single field.
+ *
+ * - `no-change`  — all three values are equal; nothing to do.
+ * - `use-local`  — only the local side changed; keep local.
+ * - `use-remote` — only the remote side changed; adopt remote.
+ * - `both-same`  — both sides changed to the same value; no conflict.
+ * - `conflict`   — both sides changed to different values; needs resolution.
+ */
+export type ConflictResult =
+  | 'no-change'
+  | 'use-local'
+  | 'use-remote'
+  | 'both-same'
+  | 'conflict'
+
+/** Output of mergeCollection. */
+export interface MergeCollectionResult {
+  /** The merged data object. Conflict fields retain the local value as a placeholder. */
+  merged: Record<string, unknown>
+  /** Fields that could not be auto-resolved. Caller must fill in `contributor`. */
+  conflicts: ConflictItem[]
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Deep equality for JSON-serializable values (primitives, null, plain objects,
+ * arrays). Does not handle Date, Set, Map, or functions.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+
+  // Handle null explicitly (typeof null === 'object')
+  if (a === null || b === null) return false
+  if (a === undefined || b === undefined) return false
+
+  if (typeof a !== typeof b) return false
+  if (typeof a !== 'object') return false
+
+  // Both are non-null objects at this point
+  if (Array.isArray(a) !== Array.isArray(b)) return false
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false
+    }
+    return true
+  }
+
+  // Plain objects
+  const aObj = a as Record<string, unknown>
+  const bObj = b as Record<string, unknown>
+  const aKeys = Object.keys(aObj)
+  const bKeys = Object.keys(bObj)
+
+  if (aKeys.length !== bKeys.length) return false
+
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bObj, key)) return false
+    if (!deepEqual(aObj[key], bObj[key])) return false
+  }
+
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Three-way conflict detection for a single field.
+ *
+ * @param last   The value at the time of the last successful sync (ancestor).
+ * @param local  The current local value.
+ * @param remote The value from the remote peer.
+ */
+export function detectConflict(
+  last: unknown,
+  local: unknown,
+  remote: unknown,
+): ConflictResult {
+  const localChanged = !deepEqual(last, local)
+  const remoteChanged = !deepEqual(last, remote)
+
+  if (!localChanged && !remoteChanged) return 'no-change'
+  if (localChanged && !remoteChanged) return 'use-local'
+  if (!localChanged && remoteChanged) return 'use-remote'
+
+  // Both changed — check if they converged on the same value
+  if (deepEqual(local, remote)) return 'both-same'
+
+  return 'conflict'
+}
+
+/**
+ * Merge two flat data objects using three-way comparison against their common
+ * ancestor (`last`).
+ *
+ * When `last` is `null` this is the first sync: fully replace with the remote
+ * state and produce no conflicts.
+ *
+ * @param last         Common ancestor record, or `null` for a first-time sync.
+ * @param local        Current local record.
+ * @param remote       Incoming remote record.
+ * @param remoteDevice Device identifier of the remote peer (stored in conflicts).
+ */
+export function mergeCollection(
+  last: Record<string, unknown> | null,
+  local: Record<string, unknown>,
+  remote: Record<string, unknown>,
+  remoteDevice: string,
+): MergeCollectionResult {
+  // First sync: full-replace from remote, no conflicts
+  if (last === null) {
+    return { merged: { ...remote }, conflicts: [] }
+  }
+
+  const merged: Record<string, unknown> = {}
+  const conflicts: ConflictItem[] = []
+
+  // Collect the union of all keys across all three objects
+  const allKeys = new Set([
+    ...Object.keys(last),
+    ...Object.keys(local),
+    ...Object.keys(remote),
+  ])
+
+  for (const key of allKeys) {
+    const lastVal = Object.prototype.hasOwnProperty.call(last, key) ? last[key] : undefined
+    const localVal = Object.prototype.hasOwnProperty.call(local, key) ? local[key] : undefined
+    const remoteVal = Object.prototype.hasOwnProperty.call(remote, key) ? remote[key] : undefined
+
+    const resolution = detectConflict(lastVal, localVal, remoteVal)
+
+    switch (resolution) {
+      case 'no-change':
+      case 'both-same':
+        // Use local (identical to remote for both-same)
+        if (localVal !== undefined) {
+          merged[key] = localVal
+        }
+        // If both are undefined (key removed from both), omit from merged
+        break
+
+      case 'use-local':
+        // Local changed; if local deleted the key, omit it
+        if (localVal !== undefined) {
+          merged[key] = localVal
+        }
+        break
+
+      case 'use-remote':
+        // Remote changed; if remote deleted the key, omit it
+        if (remoteVal !== undefined) {
+          merged[key] = remoteVal
+        }
+        break
+
+      case 'conflict':
+        // Keep local as placeholder; record conflict for UI resolution
+        if (localVal !== undefined) {
+          merged[key] = localVal
+        }
+        conflicts.push({
+          contributor: '', // caller fills this in
+          field: key,
+          lastSynced: lastVal,
+          local: localVal,
+          remote: {
+            value: remoteVal,
+            device: remoteDevice,
+          },
+        })
+        break
+    }
+  }
+
+  return { merged, conflicts }
+}

--- a/spa/src/lib/sync/types.test.ts
+++ b/spa/src/lib/sync/types.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'vitest'
+// Runtime import to ensure the module actually exists and exports its symbols.
+// The * import will fail at runtime if ./types does not resolve.
+import * as SyncTypes from './types'
+import type {
+  FullPayload,
+  ChunkedManifestEntry,
+  ChunkedPayload,
+  SyncBundle,
+  SyncContributor,
+  MergeStrategy,
+  ResolvedFields,
+  ConflictItem,
+  SyncProvider,
+  SyncState,
+  SyncSnapshot,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// Type-level compile guards
+// These assignments confirm that the interfaces are structurally correct.
+// If any required field is missing the TypeScript compiler (via Vitest) will
+// report an error and the test suite will fail.
+// ---------------------------------------------------------------------------
+
+describe('FullPayload', () => {
+  it('has required fields: version and data', () => {
+    const payload: FullPayload = {
+      version: 1,
+      data: { key: 'value' },
+    }
+    expect(payload.version).toBe(1)
+    expect(payload.data).toEqual({ key: 'value' })
+  })
+
+  it('data is Record<string, unknown>', () => {
+    const payload: FullPayload = {
+      version: 2,
+      data: { num: 42, nested: { a: true }, arr: [1, 2, 3] },
+    }
+    expect(typeof payload.data['num']).toBe('number')
+    expect(payload.data['nested']).toBeDefined()
+  })
+})
+
+describe('ChunkedManifestEntry', () => {
+  it('has id and hash fields', () => {
+    const entry: ChunkedManifestEntry = { id: 'chunk-0', hash: 'abc123' }
+    expect(entry.id).toBe('chunk-0')
+    expect(entry.hash).toBe('abc123')
+  })
+})
+
+describe('ChunkedPayload', () => {
+  it('has version, manifest and chunks', () => {
+    const payload: ChunkedPayload = {
+      version: 1,
+      manifest: [{ id: 'chunk-0', hash: 'abc123' }],
+      chunks: { abc123: new Uint8Array([1, 2, 3]) },
+    }
+    expect(payload.version).toBe(1)
+    expect(payload.manifest).toHaveLength(1)
+    expect(payload.chunks['abc123']).toBeInstanceOf(Uint8Array)
+  })
+
+  it('chunks is keyed by hash string', () => {
+    const buf = new Uint8Array([10, 20])
+    const payload: ChunkedPayload = {
+      version: 3,
+      manifest: [],
+      chunks: { deadbeef: buf },
+    }
+    expect(payload.chunks['deadbeef']).toBe(buf)
+  })
+})
+
+describe('SyncBundle', () => {
+  it('has required fields: version, timestamp, device, collections', () => {
+    const bundle: SyncBundle = {
+      version: 1,
+      timestamp: Date.now(),
+      device: 'mlab',
+      collections: {},
+    }
+    expect(bundle.version).toBe(1)
+    expect(typeof bundle.timestamp).toBe('number')
+    expect(bundle.device).toBe('mlab')
+    expect(bundle.collections).toBeDefined()
+  })
+
+  it('collections maps contributor id to FullPayload', () => {
+    const bundle: SyncBundle = {
+      version: 1,
+      timestamp: 1000,
+      device: 'air',
+      collections: {
+        prefs: { version: 1, data: { theme: 'dark' } },
+      },
+    }
+    const prefs = bundle.collections['prefs'] as FullPayload
+    expect(prefs.data['theme']).toBe('dark')
+  })
+
+  it('collections maps contributor id to ChunkedPayload', () => {
+    const bundle: SyncBundle = {
+      version: 1,
+      timestamp: 1000,
+      device: 'air',
+      collections: {
+        editor: {
+          version: 1,
+          manifest: [{ id: 'c0', hash: 'ff00' }],
+          chunks: { ff00: new Uint8Array([0xff]) },
+        },
+      },
+    }
+    const editor = bundle.collections['editor'] as ChunkedPayload
+    expect(editor.manifest[0]?.hash).toBe('ff00')
+  })
+})
+
+describe('MergeStrategy', () => {
+  it('type full-replace is valid', () => {
+    const s: MergeStrategy = { type: 'full-replace' }
+    expect(s.type).toBe('full-replace')
+  })
+
+  it('type field-merge carries ResolvedFields', () => {
+    const resolved: ResolvedFields = { theme: 'remote', fontSize: 'local' }
+    const s: MergeStrategy = { type: 'field-merge', resolved }
+    expect(s.type).toBe('field-merge')
+    if (s.type === 'field-merge') {
+      expect(s.resolved['theme']).toBe('remote')
+      expect(s.resolved['fontSize']).toBe('local')
+    }
+  })
+})
+
+describe('ResolvedFields', () => {
+  it('maps field names to local or remote', () => {
+    const r: ResolvedFields = { a: 'local', b: 'remote' }
+    expect(r['a']).toBe('local')
+    expect(r['b']).toBe('remote')
+  })
+})
+
+describe('ConflictItem', () => {
+  it('captures three-way values: lastSynced, local, remote', () => {
+    const conflict: ConflictItem = {
+      contributor: 'prefs',
+      field: 'theme',
+      lastSynced: 'light',
+      local: 'dark',
+      remote: { value: 'system', device: 'air' },
+    }
+    expect(conflict.contributor).toBe('prefs')
+    expect(conflict.field).toBe('theme')
+    expect(conflict.lastSynced).toBe('light')
+    expect(conflict.local).toBe('dark')
+    expect(conflict.remote.value).toBe('system')
+    expect(conflict.remote.device).toBe('air')
+  })
+
+  it('values are typed as unknown (accepts any)', () => {
+    const conflict: ConflictItem = {
+      contributor: 'state',
+      field: 'count',
+      lastSynced: 0,
+      local: 42,
+      remote: { value: { nested: true }, device: 'mlab' },
+    }
+    expect(conflict.local).toBe(42)
+    expect(conflict.remote.value).toEqual({ nested: true })
+  })
+})
+
+describe('SyncState', () => {
+  it('has nullable fields that default to null', () => {
+    const state: SyncState = {
+      lastSyncedBundle: null,
+      lastSyncedAt: null,
+      activeProviderId: null,
+      enabledModules: [],
+    }
+    expect(state.lastSyncedBundle).toBeNull()
+    expect(state.lastSyncedAt).toBeNull()
+    expect(state.activeProviderId).toBeNull()
+    expect(state.enabledModules).toHaveLength(0)
+  })
+
+  it('holds a bundle when synced', () => {
+    const bundle: SyncBundle = {
+      version: 1,
+      timestamp: 9999,
+      device: 'mlab',
+      collections: {},
+    }
+    const state: SyncState = {
+      lastSyncedBundle: bundle,
+      lastSyncedAt: 9999,
+      activeProviderId: 'manual',
+      enabledModules: ['prefs', 'editor'],
+    }
+    expect(state.lastSyncedBundle).toBe(bundle)
+    expect(state.enabledModules).toContain('prefs')
+  })
+})
+
+describe('SyncSnapshot', () => {
+  it('has required fields including source and bundleRef', () => {
+    const snap: SyncSnapshot = {
+      id: 'snap-1',
+      timestamp: 1000,
+      device: 'mlab',
+      source: 'local',
+      trigger: 'manual',
+      bundleRef: 'bundle-abc',
+    }
+    expect(snap.source).toBe('local')
+    expect(snap.bundleRef).toBe('bundle-abc')
+  })
+
+  it('source can be remote', () => {
+    const snap: SyncSnapshot = {
+      id: 'snap-2',
+      timestamp: 2000,
+      device: 'air',
+      source: 'remote',
+      trigger: 'auto',
+      bundleRef: 'bundle-xyz',
+    }
+    expect(snap.source).toBe('remote')
+    expect(snap.trigger).toBe('auto')
+  })
+})
+
+describe('SyncContributor interface shape', () => {
+  it('can be implemented with required methods', () => {
+    const contributor: SyncContributor = {
+      id: 'prefs',
+      strategy: 'full',
+      serialize(): FullPayload {
+        return { version: 1, data: {} }
+      },
+      deserialize(): void {},
+      getVersion(): number {
+        return 1
+      },
+    }
+    expect(contributor.id).toBe('prefs')
+    expect(contributor.strategy).toBe('full')
+    expect(contributor.getVersion()).toBe(1)
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.version).toBe(1)
+  })
+
+  it('migrate is optional', () => {
+    const withMigrate: SyncContributor = {
+      id: 'editor',
+      strategy: 'content-addressed',
+      serialize(): ChunkedPayload {
+        return { version: 2, manifest: [], chunks: {} }
+      },
+      deserialize(): void {},
+      getVersion(): number {
+        return 2
+      },
+      migrate(payload: unknown): unknown {
+        return payload
+      },
+    }
+    expect(withMigrate.migrate).toBeDefined()
+  })
+})
+
+describe('module exports', () => {
+  it('types module is importable (runtime smoke test)', () => {
+    // If ./types does not exist this import * will throw at module load time
+    // and every test in this file will fail.  This assertion confirms the
+    // module resolved successfully.
+    expect(SyncTypes).toBeDefined()
+  })
+})
+
+describe('SyncProvider interface shape', () => {
+  it('has required async methods', async () => {
+    const bundle: SyncBundle = {
+      version: 1,
+      timestamp: 0,
+      device: 'test',
+      collections: {},
+    }
+    const provider: SyncProvider = {
+      id: 'test-provider',
+      async push(): Promise<void> {},
+      async pull(): Promise<SyncBundle | null> {
+        return bundle
+      },
+      async pushChunks(): Promise<void> {},
+      async pullChunks(): Promise<Record<string, Uint8Array>> {
+        return {}
+      },
+      async listHistory(): Promise<SyncSnapshot[]> {
+        return []
+      },
+    }
+    expect(provider.id).toBe('test-provider')
+    const result = await provider.pull()
+    expect(result).toBe(bundle)
+    const history = await provider.listHistory(10)
+    expect(history).toHaveLength(0)
+  })
+})

--- a/spa/src/lib/sync/types.ts
+++ b/spa/src/lib/sync/types.ts
@@ -1,0 +1,172 @@
+// =============================================================================
+// Sync Architecture — Core Types
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// Payloads
+// ---------------------------------------------------------------------------
+
+/** Full-serialisation payload: the contributor sends its entire state. */
+export interface FullPayload {
+  version: number
+  data: Record<string, unknown>
+}
+
+/** One entry in a chunked manifest: maps a logical id to its content hash. */
+export interface ChunkedManifestEntry {
+  id: string
+  hash: string
+}
+
+/**
+ * Content-addressed payload: large blobs are split into chunks identified by
+ * their hash so unchanged chunks can be skipped during transfer.
+ */
+export interface ChunkedPayload {
+  version: number
+  manifest: ChunkedManifestEntry[]
+  chunks: Record<string, Uint8Array>
+}
+
+// ---------------------------------------------------------------------------
+// SyncBundle
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level envelope exchanged between devices.  Collections maps each
+ * contributor id to its serialised payload (full or chunked).
+ */
+export interface SyncBundle {
+  version: number
+  timestamp: number
+  device: string
+  collections: Record<string, FullPayload | ChunkedPayload>
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+/** Per-field resolution choices when a field-merge strategy is used. */
+export interface ResolvedFields {
+  [field: string]: 'local' | 'remote'
+}
+
+/**
+ * Describes how incoming remote data should be merged with local state.
+ * - `full-replace`: overwrite local state entirely with the remote payload.
+ * - `field-merge`: apply per-field decisions captured in `resolved`.
+ */
+export type MergeStrategy =
+  | { type: 'full-replace' }
+  | { type: 'field-merge'; resolved: ResolvedFields }
+
+/**
+ * A single conflict that could not be resolved automatically.
+ * Captures the three-way state required to present a conflict-resolution UI.
+ */
+export interface ConflictItem {
+  /** Contributor id that owns this field. */
+  contributor: string
+  /** Name of the conflicting field. */
+  field: string
+  /** Value at the time of the last successful sync (common ancestor). */
+  lastSynced: unknown
+  /** Current local value. */
+  local: unknown
+  /** Remote value and the device it originated from. */
+  remote: {
+    value: unknown
+    device: string
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SyncContributor
+// ---------------------------------------------------------------------------
+
+/**
+ * A store or module that participates in synchronisation.
+ *
+ * Contributors are registered with the SyncEngine and are responsible for
+ * serialising/deserialising their own state.  The engine orchestrates when
+ * these methods are called.
+ */
+export interface SyncContributor {
+  /** Unique identifier — used as the collection key in SyncBundle. */
+  id: string
+  /** Serialisation strategy this contributor uses. */
+  strategy: 'full' | 'content-addressed'
+  /** Produce a payload representing the current local state. */
+  serialize(): FullPayload | ChunkedPayload
+  /**
+   * Apply an incoming payload to local state.
+   * @param payload  Raw payload received from the bundle (typed as `unknown`
+   *                 so the contributor can validate before applying).
+   * @param merge    How conflicts should be resolved.
+   */
+  deserialize(payload: unknown, merge: MergeStrategy): void
+  /** Return the current schema version of this contributor's data. */
+  getVersion(): number
+  /**
+   * Optional: migrate a payload from an older schema version.
+   * If omitted the engine will pass the payload to `deserialize` as-is.
+   */
+  migrate?(payload: unknown, fromVersion: number): unknown
+}
+
+// ---------------------------------------------------------------------------
+// SyncProvider
+// ---------------------------------------------------------------------------
+
+/** A snapshot entry returned by listHistory. */
+export interface SyncSnapshot {
+  id: string
+  timestamp: number
+  device: string
+  /** Whether this snapshot was created locally or pulled from a remote. */
+  source: 'local' | 'remote'
+  /** What triggered the sync operation that produced this snapshot. */
+  trigger: 'auto' | 'manual'
+  /** Opaque reference to the stored bundle (path, key, URL, …). */
+  bundleRef: string
+}
+
+/**
+ * Abstraction over the transport/storage layer that actually moves
+ * SyncBundles between devices.
+ *
+ * Implementations may use the file system, a local daemon, a remote API, etc.
+ */
+export interface SyncProvider {
+  /** Unique identifier for this provider instance. */
+  id: string
+  /** Upload a full bundle. */
+  push(bundle: SyncBundle): Promise<void>
+  /** Download the most-recent bundle, or `null` if none exists yet. */
+  pull(): Promise<SyncBundle | null>
+  /** Upload raw content-addressed chunks (keyed by hash). */
+  pushChunks(chunks: Record<string, Uint8Array>): Promise<void>
+  /** Download only the chunks whose hashes are listed. */
+  pullChunks(hashes: string[]): Promise<Record<string, Uint8Array>>
+  /** Return up to `limit` historical snapshot entries, newest first. */
+  listHistory(limit: number): Promise<SyncSnapshot[]>
+}
+
+// ---------------------------------------------------------------------------
+// SyncState
+// ---------------------------------------------------------------------------
+
+/**
+ * Persisted runtime state for the sync subsystem, held in the SyncState store.
+ */
+export interface SyncState {
+  /** The bundle from the last successful sync, or `null` before first sync. */
+  lastSyncedBundle: SyncBundle | null
+  /** Unix-ms timestamp of the last successful sync, or `null`. */
+  lastSyncedAt: number | null
+  /** Id of the currently configured provider, or `null` if none. */
+  activeProviderId: string | null
+  /** Ids of contributor modules that have opted in to sync. */
+  enabledModules: string[]
+}

--- a/spa/src/lib/sync/use-sync-store.test.ts
+++ b/spa/src/lib/sync/use-sync-store.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useSyncStore } from './use-sync-store'
+import type { SyncBundle } from './types'
+
+const mockBundle: SyncBundle = {
+  version: 1,
+  timestamp: 1000,
+  device: 'test-device',
+  collections: {},
+}
+
+describe('useSyncStore', () => {
+  beforeEach(() => {
+    useSyncStore.getState().reset()
+  })
+
+  it('starts with null state', () => {
+    const state = useSyncStore.getState()
+    expect(state.lastSyncedBundle).toBeNull()
+    expect(state.lastSyncedAt).toBeNull()
+    expect(state.activeProviderId).toBeNull()
+    expect(state.enabledModules).toEqual([])
+    expect(state.clientId).toBeNull()
+  })
+
+  it('setActiveProvider updates activeProviderId', () => {
+    useSyncStore.getState().setActiveProvider('my-provider')
+    expect(useSyncStore.getState().activeProviderId).toBe('my-provider')
+  })
+
+  it('setActiveProvider resets lastSyncedBundle and lastSyncedAt to null', () => {
+    // First set a bundle
+    useSyncStore.getState().setLastSyncedBundle(mockBundle)
+    expect(useSyncStore.getState().lastSyncedBundle).not.toBeNull()
+    expect(useSyncStore.getState().lastSyncedAt).not.toBeNull()
+
+    // Then switch provider — should reset bundle and timestamp
+    useSyncStore.getState().setActiveProvider('new-provider')
+    expect(useSyncStore.getState().lastSyncedBundle).toBeNull()
+    expect(useSyncStore.getState().lastSyncedAt).toBeNull()
+  })
+
+  it('setActiveProvider accepts null', () => {
+    useSyncStore.getState().setActiveProvider('my-provider')
+    useSyncStore.getState().setActiveProvider(null)
+    expect(useSyncStore.getState().activeProviderId).toBeNull()
+  })
+
+  it('toggleModule adds module ID if not present', () => {
+    useSyncStore.getState().toggleModule('mod-a')
+    expect(useSyncStore.getState().enabledModules).toContain('mod-a')
+  })
+
+  it('toggleModule removes module ID if already present', () => {
+    useSyncStore.getState().toggleModule('mod-a')
+    useSyncStore.getState().toggleModule('mod-a')
+    expect(useSyncStore.getState().enabledModules).not.toContain('mod-a')
+  })
+
+  it('toggleModule manages multiple modules independently', () => {
+    useSyncStore.getState().toggleModule('mod-a')
+    useSyncStore.getState().toggleModule('mod-b')
+    useSyncStore.getState().toggleModule('mod-a')
+    const modules = useSyncStore.getState().enabledModules
+    expect(modules).not.toContain('mod-a')
+    expect(modules).toContain('mod-b')
+  })
+
+  it('setLastSyncedBundle updates bundle and timestamp', () => {
+    const before = Date.now()
+    useSyncStore.getState().setLastSyncedBundle(mockBundle)
+    const after = Date.now()
+
+    const state = useSyncStore.getState()
+    expect(state.lastSyncedBundle).toEqual(mockBundle)
+    expect(state.lastSyncedAt).toBeGreaterThanOrEqual(before)
+    expect(state.lastSyncedAt).toBeLessThanOrEqual(after)
+  })
+
+  it('getClientId returns stable ID on second call', () => {
+    const id1 = useSyncStore.getState().getClientId()
+    const id2 = useSyncStore.getState().getClientId()
+    expect(id1).toBe(id2)
+  })
+
+  it('getClientId matches pattern /^c_[a-z0-9]+$/', () => {
+    const id = useSyncStore.getState().getClientId()
+    expect(id).toMatch(/^c_[a-z0-9]+$/)
+  })
+
+  it('getClientId persists into clientId state field', () => {
+    const id = useSyncStore.getState().getClientId()
+    expect(useSyncStore.getState().clientId).toBe(id)
+  })
+
+  it('reset clears all state back to initial values', () => {
+    useSyncStore.getState().setLastSyncedBundle(mockBundle)
+    useSyncStore.getState().setActiveProvider('some-provider')
+    useSyncStore.getState().toggleModule('mod-x')
+    useSyncStore.getState().getClientId()
+
+    useSyncStore.getState().reset()
+
+    const state = useSyncStore.getState()
+    expect(state.lastSyncedBundle).toBeNull()
+    expect(state.lastSyncedAt).toBeNull()
+    expect(state.activeProviderId).toBeNull()
+    expect(state.enabledModules).toEqual([])
+    expect(state.clientId).toBeNull()
+  })
+})

--- a/spa/src/lib/sync/use-sync-store.ts
+++ b/spa/src/lib/sync/use-sync-store.ts
@@ -1,0 +1,107 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { purdexStorage, STORAGE_KEYS, syncManager } from '../storage'
+import type { SyncBundle } from './types'
+
+// ---------------------------------------------------------------------------
+// State shape
+// ---------------------------------------------------------------------------
+
+interface SyncStoreState {
+  // Persisted state
+  lastSyncedBundle: SyncBundle | null
+  lastSyncedAt: number | null
+  activeProviderId: string | null
+  enabledModules: string[]
+  clientId: string | null
+
+  // Actions
+  setLastSyncedBundle: (bundle: SyncBundle) => void
+  setActiveProvider: (providerId: string | null) => void
+  toggleModule: (moduleId: string) => void
+  getClientId: () => string
+  reset: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Initial state (extracted so reset() can reference it)
+// ---------------------------------------------------------------------------
+
+const initialState = {
+  lastSyncedBundle: null,
+  lastSyncedAt: null,
+  activeProviderId: null,
+  enabledModules: [] as string[],
+  clientId: null,
+} satisfies Pick<
+  SyncStoreState,
+  'lastSyncedBundle' | 'lastSyncedAt' | 'activeProviderId' | 'enabledModules' | 'clientId'
+>
+
+// ---------------------------------------------------------------------------
+// Client ID generation
+// Stable identifier for this browser/device: "c_" + 12 lowercase hex chars
+// ---------------------------------------------------------------------------
+
+function generateClientId(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(6))
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+  return `c_${hex}`
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useSyncStore = create<SyncStoreState>()(
+  persist(
+    (set, get) => ({
+      ...initialState,
+
+      setLastSyncedBundle: (bundle) =>
+        set({ lastSyncedBundle: bundle, lastSyncedAt: Date.now() }),
+
+      setActiveProvider: (providerId) =>
+        set({
+          activeProviderId: providerId,
+          lastSyncedBundle: null,
+          lastSyncedAt: null,
+        }),
+
+      toggleModule: (moduleId) =>
+        set((state) => {
+          const present = state.enabledModules.includes(moduleId)
+          return {
+            enabledModules: present
+              ? state.enabledModules.filter((id) => id !== moduleId)
+              : [...state.enabledModules, moduleId],
+          }
+        }),
+
+      getClientId: () => {
+        const existing = get().clientId
+        if (existing) return existing
+        const id = generateClientId()
+        set({ clientId: id })
+        return id
+      },
+
+      reset: () => set({ ...initialState }),
+    }),
+    {
+      name: STORAGE_KEYS.SYNC_STATE,
+      storage: purdexStorage,
+      partialize: (state) => ({
+        lastSyncedBundle: state.lastSyncedBundle,
+        lastSyncedAt: state.lastSyncedAt,
+        activeProviderId: state.activeProviderId,
+        enabledModules: state.enabledModules,
+        clientId: state.clientId,
+      }),
+    },
+  ),
+)
+
+syncManager.register(STORAGE_KEYS.SYNC_STATE, useSyncStore)

--- a/spa/src/lib/sync/use-sync-store.ts
+++ b/spa/src/lib/sync/use-sync-store.ts
@@ -3,6 +3,17 @@ import { persist } from 'zustand/middleware'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../storage'
 import type { SyncBundle } from './types'
 
+/**
+ * Registry of all known contributor IDs. Populated by registerSyncContributors()
+ * at startup, before any UI interaction triggers setActiveProvider().
+ */
+let _allContributorIds: string[] = []
+
+/** Called by register-sync.ts after all contributors are registered. */
+export function setAllContributorIds(ids: string[]): void {
+  _allContributorIds = ids
+}
+
 // ---------------------------------------------------------------------------
 // State shape
 // ---------------------------------------------------------------------------
@@ -64,10 +75,19 @@ export const useSyncStore = create<SyncStoreState>()(
         set({ lastSyncedBundle: bundle, lastSyncedAt: Date.now() }),
 
       setActiveProvider: (providerId) =>
-        set({
-          activeProviderId: providerId,
-          lastSyncedBundle: null,
-          lastSyncedAt: null,
+        set((state) => {
+          // When enabling a provider for the first time (empty modules list),
+          // auto-enable all registered contributors so sync works out of the box.
+          const modules =
+            state.enabledModules.length === 0 && providerId != null
+              ? [..._allContributorIds]
+              : state.enabledModules
+          return {
+            activeProviderId: providerId,
+            enabledModules: modules,
+            lastSyncedBundle: null,
+            lastSyncedAt: null,
+          }
         }),
 
       toggleModule: (moduleId) =>


### PR DESCRIPTION
## Summary

- SyncEngine (SPA) — pluggable module contributor registry, SyncBundle serialize/deserialize, three-way merge conflict detection
- 7 SyncContributors — workspaces, hosts (strips auth token), preferences, layout, quick-commands, i18n, notification-settings
- 3 SyncProviders — Manual (export/import), Daemon (REST push/pull via Go module), File (iCloud/Syncthing folder)
- Go Daemon sync module — SQLite storage (groups, canonical bundle, history, pairing codes), 9 HTTP endpoints
- Sync Settings UI — provider selector, module checkboxes, export/import, sync status
- 182 SPA tests + 5 Go tests, zero regressions on full suite (1626 tests)

## Spec

`docs/superpowers/specs/2026-04-16-sync-architecture-design.md`

## Test plan

- [ ] `cd spa && npx vitest run src/lib/sync/` — 15 files, 182 tests
- [ ] `cd spa && npx vitest run` — full suite, 1626 tests, no regressions
- [ ] `go test ./internal/module/sync/ -v` — 5 tests
- [ ] `go build ./cmd/pdx/` — compiles
- [ ] `cd spa && pnpm run lint` — no new sync errors
- [ ] Manual: Settings → Sync section renders, Export downloads `.purdex-sync` file