### PR TITLE
feat(sync): wire Sync Now + Import apply

### DIFF
--- a/spa/src/components/settings/SyncSection.tsx
+++ b/spa/src/components/settings/SyncSection.tsx
@@ -1,10 +1,20 @@
-import { useRef } from 'react'
-import { ArrowsClockwise, DownloadSimple, Upload } from '@phosphor-icons/react'
+import { useRef, useState } from 'react'
+import {
+  ArrowsClockwise,
+  CheckCircle,
+  DownloadSimple,
+  Upload,
+  Warning,
+  WarningCircle,
+} from '@phosphor-icons/react'
 import { SettingItem } from './SettingItem'
 import { SegmentControl } from './SegmentControl'
 import { useSyncStore } from '../../lib/sync/use-sync-store'
 import { syncEngine } from '../../lib/sync/register-sync'
 import { createManualProvider } from '../../lib/sync/providers/manual-provider'
+import { createDaemonProvider } from '../../lib/sync/providers/daemon-provider'
+import { applyImport, syncNow, type SyncActionResult } from '../../lib/sync/sync-actions'
+import { useHostStore } from '../../stores/useHostStore'
 
 // ---------------------------------------------------------------------------
 // Provider selector type
@@ -17,6 +27,19 @@ const PROVIDER_OPTIONS: { value: ProviderId; label: string }[] = [
   { value: 'daemon', label: 'Daemon' },
   { value: 'file', label: 'File' },
 ]
+
+// ---------------------------------------------------------------------------
+// Status shape (ephemeral, UI-only)
+// ---------------------------------------------------------------------------
+
+type StatusTone = 'idle' | 'busy' | 'success' | 'warn' | 'error'
+
+interface Status {
+  tone: StatusTone
+  message: string
+}
+
+const IDLE: Status = { tone: 'idle', message: '' }
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -42,6 +65,17 @@ function triggerDownload(blob: Blob, filename: string): void {
   URL.revokeObjectURL(url)
 }
 
+function statusFromResult(result: SyncActionResult, okMessage: string): Status {
+  if (result.kind === 'ok') return { tone: 'success', message: okMessage }
+  if (result.kind === 'conflicts') {
+    return {
+      tone: 'warn',
+      message: `${result.conflicts.length} field conflict(s) detected. Resolution UI coming soon; local data preserved.`,
+    }
+  }
+  return { tone: 'error', message: result.error }
+}
+
 // ---------------------------------------------------------------------------
 // SyncSection
 // ---------------------------------------------------------------------------
@@ -50,11 +84,20 @@ export function SyncSection() {
   const activeProviderId = useSyncStore((s) => s.activeProviderId)
   const setActiveProvider = useSyncStore((s) => s.setActiveProvider)
   const lastSyncedAt = useSyncStore((s) => s.lastSyncedAt)
+  const lastSyncedBundle = useSyncStore((s) => s.lastSyncedBundle)
+  const setLastSyncedBundle = useSyncStore((s) => s.setLastSyncedBundle)
   const enabledModules = useSyncStore((s) => s.enabledModules)
   const toggleModule = useSyncStore((s) => s.toggleModule)
   const getClientId = useSyncStore((s) => s.getClientId)
+  const syncHostId = useSyncStore((s) => s.syncHostId)
+  const setSyncHostId = useSyncStore((s) => s.setSyncHostId)
+
+  const hosts = useHostStore((s) => s.hosts)
+  const hostOrder = useHostStore((s) => s.hostOrder)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const [status, setStatus] = useState<Status>(IDLE)
+  const [busy, setBusy] = useState(false)
 
   // Normalise: null → 'off'
   const currentProvider: ProviderId =
@@ -62,9 +105,51 @@ export function SyncSection() {
 
   const handleProviderChange = (value: ProviderId) => {
     setActiveProvider(value === 'off' ? null : value)
+    setStatus(IDLE)
   }
 
   const contributors = syncEngine.getContributors()
+
+  // --------------------------------------------------------------------------
+  // Sync Now
+  // --------------------------------------------------------------------------
+
+  const handleSyncNow = async () => {
+    if (busy) return
+
+    if (currentProvider !== 'daemon') {
+      setStatus({
+        tone: 'warn',
+        message: 'Sync Now is only available with the Daemon provider for now.',
+      })
+      return
+    }
+
+    if (!syncHostId || !hosts[syncHostId]) {
+      setStatus({ tone: 'warn', message: 'Select a sync host first.' })
+      return
+    }
+
+    setBusy(true)
+    setStatus({ tone: 'busy', message: 'Syncing…' })
+
+    const clientId = getClientId()
+    const provider = createDaemonProvider(syncHostId, clientId)
+    const result = await syncNow({
+      provider,
+      clientId,
+      lastSyncedBundle,
+      enabledModules,
+      engine: syncEngine,
+    })
+
+    if (result.kind === 'ok') {
+      setLastSyncedBundle(result.appliedBundle)
+    }
+
+    setStatus(statusFromResult(result, 'Sync complete.'))
+    setBusy(false)
+  }
 
   // --------------------------------------------------------------------------
   // Export
@@ -77,6 +162,7 @@ export function SyncSection() {
     const blob = provider.exportToBlob(bundle)
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
     triggerDownload(blob, `purdex-sync-${timestamp}.purdex-sync`)
+    setStatus({ tone: 'success', message: 'Exported.' })
   }
 
   // --------------------------------------------------------------------------
@@ -90,17 +176,34 @@ export function SyncSection() {
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
+    if (busy) return
+
+    setBusy(true)
+    setStatus({ tone: 'busy', message: 'Importing…' })
+
     try {
       const text = await file.text()
       const provider = createManualProvider()
       const bundle = provider.importFromText(text)
-      // Full import flow will be wired in a future task
-      console.log('[SyncSection] Imported bundle:', bundle)
+
+      const result = await applyImport({
+        bundle,
+        lastSyncedBundle,
+        enabledModules,
+        engine: syncEngine,
+      })
+
+      if (result.kind === 'ok') {
+        setLastSyncedBundle(result.appliedBundle)
+      }
+
+      setStatus(statusFromResult(result, 'Import applied.'))
     } catch (err) {
-      console.error('[SyncSection] Import failed:', err)
+      const message = err instanceof Error ? err.message : String(err)
+      setStatus({ tone: 'error', message: `Import failed: ${message}` })
     } finally {
-      // Reset so the same file can be re-selected
       if (fileInputRef.current) fileInputRef.current.value = ''
+      setBusy(false)
     }
   }
 
@@ -129,6 +232,31 @@ export function SyncSection() {
 
       {currentProvider !== 'off' && (
         <>
+          {/* Sync host selector (Daemon only) */}
+          {currentProvider === 'daemon' && (
+            <SettingItem
+              label="Sync Host"
+              description="Daemon to push and pull sync data through."
+            >
+              <select
+                value={syncHostId ?? ''}
+                onChange={(e) => setSyncHostId(e.target.value || null)}
+                className="px-3 py-1.5 rounded-md border border-border-default bg-surface-base text-text-primary text-xs focus:border-border-active outline-none"
+              >
+                <option value="">— Select —</option>
+                {hostOrder.map((id) => {
+                  const host = hosts[id]
+                  if (!host) return null
+                  return (
+                    <option key={id} value={id}>
+                      {host.name} ({host.ip}:{host.port})
+                    </option>
+                  )
+                })}
+              </select>
+            </SettingItem>
+          )}
+
           {/* Sync status */}
           <SettingItem
             label="Sync Status"
@@ -139,13 +267,11 @@ export function SyncSection() {
             }
           >
             <button
-              onClick={() => {
-                // Actual sync logic will be wired in a future task
-                console.log('[SyncSection] Sync Now triggered')
-              }}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border-default text-text-secondary text-xs hover:text-text-primary hover:border-border-active"
+              onClick={handleSyncNow}
+              disabled={busy}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border-default text-text-secondary text-xs hover:text-text-primary hover:border-border-active disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <ArrowsClockwise size={14} />
+              <ArrowsClockwise size={14} className={busy ? 'animate-spin' : ''} />
               Sync Now
             </button>
           </SettingItem>
@@ -186,14 +312,16 @@ export function SyncSection() {
             <div className="flex items-center gap-2">
               <button
                 onClick={handleExportAll}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border-default text-text-secondary text-xs hover:text-text-primary hover:border-border-active"
+                disabled={busy}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border-default text-text-secondary text-xs hover:text-text-primary hover:border-border-active disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <DownloadSimple size={14} />
                 Export All
               </button>
               <button
                 onClick={handleImportClick}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border-default text-text-secondary text-xs hover:text-text-primary hover:border-border-active"
+                disabled={busy}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border-default text-text-secondary text-xs hover:text-text-primary hover:border-border-active disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Upload size={14} />
                 Import
@@ -207,8 +335,46 @@ export function SyncSection() {
               />
             </div>
           </SettingItem>
+
+          <StatusLine status={status} />
         </>
       )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// StatusLine
+// ---------------------------------------------------------------------------
+
+function StatusLine({ status }: { status: Status }) {
+  if (status.tone === 'idle' || !status.message) return null
+
+  const Icon =
+    status.tone === 'success'
+      ? CheckCircle
+      : status.tone === 'warn'
+      ? Warning
+      : status.tone === 'error'
+      ? WarningCircle
+      : ArrowsClockwise
+
+  const color =
+    status.tone === 'success'
+      ? 'text-green-500'
+      : status.tone === 'warn'
+      ? 'text-yellow-500'
+      : status.tone === 'error'
+      ? 'text-red-500'
+      : 'text-text-secondary'
+
+  return (
+    <div className={`flex items-start gap-1.5 mt-3 text-xs ${color}`}>
+      <Icon
+        size={14}
+        className={status.tone === 'busy' ? 'animate-spin mt-0.5' : 'mt-0.5'}
+      />
+      <span>{status.message}</span>
     </div>
   )
 }

--- a/spa/src/components/settings/SyncSection.tsx
+++ b/spa/src/components/settings/SyncSection.tsx
@@ -145,6 +145,10 @@ export function SyncSection() {
 
     if (result.kind === 'ok') {
       setLastSyncedBundle(result.appliedBundle)
+    } else if (result.kind === 'conflicts') {
+      // engine partial-applied non-conflicting contributors; advance their
+      // baseline so the next sync doesn't rebase them against a stale ancestor.
+      setLastSyncedBundle(result.partialBaseline)
     }
 
     setStatus(statusFromResult(result, 'Sync complete.'))
@@ -195,6 +199,8 @@ export function SyncSection() {
 
       if (result.kind === 'ok') {
         setLastSyncedBundle(result.appliedBundle)
+      } else if (result.kind === 'conflicts') {
+        setLastSyncedBundle(result.partialBaseline)
       }
 
       setStatus(statusFromResult(result, 'Import applied.'))
@@ -241,7 +247,7 @@ export function SyncSection() {
               <select
                 value={syncHostId ?? ''}
                 onChange={(e) => setSyncHostId(e.target.value || null)}
-                className="px-3 py-1.5 rounded-md border border-border-default bg-surface-base text-text-primary text-xs focus:border-border-active outline-none"
+                className="bg-surface-input border border-border-default rounded-md text-text-primary text-xs px-3 py-1.5 w-60 hover:border-text-muted focus:border-border-active focus:outline-none"
               >
                 <option value="">— Select —</option>
                 {hostOrder.map((id) => {

--- a/spa/src/lib/sync/sync-actions.test.ts
+++ b/spa/src/lib/sync/sync-actions.test.ts
@@ -151,6 +151,79 @@ describe('syncNow', () => {
     expect(contributor.getData()).toEqual({ theme: 'solarized' })
   })
 
+  it('conflicts: partialBaseline advances only for non-conflicting contributors', async () => {
+    // Second contributor with no conflict
+    const prefs = contributor // 'prefs' — conflict target
+    const hosts = createTestContributor('hosts', { h1: { name: 'a' } })
+    engine.register(hosts)
+
+    // Set up conflict on prefs: local changed theme, remote changed theme differently.
+    const lastSynced: SyncBundle = {
+      version: 1,
+      timestamp: 100,
+      device: 'c_local',
+      collections: {
+        prefs: { version: 1, data: { theme: 'dark' } },
+        hosts: { version: 1, data: { h1: { name: 'a' } } },
+      },
+    }
+    prefs.deserialize(
+      { version: 1, data: { theme: 'solarized' } },
+      { type: 'full-replace' },
+    )
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: 500,
+      device: 'c_remote',
+      collections: {
+        prefs: { version: 1, data: { theme: 'light' } },
+        hosts: { version: 1, data: { h1: { name: 'b' } } }, // changed, no local change → use-remote
+      },
+    }
+    const provider = createStubProvider({ pull: vi.fn(async () => remoteBundle) })
+
+    const result = await syncNow({
+      provider,
+      clientId: 'c_local',
+      lastSyncedBundle: lastSynced,
+      enabledModules: ['prefs', 'hosts'],
+      engine,
+    })
+
+    expect(result.kind).toBe('conflicts')
+    if (result.kind !== 'conflicts') throw new Error('unreachable')
+
+    // Non-conflicting 'hosts' was applied locally (engine partial-apply):
+    expect(hosts.getData()).toEqual({ h1: { name: 'b' } })
+
+    // partialBaseline must: keep old baseline for 'prefs' (conflict) but
+    // advance to remote for 'hosts' (applied).
+    expect(result.partialBaseline.collections['prefs']).toEqual(
+      lastSynced.collections['prefs'],
+    )
+    expect(result.partialBaseline.collections['hosts']).toEqual(
+      remoteBundle.collections['hosts'],
+    )
+  })
+
+  it('conflicts: partialBaseline works when lastSyncedBundle is null (first sync)', async () => {
+    // First sync → engine.pull uses first-sync branch with full-replace, no conflicts.
+    // Force a conflict scenario by providing a non-null lastSyncedBundle that
+    // predates both local and remote state. Here we skip: with null lastSynced
+    // engine never returns conflicts, so partialBaseline need only handle that
+    // we don't explode when given null.
+    const provider = createStubProvider({ pull: vi.fn(async () => null) })
+    const result = await syncNow({
+      provider,
+      clientId: 'c_local',
+      lastSyncedBundle: null,
+      enabledModules: ['prefs'],
+      engine,
+    })
+    // Empty remote → ok path, no partialBaseline exposed
+    expect(result.kind).toBe('ok')
+  })
+
   it('returns error when provider.pull throws', async () => {
     const provider = createStubProvider({
       pull: vi.fn(async () => {

--- a/spa/src/lib/sync/sync-actions.test.ts
+++ b/spa/src/lib/sync/sync-actions.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { applyImport, syncNow } from './sync-actions'
+import { createSyncEngine } from './engine'
+import type {
+  SyncBundle,
+  SyncContributor,
+  SyncProvider,
+  FullPayload,
+  MergeStrategy,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestContributor(
+  id: string,
+  initialData: Record<string, unknown>,
+): SyncContributor & { getData: () => Record<string, unknown> } {
+  let data = { ...initialData }
+  return {
+    id,
+    strategy: 'full',
+    serialize(): FullPayload {
+      return { version: 1, data: { ...data } }
+    },
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      const p = payload as FullPayload
+      if (merge.type === 'full-replace') {
+        data = { ...(p.data as Record<string, unknown>) }
+      } else {
+        data = { ...data, ...(p.data as Record<string, unknown>) }
+      }
+    },
+    getVersion(): number {
+      return 1
+    },
+    getData(): Record<string, unknown> {
+      return { ...data }
+    },
+  }
+}
+
+function createStubProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
+  return {
+    id: 'stub',
+    push: vi.fn(async () => {}),
+    pull: vi.fn(async () => null),
+    pushChunks: vi.fn(async () => {}),
+    pullChunks: vi.fn(async () => ({})),
+    listHistory: vi.fn(async () => []),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// syncNow
+// ---------------------------------------------------------------------------
+
+describe('syncNow', () => {
+  let engine: ReturnType<typeof createSyncEngine>
+  let contributor: ReturnType<typeof createTestContributor>
+
+  beforeEach(() => {
+    engine = createSyncEngine()
+    contributor = createTestContributor('prefs', { theme: 'dark' })
+    engine.register(contributor)
+  })
+
+  it('first sync with empty remote: pushes local state and returns ok', async () => {
+    const provider = createStubProvider({ pull: vi.fn(async () => null) })
+    const result = await syncNow({
+      provider,
+      clientId: 'c_aaa',
+      lastSyncedBundle: null,
+      enabledModules: ['prefs'],
+      engine,
+    })
+
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') throw new Error('unreachable')
+    expect(provider.push).toHaveBeenCalledOnce()
+    expect(result.appliedBundle.device).toBe('c_aaa')
+    expect(result.appliedBundle.collections['prefs']).toBeDefined()
+  })
+
+  it('first sync with remote data: applies remote and pushes merged state', async () => {
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: 500,
+      device: 'c_remote',
+      collections: {
+        prefs: { version: 1, data: { theme: 'light' } },
+      },
+    }
+    const provider = createStubProvider({ pull: vi.fn(async () => remoteBundle) })
+
+    const result = await syncNow({
+      provider,
+      clientId: 'c_local',
+      lastSyncedBundle: null,
+      enabledModules: ['prefs'],
+      engine,
+    })
+
+    expect(result.kind).toBe('ok')
+    // Local contributor should have been replaced with remote
+    expect(contributor.getData()).toEqual({ theme: 'light' })
+    expect(provider.push).toHaveBeenCalledOnce()
+  })
+
+  it('returns conflicts without pushing when three-way merge detects conflict', async () => {
+    const lastSynced: SyncBundle = {
+      version: 1,
+      timestamp: 100,
+      device: 'c_local',
+      collections: {
+        prefs: { version: 1, data: { theme: 'dark' } },
+      },
+    }
+    // Local changed theme to 'solarized'
+    contributor.deserialize(
+      { version: 1, data: { theme: 'solarized' } },
+      { type: 'full-replace' },
+    )
+    // Remote changed theme to 'light'
+    const remoteBundle: SyncBundle = {
+      version: 1,
+      timestamp: 500,
+      device: 'c_remote',
+      collections: {
+        prefs: { version: 1, data: { theme: 'light' } },
+      },
+    }
+    const provider = createStubProvider({ pull: vi.fn(async () => remoteBundle) })
+
+    const result = await syncNow({
+      provider,
+      clientId: 'c_local',
+      lastSyncedBundle: lastSynced,
+      enabledModules: ['prefs'],
+      engine,
+    })
+
+    expect(result.kind).toBe('conflicts')
+    if (result.kind !== 'conflicts') throw new Error('unreachable')
+    expect(result.conflicts).toHaveLength(1)
+    expect(result.conflicts[0].field).toBe('theme')
+    expect(provider.push).not.toHaveBeenCalled()
+    // Local state must not change when conflicts exist
+    expect(contributor.getData()).toEqual({ theme: 'solarized' })
+  })
+
+  it('returns error when provider.pull throws', async () => {
+    const provider = createStubProvider({
+      pull: vi.fn(async () => {
+        throw new Error('network down')
+      }),
+    })
+
+    const result = await syncNow({
+      provider,
+      clientId: 'c_local',
+      lastSyncedBundle: null,
+      enabledModules: ['prefs'],
+      engine,
+    })
+
+    expect(result.kind).toBe('error')
+    if (result.kind !== 'error') throw new Error('unreachable')
+    expect(result.error).toContain('network down')
+  })
+
+  it('returns error when provider.push throws', async () => {
+    const provider = createStubProvider({
+      pull: vi.fn(async () => null),
+      push: vi.fn(async () => {
+        throw new Error('daemon 500')
+      }),
+    })
+
+    const result = await syncNow({
+      provider,
+      clientId: 'c_local',
+      lastSyncedBundle: null,
+      enabledModules: ['prefs'],
+      engine,
+    })
+
+    expect(result.kind).toBe('error')
+    if (result.kind !== 'error') throw new Error('unreachable')
+    expect(result.error).toContain('daemon 500')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyImport
+// ---------------------------------------------------------------------------
+
+describe('applyImport', () => {
+  let engine: ReturnType<typeof createSyncEngine>
+  let contributor: ReturnType<typeof createTestContributor>
+
+  beforeEach(() => {
+    engine = createSyncEngine()
+    contributor = createTestContributor('prefs', { theme: 'dark' })
+    engine.register(contributor)
+  })
+
+  it('first import (no lastSynced) full-replaces local state', async () => {
+    const importedBundle: SyncBundle = {
+      version: 1,
+      timestamp: 800,
+      device: 'c_exported',
+      collections: {
+        prefs: { version: 1, data: { theme: 'light' } },
+      },
+    }
+
+    const result = await applyImport({
+      bundle: importedBundle,
+      lastSyncedBundle: null,
+      enabledModules: ['prefs'],
+      engine,
+    })
+
+    expect(result.kind).toBe('ok')
+    expect(contributor.getData()).toEqual({ theme: 'light' })
+  })
+
+  it('subsequent import with three-way merge applies non-conflicting changes', async () => {
+    // Local matches lastSynced; only remote changed fontSize → remote wins
+    contributor.deserialize(
+      { version: 1, data: { theme: 'dark', fontSize: 14 } },
+      { type: 'full-replace' },
+    )
+    const lastSynced: SyncBundle = {
+      version: 1,
+      timestamp: 100,
+      device: 'c_local',
+      collections: {
+        prefs: { version: 1, data: { theme: 'dark', fontSize: 14 } },
+      },
+    }
+    const importedBundle: SyncBundle = {
+      version: 1,
+      timestamp: 800,
+      device: 'c_other',
+      collections: {
+        prefs: { version: 1, data: { theme: 'dark', fontSize: 18 } },
+      },
+    }
+
+    const result = await applyImport({
+      bundle: importedBundle,
+      lastSyncedBundle: lastSynced,
+      enabledModules: ['prefs'],
+      engine,
+    })
+
+    expect(result.kind).toBe('ok')
+    expect(contributor.getData()).toEqual({ theme: 'dark', fontSize: 18 })
+  })
+
+  it('reports conflicts without applying when three-way merge detects conflict', async () => {
+    const lastSynced: SyncBundle = {
+      version: 1,
+      timestamp: 100,
+      device: 'c_local',
+      collections: {
+        prefs: { version: 1, data: { theme: 'dark' } },
+      },
+    }
+    // Local changed to 'solarized'
+    contributor.deserialize(
+      { version: 1, data: { theme: 'solarized' } },
+      { type: 'full-replace' },
+    )
+    // Imported bundle changed to 'light'
+    const importedBundle: SyncBundle = {
+      version: 1,
+      timestamp: 800,
+      device: 'c_other',
+      collections: {
+        prefs: { version: 1, data: { theme: 'light' } },
+      },
+    }
+
+    const result = await applyImport({
+      bundle: importedBundle,
+      lastSyncedBundle: lastSynced,
+      enabledModules: ['prefs'],
+      engine,
+    })
+
+    expect(result.kind).toBe('conflicts')
+    expect(contributor.getData()).toEqual({ theme: 'solarized' })
+  })
+})

--- a/spa/src/lib/sync/sync-actions.ts
+++ b/spa/src/lib/sync/sync-actions.ts
@@ -19,6 +19,19 @@ export type SyncActionResult =
       kind: 'conflicts'
       conflicts: ConflictItem[]
       remoteBundle: SyncBundle
+      /**
+       * The baseline to persist as the next `lastSyncedBundle`.
+       *
+       * Because `SyncEngine.pull` applies non-conflicting contributors
+       * immediately (engine.ts), the local state of those contributors has
+       * already advanced to the remote payload — so their baseline must
+       * advance too. Conflicting contributors were left untouched and keep
+       * their previous baseline until the user resolves the conflict.
+       *
+       * Persisting this bundle prevents the next sync from rebasing
+       * already-applied contributors against a stale ancestor (issue #388).
+       */
+      partialBaseline: SyncBundle
     }
   | { kind: 'error'; error: string }
 
@@ -46,6 +59,11 @@ export async function syncNow(deps: SyncNowDeps): Promise<SyncActionResult> {
         kind: 'conflicts',
         conflicts: pullResult.conflicts,
         remoteBundle: pullResult.appliedBundle,
+        partialBaseline: buildPartialBaseline(
+          lastSyncedBundle,
+          pullResult.appliedBundle,
+          pullResult.conflicts,
+        ),
       }
     }
 
@@ -93,6 +111,11 @@ export async function applyImport(deps: ApplyImportDeps): Promise<SyncActionResu
         kind: 'conflicts',
         conflicts: pullResult.conflicts,
         remoteBundle: pullResult.appliedBundle,
+        partialBaseline: buildPartialBaseline(
+          lastSyncedBundle,
+          pullResult.appliedBundle,
+          pullResult.conflicts,
+        ),
       }
     }
 
@@ -109,4 +132,29 @@ export async function applyImport(deps: ApplyImportDeps): Promise<SyncActionResu
 function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message
   return String(err)
+}
+
+/**
+ * Merge the previous `lastSyncedBundle` with the remote bundle, taking remote
+ * payloads only for contributors that had no conflicts. Conflicting
+ * contributors keep their previous baseline until the user resolves them.
+ */
+function buildPartialBaseline(
+  previous: SyncBundle | null,
+  remoteBundle: SyncBundle,
+  conflicts: ConflictItem[],
+): SyncBundle {
+  const conflictingIds = new Set(conflicts.map((c) => c.contributor))
+  const collections: SyncBundle['collections'] = { ...(previous?.collections ?? {}) }
+  for (const [id, payload] of Object.entries(remoteBundle.collections)) {
+    if (!conflictingIds.has(id)) {
+      collections[id] = payload
+    }
+  }
+  return {
+    version: remoteBundle.version,
+    timestamp: remoteBundle.timestamp,
+    device: remoteBundle.device,
+    collections,
+  }
 }

--- a/spa/src/lib/sync/sync-actions.ts
+++ b/spa/src/lib/sync/sync-actions.ts
@@ -1,0 +1,112 @@
+// =============================================================================
+// Sync Architecture — Actions
+//
+// High-level orchestration helpers that wrap SyncEngine for UI consumption.
+// Kept pure (no store access) so they are easy to test and reuse from any
+// code path that needs to trigger a sync.
+// =============================================================================
+
+import type { createSyncEngine } from './engine'
+import type { ConflictItem, SyncBundle, SyncProvider } from './types'
+
+// ---------------------------------------------------------------------------
+// Result shape
+// ---------------------------------------------------------------------------
+
+export type SyncActionResult =
+  | { kind: 'ok'; appliedBundle: SyncBundle }
+  | {
+      kind: 'conflicts'
+      conflicts: ConflictItem[]
+      remoteBundle: SyncBundle
+    }
+  | { kind: 'error'; error: string }
+
+// ---------------------------------------------------------------------------
+// syncNow — pull then push through a SyncProvider
+// ---------------------------------------------------------------------------
+
+export interface SyncNowDeps {
+  provider: SyncProvider
+  clientId: string
+  lastSyncedBundle: SyncBundle | null
+  enabledModules: string[]
+  engine: ReturnType<typeof createSyncEngine>
+}
+
+export async function syncNow(deps: SyncNowDeps): Promise<SyncActionResult> {
+  const { provider, clientId, lastSyncedBundle, enabledModules, engine } = deps
+
+  try {
+    const pullResult = await engine.pull(provider, lastSyncedBundle, enabledModules)
+
+    if (pullResult.conflicts.length > 0 && pullResult.appliedBundle) {
+      // Surface conflicts; caller decides how to resolve before the next push.
+      return {
+        kind: 'conflicts',
+        conflicts: pullResult.conflicts,
+        remoteBundle: pullResult.appliedBundle,
+      }
+    }
+
+    const pushedBundle = await engine.push(provider, clientId, enabledModules)
+    return { kind: 'ok', appliedBundle: pushedBundle }
+  } catch (err) {
+    return { kind: 'error', error: errorMessage(err) }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// applyImport — apply a bundle that came from a manual import
+// ---------------------------------------------------------------------------
+
+export interface ApplyImportDeps {
+  bundle: SyncBundle
+  lastSyncedBundle: SyncBundle | null
+  enabledModules: string[]
+  engine: ReturnType<typeof createSyncEngine>
+}
+
+export async function applyImport(deps: ApplyImportDeps): Promise<SyncActionResult> {
+  const { bundle, lastSyncedBundle, enabledModules, engine } = deps
+
+  try {
+    const oneShotProvider: SyncProvider = {
+      id: 'import',
+      async push() {},
+      async pull() {
+        return bundle
+      },
+      async pushChunks() {},
+      async pullChunks() {
+        return {}
+      },
+      async listHistory() {
+        return []
+      },
+    }
+
+    const pullResult = await engine.pull(oneShotProvider, lastSyncedBundle, enabledModules)
+
+    if (pullResult.conflicts.length > 0 && pullResult.appliedBundle) {
+      return {
+        kind: 'conflicts',
+        conflicts: pullResult.conflicts,
+        remoteBundle: pullResult.appliedBundle,
+      }
+    }
+
+    return { kind: 'ok', appliedBundle: pullResult.appliedBundle ?? bundle }
+  } catch (err) {
+    return { kind: 'error', error: errorMessage(err) }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/spa/src/lib/sync/use-sync-store.test.ts
+++ b/spa/src/lib/sync/use-sync-store.test.ts
@@ -21,6 +21,18 @@ describe('useSyncStore', () => {
     expect(state.activeProviderId).toBeNull()
     expect(state.enabledModules).toEqual([])
     expect(state.clientId).toBeNull()
+    expect(state.syncHostId).toBeNull()
+  })
+
+  it('setSyncHostId updates the sync host', () => {
+    useSyncStore.getState().setSyncHostId('h_aaa')
+    expect(useSyncStore.getState().syncHostId).toBe('h_aaa')
+  })
+
+  it('setSyncHostId accepts null', () => {
+    useSyncStore.getState().setSyncHostId('h_aaa')
+    useSyncStore.getState().setSyncHostId(null)
+    expect(useSyncStore.getState().syncHostId).toBeNull()
   })
 
   it('setActiveProvider updates activeProviderId', () => {
@@ -107,5 +119,6 @@ describe('useSyncStore', () => {
     expect(state.activeProviderId).toBeNull()
     expect(state.enabledModules).toEqual([])
     expect(state.clientId).toBeNull()
+    expect(state.syncHostId).toBeNull()
   })
 })

--- a/spa/src/lib/sync/use-sync-store.ts
+++ b/spa/src/lib/sync/use-sync-store.ts
@@ -25,12 +25,15 @@ interface SyncStoreState {
   activeProviderId: string | null
   enabledModules: string[]
   clientId: string | null
+  /** Host ID to sync through when activeProviderId === 'daemon'. */
+  syncHostId: string | null
 
   // Actions
   setLastSyncedBundle: (bundle: SyncBundle) => void
   setActiveProvider: (providerId: string | null) => void
   toggleModule: (moduleId: string) => void
   getClientId: () => string
+  setSyncHostId: (hostId: string | null) => void
   reset: () => void
 }
 
@@ -44,9 +47,15 @@ const initialState = {
   activeProviderId: null,
   enabledModules: [] as string[],
   clientId: null,
+  syncHostId: null,
 } satisfies Pick<
   SyncStoreState,
-  'lastSyncedBundle' | 'lastSyncedAt' | 'activeProviderId' | 'enabledModules' | 'clientId'
+  | 'lastSyncedBundle'
+  | 'lastSyncedAt'
+  | 'activeProviderId'
+  | 'enabledModules'
+  | 'clientId'
+  | 'syncHostId'
 >
 
 // ---------------------------------------------------------------------------
@@ -108,6 +117,8 @@ export const useSyncStore = create<SyncStoreState>()(
         return id
       },
 
+      setSyncHostId: (hostId) => set({ syncHostId: hostId }),
+
       reset: () => set({ ...initialState }),
     }),
     {
@@ -119,6 +130,7 @@ export const useSyncStore = create<SyncStoreState>()(
         activeProviderId: state.activeProviderId,
         enabledModules: state.enabledModules,
         clientId: state.clientId,
+        syncHostId: state.syncHostId,
       }),
     },
   ),


### PR DESCRIPTION
## Summary

Wires the Sync Now button and Import file flow that were stubs in PR #384, so the Sync Settings section can actually push/pull and apply bundles.

- `sync-actions.ts` — thin orchestration layer over `SyncEngine`: `syncNow()` does pull → three-way merge → push; `applyImport()` treats a parsed bundle as a one-shot remote pull. Both return a discriminated `ok | conflicts | error` result.
- `useSyncStore` gains `syncHostId` (persisted) so the Daemon provider knows which host to route through.
- `SyncSection.tsx`: Sync host dropdown (Daemon only), working Sync Now + Import, busy state + success/warn/error status line. Conflicts are reported by count only; dedicated Conflict Banner UI is the next PR.

## Out of scope (follow-up PRs)

- Add Device / Pairing UI (QR + pairing code)
- Conflict Banner + per-field resolution
- Sync History UI + restore
- File provider wiring (Electron only)

## Test Plan

- [x] `npx vitest run src/lib/sync/sync-actions.test.ts` — 8/8
- [x] Full suite — 1636/1636 pass
- [ ] Manual: Settings → Sync → switch provider to Daemon, pick sync host, click Sync Now against a running daemon
- [ ] Manual: Export → Import the same file back, verify status shows "Import applied."
- [ ] Manual: Import a tampered bundle, verify error status

## Known pre-existing issues (not introduced here)

`pnpm run build` surfaces TS errors from prior PRs (#380 editor previews, #384 sync file-provider) — all in files this PR does not touch. Vitest and my new files are clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>