### PR TITLE
style(settings): align SettingItem label to top

### DIFF
--- a/spa/src/components/settings/SettingItem.tsx
+++ b/spa/src/components/settings/SettingItem.tsx
@@ -7,7 +7,7 @@ interface SettingItemProps {
 
 export function SettingItem({ label, description, disabled, children }: SettingItemProps) {
   return (
-    <div className={`flex items-center justify-between py-3 ${disabled ? 'pointer-events-none' : ''}`}>
+    <div className={`flex items-start justify-between py-3 ${disabled ? 'pointer-events-none' : ''}`}>
       <div className="flex flex-col gap-0.5 mr-4">
         <span className="text-sm text-text-primary">{label}</span>
         {description && <span className="text-xs text-text-secondary">{description}</span>}


### PR DESCRIPTION
## Summary

- `SettingItem` 外層 flex 從 `items-center` 改為 `items-start`
- 讓右側是多行內容（例如 Sync 頁的 Modules checkbox 列表）時，左側 label/description 不再被垂直置中
- 單行 case 視覺幾乎不變

## Test plan

- [x] `cd spa && npx vitest run src/components/settings` 81 項通過
- [x] ESLint 無新 error
- [ ] 目視：Settings → Sync → Modules 區塊 label 靠上、其他 SettingItem 外觀正常