### PR TITLE
refactor(workspace): extract computeDragEndAction pure function (#407)

### DIFF
--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -11,7 +11,6 @@ import {
 import {
   SortableContext,
   verticalListSortingStrategy,
-  arrayMove,
 } from '@dnd-kit/sortable'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { useLayoutStore, MIN_WIDTH, MAX_WIDTH } from '../../../stores/useLayoutStore'
@@ -20,12 +19,9 @@ import { CollapseButton } from './CollapseButton'
 import { WorkspaceRow } from './WorkspaceRow'
 import { HomeRow } from './HomeRow'
 import type { ActivityBarProps } from './activity-bar-props'
+import { computeDragEndAction, dispatchDragEndAction } from '../lib/computeDragEndAction'
 
 const NOOP = () => {}
-
-type WorkspaceDragData = { type: 'workspace'; wsId: string }
-type TabDragData = { type: 'tab'; tabId: string; sourceWsId: string | null }
-type DragData = WorkspaceDragData | TabDragData
 
 export function ActivityBarWide(props: ActivityBarProps) {
   const {
@@ -75,43 +71,12 @@ export function ActivityBarWide(props: ActivityBarProps) {
 
   const handleDragEnd = useCallback(
     (e: DragEndEvent) => {
-      const { active, over } = e
-      if (!over || active.id === over.id) return
-
-      const activeData = active.data.current as DragData | undefined
-      const overData = over.data.current as DragData | undefined
-
-      if (!activeData) return
-
-      if (activeData.type === 'workspace') {
-        const oldIndex = wsIds.indexOf(String(active.id))
-        const newIndex = wsIds.indexOf(String(over.id))
-        if (oldIndex === -1 || newIndex === -1) return
-        const newOrder = arrayMove(wsIds, oldIndex, newIndex)
-        onReorderWorkspaces?.(newOrder)
-        return
-      }
-
-      if (activeData.type === 'tab') {
-        // Phase 3 will handle cross-zone (tab dropped on workspace row) drops;
-        // for Phase 2 require an over-target that is also a tab in the same zone.
-        if (!overData || overData.type !== 'tab') return
-        if (activeData.sourceWsId !== overData.sourceWsId) return
-        const sourceWsId = activeData.sourceWsId
-        if (sourceWsId === null) {
-          const oldIdx = standaloneTabIds.indexOf(activeData.tabId)
-          const newIdx = standaloneTabIds.indexOf(overData.tabId)
-          if (oldIdx === -1 || newIdx === -1) return
-          onReorderStandaloneTabs?.(arrayMove(standaloneTabIds, oldIdx, newIdx))
-          return
-        }
-        const ws = workspaces.find((w) => w.id === sourceWsId)
-        if (!ws) return
-        const oldIdx = ws.tabs.indexOf(activeData.tabId)
-        const newIdx = ws.tabs.indexOf(overData.tabId)
-        if (oldIdx === -1 || newIdx === -1) return
-        onReorderWorkspaceTabs?.(sourceWsId, arrayMove(ws.tabs, oldIdx, newIdx))
-      }
+      const action = computeDragEndAction(e, { wsIds, workspaces, standaloneTabIds })
+      dispatchDragEndAction(action, {
+        onReorderWorkspaces,
+        onReorderStandaloneTabs,
+        onReorderWorkspaceTabs,
+      })
     },
     [
       wsIds,

--- a/spa/src/features/workspace/lib/computeDragEndAction.test.ts
+++ b/spa/src/features/workspace/lib/computeDragEndAction.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { DragEndEvent } from '@dnd-kit/core'
+import {
+  computeDragEndAction,
+  dispatchDragEndAction,
+  type DragEndAction,
+  type DragEndContext,
+} from './computeDragEndAction'
+
+function mkEvent(
+  active: { id: string; data?: unknown } | null,
+  over: { id: string; data?: unknown } | null,
+): DragEndEvent {
+  return {
+    active: active
+      ? { id: active.id, data: { current: active.data }, rect: { current: { initial: null, translated: null } } }
+      : null,
+    over: over
+      ? { id: over.id, data: { current: over.data }, rect: {} as unknown }
+      : null,
+    delta: { x: 0, y: 0 },
+    collisions: null,
+    activatorEvent: new Event('pointerdown'),
+  } as unknown as DragEndEvent
+}
+
+const ctx = (overrides?: Partial<DragEndContext>): DragEndContext => ({
+  wsIds: ['w1', 'w2', 'w3'],
+  workspaces: [
+    { id: 'w1', tabs: ['t1a', 't1b'] },
+    { id: 'w2', tabs: ['t2a'] },
+  ],
+  standaloneTabIds: ['sA', 'sB', 'sC'],
+  ...overrides,
+})
+
+describe('computeDragEndAction', () => {
+  describe('early returns → noop', () => {
+    it('no over target', () => {
+      const action = computeDragEndAction(
+        mkEvent({ id: 'w1', data: { type: 'workspace', wsId: 'w1' } }, null),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
+    it('active === over', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 'w1', data: { type: 'workspace', wsId: 'w1' } },
+          { id: 'w1', data: { type: 'workspace', wsId: 'w1' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
+    it('activeData undefined', () => {
+      const action = computeDragEndAction(
+        mkEvent({ id: 'w1' }, { id: 'w2' }),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
+    it('tab dropped on non-tab target → noop (Phase 3 handles cross-zone later)', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1' } },
+          { id: 'w2', data: { type: 'workspace', wsId: 'w2' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
+    it('tab dropped on tab in different workspace → noop', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1' } },
+          { id: 't2a', data: { type: 'tab', tabId: 't2a', sourceWsId: 'w2' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+  })
+
+  describe('workspace reorder', () => {
+    it('moves workspace from 0 to 2', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 'w1', data: { type: 'workspace', wsId: 'w1' } },
+          { id: 'w3', data: { type: 'workspace', wsId: 'w3' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'reorder-workspaces', order: ['w2', 'w3', 'w1'] })
+    })
+
+    it('returns noop when workspace id not in wsIds', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 'wX', data: { type: 'workspace', wsId: 'wX' } },
+          { id: 'w1', data: { type: 'workspace', wsId: 'w1' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+  })
+
+  describe('standalone tab reorder (sourceWsId = null)', () => {
+    it('moves sA to end', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 'sA', data: { type: 'tab', tabId: 'sA', sourceWsId: null } },
+          { id: 'sC', data: { type: 'tab', tabId: 'sC', sourceWsId: null } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'reorder-standalone-tabs', order: ['sB', 'sC', 'sA'] })
+    })
+
+    it('returns noop when tab id not in standaloneTabIds', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 'sX', data: { type: 'tab', tabId: 'sX', sourceWsId: null } },
+          { id: 'sA', data: { type: 'tab', tabId: 'sA', sourceWsId: null } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+  })
+
+  describe('workspace tab reorder (sourceWsId = wsId)', () => {
+    it('reorders tabs within w1', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1' } },
+          { id: 't1b', data: { type: 'tab', tabId: 't1b', sourceWsId: 'w1' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({
+        kind: 'reorder-workspace-tabs',
+        wsId: 'w1',
+        order: ['t1b', 't1a'],
+      })
+    })
+
+    it('returns noop when workspace not found', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'wGhost' } },
+          { id: 't1b', data: { type: 'tab', tabId: 't1b', sourceWsId: 'wGhost' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
+    it('returns noop when tab id not in ws.tabs', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 'tGhost', data: { type: 'tab', tabId: 'tGhost', sourceWsId: 'w1' } },
+          { id: 't1b', data: { type: 'tab', tabId: 't1b', sourceWsId: 'w1' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+  })
+})
+
+describe('dispatchDragEndAction', () => {
+  it('dispatches reorder-workspaces to onReorderWorkspaces', () => {
+    const d = {
+      onReorderWorkspaces: vi.fn(),
+      onReorderStandaloneTabs: vi.fn(),
+      onReorderWorkspaceTabs: vi.fn(),
+    }
+    dispatchDragEndAction({ kind: 'reorder-workspaces', order: ['w2', 'w1'] }, d)
+    expect(d.onReorderWorkspaces).toHaveBeenCalledWith(['w2', 'w1'])
+    expect(d.onReorderStandaloneTabs).not.toHaveBeenCalled()
+    expect(d.onReorderWorkspaceTabs).not.toHaveBeenCalled()
+  })
+
+  it('dispatches reorder-standalone-tabs to onReorderStandaloneTabs', () => {
+    const d = { onReorderStandaloneTabs: vi.fn() }
+    dispatchDragEndAction({ kind: 'reorder-standalone-tabs', order: ['sB', 'sA'] }, d)
+    expect(d.onReorderStandaloneTabs).toHaveBeenCalledWith(['sB', 'sA'])
+  })
+
+  it('dispatches reorder-workspace-tabs to onReorderWorkspaceTabs with wsId', () => {
+    const d = { onReorderWorkspaceTabs: vi.fn() }
+    dispatchDragEndAction(
+      { kind: 'reorder-workspace-tabs', wsId: 'w1', order: ['t1b', 't1a'] },
+      d,
+    )
+    expect(d.onReorderWorkspaceTabs).toHaveBeenCalledWith('w1', ['t1b', 't1a'])
+  })
+
+  it('noop action fires nothing', () => {
+    const d = {
+      onReorderWorkspaces: vi.fn(),
+      onReorderStandaloneTabs: vi.fn(),
+      onReorderWorkspaceTabs: vi.fn(),
+    }
+    dispatchDragEndAction({ kind: 'noop' }, d)
+    expect(d.onReorderWorkspaces).not.toHaveBeenCalled()
+    expect(d.onReorderStandaloneTabs).not.toHaveBeenCalled()
+    expect(d.onReorderWorkspaceTabs).not.toHaveBeenCalled()
+  })
+
+  it('tolerates missing callbacks (optional chaining)', () => {
+    const action: DragEndAction = { kind: 'reorder-workspaces', order: ['a'] }
+    expect(() => dispatchDragEndAction(action, {})).not.toThrow()
+  })
+})

--- a/spa/src/features/workspace/lib/computeDragEndAction.ts
+++ b/spa/src/features/workspace/lib/computeDragEndAction.ts
@@ -1,0 +1,96 @@
+import type { DragEndEvent } from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
+
+export type WorkspaceDragData = { type: 'workspace'; wsId: string }
+export type TabDragData = {
+  type: 'tab'
+  tabId: string
+  sourceWsId: string | null
+  isPinned?: boolean
+}
+export type DragData = WorkspaceDragData | TabDragData
+
+export type DragEndAction =
+  | { kind: 'noop' }
+  | { kind: 'reorder-workspaces'; order: string[] }
+  | { kind: 'reorder-standalone-tabs'; order: string[] }
+  | { kind: 'reorder-workspace-tabs'; wsId: string; order: string[] }
+
+export interface DragEndContext {
+  wsIds: string[]
+  workspaces: Array<{ id: string; tabs: string[] }>
+  standaloneTabIds: string[]
+}
+
+const NOOP: DragEndAction = { kind: 'noop' }
+
+export function computeDragEndAction(
+  event: DragEndEvent,
+  ctx: DragEndContext,
+): DragEndAction {
+  const { active, over } = event
+  if (!over || active.id === over.id) return NOOP
+
+  const activeData = active.data.current as DragData | undefined
+  const overData = over.data.current as DragData | undefined
+  if (!activeData) return NOOP
+
+  if (activeData.type === 'workspace') {
+    const oldIndex = ctx.wsIds.indexOf(String(active.id))
+    const newIndex = ctx.wsIds.indexOf(String(over.id))
+    if (oldIndex === -1 || newIndex === -1) return NOOP
+    return { kind: 'reorder-workspaces', order: arrayMove(ctx.wsIds, oldIndex, newIndex) }
+  }
+
+  if (activeData.type === 'tab') {
+    // Phase 3 will handle cross-zone drops; for now require tab → tab in same zone.
+    if (!overData || overData.type !== 'tab') return NOOP
+    if (activeData.sourceWsId !== overData.sourceWsId) return NOOP
+
+    if (activeData.sourceWsId === null) {
+      const oldIdx = ctx.standaloneTabIds.indexOf(activeData.tabId)
+      const newIdx = ctx.standaloneTabIds.indexOf(overData.tabId)
+      if (oldIdx === -1 || newIdx === -1) return NOOP
+      return {
+        kind: 'reorder-standalone-tabs',
+        order: arrayMove(ctx.standaloneTabIds, oldIdx, newIdx),
+      }
+    }
+
+    const wsId = activeData.sourceWsId
+    const ws = ctx.workspaces.find((w) => w.id === wsId)
+    if (!ws) return NOOP
+    const oldIdx = ws.tabs.indexOf(activeData.tabId)
+    const newIdx = ws.tabs.indexOf(overData.tabId)
+    if (oldIdx === -1 || newIdx === -1) return NOOP
+    return {
+      kind: 'reorder-workspace-tabs',
+      wsId,
+      order: arrayMove(ws.tabs, oldIdx, newIdx),
+    }
+  }
+
+  return NOOP
+}
+
+export interface DragEndDispatch {
+  onReorderWorkspaces?: (order: string[]) => void
+  onReorderStandaloneTabs?: (order: string[]) => void
+  onReorderWorkspaceTabs?: (wsId: string, order: string[]) => void
+}
+
+export function dispatchDragEndAction(action: DragEndAction, d: DragEndDispatch): void {
+  switch (action.kind) {
+    case 'reorder-workspaces':
+      d.onReorderWorkspaces?.(action.order)
+      return
+    case 'reorder-standalone-tabs':
+      d.onReorderStandaloneTabs?.(action.order)
+      return
+    case 'reorder-workspace-tabs':
+      d.onReorderWorkspaceTabs?.(action.wsId, action.order)
+      return
+    case 'noop':
+      return
+  }
+}

--- a/spa/src/features/workspace/lib/computeDragEndAction.ts
+++ b/spa/src/features/workspace/lib/computeDragEndAction.ts
@@ -92,5 +92,12 @@ export function dispatchDragEndAction(action: DragEndAction, d: DragEndDispatch)
       return
     case 'noop':
       return
+    default: {
+      // Exhaustiveness check: adding a new DragEndAction kind forces a TS error
+      // here until dispatchDragEndAction is updated to handle it.
+      const _exhaustive: never = action
+      void _exhaustive
+      return
+    }
   }
 }


### PR DESCRIPTION
## Summary

Phase 3 PR B — 抽離 \`ActivityBarWide.handleDragEnd\` 的 drag 意圖判斷，改由純函式 \`computeDragEndAction\` 根據 \`DragEndEvent\` + context 產生 discriminated \`DragEndAction\`；\`dispatchDragEndAction\` 負責將 action 路由到對應的 callback。元件只剩 compose 邏輯，為 PR D 的 cross-workspace / spring-load / pinned 分支鋪好擴充點。

- 新增 \`spa/src/features/workspace/lib/computeDragEndAction.ts\`
  - \`computeDragEndAction(event, ctx)\` → \`DragEndAction\`（4 kind discriminated union）
  - \`dispatchDragEndAction(action, callbacks)\` 將 action 分派到可選 callback
- 新增單元測試：3 reorder 分支 + 5 早返回 + 5 dispatch case（共 17 test）
- \`ActivityBarWide.handleDragEnd\` 由 ~40 行行內判斷簡化為 6 行 compose
- 行為保留：既有 ActivityBarWide 5 tests 全數通過，full suite 1799 pass

## Test plan

- [x] \`cd spa && npx vitest run\` — **1799/1799 passed**
- [x] \`cd spa && pnpm run lint\` — 9 pre-existing errors (同 origin/main, 未新增; #412 追蹤)
- [ ] 手動：workspace reorder DnD 仍運作
- [ ] 手動：inline tab 同 ws reorder 仍運作
- [ ] 手動：standalone tab（Home）reorder 仍運作

## Notes

Plan reference: \`docs/superpowers/plans/2026-04-17-phase3-layout-modes.md\` § PR B

Part of Phase 3 sequence (PR A #415 merged → PR B here → PR C inline tab parity → PR D cross-ws DnD).

Closes #407.