### PR TITLE
feat(layout): Phase 3c — InlineTab visual parity (#401)

### DIFF
--- a/spa/src/features/workspace/components/InlineTab.test.tsx
+++ b/spa/src/features/workspace/components/InlineTab.test.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { DndContext } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'
 import { InlineTab } from './InlineTab'
-import type { Tab } from '../../../types/tab'
+import type { Tab, PaneContent } from '../../../types/tab'
+import { useAgentStore } from '../../../stores/useAgentStore'
+import { useHostStore } from '../../../stores/useHostStore'
 
 function renderWith(
   tab: Tab,
@@ -28,14 +30,33 @@ function renderWith(
   )
 }
 
-const mkTab = (overrides: Partial<Tab> = {}): Tab =>
-  ({
-    id: 't1',
-    kind: 'new-tab',
-    locked: false,
-    layout: { type: 'single' } as Tab['layout'],
-    ...overrides,
-  }) as Tab
+interface MkTabOpts {
+  id?: string
+  pinned?: boolean
+  locked?: boolean
+  hostId?: string
+  sessionCode?: string
+  terminated?: boolean
+}
+
+const mkTab = (opts: MkTabOpts = {}): Tab => {
+  const id = opts.id ?? 't1'
+  const content: PaneContent =
+    opts.hostId && opts.sessionCode
+      ? ({
+          kind: 'tmux-session',
+          hostId: opts.hostId,
+          sessionCode: opts.sessionCode,
+          ...(opts.terminated ? { terminated: true } : {}),
+        } as PaneContent)
+      : ({ kind: 'new-tab' } as PaneContent)
+  return {
+    id,
+    pinned: opts.pinned ?? false,
+    locked: opts.locked ?? false,
+    layout: { type: 'leaf', pane: { id: `p-${id}`, content } },
+  } as Tab
+}
 
 describe('InlineTab', () => {
   it('renders given title', () => {
@@ -71,6 +92,77 @@ describe('InlineTab', () => {
     const row = screen.getByText('Untitled').closest('[data-testid="inline-tab-row"]')!
     fireEvent.mouseDown(row, { button: 1 })
     expect(onMiddleClick).toHaveBeenCalledWith('t1')
+  })
+})
+
+describe('InlineTab — visual parity', () => {
+  beforeEach(() => {
+    cleanup()
+    useAgentStore.setState({
+      statuses: {},
+      subagents: {},
+      unread: {},
+      tabIndicatorStyle: 'overlay',
+    } as Partial<ReturnType<typeof useAgentStore.getState>> as never)
+    useHostStore.setState({ runtime: {} } as Partial<ReturnType<typeof useHostStore.getState>> as never)
+  })
+
+  it('renders Lock icon for locked tabs', () => {
+    renderWith(mkTab({ locked: true }), 'Locked')
+    expect(screen.getByTestId('inline-tab-lock')).toBeInTheDocument()
+  })
+
+  it('hides Close button for locked tabs (parity with SortableTab)', () => {
+    renderWith(mkTab({ locked: true }), 'Locked')
+    expect(screen.queryByLabelText(/^Close /)).not.toBeInTheDocument()
+  })
+
+  it('shows unread dot when tab has unread flag and is not active', () => {
+    useAgentStore.setState({
+      unread: { 'host1:sc1': true },
+    } as Partial<ReturnType<typeof useAgentStore.getState>> as never)
+    renderWith(
+      mkTab({ hostId: 'host1', sessionCode: 'sc1' }),
+      'Unread',
+      { sourceWsId: null, isActive: false },
+    )
+    expect(screen.getByTestId('inline-tab-unread')).toBeInTheDocument()
+  })
+
+  it('hides unread dot when tab is active', () => {
+    useAgentStore.setState({
+      unread: { 'host1:sc1': true },
+    } as Partial<ReturnType<typeof useAgentStore.getState>> as never)
+    renderWith(
+      mkTab({ hostId: 'host1', sessionCode: 'sc1' }),
+      'Active',
+      { sourceWsId: null, isActive: true },
+    )
+    expect(screen.queryByTestId('inline-tab-unread')).not.toBeInTheDocument()
+  })
+
+  it('shows WifiSlash when host offline and tab not terminated', () => {
+    useHostStore.setState({
+      runtime: { host1: { status: 'disconnected' } },
+    } as Partial<ReturnType<typeof useHostStore.getState>> as never)
+    renderWith(
+      mkTab({ hostId: 'host1', sessionCode: 'sc1' }),
+      'Offline',
+      { sourceWsId: null },
+    )
+    expect(screen.getByTestId('inline-tab-host-offline')).toBeInTheDocument()
+  })
+
+  it('hides WifiSlash when session is terminated', () => {
+    useHostStore.setState({
+      runtime: { host1: { status: 'disconnected' } },
+    } as Partial<ReturnType<typeof useHostStore.getState>> as never)
+    renderWith(
+      mkTab({ hostId: 'host1', sessionCode: 'sc1', terminated: true }),
+      'Terminated',
+      { sourceWsId: null },
+    )
+    expect(screen.queryByTestId('inline-tab-host-offline')).not.toBeInTheDocument()
   })
 })
 

--- a/spa/src/features/workspace/components/InlineTab.test.tsx
+++ b/spa/src/features/workspace/components/InlineTab.test.tsx
@@ -153,6 +153,19 @@ describe('InlineTab — visual parity', () => {
     expect(screen.getByTestId('inline-tab-host-offline')).toBeInTheDocument()
   })
 
+  it('hides status slot entirely when tab has no agent status nor subagents', () => {
+    renderWith(mkTab({ hostId: 'host1', sessionCode: 'sc1' }), 'No agent', { sourceWsId: null })
+    expect(screen.queryByTestId('inline-tab-status-slot')).not.toBeInTheDocument()
+  })
+
+  it('shows status slot when agent has a status', () => {
+    useAgentStore.setState({
+      statuses: { 'host1:sc1': 'running' },
+    } as Partial<ReturnType<typeof useAgentStore.getState>> as never)
+    renderWith(mkTab({ hostId: 'host1', sessionCode: 'sc1' }), 'Running', { sourceWsId: null })
+    expect(screen.getByTestId('inline-tab-status-slot')).toBeInTheDocument()
+  })
+
   it('hides WifiSlash when session is terminated', () => {
     useHostStore.setState({
       runtime: { host1: { status: 'disconnected' } },

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -1,8 +1,14 @@
-import { X } from '@phosphor-icons/react'
+import { X, Lock, WifiSlash } from '@phosphor-icons/react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import type { Tab } from '../../../types/tab'
 import { useI18nStore } from '../../../stores/useI18nStore'
+import { useAgentStore } from '../../../stores/useAgentStore'
+import { useHostStore } from '../../../stores/useHostStore'
+import { getPrimaryPane } from '../../../lib/pane-tree'
+import { compositeKey } from '../../../lib/composite-key'
+import { TabStatusDot } from '../../../components/TabStatusDot'
+import { SubagentDots } from '../../../components/SubagentDots'
 
 interface Props {
   tab: Tab
@@ -29,6 +35,21 @@ export function InlineTab({
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: tab.id,
     data: { type: 'tab', tabId: tab.id, sourceWsId, isPinned: tab.pinned },
+  })
+
+  const primaryContent = getPrimaryPane(tab.layout).content
+  const hostId = primaryContent.kind === 'tmux-session' ? primaryContent.hostId : ''
+  const sessionCode = primaryContent.kind === 'tmux-session' ? primaryContent.sessionCode : undefined
+  const ck = sessionCode && hostId ? compositeKey(hostId, sessionCode) : undefined
+  const agentStatus = useAgentStore((s) => (ck ? s.statuses[ck] : undefined))
+  const isUnread = useAgentStore((s) => (ck ? !!s.unread[ck] : false))
+  const subagentCount = useAgentStore((s) => (ck ? (s.subagents[ck]?.length ?? 0) : 0))
+  const isTerminated =
+    primaryContent.kind === 'tmux-session' && !!primaryContent.terminated
+  const isHostOffline = useHostStore((s) => {
+    if (!hostId || isTerminated) return false
+    const rt = s.runtime[hostId]
+    return rt ? rt.status !== 'connected' : false
   })
 
   const style: React.CSSProperties = {
@@ -63,6 +84,8 @@ export function InlineTab({
     }
   }
 
+  const showClose = !tab.locked
+
   return (
     <div
       ref={setNodeRef}
@@ -76,25 +99,48 @@ export function InlineTab({
       onClick={() => onSelect(tab.id)}
       onMouseDown={handleMouseDown}
       onContextMenu={(e) => onContextMenu(e, tab.id)}
-      className={`group flex items-center gap-2 mx-2 pl-5 pr-1.5 py-1 rounded-md text-xs cursor-pointer transition-colors ${
+      className={`group relative flex items-center gap-1.5 mx-2 pl-5 pr-1.5 py-1 rounded-md text-xs cursor-pointer transition-colors ${
         isActive
           ? 'bg-surface-hover text-text-primary ring-1 ring-purple-400/60'
           : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
       }`}
     >
+      <span className="relative inline-flex items-center justify-center w-3 h-3 flex-shrink-0">
+        <TabStatusDot status={agentStatus} style="overlay" isActive={isActive} />
+        {subagentCount > 0 && <SubagentDots count={subagentCount} isActive={isActive} />}
+      </span>
       <span className="flex-1 truncate" title={title}>
         {title}
       </span>
-      <button
-        type="button"
-        aria-label={`Close ${title}`}
-        title={t('common.close')}
-        onClick={handleCloseClick}
-        onMouseDown={(e) => e.stopPropagation()}
-        className="opacity-0 group-hover:opacity-100 rounded p-0.5 hover:bg-surface-secondary hover:text-text-primary"
-      >
-        <X size={12} />
-      </button>
+      {isHostOffline && (
+        <WifiSlash
+          size={12}
+          data-testid="inline-tab-host-offline"
+          className="text-red-400 flex-shrink-0"
+        />
+      )}
+      {tab.locked && (
+        <Lock size={10} data-testid="inline-tab-lock" className="flex-shrink-0" />
+      )}
+      {!isActive && isUnread && (
+        <span
+          data-testid="inline-tab-unread"
+          className="absolute -top-[2px] -right-[2px] w-1.5 h-1.5 rounded-full z-20"
+          style={{ backgroundColor: '#b91c1c' }}
+        />
+      )}
+      {showClose && (
+        <button
+          type="button"
+          aria-label={`Close ${title}`}
+          title={t('common.close')}
+          onClick={handleCloseClick}
+          onMouseDown={(e) => e.stopPropagation()}
+          className="opacity-0 group-hover:opacity-100 rounded p-0.5 hover:bg-surface-secondary hover:text-text-primary"
+        >
+          <X size={12} />
+        </button>
+      )}
     </div>
   )
 }

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -105,10 +105,15 @@ export function InlineTab({
           : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
       }`}
     >
-      <span className="relative inline-flex items-center justify-center w-3 h-3 flex-shrink-0">
-        <TabStatusDot status={agentStatus} style="overlay" isActive={isActive} />
-        {subagentCount > 0 && <SubagentDots count={subagentCount} isActive={isActive} />}
-      </span>
+      {(agentStatus !== undefined || subagentCount > 0) && (
+        <span
+          data-testid="inline-tab-status-slot"
+          className="relative inline-flex items-center justify-center w-3 h-3 flex-shrink-0"
+        >
+          <TabStatusDot status={agentStatus} style="overlay" isActive={isActive} />
+          {subagentCount > 0 && <SubagentDots count={subagentCount} isActive={isActive} />}
+        </span>
+      )}
       <span className="flex-1 truncate" title={title}>
         {title}
       </span>


### PR DESCRIPTION
## Summary

Phase 3 PR C — 讓展開的 \`InlineTab\` 視覺與頂端的 \`SortableTab\` 對齊：agent status dot + subagent dots、離線 host 的 \`WifiSlash\`、unread 紅點、locked 的 \`Lock\` icon + 隱藏 Close button。

## 實作

- \`spa/src/features/workspace/components/InlineTab.tsx\`：訂閱 \`useAgentStore\`（\`statuses\` / \`unread\` / \`subagents\`）＋ \`useHostStore\`（\`runtime\`），依照 \`getPrimaryPane(tab.layout)\` 取得 \`hostId\` / \`sessionCode\` 計算 \`compositeKey\` 再查詢。依 plan 選擇直接 inline 而非抽 shared hook（兩處共用的 ~10 行 subscribe，多一層 hook 不划算）。
- Close button 在 \`tab.locked\` 時不渲染（parity with \`SortableTab\`）。
- Terminated session 時不顯示 \`WifiSlash\`，避免跟 SmileySad 墓碑衝突。

## 測試

- \`cd spa && npx vitest run\` — **1805/1805 passed**（+6 新測試）
- \`cd spa && pnpm run lint\` — 9 pre-existing errors（原 origin/main 就有；issue #412 追蹤）
- 新 6 測試：lock icon / hide-close-when-locked / unread-inactive / hide-unread-when-active / WifiSlash-offline / hide-WifiSlash-terminated
- \`InlineTab.test.tsx\` 的 \`mkTab\` fixture 改用正確 \`PaneLayout\`（\`{ type: 'leaf', pane: { content } }\`），其餘現有 10 測試保持綠。

手動驗證待補：Settings → Appearance → tab position=left 下展開有 agent session 的 workspace，看 status / unread / WifiSlash 是否正常。

Plan: \`docs/superpowers/plans/2026-04-17-phase3-layout-modes.md\` § PR C Task 10。
Closes #401.