### PR TITLE
feat(layout): Phase 3d — cross-workspace DnD + spring-load + pinned guard (#402, #403, #404)

### DIFF
--- a/spa/src/features/workspace/components/ActivityBarWide.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.test.tsx
@@ -146,4 +146,23 @@ describe('ActivityBarWide Phase 2 — inline tabs', () => {
     // getPaneLabel for browser returns hostname
     expect(screen.getByText('example.test')).toBeInTheDocument()
   })
+
+  it('registers home-header and ws-header-<id> as droppable testids', () => {
+    render(
+      <ActivityBarWide
+        workspaces={[ws('w1', 'Alpha'), ws('w2', 'Beta')]}
+        activeWorkspaceId={null}
+        activeStandaloneTabId={null}
+        onSelectWorkspace={() => {}}
+        onSelectHome={() => {}}
+        standaloneTabIds={[]}
+        onAddWorkspace={() => {}}
+        onOpenHosts={() => {}}
+        onOpenSettings={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('home-header')).toBeInTheDocument()
+    expect(screen.getByTestId('ws-header-w1')).toBeInTheDocument()
+    expect(screen.getByTestId('ws-header-w2')).toBeInTheDocument()
+  })
 })

--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -65,6 +65,8 @@ export function ActivityBarWide(props: ActivityBarProps) {
     onReorderWorkspaceTabs,
     onReorderStandaloneTabs,
     onAddTabToWorkspace,
+    onMoveTabToWorkspace,
+    onMoveTabToStandalone,
   } = props
 
   const t = useI18nStore((s) => s.t)
@@ -92,28 +94,58 @@ export function ActivityBarWide(props: ActivityBarProps) {
   const insertTab = useWorkspaceStore((s) => s.insertTab)
   const removeTabFromWorkspace = useWorkspaceStore((s) => s.removeTabFromWorkspace)
   const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace)
-  const globalActiveTabId = useTabStore((s) => s.activeTabId)
   const toggleWorkspaceExpanded = useLayoutStore((s) => s.toggleWorkspaceExpanded)
   const springLoad = useSpringLoad(500)
 
+  // Read activeTabId via getState() at dispatch time rather than via closure,
+  // mirroring the stale-closure fix applied to the resize handler in PR #392.
+  // Default behavior mutates the store directly; callers that need to
+  // intercept (e.g. workspace-locked mode) can pass onMoveTabToWorkspace /
+  // onMoveTabToStandalone via props.
   const handleMoveTabToWorkspace = useCallback(
     (tabId: string, targetWsId: string, afterTabId: string | null) => {
+      if (onMoveTabToWorkspace) {
+        onMoveTabToWorkspace(tabId, targetWsId, afterTabId)
+        return
+      }
+      const wsStore = useWorkspaceStore.getState()
+      const sourceWs = wsStore.findWorkspaceByTab(tabId)
+      const sourceWsId = sourceWs?.id ?? null
       insertTab(tabId, targetWsId, afterTabId)
-      if (tabId === globalActiveTabId) {
+      const movedActiveTab = tabId === useTabStore.getState().activeTabId
+      const sourceBecameEmpty =
+        sourceWsId !== null &&
+        sourceWsId !== targetWsId &&
+        (useWorkspaceStore.getState().workspaces.find((w) => w.id === sourceWsId)?.tabs.length ?? 0) === 0
+      // Follow the moved tab if it was the global active, or if the source
+      // workspace we just vacated was the one currently selected — otherwise
+      // the user would stay on an empty workspace with no tabs to show.
+      if (movedActiveTab) {
+        setActiveWorkspace(targetWsId)
+      } else if (sourceBecameEmpty && wsStore.activeWorkspaceId === sourceWsId) {
         setActiveWorkspace(targetWsId)
       }
     },
-    [insertTab, setActiveWorkspace, globalActiveTabId],
+    [insertTab, setActiveWorkspace, onMoveTabToWorkspace],
   )
 
   const handleMoveTabToStandalone = useCallback(
     (tabId: string, sourceWsId: string) => {
+      if (onMoveTabToStandalone) {
+        onMoveTabToStandalone(tabId, sourceWsId)
+        return
+      }
+      const wsStore = useWorkspaceStore.getState()
+      const wasSourceActive = wsStore.activeWorkspaceId === sourceWsId
       removeTabFromWorkspace(sourceWsId, tabId)
-      if (tabId === globalActiveTabId) {
+      const movedActiveTab = tabId === useTabStore.getState().activeTabId
+      const sourceBecameEmpty =
+        (useWorkspaceStore.getState().workspaces.find((w) => w.id === sourceWsId)?.tabs.length ?? 0) === 0
+      if (movedActiveTab || (wasSourceActive && sourceBecameEmpty)) {
         setActiveWorkspace(null)
       }
     },
-    [removeTabFromWorkspace, setActiveWorkspace, globalActiveTabId],
+    [removeTabFromWorkspace, setActiveWorkspace, onMoveTabToStandalone],
   )
 
   const scheduleSpringLoad = useCallback(

--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -10,13 +10,19 @@ import {
   closestCenter,
   type CollisionDetection,
   type DragEndEvent,
+  type DragOverEvent,
 } from '@dnd-kit/core'
 import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { useI18nStore } from '../../../stores/useI18nStore'
-import { useLayoutStore, MIN_WIDTH, MAX_WIDTH } from '../../../stores/useLayoutStore'
+import {
+  useLayoutStore,
+  MIN_WIDTH,
+  MAX_WIDTH,
+  HOME_WS_KEY,
+} from '../../../stores/useLayoutStore'
 import { useWorkspaceStore } from '../store'
 import { useTabStore } from '../../../stores/useTabStore'
 import { RegionResize } from '../../../components/RegionResize'
@@ -24,7 +30,8 @@ import { CollapseButton } from './CollapseButton'
 import { WorkspaceRow } from './WorkspaceRow'
 import { HomeRow } from './HomeRow'
 import type { ActivityBarProps } from './activity-bar-props'
-import { computeDragEndAction, dispatchDragEndAction } from '../lib/computeDragEndAction'
+import { computeDragEndAction, dispatchDragEndAction, type DragData } from '../lib/computeDragEndAction'
+import { useSpringLoad } from '../lib/useSpringLoad'
 
 const customCollisionDetection: CollisionDetection = (args) => {
   const pw = pointerWithin(args)
@@ -86,6 +93,8 @@ export function ActivityBarWide(props: ActivityBarProps) {
   const removeTabFromWorkspace = useWorkspaceStore((s) => s.removeTabFromWorkspace)
   const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace)
   const globalActiveTabId = useTabStore((s) => s.activeTabId)
+  const toggleWorkspaceExpanded = useLayoutStore((s) => s.toggleWorkspaceExpanded)
+  const springLoad = useSpringLoad(500)
 
   const handleMoveTabToWorkspace = useCallback(
     (tabId: string, targetWsId: string, afterTabId: string | null) => {
@@ -107,8 +116,73 @@ export function ActivityBarWide(props: ActivityBarProps) {
     [removeTabFromWorkspace, setActiveWorkspace, globalActiveTabId],
   )
 
+  const scheduleSpringLoad = useCallback(
+    (key: string) => {
+      springLoad.schedule(key, () => {
+        // Re-check expanded state at fire time so a user who manually
+        // expanded the row during the hover doesn't get collapsed back.
+        if (!useLayoutStore.getState().workspaceExpanded[key]) {
+          toggleWorkspaceExpanded(key)
+        }
+      })
+    },
+    [springLoad, toggleWorkspaceExpanded],
+  )
+
+  const handleDragStart = useCallback(() => {
+    springLoad.cancel()
+  }, [springLoad])
+
+  const handleDragOver = useCallback(
+    (e: DragOverEvent) => {
+      const { over, active } = e
+      if (!over || !active.data.current) {
+        springLoad.cancel()
+        return
+      }
+      const activeData = active.data.current as DragData
+      if (activeData.type !== 'tab') {
+        springLoad.cancel()
+        return
+      }
+      const overData = over.data.current as DragData | undefined
+      if (!overData) {
+        springLoad.cancel()
+        return
+      }
+
+      // Pinned tab is locked to its own workspace; any header / cross-ws target
+      // is a forbidden drop, so don't auto-expand into one.
+      if (activeData.isPinned) {
+        springLoad.cancel()
+        return
+      }
+
+      if (overData.type === 'workspace-header') {
+        const key = overData.wsId
+        if (!useLayoutStore.getState().workspaceExpanded[key]) {
+          scheduleSpringLoad(key)
+        } else {
+          springLoad.cancel(key)
+        }
+        return
+      }
+      if (overData.type === 'home-header') {
+        if (!useLayoutStore.getState().workspaceExpanded[HOME_WS_KEY]) {
+          scheduleSpringLoad(HOME_WS_KEY)
+        } else {
+          springLoad.cancel(HOME_WS_KEY)
+        }
+        return
+      }
+      springLoad.cancel()
+    },
+    [springLoad, scheduleSpringLoad],
+  )
+
   const handleDragEnd = useCallback(
     (e: DragEndEvent) => {
+      springLoad.cancel()
       const action = computeDragEndAction(e, { wsIds, workspaces, standaloneTabIds })
       dispatchDragEndAction(action, {
         onReorderWorkspaces,
@@ -127,6 +201,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
       onReorderStandaloneTabs,
       handleMoveTabToWorkspace,
       handleMoveTabToStandalone,
+      springLoad,
     ],
   )
 
@@ -139,6 +214,8 @@ export function ActivityBarWide(props: ActivityBarProps) {
         <DndContext
           sensors={sensors}
           collisionDetection={customCollisionDetection}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
           onDragEnd={handleDragEnd}
         >
           <HomeRow

--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -5,7 +5,10 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
+  pointerWithin,
+  rectIntersection,
   closestCenter,
+  type CollisionDetection,
   type DragEndEvent,
 } from '@dnd-kit/core'
 import {
@@ -14,12 +17,22 @@ import {
 } from '@dnd-kit/sortable'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { useLayoutStore, MIN_WIDTH, MAX_WIDTH } from '../../../stores/useLayoutStore'
+import { useWorkspaceStore } from '../store'
+import { useTabStore } from '../../../stores/useTabStore'
 import { RegionResize } from '../../../components/RegionResize'
 import { CollapseButton } from './CollapseButton'
 import { WorkspaceRow } from './WorkspaceRow'
 import { HomeRow } from './HomeRow'
 import type { ActivityBarProps } from './activity-bar-props'
 import { computeDragEndAction, dispatchDragEndAction } from '../lib/computeDragEndAction'
+
+const customCollisionDetection: CollisionDetection = (args) => {
+  const pw = pointerWithin(args)
+  if (pw.length > 0) return pw
+  const ri = rectIntersection(args)
+  if (ri.length > 0) return ri
+  return closestCenter(args)
+}
 
 const NOOP = () => {}
 
@@ -69,6 +82,31 @@ export function ActivityBarWide(props: ActivityBarProps) {
   const contextMenuTab = onContextMenuTab ?? NOOP
   const addTabToWs = onAddTabToWorkspace ?? NOOP
 
+  const insertTab = useWorkspaceStore((s) => s.insertTab)
+  const removeTabFromWorkspace = useWorkspaceStore((s) => s.removeTabFromWorkspace)
+  const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace)
+  const globalActiveTabId = useTabStore((s) => s.activeTabId)
+
+  const handleMoveTabToWorkspace = useCallback(
+    (tabId: string, targetWsId: string, afterTabId: string | null) => {
+      insertTab(tabId, targetWsId, afterTabId)
+      if (tabId === globalActiveTabId) {
+        setActiveWorkspace(targetWsId)
+      }
+    },
+    [insertTab, setActiveWorkspace, globalActiveTabId],
+  )
+
+  const handleMoveTabToStandalone = useCallback(
+    (tabId: string, sourceWsId: string) => {
+      removeTabFromWorkspace(sourceWsId, tabId)
+      if (tabId === globalActiveTabId) {
+        setActiveWorkspace(null)
+      }
+    },
+    [removeTabFromWorkspace, setActiveWorkspace, globalActiveTabId],
+  )
+
   const handleDragEnd = useCallback(
     (e: DragEndEvent) => {
       const action = computeDragEndAction(e, { wsIds, workspaces, standaloneTabIds })
@@ -76,6 +114,8 @@ export function ActivityBarWide(props: ActivityBarProps) {
         onReorderWorkspaces,
         onReorderStandaloneTabs,
         onReorderWorkspaceTabs,
+        onMoveTabToWorkspace: handleMoveTabToWorkspace,
+        onMoveTabToStandalone: handleMoveTabToStandalone,
       })
     },
     [
@@ -85,6 +125,8 @@ export function ActivityBarWide(props: ActivityBarProps) {
       onReorderWorkspaces,
       onReorderWorkspaceTabs,
       onReorderStandaloneTabs,
+      handleMoveTabToWorkspace,
+      handleMoveTabToStandalone,
     ],
   )
 
@@ -96,7 +138,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
       >
         <DndContext
           sensors={sensors}
-          collisionDetection={closestCenter}
+          collisionDetection={customCollisionDetection}
           onDragEnd={handleDragEnd}
         >
           <HomeRow

--- a/spa/src/features/workspace/components/HomeRow.test.tsx
+++ b/spa/src/features/workspace/components/HomeRow.test.tsx
@@ -73,4 +73,11 @@ describe('HomeRow', () => {
     fireEvent.click(chevron)
     expect(useLayoutStore.getState().workspaceExpanded['home']).toBe(true)
   })
+
+  describe('droppable header (Phase 3 PR D)', () => {
+    it('exposes header with data-testid=home-header for drop target lookup', () => {
+      renderRow()
+      expect(screen.getByTestId('home-header')).toBeInTheDocument()
+    })
+  })
 })

--- a/spa/src/features/workspace/components/HomeRow.tsx
+++ b/spa/src/features/workspace/components/HomeRow.tsx
@@ -1,4 +1,5 @@
 import { CaretRight, CaretDown } from '@phosphor-icons/react'
+import { useDroppable } from '@dnd-kit/core'
 import type { Tab } from '../../../types/tab'
 import { useLayoutStore, HOME_WS_KEY } from '../../../stores/useLayoutStore'
 import { useI18nStore } from '../../../stores/useI18nStore'
@@ -32,17 +33,24 @@ export function HomeRow(props: Props) {
   const expanded = useLayoutStore((s) => !!s.workspaceExpanded[HOME_WS_KEY])
   const toggleExpanded = useLayoutStore((s) => s.toggleWorkspaceExpanded)
 
+  const { setNodeRef: setHeaderDropRef, isOver: isHeaderOver } = useDroppable({
+    id: 'home-header',
+    data: { type: 'home-header' },
+  })
+
   const Chevron = expanded ? CaretDown : CaretRight
   const chevronLabel = expanded ? 'Collapse Home' : 'Expand Home'
 
   return (
     <div className="flex flex-col">
       <div
+        ref={setHeaderDropRef}
+        data-testid="home-header"
         className={`mx-2 flex items-center gap-1 pr-1.5 rounded-md text-sm transition-colors ${
           isActive
             ? 'bg-surface-hover text-text-primary ring-1 ring-purple-400'
             : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
-        }`}
+        } ${isHeaderOver ? 'ring-2 ring-purple-400/80 bg-surface-hover' : ''}`}
       >
         <button
           type="button"

--- a/spa/src/features/workspace/components/WorkspaceRow.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.test.tsx
@@ -96,6 +96,13 @@ describe('WorkspaceRow', () => {
     expect(onAdd).toHaveBeenCalledWith('ws-1')
   })
 
+  describe('droppable header (Phase 3 PR D)', () => {
+    it('exposes header with data-testid=ws-header-<id> for drop target lookup', () => {
+      renderRow(mkWs('ws-1', 'Alpha'))
+      expect(screen.getByTestId('ws-header-ws-1')).toBeInTheDocument()
+    })
+  })
+
   describe('drag-steals-click guard', () => {
     it('name button stops pointer-down propagation so dnd-kit drag does not start on click', () => {
       renderRow(mkWs('ws-1', 'Alpha'))

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -1,4 +1,5 @@
 import { CaretRight, CaretDown, Plus } from '@phosphor-icons/react'
+import { useDroppable } from '@dnd-kit/core'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import type { Workspace, Tab } from '../../../types/tab'
@@ -44,6 +45,11 @@ export function WorkspaceRow(props: Props) {
     data: { type: 'workspace', wsId: workspace.id },
   })
 
+  const { setNodeRef: setHeaderDropRef, isOver: isHeaderOver } = useDroppable({
+    id: `ws-header-${workspace.id}`,
+    data: { type: 'workspace-header', wsId: workspace.id },
+  })
+
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -58,13 +64,15 @@ export function WorkspaceRow(props: Props) {
   return (
     <div ref={setNodeRef} style={style} className="flex flex-col">
       <div
+        ref={setHeaderDropRef}
+        data-testid={`ws-header-${workspace.id}`}
         {...attributes}
         {...listeners}
         className={`mx-2 flex items-center gap-1 pr-1.5 rounded-md text-sm transition-colors ${
           isActive
             ? 'bg-[#8b5cf6]/25 text-text-primary ring-1 ring-purple-400'
             : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
-        }`}
+        } ${isHeaderOver ? 'ring-2 ring-purple-400/80 bg-surface-hover' : ''}`}
       >
         <button
           type="button"

--- a/spa/src/features/workspace/components/activity-bar-props.ts
+++ b/spa/src/features/workspace/components/activity-bar-props.ts
@@ -29,4 +29,10 @@ export interface ActivityBarProps {
   onReorderWorkspaceTabs?: (wsId: string, tabIds: string[]) => void
   onReorderStandaloneTabs?: (tabIds: string[]) => void
   onAddTabToWorkspace?: (wsId: string) => void
+
+  // Phase 3 PR D — cross-workspace DnD.
+  // Default: ActivityBarWide calls the workspace store directly. Pass a
+  // handler here to intercept or veto (e.g. workspace-locked mode).
+  onMoveTabToWorkspace?: (tabId: string, targetWsId: string, afterTabId: string | null) => void
+  onMoveTabToStandalone?: (tabId: string, sourceWsId: string) => void
 }

--- a/spa/src/features/workspace/lib/computeDragEndAction.test.ts
+++ b/spa/src/features/workspace/lib/computeDragEndAction.test.ts
@@ -63,22 +63,11 @@ describe('computeDragEndAction', () => {
       expect(action).toEqual({ kind: 'noop' })
     })
 
-    it('tab dropped on non-tab target → noop (Phase 3 handles cross-zone later)', () => {
+    it('tab dropped on workspace-row sortable (not header) → noop', () => {
       const action = computeDragEndAction(
         mkEvent(
           { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1' } },
           { id: 'w2', data: { type: 'workspace', wsId: 'w2' } },
-        ),
-        ctx(),
-      )
-      expect(action).toEqual({ kind: 'noop' })
-    })
-
-    it('tab dropped on tab in different workspace → noop', () => {
-      const action = computeDragEndAction(
-        mkEvent(
-          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1' } },
-          { id: 't2a', data: { type: 'tab', tabId: 't2a', sourceWsId: 'w2' } },
         ),
         ctx(),
       )
@@ -172,6 +161,146 @@ describe('computeDragEndAction', () => {
       expect(action).toEqual({ kind: 'noop' })
     })
   })
+
+  describe('cross-ws (Phase 3 PR D)', () => {
+    it('tab → another ws tab-slot → move-tab-to-workspace afterTabId=targetTab', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1' } },
+          { id: 't2a', data: { type: 'tab', tabId: 't2a', sourceWsId: 'w2' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({
+        kind: 'move-tab-to-workspace',
+        tabId: 't1a',
+        targetWsId: 'w2',
+        afterTabId: 't2a',
+      })
+    })
+
+    it('tab → workspace-header drop target → move-tab-to-workspace afterTabId=null (prepend)', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1' } },
+          { id: 'ws-header-w2', data: { type: 'workspace-header', wsId: 'w2' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({
+        kind: 'move-tab-to-workspace',
+        tabId: 't1a',
+        targetWsId: 'w2',
+        afterTabId: null,
+      })
+    })
+
+    it('tab → home-header drop target → move-tab-to-standalone', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1' } },
+          { id: 'home-header', data: { type: 'home-header' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({
+        kind: 'move-tab-to-standalone',
+        tabId: 't1a',
+        sourceWsId: 'w1',
+      })
+    })
+
+    it('standalone tab → workspace-header → move-tab-to-workspace afterTabId=null', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 'sA', data: { type: 'tab', tabId: 'sA', sourceWsId: null } },
+          { id: 'ws-header-w2', data: { type: 'workspace-header', wsId: 'w2' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({
+        kind: 'move-tab-to-workspace',
+        tabId: 'sA',
+        targetWsId: 'w2',
+        afterTabId: null,
+      })
+    })
+
+    it('standalone tab → other ws tab-slot → move-tab-to-workspace afterTabId=targetTab', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 'sA', data: { type: 'tab', tabId: 'sA', sourceWsId: null } },
+          { id: 't2a', data: { type: 'tab', tabId: 't2a', sourceWsId: 'w2' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({
+        kind: 'move-tab-to-workspace',
+        tabId: 'sA',
+        targetWsId: 'w2',
+        afterTabId: 't2a',
+      })
+    })
+
+    it('standalone tab → home-header → noop (already standalone)', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 'sA', data: { type: 'tab', tabId: 'sA', sourceWsId: null } },
+          { id: 'home-header', data: { type: 'home-header' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
+    it('pinned tab → other ws tab-slot → noop (#404)', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1', isPinned: true } },
+          { id: 't2a', data: { type: 'tab', tabId: 't2a', sourceWsId: 'w2' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
+    it('pinned tab → workspace-header → noop (#404)', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1', isPinned: true } },
+          { id: 'ws-header-w2', data: { type: 'workspace-header', wsId: 'w2' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
+    it('pinned tab → home-header → noop (#404)', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1', isPinned: true } },
+          { id: 'home-header', data: { type: 'home-header' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
+    it('pinned tab same-ws reorder still works (#404)', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1', isPinned: true } },
+          { id: 't1b', data: { type: 'tab', tabId: 't1b', sourceWsId: 'w1' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({
+        kind: 'reorder-workspace-tabs',
+        wsId: 'w1',
+        order: ['t1b', 't1a'],
+      })
+    })
+  })
 })
 
 describe('dispatchDragEndAction', () => {
@@ -217,5 +346,32 @@ describe('dispatchDragEndAction', () => {
   it('tolerates missing callbacks (optional chaining)', () => {
     const action: DragEndAction = { kind: 'reorder-workspaces', order: ['a'] }
     expect(() => dispatchDragEndAction(action, {})).not.toThrow()
+  })
+
+  it('dispatches move-tab-to-workspace with tabId, targetWsId, afterTabId', () => {
+    const d = { onMoveTabToWorkspace: vi.fn() }
+    dispatchDragEndAction(
+      { kind: 'move-tab-to-workspace', tabId: 't1', targetWsId: 'w2', afterTabId: null },
+      d,
+    )
+    expect(d.onMoveTabToWorkspace).toHaveBeenCalledWith('t1', 'w2', null)
+  })
+
+  it('dispatches move-tab-to-workspace with non-null afterTabId', () => {
+    const d = { onMoveTabToWorkspace: vi.fn() }
+    dispatchDragEndAction(
+      { kind: 'move-tab-to-workspace', tabId: 't1', targetWsId: 'w2', afterTabId: 't2' },
+      d,
+    )
+    expect(d.onMoveTabToWorkspace).toHaveBeenCalledWith('t1', 'w2', 't2')
+  })
+
+  it('dispatches move-tab-to-standalone with tabId and sourceWsId', () => {
+    const d = { onMoveTabToStandalone: vi.fn() }
+    dispatchDragEndAction(
+      { kind: 'move-tab-to-standalone', tabId: 't1', sourceWsId: 'w1' },
+      d,
+    )
+    expect(d.onMoveTabToStandalone).toHaveBeenCalledWith('t1', 'w1')
   })
 })

--- a/spa/src/features/workspace/lib/computeDragEndAction.test.ts
+++ b/spa/src/features/workspace/lib/computeDragEndAction.test.ts
@@ -179,6 +179,17 @@ describe('computeDragEndAction', () => {
       })
     })
 
+    it('tab → own workspace-header drop target → noop (no phantom move)', () => {
+      const action = computeDragEndAction(
+        mkEvent(
+          { id: 't1a', data: { type: 'tab', tabId: 't1a', sourceWsId: 'w1' } },
+          { id: 'ws-header-w1', data: { type: 'workspace-header', wsId: 'w1' } },
+        ),
+        ctx(),
+      )
+      expect(action).toEqual({ kind: 'noop' })
+    })
+
     it('tab → workspace-header drop target → move-tab-to-workspace afterTabId=null (prepend)', () => {
       const action = computeDragEndAction(
         mkEvent(

--- a/spa/src/features/workspace/lib/computeDragEndAction.ts
+++ b/spa/src/features/workspace/lib/computeDragEndAction.ts
@@ -110,7 +110,11 @@ export function computeDragEndAction(
   }
 
   // Workspace header drop target → prepend to that workspace.
+  // Dropping a tab onto its own workspace header is a no-op — the tab already
+  // lives there, and falling through would call insertTab unnecessarily and
+  // flicker activeTabId without moving anything.
   if (overData.type === 'workspace-header') {
+    if (overData.wsId === activeData.sourceWsId) return NOOP
     return {
       kind: 'move-tab-to-workspace',
       tabId: activeData.tabId,

--- a/spa/src/features/workspace/lib/computeDragEndAction.ts
+++ b/spa/src/features/workspace/lib/computeDragEndAction.ts
@@ -8,13 +8,26 @@ export type TabDragData = {
   sourceWsId: string | null
   isPinned?: boolean
 }
-export type DragData = WorkspaceDragData | TabDragData
+export type WorkspaceHeaderDropData = { type: 'workspace-header'; wsId: string }
+export type HomeHeaderDropData = { type: 'home-header' }
+export type DragData =
+  | WorkspaceDragData
+  | TabDragData
+  | WorkspaceHeaderDropData
+  | HomeHeaderDropData
 
 export type DragEndAction =
   | { kind: 'noop' }
   | { kind: 'reorder-workspaces'; order: string[] }
   | { kind: 'reorder-standalone-tabs'; order: string[] }
   | { kind: 'reorder-workspace-tabs'; wsId: string; order: string[] }
+  | {
+      kind: 'move-tab-to-workspace'
+      tabId: string
+      targetWsId: string
+      afterTabId: string | null
+    }
+  | { kind: 'move-tab-to-standalone'; tabId: string; sourceWsId: string }
 
 export interface DragEndContext {
   wsIds: string[]
@@ -42,12 +55,22 @@ export function computeDragEndAction(
     return { kind: 'reorder-workspaces', order: arrayMove(ctx.wsIds, oldIndex, newIndex) }
   }
 
-  if (activeData.type === 'tab') {
-    // Phase 3 will handle cross-zone drops; for now require tab → tab in same zone.
-    if (!overData || overData.type !== 'tab') return NOOP
-    if (activeData.sourceWsId !== overData.sourceWsId) return NOOP
+  if (activeData.type !== 'tab') return NOOP
+  if (!overData) return NOOP
 
-    if (activeData.sourceWsId === null) {
+  // #404 — pinned tab may only reorder within its own workspace.
+  // Same-ws tab-slot drop falls through to the reorder branch below;
+  // every other drop target is rejected.
+  if (activeData.isPinned) {
+    const isSameWsTabDrop =
+      overData.type === 'tab' && overData.sourceWsId === activeData.sourceWsId
+    if (!isSameWsTabDrop) return NOOP
+  }
+
+  // Same-zone tab reorder
+  if (overData.type === 'tab' && overData.sourceWsId === activeData.sourceWsId) {
+    const sourceWsId = activeData.sourceWsId
+    if (sourceWsId === null) {
       const oldIdx = ctx.standaloneTabIds.indexOf(activeData.tabId)
       const newIdx = ctx.standaloneTabIds.indexOf(overData.tabId)
       if (oldIdx === -1 || newIdx === -1) return NOOP
@@ -56,17 +79,53 @@ export function computeDragEndAction(
         order: arrayMove(ctx.standaloneTabIds, oldIdx, newIdx),
       }
     }
-
-    const wsId = activeData.sourceWsId
-    const ws = ctx.workspaces.find((w) => w.id === wsId)
+    const ws = ctx.workspaces.find((w) => w.id === sourceWsId)
     if (!ws) return NOOP
     const oldIdx = ws.tabs.indexOf(activeData.tabId)
     const newIdx = ws.tabs.indexOf(overData.tabId)
     if (oldIdx === -1 || newIdx === -1) return NOOP
     return {
       kind: 'reorder-workspace-tabs',
-      wsId,
+      wsId: sourceWsId,
       order: arrayMove(ws.tabs, oldIdx, newIdx),
+    }
+  }
+
+  // Cross-zone: tab dropped on a tab of another ws / standalone zone.
+  if (overData.type === 'tab' && overData.sourceWsId !== activeData.sourceWsId) {
+    if (overData.sourceWsId === null) {
+      if (activeData.sourceWsId === null) return NOOP
+      return {
+        kind: 'move-tab-to-standalone',
+        tabId: activeData.tabId,
+        sourceWsId: activeData.sourceWsId,
+      }
+    }
+    return {
+      kind: 'move-tab-to-workspace',
+      tabId: activeData.tabId,
+      targetWsId: overData.sourceWsId,
+      afterTabId: overData.tabId,
+    }
+  }
+
+  // Workspace header drop target → prepend to that workspace.
+  if (overData.type === 'workspace-header') {
+    return {
+      kind: 'move-tab-to-workspace',
+      tabId: activeData.tabId,
+      targetWsId: overData.wsId,
+      afterTabId: null,
+    }
+  }
+
+  // Home header drop target → make tab standalone.
+  if (overData.type === 'home-header') {
+    if (activeData.sourceWsId === null) return NOOP
+    return {
+      kind: 'move-tab-to-standalone',
+      tabId: activeData.tabId,
+      sourceWsId: activeData.sourceWsId,
     }
   }
 
@@ -77,6 +136,8 @@ export interface DragEndDispatch {
   onReorderWorkspaces?: (order: string[]) => void
   onReorderStandaloneTabs?: (order: string[]) => void
   onReorderWorkspaceTabs?: (wsId: string, order: string[]) => void
+  onMoveTabToWorkspace?: (tabId: string, targetWsId: string, afterTabId: string | null) => void
+  onMoveTabToStandalone?: (tabId: string, sourceWsId: string) => void
 }
 
 export function dispatchDragEndAction(action: DragEndAction, d: DragEndDispatch): void {
@@ -90,11 +151,15 @@ export function dispatchDragEndAction(action: DragEndAction, d: DragEndDispatch)
     case 'reorder-workspace-tabs':
       d.onReorderWorkspaceTabs?.(action.wsId, action.order)
       return
+    case 'move-tab-to-workspace':
+      d.onMoveTabToWorkspace?.(action.tabId, action.targetWsId, action.afterTabId)
+      return
+    case 'move-tab-to-standalone':
+      d.onMoveTabToStandalone?.(action.tabId, action.sourceWsId)
+      return
     case 'noop':
       return
     default: {
-      // Exhaustiveness check: adding a new DragEndAction kind forces a TS error
-      // here until dispatchDragEndAction is updated to handle it.
       const _exhaustive: never = action
       void _exhaustive
       return

--- a/spa/src/features/workspace/lib/useSpringLoad.test.ts
+++ b/spa/src/features/workspace/lib/useSpringLoad.test.ts
@@ -102,4 +102,24 @@ describe('useSpringLoad', () => {
     })
     expect(onExpire).not.toHaveBeenCalled()
   })
+
+  it('unmount still cancels pending timer after delayMs changed across renders', () => {
+    // timerRef must be stable across renders so the unmount cleanup always
+    // observes the latest scheduled id, even if the caller changed delayMs.
+    vi.useFakeTimers()
+    const onExpire = vi.fn()
+    const { result, rerender, unmount } = renderHook(
+      ({ delay }: { delay: number }) => useSpringLoad(delay),
+      { initialProps: { delay: 500 } },
+    )
+    act(() => result.current.schedule('a', onExpire))
+    rerender({ delay: 1000 })
+    // Re-schedule after delayMs change — new timer id must be tracked.
+    act(() => result.current.schedule('a', onExpire))
+    unmount()
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(onExpire).not.toHaveBeenCalled()
+  })
 })

--- a/spa/src/features/workspace/lib/useSpringLoad.test.ts
+++ b/spa/src/features/workspace/lib/useSpringLoad.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useSpringLoad } from './useSpringLoad'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useSpringLoad', () => {
+  it('fires onExpire after delay', () => {
+    vi.useFakeTimers()
+    const onExpire = vi.fn()
+    const { result } = renderHook(() => useSpringLoad(500))
+    act(() => result.current.schedule('w1', onExpire))
+    expect(onExpire).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(onExpire).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancel prevents firing', () => {
+    vi.useFakeTimers()
+    const onExpire = vi.fn()
+    const { result } = renderHook(() => useSpringLoad(500))
+    act(() => result.current.schedule('w1', onExpire))
+    act(() => result.current.cancel('w1'))
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(onExpire).not.toHaveBeenCalled()
+  })
+
+  it('schedule with different key cancels previous', () => {
+    vi.useFakeTimers()
+    const onA = vi.fn()
+    const onB = vi.fn()
+    const { result } = renderHook(() => useSpringLoad(500))
+    act(() => result.current.schedule('a', onA))
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    act(() => result.current.schedule('b', onB))
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(onA).not.toHaveBeenCalled()
+    expect(onB).toHaveBeenCalledTimes(1)
+  })
+
+  it('schedule same key resets timer', () => {
+    vi.useFakeTimers()
+    const onExpire = vi.fn()
+    const { result } = renderHook(() => useSpringLoad(500))
+    act(() => result.current.schedule('a', onExpire))
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+    act(() => result.current.schedule('a', onExpire))
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+    expect(onExpire).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    expect(onExpire).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancel() without key clears all', () => {
+    vi.useFakeTimers()
+    const onExpire = vi.fn()
+    const { result } = renderHook(() => useSpringLoad(500))
+    act(() => result.current.schedule('a', onExpire))
+    act(() => result.current.cancel())
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(onExpire).not.toHaveBeenCalled()
+  })
+
+  it('cancel(mismatched key) is a no-op (does not cancel active timer)', () => {
+    vi.useFakeTimers()
+    const onExpire = vi.fn()
+    const { result } = renderHook(() => useSpringLoad(500))
+    act(() => result.current.schedule('a', onExpire))
+    act(() => result.current.cancel('other-key'))
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(onExpire).toHaveBeenCalledTimes(1)
+  })
+
+  it('unmount cancels pending timer', () => {
+    vi.useFakeTimers()
+    const onExpire = vi.fn()
+    const { result, unmount } = renderHook(() => useSpringLoad(500))
+    act(() => result.current.schedule('a', onExpire))
+    unmount()
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(onExpire).not.toHaveBeenCalled()
+  })
+})

--- a/spa/src/features/workspace/lib/useSpringLoad.ts
+++ b/spa/src/features/workspace/lib/useSpringLoad.ts
@@ -30,6 +30,9 @@ export function useSpringLoad(delayMs: number): SpringLoadHook {
     [delayMs],
   )
 
+  // timerRef is a stable mutable ref, so the unmount cleanup always reads
+  // the most recently scheduled id — empty deps are intentional and safe
+  // even if delayMs changes across renders.
   useEffect(() => {
     return () => {
       if (timerRef.current) {

--- a/spa/src/features/workspace/lib/useSpringLoad.ts
+++ b/spa/src/features/workspace/lib/useSpringLoad.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+export interface SpringLoadHook {
+  schedule: (key: string, onExpire: () => void) => void
+  cancel: (key?: string) => void
+}
+
+export function useSpringLoad(delayMs: number): SpringLoadHook {
+  const timerRef = useRef<{ key: string; id: ReturnType<typeof setTimeout> } | null>(null)
+
+  const cancel = useCallback((key?: string) => {
+    if (!timerRef.current) return
+    if (key !== undefined && timerRef.current.key !== key) return
+    clearTimeout(timerRef.current.id)
+    timerRef.current = null
+  }, [])
+
+  const schedule = useCallback(
+    (key: string, onExpire: () => void) => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current.id)
+        timerRef.current = null
+      }
+      const id = setTimeout(() => {
+        timerRef.current = null
+        onExpire()
+      }, delayMs)
+      timerRef.current = { key, id }
+    },
+    [delayMs],
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current.id)
+        timerRef.current = null
+      }
+    }
+  }, [])
+
+  return { schedule, cancel }
+}

--- a/spa/src/features/workspace/store-tabs.test.ts
+++ b/spa/src/features/workspace/store-tabs.test.ts
@@ -427,5 +427,24 @@ describe('useWorkspaceStore', () => {
       const ws = useWorkspaceStore.getState().workspaces.find((w) => w.id === wsId)!
       expect(ws.tabs).toEqual(['a', 'x'])
     })
+
+    it('afterTabId=null prepends to front', () => {
+      useWorkspaceStore.getState().addWorkspace('test')
+      const wsId = useWorkspaceStore.getState().workspaces[0].id
+      useWorkspaceStore.getState().insertTab('a', wsId)
+      useWorkspaceStore.getState().insertTab('b', wsId)
+      useWorkspaceStore.getState().insertTab('x', wsId, null)
+      const ws = useWorkspaceStore.getState().workspaces.find((w) => w.id === wsId)!
+      expect(ws.tabs).toEqual(['x', 'a', 'b'])
+    })
+
+    it('afterTabId=undefined still appends (existing behavior)', () => {
+      useWorkspaceStore.getState().addWorkspace('test')
+      const wsId = useWorkspaceStore.getState().workspaces[0].id
+      useWorkspaceStore.getState().insertTab('a', wsId)
+      useWorkspaceStore.getState().insertTab('x', wsId)
+      const ws = useWorkspaceStore.getState().workspaces.find((w) => w.id === wsId)!
+      expect(ws.tabs).toEqual(['a', 'x'])
+    })
   })
 })

--- a/spa/src/features/workspace/store-tabs.test.ts
+++ b/spa/src/features/workspace/store-tabs.test.ts
@@ -91,6 +91,18 @@ describe('useWorkspaceStore', () => {
 
   // === insertTab edge cases ===
 
+  it('insertTab with nonexistent wsId does not orphan the tab from its source workspace', () => {
+    // Regression for concurrent-delete race: caller drags tab from ws1 to
+    // ws2, but ws2 was deleted in another session before the drop lands.
+    // insertTab must abort entirely rather than running the dedup branch,
+    // which would remove the tab from ws1 and leave it in no workspace.
+    const ws1 = useWorkspaceStore.getState().addWorkspace('W1')
+    useWorkspaceStore.getState().insertTab('tab-1', ws1.id)
+    useWorkspaceStore.getState().insertTab('tab-1', 'deleted-ws')
+    const after = useWorkspaceStore.getState().workspaces.find((w) => w.id === ws1.id)!
+    expect(after.tabs).toEqual(['tab-1'])
+  })
+
   it('insertTab with nonexistent wsId is a no-op', () => {
     useWorkspaceStore.getState().addWorkspace('WS')
     useWorkspaceStore.getState().insertTab('tab-1', 'deleted-ws')

--- a/spa/src/features/workspace/store.ts
+++ b/spa/src/features/workspace/store.ts
@@ -138,6 +138,12 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
         if (!targetWsId) return
 
+        // Concurrent-delete guard: if the caller passes a target workspace
+        // that no longer exists (e.g. another session removed it mid-drag),
+        // abort rather than running the dedup branch — otherwise the tab
+        // would be removed from its source and land in no workspace at all.
+        if (!get().workspaces.some((ws) => ws.id === targetWsId)) return
+
         set((state) => ({
           workspaces: state.workspaces.map((ws) => {
             if (ws.id === targetWsId) {

--- a/spa/src/features/workspace/store.ts
+++ b/spa/src/features/workspace/store.ts
@@ -18,7 +18,7 @@ interface WorkspaceState {
   reorderWorkspaceTabs: (wsId: string, tabIds: string[]) => void
   reorderWorkspaces: (orderedIds: string[]) => void
   findWorkspaceByTab: (tabId: string) => Workspace | null
-  insertTab: (tabId: string, workspaceId?: string | null, afterTabId?: string) => void
+  insertTab: (tabId: string, workspaceId?: string | null, afterTabId?: string | null) => void
   closeTabInWorkspace: (tabId: string, opts?: { skipHistory?: boolean }) => void
   renameWorkspace: (wsId: string, name: string) => void
   setWorkspaceIcon: (wsId: string, icon: string) => void
@@ -143,7 +143,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             if (ws.id === targetWsId) {
               if (ws.tabs.includes(tabId)) return { ...ws, activeTabId: tabId }
               let newTabs: string[]
-              if (afterTabId) {
+              if (afterTabId === null) {
+                newTabs = [tabId, ...ws.tabs]
+              } else if (typeof afterTabId === 'string') {
                 const idx = ws.tabs.indexOf(afterTabId)
                 if (idx !== -1) {
                   newTabs = [...ws.tabs]


### PR DESCRIPTION
## Summary

Phase 3 PR D — cross-workspace tab drag & drop.

- `insertTab(tabId, wsId, afterTabId: string | null)` — `null` explicitly prepends; `undefined` still appends (#402)
- `computeDragEndAction` extended with `move-tab-to-workspace` / `move-tab-to-standalone`; pinned tabs are pinned to their own workspace — any other drop target returns `noop` (#402, #404)
- `dispatchDragEndAction` wires new handlers `onMoveTabToWorkspace` / `onMoveTabToStandalone`
- `WorkspaceRow` header + `HomeRow` register as `useDroppable` targets with `isOver` ring highlight
- `ActivityBarWide` wires cross-ws handlers; active tab moved across workspaces follows via `setActiveWorkspace(target)`
- Custom collision detection chain: `pointerWithin → rectIntersection → closestCenter` — overlapping headers and tab-slots resolve to the target the cursor is actually inside
- New `useSpringLoad(500)` hook; hovering a collapsed workspace-header or home-header for 500ms auto-expands it so the user can drop into a nested tab slot (#403)
- Pinned tabs short-circuit spring-load (no auto-expand into a drop target that would be rejected anyway)

Closes #402, #403, #404.

## Test plan

- [x] `computeDragEndAction` — 29 tests including 10 new cross-ws + pinned-guard cases
- [x] `useSpringLoad` — 7 timing cases (fire, cancel, key reset, different-key swap, mismatched-key no-op, unmount cleanup)
- [x] `insertTab` — null prepend + undefined append + missing afterTabId fallback
- [x] `WorkspaceRow` / `HomeRow` expose `ws-header-<id>` / `home-header` droppable testids
- [x] Full SPA test suite (1830 tests) green
- [ ] Manual smoke test (pending)

### Manual smoke checklist (tabPosition = Left, 2 workspaces w1/w2 with tabs, 2 standalone Home tabs)

| # | Scenario | Expected |
|---|---|---|
| 1 | Drag w1 tab onto w2 tab-slot | Tab lands at that position in w2; active tab follows |
| 2 | Drag w1 tab onto w2 workspace-header | Tab prepends to w2 |
| 3 | Drag w1 tab onto Home header | Tab becomes standalone |
| 4 | Drag standalone tab onto w1 workspace-header | Tab prepends to w1 |
| 5 | Drag standalone tab onto w1 tab-slot | Tab inserts at that position |
| 6 | Drag pinned tab anywhere outside own ws | Rejected (snap-back), ws unchanged |
| 7 | Hover drag over collapsed workspace-header 500ms | Row auto-expands |
| 8 | Hover drag <500ms then move away | Row does NOT expand |
| 9 | Reorder workspaces (regression) | Works |
| 10 | Same-ws tab reorder (regression, Phase 2) | Works |

## Known gaps

- DnD integration test in JSDOM is unreliable, so cross-ws behavior is verified via pure-fn tests + manual smoke
- No custom `<DragOverlay>`; visual snap-back relies on dnd-kit defaults