### PR TITLE
feat(dev-update): SSE build log streaming + full-rebuild hint

### DIFF
--- a/docs/superpowers/plans/2026-04-18-dev-update-log-streaming.md
+++ b/docs/superpowers/plans/2026-04-18-dev-update-log-streaming.md
@@ -1,0 +1,84 @@
+# Dev Update Log Streaming (Plan B Increment)
+
+> 前置：`2026-03-29-dev-update-auto-build` 已實作（`.build-info.json` writer + auto-build goroutine + 3s polling）。本計畫在其上加「使用者看得見 build 進度」。
+
+**Goal:** 讓 Air 在 check 觸發 daemon auto-build 時，即時看到 build log（取代 3 秒黑盒 polling）。並提示何時需要完整 electron rebuild。
+
+**Architecture:**
+- Daemon 把 `runCombinedOutput` 換成 pipe-based spawner；同時開一條 broadcast channel 供多個 subscriber 收 log。
+- 新增 `GET /api/dev/update/check/stream`（SSE）。舊 `/check`（JSON）保留給 Electron main 啟動背景檢查用。
+- `/download` 不動。
+- 加 `requiresFullRebuild: bool` 回傳欄位（SSE `phase:check` 事件與 JSON `/check` 回應都帶）。
+
+**Tech:** Go `bufio.Scanner` + `sync.Mutex` / Go `net/http` Flusher for SSE / React `EventSource`.
+
+---
+
+### Task A — Daemon: line-streaming spawner + broadcast
+
+**Files:** `internal/module/dev/stream.go` (new), `internal/module/dev/module.go`, `internal/module/dev/stream_test.go` (new)
+
+- [ ] A1. 先寫測試 `stream_test.go`：
+  - `TestBuildSession_FanoutToSubscribers` — 2 個 subscriber 都收到相同 sequence of events（phase-start / stdout * N / done）
+  - `TestBuildSession_LateSubscriberReceivesReplay` — 在已發出 3 行後 subscribe，應先收到 3 行 replay、再收到後續
+  - `TestBuildSession_ErrorPropagation` — build 失敗時 subscriber 收到 `error` event 後 channel close
+  - `TestBuildSession_ConcurrentUnsubscribe` — subscribe 後立刻 unsubscribe 不 deadlock
+- [ ] A2. 實作 `buildSession`：
+  - `events []buildEvent` 保存完整 log（late subscriber 用）
+  - `subs map[chan buildEvent]struct{}`
+  - `append(ev)` — 鎖 + 加 events + fanout（`select` + default 避免 block 慢 subscriber；buffer=64）
+  - `subscribe()` 回傳 `(ch, replay, unsubscribe)`
+  - `finish(err)` — 最後一個 event + 關閉所有 ch
+- [ ] A3. 把 `DevModule.execCmd` 改成回傳 channel 的版本；新舊都留（`execCmd` for legacy、`spawnStream` for streaming build）
+- [ ] A4. `runBuild` 改成建立 `buildSession` + 呼叫 `spawnStream` 串流 stdout/stderr 進 session
+- [ ] A5. `go test ./internal/module/dev/ -v` 全綠
+
+### Task B — Daemon: SSE endpoint + requiresFullRebuild
+
+**Files:** `internal/module/dev/handler.go`, `internal/module/dev/rebuild_detect.go` (new), 對應 test
+
+- [ ] B1. 寫 `TestHandleCheckStream_NotStale` — 沒 source change 時，SSE 送一個 `done`（`building:false`）即收流
+- [ ] B2. 寫 `TestHandleCheckStream_TriggersBuild` — source 改變時啟動 build + 串 log + 結尾 `done` 帶新 hash
+- [ ] B3. 寫 `TestHandleCheckStream_LateSubscribe` — 已在 build 中進來，收到 replay + 後續
+- [ ] B4. 寫 `TestRequiresFullRebuild` — package.json / electron-builder.yml / icon.icns / electron/**/Info.plist 變動 → true；純 spa/TS 變動 → false
+- [ ] B5. 實作 `handleCheckStream`：`Content-Type: text/event-stream`、`Cache-Control: no-cache`、`Connection: keep-alive`、每個 event flush
+- [ ] B6. 實作 `detectRequiresFullRebuild(repoRoot)`：檢查 `git diff HEAD~1 HEAD --name-only` 是否命中白名單；偵測新裝的 native module（掃 `node_modules` 有 `.node`）
+- [ ] B7. `handleCheck`（JSON）也回傳 `requiresFullRebuild`
+- [ ] B8. 註冊路由 `GET /api/dev/update/check/stream`
+- [ ] B9. 所有測試綠
+
+### Task C — SPA: log panel + EventSource client
+
+**Files:** `spa/src/components/settings/DevEnvironmentSection.tsx`, `spa/src/components/settings/DevBuildLogPanel.tsx` (new), test
+
+- [ ] C1. 在 `DevBuildLogPanel.test.tsx` 先寫測試：mock `EventSource`，驗證 stdout 事件 append 到 `<pre>`、auto-scroll、done 事件關閉
+- [ ] C2. 實作 `DevBuildLogPanel`：
+  - Props: `streamUrl: string`, `onDone: (result) => void`, `onError: (msg) => void`
+  - 內含 `<pre>` + ref scroll 到底
+  - 「複製完整 log」按鈕
+- [ ] C3. 改 `DevEnvironmentSection`：
+  - 當 `status === 'building'` 時改開 `<DevBuildLogPanel>`（取代 3s polling 分支）
+  - 完成後維持現有 compare 流程
+- [ ] C4. `requiresFullRebuild` 顯示警告 banner + 提示「請到 Mini 跑 `pnpm run electron:build`」
+- [ ] C5. i18n：新增 `settings.dev.log.copy` / `settings.dev.log.rebuild_hint` 兩 key（en + zh-TW）
+- [ ] C6. `npx vitest run` 綠 + `pnpm run lint` 綠
+
+### Task D — Manual verify + PR
+
+- [ ] D1. Mini 端 `go build -o bin/pdx ./cmd/pdx` + 重啟 daemon
+- [ ] D2. `pnpm run electron:build` 產新 `out/.build-info.json` + `dist/mac*/Purdex.app`
+- [ ] D3. Air：裝新 `.app`、`git push`、Settings → Development → Check → 觀察 log panel 實時滾動
+- [ ] D4. 故意退一個 commit，再 Check 一次，驗證重新觸發
+- [ ] D5. `code-review:code-review` skill
+- [ ] D6. 3 parallel agents（attack / defense / file-size）
+- [ ] D7. 處理兩輪 review → 其他用 gh issue
+- [ ] D8. 開 PR、bump VERSION + CHANGELOG
+
+---
+
+## 非目標（本 PR 不碰）
+
+- 自動觸發 electron rebuild（複雜度高、CP 值低）
+- Signed auto-updater（留正式版）
+- xterm.js 渲染 log（純 `<pre>` 足夠；未來有 ANSI 色碼需求再升級）
+- `/download` 改 SSE（職責分離：SSE 只串 log、tarball 走獨立 GET）

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -22,6 +22,17 @@ function readVersion(): string {
   }
 }
 
+// Paths whose changes hint that a full electron-builder rebuild may be
+// needed (native deps, icon, app bundle config). Kept narrow — over-flagging
+// is worse than a false negative. Must stay in sync with rebuildTrackedPaths
+// in internal/module/dev/rebuild_detect.go.
+const REBUILD_TRACKED_PATHS = [
+  'package.json',
+  'pnpm-lock.yaml',
+  'electron-builder.yml',
+  'build/',
+]
+
 function buildInfoPlugin() {
   return {
     name: 'write-build-info',
@@ -30,6 +41,7 @@ function buildInfoPlugin() {
         version: readVersion(),
         spaHash: gitHash('spa/'),
         electronHash: gitHash('electron/', 'electron.vite.config.ts'),
+        rebuildHash: gitHash(...REBUILD_TRACKED_PATHS),
         builtAt: new Date().toISOString(),
       }
       const outDir = resolve(__dirname, 'out')

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,7 +6,7 @@ import { MiniWindowManager } from './mini-browser-window'
 import { registerBrowserViewIpc } from './browser-view-ipc'
 import { registerFsIpc } from './fs-ipc'
 import { createTray } from './tray'
-import { getAppInfo, checkUpdate, applyUpdate } from './updater'
+import { getAppInfo, checkUpdate, applyUpdate, streamCheck } from './updater'
 import { getDefaultKeybindings, buildMenuTemplate } from './keybindings'
 
 // Register custom protocol before app is ready (Electron requirement).
@@ -119,6 +119,34 @@ function registerIpcHandlers(): void {
   // Dev Update
   ipcMain.handle('dev:app-info', () => getAppInfo())
   ipcMain.handle('dev:check-update', (_event, daemonUrl: string, token?: string) => checkUpdate(daemonUrl, token))
+
+  // Only one active stream at a time — a new request aborts the previous one.
+  let activeStream: AbortController | null = null
+  ipcMain.handle('dev:stream-check', async (event, daemonUrl: string, token?: string) => {
+    activeStream?.abort()
+    const controller = new AbortController()
+    activeStream = controller
+    const win = BrowserWindow.fromWebContents(event.sender)
+    try {
+      await streamCheck(daemonUrl, token, (ev) => {
+        if (win && !win.isDestroyed()) {
+          win.webContents.send('dev:stream-check-event', ev)
+        }
+      }, controller.signal)
+    } catch (err) {
+      // AbortError on manual stop is expected — surface everything else.
+      const msg = err instanceof Error ? err.message : String(err)
+      if ((err as { name?: string })?.name !== 'AbortError' && win && !win.isDestroyed()) {
+        win.webContents.send('dev:stream-check-event', { type: 'error', error: msg })
+      }
+    } finally {
+      if (activeStream === controller) activeStream = null
+    }
+  })
+  ipcMain.on('dev:stream-check-stop', () => {
+    activeStream?.abort()
+  })
+
   ipcMain.handle('dev:apply-update', async (event, daemonUrl: string, token?: string) => {
     if (updateInProgress) throw 'Update already in progress'
     updateInProgress = true

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -122,7 +122,7 @@ function registerIpcHandlers(): void {
 
   // Only one active stream at a time — a new request aborts the previous one.
   let activeStream: AbortController | null = null
-  ipcMain.handle('dev:stream-check', async (event, daemonUrl: string, token?: string) => {
+  ipcMain.handle('dev:stream-check', async (event, daemonUrl: string, token: string | undefined, channel: string) => {
     activeStream?.abort()
     const controller = new AbortController()
     activeStream = controller
@@ -130,14 +130,14 @@ function registerIpcHandlers(): void {
     try {
       await streamCheck(daemonUrl, token, (ev) => {
         if (win && !win.isDestroyed()) {
-          win.webContents.send('dev:stream-check-event', ev)
+          win.webContents.send(channel, ev)
         }
       }, controller.signal)
     } catch (err) {
       // AbortError on manual stop is expected — surface everything else.
       const msg = err instanceof Error ? err.message : String(err)
       if ((err as { name?: string })?.name !== 'AbortError' && win && !win.isDestroyed()) {
-        win.webContents.send('dev:stream-check-event', { type: 'error', error: msg })
+        win.webContents.send(channel, { type: 'error', error: msg })
       }
     } finally {
       if (activeStream === controller) activeStream = null

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -135,15 +135,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
       token: string | undefined,
       onEvent: (ev: unknown) => void,
     ) => {
+      // Each call gets its own reply channel so stale events from a previous
+      // in-flight stream can never leak into a freshly registered listener.
+      const channel = `dev:stream-check-event:${Date.now()}:${Math.random().toString(36).slice(2, 10)}`
       const handler = (_event: Electron.IpcRendererEvent, ev: unknown) => onEvent(ev)
-      ipcRenderer.on('dev:stream-check-event', handler)
-      ipcRenderer.invoke('dev:stream-check', daemonUrl, token).catch(() => {
-        // Errors arrive as dev:stream-check-event { type:'error' } — ignore the
+      ipcRenderer.on(channel, handler)
+      ipcRenderer.invoke('dev:stream-check', daemonUrl, token, channel).catch(() => {
+        // Errors arrive as { type: 'error' } on the channel — ignore the
         // rejection here.
       })
       return () => {
         ipcRenderer.send('dev:stream-check-stop')
-        ipcRenderer.removeListener('dev:stream-check-event', handler)
+        ipcRenderer.removeListener(channel, handler)
       }
     },
   } : {}),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -130,5 +130,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('dev:update-progress', handler)
       return () => ipcRenderer.removeListener('dev:update-progress', handler)
     },
+    streamCheck: (
+      daemonUrl: string,
+      token: string | undefined,
+      onEvent: (ev: unknown) => void,
+    ) => {
+      const handler = (_event: Electron.IpcRendererEvent, ev: unknown) => onEvent(ev)
+      ipcRenderer.on('dev:stream-check-event', handler)
+      ipcRenderer.invoke('dev:stream-check', daemonUrl, token).catch(() => {
+        // Errors arrive as dev:stream-check-event { type:'error' } — ignore the
+        // rejection here.
+      })
+      return () => {
+        ipcRenderer.send('dev:stream-check-stop')
+        ipcRenderer.removeListener('dev:stream-check-event', handler)
+      }
+    },
   } : {}),
 })

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -22,6 +22,8 @@ export interface RemoteVersionInfo {
   source: { spaHash: string; electronHash: string }
   building: boolean
   buildError: string
+  requiresFullRebuild: boolean
+  fullRebuildReason?: string
 }
 
 export function getAppInfo(): AppInfo {

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -45,6 +45,67 @@ export async function checkUpdate(daemonUrl: string, token?: string): Promise<Re
   return resp.json()
 }
 
+export interface StreamCheckEvent {
+  type: 'check' | 'phase' | 'stdout' | 'stderr' | 'done' | 'error'
+  phase?: string
+  line?: string
+  error?: string
+  check?: RemoteVersionInfo
+}
+
+/**
+ * Opens an SSE connection to /api/dev/update/check/stream and invokes
+ * onEvent for every message until the server closes or the signal aborts.
+ *
+ * Event contract (matches internal/module/dev/handler.go):
+ *   - first event is always { type: 'check', check: RemoteVersionInfo }
+ *   - middle events carry build progress (phase / stdout / stderr)
+ *   - a single terminal { type: 'done', check: RemoteVersionInfo } ends the stream
+ */
+export async function streamCheck(
+  daemonUrl: string,
+  token: string | undefined,
+  onEvent: (ev: StreamCheckEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const resp = await fetch(`${daemonUrl}/api/dev/update/check/stream`, {
+    headers: { ...authHeaders(token), Accept: 'text/event-stream' },
+    signal,
+  })
+  if (!resp.ok) throw new Error(`stream failed: ${resp.status}`)
+  if (!resp.body) throw new Error('stream has no body')
+
+  const reader = resp.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) return
+      buffer += decoder.decode(value, { stream: true })
+      let idx: number
+      while ((idx = buffer.indexOf('\n\n')) >= 0) {
+        const chunk = buffer.slice(0, idx)
+        buffer = buffer.slice(idx + 2)
+        for (const line of chunk.split('\n')) {
+          if (!line.startsWith('data: ')) continue
+          try {
+            onEvent(JSON.parse(line.slice(6)))
+          } catch {
+            // malformed frame — skip, keep streaming
+          }
+        }
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock()
+    } catch {
+      // reader already released
+    }
+  }
+}
+
 export type UpdateProgressFn = (step: string) => void
 
 export async function applyUpdate(

--- a/internal/module/dev/handler.go
+++ b/internal/module/dev/handler.go
@@ -97,6 +97,34 @@ func (m *DevModule) snapshotCheck() (UpdateCheckResponse, *BuildSession) {
 	}, session
 }
 
+// observeCheck returns the current check snapshot without mutating state.
+// Unlike snapshotCheck it never kicks off a build — callers that just want
+// to report post-build results (e.g. the SSE terminal event) should use
+// this to avoid retriggering a second build if .build-info.json was not
+// written for any reason. Must not be called with m.mu held.
+func (m *DevModule) observeCheck() UpdateCheckResponse {
+	build := m.readBuildInfo()
+	spaSource := m.hashFn("spa/")
+	electronSource := m.hashFn("electron/", "electron.vite.config.ts")
+	requiresFull, fullReason := m.detectRequiresFullRebuild(build.RebuildHash)
+
+	m.mu.Lock()
+	building := m.building
+	buildError := m.buildError
+	m.mu.Unlock()
+
+	return UpdateCheckResponse{
+		Version:             m.readVersion(),
+		SPAHash:             build.SPAHash,
+		ElectronHash:        build.ElectronHash,
+		Source:              SourceHashes{SPAHash: spaSource, ElectronHash: electronSource},
+		Building:            building,
+		BuildError:          buildError,
+		RequiresFullRebuild: requiresFull,
+		FullRebuildReason:   fullReason,
+	}
+}
+
 func (m *DevModule) handleCheck(w http.ResponseWriter, r *http.Request) {
 	resp, _ := m.snapshotCheck()
 	w.Header().Set("Content-Type", "application/json")
@@ -155,8 +183,10 @@ func (m *DevModule) handleCheckStream(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				// Session finished; send a single terminal event carrying the
 				// authoritative post-build check snapshot (includes buildError
-				// if the build failed).
-				final, _ := m.snapshotCheck()
+				// if the build failed). Use observeCheck so a missing
+				// .build-info.json post-build doesn't retrigger a second
+				// build.
+				final := m.observeCheck()
 				writeEvent(streamEvent{Type: "done", Check: &final})
 				return
 			}

--- a/internal/module/dev/handler.go
+++ b/internal/module/dev/handler.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -18,19 +19,33 @@ type SourceHashes struct {
 }
 
 type UpdateCheckResponse struct {
-	Version      string       `json:"version"`
-	SPAHash      string       `json:"spaHash"`
-	ElectronHash string       `json:"electronHash"`
-	Source       SourceHashes `json:"source"`
-	Building     bool         `json:"building"`
-	BuildError   string       `json:"buildError"`
+	Version             string       `json:"version"`
+	SPAHash             string       `json:"spaHash"`
+	ElectronHash        string       `json:"electronHash"`
+	Source              SourceHashes `json:"source"`
+	Building            bool         `json:"building"`
+	BuildError          string       `json:"buildError"`
+	RequiresFullRebuild bool         `json:"requiresFullRebuild"`
+	FullRebuildReason   string       `json:"fullRebuildReason,omitempty"`
 }
 
 type BuildInfo struct {
 	Version      string `json:"version"`
 	SPAHash      string `json:"spaHash"`
 	ElectronHash string `json:"electronHash"`
+	RebuildHash  string `json:"rebuildHash,omitempty"`
 	BuiltAt      string `json:"builtAt"`
+}
+
+// streamEvent is the SSE payload for /check/stream. It carries either a
+// build event (phase/stdout/stderr/done/error) or, for the initial and
+// terminal frames, a check snapshot.
+type streamEvent struct {
+	Type  string               `json:"type"`
+	Phase string               `json:"phase,omitempty"`
+	Line  string               `json:"line,omitempty"`
+	Error string               `json:"error,omitempty"`
+	Check *UpdateCheckResponse `json:"check,omitempty"`
 }
 
 func (m *DevModule) readBuildInfo() BuildInfo {
@@ -46,40 +61,128 @@ func (m *DevModule) readBuildInfo() BuildInfo {
 	return info
 }
 
-func (m *DevModule) handleCheck(w http.ResponseWriter, r *http.Request) {
+// snapshotCheck evaluates the current state and, if source is stale and no
+// build is in flight (or previously failed on the same source), kicks one
+// off. It returns the response payload plus the in-flight session (or nil
+// if no build is running). Must not be called with m.mu held.
+func (m *DevModule) snapshotCheck() (UpdateCheckResponse, *BuildSession) {
 	build := m.readBuildInfo()
 	spaSource := m.hashFn("spa/")
 	electronSource := m.hashFn("electron/", "electron.vite.config.ts")
-
-	// Determine if source differs from build
 	sourceChanged := build.SPAHash != spaSource || build.ElectronHash != electronSource
+
+	requiresFull, fullReason := m.detectRequiresFullRebuild(build.RebuildHash)
 
 	m.mu.Lock()
 	failedSameSource := m.buildError != "" && m.lastFailedSPA == spaSource && m.lastFailedElectron == electronSource
+	var session *BuildSession
 	if sourceChanged && !m.building && !failedSameSource {
-		m.building = true
-		m.buildError = ""
-		m.lastFailedSPA = spaSource
-		m.lastFailedElectron = electronSource
-		go m.runBuild()
+		session = m.startBuildLocked(spaSource, electronSource)
+	} else if m.building {
+		session = m.buildSession
 	}
 	building := m.building
 	buildError := m.buildError
 	m.mu.Unlock()
 
-	resp := UpdateCheckResponse{
-		Version:      m.readVersion(),
-		SPAHash:      build.SPAHash,
-		ElectronHash: build.ElectronHash,
-		Source: SourceHashes{
-			SPAHash:      spaSource,
-			ElectronHash: electronSource,
-		},
-		Building:   building,
-		BuildError: buildError,
-	}
+	return UpdateCheckResponse{
+		Version:             m.readVersion(),
+		SPAHash:             build.SPAHash,
+		ElectronHash:        build.ElectronHash,
+		Source:              SourceHashes{SPAHash: spaSource, ElectronHash: electronSource},
+		Building:            building,
+		BuildError:          buildError,
+		RequiresFullRebuild: requiresFull,
+		FullRebuildReason:   fullReason,
+	}, session
+}
+
+func (m *DevModule) handleCheck(w http.ResponseWriter, r *http.Request) {
+	resp, _ := m.snapshotCheck()
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+func (m *DevModule) handleCheckStream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	writeEvent := func(ev streamEvent) bool {
+		data, err := json.Marshal(ev)
+		if err != nil {
+			return false
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	initial, session := m.snapshotCheck()
+	if !writeEvent(streamEvent{Type: "check", Check: &initial}) {
+		return
+	}
+
+	// No build in flight → stream a terminal done and close.
+	if session == nil {
+		writeEvent(streamEvent{Type: "done", Check: &initial})
+		return
+	}
+
+	ch, replay, unsub := session.subscribe()
+	defer unsub()
+	for _, ev := range replay {
+		if isTerminalBuildEvent(ev) {
+			continue
+		}
+		if !writeEvent(toStreamEvent(ev)) {
+			return
+		}
+	}
+
+	ctx := r.Context()
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				// Session finished; send a single terminal event carrying the
+				// authoritative post-build check snapshot (includes buildError
+				// if the build failed).
+				final, _ := m.snapshotCheck()
+				writeEvent(streamEvent{Type: "done", Check: &final})
+				return
+			}
+			if isTerminalBuildEvent(ev) {
+				continue
+			}
+			if !writeEvent(toStreamEvent(ev)) {
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func isTerminalBuildEvent(ev BuildEvent) bool {
+	return ev.Type == BuildEventDone || ev.Type == BuildEventError
+}
+
+func toStreamEvent(ev BuildEvent) streamEvent {
+	return streamEvent{
+		Type:  string(ev.Type),
+		Phase: ev.Phase,
+		Line:  ev.Line,
+		Error: ev.Error,
+	}
 }
 
 func (m *DevModule) handleDownload(w http.ResponseWriter, r *http.Request) {

--- a/internal/module/dev/handler_stream_test.go
+++ b/internal/module/dev/handler_stream_test.go
@@ -1,0 +1,279 @@
+package dev
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func parseSSE(body string) []streamEvent {
+	var out []streamEvent
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &ev); err == nil {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func writeBuildInfo(t *testing.T, dir string, info BuildInfo) {
+	t.Helper()
+	outDir := filepath.Join(dir, "out")
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, ".build-info.json"), data, 0644); err != nil {
+		t.Fatalf("write build-info: %v", err)
+	}
+}
+
+func TestHandleCheckStream_NotStale(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.0.0\n"), 0644)
+	writeBuildInfo(t, dir, BuildInfo{Version: "1.0.0", SPAHash: "aaa", ElectronHash: "bbb"})
+
+	m := &DevModule{
+		repoRoot:    dir,
+		versionFile: filepath.Join(dir, "VERSION"),
+		hashFn: func(paths ...string) string {
+			if len(paths) > 0 && paths[0] == "spa/" {
+				return "aaa"
+			}
+			return "bbb"
+		},
+		buildCmd: func(*BuildSession) error { return nil },
+	}
+
+	req := httptest.NewRequest("GET", "/api/dev/update/check/stream", nil)
+	w := httptest.NewRecorder()
+	m.handleCheckStream(w, req)
+
+	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("content-type: want text/event-stream, got %s", ct)
+	}
+	events := parseSSE(w.Body.String())
+	if len(events) != 2 {
+		t.Fatalf("want 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "check" {
+		t.Errorf("events[0].Type: want check, got %s", events[0].Type)
+	}
+	if events[0].Check == nil || events[0].Check.Building {
+		t.Errorf("events[0].Check: want building=false, got %+v", events[0].Check)
+	}
+	if events[1].Type != "done" {
+		t.Errorf("events[1].Type: want done, got %s", events[1].Type)
+	}
+}
+
+func TestHandleCheckStream_TriggersBuildAndStreamsLog(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.0.0\n"), 0644)
+	writeBuildInfo(t, dir, BuildInfo{Version: "1.0.0", SPAHash: "old", ElectronHash: "old"})
+
+	m := &DevModule{
+		repoRoot:    dir,
+		versionFile: filepath.Join(dir, "VERSION"),
+		hashFn:      func(paths ...string) string { return "new" },
+		buildCmd: func(s *BuildSession) error {
+			s.append(BuildEvent{Type: BuildEventPhase, Phase: "install"})
+			s.append(BuildEvent{Type: BuildEventStdout, Line: "hello"})
+			s.append(BuildEvent{Type: BuildEventStderr, Line: "warn"})
+			// Simulate build writing new build-info so post-build check is fresh
+			writeBuildInfo(t, dir, BuildInfo{Version: "1.0.0", SPAHash: "new", ElectronHash: "new"})
+			return nil
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/dev/update/check/stream", nil)
+	w := httptest.NewRecorder()
+	m.handleCheckStream(w, req)
+
+	events := parseSSE(w.Body.String())
+	if len(events) < 5 {
+		t.Fatalf("want >=5 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "check" || events[0].Check == nil || !events[0].Check.Building {
+		t.Errorf("initial event: want check building=true, got %+v", events[0])
+	}
+
+	sawPhase, sawStdout, sawStderr := false, false, false
+	for _, ev := range events[1 : len(events)-1] {
+		if ev.Type == "phase" && ev.Phase == "install" {
+			sawPhase = true
+		}
+		if ev.Type == "stdout" && ev.Line == "hello" {
+			sawStdout = true
+		}
+		if ev.Type == "stderr" && ev.Line == "warn" {
+			sawStderr = true
+		}
+	}
+	if !(sawPhase && sawStdout && sawStderr) {
+		t.Errorf("missing build events phase=%v stdout=%v stderr=%v: %+v", sawPhase, sawStdout, sawStderr, events)
+	}
+
+	last := events[len(events)-1]
+	if last.Type != "done" || last.Check == nil {
+		t.Fatalf("last event: want done with check, got %+v", last)
+	}
+	if last.Check.Building {
+		t.Errorf("final check: want building=false, got %+v", last.Check)
+	}
+	if last.Check.SPAHash != "new" {
+		t.Errorf("final check SPAHash: want new, got %s", last.Check.SPAHash)
+	}
+}
+
+func TestHandleCheckStream_LateSubscriberSeesReplay(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.0.0\n"), 0644)
+	writeBuildInfo(t, dir, BuildInfo{Version: "1.0.0", SPAHash: "old", ElectronHash: "old"})
+
+	session := newBuildSession()
+	session.append(BuildEvent{Type: BuildEventPhase, Phase: "install"})
+	session.append(BuildEvent{Type: BuildEventStdout, Line: "line-A"})
+
+	m := &DevModule{
+		repoRoot:     dir,
+		versionFile:  filepath.Join(dir, "VERSION"),
+		hashFn:       func(paths ...string) string { return "new" },
+		building:     true,
+		buildSession: session,
+		buildCmd:     func(*BuildSession) error { return nil }, // defensive — not expected to be called
+	}
+
+	// Finish the session in the background so the handler's loop exits.
+	// Writes fresh build-info before flipping building flag so the handler's
+	// terminal snapshotCheck observes a non-stale state (otherwise it would
+	// think a new build is needed).
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		session.append(BuildEvent{Type: BuildEventStdout, Line: "line-B"})
+		writeBuildInfo(t, dir, BuildInfo{Version: "1.0.0", SPAHash: "new", ElectronHash: "new"})
+		m.mu.Lock()
+		m.building = false
+		m.mu.Unlock()
+		session.append(BuildEvent{Type: BuildEventDone})
+		session.finish()
+	}()
+
+	req := httptest.NewRequest("GET", "/api/dev/update/check/stream", nil)
+	w := httptest.NewRecorder()
+	m.handleCheckStream(w, req)
+
+	events := parseSSE(w.Body.String())
+	if len(events) < 4 {
+		t.Fatalf("want >=4 events, got %d: %+v", len(events), events)
+	}
+
+	hasA, hasB := false, false
+	for _, ev := range events {
+		if ev.Type == "stdout" && ev.Line == "line-A" {
+			hasA = true
+		}
+		if ev.Type == "stdout" && ev.Line == "line-B" {
+			hasB = true
+		}
+	}
+	if !hasA {
+		t.Errorf("missing replayed line-A: %+v", events)
+	}
+	if !hasB {
+		t.Errorf("missing live line-B: %+v", events)
+	}
+	if last := events[len(events)-1]; last.Type != "done" {
+		t.Errorf("last event: want done, got %s", last.Type)
+	}
+}
+
+func TestHandleCheckStream_BuildFailureCarriesErrorInFinal(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.0.0\n"), 0644)
+	writeBuildInfo(t, dir, BuildInfo{Version: "1.0.0", SPAHash: "old", ElectronHash: "old"})
+
+	m := &DevModule{
+		repoRoot:    dir,
+		versionFile: filepath.Join(dir, "VERSION"),
+		hashFn:      func(paths ...string) string { return "new" },
+		buildCmd: func(s *BuildSession) error {
+			s.append(BuildEvent{Type: BuildEventStderr, Line: "ERR_SOMETHING"})
+			return &exitError{msg: "pnpm install failed: exit status 1"}
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/dev/update/check/stream", nil)
+	w := httptest.NewRecorder()
+	m.handleCheckStream(w, req)
+
+	events := parseSSE(w.Body.String())
+	if len(events) < 3 {
+		t.Fatalf("want >=3 events, got %d: %+v", len(events), events)
+	}
+	last := events[len(events)-1]
+	if last.Type != "done" {
+		t.Fatalf("last event: want done (we always send done as terminal, error info in check payload), got %s", last.Type)
+	}
+	if last.Check == nil {
+		t.Fatal("last event check: want non-nil")
+	}
+	if last.Check.Building {
+		t.Errorf("final building: want false, got true")
+	}
+	if !strings.Contains(last.Check.BuildError, "pnpm install failed") {
+		t.Errorf("final buildError: want contains 'pnpm install failed', got %q", last.Check.BuildError)
+	}
+}
+
+func TestHandleCheckStream_IncludesRequiresFullRebuild(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.0.0\n"), 0644)
+	writeBuildInfo(t, dir, BuildInfo{Version: "1.0.0", SPAHash: "aaa", ElectronHash: "bbb", RebuildHash: "old-rebuild"})
+
+	m := &DevModule{
+		repoRoot:    dir,
+		versionFile: filepath.Join(dir, "VERSION"),
+		hashFn: func(paths ...string) string {
+			// Check which set of paths is asked
+			if len(paths) == len(rebuildTrackedPaths) {
+				return "new-rebuild"
+			}
+			if len(paths) > 0 && paths[0] == "spa/" {
+				return "aaa"
+			}
+			return "bbb"
+		},
+		buildCmd: func(*BuildSession) error { return nil },
+	}
+
+	req := httptest.NewRequest("GET", "/api/dev/update/check/stream", nil)
+	w := httptest.NewRecorder()
+	m.handleCheckStream(w, req)
+
+	events := parseSSE(w.Body.String())
+	if len(events) == 0 {
+		t.Fatal("want at least 1 event")
+	}
+	if !events[0].Check.RequiresFullRebuild {
+		t.Errorf("requiresFullRebuild: want true, got false (reason=%q)", events[0].Check.FullRebuildReason)
+	}
+	if events[0].Check.FullRebuildReason == "" {
+		t.Errorf("fullRebuildReason: want non-empty")
+	}
+}
+
+type exitError struct{ msg string }
+
+func (e *exitError) Error() string { return e.msg }

--- a/internal/module/dev/handler_stream_test.go
+++ b/internal/module/dev/handler_stream_test.go
@@ -1,11 +1,13 @@
 package dev
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -277,3 +279,111 @@ func TestHandleCheckStream_IncludesRequiresFullRebuild(t *testing.T) {
 type exitError struct{ msg string }
 
 func (e *exitError) Error() string { return e.msg }
+
+// Guards against regressing the fix for: build completed but vite plugin
+// failed to write .build-info.json → old handleCheckStream would re-enter
+// snapshotCheck() and spuriously kick off another build. After fix, the
+// terminal snapshot uses observeCheck() which never spawns builds.
+func TestHandleCheckStream_TerminalSnapshotDoesNotTriggerSecondBuild(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.0.0\n"), 0644)
+	writeBuildInfo(t, dir, BuildInfo{Version: "1.0.0", SPAHash: "old", ElectronHash: "old"})
+
+	var buildCalls atomic.Int32
+	m := &DevModule{
+		repoRoot:    dir,
+		versionFile: filepath.Join(dir, "VERSION"),
+		hashFn:      func(paths ...string) string { return "new" },
+		buildCmd: func(s *BuildSession) error {
+			buildCalls.Add(1)
+			s.append(BuildEvent{Type: BuildEventStdout, Line: "building"})
+			// Intentionally do NOT update .build-info.json — simulates vite
+			// plugin failing to write for any reason. sourceChanged will
+			// still look true after the build.
+			return nil
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/dev/update/check/stream", nil)
+	w := httptest.NewRecorder()
+	m.handleCheckStream(w, req)
+
+	// Build should run exactly once. Prior buggy code would re-enter
+	// snapshotCheck after channel close and kick off a second build.
+	if got := buildCalls.Load(); got != 1 {
+		t.Errorf("buildCalls: want 1, got %d", got)
+	}
+
+	events := parseSSE(w.Body.String())
+	last := events[len(events)-1]
+	if last.Type != "done" {
+		t.Errorf("last event: want done, got %s", last.Type)
+	}
+	// Post-build state — building must be false even though source still
+	// looks stale (because .build-info.json was not updated).
+	if last.Check == nil || last.Check.Building {
+		t.Errorf("final building: want false, got %+v", last.Check)
+	}
+}
+
+// Guards against subscription leaks when the HTTP client disconnects while
+// a build is still streaming.
+func TestHandleCheckStream_ClientDisconnectReleasesSubscription(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.0.0\n"), 0644)
+	writeBuildInfo(t, dir, BuildInfo{Version: "1.0.0", SPAHash: "old", ElectronHash: "old"})
+
+	session := newBuildSession()
+	session.append(BuildEvent{Type: BuildEventPhase, Phase: "install"})
+
+	m := &DevModule{
+		repoRoot:     dir,
+		versionFile:  filepath.Join(dir, "VERSION"),
+		hashFn:       func(paths ...string) string { return "new" },
+		building:     true,
+		buildSession: session,
+		buildCmd:     func(*BuildSession) error { return nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/api/dev/update/check/stream", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		m.handleCheckStream(w, req)
+		close(done)
+	}()
+
+	// Wait until the handler subscribes.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		session.mu.Lock()
+		n := len(session.subs)
+		session.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	session.mu.Lock()
+	if n := len(session.subs); n != 1 {
+		session.mu.Unlock()
+		t.Fatalf("want 1 subscriber before cancel, got %d", n)
+	}
+	session.mu.Unlock()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not exit after client disconnect")
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if n := len(session.subs); n != 0 {
+		t.Errorf("subscription leaked after disconnect: %d subs remain", n)
+	}
+}

--- a/internal/module/dev/handler_test.go
+++ b/internal/module/dev/handler_test.go
@@ -152,7 +152,7 @@ func TestHandleCheck_WithBuildInfo(t *testing.T) {
 		repoRoot:    dir,
 		versionFile: versionFile,
 		hashFn:      func(paths ...string) string { return "abc1234" },
-		buildCmd:    func() error { return nil },
+		buildCmd:    func(*BuildSession) error { return nil },
 	}
 
 	// hashFn returns "abc1234" for all paths; SPA build hash is "abc1234" — matches SPA source
@@ -217,7 +217,7 @@ func TestHandleCheck_NoBuildInfo(t *testing.T) {
 		repoRoot:    dir,
 		versionFile: versionFile,
 		hashFn:      func(paths ...string) string { return "abc1234" },
-		buildCmd:    func() error { return nil },
+		buildCmd:    func(*BuildSession) error { return nil },
 	}
 
 	req := httptest.NewRequest("GET", "/api/dev/update/check", nil)
@@ -268,7 +268,7 @@ func TestHandleCheck_StaleTriggersAutoBuild(t *testing.T) {
 		repoRoot:    dir,
 		versionFile: versionFile,
 		hashFn:      func(paths ...string) string { return "new3333" },
-		buildCmd:    func() error { return nil },
+		buildCmd:    func(*BuildSession) error { return nil },
 	}
 
 	req := httptest.NewRequest("GET", "/api/dev/update/check", nil)

--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -60,15 +60,24 @@ func (m *DevModule) Init(c *core.Core) error {
 	return nil
 }
 
-func (m *DevModule) runBuild() {
+// startBuildLocked transitions the module into building state, allocates a
+// fresh session, and kicks off the build goroutine. The caller must already
+// hold m.mu. Returns the session so callers can subscribe without a race.
+func (m *DevModule) startBuildLocked(spaSource, electronSource string) *BuildSession {
+	session := newBuildSession()
+	m.buildSession = session
+	m.building = true
+	m.buildError = ""
+	m.lastFailedSPA = spaSource
+	m.lastFailedElectron = electronSource
+	go m.runBuild(session)
+	return session
+}
+
+func (m *DevModule) runBuild(session *BuildSession) {
 	// Remove stale build info so a partial build doesn't leave source hashes
 	// that prevent re-triggering on next check
 	os.Remove(filepath.Join(m.repoRoot, "out", ".build-info.json"))
-
-	session := newBuildSession()
-	m.mu.Lock()
-	m.buildSession = session
-	m.mu.Unlock()
 
 	err := m.buildCmd(session)
 
@@ -77,10 +86,11 @@ func (m *DevModule) runBuild() {
 	} else {
 		session.append(BuildEvent{Type: BuildEventDone})
 	}
-	session.finish()
 
+	// Clear building state BEFORE closing subscriber channels so any handler
+	// that re-reads state after the channel close sees a consistent post-
+	// build snapshot (building=false + updated build info).
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.building = false
 	if err != nil {
 		m.buildError = err.Error()
@@ -91,14 +101,9 @@ func (m *DevModule) runBuild() {
 		m.lastFailedElectron = ""
 		log.Println("[dev] build completed successfully")
 	}
-}
+	m.mu.Unlock()
 
-// currentSession returns the in-flight or most-recent build session, or nil
-// if no build has ever run in this process.
-func (m *DevModule) currentSession() *BuildSession {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.buildSession
+	session.finish()
 }
 
 func (m *DevModule) defaultBuild(session *BuildSession) error {
@@ -145,6 +150,7 @@ func (m *DevModule) defaultBuild(session *BuildSession) error {
 
 func (m *DevModule) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/dev/update/check", m.handleCheck)
+	mux.HandleFunc("GET /api/dev/update/check/stream", m.handleCheckStream)
 	mux.HandleFunc("GET /api/dev/update/download", m.handleDownload)
 }
 

--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -15,6 +15,8 @@ import (
 	"github.com/wake/purdex/internal/core"
 )
 
+type stepRunner func(ctx context.Context, session *BuildSession, phase, dir, name string, args ...string) error
+
 type DevModule struct {
 	core               *core.Core
 	repoRoot           string
@@ -23,8 +25,9 @@ type DevModule struct {
 	mu                 sync.Mutex
 	building           bool
 	buildError         string
-	buildCmd           func() error
-	execCmd            func(ctx context.Context, dir string, name string, args ...string) ([]byte, error)
+	buildCmd           func(session *BuildSession) error
+	runStep            stepRunner
+	buildSession       *BuildSession
 	lastFailedSPA      string
 	lastFailedElectron string
 	stopCtx            context.Context
@@ -48,8 +51,8 @@ func (m *DevModule) Init(c *core.Core) error {
 	if m.hashFn == nil {
 		m.hashFn = m.gitHash
 	}
-	if m.execCmd == nil {
-		m.execCmd = runCombinedOutput
+	if m.runStep == nil {
+		m.runStep = streamCmd
 	}
 	if m.buildCmd == nil {
 		m.buildCmd = m.defaultBuild
@@ -62,7 +65,20 @@ func (m *DevModule) runBuild() {
 	// that prevent re-triggering on next check
 	os.Remove(filepath.Join(m.repoRoot, "out", ".build-info.json"))
 
-	err := m.buildCmd()
+	session := newBuildSession()
+	m.mu.Lock()
+	m.buildSession = session
+	m.mu.Unlock()
+
+	err := m.buildCmd(session)
+
+	if err != nil {
+		session.append(BuildEvent{Type: BuildEventError, Error: err.Error()})
+	} else {
+		session.append(BuildEvent{Type: BuildEventDone})
+	}
+	session.finish()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.building = false
@@ -77,7 +93,15 @@ func (m *DevModule) runBuild() {
 	}
 }
 
-func (m *DevModule) defaultBuild() error {
+// currentSession returns the in-flight or most-recent build session, or nil
+// if no build has ever run in this process.
+func (m *DevModule) currentSession() *BuildSession {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.buildSession
+}
+
+func (m *DevModule) defaultBuild(session *BuildSession) error {
 	parent := m.stopCtx
 	if parent == nil {
 		parent = context.Background()
@@ -108,14 +132,9 @@ func (m *DevModule) defaultBuild() error {
 	}
 
 	for _, step := range steps {
-		out, err := m.execCmd(ctx, m.repoRoot, step.name, step.args...)
-		if err != nil {
+		if err := m.runStep(ctx, session, step.label, m.repoRoot, step.name, step.args...); err != nil {
 			if ctx.Err() == context.DeadlineExceeded {
 				return fmt.Errorf("build timed out after 5 minutes")
-			}
-			if len(out) > 0 {
-				log.Printf("[dev] %s output: %s", step.label, string(out))
-				return fmt.Errorf("%s failed: %w\n%s", step.label, err, strings.TrimSpace(string(out)))
 			}
 			return fmt.Errorf("%s failed: %w", step.label, err)
 		}
@@ -158,10 +177,4 @@ func (m *DevModule) readVersion() string {
 		return "unknown"
 	}
 	return strings.TrimSpace(string(data))
-}
-
-func runCombinedOutput(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = dir
-	return cmd.CombinedOutput()
 }

--- a/internal/module/dev/module_test.go
+++ b/internal/module/dev/module_test.go
@@ -19,7 +19,8 @@ func TestRunBuild_Success(t *testing.T) {
 	}
 	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
 
-	m.runBuild()
+	session := newBuildSession()
+	m.runBuild(session)
 
 	if m.building {
 		t.Error("building: want false after successful build")
@@ -27,14 +28,10 @@ func TestRunBuild_Success(t *testing.T) {
 	if m.buildError != "" {
 		t.Errorf("buildError: want empty, got %q", m.buildError)
 	}
-	if m.buildSession == nil {
-		t.Fatal("buildSession: want non-nil after build, got nil")
-	}
-	// Session should be closed; final event is "done"
-	if n := len(m.buildSession.events); n == 0 {
+	if n := len(session.events); n == 0 {
 		t.Fatal("session events: want >=1, got 0")
 	}
-	last := m.buildSession.events[len(m.buildSession.events)-1]
+	last := session.events[len(session.events)-1]
 	if last.Type != BuildEventDone {
 		t.Errorf("last event: want done, got %+v", last)
 	}
@@ -48,7 +45,8 @@ func TestRunBuild_Failure(t *testing.T) {
 	}
 	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
 
-	m.runBuild()
+	session := newBuildSession()
+	m.runBuild(session)
 
 	if m.building {
 		t.Error("building: want false after failed build")
@@ -56,10 +54,7 @@ func TestRunBuild_Failure(t *testing.T) {
 	if m.buildError != "build timed out after 5 minutes" {
 		t.Errorf("buildError: want timeout message, got %q", m.buildError)
 	}
-	if m.buildSession == nil {
-		t.Fatal("buildSession: want non-nil after build, got nil")
-	}
-	last := m.buildSession.events[len(m.buildSession.events)-1]
+	last := session.events[len(session.events)-1]
 	if last.Type != BuildEventError {
 		t.Errorf("last event: want error, got %+v", last)
 	}
@@ -86,7 +81,7 @@ func TestStop_CancelsBuild(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		m.runBuild()
+		m.runBuild(newBuildSession())
 		close(done)
 	}()
 
@@ -113,7 +108,7 @@ func TestRunBuild_ClearsErrorOnSuccess(t *testing.T) {
 	}
 	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
 
-	m.runBuild()
+	m.runBuild(newBuildSession())
 
 	if m.buildError != "" {
 		t.Errorf("buildError: want empty after success, got %q", m.buildError)

--- a/internal/module/dev/module_test.go
+++ b/internal/module/dev/module_test.go
@@ -14,10 +14,9 @@ import (
 func TestRunBuild_Success(t *testing.T) {
 	m := &DevModule{
 		repoRoot: t.TempDir(),
-		buildCmd: func() error { return nil },
+		buildCmd: func(*BuildSession) error { return nil },
 		building: true,
 	}
-	// Create out/ dir so .build-info.json removal doesn't fail
 	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
 
 	m.runBuild()
@@ -28,12 +27,23 @@ func TestRunBuild_Success(t *testing.T) {
 	if m.buildError != "" {
 		t.Errorf("buildError: want empty, got %q", m.buildError)
 	}
+	if m.buildSession == nil {
+		t.Fatal("buildSession: want non-nil after build, got nil")
+	}
+	// Session should be closed; final event is "done"
+	if n := len(m.buildSession.events); n == 0 {
+		t.Fatal("session events: want >=1, got 0")
+	}
+	last := m.buildSession.events[len(m.buildSession.events)-1]
+	if last.Type != BuildEventDone {
+		t.Errorf("last event: want done, got %+v", last)
+	}
 }
 
 func TestRunBuild_Failure(t *testing.T) {
 	m := &DevModule{
 		repoRoot: t.TempDir(),
-		buildCmd: func() error { return fmt.Errorf("build timed out after 5 minutes") },
+		buildCmd: func(*BuildSession) error { return fmt.Errorf("build timed out after 5 minutes") },
 		building: true,
 	}
 	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
@@ -43,11 +53,18 @@ func TestRunBuild_Failure(t *testing.T) {
 	if m.building {
 		t.Error("building: want false after failed build")
 	}
-	if m.buildError == "" {
-		t.Error("buildError: want non-empty after failed build")
-	}
 	if m.buildError != "build timed out after 5 minutes" {
 		t.Errorf("buildError: want timeout message, got %q", m.buildError)
+	}
+	if m.buildSession == nil {
+		t.Fatal("buildSession: want non-nil after build, got nil")
+	}
+	last := m.buildSession.events[len(m.buildSession.events)-1]
+	if last.Type != BuildEventError {
+		t.Errorf("last event: want error, got %+v", last)
+	}
+	if last.Error != "build timed out after 5 minutes" {
+		t.Errorf("last event error text: want timeout, got %q", last.Error)
 	}
 }
 
@@ -59,33 +76,25 @@ func TestStop_CancelsBuild(t *testing.T) {
 	}
 	os.MkdirAll(filepath.Join(m.repoRoot, "out"), 0755)
 
-	// Init lifecycle (creates stopCtx)
 	m.Init(nil)
 
-	// Mock buildCmd that blocks until stopCtx is cancelled
-	m.buildCmd = func() error {
+	m.buildCmd = func(*BuildSession) error {
 		close(buildStarted)
 		<-m.stopCtx.Done()
 		return m.stopCtx.Err()
 	}
 
-	// Run build in goroutine
 	done := make(chan struct{})
 	go func() {
 		m.runBuild()
 		close(done)
 	}()
 
-	// Wait for build to start
 	<-buildStarted
-
-	// Stop should cancel the build
 	m.Stop(context.Background())
 
-	// Build goroutine should finish quickly
 	select {
 	case <-done:
-		// success
 	case <-time.After(2 * time.Second):
 		t.Fatal("build goroutine did not finish after Stop()")
 	}
@@ -98,7 +107,7 @@ func TestStop_CancelsBuild(t *testing.T) {
 func TestRunBuild_ClearsErrorOnSuccess(t *testing.T) {
 	m := &DevModule{
 		repoRoot:   t.TempDir(),
-		buildCmd:   func() error { return nil },
+		buildCmd:   func(*BuildSession) error { return nil },
 		building:   true,
 		buildError: "previous error",
 	}
@@ -119,50 +128,51 @@ func TestDefaultBuild_RunsInstallGenerateAndBuild(t *testing.T) {
 	}
 
 	var calls [][]string
-	m.execCmd = func(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	m.runStep = func(ctx context.Context, session *BuildSession, phase, dir, name string, args ...string) error {
 		if dir != repoRoot {
 			t.Fatalf("dir: want %s, got %s", repoRoot, dir)
 		}
-		calls = append(calls, append([]string{name}, args...))
-		return nil, nil
+		calls = append(calls, append([]string{phase, name}, args...))
+		return nil
 	}
 
-	if err := m.defaultBuild(); err != nil {
+	session := newBuildSession()
+	if err := m.defaultBuild(session); err != nil {
 		t.Fatalf("defaultBuild: %v", err)
 	}
 
 	want := [][]string{
-		{"pnpm", "install", "--frozen-lockfile"},
-		{"node", "spa/scripts/generate-icon-data.mjs"},
-		{"pnpm", "exec", "electron-vite", "build"},
+		{"dependency install", "pnpm", "install", "--frozen-lockfile"},
+		{"icon generation", "node", "spa/scripts/generate-icon-data.mjs"},
+		{"renderer/main build", "pnpm", "exec", "electron-vite", "build"},
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("commands:\nwant %#v\ngot  %#v", want, calls)
 	}
 }
 
-func TestDefaultBuild_ReturnsStepOutputOnFailure(t *testing.T) {
+func TestDefaultBuild_WrapsStepErrorWithLabel(t *testing.T) {
 	m := &DevModule{
 		repoRoot: t.TempDir(),
 		stopCtx:  context.Background(),
 	}
 
-	m.execCmd = func(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	m.runStep = func(ctx context.Context, session *BuildSession, phase, dir, name string, args ...string) error {
 		if name == "pnpm" && len(args) > 0 && args[0] == "install" {
-			return []byte("ERR_PNPM_OUTDATED_LOCKFILE"), fmt.Errorf("exit status 1")
+			return fmt.Errorf("exit status 1")
 		}
-		return nil, nil
+		return nil
 	}
 
-	err := m.defaultBuild()
+	session := newBuildSession()
+	err := m.defaultBuild(session)
 	if err == nil {
 		t.Fatal("defaultBuild: want error, got nil")
 	}
-	msg := err.Error()
-	if !strings.Contains(msg, "dependency install failed") {
-		t.Fatalf("error: want dependency install context, got %q", msg)
+	if !strings.Contains(err.Error(), "dependency install failed") {
+		t.Fatalf("error: want dependency install context, got %q", err.Error())
 	}
-	if !strings.Contains(msg, "ERR_PNPM_OUTDATED_LOCKFILE") {
-		t.Fatalf("error: want command output, got %q", msg)
+	if !strings.Contains(err.Error(), "exit status 1") {
+		t.Fatalf("error: want wrapped exit status, got %q", err.Error())
 	}
 }

--- a/internal/module/dev/rebuild_detect.go
+++ b/internal/module/dev/rebuild_detect.go
@@ -1,0 +1,28 @@
+package dev
+
+import "fmt"
+
+// rebuildTrackedPaths lists repo-root-relative paths whose changes hint that
+// a full electron-builder rebuild (not just electron-vite) may be needed.
+// Kept narrow on purpose — over-flagging is worse than a false negative.
+var rebuildTrackedPaths = []string{
+	"package.json",
+	"pnpm-lock.yaml",
+	"electron-builder.yml",
+	"build/",
+}
+
+// detectRequiresFullRebuild compares the rebuild-hash of the current source
+// tree against the one recorded in the last build. Empty buildHash (old
+// build or no build) returns (false, "") — we only flag when we have
+// enough info to trust.
+func (m *DevModule) detectRequiresFullRebuild(buildHash string) (bool, string) {
+	if buildHash == "" || buildHash == "unknown" {
+		return false, ""
+	}
+	currentHash := m.hashFn(rebuildTrackedPaths...)
+	if currentHash == "unknown" || currentHash == buildHash {
+		return false, ""
+	}
+	return true, fmt.Sprintf("rebuild-tracked paths changed (%s → %s)", buildHash, currentHash)
+}

--- a/internal/module/dev/rebuild_detect_test.go
+++ b/internal/module/dev/rebuild_detect_test.go
@@ -1,0 +1,37 @@
+package dev
+
+import "testing"
+
+func TestDetectRequiresFullRebuild(t *testing.T) {
+	cases := []struct {
+		name        string
+		buildHash   string
+		currentHash string
+		wantFlag    bool
+	}{
+		{"empty build hash (legacy build info)", "", "abc123", false},
+		{"unknown build hash", "unknown", "abc123", false},
+		{"matching hashes", "abc123", "abc123", false},
+		{"changed hashes", "abc123", "def456", true},
+		{"current unknown (git failure)", "abc123", "unknown", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &DevModule{
+				hashFn: func(paths ...string) string {
+					if len(paths) != len(rebuildTrackedPaths) {
+						t.Fatalf("hashFn called with %d paths, want %d", len(paths), len(rebuildTrackedPaths))
+					}
+					return tc.currentHash
+				},
+			}
+			got, reason := m.detectRequiresFullRebuild(tc.buildHash)
+			if got != tc.wantFlag {
+				t.Errorf("flag: want %v, got %v (reason=%q)", tc.wantFlag, got, reason)
+			}
+			if got && reason == "" {
+				t.Error("reason: want non-empty when flag=true")
+			}
+		})
+	}
+}

--- a/internal/module/dev/stream.go
+++ b/internal/module/dev/stream.go
@@ -111,9 +111,14 @@ func streamCmd(ctx context.Context, session *BuildSession, phase, dir, name stri
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
+		stdout.Close()
 		return err
 	}
 	if err := cmd.Start(); err != nil {
+		// cmd.Wait() closes these on the happy path; on Start() failure we
+		// must close them manually or the pipe read-ends leak.
+		stdout.Close()
+		stderr.Close()
 		return err
 	}
 

--- a/internal/module/dev/stream.go
+++ b/internal/module/dev/stream.go
@@ -1,0 +1,135 @@
+package dev
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os/exec"
+	"sync"
+)
+
+type BuildEventType string
+
+const (
+	BuildEventPhase  BuildEventType = "phase"
+	BuildEventStdout BuildEventType = "stdout"
+	BuildEventStderr BuildEventType = "stderr"
+	BuildEventDone   BuildEventType = "done"
+	BuildEventError  BuildEventType = "error"
+)
+
+type BuildEvent struct {
+	Type  BuildEventType `json:"type"`
+	Phase string         `json:"phase,omitempty"`
+	Line  string         `json:"line,omitempty"`
+	Error string         `json:"error,omitempty"`
+}
+
+// BuildSession broadcasts build events to any number of subscribers and keeps
+// a full replay buffer so late subscribers can catch up from the beginning.
+type BuildSession struct {
+	mu     sync.Mutex
+	events []BuildEvent
+	subs   map[chan BuildEvent]struct{}
+	closed bool
+}
+
+func newBuildSession() *BuildSession {
+	return &BuildSession{subs: make(map[chan BuildEvent]struct{})}
+}
+
+// append stores the event in the replay buffer and fans out to current
+// subscribers. Slow subscribers (full buffer) drop the live event; they can
+// still recover it from the replay on the next subscribe.
+func (s *BuildSession) append(ev BuildEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.events = append(s.events, ev)
+	for ch := range s.subs {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
+// subscribe returns a live channel, a snapshot of past events, and an
+// unsubscribe function. If the session has already finished, the channel is
+// returned already-closed.
+func (s *BuildSession) subscribe() (<-chan BuildEvent, []BuildEvent, func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	replay := append([]BuildEvent(nil), s.events...)
+	ch := make(chan BuildEvent, 64)
+	if s.closed {
+		close(ch)
+		return ch, replay, func() {}
+	}
+	s.subs[ch] = struct{}{}
+	unsub := func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if _, ok := s.subs[ch]; ok {
+			delete(s.subs, ch)
+			close(ch)
+		}
+	}
+	return ch, replay, unsub
+}
+
+// finish closes the session: appends no further events, closes every live
+// subscriber channel. Callers should append the terminal event (done/error)
+// before calling finish.
+func (s *BuildSession) finish() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	for ch := range s.subs {
+		close(ch)
+	}
+	s.subs = nil
+}
+
+// streamCmd runs a command inside `dir`, emits a phase-start event, then one
+// stdout/stderr event per line until the process exits. It does not emit
+// done/error events — the caller decides those based on overall pipeline
+// outcome.
+func streamCmd(ctx context.Context, session *BuildSession, phase, dir, name string, args ...string) error {
+	session.append(BuildEvent{Type: BuildEventPhase, Phase: phase})
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	scan := func(r io.Reader, typ BuildEventType) {
+		defer wg.Done()
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 64*1024), 1024*1024)
+		for sc.Scan() {
+			session.append(BuildEvent{Type: typ, Line: sc.Text()})
+		}
+	}
+	wg.Add(2)
+	go scan(stdout, BuildEventStdout)
+	go scan(stderr, BuildEventStderr)
+	wg.Wait()
+
+	return cmd.Wait()
+}

--- a/internal/module/dev/stream_test.go
+++ b/internal/module/dev/stream_test.go
@@ -1,0 +1,183 @@
+package dev
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func collectEvents(t *testing.T, ch <-chan BuildEvent, maxWait time.Duration) []BuildEvent {
+	t.Helper()
+	var out []BuildEvent
+	timer := time.NewTimer(maxWait)
+	defer timer.Stop()
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, ev)
+		case <-timer.C:
+			t.Fatalf("collectEvents: timeout after %v, collected %d events so far", maxWait, len(out))
+		}
+	}
+}
+
+func TestBuildSession_FanoutToSubscribers(t *testing.T) {
+	s := newBuildSession()
+	chA, _, unsubA := s.subscribe()
+	chB, _, unsubB := s.subscribe()
+	defer unsubA()
+	defer unsubB()
+
+	events := []BuildEvent{
+		{Type: BuildEventPhase, Phase: "install"},
+		{Type: BuildEventStdout, Line: "hello"},
+		{Type: BuildEventStdout, Line: "world"},
+		{Type: BuildEventDone},
+	}
+	go func() {
+		for _, ev := range events {
+			s.append(ev)
+		}
+		s.finish()
+	}()
+
+	gotA := collectEvents(t, chA, 2*time.Second)
+	gotB := collectEvents(t, chB, 2*time.Second)
+
+	if len(gotA) != len(events) {
+		t.Errorf("subscriber A: want %d events, got %d: %+v", len(events), len(gotA), gotA)
+	}
+	if len(gotB) != len(events) {
+		t.Errorf("subscriber B: want %d events, got %d: %+v", len(events), len(gotB), gotB)
+	}
+	if len(gotA) > 0 && gotA[0].Phase != "install" {
+		t.Errorf("subscriber A first event: want phase install, got %+v", gotA[0])
+	}
+}
+
+func TestBuildSession_LateSubscriberReceivesReplay(t *testing.T) {
+	s := newBuildSession()
+
+	s.append(BuildEvent{Type: BuildEventPhase, Phase: "install"})
+	s.append(BuildEvent{Type: BuildEventStdout, Line: "already-out"})
+
+	ch, replay, unsub := s.subscribe()
+	defer unsub()
+
+	if len(replay) != 2 {
+		t.Fatalf("replay: want 2 events, got %d", len(replay))
+	}
+	if replay[0].Phase != "install" {
+		t.Errorf("replay[0]: want phase install, got %+v", replay[0])
+	}
+	if replay[1].Line != "already-out" {
+		t.Errorf("replay[1]: want line already-out, got %+v", replay[1])
+	}
+
+	s.append(BuildEvent{Type: BuildEventStdout, Line: "fresh"})
+	s.finish()
+
+	got := collectEvents(t, ch, 2*time.Second)
+	if len(got) != 1 {
+		t.Fatalf("live events: want 1, got %d: %+v", len(got), got)
+	}
+	if got[0].Line != "fresh" {
+		t.Errorf("live[0]: want line fresh, got %+v", got[0])
+	}
+}
+
+func TestBuildSession_ClosedSessionReturnsClosedChannel(t *testing.T) {
+	s := newBuildSession()
+	s.append(BuildEvent{Type: BuildEventDone})
+	s.finish()
+
+	ch, replay, _ := s.subscribe()
+	if len(replay) != 1 {
+		t.Errorf("replay: want 1 event, got %d", len(replay))
+	}
+	if _, ok := <-ch; ok {
+		t.Error("expected closed channel from already-finished session")
+	}
+}
+
+func TestBuildSession_AppendAfterFinishNoOp(t *testing.T) {
+	s := newBuildSession()
+	s.finish()
+	s.append(BuildEvent{Type: BuildEventStdout, Line: "x"})
+	s.finish() // double finish no-op
+}
+
+func TestBuildSession_ConcurrentSubscribeUnsubscribe(t *testing.T) {
+	s := newBuildSession()
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, unsub := s.subscribe()
+			unsub()
+		}()
+	}
+	go func() {
+		for i := 0; i < 100; i++ {
+			s.append(BuildEvent{Type: BuildEventStdout, Line: "x"})
+		}
+		close(done)
+	}()
+
+	wg.Wait()
+	<-done
+	s.finish()
+}
+
+func TestStreamCmd_CapturesStdoutAndStderr(t *testing.T) {
+	s := newBuildSession()
+	ch, _, unsub := s.subscribe()
+	defer unsub()
+
+	go func() {
+		err := streamCmd(context.Background(), s, "test", "", "sh", "-c", "echo out-line; echo err-line 1>&2")
+		if err != nil {
+			t.Errorf("streamCmd: %v", err)
+		}
+		s.finish()
+	}()
+
+	got := collectEvents(t, ch, 3*time.Second)
+
+	seenPhase, seenStdout, seenStderr := false, false, false
+	for _, ev := range got {
+		switch ev.Type {
+		case BuildEventPhase:
+			if ev.Phase == "test" {
+				seenPhase = true
+			}
+		case BuildEventStdout:
+			if ev.Line == "out-line" {
+				seenStdout = true
+			}
+		case BuildEventStderr:
+			if ev.Line == "err-line" {
+				seenStderr = true
+			}
+		}
+	}
+	if !(seenPhase && seenStdout && seenStderr) {
+		t.Errorf("missing events: phase=%v stdout=%v stderr=%v; all=%+v", seenPhase, seenStdout, seenStderr, got)
+	}
+}
+
+func TestStreamCmd_PropagatesExitError(t *testing.T) {
+	s := newBuildSession()
+	err := streamCmd(context.Background(), s, "test", "", "sh", "-c", "exit 7")
+	s.finish()
+	if err == nil {
+		t.Fatal("want non-nil error from non-zero exit, got nil")
+	}
+}

--- a/spa/src/components/settings/DevBuildLogPanel.test.tsx
+++ b/spa/src/components/settings/DevBuildLogPanel.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DevBuildLogPanel } from './DevBuildLogPanel'
+import { useI18nStore } from '../../stores/useI18nStore'
+
+describe('DevBuildLogPanel', () => {
+  beforeEach(() => {
+    // Stub t() so the component renders i18n keys verbatim; tests match on keys.
+    useI18nStore.setState({ t: (k: string) => k })
+  })
+
+  it('renders phase + stdout + stderr lines in arrival order', () => {
+    const events: ElectronStreamCheckEvent[] = [
+      { type: 'phase', phase: 'install' },
+      { type: 'stdout', line: 'pnpm install running' },
+      { type: 'stderr', line: 'WARN: deprecated' },
+      { type: 'phase', phase: 'build' },
+      { type: 'stdout', line: 'built ok' },
+    ]
+    render(<DevBuildLogPanel events={events} streaming={true} />)
+    const pre = screen.getByTestId('dev-build-log')
+    expect(pre.textContent).toContain('── install ──')
+    expect(pre.textContent).toContain('pnpm install running')
+    expect(pre.textContent).toContain('WARN: deprecated')
+    expect(pre.textContent).toContain('── build ──')
+    expect(pre.textContent).toContain('built ok')
+    const installIdx = pre.textContent!.indexOf('── install ──')
+    const buildIdx = pre.textContent!.indexOf('── build ──')
+    expect(installIdx).toBeLessThan(buildIdx)
+  })
+
+  it('renders waiting placeholder while streaming with no events yet', () => {
+    render(<DevBuildLogPanel events={[]} streaming={true} />)
+    const pre = screen.getByTestId('dev-build-log')
+    expect(pre.textContent).toBe('settings.dev.log.waiting')
+  })
+
+  it('disables copy button when log is empty', () => {
+    render(<DevBuildLogPanel events={[]} streaming={false} />)
+    const btn = screen.getByRole('button', { name: 'settings.dev.log.copy' })
+    expect(btn).toHaveProperty('disabled', true)
+  })
+
+  it('copies log text via clipboard API', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    })
+    const events: ElectronStreamCheckEvent[] = [
+      { type: 'stdout', line: 'hello' },
+    ]
+    render(<DevBuildLogPanel events={events} streaming={false} />)
+    const btn = screen.getByRole('button', { name: 'settings.dev.log.copy' })
+    fireEvent.click(btn)
+    expect(writeText).toHaveBeenCalledWith('hello')
+  })
+
+  it('shows error events with a leading marker', () => {
+    const events: ElectronStreamCheckEvent[] = [
+      { type: 'error', error: 'build failed: exit 1' },
+    ]
+    render(<DevBuildLogPanel events={events} streaming={false} />)
+    const pre = screen.getByTestId('dev-build-log')
+    expect(pre.textContent).toContain('✖ build failed: exit 1')
+  })
+})

--- a/spa/src/components/settings/DevBuildLogPanel.tsx
+++ b/spa/src/components/settings/DevBuildLogPanel.tsx
@@ -11,11 +11,22 @@ export function DevBuildLogPanel({ events, streaming }: Props) {
   const preRef = useRef<HTMLPreElement>(null)
 
   const text = useMemo(() => formatEvents(events), [events])
+  // Stick to bottom only if the user was already near the bottom before the
+  // new content arrived. Prevents the scroll from jumping back down when
+  // the user is reading earlier log lines during a long build.
+  const stickyRef = useRef(true)
 
   useEffect(() => {
     const el = preRef.current
-    if (el) el.scrollTop = el.scrollHeight
+    if (!el) return
+    if (stickyRef.current) el.scrollTop = el.scrollHeight
   }, [text])
+
+  const handleScroll = () => {
+    const el = preRef.current
+    if (!el) return
+    stickyRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 4
+  }
 
   const handleCopy = () => {
     if (!text) return
@@ -26,6 +37,7 @@ export function DevBuildLogPanel({ events, streaming }: Props) {
     <div className="space-y-2">
       <pre
         ref={preRef}
+        onScroll={handleScroll}
         data-testid="dev-build-log"
         className="max-h-64 overflow-auto bg-surface-input border border-border-default rounded text-xs text-text-primary font-mono p-2 whitespace-pre-wrap"
       >

--- a/spa/src/components/settings/DevBuildLogPanel.tsx
+++ b/spa/src/components/settings/DevBuildLogPanel.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useI18nStore } from '../../stores/useI18nStore'
+
+interface Props {
+  events: ElectronStreamCheckEvent[]
+  streaming: boolean
+}
+
+export function DevBuildLogPanel({ events, streaming }: Props) {
+  const t = useI18nStore((s) => s.t)
+  const preRef = useRef<HTMLPreElement>(null)
+
+  const text = useMemo(() => formatEvents(events), [events])
+
+  useEffect(() => {
+    const el = preRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [text])
+
+  const handleCopy = () => {
+    if (!text) return
+    navigator.clipboard?.writeText(text).catch(() => {})
+  }
+
+  return (
+    <div className="space-y-2">
+      <pre
+        ref={preRef}
+        data-testid="dev-build-log"
+        className="max-h-64 overflow-auto bg-surface-input border border-border-default rounded text-xs text-text-primary font-mono p-2 whitespace-pre-wrap"
+      >
+        {text || (streaming ? t('settings.dev.log.waiting') : '')}
+      </pre>
+      <div className="flex gap-2">
+        <button
+          onClick={handleCopy}
+          disabled={!text}
+          className="px-2 py-0.5 text-xs rounded bg-surface-input border border-border-default text-text-primary hover:bg-surface-hover disabled:opacity-50 cursor-pointer disabled:cursor-default"
+        >
+          {t('settings.dev.log.copy')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function formatEvents(events: ElectronStreamCheckEvent[]): string {
+  const parts: string[] = []
+  for (const ev of events) {
+    if (ev.type === 'phase' && ev.phase) {
+      parts.push(`── ${ev.phase} ──`)
+    } else if ((ev.type === 'stdout' || ev.type === 'stderr') && ev.line != null) {
+      parts.push(ev.line)
+    } else if (ev.type === 'error' && ev.error) {
+      parts.push(`✖ ${ev.error}`)
+    }
+  }
+  return parts.join('\n')
+}

--- a/spa/src/components/settings/DevEnvironmentSection.test.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import { DevEnvironmentSection } from './DevEnvironmentSection'
+import { useHostStore } from '../../stores/useHostStore'
 
 const mockGetAppInfo = vi.fn().mockResolvedValue({
   version: '1.0.0-alpha.21',
@@ -129,6 +130,26 @@ describe('DevEnvironmentSection', () => {
     await waitFor(() => expect(mockStreamCheck).toHaveBeenCalled())
     unmount()
     expect(lastStreamClose).toHaveBeenCalled()
+  })
+
+  it('restarts the stream when daemonBase changes', async () => {
+    arrangeStream((cb) => {
+      cb({ type: 'check', check: baseCheck() })
+      cb({ type: 'done', check: baseCheck() })
+    })
+    await act(async () => { render(<DevEnvironmentSection />) })
+    await waitFor(() => expect(mockStreamCheck).toHaveBeenCalledTimes(1))
+    // Capture the first stream's close before arrangeStream replaces it on
+    // the next mockImplementation call.
+    const firstClose = lastStreamClose
+
+    const hostId = useHostStore.getState().hostOrder[0]
+    await act(async () => {
+      useHostStore.getState().updateHost(hostId, { port: 9999 })
+    })
+
+    await waitFor(() => expect(mockStreamCheck).toHaveBeenCalledTimes(2))
+    expect(firstClose).toHaveBeenCalled()
   })
 
   describe('SPA source mode', () => {

--- a/spa/src/components/settings/DevEnvironmentSection.test.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.test.tsx
@@ -9,19 +9,51 @@ const mockGetAppInfo = vi.fn().mockResolvedValue({
   devUpdateEnabled: true,
 })
 
-const mockCheckUpdate = vi.fn()
+const mockStreamCheck = vi.fn()
 const mockApplyUpdate = vi.fn()
 const mockForceLoadSPA = vi.fn().mockResolvedValue(undefined)
 
+function baseCheck(overrides: Partial<ElectronRemoteVersionInfo> = {}): ElectronRemoteVersionInfo {
+  return {
+    version: '1.0.0-alpha.21',
+    spaHash: 'def5678',
+    electronHash: 'abc1234',
+    source: { spaHash: 'src111', electronHash: 'src222' },
+    building: false,
+    buildError: '',
+    requiresFullRebuild: false,
+    ...overrides,
+  }
+}
+
+// Capture the latest streamCheck callback so tests can drive events post-render.
+let lastStreamCallback: ((ev: ElectronStreamCheckEvent) => void) | null = null
+let lastStreamClose = vi.fn()
+
+function arrangeStream(emitInline?: (cb: (ev: ElectronStreamCheckEvent) => void) => void) {
+  mockStreamCheck.mockImplementation((_url: string, _tok: string | undefined, cb: (ev: ElectronStreamCheckEvent) => void) => {
+    lastStreamCallback = cb
+    lastStreamClose = vi.fn()
+    emitInline?.(cb)
+    return lastStreamClose
+  })
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
+  lastStreamCallback = null
   window.electronAPI = {
     ...window.electronAPI!,
     getAppInfo: mockGetAppInfo,
-    checkUpdate: mockCheckUpdate,
+    streamCheck: mockStreamCheck,
     applyUpdate: mockApplyUpdate,
     forceLoadSPA: mockForceLoadSPA,
   } as typeof window.electronAPI
+  // Default: emit a non-stale check immediately
+  arrangeStream((cb) => {
+    cb({ type: 'check', check: baseCheck() })
+    cb({ type: 'done', check: baseCheck() })
+  })
 })
 
 afterEach(() => {
@@ -30,111 +62,90 @@ afterEach(() => {
 
 describe('DevEnvironmentSection', () => {
   it('renders section title', async () => {
-    mockCheckUpdate.mockResolvedValue({
-      version: '1.0.0-alpha.21',
-      spaHash: 'def5678',
-      electronHash: 'abc1234',
-      source: { spaHash: 'src111', electronHash: 'src222' },
-      building: false,
-      buildError: '',
-    })
-
-    render(<DevEnvironmentSection />)
+    await act(async () => { render(<DevEnvironmentSection />) })
     expect(screen.getByText(/Development|開發環境/)).toBeTruthy()
   })
 
-  it('calls getAppInfo on mount', async () => {
-    mockCheckUpdate.mockResolvedValue({
-      version: '1.0.0-alpha.21',
-      spaHash: 'def5678',
-      electronHash: 'abc1234',
-      source: { spaHash: 'src111', electronHash: 'src222' },
-      building: false,
-      buildError: '',
-    })
-
-    render(<DevEnvironmentSection />)
-    expect(mockGetAppInfo).toHaveBeenCalledOnce()
+  it('calls getAppInfo on mount and opens stream', async () => {
+    await act(async () => { render(<DevEnvironmentSection />) })
+    await waitFor(() => expect(mockGetAppInfo).toHaveBeenCalledOnce())
+    await waitFor(() => expect(mockStreamCheck).toHaveBeenCalled())
   })
 
-  it('shows building status and polls', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
+  it('shows building status and renders the log panel while build streams', async () => {
+    // Hold the stream open so we can push events manually
+    arrangeStream()
 
-    // First call: building in progress
-    mockCheckUpdate.mockResolvedValueOnce({
-      version: '1.0.0-alpha.21',
-      spaHash: 'def5678',
-      electronHash: 'abc1234',
-      source: { spaHash: 'src111', electronHash: 'src222' },
-      building: true,
-      buildError: '',
+    await act(async () => { render(<DevEnvironmentSection />) })
+
+    // Emit initial check (building=true), then phase + stdout events
+    await act(async () => {
+      lastStreamCallback!({ type: 'check', check: baseCheck({ building: true, spaHash: 'old', electronHash: 'old' }) })
     })
-    // Second call (poll): build done, new hashes
-    mockCheckUpdate.mockResolvedValueOnce({
-      version: '1.0.0-alpha.21',
-      spaHash: 'new5678',
-      electronHash: 'newabc1',
-      source: { spaHash: 'src333', electronHash: 'src444' },
-      building: false,
-      buildError: '',
-    })
+    await waitFor(() => expect(screen.getByText(/Building|建置中/)).toBeTruthy())
 
     await act(async () => {
-      render(<DevEnvironmentSection />)
+      lastStreamCallback!({ type: 'phase', phase: 'install' })
+      lastStreamCallback!({ type: 'stdout', line: 'resolving dependencies' })
     })
 
-    // Wait for initial check to complete and show building status
-    await waitFor(() => {
-      expect(screen.getByText(/Building|建置中/)).toBeTruthy()
-    })
+    const pre = screen.getByTestId('dev-build-log')
+    expect(pre.textContent).toContain('── install ──')
+    expect(pre.textContent).toContain('resolving dependencies')
 
-    // Advance timer to trigger poll
+    // Emit terminal done with fresh hashes — status should flip to update_available
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000)
+      lastStreamCallback!({ type: 'done', check: baseCheck({ spaHash: 'new5678', electronHash: 'newabc1' }) })
+    })
+    await waitFor(() => expect(screen.getByText(/Update available|有新版本/)).toBeTruthy())
+  })
+
+  it('shows buildError when done check carries it', async () => {
+    arrangeStream((cb) => {
+      cb({ type: 'check', check: baseCheck({ building: true, spaHash: 'old', electronHash: 'old' }) })
+      cb({ type: 'stderr', line: 'ERR_SOMETHING' })
+      cb({ type: 'done', check: baseCheck({ spaHash: 'old', electronHash: 'old', buildError: 'exit code 1' }) })
     })
 
-    // After poll, building is done — should show update_available
-    await waitFor(() => {
-      expect(screen.getByText(/Update available|有新版本/)).toBeTruthy()
+    await act(async () => { render(<DevEnvironmentSection />) })
+    await waitFor(() => expect(screen.getByText('exit code 1')).toBeTruthy())
+  })
+
+  it('shows requiresFullRebuild hint banner', async () => {
+    arrangeStream((cb) => {
+      const check = baseCheck({ requiresFullRebuild: true, fullRebuildReason: 'rebuild-tracked paths changed (old → new)' })
+      cb({ type: 'check', check })
+      cb({ type: 'done', check })
     })
+
+    await act(async () => { render(<DevEnvironmentSection />) })
+    await waitFor(() => expect(screen.getByText(/Full app rebuild recommended|建議重跑完整打包/)).toBeTruthy())
+    expect(screen.getByText('rebuild-tracked paths changed (old → new)')).toBeTruthy()
+  })
+
+  it('closes the stream on unmount', async () => {
+    arrangeStream()
+    const { unmount } = await act(async () => render(<DevEnvironmentSection />))
+    await waitFor(() => expect(mockStreamCheck).toHaveBeenCalled())
+    unmount()
+    expect(lastStreamClose).toHaveBeenCalled()
   })
 
   describe('SPA source mode', () => {
-    const upToDateRemote = {
-      version: '1.0.0-alpha.21',
-      spaHash: 'def5678',
-      electronHash: 'abc1234',
-      source: { spaHash: 'src111', electronHash: 'src222' },
-      building: false,
-      buildError: '',
-    }
-
     it('shows "Dev Server" when loaded from http: protocol', async () => {
-      mockCheckUpdate.mockResolvedValue(upToDateRemote)
-      // jsdom default is http://localhost — which means dev server
-      await act(async () => {
-        render(<DevEnvironmentSection />)
-      })
-      await waitFor(() => {
-        expect(screen.getByText('Dev Server')).toBeTruthy()
-      })
+      await act(async () => { render(<DevEnvironmentSection />) })
+      await waitFor(() => expect(screen.getByText('Dev Server')).toBeTruthy())
     })
 
     it('shows "Bundled" when loaded from app: protocol', async () => {
-      mockCheckUpdate.mockResolvedValue(upToDateRemote)
-      // Simulate app:// protocol by overriding location.protocol
       const originalProtocol = window.location.protocol
       Object.defineProperty(window, 'location', {
         value: { ...window.location, protocol: 'app:' },
         writable: true,
       })
       try {
-        await act(async () => {
-          render(<DevEnvironmentSection />)
-        })
-        await waitFor(() => {
-          expect(screen.getByText('Bundled')).toBeTruthy()
-        })
+        await act(async () => { render(<DevEnvironmentSection />) })
+        await waitFor(() => expect(screen.getByText('Bundled')).toBeTruthy())
       } finally {
         Object.defineProperty(window, 'location', {
           value: { ...window.location, protocol: originalProtocol },
@@ -144,33 +155,22 @@ describe('DevEnvironmentSection', () => {
     })
 
     it('shows switch button and calls forceLoadSPA("bundled") from dev mode', async () => {
-      mockCheckUpdate.mockResolvedValue(upToDateRemote)
-      // Default is http: → dev server, so button should offer "Switch to Bundled"
-      await act(async () => {
-        render(<DevEnvironmentSection />)
-      })
-      await waitFor(() => {
-        expect(screen.getByText('Dev Server')).toBeTruthy()
-      })
+      await act(async () => { render(<DevEnvironmentSection />) })
+      await waitFor(() => expect(screen.getByText('Dev Server')).toBeTruthy())
       const switchBtn = screen.getByRole('button', { name: /Bundled/i })
       fireEvent.click(switchBtn)
       expect(mockForceLoadSPA).toHaveBeenCalledWith('bundled')
     })
 
     it('shows switch button and calls forceLoadSPA("dev") from bundled mode', async () => {
-      mockCheckUpdate.mockResolvedValue(upToDateRemote)
       const originalProtocol = window.location.protocol
       Object.defineProperty(window, 'location', {
         value: { ...window.location, protocol: 'app:' },
         writable: true,
       })
       try {
-        await act(async () => {
-          render(<DevEnvironmentSection />)
-        })
-        await waitFor(() => {
-          expect(screen.getByText('Bundled')).toBeTruthy()
-        })
+        await act(async () => { render(<DevEnvironmentSection />) })
+        await waitFor(() => expect(screen.getByText('Bundled')).toBeTruthy())
         const switchBtn = screen.getByRole('button', { name: /Dev Server/i })
         fireEvent.click(switchBtn)
         expect(mockForceLoadSPA).toHaveBeenCalledWith('dev')
@@ -183,25 +183,15 @@ describe('DevEnvironmentSection', () => {
     })
 
     it('shows error when switching to bundled fails', async () => {
-      mockCheckUpdate.mockResolvedValue(upToDateRemote)
       mockForceLoadSPA.mockRejectedValueOnce('protocol error')
-      await act(async () => {
-        render(<DevEnvironmentSection />)
-      })
-      await waitFor(() => {
-        expect(screen.getByText('Dev Server')).toBeTruthy()
-      })
+      await act(async () => { render(<DevEnvironmentSection />) })
+      await waitFor(() => expect(screen.getByText('Dev Server')).toBeTruthy())
       const switchBtn = screen.getByRole('button', { name: /Bundled/i })
-      await act(async () => {
-        fireEvent.click(switchBtn)
-      })
-      await waitFor(() => {
-        expect(screen.getByText(/Failed to load bundled SPA.*protocol error/)).toBeTruthy()
-      })
+      await act(async () => { fireEvent.click(switchBtn) })
+      await waitFor(() => expect(screen.getByText(/Failed to load bundled SPA.*protocol error/)).toBeTruthy())
     })
 
     it('shows error when switching to dev server fails', async () => {
-      mockCheckUpdate.mockResolvedValue(upToDateRemote)
       mockForceLoadSPA.mockRejectedValueOnce('ERR_CONNECTION_REFUSED')
       const originalProtocol = window.location.protocol
       Object.defineProperty(window, 'location', {
@@ -209,44 +199,17 @@ describe('DevEnvironmentSection', () => {
         writable: true,
       })
       try {
-        await act(async () => {
-          render(<DevEnvironmentSection />)
-        })
-        await waitFor(() => {
-          expect(screen.getByText('Bundled')).toBeTruthy()
-        })
+        await act(async () => { render(<DevEnvironmentSection />) })
+        await waitFor(() => expect(screen.getByText('Bundled')).toBeTruthy())
         const switchBtn = screen.getByRole('button', { name: /Dev Server/i })
-        await act(async () => {
-          fireEvent.click(switchBtn)
-        })
-        await waitFor(() => {
-          expect(screen.getByText(/Dev server is not reachable.*ERR_CONNECTION_REFUSED/)).toBeTruthy()
-        })
+        await act(async () => { fireEvent.click(switchBtn) })
+        await waitFor(() => expect(screen.getByText(/Dev server is not reachable.*ERR_CONNECTION_REFUSED/)).toBeTruthy())
       } finally {
         Object.defineProperty(window, 'location', {
           value: { ...window.location, protocol: originalProtocol },
           writable: true,
         })
       }
-    })
-  })
-
-  it('shows build error', async () => {
-    mockCheckUpdate.mockResolvedValue({
-      version: '1.0.0-alpha.21',
-      spaHash: 'def5678',
-      electronHash: 'abc1234',
-      source: { spaHash: 'src111', electronHash: 'src222' },
-      building: false,
-      buildError: 'exit code 1',
-    })
-
-    await act(async () => {
-      render(<DevEnvironmentSection />)
-    })
-
-    await waitFor(() => {
-      expect(screen.getByText('exit code 1')).toBeTruthy()
     })
   })
 })

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useI18nStore } from '../../stores/useI18nStore'
 import { useHostStore } from '../../stores/useHostStore'
+import { DevBuildLogPanel } from './DevBuildLogPanel'
 
 type UpdateStatus = 'idle' | 'checking' | 'building' | 'up_to_date' | 'update_available' | 'error'
 
@@ -10,7 +11,7 @@ interface AppInfo {
   spaHash: string
 }
 
-type RemoteInfo = Awaited<ReturnType<NonNullable<typeof window.electronAPI>['checkUpdate']>>
+type RemoteInfo = ElectronRemoteVersionInfo
 
 export function DevEnvironmentSection() {
   const t = useI18nStore((s) => s.t)
@@ -27,73 +28,75 @@ export function DevEnvironmentSection() {
   const [updating, setUpdating] = useState(false)
   const [updateStep, setUpdateStep] = useState<string | null>(null)
   const [updateError, setUpdateError] = useState<string | null>(null)
+  const [buildEvents, setBuildEvents] = useState<ElectronStreamCheckEvent[]>([])
+  const [streaming, setStreaming] = useState(false)
 
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
-
-  const stopPolling = useCallback(() => {
-    if (pollRef.current) {
-      clearInterval(pollRef.current)
-      pollRef.current = null
-    }
-  }, [])
-
-  useEffect(() => () => stopPolling(), [stopPolling])
+  const streamCloseRef = useRef<(() => void) | null>(null)
 
   useEffect(() => { appInfoRef.current = appInfo }, [appInfo])
 
-  const processCheckResult = useCallback(
-    (remote: RemoteInfo) => {
-      setRemoteInfo(remote)
-      if (remote.buildError) {
-        setUpdateError(remote.buildError)
-        setStatus('error')
-        return
-      }
-      const ai = appInfoRef.current
-      if (remote.electronHash !== ai?.electronHash || remote.spaHash !== ai?.spaHash) {
-        setStatus('update_available')
-      } else {
-        setStatus('up_to_date')
-      }
-    },
-    [], // deps now empty — reads appInfo from ref
-  )
+  const closeStream = useCallback(() => {
+    streamCloseRef.current?.()
+    streamCloseRef.current = null
+    setStreaming(false)
+  }, [])
 
-  const checkUpdate = useCallback(async () => {
+  const resolveFinalStatus = useCallback((check: RemoteInfo) => {
+    if (check.buildError) {
+      setStatus('error')
+      setUpdateError(check.buildError)
+      return
+    }
+    const ai = appInfoRef.current
+    if (ai && (check.electronHash !== ai.electronHash || check.spaHash !== ai.spaHash)) {
+      setStatus('update_available')
+    } else {
+      setStatus('up_to_date')
+    }
+  }, [])
+
+  const checkUpdate = useCallback(() => {
+    closeStream()
     setStatus('checking')
     setUpdateError(null)
-    try {
-      const remote = await window.electronAPI!.checkUpdate(daemonBase, token)
-      if (remote.building) {
-        setStatus('building')
-        if (!pollRef.current) {
-          pollRef.current = setInterval(async () => {
-            try {
-              const r = await window.electronAPI!.checkUpdate(daemonBase, token)
-              if (!r.building) {
-                stopPolling()
-                processCheckResult(r)
-              }
-            } catch {
-              stopPolling()
-              setStatus('error')
-            }
-          }, 3000)
-        }
-      } else {
-        stopPolling()
-        processCheckResult(remote)
-      }
-    } catch {
-      setStatus('error')
-    }
-  }, [daemonBase, token, stopPolling, processCheckResult])
+    setBuildEvents([])
+    setStreaming(true)
 
-  // Keep ref in sync so the mount effect can call the latest version
+    const close = window.electronAPI!.streamCheck(daemonBase, token, (ev) => {
+      switch (ev.type) {
+        case 'check':
+          if (!ev.check) return
+          setRemoteInfo(ev.check)
+          setStatus(ev.check.building ? 'building' : 'checking')
+          return
+        case 'phase':
+        case 'stdout':
+        case 'stderr':
+          setBuildEvents((prev) => [...prev, ev])
+          return
+        case 'error':
+          setBuildEvents((prev) => [...prev, ev])
+          setStatus('error')
+          setUpdateError(ev.error ?? 'stream error')
+          setStreaming(false)
+          streamCloseRef.current = null
+          return
+        case 'done':
+          if (ev.check) {
+            setRemoteInfo(ev.check)
+            resolveFinalStatus(ev.check)
+          }
+          setStreaming(false)
+          streamCloseRef.current = null
+          return
+      }
+    })
+    streamCloseRef.current = close
+  }, [daemonBase, token, closeStream, resolveFinalStatus])
+
   const checkUpdateRef = useRef(checkUpdate)
   useEffect(() => { checkUpdateRef.current = checkUpdate }, [checkUpdate])
 
-  // Fetch appInfo on mount, then auto-check for updates (event-driven, not effect cascade)
   useEffect(() => {
     window.electronAPI?.getAppInfo().then((info) => {
       setAppInfo(info)
@@ -101,6 +104,8 @@ export function DevEnvironmentSection() {
       checkUpdateRef.current()
     })
   }, [])
+
+  useEffect(() => () => closeStream(), [closeStream])
 
   useEffect(() => {
     if (!window.electronAPI?.onUpdateProgress) return
@@ -111,7 +116,6 @@ export function DevEnvironmentSection() {
     setUpdating(true)
     setUpdateStep(null)
     setUpdateError(null)
-    // Fire and forget — app.exit(0) kills the process before the promise resolves
     window.electronAPI!.applyUpdate(daemonBase, token).catch((err) => {
       setUpdating(false)
       setUpdateStep(null)
@@ -128,6 +132,7 @@ export function DevEnvironmentSection() {
 
   const hasElectronUpdate = remoteInfo && appInfo && remoteInfo.electronHash !== appInfo.electronHash
   const hasSPAUpdate = remoteInfo && appInfo && remoteInfo.spaHash !== appInfo.spaHash
+  const showLogPanel = buildEvents.length > 0 || status === 'building'
 
   const statusText: Record<UpdateStatus, string> = {
     idle: '',
@@ -189,10 +194,23 @@ export function DevEnvironmentSection() {
         </div>
       </div>
 
+      {remoteInfo?.requiresFullRebuild && (
+        <div className="text-xs text-status-warning border border-status-warning/40 bg-status-warning/10 rounded p-2">
+          {t('settings.dev.full_rebuild_hint')}
+          {remoteInfo.fullRebuildReason && (
+            <span className="block text-text-secondary font-mono mt-1">{remoteInfo.fullRebuildReason}</span>
+          )}
+        </div>
+      )}
+
       {status !== 'idle' && (
         <div className={`text-sm ${status === 'error' ? 'text-status-error' : status === 'building' ? 'text-accent' : status === 'update_available' ? 'text-status-warning' : 'text-text-secondary'}`}>
           {status === 'error' && updateError ? updateError : statusText[status]}
         </div>
+      )}
+
+      {showLogPanel && (
+        <DevBuildLogPanel events={buildEvents} streaming={streaming} />
       )}
 
       {updating && updateStep && (

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -97,13 +97,20 @@ export function DevEnvironmentSection() {
   const checkUpdateRef = useRef(checkUpdate)
   useEffect(() => { checkUpdateRef.current = checkUpdate }, [checkUpdate])
 
+  // Mount: load app info. Separate effect below re-runs the check whenever
+  // the daemon host changes (daemonBase or token), which closes any stale
+  // stream pointing at the previous host.
   useEffect(() => {
     window.electronAPI?.getAppInfo().then((info) => {
       setAppInfo(info)
       appInfoRef.current = info
-      checkUpdateRef.current()
     })
   }, [])
+
+  useEffect(() => {
+    if (!appInfo) return
+    checkUpdateRef.current()
+  }, [appInfo, daemonBase, token])
 
   useEffect(() => () => closeStream(), [closeStream])
 

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -255,6 +255,9 @@
   "settings.dev.btn.switch_dev": "Switch to Dev Server",
   "settings.dev.error.dev_unreachable": "Dev server is not reachable",
   "settings.dev.error.bundled_failed": "Failed to load bundled SPA",
+  "settings.dev.log.waiting": "Waiting for build output…",
+  "settings.dev.log.copy": "Copy log",
+  "settings.dev.full_rebuild_hint": "Full app rebuild recommended — run `pnpm run electron:build` on the build host, the dev update only swaps JS bundles.",
 
   "editor.provider_label": "Editor",
   "editor.new_file": "New File",

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -257,7 +257,7 @@
   "settings.dev.error.bundled_failed": "Failed to load bundled SPA",
   "settings.dev.log.waiting": "Waiting for build output…",
   "settings.dev.log.copy": "Copy log",
-  "settings.dev.full_rebuild_hint": "Full app rebuild recommended — run `pnpm run electron:build` on the build host, the dev update only swaps JS bundles.",
+  "settings.dev.full_rebuild_hint": "Full app rebuild recommended — run `pnpm run electron:build` on the machine running the daemon, since the dev update only swaps JS bundles.",
 
   "editor.provider_label": "Editor",
   "editor.new_file": "New File",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -257,7 +257,7 @@
   "settings.dev.error.bundled_failed": "無法載入 Bundled SPA",
   "settings.dev.log.waiting": "等待建置輸出中…",
   "settings.dev.log.copy": "複製完整 log",
-  "settings.dev.full_rebuild_hint": "建議重跑完整打包 — 請在建置機執行 `pnpm run electron:build`，dev update 只會抽換 JS bundle。",
+  "settings.dev.full_rebuild_hint": "建議重跑完整打包 — 請到執行 daemon 的主機跑 `pnpm run electron:build`，dev update 只會抽換 JS bundle。",
 
   "editor.provider_label": "編輯器",
   "editor.new_file": "新增檔案",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -255,6 +255,9 @@
   "settings.dev.btn.switch_dev": "切換為 Dev Server",
   "settings.dev.error.dev_unreachable": "Dev Server 無法連線",
   "settings.dev.error.bundled_failed": "無法載入 Bundled SPA",
+  "settings.dev.log.waiting": "等待建置輸出中…",
+  "settings.dev.log.copy": "複製完整 log",
+  "settings.dev.full_rebuild_hint": "建議重跑完整打包 — 請在建置機執行 `pnpm run electron:build`，dev update 只會抽換 JS bundle。",
 
   "editor.provider_label": "編輯器",
   "editor.new_file": "新增檔案",

--- a/spa/src/types/electron.d.ts
+++ b/spa/src/types/electron.d.ts
@@ -39,6 +39,16 @@ interface ElectronRemoteVersionInfo {
   source: { spaHash: string; electronHash: string }
   building: boolean
   buildError: string
+  requiresFullRebuild: boolean
+  fullRebuildReason?: string
+}
+
+interface ElectronStreamCheckEvent {
+  type: 'check' | 'phase' | 'stdout' | 'stderr' | 'done' | 'error'
+  phase?: string
+  line?: string
+  error?: string
+  check?: ElectronRemoteVersionInfo
 }
 
 interface Window {
@@ -104,5 +114,10 @@ interface Window {
     checkUpdate: (daemonUrl: string, token?: string) => Promise<ElectronRemoteVersionInfo>
     applyUpdate: (daemonUrl: string, token?: string) => Promise<ElectronUpdateResult>
     onUpdateProgress: (callback: (step: string) => void) => () => void
+    streamCheck: (
+      daemonUrl: string,
+      token: string | undefined,
+      onEvent: (ev: ElectronStreamCheckEvent) => void,
+    ) => () => void
   }
 }


### PR DESCRIPTION
## Summary

- **Daemon**: New `GET /api/dev/update/check/stream` (SSE) streams build log in real-time. Build spawner moved from `CombinedOutput` to pipe-based `streamCmd` + `BuildSession` broadcast/replay buffer so multiple concurrent Air clients share one build.
- **Daemon**: New `requiresFullRebuild` flag on `/check` + `/check/stream`. Driven by `rebuildHash` (paths: `package.json` / `pnpm-lock.yaml` / `electron-builder.yml` / `build/`) — written into `.build-info.json` by `electron.vite.config.ts`, compared on daemon side. Hints when JS-bundle swap isn't enough.
- **SPA**: `DevEnvironmentSection` now drives Check via `streamCheck` IPC (replaces 3s JSON polling). New `DevBuildLogPanel` shows phase/stdout/stderr events in a scrollable `<pre>` with "copy log" button. `requiresFullRebuild` renders a warning banner.
- **Electron**: `dev:stream-check` IPC bridges SSE → renderer. Only one stream active at a time (new request aborts previous).

Scope is tight: full `pnpm run electron:build` auto-triggering is explicitly NOT included — rebuilding the `.app` shell remains manual (per discussion: 99% of dev iterations are JS-only and `out/` swap is enough).

## Test plan

- [ ] Mini: `go build -o bin/pdx ./cmd/pdx` + restart daemon
- [ ] Mini: `pnpm run electron:build` — verify `out/.build-info.json` contains `rebuildHash`
- [ ] Air: install new `dist/mac-arm64/Purdex.app` (needs `PDX_DEV_UPDATE=1`)
- [ ] Air: Settings → Development → Check — watch log panel scroll in real-time during build
- [ ] Air: verify status flips correctly (building → update_available) after build completes
- [ ] Air: edit `package.json` on Mini (add a noop dev dep), commit/push, Check again — `requiresFullRebuild` banner should appear
- [ ] Air: open Check on two tabs during a build — both should receive the same stream (replay + live)
- [ ] Simulate build failure (e.g. break `package.json` syntax temporarily) — final event should carry `buildError` + panel shows stderr lines

## Notes

- Plan doc: `docs/superpowers/plans/2026-04-18-dev-update-log-streaming.md`
- All 1874 SPA tests + Go dev module tests (race-clean) pass.
- Pre-existing lint errors (9, in `PaneLayoutRenderer.tsx` / `register-modules.tsx` / `fs-backend-local.test.ts`) untouched — separate PR.
- Pre-existing `internal/module/files` build failure on main — separate issue.