### PR TITLE
fix(spa): badge-mode icon nudge + subagent dot repositioning

### DIFF
--- a/spa/src/components/SubagentDots.tsx
+++ b/spa/src/components/SubagentDots.tsx
@@ -3,6 +3,9 @@ import { useMemo } from 'react'
 
 interface Props {
   count: number
+  // Literal `left` value (in px) overriding the default calc(50% + offset).
+  // Used by badge mode to nudge dots outside the icon box.
+  left?: number
 }
 
 const COLOR = '#60a5fa'
@@ -15,7 +18,7 @@ const ARC_POSITIONS: Record<number, [number, number][]> = {
   3: [[-9, -5.5], [-9, 0], [-9, 5.5]],
 }
 
-export function SubagentDots({ count }: Props) {
+export function SubagentDots({ count, left: leftOverride }: Props) {
   const clamped = Math.min(Math.max(count, 0), 3)
 
   // Recalculate phase offset when dot count changes so all dots restart
@@ -38,7 +41,7 @@ export function SubagentDots({ count }: Props) {
             width: dotSize,
             height: dotSize,
             backgroundColor: COLOR,
-            left: `calc(50% + ${left}px)`,
+            left: leftOverride !== undefined ? `${leftOverride}px` : `calc(50% + ${left}px)`,
             top: `calc(50% + ${top}px)`,
             transform: 'translate(-50%, -50%)',
             animationDelay: `${i * 0.3 - (phaseOffset / 1000) % 2}s`,

--- a/spa/src/components/TabIcon.tsx
+++ b/spa/src/components/TabIcon.tsx
@@ -55,7 +55,7 @@ export function TabIcon({
       <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
         <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
         {showDotUnreadPip && <UnreadPip />}
-        {subagentCount > 0 && <SubagentDots count={subagentCount} isActive={isActive} />}
+        {subagentCount > 0 && <SubagentDots count={subagentCount} />}
       </span>
     )
   }
@@ -66,7 +66,7 @@ export function TabIcon({
         <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
           <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
           {showDotUnreadPip && <UnreadPip />}
-          {subagentCount > 0 && <SubagentDots count={subagentCount} isActive={isActive} />}
+          {subagentCount > 0 && <SubagentDots count={subagentCount} />}
         </span>
         {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
       </span>
@@ -74,8 +74,12 @@ export function TabIcon({
   }
 
   // Unread tints the badge dot red instead of overlaying a separate pip.
+  // Nudge the whole icon+badge group 1px right and park subagent dots at
+  // left:-4 so they sit just outside the box edge, clear of the icon.
   return (
-    <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
+    <span
+      className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-px"
+    >
       {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
       <TabStatusIndicator
         status={agentStatus}
@@ -83,7 +87,7 @@ export function TabIcon({
         isActive={isActive}
         isUnread={isUnread && !isActive}
       />
-      {subagentCount > 0 && <SubagentDots count={subagentCount} isActive={isActive} />}
+      {subagentCount > 0 && <SubagentDots count={subagentCount} left={-4} />}
     </span>
   )
 }

--- a/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
+++ b/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
@@ -60,14 +60,16 @@ export function renderInlineTabIcon({
   }
 
   // badge: icon + small overlay dot
+  // Nudge the whole icon+badge group 1px right and park subagent dots at
+  // left:-4 so they sit just outside the box edge, clear of the icon.
   return (
     <span
       data-testid="inline-tab-dot-overlay"
-      className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0`}
+      className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px`}
     >
       {IconComponent && <IconComponent size={ICON_SIZE} className="flex-shrink-0" />}
       <TabStatusIndicator status={agentStatus} mode="overlay" isActive={isActive} />
-      {subagentCount > 0 && <SubagentDots count={subagentCount} />}
+      {subagentCount > 0 && <SubagentDots count={subagentCount} left={-4} />}
     </span>
   )
 }


### PR DESCRIPTION
## Summary

Badge mode visual tweak：

- Icon+badge 整組 span 右移 1px（`ml-px`），14px icon 在 16px slot 內視覺置中更準
- Subagent dots 位置改為 literal `left: -4px`（原本 `calc(50% - 9px)` ≈ `-1px`，現在夾在 box 邊緣外、完全避開 icon）
- `SubagentDots` 新增可選 `left?: number` prop；沒傳就沿用原 calc 行為（dot / iconDot 模式不變）
- 順手拿掉 `TabIcon.tsx` 在 dot / iconDot 模式傳給 `SubagentDots` 的無效 `isActive` prop（元件從來沒讀）

## Files

- `spa/src/components/SubagentDots.tsx`
- `spa/src/components/TabIcon.tsx`
- `spa/src/features/workspace/lib/renderInlineTabIcon.tsx`

## Test plan

- [x] `pnpm run lint`（pre-existing 9 errors，無新增）
- [x] `npx vitest run` — 1895/1895 pass
- [ ] 視覺檢查：top bar + left inline badge 模式下，subagent dots 應該在 icon 左側、緊貼 box 邊緣，icon 本體略右移 1px