### PR TITLE
fix(spa): tab dbl-click opens rename; host click opens settings

### DIFF
--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -200,6 +200,11 @@ export default function App() {
     useHostStore.getState().setActiveHost(hostId)
   }, [openSingletonAndSelect])
 
+  const handleRenameTab = useCallback((tabId: string) => {
+    const tab = tabs[tabId]
+    if (tab) openRenameForTab(tab)
+  }, [tabs, openRenameForTab])
+
   const handleMigrateConfirm = useCallback(() => {
     if (!migrateDialog) return
     tabOrder.forEach((tabId) => {
@@ -240,6 +245,7 @@ export default function App() {
             onCloseTab={handleCloseTab}
             onMiddleClickTab={handleMiddleClick}
             onContextMenuTab={handleContextMenu}
+            onRenameTab={handleRenameTab}
             onReorderWorkspaceTabs={handleReorderWorkspaceTabs}
             onReorderStandaloneTabs={handleReorderStandaloneTabs}
             onAddTabToWorkspace={handleAddTabToWorkspace}
@@ -256,6 +262,7 @@ export default function App() {
                 onReorderTabs={handleReorderTabs}
                 onMiddleClick={handleMiddleClick}
                 onContextMenu={handleContextMenu}
+                onRenameTab={handleRenameTab}
               />
             )}
             <div className="flex-1 flex overflow-hidden">

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -24,6 +24,7 @@ interface Props {
   onClose: (tabId: string) => void
   onMiddleClick: (tabId: string) => void
   onContextMenu: (e: React.MouseEvent, tabId: string) => void
+  onRename?: (tabId: string) => void
   onHover?: (tabId: string | null) => void
   iconMap: Record<string, React.ComponentType<{ size: number; className?: string }>>
 }
@@ -33,7 +34,7 @@ interface Props {
 const TAB_BG_INACTIVE = 'var(--surface-secondary)'
 const TAB_BG_ACTIVE = 'var(--surface-active)'
 
-export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddleClick, onContextMenu, onHover, iconMap }: Props) {
+export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddleClick, onContextMenu, onRename, onHover, iconMap }: Props) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: tab.id })
 
   const style = {
@@ -106,6 +107,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
     e.preventDefault()
     onContextMenu(e, tab.id)
   }
+  const handleDoubleClick = () => onRename?.(tab.id)
 
   const tabBg = isActive ? TAB_BG_ACTIVE : TAB_BG_INACTIVE
 
@@ -118,6 +120,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
         {...attributes}
         {...listeners}
         onClick={() => onSelect(tab.id)}
+        onDoubleClick={handleDoubleClick}
         onPointerDown={handlePointerDown}
         onMouseUp={handleMouseUp}
         onMouseEnter={handleMouseEnter}
@@ -156,6 +159,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
       role="tab"
       aria-selected={isActive}
       onClick={() => onSelect(tab.id)}
+      onDoubleClick={handleDoubleClick}
       onPointerDown={handlePointerDown}
       onKeyDown={handleKeyDown}
       onMouseUp={handleMouseUp}

--- a/spa/src/components/StatusBar.tsx
+++ b/spa/src/components/StatusBar.tsx
@@ -162,14 +162,14 @@ export function StatusBar({ activeTab, onViewModeChange, onNavigateToHost, onSta
   return (
     <div className="h-6 bg-surface-secondary border-t border-border-subtle flex items-center px-3 text-[10px] text-text-muted gap-3 flex-shrink-0 relative z-10">
       <span
-        className="text-text-secondary cursor-pointer select-none"
-        title={t('status.rename_hint')}
-        onDoubleClick={handleNameDoubleClick}
+        className="text-text-secondary select-none"
+        title={t('status.open_host_hint')}
+        onClick={agentHostId ? () => onNavigateToHost?.(agentHostId) : undefined}
       >
         {hostName}
       </span>
       <span
-        className="text-text-secondary cursor-pointer select-none"
+        className="text-text-secondary select-none"
         title={t('status.rename_hint')}
         onDoubleClick={handleNameDoubleClick}
       >

--- a/spa/src/components/TabBar.tsx
+++ b/spa/src/components/TabBar.tsx
@@ -17,6 +17,7 @@ interface Props {
   onReorderTabs: (newOrder: string[]) => void
   onMiddleClick: (tabId: string) => void
   onContextMenu: (e: React.MouseEvent, tabId: string) => void
+  onRenameTab?: (tabId: string) => void
   /** When embedded in Electron title bar — no border, no fixed height */
   embedded?: boolean
 }
@@ -25,7 +26,7 @@ function TabSeparator({ show }: { show: boolean }) {
   return <div className={`w-px h-3.5 flex-shrink-0 transition-opacity duration-150 ease-out ${show ? 'bg-border-default' : 'bg-transparent'}`} />
 }
 
-export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, onReorderTabs, onMiddleClick, onContextMenu, embedded }: Props) {
+export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, onReorderTabs, onMiddleClick, onContextMenu, onRenameTab, embedded }: Props) {
   const t = useI18nStore((s) => s.t)
   const pinnedTabs = useMemo(() => tabs.filter((t) => t.pinned), [tabs])
   const normalTabs = useMemo(() => tabs.filter((t) => !t.pinned), [tabs])
@@ -105,6 +106,7 @@ export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, o
                       onClose={onCloseTab}
                       onMiddleClick={onMiddleClick}
                       onContextMenu={onContextMenu}
+                      onRename={onRenameTab}
                       onHover={setHoveredTabId}
                       iconMap={ICON_MAP}
                     />
@@ -140,6 +142,7 @@ export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, o
                       onClose={onCloseTab}
                       onMiddleClick={onMiddleClick}
                       onContextMenu={onContextMenu}
+                      onRename={onRenameTab}
                       onHover={setHoveredTabId}
                       iconMap={ICON_MAP}
                     />

--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -62,6 +62,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
     onCloseTab,
     onMiddleClickTab,
     onContextMenuTab,
+    onRenameTab,
     onReorderWorkspaceTabs,
     onReorderStandaloneTabs,
     onAddTabToWorkspace,
@@ -90,6 +91,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
   const closeTab = onCloseTab ?? NOOP
   const middleClickTab = onMiddleClickTab ?? NOOP
   const contextMenuTab = onContextMenuTab ?? NOOP
+  const renameTab = onRenameTab
   const addTabToWs = onAddTabToWorkspace ?? NOOP
 
   const insertTab = useWorkspaceStore((s) => s.insertTab)
@@ -276,6 +278,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
             onCloseTab={closeTab}
             onMiddleClickTab={middleClickTab}
             onContextMenuTab={contextMenuTab}
+            onRenameTab={renameTab}
           />
 
           {workspaces.length > 0 && (
@@ -299,6 +302,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
                   onCloseTab={closeTab}
                   onMiddleClickTab={middleClickTab}
                   onContextMenuTab={contextMenuTab}
+                  onRenameTab={renameTab}
                   onAddTabToWorkspace={addTabToWs}
                 />
               ))}

--- a/spa/src/features/workspace/components/HomeRow.tsx
+++ b/spa/src/features/workspace/components/HomeRow.tsx
@@ -16,6 +16,7 @@ interface Props {
   onCloseTab: (tabId: string) => void
   onMiddleClickTab: (tabId: string) => void
   onContextMenuTab: (e: React.MouseEvent, tabId: string) => void
+  onRenameTab?: (tabId: string) => void
 }
 
 export function HomeRow(props: Props) {
@@ -29,6 +30,7 @@ export function HomeRow(props: Props) {
     onCloseTab,
     onMiddleClickTab,
     onContextMenuTab,
+    onRenameTab,
   } = props
   const t = useI18nStore((s) => s.t)
   const expanded = useLayoutStore((s) => !!s.workspaceExpanded[HOME_WS_KEY])
@@ -96,6 +98,7 @@ export function HomeRow(props: Props) {
           onClose={onCloseTab}
           onMiddleClick={onMiddleClickTab}
           onContextMenu={onContextMenuTab}
+          onRename={onRenameTab}
         />
       )}
     </div>

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -20,6 +20,7 @@ interface Props {
   onClose: (tabId: string) => void
   onMiddleClick: (tabId: string) => void
   onContextMenu: (e: React.MouseEvent, tabId: string) => void
+  onRename?: (tabId: string) => void
 }
 
 export function InlineTab({
@@ -31,6 +32,7 @@ export function InlineTab({
   onClose,
   onMiddleClick,
   onContextMenu,
+  onRename,
 }: Props) {
   const t = useI18nStore((s) => s.t)
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -123,6 +125,7 @@ export function InlineTab({
       role="button"
       tabIndex={0}
       onClick={() => onSelect(tab.id)}
+      onDoubleClick={() => onRename?.(tab.id)}
       onMouseDown={handleMouseDown}
       onContextMenu={(e) => onContextMenu(e, tab.id)}
       className={`group relative flex items-center gap-1.5 mx-2 pl-6 pr-1.5 py-1 rounded-md text-xs cursor-pointer transition-colors ${activeClasses}`}

--- a/spa/src/features/workspace/components/InlineTabList.tsx
+++ b/spa/src/features/workspace/components/InlineTabList.tsx
@@ -16,6 +16,7 @@ interface Props {
   onClose: (tabId: string) => void
   onMiddleClick: (tabId: string) => void
   onContextMenu: (e: React.MouseEvent, tabId: string) => void
+  onRename?: (tabId: string) => void
 }
 
 export function InlineTabList({
@@ -27,6 +28,7 @@ export function InlineTabList({
   onClose,
   onMiddleClick,
   onContextMenu,
+  onRename,
 }: Props) {
   const t = useI18nStore((s) => s.t)
   const sessionsByHost = useSessionStore((s) => s.sessions)
@@ -76,6 +78,7 @@ export function InlineTabList({
               onClose={onClose}
               onMiddleClick={onMiddleClick}
               onContextMenu={onContextMenu}
+              onRename={onRename}
             />
           )
         })}

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -19,6 +19,7 @@ interface Props {
   onCloseTab: (tabId: string) => void
   onMiddleClickTab: (tabId: string) => void
   onContextMenuTab: (e: React.MouseEvent, tabId: string) => void
+  onRenameTab?: (tabId: string) => void
   onAddTabToWorkspace: (wsId: string) => void
 }
 
@@ -34,6 +35,7 @@ export function WorkspaceRow(props: Props) {
     onCloseTab,
     onMiddleClickTab,
     onContextMenuTab,
+    onRenameTab,
     onAddTabToWorkspace,
   } = props
   const t = useI18nStore((s) => s.t)
@@ -137,6 +139,7 @@ export function WorkspaceRow(props: Props) {
           onClose={onCloseTab}
           onMiddleClick={onMiddleClickTab}
           onContextMenu={onContextMenuTab}
+          onRename={onRenameTab}
         />
       )}
     </div>

--- a/spa/src/features/workspace/components/activity-bar-props.ts
+++ b/spa/src/features/workspace/components/activity-bar-props.ts
@@ -26,6 +26,7 @@ export interface ActivityBarProps {
   onCloseTab?: (tabId: string) => void
   onMiddleClickTab?: (tabId: string) => void
   onContextMenuTab?: (e: React.MouseEvent, tabId: string) => void
+  onRenameTab?: (tabId: string) => void
   onReorderWorkspaceTabs?: (wsId: string, tabIds: string[]) => void
   onReorderStandaloneTabs?: (tabIds: string[]) => void
   onAddTabToWorkspace?: (wsId: string) => void

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -286,6 +286,7 @@
 
   "status.no_active": "No active session",
   "status.rename_hint": "Double-click to rename session",
+  "status.open_host_hint": "Click to open host settings",
 
   "stream.thinking": "Thinking...",
   "stream.waiting": "Waiting for messages...",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -286,6 +286,7 @@
 
   "status.no_active": "無使用中的 Session",
   "status.rename_hint": "雙擊可修改 session 名稱",
+  "status.open_host_hint": "點擊開啟主機設定",
 
   "stream.thinking": "思考中...",
   "stream.waiting": "等待訊息...",


### PR DESCRIPTION
## Summary
- Tab double-click (both TabBar & InlineTab) now opens the rename popover via existing `openRenameForTab`
- StatusBar `{host}` swapped from double-click rename to single-click → open host settings page
- Removed `cursor-pointer` from the host/session spans (刻意減輕介面認知負擔 — 仍可點擊，但不再顯示手型)

## Test plan
- [x] `npx vitest run` — 1903 tests pass
- [x] `npx tsc -p . --noEmit` — clean
- [ ] 手動：TabBar tab double-click → rename popover 出現
- [ ] 手動：Activity bar InlineTab double-click → rename popover 出現
- [ ] 手動：StatusBar `{host}` 單擊 → 跳到 host 設定頁並選中該 host
- [ ] 手動：StatusBar `{session}` 雙擊 → rename popover 出現
- [ ] 手動：hover host/session span 不再出現 pointer cursor