### PR TITLE
fix(spa): activity bar toggle + workspace row UI tweaks

### DIFF
--- a/spa/src/components/settings/AppearanceSection.tsx
+++ b/spa/src/components/settings/AppearanceSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { DownloadSimple, Upload, Trash, PaintBrush, Translate } from '@phosphor-icons/react'
 import { SettingItem } from './SettingItem'
+import { SegmentControl } from './SegmentControl'
 import { getAllThemes } from '../../lib/theme-registry'
 import type { ThemeDefinition } from '../../lib/theme-registry'
 import { useThemeStore } from '../../stores/useThemeStore'
@@ -88,9 +89,11 @@ export function AppearanceSection() {
     setLocale(localeId)
   }
 
-  const handleTabPositionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTabPosition(e.target.value as TabPosition)
-  }
+  const TAB_POSITION_OPTIONS: { value: TabPosition; label: string }[] = [
+    { value: 'top', label: t('settings.appearance.tab_position.top') },
+    { value: 'left', label: t('settings.appearance.tab_position.left') },
+    { value: 'both', label: t('settings.appearance.tab_position.both') },
+  ]
 
   return (
     <div>
@@ -213,41 +216,13 @@ export function AppearanceSection() {
         label={t('settings.appearance.tab_position.label')}
         description={t('settings.appearance.tab_position.desc')}
       >
-        <div className="flex flex-col gap-1.5">
-          <label className="flex items-center gap-2 text-xs text-text-primary cursor-pointer">
-            <input
-              type="radio"
-              name="tab-position"
-              value="top"
-              checked={tabPosition === 'top'}
-              onChange={handleTabPositionChange}
-              className="accent-purple-500"
-            />
-            {t('settings.appearance.tab_position.top')}
-          </label>
-          <label className="flex items-center gap-2 text-xs text-text-primary cursor-pointer">
-            <input
-              type="radio"
-              name="tab-position"
-              value="left"
-              checked={tabPosition === 'left'}
-              onChange={handleTabPositionChange}
-              className="accent-purple-500"
-            />
-            {t('settings.appearance.tab_position.left')}
-          </label>
-          <label className="flex items-center gap-2 text-xs text-text-primary cursor-pointer">
-            <input
-              type="radio"
-              name="tab-position"
-              value="both"
-              checked={tabPosition === 'both'}
-              onChange={handleTabPositionChange}
-              className="accent-purple-500"
-            />
-            {t('settings.appearance.tab_position.both')}
-          </label>
-          <p className="text-[11px] text-text-muted mt-0.5">
+        <div className="flex flex-col items-end gap-1.5">
+          <SegmentControl
+            options={TAB_POSITION_OPTIONS}
+            value={tabPosition}
+            onChange={setTabPosition}
+          />
+          <p className="text-[11px] text-text-muted">
             {t('settings.appearance.tab_position.left_hint')}
           </p>
         </div>

--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -28,6 +28,7 @@ import { useTabStore } from '../../../stores/useTabStore'
 import { RegionResize } from '../../../components/RegionResize'
 import { WorkspaceRow } from './WorkspaceRow'
 import { HomeRow } from './HomeRow'
+import { CollapseButton } from './CollapseButton'
 import type { ActivityBarProps } from './activity-bar-props'
 import { computeDragEndAction, dispatchDragEndAction, type DragData } from '../lib/computeDragEndAction'
 import { useSpringLoad } from '../lib/useSpringLoad'
@@ -259,6 +260,10 @@ export function ActivityBarWide(props: ActivityBarProps) {
         className="hidden lg:flex flex-col bg-surface-tertiary border-r border-border-subtle py-2 gap-0.5 flex-shrink-0 overflow-y-auto"
         style={{ width: renderedSize }}
       >
+        <div className="flex items-center px-3 pt-0.5 pb-1.5">
+          <CollapseButton variant="header-right" />
+        </div>
+
         <DndContext
           sensors={sensors}
           collisionDetection={customCollisionDetection}

--- a/spa/src/features/workspace/components/HomeRow.tsx
+++ b/spa/src/features/workspace/components/HomeRow.tsx
@@ -4,7 +4,6 @@ import type { Tab } from '../../../types/tab'
 import { useLayoutStore, HOME_WS_KEY } from '../../../stores/useLayoutStore'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { InlineTabList } from './InlineTabList'
-import { CollapseButton } from './CollapseButton'
 
 interface Props {
   isActive: boolean
@@ -49,30 +48,16 @@ export function HomeRow(props: Props) {
       <div
         ref={setHeaderDropRef}
         data-testid="home-header"
-        className={`group/home-header mx-2 flex items-center gap-1 pr-1.5 rounded-md text-sm transition-colors ${
+        className={`group/home-header mx-2 flex items-center gap-1 pl-1.5 rounded-md text-sm transition-colors focus:outline-none focus-visible:outline-none ${
           isActive
             ? 'bg-surface-hover text-text-primary ring-1 ring-purple-400'
             : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
         } ${isHeaderOver ? 'ring-2 ring-purple-400/80 bg-surface-hover' : ''}`}
       >
-        {showTabs && (
-          <button
-            type="button"
-            aria-label={chevronLabel}
-            aria-expanded={expanded}
-            onClick={(e) => {
-              e.stopPropagation()
-              toggleExpanded(HOME_WS_KEY)
-            }}
-            className="p-1 rounded hover:bg-surface-secondary text-text-muted cursor-pointer"
-          >
-            <Chevron size={12} />
-          </button>
-        )}
         <button
           type="button"
           onClick={onSelectHome}
-          className="flex-1 flex items-center gap-2 py-1.5 text-left cursor-pointer"
+          className="flex-1 flex items-center gap-2 py-1.5 text-left cursor-pointer focus:outline-none"
         >
           <img
             src="/icons/logo-transparent.png"
@@ -83,7 +68,20 @@ export function HomeRow(props: Props) {
           />
           <span className="truncate">{t('nav.home')}</span>
         </button>
-        <CollapseButton variant="header-right" />
+        {showTabs && (
+          <button
+            type="button"
+            aria-label={chevronLabel}
+            aria-expanded={expanded}
+            onClick={(e) => {
+              e.stopPropagation()
+              toggleExpanded(HOME_WS_KEY)
+            }}
+            className="p-1 mr-0.5 rounded hover:bg-surface-secondary text-text-muted cursor-pointer focus:outline-none"
+          >
+            <Chevron size={12} />
+          </button>
+        )}
       </div>
 
       {showTabs && expanded && (

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -70,26 +70,12 @@ export function WorkspaceRow(props: Props) {
         data-testid={`ws-header-${workspace.id}`}
         {...attributes}
         {...listeners}
-        className={`group/ws-header mx-2 flex items-center gap-1 pr-1.5 rounded-md text-sm transition-colors ${
+        className={`group/ws-header mx-2 flex items-center gap-1 pl-1.5 rounded-md text-sm transition-colors focus:outline-none focus-visible:outline-none ${
           isActive
             ? 'bg-[#8b5cf6]/25 text-text-primary ring-1 ring-purple-400'
             : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
         } ${isHeaderOver ? 'ring-2 ring-purple-400/80 bg-surface-hover' : ''}`}
       >
-        {showTabs && (
-          <button
-            type="button"
-            aria-label={chevronLabel}
-            aria-expanded={expanded}
-            onClick={(e) => {
-              e.stopPropagation()
-              toggleExpanded(workspace.id)
-            }}
-            className="p-1 rounded hover:bg-surface-secondary text-text-muted cursor-pointer"
-          >
-            <Chevron size={12} />
-          </button>
-        )}
         <button
           type="button"
           onClick={() => onSelectWorkspace(workspace.id)}
@@ -98,7 +84,7 @@ export function WorkspaceRow(props: Props) {
             e.preventDefault()
             onContextMenuWorkspace?.(e, workspace.id)
           }}
-          className="flex-1 flex items-center gap-2 py-1.5 text-left cursor-pointer"
+          className="flex-1 flex items-center gap-2 py-1.5 text-left cursor-pointer focus:outline-none"
         >
           <WorkspaceIcon
             icon={workspace.icon}
@@ -120,9 +106,23 @@ export function WorkspaceRow(props: Props) {
               onAddTabToWorkspace(workspace.id)
             }}
             onPointerDown={(e) => e.stopPropagation()}
-            className="p-1 rounded hover:bg-surface-secondary text-text-muted cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity"
+            className="p-1 rounded hover:bg-surface-secondary text-text-primary cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity focus:outline-none"
           >
-            <Plus size={12} />
+            <Plus size={14} weight="bold" />
+          </button>
+        )}
+        {showTabs && (
+          <button
+            type="button"
+            aria-label={chevronLabel}
+            aria-expanded={expanded}
+            onClick={(e) => {
+              e.stopPropagation()
+              toggleExpanded(workspace.id)
+            }}
+            className="p-1 mr-0.5 rounded hover:bg-surface-secondary text-text-muted cursor-pointer focus:outline-none"
+          >
+            <Chevron size={12} />
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary

Five small UI tweaks on the activity bar / workspace rows and the Appearance settings page.

- **Activity bar toggle** — pulled out of the Home row; now sits in a dedicated top header inside `ActivityBarWide` with breathing room (matches Claude Code desktop layout rather than glued to the Home row).
- **Workspace hover "+" button** — bolder and brighter (`text-text-primary`, `size={14}`, `weight="bold"`) so it's visible at a glance instead of washed-out muted grey.
- **Expand/collapse chevron** — moved to the right-most position in both `HomeRow` and `WorkspaceRow` (after the row body and the `+` button).
- **Focus outline fix** — `focus:outline-none focus-visible:outline-none` on the header containers and inner buttons; clicking a workspace no longer leaves a stray orange ring from the browser default focus style.
- **Tab Position setting** — replaced the radio-list with the shared `SegmentControl` so it matches the Tab indicator style field.

## Test plan

- [x] `npx vitest run features/workspace/components/HomeRow features/workspace/components/WorkspaceRow features/workspace/components/CollapseButton features/workspace/components/ActivityBar components/settings` — 185/185 pass
- [ ] Visual check: wide activity bar shows collapse button at top with spacing
- [ ] Visual check: hover on workspace row reveals a clearly-visible bold `+`
- [ ] Visual check: chevron sits on the right of the row
- [ ] Visual check: clicking a workspace no longer shows the orange focus outline
- [ ] Visual check: Settings → Appearance → Tab Position renders as a segmented control