### PR TITLE
fix(spa): activity bar tab visual parity with top TabBar

### DIFF
--- a/spa/src/features/workspace/components/HomeRow.tsx
+++ b/spa/src/features/workspace/components/HomeRow.tsx
@@ -79,7 +79,7 @@ export function HomeRow(props: Props) {
               e.stopPropagation()
               toggleExpanded(HOME_WS_KEY)
             }}
-            className="p-1 mr-0.5 rounded hover:bg-surface-secondary text-text-muted cursor-pointer focus:outline-none"
+            className="p-1 mr-0.5 rounded hover:bg-surface-secondary cursor-pointer focus:outline-none"
           >
             <Chevron size={12} />
           </button>

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -107,12 +107,12 @@ export function InlineTab({
 
   const showClose = !tab.locked
 
-  // Active tab visual distinct from active workspace:
-  //   active workspace → purple ring + translucent purple bg (set in WorkspaceRow)
-  //   active tab       → accent left border + elevated surface, no ring
+  // Match upper TabBar visual: no left-border accent; active uses subtle
+  // accent-muted ring + elevated surface, inactive keeps a transparent border
+  // so sibling rows don't shift when toggling active state.
   const activeClasses = isActive
-    ? 'bg-surface-active text-text-primary border-l-2 border-accent-base'
-    : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary border-l-2 border-transparent'
+    ? 'bg-surface-active text-white border border-accent-muted'
+    : 'text-text-muted hover:bg-surface-hover hover:text-text-primary border border-transparent'
 
   return (
     <div
@@ -128,7 +128,7 @@ export function InlineTab({
       onDoubleClick={() => onRename?.(tab.id)}
       onMouseDown={handleMouseDown}
       onContextMenu={(e) => onContextMenu(e, tab.id)}
-      className={`group relative flex items-center gap-1.5 mx-2 pl-6 pr-1.5 py-1 rounded-md text-xs cursor-pointer transition-colors ${activeClasses}`}
+      className={`group relative flex items-center gap-1.5 mx-2 pl-[18px] pr-1.5 py-1 rounded-md text-xs cursor-pointer transition-colors ${activeClasses}`}
     >
       {renderInlineTabIcon({
         IconComponent,

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -108,7 +108,7 @@ export function WorkspaceRow(props: Props) {
               onAddTabToWorkspace(workspace.id)
             }}
             onPointerDown={(e) => e.stopPropagation()}
-            className="p-1 rounded hover:bg-surface-secondary text-text-primary cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity focus:outline-none"
+            className="p-1 rounded hover:bg-surface-secondary cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity focus:outline-none"
           >
             <Plus size={14} weight="bold" />
           </button>
@@ -122,7 +122,7 @@ export function WorkspaceRow(props: Props) {
               e.stopPropagation()
               toggleExpanded(workspace.id)
             }}
-            className="p-1 mr-0.5 rounded hover:bg-surface-secondary text-text-muted cursor-pointer focus:outline-none"
+            className="p-1 mr-0.5 rounded hover:bg-surface-secondary cursor-pointer focus:outline-none"
           >
             <Chevron size={12} />
           </button>

--- a/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
+++ b/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
@@ -10,11 +10,10 @@ interface Params {
   subagentCount: number
 }
 
-// Left-mode variant of the top-tab renderer in SortableTab.tsx. Sizes are tuned
-// for the 12px (xs) row; branching mirrors SortableTab exactly so the two
-// surfaces stay visually coherent.
-const ICON_SIZE = 12
-const DOT_SLOT = 'w-3 h-3'
+// Left-mode variant of the top-tab renderer in SortableTab.tsx. Icon size
+// matches the top TabBar (14px) so both surfaces feel the same weight.
+const ICON_SIZE = 14
+const DOT_SLOT = 'w-3.5 h-3.5'
 
 export function renderInlineTabIcon({
   IconComponent,


### PR DESCRIPTION
## Summary

Left activity bar's `InlineTab` and `WorkspaceRow` now visually align with the top `TabBar` (`SortableTab`):

- **WorkspaceRow / HomeRow**: `+` and chevron buttons drop their hardcoded text colors and inherit from the row, matching the close X's behaviour.
- **InlineTab active border**: was `border-l-2 border-accent-base`. `accent-base` isn't a defined token, so it was falling back to `currentColor` and rendering as a white left stripe. Replaced with `border border-accent-muted` on active / `border border-transparent` on inactive — identical to `SortableTab`.
- **InlineTab colors**: inactive uses `text-text-muted` (was `text-text-secondary`), active uses `text-white` (was `text-text-primary`) to match top tab.
- **InlineTab content**: shifted 6px left (`pl-6` → `pl-[18px]`).
- **Icon size**: `renderInlineTabIcon` was hardcoded at 12px while `SortableTab` renders at 14px. Bumped to 14 with matching `w-3.5 h-3.5` dot slot.

Font-size was already consistent at `text-xs` (12px) on both surfaces — verified via computed style in a live dev server.

## Test plan

- [x] `pnpm run lint` — no new errors (existing lint errors unrelated)
- [x] `npx vitest run` — 1903/1903 pass
- [ ] Visual check in Electron: active InlineTab no longer shows the white left bar; icon size matches top TabBar