### PR TITLE
fix(spa): align InlineTab display rules + refresh tab/settings icons

### DIFF
--- a/spa/src/components/SessionPanel.tsx
+++ b/spa/src/components/SessionPanel.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useAgentStore } from '../stores/useAgentStore'
 import { useHostStore } from '../stores/useHostStore'
-import { Terminal, Lightning, GearSix, Circle, Spinner, CaretDown, CaretRight } from '@phosphor-icons/react'
+import { Terminal, Lightning, Sliders, Circle, Spinner, CaretDown, CaretRight } from '@phosphor-icons/react'
 import SessionStatusBadge from './SessionStatusBadge'
 import { useI18nStore } from '../stores/useI18nStore'
 import { compositeKey } from '../lib/composite-key'
@@ -123,7 +123,7 @@ export default function SessionPanel({ onSettingsOpen, onSelectSession, activeSe
           onClick={onSettingsOpen}
           className="flex items-center gap-2 text-text-secondary hover:text-text-primary text-sm cursor-pointer w-full"
         >
-          <GearSix size={16} />
+          <Sliders size={16} />
           <span>{t('session.settings')}</span>
         </button>
       </div>

--- a/spa/src/components/tab-icon-map.tsx
+++ b/spa/src/components/tab-icon-map.tsx
@@ -1,4 +1,4 @@
-import { Plus, TerminalWindow, ChatCircleDots, House, ClockCounterClockwise, GearSix, SmileySad, Globe } from '@phosphor-icons/react'
+import { Plus, TerminalWindow, ChatCircleDots, House, ClockCounterClockwise, Sliders, SmileySad, Globe, HardDrives, TextAlignLeft } from '@phosphor-icons/react'
 
 // Filled TerminalWindow variant — inlined to avoid a named component export in
 // this otherwise-constant module (react-refresh/only-export-components).
@@ -8,7 +8,9 @@ export const ICON_MAP: Record<string, React.ComponentType<{ size: number; classN
   ChatCircleDots,
   House,
   ClockCounterClockwise,
-  GearSix,
+  Sliders,
   SmileySad,
   Globe,
+  HardDrives,
+  TextAlignLeft,
 }

--- a/spa/src/features/workspace/components/ActivityBarNarrow.tsx
+++ b/spa/src/features/workspace/components/ActivityBarNarrow.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react'
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent, type Modifier } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable'
-import { Plus, GearSix, HardDrives } from '@phosphor-icons/react'
+import { Plus, Sliders, HardDrives } from '@phosphor-icons/react'
 import type { Workspace } from '../../../types/tab'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { WorkspaceIcon } from './WorkspaceIcon'
@@ -215,7 +215,7 @@ export function ActivityBarNarrow({
           onClick={onOpenSettings}
           className="w-[30px] h-[30px] rounded-md flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-secondary cursor-pointer"
         >
-          <GearSix size={16} />
+          <Sliders size={16} />
         </button>
       </div>
       </div>

--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Plus, GearSix, HardDrives } from '@phosphor-icons/react'
+import { Plus, Sliders, HardDrives } from '@phosphor-icons/react'
 import {
   DndContext,
   PointerSensor,
@@ -337,7 +337,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
             onClick={onOpenSettings}
             className="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-text-secondary hover:text-text-primary hover:bg-surface-hover cursor-pointer"
           >
-            <GearSix size={16} />
+            <Sliders size={16} />
             <span className="truncate">{t('nav.settings')}</span>
           </button>
         </div>

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -9,6 +9,7 @@ import { getPaneIcon } from '../../../lib/pane-labels'
 import { compositeKey } from '../../../lib/composite-key'
 import { getAgentIcon } from '../../../lib/agent-icons'
 import { ICON_MAP } from '../../../components/tab-icon-map'
+import { shouldShowGlobalUnreadPip } from '../../../components/tab-icon-helpers'
 import { renderInlineTabIcon } from '../lib/renderInlineTabIcon'
 
 interface Props {
@@ -107,11 +108,10 @@ export function InlineTab({
 
   const showClose = !tab.locked
 
-  // Match upper TabBar visual: no left-border accent; active uses subtle
-  // accent-muted ring + elevated surface, inactive keeps a transparent border
-  // so sibling rows don't shift when toggling active state.
+  // Active surface — no visible border; both states keep a transparent 1px
+  // border so sibling rows don't shift when toggling active state.
   const activeClasses = isActive
-    ? 'bg-surface-active text-white border border-accent-muted'
+    ? 'bg-surface-active text-white border border-transparent'
     : 'text-text-muted hover:bg-surface-hover hover:text-text-primary border border-transparent'
 
   return (
@@ -136,6 +136,7 @@ export function InlineTab({
         tabIndicatorStyle,
         isActive,
         subagentCount,
+        isUnread,
       })}
       <span className="flex-1 truncate" title={tooltip}>
         {displayTitle}
@@ -150,10 +151,10 @@ export function InlineTab({
       {tab.locked && (
         <Lock size={10} data-testid="inline-tab-lock" className="flex-shrink-0" />
       )}
-      {!isActive && isUnread && (
+      {!isActive && isUnread && shouldShowGlobalUnreadPip(tabIndicatorStyle, agentStatus) && (
         <span
           data-testid="inline-tab-unread"
-          className="absolute -top-[2px] -right-[2px] w-1.5 h-1.5 rounded-full z-20"
+          className="absolute -top-[4px] -right-[4px] w-2 h-2 rounded-full z-20"
           style={{ backgroundColor: '#b91c1c' }}
         />
       )}

--- a/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
+++ b/spa/src/features/workspace/components/WorkspaceContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { GearSix, ArrowSquareOut, ArrowSquareIn } from '@phosphor-icons/react'
+import { Sliders, ArrowSquareOut, ArrowSquareIn } from '@phosphor-icons/react'
 import { useI18nStore } from '../../../stores/useI18nStore'
 
 interface Props {
@@ -48,7 +48,7 @@ export function WorkspaceContextMenu({ position, onSettings, onTearOff, onMergeT
           onClick={() => { onSettings(); onClose() }}
           className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-surface-hover cursor-pointer transition-colors"
         >
-          <GearSix size={14} />
+          <Sliders size={14} />
           {t('nav.settings') ?? 'Settings'}
         </button>
 

--- a/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
+++ b/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
@@ -8,6 +8,7 @@ interface Params {
   tabIndicatorStyle: TabIndicatorStyle
   isActive: boolean
   subagentCount: number
+  isUnread?: boolean
 }
 
 // Left-mode variant of the top-tab renderer in SortableTab.tsx. Icon size
@@ -15,12 +16,21 @@ interface Params {
 const ICON_SIZE = 14
 const DOT_SLOT = 'w-3.5 h-3.5'
 
+const UNREAD_PIP = (
+  <span
+    data-testid="inline-tab-unread-pip"
+    className="absolute rounded-full z-20"
+    style={{ width: 5, height: 5, top: -1, right: -2, backgroundColor: '#b91c1c' }}
+  />
+)
+
 export function renderInlineTabIcon({
   IconComponent,
   agentStatus,
   tabIndicatorStyle,
   isActive,
   subagentCount,
+  isUnread = false,
 }: Params) {
   // icon-only OR no agent event → plain icon slot
   if (tabIndicatorStyle === 'icon' || !agentStatus) {
@@ -31,6 +41,9 @@ export function renderInlineTabIcon({
     )
   }
 
+  // error already louder than unread — don't also stack a pip.
+  const showDotUnreadPip = isUnread && !isActive && agentStatus !== 'error'
+
   if (tabIndicatorStyle === 'dot') {
     return (
       <span
@@ -38,6 +51,7 @@ export function renderInlineTabIcon({
         className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0`}
       >
         <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
+        {showDotUnreadPip && UNREAD_PIP}
         {subagentCount > 0 && <SubagentDots count={subagentCount} />}
       </span>
     )
@@ -51,6 +65,7 @@ export function renderInlineTabIcon({
           className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0`}
         >
           <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
+          {showDotUnreadPip && UNREAD_PIP}
           {subagentCount > 0 && <SubagentDots count={subagentCount} />}
         </span>
         {IconComponent && <IconComponent size={ICON_SIZE} className="flex-shrink-0" />}
@@ -58,16 +73,20 @@ export function renderInlineTabIcon({
     )
   }
 
-  // badge: icon + small overlay dot
-  // Nudge the whole icon+badge group 1px right and park subagent dots at
-  // left:-4 so they sit just outside the box edge, clear of the icon.
+  // badge: icon + small overlay dot. Unread tints the overlay dot red
+  // instead of stacking a separate pip (parity with TabIcon badge mode).
   return (
     <span
       data-testid="inline-tab-dot-overlay"
       className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px`}
     >
       {IconComponent && <IconComponent size={ICON_SIZE} className="flex-shrink-0" />}
-      <TabStatusIndicator status={agentStatus} mode="overlay" isActive={isActive} />
+      <TabStatusIndicator
+        status={agentStatus}
+        mode="overlay"
+        isActive={isActive}
+        isUnread={isUnread && !isActive}
+      />
       {subagentCount > 0 && <SubagentDots count={subagentCount} left={-4} />}
     </span>
   )

--- a/spa/src/lib/pane-labels.test.ts
+++ b/spa/src/lib/pane-labels.test.ts
@@ -102,8 +102,8 @@ describe('getPaneIcon', () => {
     expect(getPaneIcon({ kind: 'history' })).toBe('ClockCounterClockwise')
   })
 
-  it('returns GearSix for settings', () => {
-    expect(getPaneIcon({ kind: 'settings', scope: 'global' })).toBe('GearSix')
+  it('returns Sliders for settings', () => {
+    expect(getPaneIcon({ kind: 'settings', scope: 'global' })).toBe('Sliders')
   })
 
   it('returns HardDrives for hosts', () => {
@@ -117,5 +117,13 @@ describe('getPaneIcon', () => {
 
   it('returns ChartBar for memory-monitor', () => {
     expect(getPaneIcon({ kind: 'memory-monitor' })).toBe('ChartBar')
+  })
+
+  it('returns TextAlignLeft for editor', () => {
+    expect(getPaneIcon({ kind: 'editor', filePath: '/x.ts', source: { type: 'local' } })).toBe('TextAlignLeft')
+  })
+
+  it('returns GitDiff for editor diff mode', () => {
+    expect(getPaneIcon({ kind: 'editor', filePath: '/x.ts', source: { type: 'local' }, diff: { against: 'saved' } })).toBe('GitDiff')
   })
 })

--- a/spa/src/lib/pane-labels.ts
+++ b/spa/src/lib/pane-labels.ts
@@ -65,7 +65,7 @@ export function getPaneIcon(content: PaneContent): string {
     case 'history':
       return 'ClockCounterClockwise'
     case 'settings':
-      return 'GearSix'
+      return 'Sliders'
     case 'hosts':
       return 'HardDrives'
     case 'browser':
@@ -73,7 +73,7 @@ export function getPaneIcon(content: PaneContent): string {
     case 'memory-monitor':
       return 'ChartBar'
     case 'editor':
-      return content.diff ? 'GitDiff' : 'File'
+      return content.diff ? 'GitDiff' : 'TextAlignLeft'
     case 'image-preview':
       return 'Image'
     case 'pdf-preview':


### PR DESCRIPTION
## Summary

- **InlineTab 顯示規則對齊 SortableTab**：dot/iconDot 模式內嵌 unread pip，badge 模式改以紅色 overlay，外部 corner pip 加上 \`shouldShowGlobalUnreadPip\` 判定，位置/大小對齊上方 TabBar（\`w-2 h-2\`、\`-top-[4px] -right-[4px]\`）
- **Active tab 移除 border**：\`border border-accent-muted\` → \`border border-transparent\`，兩態都保留透明 1px 邊框，尺寸不變
- **Icon 統一**：
  - host tab：ICON_MAP 補 \`HardDrives\`，上方 TabBar 現在能渲染 host tab icon
  - settings：\`GearSix\` → \`Sliders\`（ActivityBar 寬/窄 + WorkspaceContextMenu + SessionPanel + tab-icon-map + pane-labels）
  - editor（非 diff）：\`File\` → \`TextAlignLeft\`（對齊 VSCode）

SidebarRegion 的 GearSix 是「管理 views」按鈕，非 settings，保留不動。

## Test plan

- [x] \`pnpm vitest run\`：1961 tests pass
- [x] \`pnpm lint\`：我動到的檔案零錯（其餘 9 errors pre-existing）
- [x] \`pnpm build\`：67 pre-existing TS errors，未新增
- [ ] 手動驗證：activity bar 內 active tab 無 accent 邊框、size 不跳；上方 host tab 顯示硬碟 icon；settings tab/按鈕 顯示 sliders；editor tab 顯示對齊左的文字 icon；unread 指示符不再雙重渲染