### PR TITLE
fix(spa): unify InlineTab icon slot with top TabBar (w-4 h-4)

### DIFF
--- a/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
+++ b/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
@@ -11,10 +11,12 @@ interface Params {
   isUnread?: boolean
 }
 
-// Left-mode variant of the top-tab renderer in SortableTab.tsx. Icon size
-// matches the top TabBar (14px) so both surfaces feel the same weight.
+// Left-mode variant of the top-tab renderer in SortableTab.tsx. Slot/icon
+// sizes mirror TabIcon (w-4 h-4 = 16px slot, 14px icon) so post-icon text
+// positions and overlay-dot offsets stay pixel-identical between the
+// activity bar and the top TabBar.
 const ICON_SIZE = 14
-const DOT_SLOT = 'w-3.5 h-3.5'
+const DOT_SLOT = 'w-4 h-4'
 
 const UNREAD_PIP = (
   <span
@@ -59,7 +61,7 @@ export function renderInlineTabIcon({
 
   if (tabIndicatorStyle === 'iconDot') {
     return (
-      <span className="relative inline-flex items-center flex-shrink-0 gap-1">
+      <span className="relative inline-flex items-center flex-shrink-0">
         <span
           data-testid="inline-tab-dot"
           className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0`}


### PR DESCRIPTION
## Summary

- **Icon 同寬佔位**：\`renderInlineTabIcon\` 的 \`DOT_SLOT\` 從 \`w-3.5\` (14px) 改為 \`w-4\` (16px)，跟 \`TabIcon\` 完全一致。14px icon 放進 16px slot 後會有 1px 內距，所有 icon 的顯示寬度統一，tab name 起始 x 對齊
- **Badge 偏移對齊 top bar**：slot 擴大後 \`TabStatusIndicator\` 的 \`top:-1 right:-2\` overlay 座標相對於 icon 的位置跟 top TabBar 一致（之前 slot = icon size，dot 會貼在 icon 邊緣；現在兩邊都是 slot 比 icon 大 2px，dot 浮在 icon 外側）
- **iconDot 結構對齊**：拿掉 \`gap-1\`，跟 \`TabIcon\` 一樣沒有 dot slot 與 icon 之間的額外間距

## Test plan

- [x] \`pnpm vitest run\`：1961 tests pass（含 renderInlineTabIcon + InlineTab 21 tests）
- [x] \`pnpm lint\`：touched 檔案零錯
- [ ] 手動確認：activity bar 的 tab icon（無 agent / 有 agent badge / dot / iconDot）與 top bar 的 badge dot 位置一致；tab name 在不同 icon 下起始位置對齊

Ref PR #444