### PR TITLE
feat(spa): move activity-bar collapse button to TitleBar left slot

### DIFF
--- a/spa/src/components/TitleBar.test.tsx
+++ b/spa/src/components/TitleBar.test.tsx
@@ -22,10 +22,11 @@ describe('TitleBar', () => {
     useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
     render(<TitleBar title="test" />)
     const buttons = screen.getByTestId('layout-buttons').querySelectorAll('button')
-    // CollapseButton + 4 region toggles + 4 layout patterns = 9 buttons
-    expect(buttons).toHaveLength(9)
-    // Only layout pattern buttons (last 4, indices 5-8) should be disabled
-    for (let i = 5; i < 9; i++) {
+    // 4 region toggles + 4 layout patterns = 8 buttons (CollapseButton now
+    // lives in the dedicated sidebar-toggle slot on the left).
+    expect(buttons).toHaveLength(8)
+    // Only layout pattern buttons (last 4, indices 4-7) should be disabled
+    for (let i = 4; i < 8; i++) {
       expect(buttons[i]).toHaveProperty('disabled', true)
     }
   })
@@ -33,7 +34,15 @@ describe('TitleBar', () => {
   it('renders with correct height', () => {
     const { container } = render(<TitleBar title="test" />)
     const bar = container.firstElementChild as HTMLElement
-    expect(bar.getAttribute('style')).toContain('height: 30px')
+    // Height 36 aligns the drawn bar center with the macOS traffic-light
+    // center (y=12 + 6 = 18 ↔ 36/2 = 18).
+    expect(bar.getAttribute('style')).toContain('height: 36px')
+  })
+
+  it('renders the sidebar-toggle slot containing a collapse button', () => {
+    render(<TitleBar title="test" />)
+    const slot = screen.getByTestId('sidebar-toggle')
+    expect(slot.querySelectorAll('button')).toHaveLength(1)
   })
 
   it('calls applyLayout when layout button is clicked', () => {
@@ -42,11 +51,11 @@ describe('TitleBar', () => {
 
     render(<TitleBar title="test" />)
     const buttons = screen.getByTestId('layout-buttons').querySelectorAll('button')
-    // Layout pattern buttons start after CollapseButton + 4 region toggles (index 5)
-    expect(buttons[5]).toHaveProperty('disabled', false)
+    // Layout pattern buttons start after 4 region toggles (index 4)
+    expect(buttons[4]).toHaveProperty('disabled', false)
 
-    // Click "Split horizontal" (second layout pattern button = index 6)
-    fireEvent.click(buttons[6])
+    // Click "Split horizontal" (second layout pattern button = index 5)
+    fireEvent.click(buttons[5])
     const updated = useTabStore.getState().tabs[tab.id]
     expect(updated.layout.type).toBe('split')
   })
@@ -55,7 +64,7 @@ describe('TitleBar', () => {
     useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
     render(<TitleBar title="test" />)
     const buttons = screen.getByTestId('layout-buttons').querySelectorAll('button')
-    for (let i = 5; i < 9; i++) {
+    for (let i = 4; i < 8; i++) {
       expect(buttons[i]).toHaveProperty('disabled', true)
     }
   })

--- a/spa/src/components/TitleBar.tsx
+++ b/spa/src/components/TitleBar.tsx
@@ -51,8 +51,18 @@ export function TitleBar({ title }: Props) {
   return (
     <div
       className="shrink-0 relative flex items-center bg-surface-secondary border-b border-border-subtle px-2"
-      style={{ height: 30, WebkitAppRegion: 'drag' } as React.CSSProperties}
+      style={{ height: 36, WebkitAppRegion: 'drag' } as React.CSSProperties}
     >
+      {/* macOS traffic-light reserve (titleBarStyle='hiddenInset' draws them at x=12, y=12). */}
+      <div className="w-[72px] shrink-0" aria-hidden="true" />
+      <div
+        data-testid="sidebar-toggle"
+        className="shrink-0 flex items-center"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      >
+        <CollapseButton variant="topbar" />
+      </div>
+
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none select-none px-2 gap-2">
         <span className="text-xs text-text-secondary truncate max-w-[calc(100%-27rem)]">{title}</span>
         {showSyncWarning && (
@@ -74,8 +84,6 @@ export function TitleBar({ title }: Props) {
         className="shrink-0 flex items-center gap-0.5"
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
-        <CollapseButton variant="topbar" />
-        <div className="w-px h-3.5 bg-border-subtle mx-0.5" />
         {regionToggles.map(({ region, icon: Icon, label, mirror }) => {
           const isVisible = regions[region].mode !== 'hidden'
           return (

--- a/spa/src/features/workspace/components/ActivityBarNarrow.tsx
+++ b/spa/src/features/workspace/components/ActivityBarNarrow.tsx
@@ -5,7 +5,6 @@ import { Plus, Sliders, HardDrives } from '@phosphor-icons/react'
 import type { Workspace } from '../../../types/tab'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { WorkspaceIcon } from './WorkspaceIcon'
-import { CollapseButton } from './CollapseButton'
 import { useWorkspaceIndicators } from '../useWorkspaceIndicators'
 import type { ActiveStatus } from '../workspace-indicators'
 import type { ActivityBarProps } from './activity-bar-props'
@@ -219,7 +218,6 @@ export function ActivityBarNarrow({
         </button>
       </div>
       </div>
-      <CollapseButton variant="divider" />
     </div>
   )
 }

--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -28,7 +28,6 @@ import { useTabStore } from '../../../stores/useTabStore'
 import { RegionResize } from '../../../components/RegionResize'
 import { WorkspaceRow } from './WorkspaceRow'
 import { HomeRow } from './HomeRow'
-import { CollapseButton } from './CollapseButton'
 import type { ActivityBarProps } from './activity-bar-props'
 import { computeDragEndAction, dispatchDragEndAction, type DragData } from '../lib/computeDragEndAction'
 import { useSpringLoad } from '../lib/useSpringLoad'
@@ -262,10 +261,6 @@ export function ActivityBarWide(props: ActivityBarProps) {
         className="hidden lg:flex flex-col bg-surface-tertiary border-r border-border-subtle py-2 gap-0.5 flex-shrink-0 overflow-y-auto"
         style={{ width: renderedSize }}
       >
-        <div className="flex items-center px-3 pt-0.5 pb-1.5">
-          <CollapseButton variant="header-right" />
-        </div>
-
         <DndContext
           sensors={sensors}
           collisionDetection={customCollisionDetection}

--- a/spa/src/features/workspace/components/CollapseButton.tsx
+++ b/spa/src/features/workspace/components/CollapseButton.tsx
@@ -8,11 +8,18 @@ interface Props {
   variant?: Variant
 }
 
+// topbar: inline-padding layout that matches the TitleBar's region-toggle /
+// layout-pattern buttons so the collapse control reads as a sibling of them.
 const VARIANT_CLASSES: Record<Variant, string> = {
   'header-right': 'w-6 h-6 rounded-md',
-  // Divider: floats on the narrow bar's right edge, hover-revealed.
   divider: 'absolute top-3 right-[-11px] w-[22px] h-[22px] rounded-full bg-surface-tertiary border border-border-subtle shadow-sm opacity-0 group-hover/narrow-bar:opacity-100 focus:opacity-100 transition-opacity z-10',
-  topbar: 'w-6 h-6 rounded',
+  topbar: 'p-1 rounded',
+}
+
+const ICON_SIZE: Record<Variant, number> = {
+  'header-right': 12,
+  divider: 12,
+  topbar: 14,
 }
 
 export function CollapseButton({ variant = 'header-right' }: Props) {
@@ -41,13 +48,13 @@ export function CollapseButton({ variant = 'header-right' }: Props) {
       aria-pressed={isWide}
       data-variant={variant}
       onClick={toggle}
-      className={`${VARIANT_CLASSES[variant]} flex items-center justify-center transition ${
+      className={`${VARIANT_CLASSES[variant]} flex items-center justify-center transition-colors ${
         locked
           ? 'text-text-muted/50 cursor-not-allowed'
-          : 'cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-secondary'
+          : 'cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-hover'
       }`}
     >
-      <Icon size={12} />
+      <Icon size={ICON_SIZE[variant]} />
     </button>
   )
 }


### PR DESCRIPTION
## Summary

- **位置搬家（Task 1）**：CollapseButton 從 ActivityBarWide 的 header-right 與 ActivityBarNarrow 的 divider 位置移除，改到 TitleBar 左側，放在 macOS 72px traffic-light 保留區後的 \`sidebar-toggle\` 槽（參考 Claude.ai）
- **顏色樣式（Task 2）**：CollapseButton \`topbar\` variant 改成 \`p-1 rounded\` + 14px icon + \`hover:bg-surface-hover\`，跟 TitleBar 右側版面切換 / layout pattern 按鈕同一個視覺 family
- **展開下失效修正（Task 3）**：按鈕從 ActivityBar 內部（被 DndContext 包覆的 scrollable 區塊）搬出，改掛在 TitleBar 上，不再受任何父元素 pointer 攔截影響
- **Top bar 高度置中（Task 4）**：TitleBar height \`30px\` → \`36px\`。macOS traffic-light 畫在 y=12、直徑 ~12px，中心約 18px；36/2 = 18，TitleBar 中心與 traffic-light 中心對齊

## Test plan

- [x] \`pnpm vitest run\`：1962 tests pass（新增 sidebar-toggle 存在性測試；調整 layout-buttons 按鈕數 9→8 與 disabled 索引 4-7）
- [x] \`pnpm lint\`：touched 檔案零錯
- [ ] 手動驗證：
  - traffic-light 上下置中於 top bar
  - \`<<\` / \`>>\` 按鈕出現在 top bar 左側（緊接 traffic light 右邊）
  - 點擊按鈕可在 wide ↔ narrow 來回切換
  - tabPosition 為 left / both 時按鈕 disabled（locked 狀態）