### PR TITLE
refactor(spa): extract useTabDisplay hook for SortableTab + InlineTab

### DIFF
--- a/spa/src/components/SortableTab.test.tsx
+++ b/spa/src/components/SortableTab.test.tsx
@@ -46,7 +46,6 @@ const defaultProps = {
   onClose: vi.fn(),
   onMiddleClick: vi.fn(),
   onContextMenu: vi.fn(),
-  iconMap: {} as Record<string, React.ComponentType<{ size: number; className?: string }>>,
 }
 
 beforeEach(() => {

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -1,20 +1,10 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { X, Lock, WifiSlash } from '@phosphor-icons/react'
 import type { Tab } from '../types/tab'
-import { getPaneIcon, getPaneLabel } from '../lib/pane-labels'
-import { getPrimaryPane } from '../lib/pane-tree'
-import { useSessionStore } from '../stores/useSessionStore'
-import { useHostStore } from '../stores/useHostStore'
-import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { useI18nStore } from '../stores/useI18nStore'
-import { useAgentStore } from '../stores/useAgentStore'
-import { compositeKey } from '../lib/composite-key'
-import { getAgentIcon } from '../lib/agent-icons'
+import { useTabDisplay } from '../hooks/useTabDisplay'
 import { TabIcon } from './TabIcon'
 import { shouldShowGlobalUnreadPip } from './tab-icon-helpers'
-import type { Session } from '../lib/host-api'
-
-const EMPTY_SESSIONS: Session[] = []
 
 interface Props {
   tab: Tab
@@ -26,7 +16,6 @@ interface Props {
   onContextMenu: (e: React.MouseEvent, tabId: string) => void
   onRename?: (tabId: string) => void
   onHover?: (tabId: string | null) => void
-  iconMap: Record<string, React.ComponentType<{ size: number; className?: string }>>
 }
 
 // Composite bg colors (canvas-verified for opaque X button bg)
@@ -34,7 +23,7 @@ interface Props {
 const TAB_BG_INACTIVE = 'var(--surface-secondary)'
 const TAB_BG_ACTIVE = 'var(--surface-active)'
 
-export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddleClick, onContextMenu, onRename, onHover, iconMap }: Props) {
+export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddleClick, onContextMenu, onRename, onHover }: Props) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: tab.id })
 
   const style = {
@@ -44,49 +33,17 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
     opacity: 1,
   }
 
-  const primaryContent = getPrimaryPane(tab.layout).content
-  const iconName = getPaneIcon(primaryContent)
-  const paneIcon = iconMap[iconName]
-
   const t = useI18nStore((s) => s.t)
-  const hostId = primaryContent.kind === 'tmux-session' ? primaryContent.hostId : ''
-  const sessions = useSessionStore((s) => (hostId ? s.sessions[hostId] : undefined) ?? EMPTY_SESSIONS)
-  const workspaces = useWorkspaceStore((s) => s.workspaces)
-
-  const sessionCode = primaryContent.kind === 'tmux-session' ? primaryContent.sessionCode : undefined
-  const ck = sessionCode && hostId ? compositeKey(hostId, sessionCode) : undefined
-  const agentStatus = useAgentStore((s) => {
-    if (!ck) return undefined
-    // No fallback — only show indicator when we have an actual hook event.
-    // Previously fell back to 'idle' when hooksInstalled was true, but that
-    // made it impossible to distinguish "agent running, first event pending"
-    // from "no agent running at all".
-    return s.statuses[ck]
-  })
-  const isUnread = useAgentStore((s) => ck ? !!s.unread[ck] : false)
-  const subagentCount = useAgentStore((s) => ck ? (s.subagents[ck]?.length ?? 0) : 0)
-  const agentType = useAgentStore((s) => ck ? s.agentTypes[ck] : undefined)
-  const tabIndicatorStyle = useAgentStore((s) => s.tabIndicatorStyle)
-  const ccIconVariant = useAgentStore((s) => s.ccIconVariant)
-  const showOscTitle = useAgentStore((s) => s.showOscTitle)
-  const oscTitle = useAgentStore((s) => ck ? s.oscTitles[ck] : undefined)
-  const isTerminated = primaryContent.kind === 'tmux-session' && !!primaryContent.terminated
-  // Keep the terminated pane's SmileySad tombstone instead of the agent icon.
-  const agentIcon = !isTerminated && agentType ? getAgentIcon(agentType, { ccVariant: ccIconVariant }) : undefined
-  const IconComponent = (agentIcon ?? paneIcon) as React.ComponentType<{ size: number; className?: string }> | undefined
-  const isHostOffline = useHostStore((s) => {
-    if (!hostId || isTerminated) return false
-    const rt = s.runtime[hostId]
-    return rt ? rt.status !== 'connected' : false
-  })
-  const sessionLookup = { getByCode: (code: string) => sessions.find((s) => s.code === code) }
-  const workspaceLookup = { getById: (id: string) => workspaces.find((w) => w.id === id) }
-  const sessionLabel = getPaneLabel(primaryContent, sessionLookup, workspaceLookup, t)
-  // Shell-only (non-agent) sessions keep their session name; OSC only takes
-  // over once an agent identifies itself and emits a title.
-  const useOsc = showOscTitle && !isTerminated && !!agentType && !!oscTitle
-  const label = useOsc && oscTitle ? oscTitle : sessionLabel
-  const tooltip = useOsc && oscTitle ? `${oscTitle} - ${sessionLabel}` : sessionLabel
+  const {
+    displayTitle: label,
+    tooltip,
+    IconComponent,
+    agentStatus,
+    isUnread,
+    subagentCount,
+    tabIndicatorStyle,
+    isHostOffline,
+  } = useTabDisplay(tab)
 
   // Prevent focus theft when clicking the already-active tab.
   // Must wrap dnd-kit's onPointerDown to avoid overriding it.

--- a/spa/src/components/TabBar.tsx
+++ b/spa/src/components/TabBar.tsx
@@ -6,7 +6,6 @@ import { SortableTab } from './SortableTab'
 import { useScrollOverflow } from '../hooks/useScrollOverflow'
 import type { Tab } from '../types/tab'
 import { useI18nStore } from '../stores/useI18nStore'
-import { ICON_MAP } from './tab-icon-map'
 
 interface Props {
   tabs: Tab[]
@@ -108,7 +107,6 @@ export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, o
                       onContextMenu={onContextMenu}
                       onRename={onRenameTab}
                       onHover={setHoveredTabId}
-                      iconMap={ICON_MAP}
                     />
                   </Fragment>
                 ))}
@@ -144,7 +142,6 @@ export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, o
                       onContextMenu={onContextMenu}
                       onRename={onRenameTab}
                       onHover={setHoveredTabId}
-                      iconMap={ICON_MAP}
                     />
                   </Fragment>
                 ))}

--- a/spa/src/features/workspace/components/InlineTab.test.tsx
+++ b/spa/src/features/workspace/components/InlineTab.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { useAgentStore } from '../../../stores/useAgentStore'
 import { useHostStore } from '../../../stores/useHostStore'
 import { useLayoutStore } from '../../../stores/useLayoutStore'
+import { useSessionStore } from '../../../stores/useSessionStore'
 import type { Tab } from '../../../types/tab'
 
 const mockOnPointerDown = vi.fn()
@@ -44,6 +45,12 @@ beforeEach(() => {
     tabIndicatorStyle: 'badge',
     ccIconVariant: 'bot',
   })
+  useSessionStore.setState({
+    sessions: { h1: [{ code: 'S1', name: 'work' }] as never },
+    activeHostId: null,
+    activeCode: null,
+  })
+  useHostStore.setState({ runtime: {} })
   useLayoutStore.setState(useLayoutStore.getInitialState())
 })
 
@@ -53,7 +60,6 @@ describe('InlineTab — indicator styles', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}
@@ -69,7 +75,6 @@ describe('InlineTab — indicator styles', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}
@@ -84,7 +89,6 @@ describe('InlineTab — indicator styles', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}
@@ -100,7 +104,6 @@ describe('InlineTab — indicator styles', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={onClose}
@@ -119,7 +122,6 @@ describe('InlineTab — close button visibility', () => {
     render(
       <InlineTab
         tab={locked}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}
@@ -135,7 +137,6 @@ describe('InlineTab — close button visibility', () => {
     render(
       <InlineTab
         tab={locked}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}
@@ -153,7 +154,6 @@ describe('InlineTab — unread dot', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}
@@ -169,7 +169,6 @@ describe('InlineTab — unread dot', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive={true}
         onSelect={() => {}}
         onClose={() => {}}
@@ -189,7 +188,6 @@ describe('InlineTab — host offline', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}
@@ -217,7 +215,6 @@ describe('InlineTab — host offline', () => {
     render(
       <InlineTab
         tab={terminated}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}
@@ -234,7 +231,6 @@ describe('InlineTab — pointer down (dnd-kit integration)', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}
@@ -250,7 +246,6 @@ describe('InlineTab — pointer down (dnd-kit integration)', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive
         onSelect={() => {}}
         onClose={() => {}}
@@ -268,7 +263,6 @@ describe('InlineTab — pointer down (dnd-kit integration)', () => {
     render(
       <InlineTab
         tab={baseTab}
-        title="work"
         isActive={false}
         onSelect={() => {}}
         onClose={() => {}}

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -8,7 +8,6 @@ import { renderInlineTabIcon } from '../lib/renderInlineTabIcon'
 
 interface Props {
   tab: Tab
-  title: string
   isActive: boolean
   sourceWsId?: string | null
   onSelect: (tabId: string) => void
@@ -20,7 +19,6 @@ interface Props {
 
 export function InlineTab({
   tab,
-  title,
   isActive,
   sourceWsId = null,
   onSelect,
@@ -44,7 +42,7 @@ export function InlineTab({
     subagentCount,
     tabIndicatorStyle,
     isHostOffline,
-  } = useTabDisplay(tab, { titleOverride: title })
+  } = useTabDisplay(tab)
 
   // Vertical-only drag — x locked to 0 so the row never slides horizontally
   // across the activity bar border.
@@ -136,7 +134,7 @@ export function InlineTab({
       {showClose && (
         <button
           type="button"
-          aria-label={`Close ${title}`}
+          aria-label={`Close ${displayTitle}`}
           title={t('common.close')}
           onClick={handleCloseClick}
           onMouseDown={(e) => e.stopPropagation()}

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -2,13 +2,7 @@ import { X, Lock, WifiSlash } from '@phosphor-icons/react'
 import { useSortable } from '@dnd-kit/sortable'
 import type { Tab } from '../../../types/tab'
 import { useI18nStore } from '../../../stores/useI18nStore'
-import { useAgentStore } from '../../../stores/useAgentStore'
-import { useHostStore } from '../../../stores/useHostStore'
-import { getPrimaryPane } from '../../../lib/pane-tree'
-import { getPaneIcon } from '../../../lib/pane-labels'
-import { compositeKey } from '../../../lib/composite-key'
-import { getAgentIcon } from '../../../lib/agent-icons'
-import { ICON_MAP } from '../../../components/tab-icon-map'
+import { useTabDisplay } from '../../../hooks/useTabDisplay'
 import { shouldShowGlobalUnreadPip } from '../../../components/tab-icon-helpers'
 import { renderInlineTabIcon } from '../lib/renderInlineTabIcon'
 
@@ -41,35 +35,16 @@ export function InlineTab({
     data: { type: 'tab', tabId: tab.id, sourceWsId, isPinned: tab.pinned },
   })
 
-  const primaryContent = getPrimaryPane(tab.layout).content
-  const hostId = primaryContent.kind === 'tmux-session' ? primaryContent.hostId : ''
-  const sessionCode = primaryContent.kind === 'tmux-session' ? primaryContent.sessionCode : undefined
-  const ck = sessionCode && hostId ? compositeKey(hostId, sessionCode) : undefined
-
-  const agentStatus = useAgentStore((s) => (ck ? s.statuses[ck] : undefined))
-  const isUnread = useAgentStore((s) => (ck ? !!s.unread[ck] : false))
-  const subagentCount = useAgentStore((s) => (ck ? (s.subagents[ck]?.length ?? 0) : 0))
-  const agentType = useAgentStore((s) => (ck ? s.agentTypes[ck] : undefined))
-  const tabIndicatorStyle = useAgentStore((s) => s.tabIndicatorStyle)
-  const ccIconVariant = useAgentStore((s) => s.ccIconVariant)
-  const showOscTitle = useAgentStore((s) => s.showOscTitle)
-  const oscTitle = useAgentStore((s) => (ck ? s.oscTitles[ck] : undefined))
-
-  const isTerminated = primaryContent.kind === 'tmux-session' && !!primaryContent.terminated
-
-  const useOsc = showOscTitle && !isTerminated && !!agentType && !!oscTitle
-  const displayTitle = useOsc && oscTitle ? oscTitle : title
-  const tooltip = useOsc && oscTitle ? `${oscTitle} - ${title}` : title
-  const isHostOffline = useHostStore((s) => {
-    if (!hostId || isTerminated) return false
-    const rt = s.runtime[hostId]
-    return rt ? rt.status !== 'connected' : false
-  })
-
-  const iconName = getPaneIcon(primaryContent)
-  const paneIcon = ICON_MAP[iconName]
-  const agentIcon = !isTerminated && agentType ? getAgentIcon(agentType, { ccVariant: ccIconVariant }) : undefined
-  const IconComponent = (agentIcon ?? paneIcon) as React.ComponentType<{ size: number; className?: string }> | undefined
+  const {
+    displayTitle,
+    tooltip,
+    IconComponent,
+    agentStatus,
+    isUnread,
+    subagentCount,
+    tabIndicatorStyle,
+    isHostOffline,
+  } = useTabDisplay(tab, { titleOverride: title })
 
   // Vertical-only drag — x locked to 0 so the row never slides horizontally
   // across the activity bar border.

--- a/spa/src/features/workspace/components/InlineTabList.tsx
+++ b/spa/src/features/workspace/components/InlineTabList.tsx
@@ -2,10 +2,6 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import type { Tab } from '../../../types/tab'
 import { InlineTab } from './InlineTab'
 import { useI18nStore } from '../../../stores/useI18nStore'
-import { useSessionStore } from '../../../stores/useSessionStore'
-import { useWorkspaceStore } from '../../../stores/useWorkspaceStore'
-import { getPaneLabel } from '../../../lib/pane-labels'
-import { getPrimaryPane } from '../../../lib/pane-tree'
 
 interface Props {
   tabIds: string[]
@@ -31,25 +27,6 @@ export function InlineTabList({
   onRename,
 }: Props) {
   const t = useI18nStore((s) => s.t)
-  const sessionsByHost = useSessionStore((s) => s.sessions)
-  const workspaces = useWorkspaceStore((s) => s.workspaces)
-
-  // Sessions are stored nested by hostId — flatten and search across all hosts
-  // for name lookup. Collisions (same code across hosts) are rare and the
-  // label falls back gracefully to cachedName/sessionCode when missing.
-  const sessionLookup = {
-    getByCode: (code: string) => {
-      for (const hostId in sessionsByHost) {
-        const found = sessionsByHost[hostId]?.find((s) => s.code === code)
-        if (found) return found
-      }
-      return undefined
-    },
-  }
-  const workspaceLookup = {
-    getById: (id: string) => workspaces.find((w) => w.id === id),
-  }
-
   const validIds = tabIds.filter((id) => !!tabsById[id])
 
   if (validIds.length === 0) {
@@ -63,25 +40,19 @@ export function InlineTabList({
   return (
     <SortableContext items={validIds} strategy={verticalListSortingStrategy}>
       <div className="flex flex-col gap-0.5 py-0.5">
-        {validIds.map((id) => {
-          const tab = tabsById[id]
-          const primaryContent = getPrimaryPane(tab.layout).content
-          const title = getPaneLabel(primaryContent, sessionLookup, workspaceLookup, t)
-          return (
-            <InlineTab
-              key={id}
-              tab={tab}
-              title={title}
-              isActive={activeTabId === id}
-              sourceWsId={sourceWsId}
-              onSelect={onSelect}
-              onClose={onClose}
-              onMiddleClick={onMiddleClick}
-              onContextMenu={onContextMenu}
-              onRename={onRename}
-            />
-          )
-        })}
+        {validIds.map((id) => (
+          <InlineTab
+            key={id}
+            tab={tabsById[id]}
+            isActive={activeTabId === id}
+            sourceWsId={sourceWsId}
+            onSelect={onSelect}
+            onClose={onClose}
+            onMiddleClick={onMiddleClick}
+            onContextMenu={onContextMenu}
+            onRename={onRename}
+          />
+        ))}
       </div>
     </SortableContext>
   )

--- a/spa/src/hooks/useTabDisplay.test.ts
+++ b/spa/src/hooks/useTabDisplay.test.ts
@@ -58,10 +58,22 @@ describe('useTabDisplay — label resolution', () => {
     expect(result.current.displayTitle).toBe('sc1')
   })
 
-  it('uses titleOverride when provided', () => {
-    const { result } = renderHook(() => useTabDisplay(makeTab(), { titleOverride: 'custom' }))
-    expect(result.current.displayTitle).toBe('custom')
-    expect(result.current.tooltip).toBe('custom')
+  it('falls back to cachedName when session not found and cachedName present', () => {
+    const { result } = renderHook(() => useTabDisplay(makeTab({ cachedName: 'cached' })))
+    expect(result.current.displayTitle).toBe('cached')
+  })
+
+  it('scopes session lookup to the tabs own hostId (no cross-host collisions)', () => {
+    useSessionStore.setState({
+      sessions: {
+        h1: [{ code: 'sc1', name: 'correct' }] as never,
+        h2: [{ code: 'sc1', name: 'wrong-host' }] as never,
+      },
+      activeHostId: null,
+      activeCode: null,
+    })
+    const { result } = renderHook(() => useTabDisplay(makeTab({ hostId: 'h1' })))
+    expect(result.current.displayTitle).toBe('correct')
   })
 })
 

--- a/spa/src/hooks/useTabDisplay.test.ts
+++ b/spa/src/hooks/useTabDisplay.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useAgentStore } from '../stores/useAgentStore'
+import { useHostStore } from '../stores/useHostStore'
+import { useSessionStore } from '../stores/useSessionStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+import { useI18nStore } from '../stores/useI18nStore'
+import { createTab } from '../types/tab'
+import type { Tab } from '../types/tab'
+import { useTabDisplay } from './useTabDisplay'
+
+function makeTab(
+  overrides: Partial<{ hostId: string; sessionCode: string; terminated: boolean; cachedName: string; mode: 'terminal' | 'stream' }> = {},
+): Tab {
+  const tab = createTab({
+    kind: 'tmux-session',
+    hostId: overrides.hostId ?? 'h1',
+    sessionCode: overrides.sessionCode ?? 'sc1',
+    mode: overrides.mode ?? 'terminal',
+    cachedName: overrides.cachedName ?? '',
+    tmuxInstance: '',
+    terminated: overrides.terminated ? 'session-closed' : undefined,
+  } as never)
+  return { ...tab, id: 't1' }
+}
+
+beforeEach(() => {
+  useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
+  useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: null })
+  useHostStore.setState({ runtime: {} })
+  useAgentStore.setState({
+    unread: {},
+    statuses: {},
+    subagents: {},
+    agentTypes: {},
+    oscTitles: {},
+    tabIndicatorStyle: 'badge',
+    ccIconVariant: 'bot',
+    showOscTitle: false,
+  })
+  useI18nStore.setState({ t: (k: string) => k })
+})
+
+describe('useTabDisplay — label resolution', () => {
+  it('uses session name from session store when available', () => {
+    useSessionStore.setState({
+      sessions: { h1: [{ code: 'sc1', name: 'my-session' }] as never },
+      activeHostId: null,
+      activeCode: null,
+    })
+    const { result } = renderHook(() => useTabDisplay(makeTab()))
+    expect(result.current.displayTitle).toBe('my-session')
+    expect(result.current.tooltip).toBe('my-session')
+  })
+
+  it('falls back to sessionCode when session not found', () => {
+    const { result } = renderHook(() => useTabDisplay(makeTab()))
+    expect(result.current.displayTitle).toBe('sc1')
+  })
+
+  it('uses titleOverride when provided', () => {
+    const { result } = renderHook(() => useTabDisplay(makeTab(), { titleOverride: 'custom' }))
+    expect(result.current.displayTitle).toBe('custom')
+    expect(result.current.tooltip).toBe('custom')
+  })
+})
+
+describe('useTabDisplay — OSC title override', () => {
+  it('uses OSC title when showOscTitle + agentType + oscTitle are all set', () => {
+    useSessionStore.setState({
+      sessions: { h1: [{ code: 'sc1', name: 'base' }] as never },
+      activeHostId: null,
+      activeCode: null,
+    })
+    useAgentStore.setState({
+      showOscTitle: true,
+      agentTypes: { 'h1:sc1': 'cc' },
+      oscTitles: { 'h1:sc1': 'claude' },
+    })
+    const { result } = renderHook(() => useTabDisplay(makeTab()))
+    expect(result.current.displayTitle).toBe('claude')
+    expect(result.current.tooltip).toBe('claude - base')
+  })
+
+  it('ignores OSC when showOscTitle is off', () => {
+    useAgentStore.setState({
+      showOscTitle: false,
+      agentTypes: { 'h1:sc1': 'cc' },
+      oscTitles: { 'h1:sc1': 'claude' },
+    })
+    const { result } = renderHook(() => useTabDisplay(makeTab({ cachedName: 'fallback' })))
+    expect(result.current.displayTitle).toBe('fallback')
+  })
+
+  it('ignores OSC on terminated session', () => {
+    useAgentStore.setState({
+      showOscTitle: true,
+      agentTypes: { 'h1:sc1': 'cc' },
+      oscTitles: { 'h1:sc1': 'claude' },
+    })
+    const { result } = renderHook(() => useTabDisplay(makeTab({ terminated: true, cachedName: 'gone' })))
+    expect(result.current.displayTitle).toBe('gone（Terminated）')
+  })
+})
+
+describe('useTabDisplay — icon resolution', () => {
+  it('returns agent icon when agentType is present and not terminated', () => {
+    useAgentStore.setState({ agentTypes: { 'h1:sc1': 'cc' } })
+    const { result } = renderHook(() => useTabDisplay(makeTab()))
+    expect(result.current.IconComponent).toBeDefined()
+  })
+
+  it('returns pane icon on terminated session regardless of agentType', () => {
+    useAgentStore.setState({ agentTypes: { 'h1:sc1': 'cc' } })
+    const { result } = renderHook(() => useTabDisplay(makeTab({ terminated: true })))
+    expect(result.current.IconComponent).toBeDefined()
+    expect(result.current.isTerminated).toBe(true)
+  })
+})
+
+describe('useTabDisplay — host offline', () => {
+  it('flags host offline when runtime status is not connected', () => {
+    useHostStore.setState({ runtime: { h1: { status: 'disconnected' } } } as never)
+    const { result } = renderHook(() => useTabDisplay(makeTab()))
+    expect(result.current.isHostOffline).toBe(true)
+  })
+
+  it('does not flag host offline when tab is terminated', () => {
+    useHostStore.setState({ runtime: { h1: { status: 'disconnected' } } } as never)
+    const { result } = renderHook(() => useTabDisplay(makeTab({ terminated: true })))
+    expect(result.current.isHostOffline).toBe(false)
+  })
+
+  it('does not flag host offline when host is connected', () => {
+    useHostStore.setState({ runtime: { h1: { status: 'connected' } } } as never)
+    const { result } = renderHook(() => useTabDisplay(makeTab()))
+    expect(result.current.isHostOffline).toBe(false)
+  })
+})
+
+describe('useTabDisplay — agent store fields', () => {
+  it('exposes agentStatus, unread, subagentCount, tabIndicatorStyle', () => {
+    useAgentStore.setState({
+      statuses: { 'h1:sc1': 'running' },
+      unread: { 'h1:sc1': true },
+      subagents: { 'h1:sc1': [{ id: 's1' }] as never },
+      tabIndicatorStyle: 'dot',
+    })
+    const { result } = renderHook(() => useTabDisplay(makeTab()))
+    expect(result.current.agentStatus).toBe('running')
+    expect(result.current.isUnread).toBe(true)
+    expect(result.current.subagentCount).toBe(1)
+    expect(result.current.tabIndicatorStyle).toBe('dot')
+  })
+})

--- a/spa/src/hooks/useTabDisplay.ts
+++ b/spa/src/hooks/useTabDisplay.ts
@@ -1,0 +1,103 @@
+import type { ComponentType } from 'react'
+import type { Tab } from '../types/tab'
+import type { AgentStatus, TabIndicatorStyle } from '../stores/useAgentStore'
+import { useAgentStore } from '../stores/useAgentStore'
+import { useHostStore } from '../stores/useHostStore'
+import { useSessionStore } from '../stores/useSessionStore'
+import { useWorkspaceStore } from '../stores/useWorkspaceStore'
+import { useI18nStore } from '../stores/useI18nStore'
+import { getPrimaryPane } from '../lib/pane-tree'
+import { getPaneIcon, getPaneLabel } from '../lib/pane-labels'
+import { compositeKey } from '../lib/composite-key'
+import { getAgentIcon } from '../lib/agent-icons'
+import { ICON_MAP } from '../components/tab-icon-map'
+import type { Session } from '../lib/host-api'
+
+const EMPTY_SESSIONS: Session[] = []
+
+export type TabIconComponent = ComponentType<{ size: number; className?: string }>
+
+export interface TabDisplayData {
+  displayTitle: string
+  tooltip: string
+  IconComponent: TabIconComponent | undefined
+  agentStatus: AgentStatus | undefined
+  isUnread: boolean
+  subagentCount: number
+  tabIndicatorStyle: TabIndicatorStyle
+  isHostOffline: boolean
+  isTerminated: boolean
+  hostId: string
+  sessionCode: string | undefined
+  compositeKey: string | undefined
+}
+
+interface Options {
+  /** Override the base label; OSC still takes precedence when active. */
+  titleOverride?: string
+}
+
+/**
+ * Shared tab display state for InlineTab (activity bar) and SortableTab (top
+ * TabBar). Centralises OSC title resolution, agent-icon fallback, host-offline
+ * detection, and agent store reads so both surfaces render consistently.
+ */
+export function useTabDisplay(tab: Tab, options?: Options): TabDisplayData {
+  const t = useI18nStore((s) => s.t)
+  const primaryContent = getPrimaryPane(tab.layout).content
+  const hostId = primaryContent.kind === 'tmux-session' ? primaryContent.hostId : ''
+  const sessionCode = primaryContent.kind === 'tmux-session' ? primaryContent.sessionCode : undefined
+  const ck = sessionCode && hostId ? compositeKey(hostId, sessionCode) : undefined
+  const isTerminated = primaryContent.kind === 'tmux-session' && !!primaryContent.terminated
+
+  const sessions = useSessionStore((s) => (hostId ? s.sessions[hostId] : undefined) ?? EMPTY_SESSIONS)
+  const workspaces = useWorkspaceStore((s) => s.workspaces)
+
+  const agentStatus = useAgentStore((s) => (ck ? s.statuses[ck] : undefined))
+  const isUnread = useAgentStore((s) => (ck ? !!s.unread[ck] : false))
+  const subagentCount = useAgentStore((s) => (ck ? (s.subagents[ck]?.length ?? 0) : 0))
+  const agentType = useAgentStore((s) => (ck ? s.agentTypes[ck] : undefined))
+  const tabIndicatorStyle = useAgentStore((s) => s.tabIndicatorStyle)
+  const ccIconVariant = useAgentStore((s) => s.ccIconVariant)
+  const showOscTitle = useAgentStore((s) => s.showOscTitle)
+  const oscTitle = useAgentStore((s) => (ck ? s.oscTitles[ck] : undefined))
+
+  const isHostOffline = useHostStore((s) => {
+    if (!hostId || isTerminated) return false
+    const rt = s.runtime[hostId]
+    return rt ? rt.status !== 'connected' : false
+  })
+
+  const iconName = getPaneIcon(primaryContent)
+  const paneIcon = ICON_MAP[iconName]
+  const agentIcon = !isTerminated && agentType ? getAgentIcon(agentType, { ccVariant: ccIconVariant }) : undefined
+  const IconComponent = (agentIcon ?? paneIcon) as TabIconComponent | undefined
+
+  let baseLabel: string
+  if (options?.titleOverride !== undefined) {
+    baseLabel = options.titleOverride
+  } else {
+    const sessionLookup = { getByCode: (code: string) => sessions.find((sess) => sess.code === code) }
+    const workspaceLookup = { getById: (id: string) => workspaces.find((w) => w.id === id) }
+    baseLabel = getPaneLabel(primaryContent, sessionLookup, workspaceLookup, t)
+  }
+
+  const useOsc = showOscTitle && !isTerminated && !!agentType && !!oscTitle
+  const displayTitle = useOsc && oscTitle ? oscTitle : baseLabel
+  const tooltip = useOsc && oscTitle ? `${oscTitle} - ${baseLabel}` : baseLabel
+
+  return {
+    displayTitle,
+    tooltip,
+    IconComponent,
+    agentStatus,
+    isUnread,
+    subagentCount,
+    tabIndicatorStyle,
+    isHostOffline,
+    isTerminated,
+    hostId,
+    sessionCode,
+    compositeKey: ck,
+  }
+}

--- a/spa/src/hooks/useTabDisplay.ts
+++ b/spa/src/hooks/useTabDisplay.ts
@@ -27,22 +27,15 @@ export interface TabDisplayData {
   tabIndicatorStyle: TabIndicatorStyle
   isHostOffline: boolean
   isTerminated: boolean
-  hostId: string
-  sessionCode: string | undefined
-  compositeKey: string | undefined
-}
-
-interface Options {
-  /** Override the base label; OSC still takes precedence when active. */
-  titleOverride?: string
 }
 
 /**
  * Shared tab display state for InlineTab (activity bar) and SortableTab (top
- * TabBar). Centralises OSC title resolution, agent-icon fallback, host-offline
- * detection, and agent store reads so both surfaces render consistently.
+ * TabBar). Centralises label + OSC title resolution, agent-icon fallback,
+ * host-offline detection, and agent store reads so both surfaces render
+ * identically.
  */
-export function useTabDisplay(tab: Tab, options?: Options): TabDisplayData {
+export function useTabDisplay(tab: Tab): TabDisplayData {
   const t = useI18nStore((s) => s.t)
   const primaryContent = getPrimaryPane(tab.layout).content
   const hostId = primaryContent.kind === 'tmux-session' ? primaryContent.hostId : ''
@@ -73,14 +66,9 @@ export function useTabDisplay(tab: Tab, options?: Options): TabDisplayData {
   const agentIcon = !isTerminated && agentType ? getAgentIcon(agentType, { ccVariant: ccIconVariant }) : undefined
   const IconComponent = (agentIcon ?? paneIcon) as TabIconComponent | undefined
 
-  let baseLabel: string
-  if (options?.titleOverride !== undefined) {
-    baseLabel = options.titleOverride
-  } else {
-    const sessionLookup = { getByCode: (code: string) => sessions.find((sess) => sess.code === code) }
-    const workspaceLookup = { getById: (id: string) => workspaces.find((w) => w.id === id) }
-    baseLabel = getPaneLabel(primaryContent, sessionLookup, workspaceLookup, t)
-  }
+  const sessionLookup = { getByCode: (code: string) => sessions.find((sess) => sess.code === code) }
+  const workspaceLookup = { getById: (id: string) => workspaces.find((w) => w.id === id) }
+  const baseLabel = getPaneLabel(primaryContent, sessionLookup, workspaceLookup, t)
 
   const useOsc = showOscTitle && !isTerminated && !!agentType && !!oscTitle
   const displayTitle = useOsc && oscTitle ? oscTitle : baseLabel
@@ -96,8 +84,5 @@ export function useTabDisplay(tab: Tab, options?: Options): TabDisplayData {
     tabIndicatorStyle,
     isHostOffline,
     isTerminated,
-    hostId,
-    sessionCode,
-    compositeKey: ck,
   }
 }


### PR DESCRIPTION
## Summary

- 抽出 `useTabDisplay(tab, { titleOverride? })` hook，集中 OSC title 解析、agent icon fallback、host offline 判定、agent store 訂閱
- 讓 top `TabBar`（`SortableTab`）與 activity bar (`InlineTab`) 共用同一份顯示邏輯 —— 未來加 badge/狀態只改 hook 一處
- 保留兩邊既有的視覺外殼（橫向固定寬度 vs 縱向滿寬），因為拖拉軸、close 按鈕樣式、pinned variant 差異太大，不適合共用元件
- 順手移除 `SortableTab` 的 `iconMap` prop（hook 內部解析 icon，TabBar 不再傳）

淨減 72 行，`SortableTab` 內邏輯從 67 行砍到 23 行，`InlineTab` store 訂閱全部搬走。

## Test plan
- [x] 新增 `useTabDisplay.test.ts` 12 個 case（label / OSC / icon / host offline / agent 欄位）
- [x] `vitest run`：196 files / 1974 passed
- [x] `pnpm run lint`：0 new errors（9 個 pre-existing，與本次改動無關）
- [ ] Electron 實機：開啟多 workspace，切換 tabs 確認 top bar 與 activity bar 名稱一致；開 CC `-p stream-json` agent 驗證 OSC title 兩邊同步
- [ ] 手動測 host 離線：兩邊都出現 `WifiSlash`