### PR TITLE
fix(spa): tab/workspace UI alignment and contrast pass

### DIFF
--- a/spa/src/components/SortableTab.test.tsx
+++ b/spa/src/components/SortableTab.test.tsx
@@ -164,7 +164,7 @@ describe('SortableTab renderTabIcon modes', () => {
     useAgentStore.setState({ unread: { 'h1:sc1': true } })
     render(<SortableTab {...defaultProps} isActive={false} />)
     const dot = screen.getByTestId('tab-status-indicator')
-    expect(dot.style.backgroundColor).toBe('rgb(185, 28, 28)')
+    expect(dot.style.backgroundColor).toBe('rgb(239, 68, 68)')
     expect(screen.queryByTestId('tab-unread-pip')).toBeNull()
   })
 

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -94,7 +94,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
         {tab.locked && <Lock size={10} className="absolute bottom-0.5 right-0.5" />}
         {!isActive && isUnread && shouldShowGlobalUnreadPip(tabIndicatorStyle, agentStatus) && (
           <span className="absolute -top-[4px] -right-[4px] w-2 h-2 rounded-full z-20"
-            style={{ backgroundColor: '#b91c1c' }} />
+            style={{ backgroundColor: '#ef4444' }} />
         )}
       </button>
     )

--- a/spa/src/components/StatusBar.tsx
+++ b/spa/src/components/StatusBar.tsx
@@ -164,7 +164,7 @@ export function StatusBar({ activeTab, onViewModeChange, onNavigateToHost, onSta
       <span
         className="text-text-secondary select-none"
         title={t('status.open_host_hint')}
-        onClick={agentHostId ? () => onNavigateToHost?.(agentHostId) : undefined}
+        onDoubleClick={agentHostId ? () => onNavigateToHost?.(agentHostId) : undefined}
       >
         {hostName}
       </span>

--- a/spa/src/components/TabIcon.tsx
+++ b/spa/src/components/TabIcon.tsx
@@ -13,7 +13,7 @@ function UnreadPip({ size = 5 }: { size?: number }) {
         height: size,
         top: -1,
         right: -2,
-        backgroundColor: '#b91c1c',
+        backgroundColor: '#ef4444',
       }}
     />
   )
@@ -74,11 +74,12 @@ export function TabIcon({
   }
 
   // Unread tints the badge dot red instead of overlaying a separate pip.
-  // Nudge the whole icon+badge group 1px right and park subagent dots at
-  // left:-4 so they sit just outside the box edge, clear of the icon.
+  // Nudge the whole icon+badge group 3px right to align the visually
+  // off-center robot glyph with the terminal icon, and park subagent dots
+  // at left:-4 so they sit just outside the box edge, clear of the icon.
   return (
     <span
-      className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-px"
+      className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-[3px]"
     >
       {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
       <TabStatusIndicator

--- a/spa/src/components/TabStatusIndicator.test.tsx
+++ b/spa/src/components/TabStatusIndicator.test.tsx
@@ -45,7 +45,7 @@ describe('TabStatusIndicator', () => {
       <TabStatusIndicator status="idle" mode="overlay" isActive={false} isUnread />,
     )
     const dot = screen.getByTestId('tab-status-indicator')
-    expect(dot.style.backgroundColor).toBe('rgb(185, 28, 28)')
+    expect(dot.style.backgroundColor).toBe('rgb(239, 68, 68)')
   })
 
   it('overlay mode: renders warning-diamond instead of dot when status is error', () => {

--- a/spa/src/components/TabStatusIndicator.tsx
+++ b/spa/src/components/TabStatusIndicator.tsx
@@ -19,7 +19,7 @@ const STATUS_COLORS: Record<AgentStatus, string> = {
   error: '#ef4444',
 }
 
-const UNREAD_COLOR = '#b91c1c'
+const UNREAD_COLOR = '#ef4444'
 
 export function TabStatusIndicator({ status, mode, isActive, isUnread = false }: Props) {
   if (status === undefined) return null

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -128,7 +128,7 @@ export function InlineTab({
         <span
           data-testid="inline-tab-unread"
           className="absolute -top-[4px] -right-[4px] w-2 h-2 rounded-full z-20"
-          style={{ backgroundColor: '#b91c1c' }}
+          style={{ backgroundColor: '#ef4444' }}
         />
       )}
       {showClose && (

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -72,7 +72,7 @@ export function WorkspaceRow(props: Props) {
         data-testid={`ws-header-${workspace.id}`}
         {...attributes}
         {...listeners}
-        className={`group/ws-header mx-2 flex items-center gap-1 pl-1.5 rounded-md text-sm transition-colors focus:outline-none focus-visible:outline-none ${
+        className={`group/ws-header mx-2 flex items-center gap-1 pl-1.5 pr-1.5 rounded-md text-sm transition-colors focus:outline-none focus-visible:outline-none ${
           isActive
             ? 'bg-[#8b5cf6]/25 text-text-primary ring-1 ring-purple-400'
             : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
@@ -108,9 +108,9 @@ export function WorkspaceRow(props: Props) {
               onAddTabToWorkspace(workspace.id)
             }}
             onPointerDown={(e) => e.stopPropagation()}
-            className="p-1 rounded hover:bg-surface-secondary cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity focus:outline-none"
+            className="p-0.5 rounded hover:bg-surface-secondary hover:text-text-primary cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity focus:outline-none"
           >
-            <Plus size={14} weight="bold" />
+            <Plus size={12} />
           </button>
         )}
         {showTabs && (
@@ -122,7 +122,7 @@ export function WorkspaceRow(props: Props) {
               e.stopPropagation()
               toggleExpanded(workspace.id)
             }}
-            className="p-1 mr-0.5 rounded hover:bg-surface-secondary cursor-pointer focus:outline-none"
+            className="p-0.5 rounded hover:bg-surface-secondary hover:text-text-primary cursor-pointer focus:outline-none"
           >
             <Chevron size={12} />
           </button>

--- a/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
+++ b/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
@@ -22,7 +22,7 @@ const UNREAD_PIP = (
   <span
     data-testid="inline-tab-unread-pip"
     className="absolute rounded-full z-20"
-    style={{ width: 5, height: 5, top: -1, right: -2, backgroundColor: '#b91c1c' }}
+    style={{ width: 5, height: 5, top: -1, right: -2, backgroundColor: '#ef4444' }}
   />
 )
 
@@ -80,7 +80,7 @@ export function renderInlineTabIcon({
   return (
     <span
       data-testid="inline-tab-dot-overlay"
-      className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px`}
+      className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-[3px]`}
     >
       {IconComponent && <IconComponent size={ICON_SIZE} className="flex-shrink-0" />}
       <TabStatusIndicator

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -338,7 +338,7 @@
 
   "status.no_active": "No active session",
   "status.rename_hint": "Double-click to rename session",
-  "status.open_host_hint": "Click to open host settings",
+  "status.open_host_hint": "Double-click to open host settings",
 
   "stream.thinking": "Thinking...",
   "stream.waiting": "Waiting for messages...",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -338,7 +338,7 @@
 
   "status.no_active": "無使用中的 Session",
   "status.rename_hint": "雙擊可修改 session 名稱",
-  "status.open_host_hint": "點擊開啟主機設定",
+  "status.open_host_hint": "雙擊開啟主機設定",
 
   "stream.thinking": "思考中...",
   "stream.waiting": "等待訊息...",


### PR DESCRIPTION
## Summary

Targeted UI polish in the activity bar / status bar:

1. **Tab icon alignment** — bump badge-mode container `ml-px` → `ml-[3px]` so the visually off-center robot glyph aligns with the terminal icon and leaves room for subagent dots.
2. **Workspace header buttons** — align `+` and chevron with InlineTab's close button: size 12, `p-0.5`, drop `mr-0.5` / `weight="bold"`, add `pr-1.5` on row and `hover:text-text-primary` on buttons.
3. **Unread brightness** — `#b91c1c` (red-700) → `#ef4444` (red-500) across all unread pip/overlay sites, matching the brightness of the running indicator.
4. **Host name in status bar** — single click → double click to open the host management page; zh-TW/en hint text updated.

## Test plan
- [x] `npx vitest run` — 1975/1975 passing (after updating two tests asserting the old `rgb(185,28,28)`)
- [ ] Air 端 dev update / SPA HMR 確認視覺：tab icon 對齊、+/chevron/X 同高、unread 紅燈與 running 綠燈亮度相近、host 文字需雙擊才打開設定