### PR TITLE
fix(spa): unify tab icon ml-px across all indicator styles

### DIFF
--- a/spa/src/components/TabIcon.tsx
+++ b/spa/src/components/TabIcon.tsx
@@ -39,7 +39,7 @@ export function TabIcon({
   isUnread,
 }: Props) {
   const iconBox = (
-    <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
+    <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-px">
       {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
     </span>
   )
@@ -52,7 +52,7 @@ export function TabIcon({
 
   if (tabIndicatorStyle === 'dot') {
     return (
-      <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
+      <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-px">
         <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
         {showDotUnreadPip && <UnreadPip />}
         {subagentCount > 0 && <SubagentDots count={subagentCount} />}
@@ -62,7 +62,7 @@ export function TabIcon({
 
   if (tabIndicatorStyle === 'iconDot') {
     return (
-      <span className="relative inline-flex items-center flex-shrink-0">
+      <span className="relative inline-flex items-center flex-shrink-0 ml-px">
         <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
           <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
           {showDotUnreadPip && <UnreadPip />}
@@ -74,12 +74,12 @@ export function TabIcon({
   }
 
   // Unread tints the badge dot red instead of overlaying a separate pip.
-  // Nudge the whole icon+badge group 3px right to align the visually
-  // off-center robot glyph with the terminal icon, and park subagent dots
-  // at left:-4 so they sit just outside the box edge, clear of the icon.
+  // Every mode now carries `ml-px` so the icon column aligns regardless of
+  // which indicator style a tab uses; subagent dots park at left:-4 so they
+  // sit just outside the box edge, clear of the icon.
   return (
     <span
-      className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-[3px]"
+      className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-px"
     >
       {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
       <TabStatusIndicator

--- a/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
+++ b/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
@@ -37,7 +37,7 @@ export function renderInlineTabIcon({
   // icon-only OR no agent event → plain icon slot
   if (tabIndicatorStyle === 'icon' || !agentStatus) {
     return (
-      <span className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0`}>
+      <span className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px`}>
         {IconComponent && <IconComponent size={ICON_SIZE} className="flex-shrink-0" />}
       </span>
     )
@@ -50,7 +50,7 @@ export function renderInlineTabIcon({
     return (
       <span
         data-testid="inline-tab-dot"
-        className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0`}
+        className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px`}
       >
         <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
         {showDotUnreadPip && UNREAD_PIP}
@@ -61,7 +61,7 @@ export function renderInlineTabIcon({
 
   if (tabIndicatorStyle === 'iconDot') {
     return (
-      <span className="relative inline-flex items-center flex-shrink-0">
+      <span className="relative inline-flex items-center flex-shrink-0 ml-px">
         <span
           data-testid="inline-tab-dot"
           className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0`}
@@ -80,7 +80,7 @@ export function renderInlineTabIcon({
   return (
     <span
       data-testid="inline-tab-dot-overlay"
-      className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-[3px]`}
+      className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px`}
     >
       {IconComponent && <IconComponent size={ICON_SIZE} className="flex-shrink-0" />}
       <TabStatusIndicator


### PR DESCRIPTION
## Summary

Hotfix for alpha.169's tab-icon alignment regression.

- alpha.169 changed badge-mode wrapper to `ml-[3px]` to chase a perceived robot-glyph visual offset. The compensation was wrong in both direction and magnitude — robot ended up 2–3px to the **right** of terminal (worse than the original ~1px misalignment).
- Restore badge mode to `ml-px` (the alpha.168 value) **and** apply the same `ml-px` to icon / dot / iconDot wrappers in both `TabIcon.tsx` and `renderInlineTabIcon.tsx`.
- Net effect: the icon column lands at the same x position regardless of which indicator style a tab is using.

## Test plan
- [x] `npx vitest run src/components/TabIcon src/components/SortableTab src/features/workspace` — 314/314 passing
- [ ] Air 端 dev update / SPA HMR：`>_` (terminal) 與 robot icon 同一直線，subagent dot 仍貼在 icon 左側