### PR TITLE
fix(spa): tune tab icon margins per indicator style

### DIFF
--- a/spa/src/components/TabIcon.tsx
+++ b/spa/src/components/TabIcon.tsx
@@ -39,7 +39,7 @@ export function TabIcon({
   isUnread,
 }: Props) {
   const iconBox = (
-    <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-px">
+    <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-[2px]">
       {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
     </span>
   )
@@ -52,7 +52,7 @@ export function TabIcon({
 
   if (tabIndicatorStyle === 'dot') {
     return (
-      <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-px">
+      <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-[2px]">
         <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
         {showDotUnreadPip && <UnreadPip />}
         {subagentCount > 0 && <SubagentDots count={subagentCount} />}
@@ -62,7 +62,7 @@ export function TabIcon({
 
   if (tabIndicatorStyle === 'iconDot') {
     return (
-      <span className="relative inline-flex items-center flex-shrink-0 ml-px">
+      <span className="relative inline-flex items-center flex-shrink-0 ml-[2px]">
         <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
           <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
           {showDotUnreadPip && <UnreadPip />}
@@ -74,12 +74,12 @@ export function TabIcon({
   }
 
   // Unread tints the badge dot red instead of overlaying a separate pip.
-  // Every mode now carries `ml-px` so the icon column aligns regardless of
-  // which indicator style a tab uses; subagent dots park at left:-4 so they
-  // sit just outside the box edge, clear of the icon.
+  // Badge keeps `ml-px mr-px` (1px each side) — non-badge modes get `ml-[2px]`
+  // so they align with the badge icon's visual right edge while keeping a
+  // small breathing gap to the trailing label. Subagent dots park at left:-4.
   return (
     <span
-      className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-px"
+      className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-px mr-px"
     >
       {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
       <TabStatusIndicator

--- a/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
+++ b/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
@@ -37,7 +37,7 @@ export function renderInlineTabIcon({
   // icon-only OR no agent event → plain icon slot
   if (tabIndicatorStyle === 'icon' || !agentStatus) {
     return (
-      <span className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px`}>
+      <span className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-[2px]`}>
         {IconComponent && <IconComponent size={ICON_SIZE} className="flex-shrink-0" />}
       </span>
     )
@@ -50,7 +50,7 @@ export function renderInlineTabIcon({
     return (
       <span
         data-testid="inline-tab-dot"
-        className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px`}
+        className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-[2px]`}
       >
         <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
         {showDotUnreadPip && UNREAD_PIP}
@@ -61,7 +61,7 @@ export function renderInlineTabIcon({
 
   if (tabIndicatorStyle === 'iconDot') {
     return (
-      <span className="relative inline-flex items-center flex-shrink-0 ml-px">
+      <span className="relative inline-flex items-center flex-shrink-0 ml-[2px]">
         <span
           data-testid="inline-tab-dot"
           className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0`}
@@ -80,7 +80,7 @@ export function renderInlineTabIcon({
   return (
     <span
       data-testid="inline-tab-dot-overlay"
-      className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px`}
+      className={`relative inline-flex items-center justify-center ${DOT_SLOT} flex-shrink-0 ml-px mr-px`}
     >
       {IconComponent && <IconComponent size={ICON_SIZE} className="flex-shrink-0" />}
       <TabStatusIndicator


### PR DESCRIPTION
## Summary

Per-style margin tuning on top of the alpha.170 unification:

- **icon / dot / iconDot wrappers**: `ml-px` → `ml-[2px]`. Pushes the slot one extra pixel right so the non-badge icons line up with the visual right edge of the badge icon.
- **badge wrapper**: keep `ml-px`, **add** `mr-px`. Gives the icon+overlay group a small breathing gap before the trailing label, balancing the asymmetry from the overlay dot sticking out at `right:-2`.

## Test plan
- [x] `npx vitest run src/components/TabIcon src/components/SortableTab src/features/workspace` — 314/314 passing
- [ ] Air 端 dev update / SPA HMR：terminal `>_` 與 robot 視覺對齊；badge 模式 icon 與 label 之間多 1px 呼吸感