### PR TITLE
fix(spa): activity-bar collapse button uses SidebarSimple icon

### DIFF
--- a/spa/src/features/workspace/components/CollapseButton.test.tsx
+++ b/spa/src/features/workspace/components/CollapseButton.test.tsx
@@ -77,3 +77,51 @@ describe('CollapseButton — variants', () => {
     expect(screen.getByRole('button')).toBeDisabled()
   })
 })
+
+describe('CollapseButton — icon', () => {
+  // SidebarSimple regular path has this distinctive opening signature (a
+  // 216×176 rounded rect with a vertical divider near the left). Caret icons
+  // don't share it — this assertion proves we switched to SidebarSimple
+  // rather than any Caret variant.
+  const SIDEBAR_SIMPLE_SIGNATURE = /M216,40H40/
+
+  it('renders the SidebarSimple icon when narrow', () => {
+    render(<CollapseButton />)
+    const path = screen.getByRole('button').querySelector('svg path')
+    expect(path?.getAttribute('d')).toMatch(SIDEBAR_SIMPLE_SIGNATURE)
+  })
+
+  it('renders the SidebarSimple icon when wide', () => {
+    useLayoutStore.setState({ activityBarWidth: 'wide' })
+    render(<CollapseButton />)
+    const path = screen.getByRole('button').querySelector('svg path')
+    expect(path?.getAttribute('d')).toMatch(SIDEBAR_SIMPLE_SIGNATURE)
+  })
+})
+
+describe('CollapseButton — topbar variant active state', () => {
+  // Matches the visual treatment of the region-toggle buttons in TitleBar's
+  // right cluster: accent tint when the region is "visible" (here: activity
+  // bar is wide), neutral secondary styling otherwise.
+  it('shows accent colors when wide (active)', () => {
+    useLayoutStore.setState({ activityBarWidth: 'wide' })
+    render(<CollapseButton variant="topbar" />)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toMatch(/text-accent-base/)
+    expect(btn.className).toMatch(/bg-accent-base/)
+  })
+
+  it('shows secondary colors when narrow (inactive)', () => {
+    render(<CollapseButton variant="topbar" />)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toMatch(/text-text-secondary/)
+    expect(btn.className).not.toMatch(/text-accent-base/)
+  })
+
+  it('uses the p-1 rounded pattern shared with region toggles', () => {
+    render(<CollapseButton variant="topbar" />)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toMatch(/\bp-1\b/)
+    expect(btn.className).toMatch(/\brounded\b/)
+  })
+})

--- a/spa/src/features/workspace/components/CollapseButton.tsx
+++ b/spa/src/features/workspace/components/CollapseButton.tsx
@@ -1,4 +1,4 @@
-import { CaretDoubleLeft, CaretDoubleRight } from '@phosphor-icons/react'
+import { SidebarSimple } from '@phosphor-icons/react'
 import { useLayoutStore } from '../../../stores/useLayoutStore'
 import { useI18nStore } from '../../../stores/useI18nStore'
 
@@ -8,8 +8,6 @@ interface Props {
   variant?: Variant
 }
 
-// topbar: inline-padding layout that matches the TitleBar's region-toggle /
-// layout-pattern buttons so the collapse control reads as a sibling of them.
 const VARIANT_CLASSES: Record<Variant, string> = {
   'header-right': 'w-6 h-6 rounded-md',
   divider: 'absolute top-3 right-[-11px] w-[22px] h-[22px] rounded-full bg-surface-tertiary border border-border-subtle shadow-sm opacity-0 group-hover/narrow-bar:opacity-100 focus:opacity-100 transition-opacity z-10',
@@ -22,6 +20,17 @@ const ICON_SIZE: Record<Variant, number> = {
   topbar: 14,
 }
 
+// topbar mirrors the region-toggle buttons in TitleBar's right cluster: accent
+// tint when the activity bar is "visible as wide", neutral secondary styling
+// otherwise. Other variants keep the original hover-only treatment.
+function stateClasses(variant: Variant, locked: boolean, isWide: boolean): string {
+  if (locked) return 'text-text-muted/50 cursor-not-allowed'
+  if (variant === 'topbar' && isWide) {
+    return 'cursor-pointer text-accent-base bg-accent-base/10 hover:bg-accent-base/20'
+  }
+  return 'cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-hover'
+}
+
 export function CollapseButton({ variant = 'header-right' }: Props) {
   const width = useLayoutStore((s) => s.activityBarWidth)
   const tabPosition = useLayoutStore((s) => s.tabPosition)
@@ -32,7 +41,6 @@ export function CollapseButton({ variant = 'header-right' }: Props) {
   // the activity bar to wide — the button must reflect that.
   const locked = tabPosition === 'left' || tabPosition === 'both'
   const isWide = width === 'wide'
-  const Icon = isWide ? CaretDoubleLeft : CaretDoubleRight
   const label = locked
     ? t('nav.collapse_locked_tooltip')
     : isWide
@@ -48,13 +56,9 @@ export function CollapseButton({ variant = 'header-right' }: Props) {
       aria-pressed={isWide}
       data-variant={variant}
       onClick={toggle}
-      className={`${VARIANT_CLASSES[variant]} flex items-center justify-center transition-colors ${
-        locked
-          ? 'text-text-muted/50 cursor-not-allowed'
-          : 'cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-hover'
-      }`}
+      className={`${VARIANT_CLASSES[variant]} flex items-center justify-center transition-colors ${stateClasses(variant, locked, isWide)}`}
     >
-      <Icon size={ICON_SIZE[variant]} />
+      <SidebarSimple size={ICON_SIZE[variant]} />
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- `CollapseButton` 改用單一 `SidebarSimple` icon（原本動態切換 `CaretDoubleLeft/Right`），視覺上與 TitleBar 右側 region-toggle 同一家族
- `topbar` variant 加上 region-toggle 慣用的 active 配色（wide = accent 底色；narrow = 常態 secondary）
- 單一 icon 消除每次點擊的 icon swap，順道處理 #446 commit message 裡提到的「感覺壞掉」觀感

## Test plan
- [x] `CollapseButton.test.tsx`：新增 3 組（icon 簽章 × 2、topbar active/inactive 樣式、`p-1 rounded` 共用 pattern）
- [x] `vitest run`（spa）全部 1980 測試綠
- [ ] Electron app 實機驗證 narrow↔wide 切換（需要 rebuild + dev update）