### PR TITLE
fix(spa): allow activity bar collapse in tabPosition='both'

### DIFF
--- a/spa/src/features/workspace/components/CollapseButton.test.tsx
+++ b/spa/src/features/workspace/components/CollapseButton.test.tsx
@@ -71,10 +71,13 @@ describe('CollapseButton — variants', () => {
     expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'topbar')
   })
 
-  it("is disabled when tabPosition='both'", () => {
+  it("is enabled when tabPosition='both' (top tabs remain reachable)", () => {
     useLayoutStore.setState({ activityBarWidth: 'wide', tabPosition: 'both' })
     render(<CollapseButton />)
-    expect(screen.getByRole('button')).toBeDisabled()
+    const btn = screen.getByRole('button')
+    expect(btn).not.toBeDisabled()
+    fireEvent.click(btn)
+    expect(useLayoutStore.getState().activityBarWidth).toBe('narrow')
   })
 })
 

--- a/spa/src/features/workspace/components/CollapseButton.test.tsx
+++ b/spa/src/features/workspace/components/CollapseButton.test.tsx
@@ -77,3 +77,51 @@ describe('CollapseButton — variants', () => {
     expect(screen.getByRole('button')).toBeDisabled()
   })
 })
+
+describe('CollapseButton — icon', () => {
+  // SidebarSimple regular path has this distinctive opening signature (a
+  // 216×176 rounded rect with a vertical divider near the left). Caret icons
+  // don't share it — this assertion proves we switched to SidebarSimple
+  // rather than any Caret variant.
+  const SIDEBAR_SIMPLE_SIGNATURE = /M216,40H40/
+
+  it('renders the SidebarSimple icon when narrow', () => {
+    render(<CollapseButton />)
+    const path = screen.getByRole('button').querySelector('svg path')
+    expect(path?.getAttribute('d')).toMatch(SIDEBAR_SIMPLE_SIGNATURE)
+  })
+
+  it('renders the SidebarSimple icon when wide', () => {
+    useLayoutStore.setState({ activityBarWidth: 'wide' })
+    render(<CollapseButton />)
+    const path = screen.getByRole('button').querySelector('svg path')
+    expect(path?.getAttribute('d')).toMatch(SIDEBAR_SIMPLE_SIGNATURE)
+  })
+})
+
+describe('CollapseButton — topbar variant active state', () => {
+  // Matches the visual treatment of the region-toggle buttons in TitleBar's
+  // right cluster: accent tint when the region is "visible" (here: activity
+  // bar is wide), neutral secondary styling otherwise.
+  it('shows accent colors when wide (active)', () => {
+    useLayoutStore.setState({ activityBarWidth: 'wide' })
+    render(<CollapseButton variant="topbar" />)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toMatch(/text-accent-base/)
+    expect(btn.className).toMatch(/bg-accent-base/)
+  })
+
+  it('shows secondary colors when narrow (inactive)', () => {
+    render(<CollapseButton variant="topbar" />)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toMatch(/text-text-secondary/)
+    expect(btn.className).not.toMatch(/text-accent-base/)
+  })
+
+  it('uses the p-1 rounded pattern shared with region toggles', () => {
+    render(<CollapseButton variant="topbar" />)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toMatch(/\bp-1\b/)
+    expect(btn.className).toMatch(/\brounded\b/)
+  })
+})

--- a/spa/src/features/workspace/components/CollapseButton.tsx
+++ b/spa/src/features/workspace/components/CollapseButton.tsx
@@ -37,9 +37,9 @@ export function CollapseButton({ variant = 'header-right' }: Props) {
   const toggle = useLayoutStore((s) => s.toggleActivityBarWidth)
   const t = useI18nStore((s) => s.t)
 
-  // Task 1 extended tabPosition to include 'both'. Both 'left' and 'both' lock
-  // the activity bar to wide — the button must reflect that.
-  const locked = tabPosition === 'left' || tabPosition === 'both'
+  // Only `left` forces wide (tabs live exclusively in the activity bar there).
+  // `both` keeps tabs reachable via the top tab bar, so collapse is allowed.
+  const locked = tabPosition === 'left'
   const isWide = width === 'wide'
   const label = locked
     ? t('nav.collapse_locked_tooltip')

--- a/spa/src/features/workspace/components/CollapseButton.tsx
+++ b/spa/src/features/workspace/components/CollapseButton.tsx
@@ -1,4 +1,4 @@
-import { CaretDoubleLeft, CaretDoubleRight } from '@phosphor-icons/react'
+import { SidebarSimple } from '@phosphor-icons/react'
 import { useLayoutStore } from '../../../stores/useLayoutStore'
 import { useI18nStore } from '../../../stores/useI18nStore'
 
@@ -8,8 +8,6 @@ interface Props {
   variant?: Variant
 }
 
-// topbar: inline-padding layout that matches the TitleBar's region-toggle /
-// layout-pattern buttons so the collapse control reads as a sibling of them.
 const VARIANT_CLASSES: Record<Variant, string> = {
   'header-right': 'w-6 h-6 rounded-md',
   divider: 'absolute top-3 right-[-11px] w-[22px] h-[22px] rounded-full bg-surface-tertiary border border-border-subtle shadow-sm opacity-0 group-hover/narrow-bar:opacity-100 focus:opacity-100 transition-opacity z-10',
@@ -22,6 +20,17 @@ const ICON_SIZE: Record<Variant, number> = {
   topbar: 14,
 }
 
+// topbar mirrors the region-toggle buttons in TitleBar's right cluster: accent
+// tint when the activity bar is "visible as wide", neutral secondary styling
+// otherwise. Other variants keep the original hover-only treatment.
+function stateClasses(variant: Variant, locked: boolean, isWide: boolean): string {
+  if (locked) return 'text-text-muted/50 cursor-not-allowed'
+  if (variant === 'topbar' && isWide) {
+    return 'cursor-pointer text-accent-base bg-accent-base/10 hover:bg-accent-base/20'
+  }
+  return 'cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-hover'
+}
+
 export function CollapseButton({ variant = 'header-right' }: Props) {
   const width = useLayoutStore((s) => s.activityBarWidth)
   const tabPosition = useLayoutStore((s) => s.tabPosition)
@@ -32,7 +41,6 @@ export function CollapseButton({ variant = 'header-right' }: Props) {
   // the activity bar to wide — the button must reflect that.
   const locked = tabPosition === 'left' || tabPosition === 'both'
   const isWide = width === 'wide'
-  const Icon = isWide ? CaretDoubleLeft : CaretDoubleRight
   const label = locked
     ? t('nav.collapse_locked_tooltip')
     : isWide
@@ -48,13 +56,9 @@ export function CollapseButton({ variant = 'header-right' }: Props) {
       aria-pressed={isWide}
       data-variant={variant}
       onClick={toggle}
-      className={`${VARIANT_CLASSES[variant]} flex items-center justify-center transition-colors ${
-        locked
-          ? 'text-text-muted/50 cursor-not-allowed'
-          : 'cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-hover'
-      }`}
+      className={`${VARIANT_CLASSES[variant]} flex items-center justify-center transition-colors ${stateClasses(variant, locked, isWide)}`}
     >
-      <Icon size={ICON_SIZE[variant]} />
+      <SidebarSimple size={ICON_SIZE[variant]} />
     </button>
   )
 }

--- a/spa/src/stores/useLayoutStore.test.ts
+++ b/spa/src/stores/useLayoutStore.test.ts
@@ -74,10 +74,10 @@ describe('useLayoutStore', () => {
       expect(useLayoutStore.getState().activityBarWidth).toBe('wide')
     })
 
-    it('refuses narrow when tabPosition=both', () => {
+    it('allows narrow when tabPosition=both (top tabs still available)', () => {
       useLayoutStore.setState({ activityBarWidth: 'wide', tabPosition: 'both' })
       useLayoutStore.getState().setActivityBarWidth('narrow')
-      expect(useLayoutStore.getState().activityBarWidth).toBe('wide')
+      expect(useLayoutStore.getState().activityBarWidth).toBe('narrow')
     })
   })
 
@@ -95,10 +95,10 @@ describe('useLayoutStore', () => {
       expect(useLayoutStore.getState().activityBarWidth).toBe('wide')
     })
 
-    it('no-op when currently wide and tabPosition=both', () => {
+    it('toggles wide → narrow when tabPosition=both', () => {
       useLayoutStore.setState({ activityBarWidth: 'wide', tabPosition: 'both' })
       useLayoutStore.getState().toggleActivityBarWidth()
-      expect(useLayoutStore.getState().activityBarWidth).toBe('wide')
+      expect(useLayoutStore.getState().activityBarWidth).toBe('narrow')
     })
   })
 
@@ -124,8 +124,15 @@ describe('useLayoutStore', () => {
       expect(useLayoutStore.getState().activityBarWidth).toBe('narrow')
     })
 
-    it('sets to both and forces activityBarWidth=wide', () => {
+    it('sets to both preserving current activityBarWidth (narrow stays narrow)', () => {
       useLayoutStore.setState({ activityBarWidth: 'narrow', tabPosition: 'top' })
+      useLayoutStore.getState().setTabPosition('both')
+      expect(useLayoutStore.getState().tabPosition).toBe('both')
+      expect(useLayoutStore.getState().activityBarWidth).toBe('narrow')
+    })
+
+    it('sets to both preserving current activityBarWidth (wide stays wide)', () => {
+      useLayoutStore.setState({ activityBarWidth: 'wide', tabPosition: 'top' })
       useLayoutStore.getState().setTabPosition('both')
       expect(useLayoutStore.getState().tabPosition).toBe('both')
       expect(useLayoutStore.getState().activityBarWidth).toBe('wide')
@@ -208,15 +215,16 @@ describe('useLayoutStore', () => {
       expect(healed.activityBarWidth).toBe('wide')
     })
 
-    it('forces width=wide when state has {narrow, both}', () => {
+    it('leaves {narrow, both} untouched (top tabs keep tabs reachable)', () => {
       const healed = healLayoutInvariant({ activityBarWidth: 'narrow', tabPosition: 'both' })
-      expect(healed.activityBarWidth).toBe('wide')
+      expect(healed.activityBarWidth).toBe('narrow')
     })
 
     it('leaves valid combinations untouched', () => {
       expect(healLayoutInvariant({ activityBarWidth: 'narrow', tabPosition: 'top' }).activityBarWidth).toBe('narrow')
       expect(healLayoutInvariant({ activityBarWidth: 'wide', tabPosition: 'top' }).activityBarWidth).toBe('wide')
       expect(healLayoutInvariant({ activityBarWidth: 'wide', tabPosition: 'left' }).activityBarWidth).toBe('wide')
+      expect(healLayoutInvariant({ activityBarWidth: 'wide', tabPosition: 'both' }).activityBarWidth).toBe('wide')
     })
   })
 

--- a/spa/src/stores/useLayoutStore.ts
+++ b/spa/src/stores/useLayoutStore.ts
@@ -16,11 +16,12 @@ export type TabPosition = 'top' | 'left' | 'both'
 export const HOME_WS_KEY = 'home'
 
 /**
- * Self-heal invariant: `tabPosition='left'` or `tabPosition='both'` requires `activityBarWidth='wide'`.
+ * Self-heal invariant: only `tabPosition='left'` requires `activityBarWidth='wide'`.
+ * `both` keeps tabs reachable via the top tab bar, so narrow is valid there.
  * Called by persist's onRehydrateStorage; also exported for direct testing.
  */
 export function healLayoutInvariant<T extends { activityBarWidth?: ActivityBarWidth; tabPosition?: TabPosition }>(state: T): T {
-  if ((state.tabPosition === 'left' || state.tabPosition === 'both') && state.activityBarWidth === 'narrow') {
+  if (state.tabPosition === 'left' && state.activityBarWidth === 'narrow') {
     state.activityBarWidth = 'wide'
   }
   return state
@@ -187,25 +188,23 @@ export const useLayoutStore = create<LayoutState>()(
 
       setActivityBarWidth: (width) =>
         set((state) => {
-          const nonTop = state.tabPosition === 'left' || state.tabPosition === 'both'
-          if (width === 'narrow' && nonTop) return state
+          if (width === 'narrow' && state.tabPosition === 'left') return state
           return { activityBarWidth: width }
         }),
 
       toggleActivityBarWidth: () =>
         set((state) => {
           const next: ActivityBarWidth = state.activityBarWidth === 'narrow' ? 'wide' : 'narrow'
-          const nonTop = state.tabPosition === 'left' || state.tabPosition === 'both'
-          if (next === 'narrow' && nonTop) return state
+          if (next === 'narrow' && state.tabPosition === 'left') return state
           return { activityBarWidth: next }
         }),
 
       setTabPosition: (position) =>
         set((state) => {
-          if (position === 'left' || position === 'both') {
-            return { tabPosition: position, activityBarWidth: 'wide' }
+          if (position === 'left') {
+            return { tabPosition: 'left', activityBarWidth: 'wide' }
           }
-          return { tabPosition: 'top', activityBarWidth: state.activityBarWidth }
+          return { tabPosition: position, activityBarWidth: state.activityBarWidth }
         }),
 
       setActivityBarWideSize: (size) =>


### PR DESCRIPTION
## Summary
Root cause for "toggle 沒反應" reported after #452: the button is correctly wired up, but `locked = tabPosition === 'left' || 'both'` kept it `disabled` whenever user's layout was in `both` mode (tabs top + activity bar). Tooltip "Can't collapse while tabs are on the left" even misleadingly pointed at `left`.

- `CollapseButton.locked` narrowed to `tabPosition === 'left'` only.
- Store guards (`setActivityBarWidth`, `toggleActivityBarWidth`, `setTabPosition`, `healLayoutInvariant`) all loosened so `both` no longer forces wide — top tab bar keeps tabs reachable when activity bar is narrow.
- Existing both+wide layouts untouched (heal just stops forcing wide from narrow); user can toggle freely from now.

## Test plan
- [x] `useLayoutStore.test.ts` + `CollapseButton.test.tsx` flipped to new spec (5 failing → 5 passing + new "toggle wide→narrow in both" + setTabPosition preservation tests)
- [x] `pnpm vitest run` — 1981 綠
- [x] `pnpm eslint` on touched files — clean
- [ ] Electron app 實機驗證（需 rebuild + dev update → 點按鈕應切到 narrow，再點回 wide）