### PR TITLE
polish(spa): unify TitleBar topbar button class + 5px downshift

### DIFF
--- a/spa/src/components/TitleBar.test.tsx
+++ b/spa/src/components/TitleBar.test.tsx
@@ -86,6 +86,19 @@ describe('TitleBar', () => {
       expect(btn.className).toContain('cursor-pointer')
     }
   })
+
+  // The TitleBar sits flush with the window's top edge; without an offset the
+  // buttons optically collide with the traffic-light row. Shift both button
+  // clusters down 5px so they sit on the content-side of the bar instead.
+  it('sidebar-toggle cluster is shifted down 5px', () => {
+    render(<TitleBar title="test" />)
+    expect(screen.getByTestId('sidebar-toggle').className).toMatch(/translate-y-\[5px\]/)
+  })
+
+  it('layout-buttons cluster is shifted down 5px', () => {
+    render(<TitleBar title="test" />)
+    expect(screen.getByTestId('layout-buttons').className).toMatch(/translate-y-\[5px\]/)
+  })
 })
 
 describe('TitleBar — sync conflict warning', () => {

--- a/spa/src/components/TitleBar.tsx
+++ b/spa/src/components/TitleBar.tsx
@@ -57,7 +57,7 @@ export function TitleBar({ title }: Props) {
       <div className="w-[72px] shrink-0" aria-hidden="true" />
       <div
         data-testid="sidebar-toggle"
-        className="shrink-0 flex items-center"
+        className="shrink-0 flex items-center translate-y-[5px]"
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
         <CollapseButton variant="topbar" />
@@ -81,7 +81,7 @@ export function TitleBar({ title }: Props) {
       <div className="flex-1" />
       <div
         data-testid="layout-buttons"
-        className="shrink-0 flex items-center gap-0.5"
+        className="shrink-0 flex items-center gap-0.5 translate-y-[5px]"
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
         {regionToggles.map(({ region, icon: Icon, label, mirror }) => {

--- a/spa/src/features/workspace/components/CollapseButton.test.tsx
+++ b/spa/src/features/workspace/components/CollapseButton.test.tsx
@@ -127,6 +127,35 @@ describe('CollapseButton — topbar variant active state', () => {
     expect(btn.className).toMatch(/\bp-1\b/)
     expect(btn.className).toMatch(/\brounded\b/)
   })
+
+  it('matches region-toggle structure: no flex centering classes', () => {
+    // Region toggles in TitleBar don't use `flex items-center justify-center`;
+    // the svg centers naturally. Keeping the class list identical avoids subtle
+    // layout drift between (a) and (b) buttons.
+    render(<CollapseButton variant="topbar" />)
+    const btn = screen.getByRole('button')
+    expect(btn.className).not.toMatch(/\bflex\b/)
+    expect(btn.className).not.toMatch(/\bitems-center\b/)
+    expect(btn.className).not.toMatch(/\bjustify-center\b/)
+  })
+})
+
+describe('CollapseButton — other variants keep flex centering', () => {
+  it('header-right still uses flex centering (w-6 h-6 needs explicit center)', () => {
+    render(<CollapseButton variant="header-right" />)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toMatch(/\bflex\b/)
+    expect(btn.className).toMatch(/\bitems-center\b/)
+    expect(btn.className).toMatch(/\bjustify-center\b/)
+  })
+
+  it('divider still uses flex centering', () => {
+    render(<CollapseButton variant="divider" />)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toMatch(/\bflex\b/)
+    expect(btn.className).toMatch(/\bitems-center\b/)
+    expect(btn.className).toMatch(/\bjustify-center\b/)
+  })
 })
 
 describe('CollapseButton — icon', () => {

--- a/spa/src/features/workspace/components/CollapseButton.tsx
+++ b/spa/src/features/workspace/components/CollapseButton.tsx
@@ -8,9 +8,12 @@ interface Props {
   variant?: Variant
 }
 
+// header-right and divider have explicit w/h so the icon needs flex centering;
+// topbar only wraps the icon in p-1, which matches the region-toggle buttons
+// byte-for-byte — leave flex classes off so class strings are identical.
 const VARIANT_CLASSES: Record<Variant, string> = {
-  'header-right': 'w-6 h-6 rounded-md',
-  divider: 'absolute top-3 right-[-11px] w-[22px] h-[22px] rounded-full bg-surface-tertiary border border-border-subtle shadow-sm opacity-0 group-hover/narrow-bar:opacity-100 focus:opacity-100 transition-opacity z-10',
+  'header-right': 'w-6 h-6 rounded-md flex items-center justify-center',
+  divider: 'absolute top-3 right-[-11px] w-[22px] h-[22px] rounded-full bg-surface-tertiary border border-border-subtle shadow-sm opacity-0 group-hover/narrow-bar:opacity-100 focus:opacity-100 transition-opacity z-10 flex items-center justify-center',
   topbar: 'p-1 rounded',
 }
 
@@ -56,7 +59,7 @@ export function CollapseButton({ variant = 'header-right' }: Props) {
       aria-pressed={isWide}
       data-variant={variant}
       onClick={toggle}
-      className={`${VARIANT_CLASSES[variant]} flex items-center justify-center transition-colors ${stateClasses(variant, locked, isWide)}`}
+      className={`${VARIANT_CLASSES[variant]} transition-colors ${stateClasses(variant, locked, isWide)}`}
     >
       <SidebarSimple size={ICON_SIZE[variant]} />
     </button>


### PR DESCRIPTION
## Summary
- `CollapseButton` topbar variant class string now byte-identical to the region-toggle buttons (drop redundant `flex items-center justify-center` — svg centers naturally with `display: block` + `p-1`); header-right / divider variants still flex-center because they use fixed w/h.
- `sidebar-toggle` and `layout-buttons` slots in `TitleBar` get `translate-y-[5px]` so both button groups sit below the traffic-light row instead of visually overlapping it. Title + sync warning stay put.

## Test plan
- [x] `CollapseButton.test.tsx` — new cases assert topbar has no flex classes, header-right/divider still do
- [x] `TitleBar.test.tsx` — new cases assert both slot wrappers carry `translate-y-[5px]`
- [x] `pnpm vitest run` — 1986 passing
- [ ] Electron app 實機驗證（rebuild + dev update）：topbar 按鈕視覺與 (b) 完全一致，且整體下移 5px