### PR TITLE
fix(spa): activity-bar resize handle un-clickable (0-height hit zone)

### DIFF
--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -337,7 +337,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
           </button>
         </div>
       </div>
-      <div data-testid="activity-bar-resize" className="hidden lg:block">
+      <div data-testid="activity-bar-resize" className="hidden lg:flex">
         <RegionResize
           resizeEdge="right"
           onResize={(delta) => {


### PR DESCRIPTION
## Summary

- `ActivityBarWide` wraps `RegionResize` in `<div className="hidden lg:block">`, which made `RegionResize`'s inner `.relative.w-px` collapse to `height: 0` (its only child is absolutely positioned). The hit area's `inset-y-0` then resolved to a 0-height rect, so the drag handle looked 900px tall but was un-clickable.
- Changed wrapper to `hidden lg:flex` so the inner div stretches as a flex item. Same `RegionResize` works in `SidebarRegion` because that wrapper is already `shrink-0 flex`.

## Test plan

- [x] Existing `ActivityBarWide.test.tsx` — 9/9 pass
- [x] Browser (Playwright, viewport 1400×900):
  - before: `resize-hit` rect = `11×0`
  - after: `resize-hit` rect = `11×801`
  - drag +80px → `activityBarWideSize` commits 240 → 320 on mouseup ✅
- [ ] Manual drag in Electron shell after merge