### PR TITLE
feat(spa): toggle expand on active ws/home click + fix empty-ws stuck-on-standalone

### DIFF
--- a/spa/src/features/workspace/components/HomeRow.test.tsx
+++ b/spa/src/features/workspace/components/HomeRow.test.tsx
@@ -67,6 +67,37 @@ describe('HomeRow', () => {
     expect(screen.getByText('alpha.example.com')).toBeInTheDocument()
   })
 
+  it('clicking title on ACTIVE Home toggles expand (does not re-select)', () => {
+    useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide' })
+    const onSelectHome = vi.fn()
+    renderRow({ isActive: true, onSelectHome })
+    fireEvent.click(screen.getByText(/home/i))
+    expect(useLayoutStore.getState().workspaceExpanded['home']).toBe(true)
+    expect(onSelectHome).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText(/home/i))
+    expect(useLayoutStore.getState().workspaceExpanded['home']).toBe(false)
+    expect(onSelectHome).not.toHaveBeenCalled()
+  })
+
+  it("active-click toggle is inert when tabPosition='top' (no inline tabs); still selects", () => {
+    useLayoutStore.setState({ tabPosition: 'top' })
+    const onSelectHome = vi.fn()
+    renderRow({ isActive: true, onSelectHome })
+    fireEvent.click(screen.getByText(/home/i))
+    expect(onSelectHome).toHaveBeenCalled()
+    expect(useLayoutStore.getState().workspaceExpanded['home']).toBeFalsy()
+  })
+
+  it('clicking title on INACTIVE Home selects (does not toggle)', () => {
+    useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide' })
+    const onSelectHome = vi.fn()
+    renderRow({ isActive: false, onSelectHome })
+    fireEvent.click(screen.getByText(/home/i))
+    expect(onSelectHome).toHaveBeenCalled()
+    expect(useLayoutStore.getState().workspaceExpanded['home']).toBeFalsy()
+  })
+
   it('chevron toggles home expand state', () => {
     useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide' })
     renderRow({ standaloneTabIds: ['t1'], tabsById: { t1: mkTab('t1', 'alpha') } })

--- a/spa/src/features/workspace/components/HomeRow.tsx
+++ b/spa/src/features/workspace/components/HomeRow.tsx
@@ -58,7 +58,13 @@ export function HomeRow(props: Props) {
       >
         <button
           type="button"
-          onClick={onSelectHome}
+          onClick={() => {
+            if (isActive && showTabs) {
+              toggleExpanded(HOME_WS_KEY)
+            } else {
+              onSelectHome()
+            }
+          }}
           className="flex-1 flex items-center gap-2 py-1.5 text-left cursor-pointer focus:outline-none"
         >
           <img

--- a/spa/src/features/workspace/components/WorkspaceRow.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.test.tsx
@@ -80,6 +80,37 @@ describe('WorkspaceRow', () => {
     expect(screen.getByText('alpha.example.com')).toBeInTheDocument()
   })
 
+  it('clicking title on ACTIVE ws toggles expand (does not re-select)', () => {
+    useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide' })
+    const onSelect = vi.fn()
+    renderRow(mkWs('ws-1', 'Purdex'), { isActive: true, onSelectWorkspace: onSelect })
+    fireEvent.click(screen.getByText('Purdex'))
+    expect(useLayoutStore.getState().workspaceExpanded['ws-1']).toBe(true)
+    expect(onSelect).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText('Purdex'))
+    expect(useLayoutStore.getState().workspaceExpanded['ws-1']).toBe(false)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it("active-click toggle is inert when tabPosition='top' (no inline tabs); still selects", () => {
+    useLayoutStore.setState({ tabPosition: 'top' })
+    const onSelect = vi.fn()
+    renderRow(mkWs('ws-1', 'Purdex'), { isActive: true, onSelectWorkspace: onSelect })
+    fireEvent.click(screen.getByText('Purdex'))
+    expect(onSelect).toHaveBeenCalledWith('ws-1')
+    expect(useLayoutStore.getState().workspaceExpanded['ws-1']).toBeFalsy()
+  })
+
+  it('clicking title on INACTIVE ws selects (does not toggle)', () => {
+    useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide' })
+    const onSelect = vi.fn()
+    renderRow(mkWs('ws-1', 'Purdex'), { isActive: false, onSelectWorkspace: onSelect })
+    fireEvent.click(screen.getByText('Purdex'))
+    expect(onSelect).toHaveBeenCalledWith('ws-1')
+    expect(useLayoutStore.getState().workspaceExpanded['ws-1']).toBeFalsy()
+  })
+
   it('chevron toggles expand state', () => {
     useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide' })
     renderRow(mkWs('ws-1', 'W', ['t1']), { tabsById: { t1: mkTab('t1', 'alpha') } })

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -80,7 +80,13 @@ export function WorkspaceRow(props: Props) {
       >
         <button
           type="button"
-          onClick={() => onSelectWorkspace(workspace.id)}
+          onClick={() => {
+            if (isActive && showTabs) {
+              toggleExpanded(workspace.id)
+            } else {
+              onSelectWorkspace(workspace.id)
+            }
+          }}
           onPointerDown={(e) => e.stopPropagation()}
           onContextMenu={(e) => {
             e.preventDefault()

--- a/spa/src/features/workspace/hooks.test.ts
+++ b/spa/src/features/workspace/hooks.test.ts
@@ -56,6 +56,25 @@ describe('workspace tab recall', () => {
     act(() => { result.current.handleSelectWorkspace(ws.id) })
     expect(useTabStore.getState().activeTabId).toBe(tab2.id)
   })
+
+  it('clears activeTab when selecting an empty workspace from a standalone tab', () => {
+    // Standalone tab (not in any workspace) is active (Home visually).
+    const standalone = createTab({ kind: 'dashboard' })
+    useTabStore.getState().addTab(standalone)
+    useTabStore.getState().setActiveTab(standalone.id)
+
+    // Empty workspace.
+    const emptyWs = useWorkspaceStore.getState().addWorkspace('Empty')
+
+    const { result } = renderHook(() => useTabWorkspaceActions([standalone]))
+
+    act(() => { result.current.handleSelectWorkspace(emptyWs.id) })
+
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(emptyWs.id)
+    // Must drop the standalone tab so isStandaloneTab-derived `activeStandaloneTabId`
+    // stops masking the workspace selection in ActivityBar's `isActive` logic.
+    expect(useTabStore.getState().activeTabId).toBeNull()
+  })
 })
 
 describe('openSingletonAndSelect', () => {

--- a/spa/src/features/workspace/hooks.ts
+++ b/spa/src/features/workspace/hooks.ts
@@ -32,6 +32,7 @@ export function useTabWorkspaceActions(displayTabs: Tab[]) {
     const allTabs = useTabStore.getState().tabs
     if (ws?.activeTabId && allTabs[ws.activeTabId]) setActiveTab(ws.activeTabId)
     else if (ws?.tabs[0]) setActiveTab(ws.tabs[0])
+    else setActiveTab(null)
   }, [setActiveWorkspace, setActiveTab])
 
   const handleSelectTab = useCallback((tabId: string) => {


### PR DESCRIPTION
## Summary

Two related UX fixes on the activity bar's workspace/home rows:

1. **Toggle expand on active click** — clicking the title of an already-active workspace (or Home) now toggles its inline-tabs expand/collapse when \`tabPosition !== 'top'\`. Inactive click still selects, chevron still works.

2. **Empty workspace stuck on standalone** (pre-existing, surfaced by #1) — \`handleSelectWorkspace\` now clears \`activeTabId\` when the target ws has no tabs. Previously the standalone tab stayed set, and \`isStandaloneTab\`-derived \`activeStandaloneTabId\` kept masking the workspace in \`ActivityBar\`'s \`isActive\` logic, so clicking an empty ws from Home looked like a no-op.

## Test plan

- [x] \`WorkspaceRow.test.tsx\` — new cases for active-click toggle (3) + existing 16
- [x] \`HomeRow.test.tsx\` — new cases for active-click toggle (3) + existing 9
- [x] \`hooks.test.ts\` — new \"clears activeTab when selecting an empty workspace from a standalone tab\" + existing 9
- [x] Full suite: 1998/1998 pass
- [x] Browser: active Home → click first ws title → switches correctly; click active ws title → inline tabs toggle (no re-select); tabPosition=top → no toggle, normal select
- [ ] Manual smoke in Electron shell after merge