### PR TITLE
feat(statusline): PR-1a — CC statusLine wrapper + daemon endpoints

### DIFF
--- a/cmd/pdx/main.go
+++ b/cmd/pdx/main.go
@@ -32,7 +32,7 @@ import (
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintf(os.Stderr, "Usage: pdx <command> [flags]\n")
-		fmt.Fprintf(os.Stderr, "Commands: serve, start, stop, status, relay, hook, setup, token\n")
+		fmt.Fprintf(os.Stderr, "Commands: serve, start, stop, status, statusline-proxy, relay, hook, setup, token\n")
 		os.Exit(1)
 	}
 
@@ -53,6 +53,8 @@ func main() {
 		runStop(os.Args[2:])
 	case "status":
 		runStatus(os.Args[2:])
+	case "statusline-proxy":
+		runStatuslineProxy(os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
 		os.Exit(1)

--- a/cmd/pdx/statusline_proxy.go
+++ b/cmd/pdx/statusline_proxy.go
@@ -6,9 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/wake/purdex/internal/config"
 )
 
 // readStdinWithTimeout reads the entire stdin, returning []byte("{}") if empty
@@ -102,16 +105,65 @@ func execInner(inner string, stdinJSON []byte, timeoutSec int) string {
 	return out.String()
 }
 
+type statuslinePayload struct {
+	TmuxSession string          `json:"tmux_session"`
+	AgentType   string          `json:"agent_type"`
+	RawStatus   json.RawMessage `json:"raw_status"`
+}
+
+// postStatus synchronously POSTs the payload to the daemon with a 2s timeout.
+// Returns error on any failure; caller swallows errors silently.
+func postStatus(url, token string, payload statuslinePayload) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("daemon returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
 // runStatuslineProxy is the entry point for `pdx statusline-proxy [--inner "<cmd>"]`.
-// Full implementation added in later tasks; stub for now.
 func runStatuslineProxy(args []string) {
 	inner := parseInnerFlag(args)
 	raw := readStdinWithTimeout(os.Stdin, 5)
 
+	// 1) Print to CC (never blocks on POST)
 	if inner != "" {
 		fmt.Print(execInner(inner, raw, 2))
 	} else {
 		fmt.Println(renderMinimal(raw))
 	}
+
+	// 2) Synchronously POST to daemon; silent fail.
+	tmuxSession := queryTmuxSession() // defined in cmd/pdx/hook.go
+	cfg, err := config.Load("")
+	url := "http://127.0.0.1:7860/api/agent/status"
+	var token string
+	if err == nil {
+		url = fmt.Sprintf("http://%s:%d/api/agent/status", cfg.Bind, cfg.Port)
+		token = cfg.Token
+	}
+	_ = postStatus(url, token, statuslinePayload{
+		TmuxSession: tmuxSession,
+		AgentType:   "cc",
+		RawStatus:   raw,
+	})
+
 	os.Exit(0)
 }

--- a/cmd/pdx/statusline_proxy.go
+++ b/cmd/pdx/statusline_proxy.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"time"
 )
 
@@ -74,11 +77,41 @@ func renderMinimal(raw json.RawMessage) string {
 	return out
 }
 
+// parseInnerFlag extracts the value following "--inner" from args.
+// Returns "" when absent.
+func parseInnerFlag(args []string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--inner" {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// execInner runs the user-supplied inner command via `sh -c`, feeding stdinJSON
+// to its stdin. The inner command's stdout is captured and returned; stderr
+// and non-zero exit codes are ignored. timeoutSec caps total execution.
+func execInner(inner string, stdinJSON []byte, timeoutSec int) string {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSec)*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", inner)
+	cmd.Stdin = bytes.NewReader(stdinJSON)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	_ = cmd.Run()
+	return out.String()
+}
+
 // runStatuslineProxy is the entry point for `pdx statusline-proxy [--inner "<cmd>"]`.
 // Full implementation added in later tasks; stub for now.
 func runStatuslineProxy(args []string) {
-	_ = args
+	inner := parseInnerFlag(args)
 	raw := readStdinWithTimeout(os.Stdin, 5)
-	fmt.Println(renderMinimal(raw))
+
+	if inner != "" {
+		fmt.Print(execInner(inner, raw, 2))
+	} else {
+		fmt.Println(renderMinimal(raw))
+	}
 	os.Exit(0)
 }

--- a/cmd/pdx/statusline_proxy.go
+++ b/cmd/pdx/statusline_proxy.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// readStdinWithTimeout reads the entire stdin, returning []byte("{}") if empty
+// or on any read error. The timeoutSec parameter bounds total read time.
+func readStdinWithTimeout(r io.Reader, timeoutSec int) []byte {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := io.ReadAll(r)
+		ch <- result{data, err}
+	}()
+	select {
+	case res := <-ch:
+		if res.err != nil || len(res.data) == 0 {
+			return []byte("{}")
+		}
+		return res.data
+	case <-time.After(time.Duration(timeoutSec) * time.Second):
+		return []byte("{}")
+	}
+}
+
+// renderMinimal builds the default single-line status for CC to display when
+// no --inner command is configured. Fields absent from raw are silently
+// omitted; all format errors fall back to "[pdx]".
+func renderMinimal(raw json.RawMessage) string {
+	var s struct {
+		Model struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+		} `json:"model"`
+		Context struct {
+			UsedPct *float64 `json:"used_percentage"`
+		} `json:"context_window"`
+		Cost struct {
+			TotalUSD *float64 `json:"total_cost_usd"`
+		} `json:"cost"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "[pdx]"
+	}
+	parts := []string{"[pdx]"}
+	model := s.Model.DisplayName
+	if model == "" {
+		model = s.Model.ID
+	}
+	if model != "" {
+		parts = append(parts, model)
+	}
+	if s.Context.UsedPct != nil {
+		parts = append(parts, fmt.Sprintf("ctx %.0f%%", *s.Context.UsedPct))
+	}
+	if s.Cost.TotalUSD != nil {
+		parts = append(parts, fmt.Sprintf("$%.2f", *s.Cost.TotalUSD))
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	out := parts[0] + " " + parts[1]
+	for _, p := range parts[2:] {
+		out += " · " + p
+	}
+	return out
+}
+
+// runStatuslineProxy is the entry point for `pdx statusline-proxy [--inner "<cmd>"]`.
+// Full implementation added in later tasks; stub for now.
+func runStatuslineProxy(args []string) {
+	_ = args
+	raw := readStdinWithTimeout(os.Stdin, 5)
+	fmt.Println(renderMinimal(raw))
+	os.Exit(0)
+}

--- a/cmd/pdx/statusline_proxy.go
+++ b/cmd/pdx/statusline_proxy.go
@@ -176,6 +176,4 @@ func runStatuslineProxy(args []string) {
 		AgentType:   "cc",
 		RawStatus:   raw,
 	})
-
-	os.Exit(0)
 }

--- a/cmd/pdx/statusline_proxy.go
+++ b/cmd/pdx/statusline_proxy.go
@@ -138,6 +138,18 @@ func postStatus(url, token string, payload statuslinePayload) error {
 	return nil
 }
 
+// resolveDaemonHost rewrites wildcard bind addresses (0.0.0.0, ::, empty) to
+// 127.0.0.1 so the statusline-proxy can POST to the daemon on the loopback.
+// A daemon bound to 0.0.0.0 is listening on all interfaces including loopback,
+// but 0.0.0.0 itself is not a valid connection target on macOS/Linux.
+func resolveDaemonHost(bind string) string {
+	switch bind {
+	case "", "0.0.0.0", "::", "[::]":
+		return "127.0.0.1"
+	}
+	return bind
+}
+
 // runStatuslineProxy is the entry point for `pdx statusline-proxy [--inner "<cmd>"]`.
 func runStatuslineProxy(args []string) {
 	inner := parseInnerFlag(args)
@@ -156,7 +168,7 @@ func runStatuslineProxy(args []string) {
 	url := "http://127.0.0.1:7860/api/agent/status"
 	var token string
 	if err == nil {
-		url = fmt.Sprintf("http://%s:%d/api/agent/status", cfg.Bind, cfg.Port)
+		url = fmt.Sprintf("http://%s:%d/api/agent/status", resolveDaemonHost(cfg.Bind), cfg.Port)
 		token = cfg.Token
 	}
 	_ = postStatus(url, token, statuslinePayload{

--- a/cmd/pdx/statusline_proxy_test.go
+++ b/cmd/pdx/statusline_proxy_test.go
@@ -59,3 +59,45 @@ func TestReadStdinWithTimeout_Empty(t *testing.T) {
 		t.Errorf("empty stdin got %q, want {}", got)
 	}
 }
+
+func TestParseInnerFlag(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{}, ""},
+		{[]string{"--inner", "ccstatusline"}, "ccstatusline"},
+		{[]string{"--inner", "ccstatusline --format compact"}, "ccstatusline --format compact"},
+		{[]string{"--unknown", "x"}, ""},
+	}
+	for _, tc := range cases {
+		got := parseInnerFlag(tc.args)
+		if got != tc.want {
+			t.Errorf("parseInnerFlag(%v) = %q, want %q", tc.args, got, tc.want)
+		}
+	}
+}
+
+func TestExecInner_Success(t *testing.T) {
+	stdin := []byte(`{"a":1}`)
+	got := execInner("echo hello", stdin, 2)
+	if strings.TrimSpace(got) != "hello" {
+		t.Errorf("execInner stdout = %q, want %q", got, "hello")
+	}
+}
+
+func TestExecInner_Timeout(t *testing.T) {
+	got := execInner("sleep 5", []byte("{}"), 1)
+	// Timeout is silent; empty or partial stdout is acceptable.
+	if got == "should-never-happen" {
+		t.Error("sentinel check")
+	}
+	_ = got
+}
+
+func TestExecInner_NonZeroExitCaptured(t *testing.T) {
+	got := execInner("printf 'foo'; exit 1", []byte("{}"), 2)
+	if strings.TrimSpace(got) != "foo" {
+		t.Errorf("non-zero exit should still capture stdout; got %q", got)
+	}
+}

--- a/cmd/pdx/statusline_proxy_test.go
+++ b/cmd/pdx/statusline_proxy_test.go
@@ -148,3 +148,23 @@ func TestPostStatus_SilentOn5xx(t *testing.T) {
 		t.Error("5xx should return error, got nil")
 	}
 }
+
+func TestResolveDaemonHost(t *testing.T) {
+	cases := []struct {
+		bind string
+		want string
+	}{
+		{"", "127.0.0.1"},
+		{"0.0.0.0", "127.0.0.1"},
+		{"::", "127.0.0.1"},
+		{"[::]", "127.0.0.1"},
+		{"127.0.0.1", "127.0.0.1"},
+		{"100.64.0.2", "100.64.0.2"},
+		{"localhost", "localhost"},
+	}
+	for _, tc := range cases {
+		if got := resolveDaemonHost(tc.bind); got != tc.want {
+			t.Errorf("resolveDaemonHost(%q) = %q, want %q", tc.bind, got, tc.want)
+		}
+	}
+}

--- a/cmd/pdx/statusline_proxy_test.go
+++ b/cmd/pdx/statusline_proxy_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRenderMinimal_FullFields(t *testing.T) {
+	raw := json.RawMessage(`{
+		"model": {"id": "claude-sonnet-4-6", "display_name": "Sonnet"},
+		"context_window": {"used_percentage": 23},
+		"cost": {"total_cost_usd": 0.12}
+	}`)
+	got := renderMinimal(raw)
+	want := "[pdx] Sonnet · ctx 23% · $0.12"
+	if got != want {
+		t.Errorf("renderMinimal = %q, want %q", got, want)
+	}
+}
+
+func TestRenderMinimal_MissingDisplayName(t *testing.T) {
+	raw := json.RawMessage(`{"model":{"id":"claude-opus-4-7"}}`)
+	got := renderMinimal(raw)
+	if !strings.Contains(got, "claude-opus-4-7") {
+		t.Errorf("renderMinimal = %q, expected id fallback", got)
+	}
+}
+
+func TestRenderMinimal_NoCost(t *testing.T) {
+	raw := json.RawMessage(`{"model":{"display_name":"Opus"},"context_window":{"used_percentage":8}}`)
+	got := renderMinimal(raw)
+	want := "[pdx] Opus · ctx 8%"
+	if got != want {
+		t.Errorf("renderMinimal = %q, want %q", got, want)
+	}
+}
+
+func TestRenderMinimal_Empty(t *testing.T) {
+	got := renderMinimal(json.RawMessage(`{}`))
+	want := "[pdx]"
+	if got != want {
+		t.Errorf("renderMinimal = %q, want %q", got, want)
+	}
+}
+
+func TestReadStdinWithTimeout_Valid(t *testing.T) {
+	src := bytes.NewBufferString(`{"a":1}`)
+	got := readStdinWithTimeout(src, 1)
+	if string(got) != `{"a":1}` {
+		t.Errorf("got %q, want JSON", got)
+	}
+}
+
+func TestReadStdinWithTimeout_Empty(t *testing.T) {
+	got := readStdinWithTimeout(bytes.NewBuffer(nil), 1)
+	if string(got) != "{}" {
+		t.Errorf("empty stdin got %q, want {}", got)
+	}
+}

--- a/cmd/pdx/statusline_proxy_test.go
+++ b/cmd/pdx/statusline_proxy_test.go
@@ -3,8 +3,11 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRenderMinimal_FullFields(t *testing.T) {
@@ -99,5 +102,49 @@ func TestExecInner_NonZeroExitCaptured(t *testing.T) {
 	got := execInner("printf 'foo'; exit 1", []byte("{}"), 2)
 	if strings.TrimSpace(got) != "foo" {
 		t.Errorf("non-zero exit should still capture stdout; got %q", got)
+	}
+}
+
+func TestPostStatus_Success(t *testing.T) {
+	var received statuslinePayload
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	err := postStatus(ts.URL+"/api/agent/status", "tok", statuslinePayload{
+		TmuxSession: "sess1",
+		AgentType:   "cc",
+		RawStatus:   json.RawMessage(`{"x":1}`),
+	})
+	if err != nil {
+		t.Fatalf("postStatus: %v", err)
+	}
+	if received.TmuxSession != "sess1" {
+		t.Errorf("tmux_session mismatch: %q", received.TmuxSession)
+	}
+}
+
+func TestPostStatus_Timeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+	}))
+	defer ts.Close()
+
+	err := postStatus(ts.URL, "", statuslinePayload{TmuxSession: "x", AgentType: "cc"})
+	if err == nil {
+		t.Error("expected timeout error, got nil")
+	}
+}
+
+func TestPostStatus_SilentOn5xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+	err := postStatus(ts.URL, "", statuslinePayload{TmuxSession: "x", AgentType: "cc"})
+	if err == nil {
+		t.Error("5xx should return error, got nil")
 	}
 }

--- a/docs/superpowers/plans/2026-04-18-statusline-installer-pr1.md
+++ b/docs/superpowers/plans/2026-04-18-statusline-installer-pr1.md
@@ -1038,7 +1038,8 @@ func writeSettingsAtomic(path string, settings map[string]any) error {
 	return nil
 }
 
-func readSettings(path string) (map[string]any, error) {
+// Note: not `readSettings` because hooks_test.go already uses that name as a test helper.
+func loadSettings(path string) (map[string]any, error) {
 	settings := make(map[string]any)
 	data, err := os.ReadFile(path)
 	if err == nil {
@@ -1052,7 +1053,7 @@ func readSettings(path string) (map[string]any, error) {
 }
 
 func installStatuslinePdx(path, pdxPath string) error {
-	settings, err := readSettings(path)
+	settings, err := loadSettings(path)
 	if err != nil {
 		return err
 	}
@@ -1064,7 +1065,7 @@ func installStatuslinePdx(path, pdxPath string) error {
 }
 
 func installStatuslineWrap(path, pdxPath, inner string) error {
-	settings, err := readSettings(path)
+	settings, err := loadSettings(path)
 	if err != nil {
 		return err
 	}
@@ -1080,7 +1081,7 @@ func removeStatusline(path string) error {
 	if err != nil {
 		return err
 	}
-	settings, err := readSettings(path)
+	settings, err := loadSettings(path)
 	if err != nil {
 		return err
 	}

--- a/docs/superpowers/plans/2026-04-18-statusline-installer-pr1.md
+++ b/docs/superpowers/plans/2026-04-18-statusline-installer-pr1.md
@@ -284,8 +284,9 @@ func renderMinimal(raw json.RawMessage) string {
 	if len(parts) == 1 {
 		return parts[0]
 	}
-	out := parts[0]
-	for _, p := range parts[1:] {
+	// "[pdx]" is a label prefix (space-joined); remaining parts bullet-separated.
+	out := parts[0] + " " + parts[1]
+	for _, p := range parts[2:] {
 		out += " · " + p
 	}
 	return out

--- a/docs/superpowers/plans/2026-04-18-statusline-installer-pr1.md
+++ b/docs/superpowers/plans/2026-04-18-statusline-installer-pr1.md
@@ -696,9 +696,11 @@ func TestDetectStatuslineMode_Wrapped(t *testing.T) {
 }
 
 func TestDetectStatuslineMode_WrappedWithSingleQuoteEscape(t *testing.T) {
-	// Shell: --inner 'it'\''s'   after escape
+	// Shell escape we want to exercise: --inner 'it'\''s'   (POSIX single-quote escape for it's)
+	// In the on-disk JSON the backslash must itself be escaped (`\\`), so the raw-string literal
+	// below writes `'it'\\''s'` which JSON decodes to `'it'\''s'` — then shellwords parses to "it's".
 	path := writeSettings(t, `{
-  "statusLine": {"type": "command", "command": "/x/pdx statusline-proxy --inner 'it'\''s'"}
+  "statusLine": {"type": "command", "command": "/x/pdx statusline-proxy --inner 'it'\\''s'"}
 }`)
 	m, _ := detectStatuslineMode(path)
 	if m.Mode != "wrapped" {

--- a/docs/superpowers/plans/2026-04-18-statusline-installer-pr1.md
+++ b/docs/superpowers/plans/2026-04-18-statusline-installer-pr1.md
@@ -1223,7 +1223,7 @@ func TestHandleStatuslineStatus_CC(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Errorf("status = %d", resp.StatusCode)
 	}
-	var body cc.StatuslineState
+	var body agent.StatuslineState
 	_ = json.NewDecoder(resp.Body).Decode(&body)
 	if body.Mode == "" {
 		t.Error("empty mode")
@@ -1249,7 +1249,7 @@ func (m *Module) handleStatuslineStatus(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, `{"error":"unknown agent"}`, http.StatusNotFound)
 		return
 	}
-	installer, ok := provider.(cc.StatuslineInstaller)
+	installer, ok := provider.(agent.StatuslineInstaller)
 	if !ok {
 		http.Error(w, `{"error":"agent does not support statusline"}`, http.StatusNotFound)
 		return
@@ -1367,7 +1367,7 @@ func (m *Module) handleStatuslineSetup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"unknown agent"}`, http.StatusNotFound)
 		return
 	}
-	installer, ok := provider.(cc.StatuslineInstaller)
+	installer, ok := provider.(agent.StatuslineInstaller)
 	if !ok {
 		http.Error(w, `{"error":"agent does not support statusline"}`, http.StatusNotFound)
 		return

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/creack/pty v1.1.24
 	github.com/gorilla/websocket v1.5.3
+	github.com/mattn/go-shellwords v1.0.13
 	modernc.org/sqlite v1.46.2
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/mattn/go-shellwords v1.0.13 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mattn/go-shellwords v1.0.13 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-shellwords v1.0.13 h1:DC0OMEpGjm6LfNFU4ckYcvbQKyp2vE8atyFGXNtDcf4=
+github.com/mattn/go-shellwords v1.0.13/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -16,29 +16,26 @@ var ccHookEvents = []string{
 }
 
 func (p *Provider) InstallHooks(pdxPath string) error {
-	home, err := os.UserHomeDir()
+	settingsPath, err := ccSettingsPath()
 	if err != nil {
 		return fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	return mergeClaudeHooks(settingsPath, pdxPath, false)
 }
 
 func (p *Provider) RemoveHooks(pdxPath string) error {
-	home, err := os.UserHomeDir()
+	settingsPath, err := ccSettingsPath()
 	if err != nil {
 		return fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	return mergeClaudeHooks(settingsPath, pdxPath, true)
 }
 
 func (p *Provider) CheckHooks() (agent.HookStatus, error) {
-	home, err := os.UserHomeDir()
+	settingsPath, err := ccSettingsPath()
 	if err != nil {
 		return agent.HookStatus{Issues: []string{"cannot find home dir"}}, err
 	}
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	data, err := os.ReadFile(settingsPath)
 	if err != nil {
 		return agent.HookStatus{

--- a/internal/agent/cc/paths.go
+++ b/internal/agent/cc/paths.go
@@ -1,0 +1,17 @@
+package cc
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ccSettingsPath returns the absolute path to the user's Claude Code
+// settings.json (~/.claude/settings.json). It returns an error only if
+// the user's home directory cannot be determined.
+func ccSettingsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "settings.json"), nil
+}

--- a/internal/agent/cc/provider.go
+++ b/internal/agent/cc/provider.go
@@ -57,3 +57,35 @@ func (p *Provider) RegisterServices(registry *core.ServiceRegistry) {
 	registry.Register(HistoryKey, CCHistoryProvider(p))
 	registry.Register(OperatorKey, CCOperator(p))
 }
+
+func (p *Provider) CheckStatusline() (agent.StatuslineState, error) {
+	path, err := ccSettingsPath()
+	if err != nil {
+		return agent.StatuslineState{}, err
+	}
+	return detectStatuslineMode(path)
+}
+
+func (p *Provider) InstallStatuslinePdx(pdxPath string) error {
+	path, err := ccSettingsPath()
+	if err != nil {
+		return err
+	}
+	return installStatuslinePdx(path, pdxPath)
+}
+
+func (p *Provider) InstallStatuslineWrap(pdxPath, inner string) error {
+	path, err := ccSettingsPath()
+	if err != nil {
+		return err
+	}
+	return installStatuslineWrap(path, pdxPath, inner)
+}
+
+func (p *Provider) RemoveStatusline() error {
+	path, err := ccSettingsPath()
+	if err != nil {
+		return err
+	}
+	return removeStatusline(path)
+}

--- a/internal/agent/cc/statusline.go
+++ b/internal/agent/cc/statusline.go
@@ -8,21 +8,14 @@ import (
 	"strings"
 
 	shellwords "github.com/mattn/go-shellwords"
-)
 
-// StatuslineState describes the current state of CC's statusLine config.
-type StatuslineState struct {
-	Mode         string `json:"mode"` // "none" | "pdx" | "wrapped" | "unmanaged"
-	Installed    bool   `json:"installed"`
-	Inner        string `json:"innerCommand,omitempty"`
-	RawCommand   string `json:"rawCommand,omitempty"`
-	SettingsPath string `json:"settingsPath"`
-}
+	"github.com/wake/purdex/internal/agent"
+)
 
 // detectStatuslineMode reads ~/.claude/settings.json and classifies the
 // current statusLine.command value.
-func detectStatuslineMode(path string) (StatuslineState, error) {
-	s := StatuslineState{Mode: "none", SettingsPath: path}
+func detectStatuslineMode(path string) (agent.StatuslineState, error) {
+	s := agent.StatuslineState{Mode: "none", SettingsPath: path}
 
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/agent/cc/statusline.go
+++ b/internal/agent/cc/statusline.go
@@ -130,7 +130,7 @@ func installStatuslinePdx(path, pdxPath string) error {
 	}
 	settings["statusLine"] = map[string]any{
 		"type":    "command",
-		"command": fmt.Sprintf("%s statusline-proxy", pdxPath),
+		"command": fmt.Sprintf("%s statusline-proxy", shellSingleQuote(pdxPath)),
 	}
 	return writeSettingsAtomic(path, settings)
 }
@@ -142,7 +142,7 @@ func installStatuslineWrap(path, pdxPath, inner string) error {
 	}
 	settings["statusLine"] = map[string]any{
 		"type":    "command",
-		"command": fmt.Sprintf("%s statusline-proxy --inner %s", pdxPath, shellSingleQuote(inner)),
+		"command": fmt.Sprintf("%s statusline-proxy --inner %s", shellSingleQuote(pdxPath), shellSingleQuote(inner)),
 	}
 	return writeSettingsAtomic(path, settings)
 }

--- a/internal/agent/cc/statusline.go
+++ b/internal/agent/cc/statusline.go
@@ -100,8 +100,14 @@ func writeSettingsAtomic(path string, settings map[string]any) error {
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
 	}
+	// Preserve existing file mode so we never widen permissions (e.g. 0600 → 0644).
+	mode := os.FileMode(0644)
+	if st, err := os.Stat(path); err == nil {
+		mode = st.Mode().Perm()
+	}
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, out, 0644); err != nil {
+	if err := os.WriteFile(tmp, out, mode); err != nil {
+		os.Remove(tmp)
 		return fmt.Errorf("write temp: %w", err)
 	}
 	if err := os.Rename(tmp, path); err != nil {

--- a/internal/agent/cc/statusline.go
+++ b/internal/agent/cc/statusline.go
@@ -1,0 +1,85 @@
+package cc
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	shellwords "github.com/mattn/go-shellwords"
+)
+
+// StatuslineState describes the current state of CC's statusLine config.
+type StatuslineState struct {
+	Mode         string `json:"mode"` // "none" | "pdx" | "wrapped" | "unmanaged"
+	Installed    bool   `json:"installed"`
+	Inner        string `json:"innerCommand,omitempty"`
+	RawCommand   string `json:"rawCommand,omitempty"`
+	SettingsPath string `json:"settingsPath"`
+}
+
+// detectStatuslineMode reads ~/.claude/settings.json and classifies the
+// current statusLine.command value.
+func detectStatuslineMode(path string) (StatuslineState, error) {
+	s := StatuslineState{Mode: "none", SettingsPath: path}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return s, err
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return s, err
+	}
+	slRaw, ok := settings["statusLine"]
+	if !ok || slRaw == nil {
+		return s, nil
+	}
+	slObj, isObj := slRaw.(map[string]any)
+	if !isObj {
+		return s, nil // non-object: treat as none (safe overwrite)
+	}
+	cmdAny, ok := slObj["command"]
+	if !ok {
+		return s, nil
+	}
+	cmd, ok := cmdAny.(string)
+	if !ok || strings.TrimSpace(cmd) == "" {
+		return s, nil
+	}
+
+	s.Installed = true
+	s.RawCommand = cmd
+
+	argv, err := shellwords.Parse(cmd)
+	if err != nil || len(argv) < 2 {
+		s.Mode = "unmanaged"
+		s.Inner = cmd
+		return s, nil
+	}
+	base := filepath.Base(argv[0])
+	if base != "pdx" && base != "pdx.exe" {
+		s.Mode = "unmanaged"
+		s.Inner = cmd
+		return s, nil
+	}
+	if argv[1] != "statusline-proxy" {
+		s.Mode = "unmanaged"
+		s.Inner = cmd
+		return s, nil
+	}
+	switch {
+	case len(argv) == 2:
+		s.Mode = "pdx"
+	case len(argv) >= 4 && argv[2] == "--inner":
+		s.Mode = "wrapped"
+		s.Inner = argv[3]
+	default:
+		s.Mode = "unmanaged"
+		s.Inner = cmd
+	}
+	return s, nil
+}

--- a/internal/agent/cc/statusline.go
+++ b/internal/agent/cc/statusline.go
@@ -2,6 +2,7 @@ package cc
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,4 +83,94 @@ func detectStatuslineMode(path string) (StatuslineState, error) {
 		s.Inner = cmd
 	}
 	return s, nil
+}
+
+// shellSingleQuote returns a POSIX-safe single-quoted form of s that round-trips
+// through `sh -c`. Embedded ' characters become '\''.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// writeSettingsAtomic marshals settings as JSON and writes to path via temp+rename.
+func writeSettingsAtomic(path string, settings map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0644); err != nil {
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+func loadSettings(path string) (map[string]any, error) {
+	settings := make(map[string]any)
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return nil, err
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	return settings, nil
+}
+
+func installStatuslinePdx(path, pdxPath string) error {
+	settings, err := loadSettings(path)
+	if err != nil {
+		return err
+	}
+	settings["statusLine"] = map[string]any{
+		"type":    "command",
+		"command": fmt.Sprintf("%s statusline-proxy", pdxPath),
+	}
+	return writeSettingsAtomic(path, settings)
+}
+
+func installStatuslineWrap(path, pdxPath, inner string) error {
+	settings, err := loadSettings(path)
+	if err != nil {
+		return err
+	}
+	settings["statusLine"] = map[string]any{
+		"type":    "command",
+		"command": fmt.Sprintf("%s statusline-proxy --inner %s", pdxPath, shellSingleQuote(inner)),
+	}
+	return writeSettingsAtomic(path, settings)
+}
+
+func removeStatusline(path string) error {
+	state, err := detectStatuslineMode(path)
+	if err != nil {
+		return err
+	}
+	settings, err := loadSettings(path)
+	if err != nil {
+		return err
+	}
+	switch state.Mode {
+	case "none":
+		return nil
+	case "unmanaged":
+		return fmt.Errorf("refusing to remove unmanaged statusLine; please remove manually")
+	case "pdx":
+		delete(settings, "statusLine")
+	case "wrapped":
+		sl, _ := settings["statusLine"].(map[string]any)
+		if sl == nil {
+			sl = map[string]any{"type": "command"}
+		}
+		sl["command"] = state.Inner
+		settings["statusLine"] = sl
+	}
+	return writeSettingsAtomic(path, settings)
 }

--- a/internal/agent/cc/statusline_test.go
+++ b/internal/agent/cc/statusline_test.go
@@ -244,3 +244,40 @@ func TestRemoveStatusline_None_NoOp(t *testing.T) {
 		t.Fatalf("remove of none should no-op: %v", err)
 	}
 }
+
+func TestWriteSettings_PreservesFileMode(t *testing.T) {
+	path := writeSettings(t, `{"statusLine":{"type":"command","command":"/opt/bin/pdx statusline-proxy"}}`)
+	if err := os.Chmod(path, 0600); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	// Any install/remove operation goes through writeSettingsAtomic.
+	if err := installStatuslinePdx(path, "/opt/bin/pdx"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := st.Mode().Perm(); got != 0600 {
+		t.Errorf("mode = %o, want 0600", got)
+	}
+}
+
+func TestWriteSettings_NoTmpLeftAfterRenameFailure(t *testing.T) {
+	// Force a rename failure by making the target an un-renameable-onto directory.
+	// We simulate by pointing path into a dir that can't be created; MkdirAll fails first.
+	// Simpler: use an invalid path under a regular file.
+	base := writeSettings(t, `{}`) // a regular file
+	invalid := filepath.Join(base, "nested", "settings.json")
+	// MkdirAll will fail because base is a file, not a dir.
+	err := installStatuslinePdx(invalid, "/opt/bin/pdx")
+	if err == nil {
+		t.Fatal("expected error writing under a regular file")
+	}
+	// No .tmp sibling should be left next to any part of the invalid path.
+	// (installs must not leave garbage on failure.)
+	entries, _ := filepath.Glob(base + "*.tmp")
+	if len(entries) != 0 {
+		t.Errorf("tmp leak: %v", entries)
+	}
+}

--- a/internal/agent/cc/statusline_test.go
+++ b/internal/agent/cc/statusline_test.go
@@ -1,6 +1,7 @@
 package cc
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -101,5 +102,145 @@ func TestDetectStatuslineMode_MissingFile(t *testing.T) {
 	}
 	if m.Mode != "none" {
 		t.Errorf("missing file: mode = %q, want none", m.Mode)
+	}
+}
+
+func readSettingsMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func getStatusLineCommand(t *testing.T, path string) string {
+	t.Helper()
+	s := readSettingsMap(t, path)
+	sl, _ := s["statusLine"].(map[string]any)
+	if sl == nil {
+		return ""
+	}
+	c, _ := sl["command"].(string)
+	return c
+}
+
+func TestInstallStatuslinePdx_Empty(t *testing.T) {
+	path := writeSettings(t, `{}`)
+	if err := installStatuslinePdx(path, "/opt/bin/pdx"); err != nil {
+		t.Fatal(err)
+	}
+	got := getStatusLineCommand(t, path)
+	if got != "/opt/bin/pdx statusline-proxy" {
+		t.Errorf("command = %q", got)
+	}
+}
+
+func TestInstallStatuslinePdx_PreservesHooks(t *testing.T) {
+	path := writeSettings(t, `{"hooks": {"Stop": "something"}}`)
+	if err := installStatuslinePdx(path, "/opt/bin/pdx"); err != nil {
+		t.Fatal(err)
+	}
+	s := readSettingsMap(t, path)
+	if _, ok := s["hooks"]; !ok {
+		t.Error("hooks dropped")
+	}
+	sl, _ := s["statusLine"].(map[string]any)
+	if sl["type"] != "command" {
+		t.Errorf("type = %v", sl["type"])
+	}
+}
+
+func TestInstallStatuslineWrap_SimpleInner(t *testing.T) {
+	path := writeSettings(t, `{}`)
+	if err := installStatuslineWrap(path, "/opt/bin/pdx", "ccstatusline"); err != nil {
+		t.Fatal(err)
+	}
+	got := getStatusLineCommand(t, path)
+	want := "/opt/bin/pdx statusline-proxy --inner 'ccstatusline'"
+	if got != want {
+		t.Errorf("command = %q, want %q", got, want)
+	}
+}
+
+func TestInstallStatuslineWrap_InnerWithSingleQuote(t *testing.T) {
+	path := writeSettings(t, `{}`)
+	if err := installStatuslineWrap(path, "/opt/bin/pdx", "it's"); err != nil {
+		t.Fatal(err)
+	}
+	got := getStatusLineCommand(t, path)
+	// POSIX single-quote escape: ' -> '\''
+	want := "/opt/bin/pdx statusline-proxy --inner 'it'\\''s'"
+	if got != want {
+		t.Errorf("command = %q, want %q", got, want)
+	}
+	// Round-trip: detect should return the original inner.
+	m, _ := detectStatuslineMode(path)
+	if m.Inner != "it's" {
+		t.Errorf("round-trip inner = %q, want \"it's\"", m.Inner)
+	}
+}
+
+func TestInstallStatuslineWrap_InnerWithSpaceAndAmpersand(t *testing.T) {
+	inner := `foo "bar" & baz 'qux'`
+	path := writeSettings(t, `{}`)
+	if err := installStatuslineWrap(path, "/opt/bin/pdx", inner); err != nil {
+		t.Fatal(err)
+	}
+	m, _ := detectStatuslineMode(path)
+	if m.Inner != inner {
+		t.Errorf("round-trip: got %q, want %q", m.Inner, inner)
+	}
+}
+
+func TestRemoveStatusline_Pdx(t *testing.T) {
+	path := writeSettings(t, `{"hooks":{"Stop":"x"},"statusLine":{"type":"command","command":"/opt/bin/pdx statusline-proxy"}}`)
+	if err := removeStatusline(path); err != nil {
+		t.Fatal(err)
+	}
+	s := readSettingsMap(t, path)
+	if _, ok := s["statusLine"]; ok {
+		t.Error("statusLine should be removed")
+	}
+	if _, ok := s["hooks"]; !ok {
+		t.Error("hooks should be preserved")
+	}
+}
+
+func TestRemoveStatusline_WrappedRestoresInner(t *testing.T) {
+	path := writeSettings(t, `{"statusLine":{"type":"command","command":"/opt/bin/pdx statusline-proxy --inner 'ccstatusline --format compact'","padding":0}}`)
+	if err := removeStatusline(path); err != nil {
+		t.Fatal(err)
+	}
+	got := getStatusLineCommand(t, path)
+	if got != "ccstatusline --format compact" {
+		t.Errorf("restored command = %q", got)
+	}
+	s := readSettingsMap(t, path)
+	sl, _ := s["statusLine"].(map[string]any)
+	if sl["type"] != "command" {
+		t.Errorf("type not preserved: %v", sl["type"])
+	}
+	if sl["padding"] == nil {
+		t.Errorf("padding not preserved")
+	}
+}
+
+func TestRemoveStatusline_UnmanagedRefuses(t *testing.T) {
+	path := writeSettings(t, `{"statusLine":{"type":"command","command":"ccstatusline"}}`)
+	err := removeStatusline(path)
+	if err == nil {
+		t.Error("expected refusal on unmanaged remove")
+	}
+}
+
+func TestRemoveStatusline_None_NoOp(t *testing.T) {
+	path := writeSettings(t, `{}`)
+	if err := removeStatusline(path); err != nil {
+		t.Fatalf("remove of none should no-op: %v", err)
 	}
 }

--- a/internal/agent/cc/statusline_test.go
+++ b/internal/agent/cc/statusline_test.go
@@ -1,0 +1,105 @@
+package cc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSettings(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	return path
+}
+
+func TestDetectStatuslineMode_None(t *testing.T) {
+	path := writeSettings(t, `{}`)
+	m, err := detectStatuslineMode(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Mode != "none" {
+		t.Errorf("mode = %q, want none", m.Mode)
+	}
+}
+
+func TestDetectStatuslineMode_NullField(t *testing.T) {
+	path := writeSettings(t, `{"statusLine": null}`)
+	m, _ := detectStatuslineMode(path)
+	if m.Mode != "none" {
+		t.Errorf("null statusLine: mode = %q, want none", m.Mode)
+	}
+}
+
+func TestDetectStatuslineMode_NonObject(t *testing.T) {
+	path := writeSettings(t, `{"statusLine": "raw string"}`)
+	m, _ := detectStatuslineMode(path)
+	if m.Mode != "none" {
+		t.Errorf("non-object statusLine: mode = %q, want none", m.Mode)
+	}
+}
+
+func TestDetectStatuslineMode_Pdx(t *testing.T) {
+	path := writeSettings(t, `{
+  "statusLine": {"type": "command", "command": "/opt/homebrew/bin/pdx statusline-proxy"}
+}`)
+	m, _ := detectStatuslineMode(path)
+	if m.Mode != "pdx" {
+		t.Errorf("mode = %q, want pdx", m.Mode)
+	}
+}
+
+func TestDetectStatuslineMode_Wrapped(t *testing.T) {
+	path := writeSettings(t, `{
+  "statusLine": {"type": "command", "command": "/a/b/pdx statusline-proxy --inner 'ccstatusline --format compact'"}
+}`)
+	m, _ := detectStatuslineMode(path)
+	if m.Mode != "wrapped" {
+		t.Errorf("mode = %q, want wrapped", m.Mode)
+	}
+	if m.Inner != "ccstatusline --format compact" {
+		t.Errorf("inner = %q", m.Inner)
+	}
+}
+
+func TestDetectStatuslineMode_WrappedWithSingleQuoteEscape(t *testing.T) {
+	// Shell: --inner 'it'\''s'   after escape
+	// JSON encodes the literal backslash as \\, so the on-disk value is 'it'\''s'.
+	path := writeSettings(t, `{
+  "statusLine": {"type": "command", "command": "/x/pdx statusline-proxy --inner 'it'\\''s'"}
+}`)
+	m, _ := detectStatuslineMode(path)
+	if m.Mode != "wrapped" {
+		t.Errorf("mode = %q, want wrapped", m.Mode)
+	}
+	if m.Inner != "it's" {
+		t.Errorf("inner = %q, want \"it's\"", m.Inner)
+	}
+}
+
+func TestDetectStatuslineMode_Unmanaged(t *testing.T) {
+	path := writeSettings(t, `{
+  "statusLine": {"type": "command", "command": "ccstatusline --format compact"}
+}`)
+	m, _ := detectStatuslineMode(path)
+	if m.Mode != "unmanaged" {
+		t.Errorf("mode = %q, want unmanaged", m.Mode)
+	}
+	if m.Inner != "ccstatusline --format compact" {
+		t.Errorf("inner (raw command) = %q", m.Inner)
+	}
+}
+
+func TestDetectStatuslineMode_MissingFile(t *testing.T) {
+	m, err := detectStatuslineMode(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("missing file should be ok: %v", err)
+	}
+	if m.Mode != "none" {
+		t.Errorf("missing file: mode = %q, want none", m.Mode)
+	}
+}

--- a/internal/agent/cc/statusline_test.go
+++ b/internal/agent/cc/statusline_test.go
@@ -135,7 +135,7 @@ func TestInstallStatuslinePdx_Empty(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := getStatusLineCommand(t, path)
-	if got != "/opt/bin/pdx statusline-proxy" {
+	if got != "'/opt/bin/pdx' statusline-proxy" {
 		t.Errorf("command = %q", got)
 	}
 }
@@ -161,7 +161,7 @@ func TestInstallStatuslineWrap_SimpleInner(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := getStatusLineCommand(t, path)
-	want := "/opt/bin/pdx statusline-proxy --inner 'ccstatusline'"
+	want := "'/opt/bin/pdx' statusline-proxy --inner 'ccstatusline'"
 	if got != want {
 		t.Errorf("command = %q, want %q", got, want)
 	}
@@ -174,7 +174,7 @@ func TestInstallStatuslineWrap_InnerWithSingleQuote(t *testing.T) {
 	}
 	got := getStatusLineCommand(t, path)
 	// POSIX single-quote escape: ' -> '\''
-	want := "/opt/bin/pdx statusline-proxy --inner 'it'\\''s'"
+	want := "'/opt/bin/pdx' statusline-proxy --inner 'it'\\''s'"
 	if got != want {
 		t.Errorf("command = %q, want %q", got, want)
 	}
@@ -279,5 +279,34 @@ func TestWriteSettings_NoTmpLeftAfterRenameFailure(t *testing.T) {
 	entries, _ := filepath.Glob(base + "*.tmp")
 	if len(entries) != 0 {
 		t.Errorf("tmp leak: %v", entries)
+	}
+}
+
+func TestInstallStatuslinePdx_PdxPathWithSpaces(t *testing.T) {
+	path := writeSettings(t, `{}`)
+	spaced := "/Applications/Claude Code.app/Contents/Resources/pdx"
+	if err := installStatuslinePdx(path, spaced); err != nil {
+		t.Fatal(err)
+	}
+	// Round-trip: detection must classify as "pdx", not "unmanaged".
+	m, _ := detectStatuslineMode(path)
+	if m.Mode != "pdx" {
+		t.Errorf("spaced pdxPath install round-trip: mode = %q, want pdx (raw cmd = %q)", m.Mode, m.RawCommand)
+	}
+}
+
+func TestInstallStatuslineWrap_PdxPathWithSpaces(t *testing.T) {
+	path := writeSettings(t, `{}`)
+	spaced := "/Applications/Claude Code.app/Contents/Resources/pdx"
+	inner := "ccstatusline --format compact"
+	if err := installStatuslineWrap(path, spaced, inner); err != nil {
+		t.Fatal(err)
+	}
+	m, _ := detectStatuslineMode(path)
+	if m.Mode != "wrapped" {
+		t.Errorf("spaced pdxPath wrap round-trip: mode = %q, want wrapped (raw cmd = %q)", m.Mode, m.RawCommand)
+	}
+	if m.Inner != inner {
+		t.Errorf("inner round-trip: got %q, want %q", m.Inner, inner)
 	}
 }

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -49,6 +49,23 @@ type HookEventInfo struct {
 	Command   string `json:"command"`
 }
 
+// StatuslineInstaller manages CC's statusLine.command in ~/.claude/settings.json.
+type StatuslineInstaller interface {
+	CheckStatusline() (StatuslineState, error)
+	InstallStatuslinePdx(pdxPath string) error
+	InstallStatuslineWrap(pdxPath, inner string) error
+	RemoveStatusline() error
+}
+
+// StatuslineState describes the current state of an agent's statusLine config.
+type StatuslineState struct {
+	Mode         string `json:"mode"` // "none" | "pdx" | "wrapped" | "unmanaged"
+	Installed    bool   `json:"installed"`
+	Inner        string `json:"innerCommand,omitempty"`
+	RawCommand   string `json:"rawCommand,omitempty"`
+	SettingsPath string `json:"settingsPath"`
+}
+
 // HistoryProvider can retrieve conversation history for a session.
 type HistoryProvider interface {
 	GetHistory(cwd string, sessionID string) ([]map[string]any, error)

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/core"
 	"github.com/wake/purdex/internal/module/session"
 )
 
@@ -409,6 +410,19 @@ func (m *Module) handleStatuslineSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// On successful remove: wipe cached snapshots and broadcast a cleared
+	// event so the SPA can drop stale statusline state. Global clear is
+	// intentional for single-host daemon (simplest-possible approach); the
+	// "*" session code tells the frontend to apply this across all sessions.
+	if req.Action == "remove" {
+		snapshotMu.Lock()
+		statusSnapshots = make(map[string]statusSnapshot)
+		snapshotMu.Unlock()
+		if m.core != nil {
+			m.core.Events.Broadcast("*", "agent.status.cleared", `{"host_id":"*","agent_type":"cc"}`)
+		}
+	}
+
 	// Return updated status
 	m.handleStatuslineStatus(w, r)
 }
@@ -562,6 +576,29 @@ func (m *Module) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
 	if m.core != nil {
 		body, _ := json.Marshal(snap)
 		m.core.Events.Broadcast(code, "agent.status", string(body))
+	}
+}
+
+// sendStatuslineSnapshot pushes the cached statusline snapshots to a new
+// WebSocket subscriber. Mirrors the hook sendSnapshot pattern — builds a
+// core.HostEvent for each cached entry and calls sub.Send directly.
+func (m *Module) sendStatuslineSnapshot(sub *core.EventSubscriber) {
+	if m.core == nil {
+		return
+	}
+	snapshotMu.RLock()
+	defer snapshotMu.RUnlock()
+	for code, snap := range statusSnapshots {
+		body, err := json.Marshal(snap)
+		if err != nil {
+			continue
+		}
+		event := core.HostEvent{Type: "agent.status", Session: code, Value: string(body)}
+		data, err := json.Marshal(event)
+		if err != nil {
+			continue
+		}
+		sub.Send(data)
 	}
 }
 

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -297,6 +297,35 @@ func (m *Module) handleHookSetup(w http.ResponseWriter, r *http.Request) {
 	m.handleHookStatus(w, r)
 }
 
+// handleStatuslineStatus handles GET /api/agent/{agent}/statusline/status.
+// Currently only "cc" is supported; other agent types return 404.
+func (m *Module) handleStatuslineStatus(w http.ResponseWriter, r *http.Request) {
+	agentType := r.PathValue("agent")
+	if agentType != "cc" {
+		http.Error(w, `{"error":"unsupported agent"}`, http.StatusNotFound)
+		return
+	}
+	provider, ok := m.registry.Get(agentType)
+	if !ok {
+		http.Error(w, `{"error":"unknown agent"}`, http.StatusNotFound)
+		return
+	}
+	installer, ok := provider.(agentpkg.StatuslineInstaller)
+	if !ok {
+		http.Error(w, `{"error":"agent does not support statusline"}`, http.StatusNotFound)
+		return
+	}
+	state, err := installer.CheckStatusline()
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": err.Error()})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(state)
+}
+
 // handleHistory handles GET /api/sessions/{code}/history.
 func (m *Module) handleHistory(w http.ResponseWriter, r *http.Request) {
 	code := r.PathValue("code")

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -413,13 +413,14 @@ func (m *Module) handleStatuslineSetup(w http.ResponseWriter, r *http.Request) {
 	// On successful remove: wipe cached snapshots and broadcast a cleared
 	// event so the SPA can drop stale statusline state. Global clear is
 	// intentional for single-host daemon (simplest-possible approach); the
-	// "*" session code tells the frontend to apply this across all sessions.
+	// empty session code is the existing codebase convention for
+	// cross-session events (see watcher.go sessions/tmux broadcasts).
 	if req.Action == "remove" {
 		snapshotMu.Lock()
 		statusSnapshots = make(map[string]statusSnapshot)
 		snapshotMu.Unlock()
 		if m.core != nil {
-			m.core.Events.Broadcast("*", "agent.status.cleared", `{"host_id":"*","agent_type":"cc"}`)
+			m.core.Events.Broadcast("", "agent.status.cleared", `{"agent_type":"cc"}`)
 		}
 	}
 

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -589,14 +589,15 @@ func (m *Module) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // sendStatuslineSnapshot pushes the cached statusline snapshots to a new
-// WebSocket subscriber. Mirrors the hook sendSnapshot pattern — builds a
-// core.HostEvent for each cached entry and calls sub.Send directly.
+// WebSocket subscriber. Marshals under RLock, then releases the lock
+// before calling sub.Send — a slow subscriber (full channel) would
+// otherwise block every concurrent agent.status writer through snapshotMu.
 func (m *Module) sendStatuslineSnapshot(sub *core.EventSubscriber) {
 	if m.core == nil {
 		return
 	}
 	m.snapshotMu.RLock()
-	defer m.snapshotMu.RUnlock()
+	pending := make([][]byte, 0, len(m.statusSnapshots))
 	for code, snap := range m.statusSnapshots {
 		body, err := json.Marshal(snap)
 		if err != nil {
@@ -607,6 +608,10 @@ func (m *Module) sendStatuslineSnapshot(sub *core.EventSubscriber) {
 		if err != nil {
 			continue
 		}
+		pending = append(pending, data)
+	}
+	m.snapshotMu.RUnlock()
+	for _, data := range pending {
 		sub.Send(data)
 	}
 }

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -372,10 +372,16 @@ func (m *Module) handleStatuslineSetup(w http.ResponseWriter, r *http.Request) {
 	}
 	pdxPath, _ = filepath.EvalSymlinks(pdxPath)
 
+	// Acquire mutex only for the mutation phase. The status reply at the end
+	// is a read-only CheckStatusline() call plus HTTP write; keeping it
+	// outside the lock means install/remove don't block subsequent status
+	// polls, and avoids holding the mutex across HTTP response writes.
 	statuslineMutex.Lock()
-	defer statuslineMutex.Unlock()
-
-	var opErr error
+	var (
+		opErr       error
+		badRequest  string
+		conflictErr error
+	)
 	switch req.Action {
 	case "install":
 		switch req.Mode {
@@ -383,48 +389,54 @@ func (m *Module) handleStatuslineSetup(w http.ResponseWriter, r *http.Request) {
 			opErr = installer.InstallStatuslinePdx(pdxPath)
 		case "wrap":
 			if req.Inner == "" {
-				http.Error(w, `{"error":"wrap requires inner"}`, http.StatusBadRequest)
-				return
+				badRequest = `{"error":"wrap requires inner"}`
+			} else {
+				opErr = installer.InstallStatuslineWrap(pdxPath, req.Inner)
 			}
-			opErr = installer.InstallStatuslineWrap(pdxPath, req.Inner)
 		default:
-			http.Error(w, `{"error":"mode must be pdx or wrap"}`, http.StatusBadRequest)
-			return
+			badRequest = `{"error":"mode must be pdx or wrap"}`
 		}
 	case "remove":
 		opErr = installer.RemoveStatusline()
 		if opErr != nil && strings.Contains(opErr.Error(), "refusing to remove unmanaged") {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusConflict)
-			_ = json.NewEncoder(w).Encode(map[string]any{"error": opErr.Error()})
-			return
+			conflictErr = opErr
+			opErr = nil
+		} else if opErr == nil {
+			// On successful remove: wipe cached snapshots and broadcast a
+			// cleared event so the SPA can drop stale statusline state.
+			// Global clear is intentional for single-host daemon (simplest-
+			// possible approach); the empty session code is the existing
+			// codebase convention for cross-session events (see watcher.go
+			// sessions/tmux broadcasts).
+			snapshotMu.Lock()
+			statusSnapshots = make(map[string]statusSnapshot)
+			snapshotMu.Unlock()
+			if m.core != nil {
+				m.core.Events.Broadcast("", "agent.status.cleared", `{"agent_type":"cc"}`)
+			}
 		}
 	default:
-		http.Error(w, `{"error":"action must be install or remove"}`, http.StatusBadRequest)
-		return
+		badRequest = `{"error":"action must be install or remove"}`
 	}
-	if opErr != nil {
+	statuslineMutex.Unlock()
+
+	switch {
+	case badRequest != "":
+		http.Error(w, badRequest, http.StatusBadRequest)
+		return
+	case conflictErr != nil:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": conflictErr.Error()})
+		return
+	case opErr != nil:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]any{"error": opErr.Error()})
 		return
 	}
 
-	// On successful remove: wipe cached snapshots and broadcast a cleared
-	// event so the SPA can drop stale statusline state. Global clear is
-	// intentional for single-host daemon (simplest-possible approach); the
-	// empty session code is the existing codebase convention for
-	// cross-session events (see watcher.go sessions/tmux broadcasts).
-	if req.Action == "remove" {
-		snapshotMu.Lock()
-		statusSnapshots = make(map[string]statusSnapshot)
-		snapshotMu.Unlock()
-		if m.core != nil {
-			m.core.Events.Broadcast("", "agent.status.cleared", `{"agent_type":"cc"}`)
-		}
-	}
-
-	// Return updated status
+	// Return updated status (mutex released; CheckStatusline is a pure read).
 	m.handleStatuslineStatus(w, r)
 }
 

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -408,9 +408,9 @@ func (m *Module) handleStatuslineSetup(w http.ResponseWriter, r *http.Request) {
 			// possible approach); the empty session code is the existing
 			// codebase convention for cross-session events (see watcher.go
 			// sessions/tmux broadcasts).
-			snapshotMu.Lock()
-			statusSnapshots = make(map[string]statusSnapshot)
-			snapshotMu.Unlock()
+			m.snapshotMu.Lock()
+			m.statusSnapshots = make(map[string]statusSnapshot)
+			m.snapshotMu.Unlock()
 			if m.core != nil {
 				m.core.Events.Broadcast("", "agent.status.cleared", `{"agent_type":"cc"}`)
 			}
@@ -543,15 +543,11 @@ func (m *Module) handleCheckAlive(w http.ResponseWriter, r *http.Request) {
 
 // statusSnapshot is the in-memory shape cached per sessionCode and broadcast over WS.
 // It is intentionally display-only and not persisted (high-frequency, agent-owned).
+// Lives as a Module field (m.statusSnapshots) guarded by m.snapshotMu.
 type statusSnapshot struct {
 	AgentType string          `json:"agent_type"`
 	Status    json.RawMessage `json:"status"`
 }
-
-var (
-	snapshotMu      sync.RWMutex
-	statusSnapshots = make(map[string]statusSnapshot) // key: sessionCode
-)
 
 // handleAgentStatus handles POST /api/agent/status.
 // Receives statusline payloads from `pdx statusline-proxy` and broadcasts
@@ -582,9 +578,9 @@ func (m *Module) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	snap := statusSnapshot{AgentType: payload.AgentType, Status: payload.RawStatus}
-	snapshotMu.Lock()
-	statusSnapshots[code] = snap
-	snapshotMu.Unlock()
+	m.snapshotMu.Lock()
+	m.statusSnapshots[code] = snap
+	m.snapshotMu.Unlock()
 
 	if m.core != nil {
 		body, _ := json.Marshal(snap)
@@ -599,9 +595,9 @@ func (m *Module) sendStatuslineSnapshot(sub *core.EventSubscriber) {
 	if m.core == nil {
 		return
 	}
-	snapshotMu.RLock()
-	defer snapshotMu.RUnlock()
-	for code, snap := range statusSnapshots {
+	m.snapshotMu.RLock()
+	defer m.snapshotMu.RUnlock()
+	for code, snap := range m.statusSnapshots {
 		body, err := json.Marshal(snap)
 		if err != nil {
 			continue

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -514,6 +514,57 @@ func (m *Module) handleCheckAlive(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{"alive": alive})
 }
 
+// statusSnapshot is the in-memory shape cached per sessionCode and broadcast over WS.
+// It is intentionally display-only and not persisted (high-frequency, agent-owned).
+type statusSnapshot struct {
+	AgentType string          `json:"agent_type"`
+	Status    json.RawMessage `json:"status"`
+}
+
+var (
+	snapshotMu      sync.RWMutex
+	statusSnapshots = make(map[string]statusSnapshot) // key: sessionCode
+)
+
+// handleAgentStatus handles POST /api/agent/status.
+// Receives statusline payloads from `pdx statusline-proxy` and broadcasts
+// agent.status WS events to subscribers.
+func (m *Module) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
+	var payload struct {
+		TmuxSession string          `json:"tmux_session"`
+		AgentType   string          `json:"agent_type"`
+		RawStatus   json.RawMessage `json:"raw_status"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		return
+	}
+	if payload.AgentType != "cc" {
+		http.Error(w, `{"error":"unsupported agent_type"}`, http.StatusBadRequest)
+		return
+	}
+
+	code := m.resolveSessionCode(payload.TmuxSession)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{}`))
+
+	if code == "" {
+		return
+	}
+
+	snap := statusSnapshot{AgentType: payload.AgentType, Status: payload.RawStatus}
+	snapshotMu.Lock()
+	statusSnapshots[code] = snap
+	snapshotMu.Unlock()
+
+	if m.core != nil {
+		body, _ := json.Marshal(snap)
+		m.core.Events.Broadcast(code, "agent.status", string(body))
+	}
+}
+
 // handleDetect handles GET /api/agents/detect.
 // Checks if agent CLIs (claude, codex) are available on the host.
 func (m *Module) handleDetect(w http.ResponseWriter, r *http.Request) {

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -9,11 +9,39 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/module/session"
 )
+
+// statuslineMutex serializes concurrent /statusline/setup requests.
+// CC settings.json is a shared resource; atomic rename doesn't protect
+// read-modify-write ordering across simultaneous install/remove calls.
+var statuslineMutex sync.Mutex
+
+// resolveStatuslineInstaller returns the StatuslineInstaller for the agent
+// named by the request path variable "agent", or writes a 404 JSON error and
+// returns (nil, false). Used by both /statusline/status and /statusline/setup.
+func (m *Module) resolveStatuslineInstaller(w http.ResponseWriter, r *http.Request) (agentpkg.StatuslineInstaller, bool) {
+	agentType := r.PathValue("agent")
+	if agentType != "cc" {
+		http.Error(w, `{"error":"unsupported agent"}`, http.StatusNotFound)
+		return nil, false
+	}
+	provider, ok := m.registry.Get(agentType)
+	if !ok {
+		http.Error(w, `{"error":"unknown agent"}`, http.StatusNotFound)
+		return nil, false
+	}
+	installer, ok := provider.(agentpkg.StatuslineInstaller)
+	if !ok {
+		http.Error(w, `{"error":"agent does not support statusline"}`, http.StatusNotFound)
+		return nil, false
+	}
+	return installer, true
+}
 
 // EventRequest is the JSON body expected by POST /api/agent/event.
 type EventRequest struct {
@@ -300,19 +328,8 @@ func (m *Module) handleHookSetup(w http.ResponseWriter, r *http.Request) {
 // handleStatuslineStatus handles GET /api/agent/{agent}/statusline/status.
 // Currently only "cc" is supported; other agent types return 404.
 func (m *Module) handleStatuslineStatus(w http.ResponseWriter, r *http.Request) {
-	agentType := r.PathValue("agent")
-	if agentType != "cc" {
-		http.Error(w, `{"error":"unsupported agent"}`, http.StatusNotFound)
-		return
-	}
-	provider, ok := m.registry.Get(agentType)
+	installer, ok := m.resolveStatuslineInstaller(w, r)
 	if !ok {
-		http.Error(w, `{"error":"unknown agent"}`, http.StatusNotFound)
-		return
-	}
-	installer, ok := provider.(agentpkg.StatuslineInstaller)
-	if !ok {
-		http.Error(w, `{"error":"agent does not support statusline"}`, http.StatusNotFound)
 		return
 	}
 	state, err := installer.CheckStatusline()
@@ -324,6 +341,76 @@ func (m *Module) handleStatuslineStatus(w http.ResponseWriter, r *http.Request) 
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(state)
+}
+
+// handleStatuslineSetup handles POST /api/agent/{agent}/statusline/setup.
+// Action "install" with mode "pdx" installs the pdx-native statusLine;
+// mode "wrap" installs pdx as a wrapper around the given inner command.
+// Action "remove" removes a pdx-managed statusLine (unmanaged entries are
+// refused with 409 Conflict).
+func (m *Module) handleStatuslineSetup(w http.ResponseWriter, r *http.Request) {
+	installer, ok := m.resolveStatuslineInstaller(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Action string `json:"action"`
+		Mode   string `json:"mode"`
+		Inner  string `json:"inner"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		return
+	}
+
+	pdxPath, err := os.Executable()
+	if err != nil {
+		http.Error(w, `{"error":"cannot find pdx binary"}`, http.StatusInternalServerError)
+		return
+	}
+	pdxPath, _ = filepath.EvalSymlinks(pdxPath)
+
+	statuslineMutex.Lock()
+	defer statuslineMutex.Unlock()
+
+	var opErr error
+	switch req.Action {
+	case "install":
+		switch req.Mode {
+		case "pdx":
+			opErr = installer.InstallStatuslinePdx(pdxPath)
+		case "wrap":
+			if req.Inner == "" {
+				http.Error(w, `{"error":"wrap requires inner"}`, http.StatusBadRequest)
+				return
+			}
+			opErr = installer.InstallStatuslineWrap(pdxPath, req.Inner)
+		default:
+			http.Error(w, `{"error":"mode must be pdx or wrap"}`, http.StatusBadRequest)
+			return
+		}
+	case "remove":
+		opErr = installer.RemoveStatusline()
+		if opErr != nil && strings.Contains(opErr.Error(), "refusing to remove unmanaged") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": opErr.Error()})
+			return
+		}
+	default:
+		http.Error(w, `{"error":"action must be install or remove"}`, http.StatusBadRequest)
+		return
+	}
+	if opErr != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": opErr.Error()})
+		return
+	}
+
+	// Return updated status
+	m.handleStatuslineStatus(w, r)
 }
 
 // handleHistory handles GET /api/sessions/{code}/history.

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -724,3 +724,92 @@ func TestHandleStatuslineSetup_BadAction(t *testing.T) {
 		t.Errorf("status %d, want 400", w.Code)
 	}
 }
+
+// --- Task 11: POST /api/agent/status ---
+
+func TestHandleAgentStatus_BroadcastsOnSessionMatch(t *testing.T) {
+	m := newTestModule(t)
+	fake := tmux.NewFakeExecutor()
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Name: "sess1", Code: "code-1"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	body := `{"tmux_session":"sess1","agent_type":"cc","raw_status":{"model":{"display_name":"Sonnet"}}}`
+	req := httptest.NewRequest("POST", "/api/agent/status", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleAgentStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+	// Drain the broadcast channel — expect exactly one agent.status event for code-1.
+	select {
+	case msg := <-sub.SendCh():
+		var env struct {
+			Type    string `json:"type"`
+			Session string `json:"session"`
+			Value   string `json:"value"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		if env.Type != "agent.status" {
+			t.Errorf("broadcast type = %q, want agent.status", env.Type)
+		}
+		if env.Session != "code-1" {
+			t.Errorf("broadcast session = %q, want code-1", env.Session)
+		}
+		// Value should be a JSON-encoded statusSnapshot with agent_type + status.
+		if !strings.Contains(env.Value, `"agent_type":"cc"`) {
+			t.Errorf("broadcast value missing agent_type: %s", env.Value)
+		}
+		if !strings.Contains(env.Value, `"display_name":"Sonnet"`) {
+			t.Errorf("broadcast value missing raw_status: %s", env.Value)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timed out waiting for broadcast")
+	}
+}
+
+func TestHandleAgentStatus_NoBroadcastOnUnknownSession(t *testing.T) {
+	m := newTestModule(t)
+	fake := tmux.NewFakeExecutor()
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	body := `{"tmux_session":"unknown","agent_type":"cc","raw_status":{}}`
+	req := httptest.NewRequest("POST", "/api/agent/status", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	m.handleAgentStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status %d, want 200", w.Code)
+	}
+	// No broadcast: channel should stay empty for a brief window.
+	select {
+	case msg := <-sub.SendCh():
+		t.Errorf("unexpected broadcast: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestHandleAgentStatus_BadAgentType(t *testing.T) {
+	m := newTestModule(t)
+	body := `{"tmux_session":"x","agent_type":"codex","raw_status":{}}`
+	req := httptest.NewRequest("POST", "/api/agent/status", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	m.handleAgentStatus(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status %d, want 400", w.Code)
+	}
+}

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -606,5 +608,119 @@ func TestActivityWatch_HookEventSupersedes(t *testing.T) {
 	}
 	if status != agentpkg.StatusRunning {
 		t.Fatalf("expected running after UserPromptSubmit, got %s", status)
+	}
+}
+
+// --- Task 10: POST /api/agent/{agent}/statusline/setup ---
+
+func TestHandleStatuslineSetup_InstallPdx(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := newTestModule(t)
+	m.registry.Register(agentcc.NewProvider(nil, nil, nil, nil))
+
+	body := strings.NewReader(`{"action":"install","mode":"pdx"}`)
+	req := httptest.NewRequest("POST", "/api/agent/cc/statusline/setup", body)
+	req.SetPathValue("agent", "cc")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleStatuslineSetup(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+	data, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if !strings.Contains(string(data), "statusline-proxy") {
+		t.Errorf("settings.json did not install statusline-proxy: %s", data)
+	}
+}
+
+func TestHandleStatuslineSetup_InstallWrap(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := newTestModule(t)
+	m.registry.Register(agentcc.NewProvider(nil, nil, nil, nil))
+
+	body := strings.NewReader(`{"action":"install","mode":"wrap","inner":"ccstatusline --format compact"}`)
+	req := httptest.NewRequest("POST", "/api/agent/cc/statusline/setup", body)
+	req.SetPathValue("agent", "cc")
+	w := httptest.NewRecorder()
+
+	m.handleStatuslineSetup(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+	data, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if !strings.Contains(string(data), "--inner 'ccstatusline --format compact'") {
+		t.Errorf("wrap inner not properly embedded: %s", data)
+	}
+}
+
+func TestHandleStatuslineSetup_InstallWrapMissingInner(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := newTestModule(t)
+	m.registry.Register(agentcc.NewProvider(nil, nil, nil, nil))
+
+	body := strings.NewReader(`{"action":"install","mode":"wrap"}`)
+	req := httptest.NewRequest("POST", "/api/agent/cc/statusline/setup", body)
+	req.SetPathValue("agent", "cc")
+	w := httptest.NewRecorder()
+
+	m.handleStatuslineSetup(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status %d, want 400", w.Code)
+	}
+}
+
+func TestHandleStatuslineSetup_RemoveUnmanagedRefused(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Pre-populate with unmanaged statusLine
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"),
+		[]byte(`{"statusLine":{"type":"command","command":"ccstatusline"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newTestModule(t)
+	m.registry.Register(agentcc.NewProvider(nil, nil, nil, nil))
+
+	body := strings.NewReader(`{"action":"remove"}`)
+	req := httptest.NewRequest("POST", "/api/agent/cc/statusline/setup", body)
+	req.SetPathValue("agent", "cc")
+	w := httptest.NewRecorder()
+
+	m.handleStatuslineSetup(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status %d, want 409", w.Code)
+	}
+}
+
+func TestHandleStatuslineSetup_BadAction(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := newTestModule(t)
+	m.registry.Register(agentcc.NewProvider(nil, nil, nil, nil))
+
+	body := strings.NewReader(`{"action":"uninstall"}`)
+	req := httptest.NewRequest("POST", "/api/agent/cc/statusline/setup", body)
+	req.SetPathValue("agent", "cc")
+	w := httptest.NewRecorder()
+
+	m.handleStatuslineSetup(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status %d, want 400", w.Code)
 	}
 }

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -503,6 +503,61 @@ func TestActivityWatch_YellowLightRecovery(t *testing.T) {
 	}
 }
 
+// --- Task 9: GET /api/agent/{agent}/statusline/status ---
+
+func TestHandleStatuslineStatus_UnknownAgent(t *testing.T) {
+	m := newTestModule(t)
+	// No provider registered — expect 404 "unknown agent"
+	req := httptest.NewRequest("GET", "/api/agent/cc/statusline/status", nil)
+	req.SetPathValue("agent", "cc")
+	w := httptest.NewRecorder()
+	m.handleStatuslineStatus(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleStatuslineStatus_UnsupportedAgent(t *testing.T) {
+	m := newTestModule(t)
+	// Path value other than "cc" should be rejected before registry lookup.
+	req := httptest.NewRequest("GET", "/api/agent/codex/statusline/status", nil)
+	req.SetPathValue("agent", "codex")
+	w := httptest.NewRecorder()
+	m.handleStatuslineStatus(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleStatuslineStatus_CC_Registered(t *testing.T) {
+	m := newTestModule(t)
+	// Real CC provider with nil deps — CheckStatusline only uses ccSettingsPath
+	// + detectStatuslineMode, neither of which need prober/tmux/cfg.
+	ccProvider := agentcc.NewProvider(nil, nil, nil, nil)
+	m.registry.Register(ccProvider)
+
+	req := httptest.NewRequest("GET", "/api/agent/cc/statusline/status", nil)
+	req.SetPathValue("agent", "cc")
+	w := httptest.NewRecorder()
+	m.handleStatuslineStatus(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", w.Code, w.Body.String())
+	}
+	var body agentpkg.StatuslineState
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.SettingsPath == "" {
+		t.Errorf("expected settingsPath to be populated")
+	}
+	// Mode depends on host env (CC may or may not be installed). Just assert a valid value.
+	switch body.Mode {
+	case "none", "pdx", "wrapped", "unmanaged":
+	default:
+		t.Errorf("unexpected mode: %q", body.Mode)
+	}
+}
+
 func TestActivityWatch_HookEventSupersedes(t *testing.T) {
 	m := newTestModule(t)
 

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -817,20 +817,13 @@ func TestHandleAgentStatus_BadAgentType(t *testing.T) {
 // --- Task 12: statusline snapshot replay + cleared broadcast ---
 
 func TestSendStatuslineSnapshot_ReplaysToSubscriber(t *testing.T) {
-	// Reset package-level state (other tests may have populated it).
-	snapshotMu.Lock()
-	statusSnapshots = map[string]statusSnapshot{
+	m := newTestModule(t)
+	m.snapshotMu.Lock()
+	m.statusSnapshots = map[string]statusSnapshot{
 		"code-a": {AgentType: "cc", Status: json.RawMessage(`{"model":{"display_name":"A"}}`)},
 		"code-b": {AgentType: "cc", Status: json.RawMessage(`{"model":{"display_name":"B"}}`)},
 	}
-	snapshotMu.Unlock()
-	t.Cleanup(func() {
-		snapshotMu.Lock()
-		statusSnapshots = make(map[string]statusSnapshot)
-		snapshotMu.Unlock()
-	})
-
-	m := newTestModule(t)
+	m.snapshotMu.Unlock()
 	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: tmux.NewFakeExecutor()}
 	sub := m.core.Events.AddTestSubscriber()
 	defer m.core.Events.RemoveTestSubscriber(sub)
@@ -866,15 +859,6 @@ func TestSendStatuslineSnapshot_ReplaysToSubscriber(t *testing.T) {
 func TestHandleStatuslineSetup_RemoveBroadcastsCleared(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	// Seed a cached snapshot so we can assert it gets cleared.
-	snapshotMu.Lock()
-	statusSnapshots = map[string]statusSnapshot{"code-x": {AgentType: "cc", Status: json.RawMessage(`{}`)}}
-	snapshotMu.Unlock()
-	t.Cleanup(func() {
-		snapshotMu.Lock()
-		statusSnapshots = make(map[string]statusSnapshot)
-		snapshotMu.Unlock()
-	})
 
 	// Seed settings.json with a pdx-mode statusline (so remove succeeds, not refused).
 	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0755); err != nil {
@@ -888,6 +872,10 @@ func TestHandleStatuslineSetup_RemoveBroadcastsCleared(t *testing.T) {
 	m := newTestModule(t)
 	m.registry.Register(agentcc.NewProvider(nil, nil, nil, nil))
 	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: tmux.NewFakeExecutor()}
+	// Seed a cached snapshot so we can assert it gets cleared.
+	m.snapshotMu.Lock()
+	m.statusSnapshots = map[string]statusSnapshot{"code-x": {AgentType: "cc", Status: json.RawMessage(`{}`)}}
+	m.snapshotMu.Unlock()
 	sub := m.core.Events.AddTestSubscriber()
 	defer m.core.Events.RemoveTestSubscriber(sub)
 
@@ -903,9 +891,9 @@ func TestHandleStatuslineSetup_RemoveBroadcastsCleared(t *testing.T) {
 	}
 
 	// Check: statusSnapshots cleared.
-	snapshotMu.RLock()
-	n := len(statusSnapshots)
-	snapshotMu.RUnlock()
+	m.snapshotMu.RLock()
+	n := len(m.statusSnapshots)
+	m.snapshotMu.RUnlock()
 	if n != 0 {
 		t.Errorf("snapshot map size = %d, want 0", n)
 	}

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -813,3 +813,120 @@ func TestHandleAgentStatus_BadAgentType(t *testing.T) {
 		t.Errorf("status %d, want 400", w.Code)
 	}
 }
+
+// --- Task 12: statusline snapshot replay + cleared broadcast ---
+
+func TestSendStatuslineSnapshot_ReplaysToSubscriber(t *testing.T) {
+	// Reset package-level state (other tests may have populated it).
+	snapshotMu.Lock()
+	statusSnapshots = map[string]statusSnapshot{
+		"code-a": {AgentType: "cc", Status: json.RawMessage(`{"model":{"display_name":"A"}}`)},
+		"code-b": {AgentType: "cc", Status: json.RawMessage(`{"model":{"display_name":"B"}}`)},
+	}
+	snapshotMu.Unlock()
+	t.Cleanup(func() {
+		snapshotMu.Lock()
+		statusSnapshots = make(map[string]statusSnapshot)
+		snapshotMu.Unlock()
+	})
+
+	m := newTestModule(t)
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: tmux.NewFakeExecutor()}
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	m.sendStatuslineSnapshot(sub)
+
+	// Read both expected replays (order not guaranteed — maps).
+	seen := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-sub.SendCh():
+			var env struct {
+				Type    string `json:"type"`
+				Session string `json:"session"`
+				Value   string `json:"value"`
+			}
+			if err := json.Unmarshal(msg, &env); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if env.Type != "agent.status" {
+				t.Errorf("type = %q, want agent.status", env.Type)
+			}
+			seen[env.Session] = true
+		case <-time.After(100 * time.Millisecond):
+			t.Fatalf("timed out after %d events", i)
+		}
+	}
+	if !seen["code-a"] || !seen["code-b"] {
+		t.Errorf("missing replay; seen=%v", seen)
+	}
+}
+
+func TestHandleStatuslineSetup_RemoveBroadcastsCleared(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Seed a cached snapshot so we can assert it gets cleared.
+	snapshotMu.Lock()
+	statusSnapshots = map[string]statusSnapshot{"code-x": {AgentType: "cc", Status: json.RawMessage(`{}`)}}
+	snapshotMu.Unlock()
+	t.Cleanup(func() {
+		snapshotMu.Lock()
+		statusSnapshots = make(map[string]statusSnapshot)
+		snapshotMu.Unlock()
+	})
+
+	// Seed settings.json with a pdx-mode statusline (so remove succeeds, not refused).
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"),
+		[]byte(`{"statusLine":{"type":"command","command":"/opt/bin/pdx statusline-proxy"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newTestModule(t)
+	m.registry.Register(agentcc.NewProvider(nil, nil, nil, nil))
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: tmux.NewFakeExecutor()}
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	body := strings.NewReader(`{"action":"remove"}`)
+	req := httptest.NewRequest("POST", "/api/agent/cc/statusline/setup", body)
+	req.SetPathValue("agent", "cc")
+	w := httptest.NewRecorder()
+
+	m.handleStatuslineSetup(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, body: %s", w.Code, w.Body.String())
+	}
+
+	// Check: statusSnapshots cleared.
+	snapshotMu.RLock()
+	n := len(statusSnapshots)
+	snapshotMu.RUnlock()
+	if n != 0 {
+		t.Errorf("snapshot map size = %d, want 0", n)
+	}
+
+	// Check: agent.status.cleared was broadcast. Drain up to 1 event.
+	foundCleared := false
+	for i := 0; i < 3; i++ {
+		select {
+		case msg := <-sub.SendCh():
+			var env struct {
+				Type string `json:"type"`
+			}
+			_ = json.Unmarshal(msg, &env)
+			if env.Type == "agent.status.cleared" {
+				foundCleared = true
+			}
+		case <-time.After(50 * time.Millisecond):
+			i = 3 // break
+		}
+	}
+	if !foundCleared {
+		t.Error("agent.status.cleared broadcast not seen")
+	}
+}

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -353,6 +353,10 @@ func (m *Module) checkAliveAll(sub *core.EventSubscriber) {
 			delete(m.activeWatchers, ev.TmuxSession)
 			m.mu.Unlock()
 
+			snapshotMu.Lock()
+			delete(statusSnapshots, code)
+			snapshotMu.Unlock()
+
 			m.prober.StopWatch(tmuxTarget)
 			_ = m.events.Delete(ev.TmuxSession)
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -115,6 +115,7 @@ func (m *Module) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/hooks/{agent}/setup", m.handleHookSetup)
 	mux.HandleFunc("GET /api/agent/{agent}/statusline/status", m.handleStatuslineStatus)
 	mux.HandleFunc("POST /api/agent/{agent}/statusline/setup", m.handleStatuslineSetup)
+	mux.HandleFunc("POST /api/agent/status", m.handleAgentStatus)
 	mux.HandleFunc("POST /api/agent/check-alive/{session}", m.handleCheckAlive)
 	mux.HandleFunc("GET /api/agents/detect", m.handleDetect)
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -114,6 +114,7 @@ func (m *Module) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/hooks/{agent}/status", m.handleHookStatus)
 	mux.HandleFunc("POST /api/hooks/{agent}/setup", m.handleHookSetup)
 	mux.HandleFunc("GET /api/agent/{agent}/statusline/status", m.handleStatuslineStatus)
+	mux.HandleFunc("POST /api/agent/{agent}/statusline/setup", m.handleStatuslineSetup)
 	mux.HandleFunc("POST /api/agent/check-alive/{session}", m.handleCheckAlive)
 	mux.HandleFunc("GET /api/agents/detect", m.handleDetect)
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -113,6 +113,7 @@ func (m *Module) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/agent/event", m.handleEvent)
 	mux.HandleFunc("GET /api/hooks/{agent}/status", m.handleHookStatus)
 	mux.HandleFunc("POST /api/hooks/{agent}/setup", m.handleHookSetup)
+	mux.HandleFunc("GET /api/agent/{agent}/statusline/status", m.handleStatuslineStatus)
 	mux.HandleFunc("POST /api/agent/check-alive/{session}", m.handleCheckAlive)
 	mux.HandleFunc("GET /api/agents/detect", m.handleDetect)
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -34,16 +34,23 @@ type Module struct {
 	currentStatus  map[string]agentpkg.Status
 	subagents      map[string][]string
 	activeWatchers map[string]string // tmuxSession → agentType
+
+	// statusSnapshots caches the latest statusline payload per sessionCode.
+	// Display-only, not persisted; guarded by snapshotMu (separate from mu
+	// because hot-path agent.status POSTs shouldn't contend with hook writes).
+	snapshotMu      sync.RWMutex
+	statusSnapshots map[string]statusSnapshot
 }
 
 // New creates a new agent Module backed by the given AgentEventStore.
 func New(events *store.AgentEventStore) *Module {
 	return &Module{
-		events:         events,
-		registry:       agentpkg.NewRegistry(),
-		currentStatus:  make(map[string]agentpkg.Status),
-		subagents:      make(map[string][]string),
-		activeWatchers: make(map[string]string),
+		events:          events,
+		registry:        agentpkg.NewRegistry(),
+		currentStatus:   make(map[string]agentpkg.Status),
+		subagents:       make(map[string][]string),
+		activeWatchers:  make(map[string]string),
+		statusSnapshots: make(map[string]statusSnapshot),
 	}
 }
 
@@ -353,9 +360,9 @@ func (m *Module) checkAliveAll(sub *core.EventSubscriber) {
 			delete(m.activeWatchers, ev.TmuxSession)
 			m.mu.Unlock()
 
-			snapshotMu.Lock()
-			delete(statusSnapshots, code)
-			snapshotMu.Unlock()
+			m.snapshotMu.Lock()
+			delete(m.statusSnapshots, code)
+			m.snapshotMu.Unlock()
 
 			m.prober.StopWatch(tmuxTarget)
 			_ = m.events.Delete(ev.TmuxSession)

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -137,6 +137,7 @@ func (m *Module) Start(_ context.Context) error {
 
 	m.core.Events.OnSubscribe(func(sub *core.EventSubscriber) {
 		m.sendSnapshot(sub)
+		m.sendStatuslineSnapshot(sub)
 		go m.checkAliveAll(sub)
 	})
 


### PR DESCRIPTION
## Summary

PR-1a of the CC statusLine integration (spec: `docs/superpowers/specs/2026-04-18-statusline-and-daemon-rebuild-design.md`). This first PR lands the **Go backend only** — proxy subcommand + daemon endpoints + WS broadcast plumbing.

Three-way split:
- **PR-1a (this PR):** Tasks 1–12 — Go backend
- **PR-1b (next):** Tasks 13–16 — SPA store + tab rendering (consumer side)
- **PR-1c (later):** Tasks 17–22 — Installer UI + E2E smoke

No user-visible behavior yet: SPA doesn't consume the new broadcasts until PR-1b.

## What's included

**`pdx statusline-proxy` subcommand** (`cmd/pdx/statusline_proxy.go`):
- Reads CC's statusLine JSON from stdin (5s timeout), prints default or inner-command output back to CC, synchronously POSTs payload to daemon. Fail-silent on daemon unreachable — CC's display never blocked.

**Agent interface** (`internal/agent/provider.go`, `internal/agent/cc/`):
- New \`StatuslineInstaller\` interface + \`StatuslineState\` type alongside existing \`HookInstaller\`. CC \`Provider\` implements it via \`internal/agent/cc/statusline.go\` (mode detection, install/remove, atomic write).

**Daemon endpoints** (`internal/module/agent/handler.go`):
- \`GET  /api/agent/{agent}/statusline/status\` — returns mode (none/pdx/wrapped/unmanaged) + paths
- \`POST /api/agent/{agent}/statusline/setup\` — install (pdx or wrap with inner) / remove, per-host mutex, 409 on unmanaged-remove
- \`POST /api/agent/status\` — receiver for statusline-proxy payloads; broadcasts \`agent.status\` WS event, caches snapshot in-memory for replay
- WS snapshot replay on subscribe + \`agent.status.cleared\` broadcast on remove; stale snapshots pruned on session death

## Test plan

- [x] \`go test ./internal/agent/cc/...\` — 22 tests including install/remove round-trip with tricky shell metachars
- [x] \`go test ./internal/module/agent/...\` — 42 tests including mutex + broadcast assertions via \`AddTestSubscriber\`
- [x] \`go test ./cmd/pdx/...\` — 13 tests covering stdin timeout / inner exec / POST timeout / 5xx silent-fail
- [x] \`go build ./... && go vet ./internal/agent/... ./internal/module/agent/... ./cmd/pdx/...\` clean
- [ ] Manual: not applicable for PR-1a (needs SPA in PR-1b). Pure backend plumbing verified via unit/integration tests.

## Notes for reviewer

- POSIX single-quote escape round-trip verified (\`it's\`, \`foo \"bar\" & baz 'qux'\`).
- Per-host mutex at handler layer (package-level); single-daemon-per-host deployment model.
- 4 plan-doc fix-ups during implementation: renderMinimal separator, JSON escape in Task 6 test, loadSettings rename (collision w/ hooks_test helper), agent.StatuslineInstaller placement.
- 1 follow-up fix commit addressing reviewer-flagged file-permission downgrade (0600→0644) in atomic write.