### PR TITLE
feat(spa): statusline PR-1b — SPA ccStatus store + tab rendering

### DIFF
--- a/spa/src/components/HoverTooltip.test.tsx
+++ b/spa/src/components/HoverTooltip.test.tsx
@@ -44,4 +44,13 @@ describe('HoverTooltip', () => {
     expect(el.className).toMatch(/\bgroup-hover:opacity-100\b/)
     expect(el.className).toMatch(/\btransition-opacity\b/)
   })
+
+  it('has role="tooltip" for screen readers', () => {
+    render(
+      <div className="relative group">
+        <HoverTooltip>a11y</HoverTooltip>
+      </div>
+    )
+    expect(screen.getByText('a11y').getAttribute('role')).toBe('tooltip')
+  })
 })

--- a/spa/src/components/HoverTooltip.test.tsx
+++ b/spa/src/components/HoverTooltip.test.tsx
@@ -32,4 +32,16 @@ describe('HoverTooltip', () => {
     const el = screen.getByText('r tip')
     expect(el.className).toContain('left-full')
   })
+
+  it('includes fade-on-hover classes (opacity-0 + group-hover:opacity-100 + transition-opacity)', () => {
+    render(
+      <div className="relative group">
+        <HoverTooltip>fade</HoverTooltip>
+      </div>
+    )
+    const el = screen.getByText('fade')
+    expect(el.className).toMatch(/\bopacity-0\b/)
+    expect(el.className).toMatch(/\bgroup-hover:opacity-100\b/)
+    expect(el.className).toMatch(/\btransition-opacity\b/)
+  })
 })

--- a/spa/src/components/HoverTooltip.test.tsx
+++ b/spa/src/components/HoverTooltip.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HoverTooltip } from './HoverTooltip'
+
+describe('HoverTooltip', () => {
+  it('renders the provided text', () => {
+    render(
+      <div className="relative group">
+        <span>trigger</span>
+        <HoverTooltip>Hello world</HoverTooltip>
+      </div>
+    )
+    expect(screen.getByText('Hello world')).toBeInTheDocument()
+  })
+
+  it('supports placement=top (absolute bottom-full)', () => {
+    render(
+      <div className="relative group">
+        <HoverTooltip placement="top">top tip</HoverTooltip>
+      </div>
+    )
+    const el = screen.getByText('top tip')
+    expect(el.className).toContain('bottom-full')
+  })
+
+  it('defaults to placement=right (absolute left-full)', () => {
+    render(
+      <div className="relative group">
+        <HoverTooltip>r tip</HoverTooltip>
+      </div>
+    )
+    const el = screen.getByText('r tip')
+    expect(el.className).toContain('left-full')
+  })
+})

--- a/spa/src/components/HoverTooltip.tsx
+++ b/spa/src/components/HoverTooltip.tsx
@@ -20,6 +20,7 @@ export function HoverTooltip({ children, placement = 'right', 'data-testid': tes
   const pos = PLACEMENTS[placement]
   return (
     <span
+      role="tooltip"
       data-testid={testId}
       className={`pointer-events-none absolute ${pos} whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50`}
     >

--- a/spa/src/components/HoverTooltip.tsx
+++ b/spa/src/components/HoverTooltip.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react'
+
+export type HoverTooltipPlacement = 'top' | 'right'
+
+interface Props {
+  children: ReactNode
+  placement?: HoverTooltipPlacement
+  'data-testid'?: string
+}
+
+const PLACEMENTS: Record<HoverTooltipPlacement, string> = {
+  right: 'left-full ml-2 top-1/2 -translate-y-1/2',
+  top: 'bottom-full mb-2 left-1/2 -translate-x-1/2',
+}
+
+// HoverTooltip is a CSS-only tooltip that fades in when its parent has the
+// `.group` class and the user hovers. Extracted from the ActivityBarNarrow
+// ws-tooltip pattern; parent MUST have `class="relative group"`.
+export function HoverTooltip({ children, placement = 'right', 'data-testid': testId }: Props) {
+  const pos = PLACEMENTS[placement]
+  return (
+    <span
+      data-testid={testId}
+      className={`pointer-events-none absolute ${pos} whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50`}
+    >
+      {children}
+    </span>
+  )
+}

--- a/spa/src/components/SortableTab.test.tsx
+++ b/spa/src/components/SortableTab.test.tsx
@@ -114,6 +114,55 @@ describe('SortableTab', () => {
     expect(onClose).toHaveBeenCalledWith('t1')
     expect(onSelect).not.toHaveBeenCalled()
   })
+
+  it('renders HoverTooltip with combined text on regular tab (not native title attr)', () => {
+    useSessionStore.setState({
+      sessions: { h1: [{ code: 'sc1', name: 'work' }] as never },
+      activeHostId: null,
+      activeCode: null,
+    })
+    useAgentStore.setState({
+      unread: {},
+      statuses: {},
+      subagents: {},
+      tabIndicatorStyle: 'badge',
+      showOscTitle: true,
+      agentTypes: { 'h1:sc1': 'cc' },
+      oscTitles: { 'h1:sc1': 'my-feature' },
+    } as never)
+    const { container } = render(<SortableTab {...defaultProps} />)
+    // The visible label span should NOT have a native title attribute anymore.
+    const tabRoot = container.querySelector('[data-tab-id="t1"]')!
+    const labelSpan = tabRoot.querySelector('span.overflow-hidden')!
+    expect(labelSpan.getAttribute('title')).toBeNull()
+    expect(labelSpan.textContent).toBe('my-feature - work')
+    // HoverTooltip renders as a sibling with role="tooltip".
+    const tooltip = screen.getByRole('tooltip')
+    expect(tooltip.textContent).toBe('my-feature - work')
+  })
+
+  it('renders HoverTooltip on pinned tab (not native title attr)', () => {
+    useSessionStore.setState({
+      sessions: { h1: [{ code: 'sc1', name: 'work' }] as never },
+      activeHostId: null,
+      activeCode: null,
+    })
+    useAgentStore.setState({
+      unread: {},
+      statuses: {},
+      subagents: {},
+      tabIndicatorStyle: 'badge',
+      showOscTitle: true,
+      agentTypes: { 'h1:sc1': 'cc' },
+      oscTitles: { 'h1:sc1': 'my-feature' },
+    } as never)
+    const pinnedTab = makeTestTab('t1', { pinned: true })
+    const { container } = render(<SortableTab {...defaultProps} tab={pinnedTab} pinned />)
+    const tabRoot = container.querySelector('[data-tab-id="t1"]')!
+    expect(tabRoot.getAttribute('title')).toBeNull()
+    const tooltip = screen.getByRole('tooltip')
+    expect(tooltip.textContent).toBe('my-feature - work')
+  })
 })
 
 describe('SortableTab renderTabIcon modes', () => {

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -4,6 +4,7 @@ import type { Tab } from '../types/tab'
 import { useI18nStore } from '../stores/useI18nStore'
 import { useTabDisplay } from '../hooks/useTabDisplay'
 import { TabIcon } from './TabIcon'
+import { HoverTooltip } from './HoverTooltip'
 import { shouldShowGlobalUnreadPip } from './tab-icon-helpers'
 
 interface Props {
@@ -36,7 +37,6 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
   const t = useI18nStore((s) => s.t)
   const {
     displayTitle: label,
-    tooltip,
     IconComponent,
     agentStatus,
     isUnread,
@@ -83,12 +83,11 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         onContextMenu={handleContextMenu}
-        className={`relative flex items-center justify-center w-9 rounded-[6px] cursor-pointer transition-colors duration-150 ease-out ${
+        className={`group relative flex items-center justify-center w-9 rounded-[6px] cursor-pointer transition-colors duration-150 ease-out ${
           isActive
             ? 'text-white bg-surface-active border border-accent-muted'
             : 'text-text-muted hover:text-text-primary bg-surface-secondary hover:bg-surface-hover border border-transparent'
         }`}
-        title={tooltip}
       >
         <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={isActive} iconSize={14} subagentCount={subagentCount} isUnread={isUnread} />
         {tab.locked && <Lock size={10} className="absolute bottom-0.5 right-0.5" />}
@@ -96,6 +95,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
           <span className="absolute -top-[4px] -right-[4px] w-2 h-2 rounded-full z-20"
             style={{ backgroundColor: '#ef4444' }} />
         )}
+        <HoverTooltip placement="top">{label}</HoverTooltip>
       </button>
     )
   }
@@ -130,7 +130,8 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
       }`}
     >
       <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={isActive} iconSize={14} subagentCount={subagentCount} isUnread={isUnread} />
-      <span className="overflow-hidden flex-1 min-w-0 text-left" title={tooltip}>{label}</span>
+      <span className="overflow-hidden flex-1 min-w-0 text-left">{label}</span>
+      <HoverTooltip placement="top">{label}</HoverTooltip>
       {isHostOffline && <WifiSlash size={12} className="text-red-400 flex-shrink-0" />}
       {tab.locked && <Lock size={10} className="ml-0.5 flex-shrink-0" />}
       {!isActive && isUnread && shouldShowGlobalUnreadPip(tabIndicatorStyle, agentStatus) && (

--- a/spa/src/components/TabBar.test.tsx
+++ b/spa/src/components/TabBar.test.tsx
@@ -45,22 +45,24 @@ const pinnedTabs: Tab[] = [
 describe('TabBar', () => {
   it('renders all tabs', () => {
     render(<TabBar tabs={mockTabs} activeTabId="t1" {...defaultHandlers} />)
-    // Session tabs show sessionCode as fallback label (no session store data)
-    expect(screen.getByText('dev001')).toBeTruthy()
-    expect(screen.getByText('cld001')).toBeTruthy()
-    expect(screen.getByText('Dashboard')).toBeTruthy()
+    // Session tabs show sessionCode as fallback label (no session store data).
+    // Each label appears twice per tab: visible span + HoverTooltip sibling.
+    expect(screen.getAllByText('dev001')).toHaveLength(2)
+    expect(screen.getAllByText('cld001')).toHaveLength(2)
+    expect(screen.getAllByText('Dashboard')).toHaveLength(2)
   })
 
   it('highlights active tab', () => {
     render(<TabBar tabs={mockTabs} activeTabId="t1" {...defaultHandlers} />)
-    const activeTab = screen.getByText('dev001').closest('[role="tab"]')!
+    // First match is the visible span; either is inside the same tab root.
+    const activeTab = screen.getAllByText('dev001')[0].closest('[role="tab"]')!
     expect(activeTab.className).toContain('text-white')
   })
 
   it('calls onSelectTab on click', () => {
     const onSelect = vi.fn()
     render(<TabBar tabs={mockTabs} activeTabId="t1" {...defaultHandlers} onSelectTab={onSelect} />)
-    fireEvent.click(screen.getByText('cld001'))
+    fireEvent.click(screen.getAllByText('cld001')[0])
     expect(onSelect).toHaveBeenCalledWith('t2')
   })
 
@@ -72,19 +74,23 @@ describe('TabBar', () => {
     expect(onClose).toHaveBeenCalledWith('t1')
   })
 
-  it('renders pinned tabs as icon-only with title', () => {
-    render(<TabBar tabs={pinnedTabs} activeTabId="t1" {...defaultHandlers} />)
-    // Pinned tab shows label as title attribute (sessionCode fallback)
-    const pinnedBtn = screen.getByTitle('aaa001')
-    expect(pinnedBtn).toBeInTheDocument()
-    // Pinned tab should not render label text in the button content
-    expect(pinnedBtn.textContent).not.toContain('aaa001')
+  it('renders pinned tabs as icon-only with HoverTooltip label', () => {
+    const { container } = render(<TabBar tabs={pinnedTabs} activeTabId="t1" {...defaultHandlers} />)
+    // Pinned tab no longer uses native title attr — label comes via HoverTooltip.
+    const pinnedRoot = container.querySelector('[data-tab-id="p1"]')!
+    const tooltip = pinnedRoot.querySelector('[role="tooltip"]')!
+    expect(tooltip).toBeInTheDocument()
+    expect(tooltip.textContent).toBe('aaa001')
+    // Pinned tab should not render the label as a visible (non-tooltip) text node
+    // inside the button — only the icon + the (visually hidden until hover) tooltip.
+    expect(pinnedRoot.querySelector('span.overflow-hidden')).toBeNull()
   })
 
   it('renders normal tabs with label', () => {
     render(<TabBar tabs={pinnedTabs} activeTabId="t1" {...defaultHandlers} />)
-    expect(screen.getByText('bbb001')).toBeInTheDocument()
-    expect(screen.getByText('ccc001')).toBeInTheDocument()
+    // Each label appears twice per tab: visible span + HoverTooltip sibling.
+    expect(screen.getAllByText('bbb001')).toHaveLength(2)
+    expect(screen.getAllByText('ccc001')).toHaveLength(2)
   })
 
   it('locked tab hides close button', () => {
@@ -100,9 +106,10 @@ describe('TabBar', () => {
       makeTab('t1', { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'xxx001', mode: 'terminal', cachedName: '', tmuxInstance: '' }, { locked: true }),
     ]
     render(<TabBar tabs={lockedTabs} activeTabId="t1" {...defaultHandlers} />)
-    expect(screen.getByText('xxx001')).toBeInTheDocument()
+    // Label appears twice per tab: visible span + HoverTooltip sibling.
+    expect(screen.getAllByText('xxx001')).toHaveLength(2)
     // Lock icon rendered — verify SVG with Lock's presence
-    const tabBtn = screen.getByText('xxx001').closest('[role="tab"]')!
+    const tabBtn = screen.getAllByText('xxx001')[0].closest('[role="tab"]')!
     const svgs = tabBtn.querySelectorAll('svg')
     // Should have at least 2 SVGs: tab icon + lock icon
     expect(svgs.length).toBeGreaterThanOrEqual(2)
@@ -111,7 +118,7 @@ describe('TabBar', () => {
   it('activates tab on Enter key', () => {
     const onSelect = vi.fn()
     render(<TabBar tabs={mockTabs} activeTabId="t1" {...defaultHandlers} onSelectTab={onSelect} />)
-    const tab = screen.getByText('cld001').closest('[role="tab"]')!
+    const tab = screen.getAllByText('cld001')[0].closest('[role="tab"]')!
     fireEvent.keyDown(tab, { key: 'Enter' })
     expect(onSelect).toHaveBeenCalledWith('t2')
   })

--- a/spa/src/features/workspace/components/ActivityBarNarrow.tsx
+++ b/spa/src/features/workspace/components/ActivityBarNarrow.tsx
@@ -8,6 +8,7 @@ import { WorkspaceIcon } from './WorkspaceIcon'
 import { useWorkspaceIndicators } from '../useWorkspaceIndicators'
 import type { ActiveStatus } from '../workspace-indicators'
 import type { ActivityBarProps } from './activity-bar-props'
+import { HoverTooltip } from '../../../components/HoverTooltip'
 
 const PILL_COLORS: Record<ActiveStatus, string> = {
   running: '#4ade80',
@@ -81,9 +82,7 @@ function SortableWorkspaceButton({ workspace: ws, isActive, onSelect, onContextM
           {unreadCount > 99 ? '99+' : unreadCount}
         </span>
       )}
-      <span data-testid="ws-tooltip" className="pointer-events-none absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50">
-        {tooltipText}
-      </span>
+      <HoverTooltip data-testid="ws-tooltip" placement="right">{tooltipText}</HoverTooltip>
     </div>
   )
 }

--- a/spa/src/features/workspace/components/ActivityBarWide.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.test.tsx
@@ -143,8 +143,9 @@ describe('ActivityBarWide Phase 2 — inline tabs', () => {
         onAddTabToWorkspace={() => {}}
       />,
     )
-    // getPaneLabel for browser returns hostname
-    expect(screen.getByText('example.test')).toBeInTheDocument()
+    // getPaneLabel for browser returns hostname.
+    // Label appears twice per row: visible title span + HoverTooltip.
+    expect(screen.getAllByText('example.test').length).toBeGreaterThan(0)
   })
 
   it('registers home-header and ws-header-<id> as droppable testids', () => {

--- a/spa/src/features/workspace/components/HomeRow.test.tsx
+++ b/spa/src/features/workspace/components/HomeRow.test.tsx
@@ -64,7 +64,8 @@ describe('HomeRow', () => {
   it('tabs shown when workspaceExpanded["home"]=true', () => {
     useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide', workspaceExpanded: { home: true } })
     renderRow({ standaloneTabIds: ['t1'], tabsById: { t1: mkTab('t1', 'alpha') } })
-    expect(screen.getByText('alpha.example.com')).toBeInTheDocument()
+    // Label appears twice per row: visible title span + HoverTooltip.
+    expect(screen.getAllByText('alpha.example.com').length).toBeGreaterThan(0)
   })
 
   it('clicking title on ACTIVE Home toggles expand (does not re-select)', () => {

--- a/spa/src/features/workspace/components/InlineTab.test.tsx
+++ b/spa/src/features/workspace/components/InlineTab.test.tsx
@@ -42,6 +42,8 @@ beforeEach(() => {
     unread: {},
     subagents: {},
     agentTypes: {},
+    oscTitles: {},
+    showOscTitle: false,
     tabIndicatorStyle: 'badge',
     ccIconVariant: 'bot',
   })
@@ -223,6 +225,93 @@ describe('InlineTab — host offline', () => {
       />,
     )
     expect(screen.queryByTestId('inline-tab-host-offline')).not.toBeInTheDocument()
+  })
+})
+
+describe('InlineTab — statusline display', () => {
+  it('shows "{oscTitle} - {baseLabel}" when showOscTitle + oscTitle + agentType all set', () => {
+    useAgentStore.setState({
+      showOscTitle: true,
+      agentTypes: { 'h1:S1': 'cc' },
+      oscTitles: { 'h1:S1': 'my-feature' },
+    })
+    render(
+      <InlineTab
+        tab={baseTab}
+        isActive={false}
+        onSelect={() => {}}
+        onClose={() => {}}
+        onMiddleClick={() => {}}
+        onContextMenu={() => {}}
+      />,
+    )
+    const title = screen.getByTestId('inline-tab-title')
+    expect(title.textContent).toBe('my-feature - work')
+  })
+
+  it('shows only baseLabel when oscTitle absent', () => {
+    useAgentStore.setState({
+      showOscTitle: true,
+      agentTypes: { 'h1:S1': 'cc' },
+      oscTitles: {},
+    })
+    render(
+      <InlineTab
+        tab={baseTab}
+        isActive={false}
+        onSelect={() => {}}
+        onClose={() => {}}
+        onMiddleClick={() => {}}
+        onContextMenu={() => {}}
+      />,
+    )
+    const title = screen.getByTestId('inline-tab-title')
+    expect(title.textContent).toBe('work')
+    expect(title.textContent).not.toContain(' - ')
+  })
+
+  it('shows only baseLabel when showOscTitle is disabled', () => {
+    useAgentStore.setState({
+      showOscTitle: false,
+      agentTypes: { 'h1:S1': 'cc' },
+      oscTitles: { 'h1:S1': 'my-feature' },
+    })
+    render(
+      <InlineTab
+        tab={baseTab}
+        isActive={false}
+        onSelect={() => {}}
+        onClose={() => {}}
+        onMiddleClick={() => {}}
+        onContextMenu={() => {}}
+      />,
+    )
+    const title = screen.getByTestId('inline-tab-title')
+    expect(title.textContent).toBe('work')
+  })
+
+  it('renders HoverTooltip with combined text (not native title attr)', () => {
+    useAgentStore.setState({
+      showOscTitle: true,
+      agentTypes: { 'h1:S1': 'cc' },
+      oscTitles: { 'h1:S1': 'my-feature' },
+    })
+    render(
+      <InlineTab
+        tab={baseTab}
+        isActive={false}
+        onSelect={() => {}}
+        onClose={() => {}}
+        onMiddleClick={() => {}}
+        onContextMenu={() => {}}
+      />,
+    )
+    const title = screen.getByTestId('inline-tab-title')
+    // Native title attribute must be gone
+    expect(title.getAttribute('title')).toBeNull()
+    // HoverTooltip renders combined text as a sibling
+    const tooltip = screen.getByTestId('inline-tab-tooltip')
+    expect(tooltip.textContent).toBe('my-feature - work')
   })
 })
 

--- a/spa/src/features/workspace/components/InlineTab.test.tsx
+++ b/spa/src/features/workspace/components/InlineTab.test.tsx
@@ -313,6 +313,25 @@ describe('InlineTab — statusline display', () => {
     const tooltip = screen.getByTestId('inline-tab-tooltip')
     expect(tooltip.textContent).toBe('my-feature - work')
   })
+
+  it('uses placement=right for tooltip (escapes sidebar overflow-y-auto clipping)', () => {
+    render(
+      <InlineTab
+        tab={baseTab}
+        isActive={false}
+        onSelect={() => {}}
+        onClose={() => {}}
+        onMiddleClick={() => {}}
+        onContextMenu={() => {}}
+      />,
+    )
+    const tooltip = screen.getByTestId('inline-tab-tooltip')
+    // placement=right uses left-full (mirrors ActivityBarNarrow pattern).
+    // placement=top would use bottom-full, which can be clipped by the sidebar's
+    // vertical scroll container near the top edge.
+    expect(tooltip.className).toContain('left-full')
+    expect(tooltip.className).not.toContain('bottom-full')
+  })
 })
 
 describe('InlineTab — pointer down (dnd-kit integration)', () => {

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -114,7 +114,12 @@ export function InlineTab({
       <span data-testid="inline-tab-title" className="flex-1 truncate">
         {displayTitle}
       </span>
-      <HoverTooltip placement="top" data-testid="inline-tab-tooltip">
+      {/*
+        placement=right mirrors ActivityBarNarrow's pattern — the sidebar is an
+        overflow-y-auto scroll container, so a top-anchored tooltip can be
+        clipped near the edge. Right escapes into the main content area.
+      */}
+      <HoverTooltip placement="right" data-testid="inline-tab-tooltip">
         {displayTitle}
       </HoverTooltip>
       {isHostOffline && (

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -4,6 +4,7 @@ import type { Tab } from '../../../types/tab'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { useTabDisplay } from '../../../hooks/useTabDisplay'
 import { shouldShowGlobalUnreadPip } from '../../../components/tab-icon-helpers'
+import { HoverTooltip } from '../../../components/HoverTooltip'
 import { renderInlineTabIcon } from '../lib/renderInlineTabIcon'
 
 interface Props {
@@ -35,7 +36,6 @@ export function InlineTab({
 
   const {
     displayTitle,
-    tooltip,
     IconComponent,
     agentStatus,
     isUnread,
@@ -111,9 +111,12 @@ export function InlineTab({
         subagentCount,
         isUnread,
       })}
-      <span className="flex-1 truncate" title={tooltip}>
+      <span data-testid="inline-tab-title" className="flex-1 truncate">
         {displayTitle}
       </span>
+      <HoverTooltip placement="top" data-testid="inline-tab-tooltip">
+        {displayTitle}
+      </HoverTooltip>
       {isHostOffline && (
         <WifiSlash
           size={12}

--- a/spa/src/features/workspace/components/InlineTabList.test.tsx
+++ b/spa/src/features/workspace/components/InlineTabList.test.tsx
@@ -56,9 +56,10 @@ describe('InlineTabList', () => {
         />
       </DndContext>,
     )
-    // `browser` kind in getPaneLabel extracts hostname from URL
-    expect(screen.getByText('alpha.example.com')).toBeInTheDocument()
-    expect(screen.getByText('beta.example.com')).toBeInTheDocument()
+    // `browser` kind in getPaneLabel extracts hostname from URL.
+    // Label appears twice per row: visible title span + HoverTooltip.
+    expect(screen.getAllByText('alpha.example.com').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('beta.example.com').length).toBeGreaterThan(0)
   })
 
   it('skips ids with no matching tab entry', () => {
@@ -76,7 +77,7 @@ describe('InlineTabList', () => {
         />
       </DndContext>,
     )
-    expect(screen.getByText('alpha.example.com')).toBeInTheDocument()
+    expect(screen.getAllByText('alpha.example.com').length).toBeGreaterThan(0)
     expect(screen.queryByText('missing')).not.toBeInTheDocument()
   })
 })

--- a/spa/src/features/workspace/components/WorkspaceRow.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.test.tsx
@@ -77,7 +77,8 @@ describe('WorkspaceRow', () => {
   it('tabs shown when workspaceExpanded[id]=true', () => {
     useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide', workspaceExpanded: { 'ws-1': true } })
     renderRow(mkWs('ws-1', 'W', ['t1']), { tabsById: { t1: mkTab('t1', 'alpha') } })
-    expect(screen.getByText('alpha.example.com')).toBeInTheDocument()
+    // Label appears twice per row: visible title span + HoverTooltip.
+    expect(screen.getAllByText('alpha.example.com').length).toBeGreaterThan(0)
   })
 
   it('clicking title on ACTIVE ws toggles expand (does not re-select)', () => {

--- a/spa/src/hooks/useMultiHostEventWs.ts
+++ b/spa/src/hooks/useMultiHostEventWs.ts
@@ -6,6 +6,7 @@ import { useStreamStore } from '../stores/useStreamStore'
 import { useAgentStore } from '../stores/useAgentStore'
 import { useTabStore } from '../stores/useTabStore'
 import { connectHostEvents, type EventConnection } from '../lib/host-events'
+import { dispatchAgentWsEvent } from '../lib/agent-ws-dispatch'
 import { scanPaneTree } from '../lib/pane-tree'
 import { hostWsUrl, fetchWsTicket, fetchHistory, type Session } from '../lib/host-api'
 import { checkHealth, type HealthResult } from '../lib/host-connection'
@@ -160,6 +161,10 @@ export function useMultiHostEventWs() {
             } else {
               store.setHandoffProgress(hostId, event.session, event.value)
             }
+          }
+          if (event.type === 'agent.status' || event.type === 'agent.status.cleared') {
+            dispatchAgentWsEvent(hostId, event)
+            return
           }
         },
         // onClose — trigger SM health check (no auto-reconnect)

--- a/spa/src/hooks/useTabDisplay.test.ts
+++ b/spa/src/hooks/useTabDisplay.test.ts
@@ -90,7 +90,7 @@ describe('useTabDisplay — OSC title override', () => {
       oscTitles: { 'h1:sc1': 'claude' },
     })
     const { result } = renderHook(() => useTabDisplay(makeTab()))
-    expect(result.current.displayTitle).toBe('claude')
+    expect(result.current.displayTitle).toBe('claude - base')
     expect(result.current.tooltip).toBe('claude - base')
   })
 

--- a/spa/src/hooks/useTabDisplay.test.ts
+++ b/spa/src/hooks/useTabDisplay.test.ts
@@ -50,7 +50,6 @@ describe('useTabDisplay — label resolution', () => {
     })
     const { result } = renderHook(() => useTabDisplay(makeTab()))
     expect(result.current.displayTitle).toBe('my-session')
-    expect(result.current.tooltip).toBe('my-session')
   })
 
   it('falls back to sessionCode when session not found', () => {
@@ -91,7 +90,6 @@ describe('useTabDisplay — OSC title override', () => {
     })
     const { result } = renderHook(() => useTabDisplay(makeTab()))
     expect(result.current.displayTitle).toBe('claude - base')
-    expect(result.current.tooltip).toBe('claude - base')
   })
 
   it('ignores OSC when showOscTitle is off', () => {

--- a/spa/src/hooks/useTabDisplay.ts
+++ b/spa/src/hooks/useTabDisplay.ts
@@ -19,12 +19,6 @@ export type TabIconComponent = ComponentType<{ size: number; className?: string 
 
 export interface TabDisplayData {
   displayTitle: string
-  /**
-   * @deprecated Identical to `displayTitle` post-T16. Kept only because
-   * SortableTab still passes this as a native `title=""` attribute. Remove
-   * once SortableTab migrates to HoverTooltip.
-   */
-  tooltip: string
   IconComponent: TabIconComponent | undefined
   agentStatus: AgentStatus | undefined
   isUnread: boolean
@@ -77,11 +71,9 @@ export function useTabDisplay(tab: Tab): TabDisplayData {
 
   const useOsc = showOscTitle && !isTerminated && !!agentType && !!oscTitle
   const displayTitle = useOsc && oscTitle ? `${oscTitle} - ${baseLabel}` : baseLabel
-  const tooltip = useOsc && oscTitle ? `${oscTitle} - ${baseLabel}` : baseLabel
 
   return {
     displayTitle,
-    tooltip,
     IconComponent,
     agentStatus,
     isUnread,

--- a/spa/src/hooks/useTabDisplay.ts
+++ b/spa/src/hooks/useTabDisplay.ts
@@ -71,7 +71,7 @@ export function useTabDisplay(tab: Tab): TabDisplayData {
   const baseLabel = getPaneLabel(primaryContent, sessionLookup, workspaceLookup, t)
 
   const useOsc = showOscTitle && !isTerminated && !!agentType && !!oscTitle
-  const displayTitle = useOsc && oscTitle ? oscTitle : baseLabel
+  const displayTitle = useOsc && oscTitle ? `${oscTitle} - ${baseLabel}` : baseLabel
   const tooltip = useOsc && oscTitle ? `${oscTitle} - ${baseLabel}` : baseLabel
 
   return {

--- a/spa/src/hooks/useTabDisplay.ts
+++ b/spa/src/hooks/useTabDisplay.ts
@@ -19,6 +19,11 @@ export type TabIconComponent = ComponentType<{ size: number; className?: string 
 
 export interface TabDisplayData {
   displayTitle: string
+  /**
+   * @deprecated Identical to `displayTitle` post-T16. Kept only because
+   * SortableTab still passes this as a native `title=""` attribute. Remove
+   * once SortableTab migrates to HoverTooltip.
+   */
   tooltip: string
   IconComponent: TabIconComponent | undefined
   agentStatus: AgentStatus | undefined

--- a/spa/src/lib/agent-ws-dispatch.test.ts
+++ b/spa/src/lib/agent-ws-dispatch.test.ts
@@ -1,0 +1,40 @@
+// spa/src/lib/agent-ws-dispatch.test.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { dispatchAgentWsEvent } from './agent-ws-dispatch'
+import { useAgentStore } from '../stores/useAgentStore'
+
+const H = 'test-host'
+
+beforeEach(() => {
+  useAgentStore.setState({
+    statuses: {},
+    agentTypes: {},
+    models: {},
+    subagents: {},
+    lastEvents: {},
+    oscTitles: {},
+    ccStatus: {},
+    unread: {},
+    showOscTitle: false,
+  })
+})
+
+describe('dispatchAgentWsEvent', () => {
+  it('agent.status event calls setCcStatus with parsed value', () => {
+    const payload = { session_name: 'abc', model: { display_name: 'Sonnet' } }
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: JSON.stringify(payload) })
+    const entry = useAgentStore.getState().ccStatus[`${H}:dev`]
+    expect(entry?.raw).toEqual(payload)
+  })
+
+  it('agent.status with malformed value is silently ignored', () => {
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: 'not-json' })
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+  })
+
+  it('agent.status.cleared event calls clearHostAgentStatus', () => {
+    useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'stale' })
+    dispatchAgentWsEvent(H, { type: 'agent.status.cleared', session: '', value: '{"agent_type":"cc"}' })
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+  })
+})

--- a/spa/src/lib/agent-ws-dispatch.test.ts
+++ b/spa/src/lib/agent-ws-dispatch.test.ts
@@ -20,11 +20,13 @@ beforeEach(() => {
 })
 
 describe('dispatchAgentWsEvent', () => {
-  it('agent.status event calls setCcStatus with parsed value', () => {
-    const payload = { session_name: 'abc', model: { display_name: 'Sonnet' } }
-    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: JSON.stringify(payload) })
+  it('agent.status event unwraps {agent_type,status} wire shape and stores inner status', () => {
+    const status = { session_name: 'abc', model: { display_name: 'Sonnet' } }
+    const wire = { agent_type: 'cc', status }
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: JSON.stringify(wire) })
     const entry = useAgentStore.getState().ccStatus[`${H}:dev`]
-    expect(entry?.raw).toEqual(payload)
+    // The store should hold the INNER status object, not the outer wrapper.
+    expect(entry?.raw).toEqual(status)
   })
 
   it('agent.status with malformed value is silently ignored', () => {
@@ -37,6 +39,24 @@ describe('dispatchAgentWsEvent', () => {
     dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: '123' })
     dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: '[1,2,3]' })
     dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: '"bare"' })
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+  })
+
+  it('ignores agent.status with non-"cc" agent_type', () => {
+    const wire = { agent_type: 'codex', status: { session_name: 'abc' } }
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: JSON.stringify(wire) })
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+  })
+
+  it('ignores agent.status with missing status field', () => {
+    const wire = { agent_type: 'cc' }
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: JSON.stringify(wire) })
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+  })
+
+  it('ignores agent.status with non-object status field', () => {
+    const wire = { agent_type: 'cc', status: 'not-an-object' }
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: JSON.stringify(wire) })
     expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
   })
 

--- a/spa/src/lib/agent-ws-dispatch.test.ts
+++ b/spa/src/lib/agent-ws-dispatch.test.ts
@@ -32,6 +32,14 @@ describe('dispatchAgentWsEvent', () => {
     expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
   })
 
+  it('agent.status with non-object JSON (null/array/primitive) is ignored', () => {
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: 'null' })
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: '123' })
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: '[1,2,3]' })
+    dispatchAgentWsEvent(H, { type: 'agent.status', session: 'dev', value: '"bare"' })
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+  })
+
   it('agent.status.cleared event calls clearHostAgentStatus', () => {
     useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'stale' })
     dispatchAgentWsEvent(H, { type: 'agent.status.cleared', session: '', value: '{"agent_type":"cc"}' })

--- a/spa/src/lib/agent-ws-dispatch.ts
+++ b/spa/src/lib/agent-ws-dispatch.ts
@@ -9,10 +9,19 @@ import { useAgentStore } from '../stores/useAgentStore'
 export function dispatchAgentWsEvent(hostId: string, event: HostEvent): void {
   if (event.type === 'agent.status') {
     try {
+      // Daemon broadcasts {"agent_type":"cc","status":<raw CC statusLine JSON>}
+      // (see internal/module/agent/handler.go statusSnapshot). We must unwrap
+      // and pass the inner `status` to the store — otherwise `raw.session_name`
+      // (read by setCcStatus) lives one level too deep and oscTitles never
+      // populate in real environments.
       const parsed = JSON.parse(event.value)
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        useAgentStore.getState().setCcStatus(hostId, event.session, parsed as Record<string, unknown>)
-      }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return
+      const wire = parsed as Record<string, unknown>
+      // SPA only supports cc today; future Codex payloads should route elsewhere.
+      if (wire.agent_type !== 'cc') return
+      const status = wire.status
+      if (!status || typeof status !== 'object' || Array.isArray(status)) return
+      useAgentStore.getState().setCcStatus(hostId, event.session, status as Record<string, unknown>)
     } catch { /* ignore malformed payload */ }
     return
   }

--- a/spa/src/lib/agent-ws-dispatch.ts
+++ b/spa/src/lib/agent-ws-dispatch.ts
@@ -9,8 +9,10 @@ import { useAgentStore } from '../stores/useAgentStore'
 export function dispatchAgentWsEvent(hostId: string, event: HostEvent): void {
   if (event.type === 'agent.status') {
     try {
-      const parsed = JSON.parse(event.value) as Record<string, unknown>
-      useAgentStore.getState().setCcStatus(hostId, event.session, parsed)
+      const parsed = JSON.parse(event.value)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        useAgentStore.getState().setCcStatus(hostId, event.session, parsed as Record<string, unknown>)
+      }
     } catch { /* ignore malformed payload */ }
     return
   }

--- a/spa/src/lib/agent-ws-dispatch.ts
+++ b/spa/src/lib/agent-ws-dispatch.ts
@@ -1,0 +1,23 @@
+// spa/src/lib/agent-ws-dispatch.ts
+// Pure dispatcher for agent.* WS events → useAgentStore actions.
+// Kept out of useMultiHostEventWs.ts for testability and future extension
+// (e.g. Codex statusLine may arrive via a different event.type or carry an
+// agent_type discriminator inside value).
+import type { HostEvent } from './host-events'
+import { useAgentStore } from '../stores/useAgentStore'
+
+export function dispatchAgentWsEvent(hostId: string, event: HostEvent): void {
+  if (event.type === 'agent.status') {
+    try {
+      const parsed = JSON.parse(event.value) as Record<string, unknown>
+      useAgentStore.getState().setCcStatus(hostId, event.session, parsed)
+    } catch { /* ignore malformed payload */ }
+    return
+  }
+  if (event.type === 'agent.status.cleared') {
+    // Daemon currently always sends {"agent_type":"cc"}; the store wipes all
+    // ccStatus entries for the host regardless, so we skip parsing value.
+    useAgentStore.getState().clearHostAgentStatus(hostId)
+    return
+  }
+}

--- a/spa/src/lib/host-events.ts
+++ b/spa/src/lib/host-events.ts
@@ -1,7 +1,7 @@
 // spa/src/lib/host-events.ts
 
 export interface HostEvent {
-  type: 'handoff' | 'relay' | 'hook' | 'sessions' | 'tmux'
+  type: 'handoff' | 'relay' | 'hook' | 'sessions' | 'tmux' | 'agent.status' | 'agent.status.cleared'
   session: string
   value: string
 }

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
     subagents: {},
     lastEvents: {},
     oscTitles: {},
+    ccStatus: {},
     unread: {},
     showOscTitle: false,
   })
@@ -388,6 +389,49 @@ describe('useAgentStore.setOscTitle', () => {
     useAgentStore.getState().removeHost(H)
     expect(useAgentStore.getState().oscTitles[`${H}:dev`]).toBeUndefined()
     expect(useAgentStore.getState().oscTitles['other-host:dev']).toBe('other-title')
+  })
+})
+
+describe('useAgentStore.ccStatus', () => {
+  it('setCcStatus stores snapshot under composite key', () => {
+    const raw = { model: { display_name: 'Sonnet' } }
+    useAgentStore.getState().setCcStatus(H, 'dev', raw)
+    const entry = useAgentStore.getState().ccStatus[`${H}:dev`]
+    expect(entry?.raw).toEqual(raw)
+    expect(typeof entry?.receivedAt).toBe('number')
+  })
+
+  it('setCcStatus with session_name also sets oscTitle', () => {
+    useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'my-feature' })
+    expect(useAgentStore.getState().oscTitles[`${H}:dev`]).toBe('my-feature')
+  })
+
+  it('setCcStatus with empty session_name clears oscTitle', () => {
+    useAgentStore.getState().setOscTitle(H, 'dev', 'stale')
+    useAgentStore.getState().setCcStatus(H, 'dev', { model: { display_name: 'x' } })
+    expect(useAgentStore.getState().oscTitles[`${H}:dev`]).toBeUndefined()
+  })
+
+  it('clearHostAgentStatus wipes ccStatus + oscTitles for host', () => {
+    useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'a' })
+    useAgentStore.getState().setCcStatus(H, 'prod', { session_name: 'b' })
+    useAgentStore.getState().clearHostAgentStatus(H)
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+    expect(useAgentStore.getState().ccStatus[`${H}:prod`]).toBeUndefined()
+    expect(useAgentStore.getState().oscTitles[`${H}:dev`]).toBeUndefined()
+    expect(useAgentStore.getState().oscTitles[`${H}:prod`]).toBeUndefined()
+  })
+
+  it('clearSession also wipes ccStatus', () => {
+    useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'a' })
+    useAgentStore.getState().clearSession(H, 'dev')
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+  })
+
+  it('removeHost wipes ccStatus', () => {
+    useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'a' })
+    useAgentStore.getState().removeHost(H)
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
   })
 })
 

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -412,6 +412,12 @@ describe('useAgentStore.ccStatus', () => {
     expect(useAgentStore.getState().oscTitles[`${H}:dev`]).toBeUndefined()
   })
 
+  it('setCcStatus with null session_name leaves oscTitle cleared', () => {
+    useAgentStore.getState().setOscTitle(H, 'dev', 'stale')
+    useAgentStore.getState().setCcStatus(H, 'dev', { session_name: null as unknown as string })
+    expect(useAgentStore.getState().oscTitles[`${H}:dev`]).toBeUndefined()
+  })
+
   it('clearHostAgentStatus wipes ccStatus + oscTitles for host', () => {
     useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'a' })
     useAgentStore.getState().setCcStatus(H, 'prod', { session_name: 'b' })

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -418,7 +418,7 @@ describe('useAgentStore.ccStatus', () => {
     expect(useAgentStore.getState().oscTitles[`${H}:dev`]).toBeUndefined()
   })
 
-  it('clearHostAgentStatus wipes ccStatus + oscTitles for host', () => {
+  it('clearHostAgentStatus wipes ccStatus + cc-sourced oscTitles for host', () => {
     useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'a' })
     useAgentStore.getState().setCcStatus(H, 'prod', { session_name: 'b' })
     useAgentStore.getState().clearHostAgentStatus(H)
@@ -426,6 +426,48 @@ describe('useAgentStore.ccStatus', () => {
     expect(useAgentStore.getState().ccStatus[`${H}:prod`]).toBeUndefined()
     expect(useAgentStore.getState().oscTitles[`${H}:dev`]).toBeUndefined()
     expect(useAgentStore.getState().oscTitles[`${H}:prod`]).toBeUndefined()
+  })
+
+  it('clearHostAgentStatus preserves non-CC oscTitles for the host', () => {
+    // Terminal-sourced oscTitle (no ccStatus mirror)
+    useAgentStore.getState().setOscTitle(H, 'term', 'terminal-title')
+    // CC-sourced oscTitle (mirrored via setCcStatus)
+    useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'cc-feature' })
+    useAgentStore.getState().clearHostAgentStatus(H)
+
+    // CC-sourced wiped (both ccStatus and mirrored oscTitle)
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+    expect(useAgentStore.getState().oscTitles[`${H}:dev`]).toBeUndefined()
+    // Terminal-sourced oscTitle preserved
+    expect(useAgentStore.getState().oscTitles[`${H}:term`]).toBe('terminal-title')
+  })
+
+  it('clearHostAgentStatus is a no-op when no ccStatus exists for host', () => {
+    // Seed terminal-only oscTitles for the host (no ccStatus entries)
+    useAgentStore.getState().setOscTitle(H, 'a', 'title-a')
+    useAgentStore.getState().setOscTitle(H, 'b', 'title-b')
+    const beforeState = useAgentStore.getState()
+    const beforeCc = beforeState.ccStatus
+    const beforeOsc = beforeState.oscTitles
+
+    useAgentStore.getState().clearHostAgentStatus(H)
+
+    const afterState = useAgentStore.getState()
+    // Reference equality: no slice rebuilt
+    expect(afterState.ccStatus).toBe(beforeCc)
+    expect(afterState.oscTitles).toBe(beforeOsc)
+    // Values intact
+    expect(afterState.oscTitles[`${H}:a`]).toBe('title-a')
+    expect(afterState.oscTitles[`${H}:b`]).toBe('title-b')
+  })
+
+  it('clearHostAgentStatus preserves other hosts ccStatus + oscTitles', () => {
+    useAgentStore.getState().setCcStatus(H, 'dev', { session_name: 'a' })
+    useAgentStore.getState().setCcStatus('other-host', 'dev', { session_name: 'other' })
+    useAgentStore.getState().clearHostAgentStatus(H)
+    expect(useAgentStore.getState().ccStatus[`${H}:dev`]).toBeUndefined()
+    expect(useAgentStore.getState().ccStatus['other-host:dev']?.raw).toEqual({ session_name: 'other' })
+    expect(useAgentStore.getState().oscTitles['other-host:dev']).toBe('other')
   })
 
   it('clearSession also wipes ccStatus', () => {

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -20,6 +20,22 @@ export function sanitizeOscTitle(raw: string): string {
   return raw.replace(/\x1b\[[\d;]*[A-Za-z]/g, '').replace(/[\x00-\x1f\x7f]/g, '').trim()
 }
 
+/**
+ * Return a new record containing every entry of `rec` except those whose key
+ * matches `shouldOmit`. Shared by `removeHost` (prefix match) and
+ * `clearHostAgentStatus` (set membership).
+ */
+function omitKeys<T>(
+  rec: Record<string, T>,
+  shouldOmit: (key: string) => boolean,
+): Record<string, T> {
+  const out: Record<string, T> = {}
+  for (const [k, v] of Object.entries(rec)) {
+    if (!shouldOmit(k)) out[k] = v
+  }
+  return out
+}
+
 /** Normalized event from backend (replaces AgentHookEvent). */
 export interface NormalizedEvent {
   agent_type: string
@@ -158,22 +174,16 @@ export const useAgentStore = create<AgentState>()(
 
       removeHost: (hostId) => set((s) => {
         const prefix = `${hostId}:`
-        const filterKeys = <T,>(record: Record<string, T>): Record<string, T> => {
-          const result: Record<string, T> = {}
-          for (const [k, v] of Object.entries(record)) {
-            if (!k.startsWith(prefix)) result[k] = v
-          }
-          return result
-        }
+        const byPrefix = (k: string) => k.startsWith(prefix)
         return {
-          statuses: filterKeys(s.statuses),
-          agentTypes: filterKeys(s.agentTypes),
-          models: filterKeys(s.models),
-          subagents: filterKeys(s.subagents),
-          lastEvents: filterKeys(s.lastEvents),
-          oscTitles: filterKeys(s.oscTitles),
-          ccStatus: filterKeys(s.ccStatus),
-          unread: filterKeys(s.unread),
+          statuses: omitKeys(s.statuses, byPrefix),
+          agentTypes: omitKeys(s.agentTypes, byPrefix),
+          models: omitKeys(s.models, byPrefix),
+          subagents: omitKeys(s.subagents, byPrefix),
+          lastEvents: omitKeys(s.lastEvents, byPrefix),
+          oscTitles: omitKeys(s.oscTitles, byPrefix),
+          ccStatus: omitKeys(s.ccStatus, byPrefix),
+          unread: omitKeys(s.unread, byPrefix),
         }
       }),
 
@@ -203,23 +213,28 @@ export const useAgentStore = create<AgentState>()(
       },
 
       /**
-       * Wipe all ccStatus + oscTitles entries for a host. Called on the
-       * `agent.status.cleared` WS event (e.g., when CC statusLine is uninstalled).
-       * Note: also clears non-CC oscTitles for the host — terminals will re-emit
-       * on their next prompt.
+       * Wipe CC statusLine state for a host: all ccStatus entries with the host's
+       * prefix, plus the oscTitles entries that were mirrored from those ccStatus
+       * snapshots (same composite keys). Non-CC oscTitles (from terminal OSC
+       * 0/2 sequences) are preserved.
+       *
+       * Called on the `agent.status.cleared` WS event, broadcast by the daemon
+       * when the CC statusLine wrapper is uninstalled.
+       *
+       * Does NOT touch statuses / agentTypes / models / subagents / unread /
+       * lastEvents — those track agent hook events, which are orthogonal to
+       * statusLine install state. Uninstalling the wrapper does not imply the
+       * CC session has ended; the hook stream may continue.
        */
       clearHostAgentStatus: (hostId) => set((s) => {
         const prefix = `${hostId}:`
-        const filterKeys = <T,>(record: Record<string, T>): Record<string, T> => {
-          const result: Record<string, T> = {}
-          for (const [k, v] of Object.entries(record)) {
-            if (!k.startsWith(prefix)) result[k] = v
-          }
-          return result
-        }
+        const ccKeysToRemove = Object.keys(s.ccStatus).filter((k) => k.startsWith(prefix))
+        if (ccKeysToRemove.length === 0) return s
+        const removeSet = new Set(ccKeysToRemove)
+        const shouldOmit = (k: string) => removeSet.has(k)
         return {
-          ccStatus: filterKeys(s.ccStatus),
-          oscTitles: filterKeys(s.oscTitles),
+          ccStatus: omitKeys(s.ccStatus, shouldOmit),
+          oscTitles: omitKeys(s.oscTitles, shouldOmit),
         }
       }),
     }),

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -202,6 +202,12 @@ export const useAgentStore = create<AgentState>()(
         get().setOscTitle(hostId, sessionCode, sessionName)
       },
 
+      /**
+       * Wipe all ccStatus + oscTitles entries for a host. Called on the
+       * `agent.status.cleared` WS event (e.g., when CC statusLine is uninstalled).
+       * Note: also clears non-CC oscTitles for the host — terminals will re-emit
+       * on their next prompt.
+       */
       clearHostAgentStatus: (hostId) => set((s) => {
         const prefix = `${hostId}:`
         const filterKeys = <T,>(record: Record<string, T>): Record<string, T> => {

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -31,6 +31,12 @@ export interface NormalizedEvent {
   detail?: Record<string, unknown>
 }
 
+/** Latest CC statusLine snapshot per session (ephemeral, from statusLine wrapper). */
+export interface CcStatusEntry {
+  receivedAt: number
+  raw: Record<string, unknown>
+}
+
 interface AgentState {
   // Backend-derived state
   statuses: Record<string, AgentStatus>
@@ -39,6 +45,7 @@ interface AgentState {
   subagents: Record<string, string[]>
   lastEvents: Record<string, NormalizedEvent>  // for notification dispatcher
   oscTitles: Record<string, string>  // latest OSC 0/2 title per session (ephemeral)
+  ccStatus: Record<string, CcStatusEntry>  // latest CC statusLine snapshot (ephemeral)
 
   // UI state
   unread: Record<string, boolean>
@@ -55,6 +62,8 @@ interface AgentState {
   setCcIconVariant: (variant: CcIconVariant) => void
   setShowOscTitle: (show: boolean) => void
   setOscTitle: (hostId: string, sessionCode: string, title: string) => void
+  setCcStatus: (hostId: string, sessionCode: string, raw: Record<string, unknown>) => void
+  clearHostAgentStatus: (hostId: string) => void
 }
 
 export const useAgentStore = create<AgentState>()(
@@ -66,6 +75,7 @@ export const useAgentStore = create<AgentState>()(
       subagents: {},
       lastEvents: {},
       oscTitles: {},
+      ccStatus: {},
       unread: {},
       tabIndicatorStyle: 'badge' as TabIndicatorStyle,
       ccIconVariant: 'bot' as CcIconVariant,
@@ -86,6 +96,7 @@ export const useAgentStore = create<AgentState>()(
             subagents: filterOut(s.subagents),
             lastEvents: filterOut(s.lastEvents),
             oscTitles: filterOut(s.oscTitles),
+            ccStatus: filterOut(s.ccStatus),
             unread: filterOut(s.unread),
           }
         })
@@ -161,6 +172,7 @@ export const useAgentStore = create<AgentState>()(
           subagents: filterKeys(s.subagents),
           lastEvents: filterKeys(s.lastEvents),
           oscTitles: filterKeys(s.oscTitles),
+          ccStatus: filterKeys(s.ccStatus),
           unread: filterKeys(s.unread),
         }
       }),
@@ -178,6 +190,31 @@ export const useAgentStore = create<AgentState>()(
         }
         if (s.oscTitles[key] === cleaned) return s
         return { oscTitles: { ...s.oscTitles, [key]: cleaned } }
+      }),
+
+      setCcStatus: (hostId, sessionCode, raw) => {
+        const key = compositeKey(hostId, sessionCode)
+        const entry: CcStatusEntry = { receivedAt: Date.now(), raw }
+        set((s) => ({ ccStatus: { ...s.ccStatus, [key]: entry } }))
+        // Mirror session_name → oscTitle (statusline's channel for cc session name).
+        // Empty / missing session_name → setOscTitle deletes the key via sanitizeOscTitle.
+        const sessionName = typeof raw?.session_name === 'string' ? raw.session_name : ''
+        get().setOscTitle(hostId, sessionCode, sessionName)
+      },
+
+      clearHostAgentStatus: (hostId) => set((s) => {
+        const prefix = `${hostId}:`
+        const filterKeys = <T,>(record: Record<string, T>): Record<string, T> => {
+          const result: Record<string, T> = {}
+          for (const [k, v] of Object.entries(record)) {
+            if (!k.startsWith(prefix)) result[k] = v
+          }
+          return result
+        }
+        return {
+          ccStatus: filterKeys(s.ccStatus),
+          oscTitles: filterKeys(s.oscTitles),
+        }
       }),
     }),
     {


### PR DESCRIPTION
## Summary

PR-1b of 3 for the CC statusLine Installer feature. Builds on PR-1a (#464) Go daemon backend. Connects daemon-broadcast `agent.status` + `agent.status.cleared` WS events into a new `ccStatus` store slot, and renders the CC session name into tab titles as `{cc} - {tmux}`.

End-to-end user-visible result after this merges: a user who has `pdx statusline-proxy` installed in CC's `settings.json` (via PR-1a) sees their current CC session name in tab titles automatically, across both InlineTab (activity bar) and SortableTab (top TabBar).

PR-1c (Installer UI) remains pending.

## What changed

- **`<HoverTooltip>` component** extracted from `ActivityBarNarrow`'s ws-tooltip CSS pattern. Reusable, placement=`top|right`, preserves `data-testid` passthrough. Parent must carry `.relative.group`.
- **`useAgentStore.ccStatus`** — new ephemeral (non-persisted) state slot keyed by `compositeKey(hostId, sessionCode)`. Two new actions:
  - `setCcStatus(hostId, sessionCode, raw)` — stores the full statusLine payload; mirrors `raw.session_name` → existing `setOscTitle` channel (empty/missing → delete).
  - `clearHostAgentStatus(hostId)` — wipes `ccStatus` + `oscTitles` for a host, for the `agent.status.cleared` event (e.g., when CC statusLine is uninstalled).
  - Threaded into existing `clearSession` / `removeHost` helpers.
- **WS dispatcher** — new pure helper `spa/src/lib/agent-ws-dispatch.ts` called from `useMultiHostEventWs`. `HostEvent.type` union extended with the two new literals. Defensive: JSON.parse errors swallowed; non-object JSON (null/array/primitive) rejected; `.cleared` doesn't parse `value`.
- **`useTabDisplay.displayTitle`** composition changed — when OSC state is active, returns `${oscTitle} - ${baseLabel}` instead of `oscTitle` alone. Both InlineTab and SortableTab inherit identically.
- **`InlineTab`** swaps native `title=""` for `<HoverTooltip placement="top">`. Reuses the `group relative` parent `<div>` so no class churn.
- **`TabDisplayData.tooltip`** marked `@deprecated` — now identical to `displayTitle`; kept only because SortableTab still uses native title attr.

PR-1a backend broadcast shape (reference):
- `{Type: "agent.status", Session: <code>, Value: <JSON statusLine input>}`
- `{Type: "agent.status.cleared", Session: "", Value: '{"agent_type":"cc"}'}`

## Plan drift handled

The original plan's T16 assumed `InlineTab` reads `oscTitle` directly and composes display inline. Actual structure: composition lives in `useTabDisplay` (shared by `InlineTab` and `SortableTab`); path was `features/workspace/components/InlineTab.tsx`, not `components/InlineTab.tsx`. Drift redirected during implementation — composition pushed up to the hook so both surfaces render identically.

## Test plan

- [x] `cd spa && npx vitest run` → 2055/2055 pass (204 files)
- [x] `cd spa && npx eslint <touched files>` clean on all 12 touched files
- [x] TDD cycle followed for each of T13/T14/T15/T16 (test → fail → implement → pass)
- [x] Defensive tests: malformed JSON, non-object JSON, null `session_name`, missing `oscTitle`, `showOscTitle=false`
- [x] Regression test: HoverTooltip fade classes (`opacity-0` + `group-hover:opacity-100` + `transition-opacity`) locked via word-boundary regex
- [ ] Manual E2E (deferred to PR-1c since Installer UI isn't built yet — after PR-1c lands, installer a wrapper → CC `-p` session → observe tab name switch to `{cc} - {tmux}`)

## Commit list (8 commits, each task + its adopted review follow-up)

| SHA | Subject |
|---|---|
| `197801f2` | refactor(spa): extract <HoverTooltip> from ws-tooltip pattern |
| `f03ce8fa` | test(spa): HoverTooltip fade-class regression test |
| `c2f4f7b8` | feat(store): ccStatus field + setCcStatus / clearHostAgentStatus actions |
| `f6973f1c` | docs+test(store): document clearHostAgentStatus + null session_name case |
| `61d1eb8f` | feat(spa): dispatch agent.status + agent.status.cleared WS events |
| `14914158` | harden(spa): reject non-object JSON in agent.status dispatch |
| `40cab773` | feat(spa): tab title shows {cc} - {tmux}; hover tooltip via HoverTooltip |
| `b3d1ddff` | docs(spa): flag tooltip field as deprecated duplicate of displayTitle |

## Not in this PR

- SortableTab migration to HoverTooltip — deliberate scope cut; `tooltip` field flagged `@deprecated` until that happens.
- Installer UI (Host → Agents → Extensions) — PR-1c.
- i18n + manual E2E — PR-1c.