### PR TITLE
feat(spa): status icon on Extensions sub-row (#480)

### DIFF
--- a/spa/src/components/hosts/AgentExtensionRow.test.tsx
+++ b/spa/src/components/hosts/AgentExtensionRow.test.tsx
@@ -98,6 +98,47 @@ describe('AgentExtensionRow (statusline)', () => {
     confirmSpy.mockRestore()
   })
 
+  // --- Status icon (#480) ---
+
+  it('renders green CheckCircle icon when mode=pdx', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ mode: 'pdx', installed: true, settingsPath: '/x' }) })
+    const { container } = render(<AgentExtensionRow hostId="h1" extensionId="statusline" />)
+    await waitFor(() => screen.getByRole('button', { name: /remove/i }))
+    const icon = container.querySelector('[data-testid="ext-status-icon"]')
+    expect(icon).not.toBeNull()
+    expect(icon?.getAttribute('data-icon')).toBe('check')
+    expect(icon?.classList.contains('text-green-400')).toBe(true)
+    expect(icon?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('renders green CheckCircle icon when mode=wrapped', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ mode: 'wrapped', installed: true, innerCommand: 'x', settingsPath: '/x' }) })
+    const { container } = render(<AgentExtensionRow hostId="h1" extensionId="statusline" />)
+    await waitFor(() => screen.getByRole('button', { name: /remove/i }))
+    const icon = container.querySelector('[data-testid="ext-status-icon"]')
+    expect(icon).not.toBeNull()
+    expect(icon?.getAttribute('data-icon')).toBe('check')
+    expect(icon?.classList.contains('text-green-400')).toBe(true)
+  })
+
+  it('renders yellow WarningCircle icon when mode=unmanaged', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ mode: 'unmanaged', installed: true, rawCommand: 'ccstatusline', settingsPath: '/x' }) })
+    const { container } = render(<AgentExtensionRow hostId="h1" extensionId="statusline" />)
+    await waitFor(() => screen.getByRole('button', { name: /install/i }))
+    const icon = container.querySelector('[data-testid="ext-status-icon"]')
+    expect(icon).not.toBeNull()
+    expect(icon?.getAttribute('data-icon')).toBe('warning')
+    expect(icon?.classList.contains('text-yellow-400')).toBe(true)
+    expect(icon?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('omits status icon when mode=none', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ mode: 'none', installed: false, settingsPath: '/x' }) })
+    const { container } = render(<AgentExtensionRow hostId="h1" extensionId="statusline" />)
+    await waitFor(() => screen.getByRole('button', { name: /install/i }))
+    expect(container.querySelector('[data-testid="ext-status-icon"]')).toBeNull()
+  })
+
   // --- Offline guard (Fix 3) ---
 
   it('disables buttons when host is offline', async () => {

--- a/spa/src/components/hosts/AgentExtensionRow.tsx
+++ b/spa/src/components/hosts/AgentExtensionRow.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { CheckCircle, WarningCircle } from '@phosphor-icons/react'
 import { useI18nStore } from '../../stores/useI18nStore'
 import { useHostStore } from '../../stores/useHostStore'
 import { useStatuslineInstall } from '../../hooks/useStatuslineInstall'
@@ -51,10 +52,39 @@ export function AgentExtensionRow({ hostId, extensionId }: Props) {
     }
   })()
 
+  const statusIcon = (() => {
+    if (state.mode === 'pdx' || state.mode === 'wrapped') {
+      return (
+        <CheckCircle
+          size={13}
+          weight="fill"
+          className="text-green-400"
+          data-testid="ext-status-icon"
+          data-icon="check"
+          aria-hidden="true"
+        />
+      )
+    }
+    if (state.mode === 'unmanaged') {
+      return (
+        <WarningCircle
+          size={13}
+          weight="fill"
+          className="text-yellow-400"
+          data-testid="ext-status-icon"
+          data-icon="warning"
+          aria-hidden="true"
+        />
+      )
+    }
+    return null
+  })()
+
   return (
     <>
       <div className="flex items-center justify-between py-2">
         <div className="flex items-center gap-2">
+          {statusIcon}
           <span className="text-sm">{t(`hosts.extensions.${extensionId}`)}</span>
           <span className="text-xs text-text-muted">{badge}</span>
         </div>


### PR DESCRIPTION
## Summary

- Add 13px Phosphor status icon left of the Status integration label in `AgentExtensionRow`
- `pdx`/`wrapped` → `CheckCircle` (green-400), `unmanaged` → `WarningCircle` (yellow-400), `none` → omitted
- Icons marked `aria-hidden="true"` — the existing text badge already conveys state to screen readers

Closes #480

## Test plan

- [x] `npx vitest run src/components/hosts/AgentExtensionRow.test.tsx` — 14/14 pass (4 new tests cover all 4 modes + icon type + a11y attr)
- [x] Full SPA suite: `npx vitest run` — 2139/2139 pass
- [x] Lint: clean on touched files
- [ ] Manual: Settings → Host → Agents → verify icon appears/disappears across install/uninstall/external-conflict flows