### PR TITLE
fix(agent): probe wrapped descendants with bounded cache

### DIFF
--- a/internal/agent/probe/liveness.go
+++ b/internal/agent/probe/liveness.go
@@ -1,14 +1,25 @@
 package probe
 
-import "strings"
+import (
+	"sort"
+	"strings"
+	"time"
+)
 
 var defaultShells = map[string]bool{
 	"zsh": true, "bash": true, "sh": true, "fish": true, "dash": true,
 }
 
+const recursiveDescendantCacheTTL = 250 * time.Millisecond
+
+type descendantCommandQuerier interface {
+	PaneDescendantCommands(target string) ([]string, error)
+}
+
 // IsAliveFor checks whether the given tmux target is running an agent of the
-// specified type. It checks in order: (1) pane foreground command, (2) child
-// processes, (3) optional content fallback.
+// specified type. It checks in order: (1) pane foreground command,
+// (2) direct child processes, (3) cached recursive descendants,
+// (4) optional content fallback.
 func (p *Prober) IsAliveFor(agentType, target string) bool {
 	p.matcherMu.RLock()
 	matcher, ok := p.matchers[agentType]
@@ -18,34 +29,61 @@ func (p *Prober) IsAliveFor(agentType, target string) bool {
 		return false
 	}
 
+	p.livenessMu.Lock()
+	p.pruneExpiredDescendantCacheLocked(p.now())
+	p.livenessMu.Unlock()
+
 	// Layer 1a: foreground command
 	cmd, err := p.tmux.PaneCurrentCommand(target)
 	if err != nil {
 		return false
 	}
 	cmd = strings.TrimSpace(cmd)
-	if matcher.commands[cmd] {
+	if matcher.commands[baseCommand(cmd)] {
 		return true
 	}
-	if defaultShells[cmd] {
-		return false
+
+	panePID := ""
+	panePIDKnown := false
+	if pid, err := p.tmux.PanePID(target); err == nil {
+		panePID = strings.TrimSpace(pid)
+		panePIDKnown = true
 	}
 
 	// Layer 1b: child processes
-	children, err := p.tmux.PaneChildCommands(target)
+	childrenKnown := false
+	var children []string
+	children, err = p.tmux.PaneChildCommands(target)
 	if err == nil {
+		childrenKnown = true
 		for _, child := range children {
-			base := child
-			if idx := strings.LastIndex(child, "/"); idx >= 0 {
-				base = child[idx+1:]
-			}
-			if matcher.commands[base] {
+			if matcher.commands[baseCommand(child)] {
 				return true
 			}
 		}
 	}
 
-	// Layer 1c: content fallback (optional)
+	// Layer 1c: recursive descendants (cached by target + current snapshot)
+	descendants, err := p.cachedDescendants(target, descendantCacheSnapshot{
+		panePID:       panePID,
+		panePIDKnown:  panePIDKnown,
+		paneCommand:   cmd,
+		childrenKey:   childSnapshotKey(children),
+		childrenKnown: childrenKnown,
+	})
+	if err == nil {
+		for _, descendant := range descendants {
+			if matcher.commands[baseCommand(descendant)] {
+				return true
+			}
+		}
+	}
+
+	if defaultShells[baseCommand(cmd)] {
+		return false
+	}
+
+	// Layer 1d: content fallback (optional)
 	if contentMatcher != nil {
 		content, err := p.tmux.CapturePaneContent(target, 5)
 		if err == nil && contentMatcher.LooksLikeAgent(content) {
@@ -54,4 +92,79 @@ func (p *Prober) IsAliveFor(agentType, target string) bool {
 	}
 
 	return false
+}
+
+type descendantCacheSnapshot struct {
+	panePID       string
+	panePIDKnown  bool
+	paneCommand   string
+	childrenKey   string
+	childrenKnown bool
+}
+
+type descendantCacheEntry struct {
+	snapshot    descendantCacheSnapshot
+	descendants []string
+	expiresAt   time.Time
+}
+
+func (p *Prober) cachedDescendants(target string, snapshot descendantCacheSnapshot) ([]string, error) {
+	now := p.now()
+	p.livenessMu.Lock()
+	entry, ok := p.descendantCache[target]
+	if ok && entry.snapshot == snapshot && now.Before(entry.expiresAt) {
+		descendants := append([]string(nil), entry.descendants...)
+		p.livenessMu.Unlock()
+		return descendants, nil
+	}
+	p.livenessMu.Unlock()
+
+	descendants, err := p.queryDescendants(target)
+	if err != nil {
+		return nil, err
+	}
+	descendants = append([]string(nil), descendants...)
+
+	p.livenessMu.Lock()
+	p.descendantCache[target] = descendantCacheEntry{
+		snapshot:    snapshot,
+		descendants: descendants,
+		expiresAt:   now.Add(recursiveDescendantCacheTTL),
+	}
+	p.livenessMu.Unlock()
+
+	return append([]string(nil), descendants...), nil
+}
+
+func (p *Prober) queryDescendants(target string) ([]string, error) {
+	querier, ok := p.tmux.(descendantCommandQuerier)
+	if !ok {
+		return nil, nil
+	}
+	return querier.PaneDescendantCommands(target)
+}
+
+func (p *Prober) pruneExpiredDescendantCacheLocked(now time.Time) {
+	for target, entry := range p.descendantCache {
+		if !now.Before(entry.expiresAt) {
+			delete(p.descendantCache, target)
+		}
+	}
+}
+
+func childSnapshotKey(children []string) string {
+	if len(children) == 0 {
+		return ""
+	}
+	snapshot := append([]string(nil), children...)
+	sort.Strings(snapshot)
+	return strings.Join(snapshot, "\x00")
+}
+
+func baseCommand(cmd string) string {
+	cmd = strings.TrimSpace(cmd)
+	if idx := strings.LastIndex(cmd, "/"); idx >= 0 {
+		return cmd[idx+1:]
+	}
+	return cmd
 }

--- a/internal/agent/probe/liveness_test.go
+++ b/internal/agent/probe/liveness_test.go
@@ -1,9 +1,9 @@
-package probe_test
+package probe
 
 import (
 	"testing"
+	"time"
 
-	"github.com/wake/purdex/internal/agent/probe"
 	"github.com/wake/purdex/internal/tmux"
 )
 
@@ -15,7 +15,7 @@ func (f *fakeContentMatcher) LooksLikeAgent(string) bool { return f.result }
 
 func TestIsAliveFor_DirectCommand(t *testing.T) {
 	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+	p := New(fake)
 	p.RegisterProcessNames("cc", []string{"claude", "cld"})
 
 	fake.SetPaneCommand("sess:", "claude")
@@ -26,7 +26,7 @@ func TestIsAliveFor_DirectCommand(t *testing.T) {
 
 func TestIsAliveFor_ShellIsDead(t *testing.T) {
 	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+	p := New(fake)
 	p.RegisterProcessNames("cc", []string{"claude"})
 
 	fake.SetPaneCommand("sess:", "zsh")
@@ -37,7 +37,7 @@ func TestIsAliveFor_ShellIsDead(t *testing.T) {
 
 func TestIsAliveFor_ChildProcess(t *testing.T) {
 	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+	p := New(fake)
 	p.RegisterProcessNames("cc", []string{"claude"})
 
 	fake.SetPaneCommand("sess:", "node")
@@ -47,9 +47,85 @@ func TestIsAliveFor_ChildProcess(t *testing.T) {
 	}
 }
 
+func TestIsAliveFor_RecursiveDescendant(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	p := New(fake)
+	p.RegisterProcessNames("cc", []string{"claude"})
+
+	fake.SetPaneCommand("sess:", "zsh")
+	fake.SetPaneChildren("sess:", []string{"bash"})
+	fake.SetPaneDescendants("sess:", []string{"bash", "/usr/local/bin/claude"})
+	if !p.IsAliveFor("cc", "sess:") {
+		t.Fatal("expected alive when descendant process matches")
+	}
+}
+
+func TestIsAliveFor_RecursiveDescendantUsesCacheWithinTTL(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	p := New(fake)
+	p.RegisterProcessNames("cc", []string{"claude"})
+	now := time.Unix(100, 0)
+	p.now = func() time.Time { return now }
+
+	fake.SetPaneCommand("sess:", "node")
+	fake.SetPaneChildren("sess:", []string{"npm"})
+	fake.SetPaneDescendants("sess:", []string{"npm", "/usr/bin/claude"})
+
+	if !p.IsAliveFor("cc", "sess:") {
+		t.Fatal("expected alive on first recursive descendant lookup")
+	}
+	fake.SetPaneDescendants("sess:", []string{"npm"})
+	if !p.IsAliveFor("cc", "sess:") {
+		t.Fatal("expected cached descendant lookup to keep reporting alive")
+	}
+}
+
+func TestIsAliveFor_RecursiveDescendantCacheExpiresWhenGrandchildChanges(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	p := New(fake)
+	p.RegisterProcessNames("cc", []string{"claude"})
+	now := time.Unix(100, 0)
+	p.now = func() time.Time { return now }
+
+	fake.SetPaneCommand("sess:", "node")
+	fake.SetPaneChildren("sess:", []string{"bash"})
+	fake.SetPaneDescendants("sess:", []string{"bash", "/usr/bin/claude"})
+
+	if !p.IsAliveFor("cc", "sess:") {
+		t.Fatal("expected alive before matching descendant exits")
+	}
+	fake.SetPaneDescendants("sess:", []string{"bash"})
+	now = now.Add(recursiveDescendantCacheTTL + time.Millisecond)
+	if p.IsAliveFor("cc", "sess:") {
+		t.Fatal("expected dead after cache expiry rechecks unchanged direct-child snapshot")
+	}
+}
+
+func TestIsAliveFor_RecursiveDescendantCacheInvalidatesOnPanePIDChange(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	p := New(fake)
+	p.RegisterProcessNames("cc", []string{"claude"})
+	now := time.Unix(100, 0)
+	p.now = func() time.Time { return now }
+
+	fake.SetPanePID("sess:", "pid-1")
+	fake.SetPaneCommand("sess:", "node")
+	fake.SetPaneChildren("sess:", []string{"bash"})
+	fake.SetPaneDescendants("sess:", []string{"bash", "/usr/bin/claude"})
+	if !p.IsAliveFor("cc", "sess:") {
+		t.Fatal("expected alive before pane is recreated")
+	}
+
+	fake.SetPanePID("sess:", "pid-2")
+	fake.SetPaneDescendants("sess:", []string{"bash"})
+	if p.IsAliveFor("cc", "sess:") {
+		t.Fatal("expected dead after pane PID changes and descendant no longer matches")
+	}
+}
+
 func TestIsAliveFor_ContentFallback(t *testing.T) {
 	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+	p := New(fake)
 	p.RegisterProcessNames("cc", []string{"claude"})
 	p.RegisterContentMatcher("cc", &fakeContentMatcher{result: true})
 
@@ -63,7 +139,7 @@ func TestIsAliveFor_ContentFallback(t *testing.T) {
 
 func TestIsAliveFor_NoContentMatcherReturnsDead(t *testing.T) {
 	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+	p := New(fake)
 	p.RegisterProcessNames("cc", []string{"claude"})
 
 	fake.SetPaneCommand("sess:", "node")
@@ -76,7 +152,7 @@ func TestIsAliveFor_NoContentMatcherReturnsDead(t *testing.T) {
 
 func TestIsAliveFor_ContentMatcherReturnsFalse(t *testing.T) {
 	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+	p := New(fake)
 	p.RegisterProcessNames("cc", []string{"claude"})
 	p.RegisterContentMatcher("cc", &fakeContentMatcher{result: false})
 
@@ -90,7 +166,7 @@ func TestIsAliveFor_ContentMatcherReturnsFalse(t *testing.T) {
 
 func TestIsAliveFor_UnknownAgentType(t *testing.T) {
 	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+	p := New(fake)
 
 	fake.SetPaneCommand("sess:", "claude")
 	if p.IsAliveFor("unknown", "sess:") {
@@ -100,7 +176,7 @@ func TestIsAliveFor_UnknownAgentType(t *testing.T) {
 
 func TestUpdateProcessNames(t *testing.T) {
 	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+	p := New(fake)
 	p.RegisterProcessNames("cc", []string{"claude"})
 
 	fake.SetPaneCommand("sess:", "cld")

--- a/internal/agent/probe/probe.go
+++ b/internal/agent/probe/probe.go
@@ -2,6 +2,7 @@ package probe
 
 import (
 	"sync"
+	"time"
 
 	"github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/tmux"
@@ -42,6 +43,10 @@ type Prober struct {
 	content   map[string]ContentMatcher   // agentType → optional
 	readiness map[string]ReadinessChecker // agentType → checker
 
+	livenessMu      sync.Mutex
+	descendantCache map[string]descendantCacheEntry // target → recursive descendant snapshot
+	now             func() time.Time
+
 	watcherMu sync.Mutex
 	watchers  map[string]watchEntry // target → active watcher
 }
@@ -54,11 +59,13 @@ type watchEntry struct {
 // New creates a Prober backed by the given tmux executor.
 func New(tmux tmux.Executor) *Prober {
 	return &Prober{
-		tmux:      tmux,
-		matchers:  make(map[string]*processMatcher),
-		content:   make(map[string]ContentMatcher),
-		readiness: make(map[string]ReadinessChecker),
-		watchers:  make(map[string]watchEntry),
+		tmux:            tmux,
+		matchers:        make(map[string]*processMatcher),
+		content:         make(map[string]ContentMatcher),
+		readiness:       make(map[string]ReadinessChecker),
+		descendantCache: make(map[string]descendantCacheEntry),
+		now:             time.Now,
+		watchers:        make(map[string]watchEntry),
 	}
 }
 

--- a/internal/tmux/executor.go
+++ b/internal/tmux/executor.go
@@ -165,22 +165,53 @@ func (r *RealExecutor) PanePID(target string) (string, error) {
 }
 
 func (r *RealExecutor) PaneChildCommands(target string) ([]string, error) {
+	return r.paneProcessCommands(target, false)
+}
+
+func (r *RealExecutor) PaneDescendantCommands(target string) ([]string, error) {
+	return r.paneProcessCommands(target, true)
+}
+
+func (r *RealExecutor) paneProcessCommands(target string, recursive bool) ([]string, error) {
 	panePID, err := r.PanePID(target)
 	if err != nil {
 		return nil, err
 	}
-	// ps -ax -o pid,ppid,comm → find children of the pane's shell PID
-	out, err := exec.Command("ps", "-ax", "-o", "pid,ppid,comm").Output()
+	// Build a process tree from ps output, then walk the pane shell's descendants.
+	out, err := exec.Command("ps", "-ax", "-o", "pid=,ppid=,comm=").Output()
 	if err != nil {
 		return nil, fmt.Errorf("ps: %w", err)
 	}
-	var cmds []string
+	childrenByPPID := make(map[string][]processEntry)
 	for _, line := range strings.Split(string(out), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) >= 3 && fields[1] == panePID {
-			cmds = append(cmds, fields[2])
+		if len(fields) < 3 {
+			continue
+		}
+		entry := processEntry{
+			pid:     fields[0],
+			ppid:    fields[1],
+			command: fields[2],
+		}
+		childrenByPPID[entry.ppid] = append(childrenByPPID[entry.ppid], entry)
+	}
+
+	queue := append([]string(nil), panePID)
+	var cmds []string
+	for len(queue) > 0 {
+		parentPID := queue[0]
+		queue = queue[1:]
+		for _, child := range childrenByPPID[parentPID] {
+			cmds = append(cmds, child.command)
+			if recursive {
+				queue = append(queue, child.pid)
+			}
+		}
+		if !recursive {
+			break
 		}
 	}
+
 	return cmds, nil
 }
 
@@ -249,3 +280,8 @@ func (r *RealExecutor) TmuxAlive() bool {
 	return exec.CommandContext(ctx, "tmux", "info").Run() == nil
 }
 
+type processEntry struct {
+	pid     string
+	ppid    string
+	command string
+}

--- a/internal/tmux/fake_executor.go
+++ b/internal/tmux/fake_executor.go
@@ -37,6 +37,8 @@ type FakeExecutor struct {
 	paneCommandCalls     map[string]int         // target → PaneCurrentCommand call count
 	paneContents         map[string]string      // target → captured text
 	paneChildren         map[string][]string    // target → child command names
+	paneDescendants      map[string][]string    // target → recursive descendant command names
+	panePIDs             map[string]string      // target → pane pid
 	paneCwds             map[string]string      // target → pane_current_path
 	paneSizes            map[string][2]int      // target → [cols, rows]
 	rawKeysCalls         []RawKeysCall
@@ -58,6 +60,8 @@ func NewFakeExecutor() *FakeExecutor {
 		paneCommandCalls: make(map[string]int),
 		paneContents:     make(map[string]string),
 		paneChildren:     make(map[string][]string),
+		paneDescendants:  make(map[string][]string),
+		panePIDs:         make(map[string]string),
 		paneCwds:         make(map[string]string),
 		paneSizes:        make(map[string][2]int),
 		alive:            true,
@@ -219,7 +223,24 @@ func (f *FakeExecutor) SetPaneChildren(target string, cmds []string) {
 	f.paneChildren[target] = cmds
 }
 
+func (f *FakeExecutor) SetPaneDescendants(target string, cmds []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.paneDescendants[target] = cmds
+}
+
+func (f *FakeExecutor) SetPanePID(target, pid string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.panePIDs[target] = pid
+}
+
 func (f *FakeExecutor) PanePID(target string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if pid, ok := f.panePIDs[target]; ok {
+		return pid, nil
+	}
 	return "fake-pid", nil
 }
 
@@ -230,7 +251,19 @@ func (f *FakeExecutor) PaneChildCommands(target string) ([]string, error) {
 	if !ok {
 		return nil, nil // no children
 	}
-	return cmds, nil
+	return append([]string(nil), cmds...), nil
+}
+
+func (f *FakeExecutor) PaneDescendantCommands(target string) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if cmds, ok := f.paneDescendants[target]; ok {
+		return append([]string(nil), cmds...), nil
+	}
+	if cmds, ok := f.paneChildren[target]; ok {
+		return append([]string(nil), cmds...), nil
+	}
+	return nil, nil
 }
 
 func (f *FakeExecutor) PaneCurrentCommand(target string) (string, error) {
@@ -338,7 +371,7 @@ func (f *FakeExecutor) SetWindowOptionCalls() []SetWindowOptionCall {
 }
 
 func (f *FakeExecutor) SetHookGlobal(event, command string) error { return nil }
-func (f *FakeExecutor) RemoveHookGlobal(event string) error      { return nil }
+func (f *FakeExecutor) RemoveHookGlobal(event string) error       { return nil }
 
 func (f *FakeExecutor) ShowHooksGlobal() (string, error) {
 	f.mu.Lock()


### PR DESCRIPTION
## Summary
- add recursive descendant probing for wrapped agent processes such as `shell -> node -> codex`
- keep pane command and direct-child fast paths, then cache descendant results with pane-PID-aware snapshots and a short TTL
- cover cache TTL, pane recreation, and wrapped descendant detection in probe tests

## Testing
- `go test ./internal/agent/probe ./internal/tmux ./internal/module/agent`

## Notes
- full `go test ./...` is currently blocked by pre-existing compile failures in `internal/module/files`
