### PR TITLE
feat(agent): periodic liveness sweep via watchAlive

### DIFF
--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -341,7 +342,7 @@ func TestCheckAliveAll_OrphanNotInTmuxDeleted(t *testing.T) {
 	sub := m.core.Events.AddTestSubscriber()
 	defer m.core.Events.RemoveTestSubscriber(sub)
 
-	m.checkAliveAll(sub)
+	m.checkAliveAll()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -374,7 +375,7 @@ func TestCheckAliveAll_OrphanStillInTmuxPreserved(t *testing.T) {
 	sub := m.core.Events.AddTestSubscriber()
 	defer m.core.Events.RemoveTestSubscriber(sub)
 
-	m.checkAliveAll(sub)
+	m.checkAliveAll()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -383,6 +384,115 @@ func TestCheckAliveAll_OrphanStillInTmuxPreserved(t *testing.T) {
 	}
 	if ev, _ := m.events.Get("transient-session"); ev == nil {
 		t.Error("orphan still in tmux should preserve DB entry")
+	}
+}
+
+func TestCheckAliveAll_TrackedDeadSessionBroadcastsClear(t *testing.T) {
+	m := newTestModule(t)
+	provider := &fakeAgentProvider{typeName: "codex"}
+	m.registry.Register(provider)
+	_ = m.events.Set("work", "UserPromptSubmit", json.RawMessage(`{}`), "codex", 1)
+
+	m.mu.Lock()
+	m.subagents["work"] = []string{"agent-1"}
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.activeWatchers["work"] = "codex"
+	m.mu.Unlock()
+
+	fake := tmux.NewFakeExecutor()
+	fake.AddSession("work", "/tmp")
+	fake.SetPaneCommand("work:", "zsh")
+	m.prober = probe.New(fake)
+	m.prober.RegisterProcessNames("codex", []string{"codex"})
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	m.checkAliveAll()
+
+	select {
+	case raw := <-sub.SendCh():
+		var env core.HostEvent
+		if err := json.Unmarshal(raw, &env); err != nil {
+			t.Fatalf("unmarshal host event: %v", err)
+		}
+		if env.Type != "hook" {
+			t.Fatalf("event type = %q, want hook", env.Type)
+		}
+		if env.Session != "code-work" {
+			t.Fatalf("event session = %q, want code-work", env.Session)
+		}
+		var normalized agentpkg.NormalizedEvent
+		if err := json.Unmarshal([]byte(env.Value), &normalized); err != nil {
+			t.Fatalf("unmarshal normalized event: %v", err)
+		}
+		if normalized.Status != string(agentpkg.StatusClear) {
+			t.Fatalf("status = %q, want clear", normalized.Status)
+		}
+		if normalized.RawEventName != "isAlive:dead" {
+			t.Fatalf("raw_event_name = %q, want isAlive:dead", normalized.RawEventName)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected clear broadcast")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.currentStatus["work"]; ok {
+		t.Error("dead tracked session should be cleared from currentStatus")
+	}
+	if _, ok := m.subagents["work"]; ok {
+		t.Error("dead tracked session should be cleared from subagents")
+	}
+	if _, ok := m.activeWatchers["work"]; ok {
+		t.Error("dead tracked session should be cleared from activeWatchers")
+	}
+	if ev, _ := m.events.Get("work"); ev != nil {
+		t.Error("dead tracked session DB entry should be deleted")
+	}
+}
+
+func TestWatchAlive_PeriodicallyClearsDeadSession(t *testing.T) {
+	m := newTestModule(t)
+	provider := &fakeAgentProvider{typeName: "codex"}
+	m.registry.Register(provider)
+	_ = m.events.Set("work", "UserPromptSubmit", json.RawMessage(`{}`), "codex", 1)
+
+	fake := tmux.NewFakeExecutor()
+	fake.AddSession("work", "/tmp")
+	fake.SetPaneCommand("work:", "zsh")
+	m.prober = probe.New(fake)
+	m.prober.RegisterProcessNames("codex", []string{"codex"})
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.watchAlive(ctx, 10*time.Millisecond)
+
+	select {
+	case raw := <-sub.SendCh():
+		var env core.HostEvent
+		if err := json.Unmarshal(raw, &env); err != nil {
+			t.Fatalf("unmarshal host event: %v", err)
+		}
+		if env.Type != "hook" {
+			t.Fatalf("event type = %q, want hook", env.Type)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected periodic clear broadcast")
+	}
+
+	if fake.PaneCommandCallCount("work:") == 0 {
+		t.Fatal("watchAlive should poll pane liveness")
+	}
+	if ev, _ := m.events.Get("work"); ev != nil {
+		t.Fatal("periodic liveness sweep should delete dead session event")
 	}
 }
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -30,6 +30,8 @@ type Module struct {
 
 	prober *probe.Prober
 
+	cancelAliveSweep context.CancelFunc
+
 	mu             sync.Mutex
 	currentStatus  map[string]agentpkg.Status
 	subagents      map[string][]string
@@ -151,14 +153,18 @@ func (m *Module) RegisterRoutes(mux *http.ServeMux) {
 }
 
 // Start replays DB state and registers OnSubscribe callback.
-func (m *Module) Start(_ context.Context) error {
+func (m *Module) Start(ctx context.Context) error {
 	m.replayFromDB()
 
 	m.core.Events.OnSubscribe(func(sub *core.EventSubscriber) {
 		m.sendSnapshot(sub)
 		m.sendStatuslineSnapshot(sub)
-		go m.checkAliveAll(sub)
+		go m.checkAliveAll()
 	})
+
+	aliveCtx, cancel := context.WithCancel(ctx)
+	m.cancelAliveSweep = cancel
+	m.watchAlive(aliveCtx, 2*time.Second)
 
 	log.Println("[agent] hook event endpoint registered")
 	return nil
@@ -173,6 +179,9 @@ func (m *Module) getUploadDir() string {
 
 // Stop cancels all active Activity watchers and resets transient state.
 func (m *Module) Stop(_ context.Context) error {
+	if m.cancelAliveSweep != nil {
+		m.cancelAliveSweep()
+	}
 	if m.prober != nil {
 		m.prober.StopAllWatches()
 	}
@@ -180,6 +189,22 @@ func (m *Module) Stop(_ context.Context) error {
 	m.activeWatchers = make(map[string]string)
 	m.mu.Unlock()
 	return nil
+}
+
+func (m *Module) watchAlive(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.checkAliveAll()
+			}
+		}
+	}()
 }
 
 // renameSessionLocked transfers in-memory agent state (subagents, currentStatus,
@@ -305,7 +330,7 @@ func (m *Module) sendSnapshot(sub *core.EventSubscriber) {
 }
 
 // checkAliveAll checks all tracked sessions for liveness and broadcasts clear events for dead ones.
-func (m *Module) checkAliveAll(sub *core.EventSubscriber) {
+func (m *Module) checkAliveAll() {
 	if m.sessions == nil {
 		return
 	}


### PR DESCRIPTION
## Summary

- 目前 `checkAliveAll` 只在 WS `OnSubscribe` 觸發，使用者若不重連 SPA，dead agent session 的燈號會一直卡在 running/waiting 直到重連才清掉
- 新增 `watchAlive` 背景 goroutine，Module `Start(ctx)` 啟動、`Stop()` 取消；每 2 秒執行一次 `checkAliveAll`，主動偵測 dead session 並廣播 `StatusClear` + `isAlive:dead`
- `checkAliveAll` 改走 `Events.Broadcast`，讓所有活著的 subscriber 一致觀察到 clear，不再只通知觸發的單一 subscriber

## Why

承接 SubagentDots bug fix (#283) 的延伸——當時修了「觸發時的邏輯」，這輪補「觸發頻率」。Liveness 成本低（只跑 `pane_current_command` + 子行程比對），每 2 秒掃一次對 N 個 tracked session 負擔可忽略，可根治「SPA 開著不動，dead session 燈號卡死」的 UX 問題。

## Test plan

- [x] `go test ./internal/module/agent/ -run 'CheckAlive|WatchAlive' -count=1` — 4 tests pass
- [x] `go test ./internal/module/agent/ -count=1` — 全模組 pass
- [x] `go build ./...` — 整包 build 過
- [ ] 手動：啟動 daemon + SPA，tmux 內 exit codex，觀察燈號在 ≤ 2s 內清掉（不重連 SPA）
- [ ] 手動：daemon shutdown 時確認無 goroutine leak（pprof or log 觀察）