### PR TITLE
fix(spa): statusline test — stage 4 grace window for late WS events

### DIFF
--- a/spa/src/hooks/useStatuslineTest.test.ts
+++ b/spa/src/hooks/useStatuslineTest.test.ts
@@ -78,6 +78,37 @@ describe('useStatuslineTest', () => {
     expect(result.current.state.stages[5].status).toBe('skipped')
   })
 
+  it('SSE done without WS event → stage 4 fails after grace period', async () => {
+    vi.useFakeTimers()
+    const nonce = '__pdx_test_bbbb2222'
+    const body = sseBodyFrom([
+      { type: 'stage', stage: 1, name: 'Proxy spawned', status: 'passed', elapsed_ms: 5, nonce },
+      { type: 'stage', stage: 2, name: 'Proxy → daemon POST received', status: 'passed', elapsed_ms: 3, nonce },
+      { type: 'stage', stage: 3, name: 'Daemon → WS broadcast', status: 'passed', elapsed_ms: 2, nonce },
+      { type: 'done', nonce },
+    ])
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body } as unknown as Response)
+
+    const { result } = renderHook(() => useStatuslineTest('h1'))
+    let runPromise: Promise<void> = Promise.resolve()
+    await act(async () => {
+      runPromise = result.current.run()
+      // Advance past the stage-4 grace period (currently 2000ms). The SSE
+      // stream completes synchronously in microtasks; then the grace timer
+      // fires because no bus event / ccStatus entry arrived.
+      await vi.advanceTimersByTimeAsync(2100)
+      await runPromise
+    })
+
+    expect(result.current.state.stages[1].status).toBe('passed')
+    expect(result.current.state.stages[2].status).toBe('passed')
+    expect(result.current.state.stages[3].status).toBe('passed')
+    expect(result.current.state.stages[4].status).toBe('failed')
+    expect(result.current.state.stages[4].error).toMatch(/WS event not received/i)
+    expect(result.current.state.stages[5].status).toBe('skipped')
+    vi.useRealTimers()
+  })
+
   it('overall timeout marks incomplete stages failed', async () => {
     vi.useFakeTimers()
     const pendingBody = new ReadableStream<Uint8Array>({ start() { /* never writes */ } })

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -46,6 +46,14 @@ const INITIAL: StatuslineTestState = {
 // proxy subprocess is slow to spawn.
 const OVERALL_TIMEOUT_MS = 8000
 
+// After SSE completes, wait this long for the WS-delivered agent.status to
+// reach the dispatcher. SSE and WS travel over separate sockets, so the server
+// can finish signalling stage 3 + done before the broadcast message traverses
+// the WS writer pump → network → browser → dispatcher. Without this grace
+// window the bus subscriber gets torn down prematurely and stages 4/5 spin
+// forever.
+const STAGE4_GRACE_MS = 2000
+
 type StageNum = 1 | 2 | 3 | 4 | 5
 
 interface ServerStageEvent {
@@ -88,12 +96,31 @@ export function useStatuslineTest(hostId: string) {
     let unsubBus: (() => void) | null = null
     let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
 
+    // stage4Signal resolves when the bus subscriber fires (or the early-hit
+    // fallback catches a pre-subscribe store entry). The post-SSE grace block
+    // races this against STAGE4_GRACE_MS; if the timeout wins we know the WS
+    // event is missing and can fail stage 4 with a real error instead of
+    // leaving a permanent spinner.
+    let stage4Resolver: (() => void) | null = null
+    const stage4Signal = new Promise<void>((resolve) => { stage4Resolver = resolve })
+    let stage4Awaiting = false
+    const fireStage4 = () => {
+      stage4Awaiting = false
+      const r = stage4Resolver
+      stage4Resolver = null
+      r?.()
+    }
+
     const markStage = (n: StageNum, patch: StageState) => {
       if (!mountedRef.current) return
       setState((s) => ({ ...s, stages: { ...s.stages, [n]: patch } }))
     }
 
     const markFailThenSkipRest = (failedAt: StageNum, reason: string) => {
+      // Any failure short-circuits the rest of the pipeline — suppress the
+      // post-SSE stage-4 grace wait so we don't hang waiting for a bus event
+      // that will never come.
+      stage4Awaiting = false
       if (!mountedRef.current) return
       setState((s) => {
         const next = { ...s.stages }
@@ -146,6 +173,7 @@ export function useStatuslineTest(hostId: string) {
               if (useAgentStore.getState().ccStatus[key]) {
                 markStage(5, { status: 'passed' })
               }
+              fireStage4()
             })
             // If the dispatcher already fired (setCcStatus + emit) before we
             // subscribed — possible because the WS broadcast can race the SSE
@@ -156,12 +184,18 @@ export function useStatuslineTest(hostId: string) {
             if (useAgentStore.getState().ccStatus[earlyKey]) {
               markStage(4, { status: 'passed' })
               markStage(5, { status: 'passed' })
+              fireStage4()
             }
           } else if (n === 2) {
             setState((s) => s.stages[3].status === 'untested'
               ? { ...s, stages: { ...s.stages, 3: { status: 'running' } } }
               : s)
           } else if (n === 3) {
+            // Only opt in to the post-SSE grace wait if stage 4 hasn't
+            // already fired via early-hit / racing bus event — otherwise
+            // we'd block on a signal that already resolved to no-op and
+            // waste the grace window.
+            if (stage4Resolver !== null) stage4Awaiting = true
             setState((s) => {
               const next = { ...s.stages }
               if (next[4].status === 'untested') next[4] = { status: 'running' }
@@ -203,6 +237,30 @@ export function useStatuslineTest(hostId: string) {
         }
         return { ...s, stages: next }
       })
+    }
+
+    // SSE finished cleanly but stage 4 is still pending → give the WS a
+    // grace window, otherwise the spinner for stages 4/5 would hang forever.
+    if (outcome === 'done' && mountedRef.current && stage4Awaiting) {
+      let graceId: ReturnType<typeof setTimeout> | undefined
+      const graceTimeout = new Promise<'grace-timeout'>((resolve) => {
+        graceId = setTimeout(() => resolve('grace-timeout'), STAGE4_GRACE_MS)
+      })
+      const graceOutcome = await Promise.race([
+        stage4Signal.then(() => 'fired' as const),
+        graceTimeout,
+      ])
+      if (graceId !== undefined) clearTimeout(graceId)
+      if (graceOutcome === 'grace-timeout' && mountedRef.current) {
+        // Detach the bus before marking failure so a late-arriving WS event
+        // can't overwrite the failed state.
+        unsubBus?.()
+        unsubBus = null
+        markFailThenSkipRest(
+          4,
+          `WS event not received within ${STAGE4_GRACE_MS}ms after stream completed`,
+        )
+      }
     }
 
     unsubBus?.()

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -44,6 +44,10 @@ const INITIAL: StatuslineTestState = {
 // stage2 + stage3 channel waits). Giving the client budget a cushion above
 // that prevents spurious "timeout" failures on loaded systems where the
 // proxy subprocess is slow to spawn.
+//
+// Note: this bounds only the SSE round-trip (`work`). The post-SSE stage-4
+// grace wait (STAGE4_GRACE_MS) runs after `work` resolves, so the absolute
+// worst-case run duration is OVERALL_TIMEOUT_MS + STAGE4_GRACE_MS = 10s.
 const OVERALL_TIMEOUT_MS = 8000
 
 // After SSE completes, wait this long for the WS-delivered agent.status to
@@ -53,6 +57,16 @@ const OVERALL_TIMEOUT_MS = 8000
 // window the bus subscriber gets torn down prematurely and stages 4/5 spin
 // forever.
 const STAGE4_GRACE_MS = 2000
+
+// Stage 4 lifecycle:
+//   pending   → initial; stage 3 hasn't emitted yet
+//   armed     → stage 3 passed, we're now waiting for the bus event
+//   fired     → bus or early-hit resolved stage 4 (success path)
+//   cancelled → upstream failure short-circuited the pipeline
+// Keeping this as a single union (instead of a boolean pair) makes the
+// post-SSE grace guard a single equality check and prevents the two flags
+// from drifting out of sync when transitions fire in unexpected orders.
+type Stage4State = 'pending' | 'armed' | 'fired' | 'cancelled'
 
 type StageNum = 1 | 2 | 3 | 4 | 5
 
@@ -101,11 +115,14 @@ export function useStatuslineTest(hostId: string) {
     // races this against STAGE4_GRACE_MS; if the timeout wins we know the WS
     // event is missing and can fail stage 4 with a real error instead of
     // leaving a permanent spinner.
+    let stage4State: Stage4State = 'pending'
     let stage4Resolver: (() => void) | null = null
     const stage4Signal = new Promise<void>((resolve) => { stage4Resolver = resolve })
-    let stage4Awaiting = false
     const fireStage4 = () => {
-      stage4Awaiting = false
+      // Idempotent — bus subscriber + early-hit may both invoke this; only
+      // the first transition out of pending/armed actually resolves the signal.
+      if (stage4State === 'fired' || stage4State === 'cancelled') return
+      stage4State = 'fired'
       const r = stage4Resolver
       stage4Resolver = null
       r?.()
@@ -119,8 +136,9 @@ export function useStatuslineTest(hostId: string) {
     const markFailThenSkipRest = (failedAt: StageNum, reason: string) => {
       // Any failure short-circuits the rest of the pipeline — suppress the
       // post-SSE stage-4 grace wait so we don't hang waiting for a bus event
-      // that will never come.
-      stage4Awaiting = false
+      // that will never come. Don't clobber an already-fired state, though:
+      // the grace-timeout path calls this *after* the bus might have fired.
+      if (stage4State !== 'fired') stage4State = 'cancelled'
       if (!mountedRef.current) return
       setState((s) => {
         const next = { ...s.stages }
@@ -185,17 +203,21 @@ export function useStatuslineTest(hostId: string) {
               markStage(4, { status: 'passed' })
               markStage(5, { status: 'passed' })
               fireStage4()
+              // Stage 4 is done — detach immediately so a later WS event
+              // can't re-invoke the subscriber with stale state.
+              unsubBus?.()
+              unsubBus = null
             }
           } else if (n === 2) {
             setState((s) => s.stages[3].status === 'untested'
               ? { ...s, stages: { ...s.stages, 3: { status: 'running' } } }
               : s)
           } else if (n === 3) {
-            // Only opt in to the post-SSE grace wait if stage 4 hasn't
-            // already fired via early-hit / racing bus event — otherwise
-            // we'd block on a signal that already resolved to no-op and
-            // waste the grace window.
-            if (stage4Resolver !== null) stage4Awaiting = true
+            // Only arm the post-SSE grace wait if stage 4 hasn't already
+            // fired via early-hit / racing bus event — otherwise we'd block
+            // on a signal that already resolved to no-op and waste the
+            // grace window.
+            if (stage4State === 'pending') stage4State = 'armed'
             setState((s) => {
               const next = { ...s.stages }
               if (next[4].status === 'untested') next[4] = { status: 'running' }
@@ -241,7 +263,7 @@ export function useStatuslineTest(hostId: string) {
 
     // SSE finished cleanly but stage 4 is still pending → give the WS a
     // grace window, otherwise the spinner for stages 4/5 would hang forever.
-    if (outcome === 'done' && mountedRef.current && stage4Awaiting) {
+    if (outcome === 'done' && mountedRef.current && stage4State === 'armed') {
       let graceId: ReturnType<typeof setTimeout> | undefined
       const graceTimeout = new Promise<'grace-timeout'>((resolve) => {
         graceId = setTimeout(() => resolve('grace-timeout'), STAGE4_GRACE_MS)


### PR DESCRIPTION
## Summary

- Stages 4/5 of the statusline pipeline self-test spin forever when the SSE `done` signal reaches the client before the WS `agent.status` event; add a 2s grace window after SSE done so late-arriving bus events can still pass stages 4/5.
- On grace timeout, detach the bus and mark stage 4 as `failed` with a real error message ("WS event not received within 2000ms after stream completed") so the existing panel log button surfaces it instead of leaving an indefinite spinner.
- Guard the grace wait behind a `stage4Awaiting` flag, set only in the stage-3 passed branch when stage 4 hasn't already fired via early-hit or a racing bus event; `markFailThenSkipRest` clears it so upstream failures don't hang.

## Test plan

- [x] `npx vitest run src/hooks/useStatuslineTest.test.ts` — new test `SSE done without WS event → stage 4 fails after grace period` (fake timers, advance 2.1s) + existing happy-path / stage-1 failure / overall-timeout tests all green
- [x] Full SPA suite — 213 files / 2158 tests pass
- [x] `eslint src/hooks/useStatuslineTest.ts src/hooks/useStatuslineTest.test.ts` clean (pre-existing lint errors on main unrelated)
- [ ] Manual verification against the live daemon: click "Run test again" with WS connected — stages 1-5 all pass (happy path)
- [ ] Manual verification: simulate WS race loss (e.g. disable dispatcher briefly) — stage 4 shows failed with error log button after ~2s, stage 5 shows skipped