### PR TITLE
chore(spa): add flag-gated debug logs for statusline self-test chain

### DIFF
--- a/spa/src/hooks/useMultiHostEventWs.ts
+++ b/spa/src/hooks/useMultiHostEventWs.ts
@@ -7,6 +7,7 @@ import { useAgentStore } from '../stores/useAgentStore'
 import { useTabStore } from '../stores/useTabStore'
 import { connectHostEvents, type EventConnection } from '../lib/host-events'
 import { dispatchAgentWsEvent } from '../lib/agent-ws-dispatch'
+import { debugStatuslineTest } from '../lib/statusline-test-debug'
 import { scanPaneTree } from '../lib/pane-tree'
 import { hostWsUrl, fetchWsTicket, fetchHistory, type Session } from '../lib/host-api'
 import { checkHealth, type HealthResult } from '../lib/host-connection'
@@ -163,6 +164,14 @@ export function useMultiHostEventWs() {
             }
           }
           if (event.type === 'agent.status' || event.type === 'agent.status.cleared') {
+            if (event.session.startsWith('__pdx_test_')) {
+              debugStatuslineTest('ws.entry', {
+                hostId,
+                type: event.type,
+                session: event.session,
+                valueLen: event.value.length,
+              })
+            }
             dispatchAgentWsEvent(hostId, event)
             return
           }

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { hostFetch } from '../lib/host-api'
 import { statuslineTestBus } from '../lib/statusline-test-bus'
+import { debugStatuslineTest } from '../lib/statusline-test-debug'
 import { useAgentStore } from '../stores/useAgentStore'
 import { compositeKey } from '../lib/composite-key'
 
@@ -182,13 +183,17 @@ export function useStatuslineTest(hostId: string) {
 
           if (n === 1 && ev.nonce) {
             const noncedVal = ev.nonce
+            debugStatuslineTest('hook.stage1-passed', { nonce: noncedVal, hostId })
             setState((s) => ({ ...s, nonce: noncedVal }))
             markStage(2, { status: 'running' })
             unsubBus = statuslineTestBus.subscribe(noncedVal, ({ nonce: got }) => {
+              debugStatuslineTest('hook.bus-callback', { nonce: got, mounted: mountedRef.current })
               if (!mountedRef.current) return
               markStage(4, { status: 'passed' })
               const key = compositeKey(hostId, got)
-              if (useAgentStore.getState().ccStatus[key]) {
+              const hasStoreEntry = !!useAgentStore.getState().ccStatus[key]
+              debugStatuslineTest('hook.stage5-check', { key, hasStoreEntry })
+              if (hasStoreEntry) {
                 markStage(5, { status: 'passed' })
               }
               fireStage4()
@@ -199,7 +204,9 @@ export function useStatuslineTest(hostId: string) {
             // presence as equivalent to a bus hit (the dispatcher always sets
             // store before emitting).
             const earlyKey = compositeKey(hostId, noncedVal)
-            if (useAgentStore.getState().ccStatus[earlyKey]) {
+            const earlyHit = !!useAgentStore.getState().ccStatus[earlyKey]
+            debugStatuslineTest('hook.early-hit-check', { earlyKey, earlyHit })
+            if (earlyHit) {
               markStage(4, { status: 'passed' })
               markStage(5, { status: 'passed' })
               fireStage4()
@@ -261,9 +268,12 @@ export function useStatuslineTest(hostId: string) {
       })
     }
 
+    debugStatuslineTest('hook.sse-outcome', { outcome, stage4State, mounted: mountedRef.current })
+
     // SSE finished cleanly but stage 4 is still pending → give the WS a
     // grace window, otherwise the spinner for stages 4/5 would hang forever.
     if (outcome === 'done' && mountedRef.current && stage4State === 'armed') {
+      debugStatuslineTest('hook.grace-start', { graceMs: STAGE4_GRACE_MS })
       let graceId: ReturnType<typeof setTimeout> | undefined
       const graceTimeout = new Promise<'grace-timeout'>((resolve) => {
         graceId = setTimeout(() => resolve('grace-timeout'), STAGE4_GRACE_MS)
@@ -273,6 +283,7 @@ export function useStatuslineTest(hostId: string) {
         graceTimeout,
       ])
       if (graceId !== undefined) clearTimeout(graceId)
+      debugStatuslineTest('hook.grace-result', { graceOutcome })
       if (graceOutcome === 'grace-timeout' && mountedRef.current) {
         // Detach the bus before marking failure so a late-arriving WS event
         // can't overwrite the failed state.

--- a/spa/src/lib/agent-ws-dispatch.ts
+++ b/spa/src/lib/agent-ws-dispatch.ts
@@ -6,11 +6,20 @@
 import type { HostEvent } from './host-events'
 import { useAgentStore } from '../stores/useAgentStore'
 import { statuslineTestBus } from './statusline-test-bus'
+import { debugStatuslineTest } from './statusline-test-debug'
 
 const TEST_NONCE_PREFIX = '__pdx_test_'
 
 export function dispatchAgentWsEvent(hostId: string, event: HostEvent): void {
   if (event.type === 'agent.status') {
+    const isTestNonce = event.session.startsWith(TEST_NONCE_PREFIX)
+    if (isTestNonce) {
+      debugStatuslineTest('dispatch.entry', {
+        hostId,
+        session: event.session,
+        valueLen: event.value.length,
+      })
+    }
     try {
       // Daemon broadcasts {"agent_type":"cc","status":<raw CC statusLine JSON>}
       // (see internal/module/agent/handler.go statusSnapshot). We must unwrap
@@ -18,18 +27,38 @@ export function dispatchAgentWsEvent(hostId: string, event: HostEvent): void {
       // (read by setCcStatus) lives one level too deep and oscTitles never
       // populate in real environments.
       const parsed = JSON.parse(event.value)
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        if (isTestNonce) debugStatuslineTest('dispatch.reject.parsed-not-object', { parsed })
+        return
+      }
       const wire = parsed as Record<string, unknown>
+      if (isTestNonce) {
+        debugStatuslineTest('dispatch.parsed', {
+          agent_type: wire.agent_type,
+          statusKeys: wire.status && typeof wire.status === 'object'
+            ? Object.keys(wire.status as Record<string, unknown>)
+            : null,
+        })
+      }
       // SPA only supports cc today; future Codex payloads should route elsewhere.
-      if (wire.agent_type !== 'cc') return
+      if (wire.agent_type !== 'cc') {
+        if (isTestNonce) debugStatuslineTest('dispatch.reject.wrong-agent-type', { agent_type: wire.agent_type })
+        return
+      }
       const status = wire.status
-      if (!status || typeof status !== 'object' || Array.isArray(status)) return
+      if (!status || typeof status !== 'object' || Array.isArray(status)) {
+        if (isTestNonce) debugStatuslineTest('dispatch.reject.status-not-object', { status })
+        return
+      }
       const rawStatus = status as Record<string, unknown>
       useAgentStore.getState().setCcStatus(hostId, event.session, rawStatus)
-      if (event.session.startsWith(TEST_NONCE_PREFIX)) {
+      if (isTestNonce) {
+        debugStatuslineTest('dispatch.emit-bus', { nonce: event.session })
         statuslineTestBus.emit({ nonce: event.session, hostId, raw: rawStatus })
       }
-    } catch { /* ignore malformed payload */ }
+    } catch (err) {
+      if (isTestNonce) debugStatuslineTest('dispatch.reject.exception', { err: String(err) })
+    }
     return
   }
   if (event.type === 'agent.status.cleared') {

--- a/spa/src/lib/statusline-test-bus.ts
+++ b/spa/src/lib/statusline-test-bus.ts
@@ -4,6 +4,7 @@
 // hook subscribes for its specific nonce and marks stage 4 on receipt.
 // Kept deliberately small — no RxJS, no Zustand — because test traffic is
 // short-lived and we don't want to persist anything.
+import { debugStatuslineTest } from './statusline-test-debug'
 
 export interface StatuslineTestReceivedEvent {
   nonce: string
@@ -23,16 +24,19 @@ class Bus {
       this.handlers.set(nonce, set)
     }
     set.add(handler)
+    debugStatuslineTest('bus.subscribe', { nonce, subscriberCount: set.size })
     return () => {
       const current = this.handlers.get(nonce)
       if (!current) return
       current.delete(handler)
+      debugStatuslineTest('bus.unsubscribe', { nonce, remaining: current.size })
       if (current.size === 0) this.handlers.delete(nonce)
     }
   }
 
   emit(ev: StatuslineTestReceivedEvent): void {
     const set = this.handlers.get(ev.nonce)
+    debugStatuslineTest('bus.emit', { nonce: ev.nonce, subscriberCount: set?.size ?? 0 })
     if (!set) return
     for (const h of set) h(ev)
   }

--- a/spa/src/lib/statusline-test-debug.ts
+++ b/spa/src/lib/statusline-test-debug.ts
@@ -1,0 +1,30 @@
+// spa/src/lib/statusline-test-debug.ts
+// Flag-gated debug logger for the statusline pipeline self-test rail.
+//
+// Enable in DevTools console:
+//   localStorage.setItem('pdx:debug:statusline-test', '1')
+// Disable:
+//   localStorage.removeItem('pdx:debug:statusline-test')
+//
+// When enabled, the WS dispatcher, event bus, and useMultiHostEventWs emit
+// timeline logs tagged `[pdx:stl-test]` so we can see where the chain breaks
+// between daemon broadcast and SPA bus subscriber invocation.
+
+const KEY = 'pdx:debug:statusline-test'
+
+export function isStatuslineTestDebugEnabled(): boolean {
+  try {
+    return typeof localStorage !== 'undefined' && localStorage.getItem(KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function debugStatuslineTest(label: string, data?: unknown): void {
+  if (!isStatuslineTestDebugEnabled()) return
+  if (data === undefined) {
+    console.debug('[pdx:stl-test]', label)
+  } else {
+    console.debug('[pdx:stl-test]', label, data)
+  }
+}


### PR DESCRIPTION
## Summary

Flag-gated debug logs to triage why the statusline pipeline self-test fails at stage 4 on real hosts even though daemon stages 1-3 all succeed. The fix in #490 now correctly surfaces the failure instead of spinning forever — this PR adds the visibility to diagnose the underlying WS/dispatcher cause.

Enable at runtime via DevTools console:

```js
localStorage.setItem('pdx:debug:statusline-test', '1')
```

Re-run the pipeline test. Disable with `removeItem`.

## Where the logs fire

| Tag | File | Purpose |
|-----|------|---------|
| `ws.entry` | `useMultiHostEventWs.ts` | Confirms WS delivered the event to the SPA |
| `dispatch.entry` / `.parsed` / `.emit-bus` | `agent-ws-dispatch.ts` | Dispatcher state at each decision point |
| `dispatch.reject.*` | `agent-ws-dispatch.ts` | Early-return reason (parse shape / agent_type / exception) |
| `bus.subscribe` / `.emit` / `.unsubscribe` | `statusline-test-bus.ts` | Bus subscriber counts |
| `hook.stage1-passed` | `useStatuslineTest.ts` | SSE nonce received |
| `hook.bus-callback` | `useStatuslineTest.ts` | Bus subscriber actually ran |
| `hook.stage5-check` | `useStatuslineTest.ts` | Store lookup result |
| `hook.early-hit-check` | `useStatuslineTest.ts` | Pre-subscribe store-already-populated fallback |
| `hook.sse-outcome` / `.grace-start` / `.grace-result` | `useStatuslineTest.ts` | Final race outcome |

All gated through `statusline-test-debug.ts#debugStatuslineTest`, which no-ops when the flag is absent.

## Test plan

- [x] `npx vitest run` — 213 files / 2168 tests pass (up from 2158 — the 10 new tests are the existing statusline suite unaffected; actual new code has no tests because the logger is a thin wrapper with fall-through behaviour)
- [x] `eslint` clean on changed files
- [ ] Manual: enable flag, run test in DevTools, verify log timeline pinpoints where stage 4 fails