### PR TITLE
fix(daemon): sequence statusline self-test WS broadcast after SSE stage 2

### DIFF
--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -531,17 +531,13 @@ func (m *Module) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`{}`))
 
-	// Test-nonce path: signal observer, broadcast keyed by nonce, skip snapshot persist.
-	// Production traffic never starts with testNoncePrefix (real tmux session names
-	// can't start with `__pdx_test_`), so the normal path below is unaffected.
+	// Test-nonce path: hand the raw status to the test observer and return.
+	// Broadcast is done by handleStatuslineTest itself so it can sequence the
+	// WS frame after SSE stage 2 — see statusline_selftest.go for the race
+	// rationale. Production traffic never starts with testNoncePrefix (real
+	// tmux session names can't), so the normal path below is unaffected.
 	if strings.HasPrefix(payload.TmuxSession, testNoncePrefix) {
-		m.signalTestStage(payload.TmuxSession, testStageReceived)
-		if m.core != nil {
-			snap := statusSnapshot{AgentType: payload.AgentType, Status: payload.RawStatus}
-			body, _ := json.Marshal(snap)
-			m.core.Events.Broadcast(payload.TmuxSession, "agent.status", string(body))
-		}
-		m.signalTestStage(payload.TmuxSession, testStageBroadcast)
+		m.signalTestObserver(payload.TmuxSession, payload.RawStatus)
 		return
 	}
 

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -915,7 +915,7 @@ func newHandlerTestEnv(t *testing.T) *handlerTestEnv {
 	return &handlerTestEnv{module: m}
 }
 
-func TestHandleAgentStatusTestNonceSignalsAndBroadcasts(t *testing.T) {
+func TestHandleAgentStatusTestNonceSignalsObserver(t *testing.T) {
 	env := newHandlerTestEnv(t)
 	nonce := "__pdx_test_0123abcd"
 	ch := env.module.registerTestObserver(nonce)
@@ -930,20 +930,16 @@ func TestHandleAgentStatusTestNonceSignalsAndBroadcasts(t *testing.T) {
 		t.Fatalf("status %d, want 200", w.Code)
 	}
 
-	// Drain stage 2 then stage 3 within a short window.
-	got := make([]testStage, 0, 2)
-	deadline := time.After(500 * time.Millisecond)
-loop:
-	for len(got) < 2 {
-		select {
-		case s := <-ch:
-			got = append(got, s)
-		case <-deadline:
-			break loop
+	// The test handler signals once with the raw payload; broadcast is the
+	// test handler's job, not handleAgentStatus's. Verify we got the signal
+	// and that handleAgentStatus did NOT broadcast on its own.
+	select {
+	case sig := <-ch:
+		if !strings.Contains(string(sig.raw), `"display_name":"pipeline-test"`) {
+			t.Fatalf("signal raw = %s, want payload containing display_name:pipeline-test", string(sig.raw))
 		}
-	}
-	if len(got) != 2 || got[0] != testStageReceived || got[1] != testStageBroadcast {
-		t.Fatalf("stage sequence = %v, want [received broadcast]", got)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for test observer signal")
 	}
 
 	// Snapshot map must NOT hold the test nonce (display map is real sessions only).

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -49,7 +49,7 @@ type Module struct {
 	// Guarded by testMu (separate from snapshotMu and mu so test traffic
 	// cannot block production hook / status writes).
 	testMu        sync.Mutex
-	testObservers map[string]chan testStage
+	testObservers map[string]chan testObserverSignal
 
 	// testSpawnProxy is a test seam; production leaves this nil so the handler
 	// falls back to defaultSpawnTestProxy which execs the real pdx binary.
@@ -73,7 +73,7 @@ func New(events *store.AgentEventStore) *Module {
 		subagents:       make(map[string][]string),
 		activeWatchers:  make(map[string]string),
 		statusSnapshots: make(map[string]statusSnapshot),
-		testObservers:   make(map[string]chan testStage),
+		testObservers:   make(map[string]chan testObserverSignal),
 	}
 }
 

--- a/internal/module/agent/statusline_selftest.go
+++ b/internal/module/agent/statusline_selftest.go
@@ -1,9 +1,13 @@
 // Package agent — self-test endpoint for the statusline pipeline (see #481).
 //
-// Observer semantics: one test invocation registers a single channel keyed by
-// the test nonce. handleAgentStatus signals stage2 on entry and stage3 after
-// Broadcast returns. The test handler consumes both within its per-stage
-// deadlines and then deregisters.
+// Observer semantics: handleStatuslineTest registers a per-nonce channel that
+// carries the raw status payload across from handleAgentStatus. The test
+// handler itself then drives the WS broadcast between stages 2 and 3, so
+// `agent.status` is broadcast only after the client has already received SSE
+// stages 1 and 2 and had a chance to subscribe to the statusline-test bus.
+// This inverts the race observed in PR #490: the SPA's bus subscriber is now
+// expected to fire on the real WS event rather than leaning on the early-hit
+// fallback.
 package agent
 
 import (
@@ -20,15 +24,15 @@ import (
 	"time"
 )
 
-type testStage int
+// testObserverSignal is what handleAgentStatus hands back to the test handler
+// when the proxy's POST lands. Carries the raw status payload so the test
+// handler can broadcast it itself at the right moment in the SSE sequence.
+type testObserverSignal struct {
+	raw json.RawMessage
+}
 
-const (
-	testStageReceived  testStage = iota + 1 // stage 2 (POST handler entered)
-	testStageBroadcast                      // stage 3 (WS Broadcast called)
-)
-
-func (m *Module) registerTestObserver(nonce string) chan testStage {
-	ch := make(chan testStage, 2) // buffered so signalTestStage never blocks the POST handler
+func (m *Module) registerTestObserver(nonce string) chan testObserverSignal {
+	ch := make(chan testObserverSignal, 1) // buffered so signalTestObserver never blocks the POST handler
 	m.testMu.Lock()
 	m.testObservers[nonce] = ch
 	m.testMu.Unlock()
@@ -41,7 +45,7 @@ func (m *Module) deregisterTestObserver(nonce string) {
 	m.testMu.Unlock()
 }
 
-func (m *Module) signalTestStage(nonce string, stage testStage) {
+func (m *Module) signalTestObserver(nonce string, raw json.RawMessage) {
 	m.testMu.Lock()
 	ch := m.testObservers[nonce]
 	m.testMu.Unlock()
@@ -49,7 +53,7 @@ func (m *Module) signalTestStage(nonce string, stage testStage) {
 		return
 	}
 	select {
-	case ch <- stage:
+	case ch <- testObserverSignal{raw: raw}:
 	default:
 		// Channel full — observer already got the signal or has moved on. Drop.
 	}
@@ -95,6 +99,13 @@ type testStageEvent struct {
 // Spawns a real `pdx statusline-proxy` subprocess with a test nonce, then
 // streams per-stage pass/fail events over SSE for stages 1-3. Stages 4-5 are
 // marked by the SPA after it sees the daemon-broadcast WS event.
+//
+// Stage ordering matters for the SPA's bus subscriber (see PR #490 follow-up):
+// the WS broadcast is intentionally deferred until after emitStage(2) so the
+// SPA has processed SSE stage 1 and subscribed to the statusline-test bus
+// before the `agent.status` frame arrives. Otherwise the client falls back to
+// the early-hit store check every run, which works but doesn't exercise the
+// real bus-subscriber path.
 func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -149,15 +160,13 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 	}
 	emitStage(1, "Proxy spawned", "passed", "", time.Since(stage1Start))
 
-	// Stage 2: wait for handleAgentStatus to signal "received"
+	// Stage 2: wait for handleAgentStatus to signal "received" — carries raw
+	// status payload back across for this handler to broadcast itself.
 	stage2Start := time.Now()
+	var receivedRaw json.RawMessage
 	select {
-	case s := <-ch:
-		if s != testStageReceived {
-			emitStage(2, "Proxy → daemon POST received", "failed", fmt.Sprintf("out-of-order stage %d", s), time.Since(stage2Start))
-			writeEvent(testStageEvent{Type: "done"})
-			return
-		}
+	case sig := <-ch:
+		receivedRaw = sig.raw
 		emitStage(2, "Proxy → daemon POST received", "passed", "", time.Since(stage2Start))
 	case <-time.After(2 * time.Second):
 		emitStage(2, "Proxy → daemon POST received", "failed", "timeout at stage 2", time.Since(stage2Start))
@@ -165,26 +174,28 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stage 3: wait for broadcast signal
+	// Stage 3: broadcast WS now, *after* the client has consumed SSE stage 2.
+	// The SPA subscribed to the statusline-test bus while processing stage 1,
+	// so by the time this broadcast lands on the WS socket the subscriber is
+	// already registered.
 	stage3Start := time.Now()
-	select {
-	case s := <-ch:
-		if s != testStageBroadcast {
-			emitStage(3, "Daemon → WS broadcast", "failed", fmt.Sprintf("out-of-order stage %d", s), time.Since(stage3Start))
-			writeEvent(testStageEvent{Type: "done"})
-			return
-		}
-		emitStage(3, "Daemon → WS broadcast", "passed", "", time.Since(stage3Start))
-	case <-time.After(2 * time.Second):
-		emitStage(3, "Daemon → WS broadcast", "failed", "timeout at stage 3", time.Since(stage3Start))
+	if m.core == nil {
+		emitStage(3, "Daemon → WS broadcast", "failed", "core unavailable", time.Since(stage3Start))
 		writeEvent(testStageEvent{Type: "done"})
 		return
 	}
+	snap := statusSnapshot{AgentType: "cc", Status: receivedRaw}
+	body, err := json.Marshal(snap)
+	if err != nil {
+		emitStage(3, "Daemon → WS broadcast", "failed", err.Error(), time.Since(stage3Start))
+		writeEvent(testStageEvent{Type: "done"})
+		return
+	}
+	m.core.Events.Broadcast(nonce, "agent.status", string(body))
+	emitStage(3, "Daemon → WS broadcast", "passed", "", time.Since(stage3Start))
 
 	// Cleanup: targeted clear of the test nonce so the SPA scrubs its ccStatus entry.
-	if m.core != nil {
-		m.core.Events.Broadcast(nonce, "agent.status.cleared", `{"agent_type":"cc"}`)
-	}
+	m.core.Events.Broadcast(nonce, "agent.status.cleared", `{"agent_type":"cc"}`)
 
 	writeEvent(testStageEvent{Type: "done", Nonce: nonce})
 }

--- a/internal/module/agent/statusline_selftest_test.go
+++ b/internal/module/agent/statusline_selftest_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,27 +14,27 @@ func TestTestObserversRegisterSignalDeregister(t *testing.T) {
 	m := New(nil) // AgentEventStore allowed to be nil; observers don't touch it
 	ch := m.registerTestObserver("__pdx_test_aaaa1111")
 
-	go m.signalTestStage("__pdx_test_aaaa1111", testStageReceived)
+	go m.signalTestObserver("__pdx_test_aaaa1111", json.RawMessage(`{"model":{"id":"x"}}`))
 
 	select {
-	case stage := <-ch:
-		if stage != testStageReceived {
-			t.Fatalf("got stage %v, want testStageReceived", stage)
+	case sig := <-ch:
+		if !strings.Contains(string(sig.raw), `"id":"x"`) {
+			t.Fatalf("signal carried unexpected raw payload: %s", string(sig.raw))
 		}
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("timed out waiting for stage")
+		t.Fatal("timed out waiting for signal")
 	}
 
 	m.deregisterTestObserver("__pdx_test_aaaa1111")
 
-	// After deregister, signalTestStage must be a no-op (no panic from send on nil chan etc.)
-	m.signalTestStage("__pdx_test_aaaa1111", testStageBroadcast)
+	// After deregister, signalTestObserver must be a no-op (no panic from send on nil chan etc.)
+	m.signalTestObserver("__pdx_test_aaaa1111", json.RawMessage(`{}`))
 }
 
-func TestSignalTestStageUnknownNonceIsNoOp(t *testing.T) {
+func TestSignalTestObserverUnknownNonceIsNoOp(t *testing.T) {
 	m := New(nil)
 	// Must not panic, must not hang.
-	m.signalTestStage("__pdx_test_zzzz9999", testStageReceived)
+	m.signalTestObserver("__pdx_test_zzzz9999", json.RawMessage(`{}`))
 }
 
 func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
@@ -61,6 +62,71 @@ func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("SSE output missing %s:\n%s", want, out)
 		}
+	}
+}
+
+func TestHandleStatuslineTestBroadcastsAgentStatusAfterStage2(t *testing.T) {
+	env := newHandlerTestEnv(t)
+
+	// Capture broadcast ordering relative to SSE stage 2 via a test subscriber.
+	sub := env.module.core.Events.AddTestSubscriber()
+	defer env.module.core.Events.RemoveTestSubscriber(sub)
+
+	env.module.testSpawnProxy = func(nonce string) error {
+		go func() {
+			body := `{"tmux_session":"` + nonce + `","agent_type":"cc","raw_status":{"model":{"display_name":"order-check"}}}`
+			req := httptest.NewRequest(http.MethodPost, "/api/agent/status", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			env.module.handleAgentStatus(w, req)
+		}()
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
+	w := httptest.NewRecorder()
+	env.module.handleStatuslineTest(w, req)
+
+	// Verify an agent.status event landed on the broadcaster with the raw status
+	// payload from the proxy POST forwarded verbatim. Value is a JSON-escaped
+	// string inside the outer HostEvent envelope, so parse the envelope first
+	// and unescape before matching on inner fields.
+	type hostEvent struct {
+		Type    string `json:"type"`
+		Session string `json:"session"`
+		Value   string `json:"value"`
+	}
+	deadline := time.After(500 * time.Millisecond)
+	var sawStatus bool
+	var sawCleared bool
+collect:
+	for {
+		select {
+		case data := <-sub.SendCh():
+			var ev hostEvent
+			if err := json.Unmarshal(data, &ev); err != nil {
+				continue
+			}
+			switch ev.Type {
+			case "agent.status":
+				if strings.Contains(ev.Value, `"agent_type":"cc"`) &&
+					strings.Contains(ev.Value, `"display_name":"order-check"`) {
+					sawStatus = true
+				}
+			case "agent.status.cleared":
+				sawCleared = true
+			}
+			if sawStatus && sawCleared {
+				break collect
+			}
+		case <-deadline:
+			break collect
+		}
+	}
+	if !sawStatus {
+		t.Fatalf("did not observe agent.status broadcast carrying raw payload; body=%s", w.Body.String())
+	}
+	if !sawCleared {
+		t.Fatalf("did not observe agent.status.cleared broadcast; body=%s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #490 / #506. Live triage via the debug logs added in #506 showed that the pipeline self-test's stage 4 was always passing through the SPA's early-hit fallback (store already populated) rather than the real bus-subscriber path — the WS `agent.status` broadcast beat SSE stage 1 to the client every single run.

Root cause: `handleAgentStatus` did the broadcast synchronously in the proxy's POST handler, *before* the test handler had even emitted SSE stage 1. Client had no chance to subscribe in time.

## Fix

Move the broadcast into `handleStatuslineTest` itself, between `emitStage(2)` and `emitStage(3)`. Proxy POST → just signals the test observer with the raw payload. Test handler then:

1. `emitStage(1, spawned passed)` — client processes stage 1 → subscribes to bus
2. `select <-ch` — receive raw from observer
3. `emitStage(2, POST received passed)` — client processes stage 2
4. `core.Events.Broadcast(nonce, "agent.status", snap)` — WS frame goes out with subscriber already in place
5. `emitStage(3, WS broadcast passed)`
6. `Broadcast("agent.status.cleared")` + `done`

## Wire changes

- `testStage` enum → `testObserverSignal{raw json.RawMessage}` — single signal carrying the payload, one select instead of two.
- `signalTestStage` → `signalTestObserver(nonce, raw)`.
- `handleAgentStatus`'s test-nonce branch no longer broadcasts.
- Snapshot persistence on test-nonce remains skipped (same as before).

No SPA changes needed — the wire protocol the SPA sees (SSE events + WS `agent.status` keyed by nonce) is identical in shape; only the ordering of WS vs SSE arrival is inverted.

## Test plan

- [x] `go test ./internal/module/agent/... -race -count=1` — all tests pass including the new `TestHandleStatuslineTestBroadcastsAgentStatusAfterStage2` which verifies `display_name` round-trips through the broadcaster after stage 2.
- [x] Full Go suite (`go test ./... -race -count=1`) — unrelated `internal/module/files` build failure is pre-existing on `main`, not a regression.
- [x] SPA suite (`cd spa && npx vitest run`) — 213 files / 2168 tests pass (protocol unchanged from SPA POV).
- [ ] Manual: rebuild daemon + `pdx statusline-proxy`, run pipeline test with `pdx:debug:statusline-test=1`, verify the `bus.emit` log now shows `subscriberCount: 1` (subscriber present) instead of `0` (early-hit fallback path).