### PR TITLE
fix(agent): sequence self-test WS broadcast after SSE stage 2

### DIFF
--- a/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
+++ b/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
@@ -10,52 +10,59 @@
 
 ## 目的
 
-主功能與 stage-4 grace fallback 已經在 `main`。本 follow-up 只處理 daemon-side sequencing refinement：
+主功能與 stage-4 grace fallback 已經在 `main`。本 follow-up 處理 self-test race 的最小可驗證修正：
 
-- 讓 statusline self-test 的 `agent.status` WS broadcast 明確發生在 SSE stage 2 之後
-- 讓 SPA 更常走到真實的 `statuslineTestBus` subscriber 路徑，而不是仰賴 early-hit / grace fallback
+- 在 self-test 開始時先送 `init` nonce，讓 SPA 先訂閱 `statuslineTestBus`
+- 加入 ready ack，讓 daemon 在 client 宣告 ready 之後才 spawn proxy
+- 保留真實 `/api/agent/status -> agent.status broadcast` 路徑，不把 broadcast 移到 self-test handler 自己重建
 
 這是 `2026-04-19-statusline-pipeline-test.md` 的 post-plan 修正；不改 spec contract，只修正 plan 落地後暴露的 race。
 
 ## 非目標
 
 - 不重做 `stage45-timeout` 的 SPA grace-window；該修正已在 `main`
-- 不擴大到 `StatuslineTestPanel` UI 或 i18n 變更
+- 不擴大到 `StatuslineTestPanel` UI、i18n、installer、daemon rebuild 題目
 - 不處理其他 statusline / installer / daemon rebuild 題目
 
 ## 範圍
 
-只允許變更以下 5 個檔案：
+允許變更以下檔案：
 
 - `internal/module/agent/handler.go`
 - `internal/module/agent/handler_test.go`
 - `internal/module/agent/module.go`
 - `internal/module/agent/statusline_selftest.go`
 - `internal/module/agent/statusline_selftest_test.go`
+- `spa/src/hooks/useStatuslineTest.ts`
+- `spa/src/hooks/useStatuslineTest.test.ts`
 
 ## 預期行為
 
 ### 目前 main 的風險
 
-- `handleAgentStatus` 在 test nonce 路徑中直接 broadcast `agent.status`
-- SSE stage 2 與 WS event 抵達 SPA 的時序沒有被 self-test handler 額外約束
+- daemon 無法得知 SPA 是否已拿到 nonce 並完成 bus subscriber 註冊
+- 單靠 SSE / WS 兩條獨立連線的寫出順序，無法建立 client-ready barrier
 - 結果是 stage 4 可能常落到 early-hit / grace fallback，而非真實 bus callback
 
 ### Follow-up 後
 
-1. `handleAgentStatus` 在 test nonce 路徑只把 raw status payload 傳給 test observer
-2. `handleStatuslineTest` 在 SSE stage 2 成功後，自己執行 `agent.status` WS broadcast
-3. SSE stage 3 代表「daemon 已完成 WS broadcast」
-4. `agent.status.cleared` 仍由 self-test handler 在結尾送出，清掉 synthetic nonce state
+1. `handleStatuslineTest` 先送 `init` event，讓 SPA 取得 nonce
+2. SPA 用 nonce 先訂閱 `statuslineTestBus`，再呼叫 ready ack endpoint
+3. daemon 收到 ready ack 後才 spawn proxy
+4. test nonce 仍走真實 `handleAgentStatus -> agent.status broadcast` 路徑
+5. `agent.status.cleared` 仍由 self-test handler 在結尾送出，清掉 synthetic nonce state
 
 ## 驗證
 
 - `go test ./internal/module/agent -count=1`
+- `pnpm --prefix spa exec vitest run src/hooks/useStatuslineTest.test.ts src/lib/agent-ws-dispatch.test.ts`
+- `pnpm --prefix spa exec eslint src/hooks/useStatuslineTest.ts src/hooks/useStatuslineTest.test.ts`
 - 至少保留 / 補強以下行為測試：
   - observer register / signal / deregister
+  - self-test ready ack 會 gate proxy spawn
+  - test nonce 只有在 observer 存在時才走 self-test special-case；否則仍走 production path
   - self-test endpoint 正常輸出 stage 1-3 + done
-  - `handleAgentStatus` test nonce 路徑只 signal observer，不自行 broadcast
-  - self-test endpoint 會在 stage 2 之後 broadcast `agent.status` 與 `agent.status.cleared`
+  - self-test endpoint 在 client ready 後能走到真實 `agent.status` broadcast 與 cleanup
   - proxy spawn failure 路徑
 
 ## 交付方式

--- a/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
+++ b/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
@@ -51,6 +51,9 @@
 3. daemon 收到 ready ack 後才 spawn proxy
 4. test nonce 仍走真實 `handleAgentStatus -> agent.status broadcast` 路徑
 5. `agent.status.cleared` 仍由 self-test handler 在結尾送出，清掉 synthetic nonce state
+6. 新舊版相容：
+   - 新 frontend + 舊 daemon：保留 stage-1 nonce fallback
+   - 新 daemon + 舊 frontend：ready wait 逾時後回退舊行為，不在 spawn 前直接 fail
 
 ## 驗證
 

--- a/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
+++ b/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
@@ -13,7 +13,8 @@
 主功能與 stage-4 grace fallback 已經在 `main`。本 follow-up 處理 self-test race 的最小可驗證修正：
 
 - 在 self-test 開始時先送 `init` nonce，讓 SPA 先訂閱 `statuslineTestBus`
-- 加入 ready ack，讓 daemon 在 client 宣告 ready 之後才 spawn proxy
+- 新 frontend 會在 `/test` 請求裡宣告 `client_protocol=ready-v1`
+- daemon 只有在看到 `ready-v1` capability 時，才強制要求 ready ack 後再 spawn proxy
 - 保留真實 `/api/agent/status -> agent.status broadcast` 路徑，不把 broadcast 移到 self-test handler 自己重建
 
 這是 `2026-04-19-statusline-pipeline-test.md` 的 post-plan 修正；不改 spec contract，只修正 plan 落地後暴露的 race。
@@ -47,14 +48,15 @@
 ### Follow-up 後
 
 1. `handleStatuslineTest` 先送 `init` event，讓 SPA 取得 nonce
-2. SPA 用 nonce 先訂閱 `statuslineTestBus`，再呼叫 ready ack endpoint
-3. daemon 優先等待 ready ack，再 spawn proxy；若 SPA 尚未升級，逾時後回退舊行為
-4. test nonce 仍走真實 `handleAgentStatus -> agent.status broadcast` 路徑
-5. `agent.status.cleared` 仍由 self-test handler 在結尾送出，清掉 synthetic nonce state
-6. 新舊版相容：
+2. 新 frontend 在 `/test` 請求中帶 `client_protocol=ready-v1`
+3. daemon 看到 `ready-v1` 時，先送 `init`，再等待 ready ack 後才 spawn proxy
+4. 沒有 `ready-v1` capability 的舊 frontend，直接走 legacy path
+5. test nonce 仍走真實 `handleAgentStatus -> agent.status broadcast` 路徑
+6. `agent.status.cleared` 仍由 self-test handler 在結尾送出，清掉 synthetic nonce state
+7. 新舊版相容：
    - 新 frontend + 舊 daemon：保留 stage-1 nonce fallback
-   - 新 daemon + 舊 frontend：ready wait 逾時後回退舊行為，不在 spawn 前直接 fail
-   - 新 frontend + 新 daemon：走 init/ready 優先路徑，減少 bus subscriber race
+   - 新 daemon + 舊 frontend：因沒有 `ready-v1` capability，直接走 legacy path
+   - 新 frontend + 新 daemon：走 capability-based init/ready path，避免靜默退回舊 race
 
 ## 驗證
 

--- a/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
+++ b/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
@@ -48,12 +48,13 @@
 
 1. `handleStatuslineTest` 先送 `init` event，讓 SPA 取得 nonce
 2. SPA 用 nonce 先訂閱 `statuslineTestBus`，再呼叫 ready ack endpoint
-3. daemon 收到 ready ack 後才 spawn proxy
+3. daemon 優先等待 ready ack，再 spawn proxy；若 SPA 尚未升級，逾時後回退舊行為
 4. test nonce 仍走真實 `handleAgentStatus -> agent.status broadcast` 路徑
 5. `agent.status.cleared` 仍由 self-test handler 在結尾送出，清掉 synthetic nonce state
 6. 新舊版相容：
    - 新 frontend + 舊 daemon：保留 stage-1 nonce fallback
    - 新 daemon + 舊 frontend：ready wait 逾時後回退舊行為，不在 spawn 前直接 fail
+   - 新 frontend + 新 daemon：走 init/ready 優先路徑，減少 bus subscriber race
 
 ## 驗證
 

--- a/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
+++ b/docs/superpowers/plans/2026-04-21-statusline-bus-hit-followup.md
@@ -1,0 +1,65 @@
+# Statusline Pipeline Self-Test - Bus Hit Follow-up
+
+> 日期：2026-04-21
+> 狀態：In Progress
+> 基線：`origin/main` at `9e57f17f`
+> 承接計畫：`docs/superpowers/plans/2026-04-19-statusline-pipeline-test.md`
+> 相關 spec：
+> - `docs/superpowers/specs/2026-04-18-cc-statusline-integration-design.md`
+> - `docs/superpowers/specs/2026-04-18-statusline-and-daemon-rebuild-design.md`
+
+## 目的
+
+主功能與 stage-4 grace fallback 已經在 `main`。本 follow-up 只處理 daemon-side sequencing refinement：
+
+- 讓 statusline self-test 的 `agent.status` WS broadcast 明確發生在 SSE stage 2 之後
+- 讓 SPA 更常走到真實的 `statuslineTestBus` subscriber 路徑，而不是仰賴 early-hit / grace fallback
+
+這是 `2026-04-19-statusline-pipeline-test.md` 的 post-plan 修正；不改 spec contract，只修正 plan 落地後暴露的 race。
+
+## 非目標
+
+- 不重做 `stage45-timeout` 的 SPA grace-window；該修正已在 `main`
+- 不擴大到 `StatuslineTestPanel` UI 或 i18n 變更
+- 不處理其他 statusline / installer / daemon rebuild 題目
+
+## 範圍
+
+只允許變更以下 5 個檔案：
+
+- `internal/module/agent/handler.go`
+- `internal/module/agent/handler_test.go`
+- `internal/module/agent/module.go`
+- `internal/module/agent/statusline_selftest.go`
+- `internal/module/agent/statusline_selftest_test.go`
+
+## 預期行為
+
+### 目前 main 的風險
+
+- `handleAgentStatus` 在 test nonce 路徑中直接 broadcast `agent.status`
+- SSE stage 2 與 WS event 抵達 SPA 的時序沒有被 self-test handler 額外約束
+- 結果是 stage 4 可能常落到 early-hit / grace fallback，而非真實 bus callback
+
+### Follow-up 後
+
+1. `handleAgentStatus` 在 test nonce 路徑只把 raw status payload 傳給 test observer
+2. `handleStatuslineTest` 在 SSE stage 2 成功後，自己執行 `agent.status` WS broadcast
+3. SSE stage 3 代表「daemon 已完成 WS broadcast」
+4. `agent.status.cleared` 仍由 self-test handler 在結尾送出，清掉 synthetic nonce state
+
+## 驗證
+
+- `go test ./internal/module/agent -count=1`
+- 至少保留 / 補強以下行為測試：
+  - observer register / signal / deregister
+  - self-test endpoint 正常輸出 stage 1-3 + done
+  - `handleAgentStatus` test nonce 路徑只 signal observer，不自行 broadcast
+  - self-test endpoint 會在 stage 2 之後 broadcast `agent.status` 與 `agent.status.cleared`
+  - proxy spawn failure 路徑
+
+## 交付方式
+
+- 一個 focused commit
+- 後續走 PR 與兩輪 review
+- merge 後再做 bump PR（不在本 worktree 內先改 `VERSION` / `CHANGELOG.md`）

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -531,17 +531,13 @@ func (m *Module) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`{}`))
 
-	// Test-nonce path: signal observer, broadcast keyed by nonce, skip snapshot persist.
-	// Production traffic never starts with testNoncePrefix (real tmux session names
-	// can't start with `__pdx_test_`), so the normal path below is unaffected.
+	// Test-nonce path: hand the raw status to the test observer and return.
+	// Broadcast is done by handleStatuslineTest itself so it can sequence the
+	// WS frame after SSE stage 2 — see statusline_selftest.go for the race
+	// rationale. Production traffic never starts with testNoncePrefix (real
+	// tmux session names can't), so the normal path below is unaffected.
 	if strings.HasPrefix(payload.TmuxSession, testNoncePrefix) {
-		m.signalTestStage(payload.TmuxSession, testStageReceived)
-		if m.core != nil {
-			snap := statusSnapshot{AgentType: payload.AgentType, Status: payload.RawStatus}
-			body, _ := json.Marshal(snap)
-			m.core.Events.Broadcast(payload.TmuxSession, "agent.status", string(body))
-		}
-		m.signalTestStage(payload.TmuxSession, testStageBroadcast)
+		m.signalTestObserver(payload.TmuxSession, payload.RawStatus)
 		return
 	}
 

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -531,13 +531,18 @@ func (m *Module) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`{}`))
 
-	// Test-nonce path: hand the raw status to the test observer and return.
-	// Broadcast is done by handleStatuslineTest itself so it can sequence the
-	// WS frame after SSE stage 2 — see statusline_selftest.go for the race
-	// rationale. Production traffic never starts with testNoncePrefix (real
-	// tmux session names can't), so the normal path below is unaffected.
-	if strings.HasPrefix(payload.TmuxSession, testNoncePrefix) {
-		m.signalTestObserver(payload.TmuxSession, payload.RawStatus)
+	// Test-nonce path: only treat the request as self-test traffic when there is
+	// an active observer for that nonce. This prevents legitimate sessions whose
+	// names happen to start with the prefix from silently losing production
+	// status updates.
+	if strings.HasPrefix(payload.TmuxSession, testNoncePrefix) && m.hasTestObserver(payload.TmuxSession) {
+		m.signalTestStage(payload.TmuxSession, testStageReceived)
+		if m.core != nil {
+			snap := statusSnapshot{AgentType: payload.AgentType, Status: payload.RawStatus}
+			body, _ := json.Marshal(snap)
+			m.core.Events.Broadcast(payload.TmuxSession, "agent.status", string(body))
+		}
+		m.signalTestStage(payload.TmuxSession, testStageBroadcast)
 		return
 	}
 

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -915,11 +915,13 @@ func newHandlerTestEnv(t *testing.T) *handlerTestEnv {
 	return &handlerTestEnv{module: m}
 }
 
-func TestHandleAgentStatusTestNonceSignalsAndBroadcasts(t *testing.T) {
+func TestHandleAgentStatusTestNonceSignalsObserver(t *testing.T) {
 	env := newHandlerTestEnv(t)
 	nonce := "__pdx_test_0123abcd"
 	ch := env.module.registerTestObserver(nonce)
 	defer env.module.deregisterTestObserver(nonce)
+	sub := env.module.core.Events.AddTestSubscriber()
+	defer env.module.core.Events.RemoveTestSubscriber(sub)
 
 	body := `{"tmux_session":"` + nonce + `","agent_type":"cc","raw_status":{"model":{"display_name":"pipeline-test"}}}`
 	req := httptest.NewRequest(http.MethodPost, "/api/agent/status", strings.NewReader(body))
@@ -930,20 +932,22 @@ func TestHandleAgentStatusTestNonceSignalsAndBroadcasts(t *testing.T) {
 		t.Fatalf("status %d, want 200", w.Code)
 	}
 
-	// Drain stage 2 then stage 3 within a short window.
-	got := make([]testStage, 0, 2)
-	deadline := time.After(500 * time.Millisecond)
-loop:
-	for len(got) < 2 {
-		select {
-		case s := <-ch:
-			got = append(got, s)
-		case <-deadline:
-			break loop
+	// The test handler signals once with the raw payload; broadcast is the
+	// test handler's job, not handleAgentStatus's. Verify we got the signal
+	// and that handleAgentStatus did NOT broadcast on its own.
+	select {
+	case sig := <-ch:
+		if !strings.Contains(string(sig.raw), `"display_name":"pipeline-test"`) {
+			t.Fatalf("signal raw = %s, want payload containing display_name:pipeline-test", string(sig.raw))
 		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for test observer signal")
 	}
-	if len(got) != 2 || got[0] != testStageReceived || got[1] != testStageBroadcast {
-		t.Fatalf("stage sequence = %v, want [received broadcast]", got)
+
+	select {
+	case msg := <-sub.SendCh():
+		t.Fatalf("handleAgentStatus broadcast unexpectedly: %s", string(msg))
+	default:
 	}
 
 	// Snapshot map must NOT hold the test nonce (display map is real sessions only).

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -915,10 +915,10 @@ func newHandlerTestEnv(t *testing.T) *handlerTestEnv {
 	return &handlerTestEnv{module: m}
 }
 
-func TestHandleAgentStatusTestNonceSignalsObserver(t *testing.T) {
+func TestHandleAgentStatusTestNonceSignalsAndBroadcastsWhenObserverPresent(t *testing.T) {
 	env := newHandlerTestEnv(t)
 	nonce := "__pdx_test_0123abcd"
-	ch := env.module.registerTestObserver(nonce)
+	obs := env.module.registerTestObserver(nonce)
 	defer env.module.deregisterTestObserver(nonce)
 	sub := env.module.core.Events.AddTestSubscriber()
 	defer env.module.core.Events.RemoveTestSubscriber(sub)
@@ -932,22 +932,27 @@ func TestHandleAgentStatusTestNonceSignalsObserver(t *testing.T) {
 		t.Fatalf("status %d, want 200", w.Code)
 	}
 
-	// The test handler signals once with the raw payload; broadcast is the
-	// test handler's job, not handleAgentStatus's. Verify we got the signal
-	// and that handleAgentStatus did NOT broadcast on its own.
-	select {
-	case sig := <-ch:
-		if !strings.Contains(string(sig.raw), `"display_name":"pipeline-test"`) {
-			t.Fatalf("signal raw = %s, want payload containing display_name:pipeline-test", string(sig.raw))
+	got := make([]testStage, 0, 2)
+	deadline := time.After(500 * time.Millisecond)
+	for len(got) < 2 {
+		select {
+		case stage := <-obs.stages:
+			got = append(got, stage)
+		case <-deadline:
+			t.Fatalf("timed out waiting for test stages; got=%v", got)
 		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for test observer signal")
+	}
+	if got[0] != testStageReceived || got[1] != testStageBroadcast {
+		t.Fatalf("stage sequence = %v, want [received broadcast]", got)
 	}
 
 	select {
 	case msg := <-sub.SendCh():
-		t.Fatalf("handleAgentStatus broadcast unexpectedly: %s", string(msg))
-	default:
+		if !strings.Contains(string(msg), `"type":"agent.status"`) || !strings.Contains(string(msg), `"session":"`+nonce+`"`) {
+			t.Fatalf("unexpected broadcast: %s", string(msg))
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for test-nonce broadcast")
 	}
 
 	// Snapshot map must NOT hold the test nonce (display map is real sessions only).
@@ -967,6 +972,38 @@ func TestHandleAgentStatusTestNonceWithoutObserverIsSilent(t *testing.T) {
 	env.module.handleAgentStatus(w, req) // must not panic, must return 200
 	if w.Code != http.StatusOK {
 		t.Fatalf("status %d, want 200", w.Code)
+	}
+}
+
+func TestHandleAgentStatusTestPrefixWithoutObserverFallsThroughToProduction(t *testing.T) {
+	env := newHandlerTestEnv(t)
+	env.module.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-1", Name: "__pdx_test_real"}}}
+	sub := env.module.core.Events.AddTestSubscriber()
+	defer env.module.core.Events.RemoveTestSubscriber(sub)
+
+	body := `{"tmux_session":"__pdx_test_real","agent_type":"cc","raw_status":{"model":{"display_name":"prod-like"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/status", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	env.module.handleAgentStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", w.Code)
+	}
+
+	select {
+	case msg := <-sub.SendCh():
+		if !strings.Contains(string(msg), `"type":"agent.status"`) || !strings.Contains(string(msg), `"session":"code-1"`) {
+			t.Fatalf("unexpected broadcast: %s", string(msg))
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for production-path status broadcast")
+	}
+
+	env.module.snapshotMu.RLock()
+	_, persisted := env.module.statusSnapshots["code-1"]
+	env.module.snapshotMu.RUnlock()
+	if !persisted {
+		t.Fatal("expected production-path payload to persist in statusSnapshots")
 	}
 }
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -49,7 +49,7 @@ type Module struct {
 	// Guarded by testMu (separate from snapshotMu and mu so test traffic
 	// cannot block production hook / status writes).
 	testMu        sync.Mutex
-	testObservers map[string]chan testStage
+	testObservers map[string]chan testObserverSignal
 
 	// testSpawnProxy is a test seam; production leaves this nil so the handler
 	// falls back to defaultSpawnTestProxy which execs the real pdx binary.
@@ -73,7 +73,7 @@ func New(events *store.AgentEventStore) *Module {
 		subagents:       make(map[string][]string),
 		activeWatchers:  make(map[string]string),
 		statusSnapshots: make(map[string]statusSnapshot),
-		testObservers:   make(map[string]chan testStage),
+		testObservers:   make(map[string]chan testObserverSignal),
 	}
 }
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -49,7 +49,7 @@ type Module struct {
 	// Guarded by testMu (separate from snapshotMu and mu so test traffic
 	// cannot block production hook / status writes).
 	testMu        sync.Mutex
-	testObservers map[string]chan testObserverSignal
+	testObservers map[string]*testObserver
 
 	// testSpawnProxy is a test seam; production leaves this nil so the handler
 	// falls back to defaultSpawnTestProxy which execs the real pdx binary.
@@ -73,7 +73,7 @@ func New(events *store.AgentEventStore) *Module {
 		subagents:       make(map[string][]string),
 		activeWatchers:  make(map[string]string),
 		statusSnapshots: make(map[string]statusSnapshot),
-		testObservers:   make(map[string]chan testObserverSignal),
+		testObservers:   make(map[string]*testObserver),
 	}
 }
 
@@ -144,6 +144,7 @@ func (m *Module) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/agent/{agent}/statusline/status", m.handleStatuslineStatus)
 	mux.HandleFunc("POST /api/agent/{agent}/statusline/setup", m.handleStatuslineSetup)
 	mux.HandleFunc("POST /api/agent/cc/statusline/test", m.handleStatuslineTest)
+	mux.HandleFunc("POST /api/agent/cc/statusline/test/ready", m.handleStatuslineTestReady)
 	mux.HandleFunc("POST /api/agent/status", m.handleAgentStatus)
 	mux.HandleFunc("GET /api/agents/detect", m.handleDetect)
 

--- a/internal/module/agent/statusline_selftest.go
+++ b/internal/module/agent/statusline_selftest.go
@@ -250,7 +250,9 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Cleanup: targeted clear of the test nonce so the SPA scrubs its ccStatus entry.
-	m.core.Events.Broadcast(nonce, "agent.status.cleared", `{"agent_type":"cc"}`)
+	if m.core != nil {
+		m.core.Events.Broadcast(nonce, "agent.status.cleared", `{"agent_type":"cc"}`)
+	}
 
 	writeEvent(testStageEvent{Type: "done", Nonce: nonce})
 }

--- a/internal/module/agent/statusline_selftest.go
+++ b/internal/module/agent/statusline_selftest.go
@@ -37,6 +37,8 @@ type testObserver struct {
 	readyOnce sync.Once
 }
 
+const testReadyWait = 250 * time.Millisecond
+
 func (m *Module) registerTestObserver(nonce string) *testObserver {
 	obs := &testObserver{
 		stages: make(chan testStage, 2),
@@ -190,13 +192,14 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 	if !writeEvent(testStageEvent{Type: "init", Nonce: nonce}) {
 		return
 	}
-	readyStart := time.Now()
 	select {
 	case <-obs.ready:
-	case <-time.After(2 * time.Second):
-		emitStage(1, "Proxy spawned", "failed", "timeout waiting for client ready", time.Since(readyStart))
-		writeEvent(testStageEvent{Type: "done", Nonce: nonce})
-		return
+	case <-time.After(testReadyWait):
+		// Backward-compatible fallback: older SPAs do not know about the init/ready
+		// handshake yet, and dev-mode HMR can temporarily skew frontend/backend
+		// versions. In those cases keep the legacy behavior rather than failing the
+		// self-test before spawn. When the ready ack does arrive, this wait gives
+		// the client a best-effort head start before the proxy POST lands.
 	}
 
 	spawn := m.testSpawnProxy

--- a/internal/module/agent/statusline_selftest.go
+++ b/internal/module/agent/statusline_selftest.go
@@ -1,9 +1,13 @@
 // Package agent — self-test endpoint for the statusline pipeline (see #481).
 //
-// Observer semantics: one test invocation registers a single channel keyed by
-// the test nonce. handleAgentStatus signals stage2 on entry and stage3 after
-// Broadcast returns. The test handler consumes both within its per-stage
-// deadlines and then deregisters.
+// Observer semantics: handleStatuslineTest registers a per-nonce channel that
+// carries the raw status payload across from handleAgentStatus. The test
+// handler itself then drives the WS broadcast between stages 2 and 3, so
+// `agent.status` is broadcast only after the client has already received SSE
+// stages 1 and 2 and had a chance to subscribe to the statusline-test bus.
+// This inverts the race observed in PR #490: the SPA's bus subscriber is now
+// expected to fire on the real WS event rather than leaning on the early-hit
+// fallback.
 package agent
 
 import (
@@ -20,15 +24,15 @@ import (
 	"time"
 )
 
-type testStage int
+// testObserverSignal is what handleAgentStatus hands back to the test handler
+// when the proxy's POST lands. Carries the raw status payload so the test
+// handler can broadcast it itself at the right moment in the SSE sequence.
+type testObserverSignal struct {
+	raw json.RawMessage
+}
 
-const (
-	testStageReceived  testStage = iota + 1 // stage 2 (POST handler entered)
-	testStageBroadcast                      // stage 3 (WS Broadcast called)
-)
-
-func (m *Module) registerTestObserver(nonce string) chan testStage {
-	ch := make(chan testStage, 2) // buffered so signalTestStage never blocks the POST handler
+func (m *Module) registerTestObserver(nonce string) chan testObserverSignal {
+	ch := make(chan testObserverSignal, 1) // buffered so signalTestObserver never blocks the POST handler
 	m.testMu.Lock()
 	m.testObservers[nonce] = ch
 	m.testMu.Unlock()
@@ -41,7 +45,7 @@ func (m *Module) deregisterTestObserver(nonce string) {
 	m.testMu.Unlock()
 }
 
-func (m *Module) signalTestStage(nonce string, stage testStage) {
+func (m *Module) signalTestObserver(nonce string, raw json.RawMessage) {
 	m.testMu.Lock()
 	ch := m.testObservers[nonce]
 	m.testMu.Unlock()
@@ -49,7 +53,7 @@ func (m *Module) signalTestStage(nonce string, stage testStage) {
 		return
 	}
 	select {
-	case ch <- stage:
+	case ch <- testObserverSignal{raw: raw}:
 	default:
 		// Channel full — observer already got the signal or has moved on. Drop.
 	}
@@ -95,6 +99,13 @@ type testStageEvent struct {
 // Spawns a real `pdx statusline-proxy` subprocess with a test nonce, then
 // streams per-stage pass/fail events over SSE for stages 1-3. Stages 4-5 are
 // marked by the SPA after it sees the daemon-broadcast WS event.
+//
+// Stage ordering matters for the SPA's bus subscriber (see PR #490 follow-up):
+// the WS broadcast is intentionally deferred until after emitStage(2) so the
+// SPA has processed SSE stage 1 and subscribed to the statusline-test bus
+// before the `agent.status` frame arrives. Otherwise the client falls back to
+// the early-hit store check every run, which works but doesn't exercise the
+// real bus-subscriber path.
 func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -149,15 +160,13 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 	}
 	emitStage(1, "Proxy spawned", "passed", "", time.Since(stage1Start))
 
-	// Stage 2: wait for handleAgentStatus to signal "received"
+	// Stage 2: wait for handleAgentStatus to signal "received" — carries raw
+	// status payload back across for this handler to broadcast itself.
 	stage2Start := time.Now()
+	var receivedRaw json.RawMessage
 	select {
-	case s := <-ch:
-		if s != testStageReceived {
-			emitStage(2, "Proxy → daemon POST received", "failed", fmt.Sprintf("out-of-order stage %d", s), time.Since(stage2Start))
-			writeEvent(testStageEvent{Type: "done"})
-			return
-		}
+	case sig := <-ch:
+		receivedRaw = sig.raw
 		emitStage(2, "Proxy → daemon POST received", "passed", "", time.Since(stage2Start))
 	case <-time.After(2 * time.Second):
 		emitStage(2, "Proxy → daemon POST received", "failed", "timeout at stage 2", time.Since(stage2Start))
@@ -165,26 +174,28 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stage 3: wait for broadcast signal
+	// Stage 3: broadcast WS now, *after* the client has consumed SSE stage 2.
+	// The SPA subscribed to the statusline-test bus while processing stage 1,
+	// so by the time this broadcast lands on the WS socket the subscriber is
+	// already registered.
 	stage3Start := time.Now()
-	select {
-	case s := <-ch:
-		if s != testStageBroadcast {
-			emitStage(3, "Daemon → WS broadcast", "failed", fmt.Sprintf("out-of-order stage %d", s), time.Since(stage3Start))
-			writeEvent(testStageEvent{Type: "done"})
-			return
-		}
-		emitStage(3, "Daemon → WS broadcast", "passed", "", time.Since(stage3Start))
-	case <-time.After(2 * time.Second):
-		emitStage(3, "Daemon → WS broadcast", "failed", "timeout at stage 3", time.Since(stage3Start))
+	if m.core == nil {
+		emitStage(3, "Daemon → WS broadcast", "failed", "core unavailable", time.Since(stage3Start))
 		writeEvent(testStageEvent{Type: "done"})
 		return
 	}
+	snap := statusSnapshot{AgentType: "cc", Status: receivedRaw}
+	body, err := json.Marshal(snap)
+	if err != nil {
+		emitStage(3, "Daemon → WS broadcast", "failed", err.Error(), time.Since(stage3Start))
+		writeEvent(testStageEvent{Type: "done"})
+		return
+	}
+	m.core.Events.Broadcast(nonce, "agent.status", string(body))
+	emitStage(3, "Daemon → WS broadcast", "passed", "", time.Since(stage3Start))
 
 	// Cleanup: targeted clear of the test nonce so the SPA scrubs its ccStatus entry.
-	if m.core != nil {
-		m.core.Events.Broadcast(nonce, "agent.status.cleared", `{"agent_type":"cc"}`)
-	}
+	m.core.Events.Broadcast(nonce, "agent.status.cleared", `{"agent_type":"cc"}`)
 
 	writeEvent(testStageEvent{Type: "done", Nonce: nonce})
 }

--- a/internal/module/agent/statusline_selftest.go
+++ b/internal/module/agent/statusline_selftest.go
@@ -14,7 +14,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -37,7 +39,9 @@ type testObserver struct {
 	readyOnce sync.Once
 }
 
-const testReadyWait = 250 * time.Millisecond
+const testReadyClientProtocol = "ready-v1"
+
+var testReadyTimeout = 2 * time.Second
 
 func (m *Module) registerTestObserver(nonce string) *testObserver {
 	obs := &testObserver{
@@ -151,6 +155,14 @@ func (m *Module) handleStatuslineTestReady(w http.ResponseWriter, r *http.Reques
 // marked by the SPA after it sees the daemon-broadcast WS event.
 //
 func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClientProtocol string `json:"client_protocol"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
@@ -189,17 +201,17 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	if !writeEvent(testStageEvent{Type: "init", Nonce: nonce}) {
-		return
-	}
-	select {
-	case <-obs.ready:
-	case <-time.After(testReadyWait):
-		// Backward-compatible fallback: older SPAs do not know about the init/ready
-		// handshake yet, and dev-mode HMR can temporarily skew frontend/backend
-		// versions. In those cases keep the legacy behavior rather than failing the
-		// self-test before spawn. When the ready ack does arrive, this wait gives
-		// the client a best-effort head start before the proxy POST lands.
+	if req.ClientProtocol == testReadyClientProtocol {
+		if !writeEvent(testStageEvent{Type: "init", Nonce: nonce}) {
+			return
+		}
+		select {
+		case <-obs.ready:
+		case <-time.After(testReadyTimeout):
+			emitStage(1, "Proxy spawned", "failed", "timeout waiting for client ready", 0)
+			writeEvent(testStageEvent{Type: "done", Nonce: nonce})
+			return
+		}
 	}
 
 	spawn := m.testSpawnProxy

--- a/internal/module/agent/statusline_selftest.go
+++ b/internal/module/agent/statusline_selftest.go
@@ -1,13 +1,12 @@
 // Package agent — self-test endpoint for the statusline pipeline (see #481).
 //
-// Observer semantics: handleStatuslineTest registers a per-nonce channel that
-// carries the raw status payload across from handleAgentStatus. The test
-// handler itself then drives the WS broadcast between stages 2 and 3, so
-// `agent.status` is broadcast only after the client has already received SSE
-// stages 1 and 2 and had a chance to subscribe to the statusline-test bus.
-// This inverts the race observed in PR #490: the SPA's bus subscriber is now
-// expected to fire on the real WS event rather than leaning on the early-hit
-// fallback.
+// Observer semantics: one self-test invocation registers a per-nonce observer
+// with two signals:
+//   - ready: the SPA has received the nonce and subscribed to statuslineTestBus
+//   - stages: handleAgentStatus has received the POST and broadcast the WS event
+//
+// The ready handshake avoids treating SSE write order as a client-ready
+// barrier, while keeping the real `handleAgentStatus -> Broadcast` path intact.
 package agent
 
 import (
@@ -21,22 +20,32 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
-// testObserverSignal is what handleAgentStatus hands back to the test handler
-// when the proxy's POST lands. Carries the raw status payload so the test
-// handler can broadcast it itself at the right moment in the SSE sequence.
-type testObserverSignal struct {
-	raw json.RawMessage
+type testStage int
+
+const (
+	testStageReceived  testStage = iota + 1 // stage 2 (POST handler entered)
+	testStageBroadcast                      // stage 3 (WS Broadcast called)
+)
+
+type testObserver struct {
+	stages    chan testStage
+	ready     chan struct{}
+	readyOnce sync.Once
 }
 
-func (m *Module) registerTestObserver(nonce string) chan testObserverSignal {
-	ch := make(chan testObserverSignal, 1) // buffered so signalTestObserver never blocks the POST handler
+func (m *Module) registerTestObserver(nonce string) *testObserver {
+	obs := &testObserver{
+		stages: make(chan testStage, 2),
+		ready:  make(chan struct{}),
+	}
 	m.testMu.Lock()
-	m.testObservers[nonce] = ch
+	m.testObservers[nonce] = obs
 	m.testMu.Unlock()
-	return ch
+	return obs
 }
 
 func (m *Module) deregisterTestObserver(nonce string) {
@@ -45,15 +54,33 @@ func (m *Module) deregisterTestObserver(nonce string) {
 	m.testMu.Unlock()
 }
 
-func (m *Module) signalTestObserver(nonce string, raw json.RawMessage) {
+func (m *Module) hasTestObserver(nonce string) bool {
 	m.testMu.Lock()
-	ch := m.testObservers[nonce]
+	_, ok := m.testObservers[nonce]
 	m.testMu.Unlock()
-	if ch == nil {
+	return ok
+}
+
+func (m *Module) markTestObserverReady(nonce string) bool {
+	m.testMu.Lock()
+	obs := m.testObservers[nonce]
+	m.testMu.Unlock()
+	if obs == nil {
+		return false
+}
+	obs.readyOnce.Do(func() { close(obs.ready) })
+	return true
+}
+
+func (m *Module) signalTestStage(nonce string, stage testStage) {
+	m.testMu.Lock()
+	obs := m.testObservers[nonce]
+	m.testMu.Unlock()
+	if obs == nil {
 		return
 	}
 	select {
-	case ch <- testObserverSignal{raw: raw}:
+	case obs.stages <- stage:
 	default:
 		// Channel full — observer already got the signal or has moved on. Drop.
 	}
@@ -95,17 +122,32 @@ type testStageEvent struct {
 	Nonce     string `json:"nonce,omitempty"`
 }
 
+func (m *Module) handleStatuslineTestReady(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Nonce string `json:"nonce"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		return
+	}
+	if req.Nonce == "" {
+		http.Error(w, `{"error":"nonce required"}`, http.StatusBadRequest)
+		return
+	}
+	if !m.markTestObserverReady(req.Nonce) {
+		http.Error(w, `{"error":"unknown nonce"}`, http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{}`))
+}
+
 // handleStatuslineTest handles POST /api/agent/cc/statusline/test.
 // Spawns a real `pdx statusline-proxy` subprocess with a test nonce, then
 // streams per-stage pass/fail events over SSE for stages 1-3. Stages 4-5 are
 // marked by the SPA after it sees the daemon-broadcast WS event.
 //
-// Stage ordering matters for the SPA's bus subscriber (see PR #490 follow-up):
-// the WS broadcast is intentionally deferred until after emitStage(2) so the
-// SPA has processed SSE stage 1 and subscribed to the statusline-test bus
-// before the `agent.status` frame arrives. Otherwise the client falls back to
-// the early-hit store check every run, which works but doesn't exercise the
-// real bus-subscriber path.
 func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -118,7 +160,7 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Accel-Buffering", "no")
 
 	nonce := "__pdx_test_" + randomNonceHex()
-	ch := m.registerTestObserver(nonce)
+	obs := m.registerTestObserver(nonce)
 	defer m.deregisterTestObserver(nonce)
 
 	writeEvent := func(ev testStageEvent) bool {
@@ -145,6 +187,18 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	if !writeEvent(testStageEvent{Type: "init", Nonce: nonce}) {
+		return
+	}
+	readyStart := time.Now()
+	select {
+	case <-obs.ready:
+	case <-time.After(2 * time.Second):
+		emitStage(1, "Proxy spawned", "failed", "timeout waiting for client ready", time.Since(readyStart))
+		writeEvent(testStageEvent{Type: "done", Nonce: nonce})
+		return
+	}
+
 	spawn := m.testSpawnProxy
 	if spawn == nil {
 		spawn = m.defaultSpawnTestProxy
@@ -160,13 +214,15 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 	}
 	emitStage(1, "Proxy spawned", "passed", "", time.Since(stage1Start))
 
-	// Stage 2: wait for handleAgentStatus to signal "received" — carries raw
-	// status payload back across for this handler to broadcast itself.
+	// Stage 2: wait for handleAgentStatus to signal "received".
 	stage2Start := time.Now()
-	var receivedRaw json.RawMessage
 	select {
-	case sig := <-ch:
-		receivedRaw = sig.raw
+	case s := <-obs.stages:
+		if s != testStageReceived {
+			emitStage(2, "Proxy → daemon POST received", "failed", fmt.Sprintf("out-of-order stage %d", s), time.Since(stage2Start))
+			writeEvent(testStageEvent{Type: "done"})
+			return
+		}
 		emitStage(2, "Proxy → daemon POST received", "passed", "", time.Since(stage2Start))
 	case <-time.After(2 * time.Second):
 		emitStage(2, "Proxy → daemon POST received", "failed", "timeout at stage 2", time.Since(stage2Start))
@@ -174,25 +230,21 @@ func (m *Module) handleStatuslineTest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stage 3: broadcast WS now, *after* the client has consumed SSE stage 2.
-	// The SPA subscribed to the statusline-test bus while processing stage 1,
-	// so by the time this broadcast lands on the WS socket the subscriber is
-	// already registered.
+	// Stage 3: wait for the real /api/agent/status handler to broadcast.
 	stage3Start := time.Now()
-	if m.core == nil {
-		emitStage(3, "Daemon → WS broadcast", "failed", "core unavailable", time.Since(stage3Start))
+	select {
+	case s := <-obs.stages:
+		if s != testStageBroadcast {
+			emitStage(3, "Daemon → WS broadcast", "failed", fmt.Sprintf("out-of-order stage %d", s), time.Since(stage3Start))
+			writeEvent(testStageEvent{Type: "done"})
+			return
+		}
+		emitStage(3, "Daemon → WS broadcast", "passed", "", time.Since(stage3Start))
+	case <-time.After(2 * time.Second):
+		emitStage(3, "Daemon → WS broadcast", "failed", "timeout at stage 3", time.Since(stage3Start))
 		writeEvent(testStageEvent{Type: "done"})
 		return
 	}
-	snap := statusSnapshot{AgentType: "cc", Status: receivedRaw}
-	body, err := json.Marshal(snap)
-	if err != nil {
-		emitStage(3, "Daemon → WS broadcast", "failed", err.Error(), time.Since(stage3Start))
-		writeEvent(testStageEvent{Type: "done"})
-		return
-	}
-	m.core.Events.Broadcast(nonce, "agent.status", string(body))
-	emitStage(3, "Daemon → WS broadcast", "passed", "", time.Since(stage3Start))
 
 	// Cleanup: targeted clear of the test nonce so the SPA scrubs its ccStatus entry.
 	m.core.Events.Broadcast(nonce, "agent.status.cleared", `{"agent_type":"cc"}`)

--- a/internal/module/agent/statusline_selftest_test.go
+++ b/internal/module/agent/statusline_selftest_test.go
@@ -111,6 +111,9 @@ func TestSignalTestStageUnknownNonceIsNoOp(t *testing.T) {
 
 func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
 	env := newHandlerTestEnv(t) // same helper used by handler_test.go
+	prevReadyTimeout := testReadyTimeout
+	testReadyTimeout = 100 * time.Millisecond
+	defer func() { testReadyTimeout = prevReadyTimeout }()
 	env.module.testSpawnProxy = func(nonce string) error {
 		// Simulate the proxy posting to /api/agent/status with the nonce.
 		go func() {
@@ -122,7 +125,7 @@ func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
 		return nil // simulate proxy exit 0
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", strings.NewReader(`{"client_protocol":"ready-v1"}`))
 	w := newStageAwareRecorder()
 	done := make(chan struct{})
 	go func() {
@@ -150,6 +153,9 @@ func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
 
 func TestHandleStatuslineTestWaitsForReadyBeforeSpawning(t *testing.T) {
 	env := newHandlerTestEnv(t)
+	prevReadyTimeout := testReadyTimeout
+	testReadyTimeout = 100 * time.Millisecond
+	defer func() { testReadyTimeout = prevReadyTimeout }()
 	spawnCalled := make(chan struct{}, 1)
 	env.module.testSpawnProxy = func(nonce string) error {
 		spawnCalled <- struct{}{}
@@ -162,7 +168,7 @@ func TestHandleStatuslineTestWaitsForReadyBeforeSpawning(t *testing.T) {
 		return nil
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", strings.NewReader(`{"client_protocol":"ready-v1"}`))
 	w := newStageAwareRecorder()
 	done := make(chan struct{})
 	go func() {
@@ -193,7 +199,7 @@ func TestHandleStatuslineTestWaitsForReadyBeforeSpawning(t *testing.T) {
 	}
 }
 
-func TestHandleStatuslineTestFallsBackWhenReadyAckNeverArrives(t *testing.T) {
+func TestHandleStatuslineTestLegacyClientSkipsReadyGate(t *testing.T) {
 	env := newHandlerTestEnv(t)
 	spawnCalled := make(chan struct{}, 1)
 	env.module.testSpawnProxy = func(nonce string) error {
@@ -215,11 +221,9 @@ func TestHandleStatuslineTestFallsBackWhenReadyAckNeverArrives(t *testing.T) {
 		close(done)
 	}()
 
-	_ = waitForInitNonce(t, w)
 	select {
 	case <-spawnCalled:
-		// Ready ack never arrived; this should only happen after the compatibility timeout.
-	case <-time.After(testReadyWait + 300*time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		t.Fatal("timed out waiting for legacy fallback spawn")
 	}
 
@@ -234,8 +238,46 @@ func TestHandleStatuslineTestFallsBackWhenReadyAckNeverArrives(t *testing.T) {
 	}
 }
 
+func TestHandleStatuslineTestReadyClientWithoutAckFailsStage1(t *testing.T) {
+	env := newHandlerTestEnv(t)
+	prevReadyTimeout := testReadyTimeout
+	testReadyTimeout = 100 * time.Millisecond
+	defer func() { testReadyTimeout = prevReadyTimeout }()
+	spawnCalled := make(chan struct{}, 1)
+	env.module.testSpawnProxy = func(nonce string) error {
+		spawnCalled <- struct{}{}
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", strings.NewReader(`{"client_protocol":"ready-v1"}`))
+	w := newStageAwareRecorder()
+	done := make(chan struct{})
+	go func() {
+		env.module.handleStatuslineTest(w, req)
+		close(done)
+	}()
+
+	_ = waitForInitNonce(t, w)
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("timed out waiting for self-test handler completion; body=%s", w.BodyString())
+	}
+	select {
+	case <-spawnCalled:
+		t.Fatal("ready-aware client should not spawn without ack")
+	default:
+	}
+	if !strings.Contains(w.BodyString(), "timeout waiting for client ready") {
+		t.Fatalf("expected ready timeout failure; body=%s", w.BodyString())
+	}
+}
+
 func TestHandleStatuslineTestBroadcastsAgentStatusAfterClientReady(t *testing.T) {
 	env := newHandlerTestEnv(t)
+	prevReadyTimeout := testReadyTimeout
+	testReadyTimeout = 100 * time.Millisecond
+	defer func() { testReadyTimeout = prevReadyTimeout }()
 
 	sub := env.module.core.Events.AddTestSubscriber()
 	defer env.module.core.Events.RemoveTestSubscriber(sub)
@@ -250,7 +292,7 @@ func TestHandleStatuslineTestBroadcastsAgentStatusAfterClientReady(t *testing.T)
 		return nil
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", strings.NewReader(`{"client_protocol":"ready-v1"}`))
 	w := newStageAwareRecorder()
 	done := make(chan struct{})
 
@@ -325,10 +367,13 @@ collect:
 
 func TestHandleStatuslineTestReportsProxySpawnFailure(t *testing.T) {
 	env := newHandlerTestEnv(t)
+	prevReadyTimeout := testReadyTimeout
+	testReadyTimeout = 100 * time.Millisecond
+	defer func() { testReadyTimeout = prevReadyTimeout }()
 	env.module.testSpawnProxy = func(nonce string) error {
 		return fmt.Errorf("proxy spawn failed: no such executable")
 	}
-	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", strings.NewReader(`{"client_protocol":"ready-v1"}`))
 	w := newStageAwareRecorder()
 	done := make(chan struct{})
 	go func() {

--- a/internal/module/agent/statusline_selftest_test.go
+++ b/internal/module/agent/statusline_selftest_test.go
@@ -1,39 +1,82 @@
 package agent
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
+
+type stageAwareRecorder struct {
+	header     http.Header
+	buf        bytes.Buffer
+	statusCode int
+	stage2Seen chan struct{}
+	stage2Once sync.Once
+	mu         sync.Mutex
+}
+
+func newStageAwareRecorder() *stageAwareRecorder {
+	return &stageAwareRecorder{
+		header:     make(http.Header),
+		stage2Seen: make(chan struct{}),
+	}
+}
+
+func (r *stageAwareRecorder) Header() http.Header { return r.header }
+
+func (r *stageAwareRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n, err := r.buf.Write(p)
+	if strings.Contains(r.buf.String(), `"stage":2`) {
+		r.stage2Once.Do(func() { close(r.stage2Seen) })
+	}
+	return n, err
+}
+
+func (r *stageAwareRecorder) WriteHeader(statusCode int) {
+	r.statusCode = statusCode
+}
+
+func (r *stageAwareRecorder) Flush() {}
+
+func (r *stageAwareRecorder) BodyString() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.buf.String()
+}
 
 func TestTestObserversRegisterSignalDeregister(t *testing.T) {
 	m := New(nil) // AgentEventStore allowed to be nil; observers don't touch it
 	ch := m.registerTestObserver("__pdx_test_aaaa1111")
 
-	go m.signalTestStage("__pdx_test_aaaa1111", testStageReceived)
+	go m.signalTestObserver("__pdx_test_aaaa1111", json.RawMessage(`{"model":{"id":"x"}}`))
 
 	select {
-	case stage := <-ch:
-		if stage != testStageReceived {
-			t.Fatalf("got stage %v, want testStageReceived", stage)
+	case sig := <-ch:
+		if !strings.Contains(string(sig.raw), `"id":"x"`) {
+			t.Fatalf("signal carried unexpected raw payload: %s", string(sig.raw))
 		}
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("timed out waiting for stage")
+		t.Fatal("timed out waiting for signal")
 	}
 
 	m.deregisterTestObserver("__pdx_test_aaaa1111")
 
-	// After deregister, signalTestStage must be a no-op (no panic from send on nil chan etc.)
-	m.signalTestStage("__pdx_test_aaaa1111", testStageBroadcast)
+	// After deregister, signalTestObserver must be a no-op (no panic from send on nil chan etc.)
+	m.signalTestObserver("__pdx_test_aaaa1111", json.RawMessage(`{}`))
 }
 
-func TestSignalTestStageUnknownNonceIsNoOp(t *testing.T) {
+func TestSignalTestObserverUnknownNonceIsNoOp(t *testing.T) {
 	m := New(nil)
 	// Must not panic, must not hang.
-	m.signalTestStage("__pdx_test_zzzz9999", testStageReceived)
+	m.signalTestObserver("__pdx_test_zzzz9999", json.RawMessage(`{}`))
 }
 
 func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
@@ -61,6 +104,90 @@ func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("SSE output missing %s:\n%s", want, out)
 		}
+	}
+}
+
+func TestHandleStatuslineTestBroadcastsAgentStatusAfterStage2(t *testing.T) {
+	env := newHandlerTestEnv(t)
+
+	// Capture broadcast ordering relative to SSE stage 2 via a test subscriber.
+	sub := env.module.core.Events.AddTestSubscriber()
+	defer env.module.core.Events.RemoveTestSubscriber(sub)
+
+	env.module.testSpawnProxy = func(nonce string) error {
+		go func() {
+			body := `{"tmux_session":"` + nonce + `","agent_type":"cc","raw_status":{"model":{"display_name":"order-check"}}}`
+			req := httptest.NewRequest(http.MethodPost, "/api/agent/status", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			env.module.handleAgentStatus(w, req)
+		}()
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
+	w := newStageAwareRecorder()
+
+	type hostEvent struct {
+		Type    string `json:"type"`
+		Session string `json:"session"`
+		Value   string `json:"value"`
+	}
+	broadcastAfterStage2 := make(chan bool, 1)
+	go func() {
+		deadline := time.After(500 * time.Millisecond)
+		for {
+			select {
+			case data := <-sub.SendCh():
+				var ev hostEvent
+				if err := json.Unmarshal(data, &ev); err != nil {
+					continue
+				}
+				if ev.Type != "agent.status" || !strings.Contains(ev.Value, `"display_name":"order-check"`) {
+					continue
+				}
+				select {
+				case <-w.stage2Seen:
+					broadcastAfterStage2 <- true
+				default:
+					broadcastAfterStage2 <- false
+				}
+				return
+			case <-deadline:
+				broadcastAfterStage2 <- false
+				return
+			}
+		}
+	}()
+
+	env.module.handleStatuslineTest(w, req)
+	if ok := <-broadcastAfterStage2; !ok {
+		t.Fatalf("agent.status broadcast arrived before SSE stage 2 was written; body=%s", w.BodyString())
+	}
+
+	// Verify cleanup broadcast still lands after the agent.status event.
+	deadline := time.After(500 * time.Millisecond)
+	var sawCleared bool
+collect:
+	for {
+		select {
+		case data := <-sub.SendCh():
+			var ev hostEvent
+			if err := json.Unmarshal(data, &ev); err != nil {
+				continue
+			}
+			switch ev.Type {
+			case "agent.status.cleared":
+				sawCleared = true
+			}
+			if sawCleared {
+				break collect
+			}
+		case <-deadline:
+			break collect
+		}
+	}
+	if !sawCleared {
+		t.Fatalf("did not observe agent.status.cleared broadcast; body=%s", w.BodyString())
 	}
 }
 

--- a/internal/module/agent/statusline_selftest_test.go
+++ b/internal/module/agent/statusline_selftest_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -52,31 +53,60 @@ func (r *stageAwareRecorder) BodyString() string {
 	return r.buf.String()
 }
 
+func waitForInitNonce(t *testing.T, w *stageAwareRecorder) string {
+	t.Helper()
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		body := w.BodyString()
+		if strings.Contains(body, `"type":"init"`) {
+			match := regexp.MustCompile(`"nonce":"([^"]+)"`).FindStringSubmatch(body)
+			if len(match) == 2 {
+				return match[1]
+			}
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for init event; body=%s", body)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func ackReady(t *testing.T, env *handlerTestEnv, nonce string) {
+	t.Helper()
+	readyReq := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test/ready", strings.NewReader(`{"nonce":"`+nonce+`"}`))
+	readyW := httptest.NewRecorder()
+	env.module.handleStatuslineTestReady(readyW, readyReq)
+	if readyW.Code != http.StatusOK {
+		t.Fatalf("ready status %d, want 200", readyW.Code)
+	}
+}
+
 func TestTestObserversRegisterSignalDeregister(t *testing.T) {
 	m := New(nil) // AgentEventStore allowed to be nil; observers don't touch it
-	ch := m.registerTestObserver("__pdx_test_aaaa1111")
+	obs := m.registerTestObserver("__pdx_test_aaaa1111")
 
-	go m.signalTestObserver("__pdx_test_aaaa1111", json.RawMessage(`{"model":{"id":"x"}}`))
+	go m.signalTestStage("__pdx_test_aaaa1111", testStageReceived)
 
 	select {
-	case sig := <-ch:
-		if !strings.Contains(string(sig.raw), `"id":"x"`) {
-			t.Fatalf("signal carried unexpected raw payload: %s", string(sig.raw))
+	case stage := <-obs.stages:
+		if stage != testStageReceived {
+			t.Fatalf("got stage %v, want testStageReceived", stage)
 		}
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("timed out waiting for signal")
+		t.Fatal("timed out waiting for stage")
 	}
 
 	m.deregisterTestObserver("__pdx_test_aaaa1111")
 
-	// After deregister, signalTestObserver must be a no-op (no panic from send on nil chan etc.)
-	m.signalTestObserver("__pdx_test_aaaa1111", json.RawMessage(`{}`))
+	// After deregister, signalTestStage must be a no-op (no panic from send on nil chan etc.)
+	m.signalTestStage("__pdx_test_aaaa1111", testStageBroadcast)
 }
 
-func TestSignalTestObserverUnknownNonceIsNoOp(t *testing.T) {
+func TestSignalTestStageUnknownNonceIsNoOp(t *testing.T) {
 	m := New(nil)
 	// Must not panic, must not hang.
-	m.signalTestObserver("__pdx_test_zzzz9999", json.RawMessage(`{}`))
+	m.signalTestStage("__pdx_test_zzzz9999", testStageReceived)
 }
 
 func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
@@ -93,13 +123,24 @@ func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
-	w := httptest.NewRecorder()
-	env.module.handleStatuslineTest(w, req)
+	w := newStageAwareRecorder()
+	done := make(chan struct{})
+	go func() {
+		env.module.handleStatuslineTest(w, req)
+		close(done)
+	}()
+	nonce := waitForInitNonce(t, w)
+	ackReady(t, env, nonce)
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("timed out waiting for self-test handler completion; body=%s", w.BodyString())
+	}
 
 	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
 		t.Fatalf("content-type = %q, want text/event-stream", ct)
 	}
-	out := w.Body.String()
+	out := w.BodyString()
 	for _, want := range []string{`"stage":1`, `"stage":2`, `"stage":3`, `"type":"done"`} {
 		if !strings.Contains(out, want) {
 			t.Errorf("SSE output missing %s:\n%s", want, out)
@@ -107,10 +148,54 @@ func TestHandleStatuslineTestStreamsStagesAndCleans(t *testing.T) {
 	}
 }
 
-func TestHandleStatuslineTestBroadcastsAgentStatusAfterStage2(t *testing.T) {
+func TestHandleStatuslineTestWaitsForReadyBeforeSpawning(t *testing.T) {
+	env := newHandlerTestEnv(t)
+	spawnCalled := make(chan struct{}, 1)
+	env.module.testSpawnProxy = func(nonce string) error {
+		spawnCalled <- struct{}{}
+		go func() {
+			body := `{"tmux_session":"` + nonce + `","agent_type":"cc","raw_status":{"model":{"display_name":"ready-check"}}}`
+			req := httptest.NewRequest(http.MethodPost, "/api/agent/status", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			env.module.handleAgentStatus(w, req)
+		}()
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
+	w := newStageAwareRecorder()
+	done := make(chan struct{})
+	go func() {
+		env.module.handleStatuslineTest(w, req)
+		close(done)
+	}()
+
+	nonce := waitForInitNonce(t, w)
+
+	select {
+	case <-spawnCalled:
+		t.Fatal("spawned before ready ack")
+	default:
+	}
+
+	ackReady(t, env, nonce)
+
+	select {
+	case <-spawnCalled:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for spawn after ready ack")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("timed out waiting for self-test handler completion; body=%s", w.BodyString())
+	}
+}
+
+func TestHandleStatuslineTestBroadcastsAgentStatusAfterClientReady(t *testing.T) {
 	env := newHandlerTestEnv(t)
 
-	// Capture broadcast ordering relative to SSE stage 2 via a test subscriber.
 	sub := env.module.core.Events.AddTestSubscriber()
 	defer env.module.core.Events.RemoveTestSubscriber(sub)
 
@@ -126,13 +211,14 @@ func TestHandleStatuslineTestBroadcastsAgentStatusAfterStage2(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
 	w := newStageAwareRecorder()
+	done := make(chan struct{})
 
 	type hostEvent struct {
 		Type    string `json:"type"`
 		Session string `json:"session"`
 		Value   string `json:"value"`
 	}
-	broadcastAfterStage2 := make(chan bool, 1)
+	broadcastSeen := make(chan bool, 1)
 	go func() {
 		deadline := time.After(500 * time.Millisecond)
 		for {
@@ -145,23 +231,28 @@ func TestHandleStatuslineTestBroadcastsAgentStatusAfterStage2(t *testing.T) {
 				if ev.Type != "agent.status" || !strings.Contains(ev.Value, `"display_name":"order-check"`) {
 					continue
 				}
-				select {
-				case <-w.stage2Seen:
-					broadcastAfterStage2 <- true
-				default:
-					broadcastAfterStage2 <- false
-				}
+				broadcastSeen <- true
 				return
 			case <-deadline:
-				broadcastAfterStage2 <- false
+				broadcastSeen <- false
 				return
 			}
 		}
 	}()
+	go func() {
+		env.module.handleStatuslineTest(w, req)
+		close(done)
+	}()
+	nonce := waitForInitNonce(t, w)
+	ackReady(t, env, nonce)
 
-	env.module.handleStatuslineTest(w, req)
-	if ok := <-broadcastAfterStage2; !ok {
-		t.Fatalf("agent.status broadcast arrived before SSE stage 2 was written; body=%s", w.BodyString())
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("timed out waiting for self-test handler completion; body=%s", w.BodyString())
+	}
+	if ok := <-broadcastSeen; !ok {
+		t.Fatalf("did not observe agent.status broadcast after ready ack; body=%s", w.BodyString())
 	}
 
 	// Verify cleanup broadcast still lands after the agent.status event.
@@ -197,10 +288,21 @@ func TestHandleStatuslineTestReportsProxySpawnFailure(t *testing.T) {
 		return fmt.Errorf("proxy spawn failed: no such executable")
 	}
 	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
-	w := httptest.NewRecorder()
-	env.module.handleStatuslineTest(w, req)
+	w := newStageAwareRecorder()
+	done := make(chan struct{})
+	go func() {
+		env.module.handleStatuslineTest(w, req)
+		close(done)
+	}()
+	nonce := waitForInitNonce(t, w)
+	ackReady(t, env, nonce)
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("timed out waiting for self-test handler completion; body=%s", w.BodyString())
+	}
 
-	out := w.Body.String()
+	out := w.BodyString()
 	if !strings.Contains(out, `"stage":1`) || !strings.Contains(out, `"status":"failed"`) {
 		t.Errorf("expected stage1 failure, got:\n%s", out)
 	}

--- a/internal/module/agent/statusline_selftest_test.go
+++ b/internal/module/agent/statusline_selftest_test.go
@@ -193,6 +193,47 @@ func TestHandleStatuslineTestWaitsForReadyBeforeSpawning(t *testing.T) {
 	}
 }
 
+func TestHandleStatuslineTestFallsBackWhenReadyAckNeverArrives(t *testing.T) {
+	env := newHandlerTestEnv(t)
+	spawnCalled := make(chan struct{}, 1)
+	env.module.testSpawnProxy = func(nonce string) error {
+		spawnCalled <- struct{}{}
+		go func() {
+			body := `{"tmux_session":"` + nonce + `","agent_type":"cc","raw_status":{"model":{"display_name":"legacy-fallback"}}}`
+			req := httptest.NewRequest(http.MethodPost, "/api/agent/status", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			env.module.handleAgentStatus(w, req)
+		}()
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/cc/statusline/test", nil)
+	w := newStageAwareRecorder()
+	done := make(chan struct{})
+	go func() {
+		env.module.handleStatuslineTest(w, req)
+		close(done)
+	}()
+
+	_ = waitForInitNonce(t, w)
+	select {
+	case <-spawnCalled:
+		// Ready ack never arrived; this should only happen after the compatibility timeout.
+	case <-time.After(testReadyWait + 300*time.Millisecond):
+		t.Fatal("timed out waiting for legacy fallback spawn")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("timed out waiting for self-test handler completion; body=%s", w.BodyString())
+	}
+
+	if strings.Contains(w.BodyString(), "timeout waiting for client ready") {
+		t.Fatalf("legacy fallback should not fail the self-test before spawn; body=%s", w.BodyString())
+	}
+}
+
 func TestHandleStatuslineTestBroadcastsAgentStatusAfterClientReady(t *testing.T) {
 	env := newHandlerTestEnv(t)
 

--- a/spa/src/hooks/useStatuslineTest.test.ts
+++ b/spa/src/hooks/useStatuslineTest.test.ts
@@ -36,12 +36,14 @@ describe('useStatuslineTest', () => {
   it('happy path: all 5 stages pass', async () => {
     const nonce = '__pdx_test_aaaa1111'
     const body = sseBodyFrom([
+      { type: 'init', nonce },
       { type: 'stage', stage: 1, name: 'Proxy spawned', status: 'passed', elapsed_ms: 12, nonce },
       { type: 'stage', stage: 2, name: 'Proxy → daemon POST received', status: 'passed', elapsed_ms: 8, nonce },
       { type: 'stage', stage: 3, name: 'Daemon → WS broadcast', status: 'passed', elapsed_ms: 3, nonce },
       { type: 'done', nonce },
     ])
     mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body } as unknown as Response)
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 } as unknown as Response)
 
     const { result } = renderHook(() => useStatuslineTest('h1'))
     await act(async () => {
@@ -60,14 +62,22 @@ describe('useStatuslineTest', () => {
     expect(result.current.state.stages[4].status).toBe('passed')
     expect(result.current.state.stages[5].status).toBe('passed')
     expect(result.current.state.lastRunAt).not.toBeNull()
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      'h1',
+      '/api/agent/cc/statusline/test/ready',
+      expect.objectContaining({ method: 'POST' }),
+    )
   })
 
   it('stage 1 failure marks later stages skipped', async () => {
     const body = sseBodyFrom([
+      { type: 'init', nonce: '__pdx_test_fail1111' },
       { type: 'stage', stage: 1, status: 'failed', error: 'proxy spawn failed: no such executable', elapsed_ms: 5 },
       { type: 'done' },
     ])
     mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body } as unknown as Response)
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 } as unknown as Response)
 
     const { result } = renderHook(() => useStatuslineTest('h1'))
     await act(async () => { await result.current.run() })
@@ -82,12 +92,14 @@ describe('useStatuslineTest', () => {
     vi.useFakeTimers()
     const nonce = '__pdx_test_bbbb2222'
     const body = sseBodyFrom([
+      { type: 'init', nonce },
       { type: 'stage', stage: 1, name: 'Proxy spawned', status: 'passed', elapsed_ms: 5, nonce },
       { type: 'stage', stage: 2, name: 'Proxy → daemon POST received', status: 'passed', elapsed_ms: 3, nonce },
       { type: 'stage', stage: 3, name: 'Daemon → WS broadcast', status: 'passed', elapsed_ms: 2, nonce },
       { type: 'done', nonce },
     ])
     mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body } as unknown as Response)
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 } as unknown as Response)
 
     const { result } = renderHook(() => useStatuslineTest('h1'))
     let runPromise: Promise<void> = Promise.resolve()
@@ -107,6 +119,20 @@ describe('useStatuslineTest', () => {
     expect(result.current.state.stages[4].error).toMatch(/WS event not received/i)
     expect(result.current.state.stages[5].status).toBe('skipped')
     vi.useRealTimers()
+  })
+
+  it('ready ack failure fails stage 1 before proxy spawn', async () => {
+    const nonce = '__pdx_test_readyfail'
+    const body = sseBodyFrom([{ type: 'init', nonce }])
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body } as unknown as Response)
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 } as unknown as Response)
+
+    const { result } = renderHook(() => useStatuslineTest('h1'))
+    await act(async () => { await result.current.run() })
+
+    expect(result.current.state.stages[1].status).toBe('failed')
+    expect(result.current.state.stages[1].error).toMatch(/ready/i)
+    expect(result.current.state.stages[2].status).toBe('skipped')
   })
 
   it('overall timeout marks incomplete stages failed', async () => {

--- a/spa/src/hooks/useStatuslineTest.test.ts
+++ b/spa/src/hooks/useStatuslineTest.test.ts
@@ -212,8 +212,8 @@ describe('useStatuslineTest', () => {
     let runPromise: Promise<void> = Promise.resolve()
     await act(async () => {
       runPromise = result.current.run()
-      // Advance past OVERALL_TIMEOUT_MS (currently 8000ms).
-      await vi.advanceTimersByTimeAsync(8100)
+      // Advance past OVERALL_TIMEOUT_MS (currently 10000ms).
+      await vi.advanceTimersByTimeAsync(10100)
       await runPromise
     })
     expect(result.current.state.stages[1].status).toBe('failed')

--- a/spa/src/hooks/useStatuslineTest.test.ts
+++ b/spa/src/hooks/useStatuslineTest.test.ts
@@ -88,6 +88,31 @@ describe('useStatuslineTest', () => {
     expect(result.current.state.stages[5].status).toBe('skipped')
   })
 
+  it('falls back to stage-1 nonce when daemon does not send init', async () => {
+    const nonce = '__pdx_test_legacy111'
+    const body = sseBodyFrom([
+      { type: 'stage', stage: 1, name: 'Proxy spawned', status: 'passed', elapsed_ms: 12, nonce },
+      { type: 'stage', stage: 2, name: 'Proxy → daemon POST received', status: 'passed', elapsed_ms: 8, nonce },
+      { type: 'stage', stage: 3, name: 'Daemon → WS broadcast', status: 'passed', elapsed_ms: 3, nonce },
+      { type: 'done', nonce },
+    ])
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body } as unknown as Response)
+
+    const { result } = renderHook(() => useStatuslineTest('h1'))
+    await act(async () => {
+      const p = result.current.run()
+      queueMicrotask(() => {
+        useAgentStore.getState().setCcStatus('h1', nonce, { model: { id: 'x' } })
+        statuslineTestBus.emit({ nonce, hostId: 'h1', raw: { model: { id: 'x' } } })
+      })
+      await p
+    })
+
+    expect(result.current.state.stages[4].status).toBe('passed')
+    expect(result.current.state.stages[5].status).toBe('passed')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
   it('SSE done without WS event → stage 4 fails after grace period', async () => {
     vi.useFakeTimers()
     const nonce = '__pdx_test_bbbb2222'

--- a/spa/src/hooks/useStatuslineTest.test.ts
+++ b/spa/src/hooks/useStatuslineTest.test.ts
@@ -113,6 +113,36 @@ describe('useStatuslineTest', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 
+  it('ignores bus events for the same nonce from another host', async () => {
+    vi.useFakeTimers()
+    const nonce = '__pdx_test_crosshost'
+    const body = sseBodyFrom([
+      { type: 'init', nonce },
+      { type: 'stage', stage: 1, name: 'Proxy spawned', status: 'passed', elapsed_ms: 5, nonce },
+      { type: 'stage', stage: 2, name: 'Proxy → daemon POST received', status: 'passed', elapsed_ms: 3, nonce },
+      { type: 'stage', stage: 3, name: 'Daemon → WS broadcast', status: 'passed', elapsed_ms: 2, nonce },
+      { type: 'done', nonce },
+    ])
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body } as unknown as Response)
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 } as unknown as Response)
+
+    const { result } = renderHook(() => useStatuslineTest('h1'))
+    let runPromise: Promise<void> = Promise.resolve()
+    await act(async () => {
+      runPromise = result.current.run()
+      queueMicrotask(() => {
+        useAgentStore.getState().setCcStatus('h2', nonce, { model: { id: 'other-host' } })
+        statuslineTestBus.emit({ nonce, hostId: 'h2', raw: { model: { id: 'other-host' } } })
+      })
+      await vi.advanceTimersByTimeAsync(2100)
+      await runPromise
+    })
+
+    expect(result.current.state.stages[4].status).toBe('failed')
+    expect(result.current.state.stages[5].status).toBe('skipped')
+    vi.useRealTimers()
+  })
+
   it('SSE done without WS event → stage 4 fails after grace period', async () => {
     vi.useFakeTimers()
     const nonce = '__pdx_test_bbbb2222'

--- a/spa/src/hooks/useStatuslineTest.test.ts
+++ b/spa/src/hooks/useStatuslineTest.test.ts
@@ -146,18 +146,31 @@ describe('useStatuslineTest', () => {
     vi.useRealTimers()
   })
 
-  it('ready ack failure fails stage 1 before proxy spawn', async () => {
+  it('ready ack failure falls back to the legacy flow', async () => {
     const nonce = '__pdx_test_readyfail'
-    const body = sseBodyFrom([{ type: 'init', nonce }])
+    const body = sseBodyFrom([
+      { type: 'init', nonce },
+      { type: 'stage', stage: 1, name: 'Proxy spawned', status: 'passed', elapsed_ms: 5, nonce },
+      { type: 'stage', stage: 2, name: 'Proxy → daemon POST received', status: 'passed', elapsed_ms: 3, nonce },
+      { type: 'stage', stage: 3, name: 'Daemon → WS broadcast', status: 'passed', elapsed_ms: 2, nonce },
+      { type: 'done', nonce },
+    ])
     mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body } as unknown as Response)
     mockFetch.mockResolvedValueOnce({ ok: false, status: 500 } as unknown as Response)
 
     const { result } = renderHook(() => useStatuslineTest('h1'))
-    await act(async () => { await result.current.run() })
+    await act(async () => {
+      const p = result.current.run()
+      queueMicrotask(() => {
+        useAgentStore.getState().setCcStatus('h1', nonce, { model: { id: 'x' } })
+        statuslineTestBus.emit({ nonce, hostId: 'h1', raw: { model: { id: 'x' } } })
+      })
+      await p
+    })
 
-    expect(result.current.state.stages[1].status).toBe('failed')
-    expect(result.current.state.stages[1].error).toMatch(/ready/i)
-    expect(result.current.state.stages[2].status).toBe('skipped')
+    expect(result.current.state.stages[1].status).toBe('passed')
+    expect(result.current.state.stages[4].status).toBe('passed')
+    expect(result.current.state.stages[5].status).toBe('passed')
   })
 
   it('overall timeout marks incomplete stages failed', async () => {

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -179,21 +179,22 @@ export function useStatuslineTest(hostId: string) {
         unsubBus = null
       }
       if (!sendReadyAck) return true
-      try {
-        const ready = await hostFetch(hostId, '/api/agent/cc/statusline/test/ready', {
+      hostFetch(hostId, '/api/agent/cc/statusline/test/ready', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ nonce: noncedVal }),
         })
+        .then((ready) => {
         if (!ready.ok) {
           debugStatuslineTest('hook.ready-ack-fallback', { nonce: noncedVal, status: ready.status })
         }
-      } catch (err) {
-        debugStatuslineTest('hook.ready-ack-fallback', {
-          nonce: noncedVal,
-          error: err instanceof Error ? err.message : String(err),
         })
-      }
+        .catch((err) => {
+          debugStatuslineTest('hook.ready-ack-fallback', {
+            nonce: noncedVal,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        })
       return true
     }
 

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -200,7 +200,11 @@ export function useStatuslineTest(hostId: string) {
     }
 
     const work = (async () => {
-      const res = await hostFetch(hostId, '/api/agent/cc/statusline/test', { method: 'POST' })
+      const res = await hostFetch(hostId, '/api/agent/cc/statusline/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ client_protocol: 'ready-v1' }),
+      })
       if (!res.ok || !res.body) {
         markFailThenSkipRest(1, `HTTP ${res.status}`)
         return

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -179,14 +179,20 @@ export function useStatuslineTest(hostId: string) {
         unsubBus = null
       }
       if (!sendReadyAck) return true
-      const ready = await hostFetch(hostId, '/api/agent/cc/statusline/test/ready', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ nonce: noncedVal }),
-      })
-      if (!ready.ok) {
-        markFailThenSkipRest(1, `ready ack failed: HTTP ${ready.status}`)
-        return false
+      try {
+        const ready = await hostFetch(hostId, '/api/agent/cc/statusline/test/ready', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ nonce: noncedVal }),
+        })
+        if (!ready.ok) {
+          debugStatuslineTest('hook.ready-ack-fallback', { nonce: noncedVal, status: ready.status })
+        }
+      } catch (err) {
+        debugStatuslineTest('hook.ready-ack-fallback', {
+          nonce: noncedVal,
+          error: err instanceof Error ? err.message : String(err),
+        })
       }
       return true
     }

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -156,8 +156,9 @@ export function useStatuslineTest(hostId: string) {
       activeNonce = noncedVal
       debugStatuslineTest('hook.stage1-passed', { nonce: noncedVal, hostId, phase: sendReadyAck ? 'init' : 'stage1-fallback' })
       setState((s) => ({ ...s, nonce: noncedVal }))
-      unsubBus = statuslineTestBus.subscribe(noncedVal, ({ nonce: got }) => {
-        debugStatuslineTest('hook.bus-callback', { nonce: got, mounted: mountedRef.current })
+      unsubBus = statuslineTestBus.subscribe(noncedVal, ({ nonce: got, hostId: eventHostId }) => {
+        debugStatuslineTest('hook.bus-callback', { nonce: got, eventHostId, mounted: mountedRef.current })
+        if (eventHostId !== hostId) return
         if (!mountedRef.current) return
         markStage(4, { status: 'passed' })
         const key = compositeKey(hostId, got)

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -110,6 +110,7 @@ export function useStatuslineTest(hostId: string) {
 
     let unsubBus: (() => void) | null = null
     let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
+    let activeNonce: string | null = null
 
     // stage4Signal resolves when the bus subscriber fires (or the early-hit
     // fallback catches a pre-subscribe store entry). The post-SSE grace block
@@ -151,6 +152,45 @@ export function useStatuslineTest(hostId: string) {
       })
     }
 
+    const armNonce = async (noncedVal: string, sendReadyAck: boolean) => {
+      activeNonce = noncedVal
+      debugStatuslineTest('hook.stage1-passed', { nonce: noncedVal, hostId, phase: sendReadyAck ? 'init' : 'stage1-fallback' })
+      setState((s) => ({ ...s, nonce: noncedVal }))
+      unsubBus = statuslineTestBus.subscribe(noncedVal, ({ nonce: got }) => {
+        debugStatuslineTest('hook.bus-callback', { nonce: got, mounted: mountedRef.current })
+        if (!mountedRef.current) return
+        markStage(4, { status: 'passed' })
+        const key = compositeKey(hostId, got)
+        const hasStoreEntry = !!useAgentStore.getState().ccStatus[key]
+        debugStatuslineTest('hook.stage5-check', { key, hasStoreEntry })
+        if (hasStoreEntry) {
+          markStage(5, { status: 'passed' })
+        }
+        fireStage4()
+      })
+      const earlyKey = compositeKey(hostId, noncedVal)
+      const earlyHit = !!useAgentStore.getState().ccStatus[earlyKey]
+      debugStatuslineTest('hook.early-hit-check', { earlyKey, earlyHit })
+      if (earlyHit) {
+        markStage(4, { status: 'passed' })
+        markStage(5, { status: 'passed' })
+        fireStage4()
+        unsubBus?.()
+        unsubBus = null
+      }
+      if (!sendReadyAck) return true
+      const ready = await hostFetch(hostId, '/api/agent/cc/statusline/test/ready', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce: noncedVal }),
+      })
+      if (!ready.ok) {
+        markFailThenSkipRest(1, `ready ack failed: HTTP ${ready.status}`)
+        return false
+      }
+      return true
+    }
+
     const work = (async () => {
       const res = await hostFetch(hostId, '/api/agent/cc/statusline/test', { method: 'POST' })
       if (!res.ok || !res.body) {
@@ -172,38 +212,8 @@ export function useStatuslineTest(hostId: string) {
           let ev: ServerStageEvent
           try { ev = JSON.parse(dataLine.slice(6)) } catch { continue }
           if (ev.type === 'init' && ev.nonce) {
-            const noncedVal = ev.nonce
-            debugStatuslineTest('hook.stage1-passed', { nonce: noncedVal, hostId, phase: 'init' })
-            setState((s) => ({ ...s, nonce: noncedVal }))
-            unsubBus = statuslineTestBus.subscribe(noncedVal, ({ nonce: got }) => {
-              debugStatuslineTest('hook.bus-callback', { nonce: got, mounted: mountedRef.current })
-              if (!mountedRef.current) return
-              markStage(4, { status: 'passed' })
-              const key = compositeKey(hostId, got)
-              const hasStoreEntry = !!useAgentStore.getState().ccStatus[key]
-              debugStatuslineTest('hook.stage5-check', { key, hasStoreEntry })
-              if (hasStoreEntry) {
-                markStage(5, { status: 'passed' })
-              }
-              fireStage4()
-            })
-            const earlyKey = compositeKey(hostId, noncedVal)
-            const earlyHit = !!useAgentStore.getState().ccStatus[earlyKey]
-            debugStatuslineTest('hook.early-hit-check', { earlyKey, earlyHit })
-            if (earlyHit) {
-              markStage(4, { status: 'passed' })
-              markStage(5, { status: 'passed' })
-              fireStage4()
-              unsubBus?.()
-              unsubBus = null
-            }
-            const ready = await hostFetch(hostId, '/api/agent/cc/statusline/test/ready', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ nonce: noncedVal }),
-            })
-            if (!ready.ok) {
-              markFailThenSkipRest(1, `ready ack failed: HTTP ${ready.status}`)
+            const ok = await armNonce(ev.nonce, true)
+            if (!ok) {
               return
             }
             continue
@@ -219,9 +229,9 @@ export function useStatuslineTest(hostId: string) {
           markStage(n, { status: 'passed', elapsedMs: ev.elapsed_ms })
 
           if (n === 1) {
-            if (ev.nonce) {
-              debugStatuslineTest('hook.stage1-passed', { nonce: ev.nonce, hostId })
-              setState((s) => ({ ...s, nonce: ev.nonce }))
+            if (ev.nonce && !activeNonce) {
+              const ok = await armNonce(ev.nonce, false)
+              if (!ok) return
             }
             markStage(2, { status: 'running' })
           } else if (n === 2) {

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -41,15 +41,14 @@ const INITIAL: StatuslineTestState = {
   nonce: null,
 }
 
-// Server per-stage deadline is 2s × 3 = 6s worst case (stage1 exec timeout +
-// stage2 + stage3 channel waits). Giving the client budget a cushion above
-// that prevents spurious "timeout" failures on loaded systems where the
-// proxy subprocess is slow to spawn.
+// Server worst case on the ready-v1 path is 2s ready wait + 2s stage1 spawn +
+// 2s stage2 + 2s stage3 = 8s before the SSE stream completes. Give the client
+// budget a cushion above that to avoid false timeouts on loaded systems.
 //
 // Note: this bounds only the SSE round-trip (`work`). The post-SSE stage-4
 // grace wait (STAGE4_GRACE_MS) runs after `work` resolves, so the absolute
-// worst-case run duration is OVERALL_TIMEOUT_MS + STAGE4_GRACE_MS = 10s.
-const OVERALL_TIMEOUT_MS = 8000
+// worst-case run duration is OVERALL_TIMEOUT_MS + STAGE4_GRACE_MS = 12s.
+const OVERALL_TIMEOUT_MS = 10000
 
 // After SSE completes, wait this long for the WS-delivered agent.status to
 // reach the dispatcher. SSE and WS travel over separate sockets, so the server

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -72,7 +72,7 @@ type Stage4State = 'pending' | 'armed' | 'fired' | 'cancelled'
 type StageNum = 1 | 2 | 3 | 4 | 5
 
 interface ServerStageEvent {
-  type: 'stage' | 'done'
+  type: 'init' | 'stage' | 'done'
   stage?: number
   status?: 'passed' | 'failed'
   elapsed_ms?: number
@@ -171,21 +171,10 @@ export function useStatuslineTest(hostId: string) {
           if (!dataLine) continue
           let ev: ServerStageEvent
           try { ev = JSON.parse(dataLine.slice(6)) } catch { continue }
-          if (ev.type === 'done') return
-          if (ev.type !== 'stage' || !ev.stage || ev.stage < 1 || ev.stage > 3) continue
-
-          const n = ev.stage as 1 | 2 | 3
-          if (ev.status === 'failed') {
-            markFailThenSkipRest(n, ev.error ?? 'stage failed')
-            return
-          }
-          markStage(n, { status: 'passed', elapsedMs: ev.elapsed_ms })
-
-          if (n === 1 && ev.nonce) {
+          if (ev.type === 'init' && ev.nonce) {
             const noncedVal = ev.nonce
-            debugStatuslineTest('hook.stage1-passed', { nonce: noncedVal, hostId })
+            debugStatuslineTest('hook.stage1-passed', { nonce: noncedVal, hostId, phase: 'init' })
             setState((s) => ({ ...s, nonce: noncedVal }))
-            markStage(2, { status: 'running' })
             unsubBus = statuslineTestBus.subscribe(noncedVal, ({ nonce: got }) => {
               debugStatuslineTest('hook.bus-callback', { nonce: got, mounted: mountedRef.current })
               if (!mountedRef.current) return
@@ -198,11 +187,6 @@ export function useStatuslineTest(hostId: string) {
               }
               fireStage4()
             })
-            // If the dispatcher already fired (setCcStatus + emit) before we
-            // subscribed — possible because the WS broadcast can race the SSE
-            // stream — the store will already have the entry. Treat store
-            // presence as equivalent to a bus hit (the dispatcher always sets
-            // store before emitting).
             const earlyKey = compositeKey(hostId, noncedVal)
             const earlyHit = !!useAgentStore.getState().ccStatus[earlyKey]
             debugStatuslineTest('hook.early-hit-check', { earlyKey, earlyHit })
@@ -210,11 +194,36 @@ export function useStatuslineTest(hostId: string) {
               markStage(4, { status: 'passed' })
               markStage(5, { status: 'passed' })
               fireStage4()
-              // Stage 4 is done — detach immediately so a later WS event
-              // can't re-invoke the subscriber with stale state.
               unsubBus?.()
               unsubBus = null
             }
+            const ready = await hostFetch(hostId, '/api/agent/cc/statusline/test/ready', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ nonce: noncedVal }),
+            })
+            if (!ready.ok) {
+              markFailThenSkipRest(1, `ready ack failed: HTTP ${ready.status}`)
+              return
+            }
+            continue
+          }
+          if (ev.type === 'done') return
+          if (ev.type !== 'stage' || !ev.stage || ev.stage < 1 || ev.stage > 3) continue
+
+          const n = ev.stage as 1 | 2 | 3
+          if (ev.status === 'failed') {
+            markFailThenSkipRest(n, ev.error ?? 'stage failed')
+            return
+          }
+          markStage(n, { status: 'passed', elapsedMs: ev.elapsed_ms })
+
+          if (n === 1) {
+            if (ev.nonce) {
+              debugStatuslineTest('hook.stage1-passed', { nonce: ev.nonce, hostId })
+              setState((s) => ({ ...s, nonce: ev.nonce }))
+            }
+            markStage(2, { status: 'running' })
           } else if (n === 2) {
             setState((s) => s.stages[3].status === 'untested'
               ? { ...s, stages: { ...s.stages, 3: { status: 'running' } } }


### PR DESCRIPTION
## Summary
- move test-nonce `agent.status` broadcast out of `handleAgentStatus` so the self-test handler can emit SSE stage 2 before publishing WS status
- add regression coverage that the test nonce path only signals the observer in `handleAgentStatus` and that `agent.status` is broadcast after stage 2 is written
- record the focused follow-up scope in a dedicated plan file based on the original statusline pipeline self-test plan

## Verification
- `go test ./internal/module/agent -run 'TestHandleAgentStatusTestNonceSignalsObserver|TestHandleStatuslineTest' -count=1`
- `go test ./internal/module/agent -count=1`
