### PR TITLE
fix(spa): align sync history settings UI

### DIFF
--- a/spa/src/features/settings/sections/sync-history/HistoryList.tsx
+++ b/spa/src/features/settings/sections/sync-history/HistoryList.tsx
@@ -17,7 +17,7 @@ export function HistoryList(props: HistoryListProps) {
 
   if (props.loading) {
     return (
-      <div className="flex items-center justify-center p-6" data-testid="loading">
+      <div className="flex min-h-[24rem] items-center justify-center p-6" data-testid="loading">
         <CircleNotch className="animate-spin text-text-muted" size={18} />
       </div>
     )
@@ -25,27 +25,35 @@ export function HistoryList(props: HistoryListProps) {
 
   if (props.error) {
     return (
-      <div className="p-6 text-sm text-text-muted">
-        {t('settings.sync.history.error.loadList')}
-        {props.onRetry && (
-          <button type="button" onClick={props.onRetry} className="ml-2 text-accent-base">
-            {t('settings.sync.history.retry')}
-          </button>
-        )}
+      <div className="flex min-h-[24rem] items-center justify-center p-6">
+        <div className="max-w-xs text-center text-sm text-text-muted">
+          <p>{t('settings.sync.history.error.loadList')}</p>
+          {props.onRetry && (
+            <button
+              type="button"
+              onClick={props.onRetry}
+              className="mt-3 rounded-md border border-border-default px-3 py-1.5 text-xs text-text-primary hover:border-border-active"
+            >
+              {t('settings.sync.history.retry')}
+            </button>
+          )}
+        </div>
       </div>
     )
   }
 
   if (props.items.length === 0) {
     return (
-      <div className="p-6 text-sm text-text-muted" data-testid="empty">
-        {t('settings.sync.history.empty.local')}
+      <div className="flex min-h-[24rem] items-center justify-center p-6" data-testid="empty">
+        <div className="max-w-xs text-center text-sm text-text-muted">
+          {t('settings.sync.history.empty.local')}
+        </div>
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col gap-2 p-3">
       {props.items.map((m) => (
         <HistoryRow
           key={m.id}

--- a/spa/src/features/settings/sections/sync-history/HistoryRow.tsx
+++ b/spa/src/features/settings/sections/sync-history/HistoryRow.tsx
@@ -20,6 +20,12 @@ function formatRelative(ms: number): string {
   return `${days}d`
 }
 
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / 1024 / 1024).toFixed(2)} MB`
+}
+
 export interface HistoryRowProps {
   meta: SnapshotMetadata
   selected: boolean
@@ -35,24 +41,34 @@ export function HistoryRow({ meta, selected, onSelect }: HistoryRowProps) {
       data-selected={selected}
       onClick={onSelect}
       className={[
-        'w-full px-3 py-2 flex items-center gap-2 text-left',
-        'border-b border-text-subtle/10',
-        selected ? 'bg-accent-muted' : 'hover:bg-text-subtle/5',
+        'w-full rounded-lg border px-3 py-3 text-left transition-colors',
+        selected
+          ? 'border-border-active bg-surface-elevated'
+          : 'border-border-subtle hover:border-border-default hover:bg-surface-hover',
       ].join(' ')}
     >
-      <Icon size={16} className="text-text-muted" />
-      <div className="flex-1">
-        <div className="text-sm text-text-primary">
-          {t(`settings.sync.history.trigger.${meta.trigger === 'pre-import' ? 'preImport' : meta.trigger === 'pre-restore' ? 'preRestore' : meta.trigger}`)}
-          <span className="ml-2 text-xs text-text-muted">{formatRelative(meta.timestamp)}</span>
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border-default bg-bg-surface text-text-muted">
+          <Icon size={16} className="shrink-0" />
         </div>
-        <div className="text-xs text-text-muted">{meta.device}</div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-text-primary">
+              {t(`settings.sync.history.trigger.${meta.trigger === 'pre-import' ? 'preImport' : meta.trigger === 'pre-restore' ? 'preRestore' : meta.trigger}`)}
+            </span>
+            <span className="text-xs text-text-muted">{formatRelative(meta.timestamp)}</span>
+          </div>
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-text-secondary">
+            <span>{meta.device}</span>
+            <span>{formatBytes(meta.bundleSize)}</span>
+          </div>
+        </div>
+        {meta.isSessionPristine && (
+          <span data-testid="pristine-badge" className="shrink-0 rounded-md bg-accent-muted px-2 py-1 text-[11px] font-medium text-accent-base">
+            {t('settings.sync.history.trigger.sessionPristine')}
+          </span>
+        )}
       </div>
-      {meta.isSessionPristine && (
-        <span data-testid="pristine-badge" className="text-xs px-1 rounded bg-accent-muted text-accent-base">
-          {t('settings.sync.history.trigger.sessionPristine')}
-        </span>
-      )}
     </button>
   )
 }

--- a/spa/src/features/settings/sections/sync-history/HistoryTabs.tsx
+++ b/spa/src/features/settings/sections/sync-history/HistoryTabs.tsx
@@ -9,14 +9,16 @@ export interface HistoryTabsProps {
 export function HistoryTabs(props: HistoryTabsProps) {
   const t = useI18nStore((s) => s.t)
   return (
-    <div role="tablist" className="flex border-b border-text-subtle/20">
+    <div role="tablist" className="inline-flex rounded-md border border-border-default bg-surface-secondary p-1">
       <button
         role="tab"
         aria-selected={props.active === 'local'}
         onClick={() => props.onChange('local')}
         className={[
-          'px-4 py-2 text-sm',
-          props.active === 'local' ? 'border-b-2 border-accent-base text-accent-base' : 'text-text-muted',
+          'rounded-md px-4 py-1.5 text-xs font-medium transition-colors',
+          props.active === 'local'
+            ? 'bg-surface-elevated text-text-primary'
+            : 'text-text-muted hover:text-text-primary',
         ].join(' ')}
       >
         {t('settings.sync.history.tabs.local')}
@@ -28,9 +30,11 @@ export function HistoryTabs(props: HistoryTabsProps) {
         onClick={() => props.onChange('remote')}
         title={!props.remoteAvailable ? t('settings.sync.history.tabs.remoteDaemonOnly') : undefined}
         className={[
-          'px-4 py-2 text-sm',
-          props.active === 'remote' ? 'border-b-2 border-accent-base text-accent-base' : 'text-text-muted',
-          !props.remoteAvailable ? 'opacity-50 cursor-not-allowed' : '',
+          'rounded-md px-4 py-1.5 text-xs font-medium transition-colors',
+          props.active === 'remote'
+            ? 'bg-surface-elevated text-text-primary'
+            : 'text-text-muted hover:text-text-primary',
+          !props.remoteAvailable ? 'cursor-not-allowed opacity-50' : '',
         ].join(' ')}
       >
         {t('settings.sync.history.tabs.remote')}

--- a/spa/src/features/settings/sections/sync-history/SnapshotDetail.tsx
+++ b/spa/src/features/settings/sections/sync-history/SnapshotDetail.tsx
@@ -15,48 +15,85 @@ function formatBytes(n: number): string {
   return `${(n / 1024 / 1024).toFixed(2)} MB`
 }
 
+function diffTone(status: ContributorDiff['status']): string {
+  switch (status) {
+    case 'identical':
+      return 'bg-surface-elevated text-text-secondary'
+    case 'changed':
+      return 'bg-accent-muted text-accent-base'
+    case 'missing-in-current':
+    case 'missing-in-snapshot':
+      return 'bg-yellow-500/10 text-yellow-400'
+  }
+}
+
 export function SnapshotDetail({ snapshot, diff, onRestore, restoring }: SnapshotDetailProps) {
   const t = useI18nStore((s) => s.t)
   if (!snapshot) {
     return (
-      <div className="p-6 text-sm text-text-muted">
-        {t('settings.sync.history.detail.selectPrompt')}
+      <div className="flex min-h-[24rem] items-center justify-center p-6 text-sm text-text-muted">
+        <div className="max-w-sm text-center">
+          {t('settings.sync.history.detail.selectPrompt')}
+        </div>
       </div>
     )
   }
   return (
-    <div className="p-6 flex flex-col gap-4">
-      <section>
-        <h3 className="text-sm font-semibold text-text-primary">{t('settings.sync.history.detail.metadata')}</h3>
-        <dl className="mt-2 text-sm text-text-muted space-y-1">
-          <div><dt className="inline">{t('settings.sync.history.detail.timestamp')}:</dt> <dd className="inline">{new Date(snapshot.timestamp).toLocaleString()}</dd></div>
-          <div><dt className="inline">{t('settings.sync.history.detail.device')}:</dt> <dd className="inline">{snapshot.device}</dd></div>
-          <div><dt className="inline">{t('settings.sync.history.detail.size')}:</dt> <dd className="inline">{formatBytes(snapshot.bundleSize)}</dd></div>
-        </dl>
+    <div className="flex h-full flex-col gap-4 p-5">
+      <div className="flex flex-col gap-4 border-b border-border-subtle pb-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-text-muted">
+            {t('settings.sync.history.detail.metadata')}
+          </p>
+          <h3 className="mt-2 text-lg font-medium text-text-primary">{snapshot.device}</h3>
+          <p className="mt-1 text-sm text-text-secondary">{new Date(snapshot.timestamp).toLocaleString()}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onRestore}
+          disabled={restoring}
+          className="rounded-md border border-border-active bg-surface-elevated px-4 py-2 text-sm text-text-primary transition-colors hover:border-accent-base disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {t('settings.sync.history.detail.restore')}
+        </button>
+      </div>
+
+      <section className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-lg border border-border-default bg-bg-surface px-4 py-3">
+          <div className="text-[11px] uppercase tracking-[0.16em] text-text-muted">
+            {t('settings.sync.history.detail.timestamp')}
+          </div>
+          <div className="mt-2 text-sm text-text-primary">{new Date(snapshot.timestamp).toLocaleString()}</div>
+        </div>
+        <div className="rounded-lg border border-border-default bg-bg-surface px-4 py-3">
+          <div className="text-[11px] uppercase tracking-[0.16em] text-text-muted">
+            {t('settings.sync.history.detail.device')}
+          </div>
+          <div className="mt-2 text-sm text-text-primary">{snapshot.device}</div>
+        </div>
+        <div className="rounded-lg border border-border-default bg-bg-surface px-4 py-3">
+          <div className="text-[11px] uppercase tracking-[0.16em] text-text-muted">
+            {t('settings.sync.history.detail.size')}
+          </div>
+          <div className="mt-2 text-sm text-text-primary">{formatBytes(snapshot.bundleSize)}</div>
+        </div>
       </section>
+
       {diff && diff.length > 0 && (
-        <section>
+        <section className="rounded-lg border border-border-default bg-bg-surface p-4">
           <h3 className="text-sm font-semibold text-text-primary">{t('settings.sync.history.detail.diff.title')}</h3>
-          <ul className="mt-2 text-sm space-y-1">
+          <ul className="mt-3 space-y-2 text-sm">
             {diff.map((d) => (
-              <li key={d.id} className="flex items-center gap-2">
+              <li key={d.id} className="flex items-center justify-between gap-3 rounded-md border border-border-subtle px-3 py-2">
                 <span className="text-text-primary">{d.id}</span>
-                <span className="text-text-muted text-xs">{t(`settings.sync.history.detail.diff.${d.status === 'missing-in-snapshot' ? 'missingInSnapshot' : d.status === 'missing-in-current' ? 'missingInCurrent' : d.status}`)}</span>
+                <span className={`rounded-md px-2 py-1 text-[11px] font-medium ${diffTone(d.status)}`}>
+                  {t(`settings.sync.history.detail.diff.${d.status === 'missing-in-snapshot' ? 'missingInSnapshot' : d.status === 'missing-in-current' ? 'missingInCurrent' : d.status}`)}
+                </span>
               </li>
             ))}
           </ul>
         </section>
       )}
-      <div>
-        <button
-          type="button"
-          onClick={onRestore}
-          disabled={restoring}
-          className="px-4 py-2 bg-accent-base text-white rounded disabled:opacity-50"
-        >
-          {t('settings.sync.history.detail.restore')}
-        </button>
-      </div>
     </div>
   )
 }

--- a/spa/src/features/settings/sections/sync-history/SnapshotHistoryPage.tsx
+++ b/spa/src/features/settings/sections/sync-history/SnapshotHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { ClockCounterClockwise, WarningCircle } from '@phosphor-icons/react'
 import { HistoryTabs } from './HistoryTabs'
 import { HistoryList } from './HistoryList'
 import { SnapshotDetail } from './SnapshotDetail'
@@ -41,6 +42,7 @@ export function SnapshotHistoryPage() {
   const pendingConflicts = useSyncStore((s) => s.pendingConflicts)
   const restoreFromSnapshot = useSyncStore((s) => s.restoreFromSnapshot)
   const t = useI18nStore((s) => s.t)
+  const remoteAvailable = activeProviderId === 'daemon'
 
   const diff = useSnapshotDiff(selectedSnap)
 
@@ -126,14 +128,39 @@ export function SnapshotHistoryPage() {
   }
 
   return (
-    <div className="flex h-full flex-col">
-      <HistoryTabs
-        active={activeTab}
-        remoteAvailable={activeProviderId === 'daemon'}
-        onChange={setActiveTab}
-      />
-      <div className="flex flex-1 overflow-hidden">
-        <div className="w-80 overflow-y-auto border-r border-text-subtle/20">
+    <div className="mx-auto flex h-full w-full max-w-6xl flex-col gap-6">
+      <div>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-border-default bg-surface-secondary text-text-secondary">
+            <ClockCounterClockwise size={18} />
+          </div>
+          <div>
+            <h2 className="text-lg text-text-primary">{t('settings.sync.history.title')}</h2>
+            <p className="text-xs text-text-secondary">{t('settings.sync.history.description')}</p>
+          </div>
+        </div>
+      </div>
+
+      {warningText && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-status-warn-text"
+        >
+          <WarningCircle size={18} className="mt-0.5 shrink-0 text-yellow-500" />
+          <span>{warningText}</span>
+        </div>
+      )}
+
+      <div className="flex items-center gap-4">
+        <HistoryTabs
+          active={activeTab}
+          remoteAvailable={remoteAvailable}
+          onChange={setActiveTab}
+        />
+      </div>
+
+      <div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(19rem,24rem)_minmax(0,1fr)]">
+        <section className="min-h-[24rem] overflow-hidden rounded-lg border border-border-default bg-surface-secondary">
           {activeTab === 'local' ? (
             <HistoryList
               items={items}
@@ -144,23 +171,29 @@ export function SnapshotHistoryPage() {
               onRetry={refresh}
             />
           ) : (
-            <div className="p-6 text-sm text-text-muted">Remote tab: PR B</div>
+            <div className="flex min-h-[24rem] items-center justify-center p-6">
+              <div className="max-w-sm text-center">
+                <p className="text-sm text-text-primary">{t('settings.sync.history.tabs.remote')}</p>
+                <p className="mt-2 text-xs text-text-secondary">
+                  {remoteAvailable
+                    ? t('settings.sync.history.empty.remote')
+                    : t('settings.sync.history.tabs.remoteDaemonOnly')}
+                </p>
+              </div>
+            </div>
           )}
-        </div>
-        <div className="flex-1 overflow-y-auto">
-          {warningText && (
-            <p role="alert" className="m-4 text-sm text-status-warn-text">
-              {warningText}
-            </p>
-          )}
+        </section>
+
+        <section className="min-h-[24rem] overflow-hidden rounded-lg border border-border-default bg-surface-secondary">
           <SnapshotDetail
             snapshot={selectedSnap}
             diff={diff}
             onRestore={() => setDialogMode('confirm')}
             restoring={restoring}
           />
-        </div>
+        </section>
       </div>
+
       <SnapshotRestoreDialog
         open={dialogMode !== 'idle'}
         mode={dialogMode === 'idle' ? 'confirm' : dialogMode}

--- a/spa/src/features/settings/sections/sync-history/SnapshotRestoreDialog.tsx
+++ b/spa/src/features/settings/sections/sync-history/SnapshotRestoreDialog.tsx
@@ -34,12 +34,12 @@ export function SnapshotRestoreDialog(props: SnapshotRestoreDialogProps) {
     : t('settings.sync.history.restore.proceed')
 
   return (
-    <div role="dialog" aria-modal="true" className="fixed inset-0 flex items-center justify-center bg-black/40 z-50">
-      <div className="bg-bg-surface border border-text-subtle/20 rounded-md p-6 max-w-md">
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+      <div className="w-full max-w-md rounded-xl border border-border-default bg-bg-surface p-6 shadow-2xl">
         <h2 className="text-lg font-semibold text-text-primary">{title}</h2>
-        <p className="mt-2 text-sm text-text-muted">{body}</p>
+        <p className="mt-2 text-sm leading-6 text-text-muted">{body}</p>
         {props.pendingConflictCount > 0 && !isPreOpFailed && !isCoverageWarning && (
-          <p className="mt-2 text-sm text-status-warn-text">
+          <p className="mt-3 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-status-warn-text">
             {t(pluralKey('settings.sync.history.restore.confirmPendingConflicts', props.pendingConflictCount), { n: props.pendingConflictCount })}
           </p>
         )}
@@ -48,7 +48,7 @@ export function SnapshotRestoreDialog(props: SnapshotRestoreDialogProps) {
             type="button"
             onClick={props.onCancel}
             disabled={props.restoring}
-            className="px-3 py-1 text-sm text-text-muted disabled:opacity-50"
+            className="rounded-md px-3 py-1.5 text-sm text-text-muted transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
           >
             {t('settings.sync.history.restore.cancel')}
           </button>
@@ -56,7 +56,7 @@ export function SnapshotRestoreDialog(props: SnapshotRestoreDialogProps) {
             type="button"
             onClick={props.onConfirm}
             disabled={props.restoring}
-            className="px-3 py-1 text-sm bg-accent-base text-white rounded disabled:opacity-50"
+            className="rounded-md border border-border-active bg-surface-elevated px-3 py-1.5 text-sm text-text-primary transition-colors hover:border-accent-base disabled:opacity-50"
           >
             {proceedLabel}
           </button>


### PR DESCRIPTION
## Summary
- align the sync history page with the current settings visual system instead of the earlier wireframe-style split pane
- restyle the history tabs, rows, detail panel, and restore dialog to use the project's existing surface, border, and state tokens
- keep the existing restore behavior intact while making empty, loading, and error states match the rest of Settings