### PR TITLE
feat(agent): add opencode hook integration

### DIFF
--- a/cmd/pdx/setup.go
+++ b/cmd/pdx/setup.go
@@ -12,6 +12,7 @@ import (
 
 	agentcc "github.com/wake/purdex/internal/agent/cc"
 	"github.com/wake/purdex/internal/agent/codex"
+	"github.com/wake/purdex/internal/agent/opencode"
 	"github.com/wake/purdex/internal/config"
 )
 
@@ -32,7 +33,7 @@ func runSetup(args []string) {
 	}
 
 	if agentType == "" {
-		fmt.Fprintf(os.Stderr, "pdx setup: --agent flag is required (e.g. --agent cc, --agent codex)\n")
+		fmt.Fprintf(os.Stderr, "pdx setup: --agent flag is required (e.g. --agent cc, --agent codex, --agent opencode)\n")
 		os.Exit(1)
 	}
 
@@ -121,7 +122,13 @@ func localSetup(agentType string, remove bool) error {
 			return p.RemoveHooks(pdxPath)
 		}
 		return p.InstallHooks(pdxPath)
+	case "opencode":
+		p := opencode.NewProvider()
+		if remove {
+			return p.RemoveHooks(pdxPath)
+		}
+		return p.InstallHooks(pdxPath)
 	default:
-		return fmt.Errorf("unknown agent type: %s (supported: cc, codex)", agentType)
+		return fmt.Errorf("unknown agent type: %s (supported: cc, codex, opencode)", agentType)
 	}
 }

--- a/cmd/pdx/setup_test.go
+++ b/cmd/pdx/setup_test.go
@@ -62,6 +62,25 @@ func TestLocalSetup(t *testing.T) {
 		}
 	})
 
+	t.Run("opencode install creates project plugin", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("HOME", root)
+
+		err := localSetup("opencode", false)
+		if err != nil {
+			t.Fatalf("localSetup opencode install: %v", err)
+		}
+
+		pluginPath := filepath.Join(root, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+		data, err := os.ReadFile(pluginPath)
+		if err != nil {
+			t.Fatalf("read plugin: %v", err)
+		}
+		if len(data) == 0 {
+			t.Fatal("plugin file is empty")
+		}
+	})
+
 	t.Run("unknown agent returns error", func(t *testing.T) {
 		err := localSetup("unknown", false)
 		if err == nil {
@@ -86,6 +105,16 @@ func TestLocalSetup(t *testing.T) {
 		err := localSetup("codex", true)
 		if err != nil {
 			t.Fatalf("localSetup codex remove: %v", err)
+		}
+	})
+
+	t.Run("opencode remove on empty dir succeeds", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("HOME", root)
+
+		err := localSetup("opencode", true)
+		if err != nil {
+			t.Fatalf("localSetup opencode remove: %v", err)
 		}
 	})
 }

--- a/docs/superpowers/plans/2026-04-21-opencode-hook-integration.md
+++ b/docs/superpowers/plans/2026-04-21-opencode-hook-integration.md
@@ -1,0 +1,86 @@
+# OpenCode Hook Integration Implementation Plan
+
+**Goal:** 為 Purdex 新增 `opencode` 等位 agent hooks，走 host-global plugin 安裝，並接入現有 agent provider / hook status / settings UI，同時對齊 Claude Code 的 subagent lifecycle 行為。
+
+**Spec:** `docs/superpowers/specs/2026-04-21-opencode-hook-integration-design.md`
+
+**本階段刻意不做：** 不處理 `session.status=busy/retry` → running 映射，僅保留為觀察項。
+
+---
+
+## File Map
+
+### New Files
+
+| Path | Responsibility |
+|------|---------------|
+| `internal/agent/opencode/provider.go` | OpenCode provider assembly / identify |
+| `internal/agent/opencode/status.go` | OpenCode status derivation |
+| `internal/agent/opencode/hooks.go` | Host-global plugin installer / checker / remover |
+| `internal/agent/opencode/plugin_template.go` | Render managed OpenCode plugin source and own all OpenCode-specific event normalization |
+| `internal/agent/opencode/status_test.go` | Status derivation tests |
+| `internal/agent/opencode/hooks_test.go` | Plugin install/check/remove tests |
+| `internal/agent/opencode/plugin_template_test.go` | Plugin mapping / suppress / subagent pairing tests, including negative pairing cases |
+
+### Modified Files
+
+| Path | Change |
+|------|--------|
+| `internal/module/agent/module.go` | Register OpenCode provider |
+| `internal/module/agent/handler.go` | Agent detect 增加 `opencode`; adjust `handleEvent` error guard for OpenCode |
+| `internal/module/agent/frame_ops.go` | Ensure `SessionStart` clears persisted subagent membership before projection sync |
+| `internal/module/agent/frame_ops_test.go` | Add OpenCode projection cleanup and subagent membership tests |
+| `internal/module/agent/handler_test.go` | Add OpenCode error guard tests |
+| `cmd/pdx/setup.go` | `--agent opencode` local setup |
+| `cmd/pdx/setup_test.go` | OpenCode install/remove cases |
+| `spa/src/lib/hook-modules.ts` | Add OpenCode hooks module |
+| `spa/src/lib/agent-metadata.ts` | Add OpenCode display name |
+| `spa/src/locales/en.json` | Add OpenCode hook labels |
+| `spa/src/locales/zh-TW.json` | Add OpenCode hook labels |
+
+---
+
+## Task 1: Backend Provider + TDD
+
+- [ ] 新增 `internal/agent/opencode/status_test.go`
+- [ ] 新增 `internal/agent/opencode/hooks_test.go`
+- [ ] 新增 `internal/agent/opencode/plugin_template_test.go`
+- [ ] 實作 `provider.go`
+- [ ] 實作 `status.go`
+- [ ] 實作 `hooks.go`
+- [ ] 實作 `plugin_template.go`
+- [ ] 在 plugin template 中實作 `task` tool → `SubagentStart` / `SubagentStop` mapping
+- [ ] 在 plugin template 中實作 `session.error` 後 `session.idle` suppress
+- [ ] 在 `plugin_template_test.go` 覆蓋負向 pairing：unknown callID、stop-before-start、duplicate start、missing `agent_id`
+- [ ] 確認 install/check/remove 與 unmanaged guard 行為都被測到
+
+## Task 2: Agent Module / CLI Wiring
+
+- [ ] 在 `internal/module/agent/module.go` 註冊 `opencode` provider
+- [ ] 在 `internal/module/agent/module.go` 註冊 `m.prober.RegisterIdentifier(opencodeProvider.Type(), opencodeProvider.Identify)`
+- [ ] 視需要決定本階段是否略過 `RegisterReadiness`，不要把它當成必做項目
+- [ ] 在 `internal/module/agent/handler.go` 的 `handleEvent` error guard 明確調整 OpenCode whitelist：`SessionEnd` 可通過、`Stop` 不會清掉 error
+- [ ] 在 `internal/module/agent/frame_ops.go` 或等位路徑確保 `SessionStart` 會清除 persisted `Subagents`，不只清 in-memory state
+- [ ] 在 `internal/module/agent/handler.go` 的 `/api/agents/detect` 增加 `opencode --version`
+- [ ] 在 `cmd/pdx/setup.go` 補上 `opencode` 分支與錯誤訊息
+- [ ] 在 `cmd/pdx/setup_test.go` 補 install/remove case
+
+## Task 2.1: Module-Level Behavior Tests
+
+- [ ] 補 `internal/module/agent` 測試，覆蓋 `opencode` 的 `SubagentStart` / `SubagentStop` projection path
+- [ ] 補 `internal/module/agent` 測試，覆蓋 `opencode` 的 `SessionStart` 會清殘留 subagent，且不會被 projection 寫回
+- [ ] 補 `internal/module/agent` 測試，覆蓋 `opencode` 的 `SessionEnd` 在 error 狀態下仍可 cleanup
+- [ ] 補 `internal/module/agent` 測試，覆蓋 `opencode` 的 `Stop` 不可作為 error clear 事件
+
+## Task 3: SPA Hook 管理 UI
+
+- [ ] 在 `spa/src/lib/hook-modules.ts` 新增 `opencode` card
+- [ ] 在 `spa/src/lib/agent-metadata.ts` 新增 `OpenCode`
+- [ ] 同步更新 `en.json` / `zh-TW.json`
+- [ ] 確認 hooks settings page 會列出第三個 agent hook module
+
+## Task 4: Verification
+
+- [ ] 跑 `go test ./internal/agent/opencode ./cmd/pdx ./internal/module/agent -count=1`
+- [ ] 跑 `pnpm --prefix spa run build`
+- [ ] 檢查 worktree diff，確認沒有碰到產物或無關檔案

--- a/docs/superpowers/specs/2026-04-21-opencode-hook-integration-design.md
+++ b/docs/superpowers/specs/2026-04-21-opencode-hook-integration-design.md
@@ -1,0 +1,281 @@
+# OpenCode Hook Integration Design
+
+## 目標
+
+在既有 `cc` / `codex` agent hook 架構下，新增一套供 `opencode` 使用的等位 hooks 整合，讓 Purdex 可以：
+
+1. 辨識 `opencode` process 並接受其 hook 事件。
+2. 以 host-global plugin 方式安裝 / 移除 / 檢查 `opencode` hooks，對齊現有 `host > hooks` 控制語意。
+3. 將 `opencode` 原生 event 映射為 Purdex 既有的 normalized status 流程，並對齊 Claude Code 的 subagent 處理語意。
+4. 在設定頁面中把 `opencode` 當成第三種可管理的 agent hook module。
+
+## 背景與限制
+
+- `cc` 與 `codex` 走 CLI 原生 hook 設定檔：`~/.claude/settings.json`、`~/.codex/hooks.json`。
+- `opencode` 沒有對等的 CLI hook 設定檔；官方擴充點是 plugin system。
+- `opencode` plugin 可在 `.opencode/plugins/` 放 JS/TS 模組，OpenCode 啟動時自動載入。
+- plugin 可透過 `event` 與 `chat.message` 等 hook 監聽 session / permission / message lifecycle。
+- 現有 `pdx hook --agent <type> <event>` 已處理 tmux session、pane、sender PID/start time、daemon URL/token，應直接重用。
+
+## 方案摘要
+
+### 1. 新增 `internal/agent/opencode` provider
+
+Provider 責任：
+
+- `Type()` 回傳 `opencode`
+- `DisplayName()` 回傳 `OpenCode`
+- `Identify()` 支援：
+  - executable basename = `opencode`
+  - JS runtime argv 含 `opencode-ai` / `/opencode/`
+- `Claim()`：hook event 時以 `agent_type == "opencode"` 為準
+- `DeriveStatus()`：處理 plugin 送進來的語意事件
+- `HookInstaller`：管理 host-global plugin 檔案
+
+Provider 與 plugin 的責任邊界：
+
+- **OpenCode plugin 層**：負責 OpenCode-specific event 正規化
+  - 訂閱 `event` / `chat.message` / `tool.execute.before` / `tool.execute.after`
+  - `callID -> agent_id`
+  - `args.subagent_type` / `args.agent` -> `agent_type`
+  - `session.error` 後的 `session.idle` suppress
+  - 將正規化後的事件送進 `pdx hook --agent opencode <EventName>`
+- **Go provider 層**：只處理已正規化的 Purdex event
+  - `DeriveStatus()` 不解析 OpenCode 原生 schema
+  - `HookInstaller` 不承擔 event mapping，只負責安裝/移除/檢查 managed plugin
+
+對齊 Claude Code 基準的要求：
+
+- 使用相同 event 名稱集合：`SessionStart`、`UserPromptSubmit`、`SubagentStart`、`SubagentStop`、`Stop`、`StopFailure`、`PermissionRequest`、`SessionEnd`
+- `SubagentStart` / `SubagentStop` 與 `cc` 一樣只更新 subagent tracking，不改主 status
+- subagent 事件 payload 也保留 `agent_id` / `agent_type`，讓現有 agent module 可以直接沿用
+
+### 2. Hook 安裝方式改為 host-global plugin
+
+安裝檔案位置：
+
+`~/.config/opencode/plugins/pdx-agent-hooks.js`
+
+原因：
+
+- 這是 `opencode` 官方支援的擴充路徑
+- 不需要修改使用者全域 `~/.config/opencode/opencode.json`
+- `host > hooks` 現有 UI / API 是 host-scoped toggle，不是 project-scoped toggle
+- 對使用者而言，按下 Install/Remove 應代表「這台 host 上的 OpenCode hooks 啟用/停用」，而不是只對某個 repo 生效
+
+plugin 檔由 `pdx setup --agent opencode` 或 `/api/hooks/opencode/setup` 產生；內容帶入實際 `pdx` executable path。
+
+這個設計刻意對齊現有 `cc` / `codex` hook card 的控制語意：
+
+- `GET /api/hooks/opencode/status` 代表 host 上的全域安裝狀態
+- `POST /api/hooks/opencode/setup` 的 install/remove 也是 host-global 作用域
+- 不要求前端額外提供 repo path / cwd / git root
+
+### 3. plugin 不直接 POST daemon，改呼叫既有 `pdx hook`
+
+plugin 只做 event mapping，真正送事件一律走：
+
+`"/path/to/pdx" hook --agent opencode <EventName>`
+
+優點：
+
+- 不重做 daemon URL / token 解析
+- 不重做 tmux session / pane lookup
+- 不重做 sender PID / start time provenance
+- verify path 與現有 `cc` / `codex` 完全一致
+
+### 3.1 OpenCode plugin source 的實作邊界
+
+為了避免把核心 event mapping 藏在 `hooks.go` 的內嵌字串中，本次實作要求 plugin source 有獨立 owner：
+
+- managed plugin 內容由獨立 template / source 檔產生
+- `hooks.go` 只負責 render / write / check / remove
+- OpenCode-specific lifecycle mapping 不應直接散落在 installer 邏輯內
+
+### 4. `opencode` event → Purdex event 映射
+
+plugin 監聽以下 OpenCode hooks：
+
+| OpenCode hook | 條件 | 送給 `pdx hook` 的事件 | 說明 |
+|---------------|------|-------------------------|------|
+| `event` | `session.created` | `SessionStart` | 新 session 建立 |
+| `chat.message` | 每次 user turn | `UserPromptSubmit` | 開始新一輪工作 |
+| `tool.execute.before` | `tool == "task"` | `SubagentStart` | 啟動 subagent/task |
+| `tool.execute.after` | `tool == "task"` | `SubagentStop` | subagent/task 結束 |
+| `event` | `permission.asked` | `PermissionRequest` | 工具權限等待 |
+| `event` | `question.asked` | `PermissionRequest` | user question / elicitation 也視為 waiting |
+| `event` | `session.idle` | `Stop` | 正常回到 idle |
+| `event` | `session.error` | `StopFailure` | 回報錯誤狀態 |
+| `event` | `session.deleted` | `SessionEnd` | session 結束 |
+
+補充：
+
+- `session.error` 後若緊接 `session.idle`，plugin 需 suppress 該次 `Stop`，避免錯誤狀態被立即清掉。
+- `tool.execute.before/after(task)` 使用 `callID` 當 `agent_id`；`args.subagent_type` 或 `args.agent` 映射為 `agent_type`，若缺少則 fallback `task`。
+- 這裡刻意不用 `message.part.updated` 推 subagent lifecycle，因為 `task` tool hook 可直接拿到穩定 `callID`，較接近 Claude Code 的 `agent_id` 配對模型。
+
+### 4.2 Error guard 對齊要求
+
+僅靠 plugin suppress `session.error -> session.idle` 不足以保證狀態正確，backend 也要提供第二層保護。
+
+本次規格要求：
+
+- **`SessionEnd` 必須能在 error 狀態下通過**，不能被現有 error guard 擋掉
+- **對 `opencode` 而言，`Stop` 不是 error 清除白名單事件**
+- `opencode` error 狀態只能由以下事件清除：
+  - `UserPromptSubmit`
+  - `SessionStart`
+  - `SessionEnd`
+
+理由：
+
+- OpenCode 的 `session.idle` 是執行結束訊號，但在 `session.error` 後可能只是 error 後續收尾，不能視為成功回到 idle
+- 若 backend 仍把 `Stop` 當成 error 清除事件，任何 plugin suppress 漏網都會把錯誤狀態洗掉
+- `SessionEnd` 若被 error guard 擋掉，session/subagent cleanup 會失效，與 Claude Code 既有 lifecycle 模型衝突
+
+### 4.1 觀察項：`session.status=busy/retry`
+
+目前先不把 `session.status=busy/retry` 映射成 `UserPromptSubmit` 或其他 running 類事件。
+
+原因：
+
+- 這不是 Claude Code hook 的直接等位事件，比較偏 OpenCode 特有的執行態訊號。
+- 若直接映射為 `UserPromptSubmit`，會把「使用者送出 prompt 邊界」和「執行中狀態變化」混在一起。
+- 先以 `chat.message` 作為唯一 running 起點，比較容易對齊既有 Claude Code 語意。
+
+但這個訊號仍記錄為後續觀察項：
+
+- 若實測發現 `opencode` 在 permission/question/error 後恢復執行時，Purdex 長時間停在舊狀態，才再考慮把 `busy/retry` 納入第二階段設計。
+
+### 5. `DeriveStatus()` 規則
+
+`opencode` provider 使用和 `cc` 相同的 normalized status 集合：
+
+| Event | Status |
+|-------|--------|
+| `SessionStart` | `idle` |
+| `UserPromptSubmit` | `running` |
+| `SubagentStart` | 無狀態變更 |
+| `SubagentStop` | 無狀態變更 |
+| `PermissionRequest` | `waiting` |
+| `Stop` | `idle` |
+| `StopFailure` | `error` |
+| `SessionEnd` | `clear` |
+
+raw detail 保留：
+
+- `UserPromptSubmit`: `session_id`, `message_id`, `agent`, `modelName`, `source`
+- `SubagentStart`: `agent_id`, `agent_type`, `description`, `prompt`
+- `SubagentStop`: `agent_id`, `agent_type`, `title`, `output`
+- `PermissionRequest`: `request_type`, `permission`, `patterns`, `questions`
+- `StopFailure`: `error`, `error_details`
+
+### 5.1 Subagent 處理基準
+
+這一段明確對齊目前 Claude Code provider / agent module 的行為：
+
+- `SubagentStart` / `SubagentStop` 是 transient event，只進 broadcast path，不改主 status
+- event 需讓 backend 能用現有 `applyFrameEvent` / `syncProjectionState` 流程追蹤 active subagents
+- `SessionStart` / `SessionEnd` 清理 subagent 狀態的語意不變
+- 若 `task` tool 異常中斷而沒收到對應 stop，殘留 subagent 與目前 `cc` 一樣屬 best-effort；會由後續 session lifecycle 事件或新一輪 start/clear 清理
+
+進一步要求：
+
+- `SessionStart` 的 cleanup 不能只清 in-memory `m.subagents`；也必須同步清除 projection / frame 上殘留的 `Subagents`
+- 否則 `handleEvent()` 在 `SessionStart` 後重新 `syncProjectionState()` 時，舊的 frame subagents 會被寫回記憶體，造成跨輪殘留
+- 因此，`SessionStart` 在 `opencode` 路徑下必須被視為 subagent cleanup 事件，和 `SessionEnd` 一樣需要有 module-level 驗證
+
+### 5.1.1 Subagent pairing 合約
+
+`task` tool 的 `callID -> agent_id` 是本次 OpenCode subagent lifecycle 的唯一配對鍵，不能只測 happy path。
+
+本次規格要求至少覆蓋以下負向案例：
+
+- `SubagentStop` 的 `agent_id` 不存在於當前 active set
+- `SubagentStop` 先於 `SubagentStart` 到達
+- 重複 `SubagentStart` 使用相同 `agent_id`
+- 缺少 `agent_id` 的 `SubagentStart` / `SubagentStop`
+
+對應語意：
+
+- malformed 或缺配事件不得讓 UI 看起來像成功更新了 subagent 狀態
+- malformed event 可以被忽略，但必須有測試保證不會污染 projection / in-memory state
+
+### 5.2 Process detection 對齊要求
+
+spec 第 1 點的「辨識 `opencode` process」不是只有 provider 存在即可，還必須接進現有 `prober`。
+
+本次規格要求：
+
+- 在 agent module 初始化時註冊 `m.prober.RegisterIdentifier(opencodeProvider.Type(), opencodeProvider.Identify)`
+- `RegisterReadiness` 本階段不是必要條件；若沒有可靠的 OpenCode readiness 訊號，可以先不做
+
+也就是說，本階段要完成的是 **liveness/process identification**，不是完整 readiness integration。
+
+### 6. Hook 狀態檢查與 install/remove 語義
+
+`CheckHooks()`：
+
+- 檢查 plugin 檔是否存在
+- 檢查檔案是否帶有 `pdx-managed:opencode-hooks:v1` marker
+- 若是 managed file，回報所有 `opencodeHookEvents` 為 installed=true
+- 若檔案不存在，回報未安裝
+- 若同名檔存在但不是 managed file，回報 issue `plugin file exists but is unmanaged`
+
+`InstallHooks()`：
+
+- 解析使用者 home directory
+- 確保 `~/.config/opencode/plugins/` 存在
+- 若同名 unmanaged file 已存在，拒絕覆寫
+- 以 atomic write 產生 managed plugin
+
+`RemoveHooks()`：
+
+- 若 managed file 存在則刪除
+- 若不存在則視為成功
+- 若是 unmanaged file，拒絕移除
+
+### 6.1 `host > hooks` 對齊要求
+
+`opencode` hook installer 的控制語意需與既有 UI 完全對齊：
+
+| 面向 | 對齊要求 |
+|------|----------|
+| 作用域 | host-global |
+| 前端輸入 | 只需要 `hostId`，不需要 repo path |
+| 狀態檢查 | 單一全域狀態，不因不同 repo 改變 |
+| Install | 對 host 上所有 OpenCode session 生效 |
+| Remove | 對 host 上所有 OpenCode session 失效 |
+
+因此本次不做 project-local plugin 安裝。若未來需要 repo-scoped hooks，應另外設計新的 UI / API 與使用者心智模型。
+
+### 7. UI 與 CLI 整合
+
+需要同步擴充：
+
+- `internal/module/agent/module.go`：註冊 `opencode` provider
+- `internal/module/agent/handler.go`：`/api/agents/detect` 增加 `opencode --version`
+- `cmd/pdx/setup.go`：支援 `--agent opencode`
+- `spa/src/lib/hook-modules.ts`：新增 `opencode` hook card
+- `spa/src/lib/agent-metadata.ts`：新增 `opencode: 'OpenCode'`
+- `spa/src/locales/en.json` / `zh-TW.json`：新增 hooks 文案
+
+## 驗證策略
+
+### Go
+
+- `internal/agent/opencode/status_test.go`
+- `internal/agent/opencode/hooks_test.go`
+- `internal/agent/opencode/plugin_template_test.go` 或等位測試：驗證 plugin event mapping、subagent pairing 與 error-after-idle suppress
+- `cmd/pdx/setup_test.go` 補 `opencode` case
+- `internal/module/agent` 補 module-level 測試：驗證 `SubagentStart` / `SubagentStop` / `SessionEnd` 在 `opencode` 路徑下的 projection 與 error guard 行為
+
+### 前端
+
+- 以型別 / build 驗證 `hook-modules`、locales、agent metadata 變更可編譯
+
+## 風險
+
+1. `opencode` event 順序可能與文件或本機觀察不同，plugin 需要做最小量 state 去重與 suppress。
+2. host-global plugin 代表使用者若在同一 host 上跑多個 repo，都會共用同一份 hook plugin；這和 `host > hooks` 的現有心智模型一致，但不是 repo-isolated 行為。
+3. `opencode` plugin API 是設定驅動而非固定 hook schema，未來版本若改 event 名稱，需要更新 plugin mapping。

--- a/internal/agent/opencode/hooks.go
+++ b/internal/agent/opencode/hooks.go
@@ -1,0 +1,116 @@
+package opencode
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wake/purdex/internal/agent"
+)
+
+var opencodeHookEvents = []string{
+	"SessionStart",
+	"UserPromptSubmit",
+	"SubagentStart",
+	"SubagentStop",
+	"PermissionRequest",
+	"Stop",
+	"StopFailure",
+	"SessionEnd",
+}
+
+func (p *Provider) InstallHooks(pdxPath string) error {
+	pluginPath, err := opencodePluginPath()
+	if err != nil {
+		return err
+	}
+	return writeManagedPlugin(pluginPath, pdxPath)
+}
+
+func (p *Provider) RemoveHooks(_ string) error {
+	pluginPath, err := opencodePluginPath()
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(pluginPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read plugin: %w", err)
+	}
+	if !isManagedPlugin(data) {
+		return fmt.Errorf("plugin file exists but is unmanaged")
+	}
+	if err := os.Remove(pluginPath); err != nil {
+		return fmt.Errorf("remove plugin: %w", err)
+	}
+	return nil
+}
+
+func (p *Provider) CheckHooks() (agent.HookStatus, error) {
+	pluginPath, err := opencodePluginPath()
+	if err != nil {
+		return agent.HookStatus{Issues: []string{"cannot find home dir"}}, err
+	}
+	agentVersion := agent.DetectHookAgentVersion("opencode", "--version")
+	data, err := os.ReadFile(pluginPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return agent.HookStatus{
+				Installed:    false,
+				Events:       map[string]agent.HookEventInfo{},
+				Issues:       []string{"pdx-agent-hooks.js not found"},
+				AgentVersion: agentVersion,
+			}, nil
+		}
+		return agent.HookStatus{}, fmt.Errorf("read plugin: %w", err)
+	}
+	if !isManagedPlugin(data) {
+		return agent.HookStatus{
+			Installed:    false,
+			Events:       map[string]agent.HookEventInfo{},
+			Issues:       []string{"plugin file exists but is unmanaged"},
+			AgentVersion: agentVersion,
+		}, nil
+	}
+	events := make(map[string]agent.HookEventInfo, len(opencodeHookEvents))
+	for _, event := range opencodeHookEvents {
+		events[event] = agent.HookEventInfo{Installed: true, Command: pluginPath}
+	}
+	return agent.HookStatus{Installed: true, Events: events, Issues: []string{}, AgentVersion: agentVersion}, nil
+}
+
+func opencodePluginPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js"), nil
+}
+
+func writeManagedPlugin(path, pdxPath string) error {
+	if data, err := os.ReadFile(path); err == nil && !isManagedPlugin(data) {
+		return fmt.Errorf("plugin file exists but is unmanaged")
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read plugin: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+	out := []byte(renderManagedPlugin(pdxPath))
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, out, 0644); err != nil {
+		return fmt.Errorf("write plugin: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename plugin: %w", err)
+	}
+	return nil
+}
+
+func isManagedPlugin(data []byte) bool {
+	return strings.Contains(string(data), managedMarker)
+}

--- a/internal/agent/opencode/hooks_test.go
+++ b/internal/agent/opencode/hooks_test.go
@@ -1,0 +1,97 @@
+package opencode_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wake/purdex/internal/agent/opencode"
+)
+
+func TestOpenCodeHooks_InstallCheckRemove(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	data, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("read plugin: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "pdx-managed:opencode-hooks:v1") {
+		t.Fatalf("missing managed marker in plugin: %s", content)
+	}
+	if !strings.Contains(content, "/usr/local/bin/pdx") {
+		t.Fatalf("missing pdx path in plugin: %s", content)
+	}
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("check hooks: %v", err)
+	}
+	if !status.Installed {
+		t.Fatalf("expected installed status, got %+v", status)
+	}
+	if len(status.Events) == 0 {
+		t.Fatalf("expected managed events in status, got %+v", status)
+	}
+
+	if err := p.RemoveHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("remove hooks: %v", err)
+	}
+	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
+		t.Fatalf("expected plugin removal, stat err=%v", err)
+	}
+
+	status, err = p.CheckHooks()
+	if err != nil {
+		t.Fatalf("check hooks after remove: %v", err)
+	}
+	if status.Installed {
+		t.Fatalf("expected uninstalled status after remove, got %+v", status)
+	}
+	if len(status.Issues) == 0 {
+		t.Fatalf("expected issues after remove, got %+v", status)
+	}
+}
+
+func TestOpenCodeHooks_UnmanagedFileRejected(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("export const Existing = async () => ({})\n"), 0644); err != nil {
+		t.Fatalf("write unmanaged plugin: %v", err)
+	}
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err == nil {
+		t.Fatal("expected install to reject unmanaged file")
+	}
+	if err := p.RemoveHooks("/usr/local/bin/pdx"); err == nil {
+		t.Fatal("expected remove to reject unmanaged file")
+	}
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("check hooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatalf("expected unmanaged file to report not installed, got %+v", status)
+	}
+	if len(status.Issues) == 0 {
+		t.Fatalf("expected unmanaged issue, got %+v", status)
+	}
+	if !strings.Contains(strings.Join(status.Issues, " | "), "unmanaged") {
+		t.Fatalf("expected unmanaged issue text, got %+v", status.Issues)
+	}
+}

--- a/internal/agent/opencode/plugin_template.go
+++ b/internal/agent/opencode/plugin_template.go
@@ -1,0 +1,206 @@
+package opencode
+
+import "fmt"
+
+const managedMarker = "pdx-managed:opencode-hooks:v1"
+
+type mappedHookEvent struct {
+	Name    string
+	Payload map[string]any
+}
+
+type pluginState struct {
+	activeSubagents map[string]string
+	suppressIdle    bool
+}
+
+func newPluginState() *pluginState {
+	return &pluginState{activeSubagents: make(map[string]string)}
+}
+
+func (s *pluginState) handleTaskStart(callID string, args map[string]any) (mappedHookEvent, bool) {
+	if callID == "" {
+		return mappedHookEvent{}, false
+	}
+	if _, exists := s.activeSubagents[callID]; exists {
+		return mappedHookEvent{}, false
+	}
+	agentType := firstString(args, "subagent_type", "agent")
+	if agentType == "" {
+		agentType = "task"
+	}
+	s.activeSubagents[callID] = agentType
+	payload := map[string]any{
+		"agent_id":   callID,
+		"agent_type": agentType,
+	}
+	if description := strMapVal(args, "description"); description != "" {
+		payload["description"] = description
+	}
+	if prompt := strMapVal(args, "prompt"); prompt != "" {
+		payload["prompt"] = prompt
+	}
+	return mappedHookEvent{Name: "SubagentStart", Payload: payload}, true
+}
+
+func (s *pluginState) handleTaskStop(callID, title, output string) (mappedHookEvent, bool) {
+	if callID == "" {
+		return mappedHookEvent{}, false
+	}
+	agentType, exists := s.activeSubagents[callID]
+	if !exists {
+		return mappedHookEvent{}, false
+	}
+	delete(s.activeSubagents, callID)
+	payload := map[string]any{
+		"agent_id":   callID,
+		"agent_type": agentType,
+	}
+	if title != "" {
+		payload["title"] = title
+	}
+	if output != "" {
+		payload["output"] = output
+	}
+	return mappedHookEvent{Name: "SubagentStop", Payload: payload}, true
+}
+
+func (s *pluginState) handleSessionError(errorName, errorDetails string) (mappedHookEvent, bool) {
+	s.suppressIdle = true
+	payload := map[string]any{}
+	if errorName != "" {
+		payload["error"] = errorName
+	}
+	if errorDetails != "" {
+		payload["error_details"] = errorDetails
+	}
+	return mappedHookEvent{Name: "StopFailure", Payload: payload}, true
+}
+
+func (s *pluginState) handleSessionIdle() (mappedHookEvent, bool) {
+	if s.suppressIdle {
+		s.suppressIdle = false
+		return mappedHookEvent{}, false
+	}
+	return mappedHookEvent{Name: "Stop", Payload: map[string]any{}}, true
+}
+
+func renderManagedPlugin(pdxPath string) string {
+	return fmt.Sprintf(`// %s
+export const PurdexOpenCodeHooks = async () => {
+  const activeSubagents = new Map()
+  const suppressIdleForSession = new Set()
+  const pdxPath = %q
+
+  async function emit(eventName, payload = {}) {
+    const proc = Bun.spawn({
+      cmd: [pdxPath, 'hook', '--agent', 'opencode', eventName],
+      stdin: JSON.stringify(payload),
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+    await proc.exited
+  }
+
+  function agentTypeFromArgs(args) {
+    if (!args || typeof args !== 'object') return 'task'
+    if (typeof args.subagent_type === 'string' && args.subagent_type) return args.subagent_type
+    if (typeof args.agent === 'string' && args.agent) return args.agent
+    return 'task'
+  }
+
+  return {
+    event: async ({ event }) => {
+      switch (event.type) {
+        case 'session.created':
+          await emit('SessionStart', { session_id: event.properties.sessionID })
+          return
+        case 'permission.asked':
+          await emit('PermissionRequest', {
+            request_type: 'permission',
+            permission: event.properties.permission,
+            patterns: event.properties.patterns,
+          })
+          return
+        case 'question.asked':
+          await emit('PermissionRequest', {
+            request_type: 'question',
+            questions: event.properties.questions,
+          })
+          return
+        case 'session.error':
+          if (event.properties.sessionID) suppressIdleForSession.add(event.properties.sessionID)
+          await emit('StopFailure', {
+            error: event.properties.error?.name || '',
+            error_details: event.properties.error?.data?.message || '',
+          })
+          return
+        case 'session.idle':
+          if (suppressIdleForSession.has(event.properties.sessionID)) {
+            suppressIdleForSession.delete(event.properties.sessionID)
+            return
+          }
+          await emit('Stop', { session_id: event.properties.sessionID })
+          return
+        case 'session.deleted':
+          await emit('SessionEnd', { session_id: event.properties.sessionID })
+          return
+      }
+    },
+    'chat.message': async (input, output) => {
+      const model = output.message?.model
+      const modelName = model ? (model.providerID + '/' + model.modelID) : ''
+      await emit('UserPromptSubmit', {
+        session_id: input.sessionID,
+        message_id: input.messageID || output.message?.id || '',
+        agent: output.message?.agent || input.agent || '',
+        modelName,
+        source: 'chat.message',
+      })
+    },
+    'tool.execute.before': async (input, output) => {
+      if (input.tool !== 'task' || !input.callID) return
+      const agentType = agentTypeFromArgs(output.args)
+      activeSubagents.set(input.callID, agentType)
+      await emit('SubagentStart', {
+        agent_id: input.callID,
+        agent_type: agentType,
+        description: typeof output.args?.description === 'string' ? output.args.description : '',
+        prompt: typeof output.args?.prompt === 'string' ? output.args.prompt : '',
+      })
+    },
+    'tool.execute.after': async (input, output) => {
+      if (input.tool !== 'task' || !input.callID) return
+      const agentType = activeSubagents.get(input.callID)
+      if (!agentType) return
+      activeSubagents.delete(input.callID)
+      await emit('SubagentStop', {
+        agent_id: input.callID,
+        agent_type: agentType,
+        title: output.title || '',
+        output: output.output || '',
+      })
+    },
+  }
+}
+`, managedMarker, pdxPath)
+}
+
+func firstString(values map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := strMapVal(values, key); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func strMapVal(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	if value, ok := values[key].(string); ok {
+		return value
+	}
+	return ""
+}

--- a/internal/agent/opencode/plugin_template.go
+++ b/internal/agent/opencode/plugin_template.go
@@ -18,18 +18,19 @@ func newPluginState() *pluginState {
 	return &pluginState{activeSubagents: make(map[string]string)}
 }
 
-func (s *pluginState) handleTaskStart(callID string, args map[string]any) (mappedHookEvent, bool) {
-	if callID == "" {
+func (s *pluginState) handleTaskStart(sessionID, callID string, args map[string]any) (mappedHookEvent, bool) {
+	key := subagentKey(sessionID, callID)
+	if key == "" {
 		return mappedHookEvent{}, false
 	}
-	if _, exists := s.activeSubagents[callID]; exists {
+	if _, exists := s.activeSubagents[key]; exists {
 		return mappedHookEvent{}, false
 	}
 	agentType := firstString(args, "subagent_type", "agent")
 	if agentType == "" {
 		agentType = "task"
 	}
-	s.activeSubagents[callID] = agentType
+	s.activeSubagents[key] = agentType
 	payload := map[string]any{
 		"agent_id":   callID,
 		"agent_type": agentType,
@@ -43,15 +44,16 @@ func (s *pluginState) handleTaskStart(callID string, args map[string]any) (mappe
 	return mappedHookEvent{Name: "SubagentStart", Payload: payload}, true
 }
 
-func (s *pluginState) handleTaskStop(callID, title, output string) (mappedHookEvent, bool) {
-	if callID == "" {
+func (s *pluginState) handleTaskStop(sessionID, callID, title, output string) (mappedHookEvent, bool) {
+	key := subagentKey(sessionID, callID)
+	if key == "" {
 		return mappedHookEvent{}, false
 	}
-	agentType, exists := s.activeSubagents[callID]
+	agentType, exists := s.activeSubagents[key]
 	if !exists {
 		return mappedHookEvent{}, false
 	}
-	delete(s.activeSubagents, callID)
+	delete(s.activeSubagents, key)
 	payload := map[string]any{
 		"agent_id":   callID,
 		"agent_type": agentType,
@@ -83,6 +85,13 @@ func (s *pluginState) handleSessionIdle() (mappedHookEvent, bool) {
 		return mappedHookEvent{}, false
 	}
 	return mappedHookEvent{Name: "Stop", Payload: map[string]any{}}, true
+}
+
+func subagentKey(sessionID, callID string) string {
+	if sessionID == "" || callID == "" {
+		return ""
+	}
+	return sessionID + ":" + callID
 }
 
 func renderManagedPlugin(pdxPath string) string {
@@ -148,7 +157,7 @@ export const PurdexOpenCodeHooks = async () => {
       }
     },
     'chat.message': async (input, output) => {
-      const model = output.message?.model
+      const model = input.model
       const modelName = model ? (model.providerID + '/' + model.modelID) : ''
       await emit('UserPromptSubmit', {
         session_id: input.sessionID,
@@ -160,8 +169,10 @@ export const PurdexOpenCodeHooks = async () => {
     },
     'tool.execute.before': async (input, output) => {
       if (input.tool !== 'task' || !input.callID) return
+      const subagentKey = input.sessionID + ':' + input.callID
+      if (activeSubagents.has(subagentKey)) return
       const agentType = agentTypeFromArgs(output.args)
-      activeSubagents.set(input.callID, agentType)
+      activeSubagents.set(subagentKey, agentType)
       await emit('SubagentStart', {
         agent_id: input.callID,
         agent_type: agentType,
@@ -171,9 +182,10 @@ export const PurdexOpenCodeHooks = async () => {
     },
     'tool.execute.after': async (input, output) => {
       if (input.tool !== 'task' || !input.callID) return
-      const agentType = activeSubagents.get(input.callID)
+      const subagentKey = input.sessionID + ':' + input.callID
+      const agentType = activeSubagents.get(subagentKey)
       if (!agentType) return
-      activeSubagents.delete(input.callID)
+      activeSubagents.delete(subagentKey)
       await emit('SubagentStop', {
         agent_id: input.callID,
         agent_type: agentType,

--- a/internal/agent/opencode/plugin_template_test.go
+++ b/internal/agent/opencode/plugin_template_test.go
@@ -1,0 +1,111 @@
+package opencode
+
+import "testing"
+
+func TestPluginState_TaskStartMapsSubagentStart(t *testing.T) {
+	state := newPluginState()
+	event, ok := state.handleTaskStart("call-1", map[string]any{
+		"subagent_type": "Explore",
+		"description":   "trace tree",
+		"prompt":        "inspect process tree",
+	})
+	if !ok {
+		t.Fatal("expected task start event")
+	}
+	if event.Name != "SubagentStart" {
+		t.Fatalf("event name = %q, want SubagentStart", event.Name)
+	}
+	if event.Payload["agent_id"] != "call-1" {
+		t.Fatalf("agent_id = %#v, want call-1", event.Payload["agent_id"])
+	}
+	if event.Payload["agent_type"] != "Explore" {
+		t.Fatalf("agent_type = %#v, want Explore", event.Payload["agent_type"])
+	}
+	if len(state.activeSubagents) != 1 || state.activeSubagents["call-1"] != "Explore" {
+		t.Fatalf("activeSubagents = %#v, want call-1 => Explore", state.activeSubagents)
+	}
+}
+
+func TestPluginState_TaskStartDuplicateCallIDIgnored(t *testing.T) {
+	state := newPluginState()
+	if _, ok := state.handleTaskStart("call-1", map[string]any{"agent": "Explore"}); !ok {
+		t.Fatal("first start should be accepted")
+	}
+	if _, ok := state.handleTaskStart("call-1", map[string]any{"agent": "Plan"}); ok {
+		t.Fatal("duplicate start should be ignored")
+	}
+	if got := state.activeSubagents["call-1"]; got != "Explore" {
+		t.Fatalf("activeSubagents[call-1] = %q, want Explore", got)
+	}
+}
+
+func TestPluginState_TaskStartEmptyCallIDIgnored(t *testing.T) {
+	state := newPluginState()
+	if _, ok := state.handleTaskStart("", map[string]any{"agent": "Explore"}); ok {
+		t.Fatal("empty callID should be ignored")
+	}
+	if len(state.activeSubagents) != 0 {
+		t.Fatalf("activeSubagents = %#v, want empty", state.activeSubagents)
+	}
+}
+
+func TestPluginState_TaskStopMapsSubagentStop(t *testing.T) {
+	state := newPluginState()
+	if _, ok := state.handleTaskStart("call-1", map[string]any{"agent": "Explore"}); !ok {
+		t.Fatal("task start should be accepted")
+	}
+	event, ok := state.handleTaskStop("call-1", "done", "all good")
+	if !ok {
+		t.Fatal("expected task stop event")
+	}
+	if event.Name != "SubagentStop" {
+		t.Fatalf("event name = %q, want SubagentStop", event.Name)
+	}
+	if event.Payload["agent_id"] != "call-1" {
+		t.Fatalf("agent_id = %#v, want call-1", event.Payload["agent_id"])
+	}
+	if event.Payload["agent_type"] != "Explore" {
+		t.Fatalf("agent_type = %#v, want Explore", event.Payload["agent_type"])
+	}
+	if len(state.activeSubagents) != 0 {
+		t.Fatalf("activeSubagents = %#v, want empty", state.activeSubagents)
+	}
+}
+
+func TestPluginState_TaskStopUnknownCallIDIgnored(t *testing.T) {
+	state := newPluginState()
+	if _, ok := state.handleTaskStop("missing", "done", "all good"); ok {
+		t.Fatal("unknown callID stop should be ignored")
+	}
+}
+
+func TestPluginState_TaskStopBeforeStartIgnored(t *testing.T) {
+	state := newPluginState()
+	if _, ok := state.handleTaskStop("call-1", "done", "all good"); ok {
+		t.Fatal("stop-before-start should be ignored")
+	}
+	if len(state.activeSubagents) != 0 {
+		t.Fatalf("activeSubagents = %#v, want empty", state.activeSubagents)
+	}
+}
+
+func TestPluginState_SuppressIdleAfterError(t *testing.T) {
+	state := newPluginState()
+	event, ok := state.handleSessionError("provider_error", "boom")
+	if !ok {
+		t.Fatal("expected stop failure event")
+	}
+	if event.Name != "StopFailure" {
+		t.Fatalf("event name = %q, want StopFailure", event.Name)
+	}
+	if _, ok := state.handleSessionIdle(); ok {
+		t.Fatal("first idle after error should be suppressed")
+	}
+	event, ok = state.handleSessionIdle()
+	if !ok {
+		t.Fatal("second idle should emit stop")
+	}
+	if event.Name != "Stop" {
+		t.Fatalf("event name = %q, want Stop", event.Name)
+	}
+}

--- a/internal/agent/opencode/plugin_template_test.go
+++ b/internal/agent/opencode/plugin_template_test.go
@@ -1,10 +1,13 @@
 package opencode
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestPluginState_TaskStartMapsSubagentStart(t *testing.T) {
 	state := newPluginState()
-	event, ok := state.handleTaskStart("call-1", map[string]any{
+	event, ok := state.handleTaskStart("sess-1", "call-1", map[string]any{
 		"subagent_type": "Explore",
 		"description":   "trace tree",
 		"prompt":        "inspect process tree",
@@ -21,27 +24,40 @@ func TestPluginState_TaskStartMapsSubagentStart(t *testing.T) {
 	if event.Payload["agent_type"] != "Explore" {
 		t.Fatalf("agent_type = %#v, want Explore", event.Payload["agent_type"])
 	}
-	if len(state.activeSubagents) != 1 || state.activeSubagents["call-1"] != "Explore" {
-		t.Fatalf("activeSubagents = %#v, want call-1 => Explore", state.activeSubagents)
+	if len(state.activeSubagents) != 1 || state.activeSubagents["sess-1:call-1"] != "Explore" {
+		t.Fatalf("activeSubagents = %#v, want sess-1:call-1 => Explore", state.activeSubagents)
 	}
 }
 
 func TestPluginState_TaskStartDuplicateCallIDIgnored(t *testing.T) {
 	state := newPluginState()
-	if _, ok := state.handleTaskStart("call-1", map[string]any{"agent": "Explore"}); !ok {
+	if _, ok := state.handleTaskStart("sess-1", "call-1", map[string]any{"agent": "Explore"}); !ok {
 		t.Fatal("first start should be accepted")
 	}
-	if _, ok := state.handleTaskStart("call-1", map[string]any{"agent": "Plan"}); ok {
+	if _, ok := state.handleTaskStart("sess-1", "call-1", map[string]any{"agent": "Plan"}); ok {
 		t.Fatal("duplicate start should be ignored")
 	}
-	if got := state.activeSubagents["call-1"]; got != "Explore" {
-		t.Fatalf("activeSubagents[call-1] = %q, want Explore", got)
+	if got := state.activeSubagents["sess-1:call-1"]; got != "Explore" {
+		t.Fatalf("activeSubagents[sess-1:call-1] = %q, want Explore", got)
+	}
+}
+
+func TestPluginState_TaskStartSameCallIDDifferentSessionAllowed(t *testing.T) {
+	state := newPluginState()
+	if _, ok := state.handleTaskStart("sess-1", "call-1", map[string]any{"agent": "Explore"}); !ok {
+		t.Fatal("first start should be accepted")
+	}
+	if _, ok := state.handleTaskStart("sess-2", "call-1", map[string]any{"agent": "Plan"}); !ok {
+		t.Fatal("same callID in different session should be accepted")
+	}
+	if got := state.activeSubagents["sess-2:call-1"]; got != "Plan" {
+		t.Fatalf("activeSubagents[sess-2:call-1] = %q, want Plan", got)
 	}
 }
 
 func TestPluginState_TaskStartEmptyCallIDIgnored(t *testing.T) {
 	state := newPluginState()
-	if _, ok := state.handleTaskStart("", map[string]any{"agent": "Explore"}); ok {
+	if _, ok := state.handleTaskStart("sess-1", "", map[string]any{"agent": "Explore"}); ok {
 		t.Fatal("empty callID should be ignored")
 	}
 	if len(state.activeSubagents) != 0 {
@@ -51,10 +67,10 @@ func TestPluginState_TaskStartEmptyCallIDIgnored(t *testing.T) {
 
 func TestPluginState_TaskStopMapsSubagentStop(t *testing.T) {
 	state := newPluginState()
-	if _, ok := state.handleTaskStart("call-1", map[string]any{"agent": "Explore"}); !ok {
+	if _, ok := state.handleTaskStart("sess-1", "call-1", map[string]any{"agent": "Explore"}); !ok {
 		t.Fatal("task start should be accepted")
 	}
-	event, ok := state.handleTaskStop("call-1", "done", "all good")
+	event, ok := state.handleTaskStop("sess-1", "call-1", "done", "all good")
 	if !ok {
 		t.Fatal("expected task stop event")
 	}
@@ -74,14 +90,14 @@ func TestPluginState_TaskStopMapsSubagentStop(t *testing.T) {
 
 func TestPluginState_TaskStopUnknownCallIDIgnored(t *testing.T) {
 	state := newPluginState()
-	if _, ok := state.handleTaskStop("missing", "done", "all good"); ok {
+	if _, ok := state.handleTaskStop("sess-1", "missing", "done", "all good"); ok {
 		t.Fatal("unknown callID stop should be ignored")
 	}
 }
 
 func TestPluginState_TaskStopBeforeStartIgnored(t *testing.T) {
 	state := newPluginState()
-	if _, ok := state.handleTaskStop("call-1", "done", "all good"); ok {
+	if _, ok := state.handleTaskStop("sess-1", "call-1", "done", "all good"); ok {
 		t.Fatal("stop-before-start should be ignored")
 	}
 	if len(state.activeSubagents) != 0 {
@@ -107,5 +123,18 @@ func TestPluginState_SuppressIdleAfterError(t *testing.T) {
 	}
 	if event.Name != "Stop" {
 		t.Fatalf("event name = %q, want Stop", event.Name)
+	}
+}
+
+func TestRenderManagedPlugin_UsesInputModelAndSessionScopedSubagentKeys(t *testing.T) {
+	rendered := renderManagedPlugin("/usr/local/bin/pdx")
+	if !strings.Contains(rendered, "const model = input.model") {
+		t.Fatalf("rendered plugin should read model from input.model: %s", rendered)
+	}
+	if !strings.Contains(rendered, "const subagentKey = input.sessionID + ':' + input.callID") {
+		t.Fatalf("rendered plugin should scope subagent keys by sessionID+callID: %s", rendered)
+	}
+	if !strings.Contains(rendered, "if (activeSubagents.has(subagentKey)) return") {
+		t.Fatalf("rendered plugin should ignore duplicate subagent starts: %s", rendered)
 	}
 }

--- a/internal/agent/opencode/provider.go
+++ b/internal/agent/opencode/provider.go
@@ -1,0 +1,45 @@
+package opencode
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"github.com/wake/purdex/internal/agent"
+)
+
+type Provider struct{}
+
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+func (p *Provider) Type() string        { return "opencode" }
+func (p *Provider) DisplayName() string { return "OpenCode" }
+func (p *Provider) IconHint() string    { return "opencode" }
+
+func (p *Provider) Claim(ctx agent.ClaimContext) bool {
+	if ctx.HookEvent != nil {
+		return ctx.HookEvent.AgentType == "opencode"
+	}
+	return false
+}
+
+func (p *Provider) Identify(proc agent.ProcessInfo) bool {
+	exeName := strings.ToLower(filepath.Base(proc.ExePath))
+	if exeName == "opencode" {
+		return true
+	}
+	if !agent.IsJSRuntime(exeName) {
+		return false
+	}
+	return agent.ArgvContainsFragment(proc.Argv, "opencode-ai", "/opencode/", "/opencode-ai/", "opencode/dist")
+}
+
+func (p *Provider) DeriveStatus(eventName string, rawEvent json.RawMessage) agent.DeriveResult {
+	return deriveOpenCodeStatus(eventName, rawEvent)
+}
+
+func (p *Provider) IsAlive(tmuxTarget string) bool {
+	return false
+}

--- a/internal/agent/opencode/status.go
+++ b/internal/agent/opencode/status.go
@@ -1,0 +1,48 @@
+package opencode
+
+import (
+	"encoding/json"
+
+	"github.com/wake/purdex/internal/agent"
+)
+
+func deriveOpenCodeStatus(eventName string, rawEvent json.RawMessage) agent.DeriveResult {
+	var raw map[string]any
+	_ = json.Unmarshal(rawEvent, &raw)
+
+	switch eventName {
+	case "SessionStart":
+		return agent.DeriveResult{Valid: true, Status: agent.StatusIdle}
+	case "UserPromptSubmit":
+		return agent.DeriveResult{Valid: true, Status: agent.StatusRunning, Model: strVal(raw, "modelName")}
+	case "SubagentStart", "SubagentStop":
+		return agent.DeriveResult{Valid: true, Detail: detailSubset(raw, "agent_id", "agent_type", "description", "prompt", "title", "output")}
+	case "PermissionRequest":
+		return agent.DeriveResult{Valid: true, Status: agent.StatusWaiting, Detail: detailSubset(raw, "request_type", "permission", "patterns", "questions")}
+	case "Stop":
+		return agent.DeriveResult{Valid: true, Status: agent.StatusIdle}
+	case "StopFailure":
+		return agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: detailSubset(raw, "error", "error_details")}
+	case "SessionEnd":
+		return agent.DeriveResult{Valid: true, Status: agent.StatusClear}
+	default:
+		return agent.DeriveResult{Valid: false}
+	}
+}
+
+func detailSubset(raw map[string]any, keys ...string) map[string]any {
+	out := make(map[string]any, len(keys))
+	for _, key := range keys {
+		if value, ok := raw[key]; ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func strVal(raw map[string]any, key string) string {
+	if value, ok := raw[key].(string); ok {
+		return value
+	}
+	return ""
+}

--- a/internal/agent/opencode/status_test.go
+++ b/internal/agent/opencode/status_test.go
@@ -1,0 +1,99 @@
+package opencode_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/opencode"
+)
+
+func deriveViaProvider(eventName string, rawEvent map[string]any) agent.DeriveResult {
+	p := opencode.NewProvider()
+	raw, _ := json.Marshal(rawEvent)
+	return p.DeriveStatus(eventName, raw)
+}
+
+func TestOpenCodeDeriveStatus_SessionStart(t *testing.T) {
+	r := deriveViaProvider("SessionStart", map[string]any{})
+	if !r.Valid || r.Status != agent.StatusIdle {
+		t.Fatalf("expected idle, got %+v", r)
+	}
+}
+
+func TestOpenCodeDeriveStatus_UserPromptSubmit(t *testing.T) {
+	r := deriveViaProvider("UserPromptSubmit", map[string]any{"modelName": "openai/gpt-5.4"})
+	if !r.Valid || r.Status != agent.StatusRunning {
+		t.Fatalf("expected running, got %+v", r)
+	}
+	if r.Model != "openai/gpt-5.4" {
+		t.Fatalf("expected model extraction, got %+v", r)
+	}
+}
+
+func TestOpenCodeDeriveStatus_PermissionRequest(t *testing.T) {
+	r := deriveViaProvider("PermissionRequest", map[string]any{"request_type": "permission", "permission": "bash"})
+	if !r.Valid || r.Status != agent.StatusWaiting {
+		t.Fatalf("expected waiting, got %+v", r)
+	}
+	if r.Detail["permission"] != "bash" {
+		t.Fatalf("expected detail.permission bash, got %+v", r.Detail)
+	}
+}
+
+func TestOpenCodeDeriveStatus_SubagentStart(t *testing.T) {
+	r := deriveViaProvider("SubagentStart", map[string]any{"agent_id": "call-1", "agent_type": "Explore"})
+	if !r.Valid {
+		t.Fatal("SubagentStart should be valid")
+	}
+	if r.Status != "" {
+		t.Fatalf("SubagentStart should not set status, got %q", r.Status)
+	}
+	if r.Detail["agent_id"] != "call-1" {
+		t.Fatalf("agent_id = %#v, want call-1", r.Detail["agent_id"])
+	}
+}
+
+func TestOpenCodeDeriveStatus_SubagentStop(t *testing.T) {
+	r := deriveViaProvider("SubagentStop", map[string]any{"agent_id": "call-1", "agent_type": "Explore", "title": "done"})
+	if !r.Valid {
+		t.Fatal("SubagentStop should be valid")
+	}
+	if r.Status != "" {
+		t.Fatalf("SubagentStop should not set status, got %q", r.Status)
+	}
+	if r.Detail["agent_type"] != "Explore" {
+		t.Fatalf("agent_type = %#v, want Explore", r.Detail["agent_type"])
+	}
+}
+
+func TestOpenCodeDeriveStatus_Stop(t *testing.T) {
+	r := deriveViaProvider("Stop", map[string]any{})
+	if !r.Valid || r.Status != agent.StatusIdle {
+		t.Fatalf("expected idle, got %+v", r)
+	}
+}
+
+func TestOpenCodeDeriveStatus_StopFailure(t *testing.T) {
+	r := deriveViaProvider("StopFailure", map[string]any{"error": "provider_error", "error_details": "boom"})
+	if !r.Valid || r.Status != agent.StatusError {
+		t.Fatalf("expected error, got %+v", r)
+	}
+	if r.Detail["error_details"] != "boom" {
+		t.Fatalf("expected error details, got %+v", r.Detail)
+	}
+}
+
+func TestOpenCodeDeriveStatus_SessionEnd(t *testing.T) {
+	r := deriveViaProvider("SessionEnd", map[string]any{})
+	if !r.Valid || r.Status != agent.StatusClear {
+		t.Fatalf("expected clear, got %+v", r)
+	}
+}
+
+func TestOpenCodeDeriveStatus_UnknownEvent(t *testing.T) {
+	r := deriveViaProvider("Notification", map[string]any{})
+	if r.Valid {
+		t.Fatalf("unexpected valid result: %+v", r)
+	}
+}

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -106,6 +106,9 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		startedAt = frame.StartedAt
 		parentFrameID = frame.ParentFrameID
 	}
+	if req.EventName == "SessionStart" {
+		subagents = []string{}
+	}
 	if parentFrameID == "" {
 		parent, err := m.frames.FindByPanePID(req.TmuxPaneID, info.PPID)
 		if err != nil {

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -142,6 +142,51 @@ func TestHandleEvent_SubagentDoesNotCreateFrame(t *testing.T) {
 	}
 }
 
+func TestHandleEvent_OpenCodeSessionStartClearsPersistedSubagents(t *testing.T) {
+	m := newTestModule(t)
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "opencode",
+		derive: func(event string, _ json.RawMessage) agentpkg.DeriveResult {
+			switch event {
+			case "SessionStart":
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			case "SubagentStart":
+				return agentpkg.DeriveResult{Valid: true, Detail: map[string]any{"agent_id": "call-1", "agent_type": "Explore"}}
+			default:
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			}
+		},
+	})
+
+	for _, body := range []string{
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"opencode"}`,
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SubagentStart","raw_event":{},"agent_type":"opencode"}`,
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"opencode"}`,
+	} {
+		req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		m.handleEvent(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+	}
+
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("frame subagents = %#v, want empty after SessionStart cleanup", frames[0].Subagents)
+	}
+	if got := m.subagents["work"]; len(got) != 0 {
+		t.Fatalf("in-memory subagents = %#v, want empty after SessionStart cleanup", got)
+	}
+}
+
 func TestReplay_SkipsFramesWithStaleStartTime(t *testing.T) {
 	m := newTestModule(t)
 	fakeTmux := tmux.NewFakeExecutor()

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -119,9 +119,12 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		current := m.currentStatus[req.TmuxSession]
 		m.mu.Unlock()
 		if current == agentpkg.StatusError {
-			canClear := req.EventName == "UserPromptSubmit" ||
-				req.EventName == "SessionStart" ||
-				req.EventName == "Stop"
+			canClear := req.EventName == "UserPromptSubmit" || req.EventName == "SessionStart"
+			if req.AgentType == "opencode" {
+				canClear = canClear || req.EventName == "SessionEnd"
+			} else {
+				canClear = canClear || req.EventName == "Stop"
+			}
 			if !canClear {
 				normalized := buildProjectionNormalized(nil, req.AgentType, req.EventName, broadcastTs, result)
 				trace.Emit(normalized, normalized.AgentType, normalized.RawEventName, "skipped", "error_guard_blocked")
@@ -168,6 +171,13 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 
 	// Handle subagent events (transient — broadcast only, don't persist)
 	if req.EventName == "SubagentStart" || req.EventName == "SubagentStop" {
+		if frameMeta.Decision != "updated_frame" {
+			trace.Finish("completed", "emit_skipped")
+			traceFinished = true
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+			return
+		}
 		m.mu.Lock()
 		syncProjectionState(m.currentStatus, m.subagents, req.TmuxSession, projection)
 		m.mu.Unlock()
@@ -661,8 +671,9 @@ func (m *Module) handleDetect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result := map[string]agentInfo{
-		"cc":    detect("claude", "--version"),
-		"codex": detect("codex", "--version"),
+		"cc":       detect("claude", "--version"),
+		"codex":    detect("codex", "--version"),
+		"opencode": detect("opencode", "--version"),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	agentcc "github.com/wake/purdex/internal/agent/cc"
+	"github.com/wake/purdex/internal/agent/opencode"
 	"github.com/wake/purdex/internal/agent/probe"
 	"github.com/wake/purdex/internal/core"
 	"github.com/wake/purdex/internal/module/session"
@@ -281,6 +282,215 @@ func TestHandleEvent_ErrorGuardBlocksFrameMutation(t *testing.T) {
 	}
 }
 
+func TestHandleEvent_OpenCodeSessionEndClearsErrorState(t *testing.T) {
+	m := newTestModule(t)
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "opencode",
+		derive: func(event string, _ json.RawMessage) agentpkg.DeriveResult {
+			switch event {
+			case "SessionEnd":
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusClear}
+			default:
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			}
+		},
+	})
+
+	for _, body := range []string{
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"opencode"}`,
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionEnd","raw_event":{},"agent_type":"opencode"}`,
+	} {
+		if strings.Contains(body, `"SessionEnd"`) {
+			m.currentStatus["work"] = agentpkg.StatusError
+		}
+		req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		m.handleEvent(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+	}
+
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0", len(frames))
+	}
+	if got := m.currentStatus["work"]; got != "" {
+		t.Fatalf("currentStatus = %q, want cleared", got)
+	}
+}
+
+func TestHandleEvent_OpenCodeStopDoesNotClearError(t *testing.T) {
+	m := newTestModule(t)
+	m.currentStatus["work"] = agentpkg.StatusError
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "opencode",
+		derive: func(string, json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+		},
+	})
+
+	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"Stop","raw_event":{},"agent_type":"opencode"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleEvent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := m.currentStatus["work"]; got != agentpkg.StatusError {
+		t.Fatalf("currentStatus = %q, want error", got)
+	}
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0", len(frames))
+	}
+}
+
+func TestHandleEvent_OpenCodeValidSubagentBroadcasts(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "opencode",
+		derive: func(event string, _ json.RawMessage) agentpkg.DeriveResult {
+			switch event {
+			case "SessionStart":
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			case "SubagentStart":
+				return agentpkg.DeriveResult{Valid: true, Detail: map[string]any{"agent_id": "call-1", "agent_type": "Explore"}}
+			default:
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			}
+		},
+	})
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	for _, body := range []string{
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"opencode"}`,
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SubagentStart","raw_event":{},"agent_type":"opencode"}`,
+	} {
+		req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		m.handleEvent(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+	}
+
+	select {
+	case <-sub.SendCh():
+		// SessionStart broadcast
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for SessionStart broadcast")
+	}
+
+	select {
+	case msg := <-sub.SendCh():
+		var env struct {
+			Type    string `json:"type"`
+			Session string `json:"session"`
+			Value   string `json:"value"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		if env.Type != "hook" {
+			t.Fatalf("broadcast type = %q, want hook", env.Type)
+		}
+		if env.Session != "code-work" {
+			t.Fatalf("broadcast session = %q, want code-work", env.Session)
+		}
+		if !strings.Contains(env.Value, `"raw_event_name":"SubagentStart"`) {
+			t.Fatalf("broadcast value missing raw_event_name: %s", env.Value)
+		}
+		if !strings.Contains(env.Value, `"subagents":["call-1"]`) {
+			t.Fatalf("broadcast value missing subagent membership: %s", env.Value)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for SubagentStart broadcast")
+	}
+}
+
+func TestHandleEvent_OpenCodeMalformedSubagentDoesNotBroadcast(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "opencode",
+		derive: func(event string, _ json.RawMessage) agentpkg.DeriveResult {
+			switch event {
+			case "SessionStart":
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			case "SubagentStart":
+				return agentpkg.DeriveResult{Valid: true, Detail: map[string]any{"agent_type": "Explore"}}
+			default:
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			}
+		},
+	})
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	for _, body := range []string{
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"opencode"}`,
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SubagentStart","raw_event":{},"agent_type":"opencode"}`,
+	} {
+		req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		m.handleEvent(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+	}
+
+	select {
+	case <-sub.SendCh():
+		// SessionStart broadcast
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for SessionStart broadcast")
+	}
+
+	select {
+	case msg := <-sub.SendCh():
+		t.Fatalf("unexpected malformed subagent broadcast: %s", string(msg))
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("frame subagents = %#v, want empty", frames[0].Subagents)
+	}
+	if got := m.subagents["work"]; len(got) != 0 {
+		t.Fatalf("in-memory subagents = %#v, want empty", got)
+	}
+}
+
 // --- Bug 0: buildNormalized always includes Subagents field ---
 
 func TestBuildNormalized_EmptySubagentsIsNotNil(t *testing.T) {
@@ -529,6 +739,105 @@ func TestHandleStatuslineStatus_CC_Registered(t *testing.T) {
 	case "none", "pdx", "wrapped", "unmanaged":
 	default:
 		t.Errorf("unexpected mode: %q", body.Mode)
+	}
+}
+
+func TestHandleHookStatus_OpenCodeRegistered(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := newTestModule(t)
+	m.registry.Register(opencode.NewProvider())
+
+	req := httptest.NewRequest("GET", "/api/hooks/opencode/status", nil)
+	req.SetPathValue("agent", "opencode")
+	w := httptest.NewRecorder()
+
+	m.handleHookStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", w.Code, w.Body.String())
+	}
+	var body agentpkg.HookStatus
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Installed {
+		t.Fatalf("expected not installed by default, got %+v", body)
+	}
+	if len(body.Issues) == 0 {
+		t.Fatalf("expected issues for missing plugin, got %+v", body)
+	}
+}
+
+func TestHandleHookSetup_OpenCodeInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := newTestModule(t)
+	m.registry.Register(opencode.NewProvider())
+
+	body := strings.NewReader(`{"action":"install"}`)
+	req := httptest.NewRequest("POST", "/api/hooks/opencode/setup", body)
+	req.SetPathValue("agent", "opencode")
+	w := httptest.NewRecorder()
+
+	m.handleHookSetup(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", w.Code, w.Body.String())
+	}
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	if _, err := os.Stat(pluginPath); err != nil {
+		t.Fatalf("expected plugin install, stat err=%v", err)
+	}
+	var bodyStatus agentpkg.HookStatus
+	if err := json.NewDecoder(w.Body).Decode(&bodyStatus); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !bodyStatus.Installed {
+		t.Fatalf("expected installed status, got %+v", bodyStatus)
+	}
+	if !bodyStatus.Events["SubagentStart"].Installed {
+		t.Fatalf("expected SubagentStart installed, got %+v", bodyStatus.Events)
+	}
+}
+
+func TestHandleDetect_IncludesOpenCode(t *testing.T) {
+	binDir := t.TempDir()
+	for name, content := range map[string]string{
+		"opencode": "#!/bin/sh\necho 1.2.3\n",
+	} {
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+
+	m := newTestModule(t)
+	req := httptest.NewRequest("GET", "/api/agents/detect", nil)
+	w := httptest.NewRecorder()
+
+	m.handleDetect(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", w.Code, w.Body.String())
+	}
+	var body map[string]struct {
+		Installed bool   `json:"installed"`
+		Path      string `json:"path"`
+		Version   string `json:"version"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body["opencode"].Installed {
+		t.Fatalf("expected opencode detected, got %+v", body)
+	}
+	if body["opencode"].Version != "1.2.3" {
+		t.Fatalf("opencode version = %q, want 1.2.3", body["opencode"].Version)
 	}
 }
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -15,6 +15,7 @@ import (
 	agentpkg "github.com/wake/purdex/internal/agent"
 	agentcc "github.com/wake/purdex/internal/agent/cc"
 	"github.com/wake/purdex/internal/agent/codex"
+	"github.com/wake/purdex/internal/agent/opencode"
 	"github.com/wake/purdex/internal/agent/probe"
 	"github.com/wake/purdex/internal/core"
 	"github.com/wake/purdex/internal/module/session"
@@ -138,6 +139,10 @@ func (m *Module) Init(c *core.Core) error {
 
 	// Codex provider
 	m.registry.Register(codexProvider)
+
+	opencodeProvider := opencode.NewProvider()
+	m.prober.RegisterIdentifier(opencodeProvider.Type(), opencodeProvider.Identify)
+	m.registry.Register(opencodeProvider)
 
 	// Expose registry for other modules
 	c.Registry.Register("agent.registry", m.registry)

--- a/spa/src/components/hosts/HooksSection.opencode.test.tsx
+++ b/spa/src/components/hosts/HooksSection.opencode.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { HooksSection } from './HooksSection'
+import { useHostStore } from '../../stores/useHostStore'
+
+const hostFetchMock = vi.fn()
+
+vi.mock('../../lib/host-api', () => ({
+  hostFetch: (...args: unknown[]) => hostFetchMock(...args),
+}))
+
+const HOST_ID = 'test-host'
+
+beforeEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  useHostStore.setState({
+    hosts: { [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '1.2.3.4', port: 7860, order: 0 } },
+    hostOrder: [HOST_ID],
+    runtime: { [HOST_ID]: { status: 'connected' } },
+  })
+  hostFetchMock.mockImplementation(async (_hostId: string, path: string) => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({
+      installed: path.includes('/opencode/') ? false : true,
+      events: path.includes('/opencode/')
+        ? { SessionStart: { installed: false }, SubagentStart: { installed: false } }
+        : { SessionStart: { installed: true } },
+      issues: [],
+    }),
+  }))
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('HooksSection opencode integration', () => {
+  it('renders OpenCode hook card from real HOOK_MODULES', async () => {
+    render(<HooksSection hostId={HOST_ID} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('OpenCode Hooks')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('OpenCode hooks configured in ~/.config/opencode/plugins for agent event monitoring')).toBeInTheDocument()
+    expect(hostFetchMock).toHaveBeenCalledWith(HOST_ID, '/api/hooks/opencode/status', undefined)
+  })
+})

--- a/spa/src/lib/agent-metadata.test.ts
+++ b/spa/src/lib/agent-metadata.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import { AGENT_NAMES } from './agent-metadata'
+
+describe('agent-metadata', () => {
+  it('includes opencode display name', () => {
+    expect(AGENT_NAMES.opencode).toBe('OpenCode')
+  })
+})

--- a/spa/src/lib/agent-metadata.ts
+++ b/spa/src/lib/agent-metadata.ts
@@ -1,4 +1,5 @@
 export const AGENT_NAMES: Record<string, string> = {
   cc: 'Claude Code',
   codex: 'Codex',
+  opencode: 'OpenCode',
 }

--- a/spa/src/lib/hook-modules.test.ts
+++ b/spa/src/lib/hook-modules.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useAgentStore } from '../stores/useAgentStore'
+
+const hostFetchMock = vi.fn()
+
+vi.mock('./host-api', () => ({
+  hostFetch: (...args: unknown[]) => hostFetchMock(...args),
+}))
+
+describe('hook-modules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAgentStore.setState({ lastEvents: {}, statuses: {}, unread: {}, subagents: {}, models: {} })
+  })
+
+  it('includes an opencode hook module', async () => {
+    const { HOOK_MODULES } = await import('./hook-modules')
+    const opencodeModule = HOOK_MODULES.find((mod) => mod.id === 'opencode')
+    expect(opencodeModule).toBeTruthy()
+    expect(opencodeModule?.labelKey).toBe('hosts.opencode_hooks')
+    expect(opencodeModule?.descKey).toBe('hosts.opencode_hooks_desc')
+  })
+
+  it('opencode fetchStatus/setup use opencode hook routes', async () => {
+    hostFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ installed: false, events: {}, issues: [] }),
+    })
+
+    const { HOOK_MODULES } = await import('./hook-modules')
+    const opencodeModule = HOOK_MODULES.find((mod) => mod.id === 'opencode')
+    expect(opencodeModule).toBeTruthy()
+
+    await opencodeModule!.fetchStatus('host-1')
+    expect(hostFetchMock).toHaveBeenCalledWith('host-1', '/api/hooks/opencode/status', undefined)
+
+    await opencodeModule!.setup('host-1', 'install')
+    expect(hostFetchMock).toHaveBeenLastCalledWith('host-1', '/api/hooks/opencode/setup', expect.objectContaining({ method: 'POST' }))
+  })
+
+  it('opencode getLastTrigger filters only opencode events', async () => {
+    const { HOOK_MODULES } = await import('./hook-modules')
+    const opencodeModule = HOOK_MODULES.find((mod) => mod.id === 'opencode')
+    expect(opencodeModule?.getLastTrigger).toBeTruthy()
+
+    const result = opencodeModule!.getLastTrigger!('host-1', {
+      'host-1:s1': {
+        agent_type: 'opencode',
+        status: 'idle',
+        raw_event_name: 'SubagentStart',
+        broadcast_ts: 10,
+      },
+      'host-1:s2': {
+        agent_type: 'opencode',
+        status: 'idle',
+        raw_event_name: 'SubagentStart',
+        broadcast_ts: 20,
+      },
+      'host-1:s3': {
+        agent_type: 'cc',
+        status: 'idle',
+        raw_event_name: 'SubagentStart',
+        broadcast_ts: 999,
+      },
+    })
+
+    expect(result).toEqual({ SubagentStart: 20 })
+  })
+})

--- a/spa/src/lib/hook-modules.ts
+++ b/spa/src/lib/hook-modules.ts
@@ -99,4 +99,29 @@ const CODEX_HOOKS: HookModule = {
   },
 }
 
-export const HOOK_MODULES: HookModule[] = [TMUX_HOOKS, CC_HOOKS, CODEX_HOOKS]
+const OPENCODE_HOOKS: HookModule = {
+  id: 'opencode',
+  labelKey: 'hosts.opencode_hooks',
+  descKey: 'hosts.opencode_hooks_desc',
+  fetchStatus: (hostId) => hookFetch(hostId, '/api/hooks/opencode/status'),
+  setup: (hostId, action) =>
+    hookFetch(hostId, '/api/hooks/opencode/setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action }),
+    }),
+  getLastTrigger: (hostId, events) => {
+    const prefix = `${hostId}:`
+    const result: Record<string, number> = {}
+    for (const [key, event] of Object.entries(events)) {
+      if (!key.startsWith(prefix) || event.agent_type !== 'opencode') continue
+      const existing = result[event.raw_event_name]
+      if (!existing || event.broadcast_ts > existing) {
+        result[event.raw_event_name] = event.broadcast_ts
+      }
+    }
+    return Object.keys(result).length > 0 ? result : null
+  },
+}
+
+export const HOOK_MODULES: HookModule[] = [TMUX_HOOKS, CC_HOOKS, CODEX_HOOKS, OPENCODE_HOOKS]

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -553,6 +553,8 @@
   "hosts.cc_hooks_desc": "Claude Code hooks configured in settings.json for agent event monitoring",
   "hosts.codex_hooks": "Codex Hooks",
   "hosts.codex_hooks_desc": "Codex hooks configured in hooks.json for agent event monitoring",
+  "hosts.opencode_hooks": "OpenCode Hooks",
+  "hosts.opencode_hooks_desc": "OpenCode hooks configured in ~/.config/opencode/plugins for agent event monitoring",
   "hosts.hook_agent_version": "Agent Version",
   "hosts.hook_supported_version": "Hook Support Through",
   "hosts.hook_version_warning": "Agent version is newer than the currently supported hook version",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -553,6 +553,8 @@
   "hosts.cc_hooks_desc": "在 settings.json 中設定的 Claude Code hooks，用於 Agent 事件監控",
   "hosts.codex_hooks": "Codex Hooks",
   "hosts.codex_hooks_desc": "在 hooks.json 中設定的 Codex hooks，用於 Agent 事件監控",
+  "hosts.opencode_hooks": "OpenCode Hooks",
+  "hosts.opencode_hooks_desc": "在 ~/.config/opencode/plugins 中設定的 OpenCode hooks，用於 Agent 事件監控",
   "hosts.hook_agent_version": "Agent 版本",
   "hosts.hook_supported_version": "Hook 支援到版本",
   "hosts.hook_version_warning": "目前 agent 版本已高於現在支援的 hook 版本",


### PR DESCRIPTION
## Summary
- add an OpenCode agent provider, managed global plugin installer, and CLI wiring for `/api/hooks/opencode/*` plus `pdx setup --agent opencode`
- map OpenCode task tool lifecycle into Claude-compatible subagent events, including pairing/error-guard cleanup rules and module-level contract coverage
- surface OpenCode in host hooks UI with focused frontend tests and localized labels

## Verification
- `go test ./internal/agent/opencode ./internal/module/agent ./cmd/pdx -count=1`
- `pnpm --prefix spa exec vitest run "src/components/hosts/HooksSection.opencode.test.tsx" "src/lib/hook-modules.test.ts" "src/lib/agent-metadata.test.ts"`
- `pnpm --prefix spa run build` currently fails on baseline TypeScript errors already present on `origin/main`; verified separately in a clean `origin/main` worktree