### PR TITLE
docs(hsr): align spec to 5 decisions + PR-2/3/4/5 plans

### DIFF
--- a/docs/specs/2026-04-21-settings-contribution-registry-design.md
+++ b/docs/specs/2026-04-21-settings-contribution-registry-design.md
@@ -1,7 +1,7 @@
 # Settings Contribution Registry 設計 Spec（三層 Scope）
 
-> 日期：2026-04-21
-> 狀態：Draft v2（post spec-review，PR-1 implementation plan 另見 `2026-04-21-hsr-pr1-registry-core-plan.md`）
+> 日期：2026-04-21（v3 對齊 2026-04-22）
+> 狀態：Draft v3（post PR-1 landing，5 個未決策點已對齊：§6.2 / §7.1 / §7.2 / §7.3 / §8 / §13）
 > 關聯：kickoff `kickoff_host_module_settings.md`（擴大版，涵蓋三層 scope 而非僅 host）
 > 參考：
 > - Codex 探索結果：job `task-mo8crieu-phjsc8`（2026-04-21）
@@ -212,7 +212,7 @@ clearContributions(): void   // 測試用
 - `listContributions(scope)`：依 `order` 升冪排序；只回傳指定 scope；不做 `disabled(ctx)` filter（由 shell 處理）
 - `clearContributions()`：測試隔離用；production flow 不呼叫
 
-**與既有 `settings-section-registry` 的關係**：PR-1 **保留**舊 registry 原樣，新 registry 並存。PR-2 合流策略在該 PR plan 決定。
+**與既有 `settings-section-registry` 的關係**：PR-1 保留舊 registry 原樣，新 registry 並存。**PR-2 合流策略鎖定 adapter-only**（決策 1c）：舊 `registerSettingsSection()` 改為對新 registry 的 adapter，所有既有 callsite 不用動；`SettingsPage` / `WorkspaceSettingsPage` / `HostPage` 只信新 registry。
 
 ### 6.3 `ModuleDefinition` 擴充
 
@@ -269,34 +269,49 @@ interface ModuleDefinition {
 
 理由：這些是 SPA 必備 core（bootstrap 必讀、不可延遲載入、不可由 module 卸載），不符合「可選式 module-contributed settings」語意。詳見 `feedback_core_vs_module_settings.md`。
 
-AppearanceSection / TerminalSection 等屬 **core section**，PR-2 遷移時走 adapter 掛進新 registry，不改其內部資料層。
+**既有 section 搬家節奏（決策 2b）**：AppearanceSection / TerminalSection / SyncSection / LinkDetectionSection 等既有 built-in section，在 HSR PR-2/3/4 階段**只換掛法**（透過 §7.2 adapter 進新 registry），**不改內部程式碼、也不強制轉為 module-owned declaration**。真正把 section 搬進各自 module 的 `settings: []` 宣告，由各 owner（Sync / Editor / Appearance 等）後續獨立 refactor PR 接手，不是 HSR 系列的 scope。
 
-### 7.2 既有 `settings-section-registry`
+### 7.2 既有 `settings-section-registry`（決策 1c — adapter-only）
 
-PR-1 保留不動。合流策略 defer 到 PR-2 plan：
-- (a) 舊 registry 改 export 適配層，內部改走新 registry
-- (b) 舊 registry 廢棄，所有 section 改註冊到新 registry
-- (c) 並存（不建議）
+**鎖定策略**：adapter-only。
+
+- 舊 `registerSettingsSection(section)` 實作改成：組出 `SettingsContributionDeclaration`（`localId` = 原 `id`、`scope: 'purdex'`、`labelKey` = 原 `label`、`component` = 原 component 包一層吃 `{ ctx }` 的 wrapper），同步呼叫 `registerSettingsContribution(...)` 把項目註冊進新 registry
+- 舊 `getSettingsSections()` 與舊 registry 的其他 read API 保留，實作改成對新 registry 的 scope='purdex' filtered view（供尚未遷的 callsite 過渡）
+- `SettingsPage` / `WorkspaceSettingsPage` / `HostPage` 自 PR-2/3/4 起**只讀新 registry**，不再經過舊 API
+- 舊 registry 的完全移除延到 HSR 系列全部 land 後，當舊 callsite 清空再獨立 refactor PR 拔除
+
+**理由**：alpha 階段雖無 backwards-compat 包袱，但一次全遷會迫使 PR-2 同時處理 shell 切換 + section 搬家，scope 難收斂；adapter 讓既有 7 個 builtin section 零改動進新 registry，PR-2 scope 聚焦於 shell 與 adapter 正確性。
 
 ### 7.3 待清理項
 
-- `workspace` reserved section（`register-modules.tsx:258-259`）—— PR-3 清掉
-- `module-config` 空頁 section（`register-modules.tsx:260-265`）—— PR-3 或 PR-5 清掉
-- 舊 `globalConfig` / `workspaceConfig` 欄位：invariant I1 守住雙軌禁令；全面移除延到有 module 將舊軌遷移完畢之後（PR-5 或後續）
+- `workspace` reserved section（`register-modules.tsx:258-259`）—— **PR-3 清掉**（決策 5a）
+- `module-config` 空頁 section（`register-modules.tsx:260-265`）—— **PR-3 清掉**（決策 5a；PR-3 shell 本就動 WorkspaceSettingsPage，順手最省事）
+- 舊 `globalConfig` / `workspaceConfig` 欄位（決策 3b）：invariant I1 守住雙軌禁令；**PR-5 merge 後**發 deprecation warning（console.warn + JSDoc `@deprecated`），指向新 `settings: [{ scope: 'workspace', ... }]`；**全面移除**延到至少 1 個 module 將舊軌遷移完畢之後，由獨立 cleanup PR 處理
+
+**理由（決策 3b）**：deprecate 要有替代範例可指，PR-5（Editor `homePath`）才是第一個真正用新 `hostConfig` / `workspaceConfig` 替代路徑的用例；PR-5 merge 後再發 deprecation 警告，避免 API 消費者沒有可行遷移路徑就被警告轟炸。
 
 ---
 
 ## 8. 實作 Phase（Roadmap）
 
-| PR | 範圍 | Plan 文件 |
-|---|---|---|
-| **PR-1** | Registry 核心 + types + 三層 stores + `ModuleDefinition.settings` + register pass（**不動任何頁面**） | `2026-04-21-hsr-pr1-registry-core-plan.md` |
-| PR-2 | Purdex Settings 頁 shell → registry-driven + core sections adapter | 待寫 |
-| PR-3 | Workspace Settings 頁 shell → registry-driven + 清理 reserved `workspace` section | 待寫 |
-| PR-4 | Host Settings 頁 shell → registry-driven + 六子頁轉 built-in host contributions | 待寫 |
-| PR-5 | Editor `hostSettings.homePath` 首個 module 用例 + 清理 `module-config` 空頁 | 待寫 |
+| PR | 範圍 | Plan 文件 | 狀態 |
+|---|---|---|---|
+| **PR-1** | Registry 核心 + types + 三層 stores + `ModuleDefinition.settings` + register pass（**不動任何頁面**） | `2026-04-21-hsr-pr1-registry-core-plan.md` | ✅ merged (#542, alpha.199) |
+| PR-2 | Purdex Settings 頁 shell → registry-driven + 舊 `settings-section-registry` adapter（決策 1c） | `2026-04-22-hsr-pr2-purdex-shell-plan.md` | 📝 plan |
+| PR-3 | Workspace Settings 頁 shell → registry-driven + 清理 reserved `workspace` section + 清理 `module-config` 空頁（決策 5a） | `2026-04-22-hsr-pr3-workspace-shell-plan.md` | 📝 plan |
+| PR-4 | Host Settings 頁 shell → registry-driven + 六子頁走 built-in adapter registration（決策 4c，非 module 宣告，但走同 contract） | `2026-04-22-hsr-pr4-host-shell-plan.md` | 📝 plan |
+| PR-5 | Editor `settings: [{ scope: 'host', localId: 'homePath' }, { scope: 'workspace', localId: 'homePath' }]` 首個 module 用例 + PR-5 merge 後對舊 `globalConfig` / `workspaceConfig` 發 deprecation warning（決策 3b） | `2026-04-22-hsr-pr5-editor-homepath-plan.md` | 📝 plan |
 
-PR-2/3/4 可並行開（三頁獨立）。PR-5 依賴 PR-4。
+**相依與並行**：
+- PR-2 / PR-3 / PR-4 彼此**不動共用檔案**（三頁 shell 各自獨立），可並行
+- PR-5 依賴 PR-4（`ctx.hostId` 由 PR-4 的 HostPage shell 注入）＋ PR-3（`ctx.workspaceId` 由 PR-3 的 WorkspaceSettingsPage shell 注入）
+- 既有 section（Appearance / Terminal / Sync / LinkDetection 等）的真正搬家到 module-owned declaration **不在** HSR 系列 scope，由各 owner 後續獨立 refactor PR 接手（決策 2b）
+
+**延後 issue 對應**：
+- PR-2/3/4 任一 land 後 → 補 **#538**（render-level smoke test）
+- 第一個 consumer PR 一併處理 → **#539**（`registerSettingsContribution` 收斂為 internal API；PR-2 切斷外部 callsite 最合適）
+- PR-5 前必解 → **#540**（三層 store `get()` 回傳 internal ref / 改回 immutable snapshot）
+- PR-4 sync subsystem 驗證 → **#541**（cross-store rehydrate order）
 
 ---
 
@@ -351,9 +366,9 @@ PR-1 具體驗收條件見 `2026-04-21-hsr-pr1-registry-core-plan.md`。
 
 ---
 
-## 13. 後續 PR 銜接備忘
+## 13. 後續 PR 銜接備忘（決策對齊版）
 
-- **PR-2 起點**：SettingsPage 先做 feature flag 並存吃新舊 registry，穩定後拔舊 registry；既有 sections 以 adapter 掛進新 registry
-- **PR-3 起點**：WorkspaceSettingsPage 拆 shell + reserved `workspace` section 清除 + `removeWorkspace()` cleanup hook
-- **PR-4 起點**：HostPage switch → shell + 六子頁 built-in host contributions 宣告；`ctx.hostId` 來源由 route resolution 提供（§5.3 rule 2）；`removeHost()` cleanup hook
-- **PR-5 起點**：Editor module 宣告 `settings: [{ localId: 'homePath', scope: 'host', ... }]`；搭配 daemon 端已完成的 tilde path 支援
+- **PR-2 起點（決策 1c）**：`SettingsPage` 改**只讀新 registry**（無 feature flag）；同步把舊 `settings-section-registry` 的 `registerSettingsSection` / `getSettingsSections` / 其他 read API 實作改為對新 registry 的薄 adapter；既有 7 個 built-in section 無需改碼，透過 adapter 自動進新 registry；#539 在此 PR 一併把 `registerSettingsContribution` 收斂為 internal（僅供 adapter + register pass 呼叫）
+- **PR-3 起點（決策 5a）**：`WorkspaceSettingsPage` 拆 shell + reserved `workspace` section 清除 + `module-config` 空頁清除 + `removeWorkspace()` cleanup hook（與 PR-1 的 `useWorkspaceSettingsStore.clearWorkspace` 對接）
+- **PR-4 起點（決策 4c）**：`HostPage` switch → shell；六子頁（overview/sessions/hooks/agents/uploads/logs）**不轉為 module 宣告**，改為 shell 內部的「built-in adapter registration」— 由 `HostPage` 載入時自動 `registerSettingsContribution({ moduleId: '_builtin.host', ... })`，走同一條 contract 但來源標記為 built-in；`ctx.hostId` 來源由 route resolution 提供（§5.3 rule 2）；`removeHost()` cleanup hook 對接 `useHostSettingsStore.clearHost`；#541 在此 PR 驗證 cross-store rehydrate order
+- **PR-5 起點（決策 3b）**：Editor module 宣告 `settings: [{ localId: 'homePath', scope: 'host', ... }, { localId: 'homePath', scope: 'workspace', ... }]`；opener 層做層疊 resolve（workspace → host → `fetchPaneHome` fallback）；PR-5 merge 時對舊 `globalConfig` / `workspaceConfig` 加 console.warn + JSDoc `@deprecated`，指向新 `settings` 路徑；全面移除延後獨立 PR

--- a/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
@@ -1,0 +1,195 @@
+# HSR PR-2：Purdex Settings Shell + Legacy Adapter — Implementation Plan
+
+> 日期：2026-04-22
+> 狀態：Ready for Implementation
+> 主 spec：`2026-04-21-settings-contribution-registry-design.md`
+> 決策對齊：1c（adapter-only）+ 2b（既有 section 不搬家）+ 3b（舊 API deprecate 時點）
+> PR 系列：PR-1 ✅ / **PR-2（本文件）** / PR-3 / PR-4 / PR-5
+
+---
+
+## 1. 範圍
+
+**Shell 改造 + legacy adapter**。`SettingsPage` 的 `GlobalSettingsPage` 改讀新 registry；舊 `settings-section-registry` 改為薄 adapter：`registerSettingsSection()` 內部轉呼 `registerSettingsContribution()`；`getSettingsSections()` 改為對新 registry 的 filtered view。既有 7 個 built-in section 內部程式碼**零改動**（決策 2b）。
+
+同步完成 **#539**：把 `registerSettingsContribution` / `clearContributions` 收斂為 internal API（僅供 adapter + register pass + test 呼叫；外部 module 不得直接呼叫）。
+
+PR-2 結束時：
+- `GlobalSettingsPage` 透過 `listContributions('purdex')` + `SettingsContext({ scope: 'purdex' })` 渲染
+- 既有 7 個 section UI 外觀、order、URL 行為 100% 與 main 一致
+- 舊 `registerSettingsSection` 所有 callsite 無需改碼即自動進新 registry
+- `WorkspaceSettingsPage` / `HostPage` 不在本 PR scope（PR-3 / PR-4 接手）
+- `workspace` reserved / `module-config` 空頁不在本 PR 清（PR-3 決策 5a）
+
+---
+
+## 2. 檔案清單
+
+### 修改
+- `spa/src/components/SettingsPage.tsx`
+  - `GlobalSettingsPage` 內部 `getSettingsSections()` 改為 `listContributions('purdex')`
+  - 新增 `const ctx: SettingsContext = { scope: 'purdex' }` 傳入 `<ActiveComponent ctx={ctx} />`
+  - 排序依舊 by `order` 升冪（新 registry 已保證）
+  - URL 分派 / `lastSection` / `SettingsRouteContext` 邏輯保留
+- `spa/src/components/settings/SettingsSidebar.tsx`
+  - 改吃 `listContributions('purdex')`
+  - `reservedStart` 邏輯保留（因為 reserved section 會在 PR-3 才清，PR-2 期間仍可能出現無 `component` 的 contribution；但新 registry 的 `component` 是 required，所以實務上不會有 reserved 進 registry — adapter 在組 declaration 時若原 def `component` 為 undefined，**跳過註冊**，由 PR-3 shell 改造時一併拔除 reserved 顯示）
+  - `label` → `labelKey`（其實只是欄位 rename，值原本就是 i18n key）
+- `spa/src/lib/settings-section-registry.ts`（adapter 化）
+  - `registerSettingsSection(def)`：組 `SettingsContributionDeclaration`（`localId = def.id`、`scope: 'purdex'`、`order = def.order`、`labelKey = def.label`、`component = wrapLegacyComponent(def.component)`）+ `moduleId = '_builtin.legacy-section'`，呼叫 `registerSettingsContribution({ ...decl, moduleId, id: `${moduleId}.${def.id}` })`
+  - 若 `def.component` 為 `undefined` → **跳過註冊**（避免新 registry required field 衝突；reserved section 的 UI 由 PR-3 sidebar 改造時明確處理）
+  - `getSettingsSections()`：`listContributions('purdex').filter(c => c.moduleId === '_builtin.legacy-section').map(c => ({ id: c.localId, label: c.labelKey, order: c.order, component: unwrapLegacyComponent(c.component) }))`
+  - `clearSettingsSectionRegistry()`：呼叫 `clearContributions()`（registry test-only）或只清 legacy namespace（取決於是否只測 legacy adapter — 安全作法：只清 `_builtin.legacy-section.*`）
+  - `wrapLegacyComponent(Comp)`：`(props: { ctx: SettingsContext }) => <Comp />`（忽略 ctx — legacy component 不吃 ctx）
+  - `unwrapLegacyComponent(Wrapped)`：adapter 內部把 wrap 時原 Comp 掛在 `Wrapped.__legacyComponent` 取回；或直接存 map — 任一皆可，一致即可
+- `spa/src/lib/settings-contribution-registry.ts`（#539 internal 收斂）
+  - `registerSettingsContribution` / `clearContributions` 加 `/** @internal */` JSDoc tag
+  - Re-export 從 `module-registry.ts` 拿掉（module 作者只透過 `ModuleDefinition.settings` 宣告，不得繞過 register pass 直接呼叫）
+  - `listContributions` / `getContribution` 保持 public（shell 消費）
+  - 若有外部 callsite（PR-1 後除 adapter 外理論應為 0 個），lint rule 或 ESLint `no-restricted-imports` 擋（optional，有則做）
+
+### 新增
+- `spa/src/components/SettingsPage.test.tsx`
+  - Render-level smoke：註冊 fake contribution（scope: 'purdex'）→ `SettingsPage` render 後 sidebar 顯示該 label、active 時 content 區 render 該 component
+  - URL routing：`/settings/<localId>` → 該 section active；URL subsection 可讀 `useSettingsRoute()`
+  - `lastSection` 保留（remount 仍回到前次 section）
+  - adapter 自動遷移：先呼 `registerSettingsSection({ id: 'test-legacy', label: '...', order: 99, component: Comp })` → `listContributions('purdex')` 回傳該項目
+  - 關閉 #538 首個 render-level 目標
+- `spa/src/lib/settings-section-registry.test.ts`（新增 adapter 行為測試）
+  - adapter round-trip：`registerSettingsSection` → `getSettingsSections` 回傳原 shape
+  - adapter 與 `listContributions('purdex')` 一致性（同一批資料）
+  - `component` undefined 時跳過註冊（無 throw）
+  - `clearSettingsSectionRegistry` 只清 legacy namespace，不清其他 module 的 contribution
+
+### 不動
+- 7 個既有 built-in section 檔（`AppearanceSection` / `TerminalSection` / `SyncSection` / `LinkDetectionSection` / `DevEnvironmentSection` / `TmuxAgentSection` 等 — 確切數量以當下 `register-modules.tsx` 註冊為準）
+- `spa/src/lib/register-modules.tsx`（section 宣告照舊透過舊 `registerSettingsSection` 呼叫；adapter 會接住）
+- `WorkspaceSettingsPage.tsx` / `HostPage.tsx` / `HostSidebar.tsx` / `host-routes.ts`
+- 三層 settings store（PR-1 已建）
+- PR-1 新 registry 的 `settings-contribution-types.ts`
+
+---
+
+## 3. Test Case Matrix
+
+### 3.1 `settings-section-registry.test.ts`（adapter）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Adapter round-trip | `registerSettingsSection({ id, label, order, component })` → `getSettingsSections()` 回傳原 shape | 通過 |
+| Adapter 轉遷 | 註冊後 `listContributions('purdex')` 含該項（`moduleId='_builtin.legacy-section'`、`localId=id`、`labelKey=label`） | 通過 |
+| Order 保留 | 多項註冊後 `getSettingsSections` / `listContributions` 均依 order 升冪 | 通過 |
+| Reserved skip | `registerSettingsSection({ ..., component: undefined })` → 新 registry 內**無該項**，不 throw | 通過 |
+| Namespace 隔離 | 另一 module（透過 `ModuleDefinition.settings`）註冊 `scope: 'purdex'` 的 contribution 不出現在 `getSettingsSections()` | 通過 |
+| Clear | `clearSettingsSectionRegistry()` 只清 legacy namespace | 通過 |
+| Identity | 同 object 重複呼叫 `registerSettingsSection` → 不 throw（對應 PR-1 §6.2 identity check） | 通過 |
+
+### 3.2 `SettingsPage.test.tsx`（render-level）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Render | 註冊 fake contribution → `<SettingsPage>` render 後 sidebar 含 label、content 區 render fake component | 通過 |
+| Ctx 注入 | fake component 讀 `props.ctx.scope` === `'purdex'` | 通過 |
+| Order | 多項註冊 → sidebar 順序依 order | 通過 |
+| URL 同步 | 初始 URL `/settings/<fakeId>` → 該 section active | 通過 |
+| URL 自癒 | URL 指 invalid section → redirect 到 default | 通過（保留既有行為） |
+| URL 自癒 | URL `>2` 段 → trim 到 `/settings/<section>` | 通過 |
+| Subsection | fake component 透過 `useSettingsRoute()` 讀 subsection | 通過 |
+| `lastSection` 持久 | remount `<SettingsPage>` 仍回到前次 active | 通過 |
+| Adapter 整合 | 只透過舊 `registerSettingsSection` 註冊 → `<SettingsPage>` 仍 render 該 section | 通過 |
+| Workspace 分派 | `props.pane.content.scope = { workspaceId: 'wsA' }` → render `WorkspaceSettingsPage`，不走 `GlobalSettingsPage` | 通過（保留既有） |
+
+### 3.3 `register-modules.test.ts` 擴充
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| 端對端 | 跑 `registerBuiltinModules()` 後，現有 7 個 built-in section 皆在 `listContributions('purdex')` 中，`moduleId='_builtin.legacy-section'` | 通過 |
+| 無 regression | I1 guard 對既有 module fixture 仍不 throw | 通過 |
+
+### 3.4 視覺回歸（肉眼 / 手動）
+
+- `cd spa && pnpm dev` 起站
+- 開 `/settings`：sidebar 上 7 個 section 顯示順序、label、active highlight 與 `main` 分支一致
+- 點每個 section：右側 content 正常渲染（無 console error / 白屏）
+- `/settings/<section>/<subsection>`：subsection context 仍可用（挑一個目前有用 subsection 的 section 驗，如 `/settings/sync/history`）
+- Workspace 打開 settings tab（`pane.content.scope` object）：仍走 `WorkspaceSettingsPage`（本 PR 不動）
+
+---
+
+## 4. 實作順序（TDD）
+
+1. **紅**：寫 §3.1 adapter 測試（僅對 adapter 層）
+2. **綠**：改 `settings-section-registry.ts` 為 adapter
+3. **紅**：寫 §3.2 `SettingsPage.test.tsx`
+4. **綠**：改 `SettingsPage.tsx` `GlobalSettingsPage` + `SettingsSidebar.tsx` 吃新 registry；構造 `ctx` 注入
+5. **紅**：寫 §3.3 register-modules 端對端擴充測試
+6. **綠**：驗證 `registerBuiltinModules` 走 adapter 後仍 pass；若 I1 在 adapter scope 有誤擋，調整 I1 判斷（理論上不需，因為 built-in section 走 legacy adapter 的 moduleId 是 `_builtin.legacy-section`，與 module 宣告的 moduleId 不同，I1 不會觸發）
+7. **#539 收斂**：加 `@internal` + 調整 re-export
+8. **驗證**：`cd spa && pnpm exec vitest run` / `pnpm run lint` / `pnpm run build` 三綠
+9. **手動**：§3.4 視覺回歸
+
+---
+
+## 5. 驗收條件
+
+- [ ] §3.1–3.3 測試全綠
+- [ ] `cd spa && pnpm exec vitest run` 全綠
+- [ ] `cd spa && pnpm run lint` 全綠
+- [ ] `cd spa && pnpm run build` 全綠
+- [ ] §3.4 手動視覺回歸無差異
+- [ ] 現有 7 個 built-in section 在 `listContributions('purdex')` 出現，`moduleId='_builtin.legacy-section'`
+- [ ] `registerSettingsContribution` 標為 `@internal`；非 adapter / register-pass / test 的 callsite 為 0（`rg "registerSettingsContribution"` 人工 audit）
+- [ ] Codex 兩輪 review（標準 + 三路對抗）無 critical / P1 未修項
+- [ ] #538 關閉或標記為「部分關閉 — Purdex 層已補 render smoke，待 PR-3/4 補 Workspace / Host 層」
+
+---
+
+## 6. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| Adapter 的 wrap / unwrap 破壞 React component identity（影響 memo / render optimization） | 中 | wrap 時把原 component 存在 `WeakMap<WrappedComp, OrigComp>` 或 static field，unwrap 時穩定取回；測試覆蓋 `getSettingsSections().component === 原 component` 不強求，只求 render 正確 |
+| `_builtin.legacy-section.<id>` 撞到未來真 module 的 id | 低 | `_builtin.*` 前綴保留為 built-in namespace；I1 / I2 對 moduleId 本身不做格式限制，但文件註明 `_builtin.*` 保留 |
+| `SettingsRouteContext` 行為被無意破壞 | 中 | §3.2 subsection 測試覆蓋 |
+| Reserved section（`component` undefined）原本 sidebar 顯示「coming_soon」灰字 — adapter skip 後 UI 少一格 | 中 | 驗 `main` 分支 reserved section 目前確實顯示於 sidebar（`workspace` / `module-config`）；若是 → PR-2 **暫時保留**現有行為（`SettingsSidebar` 仍吃舊 `getSettingsSections()` 或特殊 branch），待 PR-3 決策 5a 一併清；不提前在 PR-2 清 |
+| `@internal` JSDoc 沒實際效力（TypeScript 不強制） | 低 | 加註 + optional lint rule（`no-restricted-imports` pattern），不阻擋 PR |
+
+**風險備註**：reserved section 處理有兩條路。若 PR-2 要保持 UI 100% 一致（包含 coming_soon 灰字），`SettingsSidebar` 內部仍需透過舊 API 取得 reserved 項目；adapter 保留 `component: undefined` 項目於 legacy namespace 但不轉進新 registry — 這條路讓 PR-2 完全無 UX 變動。**本 plan 採此路**：adapter `registerSettingsSection` 時，若 `component` 為 undefined，項目仍存在 legacy local buffer（不進新 registry），`getSettingsSections()` 同時回傳 new registry + local reserved，`SettingsSidebar` 原 reservedStart 邏輯照舊。PR-3 清完 reserved 後 local buffer 也可拔。
+
+---
+
+## 7. 超出 PR-2 範圍（明確不做）
+
+- `WorkspaceSettingsPage` 改 registry-driven（PR-3）
+- `HostPage` / `HostSidebar` / `host-routes` 改 registry-driven（PR-4）
+- 清理 reserved `workspace` section 與 `module-config` 空頁（PR-3，決策 5a）
+- 既有 7 個 section 搬家為 module-owned declaration（決策 2b — 不在 HSR 系列 scope）
+- 舊 `globalConfig` / `workspaceConfig` deprecate（PR-5 後，決策 3b）
+- 三層 store `get()` 回傳 immutable snapshot（#540；等 PR-5 前必解，本 PR 可先開 issue 交付）
+- `registerSettingsContribution` 完全移除 public export（`@internal` JSDoc 即可；強制移除留到至少確認 0 外部 callsite 之後）
+
+---
+
+## 8. Commit 規劃
+
+每個 commit 必須獨立過 vitest / lint / build（完全綠）。
+
+1. **`docs: HSR spec v3 + PR-2/3/4/5 plans`**（若尚未於前置 docs PR merge 則此 commit 納入；若已 merge 可省略）
+2. **`feat(spa): adapt legacy settings-section-registry to new contribution registry`**
+   - `settings-section-registry.ts` adapter 化 + `settings-section-registry.test.ts` 新增
+3. **`feat(spa): SettingsPage reads new contribution registry`**
+   - `SettingsPage.tsx` + `SettingsSidebar.tsx` 改吃新 registry + `SettingsPage.test.tsx` 新增
+4. **`refactor(spa): mark registerSettingsContribution as internal (#539)`**
+   - JSDoc `@internal` + re-export 調整
+5. **（若 adapter PR scope 大）** 拆分 reserved section 兼容處理為獨立 commit
+
+共 3–5 commits。
+
+---
+
+## 9. 與其他 PR 的關聯
+
+- **依賴**：PR-1（已 merged）
+- **不依賴**：PR-3 / PR-4（三頁 shell 改造彼此獨立）
+- **被依賴**：PR-5（Editor 首個用例需要 PR-2 的 shell 已完成，才能在 `/settings/editor` 看到新 section — 但 PR-5 的 Editor `homePath` 是 workspace/host scope，不是 purdex scope，因此嚴格來說也不依賴 PR-2）
+- **順風解決**：#538（Purdex 層）/ #539（internal 收斂）

--- a/docs/specs/2026-04-22-hsr-pr3-workspace-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr3-workspace-shell-plan.md
@@ -1,0 +1,172 @@
+# HSR PR-3：Workspace Settings Shell + Reserved Cleanup — Implementation Plan
+
+> 日期：2026-04-22
+> 狀態：Ready for Implementation
+> 主 spec：`2026-04-21-settings-contribution-registry-design.md`
+> 決策對齊：5a（PR-3 清 reserved + 空頁）+ 2b（既有 `ModuleConfigSection` 不動）
+> PR 系列：PR-1 ✅ / PR-2 / **PR-3（本文件）** / PR-4 / PR-5
+
+---
+
+## 1. 範圍
+
+**Shell 改造 + 清理**。`WorkspaceSettingsPage` 在現有單頁佈局中插入一個「workspace-scoped contributions」區，疊渲染 `listContributions('workspace')`，每個 contribution 以 `ctx: { scope: 'workspace', workspaceId }` 傳入。同步清掉 `register-modules.tsx` 中兩個待清項目：reserved `workspace` section（`order: 10`，無 component）與 `module-config` section（global scope 下的空容器，production 無 `globalConfig` 使用者）。
+
+**保留不動**（決策 2b + 3b）：
+- `ModuleConfigSection.tsx`（`WorkspaceSettingsPage` 直接 render 以承接 `workspaceConfig` 舊軌，特別是 `files.projectPath`）
+- 舊 `globalConfig` / `workspaceConfig` API 與 `useModuleConfigStore`
+- 既有 settings section 內部
+
+PR-3 結束時：
+- `WorkspaceSettingsPage` 新增 registry-driven 區，可顯示任何宣告 `scope: 'workspace'` 的 contribution
+- `register-modules.tsx` 不再註冊 `workspace` reserved 與 `module-config` section
+- SettingsSidebar 在 PR-2 reserved 兼容路徑可拔除（或保留等更晚）
+- Workspace 刪除時 `useWorkspaceSettingsStore` 已由 PR-1 cascade 清理（本 PR 不重做）
+- URL 無變動（workspace settings 仍透過 `pane.content.scope = { workspaceId }` 進入）
+
+---
+
+## 2. 檔案清單
+
+### 修改
+- `spa/src/features/workspace/components/WorkspaceSettingsPage.tsx`
+  - 在 `ModuleConfigSection` 下方插入 registry 區塊：遍歷 `listContributions('workspace')`，每個 contribution 以 `<section>` 包 header（`t(c.labelKey)`）+ body（`<c.component ctx={{ scope: 'workspace', workspaceId }} />`）；`disabled(ctx)` 為 true 時 section 隱藏（或顯示禁用樣式 — 任一策略，測試覆蓋）
+  - 使用 `useMemo` 避免 list 每次 rerender 重算
+  - 排序依 `order` 升冪（registry 已保證）
+- `spa/src/lib/register-modules.tsx`
+  - 移除 `registerSettingsSection({ id: 'workspace', ..., order: 10 })`（reserved 行）
+  - 移除 `registerSettingsSection({ id: 'module-config', ..., order: 8, component: () => <ModuleConfigSection scope="global" /> })`（global scope 無 production 消費者）
+  - 若 PR-2 有為 reserved 保留 local buffer 兼容路徑，同步拔除該 buffer
+- `spa/src/components/settings/SettingsSidebar.tsx`
+  - 清掉 `reservedStart` 分隔線邏輯（reserved 已不存在）
+  - （optional）移除 coming_soon disabled 灰字樣式（若已無 reserved item，分支恆未觸發）
+- `spa/src/locales/en.json` / `zh-TW.json`
+  - 移除 `settings.section.workspace` i18n key（若 reserved 特有，且無其他 callsite）
+  - 保留 `settings.section.modules` key（`module-config` section 相關，但 `ModuleConfigSection` 本身仍在 workspace 頁用，key 可能仍有用；實作時 audit）
+
+### 新增
+- `spa/src/features/workspace/components/WorkspaceSettingsPage.test.tsx`
+  - Render-level：註冊 fake contribution（`scope: 'workspace'`）→ `WorkspaceSettingsPage` render 後該 section 顯示 labelKey 與 body
+  - ctx 注入：fake component 讀 `props.ctx.workspaceId === workspaceId`
+  - `disabled(ctx)` 隱藏：註冊 disabled fake contribution → UI 不顯示（或 disabled 樣式）
+  - order：多 contribution 順序正確
+  - 無 contribution 時 registry 區塊不 render（或 render 空無影響 — 任一實作，測試明確）
+  - reserved 清理回歸：hostsidebar / settingspage 不再顯示 `workspace` reserved item
+
+### 不動
+- `spa/src/components/settings/ModuleConfigSection.tsx`
+- `spa/src/stores/useModuleConfigStore.ts`
+- PR-1 新建的 `settings-contribution-registry.ts` / 三層 store
+- `HostPage.tsx` / `SettingsPage.tsx`（其中 `SettingsPage` 的 Global 分支由 PR-2 改；本 PR 只動 `WorkspaceSettingsPage`）
+- 既有 workspace-scoped 功能（icon picker / delete dialog / danger zone）
+
+---
+
+## 3. Test Case Matrix
+
+### 3.1 `WorkspaceSettingsPage.test.tsx`（新增）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Baseline | 無 contribution 時頁面 render（含 icon picker、name input、ModuleConfigSection、danger zone） | 通過，無 registry 區塊 |
+| Render | 註冊 1 個 fake `scope: 'workspace'` contribution → 頁面 render 該 labelKey + body | 通過 |
+| Ctx 注入 | fake component 讀 `props.ctx` → `scope === 'workspace'` && `workspaceId === 'wsA'` | 通過 |
+| Multi + order | 註冊 3 個 contribution（order 10 / 20 / 5）→ 顯示順序 5 / 10 / 20 | 通過 |
+| Disabled | contribution `disabled: (ctx) => true` → 該 section 不 render（或 UI 禁用） | 通過 |
+| ctx.workspaceId 正確性 | 切換 workspace（重新 mount 帶不同 `workspaceId` prop）→ ctx 帶新 id | 通過 |
+| Cascade（PR-1 已做） | 刪除該 workspace → `useWorkspaceSettingsStore.get(wsId, moduleId)` 回傳 undefined | 通過（驗 PR-1 cascade 仍生效） |
+
+### 3.2 `register-modules.test.ts` 擴充
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Reserved 清理 | `getSettingsSections()` 回傳中**無** `id='workspace'` 項 | 通過 |
+| Module-config 清理 | `getSettingsSections()` 回傳中**無** `id='module-config'` 項 | 通過 |
+| 其餘 section 不變 | `appearance` / `terminal` / `interface` / `sync` / `editor-buffers` 仍存在，順序不變 | 通過 |
+
+### 3.3 視覺回歸（手動）
+
+- `cd spa && pnpm dev`
+- 開一個 workspace → 打開 workspace settings（tab → 齒輪 / command）
+- 驗：icon picker、name input、`ModuleConfigSection`（含 files.projectPath 輸入框）、danger zone 正常
+- 驗：sidebar / settings 頁面**不再顯示** "Workspace" reserved 灰字項
+- 驗：sidebar / settings 頁面**不再顯示** "Modules" / module-config 項
+- 註冊一個臨時 workspace contribution（dev console 或臨時 module）→ 新區塊出現
+
+### 3.4 i18n 驗證
+
+- `settings.section.workspace` 若有其他 callsite 則保留（grep `settings.section.workspace`）
+- `settings.section.modules` 同上 audit
+
+---
+
+## 4. 實作順序（TDD）
+
+1. **紅**：寫 §3.1 `WorkspaceSettingsPage.test.tsx` 所有案例
+2. **綠**：改 `WorkspaceSettingsPage.tsx` 插 registry 區塊
+3. **紅**：寫 §3.2 register-modules 擴充測試
+4. **綠**：拔 `register-modules.tsx` 兩個 `registerSettingsSection`
+5. **紅**（optional）：SettingsSidebar reservedStart 分支測試（若 PR-2 已有此測試則順風消失）
+6. **綠**：精簡 SettingsSidebar
+7. **i18n audit**：grep 兩個 key 的 callsite，決定移或留
+8. **驗證**：`cd spa && pnpm exec vitest run` / `pnpm run lint` / `pnpm run build` 全綠
+9. **手動**：§3.3 視覺回歸
+
+---
+
+## 5. 驗收條件
+
+- [ ] §3.1 / §3.2 測試全綠
+- [ ] `cd spa && pnpm exec vitest run` 全綠
+- [ ] `cd spa && pnpm run lint` 全綠
+- [ ] `cd spa && pnpm run build` 全綠
+- [ ] §3.3 手動視覺回歸：`ModuleConfigSection` 正常、reserved 項消失、workspace registry 區可擴充
+- [ ] `gh issue close #538`（部分關閉 — 若 PR-2 已關則補充 workspace 層註記；若 PR-2 未關則本 PR 一併關）
+- [ ] Codex 兩輪 review 無 critical / P1 未修項
+
+---
+
+## 6. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| 刪除 `module-config` 後，未來若真有 module 要宣告 `globalConfig` 將無 UI 入口 | 中 | 決策 3b 已指示 `globalConfig` 在 PR-5 後 deprecate；新 `globalConfig` 用例應走新 `settings: [{ scope: 'purdex' }]`；若 PR-3 ship 後到 PR-5 前的空窗期出現新 `globalConfig` 需求，可臨時在 `SettingsPage` 以 `<ModuleConfigSection scope="global" />` render（僅 alpha 內部成本低） |
+| `WorkspaceSettingsPage` 現有佈局（icon + name + ModuleConfig + danger zone）穿插 registry section 後視覺失衡 | 中 | registry 區塊用與 `ModuleConfigSection` 一致的 `<section>` 樣式；無 contribution 時不顯示任何空 header；§3.3 手動驗 |
+| reserved item i18n key 被其他地方引用 | 低 | 移除前 grep `settings.section.workspace` + `settings.section.modules`；兩者若有外部 callsite 則保留 i18n，只拔 registry 註冊 |
+| Disabled contribution 策略（隱藏 vs 禁用樣式）未對齊 | 低 | 本 plan §3.1 測試明確採「隱藏」；實作照此 |
+| `WorkspaceSettingsPage` 使用者體驗：registry 區是否要 scroll 進 view、section anchor link、collapse | 低 | 本 PR 不做 UX 加分；只達基本渲染；進階 UX 進 backlog |
+
+---
+
+## 7. 超出 PR-3 範圍（明確不做）
+
+- `SettingsPage` global shell 改造（PR-2）
+- `HostPage` / `HostSidebar` / `host-routes` 改造（PR-4）
+- `ModuleConfigSection.tsx` 本身遷到新 registry（等舊 `workspaceConfig` API 全移除之後，獨立 refactor PR）
+- `files.projectPath` 搬家到新 `settings: [{ scope: 'workspace', localId: 'projectPath' }]`（決策 2b — 由 files module owner 後續 refactor）
+- Editor `homePath` 用例（PR-5）
+- #540 三層 store `get()` immutable snapshot（PR-5 前必解）
+- URL subsection 支援於 workspace 層（目前 workspace 單頁無此需求）
+- Sync contributor 於三層 store 的 wire shape（spec §10 sketch）
+
+---
+
+## 8. Commit 規劃
+
+每 commit 綠。
+
+1. **`feat(spa): WorkspaceSettingsPage renders workspace-scoped contributions`**
+   - `WorkspaceSettingsPage.tsx` + test
+2. **`refactor(spa): drop reserved workspace and module-config sections`**
+   - `register-modules.tsx` 拔兩行 + test 擴充 + SettingsSidebar 精簡 + i18n audit 移除
+
+共 2 commits。
+
+---
+
+## 9. 與其他 PR 的關聯
+
+- **依賴**：PR-1（已 merged）
+- **不依賴**：PR-2 / PR-4（三頁 shell 彼此獨立；PR-2 reserved 兼容 buffer 若存在，PR-3 順手拔）
+- **被依賴**：PR-5（Editor `workspaceConfig.homePath` 首個用例 — 需要 PR-3 的 workspace shell 已能 render 新 contribution）
+- **順風解決**：#538（workspace 層）

--- a/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
@@ -1,0 +1,198 @@
+# HSR PR-4：Host Settings Shell + Built-in Sub-page Adapter — Implementation Plan
+
+> 日期：2026-04-22
+> 狀態：Ready for Implementation
+> 主 spec：`2026-04-21-settings-contribution-registry-design.md`
+> 決策對齊：4c（HostPage registry-driven + 六子頁走 built-in adapter registration）
+> PR 系列：PR-1 ✅ / PR-2 / PR-3 / **PR-4（本文件）** / PR-5
+
+---
+
+## 1. 範圍
+
+**Shell 改造 + built-in adapter registration**。`HostPage` / `HostSidebar` / `host-routes` 改為 registry-driven；六個既有 sub-page（`overview` / `sessions` / `hooks` / `agents` / `uploads` / `logs`）**不改內部程式碼**，透過 built-in adapter 在 `registerBuiltinModules()` 尾段以 `moduleId: '_builtin.host'` 一次註冊進新 registry（走相同 `registerSettingsContribution` contract，但標記為 built-in 來源）。
+
+`ctx.hostId` 由 shell 依 route resolution 結果注入（§5.3 rule 2）；`ctx.scope: 'host'`。
+
+本 PR 順帶驗證 **#541**（cross-store rehydrate order）：`host-lifecycle.test.ts` 擴充測試，確保 `hostWasRecreated` 判定在 `HostStore` 與 `useHostSettingsStore` 兩種 rehydrate 順序下皆正確。
+
+PR-4 結束時：
+- `HostPage` 的 sub-page 渲染透過 `listContributions('host')` + ctx 注入
+- 六子頁以 `_builtin.host.<id>` 存在於 registry，與任何 future module-contributed host section 走同一條 render 路徑
+- URL `/hosts/:hostId/:subPage` 的 `subPage` 合法性判定改為對 registry 查詢
+- 新 module 可宣告 `settings: [{ scope: 'host', ... }]` 並出現在 `HostPage` 左側 sidebar（module owner 自定 header / 分組策略由 sidebar 實作決定）
+- `removeHost()` cascade 對 `useHostSettingsStore` 的清理 PR-1 已完成；本 PR 驗回歸
+
+---
+
+## 2. 檔案清單
+
+### 修改
+- `spa/src/components/HostPage.tsx`
+  - `renderContent()`：從 switch 改為 `const contribution = getContribution(`_builtin.host.${selection.subPage}`)` 或更一般化 `listContributions('host').find(c => c.localId === selection.subPage)`
+  - 找到 contribution 後以 `<contribution.component ctx={{ scope: 'host', hostId: selection.hostId }} />` render
+  - fallback（contribution 不存在）：render `no_host_selected` 或等效空態
+- `spa/src/components/hosts/HostSidebar.tsx`
+  - 移除硬編 `SUB_PAGES` const
+  - `const subPages = listContributions('host')` — 排序已保證
+  - 每項顯示 `t(c.labelKey)`（現 `labelKey` 在 contribution 內；與舊 `SUB_PAGES[].labelKey` 一致）
+  - `onSelect(hostId, subPage)` 參數仍用 `localId`（即現在的 `'overview'` / `'sessions'` 等值）
+- `spa/src/lib/host-routes.ts`
+  - `HOST_SUB_PAGES` 移除或保留為 fallback（implementation choice）
+  - `isHostSubPage(value)` 改為 `listContributions('host').some(c => c.localId === value)`
+  - 若保留 `HOST_SUB_PAGES`：只當 SSR / 極早期 bootstrap 時期 fallback（實務上 `registerBuiltinModules()` 在 React render 前就跑，通常不需要 fallback）
+- `spa/src/lib/register-modules.tsx`
+  - 結尾新增 `registerBuiltinHostSections()` pass（或直接 inline）：
+    - 依序 `registerSettingsContribution({ id: '_builtin.host.overview', moduleId: '_builtin.host', localId: 'overview', scope: 'host', order: 0, labelKey: 'hosts.overview', component: wrap(OverviewSection) })`
+    - 同樣六項：sessions (1) / hooks (2) / agents (3) / uploads (4) / logs (5)
+    - `wrap(Section)` = `(props: { ctx: SettingsContext }) => props.ctx.scope === 'host' ? <Section hostId={props.ctx.hostId} /> : null`
+  - 此 pass 為 internal — `registerSettingsContribution` `@internal` JSDoc 允許 `_builtin.*` 內部 callsite（#539 PR-2 已落地）
+- `spa/src/lib/host-lifecycle.ts`（僅測試擴充，若現有邏輯未觸及 cross-store order 則不動 source）
+- `spa/src/lib/host-lifecycle.test.ts`（擴充 #541 驗證）
+
+### 新增
+- `spa/src/components/HostPage.test.tsx`（render-level）
+  - 現有六 sub-page 能正常 render（透過 registry）
+  - fake `scope: 'host'` contribution 註冊後出現在 sidebar + 可導航
+  - `ctx.hostId` 正確注入
+- `spa/src/lib/host-builtin-sections.test.ts`（optional — 可合併進 `register-modules.test.ts`）
+  - Built-in adapter 註冊後 `listContributions('host').length >= 6`
+  - 順序：overview → sessions → hooks → agents → uploads → logs
+  - Wrap 的 component 正確 forward `hostId`
+
+### 不動
+- 六個既有 sub-page component 內部（`OverviewSection` / `SessionsSection` / `HooksSection` / `AgentsSection` / `UploadSection` / `LogsSection`）
+- URL 結構 `/hosts/:hostId/:subPage`（decode / encode 不變）
+- PR-1 三層 store 內部
+- PR-2 / PR-3 shell
+
+---
+
+## 3. Test Case Matrix
+
+### 3.1 `HostPage.test.tsx`（render-level）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Built-in 渲染 | URL `/hosts/hA/overview` → render `OverviewSection` | 通過 |
+| Built-in 渲染 | URL `/hosts/hA/sessions` → render `SessionsSection` | 通過 |
+| Sidebar 順序 | 六 sub-page 顯示順序 = built-in 註冊 order | 通過 |
+| Fake 擴充 | 註冊 fake `scope: 'host'` contribution（order=100）→ sidebar 多一項、URL `/hosts/hA/<fakeId>` 可 render fake body | 通過 |
+| Ctx 注入 | fake component 讀 `props.ctx` → `scope === 'host'` && `hostId === 'hA'` | 通過 |
+| Invalid subPage | URL `/hosts/hA/nonexistent` → redirect 到 `canonicalPath`（既有 resolveSelection 行為） | 通過 |
+| Disabled | fake contribution `disabled: (ctx) => true` → sidebar 隱藏（或禁用樣式） | 通過 |
+
+### 3.2 `host-routes.test.ts` 擴充或新增
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| `isHostSubPage` | 現六 ID 回 true | 通過 |
+| `isHostSubPage` | 任何 module-contributed host localId 回 true（註冊 fake 後） | 通過 |
+| `isHostSubPage` | 未註冊的 ID 回 false | 通過 |
+
+### 3.3 `register-modules.test.ts` 擴充
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Built-in 註冊 | 跑 `registerBuiltinModules()` 後 `listContributions('host')` 含六項，`moduleId='_builtin.host'` | 通過 |
+| Order | 順序：overview / sessions / hooks / agents / uploads / logs | 通過 |
+| Wrap forward | 取得第 0 項 `listContributions('host')[0]`，用 `ctx={{ scope:'host', hostId:'hA' }}` render → 等同 `<OverviewSection hostId='hA' />` 行為（以 render 內含可辨識文字斷言） | 通過 |
+| Scope guard | `_builtin.host.overview` contribution 收到 `ctx.scope !== 'host'` 時 render null（wrap 的 guard） | 通過 |
+
+### 3.4 `host-lifecycle.test.ts` 擴充（#541）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Rehydrate order A | 模擬 HostStore 先 rehydrate 完成、`useHostSettingsStore` 後 → 刪除 + undo 情境下 `hostWasRecreated` 判定正確 | 通過 |
+| Rehydrate order B | 模擬 `useHostSettingsStore` 先、HostStore 後 → 同上 | 通過 |
+| Cascade 回歸 | 刪除 host → `useHostSettingsStore.get(hostId, moduleId)` 為 undefined（PR-1 功能）| 通過 |
+| Undo 回歸 | 在 cascade clear 後的 undo window 內 undo → host 與其 hostSettings 均回復（PR-1 功能）| 通過 |
+
+若 rehydrate order 測試發現 `hostWasRecreated` 需要改邏輯（e.g. 考慮 `useHostSettingsStore` 中該 host 的 key 是否存在），則加 source 改動（`host-lifecycle.ts`），並追加測試覆蓋新邏輯。
+
+### 3.5 視覺回歸（手動）
+
+- `cd spa && pnpm dev`
+- 開 `/hosts`：左側 sidebar 顯示 host 列表 + 展開每個 host 顯示六 sub-page
+- 點每個 sub-page：右側正常 render
+- 點新增 host button、切換 host、切換 sub-page 均正常
+- 無 console error
+
+---
+
+## 4. 實作順序（TDD）
+
+1. **紅**：寫 §3.3 built-in 註冊測試（registry 有六項、順序正確）
+2. **綠**：在 `register-modules.tsx` 加 `registerBuiltinHostSections()`
+3. **紅**：寫 §3.1 `HostPage.test.tsx`
+4. **綠**：改 `HostPage.tsx` `renderContent()` + `HostSidebar.tsx` 讀 registry
+5. **紅**：寫 §3.2 `host-routes.test.ts` 擴充
+6. **綠**：改 `host-routes.ts` `isHostSubPage` 為動態
+7. **紅**：寫 §3.4 `host-lifecycle.test.ts` #541 案例
+8. **綠**：若需要，修 `host-lifecycle.ts` 判定邏輯（否則只補 test）
+9. **驗證**：`cd spa && pnpm exec vitest run` / `pnpm run lint` / `pnpm run build` 全綠
+10. **手動**：§3.5 視覺回歸
+
+---
+
+## 5. 驗收條件
+
+- [ ] §3.1–§3.4 測試全綠
+- [ ] `cd spa && pnpm exec vitest run` 全綠
+- [ ] `cd spa && pnpm run lint` 全綠
+- [ ] `cd spa && pnpm run build` 全綠
+- [ ] §3.5 手動視覺回歸：六 sub-page 行為與 `main` 一致、無 console error、registry 擴充可見
+- [ ] `gh issue close #541`（或補充「PR-4 已驗證 cross-store rehydrate order」）
+- [ ] `gh issue close #538`（若 PR-2/3 尚未關閉 Host 層，則本 PR 關；否則補充）
+- [ ] Codex 兩輪 review 無 critical / P1 未修項
+
+---
+
+## 6. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| Built-in 註冊時機錯過第一次 render（race）| 中 | `registerBuiltinModules()` 在 app bootstrap 早期同步跑；`HostPage` render 前已完成；測試覆蓋「initial URL `/hosts/hA/overview` 即 render」 |
+| `HOST_SUB_PAGES` 移除後其他 callsite 爆 | 中 | grep `HOST_SUB_PAGES` 找所有 import → 改為動態查詢 或 保留為 optional fallback |
+| Wrap 的 scope guard 漏寫，contribution 收到錯誤 ctx | 低 | §3.3 scope guard 測試強制覆蓋 |
+| #541 測試發現 rehydrate order 確實有 bug，需要動 `host-lifecycle.ts` | 中 | Plan §3.4 已預留修 source 的餘地；若 bug 過大影響 PR-4 scope，可切成獨立 fix PR，PR-4 blocker |
+| labelKey 顯示（sidebar）與 URL localId 可能不一致（例：label 翻譯後中文，但 URL 還是英文）| 低 | 現行 `SUB_PAGES` 已如此；保留 localId 為 URL token，labelKey 為顯示名稱 |
+| 新 host contribution 被註冊時 URL `/hosts/hA/<new>` 可直接進入 — 但沒有 invariant 保證新 localId 不與既有撞（overview/sessions/…）| 低 | PR-1 registry `id` collision throw 已擋（兩個 `_builtin.host.overview` 會拋錯）；module 作者撞 built-in localId 也會拋 |
+
+---
+
+## 7. 超出 PR-4 範圍（明確不做）
+
+- `SettingsPage` global shell 改造（PR-2）
+- `WorkspaceSettingsPage` shell 改造（PR-3）
+- 六 sub-page 轉為 module-owned declaration（決策 4c 明確採 built-in adapter，不搬家）
+- Editor `hostConfig.homePath` 用例（PR-5）
+- 舊 `globalConfig` / `workspaceConfig` deprecate（PR-5 後）
+- Host tab 拖放 / 排序 等 UX 改動
+- `HostStore` persist schema 遷移（alpha 階段不處理，決策依記憶 `feedback_no_alpha_migration`）
+
+---
+
+## 8. Commit 規劃
+
+每 commit 綠。
+
+1. **`feat(spa): register six built-in host sub-pages as host contributions`**
+   - `register-modules.tsx` 加 `registerBuiltinHostSections()` + test（§3.3）
+2. **`feat(spa): HostPage + HostSidebar read new contribution registry`**
+   - `HostPage.tsx` / `HostSidebar.tsx` + `HostPage.test.tsx`
+3. **`refactor(spa): isHostSubPage dynamic via contribution registry`**
+   - `host-routes.ts` + test
+4. **`test(spa): cross-store rehydrate order invariants (#541)`**
+   - `host-lifecycle.test.ts` 擴充（若需要連帶改 source 則拆 refactor + test 兩 commit）
+
+共 4 commits。
+
+---
+
+## 9. 與其他 PR 的關聯
+
+- **依賴**：PR-1（已 merged）
+- **不依賴**：PR-2 / PR-3（三頁 shell 彼此獨立）
+- **被依賴**：PR-5（Editor `hostConfig.homePath` 需要 PR-4 的 HostPage shell 能顯示 module-contributed host section）
+- **順風解決**：#538（Host 層）/ #541（cross-store rehydrate order）

--- a/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
@@ -1,0 +1,220 @@
+# HSR PR-5：Editor `homePath` First Module User — Implementation Plan
+
+> 日期：2026-04-22
+> 狀態：Ready for Implementation（但依賴 PR-3 / PR-4 land）
+> 主 spec：`2026-04-21-settings-contribution-registry-design.md`
+> 決策對齊：3b（舊 API 在 PR-5 merge 時發 deprecation）+ 1c（走 adapter 的新 registry 路徑）
+> PR 系列：PR-1 ✅ / PR-2 / PR-3 / PR-4 / **PR-5（本文件）**
+
+---
+
+## 1. 範圍
+
+**HSR 第一個 module 用例**。Editor module 透過新 `ModuleDefinition.settings` 宣告兩個 contribution：
+- `{ scope: 'workspace', localId: 'homePath' }` — workspace 手動 home（Layer 1）
+- `{ scope: 'host', localId: 'homePath' }` — host 手動 home（Layer 2）
+
+Tilde path opener（`spa/src/lib/terminal-link/openers/file-path.ts`）的 `~/...` 分支改為**層疊 resolve**：workspace settings → host settings → `fetchPaneHome()`（Layer 3，PR #530 既有）→ 無則 fallthrough 原 rawPath 行為。
+
+PR-5 merge 時同步：
+- **#540 解決**：三層 store `get()` 回傳 frozen shallow clone（防止 consumer 以 in-place mutation 繞過 persist / sync）
+- **決策 3b**：對舊 `ModuleDefinition.globalConfig` / `workspaceConfig` 欄位加 JSDoc `@deprecated` + `register-modules.tsx` 在 register pass 偵測到 **非 `files` module** 使用舊欄位時 console.warn（files 保留無警告，由 files owner 後續 refactor 處理）
+
+PR-5 結束時：
+- Editor 在 Workspace settings 頁與 Host 設定頁各顯示一個 "Home path" 區塊（文字輸入 + clear 按鈕）
+- `~/foo.ts` 點擊先用 workspace settings 解析，否則 host，否則 pane shell fallback
+- HSR 架構透過「真實 module + 真實 UI + 真實行為」完整閉環驗證
+- 舊 `globalConfig` / `workspaceConfig` 發 deprecation 警告（保留可運作）
+
+---
+
+## 2. 檔案清單
+
+### 新增
+- `spa/src/modules/editor/EditorHomePathWorkspaceSection.tsx`（或 `spa/src/features/editor/settings/` — 路徑以實作時確認）
+  - Props: `{ ctx: SettingsContext }`（scope === 'workspace' 守護）
+  - 讀 `useWorkspaceSettingsStore.get(ctx.workspaceId, 'editor')?.homePath`
+  - 一個輸入框（placeholder「Auto-detect from pane shell」）+ Clear button
+  - `onChange` 呼叫 `useWorkspaceSettingsStore.set(ctx.workspaceId, 'editor', { homePath: value })` 或 `delete` patch
+- `spa/src/modules/editor/EditorHomePathHostSection.tsx`
+  - 類似但 scope === 'host'；store 用 `useHostSettingsStore`
+- `spa/src/modules/editor/EditorHomePathWorkspaceSection.test.tsx`
+- `spa/src/modules/editor/EditorHomePathHostSection.test.tsx`
+- `spa/src/lib/editor-home-resolver.ts`（抽出 tilde 層疊 resolve 邏輯）
+  - `resolveEditorHomePath(ctx: { hostId, workspaceId?, sessionCode, signal }, deps): Promise<string | null>`
+  - 依序嘗試：workspace → host → `fetchPaneHome` → null
+- `spa/src/lib/editor-home-resolver.test.ts`
+
+### 修改
+- `spa/src/lib/register-modules.tsx`
+  - Editor `registerModule({ id: 'editor', ..., settings: [{ localId: 'homePath', scope: 'workspace', order: 0, labelKey: 'editor.settings.home_path.workspace', component: EditorHomePathWorkspaceSection }, { localId: 'homePath', scope: 'host', order: 0, labelKey: 'editor.settings.home_path.host', component: EditorHomePathHostSection }] })`
+  - 加舊 API deprecation warning（僅對非 `files` 使用者）—— 在 register pass 中偵測 `globalConfig.length > 0` 或 `workspaceConfig.length > 0` 且 moduleId !== 'files' → `console.warn('[module] ${id} uses deprecated globalConfig/workspaceConfig; migrate to settings: [{ scope, localId }]')`
+- `spa/src/lib/terminal-link/openers/file-path.ts`
+  - 將 `~/...` 分支的 `fetchPaneHome` 直呼改為 `resolveEditorHomePath(...)` 呼叫（內部仍會 fallback 回 `fetchPaneHome`）
+  - opener deps 若需擴充介面（`getWorkspaceHomePath(wsId)` / `getHostHomePath(hostId)`），一併擴充；但**傾向** resolver 直接 `import` store（opener 在 SPA 內部，無跨 boundary）
+- `spa/src/stores/useGlobalSettingsStore.ts`（#540）
+  - `get(moduleId)` 回 `Object.freeze({ ...internal })`（shallow clone + freeze）
+- `spa/src/stores/useHostSettingsStore.ts`（#540）
+  - `get(hostId, moduleId)` 同上
+- `spa/src/stores/useWorkspaceSettingsStore.ts`（#540）
+  - `get(wsId, moduleId)` 同上
+- `spa/src/stores/useGlobalSettingsStore.test.ts` / `useHostSettingsStore.test.ts` / `useWorkspaceSettingsStore.test.ts`
+  - 新增測試：`get` 回傳物件 frozen（`Object.isFrozen()` 為 true）
+  - 新增測試：mutate returned object throws / 不影響 store 內部
+- `spa/src/lib/module-registry.ts`
+  - `globalConfig?` / `workspaceConfig?` 加 `/** @deprecated Use settings: [{ scope: 'purdex' | 'workspace', localId }] instead. */`
+- `spa/src/locales/en.json` / `zh-TW.json`
+  - 新增 `editor.settings.home_path.workspace` / `.host` / `.description` / `.clear` 等 key
+
+### 不動
+- `fetchPaneHome` 介面（opener 內部改實作即可）
+- daemon 端 `/api/sessions/{code}/home`（PR #530 已完成）
+- 其他 terminal-link opener / matcher
+- PR-1 / PR-2 / PR-3 / PR-4 shell
+- 其他 module 的 `globalConfig` / `workspaceConfig`（`files.projectPath` 照常運作，但不觸發 deprecation warning）
+
+---
+
+## 3. Test Case Matrix
+
+### 3.1 `EditorHomePathWorkspaceSection.test.tsx`
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Render | 無 value → input placeholder 顯示 | 通過 |
+| Render | 已存 value → input 顯示該值 | 通過 |
+| Write | 輸入 `/Users/foo` 後 blur / enter → `useWorkspaceSettingsStore.get(wsId, 'editor').homePath === '/Users/foo'` | 通過 |
+| Clear | 按 clear → store `homePath` 變 undefined | 通過 |
+| Ctx guard | 傳 `ctx.scope !== 'workspace'` → render null 或 throw（實作擇一） | 通過 |
+
+### 3.2 `EditorHomePathHostSection.test.tsx`
+
+對 `useHostSettingsStore` 做相同矩陣。
+
+### 3.3 `editor-home-resolver.test.ts`
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Priority | workspace 有值 + host 有值 + fetchPaneHome 有值 → 回 workspace 值 | 通過 |
+| Priority | workspace 空 + host 有值 → 回 host 值 | 通過 |
+| Priority | workspace / host 皆空 + fetchPaneHome OK → 回 fetchPaneHome 值 | 通過 |
+| Priority | 三層皆空（fetchPaneHome reject / 回空字串）→ 回 null | 通過 |
+| Priority | workspace 值為空字串（使用者 clear）→ 視為無值，fallthrough 到 host | 通過 |
+| Abort | `signal.aborted` → fetchPaneHome 不呼叫、回 null | 通過 |
+| Absolute only | workspace / host 值非以 `/` 開頭 → 視為無效，fallthrough | 通過 |
+
+### 3.4 `openers/file-path.test.ts` 擴充
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Tilde + workspace override | 點 `~/foo.ts`；workspace 有 `homePath='/Users/x'` → 開啟 `/Users/x/foo.ts` | 通過 |
+| Tilde + host override | 點 `~/foo.ts`；workspace 空、host 有 `homePath='/home/y'` → 開啟 `/home/y/foo.ts` | 通過 |
+| Tilde fallback | 三層皆空、`fetchPaneHome` 回 `/Users/z` → 開啟 `/Users/z/foo.ts` | 通過（PR #530 回歸） |
+| Tilde all fail | 三層皆空、`fetchPaneHome` reject → 開啟 raw `~/foo.ts`（blank buffer；既有行為） | 通過 |
+
+### 3.5 Store immutability (#540)
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Frozen | `useWorkspaceSettingsStore.get(ws, mod)` 回傳 `Object.isFrozen()` 為 true | 通過 |
+| Mutation guard | `store.get(ws, mod).foo = 'x'` 在 strict mode 拋（或在 loose mode 靜默忽略）；**store 內部狀態不變** | 通過 |
+| Patch 仍可 | `store.set(ws, mod, { foo: 'x' })` 正常運作（set 不受 frozen 影響） | 通過 |
+
+### 3.6 Deprecation warning (#3b)
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Warn | 註冊一個 fake module `{ id: 'fake', globalConfig: [{...}], ... }` → `console.warn` 被呼叫，訊息含 `fake` 與 `deprecated` | 通過 |
+| 不 warn | 註冊 `files` module（已使用 `workspaceConfig`）→ 無 warn | 通過 |
+| 不 warn | 註冊使用新 `settings` 的 module → 無 warn | 通過 |
+
+### 3.7 視覺回歸（手動）
+
+- `cd spa && pnpm dev`
+- 打開 workspace settings → 看到 Editor Home Path (Workspace) 區塊；輸入 `/tmp/foo` → 開 terminal 點 `~/x` → Editor 開 `/tmp/foo/x`
+- 打開 host 設定 → 看到 Editor Home Path (Host) 區塊；清空 workspace 的值，輸入 host 值 `/home/bar` → 點 `~/y` → 開 `/home/bar/y`
+- 三層全空 → 點 `~/z` → 依 pane shell fallback 行為
+
+---
+
+## 4. 實作順序（TDD）
+
+1. **紅**：寫 §3.5 store immutability 測試
+2. **綠**：三層 store `get()` 加 freeze + shallow clone
+3. **紅**：寫 §3.3 resolver 測試
+4. **綠**：建 `editor-home-resolver.ts`
+5. **紅**：寫 §3.4 opener 擴充測試
+6. **綠**：改 `file-path.ts` `~/` 分支用 resolver
+7. **紅**：寫 §3.1 / §3.2 section 測試
+8. **綠**：建兩個 section component
+9. **紅**：寫 §3.6 deprecation warning 測試
+10. **綠**：`register-modules.tsx` 加 warning + Editor `settings` 宣告 + i18n keys
+11. **驗證**：`cd spa && pnpm exec vitest run` / `pnpm run lint` / `pnpm run build`
+12. **手動**：§3.7 視覺回歸
+
+---
+
+## 5. 驗收條件
+
+- [ ] §3.1–§3.6 測試全綠
+- [ ] `cd spa && pnpm exec vitest run` 全綠
+- [ ] `cd spa && pnpm run lint` 全綠
+- [ ] `cd spa && pnpm run build` 全綠
+- [ ] §3.7 手動驗：workspace / host / fallback 三路徑皆可用
+- [ ] `gh issue close #540`
+- [ ] Codex 兩輪 review 無 critical / P1 未修項
+- [ ] Kickoff 記憶更新：HSR PR-5 完成，全部 PR 落地
+
+---
+
+## 6. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| freeze 後既有 consumer mutate frozen object 造成既有 bug 顯性化 | 中 | PR-1 後 store 無 production consumer；§3.5 測試保證 immutability；若發現 consumer 依賴 mutation，改為 `set()` callsite |
+| resolver 的 abort signal 傳遞遺漏 | 中 | §3.3 abort 測試覆蓋；resolver 需支援 `AbortSignal` 貫穿 |
+| workspace / host 的 `homePath` 值為相對路徑或含 `..` 的 traversal | 中 | §3.3 「absolute only」測試；值非 `/` 開頭 → 視為無效；相對值不納入（由 PR #531 tracking，不在 PR-5 scope 擴展） |
+| Editor section UI 與 WorkspaceSettingsPage 既有佈局（ModuleConfigSection 的 files.projectPath）並排視覺不一致 | 低 | 採同樣 `<section>` + `<h3>` 樣式；§3.7 手動驗 |
+| Deprecation warning 吵到 dev 輸出（每次 HMR 重跑都 warn 一次）| 中 | warn 加 de-dupe（per (moduleId, scope) 只 warn 一次）—— 用 `Set` in module scope 記已 warn 過的 id |
+| `files` module 被豁免 warn 的判定太寬鬆（未來若 `files` 也該遷但仍保留就永遠沒 warn）| 中 | 豁免清單明確為 `['files']`；未來若決定搬，就從豁免清單移除並處理；清單在 `register-modules.tsx` 內顯式定義 |
+
+---
+
+## 7. 超出 PR-5 範圍（明確不做）
+
+- 舊 `globalConfig` / `workspaceConfig` 欄位**完全移除**（還要等所有 consumer 遷完）
+- `files.projectPath` 搬到新 `settings`（決策 2b — files owner 後續 refactor）
+- `ModuleConfigSection.tsx` 移除（同上）
+- `useModuleConfigStore` 移除
+- `~/../foo` traversal 防護（遺留 issue #531，不在 PR-5 scope）
+- Darwin `ps -E` 空白切割（#532，不在 PR-5 scope）
+- Editor 其他偏好（字型 / theme）走新 registry — 保留舊實作
+- PR-5 後續 clean-up PR（全面移除舊 API）
+
+---
+
+## 8. Commit 規劃
+
+每 commit 綠。
+
+1. **`refactor(spa): settings stores return frozen immutable snapshot (#540)`**
+   - 三層 store `get` + test
+2. **`feat(spa): editor-home-resolver with layered workspace → host → pane-shell resolve`**
+   - `editor-home-resolver.ts` + test
+3. **`feat(spa): terminal-link opener uses editor-home-resolver for tilde paths`**
+   - `file-path.ts` 改 resolver 呼叫 + test 擴充
+4. **`feat(spa): Editor module declares homePath contributions (workspace + host)`**
+   - 兩個 section component + test + `register-modules.tsx` Editor `settings` 宣告 + i18n
+5. **`refactor(spa): deprecate ModuleDefinition.globalConfig / workspaceConfig`**
+   - `module-registry.ts` JSDoc + `register-modules.tsx` warn + test
+
+共 5 commits。
+
+---
+
+## 9. 與其他 PR 的關聯
+
+- **依賴**：PR-1（已 merged）+ **PR-3**（workspace shell 能渲染 workspace contribution）+ **PR-4**（host shell 能渲染 host contribution）
+- **不依賴**：PR-2（Purdex shell — Editor 不宣告 `scope: 'purdex'`）
+- **被依賴**：後續「全面移除舊 `globalConfig` / `workspaceConfig`」的獨立 refactor PR
+- **順風解決**：#540 / 決策 3b deprecation


### PR DESCRIPTION
## Summary

Post-PR-1 (#542) alignment of the HSR (Host-scoped Module Settings Registry) design spec, followed by drafting implementation plans for the remaining 4 PRs in the series.

### 5 locked decisions (main spec update)

| # | Decision | Rationale |
|---|---|---|
| 1c | Legacy `settings-section-registry` → adapter-only | PR-2 scope stays small; 7 built-in sections zero-change |
| 2b | Existing section internals **not** migrated in HSR series | Owners (Sync / Editor / Appearance) do their own refactor PR later |
| 3b | Deprecate `globalConfig` / `workspaceConfig` **after** PR-5 merge | Need a replacement example (Editor `homePath`) before warning consumers |
| 4c | `HostPage` registry-driven + 6 sub-pages via built-in adapter | Same contract, no module ownership churn |
| 5a | PR-3 cleans reserved `workspace` section + `module-config` empty page | PR-3 shell already touches WorkspaceSettingsPage |

### New plan documents

- `2026-04-22-hsr-pr2-purdex-shell-plan.md` — Purdex Settings shell + legacy adapter + #539 (internal API)
- `2026-04-22-hsr-pr3-workspace-shell-plan.md` — Workspace shell + reserved cleanup
- `2026-04-22-hsr-pr4-host-shell-plan.md` — Host shell + 6 built-in sub-page adapters + #541 (cross-store rehydrate verification)
- `2026-04-22-hsr-pr5-editor-homepath-plan.md` — Editor `homePath` first module user + deprecation warning + #540 (immutable store snapshots)

Each plan mirrors PR-1 plan structure: scope / files / TDD test matrix / implementation order / acceptance / risks / out-of-scope / commit plan / cross-PR dependencies.

### Dependency map

- PR-2 / PR-3 / PR-4: parallel (three shells touch disjoint files)
- PR-5: depends on PR-3 + PR-4 (needs workspace and host shells rendering)
- Follow-up issues #538–#541 each mapped to the PR best-positioned to close them

## Test plan

- [x] Design spec still readable after revision (structure preserved, v3 revision note added)
- [x] 4 new plan documents each self-contained with concrete file paths, test matrices, commit plans
- [x] Cross-references between spec §8 roadmap and individual plan filenames consistent
- [ ] Docs-only PR — no code changes, CI only runs whatever docs linting exists