### PR TITLE
docs(hsr): PR-2/3/4/5 implementation plans (v3.1)

### DIFF
--- a/docs/specs/2026-04-21-settings-contribution-registry-design.md
+++ b/docs/specs/2026-04-21-settings-contribution-registry-design.md
@@ -1,7 +1,7 @@
 # Settings Contribution Registry 設計 Spec（三層 Scope）
 
-> 日期：2026-04-21（v3.1 對齊 2026-04-22，post-codex-review task-mo8xtpa8-bdxsh4）
-> 狀態：Draft v3.1 — v3 對齊 5 個未決策點（§6.2 / §7.1 / §7.2 / §7.3 / §8 / §13）；v3.1 回應 codex review Finding 1+2（§7.2 dispatch 硬約束、§8 並行敘述修正）
+> 日期：2026-04-21（v3.2 對齊 2026-04-22，post-codex-review Round 2 task-mo8z6ppx-pj07yk）
+> 狀態：Draft v3.2 — v3 對齊 5 個未決策點（§6.2 / §7.1 / §7.2 / §7.3 / §8 / §13）；v3.1 回應 Round 1 Finding 1+2（§7.2 dispatch 硬約束、§8 並行敘述修正）；v3.2 回應 Round 2 新 Finding N2（§13 PR-4 起點對齊 dispatch-flushed pattern）
 > 關聯：kickoff `kickoff_host_module_settings.md`（擴大版，涵蓋三層 scope 而非僅 host）
 > 參考：
 > - Codex 探索結果：job `task-mo8crieu-phjsc8`（2026-04-21）
@@ -389,5 +389,5 @@ PR-1 具體驗收條件見 `2026-04-21-hsr-pr1-registry-core-plan.md`。
 
 - **PR-2 起點（決策 1c）**：`SettingsPage` 改**只讀新 registry**（無 feature flag）；`settings-section-registry` 的 `registerSettingsSection` 改為 push 到 pending buffer + export `drainLegacyContributionQueue()`；`dispatchSettingsContributions()` 修改為同時 flush module-declared + legacy pending（見 §7.2 硬約束）；既有 7 個 built-in section 無需改碼即自動進新 registry；#539 在此 PR 把 `registerSettingsContribution` 降級為 `@internal`（adapter 改走 pending buffer，dispatch 成為新 registry 唯一寫入入口）
 - **PR-3 起點（決策 5a）**：`WorkspaceSettingsPage` 拆 shell + reserved `workspace` section 清除 + `module-config` 空頁清除 + `removeWorkspace()` cleanup hook（與 PR-1 的 `useWorkspaceSettingsStore.clearWorkspace` 對接）
-- **PR-4 起點（決策 4c）**：`HostPage` switch → shell；六子頁（overview/sessions/hooks/agents/uploads/logs）**不轉為 module 宣告**，改為 shell 內部的「built-in adapter registration」— 由 `HostPage` 載入時自動 `registerSettingsContribution({ moduleId: '_builtin.host', ... })`，走同一條 contract 但來源標記為 built-in；`ctx.hostId` 來源由 route resolution 提供（§5.3 rule 2）；`removeHost()` cleanup hook 對接 `useHostSettingsStore.clearHost`；#541 在此 PR 驗證 cross-store rehydrate order
+- **PR-4 起點（決策 4c）**：`HostPage` switch → shell；六子頁（overview/sessions/hooks/agents/uploads/logs）**不轉為 module 宣告**，改為 **`registerBuiltinModules()` 階段 push 到 pending queue** 的「built-in adapter registration」— 由 `dispatchSettingsContributions()` 統一 flush（沿用 §7.2 的 dispatch-flushed pattern，**不得**在 `HostPage` 載入時直接呼叫 `registerSettingsContribution()`，否則 dispatch 的 `clearContributions()` 會把 built-in 項整批清掉；與 PR-2 legacy adapter 同一機制），走同一條 contract 但來源標記為 built-in；`ctx.hostId` 來源由 route resolution 提供（§5.3 rule 2）；`removeHost()` cleanup hook 對接 `useHostSettingsStore.clearHost`；#541 在此 PR 驗證 cross-store rehydrate order
 - **PR-5 起點（決策 3b）**：Editor module 宣告 `settings: [{ localId: 'homePath', scope: 'host', ... }, { localId: 'homePath', scope: 'workspace', ... }]`；opener 層做層疊 resolve（workspace → host → `fetchPaneHome` fallback）；PR-5 merge 時對舊 `globalConfig` / `workspaceConfig` 加 console.warn + JSDoc `@deprecated`，指向新 `settings` 路徑；全面移除延後獨立 PR

--- a/docs/specs/2026-04-21-settings-contribution-registry-design.md
+++ b/docs/specs/2026-04-21-settings-contribution-registry-design.md
@@ -1,7 +1,7 @@
 # Settings Contribution Registry 設計 Spec（三層 Scope）
 
-> 日期：2026-04-21
-> 狀態：Draft v2（post spec-review，PR-1 implementation plan 另見 `2026-04-21-hsr-pr1-registry-core-plan.md`）
+> 日期：2026-04-21（v3 對齊 2026-04-22）
+> 狀態：Draft v3（post PR-1 landing，5 個未決策點已對齊：§6.2 / §7.1 / §7.2 / §7.3 / §8 / §13）
 > 關聯：kickoff `kickoff_host_module_settings.md`（擴大版，涵蓋三層 scope 而非僅 host）
 > 參考：
 > - Codex 探索結果：job `task-mo8crieu-phjsc8`（2026-04-21）
@@ -212,7 +212,7 @@ clearContributions(): void   // 測試用
 - `listContributions(scope)`：依 `order` 升冪排序；只回傳指定 scope；不做 `disabled(ctx)` filter（由 shell 處理）
 - `clearContributions()`：測試隔離用；production flow 不呼叫
 
-**與既有 `settings-section-registry` 的關係**：PR-1 **保留**舊 registry 原樣，新 registry 並存。PR-2 合流策略在該 PR plan 決定。
+**與既有 `settings-section-registry` 的關係**：PR-1 保留舊 registry 原樣，新 registry 並存。**PR-2 合流策略鎖定 adapter-only**（決策 1c）：舊 `registerSettingsSection()` 改為對新 registry 的 adapter，所有既有 callsite 不用動；`SettingsPage` / `WorkspaceSettingsPage` / `HostPage` 只信新 registry。
 
 ### 6.3 `ModuleDefinition` 擴充
 
@@ -269,34 +269,49 @@ interface ModuleDefinition {
 
 理由：這些是 SPA 必備 core（bootstrap 必讀、不可延遲載入、不可由 module 卸載），不符合「可選式 module-contributed settings」語意。詳見 `feedback_core_vs_module_settings.md`。
 
-AppearanceSection / TerminalSection 等屬 **core section**，PR-2 遷移時走 adapter 掛進新 registry，不改其內部資料層。
+**既有 section 搬家節奏（決策 2b）**：AppearanceSection / TerminalSection / SyncSection / LinkDetectionSection 等既有 built-in section，在 HSR PR-2/3/4 階段**只換掛法**（透過 §7.2 adapter 進新 registry），**不改內部程式碼、也不強制轉為 module-owned declaration**。真正把 section 搬進各自 module 的 `settings: []` 宣告，由各 owner（Sync / Editor / Appearance 等）後續獨立 refactor PR 接手，不是 HSR 系列的 scope。
 
-### 7.2 既有 `settings-section-registry`
+### 7.2 既有 `settings-section-registry`（決策 1c — adapter-only）
 
-PR-1 保留不動。合流策略 defer 到 PR-2 plan：
-- (a) 舊 registry 改 export 適配層，內部改走新 registry
-- (b) 舊 registry 廢棄，所有 section 改註冊到新 registry
-- (c) 並存（不建議）
+**鎖定策略**：adapter-only。
+
+- 舊 `registerSettingsSection(section)` 實作改成：組出 `SettingsContributionDeclaration`（`localId` = 原 `id`、`scope: 'purdex'`、`labelKey` = 原 `label`、`component` = 原 component 包一層吃 `{ ctx }` 的 wrapper），同步呼叫 `registerSettingsContribution(...)` 把項目註冊進新 registry
+- 舊 `getSettingsSections()` 與舊 registry 的其他 read API 保留，實作改成對新 registry 的 scope='purdex' filtered view（供尚未遷的 callsite 過渡）
+- `SettingsPage` / `WorkspaceSettingsPage` / `HostPage` 自 PR-2/3/4 起**只讀新 registry**，不再經過舊 API
+- 舊 registry 的完全移除延到 HSR 系列全部 land 後，當舊 callsite 清空再獨立 refactor PR 拔除
+
+**理由**：alpha 階段雖無 backwards-compat 包袱，但一次全遷會迫使 PR-2 同時處理 shell 切換 + section 搬家，scope 難收斂；adapter 讓既有 7 個 builtin section 零改動進新 registry，PR-2 scope 聚焦於 shell 與 adapter 正確性。
 
 ### 7.3 待清理項
 
-- `workspace` reserved section（`register-modules.tsx:258-259`）—— PR-3 清掉
-- `module-config` 空頁 section（`register-modules.tsx:260-265`）—— PR-3 或 PR-5 清掉
-- 舊 `globalConfig` / `workspaceConfig` 欄位：invariant I1 守住雙軌禁令；全面移除延到有 module 將舊軌遷移完畢之後（PR-5 或後續）
+- `workspace` reserved section（`register-modules.tsx:258-259`）—— **PR-3 清掉**（決策 5a）
+- `module-config` 空頁 section（`register-modules.tsx:260-265`）—— **PR-3 清掉**（決策 5a；PR-3 shell 本就動 WorkspaceSettingsPage，順手最省事）
+- 舊 `globalConfig` / `workspaceConfig` 欄位（決策 3b）：invariant I1 守住雙軌禁令；**PR-5 merge 後**發 deprecation warning（console.warn + JSDoc `@deprecated`），指向新 `settings: [{ scope: 'workspace', ... }]`；**全面移除**延到至少 1 個 module 將舊軌遷移完畢之後，由獨立 cleanup PR 處理
+
+**理由（決策 3b）**：deprecate 要有替代範例可指，PR-5（Editor `homePath`）才是第一個真正用新 `hostConfig` / `workspaceConfig` 替代路徑的用例；PR-5 merge 後再發 deprecation 警告，避免 API 消費者沒有可行遷移路徑就被警告轟炸。
 
 ---
 
 ## 8. 實作 Phase（Roadmap）
 
-| PR | 範圍 | Plan 文件 |
-|---|---|---|
-| **PR-1** | Registry 核心 + types + 三層 stores + `ModuleDefinition.settings` + register pass（**不動任何頁面**） | `2026-04-21-hsr-pr1-registry-core-plan.md` |
-| PR-2 | Purdex Settings 頁 shell → registry-driven + core sections adapter | 待寫 |
-| PR-3 | Workspace Settings 頁 shell → registry-driven + 清理 reserved `workspace` section | 待寫 |
-| PR-4 | Host Settings 頁 shell → registry-driven + 六子頁轉 built-in host contributions | 待寫 |
-| PR-5 | Editor `hostSettings.homePath` 首個 module 用例 + 清理 `module-config` 空頁 | 待寫 |
+| PR | 範圍 | Plan 文件 | 狀態 |
+|---|---|---|---|
+| **PR-1** | Registry 核心 + types + 三層 stores + `ModuleDefinition.settings` + register pass（**不動任何頁面**） | `2026-04-21-hsr-pr1-registry-core-plan.md` | ✅ merged (#542, alpha.199) |
+| PR-2 | Purdex Settings 頁 shell → registry-driven + 舊 `settings-section-registry` adapter（決策 1c） | `2026-04-22-hsr-pr2-purdex-shell-plan.md` | 📝 plan |
+| PR-3 | Workspace Settings 頁 shell → registry-driven + 清理 reserved `workspace` section + 清理 `module-config` 空頁（決策 5a） | `2026-04-22-hsr-pr3-workspace-shell-plan.md` | 📝 plan |
+| PR-4 | Host Settings 頁 shell → registry-driven + 六子頁走 built-in adapter registration（決策 4c，非 module 宣告，但走同 contract） | `2026-04-22-hsr-pr4-host-shell-plan.md` | 📝 plan |
+| PR-5 | Editor `settings: [{ scope: 'host', localId: 'homePath' }, { scope: 'workspace', localId: 'homePath' }]` 首個 module 用例 + PR-5 merge 後對舊 `globalConfig` / `workspaceConfig` 發 deprecation warning（決策 3b） | `2026-04-22-hsr-pr5-editor-homepath-plan.md` | 📝 plan |
 
-PR-2/3/4 可並行開（三頁獨立）。PR-5 依賴 PR-4。
+**相依與並行**：
+- PR-2 / PR-3 / PR-4 彼此**不動共用檔案**（三頁 shell 各自獨立），可並行
+- PR-5 依賴 PR-4（`ctx.hostId` 由 PR-4 的 HostPage shell 注入）＋ PR-3（`ctx.workspaceId` 由 PR-3 的 WorkspaceSettingsPage shell 注入）
+- 既有 section（Appearance / Terminal / Sync / LinkDetection 等）的真正搬家到 module-owned declaration **不在** HSR 系列 scope，由各 owner 後續獨立 refactor PR 接手（決策 2b）
+
+**延後 issue 對應**：
+- PR-2/3/4 任一 land 後 → 補 **#538**（render-level smoke test）
+- 第一個 consumer PR 一併處理 → **#539**（`registerSettingsContribution` 收斂為 internal API；PR-2 切斷外部 callsite 最合適）
+- PR-5 前必解 → **#540**（三層 store `get()` 回傳 internal ref / 改回 immutable snapshot）
+- PR-4 sync subsystem 驗證 → **#541**（cross-store rehydrate order）
 
 ---
 
@@ -351,9 +366,9 @@ PR-1 具體驗收條件見 `2026-04-21-hsr-pr1-registry-core-plan.md`。
 
 ---
 
-## 13. 後續 PR 銜接備忘
+## 13. 後續 PR 銜接備忘（決策對齊版）
 
-- **PR-2 起點**：SettingsPage 先做 feature flag 並存吃新舊 registry，穩定後拔舊 registry；既有 sections 以 adapter 掛進新 registry
-- **PR-3 起點**：WorkspaceSettingsPage 拆 shell + reserved `workspace` section 清除 + `removeWorkspace()` cleanup hook
-- **PR-4 起點**：HostPage switch → shell + 六子頁 built-in host contributions 宣告；`ctx.hostId` 來源由 route resolution 提供（§5.3 rule 2）；`removeHost()` cleanup hook
-- **PR-5 起點**：Editor module 宣告 `settings: [{ localId: 'homePath', scope: 'host', ... }]`；搭配 daemon 端已完成的 tilde path 支援
+- **PR-2 起點（決策 1c）**：`SettingsPage` 改**只讀新 registry**（無 feature flag）；同步把舊 `settings-section-registry` 的 `registerSettingsSection` / `getSettingsSections` / 其他 read API 實作改為對新 registry 的薄 adapter；既有 7 個 built-in section 無需改碼，透過 adapter 自動進新 registry；#539 在此 PR 一併把 `registerSettingsContribution` 收斂為 internal（僅供 adapter + register pass 呼叫）
+- **PR-3 起點（決策 5a）**：`WorkspaceSettingsPage` 拆 shell + reserved `workspace` section 清除 + `module-config` 空頁清除 + `removeWorkspace()` cleanup hook（與 PR-1 的 `useWorkspaceSettingsStore.clearWorkspace` 對接）
+- **PR-4 起點（決策 4c）**：`HostPage` switch → shell；六子頁（overview/sessions/hooks/agents/uploads/logs）**不轉為 module 宣告**，改為 shell 內部的「built-in adapter registration」— 由 `HostPage` 載入時自動 `registerSettingsContribution({ moduleId: '_builtin.host', ... })`，走同一條 contract 但來源標記為 built-in；`ctx.hostId` 來源由 route resolution 提供（§5.3 rule 2）；`removeHost()` cleanup hook 對接 `useHostSettingsStore.clearHost`；#541 在此 PR 驗證 cross-store rehydrate order
+- **PR-5 起點（決策 3b）**：Editor module 宣告 `settings: [{ localId: 'homePath', scope: 'host', ... }, { localId: 'homePath', scope: 'workspace', ... }]`；opener 層做層疊 resolve（workspace → host → `fetchPaneHome` fallback）；PR-5 merge 時對舊 `globalConfig` / `workspaceConfig` 加 console.warn + JSDoc `@deprecated`，指向新 `settings` 路徑；全面移除延後獨立 PR

--- a/docs/specs/2026-04-21-settings-contribution-registry-design.md
+++ b/docs/specs/2026-04-21-settings-contribution-registry-design.md
@@ -1,7 +1,7 @@
 # Settings Contribution Registry 設計 Spec（三層 Scope）
 
-> 日期：2026-04-21（v3 對齊 2026-04-22）
-> 狀態：Draft v3（post PR-1 landing，5 個未決策點已對齊：§6.2 / §7.1 / §7.2 / §7.3 / §8 / §13）
+> 日期：2026-04-21（v3.1 對齊 2026-04-22，post-codex-review task-mo8xtpa8-bdxsh4）
+> 狀態：Draft v3.1 — v3 對齊 5 個未決策點（§6.2 / §7.1 / §7.2 / §7.3 / §8 / §13）；v3.1 回應 codex review Finding 1+2（§7.2 dispatch 硬約束、§8 並行敘述修正）
 > 關聯：kickoff `kickoff_host_module_settings.md`（擴大版，涵蓋三層 scope 而非僅 host）
 > 參考：
 > - Codex 探索結果：job `task-mo8crieu-phjsc8`（2026-04-21）
@@ -273,12 +273,20 @@ interface ModuleDefinition {
 
 ### 7.2 既有 `settings-section-registry`（決策 1c — adapter-only）
 
-**鎖定策略**：adapter-only。
+**鎖定策略**：adapter-only，且 **legacy adapter 的寫入必須經由 `dispatchSettingsContributions()` 統一 flush**（見下方硬約束）。
 
-- 舊 `registerSettingsSection(section)` 實作改成：組出 `SettingsContributionDeclaration`（`localId` = 原 `id`、`scope: 'purdex'`、`labelKey` = 原 `label`、`component` = 原 component 包一層吃 `{ ctx }` 的 wrapper），同步呼叫 `registerSettingsContribution(...)` 把項目註冊進新 registry
-- 舊 `getSettingsSections()` 與舊 registry 的其他 read API 保留，實作改成對新 registry 的 scope='purdex' filtered view（供尚未遷的 callsite 過渡）
+- 舊 `registerSettingsSection(section)` 實作改成：組出 `SettingsContributionDeclaration`（`localId` = 原 `id`、`scope: 'purdex'`、`labelKey` = 原 `label`、`component` = 原 component 包一層吃 `{ ctx }` 的 wrapper），**push 到 module-scope pending buffer**（不立刻呼叫 `registerSettingsContribution`）
+- `dispatchSettingsContributions(modules)` 於 Phase 2 `clearContributions()` 之後，同時 register：
+  1. module-declared contributions（來自 `ModuleDefinition.settings`）
+  2. legacy adapter pending buffer（由 `drainLegacyContributionQueue()` 取出並清空 buffer）
+- 舊 `getSettingsSections()` 與舊 registry 的其他 read API 保留，實作改成對新 registry 的 `moduleId === '_builtin.legacy-section'` filtered view（供尚未遷的 callsite 過渡）
 - `SettingsPage` / `WorkspaceSettingsPage` / `HostPage` 自 PR-2/3/4 起**只讀新 registry**，不再經過舊 API
 - 舊 registry 的完全移除延到 HSR 系列全部 land 後，當舊 callsite 清空再獨立 refactor PR 拔除
+
+**硬約束（dispatch 時序，防 Finding 1 的 regression）**：
+- `registerSettingsSection()` **不得**直接呼叫 `registerSettingsContribution()`，否則 `registerBuiltinModules()` 結尾的 `dispatchSettingsContributions()` → `clearContributions()` 會把 legacy 項整批清掉
+- 新 registry 的**唯一**寫入入口是 `dispatchSettingsContributions()`；#539 將 `registerSettingsContribution` 降級 `@internal` 後，adapter 也需改走 pending buffer
+- HMR 重跑 `registerBuiltinModules()` → `registerSettingsSection()` 再次 push 到 pending buffer → dispatch 再次 drain；buffer 為本輪用完即清
 
 **理由**：alpha 階段雖無 backwards-compat 包袱，但一次全遷會迫使 PR-2 同時處理 shell 切換 + section 搬家，scope 難收斂；adapter 讓既有 7 個 builtin section 零改動進新 registry，PR-2 scope 聚焦於 shell 與 adapter 正確性。
 
@@ -302,10 +310,21 @@ interface ModuleDefinition {
 | PR-4 | Host Settings 頁 shell → registry-driven + 六子頁走 built-in adapter registration（決策 4c，非 module 宣告，但走同 contract） | `2026-04-22-hsr-pr4-host-shell-plan.md` | 📝 plan |
 | PR-5 | Editor `settings: [{ scope: 'host', localId: 'homePath' }, { scope: 'workspace', localId: 'homePath' }]` 首個 module 用例 + PR-5 merge 後對舊 `globalConfig` / `workspaceConfig` 發 deprecation warning（決策 3b） | `2026-04-22-hsr-pr5-editor-homepath-plan.md` | 📝 plan |
 
-**相依與並行**：
-- PR-2 / PR-3 / PR-4 彼此**不動共用檔案**（三頁 shell 各自獨立），可並行
-- PR-5 依賴 PR-4（`ctx.hostId` 由 PR-4 的 HostPage shell 注入）＋ PR-3（`ctx.workspaceId` 由 PR-3 的 WorkspaceSettingsPage shell 注入）
-- 既有 section（Appearance / Terminal / Sync / LinkDetection 等）的真正搬家到 module-owned declaration **不在** HSR 系列 scope，由各 owner 後續獨立 refactor PR 接手（決策 2b）
+**相依與順序（修正：PR-2/3/4 並非無衝突並行）**：
+
+PR-2/3/4 共享兩個檔案，無法零衝突並行：
+- `spa/src/components/settings/SettingsSidebar.tsx`：PR-2 改 source（讀新 registry）+ PR-3 清 `reservedStart` 分隔線分支
+- `spa/src/lib/register-modules.tsx`：PR-3 拔 reserved 項 + PR-4 加 `registerBuiltinHostSections()`
+
+**建議合併順序**：**PR-2 → PR-3 → PR-4 → PR-5**（序列化）。若真要並行，PR-3 / PR-4 必須 rebase PR-2，PR-4 必須 rebase PR-3，並在 rebase 時手動 resolve：
+- `SettingsSidebar.tsx`：PR-3 的 reservedStart 清除 build on PR-2 的 registry-read 版本
+- `register-modules.tsx`：PR-3 的 reserved 拔除與 PR-4 的 built-in host adapter 註冊位於不同函式區塊，衝突可機械合併
+
+PR-5 依賴：
+- **PR-3**（`ctx.workspaceId` 由 PR-3 的 WorkspaceSettingsPage shell 注入）
+- **PR-4**（`ctx.hostId` 由 PR-4 的 HostPage shell 注入；PR-4 的 host route contract 重構讓 Editor host contribution 能走動態 subPage）
+
+既有 section（Appearance / Terminal / Sync / LinkDetection 等）的真正搬家到 module-owned declaration **不在** HSR 系列 scope，由各 owner 後續獨立 refactor PR 接手（決策 2b）。
 
 **延後 issue 對應**：
 - PR-2/3/4 任一 land 後 → 補 **#538**（render-level smoke test）
@@ -368,7 +387,7 @@ PR-1 具體驗收條件見 `2026-04-21-hsr-pr1-registry-core-plan.md`。
 
 ## 13. 後續 PR 銜接備忘（決策對齊版）
 
-- **PR-2 起點（決策 1c）**：`SettingsPage` 改**只讀新 registry**（無 feature flag）；同步把舊 `settings-section-registry` 的 `registerSettingsSection` / `getSettingsSections` / 其他 read API 實作改為對新 registry 的薄 adapter；既有 7 個 built-in section 無需改碼，透過 adapter 自動進新 registry；#539 在此 PR 一併把 `registerSettingsContribution` 收斂為 internal（僅供 adapter + register pass 呼叫）
+- **PR-2 起點（決策 1c）**：`SettingsPage` 改**只讀新 registry**（無 feature flag）；`settings-section-registry` 的 `registerSettingsSection` 改為 push 到 pending buffer + export `drainLegacyContributionQueue()`；`dispatchSettingsContributions()` 修改為同時 flush module-declared + legacy pending（見 §7.2 硬約束）；既有 7 個 built-in section 無需改碼即自動進新 registry；#539 在此 PR 把 `registerSettingsContribution` 降級為 `@internal`（adapter 改走 pending buffer，dispatch 成為新 registry 唯一寫入入口）
 - **PR-3 起點（決策 5a）**：`WorkspaceSettingsPage` 拆 shell + reserved `workspace` section 清除 + `module-config` 空頁清除 + `removeWorkspace()` cleanup hook（與 PR-1 的 `useWorkspaceSettingsStore.clearWorkspace` 對接）
 - **PR-4 起點（決策 4c）**：`HostPage` switch → shell；六子頁（overview/sessions/hooks/agents/uploads/logs）**不轉為 module 宣告**，改為 shell 內部的「built-in adapter registration」— 由 `HostPage` 載入時自動 `registerSettingsContribution({ moduleId: '_builtin.host', ... })`，走同一條 contract 但來源標記為 built-in；`ctx.hostId` 來源由 route resolution 提供（§5.3 rule 2）；`removeHost()` cleanup hook 對接 `useHostSettingsStore.clearHost`；#541 在此 PR 驗證 cross-store rehydrate order
 - **PR-5 起點（決策 3b）**：Editor module 宣告 `settings: [{ localId: 'homePath', scope: 'host', ... }, { localId: 'homePath', scope: 'workspace', ... }]`；opener 層做層疊 resolve（workspace → host → `fetchPaneHome` fallback）；PR-5 merge 時對舊 `globalConfig` / `workspaceConfig` 加 console.warn + JSDoc `@deprecated`，指向新 `settings` 路徑；全面移除延後獨立 PR

--- a/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
@@ -1,10 +1,11 @@
 # HSR PR-2：Purdex Settings Shell + Legacy Adapter — Implementation Plan
 
-> 日期：2026-04-22（v2 post-codex-review task-mo8xtpa8-bdxsh4）
+> 日期：2026-04-22（v3 post-codex-review Round 2 task-mo8z6ppx-pj07yk）
 > 狀態：Ready for Implementation
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
 > 決策對齊：1c（adapter-only, **dispatch-flushed**）+ 2b（既有 section 不搬家）+ 3b（舊 API deprecate 時點）
 > PR 系列：PR-1 ✅ / **PR-2（本文件）** / PR-3 / PR-4 / PR-5
+> v3 收斂：Round 1 Finding 1/6 → v2 修；Round 2 Finding 6 partial（§2/§8 sidebar 敘事矛盾）+ N1（reserved buffer idempotent/HMR）+ N3（commit 1→2 依賴）→ 本版修
 
 ---
 
@@ -32,18 +33,22 @@ PR-2 結束時：
   - 排序依舊 by `order` 升冪（新 registry 已保證）
   - URL 分派 / `lastSection` / `SettingsRouteContext` 邏輯保留
 - `spa/src/components/settings/SettingsSidebar.tsx`
-  - 改吃 `listContributions('purdex')`
-  - `reservedStart` 邏輯保留（因為 reserved section 會在 PR-3 才清，PR-2 期間仍可能出現無 `component` 的 contribution；但新 registry 的 `component` 是 required，所以實務上不會有 reserved 進 registry — adapter 在組 declaration 時若原 def `component` 為 undefined，**跳過註冊**，由 PR-3 shell 改造時一併拔除 reserved 顯示）
+  - 改吃 `listContributions('purdex')`（active sections，來源皆為新 registry — 含 module-declared 與 legacy adapter flush 後的 `_builtin.legacy-section.*`）
+  - 另呼叫新 export `listReservedItems()`（來自 `settings-section-registry.ts`，回傳當下 `pendingReservedItems` 的 read-only snapshot）補顯示 reserved coming_soon 項
+  - Sidebar 內部以統一資料流合併兩陣列，按 `order` 升冪一次排序（不用 `getSettingsSections()`）；`getSettingsSections()` 保留給尚未遷的外部 callsite（read-only 過渡，由 PR-3 清除 reserved 後再評估拔除）
+  - `reservedStart` 分隔線邏輯保留（`component: undefined` 的項分到 reserved 區）；PR-3 清 reserved 後該分支成為 dead code，由 PR-3 移除
   - `label` → `labelKey`（其實只是欄位 rename，值原本就是 i18n key）
 - `spa/src/lib/settings-section-registry.ts`（adapter 化 + pending buffer）
-  - 新增 module-scope `let pendingLegacyContributions: SettingsContributionDeclaration[] = []`
-  - 新增 module-scope `let pendingReservedItems: SettingsSectionDef[] = []`（**Finding 6 的統一解法**：reserved `component: undefined` 不進新 registry，僅保留在 legacy buffer 供 `SettingsSidebar` 顯示 coming_soon）
+  - 新增 module-scope `let pendingLegacyContributions: SettingsContributionDeclaration[] = []`（active，順序保留 push 序）
+  - 新增 module-scope **`const pendingReservedItems = new Map<string, SettingsSectionDef>()`**（N1：keyed by `def.id`，upsert 語義，HMR / 重複 register 不累積）— reserved `component: undefined` 不進新 registry，僅保留在此 buffer 供 sidebar 顯示 coming_soon（Finding 6 統一解）
   - `registerSettingsSection(def)`：
-    - 若 `def.component` 為 undefined → push 到 `pendingReservedItems`
-    - 否則 → 組 `SettingsContributionDeclaration`（`localId = def.id`、`scope: 'purdex'`、`order = def.order`、`labelKey = def.label`、`component = wrapLegacyComponent(def.component)`） push 到 `pendingLegacyContributions`（`moduleId = '_builtin.legacy-section'`；完整 `id` 由 dispatch 時組）
+    - 若 `def.component` 為 undefined → `pendingReservedItems.set(def.id, def)`（upsert；同 id 重 register 覆寫，不重複）
+    - 否則 → 組 `SettingsContributionDeclaration`（`localId = def.id`、`scope: 'purdex'`、`order = def.order`、`labelKey = def.label`、`component = wrapLegacyComponent(def.component)`） push 到 `pendingLegacyContributions`（`moduleId = '_builtin.legacy-section'`；完整 `id` 由 dispatch 時組）；同 `def.id` 若已在 buffer 中，**覆寫**該項（upsert；避免 HMR 累積）
     - **不呼叫** `registerSettingsContribution`
   - 新增 export `drainLegacyContributionQueue(): SettingsContributionDeclaration[]`：回傳 pending buffer 的 deep copy 並清空 buffer（dispatch pass 呼叫）
-  - `getSettingsSections(): SettingsSectionDef[]`：將 `listContributions('purdex').filter(c => c.moduleId === '_builtin.legacy-section').map(toLegacyShape)` 與 `pendingReservedItems` 合併，依 `order` 升冪排序回傳（讓 `SettingsSidebar` 一次看到 active + reserved）
+  - 新增 export `listReservedItems(): readonly SettingsSectionDef[]`：回傳 `pendingReservedItems` 的 snapshot array（依 `order` 升冪），供 `SettingsSidebar` 顯示 coming_soon（讀取介面，不提供寫入）
+  - 新增 HMR dispose hook（`register-modules.tsx` 既有 HMR 流程內呼叫）：`clearLegacyPending()` 清 `pendingLegacyContributions` **與** `pendingReservedItems`（N1：reserved 必須一併清，否則 HMR 重跑時 reserved 會被下輪 upsert 覆寫但孤兒 key 殘留；用 upsert + dispose 雙保險）
+  - `getSettingsSections(): SettingsSectionDef[]`：將 `listContributions('purdex').filter(c => c.moduleId === '_builtin.legacy-section').map(toLegacyShape)` 與 `Array.from(pendingReservedItems.values())` 合併，依 `order` 升冪排序回傳（**保留給尚未遷的外部 callsite 過渡**；`SettingsSidebar` 改走 `listContributions('purdex') + listReservedItems()` 明確兩路，不經過本 API）
   - `clearSettingsSectionRegistry()`：清 `pendingLegacyContributions` + `pendingReservedItems`（僅 test 用）
   - `wrapLegacyComponent(Comp)`：`(props: { ctx: SettingsContext }) => <Comp />`（忽略 ctx；legacy component 不吃 ctx）
   - `toLegacyShape(c)`：將 contribution 還原回 `{ id, label, order, component }` shape（`component` 透過 `legacyComponentMap` WeakMap 取原 component reference，避免 wrap 破壞 React identity）
@@ -94,8 +99,11 @@ PR-2 結束時：
 | Adapter round-trip | dispatch 後 `getSettingsSections()` 回傳 active 項目原 shape（id / label / order / component reference 等於原 def.component） | 通過 |
 | React identity | dispatch 後 `getSettingsSections()[i].component === 原 passed-in Comp`（透過 `legacyComponentMap` unwrap） | 通過 |
 | Order 保留 | 多項 active + reserved 混合註冊後 `getSettingsSections()` 依 order 升冪交錯回傳 | 通過 |
-| Reserved buffer | `registerSettingsSection({ ..., component: undefined })` → dispatch 後新 registry **無** 該項；`getSettingsSections()` **有** 該項（from `pendingReservedItems`），`component` 為 undefined | **Finding 6 — 統一策略驗證** |
-| HMR re-run | `registerSettingsSection(x)` → dispatch → 再次 `registerSettingsSection(x)` → dispatch → 不 throw，最終一份（pending drain 每輪用完即清） | 通過 |
+| Reserved buffer | `registerSettingsSection({ ..., component: undefined })` → dispatch 後新 registry **無** 該項；`listReservedItems()` **有** 該項，`component` 為 undefined；`getSettingsSections()` 合併 active + reserved 也回該項（過渡 API） | **Finding 6 — 統一策略驗證** |
+| Reserved upsert | 連續 `registerSettingsSection({ id: 'r1', component: undefined, order: 10, label: 'A' })` × N 次（N≥3）→ `listReservedItems()` 長度 = 1；若最後一次改 `order: 5` → 該項 `order === 5`（upsert 覆寫，N1 驗證） | **N1 — reserved 不累積** |
+| Active upsert | 連續 `registerSettingsSection({ id: 'a1', component: Comp1 })` → `registerSettingsSection({ id: 'a1', component: Comp2 })` → dispatch → `listContributions('purdex')` 中 id `_builtin.legacy-section.a1` 只 1 項，component unwrap 後 `=== Comp2`（N1 驗證 active 也不累積） | **N1 — active 不累積** |
+| HMR dispose | `registerSettingsSection({ component: undefined })` → `clearLegacyPending()` → `listReservedItems().length === 0`；同樣對 active buffer → `drainLegacyContributionQueue()` 已回空 | **N1 — HMR dispose 雙 buffer 清** |
+| HMR re-run | `registerSettingsSection(x)` → dispatch → `clearLegacyPending()` → 再次 `registerSettingsSection(x)` → dispatch → 不 throw，最終一份（upsert + dispose 雙保險） | 通過 |
 | Namespace 隔離 | 另一 module 透過 `ModuleDefinition.settings` 宣告 `scope: 'purdex'` → dispatch 後 `getSettingsSections()` **不**回傳該項（filter `moduleId === '_builtin.legacy-section'`） | 通過 |
 | Clear | `clearSettingsSectionRegistry()` 清 pending buffer（不碰新 registry；dispatch 後的結果由 `clearContributions()` 負責） | 通過 |
 | Cross-id guard | module 宣告 `moduleId='foo', localId='appearance'` + legacy adapter 收 `id='appearance'` → dispatch 後兩者 id 不同（`foo.appearance` vs `_builtin.legacy-section.appearance`），無衝突 | 通過 |
@@ -191,19 +199,28 @@ PR-2 結束時：
 
 每個 commit 必須獨立過 vitest / lint / build（完全綠）。
 
-1. **`feat(spa): dispatch pass also flushes legacy contribution queue`**
-   - `dispatch-settings-contributions.ts` 加 `drainLegacyContributionQueue()` 整合 + 測試（`dispatch-settings-contributions.test.ts` 擴充）
-   - 這個 commit 之前 legacy queue empty，測試預設空 drain；commit 後 dispatch 行為新增，但仍 backwards-compat（無 legacy item 時行為不變）— 單測獨立可綠
-2. **`feat(spa): settings-section-registry uses pending buffer + reserved items`**
-   - `settings-section-registry.ts` 改實作（pending buffer + `drainLegacyContributionQueue` export + `getSettingsSections` 合併 registry + reserved）+ `settings-section-registry.test.ts` 新增 §3.1 全部案例
-   - 依賴 commit 1（dispatch drain 語義）；此 commit 後 `registerBuiltinModules()` 跑完的 end-to-end 行為與 `main` 一致（existing 6 active + 1 reserved）
-3. **`feat(spa): SettingsPage reads new contribution registry with ctx`**
-   - `SettingsPage.tsx` + `SettingsSidebar.tsx` 改 `listContributions('purdex')` / `ctx` 注入 + `SettingsPage.test.tsx`
-   - Sidebar 繼續透過 `getSettingsSections()` 拿 reserved（因 reserved 不在新 registry），保持 coming_soon 視覺
+**N3 修正**：commit 1 要呼叫 `drainLegacyContributionQueue()`，該 export 必須同 commit 提供（否則 commit 1 無法獨立編譯）。策略：commit 1 在 `settings-section-registry.ts` 先 export **no-op stub**（`export function drainLegacyContributionQueue(): SettingsContributionDeclaration[] { return [] }` + `export function listReservedItems(): readonly SettingsSectionDef[] { return [] }` + `export function clearLegacyPending(): void {}`），commit 2 才把這三個 API 接上真實 buffer。commit 1 的 stub 行為等同「legacy queue 一直是空」，既有 `registerSettingsSection` 仍走舊 registry 寫入 — 所以 commit 1 land 時 end-to-end 行為與 `main` 一致，獨立可綠。
+
+1. **`feat(spa): dispatch pass flushes legacy contribution queue (stub)`**
+   - `settings-section-registry.ts` 先 export `drainLegacyContributionQueue` / `listReservedItems` / `clearLegacyPending` no-op stub（真實 buffer 在 commit 2）
+   - `dispatch-settings-contributions.ts` 加 drain 呼叫 + stub 情境測試（`dispatch-settings-contributions.test.ts` 擴充）
+   - 此 commit 前後 end-to-end 行為不變（stub 回空 → dispatch drain 無項目 → 同 `main`）；型別 / lint / vitest 三綠
+2. **`feat(spa): settings-section-registry uses pending buffer + reserved upsert map`**
+   - `settings-section-registry.ts` 把 commit 1 的 stub 換成真實實作（pending buffer + `Map<string, SettingsSectionDef>` reserved upsert + `clearLegacyPending` 雙清 + `listReservedItems` snapshot + `getSettingsSections` 合併）
+   - `settings-section-registry.test.ts` 新增 §3.1 全部案例（含 upsert / HMR dispose / reserved buffer）
+   - 此 commit 後 `registerBuiltinModules()` 跑完的 end-to-end 行為與 `main` 一致（existing 6 active + 1 reserved）
+3. **`feat(spa): SettingsPage + SettingsSidebar read new contribution registry with ctx`**
+   - `SettingsPage.tsx` 改 `listContributions('purdex')` + `ctx: { scope: 'purdex' }` 注入
+   - `SettingsSidebar.tsx` 改 `listContributions('purdex') + listReservedItems()` 合併渲染（不走 `getSettingsSections()`）
+   - `SettingsPage.test.tsx`（§3.2 全部）
 4. **`refactor(spa): mark registerSettingsContribution as internal (#539)`**
    - JSDoc `@internal` + re-export 調整 + optional ESLint rule
 
-共 4 commits。每個皆獨立可綠（commit 1 僅新增 drain 入口但不影響既有行為；commit 2 遷 adapter 時 dispatch 已 ready；commit 3 只讀，不動 registry；commit 4 純文檔/型別）。
+共 4 commits。每個皆獨立可綠：
+- commit 1：純新增 API stub + dispatch drain 呼叫；stub 回空所以既有流程行為不變
+- commit 2：把 stub 替換為真實實作；此 commit 的測試依賴 commit 1 的 drain 整合
+- commit 3：只讀 registry + reserved snapshot，不動 registry 寫入
+- commit 4：純文檔/型別
 
 ---
 

--- a/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
@@ -1,0 +1,195 @@
+# HSR PR-2：Purdex Settings Shell + Legacy Adapter — Implementation Plan
+
+> 日期：2026-04-22
+> 狀態：Ready for Implementation
+> 主 spec：`2026-04-21-settings-contribution-registry-design.md`
+> 決策對齊：1c（adapter-only）+ 2b（既有 section 不搬家）+ 3b（舊 API deprecate 時點）
+> PR 系列：PR-1 ✅ / **PR-2（本文件）** / PR-3 / PR-4 / PR-5
+
+---
+
+## 1. 範圍
+
+**Shell 改造 + legacy adapter**。`SettingsPage` 的 `GlobalSettingsPage` 改讀新 registry；舊 `settings-section-registry` 改為薄 adapter：`registerSettingsSection()` 內部轉呼 `registerSettingsContribution()`；`getSettingsSections()` 改為對新 registry 的 filtered view。既有 7 個 built-in section 內部程式碼**零改動**（決策 2b）。
+
+同步完成 **#539**：把 `registerSettingsContribution` / `clearContributions` 收斂為 internal API（僅供 adapter + register pass + test 呼叫；外部 module 不得直接呼叫）。
+
+PR-2 結束時：
+- `GlobalSettingsPage` 透過 `listContributions('purdex')` + `SettingsContext({ scope: 'purdex' })` 渲染
+- 既有 7 個 section UI 外觀、order、URL 行為 100% 與 main 一致
+- 舊 `registerSettingsSection` 所有 callsite 無需改碼即自動進新 registry
+- `WorkspaceSettingsPage` / `HostPage` 不在本 PR scope（PR-3 / PR-4 接手）
+- `workspace` reserved / `module-config` 空頁不在本 PR 清（PR-3 決策 5a）
+
+---
+
+## 2. 檔案清單
+
+### 修改
+- `spa/src/components/SettingsPage.tsx`
+  - `GlobalSettingsPage` 內部 `getSettingsSections()` 改為 `listContributions('purdex')`
+  - 新增 `const ctx: SettingsContext = { scope: 'purdex' }` 傳入 `<ActiveComponent ctx={ctx} />`
+  - 排序依舊 by `order` 升冪（新 registry 已保證）
+  - URL 分派 / `lastSection` / `SettingsRouteContext` 邏輯保留
+- `spa/src/components/settings/SettingsSidebar.tsx`
+  - 改吃 `listContributions('purdex')`
+  - `reservedStart` 邏輯保留（因為 reserved section 會在 PR-3 才清，PR-2 期間仍可能出現無 `component` 的 contribution；但新 registry 的 `component` 是 required，所以實務上不會有 reserved 進 registry — adapter 在組 declaration 時若原 def `component` 為 undefined，**跳過註冊**，由 PR-3 shell 改造時一併拔除 reserved 顯示）
+  - `label` → `labelKey`（其實只是欄位 rename，值原本就是 i18n key）
+- `spa/src/lib/settings-section-registry.ts`（adapter 化）
+  - `registerSettingsSection(def)`：組 `SettingsContributionDeclaration`（`localId = def.id`、`scope: 'purdex'`、`order = def.order`、`labelKey = def.label`、`component = wrapLegacyComponent(def.component)`）+ `moduleId = '_builtin.legacy-section'`，呼叫 `registerSettingsContribution({ ...decl, moduleId, id: `${moduleId}.${def.id}` })`
+  - 若 `def.component` 為 `undefined` → **跳過註冊**（避免新 registry required field 衝突；reserved section 的 UI 由 PR-3 sidebar 改造時明確處理）
+  - `getSettingsSections()`：`listContributions('purdex').filter(c => c.moduleId === '_builtin.legacy-section').map(c => ({ id: c.localId, label: c.labelKey, order: c.order, component: unwrapLegacyComponent(c.component) }))`
+  - `clearSettingsSectionRegistry()`：呼叫 `clearContributions()`（registry test-only）或只清 legacy namespace（取決於是否只測 legacy adapter — 安全作法：只清 `_builtin.legacy-section.*`）
+  - `wrapLegacyComponent(Comp)`：`(props: { ctx: SettingsContext }) => <Comp />`（忽略 ctx — legacy component 不吃 ctx）
+  - `unwrapLegacyComponent(Wrapped)`：adapter 內部把 wrap 時原 Comp 掛在 `Wrapped.__legacyComponent` 取回；或直接存 map — 任一皆可，一致即可
+- `spa/src/lib/settings-contribution-registry.ts`（#539 internal 收斂）
+  - `registerSettingsContribution` / `clearContributions` 加 `/** @internal */` JSDoc tag
+  - Re-export 從 `module-registry.ts` 拿掉（module 作者只透過 `ModuleDefinition.settings` 宣告，不得繞過 register pass 直接呼叫）
+  - `listContributions` / `getContribution` 保持 public（shell 消費）
+  - 若有外部 callsite（PR-1 後除 adapter 外理論應為 0 個），lint rule 或 ESLint `no-restricted-imports` 擋（optional，有則做）
+
+### 新增
+- `spa/src/components/SettingsPage.test.tsx`
+  - Render-level smoke：註冊 fake contribution（scope: 'purdex'）→ `SettingsPage` render 後 sidebar 顯示該 label、active 時 content 區 render 該 component
+  - URL routing：`/settings/<localId>` → 該 section active；URL subsection 可讀 `useSettingsRoute()`
+  - `lastSection` 保留（remount 仍回到前次 section）
+  - adapter 自動遷移：先呼 `registerSettingsSection({ id: 'test-legacy', label: '...', order: 99, component: Comp })` → `listContributions('purdex')` 回傳該項目
+  - 關閉 #538 首個 render-level 目標
+- `spa/src/lib/settings-section-registry.test.ts`（新增 adapter 行為測試）
+  - adapter round-trip：`registerSettingsSection` → `getSettingsSections` 回傳原 shape
+  - adapter 與 `listContributions('purdex')` 一致性（同一批資料）
+  - `component` undefined 時跳過註冊（無 throw）
+  - `clearSettingsSectionRegistry` 只清 legacy namespace，不清其他 module 的 contribution
+
+### 不動
+- 7 個既有 built-in section 檔（`AppearanceSection` / `TerminalSection` / `SyncSection` / `LinkDetectionSection` / `DevEnvironmentSection` / `TmuxAgentSection` 等 — 確切數量以當下 `register-modules.tsx` 註冊為準）
+- `spa/src/lib/register-modules.tsx`（section 宣告照舊透過舊 `registerSettingsSection` 呼叫；adapter 會接住）
+- `WorkspaceSettingsPage.tsx` / `HostPage.tsx` / `HostSidebar.tsx` / `host-routes.ts`
+- 三層 settings store（PR-1 已建）
+- PR-1 新 registry 的 `settings-contribution-types.ts`
+
+---
+
+## 3. Test Case Matrix
+
+### 3.1 `settings-section-registry.test.ts`（adapter）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Adapter round-trip | `registerSettingsSection({ id, label, order, component })` → `getSettingsSections()` 回傳原 shape | 通過 |
+| Adapter 轉遷 | 註冊後 `listContributions('purdex')` 含該項（`moduleId='_builtin.legacy-section'`、`localId=id`、`labelKey=label`） | 通過 |
+| Order 保留 | 多項註冊後 `getSettingsSections` / `listContributions` 均依 order 升冪 | 通過 |
+| Reserved skip | `registerSettingsSection({ ..., component: undefined })` → 新 registry 內**無該項**，不 throw | 通過 |
+| Namespace 隔離 | 另一 module（透過 `ModuleDefinition.settings`）註冊 `scope: 'purdex'` 的 contribution 不出現在 `getSettingsSections()` | 通過 |
+| Clear | `clearSettingsSectionRegistry()` 只清 legacy namespace | 通過 |
+| Identity | 同 object 重複呼叫 `registerSettingsSection` → 不 throw（對應 PR-1 §6.2 identity check） | 通過 |
+
+### 3.2 `SettingsPage.test.tsx`（render-level）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Render | 註冊 fake contribution → `<SettingsPage>` render 後 sidebar 含 label、content 區 render fake component | 通過 |
+| Ctx 注入 | fake component 讀 `props.ctx.scope` === `'purdex'` | 通過 |
+| Order | 多項註冊 → sidebar 順序依 order | 通過 |
+| URL 同步 | 初始 URL `/settings/<fakeId>` → 該 section active | 通過 |
+| URL 自癒 | URL 指 invalid section → redirect 到 default | 通過（保留既有行為） |
+| URL 自癒 | URL `>2` 段 → trim 到 `/settings/<section>` | 通過 |
+| Subsection | fake component 透過 `useSettingsRoute()` 讀 subsection | 通過 |
+| `lastSection` 持久 | remount `<SettingsPage>` 仍回到前次 active | 通過 |
+| Adapter 整合 | 只透過舊 `registerSettingsSection` 註冊 → `<SettingsPage>` 仍 render 該 section | 通過 |
+| Workspace 分派 | `props.pane.content.scope = { workspaceId: 'wsA' }` → render `WorkspaceSettingsPage`，不走 `GlobalSettingsPage` | 通過（保留既有） |
+
+### 3.3 `register-modules.test.ts` 擴充
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| 端對端 | 跑 `registerBuiltinModules()` 後，現有 7 個 built-in section 皆在 `listContributions('purdex')` 中，`moduleId='_builtin.legacy-section'` | 通過 |
+| 無 regression | I1 guard 對既有 module fixture 仍不 throw | 通過 |
+
+### 3.4 視覺回歸（肉眼 / 手動）
+
+- `cd spa && pnpm dev` 起站
+- 開 `/settings`：sidebar 上 7 個 section 顯示順序、label、active highlight 與 `main` 分支一致
+- 點每個 section：右側 content 正常渲染（無 console error / 白屏）
+- `/settings/<section>/<subsection>`：subsection context 仍可用（挑一個目前有用 subsection 的 section 驗，如 `/settings/sync/history`）
+- Workspace 打開 settings tab（`pane.content.scope` object）：仍走 `WorkspaceSettingsPage`（本 PR 不動）
+
+---
+
+## 4. 實作順序（TDD）
+
+1. **紅**：寫 §3.1 adapter 測試（僅對 adapter 層）
+2. **綠**：改 `settings-section-registry.ts` 為 adapter
+3. **紅**：寫 §3.2 `SettingsPage.test.tsx`
+4. **綠**：改 `SettingsPage.tsx` `GlobalSettingsPage` + `SettingsSidebar.tsx` 吃新 registry；構造 `ctx` 注入
+5. **紅**：寫 §3.3 register-modules 端對端擴充測試
+6. **綠**：驗證 `registerBuiltinModules` 走 adapter 後仍 pass；若 I1 在 adapter scope 有誤擋，調整 I1 判斷（理論上不需，因為 built-in section 走 legacy adapter 的 moduleId 是 `_builtin.legacy-section`，與 module 宣告的 moduleId 不同，I1 不會觸發）
+7. **#539 收斂**：加 `@internal` + 調整 re-export
+8. **驗證**：`cd spa && pnpm exec vitest run` / `pnpm run lint` / `pnpm run build` 三綠
+9. **手動**：§3.4 視覺回歸
+
+---
+
+## 5. 驗收條件
+
+- [ ] §3.1–3.3 測試全綠
+- [ ] `cd spa && pnpm exec vitest run` 全綠
+- [ ] `cd spa && pnpm run lint` 全綠
+- [ ] `cd spa && pnpm run build` 全綠
+- [ ] §3.4 手動視覺回歸無差異
+- [ ] 現有 7 個 built-in section 在 `listContributions('purdex')` 出現，`moduleId='_builtin.legacy-section'`
+- [ ] `registerSettingsContribution` 標為 `@internal`；非 adapter / register-pass / test 的 callsite 為 0（`rg "registerSettingsContribution"` 人工 audit）
+- [ ] Codex 兩輪 review（標準 + 三路對抗）無 critical / P1 未修項
+- [ ] #538 關閉或標記為「部分關閉 — Purdex 層已補 render smoke，待 PR-3/4 補 Workspace / Host 層」
+
+---
+
+## 6. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| Adapter 的 wrap / unwrap 破壞 React component identity（影響 memo / render optimization） | 中 | wrap 時把原 component 存在 `WeakMap<WrappedComp, OrigComp>` 或 static field，unwrap 時穩定取回；測試覆蓋 `getSettingsSections().component === 原 component` 不強求，只求 render 正確 |
+| `_builtin.legacy-section.<id>` 撞到未來真 module 的 id | 低 | `_builtin.*` 前綴保留為 built-in namespace；I1 / I2 對 moduleId 本身不做格式限制，但文件註明 `_builtin.*` 保留 |
+| `SettingsRouteContext` 行為被無意破壞 | 中 | §3.2 subsection 測試覆蓋 |
+| Reserved section（`component` undefined）原本 sidebar 顯示「coming_soon」灰字 — adapter skip 後 UI 少一格 | 中 | 驗 `main` 分支 reserved section 目前確實顯示於 sidebar（`workspace` / `module-config`）；若是 → PR-2 **暫時保留**現有行為（`SettingsSidebar` 仍吃舊 `getSettingsSections()` 或特殊 branch），待 PR-3 決策 5a 一併清；不提前在 PR-2 清 |
+| `@internal` JSDoc 沒實際效力（TypeScript 不強制） | 低 | 加註 + optional lint rule（`no-restricted-imports` pattern），不阻擋 PR |
+
+**風險備註**：reserved section 處理有兩條路。若 PR-2 要保持 UI 100% 一致（包含 coming_soon 灰字），`SettingsSidebar` 內部仍需透過舊 API 取得 reserved 項目；adapter 保留 `component: undefined` 項目於 legacy namespace 但不轉進新 registry — 這條路讓 PR-2 完全無 UX 變動。**本 plan 採此路**：adapter `registerSettingsSection` 時，若 `component` 為 undefined，項目仍存在 legacy local buffer（不進新 registry），`getSettingsSections()` 同時回傳 new registry + local reserved，`SettingsSidebar` 原 reservedStart 邏輯照舊。PR-3 清完 reserved 後 local buffer 也可拔。
+
+---
+
+## 7. 超出 PR-2 範圍（明確不做）
+
+- `WorkspaceSettingsPage` 改 registry-driven（PR-3）
+- `HostPage` / `HostSidebar` / `host-routes` 改 registry-driven（PR-4）
+- 清理 reserved `workspace` section 與 `module-config` 空頁（PR-3，決策 5a）
+- 既有 7 個 section 搬家為 module-owned declaration（決策 2b — 不在 HSR 系列 scope）
+- 舊 `globalConfig` / `workspaceConfig` deprecate（PR-5 後，決策 3b）
+- 三層 store `get()` 回傳 immutable snapshot（#540；等 PR-5 前必解，本 PR 可先開 issue 交付）
+- `registerSettingsContribution` 完全移除 public export（`@internal` JSDoc 即可；強制移除留到至少確認 0 外部 callsite 之後）
+
+---
+
+## 8. Commit 規劃
+
+每個 commit 必須獨立過 vitest / lint / build（完全綠）。
+
+1. **`docs: HSR spec v3 + PR-2/3/4/5 plans`**（若尚未於前置 docs PR merge 則此 commit 納入；若已 merge 可省略）
+2. **`feat(spa): adapt legacy settings-section-registry to new contribution registry`**
+   - `settings-section-registry.ts` adapter 化 + `settings-section-registry.test.ts` 新增
+3. **`feat(spa): SettingsPage reads new contribution registry`**
+   - `SettingsPage.tsx` + `SettingsSidebar.tsx` 改吃新 registry + `SettingsPage.test.tsx` 新增
+4. **`refactor(spa): mark registerSettingsContribution as internal (#539)`**
+   - JSDoc `@internal` + re-export 調整
+5. **（若 adapter PR scope 大）** 拆分 reserved section 兼容處理為獨立 commit
+
+共 3–5 commits。
+
+---
+
+## 9. 與其他 PR 的關聯
+
+- **依賴**：PR-1（已 merged）
+- **不依賴**：PR-3 / PR-4（三頁 shell 改造彼此獨立）
+- **被依賴**：PR-5（Editor 首個用例需要 PR-2 的 shell 已完成，才能在 `/settings/editor` 看到新 section — 但 PR-5 的 Editor `homePath` 是 workspace/host scope，不是 purdex scope，因此嚴格來說也不依賴 PR-2）
+- **順風解決**：#538（Purdex 層）/ #539（internal 收斂）

--- a/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
@@ -1,11 +1,12 @@
 # HSR PR-2：Purdex Settings Shell + Legacy Adapter — Implementation Plan
 
-> 日期：2026-04-22（v3 post-codex-review Round 2 task-mo8z6ppx-pj07yk）
+> 日期：2026-04-22（v3.1 post-codex-review Round 3 task-mo90eijb-mk3gfg）
 > 狀態：Ready for Implementation
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
 > 決策對齊：1c（adapter-only, **dispatch-flushed**）+ 2b（既有 section 不搬家）+ 3b（舊 API deprecate 時點）
 > PR 系列：PR-1 ✅ / **PR-2（本文件）** / PR-3 / PR-4 / PR-5
-> v3 收斂：Round 1 Finding 1/6 → v2 修；Round 2 Finding 6 partial（§2/§8 sidebar 敘事矛盾）+ N1（reserved buffer idempotent/HMR）+ N3（commit 1→2 依賴）→ 本版修
+> v3 收斂：Round 1 Finding 1/6 → v2 修；Round 2 Finding 6 partial + N1 + N3 → v3 修
+> v3.1 收斂：Round 3 MED（§2/§3.2 test 敘述仍把 adapter 寫成「直接可見」與 pending-buffer 衝突、active section 數硬編 6/7）→ 本版補上 `dispatchSettingsContributions()` 敘述、去掉硬編數字改為「至少 6 + 條件式」
 
 ---
 
@@ -66,19 +67,19 @@ PR-2 結束時：
 
 ### 新增
 - `spa/src/components/SettingsPage.test.tsx`
-  - Render-level smoke：註冊 fake contribution（scope: 'purdex'）→ `SettingsPage` render 後 sidebar 顯示該 label、active 時 content 區 render 該 component
+  - Render-level smoke：**先** register fake contribution + **呼叫 `dispatchSettingsContributions([...modules])`**（或透過 `registerBuiltinModules()` 完整 bootstrap fixture，其內部已含 dispatch）→ `SettingsPage` render 後 sidebar 顯示該 label、active 時 content 區 render 該 component
   - URL routing：`/settings/<localId>` → 該 section active；URL subsection 可讀 `useSettingsRoute()`
   - `lastSection` 保留（remount 仍回到前次 section）
-  - adapter 自動遷移：先呼 `registerSettingsSection({ id: 'test-legacy', label: '...', order: 99, component: Comp })` → `listContributions('purdex')` 回傳該項目
+  - adapter 自動遷移：`registerSettingsSection({ id: 'test-legacy', label: '...', order: 99, component: Comp })` → `dispatchSettingsContributions([])` → `listContributions('purdex')` 回傳該項目（dispatch 是唯一 flush 入口）
   - 關閉 #538 首個 render-level 目標
 - `spa/src/lib/settings-section-registry.test.ts`（新增 adapter 行為測試）
-  - adapter round-trip：`registerSettingsSection` → `getSettingsSections` 回傳原 shape
-  - adapter 與 `listContributions('purdex')` 一致性（同一批資料）
-  - `component` undefined 時跳過註冊（無 throw）
-  - `clearSettingsSectionRegistry` 只清 legacy namespace，不清其他 module 的 contribution
+  - adapter round-trip：`registerSettingsSection(x)` → `dispatchSettingsContributions([])` → `getSettingsSections()` 回傳原 shape（**dispatch 後** active 項來自新 registry filter + reserved 來自 `pendingReservedItems`）
+  - adapter 與 `listContributions('purdex')` 一致性：dispatch 後同一批資料（active 項目）；dispatch 前兩者都空（pending buffer 未 flush）
+  - `component` undefined 時改進 reserved map（無 throw）；`listReservedItems()` 含該項
+  - `clearSettingsSectionRegistry` 只清 pending buffer（legacy namespace），不清其他 module 的 contribution（走新 registry 的 `clearContributions`）
 
 ### 不動
-- 7 個既有 built-in section 檔（`AppearanceSection` / `TerminalSection` / `SyncSection` / `LinkDetectionSection` / `DevEnvironmentSection` / `TmuxAgentSection` 等 — 確切數量以當下 `register-modules.tsx` 註冊為準）
+- 既有 built-in section 檔（`AppearanceSection` / `TerminalSection` / `InterfaceSectionHost` / `SyncSection` / `ModuleConfigSection` / `BufferListSection` 等；conditional: `ElectronSection` / `DevEnvironmentSection` / `TmuxAgentMonitorSection` — 確切清單以當下 `register-modules.tsx` 註冊 + caps flag 為準）
 - `spa/src/lib/register-modules.tsx`（section 宣告照舊透過舊 `registerSettingsSection` 呼叫；adapter 會接住）
 - `WorkspaceSettingsPage.tsx` / `HostPage.tsx` / `HostSidebar.tsx` / `host-routes.ts`
 - 三層 settings store（PR-1 已建）
@@ -120,22 +121,22 @@ PR-2 結束時：
 | URL 自癒 | URL `>2` 段 → trim 到 `/settings/<section>` | 通過 |
 | Subsection | fake component 透過 `useSettingsRoute()` 讀 subsection | 通過 |
 | `lastSection` 持久 | remount `<SettingsPage>` 仍回到前次 active | 通過 |
-| Adapter 整合 | 只透過舊 `registerSettingsSection` 註冊 → `<SettingsPage>` 仍 render 該 section | 通過 |
+| Adapter 整合 | 透過舊 `registerSettingsSection` 註冊 + 呼叫 `dispatchSettingsContributions([])` → `<SettingsPage>` 仍 render 該 section（bootstrap fixture 走完整 `registerBuiltinModules()` 或測試顯式 dispatch） | 通過（保留既有） |
 | Workspace 分派 | `props.pane.content.scope = { workspaceId: 'wsA' }` → render `WorkspaceSettingsPage`，不走 `GlobalSettingsPage` | 通過（保留既有） |
 
 ### 3.3 `register-modules.test.ts` 擴充
 
 | 類別 | 測試項 | 預期 |
 |---|---|---|
-| 端對端 | 跑 `registerBuiltinModules()` 後，現有 **active** built-in section 皆在 `listContributions('purdex')`，`moduleId='_builtin.legacy-section'`；active 數 = 6（appearance / terminal / interface / sync / module-config / editor-buffers，workspace 為 reserved 不進 registry） | 通過 |
-| Reserved 顯示 | `getSettingsSections()` 回傳 7 項（含 workspace reserved），`component: undefined` 的項可被 sidebar render 為 coming_soon | 通過 |
+| 端對端 | 跑 `registerBuiltinModules()` 後，現有 **active** built-in section 皆在 `listContributions('purdex')`，`moduleId='_builtin.legacy-section'`；至少 6 項（appearance / terminal / interface / sync / module-config / editor-buffers；workspace 為 reserved 不進 registry；conditional: electron / dev-environment / tmux-agent-monitor 視 caps / `import.meta.env.DEV` 而定）| 通過 |
+| Reserved 顯示 | `listReservedItems()` 含 workspace reserved（`component: undefined`，可被 sidebar render 為 coming_soon）；數量為 1（目前僅 workspace reserved） | 通過 |
 | 無 regression | I1 guard 對既有 module fixture 仍不 throw | 通過 |
 | Dispatch 時序 | 對 `registerBuiltinModules()` 流程做 integration test：`registerModule` + `registerSettingsSection` 都跑完後 `dispatchSettingsContributions()` 最後呼叫，確認 legacy 項不被清 | 通過 |
 
 ### 3.4 視覺回歸（肉眼 / 手動）
 
 - `cd spa && pnpm dev` 起站
-- 開 `/settings`：sidebar 上 7 個 section 顯示順序、label、active highlight 與 `main` 分支一致
+- 開 `/settings`：sidebar 的 active sections + reserved 分隔線排序、label、active highlight 與 `main` 分支一致（實際項數視 dev/caps 而異；以 `main` 同環境為基準 diff）
 - 點每個 section：右側 content 正常渲染（無 console error / 白屏）
 - `/settings/<section>/<subsection>`：subsection context 仍可用（挑一個目前有用 subsection 的 section 驗，如 `/settings/sync/history`）
 - Workspace 打開 settings tab（`pane.content.scope` object）：仍走 `WorkspaceSettingsPage`（本 PR 不動）

--- a/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md
@@ -1,18 +1,18 @@
 # HSR PR-2：Purdex Settings Shell + Legacy Adapter — Implementation Plan
 
-> 日期：2026-04-22
+> 日期：2026-04-22（v2 post-codex-review task-mo8xtpa8-bdxsh4）
 > 狀態：Ready for Implementation
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
-> 決策對齊：1c（adapter-only）+ 2b（既有 section 不搬家）+ 3b（舊 API deprecate 時點）
+> 決策對齊：1c（adapter-only, **dispatch-flushed**）+ 2b（既有 section 不搬家）+ 3b（舊 API deprecate 時點）
 > PR 系列：PR-1 ✅ / **PR-2（本文件）** / PR-3 / PR-4 / PR-5
 
 ---
 
 ## 1. 範圍
 
-**Shell 改造 + legacy adapter**。`SettingsPage` 的 `GlobalSettingsPage` 改讀新 registry；舊 `settings-section-registry` 改為薄 adapter：`registerSettingsSection()` 內部轉呼 `registerSettingsContribution()`；`getSettingsSections()` 改為對新 registry 的 filtered view。既有 7 個 built-in section 內部程式碼**零改動**（決策 2b）。
+**Shell 改造 + legacy adapter（dispatch-flushed）**。`SettingsPage` 的 `GlobalSettingsPage` 改讀新 registry；舊 `settings-section-registry` 改為 pending-buffer adapter（**不直接呼叫** `registerSettingsContribution()`，否則 `dispatchSettingsContributions()` 的 `clearContributions()` 會把 legacy 項整批清掉 — codex review Finding 1 的硬約束）；改 push 到 `pendingLegacyContributions` module-scope buffer，由 `dispatchSettingsContributions()` 統一 drain + register；`getSettingsSections()` 改為對新 registry `moduleId === '_builtin.legacy-section'` 的 filtered view。既有 7 個 built-in section 內部程式碼**零改動**（決策 2b）。
 
-同步完成 **#539**：把 `registerSettingsContribution` / `clearContributions` 收斂為 internal API（僅供 adapter + register pass + test 呼叫；外部 module 不得直接呼叫）。
+同步完成 **#539**：把 `registerSettingsContribution` / `clearContributions` 降級為 `@internal`（僅 `dispatch-settings-contributions.ts` 與 test 呼叫；legacy adapter 也不直接呼叫，走 pending buffer）。
 
 PR-2 結束時：
 - `GlobalSettingsPage` 透過 `listContributions('purdex')` + `SettingsContext({ scope: 'purdex' })` 渲染
@@ -35,18 +35,29 @@ PR-2 結束時：
   - 改吃 `listContributions('purdex')`
   - `reservedStart` 邏輯保留（因為 reserved section 會在 PR-3 才清，PR-2 期間仍可能出現無 `component` 的 contribution；但新 registry 的 `component` 是 required，所以實務上不會有 reserved 進 registry — adapter 在組 declaration 時若原 def `component` 為 undefined，**跳過註冊**，由 PR-3 shell 改造時一併拔除 reserved 顯示）
   - `label` → `labelKey`（其實只是欄位 rename，值原本就是 i18n key）
-- `spa/src/lib/settings-section-registry.ts`（adapter 化）
-  - `registerSettingsSection(def)`：組 `SettingsContributionDeclaration`（`localId = def.id`、`scope: 'purdex'`、`order = def.order`、`labelKey = def.label`、`component = wrapLegacyComponent(def.component)`）+ `moduleId = '_builtin.legacy-section'`，呼叫 `registerSettingsContribution({ ...decl, moduleId, id: `${moduleId}.${def.id}` })`
-  - 若 `def.component` 為 `undefined` → **跳過註冊**（避免新 registry required field 衝突；reserved section 的 UI 由 PR-3 sidebar 改造時明確處理）
-  - `getSettingsSections()`：`listContributions('purdex').filter(c => c.moduleId === '_builtin.legacy-section').map(c => ({ id: c.localId, label: c.labelKey, order: c.order, component: unwrapLegacyComponent(c.component) }))`
-  - `clearSettingsSectionRegistry()`：呼叫 `clearContributions()`（registry test-only）或只清 legacy namespace（取決於是否只測 legacy adapter — 安全作法：只清 `_builtin.legacy-section.*`）
-  - `wrapLegacyComponent(Comp)`：`(props: { ctx: SettingsContext }) => <Comp />`（忽略 ctx — legacy component 不吃 ctx）
-  - `unwrapLegacyComponent(Wrapped)`：adapter 內部把 wrap 時原 Comp 掛在 `Wrapped.__legacyComponent` 取回；或直接存 map — 任一皆可，一致即可
+- `spa/src/lib/settings-section-registry.ts`（adapter 化 + pending buffer）
+  - 新增 module-scope `let pendingLegacyContributions: SettingsContributionDeclaration[] = []`
+  - 新增 module-scope `let pendingReservedItems: SettingsSectionDef[] = []`（**Finding 6 的統一解法**：reserved `component: undefined` 不進新 registry，僅保留在 legacy buffer 供 `SettingsSidebar` 顯示 coming_soon）
+  - `registerSettingsSection(def)`：
+    - 若 `def.component` 為 undefined → push 到 `pendingReservedItems`
+    - 否則 → 組 `SettingsContributionDeclaration`（`localId = def.id`、`scope: 'purdex'`、`order = def.order`、`labelKey = def.label`、`component = wrapLegacyComponent(def.component)`） push 到 `pendingLegacyContributions`（`moduleId = '_builtin.legacy-section'`；完整 `id` 由 dispatch 時組）
+    - **不呼叫** `registerSettingsContribution`
+  - 新增 export `drainLegacyContributionQueue(): SettingsContributionDeclaration[]`：回傳 pending buffer 的 deep copy 並清空 buffer（dispatch pass 呼叫）
+  - `getSettingsSections(): SettingsSectionDef[]`：將 `listContributions('purdex').filter(c => c.moduleId === '_builtin.legacy-section').map(toLegacyShape)` 與 `pendingReservedItems` 合併，依 `order` 升冪排序回傳（讓 `SettingsSidebar` 一次看到 active + reserved）
+  - `clearSettingsSectionRegistry()`：清 `pendingLegacyContributions` + `pendingReservedItems`（僅 test 用）
+  - `wrapLegacyComponent(Comp)`：`(props: { ctx: SettingsContext }) => <Comp />`（忽略 ctx；legacy component 不吃 ctx）
+  - `toLegacyShape(c)`：將 contribution 還原回 `{ id, label, order, component }` shape（`component` 透過 `legacyComponentMap` WeakMap 取原 component reference，避免 wrap 破壞 React identity）
+- `spa/src/lib/dispatch-settings-contributions.ts`（配合 adapter）
+  - `dispatchSettingsContributions(modules)` 的 Phase 2，`clearContributions()` 後除了 register module-declared batch，還要：
+    - `const legacyBatch = drainLegacyContributionQueue()`
+    - 將 legacy declarations 補上 `moduleId + id`，透過相同 `assertValidSettingsContribution` + 重複 id 檢查，加入 `seenIds`
+    - `registerSettingsContribution(...)` 兩批合計
+  - 新增 invariant：module-declared 與 legacy 間不得出現同 `id`（理論上不會撞，因為 `moduleId` 不同；但防禦檢查）
 - `spa/src/lib/settings-contribution-registry.ts`（#539 internal 收斂）
-  - `registerSettingsContribution` / `clearContributions` 加 `/** @internal */` JSDoc tag
-  - Re-export 從 `module-registry.ts` 拿掉（module 作者只透過 `ModuleDefinition.settings` 宣告，不得繞過 register pass 直接呼叫）
+  - `registerSettingsContribution` / `clearContributions` / `assertValidSettingsContribution` 加 `/** @internal */` JSDoc tag
+  - Re-export 從 `module-registry.ts` 拿掉（module 作者只透過 `ModuleDefinition.settings` 宣告；legacy adapter 透過 pending buffer；兩條路之外不得寫入）
   - `listContributions` / `getContribution` 保持 public（shell 消費）
-  - 若有外部 callsite（PR-1 後除 adapter 外理論應為 0 個），lint rule 或 ESLint `no-restricted-imports` 擋（optional，有則做）
+  - ESLint `no-restricted-imports`（optional）：僅允許 `dispatch-settings-contributions.ts` / `settings-section-registry.ts` / 測試檔 import `registerSettingsContribution` / `clearContributions`
 
 ### 新增
 - `spa/src/components/SettingsPage.test.tsx`
@@ -72,17 +83,22 @@ PR-2 結束時：
 
 ## 3. Test Case Matrix
 
-### 3.1 `settings-section-registry.test.ts`（adapter）
+### 3.1 `settings-section-registry.test.ts`（adapter + pending buffer）
 
 | 類別 | 測試項 | 預期 |
 |---|---|---|
-| Adapter round-trip | `registerSettingsSection({ id, label, order, component })` → `getSettingsSections()` 回傳原 shape | 通過 |
-| Adapter 轉遷 | 註冊後 `listContributions('purdex')` 含該項（`moduleId='_builtin.legacy-section'`、`localId=id`、`labelKey=label`） | 通過 |
-| Order 保留 | 多項註冊後 `getSettingsSections` / `listContributions` 均依 order 升冪 | 通過 |
-| Reserved skip | `registerSettingsSection({ ..., component: undefined })` → 新 registry 內**無該項**，不 throw | 通過 |
-| Namespace 隔離 | 另一 module（透過 `ModuleDefinition.settings`）註冊 `scope: 'purdex'` 的 contribution 不出現在 `getSettingsSections()` | 通過 |
-| Clear | `clearSettingsSectionRegistry()` 只清 legacy namespace | 通過 |
-| Identity | 同 object 重複呼叫 `registerSettingsSection` → 不 throw（對應 PR-1 §6.2 identity check） | 通過 |
+| Pending buffer | `registerSettingsSection({ id, label, order, component })` 後 `listContributions('purdex')` **空**（因 dispatch 尚未跑） | 通過 |
+| Pending buffer | 同上後呼叫 `drainLegacyContributionQueue()` 回傳含該項的 declaration；再呼叫一次回傳空陣列 | 通過 |
+| Dispatch flush | 完整流程：`registerSettingsSection(x)` → `dispatchSettingsContributions([module])` → `listContributions('purdex')` 含 `_builtin.legacy-section.x` | 通過 |
+| Dispatch survive | `registerSettingsSection(x)` → `dispatchSettingsContributions([])` → `listContributions('purdex')` 仍含該項（legacy drain 後 clear 重 register，**不會被清**） | **關鍵 — Finding 1 回歸** |
+| Adapter round-trip | dispatch 後 `getSettingsSections()` 回傳 active 項目原 shape（id / label / order / component reference 等於原 def.component） | 通過 |
+| React identity | dispatch 後 `getSettingsSections()[i].component === 原 passed-in Comp`（透過 `legacyComponentMap` unwrap） | 通過 |
+| Order 保留 | 多項 active + reserved 混合註冊後 `getSettingsSections()` 依 order 升冪交錯回傳 | 通過 |
+| Reserved buffer | `registerSettingsSection({ ..., component: undefined })` → dispatch 後新 registry **無** 該項；`getSettingsSections()` **有** 該項（from `pendingReservedItems`），`component` 為 undefined | **Finding 6 — 統一策略驗證** |
+| HMR re-run | `registerSettingsSection(x)` → dispatch → 再次 `registerSettingsSection(x)` → dispatch → 不 throw，最終一份（pending drain 每輪用完即清） | 通過 |
+| Namespace 隔離 | 另一 module 透過 `ModuleDefinition.settings` 宣告 `scope: 'purdex'` → dispatch 後 `getSettingsSections()` **不**回傳該項（filter `moduleId === '_builtin.legacy-section'`） | 通過 |
+| Clear | `clearSettingsSectionRegistry()` 清 pending buffer（不碰新 registry；dispatch 後的結果由 `clearContributions()` 負責） | 通過 |
+| Cross-id guard | module 宣告 `moduleId='foo', localId='appearance'` + legacy adapter 收 `id='appearance'` → dispatch 後兩者 id 不同（`foo.appearance` vs `_builtin.legacy-section.appearance`），無衝突 | 通過 |
 
 ### 3.2 `SettingsPage.test.tsx`（render-level）
 
@@ -103,8 +119,10 @@ PR-2 結束時：
 
 | 類別 | 測試項 | 預期 |
 |---|---|---|
-| 端對端 | 跑 `registerBuiltinModules()` 後，現有 7 個 built-in section 皆在 `listContributions('purdex')` 中，`moduleId='_builtin.legacy-section'` | 通過 |
+| 端對端 | 跑 `registerBuiltinModules()` 後，現有 **active** built-in section 皆在 `listContributions('purdex')`，`moduleId='_builtin.legacy-section'`；active 數 = 6（appearance / terminal / interface / sync / module-config / editor-buffers，workspace 為 reserved 不進 registry） | 通過 |
+| Reserved 顯示 | `getSettingsSections()` 回傳 7 項（含 workspace reserved），`component: undefined` 的項可被 sidebar render 為 coming_soon | 通過 |
 | 無 regression | I1 guard 對既有 module fixture 仍不 throw | 通過 |
+| Dispatch 時序 | 對 `registerBuiltinModules()` 流程做 integration test：`registerModule` + `registerSettingsSection` 都跑完後 `dispatchSettingsContributions()` 最後呼叫，確認 legacy 項不被清 | 通過 |
 
 ### 3.4 視覺回歸（肉眼 / 手動）
 
@@ -148,13 +166,12 @@ PR-2 結束時：
 
 | 風險 | 發生可能 | 緩解 |
 |---|---|---|
-| Adapter 的 wrap / unwrap 破壞 React component identity（影響 memo / render optimization） | 中 | wrap 時把原 component 存在 `WeakMap<WrappedComp, OrigComp>` 或 static field，unwrap 時穩定取回；測試覆蓋 `getSettingsSections().component === 原 component` 不強求，只求 render 正確 |
-| `_builtin.legacy-section.<id>` 撞到未來真 module 的 id | 低 | `_builtin.*` 前綴保留為 built-in namespace；I1 / I2 對 moduleId 本身不做格式限制，但文件註明 `_builtin.*` 保留 |
+| Adapter wrap / unwrap 破壞 React component identity（影響 memo） | 中 | wrap 時 `legacyComponentMap: WeakMap<WrappedComp, OrigComp>`；`getSettingsSections()` 的 `toLegacyShape` 透過 map 取原 component；§3.1 「React identity」測試明確 assert `component === 原 Comp` |
+| `_builtin.legacy-section.<id>` / `_builtin.host.<id>` 撞到未來真 module 的 id | 低 | `_builtin.*` 前綴保留為 built-in namespace；本 PR 在 `settings-section-registry.ts` 硬編 `'_builtin.legacy-section'` 常數，集中管理；未來引入 namespace guard（禁止 module 作者用 `_builtin.` 開頭的 moduleId）由 #539 延伸追蹤 issue |
 | `SettingsRouteContext` 行為被無意破壞 | 中 | §3.2 subsection 測試覆蓋 |
-| Reserved section（`component` undefined）原本 sidebar 顯示「coming_soon」灰字 — adapter skip 後 UI 少一格 | 中 | 驗 `main` 分支 reserved section 目前確實顯示於 sidebar（`workspace` / `module-config`）；若是 → PR-2 **暫時保留**現有行為（`SettingsSidebar` 仍吃舊 `getSettingsSections()` 或特殊 branch），待 PR-3 決策 5a 一併清；不提前在 PR-2 清 |
-| `@internal` JSDoc 沒實際效力（TypeScript 不強制） | 低 | 加註 + optional lint rule（`no-restricted-imports` pattern），不阻擋 PR |
-
-**風險備註**：reserved section 處理有兩條路。若 PR-2 要保持 UI 100% 一致（包含 coming_soon 灰字），`SettingsSidebar` 內部仍需透過舊 API 取得 reserved 項目；adapter 保留 `component: undefined` 項目於 legacy namespace 但不轉進新 registry — 這條路讓 PR-2 完全無 UX 變動。**本 plan 採此路**：adapter `registerSettingsSection` 時，若 `component` 為 undefined，項目仍存在 legacy local buffer（不進新 registry），`getSettingsSections()` 同時回傳 new registry + local reserved，`SettingsSidebar` 原 reservedStart 邏輯照舊。PR-3 清完 reserved 後 local buffer 也可拔。
+| Reserved section 與 active section 的 order 混排視覺順序改變 | 低 | §3.1「Order 保留 — 多項 active + reserved 混合註冊後依 order 升冪交錯」測試；現況 active/reserved 已依 order 分佈（active order=0/1/2/8/9/11, reserved order=10），交錯順序與 `main` 一致 |
+| `@internal` JSDoc 沒實際效力（TypeScript 不強制） | 低 | 加註 + optional `no-restricted-imports`；不阻擋 PR |
+| Dispatch pass 被多次呼叫 → legacy buffer drain 後 buffer 空 → 第 2 次 dispatch 後新 registry 只剩 module-declared（legacy 消失） | **高（若不小心實作）** | §3.1「HMR re-run」測試要求：每次 `registerBuiltinModules()` 前端流程 `registerSettingsSection` 會重新 push，所以每次 dispatch 都能 drain 到完整 legacy 批次；HMR 中須保證 `registerSettingsSection` 先於 `dispatchSettingsContributions` 重新跑（這是現況流程 — dispatch 在 `registerBuiltinModules()` 結尾） |
 
 ---
 
@@ -174,22 +191,28 @@ PR-2 結束時：
 
 每個 commit 必須獨立過 vitest / lint / build（完全綠）。
 
-1. **`docs: HSR spec v3 + PR-2/3/4/5 plans`**（若尚未於前置 docs PR merge 則此 commit 納入；若已 merge 可省略）
-2. **`feat(spa): adapt legacy settings-section-registry to new contribution registry`**
-   - `settings-section-registry.ts` adapter 化 + `settings-section-registry.test.ts` 新增
-3. **`feat(spa): SettingsPage reads new contribution registry`**
-   - `SettingsPage.tsx` + `SettingsSidebar.tsx` 改吃新 registry + `SettingsPage.test.tsx` 新增
+1. **`feat(spa): dispatch pass also flushes legacy contribution queue`**
+   - `dispatch-settings-contributions.ts` 加 `drainLegacyContributionQueue()` 整合 + 測試（`dispatch-settings-contributions.test.ts` 擴充）
+   - 這個 commit 之前 legacy queue empty，測試預設空 drain；commit 後 dispatch 行為新增，但仍 backwards-compat（無 legacy item 時行為不變）— 單測獨立可綠
+2. **`feat(spa): settings-section-registry uses pending buffer + reserved items`**
+   - `settings-section-registry.ts` 改實作（pending buffer + `drainLegacyContributionQueue` export + `getSettingsSections` 合併 registry + reserved）+ `settings-section-registry.test.ts` 新增 §3.1 全部案例
+   - 依賴 commit 1（dispatch drain 語義）；此 commit 後 `registerBuiltinModules()` 跑完的 end-to-end 行為與 `main` 一致（existing 6 active + 1 reserved）
+3. **`feat(spa): SettingsPage reads new contribution registry with ctx`**
+   - `SettingsPage.tsx` + `SettingsSidebar.tsx` 改 `listContributions('purdex')` / `ctx` 注入 + `SettingsPage.test.tsx`
+   - Sidebar 繼續透過 `getSettingsSections()` 拿 reserved（因 reserved 不在新 registry），保持 coming_soon 視覺
 4. **`refactor(spa): mark registerSettingsContribution as internal (#539)`**
-   - JSDoc `@internal` + re-export 調整
-5. **（若 adapter PR scope 大）** 拆分 reserved section 兼容處理為獨立 commit
+   - JSDoc `@internal` + re-export 調整 + optional ESLint rule
 
-共 3–5 commits。
+共 4 commits。每個皆獨立可綠（commit 1 僅新增 drain 入口但不影響既有行為；commit 2 遷 adapter 時 dispatch 已 ready；commit 3 只讀，不動 registry；commit 4 純文檔/型別）。
 
 ---
 
 ## 9. 與其他 PR 的關聯
 
 - **依賴**：PR-1（已 merged）
-- **不依賴**：PR-3 / PR-4（三頁 shell 改造彼此獨立）
-- **被依賴**：PR-5（Editor 首個用例需要 PR-2 的 shell 已完成，才能在 `/settings/editor` 看到新 section — 但 PR-5 的 Editor `homePath` 是 workspace/host scope，不是 purdex scope，因此嚴格來說也不依賴 PR-2）
-- **順風解決**：#538（Purdex 層）/ #539（internal 收斂）
+- **必須先於**：
+  - PR-3（共改 `SettingsSidebar.tsx` — PR-3 清 `reservedStart` 分支 build on PR-2 新版；共改 `dispatch-settings-contributions.ts` 時序假設）
+  - PR-4（共改 `register-modules.tsx` — PR-4 加 `registerBuiltinHostSections()` 假設 dispatch pass 能正確吸收多種 contribution 來源）
+- **不依賴**：純 purdex scope 的 `SettingsPage` 改動不影響 host / workspace shell
+- **被依賴**：PR-3 / PR-4 / PR-5（都依 PR-2 建立的 dispatch-flushed adapter pattern 與 `@internal` boundary）
+- **順風解決**：#538（Purdex 層 render-level smoke）/ #539（internal 收斂 + adapter 為唯一合法 side-channel）

--- a/docs/specs/2026-04-22-hsr-pr3-workspace-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr3-workspace-shell-plan.md
@@ -1,7 +1,7 @@
 # HSR PR-3：Workspace Settings Shell + Reserved Cleanup — Implementation Plan
 
-> 日期：2026-04-22
-> 狀態：Ready for Implementation
+> 日期：2026-04-22（v2 post-codex-review task-mo8xtpa8-bdxsh4）
+> 狀態：Ready for Implementation（**依序 build on PR-2**，不可與 PR-2 並行）
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
 > 決策對齊：5a（PR-3 清 reserved + 空頁）+ 2b（既有 `ModuleConfigSection` 不動）
 > PR 系列：PR-1 ✅ / PR-2 / **PR-3（本文件）** / PR-4 / PR-5
@@ -37,9 +37,10 @@ PR-3 結束時：
   - 移除 `registerSettingsSection({ id: 'workspace', ..., order: 10 })`（reserved 行）
   - 移除 `registerSettingsSection({ id: 'module-config', ..., order: 8, component: () => <ModuleConfigSection scope="global" /> })`（global scope 無 production 消費者）
   - 若 PR-2 有為 reserved 保留 local buffer 兼容路徑，同步拔除該 buffer
-- `spa/src/components/settings/SettingsSidebar.tsx`
-  - 清掉 `reservedStart` 分隔線邏輯（reserved 已不存在）
-  - （optional）移除 coming_soon disabled 灰字樣式（若已無 reserved item，分支恆未觸發）
+- `spa/src/components/settings/SettingsSidebar.tsx`（build on PR-2 新版 — PR-2 已改為讀 `listContributions('purdex')` + `getSettingsSections()` 合併 reserved；本 PR 拔除 reserved 後 sidebar 可簡化）
+  - PR-3 rebase PR-2 後：清掉 `reservedStart` 分隔線邏輯（reserved 已不存在）
+  - 移除 coming_soon disabled 灰字樣式（無 reserved item，分支恆未觸發）
+  - 若 PR-2 的 PR-2 sidebar 實作仍保留 reserved 透過 `getSettingsSections()` 回傳，本 PR 一併把 `SettingsSidebar` 簡化為**只讀 `listContributions('purdex')`**，拋棄 `getSettingsSections()` 依賴（可連帶開始規劃 `settings-section-registry.ts` 的最終拔除時點，但不在本 PR 完成）
 - `spa/src/locales/en.json` / `zh-TW.json`
   - 移除 `settings.section.workspace` i18n key（若 reserved 特有，且無其他 callsite）
   - 保留 `settings.section.modules` key（`module-config` section 相關，但 `ModuleConfigSection` 本身仍在 workspace 頁用，key 可能仍有用；實作時 audit）
@@ -166,7 +167,8 @@ PR-3 結束時：
 
 ## 9. 與其他 PR 的關聯
 
-- **依賴**：PR-1（已 merged）
-- **不依賴**：PR-2 / PR-4（三頁 shell 彼此獨立；PR-2 reserved 兼容 buffer 若存在，PR-3 順手拔）
+- **依賴**：PR-1（已 merged）+ **PR-2**（PR-3 build on PR-2 修好的 `SettingsSidebar.tsx` 與 dispatch-flushed adapter；reserved 清除會同步拔除 PR-2 留下的 `pendingReservedItems` buffer 與 `getSettingsSections()` 合併邏輯）
+- **rebase 衝突點**（若與 PR-4 並行）：
+  - `spa/src/lib/register-modules.tsx` — PR-3 拔 `workspace` / `module-config` 兩行；PR-4 加 `registerBuiltinHostSections()`。兩個位置不同，機械合併可行
 - **被依賴**：PR-5（Editor `workspaceConfig.homePath` 首個用例 — 需要 PR-3 的 workspace shell 已能 render 新 contribution）
-- **順風解決**：#538（workspace 層）
+- **順風解決**：#538（workspace 層 render-level smoke）

--- a/docs/specs/2026-04-22-hsr-pr3-workspace-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr3-workspace-shell-plan.md
@@ -1,10 +1,11 @@
 # HSR PR-3：Workspace Settings Shell + Reserved Cleanup — Implementation Plan
 
-> 日期：2026-04-22（v2 post-codex-review task-mo8xtpa8-bdxsh4）
+> 日期：2026-04-22（v3 post-codex-review Round 2 task-mo8z6ppx-pj07yk）
 > 狀態：Ready for Implementation（**依序 build on PR-2**，不可與 PR-2 並行）
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
 > 決策對齊：5a（PR-3 清 reserved + 空頁）+ 2b（既有 `ModuleConfigSection` 不動）
 > PR 系列：PR-1 ✅ / PR-2 / **PR-3（本文件）** / PR-4 / PR-5
+> v3 收斂：Round 1 + Round 2 皆對 PR-3 無 finding；僅隨 PR-2 sidebar 敘事更新對齊（reserved buffer 在 PR-2 v3 改為 `Map` upsert，PR-3 清除時一併拔除 map 與 `listReservedItems` export）
 
 ---
 
@@ -37,10 +38,11 @@ PR-3 結束時：
   - 移除 `registerSettingsSection({ id: 'workspace', ..., order: 10 })`（reserved 行）
   - 移除 `registerSettingsSection({ id: 'module-config', ..., order: 8, component: () => <ModuleConfigSection scope="global" /> })`（global scope 無 production 消費者）
   - 若 PR-2 有為 reserved 保留 local buffer 兼容路徑，同步拔除該 buffer
-- `spa/src/components/settings/SettingsSidebar.tsx`（build on PR-2 新版 — PR-2 已改為讀 `listContributions('purdex')` + `getSettingsSections()` 合併 reserved；本 PR 拔除 reserved 後 sidebar 可簡化）
+- `spa/src/components/settings/SettingsSidebar.tsx`（build on PR-2 v3 — PR-2 改為讀 `listContributions('purdex')` + `listReservedItems()` 兩路合併；本 PR 拔除 reserved 後 sidebar 簡化為只讀 `listContributions('purdex')`）
   - PR-3 rebase PR-2 後：清掉 `reservedStart` 分隔線邏輯（reserved 已不存在）
   - 移除 coming_soon disabled 灰字樣式（無 reserved item，分支恆未觸發）
-  - 若 PR-2 的 PR-2 sidebar 實作仍保留 reserved 透過 `getSettingsSections()` 回傳，本 PR 一併把 `SettingsSidebar` 簡化為**只讀 `listContributions('purdex')`**，拋棄 `getSettingsSections()` 依賴（可連帶開始規劃 `settings-section-registry.ts` 的最終拔除時點，但不在本 PR 完成）
+  - 移除對 `listReservedItems()` 的呼叫；`settings-section-registry.ts` 的 `listReservedItems` export + `pendingReservedItems` Map 連帶拔除（dead code）
+  - `getSettingsSections()` 過渡 API 保留給尚未遷的外部 callsite（若 grep 已無外部 callsite，可在本 PR 直接移除；實作時 audit 後決定）
 - `spa/src/locales/en.json` / `zh-TW.json`
   - 移除 `settings.section.workspace` i18n key（若 reserved 特有，且無其他 callsite）
   - 保留 `settings.section.modules` key（`module-config` section 相關，但 `ModuleConfigSection` 本身仍在 workspace 頁用，key 可能仍有用；實作時 audit）

--- a/docs/specs/2026-04-22-hsr-pr3-workspace-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr3-workspace-shell-plan.md
@@ -1,0 +1,172 @@
+# HSR PR-3：Workspace Settings Shell + Reserved Cleanup — Implementation Plan
+
+> 日期：2026-04-22
+> 狀態：Ready for Implementation
+> 主 spec：`2026-04-21-settings-contribution-registry-design.md`
+> 決策對齊：5a（PR-3 清 reserved + 空頁）+ 2b（既有 `ModuleConfigSection` 不動）
+> PR 系列：PR-1 ✅ / PR-2 / **PR-3（本文件）** / PR-4 / PR-5
+
+---
+
+## 1. 範圍
+
+**Shell 改造 + 清理**。`WorkspaceSettingsPage` 在現有單頁佈局中插入一個「workspace-scoped contributions」區，疊渲染 `listContributions('workspace')`，每個 contribution 以 `ctx: { scope: 'workspace', workspaceId }` 傳入。同步清掉 `register-modules.tsx` 中兩個待清項目：reserved `workspace` section（`order: 10`，無 component）與 `module-config` section（global scope 下的空容器，production 無 `globalConfig` 使用者）。
+
+**保留不動**（決策 2b + 3b）：
+- `ModuleConfigSection.tsx`（`WorkspaceSettingsPage` 直接 render 以承接 `workspaceConfig` 舊軌，特別是 `files.projectPath`）
+- 舊 `globalConfig` / `workspaceConfig` API 與 `useModuleConfigStore`
+- 既有 settings section 內部
+
+PR-3 結束時：
+- `WorkspaceSettingsPage` 新增 registry-driven 區，可顯示任何宣告 `scope: 'workspace'` 的 contribution
+- `register-modules.tsx` 不再註冊 `workspace` reserved 與 `module-config` section
+- SettingsSidebar 在 PR-2 reserved 兼容路徑可拔除（或保留等更晚）
+- Workspace 刪除時 `useWorkspaceSettingsStore` 已由 PR-1 cascade 清理（本 PR 不重做）
+- URL 無變動（workspace settings 仍透過 `pane.content.scope = { workspaceId }` 進入）
+
+---
+
+## 2. 檔案清單
+
+### 修改
+- `spa/src/features/workspace/components/WorkspaceSettingsPage.tsx`
+  - 在 `ModuleConfigSection` 下方插入 registry 區塊：遍歷 `listContributions('workspace')`，每個 contribution 以 `<section>` 包 header（`t(c.labelKey)`）+ body（`<c.component ctx={{ scope: 'workspace', workspaceId }} />`）；`disabled(ctx)` 為 true 時 section 隱藏（或顯示禁用樣式 — 任一策略，測試覆蓋）
+  - 使用 `useMemo` 避免 list 每次 rerender 重算
+  - 排序依 `order` 升冪（registry 已保證）
+- `spa/src/lib/register-modules.tsx`
+  - 移除 `registerSettingsSection({ id: 'workspace', ..., order: 10 })`（reserved 行）
+  - 移除 `registerSettingsSection({ id: 'module-config', ..., order: 8, component: () => <ModuleConfigSection scope="global" /> })`（global scope 無 production 消費者）
+  - 若 PR-2 有為 reserved 保留 local buffer 兼容路徑，同步拔除該 buffer
+- `spa/src/components/settings/SettingsSidebar.tsx`
+  - 清掉 `reservedStart` 分隔線邏輯（reserved 已不存在）
+  - （optional）移除 coming_soon disabled 灰字樣式（若已無 reserved item，分支恆未觸發）
+- `spa/src/locales/en.json` / `zh-TW.json`
+  - 移除 `settings.section.workspace` i18n key（若 reserved 特有，且無其他 callsite）
+  - 保留 `settings.section.modules` key（`module-config` section 相關，但 `ModuleConfigSection` 本身仍在 workspace 頁用，key 可能仍有用；實作時 audit）
+
+### 新增
+- `spa/src/features/workspace/components/WorkspaceSettingsPage.test.tsx`
+  - Render-level：註冊 fake contribution（`scope: 'workspace'`）→ `WorkspaceSettingsPage` render 後該 section 顯示 labelKey 與 body
+  - ctx 注入：fake component 讀 `props.ctx.workspaceId === workspaceId`
+  - `disabled(ctx)` 隱藏：註冊 disabled fake contribution → UI 不顯示（或 disabled 樣式）
+  - order：多 contribution 順序正確
+  - 無 contribution 時 registry 區塊不 render（或 render 空無影響 — 任一實作，測試明確）
+  - reserved 清理回歸：hostsidebar / settingspage 不再顯示 `workspace` reserved item
+
+### 不動
+- `spa/src/components/settings/ModuleConfigSection.tsx`
+- `spa/src/stores/useModuleConfigStore.ts`
+- PR-1 新建的 `settings-contribution-registry.ts` / 三層 store
+- `HostPage.tsx` / `SettingsPage.tsx`（其中 `SettingsPage` 的 Global 分支由 PR-2 改；本 PR 只動 `WorkspaceSettingsPage`）
+- 既有 workspace-scoped 功能（icon picker / delete dialog / danger zone）
+
+---
+
+## 3. Test Case Matrix
+
+### 3.1 `WorkspaceSettingsPage.test.tsx`（新增）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Baseline | 無 contribution 時頁面 render（含 icon picker、name input、ModuleConfigSection、danger zone） | 通過，無 registry 區塊 |
+| Render | 註冊 1 個 fake `scope: 'workspace'` contribution → 頁面 render 該 labelKey + body | 通過 |
+| Ctx 注入 | fake component 讀 `props.ctx` → `scope === 'workspace'` && `workspaceId === 'wsA'` | 通過 |
+| Multi + order | 註冊 3 個 contribution（order 10 / 20 / 5）→ 顯示順序 5 / 10 / 20 | 通過 |
+| Disabled | contribution `disabled: (ctx) => true` → 該 section 不 render（或 UI 禁用） | 通過 |
+| ctx.workspaceId 正確性 | 切換 workspace（重新 mount 帶不同 `workspaceId` prop）→ ctx 帶新 id | 通過 |
+| Cascade（PR-1 已做） | 刪除該 workspace → `useWorkspaceSettingsStore.get(wsId, moduleId)` 回傳 undefined | 通過（驗 PR-1 cascade 仍生效） |
+
+### 3.2 `register-modules.test.ts` 擴充
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Reserved 清理 | `getSettingsSections()` 回傳中**無** `id='workspace'` 項 | 通過 |
+| Module-config 清理 | `getSettingsSections()` 回傳中**無** `id='module-config'` 項 | 通過 |
+| 其餘 section 不變 | `appearance` / `terminal` / `interface` / `sync` / `editor-buffers` 仍存在，順序不變 | 通過 |
+
+### 3.3 視覺回歸（手動）
+
+- `cd spa && pnpm dev`
+- 開一個 workspace → 打開 workspace settings（tab → 齒輪 / command）
+- 驗：icon picker、name input、`ModuleConfigSection`（含 files.projectPath 輸入框）、danger zone 正常
+- 驗：sidebar / settings 頁面**不再顯示** "Workspace" reserved 灰字項
+- 驗：sidebar / settings 頁面**不再顯示** "Modules" / module-config 項
+- 註冊一個臨時 workspace contribution（dev console 或臨時 module）→ 新區塊出現
+
+### 3.4 i18n 驗證
+
+- `settings.section.workspace` 若有其他 callsite 則保留（grep `settings.section.workspace`）
+- `settings.section.modules` 同上 audit
+
+---
+
+## 4. 實作順序（TDD）
+
+1. **紅**：寫 §3.1 `WorkspaceSettingsPage.test.tsx` 所有案例
+2. **綠**：改 `WorkspaceSettingsPage.tsx` 插 registry 區塊
+3. **紅**：寫 §3.2 register-modules 擴充測試
+4. **綠**：拔 `register-modules.tsx` 兩個 `registerSettingsSection`
+5. **紅**（optional）：SettingsSidebar reservedStart 分支測試（若 PR-2 已有此測試則順風消失）
+6. **綠**：精簡 SettingsSidebar
+7. **i18n audit**：grep 兩個 key 的 callsite，決定移或留
+8. **驗證**：`cd spa && pnpm exec vitest run` / `pnpm run lint` / `pnpm run build` 全綠
+9. **手動**：§3.3 視覺回歸
+
+---
+
+## 5. 驗收條件
+
+- [ ] §3.1 / §3.2 測試全綠
+- [ ] `cd spa && pnpm exec vitest run` 全綠
+- [ ] `cd spa && pnpm run lint` 全綠
+- [ ] `cd spa && pnpm run build` 全綠
+- [ ] §3.3 手動視覺回歸：`ModuleConfigSection` 正常、reserved 項消失、workspace registry 區可擴充
+- [ ] `gh issue close #538`（部分關閉 — 若 PR-2 已關則補充 workspace 層註記；若 PR-2 未關則本 PR 一併關）
+- [ ] Codex 兩輪 review 無 critical / P1 未修項
+
+---
+
+## 6. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| 刪除 `module-config` 後，未來若真有 module 要宣告 `globalConfig` 將無 UI 入口 | 中 | 決策 3b 已指示 `globalConfig` 在 PR-5 後 deprecate；新 `globalConfig` 用例應走新 `settings: [{ scope: 'purdex' }]`；若 PR-3 ship 後到 PR-5 前的空窗期出現新 `globalConfig` 需求，可臨時在 `SettingsPage` 以 `<ModuleConfigSection scope="global" />` render（僅 alpha 內部成本低） |
+| `WorkspaceSettingsPage` 現有佈局（icon + name + ModuleConfig + danger zone）穿插 registry section 後視覺失衡 | 中 | registry 區塊用與 `ModuleConfigSection` 一致的 `<section>` 樣式；無 contribution 時不顯示任何空 header；§3.3 手動驗 |
+| reserved item i18n key 被其他地方引用 | 低 | 移除前 grep `settings.section.workspace` + `settings.section.modules`；兩者若有外部 callsite 則保留 i18n，只拔 registry 註冊 |
+| Disabled contribution 策略（隱藏 vs 禁用樣式）未對齊 | 低 | 本 plan §3.1 測試明確採「隱藏」；實作照此 |
+| `WorkspaceSettingsPage` 使用者體驗：registry 區是否要 scroll 進 view、section anchor link、collapse | 低 | 本 PR 不做 UX 加分；只達基本渲染；進階 UX 進 backlog |
+
+---
+
+## 7. 超出 PR-3 範圍（明確不做）
+
+- `SettingsPage` global shell 改造（PR-2）
+- `HostPage` / `HostSidebar` / `host-routes` 改造（PR-4）
+- `ModuleConfigSection.tsx` 本身遷到新 registry（等舊 `workspaceConfig` API 全移除之後，獨立 refactor PR）
+- `files.projectPath` 搬家到新 `settings: [{ scope: 'workspace', localId: 'projectPath' }]`（決策 2b — 由 files module owner 後續 refactor）
+- Editor `homePath` 用例（PR-5）
+- #540 三層 store `get()` immutable snapshot（PR-5 前必解）
+- URL subsection 支援於 workspace 層（目前 workspace 單頁無此需求）
+- Sync contributor 於三層 store 的 wire shape（spec §10 sketch）
+
+---
+
+## 8. Commit 規劃
+
+每 commit 綠。
+
+1. **`feat(spa): WorkspaceSettingsPage renders workspace-scoped contributions`**
+   - `WorkspaceSettingsPage.tsx` + test
+2. **`refactor(spa): drop reserved workspace and module-config sections`**
+   - `register-modules.tsx` 拔兩行 + test 擴充 + SettingsSidebar 精簡 + i18n audit 移除
+
+共 2 commits。
+
+---
+
+## 9. 與其他 PR 的關聯
+
+- **依賴**：PR-1（已 merged）
+- **不依賴**：PR-2 / PR-4（三頁 shell 彼此獨立；PR-2 reserved 兼容 buffer 若存在，PR-3 順手拔）
+- **被依賴**：PR-5（Editor `workspaceConfig.homePath` 首個用例 — 需要 PR-3 的 workspace shell 已能 render 新 contribution）
+- **順風解決**：#538（workspace 層）

--- a/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
@@ -1,0 +1,198 @@
+# HSR PR-4：Host Settings Shell + Built-in Sub-page Adapter — Implementation Plan
+
+> 日期：2026-04-22
+> 狀態：Ready for Implementation
+> 主 spec：`2026-04-21-settings-contribution-registry-design.md`
+> 決策對齊：4c（HostPage registry-driven + 六子頁走 built-in adapter registration）
+> PR 系列：PR-1 ✅ / PR-2 / PR-3 / **PR-4（本文件）** / PR-5
+
+---
+
+## 1. 範圍
+
+**Shell 改造 + built-in adapter registration**。`HostPage` / `HostSidebar` / `host-routes` 改為 registry-driven；六個既有 sub-page（`overview` / `sessions` / `hooks` / `agents` / `uploads` / `logs`）**不改內部程式碼**，透過 built-in adapter 在 `registerBuiltinModules()` 尾段以 `moduleId: '_builtin.host'` 一次註冊進新 registry（走相同 `registerSettingsContribution` contract，但標記為 built-in 來源）。
+
+`ctx.hostId` 由 shell 依 route resolution 結果注入（§5.3 rule 2）；`ctx.scope: 'host'`。
+
+本 PR 順帶驗證 **#541**（cross-store rehydrate order）：`host-lifecycle.test.ts` 擴充測試，確保 `hostWasRecreated` 判定在 `HostStore` 與 `useHostSettingsStore` 兩種 rehydrate 順序下皆正確。
+
+PR-4 結束時：
+- `HostPage` 的 sub-page 渲染透過 `listContributions('host')` + ctx 注入
+- 六子頁以 `_builtin.host.<id>` 存在於 registry，與任何 future module-contributed host section 走同一條 render 路徑
+- URL `/hosts/:hostId/:subPage` 的 `subPage` 合法性判定改為對 registry 查詢
+- 新 module 可宣告 `settings: [{ scope: 'host', ... }]` 並出現在 `HostPage` 左側 sidebar（module owner 自定 header / 分組策略由 sidebar 實作決定）
+- `removeHost()` cascade 對 `useHostSettingsStore` 的清理 PR-1 已完成；本 PR 驗回歸
+
+---
+
+## 2. 檔案清單
+
+### 修改
+- `spa/src/components/HostPage.tsx`
+  - `renderContent()`：從 switch 改為 `const contribution = getContribution(`_builtin.host.${selection.subPage}`)` 或更一般化 `listContributions('host').find(c => c.localId === selection.subPage)`
+  - 找到 contribution 後以 `<contribution.component ctx={{ scope: 'host', hostId: selection.hostId }} />` render
+  - fallback（contribution 不存在）：render `no_host_selected` 或等效空態
+- `spa/src/components/hosts/HostSidebar.tsx`
+  - 移除硬編 `SUB_PAGES` const
+  - `const subPages = listContributions('host')` — 排序已保證
+  - 每項顯示 `t(c.labelKey)`（現 `labelKey` 在 contribution 內；與舊 `SUB_PAGES[].labelKey` 一致）
+  - `onSelect(hostId, subPage)` 參數仍用 `localId`（即現在的 `'overview'` / `'sessions'` 等值）
+- `spa/src/lib/host-routes.ts`
+  - `HOST_SUB_PAGES` 移除或保留為 fallback（implementation choice）
+  - `isHostSubPage(value)` 改為 `listContributions('host').some(c => c.localId === value)`
+  - 若保留 `HOST_SUB_PAGES`：只當 SSR / 極早期 bootstrap 時期 fallback（實務上 `registerBuiltinModules()` 在 React render 前就跑，通常不需要 fallback）
+- `spa/src/lib/register-modules.tsx`
+  - 結尾新增 `registerBuiltinHostSections()` pass（或直接 inline）：
+    - 依序 `registerSettingsContribution({ id: '_builtin.host.overview', moduleId: '_builtin.host', localId: 'overview', scope: 'host', order: 0, labelKey: 'hosts.overview', component: wrap(OverviewSection) })`
+    - 同樣六項：sessions (1) / hooks (2) / agents (3) / uploads (4) / logs (5)
+    - `wrap(Section)` = `(props: { ctx: SettingsContext }) => props.ctx.scope === 'host' ? <Section hostId={props.ctx.hostId} /> : null`
+  - 此 pass 為 internal — `registerSettingsContribution` `@internal` JSDoc 允許 `_builtin.*` 內部 callsite（#539 PR-2 已落地）
+- `spa/src/lib/host-lifecycle.ts`（僅測試擴充，若現有邏輯未觸及 cross-store order 則不動 source）
+- `spa/src/lib/host-lifecycle.test.ts`（擴充 #541 驗證）
+
+### 新增
+- `spa/src/components/HostPage.test.tsx`（render-level）
+  - 現有六 sub-page 能正常 render（透過 registry）
+  - fake `scope: 'host'` contribution 註冊後出現在 sidebar + 可導航
+  - `ctx.hostId` 正確注入
+- `spa/src/lib/host-builtin-sections.test.ts`（optional — 可合併進 `register-modules.test.ts`）
+  - Built-in adapter 註冊後 `listContributions('host').length >= 6`
+  - 順序：overview → sessions → hooks → agents → uploads → logs
+  - Wrap 的 component 正確 forward `hostId`
+
+### 不動
+- 六個既有 sub-page component 內部（`OverviewSection` / `SessionsSection` / `HooksSection` / `AgentsSection` / `UploadSection` / `LogsSection`）
+- URL 結構 `/hosts/:hostId/:subPage`（decode / encode 不變）
+- PR-1 三層 store 內部
+- PR-2 / PR-3 shell
+
+---
+
+## 3. Test Case Matrix
+
+### 3.1 `HostPage.test.tsx`（render-level）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Built-in 渲染 | URL `/hosts/hA/overview` → render `OverviewSection` | 通過 |
+| Built-in 渲染 | URL `/hosts/hA/sessions` → render `SessionsSection` | 通過 |
+| Sidebar 順序 | 六 sub-page 顯示順序 = built-in 註冊 order | 通過 |
+| Fake 擴充 | 註冊 fake `scope: 'host'` contribution（order=100）→ sidebar 多一項、URL `/hosts/hA/<fakeId>` 可 render fake body | 通過 |
+| Ctx 注入 | fake component 讀 `props.ctx` → `scope === 'host'` && `hostId === 'hA'` | 通過 |
+| Invalid subPage | URL `/hosts/hA/nonexistent` → redirect 到 `canonicalPath`（既有 resolveSelection 行為） | 通過 |
+| Disabled | fake contribution `disabled: (ctx) => true` → sidebar 隱藏（或禁用樣式） | 通過 |
+
+### 3.2 `host-routes.test.ts` 擴充或新增
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| `isHostSubPage` | 現六 ID 回 true | 通過 |
+| `isHostSubPage` | 任何 module-contributed host localId 回 true（註冊 fake 後） | 通過 |
+| `isHostSubPage` | 未註冊的 ID 回 false | 通過 |
+
+### 3.3 `register-modules.test.ts` 擴充
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Built-in 註冊 | 跑 `registerBuiltinModules()` 後 `listContributions('host')` 含六項，`moduleId='_builtin.host'` | 通過 |
+| Order | 順序：overview / sessions / hooks / agents / uploads / logs | 通過 |
+| Wrap forward | 取得第 0 項 `listContributions('host')[0]`，用 `ctx={{ scope:'host', hostId:'hA' }}` render → 等同 `<OverviewSection hostId='hA' />` 行為（以 render 內含可辨識文字斷言） | 通過 |
+| Scope guard | `_builtin.host.overview` contribution 收到 `ctx.scope !== 'host'` 時 render null（wrap 的 guard） | 通過 |
+
+### 3.4 `host-lifecycle.test.ts` 擴充（#541）
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Rehydrate order A | 模擬 HostStore 先 rehydrate 完成、`useHostSettingsStore` 後 → 刪除 + undo 情境下 `hostWasRecreated` 判定正確 | 通過 |
+| Rehydrate order B | 模擬 `useHostSettingsStore` 先、HostStore 後 → 同上 | 通過 |
+| Cascade 回歸 | 刪除 host → `useHostSettingsStore.get(hostId, moduleId)` 為 undefined（PR-1 功能）| 通過 |
+| Undo 回歸 | 在 cascade clear 後的 undo window 內 undo → host 與其 hostSettings 均回復（PR-1 功能）| 通過 |
+
+若 rehydrate order 測試發現 `hostWasRecreated` 需要改邏輯（e.g. 考慮 `useHostSettingsStore` 中該 host 的 key 是否存在），則加 source 改動（`host-lifecycle.ts`），並追加測試覆蓋新邏輯。
+
+### 3.5 視覺回歸（手動）
+
+- `cd spa && pnpm dev`
+- 開 `/hosts`：左側 sidebar 顯示 host 列表 + 展開每個 host 顯示六 sub-page
+- 點每個 sub-page：右側正常 render
+- 點新增 host button、切換 host、切換 sub-page 均正常
+- 無 console error
+
+---
+
+## 4. 實作順序（TDD）
+
+1. **紅**：寫 §3.3 built-in 註冊測試（registry 有六項、順序正確）
+2. **綠**：在 `register-modules.tsx` 加 `registerBuiltinHostSections()`
+3. **紅**：寫 §3.1 `HostPage.test.tsx`
+4. **綠**：改 `HostPage.tsx` `renderContent()` + `HostSidebar.tsx` 讀 registry
+5. **紅**：寫 §3.2 `host-routes.test.ts` 擴充
+6. **綠**：改 `host-routes.ts` `isHostSubPage` 為動態
+7. **紅**：寫 §3.4 `host-lifecycle.test.ts` #541 案例
+8. **綠**：若需要，修 `host-lifecycle.ts` 判定邏輯（否則只補 test）
+9. **驗證**：`cd spa && pnpm exec vitest run` / `pnpm run lint` / `pnpm run build` 全綠
+10. **手動**：§3.5 視覺回歸
+
+---
+
+## 5. 驗收條件
+
+- [ ] §3.1–§3.4 測試全綠
+- [ ] `cd spa && pnpm exec vitest run` 全綠
+- [ ] `cd spa && pnpm run lint` 全綠
+- [ ] `cd spa && pnpm run build` 全綠
+- [ ] §3.5 手動視覺回歸：六 sub-page 行為與 `main` 一致、無 console error、registry 擴充可見
+- [ ] `gh issue close #541`（或補充「PR-4 已驗證 cross-store rehydrate order」）
+- [ ] `gh issue close #538`（若 PR-2/3 尚未關閉 Host 層，則本 PR 關；否則補充）
+- [ ] Codex 兩輪 review 無 critical / P1 未修項
+
+---
+
+## 6. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| Built-in 註冊時機錯過第一次 render（race）| 中 | `registerBuiltinModules()` 在 app bootstrap 早期同步跑；`HostPage` render 前已完成；測試覆蓋「initial URL `/hosts/hA/overview` 即 render」 |
+| `HOST_SUB_PAGES` 移除後其他 callsite 爆 | 中 | grep `HOST_SUB_PAGES` 找所有 import → 改為動態查詢 或 保留為 optional fallback |
+| Wrap 的 scope guard 漏寫，contribution 收到錯誤 ctx | 低 | §3.3 scope guard 測試強制覆蓋 |
+| #541 測試發現 rehydrate order 確實有 bug，需要動 `host-lifecycle.ts` | 中 | Plan §3.4 已預留修 source 的餘地；若 bug 過大影響 PR-4 scope，可切成獨立 fix PR，PR-4 blocker |
+| labelKey 顯示（sidebar）與 URL localId 可能不一致（例：label 翻譯後中文，但 URL 還是英文）| 低 | 現行 `SUB_PAGES` 已如此；保留 localId 為 URL token，labelKey 為顯示名稱 |
+| 新 host contribution 被註冊時 URL `/hosts/hA/<new>` 可直接進入 — 但沒有 invariant 保證新 localId 不與既有撞（overview/sessions/…）| 低 | PR-1 registry `id` collision throw 已擋（兩個 `_builtin.host.overview` 會拋錯）；module 作者撞 built-in localId 也會拋 |
+
+---
+
+## 7. 超出 PR-4 範圍（明確不做）
+
+- `SettingsPage` global shell 改造（PR-2）
+- `WorkspaceSettingsPage` shell 改造（PR-3）
+- 六 sub-page 轉為 module-owned declaration（決策 4c 明確採 built-in adapter，不搬家）
+- Editor `hostConfig.homePath` 用例（PR-5）
+- 舊 `globalConfig` / `workspaceConfig` deprecate（PR-5 後）
+- Host tab 拖放 / 排序 等 UX 改動
+- `HostStore` persist schema 遷移（alpha 階段不處理，決策依記憶 `feedback_no_alpha_migration`）
+
+---
+
+## 8. Commit 規劃
+
+每 commit 綠。
+
+1. **`feat(spa): register six built-in host sub-pages as host contributions`**
+   - `register-modules.tsx` 加 `registerBuiltinHostSections()` + test（§3.3）
+2. **`feat(spa): HostPage + HostSidebar read new contribution registry`**
+   - `HostPage.tsx` / `HostSidebar.tsx` + `HostPage.test.tsx`
+3. **`refactor(spa): isHostSubPage dynamic via contribution registry`**
+   - `host-routes.ts` + test
+4. **`test(spa): cross-store rehydrate order invariants (#541)`**
+   - `host-lifecycle.test.ts` 擴充（若需要連帶改 source 則拆 refactor + test 兩 commit）
+
+共 4 commits。
+
+---
+
+## 9. 與其他 PR 的關聯
+
+- **依賴**：PR-1（已 merged）
+- **不依賴**：PR-2 / PR-3（三頁 shell 彼此獨立）
+- **被依賴**：PR-5（Editor `hostConfig.homePath` 需要 PR-4 的 HostPage shell 能顯示 module-contributed host section）
+- **順風解決**：#538（Host 層）/ #541（cross-store rehydrate order）

--- a/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
@@ -1,11 +1,12 @@
 # HSR PR-4：Host Settings Shell + Built-in Sub-page Adapter — Implementation Plan
 
-> 日期：2026-04-22（v3 post-codex-review Round 2 task-mo8z6ppx-pj07yk）
+> 日期：2026-04-22（v3.1 post-codex-review Round 3 task-mo90eijb-mk3gfg）
 > 狀態：Ready for Implementation（**必須 build on PR-2**；功能上不依賴 PR-3 但與 PR-3 有 rebase 衝突 — 見 §9）
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
 > 決策對齊：4c（HostPage registry-driven + 六子頁走 built-in adapter registration + host route contract 鬆綁）
 > PR 系列：PR-1 ✅ / PR-2 / PR-3 / **PR-4（本文件）** / PR-5
-> v3 收斂：Round 1 Finding 3/5 → v2 修；Round 2 Finding 5 partial（harness 綁 singleton）→ 本版改為 `store.setState()` 方案
+> v3 收斂：Round 1 Finding 3/5 → v2 修；Round 2 Finding 5 partial → v3 改為 `store.setState()` 方案
+> v3.1 收斂：Round 3 MED（harness 把 `useHostSettingsStore` 寫成 `settings` 實際是 `hosts`、`useHostStore` 初始誤寫為空 hosts）→ 本版對齊實際 store shape + 明確空白 state 寫法（不依賴 `getInitialState()`）
 
 ---
 
@@ -109,7 +110,12 @@ PR-4 結束時：
 
 **現況限制**：`host-lifecycle.ts` 直接綁 module singleton（`useHostStore.getState()` / `useHostSettingsStore.getState()` 等），不接受 store instance 注入 — 所以 harness **不能**用 `createStore()` 新建獨立 instance（那樣測不到 source）。
 
-**Harness 設計（v3 修正）**：用 `store.setState()` 直接操控 singleton 的狀態，模擬「rehydrate 完成後的 state shape」，再呼叫 `removeHost` / `undo` / `hostWasRecreated` 等 lifecycle 操作。
+**Harness 設計（v3.1 修正 — 對齊實際 store shape）**：用 `store.setState()` 直接操控 singleton 的狀態，模擬「rehydrate 完成後的 state shape」，再呼叫 `removeHost` / `undo` / `hostWasRecreated` 等 lifecycle 操作。
+
+**實際 store shape 校正**：
+- `useHostStore` 的狀態欄位：`hosts` / `hostOrder` / `runtime` / `activeHostId`（**非** `settings`；見 `spa/src/stores/useHostStore.ts:55-70`）。`createDefaultState()` 回傳含一個 default host `mlab`（id 為隨機 `generateId()`），**不是**空 `hosts: {}` — 所以 `getInitialState()` 不等於空 hosts
+- `useHostSettingsStore` 的狀態欄位：`hosts: Record<string, HostSlot>`（**非** `settings`；見 `spa/src/stores/useHostSettingsStore.ts:9-15`）
+- `removeHost` 內建 last-host veto：`if (Object.keys(state.hosts).length <= 1) return state`（`useHostStore.ts:104`）— harness 測此路徑時，hosts 需至少 2 個才能真 remove
 
 ```ts
 import { useHostStore } from '@/stores/useHostStore'
@@ -120,31 +126,62 @@ import { useSessionStore } from '@/stores/useSessionStore'
 import { useStreamStore } from '@/stores/useStreamStore'
 import { useAgentStore } from '@/stores/useAgentStore'
 
-// 每個 test 前把所有被觸及的 singleton 歸零（getInitialState 可從 zustand 拿原始 initial state fn）
+// 每個 test 前顯式把所有被觸及的 singleton 設定成「已 rehydrate、可控」的空狀態
+// 注意：不用 getInitialState()，因為 useHostStore 的 initial 含 default host；我們要空白畫布
 beforeEach(() => {
-  useHostStore.setState(useHostStore.getInitialState(), true)  // true = replace
-  useHostSettingsStore.setState(useHostSettingsStore.getInitialState(), true)
-  useWorkspaceSettingsStore.setState(useWorkspaceSettingsStore.getInitialState(), true)
-  useTabStore.setState(useTabStore.getInitialState(), true)
-  // 其餘 cascade 涉及的 store 同上
+  useHostStore.setState(
+    { hosts: {}, hostOrder: [], runtime: {}, activeHostId: null },
+    true,  // true = replace（避免與既有 default host 狀態 merge）
+  )
+  useHostSettingsStore.setState({ hosts: {} }, true)
+  useWorkspaceSettingsStore.setState({ workspaces: {} }, true)  // shape 以 useWorkspaceSettingsStore.ts 為準（本 PR 實作時再 double-check）
+  // useTabStore / useSessionStore / useStreamStore / useAgentStore 等 cascade 涉及的 store 同上顯式 reset
 })
 
-// 模擬「hosts rehydrate 完成 + hostSettings rehydrate 完成」狀態
+// 模擬「hosts rehydrate 完成 + hostSettings rehydrate 完成」狀態（hosts ≥ 2 以避免 last-host veto）
 function seedBothRehydrated() {
-  useHostStore.setState({ hosts: { hA: { id: 'hA', name: 'Host A', ... }, hB: {...} }, activeHostId: 'hA' })
-  useHostSettingsStore.setState({ settings: { hA: { editor: { homePath: '/tmp/a' } } } })
+  useHostStore.setState(
+    {
+      hosts: {
+        hA: { id: 'hA', name: 'Host A', ip: '127.0.0.1', port: 7860, order: 0 },
+        hB: { id: 'hB', name: 'Host B', ip: '127.0.0.1', port: 7861, order: 1 },
+      },
+      hostOrder: ['hA', 'hB'],
+      runtime: {},
+      activeHostId: 'hA',
+    },
+    true,
+  )
+  useHostSettingsStore.setState(
+    { hosts: { hA: { editor: { homePath: '/tmp/a' } } } },
+    true,
+  )
 }
 
 // 模擬「hosts 已 rehydrate + hostSettings 尚未 rehydrate」瞬間
 function seedHostOnly() {
-  useHostStore.setState({ hosts: { hA: {...}, hB: {...} }, activeHostId: 'hA' })
-  // hostSettings 保留 initial state（visual: 'rehydrate 還沒跑到'）
+  useHostStore.setState(
+    {
+      hosts: {
+        hA: { id: 'hA', name: 'Host A', ip: '127.0.0.1', port: 7860, order: 0 },
+        hB: { id: 'hB', name: 'Host B', ip: '127.0.0.1', port: 7861, order: 1 },
+      },
+      hostOrder: ['hA', 'hB'],
+      runtime: {},
+      activeHostId: 'hA',
+    },
+    true,
+  )
+  // hostSettings 維持 beforeEach 空白 `{ hosts: {} }`（'rehydrate 還沒跑到' 的瞬間）
 }
 
 // 模擬「hostSettings 先 rehydrate + hosts 尚未 rehydrate」瞬間
 function seedSettingsOnly() {
-  useHostSettingsStore.setState({ settings: { hA: { editor: { homePath: '/tmp/a' } } } })
-  // hostStore 保留 initial state（hosts: {}）
+  useHostSettingsStore.setState(
+    { hosts: { hA: { editor: { homePath: '/tmp/a' } } } },
+    true,
+  )
+  // hostStore 維持 beforeEach 空白（hosts: {}）
 }
 ```
 
@@ -152,19 +189,22 @@ function seedSettingsOnly() {
 
 | 類別 | 測試項 | 預期 |
 |---|---|---|
-| Rehydrate order A（both done） | `seedBothRehydrated()` → `removeHost('hA')` → `useHostSettingsStore.getState().settings.hA` undefined；undo window 內 `undoRemove()` → hosts + hostSettings 都恢復 | 通過 |
-| Rehydrate order B（settings only） | `seedSettingsOnly()` → `removeHost('hA')` → precheck 因 `hostStore.hosts[hA]` undefined 直接 veto + no-op（B1 回歸）；hostSettings 不被清 | 通過 |
+| Rehydrate order A（both done） | `seedBothRehydrated()` → `removeHost('hA')` → `useHostSettingsStore.getState().hosts.hA` undefined；undo window 內 `undoRemove()` → hosts + hostSettings 都恢復 | 通過 |
+| Rehydrate order B（settings only） | `seedSettingsOnly()` → `removeHost('hA')` → precheck 因 `hostStore.hosts` 空直接走 last-host veto 或 hostId-not-found 分支，no-op；hostSettings 不被清 | 通過 |
 | Rehydrate order C（host only） | `seedHostOnly()` → `removeHost('hA')` → cascade 跑完（hostSettings 本就空，清 no-op）；undo 恢復 hosts、hostSettings 仍空（對應 source rehydrate 還沒跑到的瞬間） | 通過 |
-| Interleaved write during cascade | `seedBothRehydrated()` → 開始 `removeHost('hA')` → 在 undo window 內再對 `useHostSettingsStore.setState(...)` 寫入相同 hostId → undo 的 `hostWasRecreated` 判斷應 **gate 住** restore，避免蓋掉較新的 write（B2 回歸） | 通過 |
-| hostWasRecreated | `seedBothRehydrated()` → `removeHost('hA')` → 在 undo window 內重建 same-id host（`useHostStore.setState({ hosts: { hA: {新 payload} } })`）→ `hostWasRecreated('hA')` 回 true；`undoRemove()` 的 5 類 restore 全 gate | 通過 |
-| Last-host veto | `useHostStore.setState({ hosts: { hA: {...} } })`（僅剩一 host）→ `removeHost('hA')` veto + no-op（B1 回歸） | 通過 |
-| Cascade 回歸 | `seedBothRehydrated()` → `removeHost('hA')` → `useHostSettingsStore.getState().settings.hA` undefined（PR-1 cascade） | 通過 |
+| Interleaved write during cascade | `seedBothRehydrated()` → 開始 `removeHost('hA')` → 在 undo window 內再對 `useHostSettingsStore.setState(s => ({ hosts: { ...s.hosts, hA: { editor: { homePath: '/new' } } } }))` 寫入相同 hostId → undo 的 `hostWasRecreated` 判斷應 **gate 住** restore，避免蓋掉較新的 write（B2 回歸） | 通過 |
+| hostWasRecreated | `seedBothRehydrated()` → `removeHost('hA')` → 在 undo window 內重建 same-id host（`useHostStore.setState(s => ({ hosts: { ...s.hosts, hA: {新 payload} }, hostOrder: [...s.hostOrder, 'hA'] }))`）→ `hostWasRecreated('hA')` 回 true；`undoRemove()` 的 5 類 restore 全 gate | 通過 |
+| Last-host veto | `useHostStore.setState({ hosts: { hA: {...} }, hostOrder: ['hA'], runtime: {}, activeHostId: 'hA' }, true)` → `removeHost('hA')` veto + no-op（source 現況已守；`useHostStore.ts:104`） | 通過 |
+| Cascade 回歸 | `seedBothRehydrated()` → `removeHost('hA')` → `useHostSettingsStore.getState().hosts.hA` undefined（PR-1 cascade） | 通過 |
 | Undo 回歸 | Cascade clear 後 undo window 內 undo → hosts + hostSettings 都恢復（PR-1） | 通過 |
 | Workspace 交叉 | `seedBothRehydrated()` + 額外 seed workspaceSettings for hA-owned workspace → tearOff / mergeWorkspace → workspaceSettings 不被連坐清（PR-1 的 D finding 回歸） | 通過 |
 
 **若 harness 發現 bug**：改 `host-lifecycle.ts` source 修邏輯。若 bug 過大，選項 B：#541 拆獨立 PR，PR-4 scope 保留 built-in adapter + shell 部分（先 ship），#541 後補 follow-up。
 
-**Harness 驗證原則**：本設計用 `setState(..., true)` 做 replace 而非 merge，確保 test 之間完全隔離；避免相依 `persist.rehydrate()` 的非確定性 timing。
+**Harness 驗證原則**：
+- 用 `setState(..., true)` 做 **replace** 而非 merge，確保 test 之間完全隔離；避免相依 `persist.rehydrate()` 的非確定性 timing
+- **不使用** `getInitialState()`，因為 `useHostStore` 的 initial 含 default host；我們要顯式空白 state 才好控制場景
+- `useWorkspaceSettingsStore` / `useTabStore` 等 cascade-adjacent store 的 shape 與初始值於實作時由 test 作者對照 source 再 double-check（本文件僅列 `useHostStore` / `useHostSettingsStore` 兩者的具體 shape，因其為本 PR 主軸）
 
 ### 3.5 視覺回歸（手動）
 

--- a/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
@@ -1,54 +1,59 @@
 # HSR PR-4：Host Settings Shell + Built-in Sub-page Adapter — Implementation Plan
 
-> 日期：2026-04-22
-> 狀態：Ready for Implementation
+> 日期：2026-04-22（v2 post-codex-review task-mo8xtpa8-bdxsh4）
+> 狀態：Ready for Implementation（**依序 build on PR-2 + PR-3**）
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
-> 決策對齊：4c（HostPage registry-driven + 六子頁走 built-in adapter registration）
+> 決策對齊：4c（HostPage registry-driven + 六子頁走 built-in adapter registration + host route contract 鬆綁）
 > PR 系列：PR-1 ✅ / PR-2 / PR-3 / **PR-4（本文件）** / PR-5
 
 ---
 
 ## 1. 範圍
 
-**Shell 改造 + built-in adapter registration**。`HostPage` / `HostSidebar` / `host-routes` 改為 registry-driven；六個既有 sub-page（`overview` / `sessions` / `hooks` / `agents` / `uploads` / `logs`）**不改內部程式碼**，透過 built-in adapter 在 `registerBuiltinModules()` 尾段以 `moduleId: '_builtin.host'` 一次註冊進新 registry（走相同 `registerSettingsContribution` contract，但標記為 built-in 來源）。
+**Shell 改造 + built-in adapter registration + host route contract 鬆綁**。
 
-`ctx.hostId` 由 shell 依 route resolution 結果注入（§5.3 rule 2）；`ctx.scope: 'host'`。
+三層工作：
+1. **Host route 型別鬆綁**：`HostSubPage` 從六字串 union 改為 `string`（runtime 由 registry 驗證）；`HOST_SUB_PAGES` 保留為 built-in 的預設值 const 但不再是型別來源；`parseRoute()` / `resolveSelection()` / `HostPage` / `HostSidebar` 所有 exhaustiveness 假設改為動態（codex review Finding 3 的硬約束）
+2. **Built-in adapter 註冊**：六個既有 sub-page 透過 `registerSettingsSection` 風格的 host adapter 走 pending buffer，由 `dispatchSettingsContributions()` 統一 flush（沿用 PR-2 建立的 dispatch-flushed pattern，避免 clearContributions 清掉 built-in）；六子頁內部程式碼**零改動**
+3. **Shell 吃 registry**：`HostPage.renderContent` + `HostSidebar.SUB_PAGES` 改讀 `listContributions('host')` + 以 `ctx: { scope: 'host', hostId }` 注入
 
-本 PR 順帶驗證 **#541**（cross-store rehydrate order）：`host-lifecycle.test.ts` 擴充測試，確保 `hostWasRecreated` 判定在 `HostStore` 與 `useHostSettingsStore` 兩種 rehydrate 順序下皆正確。
+本 PR 一併驗證 **#541**（cross-store rehydrate order），使用具體 harness（§3.4），不僅口頭描述。
 
 PR-4 結束時：
 - `HostPage` 的 sub-page 渲染透過 `listContributions('host')` + ctx 注入
 - 六子頁以 `_builtin.host.<id>` 存在於 registry，與任何 future module-contributed host section 走同一條 render 路徑
-- URL `/hosts/:hostId/:subPage` 的 `subPage` 合法性判定改為對 registry 查詢
-- 新 module 可宣告 `settings: [{ scope: 'host', ... }]` 並出現在 `HostPage` 左側 sidebar（module owner 自定 header / 分組策略由 sidebar 實作決定）
-- `removeHost()` cascade 對 `useHostSettingsStore` 的清理 PR-1 已完成；本 PR 驗回歸
+- URL `/hosts/:hostId/:subPage` 的 `subPage` 從「六個 literal 之一」放寬為「registry 中 scope='host' 的任一 localId」
+- `HostSubPage` 型別收斂為 `string` 或 branded string；exhaustive switch 被動態 dispatch 取代
+- 新 module 可宣告 `settings: [{ scope: 'host', ... }]` 並出現在 `HostPage` 左側 sidebar
+- `removeHost()` cascade 對 `useHostSettingsStore` 的清理 PR-1 已完成；本 PR 的 #541 harness 驗回歸 + rehydrate order invariant
 
 ---
 
 ## 2. 檔案清單
 
 ### 修改
+- `spa/src/lib/host-routes.ts`（型別鬆綁 — Finding 3）
+  - `HostSubPage` 改為 `type HostSubPage = string`（或 `type HostSubPage = string & { readonly __brand: 'HostSubPage' }` branded string，實作擇一）
+  - `HOST_SUB_PAGES` 保留為 `const` 陣列但**僅作** built-in 預設值（供 `parseRoute()` fallback、測試 fixture、i18n key 檢索），**不再**作為 type literal 來源
+  - `isHostSubPage(value): value is HostSubPage` 改為 `listContributions('host').some(c => c.localId === value)`
+  - `parseRoute()` 回傳 shape 不變（`subPage: HostSubPage`），但型別 narrow 靠 `isHostSubPage` runtime 而非 literal union
 - `spa/src/components/HostPage.tsx`
-  - `renderContent()`：從 switch 改為 `const contribution = getContribution(`_builtin.host.${selection.subPage}`)` 或更一般化 `listContributions('host').find(c => c.localId === selection.subPage)`
-  - 找到 contribution 後以 `<contribution.component ctx={{ scope: 'host', hostId: selection.hostId }} />` render
-  - fallback（contribution 不存在）：render `no_host_selected` 或等效空態
+  - `renderContent()`：從 `switch (selection.subPage)` 改為 `const contribution = listContributions('host').find(c => c.localId === selection.subPage)`；找到則 `<contribution.component ctx={{ scope: 'host', hostId: selection.hostId }} />`；否則 redirect 到 default（沿用 `resolveSelection` 自癒邏輯）
+  - 移除對六字串 literal 的 exhaustive switch 假設；以 registry lookup 取代
+  - `getFallbackSubPage()` 現況為 const return；改為讀 `listContributions('host')[0]?.localId ?? 'overview'`（registry 空時 fallback 到 `'overview'` 字面值作 safety net）
 - `spa/src/components/hosts/HostSidebar.tsx`
   - 移除硬編 `SUB_PAGES` const
   - `const subPages = listContributions('host')` — 排序已保證
-  - 每項顯示 `t(c.labelKey)`（現 `labelKey` 在 contribution 內；與舊 `SUB_PAGES[].labelKey` 一致）
-  - `onSelect(hostId, subPage)` 參數仍用 `localId`（即現在的 `'overview'` / `'sessions'` 等值）
-- `spa/src/lib/host-routes.ts`
-  - `HOST_SUB_PAGES` 移除或保留為 fallback（implementation choice）
-  - `isHostSubPage(value)` 改為 `listContributions('host').some(c => c.localId === value)`
-  - 若保留 `HOST_SUB_PAGES`：只當 SSR / 極早期 bootstrap 時期 fallback（實務上 `registerBuiltinModules()` 在 React render 前就跑，通常不需要 fallback）
-- `spa/src/lib/register-modules.tsx`
-  - 結尾新增 `registerBuiltinHostSections()` pass（或直接 inline）：
-    - 依序 `registerSettingsContribution({ id: '_builtin.host.overview', moduleId: '_builtin.host', localId: 'overview', scope: 'host', order: 0, labelKey: 'hosts.overview', component: wrap(OverviewSection) })`
-    - 同樣六項：sessions (1) / hooks (2) / agents (3) / uploads (4) / logs (5)
-    - `wrap(Section)` = `(props: { ctx: SettingsContext }) => props.ctx.scope === 'host' ? <Section hostId={props.ctx.hostId} /> : null`
-  - 此 pass 為 internal — `registerSettingsContribution` `@internal` JSDoc 允許 `_builtin.*` 內部 callsite（#539 PR-2 已落地）
-- `spa/src/lib/host-lifecycle.ts`（僅測試擴充，若現有邏輯未觸及 cross-store order 則不動 source）
-- `spa/src/lib/host-lifecycle.test.ts`（擴充 #541 驗證）
+  - 每項顯示 `t(c.labelKey)`（與舊 `SUB_PAGES[].labelKey` 一致）
+  - `onSelect(hostId, subPage: string)` 參數型別鬆綁（subPage 是 registry localId，不再是六 literal 之一）
+- `spa/src/lib/register-modules.tsx`（走 pending buffer，PR-2 dispatch-flushed pattern）
+  - 新增 `registerBuiltinHostSection(def: HostSectionDef)` helper（可放 `settings-section-registry.ts` 或 `host-builtin-sections.ts`）：組 `SettingsContributionDeclaration`（`scope: 'host'`、`moduleId: '_builtin.host'`、wrap 過的 `component: (props) => props.ctx.scope === 'host' ? <Section hostId={props.ctx.hostId} /> : null`）push 到 pending buffer（與 legacy adapter 同一 queue，或獨立第二 queue — 任一實作，測試明確）
+  - `registerBuiltinModules()` 結尾在 `dispatchSettingsContributions()` 之前（與 `registerSettingsSection` 同階段）呼叫六次 `registerBuiltinHostSection(...)` — sessions (1) / hooks (2) / agents (3) / uploads (4) / logs (5)（overview 為 0）
+  - Dispatch pass 統一 flush 後六項進 `listContributions('host')`，與 PR-2 的 legacy adapter 機制一致
+- `spa/src/lib/dispatch-settings-contributions.ts`（若採獨立第二 queue）
+  - `drainHostBuiltinQueue()` 整合進 Phase 2，與 legacy queue、module-declared batch 三者合併
+- `spa/src/lib/host-lifecycle.test.ts`（#541 具體 harness — Finding 5）
+  - 不動 `host-lifecycle.ts` source（現況已 guard；本 PR 驗回歸 + 加 order 測試）
 
 ### 新增
 - `spa/src/components/HostPage.test.tsx`（render-level）
@@ -99,16 +104,48 @@ PR-4 結束時：
 | Wrap forward | 取得第 0 項 `listContributions('host')[0]`，用 `ctx={{ scope:'host', hostId:'hA' }}` render → 等同 `<OverviewSection hostId='hA' />` 行為（以 render 內含可辨識文字斷言） | 通過 |
 | Scope guard | `_builtin.host.overview` contribution 收到 `ctx.scope !== 'host'` 時 render null（wrap 的 guard） | 通過 |
 
-### 3.4 `host-lifecycle.test.ts` 擴充（#541）
+### 3.4 `host-lifecycle.test.ts` 擴充（#541 — 具體 harness）
+
+**Harness 設計**：zustand persist 的 rehydrate 是自動的，要精準控制順序需用 test fixture：
+
+```ts
+// Setup pattern
+import { createStore } from 'zustand/vanilla'
+// 手動 create store instance（不經過 module singleton）
+const makeHostStore = () => createStore(...)
+const makeHostSettingsStore = () => createStore(...)
+
+// 控制 rehydrate 順序
+function harnessOrderA() {
+  const hostStore = makeHostStore()
+  hostStore.persist.rehydrate()  // 完成
+  const settingsStore = makeHostSettingsStore()
+  settingsStore.persist.rehydrate()  // 完成
+  return { hostStore, settingsStore }
+}
+
+function harnessOrderB() {
+  const settingsStore = makeHostSettingsStore()
+  settingsStore.persist.rehydrate()
+  const hostStore = makeHostStore()
+  hostStore.persist.rehydrate()
+  return { hostStore, settingsStore }
+}
+```
 
 | 類別 | 測試項 | 預期 |
 |---|---|---|
-| Rehydrate order A | 模擬 HostStore 先 rehydrate 完成、`useHostSettingsStore` 後 → 刪除 + undo 情境下 `hostWasRecreated` 判定正確 | 通過 |
-| Rehydrate order B | 模擬 `useHostSettingsStore` 先、HostStore 後 → 同上 | 通過 |
-| Cascade 回歸 | 刪除 host → `useHostSettingsStore.get(hostId, moduleId)` 為 undefined（PR-1 功能）| 通過 |
-| Undo 回歸 | 在 cascade clear 後的 undo window 內 undo → host 與其 hostSettings 均回復（PR-1 功能）| 通過 |
+| Rehydrate order A | `harnessOrderA()` → 預設 seed data（hosts[hostA], hostSettings[hostA][editor]）→ 刪除 hostA → `hostSettingsStore.get(hostA, 'editor')` undefined；undo 在 window 內 → 兩 store 都恢復 | 通過 |
+| Rehydrate order B | `harnessOrderB()` → 相同 seed + 行為 → 兩 store 恢復 | 通過 |
+| Interleaved | 模擬「HostStore 半 rehydrate（hosts[hostA] 存在但 runtime 還沒）時觸發刪除」— 驗 `removeHost` 的 precheck 不會因部分 state 誤判 last-host | 通過 |
+| hostWasRecreated | Rehydrate 完成後模擬 same-id 重建 → `hostWasRecreated(hostId)` 回 true（沿用 PR-1 實作） | 通過 |
+| Cascade 回歸 | 刪除 hostA → `hostSettingsStore.get(hostA, *)` undefined（PR-1 cascade） | 通過 |
+| Undo 回歸 | Cascade clear 後 undo window 內 undo → host + hostSettings 都恢復（PR-1） | 通過 |
+| Workspace 交叉 | 刪 hostA + hostA 參與的 workspace tear-off / merge → workspaceSettings 不被連坐清（PR-1 的 D finding） | 通過（回歸） |
 
-若 rehydrate order 測試發現 `hostWasRecreated` 需要改邏輯（e.g. 考慮 `useHostSettingsStore` 中該 host 的 key 是否存在），則加 source 改動（`host-lifecycle.ts`），並追加測試覆蓋新邏輯。
+**若 harness 發現 bug**：改 `host-lifecycle.ts` source 修邏輯（不再 ship PR-4 直到 #541 解決）。若發現 bug 過大，選項 B：#541 拆獨立 PR，PR-4 scope 保留 built-in adapter + shell 部分（先 ship），#541 後補 follow-up。
+
+**Harness 複雜度風險**：若 zustand v4+ 的 `persist.rehydrate()` API 無法精準控制，改用較直接的 state mutation：`store.setState(mockedRehydratedState)` 模擬「已 rehydrate」狀態；`store.setState(initialState)` 模擬「未 rehydrate」狀態。兩種實作擇一，測試先綠為準。
 
 ### 3.5 視覺回歸（手動）
 
@@ -192,7 +229,9 @@ PR-4 結束時：
 
 ## 9. 與其他 PR 的關聯
 
-- **依賴**：PR-1（已 merged）
-- **不依賴**：PR-2 / PR-3（三頁 shell 彼此獨立）
-- **被依賴**：PR-5（Editor `hostConfig.homePath` 需要 PR-4 的 HostPage shell 能顯示 module-contributed host section）
-- **順風解決**：#538（Host 層）/ #541（cross-store rehydrate order）
+- **依賴**：PR-1（已 merged）+ **PR-2**（本 PR 的 built-in host adapter 沿用 PR-2 的 dispatch-flushed pattern + pending buffer 機制；若 PR-2 尚未 merge，PR-4 的 built-in adapter 會被 `dispatchSettingsContributions()` 的 `clearContributions()` 清掉）
+- **不依賴**：PR-3（shell 檔案不重疊，但 `register-modules.tsx` 有 rebase 衝突 — 見 §9 rebase 備註）
+- **rebase 衝突點**（若與 PR-3 並行）：
+  - `spa/src/lib/register-modules.tsx` — PR-3 拔 reserved 兩行；PR-4 加 built-in host sections 六行。位置不同，機械合併可行
+- **被依賴**：PR-5（Editor `hostConfig.homePath` 需要 PR-4 的動態 subPage 機制與 host shell render 新 contribution）
+- **順風解決**：#538（Host 層 render-level smoke）/ #541（cross-store rehydrate order，具體 harness）

--- a/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md
@@ -1,10 +1,11 @@
 # HSR PR-4：Host Settings Shell + Built-in Sub-page Adapter — Implementation Plan
 
-> 日期：2026-04-22（v2 post-codex-review task-mo8xtpa8-bdxsh4）
-> 狀態：Ready for Implementation（**依序 build on PR-2 + PR-3**）
+> 日期：2026-04-22（v3 post-codex-review Round 2 task-mo8z6ppx-pj07yk）
+> 狀態：Ready for Implementation（**必須 build on PR-2**；功能上不依賴 PR-3 但與 PR-3 有 rebase 衝突 — 見 §9）
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
 > 決策對齊：4c（HostPage registry-driven + 六子頁走 built-in adapter registration + host route contract 鬆綁）
 > PR 系列：PR-1 ✅ / PR-2 / PR-3 / **PR-4（本文件）** / PR-5
+> v3 收斂：Round 1 Finding 3/5 → v2 修；Round 2 Finding 5 partial（harness 綁 singleton）→ 本版改為 `store.setState()` 方案
 
 ---
 
@@ -106,46 +107,64 @@ PR-4 結束時：
 
 ### 3.4 `host-lifecycle.test.ts` 擴充（#541 — 具體 harness）
 
-**Harness 設計**：zustand persist 的 rehydrate 是自動的，要精準控制順序需用 test fixture：
+**現況限制**：`host-lifecycle.ts` 直接綁 module singleton（`useHostStore.getState()` / `useHostSettingsStore.getState()` 等），不接受 store instance 注入 — 所以 harness **不能**用 `createStore()` 新建獨立 instance（那樣測不到 source）。
+
+**Harness 設計（v3 修正）**：用 `store.setState()` 直接操控 singleton 的狀態，模擬「rehydrate 完成後的 state shape」，再呼叫 `removeHost` / `undo` / `hostWasRecreated` 等 lifecycle 操作。
 
 ```ts
-// Setup pattern
-import { createStore } from 'zustand/vanilla'
-// 手動 create store instance（不經過 module singleton）
-const makeHostStore = () => createStore(...)
-const makeHostSettingsStore = () => createStore(...)
+import { useHostStore } from '@/stores/useHostStore'
+import { useHostSettingsStore } from '@/stores/useHostSettingsStore'
+import { useWorkspaceSettingsStore } from '@/stores/useWorkspaceSettingsStore'
+import { useTabStore } from '@/stores/useTabStore'
+import { useSessionStore } from '@/stores/useSessionStore'
+import { useStreamStore } from '@/stores/useStreamStore'
+import { useAgentStore } from '@/stores/useAgentStore'
 
-// 控制 rehydrate 順序
-function harnessOrderA() {
-  const hostStore = makeHostStore()
-  hostStore.persist.rehydrate()  // 完成
-  const settingsStore = makeHostSettingsStore()
-  settingsStore.persist.rehydrate()  // 完成
-  return { hostStore, settingsStore }
+// 每個 test 前把所有被觸及的 singleton 歸零（getInitialState 可從 zustand 拿原始 initial state fn）
+beforeEach(() => {
+  useHostStore.setState(useHostStore.getInitialState(), true)  // true = replace
+  useHostSettingsStore.setState(useHostSettingsStore.getInitialState(), true)
+  useWorkspaceSettingsStore.setState(useWorkspaceSettingsStore.getInitialState(), true)
+  useTabStore.setState(useTabStore.getInitialState(), true)
+  // 其餘 cascade 涉及的 store 同上
+})
+
+// 模擬「hosts rehydrate 完成 + hostSettings rehydrate 完成」狀態
+function seedBothRehydrated() {
+  useHostStore.setState({ hosts: { hA: { id: 'hA', name: 'Host A', ... }, hB: {...} }, activeHostId: 'hA' })
+  useHostSettingsStore.setState({ settings: { hA: { editor: { homePath: '/tmp/a' } } } })
 }
 
-function harnessOrderB() {
-  const settingsStore = makeHostSettingsStore()
-  settingsStore.persist.rehydrate()
-  const hostStore = makeHostStore()
-  hostStore.persist.rehydrate()
-  return { hostStore, settingsStore }
+// 模擬「hosts 已 rehydrate + hostSettings 尚未 rehydrate」瞬間
+function seedHostOnly() {
+  useHostStore.setState({ hosts: { hA: {...}, hB: {...} }, activeHostId: 'hA' })
+  // hostSettings 保留 initial state（visual: 'rehydrate 還沒跑到'）
+}
+
+// 模擬「hostSettings 先 rehydrate + hosts 尚未 rehydrate」瞬間
+function seedSettingsOnly() {
+  useHostSettingsStore.setState({ settings: { hA: { editor: { homePath: '/tmp/a' } } } })
+  // hostStore 保留 initial state（hosts: {}）
 }
 ```
 
+`vi.mock` 方案備選：若某些 cascade 的相依 store 有複雜 side-effect 不易用 `setState` 重現（例：`useTabStore` 的 derived getter），可用 `vi.mock('@/stores/useTabStore', ...)` 覆寫整個 module export；但測試先用 setState 方案完成，mock 僅作 fallback。
+
 | 類別 | 測試項 | 預期 |
 |---|---|---|
-| Rehydrate order A | `harnessOrderA()` → 預設 seed data（hosts[hostA], hostSettings[hostA][editor]）→ 刪除 hostA → `hostSettingsStore.get(hostA, 'editor')` undefined；undo 在 window 內 → 兩 store 都恢復 | 通過 |
-| Rehydrate order B | `harnessOrderB()` → 相同 seed + 行為 → 兩 store 恢復 | 通過 |
-| Interleaved | 模擬「HostStore 半 rehydrate（hosts[hostA] 存在但 runtime 還沒）時觸發刪除」— 驗 `removeHost` 的 precheck 不會因部分 state 誤判 last-host | 通過 |
-| hostWasRecreated | Rehydrate 完成後模擬 same-id 重建 → `hostWasRecreated(hostId)` 回 true（沿用 PR-1 實作） | 通過 |
-| Cascade 回歸 | 刪除 hostA → `hostSettingsStore.get(hostA, *)` undefined（PR-1 cascade） | 通過 |
-| Undo 回歸 | Cascade clear 後 undo window 內 undo → host + hostSettings 都恢復（PR-1） | 通過 |
-| Workspace 交叉 | 刪 hostA + hostA 參與的 workspace tear-off / merge → workspaceSettings 不被連坐清（PR-1 的 D finding） | 通過（回歸） |
+| Rehydrate order A（both done） | `seedBothRehydrated()` → `removeHost('hA')` → `useHostSettingsStore.getState().settings.hA` undefined；undo window 內 `undoRemove()` → hosts + hostSettings 都恢復 | 通過 |
+| Rehydrate order B（settings only） | `seedSettingsOnly()` → `removeHost('hA')` → precheck 因 `hostStore.hosts[hA]` undefined 直接 veto + no-op（B1 回歸）；hostSettings 不被清 | 通過 |
+| Rehydrate order C（host only） | `seedHostOnly()` → `removeHost('hA')` → cascade 跑完（hostSettings 本就空，清 no-op）；undo 恢復 hosts、hostSettings 仍空（對應 source rehydrate 還沒跑到的瞬間） | 通過 |
+| Interleaved write during cascade | `seedBothRehydrated()` → 開始 `removeHost('hA')` → 在 undo window 內再對 `useHostSettingsStore.setState(...)` 寫入相同 hostId → undo 的 `hostWasRecreated` 判斷應 **gate 住** restore，避免蓋掉較新的 write（B2 回歸） | 通過 |
+| hostWasRecreated | `seedBothRehydrated()` → `removeHost('hA')` → 在 undo window 內重建 same-id host（`useHostStore.setState({ hosts: { hA: {新 payload} } })`）→ `hostWasRecreated('hA')` 回 true；`undoRemove()` 的 5 類 restore 全 gate | 通過 |
+| Last-host veto | `useHostStore.setState({ hosts: { hA: {...} } })`（僅剩一 host）→ `removeHost('hA')` veto + no-op（B1 回歸） | 通過 |
+| Cascade 回歸 | `seedBothRehydrated()` → `removeHost('hA')` → `useHostSettingsStore.getState().settings.hA` undefined（PR-1 cascade） | 通過 |
+| Undo 回歸 | Cascade clear 後 undo window 內 undo → hosts + hostSettings 都恢復（PR-1） | 通過 |
+| Workspace 交叉 | `seedBothRehydrated()` + 額外 seed workspaceSettings for hA-owned workspace → tearOff / mergeWorkspace → workspaceSettings 不被連坐清（PR-1 的 D finding 回歸） | 通過 |
 
-**若 harness 發現 bug**：改 `host-lifecycle.ts` source 修邏輯（不再 ship PR-4 直到 #541 解決）。若發現 bug 過大，選項 B：#541 拆獨立 PR，PR-4 scope 保留 built-in adapter + shell 部分（先 ship），#541 後補 follow-up。
+**若 harness 發現 bug**：改 `host-lifecycle.ts` source 修邏輯。若 bug 過大，選項 B：#541 拆獨立 PR，PR-4 scope 保留 built-in adapter + shell 部分（先 ship），#541 後補 follow-up。
 
-**Harness 複雜度風險**：若 zustand v4+ 的 `persist.rehydrate()` API 無法精準控制，改用較直接的 state mutation：`store.setState(mockedRehydratedState)` 模擬「已 rehydrate」狀態；`store.setState(initialState)` 模擬「未 rehydrate」狀態。兩種實作擇一，測試先綠為準。
+**Harness 驗證原則**：本設計用 `setState(..., true)` 做 replace 而非 merge，確保 test 之間完全隔離；避免相依 `persist.rehydrate()` 的非確定性 timing。
 
 ### 3.5 視覺回歸（手動）
 
@@ -230,8 +249,8 @@ function harnessOrderB() {
 ## 9. 與其他 PR 的關聯
 
 - **依賴**：PR-1（已 merged）+ **PR-2**（本 PR 的 built-in host adapter 沿用 PR-2 的 dispatch-flushed pattern + pending buffer 機制；若 PR-2 尚未 merge，PR-4 的 built-in adapter 會被 `dispatchSettingsContributions()` 的 `clearContributions()` 清掉）
-- **不依賴**：PR-3（shell 檔案不重疊，但 `register-modules.tsx` 有 rebase 衝突 — 見 §9 rebase 備註）
-- **rebase 衝突點**（若與 PR-3 並行）：
-  - `spa/src/lib/register-modules.tsx` — PR-3 拔 reserved 兩行；PR-4 加 built-in host sections 六行。位置不同，機械合併可行
+- **與 PR-3 的關係**（統一敘事，Round 2 提醒）：功能層**不依賴** PR-3（shell 檔案 `HostPage.tsx` / `HostSidebar.tsx` / `host-routes.ts` 與 PR-3 的 `WorkspaceSettingsPage.tsx` 不重疊）；**但** `spa/src/lib/register-modules.tsx` 有 rebase 衝突（見下），合併順序**建議 PR-3 先於 PR-4**（spec §8 序列化順序）以單純化 rebase
+- **rebase 衝突點**：
+  - `spa/src/lib/register-modules.tsx` — PR-3 拔 reserved 兩行；PR-4 加 built-in host sections 六行。位置不同，機械合併可行（本 PR rebase on PR-3 時只需保留 PR-3 的拔除、疊加本 PR 的新增）
 - **被依賴**：PR-5（Editor `hostConfig.homePath` 需要 PR-4 的動態 subPage 機制與 host shell render 新 contribution）
 - **順風解決**：#538（Host 層 render-level smoke）/ #541（cross-store rehydrate order，具體 harness）

--- a/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
@@ -1,10 +1,11 @@
 # HSR PR-5：Editor `homePath` First Module User — Implementation Plan
 
-> 日期：2026-04-22（v2 post-codex-review task-mo8xtpa8-bdxsh4）
+> 日期：2026-04-22（v3 post-codex-review Round 2 task-mo8z6ppx-pj07yk）
 > 狀態：Ready for Implementation（依賴 PR-2 + PR-3 + PR-4 全部 land）
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
 > 決策對齊：3b（舊 API 在 PR-5 merge 時發 deprecation）+ 1c（走 adapter 的新 registry 路徑）
 > PR 系列：PR-1 ✅ / PR-2 / PR-3 / PR-4 / **PR-5（本文件）**
+> v3 收斂：Round 1 Finding 4 → v2 修 LinkContext API；Round 2 Finding 4 partial（plumbing 未閉環）+ N3（commit 切分漏 plumbing）→ 本版改以 `SessionPaneContent` 為 workspaceId 來源，獨立 commit
 
 ---
 
@@ -16,7 +17,12 @@
 
 Tilde path opener（`spa/src/lib/terminal-link/openers/file-path.ts`）的 `~/...` 分支改為**層疊 resolve**：workspace settings → host settings → `fetchPaneHome()`（Layer 3，PR #530 既有）→ 無則 fallthrough 原 rawPath 行為。
 
-**關鍵前置（codex review Finding 4）**：`LinkContext`（`spa/src/lib/terminal-link/types.ts:29`）目前只有 `hostId?: string` + `sessionCode?: string`，無 `workspaceId`。本 PR 必須擴 `LinkContext` 加 `workspaceId?: string`，並在 `TerminalView.tsx:28` 的 `linkContext` 構造處注入正確的 workspaceId（link 來源 terminal 所屬的 workspace，**不是** `getActiveWorkspaceId()` — 兩者在 inactive pane / split screen / 多 workspace 並存時不同）。resolver 用 `ctx.workspaceId` 查 `useWorkspaceSettingsStore`，確保 multi-workspace 情境下 override 來源正確。
+**關鍵前置（Round 1 Finding 4 + Round 2 partial 閉環）**：
+
+- `LinkContext`（`spa/src/lib/terminal-link/types.ts:29`）目前只有 `hostId?: string` + `sessionCode?: string`，無 `workspaceId`。本 PR 擴 `LinkContext` 加 `workspaceId?: string`（link 來源 terminal 所屬的 workspace，**不是** `getActiveWorkspaceId()`）
+- **Plumbing 來源（v3 確定）**：`workspaceId` 必須由 link 來源 pane 帶上來。可靠的入口是 `spa/src/components/SessionPaneContent.tsx:56-61`（現況已由 `useTabStore` 查到 `tabId`）；該層再查 `useWorkspaceStore` 找「包含此 tabId 的 workspace」得 `workspaceId`，以 prop 傳入 `TerminalView`。`TerminalView` 不自己找 workspace（避免在多層組件各自用 `activeWorkspaceId` 猜，造成 inactive pane / split / multi-workspace 不一致）
+- `TerminalView` 接 `workspaceId?: string` prop，`linkContext` 構造改為 `useMemo(() => ({ hostId, sessionCode, workspaceId }), [hostId, sessionCode, workspaceId])`
+- Resolver 用 `ctx.workspaceId` 查 `useWorkspaceSettingsStore`，確保 multi-workspace 情境下 override 來源正確；`ctx.workspaceId === undefined`（standalone pane）時跳過 workspace 層
 
 PR-5 merge 時同步：
 - **#540 解決**：三層 store `get()` 回傳 frozen shallow clone（防止 consumer 以 in-place mutation 繞過 persist / sync）
@@ -50,11 +56,16 @@ PR-5 結束時：
 ### 修改
 - `spa/src/lib/terminal-link/types.ts`（Finding 4 — LinkContext 擴充）
   - `interface LinkContext` 加 `workspaceId?: string`（optional — legacy callsite 不給時 resolver 直接 fallthrough 到 host 層）
-  - JSDoc 標示：「workspaceId 應為 link 來源 terminal 所屬的 workspace id，**不是** active workspace id」
+  - JSDoc 標示：「workspaceId 應為 link 來源 terminal 所屬的 workspace id，**不是** active workspace id；由 `SessionPaneContent` 用 pane-to-tab-to-workspace 查詢得出並透過 `TerminalView.workspaceId` prop 注入」
 - `spa/src/components/TerminalView.tsx`
+  - Props 加 `workspaceId?: string`
   - `linkContext` 構造改為 `useMemo(() => ({ hostId, sessionCode, workspaceId }), [hostId, sessionCode, workspaceId])`
-  - 新增 `workspaceId` prop 或 context 來源：TerminalView 的 tab 屬於某 workspace，透過 `useTabStore` + `useWorkspaceStore` 查「包含此 tab 的 workspace」—— 即 `workspaces.find(ws => ws.tabs.includes(tabId))?.id`
-  - 若該 tab 屬 standalone（不在任一 workspace），`workspaceId` 為 undefined；resolver 跳過 workspace 層
+  - **不自行查 workspace**（依 v3 plumbing 約定由父層注入；若 prop undefined 表示 standalone pane，linkContext.workspaceId 為 undefined）
+- `spa/src/components/SessionPaneContent.tsx`（v3 新增 — Finding 4 plumbing 真來源）
+  - 現況已用 `useTabStore` 查出 `tabId`（line 56-61）
+  - 新增：再用 `useWorkspaceStore` 查「包含此 tabId 的 workspace」得 `workspaceId`；偽碼：`const workspaceId = useWorkspaceStore((s) => tabId ? s.workspaces.find(ws => ws.tabIds?.includes(tabId))?.id : undefined)`（實際 store shape 以當下 `useWorkspaceStore` API 為準；實作時需對照 current store schema — tearoff 後 workspace 的 tabs field 命名可能為 `tabIds` / `tabs` 之一）
+  - 把 `workspaceId` 以 prop 傳入 `<TerminalView workspaceId={workspaceId} ... />`
+  - `<ConversationView>` 分支（stream mode）若未來也吃 linkContext（現況不吃）則同樣由此注入；PR-5 scope 內不動 ConversationView
 - `spa/src/lib/register-modules.tsx`
   - Editor `registerModule({ id: 'editor', ..., settings: [{ localId: 'homePath', scope: 'workspace', order: 0, labelKey: 'editor.settings.home_path.workspace', component: EditorHomePathWorkspaceSection }, { localId: 'homePath', scope: 'host', order: 0, labelKey: 'editor.settings.home_path.host', component: EditorHomePathHostSection }] })`
   - 加舊 API deprecation warning（僅對非 `files` 使用者）—— 在 register pass 中偵測 `globalConfig.length > 0` 或 `workspaceConfig.length > 0` 且 moduleId !== 'files' → `console.warn('[module] ${id} uses deprecated globalConfig/workspaceConfig; migrate to settings: [{ scope, localId }]')`
@@ -135,6 +146,18 @@ PR-5 結束時：
 | Mutation guard | `store.get(ws, mod).foo = 'x'` 在 strict mode 拋（或在 loose mode 靜默忽略）；**store 內部狀態不變** | 通過 |
 | Patch 仍可 | `store.set(ws, mod, { foo: 'x' })` 正常運作（set 不受 frozen 影響） | 通過 |
 
+### 3.6a LinkContext plumbing（commit 2 — v3 新增）
+
+測試分兩處：`TerminalView.test.tsx` 與 `SessionPaneContent.test.tsx`（或合併為 `SessionPaneContent.test.tsx` 一處）。
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| TerminalView prop | 傳 `workspaceId='wsA'` → `linkContext.workspaceId === 'wsA'`（可透過 mock `useTerminal` 觀察 `linkContext` 參數） | 通過 |
+| TerminalView prop | 不傳 workspaceId → `linkContext.workspaceId === undefined` | 通過 |
+| SessionPaneContent 查詢 | pane 在 workspace `wsA` 的 tab `tX` 下 → `<TerminalView>` 收到 `workspaceId='wsA'` | 通過 |
+| SessionPaneContent standalone | pane 在 tab `tY`，`tY` 不屬任何 workspace → `<TerminalView>` 收到 `workspaceId={undefined}` | 通過 |
+| Multi-workspace isolation | `workspaces: { wsA: { tabIds:['tX'] }, wsB: { tabIds:['tY'] } }`；pane 在 `tY` → 收到 `workspaceId='wsB'`，非 active 的 `wsA` | **關鍵 — Finding 4 plumbing 閉環** |
+
 ### 3.6 Deprecation warning (#3b)
 
 | 類別 | 測試項 | 預期 |
@@ -214,16 +237,29 @@ PR-5 結束時：
 
 1. **`refactor(spa): settings stores return frozen immutable snapshot (#540)`**
    - 三層 store `get` + test
-2. **`feat(spa): editor-home-resolver with layered workspace → host → pane-shell resolve`**
-   - `editor-home-resolver.ts` + test
-3. **`feat(spa): terminal-link opener uses editor-home-resolver for tilde paths`**
-   - `file-path.ts` 改 resolver 呼叫 + test 擴充
-4. **`feat(spa): Editor module declares homePath contributions (workspace + host)`**
+2. **`feat(spa): LinkContext carries link-source workspaceId (plumbing)`**
+   - `terminal-link/types.ts` 加 `workspaceId?`
+   - `TerminalView.tsx` 加 prop + linkContext 注入
+   - `SessionPaneContent.tsx` 查 workspaceId 傳 prop
+   - 單測：`TerminalView.test.tsx` / `SessionPaneContent.test.tsx` 驗 workspaceId 正確傳遞（active ws / standalone pane / multi-workspace inactive pane 三路徑）
+   - 此 commit 後 `linkContext.workspaceId` 在所有開啟 terminal 的情境都填對；因 opener 還沒消費該欄位，行為與 main 一致
+3. **`feat(spa): editor-home-resolver with layered workspace → host → pane-shell resolve`**
+   - `editor-home-resolver.ts` + test（含 wrong-workspaceId 回歸）
+4. **`feat(spa): terminal-link opener uses editor-home-resolver for tilde paths`**
+   - `file-path.ts` 改 resolver 呼叫 + test 擴充（含 Multi-workspace / Standalone pane 測試）
+   - 此 commit 消費 commit 2 的 `workspaceId` plumbing + commit 3 的 resolver
+5. **`feat(spa): Editor module declares homePath contributions (workspace + host)`**
    - 兩個 section component + test + `register-modules.tsx` Editor `settings` 宣告 + i18n
-5. **`refactor(spa): deprecate ModuleDefinition.globalConfig / workspaceConfig`**
+6. **`refactor(spa): deprecate ModuleDefinition.globalConfig / workspaceConfig`**
    - `module-registry.ts` JSDoc + `register-modules.tsx` warn + test
 
-共 5 commits。
+共 6 commits。每 commit 獨立可綠：
+- commit 1：只動 store.get 實作與測試
+- commit 2：plumbing 純傳值，無邏輯消費者（`workspaceId` 進 linkContext 但 opener 還沒讀）— 行為與 main 一致
+- commit 3：resolver 純邏輯 + 測試，無 callsite 接進
+- commit 4：opener 切到 resolver，同時消費 commit 2 plumbing + commit 3 resolver
+- commit 5：加 section + module 宣告，UI 出現但不影響其他流程
+- commit 6：deprecation warning，純 runtime 觀察，不改行為
 
 ---
 

--- a/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
@@ -1,0 +1,220 @@
+# HSR PR-5：Editor `homePath` First Module User — Implementation Plan
+
+> 日期：2026-04-22
+> 狀態：Ready for Implementation（但依賴 PR-3 / PR-4 land）
+> 主 spec：`2026-04-21-settings-contribution-registry-design.md`
+> 決策對齊：3b（舊 API 在 PR-5 merge 時發 deprecation）+ 1c（走 adapter 的新 registry 路徑）
+> PR 系列：PR-1 ✅ / PR-2 / PR-3 / PR-4 / **PR-5（本文件）**
+
+---
+
+## 1. 範圍
+
+**HSR 第一個 module 用例**。Editor module 透過新 `ModuleDefinition.settings` 宣告兩個 contribution：
+- `{ scope: 'workspace', localId: 'homePath' }` — workspace 手動 home（Layer 1）
+- `{ scope: 'host', localId: 'homePath' }` — host 手動 home（Layer 2）
+
+Tilde path opener（`spa/src/lib/terminal-link/openers/file-path.ts`）的 `~/...` 分支改為**層疊 resolve**：workspace settings → host settings → `fetchPaneHome()`（Layer 3，PR #530 既有）→ 無則 fallthrough 原 rawPath 行為。
+
+PR-5 merge 時同步：
+- **#540 解決**：三層 store `get()` 回傳 frozen shallow clone（防止 consumer 以 in-place mutation 繞過 persist / sync）
+- **決策 3b**：對舊 `ModuleDefinition.globalConfig` / `workspaceConfig` 欄位加 JSDoc `@deprecated` + `register-modules.tsx` 在 register pass 偵測到 **非 `files` module** 使用舊欄位時 console.warn（files 保留無警告，由 files owner 後續 refactor 處理）
+
+PR-5 結束時：
+- Editor 在 Workspace settings 頁與 Host 設定頁各顯示一個 "Home path" 區塊（文字輸入 + clear 按鈕）
+- `~/foo.ts` 點擊先用 workspace settings 解析，否則 host，否則 pane shell fallback
+- HSR 架構透過「真實 module + 真實 UI + 真實行為」完整閉環驗證
+- 舊 `globalConfig` / `workspaceConfig` 發 deprecation 警告（保留可運作）
+
+---
+
+## 2. 檔案清單
+
+### 新增
+- `spa/src/modules/editor/EditorHomePathWorkspaceSection.tsx`（或 `spa/src/features/editor/settings/` — 路徑以實作時確認）
+  - Props: `{ ctx: SettingsContext }`（scope === 'workspace' 守護）
+  - 讀 `useWorkspaceSettingsStore.get(ctx.workspaceId, 'editor')?.homePath`
+  - 一個輸入框（placeholder「Auto-detect from pane shell」）+ Clear button
+  - `onChange` 呼叫 `useWorkspaceSettingsStore.set(ctx.workspaceId, 'editor', { homePath: value })` 或 `delete` patch
+- `spa/src/modules/editor/EditorHomePathHostSection.tsx`
+  - 類似但 scope === 'host'；store 用 `useHostSettingsStore`
+- `spa/src/modules/editor/EditorHomePathWorkspaceSection.test.tsx`
+- `spa/src/modules/editor/EditorHomePathHostSection.test.tsx`
+- `spa/src/lib/editor-home-resolver.ts`（抽出 tilde 層疊 resolve 邏輯）
+  - `resolveEditorHomePath(ctx: { hostId, workspaceId?, sessionCode, signal }, deps): Promise<string | null>`
+  - 依序嘗試：workspace → host → `fetchPaneHome` → null
+- `spa/src/lib/editor-home-resolver.test.ts`
+
+### 修改
+- `spa/src/lib/register-modules.tsx`
+  - Editor `registerModule({ id: 'editor', ..., settings: [{ localId: 'homePath', scope: 'workspace', order: 0, labelKey: 'editor.settings.home_path.workspace', component: EditorHomePathWorkspaceSection }, { localId: 'homePath', scope: 'host', order: 0, labelKey: 'editor.settings.home_path.host', component: EditorHomePathHostSection }] })`
+  - 加舊 API deprecation warning（僅對非 `files` 使用者）—— 在 register pass 中偵測 `globalConfig.length > 0` 或 `workspaceConfig.length > 0` 且 moduleId !== 'files' → `console.warn('[module] ${id} uses deprecated globalConfig/workspaceConfig; migrate to settings: [{ scope, localId }]')`
+- `spa/src/lib/terminal-link/openers/file-path.ts`
+  - 將 `~/...` 分支的 `fetchPaneHome` 直呼改為 `resolveEditorHomePath(...)` 呼叫（內部仍會 fallback 回 `fetchPaneHome`）
+  - opener deps 若需擴充介面（`getWorkspaceHomePath(wsId)` / `getHostHomePath(hostId)`），一併擴充；但**傾向** resolver 直接 `import` store（opener 在 SPA 內部，無跨 boundary）
+- `spa/src/stores/useGlobalSettingsStore.ts`（#540）
+  - `get(moduleId)` 回 `Object.freeze({ ...internal })`（shallow clone + freeze）
+- `spa/src/stores/useHostSettingsStore.ts`（#540）
+  - `get(hostId, moduleId)` 同上
+- `spa/src/stores/useWorkspaceSettingsStore.ts`（#540）
+  - `get(wsId, moduleId)` 同上
+- `spa/src/stores/useGlobalSettingsStore.test.ts` / `useHostSettingsStore.test.ts` / `useWorkspaceSettingsStore.test.ts`
+  - 新增測試：`get` 回傳物件 frozen（`Object.isFrozen()` 為 true）
+  - 新增測試：mutate returned object throws / 不影響 store 內部
+- `spa/src/lib/module-registry.ts`
+  - `globalConfig?` / `workspaceConfig?` 加 `/** @deprecated Use settings: [{ scope: 'purdex' | 'workspace', localId }] instead. */`
+- `spa/src/locales/en.json` / `zh-TW.json`
+  - 新增 `editor.settings.home_path.workspace` / `.host` / `.description` / `.clear` 等 key
+
+### 不動
+- `fetchPaneHome` 介面（opener 內部改實作即可）
+- daemon 端 `/api/sessions/{code}/home`（PR #530 已完成）
+- 其他 terminal-link opener / matcher
+- PR-1 / PR-2 / PR-3 / PR-4 shell
+- 其他 module 的 `globalConfig` / `workspaceConfig`（`files.projectPath` 照常運作，但不觸發 deprecation warning）
+
+---
+
+## 3. Test Case Matrix
+
+### 3.1 `EditorHomePathWorkspaceSection.test.tsx`
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Render | 無 value → input placeholder 顯示 | 通過 |
+| Render | 已存 value → input 顯示該值 | 通過 |
+| Write | 輸入 `/Users/foo` 後 blur / enter → `useWorkspaceSettingsStore.get(wsId, 'editor').homePath === '/Users/foo'` | 通過 |
+| Clear | 按 clear → store `homePath` 變 undefined | 通過 |
+| Ctx guard | 傳 `ctx.scope !== 'workspace'` → render null 或 throw（實作擇一） | 通過 |
+
+### 3.2 `EditorHomePathHostSection.test.tsx`
+
+對 `useHostSettingsStore` 做相同矩陣。
+
+### 3.3 `editor-home-resolver.test.ts`
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Priority | workspace 有值 + host 有值 + fetchPaneHome 有值 → 回 workspace 值 | 通過 |
+| Priority | workspace 空 + host 有值 → 回 host 值 | 通過 |
+| Priority | workspace / host 皆空 + fetchPaneHome OK → 回 fetchPaneHome 值 | 通過 |
+| Priority | 三層皆空（fetchPaneHome reject / 回空字串）→ 回 null | 通過 |
+| Priority | workspace 值為空字串（使用者 clear）→ 視為無值，fallthrough 到 host | 通過 |
+| Abort | `signal.aborted` → fetchPaneHome 不呼叫、回 null | 通過 |
+| Absolute only | workspace / host 值非以 `/` 開頭 → 視為無效，fallthrough | 通過 |
+
+### 3.4 `openers/file-path.test.ts` 擴充
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Tilde + workspace override | 點 `~/foo.ts`；workspace 有 `homePath='/Users/x'` → 開啟 `/Users/x/foo.ts` | 通過 |
+| Tilde + host override | 點 `~/foo.ts`；workspace 空、host 有 `homePath='/home/y'` → 開啟 `/home/y/foo.ts` | 通過 |
+| Tilde fallback | 三層皆空、`fetchPaneHome` 回 `/Users/z` → 開啟 `/Users/z/foo.ts` | 通過（PR #530 回歸） |
+| Tilde all fail | 三層皆空、`fetchPaneHome` reject → 開啟 raw `~/foo.ts`（blank buffer；既有行為） | 通過 |
+
+### 3.5 Store immutability (#540)
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Frozen | `useWorkspaceSettingsStore.get(ws, mod)` 回傳 `Object.isFrozen()` 為 true | 通過 |
+| Mutation guard | `store.get(ws, mod).foo = 'x'` 在 strict mode 拋（或在 loose mode 靜默忽略）；**store 內部狀態不變** | 通過 |
+| Patch 仍可 | `store.set(ws, mod, { foo: 'x' })` 正常運作（set 不受 frozen 影響） | 通過 |
+
+### 3.6 Deprecation warning (#3b)
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Warn | 註冊一個 fake module `{ id: 'fake', globalConfig: [{...}], ... }` → `console.warn` 被呼叫，訊息含 `fake` 與 `deprecated` | 通過 |
+| 不 warn | 註冊 `files` module（已使用 `workspaceConfig`）→ 無 warn | 通過 |
+| 不 warn | 註冊使用新 `settings` 的 module → 無 warn | 通過 |
+
+### 3.7 視覺回歸（手動）
+
+- `cd spa && pnpm dev`
+- 打開 workspace settings → 看到 Editor Home Path (Workspace) 區塊；輸入 `/tmp/foo` → 開 terminal 點 `~/x` → Editor 開 `/tmp/foo/x`
+- 打開 host 設定 → 看到 Editor Home Path (Host) 區塊；清空 workspace 的值，輸入 host 值 `/home/bar` → 點 `~/y` → 開 `/home/bar/y`
+- 三層全空 → 點 `~/z` → 依 pane shell fallback 行為
+
+---
+
+## 4. 實作順序（TDD）
+
+1. **紅**：寫 §3.5 store immutability 測試
+2. **綠**：三層 store `get()` 加 freeze + shallow clone
+3. **紅**：寫 §3.3 resolver 測試
+4. **綠**：建 `editor-home-resolver.ts`
+5. **紅**：寫 §3.4 opener 擴充測試
+6. **綠**：改 `file-path.ts` `~/` 分支用 resolver
+7. **紅**：寫 §3.1 / §3.2 section 測試
+8. **綠**：建兩個 section component
+9. **紅**：寫 §3.6 deprecation warning 測試
+10. **綠**：`register-modules.tsx` 加 warning + Editor `settings` 宣告 + i18n keys
+11. **驗證**：`cd spa && pnpm exec vitest run` / `pnpm run lint` / `pnpm run build`
+12. **手動**：§3.7 視覺回歸
+
+---
+
+## 5. 驗收條件
+
+- [ ] §3.1–§3.6 測試全綠
+- [ ] `cd spa && pnpm exec vitest run` 全綠
+- [ ] `cd spa && pnpm run lint` 全綠
+- [ ] `cd spa && pnpm run build` 全綠
+- [ ] §3.7 手動驗：workspace / host / fallback 三路徑皆可用
+- [ ] `gh issue close #540`
+- [ ] Codex 兩輪 review 無 critical / P1 未修項
+- [ ] Kickoff 記憶更新：HSR PR-5 完成，全部 PR 落地
+
+---
+
+## 6. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| freeze 後既有 consumer mutate frozen object 造成既有 bug 顯性化 | 中 | PR-1 後 store 無 production consumer；§3.5 測試保證 immutability；若發現 consumer 依賴 mutation，改為 `set()` callsite |
+| resolver 的 abort signal 傳遞遺漏 | 中 | §3.3 abort 測試覆蓋；resolver 需支援 `AbortSignal` 貫穿 |
+| workspace / host 的 `homePath` 值為相對路徑或含 `..` 的 traversal | 中 | §3.3 「absolute only」測試；值非 `/` 開頭 → 視為無效；相對值不納入（由 PR #531 tracking，不在 PR-5 scope 擴展） |
+| Editor section UI 與 WorkspaceSettingsPage 既有佈局（ModuleConfigSection 的 files.projectPath）並排視覺不一致 | 低 | 採同樣 `<section>` + `<h3>` 樣式；§3.7 手動驗 |
+| Deprecation warning 吵到 dev 輸出（每次 HMR 重跑都 warn 一次）| 中 | warn 加 de-dupe（per (moduleId, scope) 只 warn 一次）—— 用 `Set` in module scope 記已 warn 過的 id |
+| `files` module 被豁免 warn 的判定太寬鬆（未來若 `files` 也該遷但仍保留就永遠沒 warn）| 中 | 豁免清單明確為 `['files']`；未來若決定搬，就從豁免清單移除並處理；清單在 `register-modules.tsx` 內顯式定義 |
+
+---
+
+## 7. 超出 PR-5 範圍（明確不做）
+
+- 舊 `globalConfig` / `workspaceConfig` 欄位**完全移除**（還要等所有 consumer 遷完）
+- `files.projectPath` 搬到新 `settings`（決策 2b — files owner 後續 refactor）
+- `ModuleConfigSection.tsx` 移除（同上）
+- `useModuleConfigStore` 移除
+- `~/../foo` traversal 防護（遺留 issue #531，不在 PR-5 scope）
+- Darwin `ps -E` 空白切割（#532，不在 PR-5 scope）
+- Editor 其他偏好（字型 / theme）走新 registry — 保留舊實作
+- PR-5 後續 clean-up PR（全面移除舊 API）
+
+---
+
+## 8. Commit 規劃
+
+每 commit 綠。
+
+1. **`refactor(spa): settings stores return frozen immutable snapshot (#540)`**
+   - 三層 store `get` + test
+2. **`feat(spa): editor-home-resolver with layered workspace → host → pane-shell resolve`**
+   - `editor-home-resolver.ts` + test
+3. **`feat(spa): terminal-link opener uses editor-home-resolver for tilde paths`**
+   - `file-path.ts` 改 resolver 呼叫 + test 擴充
+4. **`feat(spa): Editor module declares homePath contributions (workspace + host)`**
+   - 兩個 section component + test + `register-modules.tsx` Editor `settings` 宣告 + i18n
+5. **`refactor(spa): deprecate ModuleDefinition.globalConfig / workspaceConfig`**
+   - `module-registry.ts` JSDoc + `register-modules.tsx` warn + test
+
+共 5 commits。
+
+---
+
+## 9. 與其他 PR 的關聯
+
+- **依賴**：PR-1（已 merged）+ **PR-3**（workspace shell 能渲染 workspace contribution）+ **PR-4**（host shell 能渲染 host contribution）
+- **不依賴**：PR-2（Purdex shell — Editor 不宣告 `scope: 'purdex'`）
+- **被依賴**：後續「全面移除舊 `globalConfig` / `workspaceConfig`」的獨立 refactor PR
+- **順風解決**：#540 / 決策 3b deprecation

--- a/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
@@ -1,7 +1,7 @@
 # HSR PR-5：Editor `homePath` First Module User — Implementation Plan
 
-> 日期：2026-04-22
-> 狀態：Ready for Implementation（但依賴 PR-3 / PR-4 land）
+> 日期：2026-04-22（v2 post-codex-review task-mo8xtpa8-bdxsh4）
+> 狀態：Ready for Implementation（依賴 PR-2 + PR-3 + PR-4 全部 land）
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
 > 決策對齊：3b（舊 API 在 PR-5 merge 時發 deprecation）+ 1c（走 adapter 的新 registry 路徑）
 > PR 系列：PR-1 ✅ / PR-2 / PR-3 / PR-4 / **PR-5（本文件）**
@@ -15,6 +15,8 @@
 - `{ scope: 'host', localId: 'homePath' }` — host 手動 home（Layer 2）
 
 Tilde path opener（`spa/src/lib/terminal-link/openers/file-path.ts`）的 `~/...` 分支改為**層疊 resolve**：workspace settings → host settings → `fetchPaneHome()`（Layer 3，PR #530 既有）→ 無則 fallthrough 原 rawPath 行為。
+
+**關鍵前置（codex review Finding 4）**：`LinkContext`（`spa/src/lib/terminal-link/types.ts:29`）目前只有 `hostId?: string` + `sessionCode?: string`，無 `workspaceId`。本 PR 必須擴 `LinkContext` 加 `workspaceId?: string`，並在 `TerminalView.tsx:28` 的 `linkContext` 構造處注入正確的 workspaceId（link 來源 terminal 所屬的 workspace，**不是** `getActiveWorkspaceId()` — 兩者在 inactive pane / split screen / 多 workspace 並存時不同）。resolver 用 `ctx.workspaceId` 查 `useWorkspaceSettingsStore`，確保 multi-workspace 情境下 override 來源正確。
 
 PR-5 merge 時同步：
 - **#540 解決**：三層 store `get()` 回傳 frozen shallow clone（防止 consumer 以 in-place mutation 繞過 persist / sync）
@@ -46,12 +48,21 @@ PR-5 結束時：
 - `spa/src/lib/editor-home-resolver.test.ts`
 
 ### 修改
+- `spa/src/lib/terminal-link/types.ts`（Finding 4 — LinkContext 擴充）
+  - `interface LinkContext` 加 `workspaceId?: string`（optional — legacy callsite 不給時 resolver 直接 fallthrough 到 host 層）
+  - JSDoc 標示：「workspaceId 應為 link 來源 terminal 所屬的 workspace id，**不是** active workspace id」
+- `spa/src/components/TerminalView.tsx`
+  - `linkContext` 構造改為 `useMemo(() => ({ hostId, sessionCode, workspaceId }), [hostId, sessionCode, workspaceId])`
+  - 新增 `workspaceId` prop 或 context 來源：TerminalView 的 tab 屬於某 workspace，透過 `useTabStore` + `useWorkspaceStore` 查「包含此 tab 的 workspace」—— 即 `workspaces.find(ws => ws.tabs.includes(tabId))?.id`
+  - 若該 tab 屬 standalone（不在任一 workspace），`workspaceId` 為 undefined；resolver 跳過 workspace 層
 - `spa/src/lib/register-modules.tsx`
   - Editor `registerModule({ id: 'editor', ..., settings: [{ localId: 'homePath', scope: 'workspace', order: 0, labelKey: 'editor.settings.home_path.workspace', component: EditorHomePathWorkspaceSection }, { localId: 'homePath', scope: 'host', order: 0, labelKey: 'editor.settings.home_path.host', component: EditorHomePathHostSection }] })`
   - 加舊 API deprecation warning（僅對非 `files` 使用者）—— 在 register pass 中偵測 `globalConfig.length > 0` 或 `workspaceConfig.length > 0` 且 moduleId !== 'files' → `console.warn('[module] ${id} uses deprecated globalConfig/workspaceConfig; migrate to settings: [{ scope, localId }]')`
+  - Warn de-dupe：module-scope `Set<string>` 記 `${moduleId}:${scope}` 已 warn 過的 key，避免 HMR 重跑反覆 warn
 - `spa/src/lib/terminal-link/openers/file-path.ts`
-  - 將 `~/...` 分支的 `fetchPaneHome` 直呼改為 `resolveEditorHomePath(...)` 呼叫（內部仍會 fallback 回 `fetchPaneHome`）
-  - opener deps 若需擴充介面（`getWorkspaceHomePath(wsId)` / `getHostHomePath(hostId)`），一併擴充；但**傾向** resolver 直接 `import` store（opener 在 SPA 內部，無跨 boundary）
+  - 將 `~/...` 分支的 `fetchPaneHome` 直呼改為 `resolveEditorHomePath(ctx, deps)` 呼叫（內部依序嘗試 workspace → host → fetchPaneHome）
+  - `ctx` 傳入 resolver 的完整 LinkContext（含 `workspaceId`）；resolver 內部直接 `import` 三層 store，不走 deps injection（SPA 內部不跨 boundary）
+  - Inactive workspace / undefined workspaceId 時，resolver 自動 skip workspace 層
 - `spa/src/stores/useGlobalSettingsStore.ts`（#540）
   - `get(moduleId)` 回 `Object.freeze({ ...internal })`（shallow clone + freeze）
 - `spa/src/stores/useHostSettingsStore.ts`（#540）
@@ -95,11 +106,13 @@ PR-5 結束時：
 
 | 類別 | 測試項 | 預期 |
 |---|---|---|
-| Priority | workspace 有值 + host 有值 + fetchPaneHome 有值 → 回 workspace 值 | 通過 |
+| Priority | `ctx.workspaceId` 有值 + workspace store 有值 + host 有值 + fetchPaneHome 有值 → 回 workspace 值 | 通過 |
 | Priority | workspace 空 + host 有值 → 回 host 值 | 通過 |
 | Priority | workspace / host 皆空 + fetchPaneHome OK → 回 fetchPaneHome 值 | 通過 |
 | Priority | 三層皆空（fetchPaneHome reject / 回空字串）→ 回 null | 通過 |
 | Priority | workspace 值為空字串（使用者 clear）→ 視為無值，fallthrough 到 host | 通過 |
+| **Workspace skip — undefined workspaceId** | `ctx.workspaceId === undefined`（link 來源 pane 非屬任一 workspace）→ resolver 跳過 workspace 層，直接進 host → fetchPaneHome | 通過 |
+| **Workspace skip — wrong workspaceId** | workspace store 有 `wsA.homePath`，但 `ctx.workspaceId === 'wsB'` → resolver 讀 `wsB.homePath`（undefined）→ fallthrough 到 host，**不**讀 `wsA` 的值（即 multi-workspace inactive pane 正確性） | **關鍵 — Finding 4 回歸** |
 | Abort | `signal.aborted` → fetchPaneHome 不呼叫、回 null | 通過 |
 | Absolute only | workspace / host 值非以 `/` 開頭 → 視為無效，fallthrough | 通過 |
 
@@ -107,10 +120,12 @@ PR-5 結束時：
 
 | 類別 | 測試項 | 預期 |
 |---|---|---|
-| Tilde + workspace override | 點 `~/foo.ts`；workspace 有 `homePath='/Users/x'` → 開啟 `/Users/x/foo.ts` | 通過 |
+| Tilde + workspace override | 點 `~/foo.ts`；`ctx.workspaceId='wsA'`、workspace store `wsA.editor.homePath='/Users/x'` → 開啟 `/Users/x/foo.ts` | 通過 |
 | Tilde + host override | 點 `~/foo.ts`；workspace 空、host 有 `homePath='/home/y'` → 開啟 `/home/y/foo.ts` | 通過 |
 | Tilde fallback | 三層皆空、`fetchPaneHome` 回 `/Users/z` → 開啟 `/Users/z/foo.ts` | 通過（PR #530 回歸） |
 | Tilde all fail | 三層皆空、`fetchPaneHome` reject → 開啟 raw `~/foo.ts`（blank buffer；既有行為） | 通過 |
+| **Multi-workspace** | 點 `~/foo.ts`；active workspace = `wsA`（有 `/Users/x`），但 link 來源 pane 屬 `wsB`（無 value）；`ctx.workspaceId='wsB'` → resolver 不讀 `wsA`，進 host 層或 fetchPaneHome | **關鍵 — Finding 4 回歸** |
+| **Standalone pane** | 點 `~/foo.ts`；pane 非屬任一 workspace；`ctx.workspaceId === undefined` → skip workspace 層，走 host / fetchPaneHome | 通過 |
 
 ### 3.5 Store immutability (#540)
 
@@ -214,7 +229,11 @@ PR-5 結束時：
 
 ## 9. 與其他 PR 的關聯
 
-- **依賴**：PR-1（已 merged）+ **PR-3**（workspace shell 能渲染 workspace contribution）+ **PR-4**（host shell 能渲染 host contribution）
-- **不依賴**：PR-2（Purdex shell — Editor 不宣告 `scope: 'purdex'`）
-- **被依賴**：後續「全面移除舊 `globalConfig` / `workspaceConfig`」的獨立 refactor PR
-- **順風解決**：#540 / 決策 3b deprecation
+- **依賴**：
+  - PR-1（已 merged）— 三層 store + registry 基礎
+  - **PR-2** — dispatch-flushed adapter pattern；`@internal` boundary（本 PR 的新 registry 消費遵守同樣 boundary）
+  - **PR-3** — WorkspaceSettingsPage shell 能渲染 workspace contribution（Editor `workspace.homePath` section 的 render 環境）
+  - **PR-4** — HostPage shell + host route contract 鬆綁（Editor `host.homePath` section 走動態 subPage localId）
+- **rebase 衝突點**：無（PR-5 動 `terminal-link/types.ts` + `TerminalView.tsx` + `register-modules.tsx` Editor module 段，與前面 PR 不重疊）
+- **被依賴**：後續「全面移除舊 `globalConfig` / `workspaceConfig`」的獨立 refactor PR（要等至少 `files` 也遷完）
+- **順風解決**：#540（三層 store immutable snapshot）/ 決策 3b（deprecation warning 落地 + de-dupe 機制）

--- a/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr5-editor-homepath-plan.md
@@ -5,15 +5,17 @@
 > 主 spec：`2026-04-21-settings-contribution-registry-design.md`
 > 決策對齊：3b（舊 API 在 PR-5 merge 時發 deprecation）+ 1c（走 adapter 的新 registry 路徑）
 > PR 系列：PR-1 ✅ / PR-2 / PR-3 / PR-4 / **PR-5（本文件）**
-> v3 收斂：Round 1 Finding 4 → v2 修 LinkContext API；Round 2 Finding 4 partial（plumbing 未閉環）+ N3（commit 切分漏 plumbing）→ 本版改以 `SessionPaneContent` 為 workspaceId 來源，獨立 commit
+> v3.1 收斂：Round 1 Finding 4 → v2 修 LinkContext API；Round 2 Finding 4 partial → v3 改以 `SessionPaneContent` 為 workspaceId 來源 + 獨立 plumbing commit；Round 3 HIGH（duplicate localId `homePath`）+ MED（`tabIds` 應為 `tabs`）→ v3.1 修 localId 拆為 `workspaceHomePath` / `hostHomePath` + plumbing 改用現成 `findWorkspaceByTab()`
 
 ---
 
 ## 1. 範圍
 
 **HSR 第一個 module 用例**。Editor module 透過新 `ModuleDefinition.settings` 宣告兩個 contribution：
-- `{ scope: 'workspace', localId: 'homePath' }` — workspace 手動 home（Layer 1）
-- `{ scope: 'host', localId: 'homePath' }` — host 手動 home（Layer 2）
+- `{ scope: 'workspace', localId: 'workspaceHomePath' }` — workspace 手動 home（Layer 1）
+- `{ scope: 'host', localId: 'hostHomePath' }` — host 手動 home（Layer 2）
+
+**注意（v3.1 修正，Round 3 HIGH）**：兩個 contribution **不得共用同一 `localId: 'homePath'`** — PR-1 registry 規定 `id = ${moduleId}.${localId}` 全域唯一，同 module 內兩個 localId 相同會在 `dispatchSettingsContributions()` collision check throw（`assertValidSettingsContribution` + seen-id set）。即使 scope 不同，id 仍會撞。因此 workspace / host 兩層各用獨立 localId。
 
 Tilde path opener（`spa/src/lib/terminal-link/openers/file-path.ts`）的 `~/...` 分支改為**層疊 resolve**：workspace settings → host settings → `fetchPaneHome()`（Layer 3，PR #530 既有）→ 無則 fallthrough 原 rawPath 行為。
 
@@ -63,11 +65,11 @@ PR-5 結束時：
   - **不自行查 workspace**（依 v3 plumbing 約定由父層注入；若 prop undefined 表示 standalone pane，linkContext.workspaceId 為 undefined）
 - `spa/src/components/SessionPaneContent.tsx`（v3 新增 — Finding 4 plumbing 真來源）
   - 現況已用 `useTabStore` 查出 `tabId`（line 56-61）
-  - 新增：再用 `useWorkspaceStore` 查「包含此 tabId 的 workspace」得 `workspaceId`；偽碼：`const workspaceId = useWorkspaceStore((s) => tabId ? s.workspaces.find(ws => ws.tabIds?.includes(tabId))?.id : undefined)`（實際 store shape 以當下 `useWorkspaceStore` API 為準；實作時需對照 current store schema — tearoff 後 workspace 的 tabs field 命名可能為 `tabIds` / `tabs` 之一）
+  - 新增：用 `useWorkspaceStore` 的現成 helper `findWorkspaceByTab(tabId)` 查 workspace（見 `spa/src/features/workspace/store.ts:136-138`；實際 workspace.tabs 欄位為 `tabs: string[]`，非 `tabIds`）：`const workspaceId = useWorkspaceStore((s) => tabId ? s.findWorkspaceByTab(tabId)?.id : undefined) ?? undefined`
   - 把 `workspaceId` 以 prop 傳入 `<TerminalView workspaceId={workspaceId} ... />`
   - `<ConversationView>` 分支（stream mode）若未來也吃 linkContext（現況不吃）則同樣由此注入；PR-5 scope 內不動 ConversationView
 - `spa/src/lib/register-modules.tsx`
-  - Editor `registerModule({ id: 'editor', ..., settings: [{ localId: 'homePath', scope: 'workspace', order: 0, labelKey: 'editor.settings.home_path.workspace', component: EditorHomePathWorkspaceSection }, { localId: 'homePath', scope: 'host', order: 0, labelKey: 'editor.settings.home_path.host', component: EditorHomePathHostSection }] })`
+  - Editor `registerModule({ id: 'editor', ..., settings: [{ localId: 'workspaceHomePath', scope: 'workspace', order: 0, labelKey: 'editor.settings.home_path.workspace', component: EditorHomePathWorkspaceSection }, { localId: 'hostHomePath', scope: 'host', order: 0, labelKey: 'editor.settings.home_path.host', component: EditorHomePathHostSection }] })` — 兩個 contribution 的完整 id 為 `editor.workspaceHomePath` 與 `editor.hostHomePath`，無 collision
   - 加舊 API deprecation warning（僅對非 `files` 使用者）—— 在 register pass 中偵測 `globalConfig.length > 0` 或 `workspaceConfig.length > 0` 且 moduleId !== 'files' → `console.warn('[module] ${id} uses deprecated globalConfig/workspaceConfig; migrate to settings: [{ scope, localId }]')`
   - Warn de-dupe：module-scope `Set<string>` 記 `${moduleId}:${scope}` 已 warn 過的 key，避免 HMR 重跑反覆 warn
 - `spa/src/lib/terminal-link/openers/file-path.ts`
@@ -156,7 +158,7 @@ PR-5 結束時：
 | TerminalView prop | 不傳 workspaceId → `linkContext.workspaceId === undefined` | 通過 |
 | SessionPaneContent 查詢 | pane 在 workspace `wsA` 的 tab `tX` 下 → `<TerminalView>` 收到 `workspaceId='wsA'` | 通過 |
 | SessionPaneContent standalone | pane 在 tab `tY`，`tY` 不屬任何 workspace → `<TerminalView>` 收到 `workspaceId={undefined}` | 通過 |
-| Multi-workspace isolation | `workspaces: { wsA: { tabIds:['tX'] }, wsB: { tabIds:['tY'] } }`；pane 在 `tY` → 收到 `workspaceId='wsB'`，非 active 的 `wsA` | **關鍵 — Finding 4 plumbing 閉環** |
+| Multi-workspace isolation | `workspaces: [{ id: 'wsA', tabs: ['tX'], ... }, { id: 'wsB', tabs: ['tY'], ... }]`；pane 在 `tY` → `findWorkspaceByTab('tY')?.id === 'wsB'`，TerminalView 收到 `workspaceId='wsB'`，非 active 的 `wsA` | **關鍵 — Finding 4 plumbing 閉環** |
 
 ### 3.6 Deprecation warning (#3b)
 


### PR DESCRIPTION
## Summary

- 新增 HSR（Host Settings Registry）系列的 4 份 plan 文件（PR-2 Purdex shell / PR-3 Workspace shell / PR-4 Host shell + route contract 鬆綁 / PR-5 Editor homePath 首個用例），並同步更新主 spec（`2026-04-21-settings-contribution-registry-design.md`）到 v3.2 對齊後續 PR 的 dispatch-flushed pattern。
- 所有 plan 經三輪 codex cross-model review 收斂（Round 1 → Round 3），修完 4 HIGH + 8 MED findings，本 PR 僅涉及 docs，無程式碼改動。

## Codex review 收斂軌跡

| Round | Severity | Findings | 修在 |
|---|---|---|---|
| 1 (task-mo8xtpa8-bdxsh4) | 4 HIGH + 2 MED | dispatch legacy clear / 共改檔無法並行 / host route 型別硬綁 / LinkContext 缺 workspaceId / #541 harness 抽象 / reserved 策略矛盾 | v2 (0525edd8) |
| 2 (task-mo8z6ppx-pj07yk) | 3 partial + 3 new MED | PR-5 plumbing 未閉環 / PR-4 harness 綁 singleton / PR-2 sidebar 敘事矛盾 / reserved buffer idempotent / spec §13 vs PR-4 / commit 切分依賴 | v3 (96693bd1) |
| 3 (task-mo90eijb-mk3gfg) | 1 HIGH + 3 MED | duplicate localId `homePath` / plumbing 用不存在 `tabIds` / PR-4 harness shape 失真 / PR-2 adapter 敘述跳過 dispatch | v3.1 (ae564250) |

Round 3 結束後剩餘皆為 low-severity 文件枝節，依 `feedback_codex_review_termination.md` 的 ship 原則進 PR。

## Scope

- **涵蓋**：HSR 系列 PR-2/3/4/5 的 implementation plan + spec 對齊
- **不涵蓋**：任何程式碼（plans 本身為實作指導；PR-2/3/4/5 各自 PR 才真正動 code）

## Test plan

- [ ] docs-only PR，無測試
- [ ] 人工讀過 4 份 plan + spec 確認對 PR-1 程式碼（已 merged #542）的引用正確（localId 格式、store shape、helper 名稱）