### PR TITLE
fix(spa): restore editor state and toolbar actions

### DIFF
--- a/docs/specs/2026-04-22-editor-state-toolbar-wysiwyg-design.md
+++ b/docs/specs/2026-04-22-editor-state-toolbar-wysiwyg-design.md
@@ -1,0 +1,225 @@
+# Editor State / Toolbar / WYSIWYG 修正 Spec
+
+> 日期：2026-04-22
+> 狀態：Draft v2（post spec-review）
+> 範圍：`spa/src/components/editor/*`、`spa/src/stores/useEditorStore.ts`、editor 相關測試
+> 參考：
+> - 現行 editor 設計：`docs/superpowers/specs/2026-04-14-editor-module-design.md`
+> - 相關實作：`spa/src/components/editor/EditorPane.tsx`、`EditorToolbar.tsx`、`MonacoWrapper.tsx`、`TiptapEditor.tsx`
+> - Codex spec 審查：thread `019db160-4793-7310-bc6a-352bfc97b969`（2026-04-22）
+
+---
+
+## 1. 概述
+
+這次修正聚焦 Editor module 的 4 個已知使用性缺陷：
+
+1. 切換 tab 後回來，editor state 會遺失
+2. top bar 只顯示檔名，沒有完整路徑 breadcrumbs
+3. 無法直接在 top bar 雙擊檔名重新命名
+4. Markdown WYSIWYG 模式的容器與捲動行為錯亂
+
+本 spec 只處理 SPA editor runtime 與 UI，不改 daemon / Electron API contract；rename 仍沿用既有 `FsBackend.rename()`。
+
+---
+
+## 2. 問題定義
+
+### 2.1 現況根因
+
+根據目前程式碼檢查：
+
+1. `EditorPane.tsx` 在 component unmount 時直接 `closeBuffer(key)`，而 tab keep-alive 預設是 `0`，所以切到別的 tab 時 editor pane 會被 unmount，buffer 跟著被刪掉。
+2. `EditorPane.tsx` 的 `editorMode` / `showDiff` 是 local state，pane remount 後會回到初始值。
+3. `EditorToolbar.tsx` 目前只 render basename，breadcrumbs UI 已不存在。
+4. `MonacoWrapper.tsx` 沒有提供穩定 model identity；即使 buffer 內容保住，Monaco 的 view state / undo stack 也無法可靠保留。
+5. `TiptapEditor.tsx` 把 `prose` 樣式掛在外層 scroll container，缺少明確的 `min-h-0` / `h-full` / editable root 佈局，導致編輯區外框與捲動異常。
+
+### 2.2 使用者可見症狀
+
+- 切 tab 回來後，游標位置、scroll、undo/redo 狀態消失
+- Markdown tab 切回來後，raw/WYSIWYG 模式與 diff 開關重置
+- top bar 無法辨識同名檔案所在目錄
+- top bar 不能直接 rename 檔案
+- WYSIWYG 模式會出現不合理的外框，且捲動不跟內容區正常配合
+
+---
+
+## 3. 目標 / 非目標
+
+### 3.1 目標
+
+1. editor tab 在一般 tab 切換後保留 runtime state
+2. top bar 顯示完整路徑 breadcrumbs，而不是只有 basename
+3. top bar 最後一段檔名可雙擊進入 rename 模式
+4. rename 前先做同目錄同名衝突檢查，已存在則顯示警告，不覆蓋
+5. 修正 WYSIWYG 模式的容器邊界與捲動行為
+6. 以測試先行方式覆蓋上述行為
+
+### 3.2 非目標
+
+1. 不做跨資料夾 move UI；rename 仍限定在原資料夾改 basename
+2. 不新增全域通知系統；rename 警告只需在 editor toolbar inline 顯示
+3. 不重做 editor module 架構；以最小修改修正現有行為
+4. 不處理 Markdown serializer / schema 額外功能
+
+---
+
+## 4. 設計決策
+
+### 4.1 Shared buffer 與 pane view state 分離
+
+這次修正要明確分成兩層狀態：
+
+1. **shared buffer state**：同一個 `source + filePath` 共用
+   - `content`
+   - `savedContent`
+   - `isDirty`
+   - `language`
+   - `lastStat`
+   - 穩定 `modelId`
+2. **pane-local view state**：同一檔案在不同 split / tab / detached pane 之間不可互相污染
+   - `editorMode`
+   - `showDiff`
+   - cursor / selection / scroll / view state
+
+`pane-local view state` 的 key 使用 `pane.id`，而不是 `source + filePath`。理由是系統已支援 split / detach，同一檔案可以同時出現在多個 pane；若直接把 view state 綁檔案 key，任一 pane 的 diff / scroll / cursor 會覆寫其他 pane。
+
+### 4.2 Buffer lifetime 與 tab 切換解耦
+
+`useEditorStore` 的 buffer 不再因 pane unmount 就直接刪除。清理條件改為：當前 worktree 內已沒有任何 pane 引用同一個 editor content（`source + filePath`）時，才允許關閉 buffer。
+
+這樣可讓 keep-alive = 0 的情況下，tab 切換仍保留：
+
+- buffer content / dirty 狀態
+- pane-local cursor / scroll / mode / diff
+
+### 4.3 editor UI state 進 store
+
+`editorMode` 與 `showDiff` 從 `EditorPane` local state 提升到 `useEditorStore`，但必須以 `pane.id` 管理。原因是這兩者屬於 view state，不是檔案內容本身。
+
+### 4.4 Monaco 使用穩定 model identity
+
+`MonacoWrapper` 需要區分 model 與 view state：
+
+1. **model identity**：綁 shared buffer 的穩定 `modelId`，不是直接綁 `filePath`
+2. **view state**：以 `pane.id` 儲存 / 還原 Monaco view state
+
+這樣 tab 切換後仍能恢復：
+
+- selection / cursor
+- scroll position
+- undo/redo stack
+
+rename 時 shared buffer 的 key 會變，但 `modelId` 必須維持穩定，避免 URI 切換直接丟失 undo stack。view state 則繼續綁各自的 `pane.id`。
+
+### 4.5 Toolbar 改為 breadcrumbs + inline rename
+
+Toolbar 左側改成：
+
+- 完整 path breadcrumbs
+- 最後一段檔名為主要焦點
+- 雙擊最後一段進入 rename input
+
+rename 流程：
+
+1. 使用者雙擊檔名
+2. 只允許編輯 basename，不允許改父路徑
+3. basename 經過 trim 後若為空、`.`、`..`、含 path separator，視為非法名稱，顯示 inline warning
+4. 若新名稱與原名稱相同，結束 edit mode，不做 rename
+5. 可先做目標 path 存在性檢查，提早提供 UX warning；但這不是最終保證
+6. `backend.rename(from, to)` 的成功 / 失敗才是最終權威，不能只依賴前置檢查
+7. 若 rename 失敗（包含衝突、權限、case-only rename 正規化差異、backend 拒絕），將 backend error 映射為 inline warning
+8. 成功後要做**跨所有引用**的 migration：
+   - 更新所有引用同一 `source + oldFilePath` 的 pane content
+   - 搬移 shared buffer key（保留 `modelId`）
+   - 保留既有 pane-local view state
+
+rename 不得只更新單一 pane，否則 split / duplicate view 會殘留舊路徑。
+
+### 4.6 WYSIWYG 佈局修正
+
+`TiptapEditor` 改為明確的兩層結構：
+
+- 外層：`h-full min-h-0 overflow-auto`
+- 內層 editable root：承接 `prose` 樣式、padding、focus outline 控制、最小高度
+
+重點是把 typography 樣式掛到 editable root，而不是 scroll 容器本身，避免容器尺寸與內容尺寸彼此污染。
+
+另外，WYSIWYG 也有自己的 pane-local runtime state 問題。這次至少要保證：
+
+- tab 切換回來後，不會因 remount 直接回到 raw 模式
+- WYSIWYG 模式本身仍可繼續編輯與捲動
+
+Tiptap 的 selection / undo history 若無法在本輪以低風險方式完整保留，需在 plan 與驗收條件中明講，避免規格承諾過頭。
+
+---
+
+## 5. Phase / PR 切分
+
+| Phase | 範圍 | 尺寸 | 依賴 |
+|---|---|---|---|
+| Phase 1 | shared buffer lifetime、pane-local UI state、Monaco model/view-state foundation、相關測試 | 中 | 無 |
+| Phase 2 | toolbar breadcrumbs | 小 | Phase 1 |
+| Phase 3 | inline rename、衝突 / 非法名稱 warning、跨引用 migration、相關測試 | 中 | Phase 1 |
+| Phase 4 | Tiptap/WYSIWYG container 與 scroll 修正、相關測試 | 小 | Phase 1 |
+
+說明：breadcrumbs 與 rename 拆開，避免單一 PR 同時混入純 UI 與 state migration 邏輯。
+
+---
+
+## 6. 測試策略
+
+### 6.1 `EditorPane.test.tsx`
+
+至少新增以下案例：
+
+1. tab 切換造成 unmount/remount 後，buffer 與 pane-local UI state 不丟失
+2. 同一檔案在兩個 pane 同時開啟時，mode / diff / cursor / scroll 不互相污染
+3. 切回 tab 後仍保留 cursor / mode / diff state
+4. toolbar 顯示完整 breadcrumbs
+5. rename 成功後會更新所有相關 pane path，並保留 shared buffer
+6. rename 目標已存在或 backend 拒絕時顯示 warning，且不覆蓋目標檔
+
+### 6.2 `useEditorStore.test.ts`
+
+至少新增：
+
+1. shared buffer 與 pane-local state 的讀寫邊界
+2. buffer rename / key migration
+3. conditional close 行為
+4. 多 pane 引用同一檔案時的 migration 正確性
+
+### 6.3 WYSIWYG 測試
+
+若 jsdom 無法可靠驗證真實 scroll 行為，至少測：
+
+1. `TiptapEditor` render 出正確的容器 class / 結構
+2. editable root 帶有預期 class
+3. 不再把 `prose` 直接掛在 scroll 容器
+4. tab remount 後仍停留在 WYSIWYG 模式
+
+---
+
+## 7. 驗收條件
+
+- [ ] keepAlive = 0 時，切換 editor tab 再切回，不會丟失 shared buffer 與 pane-local runtime state
+- [ ] 同一檔案在不同 pane 的 mode / diff / cursor / scroll 互不污染
+- [ ] top bar 顯示完整路徑 breadcrumbs
+- [ ] 雙擊檔名可 rename，撞名時只警告不覆蓋
+- [ ] WYSIWYG 模式容器不再外溢，且可在 pane 內正常捲動
+- [ ] `pnpm --prefix spa exec vitest run` 相關測試綠
+- [ ] `pnpm --prefix spa run lint` 綠
+- [ ] `pnpm --prefix spa run build` 綠
+
+---
+
+## 8. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| buffer 改成延後清理後，可能殘留無引用 editor state | 中 | close 時掃描 `useTabStore` 實際引用；測試覆蓋「仍有 tab 引用」與「最後一個引用移除」 |
+| 把 pane-local state 錯綁到 shared buffer，導致 split 視圖互相污染 | 高 | `pane.id` 與 buffer key 分層；加入同檔多 pane 測試 |
+| Monaco model 保留若 key 設計錯誤，可能造成不同檔案共用 state | 中 | model identity 必須綁定 shared buffer 的穩定 `modelId`；加入不同 filePath 不共享的測試 |
+| rename 後 buffer / pane path 不同步，造成 save 寫回舊路徑 | 高 | rename 成功後以單一 migration 更新所有引用 pane 與 shared buffer key；測試覆蓋多 pane 引用 |
+| jsdom 難完整重現 Tiptap scroll 問題 | 高 | 自動化測試只驗證 DOM 結構與 class，最終以手動 smoke 驗證補足 |

--- a/docs/specs/2026-04-22-editor-state-toolbar-wysiwyg-plan.md
+++ b/docs/specs/2026-04-22-editor-state-toolbar-wysiwyg-plan.md
@@ -1,0 +1,244 @@
+# Editor State / Toolbar / WYSIWYG 修正 Implementation Plan
+
+> 日期：2026-04-22
+> 狀態：Draft v2（post plan-review）
+> 主 spec：`2026-04-22-editor-state-toolbar-wysiwyg-design.md`
+> 範圍：純 SPA（editor module / tab store / tests）
+> 參考：
+> - Codex plan 審查：thread `019db16a-e715-72f1-b284-a5b5411b1126`（2026-04-22）
+
+---
+
+## 1. 範圍
+
+本計畫只處理 editor module 的四個使用者問題：
+
+1. tab 切換後 editor runtime state 遺失
+2. top bar 缺 breadcrumbs
+3. top bar 缺 inline rename 與撞名保護
+4. WYSIWYG 容器與捲動異常
+
+不改 daemon / Electron API，不改檔案 backend contract；rename 仍使用既有 `FsBackend.rename()`。
+
+---
+
+## 2. 檔案清單
+
+### 修改
+
+- `spa/src/stores/useEditorStore.ts`
+  - 分離 shared buffer state 與 pane-local view state
+  - 加入 shared buffer rename / conditional close / Monaco view state 保存 API
+- `spa/src/stores/useEditorStore.test.ts`
+  - 覆蓋 shared vs pane-local 邊界、rename migration、conditional close
+- `spa/src/components/editor/EditorPane.tsx`
+  - 移除 local `editorMode` / `showDiff`
+  - 接上 pane-local state
+  - unmount 時改為 conditional close
+  - 接上 rename 流程與 warning
+- `spa/src/components/editor/__tests__/EditorPane.test.tsx`
+  - 補 tab 切換 state 保留、breadcrumbs、rename success / conflict
+- `spa/src/components/editor/MonacoWrapper.tsx`
+  - 對 shared buffer 使用穩定 `modelId`
+  - 對 pane 儲存 / 還原 view state
+- `spa/src/components/editor/MonacoWrapper.test.tsx`
+  - 驗證 `modelId`、view-state save / restore wiring
+- `spa/src/components/editor/EditorToolbar.tsx`
+  - 顯示 breadcrumbs
+  - 支援雙擊最後一段檔名進入 rename
+  - 顯示 inline warning
+- `spa/src/components/editor/TiptapEditor.tsx`
+  - 調整 scroll 容器與 editable root 結構
+- `spa/src/stores/useTabStore.ts`
+  - 新增 editor path migration helper，將同一 `source + oldPath` 的所有 pane 一次更新到 `newPath`
+- `spa/src/stores/useTabStore.test.ts`
+  - 覆蓋多 tab / split pane 的 editor path migration
+
+### 新增
+
+- `spa/src/components/editor/TiptapEditor.test.tsx`
+  - 驗證 WYSIWYG 容器 class / editable root 結構
+
+---
+
+## 3. 設計映射
+
+### 3.1 Shared buffer state（key = `source + filePath`）
+
+保留在 `buffers`：
+
+- `content`
+- `savedContent`
+- `isDirty`
+- `language`
+- `lastStat`
+- `modelId`
+
+### 3.2 Pane-local view state（key = `pane.id`）
+
+新增 `views`：
+
+- `editorMode`
+- `showDiff`
+- `cursorPosition`
+- `monacoViewState`
+- `renameDraft` / `renameWarning` 不進 store，維持 `EditorPane` local state 即可
+
+原則：view state 是 pane 自己的，不與其他同檔 pane 共用。
+
+### 3.3 Rename migration 邊界
+
+rename 成功後要同時更新兩層：
+
+1. `useTabStore`：所有引用該 editor content 的 pane path 一次改成新 path
+2. `useEditorStore`：shared buffer key 搬移到新 key，但保留 `modelId`
+
+pane-local view state 維持以 `pane.id` 為 key，不搬動。
+
+---
+
+## 4. Test Case Matrix
+
+### 4.1 `useEditorStore.test.ts`
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Shared buffer | openBuffer 會建立 shared buffer，含穩定 `modelId` | 通過 |
+| Shared buffer | updateContent 只改 shared buffer，不影響 pane-local state | 通過 |
+| Pane-local | 同一檔案兩個 pane 的 `editorMode` / `showDiff` 互不污染 | 通過 |
+| Pane-local | `updateCursor` 僅更新指定 pane | 通過 |
+| Close | 仍有 pane 引用時不 close buffer | 通過 |
+| Close | 最後一個引用移除時才 close buffer | 通過 |
+
+### 4.1b `MonacoWrapper.test.tsx`
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Model identity | 以 shared buffer 的 `modelId` 當作 path / identity 傳給 Monaco | 通過 |
+| View state | mount 時會 restore 指定 `pane.id` 的 view state | 通過 |
+| View state | unmount 或切換前會保存目前 pane 的 view state | 通過 |
+
+### 4.2 `useTabStore.test.ts`
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Migration | 單 tab 單 pane editor path 會更新 | 通過 |
+| Migration | split pane 中所有 matching editor path 都更新 | 通過 |
+| Migration | 不同 source 或不同 path 的 editor pane 不受影響 | 通過 |
+
+### 4.3 `EditorPane.test.tsx`
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| State retention | tab 切換造成 unmount/remount 後，shared buffer 保留 | 通過 |
+| State retention | remount 後仍使用既有 pane-local `editorMode` / `showDiff` | 通過 |
+| Isolation | 同一檔案兩個 pane 同時開啟時，pane-local state 不互相污染 | 通過 |
+| Toolbar | 顯示完整 breadcrumbs | 通過 |
+| Rename | 雙擊檔名進入 rename mode | 通過 |
+| Rename | 空字串、`.`、`..`、含 path separator 的 basename 會顯示 warning，且不送出 rename | 通過 |
+| Rename | rename 成功後呼叫 backend.rename，更新所有 matching pane path，shared buffer 保留 | 通過 |
+| Rename | target 已存在時顯示 warning，且不覆蓋 | 通過 |
+| Rename | backend.rename 失敗時顯示 warning，且保留舊 path | 通過 |
+
+### 4.4 `TiptapEditor.test.tsx`
+
+| 類別 | 測試項 | 預期 |
+|---|---|---|
+| Layout | scroll 容器具有 `h-full min-h-0 overflow-auto` | 通過 |
+| Layout | editable root 承接 typography class，不是外層容器 | 通過 |
+| Integration | render 結構存在，不因 class 調整破壞 `EditorContent` 掛載 | 通過 |
+
+---
+
+## 5. 實作順序（TDD）
+
+### Phase 1: Runtime state foundation
+
+**目標**：先修 tab 切換 state 遺失的根因。
+
+1. 寫 `useEditorStore.test.ts` failing cases：shared vs pane-local state、conditional close
+2. 寫 `EditorPane.test.tsx` failing case：模擬 tab 切換 unmount/remount 後 state 保留
+3. 寫 `MonacoWrapper.test.tsx` failing cases：`modelId` 與 view-state save / restore wiring
+4. 實作 `useEditorStore` 新 state shape 與 API
+5. 實作 `EditorPane` 改讀 pane-local state，移除 local `editorMode` / `showDiff`
+6. 實作 `MonacoWrapper` 的 `modelId` + view-state save/restore
+7. 跑：
+   - `pnpm --prefix spa exec vitest run src/stores/useEditorStore.test.ts`
+   - `pnpm --prefix spa exec vitest run src/components/editor/MonacoWrapper.test.tsx`
+   - `pnpm --prefix spa exec vitest run src/components/editor/__tests__/EditorPane.test.tsx`
+
+### Phase 2: Breadcrumbs
+
+**目標**：先把純 UI 的完整路徑顯示獨立完成。
+
+1. 在 `EditorPane.test.tsx` 新增 breadcrumbs failing test
+2. 修改 `EditorToolbar.tsx` render 完整路徑 breadcrumbs
+3. 跑：
+   - `pnpm --prefix spa exec vitest run src/components/editor/__tests__/EditorPane.test.tsx`
+
+### Phase 3: Inline rename + migration
+
+**目標**：完成 rename UX 與跨引用 migration。
+
+1. 在 `useTabStore.test.ts` 新增 editor path migration failing tests
+2. 在 `useEditorStore.test.ts` 新增 `renameBuffer()` failing tests
+3. 在 `EditorPane.test.tsx` 新增非法 basename / rename success / conflict / backend failure tests
+4. 實作 `useTabStore` editor path migration helper
+5. 實作 `EditorToolbar` rename UI
+6. 實作 `EditorPane` rename flow：basename 驗證、preflight stat、backend.rename、error mapping
+7. 實作 `useEditorStore.renameBuffer()` 與成功 rename 後的 shared buffer 搬移
+8. 跑：
+   - `pnpm --prefix spa exec vitest run src/stores/useEditorStore.test.ts`
+   - `pnpm --prefix spa exec vitest run src/stores/useTabStore.test.ts src/stores/useTabStore.migration.test.ts`
+   - `pnpm --prefix spa exec vitest run src/components/editor/__tests__/EditorPane.test.tsx`
+
+### Phase 4: WYSIWYG container / scroll
+
+**目標**：修正 Tiptap 容器與可捲動區域。
+
+1. 新增 `TiptapEditor.test.tsx` failing tests
+2. 調整 `TiptapEditor.tsx` 容器結構與 class 掛載位置
+3. 跑：
+   - `pnpm --prefix spa exec vitest run src/components/editor/TiptapEditor.test.tsx`
+
+### Final verification
+
+1. `pnpm --prefix spa exec vitest run src/stores/useEditorStore.test.ts src/stores/useTabStore.test.ts src/stores/useTabStore.migration.test.ts src/components/editor/MonacoWrapper.test.tsx src/components/editor/__tests__/EditorPane.test.tsx src/components/editor/TiptapEditor.test.tsx`
+2. `pnpm --prefix spa run lint`
+3. `pnpm --prefix spa run build`
+
+---
+
+## 6. 驗收條件
+
+- [ ] keepAlive = 0 時，切換 editor tab 後再回來，shared buffer 與 pane-local runtime state 保留
+- [ ] 同一檔案在不同 pane 的 view state 不互相污染
+- [ ] toolbar 顯示完整 breadcrumbs
+- [ ] 雙擊最後一段檔名可 rename
+- [ ] rename target 已存在或 backend 拒絕時，只顯示 warning，不覆蓋目標檔
+- [ ] rename 成功後，所有 matching pane 轉到新 path，且 shared buffer 不丟失
+- [ ] WYSIWYG 容器不再外溢，pane 內可正常捲動
+- [ ] `vitest`、`lint`、`build` 全綠
+
+---
+
+## 7. 風險
+
+| 風險 | 發生可能 | 緩解 |
+|---|---|---|
+| `useEditorStore` state shape 變更導致既有測試或呼叫點壞掉 | 中 | 先寫 store tests，再逐步替換 `EditorPane` / `MonacoWrapper` 呼叫 |
+| Monaco view-state 在 jsdom 難完整驗證 | 中 | 單元測試以 store API 與 prop wiring 為主；最後 build 前做實機 smoke |
+| rename migration 若只更新 active pane，會留下 stale path | 高 | `useTabStore` 提供全域 migration helper，禁止在 component 內逐一手動 patch |
+| WYSIWYG 問題若包含 Tiptap selection/undo persistence，可能超出本輪最小修復範圍 | 中 | 本輪先明確驗收「容器與捲動修正」；若 selection history 仍不穩，另開 follow-up |
+
+---
+
+## 8. Commit 規劃
+
+每個 phase 一個 commit，維持可獨立 review：
+
+1. `docs: add editor state toolbar wysiwyg spec and plan`
+2. `fix(spa): preserve editor runtime state across tab switches`
+3. `fix(spa): restore editor breadcrumbs in toolbar`
+4. `fix(spa): add inline editor rename with conflict guard`
+5. `fix(spa): fix wysiwyg editor container scrolling`

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -2,11 +2,13 @@
 import { lazy, Suspense, useEffect, useCallback, useState } from 'react'
 import type { PaneRendererProps } from '../../lib/module-registry'
 import { useEditorStore } from '../../stores/useEditorStore'
+import { useTabStore } from '../../stores/useTabStore'
 import { getFsBackend } from '../../lib/fs-backend'
 import { MonacoWrapper } from './MonacoWrapper'
 import { DiffView } from './DiffView'
 import { EditorToolbar } from './EditorToolbar'
 import { EditorStatusBar } from './EditorStatusBar'
+import { findPane } from '../../lib/pane-tree'
 import type { FileSource } from '../../types/fs'
 
 const TiptapEditor = lazy(() =>
@@ -30,19 +32,59 @@ function detectLanguage(filePath: string): string {
   return map[ext] ?? 'plaintext'
 }
 
+function fileName(filePath: string): string {
+  return filePath.split('/').pop() ?? filePath
+}
+
+function siblingPath(filePath: string, nextBaseName: string): string {
+  const separatorIndex = filePath.lastIndexOf('/')
+  return separatorIndex === -1 ? nextBaseName : `${filePath.slice(0, separatorIndex)}/${nextBaseName}`
+}
+
+function isInvalidRename(name: string): boolean {
+  const trimmed = name.trim()
+  return trimmed === '' || trimmed === '.' || trimmed === '..' || trimmed.includes('/') || trimmed.includes('\\')
+}
+
+function isCaseOnlyRename(oldPath: string, nextPath: string): boolean {
+  return oldPath !== nextPath && oldPath.toLowerCase() === nextPath.toLowerCase()
+}
+
+function renameWarningMessage(error: unknown): string {
+  if (error instanceof Error) {
+    if (/exist/i.test(error.message)) return 'File already exists'
+    return error.message || 'Rename failed'
+  }
+  return 'Rename failed'
+}
+
 // Outer component does kind guard to avoid hooks-after-early-return
 export function EditorPane({ pane, isActive }: PaneRendererProps) {
   const content = pane.content
   if (content.kind !== 'editor') return null
-  return <EditorPaneInner source={content.source} filePath={content.filePath} isActive={isActive} />
+  return <EditorPaneInner paneId={pane.id} source={content.source} filePath={content.filePath} isActive={isActive} />
 }
 
-function EditorPaneInner({ source, filePath, isActive }: { source: FileSource; filePath: string; isActive: boolean }) {
+function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: string; source: FileSource; filePath: string; isActive: boolean }) {
   const key = bufferKey(source, filePath)
   const buffer = useEditorStore((s) => s.buffers[key])
+  const paneState = useEditorStore((s) => s.paneStates[paneId])
   const isMarkdown = filePath.endsWith('.md') || filePath.endsWith('.mdx')
-  const [editorMode, setEditorMode] = useState<'raw' | 'wysiwyg'>('raw')
-  const [showDiff, setShowDiff] = useState(false)
+  const editorMode = paneState?.editorMode ?? 'raw'
+  const showDiff = paneState?.showDiff ?? false
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [renameDraft, setRenameDraft] = useState('')
+  const [renameWarning, setRenameWarning] = useState<string>()
+
+  useEffect(() => {
+    useEditorStore.getState().attachPane(paneId, key)
+  }, [paneId, key])
+
+  useEffect(() => {
+    setIsRenaming(false)
+    setRenameDraft('')
+    setRenameWarning(undefined)
+  }, [filePath])
 
   // Load file on mount, cleanup buffer on unmount
   useEffect(() => {
@@ -70,10 +112,15 @@ function EditorPaneInner({ source, filePath, isActive }: { source: FileSource; f
     return () => { stale = true }
   }, [key, source, filePath])
 
-  // Cleanup buffer on unmount
+  // Cleanup pane state only when the pane is truly gone, not just hidden by tab switching.
   useEffect(() => {
-    return () => { useEditorStore.getState().closeBuffer(key) }
-  }, [key])
+    return () => {
+      const paneStillExists = Object.values(useTabStore.getState().tabs).some((tab) => findPane(tab.layout, paneId))
+      if (!paneStillExists) {
+        useEditorStore.getState().closePane(paneId)
+      }
+    }
+  }, [paneId])
 
   // Detect external file changes when tab becomes active
   useEffect(() => {
@@ -117,11 +164,51 @@ function EditorPaneInner({ source, filePath, isActive }: { source: FileSource; f
       await backend.write(filePath, encoded)
       const newStat = await backend.stat(filePath)
       useEditorStore.getState().markSaved(key, { mtime: newStat.mtime, size: newStat.size })
-      setShowDiff(false)
+      useEditorStore.getState().setShowDiff(paneId, false)
     } catch (err) {
       console.error('[editor] Save failed:', err)
     }
-  }, [key, source, filePath])
+  }, [filePath, key, paneId, source])
+
+  const handleRenameSubmit = useCallback(async () => {
+    const backend = getFsBackend(source)
+    if (!backend) return
+
+    const nextName = renameDraft.trim()
+    if (isInvalidRename(nextName)) {
+      setRenameWarning('Invalid file name')
+      return
+    }
+
+    if (nextName === fileName(filePath)) {
+      setIsRenaming(false)
+      setRenameDraft('')
+      setRenameWarning(undefined)
+      return
+    }
+
+    const nextPath = siblingPath(filePath, nextName)
+    if (!isCaseOnlyRename(filePath, nextPath)) {
+      try {
+        await backend.stat(nextPath)
+        setRenameWarning('File already exists')
+        return
+      } catch {
+        // Missing target is expected.
+      }
+    }
+
+    try {
+      await backend.rename(filePath, nextPath)
+      useTabStore.getState().renameEditorPanes(source, filePath, nextPath)
+      useEditorStore.getState().renameBuffer(key, bufferKey(source, nextPath))
+      setIsRenaming(false)
+      setRenameDraft('')
+      setRenameWarning(undefined)
+    } catch (error) {
+      setRenameWarning(renameWarningMessage(error))
+    }
+  }, [filePath, key, renameDraft, source])
 
   if (!buffer) {
     return <div className="flex-1 flex items-center justify-center text-text-muted text-xs">Loading...</div>
@@ -135,9 +222,29 @@ function EditorPaneInner({ source, filePath, isActive }: { source: FileSource; f
         isMarkdown={isMarkdown}
         editorMode={editorMode}
         showDiff={showDiff}
+        isRenaming={isRenaming}
+        renameValue={renameDraft}
+        renameWarning={renameWarning}
         onSave={handleSave}
-        onToggleMode={isMarkdown ? () => setEditorMode((m) => (m === 'raw' ? 'wysiwyg' : 'raw')) : undefined}
-        onDiff={() => setShowDiff((d) => !d)}
+        onToggleMode={isMarkdown ? () => useEditorStore.getState().setEditorMode(paneId, editorMode === 'raw' ? 'wysiwyg' : 'raw') : undefined}
+        onDiff={() => useEditorStore.getState().setShowDiff(paneId, !showDiff)}
+        onRenameStart={() => {
+          setIsRenaming(true)
+          setRenameDraft(fileName(filePath))
+          setRenameWarning(undefined)
+        }}
+        onRenameChange={(value) => {
+          setRenameDraft(value)
+          if (renameWarning) setRenameWarning(undefined)
+        }}
+        onRenameSubmit={() => {
+          void handleRenameSubmit()
+        }}
+        onRenameCancel={() => {
+          setIsRenaming(false)
+          setRenameDraft('')
+          setRenameWarning(undefined)
+        }}
       />
       <div className="flex-1 min-h-0 overflow-hidden">
         {showDiff ? (
@@ -150,8 +257,11 @@ function EditorPaneInner({ source, filePath, isActive }: { source: FileSource; f
           <MonacoWrapper
             content={buffer.content}
             language={buffer.language}
+            modelId={buffer.modelId}
+            initialViewState={paneState?.monacoViewState ?? null}
             onChange={(value) => useEditorStore.getState().updateContent(key, value)}
-            onCursorChange={(line, col) => useEditorStore.getState().updateCursor(key, line, col)}
+            onCursorChange={(line, col) => useEditorStore.getState().updateCursor(paneId, line, col)}
+            onViewStateChange={(viewState) => useEditorStore.getState().saveMonacoViewState(paneId, viewState)}
             onSave={handleSave}
           />
         ) : (
@@ -166,8 +276,8 @@ function EditorPaneInner({ source, filePath, isActive }: { source: FileSource; f
       </div>
       <EditorStatusBar
         language={buffer.language}
-        line={buffer.cursorPosition.line}
-        column={buffer.cursorPosition.column}
+        line={paneState?.cursorPosition.line ?? 1}
+        column={paneState?.cursorPosition.column ?? 1}
       />
     </div>
   )

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -58,6 +58,18 @@ function renameWarningMessage(error: unknown): string {
   return 'Rename failed'
 }
 
+function sameSource(a: FileSource, b: FileSource): boolean {
+  if (a.type !== b.type) return false
+  if (a.type === 'daemon' && b.type === 'daemon') {
+    return a.hostId === b.hostId
+  }
+  return true
+}
+
+function sourceIdentity(source: FileSource): string {
+  return source.type === 'daemon' ? `daemon:${source.hostId}` : source.type
+}
+
 // Outer component does kind guard to avoid hooks-after-early-return
 export function EditorPane({ pane, isActive }: PaneRendererProps) {
   const content = pane.content
@@ -67,6 +79,7 @@ export function EditorPane({ pane, isActive }: PaneRendererProps) {
 
 function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: string; source: FileSource; filePath: string; isActive: boolean }) {
   const key = bufferKey(source, filePath)
+  const sourceId = sourceIdentity(source)
   const buffer = useEditorStore((s) => s.buffers[key])
   const paneState = useEditorStore((s) => s.paneStates[paneId])
   const isMarkdown = filePath.endsWith('.md') || filePath.endsWith('.mdx')
@@ -75,6 +88,14 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
   const [isRenaming, setIsRenaming] = useState(false)
   const [renameDraft, setRenameDraft] = useState('')
   const [renameWarning, setRenameWarning] = useState<string>()
+
+  const handleCursorChange = useCallback((line: number, column: number) => {
+    useEditorStore.getState().updateCursor(paneId, line, column)
+  }, [paneId])
+
+  const handleViewStateChange = useCallback((viewState: import('monaco-editor').editor.ICodeEditorViewState | null) => {
+    useEditorStore.getState().saveMonacoViewState(paneId, viewState)
+  }, [paneId])
 
   useEffect(() => {
     useEditorStore.getState().attachPane(paneId, key)
@@ -110,17 +131,22 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
       })
 
     return () => { stale = true }
-  }, [key, source, filePath])
+  }, [filePath, key, sourceId])
 
   // Cleanup pane state only when the pane is truly gone, not just hidden by tab switching.
   useEffect(() => {
     return () => {
-      const paneStillExists = Object.values(useTabStore.getState().tabs).some((tab) => findPane(tab.layout, paneId))
-      if (!paneStillExists) {
-        useEditorStore.getState().closePane(paneId)
+      const currentPane = Object.values(useTabStore.getState().tabs)
+        .map((tab) => findPane(tab.layout, paneId))
+        .find(Boolean)
+      const stillSameEditor = currentPane?.content.kind === 'editor' &&
+        currentPane.content.filePath === filePath &&
+        sameSource(currentPane.content.source, source)
+      if (!stillSameEditor) {
+        useEditorStore.getState().closePane(paneId, key)
       }
     }
-  }, [paneId])
+  }, [filePath, key, paneId, sourceId])
 
   // Detect external file changes when tab becomes active
   useEffect(() => {
@@ -188,6 +214,12 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
     }
 
     const nextPath = siblingPath(filePath, nextName)
+    const nextKey = bufferKey(source, nextPath)
+    if (nextKey !== key && useEditorStore.getState().buffers[nextKey]) {
+      setRenameWarning('File already exists')
+      return
+    }
+
     if (!isCaseOnlyRename(filePath, nextPath)) {
       try {
         await backend.stat(nextPath)
@@ -201,7 +233,7 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
     try {
       await backend.rename(filePath, nextPath)
       useTabStore.getState().renameEditorPanes(source, filePath, nextPath)
-      useEditorStore.getState().renameBuffer(key, bufferKey(source, nextPath))
+      useEditorStore.getState().renameBuffer(key, nextKey, detectLanguage(nextPath))
       setIsRenaming(false)
       setRenameDraft('')
       setRenameWarning(undefined)
@@ -255,13 +287,14 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
           />
         ) : editorMode === 'raw' ? (
           <MonacoWrapper
+            key={buffer.modelId}
             content={buffer.content}
             language={buffer.language}
             modelId={buffer.modelId}
             initialViewState={paneState?.monacoViewState ?? null}
             onChange={(value) => useEditorStore.getState().updateContent(key, value)}
-            onCursorChange={(line, col) => useEditorStore.getState().updateCursor(paneId, line, col)}
-            onViewStateChange={(viewState) => useEditorStore.getState().saveMonacoViewState(paneId, viewState)}
+            onCursorChange={handleCursorChange}
+            onViewStateChange={handleViewStateChange}
             onSave={handleSave}
           />
         ) : (

--- a/spa/src/components/editor/EditorToolbar.tsx
+++ b/spa/src/components/editor/EditorToolbar.tsx
@@ -6,21 +6,71 @@ interface Props {
   isMarkdown: boolean
   editorMode: 'raw' | 'wysiwyg'
   showDiff?: boolean
+  isRenaming?: boolean
+  renameValue?: string
+  renameWarning?: string
   onSave: () => void
   onToggleMode?: () => void
   onDiff?: () => void
+  onRenameStart?: () => void
+  onRenameChange?: (value: string) => void
+  onRenameSubmit?: () => void
+  onRenameCancel?: () => void
 }
 
-export function EditorToolbar({ filePath, isDirty, isMarkdown, editorMode, showDiff, onSave, onToggleMode, onDiff }: Props) {
-  const fileName = filePath.split('/').pop() ?? filePath
+export function EditorToolbar({ filePath, isDirty, isMarkdown, editorMode, showDiff, isRenaming = false, renameValue = '', renameWarning, onSave, onToggleMode, onDiff, onRenameStart, onRenameChange, onRenameSubmit, onRenameCancel }: Props) {
+  const segments = filePath.split('/').filter(Boolean)
 
   return (
-    <div className="flex items-center justify-between px-3 py-1 border-b border-border-subtle bg-surface-secondary">
-      <div className="flex items-center gap-2 text-xs text-text-secondary truncate">
-        <span className="truncate" title={filePath}>{fileName}</span>
-        {isDirty && <span className="text-accent-base" title="Unsaved changes">●</span>}
+    <div className="flex items-start justify-between gap-3 px-3 py-1 border-b border-border-subtle bg-surface-secondary">
+      <div className="min-w-0 flex flex-col gap-1 text-xs text-text-secondary">
+        <div className="min-w-0 flex items-center gap-2">
+          <div className="min-w-0 flex items-center gap-1 overflow-hidden" title={filePath}>
+            {filePath.startsWith('/') && <span className="shrink-0 text-text-muted">/</span>}
+            {segments.map((segment, index) => {
+              const isLast = index === segments.length - 1
+              return (
+                <div key={`${segment}-${index}`} className="min-w-0 flex items-center gap-1">
+                  {index > 0 && <span className="shrink-0 text-text-muted">/</span>}
+                  {isLast && isRenaming ? (
+                    <input
+                      autoFocus
+                      value={renameValue}
+                      onChange={(event) => onRenameChange?.(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          event.preventDefault()
+                          onRenameSubmit?.()
+                        }
+                        if (event.key === 'Escape') {
+                          event.preventDefault()
+                          onRenameCancel?.()
+                        }
+                      }}
+                      onBlur={() => onRenameCancel?.()}
+                      aria-label="Rename file"
+                      className="min-w-0 rounded border border-border-subtle bg-surface px-1.5 py-0.5 text-text-primary outline-none"
+                    />
+                  ) : isLast && onRenameStart ? (
+                    <button
+                      type="button"
+                      onDoubleClick={onRenameStart}
+                      className="truncate text-text-primary text-left"
+                    >
+                      {segment}
+                    </button>
+                  ) : (
+                    <span className={isLast ? 'truncate text-text-primary' : 'shrink-0'}>{segment}</span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+          {isDirty && <span className="text-accent-base" title="Unsaved changes">●</span>}
+        </div>
+        {renameWarning && <div role="alert" className="text-[10px] text-status-error">{renameWarning}</div>}
       </div>
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 pt-0.5">
         {isMarkdown && onToggleMode && (
           <button
             onClick={onToggleMode}

--- a/spa/src/components/editor/MonacoWrapper.test.tsx
+++ b/spa/src/components/editor/MonacoWrapper.test.tsx
@@ -68,4 +68,78 @@ describe('MonacoWrapper', () => {
 
     expect(onViewStateChange).toHaveBeenCalledWith({ scrollTop: 42 })
   })
+
+  it('does not save view state during a normal rerender', () => {
+    const firstOnViewStateChange = vi.fn()
+    const secondOnViewStateChange = vi.fn()
+    const { rerender, unmount } = render(
+      <MonacoWrapper
+        content="hello"
+        language="markdown"
+        modelId="model-1"
+        initialViewState={null}
+        onChange={() => {}}
+        onCursorChange={() => {}}
+        onViewStateChange={firstOnViewStateChange}
+        onSave={() => {}}
+      />,
+    )
+
+    rerender(
+      <MonacoWrapper
+        content="hello world"
+        language="markdown"
+        modelId="model-1"
+        initialViewState={null}
+        onChange={() => {}}
+        onCursorChange={() => {}}
+        onViewStateChange={secondOnViewStateChange}
+        onSave={() => {}}
+      />,
+    )
+
+    expect(firstOnViewStateChange).not.toHaveBeenCalled()
+    expect(secondOnViewStateChange).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(firstOnViewStateChange).not.toHaveBeenCalled()
+    expect(secondOnViewStateChange).toHaveBeenCalledWith({ scrollTop: 42 })
+  })
+
+  it('uses the latest onSave callback for Monaco save action', () => {
+    const firstOnSave = vi.fn()
+    const secondOnSave = vi.fn()
+    const { rerender } = render(
+      <MonacoWrapper
+        content="hello"
+        language="markdown"
+        modelId="model-1"
+        initialViewState={null}
+        onChange={() => {}}
+        onCursorChange={() => {}}
+        onViewStateChange={() => {}}
+        onSave={firstOnSave}
+      />,
+    )
+
+    rerender(
+      <MonacoWrapper
+        content="hello"
+        language="markdown"
+        modelId="model-1"
+        initialViewState={null}
+        onChange={() => {}}
+        onCursorChange={() => {}}
+        onViewStateChange={() => {}}
+        onSave={secondOnSave}
+      />,
+    )
+
+    const action = editorMock.addAction.mock.calls[0]?.[0] as { run: () => void }
+    action.run()
+
+    expect(firstOnSave).not.toHaveBeenCalled()
+    expect(secondOnSave).toHaveBeenCalledTimes(1)
+  })
 })

--- a/spa/src/components/editor/MonacoWrapper.test.tsx
+++ b/spa/src/components/editor/MonacoWrapper.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { editor } from 'monaco-editor'
+import { MonacoWrapper } from './MonacoWrapper'
+
+const editorPropsSpy = vi.hoisted(() => vi.fn())
+const editorMock = vi.hoisted(() => ({
+  addAction: vi.fn(),
+  onDidChangeCursorPosition: vi.fn(),
+  restoreViewState: vi.fn(),
+  saveViewState: vi.fn(() => ({ scrollTop: 42 })),
+}))
+
+vi.mock('@monaco-editor/react', () => ({
+  default: (props: Record<string, unknown>) => {
+    editorPropsSpy(props)
+    const onMount = props.onMount as ((editor: typeof editorMock, monaco: { KeyMod: { CtrlCmd: number }; KeyCode: { KeyS: number } }) => void) | undefined
+    onMount?.(editorMock, { KeyMod: { CtrlCmd: 1 }, KeyCode: { KeyS: 2 } })
+    return <div data-testid="monaco-editor" />
+  },
+}))
+
+describe('MonacoWrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('uses the provided modelId as Monaco path', () => {
+    render(
+      <MonacoWrapper
+        content="hello"
+        language="markdown"
+        modelId="model-1"
+        initialViewState={null}
+        onChange={() => {}}
+        onCursorChange={() => {}}
+        onViewStateChange={() => {}}
+        onSave={() => {}}
+      />,
+    )
+
+    expect(editorPropsSpy).toHaveBeenCalledWith(expect.objectContaining({ path: 'model-1' }))
+  })
+
+  it('restores and saves pane view state', () => {
+    const onViewStateChange = vi.fn()
+    const initialViewState = { scrollTop: 12 } as unknown as editor.ICodeEditorViewState
+    const { unmount } = render(
+      <MonacoWrapper
+        content="hello"
+        language="markdown"
+        modelId="model-1"
+        initialViewState={initialViewState}
+        onChange={() => {}}
+        onCursorChange={() => {}}
+        onViewStateChange={onViewStateChange}
+        onSave={() => {}}
+      />,
+    )
+
+    expect(editorMock.restoreViewState).toHaveBeenCalledWith(initialViewState)
+
+    unmount()
+
+    expect(onViewStateChange).toHaveBeenCalledWith({ scrollTop: 42 })
+  })
+})

--- a/spa/src/components/editor/MonacoWrapper.tsx
+++ b/spa/src/components/editor/MonacoWrapper.tsx
@@ -1,20 +1,26 @@
 import Editor, { type OnMount } from '@monaco-editor/react'
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import type { editor } from 'monaco-editor'
 
 interface Props {
   content: string
   language: string
+  modelId: string
+  initialViewState: editor.ICodeEditorViewState | null
   onChange: (value: string) => void
   onCursorChange: (line: number, column: number) => void
+  onViewStateChange: (viewState: editor.ICodeEditorViewState | null) => void
   onSave: () => void
 }
 
-export function MonacoWrapper({ content, language, onChange, onCursorChange, onSave }: Props) {
+export function MonacoWrapper({ content, language, modelId, initialViewState, onChange, onCursorChange, onViewStateChange, onSave }: Props) {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
 
   const handleMount: OnMount = useCallback((ed, monaco) => {
     editorRef.current = ed
+    if (initialViewState) {
+      ed.restoreViewState(initialViewState)
+    }
     ed.addAction({
       id: 'purdex-save',
       label: 'Save',
@@ -24,15 +30,24 @@ export function MonacoWrapper({ content, language, onChange, onCursorChange, onS
     ed.onDidChangeCursorPosition((e) => {
       onCursorChange(e.position.lineNumber, e.position.column)
     })
-  }, [onSave, onCursorChange])
+  }, [initialViewState, onSave, onCursorChange])
+
+  useEffect(() => {
+    return () => {
+      onViewStateChange(editorRef.current?.saveViewState() ?? null)
+      editorRef.current = null
+    }
+  }, [onViewStateChange])
 
   return (
     <Editor
+      path={modelId}
       value={content}
       language={language}
       theme="vs-dark"
       onChange={(value) => onChange(value ?? '')}
       onMount={handleMount}
+      keepCurrentModel={true}
       options={{
         minimap: { enabled: true },
         fontSize: 13,

--- a/spa/src/components/editor/MonacoWrapper.tsx
+++ b/spa/src/components/editor/MonacoWrapper.tsx
@@ -15,6 +15,16 @@ interface Props {
 
 export function MonacoWrapper({ content, language, modelId, initialViewState, onChange, onCursorChange, onViewStateChange, onSave }: Props) {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
+  const onSaveRef = useRef(onSave)
+  const onViewStateChangeRef = useRef(onViewStateChange)
+
+  useEffect(() => {
+    onSaveRef.current = onSave
+  }, [onSave])
+
+  useEffect(() => {
+    onViewStateChangeRef.current = onViewStateChange
+  }, [onViewStateChange])
 
   const handleMount: OnMount = useCallback((ed, monaco) => {
     editorRef.current = ed
@@ -25,19 +35,19 @@ export function MonacoWrapper({ content, language, modelId, initialViewState, on
       id: 'purdex-save',
       label: 'Save',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
-      run: () => onSave(),
+      run: () => onSaveRef.current(),
     })
     ed.onDidChangeCursorPosition((e) => {
       onCursorChange(e.position.lineNumber, e.position.column)
     })
-  }, [initialViewState, onSave, onCursorChange])
+  }, [initialViewState, onCursorChange])
 
   useEffect(() => {
     return () => {
-      onViewStateChange(editorRef.current?.saveViewState() ?? null)
+      onViewStateChangeRef.current(editorRef.current?.saveViewState() ?? null)
       editorRef.current = null
     }
-  }, [onViewStateChange])
+  }, [])
 
   return (
     <Editor

--- a/spa/src/components/editor/TiptapEditor.test.tsx
+++ b/spa/src/components/editor/TiptapEditor.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TiptapEditor } from './TiptapEditor'
+
+const useEditorSpy = vi.hoisted(() => vi.fn())
+const editorClassRef = vi.hoisted(() => ({ current: '' }))
+
+vi.mock('@tiptap/react', () => ({
+  useEditor: (config: { editorProps?: { attributes?: { class?: string } } }) => {
+    editorClassRef.current = config.editorProps?.attributes?.class ?? ''
+    return useEditorSpy(config)
+  },
+  EditorContent: () => <div data-testid="editor-content" data-editor-class={editorClassRef.current} />,
+}))
+
+vi.mock('@tiptap/starter-kit', () => ({
+  default: {},
+}))
+
+vi.mock('@tiptap/markdown', () => ({
+  Markdown: {},
+}))
+
+describe('TiptapEditor', () => {
+  beforeEach(() => {
+    useEditorSpy.mockReturnValue({
+      getMarkdown: () => 'hello',
+      commands: {
+        setContent: vi.fn(),
+      },
+    })
+  })
+
+  it('uses a dedicated scroll container instead of putting prose on it', () => {
+    render(<TiptapEditor content="# Hello" onChange={() => {}} onSave={() => {}} />)
+
+    const scrollRoot = screen.getByTestId('tiptap-scroll-root')
+    expect(scrollRoot.className).toContain('h-full')
+    expect(scrollRoot.className).toContain('min-h-0')
+    expect(scrollRoot.className).toContain('overflow-auto')
+    expect(scrollRoot.className).not.toContain('prose')
+  })
+
+  it('applies typography classes to the editable root', () => {
+    render(<TiptapEditor content="# Hello" onChange={() => {}} onSave={() => {}} />)
+
+    expect(screen.getByTestId('editor-content')).toHaveAttribute(
+      'data-editor-class',
+      expect.stringContaining('prose prose-invert prose-sm max-w-none'),
+    )
+  })
+})

--- a/spa/src/components/editor/TiptapEditor.test.tsx
+++ b/spa/src/components/editor/TiptapEditor.test.tsx
@@ -49,4 +49,17 @@ describe('TiptapEditor', () => {
       expect.stringContaining('prose prose-invert prose-sm max-w-none'),
     )
   })
+
+  it('keeps a visible focus style on the editable root', () => {
+    render(<TiptapEditor content="# Hello" onChange={() => {}} onSave={() => {}} />)
+
+    expect(screen.getByTestId('editor-content')).toHaveAttribute(
+      'data-editor-class',
+      expect.not.stringContaining('focus:outline-none'),
+    )
+    expect(screen.getByTestId('editor-content')).toHaveAttribute(
+      'data-editor-class',
+      expect.stringContaining('focus-visible:outline'),
+    )
+  })
 })

--- a/spa/src/components/editor/TiptapEditor.tsx
+++ b/spa/src/components/editor/TiptapEditor.tsx
@@ -29,6 +29,9 @@ export function TiptapEditor({ content, onChange, onSave }: Props) {
       onChange(md)
     },
     editorProps: {
+      attributes: {
+        class: 'prose prose-invert prose-sm max-w-none min-h-full px-4 py-4 focus:outline-none',
+      },
       handleKeyDown: (_view, event) => {
         if ((event.metaKey || event.ctrlKey) && event.key === 's') {
           event.preventDefault()
@@ -53,8 +56,10 @@ export function TiptapEditor({ content, onChange, onSave }: Props) {
   if (!editor) return null
 
   return (
-    <div className="flex-1 overflow-auto p-4 prose prose-invert prose-sm max-w-none">
-      <EditorContent editor={editor} />
+    <div data-testid="tiptap-scroll-root" className="h-full min-h-0 overflow-auto">
+      <div className="min-h-full">
+        <EditorContent editor={editor} />
+      </div>
     </div>
   )
 }

--- a/spa/src/components/editor/TiptapEditor.tsx
+++ b/spa/src/components/editor/TiptapEditor.tsx
@@ -30,7 +30,7 @@ export function TiptapEditor({ content, onChange, onSave }: Props) {
     },
     editorProps: {
       attributes: {
-        class: 'prose prose-invert prose-sm max-w-none min-h-full px-4 py-4 focus:outline-none',
+        class: 'tiptap-editor prose prose-invert prose-sm max-w-none min-h-full px-4 py-4 focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent-base',
       },
       handleKeyDown: (_view, event) => {
         if ((event.metaKey || event.ctrlKey) && event.key === 's') {
@@ -57,7 +57,7 @@ export function TiptapEditor({ content, onChange, onSave }: Props) {
 
   return (
     <div data-testid="tiptap-scroll-root" className="h-full min-h-0 overflow-auto">
-      <div className="min-h-full">
+      <div className="min-h-full [&_.tiptap-editor]:min-h-full [&_.tiptap-editor]:cursor-text">
         <EditorContent editor={editor} />
       </div>
     </div>

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { EditorPane } from '../EditorPane'
 import { useEditorStore } from '../../../stores/useEditorStore'
+import { useTabStore } from '../../../stores/useTabStore'
 import type { Pane } from '../../../types/tab'
 import type { FsBackend } from '../../../lib/fs-backend'
 
@@ -23,9 +24,9 @@ vi.mock('../EditorStatusBar', () => ({
   EditorStatusBar: () => <div data-testid="editor-status-bar" />,
 }))
 
-function createPane(filePath = '/notes/editor.md'): Pane {
+function createPane(filePath = '/notes/editor.md', paneId = 'pane-editor'): Pane {
   return {
-    id: 'pane-editor',
+    id: paneId,
     content: {
       kind: 'editor',
       source: { type: 'inapp' },
@@ -38,6 +39,7 @@ function createBackend(): FsBackend & {
   read: ReturnType<typeof vi.fn>
   write: ReturnType<typeof vi.fn>
   stat: ReturnType<typeof vi.fn>
+  rename: ReturnType<typeof vi.fn>
 } {
   return {
     id: 'test-backend',
@@ -50,6 +52,11 @@ function createBackend(): FsBackend & {
     mkdir: vi.fn(),
     delete: vi.fn(),
     rename: vi.fn(),
+  } as FsBackend & {
+    read: ReturnType<typeof vi.fn>
+    write: ReturnType<typeof vi.fn>
+    stat: ReturnType<typeof vi.fn>
+    rename: ReturnType<typeof vi.fn>
   }
 }
 
@@ -57,10 +64,61 @@ function getBufferKey(filePath: string): string {
   return `inapp:${filePath}`
 }
 
+function registerTabPane(pane: Pane, tabId = 'tab-1') {
+  useTabStore.setState({
+    tabs: {
+      [tabId]: {
+        id: tabId,
+        pinned: false,
+        locked: false,
+        createdAt: 1,
+        layout: { type: 'leaf', pane },
+      },
+    },
+    tabOrder: [tabId],
+    activeTabId: tabId,
+    visitHistory: [],
+  })
+}
+
 describe('EditorPane', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     useEditorStore.getState().clearAllBuffers()
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+  })
+
+  it('preserves pane-local editor state across unmount when the pane still exists in tabs', async () => {
+    const pane = createPane('/notes/keep-state.md')
+    const backend = createBackend()
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 11,
+      mtime: 123,
+    })
+    getFsBackendMock.mockReturnValue(backend)
+    registerTabPane(pane)
+
+    const { unmount } = render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/keep-state.md')]).toBeDefined()
+    })
+
+    act(() => {
+      useEditorStore.getState().setEditorMode(pane.id, 'wysiwyg')
+      useEditorStore.getState().setShowDiff(pane.id, true)
+    })
+
+    unmount()
+
+    expect(useEditorStore.getState().buffers[getBufferKey('/notes/keep-state.md')]).toBeDefined()
+    expect(useEditorStore.getState().paneStates[pane.id]).toMatchObject({
+      editorMode: 'wysiwyg',
+      showDiff: true,
+    })
   })
 
   it('loads the initial file content through FsBackend', async () => {
@@ -89,6 +147,161 @@ describe('EditorPane', () => {
     expect(screen.getByText('loaded.md')).toBeInTheDocument()
     expect(backend.read).toHaveBeenCalledWith('/notes/loaded.md')
     expect(backend.stat).toHaveBeenCalledWith('/notes/loaded.md')
+  })
+
+  it('shows the full file path as breadcrumbs in the toolbar', async () => {
+    const backend = createBackend()
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 11,
+      mtime: 123,
+    })
+    getFsBackendMock.mockReturnValue(backend)
+
+    render(<EditorPane pane={createPane('/notes/project/loaded.md')} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/project/loaded.md')]).toBeDefined()
+    })
+
+    expect(screen.getByText('notes')).toBeInTheDocument()
+    expect(screen.getByText('project')).toBeInTheDocument()
+    expect(screen.getByText('loaded.md')).toBeInTheDocument()
+  })
+
+  it('enters rename mode on double click and rejects invalid base names', async () => {
+    const pane = createPane('/notes/rename.md')
+    const backend = createBackend()
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 11,
+      mtime: 123,
+    })
+    getFsBackendMock.mockReturnValue(backend)
+    registerTabPane(pane)
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/rename.md')]).toBeDefined()
+    })
+
+    fireEvent.doubleClick(screen.getByText('rename.md'))
+    fireEvent.change(screen.getByDisplayValue('rename.md'), { target: { value: '..' } })
+    fireEvent.keyDown(screen.getByDisplayValue('..'), { key: 'Enter' })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid file name')
+    expect(backend.rename).not.toHaveBeenCalled()
+  })
+
+  it('warns when the rename target already exists', async () => {
+    const pane = createPane('/notes/rename.md')
+    const backend = createBackend()
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.stat
+      .mockResolvedValueOnce({
+        isFile: true,
+        isDirectory: false,
+        size: 11,
+        mtime: 123,
+      })
+      .mockResolvedValueOnce({
+        isFile: true,
+        isDirectory: false,
+        size: 20,
+        mtime: 456,
+      })
+    getFsBackendMock.mockReturnValue(backend)
+    registerTabPane(pane)
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/rename.md')]).toBeDefined()
+    })
+
+    fireEvent.doubleClick(screen.getByText('rename.md'))
+    fireEvent.change(screen.getByDisplayValue('rename.md'), { target: { value: 'taken.md' } })
+    fireEvent.keyDown(screen.getByDisplayValue('taken.md'), { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('File already exists')
+    })
+
+    expect(backend.rename).not.toHaveBeenCalled()
+  })
+
+  it('renames all matching panes and preserves the shared buffer', async () => {
+    const paneA = createPane('/notes/rename.md', 'pane-a')
+    const paneB = createPane('/notes/rename.md', 'pane-b')
+    const backend = createBackend()
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.rename.mockResolvedValue(undefined)
+    backend.stat
+      .mockResolvedValueOnce({
+        isFile: true,
+        isDirectory: false,
+        size: 11,
+        mtime: 123,
+      })
+      .mockResolvedValueOnce({
+        isFile: true,
+        isDirectory: false,
+        size: 11,
+        mtime: 123,
+      })
+      .mockRejectedValueOnce(new Error('not found'))
+    getFsBackendMock.mockReturnValue(backend)
+    useTabStore.setState({
+      tabs: {
+        'tab-a': {
+          id: 'tab-a',
+          pinned: false,
+          locked: false,
+          createdAt: 1,
+          layout: { type: 'leaf', pane: paneA },
+        },
+        'tab-b': {
+          id: 'tab-b',
+          pinned: false,
+          locked: false,
+          createdAt: 2,
+          layout: { type: 'leaf', pane: paneB },
+        },
+      },
+      tabOrder: ['tab-a', 'tab-b'],
+      activeTabId: 'tab-a',
+      visitHistory: [],
+    })
+
+    render(<EditorPane pane={paneA} isActive />)
+    render(<EditorPane pane={paneB} isActive={false} />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/rename.md')]).toBeDefined()
+    })
+
+    fireEvent.doubleClick(screen.getAllByText('rename.md')[0])
+    fireEvent.change(screen.getByDisplayValue('rename.md'), { target: { value: 'renamed.md' } })
+    fireEvent.keyDown(screen.getByDisplayValue('renamed.md'), { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(backend.rename).toHaveBeenCalledWith('/notes/rename.md', '/notes/renamed.md')
+    })
+
+    expect(useEditorStore.getState().buffers[getBufferKey('/notes/rename.md')]).toBeUndefined()
+    expect(useEditorStore.getState().buffers[getBufferKey('/notes/renamed.md')]).toBeDefined()
+
+    const tabPaths = Object.values(useTabStore.getState().tabs).map((tab) =>
+      tab.layout.type === 'leaf' && tab.layout.pane.content.kind === 'editor'
+        ? tab.layout.pane.content.filePath
+        : null,
+    )
+    expect(tabPaths).toEqual(['/notes/renamed.md', '/notes/renamed.md'])
   })
 
   it('saves dirty content and marks the buffer clean on success', async () => {

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -121,6 +121,89 @@ describe('EditorPane', () => {
     })
   })
 
+  it('cleans up pane state when the pane is reused for non-editor content', async () => {
+    const pane = createPane('/notes/reused.md')
+    const backend = createBackend()
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 11,
+      mtime: 123,
+    })
+    getFsBackendMock.mockReturnValue(backend)
+    registerTabPane(pane)
+
+    const { unmount } = render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/reused.md')]).toBeDefined()
+    })
+
+    useTabStore.setState({
+      tabs: {
+        'tab-1': {
+          id: 'tab-1',
+          pinned: false,
+          locked: false,
+          createdAt: 1,
+          layout: { type: 'leaf', pane: { id: pane.id, content: { kind: 'dashboard' } } },
+        },
+      },
+      tabOrder: ['tab-1'],
+      activeTabId: 'tab-1',
+      visitHistory: [],
+    })
+
+    unmount()
+
+    expect(useEditorStore.getState().paneStates[pane.id]).toBeUndefined()
+    expect(useEditorStore.getState().buffers[getBufferKey('/notes/reused.md')]).toBeUndefined()
+  })
+
+  it('re-reads a file when the same pane switches away and back', async () => {
+    const backend = createBackend()
+    backend.read
+      .mockResolvedValueOnce(new TextEncoder().encode('file a v1'))
+      .mockResolvedValueOnce(new TextEncoder().encode('file b v1'))
+      .mockResolvedValueOnce(new TextEncoder().encode('file a v2'))
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 11,
+      mtime: 123,
+    })
+    getFsBackendMock.mockReturnValue(backend)
+
+    const paneA = createPane('/notes/a.md', 'pane-switch')
+    const paneB = createPane('/notes/b.md', 'pane-switch')
+    registerTabPane(paneA)
+
+    const { rerender } = render(<EditorPane pane={paneA} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/a.md')]?.content).toBe('file a v1')
+    })
+
+    registerTabPane(paneB)
+    rerender(<EditorPane pane={paneB} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/b.md')]?.content).toBe('file b v1')
+    })
+
+    registerTabPane(paneA)
+    rerender(<EditorPane pane={paneA} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/a.md')]?.content).toBe('file a v2')
+    })
+
+    expect(backend.read).toHaveBeenNthCalledWith(1, '/notes/a.md')
+    expect(backend.read).toHaveBeenNthCalledWith(2, '/notes/b.md')
+    expect(backend.read).toHaveBeenNthCalledWith(3, '/notes/a.md')
+  })
+
   it('loads the initial file content through FsBackend', async () => {
     const backend = createBackend()
     backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
@@ -235,6 +318,40 @@ describe('EditorPane', () => {
     expect(backend.rename).not.toHaveBeenCalled()
   })
 
+  it('warns when the rename target is already open in memory', async () => {
+    const pane = createPane('/notes/source.md')
+    const backend = createBackend()
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.stat
+      .mockResolvedValueOnce({
+        isFile: true,
+        isDirectory: false,
+        size: 11,
+        mtime: 123,
+      })
+      .mockRejectedValueOnce(new Error('not found'))
+    getFsBackendMock.mockReturnValue(backend)
+    registerTabPane(pane)
+    useEditorStore.getState().openBuffer(getBufferKey('/notes/taken.md'), 'draft', 'markdown')
+    useEditorStore.getState().attachPane('pane-other', getBufferKey('/notes/taken.md'))
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/source.md')]).toBeDefined()
+    })
+
+    fireEvent.doubleClick(screen.getByText('source.md'))
+    fireEvent.change(screen.getByDisplayValue('source.md'), { target: { value: 'taken.md' } })
+    fireEvent.keyDown(screen.getByDisplayValue('taken.md'), { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('File already exists')
+    })
+
+    expect(backend.rename).not.toHaveBeenCalled()
+  })
+
   it('renames all matching panes and preserves the shared buffer', async () => {
     const paneA = createPane('/notes/rename.md', 'pane-a')
     const paneB = createPane('/notes/rename.md', 'pane-b')
@@ -302,6 +419,37 @@ describe('EditorPane', () => {
         : null,
     )
     expect(tabPaths).toEqual(['/notes/renamed.md', '/notes/renamed.md'])
+  })
+
+  it('updates buffer language when a rename changes the file extension', async () => {
+    const pane = createPane('/notes/example.ts')
+    const backend = createBackend()
+    backend.read.mockResolvedValue(new TextEncoder().encode('const a = 1'))
+    backend.rename.mockResolvedValue(undefined)
+    backend.stat
+      .mockResolvedValueOnce({
+        isFile: true,
+        isDirectory: false,
+        size: 11,
+        mtime: 123,
+      })
+      .mockRejectedValueOnce(new Error('not found'))
+    getFsBackendMock.mockReturnValue(backend)
+    registerTabPane(pane)
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/example.ts')]).toBeDefined()
+    })
+
+    fireEvent.doubleClick(screen.getByText('example.ts'))
+    fireEvent.change(screen.getByDisplayValue('example.ts'), { target: { value: 'example.md' } })
+    fireEvent.keyDown(screen.getByDisplayValue('example.md'), { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/example.md')]?.language).toBe('markdown')
+    })
   })
 
   it('saves dirty content and marks the buffer clean on success', async () => {
@@ -452,7 +600,6 @@ describe('EditorPane', () => {
 
   it('does not overwrite dirty content during active reload', async () => {
     const backend = createBackend()
-    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     backend.read
       .mockResolvedValueOnce(new TextEncoder().encode('hello world'))
       .mockResolvedValueOnce(new TextEncoder().encode('reloaded from disk'))
@@ -484,7 +631,7 @@ describe('EditorPane', () => {
     rerender(<EditorPane pane={createPane('/notes/dirty-reload.md')} isActive />)
 
     await waitFor(() => {
-      expect(consoleWarn).toHaveBeenCalledWith('[editor] External change detected for /notes/dirty-reload.md, buffer is dirty')
+      expect(backend.stat).toHaveBeenCalledTimes(2)
     })
 
     expect(useEditorStore.getState().buffers[getBufferKey('/notes/dirty-reload.md')]).toMatchObject({
@@ -493,7 +640,5 @@ describe('EditorPane', () => {
       isDirty: true,
       lastStat: { mtime: 123, size: 11 },
     })
-
-    consoleWarn.mockRestore()
   })
 })

--- a/spa/src/stores/useEditorStore.test.ts
+++ b/spa/src/stores/useEditorStore.test.ts
@@ -6,6 +6,58 @@ describe('useEditorStore', () => {
     useEditorStore.getState().clearAllBuffers()
   })
 
+  it('keeps shared buffer state separate from pane-local view state', () => {
+    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
+    useEditorStore.getState().attachPane('pane-a', 'key1')
+    useEditorStore.getState().attachPane('pane-b', 'key1')
+
+    useEditorStore.getState().setEditorMode('pane-a', 'wysiwyg')
+    useEditorStore.getState().setShowDiff('pane-a', true)
+    useEditorStore.getState().updateCursor('pane-a', 10, 5)
+
+    const state = useEditorStore.getState()
+    expect(state.buffers.key1?.content).toBe('hello')
+    expect(state.paneStates['pane-a']).toMatchObject({
+      bufferKey: 'key1',
+      editorMode: 'wysiwyg',
+      showDiff: true,
+      cursorPosition: { line: 10, column: 5 },
+    })
+    expect(state.paneStates['pane-b']).toMatchObject({
+      bufferKey: 'key1',
+      editorMode: 'raw',
+      showDiff: false,
+      cursorPosition: { line: 1, column: 1 },
+    })
+  })
+
+  it('only closes a shared buffer when the last pane detaches', () => {
+    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
+    useEditorStore.getState().attachPane('pane-a', 'key1')
+    useEditorStore.getState().attachPane('pane-b', 'key1')
+
+    useEditorStore.getState().closePane('pane-a')
+    expect(useEditorStore.getState().buffers['key1']).toBeDefined()
+
+    useEditorStore.getState().closePane('pane-b')
+    expect(useEditorStore.getState().buffers['key1']).toBeUndefined()
+  })
+
+  it('renames a shared buffer key and preserves model identity', () => {
+    useEditorStore.getState().openBuffer('old-key', 'hello', 'typescript')
+    useEditorStore.getState().attachPane('pane-a', 'old-key')
+
+    const modelId = useEditorStore.getState().buffers['old-key']?.modelId
+    useEditorStore.getState().renameBuffer('old-key', 'new-key')
+
+    expect(useEditorStore.getState().buffers['old-key']).toBeUndefined()
+    expect(useEditorStore.getState().buffers['new-key']).toMatchObject({
+      content: 'hello',
+      modelId,
+    })
+    expect(useEditorStore.getState().paneStates['pane-a']?.bufferKey).toBe('new-key')
+  })
+
   it('opens a buffer with content', () => {
     useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
     const buf = useEditorStore.getState().buffers['key1']
@@ -50,9 +102,10 @@ describe('useEditorStore', () => {
 
   it('updateCursor stores cursor position', () => {
     useEditorStore.getState().openBuffer('key1', '', 'plaintext')
-    useEditorStore.getState().updateCursor('key1', 10, 5)
-    const buf = useEditorStore.getState().buffers['key1']
-    expect(buf.cursorPosition).toEqual({ line: 10, column: 5 })
+    useEditorStore.getState().attachPane('pane-a', 'key1')
+    useEditorStore.getState().updateCursor('pane-a', 10, 5)
+    const pane = useEditorStore.getState().paneStates['pane-a']
+    expect(pane.cursorPosition).toEqual({ line: 10, column: 5 })
   })
 
   it('markSaved updates lastStat when stat is provided', () => {

--- a/spa/src/stores/useEditorStore.test.ts
+++ b/spa/src/stores/useEditorStore.test.ts
@@ -43,17 +43,37 @@ describe('useEditorStore', () => {
     expect(useEditorStore.getState().buffers['key1']).toBeUndefined()
   })
 
+  it('switching a pane to another buffer resets pane-local state and releases the old buffer', () => {
+    useEditorStore.getState().openBuffer('key-a', 'A', 'typescript')
+    useEditorStore.getState().openBuffer('key-b', 'B', 'markdown')
+    useEditorStore.getState().attachPane('pane-a', 'key-a')
+    useEditorStore.getState().setEditorMode('pane-a', 'wysiwyg')
+    useEditorStore.getState().setShowDiff('pane-a', true)
+    useEditorStore.getState().updateCursor('pane-a', 8, 3)
+
+    useEditorStore.getState().attachPane('pane-a', 'key-b')
+
+    expect(useEditorStore.getState().buffers['key-a']).toBeUndefined()
+    expect(useEditorStore.getState().paneStates['pane-a']).toMatchObject({
+      bufferKey: 'key-b',
+      editorMode: 'raw',
+      showDiff: false,
+      cursorPosition: { line: 1, column: 1 },
+    })
+  })
+
   it('renames a shared buffer key and preserves model identity', () => {
     useEditorStore.getState().openBuffer('old-key', 'hello', 'typescript')
     useEditorStore.getState().attachPane('pane-a', 'old-key')
 
     const modelId = useEditorStore.getState().buffers['old-key']?.modelId
-    useEditorStore.getState().renameBuffer('old-key', 'new-key')
+    useEditorStore.getState().renameBuffer('old-key', 'new-key', 'markdown')
 
     expect(useEditorStore.getState().buffers['old-key']).toBeUndefined()
     expect(useEditorStore.getState().buffers['new-key']).toMatchObject({
       content: 'hello',
       modelId,
+      language: 'markdown',
     })
     expect(useEditorStore.getState().paneStates['pane-a']?.bufferKey).toBe('new-key')
   })

--- a/spa/src/stores/useEditorStore.ts
+++ b/spa/src/stores/useEditorStore.ts
@@ -1,40 +1,85 @@
 // spa/src/stores/useEditorStore.ts
 import { create } from 'zustand'
+import type { editor } from 'monaco-editor'
+
+export type EditorMode = 'raw' | 'wysiwyg'
 
 export interface EditorBuffer {
   content: string
   savedContent: string
   isDirty: boolean
   language: string
-  cursorPosition: { line: number; column: number }
   lastStat: { mtime: number; size: number } | null
+  modelId: string
+}
+
+export interface EditorPaneState {
+  bufferKey: string
+  editorMode: EditorMode
+  showDiff: boolean
+  cursorPosition: { line: number; column: number }
+  monacoViewState: editor.ICodeEditorViewState | null
 }
 
 interface EditorState {
   buffers: Record<string, EditorBuffer>
+  paneStates: Record<string, EditorPaneState>
   openBuffer: (key: string, content: string, language: string, stat?: { mtime: number; size: number }) => void
+  attachPane: (paneId: string, bufferKey: string) => void
   updateContent: (key: string, content: string) => void
   markSaved: (key: string, stat?: { mtime: number; size: number }) => void
+  renameBuffer: (oldKey: string, newKey: string) => void
   closeBuffer: (key: string) => void
+  closePane: (paneId: string) => void
   reloadBuffer: (key: string, content: string, stat?: { mtime: number; size: number }) => void
-  updateCursor: (key: string, line: number, column: number) => void
+  setEditorMode: (paneId: string, mode: EditorMode) => void
+  setShowDiff: (paneId: string, showDiff: boolean) => void
+  updateCursor: (paneId: string, line: number, column: number) => void
+  saveMonacoViewState: (paneId: string, viewState: editor.ICodeEditorViewState | null) => void
   clearAllBuffers: () => void
+}
+
+let nextModelId = 1
+
+function createModelId(): string {
+  const modelId = `editor-model-${nextModelId}`
+  nextModelId += 1
+  return modelId
 }
 
 export const useEditorStore = create<EditorState>()((set) => ({
   buffers: {},
+  paneStates: {},
 
-  openBuffer: (key, content, language, stat) => set((s) => ({
-    buffers: {
-      ...s.buffers,
-      [key]: {
-        content,
-        savedContent: content,
-        isDirty: false,
-        language,
-        cursorPosition: { line: 1, column: 1 },
-        lastStat: stat ?? null,
+  openBuffer: (key, content, language, stat) => set((s) => {
+    if (s.buffers[key]) return s
+    return {
+      buffers: {
+        ...s.buffers,
+        [key]: {
+          content,
+          savedContent: content,
+          isDirty: false,
+          language,
+          lastStat: stat ?? null,
+          modelId: createModelId(),
+        },
       },
+    }
+  }),
+
+  attachPane: (paneId, bufferKey) => set((s) => ({
+    paneStates: {
+      ...s.paneStates,
+      [paneId]: s.paneStates[paneId]
+        ? { ...s.paneStates[paneId], bufferKey }
+        : {
+            bufferKey,
+            editorMode: 'raw',
+            showDiff: false,
+            cursorPosition: { line: 1, column: 1 },
+            monacoViewState: null,
+          },
     },
   })),
 
@@ -69,9 +114,47 @@ export const useEditorStore = create<EditorState>()((set) => ({
     }
   }),
 
+  renameBuffer: (oldKey, newKey) => set((s) => {
+    const buffer = s.buffers[oldKey]
+    if (!buffer || oldKey === newKey) return s
+
+    const { [oldKey]: _removed, ...restBuffers } = s.buffers
+    const paneStates = Object.fromEntries(
+      Object.entries(s.paneStates).map(([paneId, paneState]) => [
+        paneId,
+        paneState.bufferKey === oldKey ? { ...paneState, bufferKey: newKey } : paneState,
+      ]),
+    )
+
+    return {
+      buffers: {
+        ...restBuffers,
+        [newKey]: buffer,
+      },
+      paneStates,
+    }
+  }),
+
   closeBuffer: (key) => set((s) => {
     const { [key]: _removed, ...rest } = s.buffers  
     return { buffers: rest }
+  }),
+
+  closePane: (paneId) => set((s) => {
+    const paneState = s.paneStates[paneId]
+    if (!paneState) return s
+
+    const { [paneId]: _removed, ...restPaneStates } = s.paneStates
+    const stillReferenced = Object.values(restPaneStates).some((state) => state.bufferKey === paneState.bufferKey)
+    if (stillReferenced) {
+      return { paneStates: restPaneStates }
+    }
+
+    const { [paneState.bufferKey]: _removedBuffer, ...restBuffers } = s.buffers
+    return {
+      buffers: restBuffers,
+      paneStates: restPaneStates,
+    }
   }),
 
   reloadBuffer: (key, content, stat) => set((s) => {
@@ -91,19 +174,64 @@ export const useEditorStore = create<EditorState>()((set) => ({
     }
   }),
 
-  updateCursor: (key, line, column) => set((s) => {
-    const buf = s.buffers[key]
-    if (!buf) return s
+  setEditorMode: (paneId, mode) => set((s) => {
+    const paneState = s.paneStates[paneId]
+    if (!paneState) return s
     return {
-      buffers: {
-        ...s.buffers,
-        [key]: {
-          ...buf,
+      paneStates: {
+        ...s.paneStates,
+        [paneId]: {
+          ...paneState,
+          editorMode: mode,
+        },
+      },
+    }
+  }),
+
+  setShowDiff: (paneId, showDiff) => set((s) => {
+    const paneState = s.paneStates[paneId]
+    if (!paneState) return s
+    return {
+      paneStates: {
+        ...s.paneStates,
+        [paneId]: {
+          ...paneState,
+          showDiff,
+        },
+      },
+    }
+  }),
+
+  updateCursor: (paneId, line, column) => set((s) => {
+    const paneState = s.paneStates[paneId]
+    if (!paneState) return s
+    return {
+      paneStates: {
+        ...s.paneStates,
+        [paneId]: {
+          ...paneState,
           cursorPosition: { line, column },
         },
       },
     }
   }),
 
-  clearAllBuffers: () => set({ buffers: {} }),
+  saveMonacoViewState: (paneId, viewState) => set((s) => {
+    const paneState = s.paneStates[paneId]
+    if (!paneState) return s
+    return {
+      paneStates: {
+        ...s.paneStates,
+        [paneId]: {
+          ...paneState,
+          monacoViewState: viewState,
+        },
+      },
+    }
+  }),
+
+  clearAllBuffers: () => {
+    nextModelId = 1
+    set({ buffers: {}, paneStates: {} })
+  },
 }))

--- a/spa/src/stores/useEditorStore.ts
+++ b/spa/src/stores/useEditorStore.ts
@@ -28,9 +28,9 @@ interface EditorState {
   attachPane: (paneId: string, bufferKey: string) => void
   updateContent: (key: string, content: string) => void
   markSaved: (key: string, stat?: { mtime: number; size: number }) => void
-  renameBuffer: (oldKey: string, newKey: string) => void
+  renameBuffer: (oldKey: string, newKey: string, language?: string) => void
   closeBuffer: (key: string) => void
-  closePane: (paneId: string) => void
+  closePane: (paneId: string, expectedBufferKey?: string) => void
   reloadBuffer: (key: string, content: string, stat?: { mtime: number; size: number }) => void
   setEditorMode: (paneId: string, mode: EditorMode) => void
   setShowDiff: (paneId: string, showDiff: boolean) => void
@@ -40,6 +40,16 @@ interface EditorState {
 }
 
 let nextModelId = 1
+
+function createPaneState(bufferKey: string): EditorPaneState {
+  return {
+    bufferKey,
+    editorMode: 'raw',
+    showDiff: false,
+    cursorPosition: { line: 1, column: 1 },
+    monacoViewState: null,
+  }
+}
 
 function createModelId(): string {
   const modelId = `editor-model-${nextModelId}`
@@ -68,20 +78,35 @@ export const useEditorStore = create<EditorState>()((set) => ({
     }
   }),
 
-  attachPane: (paneId, bufferKey) => set((s) => ({
-    paneStates: {
+  attachPane: (paneId, bufferKey) => set((s) => {
+    const currentPaneState = s.paneStates[paneId]
+    if (!currentPaneState) {
+      return {
+        paneStates: {
+          ...s.paneStates,
+          [paneId]: createPaneState(bufferKey),
+        },
+      }
+    }
+    if (currentPaneState.bufferKey === bufferKey) return s
+
+    const nextPaneStates = {
       ...s.paneStates,
-      [paneId]: s.paneStates[paneId]
-        ? { ...s.paneStates[paneId], bufferKey }
-        : {
-            bufferKey,
-            editorMode: 'raw',
-            showDiff: false,
-            cursorPosition: { line: 1, column: 1 },
-            monacoViewState: null,
-          },
-    },
-  })),
+      [paneId]: createPaneState(bufferKey),
+    }
+    const stillReferenced = Object.entries(nextPaneStates).some(([otherPaneId, state]) =>
+      otherPaneId !== paneId && state.bufferKey === currentPaneState.bufferKey,
+    )
+    if (stillReferenced) {
+      return { paneStates: nextPaneStates }
+    }
+
+    const { [currentPaneState.bufferKey]: _removedBuffer, ...restBuffers } = s.buffers
+    return {
+      buffers: restBuffers,
+      paneStates: nextPaneStates,
+    }
+  }),
 
   updateContent: (key, content) => set((s) => {
     const buf = s.buffers[key]
@@ -114,7 +139,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
     }
   }),
 
-  renameBuffer: (oldKey, newKey) => set((s) => {
+  renameBuffer: (oldKey, newKey, language) => set((s) => {
     const buffer = s.buffers[oldKey]
     if (!buffer || oldKey === newKey) return s
 
@@ -129,7 +154,10 @@ export const useEditorStore = create<EditorState>()((set) => ({
     return {
       buffers: {
         ...restBuffers,
-        [newKey]: buffer,
+        [newKey]: {
+          ...buffer,
+          language: language ?? buffer.language,
+        },
       },
       paneStates,
     }
@@ -140,9 +168,10 @@ export const useEditorStore = create<EditorState>()((set) => ({
     return { buffers: rest }
   }),
 
-  closePane: (paneId) => set((s) => {
+  closePane: (paneId, expectedBufferKey) => set((s) => {
     const paneState = s.paneStates[paneId]
     if (!paneState) return s
+    if (expectedBufferKey && paneState.bufferKey !== expectedBufferKey) return s
 
     const { [paneId]: _removed, ...restPaneStates } = s.paneStates
     const stillReferenced = Object.values(restPaneStates).some((state) => state.bufferKey === paneState.bufferKey)

--- a/spa/src/stores/useTabStore.test.ts
+++ b/spa/src/stores/useTabStore.test.ts
@@ -218,6 +218,29 @@ describe('useTabStore', () => {
     })
   })
 
+  describe('renameEditorPanes', () => {
+    it('renames matching editor panes in a split layout', () => {
+      const content: PaneContent = { kind: 'editor', source: { type: 'inapp' }, filePath: '/notes/a.md' }
+      const tab = createTab(content)
+      useTabStore.getState().addTab(tab)
+      const paneId = tab.layout.type === 'leaf' ? tab.layout.pane.id : ''
+
+      useTabStore.getState().splitPane(tab.id, paneId, 'h', content)
+      useTabStore.getState().renameEditorPanes({ type: 'inapp' }, '/notes/a.md', '/notes/b.md')
+
+      const updated = useTabStore.getState().tabs[tab.id]
+      expect(updated.layout.type).toBe('split')
+      if (updated.layout.type === 'split') {
+        const filePaths = updated.layout.children.map((child) =>
+          child.type === 'leaf' && child.pane.content.kind === 'editor'
+            ? child.pane.content.filePath
+            : null,
+        )
+        expect(filePaths).toEqual(['/notes/b.md', '/notes/b.md'])
+      }
+    })
+  })
+
   describe('updateSessionCache', () => {
     it('updates cachedName for matching session tab', () => {
       const tab = makeSessionTab('dev001', 'terminal')

--- a/spa/src/stores/useTabStore.ts
+++ b/spa/src/stores/useTabStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { Tab, PaneContent, PaneLayout, TerminatedReason, LayoutPattern } from '../types/tab'
+import type { FileSource } from '../types/fs'
 import { createTab } from '../types/tab'
 import { getPrimaryPane, findPane, updatePaneInLayout, splitAtPane, removePane, applyLayoutPattern } from '../lib/pane-tree'
 import { contentMatches } from '../lib/pane-utils'
@@ -65,6 +66,35 @@ function markHostPanesInLayout(layout: PaneLayout, hostId: string, reason: Termi
   return children.some((c, i) => c !== layout.children[i]) ? { ...layout, children } : layout
 }
 
+function sourceMatches(a: FileSource, b: FileSource): boolean {
+  if (a.type !== b.type) return false
+  if (a.type === 'daemon' && b.type === 'daemon') {
+    return a.hostId === b.hostId
+  }
+  return true
+}
+
+function renameEditorPanesInLayout(layout: PaneLayout, source: FileSource, oldPath: string, newPath: string): PaneLayout {
+  if (layout.type === 'leaf') {
+    const content = layout.pane.content
+    if (content.kind === 'editor' && content.filePath === oldPath && sourceMatches(content.source, source)) {
+      return {
+        type: 'leaf',
+        pane: {
+          ...layout.pane,
+          content: { ...content, filePath: newPath },
+        },
+      }
+    }
+    return layout
+  }
+
+  const children = layout.children.map((child) => renameEditorPanesInLayout(child, source, oldPath, newPath))
+  return children.some((child, index) => child !== layout.children[index])
+    ? { ...layout, children }
+    : layout
+}
+
 interface TabState {
   tabs: Record<string, Tab>
   tabOrder: string[]
@@ -77,6 +107,7 @@ interface TabState {
   setActiveTab: (id: string | null) => void
   setViewMode: (tabId: string, paneId: string, mode: 'terminal' | 'stream') => void
   setPaneContent: (tabId: string, paneId: string, content: PaneContent) => void
+  renameEditorPanes: (source: FileSource, oldPath: string, newPath: string) => void
   splitPane: (tabId: string, paneId: string, direction: 'h' | 'v', content: PaneContent) => void
   closePane: (tabId: string, paneId: string) => void
   resizePanes: (tabId: string, splitId: string, sizes: number[]) => void
@@ -199,6 +230,20 @@ export const useTabStore = create<TabState>()(
           if (!tab) return state
           const newLayout = updatePaneInLayout(tab.layout, paneId, content)
           return { tabs: { ...state.tabs, [tabId]: { ...tab, layout: newLayout } } }
+        }),
+
+      renameEditorPanes: (source, oldPath, newPath) =>
+        set((state) => {
+          let changed = false
+          const tabs = { ...state.tabs }
+          for (const [tabId, tab] of Object.entries(state.tabs)) {
+            const newLayout = renameEditorPanesInLayout(tab.layout, source, oldPath, newPath)
+            if (newLayout !== tab.layout) {
+              tabs[tabId] = { ...tab, layout: newLayout }
+              changed = true
+            }
+          }
+          return changed ? { tabs } : state
         }),
 
       splitPane: (tabId, paneId, direction, content) =>


### PR DESCRIPTION
## Summary
- preserve editor runtime state across tab switches by splitting shared buffer data from pane-local view state and restoring Monaco view state per pane
- restore full-path breadcrumbs in the editor toolbar and add inline file rename with invalid-name / conflict guards plus multi-pane path migration
- fix the Markdown WYSIWYG container structure so scrolling stays inside the pane and add focused tests/spec docs for the editor regression work

## Testing
- `pnpm --prefix spa exec vitest run src/stores/useEditorStore.test.ts src/stores/useTabStore.test.ts src/stores/useTabStore.migration.test.ts src/components/editor/MonacoWrapper.test.tsx src/components/editor/__tests__/EditorPane.test.tsx src/components/editor/TiptapEditor.test.tsx`

## Notes
- `pnpm --prefix spa run lint` and `pnpm --prefix spa run build` still fail on current `main` baseline in unrelated files; tracked separately in #549.