### PR TITLE
fix(spa): restore lint and build baseline

### DIFF
--- a/spa/src/components/PaneLayoutRenderer.test.tsx
+++ b/spa/src/components/PaneLayoutRenderer.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
-import { PaneLayoutRenderer, isGrid4 } from './PaneLayoutRenderer'
+import { PaneLayoutRenderer } from './PaneLayoutRenderer'
+import { isGrid4 } from './pane-layout-grid'
 import { registerModule, clearModuleRegistry } from '../lib/module-registry'
 import type { PaneLayout } from '../types/tab'
 

--- a/spa/src/components/PaneLayoutRenderer.tsx
+++ b/spa/src/components/PaneLayoutRenderer.tsx
@@ -4,6 +4,7 @@ import { getLayoutKey, collectLeaves, swapPaneContent } from '../lib/pane-tree'
 import { PaneSplitter } from './PaneSplitter'
 import { PaneHeader } from './PaneHeader'
 import { QuickCommandMenu } from './QuickCommandMenu'
+import { isGrid4 } from './pane-layout-grid'
 import { executeCommand } from '../lib/execute-command'
 import { useTabStore } from '../stores/useTabStore'
 import { useWorkspaceStore } from '../features/workspace/store'
@@ -11,13 +12,6 @@ import type { PaneLayout, SplitLayout } from '../types/tab'
 
 function isSplit(layout: PaneLayout): layout is SplitLayout {
   return layout.type === 'split'
-}
-
-export function isGrid4(layout: PaneLayout): boolean {
-  if (!isSplit(layout) || layout.direction !== 'v' || layout.children.length !== 2) return false
-  return layout.children.every(
-    (c) => c.type === 'split' && c.direction === 'h' && c.children.length === 2,
-  )
 }
 
 interface Props {

--- a/spa/src/components/SortableTab.test.tsx
+++ b/spa/src/components/SortableTab.test.tsx
@@ -53,7 +53,7 @@ beforeEach(() => {
   cleanup()
   vi.clearAllMocks()
   clearModuleRegistry()
-  registerModule({ id: 'session', name: 'Session', pane: { kind: 'tmux-session', component: () => null } })
+  registerModule({ id: 'session', name: 'Session', panes: [{ kind: 'tmux-session', component: () => null }] })
   useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
   useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: null })
   useHostStore.setState({ runtime: {} })

--- a/spa/src/components/TabBar.test.tsx
+++ b/spa/src/components/TabBar.test.tsx
@@ -9,8 +9,8 @@ import { useSessionStore } from '../stores/useSessionStore'
 beforeEach(() => {
   cleanup()
   clearModuleRegistry()
-  registerModule({ id: 'session', name: 'Session', pane: { kind: 'tmux-session', component: () => null } })
-  registerModule({ id: 'dashboard', name: 'Dashboard', pane: { kind: 'dashboard', component: () => null } })
+  registerModule({ id: 'session', name: 'Session', panes: [{ kind: 'tmux-session', component: () => null }] })
+  registerModule({ id: 'dashboard', name: 'Dashboard', panes: [{ kind: 'dashboard', component: () => null }] })
   // Provide sessions keyed by hostId for SortableTab's label lookups
   useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
 })

--- a/spa/src/components/TabContextMenu.test.tsx
+++ b/spa/src/components/TabContextMenu.test.tsx
@@ -161,19 +161,19 @@ describe('TabContextMenu', () => {
 
   // --- Tear-off section (Electron only) ---
   it('shows "Move to New Window" when caps.canTearOffTab is true', () => {
-    vi.mocked(getPlatformCapabilities).mockReturnValue({ canTearOffTab: true, canMergeWindow: false, canBrowserPane: false, canSystemTray: false, canNotification: true, isElectron: true, devUpdateEnabled: false })
+    vi.mocked(getPlatformCapabilities).mockReturnValue({ canTearOffTab: true, canMergeWindow: false, canBrowserPane: false, canSystemTray: false, canNotification: true, isElectron: true, devUpdateEnabled: false, hasLocalFilesystem: true })
     renderMenu()
     expect(screen.getByText('Move to New Window')).toBeInTheDocument()
   })
 
   it('does not show "Move to New Window" when no electronAPI (canTearOffTab false)', () => {
-    vi.mocked(getPlatformCapabilities).mockReturnValue({ canTearOffTab: false, canMergeWindow: false, canBrowserPane: false, canSystemTray: false, canNotification: false, isElectron: false, devUpdateEnabled: false })
+    vi.mocked(getPlatformCapabilities).mockReturnValue({ canTearOffTab: false, canMergeWindow: false, canBrowserPane: false, canSystemTray: false, canNotification: false, isElectron: false, devUpdateEnabled: false, hasLocalFilesystem: false })
     renderMenu()
     expect(screen.queryByText('Move to New Window')).not.toBeInTheDocument()
   })
 
   it('"Move to New Window" is disabled when tab is locked', () => {
-    vi.mocked(getPlatformCapabilities).mockReturnValue({ canTearOffTab: true, canMergeWindow: false, canBrowserPane: false, canSystemTray: false, canNotification: true, isElectron: true, devUpdateEnabled: false })
+    vi.mocked(getPlatformCapabilities).mockReturnValue({ canTearOffTab: true, canMergeWindow: false, canBrowserPane: false, canSystemTray: false, canNotification: true, isElectron: true, devUpdateEnabled: false, hasLocalFilesystem: true })
     renderMenu({ tab: makeSessionTab('terminal', { locked: true }) })
     const tearOffBtn = screen.getByText('Move to New Window').closest('button')!
     expect(tearOffBtn).toBeDisabled()

--- a/spa/src/components/editor/ImagePreviewPane.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.tsx
@@ -25,7 +25,7 @@ function ImagePreviewPaneInner({ source, filePath }: { source: FileSource; fileP
     backend.read(filePath)
       .then((data) => {
         if (stale) return
-        url = URL.createObjectURL(new Blob([data]))
+        url = URL.createObjectURL(new Blob([new Uint8Array(data)]))
         setObjectUrl(url)
       })
       .catch((err: Error) => {

--- a/spa/src/components/editor/PdfPreviewPane.tsx
+++ b/spa/src/components/editor/PdfPreviewPane.tsx
@@ -25,7 +25,7 @@ function PdfPreviewPaneInner({ source, filePath }: { source: FileSource; filePat
     backend.read(filePath)
       .then((data) => {
         if (stale) return
-        url = URL.createObjectURL(new Blob([data], { type: 'application/pdf' }))
+        url = URL.createObjectURL(new Blob([new Uint8Array(data)], { type: 'application/pdf' }))
         setObjectUrl(url)
       })
       .catch((err: Error) => {

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -39,13 +39,22 @@ function createBackend(): FsBackend & {
   write: ReturnType<typeof vi.fn>
   stat: ReturnType<typeof vi.fn>
 } {
+  const read = vi.fn(async (_path: string) => new Uint8Array())
+  const write = vi.fn(async (_path: string, _content: Uint8Array) => {})
+  const stat = vi.fn(async (_path: string) => ({
+    isFile: true,
+    isDirectory: false,
+    size: 0,
+    mtime: 0,
+  }))
+
   return {
     id: 'test-backend',
     label: 'Test Backend',
     available: vi.fn(() => true),
-    read: vi.fn(),
-    write: vi.fn(),
-    stat: vi.fn(),
+    read,
+    write,
+    stat,
     list: vi.fn(),
     mkdir: vi.fn(),
     delete: vi.fn(),

--- a/spa/src/components/pane-layout-grid.ts
+++ b/spa/src/components/pane-layout-grid.ts
@@ -1,0 +1,12 @@
+import type { PaneLayout, SplitLayout } from '../types/tab'
+
+function isSplit(layout: PaneLayout): layout is SplitLayout {
+  return layout.type === 'split'
+}
+
+export function isGrid4(layout: PaneLayout): boolean {
+  if (!isSplit(layout) || layout.direction !== 'v' || layout.children.length !== 2) return false
+  return layout.children.every(
+    (child) => child.type === 'split' && child.direction === 'h' && child.children.length === 2,
+  )
+}

--- a/spa/src/components/settings/SyncSection.test.tsx
+++ b/spa/src/components/settings/SyncSection.test.tsx
@@ -255,6 +255,10 @@ function installSnapshotSpy(): SnapshotCall[] {
       return meta
     },
     deleteLocal: async () => {},
+    demoteSessionPristine: async () => {},
+    rotateSessionPristine: async (bundle, trigger) => {
+      return stub.createSnapshot(bundle, trigger, { isSessionPristine: true })
+    },
     compact: async () => ({ kept: [], evicted: [] }),
     clear: async () => {},
   }

--- a/spa/src/components/settings/TmuxAgentMonitorSection.test.tsx
+++ b/spa/src/components/settings/TmuxAgentMonitorSection.test.tsx
@@ -7,6 +7,9 @@ import {
   fetchAgentMonitorChain,
   fetchAgentMonitorChains,
   fetchAgentMonitorProjection,
+  type AgentMonitorChainSummary,
+  type AgentMonitorProjectionSummary,
+  type AgentMonitorStepNode,
 } from '../../lib/host-api'
 
 vi.mock('../../lib/host-api', () => ({
@@ -23,6 +26,15 @@ function deferred<T>() {
     reject = rej
   })
   return { promise, resolve, reject }
+}
+
+type ChainDetailResponse = {
+  chain: AgentMonitorChainSummary
+  step_tree: AgentMonitorStepNode[]
+}
+
+type ProjectionResponse = {
+  projection: AgentMonitorProjectionSummary
 }
 
 describe('TmuxAgentMonitorSection', () => {
@@ -283,10 +295,10 @@ describe('TmuxAgentMonitorSection', () => {
   })
 
   it('ignores stale responses from an older selection request', async () => {
-    const chain1Detail = deferred<{ chain: { chain_id: string }; step_tree: Array<{ step: { step_id: string; chain_id: string; seq: number; kind: string; tmux_session: string; pane_id: string; agent_type: string; frame_id: string; parent_frame_id: string; event_name: string; decision: string; reason: string; payload_json: string; before_json: string; after_json: string; created_at: number }; children: never[] }> }>()
-    const chain2Detail = deferred<{ chain: { chain_id: string }; step_tree: Array<{ step: { step_id: string; chain_id: string; seq: number; kind: string; tmux_session: string; pane_id: string; agent_type: string; frame_id: string; parent_frame_id: string; event_name: string; decision: string; reason: string; payload_json: string; before_json: string; after_json: string; created_at: number }; children: never[] }> }>()
-    const chain1Projection = deferred<{ projection: { tmux_session: string; pane_id: string; primary_frame_id: string; top_frame_id: string; top_agent_type: string; latest_chain_id: string } }>()
-    const chain2Projection = deferred<{ projection: { tmux_session: string; pane_id: string; primary_frame_id: string; top_frame_id: string; top_agent_type: string; latest_chain_id: string } }>()
+    const chain1Detail = deferred<ChainDetailResponse>()
+    const chain2Detail = deferred<ChainDetailResponse>()
+    const chain1Projection = deferred<ProjectionResponse>()
+    const chain2Projection = deferred<ProjectionResponse>()
 
     vi.mocked(fetchAgentMonitorChains).mockResolvedValue({
       chains: [
@@ -340,7 +352,22 @@ describe('TmuxAgentMonitorSection', () => {
     fireEvent.click(screen.getByText('chain-2'))
 
     chain2Detail.resolve({
-      chain: { chain_id: 'chain-2' },
+      chain: {
+        chain_id: 'chain-2',
+        started_at: 101,
+        completed_at: 121,
+        terminal_status: 'completed',
+        terminal_reason: 'emit_broadcasted',
+        tmux_session: 'work',
+        pane_id: '%8',
+        root_agent_type: 'cc',
+        root_event_name: 'Stop',
+        root_reason: 'hook_post',
+        latest_step_kind: 'emit',
+        latest_decision: 'broadcasted',
+        latest_step_reason: 'session_code_resolved',
+        step_count: 1,
+      },
       step_tree: [{
         step: {
           step_id: 'step-2',
@@ -377,7 +404,22 @@ describe('TmuxAgentMonitorSection', () => {
     await waitFor(() => expect(screen.getByText('{"prompt":"second"}')).toBeInTheDocument())
 
     chain1Detail.resolve({
-      chain: { chain_id: 'chain-1' },
+      chain: {
+        chain_id: 'chain-1',
+        started_at: 100,
+        completed_at: 120,
+        terminal_status: 'completed',
+        terminal_reason: 'emit_broadcasted',
+        tmux_session: 'work',
+        pane_id: '%7',
+        root_agent_type: 'codex',
+        root_event_name: 'UserPromptSubmit',
+        root_reason: 'hook_post',
+        latest_step_kind: 'emit',
+        latest_decision: 'broadcasted',
+        latest_step_reason: 'session_code_resolved',
+        step_count: 1,
+      },
       step_tree: [{
         step: {
           step_id: 'step-1',

--- a/spa/src/features/settings/sections/sync-history/SnapshotHistoryPage.test.tsx
+++ b/spa/src/features/settings/sections/sync-history/SnapshotHistoryPage.test.tsx
@@ -26,6 +26,8 @@ describe('SnapshotHistoryPage', () => {
       getLocal: async (id) => (id === 'm1' ? fullSnap : null),
       createSnapshot: async () => items[0],
       deleteLocal: async () => {},
+      demoteSessionPristine: async () => {},
+      rotateSessionPristine: async () => ({ ...items[0], isSessionPristine: true }),
       compact: async () => ({ kept: [], evicted: [] }),
       clear: async () => {},
     })

--- a/spa/src/features/settings/sections/sync-history/hooks/useLocalHistory.test.ts
+++ b/spa/src/features/settings/sections/sync-history/hooks/useLocalHistory.test.ts
@@ -15,6 +15,8 @@ describe('useLocalHistory', () => {
       getLocal: async () => null,
       createSnapshot: async () => items[0],
       deleteLocal: async () => {},
+      demoteSessionPristine: async () => {},
+      rotateSessionPristine: async () => ({ ...items[0], isSessionPristine: true }),
       compact: async () => ({ kept: [], evicted: [] }),
       clear: async () => {},
     })

--- a/spa/src/features/settings/sections/sync-history/hooks/useSnapshotDiff.test.ts
+++ b/spa/src/features/settings/sections/sync-history/hooks/useSnapshotDiff.test.ts
@@ -13,6 +13,8 @@ describe('useSnapshotDiff', () => {
       getLocal: async () => null,
       createSnapshot: async () => ({ id: 'x', timestamp: 0, device: 'd', trigger: 'manual', bundleSize: 0, contributorIds: [], isSessionPristine: false }),
       deleteLocal: async () => {},
+      demoteSessionPristine: async () => {},
+      rotateSessionPristine: async () => ({ id: 'x', timestamp: 0, device: 'd', trigger: 'manual', bundleSize: 0, contributorIds: [], isSessionPristine: true }),
       compact: async () => ({ kept: [], evicted: [] }),
       clear: async () => {},
     })
@@ -62,7 +64,7 @@ describe('useSnapshotDiff', () => {
         { id: 'w', strategy: 'full', getVersion: () => 1, serialize: () => ({ version: 1, data: { x: 1 } }), deserialize: () => {} },
         { id: 'x', strategy: 'full', getVersion: () => 1, serialize: () => ({ version: 1, data: { k: 1 } }), deserialize: () => {} },
       ],
-      serialize: (_device, ids: string[]) => ({
+      serialize: (_device: string, ids: string[]) => ({
         version: 1, timestamp: 0, device: 'd',
         collections: Object.fromEntries(
           ids.map((id) => [id, id === 'w' ? { version: 1, data: { x: 1 } } : { version: 1, data: { k: 1 } }]),

--- a/spa/src/features/workspace/lib/useCrossWorkspaceDragOver.ts
+++ b/spa/src/features/workspace/lib/useCrossWorkspaceDragOver.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react'
 import type { DragOverEvent } from '@dnd-kit/core'
 import { useWorkspaceStore } from '../store'
-import type { DragData } from './computeDragEndAction'
+import type { DragData, TabDragData } from './computeDragEndAction'
 
 /**
  * Optimistic cross-workspace make-way effect: when a tab drags over a tab in a
@@ -57,6 +57,6 @@ export function useCrossWorkspaceDragOver() {
     // Update the active drag data's sourceWsId so subsequent onDragOver events
     // see the tab's new home. dnd-kit passes data.current by reference, so
     // mutating it propagates.
-    ;(active.data.current as DragData).sourceWsId = toWs as never
+    ;(active.data.current as TabDragData).sourceWsId = toWs
   }, [])
 }

--- a/spa/src/hooks/useStatuslineTest.ts
+++ b/spa/src/hooks/useStatuslineTest.ts
@@ -68,6 +68,10 @@ const STAGE4_GRACE_MS = 2000
 // from drifting out of sync when transitions fire in unexpected orders.
 type Stage4State = 'pending' | 'armed' | 'fired' | 'cancelled'
 
+function isStage4Armed(state: Stage4State): state is 'armed' {
+  return state === 'armed'
+}
+
 type StageNum = 1 | 2 | 3 | 4 | 5
 
 interface ServerStageEvent {
@@ -119,6 +123,16 @@ export function useStatuslineTest(hostId: string) {
     let stage4State: Stage4State = 'pending'
     let stage4Resolver: (() => void) | null = null
     const stage4Signal = new Promise<void>((resolve) => { stage4Resolver = resolve })
+    const unsubscribeBus = () => {
+      const unsub = unsubBus
+      unsubBus = null
+      unsub?.()
+    }
+    const cancelReader = () => {
+      const currentReader = reader
+      if (!currentReader) return
+      void currentReader.cancel().catch(() => { /* already closed — ignore */ })
+    }
     const fireStage4 = () => {
       // Idempotent — bus subscriber + early-hit may both invoke this; only
       // the first transition out of pending/armed actually resolves the signal.
@@ -171,13 +185,12 @@ export function useStatuslineTest(hostId: string) {
       const earlyKey = compositeKey(hostId, noncedVal)
       const earlyHit = !!useAgentStore.getState().ccStatus[earlyKey]
       debugStatuslineTest('hook.early-hit-check', { earlyKey, earlyHit })
-      if (earlyHit) {
-        markStage(4, { status: 'passed' })
-        markStage(5, { status: 'passed' })
-        fireStage4()
-        unsubBus?.()
-        unsubBus = null
-      }
+        if (earlyHit) {
+          markStage(4, { status: 'passed' })
+          markStage(5, { status: 'passed' })
+          fireStage4()
+          unsubscribeBus()
+        }
       if (!sendReadyAck) return true
       hostFetch(hostId, '/api/agent/cc/statusline/test/ready', {
           method: 'POST',
@@ -278,7 +291,7 @@ export function useStatuslineTest(hostId: string) {
       // Release the SSE reader so the browser closes the HTTP connection;
       // otherwise the fetch stream stays open until the server finishes
       // or its own timeouts fire.
-      reader?.cancel().catch(() => { /* already closed — ignore */ })
+      cancelReader()
     }
 
     if (outcome === 'timeout' && mountedRef.current) {
@@ -302,7 +315,8 @@ export function useStatuslineTest(hostId: string) {
 
     // SSE finished cleanly but stage 4 is still pending → give the WS a
     // grace window, otherwise the spinner for stages 4/5 would hang forever.
-    if (outcome === 'done' && mountedRef.current && stage4State === 'armed') {
+    const shouldWaitForStage4 = outcome === 'done' && mountedRef.current && isStage4Armed(stage4State)
+    if (shouldWaitForStage4) {
       debugStatuslineTest('hook.grace-start', { graceMs: STAGE4_GRACE_MS })
       let graceId: ReturnType<typeof setTimeout> | undefined
       const graceTimeout = new Promise<'grace-timeout'>((resolve) => {
@@ -317,8 +331,7 @@ export function useStatuslineTest(hostId: string) {
       if (graceOutcome === 'grace-timeout' && mountedRef.current) {
         // Detach the bus before marking failure so a late-arriving WS event
         // can't overwrite the failed state.
-        unsubBus?.()
-        unsubBus = null
+        unsubscribeBus()
         markFailThenSkipRest(
           4,
           `WS event not received within ${STAGE4_GRACE_MS}ms after stream completed`,
@@ -326,7 +339,7 @@ export function useStatuslineTest(hostId: string) {
       }
     }
 
-    unsubBus?.()
+    unsubscribeBus()
     runningRef.current = false
     if (mountedRef.current) {
       setState((s) => ({ ...s, running: false, lastRunAt: Date.now() }))

--- a/spa/src/lib/fs-backend-daemon.test.ts
+++ b/spa/src/lib/fs-backend-daemon.test.ts
@@ -3,6 +3,7 @@ import { DaemonBackend } from './fs-backend-daemon'
 
 describe('DaemonBackend', () => {
   let backend: DaemonBackend
+  const testGlobal = globalThis as typeof globalThis & { fetch: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     backend = new DaemonBackend('http://localhost:7860', () => ({ Authorization: 'Bearer test-token' }))
@@ -27,15 +28,15 @@ describe('DaemonBackend', () => {
       { name: 'file.txt', isDir: false, size: 42 },
       { name: 'subdir', isDir: true, size: 0 },
     ]
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    testGlobal.fetch.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ path: '/home/user', entries: mockEntries }),
     })
 
     const result = await backend.list('/home/user')
 
-    expect(global.fetch).toHaveBeenCalledOnce()
-    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(testGlobal.fetch).toHaveBeenCalledOnce()
+    const [url, options] = testGlobal.fetch.mock.calls[0]
     expect(url).toBe('http://localhost:7860/api/fs/list')
     expect(options.method).toBe('POST')
     expect(JSON.parse(options.body)).toEqual({ path: '/home/user' })
@@ -45,15 +46,15 @@ describe('DaemonBackend', () => {
 
   it('read returns Uint8Array from response arrayBuffer', async () => {
     const bytes = new Uint8Array([72, 101, 108, 108, 111]) // "Hello"
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    testGlobal.fetch.mockResolvedValueOnce({
       ok: true,
       arrayBuffer: () => Promise.resolve(bytes.buffer),
     })
 
     const result = await backend.read('/home/user/file.txt')
 
-    expect(global.fetch).toHaveBeenCalledOnce()
-    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(testGlobal.fetch).toHaveBeenCalledOnce()
+    const [url, options] = testGlobal.fetch.mock.calls[0]
     expect(url).toBe('http://localhost:7860/api/fs/read')
     expect(JSON.parse(options.body)).toEqual({ path: '/home/user/file.txt' })
     expect(result).toBeInstanceOf(Uint8Array)
@@ -62,22 +63,22 @@ describe('DaemonBackend', () => {
 
   it('stat returns FileStat from JSON response', async () => {
     const mockStat = { size: 1024, mtime: 1712345678000, isDirectory: false, isFile: true }
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    testGlobal.fetch.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve(mockStat),
     })
 
     const result = await backend.stat('/home/user/file.txt')
 
-    expect(global.fetch).toHaveBeenCalledOnce()
-    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(testGlobal.fetch).toHaveBeenCalledOnce()
+    const [url, options] = testGlobal.fetch.mock.calls[0]
     expect(url).toBe('http://localhost:7860/api/fs/stat')
     expect(JSON.parse(options.body)).toEqual({ path: '/home/user/file.txt' })
     expect(result).toEqual(mockStat)
   })
 
   it('write sends base64 encoded content', async () => {
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    testGlobal.fetch.mockResolvedValueOnce({
       ok: true,
       status: 204,
     })
@@ -85,8 +86,8 @@ describe('DaemonBackend', () => {
     const content = new TextEncoder().encode('Hello, World!')
     await backend.write('/home/user/file.txt', content)
 
-    expect(global.fetch).toHaveBeenCalledOnce()
-    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(testGlobal.fetch).toHaveBeenCalledOnce()
+    const [url, options] = testGlobal.fetch.mock.calls[0]
     expect(url).toBe('http://localhost:7860/api/fs/write')
     const body = JSON.parse(options.body)
     expect(body.path).toBe('/home/user/file.txt')
@@ -101,46 +102,46 @@ describe('DaemonBackend', () => {
   })
 
   it('mkdir sends POST to /api/fs/mkdir', async () => {
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    testGlobal.fetch.mockResolvedValueOnce({
       ok: true,
       status: 204,
     })
 
     await backend.mkdir('/home/user/newdir', true)
 
-    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    const [url, options] = testGlobal.fetch.mock.calls[0]
     expect(url).toBe('http://localhost:7860/api/fs/mkdir')
     expect(JSON.parse(options.body)).toEqual({ path: '/home/user/newdir', recursive: true })
   })
 
   it('delete sends POST to /api/fs/delete', async () => {
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    testGlobal.fetch.mockResolvedValueOnce({
       ok: true,
       status: 204,
     })
 
     await backend.delete('/home/user/file.txt', false)
 
-    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    const [url, options] = testGlobal.fetch.mock.calls[0]
     expect(url).toBe('http://localhost:7860/api/fs/delete')
     expect(JSON.parse(options.body)).toEqual({ path: '/home/user/file.txt', recursive: false })
   })
 
   it('rename sends POST to /api/fs/rename', async () => {
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    testGlobal.fetch.mockResolvedValueOnce({
       ok: true,
       status: 204,
     })
 
     await backend.rename('/home/user/old.txt', '/home/user/new.txt')
 
-    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    const [url, options] = testGlobal.fetch.mock.calls[0]
     expect(url).toBe('http://localhost:7860/api/fs/rename')
     expect(JSON.parse(options.body)).toEqual({ from: '/home/user/old.txt', to: '/home/user/new.txt' })
   })
 
   it('throws on non-ok response', async () => {
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    testGlobal.fetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
       text: () => Promise.resolve('file not found'),
@@ -150,7 +151,7 @@ describe('DaemonBackend', () => {
   })
 
   it('throws with HTTP status when text() fails', async () => {
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    testGlobal.fetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
       text: () => Promise.reject(new Error('network error')),

--- a/spa/src/lib/fs-backend-daemon.ts
+++ b/spa/src/lib/fs-backend-daemon.ts
@@ -4,11 +4,13 @@ import type { FileStat, FileEntry } from '../types/fs'
 export class DaemonBackend implements FsBackend {
   readonly id = 'daemon'
   readonly label = 'Remote Host'
+  private readonly baseUrl: string
+  private readonly getHeaders: () => Record<string, string>
 
-  constructor(
-    private baseUrl: string,
-    private getHeaders: () => Record<string, string>,
-  ) {}
+  constructor(baseUrl: string, getHeaders: () => Record<string, string>) {
+    this.baseUrl = baseUrl
+    this.getHeaders = getHeaders
+  }
 
   available(): boolean {
     return !!this.baseUrl

--- a/spa/src/lib/fs-backend-local.test.ts
+++ b/spa/src/lib/fs-backend-local.test.ts
@@ -16,16 +16,20 @@ describe('LocalBackend', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks()
-    ;(window as any).electronAPI = { fs: mockFs }
+    Object.defineProperty(window, 'electronAPI', {
+      value: { fs: mockFs },
+      configurable: true,
+      writable: true,
+    })
     backend = new LocalBackend()
   })
 
   afterEach(() => {
-    delete (window as any).electronAPI
+    delete window.electronAPI
   })
 
   it('available() returns false when no electronAPI', () => {
-    delete (window as any).electronAPI
+    delete window.electronAPI
     expect(backend.available()).toBe(false)
   })
 
@@ -83,7 +87,7 @@ describe('LocalBackend', () => {
   })
 
   it('throws when api not available', async () => {
-    delete (window as any).electronAPI
+    delete window.electronAPI
     await expect(backend.read('/test.txt')).rejects.toThrow('Local filesystem not available (requires Electron)')
   })
 })

--- a/spa/src/lib/interface-subsection-registry.test.ts
+++ b/spa/src/lib/interface-subsection-registry.test.ts
@@ -8,8 +8,27 @@ import {
 
 const Fake = () => null
 
-function make(overrides: Partial<InterfaceSubsection> = {}): InterfaceSubsection {
-  return { id: 'test', label: 'Test', order: 0, component: Fake, ...overrides }
+type MakeOverrides = {
+  id?: string
+  label?: string
+  order?: number
+  component?: typeof Fake
+} & (
+  | { disabled?: false; disabledReason?: never }
+  | { disabled: true; disabledReason?: string }
+)
+
+function make(overrides: MakeOverrides = {}): InterfaceSubsection {
+  const base = { id: 'test', label: 'Test', order: 0, component: Fake }
+  if (overrides.disabled) {
+    return {
+      ...base,
+      ...overrides,
+      disabled: true,
+      disabledReason: overrides.disabledReason ?? 'settings.coming_soon',
+    }
+  }
+  return { ...base, ...overrides }
 }
 
 describe('interface-subsection-registry', () => {

--- a/spa/src/lib/sync/__tests__/snapshot-store.test.ts
+++ b/spa/src/lib/sync/__tests__/snapshot-store.test.ts
@@ -65,7 +65,7 @@ describe('SnapshotStore.listLocal', () => {
     expect(list[0].id).toBe(b.id)
     expect(list[1].id).toBe(a.id)
     // bundle 不應該在 metadata 裡
-    expect((list[0] as Record<string, unknown>).bundle).toBeUndefined()
+    expect('bundle' in list[0]).toBe(false)
   })
 
   it('deleteLocal removes one', async () => {

--- a/spa/src/lib/sync/contributors/hosts.ts
+++ b/spa/src/lib/sync/contributors/hosts.ts
@@ -2,7 +2,7 @@
 // Sync Architecture — HostsContributor
 // =============================================================================
 
-import { useHostStore } from '../../../stores/useHostStore'
+import { useHostStore, type HostConfig } from '../../../stores/useHostStore'
 import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
 
 // ---------------------------------------------------------------------------
@@ -23,9 +23,9 @@ export function createHostsContributor(): SyncContributor {
       const { hosts, hostOrder, activeHostId } = state
 
       // Strip token from each HostConfig; do NOT include runtime (ephemeral)
-      const sanitized: Record<string, unknown> = {}
+      const sanitized: Record<string, Omit<HostConfig, 'token'>> = {}
       for (const [id, config] of Object.entries(hosts)) {
-        const { token, ...rest } = config as Record<string, unknown>
+        const { token, ...rest } = config
         void token // intentionally excluded
         sanitized[id] = rest
       }
@@ -46,25 +46,25 @@ export function createHostsContributor(): SyncContributor {
 
       if (merge.type === 'full-replace') {
         const current = useHostStore.getState().hosts
-        const incomingHosts = (incoming.hosts ?? {}) as Record<string, Record<string, unknown>>
-        const mergedHosts: Record<string, Record<string, unknown>> = {}
+        const incomingHosts = (incoming.hosts ?? {}) as unknown as Record<string, HostConfig>
+        const mergedHosts: Record<string, HostConfig> = {}
         for (const [id, host] of Object.entries(incomingHosts)) {
           // Only preserve token when endpoint identity (ip, port) matches.
           // A bundle reusing an id but pointing at a different endpoint must
           // force re-auth, otherwise a bearer token could be sent to an
           // attacker-controlled daemon.
-          const currentHost = (current as Record<string, { ip?: unknown; port?: unknown; token?: unknown } | undefined>)[id]
+          const currentHost = current[id]
           const sameEndpoint =
             currentHost !== undefined &&
             currentHost.ip === host.ip &&
             currentHost.port === host.port
           mergedHosts[id] = {
             ...host,
-            token: sameEndpoint ? (currentHost.token ?? null) : null,
+            token: sameEndpoint ? currentHost.token : undefined,
           }
         }
         useHostStore.setState({
-          hosts: mergedHosts as ReturnType<typeof useHostStore.getState>['hosts'],
+          hosts: mergedHosts,
           hostOrder: incoming.hostOrder as string[],
           activeHostId: incoming.activeHostId as string | null,
         })
@@ -72,15 +72,17 @@ export function createHostsContributor(): SyncContributor {
       }
 
       // field-merge: only apply fields where resolved[field] === 'remote'
-      const patch: Record<string, unknown> = {}
+      const patch: Partial<Pick<ReturnType<typeof useHostStore.getState>, 'hosts' | 'hostOrder' | 'activeHostId'>> = {}
       for (const field of ['hosts', 'hostOrder', 'activeHostId'] as const) {
         if (merge.resolved[field] === 'remote' && field in incoming) {
-          patch[field] = incoming[field]
+          if (field === 'hosts') patch.hosts = incoming[field] as unknown as Record<string, HostConfig>
+          if (field === 'hostOrder') patch.hostOrder = incoming[field] as string[]
+          if (field === 'activeHostId') patch.activeHostId = incoming[field] as string | null
         }
       }
 
       if (Object.keys(patch).length > 0) {
-        useHostStore.setState(patch as Parameters<typeof useHostStore.setState>[0])
+        useHostStore.setState(patch)
       }
     },
   }

--- a/spa/src/lib/sync/contributors/quick-commands.test.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { createQuickCommandsContributor } from './quick-commands'
 import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import type { QuickCommand } from '../../../stores/useQuickCommandStore'
 import type { FullPayload } from '../types'
 
 // ---------------------------------------------------------------------------
@@ -16,7 +17,7 @@ const DEFAULT_STATE = {
     { id: 'start-cc', name: 'Start Claude Code', command: 'claude -p --verbose --output-format stream-json', category: 'agent' },
     { id: 'start-codex', name: 'Start Codex', command: 'codex', category: 'agent' },
   ],
-  byHost: {} as Record<string, unknown[]>,
+  byHost: {} as Record<string, QuickCommand[]>,
 }
 
 // ---------------------------------------------------------------------------

--- a/spa/src/lib/sync/providers/daemon-provider.ts
+++ b/spa/src/lib/sync/providers/daemon-provider.ts
@@ -37,11 +37,9 @@ export function createDaemonProvider(hostId: string, clientId: string): SyncProv
       return res.json() as Promise<SyncBundle | null>
     },
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async pushChunks(chunks: Record<string, Uint8Array>): Promise<void> {},
+    async pushChunks(_chunks: Record<string, Uint8Array>): Promise<void> {},
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async pullChunks(hashes: string[]): Promise<Record<string, Uint8Array>> { return {} },
+    async pullChunks(_hashes: string[]): Promise<Record<string, Uint8Array>> { return {} },
 
     async listHistory(limit: number): Promise<SyncSnapshot[]> {
       if (!Number.isInteger(limit) || limit < 1) {

--- a/spa/src/lib/sync/providers/file-provider.test.ts
+++ b/spa/src/lib/sync/providers/file-provider.test.ts
@@ -13,6 +13,29 @@ const mockFs = {
   mkdir: vi.fn(),
 }
 
+function decodeBase64(value: string): Uint8Array {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+function getWriteFileCalls(): Array<[path: string, content: string]> {
+  return mockFs.writeFile.mock.calls.map((call) => [String(call[0]), String(call[1])])
+}
+
+function findWriteFileCall(predicate: (path: string) => boolean): [string, string] | undefined {
+  return getWriteFileCalls().find(([path]) => predicate(path))
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -51,30 +74,24 @@ describe('FileProvider', () => {
       await provider.push(bundle)
 
       // manifest.json
-      const manifestCall = mockFs.writeFile.mock.calls.find(([path]: [string]) =>
-        path.endsWith('manifest.json'),
-      )
+      const manifestCall = findWriteFileCall((path) => path.endsWith('manifest.json'))
       expect(manifestCall).toBeDefined()
-      expect(manifestCall[0]).toBe(`${SYNC_FOLDER}/manifest.json`)
-      expect(JSON.parse(manifestCall[1])).toEqual(bundle)
+      expect(manifestCall?.[0]).toBe(`${SYNC_FOLDER}/manifest.json`)
+      expect(JSON.parse(manifestCall?.[1] ?? '')).toEqual(bundle)
 
       // history snapshot
-      const historyCall = mockFs.writeFile.mock.calls.find(([path]: [string]) =>
-        path.includes('/history/'),
-      )
+      const historyCall = findWriteFileCall((path) => path.includes('/history/'))
       expect(historyCall).toBeDefined()
-      expect(historyCall[0]).toMatch(/\/history\/.*\.json$/)
-      expect(JSON.parse(historyCall[1])).toEqual(bundle)
+      expect(historyCall?.[0]).toMatch(/\/history\/.*\.json$/)
+      expect(JSON.parse(historyCall?.[1] ?? '')).toEqual(bundle)
     })
 
     it('history snapshot filename uses ISO timestamp with colons replaced', async () => {
       const provider = createFileProvider(SYNC_FOLDER, mockFs)
       await provider.push(makeBundle())
 
-      const historyCall = mockFs.writeFile.mock.calls.find(([path]: [string]) =>
-        path.includes('/history/'),
-      )
-      const filename = historyCall[0].split('/').pop() as string
+      const historyCall = findWriteFileCall((path) => path.includes('/history/'))
+      const filename = historyCall?.[0].split('/').pop()
       // e.g. 2026-04-16T12-00-00-000Z.json
       expect(filename).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.json$/)
     })
@@ -126,14 +143,11 @@ describe('FileProvider', () => {
       const data = new Uint8Array([1, 2, 3, 4, 5])
       await provider.pushChunks({ abc123: data })
 
-      const chunkCall = mockFs.writeFile.mock.calls.find(([path]: [string]) =>
-        path.includes('/chunks/'),
-      )
+      const chunkCall = findWriteFileCall((path) => path.includes('/chunks/'))
       expect(chunkCall).toBeDefined()
-      expect(chunkCall[0]).toBe(`${SYNC_FOLDER}/chunks/abc123.bin`)
+      expect(chunkCall?.[0]).toBe(`${SYNC_FOLDER}/chunks/abc123.bin`)
       // value must be base64-encoded string
-      const decoded = Buffer.from(chunkCall[1], 'base64')
-      expect(new Uint8Array(decoded)).toEqual(data)
+      expect(decodeBase64(chunkCall?.[1] ?? '')).toEqual(data)
     })
 
     it('calls ensureDirs before writing chunks', async () => {
@@ -155,7 +169,7 @@ describe('FileProvider', () => {
   describe('pullChunks', () => {
     it('reads and decodes chunk files', async () => {
       const data = new Uint8Array([10, 20, 30])
-      const b64 = Buffer.from(data).toString('base64')
+      const b64 = encodeBase64(data)
       mockFs.readFile.mockResolvedValue(b64)
 
       const provider = createFileProvider(SYNC_FOLDER, mockFs)
@@ -177,7 +191,7 @@ describe('FileProvider', () => {
 
     it('returns only present chunks when some are missing', async () => {
       const data = new Uint8Array([99])
-      const b64 = Buffer.from(data).toString('base64')
+      const b64 = encodeBase64(data)
       const notFound = Object.assign(new Error('no such file'), { code: 'ENOENT' })
 
       mockFs.readFile.mockImplementation(async (path: string) => {

--- a/spa/src/lib/sync/providers/file-provider.ts
+++ b/spa/src/lib/sync/providers/file-provider.ts
@@ -11,6 +11,24 @@ export interface FileSystemIpc {
   mkdir(path: string): Promise<void>
 }
 
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = ''
+  const chunkSize = 8192
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+  }
+  return btoa(binary)
+}
+
+function decodeBase64(value: string): Uint8Array {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
 // ---------------------------------------------------------------------------
 // FileProvider — iCloud / Syncthing sync folder
 // ---------------------------------------------------------------------------
@@ -94,7 +112,7 @@ export function createFileProvider(syncFolder: string, fs: FileSystemIpc): SyncP
 
       await Promise.all(
         hashes.map((hash) => {
-          const b64 = Buffer.from(chunks[hash]).toString('base64')
+          const b64 = encodeBase64(chunks[hash])
           return fs.writeFile(`${chunksDir}/${hash}.bin`, b64)
         }),
       )
@@ -107,7 +125,7 @@ export function createFileProvider(syncFolder: string, fs: FileSystemIpc): SyncP
         hashes.map(async (hash) => {
           try {
             const b64 = await fs.readFile(`${chunksDir}/${hash}.bin`)
-            result[hash] = new Uint8Array(Buffer.from(b64, 'base64'))
+            result[hash] = decodeBase64(b64)
           } catch (err) {
             if (isEnoent(err)) return // skip missing chunks
             throw err

--- a/spa/src/lib/sync/providers/manual-provider.ts
+++ b/spa/src/lib/sync/providers/manual-provider.ts
@@ -78,15 +78,11 @@ export function createManualProvider(): ManualProvider {
   return {
     id: 'manual',
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async push(bundle: SyncBundle): Promise<void> {},
+    async push(_bundle: SyncBundle): Promise<void> {},
     async pull(): Promise<SyncBundle | null> { return null },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async pushChunks(chunks: Record<string, Uint8Array>): Promise<void> {},
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async pullChunks(hashes: string[]): Promise<Record<string, Uint8Array>> { return {} },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async listHistory(limit: number): Promise<SyncSnapshot[]> { return [] },
+    async pushChunks(_chunks: Record<string, Uint8Array>): Promise<void> {},
+    async pullChunks(_hashes: string[]): Promise<Record<string, Uint8Array>> { return {} },
+    async listHistory(_limit: number): Promise<SyncSnapshot[]> { return [] },
 
     exportToBlob(bundle: SyncBundle): Blob {
       const json = JSON.stringify(bundle, null, 2)

--- a/spa/src/lib/sync/use-sync-store.test.ts
+++ b/spa/src/lib/sync/use-sync-store.test.ts
@@ -228,6 +228,16 @@ describe('useSyncStore.createPreOperationSnapshot', () => {
         }
       },
       deleteLocal: async () => {},
+      demoteSessionPristine: async () => {},
+      rotateSessionPristine: async (_b, trigger) => ({
+        id: 'stub-id',
+        timestamp: 0,
+        device: 'd',
+        trigger,
+        bundleSize: 0,
+        contributorIds: [],
+        isSessionPristine: true,
+      }),
       compact: async () => ({ kept: [], evicted: [] }),
       clear: async () => {},
     })
@@ -264,6 +274,16 @@ describe('useSyncStore.restoreFromSnapshot', () => {
         }
       },
       deleteLocal: async () => {},
+      demoteSessionPristine: async () => {},
+      rotateSessionPristine: async (_b, trigger) => ({
+        id: 'pre-' + trigger,
+        timestamp: 0,
+        device: 'd',
+        trigger,
+        bundleSize: 0,
+        contributorIds: [],
+        isSessionPristine: true,
+      }),
       compact: async () => ({ kept: [], evicted: [] }),
       clear: async () => {},
     })
@@ -287,7 +307,7 @@ describe('useSyncStore.restoreFromSnapshot', () => {
           strategy: 'full',
           getVersion: () => 1,
           serialize: () => ({ version: 1, data: {} }),
-          deserialize: (_p, merge) => {
+          deserialize: (_p: unknown, merge: { type: string }) => {
             if (merge.type === 'full-replace') deserializeCalls.push('stub1')
           },
         },
@@ -351,6 +371,20 @@ function installStubSnapshotStore(opts: StubSnapshotStoreOptions = {}) {
       }
     },
     deleteLocal: async () => {},
+    demoteSessionPristine: async () => {},
+    rotateSessionPristine: async (_b, trigger) => {
+      await opts.onCreate?.(trigger)
+      preOpCalls.push(trigger)
+      return {
+        id: 'pre-' + trigger,
+        timestamp: 0,
+        device: 'd',
+        trigger,
+        bundleSize: 0,
+        contributorIds: [],
+        isSessionPristine: true,
+      }
+    },
     compact: async () => ({ kept: [], evicted: [] }),
     clear: async () => {},
   })
@@ -560,7 +594,7 @@ describe('createPreOperationSnapshot — coverage (A2)', () => {
         { id: 'a', strategy: 'full', getVersion: () => 1, serialize: () => ({ version: 1, data: {} }), deserialize: () => {} },
         { id: 'b', strategy: 'full', getVersion: () => 1, serialize: () => ({ version: 1, data: {} }), deserialize: () => {} },
       ],
-      serialize: (_device, ids) => {
+      serialize: (_device: string, ids: string[]) => {
         serializedIds = ids
         return { version: 1, timestamp: 0, device: 'd', collections: {} }
       },

--- a/spa/src/lib/tab-lifecycle.test.ts
+++ b/spa/src/lib/tab-lifecycle.test.ts
@@ -15,12 +15,14 @@ function resetStores() {
 describe('closeTab', () => {
   beforeEach(() => {
     resetStores()
-    // @ts-expect-error -- test-only partial mock
-    window.electronAPI = { destroyBrowserView: vi.fn() }
+    Object.defineProperty(window, 'electronAPI', {
+      value: { destroyBrowserView: vi.fn() },
+      configurable: true,
+      writable: true,
+    })
   })
 
   afterEach(() => {
-    // @ts-expect-error -- cleanup
     delete window.electronAPI
   })
 

--- a/spa/src/stores/useHistoryStore.test.ts
+++ b/spa/src/stores/useHistoryStore.test.ts
@@ -13,6 +13,7 @@ function makeContent(kind: PaneContent['kind'] = 'dashboard'): PaneContent {
     case 'history': return { kind: 'history' }
     case 'browser': return { kind: 'browser', url: 'https://example.com' }
     case 'memory-monitor': return { kind: 'memory-monitor' }
+    default: return { kind: 'dashboard' }
   }
 }
 


### PR DESCRIPTION
## Summary
- restore the SPA lint baseline by separating `isGrid4` from `PaneLayoutRenderer` and aligning stale tests with current interfaces
- fix current type drift across preview panes, fs backends, sync providers, drag handling, and statusline helpers so `pnpm --prefix spa run build` passes again
- update targeted tests and fixtures to match the stricter runtime and typing contract on `main`

## Verification
- pnpm --prefix spa run lint
- pnpm --prefix spa run build
- pnpm --prefix spa exec vitest run src/components/PaneLayoutRenderer.test.tsx src/lib/fs-backend-local.test.ts src/components/editor/__tests__/EditorPane.test.tsx src/components/settings/SyncSection.test.tsx src/components/settings/TmuxAgentMonitorSection.test.tsx src/components/SortableTab.test.tsx src/components/TabBar.test.tsx src/components/TabContextMenu.test.tsx src/features/settings/sections/sync-history/hooks/useLocalHistory.test.ts src/features/settings/sections/sync-history/hooks/useSnapshotDiff.test.ts src/features/settings/sections/sync-history/SnapshotHistoryPage.test.tsx src/lib/fs-backend-daemon.test.ts src/lib/interface-subsection-registry.test.ts src/lib/sync/__tests__/snapshot-store.test.ts src/lib/sync/contributors/quick-commands.test.ts src/lib/sync/use-sync-store.test.ts src/lib/tab-lifecycle.test.ts src/stores/useHistoryStore.test.ts

## Links
- Closes #549