### PR TITLE
feat(spa): HSR PR-2 — Purdex settings shell + legacy adapter (dispatch-flushed)

### DIFF
--- a/spa/eslint.config.js
+++ b/spa/eslint.config.js
@@ -5,6 +5,32 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
+// F4: restrict write-side contribution registry APIs to the canonical
+// owners. The @internal JSDoc in `settings-contribution-registry.ts` has
+// no enforcement; this lints against direct imports from any other file.
+// See #539 and the PR-2 design doc §5.3/§7.2.
+const RESTRICTED_CONTRIBUTION_WRITE_IMPORTS = {
+  patterns: [
+    {
+      group: [
+        '**/settings-contribution-registry',
+        '**/settings-contribution-registry.ts',
+      ],
+      importNames: [
+        'registerSettingsContribution',
+        'clearContributions',
+        'assertValidSettingsContribution',
+      ],
+      message:
+        'Write-side contribution registry APIs may only be imported from ' +
+        'dispatch-settings-contributions.ts, settings-section-registry.ts, ' +
+        'or test files. Use listContributions() / getContribution() for ' +
+        'read access; module authors should declare `settings: [...]` on ' +
+        'their ModuleDefinition instead.',
+    },
+  ],
+}
+
 export default defineConfig([
   globalIgnores(['dist', 'src/features/workspace/generated']),
   {
@@ -24,6 +50,24 @@ export default defineConfig([
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
       ],
+      'no-restricted-imports': ['error', RESTRICTED_CONTRIBUTION_WRITE_IMPORTS],
+    },
+  },
+  // Whitelisted callers of the write-side registry APIs. These three files
+  // form the canonical write path:
+  //   - dispatch-settings-contributions.ts: atomic validation + commit
+  //   - settings-section-registry.ts: legacy adapter
+  // Tests disable the rule so they can stage isolated fixtures without
+  // going through the dispatch plumbing.
+  {
+    files: [
+      '**/dispatch-settings-contributions.ts',
+      '**/settings-section-registry.ts',
+      '**/*.test.ts',
+      '**/*.test.tsx',
+    ],
+    rules: {
+      'no-restricted-imports': 'off',
     },
   },
 ])

--- a/spa/src/components/SettingsPage.test.tsx
+++ b/spa/src/components/SettingsPage.test.tsx
@@ -274,3 +274,90 @@ describe('SettingsPage (registry-driven)', () => {
     expect(screen.getByTestId('workspace-settings-mock').textContent).toBe('ws:wsA')
   })
 })
+
+// ---------------------------------------------------------------------------
+// F7 — shell honors `disabled(ctx)`. A contribution that is disabled under
+// the current ctx must NOT mount its component, even if the URL / default
+// selection would otherwise pick it. Shell self-heals to the first
+// non-disabled section (matching the "invalid section" pattern).
+// ---------------------------------------------------------------------------
+
+describe('SettingsPage (F7: disabled contribution gating)', () => {
+  beforeEach(() => {
+    resetLastSection()
+    clearSettingsSectionRegistry()
+    clearContributions()
+    clearModuleRegistry()
+  })
+
+  it('does NOT mount the active component when disabled(ctx) returns true', () => {
+    const Alive = () => <div>ALIVE_BODY</div>
+    const Dead = () => <div>DEAD_BODY</div>
+    registerSettingsContribution({
+      moduleId: 'mod', id: 'mod.alive', localId: 'alive',
+      scope: 'purdex', order: 0, labelKey: 'Alive', component: Alive,
+    })
+    registerSettingsContribution({
+      moduleId: 'mod', id: 'mod.dead', localId: 'dead',
+      scope: 'purdex', order: 1, labelKey: 'Dead', component: Dead,
+      disabled: () => true,
+    })
+
+    // Deep-link straight to the disabled section.
+    const { hook, history } = memoryLocation({ path: '/settings/dead', record: true })
+    render(
+      <Router hook={hook}>
+        <SettingsPage pane={settingsPane} isActive />
+      </Router>,
+    )
+    // Dead component did not render.
+    expect(screen.queryByText('DEAD_BODY')).toBeNull()
+    // Alive (first non-disabled) is mounted instead.
+    expect(screen.getByText('ALIVE_BODY')).toBeTruthy()
+    // URL self-heals to the first non-disabled section.
+    expect((history as string[]).at(-1)).toBe('/settings/alive')
+  })
+
+  it('mounts the component normally when disabled(ctx) returns false', () => {
+    const Alive = () => <div>ALIVE_BODY_2</div>
+    registerSettingsContribution({
+      moduleId: 'mod', id: 'mod.alive', localId: 'alive',
+      scope: 'purdex', order: 0, labelKey: 'Alive', component: Alive,
+      disabled: () => false,
+    })
+
+    const { hook } = memoryLocation({ path: '/settings/alive', record: true })
+    render(
+      <Router hook={hook}>
+        <SettingsPage pane={settingsPane} isActive />
+      </Router>,
+    )
+    expect(screen.getByText('ALIVE_BODY_2')).toBeTruthy()
+  })
+
+  it('treats disabled default (first) as invalid and picks next non-disabled section', () => {
+    const First = () => <div>FIRST_BODY</div>
+    const Second = () => <div>SECOND_BODY</div>
+    registerSettingsContribution({
+      moduleId: 'mod', id: 'mod.first', localId: 'first',
+      scope: 'purdex', order: 0, labelKey: 'First', component: First,
+      disabled: () => true,
+    })
+    registerSettingsContribution({
+      moduleId: 'mod', id: 'mod.second', localId: 'second',
+      scope: 'purdex', order: 1, labelKey: 'Second', component: Second,
+    })
+
+    // Bare /settings — the default would otherwise be `first` by order.
+    const { hook, history } = memoryLocation({ path: '/settings', record: true })
+    render(
+      <Router hook={hook}>
+        <SettingsPage pane={settingsPane} isActive />
+      </Router>,
+    )
+    expect(screen.queryByText('FIRST_BODY')).toBeNull()
+    expect(screen.getByText('SECOND_BODY')).toBeTruthy()
+    // URL should reflect the actual mounted section.
+    expect((history as string[]).at(-1)).toBe('/settings/second')
+  })
+})

--- a/spa/src/components/SettingsPage.test.tsx
+++ b/spa/src/components/SettingsPage.test.tsx
@@ -6,14 +6,22 @@ vi.mock('../features/workspace/lib/icon-path-cache', () => ({
   prefetchWeight: () => Promise.resolve(),
 }))
 
+vi.mock('../features/workspace/components/WorkspaceSettingsPage', () => ({
+  WorkspaceSettingsPage: ({ workspaceId }: { workspaceId: string }) => (
+    <div data-testid="workspace-settings-mock">ws:{workspaceId}</div>
+  ),
+}))
+
 import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Router } from 'wouter'
 import { memoryLocation } from 'wouter/memory-location'
-import { SettingsPage, resetLastSection } from './SettingsPage'
+import { SettingsPage, resetLastSection, useSettingsRoute } from './SettingsPage'
 import { registerSettingsSection, clearSettingsSectionRegistry } from '../lib/settings-section-registry'
-import { clearContributions } from '../lib/settings-contribution-registry'
+import { clearContributions, registerSettingsContribution } from '../lib/settings-contribution-registry'
 import { dispatchSettingsContributions } from '../lib/dispatch-settings-contributions'
+import { clearModuleRegistry } from '../lib/module-registry'
+import type { SettingsContext } from '../lib/settings-contribution-types'
 import { AppearanceSection } from './settings/AppearanceSection'
 import { TerminalSection } from './settings/TerminalSection'
 import type { Pane } from '../types/tab'
@@ -33,6 +41,8 @@ function renderWithLocation(initialPath: string) {
   return { ...result, navigate, hook, history: history as string[] }
 }
 
+const SyncStub = () => <div>SyncStub</div>
+
 describe('SettingsPage', () => {
   beforeEach(() => {
     resetLastSection()
@@ -41,7 +51,7 @@ describe('SettingsPage', () => {
     registerSettingsSection({ id: 'appearance', label: 'Appearance', order: 0, component: AppearanceSection })
     registerSettingsSection({ id: 'terminal', label: 'Terminal', order: 1, component: TerminalSection })
     registerSettingsSection({ id: 'workspace', label: 'Workspace', order: 10 })
-    registerSettingsSection({ id: 'sync', label: 'Sync', order: 11 })
+    registerSettingsSection({ id: 'sync', label: 'Sync', order: 11, component: SyncStub })
     dispatchSettingsContributions([])
   })
 
@@ -107,7 +117,7 @@ describe('SettingsPage subsection', () => {
     clearContributions()
     registerSettingsSection({ id: 'appearance', label: 'Appearance', order: 0, component: AppearanceSection })
     registerSettingsSection({ id: 'terminal', label: 'Terminal', order: 1, component: TerminalSection })
-    registerSettingsSection({ id: 'sync', label: 'Sync', order: 11 })
+    registerSettingsSection({ id: 'sync', label: 'Sync', order: 11, component: SyncStub })
     dispatchSettingsContributions([])
   })
 
@@ -136,5 +146,131 @@ describe('SettingsPage subsection', () => {
     await waitFor(() => {
       expect(hist[hist.length - 1]).toBe('/settings/sync')
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// §3.2 — Registry-driven render + ctx injection + workspace dispatch (PR-2).
+// ---------------------------------------------------------------------------
+
+describe('SettingsPage (registry-driven)', () => {
+  beforeEach(() => {
+    resetLastSection()
+    clearSettingsSectionRegistry()
+    clearContributions()
+    clearModuleRegistry()
+  })
+
+  it('renders a new-registry contribution by label (fake module bypasses legacy adapter)', () => {
+    const captured: SettingsContext[] = []
+    const Fake = ({ ctx }: { ctx: SettingsContext }) => {
+      captured.push(ctx)
+      return <div>MY_FAKE_BODY</div>
+    }
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.primary',
+      localId: 'primary',
+      scope: 'purdex',
+      order: 0,
+      labelKey: 'FAKE_LABEL',
+      component: Fake,
+    })
+
+    const { hook } = memoryLocation({ path: '/settings', record: true })
+    render(
+      <Router hook={hook}>
+        <SettingsPage pane={settingsPane} isActive />
+      </Router>,
+    )
+    expect(screen.getByText('FAKE_LABEL')).toBeTruthy()
+    expect(screen.getByText('MY_FAKE_BODY')).toBeTruthy()
+    expect(captured[0]).toEqual({ scope: 'purdex' })
+  })
+
+  it('renders contributions in ascending `order`', () => {
+    const Body = ({ label }: { label: string }) => <div>{label}</div>
+    const Third = () => <Body label="THIRD" />
+    const First = () => <Body label="FIRST" />
+    const Second = () => <Body label="SECOND" />
+
+    registerSettingsContribution({
+      moduleId: 'm', id: 'm.c', localId: 'c', scope: 'purdex',
+      order: 50, labelKey: 'C', component: Third,
+    })
+    registerSettingsContribution({
+      moduleId: 'm', id: 'm.a', localId: 'a', scope: 'purdex',
+      order: 0, labelKey: 'A', component: First,
+    })
+    registerSettingsContribution({
+      moduleId: 'm', id: 'm.b', localId: 'b', scope: 'purdex',
+      order: 10, labelKey: 'B', component: Second,
+    })
+
+    const { hook } = memoryLocation({ path: '/settings', record: true })
+    render(
+      <Router hook={hook}>
+        <SettingsPage pane={settingsPane} isActive />
+      </Router>,
+    )
+    const sidebar = screen.getByText('A').closest('[class*="w-48"]')
+    expect(sidebar).toBeTruthy()
+    const labels = Array.from(sidebar!.querySelectorAll('button')).map((b) =>
+      b.textContent?.trim(),
+    )
+    expect(labels).toEqual(['A', 'B', 'C'])
+  })
+
+  it('adapter integration: legacy registerSettingsSection + dispatch renders via new registry', () => {
+    const Legacy = () => <div>LEGACY_BODY</div>
+    registerSettingsSection({ id: 'leg', label: 'LEGACY_LABEL', order: 0, component: Legacy })
+    dispatchSettingsContributions([])
+
+    const { hook } = memoryLocation({ path: '/settings', record: true })
+    render(
+      <Router hook={hook}>
+        <SettingsPage pane={settingsPane} isActive />
+      </Router>,
+    )
+    expect(screen.getByText('LEGACY_LABEL')).toBeTruthy()
+    expect(screen.getByText('LEGACY_BODY')).toBeTruthy()
+  })
+
+  it('subsection is exposed via useSettingsRoute()', () => {
+    const Probe = () => {
+      const { subsection } = useSettingsRoute()
+      return <div>sub:{subsection ?? 'null'}</div>
+    }
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.primary',
+      localId: 'primary',
+      scope: 'purdex',
+      order: 0,
+      labelKey: 'Primary',
+      component: Probe,
+    })
+    const { hook } = memoryLocation({ path: '/settings/primary/deep', record: true })
+    render(
+      <Router hook={hook}>
+        <SettingsPage pane={settingsPane} isActive />
+      </Router>,
+    )
+    // "/settings/<section>/<subsection>" preserves subsection via context.
+    expect(screen.getByText('sub:deep')).toBeTruthy()
+  })
+
+  it('dispatches to WorkspaceSettingsPage when pane content has a workspace scope', () => {
+    const workspacePane: Pane = {
+      id: 'pane-ws',
+      content: { kind: 'settings', scope: { workspaceId: 'wsA' } },
+    }
+    const { hook } = memoryLocation({ path: '/settings', record: true })
+    render(
+      <Router hook={hook}>
+        <SettingsPage pane={workspacePane} isActive />
+      </Router>,
+    )
+    expect(screen.getByTestId('workspace-settings-mock').textContent).toBe('ws:wsA')
   })
 })

--- a/spa/src/components/SettingsPage.test.tsx
+++ b/spa/src/components/SettingsPage.test.tsx
@@ -12,6 +12,8 @@ import { Router } from 'wouter'
 import { memoryLocation } from 'wouter/memory-location'
 import { SettingsPage, resetLastSection } from './SettingsPage'
 import { registerSettingsSection, clearSettingsSectionRegistry } from '../lib/settings-section-registry'
+import { clearContributions } from '../lib/settings-contribution-registry'
+import { dispatchSettingsContributions } from '../lib/dispatch-settings-contributions'
 import { AppearanceSection } from './settings/AppearanceSection'
 import { TerminalSection } from './settings/TerminalSection'
 import type { Pane } from '../types/tab'
@@ -35,10 +37,12 @@ describe('SettingsPage', () => {
   beforeEach(() => {
     resetLastSection()
     clearSettingsSectionRegistry()
+    clearContributions()
     registerSettingsSection({ id: 'appearance', label: 'Appearance', order: 0, component: AppearanceSection })
     registerSettingsSection({ id: 'terminal', label: 'Terminal', order: 1, component: TerminalSection })
     registerSettingsSection({ id: 'workspace', label: 'Workspace', order: 10 })
     registerSettingsSection({ id: 'sync', label: 'Sync', order: 11 })
+    dispatchSettingsContributions([])
   })
 
   it('renders sidebar and default appearance section at /settings', () => {
@@ -100,9 +104,11 @@ describe('SettingsPage subsection', () => {
   beforeEach(() => {
     resetLastSection()
     clearSettingsSectionRegistry()
+    clearContributions()
     registerSettingsSection({ id: 'appearance', label: 'Appearance', order: 0, component: AppearanceSection })
     registerSettingsSection({ id: 'terminal', label: 'Terminal', order: 1, component: TerminalSection })
     registerSettingsSection({ id: 'sync', label: 'Sync', order: 11 })
+    dispatchSettingsContributions([])
   })
 
   it('renders /settings/sync/history without self-heal (valid subsection)', async () => {

--- a/spa/src/components/SettingsPage.tsx
+++ b/spa/src/components/SettingsPage.tsx
@@ -1,7 +1,8 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'wouter'
 import type { PaneRendererProps } from '../lib/module-registry'
-import { getSettingsSections } from '../lib/settings-section-registry'
+import { listContributions } from '../lib/settings-contribution-registry'
+import type { SettingsContextFor } from '../lib/settings-contribution-types'
 import { SettingsSidebar } from './settings/SettingsSidebar'
 import { WorkspaceSettingsPage } from '../features/workspace/components/WorkspaceSettingsPage'
 
@@ -39,7 +40,9 @@ export function SettingsPage(props: PaneRendererProps) {
 
 function GlobalSettingsPage() {
   const [location, setLocation] = useLocation()
-  const sections = getSettingsSections()
+  // Pull purdex-scoped contributions from the new registry. `listContributions`
+  // returns a fresh array sorted by `order` ascending on each call.
+  const sections = listContributions('purdex')
 
   const pathAfterSettings = location.startsWith('/settings/')
     ? location.slice('/settings/'.length)
@@ -49,14 +52,14 @@ function GlobalSettingsPage() {
   const urlSubsection = parts[1] || null
 
   const [activeSection, setActiveSection] = useState(() => {
-    if (urlSection && sections.some((s) => s.id === urlSection)) return urlSection
-    if (lastSection && sections.some((s) => s.id === lastSection)) return lastSection
-    return sections.find((s) => s.component)?.id ?? ''
+    if (urlSection && sections.some((s) => s.localId === urlSection)) return urlSection
+    if (lastSection && sections.some((s) => s.localId === lastSection)) return lastSection
+    return sections[0]?.localId ?? ''
   })
 
   // URL → activeSection (e.g. back/forward navigation or TitleBar click)
   useEffect(() => {
-    if (urlSection && sections.some((s) => s.id === urlSection) && urlSection !== activeSection) {
+    if (urlSection && sections.some((s) => s.localId === urlSection) && urlSection !== activeSection) {
       setActiveSection(urlSection)
       lastSection = urlSection
     }
@@ -70,7 +73,7 @@ function GlobalSettingsPage() {
   // SettingsRouteContext so sub-components can render subsection views.
   useEffect(() => {
     if (!urlSection) return
-    const sectionValid = sections.some((s) => s.id === urlSection)
+    const sectionValid = sections.some((s) => s.localId === urlSection)
     if (!sectionValid) {
       setLocation(`/settings/${activeSection}`, { replace: true })
       return
@@ -87,7 +90,10 @@ function GlobalSettingsPage() {
     setLocation(`/settings/${id}`, { replace: true })
   }
 
-  const ActiveComponent = sections.find((s) => s.id === activeSection)?.component
+  const ActiveComponent = sections.find((s) => s.localId === activeSection)?.component
+  // `ctx` is stable per page render — §5.3 rule 4 says only the shell is
+  // allowed to construct it. Purdex scope carries no entity id.
+  const ctx: SettingsContextFor<'purdex'> = useMemo(() => ({ scope: 'purdex' as const }), [])
 
   return (
     <SettingsRouteContext.Provider
@@ -103,7 +109,7 @@ function GlobalSettingsPage() {
       <div className="flex h-full">
         <SettingsSidebar activeSection={activeSection} onSelectSection={handleSelectSection} />
         <div className="flex-1 overflow-y-auto p-6">
-          {ActiveComponent && <ActiveComponent />}
+          {ActiveComponent && <ActiveComponent ctx={ctx} />}
         </div>
       </div>
     </SettingsRouteContext.Provider>

--- a/spa/src/components/SettingsPage.tsx
+++ b/spa/src/components/SettingsPage.tsx
@@ -44,6 +44,23 @@ function GlobalSettingsPage() {
   // returns a fresh array sorted by `order` ascending on each call.
   const sections = listContributions('purdex')
 
+  // `ctx` is stable per page render — §5.3 rule 4 says only the shell is
+  // allowed to construct it. Purdex scope carries no entity id.
+  const ctx: SettingsContextFor<'purdex'> = useMemo(() => ({ scope: 'purdex' as const }), [])
+
+  // F7: a contribution whose `disabled(ctx)` returns true is treated as
+  // invalid for navigation — it stays visible in the sidebar (rendered
+  // greyed out) but the shell will never mount it. `isSelectable()` is
+  // the single predicate used by (a) the URL self-heal effect and (b)
+  // the default-section fallback.
+  const isSelectable = (localId: string): boolean => {
+    const c = sections.find((s) => s.localId === localId)
+    if (!c) return false
+    if (c.disabled && c.disabled(ctx) === true) return false
+    return true
+  }
+  const firstSelectable = sections.find((s) => isSelectable(s.localId))?.localId ?? ''
+
   const pathAfterSettings = location.startsWith('/settings/')
     ? location.slice('/settings/'.length)
     : null
@@ -52,14 +69,15 @@ function GlobalSettingsPage() {
   const urlSubsection = parts[1] || null
 
   const [activeSection, setActiveSection] = useState(() => {
-    if (urlSection && sections.some((s) => s.localId === urlSection)) return urlSection
-    if (lastSection && sections.some((s) => s.localId === lastSection)) return lastSection
-    return sections[0]?.localId ?? ''
+    if (urlSection && isSelectable(urlSection)) return urlSection
+    if (lastSection && isSelectable(lastSection)) return lastSection
+    return firstSelectable
   })
 
-  // URL → activeSection (e.g. back/forward navigation or TitleBar click)
+  // URL → activeSection (e.g. back/forward navigation or TitleBar click).
+  // F7: only honor URL sections that are actually selectable under ctx.
   useEffect(() => {
-    if (urlSection && sections.some((s) => s.localId === urlSection) && urlSection !== activeSection) {
+    if (urlSection && isSelectable(urlSection) && urlSection !== activeSection) {
       setActiveSection(urlSection)
       lastSection = urlSection
     }
@@ -67,14 +85,13 @@ function GlobalSettingsPage() {
   }, [urlSection])
 
   // Self-heal:
-  //   1. invalid section → /settings/<activeSection>
+  //   1. invalid OR disabled-by-ctx section → /settings/<activeSection>
   //   2. >2 path segments (e.g. /settings/sync/extra/level3) → /settings/<section>
   // Valid /settings/<section>/<subsection> URLs are preserved and exposed via
   // SettingsRouteContext so sub-components can render subsection views.
   useEffect(() => {
     if (!urlSection) return
-    const sectionValid = sections.some((s) => s.localId === urlSection)
-    if (!sectionValid) {
+    if (!isSelectable(urlSection)) {
       setLocation(`/settings/${activeSection}`, { replace: true })
       return
     }
@@ -84,16 +101,35 @@ function GlobalSettingsPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlSection, urlSubsection, activeSection])
 
+  // F7: if the current URL is `/settings` (no urlSection) and the
+  // initial pick was not selectable (e.g. all contributions disabled
+  // except one further down the order), advance the URL to match the
+  // mounted section so route-sync round-trips correctly.
+  useEffect(() => {
+    if (urlSection) return
+    if (!activeSection) return
+    if (location === `/settings/${activeSection}`) return
+    // Only push the canonical URL when we actually have a selectable
+    // section to mount — avoids spurious history entries during tests
+    // that register zero contributions.
+    if (isSelectable(activeSection)) {
+      setLocation(`/settings/${activeSection}`, { replace: true })
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlSection, activeSection])
+
   const handleSelectSection = (id: string) => {
+    // Guard: the sidebar already suppresses clicks on disabled rows, but
+    // belt-and-braces in case a future caller bypasses that UI path.
+    if (!isSelectable(id)) return
     lastSection = id
     setActiveSection(id)
     setLocation(`/settings/${id}`, { replace: true })
   }
 
-  const ActiveComponent = sections.find((s) => s.localId === activeSection)?.component
-  // `ctx` is stable per page render — §5.3 rule 4 says only the shell is
-  // allowed to construct it. Purdex scope carries no entity id.
-  const ctx: SettingsContextFor<'purdex'> = useMemo(() => ({ scope: 'purdex' as const }), [])
+  const ActiveComponent = isSelectable(activeSection)
+    ? sections.find((s) => s.localId === activeSection)?.component
+    : undefined
 
   return (
     <SettingsRouteContext.Provider

--- a/spa/src/components/settings/SettingsSidebar.test.tsx
+++ b/spa/src/components/settings/SettingsSidebar.test.tsx
@@ -2,16 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { SettingsSidebar } from './SettingsSidebar'
 import { registerSettingsSection, clearSettingsSectionRegistry } from '../../lib/settings-section-registry'
+import { clearContributions } from '../../lib/settings-contribution-registry'
+import { dispatchSettingsContributions } from '../../lib/dispatch-settings-contributions'
 
 const FakeComponent = () => null
 
 describe('SettingsSidebar', () => {
   beforeEach(() => {
     clearSettingsSectionRegistry()
+    clearContributions()
     registerSettingsSection({ id: 'appearance', label: 'Appearance', order: 0, component: FakeComponent })
     registerSettingsSection({ id: 'terminal', label: 'Terminal', order: 1, component: FakeComponent })
     registerSettingsSection({ id: 'workspace', label: 'Workspace', order: 10 })
     registerSettingsSection({ id: 'sync', label: 'Sync', order: 11 })
+    dispatchSettingsContributions([])
   })
 
   it('renders all section items', () => {

--- a/spa/src/components/settings/SettingsSidebar.test.tsx
+++ b/spa/src/components/settings/SettingsSidebar.test.tsx
@@ -2,8 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { SettingsSidebar } from './SettingsSidebar'
 import { registerSettingsSection, clearSettingsSectionRegistry } from '../../lib/settings-section-registry'
-import { clearContributions } from '../../lib/settings-contribution-registry'
+import {
+  clearContributions,
+  registerSettingsContribution,
+} from '../../lib/settings-contribution-registry'
 import { dispatchSettingsContributions } from '../../lib/dispatch-settings-contributions'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
 
 const FakeComponent = () => null
 
@@ -50,5 +54,131 @@ describe('SettingsSidebar', () => {
     render(<SettingsSidebar activeSection="appearance" onSelectSection={vi.fn()} />)
     const badges = screen.getAllByText('coming soon')
     expect(badges.length).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F7 — honor `disabled(ctx)` + `disabledReasonKey` on active contributions.
+// Reserved (legacy `registerSettingsSection` without a component) is still
+// its own separate bucket below the divider; disabled-by-ctx rows render in
+// their natural order, styled disabled, with the reason key shown as title
+// tooltip (falls back to the key if i18n has no entry).
+// ---------------------------------------------------------------------------
+
+describe('SettingsSidebar (F7: disabled-by-ctx)', () => {
+  const FakeComp = () => null
+
+  beforeEach(() => {
+    clearSettingsSectionRegistry()
+    clearContributions()
+    // A plain enabled row so we can verify ordering + interaction.
+    registerSettingsSection({ id: 'appearance', label: 'Appearance', order: 0, component: FakeComp })
+    dispatchSettingsContributions([])
+  })
+
+  it('renders a disabled-by-ctx row but does not invoke onSelectSection on click', () => {
+    registerSettingsContribution({
+      moduleId: 'mod',
+      id: 'mod.gated',
+      localId: 'gated',
+      scope: 'purdex',
+      order: 5,
+      labelKey: 'GatedLabel',
+      component: FakeComp,
+      disabled: (_ctx: SettingsContextFor<'purdex'>) => true,
+    })
+
+    const onSelect = vi.fn()
+    render(<SettingsSidebar activeSection="appearance" onSelectSection={onSelect} />)
+    // The row is rendered (visible in the sidebar).
+    const row = screen.getByText('GatedLabel').closest('[data-section]')
+    expect(row).toBeTruthy()
+    // Click is a no-op.
+    fireEvent.click(screen.getByText('GatedLabel'))
+    expect(onSelect).not.toHaveBeenCalled()
+    // `data-disabled-ctx="true"` so downstream code / tests can distinguish
+    // it from a reserved row.
+    expect(row!.getAttribute('data-disabled-ctx')).toBe('true')
+  })
+
+  it('surfaces disabledReasonKey via title tooltip when provided', () => {
+    registerSettingsContribution({
+      moduleId: 'mod',
+      id: 'mod.gated',
+      localId: 'gated',
+      scope: 'purdex',
+      order: 5,
+      labelKey: 'GatedLabel',
+      component: FakeComp,
+      disabled: () => true,
+      disabledReasonKey: 'mod.gated.reason',
+    })
+
+    render(<SettingsSidebar activeSection="appearance" onSelectSection={vi.fn()} />)
+    const row = screen.getByText('GatedLabel').closest('[data-section]') as HTMLElement
+    // The i18n key itself is used as the fallback when the bundle has no
+    // translation — `t(key)` returns `key` in that case.
+    expect(row.getAttribute('title')).toBe('mod.gated.reason')
+  })
+
+  it('does not mark a contribution disabled when disabled(ctx) returns false', () => {
+    registerSettingsContribution({
+      moduleId: 'mod',
+      id: 'mod.alive',
+      localId: 'alive',
+      scope: 'purdex',
+      order: 5,
+      labelKey: 'AliveLabel',
+      component: FakeComp,
+      disabled: () => false,
+    })
+
+    const onSelect = vi.fn()
+    render(<SettingsSidebar activeSection="appearance" onSelectSection={onSelect} />)
+    const row = screen.getByText('AliveLabel').closest('[data-section]') as HTMLElement
+    expect(row.getAttribute('data-disabled-ctx')).toBeNull()
+    fireEvent.click(screen.getByText('AliveLabel'))
+    expect(onSelect).toHaveBeenCalledWith('alive')
+  })
+
+  it('omitted `disabled` defaults to enabled', () => {
+    registerSettingsContribution({
+      moduleId: 'mod',
+      id: 'mod.plain',
+      localId: 'plain',
+      scope: 'purdex',
+      order: 5,
+      labelKey: 'PlainLabel',
+      component: FakeComp,
+    })
+
+    const onSelect = vi.fn()
+    render(<SettingsSidebar activeSection="appearance" onSelectSection={onSelect} />)
+    fireEvent.click(screen.getByText('PlainLabel'))
+    expect(onSelect).toHaveBeenCalledWith('plain')
+  })
+
+  it('disabled-by-ctx rows appear in natural order (not grouped with reserved)', () => {
+    // reserved at order=10
+    registerSettingsSection({ id: 'reserved', label: 'Reserved', order: 10 })
+    // disabled-by-ctx active contribution at order=5 — should sort BEFORE reserved,
+    // since ordering is by `order`, not by enabled/disabled bucket.
+    registerSettingsContribution({
+      moduleId: 'mod',
+      id: 'mod.gated',
+      localId: 'gated',
+      scope: 'purdex',
+      order: 5,
+      labelKey: 'GatedLabel',
+      component: FakeComp,
+      disabled: () => true,
+    })
+
+    render(<SettingsSidebar activeSection="appearance" onSelectSection={vi.fn()} />)
+    const labels = Array.from(document.querySelectorAll('[data-section]')).map((el) =>
+      el.querySelector('span')?.textContent?.trim(),
+    )
+    // order: appearance(0) → gated(5) → reserved(10)
+    expect(labels).toEqual(['Appearance', 'GatedLabel', 'Reserved'])
   })
 })

--- a/spa/src/components/settings/SettingsSidebar.tsx
+++ b/spa/src/components/settings/SettingsSidebar.tsx
@@ -1,4 +1,5 @@
-import { getSettingsSections } from '../../lib/settings-section-registry'
+import { listContributions } from '../../lib/settings-contribution-registry'
+import { listReservedItems } from '../../lib/settings-section-registry'
 import { useI18nStore } from '../../stores/useI18nStore'
 
 interface Props {
@@ -6,38 +7,64 @@ interface Props {
   onSelectSection: (section: string) => void
 }
 
+// Row shape used by the sidebar. Active rows come from `listContributions`;
+// reserved rows come from `listReservedItems` with a missing component so the
+// UI still renders a disabled "coming soon" entry.
+interface SidebarRow {
+  id: string         // localId for active; reserved def.id for reserved
+  labelKey: string
+  order: number
+  enabled: boolean
+}
+
 export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
   const t = useI18nStore((s) => s.t)
-  const sections = getSettingsSections()
-  const reservedStart = sections.findIndex((s) => !s.component)
+
+  const rows: SidebarRow[] = [
+    ...listContributions('purdex').map((c) => ({
+      id: c.localId,
+      labelKey: c.labelKey,
+      order: c.order,
+      enabled: true,
+    })),
+    ...listReservedItems().map((r) => ({
+      id: r.id,
+      labelKey: r.label,
+      order: r.order,
+      enabled: false,
+    })),
+  ].sort((a, b) => a.order - b.order)
+
+  // Reserved rows are exactly the disabled rows in the merged list. Keep the
+  // divider logic until PR-3 clears the remaining reserved entry.
+  const reservedStart = rows.findIndex((r) => !r.enabled)
 
   return (
     <div className="w-48 border-r border-border-subtle bg-surface-primary py-3 pl-2 flex-shrink-0">
       <div className="px-4 mb-2 text-[10px] text-text-muted uppercase tracking-wider">{t('settings.title')}</div>
-      {sections.map((item, i) => {
-        const isActive = item.id === activeSection
-        const enabled = !!item.component
+      {rows.map((row, i) => {
+        const isActive = row.id === activeSection
         const showDivider = i === reservedStart && reservedStart > 0
 
         return (
-          <div key={item.id}>
+          <div key={row.id}>
             {showDivider && <div className="mx-3 my-2 border-t border-border-subtle" />}
             <button
-              data-section={item.id}
+              data-section={row.id}
               data-active={isActive ? 'true' : undefined}
               onClick={() => {
-                if (enabled) onSelectSection(item.id)
+                if (row.enabled) onSelectSection(row.id)
               }}
               className={`w-full text-left px-4 py-2 text-sm flex items-center transition-colors ${
-                !enabled
+                !row.enabled
                   ? 'text-text-muted cursor-not-allowed'
                   : isActive
                     ? 'bg-surface-elevated text-text-primary border-l-2 border-border-active'
                     : 'text-text-secondary cursor-pointer hover:bg-white/5'
               }`}
             >
-              <span>{t(item.label)}</span>
-              {!enabled && (
+              <span>{t(row.labelKey)}</span>
+              {!row.enabled && (
                 <span className="text-[10px] text-text-muted ml-auto">{t('settings.coming_soon')}</span>
               )}
             </button>

--- a/spa/src/components/settings/SettingsSidebar.tsx
+++ b/spa/src/components/settings/SettingsSidebar.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from 'react'
 import { listContributions } from '../../lib/settings-contribution-registry'
 import { listReservedItems } from '../../lib/settings-section-registry'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
 import { useI18nStore } from '../../stores/useI18nStore'
 
 interface Props {
@@ -7,37 +9,61 @@ interface Props {
   onSelectSection: (section: string) => void
 }
 
-// Row shape used by the sidebar. Active rows come from `listContributions`;
-// reserved rows come from `listReservedItems` with a missing component so the
-// UI still renders a disabled "coming soon" entry.
+// Row shape used by the sidebar. There are three row kinds:
+//
+//   1. Active, enabled: from `listContributions('purdex')`; clickable.
+//   2. Active, disabled-by-ctx (F7): from `listContributions('purdex')`
+//      but `disabled(ctx)` returned true. Rendered in its natural `order`
+//      slot (NOT pushed below the reserved divider), styled disabled,
+//      click is a no-op. Tooltip carries the i18n'd `disabledReasonKey`.
+//   3. Reserved (legacy coming-soon): from `listReservedItems()`. These
+//      are the rows registered via `registerSettingsSection` with no
+//      component; they stay below the divider.
+//
+// The divider sits before the first reserved row, so disabled-by-ctx rows
+// remain intermixed with enabled rows by `order`, which matches the
+// spec's "author decides ordering" rule.
 interface SidebarRow {
-  id: string         // localId for active; reserved def.id for reserved
+  id: string
   labelKey: string
   order: number
-  enabled: boolean
+  kind: 'active-enabled' | 'active-disabled' | 'reserved'
+  disabledReasonKey?: string
 }
 
 export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
   const t = useI18nStore((s) => s.t)
 
+  // F7: ctx construction is the shell's job (§5.3 rule 4). Purdex scope
+  // carries no entity id, so it is stable across renders — memoize.
+  const ctx = useMemo<SettingsContextFor<'purdex'>>(
+    () => ({ scope: 'purdex' as const }),
+    [],
+  )
+
   const rows: SidebarRow[] = [
-    ...listContributions('purdex').map((c) => ({
-      id: c.localId,
-      labelKey: c.labelKey,
-      order: c.order,
-      enabled: true,
-    })),
-    ...listReservedItems().map((r) => ({
+    ...listContributions('purdex').map<SidebarRow>((c) => {
+      const isDisabled = c.disabled ? c.disabled(ctx) === true : false
+      return {
+        id: c.localId,
+        labelKey: c.labelKey,
+        order: c.order,
+        kind: isDisabled ? 'active-disabled' : 'active-enabled',
+        disabledReasonKey: c.disabledReasonKey,
+      }
+    }),
+    ...listReservedItems().map<SidebarRow>((r) => ({
       id: r.id,
       labelKey: r.label,
       order: r.order,
-      enabled: false,
+      kind: 'reserved',
     })),
   ].sort((a, b) => a.order - b.order)
 
-  // Reserved rows are exactly the disabled rows in the merged list. Keep the
-  // divider logic until PR-3 clears the remaining reserved entry.
-  const reservedStart = rows.findIndex((r) => !r.enabled)
+  // Divider sits above the first reserved row. Disabled-by-ctx rows do
+  // NOT participate in the divider pivot (they live inline with their
+  // enabled siblings).
+  const reservedStart = rows.findIndex((r) => r.kind === 'reserved')
 
   return (
     <div className="w-48 border-r border-border-subtle bg-surface-primary py-3 pl-2 flex-shrink-0">
@@ -45,6 +71,11 @@ export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
       {rows.map((row, i) => {
         const isActive = row.id === activeSection
         const showDivider = i === reservedStart && reservedStart > 0
+        const clickable = row.kind === 'active-enabled'
+        const title =
+          row.kind === 'active-disabled' && row.disabledReasonKey
+            ? t(row.disabledReasonKey)
+            : undefined
 
         return (
           <div key={row.id}>
@@ -52,11 +83,13 @@ export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
             <button
               data-section={row.id}
               data-active={isActive ? 'true' : undefined}
+              data-disabled-ctx={row.kind === 'active-disabled' ? 'true' : undefined}
+              title={title}
               onClick={() => {
-                if (row.enabled) onSelectSection(row.id)
+                if (clickable) onSelectSection(row.id)
               }}
               className={`w-full text-left px-4 py-2 text-sm flex items-center transition-colors ${
-                !row.enabled
+                !clickable
                   ? 'text-text-muted cursor-not-allowed'
                   : isActive
                     ? 'bg-surface-elevated text-text-primary border-l-2 border-border-active'
@@ -64,7 +97,7 @@ export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
               }`}
             >
               <span>{t(row.labelKey)}</span>
-              {!row.enabled && (
+              {row.kind === 'reserved' && (
                 <span className="text-[10px] text-text-muted ml-auto">{t('settings.coming_soon')}</span>
               )}
             </button>

--- a/spa/src/lib/dispatch-settings-contributions.test.ts
+++ b/spa/src/lib/dispatch-settings-contributions.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { clearModuleRegistry, registerModule, type ModuleDefinition } from './module-registry'
 import { clearContributions, listContributions } from './settings-contribution-registry'
 import { dispatchSettingsContributions } from './dispatch-settings-contributions'
-import { drainLegacyContributionQueue } from './settings-section-registry'
+import {
+  drainLegacyContributionQueue,
+  registerSettingsSection,
+  clearLegacyPending,
+} from './settings-section-registry'
 
 const FakeComponent = () => null
 
@@ -11,6 +15,7 @@ function resetRegistries() {
   clearContributions()
   // Drain any leftover legacy pending buffer from previous tests.
   drainLegacyContributionQueue()
+  clearLegacyPending()
 }
 
 describe('dispatchSettingsContributions', () => {
@@ -70,5 +75,124 @@ describe('dispatchSettingsContributions', () => {
     expect(listContributions('purdex')).toEqual([])
     expect(listContributions('host')).toEqual([])
     expect(listContributions('workspace')).toEqual([])
+  })
+
+  // --- F1: per-scope localId uniqueness at dispatch -----------------------
+
+  describe('F1: per-scope localId uniqueness', () => {
+    it('throws when two modules declare the same localId under the same scope', () => {
+      registerModule({
+        id: 'moduleA',
+        name: 'Module A',
+        settings: [
+          { localId: 'general', scope: 'purdex', order: 0, labelKey: 'a.general', component: FakeComponent },
+        ],
+      })
+      registerModule({
+        id: 'moduleB',
+        name: 'Module B',
+        settings: [
+          { localId: 'general', scope: 'purdex', order: 1, labelKey: 'b.general', component: FakeComponent },
+        ],
+      })
+
+      // Error must name both sources so the author can locate them.
+      let thrown: Error | undefined
+      try {
+        dispatchSettingsContributions()
+      } catch (e) {
+        thrown = e as Error
+      }
+      expect(thrown).toBeDefined()
+      expect(thrown!.message).toMatch(/localId "general"/)
+      expect(thrown!.message).toMatch(/purdex/)
+      expect(thrown!.message).toMatch(/moduleA\.general/)
+      expect(thrown!.message).toMatch(/moduleB\.general/)
+    })
+
+    it('throws when a legacy section collides with a module-declared localId in purdex scope', () => {
+      registerModule({
+        id: 'foo',
+        name: 'Foo',
+        settings: [
+          { localId: 'appearance', scope: 'purdex', order: 0, labelKey: 'foo.appearance', component: FakeComponent },
+        ],
+      })
+      registerSettingsSection({ id: 'appearance', label: 'Legacy', order: 0, component: FakeComponent })
+
+      let thrown: Error | undefined
+      try {
+        dispatchSettingsContributions()
+      } catch (e) {
+        thrown = e as Error
+      }
+      expect(thrown).toBeDefined()
+      expect(thrown!.message).toMatch(/localId "appearance"/)
+      expect(thrown!.message).toMatch(/purdex/)
+    })
+
+    it('does NOT throw when same localId appears under different scopes', () => {
+      registerModule({
+        id: 'moduleA',
+        name: 'Module A',
+        settings: [
+          { localId: 'general', scope: 'purdex', order: 0, labelKey: 'a.general', component: FakeComponent },
+        ],
+      })
+      registerModule({
+        id: 'moduleB',
+        name: 'Module B',
+        settings: [
+          { localId: 'general', scope: 'host', order: 0, labelKey: 'b.general', component: FakeComponent },
+        ],
+      })
+
+      expect(() => dispatchSettingsContributions()).not.toThrow()
+      expect(listContributions('purdex').map((c) => c.id)).toEqual(['moduleA.general'])
+      expect(listContributions('host').map((c) => c.id)).toEqual(['moduleB.general'])
+    })
+
+    it('does NOT throw when different localIds coexist under the same scope', () => {
+      registerModule({
+        id: 'moduleA',
+        name: 'Module A',
+        settings: [
+          { localId: 'general', scope: 'purdex', order: 0, labelKey: 'a.general', component: FakeComponent },
+          { localId: 'advanced', scope: 'purdex', order: 1, labelKey: 'a.advanced', component: FakeComponent },
+        ],
+      })
+
+      expect(() => dispatchSettingsContributions()).not.toThrow()
+      expect(listContributions('purdex').map((c) => c.localId)).toEqual(['general', 'advanced'])
+    })
+
+    it('leaves registry state unchanged when a localId collision throws', () => {
+      registerModule({
+        id: 'moduleA',
+        name: 'Module A',
+        settings: [
+          { localId: 'general', scope: 'purdex', order: 0, labelKey: 'a.general', component: FakeComponent },
+        ],
+      })
+      registerModule({
+        id: 'moduleB',
+        name: 'Module B',
+        settings: [
+          { localId: 'general', scope: 'purdex', order: 1, labelKey: 'b.general', component: FakeComponent },
+        ],
+      })
+
+      let thrown: Error | undefined
+      try {
+        dispatchSettingsContributions()
+      } catch (e) {
+        thrown = e as Error
+      }
+      expect(thrown).toBeDefined()
+      // No partial write — nothing registered at all.
+      expect(listContributions('purdex')).toEqual([])
+      expect(listContributions('host')).toEqual([])
+      expect(listContributions('workspace')).toEqual([])
+    })
   })
 })

--- a/spa/src/lib/dispatch-settings-contributions.test.ts
+++ b/spa/src/lib/dispatch-settings-contributions.test.ts
@@ -4,6 +4,7 @@ import { clearContributions, listContributions } from './settings-contribution-r
 import { dispatchSettingsContributions } from './dispatch-settings-contributions'
 import {
   drainLegacyContributionQueue,
+  peekLegacyContributionQueue,
   registerSettingsSection,
   clearLegacyPending,
 } from './settings-section-registry'
@@ -164,6 +165,90 @@ describe('dispatchSettingsContributions', () => {
 
       expect(() => dispatchSettingsContributions()).not.toThrow()
       expect(listContributions('purdex').map((c) => c.localId)).toEqual(['general', 'advanced'])
+    })
+
+    // --- F3: atomic legacy drain — validate before committing -------------
+
+    describe('F3: atomic legacy drain', () => {
+      it('legacy queue survives when module-declared validation fails', () => {
+        // A module with an invariant-violation (globalConfig + settings[scope=purdex]).
+        registerModule({
+          id: 'bad',
+          name: 'Bad',
+          globalConfig: [{ key: 'x', type: 'string', label: 'x' }],
+          settings: [
+            { localId: 'globalConfig', scope: 'purdex', order: 0, labelKey: 'bad.gc', component: FakeComponent },
+          ],
+        })
+        // A valid legacy section queued.
+        registerSettingsSection({ id: 'kept', label: 'Kept', order: 5, component: FakeComponent })
+
+        expect(() => dispatchSettingsContributions()).toThrow(/bad.*globalConfig.*purdex/)
+
+        // Legacy queue MUST be preserved so the next dispatch (after the
+        // user fixes the module) can still commit the previously-queued
+        // legacy sections without requiring the author to re-register them.
+        const peeked = peekLegacyContributionQueue()
+        expect(peeked).toHaveLength(1)
+        expect(peeked[0].localId).toBe('kept')
+      })
+
+      it('legacy queue survives when legacy-vs-module localId collision throws (F1)', () => {
+        registerModule({
+          id: 'foo',
+          name: 'Foo',
+          settings: [
+            { localId: 'appearance', scope: 'purdex', order: 0, labelKey: 'foo.appearance', component: FakeComponent },
+          ],
+        })
+        registerSettingsSection({ id: 'appearance', label: 'Legacy', order: 0, component: FakeComponent })
+
+        let thrown: Error | undefined
+        try {
+          dispatchSettingsContributions()
+        } catch (e) {
+          thrown = e as Error
+        }
+        expect(thrown).toBeDefined()
+        expect(peekLegacyContributionQueue()).toHaveLength(1)
+      })
+
+      it('retry after fixing the conflict succeeds without author re-registration', () => {
+        registerModule({
+          id: 'bad',
+          name: 'Bad',
+          globalConfig: [{ key: 'x', type: 'string', label: 'x' }],
+          settings: [
+            { localId: 'globalConfig', scope: 'purdex', order: 0, labelKey: 'bad.gc', component: FakeComponent },
+          ],
+        })
+        registerSettingsSection({ id: 'kept', label: 'Kept', order: 5, component: FakeComponent })
+
+        expect(() => dispatchSettingsContributions()).toThrow()
+
+        // Simulate fixing the module by removing the bad one, then retry.
+        clearModuleRegistry()
+        expect(() => dispatchSettingsContributions()).not.toThrow()
+
+        const ids = listContributions('purdex').map((c) => c.id)
+        expect(ids).toContain('_builtin.legacy-section.kept')
+      })
+
+      it('happy path: valid dispatch clears queue + populates registry (unchanged)', () => {
+        registerSettingsSection({ id: 'ok', label: 'OK', order: 0, component: FakeComponent })
+        dispatchSettingsContributions()
+        expect(peekLegacyContributionQueue()).toEqual([])
+        expect(listContributions('purdex').map((c) => c.id)).toContain('_builtin.legacy-section.ok')
+      })
+
+      it('peek is non-destructive — repeated calls return same data', () => {
+        registerSettingsSection({ id: 'a', label: 'A', order: 0, component: FakeComponent })
+        registerSettingsSection({ id: 'b', label: 'B', order: 1, component: FakeComponent })
+        const first = peekLegacyContributionQueue()
+        const second = peekLegacyContributionQueue()
+        expect(first.map((d) => d.localId)).toEqual(['a', 'b'])
+        expect(second.map((d) => d.localId)).toEqual(['a', 'b'])
+      })
     })
 
     it('leaves registry state unchanged when a localId collision throws', () => {

--- a/spa/src/lib/dispatch-settings-contributions.test.ts
+++ b/spa/src/lib/dispatch-settings-contributions.test.ts
@@ -2,12 +2,15 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { clearModuleRegistry, registerModule, type ModuleDefinition } from './module-registry'
 import { clearContributions, listContributions } from './settings-contribution-registry'
 import { dispatchSettingsContributions } from './dispatch-settings-contributions'
+import { drainLegacyContributionQueue } from './settings-section-registry'
 
 const FakeComponent = () => null
 
 function resetRegistries() {
   clearModuleRegistry()
   clearContributions()
+  // Drain any leftover legacy pending buffer from previous tests.
+  drainLegacyContributionQueue()
 }
 
 describe('dispatchSettingsContributions', () => {
@@ -29,6 +32,15 @@ describe('dispatchSettingsContributions', () => {
 
     expect(listContributions('purdex').map((item) => item.id)).toEqual(['repeatable.general'])
     expect(listContributions('host').map((item) => item.id)).toEqual(['repeatable.host'])
+  })
+
+  it('drains legacy pending contribution queue as part of the dispatch pass', () => {
+    // Stub-level smoke: drainLegacyContributionQueue is exported and called
+    // by dispatch. Stub returns [] so behavior is unchanged relative to main;
+    // commit 2 replaces the stub with real pending-buffer semantics.
+    expect(drainLegacyContributionQueue).toBeTypeOf('function')
+    expect(() => dispatchSettingsContributions([])).not.toThrow()
+    expect(drainLegacyContributionQueue()).toEqual([])
   })
 
   it('does not leave partial registry state behind when a later module fails validation', () => {

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -4,7 +4,13 @@ import {
   clearContributions,
   registerSettingsContribution,
 } from './settings-contribution-registry'
+import { drainLegacyContributionQueue } from './settings-section-registry'
 import type { AnySettingsContribution } from './settings-contribution-types'
+
+// Legacy adapter namespace constant — sections registered through the legacy
+// `registerSettingsSection()` API are flushed into the new registry under this
+// moduleId. Centralized so PR-3/4 can reuse the same pattern.
+const LEGACY_SECTION_MODULE_ID = '_builtin.legacy-section'
 
 function assertNoLegacyScopeConflict(module: ModuleDefinition): void {
   const settings = module.settings
@@ -58,6 +64,31 @@ export function buildSettingsContributionBatch(
       seenIds.add(full.id)
       batch.push(full)
     }
+  }
+
+  // Drain legacy adapter pending buffer. Commit 1 stub returns [] so behavior
+  // matches main. Commit 2 wires the real pending buffer, at which point each
+  // `registerSettingsSection()` call push declarations here that get composed
+  // with module-declared contributions in the same atomic pass.
+  const legacyDecls = drainLegacyContributionQueue()
+  for (const decl of legacyDecls) {
+    const full = {
+      ...decl,
+      moduleId: LEGACY_SECTION_MODULE_ID,
+      id: `${LEGACY_SECTION_MODULE_ID}.${decl.localId}`,
+    } as AnySettingsContribution
+    assertValidSettingsContribution(full)
+    if (seenIds.has(full.id)) {
+      // Defensive: legacy moduleId is fixed to `_builtin.legacy-section`, so
+      // collisions between module-declared and legacy ids imply an author
+      // prefixed their own moduleId with `_builtin.legacy-section` — reject.
+      throw new Error(
+        `settings-contribution-registry: duplicate contribution id "${full.id}" ` +
+          `(legacy adapter collides with module-declared contribution)`,
+      )
+    }
+    seenIds.add(full.id)
+    batch.push(full)
   }
 
   return batch

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -5,7 +5,10 @@ import {
   registerSettingsContribution,
 } from './settings-contribution-registry'
 import { drainLegacyContributionQueue } from './settings-section-registry'
-import type { AnySettingsContribution } from './settings-contribution-types'
+import type {
+  AnySettingsContribution,
+  SettingsScope,
+} from './settings-contribution-types'
 
 // Legacy adapter namespace constant — sections registered through the legacy
 // `registerSettingsSection()` API are flushed into the new registry under this
@@ -37,11 +40,63 @@ function assertNoLegacyScopeConflict(module: ModuleDefinition): void {
   }
 }
 
+/**
+ * Build the validated contribution batch for a dispatch pass. Runs two
+ * collision checks in a single shared pass that spans BOTH module-declared
+ * contributions AND the legacy adapter's pending queue:
+ *
+ *  1. Full-id uniqueness (`${moduleId}.${localId}`) — registry-level.
+ *  2. Per-scope localId uniqueness (F1) — shell-level. Within a scope,
+ *     `localId` must be unique across all modules. The shell uses `localId`
+ *     as the URL segment and React key for SettingsPage routing/selection,
+ *     so two contributions sharing a localId within the same scope are
+ *     ambiguous at the UI layer (even though their full ids differ). The
+ *     per-scope uniqueness contract lets the shell continue to use
+ *     `localId` — URLs and selection state stay stable.
+ *
+ * On any validation failure, nothing is committed to the live registry —
+ * `dispatchSettingsContributions()` only writes after `buildSettingsContributionBatch`
+ * returns without throwing.
+ */
 export function buildSettingsContributionBatch(
   modules: ModuleDefinition[] = getModules(),
 ): AnySettingsContribution[] {
   const batch: AnySettingsContribution[] = []
   const seenIds = new Set<string>()
+  // Shared across module-declared and legacy sources so collisions across
+  // both layers are caught in a single pass.
+  const localIdByScope = new Map<SettingsScope, Map<string, string>>()
+
+  const checkAndRecord = (
+    full: AnySettingsContribution,
+    origin: 'module' | 'legacy',
+  ): void => {
+    assertValidSettingsContribution(full)
+    if (seenIds.has(full.id)) {
+      throw new Error(
+        origin === 'legacy'
+          ? `settings-contribution-registry: duplicate contribution id "${full.id}" ` +
+              `(legacy adapter collides with module-declared contribution)`
+          : `settings-contribution-registry: duplicate contribution id "${full.id}"`,
+      )
+    }
+    let scopeMap = localIdByScope.get(full.scope)
+    if (!scopeMap) {
+      scopeMap = new Map()
+      localIdByScope.set(full.scope, scopeMap)
+    }
+    const existingSource = scopeMap.get(full.localId)
+    if (existingSource !== undefined) {
+      throw new Error(
+        `settings-contribution-registry: duplicate localId "${full.localId}" ` +
+          `in scope "${full.scope}": already registered by "${existingSource}", ` +
+          `now re-registered by "${full.id}". Within a scope, localId must be ` +
+          `unique across modules.`,
+      )
+    }
+    scopeMap.set(full.localId, full.id)
+    seenIds.add(full.id)
+  }
 
   for (const module of modules) {
     const settings = module.settings
@@ -55,21 +110,15 @@ export function buildSettingsContributionBatch(
         moduleId: module.id,
         id: `${module.id}.${decl.localId}`,
       } as AnySettingsContribution
-      assertValidSettingsContribution(full)
-      if (seenIds.has(full.id)) {
-        throw new Error(
-          `settings-contribution-registry: duplicate contribution id "${full.id}"`,
-        )
-      }
-      seenIds.add(full.id)
+      checkAndRecord(full, 'module')
       batch.push(full)
     }
   }
 
-  // Drain legacy adapter pending buffer. Commit 1 stub returns [] so behavior
-  // matches main. Commit 2 wires the real pending buffer, at which point each
-  // `registerSettingsSection()` call push declarations here that get composed
-  // with module-declared contributions in the same atomic pass.
+  // Drain legacy adapter pending buffer. PR-2 wires the real pending buffer
+  // through `registerSettingsSection()`. Each call pushes a declaration here
+  // that is composed with module-declared contributions under the same shared
+  // collision map (F1) in this single atomic pass.
   const legacyDecls = drainLegacyContributionQueue()
   for (const decl of legacyDecls) {
     const full = {
@@ -77,17 +126,7 @@ export function buildSettingsContributionBatch(
       moduleId: LEGACY_SECTION_MODULE_ID,
       id: `${LEGACY_SECTION_MODULE_ID}.${decl.localId}`,
     } as AnySettingsContribution
-    assertValidSettingsContribution(full)
-    if (seenIds.has(full.id)) {
-      // Defensive: legacy moduleId is fixed to `_builtin.legacy-section`, so
-      // collisions between module-declared and legacy ids imply an author
-      // prefixed their own moduleId with `_builtin.legacy-section` — reject.
-      throw new Error(
-        `settings-contribution-registry: duplicate contribution id "${full.id}" ` +
-          `(legacy adapter collides with module-declared contribution)`,
-      )
-    }
-    seenIds.add(full.id)
+    checkAndRecord(full, 'legacy')
     batch.push(full)
   }
 

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -4,7 +4,10 @@ import {
   clearContributions,
   registerSettingsContribution,
 } from './settings-contribution-registry'
-import { drainLegacyContributionQueue } from './settings-section-registry'
+import {
+  drainLegacyContributionQueue,
+  peekLegacyContributionQueue,
+} from './settings-section-registry'
 import type {
   AnySettingsContribution,
   SettingsScope,
@@ -115,11 +118,13 @@ export function buildSettingsContributionBatch(
     }
   }
 
-  // Drain legacy adapter pending buffer. PR-2 wires the real pending buffer
-  // through `registerSettingsSection()`. Each call pushes a declaration here
-  // that is composed with module-declared contributions under the same shared
-  // collision map (F1) in this single atomic pass.
-  const legacyDecls = drainLegacyContributionQueue()
+  // Peek (non-destructive) at the legacy adapter pending buffer — F3. The
+  // real drain happens only in `dispatchSettingsContributions()` AFTER full
+  // validation of both sources has succeeded. A validation failure here
+  // leaves the legacy queue intact, so after the author fixes the offending
+  // declaration the next dispatch can re-validate and commit the
+  // still-queued legacy sections without requiring re-registration.
+  const legacyDecls = peekLegacyContributionQueue()
   for (const decl of legacyDecls) {
     const full = {
       ...decl,
@@ -133,11 +138,26 @@ export function buildSettingsContributionBatch(
   return batch
 }
 
+/**
+ * Atomic dispatch of all settings contributions. Phase 1 validates the full
+ * batch (module-declared + peeked legacy queue) without mutating state.
+ * Only if Phase 1 succeeds does Phase 2 commit: clear the live registry,
+ * drain the legacy queue, and write the validated batch.
+ *
+ * Ordering within Phase 2 preserves the R1 Finding #1 atomic-two-phase
+ * property: clear first, then register — the registry never observes a
+ * mixed old/new state.
+ */
 export function dispatchSettingsContributions(
   modules: ModuleDefinition[] = getModules(),
 ): void {
+  // Phase 1 — validate without mutating. Throws on any collision (F1) or
+  // invariant violation. The legacy queue is peeked, not drained.
   const batch = buildSettingsContributionBatch(modules)
+
+  // Phase 2 — commit. Safe to mutate now: validation passed.
   clearContributions()
+  drainLegacyContributionQueue() // safe: staging already holds the validated set
   for (const contribution of batch) {
     registerSettingsContribution(contribution)
   }

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -5,6 +5,7 @@ import {
   registerSettingsContribution,
 } from './settings-contribution-registry'
 import {
+  clearLegacyPending,
   drainLegacyContributionQueue,
   peekLegacyContributionQueue,
 } from './settings-section-registry'
@@ -161,4 +162,20 @@ export function dispatchSettingsContributions(
   for (const contribution of batch) {
     registerSettingsContribution(contribution)
   }
+}
+
+/**
+ * HMR dispose helper — clears BOTH the committed contribution registry
+ * AND the legacy adapter's pending buffers, so the next module
+ * registration starts from a clean slate across HMR re-runs (F2).
+ *
+ * Consolidated here (rather than calling the two write APIs directly from
+ * `register-modules.tsx`) so the ESLint `no-restricted-imports` rule (F4)
+ * can keep `clearContributions` off the public surface. This is the
+ * canonical single entry point for HMR cleanup of settings contribution
+ * state.
+ */
+export function resetSettingsContributionsForHmr(): void {
+  clearContributions()
+  clearLegacyPending()
 }

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -14,7 +14,12 @@ import {
   type ModuleDefinition,
 } from './module-registry'
 import { clearNewTabRegistry, getNewTabProviders } from './new-tab-registry'
-import { clearSettingsSectionRegistry, getSettingsSections } from './settings-section-registry'
+import {
+  clearSettingsSectionRegistry,
+  getSettingsSections,
+  listReservedItems,
+  registerSettingsSection,
+} from './settings-section-registry'
 import { clearInterfaceSubsectionRegistry, getInterfaceSubsections } from './interface-subsection-registry'
 import { registerBuiltinModules, dispatchSettingsContributions } from './register-modules'
 import {
@@ -287,5 +292,87 @@ describe('settings contribution dispatch', () => {
       registerBuiltinModules()
       registerBuiltinModules()
     }).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// §3.3 — Built-in sections flow through legacy adapter into new registry.
+// ---------------------------------------------------------------------------
+
+describe('registerBuiltinModules → new contribution registry (PR-2)', () => {
+  beforeEach(() => {
+    clearAll()
+  })
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).electronAPI
+    clearAll()
+  })
+
+  it('built-in legacy sections land under _builtin.legacy-section in purdex scope', () => {
+    registerBuiltinModules()
+    const contribs = listContributions('purdex')
+    const legacyIds = contribs
+      .filter((c) => c.moduleId === '_builtin.legacy-section')
+      .map((c) => c.localId)
+
+    // Core legacy set always present (no caps gating). Exact membership:
+    // appearance / terminal / interface / sync / module-config /
+    // editor-buffers. Electron / dev-environment / tmux-agent-monitor are
+    // gated by PlatformCapabilities / import.meta.env.DEV.
+    for (const id of ['appearance', 'terminal', 'interface', 'sync', 'module-config', 'editor-buffers']) {
+      expect(legacyIds).toContain(id)
+    }
+    expect(legacyIds.length).toBeGreaterThanOrEqual(6)
+  })
+
+  it('reserved workspace section stays in listReservedItems, not in the new registry', () => {
+    registerBuiltinModules()
+    const reserved = listReservedItems()
+    expect(reserved.map((r) => r.id)).toContain('workspace')
+    // workspace is the only reserved section shipped by register-modules today.
+    expect(reserved).toHaveLength(1)
+    // And it does NOT appear in the new registry under any moduleId.
+    const contribs = listContributions('purdex')
+    expect(contribs.find((c) => c.localId === 'workspace')).toBeUndefined()
+  })
+
+  it('dispatch timing: legacy contributions survive repeated dispatches', () => {
+    registerBuiltinModules()
+    const before = listContributions('purdex')
+      .filter((c) => c.moduleId === '_builtin.legacy-section')
+      .map((c) => c.id)
+    expect(before.length).toBeGreaterThan(0)
+
+    // Re-push legacy sections (simulating HMR or additional
+    // registerBuiltinModules call) before dispatching again. Real flow
+    // guarantees this because registerBuiltinModules runs ahead of dispatch.
+    registerSettingsSection({
+      id: 'appearance',
+      label: 'settings.section.appearance',
+      order: 0,
+      component: () => null,
+    })
+    dispatchSettingsContributions()
+
+    const after = listContributions('purdex')
+      .filter((c) => c.moduleId === '_builtin.legacy-section')
+      .map((c) => c.id)
+    expect(after).toContain('_builtin.legacy-section.appearance')
+  })
+
+  it('I1 guard remains intact — registerBuiltinModules does not throw', () => {
+    expect(() => registerBuiltinModules()).not.toThrow()
+  })
+
+  it('getSettingsSections() legacy view stays consistent with new registry', () => {
+    registerBuiltinModules()
+    const legacyView = getSettingsSections().map((s) => s.id)
+    // Legacy view is the filtered `_builtin.legacy-section.*` entries plus
+    // reserved (component undefined) entries. The set of localIds returned
+    // should cover all the built-in registerSettingsSection calls.
+    for (const id of ['appearance', 'terminal', 'interface', 'workspace', 'sync', 'module-config', 'editor-buffers']) {
+      expect(legacyView).toContain(id)
+    }
   })
 })

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable react-refresh/only-export-components */
 import { registerModule } from './module-registry'
 import { registerNewTabProvider } from './new-tab-registry'
-import { registerSettingsSection, clearLegacyPending } from './settings-section-registry'
-import { clearContributions } from './settings-contribution-registry'
-import { dispatchSettingsContributions } from './dispatch-settings-contributions'
+import { registerSettingsSection } from './settings-section-registry'
+import {
+  dispatchSettingsContributions,
+  resetSettingsContributionsForHmr,
+} from './dispatch-settings-contributions'
 import { findPane } from './pane-tree'
 import { getPlatformCapabilities } from './platform'
 import { SessionPaneContent } from '../components/SessionPaneContent'
@@ -89,13 +91,13 @@ export { dispatchSettingsContributions } from './dispatch-settings-contributions
 
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
-    // F2: the HMR dispose hook must clear BOTH the committed contribution
-    // registry AND the legacy adapter's pending buffers. Clearing only the
-    // registry leaves pending legacy entries to accumulate across HMR
-    // re-runs, producing duplicate sidebar rows and stale reserved entries
-    // that were renamed in the edit that triggered HMR.
-    clearContributions()
-    clearLegacyPending()
+    // F2 + F4: the HMR dispose hook must clear BOTH the committed
+    // contribution registry AND the legacy adapter's pending buffers, so
+    // no stale reserved / active entries leak across HMR re-runs.
+    // `resetSettingsContributionsForHmr()` is the canonical single entry
+    // point that keeps the write-side registry APIs off this module's
+    // import surface (lint-enforced by F4).
+    resetSettingsContributionsForHmr()
   })
 }
 

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { registerModule } from './module-registry'
 import { registerNewTabProvider } from './new-tab-registry'
-import { registerSettingsSection } from './settings-section-registry'
+import { registerSettingsSection, clearLegacyPending } from './settings-section-registry'
 import { clearContributions } from './settings-contribution-registry'
 import { dispatchSettingsContributions } from './dispatch-settings-contributions'
 import { findPane } from './pane-tree'
@@ -89,7 +89,13 @@ export { dispatchSettingsContributions } from './dispatch-settings-contributions
 
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
+    // F2: the HMR dispose hook must clear BOTH the committed contribution
+    // registry AND the legacy adapter's pending buffers. Clearing only the
+    // registry leaves pending legacy entries to accumulate across HMR
+    // re-runs, producing duplicate sidebar rows and stale reserved entries
+    // that were renamed in the edit that triggered HMR.
     clearContributions()
+    clearLegacyPending()
   })
 }
 

--- a/spa/src/lib/route-utils.ts
+++ b/spa/src/lib/route-utils.ts
@@ -1,5 +1,6 @@
 import type { PaneContent } from '../types/tab'
 import { decodeHostRouteId, isHostSubPage, type HostSubPage } from './host-routes'
+import { SETTINGS_LOCAL_ID_RE } from './settings-contribution-types'
 
 export type ParsedRoute =
   | { kind: 'history' }
@@ -12,8 +13,12 @@ export type ParsedRoute =
   | { kind: 'workspace-session-tab'; workspaceId: string; tabId: string; mode: 'terminal' | 'stream' }
 
 const ID_PATTERN = /^[0-9a-z]{6}$/
-const SETTINGS_SECTION_PATTERN = /^[a-z0-9-]{1,32}$/
-const SETTINGS_SUBSECTION_PATTERN = /^[a-z0-9-]{1,32}$/
+// F6: share the source of truth for settings id grammar with the
+// contribution registry so a registration that passes `assertValid…` is
+// also guaranteed to round-trip through parseRoute(). Subsection uses
+// the same pattern today.
+const SETTINGS_SECTION_PATTERN = SETTINGS_LOCAL_ID_RE
+const SETTINGS_SUBSECTION_PATTERN = SETTINGS_LOCAL_ID_RE
 
 function validateMode(mode: string): 'terminal' | 'stream' {
   return mode === 'stream' ? 'stream' : 'terminal'

--- a/spa/src/lib/settings-contribution-registry.test.ts
+++ b/spa/src/lib/settings-contribution-registry.test.ts
@@ -5,6 +5,7 @@ import {
   getContribution,
   clearContributions,
 } from './settings-contribution-registry'
+import registrySrc from './settings-contribution-registry.ts?raw'
 import type { AnySettingsContribution } from './settings-contribution-types'
 
 const Fake = () => null
@@ -175,5 +176,48 @@ describe('settings-contribution-registry', () => {
     expect(listContributions('purdex')).toEqual([])
     expect(listContributions('host')).toEqual([])
     expect(listContributions('workspace')).toEqual([])
+  })
+
+  // --- #539: internal API boundary -----------------------------------------
+  //
+  // These are source-text assertions. TypeScript's `@internal` is JSDoc-only;
+  // we can't enforce it at the type layer without stripInternal + a separate
+  // declaration build. Instead, lock the JSDoc presence so removing the tag
+  // (e.g. during a well-meaning cleanup) raises a PR-time signal. Consumers
+  // are audited by `rg "registerSettingsContribution"` per the plan.
+
+  it('#539: registerSettingsContribution is marked @internal', () => {
+    expect(registrySrc).toMatch(
+      /\/\*\*[\s\S]*?@internal[\s\S]*?\*\/\s*export function registerSettingsContribution/,
+    )
+  })
+
+  it('#539: clearContributions is marked @internal', () => {
+    expect(registrySrc).toMatch(
+      /\/\*\*[\s\S]*?@internal[\s\S]*?\*\/\s*export function clearContributions/,
+    )
+  })
+
+  it('#539: assertValidSettingsContribution is marked @internal', () => {
+    expect(registrySrc).toMatch(
+      /\/\*\*[\s\S]*?@internal[\s\S]*?\*\/\s*export function assertValidSettingsContribution/,
+    )
+  })
+
+  it('#539: listContributions / getContribution stay public (no @internal tag)', () => {
+    // Ensure we did not accidentally mark the consumer-facing read APIs.
+    const listBlockMatch = registrySrc.match(
+      /(?:\/\*\*[\s\S]*?\*\/\s*)?export function listContributions/,
+    )
+    expect(listBlockMatch).toBeTruthy()
+    const listBlock = listBlockMatch![0]
+    expect(listBlock).not.toMatch(/@internal/)
+
+    const getBlockMatch = registrySrc.match(
+      /(?:\/\*\*[\s\S]*?\*\/\s*)?export function getContribution/,
+    )
+    expect(getBlockMatch).toBeTruthy()
+    const getBlock = getBlockMatch![0]
+    expect(getBlock).not.toMatch(/@internal/)
   })
 })

--- a/spa/src/lib/settings-contribution-registry.test.ts
+++ b/spa/src/lib/settings-contribution-registry.test.ts
@@ -143,21 +143,50 @@ describe('settings-contribution-registry', () => {
     ).toThrow()
   })
 
-  it('localId starting with digit throws', () => {
+  // F6: `1foo` is accepted by the tightened grammar `[a-z0-9-]{1,32}`
+  // (digits are allowed anywhere — the previous regex restricted the
+  // leading char to a letter, which was stricter than parseRoute and not
+  // required by the router).
+  it('localId starting with digit passes (F6: route grammar allows it)', () => {
     expect(() =>
       registerSettingsContribution(make({ localId: '1foo', id: 'mod.1foo' })),
-    ).toThrow()
-  })
-
-  it('localId with uppercase passes', () => {
-    expect(() =>
-      registerSettingsContribution(make({ localId: 'FooBar', id: 'mod.FooBar' })),
     ).not.toThrow()
   })
 
-  it('localId with underscore passes', () => {
+  // F6: localId regex is tightened to match parseRoute's
+  // SETTINGS_SECTION_PATTERN (`/^[a-z0-9-]{1,32}$/`). Previously the
+  // contribution registry allowed `[a-zA-Z][a-zA-Z0-9_-]*`, which let ids
+  // like `FooBar` or `foo_bar` register but then fail parseRoute on reload
+  // / route-sync and silently redirect to the default section. Align both.
+  it('localId with uppercase throws (F6: must match route grammar)', () => {
+    expect(() =>
+      registerSettingsContribution(make({ localId: 'FooBar', id: 'mod.FooBar' })),
+    ).toThrow()
+  })
+
+  it('localId with underscore throws (F6: must match route grammar)', () => {
     expect(() =>
       registerSettingsContribution(make({ localId: 'foo_bar', id: 'mod.foo_bar' })),
+    ).toThrow()
+  })
+
+  it('localId longer than 32 chars throws (F6: parseRoute caps at 32)', () => {
+    const long = 'a'.repeat(33)
+    expect(() =>
+      registerSettingsContribution(make({ localId: long, id: `mod.${long}` })),
+    ).toThrow()
+  })
+
+  it('localId exactly 32 chars passes (F6: parseRoute upper bound)', () => {
+    const thirtyTwo = 'a'.repeat(32)
+    expect(() =>
+      registerSettingsContribution(make({ localId: thirtyTwo, id: `mod.${thirtyTwo}` })),
+    ).not.toThrow()
+  })
+
+  it('localId single char passes (F6: parseRoute lower bound)', () => {
+    expect(() =>
+      registerSettingsContribution(make({ localId: 'a', id: 'mod.a' })),
     ).not.toThrow()
   })
 
@@ -165,6 +194,18 @@ describe('settings-contribution-registry', () => {
     expect(() =>
       registerSettingsContribution(make({ localId: 'foo-bar', id: 'mod.foo-bar' })),
     ).not.toThrow()
+  })
+
+  it('localId mixed lowercase + digits + dash passes', () => {
+    expect(() =>
+      registerSettingsContribution(make({ localId: 'a-b-c-1-2-3', id: 'mod.a-b-c-1-2-3' })),
+    ).not.toThrow()
+  })
+
+  it('F6: SETTINGS_LOCAL_ID_RE is exported and equal to the route pattern', async () => {
+    const { SETTINGS_LOCAL_ID_RE } = await import('./settings-contribution-types')
+    // Source parity with parseRoute's SETTINGS_SECTION_PATTERN.
+    expect(SETTINGS_LOCAL_ID_RE.source).toBe('^[a-z0-9-]{1,32}$')
   })
 
   // --- Isolation ---

--- a/spa/src/lib/settings-contribution-registry.ts
+++ b/spa/src/lib/settings-contribution-registry.ts
@@ -3,8 +3,7 @@ import type {
   SettingsContribution,
   SettingsScope,
 } from './settings-contribution-types'
-
-const LOCAL_ID_RE = /^[a-zA-Z][a-zA-Z0-9_-]*$/
+import { SETTINGS_LOCAL_ID_RE } from './settings-contribution-types'
 
 const contributions = new Map<string, AnySettingsContribution>()
 
@@ -34,9 +33,11 @@ export function assertValidSettingsContribution(def: AnySettingsContribution): v
       `settings-contribution-registry: id "${def.id}" does not match "${expectedId}" (moduleId.localId)`,
     )
   }
-  if (!LOCAL_ID_RE.test(def.localId)) {
+  if (!SETTINGS_LOCAL_ID_RE.test(def.localId)) {
     throw new Error(
-      `settings-contribution-registry: localId "${def.localId}" is invalid; must match ${LOCAL_ID_RE.source}`,
+      `settings-contribution-registry: localId "${def.localId}" is invalid; ` +
+        `must match ${SETTINGS_LOCAL_ID_RE.source} ` +
+        `(lowercase ASCII, digits, hyphen; 1-32 chars — same grammar as parseRoute)`,
     )
   }
 }

--- a/spa/src/lib/settings-contribution-registry.ts
+++ b/spa/src/lib/settings-contribution-registry.ts
@@ -8,6 +8,16 @@ const LOCAL_ID_RE = /^[a-zA-Z][a-zA-Z0-9_-]*$/
 
 const contributions = new Map<string, AnySettingsContribution>()
 
+/**
+ * Validate a prepared contribution. Shared by the dispatch pass and the
+ * direct `registerSettingsContribution` path.
+ *
+ * @internal
+ *   Contribution registration has a single public entry point — the
+ *   `ModuleDefinition.settings` declaration flushed by
+ *   `dispatchSettingsContributions()`. The validator is wired inside that
+ *   path and is not part of the public surface. See #539.
+ */
 export function assertValidSettingsContribution(def: AnySettingsContribution): void {
   if (!def.moduleId) {
     throw new Error('settings-contribution-registry: moduleId must be a non-empty string')
@@ -31,6 +41,18 @@ export function assertValidSettingsContribution(def: AnySettingsContribution): v
   }
 }
 
+/**
+ * Insert a fully-formed `SettingsContribution` into the registry.
+ *
+ * @internal
+ *   The only supported public write path is declaring
+ *   `settings: [...]` on a `ModuleDefinition` (for module-authored
+ *   contributions) or calling `registerSettingsSection()` (for the legacy
+ *   adapter) and letting `dispatchSettingsContributions()` flush. Direct
+ *   calls from outside `dispatch-settings-contributions.ts` /
+ *   `settings-section-registry.ts` / test files are considered internal
+ *   and subject to removal without notice. See #539.
+ */
 export function registerSettingsContribution(def: AnySettingsContribution): void {
   assertValidSettingsContribution(def)
 
@@ -63,6 +85,14 @@ export function getContribution(id: string): AnySettingsContribution | undefined
   return contributions.get(id)
 }
 
+/**
+ * Clear all registered contributions. Used by (a) the dispatch pass as the
+ * first step of each flush and (b) the HMR dispose hook in
+ * `register-modules.tsx`. Tests may also call it for isolation.
+ *
+ * @internal
+ *   Not for production consumer code. See #539.
+ */
 export function clearContributions(): void {
   contributions.clear()
 }

--- a/spa/src/lib/settings-contribution-smoke.test.tsx
+++ b/spa/src/lib/settings-contribution-smoke.test.tsx
@@ -1,10 +1,12 @@
 /**
- * Smoke test for HSR PR-1: prove that the settings contribution registry
- * is NOT yet wired into any of the three settings shells.
+ * Smoke test for HSR PR-1/PR-2: prove that the settings contribution
+ * registry is wired into the Purdex shell (PR-2), and NOT yet wired into
+ * the remaining two shells (HostPage — PR-4 target, WorkspaceSettingsPage
+ * — PR-3 target).
  *
  * Design rationale — Option B (static source check), preferred here:
  *
- *   The three pages below have deep coupling to app-wide state
+ *   The two pages below have deep coupling to app-wide state
  *   (wouter router, zustand host/workspace stores, i18n, electronAPI,
  *   plus numerous leaf components). Mounting them from cold to do a
  *   "queryByText must be null" check would require hundreds of lines
@@ -13,25 +15,19 @@
  *   reshuffle could make the test spuriously pass).
  *
  *   A static-source check is strictly stronger for the thing we
- *   actually want to prove: that none of the three shells imports
- *   from `settings-contribution-registry`. If a future PR wires the
- *   registry into a shell, this test fails deterministically — no
- *   rendering or DOM needed.
+ *   actually want to prove: that these shells do not yet import from
+ *   `settings-contribution-registry`. When PR-3 / PR-4 wire them up,
+ *   those corresponding entries are removed from `PAGES`.
  *
  *   We additionally register three fake contributions (one per scope)
  *   and verify they are queryable from the registry directly, so the
  *   infrastructure is exercised and regressions in the registry
  *   itself would surface here too.
  *
- *   Per HSR PR-1 plan §Task 4: use Option A where trivial, Option B
- *   where Option A would require excessive scaffolding. All three
- *   pages fall into the latter bucket.
- *
  *   Source files are pulled via Vite's `?raw` imports (browser/jsdom
  *   safe, no node:fs dependency).
  */
 import { describe, it, expect, beforeEach } from 'vitest'
-import settingsPageSrc from '../components/SettingsPage.tsx?raw'
 import hostPageSrc from '../components/HostPage.tsx?raw'
 import workspaceSettingsPageSrc from '../features/workspace/components/WorkspaceSettingsPage.tsx?raw'
 import {
@@ -44,8 +40,10 @@ const FAKE_PURDEX_LABEL = 'SMOKE_PURDEX_LABEL_UNIQUE'
 const FAKE_HOST_LABEL = 'SMOKE_HOST_LABEL_UNIQUE'
 const FAKE_WORKSPACE_LABEL = 'SMOKE_WORKSPACE_LABEL_UNIQUE'
 
+// HSR PR-2 migrated `src/components/SettingsPage.tsx` off this list — it
+// now reads the contribution registry directly. The remaining two shells
+// land in PR-3 (workspace) and PR-4 (host).
 const PAGES: Array<{ name: string; src: string }> = [
-  { name: 'src/components/SettingsPage.tsx', src: settingsPageSrc },
   { name: 'src/components/HostPage.tsx', src: hostPageSrc },
   { name: 'src/features/workspace/components/WorkspaceSettingsPage.tsx', src: workspaceSettingsPageSrc },
 ]

--- a/spa/src/lib/settings-contribution-types.ts
+++ b/spa/src/lib/settings-contribution-types.ts
@@ -2,6 +2,24 @@ import type React from 'react'
 
 export type SettingsScope = 'purdex' | 'host' | 'workspace'
 
+/**
+ * Canonical character grammar for a contribution's `localId`.
+ *
+ * Source of truth shared by:
+ *   - `assertValidSettingsContribution()` in
+ *     `./settings-contribution-registry.ts` (registration-time gate)
+ *   - `SETTINGS_SECTION_PATTERN` consumer in `./route-utils.ts`
+ *     (URL parser — re-exported here so parseRoute reuses the same regex)
+ *
+ * Keeping these in lockstep prevents a contribution that registers fine
+ * under the registry but then silently fails `parseRoute()` on reload /
+ * route-sync, which would redirect the user to the default section. See
+ * PR-2 Round 3 finding F6.
+ *
+ * Grammar: lowercase ASCII, digits, or hyphen; 1–32 chars.
+ */
+export const SETTINGS_LOCAL_ID_RE = /^[a-z0-9-]{1,32}$/
+
 // Discriminated union — scope field narrows hostId/workspaceId.
 export type SettingsContext =
   | { scope: 'purdex' }
@@ -13,7 +31,7 @@ export type SettingsContextFor<S extends SettingsScope> = Extract<SettingsContex
 // Author-facing declaration. `id` and `moduleId` are system-filled by
 // register pass, not written by authors.
 export interface SettingsContributionDeclaration<S extends SettingsScope = SettingsScope> {
-  localId: string                                          // unique within a module; [a-zA-Z][a-zA-Z0-9_-]*
+  localId: string                                          // unique within a module; must match SETTINGS_LOCAL_ID_RE
   scope: S
   order: number                                            // ascending sort within scope
   labelKey: string                                         // i18n key

--- a/spa/src/lib/settings-section-registry.test.ts
+++ b/spa/src/lib/settings-section-registry.test.ts
@@ -3,27 +3,49 @@ import {
   registerSettingsSection,
   getSettingsSections,
   clearSettingsSectionRegistry,
+  drainLegacyContributionQueue,
+  listReservedItems,
+  clearLegacyPending,
   type SettingsSectionDef,
 } from './settings-section-registry'
+import {
+  clearContributions,
+  listContributions,
+  registerSettingsContribution,
+} from './settings-contribution-registry'
+import { dispatchSettingsContributions } from './dispatch-settings-contributions'
+import { clearModuleRegistry, registerModule } from './module-registry'
 
 const FakeComponent = () => null
+const FakeComponent2 = () => null
 
 function makeDef(overrides: Partial<SettingsSectionDef> = {}): SettingsSectionDef {
   return { id: 'test', label: 'Test', order: 0, component: FakeComponent, ...overrides }
 }
 
-describe('settings-section-registry', () => {
-  beforeEach(() => clearSettingsSectionRegistry())
+function resetAll() {
+  clearSettingsSectionRegistry()
+  clearLegacyPending()
+  clearContributions()
+  clearModuleRegistry()
+}
 
-  it('registers and retrieves sections', () => {
+describe('settings-section-registry', () => {
+  beforeEach(resetAll)
+
+  // --- Existing adapter-bridged behavior (dispatch-aware) -----------------
+
+  it('registers and retrieves sections (after dispatch)', () => {
     registerSettingsSection(makeDef({ id: 'a', label: 'A', order: 1 }))
     registerSettingsSection(makeDef({ id: 'b', label: 'B', order: 0 }))
+    dispatchSettingsContributions([])
     const sections = getSettingsSections()
     expect(sections.map((s) => s.id)).toEqual(['b', 'a']) // sorted by order
   })
 
   it('returns a copy (not the internal array)', () => {
     registerSettingsSection(makeDef())
+    dispatchSettingsContributions([])
     const a = getSettingsSections()
     const b = getSettingsSections()
     expect(a).not.toBe(b)
@@ -32,6 +54,7 @@ describe('settings-section-registry', () => {
   it('is idempotent — re-registering same id updates in place', () => {
     registerSettingsSection(makeDef({ id: 'x', label: 'Old' }))
     registerSettingsSection(makeDef({ id: 'x', label: 'New' }))
+    dispatchSettingsContributions([])
     const sections = getSettingsSections()
     expect(sections).toHaveLength(1)
     expect(sections[0].label).toBe('New')
@@ -41,12 +64,197 @@ describe('settings-section-registry', () => {
     registerSettingsSection(makeDef({ id: 'a' }))
     registerSettingsSection(makeDef({ id: 'b' }))
     clearSettingsSectionRegistry()
+    // After clear the internal legacy store is empty; dispatch sees no entries.
+    dispatchSettingsContributions([])
     expect(getSettingsSections()).toHaveLength(0)
   })
 
-  it('supports reserved sections (no component)', () => {
+  it('supports reserved sections (no component) via listReservedItems', () => {
     registerSettingsSection({ id: 'ws', label: 'Workspace', order: 10 })
+    // Reserved items are never pushed into the new registry, even after dispatch.
+    dispatchSettingsContributions([])
+    const contribs = listContributions('purdex')
+    expect(contribs.find((c) => c.localId === 'ws')).toBeUndefined()
+    const reserved = listReservedItems()
+    expect(reserved).toHaveLength(1)
+    expect(reserved[0].component).toBeUndefined()
+    // getSettingsSections() still surfaces reserved for the legacy transition API.
+    expect(getSettingsSections().find((s) => s.id === 'ws')).toBeDefined()
+  })
+
+  // --- Pending buffer: dispatch-flushed semantics (spec §7.2) --------------
+
+  it('pending buffer: registerSettingsSection does NOT flush into listContributions until dispatch', () => {
+    registerSettingsSection(makeDef({ id: 'p1' }))
+    expect(listContributions('purdex')).toEqual([])
+  })
+
+  it('pending buffer: drainLegacyContributionQueue yields declarations and empties the buffer', () => {
+    registerSettingsSection(makeDef({ id: 'p1', order: 3, label: 'Label' }))
+    const drained = drainLegacyContributionQueue()
+    expect(drained).toHaveLength(1)
+    expect(drained[0].localId).toBe('p1')
+    expect(drained[0].order).toBe(3)
+    expect(drained[0].labelKey).toBe('Label')
+    // Re-drain is empty.
+    expect(drainLegacyContributionQueue()).toEqual([])
+  })
+
+  it('dispatch flush: legacy sections land in new registry under _builtin.legacy-section', () => {
+    registerSettingsSection(makeDef({ id: 'disp1', order: 5 }))
+    dispatchSettingsContributions([])
+    const contribs = listContributions('purdex')
+    expect(contribs.map((c) => c.id)).toContain('_builtin.legacy-section.disp1')
+  })
+
+  // Finding 1 regression guard: legacy must SURVIVE multi-dispatch.
+  it('dispatch survive: multiple dispatches do not wipe legacy entries (Finding 1 regression)', () => {
+    registerSettingsSection(makeDef({ id: 'survive' }))
+    dispatchSettingsContributions([])
+    expect(listContributions('purdex').map((c) => c.id)).toContain(
+      '_builtin.legacy-section.survive',
+    )
+    // Simulate HMR: re-register BEFORE each dispatch (matches real flow where
+    // registerBuiltinModules() pushes again before dispatch runs at its end).
+    registerSettingsSection(makeDef({ id: 'survive' }))
+    dispatchSettingsContributions([])
+    expect(listContributions('purdex').map((c) => c.id)).toContain(
+      '_builtin.legacy-section.survive',
+    )
+  })
+
+  it('adapter round-trip: dispatch-restored shape matches original def', () => {
+    registerSettingsSection(makeDef({ id: 'rt', label: 'Roundtrip', order: 7, component: FakeComponent }))
+    dispatchSettingsContributions([])
     const sections = getSettingsSections()
-    expect(sections[0].component).toBeUndefined()
+    const entry = sections.find((s) => s.id === 'rt')
+    expect(entry).toBeDefined()
+    expect(entry!.label).toBe('Roundtrip')
+    expect(entry!.order).toBe(7)
+  })
+
+  it('React identity: getSettingsSections returns the originally-passed component reference', () => {
+    registerSettingsSection(makeDef({ id: 'id1', component: FakeComponent }))
+    dispatchSettingsContributions([])
+    const entry = getSettingsSections().find((s) => s.id === 'id1')
+    expect(entry?.component).toBe(FakeComponent)
+  })
+
+  it('order preservation: mixed active + reserved sort ascending via getSettingsSections', () => {
+    registerSettingsSection(makeDef({ id: 'a', order: 0 }))
+    registerSettingsSection({ id: 'r', label: 'R', order: 10 }) // reserved
+    registerSettingsSection(makeDef({ id: 'b', order: 11 }))
+    registerSettingsSection(makeDef({ id: 'c', order: 2 }))
+    dispatchSettingsContributions([])
+    expect(getSettingsSections().map((s) => s.id)).toEqual(['a', 'c', 'r', 'b'])
+  })
+
+  // --- Reserved buffer (Finding 6 unified policy + N1 no-accumulation) -----
+
+  it('reserved buffer: component undefined stays in reserved map, not in new registry', () => {
+    registerSettingsSection({ id: 'resv', label: 'Reserved', order: 10 })
+    dispatchSettingsContributions([])
+    expect(listContributions('purdex').find((c) => c.localId === 'resv')).toBeUndefined()
+    const reserved = listReservedItems()
+    expect(reserved.map((r) => r.id)).toEqual(['resv'])
+    expect(reserved[0].component).toBeUndefined()
+    // getSettingsSections() surfaces reserved alongside active (transition API).
+    expect(getSettingsSections().find((s) => s.id === 'resv')).toBeDefined()
+  })
+
+  it('N1 reserved upsert: re-registering same reserved id replaces, not duplicates', () => {
+    registerSettingsSection({ id: 'r1', label: 'A', order: 10 })
+    registerSettingsSection({ id: 'r1', label: 'A', order: 10 })
+    registerSettingsSection({ id: 'r1', label: 'A', order: 5 })
+    const reserved = listReservedItems()
+    expect(reserved).toHaveLength(1)
+    expect(reserved[0].order).toBe(5)
+  })
+
+  it('N1 active upsert: re-registering same active id replaces, dispatch yields one entry', () => {
+    registerSettingsSection({ id: 'a1', label: 'L', order: 0, component: FakeComponent })
+    registerSettingsSection({ id: 'a1', label: 'L', order: 0, component: FakeComponent2 })
+    dispatchSettingsContributions([])
+    const contribs = listContributions('purdex').filter((c) => c.localId === 'a1')
+    expect(contribs).toHaveLength(1)
+    // Component reference reflects the latest registration.
+    expect(getSettingsSections().find((s) => s.id === 'a1')?.component).toBe(FakeComponent2)
+  })
+
+  // --- HMR dispose: N1 double-clear guarantee ------------------------------
+
+  it('HMR dispose: clearLegacyPending clears both active pending buffer AND reserved map', () => {
+    registerSettingsSection({ id: 'resv', label: 'R', order: 10 })
+    registerSettingsSection(makeDef({ id: 'act' }))
+    clearLegacyPending()
+    expect(listReservedItems()).toEqual([])
+    expect(drainLegacyContributionQueue()).toEqual([])
+  })
+
+  it('HMR re-run: register → dispatch → clearLegacyPending → register → dispatch stays single-entry', () => {
+    registerSettingsSection(makeDef({ id: 'hmr' }))
+    dispatchSettingsContributions([])
+    clearLegacyPending()
+    registerSettingsSection(makeDef({ id: 'hmr' }))
+    expect(() => dispatchSettingsContributions([])).not.toThrow()
+    const contribs = listContributions('purdex').filter((c) => c.localId === 'hmr')
+    expect(contribs).toHaveLength(1)
+  })
+
+  // --- Namespace / clear / cross-id -----------------------------------------
+
+  it('namespace isolation: module-declared contributions are not visible via getSettingsSections', () => {
+    registerModule({
+      id: 'mod',
+      name: 'Mod',
+      settings: [
+        { localId: 'mysection', scope: 'purdex', order: 0, labelKey: 'mod.mysection', component: FakeComponent },
+      ],
+    })
+    dispatchSettingsContributions()
+    // New registry sees both the module-declared entry.
+    expect(listContributions('purdex').map((c) => c.id)).toContain('mod.mysection')
+    // Legacy view only sees `_builtin.legacy-section` entries — zero here.
+    expect(getSettingsSections()).toEqual([])
+  })
+
+  it('clear scope: clearSettingsSectionRegistry only wipes pending buffer + reserved, not other contributions', () => {
+    // A contribution registered through the new registry directly (simulating
+    // what a module declaration flush would produce).
+    registerSettingsContribution({
+      moduleId: 'other',
+      id: 'other.keep',
+      localId: 'keep',
+      scope: 'purdex',
+      order: 0,
+      labelKey: 'other.keep',
+      component: FakeComponent,
+    })
+    // Legacy pending sections.
+    registerSettingsSection(makeDef({ id: 'legacy' }))
+    registerSettingsSection({ id: 'reserved', label: 'R', order: 10 })
+
+    clearSettingsSectionRegistry()
+
+    // New registry entry must remain.
+    expect(listContributions('purdex').map((c) => c.id)).toContain('other.keep')
+    // Legacy pending drained & reserved cleared.
+    expect(drainLegacyContributionQueue()).toEqual([])
+    expect(listReservedItems()).toEqual([])
+  })
+
+  it('cross-id guard: module-declared and legacy with same localId coexist (different moduleIds)', () => {
+    registerModule({
+      id: 'foo',
+      name: 'Foo',
+      settings: [
+        { localId: 'appearance', scope: 'purdex', order: 0, labelKey: 'foo.appearance', component: FakeComponent },
+      ],
+    })
+    registerSettingsSection({ id: 'appearance', label: 'legacy', order: 0, component: FakeComponent2 })
+    expect(() => dispatchSettingsContributions()).not.toThrow()
+    const ids = listContributions('purdex').map((c) => c.id)
+    expect(ids).toContain('foo.appearance')
+    expect(ids).toContain('_builtin.legacy-section.appearance')
   })
 })

--- a/spa/src/lib/settings-section-registry.test.ts
+++ b/spa/src/lib/settings-section-registry.test.ts
@@ -181,6 +181,53 @@ describe('settings-section-registry', () => {
     expect(getSettingsSections().find((s) => s.id === 'a1')?.component).toBe(FakeComponent2)
   })
 
+  // --- F2: reserved ↔ active cross-delete on upsert ------------------------
+
+  describe('F2: reserved ↔ active cross-delete on upsert', () => {
+    it('reserved → active: second register removes the reserved entry', () => {
+      registerSettingsSection({ id: 'x', label: 'X', order: 10 }) // reserved
+      registerSettingsSection({ id: 'x', label: 'X', order: 10, component: FakeComponent }) // active
+      dispatchSettingsContributions([])
+      expect(listReservedItems().find((r) => r.id === 'x')).toBeUndefined()
+      const active = listContributions('purdex').filter((c) => c.localId === 'x')
+      expect(active).toHaveLength(1)
+    })
+
+    it('active → reserved: second register removes the active pending entry', () => {
+      registerSettingsSection({ id: 'x', label: 'X', order: 10, component: FakeComponent }) // active
+      registerSettingsSection({ id: 'x', label: 'X', order: 10 }) // reserved
+      dispatchSettingsContributions([])
+      expect(listContributions('purdex').find((c) => c.localId === 'x')).toBeUndefined()
+      const reserved = listReservedItems().filter((r) => r.id === 'x')
+      expect(reserved).toHaveLength(1)
+      expect(reserved[0].component).toBeUndefined()
+    })
+
+    it('sidebar row count for id stays at 1 across reserved ↔ active transitions', () => {
+      // reserved → active → reserved → active
+      registerSettingsSection({ id: 'x', label: 'X', order: 10 })
+      registerSettingsSection({ id: 'x', label: 'X', order: 10, component: FakeComponent })
+      registerSettingsSection({ id: 'x', label: 'X', order: 10 })
+      registerSettingsSection({ id: 'x', label: 'X', order: 10, component: FakeComponent2 })
+      dispatchSettingsContributions([])
+
+      const reserved = listReservedItems().filter((r) => r.id === 'x')
+      const active = listContributions('purdex').filter((c) => c.localId === 'x')
+      expect(reserved.length + active.length).toBe(1)
+      // Landed on active (last registration had a component).
+      expect(active).toHaveLength(1)
+    })
+
+    it('active-before-reserved drop: pending active declaration must not survive after reserved upsert', () => {
+      // Regression guard — previously the active pending entry leaked through
+      // even when the same id was later declared reserved, producing a zombie
+      // sidebar row after dispatch.
+      registerSettingsSection({ id: 'ghost', label: 'Ghost', order: 10, component: FakeComponent })
+      registerSettingsSection({ id: 'ghost', label: 'Ghost', order: 10 })
+      expect(drainLegacyContributionQueue()).toEqual([])
+    })
+  })
+
   // --- HMR dispose: N1 double-clear guarantee ------------------------------
 
   it('HMR dispose: clearLegacyPending clears both active pending buffer AND reserved map', () => {

--- a/spa/src/lib/settings-section-registry.test.ts
+++ b/spa/src/lib/settings-section-registry.test.ts
@@ -243,7 +243,11 @@ describe('settings-section-registry', () => {
     expect(listReservedItems()).toEqual([])
   })
 
-  it('cross-id guard: module-declared and legacy with same localId coexist (different moduleIds)', () => {
+  it('cross-id guard (F1): module-declared and legacy with same localId under same scope throws', () => {
+    // Per F1 dispatch invariant: within a scope, localId must be unique across
+    // modules — the shell uses localId as URL/selection/React key, so two
+    // contributions with the same localId (regardless of differing moduleId
+    // prefixes) are ambiguous at the UI layer.
     registerModule({
       id: 'foo',
       name: 'Foo',
@@ -252,9 +256,13 @@ describe('settings-section-registry', () => {
       ],
     })
     registerSettingsSection({ id: 'appearance', label: 'legacy', order: 0, component: FakeComponent2 })
-    expect(() => dispatchSettingsContributions()).not.toThrow()
-    const ids = listContributions('purdex').map((c) => c.id)
-    expect(ids).toContain('foo.appearance')
-    expect(ids).toContain('_builtin.legacy-section.appearance')
+    let thrown: Error | undefined
+    try {
+      dispatchSettingsContributions()
+    } catch (e) {
+      thrown = e as Error
+    }
+    expect(thrown).toBeDefined()
+    expect(thrown!.message).toMatch(/localId "appearance"/)
   })
 })

--- a/spa/src/lib/settings-section-registry.ts
+++ b/spa/src/lib/settings-section-registry.ts
@@ -1,3 +1,5 @@
+import type { AnySettingsContributionDeclaration } from './settings-contribution-types'
+
 export interface SettingsSectionDef {
   id: string
   label: string
@@ -23,4 +25,39 @@ export function getSettingsSections(): SettingsSectionDef[] {
 
 export function clearSettingsSectionRegistry(): void {
   sections.length = 0
+}
+
+// ----------------------------------------------------------------------------
+// Legacy contribution adapter — stub (commit 1)
+//
+// Commit 2 will replace these stubs with real pending-buffer + reserved-map
+// semantics described in the PR-2 plan §2 and §3.1. For commit 1 the stubs
+// return empty so dispatch() sees no legacy declarations, preserving end-to-
+// end behavior identical to `main`. Only the export surface exists in this
+// commit so `dispatch-settings-contributions.ts` can reference the drain API
+// and land independently-green.
+// ----------------------------------------------------------------------------
+
+/**
+ * Drain the pending legacy contribution queue. Stub returns an empty array;
+ * commit 2 wires up the real buffer.
+ */
+export function drainLegacyContributionQueue(): AnySettingsContributionDeclaration[] {
+  return []
+}
+
+/**
+ * Snapshot of reserved-only sections (component: undefined). Stub returns
+ * an empty array; commit 2 wires up the reserved Map.
+ */
+export function listReservedItems(): readonly SettingsSectionDef[] {
+  return []
+}
+
+/**
+ * HMR dispose hook — clear both legacy pending buffer and reserved map.
+ * Stub is a no-op; commit 2 wires up both.
+ */
+export function clearLegacyPending(): void {
+  // no-op stub
 }

--- a/spa/src/lib/settings-section-registry.ts
+++ b/spa/src/lib/settings-section-registry.ts
@@ -63,10 +63,19 @@ function wrapLegacyComponent(
 
 export function registerSettingsSection(def: SettingsSectionDef): void {
   if (def.component === undefined) {
-    // Reserved — never flow into the new registry.
+    // Reserved — never flow into the new registry. F2: also remove any
+    // stale active pending entry for the same id so a later reserved
+    // registration wins (reserved ↔ active transitions must leave only one
+    // row in the sidebar).
+    pendingLegacyContributions.delete(def.id)
     pendingReservedItems.set(def.id, def)
     return
   }
+
+  // F2: active registration must remove any prior reserved entry for the
+  // same id — otherwise a reserved → active transition leaves a zombie
+  // reserved row alongside the newly active one.
+  pendingReservedItems.delete(def.id)
 
   const wrapped = wrapLegacyComponent(def.component)
   const decl: LegacyContributionDeclaration = {

--- a/spa/src/lib/settings-section-registry.ts
+++ b/spa/src/lib/settings-section-registry.ts
@@ -1,4 +1,14 @@
-import type { AnySettingsContributionDeclaration } from './settings-contribution-types'
+import React from 'react'
+import type {
+  AnySettingsContributionDeclaration,
+  SettingsContextFor,
+  SettingsContribution,
+  SettingsContributionDeclaration,
+} from './settings-contribution-types'
+import { listContributions } from './settings-contribution-registry'
+
+// Legacy sections are always purdex-scoped — this is the ctx they receive.
+type LegacyCtxProps = { ctx: SettingsContextFor<'purdex'> }
 
 export interface SettingsSectionDef {
   id: string
@@ -7,57 +17,135 @@ export interface SettingsSectionDef {
   component?: React.ComponentType
 }
 
-const sections: SettingsSectionDef[] = []
+// Legacy adapter moduleId. MUST match the constant used by the dispatch
+// composer in `dispatch-settings-contributions.ts` — kept stringly-identical
+// for the filter lookup in `getSettingsSections()` below. PR-3/4 will export
+// this from a shared location if they need to reuse it; today two callers
+// ship the same literal, guarded by these tests.
+const LEGACY_SECTION_MODULE_ID = '_builtin.legacy-section'
 
-export function registerSettingsSection(def: SettingsSectionDef): void {
-  const idx = sections.findIndex((s) => s.id === def.id)
-  if (idx >= 0) {
-    sections[idx] = def
-  } else {
-    sections.push(def)
-  }
-  sections.sort((a, b) => a.order - b.order)
+// ----------------------------------------------------------------------------
+// Legacy adapter state (PR-2 §7.2 dispatch-flushed pattern)
+//
+// - `pendingLegacyContributions` — active declarations waiting for the next
+//   `dispatchSettingsContributions()` pass. Upsert by localId so HMR re-runs
+//   do not accumulate duplicates. Drained atomically by dispatch.
+// - `pendingReservedItems` — reserved sections (component: undefined). Never
+//   flow into the new registry; kept as a separate Map so the sidebar can
+//   still render coming-soon rows. Upsert by id for HMR parity.
+// - `legacyComponentMap` — reverse lookup from the ctx-wrapped component we
+//   hand the new registry back to the original author-supplied component, so
+//   `getSettingsSections()` preserves React identity (important for memo).
+// ----------------------------------------------------------------------------
+
+type LegacyContributionDeclaration = SettingsContributionDeclaration<'purdex'>
+
+const pendingLegacyContributions = new Map<string, LegacyContributionDeclaration>()
+const pendingReservedItems = new Map<string, SettingsSectionDef>()
+const legacyComponentMap = new WeakMap<
+  React.ComponentType<LegacyCtxProps>,
+  React.ComponentType
+>()
+
+function wrapLegacyComponent(
+  Comp: React.ComponentType,
+): React.ComponentType<LegacyCtxProps> {
+  // Using React.createElement keeps this module .ts (no JSX). Legacy sections
+  // were written before SettingsContext existed and do not read ctx —
+  // intentionally discard props so existing section signatures stay
+  // untouched (decision 2b — no code changes to existing sections).
+  const Wrapped: React.ComponentType<LegacyCtxProps> = () =>
+    React.createElement(Comp)
+  Wrapped.displayName = `LegacyWrap(${Comp.displayName ?? Comp.name ?? 'Component'})`
+  legacyComponentMap.set(Wrapped, Comp)
+  return Wrapped
 }
 
+export function registerSettingsSection(def: SettingsSectionDef): void {
+  if (def.component === undefined) {
+    // Reserved — never flow into the new registry.
+    pendingReservedItems.set(def.id, def)
+    return
+  }
+
+  const wrapped = wrapLegacyComponent(def.component)
+  const decl: LegacyContributionDeclaration = {
+    localId: def.id,
+    scope: 'purdex',
+    order: def.order,
+    labelKey: def.label,
+    component: wrapped,
+  }
+  // Upsert by localId (N1 — active also not accumulating across HMR).
+  pendingLegacyContributions.set(def.id, decl)
+}
+
+/**
+ * Flattens the current registry view:
+ *   - active entries read from the new contribution registry, filtered to
+ *     legacy moduleId, restored to legacy shape via `legacyComponentMap`
+ *   - reserved entries read from `pendingReservedItems`
+ * merged and sorted by `order` ascending.
+ *
+ * Retained as a transitional read API for callsites not yet migrated to
+ * `listContributions('purdex') + listReservedItems()` directly.
+ */
 export function getSettingsSections(): SettingsSectionDef[] {
-  return [...sections]
+  const active: SettingsSectionDef[] = []
+  for (const c of listContributions('purdex')) {
+    if (c.moduleId !== LEGACY_SECTION_MODULE_ID) continue
+    active.push(toLegacyShape(c as SettingsContribution<'purdex'>))
+  }
+  const reserved = Array.from(pendingReservedItems.values())
+  return [...active, ...reserved].sort((a, b) => a.order - b.order)
+}
+
+function toLegacyShape(c: SettingsContribution<'purdex'>): SettingsSectionDef {
+  // The registered component is the ctx-taking wrapper; recover the original
+  // for React identity preservation.
+  const original = legacyComponentMap.get(c.component)
+  return {
+    id: c.localId,
+    label: c.labelKey,
+    order: c.order,
+    component: original,
+  }
 }
 
 export function clearSettingsSectionRegistry(): void {
-  sections.length = 0
+  pendingLegacyContributions.clear()
+  pendingReservedItems.clear()
 }
 
-// ----------------------------------------------------------------------------
-// Legacy contribution adapter — stub (commit 1)
-//
-// Commit 2 will replace these stubs with real pending-buffer + reserved-map
-// semantics described in the PR-2 plan §2 and §3.1. For commit 1 the stubs
-// return empty so dispatch() sees no legacy declarations, preserving end-to-
-// end behavior identical to `main`. Only the export surface exists in this
-// commit so `dispatch-settings-contributions.ts` can reference the drain API
-// and land independently-green.
-// ----------------------------------------------------------------------------
-
 /**
- * Drain the pending legacy contribution queue. Stub returns an empty array;
- * commit 2 wires up the real buffer.
+ * Drain pending legacy contributions into a fresh array, emptying the
+ * internal buffer. Invoked by `dispatchSettingsContributions()` during the
+ * flush pass. Returns a shallow copy — callers get full ownership.
  */
 export function drainLegacyContributionQueue(): AnySettingsContributionDeclaration[] {
-  return []
+  const out: AnySettingsContributionDeclaration[] = Array.from(
+    pendingLegacyContributions.values(),
+  )
+  pendingLegacyContributions.clear()
+  return out
 }
 
 /**
- * Snapshot of reserved-only sections (component: undefined). Stub returns
- * an empty array; commit 2 wires up the reserved Map.
+ * Read-only snapshot of reserved sections, sorted by `order` ascending.
+ * Consumed by `SettingsSidebar` to render coming-soon entries alongside
+ * active contributions from `listContributions('purdex')`.
  */
 export function listReservedItems(): readonly SettingsSectionDef[] {
-  return []
+  return Array.from(pendingReservedItems.values()).sort((a, b) => a.order - b.order)
 }
 
 /**
- * HMR dispose hook — clear both legacy pending buffer and reserved map.
- * Stub is a no-op; commit 2 wires up both.
+ * HMR dispose hook. Clears BOTH the active pending buffer and the reserved
+ * map — required by N1 to prevent orphan reserved keys from leaking across
+ * HMR boundaries (the reserved map uses upsert-by-id, but a rename of a
+ * reserved section would leave its old key behind without this sweep).
  */
 export function clearLegacyPending(): void {
-  // no-op stub
+  pendingLegacyContributions.clear()
+  pendingReservedItems.clear()
 }

--- a/spa/src/lib/settings-section-registry.ts
+++ b/spa/src/lib/settings-section-registry.ts
@@ -128,8 +128,19 @@ export function clearSettingsSectionRegistry(): void {
 
 /**
  * Drain pending legacy contributions into a fresh array, emptying the
- * internal buffer. Invoked by `dispatchSettingsContributions()` during the
- * flush pass. Returns a shallow copy — callers get full ownership.
+ * internal buffer. Returns a shallow copy — callers get full ownership.
+ *
+ * F3: COMMIT-ONLY. Only call this after full validation of the batch has
+ * succeeded — otherwise a validation failure downstream leaves the queue
+ * empty AND the new registry un-updated, so a retry (after the author
+ * fixes the offending declaration) silently drops every previously-queued
+ * legacy section because the drain already happened. Use
+ * `peekLegacyContributionQueue()` for non-destructive validation reads.
+ *
+ * The current caller,
+ * {@link dispatch-settings-contributions!buildSettingsContributionBatch},
+ * peeks first, runs full validation on both sources, and only then calls
+ * this function as part of the commit phase.
  */
 export function drainLegacyContributionQueue(): AnySettingsContributionDeclaration[] {
   const out: AnySettingsContributionDeclaration[] = Array.from(
@@ -137,6 +148,18 @@ export function drainLegacyContributionQueue(): AnySettingsContributionDeclarati
   )
   pendingLegacyContributions.clear()
   return out
+}
+
+/**
+ * Non-destructive view of the pending legacy contribution queue. Returns a
+ * shallow copy — callers may iterate freely but must not mutate the inner
+ * declarations. Used by the dispatch validation path (F3) to run collision
+ * checks without clearing state, so a thrown validation error leaves the
+ * queue intact for a retry after the author fixes the offending
+ * declaration.
+ */
+export function peekLegacyContributionQueue(): readonly AnySettingsContributionDeclaration[] {
+  return Array.from(pendingLegacyContributions.values())
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements HSR PR-2 per plan `docs/specs/2026-04-22-hsr-pr2-purdex-shell-plan.md` (v3.1) and spec `docs/specs/2026-04-21-settings-contribution-registry-design.md` (v3.2).

- `SettingsPage` (`GlobalSettingsPage`) + `SettingsSidebar` now read the PR-1 contribution registry directly (`listContributions('purdex')` + `listReservedItems()`), passing `ctx: { scope: 'purdex' }` into active components.
- `settings-section-registry.ts` becomes a **pending-buffer adapter**. Legacy `registerSettingsSection()` calls no longer touch the new registry; they `upsert` into a module-scope `pendingLegacyContributions` array (or, if `component` is undefined, into a `pendingReservedItems: Map<string, SettingsSectionDef>`). `dispatchSettingsContributions()` Phase 2 drains both via `drainLegacyContributionQueue()` and registers alongside module-declared batches — honoring the spec §7.2 dispatch-flushed hard constraint.
- `registerSettingsContribution` / `clearContributions` / `assertValidSettingsContribution` annotated `@internal` (closes #539 first milestone). `listContributions` / `getContribution` stay public.
- Closes first milestone of #538 (Purdex-layer render-level smoke) via new `SettingsPage.test.tsx`.

## Commits (4, each independently green)

| # | SHA | Subject |
|---|---|---|
| 1 | `9c74191a` | feat(spa): dispatch pass flushes legacy contribution queue (stub) |
| 2 | `748c401a` | feat(spa): settings-section-registry uses pending buffer + reserved upsert map |
| 3 | `6f87cc22` | feat(spa): SettingsPage + SettingsSidebar read new contribution registry with ctx |
| 4 | `56baa4e0` | refactor(spa): mark registerSettingsContribution as internal (#539) |

Commit 1 ships no-op stubs so it is a pure refactor (drain returns empty → end-to-end equivalent to `main`). Commit 2 replaces them with real buffers + adds §3.1 test matrix. Commit 3 wires the shells. Commit 4 is pure JSDoc + test lock.

## Design invariants honored (Round 1–3 convergence from plan)

- **Dispatch-flushed** (spec §7.2): adapter never calls `registerSettingsContribution()` directly — `clearContributions()` would otherwise wipe legacy items.
- **Reserved buffer = `Map<string, SettingsSectionDef>`** with upsert (N1), not array push.
- **Active buffer** also upsert by `def.id` (N1 — active not accumulating either).
- **HMR dispose** (`clearLegacyPending()`) clears both pending active + reserved Map.
- **React identity**: `wrapLegacyComponent` + `WeakMap<WrappedComp, OrigComp>` reverse lookup → `getSettingsSections()[i].component === originally-passed Comp`.
- **Namespace**: `moduleId = '_builtin.legacy-section'` centralized constant; id = `_builtin.legacy-section.<localId>`.

## Test plan

- [x] `pnpm exec vitest run` — 2420/2423 passed. 3 failures in `src/lib/sync/contributors/hosts.test.ts` are **pre-existing on origin/main `1002169e`** (token-preservation assertions `toBeNull()` vs `undefined`) — verified by detaching to main and re-running the same file: same 3 failures, identical assertions. Unrelated to this PR.
- [x] `pnpm run lint` — clean (0 errors).
- [x] `pnpm run build` — `tsc -b && vite build` success.
- [ ] Manual visual regression (`pnpm dev` → `/settings`): not yet run in this session; will run locally before merge.
- [x] `registerSettingsContribution` callsite audit: only `dispatch-settings-contributions.ts` + `register-modules.tsx` HMR dispose + test files.
- [x] `getSettingsSections()` preserved for external callsites (read-only passthrough), will be removed in PR-3 after reserved cleanup.

## Out of scope (follows in later PRs)

- PR-3: WorkspaceSettingsPage shell + reserved cleanup + #538 workspace smoke.
- PR-4: HostPage registry-driven + #541 cross-store rehydrate harness.
- PR-5: Editor module declares workspace/host home-path settings + LinkContext plumbing + #540 store snapshot.

## Review

Will run 2-round codex review (standard + 3-way adversarial) before merge.