### PR TITLE
feat(lights): trace schema upgrade + frame_divergences table (PR-1a)

### DIFF
--- a/internal/module/agent/trace.go
+++ b/internal/module/agent/trace.go
@@ -153,17 +153,22 @@ func (c *hookTraceCollector) append(in traceStepInput) string {
 	}
 	phase := in.Phase
 	if phase == "" {
-		// Legacy hook path writes directly to state, so every step is
-		// already committed from the envelope's perspective.
-		phase = "committed"
+		// Spec §3.5 phase ∈ {proposed, committed, rejected}. Derive from the
+		// decision per call site (rejected/skipped/unchanged stay proposed;
+		// frame upserts and successful emits commit).
+		phase = derivePhaseFromDecision(in.Decision)
 	}
 	outcome := in.Outcome
 	if outcome == "" {
 		outcome = deriveOutcomeFromDecision(in.Decision)
 	}
+	// Status defaults to "success": every appended step represents a
+	// completed observation. Status=failure is reserved for execution
+	// errors (panic / marshal / DB write) — not for rejected decisions,
+	// which spec §3.5 keeps under outcome.
 	status := in.Status
 	if status == "" {
-		status = deriveStatusFromOutcome(outcome)
+		status = "success"
 	}
 	action := in.Action
 	if action == "" {
@@ -318,30 +323,54 @@ func (c *hookTraceCollector) Finish(status, reason string) {
 	c.sink.Enqueue(record)
 }
 
-// deriveOutcomeFromDecision maps a step-level decision string onto the
-// spec §3.5 Outcome vocabulary. Unknown decisions fall back to "emitted"
-// so the pre-existing happy path remains unchanged, while reject/skip/
-// stable-projection paths surface their true observation outcome.
-func deriveOutcomeFromDecision(decision string) string {
-	switch decision {
-	case "rejected":
-		return "rejected"
-	case "skipped", "":
-		return "skipped"
-	case "projection_unchanged":
-		return "matched"
-	default:
-		return "emitted"
-	}
+// hookDecisionVocab enumerates every decision literal the agent hook path
+// emits (trigger / verify / frame / projection / emit call sites). An
+// unrecognised decision maps to an empty outcome — the previous "fall back
+// to emitted" default masked classification gaps that this PR's round-2
+// review flagged.
+var hookDecisionVocab = map[string]struct {
+	outcome string
+	phase   string
+}{
+	// trigger
+	"received": {outcome: "received", phase: "proposed"},
+	// verify
+	"accepted": {outcome: "accepted", phase: "proposed"},
+	"rejected": {outcome: "rejected", phase: "rejected"},
+	// frame_ops
+	"created_frame": {outcome: "created_frame", phase: "committed"},
+	"updated_frame": {outcome: "updated_frame", phase: "committed"},
+	"deleted_frame": {outcome: "deleted_frame", phase: "committed"},
+	"skipped":       {outcome: "skipped", phase: "proposed"},
+	// projection
+	"projection_changed":   {outcome: "projection_changed", phase: "committed"},
+	"projection_unchanged": {outcome: "projection_unchanged", phase: "proposed"},
+	// emit
+	"broadcasted": {outcome: "broadcasted", phase: "committed"},
 }
 
-// deriveStatusFromOutcome marks rejected observations as failures and
-// everything else as success.
-func deriveStatusFromOutcome(outcome string) string {
-	if outcome == "rejected" {
-		return "failure"
+// deriveOutcomeFromDecision maps a known decision literal onto the spec §3.5
+// Outcome vocabulary. Unknown decisions return "" so gaps surface instead of
+// defaulting to a happy-path value; the empty decision is treated as skipped
+// for legacy/no-op call sites.
+func deriveOutcomeFromDecision(decision string) string {
+	if decision == "" {
+		return "skipped"
 	}
-	return "success"
+	if entry, ok := hookDecisionVocab[decision]; ok {
+		return entry.outcome
+	}
+	return ""
+}
+
+// derivePhaseFromDecision maps a known decision literal onto Phase ∈
+// {proposed, committed, rejected}. Empty / unknown decisions default to
+// "proposed" — an observation without committed side-effects.
+func derivePhaseFromDecision(decision string) string {
+	if entry, ok := hookDecisionVocab[decision]; ok {
+		return entry.phase
+	}
+	return "proposed"
 }
 
 func marshalTraceJSON(v any) json.RawMessage {

--- a/internal/module/agent/trace.go
+++ b/internal/module/agent/trace.go
@@ -153,15 +153,17 @@ func (c *hookTraceCollector) append(in traceStepInput) string {
 	}
 	phase := in.Phase
 	if phase == "" {
+		// Legacy hook path writes directly to state, so every step is
+		// already committed from the envelope's perspective.
 		phase = "committed"
-	}
-	status := in.Status
-	if status == "" {
-		status = "success"
 	}
 	outcome := in.Outcome
 	if outcome == "" {
-		outcome = "emitted"
+		outcome = deriveOutcomeFromDecision(in.Decision)
+	}
+	status := in.Status
+	if status == "" {
+		status = deriveStatusFromOutcome(outcome)
 	}
 	action := in.Action
 	if action == "" {
@@ -314,6 +316,32 @@ func (c *hookTraceCollector) Finish(status, reason string) {
 		Steps: append([]store.TraceStep(nil), c.steps...),
 	}
 	c.sink.Enqueue(record)
+}
+
+// deriveOutcomeFromDecision maps a step-level decision string onto the
+// spec §3.5 Outcome vocabulary. Unknown decisions fall back to "emitted"
+// so the pre-existing happy path remains unchanged, while reject/skip/
+// stable-projection paths surface their true observation outcome.
+func deriveOutcomeFromDecision(decision string) string {
+	switch decision {
+	case "rejected":
+		return "rejected"
+	case "skipped", "":
+		return "skipped"
+	case "projection_unchanged":
+		return "matched"
+	default:
+		return "emitted"
+	}
+}
+
+// deriveStatusFromOutcome marks rejected observations as failures and
+// everything else as success.
+func deriveStatusFromOutcome(outcome string) string {
+	if outcome == "rejected" {
+		return "failure"
+	}
+	return "success"
 }
 
 func marshalTraceJSON(v any) json.RawMessage {

--- a/internal/module/agent/trace.go
+++ b/internal/module/agent/trace.go
@@ -100,50 +100,118 @@ func beginHookTrace(sink *hookTraceSink, req EventRequest) *hookTraceCollector {
 		},
 		nextSeq: 1,
 	}
-	collector.triggerStepID = collector.append(
-		"",
-		"trigger",
-		req.AgentType,
-		"",
-		"",
-		req.EventName,
-		"received",
-		"hook_post",
-		req,
-		nil,
-		nil,
-	)
+	collector.triggerStepID = collector.append(traceStepInput{
+		Kind:      "trigger",
+		AgentType: req.AgentType,
+		EventName: req.EventName,
+		Decision:  "received",
+		Reason:    "hook_post",
+		Payload:   req,
+	})
 	return collector
 }
 
-func (c *hookTraceCollector) append(parentStepID, kind, agentType, frameID, parentFrameID, eventName, decision, reason string, payload, before, after any) string {
+// traceStepInput carries the optional fields for a single trace step; zero
+// values fall back to hook-path defaults inside append().
+type traceStepInput struct {
+	// Identity
+	ParentStepID  string
+	Kind          string
+	AgentType     string
+	FrameID       string
+	ParentFrameID string
+	EventName     string
+	Decision      string
+	Reason        string
+
+	// Payload
+	Payload any
+	Before  any
+	After   any
+
+	// Lights envelope (spec §3.5)
+	SourceKind         string
+	Action             string
+	ReasonCode         string
+	Outcome            string
+	ScenarioKey        string
+	ObservedGeneration int64
+	DecisionPorts      string
+	Phase              string
+	Status             string
+	WatcherToken       *string
+}
+
+func (c *hookTraceCollector) append(in traceStepInput) string {
 	if c == nil {
 		return ""
 	}
 	stepID := uuid.NewString()
+	sourceKind := in.SourceKind
+	if sourceKind == "" {
+		sourceKind = "hook"
+	}
+	phase := in.Phase
+	if phase == "" {
+		phase = "committed"
+	}
+	status := in.Status
+	if status == "" {
+		status = "success"
+	}
+	outcome := in.Outcome
+	if outcome == "" {
+		outcome = "emitted"
+	}
+	action := in.Action
+	if action == "" {
+		action = in.Kind + ":" + in.Decision
+	}
+	scenarioKey := in.ScenarioKey
+	if scenarioKey == "" {
+		scenarioKey = in.EventName
+	}
+	reasonCode := in.ReasonCode
+	if reasonCode == "" {
+		reasonCode = in.Reason
+	}
+	decisionPorts := in.DecisionPorts
+	if decisionPorts == "" {
+		decisionPorts = "[]"
+	}
 	c.steps = append(c.steps, store.TraceStep{
-		StepID:        stepID,
-		ChainID:       c.chain.ChainID,
-		ParentStepID:  parentStepID,
-		Seq:           c.nextSeq,
-		Kind:          kind,
-		TmuxSession:   c.chain.TmuxSession,
-		PaneID:        c.chain.PaneID,
-		AgentType:     agentType,
-		FrameID:       frameID,
-		ParentFrameID: parentFrameID,
-		EventName:     eventName,
-		Decision:      decision,
-		Reason:        reason,
-		PayloadJSON:   marshalTraceJSON(payload),
-		BeforeJSON:    marshalTraceJSON(before),
-		AfterJSON:     marshalTraceJSON(after),
-		CreatedAt:     time.Now().UnixNano(),
+		StepID:             stepID,
+		ChainID:            c.chain.ChainID,
+		ParentStepID:       in.ParentStepID,
+		Seq:                c.nextSeq,
+		Kind:               in.Kind,
+		TmuxSession:        c.chain.TmuxSession,
+		PaneID:             c.chain.PaneID,
+		AgentType:          in.AgentType,
+		FrameID:            in.FrameID,
+		ParentFrameID:      in.ParentFrameID,
+		EventName:          in.EventName,
+		Decision:           in.Decision,
+		Reason:             in.Reason,
+		PayloadJSON:        marshalTraceJSON(in.Payload),
+		BeforeJSON:         marshalTraceJSON(in.Before),
+		AfterJSON:          marshalTraceJSON(in.After),
+		CreatedAt:          time.Now().UnixNano(),
+		SourceKind:         sourceKind,
+		Action:             action,
+		ReasonCode:         reasonCode,
+		Outcome:            outcome,
+		ScenarioKey:        scenarioKey,
+		ObservedGeneration: in.ObservedGeneration,
+		DecisionPorts:      json.RawMessage(decisionPorts),
+		Phase:              phase,
+		Status:             status,
+		WatcherToken:       in.WatcherToken,
 	})
 	c.nextSeq++
-	c.chain.LatestStepKind = kind
-	c.chain.LatestDecision = decision
-	c.chain.LatestStepReason = reason
+	c.chain.LatestStepKind = in.Kind
+	c.chain.LatestDecision = in.Decision
+	c.chain.LatestStepReason = in.Reason
 	return stepID
 }
 
@@ -151,38 +219,35 @@ func (c *hookTraceCollector) Verify(req EventRequest, decision, reason string, a
 	if c == nil {
 		return
 	}
-	c.verifyStepID = c.append(
-		c.triggerStepID,
-		"verify",
-		req.AgentType,
-		"",
-		"",
-		req.EventName,
-		decision,
-		reason,
-		req,
-		nil,
-		after,
-	)
+	c.verifyStepID = c.append(traceStepInput{
+		ParentStepID: c.triggerStepID,
+		Kind:         "verify",
+		AgentType:    req.AgentType,
+		EventName:    req.EventName,
+		Decision:     decision,
+		Reason:       reason,
+		Payload:      req,
+		After:        after,
+	})
 }
 
 func (c *hookTraceCollector) Frame(req EventRequest, meta FrameTraceMeta) {
 	if c == nil || meta.Decision == "" {
 		return
 	}
-	c.frameStepID = c.append(
-		c.verifyStepID,
-		"frame",
-		req.AgentType,
-		meta.FrameID,
-		meta.ParentFrameID,
-		req.EventName,
-		meta.Decision,
-		meta.Reason,
-		req,
-		meta.Before,
-		meta.After,
-	)
+	c.frameStepID = c.append(traceStepInput{
+		ParentStepID:  c.verifyStepID,
+		Kind:          "frame",
+		AgentType:     req.AgentType,
+		FrameID:       meta.FrameID,
+		ParentFrameID: meta.ParentFrameID,
+		EventName:     req.EventName,
+		Decision:      meta.Decision,
+		Reason:        meta.Reason,
+		Payload:       req,
+		Before:        meta.Before,
+		After:         meta.After,
+	})
 }
 
 type ProjectionTraceSummary struct {
@@ -200,19 +265,17 @@ func (c *hookTraceCollector) Projection(req EventRequest, summary ProjectionTrac
 	if parent == "" {
 		parent = c.verifyStepID
 	}
-	c.projectionStepID = c.append(
-		parent,
-		"projection",
-		req.AgentType,
-		"",
-		"",
-		req.EventName,
-		summary.Decision,
-		summary.Reason,
-		req,
-		summary.Before,
-		summary.After,
-	)
+	c.projectionStepID = c.append(traceStepInput{
+		ParentStepID: parent,
+		Kind:         "projection",
+		AgentType:    req.AgentType,
+		EventName:    req.EventName,
+		Decision:     summary.Decision,
+		Reason:       summary.Reason,
+		Payload:      req,
+		Before:       summary.Before,
+		After:        summary.After,
+	})
 }
 
 func (c *hookTraceCollector) Emit(payload any, agentType, eventName, decision, reason string) {
@@ -226,19 +289,16 @@ func (c *hookTraceCollector) Emit(payload any, agentType, eventName, decision, r
 	if parent == "" {
 		parent = c.verifyStepID
 	}
-	c.append(
-		parent,
-		"emit",
-		agentType,
-		"",
-		"",
-		eventName,
-		decision,
-		reason,
-		payload,
-		nil,
-		payload,
-	)
+	c.append(traceStepInput{
+		ParentStepID: parent,
+		Kind:         "emit",
+		AgentType:    agentType,
+		EventName:    eventName,
+		Decision:     decision,
+		Reason:       reason,
+		Payload:      payload,
+		After:        payload,
+	})
 }
 
 func (c *hookTraceCollector) Finish(status, reason string) {

--- a/internal/module/agent/trace_test.go
+++ b/internal/module/agent/trace_test.go
@@ -83,6 +83,33 @@ func TestHandleEvent_PersistAcceptedHookTrace(t *testing.T) {
 	if record.Steps[len(record.Steps)-1].Kind != "emit" {
 		t.Fatalf("last step kind = %q, want emit", record.Steps[len(record.Steps)-1].Kind)
 	}
+
+	for i, step := range record.Steps {
+		if step.SourceKind != "hook" {
+			t.Fatalf("step %d SourceKind = %q, want hook", i, step.SourceKind)
+		}
+		if step.Phase != "committed" {
+			t.Fatalf("step %d Phase = %q, want committed", i, step.Phase)
+		}
+		if step.Status != "success" {
+			t.Fatalf("step %d Status = %q, want success", i, step.Status)
+		}
+		if step.ScenarioKey == "" {
+			t.Fatalf("step %d ScenarioKey empty", i)
+		}
+		if step.Action == "" {
+			t.Fatalf("step %d Action empty", i)
+		}
+		if step.Outcome == "" {
+			t.Fatalf("step %d Outcome empty", i)
+		}
+		if string(step.DecisionPorts) != "[]" {
+			t.Fatalf("step %d DecisionPorts = %s, want []", i, string(step.DecisionPorts))
+		}
+		if step.WatcherToken != nil {
+			t.Fatalf("step %d WatcherToken = %v, want nil", i, step.WatcherToken)
+		}
+	}
 }
 
 func TestHandleEvent_VerifyRejectPersistsTerminalChain(t *testing.T) {

--- a/internal/module/agent/trace_test.go
+++ b/internal/module/agent/trace_test.go
@@ -161,6 +161,97 @@ func TestHandleEvent_VerifyRejectPersistsTerminalChain(t *testing.T) {
 	if record.Steps[1].ParentStepID != record.Steps[0].StepID {
 		t.Fatalf("verify ParentStepID = %q, want %q", record.Steps[1].ParentStepID, record.Steps[0].StepID)
 	}
+	// Verify step reflects rejection in outcome/status, not the hook-path defaults.
+	verify := record.Steps[1]
+	if verify.Decision != "rejected" {
+		t.Fatalf("verify Decision = %q, want rejected", verify.Decision)
+	}
+	if verify.Outcome != "rejected" {
+		t.Fatalf("verify Outcome = %q, want rejected", verify.Outcome)
+	}
+	if verify.Status != "failure" {
+		t.Fatalf("verify Status = %q, want failure", verify.Status)
+	}
+}
+
+func TestHandleEvent_ErrorGuardEmitSkippedPersistsSkippedOutcome(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%7", "work")
+	m.tmux = fakeTmux
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.sessions = &fakeSessionProvider{
+		sessions: []session.SessionInfo{{Code: "session-code-1", Name: "work"}},
+	}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive: func(string, json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{
+				Valid:  true,
+				Status: agentpkg.StatusRunning,
+				Detail: map[string]any{"source": "test"},
+			}
+		},
+	})
+	// Seed the session into an error state so the non-clearing event triggers
+	// the error-guard skipped emit path.
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusError
+	m.mu.Unlock()
+
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(`{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"PostToolUse",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleEvent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	page := waitForTraceChains(t, m, "work", 1)
+	if got := len(page.Chains); got != 1 {
+		t.Fatalf("len(page.Chains) = %d, want 1", got)
+	}
+	record, err := m.traces.GetChainRecord(page.Chains[0].ChainID)
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	var emit *store.TraceStep
+	for i := range record.Steps {
+		if record.Steps[i].Kind == "emit" {
+			emit = &record.Steps[i]
+			break
+		}
+	}
+	if emit == nil {
+		t.Fatalf("no emit step in chain; got kinds=%v", stepKinds(record.Steps))
+	}
+	if emit.Decision != "skipped" {
+		t.Fatalf("emit Decision = %q, want skipped", emit.Decision)
+	}
+	if emit.Outcome != "skipped" {
+		t.Fatalf("emit Outcome = %q, want skipped", emit.Outcome)
+	}
+	if emit.Status != "success" {
+		t.Fatalf("emit Status = %q, want success", emit.Status)
+	}
+}
+
+func stepKinds(steps []store.TraceStep) []string {
+	out := make([]string, len(steps))
+	for i, s := range steps {
+		out[i] = s.Kind
+	}
+	return out
 }
 
 func waitForTraceChains(t *testing.T, m *Module, tmuxSession string, want int) store.TraceChainPage {

--- a/internal/module/agent/trace_test.go
+++ b/internal/module/agent/trace_test.go
@@ -84,12 +84,31 @@ func TestHandleEvent_PersistAcceptedHookTrace(t *testing.T) {
 		t.Fatalf("last step kind = %q, want emit", record.Steps[len(record.Steps)-1].Kind)
 	}
 
+	// Spec §3.5 phase is derived from each step's decision. Happy-path
+	// decisions in this scenario: received/accepted → proposed,
+	// created_frame → committed, projection_* → committed when changed /
+	// proposed when unchanged, broadcasted → committed.
+	wantPhase := map[string]string{
+		"received":             "proposed",
+		"accepted":             "proposed",
+		"created_frame":        "committed",
+		"updated_frame":        "committed",
+		"deleted_frame":        "committed",
+		"projection_changed":   "committed",
+		"projection_unchanged": "proposed",
+		"broadcasted":          "committed",
+		"skipped":              "proposed",
+	}
 	for i, step := range record.Steps {
 		if step.SourceKind != "hook" {
 			t.Fatalf("step %d SourceKind = %q, want hook", i, step.SourceKind)
 		}
-		if step.Phase != "committed" {
-			t.Fatalf("step %d Phase = %q, want committed", i, step.Phase)
+		phase, ok := wantPhase[step.Decision]
+		if !ok {
+			t.Fatalf("step %d unexpected decision = %q", i, step.Decision)
+		}
+		if step.Phase != phase {
+			t.Fatalf("step %d (%s/%s) Phase = %q, want %q", i, step.Kind, step.Decision, step.Phase, phase)
 		}
 		if step.Status != "success" {
 			t.Fatalf("step %d Status = %q, want success", i, step.Status)
@@ -161,7 +180,9 @@ func TestHandleEvent_VerifyRejectPersistsTerminalChain(t *testing.T) {
 	if record.Steps[1].ParentStepID != record.Steps[0].StepID {
 		t.Fatalf("verify ParentStepID = %q, want %q", record.Steps[1].ParentStepID, record.Steps[0].StepID)
 	}
-	// Verify step reflects rejection in outcome/status, not the hook-path defaults.
+	// Verify step reflects rejection in outcome + phase; spec §3.5 line 511
+	// is explicit that a pre-commit reject is still a successful observation
+	// (status=success, outcome=rejected, phase=rejected).
 	verify := record.Steps[1]
 	if verify.Decision != "rejected" {
 		t.Fatalf("verify Decision = %q, want rejected", verify.Decision)
@@ -169,8 +190,11 @@ func TestHandleEvent_VerifyRejectPersistsTerminalChain(t *testing.T) {
 	if verify.Outcome != "rejected" {
 		t.Fatalf("verify Outcome = %q, want rejected", verify.Outcome)
 	}
-	if verify.Status != "failure" {
-		t.Fatalf("verify Status = %q, want failure", verify.Status)
+	if verify.Phase != "rejected" {
+		t.Fatalf("verify Phase = %q, want rejected", verify.Phase)
+	}
+	if verify.Status != "success" {
+		t.Fatalf("verify Status = %q, want success (spec §3.5)", verify.Status)
 	}
 }
 
@@ -241,8 +265,118 @@ func TestHandleEvent_ErrorGuardEmitSkippedPersistsSkippedOutcome(t *testing.T) {
 	if emit.Outcome != "skipped" {
 		t.Fatalf("emit Outcome = %q, want skipped", emit.Outcome)
 	}
+	if emit.Phase != "proposed" {
+		t.Fatalf("emit Phase = %q, want proposed (observation without commit)", emit.Phase)
+	}
 	if emit.Status != "success" {
 		t.Fatalf("emit Status = %q, want success", emit.Status)
+	}
+}
+
+// TestDeriveOutcomeFromDecision covers the explicit decision→outcome vocabulary
+// map. The round-2 adversarial review called out that an unknown decision
+// silently folded into "emitted" — we now return "" for unknown and add a
+// dedicated negative-path assertion.
+func TestDeriveOutcomeFromDecision(t *testing.T) {
+	cases := map[string]string{
+		// Verify lifecycle
+		"received": "received",
+		"accepted": "accepted",
+		"rejected": "rejected",
+		// Frame apply
+		"created_frame": "created_frame",
+		"updated_frame": "updated_frame",
+		"deleted_frame": "deleted_frame",
+		"skipped":       "skipped",
+		// Projection
+		"projection_changed":   "projection_changed",
+		"projection_unchanged": "projection_unchanged",
+		// Emit
+		"broadcasted": "broadcasted",
+		// Empty decision is treated as skipped by legacy callers.
+		"": "skipped",
+	}
+	for decision, want := range cases {
+		if got := deriveOutcomeFromDecision(decision); got != want {
+			t.Errorf("deriveOutcomeFromDecision(%q) = %q, want %q", decision, got, want)
+		}
+	}
+}
+
+func TestDeriveOutcomeFromDecision_UnknownDecisionDoesNotMapToEmitted(t *testing.T) {
+	if got := deriveOutcomeFromDecision("totally_bogus_decision"); got != "" {
+		t.Fatalf("unknown decision outcome = %q, want empty (must not default to emitted)", got)
+	}
+}
+
+// TestDerivePhaseFromDecision covers the per-decision phase classifier. Spec
+// §3.5 Phase ∈ {proposed, committed, rejected}: verify/skipped/unchanged are
+// observations without commit; frame upserts and successful emits commit.
+func TestDerivePhaseFromDecision(t *testing.T) {
+	cases := map[string]string{
+		"received":             "proposed",
+		"accepted":             "proposed",
+		"rejected":             "rejected",
+		"created_frame":        "committed",
+		"updated_frame":        "committed",
+		"deleted_frame":        "committed",
+		"skipped":              "proposed",
+		"projection_changed":   "committed",
+		"projection_unchanged": "proposed",
+		"broadcasted":          "committed",
+		"":                     "proposed",
+	}
+	for decision, want := range cases {
+		if got := derivePhaseFromDecision(decision); got != want {
+			t.Errorf("derivePhaseFromDecision(%q) = %q, want %q", decision, got, want)
+		}
+	}
+}
+
+func TestHandleEvent_Emit_PhaseIsCommittedWhenBroadcasted(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%7", "work")
+	m.tmux = fakeTmux
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.sessions = &fakeSessionProvider{
+		sessions: []session.SessionInfo{{Code: "session-code-1", Name: "work"}},
+	}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "codex",
+		derive: func(string, json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning}
+		},
+	})
+
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(`{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"UserPromptSubmit",
+		"raw_event":{"prompt":"hi"},
+		"agent_type":"codex",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleEvent(w, req)
+
+	page := waitForTraceChains(t, m, "work", 1)
+	record, err := m.traces.GetChainRecord(page.Chains[0].ChainID)
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	emit := record.Steps[len(record.Steps)-1]
+	if emit.Kind != "emit" {
+		t.Fatalf("last step kind = %q, want emit", emit.Kind)
+	}
+	if emit.Decision != "broadcasted" {
+		t.Fatalf("emit Decision = %q, want broadcasted", emit.Decision)
+	}
+	if emit.Phase != "committed" {
+		t.Fatalf("emit Phase = %q, want committed", emit.Phase)
 	}
 }
 

--- a/internal/store/agent_event.go
+++ b/internal/store/agent_event.go
@@ -45,6 +45,17 @@ func OpenAgentEvent(path string) (*AgentEventStore, error) {
 		db.Close()
 		return nil, fmt.Errorf("migrate agent event db: %w", err)
 	}
+	// frame_divergences is populated by the dual-write passthrough path that
+	// lands in a later PR; production code never reaches Divergences() via
+	// the hook hot path. Migrate eagerly at open time so the table exists
+	// for ops tooling (PR-1a review finding). Frames/Traces already get
+	// migrated by module.New() touching their getters, and their legacy
+	// migration tests seed raw schema against a freshly-opened DB — so we
+	// don't eagerly migrate those here to keep the seed helpers working.
+	if err := migrateDivergencesDB(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate divergences db: %w", err)
+	}
 	return &AgentEventStore{db: db}, nil
 }
 

--- a/internal/store/agent_event.go
+++ b/internal/store/agent_event.go
@@ -156,3 +156,12 @@ func (s *AgentEventStore) Traces() (*TraceStore, error) {
 		maxSteps:  defaultTraceMaxSteps,
 	}, nil
 }
+
+// Divergences returns a DivergenceStore backed by the same SQLite connection.
+// The table is migrated lazily on first call.
+func (s *AgentEventStore) Divergences() (*DivergenceStore, error) {
+	if err := migrateDivergencesDB(s.db); err != nil {
+		return nil, err
+	}
+	return &DivergenceStore{db: s.db}, nil
+}

--- a/internal/store/agent_event.go
+++ b/internal/store/agent_event.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
+	"sync"
 
 	_ "modernc.org/sqlite"
 )
@@ -19,7 +21,12 @@ type AgentEvent struct {
 }
 
 // AgentEventStore persists the latest agent hook event per tmux session.
-type AgentEventStore struct{ db *sql.DB }
+type AgentEventStore struct {
+	db *sql.DB
+
+	divergenceMu    sync.Mutex
+	divergenceReady bool
+}
 
 // OpenAgentEvent opens (or creates) an AgentEventStore DB at path, runs
 // migration, and enables WAL mode. Use ":memory:" for tests.
@@ -45,18 +52,17 @@ func OpenAgentEvent(path string) (*AgentEventStore, error) {
 		db.Close()
 		return nil, fmt.Errorf("migrate agent event db: %w", err)
 	}
-	// frame_divergences is populated by the dual-write passthrough path that
-	// lands in a later PR; production code never reaches Divergences() via
-	// the hook hot path. Migrate eagerly at open time so the table exists
-	// for ops tooling (PR-1a review finding). Frames/Traces already get
-	// migrated by module.New() touching their getters, and their legacy
-	// migration tests seed raw schema against a freshly-opened DB — so we
-	// don't eagerly migrate those here to keep the seed helpers working.
-	if err := migrateDivergencesDB(db); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("migrate divergences db: %w", err)
+	store := &AgentEventStore{db: db}
+	// frame_divergences is eagerly migrated so ops tooling finds the table
+	// ready. A failure here is *non-fatal*: divergences are a side channel
+	// for the dual-write observation window (spec §8.1) and should never
+	// block daemon startup. Divergences() retries lazily on demand.
+	if err := migrateDivergencesDBFn(db); err != nil {
+		log.Printf("[store] divergences migration deferred: %v", err)
+	} else {
+		store.divergenceReady = true
 	}
-	return &AgentEventStore{db: db}, nil
+	return store, nil
 }
 
 func migrateAgentEventDB(db *sql.DB) error {
@@ -169,10 +175,17 @@ func (s *AgentEventStore) Traces() (*TraceStore, error) {
 }
 
 // Divergences returns a DivergenceStore backed by the same SQLite connection.
-// The table is migrated lazily on first call.
+// If the eager migration at OpenAgentEvent time failed, retry it here so a
+// transient error (e.g. disk-full at boot) does not permanently disable the
+// side channel.
 func (s *AgentEventStore) Divergences() (*DivergenceStore, error) {
-	if err := migrateDivergencesDB(s.db); err != nil {
-		return nil, err
+	s.divergenceMu.Lock()
+	defer s.divergenceMu.Unlock()
+	if !s.divergenceReady {
+		if err := migrateDivergencesDBFn(s.db); err != nil {
+			return nil, err
+		}
+		s.divergenceReady = true
 	}
 	return &DivergenceStore{db: s.db}, nil
 }

--- a/internal/store/agent_event_test.go
+++ b/internal/store/agent_event_test.go
@@ -2,9 +2,13 @@
 package store
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"testing"
 )
+
+var errDivergenceMigrateInject = errors.New("injected divergence migrate failure")
 
 func openTestAgentEventStore(t *testing.T) *AgentEventStore {
 	t.Helper()
@@ -29,6 +33,50 @@ func TestOpenAgentEvent_DivergencesTableExistsAfterOpen(t *testing.T) {
 	).Scan(&got)
 	if err != nil {
 		t.Fatalf("frame_divergences missing after OpenAgentEvent: %v", err)
+	}
+}
+
+// TestOpenAgentEvent_DivergencesMigrationFailureIsNonFatal ensures daemon
+// startup is not blocked when the divergences migration fails. Divergences()
+// lazily retries the underlying migrate call so a transient failure does not
+// permanently disable the side channel (round-2 review D).
+func TestOpenAgentEvent_DivergencesMigrationFailureIsNonFatal(t *testing.T) {
+	fail := true
+	orig := migrateDivergencesDBFn
+	migrateDivergencesDBFn = func(db *sql.DB) error {
+		if fail {
+			return errDivergenceMigrateInject
+		}
+		return orig(db)
+	}
+	t.Cleanup(func() { migrateDivergencesDBFn = orig })
+
+	s, err := OpenAgentEvent(":memory:")
+	if err != nil {
+		t.Fatalf("OpenAgentEvent must not fail when divergences migrate errors: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	// First Divergences() call also fails while the injection is active.
+	if _, err := s.Divergences(); err == nil {
+		t.Fatal("expected Divergences() to propagate migration failure")
+	}
+
+	// Clear the injection: the next call must successfully retry.
+	fail = false
+	divs, err := s.Divergences()
+	if err != nil {
+		t.Fatalf("Divergences retry failed: %v", err)
+	}
+	if divs == nil {
+		t.Fatal("Divergences returned nil after retry")
+	}
+
+	var name string
+	if err := s.db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='frame_divergences'`,
+	).Scan(&name); err != nil {
+		t.Fatalf("frame_divergences missing after retry: %v", err)
 	}
 }
 

--- a/internal/store/agent_event_test.go
+++ b/internal/store/agent_event_test.go
@@ -16,6 +16,22 @@ func openTestAgentEventStore(t *testing.T) *AgentEventStore {
 	return s
 }
 
+// frame_divergences must exist immediately after OpenAgentEvent because no
+// production code path reaches Divergences() on the hook hot path, so a lazy
+// getter would leave the table unprovisioned in deployed daemons (PR-1a
+// review finding).
+func TestOpenAgentEvent_DivergencesTableExistsAfterOpen(t *testing.T) {
+	s := openTestAgentEventStore(t)
+
+	var got string
+	err := s.db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='frame_divergences'`,
+	).Scan(&got)
+	if err != nil {
+		t.Fatalf("frame_divergences missing after OpenAgentEvent: %v", err)
+	}
+}
+
 func TestAgentEventStore_SetAndGet(t *testing.T) {
 	s := openTestAgentEventStore(t)
 

--- a/internal/store/divergences.go
+++ b/internal/store/divergences.go
@@ -2,19 +2,24 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 )
 
 // FrameDivergence captures a single observed mismatch between the legacy
 // direct-write frame and the Arbitrator proposal during the Phase 1 dual-write
 // window (spec §8.1).
+//
+// OldStateRef / ProposalStateRef are JSON snapshots. The storage column is
+// TEXT (not BLOB, contrary to the initial spec DDL draft) so json.Marshal of
+// this struct surfaces them as nested JSON rather than base64 strings.
 type FrameDivergence struct {
 	ID                 int64
 	SessionID          string
 	TraceID            string
 	EventID            string
 	ObservedGeneration int64
-	OldStateRef        []byte
-	ProposalStateRef   []byte
+	OldStateRef        json.RawMessage
+	ProposalStateRef   json.RawMessage
 	DiffSummary        string
 	Matched            bool
 	ReasonCode         string
@@ -27,6 +32,10 @@ type DivergenceStore struct {
 	db *sql.DB
 }
 
+// migrateDivergencesDBFn is the indirection tests use to simulate an
+// unrecoverable migration failure without touching the real schema.
+var migrateDivergencesDBFn = migrateDivergencesDB
+
 func migrateDivergencesDB(db *sql.DB) error {
 	if _, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS frame_divergences (
@@ -35,8 +44,8 @@ func migrateDivergencesDB(db *sql.DB) error {
 			trace_id            TEXT NOT NULL,
 			event_id            TEXT NOT NULL,
 			observed_generation INTEGER NOT NULL,
-			old_state_ref       BLOB NOT NULL,
-			proposal_state_ref  BLOB NOT NULL,
+			old_state_ref       TEXT NOT NULL,
+			proposal_state_ref  TEXT NOT NULL,
 			diff_summary        TEXT NOT NULL,
 			matched             INTEGER NOT NULL,
 			reason_code         TEXT,
@@ -51,10 +60,17 @@ func migrateDivergencesDB(db *sql.DB) error {
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_divergence_matched ON frame_divergences(matched)`); err != nil {
 		return err
 	}
+	// Idempotency key: retrying the same observation (session/trace/event/
+	// generation tuple) must not produce duplicate rows.
+	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_divergence_idempotency ON frame_divergences(session_id, trace_id, event_id, observed_generation)`); err != nil {
+		return err
+	}
 	return nil
 }
 
-// Insert appends a divergence row and returns the generated row id.
+// Insert appends a divergence row and returns the generated row id. Duplicate
+// (session_id, trace_id, event_id, observed_generation) tuples are ignored and
+// return 0 so callers can retry safely without double-counting.
 func (s *DivergenceStore) Insert(d FrameDivergence) (int64, error) {
 	matched := 0
 	if d.Matched {
@@ -66,8 +82,9 @@ func (s *DivergenceStore) Insert(d FrameDivergence) (int64, error) {
 			old_state_ref, proposal_state_ref, diff_summary, matched,
 			reason_code, created_at
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(session_id, trace_id, event_id, observed_generation) DO NOTHING
 	`, d.SessionID, d.TraceID, d.EventID, d.ObservedGeneration,
-		d.OldStateRef, d.ProposalStateRef, d.DiffSummary, matched,
+		jsonRefText(d.OldStateRef), jsonRefText(d.ProposalStateRef), d.DiffSummary, matched,
 		nullString(d.ReasonCode), d.CreatedAt)
 	if err != nil {
 		return 0, err
@@ -80,6 +97,7 @@ func (s *DivergenceStore) Get(id int64) (*FrameDivergence, error) {
 	var d FrameDivergence
 	var matched int
 	var reasonCode sql.NullString
+	var oldState, proposalState string
 	err := s.db.QueryRow(`
 		SELECT id, session_id, trace_id, event_id, observed_generation,
 		       old_state_ref, proposal_state_ref, diff_summary, matched,
@@ -92,8 +110,8 @@ func (s *DivergenceStore) Get(id int64) (*FrameDivergence, error) {
 		&d.TraceID,
 		&d.EventID,
 		&d.ObservedGeneration,
-		&d.OldStateRef,
-		&d.ProposalStateRef,
+		&oldState,
+		&proposalState,
 		&d.DiffSummary,
 		&matched,
 		&reasonCode,
@@ -107,5 +125,16 @@ func (s *DivergenceStore) Get(id int64) (*FrameDivergence, error) {
 	}
 	d.Matched = matched != 0
 	d.ReasonCode = reasonCode.String
+	d.OldStateRef = json.RawMessage(oldState)
+	d.ProposalStateRef = json.RawMessage(proposalState)
 	return &d, nil
+}
+
+// jsonRefText normalizes a nil/empty JSON snapshot to "null" so the TEXT
+// column's NOT NULL constraint always holds without special-casing callers.
+func jsonRefText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "null"
+	}
+	return string(raw)
 }

--- a/internal/store/divergences.go
+++ b/internal/store/divergences.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"database/sql"
+)
+
+// FrameDivergence captures a single observed mismatch between the legacy
+// direct-write frame and the Arbitrator proposal during the Phase 1 dual-write
+// window (spec §8.1).
+type FrameDivergence struct {
+	ID                 int64
+	SessionID          string
+	TraceID            string
+	EventID            string
+	ObservedGeneration int64
+	OldStateRef        []byte
+	ProposalStateRef   []byte
+	DiffSummary        string
+	Matched            bool
+	ReasonCode         string
+	CreatedAt          int64
+}
+
+// DivergenceStore persists frame divergences for the dual-write observation
+// window.
+type DivergenceStore struct {
+	db *sql.DB
+}
+
+func migrateDivergencesDB(db *sql.DB) error {
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS frame_divergences (
+			id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id          TEXT NOT NULL,
+			trace_id            TEXT NOT NULL,
+			event_id            TEXT NOT NULL,
+			observed_generation INTEGER NOT NULL,
+			old_state_ref       BLOB NOT NULL,
+			proposal_state_ref  BLOB NOT NULL,
+			diff_summary        TEXT NOT NULL,
+			matched             INTEGER NOT NULL,
+			reason_code         TEXT,
+			created_at          INTEGER NOT NULL
+		)
+	`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_divergence_session ON frame_divergences(session_id, created_at)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_divergence_matched ON frame_divergences(matched)`); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Insert appends a divergence row and returns the generated row id.
+func (s *DivergenceStore) Insert(d FrameDivergence) (int64, error) {
+	matched := 0
+	if d.Matched {
+		matched = 1
+	}
+	res, err := s.db.Exec(`
+		INSERT INTO frame_divergences (
+			session_id, trace_id, event_id, observed_generation,
+			old_state_ref, proposal_state_ref, diff_summary, matched,
+			reason_code, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, d.SessionID, d.TraceID, d.EventID, d.ObservedGeneration,
+		d.OldStateRef, d.ProposalStateRef, d.DiffSummary, matched,
+		nullString(d.ReasonCode), d.CreatedAt)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// Get returns the divergence row with the given id, or nil if not found.
+func (s *DivergenceStore) Get(id int64) (*FrameDivergence, error) {
+	var d FrameDivergence
+	var matched int
+	var reasonCode sql.NullString
+	err := s.db.QueryRow(`
+		SELECT id, session_id, trace_id, event_id, observed_generation,
+		       old_state_ref, proposal_state_ref, diff_summary, matched,
+		       reason_code, created_at
+		FROM frame_divergences
+		WHERE id = ?
+	`, id).Scan(
+		&d.ID,
+		&d.SessionID,
+		&d.TraceID,
+		&d.EventID,
+		&d.ObservedGeneration,
+		&d.OldStateRef,
+		&d.ProposalStateRef,
+		&d.DiffSummary,
+		&matched,
+		&reasonCode,
+		&d.CreatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	d.Matched = matched != 0
+	d.ReasonCode = reasonCode.String
+	return &d, nil
+}

--- a/internal/store/divergences_test.go
+++ b/internal/store/divergences_test.go
@@ -1,7 +1,9 @@
 package store
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -24,8 +26,8 @@ func TestDivergenceStore_InsertAndFetchRoundtrip(t *testing.T) {
 		TraceID:            "chain-1",
 		EventID:            "evt-1",
 		ObservedGeneration: 42,
-		OldStateRef:        []byte(`{"frame":"old"}`),
-		ProposalStateRef:   []byte(`{"frame":"new"}`),
+		OldStateRef:        json.RawMessage(`{"frame":"old"}`),
+		ProposalStateRef:   json.RawMessage(`{"frame":"new"}`),
 		DiffSummary:        `{"changed":["decision"]}`,
 		Matched:            false,
 		ReasonCode:         "projection_mismatch",
@@ -76,17 +78,82 @@ func TestDivergenceStore_InsertAndFetchRoundtrip(t *testing.T) {
 	}
 }
 
+// TestDivergenceStore_StateRefsSerializeAsJSONNotBase64 guards against the
+// regression flagged by the round-2 review: when OldStateRef /
+// ProposalStateRef were []byte backed by a BLOB column, json.Marshal on the
+// struct encoded them as base64 strings and leaked the underlying bytes
+// representation into API consumers. json.RawMessage + TEXT keeps the JSON
+// structure intact.
+func TestDivergenceStore_StateRefsSerializeAsJSONNotBase64(t *testing.T) {
+	d := FrameDivergence{
+		SessionID:        "proj-a",
+		TraceID:          "t1",
+		EventID:          "e1",
+		OldStateRef:      json.RawMessage(`{"frame":"old"}`),
+		ProposalStateRef: json.RawMessage(`{"frame":"new"}`),
+		DiffSummary:      "{}",
+		CreatedAt:        1,
+	}
+	buf, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	body := string(buf)
+	// JSON snapshot must appear as nested objects, not base64-encoded strings.
+	if !strings.Contains(body, `"OldStateRef":{"frame":"old"}`) {
+		t.Fatalf("OldStateRef not rendered as nested JSON: %s", body)
+	}
+	if !strings.Contains(body, `"ProposalStateRef":{"frame":"new"}`) {
+		t.Fatalf("ProposalStateRef not rendered as nested JSON: %s", body)
+	}
+}
+
+// TestDivergenceStore_DuplicateInsertIsIdempotent ensures retry/replay with
+// the same (session, trace, event, generation) key does not produce a second
+// row. The ON CONFLICT DO NOTHING clause backs the unique index.
+func TestDivergenceStore_DuplicateInsertIsIdempotent(t *testing.T) {
+	s := openTestDivergenceStore(t)
+
+	d := FrameDivergence{
+		SessionID:          "proj-a",
+		TraceID:            "trace-1",
+		EventID:            "evt-1",
+		ObservedGeneration: 7,
+		OldStateRef:        json.RawMessage(`{"frame":"a"}`),
+		ProposalStateRef:   json.RawMessage(`{"frame":"b"}`),
+		DiffSummary:        "{}",
+		Matched:            false,
+		CreatedAt:          1,
+	}
+
+	if _, err := s.Insert(d); err != nil {
+		t.Fatalf("Insert #1: %v", err)
+	}
+	if _, err := s.Insert(d); err != nil {
+		t.Fatalf("Insert #2 (idempotent): %v", err)
+	}
+
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM frame_divergences WHERE session_id=? AND trace_id=? AND event_id=? AND observed_generation=?`,
+		d.SessionID, d.TraceID, d.EventID, d.ObservedGeneration).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("duplicate inserts produced %d rows, want 1", count)
+	}
+}
+
 func TestDivergenceStore_MatchedFlagPersistsBothValues(t *testing.T) {
 	s := openTestDivergenceStore(t)
 
 	matched := FrameDivergence{
 		SessionID: "proj-a", TraceID: "t1", EventID: "e1",
-		OldStateRef: []byte("a"), ProposalStateRef: []byte("a"),
+		OldStateRef: json.RawMessage(`{"x":"a"}`), ProposalStateRef: json.RawMessage(`{"x":"a"}`),
 		DiffSummary: "{}", Matched: true, CreatedAt: 1,
 	}
 	mismatched := FrameDivergence{
 		SessionID: "proj-a", TraceID: "t2", EventID: "e2",
-		OldStateRef: []byte("a"), ProposalStateRef: []byte("b"),
+		OldStateRef: json.RawMessage(`{"x":"a"}`), ProposalStateRef: json.RawMessage(`{"x":"b"}`),
 		DiffSummary: `{"k":"v"}`, Matched: false, ReasonCode: "x", CreatedAt: 2,
 	}
 
@@ -134,8 +201,8 @@ func TestDivergenceStore_ParallelInsertsAllPersist(t *testing.T) {
 					TraceID:            fmt.Sprintf("trace-%d-%d", gid, i),
 					EventID:            fmt.Sprintf("evt-%d-%d", gid, i),
 					ObservedGeneration: int64(i),
-					OldStateRef:        []byte("old"),
-					ProposalStateRef:   []byte("new"),
+					OldStateRef:        json.RawMessage(`{"v":"old"}`),
+					ProposalStateRef:   json.RawMessage(`{"v":"new"}`),
 					DiffSummary:        "{}",
 					Matched:            i%2 == 0,
 					CreatedAt:          int64(gid*1000 + i),
@@ -166,8 +233,9 @@ func TestDivergenceStore_IndexesAreCreated(t *testing.T) {
 	s := openTestDivergenceStore(t)
 
 	wantIndexes := map[string]bool{
-		"idx_divergence_session": false,
-		"idx_divergence_matched": false,
+		"idx_divergence_session":     false,
+		"idx_divergence_matched":     false,
+		"idx_divergence_idempotency": false,
 	}
 	rows, err := s.db.Query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='frame_divergences'`)
 	if err != nil {

--- a/internal/store/divergences_test.go
+++ b/internal/store/divergences_test.go
@@ -1,0 +1,191 @@
+package store
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func openTestDivergenceStore(t *testing.T) *DivergenceStore {
+	t.Helper()
+	events := openTestAgentEventStore(t)
+	divs, err := events.Divergences()
+	if err != nil {
+		t.Fatalf("Divergences: %v", err)
+	}
+	return divs
+}
+
+func TestDivergenceStore_InsertAndFetchRoundtrip(t *testing.T) {
+	s := openTestDivergenceStore(t)
+
+	d := FrameDivergence{
+		SessionID:          "proj-a",
+		TraceID:            "chain-1",
+		EventID:            "evt-1",
+		ObservedGeneration: 42,
+		OldStateRef:        []byte(`{"frame":"old"}`),
+		ProposalStateRef:   []byte(`{"frame":"new"}`),
+		DiffSummary:        `{"changed":["decision"]}`,
+		Matched:            false,
+		ReasonCode:         "projection_mismatch",
+		CreatedAt:          1700000000,
+	}
+
+	id, err := s.Insert(d)
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("Insert id = %d, want > 0", id)
+	}
+
+	got, err := s.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.ID != id {
+		t.Fatalf("ID = %d, want %d", got.ID, id)
+	}
+	if got.SessionID != d.SessionID || got.TraceID != d.TraceID || got.EventID != d.EventID {
+		t.Fatalf("identifiers mismatch: %+v", got)
+	}
+	if got.ObservedGeneration != d.ObservedGeneration {
+		t.Fatalf("ObservedGeneration = %d, want %d", got.ObservedGeneration, d.ObservedGeneration)
+	}
+	if string(got.OldStateRef) != string(d.OldStateRef) {
+		t.Fatalf("OldStateRef = %s", string(got.OldStateRef))
+	}
+	if string(got.ProposalStateRef) != string(d.ProposalStateRef) {
+		t.Fatalf("ProposalStateRef = %s", string(got.ProposalStateRef))
+	}
+	if got.DiffSummary != d.DiffSummary {
+		t.Fatalf("DiffSummary = %q", got.DiffSummary)
+	}
+	if got.Matched != d.Matched {
+		t.Fatalf("Matched = %v, want %v", got.Matched, d.Matched)
+	}
+	if got.ReasonCode != d.ReasonCode {
+		t.Fatalf("ReasonCode = %q", got.ReasonCode)
+	}
+	if got.CreatedAt != d.CreatedAt {
+		t.Fatalf("CreatedAt = %d", got.CreatedAt)
+	}
+}
+
+func TestDivergenceStore_MatchedFlagPersistsBothValues(t *testing.T) {
+	s := openTestDivergenceStore(t)
+
+	matched := FrameDivergence{
+		SessionID: "proj-a", TraceID: "t1", EventID: "e1",
+		OldStateRef: []byte("a"), ProposalStateRef: []byte("a"),
+		DiffSummary: "{}", Matched: true, CreatedAt: 1,
+	}
+	mismatched := FrameDivergence{
+		SessionID: "proj-a", TraceID: "t2", EventID: "e2",
+		OldStateRef: []byte("a"), ProposalStateRef: []byte("b"),
+		DiffSummary: `{"k":"v"}`, Matched: false, ReasonCode: "x", CreatedAt: 2,
+	}
+
+	mID, err := s.Insert(matched)
+	if err != nil {
+		t.Fatalf("Insert matched: %v", err)
+	}
+	unID, err := s.Insert(mismatched)
+	if err != nil {
+		t.Fatalf("Insert mismatched: %v", err)
+	}
+
+	gotMatched, err := s.Get(mID)
+	if err != nil || gotMatched == nil {
+		t.Fatalf("Get matched: %v", err)
+	}
+	if !gotMatched.Matched {
+		t.Fatalf("Matched = false, want true")
+	}
+	gotMismatch, err := s.Get(unID)
+	if err != nil || gotMismatch == nil {
+		t.Fatalf("Get mismatched: %v", err)
+	}
+	if gotMismatch.Matched {
+		t.Fatalf("Matched = true, want false")
+	}
+}
+
+// Single-conn DB serializes writes; this test verifies no lost updates at the Go layer.
+func TestDivergenceStore_ParallelInsertsAllPersist(t *testing.T) {
+	s := openTestDivergenceStore(t)
+
+	const goroutines = 8
+	const perGoroutine = 12
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines*perGoroutine)
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				d := FrameDivergence{
+					SessionID:          fmt.Sprintf("sess-%d", gid),
+					TraceID:            fmt.Sprintf("trace-%d-%d", gid, i),
+					EventID:            fmt.Sprintf("evt-%d-%d", gid, i),
+					ObservedGeneration: int64(i),
+					OldStateRef:        []byte("old"),
+					ProposalStateRef:   []byte("new"),
+					DiffSummary:        "{}",
+					Matched:            i%2 == 0,
+					CreatedAt:          int64(gid*1000 + i),
+				}
+				if _, err := s.Insert(d); err != nil {
+					errs <- err
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent insert: %v", err)
+	}
+
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM frame_divergences`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if want := goroutines * perGoroutine; count != want {
+		t.Fatalf("count = %d, want %d (lost updates)", count, want)
+	}
+}
+
+func TestDivergenceStore_IndexesAreCreated(t *testing.T) {
+	s := openTestDivergenceStore(t)
+
+	wantIndexes := map[string]bool{
+		"idx_divergence_session": false,
+		"idx_divergence_matched": false,
+	}
+	rows, err := s.db.Query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='frame_divergences'`)
+	if err != nil {
+		t.Fatalf("query indexes: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if _, ok := wantIndexes[name]; ok {
+			wantIndexes[name] = true
+		}
+	}
+	for name, seen := range wantIndexes {
+		if !seen {
+			t.Fatalf("index %q not created", name)
+		}
+	}
+}

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -99,6 +99,8 @@ type TraceStore struct {
 }
 
 func migrateTraceDB(db *sql.DB) error {
+	// PRAGMA foreign_keys is a connection-level switch and cannot run inside
+	// a transaction in SQLite, so toggle it at the DB level around the tx.
 	if err := setTraceForeignKeys(db, false); err != nil {
 		return err
 	}
@@ -106,35 +108,67 @@ func migrateTraceDB(db *sql.DB) error {
 		_ = setTraceForeignKeys(db, true)
 	}()
 
-	chainCols, err := tableColumns(db, "agent_trace_chains")
+	// Refuse to migrate if a previous rebuild left its *_legacy twin around
+	// (rename committed but copy/drop interrupted). The caller must resolve
+	// the stale state before we touch the tables again.
+	for _, table := range []string{"agent_trace_steps_legacy", "agent_trace_chains_legacy"} {
+		exists, err := traceTableExists(db, table)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("trace migration aborted: stale %s table from previous run", table)
+		}
+	}
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	chainCols, err := tableColumnsTx(tx, "agent_trace_chains")
 	if err != nil {
 		return err
 	}
 	if len(chainCols) == 0 {
-		if err := createTraceChainsTable(db); err != nil {
+		if err := createTraceChainsTableTx(tx); err != nil {
 			return err
 		}
 	} else if needsChainRebuild(chainCols) {
-		if err := rebuildLegacyTraceChains(db); err != nil {
+		if err := rebuildLegacyTraceChainsTx(tx); err != nil {
 			return err
 		}
 	}
 
-	stepCols, err := tableColumns(db, "agent_trace_steps")
+	stepCols, err := tableColumnsTx(tx, "agent_trace_steps")
 	if err != nil {
 		return err
 	}
 	if len(stepCols) == 0 {
-		if err := createTraceStepsTable(db); err != nil {
+		if err := createTraceStepsTableTx(tx); err != nil {
 			return err
 		}
-	} else if needsStepRebuild(stepCols, db) {
-		if err := rebuildLegacyTraceSteps(db); err != nil {
+	} else if needsStepRebuildTx(tx, stepCols) {
+		if err := rebuildLegacyTraceStepsTx(tx); err != nil {
 			return err
 		}
 	}
 
-	return createTraceIndexes(db)
+	if err := createTraceIndexesTx(tx); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 func setTraceForeignKeys(db *sql.DB, enabled bool) error {
@@ -152,7 +186,19 @@ func tableColumns(db *sql.DB, table string) (map[string]bool, error) {
 		return nil, err
 	}
 	defer rows.Close()
+	return scanTableInfo(rows)
+}
 
+func tableColumnsTx(tx *sql.Tx, table string) (map[string]bool, error) {
+	rows, err := tx.Query(`PRAGMA table_info(` + table + `)`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanTableInfo(rows)
+}
+
+func scanTableInfo(rows *sql.Rows) (map[string]bool, error) {
 	cols := make(map[string]bool)
 	for rows.Next() {
 		var (
@@ -196,7 +242,7 @@ func needsChainRebuild(cols map[string]bool) bool {
 	return false
 }
 
-func needsStepRebuild(cols map[string]bool, db *sql.DB) bool {
+func needsStepRebuildTx(tx *sql.Tx, cols map[string]bool) bool {
 	required := []string{
 		"seq",
 		"kind",
@@ -228,11 +274,11 @@ func needsStepRebuild(cols map[string]bool, db *sql.DB) bool {
 			return true
 		}
 	}
-	return !hasStepParentCompositeFK(db)
+	return !hasStepParentCompositeFKTx(tx)
 }
 
-func hasStepParentCompositeFK(db *sql.DB) bool {
-	rows, err := db.Query(`PRAGMA foreign_key_list(agent_trace_steps)`)
+func hasStepParentCompositeFKTx(tx *sql.Tx) bool {
+	rows, err := tx.Query(`PRAGMA foreign_key_list(agent_trace_steps)`)
 	if err != nil {
 		return false
 	}
@@ -284,103 +330,111 @@ func hasStepParentCompositeFK(db *sql.DB) bool {
 	return false
 }
 
+const traceChainsDDL = `
+	CREATE TABLE IF NOT EXISTS agent_trace_chains (
+		chain_id           TEXT PRIMARY KEY,
+		started_at         INTEGER NOT NULL DEFAULT 0,
+		completed_at       INTEGER NOT NULL DEFAULT 0,
+		terminal_status     TEXT NOT NULL DEFAULT '',
+		terminal_reason     TEXT NOT NULL DEFAULT '',
+		tmux_session        TEXT NOT NULL DEFAULT '',
+		pane_id             TEXT NOT NULL DEFAULT '',
+		root_agent_type     TEXT NOT NULL DEFAULT '',
+		root_event_name     TEXT NOT NULL DEFAULT '',
+		root_reason         TEXT NOT NULL DEFAULT '',
+		latest_step_kind    TEXT NOT NULL DEFAULT '',
+		latest_decision     TEXT NOT NULL DEFAULT '',
+		latest_step_reason  TEXT NOT NULL DEFAULT '',
+		step_count          INTEGER NOT NULL DEFAULT 0,
+		updated_at          INTEGER NOT NULL DEFAULT 0
+	)
+`
+
+const traceStepsDDL = `
+	CREATE TABLE IF NOT EXISTS agent_trace_steps (
+		step_id             TEXT PRIMARY KEY,
+		chain_id            TEXT NOT NULL,
+		parent_step_id      TEXT,
+		seq                 INTEGER NOT NULL,
+		kind                TEXT NOT NULL DEFAULT '',
+		tmux_session        TEXT NOT NULL DEFAULT '',
+		pane_id             TEXT NOT NULL DEFAULT '',
+		agent_type          TEXT NOT NULL DEFAULT '',
+		frame_id            TEXT NOT NULL DEFAULT '',
+		parent_frame_id     TEXT NOT NULL DEFAULT '',
+		event_name          TEXT NOT NULL DEFAULT '',
+		decision            TEXT NOT NULL DEFAULT '',
+		reason              TEXT NOT NULL DEFAULT '',
+		payload_json        TEXT NOT NULL DEFAULT 'null',
+		before_json         TEXT NOT NULL DEFAULT 'null',
+		after_json          TEXT NOT NULL DEFAULT 'null',
+		created_at          INTEGER NOT NULL DEFAULT 0,
+		source_kind         TEXT NOT NULL DEFAULT '',
+		action              TEXT NOT NULL DEFAULT '',
+		reason_code         TEXT NOT NULL DEFAULT '',
+		outcome             TEXT NOT NULL DEFAULT '',
+		scenario_key        TEXT NOT NULL DEFAULT '',
+		observed_generation INTEGER NOT NULL DEFAULT 0,
+		decision_ports      TEXT NOT NULL DEFAULT '[]',
+		phase               TEXT NOT NULL DEFAULT '',
+		status              TEXT NOT NULL DEFAULT '',
+		watcher_token       TEXT,
+		FOREIGN KEY (chain_id) REFERENCES agent_trace_chains(chain_id) ON DELETE CASCADE,
+		FOREIGN KEY (chain_id, parent_step_id) REFERENCES agent_trace_steps(chain_id, step_id) ON DELETE CASCADE
+	)
+`
+
+var traceIndexDDLs = []string{
+	`CREATE INDEX IF NOT EXISTS idx_trace_chains_started ON agent_trace_chains(started_at DESC, chain_id DESC)`,
+	`CREATE INDEX IF NOT EXISTS idx_trace_chains_session_started ON agent_trace_chains(tmux_session, started_at DESC, chain_id DESC)`,
+	`CREATE INDEX IF NOT EXISTS idx_trace_chains_pane_started ON agent_trace_chains(pane_id, started_at DESC, chain_id DESC)`,
+	`CREATE INDEX IF NOT EXISTS idx_trace_chains_agent_event_started ON agent_trace_chains(root_agent_type, root_event_name, started_at DESC, chain_id DESC)`,
+	`CREATE INDEX IF NOT EXISTS idx_trace_steps_chain_seq ON agent_trace_steps(chain_id, seq ASC, created_at ASC, step_id ASC)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS idx_trace_steps_chain_step ON agent_trace_steps(chain_id, step_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_trace_steps_parent ON agent_trace_steps(chain_id, parent_step_id)`,
+}
+
 func createTraceChainsTable(db *sql.DB) error {
-	_, err := db.Exec(`
-		CREATE TABLE IF NOT EXISTS agent_trace_chains (
-			chain_id           TEXT PRIMARY KEY,
-			started_at         INTEGER NOT NULL DEFAULT 0,
-			completed_at       INTEGER NOT NULL DEFAULT 0,
-			terminal_status     TEXT NOT NULL DEFAULT '',
-			terminal_reason     TEXT NOT NULL DEFAULT '',
-			tmux_session        TEXT NOT NULL DEFAULT '',
-			pane_id             TEXT NOT NULL DEFAULT '',
-			root_agent_type     TEXT NOT NULL DEFAULT '',
-			root_event_name     TEXT NOT NULL DEFAULT '',
-			root_reason         TEXT NOT NULL DEFAULT '',
-			latest_step_kind    TEXT NOT NULL DEFAULT '',
-			latest_decision     TEXT NOT NULL DEFAULT '',
-			latest_step_reason  TEXT NOT NULL DEFAULT '',
-			step_count          INTEGER NOT NULL DEFAULT 0,
-			updated_at          INTEGER NOT NULL DEFAULT 0
-		)
-	`)
+	_, err := db.Exec(traceChainsDDL)
+	return err
+}
+
+func createTraceChainsTableTx(tx *sql.Tx) error {
+	_, err := tx.Exec(traceChainsDDL)
 	return err
 }
 
 func createTraceStepsTable(db *sql.DB) error {
-	_, err := db.Exec(`
-		CREATE TABLE IF NOT EXISTS agent_trace_steps (
-			step_id             TEXT PRIMARY KEY,
-			chain_id            TEXT NOT NULL,
-			parent_step_id      TEXT,
-			seq                 INTEGER NOT NULL,
-			kind                TEXT NOT NULL DEFAULT '',
-			tmux_session        TEXT NOT NULL DEFAULT '',
-			pane_id             TEXT NOT NULL DEFAULT '',
-			agent_type          TEXT NOT NULL DEFAULT '',
-			frame_id            TEXT NOT NULL DEFAULT '',
-			parent_frame_id     TEXT NOT NULL DEFAULT '',
-			event_name          TEXT NOT NULL DEFAULT '',
-			decision            TEXT NOT NULL DEFAULT '',
-			reason              TEXT NOT NULL DEFAULT '',
-			payload_json        TEXT NOT NULL DEFAULT 'null',
-			before_json         TEXT NOT NULL DEFAULT 'null',
-			after_json          TEXT NOT NULL DEFAULT 'null',
-			created_at          INTEGER NOT NULL DEFAULT 0,
-			source_kind         TEXT NOT NULL DEFAULT '',
-			action              TEXT NOT NULL DEFAULT '',
-			reason_code         TEXT NOT NULL DEFAULT '',
-			outcome             TEXT NOT NULL DEFAULT '',
-			scenario_key        TEXT NOT NULL DEFAULT '',
-			observed_generation INTEGER NOT NULL DEFAULT 0,
-			decision_ports      TEXT NOT NULL DEFAULT '[]',
-			phase               TEXT NOT NULL DEFAULT '',
-			status              TEXT NOT NULL DEFAULT '',
-			watcher_token       TEXT,
-			FOREIGN KEY (chain_id) REFERENCES agent_trace_chains(chain_id) ON DELETE CASCADE,
-			FOREIGN KEY (chain_id, parent_step_id) REFERENCES agent_trace_steps(chain_id, step_id) ON DELETE CASCADE
-		)
-	`)
+	_, err := db.Exec(traceStepsDDL)
 	return err
 }
 
-func createTraceIndexes(db *sql.DB) error {
-	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trace_chains_started ON agent_trace_chains(started_at DESC, chain_id DESC)`); err != nil {
-		return err
-	}
-	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trace_chains_session_started ON agent_trace_chains(tmux_session, started_at DESC, chain_id DESC)`); err != nil {
-		return err
-	}
-	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trace_chains_pane_started ON agent_trace_chains(pane_id, started_at DESC, chain_id DESC)`); err != nil {
-		return err
-	}
-	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trace_chains_agent_event_started ON agent_trace_chains(root_agent_type, root_event_name, started_at DESC, chain_id DESC)`); err != nil {
-		return err
-	}
-	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trace_steps_chain_seq ON agent_trace_steps(chain_id, seq ASC, created_at ASC, step_id ASC)`); err != nil {
-		return err
-	}
-	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_trace_steps_chain_step ON agent_trace_steps(chain_id, step_id)`); err != nil {
-		return err
-	}
-	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trace_steps_parent ON agent_trace_steps(chain_id, parent_step_id)`); err != nil {
-		return err
+func createTraceStepsTableTx(tx *sql.Tx) error {
+	_, err := tx.Exec(traceStepsDDL)
+	return err
+}
+
+func createTraceIndexesTx(tx *sql.Tx) error {
+	for _, ddl := range traceIndexDDLs {
+		if _, err := tx.Exec(ddl); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func rebuildLegacyTraceChains(db *sql.DB) error {
-	stepCounts, err := legacyTraceStepCounts(db)
+func rebuildLegacyTraceChainsTx(tx *sql.Tx) error {
+	stepCounts, err := legacyTraceStepCountsTx(tx)
 	if err != nil {
 		return err
 	}
-	if _, err := db.Exec(`ALTER TABLE agent_trace_chains RENAME TO agent_trace_chains_legacy`); err != nil {
+	if _, err := tx.Exec(`ALTER TABLE agent_trace_chains RENAME TO agent_trace_chains_legacy`); err != nil {
 		return err
 	}
-	if err := createTraceChainsTable(db); err != nil {
+	if err := createTraceChainsTableTx(tx); err != nil {
 		return err
 	}
-	_, err = db.Exec(`
+	if _, err := tx.Exec(`
 		INSERT INTO agent_trace_chains (
 			chain_id, started_at, completed_at, terminal_status, terminal_reason,
 			tmux_session, pane_id, root_agent_type, root_event_name, root_reason,
@@ -403,23 +457,24 @@ func rebuildLegacyTraceChains(db *sql.DB) error {
 			0,
 			updated_at
 		FROM agent_trace_chains_legacy
-	`)
-	if err != nil {
+	`); err != nil {
 		return err
 	}
 	if len(stepCounts) > 0 {
 		for chainID, count := range stepCounts {
-			if _, err := db.Exec(`UPDATE agent_trace_chains SET step_count = ? WHERE chain_id = ?`, count, chainID); err != nil {
+			if _, err := tx.Exec(`UPDATE agent_trace_chains SET step_count = ? WHERE chain_id = ?`, count, chainID); err != nil {
 				return err
 			}
 		}
 	}
-	_, err = db.Exec(`DROP TABLE agent_trace_chains_legacy`)
-	return err
+	if _, err := tx.Exec(`DROP TABLE agent_trace_chains_legacy`); err != nil {
+		return err
+	}
+	return nil
 }
 
-func legacyTraceStepCounts(db *sql.DB) (map[string]int, error) {
-	exists, err := traceTableExists(db, "agent_trace_steps")
+func legacyTraceStepCountsTx(tx *sql.Tx) (map[string]int, error) {
+	exists, err := traceTableExistsTx(tx, "agent_trace_steps")
 	if err != nil {
 		return nil, err
 	}
@@ -427,7 +482,7 @@ func legacyTraceStepCounts(db *sql.DB) (map[string]int, error) {
 		return map[string]int{}, nil
 	}
 
-	rows, err := db.Query(`SELECT chain_id, COUNT(*) FROM agent_trace_steps GROUP BY chain_id`)
+	rows, err := tx.Query(`SELECT chain_id, COUNT(*) FROM agent_trace_steps GROUP BY chain_id`)
 	if err != nil {
 		return nil, err
 	}
@@ -461,16 +516,32 @@ func traceTableExists(db *sql.DB, table string) (bool, error) {
 	return true, nil
 }
 
-func rebuildLegacyTraceSteps(db *sql.DB) error {
-	cols, err := tableColumns(db, "agent_trace_steps")
+func traceTableExistsTx(tx *sql.Tx, table string) (bool, error) {
+	var name string
+	err := tx.QueryRow(`
+		SELECT name
+		FROM sqlite_master
+		WHERE type = 'table' AND name = ?
+	`, table).Scan(&name)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func rebuildLegacyTraceStepsTx(tx *sql.Tx) error {
+	cols, err := tableColumnsTx(tx, "agent_trace_steps")
 	if err != nil {
 		return err
 	}
-	stepRows, err := traceTableRowCount(db, "agent_trace_steps")
+	stepRows, err := traceTableRowCountTx(tx, "agent_trace_steps")
 	if err != nil {
 		return err
 	}
-	chainRows, err := traceTableRowCount(db, "agent_trace_chains")
+	chainRows, err := traceTableRowCountTx(tx, "agent_trace_chains")
 	if err != nil {
 		return err
 	}
@@ -478,18 +549,28 @@ func rebuildLegacyTraceSteps(db *sql.DB) error {
 		return fmt.Errorf("cannot migrate legacy trace steps without legacy trace chains")
 	}
 	if stepRows > 0 && chainRows > 0 {
-		orphanSteps, err := legacyTraceOrphanStepCount(db)
+		orphanSteps, err := legacyTraceOrphanStepCountTx(tx)
 		if err != nil {
 			return err
 		}
 		if orphanSteps > 0 {
 			return fmt.Errorf("cannot migrate legacy trace steps with %d orphan step references", orphanSteps)
 		}
+		// Legacy parent_step_id only referenced step_id, so a row may point
+		// at a step that lives in a different chain. We previously silently
+		// nulled those links; now abort so ops can reconcile the data.
+		crossChain, err := legacyTraceCrossChainParentCountTx(tx)
+		if err != nil {
+			return err
+		}
+		if crossChain > 0 {
+			return fmt.Errorf("cannot migrate legacy trace steps with %d cross-chain parent references", crossChain)
+		}
 	}
-	if _, err := db.Exec(`ALTER TABLE agent_trace_steps RENAME TO agent_trace_steps_legacy`); err != nil {
+	if _, err := tx.Exec(`ALTER TABLE agent_trace_steps RENAME TO agent_trace_steps_legacy`); err != nil {
 		return err
 	}
-	if err := createTraceStepsTable(db); err != nil {
+	if err := createTraceStepsTableTx(tx); err != nil {
 		return err
 	}
 	var copyQuery string
@@ -503,16 +584,7 @@ func rebuildLegacyTraceSteps(db *sql.DB) error {
 			SELECT
 				s.step_id,
 				s.chain_id,
-				CASE
-					WHEN s.parent_step_id IS NOT NULL
-					 AND EXISTS (
-						SELECT 1
-						FROM agent_trace_steps_legacy p
-						WHERE p.chain_id = s.chain_id AND p.step_id = s.parent_step_id
-					 )
-					THEN s.parent_step_id
-					ELSE NULL
-				END,
+				s.parent_step_id,
 				s.seq,
 				s.kind,
 				s.tmux_session,
@@ -540,16 +612,7 @@ func rebuildLegacyTraceSteps(db *sql.DB) error {
 			SELECT
 				s.step_id,
 				s.chain_id,
-				CASE
-					WHEN s.parent_step_id IS NOT NULL
-					 AND EXISTS (
-						SELECT 1
-						FROM agent_trace_steps_legacy p
-						WHERE p.chain_id = s.chain_id AND p.step_id = s.parent_step_id
-					 )
-					THEN s.parent_step_id
-					ELSE NULL
-				END,
+				s.parent_step_id,
 				s.step_index,
 				s.step_name,
 				c.tmux_session,
@@ -569,30 +632,48 @@ func rebuildLegacyTraceSteps(db *sql.DB) error {
 			ORDER BY s.chain_id ASC, s.step_index ASC, s.created_at ASC, s.step_id ASC
 		`
 	}
-	_, err = db.Exec(copyQuery)
-	if err != nil {
+	if _, err = tx.Exec(copyQuery); err != nil {
 		return err
 	}
-	_, err = db.Exec(`DROP TABLE agent_trace_steps_legacy`)
-	return err
+	if _, err = tx.Exec(`DROP TABLE agent_trace_steps_legacy`); err != nil {
+		return err
+	}
+	return nil
 }
 
-func traceTableRowCount(db *sql.DB, table string) (int, error) {
+func traceTableRowCountTx(tx *sql.Tx, table string) (int, error) {
 	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&count)
+	err := tx.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&count)
 	if err != nil {
 		return 0, err
 	}
 	return count, nil
 }
 
-func legacyTraceOrphanStepCount(db *sql.DB) (int, error) {
+func legacyTraceOrphanStepCountTx(tx *sql.Tx) (int, error) {
 	var count int
-	err := db.QueryRow(`
+	err := tx.QueryRow(`
 		SELECT COUNT(*)
 		FROM agent_trace_steps s
 		LEFT JOIN agent_trace_chains c ON c.chain_id = s.chain_id
 		WHERE c.chain_id IS NULL
+	`).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func legacyTraceCrossChainParentCountTx(tx *sql.Tx) (int, error) {
+	var count int
+	err := tx.QueryRow(`
+		SELECT COUNT(*)
+		FROM agent_trace_steps s
+		WHERE s.parent_step_id IS NOT NULL
+		  AND NOT EXISTS (
+			SELECT 1 FROM agent_trace_steps p
+			WHERE p.chain_id = s.chain_id AND p.step_id = s.parent_step_id
+		  )
 	`).Scan(&count)
 	if err != nil {
 		return 0, err

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -37,24 +37,35 @@ type TraceChain struct {
 }
 
 // TraceStep is a single ordered trace step within a chain.
+// Light-tracking fields back the Lights System trace envelope (spec §3.5).
 type TraceStep struct {
-	StepID        string          `json:"step_id"`
-	ChainID       string          `json:"chain_id"`
-	ParentStepID  string          `json:"parent_step_id,omitempty"`
-	Seq           int             `json:"seq"`
-	Kind          string          `json:"kind"`
-	TmuxSession   string          `json:"tmux_session"`
-	PaneID        string          `json:"pane_id"`
-	AgentType     string          `json:"agent_type"`
-	FrameID       string          `json:"frame_id"`
-	ParentFrameID string          `json:"parent_frame_id,omitempty"`
-	EventName     string          `json:"event_name"`
-	Decision      string          `json:"decision"`
-	Reason        string          `json:"reason"`
-	PayloadJSON   json.RawMessage `json:"payload_json,omitempty"`
-	BeforeJSON    json.RawMessage `json:"before_json,omitempty"`
-	AfterJSON     json.RawMessage `json:"after_json,omitempty"`
-	CreatedAt     int64           `json:"created_at"`
+	StepID             string          `json:"step_id"`
+	ChainID            string          `json:"chain_id"`
+	ParentStepID       string          `json:"parent_step_id,omitempty"`
+	Seq                int             `json:"seq"`
+	Kind               string          `json:"kind"`
+	TmuxSession        string          `json:"tmux_session"`
+	PaneID             string          `json:"pane_id"`
+	AgentType          string          `json:"agent_type"`
+	FrameID            string          `json:"frame_id"`
+	ParentFrameID      string          `json:"parent_frame_id,omitempty"`
+	EventName          string          `json:"event_name"`
+	Decision           string          `json:"decision"`
+	Reason             string          `json:"reason"`
+	PayloadJSON        json.RawMessage `json:"payload_json,omitempty"`
+	BeforeJSON         json.RawMessage `json:"before_json,omitempty"`
+	AfterJSON          json.RawMessage `json:"after_json,omitempty"`
+	CreatedAt          int64           `json:"created_at"`
+	SourceKind         string          `json:"source_kind,omitempty"`
+	Action             string          `json:"action,omitempty"`
+	ReasonCode         string          `json:"reason_code,omitempty"`
+	Outcome            string          `json:"outcome,omitempty"`
+	ScenarioKey        string          `json:"scenario_key,omitempty"`
+	ObservedGeneration int64           `json:"observed_generation,omitempty"`
+	DecisionPorts      json.RawMessage `json:"decision_ports,omitempty"`
+	Phase              string          `json:"phase,omitempty"`
+	Status             string          `json:"status,omitempty"`
+	WatcherToken       *string         `json:"watcher_token,omitempty"`
 }
 
 // TraceRecord combines a chain summary with its ordered steps.
@@ -201,6 +212,16 @@ func needsStepRebuild(cols map[string]bool, db *sql.DB) bool {
 		"before_json",
 		"after_json",
 		"created_at",
+		"source_kind",
+		"action",
+		"reason_code",
+		"outcome",
+		"scenario_key",
+		"observed_generation",
+		"decision_ports",
+		"phase",
+		"status",
+		"watcher_token",
 	}
 	for _, col := range required {
 		if !cols[col] {
@@ -289,23 +310,33 @@ func createTraceChainsTable(db *sql.DB) error {
 func createTraceStepsTable(db *sql.DB) error {
 	_, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS agent_trace_steps (
-			step_id         TEXT PRIMARY KEY,
-			chain_id        TEXT NOT NULL,
-			parent_step_id  TEXT,
-			seq             INTEGER NOT NULL,
-			kind            TEXT NOT NULL DEFAULT '',
-			tmux_session    TEXT NOT NULL DEFAULT '',
-			pane_id         TEXT NOT NULL DEFAULT '',
-			agent_type      TEXT NOT NULL DEFAULT '',
-			frame_id        TEXT NOT NULL DEFAULT '',
-			parent_frame_id TEXT NOT NULL DEFAULT '',
-			event_name      TEXT NOT NULL DEFAULT '',
-			decision        TEXT NOT NULL DEFAULT '',
-			reason          TEXT NOT NULL DEFAULT '',
-			payload_json    TEXT NOT NULL DEFAULT 'null',
-			before_json     TEXT NOT NULL DEFAULT 'null',
-			after_json      TEXT NOT NULL DEFAULT 'null',
-			created_at      INTEGER NOT NULL DEFAULT 0,
+			step_id             TEXT PRIMARY KEY,
+			chain_id            TEXT NOT NULL,
+			parent_step_id      TEXT,
+			seq                 INTEGER NOT NULL,
+			kind                TEXT NOT NULL DEFAULT '',
+			tmux_session        TEXT NOT NULL DEFAULT '',
+			pane_id             TEXT NOT NULL DEFAULT '',
+			agent_type          TEXT NOT NULL DEFAULT '',
+			frame_id            TEXT NOT NULL DEFAULT '',
+			parent_frame_id     TEXT NOT NULL DEFAULT '',
+			event_name          TEXT NOT NULL DEFAULT '',
+			decision            TEXT NOT NULL DEFAULT '',
+			reason              TEXT NOT NULL DEFAULT '',
+			payload_json        TEXT NOT NULL DEFAULT 'null',
+			before_json         TEXT NOT NULL DEFAULT 'null',
+			after_json          TEXT NOT NULL DEFAULT 'null',
+			created_at          INTEGER NOT NULL DEFAULT 0,
+			source_kind         TEXT NOT NULL DEFAULT '',
+			action              TEXT NOT NULL DEFAULT '',
+			reason_code         TEXT NOT NULL DEFAULT '',
+			outcome             TEXT NOT NULL DEFAULT '',
+			scenario_key        TEXT NOT NULL DEFAULT '',
+			observed_generation INTEGER NOT NULL DEFAULT 0,
+			decision_ports      TEXT NOT NULL DEFAULT '[]',
+			phase               TEXT NOT NULL DEFAULT '',
+			status              TEXT NOT NULL DEFAULT '',
+			watcher_token       TEXT,
 			FOREIGN KEY (chain_id) REFERENCES agent_trace_chains(chain_id) ON DELETE CASCADE,
 			FOREIGN KEY (chain_id, parent_step_id) REFERENCES agent_trace_steps(chain_id, step_id) ON DELETE CASCADE
 		)
@@ -625,11 +656,15 @@ func (s *TraceStore) SaveChain(record TraceRecord) (err error) {
 			INSERT INTO agent_trace_steps (
 				step_id, chain_id, parent_step_id, seq, kind, tmux_session, pane_id,
 				agent_type, frame_id, parent_frame_id, event_name, decision, reason,
-				payload_json, before_json, after_json, created_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				payload_json, before_json, after_json, created_at,
+				source_kind, action, reason_code, outcome, scenario_key,
+				observed_generation, decision_ports, phase, status, watcher_token
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, step.StepID, step.ChainID, nullString(step.ParentStepID), step.Seq, step.Kind, step.TmuxSession, step.PaneID,
 			step.AgentType, step.FrameID, step.ParentFrameID, step.EventName, step.Decision, step.Reason,
-			rawJSONText(step.PayloadJSON), rawJSONText(step.BeforeJSON), rawJSONText(step.AfterJSON), step.CreatedAt); err != nil {
+			rawJSONText(step.PayloadJSON), rawJSONText(step.BeforeJSON), rawJSONText(step.AfterJSON), step.CreatedAt,
+			step.SourceKind, step.Action, step.ReasonCode, step.Outcome, step.ScenarioKey,
+			step.ObservedGeneration, rawJSONArrayText(step.DecisionPorts), step.Phase, step.Status, nullableString(step.WatcherToken)); err != nil {
 			return err
 		}
 	}
@@ -712,7 +747,9 @@ func (s *TraceStore) GetChainRecord(chainID string) (*TraceRecord, error) {
 	rows, err := s.db.Query(`
 		SELECT step_id, chain_id, parent_step_id, seq, kind, tmux_session, pane_id,
 		       agent_type, frame_id, parent_frame_id, event_name, decision, reason,
-		       payload_json, before_json, after_json, created_at
+		       payload_json, before_json, after_json, created_at,
+		       source_kind, action, reason_code, outcome, scenario_key,
+		       observed_generation, decision_ports, phase, status, watcher_token
 		FROM agent_trace_steps
 		WHERE chain_id = ?
 		ORDER BY seq ASC, created_at ASC, step_id ASC
@@ -990,7 +1027,8 @@ func collectTraceSteps(rows *sql.Rows) ([]TraceStep, error) {
 	for rows.Next() {
 		var step TraceStep
 		var parent sql.NullString
-		var payload, before, after string
+		var watcher sql.NullString
+		var payload, before, after, decisionPorts string
 		if err := rows.Scan(
 			&step.StepID,
 			&step.ChainID,
@@ -1009,6 +1047,16 @@ func collectTraceSteps(rows *sql.Rows) ([]TraceStep, error) {
 			&before,
 			&after,
 			&step.CreatedAt,
+			&step.SourceKind,
+			&step.Action,
+			&step.ReasonCode,
+			&step.Outcome,
+			&step.ScenarioKey,
+			&step.ObservedGeneration,
+			&decisionPorts,
+			&step.Phase,
+			&step.Status,
+			&watcher,
 		); err != nil {
 			return nil, err
 		}
@@ -1016,6 +1064,11 @@ func collectTraceSteps(rows *sql.Rows) ([]TraceStep, error) {
 		step.PayloadJSON = json.RawMessage(payload)
 		step.BeforeJSON = json.RawMessage(before)
 		step.AfterJSON = json.RawMessage(after)
+		step.DecisionPorts = json.RawMessage(decisionPorts)
+		if watcher.Valid {
+			v := watcher.String
+			step.WatcherToken = &v
+		}
 		steps = append(steps, step)
 	}
 	return steps, rows.Err()
@@ -1045,6 +1098,20 @@ func rawJSONText(raw json.RawMessage) string {
 		return "null"
 	}
 	return string(raw)
+}
+
+func rawJSONArrayText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "[]"
+	}
+	return string(raw)
+}
+
+func nullableString(value *string) any {
+	if value == nil {
+		return nil
+	}
+	return *value
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/store/trace_test.go
+++ b/internal/store/trace_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 )
 
+func strPtr(s string) *string { return &s }
+
 func openTestTraceStore(t *testing.T) *TraceStore {
 	t.Helper()
 	events := openTestAgentEventStore(t)
@@ -41,38 +43,56 @@ func TestTraceStore_SaveAndGetChainRecord(t *testing.T) {
 		},
 		Steps: []TraceStep{
 			{
-				StepID:      "step-1",
-				ChainID:     "chain-1",
-				Seq:         1,
-				Kind:        "decision",
-				TmuxSession: "proj-a",
-				PaneID:      "%5",
-				AgentType:   "cc",
-				FrameID:     "frame-1",
-				EventName:   "SessionStart",
-				Decision:    "continue",
-				Reason:      "ready",
-				PayloadJSON: json.RawMessage(`{"status":"queued"}`),
-				BeforeJSON:  json.RawMessage(`{"before":true}`),
-				AfterJSON:   json.RawMessage(`{"after":true}`),
-				CreatedAt:   101,
+				StepID:             "step-1",
+				ChainID:            "chain-1",
+				Seq:                1,
+				Kind:               "decision",
+				TmuxSession:        "proj-a",
+				PaneID:             "%5",
+				AgentType:          "cc",
+				FrameID:            "frame-1",
+				EventName:          "SessionStart",
+				Decision:           "continue",
+				Reason:             "ready",
+				PayloadJSON:        json.RawMessage(`{"status":"queued"}`),
+				BeforeJSON:         json.RawMessage(`{"before":true}`),
+				AfterJSON:          json.RawMessage(`{"after":true}`),
+				CreatedAt:          101,
+				SourceKind:         "hook",
+				Action:             "decision:continue",
+				ReasonCode:         "ready",
+				Outcome:            "emitted",
+				ScenarioKey:        "SessionStart",
+				ObservedGeneration: 7,
+				DecisionPorts:      json.RawMessage(`[{"port":"statusline","decision":"ok"}]`),
+				Phase:              "committed",
+				Status:             "success",
+				WatcherToken:       strPtr("watcher-abc"),
 			},
 			{
-				StepID:        "step-2",
-				ChainID:       "chain-1",
-				ParentStepID:  "step-1",
-				Seq:           2,
-				Kind:          "terminal",
-				TmuxSession:   "proj-a",
-				PaneID:        "%5",
-				AgentType:     "cc",
-				FrameID:       "frame-1",
-				ParentFrameID: "frame-0",
-				EventName:     "Stop",
-				Decision:      "done",
-				Reason:        "completed",
-				PayloadJSON:   json.RawMessage(`{"status":"done"}`),
-				CreatedAt:     102,
+				StepID:             "step-2",
+				ChainID:            "chain-1",
+				ParentStepID:       "step-1",
+				Seq:                2,
+				Kind:               "terminal",
+				TmuxSession:        "proj-a",
+				PaneID:             "%5",
+				AgentType:          "cc",
+				FrameID:            "frame-1",
+				ParentFrameID:      "frame-0",
+				EventName:          "Stop",
+				Decision:           "done",
+				Reason:             "completed",
+				PayloadJSON:        json.RawMessage(`{"status":"done"}`),
+				CreatedAt:          102,
+				SourceKind:         "hook",
+				Action:             "terminal:done",
+				ReasonCode:         "completed",
+				Outcome:            "emitted",
+				ScenarioKey:        "Stop",
+				ObservedGeneration: 8,
+				Phase:              "committed",
+				Status:             "success",
 			},
 		},
 	}
@@ -108,6 +128,96 @@ func TestTraceStore_SaveAndGetChainRecord(t *testing.T) {
 	}
 	if string(got.Steps[0].BeforeJSON) != `{"before":true}` || string(got.Steps[0].AfterJSON) != `{"after":true}` {
 		t.Fatalf("payload fields = %+v", got.Steps[0])
+	}
+
+	first := got.Steps[0]
+	if first.SourceKind != "hook" || first.Action != "decision:continue" || first.ReasonCode != "ready" ||
+		first.Outcome != "emitted" || first.ScenarioKey != "SessionStart" || first.Phase != "committed" ||
+		first.Status != "success" {
+		t.Fatalf("first step lights fields = %+v", first)
+	}
+	if first.ObservedGeneration != 7 {
+		t.Fatalf("first ObservedGeneration = %d, want 7", first.ObservedGeneration)
+	}
+	if string(first.DecisionPorts) != `[{"port":"statusline","decision":"ok"}]` {
+		t.Fatalf("first DecisionPorts = %s", string(first.DecisionPorts))
+	}
+	if first.WatcherToken == nil || *first.WatcherToken != "watcher-abc" {
+		t.Fatalf("first WatcherToken = %v", first.WatcherToken)
+	}
+
+	second := got.Steps[1]
+	if second.WatcherToken != nil {
+		t.Fatalf("second WatcherToken = %v, want nil", second.WatcherToken)
+	}
+	if string(second.DecisionPorts) != `[]` {
+		t.Fatalf("second DecisionPorts = %s, want []", string(second.DecisionPorts))
+	}
+	if second.Phase != "committed" || second.Status != "success" {
+		t.Fatalf("second step lights fields = %+v", second)
+	}
+}
+
+// TestTraceStore_ZeroValueLightsFieldsRoundTrip guards the backwards-compat
+// path: older callers that do not set the new light-tracking columns must
+// still round-trip without errors. Scanned zero values must come back without
+// surfacing SQL NULL errors.
+func TestTraceStore_ZeroValueLightsFieldsRoundTrip(t *testing.T) {
+	s := openTestTraceStore(t)
+	s.maxChains = 10
+	s.maxSteps = 10
+
+	record := TraceRecord{
+		Chain: TraceChain{
+			ChainID:        "chain-legacy",
+			StartedAt:      10,
+			CompletedAt:    20,
+			TerminalStatus: "done",
+			TmuxSession:    "proj-a",
+			PaneID:         "%5",
+			RootAgentType:  "cc",
+			RootEventName:  "Stop",
+			RootReason:     "boot",
+		},
+		Steps: []TraceStep{
+			{
+				StepID:      "legacy-1",
+				ChainID:     "chain-legacy",
+				Seq:         1,
+				Kind:        "decision",
+				TmuxSession: "proj-a",
+				PaneID:      "%5",
+				AgentType:   "cc",
+				EventName:   "Stop",
+				Decision:    "done",
+				CreatedAt:   11,
+			},
+		},
+	}
+
+	if err := s.SaveChain(record); err != nil {
+		t.Fatalf("SaveChain: %v", err)
+	}
+
+	got, err := s.GetChainRecord("chain-legacy")
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	if got == nil || len(got.Steps) != 1 {
+		t.Fatalf("got = %+v", got)
+	}
+	step := got.Steps[0]
+	if step.SourceKind != "" || step.Action != "" || step.Phase != "" || step.Status != "" {
+		t.Fatalf("zero-value lights fields corrupted: %+v", step)
+	}
+	if step.ObservedGeneration != 0 {
+		t.Fatalf("ObservedGeneration = %d, want 0", step.ObservedGeneration)
+	}
+	if string(step.DecisionPorts) != `[]` {
+		t.Fatalf("DecisionPorts default = %s, want []", string(step.DecisionPorts))
+	}
+	if step.WatcherToken != nil {
+		t.Fatalf("WatcherToken = %v, want nil", step.WatcherToken)
 	}
 }
 

--- a/internal/store/trace_test.go
+++ b/internal/store/trace_test.go
@@ -335,6 +335,88 @@ func TestTraceStore_MigratesLegacyStepSchemaAndBlocksCrossChainParent(t *testing
 	}
 }
 
+// TestRebuildLegacyTraceSteps_BlocksCrossChainParent seeds intermediate-schema
+// legacy data with a parent_step_id whose target step belongs to a different
+// chain_id. The old migration silently nulled such links; the new behaviour
+// must abort migration instead so ops can reconcile the data.
+func TestRebuildLegacyTraceSteps_BlocksCrossChainParent(t *testing.T) {
+	s := openTestAgentEventStore(t)
+	seedIntermediateTraceSchema(t, s.db)
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_chains (
+			chain_id, started_at, completed_at, terminal_status, terminal_reason,
+			tmux_session, pane_id, root_agent_type, root_event_name, root_reason,
+			latest_step_kind, latest_decision, latest_step_reason, step_count, updated_at
+		) VALUES
+		('chain-a', 1, 2, 'done', 'ok', 'proj-a', '%1', 'cc', 'Stop', 'root', 'terminal', 'done', 'ok', 1, 2),
+		('chain-b', 3, 4, 'done', 'ok', 'proj-a', '%1', 'cc', 'Stop', 'root', 'terminal', 'done', 'ok', 1, 4)
+	`); err != nil {
+		t.Fatalf("seed chains: %v", err)
+	}
+	// chain-b has a step whose parent points at a step in chain-a.
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_steps (
+			step_id, chain_id, parent_step_id, seq, kind, tmux_session, pane_id,
+			agent_type, frame_id, parent_frame_id, event_name, decision, reason,
+			payload_json, before_json, after_json, created_at
+		) VALUES
+		('a-1', 'chain-a', NULL, 1, 'root',     'proj-a', '%1', 'cc', 'frame-a', '', 'Stop', '', '', 'null', 'null', 'null', 1),
+		('b-1', 'chain-b', 'a-1', 1, 'decision','proj-a', '%1', 'cc', 'frame-b', '', 'Stop', 'continue', 'x', 'null', 'null', 'null', 3)
+	`); err != nil {
+		t.Fatalf("seed cross-chain parent step: %v", err)
+	}
+
+	if _, err := s.Traces(); err == nil {
+		t.Fatal("expected Traces migration to fail on cross-chain parent reference")
+	}
+
+	// Legacy tables must still exist (migration aborted atomically).
+	var name string
+	if err := s.db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name='agent_trace_steps'`).Scan(&name); err != nil {
+		t.Fatalf("agent_trace_steps missing after aborted migration: %v", err)
+	}
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_trace_steps`).Scan(&count); err != nil {
+		t.Fatalf("count legacy steps: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("legacy step count = %d, want 2", count)
+	}
+}
+
+// TestMigrateTraceDB_ResumableIfLegacyTableRemains ensures a second Traces()
+// call after a crash-interrupted migration (legacy rename committed, new table
+// not yet populated) surfaces the stale state as an error rather than silently
+// skipping rebuild.
+func TestMigrateTraceDB_ResumableIfLegacyTableRemains(t *testing.T) {
+	s := openTestAgentEventStore(t)
+	// Simulate a partially-complete migration: new steps table exists (empty)
+	// AND agent_trace_steps_legacy remains from an aborted rebuild.
+	if err := createTraceChainsTable(s.db); err != nil {
+		t.Fatalf("create chains: %v", err)
+	}
+	if err := createTraceStepsTable(s.db); err != nil {
+		t.Fatalf("create steps: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		CREATE TABLE agent_trace_steps_legacy (
+			step_id TEXT PRIMARY KEY,
+			chain_id TEXT NOT NULL,
+			parent_step_id TEXT,
+			step_name TEXT NOT NULL,
+			payload TEXT NOT NULL DEFAULT 'null',
+			step_index INTEGER NOT NULL,
+			created_at INTEGER NOT NULL
+		)
+	`); err != nil {
+		t.Fatalf("seed legacy leftover: %v", err)
+	}
+
+	if _, err := s.Traces(); err == nil {
+		t.Fatal("expected Traces to fail fast when agent_trace_steps_legacy remains")
+	}
+}
+
 func TestTraceStore_ListChains_PaginatesWithCursorAndBefore(t *testing.T) {
 	s := openTestTraceStore(t)
 	s.maxChains = 10


### PR DESCRIPTION
## Summary

Lights System Phase 1 PR-1a（schema 層）：在 `agent_trace_steps` 加 10 個新欄位、建 `frame_divergences` 新表、hook path 填值。

- 對應 spec：§3.5 Trace Envelope、§8.1 Phase 1 雙寫過渡 DDL
- 對應 plan：`docs/superpowers/plans/2026-04-22-lights-system/phase-1.md` 主架構 1 + 2

**範圍嚴格限縮在 schema**：Observation 型別、Arbitrator 骨架、channel admission control、雙寫 passthrough 全留給 **PR-1b**。本 PR 不破壞任何使用者可見行為。

## Changes

### Schema

- `agent_trace_steps` 新增 10 欄位（spec §3.5 envelope 子集）：
  - `source_kind` / `action` / `reason_code` / `outcome` / `scenario_key` — CamelCase 低基數分類
  - `observed_generation` INTEGER — §3.3 generation gate 準備
  - `decision_ports` JSON TEXT — DecisionPort array（cap 16 留 PR-1b 建構器）
  - `phase` / `status` — proposed/committed/rejected, success/failure
  - `watcher_token` nullable — probe identity
- **新表** `frame_divergences`（spec §8.1 DDL 逐行對齊）+ 兩個索引
- Migration：沿用 `needsStepRebuild` drop-recreate（phase-1.md 明授權 alpha 階段）

### Code

- `internal/store/trace.go`: `TraceStep` struct 擴欄 + DDL + rebuild + save/get
- `internal/store/divergences.go`（新）: `FrameDivergence` + `DivergenceStore` + `Insert` / `FetchDivergenceByID`
- `internal/store/agent_event.go`: `Divergences()` lazy getter（對齊 `Frames()` / `Traces()` 模式）
- `internal/module/agent/trace.go`: `append()` 重構成 `traceStepInput` struct，集中 default 注入（`SourceKind="hook"`, `Phase="committed"`, `Status="success"`, `Outcome="emitted"` ...）

## Test plan

- [x] `go test ./... -race -count=1` 全綠
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` 乾淨
- [x] phase-1.md 主架構 1+2 五條測試全覆蓋：
  - `TestTraceStore_SaveAndGetChainRecord` — 新欄位 round-trip
  - `TestTraceStore_ZeroValueLightsFieldsRoundTrip` — 舊 caller 零值相容
  - `TestHandleEvent_PersistAcceptedHookTrace` — hook path 每 step 新欄位全非空
  - `TestDivergenceStore_InsertAndFetchRoundtrip` + `TestDivergenceStore_MatchedFlagPersistsBothValues` + `TestDivergenceStore_IndexesAreCreated`
  - `TestDivergenceStore_ParallelInsertsAllPersist` — 8 goroutine × 12 insert 無 lost update

## Out of scope（留給 PR-1b 或後續）

- `Observation` 型別、`Arbitrator` 骨架、channel admission control、雙寫 passthrough（`submitObservation` 等 helper）
- `AGENT_ARB_MODE` feature flag
- spec §3.5 剩餘 envelope 欄位：`attrs` / `reason_text` / `trace_id` / `event_id` / `span_id` / `parent_span_id` / `name` / `kind` / `started_at` / `ended_at` / `seq` / `input_refs` / `output_refs` / `state_before_ref` / `state_after_ref` / `evidence_refs`
- `reason_code` CamelCase 字典化（PR-1b Arbitrator 時建立）
- `observed_generation` 接 frame.generation 來源（§3.4.4）
- VERSION / CHANGELOG bump（獨立 bump PR）
- SPA / API route 變更

## Known minor gaps（已知，刻意留 PR-1b/後續）

- Hook direct-write 的 `phase="committed"` 會與未來 Arbitrator committed 路徑共存（PR-1b plan 明列區分策略）
- `reason_code` 目前 sink 原 `reason` 字串（snake_case `"hook_post"`），不是 CamelCase 低基數
- `outcome="emitted"` 對 verify reject / projection unchanged 路徑語意不嚴謹（PR-1b 細化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)