### PR TITLE
feat(lights): complete §3.5 trace envelope + row class discriminator (PR-1b-0)

### DIFF
--- a/docs/superpowers/plans/2026-04-22-lights-system/phase-1.md
+++ b/docs/superpowers/plans/2026-04-22-lights-system/phase-1.md
@@ -39,7 +39,7 @@ PR-1a merge 後 review 發現 §3.5 envelope 欄位仍缺 12 個（#560）、leg
 | `session_id` | `agent_trace_chains.tmux_session` + `pane_id`（既有 composite）| PR-1a |
 | `event_id` | `agent_trace_steps.step_id`（既有，uuid 全域唯一）| PR-1a |
 | `span_id / parent_span_id` | `step_id / parent_step_id`（既有）| PR-1a |
-| `name` | `event_name`（既有，PR-1b-0 擴充填法為 `hook.post.<Event>`）| PR-1a |
+| `name` | `event_name`（既有，裸事件名；PR-1b-1 擴充填法為 `hook.post.<Event>`）| PR-1a |
 | `kind` (OTel) | `otel_kind` 新欄（避開現有 `kind` 的 step_kind 語意）| PR-1b-0 |
 | `source_kind` | `source_kind` | PR-1a |
 | `watcher_token` | `watcher_token` | PR-1a |

--- a/docs/superpowers/plans/2026-04-22-lights-system/phase-1.md
+++ b/docs/superpowers/plans/2026-04-22-lights-system/phase-1.md
@@ -2,42 +2,105 @@
 
 > Spec 對照：§3.3、§3.4、§3.5、§3.5.1、§8.1
 > 依賴：Phase 0
-> PR：PR-1a（schema）+ PR-1b（observation passthrough）
+> PR：PR-1a（schema baseline）+ **PR-1b-0（schema 補完 + discriminator）** + **PR-1b-1（observation passthrough）**
 
 在不改變使用者可見行為的前提下，把新 trace schema 鋪到 SQLite，讓 hook / probe / sweep 在維持直寫 frame 的同時把同一事件轉成 `Observation` 送進 Arbitrator 的 passthrough 路徑。Arbitrator 此階段只計算 proposal、下投影到舊 schema 與 direct-write frame 比對，差異寫入 `frame_divergences`。這是 Phase 2 切換 writer 前的觀察視窗，上線後至少留一個 alpha bump 週期收集 divergence。
 
+## PR 拆分修訂（2026-04-22）
+
+PR-1a merge 後 review 發現 §3.5 envelope 欄位仍缺 12 個（#560）、legacy vs Lights row 無區分契約（#561）。原 PR-1b 範圍（Observation + Arbitrator + divergence passthrough）需這兩個前置條件。**拆分**：
+
+- **PR-1b-0**：envelope schema 補完（#560）+ row 類別 discriminator（#561）— 中等大小 schema PR
+- **PR-1b-1**：Observation 型別 + Arbitrator 骨架 + channel admission + 雙寫 passthrough + divergence 比對 — 大型 PR（原 PR-1b 範圍）
+
 ## 主架構
 
-### 1. Trace schema 升級（§3.5）
+### 1. Trace schema 升級（§3.5） — **PR-1a ✅ + PR-1b-0**
 
-- [ ] 測試：新欄位（`source_kind` / `action` / `reason_code` / `outcome` / `scenario_key` / `observed_generation` / `decision_ports[]`）寫入後可 query 回原值
-- [ ] 測試：舊 consumer 讀取新 schema 不炸（unknown 欄位忽略）
-- [ ] 測試：hook path 呼叫下新欄位全部填上非 null
+**PR-1a 已完成（10 欄位）**：
+- [x] 測試：新欄位（`source_kind` / `action` / `reason_code` / `outcome` / `scenario_key` / `observed_generation` / `decision_ports` / `phase` / `status` / `watcher_token`）寫入後可 query 回原值
+- [x] 測試：舊 consumer 讀取新 schema 不炸（zero-value roundtrip）
+- [x] 測試：hook path 呼叫下新欄位全部填上非 null
 
-### 2. `frame_divergences` 表（§8.1）
+**PR-1b-0 補完（11 欄位 + discriminator）**：
+- [ ] 測試：新欄位 `trace_id` / `reason_text` / `attrs` / `input_refs` / `output_refs` / `state_before_ref` / `state_after_ref` / `evidence_refs` / `started_at` / `ended_at` / `otel_kind` 寫入後 query 回原值
+- [ ] 測試：`attrs` JSON object / `*_refs` JSON array 解析正確
+- [ ] 測試：`trace_id` uuid 格式 roundtrip
+- [ ] 測試：hook path 下 11 個新欄位皆填上合理值
+- [ ] 測試：Legacy row（`source_kind=""`）zero-value roundtrip 仍合法（相容性）
+- [ ] 測試：Lights row（`source_kind!=""`）若 `phase` / `outcome` / `action` / `trace_id` 任一為空 → `SaveChain` 回 error（row class discriminator + validation）
+- [ ] 測試：Legacy row 與 Lights row 混合 in 同 chain 仍可 roundtrip
 
-- [ ] 測試：insert/select roundtrip 正確
-- [ ] 測試：高並發寫入無 deadlock / lost update
-- [ ] DDL migration（alpha 階段可 drop-recreate）
+**Schema 欄位對照**（完成後）：
 
-### 3. `Observation` 型別（§3.3）
+| spec §3.5 欄位 | 實作位置 | PR |
+|---|---|---|
+| `trace_id` | `agent_trace_steps.trace_id` (新) | PR-1b-0 |
+| `session_id` | `agent_trace_chains.tmux_session` + `pane_id`（既有 composite）| PR-1a |
+| `event_id` | `agent_trace_steps.step_id`（既有，uuid 全域唯一）| PR-1a |
+| `span_id / parent_span_id` | `step_id / parent_step_id`（既有）| PR-1a |
+| `name` | `event_name`（既有，PR-1b-0 擴充填法為 `hook.post.<Event>`）| PR-1a |
+| `kind` (OTel) | `otel_kind` 新欄（避開現有 `kind` 的 step_kind 語意）| PR-1b-0 |
+| `source_kind` | `source_kind` | PR-1a |
+| `watcher_token` | `watcher_token` | PR-1a |
+| `phase` | `phase` | PR-1a |
+| `status` | `status` | PR-1a |
+| `outcome` | `outcome` | PR-1a |
+| `action` | `action` | PR-1a |
+| `reason_code` | `reason_code` | PR-1a |
+| `reason_text` | `reason_text` (新) | PR-1b-0 |
+| `decision_ports` | `decision_ports` | PR-1a |
+| `scenario_key` | `scenario_key` | PR-1a |
+| `input_refs` | `input_refs` (新, JSON array) | PR-1b-0 |
+| `output_refs` | `output_refs` (新, JSON array) | PR-1b-0 |
+| `state_before_ref` | `state_before_ref` (新) | PR-1b-0 |
+| `state_after_ref` | `state_after_ref` (新) | PR-1b-0 |
+| `evidence_refs` | `evidence_refs` (新, JSON array) | PR-1b-0 |
+| `attrs` | `attrs` (新, JSON object) | PR-1b-0 |
+| `observed_generation` | `observed_generation` | PR-1a |
+| `started_at` | `started_at` (新, nano epoch) | PR-1b-0 |
+| `ended_at` | `ended_at` (新, nano epoch) | PR-1b-0 |
+| `seq` | `seq`（既有）| PR-1a |
 
-- [ ] 測試：`DecisionPort` cap 16 — 超過第 17 筆拒收不 panic
-- [ ] 測試：`WatcherToken` 儲存 roundtrip
+**Row class discriminator（#561 選項 B + validation）**：
+- **Legacy row**: `source_kind == ""`（pre-PR-1a SaveChain 寫入的 row）— 允許所有 Lights 欄位 zero-value
+- **Lights row**: `source_kind != ""`（PR-1b-0 起 Arbitrator / hook collector 寫入）— required 欄位 `source_kind` / `phase` / `outcome` / `action` / `trace_id` 全部非空；SaveChain normalize 時 validate，缺欄位回 error
+- **不加 `schema_version` 欄位**：`source_kind` 本身即 discriminator，避免重複
+- PR-1a 時期 `TestTraceStore_ZeroValueLightsFieldsRoundTrip` 測試改名為 `TestTraceStore_LegacyRowZeroValueEnvelopeRoundtrip`，明示「legacy row 才允許 zero-value」
+
+### 2. `frame_divergences` 表（§8.1） — **PR-1a ✅**
+
+- [x] 測試：insert/select roundtrip 正確
+- [x] 測試：高並發寫入無 deadlock / lost update
+- [x] 測試：idempotency key（session_id, trace_id, event_id, observed_generation）DO NOTHING on duplicate
+- [x] DDL migration（alpha 階段可 drop-recreate）
+- [x] BLOB → TEXT + `json.RawMessage`（避免 base64 外流）
+
+### 3. `Observation` 型別（§3.3） — **PR-1b-1**
+
+- [ ] 測試：`DecisionPort` cap 16 — 超過第 17 筆拒收不 panic（dev panic / prod log+truncate）
+- [ ] 測試：`WatcherToken` 儲存 roundtrip（uuid rotation 下老 token reject）
 - [ ] 測試：必填欄位缺失時 Observation 建構器回 error（不 silent pass）
+- [ ] 測試：`SourceKind` enum 值域合法性（hook|probe|sweep|reconcile|synthetic）
+- [ ] 測試：`StateProposal.ActorKey` composite key（SessionID, Generation, ActorID）roundtrip
 
-### 4. Arbitrator 骨架 + channel admission control（§3.4、§3.5.1）
+### 4. Arbitrator 骨架 + channel admission control（§3.4、§3.5.1） — **PR-1b-1**
 
 - [ ] 測試：`arb_in` cap 1024 — proposed 滿載 drop non-blocking、committed 滿載 blocking 100ms timeout
 - [ ] 測試：`retryCh` cap 256 滿載 drop retry tick 但 pending entry 仍在 buffer
 - [ ] 測試：`traceOut` cap 4096 滿載按 drop priority 丟（committed > proposed > trace-only）
 - [ ] 測試：Arbitrator 單 goroutine 擁有 pending buffer；三來源並發寫入無 race（go test `-race`）
+- [ ] 測試：Apply pipeline 9 步驟（generation gate / watcher / idempotency / pending / source priority / monotone lifecycle / invariant / mode branch / trace）各自覆蓋
+- [ ] 測試：Generation gate — `< frame.generation` reject `StaleGeneration`；`> frame.generation` 僅 `hook.SessionStart` 可推進，其他 reject `UnauthorizedGenerationBump`
+- [ ] 測試：Pending window — per-session 8 entries evict、per-observation coalescing 16 筆 drop oldest、2s deadline drop proposal 不建 actor
+- [ ] 測試：Reconcile loop — 不改 actor.status，只進 trace（`outcome=skipped, reason_code=ReconcileStaleNoted`）
 
-### 5. 雙寫 passthrough + divergence 比對（§8.1）
+### 5. 雙寫 passthrough + divergence 比對（§8.1） — **PR-1b-1**
 
 - [ ] 測試：hook path 送進 Arbitrator 的 proposal 投影到舊 schema 後與 direct-write frame 逐欄等值（無 divergence）
 - [ ] 測試：人為注入不一致 proposal → `frame_divergences` 有對應 row
 - [ ] 測試：probe/sweep 雙寫 path 同樣覆蓋（三來源都能產生 Observation）
+- [ ] 測試：`AGENT_ARB_MODE=passthrough`（PR-1b-1 預設）Arbitrator 不寫 frame
 
 ## 驗收
 

--- a/internal/module/agent/trace.go
+++ b/internal/module/agent/trace.go
@@ -140,6 +140,19 @@ type traceStepInput struct {
 	Phase              string
 	Status             string
 	WatcherToken       *string
+
+	// Lights envelope completion (PR-1b-0, spec §3.5).
+	TraceID        string
+	ReasonText     string
+	Attrs          string
+	InputRefs      string
+	OutputRefs     string
+	StateBeforeRef string
+	StateAfterRef  string
+	EvidenceRefs   string
+	StartedAt      int64
+	EndedAt        int64
+	OTelKind       string
 }
 
 func (c *hookTraceCollector) append(in traceStepInput) string {
@@ -186,6 +199,47 @@ func (c *hookTraceCollector) append(in traceStepInput) string {
 	if decisionPorts == "" {
 		decisionPorts = "[]"
 	}
+	// PR-1b-0: trace_id defaults to chain_id (one hook invocation = one
+	// generation's trace); PR-1b-1 Observation path will mint its own.
+	traceID := in.TraceID
+	if traceID == "" {
+		traceID = c.chain.ChainID
+	}
+	reasonText := in.ReasonText
+	if reasonText == "" {
+		reasonText = in.Reason
+	}
+	attrs := in.Attrs
+	if attrs == "" {
+		attrs = "{}"
+	}
+	inputRefs := in.InputRefs
+	if inputRefs == "" {
+		inputRefs = "[]"
+	}
+	outputRefs := in.OutputRefs
+	if outputRefs == "" {
+		outputRefs = "[]"
+	}
+	evidenceRefs := in.EvidenceRefs
+	if evidenceRefs == "" {
+		evidenceRefs = "[]"
+	}
+	// otel_kind "internal": hook post-callback runs inside the daemon and is
+	// not a client/server RPC edge (spec §3.5 line 488).
+	otelKind := in.OTelKind
+	if otelKind == "" {
+		otelKind = "internal"
+	}
+	now := time.Now().UnixNano()
+	startedAt := in.StartedAt
+	if startedAt == 0 {
+		startedAt = now
+	}
+	endedAt := in.EndedAt
+	if endedAt == 0 {
+		endedAt = startedAt
+	}
 	c.steps = append(c.steps, store.TraceStep{
 		StepID:             stepID,
 		ChainID:            c.chain.ChainID,
@@ -203,7 +257,7 @@ func (c *hookTraceCollector) append(in traceStepInput) string {
 		PayloadJSON:        marshalTraceJSON(in.Payload),
 		BeforeJSON:         marshalTraceJSON(in.Before),
 		AfterJSON:          marshalTraceJSON(in.After),
-		CreatedAt:          time.Now().UnixNano(),
+		CreatedAt:          now,
 		SourceKind:         sourceKind,
 		Action:             action,
 		ReasonCode:         reasonCode,
@@ -214,6 +268,17 @@ func (c *hookTraceCollector) append(in traceStepInput) string {
 		Phase:              phase,
 		Status:             status,
 		WatcherToken:       in.WatcherToken,
+		TraceID:            traceID,
+		ReasonText:         reasonText,
+		Attrs:              json.RawMessage(attrs),
+		InputRefs:          json.RawMessage(inputRefs),
+		OutputRefs:         json.RawMessage(outputRefs),
+		StateBeforeRef:     in.StateBeforeRef,
+		StateAfterRef:      in.StateAfterRef,
+		EvidenceRefs:       json.RawMessage(evidenceRefs),
+		StartedAt:          startedAt,
+		EndedAt:            endedAt,
+		OTelKind:           otelKind,
 	})
 	c.nextSeq++
 	c.chain.LatestStepKind = in.Kind

--- a/internal/module/agent/trace_test.go
+++ b/internal/module/agent/trace_test.go
@@ -128,6 +128,28 @@ func TestHandleEvent_PersistAcceptedHookTrace(t *testing.T) {
 		if step.WatcherToken != nil {
 			t.Fatalf("step %d WatcherToken = %v, want nil", i, step.WatcherToken)
 		}
+		// PR-1b-0: hook collector must populate the 11 new envelope fields.
+		if step.TraceID != record.Chain.ChainID {
+			t.Fatalf("step %d TraceID = %q, want chain id %q", i, step.TraceID, record.Chain.ChainID)
+		}
+		if step.OTelKind != "internal" {
+			t.Fatalf("step %d OTelKind = %q, want internal", i, step.OTelKind)
+		}
+		if step.ReasonText == "" {
+			t.Fatalf("step %d ReasonText empty", i)
+		}
+		if string(step.Attrs) != "{}" {
+			t.Fatalf("step %d Attrs = %s, want {}", i, string(step.Attrs))
+		}
+		if string(step.InputRefs) != "[]" || string(step.OutputRefs) != "[]" || string(step.EvidenceRefs) != "[]" {
+			t.Fatalf("step %d refs default = %s/%s/%s", i, string(step.InputRefs), string(step.OutputRefs), string(step.EvidenceRefs))
+		}
+		if step.StateBeforeRef != "" || step.StateAfterRef != "" {
+			t.Fatalf("step %d state refs = %q/%q, want empty", i, step.StateBeforeRef, step.StateAfterRef)
+		}
+		if step.StartedAt == 0 || step.EndedAt == 0 {
+			t.Fatalf("step %d started_at/ended_at = %d/%d, want non-zero", i, step.StartedAt, step.EndedAt)
+		}
 	}
 }
 

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -66,6 +66,18 @@ type TraceStep struct {
 	Phase              string          `json:"phase,omitempty"`
 	Status             string          `json:"status,omitempty"`
 	WatcherToken       *string         `json:"watcher_token,omitempty"`
+	// Spec §3.5 envelope completion (PR-1b-0).
+	TraceID        string          `json:"trace_id,omitempty"`
+	ReasonText     string          `json:"reason_text,omitempty"`
+	Attrs          json.RawMessage `json:"attrs,omitempty"`
+	InputRefs      json.RawMessage `json:"input_refs,omitempty"`
+	OutputRefs     json.RawMessage `json:"output_refs,omitempty"`
+	StateBeforeRef string          `json:"state_before_ref,omitempty"`
+	StateAfterRef  string          `json:"state_after_ref,omitempty"`
+	EvidenceRefs   json.RawMessage `json:"evidence_refs,omitempty"`
+	StartedAt      int64           `json:"started_at,omitempty"`
+	EndedAt        int64           `json:"ended_at,omitempty"`
+	OTelKind       string          `json:"otel_kind,omitempty"`
 }
 
 // TraceRecord combines a chain summary with its ordered steps.
@@ -268,6 +280,17 @@ func needsStepRebuildTx(tx *sql.Tx, cols map[string]bool) bool {
 		"phase",
 		"status",
 		"watcher_token",
+		"trace_id",
+		"reason_text",
+		"attrs",
+		"input_refs",
+		"output_refs",
+		"state_before_ref",
+		"state_after_ref",
+		"evidence_refs",
+		"started_at",
+		"ended_at",
+		"otel_kind",
 	}
 	for _, col := range required {
 		if !cols[col] {
@@ -379,6 +402,17 @@ const traceStepsDDL = `
 		phase               TEXT NOT NULL DEFAULT '',
 		status              TEXT NOT NULL DEFAULT '',
 		watcher_token       TEXT,
+		trace_id            TEXT NOT NULL DEFAULT '',
+		reason_text         TEXT NOT NULL DEFAULT '',
+		attrs               TEXT NOT NULL DEFAULT '{}',
+		input_refs          TEXT NOT NULL DEFAULT '[]',
+		output_refs         TEXT NOT NULL DEFAULT '[]',
+		state_before_ref    TEXT NOT NULL DEFAULT '',
+		state_after_ref     TEXT NOT NULL DEFAULT '',
+		evidence_refs       TEXT NOT NULL DEFAULT '[]',
+		started_at          INTEGER NOT NULL DEFAULT 0,
+		ended_at            INTEGER NOT NULL DEFAULT 0,
+		otel_kind           TEXT NOT NULL DEFAULT '',
 		FOREIGN KEY (chain_id) REFERENCES agent_trace_chains(chain_id) ON DELETE CASCADE,
 		FOREIGN KEY (chain_id, parent_step_id) REFERENCES agent_trace_steps(chain_id, step_id) ON DELETE CASCADE
 	)
@@ -739,13 +773,20 @@ func (s *TraceStore) SaveChain(record TraceRecord) (err error) {
 				agent_type, frame_id, parent_frame_id, event_name, decision, reason,
 				payload_json, before_json, after_json, created_at,
 				source_kind, action, reason_code, outcome, scenario_key,
-				observed_generation, decision_ports, phase, status, watcher_token
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				observed_generation, decision_ports, phase, status, watcher_token,
+				trace_id, reason_text, attrs, input_refs, output_refs,
+				state_before_ref, state_after_ref, evidence_refs,
+				started_at, ended_at, otel_kind
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, step.StepID, step.ChainID, nullString(step.ParentStepID), step.Seq, step.Kind, step.TmuxSession, step.PaneID,
 			step.AgentType, step.FrameID, step.ParentFrameID, step.EventName, step.Decision, step.Reason,
 			rawJSONText(step.PayloadJSON), rawJSONText(step.BeforeJSON), rawJSONText(step.AfterJSON), step.CreatedAt,
 			step.SourceKind, step.Action, step.ReasonCode, step.Outcome, step.ScenarioKey,
-			step.ObservedGeneration, rawJSONArrayText(step.DecisionPorts), step.Phase, step.Status, nullableString(step.WatcherToken)); err != nil {
+			step.ObservedGeneration, rawJSONArrayText(step.DecisionPorts), step.Phase, step.Status, nullableString(step.WatcherToken),
+			step.TraceID, step.ReasonText, rawJSONObjectText(step.Attrs),
+			rawJSONArrayText(step.InputRefs), rawJSONArrayText(step.OutputRefs),
+			step.StateBeforeRef, step.StateAfterRef, rawJSONArrayText(step.EvidenceRefs),
+			step.StartedAt, step.EndedAt, step.OTelKind); err != nil {
 			return err
 		}
 	}
@@ -830,7 +871,10 @@ func (s *TraceStore) GetChainRecord(chainID string) (*TraceRecord, error) {
 		       agent_type, frame_id, parent_frame_id, event_name, decision, reason,
 		       payload_json, before_json, after_json, created_at,
 		       source_kind, action, reason_code, outcome, scenario_key,
-		       observed_generation, decision_ports, phase, status, watcher_token
+		       observed_generation, decision_ports, phase, status, watcher_token,
+		       trace_id, reason_text, attrs, input_refs, output_refs,
+		       state_before_ref, state_after_ref, evidence_refs,
+		       started_at, ended_at, otel_kind
 		FROM agent_trace_steps
 		WHERE chain_id = ?
 		ORDER BY seq ASC, created_at ASC, step_id ASC
@@ -920,6 +964,9 @@ func normalizeTraceRecord(record TraceRecord) (TraceChain, []TraceStep, error) {
 			if _, ok := seen[steps[i].ParentStepID]; !ok {
 				return TraceChain{}, nil, fmt.Errorf("step %s references missing parent step %s", steps[i].StepID, steps[i].ParentStepID)
 			}
+		}
+		if err := validateLightsRow(steps[i]); err != nil {
+			return TraceChain{}, nil, err
 		}
 		seen[steps[i].StepID] = struct{}{}
 	}
@@ -1110,6 +1157,7 @@ func collectTraceSteps(rows *sql.Rows) ([]TraceStep, error) {
 		var parent sql.NullString
 		var watcher sql.NullString
 		var payload, before, after, decisionPorts string
+		var attrs, inputRefs, outputRefs, evidenceRefs string
 		if err := rows.Scan(
 			&step.StepID,
 			&step.ChainID,
@@ -1138,6 +1186,17 @@ func collectTraceSteps(rows *sql.Rows) ([]TraceStep, error) {
 			&step.Phase,
 			&step.Status,
 			&watcher,
+			&step.TraceID,
+			&step.ReasonText,
+			&attrs,
+			&inputRefs,
+			&outputRefs,
+			&step.StateBeforeRef,
+			&step.StateAfterRef,
+			&evidenceRefs,
+			&step.StartedAt,
+			&step.EndedAt,
+			&step.OTelKind,
 		); err != nil {
 			return nil, err
 		}
@@ -1146,6 +1205,10 @@ func collectTraceSteps(rows *sql.Rows) ([]TraceStep, error) {
 		step.BeforeJSON = json.RawMessage(before)
 		step.AfterJSON = json.RawMessage(after)
 		step.DecisionPorts = json.RawMessage(decisionPorts)
+		step.Attrs = json.RawMessage(attrs)
+		step.InputRefs = json.RawMessage(inputRefs)
+		step.OutputRefs = json.RawMessage(outputRefs)
+		step.EvidenceRefs = json.RawMessage(evidenceRefs)
 		if watcher.Valid {
 			v := watcher.String
 			step.WatcherToken = &v
@@ -1188,6 +1251,13 @@ func rawJSONArrayText(raw json.RawMessage) string {
 	return string(raw)
 }
 
+func rawJSONObjectText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "{}"
+	}
+	return string(raw)
+}
+
 func nullableString(value *string) any {
 	if value == nil {
 		return nil
@@ -1195,11 +1265,29 @@ func nullableString(value *string) any {
 	return *value
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
+// validateLightsRow enforces the row-class discriminator contract from spec
+// §3.5 / plan phase-1 #561: rows with a non-empty source_kind are Lights rows
+// and must carry the required envelope identifiers; rows with an empty
+// source_kind are legacy rows and are exempt so pre-PR-1a callers still
+// round-trip.
+func validateLightsRow(step TraceStep) error {
+	if step.SourceKind == "" {
+		return nil
+	}
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"source_kind", step.SourceKind},
+		{"phase", step.Phase},
+		{"outcome", step.Outcome},
+		{"action", step.Action},
+		{"trace_id", step.TraceID},
+	}
+	for _, field := range required {
+		if field.value == "" {
+			return fmt.Errorf("lights row step %s missing required field %s", step.StepID, field.name)
 		}
 	}
-	return ""
+	return nil
 }

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -678,29 +679,49 @@ func buildLegacyTraceStepsCopyQuery(legacyCols map[string]bool) string {
 		"observed_generation", "decision_ports", "phase", "status", "watcher_token",
 	}
 	// PR-1b-0 envelope cols — preserve if present (robustness path; normally
-	// the rebuild triggers precisely because these are missing).
-	pr1b0Envelope := []string{
-		"trace_id", "reason_text", "attrs", "input_refs", "output_refs",
+	// the rebuild triggers precisely because these are missing). trace_id is
+	// handled separately below so we can backfill PR-1a Lights rows that never
+	// had the column (contract: source_kind!="" ⇒ trace_id required).
+	pr1b0EnvelopeExceptTraceID := []string{
+		"reason_text", "attrs", "input_refs", "output_refs",
 		"state_before_ref", "state_after_ref", "evidence_refs",
 		"started_at", "ended_at", "otel_kind",
 	}
 
-	columns := make([]string, 0, len(core)+len(pr1aLights)+len(pr1b0Envelope))
+	columns := make([]string, 0, len(core)+len(pr1aLights)+len(pr1b0EnvelopeExceptTraceID)+1)
+	selectCols := make([]string, 0, cap(columns))
 	columns = append(columns, core...)
+	for _, c := range core {
+		selectCols = append(selectCols, "s."+c)
+	}
 	for _, c := range pr1aLights {
 		if legacyCols[c] {
 			columns = append(columns, c)
+			selectCols = append(selectCols, "s."+c)
 		}
 	}
-	for _, c := range pr1b0Envelope {
+	// trace_id backfill: PR-1a Lights rows lack the column; per spec §3.5 a
+	// Lights row (source_kind!="") must carry trace_id, and PR-1b-0's agent
+	// trace emitter aliases trace_id = chain_id for its transition period. We
+	// mirror that aliasing here so post-migration Lights rows satisfy
+	// validateLightsRow. Legacy rows (source_kind="") stay at empty string.
+	if legacyCols["trace_id"] {
+		columns = append(columns, "trace_id")
+		if legacyCols["source_kind"] {
+			selectCols = append(selectCols,
+				`CASE WHEN s.trace_id != '' THEN s.trace_id WHEN s.source_kind != '' THEN s.chain_id ELSE '' END`)
+		} else {
+			selectCols = append(selectCols, "s.trace_id")
+		}
+	} else if legacyCols["source_kind"] {
+		columns = append(columns, "trace_id")
+		selectCols = append(selectCols, `CASE WHEN s.source_kind != '' THEN s.chain_id ELSE '' END`)
+	}
+	for _, c := range pr1b0EnvelopeExceptTraceID {
 		if legacyCols[c] {
 			columns = append(columns, c)
+			selectCols = append(selectCols, "s."+c)
 		}
-	}
-
-	selectCols := make([]string, len(columns))
-	for i, c := range columns {
-		selectCols[i] = "s." + c
 	}
 
 	return fmt.Sprintf(`
@@ -1004,6 +1025,9 @@ func normalizeTraceRecord(record TraceRecord) (TraceChain, []TraceStep, error) {
 		if err := validateLightsRow(steps[i]); err != nil {
 			return TraceChain{}, nil, err
 		}
+		if err := validateJSONShape(steps[i]); err != nil {
+			return TraceChain{}, nil, err
+		}
 		seen[steps[i].StepID] = struct{}{}
 	}
 
@@ -1302,12 +1326,17 @@ func nullableString(value *string) any {
 }
 
 // validateLightsRow enforces the row-class discriminator contract from spec
-// §3.5 / plan phase-1 #561: rows with a non-empty source_kind are Lights rows
-// and must carry the required envelope identifiers; rows with an empty
-// source_kind are legacy rows and are exempt so pre-PR-1a callers still
-// round-trip.
+// §3.5 / plan phase-1 #561 bidirectionally: any row carrying at least one
+// Lights envelope field is treated as a Lights row and must populate all five
+// required identifiers; rows with every Lights field empty are legacy rows
+// and pass through so pre-PR-1a callers still round-trip.
 func validateLightsRow(step TraceStep) error {
-	if step.SourceKind == "" {
+	hasLightsData := step.SourceKind != "" ||
+		step.TraceID != "" ||
+		step.Phase != "" ||
+		step.Outcome != "" ||
+		step.Action != ""
+	if !hasLightsData {
 		return nil
 	}
 	required := []struct {
@@ -1324,6 +1353,59 @@ func validateLightsRow(step TraceStep) error {
 		if field.value == "" {
 			return fmt.Errorf("lights row step %s missing required field %s", step.StepID, field.name)
 		}
+	}
+	return nil
+}
+
+// validateJSONShape rejects malformed JSON or wrong top-level shapes in the
+// envelope JSON fields before they hit SQLite. attrs is an object; input_refs
+// / output_refs / evidence_refs / decision_ports are arrays. Empty values fall
+// through to rawJSON*Text defaults and are accepted.
+func validateJSONShape(step TraceStep) error {
+	if err := validateJSONObject(step.StepID, "attrs", step.Attrs); err != nil {
+		return err
+	}
+	arrayFields := []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{"input_refs", step.InputRefs},
+		{"output_refs", step.OutputRefs},
+		{"evidence_refs", step.EvidenceRefs},
+		{"decision_ports", step.DecisionPorts},
+	}
+	for _, f := range arrayFields {
+		if err := validateJSONArray(step.StepID, f.name, f.raw); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateJSONObject(stepID, field string, raw json.RawMessage) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if !json.Valid(trimmed) {
+		return fmt.Errorf("step %s field %s: invalid JSON", stepID, field)
+	}
+	if trimmed[0] != '{' {
+		return fmt.Errorf("step %s field %s: expected JSON object", stepID, field)
+	}
+	return nil
+}
+
+func validateJSONArray(stepID, field string, raw json.RawMessage) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if !json.Valid(trimmed) {
+		return fmt.Errorf("step %s field %s: invalid JSON", stepID, field)
+	}
+	if trimmed[0] != '[' {
+		return fmt.Errorf("step %s field %s: expected JSON array", stepID, field)
 	}
 	return nil
 }

--- a/internal/store/trace.go
+++ b/internal/store/trace.go
@@ -567,10 +567,6 @@ func traceTableExistsTx(tx *sql.Tx, table string) (bool, error) {
 }
 
 func rebuildLegacyTraceStepsTx(tx *sql.Tx) error {
-	cols, err := tableColumnsTx(tx, "agent_trace_steps")
-	if err != nil {
-		return err
-	}
 	stepRows, err := traceTableRowCountTx(tx, "agent_trace_steps")
 	if err != nil {
 		return err
@@ -607,37 +603,37 @@ func rebuildLegacyTraceStepsTx(tx *sql.Tx) error {
 	if err := createTraceStepsTableTx(tx); err != nil {
 		return err
 	}
-	var copyQuery string
-	if cols["seq"] {
-		copyQuery = `
-			INSERT INTO agent_trace_steps (
-				step_id, chain_id, parent_step_id, seq, kind, tmux_session, pane_id,
-				agent_type, frame_id, parent_frame_id, event_name, decision, reason,
-				payload_json, before_json, after_json, created_at
-			)
-			SELECT
-				s.step_id,
-				s.chain_id,
-				s.parent_step_id,
-				s.seq,
-				s.kind,
-				s.tmux_session,
-				s.pane_id,
-				s.agent_type,
-				s.frame_id,
-				s.parent_frame_id,
-				s.event_name,
-				s.decision,
-				s.reason,
-				s.payload_json,
-				s.before_json,
-				s.after_json,
-				s.created_at
-			FROM agent_trace_steps_legacy s
-			ORDER BY s.chain_id ASC, s.seq ASC, s.created_at ASC, s.step_id ASC
-		`
-	} else {
-		copyQuery = `
+	// Re-read the legacy column set after rename so the copy query only
+	// references columns that actually exist. PR-1a added 10 Lights columns
+	// and PR-1b-0 added 11 more envelope columns; rebuild must preserve the
+	// actual values on any table that already has them instead of silently
+	// DEFAULT-ing them (which would corrupt deployed Lights history).
+	legacyCols, err := tableColumnsTx(tx, "agent_trace_steps_legacy")
+	if err != nil {
+		return err
+	}
+	copyQuery := buildLegacyTraceStepsCopyQuery(legacyCols)
+	if _, err = tx.Exec(copyQuery); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(`DROP TABLE agent_trace_steps_legacy`); err != nil {
+		return err
+	}
+	return nil
+}
+
+// buildLegacyTraceStepsCopyQuery composes an INSERT … SELECT that copies every
+// column present on the (now-renamed) legacy steps table into the freshly
+// created agent_trace_steps table. Columns absent on the legacy side are
+// omitted from both lists so SQLite applies the new-schema DEFAULTs (spec §3.5
+// envelope defaults) instead of NULL.
+func buildLegacyTraceStepsCopyQuery(legacyCols map[string]bool) string {
+	// Two very different legacy shapes: pre-PR-1a used step_name/step_index
+	// and did not have a seq column, so we derive the new schema values from
+	// the chains table. Everything after that point keeps the same column
+	// names as the current schema and can be copied 1:1.
+	if !legacyCols["seq"] {
+		return `
 			INSERT INTO agent_trace_steps (
 				step_id, chain_id, parent_step_id, seq, kind, tmux_session, pane_id,
 				agent_type, frame_id, parent_frame_id, event_name, decision, reason,
@@ -666,13 +662,53 @@ func rebuildLegacyTraceStepsTx(tx *sql.Tx) error {
 			ORDER BY s.chain_id ASC, s.step_index ASC, s.created_at ASC, s.step_id ASC
 		`
 	}
-	if _, err = tx.Exec(copyQuery); err != nil {
-		return err
+
+	// Core 17 cols — always present on any post-PR-1a schema and always copied.
+	// parent_step_id keeps its nullable-TEXT form (cross-chain parents were
+	// rejected by legacyTraceCrossChainParentCountTx earlier in the rebuild).
+	core := []string{
+		"step_id", "chain_id", "parent_step_id", "seq", "kind",
+		"tmux_session", "pane_id", "agent_type", "frame_id", "parent_frame_id",
+		"event_name", "decision", "reason",
+		"payload_json", "before_json", "after_json", "created_at",
 	}
-	if _, err = tx.Exec(`DROP TABLE agent_trace_steps_legacy`); err != nil {
-		return err
+	// PR-1a Lights cols — preserve if present.
+	pr1aLights := []string{
+		"source_kind", "action", "reason_code", "outcome", "scenario_key",
+		"observed_generation", "decision_ports", "phase", "status", "watcher_token",
 	}
-	return nil
+	// PR-1b-0 envelope cols — preserve if present (robustness path; normally
+	// the rebuild triggers precisely because these are missing).
+	pr1b0Envelope := []string{
+		"trace_id", "reason_text", "attrs", "input_refs", "output_refs",
+		"state_before_ref", "state_after_ref", "evidence_refs",
+		"started_at", "ended_at", "otel_kind",
+	}
+
+	columns := make([]string, 0, len(core)+len(pr1aLights)+len(pr1b0Envelope))
+	columns = append(columns, core...)
+	for _, c := range pr1aLights {
+		if legacyCols[c] {
+			columns = append(columns, c)
+		}
+	}
+	for _, c := range pr1b0Envelope {
+		if legacyCols[c] {
+			columns = append(columns, c)
+		}
+	}
+
+	selectCols := make([]string, len(columns))
+	for i, c := range columns {
+		selectCols[i] = "s." + c
+	}
+
+	return fmt.Sprintf(`
+		INSERT INTO agent_trace_steps (%s)
+		SELECT %s
+		FROM agent_trace_steps_legacy s
+		ORDER BY s.chain_id ASC, s.seq ASC, s.created_at ASC, s.step_id ASC
+	`, strings.Join(columns, ", "), strings.Join(selectCols, ", "))
 }
 
 func traceTableRowCountTx(tx *sql.Tx, table string) (int, error) {

--- a/internal/store/trace_test.go
+++ b/internal/store/trace_test.go
@@ -617,6 +617,340 @@ func TestRebuildLegacyTraceSteps_BlocksCrossChainParent(t *testing.T) {
 	}
 }
 
+// TestRebuildLegacyTraceSteps_PreservesPR1aLightsColumns seeds a legacy table
+// carrying the PR-1a Lights columns (source_kind/action/reason_code/outcome/
+// scenario_key/observed_generation/decision_ports/phase/status/watcher_token)
+// and verifies that PR-1b-0's rebuild preserves their actual values instead of
+// resetting them to DEFAULT. Previous rebuild query only copied the original
+// 17 columns, which silently corrupted every deployed Lights row whenever the
+// migration triggered (e.g. any schema drift that flipped needsStepRebuildTx).
+func TestRebuildLegacyTraceSteps_PreservesPR1aLightsColumns(t *testing.T) {
+	s := openTestAgentEventStore(t)
+	// Seed chains + a "PR-1a schema" steps table: 17 legacy cols + 10 PR-1a
+	// Lights cols, but WITHOUT the composite FK and WITHOUT the PR-1b-0
+	// envelope cols. This matches what any daemon pinned at PR-1a would see.
+	if err := createTraceChainsTable(s.db); err != nil {
+		t.Fatalf("create chains: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		CREATE TABLE agent_trace_steps (
+			step_id             TEXT PRIMARY KEY,
+			chain_id            TEXT NOT NULL,
+			parent_step_id      TEXT,
+			seq                 INTEGER NOT NULL,
+			kind                TEXT NOT NULL DEFAULT '',
+			tmux_session        TEXT NOT NULL DEFAULT '',
+			pane_id             TEXT NOT NULL DEFAULT '',
+			agent_type          TEXT NOT NULL DEFAULT '',
+			frame_id            TEXT NOT NULL DEFAULT '',
+			parent_frame_id     TEXT NOT NULL DEFAULT '',
+			event_name          TEXT NOT NULL DEFAULT '',
+			decision            TEXT NOT NULL DEFAULT '',
+			reason              TEXT NOT NULL DEFAULT '',
+			payload_json        TEXT NOT NULL DEFAULT 'null',
+			before_json         TEXT NOT NULL DEFAULT 'null',
+			after_json          TEXT NOT NULL DEFAULT 'null',
+			created_at          INTEGER NOT NULL DEFAULT 0,
+			source_kind         TEXT NOT NULL DEFAULT '',
+			action              TEXT NOT NULL DEFAULT '',
+			reason_code         TEXT NOT NULL DEFAULT '',
+			outcome             TEXT NOT NULL DEFAULT '',
+			scenario_key        TEXT NOT NULL DEFAULT '',
+			observed_generation INTEGER NOT NULL DEFAULT 0,
+			decision_ports      TEXT NOT NULL DEFAULT '[]',
+			phase               TEXT NOT NULL DEFAULT '',
+			status              TEXT NOT NULL DEFAULT '',
+			watcher_token       TEXT,
+			FOREIGN KEY (chain_id) REFERENCES agent_trace_chains(chain_id) ON DELETE CASCADE,
+			FOREIGN KEY (parent_step_id) REFERENCES agent_trace_steps(step_id) ON DELETE SET NULL
+		)
+	`); err != nil {
+		t.Fatalf("create PR-1a steps: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_chains (
+			chain_id, started_at, completed_at, terminal_status, terminal_reason,
+			tmux_session, pane_id, root_agent_type, root_event_name, root_reason,
+			latest_step_kind, latest_decision, latest_step_reason, step_count, updated_at
+		) VALUES
+		('chain-pr1a', 10, 20, 'done', 'ok', 'proj-a', '%1', 'cc', 'Stop', 'root', 'terminal', 'done', 'ok', 1, 20)
+	`); err != nil {
+		t.Fatalf("seed chain: %v", err)
+	}
+	// Populate every PR-1a Lights column with a non-default value so we can
+	// detect any DEFAULT-clobber after rebuild.
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_steps (
+			step_id, chain_id, parent_step_id, seq, kind, tmux_session, pane_id,
+			agent_type, frame_id, parent_frame_id, event_name, decision, reason,
+			payload_json, before_json, after_json, created_at,
+			source_kind, action, reason_code, outcome, scenario_key,
+			observed_generation, decision_ports, phase, status, watcher_token
+		) VALUES
+		('pr1a-1', 'chain-pr1a', NULL, 1, 'terminal', 'proj-a', '%1', 'cc', 'frame-1', 'frame-0',
+		 'Stop', 'done', 'completed',
+		 '{"x":1}', '{"b":1}', '{"a":1}', 15,
+		 'hook', 'terminal:done', 'completed', 'emitted', 'Stop',
+		 42, '[{"port":"statusline","decision":"ok"}]', 'committed', 'success', 'watcher-123')
+	`); err != nil {
+		t.Fatalf("seed step: %v", err)
+	}
+
+	// Trigger migrate: missing PR-1b-0 cols make needsStepRebuildTx return true
+	// and rebuild the table.
+	if _, err := s.Traces(); err != nil {
+		t.Fatalf("Traces migrate: %v", err)
+	}
+
+	store := &TraceStore{db: s.db, maxChains: 10, maxSteps: 10}
+	rec, err := store.GetChainRecord("chain-pr1a")
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	if rec == nil || len(rec.Steps) != 1 {
+		t.Fatalf("rec = %+v", rec)
+	}
+	step := rec.Steps[0]
+	if step.SourceKind != "hook" {
+		t.Fatalf("source_kind = %q, want hook (rebuild clobbered)", step.SourceKind)
+	}
+	if step.Action != "terminal:done" {
+		t.Fatalf("action = %q, want terminal:done", step.Action)
+	}
+	if step.ReasonCode != "completed" {
+		t.Fatalf("reason_code = %q, want completed", step.ReasonCode)
+	}
+	if step.Outcome != "emitted" {
+		t.Fatalf("outcome = %q, want emitted", step.Outcome)
+	}
+	if step.ScenarioKey != "Stop" {
+		t.Fatalf("scenario_key = %q, want Stop", step.ScenarioKey)
+	}
+	if step.ObservedGeneration != 42 {
+		t.Fatalf("observed_generation = %d, want 42", step.ObservedGeneration)
+	}
+	if string(step.DecisionPorts) != `[{"port":"statusline","decision":"ok"}]` {
+		t.Fatalf("decision_ports = %s", string(step.DecisionPorts))
+	}
+	if step.Phase != "committed" {
+		t.Fatalf("phase = %q, want committed", step.Phase)
+	}
+	if step.Status != "success" {
+		t.Fatalf("status = %q, want success", step.Status)
+	}
+	if step.WatcherToken == nil || *step.WatcherToken != "watcher-123" {
+		t.Fatalf("watcher_token = %v, want watcher-123", step.WatcherToken)
+	}
+	// New PR-1b-0 cols absent from legacy table fall back to DEFAULTs.
+	if step.TraceID != "" || step.ReasonText != "" || step.StateBeforeRef != "" || step.StateAfterRef != "" || step.OTelKind != "" {
+		t.Fatalf("pr1b0 string cols must default to empty, got %+v", step)
+	}
+	if step.StartedAt != 0 || step.EndedAt != 0 {
+		t.Fatalf("pr1b0 timestamp defaults wrong: %d/%d", step.StartedAt, step.EndedAt)
+	}
+	if string(step.Attrs) != `{}` || string(step.InputRefs) != `[]` || string(step.OutputRefs) != `[]` || string(step.EvidenceRefs) != `[]` {
+		t.Fatalf("pr1b0 json defaults wrong: %s / %s / %s / %s",
+			string(step.Attrs), string(step.InputRefs), string(step.OutputRefs), string(step.EvidenceRefs))
+	}
+}
+
+// TestRebuildLegacyTraceSteps_PreservesAllLightsColumnsEvenIfFullSchemaExists
+// covers the robustness scenario where a legacy twin ends up with the full
+// PR-1b-0 schema (38 cols). Although this should never happen in practice
+// because needsStepRebuildTx also triggers on the missing composite FK, the
+// rebuild must still preserve every populated field instead of DEFAULT-ing it.
+func TestRebuildLegacyTraceSteps_PreservesAllLightsColumnsEvenIfFullSchemaExists(t *testing.T) {
+	s := openTestAgentEventStore(t)
+	if err := createTraceChainsTable(s.db); err != nil {
+		t.Fatalf("create chains: %v", err)
+	}
+	// Full PR-1b-0 steps table but without the composite FK, so
+	// hasStepParentCompositeFKTx returns false and needsStepRebuildTx triggers
+	// a rebuild.
+	if _, err := s.db.Exec(`
+		CREATE TABLE agent_trace_steps (
+			step_id             TEXT PRIMARY KEY,
+			chain_id            TEXT NOT NULL,
+			parent_step_id      TEXT,
+			seq                 INTEGER NOT NULL,
+			kind                TEXT NOT NULL DEFAULT '',
+			tmux_session        TEXT NOT NULL DEFAULT '',
+			pane_id             TEXT NOT NULL DEFAULT '',
+			agent_type          TEXT NOT NULL DEFAULT '',
+			frame_id            TEXT NOT NULL DEFAULT '',
+			parent_frame_id     TEXT NOT NULL DEFAULT '',
+			event_name          TEXT NOT NULL DEFAULT '',
+			decision            TEXT NOT NULL DEFAULT '',
+			reason              TEXT NOT NULL DEFAULT '',
+			payload_json        TEXT NOT NULL DEFAULT 'null',
+			before_json         TEXT NOT NULL DEFAULT 'null',
+			after_json          TEXT NOT NULL DEFAULT 'null',
+			created_at          INTEGER NOT NULL DEFAULT 0,
+			source_kind         TEXT NOT NULL DEFAULT '',
+			action              TEXT NOT NULL DEFAULT '',
+			reason_code         TEXT NOT NULL DEFAULT '',
+			outcome             TEXT NOT NULL DEFAULT '',
+			scenario_key        TEXT NOT NULL DEFAULT '',
+			observed_generation INTEGER NOT NULL DEFAULT 0,
+			decision_ports      TEXT NOT NULL DEFAULT '[]',
+			phase               TEXT NOT NULL DEFAULT '',
+			status              TEXT NOT NULL DEFAULT '',
+			watcher_token       TEXT,
+			trace_id            TEXT NOT NULL DEFAULT '',
+			reason_text         TEXT NOT NULL DEFAULT '',
+			attrs               TEXT NOT NULL DEFAULT '{}',
+			input_refs          TEXT NOT NULL DEFAULT '[]',
+			output_refs         TEXT NOT NULL DEFAULT '[]',
+			state_before_ref    TEXT NOT NULL DEFAULT '',
+			state_after_ref     TEXT NOT NULL DEFAULT '',
+			evidence_refs       TEXT NOT NULL DEFAULT '[]',
+			started_at          INTEGER NOT NULL DEFAULT 0,
+			ended_at            INTEGER NOT NULL DEFAULT 0,
+			otel_kind           TEXT NOT NULL DEFAULT '',
+			FOREIGN KEY (chain_id) REFERENCES agent_trace_chains(chain_id) ON DELETE CASCADE,
+			FOREIGN KEY (parent_step_id) REFERENCES agent_trace_steps(step_id) ON DELETE SET NULL
+		)
+	`); err != nil {
+		t.Fatalf("create full steps: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_chains (
+			chain_id, started_at, completed_at, terminal_status, terminal_reason,
+			tmux_session, pane_id, root_agent_type, root_event_name, root_reason,
+			latest_step_kind, latest_decision, latest_step_reason, step_count, updated_at
+		) VALUES
+		('chain-full', 10, 20, 'done', 'ok', 'proj-a', '%1', 'cc', 'Stop', 'root', 'terminal', 'done', 'ok', 1, 20)
+	`); err != nil {
+		t.Fatalf("seed chain: %v", err)
+	}
+	traceID := uuid.NewString()
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_steps (
+			step_id, chain_id, parent_step_id, seq, kind, tmux_session, pane_id,
+			agent_type, frame_id, parent_frame_id, event_name, decision, reason,
+			payload_json, before_json, after_json, created_at,
+			source_kind, action, reason_code, outcome, scenario_key,
+			observed_generation, decision_ports, phase, status, watcher_token,
+			trace_id, reason_text, attrs, input_refs, output_refs,
+			state_before_ref, state_after_ref, evidence_refs,
+			started_at, ended_at, otel_kind
+		) VALUES
+		('full-1', 'chain-full', NULL, 1, 'terminal', 'proj-a', '%1', 'cc', 'frame-1', 'frame-0',
+		 'Stop', 'done', 'completed',
+		 '{"x":1}', '{"b":1}', '{"a":1}', 15,
+		 'hook', 'terminal:done', 'completed', 'emitted', 'Stop',
+		 42, '[{"port":"statusline","decision":"ok"}]', 'committed', 'success', 'watcher-123',
+		 ?, 'reason-text', '{"hook":"post"}', '[{"kind":"event"}]', '[{"kind":"frame"}]',
+		 'snap:before', 'snap:after', '[{"source":"tmux"}]',
+		 101, 102, 'internal')
+	`, traceID); err != nil {
+		t.Fatalf("seed step: %v", err)
+	}
+
+	if _, err := s.Traces(); err != nil {
+		t.Fatalf("Traces migrate: %v", err)
+	}
+
+	store := &TraceStore{db: s.db, maxChains: 10, maxSteps: 10}
+	rec, err := store.GetChainRecord("chain-full")
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	if rec == nil || len(rec.Steps) != 1 {
+		t.Fatalf("rec = %+v", rec)
+	}
+	step := rec.Steps[0]
+	// PR-1a cols.
+	if step.SourceKind != "hook" || step.Action != "terminal:done" || step.ReasonCode != "completed" ||
+		step.Outcome != "emitted" || step.ScenarioKey != "Stop" || step.Phase != "committed" || step.Status != "success" {
+		t.Fatalf("pr1a cols wrong: %+v", step)
+	}
+	if step.ObservedGeneration != 42 {
+		t.Fatalf("observed_generation = %d", step.ObservedGeneration)
+	}
+	if string(step.DecisionPorts) != `[{"port":"statusline","decision":"ok"}]` {
+		t.Fatalf("decision_ports = %s", string(step.DecisionPorts))
+	}
+	if step.WatcherToken == nil || *step.WatcherToken != "watcher-123" {
+		t.Fatalf("watcher_token = %v", step.WatcherToken)
+	}
+	// PR-1b-0 cols.
+	if step.TraceID != traceID {
+		t.Fatalf("trace_id = %q, want %q", step.TraceID, traceID)
+	}
+	if step.ReasonText != "reason-text" {
+		t.Fatalf("reason_text = %q", step.ReasonText)
+	}
+	if string(step.Attrs) != `{"hook":"post"}` {
+		t.Fatalf("attrs = %s", string(step.Attrs))
+	}
+	if string(step.InputRefs) != `[{"kind":"event"}]` || string(step.OutputRefs) != `[{"kind":"frame"}]` {
+		t.Fatalf("ref cols wrong: %s / %s", string(step.InputRefs), string(step.OutputRefs))
+	}
+	if step.StateBeforeRef != "snap:before" || step.StateAfterRef != "snap:after" {
+		t.Fatalf("state refs = %q / %q", step.StateBeforeRef, step.StateAfterRef)
+	}
+	if string(step.EvidenceRefs) != `[{"source":"tmux"}]` {
+		t.Fatalf("evidence_refs = %s", string(step.EvidenceRefs))
+	}
+	if step.StartedAt != 101 || step.EndedAt != 102 {
+		t.Fatalf("started/ended = %d/%d", step.StartedAt, step.EndedAt)
+	}
+	if step.OTelKind != "internal" {
+		t.Fatalf("otel_kind = %q", step.OTelKind)
+	}
+}
+
+// TestRebuildLegacyTraceSteps_OldSchemaOnlyStillRestores confirms the
+// pre-PR-1a legacy schema (step_name/step_index, no Lights cols) still
+// rebuilds cleanly with every Lights field left at its DEFAULT — the existing
+// TestTraceStore_MigratesLegacy* tests cover behaviour, this adds an explicit
+// assertion on the Lights defaults after rebuild.
+func TestRebuildLegacyTraceSteps_OldSchemaOnlyStillRestores(t *testing.T) {
+	s := openTestAgentEventStore(t)
+	seedLegacyTraceSchema(t, s.db)
+	seedLegacyTraceData(t, s.db)
+
+	if _, err := s.Traces(); err != nil {
+		t.Fatalf("Traces migrate: %v", err)
+	}
+
+	store := &TraceStore{db: s.db, maxChains: 10, maxSteps: 10}
+	rec, err := store.GetChainRecord("legacy-chain")
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	if rec == nil || len(rec.Steps) != 2 {
+		t.Fatalf("rec = %+v", rec)
+	}
+	for _, step := range rec.Steps {
+		if step.SourceKind != "" || step.Action != "" || step.Phase != "" || step.Status != "" ||
+			step.Outcome != "" || step.ScenarioKey != "" || step.ReasonCode != "" {
+			t.Fatalf("legacy schema rebuild must default PR-1a Lights cols, got %+v", step)
+		}
+		if step.ObservedGeneration != 0 {
+			t.Fatalf("observed_generation default = %d", step.ObservedGeneration)
+		}
+		if string(step.DecisionPorts) != `[]` {
+			t.Fatalf("decision_ports default = %s", string(step.DecisionPorts))
+		}
+		if step.WatcherToken != nil {
+			t.Fatalf("watcher_token = %v, want nil", step.WatcherToken)
+		}
+		if step.TraceID != "" || step.ReasonText != "" || step.OTelKind != "" ||
+			step.StateBeforeRef != "" || step.StateAfterRef != "" {
+			t.Fatalf("legacy schema rebuild must default PR-1b-0 envelope string cols, got %+v", step)
+		}
+		if step.StartedAt != 0 || step.EndedAt != 0 {
+			t.Fatalf("legacy schema rebuild must default envelope timestamps, got %d/%d", step.StartedAt, step.EndedAt)
+		}
+		if string(step.Attrs) != `{}` || string(step.InputRefs) != `[]` || string(step.OutputRefs) != `[]` || string(step.EvidenceRefs) != `[]` {
+			t.Fatalf("legacy schema rebuild must default PR-1b-0 json cols, got %s / %s / %s / %s",
+				string(step.Attrs), string(step.InputRefs), string(step.OutputRefs), string(step.EvidenceRefs))
+		}
+	}
+}
+
 // TestMigrateTraceDB_ResumableIfLegacyTableRemains ensures a second Traces()
 // call after a crash-interrupted migration (legacy rename committed, new table
 // not yet populated) surfaces the stale state as an error rather than silently

--- a/internal/store/trace_test.go
+++ b/internal/store/trace_test.go
@@ -381,6 +381,174 @@ func TestTraceStore_LightsRow_MissingRequiredField_Errors(t *testing.T) {
 	}
 }
 
+// TestValidateLightsRow_HybridRow_WithTraceIDButNoSourceKind_Errors covers
+// the bidirectional row-class contract: if any Lights envelope field is set
+// but source_kind is empty, the row is a hybrid and must be rejected.
+func TestValidateLightsRow_HybridRow_WithTraceIDButNoSourceKind_Errors(t *testing.T) {
+	step := TraceStep{StepID: "hybrid-1", TraceID: uuid.NewString()}
+	if err := validateLightsRow(step); err == nil {
+		t.Fatal("expected hybrid row (trace_id set, source_kind empty) to fail validation")
+	}
+}
+
+func TestValidateLightsRow_HybridRow_WithPhaseButNoSourceKind_Errors(t *testing.T) {
+	step := TraceStep{StepID: "hybrid-2", Phase: "committed"}
+	if err := validateLightsRow(step); err == nil {
+		t.Fatal("expected hybrid row (phase set, source_kind empty) to fail validation")
+	}
+}
+
+func TestValidateLightsRow_HybridRow_WithActionButNoSourceKind_Errors(t *testing.T) {
+	step := TraceStep{StepID: "hybrid-3", Action: "decision:continue"}
+	if err := validateLightsRow(step); err == nil {
+		t.Fatal("expected hybrid row (action set, source_kind empty) to fail validation")
+	}
+}
+
+func TestValidateLightsRow_PureLegacyRow_Passes(t *testing.T) {
+	step := TraceStep{StepID: "legacy-1", Kind: "decision", Reason: "ok"}
+	if err := validateLightsRow(step); err != nil {
+		t.Fatalf("pure legacy row must pass: %v", err)
+	}
+}
+
+// TestTraceStore_InvalidJSON_* covers JSON validation for the envelope JSON
+// columns (attrs / *_refs / decision_ports). SaveChain must reject both
+// malformed JSON and wrong top-level shapes (array-where-object-expected or
+// vice versa) before they reach the database.
+func TestTraceStore_InvalidJSON_Attrs_Errors(t *testing.T) {
+	rec := newLightsRecordForJSONTest()
+	rec.Steps[0].Attrs = json.RawMessage(`{invalid`)
+	store := openTestTraceStore(t)
+	if err := store.SaveChain(rec); err == nil {
+		t.Fatal("expected malformed attrs to be rejected")
+	}
+}
+
+func TestTraceStore_InvalidJSON_InputRefs_Errors(t *testing.T) {
+	rec := newLightsRecordForJSONTest()
+	rec.Steps[0].InputRefs = json.RawMessage(`[not json`)
+	store := openTestTraceStore(t)
+	if err := store.SaveChain(rec); err == nil {
+		t.Fatal("expected malformed input_refs to be rejected")
+	}
+}
+
+func TestTraceStore_WrongShape_AttrsAsArray_Errors(t *testing.T) {
+	rec := newLightsRecordForJSONTest()
+	rec.Steps[0].Attrs = json.RawMessage(`[]`)
+	store := openTestTraceStore(t)
+	if err := store.SaveChain(rec); err == nil {
+		t.Fatal("expected attrs=array to be rejected (spec: attrs is object)")
+	}
+}
+
+func TestTraceStore_WrongShape_InputRefsAsObject_Errors(t *testing.T) {
+	rec := newLightsRecordForJSONTest()
+	rec.Steps[0].InputRefs = json.RawMessage(`{}`)
+	store := openTestTraceStore(t)
+	if err := store.SaveChain(rec); err == nil {
+		t.Fatal("expected input_refs=object to be rejected (spec: *_refs is array)")
+	}
+}
+
+func TestTraceStore_WrongShape_OutputRefsAsObject_Errors(t *testing.T) {
+	rec := newLightsRecordForJSONTest()
+	rec.Steps[0].OutputRefs = json.RawMessage(`{}`)
+	store := openTestTraceStore(t)
+	if err := store.SaveChain(rec); err == nil {
+		t.Fatal("expected output_refs=object to be rejected")
+	}
+}
+
+func TestTraceStore_WrongShape_EvidenceRefsAsObject_Errors(t *testing.T) {
+	rec := newLightsRecordForJSONTest()
+	rec.Steps[0].EvidenceRefs = json.RawMessage(`{}`)
+	store := openTestTraceStore(t)
+	if err := store.SaveChain(rec); err == nil {
+		t.Fatal("expected evidence_refs=object to be rejected")
+	}
+}
+
+func TestTraceStore_WrongShape_DecisionPortsAsObject_Errors(t *testing.T) {
+	rec := newLightsRecordForJSONTest()
+	rec.Steps[0].DecisionPorts = json.RawMessage(`{}`)
+	store := openTestTraceStore(t)
+	if err := store.SaveChain(rec); err == nil {
+		t.Fatal("expected decision_ports=object to be rejected")
+	}
+}
+
+func TestTraceStore_EmptyJSONFields_DefaultApplied(t *testing.T) {
+	rec := newLightsRecordForJSONTest()
+	rec.Steps[0].Attrs = nil
+	rec.Steps[0].InputRefs = nil
+	rec.Steps[0].OutputRefs = nil
+	rec.Steps[0].EvidenceRefs = nil
+	rec.Steps[0].DecisionPorts = nil
+	store := openTestTraceStore(t)
+	if err := store.SaveChain(rec); err != nil {
+		t.Fatalf("empty JSON fields must default without error: %v", err)
+	}
+	got, err := store.GetChainRecord(rec.Chain.ChainID)
+	if err != nil || got == nil || len(got.Steps) != 1 {
+		t.Fatalf("GetChainRecord: rec=%+v err=%v", got, err)
+	}
+	step := got.Steps[0]
+	if string(step.Attrs) != `{}` {
+		t.Fatalf("attrs default = %s", string(step.Attrs))
+	}
+	if string(step.InputRefs) != `[]` || string(step.OutputRefs) != `[]` || string(step.EvidenceRefs) != `[]` {
+		t.Fatalf("refs defaults = %s/%s/%s", string(step.InputRefs), string(step.OutputRefs), string(step.EvidenceRefs))
+	}
+	if string(step.DecisionPorts) != `[]` {
+		t.Fatalf("decision_ports default = %s", string(step.DecisionPorts))
+	}
+}
+
+// newLightsRecordForJSONTest returns a fully-populated Lights record whose
+// JSON fields are valid; tests mutate one field at a time to exercise the
+// shape / validity rejection paths.
+func newLightsRecordForJSONTest() TraceRecord {
+	return TraceRecord{
+		Chain: TraceChain{
+			ChainID:        "chain-json",
+			StartedAt:      10,
+			CompletedAt:    20,
+			TerminalStatus: "done",
+			TmuxSession:    "proj-a",
+			PaneID:         "%5",
+			RootAgentType:  "cc",
+			RootEventName:  "Stop",
+		},
+		Steps: []TraceStep{
+			{
+				StepID:        "json-step-1",
+				ChainID:       "chain-json",
+				Seq:           1,
+				Kind:          "decision",
+				TmuxSession:   "proj-a",
+				PaneID:        "%5",
+				AgentType:     "cc",
+				EventName:     "Stop",
+				Decision:      "done",
+				CreatedAt:     11,
+				SourceKind:    "hook",
+				Action:        "decision:done",
+				Outcome:       "emitted",
+				Phase:         "committed",
+				Status:        "success",
+				TraceID:       "chain-json",
+				Attrs:         json.RawMessage(`{"k":"v"}`),
+				InputRefs:     json.RawMessage(`[{"kind":"event"}]`),
+				OutputRefs:    json.RawMessage(`[{"kind":"frame"}]`),
+				EvidenceRefs:  json.RawMessage(`[{"source":"tmux"}]`),
+				DecisionPorts: json.RawMessage(`[{"port":"statusline"}]`),
+			},
+		},
+	}
+}
+
 // TestTraceStore_MixedLegacyAndLightsRows confirms legacy + lights rows can
 // live in the same chain without the discriminator tripping on the legacy
 // neighbour.
@@ -741,8 +909,13 @@ func TestRebuildLegacyTraceSteps_PreservesPR1aLightsColumns(t *testing.T) {
 	if step.WatcherToken == nil || *step.WatcherToken != "watcher-123" {
 		t.Fatalf("watcher_token = %v, want watcher-123", step.WatcherToken)
 	}
-	// New PR-1b-0 cols absent from legacy table fall back to DEFAULTs.
-	if step.TraceID != "" || step.ReasonText != "" || step.StateBeforeRef != "" || step.StateAfterRef != "" || step.OTelKind != "" {
+	// trace_id is backfilled from chain_id for Lights rows (source_kind!="")
+	// so the row satisfies validateLightsRow post-migration.
+	if step.TraceID != "chain-pr1a" {
+		t.Fatalf("pr1b0 trace_id backfill = %q, want chain-pr1a", step.TraceID)
+	}
+	// Other PR-1b-0 cols absent from legacy table fall back to DEFAULTs.
+	if step.ReasonText != "" || step.StateBeforeRef != "" || step.StateAfterRef != "" || step.OTelKind != "" {
 		t.Fatalf("pr1b0 string cols must default to empty, got %+v", step)
 	}
 	if step.StartedAt != 0 || step.EndedAt != 0 {
@@ -898,6 +1071,213 @@ func TestRebuildLegacyTraceSteps_PreservesAllLightsColumnsEvenIfFullSchemaExists
 	}
 	if step.OTelKind != "internal" {
 		t.Fatalf("otel_kind = %q", step.OTelKind)
+	}
+}
+
+// TestRebuildLegacyTraceSteps_BackfillsTraceIdForPR1aLightsRows seeds a PR-1a
+// schema (17 legacy cols + 10 PR-1a Lights cols, no PR-1b-0 envelope cols) with
+// a Lights row (source_kind="hook" …) and a neighbouring legacy row. After
+// rebuild the Lights row's trace_id must be backfilled from chain_id so the
+// row satisfies validateLightsRow; the pure-legacy row's trace_id must stay
+// empty so it keeps round-tripping as a legacy row.
+func TestRebuildLegacyTraceSteps_BackfillsTraceIdForPR1aLightsRows(t *testing.T) {
+	s := openTestAgentEventStore(t)
+	if err := createTraceChainsTable(s.db); err != nil {
+		t.Fatalf("create chains: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		CREATE TABLE agent_trace_steps (
+			step_id             TEXT PRIMARY KEY,
+			chain_id            TEXT NOT NULL,
+			parent_step_id      TEXT,
+			seq                 INTEGER NOT NULL,
+			kind                TEXT NOT NULL DEFAULT '',
+			tmux_session        TEXT NOT NULL DEFAULT '',
+			pane_id             TEXT NOT NULL DEFAULT '',
+			agent_type          TEXT NOT NULL DEFAULT '',
+			frame_id            TEXT NOT NULL DEFAULT '',
+			parent_frame_id     TEXT NOT NULL DEFAULT '',
+			event_name          TEXT NOT NULL DEFAULT '',
+			decision            TEXT NOT NULL DEFAULT '',
+			reason              TEXT NOT NULL DEFAULT '',
+			payload_json        TEXT NOT NULL DEFAULT 'null',
+			before_json         TEXT NOT NULL DEFAULT 'null',
+			after_json          TEXT NOT NULL DEFAULT 'null',
+			created_at          INTEGER NOT NULL DEFAULT 0,
+			source_kind         TEXT NOT NULL DEFAULT '',
+			action              TEXT NOT NULL DEFAULT '',
+			reason_code         TEXT NOT NULL DEFAULT '',
+			outcome             TEXT NOT NULL DEFAULT '',
+			scenario_key        TEXT NOT NULL DEFAULT '',
+			observed_generation INTEGER NOT NULL DEFAULT 0,
+			decision_ports      TEXT NOT NULL DEFAULT '[]',
+			phase               TEXT NOT NULL DEFAULT '',
+			status              TEXT NOT NULL DEFAULT '',
+			watcher_token       TEXT,
+			FOREIGN KEY (chain_id) REFERENCES agent_trace_chains(chain_id) ON DELETE CASCADE,
+			FOREIGN KEY (parent_step_id) REFERENCES agent_trace_steps(step_id) ON DELETE SET NULL
+		)
+	`); err != nil {
+		t.Fatalf("create PR-1a steps: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_chains (
+			chain_id, started_at, completed_at, terminal_status, terminal_reason,
+			tmux_session, pane_id, root_agent_type, root_event_name, root_reason,
+			latest_step_kind, latest_decision, latest_step_reason, step_count, updated_at
+		) VALUES
+		('chain-backfill', 10, 20, 'done', 'ok', 'proj-a', '%1', 'cc', 'Stop', 'root', 'terminal', 'done', 'ok', 2, 20)
+	`); err != nil {
+		t.Fatalf("seed chain: %v", err)
+	}
+	// Lights row: source_kind set → trace_id should be backfilled from chain_id.
+	// Legacy row: source_kind empty → trace_id must remain empty.
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_steps (
+			step_id, chain_id, parent_step_id, seq, kind, tmux_session, pane_id,
+			agent_type, frame_id, parent_frame_id, event_name, decision, reason,
+			payload_json, before_json, after_json, created_at,
+			source_kind, action, reason_code, outcome, scenario_key,
+			observed_generation, decision_ports, phase, status, watcher_token
+		) VALUES
+		('lights-row', 'chain-backfill', NULL, 1, 'decision', 'proj-a', '%1', 'cc', 'frame-1', '',
+		 'Stop', 'done', 'completed',
+		 'null', 'null', 'null', 15,
+		 'hook', 'decision:continue', 'ready', 'emitted', 'Stop',
+		 1, '[]', 'committed', 'success', NULL),
+		('legacy-row', 'chain-backfill', 'lights-row', 2, 'terminal', 'proj-a', '%1', 'cc', 'frame-1', '',
+		 'Stop', 'done', '',
+		 'null', 'null', 'null', 16,
+		 '', '', '', '', '',
+		 0, '[]', '', '', NULL)
+	`); err != nil {
+		t.Fatalf("seed pr1a rows: %v", err)
+	}
+
+	if _, err := s.Traces(); err != nil {
+		t.Fatalf("Traces migrate: %v", err)
+	}
+
+	store := &TraceStore{db: s.db, maxChains: 10, maxSteps: 10}
+	rec, err := store.GetChainRecord("chain-backfill")
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	if rec == nil || len(rec.Steps) != 2 {
+		t.Fatalf("rec = %+v", rec)
+	}
+	var lights, legacy TraceStep
+	for _, step := range rec.Steps {
+		switch step.StepID {
+		case "lights-row":
+			lights = step
+		case "legacy-row":
+			legacy = step
+		}
+	}
+	if lights.TraceID != "chain-backfill" {
+		t.Fatalf("lights trace_id = %q, want chain-backfill (backfilled)", lights.TraceID)
+	}
+	if err := validateLightsRow(lights); err != nil {
+		t.Fatalf("migrated lights row fails validateLightsRow: %v", err)
+	}
+	if legacy.TraceID != "" {
+		t.Fatalf("legacy trace_id = %q, want empty (no backfill)", legacy.TraceID)
+	}
+	if legacy.SourceKind != "" {
+		t.Fatalf("legacy source_kind = %q, want empty", legacy.SourceKind)
+	}
+}
+
+// TestRebuildLegacyTraceSteps_LegacyRowsTraceIdStaysEmpty is a targeted
+// regression guarding the negative half of the backfill: every row in the
+// seeded table has source_kind="" so none of them are Lights rows, and the
+// rebuild must leave trace_id at the DEFAULT empty string.
+func TestRebuildLegacyTraceSteps_LegacyRowsTraceIdStaysEmpty(t *testing.T) {
+	s := openTestAgentEventStore(t)
+	if err := createTraceChainsTable(s.db); err != nil {
+		t.Fatalf("create chains: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		CREATE TABLE agent_trace_steps (
+			step_id             TEXT PRIMARY KEY,
+			chain_id            TEXT NOT NULL,
+			parent_step_id      TEXT,
+			seq                 INTEGER NOT NULL,
+			kind                TEXT NOT NULL DEFAULT '',
+			tmux_session        TEXT NOT NULL DEFAULT '',
+			pane_id             TEXT NOT NULL DEFAULT '',
+			agent_type          TEXT NOT NULL DEFAULT '',
+			frame_id            TEXT NOT NULL DEFAULT '',
+			parent_frame_id     TEXT NOT NULL DEFAULT '',
+			event_name          TEXT NOT NULL DEFAULT '',
+			decision            TEXT NOT NULL DEFAULT '',
+			reason              TEXT NOT NULL DEFAULT '',
+			payload_json        TEXT NOT NULL DEFAULT 'null',
+			before_json         TEXT NOT NULL DEFAULT 'null',
+			after_json          TEXT NOT NULL DEFAULT 'null',
+			created_at          INTEGER NOT NULL DEFAULT 0,
+			source_kind         TEXT NOT NULL DEFAULT '',
+			action              TEXT NOT NULL DEFAULT '',
+			reason_code         TEXT NOT NULL DEFAULT '',
+			outcome             TEXT NOT NULL DEFAULT '',
+			scenario_key        TEXT NOT NULL DEFAULT '',
+			observed_generation INTEGER NOT NULL DEFAULT 0,
+			decision_ports      TEXT NOT NULL DEFAULT '[]',
+			phase               TEXT NOT NULL DEFAULT '',
+			status              TEXT NOT NULL DEFAULT '',
+			watcher_token       TEXT,
+			FOREIGN KEY (chain_id) REFERENCES agent_trace_chains(chain_id) ON DELETE CASCADE,
+			FOREIGN KEY (parent_step_id) REFERENCES agent_trace_steps(step_id) ON DELETE SET NULL
+		)
+	`); err != nil {
+		t.Fatalf("create PR-1a steps: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_chains (
+			chain_id, started_at, completed_at, terminal_status, terminal_reason,
+			tmux_session, pane_id, root_agent_type, root_event_name, root_reason,
+			latest_step_kind, latest_decision, latest_step_reason, step_count, updated_at
+		) VALUES
+		('chain-legacy-only', 10, 20, 'done', 'ok', 'proj-a', '%1', 'cc', 'Stop', 'root', 'terminal', 'done', 'ok', 1, 20)
+	`); err != nil {
+		t.Fatalf("seed chain: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		INSERT INTO agent_trace_steps (
+			step_id, chain_id, parent_step_id, seq, kind, tmux_session, pane_id,
+			agent_type, frame_id, parent_frame_id, event_name, decision, reason,
+			payload_json, before_json, after_json, created_at,
+			source_kind, action, reason_code, outcome, scenario_key,
+			observed_generation, decision_ports, phase, status, watcher_token
+		) VALUES
+		('legacy-1', 'chain-legacy-only', NULL, 1, 'decision', 'proj-a', '%1', 'cc', 'frame-1', '',
+		 'Stop', 'done', 'ok',
+		 'null', 'null', 'null', 15,
+		 '', '', '', '', '',
+		 0, '[]', '', '', NULL)
+	`); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	if _, err := s.Traces(); err != nil {
+		t.Fatalf("Traces migrate: %v", err)
+	}
+
+	store := &TraceStore{db: s.db, maxChains: 10, maxSteps: 10}
+	rec, err := store.GetChainRecord("chain-legacy-only")
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	if rec == nil || len(rec.Steps) != 1 {
+		t.Fatalf("rec = %+v", rec)
+	}
+	step := rec.Steps[0]
+	if step.TraceID != "" {
+		t.Fatalf("trace_id = %q, want empty (legacy row must not be backfilled)", step.TraceID)
+	}
+	if step.SourceKind != "" {
+		t.Fatalf("source_kind = %q, want empty", step.SourceKind)
 	}
 }
 

--- a/internal/store/trace_test.go
+++ b/internal/store/trace_test.go
@@ -4,7 +4,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func strPtr(s string) *string { return &s }
@@ -23,6 +26,8 @@ func TestTraceStore_SaveAndGetChainRecord(t *testing.T) {
 	s := openTestTraceStore(t)
 	s.maxChains = 10
 	s.maxSteps = 10
+
+	traceID := uuid.NewString()
 
 	record := TraceRecord{
 		Chain: TraceChain{
@@ -68,6 +73,17 @@ func TestTraceStore_SaveAndGetChainRecord(t *testing.T) {
 				Phase:              "committed",
 				Status:             "success",
 				WatcherToken:       strPtr("watcher-abc"),
+				TraceID:            traceID,
+				ReasonText:         "ready to continue",
+				Attrs:              json.RawMessage(`{"agent_type":"cc","hook":"post"}`),
+				InputRefs:          json.RawMessage(`[{"kind":"event","id":"e1"}]`),
+				OutputRefs:         json.RawMessage(`[{"kind":"frame","id":"f1"}]`),
+				StateBeforeRef:     "snap:before",
+				StateAfterRef:      "snap:after",
+				EvidenceRefs:       json.RawMessage(`[{"source":"tmux"}]`),
+				StartedAt:          101,
+				EndedAt:            101,
+				OTelKind:           "internal",
 			},
 			{
 				StepID:             "step-2",
@@ -93,6 +109,8 @@ func TestTraceStore_SaveAndGetChainRecord(t *testing.T) {
 				ObservedGeneration: 8,
 				Phase:              "committed",
 				Status:             "success",
+				TraceID:            traceID,
+				OTelKind:           "internal",
 			},
 		},
 	}
@@ -156,13 +174,58 @@ func TestTraceStore_SaveAndGetChainRecord(t *testing.T) {
 	if second.Phase != "committed" || second.Status != "success" {
 		t.Fatalf("second step lights fields = %+v", second)
 	}
+
+	// PR-1b-0 envelope completion: the 11 new fields must round-trip on the
+	// fully populated first step and keep well-formed zero-value defaults on
+	// the sparsely populated second step.
+	if first.TraceID != traceID {
+		t.Fatalf("first TraceID = %q, want %q", first.TraceID, traceID)
+	}
+	if first.ReasonText != "ready to continue" {
+		t.Fatalf("first ReasonText = %q", first.ReasonText)
+	}
+	if string(first.Attrs) != `{"agent_type":"cc","hook":"post"}` {
+		t.Fatalf("first Attrs = %s", string(first.Attrs))
+	}
+	if string(first.InputRefs) != `[{"kind":"event","id":"e1"}]` {
+		t.Fatalf("first InputRefs = %s", string(first.InputRefs))
+	}
+	if string(first.OutputRefs) != `[{"kind":"frame","id":"f1"}]` {
+		t.Fatalf("first OutputRefs = %s", string(first.OutputRefs))
+	}
+	if first.StateBeforeRef != "snap:before" || first.StateAfterRef != "snap:after" {
+		t.Fatalf("first state refs = %q/%q", first.StateBeforeRef, first.StateAfterRef)
+	}
+	if string(first.EvidenceRefs) != `[{"source":"tmux"}]` {
+		t.Fatalf("first EvidenceRefs = %s", string(first.EvidenceRefs))
+	}
+	if first.StartedAt != 101 || first.EndedAt != 101 {
+		t.Fatalf("first started/ended = %d/%d", first.StartedAt, first.EndedAt)
+	}
+	if first.OTelKind != "internal" {
+		t.Fatalf("first OTelKind = %q", first.OTelKind)
+	}
+
+	if second.TraceID != traceID {
+		t.Fatalf("second TraceID = %q, want %q", second.TraceID, traceID)
+	}
+	if string(second.Attrs) != `{}` {
+		t.Fatalf("second Attrs default = %s, want {}", string(second.Attrs))
+	}
+	if string(second.InputRefs) != `[]` || string(second.OutputRefs) != `[]` || string(second.EvidenceRefs) != `[]` {
+		t.Fatalf("second refs default = %s/%s/%s", string(second.InputRefs), string(second.OutputRefs), string(second.EvidenceRefs))
+	}
+	if second.OTelKind != "internal" {
+		t.Fatalf("second OTelKind = %q, want internal", second.OTelKind)
+	}
 }
 
-// TestTraceStore_ZeroValueLightsFieldsRoundTrip guards the backwards-compat
-// path: older callers that do not set the new light-tracking columns must
-// still round-trip without errors. Scanned zero values must come back without
-// surfacing SQL NULL errors.
-func TestTraceStore_ZeroValueLightsFieldsRoundTrip(t *testing.T) {
+// TestTraceStore_LegacyRowZeroValueEnvelopeRoundtrip guards the row-class
+// discriminator contract (plan phase-1 #561): a step whose source_kind is
+// empty is a legacy row and is exempt from Lights envelope validation, so
+// every new spec §3.5 field is allowed to stay at its zero value without
+// surfacing SQL NULL errors or triggering validation.
+func TestTraceStore_LegacyRowZeroValueEnvelopeRoundtrip(t *testing.T) {
 	s := openTestTraceStore(t)
 	s.maxChains = 10
 	s.maxSteps = 10
@@ -191,6 +254,8 @@ func TestTraceStore_ZeroValueLightsFieldsRoundTrip(t *testing.T) {
 				EventName:   "Stop",
 				Decision:    "done",
 				CreatedAt:   11,
+				// Intentionally no SourceKind / Phase / Outcome / Action /
+				// TraceID: legacy row, discriminator must permit zero-values.
 			},
 		},
 	}
@@ -207,7 +272,10 @@ func TestTraceStore_ZeroValueLightsFieldsRoundTrip(t *testing.T) {
 		t.Fatalf("got = %+v", got)
 	}
 	step := got.Steps[0]
-	if step.SourceKind != "" || step.Action != "" || step.Phase != "" || step.Status != "" {
+	if step.SourceKind != "" {
+		t.Fatalf("legacy row SourceKind must be empty, got %q", step.SourceKind)
+	}
+	if step.Action != "" || step.Phase != "" || step.Status != "" || step.Outcome != "" {
 		t.Fatalf("zero-value lights fields corrupted: %+v", step)
 	}
 	if step.ObservedGeneration != 0 {
@@ -218,6 +286,171 @@ func TestTraceStore_ZeroValueLightsFieldsRoundTrip(t *testing.T) {
 	}
 	if step.WatcherToken != nil {
 		t.Fatalf("WatcherToken = %v, want nil", step.WatcherToken)
+	}
+	// PR-1b-0 envelope completion: legacy rows keep zero values and
+	// well-formed JSON defaults.
+	if step.TraceID != "" || step.ReasonText != "" || step.StateBeforeRef != "" || step.StateAfterRef != "" || step.OTelKind != "" {
+		t.Fatalf("legacy row envelope fields must be zero, got %+v", step)
+	}
+	if step.StartedAt != 0 || step.EndedAt != 0 {
+		t.Fatalf("legacy row started/ended = %d/%d, want 0/0", step.StartedAt, step.EndedAt)
+	}
+	if string(step.Attrs) != `{}` {
+		t.Fatalf("legacy row Attrs default = %s, want {}", string(step.Attrs))
+	}
+	if string(step.InputRefs) != `[]` || string(step.OutputRefs) != `[]` || string(step.EvidenceRefs) != `[]` {
+		t.Fatalf("legacy row refs default = %s/%s/%s", string(step.InputRefs), string(step.OutputRefs), string(step.EvidenceRefs))
+	}
+}
+
+// TestTraceStore_LightsRow_MissingRequiredField_Errors covers the negative
+// half of the row-class discriminator: once source_kind is set, required
+// envelope fields (phase/outcome/action/trace_id) must be non-empty; otherwise
+// SaveChain rejects the record with an actionable error.
+func TestTraceStore_LightsRow_MissingRequiredField_Errors(t *testing.T) {
+	base := func() TraceRecord {
+		return TraceRecord{
+			Chain: TraceChain{
+				ChainID:        "chain-lights",
+				StartedAt:      10,
+				CompletedAt:    20,
+				TerminalStatus: "done",
+				TmuxSession:    "proj-a",
+				PaneID:         "%5",
+				RootAgentType:  "cc",
+				RootEventName:  "Stop",
+			},
+			Steps: []TraceStep{
+				{
+					StepID:      "lights-1",
+					ChainID:     "chain-lights",
+					Seq:         1,
+					Kind:        "decision",
+					TmuxSession: "proj-a",
+					PaneID:      "%5",
+					AgentType:   "cc",
+					EventName:   "Stop",
+					Decision:    "done",
+					CreatedAt:   11,
+					SourceKind:  "hook",
+					Action:      "decision:done",
+					Outcome:     "emitted",
+					Phase:       "committed",
+					Status:      "success",
+					TraceID:     uuid.NewString(),
+				},
+			},
+		}
+	}
+
+	// Sanity: fully-populated lights row persists without error.
+	s := openTestTraceStore(t)
+	s.maxChains = 10
+	s.maxSteps = 10
+	if err := s.SaveChain(base()); err != nil {
+		t.Fatalf("baseline SaveChain: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		mutate   func(*TraceStep)
+		wantHint string
+	}{
+		{"missing action", func(st *TraceStep) { st.Action = "" }, "action"},
+		{"missing outcome", func(st *TraceStep) { st.Outcome = "" }, "outcome"},
+		{"missing phase", func(st *TraceStep) { st.Phase = "" }, "phase"},
+		{"missing trace_id", func(st *TraceStep) { st.TraceID = "" }, "trace_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := openTestTraceStore(t)
+			store.maxChains = 10
+			store.maxSteps = 10
+			rec := base()
+			rec.Chain.ChainID = "chain-lights-" + tc.name
+			rec.Steps[0].ChainID = rec.Chain.ChainID
+			tc.mutate(&rec.Steps[0])
+			err := store.SaveChain(rec)
+			if err == nil {
+				t.Fatalf("expected lights row validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantHint) {
+				t.Fatalf("error %q does not mention field %q", err.Error(), tc.wantHint)
+			}
+		})
+	}
+}
+
+// TestTraceStore_MixedLegacyAndLightsRows confirms legacy + lights rows can
+// live in the same chain without the discriminator tripping on the legacy
+// neighbour.
+func TestTraceStore_MixedLegacyAndLightsRows(t *testing.T) {
+	s := openTestTraceStore(t)
+	s.maxChains = 10
+	s.maxSteps = 10
+
+	traceID := uuid.NewString()
+	rec := TraceRecord{
+		Chain: TraceChain{
+			ChainID:        "chain-mixed",
+			StartedAt:      10,
+			CompletedAt:    30,
+			TerminalStatus: "done",
+			TmuxSession:    "proj-a",
+			PaneID:         "%5",
+			RootAgentType:  "cc",
+			RootEventName:  "Stop",
+		},
+		Steps: []TraceStep{
+			{
+				StepID:      "legacy-1",
+				ChainID:     "chain-mixed",
+				Seq:         1,
+				Kind:        "decision",
+				TmuxSession: "proj-a",
+				PaneID:      "%5",
+				AgentType:   "cc",
+				EventName:   "Stop",
+				Decision:    "done",
+				CreatedAt:   11,
+			},
+			{
+				StepID:       "lights-1",
+				ChainID:      "chain-mixed",
+				ParentStepID: "legacy-1",
+				Seq:          2,
+				Kind:         "terminal",
+				TmuxSession:  "proj-a",
+				PaneID:       "%5",
+				AgentType:    "cc",
+				EventName:    "Stop",
+				Decision:     "done",
+				CreatedAt:    12,
+				SourceKind:   "hook",
+				Action:       "terminal:done",
+				Outcome:      "broadcasted",
+				Phase:        "committed",
+				Status:       "success",
+				TraceID:      traceID,
+				OTelKind:     "internal",
+			},
+		},
+	}
+	if err := s.SaveChain(rec); err != nil {
+		t.Fatalf("SaveChain mixed: %v", err)
+	}
+	got, err := s.GetChainRecord("chain-mixed")
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	if len(got.Steps) != 2 {
+		t.Fatalf("steps = %d, want 2", len(got.Steps))
+	}
+	if got.Steps[0].SourceKind != "" {
+		t.Fatalf("legacy step SourceKind = %q, want empty", got.Steps[0].SourceKind)
+	}
+	if got.Steps[1].SourceKind != "hook" || got.Steps[1].TraceID != traceID {
+		t.Fatalf("lights step = %+v", got.Steps[1])
 	}
 }
 


### PR DESCRIPTION
## Summary

Lights System Phase 1 PR-1b-0（schema 完整化）：把 spec §3.5 envelope 剩餘 11 個一級欄位加入 `agent_trace_steps`，並建立「legacy row vs Lights row」row-class discriminator + validation。

- 解決 issue #560（envelope 欄位補完）+ #561（row class 區分）
- 為 PR-1b-1（Observation + Arbitrator passthrough + divergence 比對）鋪路
- 修訂 phase-1.md 將原 PR-1b 拆成 PR-1b-0 + PR-1b-1，避免一個大 PR

## Changes

### Schema（11 new columns）

| 欄位 | 型別 | default | spec 語意 |
|------|------|---------|-----------|
| `trace_id` | TEXT NOT NULL | `''` | per session per generation |
| `reason_text` | TEXT NOT NULL | `''` | 人類可讀（reason_code 為 CamelCase）|
| `attrs` | TEXT NOT NULL | `'{}'` | JSON object flat attribute map |
| `input_refs` | TEXT NOT NULL | `'[]'` | JSON array of evidence refs |
| `output_refs` | TEXT NOT NULL | `'[]'` | JSON array |
| `state_before_ref` | TEXT NOT NULL | `''` | 單一 ref id |
| `state_after_ref` | TEXT NOT NULL | `''` | 單一 ref id |
| `evidence_refs` | TEXT NOT NULL | `'[]'` | JSON array |
| `started_at` | INTEGER NOT NULL | `0` | nano epoch |
| `ended_at` | INTEGER NOT NULL | `0` | nano epoch |
| `otel_kind` | TEXT NOT NULL | `''` | OTel internal/server/client（避開現有 `kind` step 語意）|

**既有欄位複用**（不加新欄位）：
- `event_id` ↔ `step_id`（uuid 全域唯一）
- `span_id / parent_span_id` ↔ `step_id / parent_step_id`
- `name` ↔ `event_name`（PR-1b-1 由 Observation 層擴充為 `hook.post.<Event>`）
- `session_id` ↔ `tmux_session + pane_id`（既有 composite）
- `seq` ↔ `seq`

### Row class discriminator（#561 採選項 B）

- **Legacy row**: `source_kind == ""` — 允許所有 Lights 欄位 zero-value（PR-1a 以前與測試明示 legacy 路徑使用）
- **Lights row**: `source_kind != ""` — required `source_kind / phase / outcome / action / trace_id` 五欄非空，否則 `SaveChain` 拒絕
- Validation 位置：`normalizeTraceRecord()` per-step 迴圈內，tx 前 fail-fast
- Error: `lights row step <step_id> missing required field <name>`

### Hook path 填新欄位

- `trace_id = chain_id`（PR-1b-0 chain-level aliasing；PR-1b-1 Observation 自生 trace_id）
- `otel_kind = "internal"`（hook callback 是 daemon 內部事件）
- `started_at = ended_at = time.Now().UnixNano()`（atomic point event）
- `attrs = "{}"` / `*_refs = "[]"` / `state_*_ref = ""` 預設
- `reason_text = reason`（human-readable 沿用）

### Plan 修訂

`docs/superpowers/plans/2026-04-22-lights-system/phase-1.md` 將 PR-1b 拆分為：
- **PR-1b-0**（本 PR）: schema 完整化 + discriminator
- **PR-1b-1**（後續）: Observation + Arbitrator 骨架 + admission control + 雙寫 passthrough + divergence 比對

## Test plan

- [x] `go test ./... -race -count=1` 全綠（23 packages）
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` 乾淨
- [x] phase-1.md 主架構 1「PR-1b-0 補完」7 條測試全覆蓋：
  - 11 欄位 roundtrip（`TestTraceStore_SaveAndGetChainRecord` 擴充）
  - `attrs` JSON object / `*_refs` JSON array 解析正確
  - `trace_id` uuid roundtrip
  - Legacy row zero-value roundtrip（`TestTraceStore_LegacyRowZeroValueEnvelopeRoundtrip` rename 自 PR-1a 測試）
  - Lights row missing 4 required fields → error（`TestTraceStore_LightsRow_MissingRequiredField_Errors`）
  - Legacy + Lights 混合 chain roundtrip（`TestTraceStore_MixedLegacyAndLightsRows`）
  - Hook path 11 新欄位皆填（`TestHandleEvent_PersistAcceptedHookTrace` 擴充 assertion）

## Out of scope（留 PR-1b-1）

- `Observation` 型別（§3.3）
- `Arbitrator` 骨架 + channel admission control（§3.4, §3.5.1）
- `AGENT_ARB_MODE` feature flag
- 雙寫 passthrough + divergence 比對（§8.1）
- `name` 欄位擴充為 `hook.post.<Event>` qualifier
- VERSION / CHANGELOG bump（獨立 bump PR）

Closes #560
Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)