### PR TITLE
fix(spa): polish editor footer and focus behavior

### DIFF
--- a/spa/src/components/RenamePopover.tsx
+++ b/spa/src/components/RenamePopover.tsx
@@ -10,12 +10,14 @@ interface Props {
   onCancel: () => void
   error?: string
   onClearError?: () => void
+  placeholder?: string
+  validateName?: (trimmedDraft: string, currentName: string) => string | undefined
 }
 
 const POPOVER_WIDTH = 240
 const PADDING = 4
 
-export function RenamePopover({ anchorRect, currentName, onConfirm, onCancel, error, onClearError }: Props) {
+export function RenamePopover({ anchorRect, currentName, onConfirm, onCancel, error, onClearError, placeholder, validateName }: Props) {
   const t = useI18nStore((s) => s.t)
   const [draft, setDraft] = useState(currentName)
   const [submitting, setSubmitting] = useState(false)
@@ -25,9 +27,11 @@ export function RenamePopover({ anchorRect, currentName, onConfirm, onCancel, er
   useClickOutside(containerRef, onCancel)
 
   const trimmedDraft = draft.trim()
-  const validationError = trimmedDraft && trimmedDraft !== currentName && !isValidSessionName(trimmedDraft)
-    ? t('tab.rename_invalid_format')
-    : undefined
+  const validationError = validateName
+    ? validateName(trimmedDraft, currentName)
+    : (trimmedDraft && trimmedDraft !== currentName && !isValidSessionName(trimmedDraft)
+        ? t('tab.rename_invalid_format')
+        : undefined)
   const displayError = validationError ?? error
 
   // Focus + select all on mount
@@ -67,7 +71,7 @@ export function RenamePopover({ anchorRect, currentName, onConfirm, onCancel, er
     if (e.key === 'Enter') {
       e.preventDefault()
       const trimmed = draft.trim()
-      if (!trimmed || trimmed === currentName || submitting || !isValidSessionName(trimmed)) return
+      if (!trimmed || trimmed === currentName || submitting || validationError) return
       setSubmitting(true)
       onConfirm(trimmed).finally(() => setSubmitting(false))
     }
@@ -86,7 +90,7 @@ export function RenamePopover({ anchorRect, currentName, onConfirm, onCancel, er
         onChange={(e) => { setDraft(e.target.value); onClearError?.() }}
         onKeyDown={handleKeyDown}
         disabled={submitting}
-        placeholder={t('tab.rename_placeholder')}
+        placeholder={placeholder ?? t('tab.rename_placeholder')}
         className="w-full bg-surface-input border border-border-default rounded-md text-text-primary text-xs px-3 py-1.5 focus:border-border-active focus:outline-none disabled:opacity-50"
       />
       {displayError && (

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -8,6 +8,7 @@ import { MonacoWrapper } from './MonacoWrapper'
 import { DiffView } from './DiffView'
 import { EditorToolbar } from './EditorToolbar'
 import { EditorStatusBar } from './EditorStatusBar'
+import { RenamePopover } from '../RenamePopover'
 import { findPane } from '../../lib/pane-tree'
 import type { FileSource } from '../../types/fs'
 
@@ -85,8 +86,7 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
   const isMarkdown = filePath.endsWith('.md') || filePath.endsWith('.mdx')
   const editorMode = paneState?.editorMode ?? 'raw'
   const showDiff = paneState?.showDiff ?? false
-  const [isRenaming, setIsRenaming] = useState(false)
-  const [renameDraft, setRenameDraft] = useState('')
+  const [renameAnchorRect, setRenameAnchorRect] = useState<DOMRect | null>(null)
   const [renameWarning, setRenameWarning] = useState<string>()
 
   const handleCursorChange = useCallback((line: number, column: number) => {
@@ -102,8 +102,7 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
   }, [paneId, key])
 
   useEffect(() => {
-    setIsRenaming(false)
-    setRenameDraft('')
+    setRenameAnchorRect(null)
     setRenameWarning(undefined)
   }, [filePath])
 
@@ -196,19 +195,17 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
     }
   }, [filePath, key, paneId, source])
 
-  const handleRenameSubmit = useCallback(async () => {
+  const handleRenameSubmit = useCallback(async (nextName: string) => {
     const backend = getFsBackend(source)
     if (!backend) return
 
-    const nextName = renameDraft.trim()
     if (isInvalidRename(nextName)) {
       setRenameWarning('Invalid file name')
       return
     }
 
     if (nextName === fileName(filePath)) {
-      setIsRenaming(false)
-      setRenameDraft('')
+      setRenameAnchorRect(null)
       setRenameWarning(undefined)
       return
     }
@@ -234,13 +231,12 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
       await backend.rename(filePath, nextPath)
       useTabStore.getState().renameEditorPanes(source, filePath, nextPath)
       useEditorStore.getState().renameBuffer(key, nextKey, detectLanguage(nextPath))
-      setIsRenaming(false)
-      setRenameDraft('')
+      setRenameAnchorRect(null)
       setRenameWarning(undefined)
     } catch (error) {
       setRenameWarning(renameWarningMessage(error))
     }
-  }, [filePath, key, renameDraft, source])
+  }, [filePath, key, source])
 
   if (!buffer) {
     return <div className="flex-1 flex items-center justify-center text-text-muted text-xs">Loading...</div>
@@ -251,30 +247,11 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
       <EditorToolbar
         filePath={filePath}
         isDirty={buffer.isDirty}
-        isMarkdown={isMarkdown}
-        editorMode={editorMode}
         showDiff={showDiff}
-        isRenaming={isRenaming}
-        renameValue={renameDraft}
-        renameWarning={renameWarning}
         onSave={handleSave}
-        onToggleMode={isMarkdown ? () => useEditorStore.getState().setEditorMode(paneId, editorMode === 'raw' ? 'wysiwyg' : 'raw') : undefined}
         onDiff={() => useEditorStore.getState().setShowDiff(paneId, !showDiff)}
-        onRenameStart={() => {
-          setIsRenaming(true)
-          setRenameDraft(fileName(filePath))
-          setRenameWarning(undefined)
-        }}
-        onRenameChange={(value) => {
-          setRenameDraft(value)
-          if (renameWarning) setRenameWarning(undefined)
-        }}
-        onRenameSubmit={() => {
-          void handleRenameSubmit()
-        }}
-        onRenameCancel={() => {
-          setIsRenaming(false)
-          setRenameDraft('')
+        onRenameStart={(anchorRect) => {
+          setRenameAnchorRect(anchorRect)
           setRenameWarning(undefined)
         }}
       />
@@ -291,6 +268,7 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
             content={buffer.content}
             language={buffer.language}
             modelId={buffer.modelId}
+            isActive={isActive}
             initialViewState={paneState?.monacoViewState ?? null}
             onChange={(value) => useEditorStore.getState().updateContent(key, value)}
             onCursorChange={handleCursorChange}
@@ -301,6 +279,7 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
           <Suspense fallback={<div className="flex-1 flex items-center justify-center text-text-muted text-xs">Loading editor...</div>}>
             <TiptapEditor
               content={buffer.content}
+              isActive={isActive}
               onChange={(md) => useEditorStore.getState().updateContent(key, md)}
               onSave={handleSave}
             />
@@ -308,10 +287,31 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
         )}
       </div>
       <EditorStatusBar
-        language={buffer.language}
+        source={source}
         line={paneState?.cursorPosition.line ?? 1}
         column={paneState?.cursorPosition.column ?? 1}
+        isMarkdown={isMarkdown}
+        editorMode={editorMode}
+        onModeChange={(mode) => useEditorStore.getState().setEditorMode(paneId, mode)}
       />
+      {renameAnchorRect && (
+        <RenamePopover
+          anchorRect={renameAnchorRect}
+          currentName={fileName(filePath)}
+          onConfirm={handleRenameSubmit}
+          onCancel={() => {
+            setRenameAnchorRect(null)
+            setRenameWarning(undefined)
+          }}
+          error={renameWarning}
+          onClearError={() => setRenameWarning(undefined)}
+          placeholder="File name"
+          validateName={(trimmedDraft, currentName) => {
+            if (!trimmedDraft || trimmedDraft === currentName) return undefined
+            return isInvalidRename(trimmedDraft) ? 'Invalid file name' : undefined
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/spa/src/components/editor/EditorStatusBar.test.tsx
+++ b/spa/src/components/editor/EditorStatusBar.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorStatusBar } from './EditorStatusBar'
+import { useHostStore } from '../../stores/useHostStore'
+
+describe('EditorStatusBar', () => {
+  beforeEach(() => {
+    useHostStore.getState().reset()
+    const hostId = useHostStore.getState().activeHostId
+    if (hostId) {
+      useHostStore.getState().updateHost(hostId, { name: 'mlab' })
+    }
+  })
+
+  it('shows Purdex badge for in-app editor', () => {
+    render(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={17}
+        column={25}
+        isMarkdown={true}
+        editorMode="raw"
+        onModeChange={() => {}}
+      />,
+    )
+
+    const badge = screen.getByText('Purdex')
+    expect(badge.className).toContain('violet')
+    expect(screen.getByText('Ln 17, Col 25')).toBeInTheDocument()
+  })
+
+  it('shows daemon host name on the left', () => {
+    const hostId = useHostStore.getState().activeHostId!
+    render(
+      <EditorStatusBar
+        source={{ type: 'daemon', hostId }}
+        line={3}
+        column={9}
+        isMarkdown={true}
+        editorMode="raw"
+        onModeChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('mlab')).toBeInTheDocument()
+  })
+
+  it('uses Source / Live Preview labels and switches modes from the menu', () => {
+    const onModeChange = vi.fn()
+    render(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        isMarkdown={true}
+        editorMode="raw"
+        onModeChange={onModeChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByTitle('Toggle editor mode'))
+    fireEvent.click(screen.getByText('Live Preview'))
+
+    expect(onModeChange).toHaveBeenCalledWith('wysiwyg')
+  })
+
+  it('does not show mode switcher for non-markdown files', () => {
+    render(
+      <EditorStatusBar
+        source={{ type: 'local' }}
+        line={8}
+        column={4}
+        isMarkdown={false}
+        editorMode="raw"
+      />,
+    )
+
+    expect(screen.queryByTitle('Toggle editor mode')).not.toBeInTheDocument()
+    expect(screen.getByText('Ln 8, Col 4')).toBeInTheDocument()
+  })
+})

--- a/spa/src/components/editor/EditorStatusBar.tsx
+++ b/spa/src/components/editor/EditorStatusBar.tsx
@@ -1,14 +1,94 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { CaretUp } from '@phosphor-icons/react'
+import { useClickOutside } from '../../hooks/useClickOutside'
+import { useHostStore } from '../../stores/useHostStore'
+import type { FileSource } from '../../types/fs'
+
 interface Props {
-  language: string
+  source: FileSource
   line: number
   column: number
+  isMarkdown: boolean
+  editorMode: 'raw' | 'wysiwyg'
+  onModeChange?: (mode: 'raw' | 'wysiwyg') => void
 }
 
-export function EditorStatusBar({ language, line, column }: Props) {
+const EDITOR_MODE_COLORS = 'bg-blue-900/40 text-blue-400 border-blue-700/50'
+const INAPP_BADGE_COLORS = 'bg-violet-900/40 text-violet-300 border-violet-700/50'
+
+function sourceLabel(source: FileSource, hosts: Record<string, { name: string }>): { label: string; badgeClass?: string } {
+  switch (source.type) {
+    case 'inapp':
+      return { label: 'Purdex', badgeClass: INAPP_BADGE_COLORS }
+    case 'local':
+      return { label: 'Local' }
+    case 'daemon':
+      return { label: hosts[source.hostId]?.name ?? 'Unknown' }
+  }
+}
+
+export function EditorStatusBar({ source, line, column, isMarkdown, editorMode, onModeChange }: Props) {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const hosts = useHostStore((s) => s.hosts)
+  const closeMenu = useCallback(() => setMenuOpen(false), [])
+  useClickOutside(menuRef, closeMenu)
+
+  useEffect(() => {
+    if (!menuOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMenu()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [menuOpen, closeMenu])
+
+  const currentModeLabel = editorMode === 'raw' ? 'Source' : 'Live Preview'
+  const currentSource = sourceLabel(source, hosts)
+
   return (
-    <div className="flex items-center justify-between px-3 py-0.5 border-t border-border-subtle bg-surface-secondary text-[10px] text-text-muted">
-      <span>{language}</span>
-      <span>Ln {line}, Col {column}</span>
+    <div className="h-6 bg-surface-secondary border-t border-border-subtle flex items-center px-3 text-[10px] text-text-muted gap-3 flex-shrink-0 relative z-10">
+      {currentSource.badgeClass ? (
+        <span className={`px-[7px] rounded-[3px] border text-[10px] leading-4 ${currentSource.badgeClass}`}>
+          {currentSource.label}
+        </span>
+      ) : (
+        <span className="text-text-secondary select-none">{currentSource.label}</span>
+      )}
+      <span className="ml-auto flex items-center gap-3">
+        {isMarkdown && onModeChange && (
+          <div className="relative" ref={menuRef}>
+            <button
+              title="Toggle editor mode"
+              onClick={() => setMenuOpen((v) => !v)}
+              className={`flex items-center gap-1 px-2 py-0.5 rounded border text-[10px] cursor-pointer transition-colors ${EDITOR_MODE_COLORS}`}
+            >
+              {currentModeLabel}
+              <CaretUp size={10} className={`transition-transform ${menuOpen ? '' : 'rotate-180'}`} />
+            </button>
+            {menuOpen && (
+              <div className="absolute bottom-full right-0 mb-1 bg-surface-elevated border border-border-default rounded-md shadow-lg py-1 min-w-[120px]">
+                {(['raw', 'wysiwyg'] as const).map((mode) => {
+                  const label = mode === 'raw' ? 'Source' : 'Live Preview'
+                  return (
+                    <button
+                      key={mode}
+                      onClick={() => {
+                        onModeChange(mode)
+                        setMenuOpen(false)
+                      }}
+                      className={`w-full px-3 py-1 text-left text-[10px] cursor-pointer transition-colors hover:bg-surface-hover ${mode === editorMode ? 'text-white' : 'text-text-secondary'}`}
+                    >
+                      {label} {mode === editorMode && '\u2713'}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
+        <span>Ln {line}, Col {column}</span>
+      </span>
     </div>
   )
 }

--- a/spa/src/components/editor/EditorToolbar.tsx
+++ b/spa/src/components/editor/EditorToolbar.tsx
@@ -3,58 +3,29 @@ import { FloppyDisk, GitDiff } from '@phosphor-icons/react'
 interface Props {
   filePath: string
   isDirty: boolean
-  isMarkdown: boolean
-  editorMode: 'raw' | 'wysiwyg'
   showDiff?: boolean
-  isRenaming?: boolean
-  renameValue?: string
-  renameWarning?: string
   onSave: () => void
-  onToggleMode?: () => void
   onDiff?: () => void
-  onRenameStart?: () => void
-  onRenameChange?: (value: string) => void
-  onRenameSubmit?: () => void
-  onRenameCancel?: () => void
+  onRenameStart?: (anchorRect: DOMRect) => void
 }
 
-export function EditorToolbar({ filePath, isDirty, isMarkdown, editorMode, showDiff, isRenaming = false, renameValue = '', renameWarning, onSave, onToggleMode, onDiff, onRenameStart, onRenameChange, onRenameSubmit, onRenameCancel }: Props) {
+export function EditorToolbar({ filePath, isDirty, showDiff, onSave, onDiff, onRenameStart }: Props) {
   const segments = filePath.split('/').filter(Boolean)
 
   return (
     <div className="flex items-start justify-between gap-3 px-3 py-1 border-b border-border-subtle bg-surface-secondary">
-      <div className="min-w-0 flex flex-col gap-1 text-xs text-text-secondary">
-        <div className="min-w-0 flex items-center gap-2">
-          <div className="min-w-0 flex items-center gap-1 overflow-hidden" title={filePath}>
+      <div className="min-w-0 flex items-center gap-2 text-xs text-text-secondary">
+        <div className="min-w-0 flex items-center gap-1 overflow-hidden" title={filePath}>
             {filePath.startsWith('/') && <span className="shrink-0 text-text-muted">/</span>}
             {segments.map((segment, index) => {
               const isLast = index === segments.length - 1
               return (
                 <div key={`${segment}-${index}`} className="min-w-0 flex items-center gap-1">
                   {index > 0 && <span className="shrink-0 text-text-muted">/</span>}
-                  {isLast && isRenaming ? (
-                    <input
-                      autoFocus
-                      value={renameValue}
-                      onChange={(event) => onRenameChange?.(event.target.value)}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter') {
-                          event.preventDefault()
-                          onRenameSubmit?.()
-                        }
-                        if (event.key === 'Escape') {
-                          event.preventDefault()
-                          onRenameCancel?.()
-                        }
-                      }}
-                      onBlur={() => onRenameCancel?.()}
-                      aria-label="Rename file"
-                      className="min-w-0 rounded border border-border-subtle bg-surface px-1.5 py-0.5 text-text-primary outline-none"
-                    />
-                  ) : isLast && onRenameStart ? (
+                  {isLast && onRenameStart ? (
                     <button
                       type="button"
-                      onDoubleClick={onRenameStart}
+                      onDoubleClick={(event) => onRenameStart(event.currentTarget.getBoundingClientRect())}
                       className="truncate text-text-primary text-left"
                     >
                       {segment}
@@ -65,20 +36,10 @@ export function EditorToolbar({ filePath, isDirty, isMarkdown, editorMode, showD
                 </div>
               )
             })}
-          </div>
-          {isDirty && <span className="text-accent-base" title="Unsaved changes">●</span>}
         </div>
-        {renameWarning && <div role="alert" className="text-[10px] text-status-error">{renameWarning}</div>}
+        {isDirty && <span className="text-accent-base" title="Unsaved changes">●</span>}
       </div>
       <div className="flex items-center gap-1 pt-0.5">
-        {isMarkdown && onToggleMode && (
-          <button
-            onClick={onToggleMode}
-            className="px-2 py-0.5 rounded text-[10px] border border-border-subtle hover:bg-surface-hover text-text-secondary transition-colors"
-          >
-            {editorMode === 'raw' ? 'WYSIWYG' : 'Raw'}
-          </button>
-        )}
         {isDirty && onDiff && (
           <button
             onClick={onDiff}

--- a/spa/src/components/editor/MonacoWrapper.test.tsx
+++ b/spa/src/components/editor/MonacoWrapper.test.tsx
@@ -9,6 +9,7 @@ const editorMock = vi.hoisted(() => ({
   onDidChangeCursorPosition: vi.fn(),
   restoreViewState: vi.fn(),
   saveViewState: vi.fn(() => ({ scrollTop: 42 })),
+  focus: vi.fn(),
 }))
 
 vi.mock('@monaco-editor/react', () => ({
@@ -35,6 +36,7 @@ describe('MonacoWrapper', () => {
         content="hello"
         language="markdown"
         modelId="model-1"
+        isActive={true}
         initialViewState={null}
         onChange={() => {}}
         onCursorChange={() => {}}
@@ -54,6 +56,7 @@ describe('MonacoWrapper', () => {
         content="hello"
         language="markdown"
         modelId="model-1"
+        isActive={true}
         initialViewState={initialViewState}
         onChange={() => {}}
         onCursorChange={() => {}}
@@ -77,6 +80,7 @@ describe('MonacoWrapper', () => {
         content="hello"
         language="markdown"
         modelId="model-1"
+        isActive={true}
         initialViewState={null}
         onChange={() => {}}
         onCursorChange={() => {}}
@@ -90,6 +94,7 @@ describe('MonacoWrapper', () => {
         content="hello world"
         language="markdown"
         modelId="model-1"
+        isActive={true}
         initialViewState={null}
         onChange={() => {}}
         onCursorChange={() => {}}
@@ -115,6 +120,7 @@ describe('MonacoWrapper', () => {
         content="hello"
         language="markdown"
         modelId="model-1"
+        isActive={true}
         initialViewState={null}
         onChange={() => {}}
         onCursorChange={() => {}}
@@ -141,5 +147,39 @@ describe('MonacoWrapper', () => {
 
     expect(firstOnSave).not.toHaveBeenCalled()
     expect(secondOnSave).toHaveBeenCalledTimes(1)
+  })
+
+  it('focuses the editor when the pane becomes active', () => {
+    const { rerender } = render(
+      <MonacoWrapper
+        content="hello"
+        language="markdown"
+        modelId="model-1"
+        isActive={false}
+        initialViewState={null}
+        onChange={() => {}}
+        onCursorChange={() => {}}
+        onViewStateChange={() => {}}
+        onSave={() => {}}
+      />,
+    )
+
+    editorMock.focus.mockClear()
+
+    rerender(
+      <MonacoWrapper
+        content="hello"
+        language="markdown"
+        modelId="model-1"
+        isActive={true}
+        initialViewState={null}
+        onChange={() => {}}
+        onCursorChange={() => {}}
+        onViewStateChange={() => {}}
+        onSave={() => {}}
+      />,
+    )
+
+    expect(editorMock.focus).toHaveBeenCalledTimes(1)
   })
 })

--- a/spa/src/components/editor/MonacoWrapper.tsx
+++ b/spa/src/components/editor/MonacoWrapper.tsx
@@ -6,6 +6,7 @@ interface Props {
   content: string
   language: string
   modelId: string
+  isActive: boolean
   initialViewState: editor.ICodeEditorViewState | null
   onChange: (value: string) => void
   onCursorChange: (line: number, column: number) => void
@@ -13,7 +14,7 @@ interface Props {
   onSave: () => void
 }
 
-export function MonacoWrapper({ content, language, modelId, initialViewState, onChange, onCursorChange, onViewStateChange, onSave }: Props) {
+export function MonacoWrapper({ content, language, modelId, isActive, initialViewState, onChange, onCursorChange, onViewStateChange, onSave }: Props) {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
   const onSaveRef = useRef(onSave)
   const onViewStateChangeRef = useRef(onViewStateChange)
@@ -48,6 +49,11 @@ export function MonacoWrapper({ content, language, modelId, initialViewState, on
       editorRef.current = null
     }
   }, [])
+
+  useEffect(() => {
+    if (!isActive) return
+    editorRef.current?.focus()
+  }, [isActive])
 
   return (
     <Editor

--- a/spa/src/components/editor/TiptapEditor.test.tsx
+++ b/spa/src/components/editor/TiptapEditor.test.tsx
@@ -4,13 +4,14 @@ import { TiptapEditor } from './TiptapEditor'
 
 const useEditorSpy = vi.hoisted(() => vi.fn())
 const editorClassRef = vi.hoisted(() => ({ current: '' }))
+const focusSpy = vi.hoisted(() => vi.fn())
 
 vi.mock('@tiptap/react', () => ({
   useEditor: (config: { editorProps?: { attributes?: { class?: string } } }) => {
     editorClassRef.current = config.editorProps?.attributes?.class ?? ''
     return useEditorSpy(config)
   },
-  EditorContent: () => <div data-testid="editor-content" data-editor-class={editorClassRef.current} />,
+  EditorContent: () => <div data-testid="editor-content" data-editor-class={editorClassRef.current}><div data-testid="editor-editable" contentEditable={true} tabIndex={0} ref={(node) => { if (node) node.focus = focusSpy }} /></div>,
 }))
 
 vi.mock('@tiptap/starter-kit', () => ({
@@ -23,6 +24,7 @@ vi.mock('@tiptap/markdown', () => ({
 
 describe('TiptapEditor', () => {
   beforeEach(() => {
+    focusSpy.mockReset()
     useEditorSpy.mockReturnValue({
       getMarkdown: () => 'hello',
       commands: {
@@ -32,7 +34,7 @@ describe('TiptapEditor', () => {
   })
 
   it('uses a dedicated scroll container instead of putting prose on it', () => {
-    render(<TiptapEditor content="# Hello" onChange={() => {}} onSave={() => {}} />)
+    render(<TiptapEditor content="# Hello" isActive={false} onChange={() => {}} onSave={() => {}} />)
 
     const scrollRoot = screen.getByTestId('tiptap-scroll-root')
     expect(scrollRoot.className).toContain('h-full')
@@ -42,7 +44,7 @@ describe('TiptapEditor', () => {
   })
 
   it('applies typography classes to the editable root', () => {
-    render(<TiptapEditor content="# Hello" onChange={() => {}} onSave={() => {}} />)
+    render(<TiptapEditor content="# Hello" isActive={false} onChange={() => {}} onSave={() => {}} />)
 
     expect(screen.getByTestId('editor-content')).toHaveAttribute(
       'data-editor-class',
@@ -51,7 +53,7 @@ describe('TiptapEditor', () => {
   })
 
   it('keeps a visible focus style on the editable root', () => {
-    render(<TiptapEditor content="# Hello" onChange={() => {}} onSave={() => {}} />)
+    render(<TiptapEditor content="# Hello" isActive={false} onChange={() => {}} onSave={() => {}} />)
 
     expect(screen.getByTestId('editor-content')).toHaveAttribute(
       'data-editor-class',
@@ -61,5 +63,15 @@ describe('TiptapEditor', () => {
       'data-editor-class',
       expect.stringContaining('focus-visible:outline'),
     )
+  })
+
+  it('focuses the editable content when the pane becomes active', () => {
+    const { rerender } = render(<TiptapEditor content="# Hello" isActive={false} onChange={() => {}} onSave={() => {}} />)
+
+    focusSpy.mockClear()
+
+    rerender(<TiptapEditor content="# Hello" isActive={true} onChange={() => {}} onSave={() => {}} />)
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/spa/src/components/editor/TiptapEditor.tsx
+++ b/spa/src/components/editor/TiptapEditor.tsx
@@ -5,12 +5,14 @@ import { useEffect, useRef } from 'react'
 
 interface Props {
   content: string // raw markdown
+  isActive: boolean
   onChange: (markdown: string) => void
   onSave: () => void
 }
 
-export function TiptapEditor({ content, onChange, onSave }: Props) {
+export function TiptapEditor({ content, isActive, onChange, onSave }: Props) {
   const onSaveRef = useRef(onSave)
+  const containerRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     onSaveRef.current = onSave
   }, [onSave])
@@ -53,10 +55,15 @@ export function TiptapEditor({ content, onChange, onSave }: Props) {
     editor.commands.setContent(content, { emitUpdate: false, contentType: 'markdown' })
   }, [content, editor])
 
+  useEffect(() => {
+    if (!isActive) return
+    containerRef.current?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus()
+  }, [isActive])
+
   if (!editor) return null
 
   return (
-    <div data-testid="tiptap-scroll-root" className="h-full min-h-0 overflow-auto">
+    <div ref={containerRef} data-testid="tiptap-scroll-root" className="h-full min-h-0 overflow-auto">
       <div className="min-h-full [&_.tiptap-editor]:min-h-full [&_.tiptap-editor]:cursor-text">
         <EditorContent editor={editor} />
       </div>

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../../../lib/fs-backend', () => ({
 }))
 
 vi.mock('../MonacoWrapper', () => ({
-  MonacoWrapper: () => <div data-testid="monaco-wrapper" />,
+  MonacoWrapper: ({ isActive }: { isActive?: boolean }) => <div data-testid="monaco-wrapper" data-active={isActive ? 'true' : 'false'} />,
 }))
 
 vi.mock('../DiffView', () => ({
@@ -128,6 +128,54 @@ describe('EditorPane', () => {
       editorMode: 'wysiwyg',
       showDiff: true,
     })
+  })
+
+  it('uses rename popover UI instead of inline filename input', async () => {
+    const pane = createPane('/notes/rename.md')
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 11,
+      mtime: 123,
+    })
+    registerTabPane(pane)
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/rename.md')]).toBeDefined()
+    })
+
+    fireEvent.doubleClick(screen.getByText('rename.md'))
+
+    expect(screen.getByDisplayValue('rename.md')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Rename file')).not.toBeInTheDocument()
+  })
+
+  it('passes active state through to the editor content for refocus', async () => {
+    const pane = createPane('/notes/focus.md')
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 11,
+      mtime: 123,
+    })
+
+    const { rerender } = render(<EditorPane pane={pane} isActive={false} />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/focus.md')]).toBeDefined()
+    })
+
+    rerender(<EditorPane pane={pane} isActive />)
+
+    expect(screen.getByTestId('monaco-wrapper')).toHaveAttribute('data-active', 'true')
   })
 
   it('cleans up pane state when the pane is reused for non-editor content', async () => {
@@ -286,7 +334,7 @@ describe('EditorPane', () => {
     fireEvent.change(screen.getByDisplayValue('rename.md'), { target: { value: '..' } })
     fireEvent.keyDown(screen.getByDisplayValue('..'), { key: 'Enter' })
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Invalid file name')
+    expect(screen.getByText('Invalid file name')).toBeInTheDocument()
     expect(backend.rename).not.toHaveBeenCalled()
   })
 
@@ -321,7 +369,7 @@ describe('EditorPane', () => {
     fireEvent.keyDown(screen.getByDisplayValue('taken.md'), { key: 'Enter' })
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('File already exists')
+      expect(screen.getByText('File already exists')).toBeInTheDocument()
     })
 
     expect(backend.rename).not.toHaveBeenCalled()
@@ -355,7 +403,7 @@ describe('EditorPane', () => {
     fireEvent.keyDown(screen.getByDisplayValue('taken.md'), { key: 'Enter' })
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('File already exists')
+      expect(screen.getByText('File already exists')).toBeInTheDocument()
     })
 
     expect(backend.rename).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- align the editor footer with the terminal status bar by showing the source/host on the left and a blue Source/Live Preview mode switcher on the right
- switch editor filename rename to the shared popover interaction used by session rename instead of the inline input
- re-focus Monaco and Tiptap content when switching back to an editor tab and add targeted regression coverage

## Testing
- `pnpm --prefix spa exec vitest run src/components/editor/EditorStatusBar.test.tsx src/components/RenamePopover.test.tsx src/components/editor/MonacoWrapper.test.tsx src/components/editor/TiptapEditor.test.tsx src/components/editor/__tests__/EditorPane.test.tsx src/stores/useEditorStore.test.ts src/stores/useTabStore.test.ts src/stores/useTabStore.migration.test.ts`