### PR TITLE
fix(spa): hide global status bar for editor tabs

### DIFF
--- a/spa/src/components/StatusBar.test.tsx
+++ b/spa/src/components/StatusBar.test.tsx
@@ -71,6 +71,12 @@ describe('StatusBar', () => {
     expect(screen.queryByTitle('Toggle view mode')).toBeNull()
   })
 
+  it('does not render the global fallback bar for editor tabs', () => {
+    const tab = makeTab('t1', { kind: 'editor', source: { type: 'inapp' }, filePath: '/notes/a.md' })
+    const { container } = render(<StatusBar activeTab={tab} onViewModeChange={vi.fn()} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
   it('opens popup on badge click and calls onViewModeChange', () => {
     const onChange = vi.fn()
     const tab = makeTab('t1', { kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' })

--- a/spa/src/components/StatusBar.tsx
+++ b/spa/src/components/StatusBar.tsx
@@ -144,6 +144,10 @@ export function StatusBar({ activeTab, onViewModeChange, onNavigateToHost, onSta
   const primary = getPrimaryPane(activeTab.layout)
   const { content } = primary
 
+  if (content.kind === 'editor') {
+    return null
+  }
+
   if (content.kind !== 'tmux-session') {
     return (
       <div className="h-6 bg-surface-secondary border-t border-border-subtle flex items-center px-3 text-[10px] text-text-muted flex-shrink-0">

--- a/spa/src/components/editor/EditorStatusBar.tsx
+++ b/spa/src/components/editor/EditorStatusBar.tsx
@@ -56,6 +56,7 @@ export function EditorStatusBar({ source, line, column, isMarkdown, editorMode, 
         <span className="text-text-secondary select-none">{currentSource.label}</span>
       )}
       <span className="ml-auto flex items-center gap-3">
+        <span>Ln {line}, Col {column}</span>
         {isMarkdown && onModeChange && (
           <div className="relative" ref={menuRef}>
             <button
@@ -87,7 +88,6 @@ export function EditorStatusBar({ source, line, column, isMarkdown, editorMode, 
             )}
           </div>
         )}
-        <span>Ln {line}, Col {column}</span>
       </span>
     </div>
   )


### PR DESCRIPTION
## Summary
- stop rendering the global StatusBar fallback for editor tabs so the dedicated editor footer is the only bar shown
- add a regression test to lock the editor tab behavior

## Testing
- `pnpm --prefix spa exec vitest run src/components/StatusBar.test.tsx src/components/editor/EditorStatusBar.test.tsx src/components/editor/__tests__/EditorPane.test.tsx`