### PR TITLE
feat(spa): HSR PR-3 — Workspace settings shell + reserved cleanup

### DIFF
--- a/spa/src/components/SettingsPage.test.tsx
+++ b/spa/src/components/SettingsPage.test.tsx
@@ -50,7 +50,6 @@ describe('SettingsPage', () => {
     clearContributions()
     registerSettingsSection({ id: 'appearance', label: 'Appearance', order: 0, component: AppearanceSection })
     registerSettingsSection({ id: 'terminal', label: 'Terminal', order: 1, component: TerminalSection })
-    registerSettingsSection({ id: 'workspace', label: 'Workspace', order: 10 })
     registerSettingsSection({ id: 'sync', label: 'Sync', order: 11, component: SyncStub })
     dispatchSettingsContributions([])
   })

--- a/spa/src/components/settings/SettingsSidebar.test.tsx
+++ b/spa/src/components/settings/SettingsSidebar.test.tsx
@@ -17,8 +17,7 @@ describe('SettingsSidebar', () => {
     clearContributions()
     registerSettingsSection({ id: 'appearance', label: 'Appearance', order: 0, component: FakeComponent })
     registerSettingsSection({ id: 'terminal', label: 'Terminal', order: 1, component: FakeComponent })
-    registerSettingsSection({ id: 'workspace', label: 'Workspace', order: 10 })
-    registerSettingsSection({ id: 'sync', label: 'Sync', order: 11 })
+    registerSettingsSection({ id: 'sync', label: 'Sync', order: 11, component: FakeComponent })
     dispatchSettingsContributions([])
   })
 
@@ -26,7 +25,6 @@ describe('SettingsSidebar', () => {
     render(<SettingsSidebar activeSection="appearance" onSelectSection={vi.fn()} />)
     expect(screen.getByText('Appearance')).toBeTruthy()
     expect(screen.getByText('Terminal')).toBeTruthy()
-    expect(screen.getByText('Workspace')).toBeTruthy()
     expect(screen.getByText('Sync')).toBeTruthy()
   })
 
@@ -43,26 +41,18 @@ describe('SettingsSidebar', () => {
     expect(onSelect).toHaveBeenCalledWith('terminal')
   })
 
-  it('does not call onSelectSection for reserved items', () => {
-    const onSelect = vi.fn()
-    render(<SettingsSidebar activeSection="appearance" onSelectSection={onSelect} />)
-    fireEvent.click(screen.getByText('Workspace'))
-    expect(onSelect).not.toHaveBeenCalled()
-  })
-
-  it('shows coming soon badge on reserved items', () => {
-    render(<SettingsSidebar activeSection="appearance" onSelectSection={vi.fn()} />)
-    const badges = screen.getAllByText('coming soon')
-    expect(badges.length).toBe(2)
-  })
+  // PR-3 removed the reserved (coming-soon) rows entirely. These used to be
+  // registered via `registerSettingsSection({ id, label, order })` without a
+  // component — the function now throws on that shape. The
+  // "reserved items render coming-soon badge" and "reserved row click is a
+  // no-op" assertions are preserved as a disabled-by-ctx pattern test
+  // below (see F7 describe block).
 })
 
 // ---------------------------------------------------------------------------
 // F7 — honor `disabled(ctx)` + `disabledReasonKey` on active contributions.
-// Reserved (legacy `registerSettingsSection` without a component) is still
-// its own separate bucket below the divider; disabled-by-ctx rows render in
-// their natural order, styled disabled, with the reason key shown as title
-// tooltip (falls back to the key if i18n has no entry).
+// After PR-3 there is no reserved / coming-soon bucket — disabled-by-ctx
+// rows are the only non-clickable kind, rendered in their natural order.
 // ---------------------------------------------------------------------------
 
 describe('SettingsSidebar (F7: disabled-by-ctx)', () => {
@@ -97,7 +87,7 @@ describe('SettingsSidebar (F7: disabled-by-ctx)', () => {
     fireEvent.click(screen.getByText('GatedLabel'))
     expect(onSelect).not.toHaveBeenCalled()
     // `data-disabled-ctx="true"` so downstream code / tests can distinguish
-    // it from a reserved row.
+    // it from an enabled row.
     expect(row!.getAttribute('data-disabled-ctx')).toBe('true')
   })
 
@@ -158,11 +148,14 @@ describe('SettingsSidebar (F7: disabled-by-ctx)', () => {
     expect(onSelect).toHaveBeenCalledWith('plain')
   })
 
-  it('disabled-by-ctx rows appear in natural order (not grouped with reserved)', () => {
-    // reserved at order=10
-    registerSettingsSection({ id: 'reserved', label: 'Reserved', order: 10 })
-    // disabled-by-ctx active contribution at order=5 — should sort BEFORE reserved,
-    // since ordering is by `order`, not by enabled/disabled bucket.
+  it('disabled-by-ctx rows appear in natural order (sort by `order` ascending)', () => {
+    // Two active rows with a disabled-by-ctx row in between. Ordering is by
+    // `order`, not by enabled/disabled — so gated sits between the two
+    // enabled rows even though it is not clickable. The existing
+    // `appearance` row was registered + flushed by the describe-level
+    // beforeEach; we only push the two additional rows here via the direct
+    // new-registry path (avoids a second dispatch wiping the flushed
+    // `appearance` entry).
     registerSettingsContribution({
       moduleId: 'mod',
       id: 'mod.gated',
@@ -173,12 +166,21 @@ describe('SettingsSidebar (F7: disabled-by-ctx)', () => {
       component: FakeComp,
       disabled: () => true,
     })
+    registerSettingsContribution({
+      moduleId: 'mod',
+      id: 'mod.later',
+      localId: 'later',
+      scope: 'purdex',
+      order: 10,
+      labelKey: 'Later',
+      component: FakeComp,
+    })
 
     render(<SettingsSidebar activeSection="appearance" onSelectSection={vi.fn()} />)
     const labels = Array.from(document.querySelectorAll('[data-section]')).map((el) =>
       el.querySelector('span')?.textContent?.trim(),
     )
-    // order: appearance(0) → gated(5) → reserved(10)
-    expect(labels).toEqual(['Appearance', 'GatedLabel', 'Reserved'])
+    // order: appearance(0) → gated(5) → later(10)
+    expect(labels).toEqual(['Appearance', 'GatedLabel', 'Later'])
   })
 })

--- a/spa/src/components/settings/SettingsSidebar.tsx
+++ b/spa/src/components/settings/SettingsSidebar.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
 import { listContributions } from '../../lib/settings-contribution-registry'
-import { listReservedItems } from '../../lib/settings-section-registry'
 import type { SettingsContextFor } from '../../lib/settings-contribution-types'
 import { useI18nStore } from '../../stores/useI18nStore'
 
@@ -9,25 +8,20 @@ interface Props {
   onSelectSection: (section: string) => void
 }
 
-// Row shape used by the sidebar. There are three row kinds:
+// Row shape used by the sidebar. There are two row kinds after PR-3
+// (reserved `coming_soon` rows removed with the last reserved entry —
+// `workspace` — in register-modules):
 //
 //   1. Active, enabled: from `listContributions('purdex')`; clickable.
 //   2. Active, disabled-by-ctx (F7): from `listContributions('purdex')`
 //      but `disabled(ctx)` returned true. Rendered in its natural `order`
-//      slot (NOT pushed below the reserved divider), styled disabled,
-//      click is a no-op. Tooltip carries the i18n'd `disabledReasonKey`.
-//   3. Reserved (legacy coming-soon): from `listReservedItems()`. These
-//      are the rows registered via `registerSettingsSection` with no
-//      component; they stay below the divider.
-//
-// The divider sits before the first reserved row, so disabled-by-ctx rows
-// remain intermixed with enabled rows by `order`, which matches the
-// spec's "author decides ordering" rule.
+//      slot, styled disabled, click is a no-op. Tooltip carries the
+//      i18n'd `disabledReasonKey`.
 interface SidebarRow {
   id: string
   labelKey: string
   order: number
-  kind: 'active-enabled' | 'active-disabled' | 'reserved'
+  kind: 'active-enabled' | 'active-disabled'
   disabledReasonKey?: string
 }
 
@@ -41,8 +35,8 @@ export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
     [],
   )
 
-  const rows: SidebarRow[] = [
-    ...listContributions('purdex').map<SidebarRow>((c) => {
+  const rows: SidebarRow[] = listContributions('purdex')
+    .map<SidebarRow>((c) => {
       const isDisabled = c.disabled ? c.disabled(ctx) === true : false
       return {
         id: c.localId,
@@ -51,26 +45,14 @@ export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
         kind: isDisabled ? 'active-disabled' : 'active-enabled',
         disabledReasonKey: c.disabledReasonKey,
       }
-    }),
-    ...listReservedItems().map<SidebarRow>((r) => ({
-      id: r.id,
-      labelKey: r.label,
-      order: r.order,
-      kind: 'reserved',
-    })),
-  ].sort((a, b) => a.order - b.order)
-
-  // Divider sits above the first reserved row. Disabled-by-ctx rows do
-  // NOT participate in the divider pivot (they live inline with their
-  // enabled siblings).
-  const reservedStart = rows.findIndex((r) => r.kind === 'reserved')
+    })
+    .sort((a, b) => a.order - b.order)
 
   return (
     <div className="w-48 border-r border-border-subtle bg-surface-primary py-3 pl-2 flex-shrink-0">
       <div className="px-4 mb-2 text-[10px] text-text-muted uppercase tracking-wider">{t('settings.title')}</div>
-      {rows.map((row, i) => {
+      {rows.map((row) => {
         const isActive = row.id === activeSection
-        const showDivider = i === reservedStart && reservedStart > 0
         const clickable = row.kind === 'active-enabled'
         const title =
           row.kind === 'active-disabled' && row.disabledReasonKey
@@ -79,7 +61,6 @@ export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
 
         return (
           <div key={row.id}>
-            {showDivider && <div className="mx-3 my-2 border-t border-border-subtle" />}
             <button
               data-section={row.id}
               data-active={isActive ? 'true' : undefined}
@@ -97,9 +78,6 @@ export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
               }`}
             >
               <span>{t(row.labelKey)}</span>
-              {row.kind === 'reserved' && (
-                <span className="text-[10px] text-text-muted ml-auto">{t('settings.coming_soon')}</span>
-              )}
             </button>
           </div>
         )

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.registry.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.registry.test.tsx
@@ -8,6 +8,7 @@ vi.mock('../lib/icon-path-cache', () => ({
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
+import { useState } from 'react'
 import { WorkspaceSettingsPage } from './WorkspaceSettingsPage'
 import { useWorkspaceStore } from '../store'
 import {
@@ -121,7 +122,12 @@ describe('WorkspaceSettingsPage — workspace-scoped registry rendering', () => 
     expect(idxC).toBeGreaterThan(idxB)
   })
 
-  it('hides sections whose disabled(ctx) returns true (does NOT render header or body)', () => {
+  // F2 — PR-2 disabled-row pattern: header visible (data-disabled-ctx="true")
+  // but body is not mounted, and `disabledReasonKey` surfaces via the
+  // `title` attribute on the section header. Mirrors SettingsSidebar's
+  // disabled-by-ctx behavior so the workspace shell honors the same
+  // contract across scopes.
+  it('F2: renders disabled(ctx)=true sections as a disabled header, skips body, surfaces reason', () => {
     const Alive = () => <div>ALIVE_BODY</div>
     const Dead = () => <div>DEAD_BODY</div>
     registerSettingsContribution({
@@ -132,13 +138,78 @@ describe('WorkspaceSettingsPage — workspace-scoped registry rendering', () => 
       moduleId: 'm', id: 'm.dead', localId: 'dead', scope: 'workspace',
       order: 1, labelKey: 'DEAD_LABEL', component: Dead,
       disabled: () => true,
+      disabledReasonKey: 'm.dead.reason',
     })
 
     render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    // Enabled row: header + body.
     expect(screen.getByText('ALIVE_LABEL')).toBeInTheDocument()
     expect(screen.getByText('ALIVE_BODY')).toBeInTheDocument()
-    expect(screen.queryByText('DEAD_LABEL')).toBeNull()
+    // Disabled row: header present, body absent.
+    const disabledHeader = screen.getByText('DEAD_LABEL')
+    expect(disabledHeader).toBeInTheDocument()
     expect(screen.queryByText('DEAD_BODY')).toBeNull()
+    // Disabled marker exposed on the section wrapper, and title carries the
+    // (unresolved — fallback is the key itself) i18n key.
+    const section = disabledHeader.closest('[data-section]') as HTMLElement | null
+    expect(section).not.toBeNull()
+    expect(section!.getAttribute('data-disabled-ctx')).toBe('true')
+    expect(section!.getAttribute('title')).toBe('m.dead.reason')
+  })
+
+  // F1 regression — disabled() must be re-evaluated per render so reactive
+  // state changes flip the row live. The previous implementation memoized
+  // the filtered list against ctx only (stable per workspaceId), which
+  // froze the disabled state at initial mount.
+  it('F1: re-evaluates disabled(ctx) on every render (no stale memoization)', () => {
+    let gate = false
+    const Body = () => <div>REACTIVE_BODY</div>
+    registerSettingsContribution({
+      moduleId: 'r', id: 'r.main', localId: 'main', scope: 'workspace',
+      order: 0, labelKey: 'REACTIVE_LABEL', component: Body,
+      // Closure reads the live flag each invocation.
+      disabled: () => gate,
+    })
+
+    const { rerender } = render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    // Initially enabled: body mounted.
+    expect(screen.getByText('REACTIVE_BODY')).toBeInTheDocument()
+
+    // Flip the gate — simulate reactive state (store write) without
+    // changing workspaceId. A rerender must re-ask disabled(ctx).
+    gate = true
+    rerender(<WorkspaceSettingsPage workspaceId={wsId} />)
+    // Body gone, label still rendered as disabled-row.
+    expect(screen.queryByText('REACTIVE_BODY')).toBeNull()
+    expect(screen.getByText('REACTIVE_LABEL')).toBeInTheDocument()
+  })
+
+  // F4 regression — when workspaceId changes, per-section subtrees must
+  // remount so any local state seeded from ctx.workspaceId does not leak
+  // across workspaces. Keying by `${workspaceId}:${c.id}` achieves this
+  // without disturbing intra-workspace re-renders.
+  it('F4: remounts contribution subtree when workspaceId changes (no cross-workspace state leak)', () => {
+    // Captures ctx.workspaceId into local state on mount — a common pattern
+    // for contributions that want an initial value tied to the active
+    // workspace. Without a workspaceId-aware key, React reuses the same
+    // instance and the initial stays pinned to the first workspace.
+    const Stateful = ({ ctx }: { ctx: SettingsContextFor<'workspace'> }) => {
+      const [initial] = useState(ctx.workspaceId)
+      return <div data-testid="initial-ws">{initial}</div>
+    }
+    registerSettingsContribution({
+      moduleId: 'f4', id: 'f4.probe', localId: 'probe', scope: 'workspace',
+      order: 0, labelKey: 'F4_LABEL', component: Stateful,
+    })
+
+    const wsB = makeWorkspace('Second F4 WS')
+
+    const { rerender } = render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(screen.getByTestId('initial-ws').textContent).toBe(wsId)
+
+    rerender(<WorkspaceSettingsPage workspaceId={wsB} />)
+    // After workspace swap the subtree remounted → new useState seed.
+    expect(screen.getByTestId('initial-ws').textContent).toBe(wsB)
   })
 
   it('propagates workspaceId into ctx when the prop changes (re-render yields fresh ctx)', () => {

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.registry.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.registry.test.tsx
@@ -1,0 +1,182 @@
+import { vi } from 'vitest'
+
+vi.mock('../lib/icon-path-cache', () => ({
+  getIconPath: () => 'M0,0',
+  isWeightLoaded: () => true,
+  prefetchWeight: () => Promise.resolve(),
+}))
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { WorkspaceSettingsPage } from './WorkspaceSettingsPage'
+import { useWorkspaceStore } from '../store'
+import {
+  clearContributions,
+  registerSettingsContribution,
+} from '../../../lib/settings-contribution-registry'
+import type {
+  SettingsContext,
+  SettingsContextFor,
+} from '../../../lib/settings-contribution-types'
+
+// --------------------------------------------------------------------------
+// Shared harness
+// --------------------------------------------------------------------------
+
+function makeWorkspace(name = 'Test WS'): string {
+  const ws = useWorkspaceStore.getState().addWorkspace(name)
+  return ws.id
+}
+
+describe('WorkspaceSettingsPage — workspace-scoped registry rendering', () => {
+  let wsId: string
+
+  beforeEach(() => {
+    cleanup()
+    useWorkspaceStore.getState().reset()
+    clearContributions()
+    wsId = makeWorkspace('Test WS')
+  })
+
+  afterEach(() => {
+    clearContributions()
+  })
+
+  it('baseline: renders icon picker + name input + danger zone with no registry block when no workspace contributions', () => {
+    render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    // Existing page elements still render
+    expect(screen.getByDisplayValue('Test WS')).toBeInTheDocument()
+    expect(screen.getByTestId('delete-workspace-btn')).toBeInTheDocument()
+    // No registry-driven contribution present → no body labels from fake
+    expect(screen.queryByText('NO_CONTRIBUTION_MARKER')).toBeNull()
+  })
+
+  it('renders a single registered workspace-scoped contribution (label + body)', () => {
+    const Fake = () => <div>FAKE_WS_BODY</div>
+    registerSettingsContribution({
+      moduleId: 'fakews',
+      id: 'fakews.primary',
+      localId: 'primary',
+      scope: 'workspace',
+      order: 0,
+      labelKey: 'FAKE_WS_LABEL',
+      component: Fake,
+    })
+
+    render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(screen.getByText('FAKE_WS_LABEL')).toBeInTheDocument()
+    expect(screen.getByText('FAKE_WS_BODY')).toBeInTheDocument()
+  })
+
+  it('injects ctx with scope="workspace" and matching workspaceId into the contribution component', () => {
+    const captured: SettingsContext[] = []
+    const Fake = ({ ctx }: { ctx: SettingsContextFor<'workspace'> }) => {
+      captured.push(ctx)
+      return <div>CTX_BODY</div>
+    }
+    registerSettingsContribution({
+      moduleId: 'ctxprobe',
+      id: 'ctxprobe.main',
+      localId: 'main',
+      scope: 'workspace',
+      order: 0,
+      labelKey: 'CTX_LABEL',
+      component: Fake,
+    })
+
+    render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(captured.length).toBeGreaterThan(0)
+    expect(captured[0]).toEqual({ scope: 'workspace', workspaceId: wsId })
+  })
+
+  it('renders multiple contributions in ascending order (5, 10, 20)', () => {
+    const A = () => <div data-testid="body-a">A_BODY</div>
+    const B = () => <div data-testid="body-b">B_BODY</div>
+    const C = () => <div data-testid="body-c">C_BODY</div>
+
+    // Registration order deliberately unsorted to prove sorting happens.
+    registerSettingsContribution({
+      moduleId: 'mm', id: 'mm.b', localId: 'b', scope: 'workspace',
+      order: 10, labelKey: 'LABEL_B', component: B,
+    })
+    registerSettingsContribution({
+      moduleId: 'mm', id: 'mm.c', localId: 'c', scope: 'workspace',
+      order: 20, labelKey: 'LABEL_C', component: C,
+    })
+    registerSettingsContribution({
+      moduleId: 'mm', id: 'mm.a', localId: 'a', scope: 'workspace',
+      order: 5, labelKey: 'LABEL_A', component: A,
+    })
+
+    const { container } = render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    const headers = Array.from(container.querySelectorAll('h3'))
+      .map((h) => h.textContent?.trim())
+      .filter((t): t is string => t !== undefined)
+    // Labels should appear in registered-order 5 / 10 / 20 → A / B / C
+    const idxA = headers.indexOf('LABEL_A')
+    const idxB = headers.indexOf('LABEL_B')
+    const idxC = headers.indexOf('LABEL_C')
+    expect(idxA).toBeGreaterThanOrEqual(0)
+    expect(idxB).toBeGreaterThan(idxA)
+    expect(idxC).toBeGreaterThan(idxB)
+  })
+
+  it('hides sections whose disabled(ctx) returns true (does NOT render header or body)', () => {
+    const Alive = () => <div>ALIVE_BODY</div>
+    const Dead = () => <div>DEAD_BODY</div>
+    registerSettingsContribution({
+      moduleId: 'm', id: 'm.alive', localId: 'alive', scope: 'workspace',
+      order: 0, labelKey: 'ALIVE_LABEL', component: Alive,
+    })
+    registerSettingsContribution({
+      moduleId: 'm', id: 'm.dead', localId: 'dead', scope: 'workspace',
+      order: 1, labelKey: 'DEAD_LABEL', component: Dead,
+      disabled: () => true,
+    })
+
+    render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(screen.getByText('ALIVE_LABEL')).toBeInTheDocument()
+    expect(screen.getByText('ALIVE_BODY')).toBeInTheDocument()
+    expect(screen.queryByText('DEAD_LABEL')).toBeNull()
+    expect(screen.queryByText('DEAD_BODY')).toBeNull()
+  })
+
+  it('propagates workspaceId into ctx when the prop changes (re-render yields fresh ctx)', () => {
+    const captured: SettingsContext[] = []
+    const Probe = ({ ctx }: { ctx: SettingsContextFor<'workspace'> }) => {
+      captured.push(ctx)
+      return <div>PROBE_BODY</div>
+    }
+    registerSettingsContribution({
+      moduleId: 'probe', id: 'probe.main', localId: 'main', scope: 'workspace',
+      order: 0, labelKey: 'PROBE_LABEL', component: Probe,
+    })
+
+    const wsId2 = makeWorkspace('Second WS')
+
+    const { rerender } = render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(captured.at(-1)).toEqual({ scope: 'workspace', workspaceId: wsId })
+
+    rerender(<WorkspaceSettingsPage workspaceId={wsId2} />)
+    expect(captured.at(-1)).toEqual({ scope: 'workspace', workspaceId: wsId2 })
+  })
+
+  it('purdex-scoped and host-scoped contributions do NOT appear in the workspace page', () => {
+    const Purdex = () => <div>PURDEX_BODY</div>
+    const HostC = () => <div>HOST_BODY</div>
+    registerSettingsContribution({
+      moduleId: 'x', id: 'x.p', localId: 'p', scope: 'purdex',
+      order: 0, labelKey: 'PURDEX_LABEL', component: Purdex,
+    })
+    registerSettingsContribution({
+      moduleId: 'x', id: 'x.h', localId: 'h', scope: 'host',
+      order: 0, labelKey: 'HOST_LABEL', component: HostC,
+    })
+
+    render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(screen.queryByText('PURDEX_LABEL')).toBeNull()
+    expect(screen.queryByText('PURDEX_BODY')).toBeNull()
+    expect(screen.queryByText('HOST_LABEL')).toBeNull()
+    expect(screen.queryByText('HOST_BODY')).toBeNull()
+  })
+})

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
@@ -7,7 +7,10 @@ import { getPrimaryPane } from '../../../lib/pane-tree'
 import { getPaneLabel } from '../../../lib/pane-labels'
 import { closeTab } from '../../../lib/tab-lifecycle'
 import { listContributions } from '../../../lib/settings-contribution-registry'
-import type { SettingsContextFor } from '../../../lib/settings-contribution-types'
+import type {
+  SettingsContextFor,
+  SettingsContribution,
+} from '../../../lib/settings-contribution-types'
 import { WorkspaceIcon } from './WorkspaceIcon'
 
 import { WorkspaceIconPicker } from './WorkspaceIconPicker'
@@ -38,17 +41,18 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
     [workspaceId],
   )
 
-  // Registry-driven workspace-scoped contributions. `listContributions` returns
-  // a fresh array sorted by `order` ascending per call; memoize against ctx so
-  // we do not recompute on unrelated state changes. Disabled contributions are
-  // hidden entirely (plan §3.1 — hide over disabled-style).
-  const workspaceContributions = useMemo(
-    () =>
-      listContributions('workspace').filter((c) =>
-        c.disabled ? c.disabled(ctx) !== true : true,
-      ),
-    [ctx],
-  )
+  // F1: do NOT memoize the filtered/sorted list against ctx — that caches
+  // `disabled(ctx)` once per workspaceId, which freezes rows whose `disabled`
+  // closure reads reactive state (Zustand store, capability flag). N is tiny
+  // and contributions are already sorted by the registry, so re-read per
+  // render. `listContributions` returns a fresh array on each call.
+  //
+  // F2: keep disabled rows in the list — the render pass below mirrors
+  // PR-2's SettingsSidebar pattern (disabled header visible with
+  // `data-disabled-ctx="true"` + `title=disabledReasonKey`, body skipped)
+  // instead of hiding the contribution entirely.
+  const workspaceContributions: SettingsContribution<'workspace'>[] =
+    listContributions('workspace')
 
   const handleNameBlur = useCallback(() => {
     const trimmed = nameInput.trim()
@@ -124,15 +128,36 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
         {/* Module Settings */}
         <ModuleConfigSection scope={{ workspaceId }} />
 
-        {/* Registry-driven workspace-scoped contributions */}
+        {/* Registry-driven workspace-scoped contributions.
+            F2: mirror PR-2's SettingsSidebar disabled-row pattern —
+            show the header greyed with a title tooltip carrying the
+            i18n'd `disabledReasonKey`, and skip mounting the body.
+            F4: key by `${workspaceId}:${c.id}` so swapping to a different
+            workspace forces per-section remount; contributions seeding
+            local state from `ctx.workspaceId` cannot leak across
+            workspaces. */}
         {workspaceContributions.map((c) => {
+          const isDisabled = c.disabled ? c.disabled(ctx) === true : false
+          const title = isDisabled && c.disabledReasonKey
+            ? (t(c.disabledReasonKey) ?? c.disabledReasonKey)
+            : undefined
           const Body = c.component
           return (
-            <section key={c.id} className="mb-8">
-              <h3 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-3">
+            <section
+              key={`${workspaceId}:${c.id}`}
+              data-section={c.localId}
+              data-disabled-ctx={isDisabled ? 'true' : undefined}
+              title={title}
+              className="mb-8"
+            >
+              <h3
+                className={`text-xs font-semibold uppercase tracking-wider mb-3 ${
+                  isDisabled ? 'text-text-muted' : 'text-text-secondary'
+                }`}
+              >
                 {t(c.labelKey) ?? c.labelKey}
               </h3>
-              <Body ctx={ctx} />
+              {!isDisabled && <Body ctx={ctx} />}
             </section>
           )
         })}

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { Trash } from '@phosphor-icons/react'
 import { useWorkspaceStore } from '../store'
 import { useTabStore } from '../../../stores/useTabStore'
@@ -6,6 +6,8 @@ import { useI18nStore } from '../../../stores/useI18nStore'
 import { getPrimaryPane } from '../../../lib/pane-tree'
 import { getPaneLabel } from '../../../lib/pane-labels'
 import { closeTab } from '../../../lib/tab-lifecycle'
+import { listContributions } from '../../../lib/settings-contribution-registry'
+import type { SettingsContextFor } from '../../../lib/settings-contribution-types'
 import { WorkspaceIcon } from './WorkspaceIcon'
 
 import { WorkspaceIconPicker } from './WorkspaceIconPicker'
@@ -27,6 +29,26 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
 
   const [nameInput, setNameInput] = useState(ws?.name ?? '')
   const [showDelete, setShowDelete] = useState(false)
+
+  // Workspace-scoped ctx per spec §5.3 rule 4 (ctx only produced by the shell).
+  // Rebuilt whenever workspaceId changes so `disabled(ctx)` and child
+  // components see a fresh, matching entity id.
+  const ctx = useMemo<SettingsContextFor<'workspace'>>(
+    () => ({ scope: 'workspace' as const, workspaceId }),
+    [workspaceId],
+  )
+
+  // Registry-driven workspace-scoped contributions. `listContributions` returns
+  // a fresh array sorted by `order` ascending per call; memoize against ctx so
+  // we do not recompute on unrelated state changes. Disabled contributions are
+  // hidden entirely (plan §3.1 — hide over disabled-style).
+  const workspaceContributions = useMemo(
+    () =>
+      listContributions('workspace').filter((c) =>
+        c.disabled ? c.disabled(ctx) !== true : true,
+      ),
+    [ctx],
+  )
 
   const handleNameBlur = useCallback(() => {
     const trimmed = nameInput.trim()
@@ -101,6 +123,19 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
 
         {/* Module Settings */}
         <ModuleConfigSection scope={{ workspaceId }} />
+
+        {/* Registry-driven workspace-scoped contributions */}
+        {workspaceContributions.map((c) => {
+          const Body = c.component
+          return (
+            <section key={c.id} className="mb-8">
+              <h3 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-3">
+                {t(c.labelKey) ?? c.labelKey}
+              </h3>
+              <Body ctx={ctx} />
+            </section>
+          )
+        })}
 
         {/* Danger Zone */}
         <section className="border-t border-border-subtle pt-6 mt-8">

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -315,15 +315,20 @@ describe('registerBuiltinModules → new contribution registry (PR-2)', () => {
       .filter((c) => c.moduleId === '_builtin.legacy-section')
       .map((c) => c.localId)
 
-    // Core legacy set always present (no caps gating). Exact membership
-    // after PR-3 (reserved `workspace` and global `module-config` removed):
-    // appearance / terminal / interface / sync / editor-buffers.
-    // Electron / dev-environment / tmux-agent-monitor are gated by
-    // PlatformCapabilities / import.meta.env.DEV.
-    for (const id of ['appearance', 'terminal', 'interface', 'sync', 'editor-buffers']) {
+    // Core legacy set always present (no caps gating). After the F3
+    // follow-up the `module-config` global wrapper is restored (still
+    // needed while `ModuleDefinition.globalConfig` remains public —
+    // tracked by #574 for removal alongside HSR PR-5). The reserved
+    // `workspace` row stays removed (PR-3 decision 5a — nothing
+    // consumes the reserved-items plumbing and the entry itself is dead).
+    //
+    // Always-on: appearance / terminal / interface / sync / module-config /
+    // editor-buffers.  Electron / dev-environment / tmux-agent-monitor are
+    // gated by PlatformCapabilities / import.meta.env.DEV.
+    for (const id of ['appearance', 'terminal', 'interface', 'sync', 'module-config', 'editor-buffers']) {
       expect(legacyIds).toContain(id)
     }
-    expect(legacyIds.length).toBeGreaterThanOrEqual(5)
+    expect(legacyIds.length).toBeGreaterThanOrEqual(6)
   })
 
   it('PR-3: reserved workspace section is no longer registered', () => {
@@ -335,14 +340,16 @@ describe('registerBuiltinModules → new contribution registry (PR-2)', () => {
     expect(getSettingsSections().find((s) => s.id === 'workspace')).toBeUndefined()
   })
 
-  it('PR-3: global module-config section is no longer registered', () => {
+  it('F3: global module-config section is registered (restored until globalConfig deprecates — #574)', () => {
     registerBuiltinModules()
-    // Removed by PR-3: no production consumer of globalConfig; legacy
-    // workspaceConfig still renders via ModuleConfigSection inside
-    // WorkspaceSettingsPage directly.
+    // F3 follow-up restored `module-config` — removing it left
+    // `ModuleDefinition.globalConfig` API live-but-unreachable (silent
+    // dead-end). Deferred removal to HSR PR-5 tracked by #574.
     const contribs = listContributions('purdex')
-    expect(contribs.find((c) => c.localId === 'module-config')).toBeUndefined()
-    expect(getSettingsSections().find((s) => s.id === 'module-config')).toBeUndefined()
+    const entry = contribs.find((c) => c.localId === 'module-config')
+    expect(entry).toBeDefined()
+    expect(entry?.order).toBe(8)
+    expect(getSettingsSections().find((s) => s.id === 'module-config')).toBeDefined()
   })
 
   it('dispatch timing: legacy contributions survive repeated dispatches', () => {
@@ -376,15 +383,13 @@ describe('registerBuiltinModules → new contribution registry (PR-2)', () => {
   it('getSettingsSections() legacy view stays consistent with new registry', () => {
     registerBuiltinModules()
     const legacyView = getSettingsSections().map((s) => s.id)
-    // Legacy view is the filtered `_builtin.legacy-section.*` entries. After
-    // PR-3 there are no reserved entries and `module-config` is gone, so the
-    // active set returned by getSettingsSections() covers the remaining
-    // always-on built-in registerSettingsSection calls.
-    for (const id of ['appearance', 'terminal', 'interface', 'sync', 'editor-buffers']) {
+    // Legacy view is the filtered `_builtin.legacy-section.*` entries.
+    // After the F3 follow-up `module-config` is back (tracked by #574 for
+    // removal alongside globalConfig deprecation).  Reserved `workspace`
+    // stays removed.
+    for (const id of ['appearance', 'terminal', 'interface', 'sync', 'module-config', 'editor-buffers']) {
       expect(legacyView).toContain(id)
     }
-    // Removed by PR-3.
     expect(legacyView).not.toContain('workspace')
-    expect(legacyView).not.toContain('module-config')
   })
 })

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -17,7 +17,6 @@ import { clearNewTabRegistry, getNewTabProviders } from './new-tab-registry'
 import {
   clearSettingsSectionRegistry,
   getSettingsSections,
-  listReservedItems,
   registerSettingsSection,
 } from './settings-section-registry'
 import { clearInterfaceSubsectionRegistry, getInterfaceSubsections } from './interface-subsection-registry'
@@ -316,25 +315,34 @@ describe('registerBuiltinModules → new contribution registry (PR-2)', () => {
       .filter((c) => c.moduleId === '_builtin.legacy-section')
       .map((c) => c.localId)
 
-    // Core legacy set always present (no caps gating). Exact membership:
-    // appearance / terminal / interface / sync / module-config /
-    // editor-buffers. Electron / dev-environment / tmux-agent-monitor are
-    // gated by PlatformCapabilities / import.meta.env.DEV.
-    for (const id of ['appearance', 'terminal', 'interface', 'sync', 'module-config', 'editor-buffers']) {
+    // Core legacy set always present (no caps gating). Exact membership
+    // after PR-3 (reserved `workspace` and global `module-config` removed):
+    // appearance / terminal / interface / sync / editor-buffers.
+    // Electron / dev-environment / tmux-agent-monitor are gated by
+    // PlatformCapabilities / import.meta.env.DEV.
+    for (const id of ['appearance', 'terminal', 'interface', 'sync', 'editor-buffers']) {
       expect(legacyIds).toContain(id)
     }
-    expect(legacyIds.length).toBeGreaterThanOrEqual(6)
+    expect(legacyIds.length).toBeGreaterThanOrEqual(5)
   })
 
-  it('reserved workspace section stays in listReservedItems, not in the new registry', () => {
+  it('PR-3: reserved workspace section is no longer registered', () => {
     registerBuiltinModules()
-    const reserved = listReservedItems()
-    expect(reserved.map((r) => r.id)).toContain('workspace')
-    // workspace is the only reserved section shipped by register-modules today.
-    expect(reserved).toHaveLength(1)
-    // And it does NOT appear in the new registry under any moduleId.
+    // Removed by PR-3 per plan decision 5a: `workspace` was the sole reserved
+    // entry; after its removal the reserved-items plumbing has been dropped.
     const contribs = listContributions('purdex')
     expect(contribs.find((c) => c.localId === 'workspace')).toBeUndefined()
+    expect(getSettingsSections().find((s) => s.id === 'workspace')).toBeUndefined()
+  })
+
+  it('PR-3: global module-config section is no longer registered', () => {
+    registerBuiltinModules()
+    // Removed by PR-3: no production consumer of globalConfig; legacy
+    // workspaceConfig still renders via ModuleConfigSection inside
+    // WorkspaceSettingsPage directly.
+    const contribs = listContributions('purdex')
+    expect(contribs.find((c) => c.localId === 'module-config')).toBeUndefined()
+    expect(getSettingsSections().find((s) => s.id === 'module-config')).toBeUndefined()
   })
 
   it('dispatch timing: legacy contributions survive repeated dispatches', () => {
@@ -368,11 +376,15 @@ describe('registerBuiltinModules → new contribution registry (PR-2)', () => {
   it('getSettingsSections() legacy view stays consistent with new registry', () => {
     registerBuiltinModules()
     const legacyView = getSettingsSections().map((s) => s.id)
-    // Legacy view is the filtered `_builtin.legacy-section.*` entries plus
-    // reserved (component undefined) entries. The set of localIds returned
-    // should cover all the built-in registerSettingsSection calls.
-    for (const id of ['appearance', 'terminal', 'interface', 'workspace', 'sync', 'module-config', 'editor-buffers']) {
+    // Legacy view is the filtered `_builtin.legacy-section.*` entries. After
+    // PR-3 there are no reserved entries and `module-config` is gone, so the
+    // active set returned by getSettingsSections() covers the remaining
+    // always-on built-in registerSettingsSection calls.
+    for (const id of ['appearance', 'terminal', 'interface', 'sync', 'editor-buffers']) {
       expect(legacyView).toContain(id)
     }
+    // Removed by PR-3.
+    expect(legacyView).not.toContain('workspace')
+    expect(legacyView).not.toContain('module-config')
   })
 })

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -23,6 +23,7 @@ import { TerminalSection } from '../components/settings/TerminalSection'
 import { ElectronSection } from '../components/settings/ElectronSection'
 import { DevEnvironmentSection } from '../components/settings/DevEnvironmentSection'
 import { TmuxAgentMonitorSection } from '../components/settings/TmuxAgentMonitorSection'
+import { ModuleConfigSection } from '../components/settings/ModuleConfigSection'
 import { SyncSection } from '../components/settings/SyncSection'
 import { FileTreeWorkspaceView } from '../components/FileTreeView'
 import { FileTreeSessionView } from '../components/FileTreeSessionView'
@@ -273,6 +274,16 @@ export function registerBuiltinModules(): void {
     component: InterfaceSectionHost,
   })
   registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: 11, component: SyncSection })
+  // F3: retained until HSR PR-5 deprecates `ModuleDefinition.globalConfig`.
+  // Dropping this section (PR-3 commit 2) left the `globalConfig` API
+  // live-but-unreachable — any module declaring `globalConfig` had no UI
+  // surface. Removal tracked by #574.
+  registerSettingsSection({
+    id: 'module-config',
+    label: 'settings.section.modules',
+    order: 8,
+    component: () => <ModuleConfigSection scope="global" />,
+  })
   registerSettingsSection({
     id: 'editor-buffers',
     label: 'settings.section.editor_buffers',

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -23,7 +23,6 @@ import { TerminalSection } from '../components/settings/TerminalSection'
 import { ElectronSection } from '../components/settings/ElectronSection'
 import { DevEnvironmentSection } from '../components/settings/DevEnvironmentSection'
 import { TmuxAgentMonitorSection } from '../components/settings/TmuxAgentMonitorSection'
-import { ModuleConfigSection } from '../components/settings/ModuleConfigSection'
 import { SyncSection } from '../components/settings/SyncSection'
 import { FileTreeWorkspaceView } from '../components/FileTreeView'
 import { FileTreeSessionView } from '../components/FileTreeSessionView'
@@ -273,14 +272,7 @@ export function registerBuiltinModules(): void {
     order: 2,
     component: InterfaceSectionHost,
   })
-  registerSettingsSection({ id: 'workspace', label: 'settings.section.workspace', order: 10 }) // reserved
   registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: 11, component: SyncSection })
-  registerSettingsSection({
-    id: 'module-config',
-    label: 'settings.section.modules',
-    order: 8,
-    component: () => <ModuleConfigSection scope="global" />,
-  })
   registerSettingsSection({
     id: 'editor-buffers',
     label: 'settings.section.editor_buffers',

--- a/spa/src/lib/settings-contribution-smoke.test.tsx
+++ b/spa/src/lib/settings-contribution-smoke.test.tsx
@@ -1,23 +1,23 @@
 /**
- * Smoke test for HSR PR-1/PR-2: prove that the settings contribution
- * registry is wired into the Purdex shell (PR-2), and NOT yet wired into
- * the remaining two shells (HostPage — PR-4 target, WorkspaceSettingsPage
- * — PR-3 target).
+ * Smoke test for HSR PR-1/PR-2/PR-3: prove that the settings contribution
+ * registry is wired into the Purdex shell (PR-2) and the Workspace shell
+ * (PR-3), and NOT yet wired into the remaining shell (HostPage — PR-4
+ * target).
  *
  * Design rationale — Option B (static source check), preferred here:
  *
- *   The two pages below have deep coupling to app-wide state
- *   (wouter router, zustand host/workspace stores, i18n, electronAPI,
- *   plus numerous leaf components). Mounting them from cold to do a
- *   "queryByText must be null" check would require hundreds of lines
- *   of setup / mocking purely to observe the absence of a string —
- *   and would be brittle (any future i18n key collision or mock
- *   reshuffle could make the test spuriously pass).
+ *   The page below has deep coupling to app-wide state (wouter router,
+ *   zustand host store, i18n, electronAPI, plus numerous leaf
+ *   components). Mounting it from cold to do a "queryByText must be
+ *   null" check would require hundreds of lines of setup / mocking
+ *   purely to observe the absence of a string — and would be brittle
+ *   (any future i18n key collision or mock reshuffle could make the
+ *   test spuriously pass).
  *
  *   A static-source check is strictly stronger for the thing we
- *   actually want to prove: that these shells do not yet import from
- *   `settings-contribution-registry`. When PR-3 / PR-4 wire them up,
- *   those corresponding entries are removed from `PAGES`.
+ *   actually want to prove: that this shell does not yet import from
+ *   `settings-contribution-registry`. When PR-4 wires it up, the
+ *   corresponding entry is removed from `PAGES`.
  *
  *   We additionally register three fake contributions (one per scope)
  *   and verify they are queryable from the registry directly, so the
@@ -29,7 +29,6 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import hostPageSrc from '../components/HostPage.tsx?raw'
-import workspaceSettingsPageSrc from '../features/workspace/components/WorkspaceSettingsPage.tsx?raw'
 import {
   registerSettingsContribution,
   listContributions,
@@ -41,11 +40,12 @@ const FAKE_HOST_LABEL = 'SMOKE_HOST_LABEL_UNIQUE'
 const FAKE_WORKSPACE_LABEL = 'SMOKE_WORKSPACE_LABEL_UNIQUE'
 
 // HSR PR-2 migrated `src/components/SettingsPage.tsx` off this list — it
-// now reads the contribution registry directly. The remaining two shells
-// land in PR-3 (workspace) and PR-4 (host).
+// now reads the contribution registry directly. HSR PR-3 migrated
+// `src/features/workspace/components/WorkspaceSettingsPage.tsx` off this
+// list — workspace-scoped contributions now render via the registry. The
+// remaining shell lands in PR-4 (host).
 const PAGES: Array<{ name: string; src: string }> = [
   { name: 'src/components/HostPage.tsx', src: hostPageSrc },
-  { name: 'src/features/workspace/components/WorkspaceSettingsPage.tsx', src: workspaceSettingsPageSrc },
 ]
 
 function FakeComponent() {

--- a/spa/src/lib/settings-section-registry.test.ts
+++ b/spa/src/lib/settings-section-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   registerSettingsSection,
   getSettingsSections,
@@ -68,22 +68,60 @@ describe('settings-section-registry', () => {
     expect(getSettingsSections()).toHaveLength(0)
   })
 
-  // --- PR-3: reserved (component: undefined) is now a hard error -----------
+  // --- F5: reserved (component: undefined) soft-fails with a warning ------
 
-  it('PR-3: registerSettingsSection throws when component is undefined', () => {
-    // Reserved semantics were removed alongside the last reserved entry
-    // (`workspace`). A caller attempting to register a component-less
-    // section must fail loudly rather than silently buffering a coming-soon
-    // row.
-    expect(() =>
+  it('F5: registerSettingsSection with component=undefined does NOT throw', () => {
+    // Upgraded from a throw to a warn+return in the F5 follow-up. Throwing
+    // crashed `registerBuiltinModules()` at bootstrap whenever any stale
+    // caller (dev snippet, HMR leftover, parallel-session version mismatch)
+    // invoked the function without a component — killing the whole shell.
+    // Soft-fail: log a clear warning and skip the registration so the rest
+    // of the bootstrap completes.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      expect(() =>
+        registerSettingsSection({
+          id: 'ghost',
+          label: 'Ghost',
+          order: 10,
+          // @ts-expect-error — intentional misuse for the runtime guard
+          component: undefined,
+        }),
+      ).not.toThrow()
+      // Warning message must name the offending id + explain the
+      // reserved-semantics removal + suggest the replacement path.
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const msg = String(warnSpy.mock.calls[0]?.[0] ?? '')
+      expect(msg).toMatch(/settings-section-registry/)
+      expect(msg).toMatch(/id="ghost"/)
+      expect(msg).toMatch(/HSR PR-3/)
+      expect(msg).toMatch(/disabled\(ctx\)/)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('F5: warn-and-skip — nothing lands in listContributions / drain queue', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
       registerSettingsSection({
-        id: 'ghost',
-        label: 'Ghost',
-        order: 10,
+        id: 'ghost-skip',
+        label: 'Ghost Skip',
+        order: 20,
         // @ts-expect-error — intentional misuse for the runtime guard
         component: undefined,
-      }),
-    ).toThrow(/Reserved .* removed/i)
+      })
+      // Drain yields nothing for the skipped id.
+      const drained = drainLegacyContributionQueue()
+      expect(drained.find((d) => d.localId === 'ghost-skip')).toBeUndefined()
+      // Dispatch after the skip must not publish a `ghost-skip` contribution.
+      dispatchSettingsContributions([])
+      expect(
+        listContributions('purdex').find((c) => c.localId === 'ghost-skip'),
+      ).toBeUndefined()
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   // --- Pending buffer: dispatch-flushed semantics (spec §7.2) --------------

--- a/spa/src/lib/settings-section-registry.test.ts
+++ b/spa/src/lib/settings-section-registry.test.ts
@@ -4,7 +4,6 @@ import {
   getSettingsSections,
   clearSettingsSectionRegistry,
   drainLegacyContributionQueue,
-  listReservedItems,
   clearLegacyPending,
   type SettingsSectionDef,
 } from './settings-section-registry'
@@ -69,17 +68,22 @@ describe('settings-section-registry', () => {
     expect(getSettingsSections()).toHaveLength(0)
   })
 
-  it('supports reserved sections (no component) via listReservedItems', () => {
-    registerSettingsSection({ id: 'ws', label: 'Workspace', order: 10 })
-    // Reserved items are never pushed into the new registry, even after dispatch.
-    dispatchSettingsContributions([])
-    const contribs = listContributions('purdex')
-    expect(contribs.find((c) => c.localId === 'ws')).toBeUndefined()
-    const reserved = listReservedItems()
-    expect(reserved).toHaveLength(1)
-    expect(reserved[0].component).toBeUndefined()
-    // getSettingsSections() still surfaces reserved for the legacy transition API.
-    expect(getSettingsSections().find((s) => s.id === 'ws')).toBeDefined()
+  // --- PR-3: reserved (component: undefined) is now a hard error -----------
+
+  it('PR-3: registerSettingsSection throws when component is undefined', () => {
+    // Reserved semantics were removed alongside the last reserved entry
+    // (`workspace`). A caller attempting to register a component-less
+    // section must fail loudly rather than silently buffering a coming-soon
+    // row.
+    expect(() =>
+      registerSettingsSection({
+        id: 'ghost',
+        label: 'Ghost',
+        order: 10,
+        // @ts-expect-error — intentional misuse for the runtime guard
+        component: undefined,
+      }),
+    ).toThrow(/Reserved .* removed/i)
   })
 
   // --- Pending buffer: dispatch-flushed semantics (spec §7.2) --------------
@@ -140,36 +144,15 @@ describe('settings-section-registry', () => {
     expect(entry?.component).toBe(FakeComponent)
   })
 
-  it('order preservation: mixed active + reserved sort ascending via getSettingsSections', () => {
+  it('order preservation: active sections sort ascending via getSettingsSections', () => {
     registerSettingsSection(makeDef({ id: 'a', order: 0 }))
-    registerSettingsSection({ id: 'r', label: 'R', order: 10 }) // reserved
     registerSettingsSection(makeDef({ id: 'b', order: 11 }))
     registerSettingsSection(makeDef({ id: 'c', order: 2 }))
     dispatchSettingsContributions([])
-    expect(getSettingsSections().map((s) => s.id)).toEqual(['a', 'c', 'r', 'b'])
+    expect(getSettingsSections().map((s) => s.id)).toEqual(['a', 'c', 'b'])
   })
 
-  // --- Reserved buffer (Finding 6 unified policy + N1 no-accumulation) -----
-
-  it('reserved buffer: component undefined stays in reserved map, not in new registry', () => {
-    registerSettingsSection({ id: 'resv', label: 'Reserved', order: 10 })
-    dispatchSettingsContributions([])
-    expect(listContributions('purdex').find((c) => c.localId === 'resv')).toBeUndefined()
-    const reserved = listReservedItems()
-    expect(reserved.map((r) => r.id)).toEqual(['resv'])
-    expect(reserved[0].component).toBeUndefined()
-    // getSettingsSections() surfaces reserved alongside active (transition API).
-    expect(getSettingsSections().find((s) => s.id === 'resv')).toBeDefined()
-  })
-
-  it('N1 reserved upsert: re-registering same reserved id replaces, not duplicates', () => {
-    registerSettingsSection({ id: 'r1', label: 'A', order: 10 })
-    registerSettingsSection({ id: 'r1', label: 'A', order: 10 })
-    registerSettingsSection({ id: 'r1', label: 'A', order: 5 })
-    const reserved = listReservedItems()
-    expect(reserved).toHaveLength(1)
-    expect(reserved[0].order).toBe(5)
-  })
+  // --- N1: active upsert -----------------------------------------------------
 
   it('N1 active upsert: re-registering same active id replaces, dispatch yields one entry', () => {
     registerSettingsSection({ id: 'a1', label: 'L', order: 0, component: FakeComponent })
@@ -181,60 +164,11 @@ describe('settings-section-registry', () => {
     expect(getSettingsSections().find((s) => s.id === 'a1')?.component).toBe(FakeComponent2)
   })
 
-  // --- F2: reserved ↔ active cross-delete on upsert ------------------------
+  // --- HMR dispose: pending buffer clear -----------------------------------
 
-  describe('F2: reserved ↔ active cross-delete on upsert', () => {
-    it('reserved → active: second register removes the reserved entry', () => {
-      registerSettingsSection({ id: 'x', label: 'X', order: 10 }) // reserved
-      registerSettingsSection({ id: 'x', label: 'X', order: 10, component: FakeComponent }) // active
-      dispatchSettingsContributions([])
-      expect(listReservedItems().find((r) => r.id === 'x')).toBeUndefined()
-      const active = listContributions('purdex').filter((c) => c.localId === 'x')
-      expect(active).toHaveLength(1)
-    })
-
-    it('active → reserved: second register removes the active pending entry', () => {
-      registerSettingsSection({ id: 'x', label: 'X', order: 10, component: FakeComponent }) // active
-      registerSettingsSection({ id: 'x', label: 'X', order: 10 }) // reserved
-      dispatchSettingsContributions([])
-      expect(listContributions('purdex').find((c) => c.localId === 'x')).toBeUndefined()
-      const reserved = listReservedItems().filter((r) => r.id === 'x')
-      expect(reserved).toHaveLength(1)
-      expect(reserved[0].component).toBeUndefined()
-    })
-
-    it('sidebar row count for id stays at 1 across reserved ↔ active transitions', () => {
-      // reserved → active → reserved → active
-      registerSettingsSection({ id: 'x', label: 'X', order: 10 })
-      registerSettingsSection({ id: 'x', label: 'X', order: 10, component: FakeComponent })
-      registerSettingsSection({ id: 'x', label: 'X', order: 10 })
-      registerSettingsSection({ id: 'x', label: 'X', order: 10, component: FakeComponent2 })
-      dispatchSettingsContributions([])
-
-      const reserved = listReservedItems().filter((r) => r.id === 'x')
-      const active = listContributions('purdex').filter((c) => c.localId === 'x')
-      expect(reserved.length + active.length).toBe(1)
-      // Landed on active (last registration had a component).
-      expect(active).toHaveLength(1)
-    })
-
-    it('active-before-reserved drop: pending active declaration must not survive after reserved upsert', () => {
-      // Regression guard — previously the active pending entry leaked through
-      // even when the same id was later declared reserved, producing a zombie
-      // sidebar row after dispatch.
-      registerSettingsSection({ id: 'ghost', label: 'Ghost', order: 10, component: FakeComponent })
-      registerSettingsSection({ id: 'ghost', label: 'Ghost', order: 10 })
-      expect(drainLegacyContributionQueue()).toEqual([])
-    })
-  })
-
-  // --- HMR dispose: N1 double-clear guarantee ------------------------------
-
-  it('HMR dispose: clearLegacyPending clears both active pending buffer AND reserved map', () => {
-    registerSettingsSection({ id: 'resv', label: 'R', order: 10 })
+  it('HMR dispose: clearLegacyPending clears the active pending buffer', () => {
     registerSettingsSection(makeDef({ id: 'act' }))
     clearLegacyPending()
-    expect(listReservedItems()).toEqual([])
     expect(drainLegacyContributionQueue()).toEqual([])
   })
 
@@ -265,7 +199,7 @@ describe('settings-section-registry', () => {
     expect(getSettingsSections()).toEqual([])
   })
 
-  it('clear scope: clearSettingsSectionRegistry only wipes pending buffer + reserved, not other contributions', () => {
+  it('clear scope: clearSettingsSectionRegistry only wipes pending buffer, not other contributions', () => {
     // A contribution registered through the new registry directly (simulating
     // what a module declaration flush would produce).
     registerSettingsContribution({
@@ -277,17 +211,15 @@ describe('settings-section-registry', () => {
       labelKey: 'other.keep',
       component: FakeComponent,
     })
-    // Legacy pending sections.
+    // Legacy pending section.
     registerSettingsSection(makeDef({ id: 'legacy' }))
-    registerSettingsSection({ id: 'reserved', label: 'R', order: 10 })
 
     clearSettingsSectionRegistry()
 
     // New registry entry must remain.
     expect(listContributions('purdex').map((c) => c.id)).toContain('other.keep')
-    // Legacy pending drained & reserved cleared.
+    // Legacy pending drained.
     expect(drainLegacyContributionQueue()).toEqual([])
-    expect(listReservedItems()).toEqual([])
   })
 
   it('cross-id guard (F1): module-declared and legacy with same localId under same scope throws', () => {

--- a/spa/src/lib/settings-section-registry.ts
+++ b/spa/src/lib/settings-section-registry.ts
@@ -14,7 +14,7 @@ export interface SettingsSectionDef {
   id: string
   label: string
   order: number
-  component?: React.ComponentType
+  component: React.ComponentType
 }
 
 // Legacy adapter moduleId. MUST match the constant used by the dispatch
@@ -25,23 +25,24 @@ export interface SettingsSectionDef {
 const LEGACY_SECTION_MODULE_ID = '_builtin.legacy-section'
 
 // ----------------------------------------------------------------------------
-// Legacy adapter state (PR-2 §7.2 dispatch-flushed pattern)
+// Legacy adapter state (PR-2 §7.2 dispatch-flushed pattern, PR-3 trimmed)
 //
 // - `pendingLegacyContributions` — active declarations waiting for the next
 //   `dispatchSettingsContributions()` pass. Upsert by localId so HMR re-runs
 //   do not accumulate duplicates. Drained atomically by dispatch.
-// - `pendingReservedItems` — reserved sections (component: undefined). Never
-//   flow into the new registry; kept as a separate Map so the sidebar can
-//   still render coming-soon rows. Upsert by id for HMR parity.
 // - `legacyComponentMap` — reverse lookup from the ctx-wrapped component we
 //   hand the new registry back to the original author-supplied component, so
 //   `getSettingsSections()` preserves React identity (important for memo).
+//
+// Reserved (`component: undefined`) plumbing was dropped in PR-3 — the sole
+// reserved entry (`workspace`) was removed alongside the removal, so
+// `registerSettingsSection` now throws loudly on missing component rather
+// than silently buffering a coming-soon row.
 // ----------------------------------------------------------------------------
 
 type LegacyContributionDeclaration = SettingsContributionDeclaration<'purdex'>
 
 const pendingLegacyContributions = new Map<string, LegacyContributionDeclaration>()
-const pendingReservedItems = new Map<string, SettingsSectionDef>()
 const legacyComponentMap = new WeakMap<
   React.ComponentType<LegacyCtxProps>,
   React.ComponentType
@@ -62,20 +63,17 @@ function wrapLegacyComponent(
 }
 
 export function registerSettingsSection(def: SettingsSectionDef): void {
+  // PR-3: reserved semantics (`component: undefined`) have been removed. A
+  // caller trying to register a component-less section is almost certainly
+  // re-introducing the reserved-items plumbing this PR just deleted — fail
+  // loudly rather than silently dropping the row.
   if (def.component === undefined) {
-    // Reserved — never flow into the new registry. F2: also remove any
-    // stale active pending entry for the same id so a later reserved
-    // registration wins (reserved ↔ active transitions must leave only one
-    // row in the sidebar).
-    pendingLegacyContributions.delete(def.id)
-    pendingReservedItems.set(def.id, def)
-    return
+    throw new Error(
+      `settings-section-registry: registerSettingsSection("${def.id}") called with ` +
+        `component=undefined. Reserved (coming-soon) sections were removed in ` +
+        `HSR PR-3. Provide a component, or use disabled(ctx) for runtime gating.`,
+    )
   }
-
-  // F2: active registration must remove any prior reserved entry for the
-  // same id — otherwise a reserved → active transition leaves a zombie
-  // reserved row alongside the newly active one.
-  pendingReservedItems.delete(def.id)
 
   const wrapped = wrapLegacyComponent(def.component)
   const decl: LegacyContributionDeclaration = {
@@ -85,19 +83,18 @@ export function registerSettingsSection(def: SettingsSectionDef): void {
     labelKey: def.label,
     component: wrapped,
   }
-  // Upsert by localId (N1 — active also not accumulating across HMR).
+  // Upsert by localId (N1 — active not accumulating across HMR).
   pendingLegacyContributions.set(def.id, decl)
 }
 
 /**
- * Flattens the current registry view:
- *   - active entries read from the new contribution registry, filtered to
- *     legacy moduleId, restored to legacy shape via `legacyComponentMap`
- *   - reserved entries read from `pendingReservedItems`
- * merged and sorted by `order` ascending.
+ * Flattens the current registry view: active entries read from the new
+ * contribution registry, filtered to legacy moduleId, restored to legacy
+ * shape via `legacyComponentMap`; sorted by `order` ascending.
  *
- * Retained as a transitional read API for callsites not yet migrated to
- * `listContributions('purdex') + listReservedItems()` directly.
+ * Retained as a transitional read API for tests that inspect the legacy
+ * adapter pathway directly (no production callers remain). Reserved rows
+ * are no longer part of this shape — see PR-3.
  */
 export function getSettingsSections(): SettingsSectionDef[] {
   const active: SettingsSectionDef[] = []
@@ -105,25 +102,26 @@ export function getSettingsSections(): SettingsSectionDef[] {
     if (c.moduleId !== LEGACY_SECTION_MODULE_ID) continue
     active.push(toLegacyShape(c as SettingsContribution<'purdex'>))
   }
-  const reserved = Array.from(pendingReservedItems.values())
-  return [...active, ...reserved].sort((a, b) => a.order - b.order)
+  return active.sort((a, b) => a.order - b.order)
 }
 
 function toLegacyShape(c: SettingsContribution<'purdex'>): SettingsSectionDef {
   // The registered component is the ctx-taking wrapper; recover the original
   // for React identity preservation.
   const original = legacyComponentMap.get(c.component)
+  // PR-3 invariant: registerSettingsSection now refuses component-undefined,
+  // so every wrapped component in the registry maps back to a real original.
+  // Fall back to the wrapper defensively — callers inspect identity at most.
   return {
     id: c.localId,
     label: c.labelKey,
     order: c.order,
-    component: original,
+    component: original ?? (c.component as unknown as React.ComponentType),
   }
 }
 
 export function clearSettingsSectionRegistry(): void {
   pendingLegacyContributions.clear()
-  pendingReservedItems.clear()
 }
 
 /**
@@ -163,21 +161,9 @@ export function peekLegacyContributionQueue(): readonly AnySettingsContributionD
 }
 
 /**
- * Read-only snapshot of reserved sections, sorted by `order` ascending.
- * Consumed by `SettingsSidebar` to render coming-soon entries alongside
- * active contributions from `listContributions('purdex')`.
- */
-export function listReservedItems(): readonly SettingsSectionDef[] {
-  return Array.from(pendingReservedItems.values()).sort((a, b) => a.order - b.order)
-}
-
-/**
- * HMR dispose hook. Clears BOTH the active pending buffer and the reserved
- * map — required by N1 to prevent orphan reserved keys from leaking across
- * HMR boundaries (the reserved map uses upsert-by-id, but a rename of a
- * reserved section would leave its old key behind without this sweep).
+ * HMR dispose hook. Clears the active pending buffer. Reserved-map clearing
+ * was dropped in PR-3 alongside the reserved-items feature itself.
  */
 export function clearLegacyPending(): void {
   pendingLegacyContributions.clear()
-  pendingReservedItems.clear()
 }

--- a/spa/src/lib/settings-section-registry.ts
+++ b/spa/src/lib/settings-section-registry.ts
@@ -35,9 +35,10 @@ const LEGACY_SECTION_MODULE_ID = '_builtin.legacy-section'
 //   `getSettingsSections()` preserves React identity (important for memo).
 //
 // Reserved (`component: undefined`) plumbing was dropped in PR-3 — the sole
-// reserved entry (`workspace`) was removed alongside the removal, so
-// `registerSettingsSection` now throws loudly on missing component rather
-// than silently buffering a coming-soon row.
+// reserved entry (`workspace`) was removed alongside the removal. F5 follow-up
+// softened the missing-component handling from `throw` to `console.warn +
+// early return` so a stale caller (HMR leftover, version-mismatched dev
+// snippet) no longer crashes the whole shell at bootstrap.
 // ----------------------------------------------------------------------------
 
 type LegacyContributionDeclaration = SettingsContributionDeclaration<'purdex'>
@@ -63,16 +64,21 @@ function wrapLegacyComponent(
 }
 
 export function registerSettingsSection(def: SettingsSectionDef): void {
-  // PR-3: reserved semantics (`component: undefined`) have been removed. A
-  // caller trying to register a component-less section is almost certainly
-  // re-introducing the reserved-items plumbing this PR just deleted — fail
-  // loudly rather than silently dropping the row.
+  // F5: reserved semantics (`component: undefined`) have been removed, but
+  // throwing here previously crashed `registerBuiltinModules()` at bootstrap
+  // whenever any stale caller (dev-console snippet, HMR leftover, parallel-
+  // session version mismatch) hit the function without a component — which
+  // killed the whole shell. Soft-fail: log a clear warning and skip the
+  // registration so subsequent calls complete.
   if (def.component === undefined) {
-    throw new Error(
-      `settings-section-registry: registerSettingsSection("${def.id}") called with ` +
-        `component=undefined. Reserved (coming-soon) sections were removed in ` +
-        `HSR PR-3. Provide a component, or use disabled(ctx) for runtime gating.`,
+    console.warn(
+      `[settings-section-registry] registerSettingsSection called with ` +
+        `component: undefined for id="${def.id}". Reserved-row semantics were ` +
+        `removed in HSR PR-3; this registration is ignored. If you intended to ` +
+        `declare a disabled contribution, use ModuleDefinition.settings with ` +
+        `disabled(ctx) returning true instead.`,
     )
+    return
   }
 
   const wrapped = wrapLegacyComponent(def.component)

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -14,7 +14,6 @@
   "settings.coming_soon": "coming soon",
   "settings.section.appearance": "Appearance",
   "settings.section.terminal": "Terminal",
-  "settings.section.workspace": "Workspace",
   "settings.section.sync": "Sync",
   "settings.sync.description": "Synchronise settings and workspaces across devices.",
   "settings.sync.provider.label": "Provider",
@@ -131,7 +130,6 @@
   "settings.interface.palette_unavailable": "unavailable here",
   "settings.interface.canvas_drop_here": "Drop module here",
   "settings.section.agent": "Agent",
-  "settings.section.modules": "Modules",
   "settings.section.editor_buffers": "Editor Buffers",
 
   "settings.agent.title": "Agent",

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -15,6 +15,7 @@
   "settings.section.appearance": "Appearance",
   "settings.section.terminal": "Terminal",
   "settings.section.sync": "Sync",
+  "settings.section.modules": "Modules",
   "settings.sync.description": "Synchronise settings and workspaces across devices.",
   "settings.sync.provider.label": "Provider",
   "settings.sync.provider.description": "Select where sync data is stored and exchanged.",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -14,7 +14,6 @@
   "settings.coming_soon": "即將推出",
   "settings.section.appearance": "外觀",
   "settings.section.terminal": "終端機",
-  "settings.section.workspace": "工作區",
   "settings.section.sync": "同步",
   "settings.sync.description": "在多裝置之間同步設定與工作區。",
   "settings.sync.provider.label": "提供者",
@@ -131,7 +130,6 @@
   "settings.interface.palette_unavailable": "此環境不可用",
   "settings.interface.canvas_drop_here": "拖曳 module 到此",
   "settings.section.agent": "Agent",
-  "settings.section.modules": "模組",
   "settings.section.editor_buffers": "編輯器暫存",
 
   "settings.agent.title": "Agent",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -15,6 +15,7 @@
   "settings.section.appearance": "外觀",
   "settings.section.terminal": "終端機",
   "settings.section.sync": "同步",
+  "settings.section.modules": "模組",
   "settings.sync.description": "在多裝置之間同步設定與工作區。",
   "settings.sync.provider.label": "提供者",
   "settings.sync.provider.description": "選擇同步資料的儲存與交換位置。",


### PR DESCRIPTION
## Summary

Implements HSR PR-3 per plan \`docs/specs/2026-04-22-hsr-pr3-workspace-shell-plan.md\` (v3). Follow-up to PR-2 (#558).

- \`WorkspaceSettingsPage\` inserts a registry-driven section below \`ModuleConfigSection\`, reading \`listContributions('workspace')\` sorted by \`order\`. Each contribution receives \`ctx: { scope: 'workspace', workspaceId }\` per spec §5.3 rule 4. \`disabled(ctx)\` → section hidden.
- \`register-modules.tsx\` drops reserved \`workspace\` section + \`module-config\` global wrapper (no production \`globalConfig\` consumer).
- \`SettingsSidebar\` simplified: \`listReservedItems()\` call + \`reservedStart\` divider + coming_soon styling removed (dead code after reserved cleanup). F7 disabled-by-ctx from PR-2 retained.
- \`settings-section-registry\` drops \`pendingReservedItems\` Map + \`listReservedItems\` export + reserved branch of \`registerSettingsSection\` (aggressive drop — function now throws on \`component === undefined\` with a message pointing at HSR PR-3, so revival attempts fail loudly).
- Closes workspace milestone of #538.

## Commits

| # | SHA | Subject |
|---|---|---|
| 1 | \`9b6d20cc\` | feat(spa): WorkspaceSettingsPage renders workspace-scoped contributions |
| 2 | \`9a82ed1a\` | refactor(spa): drop reserved workspace and module-config sections |

## Design decisions (documented in commits)

- **\`getSettingsSections()\` kept** (transitional) — only test callers remain; removal cascades into ~10 test rewrites with no prod benefit in this PR. Follow-up cleanup when the legacy adapter is fully dismantled.
- **Reserved plumbing: aggressive drop** — \`registerSettingsSection({ component: undefined })\` now throws, not silently ignored. Fails loudly if anyone tries to revive reserved semantics.
- **i18n keys removed**: \`settings.section.workspace\`, \`settings.section.modules\` (zero other callsites confirmed by grep).
- **i18n keys kept**: \`settings.coming_soon\` (still referenced by \`InterfaceSubNav\` for unrelated subsections).

## Remaining built-in sections

After cleanup, \`register-modules.tsx\` registers 5 always-on (\`appearance / terminal / interface / sync / editor-buffers\`) + 3 conditional (\`electron\` / \`dev-environment\` / \`tmux-agent-monitor\` per caps + DEV).

## Test plan

- [x] \`pnpm exec vitest run\`: 2474 passed / 3 failed. The 3 failures are the documented \`src/lib/sync/contributors/hosts.test.ts\` token-preservation baseline (pre-existing on \`origin/main@10100eb4\`, unrelated).
- [x] \`pnpm run lint\`: clean (0 errors, 2 pre-existing warnings in \`EditorPane.tsx\` unrelated to this PR).
- [ ] \`pnpm run build\`: **fails on pre-existing baseline** — \`MonacoWrapper.test.tsx:133\` missing \`isActive\` prop, introduced by PR #570. Tracked as **#572**. Not in PR-3 scope; fix should land as a separate tiny baseline PR before PR-4.
- [ ] Manual visual regression: open workspace → workspace settings tab; verify icon picker + name input + \`ModuleConfigSection\` + danger zone still render; no "Workspace" reserved divider; no "Modules" item. (Will run locally.)

## Out of scope (follows later)

- PR-4: HostPage shell registry-driven (#541 cross-store rehydrate harness)
- PR-5: Editor module declares \`workspaceHomePath\` + \`hostHomePath\` settings + LinkContext plumbing (first real use of this shell)
- #538 (smoke) / #539 (internal) / #540 (store snapshot) / #541 — follow subsequent PRs
- #572 baseline build fix — separate baseline PR

## Review

Will run 2-round codex review (standard + 3-way adversarial).