### PR TITLE
feat(lights): PR-1b-1a — Observation types + AGENT_ARB_MODE + trace_id strategy

### DIFF
--- a/docs/superpowers/plans/2026-04-22-lights-system/phase-1.md
+++ b/docs/superpowers/plans/2026-04-22-lights-system/phase-1.md
@@ -2,16 +2,21 @@
 
 > Spec 對照：§3.3、§3.4、§3.5、§3.5.1、§8.1
 > 依賴：Phase 0
-> PR：PR-1a（schema baseline）+ **PR-1b-0（schema 補完 + discriminator）** + **PR-1b-1（observation passthrough）**
+> PR：PR-1a ✅ + PR-1b-0 ✅ + **PR-1b-1a**（Observation 型別 + flag + trace_id）+ **PR-1b-1b**（Arbitrator + admission）+ **PR-1b-1c**（passthrough + divergence + API 穿透）
 
 在不改變使用者可見行為的前提下，把新 trace schema 鋪到 SQLite，讓 hook / probe / sweep 在維持直寫 frame 的同時把同一事件轉成 `Observation` 送進 Arbitrator 的 passthrough 路徑。Arbitrator 此階段只計算 proposal、下投影到舊 schema 與 direct-write frame 比對，差異寫入 `frame_divergences`。這是 Phase 2 切換 writer 前的觀察視窗，上線後至少留一個 alpha bump 週期收集 divergence。
 
 ## PR 拆分修訂（2026-04-22）
 
-PR-1a merge 後 review 發現 §3.5 envelope 欄位仍缺 12 個（#560）、legacy vs Lights row 無區分契約（#561）。原 PR-1b 範圍（Observation + Arbitrator + divergence passthrough）需這兩個前置條件。**拆分**：
+PR-1a merge 後 review 發現 §3.5 envelope 欄位仍缺 12 個（#560）、legacy vs Lights row 無區分契約（#561）。原 PR-1b 範圍（Observation + Arbitrator + divergence passthrough）需這兩個前置條件。**初次拆分**：
 
-- **PR-1b-0**：envelope schema 補完（#560）+ row 類別 discriminator（#561）— 中等大小 schema PR
-- **PR-1b-1**：Observation 型別 + Arbitrator 骨架 + channel admission + 雙寫 passthrough + divergence 比對 — 大型 PR（原 PR-1b 範圍）
+- **PR-1b-0** ✅（#564，alpha.202）：envelope schema 補完（#560）+ row 類別 discriminator（#561）
+
+**PR-1b-1 二次拆分（2026-04-22 夜）** — 原 plan 2000-3000 LOC 過大，且 PR-1a + PR-1b-0 累計 8 commit / 9 輪 review 導致 reviewer 疲勞；拆成 3 段，每段 600-1200 LOC，review 可聚焦單一主題：
+
+- **PR-1b-1a**（~600 LOC）：Observation 型別（§3.3）+ `AGENT_ARB_MODE` feature flag（§8.3）+ #568 trace_id per-session-per-generation strategy — 資料模型與設定開關，不含執行邏輯，依賴 plan `pr-1b-1a.md`
+- **PR-1b-1b**（~1200 LOC）：Arbitrator goroutine（§3.4）+ channel admission（§3.5.1）+ apply pipeline 9 步 + pending window（§3.4.2）+ reconcile loop（§3.4.5）— 核心邏輯，依賴 1b-1a 型別，依賴 plan `pr-1b-1b.md`（1b-1a merge 後再寫）
+- **PR-1b-1c**（~800 LOC）：hook / probe / sweep 轉 Observation 雙寫 + 投影比對與 `frame_divergences` 落表（§8.1）+ #569 Monitor API envelope 穿透 — 整合收尾，1b-1b merge 後寫 plan `pr-1b-1c.md`
 
 ## 主架構
 
@@ -76,7 +81,7 @@ PR-1a merge 後 review 發現 §3.5 envelope 欄位仍缺 12 個（#560）、leg
 - [x] DDL migration（alpha 階段可 drop-recreate）
 - [x] BLOB → TEXT + `json.RawMessage`（避免 base64 外流）
 
-### 3. `Observation` 型別（§3.3） — **PR-1b-1**
+### 3. `Observation` 型別（§3.3） — **PR-1b-1a**
 
 - [ ] 測試：`DecisionPort` cap 16 — 超過第 17 筆拒收不 panic（dev panic / prod log+truncate）
 - [ ] 測試：`WatcherToken` 儲存 roundtrip（uuid rotation 下老 token reject）
@@ -84,7 +89,7 @@ PR-1a merge 後 review 發現 §3.5 envelope 欄位仍缺 12 個（#560）、leg
 - [ ] 測試：`SourceKind` enum 值域合法性（hook|probe|sweep|reconcile|synthetic）
 - [ ] 測試：`StateProposal.ActorKey` composite key（SessionID, Generation, ActorID）roundtrip
 
-### 4. Arbitrator 骨架 + channel admission control（§3.4、§3.5.1） — **PR-1b-1**
+### 4. Arbitrator 骨架 + channel admission control（§3.4、§3.5.1） — **PR-1b-1b**
 
 - [ ] 測試：`arb_in` cap 1024 — proposed 滿載 drop non-blocking、committed 滿載 blocking 100ms timeout
 - [ ] 測試：`retryCh` cap 256 滿載 drop retry tick 但 pending entry 仍在 buffer
@@ -95,7 +100,7 @@ PR-1a merge 後 review 發現 §3.5 envelope 欄位仍缺 12 個（#560）、leg
 - [ ] 測試：Pending window — per-session 8 entries evict、per-observation coalescing 16 筆 drop oldest、2s deadline drop proposal 不建 actor
 - [ ] 測試：Reconcile loop — 不改 actor.status，只進 trace（`outcome=skipped, reason_code=ReconcileStaleNoted`）
 
-### 5. 雙寫 passthrough + divergence 比對（§8.1） — **PR-1b-1**
+### 5. 雙寫 passthrough + divergence 比對（§8.1） — **PR-1b-1c**
 
 - [ ] 測試：hook path 送進 Arbitrator 的 proposal 投影到舊 schema 後與 direct-write frame 逐欄等值（無 divergence）
 - [ ] 測試：人為注入不一致 proposal → `frame_divergences` 有對應 row

--- a/docs/superpowers/plans/2026-04-22-lights-system/pr-1b-1a.md
+++ b/docs/superpowers/plans/2026-04-22-lights-system/pr-1b-1a.md
@@ -1,0 +1,489 @@
+# PR-1b-1a — Observation 型別 + AGENT_ARB_MODE flag + trace_id strategy
+
+> Phase：1（Schema + 雙寫過渡）
+> 依賴：PR-1b-0 (#564, alpha.202)
+> 後續：PR-1b-1b（Arbitrator goroutine + admission + apply pipeline）
+> Spec 對照：§3.3（Observation）、§3.5 line 482-508（trace_id）、§8.3（AGENT_ARB_MODE）
+> 關聯 Issue：#568 trace_id per-session-per-generation strategy
+
+## Context
+
+PR-1b-0 已把 §3.5 envelope 11 個新欄位 + row class discriminator 鋪到 SQLite。hook path 目前用 `trace_id == chain_id` 做 transitional aliasing（每次 hook callback 新建一個 chain，trace_id 跟著複製），**不符合 spec §3.5 line 483** 「per session per generation」語意；defender review 在 #568 點名此缺口。
+
+PR-1b-1 原本打算一次交付 Observation 型別 + Arbitrator + 雙寫 passthrough，合計 2000-3000 LOC。累計 PR-1a + PR-1b-0 已 8 commits / 9 輪 review，reviewer 疲勞。拆成 a/b/c 三段後，**PR-1b-1a 只落資料模型與開關**，不含執行邏輯，約 600 LOC。
+
+**關於 #568 — 分階段交付**：此 PR 落地 trace_id 的**型別契約 + Registry primitive**；實際 Mint trigger（SessionStart hook）在 PR-1b-1b，hook trace 路徑汰換（取代 chain_id aliasing）在 PR-1b-1c。Issue #568 直到 1b-1c merge 後才可關；本 PR 僅解 foundation。
+
+## Goals
+
+1. 定義 §3.3 Observation 型別與所有子型別（`SourceKind` / `ObsPhase` / `StateProposal` / `DecisionPort` / `Branch` / `EvidenceRef` / `ActorKey`）
+2. Observation builder + validation（cap 16 DecisionPort / required fields / SourceKind enum / WatcherToken 規則）
+3. 解決 #568：提供 per-(session, generation) trace_id 生成機制，hook path aliasing 暫時保留（由 1b-1c 接 Observation 路徑後汰換）
+4. 導入 `AGENT_ARB_MODE` feature flag（env > config，env-locked 語意，預設 passthrough，切換鎖到下次 SessionStart）
+5. `GET /api/agent/arbitrator/mode` 唯讀 API 回傳 `{current, pending, env_locked}`
+
+## Non-Goals（明確排除）
+
+- ❌ Arbitrator goroutine、channel admission、apply pipeline — **PR-1b-1b**
+- ❌ Pending window、reconcile loop — **PR-1b-1b**
+- ❌ hook/probe/sweep 轉 Observation 實際寫入 — **PR-1b-1c**
+- ❌ Divergence 比對與 `frame_divergences` 寫入（表已在，但比對邏輯延後） — **PR-1b-1c**
+- ❌ Monitor API envelope 穿透 + SPA type 同步（#569） — **PR-1b-1c**
+- ❌ 現有 hook trace path 切換到新 trace_id（`trace.go` line 202-206 保留 chain_id aliasing 不動） — **PR-1b-1c**
+
+## 設計決策
+
+### D1. Package 組織
+
+**決策**：新增兩個 package 放在 `internal/module/agent/` 下
+- `internal/module/agent/observation/` — Observation 型別、builder、validation、TraceIDRegistry
+- `internal/module/agent/arbmode/` — `AGENT_ARB_MODE` state machine + API handler
+
+**理由**：
+- 與既有 `internal/module/agent/{trace,sweep,verify,...}` 同層，符合現況 feature-module 組織
+- 不放 `internal/agent/`（那是 provider layer, codex/cc/opencode/probe）
+- `observation` 與 `arbmode` 分離：前者純資料模型 + 工具函式無 side-effect；後者牽涉 config 熱重載 + HTTP handler，職責不同
+
+### D2. `ActorKey` 設計
+
+**結構**（§3.2 / §3.3）：
+```go
+type ActorKey struct {
+    SessionID  string  // tmux session id（與 frame 對齊）
+    Generation int64   // frame.Generation；跨 generation 的 actor 視為不同 actor
+    ActorID    string  // "primary:main" / "subagent:explore-42" / "proxy:editor"
+}
+```
+- 提供 `String() string`（格式 `<sessionID>/<generation>/<actorID>`）供 log / idempotency hash 用
+- Composite key 不用 tuple alias，因為 Go map 需要 `struct{}` 型別
+
+### D3. Observation cap / validation 規則
+
+| 檢查項 | 規則 | 失敗行為 |
+|---|---|---|
+| `len(DecisionPorts)` ≤ 16 | 超過視為程式錯誤 | dev: panic；prod: log warn + truncate 到 16（保留前 16 筆，棄後續）|
+| `SourceKind` 值域 | `hook` / `probe` / `sweep` / `reconcile` / `synthetic` | 不合法 builder 回 `ErrInvalidSourceKind` |
+| `Phase` 值域 | `proposed` / `committed` / `rejected`（spec §3.3）**必填** | 空值或非法 builder 回 `ErrInvalidPhase` |
+| `WatcherToken` | `probe` source **必填**；其他 source 選填 | probe 缺 token builder 回 `ErrMissingWatcherToken` |
+| 必填欄位 | `TraceID` / `SessionID` / `SourceKind` / `Action` / `Phase` / `ObservedAt` | 缺任一 builder 回 `ErrMissingRequiredField`（`ObservedGeneration` 為 int64 允許 zero-value，不強制；但 ActorKey.Generation mismatch 檢查仍需一致）|
+| `Proposal.ActorKey.SessionID` | 必須 == `Observation.SessionID` | 不一致回 `ErrActorKeySessionMismatch` |
+| `Proposal.ActorKey.Generation` | 必須 == `Observation.ObservedGeneration` | 不一致回 `ErrActorKeyGenerationMismatch`（D2 composite key 的 integrity 保證）|
+
+**Dev / prod 判定**：統一走 `BuilderOption` 單一機制（D7）；不使用 build tag。預設 prod（log + truncate）；測試檔顯式 `NewBuilder(registry, WithDevMode(true))` 觸 panic 路徑。
+
+### D4. #568 trace_id 策略 — **Minted at SessionStart**
+
+選項評估：
+
+| 選項 | 描述 | 取捨 |
+|---|---|---|
+| A. Deterministic (uuidv5) | `trace_id = uuidv5(NS_LIGHTS, session_id+generation)` | ✅ 無 state、可 reproduce；❌ daemon restart 前後同 trace_id，違反 §8 line 1222 「span IDs 不延續」 |
+| **B. Minted at SessionStart** ✅ | SessionStart hook 觸發 `registry.Mint(session, generation)` → 塞 `map[Key]uuidv4`；Observation builder 呼叫 `registry.Get()` | ✅ 符合 spec 「restart 開新 trace_id」；❌ 需要 in-memory state |
+
+**採 B**。實作：
+```go
+type TraceIDKey struct {
+    SessionID  string
+    Generation int64
+}
+
+type TraceIDRegistry struct {
+    mu    sync.RWMutex
+    cache map[TraceIDKey]string  // trace_id (uuidv4)
+}
+
+// Mint：若 key 已存在 → 回既有值 + log warn（同 generation 重複 mint 視為 bug，
+// 但絕不 rotate，否則會把已發出觀察的 trace_id 切裂，破壞 #568 correlation）
+func (r *TraceIDRegistry) Mint(sessionID string, generation int64) string
+
+// Get：命中回 (id, true)；未命中回 ("", false)
+func (r *TraceIDRegistry) Get(sessionID string, generation int64) (string, bool)
+
+// PruneSessionBefore：清除指定 session 在 generation 之前的所有 trace_id
+// 由 Arbitrator 在 SessionStart apply 完成後呼叫（新 generation 推進時舊的不再需要）
+// 同時提供 PruneSession(sessionID) 清整個 session — SessionEnd observation 呼叫
+func (r *TraceIDRegistry) PruneSessionBefore(sessionID string, generation int64) int
+func (r *TraceIDRegistry) PruneSession(sessionID string) int
+
+// 注意：**沒有 MintOrGet**。Miss 代表 SessionStart Mint 尚未觸發或 key 錯誤，
+// 絕對不可在 Get path 自行 mint（避免 A → B 切裂）。
+// Observation builder miss 時應回 error (ErrTraceIDNotMinted)，caller 決定是否重試。
+
+// Daemon restart：registry 是 in-memory，重啟即清空 — 符合 spec §8 line 1222
+```
+
+**Prune 策略**（解決 P1 memory leak）：
+- 每次 SessionStart apply 後 Arbitrator 呼叫 `PruneSessionBefore(sessionID, newGeneration)` 清舊 generation
+- 若無法取得明確 SessionEnd 信號，alpha 階段可以「每 session 只保留最近 N=3 個 generation」（在 Mint 時順手 evict）；v1 前收緊策略
+- 實際 prune trigger 在 PR-1b-1b（Arbitrator apply pipeline）；PR-1b-1a 只提供 API contract + 單元測試
+
+**既有 hook path aliasing 保留**：`trace.go` line 202-206 `traceID = chain.ChainID` 不動；PR-1b-1c 接入 Observation 時才改。PR-1b-1a **不改 hook 實際路徑**，只提供 registry API。
+
+**Mint 的呼叫者是誰？** — PR-1b-1a 不實際呼叫，但在 plan 內明示：1b-1b Arbitrator 在 apply SessionStart hook 觀察後呼叫 `Mint()` + `PruneSessionBefore()`；1b-1c hook path 改用 `Get()` 取 trace_id（miss 則 log error，**不自行 mint**）。
+
+**UUID format**：`uuidv4`（`github.com/google/uuid` 已在 go.mod）。
+
+### D5. AGENT_ARB_MODE 狀態機
+
+**`ArbMode` type**：
+```go
+type ArbMode string
+const (
+    ModePassthrough   ArbMode = "passthrough"
+    ModeAuthoritative ArbMode = "authoritative"
+)
+```
+
+**Manager struct**：
+```go
+type Manager struct {
+    mu          sync.RWMutex
+    current     ArbMode   // 當前生效
+    pending     ArbMode   // 下一 SessionStart 套用
+    envLocked   bool      // env 鎖定 config hot reload
+    envValue    ArbMode
+}
+
+type Snapshot struct {
+    Current   ArbMode
+    Pending   ArbMode
+    EnvLocked bool
+}
+
+// env/configVal are raw strings (env var value / TOML config value); Manager
+// validates internally. Invalid/empty values fall back to ModePassthrough with log warn.
+func NewManager(env, configVal string) *Manager
+// Snapshot：在單一 Lock 範圍內取三欄，避免 mid-config-change 讀到撕裂快照
+func (m *Manager) Snapshot() Snapshot
+func (m *Manager) OnConfigChange(configVal ArbMode) (changed bool)  // env-locked 時 no-op
+func (m *Manager) ApplyAtSessionStart()  // pending → current
+```
+
+**API handler 一律透過 `Snapshot()` 取狀態**；不暴露分欄 getter（否則 handler 需要自行跨 call 處理一致性）。
+
+**Boot 邏輯**：
+1. 讀 `AGENT_ARB_MODE` env
+2. 若 env set 且值合法 → `current = pending = env value, envLocked = true`
+3. 若 env set 但值非法 → log warn + 視同 env unset
+4. Env unset → `current = pending = config [agent] arb_mode`（缺省預設 `passthrough`）
+
+**Hot reload 流程**：
+- `core.OnConfigChange` callback 讀 config `[agent] arb_mode`
+- `manager.OnConfigChange(configVal)`：env-locked log warn + 忽略；否則 `pending = configVal`（若跟 current 不同）
+- **`current` 不立即切換**；等 `ApplyAtSessionStart()` 觸發（由 1b-1b Arbitrator 在 SessionStart 時呼叫）
+
+**`agent.arb_mode` config 欄位**（路徑與 hot reload 機制對齊現況）：
+- 加到 **`internal/config/config.go`** 的 `Config` struct：新增 `Agent AgentConfig`（或既有 struct 加欄位）
+  - 專案的 config struct 在 `internal/config/`（不是 `internal/core/config.go`）
+- TOML 預設值 `"passthrough"`；config_test.go 加 default 驗證
+- 不合法值 decode 成功但 Manager init 時 fallback + log warn
+- **`PUT /api/config` 是 JSON partial update**（非 TOML）— 在 `internal/core/config_handler.go:27` `configUpdateRequest` struct 加 `Agent *AgentUpdateRequest` 欄位，照既有 `Stream *config.StreamConfig` / `Terminal *config.TerminalConfig` 模式
+- Hot reload：`handlePutConfig` 更新完呼叫 `c.NotifyConfigChange()`（現有機制，`internal/core/config_handler.go:121`）；Manager 透過 `core.OnConfigChange()` 訂閱後讀新值 → `OnConfigChange(newVal)` 更新 pending
+
+### D6. API endpoint
+
+`GET /api/agent/arbitrator/mode` 由 `arbmode.Handler` 註冊到 core mux 或 agent module mux：
+
+Response：
+```json
+{
+  "current":   "passthrough",
+  "pending":   "authoritative",
+  "env_locked": false
+}
+```
+
+- 回傳 `application/json`；沒有任何寫入接口（POST/PUT 在 PR-1b-1b 或以後才考慮）
+- 錯誤狀況無（純讀 Manager 狀態），一律 200
+
+### D7. 關於 dev/prod 模式
+
+**統一走 `BuilderOption`，不使用 build tag、不引入全域 env**。Observation builder 透過 constructor option：
+```go
+type BuilderOption func(*Builder)
+func WithDevMode(dev bool) BuilderOption
+```
+- 測試檔顯式呼叫 `NewBuilder(registry, WithDevMode(true))`
+- 生產碼 `NewBuilder(registry)` 預設 prod（log + truncate）
+- 避免把 dev/prod 變成 global state
+- Panic / log warn 行為由 Builder 本身決定，caller 無需知道當前模式
+
+### D8. EvidenceRef shape
+
+Spec §3.3 只列 `Evidence []EvidenceRef`，未單獨定義 struct；但 line 977-980 範例已明示 shape：
+```go
+Evidence: []EvidenceRef{
+    {Key: "parent_actor_key", Value: parentActor.Key},
+    {Key: "subagent_type",    Value: hookDetail["agent_type"]},
+}
+```
+
+**決定 shape**（PR-1b-1a 定義，1b-1b/1c 不再變）：
+```go
+type EvidenceRef struct {
+    Key   string  // low-cardinality label; e.g., "pid" / "parent_actor_key" / "screen_hash" / "hook_payload_ref"
+    Value any     // string / int64 / ActorKey / map — JSON marshal 時由調用方保證可序列化
+}
+```
+
+- `Value any` 因為 spec 例子已混用 string 與 ActorKey 等 struct
+- JSON marshal 時 `Value` 欄位由 `encoding/json` 預設序列化；不可序列化的型別（chan / func）呼叫方責任
+- **不**提供 typed variant `StringEvidenceRef` / `ActorKeyEvidenceRef` — 避免過早抽象；使用端若需要檢驗型別再上層 assert
+- Used by `Observation.Evidence` / `DecisionPort.InputRefs`（spec line 247）
+
+## Tasks（staged parallelism）
+
+**執行順序**（有實際依賴）：
+
+| Stage | 可並行 Task | 依賴 |
+|---|---|---|
+| **Stage 1** | Task 1（型別）, Task 4（Manager） | 無 |
+| **Stage 2** | Task 2（Builder）, Task 3（TraceIDRegistry）, Task 5（API + wiring） | Task 2/3 依賴 Task 1 型別；Task 5 依賴 Task 4 Manager |
+
+Controller（主 Claude）依此順序派發，不可無視依賴並行全部。每個 Task 完成後經 spec reviewer + code quality reviewer 雙審再開下一個。
+
+### Task 1 — Observation 型別 + 子型別 + ActorKey + EvidenceRef
+
+**檔案**：
+- `internal/module/agent/observation/observation.go`（新增）
+- `internal/module/agent/observation/observation_test.go`（新增）
+- `internal/module/agent/observation/actor_key.go`（新增）
+- `internal/module/agent/observation/actor_key_test.go`（新增）
+- `internal/module/agent/observation/evidence.go`（新增，EvidenceRef 與相關 helpers）
+- `internal/module/agent/observation/evidence_test.go`（新增）
+
+**TDD checklist**（先寫測試）：
+- [ ] `TestActorKey_String_Format` — `String()` 輸出 `<sessionID>/<generation>/<actorID>`
+- [ ] `TestActorKey_Equal` — 相同 triple equal，任一欄位差異 not equal
+- [ ] `TestActorKey_UsableAsMapKey` — `map[ActorKey]string` 寫入/讀取不 panic
+- [ ] `TestSourceKind_ValidValues` — 5 個合法值 `IsValid()` 皆 true；未知值 false
+- [ ] `TestObsPhase_ValidValues` — `proposed` / `committed` / `rejected` 合法，其他非法
+- [ ] `TestObservation_ZeroValue_String` — `Observation{}.String()` 不 panic
+- [ ] `TestStateProposal_ZeroValue` — roundtrip through JSON marshal/unmarshal 不 lossy
+- [ ] `TestDecisionPort_ZeroValue_JSON` — `DecisionPort{}` marshal 後 unmarshal 回原值
+- [ ] `TestDecisionPort_InputRefs_EvidenceRef_JSON` — `InputRefs []EvidenceRef` 含多筆 entry roundtrip 成功
+- [ ] `TestBranch_Fields` — `ID` / `Condition` / `Outcome` 三欄 roundtrip
+- [ ] `TestEvidenceRef_StringValue_JSON` — `{Key:"pid", Value:"12345"}` marshal/unmarshal roundtrip
+- [ ] `TestEvidenceRef_Int64Value_JSON` — `{Key:"pid", Value:int64(12345)}` marshal；unmarshal 因 JSON number 會回 float64 → 文件化此行為，測試只驗 Key 一致 + Value 非空
+- [ ] `TestEvidenceRef_ActorKeyValue_JSON` — `{Key:"parent_actor_key", Value:ActorKey{...}}` marshal 後含 `session_id/generation/actor_id` 三鍵
+- [ ] `TestEvidenceRef_ZeroValue` — `EvidenceRef{}` marshal 回 `{"key":"","value":null}` 不 panic
+
+**實作注意**：
+- 型別全部在單一 package，不向外暴露 internal struct
+- `Observation` struct 欄位順序依 spec §3.3 line 208-225
+- `SourceKind.IsValid()` 用 switch case，不用 map（avoid alloc）
+- `ActorKey.String()` 用 `fmt.Sprintf`，避開 `strings.Builder`（簡潔）
+- `EvidenceRef.Value` 型別 `any`（`interface{}`）；JSON unmarshal 不做型別 assertion，caller 責任
+
+**Subagent 交付標準**：
+- 所有測試通過 (`go test ./internal/module/agent/observation/...`)
+- `go vet` 通過
+- 沒有跨 package 依賴（只進不出）
+
+### Task 2 — Observation Builder + Validation
+
+**檔案**：
+- `internal/module/agent/observation/builder.go`（新增）
+- `internal/module/agent/observation/builder_test.go`（新增）
+- `internal/module/agent/observation/errors.go`（新增，定義 sentinel errors）
+
+**TDD checklist**：
+- [ ] `TestBuilder_Build_Minimal` — 填齊 required fields + empty DecisionPorts，`Build()` 成功
+- [ ] `TestBuilder_MissingTraceID_Error` — 其他齊備缺 TraceID → `ErrMissingRequiredField`
+- [ ] `TestBuilder_MissingSessionID_Error`
+- [ ] `TestBuilder_MissingSourceKind_Error`
+- [ ] `TestBuilder_MissingAction_Error`
+- [ ] `TestBuilder_MissingPhase_Error` — Phase 為空 → `ErrMissingRequiredField`
+- [ ] `TestBuilder_InvalidPhase_Error` — Phase="bogus" → `ErrInvalidPhase`
+- [ ] `TestBuilder_ZeroObservedGeneration_OK` — ObservedGeneration=0 合法（int64 允許 zero-value；mismatch 檢查透過 ActorKey.Generation 比對）
+- [ ] `TestBuilder_ZeroObservedAt_Error` — `time.Time{}` 觸發 error
+- [ ] `TestBuilder_InvalidSourceKind_Error` — source="invalid" → `ErrInvalidSourceKind`
+- [ ] `TestBuilder_ProbeWithoutWatcherToken_Error` — source=probe, WatcherToken="" → `ErrMissingWatcherToken`
+- [ ] `TestBuilder_HookWithoutWatcherToken_OK` — source=hook, WatcherToken="" 正常
+- [ ] `TestBuilder_ActorKeySessionMismatch_Error` — `Proposal.ActorKey.SessionID != Observation.SessionID` → `ErrActorKeySessionMismatch`
+- [ ] `TestBuilder_ActorKeyGenerationMismatch_Error` — `Proposal.ActorKey.Generation != Observation.ObservedGeneration` → `ErrActorKeyGenerationMismatch`
+- [ ] `TestBuilder_DecisionPorts_Exactly16_OK`
+- [ ] `TestBuilder_DecisionPorts_17_ProdTruncate` — WithDevMode(false)；回 observation 含 16 筆，log 有 "decision_ports truncated" warn（1b-1a 暫 log；metrics counter 待 1b-1b 補）
+- [ ] `TestBuilder_DecisionPorts_17_DevPanic` — WithDevMode(true)；`Build()` panic（recover 驗證 message）
+- [ ] `TestBuilder_DecisionPorts_Empty_OK` — 允許 empty slice
+
+**實作注意**：
+- Sentinel error list 用 `errors.Is` 可識別
+- Truncate 時記 metric：`observation.go` 定義 `lightsDecisionPortsTruncated prometheus.Counter`（或 expvar，看專案現況）
+  - 若專案尚未有 metrics 基礎 → **用 log.Printf + TODO 註解，等 1b-1b 補 metrics**（不自建 metrics 子系統）
+- `Build()` 接 `validate()` helper；validate fail 回 non-nil error，caller 決定是否 log
+
+**Subagent 交付標準**：
+- 所有測試通過含 panic case
+- 沒有向 Task 1 之外的 package 加依賴
+- `errors.go` 所有 error 有 godoc 註解說明觸發條件
+
+### Task 3 — TraceIDRegistry (#568)
+
+**檔案**：
+- `internal/module/agent/observation/trace_id.go`（新增）
+- `internal/module/agent/observation/trace_id_test.go`（新增）
+
+**TDD checklist**：
+- [ ] `TestTraceIDRegistry_Mint_NewKey_UUIDv4` — `Mint("s1", 1)` 回 uuidv4 格式字串
+- [ ] `TestTraceIDRegistry_Mint_SameKeyTwice_ReturnsExisting` — 同 key 呼叫兩次 Mint → 回同一個 id（**不 rotate**）+ 第二次 log warn（"mint called twice"）。Rotate 會切裂 trace_id，破壞 #568 correlation
+- [ ] `TestTraceIDRegistry_Get_Hit` — Mint 後 Get 回 same id + true
+- [ ] `TestTraceIDRegistry_Get_Miss` — 未 Mint 直接 Get → "", false
+- [ ] `TestTraceIDRegistry_DifferentGeneration_DifferentID` — `Mint("s1", 1)` 與 `Mint("s1", 2)` 分別產生不同 id（兩者皆先 mint 再 Get）
+- [ ] `TestTraceIDRegistry_DifferentSession_DifferentID` — `Mint("s1", 1)` 與 `Mint("s2", 1)` 分別產生不同 id
+- [ ] `TestTraceIDRegistry_PruneSessionBefore` — Mint (s1, 1), (s1, 2), (s1, 3) → `PruneSessionBefore("s1", 3)` 回 2；`Get("s1", 1)` / `Get("s1", 2)` 皆 miss；`Get("s1", 3)` hit
+- [ ] `TestTraceIDRegistry_PruneSession` — `PruneSession("s1")` 清 s1 所有 entry；s2 entry 不動
+- [ ] `TestTraceIDRegistry_PruneSessionBefore_NonExistent` — 呼叫無 entry 的 session 回 0，不 panic
+- [ ] `TestTraceIDRegistry_Concurrent_Race` — 100 goroutine 並發 Mint 不同 key + 並發 Prune 無 race（`go test -race`）
+- [ ] `TestTraceIDRegistry_FreshInstance_EmptyState` — `NewTraceIDRegistry()` 回傳 registry 所有 Get 皆 miss（模擬 daemon restart）
+
+**實作注意**：
+- UUID 來源 `github.com/google/uuid`
+- `sync.RWMutex`：Get 用 RLock；Mint / Prune 用 Lock
+- **無 `MintOrGet` / `Clear()` / `Delete()`**：Miss 時 caller 自行處理（log error + 回 error），不讓 registry 默默補 mint（會切裂）
+- 不暴露 internal map；所有 mutation 通過 method
+
+**Subagent 交付標準**：
+- `go test -race` 通過
+- UUID 格式驗證用 `uuid.Parse`（合法則測試通過）
+
+### Task 4 — AGENT_ARB_MODE Manager
+
+**檔案**：
+- `internal/module/agent/arbmode/manager.go`（新增）
+- `internal/module/agent/arbmode/manager_test.go`（新增）
+- `internal/module/agent/arbmode/mode.go`（`ArbMode` type + const + `IsValid`）
+
+**TDD checklist**：
+- [ ] `TestArbMode_IsValid` — passthrough/authoritative 合法；其他非法
+- [ ] `TestManager_DefaultPassthrough_Snapshot` — env="" config="" → `Snapshot() == {Current:passthrough, Pending:passthrough, EnvLocked:false}`
+- [ ] `TestManager_ConfigOnly_Authoritative` — env="" config=authoritative → Snapshot.Current=authoritative
+- [ ] `TestManager_EnvPassthrough_ConfigAuthoritative_EnvWins` — env=passthrough config=authoritative → Snapshot.Current=passthrough EnvLocked=true
+- [ ] `TestManager_EnvInvalid_FallbackToConfig` — env="bogus" config=authoritative → Snapshot.Current=authoritative EnvLocked=false + log warn
+- [ ] `TestManager_OnConfigChange_EnvUnset_UpdatesPending` — env unset，Snapshot.Current=passthrough；OnConfigChange(authoritative) → Snapshot.Pending=authoritative Snapshot.Current=passthrough returns changed=true
+- [ ] `TestManager_OnConfigChange_EnvLocked_NoOp` — EnvLocked=true；OnConfigChange(authoritative) → Snapshot.Pending unchanged returns changed=false + log warn
+- [ ] `TestManager_OnConfigChange_SameValue_NoOp` — 相同值 changed=false 無 log
+- [ ] `TestManager_ApplyAtSessionStart_PromotesPending` — Snapshot.Current=passthrough Snapshot.Pending=authoritative → ApplyAtSessionStart() 後 Snapshot.Current=authoritative Snapshot.Pending=authoritative
+- [ ] `TestManager_ApplyAtSessionStart_NoPendingDiff_NoOp` — current==pending；Apply no-op
+- [ ] `TestManager_Snapshot_NotTornDuringConfigChange` — 一個 goroutine 反覆 OnConfigChange 交替 authoritative/passthrough；另一 goroutine 反覆 Snapshot；Snapshot 每次回傳必為 self-consistent（Current+Pending+EnvLocked 來自同一 lock 時段，非 partial mix）
+- [ ] `TestManager_ConcurrentReadWrite_Race` — OnConfigChange 與 Snapshot 並發無 race（`go test -race`）
+
+**實作注意**：
+- `sync.RWMutex` 保護 current / pending / envLocked / envValue 四欄
+- 所有 write path 經單一 Lock 範圍，避免部分更新
+- `Snapshot()` 必須在同一 RLock 範圍內讀三欄，一次性回傳 Snapshot struct
+- `log.Printf` 用 `[arbmode]` 前綴
+- 不暴露分欄 `Current()` / `Pending()` / `EnvLocked()` getter（避免 caller 自行拼湊破壞一致性）
+
+**Subagent 交付標準**：
+- `go test -race` 通過
+- 所有 log.Printf output 在測試時可被捕獲（`log.SetOutput(&buf)`）
+
+### Task 5 — Arbitrator Mode API endpoint + Config wiring
+
+**檔案**：
+- `internal/module/agent/arbmode/handler.go`（新增）
+- `internal/module/agent/arbmode/handler_test.go`（新增）
+- **`internal/config/config.go`**（修改：加 `AgentConfig` struct 或對應欄位，含 `ArbMode string \`toml:"arb_mode"\``）
+- **`internal/config/config_test.go`**（修改：驗證 TOML default + explicit value + invalid value 行為）
+- **`internal/core/config_handler.go`**（修改：`configUpdateRequest` 加 `Agent *agentUpdateRequest` 欄位；handlePutConfig 多處理一段 Agent partial update）
+- **`internal/core/config_handler_test.go`**（修改：PUT /api/config 含 agent.arb_mode 的測試）
+- `internal/module/agent/module.go` 或 wiring 點（修改：建 Manager + 註冊 handler + 接 `core.OnConfigChange`）
+
+**TDD checklist**：
+- [ ] `TestAgentConfig_ArbMode_DefaultPassthrough` — 空 TOML decode 後 ArbMode = "passthrough"（或空字串 → Manager init fallback）
+- [ ] `TestAgentConfig_ArbMode_ExplicitAuthoritative` — TOML `[agent]\narb_mode = "authoritative"` decode 成功
+- [ ] `TestAgentConfig_ArbMode_InvalidValue_AcceptedByDecoder` — TOML 非法值 decode 成功（純字串）；後續 Manager init 時 fallback（log warn）
+- [ ] `TestPutConfig_Agent_ArbMode_Passthrough` — PUT body `{"agent":{"arb_mode":"passthrough"}}` → 200 + in-memory Cfg.Agent.ArbMode 更新
+- [ ] `TestPutConfig_Agent_ArbMode_InvalidValue_400` — PUT body `{"agent":{"arb_mode":"bogus"}}` → 400 "invalid arb_mode"
+- [ ] `TestPutConfig_Agent_ArbMode_TriggersOnConfigChange` — PUT 成功後 OnConfigChange callback 被呼叫一次
+- [ ] `TestPutConfig_Agent_Rollback_OnWriteFailure` — mock writeConfig fail → Cfg 回滾到 snapshot
+- [ ] `TestArbModeHandler_Get_Snapshot_Shape` — 用 mock Manager return Snapshot{Current:p, Pending:a, EnvLocked:false}；handler 回 JSON `{"current":"passthrough","pending":"authoritative","env_locked":false}`
+- [ ] `TestArbModeHandler_Get_Method_Disallowed` — POST/PUT → 405
+- [ ] `TestArbModeHandler_Get_Snapshot_UsesSingleCall` — mock Manager 記錄 Snapshot() 被呼叫次數；handler 每次 request 只呼叫一次（不呼叫分欄 getter）
+- [ ] `TestAgentModuleWiring_ArbModeManager_ReceivesConfigChange` — 建 module + 觸發 NotifyConfigChange → Manager.Snapshot().Pending 更新（若值不同）
+
+**實作注意**：
+- **Config struct 位置**：`internal/config/config.go`（**不是** `internal/core/config.go`）— 現有 `Stream / Detect / Terminal / UploadDir` 等欄位都在這
+- **PUT /api/config JSON partial update** 模式在 `internal/core/config_handler.go:27` `configUpdateRequest` struct；參考 `Stream *config.StreamConfig \`json:"stream,omitempty"\`` 既有風格加 `Agent *agentUpdateRequest \`json:"agent,omitempty"\``
+- `agentUpdateRequest` struct 用 `ArbMode *string \`json:"arb_mode,omitempty"\`` 指標型態（區分「未提供」vs「零值」）
+- 非法值在 `handlePutConfig` validate 段（像 line 52-60 `req.Terminal.SizingMode` 模式）直接回 400
+- Snapshot 前的 `snapshot := *c.Cfg` 複製模式要繼續遵守（invariant 寫在 line 80-82）— 新欄位 assignment 必須 wholesale
+- Handler 依賴 Manager interface `type Snapshotter interface { Snapshot() Snapshot }`，便於 test mock
+- Module wiring：`agent.Module` init 時 `os.Getenv("AGENT_ARB_MODE")` 讀一次 → 建 Manager；註冊 `core.OnConfigChange(func(){ m.OnConfigChange(cfg.Agent.ArbMode) })`
+- 路由：`GET /api/agent/arbitrator/mode` — 註冊在 agent module 的 mux（查 `internal/module/agent/handler.go` 現有路由風格對齊）
+
+**Subagent 交付標準**：
+- `go test -race ./internal/module/agent/arbmode/... ./internal/config/... ./internal/core/...` 全通過
+- 手動驗證：
+  - 啟 daemon：`curl -s http://127.0.0.1:7860/api/agent/arbitrator/mode | jq` → `{"current":"passthrough","pending":"passthrough","env_locked":false}`
+  - PUT 改值：`curl -X PUT http://127.0.0.1:7860/api/config -H 'Content-Type: application/json' -d '{"agent":{"arb_mode":"authoritative"}}'`
+  - 再 GET：`pending="authoritative", current="passthrough"`（未 ApplyAtSessionStart）
+  - Env 鎖：`AGENT_ARB_MODE=authoritative ./bin/pdx` 啟 → GET `env_locked=true, current="authoritative"`；PUT 改值 → GET `pending` 保持 authoritative + log 有 `overridden by env`
+
+## 檔案變動總覽
+
+| 檔 | 動作 | Task |
+|---|---|---|
+| `internal/module/agent/observation/observation.go` | 新增 | 1 |
+| `internal/module/agent/observation/observation_test.go` | 新增 | 1 |
+| `internal/module/agent/observation/actor_key.go` | 新增 | 1 |
+| `internal/module/agent/observation/actor_key_test.go` | 新增 | 1 |
+| `internal/module/agent/observation/evidence.go` | 新增 | 1 |
+| `internal/module/agent/observation/evidence_test.go` | 新增 | 1 |
+| `internal/module/agent/observation/builder.go` | 新增 | 2 |
+| `internal/module/agent/observation/builder_test.go` | 新增 | 2 |
+| `internal/module/agent/observation/errors.go` | 新增 | 2 |
+| `internal/module/agent/observation/trace_id.go` | 新增 | 3 |
+| `internal/module/agent/observation/trace_id_test.go` | 新增 | 3 |
+| `internal/module/agent/arbmode/mode.go` | 新增 | 4 |
+| `internal/module/agent/arbmode/manager.go` | 新增 | 4 |
+| `internal/module/agent/arbmode/manager_test.go` | 新增 | 4 |
+| `internal/module/agent/arbmode/handler.go` | 新增 | 5 |
+| `internal/module/agent/arbmode/handler_test.go` | 新增 | 5 |
+| `internal/config/config.go` | 修改 | 5 |
+| `internal/config/config_test.go` | 修改 | 5 |
+| `internal/core/config_handler.go` | 修改 | 5 |
+| `internal/core/config_handler_test.go` | 修改 | 5 |
+| `internal/module/agent/module.go`（或對等 wiring） | 修改 | 5 |
+
+**預估**：~650 LOC 含測試（含 EvidenceRef / Prune / Snapshot 追加）
+
+## Verification
+
+1. `cd .claude/worktrees/lights-pr-1b-1a && go test -race ./internal/module/agent/observation/... ./internal/module/agent/arbmode/... ./internal/config/... ./internal/core/...`
+2. `go vet ./...`
+3. `go build ./...`
+4. 手動：起 daemon，`curl -s http://127.0.0.1:7860/api/agent/arbitrator/mode | jq` → `{"current":"passthrough","pending":"passthrough","env_locked":false}`
+5. 手動 JSON partial update：
+   ```bash
+   curl -X PUT http://127.0.0.1:7860/api/config \
+     -H 'Content-Type: application/json' \
+     -d '{"agent":{"arb_mode":"authoritative"}}'
+   ```
+   再 GET → `{"current":"passthrough","pending":"authoritative","env_locked":false}`（未 ApplyAtSessionStart）
+6. 手動 env 鎖：`AGENT_ARB_MODE=authoritative ./bin/pdx` 起 → GET `{"current":"authoritative","pending":"authoritative","env_locked":true}`；PUT config 改 passthrough → GET 仍 pending=authoritative + daemon log 有 `[arbmode] overridden by env`
+
+## Rollout / Rollback
+
+- **Alpha 階段**：直接 merge 進 main，不加額外 feature gate
+- **Rollback**：revert 整個 PR 即可；無 schema 變動、無持久化狀態（TraceIDRegistry in-memory、Manager in-memory）
+- **行為影響**：使用者不可見（未接入執行路徑）；daemon 多一個 GET API、多兩個 in-memory struct
+
+## 已知 follow-up（1b-1a 不做，留後續）
+
+| # | 項目 | 歸屬 |
+|---|---|---|
+| 1 | Arbitrator goroutine 消費 Observation + apply pipeline | PR-1b-1b |
+| 2 | `Manager.ApplyAtSessionStart()` 被 Arbitrator 在 SessionStart hook observation 時呼叫 | PR-1b-1b |
+| 3 | `TraceIDRegistry.Mint()` 被 Arbitrator 在 SessionStart observation 時呼叫 | PR-1b-1b |
+| 4 | `TraceIDRegistry.PruneSessionBefore()` 被 Arbitrator 在 generation 推進後呼叫 | PR-1b-1b |
+| 5 | `DecisionPort` 被 truncate 時 metrics counter `lights_decision_ports_truncated` | PR-1b-1b |
+| 6 | hook/probe/sweep path 從 direct-write 切到 Observation 路徑 | PR-1b-1c |
+| 7 | hook path 的 `trace_id == chain_id` aliasing 汰換（使用 `TraceIDRegistry.Get()`） | PR-1b-1c |
+| 8 | `frame_divergences` 實際寫入 | PR-1b-1c |
+| 9 | Monitor API envelope 穿透 + SPA `MonitorStep` type 同步（#569）| PR-1b-1c |
+| 10 | `TraceIDRegistry.PruneSession()` 被 SessionEnd observation 呼叫 | PR-1b-1c 或更晚 |
+| 11 | `POST /api/agent/arbitrator/mode`（runtime 強制切換）| 非 Phase 1 範圍，暫不規劃 |
+
+**#568 何時可關**：PR-1b-1c merge 後（hook path 改用 `TraceIDRegistry.Get()` 取 per-(session, generation) trace_id，完成 end-to-end 交付）。PR-1b-1a/b 只完成 foundation。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,14 @@ func (tc TerminalConfig) GetSizingMode() string {
 	return tc.SizingMode
 }
 
+// AgentConfig holds per-agent-module settings. Currently the single setting is
+// the arbitrator mode flag (AGENT_ARB_MODE) which governs whether the
+// Arbitrator writes frames authoritatively or only observes via the legacy
+// direct-write path.
+type AgentConfig struct {
+	ArbMode string `toml:"arb_mode" json:"arb_mode"`
+}
+
 type Config struct {
 	HostID       string         `toml:"host_id"        json:"host_id"`
 	Bind         string         `toml:"bind"           json:"bind"`
@@ -58,6 +66,7 @@ type Config struct {
 	Detect       DetectConfig   `toml:"detect"         json:"detect"`
 	Features     FeaturesConfig `toml:"features"       json:"features"`
 	Dev          DevConfig      `toml:"dev"            json:"dev"`
+	Agent        AgentConfig    `toml:"agent"          json:"agent"`
 }
 
 func defaults() Config {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -143,3 +143,45 @@ func TestGetSizingModeExplicit(t *testing.T) {
 		t.Errorf("expected 'terminal-first', got %q", tc.GetSizingMode())
 	}
 }
+
+// ── AgentConfig ──────────────────────────────────────────────────────────────
+
+func TestAgentConfig_ArbMode_DefaultEmpty(t *testing.T) {
+	// An empty TOML file should yield an empty arb_mode (no default set in
+	// code for agent config — the Manager handles the fallback to passthrough).
+	cfg, err := config.Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Agent.ArbMode != "" {
+		t.Errorf("Agent.ArbMode = %q, want empty string by default", cfg.Agent.ArbMode)
+	}
+}
+
+func TestAgentConfig_ArbMode_ExplicitAuthoritative(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(path, []byte("[agent]\narb_mode = \"authoritative\"\n"), 0644)
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Agent.ArbMode != "authoritative" {
+		t.Errorf("Agent.ArbMode = %q, want %q", cfg.Agent.ArbMode, "authoritative")
+	}
+}
+
+func TestAgentConfig_ArbMode_InvalidValue_AcceptedByDecoder(t *testing.T) {
+	// The TOML decoder does NOT validate enum values — that's the caller's job
+	// (Manager.NewManager). The decoder must simply round-trip the raw string.
+	path := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(path, []byte("[agent]\narb_mode = \"bogus\"\n"), 0644)
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Agent.ArbMode != "bogus" {
+		t.Errorf("Agent.ArbMode = %q, want %q (decoder must not reject invalid values)", cfg.Agent.ArbMode, "bogus")
+	}
+}

--- a/internal/core/config_handler.go
+++ b/internal/core/config_handler.go
@@ -29,6 +29,12 @@ type configUpdateRequest struct {
 	Detect    *detectUpdateRequest   `json:"detect,omitempty"`
 	Terminal  *config.TerminalConfig `json:"terminal,omitempty"`
 	UploadDir *string                `json:"upload_dir,omitempty"`
+	Agent     *agentUpdateRequest    `json:"agent,omitempty"`
+}
+
+// agentUpdateRequest allows partial updates to agent config.
+type agentUpdateRequest struct {
+	ArbMode *string `json:"arb_mode,omitempty"`
 }
 
 // detectUpdateRequest allows partial updates to detect config.
@@ -68,6 +74,18 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Validate agent.arb_mode if provided.
+	if req.Agent != nil && req.Agent.ArbMode != nil && *req.Agent.ArbMode != "" {
+		switch *req.Agent.ArbMode {
+		case "passthrough", "authoritative":
+			// valid
+		default:
+			c.CfgMu.Unlock()
+			http.Error(w, "invalid agent.arb_mode: must be passthrough or authoritative", http.StatusBadRequest)
+			return
+		}
+	}
+
 	// Snapshot before any mutation so writeConfig failure can roll back the
 	// in-memory state, keeping c.Cfg and disk consistent. Shallow copy is
 	// sufficient because every mutation below replaces fields wholesale
@@ -102,6 +120,10 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		c.Cfg.UploadDir = *req.UploadDir
 	}
 
+	if req.Agent != nil && req.Agent.ArbMode != nil {
+		c.Cfg.Agent.ArbMode = *req.Agent.ArbMode
+	}
+
 	// Write back to config file
 	if c.CfgPath != "" {
 		if err := config.WriteFile(c.CfgPath, *c.Cfg); err != nil {
@@ -117,7 +139,7 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	c.CfgMu.Unlock()
 
 	// Notify registered callbacks about config changes (outside lock)
-	if detectChanged || req.UploadDir != nil {
+	if detectChanged || req.UploadDir != nil || req.Agent != nil {
 		c.NotifyConfigChange()
 	}
 

--- a/internal/core/config_handler.go
+++ b/internal/core/config_handler.go
@@ -74,14 +74,17 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Validate agent.arb_mode if provided.
-	if req.Agent != nil && req.Agent.ArbMode != nil && *req.Agent.ArbMode != "" {
+	// Validate agent.arb_mode if provided. Empty string is accepted as "reset to
+	// default" — the arbmode Manager handles empty by falling back to passthrough.
+	// We duplicate the enum literals here rather than import arbmode.IsValid()
+	// because internal/core is a lower layer than internal/module/agent.
+	if req.Agent != nil && req.Agent.ArbMode != nil {
 		switch *req.Agent.ArbMode {
-		case "passthrough", "authoritative":
+		case "", "passthrough", "authoritative":
 			// valid
 		default:
 			c.CfgMu.Unlock()
-			http.Error(w, "invalid agent.arb_mode: must be passthrough or authoritative", http.StatusBadRequest)
+			http.Error(w, "invalid agent.arb_mode: must be passthrough or authoritative (or empty to reset)", http.StatusBadRequest)
 			return
 		}
 	}
@@ -120,8 +123,10 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		c.Cfg.UploadDir = *req.UploadDir
 	}
 
+	agentChanged := false
 	if req.Agent != nil && req.Agent.ArbMode != nil {
 		c.Cfg.Agent.ArbMode = *req.Agent.ArbMode
+		agentChanged = true
 	}
 
 	// Write back to config file
@@ -139,7 +144,7 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	c.CfgMu.Unlock()
 
 	// Notify registered callbacks about config changes (outside lock)
-	if detectChanged || req.UploadDir != nil || req.Agent != nil {
+	if detectChanged || req.UploadDir != nil || agentChanged {
 		c.NotifyConfigChange()
 	}
 

--- a/internal/core/config_handler.go
+++ b/internal/core/config_handler.go
@@ -125,8 +125,18 @@ func (c *Core) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 
 	agentChanged := false
 	if req.Agent != nil && req.Agent.ArbMode != nil {
-		c.Cfg.Agent.ArbMode = *req.Agent.ArbMode
-		agentChanged = true
+		// Canonicalize empty as reset-to-default to keep persisted state and
+		// runtime mode in sync. arbmode.Manager treats "" as invalid; writing ""
+		// through would make GET /api/config and GET /api/agent/arbitrator/mode
+		// disagree forever.
+		newMode := *req.Agent.ArbMode
+		if newMode == "" {
+			newMode = "passthrough"
+		}
+		if c.Cfg.Agent.ArbMode != newMode {
+			c.Cfg.Agent.ArbMode = newMode
+			agentChanged = true
+		}
 	}
 
 	// Write back to config file

--- a/internal/core/config_handler_test.go
+++ b/internal/core/config_handler_test.go
@@ -237,6 +237,69 @@ func TestPutConfigIgnoresZeroPollInterval(t *testing.T) {
 	c.CfgMu.RUnlock()
 }
 
+func TestPutConfig_Agent_ArbMode_Passthrough(t *testing.T) {
+	c := newTestCore()
+
+	body := `{"agent":{"arb_mode":"passthrough"}}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	c.CfgMu.RLock()
+	assert.Equal(t, "passthrough", c.Cfg.Agent.ArbMode)
+	c.CfgMu.RUnlock()
+}
+
+func TestPutConfig_Agent_ArbMode_Authoritative(t *testing.T) {
+	c := newTestCore()
+
+	body := `{"agent":{"arb_mode":"authoritative"}}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	c.CfgMu.RLock()
+	assert.Equal(t, "authoritative", c.Cfg.Agent.ArbMode)
+	c.CfgMu.RUnlock()
+}
+
+func TestPutConfig_Agent_ArbMode_InvalidValue_400(t *testing.T) {
+	c := newTestCore()
+
+	body := `{"agent":{"arb_mode":"bogus"}}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid agent.arb_mode")
+}
+
+func TestPutConfig_Agent_ArbMode_TriggersOnConfigChange(t *testing.T) {
+	c := newTestCore()
+
+	var callbackCalled int
+	c.OnConfigChange(func() {
+		callbackCalled++
+	})
+
+	body := `{"agent":{"arb_mode":"authoritative"}}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, callbackCalled, "OnConfigChange callback should be called exactly once")
+
+	c.CfgMu.RLock()
+	assert.Equal(t, "authoritative", c.Cfg.Agent.ArbMode)
+	c.CfgMu.RUnlock()
+}
+
 func TestRegisterCoreRoutesIncludesConfigEndpoints(t *testing.T) {
 	c := newTestCore()
 	mux := http.NewServeMux()

--- a/internal/core/config_handler_test.go
+++ b/internal/core/config_handler_test.go
@@ -300,9 +300,11 @@ func TestPutConfig_Agent_ArbMode_TriggersOnConfigChange(t *testing.T) {
 	c.CfgMu.RUnlock()
 }
 
-// Empty arb_mode is accepted as "reset to default" — arbmode.Manager handles
-// the empty string by falling back to ModePassthrough. Validation + mutation
-// must stay symmetric, so this path is explicitly tested.
+// Empty arb_mode is canonicalized to "passthrough" at the PUT boundary so
+// that GET /api/config and GET /api/agent/arbitrator/mode always agree.
+// Previously the empty string was written through, but arbmode.Manager treats
+// "" as invalid and silently falls back to passthrough, causing the two APIs
+// to disagree.
 func TestPutConfig_Agent_ArbMode_EmptyString_Accepted(t *testing.T) {
 	c := newTestCore()
 
@@ -317,10 +319,47 @@ func TestPutConfig_Agent_ArbMode_EmptyString_Accepted(t *testing.T) {
 	c.handlePutConfig(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, 1, callbackCalled, "empty value counts as an agent change")
+	// Empty string canonicalizes to "passthrough" — the initial Cfg.Agent.ArbMode
+	// is "" so this is a real change (default "" → canonical "passthrough").
+	assert.Equal(t, 1, callbackCalled, "canonicalized value differs from initial empty default → callback fires")
 
 	c.CfgMu.RLock()
-	assert.Equal(t, "", c.Cfg.Agent.ArbMode)
+	// Fix A: empty input is now canonicalized to "passthrough", not stored as "".
+	assert.Equal(t, "passthrough", c.Cfg.Agent.ArbMode)
+	c.CfgMu.RUnlock()
+}
+
+// TestPutConfig_Agent_ArbMode_SameValue_DoesNotTrigger verifies that sending
+// a value identical to the persisted state does not fire NotifyConfigChange.
+// Scenario: first PUT "" canonicalizes to "passthrough" and fires. Second PUT
+// "" also canonicalizes to "passthrough" — no actual change → callback must NOT
+// fire a second time.
+func TestPutConfig_Agent_ArbMode_SameValue_DoesNotTrigger(t *testing.T) {
+	c := newTestCore()
+
+	var callbackCalled int
+	c.OnConfigChange(func() {
+		callbackCalled++
+	})
+
+	// First call: "" → canonicalize to "passthrough"; default was "", so change fires.
+	body := `{"agent":{"arb_mode":""}}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, callbackCalled, "first call fires (default→passthrough)")
+
+	// Second call: same empty string → canonicalizes to "passthrough" again.
+	// Cfg.Agent.ArbMode is already "passthrough" → no mutation → callback must not fire.
+	req2 := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec2 := httptest.NewRecorder()
+	c.handlePutConfig(rec2, req2)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	assert.Equal(t, 1, callbackCalled, "second idempotent call must NOT re-fire callback")
+
+	c.CfgMu.RLock()
+	assert.Equal(t, "passthrough", c.Cfg.Agent.ArbMode)
 	c.CfgMu.RUnlock()
 }
 

--- a/internal/core/config_handler_test.go
+++ b/internal/core/config_handler_test.go
@@ -300,6 +300,50 @@ func TestPutConfig_Agent_ArbMode_TriggersOnConfigChange(t *testing.T) {
 	c.CfgMu.RUnlock()
 }
 
+// Empty arb_mode is accepted as "reset to default" — arbmode.Manager handles
+// the empty string by falling back to ModePassthrough. Validation + mutation
+// must stay symmetric, so this path is explicitly tested.
+func TestPutConfig_Agent_ArbMode_EmptyString_Accepted(t *testing.T) {
+	c := newTestCore()
+
+	var callbackCalled int
+	c.OnConfigChange(func() {
+		callbackCalled++
+	})
+
+	body := `{"agent":{"arb_mode":""}}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, callbackCalled, "empty value counts as an agent change")
+
+	c.CfgMu.RLock()
+	assert.Equal(t, "", c.Cfg.Agent.ArbMode)
+	c.CfgMu.RUnlock()
+}
+
+// When the PUT body has `{"agent":{}}` (agent key present but arb_mode absent),
+// nothing actually changes — NotifyConfigChange must NOT fire, otherwise all
+// OnConfigChange subscribers get woken up for nothing.
+func TestPutConfig_Agent_Empty_DoesNotTriggerOnConfigChange(t *testing.T) {
+	c := newTestCore()
+
+	var callbackCalled int
+	c.OnConfigChange(func() {
+		callbackCalled++
+	})
+
+	body := `{"agent":{}}`
+	req := httptest.NewRequest("PUT", "/api/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	c.handlePutConfig(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 0, callbackCalled, "no-op PUT must not trigger OnConfigChange")
+}
+
 func TestRegisterCoreRoutesIncludesConfigEndpoints(t *testing.T) {
 	c := newTestCore()
 	mux := http.NewServeMux()

--- a/internal/module/agent/arbmode/handler.go
+++ b/internal/module/agent/arbmode/handler.go
@@ -1,0 +1,42 @@
+package arbmode
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Snapshotter is the subset of Manager the Handler needs. Interface used for
+// test mocking without requiring a full Manager in unit tests.
+type Snapshotter interface {
+	Snapshot() Snapshot
+}
+
+// Handler serves GET /api/agent/arbitrator/mode — returns the current mode
+// snapshot as JSON. Read-only; non-GET methods return 405.
+type Handler struct {
+	mgr Snapshotter
+}
+
+// NewHandler creates a Handler backed by the given Snapshotter.
+func NewHandler(mgr Snapshotter) *Handler {
+	return &Handler{mgr: mgr}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	snap := h.mgr.Snapshot()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(struct {
+		Current   ArbMode `json:"current"`
+		Pending   ArbMode `json:"pending"`
+		EnvLocked bool    `json:"env_locked"`
+	}{
+		Current:   snap.Current,
+		Pending:   snap.Pending,
+		EnvLocked: snap.EnvLocked,
+	})
+}

--- a/internal/module/agent/arbmode/handler_test.go
+++ b/internal/module/agent/arbmode/handler_test.go
@@ -1,0 +1,123 @@
+package arbmode
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeSnapshotter is a mock Snapshotter that records call counts.
+type fakeSnapshotter struct {
+	snap      Snapshot
+	callCount int
+}
+
+func (f *fakeSnapshotter) Snapshot() Snapshot {
+	f.callCount++
+	return f.snap
+}
+
+// ── TestArbModeHandler_Get_Snapshot_Shape ────────────────────────────────────
+
+func TestArbModeHandler_Get_Snapshot_Shape(t *testing.T) {
+	fake := &fakeSnapshotter{
+		snap: Snapshot{
+			Current:   ModePassthrough,
+			Pending:   ModeAuthoritative,
+			EnvLocked: false,
+		},
+	}
+	h := NewHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/arbitrator/mode", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var got struct {
+		Current   ArbMode `json:"current"`
+		Pending   ArbMode `json:"pending"`
+		EnvLocked bool    `json:"env_locked"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.Current != ModePassthrough {
+		t.Errorf("current = %q, want %q", got.Current, ModePassthrough)
+	}
+	if got.Pending != ModeAuthoritative {
+		t.Errorf("pending = %q, want %q", got.Pending, ModeAuthoritative)
+	}
+	if got.EnvLocked {
+		t.Error("env_locked = true, want false")
+	}
+}
+
+// ── TestArbModeHandler_Get_Method_Disallowed ─────────────────────────────────
+
+func TestArbModeHandler_Get_Method_Disallowed(t *testing.T) {
+	h := NewHandler(&fakeSnapshotter{})
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/agent/arbitrator/mode", strings.NewReader("{}"))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+			}
+			allow := rec.Header().Get("Allow")
+			if allow != http.MethodGet {
+				t.Errorf("Allow header = %q, want %q", allow, http.MethodGet)
+			}
+		})
+	}
+}
+
+// ── TestArbModeHandler_Get_Snapshot_UsesSingleCall ───────────────────────────
+
+func TestArbModeHandler_Get_Snapshot_UsesSingleCall(t *testing.T) {
+	fake := &fakeSnapshotter{
+		snap: Snapshot{
+			Current:   ModePassthrough,
+			Pending:   ModePassthrough,
+			EnvLocked: false,
+		},
+	}
+	h := NewHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/arbitrator/mode", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if fake.callCount != 1 {
+		t.Errorf("Snapshot() called %d times, want exactly 1", fake.callCount)
+	}
+}
+
+// ── TestArbModeHandler_ContentType_JSON ──────────────────────────────────────
+
+func TestArbModeHandler_ContentType_JSON(t *testing.T) {
+	h := NewHandler(&fakeSnapshotter{
+		snap: Snapshot{
+			Current: ModePassthrough,
+			Pending: ModePassthrough,
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/arbitrator/mode", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}

--- a/internal/module/agent/arbmode/manager.go
+++ b/internal/module/agent/arbmode/manager.go
@@ -1,0 +1,123 @@
+package arbmode
+
+import (
+	"log"
+	"sync"
+)
+
+// Manager is a state machine for the AGENT_ARB_MODE feature flag.
+//
+// Precedence rules (evaluated once at construction):
+//   - env set & valid   → current=pending=envValue; envLocked=true
+//   - env set & invalid → log warn; fall through to configVal
+//   - env unset         → current=pending=configVal (invalid/empty falls back
+//     to ModePassthrough with log warn)
+//
+// Hot-reload behaviour:
+//   - OnConfigChange updates pending only; it is a no-op when envLocked=true.
+//   - ApplyAtSessionStart promotes pending → current.
+//
+// All reads go through Snapshot to avoid torn state across concurrent calls.
+type Manager struct {
+	mu        sync.RWMutex
+	current   ArbMode // active mode
+	pending   ArbMode // mode applied at the next SessionStart
+	envLocked bool    // true when env var overrides config hot reload
+	envValue  ArbMode // recorded env value (valid; zero when env unset/invalid)
+}
+
+// Snapshot is an immutable point-in-time view of the Manager's state.
+type Snapshot struct {
+	Current   ArbMode
+	Pending   ArbMode
+	EnvLocked bool
+}
+
+// NewManager constructs a Manager from a raw env string and a raw config value
+// string. Both are validated internally; invalid or empty values fall back to
+// ModePassthrough with a log warning.
+func NewManager(env, configVal string) *Manager {
+	m := &Manager{}
+
+	// Env takes highest precedence.
+	if env != "" {
+		ev := ArbMode(env)
+		if ev.IsValid() {
+			m.current = ev
+			m.pending = ev
+			m.envLocked = true
+			m.envValue = ev
+			return m
+		}
+		log.Printf("[arbmode] invalid env value %q — falling through to config", env)
+	}
+
+	// No env (or invalid env): use config value.
+	cv := ArbMode(configVal)
+	if cv.IsValid() {
+		m.current = cv
+		m.pending = cv
+		return m
+	}
+
+	if configVal != "" {
+		log.Printf("[arbmode] invalid config value %q — falling back to passthrough", configVal)
+	}
+	m.current = ModePassthrough
+	m.pending = ModePassthrough
+	return m
+}
+
+// Snapshot returns the current state in a single RLock span to prevent torn
+// reads during a concurrent OnConfigChange call.
+func (m *Manager) Snapshot() Snapshot {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return Snapshot{
+		Current:   m.current,
+		Pending:   m.pending,
+		EnvLocked: m.envLocked,
+	}
+}
+
+// OnConfigChange receives a new raw config value and updates pending if it
+// differs from the current pending value.
+//
+// Returns true when pending was changed, false otherwise.
+//
+// It is a no-op (returns false, logs warn) when the Manager is env-locked.
+// An invalid or empty configVal falls back to ModePassthrough with a log warn.
+func (m *Manager) OnConfigChange(configVal string) (changed bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.envLocked {
+		log.Printf("[arbmode] hot reload ignored: overridden by env (%q)", m.envValue)
+		return false
+	}
+
+	cv := ArbMode(configVal)
+	if !cv.IsValid() {
+		log.Printf("[arbmode] invalid config value %q — falling back to passthrough", configVal)
+		cv = ModePassthrough
+	}
+
+	if cv == m.pending {
+		return false
+	}
+
+	m.pending = cv
+	return true
+}
+
+// ApplyAtSessionStart promotes pending → current.
+// It is a no-op when current already equals pending.
+func (m *Manager) ApplyAtSessionStart() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.current == m.pending {
+		return
+	}
+	m.current = m.pending
+}

--- a/internal/module/agent/arbmode/manager.go
+++ b/internal/module/agent/arbmode/manager.go
@@ -49,7 +49,7 @@ func NewManager(env, configVal string) *Manager {
 			m.envValue = ev
 			return m
 		}
-		log.Printf("[arbmode] invalid env value %q — falling through to config", env)
+		log.Printf("[agent][arbmode] invalid env value %q — falling through to config", env)
 	}
 
 	// No env (or invalid env): use config value.
@@ -61,7 +61,7 @@ func NewManager(env, configVal string) *Manager {
 	}
 
 	if configVal != "" {
-		log.Printf("[arbmode] invalid config value %q — falling back to passthrough", configVal)
+		log.Printf("[agent][arbmode] invalid config value %q — falling back to passthrough", configVal)
 	}
 	m.current = ModePassthrough
 	m.pending = ModePassthrough
@@ -92,13 +92,13 @@ func (m *Manager) OnConfigChange(configVal string) (changed bool) {
 	defer m.mu.Unlock()
 
 	if m.envLocked {
-		log.Printf("[arbmode] hot reload ignored: overridden by env (%q)", m.envValue)
+		log.Printf("[agent][arbmode] hot reload ignored: overridden by env (%q)", m.envValue)
 		return false
 	}
 
 	cv := ArbMode(configVal)
 	if !cv.IsValid() {
-		log.Printf("[arbmode] invalid config value %q — falling back to passthrough", configVal)
+		log.Printf("[agent][arbmode] invalid config value %q — falling back to passthrough", configVal)
 		cv = ModePassthrough
 	}
 

--- a/internal/module/agent/arbmode/manager_test.go
+++ b/internal/module/agent/arbmode/manager_test.go
@@ -158,7 +158,10 @@ func TestManager_OnConfigChange_InvalidValue_FallbackToPassthrough(t *testing.T)
 	buf := captureLog(t)
 	// "bogus" is invalid; should fall back to passthrough.
 	// Since current pending is authoritative and fallback is passthrough, changed=true.
-	m.OnConfigChange("bogus")
+	changed := m.OnConfigChange("bogus")
+	if !changed {
+		t.Error("OnConfigChange returned false; want true when fallback changes pending (authoritative → passthrough)")
+	}
 	if !strings.Contains(buf.String(), "invalid config value") {
 		t.Errorf("expected log to contain %q, got: %q", "invalid config value", buf.String())
 	}
@@ -240,35 +243,6 @@ func TestManager_Snapshot_NotTornDuringConfigChange(t *testing.T) {
 			}
 		}
 	}()
-
-	wg.Wait()
-}
-
-func TestManager_ConcurrentReadWrite_Race(t *testing.T) {
-	m := NewManager("", "passthrough")
-
-	const goroutines = 100
-	var wg sync.WaitGroup
-
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_ = m.Snapshot()
-		}()
-	}
-
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			if i%2 == 0 {
-				m.OnConfigChange("authoritative")
-			} else {
-				m.OnConfigChange("passthrough")
-			}
-		}(i)
-	}
 
 	wg.Wait()
 }

--- a/internal/module/agent/arbmode/manager_test.go
+++ b/internal/module/agent/arbmode/manager_test.go
@@ -1,0 +1,274 @@
+package arbmode
+
+import (
+	"log"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// captureLog redirects the default logger to a buffer for the duration of t.
+// It restores the original writer via t.Cleanup.
+func captureLog(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	old := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(old) })
+	return &buf
+}
+
+// ── ArbMode ─────────────────────────────────────────────────────────────────
+
+func TestArbMode_IsValid(t *testing.T) {
+	if !ModePassthrough.IsValid() {
+		t.Error("ModePassthrough.IsValid() should be true")
+	}
+	if !ModeAuthoritative.IsValid() {
+		t.Error("ModeAuthoritative.IsValid() should be true")
+	}
+	if ArbMode("bogus").IsValid() {
+		t.Error(`ArbMode("bogus").IsValid() should be false`)
+	}
+	if ArbMode("").IsValid() {
+		t.Error(`ArbMode("").IsValid() should be false`)
+	}
+}
+
+// ── NewManager ───────────────────────────────────────────────────────────────
+
+func TestManager_DefaultPassthrough_Snapshot(t *testing.T) {
+	m := NewManager("", "")
+	snap := m.Snapshot()
+	if snap.Current != ModePassthrough {
+		t.Errorf("Current=%q, want %q", snap.Current, ModePassthrough)
+	}
+	if snap.Pending != ModePassthrough {
+		t.Errorf("Pending=%q, want %q", snap.Pending, ModePassthrough)
+	}
+	if snap.EnvLocked {
+		t.Error("EnvLocked should be false")
+	}
+}
+
+func TestManager_ConfigOnly_Authoritative(t *testing.T) {
+	m := NewManager("", "authoritative")
+	snap := m.Snapshot()
+	if snap.Current != ModeAuthoritative {
+		t.Errorf("Current=%q, want %q", snap.Current, ModeAuthoritative)
+	}
+	if snap.EnvLocked {
+		t.Error("EnvLocked should be false")
+	}
+}
+
+func TestManager_EnvPassthrough_ConfigAuthoritative_EnvWins(t *testing.T) {
+	m := NewManager("passthrough", "authoritative")
+	snap := m.Snapshot()
+	if snap.Current != ModePassthrough {
+		t.Errorf("Current=%q, want passthrough", snap.Current)
+	}
+	if snap.Pending != ModePassthrough {
+		t.Errorf("Pending=%q, want passthrough", snap.Pending)
+	}
+	if !snap.EnvLocked {
+		t.Error("EnvLocked should be true when env is set")
+	}
+}
+
+func TestManager_EnvInvalid_FallbackToConfig(t *testing.T) {
+	buf := captureLog(t)
+	m := NewManager("bogus", "authoritative")
+	snap := m.Snapshot()
+	if snap.Current != ModeAuthoritative {
+		t.Errorf("Current=%q, want authoritative", snap.Current)
+	}
+	if snap.EnvLocked {
+		t.Error("EnvLocked should be false when env value is invalid")
+	}
+	if !strings.Contains(buf.String(), "invalid env value") {
+		t.Errorf("expected log to contain %q, got: %q", "invalid env value", buf.String())
+	}
+}
+
+func TestManager_ConfigInvalid_FallbackToPassthrough(t *testing.T) {
+	buf := captureLog(t)
+	m := NewManager("", "bogus")
+	snap := m.Snapshot()
+	if snap.Current != ModePassthrough {
+		t.Errorf("Current=%q, want passthrough", snap.Current)
+	}
+	if !strings.Contains(buf.String(), "invalid config value") {
+		t.Errorf("expected log to contain %q, got: %q", "invalid config value", buf.String())
+	}
+}
+
+// ── OnConfigChange ────────────────────────────────────────────────────────────
+
+func TestManager_OnConfigChange_EnvUnset_UpdatesPending(t *testing.T) {
+	m := NewManager("", "passthrough")
+	changed := m.OnConfigChange("authoritative")
+	if !changed {
+		t.Error("OnConfigChange should return true when pending changes")
+	}
+	snap := m.Snapshot()
+	if snap.Current != ModePassthrough {
+		t.Errorf("Current=%q, want passthrough (should not change yet)", snap.Current)
+	}
+	if snap.Pending != ModeAuthoritative {
+		t.Errorf("Pending=%q, want authoritative", snap.Pending)
+	}
+	if snap.EnvLocked {
+		t.Error("EnvLocked should be false")
+	}
+}
+
+func TestManager_OnConfigChange_EnvLocked_NoOp(t *testing.T) {
+	buf := captureLog(t)
+	m := NewManager("authoritative", "passthrough")
+	changed := m.OnConfigChange("passthrough")
+	if changed {
+		t.Error("OnConfigChange should return false when env-locked")
+	}
+	snap := m.Snapshot()
+	if snap.Pending != ModeAuthoritative {
+		t.Errorf("Pending=%q, should stay authoritative (env-locked)", snap.Pending)
+	}
+	if !strings.Contains(buf.String(), "overridden by env") {
+		t.Errorf("expected log to contain %q, got: %q", "overridden by env", buf.String())
+	}
+}
+
+func TestManager_OnConfigChange_SameValue_NoOp(t *testing.T) {
+	m := NewManager("", "passthrough")
+	// Clear any log from NewManager by using a fresh capture after construction.
+	buf := captureLog(t)
+	changed := m.OnConfigChange("passthrough")
+	if changed {
+		t.Error("OnConfigChange should return false when value unchanged")
+	}
+	if buf.String() != "" {
+		t.Errorf("expected no log output, got: %q", buf.String())
+	}
+}
+
+func TestManager_OnConfigChange_InvalidValue_FallbackToPassthrough(t *testing.T) {
+	// Start with pending=authoritative.
+	m := NewManager("", "authoritative")
+	buf := captureLog(t)
+	// "bogus" is invalid; should fall back to passthrough.
+	// Since current pending is authoritative and fallback is passthrough, changed=true.
+	m.OnConfigChange("bogus")
+	if !strings.Contains(buf.String(), "invalid config value") {
+		t.Errorf("expected log to contain %q, got: %q", "invalid config value", buf.String())
+	}
+	snap := m.Snapshot()
+	if snap.Pending != ModePassthrough {
+		t.Errorf("Pending=%q, want passthrough after invalid config", snap.Pending)
+	}
+}
+
+// ── ApplyAtSessionStart ───────────────────────────────────────────────────────
+
+func TestManager_ApplyAtSessionStart_PromotesPending(t *testing.T) {
+	m := NewManager("", "passthrough")
+	m.OnConfigChange("authoritative") // pending=authoritative, current=passthrough
+	m.ApplyAtSessionStart()
+	snap := m.Snapshot()
+	if snap.Current != ModeAuthoritative {
+		t.Errorf("Current=%q, want authoritative after apply", snap.Current)
+	}
+	if snap.Pending != ModeAuthoritative {
+		t.Errorf("Pending=%q, want authoritative after apply", snap.Pending)
+	}
+}
+
+func TestManager_ApplyAtSessionStart_NoPendingDiff_NoOp(t *testing.T) {
+	m := NewManager("", "passthrough")
+	// current == pending == passthrough; apply should be a no-op.
+	m.ApplyAtSessionStart()
+	snap := m.Snapshot()
+	if snap.Current != ModePassthrough {
+		t.Errorf("Current=%q, want passthrough", snap.Current)
+	}
+	if snap.Pending != ModePassthrough {
+		t.Errorf("Pending=%q, want passthrough", snap.Pending)
+	}
+}
+
+// ── Concurrency ───────────────────────────────────────────────────────────────
+
+func TestManager_Snapshot_NotTornDuringConfigChange(t *testing.T) {
+	m := NewManager("", "passthrough") // current=passthrough, pending=passthrough
+
+	const iters = 10_000
+	var wg sync.WaitGroup
+
+	// Goroutine A: flip OnConfigChange between passthrough and authoritative.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if i%2 == 0 {
+				m.OnConfigChange("authoritative")
+			} else {
+				m.OnConfigChange("passthrough")
+			}
+		}
+	}()
+
+	// Goroutine B: read Snapshot and assert invariants.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			snap := m.Snapshot()
+			// current must stay passthrough (we never call ApplyAtSessionStart).
+			if snap.Current != ModePassthrough {
+				t.Errorf("torn read: Current=%q, want passthrough", snap.Current)
+				return
+			}
+			// EnvLocked must stay false (no env set).
+			if snap.EnvLocked {
+				t.Error("torn read: EnvLocked should be false")
+				return
+			}
+			// Pending must be one of the two valid modes (never zero/invalid).
+			if !snap.Pending.IsValid() {
+				t.Errorf("torn read: Pending=%q is invalid", snap.Pending)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestManager_ConcurrentReadWrite_Race(t *testing.T) {
+	m := NewManager("", "passthrough")
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = m.Snapshot()
+		}()
+	}
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				m.OnConfigChange("authoritative")
+			} else {
+				m.OnConfigChange("passthrough")
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/internal/module/agent/arbmode/mode.go
+++ b/internal/module/agent/arbmode/mode.go
@@ -1,0 +1,26 @@
+// Package arbmode implements the AGENT_ARB_MODE feature flag state machine.
+// It tracks the current and pending arbitrator mode, respects env-lock
+// semantics, and promotes pending → current only at SessionStart.
+package arbmode
+
+// ArbMode identifies which arbitration strategy is active.
+type ArbMode string
+
+const (
+	// ModePassthrough means the Arbitrator forwards observations unchanged
+	// without applying any override logic.
+	ModePassthrough ArbMode = "passthrough"
+
+	// ModeAuthoritative means the Arbitrator actively adjudicates observations
+	// and may accept, reject, or merge proposals.
+	ModeAuthoritative ArbMode = "authoritative"
+)
+
+// IsValid reports whether m is one of the two defined ArbMode values.
+func (m ArbMode) IsValid() bool {
+	switch m {
+	case ModePassthrough, ModeAuthoritative:
+		return true
+	}
+	return false
+}

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -106,10 +106,30 @@ func (m *Module) Init(c *core.Core) error {
 	// dependency.
 	c.CfgMu.RLock()
 	initialArbMode := c.Cfg.Agent.ArbMode
+	initialUploadDir := c.Cfg.UploadDir
 	c.CfgMu.RUnlock()
 	m.arbmodeMgr = arbmode.NewManager(os.Getenv("AGENT_ARB_MODE"), initialArbMode)
 	m.arbmodeHandler = arbmode.NewHandler(m.arbmodeMgr)
 	c.Registry.Register("agent.arbmode.manager", m.arbmodeMgr)
+	if m.uploadDir == "" {
+		m.uploadDir = initialUploadDir
+	}
+
+	// Register the OnConfigChange callback before the session-provider check so
+	// that hot-reload of agent.arb_mode (and UploadDir) keeps working even when
+	// the agent module falls into the degraded path.
+	c.OnConfigChange(func() {
+		c.CfgMu.RLock()
+		newDir := c.Cfg.UploadDir
+		newArbMode := c.Cfg.Agent.ArbMode
+		c.CfgMu.RUnlock()
+		if newDir != "" {
+			m.mu.Lock()
+			m.uploadDir = newDir
+			m.mu.Unlock()
+		}
+		m.arbmodeMgr.OnConfigChange(newArbMode)
+	})
 
 	svc, ok := c.Registry.Get(session.RegistryKey)
 	if !ok {
@@ -121,12 +141,6 @@ func (m *Module) Init(c *core.Core) error {
 	// Expose event store and module so other modules (e.g. session rename) can update it.
 	c.Registry.Register("agent.events", m.events)
 	c.Registry.Register("agent.module", m)
-
-	if m.uploadDir == "" {
-		c.CfgMu.RLock()
-		m.uploadDir = c.Cfg.UploadDir
-		c.CfgMu.RUnlock()
-	}
 
 	// Prober (shared across all providers)
 	m.tmux = c.Tmux
@@ -141,20 +155,6 @@ func (m *Module) Init(c *core.Core) error {
 	m.prober.RegisterIdentifier(codexProvider.Type(), codexProvider.Identify)
 	m.prober.RegisterReadiness(codexProvider.Type(), codex.NewReadinessChecker(c.Tmux))
 	c.Registry.Register("agent.prober", m.prober)
-
-	// Listen for config changes to update mutable module state.
-	c.OnConfigChange(func() {
-		c.CfgMu.RLock()
-		newDir := c.Cfg.UploadDir
-		newArbMode := c.Cfg.Agent.ArbMode
-		c.CfgMu.RUnlock()
-		if newDir != "" {
-			m.mu.Lock()
-			m.uploadDir = newDir
-			m.mu.Unlock()
-		}
-		m.arbmodeMgr.OnConfigChange(newArbMode)
-	})
 
 	// Codex provider
 	m.registry.Register(codexProvider)

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -99,6 +99,18 @@ func (m *Module) Dependencies() []string { return []string{"session"} }
 // and registers CC and Codex providers.
 func (m *Module) Init(c *core.Core) error {
 	m.core = c
+
+	// Build arbmode Manager + handler BEFORE the session-provider check so the
+	// /api/agent/arbitrator/mode endpoint is always available even in the
+	// degraded path where session provider is missing. arbmode has no session
+	// dependency.
+	c.CfgMu.RLock()
+	initialArbMode := c.Cfg.Agent.ArbMode
+	c.CfgMu.RUnlock()
+	m.arbmodeMgr = arbmode.NewManager(os.Getenv("AGENT_ARB_MODE"), initialArbMode)
+	m.arbmodeHandler = arbmode.NewHandler(m.arbmodeMgr)
+	c.Registry.Register("agent.arbmode.manager", m.arbmodeMgr)
+
 	svc, ok := c.Registry.Get(session.RegistryKey)
 	if !ok {
 		log.Printf("[agent] warning: session provider not found")
@@ -130,14 +142,6 @@ func (m *Module) Init(c *core.Core) error {
 	m.prober.RegisterReadiness(codexProvider.Type(), codex.NewReadinessChecker(c.Tmux))
 	c.Registry.Register("agent.prober", m.prober)
 
-	// arbmode: env > config > default (passthrough)
-	c.CfgMu.RLock()
-	initialArbMode := c.Cfg.Agent.ArbMode
-	c.CfgMu.RUnlock()
-	m.arbmodeMgr = arbmode.NewManager(os.Getenv("AGENT_ARB_MODE"), initialArbMode)
-	m.arbmodeHandler = arbmode.NewHandler(m.arbmodeMgr)
-	c.Registry.Register("agent.arbmode.manager", m.arbmodeMgr)
-
 	// Listen for config changes to update mutable module state.
 	c.OnConfigChange(func() {
 		c.CfgMu.RLock()
@@ -149,9 +153,7 @@ func (m *Module) Init(c *core.Core) error {
 			m.uploadDir = newDir
 			m.mu.Unlock()
 		}
-		if m.arbmodeMgr != nil {
-			m.arbmodeMgr.OnConfigChange(newArbMode)
-		}
+		m.arbmodeMgr.OnConfigChange(newArbMode)
 	})
 
 	// Codex provider

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/wake/purdex/internal/agent/opencode"
 	"github.com/wake/purdex/internal/agent/probe"
 	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/agent/arbmode"
 	"github.com/wake/purdex/internal/module/session"
 	"github.com/wake/purdex/internal/store"
 	"github.com/wake/purdex/internal/tmux"
@@ -60,6 +62,9 @@ type Module struct {
 
 	sweepCancel context.CancelFunc
 	sweepWG     sync.WaitGroup
+
+	arbmodeMgr     *arbmode.Manager
+	arbmodeHandler *arbmode.Handler
 }
 
 // New creates a new agent Module backed by the given AgentEventStore.
@@ -125,15 +130,27 @@ func (m *Module) Init(c *core.Core) error {
 	m.prober.RegisterReadiness(codexProvider.Type(), codex.NewReadinessChecker(c.Tmux))
 	c.Registry.Register("agent.prober", m.prober)
 
+	// arbmode: env > config > default (passthrough)
+	c.CfgMu.RLock()
+	initialArbMode := c.Cfg.Agent.ArbMode
+	c.CfgMu.RUnlock()
+	m.arbmodeMgr = arbmode.NewManager(os.Getenv("AGENT_ARB_MODE"), initialArbMode)
+	m.arbmodeHandler = arbmode.NewHandler(m.arbmodeMgr)
+	c.Registry.Register("agent.arbmode.manager", m.arbmodeMgr)
+
 	// Listen for config changes to update mutable module state.
 	c.OnConfigChange(func() {
 		c.CfgMu.RLock()
 		newDir := c.Cfg.UploadDir
+		newArbMode := c.Cfg.Agent.ArbMode
 		c.CfgMu.RUnlock()
 		if newDir != "" {
 			m.mu.Lock()
 			m.uploadDir = newDir
 			m.mu.Unlock()
+		}
+		if m.arbmodeMgr != nil {
+			m.arbmodeMgr.OnConfigChange(newArbMode)
 		}
 	})
 
@@ -164,6 +181,9 @@ func (m *Module) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/agent/cc/statusline/test/ready", m.handleStatuslineTestReady)
 	mux.HandleFunc("POST /api/agent/status", m.handleAgentStatus)
 	mux.HandleFunc("GET /api/agents/detect", m.handleDetect)
+
+	// Arbitrator mode (read-only snapshot)
+	mux.Handle("GET /api/agent/arbitrator/mode", m.arbmodeHandler)
 
 	// History (delegates to provider)
 	mux.HandleFunc("GET /api/sessions/{code}/history", m.handleHistory)

--- a/internal/module/agent/observation/actor_key.go
+++ b/internal/module/agent/observation/actor_key.go
@@ -12,8 +12,7 @@ type ActorKey struct {
 	ActorID    string `json:"actor_id"`
 }
 
-// String returns a human-readable representation of the key in the form
-// "<sessionID>/<generation>/<actorID>". It is safe to call on a zero value.
+// String implements fmt.Stringer. Safe on zero value.
 func (k ActorKey) String() string {
 	return fmt.Sprintf("%s/%d/%s", k.SessionID, k.Generation, k.ActorID)
 }

--- a/internal/module/agent/observation/actor_key.go
+++ b/internal/module/agent/observation/actor_key.go
@@ -1,0 +1,19 @@
+package observation
+
+import "fmt"
+
+// ActorKey is a composite key that uniquely identifies an actor within a
+// session and generation. It is suitable for use as a Go map key.
+//
+// Format: <sessionID>/<generation>/<actorID>
+type ActorKey struct {
+	SessionID  string `json:"session_id"`
+	Generation int64  `json:"generation"`
+	ActorID    string `json:"actor_id"`
+}
+
+// String returns a human-readable representation of the key in the form
+// "<sessionID>/<generation>/<actorID>". It is safe to call on a zero value.
+func (k ActorKey) String() string {
+	return fmt.Sprintf("%s/%d/%s", k.SessionID, k.Generation, k.ActorID)
+}

--- a/internal/module/agent/observation/actor_key_test.go
+++ b/internal/module/agent/observation/actor_key_test.go
@@ -1,0 +1,55 @@
+package observation_test
+
+import (
+	"testing"
+
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+func TestActorKey_String_Format(t *testing.T) {
+	k := observation.ActorKey{SessionID: "s1", Generation: 7, ActorID: "primary:main"}
+	want := "s1/7/primary:main"
+	if got := k.String(); got != want {
+		t.Errorf("ActorKey.String() = %q; want %q", got, want)
+	}
+}
+
+func TestActorKey_Equal(t *testing.T) {
+	k1 := observation.ActorKey{SessionID: "s1", Generation: 3, ActorID: "primary:main"}
+	k2 := observation.ActorKey{SessionID: "s1", Generation: 3, ActorID: "primary:main"}
+	if k1 != k2 {
+		t.Error("identical ActorKey structs should be equal")
+	}
+
+	k3 := observation.ActorKey{SessionID: "s2", Generation: 3, ActorID: "primary:main"}
+	if k1 == k3 {
+		t.Error("different SessionID should not be equal")
+	}
+
+	k4 := observation.ActorKey{SessionID: "s1", Generation: 4, ActorID: "primary:main"}
+	if k1 == k4 {
+		t.Error("different Generation should not be equal")
+	}
+
+	k5 := observation.ActorKey{SessionID: "s1", Generation: 3, ActorID: "subagent:explore-42"}
+	if k1 == k5 {
+		t.Error("different ActorID should not be equal")
+	}
+}
+
+func TestActorKey_UsableAsMapKey(t *testing.T) {
+	key1 := observation.ActorKey{SessionID: "s1", Generation: 1, ActorID: "primary:main"}
+	key2 := observation.ActorKey{SessionID: "s1", Generation: 2, ActorID: "primary:main"}
+
+	m := map[observation.ActorKey]string{}
+	m[key1] = "x"
+	m[key2] = "y"
+
+	got := m[key1]
+	if got != "x" {
+		t.Errorf("map[key1] = %q; want \"x\"", got)
+	}
+	if m[key2] != "y" {
+		t.Errorf("map[key2] = %q; want \"y\"", m[key2])
+	}
+}

--- a/internal/module/agent/observation/builder.go
+++ b/internal/module/agent/observation/builder.go
@@ -21,14 +21,15 @@ func WithDevMode(dev bool) BuilderOption {
 
 // Builder accumulates fields and produces a validated Observation via Build().
 //
-// Single-use: Build() does not deep-copy slices, so the returned Observation
-// shares DecisionPorts/Evidence backing arrays with the Builder. Mutating the
-// returned Observation's slices, or calling Build() again after Build(), will
-// produce undefined behaviour. Create a fresh Builder for each Observation.
-// Not thread-safe.
+// Single-use: Build() deep-copies top-level mutable fields (DecisionPorts,
+// Evidence, and their nested slices) so the returned Observation is safe to
+// hand off. EvidenceRef.Value is shallow-copied — if it holds a map or
+// pointer, callers must not mutate Value contents after Build(). Calling
+// Build() twice panics. Not thread-safe.
 type Builder struct {
-	dev bool
-	obs Observation
+	dev      bool
+	consumed bool
+	obs      Observation
 }
 
 // NewBuilder returns a fresh Builder with options applied in order.
@@ -129,7 +130,14 @@ func (b *Builder) Seq(v int64) *Builder {
 // DecisionPorts cap (16):
 //   - dev mode: panics
 //   - prod mode: truncates to 16 and logs "[agent][observation] decision_ports truncated from N to 16"
+//
+// Build panics if called more than once on the same Builder. Create a fresh
+// Builder for each Observation.
 func (b *Builder) Build() (Observation, error) {
+	if b.consumed {
+		panic("observation: Builder.Build called more than once — create a fresh Builder per Observation")
+	}
+
 	// --- required string fields ---
 	if b.obs.TraceID == "" {
 		return Observation{}, fmt.Errorf("%w: %s", ErrMissingRequiredField, "trace_id")
@@ -174,6 +182,12 @@ func (b *Builder) Build() (Observation, error) {
 	// SessionID + ObservedGeneration per D3.
 	ak := b.obs.Proposal.ActorKey
 	if ak != (ActorKey{}) {
+		// ActorID is required for a non-zero ActorKey. Without it, actors with
+		// different sessions/generations but empty ActorID would collapse onto the
+		// same identity key downstream.
+		if ak.ActorID == "" {
+			return Observation{}, ErrInvalidActorKey
+		}
 		if ak.SessionID != b.obs.SessionID {
 			return Observation{}, fmt.Errorf("%w: proposal=%q observation=%q",
 				ErrActorKeySessionMismatch, ak.SessionID, b.obs.SessionID)
@@ -194,6 +208,41 @@ func (b *Builder) Build() (Observation, error) {
 		b.obs.DecisionPorts = b.obs.DecisionPorts[:maxDecisionPorts]
 	}
 
+	// Deep-copy top-level mutable fields before returning so the returned
+	// Observation's slices do not alias the Builder's internal state.
+	// EvidenceRef.Value is any-typed and only shallow-copied; callers must
+	// not mutate Value contents (e.g. map entries) after Build().
 	out := b.obs
+	if len(out.DecisionPorts) > 0 {
+		ports := make([]DecisionPort, len(out.DecisionPorts))
+		for i, p := range out.DecisionPorts {
+			ports[i] = copyDecisionPort(p)
+		}
+		out.DecisionPorts = ports
+	}
+	if len(out.Evidence) > 0 {
+		evi := make([]EvidenceRef, len(out.Evidence))
+		copy(evi, out.Evidence)
+		out.Evidence = evi
+	}
+	b.consumed = true
 	return out, nil
+}
+
+// copyDecisionPort returns a deep copy of p with independent InputRefs and
+// Branches slices. The scalar fields (PortID, Selected, Reason) are value
+// types and are copied by the struct assignment.
+func copyDecisionPort(p DecisionPort) DecisionPort {
+	out := p
+	if len(p.InputRefs) > 0 {
+		refs := make([]EvidenceRef, len(p.InputRefs))
+		copy(refs, p.InputRefs)
+		out.InputRefs = refs
+	}
+	if len(p.Branches) > 0 {
+		branches := make([]Branch, len(p.Branches))
+		copy(branches, p.Branches)
+		out.Branches = branches
+	}
+	return out
 }

--- a/internal/module/agent/observation/builder.go
+++ b/internal/module/agent/observation/builder.go
@@ -20,8 +20,12 @@ func WithDevMode(dev bool) BuilderOption {
 }
 
 // Builder accumulates fields and produces a validated Observation via Build().
-// Safe to reuse across multiple observations within a single goroutine. Not
-// thread-safe — callers must hold their own synchronization if needed.
+//
+// Single-use: Build() does not deep-copy slices, so the returned Observation
+// shares DecisionPorts/Evidence backing arrays with the Builder. Mutating the
+// returned Observation's slices, or calling Build() again after Build(), will
+// produce undefined behaviour. Create a fresh Builder for each Observation.
+// Not thread-safe.
 type Builder struct {
 	dev bool
 	obs Observation
@@ -42,67 +46,56 @@ func (b *Builder) TraceID(v string) *Builder {
 	return b
 }
 
-// SpanID sets the span_id field.
 func (b *Builder) SpanID(v string) *Builder {
 	b.obs.SpanID = v
 	return b
 }
 
-// ParentSpanID sets the parent_span_id field.
 func (b *Builder) ParentSpanID(v string) *Builder {
 	b.obs.ParentSpanID = v
 	return b
 }
 
-// SessionID sets the session_id field.
 func (b *Builder) SessionID(v string) *Builder {
 	b.obs.SessionID = v
 	return b
 }
 
-// ObservedGeneration sets the observed_generation field.
 func (b *Builder) ObservedGeneration(v int64) *Builder {
 	b.obs.ObservedGeneration = v
 	return b
 }
 
-// SourceKind sets the source_kind field.
 func (b *Builder) SourceKind(v SourceKind) *Builder {
 	b.obs.SourceKind = v
 	return b
 }
 
-// WatcherToken sets the watcher_token field.
 func (b *Builder) WatcherToken(v string) *Builder {
 	b.obs.WatcherToken = v
 	return b
 }
 
-// Action sets the action field.
 func (b *Builder) Action(v string) *Builder {
 	b.obs.Action = v
 	return b
 }
 
-// Phase sets the phase field.
 func (b *Builder) Phase(v ObsPhase) *Builder {
 	b.obs.Phase = v
 	return b
 }
 
-// Proposal sets the proposal field.
 func (b *Builder) Proposal(v StateProposal) *Builder {
 	b.obs.Proposal = v
 	return b
 }
 
-// ReasonCode sets the reason_code field.
 func (b *Builder) ReasonCode(v string) *Builder {
 	b.obs.ReasonCode = v
 	return b
 }
 
-// ReasonText sets the reason_text field.
 func (b *Builder) ReasonText(v string) *Builder {
 	b.obs.ReasonText = v
 	return b
@@ -114,19 +107,16 @@ func (b *Builder) AddDecisionPort(v DecisionPort) *Builder {
 	return b
 }
 
-// Evidence sets the evidence field.
 func (b *Builder) Evidence(v []EvidenceRef) *Builder {
 	b.obs.Evidence = v
 	return b
 }
 
-// ObservedAt sets the observed_at field.
 func (b *Builder) ObservedAt(v time.Time) *Builder {
 	b.obs.ObservedAt = v
 	return b
 }
 
-// Seq sets the seq field.
 func (b *Builder) Seq(v int64) *Builder {
 	b.obs.Seq = v
 	return b

--- a/internal/module/agent/observation/builder.go
+++ b/internal/module/agent/observation/builder.go
@@ -1,0 +1,205 @@
+package observation
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+// BuilderOption is a functional option for configuring a Builder.
+type BuilderOption func(*Builder)
+
+// WithDevMode toggles the over-cap behaviour for DecisionPorts.
+// When dev is true, Build() panics if more than 16 DecisionPorts are present.
+// When dev is false (default / prod), Build() truncates to 16 and logs a
+// warning with prefix [agent][observation].
+func WithDevMode(dev bool) BuilderOption {
+	return func(b *Builder) {
+		b.dev = dev
+	}
+}
+
+// Builder accumulates fields and produces a validated Observation via Build().
+// Safe to reuse across multiple observations within a single goroutine. Not
+// thread-safe — callers must hold their own synchronization if needed.
+type Builder struct {
+	dev bool
+	obs Observation
+}
+
+// NewBuilder returns a fresh Builder with options applied in order.
+func NewBuilder(opts ...BuilderOption) *Builder {
+	b := &Builder{}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+// TraceID sets the trace_id field. No validation here; validation runs at Build().
+func (b *Builder) TraceID(v string) *Builder {
+	b.obs.TraceID = v
+	return b
+}
+
+// SpanID sets the span_id field.
+func (b *Builder) SpanID(v string) *Builder {
+	b.obs.SpanID = v
+	return b
+}
+
+// ParentSpanID sets the parent_span_id field.
+func (b *Builder) ParentSpanID(v string) *Builder {
+	b.obs.ParentSpanID = v
+	return b
+}
+
+// SessionID sets the session_id field.
+func (b *Builder) SessionID(v string) *Builder {
+	b.obs.SessionID = v
+	return b
+}
+
+// ObservedGeneration sets the observed_generation field.
+func (b *Builder) ObservedGeneration(v int64) *Builder {
+	b.obs.ObservedGeneration = v
+	return b
+}
+
+// SourceKind sets the source_kind field.
+func (b *Builder) SourceKind(v SourceKind) *Builder {
+	b.obs.SourceKind = v
+	return b
+}
+
+// WatcherToken sets the watcher_token field.
+func (b *Builder) WatcherToken(v string) *Builder {
+	b.obs.WatcherToken = v
+	return b
+}
+
+// Action sets the action field.
+func (b *Builder) Action(v string) *Builder {
+	b.obs.Action = v
+	return b
+}
+
+// Phase sets the phase field.
+func (b *Builder) Phase(v ObsPhase) *Builder {
+	b.obs.Phase = v
+	return b
+}
+
+// Proposal sets the proposal field.
+func (b *Builder) Proposal(v StateProposal) *Builder {
+	b.obs.Proposal = v
+	return b
+}
+
+// ReasonCode sets the reason_code field.
+func (b *Builder) ReasonCode(v string) *Builder {
+	b.obs.ReasonCode = v
+	return b
+}
+
+// ReasonText sets the reason_text field.
+func (b *Builder) ReasonText(v string) *Builder {
+	b.obs.ReasonText = v
+	return b
+}
+
+// AddDecisionPort appends a DecisionPort. The cap of 16 is enforced at Build().
+func (b *Builder) AddDecisionPort(v DecisionPort) *Builder {
+	b.obs.DecisionPorts = append(b.obs.DecisionPorts, v)
+	return b
+}
+
+// Evidence sets the evidence field.
+func (b *Builder) Evidence(v []EvidenceRef) *Builder {
+	b.obs.Evidence = v
+	return b
+}
+
+// ObservedAt sets the observed_at field.
+func (b *Builder) ObservedAt(v time.Time) *Builder {
+	b.obs.ObservedAt = v
+	return b
+}
+
+// Seq sets the seq field.
+func (b *Builder) Seq(v int64) *Builder {
+	b.obs.Seq = v
+	return b
+}
+
+// Build runs all validation rules defined in D3 and returns the Observation or
+// an error wrapping a sentinel. Callers may use errors.Is to match sentinels
+// and inspect err.Error() for the specific field name.
+//
+// DecisionPorts cap (16):
+//   - dev mode: panics
+//   - prod mode: truncates to 16 and logs "[agent][observation] decision_ports truncated from N to 16"
+func (b *Builder) Build() (Observation, error) {
+	// --- required string fields ---
+	if b.obs.TraceID == "" {
+		return Observation{}, fmt.Errorf("%w: %s", ErrMissingRequiredField, "trace_id")
+	}
+	if b.obs.SessionID == "" {
+		return Observation{}, fmt.Errorf("%w: %s", ErrMissingRequiredField, "session_id")
+	}
+
+	// --- SourceKind: required + valid ---
+	if b.obs.SourceKind == "" {
+		return Observation{}, fmt.Errorf("%w: %s", ErrMissingRequiredField, "source_kind")
+	}
+	if !b.obs.SourceKind.IsValid() {
+		return Observation{}, fmt.Errorf("%w: %q", ErrInvalidSourceKind, string(b.obs.SourceKind))
+	}
+
+	if b.obs.Action == "" {
+		return Observation{}, fmt.Errorf("%w: %s", ErrMissingRequiredField, "action")
+	}
+
+	// --- Phase: required + valid ---
+	if b.obs.Phase == "" {
+		return Observation{}, fmt.Errorf("%w: %s", ErrMissingRequiredField, "phase")
+	}
+	if !b.obs.Phase.IsValid() {
+		return Observation{}, fmt.Errorf("%w: %q", ErrInvalidPhase, string(b.obs.Phase))
+	}
+
+	if b.obs.ObservedAt.IsZero() {
+		return Observation{}, fmt.Errorf("%w: %s", ErrMissingRequiredField, "observed_at")
+	}
+
+	// --- probe requires watcher_token ---
+	if b.obs.SourceKind == SourceProbe && b.obs.WatcherToken == "" {
+		return Observation{}, ErrMissingWatcherToken
+	}
+
+	// --- ActorKey consistency (only when Proposal.ActorKey is non-zero) ---
+	ak := b.obs.Proposal.ActorKey
+	if ak != (ActorKey{}) {
+		if ak.SessionID != b.obs.SessionID {
+			return Observation{}, fmt.Errorf("%w: proposal=%q observation=%q",
+				ErrActorKeySessionMismatch, ak.SessionID, b.obs.SessionID)
+		}
+		if ak.Generation != b.obs.ObservedGeneration {
+			return Observation{}, fmt.Errorf("%w: proposal=%d observation=%d",
+				ErrActorKeyGenerationMismatch, ak.Generation, b.obs.ObservedGeneration)
+		}
+	}
+
+	// --- DecisionPorts cap ---
+	const maxDecisionPorts = 16
+	if n := len(b.obs.DecisionPorts); n > maxDecisionPorts {
+		if b.dev {
+			panic(fmt.Sprintf("[agent][observation] decision_ports cap exceeded: %d > %d", n, maxDecisionPorts))
+		}
+		log.Printf("[agent][observation] decision_ports truncated from %d to %d", n, maxDecisionPorts)
+		b.obs.DecisionPorts = b.obs.DecisionPorts[:maxDecisionPorts]
+	}
+
+	out := b.obs
+	return out, nil
+}

--- a/internal/module/agent/observation/builder.go
+++ b/internal/module/agent/observation/builder.go
@@ -177,7 +177,11 @@ func (b *Builder) Build() (Observation, error) {
 		return Observation{}, ErrMissingWatcherToken
 	}
 
-	// --- ActorKey consistency (only when Proposal.ActorKey is non-zero) ---
+	// --- ActorKey consistency ---
+	// Zero ActorKey means "no proposal attached" — reconcile-only observations
+	// emit trace without a proposal target (spec §3.4.5: stale_detected trace with
+	// no actor mutation). Non-zero ActorKey MUST align with the observation's
+	// SessionID + ObservedGeneration per D3.
 	ak := b.obs.Proposal.ActorKey
 	if ak != (ActorKey{}) {
 		if ak.SessionID != b.obs.SessionID {

--- a/internal/module/agent/observation/builder_test.go
+++ b/internal/module/agent/observation/builder_test.go
@@ -374,6 +374,126 @@ func TestBuilder_DecisionPorts_Empty_OK(t *testing.T) {
 	}
 }
 
+// ── 19b: Build() twice panics (consumed guard) ──────────────────────────────
+
+func TestBuilder_Build_Twice_Panics(t *testing.T) {
+	b := minimalBuilder()
+	if _, err := b.Build(); err != nil {
+		t.Fatalf("first Build() unexpected error: %v", err)
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("second Build() did not panic; want panic (consumed guard)")
+		}
+	}()
+	b.Build() //nolint:errcheck // expecting panic
+}
+
+// ── 19c: Mutating builder after Build() does not corrupt returned Observation ─
+
+func TestBuilder_Build_MutateBuilderAfter_DoesNotCorruptObservation(t *testing.T) {
+	b := minimalBuilder()
+	b.AddDecisionPort(observation.DecisionPort{PortID: "dp-1"})
+	b.Evidence([]observation.EvidenceRef{{Key: "ek", Value: "ev"}})
+
+	obs, err := b.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	// Snapshot lengths immediately after Build.
+	wantPorts := len(obs.DecisionPorts)
+	wantEvidence := len(obs.Evidence)
+
+	// Attempt to corrupt via the builder's internal slice (would work pre-fix
+	// since DecisionPorts was aliased). We cannot call AddDecisionPort again
+	// because consumed is set; instead confirm that the returned slice is
+	// independent by directly checking that lengths are unchanged.
+	if len(obs.DecisionPorts) != wantPorts {
+		t.Errorf("DecisionPorts len changed after Build: got %d want %d", len(obs.DecisionPorts), wantPorts)
+	}
+	if len(obs.Evidence) != wantEvidence {
+		t.Errorf("Evidence len changed after Build: got %d want %d", len(obs.Evidence), wantEvidence)
+	}
+}
+
+// ── 19d: Mutating returned slice does not affect builder's internal state ────
+
+func TestBuilder_Build_MutateReturnedSlice_DoesNotCorruptBuilder(t *testing.T) {
+	// We can only test independence: mutate the returned Observation's
+	// DecisionPorts and verify the values we stored are unaffected. Since
+	// Build() panics on second call we test via the copy itself.
+	b := minimalBuilder()
+	b.AddDecisionPort(observation.DecisionPort{PortID: "original"})
+
+	obs, err := b.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(obs.DecisionPorts) != 1 {
+		t.Fatalf("expected 1 DecisionPort, got %d", len(obs.DecisionPorts))
+	}
+
+	// Mutate the returned copy.
+	obs.DecisionPorts[0].PortID = "mutated"
+
+	// The builder's internal obs.DecisionPorts should still have "original"
+	// (pre-copy) — we verify indirectly by confirming obs was a deep copy:
+	// if it were aliased, both would now be "mutated"; since the test can't
+	// re-call Build(), we verify the returned copy has the mutated value
+	// (proving it's a separate slice that we own).
+	if obs.DecisionPorts[0].PortID != "mutated" {
+		t.Errorf("returned slice element not writable — unexpected aliasing")
+	}
+}
+
+// ── 20a: ActorKey with empty ActorID returns ErrInvalidActorKey ─────────────
+
+func TestBuilder_ActorKey_EmptyActorID_Error(t *testing.T) {
+	_, err := minimalBuilder().
+		SessionID("sess-1").
+		ObservedGeneration(5).
+		Proposal(observation.StateProposal{
+			ActorKey: observation.ActorKey{
+				SessionID:  "sess-1",
+				Generation: 5,
+				ActorID:    "", // empty ActorID with non-zero key
+			},
+		}).
+		Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrInvalidActorKey")
+	}
+	if !errors.Is(err, observation.ErrInvalidActorKey) {
+		t.Errorf("errors.Is(err, ErrInvalidActorKey) = false; err = %v", err)
+	}
+}
+
+// ── 20b: ActorKey with missing SessionID still returns mismatch (not invalid) ─
+
+func TestBuilder_ActorKey_MissingSessionID_Error(t *testing.T) {
+	// SessionID="" + non-empty ActorID: ActorKey is non-zero, ActorID non-empty,
+	// so ErrInvalidActorKey is NOT returned. Instead SessionID "" != obs.SessionID
+	// → ErrActorKeySessionMismatch.
+	_, err := minimalBuilder().
+		SessionID("sess-1").
+		ObservedGeneration(5).
+		Proposal(observation.StateProposal{
+			ActorKey: observation.ActorKey{
+				SessionID:  "", // empty session, but ActorID is non-empty
+				Generation: 5,
+				ActorID:    "primary:main",
+			},
+		}).
+		Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrActorKeySessionMismatch")
+	}
+	if !errors.Is(err, observation.ErrActorKeySessionMismatch) {
+		t.Errorf("errors.Is(err, ErrActorKeySessionMismatch) = false; err = %v", err)
+	}
+}
+
 // ── 19: Fluent chaining does not nil-deref ──────────────────────────────────
 
 func TestBuilder_Chaining(t *testing.T) {

--- a/internal/module/agent/observation/builder_test.go
+++ b/internal/module/agent/observation/builder_test.go
@@ -1,0 +1,400 @@
+package observation_test
+
+import (
+	"errors"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+// captureLog redirects the default logger to a buffer for the duration of t.
+// It restores the original writer via t.Cleanup.
+func captureLog(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	old := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(old) })
+	return &buf
+}
+
+// minimalBuilder returns a Builder with all required fields set to valid
+// non-zero values for use as a base in tests that only care about one field.
+func minimalBuilder() *observation.Builder {
+	return observation.NewBuilder().
+		TraceID("trace-1").
+		SessionID("sess-1").
+		SourceKind(observation.SourceHook).
+		Action("window-changed").
+		Phase(observation.PhaseProposed).
+		ObservedAt(time.Now())
+}
+
+// ── 1: Minimal happy path ────────────────────────────────────────────────────
+
+func TestBuilder_Build_Minimal(t *testing.T) {
+	now := time.Now()
+	obs, err := observation.NewBuilder().
+		TraceID("trace-abc").
+		SessionID("sess-xyz").
+		SourceKind(observation.SourceHook).
+		Action("pane-created").
+		Phase(observation.PhaseProposed).
+		ObservedAt(now).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() error = %v; want nil", err)
+	}
+	if obs.TraceID != "trace-abc" {
+		t.Errorf("TraceID = %q; want %q", obs.TraceID, "trace-abc")
+	}
+	if obs.SessionID != "sess-xyz" {
+		t.Errorf("SessionID = %q; want %q", obs.SessionID, "sess-xyz")
+	}
+	if obs.SourceKind != observation.SourceHook {
+		t.Errorf("SourceKind = %q; want %q", obs.SourceKind, observation.SourceHook)
+	}
+	if obs.Action != "pane-created" {
+		t.Errorf("Action = %q; want %q", obs.Action, "pane-created")
+	}
+	if obs.Phase != observation.PhaseProposed {
+		t.Errorf("Phase = %q; want %q", obs.Phase, observation.PhaseProposed)
+	}
+	if !obs.ObservedAt.Equal(now) {
+		t.Errorf("ObservedAt = %v; want %v", obs.ObservedAt, now)
+	}
+	if len(obs.DecisionPorts) != 0 {
+		t.Errorf("DecisionPorts len = %d; want 0", len(obs.DecisionPorts))
+	}
+}
+
+// ── 2: Missing TraceID ───────────────────────────────────────────────────────
+
+func TestBuilder_MissingTraceID_Error(t *testing.T) {
+	_, err := minimalBuilder().TraceID("").Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrMissingRequiredField")
+	}
+	if !errors.Is(err, observation.ErrMissingRequiredField) {
+		t.Errorf("errors.Is(err, ErrMissingRequiredField) = false; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "trace_id") {
+		t.Errorf("err.Error() = %q; want to contain %q", err.Error(), "trace_id")
+	}
+}
+
+// ── 3: Missing SessionID ─────────────────────────────────────────────────────
+
+func TestBuilder_MissingSessionID_Error(t *testing.T) {
+	_, err := minimalBuilder().SessionID("").Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrMissingRequiredField")
+	}
+	if !errors.Is(err, observation.ErrMissingRequiredField) {
+		t.Errorf("errors.Is(err, ErrMissingRequiredField) = false; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "session_id") {
+		t.Errorf("err.Error() = %q; want to contain %q", err.Error(), "session_id")
+	}
+}
+
+// ── 4: Missing SourceKind ────────────────────────────────────────────────────
+
+func TestBuilder_MissingSourceKind_Error(t *testing.T) {
+	_, err := minimalBuilder().SourceKind("").Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrMissingRequiredField")
+	}
+	if !errors.Is(err, observation.ErrMissingRequiredField) {
+		t.Errorf("errors.Is(err, ErrMissingRequiredField) = false; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "source_kind") {
+		t.Errorf("err.Error() = %q; want to contain %q", err.Error(), "source_kind")
+	}
+}
+
+// ── 5: Missing Action ────────────────────────────────────────────────────────
+
+func TestBuilder_MissingAction_Error(t *testing.T) {
+	_, err := minimalBuilder().Action("").Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrMissingRequiredField")
+	}
+	if !errors.Is(err, observation.ErrMissingRequiredField) {
+		t.Errorf("errors.Is(err, ErrMissingRequiredField) = false; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "action") {
+		t.Errorf("err.Error() = %q; want to contain %q", err.Error(), "action")
+	}
+}
+
+// ── 6: Missing Phase ─────────────────────────────────────────────────────────
+
+func TestBuilder_MissingPhase_Error(t *testing.T) {
+	_, err := minimalBuilder().Phase("").Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrMissingRequiredField")
+	}
+	if !errors.Is(err, observation.ErrMissingRequiredField) {
+		t.Errorf("errors.Is(err, ErrMissingRequiredField) = false; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "phase") {
+		t.Errorf("err.Error() = %q; want to contain %q", err.Error(), "phase")
+	}
+}
+
+// ── 7: Invalid Phase ─────────────────────────────────────────────────────────
+
+func TestBuilder_InvalidPhase_Error(t *testing.T) {
+	_, err := minimalBuilder().Phase("bogus").Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrInvalidPhase")
+	}
+	if !errors.Is(err, observation.ErrInvalidPhase) {
+		t.Errorf("errors.Is(err, ErrInvalidPhase) = false; err = %v", err)
+	}
+}
+
+// ── 8: Missing ObservedAt ────────────────────────────────────────────────────
+
+func TestBuilder_MissingObservedAt_Error(t *testing.T) {
+	_, err := minimalBuilder().ObservedAt(time.Time{}).Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrMissingRequiredField")
+	}
+	if !errors.Is(err, observation.ErrMissingRequiredField) {
+		t.Errorf("errors.Is(err, ErrMissingRequiredField) = false; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "observed_at") {
+		t.Errorf("err.Error() = %q; want to contain %q", err.Error(), "observed_at")
+	}
+}
+
+// ── 9: Invalid SourceKind ────────────────────────────────────────────────────
+
+func TestBuilder_InvalidSourceKind_Error(t *testing.T) {
+	_, err := minimalBuilder().SourceKind("bogus").Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrInvalidSourceKind")
+	}
+	if !errors.Is(err, observation.ErrInvalidSourceKind) {
+		t.Errorf("errors.Is(err, ErrInvalidSourceKind) = false; err = %v", err)
+	}
+}
+
+// ── 10: Probe without WatcherToken ──────────────────────────────────────────
+
+func TestBuilder_ProbeWithoutWatcherToken_Error(t *testing.T) {
+	_, err := minimalBuilder().
+		SourceKind(observation.SourceProbe).
+		WatcherToken("").
+		Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrMissingWatcherToken")
+	}
+	if !errors.Is(err, observation.ErrMissingWatcherToken) {
+		t.Errorf("errors.Is(err, ErrMissingWatcherToken) = false; err = %v", err)
+	}
+}
+
+// ── 11: Hook without WatcherToken is OK ─────────────────────────────────────
+
+func TestBuilder_HookWithoutWatcherToken_OK(t *testing.T) {
+	_, err := minimalBuilder().
+		SourceKind(observation.SourceHook).
+		WatcherToken("").
+		Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v; want nil (hook does not require watcher_token)", err)
+	}
+}
+
+// ── 12: ActorKey SessionID mismatch ─────────────────────────────────────────
+
+func TestBuilder_ActorKeySessionMismatch_Error(t *testing.T) {
+	_, err := minimalBuilder().
+		SessionID("sess-1").
+		Proposal(observation.StateProposal{
+			ActorKey: observation.ActorKey{
+				SessionID:  "other-session",
+				Generation: 0,
+				ActorID:    "primary:main",
+			},
+		}).
+		Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrActorKeySessionMismatch")
+	}
+	if !errors.Is(err, observation.ErrActorKeySessionMismatch) {
+		t.Errorf("errors.Is(err, ErrActorKeySessionMismatch) = false; err = %v", err)
+	}
+}
+
+// ── 13: ActorKey Generation mismatch ────────────────────────────────────────
+
+func TestBuilder_ActorKeyGenerationMismatch_Error(t *testing.T) {
+	_, err := minimalBuilder().
+		SessionID("sess-1").
+		ObservedGeneration(5).
+		Proposal(observation.StateProposal{
+			ActorKey: observation.ActorKey{
+				SessionID:  "sess-1",
+				Generation: 7, // mismatch
+				ActorID:    "primary:main",
+			},
+		}).
+		Build()
+	if err == nil {
+		t.Fatal("Build() error = nil; want ErrActorKeyGenerationMismatch")
+	}
+	if !errors.Is(err, observation.ErrActorKeyGenerationMismatch) {
+		t.Errorf("errors.Is(err, ErrActorKeyGenerationMismatch) = false; err = %v", err)
+	}
+}
+
+// ── 14: Zero ObservedGeneration with matching ActorKey.Generation = 0 ──────
+
+func TestBuilder_ZeroObservedGeneration_OK(t *testing.T) {
+	_, err := minimalBuilder().
+		SessionID("sess-1").
+		ObservedGeneration(0).
+		Proposal(observation.StateProposal{
+			ActorKey: observation.ActorKey{
+				SessionID:  "sess-1",
+				Generation: 0,
+				ActorID:    "primary:main",
+			},
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v; want nil (zero generation is allowed)", err)
+	}
+}
+
+// ── 15: Exactly 16 DecisionPorts — OK ───────────────────────────────────────
+
+func TestBuilder_DecisionPorts_Exactly16_OK(t *testing.T) {
+	b := minimalBuilder()
+	for i := 0; i < 16; i++ {
+		b.AddDecisionPort(observation.DecisionPort{PortID: "p"})
+	}
+	obs, err := b.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v; want nil", err)
+	}
+	if len(obs.DecisionPorts) != 16 {
+		t.Errorf("DecisionPorts len = %d; want 16", len(obs.DecisionPorts))
+	}
+}
+
+// ── 16: 17 DecisionPorts in prod → truncate + log ───────────────────────────
+
+func TestBuilder_DecisionPorts_17_ProdTruncate(t *testing.T) {
+	buf := captureLog(t)
+
+	b := minimalBuilder() // prod mode (default)
+	for i := 0; i < 17; i++ {
+		b.AddDecisionPort(observation.DecisionPort{PortID: "p"})
+	}
+	obs, err := b.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v; want nil (prod truncates, not errors)", err)
+	}
+	if len(obs.DecisionPorts) != 16 {
+		t.Errorf("DecisionPorts len = %d; want 16", len(obs.DecisionPorts))
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "[agent][observation] decision_ports truncated from 17 to 16") {
+		t.Errorf("log output = %q; want to contain truncation message", logged)
+	}
+}
+
+// ── 17: 17 DecisionPorts in dev mode → panic ────────────────────────────────
+
+func TestBuilder_DecisionPorts_17_DevPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Build() did not panic; want panic in dev mode with 17 DecisionPorts")
+		}
+	}()
+
+	b := observation.NewBuilder(observation.WithDevMode(true)).
+		TraceID("trace-1").
+		SessionID("sess-1").
+		SourceKind(observation.SourceHook).
+		Action("window-changed").
+		Phase(observation.PhaseProposed).
+		ObservedAt(time.Now())
+
+	for i := 0; i < 17; i++ {
+		b.AddDecisionPort(observation.DecisionPort{PortID: "p"})
+	}
+	//nolint:errcheck // expecting panic
+	b.Build() //nolint:errcheck
+}
+
+// ── 18: Empty DecisionPorts — OK ────────────────────────────────────────────
+
+func TestBuilder_DecisionPorts_Empty_OK(t *testing.T) {
+	obs, err := minimalBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v; want nil", err)
+	}
+	if len(obs.DecisionPorts) != 0 {
+		t.Errorf("DecisionPorts len = %d; want 0", len(obs.DecisionPorts))
+	}
+}
+
+// ── 19: Fluent chaining does not nil-deref ──────────────────────────────────
+
+func TestBuilder_Chaining(t *testing.T) {
+	now := time.Now()
+	obs, err := observation.NewBuilder().
+		TraceID("t").
+		SpanID("s").
+		ParentSpanID("p").
+		SessionID("sess").
+		ObservedGeneration(3).
+		SourceKind(observation.SourceSweep).
+		WatcherToken("tok").
+		Action("sweep-cycle").
+		Phase(observation.PhaseCommitted).
+		ReasonCode("rc").
+		ReasonText("all good").
+		Evidence([]observation.EvidenceRef{{Key: "k", Value: "v"}}).
+		ObservedAt(now).
+		Seq(42).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() error = %v; want nil", err)
+	}
+	if obs.SpanID != "s" {
+		t.Errorf("SpanID = %q; want %q", obs.SpanID, "s")
+	}
+	if obs.ParentSpanID != "p" {
+		t.Errorf("ParentSpanID = %q; want %q", obs.ParentSpanID, "p")
+	}
+	if obs.ObservedGeneration != 3 {
+		t.Errorf("ObservedGeneration = %d; want 3", obs.ObservedGeneration)
+	}
+	if obs.WatcherToken != "tok" {
+		t.Errorf("WatcherToken = %q; want %q", obs.WatcherToken, "tok")
+	}
+	if obs.ReasonCode != "rc" {
+		t.Errorf("ReasonCode = %q; want %q", obs.ReasonCode, "rc")
+	}
+	if obs.ReasonText != "all good" {
+		t.Errorf("ReasonText = %q; want %q", obs.ReasonText, "all good")
+	}
+	if obs.Seq != 42 {
+		t.Errorf("Seq = %d; want 42", obs.Seq)
+	}
+	if len(obs.Evidence) != 1 || obs.Evidence[0].Key != "k" {
+		t.Errorf("Evidence = %+v; want [{k v}]", obs.Evidence)
+	}
+}

--- a/internal/module/agent/observation/builder_test.go
+++ b/internal/module/agent/observation/builder_test.go
@@ -159,9 +159,9 @@ func TestBuilder_InvalidPhase_Error(t *testing.T) {
 	}
 }
 
-// ── 8: Missing ObservedAt ────────────────────────────────────────────────────
+// ── 8: Zero ObservedAt ───────────────────────────────────────────────────────
 
-func TestBuilder_MissingObservedAt_Error(t *testing.T) {
+func TestBuilder_ZeroObservedAt_Error(t *testing.T) {
 	_, err := minimalBuilder().ObservedAt(time.Time{}).Build()
 	if err == nil {
 		t.Fatal("Build() error = nil; want ErrMissingRequiredField")
@@ -171,6 +171,32 @@ func TestBuilder_MissingObservedAt_Error(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "observed_at") {
 		t.Errorf("err.Error() = %q; want to contain %q", err.Error(), "observed_at")
+	}
+}
+
+// ── 8b: No-proposal case (zero Proposal.ActorKey with non-zero SessionID/Generation)
+//
+// Reconcile-only observations (spec §3.4.5) emit trace without a proposal.
+// Zero ActorKey must skip mismatch checks even when SessionID/ObservedGeneration
+// on the observation are non-zero. This guards against the comment in builder.go
+// becoming a regression over time.
+
+func TestBuilder_NoProposal_OK(t *testing.T) {
+	obs, err := observation.NewBuilder().
+		TraceID("trace-reconcile").
+		SessionID("sess-abc").
+		SourceKind(observation.SourceReconcile).
+		Action("actor.stale_detected").
+		Phase(observation.PhaseProposed).
+		ObservedGeneration(5).
+		ObservedAt(time.Now()).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() error = %v; want nil (no-proposal path)", err)
+	}
+	if (obs.Proposal.ActorKey != observation.ActorKey{}) {
+		t.Errorf("Proposal.ActorKey = %+v; want zero", obs.Proposal.ActorKey)
 	}
 }
 

--- a/internal/module/agent/observation/builder_test.go
+++ b/internal/module/agent/observation/builder_test.go
@@ -359,8 +359,7 @@ func TestBuilder_DecisionPorts_17_DevPanic(t *testing.T) {
 	for i := 0; i < 17; i++ {
 		b.AddDecisionPort(observation.DecisionPort{PortID: "p"})
 	}
-	//nolint:errcheck // expecting panic
-	b.Build() //nolint:errcheck
+	b.Build() //nolint:errcheck // expecting panic
 }
 
 // ── 18: Empty DecisionPorts — OK ────────────────────────────────────────────

--- a/internal/module/agent/observation/errors.go
+++ b/internal/module/agent/observation/errors.go
@@ -1,0 +1,29 @@
+package observation
+
+import "errors"
+
+// ErrMissingRequiredField is returned by Builder.Build when a required field
+// is empty or zero. The error is wrapped with the field name so callers can
+// inspect it via err.Error() while still using errors.Is for type checking.
+var ErrMissingRequiredField = errors.New("observation: required field missing")
+
+// ErrInvalidSourceKind is returned by Builder.Build when SourceKind is set to
+// a non-empty value that is not one of the five defined constants.
+var ErrInvalidSourceKind = errors.New("observation: invalid source kind")
+
+// ErrInvalidPhase is returned by Builder.Build when Phase is set to a
+// non-empty value that is not one of the three defined ObsPhase constants.
+var ErrInvalidPhase = errors.New("observation: invalid phase")
+
+// ErrMissingWatcherToken is returned by Builder.Build when SourceKind is
+// SourceProbe but WatcherToken is empty.
+var ErrMissingWatcherToken = errors.New("observation: probe observation missing watcher_token")
+
+// ErrActorKeySessionMismatch is returned by Builder.Build when
+// Proposal.ActorKey.SessionID does not equal the Observation's SessionID.
+var ErrActorKeySessionMismatch = errors.New("observation: proposal actor key session mismatch")
+
+// ErrActorKeyGenerationMismatch is returned by Builder.Build when
+// Proposal.ActorKey.Generation does not equal the Observation's
+// ObservedGeneration.
+var ErrActorKeyGenerationMismatch = errors.New("observation: proposal actor key generation mismatch")

--- a/internal/module/agent/observation/errors.go
+++ b/internal/module/agent/observation/errors.go
@@ -27,3 +27,8 @@ var ErrActorKeySessionMismatch = errors.New("observation: proposal actor key ses
 // Proposal.ActorKey.Generation does not equal the Observation's
 // ObservedGeneration.
 var ErrActorKeyGenerationMismatch = errors.New("observation: proposal actor key generation mismatch")
+
+// ErrInvalidActorKey is returned when a Proposal is present (non-zero
+// ActorKey) but the ActorKey is not complete (SessionID, Generation, ActorID
+// must all be meaningful; empty ActorID is rejected).
+var ErrInvalidActorKey = errors.New("observation: invalid actor key (non-zero ActorKey must have non-empty ActorID)")

--- a/internal/module/agent/observation/evidence.go
+++ b/internal/module/agent/observation/evidence.go
@@ -1,0 +1,13 @@
+package observation
+
+// EvidenceRef is a low-cardinality key/value pair that carries supporting
+// evidence for an Observation or DecisionPort. Value may be a string, int64,
+// ActorKey, or any other JSON-serializable type; the caller is responsible for
+// ensuring serializability.
+//
+// JSON unmarshal decodes numeric values as float64 (stdlib behavior). Callers
+// that require the original int64 must type-assert after Unmarshal.
+type EvidenceRef struct {
+	Key   string `json:"key"`
+	Value any    `json:"value"`
+}

--- a/internal/module/agent/observation/evidence_test.go
+++ b/internal/module/agent/observation/evidence_test.go
@@ -1,0 +1,95 @@
+package observation_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+func TestEvidenceRef_StringValue_JSON(t *testing.T) {
+	orig := observation.EvidenceRef{Key: "pid", Value: "12345"}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got observation.EvidenceRef
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Key != "pid" {
+		t.Errorf("Key = %q; want \"pid\"", got.Key)
+	}
+	if got.Value != "12345" {
+		t.Errorf("Value = %v; want \"12345\"", got.Value)
+	}
+}
+
+func TestEvidenceRef_Int64Value_JSON(t *testing.T) {
+	// NOTE: JSON numbers decode to float64 when unmarshaled into `any`.
+	// This is stdlib behavior, not a bug. We only assert Key roundtrips and
+	// Value is non-nil.
+	orig := observation.EvidenceRef{Key: "pid", Value: int64(12345)}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got observation.EvidenceRef
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Key != "pid" {
+		t.Errorf("Key = %q; want \"pid\"", got.Key)
+	}
+	if got.Value == nil {
+		t.Error("Value is nil; want non-nil")
+	}
+	// JSON number → float64 is expected stdlib behavior.
+	// Callers that need int64 must type-assert after Unmarshal.
+}
+
+func TestEvidenceRef_ActorKeyValue_JSON(t *testing.T) {
+	ak := observation.ActorKey{SessionID: "s1", Generation: 2, ActorID: "primary:main"}
+	orig := observation.EvidenceRef{Key: "parent_actor_key", Value: ak}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// Inspect raw JSON bytes for ActorKey field names.
+	if !bytes.Contains(data, []byte(`"session_id":"s1"`)) {
+		t.Errorf("marshaled JSON missing session_id field; got: %s", data)
+	}
+	if !bytes.Contains(data, []byte(`"generation":2`)) {
+		t.Errorf("marshaled JSON missing generation field; got: %s", data)
+	}
+	if !bytes.Contains(data, []byte(`"actor_id":"primary:main"`)) {
+		t.Errorf("marshaled JSON missing actor_id field; got: %s", data)
+	}
+	// Note: we do NOT re-unmarshal into EvidenceRef because the `any` field
+	// loses type information (ActorKey becomes map[string]interface{}).
+}
+
+func TestEvidenceRef_ZeroValue(t *testing.T) {
+	ref := observation.EvidenceRef{}
+
+	data, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("MarshalJSON on zero EvidenceRef panicked or errored: %v", err)
+	}
+
+	if !bytes.Contains(data, []byte(`"key":""`)) {
+		t.Errorf("expected key:\"\" in JSON; got: %s", data)
+	}
+	if !bytes.Contains(data, []byte(`"value":null`)) {
+		t.Errorf("expected value:null in JSON; got: %s", data)
+	}
+}

--- a/internal/module/agent/observation/observation.go
+++ b/internal/module/agent/observation/observation.go
@@ -26,7 +26,6 @@ const (
 )
 
 // IsValid reports whether sk is one of the five defined SourceKind values.
-// Uses a switch statement to avoid heap allocation.
 func (sk SourceKind) IsValid() bool {
 	switch sk {
 	case SourceHook, SourceProbe, SourceSweep, SourceReconcile, SourceSynthetic:

--- a/internal/module/agent/observation/observation.go
+++ b/internal/module/agent/observation/observation.go
@@ -1,0 +1,119 @@
+// Package observation defines the core data model for the Lights observation
+// pipeline. It is intentionally free of business logic and side-effects; all
+// construction and validation lives in builder.go (Task 2), and the
+// TraceIDRegistry lives in trace_id.go (Task 3).
+package observation
+
+import (
+	"fmt"
+	"time"
+)
+
+// SourceKind identifies the origin of an Observation.
+type SourceKind string
+
+const (
+	// SourceHook is produced by a tmux hook callback.
+	SourceHook SourceKind = "hook"
+	// SourceProbe is produced by a periodic probe.
+	SourceProbe SourceKind = "probe"
+	// SourceSweep is produced by a background sweep pass.
+	SourceSweep SourceKind = "sweep"
+	// SourceReconcile is produced by a reconcile loop (observer only).
+	SourceReconcile SourceKind = "reconcile"
+	// SourceSynthetic is produced by internal inference (e.g. timeout).
+	SourceSynthetic SourceKind = "synthetic"
+)
+
+// IsValid reports whether sk is one of the five defined SourceKind values.
+// Uses a switch statement to avoid heap allocation.
+func (sk SourceKind) IsValid() bool {
+	switch sk {
+	case SourceHook, SourceProbe, SourceSweep, SourceReconcile, SourceSynthetic:
+		return true
+	}
+	return false
+}
+
+// ObsPhase represents the lifecycle phase of an Observation.
+type ObsPhase string
+
+const (
+	// PhaseProposed means the Observation has been submitted but not yet
+	// accepted by the Arbitrator.
+	PhaseProposed ObsPhase = "proposed"
+	// PhaseCommitted means the Arbitrator has applied the Observation's
+	// proposal to the frame.
+	PhaseCommitted ObsPhase = "committed"
+	// PhaseRejected means the Arbitrator rejected the Observation's proposal.
+	PhaseRejected ObsPhase = "rejected"
+)
+
+// IsValid reports whether p is one of the three defined ObsPhase values.
+func (p ObsPhase) IsValid() bool {
+	switch p {
+	case PhaseProposed, PhaseCommitted, PhaseRejected:
+		return true
+	}
+	return false
+}
+
+// StateProposal captures what an Observation proposes should happen to a
+// specific actor (identified by ActorKey).
+type StateProposal struct {
+	ActorKey      ActorKey `json:"actor_key"`
+	SuggestStatus string   `json:"suggest_status"`
+	EndLifecycle  bool     `json:"end_lifecycle"`
+	EndReason     string   `json:"end_reason"`
+}
+
+// Branch is one possible outcome within a DecisionPort.
+type Branch struct {
+	ID        string `json:"id"`
+	Condition string `json:"condition"`
+	Outcome   string `json:"outcome"` // matched | rejected | skipped
+}
+
+// DecisionPort records the inputs, branches, and selected outcome for a single
+// decision point within an Observation. Supports goal #4: flow-chart tracing.
+//
+// A single Observation may contain 0–16 DecisionPorts. More than 16 is a
+// programming error (builder enforces the cap in Task 2).
+type DecisionPort struct {
+	PortID    string        `json:"port_id"`
+	InputRefs []EvidenceRef `json:"input_refs"`
+	Branches  []Branch      `json:"branches"`
+	Selected  string        `json:"selected"`
+	Reason    string        `json:"reason"`
+}
+
+// Observation is the top-level data model for the Lights observation pipeline.
+// Field order follows spec §3.3 line 208-225.
+//
+// Observations are produced by hooks, probes, sweeps, reconcile loops, or
+// synthetic internal inference, and are consumed by the Arbitrator (PR-1b-1b).
+type Observation struct {
+	TraceID            string         `json:"trace_id"`
+	SpanID             string         `json:"span_id"`
+	ParentSpanID       string         `json:"parent_span_id"`
+	SessionID          string         `json:"session_id"`
+	ObservedGeneration int64          `json:"observed_generation"`
+	SourceKind         SourceKind     `json:"source_kind"`
+	WatcherToken       string         `json:"watcher_token"`
+	Action             string         `json:"action"`
+	Phase              ObsPhase       `json:"phase"`
+	Proposal           StateProposal  `json:"proposal"`
+	ReasonCode         string         `json:"reason_code"`
+	ReasonText         string         `json:"reason_text"`
+	DecisionPorts      []DecisionPort `json:"decision_ports"`
+	Evidence           []EvidenceRef  `json:"evidence"`
+	ObservedAt         time.Time      `json:"observed_at"`
+	Seq                int64          `json:"seq"`
+}
+
+// String returns a concise, human-readable summary of the Observation. It is
+// safe to call on a zero value and must not panic.
+func (o Observation) String() string {
+	return fmt.Sprintf("Observation{trace_id:%s session_id:%s action:%s phase:%s}",
+		o.TraceID, o.SessionID, o.Action, o.Phase)
+}

--- a/internal/module/agent/observation/observation_test.go
+++ b/internal/module/agent/observation/observation_test.go
@@ -3,7 +3,6 @@ package observation_test
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/wake/purdex/internal/module/agent/observation"
 )
@@ -50,9 +49,10 @@ func TestObsPhase_ValidValues(t *testing.T) {
 
 func TestObservation_ZeroValue_String(t *testing.T) {
 	var obs observation.Observation
-	s := obs.String()
-	if s == "" {
-		t.Error("Observation{}.String() returned empty string; want non-empty")
+	got := obs.String()
+	want := "Observation{trace_id: session_id: action: phase:}"
+	if got != want {
+		t.Errorf("Observation{}.String() = %q; want %q", got, want)
 	}
 }
 
@@ -89,6 +89,31 @@ func TestStateProposal_JSONRoundtrip(t *testing.T) {
 	}
 	if got.EndReason != orig.EndReason {
 		t.Errorf("EndReason = %q; want %q", got.EndReason, orig.EndReason)
+	}
+}
+
+// Covers the bool-zero-value path that JSONRoundtrip (with EndLifecycle=true)
+// cannot: without omitempty, false must survive marshal/unmarshal.
+func TestStateProposal_ZeroValue(t *testing.T) {
+	var orig observation.StateProposal
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal zero StateProposal: %v", err)
+	}
+
+	var got observation.StateProposal
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal zero StateProposal: %v", err)
+	}
+
+	if got.EndLifecycle {
+		t.Errorf("EndLifecycle = true; want false (zero-value must roundtrip)")
+	}
+	if got.ActorKey != (observation.ActorKey{}) {
+		t.Errorf("ActorKey = %+v; want zero value", got.ActorKey)
+	}
+	if got.SuggestStatus != "" || got.EndReason != "" {
+		t.Errorf("non-empty string fields: SuggestStatus=%q EndReason=%q", got.SuggestStatus, got.EndReason)
 	}
 }
 
@@ -179,6 +204,3 @@ func TestBranch_Fields(t *testing.T) {
 		t.Errorf("Outcome = %q; want %q", got.Outcome, orig.Outcome)
 	}
 }
-
-// Compile-time check: Observation uses time.Time.
-var _ = time.Now

--- a/internal/module/agent/observation/observation_test.go
+++ b/internal/module/agent/observation/observation_test.go
@@ -1,0 +1,184 @@
+package observation_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+func TestSourceKind_ValidValues(t *testing.T) {
+	valid := []observation.SourceKind{
+		observation.SourceHook,
+		observation.SourceProbe,
+		observation.SourceSweep,
+		observation.SourceReconcile,
+		observation.SourceSynthetic,
+	}
+	for _, sk := range valid {
+		if !sk.IsValid() {
+			t.Errorf("SourceKind(%q).IsValid() = false; want true", sk)
+		}
+	}
+	if observation.SourceKind("bogus").IsValid() {
+		t.Error(`SourceKind("bogus").IsValid() = true; want false`)
+	}
+	if observation.SourceKind("").IsValid() {
+		t.Error(`SourceKind("").IsValid() = true; want false`)
+	}
+}
+
+func TestObsPhase_ValidValues(t *testing.T) {
+	valid := []observation.ObsPhase{
+		observation.PhaseProposed,
+		observation.PhaseCommitted,
+		observation.PhaseRejected,
+	}
+	for _, p := range valid {
+		if !p.IsValid() {
+			t.Errorf("ObsPhase(%q).IsValid() = false; want true", p)
+		}
+	}
+	if observation.ObsPhase("bogus").IsValid() {
+		t.Error(`ObsPhase("bogus").IsValid() = true; want false`)
+	}
+	if observation.ObsPhase("").IsValid() {
+		t.Error(`ObsPhase("").IsValid() = true; want false`)
+	}
+}
+
+func TestObservation_ZeroValue_String(t *testing.T) {
+	var obs observation.Observation
+	s := obs.String()
+	if s == "" {
+		t.Error("Observation{}.String() returned empty string; want non-empty")
+	}
+}
+
+func TestStateProposal_JSONRoundtrip(t *testing.T) {
+	orig := observation.StateProposal{
+		ActorKey: observation.ActorKey{
+			SessionID:  "sess-abc",
+			Generation: 5,
+			ActorID:    "primary:main",
+		},
+		SuggestStatus: "active",
+		EndLifecycle:  true,
+		EndReason:     "replaced_by_new_primary",
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal StateProposal: %v", err)
+	}
+
+	var got observation.StateProposal
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal StateProposal: %v", err)
+	}
+
+	if got.ActorKey != orig.ActorKey {
+		t.Errorf("ActorKey mismatch: got %+v; want %+v", got.ActorKey, orig.ActorKey)
+	}
+	if got.SuggestStatus != orig.SuggestStatus {
+		t.Errorf("SuggestStatus = %q; want %q", got.SuggestStatus, orig.SuggestStatus)
+	}
+	if got.EndLifecycle != orig.EndLifecycle {
+		t.Errorf("EndLifecycle = %v; want %v", got.EndLifecycle, orig.EndLifecycle)
+	}
+	if got.EndReason != orig.EndReason {
+		t.Errorf("EndReason = %q; want %q", got.EndReason, orig.EndReason)
+	}
+}
+
+func TestDecisionPort_ZeroValue_JSON(t *testing.T) {
+	orig := observation.DecisionPort{}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal DecisionPort{}: %v", err)
+	}
+
+	var got observation.DecisionPort
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal DecisionPort{}: %v", err)
+	}
+
+	if got.PortID != "" {
+		t.Errorf("PortID = %q; want \"\"", got.PortID)
+	}
+	if len(got.InputRefs) != 0 {
+		t.Errorf("InputRefs len = %d; want 0", len(got.InputRefs))
+	}
+	if len(got.Branches) != 0 {
+		t.Errorf("Branches len = %d; want 0", len(got.Branches))
+	}
+	if got.Selected != "" {
+		t.Errorf("Selected = %q; want \"\"", got.Selected)
+	}
+	if got.Reason != "" {
+		t.Errorf("Reason = %q; want \"\"", got.Reason)
+	}
+}
+
+func TestDecisionPort_InputRefs_EvidenceRef_JSON(t *testing.T) {
+	orig := observation.DecisionPort{
+		PortID: "verify.ancestor_walk",
+		InputRefs: []observation.EvidenceRef{
+			{Key: "pid", Value: "123"},
+			{Key: "hash", Value: "abc"},
+		},
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got observation.DecisionPort
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if len(got.InputRefs) != 2 {
+		t.Fatalf("InputRefs len = %d; want 2", len(got.InputRefs))
+	}
+	if got.InputRefs[0].Key != "pid" {
+		t.Errorf("InputRefs[0].Key = %q; want \"pid\"", got.InputRefs[0].Key)
+	}
+	if got.InputRefs[1].Key != "hash" {
+		t.Errorf("InputRefs[1].Key = %q; want \"hash\"", got.InputRefs[1].Key)
+	}
+}
+
+func TestBranch_Fields(t *testing.T) {
+	orig := observation.Branch{
+		ID:        "hit_known_actor",
+		Condition: "pid matches existing actor",
+		Outcome:   "matched",
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal Branch: %v", err)
+	}
+
+	var got observation.Branch
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal Branch: %v", err)
+	}
+
+	if got.ID != orig.ID {
+		t.Errorf("ID = %q; want %q", got.ID, orig.ID)
+	}
+	if got.Condition != orig.Condition {
+		t.Errorf("Condition = %q; want %q", got.Condition, orig.Condition)
+	}
+	if got.Outcome != orig.Outcome {
+		t.Errorf("Outcome = %q; want %q", got.Outcome, orig.Outcome)
+	}
+}
+
+// Compile-time check: Observation uses time.Time.
+var _ = time.Now

--- a/internal/module/agent/observation/trace_id.go
+++ b/internal/module/agent/observation/trace_id.go
@@ -7,7 +7,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// TraceIDKey identifies a (session, generation) pair.
+// TraceIDKey identifies a (session, generation) pair. Fields are comparable,
+// making the struct safe to use as a Go map key. Do not add slice/map/func
+// fields to this type.
 type TraceIDKey struct {
 	SessionID  string
 	Generation int64

--- a/internal/module/agent/observation/trace_id.go
+++ b/internal/module/agent/observation/trace_id.go
@@ -1,0 +1,102 @@
+package observation
+
+import (
+	"log"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// TraceIDKey identifies a (session, generation) pair.
+type TraceIDKey struct {
+	SessionID  string
+	Generation int64
+}
+
+// TraceIDRegistry owns the per-(session, generation) → trace_id mapping for
+// the Lights observation pipeline.
+//
+// In-memory only — daemon restart clears all entries. This matches spec §8
+// line 1222 "restart opens a fresh trace_id for active sessions".
+//
+// Concurrent use is safe: Get takes RLock, Mint/PruneSession* take Lock.
+type TraceIDRegistry struct {
+	mu    sync.RWMutex
+	cache map[TraceIDKey]string
+}
+
+// NewTraceIDRegistry returns an empty Registry. Callers hold the pointer for
+// the Daemon lifetime; no disposal/close required.
+func NewTraceIDRegistry() *TraceIDRegistry {
+	return &TraceIDRegistry{
+		cache: make(map[TraceIDKey]string),
+	}
+}
+
+// Mint returns the trace_id for (sessionID, generation). If the key already
+// exists, returns the EXISTING value and logs a warning — repeat-Mint is a
+// bug signal (SessionStart should only mint once per generation). Rotation
+// would split an active trace across two IDs, breaking #568 correlation.
+func (r *TraceIDRegistry) Mint(sessionID string, generation int64) string {
+	key := TraceIDKey{SessionID: sessionID, Generation: generation}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.cache[key]; ok {
+		log.Printf("[agent][observation] mint called twice for session=%q generation=%d (keeping existing trace_id)",
+			sessionID, generation)
+		return existing
+	}
+
+	id := uuid.NewString()
+	r.cache[key] = id
+	return id
+}
+
+// Get returns (traceID, true) on hit, ("", false) on miss. Miss indicates
+// SessionStart Mint was never called or the Observation references a wrong
+// generation — callers should log an error and NOT auto-mint a new id
+// (would split trace the same way Mint rotation does).
+func (r *TraceIDRegistry) Get(sessionID string, generation int64) (string, bool) {
+	key := TraceIDKey{SessionID: sessionID, Generation: generation}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	id, ok := r.cache[key]
+	return id, ok
+}
+
+// PruneSessionBefore deletes entries where SessionID == sessionID AND
+// Generation < generation. Returns number of entries removed. Called by
+// Arbitrator (PR-1b-1b) after generation advance on SessionStart.
+func (r *TraceIDRegistry) PruneSessionBefore(sessionID string, generation int64) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	removed := 0
+	for k := range r.cache {
+		if k.SessionID == sessionID && k.Generation < generation {
+			delete(r.cache, k)
+			removed++
+		}
+	}
+	return removed
+}
+
+// PruneSession deletes all entries for the given sessionID. Called when a
+// session ends (PR-1b-1c or later). Returns number of entries removed.
+func (r *TraceIDRegistry) PruneSession(sessionID string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	removed := 0
+	for k := range r.cache {
+		if k.SessionID == sessionID {
+			delete(r.cache, k)
+			removed++
+		}
+	}
+	return removed
+}

--- a/internal/module/agent/observation/trace_id.go
+++ b/internal/module/agent/observation/trace_id.go
@@ -21,17 +21,23 @@ type TraceIDKey struct {
 // In-memory only — daemon restart clears all entries. This matches spec §8
 // line 1222 "restart opens a fresh trace_id for active sessions".
 //
+// Per-session watermark tracks the last pruned generation; mint attempts below
+// the watermark are rejected to protect correlation consistency after
+// PruneSessionBefore.
+//
 // Concurrent use is safe: Get takes RLock, Mint/PruneSession* take Lock.
 type TraceIDRegistry struct {
-	mu    sync.RWMutex
-	cache map[TraceIDKey]string
+	mu        sync.RWMutex
+	cache     map[TraceIDKey]string
+	watermark map[string]int64 // per-session: exclusive floor; generations < floor are rejected
 }
 
 // NewTraceIDRegistry returns an empty Registry. Callers hold the pointer for
 // the Daemon lifetime; no disposal/close required.
 func NewTraceIDRegistry() *TraceIDRegistry {
 	return &TraceIDRegistry{
-		cache: make(map[TraceIDKey]string),
+		cache:     make(map[TraceIDKey]string),
+		watermark: make(map[string]int64),
 	}
 }
 
@@ -39,11 +45,22 @@ func NewTraceIDRegistry() *TraceIDRegistry {
 // exists, returns the EXISTING value and logs a warning — repeat-Mint is a
 // bug signal (SessionStart should only mint once per generation). Rotation
 // would split an active trace across two IDs, breaking #568 correlation.
+//
+// If generation is below the per-session watermark (set by PruneSessionBefore),
+// Mint returns "" and logs an error. Callers must check for the empty return:
+// an empty string means the generation has been retired and must not be used.
 func (r *TraceIDRegistry) Mint(sessionID string, generation int64) string {
 	key := TraceIDKey{SessionID: sessionID, Generation: generation}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// Reject stale mints for generations that have already been pruned.
+	if floor, ok := r.watermark[sessionID]; ok && generation < floor {
+		log.Printf("[agent][observation] stale mint rejected: session=%q generation=%d watermark=%d",
+			sessionID, generation, floor)
+		return ""
+	}
 
 	if existing, ok := r.cache[key]; ok {
 		log.Printf("[agent][observation] mint called twice for session=%q generation=%d (keeping existing trace_id)",
@@ -73,6 +90,10 @@ func (r *TraceIDRegistry) Get(sessionID string, generation int64) (string, bool)
 // PruneSessionBefore deletes entries where SessionID == sessionID AND
 // Generation < generation. Returns number of entries removed. Called by
 // Arbitrator (PR-1b-1b) after generation advance on SessionStart.
+//
+// After pruning, a per-session watermark is updated so that subsequent Mint
+// calls for generations below this threshold are rejected, preventing stale
+// hook-replays or retries from reviving retired trace IDs.
 func (r *TraceIDRegistry) PruneSessionBefore(sessionID string, generation int64) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -84,11 +105,17 @@ func (r *TraceIDRegistry) PruneSessionBefore(sessionID string, generation int64)
 			removed++
 		}
 	}
+	// Advance watermark: only move forward, never back (monotonically increasing).
+	if prev, ok := r.watermark[sessionID]; !ok || generation > prev {
+		r.watermark[sessionID] = generation
+	}
 	return removed
 }
 
-// PruneSession deletes all entries for the given sessionID. Called when a
-// session ends (PR-1b-1c or later). Returns number of entries removed.
+// PruneSession deletes all entries for the given sessionID and clears the
+// per-session watermark. Called when a session ends (PR-1b-1c or later).
+// Returns number of entries removed. After PruneSession, Mint is allowed again
+// for any generation of this sessionID (fresh-session semantics).
 func (r *TraceIDRegistry) PruneSession(sessionID string) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -100,5 +127,6 @@ func (r *TraceIDRegistry) PruneSession(sessionID string) int {
 			removed++
 		}
 	}
+	delete(r.watermark, sessionID)
 	return removed
 }

--- a/internal/module/agent/observation/trace_id_test.go
+++ b/internal/module/agent/observation/trace_id_test.go
@@ -1,0 +1,261 @@
+package observation_test
+
+import (
+	"log"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+// captureTraceIDLog redirects the default logger to a buffer for the duration
+// of t. It is a per-test-file capture helper distinct from captureLog in
+// builder_test.go to avoid a compile-time duplicate declaration in the same
+// test package.
+func captureTraceIDLog(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	old := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(old) })
+	return &buf
+}
+
+// TestTraceIDRegistry_FreshInstance_EmptyState verifies that a newly created
+// registry has no entries (simulates daemon restart).
+func TestTraceIDRegistry_FreshInstance_EmptyState(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+	id, ok := r.Get("s1", 1)
+	if ok {
+		t.Fatalf("expected miss on fresh registry, got hit with id=%q", id)
+	}
+	if id != "" {
+		t.Fatalf("expected empty string on miss, got %q", id)
+	}
+}
+
+// TestTraceIDRegistry_Mint_NewKey_UUIDv4 verifies that Mint returns a valid
+// uuidv4 and that Get returns the same value.
+func TestTraceIDRegistry_Mint_NewKey_UUIDv4(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+	got := r.Mint("s1", 1)
+
+	parsed, err := uuid.Parse(got)
+	if err != nil {
+		t.Fatalf("Mint returned non-UUID value %q: %v", got, err)
+	}
+	// version 4
+	if parsed.Version() != 4 {
+		t.Fatalf("expected UUID version 4, got version %d", parsed.Version())
+	}
+
+	got2, ok := r.Get("s1", 1)
+	if !ok {
+		t.Fatal("Get after Mint returned miss")
+	}
+	if got2 != got {
+		t.Fatalf("Get returned different id: Mint=%q Get=%q", got, got2)
+	}
+}
+
+// TestTraceIDRegistry_Mint_SameKeyTwice_ReturnsExisting verifies that a
+// repeat Mint returns the existing value and logs a warning.
+func TestTraceIDRegistry_Mint_SameKeyTwice_ReturnsExisting(t *testing.T) {
+	buf := captureTraceIDLog(t)
+	r := observation.NewTraceIDRegistry()
+
+	first := r.Mint("s1", 1)
+	second := r.Mint("s1", 1)
+
+	if first != second {
+		t.Fatalf("repeat Mint must return existing id: first=%q second=%q", first, second)
+	}
+	if !strings.Contains(buf.String(), "mint called twice") {
+		t.Fatalf("expected 'mint called twice' warning in log, got: %q", buf.String())
+	}
+}
+
+// TestTraceIDRegistry_Get_Hit verifies that Get returns (id, true) for a
+// previously minted key.
+func TestTraceIDRegistry_Get_Hit(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+	minted := r.Mint("s1", 1)
+
+	got, ok := r.Get("s1", 1)
+	if !ok {
+		t.Fatal("Get returned miss for minted key")
+	}
+	if got != minted {
+		t.Fatalf("Get returned %q, want %q", got, minted)
+	}
+}
+
+// TestTraceIDRegistry_Get_Miss verifies that Get returns ("", false) when no
+// Mint has been called. The registry must produce no log output for a clean
+// read-path miss.
+func TestTraceIDRegistry_Get_Miss(t *testing.T) {
+	buf := captureTraceIDLog(t)
+	r := observation.NewTraceIDRegistry()
+
+	got, ok := r.Get("s1", 1)
+	if ok {
+		t.Fatalf("expected miss, got hit with id=%q", got)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string on miss, got %q", got)
+	}
+	if buf.String() != "" {
+		t.Fatalf("Get miss should produce no log output, got: %q", buf.String())
+	}
+}
+
+// TestTraceIDRegistry_DifferentGeneration_DifferentID verifies that different
+// generations for the same session receive different trace IDs.
+func TestTraceIDRegistry_DifferentGeneration_DifferentID(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+	id1 := r.Mint("s1", 1)
+	id2 := r.Mint("s1", 2)
+
+	if id1 == id2 {
+		t.Fatalf("different generations must have different trace IDs, both got %q", id1)
+	}
+
+	got1, ok1 := r.Get("s1", 1)
+	got2, ok2 := r.Get("s1", 2)
+	if !ok1 || !ok2 {
+		t.Fatalf("Get miss after Mint: ok1=%v ok2=%v", ok1, ok2)
+	}
+	if got1 != id1 {
+		t.Fatalf("gen 1: want %q got %q", id1, got1)
+	}
+	if got2 != id2 {
+		t.Fatalf("gen 2: want %q got %q", id2, got2)
+	}
+
+	// Both must be valid uuidv4.
+	for _, id := range []string{id1, id2} {
+		if _, err := uuid.Parse(id); err != nil {
+			t.Fatalf("Mint returned non-UUID %q: %v", id, err)
+		}
+	}
+}
+
+// TestTraceIDRegistry_DifferentSession_DifferentID verifies that the same
+// generation for different sessions receives different trace IDs.
+func TestTraceIDRegistry_DifferentSession_DifferentID(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+	id1 := r.Mint("s1", 1)
+	id2 := r.Mint("s2", 1)
+
+	if id1 == id2 {
+		t.Fatalf("different sessions must have different trace IDs, both got %q", id1)
+	}
+}
+
+// TestTraceIDRegistry_PruneSessionBefore verifies that PruneSessionBefore
+// removes entries with generation < threshold and leaves ≥ threshold intact.
+func TestTraceIDRegistry_PruneSessionBefore(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+	r.Mint("s1", 1)
+	r.Mint("s1", 2)
+	id3 := r.Mint("s1", 3)
+
+	removed := r.PruneSessionBefore("s1", 3)
+	if removed != 2 {
+		t.Fatalf("PruneSessionBefore returned %d, want 2", removed)
+	}
+
+	if _, ok := r.Get("s1", 1); ok {
+		t.Error("gen 1 should have been pruned")
+	}
+	if _, ok := r.Get("s1", 2); ok {
+		t.Error("gen 2 should have been pruned")
+	}
+
+	got3, ok3 := r.Get("s1", 3)
+	if !ok3 {
+		t.Error("gen 3 should survive PruneSessionBefore")
+	}
+	if got3 != id3 {
+		t.Fatalf("gen 3 id changed after prune: want %q got %q", id3, got3)
+	}
+}
+
+// TestTraceIDRegistry_PruneSession verifies that PruneSession removes all
+// entries for a session and does not affect other sessions.
+func TestTraceIDRegistry_PruneSession(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+	r.Mint("s1", 1)
+	r.Mint("s1", 2)
+	id2 := r.Mint("s2", 1)
+
+	removed := r.PruneSession("s1")
+	if removed != 2 {
+		t.Fatalf("PruneSession returned %d, want 2", removed)
+	}
+
+	if _, ok := r.Get("s1", 1); ok {
+		t.Error("s1 gen 1 should have been pruned")
+	}
+	if _, ok := r.Get("s1", 2); ok {
+		t.Error("s1 gen 2 should have been pruned")
+	}
+
+	got, ok := r.Get("s2", 1)
+	if !ok {
+		t.Error("s2 gen 1 should survive PruneSession(s1)")
+	}
+	if got != id2 {
+		t.Fatalf("s2 gen 1 id changed: want %q got %q", id2, got)
+	}
+}
+
+// TestTraceIDRegistry_PruneSessionBefore_NonExistent verifies that pruning an
+// unknown session returns 0 and does not panic.
+func TestTraceIDRegistry_PruneSessionBefore_NonExistent(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+	removed := r.PruneSessionBefore("unknown", 99)
+	if removed != 0 {
+		t.Fatalf("expected 0 removed for unknown session, got %d", removed)
+	}
+}
+
+// TestTraceIDRegistry_Concurrent_Race exercises Mint and PruneSessionBefore
+// concurrently to surface data races under -race. A panic or race report is
+// the failure signal.
+func TestTraceIDRegistry_Concurrent_Race(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+
+	const sessions = 5
+	const pairs = 100 // generations per session = 500 total Mint calls
+
+	var wg sync.WaitGroup
+
+	// Goroutine A: Mint 500 different (session, generation) pairs.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for s := 0; s < sessions; s++ {
+			sessionID := "race-session-" + string(rune('A'+s))
+			for g := int64(0); g < pairs; g++ {
+				r.Mint(sessionID, g)
+			}
+		}
+	}()
+
+	// Goroutine B: Concurrently prune sessions.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for s := 0; s < sessions; s++ {
+			sessionID := "race-session-" + string(rune('A'+s))
+			for g := int64(0); g < pairs; g += 10 {
+				r.PruneSessionBefore(sessionID, g)
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/module/agent/observation/trace_id_test.go
+++ b/internal/module/agent/observation/trace_id_test.go
@@ -244,6 +244,87 @@ func TestTraceIDRegistry_PruneSession_NonExistent(t *testing.T) {
 	}
 }
 
+// TestTraceIDRegistry_Mint_StaleAfterPrune_ReturnsEmpty verifies that a Mint
+// for a generation below the watermark (set by PruneSessionBefore) returns ""
+// and logs a rejection message, while Mint above the watermark still works.
+func TestTraceIDRegistry_Mint_StaleAfterPrune_ReturnsEmpty(t *testing.T) {
+	buf := captureTraceIDLog(t)
+	r := observation.NewTraceIDRegistry()
+
+	r.Mint("s1", 1)
+	r.Mint("s1", 2)
+	r.Mint("s1", 3)
+
+	r.PruneSessionBefore("s1", 3) // watermark = 3; gens 1,2 pruned; gen 3 survives
+
+	// Stale mint for pruned generation must return empty string.
+	got := r.Mint("s1", 2)
+	if got != "" {
+		t.Fatalf("Mint for pruned generation should return empty, got %q", got)
+	}
+	if !strings.Contains(buf.String(), "stale mint rejected") {
+		t.Errorf("expected 'stale mint rejected' in log, got: %q", buf.String())
+	}
+
+	// Mint at the watermark boundary (generation == floor) is allowed.
+	id4 := r.Mint("s1", 4) // above watermark — fresh generation
+	if id4 == "" {
+		t.Error("Mint above watermark should succeed, got empty string")
+	}
+}
+
+// TestTraceIDRegistry_Mint_AtWatermark_Rejected verifies watermark boundary
+// semantics: PruneSessionBefore(s1, 5) deletes gens < 5, watermark = 5.
+// generation 4 → rejected (< 5); generation 5 → allowed (>= 5).
+func TestTraceIDRegistry_Mint_AtWatermark_Rejected(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+
+	r.PruneSessionBefore("s1", 5) // sets watermark = 5; nothing to delete
+
+	// Generation strictly below watermark → rejected.
+	got4 := r.Mint("s1", 4)
+	if got4 != "" {
+		t.Fatalf("Mint(s1, 4) below watermark 5 should return empty, got %q", got4)
+	}
+
+	// Generation equal to watermark → allowed (exclusive-floor semantics).
+	got5 := r.Mint("s1", 5)
+	if got5 == "" {
+		t.Error("Mint(s1, 5) at watermark floor should succeed, got empty string")
+	}
+
+	// Generation above watermark → allowed.
+	got6 := r.Mint("s1", 6)
+	if got6 == "" {
+		t.Error("Mint(s1, 6) above watermark should succeed, got empty string")
+	}
+}
+
+// TestTraceIDRegistry_PruneSession_ResetsWatermark verifies that PruneSession
+// clears the per-session watermark, allowing subsequent Mints for any
+// generation (fresh-session semantics after full session cleanup).
+func TestTraceIDRegistry_PruneSession_ResetsWatermark(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+
+	r.Mint("s1", 1)
+	r.PruneSessionBefore("s1", 2) // watermark = 2; gen 1 pruned
+
+	// Confirm stale mint is blocked before PruneSession.
+	staleBefore := r.Mint("s1", 0)
+	if staleBefore != "" {
+		t.Fatalf("expected stale mint to be blocked, got %q", staleBefore)
+	}
+
+	// Full session cleanup resets watermark.
+	r.PruneSession("s1")
+
+	// After PruneSession, even generation 0 is allowed (watermark cleared).
+	gotAfter := r.Mint("s1", 0)
+	if gotAfter == "" {
+		t.Error("Mint after PruneSession should succeed (watermark cleared), got empty string")
+	}
+}
+
 // TestTraceIDRegistry_Concurrent_Race exercises Mint and PruneSessionBefore
 // concurrently to surface data races under -race. A panic or race report is
 // the failure signal.

--- a/internal/module/agent/observation/trace_id_test.go
+++ b/internal/module/agent/observation/trace_id_test.go
@@ -46,9 +46,11 @@ func TestTraceIDRegistry_Mint_NewKey_UUIDv4(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Mint returned non-UUID value %q: %v", got, err)
 	}
-	// version 4
 	if parsed.Version() != 4 {
 		t.Fatalf("expected UUID version 4, got version %d", parsed.Version())
+	}
+	if parsed.Variant() != uuid.RFC4122 {
+		t.Fatalf("expected UUID variant RFC4122, got %v", parsed.Variant())
 	}
 
 	got2, ok := r.Get("s1", 1)
@@ -143,7 +145,8 @@ func TestTraceIDRegistry_DifferentGeneration_DifferentID(t *testing.T) {
 }
 
 // TestTraceIDRegistry_DifferentSession_DifferentID verifies that the same
-// generation for different sessions receives different trace IDs.
+// generation for different sessions receives different trace IDs, and that
+// Get returns each session's id independently.
 func TestTraceIDRegistry_DifferentSession_DifferentID(t *testing.T) {
 	r := observation.NewTraceIDRegistry()
 	id1 := r.Mint("s1", 1)
@@ -151,6 +154,15 @@ func TestTraceIDRegistry_DifferentSession_DifferentID(t *testing.T) {
 
 	if id1 == id2 {
 		t.Fatalf("different sessions must have different trace IDs, both got %q", id1)
+	}
+
+	got1, ok1 := r.Get("s1", 1)
+	if !ok1 || got1 != id1 {
+		t.Fatalf("Get(s1,1) = (%q,%v); want (%q,true)", got1, ok1, id1)
+	}
+	got2, ok2 := r.Get("s2", 1)
+	if !ok2 || got2 != id2 {
+		t.Fatalf("Get(s2,1) = (%q,%v); want (%q,true)", got2, ok2, id2)
 	}
 }
 
@@ -222,6 +234,16 @@ func TestTraceIDRegistry_PruneSessionBefore_NonExistent(t *testing.T) {
 	}
 }
 
+// TestTraceIDRegistry_PruneSession_NonExistent verifies that PruneSession on an
+// unknown session returns 0 and does not panic (symmetric with PruneSessionBefore).
+func TestTraceIDRegistry_PruneSession_NonExistent(t *testing.T) {
+	r := observation.NewTraceIDRegistry()
+	removed := r.PruneSession("unknown")
+	if removed != 0 {
+		t.Fatalf("expected 0 removed for unknown session, got %d", removed)
+	}
+}
+
 // TestTraceIDRegistry_Concurrent_Race exercises Mint and PruneSessionBefore
 // concurrently to surface data races under -race. A panic or race report is
 // the failure signal.
@@ -253,6 +275,18 @@ func TestTraceIDRegistry_Concurrent_Race(t *testing.T) {
 			sessionID := "race-session-" + string(rune('A'+s))
 			for g := int64(0); g < pairs; g += 10 {
 				r.PruneSessionBefore(sessionID, g)
+			}
+		}
+	}()
+
+	// Goroutine C: Concurrently Get (exercises RLock vs Prune's Lock).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for s := 0; s < sessions; s++ {
+			sessionID := "race-session-" + string(rune('A'+s))
+			for g := int64(0); g < pairs; g++ {
+				_, _ = r.Get(sessionID, g)
 			}
 		}
 	}()


### PR DESCRIPTION
## Summary

First of three PRs in the PR-1b-1 sub-split (§3.3 / §3.4 / §8.1 / §8.3). Ships pure foundation — data model + state-machine + Registry primitive — with **zero runtime behavior change**. Arbitrator execution (PR-1b-1b) and hook/probe/sweep passthrough + divergence (PR-1b-1c) come next.

Scope:
- `internal/module/agent/observation/` — Observation types (§3.3) + Builder + validation + TraceIDRegistry (#568)
- `internal/module/agent/arbmode/` — `AGENT_ARB_MODE` Manager + `GET /api/agent/arbitrator/mode` (§8.3)
- `internal/config/` + `internal/core/config_handler.go` — config wiring (JSON partial update via `{agent:{arb_mode}}`)

Plan: `docs/superpowers/plans/2026-04-22-lights-system/pr-1b-1a.md` (committed in `bb1ca762`)
Secondary split rationale: `docs/superpowers/plans/2026-04-22-lights-system/phase-1.md`

## What lands

### Observation package (Tasks 1-3)
- `ActorKey{SessionID, Generation, ActorID}` — composite, hashable, `String()` format `<sess>/<gen>/<actor>`
- `SourceKind` / `ObsPhase` — string-backed enums + `IsValid()`
- `EvidenceRef{Key string, Value any}` — shape locked per spec §3.3 line 977
- `StateProposal` / `DecisionPort` / `Branch` / `Observation` — field order per spec §3.3 line 208-225
- `Builder` — fluent API; validates on `Build()`; `WithDevMode(bool)` controls DecisionPort cap-16 behaviour (dev panic / prod truncate + log)
  - Validation covers D3 matrix: required fields / SourceKind enum / Phase enum / probe-requires-WatcherToken / ActorKey↔SessionID↔Generation consistency (zero ActorKey = no-proposal case, per §3.4.5 reconcile trace)
- `TraceIDRegistry` — addresses #568 foundation; Mint-at-SessionStart strategy (D4); existing-key returns existing (no rotate — rotation would split active traces); `PruneSessionBefore` / `PruneSession` bound memory; no `MintOrGet` fallback

### arbmode package (Tasks 4-5)
- `ArbMode` enum `{passthrough, authoritative}`
- `Manager` — precedence: env > config > default(passthrough); env-lock disables hot reload; `OnConfigChange` updates pending; `ApplyAtSessionStart` promotes pending → current (call site in 1b-1b)
- `Snapshot()` — single-RLock read, no torn state; sole reader interface (no individual `Current()/Pending()/EnvLocked()` getters)
- `Handler` — `GET /api/agent/arbitrator/mode` returns `{current, pending, env_locked}`; non-GET → 405 with `Allow: GET`
- Wired into `internal/config/config.go` (`AgentConfig.ArbMode`) and `internal/core/config_handler.go` (JSON partial update); PUT triggers `NotifyConfigChange` only when a field actually changed

### Follow-up issues (deferred to later PRs per plan)
- PR-1b-1b: Arbitrator goroutine consumes Observations; calls `Manager.ApplyAtSessionStart()` + `TraceIDRegistry.Mint()`/`PruneSessionBefore()` at SessionStart; 9-step apply pipeline; pending window; reconcile loop
- PR-1b-1c: hook / probe / sweep direct-write → Observation passthrough; `frame_divergences` writes; Monitor API envelope (#569)
- Issue #568 officially closes only after PR-1b-1c (hook path migrated from `chain_id` aliasing to `TraceIDRegistry.Get()`)

## Plan & review history

Codex plan review (task-mo9ecevx-9hzyqz) caught 3 P0 / 4 P1 / 3 P2 / 1 P3 before implementation started. All addressed in `bb1ca762`. Per-task subagent TDD + spec compliance review + code quality review (11 review rounds total) caught and fixed another 2 Critical + 6 Important + assorted Minor issues across Tasks 1-5.

## Test plan

- [x] `go test -race -count=1 ./internal/config/... ./internal/core/... ./internal/module/agent/...` — all pass
- [x] `go build ./...` clean
- [x] Task 1: 15 types tests (actor_key, observation, evidence)
- [x] Task 2: 20 builder tests (D3 matrix + Edge cases)
- [x] Task 3: 12 TraceIDRegistry tests (Mint / Get / Prune / Concurrent)
- [x] Task 4: 13 Manager tests (precedence / hot reload / Apply / torn-read)
- [x] Task 5: 7 handler + config tests (shape / 405 / JSON partial / empty-vs-missing semantics)
- [ ] Manual: start daemon, `curl -s http://127.0.0.1:7860/api/agent/arbitrator/mode | jq` → `{current:passthrough, pending:passthrough, env_locked:false}`
- [ ] Manual: `curl -X PUT .../api/config -d '{"agent":{"arb_mode":"authoritative"}}'` → next GET shows `pending=authoritative`
- [ ] Manual: `AGENT_ARB_MODE=authoritative ./bin/pdx` → GET shows `env_locked=true`, PUT changes ignored with log warn

## Breaking changes

None. New API endpoint + new config field; existing behaviour unchanged.