### PR TITLE
fix(spa): restore build baseline — MonacoWrapper test missing isActive

### DIFF
--- a/spa/src/components/editor/MonacoWrapper.test.tsx
+++ b/spa/src/components/editor/MonacoWrapper.test.tsx
@@ -134,6 +134,7 @@ describe('MonacoWrapper', () => {
         content="hello"
         language="markdown"
         modelId="model-1"
+        isActive={true}
         initialViewState={null}
         onChange={() => {}}
         onCursorChange={() => {}}


### PR DESCRIPTION
## Summary

Closes #572. One-line fix: `MonacoWrapper.test.tsx:133` rerender call was missing the required `isActive` prop, so `tsc -b && vite build` failed on \`main\` since PR #570 (f79e2c16 editor footer).

Vitest did not flag this because its type-checking is more permissive than tsc's strict build.

## Test plan

- [x] \`pnpm --prefix spa run build\` — now green
- [x] \`pnpm --prefix spa run lint\` — unchanged (2 pre-existing \`EditorPane\` warnings)
- [x] Vitest — unchanged baseline