### PR TITLE
feat(spa): HSR PR-4 — Host settings shell + built-in adapter + #541 harness

### DIFF
--- a/spa/src/components/HostPage.route-sync.test.tsx
+++ b/spa/src/components/HostPage.route-sync.test.tsx
@@ -1,9 +1,12 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { Router } from 'wouter'
 import { memoryLocation } from 'wouter/memory-location'
 import { useRouteSync } from '../hooks/useRouteSync'
 import { getPrimaryPane } from '../lib/pane-tree'
+import { clearContributions } from '../lib/settings-contribution-registry'
+import { clearModuleRegistry } from '../lib/module-registry'
+import { registerBuiltinModules } from '../lib/register-modules'
 import { useHistoryStore } from '../stores/useHistoryStore'
 import { useHostStore } from '../stores/useHostStore'
 import { useTabStore } from '../stores/useTabStore'
@@ -108,6 +111,18 @@ describe('HostPage route sync', () => {
     useHistoryStore.setState({ browseHistory: [], closedTabs: [] })
     resetLastHostSelection()
     seedHosts()
+    // HostPage.renderContent() now reads listContributions('host') — populate
+    // the registry with the six built-in host sub-pages so section bodies render.
+    // vi.mock hoisting ensures the mocked section stubs are used by registerBuiltinModules.
+    clearContributions()
+    clearModuleRegistry()
+    registerBuiltinModules()
+  })
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).electronAPI
+    clearContributions()
+    clearModuleRegistry()
   })
 
   it('canonicalizes bare /hosts to the fallback selection with replace semantics', async () => {

--- a/spa/src/components/HostPage.test.tsx
+++ b/spa/src/components/HostPage.test.tsx
@@ -380,7 +380,7 @@ describe('HostPage (registry-driven, §3.1)', () => {
     expect(lastPath).toBe('/hosts/hA/overview')
   })
 
-  // Test 7: Disabled contribution → body NOT rendered.
+  // Test 7: Disabled contribution → body NOT rendered + URL redirects.
   // NOTE: HostSidebar is mocked in this file, so we can only assert the body
   // absence here. The disabled-row sidebar styling (data-disabled-ctx) is tested
   // in HostSidebar.test.tsx which renders the real sidebar with the registry.
@@ -400,9 +400,153 @@ describe('HostPage (registry-driven, §3.1)', () => {
     })
 
     // Navigate to the disabled section's URL
-    renderHostPage('/hosts/hA/disabled-section')
+    const { mem } = renderHostPage('/hosts/hA/disabled-section')
 
     // Body must NOT be rendered (disabled contribution skipped by HostPage.renderContent)
     expect(screen.queryByTestId('disabled-body')).not.toBeInTheDocument()
+    // URL must self-heal to the first selectable sub-page (overview)
+    expect(currentPath(mem)).toBe('/hosts/hA/overview')
+    // The selectable overview renders
+    expect(screen.getByTestId('overview-section')).toBeInTheDocument()
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // §A.7 — Finding A regression tests (R1+R2 fixup)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  // A.7 Test 1: Direct deep-link to disabled sub-page redirects to first selectable.
+  it('A.7-1: disabled deep-link redirects to first selectable sub-page', () => {
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.disabled-section',
+      localId: 'disabled-section',
+      scope: 'host',
+      order: 100,
+      labelKey: 'disabled-section',
+      component: () => <div data-testid="disabled-body" />,
+      disabled: () => true,
+    })
+
+    const { mem } = renderHostPage('/hosts/hA/disabled-section')
+
+    // URL must canonicalize to the first selectable page (overview)
+    expect(currentPath(mem)).toBe('/hosts/hA/overview')
+    // OverviewSection renders — not blank
+    expect(screen.getByTestId('overview-section')).toBeInTheDocument()
+    expect(screen.queryByTestId('disabled-body')).not.toBeInTheDocument()
+  })
+
+  // A.7 Test 2: lastSelection clamped when contribution removed from registry.
+  it('A.7-2: removed contribution in lastSelection falls back to overview, not stale sub-page', () => {
+    // Step 1: register fake custom contribution, navigate to it → seeds lastSelection
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.custom',
+      localId: 'custom',
+      scope: 'host',
+      order: 100,
+      labelKey: 'custom',
+      component: () => <div data-testid="custom-body" />,
+    })
+
+    const firstMount = renderHostPage('/hosts/hA/custom')
+    expect(screen.getByTestId('custom-body')).toBeInTheDocument()
+    firstMount.unmount()
+
+    // Step 2: clear all, re-register only built-ins (no 'custom')
+    clearContributions()
+    clearModuleRegistry()
+    registerBuiltinModules()
+
+    // Step 3: render bare /hosts — lastSelection.subPage='custom' must be ignored
+    const { mem } = renderHostPage('/hosts')
+
+    // Must fall back to 'overview', not the stale 'custom'
+    expect(screen.getByTestId('overview-section')).toBeInTheDocument()
+    expect(screen.queryByTestId('custom-body')).not.toBeInTheDocument()
+    // URL must have been redirected to overview (not custom which no longer exists)
+    const lastPath = currentPath(mem)
+    expect(lastPath).toBe('/hosts/hA/overview')
+  })
+
+  // A.7 Test 3: Cross-host switch with per-host disabled → redirects to first selectable.
+  it('A.7-3: cross-host switch to host where current sub-page is disabled redirects', () => {
+    const HOST_B = 'hB'
+    // Seed two hosts
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+        [HOST_B]: { id: HOST_B, name: 'Host B', ip: '5.6.7.8', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_A, HOST_B],
+      activeHostId: HOST_A,
+      runtime: {},
+    })
+
+    // Register featureX: enabled on hA, disabled on hB
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.feature-x',
+      localId: 'feature-x',
+      scope: 'host',
+      order: 100,
+      labelKey: 'feature-x',
+      component: () => <div data-testid="feature-x-body" />,
+      disabled: (ctx) => ctx.hostId === HOST_B,
+    })
+
+    // Start on hA/feature-x (enabled)
+    const { mem, rerender } = renderHostPage('/hosts/hA/feature-x')
+    expect(screen.getByTestId('feature-x-body')).toBeInTheDocument()
+
+    // Simulate cross-host switch to hB/feature-x (disabled on hB)
+    // Navigate directly to hB/feature-x — resolveSelection must redirect
+    mem.navigate('/hosts/hB/feature-x')
+    rerender(
+      <Router hook={mem.hook}>
+        <HostPage pane={hostPane} isActive />
+      </Router>,
+    )
+
+    // URL must canonicalize to hB's first selectable page (overview)
+    expect(currentPath(mem)).toBe('/hosts/hB/overview')
+    // Overview renders for hB — not blank
+    expect(screen.getByTestId('overview-section')).toHaveAttribute('data-host', HOST_B)
+    expect(screen.queryByTestId('feature-x-body')).not.toBeInTheDocument()
+  })
+
+  // A.7 Test 4: lastSelection sub-page clamped on read when not in live registry.
+  it('A.7-4: stale lastSelection subPage not in registry is clamped to overview on render', () => {
+    // Seed lastSelection with a sub-page that is no longer in the registry
+    // by mounting with it, then removing it before the next render.
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.gone',
+      localId: 'gone',
+      scope: 'host',
+      order: 100,
+      labelKey: 'gone',
+      component: () => <div data-testid="gone-body" />,
+    })
+
+    const first = renderHostPage('/hosts/hA/gone')
+    expect(screen.getByTestId('gone-body')).toBeInTheDocument()
+    first.unmount()
+
+    // Remove 'gone' from the registry
+    clearContributions()
+    clearModuleRegistry()
+    registerBuiltinModules()
+    // 'gone' is no longer registered.
+
+    // Render with no URL sub-page — bare /hosts
+    const { mem } = renderHostPage('/hosts')
+
+    // lastSelection.subPage = 'gone' must be clamped — overview must render
+    expect(screen.getByTestId('overview-section')).toBeInTheDocument()
+    expect(screen.queryByTestId('gone-body')).not.toBeInTheDocument()
+    // URL settles on overview (or the first selectable in the canonicalized path)
+    const lastPath = currentPath(mem)
+    expect(lastPath).toBe('/hosts/hA/overview')
   })
 })

--- a/spa/src/components/HostPage.test.tsx
+++ b/spa/src/components/HostPage.test.tsx
@@ -12,10 +12,10 @@
  *    These assert that HostPage + HostSidebar read `listContributions('host')`
  *    and render via the contribution registry.
  *
- * NOTE: `isHostSubPage` is still the static six-literal check in commit 2.
- * For §3.1 T4/T5/T7 we need custom localIds to route correctly, so we mock
- * isHostSubPage to also accept any value registered in the contribution
- * registry. This mirrors the commit 3 behavior and is the correct contract.
+ * NOTE (commit 3): `isHostSubPage` is now dynamic via the contribution
+ * registry. No shim is needed — the real implementation accepts any localId
+ * registered in the registry, so §3.1 T4/T5/T7 with custom localIds work
+ * out of the box.
  */
 
 // vi.mock calls must come before any imports that reference the mocked modules.
@@ -23,23 +23,6 @@
 vi.mock('../lib/host-api', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return { ...actual, listSessions: vi.fn().mockResolvedValue([]) }
-})
-
-// Pre-commit-3 shim: isHostSubPage is static in commit 2, but the §3.1 tests
-// for registry-contributed subPages need it to accept the fake localId so that
-// parseRoute() classifies `/hosts/hA/<fakeId>` as 'hosts' (not 'hosts-invalid').
-vi.mock('../lib/host-routes', async (importOriginal) => {
-  const actual = await importOriginal() as Record<string, unknown>
-  const { listContributions } = await import('../lib/settings-contribution-registry')
-  return {
-    ...actual,
-    isHostSubPage: (value: string) => {
-      // Accept built-in literals OR any registered host contribution localId.
-      const builtinCheck = (actual.isHostSubPage as (v: string) => boolean)(value)
-      if (builtinCheck) return true
-      return listContributions('host').some((c) => c.localId === value)
-    },
-  }
 })
 
 vi.mock('./hosts/HostSidebar', () => ({

--- a/spa/src/components/HostPage.test.tsx
+++ b/spa/src/components/HostPage.test.tsx
@@ -1,21 +1,52 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
-import { Router } from 'wouter'
-import { memoryLocation } from 'wouter/memory-location'
-import { HostPage, resetLastHostSelection } from './HostPage'
-import { useHostStore } from '../stores/useHostStore'
-import type { Pane } from '../types/tab'
+/**
+ * HostPage.test.tsx
+ *
+ * Two test suites:
+ *
+ * 1. `HostPage` — original route-navigation smoke tests (survive refactor).
+ *    These mock HostSidebar + individual section stubs, then assert the right
+ *    section stub is rendered for the given URL and that route
+ *    canonicalization works correctly.
+ *
+ * 2. `HostPage (registry-driven, §3.1)` — Commit 2 render-level tests.
+ *    These assert that HostPage + HostSidebar read `listContributions('host')`
+ *    and render via the contribution registry.
+ *
+ * NOTE: `isHostSubPage` is still the static six-literal check in commit 2.
+ * For §3.1 T4/T5/T7 we need custom localIds to route correctly, so we mock
+ * isHostSubPage to also accept any value registered in the contribution
+ * registry. This mirrors the commit 3 behavior and is the correct contract.
+ */
+
+// vi.mock calls must come before any imports that reference the mocked modules.
 
 vi.mock('../lib/host-api', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return { ...actual, listSessions: vi.fn().mockResolvedValue([]) }
 })
 
+// Pre-commit-3 shim: isHostSubPage is static in commit 2, but the §3.1 tests
+// for registry-contributed subPages need it to accept the fake localId so that
+// parseRoute() classifies `/hosts/hA/<fakeId>` as 'hosts' (not 'hosts-invalid').
+vi.mock('../lib/host-routes', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  const { listContributions } = await import('../lib/settings-contribution-registry')
+  return {
+    ...actual,
+    isHostSubPage: (value: string) => {
+      // Accept built-in literals OR any registered host contribution localId.
+      const builtinCheck = (actual.isHostSubPage as (v: string) => boolean)(value)
+      if (builtinCheck) return true
+      return listContributions('host').some((c) => c.localId === value)
+    },
+  }
+})
+
 vi.mock('./hosts/HostSidebar', () => ({
   HostSidebar: (props: {
     selectedHostId: string
     selectedSubPage: string
-    onSelect: (hostId: string, subPage: 'overview' | 'sessions' | 'hooks' | 'agents' | 'uploads' | 'logs') => void
+    onSelect: (hostId: string, subPage: string) => void
   }) => (
     <div data-testid="host-sidebar" data-host={props.selectedHostId} data-subpage={props.selectedSubPage}>
       <button data-testid="select-test-host-logs" onClick={() => props.onSelect('test-host', 'logs')}>
@@ -49,8 +80,25 @@ vi.mock('./hosts/AddHostDialog', () => ({
   AddHostDialog: (props: { onClose: () => void }) => <div data-testid="add-host-dialog" onClick={props.onClose} />,
 }))
 
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Router } from 'wouter'
+import { memoryLocation } from 'wouter/memory-location'
+import { HostPage, resetLastHostSelection } from './HostPage'
+import { useHostStore } from '../stores/useHostStore'
+import {
+  clearContributions,
+  listContributions,
+  registerSettingsContribution,
+} from '../lib/settings-contribution-registry'
+import { clearModuleRegistry } from '../lib/module-registry'
+import { registerBuiltinModules } from '../lib/register-modules'
+import type { Pane } from '../types/tab'
+import type { SettingsContextFor } from '../lib/settings-contribution-types'
+
 const TEST_HOST_ID = 'test-host'
 const SECOND_HOST_ID = 'second-host'
+const HOST_A = 'hA'
 
 const hostPane: Pane = {
   id: 'pane-hosts',
@@ -83,11 +131,29 @@ function currentPath(mem: ReturnType<typeof memoryLocation>) {
   return mem.history[mem.history.length - 1]
 }
 
+// ---------------------------------------------------------------------------
+// Shared beforeEach: populate registry + seed hosts
+// HostPage.renderContent() reads listContributions('host') — the registry must
+// be populated with built-in host sub-pages so section bodies render.
+// vi.mock hoisting ensures mocked section stubs are used by registerBuiltinModules.
+// ---------------------------------------------------------------------------
 beforeEach(() => {
   resetLastHostSelection()
+  clearContributions()
+  clearModuleRegistry()
+  registerBuiltinModules()
   seedHosts()
 })
 
+afterEach(() => {
+  delete (window as unknown as Record<string, unknown>).electronAPI
+  clearContributions()
+  clearModuleRegistry()
+})
+
+// ---------------------------------------------------------------------------
+// Suite 1: Original route-navigation smoke tests (HostPage switch → registry)
+// ---------------------------------------------------------------------------
 describe('HostPage', () => {
   it('mounts from a deep link on first paint', () => {
     renderHostPage('/hosts/test-host/logs')
@@ -219,5 +285,141 @@ describe('HostPage', () => {
 
     expect(screen.getByText('No host selected.')).toBeInTheDocument()
     expect(currentPath(mem)).toBe('/hosts')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Suite 2: §3.1 registry-driven render tests (Commit 2)
+// ---------------------------------------------------------------------------
+
+function seedSingleHost(hostId = HOST_A) {
+  useHostStore.setState({
+    hosts: {
+      [hostId]: { id: hostId, name: `Host ${hostId}`, ip: '1.2.3.4', port: 7860, order: 0 },
+    },
+    hostOrder: [hostId],
+    activeHostId: hostId,
+    runtime: {},
+  })
+}
+
+describe('HostPage (registry-driven, §3.1)', () => {
+  beforeEach(() => {
+    seedSingleHost()
+  })
+
+  // Test 1: URL /hosts/hA/overview → render OverviewSection stub
+  it('T1: /hosts/hA/overview renders OverviewSection', () => {
+    renderHostPage('/hosts/hA/overview')
+    expect(screen.getByTestId('overview-section')).toBeInTheDocument()
+    expect(screen.getByTestId('overview-section')).toHaveAttribute('data-host', HOST_A)
+    expect(screen.queryByTestId('sessions-section')).not.toBeInTheDocument()
+  })
+
+  // Test 2: URL /hosts/hA/sessions → render SessionsSection stub
+  it('T2: /hosts/hA/sessions renders SessionsSection', () => {
+    renderHostPage('/hosts/hA/sessions')
+    expect(screen.getByTestId('sessions-section')).toBeInTheDocument()
+    expect(screen.getByTestId('sessions-section')).toHaveAttribute('data-host', HOST_A)
+    expect(screen.queryByTestId('overview-section')).not.toBeInTheDocument()
+  })
+
+  // Test 3: Registry has six built-in sub-pages in correct order
+  it('T3: registry has six built-in sub-pages in correct order', () => {
+    const contributions = listContributions('host')
+    expect(contributions.length).toBeGreaterThanOrEqual(6)
+
+    const localIds = contributions.map((c) => c.localId)
+    expect(localIds.slice(0, 6)).toEqual([
+      'overview', 'sessions', 'hooks', 'agents', 'uploads', 'logs',
+    ])
+  })
+
+  // Test 4: Extra registered contribution (order=100) → URL renders its body
+  it('T4: extra registered contribution appears in registry and renders its body', () => {
+    const FakeBody = () => <div data-testid="fake-body">FAKE_CONTENT</div>
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.custom-host-section',
+      localId: 'custom-host-section',
+      scope: 'host',
+      order: 100,
+      labelKey: 'custom-host-section',
+      component: FakeBody,
+    })
+
+    renderHostPage('/hosts/hA/custom-host-section')
+
+    // Fake body is rendered via registry
+    expect(screen.getByTestId('fake-body')).toBeInTheDocument()
+
+    // Registry now has 7 contributions (6 built-in + 1 fake)
+    expect(listContributions('host').length).toBeGreaterThanOrEqual(7)
+  })
+
+  // Test 5: Fake contribution receives ctx with scope==='host' && hostId===HOST_A
+  it('T5: fake contribution receives ctx.scope="host" and ctx.hostId=HOST_A', () => {
+    // Use a mutable container array to capture ctx without reassigning a let binding
+    // (avoids react-hooks/globals lint error for closed-over mutation in component body).
+    const capturedCtx: Array<SettingsContextFor<'host'>> = []
+
+    const FakeBodyWithCtx = ({ ctx }: { ctx: SettingsContextFor<'host'> }) => {
+      capturedCtx.push(ctx)
+      return <div data-testid="fake-body-ctx">CTX_RECEIVED</div>
+    }
+
+    registerSettingsContribution({
+      moduleId: 'fakectx',
+      id: 'fakectx.ctx-probe',
+      localId: 'ctx-probe',
+      scope: 'host',
+      order: 100,
+      labelKey: 'ctx-probe',
+      component: FakeBodyWithCtx,
+    })
+
+    renderHostPage('/hosts/hA/ctx-probe')
+
+    expect(screen.getByTestId('fake-body-ctx')).toBeInTheDocument()
+    expect(capturedCtx.length).toBeGreaterThan(0)
+    expect(capturedCtx[0].scope).toBe('host')
+    expect(capturedCtx[0].hostId).toBe(HOST_A)
+  })
+
+  // Test 6: URL /hosts/hA/nonexistent → redirects to canonical path
+  it('T6: /hosts/hA/nonexistent redirects to canonical (overview)', () => {
+    const { mem } = renderHostPage('/hosts/hA/nonexistent')
+
+    // resolveSelection self-heals to the first contribution's localId
+    const history = mem.history
+    const lastPath = history[history.length - 1]
+    // Should redirect to the fallback sub-page (overview = first built-in)
+    expect(lastPath).toBe('/hosts/hA/overview')
+  })
+
+  // Test 7: Disabled contribution → body NOT rendered.
+  // NOTE: HostSidebar is mocked in this file, so we can only assert the body
+  // absence here. The disabled-row sidebar styling (data-disabled-ctx) is tested
+  // in HostSidebar.test.tsx which renders the real sidebar with the registry.
+  it('T7: disabled fake contribution does NOT render body when navigated to', () => {
+    const DisabledBody = () => <div data-testid="disabled-body">DISABLED_CONTENT</div>
+
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.disabled-section',
+      localId: 'disabled-section',
+      scope: 'host',
+      order: 100,
+      labelKey: 'disabled-section',
+      component: DisabledBody,
+      disabled: () => true,
+      disabledReasonKey: 'settings.coming_soon',
+    })
+
+    // Navigate to the disabled section's URL
+    renderHostPage('/hosts/hA/disabled-section')
+
+    // Body must NOT be rendered (disabled contribution skipped by HostPage.renderContent)
+    expect(screen.queryByTestId('disabled-body')).not.toBeInTheDocument()
   })
 })

--- a/spa/src/components/HostPage.tsx
+++ b/spa/src/components/HostPage.tsx
@@ -4,6 +4,7 @@ import type { PaneRendererProps } from '../lib/module-registry'
 import { encodeHostRouteId, isHostSubPage, type HostSubPage } from '../lib/host-routes'
 import { parseRoute } from '../lib/route-utils'
 import { listContributions } from '../lib/settings-contribution-registry'
+import type { SettingsContribution, SettingsContextFor } from '../lib/settings-contribution-types'
 import { useHostStore } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { HostSidebar } from './hosts/HostSidebar'
@@ -27,19 +28,52 @@ function getFallbackHostId(hostOrder: string[], activeHostId: string | null) {
   return hostOrder[0] ?? null
 }
 
+/**
+ * Returns true when a contribution may be selected for `ctx`.
+ * A contribution is selectable when its `disabled` predicate is absent or
+ * returns false.  Mirrors `SettingsPage.isSelectable` (PR-2 pattern).
+ */
+function isSelectable(
+  c: SettingsContribution<'host'>,
+  ctx: SettingsContextFor<'host'>,
+): boolean {
+  return c.disabled?.(ctx) !== true
+}
+
+/**
+ * Given a target `hostId` and an optional `requestedSubPage`, return the best
+ * selectable subPage:
+ *
+ * 1. If `requestedSubPage` is provided, exists in the registry AND is
+ *    selectable for `hostId` → return it as-is.
+ * 2. Otherwise return the first contribution that is selectable for `hostId`.
+ * 3. Ultimate safety net: return `'overview'` literal if the registry is empty
+ *    or every contribution is disabled.
+ *
+ * Replaces `getFallbackSubPage()` — strict superset that also checks
+ * `disabled(ctx)`.
+ */
+function pickSelectableSubPage(hostId: string, requestedSubPage: string | null | undefined): HostSubPage {
+  const ctx: SettingsContextFor<'host'> = { scope: 'host', hostId }
+  const contributions = listContributions('host') as SettingsContribution<'host'>[]
+
+  if (requestedSubPage) {
+    const c = contributions.find((c) => c.localId === requestedSubPage)
+    if (c && isSelectable(c, ctx)) return requestedSubPage as HostSubPage
+  }
+
+  const first = contributions.find((c) => isSelectable(c, ctx))
+  return (first?.localId ?? 'overview') as HostSubPage
+}
+
 function getFallbackSelection(hostOrder: string[], activeHostId: string | null): Selection | null {
   const hostId = getFallbackHostId(hostOrder, activeHostId)
   if (!hostId) return null
 
   return {
     hostId,
-    subPage: lastSelection?.subPage ?? getFallbackSubPage(),
+    subPage: pickSelectableSubPage(hostId, lastSelection?.subPage),
   }
-}
-
-function getFallbackSubPage(): HostSubPage {
-  if (lastSelection?.subPage) return lastSelection.subPage
-  return listContributions('host')[0]?.localId ?? 'overview'
 }
 
 function resolveSelection(location: string, hostOrder: string[], activeHostId: string | null) {
@@ -65,24 +99,31 @@ function resolveSelection(location: string, hostOrder: string[], activeHostId: s
 
   if (parsed?.kind === 'hosts') {
     if (parsed.hostId && parsed.subPage) {
-      if (hostOrder.includes(parsed.hostId)) {
+      const resolvedHostId = hostOrder.includes(parsed.hostId) ? parsed.hostId : fallbackSelection.hostId
+      const resolvedSubPage = pickSelectableSubPage(resolvedHostId, parsed.subPage)
+      const needsHostRedirect = resolvedHostId !== parsed.hostId
+      const needsSubPageRedirect = resolvedSubPage !== parsed.subPage
+      const needsRedirect = needsHostRedirect || needsSubPageRedirect
+
+      if (!needsRedirect) {
         return {
-          selection: { hostId: parsed.hostId, subPage: parsed.subPage },
+          selection: { hostId: resolvedHostId, subPage: resolvedSubPage },
           canonicalPath: null as string | null,
           shouldPersistSelection: true,
         }
       }
 
       return {
-        selection: { hostId: fallbackSelection.hostId, subPage: parsed.subPage },
-        canonicalPath: buildHostPath({ hostId: fallbackSelection.hostId, subPage: parsed.subPage }),
+        selection: { hostId: resolvedHostId, subPage: resolvedSubPage },
+        canonicalPath: buildHostPath({ hostId: resolvedHostId, subPage: resolvedSubPage }),
         shouldPersistSelection: true,
       }
     }
 
     if (lastSelection) {
       const hostId = hostOrder.includes(lastSelection.hostId) ? lastSelection.hostId : fallbackSelection.hostId
-      const selection = { hostId, subPage: lastSelection.subPage }
+      const subPage = pickSelectableSubPage(hostId, lastSelection.subPage)
+      const selection = { hostId, subPage }
       return { selection, canonicalPath: buildHostPath(selection), shouldPersistSelection: true }
     }
 
@@ -95,9 +136,10 @@ function resolveSelection(location: string, hostOrder: string[], activeHostId: s
 
   if (parsed?.kind === 'hosts-invalid') {
     const hostId = parsed.hostId && hostOrder.includes(parsed.hostId) ? parsed.hostId : fallbackSelection.hostId
+    const rawSubPage = parsed.subPage && isHostSubPage(parsed.subPage) ? parsed.subPage : null
     const selection = {
       hostId,
-      subPage: parsed.subPage && isHostSubPage(parsed.subPage) ? parsed.subPage : getFallbackSubPage(),
+      subPage: pickSelectableSubPage(hostId, rawSubPage),
     }
 
     return {
@@ -107,8 +149,19 @@ function resolveSelection(location: string, hostOrder: string[], activeHostId: s
     }
   }
 
+  // Non-host route: keep lastSelection if available, clamped to live registry.
+  if (lastSelection) {
+    const hostId = hostOrder.includes(lastSelection.hostId) ? lastSelection.hostId : fallbackSelection.hostId
+    const subPage = pickSelectableSubPage(hostId, lastSelection.subPage)
+    return {
+      selection: { hostId, subPage },
+      canonicalPath: null as string | null,
+      shouldPersistSelection: false,
+    }
+  }
+
   return {
-    selection: lastSelection ?? fallbackSelection,
+    selection: fallbackSelection,
     canonicalPath: null as string | null,
     shouldPersistSelection: false,
   }
@@ -144,16 +197,18 @@ export function HostPage(_props: PaneRendererProps) {
       return <p className="text-text-muted">{t('hosts.no_host_selected')}</p>
     }
     const { hostId, subPage } = selection
-    const contributions = listContributions('host')
+    const contributions = listContributions('host') as SettingsContribution<'host'>[]
     const contribution = contributions.find((c) => c.localId === subPage)
     if (!contribution) {
       // subPage not in registry — self-heal via resolveSelection redirect.
       // Return null here; the canonicalPath effect will navigate away.
       return null
     }
-    const ctx = { scope: 'host' as const, hostId }
-    // F7: disabled contributions must not mount their body component.
-    if (contribution.disabled && contribution.disabled(ctx) === true) {
+    const ctx: SettingsContextFor<'host'> = { scope: 'host', hostId }
+    // F7 + A.1: disabled contributions must not mount their body component.
+    // `isSelectable` is the single predicate; resolveSelection already redirected
+    // away, so this is a last-resort guard.
+    if (!isSelectable(contribution, ctx)) {
       return null
     }
     const Component = contribution.component
@@ -162,11 +217,19 @@ export function HostPage(_props: PaneRendererProps) {
     return <Component key={`${hostId}:${contribution.id}`} ctx={ctx} />
   }
 
+  // A.3: HostSidebar selectedSubPage comes from pickSelectableSubPage so that
+  // the sidebar highlight never lands on a disabled row after a cross-host
+  // switch.
+  const sidebarHostId = selection?.hostId ?? lastSelection?.hostId ?? ''
+  const sidebarSubPage = sidebarHostId
+    ? pickSelectableSubPage(sidebarHostId, selection?.subPage ?? lastSelection?.subPage)
+    : (listContributions('host')[0]?.localId ?? 'overview') as HostSubPage
+
   return (
     <div className="flex h-full">
       <HostSidebar
         selectedHostId={selection?.hostId ?? ''}
-        selectedSubPage={selection?.subPage ?? lastSelection?.subPage ?? getFallbackSubPage()}
+        selectedSubPage={sidebarSubPage}
         onSelect={(hostId, subPage) => setLocation(buildHostPath({ hostId, subPage }), { replace: true })}
         onAddHost={() => setShowAddHost(true)}
       />

--- a/spa/src/components/HostPage.tsx
+++ b/spa/src/components/HostPage.tsx
@@ -39,9 +39,7 @@ function getFallbackSelection(hostOrder: string[], activeHostId: string | null):
 
 function getFallbackSubPage(): HostSubPage {
   if (lastSelection?.subPage) return lastSelection.subPage
-  // Cast: commit 3 will change HostSubPage to string; until then, the localId
-  // of a registered host contribution is always a valid URL token.
-  return (listContributions('host')[0]?.localId ?? 'overview') as HostSubPage
+  return listContributions('host')[0]?.localId ?? 'overview'
 }
 
 function resolveSelection(location: string, hostOrder: string[], activeHostId: string | null) {
@@ -169,7 +167,7 @@ export function HostPage(_props: PaneRendererProps) {
       <HostSidebar
         selectedHostId={selection?.hostId ?? ''}
         selectedSubPage={selection?.subPage ?? lastSelection?.subPage ?? getFallbackSubPage()}
-        onSelect={(hostId, subPage) => setLocation(buildHostPath({ hostId, subPage: subPage as HostSubPage }), { replace: true })}
+        onSelect={(hostId, subPage) => setLocation(buildHostPath({ hostId, subPage }), { replace: true })}
         onAddHost={() => setShowAddHost(true)}
       />
       <div className="flex-1 overflow-y-auto p-6">

--- a/spa/src/components/HostPage.tsx
+++ b/spa/src/components/HostPage.tsx
@@ -3,15 +3,10 @@ import { useLocation } from 'wouter'
 import type { PaneRendererProps } from '../lib/module-registry'
 import { encodeHostRouteId, isHostSubPage, type HostSubPage } from '../lib/host-routes'
 import { parseRoute } from '../lib/route-utils'
+import { listContributions } from '../lib/settings-contribution-registry'
 import { useHostStore } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { HostSidebar } from './hosts/HostSidebar'
-import { OverviewSection } from './hosts/OverviewSection'
-import { SessionsSection } from './hosts/SessionsSection'
-import { HooksSection } from './hosts/HooksSection'
-import { AgentsSection } from './hosts/AgentsSection'
-import { UploadSection } from './hosts/UploadSection'
-import { LogsSection } from './hosts/LogsSection'
 import { AddHostDialog } from './hosts/AddHostDialog'
 
 export type { HostSubPage } from '../lib/host-routes'
@@ -38,12 +33,15 @@ function getFallbackSelection(hostOrder: string[], activeHostId: string | null):
 
   return {
     hostId,
-    subPage: lastSelection?.subPage ?? 'overview',
+    subPage: lastSelection?.subPage ?? getFallbackSubPage(),
   }
 }
 
-function getFallbackSubPage() {
-  return lastSelection?.subPage ?? 'overview'
+function getFallbackSubPage(): HostSubPage {
+  if (lastSelection?.subPage) return lastSelection.subPage
+  // Cast: commit 3 will change HostSubPage to string; until then, the localId
+  // of a registered host contribution is always a valid URL token.
+  return (listContributions('host')[0]?.localId ?? 'overview') as HostSubPage
 }
 
 function resolveSelection(location: string, hostOrder: string[], activeHostId: string | null) {
@@ -147,28 +145,31 @@ export function HostPage(_props: PaneRendererProps) {
     if (!selection?.hostId) {
       return <p className="text-text-muted">{t('hosts.no_host_selected')}</p>
     }
-    switch (selection.subPage) {
-      case 'overview':
-        return <OverviewSection hostId={selection.hostId} />
-      case 'sessions':
-        return <SessionsSection hostId={selection.hostId} />
-      case 'hooks':
-        return <HooksSection hostId={selection.hostId} />
-      case 'agents':
-        return <AgentsSection hostId={selection.hostId} />
-      case 'uploads':
-        return <UploadSection hostId={selection.hostId} />
-      case 'logs':
-        return <LogsSection hostId={selection.hostId} />
+    const { hostId, subPage } = selection
+    const contributions = listContributions('host')
+    const contribution = contributions.find((c) => c.localId === subPage)
+    if (!contribution) {
+      // subPage not in registry — self-heal via resolveSelection redirect.
+      // Return null here; the canonicalPath effect will navigate away.
+      return null
     }
+    const ctx = { scope: 'host' as const, hostId }
+    // F7: disabled contributions must not mount their body component.
+    if (contribution.disabled && contribution.disabled(ctx) === true) {
+      return null
+    }
+    const Component = contribution.component
+    // Wrap with a key that includes hostId so switching hosts forces a remount
+    // and prevents cross-host state leak (PR-4 analog of PR-3 F3).
+    return <Component key={`${hostId}:${contribution.id}`} ctx={ctx} />
   }
 
   return (
     <div className="flex h-full">
       <HostSidebar
         selectedHostId={selection?.hostId ?? ''}
-        selectedSubPage={selection?.subPage ?? lastSelection?.subPage ?? 'overview'}
-        onSelect={(hostId, subPage) => setLocation(buildHostPath({ hostId, subPage }), { replace: true })}
+        selectedSubPage={selection?.subPage ?? lastSelection?.subPage ?? getFallbackSubPage()}
+        onSelect={(hostId, subPage) => setLocation(buildHostPath({ hostId, subPage: subPage as HostSubPage }), { replace: true })}
         onAddHost={() => setShowAddHost(true)}
       />
       <div className="flex-1 overflow-y-auto p-6">

--- a/spa/src/components/hosts/HostSidebar.test.tsx
+++ b/spa/src/components/hosts/HostSidebar.test.tsx
@@ -1,8 +1,11 @@
 // spa/src/components/hosts/HostSidebar.test.tsx
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { HostSidebar } from './HostSidebar'
 import { useHostStore } from '../../stores/useHostStore'
+import { clearContributions, registerSettingsContribution } from '../../lib/settings-contribution-registry'
+import { clearModuleRegistry } from '../../lib/module-registry'
+import { registerBuiltinModules } from '../../lib/register-modules'
 
 vi.mock('../../lib/host-api', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
@@ -14,11 +17,24 @@ const HOST_B = 'host-b'
 
 beforeEach(() => {
   cleanup()
+  // Populate the contribution registry with the six built-in host sub-pages.
+  // HostSidebar now reads listContributions('host') instead of the old hard-coded
+  // SUB_PAGES const, so the registry must be populated for sub-page labels to appear.
+  clearContributions()
+  clearModuleRegistry()
+  registerBuiltinModules()
+
   useHostStore.setState({
     hosts: { [HOST_ID]: { id: HOST_ID, name: 'Test Host', ip: '1.2.3.4', port: 7860, order: 0 } },
     hostOrder: [HOST_ID],
     runtime: {},
   })
+})
+
+afterEach(() => {
+  delete (window as unknown as Record<string, unknown>).electronAPI
+  clearContributions()
+  clearModuleRegistry()
 })
 
 describe('HostSidebar', () => {
@@ -202,5 +218,34 @@ describe('HostSidebar', () => {
     expect(overviewItems.length).toBeGreaterThanOrEqual(1)
     const sessionsItems = screen.getAllByText('Sessions')
     expect(sessionsItems.length).toBeGreaterThanOrEqual(1)
+  })
+
+  // T7 companion (§3.1): disabled contribution → sidebar row appears with
+  // data-disabled-ctx="true" attribute, click is a no-op (F7 contract).
+  it('T7 (§3.1): disabled contribution renders as disabled row in sidebar', () => {
+    const DisabledBody = () => null
+
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.disabled-section',
+      localId: 'disabled-section',
+      scope: 'host',
+      order: 100,
+      labelKey: 'disabled-section',
+      component: DisabledBody,
+      disabled: () => true,
+      disabledReasonKey: 'settings.coming_soon',
+    })
+
+    render(<HostSidebar {...defaultProps} />)
+
+    // Disabled row must appear (not filtered out)
+    const disabledRows = document.querySelectorAll('[data-disabled-ctx="true"]')
+    expect(disabledRows.length).toBeGreaterThan(0)
+
+    // Click on disabled row must NOT call onSelect
+    const disabledButton = disabledRows[0] as HTMLButtonElement
+    fireEvent.click(disabledButton)
+    expect(defaultProps.onSelect).not.toHaveBeenCalled()
   })
 })

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -1,22 +1,14 @@
 import { Plus, CaretDown, CaretRight, Circle, LockSimple, Spinner, Warning } from '@phosphor-icons/react'
 import { useState } from 'react'
-import type { HostSubPage } from '../../lib/host-routes'
+import type { HostSubPage as _HostSubPage } from '../../lib/host-routes'
+import { listContributions } from '../../lib/settings-contribution-registry'
 import { useHostStore, type HostRuntime } from '../../stores/useHostStore'
 import { useI18nStore } from '../../stores/useI18nStore'
 
-const SUB_PAGES: { id: HostSubPage; labelKey: string }[] = [
-  { id: 'overview', labelKey: 'hosts.overview' },
-  { id: 'sessions', labelKey: 'hosts.sessions' },
-  { id: 'hooks', labelKey: 'hosts.hooks' },
-  { id: 'agents', labelKey: 'hosts.agents' },
-  { id: 'uploads', labelKey: 'hosts.uploads' },
-  { id: 'logs', labelKey: 'hosts.logs' },
-]
-
 interface Props {
   selectedHostId: string
-  selectedSubPage: HostSubPage
-  onSelect: (hostId: string, subPage: HostSubPage) => void
+  selectedSubPage: string
+  onSelect: (hostId: string, subPage: string) => void
   onAddHost?: () => void
 }
 
@@ -40,6 +32,10 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
     [selectedHostId]: true,
   }))
 
+  // Read sub-pages from the contribution registry (order guaranteed by registry sort).
+  // Do NOT memoize — ctx may change scope-narrow inputs React cannot track in deps.
+  const subPages = listContributions('host')
+
   const toggleExpand = (hostId: string) => {
     setExpanded((prev) => ({ ...prev, [hostId]: !prev[hostId] }))
   }
@@ -54,6 +50,7 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
           const host = hosts[hostId]
           if (!host) return null
           const isExpanded = expanded[hostId] || hostId === selectedHostId
+          const hostCtx = { scope: 'host' as const, hostId }
           return (
             <div key={hostId} className="mb-1">
               <button
@@ -77,19 +74,35 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
               </button>
               {isExpanded && (
                 <div className="ml-4 border-l-2 border-border-subtle pl-2 mt-1">
-                  {SUB_PAGES.map((page) => (
-                    <button
-                      key={page.id}
-                      onClick={() => onSelect(hostId, page.id)}
-                      className={`w-full text-left px-2 py-1 rounded text-xs cursor-pointer ${
-                        selectedHostId === hostId && selectedSubPage === page.id
-                          ? 'text-accent font-semibold bg-accent/10'
-                          : 'text-text-muted hover:text-text-secondary'
-                      }`}
-                    >
-                      {t(page.labelKey)}
-                    </button>
-                  ))}
+                  {subPages.map((page) => {
+                    // F7: disabled contributions show as a disabled row but are NOT
+                    // filtered out. Clicking a disabled row is a no-op.
+                    const isDisabled = page.disabled ? page.disabled(hostCtx) === true : false
+                    const isActive = selectedHostId === hostId && selectedSubPage === page.localId
+                    const disabledTitle =
+                      isDisabled && page.disabledReasonKey
+                        ? t(page.disabledReasonKey)
+                        : undefined
+                    return (
+                      <button
+                        key={page.localId}
+                        data-disabled-ctx={isDisabled ? 'true' : undefined}
+                        title={disabledTitle}
+                        onClick={() => {
+                          if (!isDisabled) onSelect(hostId, page.localId)
+                        }}
+                        className={`w-full text-left px-2 py-1 rounded text-xs ${
+                          isDisabled
+                            ? 'text-text-muted cursor-not-allowed'
+                            : isActive
+                              ? 'text-accent font-semibold bg-accent/10 cursor-pointer'
+                              : 'text-text-muted hover:text-text-secondary cursor-pointer'
+                        }`}
+                      >
+                        {t(page.labelKey)}
+                      </button>
+                    )
+                  })}
                 </div>
               )}
             </div>

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -1,6 +1,5 @@
 import { Plus, CaretDown, CaretRight, Circle, LockSimple, Spinner, Warning } from '@phosphor-icons/react'
 import { useState } from 'react'
-import type { HostSubPage as _HostSubPage } from '../../lib/host-routes'
 import { listContributions } from '../../lib/settings-contribution-registry'
 import { useHostStore, type HostRuntime } from '../../stores/useHostStore'
 import { useI18nStore } from '../../stores/useI18nStore'

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -9,6 +9,12 @@ import {
   drainLegacyContributionQueue,
   peekLegacyContributionQueue,
 } from './settings-section-registry'
+import {
+  clearHostBuiltinPending,
+  drainHostBuiltinQueue,
+  HOST_BUILTIN_MODULE_ID,
+  peekHostBuiltinQueue,
+} from './host-builtin-sections'
 import type {
   AnySettingsContribution,
   SettingsScope,
@@ -73,15 +79,18 @@ export function buildSettingsContributionBatch(
 
   const checkAndRecord = (
     full: AnySettingsContribution,
-    origin: 'module' | 'legacy',
+    origin: 'module' | 'legacy' | 'host-builtin',
   ): void => {
     assertValidSettingsContribution(full)
     if (seenIds.has(full.id)) {
-      throw new Error(
+      const suffix =
         origin === 'legacy'
-          ? `settings-contribution-registry: duplicate contribution id "${full.id}" ` +
-              `(legacy adapter collides with module-declared contribution)`
-          : `settings-contribution-registry: duplicate contribution id "${full.id}"`,
+          ? ` (legacy adapter collides with module-declared contribution)`
+          : origin === 'host-builtin'
+            ? ` (host-builtin adapter collides with module-declared contribution)`
+            : ``
+      throw new Error(
+        `settings-contribution-registry: duplicate contribution id "${full.id}"${suffix}`,
       )
     }
     let scopeMap = localIdByScope.get(full.scope)
@@ -136,6 +145,20 @@ export function buildSettingsContributionBatch(
     batch.push(full)
   }
 
+  // Peek (non-destructive) at the host built-in adapter pending buffer.
+  // Same F3 atomicity contract: peeked here for validation, drained only
+  // in the commit phase of `dispatchSettingsContributions()`.
+  const hostBuiltinDecls = peekHostBuiltinQueue()
+  for (const decl of hostBuiltinDecls) {
+    const full = {
+      ...decl,
+      moduleId: HOST_BUILTIN_MODULE_ID,
+      id: `${HOST_BUILTIN_MODULE_ID}.${decl.localId}`,
+    } as AnySettingsContribution
+    checkAndRecord(full, 'host-builtin')
+    batch.push(full)
+  }
+
   return batch
 }
 
@@ -158,7 +181,8 @@ export function dispatchSettingsContributions(
 
   // Phase 2 — commit. Safe to mutate now: validation passed.
   clearContributions()
-  drainLegacyContributionQueue() // safe: staging already holds the validated set
+  drainLegacyContributionQueue()  // safe: staging already holds the validated set
+  drainHostBuiltinQueue()         // same atomicity contract as legacy drain
   for (const contribution of batch) {
     registerSettingsContribution(contribution)
   }
@@ -178,4 +202,5 @@ export function dispatchSettingsContributions(
 export function resetSettingsContributionsForHmr(): void {
   clearContributions()
   clearLegacyPending()
+  clearHostBuiltinPending()
 }

--- a/spa/src/lib/host-builtin-sections.test.tsx
+++ b/spa/src/lib/host-builtin-sections.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * §3.3 — Built-in host sub-page adapter tests (PR-4 Commit 1)
+ *
+ * Verifies that `registerBuiltinModules()` registers exactly six host-scoped
+ * contributions with the correct moduleId, order, wrap semantics, and scope
+ * guard.
+ *
+ * Test design — Test 3 (render-level props forwarding):
+ *   OverviewSection is swapped for a spy stub via vi.mock so zustand/HTTP
+ *   dependencies are never loaded.  The wrapper is rendered with a real host
+ *   ctx and the resulting DOM is asserted — proving (a) the wrapper renders,
+ *   (b) the underlying section component is invoked, (c) hostId is forwarded.
+ *
+ *   The "all six identity" extra test uses the WeakMap as a complementary
+ *   structural check and keeps that coverage without duplicating the render
+ *   assertion for every section.
+ *
+ *   Test 4 (scope guard) renders the wrapper component directly with a wrong-
+ *   scope ctx and asserts the output is null — the wrapper is a pure function
+ *   with no external dependencies, so no mocks are needed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import React from 'react'
+
+// Mock icon-path-cache — required by register-modules (phosphor weight loader)
+vi.mock('../features/workspace/lib/icon-path-cache', () => ({
+  getIconPath: () => null,
+  isWeightLoaded: () => true,
+  prefetchWeight: () => Promise.resolve(),
+}))
+
+// Mock OverviewSection so Test 3 can render the wrapper without pulling in
+// zustand / HTTP dependencies.  The stub is a named export (matching the
+// real module's export shape) and renders identifiable content that includes
+// the forwarded hostId prop.
+vi.mock('../components/hosts/OverviewSection', () => ({
+  OverviewSection: vi.fn(({ hostId }: { hostId: string }) => (
+    <div data-testid="overview-stub">overview-for-{hostId}</div>
+  )),
+}))
+
+import {
+  clearModuleRegistry,
+} from './module-registry'
+import { clearNewTabRegistry } from './new-tab-registry'
+import {
+  clearSettingsSectionRegistry,
+} from './settings-section-registry'
+import { clearInterfaceSubsectionRegistry } from './interface-subsection-registry'
+import { registerBuiltinModules } from './register-modules'
+import {
+  clearContributions,
+  listContributions,
+} from './settings-contribution-registry'
+import {
+  clearHostBuiltinPending,
+  hostBuiltinComponentMap,
+  HOST_BUILTIN_MODULE_ID,
+} from './host-builtin-sections'
+
+// Import the six section components so we can verify identity (extra test).
+import { OverviewSection } from '../components/hosts/OverviewSection'
+import { SessionsSection } from '../components/hosts/SessionsSection'
+import { HooksSection } from '../components/hosts/HooksSection'
+import { AgentsSection } from '../components/hosts/AgentsSection'
+import { UploadSection } from '../components/hosts/UploadSection'
+import { LogsSection } from '../components/hosts/LogsSection'
+
+function clearAll() {
+  clearModuleRegistry()
+  clearNewTabRegistry()
+  clearSettingsSectionRegistry()
+  clearInterfaceSubsectionRegistry()
+  clearContributions()
+  clearHostBuiltinPending()
+}
+
+describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions', () => {
+  beforeEach(() => {
+    clearAll()
+  })
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).electronAPI
+    clearAll()
+  })
+
+  // Test 1: After registerBuiltinModules(), listContributions('host') contains
+  // exactly 6 items, all with moduleId === '_builtin.host'
+  it('registers exactly 6 host-scoped contributions with moduleId _builtin.host', () => {
+    registerBuiltinModules()
+    const hostContribs = listContributions('host')
+    expect(hostContribs).toHaveLength(6)
+    for (const c of hostContribs) {
+      expect(c.moduleId).toBe(HOST_BUILTIN_MODULE_ID)
+    }
+  })
+
+  // Test 2: Order is exactly overview → sessions → hooks → agents → uploads → logs
+  it('orders contributions as: overview, sessions, hooks, agents, uploads, logs', () => {
+    registerBuiltinModules()
+    const hostContribs = listContributions('host')
+    const localIds = hostContribs.map((c) => c.localId)
+    expect(localIds).toEqual(['overview', 'sessions', 'hooks', 'agents', 'uploads', 'logs'])
+  })
+
+  // Test 3: The contribution's component wraps OverviewSection and forwards hostId.
+  // Renders the wrapper with a real host ctx and asserts on the stub's DOM output,
+  // proving (a) wrapper renders, (b) section is invoked, (c) hostId is forwarded.
+  it('renders OverviewSection with forwarded hostId for host ctx', () => {
+    registerBuiltinModules()
+    const overview = listContributions('host').find((c) => c.localId === 'overview')
+    expect(overview).toBeDefined()
+
+    const Wrapper = overview!.component as React.ComponentType<{
+      ctx: { scope: 'host'; hostId: string }
+    }>
+    const { getByTestId } = render(<Wrapper ctx={{ scope: 'host', hostId: 'hA' }} />)
+    const node = getByTestId('overview-stub')
+    expect(node.textContent).toBe('overview-for-hA')
+  })
+
+  // Bonus identity checks for the remaining five sections (keeps Test 3's spirit).
+  it('wraps all six sections to their original components', () => {
+    registerBuiltinModules()
+    const hostContribs = listContributions('host')
+
+    const expected = [
+      { localId: 'overview', component: OverviewSection },
+      { localId: 'sessions', component: SessionsSection },
+      { localId: 'hooks', component: HooksSection },
+      { localId: 'agents', component: AgentsSection },
+      { localId: 'uploads', component: UploadSection },
+      { localId: 'logs', component: LogsSection },
+    ]
+
+    for (const { localId, component } of expected) {
+      const contrib = hostContribs.find((c) => c.localId === localId)
+      expect(contrib, `contribution for '${localId}' must exist`).toBeDefined()
+      const original = hostBuiltinComponentMap.get(
+        contrib!.component as React.ComponentType<{ ctx: { scope: 'host'; hostId: string } }>,
+      )
+      expect(original, `'${localId}' must wrap the correct section`).toBe(component)
+    }
+  })
+
+  // Test 4: Scope guard — render with ctx.scope !== 'host' returns null.
+  it('scope guard: wrapper returns null when ctx.scope is not "host"', () => {
+    registerBuiltinModules()
+    const hostContribs = listContributions('host')
+    const overviewContrib = hostContribs.find((c) => c.localId === 'overview')
+    expect(overviewContrib).toBeDefined()
+
+    const Wrapper = overviewContrib!.component as React.ComponentType<{
+      ctx: { scope: string; workspaceId?: string }
+    }>
+
+    // Render with a workspace ctx — must produce null (no DOM nodes).
+    // The guard is a single `!== 'host'` check, so any non-host scope suffices.
+    const { container } = render(
+      <Wrapper ctx={{ scope: 'workspace', workspaceId: 'wA' }} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  // Structural checks on all contributions.
+  it('all contributions have correct scope, valid localIds, and labelKey starting with "hosts."', () => {
+    registerBuiltinModules()
+    const hostContribs = listContributions('host')
+
+    for (const c of hostContribs) {
+      expect(c.scope).toBe('host')
+      expect(c.id).toBe(`${HOST_BUILTIN_MODULE_ID}.${c.localId}`)
+      expect(c.labelKey).toMatch(/^hosts\./)
+    }
+  })
+
+  // HMR safety: re-running registerBuiltinModules does not accumulate duplicates.
+  it('is HMR-safe: re-running registerBuiltinModules after clearAll does not duplicate', () => {
+    registerBuiltinModules()
+    const first = listContributions('host').length
+    clearAll()
+    registerBuiltinModules()
+    const second = listContributions('host').length
+    expect(first).toBe(6)
+    expect(second).toBe(6)
+  })
+})

--- a/spa/src/lib/host-builtin-sections.ts
+++ b/spa/src/lib/host-builtin-sections.ts
@@ -1,0 +1,132 @@
+/**
+ * host-builtin-sections.ts
+ *
+ * Built-in host sub-page adapter — mirrors the PR-2 dispatch-flushed
+ * pattern used by the legacy settings adapter (`settings-section-registry`),
+ * but scoped to `'host'` contributions with `moduleId = '_builtin.host'`.
+ *
+ * ## Why a separate queue (not shared with the legacy adapter)
+ *
+ * The legacy adapter (`_builtin.legacy-section`) is purdex-scoped.  Sharing
+ * the same pending buffer would conflate two independent namespaces and make
+ * the collision-checking logic in `buildSettingsContributionBatch` harder to
+ * reason about.  A parallel queue keeps each adapter's invariants isolated
+ * and the drain/peek surface matches the legacy adapter's contract exactly
+ * (same shape, same atomicity guarantees — PR-3 Finding F3).
+ *
+ * ## Dispatch contract (§7.2 hard constraint)
+ *
+ * `registerBuiltinHostSection()` MUST NOT call `registerSettingsContribution()`
+ * directly.  It pushes to `pendingHostBuiltinContributions`, which is peeked
+ * (non-destructively) during Phase 1 validation and drained atomically during
+ * Phase 2 commit inside `dispatchSettingsContributions()`.  This prevents
+ * `clearContributions()` from nuking built-ins registered before dispatch.
+ *
+ * ## HMR safety
+ *
+ * `registerBuiltinModules()` may re-run on hot-reload.  The buffer is drained
+ * (cleared) after each successful dispatch, so re-runs produce a clean batch
+ * without duplicates.  The `clearHostBuiltinPending()` helper is also exposed
+ * for the `resetSettingsContributionsForHmr()` path.
+ */
+import React from 'react'
+import type {
+  AnySettingsContributionDeclaration,
+  SettingsContributionDeclaration,
+  SettingsContextFor,
+} from './settings-contribution-types'
+
+export const HOST_BUILTIN_MODULE_ID = '_builtin.host'
+
+export interface HostBuiltinSectionDef {
+  /** URL segment and registry localId (must match SETTINGS_LOCAL_ID_RE). */
+  localId: string
+  /** i18n key for sidebar label. */
+  labelKey: string
+  /** Position within host scope; lower = earlier. */
+  order: number
+  /**
+   * The underlying section component.  Receives `{ hostId: string }` props
+   * (the standard shape shared by all six built-in host sections).  The
+   * adapter wraps it with a scope guard so contributions receive the correct
+   * `ctx` shape without modifying the section components.
+   */
+  component: React.ComponentType<{ hostId: string }>
+}
+
+// ----------------------------------------------------------------------------
+// Pending buffer (PR-2 dispatch-flushed pattern)
+// ----------------------------------------------------------------------------
+
+type HostBuiltinDeclaration = SettingsContributionDeclaration<'host'>
+type HostCtxProps = { ctx: SettingsContextFor<'host'> }
+
+/**
+ * WeakMap from the ctx-wrapper component → the original section component.
+ * Exposed for tests that verify `hostId` forwarding without a full DOM render.
+ */
+// Exported for test identity assertions only — see host-builtin-sections.test.tsx
+export const hostBuiltinComponentMap = new WeakMap<
+  React.ComponentType<HostCtxProps>,
+  React.ComponentType<{ hostId: string }>
+>()
+
+// Upsert map by localId so HMR re-runs do not accumulate duplicates.
+const pendingHostBuiltinContributions = new Map<string, HostBuiltinDeclaration>()
+
+/**
+ * Register a built-in host sub-page into the pending buffer.  The
+ * contribution is NOT committed to the live registry here — it waits for the
+ * next `dispatchSettingsContributions()` call to flush.
+ */
+export function registerBuiltinHostSection(def: HostBuiltinSectionDef): void {
+  // Scope guard wrapper: forward `hostId` from ctx; return null for wrong scope.
+  // Using React.createElement keeps this file as .ts (no JSX transform needed).
+  const Section = def.component
+  const Wrapped: React.FC<HostCtxProps> = (props) => {
+    if (props.ctx.scope !== 'host') return null
+    return React.createElement(Section, { hostId: props.ctx.hostId })
+  }
+  Wrapped.displayName = `HostBuiltinWrap(${Section.displayName ?? Section.name ?? def.localId})`
+
+  hostBuiltinComponentMap.set(Wrapped, Section)
+
+  const decl: HostBuiltinDeclaration = {
+    localId: def.localId,
+    scope: 'host',
+    order: def.order,
+    labelKey: def.labelKey,
+    component: Wrapped,
+  }
+  pendingHostBuiltinContributions.set(def.localId, decl)
+}
+
+/**
+ * Non-destructive view of the pending host built-in queue.  Used by the
+ * dispatch validation phase (Phase 1) so a validation failure leaves the
+ * queue intact for a retry.
+ */
+export function peekHostBuiltinQueue(): readonly AnySettingsContributionDeclaration[] {
+  return Array.from(pendingHostBuiltinContributions.values())
+}
+
+/**
+ * Drain pending host built-in contributions into a fresh array, emptying the
+ * internal buffer.  F3: COMMIT-ONLY — call only after full validation has
+ * succeeded (see `drainLegacyContributionQueue` docs for rationale).
+ */
+export function drainHostBuiltinQueue(): AnySettingsContributionDeclaration[] {
+  const out: AnySettingsContributionDeclaration[] = Array.from(
+    pendingHostBuiltinContributions.values(),
+  )
+  pendingHostBuiltinContributions.clear()
+  return out
+}
+
+/**
+ * HMR dispose hook.  Clears the active pending buffer so no stale entries
+ * leak across HMR re-runs.
+ */
+export function clearHostBuiltinPending(): void {
+  pendingHostBuiltinContributions.clear()
+}

--- a/spa/src/lib/host-lifecycle.test.ts
+++ b/spa/src/lib/host-lifecycle.test.ts
@@ -7,6 +7,7 @@ import { useAgentStore, type NormalizedEvent } from '../stores/useAgentStore'
 import { useStreamStore } from '../stores/useStreamStore'
 import { useHistoryStore } from '../stores/useHistoryStore'
 import { useHostSettingsStore } from '../stores/useHostSettingsStore'
+import { useWorkspaceSettingsStore } from '../stores/useWorkspaceSettingsStore'
 import { useWorkspaceStore } from '../features/workspace/store'
 import { useUndoToast } from '../stores/useUndoToast'
 import { createTab } from '../types/tab'
@@ -505,5 +506,305 @@ describe('session-closed detection', () => {
     if (c2.kind === 'tmux-session') {
       expect(c2.terminated).toBe('session-closed')
     }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §3.4 — #541 Cross-store rehydrate order invariants harness
+//
+// These tests validate that `deleteHostCascade` (and its undo callback) behave
+// correctly under all rehydrate-timing combinations:
+//   A. Both useHostStore + useHostSettingsStore fully rehydrated
+//   B. Only useHostSettingsStore rehydrated (hosts store still empty — e.g. it
+//      rehydrated first in a race)
+//   C. Only useHostStore rehydrated (hostSettings store not yet rehydrated)
+//   + interleaved-write gate, hostWasRecreated, last-host veto, and workspace
+//     settings isolation.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#541 cross-store rehydrate order invariants', () => {
+  const hA = 'hA'
+  const hB = 'hB'
+
+  // Wipe all singleton stores to a blank canvas before each test.
+  //
+  // IMPORTANT: We use setState WITHOUT replace-mode (no `true` second arg) for
+  // all stores. This keeps Zustand action methods intact in the store state
+  // object, which host-lifecycle.ts needs because it snapshots store state at
+  // call time (e.g. `const sessionStore = useSessionStore.getState()`) and then
+  // calls action methods on the snapshot (e.g. `sessionStore.removeHost(...)`).
+  // Replace-mode would wipe those methods, causing "not a function" errors.
+  //
+  // The data fields we set here ({hosts:{}, ...}) are shallowly merged on top
+  // of the current state, overwriting the default mlab host that
+  // createDefaultState() bakes in — so we get a clean slate without clobbering
+  // the action closures.
+  beforeEach(() => {
+    localStorage.clear()
+    // Merge-mode: set data fields to blank without clobbering action methods
+    useHostStore.setState({ hosts: {}, hostOrder: [], runtime: {}, activeHostId: null })
+    useHostSettingsStore.setState({ hosts: {} })
+    useWorkspaceSettingsStore.setState({ workspaces: {} })
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+    useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
+    useAgentStore.setState({ lastEvents: {}, statuses: {}, unread: {}, subagents: {}, agentTypes: {}, models: {} })
+    useStreamStore.setState({ sessions: {}, relayStatus: {}, handoffProgress: {} })
+    useHistoryStore.setState({ browseHistory: [], closedTabs: [] })
+    useWorkspaceStore.getState().reset()
+    useUndoToast.setState({ toast: null })
+  })
+
+  // ── Seed helpers ──────────────────────────────────────────────────────────
+
+  /** Both stores fully rehydrated: hA + hB in hostStore, hA has settings. */
+  function seedBothRehydrated() {
+    // Merge-mode: preserve action methods in store state
+    useHostStore.setState({
+      hosts: {
+        [hA]: { id: hA, name: 'Host A', ip: '127.0.0.1', port: 7860, order: 0 },
+        [hB]: { id: hB, name: 'Host B', ip: '127.0.0.1', port: 7861, order: 1 },
+      },
+      hostOrder: [hA, hB],
+      runtime: {},
+      activeHostId: hA,
+    })
+    useHostSettingsStore.setState({ hosts: { [hA]: { editor: { homePath: '/tmp/a' } } } })
+  }
+
+  /** Only hostStore rehydrated; hostSettings store is empty (hasn't rehydrated yet). */
+  function seedHostOnly() {
+    // Merge-mode: preserve action methods in store state
+    useHostStore.setState({
+      hosts: {
+        [hA]: { id: hA, name: 'Host A', ip: '127.0.0.1', port: 7860, order: 0 },
+        [hB]: { id: hB, name: 'Host B', ip: '127.0.0.1', port: 7861, order: 1 },
+      },
+      hostOrder: [hA, hB],
+      runtime: {},
+      activeHostId: hA,
+    })
+    // hostSettings intentionally left as beforeEach blank { hosts: {} }
+  }
+
+  /** Only hostSettings store rehydrated; hostStore is empty (hasn't rehydrated yet). */
+  function seedSettingsOnly() {
+    // Merge-mode: preserve action methods in store state
+    useHostSettingsStore.setState({ hosts: { [hA]: { editor: { homePath: '/tmp/a' } } } })
+    // hostStore intentionally left as beforeEach blank { hosts: {} }
+  }
+
+  // ── Case 1: Rehydrate order A — both stores rehydrated ───────────────────
+
+  it('A: both rehydrated — removeHost clears hostSettings; undo restores both', () => {
+    seedBothRehydrated()
+
+    const restore = deleteHostCascade(hA, true)
+
+    // Cascade: hA gone from both stores
+    expect(useHostStore.getState().hosts[hA]).toBeUndefined()
+    expect(useHostSettingsStore.getState().hosts[hA]).toBeUndefined()
+    // hB untouched
+    expect(useHostStore.getState().hosts[hB]).toBeDefined()
+
+    // Undo: both restored
+    restore()
+    expect(useHostStore.getState().hosts[hA]).toBeDefined()
+    expect(useHostSettingsStore.getState().hosts[hA]).toEqual({ editor: { homePath: '/tmp/a' } })
+  })
+
+  // ── Case 2: Rehydrate order B — hostSettings only, hostStore empty ────────
+
+  it('B: settings-only rehydrate — removeHost is no-op (host not in store); hostSettings unchanged', () => {
+    seedSettingsOnly()
+
+    // hA is NOT in hostStore.hosts, so deleteHostCascade's pre-check aborts
+    const restore = deleteHostCascade(hA, true)
+
+    // Settings must be untouched — cascade aborted before touching anything
+    expect(useHostSettingsStore.getState().hosts[hA]).toEqual({ editor: { homePath: '/tmp/a' } })
+
+    // Undo must be a safe no-op
+    expect(() => restore()).not.toThrow()
+    // Settings still intact after undo no-op
+    expect(useHostSettingsStore.getState().hosts[hA]).toEqual({ editor: { homePath: '/tmp/a' } })
+  })
+
+  // ── Case 3: Rehydrate order C — hostStore only, hostSettings empty ────────
+
+  it('C: host-only rehydrate — removeHost cascades; undo restores host, hostSettings stays empty', () => {
+    seedHostOnly()
+
+    const restore = deleteHostCascade(hA, true)
+
+    // Cascade ran: hA removed from hostStore, hostSettings was already empty (no-op clear)
+    expect(useHostStore.getState().hosts[hA]).toBeUndefined()
+    expect(useHostSettingsStore.getState().hosts[hA]).toBeUndefined()
+
+    // Undo: hostStore restored, hostSettings still empty (nothing was snapshotted)
+    restore()
+    expect(useHostStore.getState().hosts[hA]).toBeDefined()
+    expect(useHostStore.getState().hostOrder).toContain(hA)
+    // hostSettings was empty at snapshot time — undo must not invent new data
+    expect(useHostSettingsStore.getState().hosts[hA]).toBeUndefined()
+  })
+
+  // ── Case 4: Interleaved write during cascade — undo must NOT clobber ──────
+
+  it('interleaved write: fresh hostSettings write during undo window is preserved by undo gate', () => {
+    seedBothRehydrated()
+
+    const restore = deleteHostCascade(hA, true)
+    expect(useHostSettingsStore.getState().hosts[hA]).toBeUndefined()
+
+    // Simulate a BroadcastChannel sync or re-add writing fresh settings for hA
+    // (recreate host first so hostWasRecreated guard kicks in)
+    useHostStore.setState((s) => ({
+      hosts: {
+        ...s.hosts,
+        [hA]: { id: hA, name: 'Host A (fresh)', ip: '9.9.9.9', port: 7860, order: 2 },
+      },
+      hostOrder: [...s.hostOrder, hA],
+    }))
+    // Write new settings for the recreated host
+    useHostSettingsStore.setState((s) => ({
+      hosts: { ...s.hosts, [hA]: { editor: { homePath: '/new' } } },
+    }))
+
+    restore()
+
+    // Undo must NOT overwrite the freshly written settings (hostWasRecreated gate)
+    expect(useHostSettingsStore.getState().hosts[hA]).toEqual({ editor: { homePath: '/new' } })
+    // And the recreated host survives
+    expect(useHostStore.getState().hosts[hA]?.name).toBe('Host A (fresh)')
+  })
+
+  // ── Case 5: hostWasRecreated gate covers all 6 restore categories ─────────
+
+  it('hostWasRecreated: recreating same-id host during undo window blocks all 6 restore categories', () => {
+    seedBothRehydrated()
+
+    // Seed additional data in all cascaded stores so we can assert each is gated
+    const event: NormalizedEvent = {
+      agent_type: 'cc',
+      status: 'idle',
+      raw_event_name: 'Stop',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleNormalizedEvent(hA, 'dev001', event)
+    // Also seed statuses directly so the snapshot is non-vacuous (handleNormalizedEvent
+    // may or may not write statuses depending on event.status; seed directly to be sure)
+    useAgentStore.setState((s) => ({
+      statuses: { ...s.statuses, [`${hA}:dev001`]: 'running' as const },
+    }))
+    useStreamStore.getState().addMessage(hA, 'dev001', { type: 'assistant' } as StreamMessage)
+    useSessionStore.getState().replaceHost(hA, [{ code: 'dev001', name: 'Dev', mode: 'terminal', cwd: '~', cc_session_id: '', cc_model: '', has_relay: false }])
+    // Seed a tab in a workspace so the tab-restore gate (category 6) can be asserted
+    const ws6 = useWorkspaceStore.getState().addWorkspace('WS for gate test')
+    const tab6 = makeSessionTab(hA, 'dev001')
+    useTabStore.getState().addTab(tab6)
+    useWorkspaceStore.getState().addTabToWorkspace(ws6.id, tab6.id)
+
+    const restore = deleteHostCascade(hA, true)
+
+    // Recreate hA as a different entity during undo window
+    useHostStore.setState((s) => ({
+      hosts: {
+        ...s.hosts,
+        [hA]: { id: hA, name: 'Recreated A', ip: '9.9.9.9', port: 7860, order: 2 },
+      },
+      hostOrder: [...s.hostOrder, hA],
+    }))
+
+    restore()
+
+    // hostWasRecreated = true → all 6 restore categories must be blocked:
+    // 1. host position/order — recreated entry stays, snapshot hostOrder NOT applied
+    expect(useHostStore.getState().hosts[hA]?.name).toBe('Recreated A')
+    // 2. hostSettings — not restored (stays undefined)
+    expect(useHostSettingsStore.getState().hosts[hA]).toBeUndefined()
+    // 3. sessions — not restored
+    expect(useSessionStore.getState().sessions[hA]).toBeUndefined()
+    // 4. agentStore statuses — not restored (seeded directly above; snapshot captured it; gate must block)
+    expect(useAgentStore.getState().statuses[`${hA}:dev001`]).toBeUndefined()
+    // 5. streamStore data — not restored
+    expect(useStreamStore.getState().sessions[`${hA}:dev001`]).toBeUndefined()
+    // 6. tab/workspace-membership restore — tab must NOT be re-added to the workspace
+    expect(useTabStore.getState().tabs[tab6.id]).toBeUndefined()
+    expect(useWorkspaceStore.getState().findWorkspaceByTab(tab6.id)).toBeNull()
+  })
+
+  // ── Case 6: Last-host veto ────────────────────────────────────────────────
+
+  it('last-host veto: removeHost with only one host is no-op; cascade aborted', () => {
+    // Seed only hA — removeHost will veto because hosts.length <= 1
+    // Merge-mode: preserve action methods
+    useHostStore.setState({
+      hosts: {
+        [hA]: { id: hA, name: 'Host A', ip: '127.0.0.1', port: 7860, order: 0 },
+      },
+      hostOrder: [hA],
+      runtime: {},
+      activeHostId: hA,
+    })
+    useHostSettingsStore.setState({ hosts: { [hA]: { editor: { homePath: '/tmp/a' } } } })
+
+    const restore = deleteHostCascade(hA, true)
+
+    // Host still present (veto)
+    expect(useHostStore.getState().hosts[hA]).toBeDefined()
+    // Settings untouched (cascade never ran)
+    expect(useHostSettingsStore.getState().hosts[hA]).toEqual({ editor: { homePath: '/tmp/a' } })
+    // Undo is safe no-op
+    expect(() => restore()).not.toThrow()
+  })
+
+  // ── Case 7: Cascade regression — PR-1 contract ───────────────────────────
+
+  it('cascade regression: removeHost clears hostSettings.hA (PR-1 contract)', () => {
+    seedBothRehydrated()
+
+    deleteHostCascade(hA, true)
+
+    expect(useHostSettingsStore.getState().hosts[hA]).toBeUndefined()
+    // hB settings not affected (hB had no settings — stays undefined)
+    expect(useHostStore.getState().hosts[hB]).toBeDefined()
+  })
+
+  // ── Case 8: Undo regression — PR-1 contract ──────────────────────────────
+
+  it('undo regression: cascade then undo restores hosts + hostSettings (PR-1 contract)', () => {
+    seedBothRehydrated()
+
+    const restore = deleteHostCascade(hA, true)
+    // Verify cascade ran
+    expect(useHostStore.getState().hosts[hA]).toBeUndefined()
+    expect(useHostSettingsStore.getState().hosts[hA]).toBeUndefined()
+
+    restore()
+
+    // Both restored
+    expect(useHostStore.getState().hosts[hA]).toBeDefined()
+    expect(useHostStore.getState().hostOrder).toContain(hA)
+    expect(useHostSettingsStore.getState().hosts[hA]).toEqual({ editor: { homePath: '/tmp/a' } })
+  })
+
+  // ── Case 9: Workspace cross — useWorkspaceSettingsStore isolation ─────────
+
+  it('workspace cross: removeHost does NOT clear useWorkspaceSettingsStore entries for hA-owned workspace', () => {
+    seedBothRehydrated()
+
+    // Seed a workspace with settings that reference hA indirectly (as module owner context)
+    const WS_ID = 'ws-hA'
+    // Merge-mode: preserve action methods
+    useWorkspaceSettingsStore.setState({ workspaces: { [WS_ID]: { 'some-module': { hostId: hA, value: 42 } } } })
+
+    deleteHostCascade(hA, true)
+
+    // deleteHostCascade only uses useWorkspaceStore (tab membership), NOT useWorkspaceSettingsStore
+    // — the module-settings store for workspaces must remain untouched as collateral-clear regression
+    expect(useWorkspaceSettingsStore.getState().workspaces[WS_ID]).toEqual({
+      'some-module': { hostId: hA, value: 42 },
+    })
   })
 })

--- a/spa/src/lib/host-lifecycle.test.ts
+++ b/spa/src/lib/host-lifecycle.test.ts
@@ -542,13 +542,26 @@ describe('#541 cross-store rehydrate order invariants', () => {
   // the action closures.
   beforeEach(() => {
     localStorage.clear()
-    // Merge-mode: set data fields to blank without clobbering action methods
+    // Merge-mode: set ALL mutable data fields to blank without clobbering
+    // action methods (Finding D fix: explicit field-by-field reset prevents
+    // cross-test leakage of fields not listed).
     useHostStore.setState({ hosts: {}, hostOrder: [], runtime: {}, activeHostId: null })
     useHostSettingsStore.setState({ hosts: {} })
     useWorkspaceSettingsStore.setState({ workspaces: {} })
-    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+    // visitHistory added — codex Finding D flagged it as a cross-test leak vector
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
     useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
-    useAgentStore.setState({ lastEvents: {}, statuses: {}, unread: {}, subagents: {}, agentTypes: {}, models: {} })
+    // oscTitles + ccStatus added — codex Finding D flagged them as cross-test leak vectors
+    useAgentStore.setState({
+      lastEvents: {},
+      statuses: {},
+      unread: {},
+      subagents: {},
+      agentTypes: {},
+      models: {},
+      oscTitles: {},
+      ccStatus: {},
+    })
     useStreamStore.setState({ sessions: {}, relayStatus: {}, handoffProgress: {} })
     useHistoryStore.setState({ browseHistory: [], closedTabs: [] })
     useWorkspaceStore.getState().reset()

--- a/spa/src/lib/host-routes.test.ts
+++ b/spa/src/lib/host-routes.test.ts
@@ -1,0 +1,60 @@
+/**
+ * host-routes.test.ts
+ *
+ * §3.2 tests for Commit 3: isHostSubPage dynamic via contribution registry.
+ *
+ * Case 1: Built-in sub-pages (all six) → isHostSubPage returns true.
+ * Case 2: After registering a fake host contribution → isHostSubPage returns true.
+ * Case 3: Unknown value → isHostSubPage returns false.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { isHostSubPage, HOST_SUB_PAGES } from './host-routes'
+import {
+  clearContributions,
+  registerSettingsContribution,
+} from './settings-contribution-registry'
+import { clearModuleRegistry } from './module-registry'
+import { registerBuiltinModules } from './register-modules'
+
+beforeEach(() => {
+  clearContributions()
+  clearModuleRegistry()
+  registerBuiltinModules()
+})
+
+afterEach(() => {
+  clearContributions()
+  clearModuleRegistry()
+})
+
+describe('isHostSubPage (§3.2)', () => {
+  // Case 1: all six built-in sub-pages return true
+  it('C1: all six built-in sub-pages return true', () => {
+    for (const page of HOST_SUB_PAGES) {
+      expect(isHostSubPage(page), `expected isHostSubPage('${page}') to be true`).toBe(true)
+    }
+  })
+
+  // Case 2: a dynamically registered host contribution also returns true
+  it('C2: dynamically registered localId returns true', () => {
+    registerSettingsContribution({
+      moduleId: 'testmod',
+      id: 'testmod.mysection',
+      localId: 'mysection',
+      scope: 'host',
+      order: 100,
+      labelKey: 'testmod.mysection',
+      component: () => null,
+    })
+
+    expect(isHostSubPage('mysection')).toBe(true)
+  })
+
+  // Case 3: unknown value returns false
+  it('C3: nonexistent value returns false', () => {
+    expect(isHostSubPage('nonexistent')).toBe(false)
+    expect(isHostSubPage('')).toBe(false)
+    expect(isHostSubPage('OVERVIEW')).toBe(false) // case-sensitive
+  })
+})

--- a/spa/src/lib/host-routes.ts
+++ b/spa/src/lib/host-routes.ts
@@ -1,9 +1,21 @@
+import { listContributions } from './settings-contribution-registry'
+
+/**
+ * Canonical order of built-in host sub-pages.
+ * Not the type source for `HostSubPage` (widened to `string` in commit 3) and
+ * not consulted by `isHostSubPage` (which queries the contribution registry).
+ * Retained for: (a) test reference in host-routes.test.ts C1, (b) ordering
+ * annotation in register-modules.tsx where these are registered as built-in
+ * host contributions.
+ */
 export const HOST_SUB_PAGES = ['overview', 'sessions', 'hooks', 'agents', 'uploads', 'logs'] as const
 
-export type HostSubPage = (typeof HOST_SUB_PAGES)[number]
+// Commit 3: loosened from the six-literal union to plain string so that
+// module-contributed host sub-pages can navigate via URL without type casts.
+export type HostSubPage = string
 
-export function isHostSubPage(value: string): value is HostSubPage {
-  return HOST_SUB_PAGES.includes(value as HostSubPage)
+export function isHostSubPage(value: string): boolean {
+  return listContributions('host').some((c) => c.localId === value)
 }
 
 export function encodeHostRouteId(hostId: string): string {

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -52,6 +52,13 @@ import { fetchSessionCwd, fetchSessionHome } from './host-api'
 import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { openBrowserTab } from './open-browser-tab'
 import { getDefaultOpener } from './file-opener-registry'
+import { registerBuiltinHostSection } from './host-builtin-sections'
+import { OverviewSection } from '../components/hosts/OverviewSection'
+import { SessionsSection } from '../components/hosts/SessionsSection'
+import { HooksSection } from '../components/hosts/HooksSection'
+import { AgentsSection } from '../components/hosts/AgentsSection'
+import { UploadSection } from '../components/hosts/UploadSection'
+import { LogsSection } from '../components/hosts/LogsSection'
 
 function NewTabPaneWrapper({ pane }: PaneRendererProps) {
   const handleSelect = (content: PaneContent) => {
@@ -384,6 +391,17 @@ export function registerBuiltinModules(): void {
       fetchPaneHome: (hostId, sessionCode, signal) => fetchSessionHome(hostId, sessionCode, signal),
     },
   })
+
+  // Built-in host sub-page contributions (PR-4).
+  // Push into the host-builtin pending buffer; flushed atomically by the
+  // dispatchSettingsContributions() call below (§7.2 dispatch-flushed pattern).
+  // Order follows the established HOST_SUB_PAGES sequence: 0–5.
+  registerBuiltinHostSection({ localId: 'overview',  labelKey: 'hosts.overview',  order: 0, component: OverviewSection })
+  registerBuiltinHostSection({ localId: 'sessions',  labelKey: 'hosts.sessions',  order: 1, component: SessionsSection })
+  registerBuiltinHostSection({ localId: 'hooks',     labelKey: 'hosts.hooks',     order: 2, component: HooksSection })
+  registerBuiltinHostSection({ localId: 'agents',    labelKey: 'hosts.agents',    order: 3, component: AgentsSection })
+  registerBuiltinHostSection({ localId: 'uploads',   labelKey: 'hosts.uploads',   order: 4, component: UploadSection })
+  registerBuiltinHostSection({ localId: 'logs',      labelKey: 'hosts.logs',      order: 5, component: LogsSection })
 
   // Dispatch module-declared settings contributions into the contribution registry.
   // Must run AFTER all registerModule(...) calls so every module is visible.

--- a/spa/src/lib/route-utils.test.ts
+++ b/spa/src/lib/route-utils.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { parseRoute, tabToUrl } from './route-utils'
+import { clearContributions } from './settings-contribution-registry'
+import { clearModuleRegistry } from './module-registry'
+import { registerBuiltinModules } from './register-modules'
+
+beforeEach(() => {
+  clearContributions()
+  clearModuleRegistry()
+  registerBuiltinModules()
+})
+
+afterEach(() => {
+  clearContributions()
+  clearModuleRegistry()
+})
 
 describe('parseRoute', () => {
   it('/ returns null (no-op, preserves persisted state)', () => {

--- a/spa/src/lib/settings-contribution-smoke.test.tsx
+++ b/spa/src/lib/settings-contribution-smoke.test.tsx
@@ -1,31 +1,22 @@
 /**
- * Smoke test for HSR PR-1/PR-2/PR-3: prove that the settings contribution
- * registry is wired into the Purdex shell (PR-2) and the Workspace shell
- * (PR-3), and NOT yet wired into the remaining shell (HostPage — PR-4
- * target).
+ * Smoke test for HSR PR-1/PR-2/PR-3/PR-4: prove that the settings contribution
+ * registry is wired into all three shells (Purdex / Workspace / Host).
  *
  * Design rationale — Option B (static source check), preferred here:
  *
- *   The page below has deep coupling to app-wide state (wouter router,
- *   zustand host store, i18n, electronAPI, plus numerous leaf
- *   components). Mounting it from cold to do a "queryByText must be
- *   null" check would require hundreds of lines of setup / mocking
- *   purely to observe the absence of a string — and would be brittle
- *   (any future i18n key collision or mock reshuffle could make the
- *   test spuriously pass).
+ *   These shells have deep coupling to app-wide state (wouter router,
+ *   zustand stores, i18n, electronAPI, plus numerous leaf components).
+ *   Mounting them from cold to do a "queryByText must be null" check
+ *   would require hundreds of lines of setup / mocking purely to observe
+ *   the absence of a string — and would be brittle.
  *
- *   A static-source check is strictly stronger for the thing we
- *   actually want to prove: that this shell does not yet import from
- *   `settings-contribution-registry`. When PR-4 wires it up, the
- *   corresponding entry is removed from `PAGES`.
+ *   A static-source check is strictly stronger for the thing we actually
+ *   want to prove. Source files are pulled via Vite's `?raw` imports
+ *   (browser/jsdom safe, no node:fs dependency).
  *
- *   We additionally register three fake contributions (one per scope)
- *   and verify they are queryable from the registry directly, so the
- *   infrastructure is exercised and regressions in the registry
- *   itself would surface here too.
- *
- *   Source files are pulled via Vite's `?raw` imports (browser/jsdom
- *   safe, no node:fs dependency).
+ * PR-4 update: HostPage.tsx is now wired into the registry (commit 2).
+ * The `PAGES` negative-guard list is now empty (all three shells migrated).
+ * Positive assertion added to confirm HostPage does import from registry.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import hostPageSrc from '../components/HostPage.tsx?raw'
@@ -39,14 +30,14 @@ const FAKE_PURDEX_LABEL = 'SMOKE_PURDEX_LABEL_UNIQUE'
 const FAKE_HOST_LABEL = 'SMOKE_HOST_LABEL_UNIQUE'
 const FAKE_WORKSPACE_LABEL = 'SMOKE_WORKSPACE_LABEL_UNIQUE'
 
-// HSR PR-2 migrated `src/components/SettingsPage.tsx` off this list — it
-// now reads the contribution registry directly. HSR PR-3 migrated
-// `src/features/workspace/components/WorkspaceSettingsPage.tsx` off this
-// list — workspace-scoped contributions now render via the registry. The
-// remaining shell lands in PR-4 (host).
-const PAGES: Array<{ name: string; src: string }> = [
-  { name: 'src/components/HostPage.tsx', src: hostPageSrc },
-]
+// All three shells have been migrated to the contribution registry.
+// PR-2: SettingsPage.tsx; PR-3: WorkspaceSettingsPage.tsx; PR-4: HostPage.tsx.
+// This list is intentionally empty — kept for visibility that no shell
+// remains unwired. Remove the iteration block below if no new shells are added.
+const PAGES: Array<{ name: string; src: string }> = []
+
+// Positive guard: HostPage.tsx MUST import listContributions (PR-4 commit 2).
+// If this breaks, it means someone accidentally reverted the migration.
 
 function FakeComponent() {
   return null
@@ -90,6 +81,14 @@ describe('settings-contribution-smoke (PR-1)', () => {
     expect(listContributions('workspace').map((c) => c.id)).toContain('smoketest.workspace-fake')
   })
 
+  // PR-4 (commit 2): HostPage is now wired into the registry — positive guard.
+  it('src/components/HostPage.tsx DOES import from settings-contribution-registry', () => {
+    expect(hostPageSrc).toMatch(/from\s+['"][^'"]*settings-contribution-registry['"]/)
+    expect(hostPageSrc).toMatch(/\blistContributions\b/)
+  })
+
+  // No unwired shells remain. The iteration block below is kept as a template
+  // in case new shells are added before their migration PR.
   for (const page of PAGES) {
     it(`${page.name} does NOT import from settings-contribution-registry`, () => {
       // Any import line referring to the registry module, relative or absolute.


### PR DESCRIPTION
## Summary

HSR 系列 PR-4：HostPage shell 改為 registry-driven，六個 built-in host sub-pages 透過「pending buffer + dispatch flush」adapter 註冊到新 contribution registry，未來 module 可宣告 `settings: [{ scope: 'host', ... }]` 直接出現在 HostPage 左側並可由 URL `/hosts/<hostId>/<localId>` 導航。

依賴 **PR-2 (#558)** 的 dispatch-flushed pattern；功能上不依賴 PR-3，但 `register-modules.tsx` 與 PR-3 在不同行有疊加（已基於 alpha.203 = 含 PR-3 + baseline #576 + bump #577）。

## Commits（每個 commit 必綠 + 通過 spec + quality 兩階段 review）

| # | SHA | Subject |
|---|-----|---------|
| 1 | `39668638` | feat(spa): register six built-in host sub-pages as host contributions |
| 2 | `35026695` | feat(spa): HostPage + HostSidebar read new contribution registry |
| 3 | `fd64f74d` | refactor(spa): isHostSubPage dynamic via contribution registry |
| 4 | `5ba456a2` | test(spa): cross-store rehydrate order invariants (#541) |

**規模**：14 files, +1104/-98

## Highlights

- **Built-in adapter 走 dispatch-flushed**：`registerBuiltinHostSection()` 推進 `pendingHostBuiltinContributions` Map，由 `dispatchSettingsContributions()` Phase 2 在 `clearContributions()` 後 drain — 與 PR-2 的 legacy adapter 同 contract（master spec §7.2 硬約束）
- **`HostSubPage` 型別鬆綁**：`type HostSubPage = string`；`isHostSubPage()` 改為 `listContributions('host').some(c => c.localId === value)` 動態驗證；`HOST_SUB_PAGES` const 保留作 i18n key 參考 + 註冊順序註解
- **Section subtree key**：`HostPage.renderContent` 使用 `key={`${hostId}:${contribution.id}`}` 強制跨 host 切換 remount（沿用 PR-3 `${workspaceId}:${c.id}` pattern）
- **Disabled contribution UX**：sidebar 不 filter，渲染 disabled row + `disabledReasonKey` title；body 不 render（對齊 PR-2 F7 / PR-3 F2）
- **#541 cross-store rehydrate harness**：9 個 invariant 測試覆蓋 `host-lifecycle.ts` 全部 6 個 `!hostWasRecreated` gate（含 tab restore），全綠確認 PR-1 cascade + undo guards 已正確（**source code 0 改動**）

## Review 履歷（per-commit local subagent review）

每個 commit 走 **implementer → spec compliance review → code quality review** 三段：

| Commit | Spec | Quality | Nits 修了 |
|---|---|---|---|
| 1 | ✅ | APPROVED WITH NITS | dispatch error origin label / WeakMap export 註解 / 冗餘 test |
| 2 | ✅ | APPROVED WITH NITS | hardcoded 'overview' fallback 統一 / `selectedSubPage` type 對稱 / mock type widen / `_hostPageSrc` alias |
| 3 | ✅ | APPROVED WITH NITS | vacuous type predicate → boolean / `HOST_SUB_PAGES` JSDoc |
| 4 | ✅ (documented merge-mode deviation) | APPROVED WITH NITS | tab restore gate 補測（all 6 categories）/ stale replace-mode 註解刪除 / agentStore.statuses 直接 seed 解 vacuous assertion |

## Test Plan

- [ ] `cd spa && pnpm exec vitest run` — 預期 2502 pass / 3 fail（皆為 base alpha.203 既存的 `src/lib/sync/contributors/hosts.test.ts` failures，與 PR-4 無關）
- [ ] `cd spa && pnpm run lint` — 0 errors / 2 pre-existing warnings (`EditorPane.tsx`)
- [ ] `cd spa && pnpm run build` — clean
- [ ] §3.5 手動視覺回歸（dev server 上 `/hosts/<hostId>` 切換六子頁、新增 host、切 host、無 console error）

## 已知 follow-up（不在本 PR scope）

- **#581** — disabled built-in host subPage URL 不 self-heal（commit 2 quality review I-2 揭露；目前無 production 觸發路徑因六子頁皆無 `disabled`；修法需引入 `isSelectable()` predicate 統一三處 fallback，scope 較大）

## 不在本 PR scope（per plan §7）

- `SettingsPage` global shell 改造（PR-2 ✅）
- `WorkspaceSettingsPage` shell 改造（PR-3 ✅）
- 六 sub-page 轉為 module-owned declaration（決策 4c：built-in adapter，不搬家）
- Editor `hostConfig.homePath` 用例（**PR-5**，下一棒）
- 舊 `globalConfig` / `workspaceConfig` deprecate（PR-5 後）

## Plan / Spec

- Plan: `docs/specs/2026-04-22-hsr-pr4-host-shell-plan.md`
- Master spec: `docs/specs/2026-04-21-settings-contribution-registry-design.md` §7.2 dispatch hard constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
