### PR TITLE
feat(lights): PR-1b-1c — hook/probe/sweep dual-write + divergence + Monitor envelope

### DIFF
--- a/docs/superpowers/plans/2026-04-22-lights-system/pr-1b-1c.md
+++ b/docs/superpowers/plans/2026-04-22-lights-system/pr-1b-1c.md
@@ -12,24 +12,27 @@ PR-1b-1b 落地 Arbitrator 的執行層但**沒有上游**：hook / probe / swee
 
 PR-1b-1c 把這些缺口一次收完，讓 Arbitrator 真的吃到三來源流量、divergence table 真的被寫、Monitor UI 能看到 envelope 欄位、#568 / #569 / #584 全關。**沒有 frame schema 變動**（留 Phase 2）；passthrough 期間 FramesStore 與 WS broadcast **仍走 legacy path**，Arbitrator 只負責計算 proposal + 寫 divergence + 寫 trace。
 
-**alpha.205 之前已經 ship 的契約全部不動**；本 PR 只新增流量來源 + divergence writer + Monitor envelope 穿透 + Retry + Pending production trigger。
+**alpha.205 之前已經 ship 的契約全部不動**；本 PR 只新增流量來源 + divergence writer + Monitor envelope 穿透 + Pending production trigger（**無 active retry scheduler** — Non-Goals）。
 
-預估 ~1100 LOC 含測試（+ SPA 小段 type 同步）。
+預估 ~1250 LOC 含測試（+ SPA 小段 type 同步；probe 擴 Watcher API 相較原估 +150 LOC）。
 
 ## Goals
 
-1. **Hook path dual-write**：`handleEvent` 除既有 `hookTraceCollector` 外，再 build `observation.Observation` 送 `Module.SubmitObservation`；legacy frame path 不變
-2. **Hook trace_id 汰換**：`hookTraceCollector` 用 `TraceIDLookup.Get(session, generation)` 取 per-(session, generation) trace_id；miss 則保留 chain_id aliasing + 記 warn（避免 bootstrap regression）。SessionStart hook observation 由 Arbitrator Mint；後續 hook 事件讀取同 gen 的 trace_id → **完成 #568**
-3. **Probe path produce observation**：`probe/liveness`、`probe/activity`、`probe/readiness` 的 callback 改為透過 adapter 轉 `Observation` 送 Arbitrator（保留 legacy `applyProbe*` path）
+1. **Hook path dual-write**：`handleEvent` 在 `verifyEventFn` 結果之後（不論 accept / reject）都 build `observation.Observation` 送 `Module.SubmitObservation`；legacy frame path（applyFrameEvent / broadcast / 202 early-return）全部不變
+2. **Hook trace_id 汰換**：
+   - hook path **在送 Arbitrator 前自產 provisional UUID**（每筆 hook 事件獨立 mint，無需讀狀態），做為 `Observation.TraceID` 值以繞過 builder 非空驗證（`builder.go:142`）
+   - Arbitrator apply `SessionStart` 時改走 **`AdoptTraceID(sid, nextGen, seed)`**——沿用 observation 帶來的 provisional UUID 做為該 (session, gen) 的公共 trace_id；非 SessionStart 事件透過 `TraceIDLookup.Get(session, generation)` 讀已 adopted 值
+   - `hookTraceCollector` 的 chain trace_id 同步改：先試 `traceLookup.Get`，miss 才用 chain_id fallback 並記 warn（transient bootstrap 期）→ **完成 #568**
+3. **Probe path produce observation**：`probe/liveness`、`probe/activity`、`probe/readiness` callback 透過 adapter 轉 `Observation` 送 Arbitrator；**probe package 增 start/stop + token rotation 契約**讓 Module 能顯式 rotate watcher token；legacy `applyProbe*` path 保留
 4. **Sweep path produce observation**：`sweepOnce` 對每個 detect-to-end 的 frame 送一筆 `SourceSweep` + `SuggestStatus=ended` observation；legacy `clearFrame` 仍同步跑
-5. **Retry + Pending production entry (#584 + spec §5.4)**：
-   - Arbitrator apply 增「role 判不出 / evidence 不足」分支：將 observation addPending + `scheduleRetry([100ms, 250ms, 500ms])`
-   - `retryCh` 重新納入 1b-1c scope（1b-1b 時延後的）；Arbitrator Run 的 select 加 `case <-retryCh`
-   - 3 strike 後 `emitTraceOnly` drop（reason_code=`RetryExhausted`）
-6. **Divergence 落地（§8.1）**：Arbitrator 在 passthrough 下把 proposal 投影回舊 schema → 與 legacy frame 比對 → 有差異寫 `frame_divergences` row；已存在 `store.SaveFrameDivergence` 等 API（alpha.192 PR-1a 已 ship divergences 表）—— 確認介面可用，否則補
+5. **Pending production entry (#584 + spec §5.4 pending window)**：
+   - Arbitrator apply 增「role-resolution 未定」分支：observation evidence 帶 `role_resolution: RoleRetryableUnresolved` 時 addPending（first entry or coalesce）
+   - `tryPromoteToActor` 在 `flushPendingDue` 觸發時檢查 entry.Observations，最後一筆含 `role_resolution: RoleResolved` + 合法 proposal → 走 apply 後續 step 5-9；否則 deadline drop
+   - **不做** retry scheduler：pending 只靠 `flushPendingDue` 的 deadline 驅動 + 後續 observation coalescing promote；active retry 延後到後續 PR（Non-Goals）
+6. **Divergence 落地（§8.1）**：Arbitrator 在 passthrough 下把 **primary-only** proposal 投影回舊 schema → 與 legacy frame 比對 → 有差異寫 `frame_divergences` row（subagent / proxy divergence 延後到 Phase 2）
 7. **Monitor API envelope passthrough (#569 backend)**：`MonitorStep` / `monitorStepFromStore` / `MonitorChainSummary` 穿透 PR-1b-0 新 22 欄；加 `schema_version` 提示（defender 建議）；單一 normalize 點處理 `""`/`{}`/`[]` default
 8. **SPA type sync (#569 frontend)**：`spa/src/types/` 或對等型別檔增加新欄位；既有 trace list consumer 若有則同步 shape
-9. **Sampling（§3.5.1 line 567）**：sweep/synthetic `proposed` 取 1/10；committed 全留。在 apply 的 emit trace 前套
+9. **Sampling（§3.5.1 line 567）**：sweep/synthetic `proposed` 取 1/10；committed 全留。在 apply 的 emit trace 前套，**無鎖**（apply 單 goroutine owner）
 
 ## Non-Goals（明確排除）
 
@@ -40,37 +43,169 @@ PR-1b-1c 把這些缺口一次收完，讓 Arbitrator 真的吃到三來源流�
 - ❌ Arbitrator daemon restart replay — **Phase 2**
 - ❌ Trace viewer SPA UI（decision ports 流程圖）— **PR-6b（trace viewer 專 PR）**
 - ❌ Host module observation wiring（host 沒有 hook lifecycle）— **不在 Lights 範圍**
+- ❌ **Retry scheduler**（`scheduleRetry` / `attemptRetry` / `retryCh` / `retryTick` / `RetryDelays`）— 延後到後續 PR；本 PR 的 pending 只靠 deadline flush + coalescing promote。TODO 留在 apply.go 與 spec §5.4 註記
+- ❌ **Subagent / proxy divergence projection** — Phase 2；本 PR divergence 僅對 `Proposal.ActorKey.ActorID` 開頭為 `"primary:"` 者寫入
 
 ## 設計決策
 
 ### D1. Hook path dual-write 架構
 
-**現況**：`handleEvent` 在 `handler.go:68` → `verifyEventFn` → `applyFrameEvent` → `hookTraceCollector` → broadcast。Trace 寫 store 走 `collector.complete()` 把 `chain + steps` 整包 SaveChain。
+**現況**：`handleEvent` 在 `handler.go:68` → `verifyEventFn` → （accept 分支）`applyFrameEvent` → `hookTraceCollector` → broadcast；reject 分支直接 202 early-return。Trace 寫 store 走 `collector.complete()` 把 `chain + steps` 整包 SaveChain。
 
-**改動**：在 `applyFrameEvent` 之後、`broadcast` 之前加一個 `buildObservationFromHook(req, verifyResult, projection) observation.Observation` helper，產 observation 送 `m.SubmitObservation(obs)`。
+**改動要點**（P0-1 / P0-2 / P0-3 整合）：
 
-**TraceID 來源**：
-- 如果 `req.EventName == "SessionStart"` → observation 走 Arbitrator apply 路徑會**由 Arbitrator 的 SessionStart helper 執行 Mint**（1b-1b 已實作），此時 Observation.TraceID 可空，Arbitrator apply 後 boundary trace 會帶新 trace_id
-- 其他 hook → `traceID, ok := m.traceLookup.Get(req.SessionCode, generation)`；miss 表示 Arbitrator 尚未 Mint 過 → 降級回舊 chain_id 作 traceID，並 log warn（transient bootstrap 期，Arbitrator 正常運作下不該發生）
-- Legacy `hookTraceCollector` 的 trace_id 來源同步改：先試 `traceLookup.Get`，miss 才用 chain_id fallback（**完成 #568 的 end-to-end 汰換**）
+#### D1.1 Dual-write 位置（P0-2）
 
-**Observation 建構**：
+Submit observation 移到 **`verifyEventFn` 結果之後的共用邊界**，也就是說：
+
+```
+handleEvent:
+    verifyResult := verifyEventFn(req)
+    obs := buildHookObservation(req, verifyResult)      // ★ 共用邊界
+    m.SubmitObservation(obs)                             // ★ accept / reject 都送
+    if !verifyResult.Accepted {
+        // 原 reject 分支（202 + legacy trace reject row）
+        return 202
+    }
+    applyFrameEvent(...)  // legacy 不動
+    hookTraceCollector.complete(...)
+    broadcast(...)
+```
+
+- reject 分支也建 + submit observation；evidence 帶 `verify_reason`（drop/reject 原因）
+- accept 分支 observation `Phase = PhaseCommitted`；reject 分支 `Phase = PhaseProposed`
+- 若 `SubmitObservation` inCh 滿載 drop（1b-1b 行為），legacy 仍跑 — 使用者可見行為不變，D9 細節不變
+
+#### D1.2 TraceID 來源（P0-1 — hook 端產 provisional UUID，Arbitrator adopt）
+
+`Observation.Builder.Build()`（`builder.go:142`）強制 `TraceID != ""`，不改 builder。改 hook 端自帶 seed：
+
+- **所有 hook observation 都在建構時 mint 一個 provisional UUID 做 `Observation.TraceID`**（`uuid.NewString()`，每筆獨立；不讀任何狀態，保證非空）
+- Arbitrator apply `SessionStart` 的 SessionStart helper **改用 `AdoptTraceID(sid, nextGen, seed)`**：
+  - 若該 (sessionID, nextGen) 的 trace_id 已存在 → 直接回舊值（冪等；例如 idempotent replay）
+  - 否則以 `seed` 為值寫入 registry，回寫的 trace_id 即 seed
+  - 實作位置：`internal/module/agent/observation/trace_id.go`（既有）— 在 `TraceIDMinter` interface 加 method，private `traceIDRegistry` 實作：
+    ```go
+    // TraceIDMinter 加新 method
+    type TraceIDMinter interface {
+        Mint(sessionID string, generation int64) string
+        AdoptTraceID(sessionID string, generation int64, seed string) string  // new
+        PruneSessionBefore(sessionID string, generation int64)                // existing
+    }
+
+    // traceIDRegistry.AdoptTraceID：seed 非空且 key 未存在 → 以 seed 寫入並回 seed；否則回已存在值（冪等）；seed 空字串 → panic 或回退 Mint（實作決定，tests 鎖行為）
+    func (r *traceIDRegistry) AdoptTraceID(sessionID string, generation int64, seed string) string
+    ```
+  - Arbitrator SessionStart helper 內原先呼叫 `minter.Mint(sid, nextGen)` 改成 `minter.AdoptTraceID(sid, nextGen, obs.TraceID)`；boundary synthetic trace 用 adopted 值
+- 非 SessionStart hook 事件：Observation.TraceID 帶 provisional UUID **與 (session, gen) 的公共 trace_id 無關**；但 `hookTraceCollector` 的 chain trace_id 另走 lookup：
+  - 先試 `traceLookup.Get(req.SessionCode, generation)`；hit → 用它；miss → fallback 到 chain_id 並 log warn（transient bootstrap；Arbitrator 正常時不該發生）
+  - 這條路徑**完成 #568 的 end-to-end 汰換**：同 (session, gen) 所有 hook chain 共享同一 trace_id
+- 不需要改 `observation.Builder`；P0-1 解
+
+> 注意：observation.TraceID（個別 observation 層）與 hook chain trace_id（hookTraceCollector 聚合層）是**兩條獨立資料流**：前者用於 Arbitrator apply / divergence / emit trace row 的 trace_id 欄；後者用於 SaveChain 寫 `agent_trace_chains`。SessionStart 透過 `AdoptTraceID` 把兩者的 (session, gen) 公共值綁成同一個 UUID。
+
+#### D1.3 ObservedGeneration 與 gen gate（P0-3）
+
+SessionStart 的 generation 推進由 hook observation 發起 —— **SessionStart observation 的 `ObservedGeneration = arbitrator.CurrentGeneration(sid) + 1`**（不是 == current）：
+
+```go
+// buildHookObservation — SessionStart 分支
+if req.EventName == "SessionStart" {
+    observedGen = arbitrator.CurrentGeneration(req.SessionCode) + 1  // 推進一代
+    proposal.ActorKey.Generation = observedGen
+} else {
+    observedGen = arbitrator.CurrentGeneration(req.SessionCode)       // 當前代
+    proposal.ActorKey.Generation = observedGen
+}
+```
+
+Arbitrator apply 的 generation gate 對應改寫 —— 只在 **`obs.ObservedGeneration > frameState.sessions[sid].Generation`** 時走 SessionStart helper（force-end 舊代 / clear pending / AdoptTraceID / PruneSessionBefore / ApplyAtSessionStart / boundary synthetic trace）；`==` 視為同代事件，`<` 則為 stale observation drop。
+
+非 SessionStart hook 的 ObservedGeneration 若與當前 generation 不符：
+- `observedGen < current` → apply step 1 gen gate reject（`ObservedGenerationStale`）
+- `observedGen > current` 且 `obs.Action != "SessionStart"` → reject（`ObservedGenerationAhead`，防非 SessionStart 推 gen）
+
+#### D1.4 Observation 建構（其餘欄位）
+
 - `SourceKind: SourceHook`
 - `Action: req.EventName`（e.g. "SessionStart" / "PostToolUse"）
-- `Phase: PhaseProposed` 預設；若 verifyResult.Accepted == true 則 `PhaseCommitted`
-- `ObservedGeneration`：目前 legacy path 沒有 generation 概念（Phase 2 加欄位）；**暫用 per-session in-memory counter**：`frameState` 已在 Arbitrator 維護，hook observation 設為 `observedGeneration = frameState.sessions[sid].Generation`（需要 hook path 能讀到 — 提供 `Arbitrator.SnapshotGeneration(sid) int64` method 或走 Arbitrator 單向 inference：hook 送 obs 時 ObservedGeneration 留 0 或複製自 Arbitrator 當前 generation —— **選後者**：builder 不強制對齊；generation gate 會自行處理。實務上 observation builder 的 ActorKey.Generation 必須對齊 ObservedGeneration（§pr-1b-1a D3 契約），所以此處需有 generation source）
-- **決策**：新增 `Module.currentGenerationFor(sessionID)` helper，從 `frameState` 透過一個公開 snapshot 方法讀當前 generation（thread-safe：atomic.Int64 per session OR mu-guarded map）。或用更簡單的方式：Arbitrator 開放 `CurrentGeneration(sid) int64` method（內部 lock 或 sync.Map）——**選此方案**，Arbitrator 新增 `CurrentGeneration(sid) int64` 只讀 API，hook path 透過 `m.arbitrator.CurrentGeneration(...)` 取
-- `Proposal`：`ActorKey{SessionID: sid, Generation: gen, ActorID: "primary:" + agentType}` + `SuggestStatus: projection-inferred-status` + `EndLifecycle: eventName == "SessionEnd"` + `EndReason: "session_end"`
-- `Evidence`：`{Key:"pid", Value: req.SenderPID}` + `{Key:"pane_id", Value: req.TmuxPaneID}` + `{Key:"event_name", Value: req.EventName}` + verify reason if failed
+- `Phase: PhaseCommitted` 若 verifyResult.Accepted；否則 `PhaseProposed`
+- `Proposal`：`ActorKey{SessionID: sid, Generation: observedGen, ActorID: "primary:" + agentType}`；SessionStart 設 `SuggestStatus: active`；SessionEnd 設 `EndLifecycle: true, EndReason: "session_end"`；其他 hook 依 projection 決定 status（legacy projection 由 applyFrameEvent 產出，此處同樣以 req 欄位推斷）
+- `Evidence`（**P0-5 / D5.2 divergence identity 必備三欄**）：
+  - `{Key: "pid", Value: req.SenderPID}`（int64）
+  - `{Key: "pane_id", Value: req.TmuxPaneID}`（string）
+  - `{Key: "start_time", Value: req.ProcessStartTime}`（string，對應 Frame.ProcessStartTime；若 hook req 無此欄位，由 Module 在 submit 前透過 `FramesStore.GetByIdentity` 回填，仍查不到則標 `"unknown"`）
+  - `{Key: "event_name", Value: req.EventName}`
+  - `{Key: "role_resolution", Value: "RoleResolved" | "RoleRetryableUnresolved" | "RoleTerminalUnresolved"}`（**P1-8 常數化，見 D4.1**）
+  - verify_reason if !Accepted（舊格式保留，但不再驅動 pending 路由 — 見 D4.1）
 - `DecisionPorts`：legacy hook 不帶；留空 slice
-- `ObservedAt: time.Now()` / `Seq: monotonic per session`（簡化：time.Now().UnixNano()）
+- `ObservedAt: time.Now()` / `Seq: monotonic per session`（`time.Now().UnixNano()`）
+- `TraceID: uuid.NewString()` — 保證非空（D1.2）
 
-### D2. Probe adapter
+### D2. Probe adapter + probe package 契約（P1-7）
 
-**現況**：`probe/activity`、`probe/liveness`、`probe/readiness` 皆有 callback 形式；主要由 `agentcc / codex` 等 provider 在 register 時注入 callback。`module.go` 的 `onActivityDetected` 是 hook 之一。
+**現況**：`probe/activity`、`probe/liveness`、`probe/readiness` 是同步函式 / 單次 callback 形式，沒有 watcher token 外部介面；provider（`agentcc / codex`）在 register 時注入 callback，watcher 生命週期全部由 provider 自行管（probe 對外無 start / stop 對應物）。
 
-**改動**：建立 `internal/module/agent/arbitrator/probe_observation.go`（或 `internal/module/agent/observation_builders.go` 放 Module package）— 提供 helper：
+**改動 scope 擴張**：T7 納入 probe package 修改，加上「顯式 start / stop + token rotation」契約。Probe 升為 stateful watcher：
+
+#### D2.1 probe package 新 API shape
+
+於 `internal/agent/probe/` 各模組（以 `liveness` 為例）：
+
 ```go
+// internal/agent/probe/liveness/liveness.go
+
+// Watcher 代表一個持續監測實體；每個實體擁有獨一 Token
+type Watcher interface {
+    // Token 回目前 watcher identity；rotate 後回新值
+    Token() string
+    // Rotate 重置 token（caller 先 Rotate 再重建狀態）；回新 token
+    Rotate() string
+    // Stop 結束監測；可多次呼叫冪等
+    Stop()
+}
+
+// Start 啟動 liveness 監測並回傳 Watcher handle
+// - onOutcome 每次 probe fire 被呼叫，帶 outcome + evidence
+// - onOutcome 內部可產 Observation 並 submit
+func Start(ctx context.Context, spec Spec, onOutcome Callback) Watcher
+
+type Callback func(outcome Outcome, token string, evidence []EvidenceRef)
+type Outcome string // "alive" | "dead" | "active" | "idle" | "ready" | "error" ...
+```
+
+對等地 `activity` / `readiness` 各自 expose `Start(ctx, spec, onOutcome) Watcher`。
+
+#### D2.2 Module 使用模式
+
+```go
+// internal/module/agent/module.go — provider register 時的典型 pattern
+watcher := liveness.Start(ctx, spec, func(outcome liveness.Outcome, token string, ev []probe.EvidenceRef) {
+    obs := buildProbeObservation(
+        sessionID, generation, agentType,
+        probeID, token, "liveness", string(outcome), ev,
+    )
+    m.SubmitObservation(obs)
+    // legacy applyProbe* path 保留（由現有 dispatcher 執行）
+})
+m.storeWatcher(sessionID, "liveness", watcher)
+```
+
+當 session 換代或 agent teardown：
+```go
+old := m.takeWatcher(sessionID, "liveness")
+if old != nil { old.Stop() }
+```
+
+Rotation 語意：
+- `Rotate()` 由 **caller（Module / provider）** 顯式呼叫，意圖是「保留 watcher 但重建 token identity」（如 agent type 切換、re-register）
+- 舊 token 的 probe callback 若還在排隊，到達 Arbitrator 時會被 step 2 watcher check reject（token 不符）
+- 這解決舊設計「兩個 probe 實例並發會互相覆蓋」的問題：每個 watcher 自持 token；rotate 前 caller 必須完成上下文搬遷
+
+#### D2.3 buildProbeObservation helper
+
+```go
+// internal/module/agent/observation_builders.go
 func buildProbeObservation(
     sessionID string,
     generation int64,
@@ -78,19 +213,26 @@ func buildProbeObservation(
     probeID string,
     probeToken string,
     probeKind string,            // "liveness" | "activity" | "readiness"
-    probeOutcome string,         // "alive" | "dead" | "active" | "idle" | "ready" | ...
+    probeOutcome string,         // "alive" | "dead" | "active" | "idle" | ...
     evidence []observation.EvidenceRef,
 ) observation.Observation
 ```
 
-Probe callback 在 fire 時呼叫此 helper 產 observation → `m.SubmitObservation`。
-
 - `SourceKind: SourceProbe`
-- `WatcherToken: probeToken`（probe 實例化時 uuid.NewString，存進 provider 自身 state；同一 probeID 的 rotate 由上層 caller 管）
-- `Action: "probe.<probeKind>.<probeOutcome>"`
-- `Proposal.SuggestStatus` 視 outcome 映射（dead → `ended`、active → `active`、idle → `waiting`、error → `error`）
+- `WatcherToken: probeToken`
+- `Action: "probe." + probeKind + "." + probeOutcome`
+- `Proposal.SuggestStatus`：outcome 映射（`dead → ended` / `active → active` / `idle → waiting` / `ready → ready` / `error → error`）
+- `Proposal.EndLifecycle`：`dead` 設 true，`EndReason: "probe_dead"`
+- `Proposal.ActorKey.ActorID`：`"primary:" + agentType`
+- `TraceID: uuid.NewString()` — provisional；apply 階段不 adopt（只 SessionStart adopt）
+- `Evidence`（D5.2 divergence identity 必備三欄）：`pid` / `pane_id` / `start_time` + callback 傳入的 evidence
+- `Evidence` 額外帶 `role_resolution` 常數（probe path 的 role 一般為 `RoleResolved`；若 callback 報 `identify_mismatch` / `sender_uncertain` 則帶 `RoleRetryableUnresolved` 並觸發 pending）
 
-**WatcherToken rotate**：Arbitrator `frameState.rotateWatcherToken(key, probeID, newToken)` 目前只在測試用；PR-1b-1c 需在 probe 實例化時呼叫（透過 Arbitrator 新增 public API `UpdateWatcherToken(actorKey, probeID, token)` 或更乾淨的做法：probe 產 observation 帶 `WatcherToken`，apply 層的 step 2 watcher check 改為**先 upsert 新 token**再驗證）— **選後者**：簡化 API 面積，watcher identity 由 observation 的 WatcherToken 欄位單向推進（舊 token 的 probe callback 到 Arbitrator 已經晚，reject 正確）。但這破壞 rotation 語意：若兩個 probe 實例並發，舊 probe token 會取代新 token。**實務上 rotate 是 caller 顯式 stop old watch + start new** 的動作，兩實例並發只在 bug 下發生；接受此風險，在 `frame_state.rotateWatcherToken` 的註解寫清楚 Phase 1 語意。
+#### D2.4 Apply step 2 watcher check 行為（1b-1b 既有）
+
+保留 1b-1b 現有 watcher check 邏輯：`frameState.watcherToken(actorKey, probeID)` 回目前 token；observation 帶的 token 不符 → reject。不改 apply 面。
+
+**不引入** `UpdateWatcherToken` public API — watcher identity 由 probe package 自持，Module 透過 `watcher.Rotate()` 推進；Arbitrator 只被動 observe。
 
 ### D3. Sweep path
 
@@ -102,15 +244,52 @@ Observation shape：
 - `SourceKind: SourceSweep`
 - `Action: "sweep.frame_cleared"`
 - `Phase: PhaseProposed`（sweep 永遠 proposed，不升 committed）
-- `Proposal.ActorKey`: 以 `primary:<agent_type>` 或 sessionCode 派生
+- `Proposal.ActorKey`: `"primary:" + frame.AgentType`（D5.2 的 primary-only projection 會對此判斷）
 - `Proposal.EndLifecycle: true; EndReason: reason`
-- `Evidence: [{Key:"pid", Value:frame.PID}, {Key:"reason", Value:reason}]`
+- `ObservedGeneration: arbitrator.CurrentGeneration(frame.SessionCode)`（sweep 不推進 gen）
+- `TraceID: uuid.NewString()` — provisional；apply 不 adopt
+- `Evidence`（D5.2 identity 三欄 + D4.1 role_resolution 必備）：
+  - `{Key: "pid", Value: frame.PID}`
+  - `{Key: "pane_id", Value: frame.PaneID}`
+  - `{Key: "start_time", Value: frame.ProcessStartTime}`
+  - `{Key: "reason", Value: reason}`（pid_dead / pid_reused / ...）
+  - `{Key: "role_resolution", Value: "RoleResolved"}` — sweep 已確認 frame identity（若查不到帶 `RoleTerminalUnresolved`，D4.1 已涵蓋）
 
-### D4. Retry scheduler (§5.4) + Pending production entry (#584)
+### D4. Pending production entry (#584 + spec §5.4) — no active retry
 
-#### D4.1 Pending production trigger
+> **P0-4 決策**：本 PR 不引入 retry scheduler。Pending entry 只靠 `flushPendingDue` deadline drop + 後續 observation coalescing promote。此決策在 Non-Goals 已明列；spec §5.4 文字保留，1b-1c 落地路徑以 TODO 註記等待後續 PR。
 
-Arbitrator apply step 4 原本只有「sweep 且 actor 已 pending → addPending」的 sweep-override 分支。增加新分支：
+#### D4.1 Evidence 常數化（P1-8）
+
+在 `internal/module/agent/observation/` 新增（或擴充既有 constants file）：
+
+```go
+// package observation
+
+const EvidenceKeyRoleResolution = "role_resolution"
+
+type RoleResolutionState string
+
+const (
+    RoleResolved              RoleResolutionState = "RoleResolved"              // positive signal
+    RoleRetryableUnresolved   RoleResolutionState = "RoleRetryableUnresolved"   // pending
+    RoleTerminalUnresolved    RoleResolutionState = "RoleTerminalUnresolved"    // drop (terminal)
+)
+
+// RoleResolutionFromEvidence 掃 evidence，回 state + ok；未帶 key 回 "" + false
+func RoleResolutionFromEvidence(ev []EvidenceRef) (RoleResolutionState, bool)
+```
+
+所有 source（hook / probe / sweep）build observation 時 **必帶** `{Key: EvidenceKeyRoleResolution, Value: <state>}`：
+- hook path：verifyResult.Accepted → `RoleResolved`；reject 且原因屬 `pane_unresolvable / sender_uncertain / identify_mismatch` → `RoleRetryableUnresolved`；reject 且終端原因（e.g. `session_not_found`）→ `RoleTerminalUnresolved`
+- probe path：預設 `RoleResolved`；probe outcome 含 `identify_mismatch` → `RoleRetryableUnresolved`
+- sweep path：預設 `RoleResolved`（sweep 已確認 pid dead）；若查不到 frame identity → `RoleTerminalUnresolved`
+
+`verify_reason` 仍保留供 debug / trace display，但 **apply 層路由只認 `role_resolution` + enum**，不再掃 `verify_reason` 字串。
+
+#### D4.2 Pending production trigger
+
+Arbitrator apply step 4 原本只有「sweep 且 actor 已 pending → addPending」的 sweep-override 分支。增加 role-based 分支：
 
 ```go
 // apply.go step 4 revised
@@ -120,126 +299,97 @@ func (d *applyDeps) routeToPendingIfUnresolved(obs observation.Observation) (sta
         d.pending.addPending(obs, d.now(), ...)
         return true
     }
-    // new: role-unresolved trigger
-    if obs.SourceKind == observation.SourceHook && needsRoleResolution(obs) {
-        if d.pending.count() == 0 || !d.pending.isPending(obs.Proposal.ActorKey) {
-            d.pending.addPending(obs, d.now(), ...)  // first entry for this actor
-            d.scheduleRetry(obs)                      // schedule [100ms, 250ms, 500ms]
+    // role-based routing
+    state, ok := observation.RoleResolutionFromEvidence(obs.Evidence)
+    if !ok {
+        // 缺 role_resolution → 視為 malformed，走一般 reject path（不 pending）
+        return false
+    }
+    switch state {
+    case observation.RoleRetryableUnresolved:
+        // first entry 或 coalesce 進現有 entry
+        d.pending.addPending(obs, d.now(), ...)
+        // TODO(retry-scheduler, post-1b-1c): 此處原規劃 scheduleRetry([100ms, 250ms, 500ms])，
+        // 後續 PR 接入。當下只靠 deadline flush + 後續 observation coalescing promote。
+        return true
+    case observation.RoleTerminalUnresolved:
+        // 終端未解 — 直接 drop + emit trace reason_code=RoleTerminalUnresolved；不 pending
+        d.emitTraceOnly(obs, "RoleTerminalUnresolved")
+        return true
+    case observation.RoleResolved:
+        // 正常流程 — 若該 actor 目前 pending 中，coalesce 後 flushPending 會嘗試 promote
+        if d.pending.isPending(obs.Proposal.ActorKey) {
+            d.pending.addPending(obs, d.now(), ...)
+            // 不在此處 promote；由下一個 reconcile tick 的 flushPendingDue 驅動（若 deadline 已到）
+            // 亦可主動觸發 tryPromoteNow；本 PR 採後者以縮短 latency：
+            _ = d.tryPromoteToActorNow(obs.Proposal.ActorKey)
             return true
         }
-        d.pending.addPending(obs, ...)  // coalesce into existing entry
-        return true
-    }
-    return false
-}
-
-// needsRoleResolution — evidence-based judgment
-func needsRoleResolution(obs observation.Observation) bool {
-    // pid_tree_unresolvable / pane_unresolvable / sender_uncertain → yes
-    for _, e := range obs.Evidence {
-        if e.Key == "verify_reason" {
-            if s, ok := e.Value.(string); ok {
-                switch s {
-                case "pid_not_in_pane_tree", "pane_unresolvable", "sender_uncertain", "identify_mismatch":
-                    return true
-                }
-            }
-        }
+        return false
     }
     return false
 }
 ```
 
-#### D4.2 Retry scheduler
+#### D4.3 tryPromoteToActor 契約（1b-1b 佔位，1b-1c 定義 — 只認 positive signal）
+
+`pendingStore.flushPendingDue` 的 `tryPromote func(*PendingEntry) bool` 以及 D4.2 的 `tryPromoteToActorNow(ActorKey)` 共用邏輯：
 
 ```go
-// arbitrator.go
-type retryTick struct {
-    Obs      observation.Observation
-    Attempt  int  // 1..3
-}
-
-// Options 新增
-type Options struct {
-    ... existing ...
-    RetryCh chan retryTick  // cap 256
-    RetryDelays []time.Duration  // default [100ms, 250ms, 500ms]
-}
-
-// Arbitrator Run select 加 retryCh case
-func (a *Arbitrator) Run(ctx context.Context) {
-    ticker := time.NewTicker(a.opts.ReconcileEvery)
-    defer ticker.Stop()
-    for {
-        select {
-        case obs := <-a.inCh:
-            a.deps.apply(obs)
-        case tick := <-a.opts.RetryCh:
-            a.deps.attemptRetry(tick)
-        case <-ticker.C:
-            a.reconciler.reconcile()
-        case <-ctx.Done():
-            // drain
-            ...
+func (d *applyDeps) tryPromoteFromEntry(entry *PendingEntry) bool {
+    // 必要條件：entry.Observations 內至少一筆 role_resolution == RoleResolved
+    // 取最新的 RoleResolved observation
+    var winner *observation.Observation
+    for i := len(entry.Observations) - 1; i >= 0; i-- {
+        obs := &entry.Observations[i]
+        if state, ok := observation.RoleResolutionFromEvidence(obs.Evidence); ok && state == observation.RoleResolved {
+            winner = obs
+            break
         }
     }
-}
-```
-
-**scheduleRetry** 用 `time.AfterFunc` 排程（不阻塞 caller）：
-```go
-func (d *applyDeps) scheduleRetry(obs observation.Observation) {
-    for i, delay := range d.retryDelays {
-        attempt := i + 1
-        time.AfterFunc(delay, func() {
-            select {
-            case d.retryCh <- retryTick{Obs: obs, Attempt: attempt}:
-            default:
-                metrics.Inc("lights_arb_retry_dropped")
-            }
-        })
+    if winner == nil {
+        return false  // 無 positive signal — 等 deadline drop
     }
+    // 必要條件：winner 有明確 proposal（SuggestStatus != "" 或 EndLifecycle == true）
+    if winner.Proposal.SuggestStatus == "" && !winner.Proposal.EndLifecycle {
+        return false
+    }
+    // 走 apply 後續 step 5-9（coalesce actor → projection → emit → divergence）
+    d.applyResolvedProposal(*winner)
+    return true
 }
 ```
 
-**attemptRetry**：
-```go
-func (d *applyDeps) attemptRetry(tick retryTick) {
-    entry, ok := d.pending.getPendingEntry(tick.Obs.Proposal.ActorKey)
-    if !ok { return }  // pending 已被清（SessionStart or deadline flush）
-    // re-verify（此處 1b-1c 用 hook path 的 verify 結果，透過 observation Evidence 帶回）
-    // 若仍未解 → wait next attempt
-    // 若已達 attempt=3 仍未解 → flushPendingDue 的 deadline 會走 drop path (PidTreeUnresolvable)
-    // Promote 邏輯：Arbitrator 收到後續 observation 若對同 ActorKey 有 clear evidence → 正常 apply 時會 coalesce
-    // 實際 "promote" 靠後續 observation trigger — attemptRetry 本身只是 heartbeat
-    // 簡化：attemptRetry 記 trace reason_code=RetryAttempt{N}; 不做 promote logic
-}
-```
+關鍵變化（對照 review）：
+- 不再看「evidence 不含未解 key」，改看 `role_resolution == RoleResolved` 正面判斷 — 沒發現「沒 role_resolution」這個 evidence key 就不 promote（conservative default）
+- `tryPromoteToActorNow` 縮短 latency：`RoleResolved` observation 進來時若該 actor 正 pending → 立即嘗試 promote，不等下個 reconcile tick
 
-#### D4.3 tryPromoteToActor 契約（1b-1b 佔位，1b-1c 定義）
-
-`pendingStore.flushPendingDue` 的 `tryPromote func(*PendingEntry) bool`：
-- 1b-1b 永遠回 false（走 drop path）
-- 1b-1c 改為：取 entry.Observations 最後一筆，若該 obs 有明確 proposal（`Proposal.SuggestStatus != ""` 或 `EndLifecycle == true`）且 evidence 不含未解 key（不含 pane_unresolvable/sender_uncertain）→ promote：直接套用 proposal 到 frameState（走 apply 後續 step 5-9）+ return true
+**TODO（post-1b-1c）**：接入 active retry scheduler（re-verify + exponential backoff）。當前 coalesce-on-arrival 模式對穩定下游是 OK 的（後續 observation 會帶更 fresh 的 role_resolution），但對「pane 永遠 unresolvable 但 pid 活著」的 edge case 需要 deadline drop 接住。
 
 ### D5. Divergence writer（§8.1）
 
-#### D5.1 已存在的 divergences API
+#### D5.1 已存在的 divergences API（sanity 確認 — 無需新增）
 
-`internal/store/divergences.go`（alpha.192 PR-1a 已 ship）應已有 `SaveFrameDivergence` 或對等方法；本 PR 確認介面可用。若尚無 append API，補一個：
+`internal/store/divergences.go`（alpha.192 PR-1a 已 ship）實際簽章：
+
 ```go
-func (s *DivergencesStore) Insert(row FrameDivergence) error
+type DivergenceStore struct { ... }   // 單數，非 "DivergencesStore"
+
+func (s *DivergenceStore) Insert(d FrameDivergence) (int64, error)
+func (s *DivergenceStore) Get(id int64) (*FrameDivergence, error)
 ```
 
-FrameDivergence shape 對應 spec §8.1 schema（session_id / trace_id / event_id / observed_generation / old_state_ref / proposal_state_ref / diff_summary / matched / reason_code / created_at）。
+Duplicate 行為：INSERT OR IGNORE，回 `(0, nil)`。FrameDivergence struct 已涵蓋 §8.1 schema 所有欄位（session_id / trace_id / event_id / observed_generation / old_state_ref / proposal_state_ref / diff_summary / matched / reason_code / created_at）。
 
-#### D5.2 Arbitrator 整合
+**本 PR 不改 divergences store**；T3 只做回歸測試 + sanity 驗收。
+
+#### D5.2 Arbitrator 整合（P0-5：identity 三欄 + primary-only projection）
 
 `applyDeps` 加 `divergences DivergencesWriter` 與 `frames LegacyFramesView`（從 FramesStore 讀當前 legacy frame state）依賴：
 
 ```go
 type DivergencesWriter interface {
-    Insert(row store.FrameDivergence) error
+    Insert(row store.FrameDivergence) (int64, error)  // 對齊 alpha.192 PR-1a 既有簽章
 }
 
 type LegacyFramesView interface {
@@ -247,19 +397,41 @@ type LegacyFramesView interface {
 }
 ```
 
+**Identity 三欄強制**：`buildHookObservation / buildProbeObservation / buildSweepObservation` 三者產出的 evidence 都必須帶 `{pid, pane_id, start_time}` 三個 key（D1.4 / D2.3 / D3 已註記）。Apply step 8 入口若 evidence 缺任一欄 → 跳過 divergence + metric `lights_divergence_identity_missing{source}`。
+
+**Projection primary-only**：只處理 `Proposal.ActorKey.ActorID` 開頭為 `"primary:"` 的 observation；非 primary → 跳過 divergence + metric `lights_divergence_non_primary_skipped{actor_kind}`。subagent / proxy 的 projection 需要新欄位（Phase 2 PR-2a frame schema 升 Actors JSON 後才可行），當前 legacy Frame 只有 primary 語意。
+
 Apply 的 step 8 mode branch — passthrough 路徑加 divergence 寫入：
 ```go
-// apply.go step 8 (passthrough branch, after pre-gate mode check moved to step 0b)
+// apply.go step 8 (passthrough branch)
 func (d *applyDeps) writeDivergenceIfAny(obs observation.Observation) {
-    if obs.Proposal.ActorKey.ActorID == "" { return }  // no proposal to project
-    // project Arbitrator proposal down to legacy Frame shape
-    projected := projectProposalToLegacy(obs.Proposal)
-    // read legacy frame
-    legacyFrame, err := d.frames.GetByIdentity(paneID, pid, startTime)  // pane/pid/startTime from evidence
-    if err != nil || legacyFrame == nil { return }
-    if framesMatch(projected, *legacyFrame) { return }  // no divergence
-    // write divergence row
-    _ = d.divergences.Insert(store.FrameDivergence{
+    if obs.Proposal.ActorKey.ActorID == "" {
+        return  // no proposal to project
+    }
+    // P0-5 (b): primary-only projection
+    if !strings.HasPrefix(obs.Proposal.ActorKey.ActorID, "primary:") {
+        metrics.Inc("lights_divergence_non_primary_skipped", "actor_kind="+actorKindOf(obs.Proposal.ActorKey.ActorID))
+        return
+    }
+    // P0-5 (a): identity triple required
+    paneID, panePresent := evidenceString(obs.Evidence, "pane_id")
+    pid, pidPresent := evidenceInt64(obs.Evidence, "pid")
+    startTime, stPresent := evidenceString(obs.Evidence, "start_time")
+    if !panePresent || !pidPresent || !stPresent {
+        metrics.Inc("lights_divergence_identity_missing", "source="+string(obs.SourceKind))
+        return
+    }
+    legacyFrame, err := d.frames.GetByIdentity(paneID, int(pid), startTime)
+    if err != nil || legacyFrame == nil {
+        metrics.Inc("lights_divergence_legacy_missing")
+        return
+    }
+    projected := projectProposalToLegacy(obs.Proposal, *legacyFrame)  // 帶 legacy base + proposal overlay
+    if framesMatch(projected, *legacyFrame) {
+        metrics.Inc("lights_divergence_total", "matched=1")
+        return  // no divergence — 可選擇是否寫 matched=1 row；本 PR 採「只寫 matched=0」降量
+    }
+    _, _ = d.divergences.Insert(store.FrameDivergence{
         SessionID: obs.SessionID,
         TraceID: obs.TraceID,
         EventID: obs.SpanID,
@@ -277,6 +449,8 @@ func (d *applyDeps) writeDivergenceIfAny(obs observation.Observation) {
 
 Divergence 寫失敗只 log，不影響 apply（passthrough 本身就是 observability 層）。
 
+**Helper**：`actorKindOf("subagent:xxx")` → `"subagent"`；`"proxy:xxx"` → `"proxy"`；`"primary:xxx"` → `"primary"`（unreachable due to prefix gate，但保留以備未來）。
+
 ### D6. Monitor API envelope (#569 backend)
 
 `monitor.go` `MonitorStep` 加 16 個新欄位（對應 `store.TraceStep` 的 lights envelope fields）。`monitorStepFromStore` 同步填。
@@ -285,28 +459,49 @@ Divergence 寫失敗只 log，不影響 apply（passthrough 本身就是 observa
 
 **Normalize**：`""` 保留 `""`；JSON 欄位（attrs/input_refs/output_refs/evidence_refs/decision_ports）空時 `monitorRawJSON` 回 `"null"` — 保留現有行為；**加 `schema_version: "1.0.0-lights-1b"` 欄位到 chain summary response**（defender 建議）便於 SPA 偵測 store rollback。
 
-### D7. Sampling（§3.5.1 line 567）
+### D7. Sampling（§3.5.1 line 567）— 單 goroutine reducer state（P2-9）
 
-`apply.go` emitAcceptedTrace / emitRejectedTrace 前加 sampler：
+Sampler 在 apply pipeline 內被呼叫，apply 為單 goroutine（Arbitrator Run owned）—— 無需 mutex。counter 改為 per-session map，避免 cross-session 交叉影響：
+
 ```go
+// sampler.go — reducer state；只由 apply goroutine 讀寫
 type sampler struct {
-    mu      sync.Mutex
-    counts  map[observation.SourceKind]int  // modulo 10 counter
+    // counts[sessionID][sourceKind] = 已 emit 累計（modulo 10）
+    counts map[string]map[observation.SourceKind]int
+}
+
+func newSampler() *sampler {
+    return &sampler{counts: make(map[string]map[observation.SourceKind]int)}
 }
 
 // ShouldEmit: committed 全 true；sweep/synthetic proposed 每 10 取 1；其他 proposed 全 true
-func (s *sampler) ShouldEmit(source observation.SourceKind, phase observation.ObsPhase) bool {
-    if phase == observation.PhaseCommitted { return true }
-    if source != observation.SourceSweep && source != observation.SourceSynthetic { return true }
-    s.mu.Lock()
-    defer s.mu.Unlock()
-    c := s.counts[source]
-    s.counts[source] = c + 1
-    return c % 10 == 0
+// 呼叫方保證單 goroutine invocation（apply pipeline owner）
+func (s *sampler) ShouldEmit(sessionID string, source observation.SourceKind, phase observation.ObsPhase) bool {
+    if phase == observation.PhaseCommitted {
+        return true
+    }
+    if source != observation.SourceSweep && source != observation.SourceSynthetic {
+        return true
+    }
+    sessCounts, ok := s.counts[sessionID]
+    if !ok {
+        sessCounts = make(map[observation.SourceKind]int)
+        s.counts[sessionID] = sessCounts
+    }
+    c := sessCounts[source]
+    sessCounts[source] = c + 1
+    return c%10 == 0
+}
+
+// ClearSession — SessionStart helper 推進 generation 時呼叫，回收舊 session 的 counter
+func (s *sampler) ClearSession(sessionID string) {
+    delete(s.counts, sessionID)
 }
 ```
 
-被 sample 掉的仍計 metric `lights_trace_sampled_dropped{source,phase}`。
+被 sample 掉的仍計 metric `lights_trace_sampled_dropped{source,phase,session}`。
+
+**單元測試**需涵蓋 cross-session 獨立計數（session A 的 sweep 不干擾 session B 的 sweep）。**Race 測試**覆蓋面仍由 T5 apply pipeline 測試承擔（single-goroutine invariant），不對 sampler 跑 `-race` 多 goroutine 測試（違反使用契約）。
 
 ### D8. SPA type sync (#569 frontend)
 
@@ -318,67 +513,97 @@ func (s *sampler) ShouldEmit(source observation.SourceKind, phase observation.Ob
 
 若 legacy frame path 失敗而 observation 已送：Arbitrator 會計算 proposal；divergence 寫入時讀 legacy frame state 可能是舊值或 nil → diff_summary 顯示「legacy_write_failed」這類標記即可。接受。
 
-### D10. ObservedGeneration 來源
+### D10. CurrentGeneration thread-safety（P0-6 — 全 RWMutex）
 
-`Arbitrator.CurrentGeneration(sessionID string) int64` — 新增 thread-safe public method。內部讀 `frameState.sessions[sessionID].Generation`；需要 **加一個 atomic read path**（frameState 是單 goroutine owner，無 lock；此方法跨 goroutine 呼叫）。
+`Arbitrator.CurrentGeneration(sessionID string) int64` — 新增 thread-safe public method。跨 goroutine 呼叫，而 `frameState.sessions` map 原本是 Arbitrator Run goroutine 單 owner（無 lock）。
 
-**實作**：frameState 改為**每個 sessionGen 的 Generation 用 `atomic.Int64`**，讓外部只讀操作免持 lock：
+**決策（P0-6）**：**不混合 atomic + map 不保護**的做法（先前版本）。統一用 `sync.RWMutex` 保護 `frameState.sessions` 整張 map 以及每個 sessionGen 的所有欄位：
 
 ```go
+// frame_state.go
+type frameState struct {
+    mu       sync.RWMutex                    // protects sessions + sessionGen inner fields
+    sessions map[string]*sessionGen
+}
+
 type sessionGen struct {
-    Generation atomic.Int64   // publicly readable via CurrentGeneration
+    Generation int64                          // guarded by frameState.mu
     Actors     map[observation.ActorKey]*actorSummary
+}
+
+// Arbitrator Run goroutine (writer) — 所有寫路徑取 Lock
+func (fs *frameState) advanceGeneration(sid string, nextGen int64) {
+    fs.mu.Lock()
+    defer fs.mu.Unlock()
+    s := fs.getOrCreateLocked(sid)
+    s.Generation = nextGen
+    // clear actors / watchers / per-gen state
+}
+
+// 外部（hook / probe / sweep / monitor）reader — RLock
+func (a *Arbitrator) CurrentGeneration(sessionID string) int64 {
+    a.frameState.mu.RLock()
+    defer a.frameState.mu.RUnlock()
+    s, ok := a.frameState.sessions[sessionID]
+    if !ok {
+        return 0
+    }
+    return s.Generation
 }
 ```
 
-Arbitrator goroutine 內寫 Generation 用 `Store`；hook path 讀用 `Load`。其他 actorSummary 欄位仍單 owner 無鎖。
+**統一規則**：
+- `frameState.mu` RWMutex 保護整個 `sessions` map 以及每個 `sessionGen` 的所有欄位
+- Arbitrator Run goroutine 所有寫路徑必須 `Lock()`（包含 step 1-9 內部對 sessions / actors / watcher 的寫）
+- 外部讀（跨 goroutine）必須 `RLock()`
+- **不用 `atomic.Int64`** — 避免 atomic + map-access 的混合模型讓後續維護者誤判 invariant
 
 若 session 不存在 → 回 0（等同「尚未 SessionStart」）。
+
+**Race 覆蓋**：T1 新增 `TestArbitrator_CurrentGeneration_ConcurrentRead_NoRace` 以 `-race` 跑 N goroutine 並發讀 + 寫（Run 內部 advanceGeneration），確認無 race。
 
 ## Tasks（staged parallelism）
 
 | Stage | Task | 依賴 |
 |---|---|---|
-| **Stage 1** | T1（Arbitrator 新 public API：CurrentGeneration + RetryCh + retryTick）, T2（sampler）, T3（divergences store 介面確認/補） | 無 |
-| **Stage 2** | T4（observation builder helpers: hook / probe / sweep）, T5（apply pipeline: pending production trigger + scheduleRetry + attemptRetry + tryPromote 實作 + divergence writer + sampler 接入） | T1/T2/T3 |
-| **Stage 3** | T6（hook path wiring: handler.go + trace.go + trace_id lookup）, T7（probe wiring: probe.go + provider register callback）, T8（sweep wiring） | T4/T5 |
+| **Stage 1** | T1（Arbitrator CurrentGeneration + frameState RWMutex + AdoptTraceID）, T2（sampler 單 goroutine + per-session map）, T3（divergences store 介面確認/補）, T3b（observation role_resolution 常數 + helper） | 無 |
+| **Stage 2** | T4（observation builder helpers: hook / probe / sweep — 含 identity 三欄 + role_resolution）, T5（apply pipeline: pending production trigger + tryPromoteFromEntry/Now + divergence writer primary-only + sampler 接入 + SessionStart adopt trace_id + gen gate 改寫） | T1/T2/T3/T3b |
+| **Stage 3** | T6（hook path wiring: handler.go + trace.go + provisional UUID + traceLookup fallback）, T7（probe package 擴 Start/Stop/Rotate API + Module provider rewire）, T8（sweep wiring） | T4/T5 |
 | **Stage 4** | T9（Monitor API envelope + schema_version）, T10（SPA type sync） | 無（與 Stage 1-3 可 parallel） |
 
-### Task 1 — Arbitrator 新 public API
+### Task 1 — Arbitrator CurrentGeneration + frameState RWMutex + AdoptTraceID
 
 **檔案**：
-- `internal/module/agent/arbitrator/arbitrator.go`（改）
+- `internal/module/agent/arbitrator/arbitrator.go`（改 — 加 CurrentGeneration public method）
 - `internal/module/agent/arbitrator/arbitrator_test.go`（改）
-- `internal/module/agent/arbitrator/frame_state.go`（改：Generation → atomic.Int64）
+- `internal/module/agent/arbitrator/frame_state.go`（改 — 整張 map + sessionGen 欄位改由 `sync.RWMutex` 保護；寫路徑 Lock、讀路徑 RLock）
 - `internal/module/agent/arbitrator/frame_state_test.go`（改）
-- `internal/module/agent/arbitrator/types.go`（改：加 retryTick）
+- `internal/module/agent/observation/trace_id.go`（改 — `TraceIDMinter` interface 加 `AdoptTraceID(sid, gen, seed) string`；`traceIDRegistry` 實作冪等）
+- `internal/module/agent/observation/trace_id_test.go`（改）
 
 **契約**：
 ```go
 // arbitrator.go
-func (a *Arbitrator) CurrentGeneration(sessionID string) int64
+func (a *Arbitrator) CurrentGeneration(sessionID string) int64  // RLock-based read
 
-// Options
-type Options struct {
-    ... existing ...
-    RetryDelays []time.Duration  // default [100ms, 250ms, 500ms]
-    RetryChCap int               // default 256
-}
-
-// types.go
-type retryTick struct {
-    Obs     observation.Observation
-    Attempt int
-}
+// observation/trace_id.go — 加到 TraceIDMinter interface；traceIDRegistry 實作
+// AdoptTraceID：以 seed 做 (sid, gen) 公共 trace_id；已存在則回舊值（冪等）
+AdoptTraceID(sessionID string, generation int64, seed string) string
 ```
+
+**移除**（對照 P0-4）：原規劃的 `RetryDelays` / `RetryChCap` / `retryTick` 全數拿掉。
 
 **TDD**：
 - `TestArbitrator_CurrentGeneration_UnknownSession_ReturnsZero`
 - `TestArbitrator_CurrentGeneration_AfterSessionStart_ReturnsNewGen`
-- `TestArbitrator_CurrentGeneration_ConcurrentRead_NoRace`
-- `TestFrameState_Generation_AtomicReadWrite`
+- `TestArbitrator_CurrentGeneration_ConcurrentRead_NoRace` — 多 reader + 單 writer `-race` pass
+- `TestFrameState_RWMutex_WriteExcludesReads` — Lock 下 RLock 需 block
+- `TestFrameState_RWMutex_MultipleReadersConcurrent` — RLock 可並發
+- `TestTraceIDRegistry_AdoptTraceID_NewPair_UsesSeed`
+- `TestTraceIDRegistry_AdoptTraceID_ExistingPair_ReturnsOld` — 冪等
+- `TestTraceIDRegistry_AdoptTraceID_EmptySeed_Error`（行為由實作定：回錯或退回 Mint；測試驗契約）
 
-### Task 2 — sampler
+### Task 2 — sampler（單 goroutine owner + per-session map）
 
 **檔案**：
 - `internal/module/agent/arbitrator/sampler.go`（新）
@@ -389,80 +614,139 @@ type retryTick struct {
 - `TestSampler_Proposed_Hook_AlwaysEmits` — hook/probe proposed 不 sample
 - `TestSampler_Proposed_Sweep_1In10`
 - `TestSampler_Proposed_Synthetic_1In10`
-- `TestSampler_ConcurrentCounters_NoRace`
+- `TestSampler_CrossSession_IndependentCounters` — session A sweep 累計不影響 session B sweep
+- `TestSampler_ClearSession_ResetsCounts`
+- （不跑多 goroutine race 測試，因 single-owner 契約；race 覆蓋由 apply pipeline 測試承擔）
 
-### Task 3 — Divergences store 介面確認
+### Task 3 — DivergenceStore 介面 sanity（無改動，僅驗收）
 
 **檔案**：
-- `internal/store/divergences.go`（改如需）
-- `internal/store/divergences_test.go`（改如需）
+- `internal/store/divergences.go`（sanity check — 不改）
+- `internal/store/divergences_test.go`（sanity check — 不改；若既有 test 不夠可在 T5 apply_test 使用真 store integration 補足）
 
-**檢查項**：
-- `DivergencesStore` 是否有 `Insert(row FrameDivergence) error` 方法？若無則補
-- `FrameDivergence` struct 是否涵蓋 §8.1 schema 所有欄位？若缺則補
+**驗收項**（D5.1 已確認）：
+- `DivergenceStore`（單數）與 `Insert(d FrameDivergence) (int64, error)` 已存在（alpha.192 ship）
+- FrameDivergence struct 已涵蓋 §8.1 schema
+- INSERT OR IGNORE 語意正常
 
-**TDD**（若新增 Insert）：
-- `TestDivergencesStore_Insert_Roundtrip`
-- `TestDivergencesStore_Insert_IdempotencyKey_NoDuplicate`（session_id, trace_id, event_id, observed_generation tuple DO NOTHING）
+若以上驗收失敗再補 Task 3a（schema migration + Insert 實作）；目前預期不會發生。
 
-### Task 4 — Observation builder helpers
+### Task 3b — observation role_resolution 常數 + helper
+
+**檔案**：
+- `internal/module/agent/observation/role_resolution.go`（新）— `EvidenceKeyRoleResolution` 常數 + `RoleResolutionState` enum + `RoleResolutionFromEvidence(ev)` helper
+- `internal/module/agent/observation/role_resolution_test.go`
+
+**TDD**：
+- `TestRoleResolutionFromEvidence_Resolved`
+- `TestRoleResolutionFromEvidence_RetryableUnresolved`
+- `TestRoleResolutionFromEvidence_TerminalUnresolved`
+- `TestRoleResolutionFromEvidence_MissingKey_ReturnsFalse`
+- `TestRoleResolutionFromEvidence_InvalidEnum_ReturnsFalse`
+
+### Task 4 — Observation builder helpers（含 identity 三欄 + role_resolution）
 
 **檔案**：
 - `internal/module/agent/observation_builders.go`（新）— `buildHookObservation` / `buildProbeObservation` / `buildSweepObservation`
 - `internal/module/agent/observation_builders_test.go`
 
 **TDD**：
-- `TestBuildHookObservation_FullShape`
-- `TestBuildHookObservation_SessionStart_EmptyTraceID_ArbitratorMints`
-- `TestBuildHookObservation_VerifyFailed_EvidenceContainsReason`
+- `TestBuildHookObservation_FullShape_IncludesIdentityTriple_AndRoleResolution`
+- `TestBuildHookObservation_ProvisionalTraceID_NonEmpty` — TraceID 永遠非空，builder 不會被 `ErrMissingRequiredField` reject
+- `TestBuildHookObservation_SessionStart_ObservedGenerationIsCurrentPlusOne`
+- `TestBuildHookObservation_VerifyFailed_RoleResolutionRetryable` — 驗 pane_unresolvable / sender_uncertain 映射
+- `TestBuildHookObservation_VerifyFailed_RoleResolutionTerminal_IfTerminalReason`
 - `TestBuildProbeObservation_OutcomeMapping_DeadToEnded`
-- `TestBuildProbeObservation_WatcherTokenSet`
-- `TestBuildSweepObservation_PidDead_ProposalEndLifecycle`
+- `TestBuildProbeObservation_WatcherTokenSet_IdentityTriplePresent`
+- `TestBuildSweepObservation_PidDead_ProposalEndLifecycle_IdentityTriplePresent_RoleResolved`
+- `TestBuildSweepObservation_FrameMissing_RoleTerminalUnresolved`
 
 ### Task 5 — Apply pipeline 擴充
 
 **檔案**：
-- `internal/module/agent/arbitrator/apply.go`（改 — pending production trigger + scheduleRetry + attemptRetry + tryPromote + divergence writer + sampler wiring）
+- `internal/module/agent/arbitrator/apply.go`（改 — role-based pending routing + tryPromoteFromEntry + tryPromoteToActorNow + divergence writer primary-only + sampler wiring + SessionStart helper 改走 AdoptTraceID + gen gate 只在 `>` 時推進）
 - `internal/module/agent/arbitrator/apply_test.go`（補 tests）
-- `internal/module/agent/arbitrator/arbitrator.go`（改 — Run select 加 retryCh case + drain 時同步處理 retryCh 剩餘）
+- `internal/module/agent/arbitrator/arbitrator.go`（改 — 只加 CurrentGeneration；**不** 動 Run select）
+- `internal/module/agent/arbitrator/pending.go`（改如需 — `flushPendingDue` 的 `tryPromote` callback 對應新契約）
 
-**TDD（新增）**：
-- `TestApply_HookUnresolved_CreatesFirstPendingEntry_SchedulesRetry` — hook obs 帶 verify_reason=pane_unresolvable → addPending + scheduleRetry 呼叫（用 fake retryCh）
-- `TestApply_HookResolved_NotPending` — verify reason not unresolved → 不 addPending
-- `TestApply_AttemptRetry_PendingPromotedOnSuccess`
-- `TestApply_AttemptRetry_PendingStillUnresolved_NoPromoteWaitDeadline`
-- `TestApply_TryPromote_SuccessfulPromotion_CallsApplyProposalPath`
-- `TestApply_TryPromote_NoEvidence_ReturnsFalse`
-- `TestApply_Passthrough_DivergenceWritten_WhenLegacyDiffers`
+**TDD（新增；retry-scheduler 相關 case 全數移除）**：
+- `TestApply_HookRoleResolutionMissing_NotPending` — 無 role_resolution key → 不 addPending
+- `TestApply_HookRetryableUnresolved_CreatesFirstPendingEntry_NoRetryScheduled` — addPending 被呼叫；retryCh/AfterFunc 完全不被呼叫（不再有 retry）
+- `TestApply_HookTerminalUnresolved_EmitsTraceOnly_NotPending`
+- `TestApply_HookResolved_WhilePending_TriggersTryPromoteToActorNow` — 活人 signal 立刻嘗試 promote
+- `TestApply_TryPromoteFromEntry_NoPositiveSignal_ReturnsFalse_WaitsForDeadline`
+- `TestApply_TryPromoteFromEntry_HasResolvedObs_Promotes`
+- `TestApply_TryPromoteFromEntry_ResolvedButNoProposal_ReturnsFalse`
+- `TestApply_GenGate_ObservedEqualCurrent_NotSessionStart_AppliesNormally`
+- `TestApply_GenGate_ObservedGreaterCurrent_SessionStart_RunsHelper_Adopts`
+- `TestApply_GenGate_ObservedGreaterCurrent_NotSessionStart_Rejects` — ObservedGenerationAhead
+- `TestApply_SessionStart_AdoptTraceID_UsesObservationSeed`
+- `TestApply_SessionStart_AdoptTraceID_Idempotent_WhenReplayed`
+- `TestApply_Passthrough_DivergenceWritten_WhenLegacyDiffers_Primary`
+- `TestApply_Passthrough_DivergenceSkipped_WhenActorIsSubagent_MetricIncremented`
+- `TestApply_Passthrough_DivergenceSkipped_WhenIdentityTripleMissing_MetricIncremented`
 - `TestApply_Passthrough_NoDivergenceWrite_WhenMatches`
-- `TestApply_Sampler_Sweep_DropsNineInTen`
+- `TestApply_Sampler_Sweep_DropsNineInTen_PerSession`
 
 ### Task 6 — Hook path wiring
 
 **檔案**：
-- `internal/module/agent/handler.go`（改 — handleEvent 在 applyFrameEvent 後 SubmitObservation）
-- `internal/module/agent/trace.go`（改 — `traceID` 來源先試 TraceIDLookup）
+- `internal/module/agent/handler.go`（改 — handleEvent 在 verifyEventFn 結果之後的共用邊界 SubmitObservation；accept / reject 兩分支都送）
+- `internal/module/agent/trace.go`（改 — `hookTraceCollector` 的 `traceID` 先試 `TraceIDLookup.Get`，miss 才 fallback 到 chain_id 並 log warn）
 - `internal/module/agent/handler_test.go`（改）
 
+**實作要點**：
+- observation 在 build 時 mint provisional UUID 做 `Observation.TraceID`（D1.2）
+- identity triple（`pid / pane_id / start_time`）由 Module 回填：若 hook req 缺 `ProcessStartTime` 欄位 → 以 `FramesStore.GetByIdentity(paneID, pid, "")` 反查；查不到則填 `"unknown"` 並標 metric `lights_hook_identity_unknown`
+- SessionStart 的 `ObservedGeneration = arbitrator.CurrentGeneration(sid) + 1`（D1.3）
+- 非 SessionStart 的 `ObservedGeneration = arbitrator.CurrentGeneration(sid)`
+- role_resolution 常數化映射：accept → `RoleResolved`；reject/retryable reason → `RoleRetryableUnresolved`；reject/terminal reason → `RoleTerminalUnresolved`
+
 **TDD**：
-- `TestHandleEvent_AfterApply_SubmitsObservation`
-- `TestHandleEvent_SessionStart_SubmitsObservationWithEmptyTraceID` — Mint 在 apply 階段
-- `TestHandleEvent_VerifyFailed_SubmitsObservationWithFailureEvidence`
+- `TestHandleEvent_Accept_SubmitsObservation` — accept 分支 observation Phase=Committed
+- `TestHandleEvent_Reject_SubmitsObservation` — reject 分支 observation Phase=Proposed、RoleResolution=Retryable/Terminal
+- `TestHandleEvent_SessionStart_ObservationObservedGenerationIsCurrentPlusOne`
+- `TestHandleEvent_NonSessionStart_ObservationObservedGenerationIsCurrent`
+- `TestHandleEvent_ProvisionalTraceID_NonEmpty` — 永遠非空繞過 builder
+- `TestHandleEvent_IdentityTriple_StartTimeBackfilled_WhenReqMissing`
 - `TestHookTraceCollector_TraceIDFromLookup_WhenAvailable`
 - `TestHookTraceCollector_TraceIDFallsBackToChainID_WhenMinterNotYetCalled`
 - `TestHandleEvent_SubmitObservationDrop_LegacyPathStillRuns` — inCh 滿載；legacy broadcast + trace 仍跑
 
-### Task 7 — Probe path wiring
+### Task 7 — Probe package 擴 API + Module provider rewire（P1-7）
 
-**檔案**：
-- `internal/module/agent/module.go`（改 — onActivityDetected / onReadinessDetected callback 產 observation + submit）
-- `internal/agent/probe/*.go`（**不改 probe 本身**；只讓 Module 在收到 probe callback 時 submit）
-- `internal/module/agent/module_test.go`（改）
+**檔案**（**probe package 可改，scope 擴張**）：
+- `internal/agent/probe/liveness/liveness.go`（改 — 加 `Watcher` interface + `Start(ctx, spec, onOutcome) Watcher`）
+- `internal/agent/probe/liveness/liveness_test.go`（改）
+- `internal/agent/probe/activity/activity.go`（改）
+- `internal/agent/probe/activity/activity_test.go`（改）
+- `internal/agent/probe/readiness/readiness.go`（改）
+- `internal/agent/probe/readiness/readiness_test.go`（改）
+- `internal/module/agent/module.go`（改 — provider register 改用 `watcher := liveness.Start(...)`；`m.storeWatcher(sessionID, kind, watcher)`；session 換代 / teardown 時 `watcher.Stop()`）
+- `internal/module/agent/module_test.go` 或對應（改）
+
+**新 API 形狀**（詳 D2.1 / D2.2）：
+```go
+type Watcher interface {
+    Token() string
+    Rotate() string
+    Stop()
+}
+
+type Callback func(outcome Outcome, token string, evidence []EvidenceRef)
+
+func Start(ctx context.Context, spec Spec, onOutcome Callback) Watcher
+```
 
 **TDD**：
-- `TestProbeActivity_SubmitsObservation`
-- `TestProbeLiveness_Dead_SubmitsEndLifecycleObservation`
-- `TestProbeReadiness_Ready_SubmitsWatcherTokenMatchingObservation`
+- `TestLivenessWatcher_Start_FiresOutcome_WithStableToken`
+- `TestLivenessWatcher_Rotate_ReturnsNewToken_OldToken_BecomesInvalid`
+- `TestLivenessWatcher_Stop_Idempotent`
+- `TestActivityWatcher_Start_FiresOnActivity` / `TestReadinessWatcher_Start_FiresOnReady`
+- `TestModule_ProbeCallback_SubmitsObservation_WithIdentityTriple_AndRoleResolved`
+- `TestModule_ProbeLivenessDead_SubmitsEndLifecycleObservation`
+- `TestModule_SessionTeardown_StopsAllWatchers`
+- `TestModule_ProbeOutdatedToken_RejectsAtArbitratorWatcherCheck` — 走 apply step 2 既有 watcher check（整合測）
 
 ### Task 8 — Sweep path wiring
 
@@ -471,8 +755,9 @@ type retryTick struct {
 - `internal/module/agent/sweep_test.go`（改）
 
 **TDD**：
-- `TestSweep_PidDead_SubmitsObservation_BeforeClearFrame`
+- `TestSweep_PidDead_SubmitsObservation_BeforeClearFrame_IdentityTriplePresent_RoleResolved`
 - `TestSweep_PidReused_SubmitsObservationWithReusedReason`
+- `TestSweep_FrameIdentityMissing_RoleTerminalUnresolved`
 - `TestSweep_SubmitFails_ClearFrameStillRuns`
 
 ### Task 9 — Monitor API envelope (#569 backend)
@@ -503,21 +788,31 @@ type retryTick struct {
 |---|---|---|
 | `internal/module/agent/arbitrator/arbitrator.go` | 改 | 1, 5 |
 | `internal/module/agent/arbitrator/arbitrator_test.go` | 改 | 1, 5 |
-| `internal/module/agent/arbitrator/frame_state.go` | 改 | 1 |
+| `internal/module/agent/arbitrator/frame_state.go` | 改（RWMutex） | 1 |
 | `internal/module/agent/arbitrator/frame_state_test.go` | 改 | 1 |
-| `internal/module/agent/arbitrator/types.go` | 改 | 1 |
+| `internal/module/agent/observation/trace_id.go` | 改（AdoptTraceID） | 1 |
+| `internal/module/agent/observation/trace_id_test.go` | 改 | 1 |
 | `internal/module/agent/arbitrator/sampler.go` | 新 | 2 |
 | `internal/module/agent/arbitrator/sampler_test.go` | 新 | 2 |
-| `internal/store/divergences.go` | 改如需 | 3 |
-| `internal/store/divergences_test.go` | 改如需 | 3 |
+| `internal/store/divergences.go` | 不改（sanity） | 3 |
+| `internal/store/divergences_test.go` | 不改（sanity） | 3 |
+| `internal/module/agent/observation/role_resolution.go` | 新 | 3b |
+| `internal/module/agent/observation/role_resolution_test.go` | 新 | 3b |
 | `internal/module/agent/observation_builders.go` | 新 | 4 |
 | `internal/module/agent/observation_builders_test.go` | 新 | 4 |
 | `internal/module/agent/arbitrator/apply.go` | 改 | 5 |
 | `internal/module/agent/arbitrator/apply_test.go` | 改 | 5 |
+| `internal/module/agent/arbitrator/pending.go` | 改如需 | 5 |
 | `internal/module/agent/handler.go` | 改 | 6 |
 | `internal/module/agent/trace.go` | 改 | 6 |
 | `internal/module/agent/handler_test.go` | 改 | 6 |
-| `internal/module/agent/module.go` | 改 | 7 |
+| `internal/agent/probe/liveness/liveness.go` | 改（Watcher / Start） | 7 |
+| `internal/agent/probe/liveness/liveness_test.go` | 改 | 7 |
+| `internal/agent/probe/activity/activity.go` | 改 | 7 |
+| `internal/agent/probe/activity/activity_test.go` | 改 | 7 |
+| `internal/agent/probe/readiness/readiness.go` | 改 | 7 |
+| `internal/agent/probe/readiness/readiness_test.go` | 改 | 7 |
+| `internal/module/agent/module.go` | 改（watcher 管理） | 7 |
 | `internal/module/agent/module_test.go` 或對應 | 改 | 7 |
 | `internal/module/agent/sweep.go` | 改 | 8 |
 | `internal/module/agent/sweep_test.go` | 改 | 8 |
@@ -525,7 +820,9 @@ type retryTick struct {
 | `internal/module/agent/monitor_test.go` | 改 | 9 |
 | `spa/src/types/monitor.ts`（或 grep 確認） | 改 | 10 |
 
-**預估**：~1100 LOC（Go ~1000 + SPA ~100）。
+**移除**（對照 P0-4）：`internal/module/agent/arbitrator/types.go` 的 retryTick 新增、Options 的 RetryDelays / RetryChCap 全不做。
+
+**預估**：~1250 LOC（Go ~1150 + SPA ~100；probe 擴 API 多 ~150，退款 retry ~200）。
 
 ## Verification
 
@@ -547,7 +844,7 @@ npx vitest run
 1. 啟 daemon；啟 SPA；開一個 tmux pane + Claude Code session
 2. 觸發 hook（SessionStart + PostToolUse）
 3. `curl http://127.0.0.1:7860/api/agent/monitor/chains?limit=5 | jq` — trace step 含 trace_id 非空、source_kind=hook、對應 envelope 欄位
-4. `sqlite3 <db> "SELECT COUNT(*) FROM frame_divergences"` — 有 row（matched=1 與 matched=0 都可能，端視 projection 是否對齊）
+4. `sqlite3 <db> "SELECT COUNT(*) FROM frame_divergences"` — 若 projection 與 legacy 完全對齊可能為 0 row（D5.2 只寫 matched=0；matched=1 走 metric counter 不寫 row）；若出現 row，讀 `diff_summary` 確認是預期 drift 還是 bug
 5. Arbitrator log 有 `[agent][arbitrator] Run started`，reconcile tick 固定觸發
 6. 連續 PUT `/api/config '{"agent":{"arb_mode":"authoritative"}}'` + 觸發 SessionStart → 所有 hook obs 都被 fail-closed reject（trace 含 `AuthoritativeNotSupportedPhase1`）；無 frame_divergences 寫入（authoritative path 不走 divergence）
 
@@ -558,7 +855,7 @@ npx vitest run
 
 - **Rollout**：merge 後 daemon 會開始 dual-write，divergences 表開始寫。使用者可見行為不變（legacy path 仍主導 FramesStore 與 broadcast）
 - **Rollback**：revert 整 PR；legacy direct-write path 未動，立即回復舊行為
-- **Monitor**：`sqlite3 <db> "SELECT matched, COUNT(*) FROM frame_divergences GROUP BY matched"` 觀察 divergence rate；若 matched=0 比例過高代表 projection 邏輯有 bug（trigger rollback 或 iterate projection code）
+- **Monitor**：`sqlite3 <db> "SELECT COUNT(*) FROM frame_divergences"` 觀察 matched=0 divergence 絕對量；配合 metric `lights_divergence_total{matched=0/1}` 看比率。matched=0 比例過高（> 5%）代表 projection 邏輯或 legacy 讀取點有 bug（trigger rollback 或 iterate projection code）。`lights_divergence_non_primary_skipped` 與 `lights_divergence_identity_missing` 需為 0（若非 0 表示 observation builder 漏欄）
 
 ## 已知 follow-up（1b-1c 不做）
 
@@ -571,5 +868,7 @@ npx vitest run
 | 5 | Daemon restart frame / actor state replay | Phase 2 |
 | 6 | Trace viewer SPA UI（decision ports 流程圖）| PR-6b |
 | 7 | `AGENT_ARB_MODE=authoritative` 真 frame write（1b-1c 仍 fail-closed）| PR-2b |
+| 8 | **Pending retry scheduler**（`scheduleRetry` / `attemptRetry` / `retryCh` / exponential backoff） | post-1b-1c（獨立小 PR；本 PR 以 coalesce-on-arrival + deadline drop 取代） |
+| 9 | **Subagent / proxy divergence projection**（需 frame schema 升級後才可行） | Phase 2 (PR-2a) |
 
-**#568 / #569 / #584 何時可關**：本 PR merge 後即可關。
+**#568 / #569 / #584 何時可關**：本 PR merge 後即可關。**新增 issue 候選**：retry scheduler follow-up 建議 merge 後 `gh issue create`。

--- a/docs/superpowers/plans/2026-04-22-lights-system/pr-1b-1c.md
+++ b/docs/superpowers/plans/2026-04-22-lights-system/pr-1b-1c.md
@@ -436,16 +436,18 @@ func (d *applyDeps) writeDivergenceIfAny(obs observation.Observation) {
         TraceID: obs.TraceID,
         EventID: obs.SpanID,
         ObservedGeneration: obs.ObservedGeneration,
-        OldStateRef: mustJSON(legacyFrame),
-        ProposalStateRef: mustJSON(projected),
+        OldStateRef: mustJSON(legacyFrame),       // json.RawMessage
+        ProposalStateRef: mustJSON(projected),    // json.RawMessage
         DiffSummary: humanDiff(legacyFrame, projected),
-        Matched: 0,
+        Matched: false,                            // bool — 僅在有 divergence 時寫 row
         ReasonCode: obs.ReasonCode,
         CreatedAt: d.now().UnixNano(),
     })
     metrics.Inc("lights_divergence_total", "matched=0")
 }
 ```
+
+> 實際 `store.FrameDivergence.Matched` 型別是 `bool`（Insert 時 driver 轉為 INTEGER column：true=1 / false=0）；`OldStateRef` / `ProposalStateRef` 是 `json.RawMessage`（存為 TEXT），`mustJSON(v)` 回 `json.RawMessage`。
 
 Divergence 寫失敗只 log，不影響 apply（passthrough 本身就是 observability 層）。
 

--- a/docs/superpowers/plans/2026-04-22-lights-system/pr-1b-1c.md
+++ b/docs/superpowers/plans/2026-04-22-lights-system/pr-1b-1c.md
@@ -1,0 +1,575 @@
+# PR-1b-1c — hook/probe/sweep dual-write + divergence + Monitor API passthrough
+
+> Phase：1（Schema + 雙寫過渡）收尾
+> 依賴：PR-1b-1b（#583, alpha.205）— Arbitrator goroutine、admission、9-step apply、TraceWriter、AppendSteps、TraceIDMinter/Lookup、arbmode atomic published
+> 後續：Phase 2（PR-2a/b/c — frame schema 升級 + authoritative mode + 刪 legacy direct-write）
+> Spec 對照：§3.4.2 pending（production entry）、§3.4.3 sweep vs pending、§5.4 retry + pending window、§8.1 divergence 落地、§3.5.1 sampling、#569 Monitor API、#568 trace_id end-to-end、#584 pending production entry
+> 關聯 Issue：#568（trace_id correlation end-to-end）/ #569（Monitor API envelope）/ #584（pending production entry，1b-1b 延後項）
+
+## Context
+
+PR-1b-1b 落地 Arbitrator 的執行層但**沒有上游**：hook / probe / sweep 仍走 legacy direct-write path，Arbitrator 的 `in` channel 只在測試裡被送料；`Module.traceLookup` 建好放著沒人用；pending 視窗 production 路徑無入口（#584）。`hookTraceCollector` 繼續用 `trace_id == chain_id` aliasing（#568 仍未關）；monitor API 與 SPA 對新 22 欄 envelope 無知（#569 仍未關）。
+
+PR-1b-1c 把這些缺口一次收完，讓 Arbitrator 真的吃到三來源流量、divergence table 真的被寫、Monitor UI 能看到 envelope 欄位、#568 / #569 / #584 全關。**沒有 frame schema 變動**（留 Phase 2）；passthrough 期間 FramesStore 與 WS broadcast **仍走 legacy path**，Arbitrator 只負責計算 proposal + 寫 divergence + 寫 trace。
+
+**alpha.205 之前已經 ship 的契約全部不動**；本 PR 只新增流量來源 + divergence writer + Monitor envelope 穿透 + Retry + Pending production trigger。
+
+預估 ~1100 LOC 含測試（+ SPA 小段 type 同步）。
+
+## Goals
+
+1. **Hook path dual-write**：`handleEvent` 除既有 `hookTraceCollector` 外，再 build `observation.Observation` 送 `Module.SubmitObservation`；legacy frame path 不變
+2. **Hook trace_id 汰換**：`hookTraceCollector` 用 `TraceIDLookup.Get(session, generation)` 取 per-(session, generation) trace_id；miss 則保留 chain_id aliasing + 記 warn（避免 bootstrap regression）。SessionStart hook observation 由 Arbitrator Mint；後續 hook 事件讀取同 gen 的 trace_id → **完成 #568**
+3. **Probe path produce observation**：`probe/liveness`、`probe/activity`、`probe/readiness` 的 callback 改為透過 adapter 轉 `Observation` 送 Arbitrator（保留 legacy `applyProbe*` path）
+4. **Sweep path produce observation**：`sweepOnce` 對每個 detect-to-end 的 frame 送一筆 `SourceSweep` + `SuggestStatus=ended` observation；legacy `clearFrame` 仍同步跑
+5. **Retry + Pending production entry (#584 + spec §5.4)**：
+   - Arbitrator apply 增「role 判不出 / evidence 不足」分支：將 observation addPending + `scheduleRetry([100ms, 250ms, 500ms])`
+   - `retryCh` 重新納入 1b-1c scope（1b-1b 時延後的）；Arbitrator Run 的 select 加 `case <-retryCh`
+   - 3 strike 後 `emitTraceOnly` drop（reason_code=`RetryExhausted`）
+6. **Divergence 落地（§8.1）**：Arbitrator 在 passthrough 下把 proposal 投影回舊 schema → 與 legacy frame 比對 → 有差異寫 `frame_divergences` row；已存在 `store.SaveFrameDivergence` 等 API（alpha.192 PR-1a 已 ship divergences 表）—— 確認介面可用，否則補
+7. **Monitor API envelope passthrough (#569 backend)**：`MonitorStep` / `monitorStepFromStore` / `MonitorChainSummary` 穿透 PR-1b-0 新 22 欄；加 `schema_version` 提示（defender 建議）；單一 normalize 點處理 `""`/`{}`/`[]` default
+8. **SPA type sync (#569 frontend)**：`spa/src/types/` 或對等型別檔增加新欄位；既有 trace list consumer 若有則同步 shape
+9. **Sampling（§3.5.1 line 567）**：sweep/synthetic `proposed` 取 1/10；committed 全留。在 apply 的 emit trace 前套
+
+## Non-Goals（明確排除）
+
+- ❌ Frame schema 改 Generation + Actors JSON — **Phase 2 (PR-2a)**
+- ❌ Authoritative mode 實際寫 frame — **Phase 2 (PR-2b)**
+- ❌ 刪 hook/probe/sweep direct-write legacy path — **Phase 2 (PR-2c)**
+- ❌ Trace retention 24h per-session TTL — **Phase 2**
+- ❌ Arbitrator daemon restart replay — **Phase 2**
+- ❌ Trace viewer SPA UI（decision ports 流程圖）— **PR-6b（trace viewer 專 PR）**
+- ❌ Host module observation wiring（host 沒有 hook lifecycle）— **不在 Lights 範圍**
+
+## 設計決策
+
+### D1. Hook path dual-write 架構
+
+**現況**：`handleEvent` 在 `handler.go:68` → `verifyEventFn` → `applyFrameEvent` → `hookTraceCollector` → broadcast。Trace 寫 store 走 `collector.complete()` 把 `chain + steps` 整包 SaveChain。
+
+**改動**：在 `applyFrameEvent` 之後、`broadcast` 之前加一個 `buildObservationFromHook(req, verifyResult, projection) observation.Observation` helper，產 observation 送 `m.SubmitObservation(obs)`。
+
+**TraceID 來源**：
+- 如果 `req.EventName == "SessionStart"` → observation 走 Arbitrator apply 路徑會**由 Arbitrator 的 SessionStart helper 執行 Mint**（1b-1b 已實作），此時 Observation.TraceID 可空，Arbitrator apply 後 boundary trace 會帶新 trace_id
+- 其他 hook → `traceID, ok := m.traceLookup.Get(req.SessionCode, generation)`；miss 表示 Arbitrator 尚未 Mint 過 → 降級回舊 chain_id 作 traceID，並 log warn（transient bootstrap 期，Arbitrator 正常運作下不該發生）
+- Legacy `hookTraceCollector` 的 trace_id 來源同步改：先試 `traceLookup.Get`，miss 才用 chain_id fallback（**完成 #568 的 end-to-end 汰換**）
+
+**Observation 建構**：
+- `SourceKind: SourceHook`
+- `Action: req.EventName`（e.g. "SessionStart" / "PostToolUse"）
+- `Phase: PhaseProposed` 預設；若 verifyResult.Accepted == true 則 `PhaseCommitted`
+- `ObservedGeneration`：目前 legacy path 沒有 generation 概念（Phase 2 加欄位）；**暫用 per-session in-memory counter**：`frameState` 已在 Arbitrator 維護，hook observation 設為 `observedGeneration = frameState.sessions[sid].Generation`（需要 hook path 能讀到 — 提供 `Arbitrator.SnapshotGeneration(sid) int64` method 或走 Arbitrator 單向 inference：hook 送 obs 時 ObservedGeneration 留 0 或複製自 Arbitrator 當前 generation —— **選後者**：builder 不強制對齊；generation gate 會自行處理。實務上 observation builder 的 ActorKey.Generation 必須對齊 ObservedGeneration（§pr-1b-1a D3 契約），所以此處需有 generation source）
+- **決策**：新增 `Module.currentGenerationFor(sessionID)` helper，從 `frameState` 透過一個公開 snapshot 方法讀當前 generation（thread-safe：atomic.Int64 per session OR mu-guarded map）。或用更簡單的方式：Arbitrator 開放 `CurrentGeneration(sid) int64` method（內部 lock 或 sync.Map）——**選此方案**，Arbitrator 新增 `CurrentGeneration(sid) int64` 只讀 API，hook path 透過 `m.arbitrator.CurrentGeneration(...)` 取
+- `Proposal`：`ActorKey{SessionID: sid, Generation: gen, ActorID: "primary:" + agentType}` + `SuggestStatus: projection-inferred-status` + `EndLifecycle: eventName == "SessionEnd"` + `EndReason: "session_end"`
+- `Evidence`：`{Key:"pid", Value: req.SenderPID}` + `{Key:"pane_id", Value: req.TmuxPaneID}` + `{Key:"event_name", Value: req.EventName}` + verify reason if failed
+- `DecisionPorts`：legacy hook 不帶；留空 slice
+- `ObservedAt: time.Now()` / `Seq: monotonic per session`（簡化：time.Now().UnixNano()）
+
+### D2. Probe adapter
+
+**現況**：`probe/activity`、`probe/liveness`、`probe/readiness` 皆有 callback 形式；主要由 `agentcc / codex` 等 provider 在 register 時注入 callback。`module.go` 的 `onActivityDetected` 是 hook 之一。
+
+**改動**：建立 `internal/module/agent/arbitrator/probe_observation.go`（或 `internal/module/agent/observation_builders.go` 放 Module package）— 提供 helper：
+```go
+func buildProbeObservation(
+    sessionID string,
+    generation int64,
+    agentType string,
+    probeID string,
+    probeToken string,
+    probeKind string,            // "liveness" | "activity" | "readiness"
+    probeOutcome string,         // "alive" | "dead" | "active" | "idle" | "ready" | ...
+    evidence []observation.EvidenceRef,
+) observation.Observation
+```
+
+Probe callback 在 fire 時呼叫此 helper 產 observation → `m.SubmitObservation`。
+
+- `SourceKind: SourceProbe`
+- `WatcherToken: probeToken`（probe 實例化時 uuid.NewString，存進 provider 自身 state；同一 probeID 的 rotate 由上層 caller 管）
+- `Action: "probe.<probeKind>.<probeOutcome>"`
+- `Proposal.SuggestStatus` 視 outcome 映射（dead → `ended`、active → `active`、idle → `waiting`、error → `error`）
+
+**WatcherToken rotate**：Arbitrator `frameState.rotateWatcherToken(key, probeID, newToken)` 目前只在測試用；PR-1b-1c 需在 probe 實例化時呼叫（透過 Arbitrator 新增 public API `UpdateWatcherToken(actorKey, probeID, token)` 或更乾淨的做法：probe 產 observation 帶 `WatcherToken`，apply 層的 step 2 watcher check 改為**先 upsert 新 token**再驗證）— **選後者**：簡化 API 面積，watcher identity 由 observation 的 WatcherToken 欄位單向推進（舊 token 的 probe callback 到 Arbitrator 已經晚，reject 正確）。但這破壞 rotation 語意：若兩個 probe 實例並發，舊 probe token 會取代新 token。**實務上 rotate 是 caller 顯式 stop old watch + start new** 的動作，兩實例並發只在 bug 下發生；接受此風險，在 `frame_state.rotateWatcherToken` 的註解寫清楚 Phase 1 語意。
+
+### D3. Sweep path
+
+**現況**：`sweep.go` `sweepOnce()` 對每個 `!isPidAliveFn(frame.PID)` 或 `startTime != frame.ProcessStartTime` 的 frame 呼叫 `clearFrame`。
+
+**改動**：`clearFrame` 前呼叫 `m.SubmitObservation(buildSweepObservation(frame, reason))`；legacy clearFrame 仍跑。Sampling（§3.5.1 line 567）在 emit trace 階段處理（D7）。
+
+Observation shape：
+- `SourceKind: SourceSweep`
+- `Action: "sweep.frame_cleared"`
+- `Phase: PhaseProposed`（sweep 永遠 proposed，不升 committed）
+- `Proposal.ActorKey`: 以 `primary:<agent_type>` 或 sessionCode 派生
+- `Proposal.EndLifecycle: true; EndReason: reason`
+- `Evidence: [{Key:"pid", Value:frame.PID}, {Key:"reason", Value:reason}]`
+
+### D4. Retry scheduler (§5.4) + Pending production entry (#584)
+
+#### D4.1 Pending production trigger
+
+Arbitrator apply step 4 原本只有「sweep 且 actor 已 pending → addPending」的 sweep-override 分支。增加新分支：
+
+```go
+// apply.go step 4 revised
+func (d *applyDeps) routeToPendingIfUnresolved(obs observation.Observation) (stashed bool) {
+    // existing sweep override (keep)
+    if obs.SourceKind == observation.SourceSweep && d.pending.isPending(obs.Proposal.ActorKey) {
+        d.pending.addPending(obs, d.now(), ...)
+        return true
+    }
+    // new: role-unresolved trigger
+    if obs.SourceKind == observation.SourceHook && needsRoleResolution(obs) {
+        if d.pending.count() == 0 || !d.pending.isPending(obs.Proposal.ActorKey) {
+            d.pending.addPending(obs, d.now(), ...)  // first entry for this actor
+            d.scheduleRetry(obs)                      // schedule [100ms, 250ms, 500ms]
+            return true
+        }
+        d.pending.addPending(obs, ...)  // coalesce into existing entry
+        return true
+    }
+    return false
+}
+
+// needsRoleResolution — evidence-based judgment
+func needsRoleResolution(obs observation.Observation) bool {
+    // pid_tree_unresolvable / pane_unresolvable / sender_uncertain → yes
+    for _, e := range obs.Evidence {
+        if e.Key == "verify_reason" {
+            if s, ok := e.Value.(string); ok {
+                switch s {
+                case "pid_not_in_pane_tree", "pane_unresolvable", "sender_uncertain", "identify_mismatch":
+                    return true
+                }
+            }
+        }
+    }
+    return false
+}
+```
+
+#### D4.2 Retry scheduler
+
+```go
+// arbitrator.go
+type retryTick struct {
+    Obs      observation.Observation
+    Attempt  int  // 1..3
+}
+
+// Options 新增
+type Options struct {
+    ... existing ...
+    RetryCh chan retryTick  // cap 256
+    RetryDelays []time.Duration  // default [100ms, 250ms, 500ms]
+}
+
+// Arbitrator Run select 加 retryCh case
+func (a *Arbitrator) Run(ctx context.Context) {
+    ticker := time.NewTicker(a.opts.ReconcileEvery)
+    defer ticker.Stop()
+    for {
+        select {
+        case obs := <-a.inCh:
+            a.deps.apply(obs)
+        case tick := <-a.opts.RetryCh:
+            a.deps.attemptRetry(tick)
+        case <-ticker.C:
+            a.reconciler.reconcile()
+        case <-ctx.Done():
+            // drain
+            ...
+        }
+    }
+}
+```
+
+**scheduleRetry** 用 `time.AfterFunc` 排程（不阻塞 caller）：
+```go
+func (d *applyDeps) scheduleRetry(obs observation.Observation) {
+    for i, delay := range d.retryDelays {
+        attempt := i + 1
+        time.AfterFunc(delay, func() {
+            select {
+            case d.retryCh <- retryTick{Obs: obs, Attempt: attempt}:
+            default:
+                metrics.Inc("lights_arb_retry_dropped")
+            }
+        })
+    }
+}
+```
+
+**attemptRetry**：
+```go
+func (d *applyDeps) attemptRetry(tick retryTick) {
+    entry, ok := d.pending.getPendingEntry(tick.Obs.Proposal.ActorKey)
+    if !ok { return }  // pending 已被清（SessionStart or deadline flush）
+    // re-verify（此處 1b-1c 用 hook path 的 verify 結果，透過 observation Evidence 帶回）
+    // 若仍未解 → wait next attempt
+    // 若已達 attempt=3 仍未解 → flushPendingDue 的 deadline 會走 drop path (PidTreeUnresolvable)
+    // Promote 邏輯：Arbitrator 收到後續 observation 若對同 ActorKey 有 clear evidence → 正常 apply 時會 coalesce
+    // 實際 "promote" 靠後續 observation trigger — attemptRetry 本身只是 heartbeat
+    // 簡化：attemptRetry 記 trace reason_code=RetryAttempt{N}; 不做 promote logic
+}
+```
+
+#### D4.3 tryPromoteToActor 契約（1b-1b 佔位，1b-1c 定義）
+
+`pendingStore.flushPendingDue` 的 `tryPromote func(*PendingEntry) bool`：
+- 1b-1b 永遠回 false（走 drop path）
+- 1b-1c 改為：取 entry.Observations 最後一筆，若該 obs 有明確 proposal（`Proposal.SuggestStatus != ""` 或 `EndLifecycle == true`）且 evidence 不含未解 key（不含 pane_unresolvable/sender_uncertain）→ promote：直接套用 proposal 到 frameState（走 apply 後續 step 5-9）+ return true
+
+### D5. Divergence writer（§8.1）
+
+#### D5.1 已存在的 divergences API
+
+`internal/store/divergences.go`（alpha.192 PR-1a 已 ship）應已有 `SaveFrameDivergence` 或對等方法；本 PR 確認介面可用。若尚無 append API，補一個：
+```go
+func (s *DivergencesStore) Insert(row FrameDivergence) error
+```
+
+FrameDivergence shape 對應 spec §8.1 schema（session_id / trace_id / event_id / observed_generation / old_state_ref / proposal_state_ref / diff_summary / matched / reason_code / created_at）。
+
+#### D5.2 Arbitrator 整合
+
+`applyDeps` 加 `divergences DivergencesWriter` 與 `frames LegacyFramesView`（從 FramesStore 讀當前 legacy frame state）依賴：
+
+```go
+type DivergencesWriter interface {
+    Insert(row store.FrameDivergence) error
+}
+
+type LegacyFramesView interface {
+    GetByIdentity(paneID string, pid int, startTime string) (*store.Frame, error)
+}
+```
+
+Apply 的 step 8 mode branch — passthrough 路徑加 divergence 寫入：
+```go
+// apply.go step 8 (passthrough branch, after pre-gate mode check moved to step 0b)
+func (d *applyDeps) writeDivergenceIfAny(obs observation.Observation) {
+    if obs.Proposal.ActorKey.ActorID == "" { return }  // no proposal to project
+    // project Arbitrator proposal down to legacy Frame shape
+    projected := projectProposalToLegacy(obs.Proposal)
+    // read legacy frame
+    legacyFrame, err := d.frames.GetByIdentity(paneID, pid, startTime)  // pane/pid/startTime from evidence
+    if err != nil || legacyFrame == nil { return }
+    if framesMatch(projected, *legacyFrame) { return }  // no divergence
+    // write divergence row
+    _ = d.divergences.Insert(store.FrameDivergence{
+        SessionID: obs.SessionID,
+        TraceID: obs.TraceID,
+        EventID: obs.SpanID,
+        ObservedGeneration: obs.ObservedGeneration,
+        OldStateRef: mustJSON(legacyFrame),
+        ProposalStateRef: mustJSON(projected),
+        DiffSummary: humanDiff(legacyFrame, projected),
+        Matched: 0,
+        ReasonCode: obs.ReasonCode,
+        CreatedAt: d.now().UnixNano(),
+    })
+    metrics.Inc("lights_divergence_total", "matched=0")
+}
+```
+
+Divergence 寫失敗只 log，不影響 apply（passthrough 本身就是 observability 層）。
+
+### D6. Monitor API envelope (#569 backend)
+
+`monitor.go` `MonitorStep` 加 16 個新欄位（對應 `store.TraceStep` 的 lights envelope fields）。`monitorStepFromStore` 同步填。
+
+新增欄位清單（與 `store.TraceStep` 對齊）：`source_kind` / `action` / `reason_code` / `outcome` / `scenario_key` / `observed_generation` / `decision_ports`（JSON string）/ `phase` / `status` / `watcher_token` / `trace_id` / `reason_text` / `attrs` / `input_refs` / `output_refs` / `state_before_ref` / `state_after_ref` / `evidence_refs` / `started_at` / `ended_at` / `otel_kind`
+
+**Normalize**：`""` 保留 `""`；JSON 欄位（attrs/input_refs/output_refs/evidence_refs/decision_ports）空時 `monitorRawJSON` 回 `"null"` — 保留現有行為；**加 `schema_version: "1.0.0-lights-1b"` 欄位到 chain summary response**（defender 建議）便於 SPA 偵測 store rollback。
+
+### D7. Sampling（§3.5.1 line 567）
+
+`apply.go` emitAcceptedTrace / emitRejectedTrace 前加 sampler：
+```go
+type sampler struct {
+    mu      sync.Mutex
+    counts  map[observation.SourceKind]int  // modulo 10 counter
+}
+
+// ShouldEmit: committed 全 true；sweep/synthetic proposed 每 10 取 1；其他 proposed 全 true
+func (s *sampler) ShouldEmit(source observation.SourceKind, phase observation.ObsPhase) bool {
+    if phase == observation.PhaseCommitted { return true }
+    if source != observation.SourceSweep && source != observation.SourceSynthetic { return true }
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    c := s.counts[source]
+    s.counts[source] = c + 1
+    return c % 10 == 0
+}
+```
+
+被 sample 掉的仍計 metric `lights_trace_sampled_dropped{source,phase}`。
+
+### D8. SPA type sync (#569 frontend)
+
+`spa/src/` 搜 `MonitorStep` type / `agent/monitor` fetcher。更新 interface 含新欄位（optional string 為主）。若有 `useMonitorChain` / `useMonitorStep` hook 顯示舊 shape，**1b-1c 只 sync type，不動 UI rendering**（trace viewer UI 是 PR-6b）。
+
+### D9. Hook path dual-write 的失敗語意
+
+若 `m.SubmitObservation` 因 inCh 滿載 drop：legacy frame path 仍跑，使用者可見行為不變；只是 Arbitrator 少一筆 observation → divergence table 少一筆比對。metric `lights_arb_in_dropped` 已在 1b-1b 記錄。可接受。
+
+若 legacy frame path 失敗而 observation 已送：Arbitrator 會計算 proposal；divergence 寫入時讀 legacy frame state 可能是舊值或 nil → diff_summary 顯示「legacy_write_failed」這類標記即可。接受。
+
+### D10. ObservedGeneration 來源
+
+`Arbitrator.CurrentGeneration(sessionID string) int64` — 新增 thread-safe public method。內部讀 `frameState.sessions[sessionID].Generation`；需要 **加一個 atomic read path**（frameState 是單 goroutine owner，無 lock；此方法跨 goroutine 呼叫）。
+
+**實作**：frameState 改為**每個 sessionGen 的 Generation 用 `atomic.Int64`**，讓外部只讀操作免持 lock：
+
+```go
+type sessionGen struct {
+    Generation atomic.Int64   // publicly readable via CurrentGeneration
+    Actors     map[observation.ActorKey]*actorSummary
+}
+```
+
+Arbitrator goroutine 內寫 Generation 用 `Store`；hook path 讀用 `Load`。其他 actorSummary 欄位仍單 owner 無鎖。
+
+若 session 不存在 → 回 0（等同「尚未 SessionStart」）。
+
+## Tasks（staged parallelism）
+
+| Stage | Task | 依賴 |
+|---|---|---|
+| **Stage 1** | T1（Arbitrator 新 public API：CurrentGeneration + RetryCh + retryTick）, T2（sampler）, T3（divergences store 介面確認/補） | 無 |
+| **Stage 2** | T4（observation builder helpers: hook / probe / sweep）, T5（apply pipeline: pending production trigger + scheduleRetry + attemptRetry + tryPromote 實作 + divergence writer + sampler 接入） | T1/T2/T3 |
+| **Stage 3** | T6（hook path wiring: handler.go + trace.go + trace_id lookup）, T7（probe wiring: probe.go + provider register callback）, T8（sweep wiring） | T4/T5 |
+| **Stage 4** | T9（Monitor API envelope + schema_version）, T10（SPA type sync） | 無（與 Stage 1-3 可 parallel） |
+
+### Task 1 — Arbitrator 新 public API
+
+**檔案**：
+- `internal/module/agent/arbitrator/arbitrator.go`（改）
+- `internal/module/agent/arbitrator/arbitrator_test.go`（改）
+- `internal/module/agent/arbitrator/frame_state.go`（改：Generation → atomic.Int64）
+- `internal/module/agent/arbitrator/frame_state_test.go`（改）
+- `internal/module/agent/arbitrator/types.go`（改：加 retryTick）
+
+**契約**：
+```go
+// arbitrator.go
+func (a *Arbitrator) CurrentGeneration(sessionID string) int64
+
+// Options
+type Options struct {
+    ... existing ...
+    RetryDelays []time.Duration  // default [100ms, 250ms, 500ms]
+    RetryChCap int               // default 256
+}
+
+// types.go
+type retryTick struct {
+    Obs     observation.Observation
+    Attempt int
+}
+```
+
+**TDD**：
+- `TestArbitrator_CurrentGeneration_UnknownSession_ReturnsZero`
+- `TestArbitrator_CurrentGeneration_AfterSessionStart_ReturnsNewGen`
+- `TestArbitrator_CurrentGeneration_ConcurrentRead_NoRace`
+- `TestFrameState_Generation_AtomicReadWrite`
+
+### Task 2 — sampler
+
+**檔案**：
+- `internal/module/agent/arbitrator/sampler.go`（新）
+- `internal/module/agent/arbitrator/sampler_test.go`
+
+**TDD**：
+- `TestSampler_Committed_AlwaysEmits`
+- `TestSampler_Proposed_Hook_AlwaysEmits` — hook/probe proposed 不 sample
+- `TestSampler_Proposed_Sweep_1In10`
+- `TestSampler_Proposed_Synthetic_1In10`
+- `TestSampler_ConcurrentCounters_NoRace`
+
+### Task 3 — Divergences store 介面確認
+
+**檔案**：
+- `internal/store/divergences.go`（改如需）
+- `internal/store/divergences_test.go`（改如需）
+
+**檢查項**：
+- `DivergencesStore` 是否有 `Insert(row FrameDivergence) error` 方法？若無則補
+- `FrameDivergence` struct 是否涵蓋 §8.1 schema 所有欄位？若缺則補
+
+**TDD**（若新增 Insert）：
+- `TestDivergencesStore_Insert_Roundtrip`
+- `TestDivergencesStore_Insert_IdempotencyKey_NoDuplicate`（session_id, trace_id, event_id, observed_generation tuple DO NOTHING）
+
+### Task 4 — Observation builder helpers
+
+**檔案**：
+- `internal/module/agent/observation_builders.go`（新）— `buildHookObservation` / `buildProbeObservation` / `buildSweepObservation`
+- `internal/module/agent/observation_builders_test.go`
+
+**TDD**：
+- `TestBuildHookObservation_FullShape`
+- `TestBuildHookObservation_SessionStart_EmptyTraceID_ArbitratorMints`
+- `TestBuildHookObservation_VerifyFailed_EvidenceContainsReason`
+- `TestBuildProbeObservation_OutcomeMapping_DeadToEnded`
+- `TestBuildProbeObservation_WatcherTokenSet`
+- `TestBuildSweepObservation_PidDead_ProposalEndLifecycle`
+
+### Task 5 — Apply pipeline 擴充
+
+**檔案**：
+- `internal/module/agent/arbitrator/apply.go`（改 — pending production trigger + scheduleRetry + attemptRetry + tryPromote + divergence writer + sampler wiring）
+- `internal/module/agent/arbitrator/apply_test.go`（補 tests）
+- `internal/module/agent/arbitrator/arbitrator.go`（改 — Run select 加 retryCh case + drain 時同步處理 retryCh 剩餘）
+
+**TDD（新增）**：
+- `TestApply_HookUnresolved_CreatesFirstPendingEntry_SchedulesRetry` — hook obs 帶 verify_reason=pane_unresolvable → addPending + scheduleRetry 呼叫（用 fake retryCh）
+- `TestApply_HookResolved_NotPending` — verify reason not unresolved → 不 addPending
+- `TestApply_AttemptRetry_PendingPromotedOnSuccess`
+- `TestApply_AttemptRetry_PendingStillUnresolved_NoPromoteWaitDeadline`
+- `TestApply_TryPromote_SuccessfulPromotion_CallsApplyProposalPath`
+- `TestApply_TryPromote_NoEvidence_ReturnsFalse`
+- `TestApply_Passthrough_DivergenceWritten_WhenLegacyDiffers`
+- `TestApply_Passthrough_NoDivergenceWrite_WhenMatches`
+- `TestApply_Sampler_Sweep_DropsNineInTen`
+
+### Task 6 — Hook path wiring
+
+**檔案**：
+- `internal/module/agent/handler.go`（改 — handleEvent 在 applyFrameEvent 後 SubmitObservation）
+- `internal/module/agent/trace.go`（改 — `traceID` 來源先試 TraceIDLookup）
+- `internal/module/agent/handler_test.go`（改）
+
+**TDD**：
+- `TestHandleEvent_AfterApply_SubmitsObservation`
+- `TestHandleEvent_SessionStart_SubmitsObservationWithEmptyTraceID` — Mint 在 apply 階段
+- `TestHandleEvent_VerifyFailed_SubmitsObservationWithFailureEvidence`
+- `TestHookTraceCollector_TraceIDFromLookup_WhenAvailable`
+- `TestHookTraceCollector_TraceIDFallsBackToChainID_WhenMinterNotYetCalled`
+- `TestHandleEvent_SubmitObservationDrop_LegacyPathStillRuns` — inCh 滿載；legacy broadcast + trace 仍跑
+
+### Task 7 — Probe path wiring
+
+**檔案**：
+- `internal/module/agent/module.go`（改 — onActivityDetected / onReadinessDetected callback 產 observation + submit）
+- `internal/agent/probe/*.go`（**不改 probe 本身**；只讓 Module 在收到 probe callback 時 submit）
+- `internal/module/agent/module_test.go`（改）
+
+**TDD**：
+- `TestProbeActivity_SubmitsObservation`
+- `TestProbeLiveness_Dead_SubmitsEndLifecycleObservation`
+- `TestProbeReadiness_Ready_SubmitsWatcherTokenMatchingObservation`
+
+### Task 8 — Sweep path wiring
+
+**檔案**：
+- `internal/module/agent/sweep.go`（改 — clearFrame 前 submit observation）
+- `internal/module/agent/sweep_test.go`（改）
+
+**TDD**：
+- `TestSweep_PidDead_SubmitsObservation_BeforeClearFrame`
+- `TestSweep_PidReused_SubmitsObservationWithReusedReason`
+- `TestSweep_SubmitFails_ClearFrameStillRuns`
+
+### Task 9 — Monitor API envelope (#569 backend)
+
+**檔案**：
+- `internal/module/agent/monitor.go`（改）
+- `internal/module/agent/monitor_test.go`（改）
+
+**TDD**：
+- `TestMonitorStep_IncludesAllEnvelopeFields`
+- `TestMonitorStep_NormalizeEmptyJSON_ToNull`
+- `TestMonitorChainSummary_IncludesSchemaVersion`
+- `TestMonitorProjection_UnchangedShape` — 回歸測試
+
+### Task 10 — SPA type sync (#569 frontend)
+
+**檔案**：
+- `spa/src/types/monitor.ts`（或實際路徑 — 先用 `grep MonitorStep spa/src` 確認）
+- 相關 consumer fetcher type 更新
+
+**TDD**：
+- 無 unit test（純 type）；`pnpm run build` 綠即可
+- 若有 type smoke test（e.g. `spa/src/types/monitor.test.ts`）更新
+
+## 檔案變動總覽
+
+| 檔 | 動作 | Task |
+|---|---|---|
+| `internal/module/agent/arbitrator/arbitrator.go` | 改 | 1, 5 |
+| `internal/module/agent/arbitrator/arbitrator_test.go` | 改 | 1, 5 |
+| `internal/module/agent/arbitrator/frame_state.go` | 改 | 1 |
+| `internal/module/agent/arbitrator/frame_state_test.go` | 改 | 1 |
+| `internal/module/agent/arbitrator/types.go` | 改 | 1 |
+| `internal/module/agent/arbitrator/sampler.go` | 新 | 2 |
+| `internal/module/agent/arbitrator/sampler_test.go` | 新 | 2 |
+| `internal/store/divergences.go` | 改如需 | 3 |
+| `internal/store/divergences_test.go` | 改如需 | 3 |
+| `internal/module/agent/observation_builders.go` | 新 | 4 |
+| `internal/module/agent/observation_builders_test.go` | 新 | 4 |
+| `internal/module/agent/arbitrator/apply.go` | 改 | 5 |
+| `internal/module/agent/arbitrator/apply_test.go` | 改 | 5 |
+| `internal/module/agent/handler.go` | 改 | 6 |
+| `internal/module/agent/trace.go` | 改 | 6 |
+| `internal/module/agent/handler_test.go` | 改 | 6 |
+| `internal/module/agent/module.go` | 改 | 7 |
+| `internal/module/agent/module_test.go` 或對應 | 改 | 7 |
+| `internal/module/agent/sweep.go` | 改 | 8 |
+| `internal/module/agent/sweep_test.go` | 改 | 8 |
+| `internal/module/agent/monitor.go` | 改 | 9 |
+| `internal/module/agent/monitor_test.go` | 改 | 9 |
+| `spa/src/types/monitor.ts`（或 grep 確認） | 改 | 10 |
+
+**預估**：~1100 LOC（Go ~1000 + SPA ~100）。
+
+## Verification
+
+### 單元測試
+```bash
+cd .claude/worktrees/lights-pr-1b-1c
+go test -race -count=3 ./internal/module/agent/... ./internal/store/...
+go test -race -count=1 ./...
+go vet ./...
+go build ./...
+
+cd spa
+pnpm run lint
+pnpm run build
+npx vitest run
+```
+
+### 手動驗證
+1. 啟 daemon；啟 SPA；開一個 tmux pane + Claude Code session
+2. 觸發 hook（SessionStart + PostToolUse）
+3. `curl http://127.0.0.1:7860/api/agent/monitor/chains?limit=5 | jq` — trace step 含 trace_id 非空、source_kind=hook、對應 envelope 欄位
+4. `sqlite3 <db> "SELECT COUNT(*) FROM frame_divergences"` — 有 row（matched=1 與 matched=0 都可能，端視 projection 是否對齊）
+5. Arbitrator log 有 `[agent][arbitrator] Run started`，reconcile tick 固定觸發
+6. 連續 PUT `/api/config '{"agent":{"arb_mode":"authoritative"}}'` + 觸發 SessionStart → 所有 hook obs 都被 fail-closed reject（trace 含 `AuthoritativeNotSupportedPhase1`）；無 frame_divergences 寫入（authoritative path 不走 divergence）
+
+### 手動驗證 SPA
+- Open Monitor page（若已實作）→ trace list 顯示新欄位（或至少 type 不 crash；UI rendering PR-6b 接）
+
+## Rollout / Rollback
+
+- **Rollout**：merge 後 daemon 會開始 dual-write，divergences 表開始寫。使用者可見行為不變（legacy path 仍主導 FramesStore 與 broadcast）
+- **Rollback**：revert 整 PR；legacy direct-write path 未動，立即回復舊行為
+- **Monitor**：`sqlite3 <db> "SELECT matched, COUNT(*) FROM frame_divergences GROUP BY matched"` 觀察 divergence rate；若 matched=0 比例過高代表 projection 邏輯有 bug（trigger rollback 或 iterate projection code）
+
+## 已知 follow-up（1b-1c 不做）
+
+| # | 項目 | 歸屬 |
+|---|---|---|
+| 1 | Frame schema 升 Generation + Actors JSON | Phase 2 (PR-2a) |
+| 2 | Authoritative mode 實際寫 frame + broadcast | Phase 2 (PR-2b) |
+| 3 | 刪 hook/probe/sweep direct-write legacy path | Phase 2 (PR-2c) |
+| 4 | Trace retention 24h per-session TTL | Phase 2 |
+| 5 | Daemon restart frame / actor state replay | Phase 2 |
+| 6 | Trace viewer SPA UI（decision ports 流程圖）| PR-6b |
+| 7 | `AGENT_ARB_MODE=authoritative` 真 frame write（1b-1c 仍 fail-closed）| PR-2b |
+
+**#568 / #569 / #584 何時可關**：本 PR merge 後即可關。

--- a/internal/agent/probe/watchers.go
+++ b/internal/agent/probe/watchers.go
@@ -1,0 +1,309 @@
+package probe
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	agentpkg "github.com/wake/purdex/internal/agent"
+)
+
+// EvidenceRef is probe's lightweight key/value carrier for supporting
+// evidence attached to an Outcome. The Module layer maps this into
+// observation.EvidenceRef; probe intentionally does not import the
+// observation package to avoid a layering inversion.
+type EvidenceRef struct {
+	Key   string
+	Value any
+}
+
+// Outcome is the narrow string enum every Watcher reports through its
+// Callback.
+type Outcome string
+
+const (
+	OutcomeAlive            Outcome = "alive"
+	OutcomeDead             Outcome = "dead"
+	OutcomeActive           Outcome = "active"
+	OutcomeIdle             Outcome = "idle"
+	OutcomeShellPrompt      Outcome = "shell_prompt"
+	OutcomeReady            Outcome = "ready"
+	OutcomeError            Outcome = "error"
+	OutcomeIdentifyMismatch Outcome = "identify_mismatch"
+)
+
+// Kind tags which probe family produced the Outcome (matches probe_kind
+// evidence tag the apply pipeline / trace writer consume).
+type Kind string
+
+const (
+	KindLiveness  Kind = "liveness"
+	KindActivity  Kind = "activity"
+	KindReadiness Kind = "readiness"
+)
+
+// Spec is the minimal configuration a Watcher needs.
+type Spec struct {
+	Target    string // tmux target (e.g. "sess:")
+	AgentType string
+	// Interval lets tests override the poll cadence. Zero → default
+	// per-kind interval (500ms for liveness, 1s for readiness).
+	Interval time.Duration
+}
+
+// Callback is invoked by a Watcher every time an Outcome is produced.
+type Callback func(outcome Outcome, token string, evidence []EvidenceRef)
+
+// Watcher is the handle a Start* constructor returns.
+type Watcher interface {
+	Token() string
+	Rotate() string
+	Stop()
+}
+
+// LivenessChecker is the function the Watcher polls to decide whether
+// the agent process is still alive.
+type LivenessChecker func(agentType, target string) bool
+
+// ActivityStarter arms a one-shot StartWatch call on the underlying
+// Prober.
+type ActivityStarter func(target string, cb ActivityCallback)
+
+// ReadinessPoller polls the registered readiness checker.
+type ReadinessPoller func(agentType, target string) (ReadinessResult, bool)
+
+type baseWatcher struct {
+	tokenMu sync.RWMutex
+	token   string
+
+	cancel context.CancelFunc
+
+	doneOnce sync.Once
+}
+
+func newBaseWatcher(ctx context.Context) (*baseWatcher, context.Context) {
+	child, cancel := context.WithCancel(ctx)
+	return &baseWatcher{
+		token:  uuid.NewString(),
+		cancel: cancel,
+	}, child
+}
+
+func (w *baseWatcher) Token() string {
+	w.tokenMu.RLock()
+	defer w.tokenMu.RUnlock()
+	return w.token
+}
+
+func (w *baseWatcher) Rotate() string {
+	next := uuid.NewString()
+	w.tokenMu.Lock()
+	w.token = next
+	w.tokenMu.Unlock()
+	return next
+}
+
+func (w *baseWatcher) Stop() {
+	w.doneOnce.Do(func() {
+		w.cancel()
+	})
+}
+
+// StartLiveness spawns a goroutine that polls checker on spec.Interval
+// (default 500ms) and emits Outcome transitions (alive ⇄ dead).
+func StartLiveness(ctx context.Context, spec Spec, checker LivenessChecker, cb Callback) Watcher {
+	w, child := newBaseWatcher(ctx)
+	interval := spec.Interval
+	if interval <= 0 {
+		interval = 500 * time.Millisecond
+	}
+	go livenessLoop(child, w, spec, interval, checker, cb)
+	return w
+}
+
+func livenessLoop(ctx context.Context, w *baseWatcher, spec Spec, interval time.Duration, checker LivenessChecker, cb Callback) {
+	if checker == nil || cb == nil {
+		<-ctx.Done()
+		return
+	}
+	var last bool
+	var seeded bool
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	probeID := uuid.NewString()
+
+	fire := func(alive bool) {
+		outcome := OutcomeAlive
+		if !alive {
+			outcome = OutcomeDead
+		}
+		ev := []EvidenceRef{
+			{Key: "probe_id", Value: probeID},
+			{Key: "probe_kind", Value: string(KindLiveness)},
+		}
+		cb(outcome, w.Token(), ev)
+	}
+
+	check := func() {
+		alive := checker(spec.AgentType, spec.Target)
+		if !seeded {
+			seeded = true
+			last = alive
+			fire(alive)
+			return
+		}
+		if alive != last {
+			last = alive
+			fire(alive)
+		}
+	}
+
+	check()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			check()
+		}
+	}
+}
+
+// StartActivity wires a one-shot StartWatch loop into the Watcher
+// contract. Each time the inner callback fires, the Watcher translates
+// ActivitySignal → Outcome, forwards it, and re-arms the watch so the
+// caller sees continuous activity transitions.
+func StartActivity(ctx context.Context, spec Spec, starter ActivityStarter, stopper func(target string), cb Callback) Watcher {
+	w, child := newBaseWatcher(ctx)
+	go activityLoop(child, w, spec, starter, stopper, cb)
+	return w
+}
+
+func activityLoop(ctx context.Context, w *baseWatcher, spec Spec, starter ActivityStarter, stopper func(target string), cb Callback) {
+	if starter == nil || cb == nil {
+		<-ctx.Done()
+		return
+	}
+	probeID := uuid.NewString()
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		done := make(chan struct{})
+		starter(spec.Target, func(target string, signal ActivitySignal) {
+			defer close(done)
+			if ctx.Err() != nil {
+				return
+			}
+			outcome := OutcomeIdle
+			switch signal {
+			case ActivitySignalRunning:
+				outcome = OutcomeActive
+			case ActivitySignalIdle:
+				outcome = OutcomeIdle
+			case ActivitySignalShellPrompt:
+				outcome = OutcomeShellPrompt
+			}
+			ev := []EvidenceRef{
+				{Key: "probe_id", Value: probeID},
+				{Key: "probe_kind", Value: string(KindActivity)},
+				{Key: "activity_signal", Value: string(signal)},
+			}
+			cb(outcome, w.Token(), ev)
+		})
+		select {
+		case <-ctx.Done():
+			if stopper != nil {
+				stopper(spec.Target)
+			}
+			return
+		case <-done:
+			// loop again to re-arm the next StartWatch
+		}
+	}
+}
+
+// StartReadiness polls poller on spec.Interval (default 1s) and emits
+// Outcome transitions.
+func StartReadiness(ctx context.Context, spec Spec, poller ReadinessPoller, cb Callback) Watcher {
+	w, child := newBaseWatcher(ctx)
+	interval := spec.Interval
+	if interval <= 0 {
+		interval = time.Second
+	}
+	go readinessLoop(child, w, spec, interval, poller, cb)
+	return w
+}
+
+func readinessLoop(ctx context.Context, w *baseWatcher, spec Spec, interval time.Duration, poller ReadinessPoller, cb Callback) {
+	if poller == nil || cb == nil {
+		<-ctx.Done()
+		return
+	}
+	var last agentpkg.Status
+	var seeded bool
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	probeID := uuid.NewString()
+
+	statusToOutcome := func(status agentpkg.Status) Outcome {
+		switch status {
+		case agentpkg.StatusIdle:
+			return OutcomeIdle
+		case agentpkg.StatusRunning, agentpkg.StatusWaiting:
+			return OutcomeReady
+		case agentpkg.StatusError:
+			return OutcomeError
+		default:
+			return OutcomeIdle
+		}
+	}
+
+	fire := func(status agentpkg.Status) {
+		ev := []EvidenceRef{
+			{Key: "probe_id", Value: probeID},
+			{Key: "probe_kind", Value: string(KindReadiness)},
+			{Key: "readiness_status", Value: string(status)},
+		}
+		cb(statusToOutcome(status), w.Token(), ev)
+	}
+
+	check := func() {
+		res, ok := poller(spec.AgentType, spec.Target)
+		if !ok {
+			if !seeded {
+				seeded = true
+				fire(agentpkg.StatusIdle)
+			}
+			return
+		}
+		if !seeded {
+			seeded = true
+			last = res.Status
+			fire(res.Status)
+			return
+		}
+		if res.Status != last {
+			last = res.Status
+			fire(res.Status)
+		}
+	}
+
+	check()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			check()
+		}
+	}
+}

--- a/internal/agent/probe/watchers_test.go
+++ b/internal/agent/probe/watchers_test.go
@@ -1,0 +1,227 @@
+package probe_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/probe"
+)
+
+// TestLivenessWatcher_Start_FiresOutcome_WithStableToken verifies the initial
+// check fires an Outcome carrying the Watcher's current token, and that
+// repeated callbacks without Rotate() keep the same token.
+func TestLivenessWatcher_Start_FiresOutcome_WithStableToken(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	var tokens []string
+	var outcomes []probe.Outcome
+
+	spec := probe.Spec{Target: "sess:", AgentType: "cc", Interval: 20 * time.Millisecond}
+
+	var tick atomic.Int32
+	checker := func(at, tgt string) bool {
+		if at != "cc" || tgt != "sess:" {
+			t.Errorf("unexpected checker args: agentType=%q target=%q", at, tgt)
+		}
+		return tick.Add(1) < 2
+	}
+
+	w := probe.StartLiveness(ctx, spec, checker, func(outcome probe.Outcome, token string, _ []probe.EvidenceRef) {
+		mu.Lock()
+		tokens = append(tokens, token)
+		outcomes = append(outcomes, outcome)
+		mu.Unlock()
+	})
+	t.Cleanup(w.Stop)
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(outcomes)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(outcomes) < 2 {
+		t.Fatalf("expected >=2 outcomes, got %d", len(outcomes))
+	}
+	if outcomes[0] != probe.OutcomeAlive {
+		t.Fatalf("expected first outcome alive, got %q", outcomes[0])
+	}
+	if outcomes[1] != probe.OutcomeDead {
+		t.Fatalf("expected second outcome dead, got %q", outcomes[1])
+	}
+	if tokens[0] == "" {
+		t.Fatal("expected non-empty token on first callback")
+	}
+	if tokens[0] != tokens[1] {
+		t.Fatalf("expected stable token across callbacks without rotate, got %q then %q", tokens[0], tokens[1])
+	}
+	if tokens[0] != w.Token() {
+		t.Fatalf("watcher Token() %q does not match callback token %q", w.Token(), tokens[0])
+	}
+}
+
+// TestLivenessWatcher_Rotate_ReturnsNewToken_OldToken_BecomesInvalid: after
+// Rotate() the Watcher reports the new token to subsequent callbacks.
+func TestLivenessWatcher_Rotate_ReturnsNewToken_OldToken_BecomesInvalid(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var alive atomic.Bool
+	alive.Store(true)
+
+	var mu sync.Mutex
+	var tokens []string
+
+	spec := probe.Spec{Target: "sess:", AgentType: "cc", Interval: 15 * time.Millisecond}
+	w := probe.StartLiveness(ctx, spec, func(string, string) bool { return alive.Load() }, func(_ probe.Outcome, token string, _ []probe.EvidenceRef) {
+		mu.Lock()
+		tokens = append(tokens, token)
+		mu.Unlock()
+	})
+	t.Cleanup(w.Stop)
+
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(tokens)
+		mu.Unlock()
+		if n >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	original := w.Token()
+	newTok := w.Rotate()
+	if newTok == original {
+		t.Fatalf("Rotate returned the same token: %q", newTok)
+	}
+	if w.Token() != newTok {
+		t.Fatalf("Token() returned %q, expected rotated %q", w.Token(), newTok)
+	}
+
+	alive.Store(false)
+
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		last := ""
+		if len(tokens) > 0 {
+			last = tokens[len(tokens)-1]
+		}
+		mu.Unlock()
+		if last == newTok {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	t.Fatalf("expected a callback carrying rotated token %q, got tokens=%v", newTok, tokens)
+}
+
+// TestLivenessWatcher_Stop_Idempotent: calling Stop() multiple times must
+// not panic and subsequent callbacks must cease.
+func TestLivenessWatcher_Stop_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	spec := probe.Spec{Target: "sess:", AgentType: "cc", Interval: 10 * time.Millisecond}
+	var calls atomic.Int32
+	w := probe.StartLiveness(ctx, spec, func(string, string) bool { return true }, func(probe.Outcome, string, []probe.EvidenceRef) {
+		calls.Add(1)
+	})
+	time.Sleep(40 * time.Millisecond)
+	w.Stop()
+	w.Stop()
+	w.Stop()
+	before := calls.Load()
+	time.Sleep(60 * time.Millisecond)
+	after := calls.Load()
+	if after != before {
+		t.Fatalf("expected no further callbacks after Stop; before=%d after=%d", before, after)
+	}
+}
+
+// TestActivityWatcher_Start_FiresOnActivity verifies that an ActivitySignal
+// gets translated into an OutcomeActive event through the callback.
+func TestActivityWatcher_Start_FiresOnActivity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var called sync.WaitGroup
+	called.Add(1)
+	var mu sync.Mutex
+	var outcomes []probe.Outcome
+
+	var starterInvoked atomic.Int32
+	starter := func(target string, cb probe.ActivityCallback) {
+		starterInvoked.Add(1)
+		if target != "sess:" {
+			t.Errorf("unexpected target: %q", target)
+		}
+		signal := probe.ActivitySignalRunning
+		if starterInvoked.Load() > 1 {
+			signal = probe.ActivitySignalIdle
+		}
+		go cb(target, signal)
+	}
+
+	w := probe.StartActivity(ctx, probe.Spec{Target: "sess:", AgentType: "cc"}, starter, nil, func(outcome probe.Outcome, _ string, _ []probe.EvidenceRef) {
+		mu.Lock()
+		outcomes = append(outcomes, outcome)
+		mu.Unlock()
+		if outcome == probe.OutcomeActive {
+			called.Done()
+		}
+	})
+	t.Cleanup(w.Stop)
+
+	done := make(chan struct{})
+	go func() { called.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected OutcomeActive within 500ms")
+	}
+}
+
+// TestReadinessWatcher_Start_FiresOnReady verifies that a registered
+// ReadinessPoller returning StatusRunning results in OutcomeReady.
+func TestReadinessWatcher_Start_FiresOnReady(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var called sync.WaitGroup
+	called.Add(1)
+
+	poller := func(agentType, target string) (probe.ReadinessResult, bool) {
+		return probe.ReadinessResult{Status: agentpkg.StatusRunning}, true
+	}
+
+	w := probe.StartReadiness(ctx, probe.Spec{Target: "sess:", AgentType: "cc", Interval: 10 * time.Millisecond}, poller, func(outcome probe.Outcome, _ string, _ []probe.EvidenceRef) {
+		if outcome == probe.OutcomeReady {
+			called.Done()
+		}
+	})
+	t.Cleanup(w.Stop)
+
+	done := make(chan struct{})
+	go func() { called.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected OutcomeReady within 500ms")
+	}
+}

--- a/internal/module/agent/arbitrator/apply.go
+++ b/internal/module/agent/arbitrator/apply.go
@@ -1,11 +1,16 @@
 package arbitrator
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/module/agent/arbmode"
 	"github.com/wake/purdex/internal/module/agent/observation"
+	"github.com/wake/purdex/internal/store"
 )
 
 // actionSessionStart is the canonical Action string a hook Observation uses
@@ -29,6 +34,18 @@ const actionSessionGenerationAdvanced = "session.generation_advanced"
 // observations that end a displaced primary actor (spec §3.4.1 #6 example).
 const endReasonReplacedByNewPrimary = "replaced_by_new_primary"
 
+// primaryActorPrefix gates the divergence writer: only observations whose
+// Proposal.ActorKey.ActorID begins with this prefix are projected onto the
+// legacy Frame schema. Subagent / proxy actors need Phase-2 frame schema
+// fields to project faithfully; see D5.2 / Non-Goals.
+const primaryActorPrefix = "primary:"
+
+// reasonRoleTerminalUnresolved is the ReasonCode emitted when a hook or
+// probe reports role_resolution == RoleTerminalUnresolved — the role
+// cannot be determined and retry is pointless. The observation is dropped
+// with a trace but never added to pending.
+const reasonRoleTerminalUnresolved = "RoleTerminalUnresolved"
+
 // ArbmodeView is the narrow subset of arbmode.Manager that the apply
 // pipeline needs. Task 8 wires *arbmode.Manager directly; tests supply a
 // fake that records ApplyAtSessionStart calls.
@@ -41,12 +58,32 @@ type ArbmodeView interface {
 	ApplyAtSessionStart()
 }
 
+// DivergencesWriter is the narrow contract for writing divergence rows from
+// the apply pipeline. Only the primary-actor passthrough branch exercises
+// it; tests provide fakes that capture inserts for assertion.
+type DivergencesWriter interface {
+	Insert(row store.FrameDivergence) (int64, error)
+}
+
+// LegacyFramesView is the read-side projection of FramesStore the apply
+// pipeline needs to compare a proposal against the existing legacy frame.
+// Only GetByIdentity is used; future PR-2 work may widen the interface.
+type LegacyFramesView interface {
+	GetByIdentity(paneID string, pid int, startTime string) (*store.Frame, error)
+}
+
 // applyDeps is the full dependency bundle for the apply pipeline. Task 7's
 // Arbitrator struct holds and constructs one; tests build one directly with
 // hand-rolled fakes.
 //
 // All fields are required unless noted; nil fields cause panics on first use
 // (apply() is single-owner and never invoked before Arbitrator wiring).
+//
+// sampler, divergences, legacyFrames are new in PR-1b-1c T5; nil values are
+// tolerated (sampler=nil degenerates to always-emit; divergences/legacyFrames
+// nil skips the passthrough divergence write path silently). The tolerant
+// behaviour lets Stage 3 wiring reach production before every call site is
+// updated.
 type applyDeps struct {
 	frames          *frameState
 	pending         *pendingStore
@@ -55,6 +92,9 @@ type applyDeps struct {
 	minter          observation.TraceIDMinter
 	arbmode         ArbmodeView
 	traceSubmit     TraceSubmitter
+	sampler         *sampler
+	divergences     DivergencesWriter
+	legacyFrames    LegacyFramesView
 	now             func() time.Time
 	pendingDeadline time.Duration
 	perSessionCap   int
@@ -107,12 +147,23 @@ func (d *applyDeps) apply(obs observation.Observation) {
 		return
 	}
 
-	// Step 4 — Pending routing. Sweep obs targeting a still-pending actor
-	// stash onto the pending entry without falling through to apply.
-	if d.routeToPendingIfSweepStashing(obs) {
+	// Step 4 — Pending routing (role-based). Sweep-override keeps stashing
+	// sweep proposals onto still-pending entries; role_resolution drives
+	// the hook/probe branches.
+	if d.routeToPendingIfUnresolved(obs) {
 		return
 	}
 
+	// Steps 5-9 run for any observation that reached this point.
+	d.applyResolvedProposal(obs)
+}
+
+// applyResolvedProposal runs steps 5-9 (source priority, monotone lifecycle,
+// single-primary, mode branch, trace emit + divergence). It is invoked
+// from the main apply() path AND from tryPromoteFromEntry when a pending
+// observation is promoted; the pending path has already cleared steps 0-4
+// (idempotency + pending routing), so re-running them would double-count.
+func (d *applyDeps) applyResolvedProposal(obs observation.Observation) {
 	// Step 5 — Source priority.
 	if !d.checkSourcePriority(obs) {
 		return
@@ -130,10 +181,12 @@ func (d *applyDeps) apply(obs observation.Observation) {
 	// Step 8 — Mode branch (defensive). Authoritative is already rejected
 	// at step 0b; the branch here is a belt-and-braces guard against
 	// unknown modes slipping past the pre-gate. Passthrough falls through
-	// to step 9 (trace emission).
+	// to step 9 (trace emission), but first writes a divergence row if the
+	// proposal diverges from the legacy frame (D5.2; primary-only).
 	if !d.applyModeBranch(obs) {
 		return
 	}
+	d.writeDivergenceIfAny(obs)
 
 	// Step 9 — Emit accepted trace.
 	d.emitAcceptedTrace(obs)
@@ -168,13 +221,21 @@ func (d *applyDeps) checkGenerationGate(obs observation.Observation) bool {
 
 // applySessionStart is the D5b boundary helper. It bumps the session's
 // generation, ends old-gen actors, clears stale pending observations,
-// rotates the trace_id watermark, consumes any published arbmode pending,
-// and emits a synthetic boundary trace.
+// adopts the hook-provisioned trace_id for the new (session, gen), prunes
+// the trace_id watermark, consumes any published arbmode pending, clears
+// the sampler's per-session counter, and emits a synthetic boundary trace.
 //
 // All frameState mutations (read oldGen, end old-gen actors, advance
 // generation) go through locked frameState methods. GenerationOf is read
 // before the end-old-gen path so the oldGen snapshot is consistent with the
 // value that forceEndOldGenActors will filter on.
+//
+// AdoptTraceID replaces the former Mint call: the hook-side builder mints
+// a provisional UUID that propagates into the apply pipeline as
+// obs.TraceID; AdoptTraceID binds that seed to the (session, newGen) slot
+// so downstream Lookup.Get calls return the same trace_id that Observation.
+// TraceID already carries. Replay of the same SessionStart observation is
+// idempotent: the registry returns the existing id and discards the seed.
 func (d *applyDeps) applySessionStart(obs observation.Observation) {
 	sid := obs.SessionID
 	newGen := obs.ObservedGeneration
@@ -195,11 +256,12 @@ func (d *applyDeps) applySessionStart(obs observation.Observation) {
 	// Step 1 — bump generation after stashing oldGen side-effects.
 	d.frames.SetGeneration(sid, newGen)
 
-	// Step 5 — mint the new generation's trace_id. The returned id becomes
-	// the authoritative tag for every boundary-synthesis event emitted for
-	// this new generation; obs.TraceID still carries the *incoming* hook's
-	// trace-id which is stale relative to the newly bumped generation.
-	newTraceID := d.minter.Mint(sid, newGen)
+	// Step 5 — adopt the hook-provisioned trace_id for (sid, newGen). The
+	// returned id becomes the authoritative tag for every boundary-synthesis
+	// event emitted for this new generation. On replay of an identical
+	// SessionStart, AdoptTraceID returns the previously-adopted id (seed
+	// discarded), preserving chain correlation across retries.
+	adoptedTraceID := d.minter.AdoptTraceID(sid, newGen, obs.TraceID)
 
 	// Step 6 — prune any trace_id entries for generations below newGen.
 	d.minter.PruneSessionBefore(sid, newGen)
@@ -207,11 +269,18 @@ func (d *applyDeps) applySessionStart(obs observation.Observation) {
 	// Step 7 — consume the latest published arbmode target.
 	d.arbmode.ApplyAtSessionStart()
 
-	// Step 8 — emit synthetic boundary trace stamped with the newly minted
-	// trace_id (not obs.TraceID which is from the old generation's trace
-	// chain). Empty trace_id would trip validateLightsRow and poison the
-	// whole flush batch.
-	d.emitBoundaryTrace(obs, newGen, newTraceID, len(endedActors), clearedPending)
+	// Step 7b — reset the sampler's per-session counter so the first sweep
+	// of the new generation always emits. No-op when sampler is nil (tests
+	// that do not exercise sampling).
+	if d.sampler != nil {
+		d.sampler.ClearSession(sid)
+	}
+
+	// Step 8 — emit synthetic boundary trace stamped with the newly adopted
+	// trace_id (identical to obs.TraceID when this is a fresh SessionStart).
+	// Empty trace_id would trip validateLightsRow and poison the whole
+	// flush batch.
+	d.emitBoundaryTrace(obs, newGen, adoptedTraceID, len(endedActors), clearedPending)
 }
 
 // checkWatcher verifies a probe observation's WatcherToken matches the
@@ -253,23 +322,145 @@ func (d *applyDeps) checkIdempotency(obs observation.Observation) bool {
 	return false
 }
 
-// routeToPendingIfSweepStashing stashes a sweep observation onto an
-// existing pending entry, short-circuiting the rest of apply. Non-sweep
-// sources always proceed; sweep obs against non-pending actors also
-// proceed (they may create a new actor through normal apply).
-func (d *applyDeps) routeToPendingIfSweepStashing(obs observation.Observation) (stashed bool) {
-	if obs.SourceKind != observation.SourceSweep {
+// routeToPendingIfUnresolved is the PR-1b-1c replacement for the former
+// sweep-only routeToPendingIfSweepStashing helper. It keeps the sweep
+// override (sweep observations targeting a still-pending actor coalesce
+// onto that entry) and adds role-based routing driven by role_resolution
+// evidence (D4.1 / D4.2):
+//
+//   - RoleRetryableUnresolved: stash into pending as first entry or coalesce.
+//     No retry scheduler is wired in this PR (Non-Goals); pending entries
+//     are driven by flushPendingDue deadline drop + coalesce-on-arrival
+//     promote.
+//   - RoleTerminalUnresolved: emit a trace-only rejection (reason code
+//     "RoleTerminalUnresolved") and drop — never added to pending.
+//   - RoleResolved + actor already pending: coalesce onto existing entry
+//     and trigger tryPromoteToActorNow to shorten latency (avoid waiting
+//     for the reconcile tick).
+//   - RoleResolved + actor NOT pending: proceed through the rest of apply.
+//   - Missing role_resolution key: malformed observation — fall through
+//     to normal apply (not stashed). The builder layer guarantees the
+//     key is present for hook/probe/sweep in Stage 3; this branch is a
+//     conservative default for legacy test observations.
+//
+// Returns true when the observation was stashed (or terminally dropped with
+// a trace) so apply() can short-circuit steps 5-9.
+func (d *applyDeps) routeToPendingIfUnresolved(obs observation.Observation) (stashed bool) {
+	// Existing sweep override — keep. Sweep observations can land on a
+	// pending entry regardless of role_resolution because sweep semantics
+	// are always "pid state suggests end"; the pending entry itself came
+	// from a hook/probe that could not resolve the role.
+	if obs.SourceKind == observation.SourceSweep && d.pending.isPending(obs.Proposal.ActorKey) {
+		d.pending.addPending(obs, d.now(), d.pendingDeadline, d.perSessionCap, d.perEntryObsCap, func(entry *PendingEntry, _ string) {
+			for _, pObs := range entry.Observations {
+				d.emitRejectedTrace(pObs, ReasonPendingEvicted, "pending evicted due to per-session cap")
+			}
+		})
+		return true
+	}
+
+	state, ok := observation.RoleResolutionFromEvidence(obs.Evidence)
+	if !ok {
+		// No role_resolution key → legacy / malformed; fall through.
 		return false
 	}
-	if !d.pending.isPending(obs.Proposal.ActorKey) {
-		return false
-	}
-	d.pending.addPending(obs, d.now(), d.pendingDeadline, d.perSessionCap, d.perEntryObsCap, func(entry *PendingEntry, _ string) {
-		for _, pObs := range entry.Observations {
-			d.emitRejectedTrace(pObs, ReasonPendingEvicted, "pending evicted due to per-session cap")
+
+	switch state {
+	case observation.RoleRetryableUnresolved:
+		d.pending.addPending(obs, d.now(), d.pendingDeadline, d.perSessionCap, d.perEntryObsCap, func(entry *PendingEntry, _ string) {
+			for _, pObs := range entry.Observations {
+				d.emitRejectedTrace(pObs, ReasonPendingEvicted, "pending evicted due to per-session cap")
+			}
+		})
+		// TODO(retry-scheduler, post-1b-1c): scheduleRetry([100ms, 250ms,
+		// 500ms]) — deferred. Promote path is deadline flush +
+		// coalesce-on-arrival only.
+		return true
+
+	case observation.RoleTerminalUnresolved:
+		// Terminal unresolved: emit trace-only rejection and drop.
+		d.emitTraceOnly(obs, reasonRoleTerminalUnresolved, "role cannot be resolved (terminal)")
+		return true
+
+	case observation.RoleResolved:
+		// If the actor is already pending, coalesce + try to promote now so
+		// a fresh positive signal short-circuits the deadline wait.
+		if d.pending.isPending(obs.Proposal.ActorKey) {
+			d.pending.addPending(obs, d.now(), d.pendingDeadline, d.perSessionCap, d.perEntryObsCap, func(entry *PendingEntry, _ string) {
+				for _, pObs := range entry.Observations {
+					d.emitRejectedTrace(pObs, ReasonPendingEvicted, "pending evicted due to per-session cap")
+				}
+			})
+			_ = d.tryPromoteToActorNow(obs.Proposal.ActorKey)
+			return true
 		}
-	})
+		// Not pending — fall through to normal apply.
+		return false
+	}
+
+	// Unknown state: defensive fall-through.
+	return false
+}
+
+// tryPromoteFromEntry inspects pendingEntry.Observations for a winning
+// positive signal (RoleResolved + meaningful proposal). On success it runs
+// apply steps 5-9 on the winner and returns true so the caller can clean
+// up the pending entry. See D4.3 for the full contract.
+//
+// No-signal entries return false; flushPendingDue then emits the deadline
+// drop trace. "Resolved but empty proposal" also returns false — an empty
+// proposal offers no frame state to project, so promoting it would just
+// thrash the actor.
+func (d *applyDeps) tryPromoteFromEntry(entry *PendingEntry) bool {
+	if entry == nil || len(entry.Observations) == 0 {
+		return false
+	}
+	// Scan newest → oldest for the first RoleResolved observation.
+	var winner *observation.Observation
+	for i := len(entry.Observations) - 1; i >= 0; i-- {
+		obs := &entry.Observations[i]
+		if state, ok := observation.RoleResolutionFromEvidence(obs.Evidence); ok && state == observation.RoleResolved {
+			winner = obs
+			break
+		}
+	}
+	if winner == nil {
+		return false
+	}
+	// Must carry a meaningful proposal — empty proposals cannot drive
+	// frame projection.
+	if winner.Proposal.SuggestStatus == "" && !winner.Proposal.EndLifecycle {
+		return false
+	}
+	d.applyResolvedProposal(*winner)
 	return true
+}
+
+// tryPromoteToActorNow is the latency-shortening helper invoked from the
+// routeToPendingIfUnresolved RoleResolved branch. It looks up the current
+// pending entry for actorKey and calls tryPromoteFromEntry; on success the
+// entry is removed so subsequent flushPendingDue ticks skip it.
+//
+// Returns true when promotion fired + cleanup happened; false when no
+// pending entry exists or promotion was declined.
+func (d *applyDeps) tryPromoteToActorNow(actorKey observation.ActorKey) bool {
+	entry, ok := d.pending.entries[actorKey]
+	if !ok {
+		return false
+	}
+	if !d.tryPromoteFromEntry(entry) {
+		return false
+	}
+	delete(d.pending.entries, actorKey)
+	return true
+}
+
+// emitTraceOnly emits a rejected trace for an observation that has been
+// classified as terminal unresolved (or any "drop with note" case we want
+// to surface). It is a thin wrapper around emitRejectedTrace with a
+// canonical reason code.
+func (d *applyDeps) emitTraceOnly(obs observation.Observation, reasonCode, reasonText string) {
+	d.emitRejectedTrace(obs, reasonCode, reasonText)
 }
 
 // checkSourcePriority enforces the source-priority order
@@ -443,6 +634,9 @@ func (d *applyDeps) emitAcceptedTrace(obs observation.Observation) {
 		Seq:                obs.Seq,
 		DropPriority:       dropPriority(obs.SourceKind, phase),
 	}
+	if !d.sampleAllowEmit(obs.SessionID, obs.SourceKind, phase) {
+		return
+	}
 	d.traceSubmit.Submit(r)
 }
 
@@ -477,7 +671,31 @@ func (d *applyDeps) emitRejectedTrace(obs observation.Observation, reasonCode, r
 		Seq:                obs.Seq,
 		DropPriority:       dropPriority(obs.SourceKind, observation.PhaseRejected),
 	}
+	// Rejected traces bypass sampling: they are diagnostic signal and the
+	// sweep/synthetic PhaseRejected volume is driven by external events
+	// (session restart clears pending, actor-ended rejects, ...) rather
+	// than the high-frequency sweep accept path that sampling targets.
 	d.traceSubmit.Submit(r)
+}
+
+// sampleAllowEmit consults the sampler (if wired) to decide whether a
+// trace for (sessionID, sourceKind, phase) should be emitted. Records
+// that are dropped bump lights_trace_sampled_dropped with canonical tags.
+// When the sampler is nil the call always allows — Stage 3 will wire the
+// sampler into Arbitrator construction.
+func (d *applyDeps) sampleAllowEmit(sessionID string, sourceKind observation.SourceKind, phase observation.ObsPhase) bool {
+	if d.sampler == nil {
+		return true
+	}
+	if d.sampler.ShouldEmit(sessionID, sourceKind, phase) {
+		return true
+	}
+	Inc("lights_trace_sampled_dropped",
+		"source="+string(sourceKind),
+		"phase="+string(phase),
+		"session="+sessionID,
+	)
+	return false
 }
 
 // emitBoundaryTrace submits the synthetic "session.generation_advanced"
@@ -538,6 +756,173 @@ func (d *applyDeps) emitSyntheticReplacedPrimaryTrace(obs observation.Observatio
 		},
 	}
 	d.traceSubmit.Submit(r)
+}
+
+// writeDivergenceIfAny is the D5.2 passthrough-only helper that compares an
+// accepted proposal's projection against the legacy FramesStore frame and
+// writes a frame_divergences row when they diverge. It never writes when
+// any gate fails (non-primary actor, identity triple missing, legacy frame
+// missing); those paths bump per-reason metrics so operators can spot
+// missing identity data without silent divergence loss.
+//
+// Only primary actors are projected in Phase 1 — subagent / proxy
+// projection requires the Phase-2 frame schema (Actors JSON). See plan
+// D5.2 / Non-Goals.
+//
+// Divergence write failure is logged via metrics but does NOT fail apply;
+// passthrough is an observability layer and must not block the legacy
+// path's side-effects.
+func (d *applyDeps) writeDivergenceIfAny(obs observation.Observation) {
+	if d.divergences == nil || d.legacyFrames == nil {
+		// Deps not wired yet (early bring-up); silent no-op until Stage 3.
+		return
+	}
+	if obs.Proposal.ActorKey.ActorID == "" {
+		return
+	}
+	if !strings.HasPrefix(obs.Proposal.ActorKey.ActorID, primaryActorPrefix) {
+		Inc("lights_divergence_non_primary_skipped", "actor_kind="+actorKindOf(obs.Proposal.ActorKey.ActorID))
+		return
+	}
+
+	paneID, panePresent := evidenceString(obs.Evidence, "pane_id")
+	pid, pidPresent := evidenceInt64(obs.Evidence, "pid")
+	startTime, stPresent := evidenceString(obs.Evidence, "start_time")
+	if !panePresent || !pidPresent || !stPresent {
+		Inc("lights_divergence_identity_missing", "source="+string(obs.SourceKind))
+		return
+	}
+
+	legacyFrame, err := d.legacyFrames.GetByIdentity(paneID, int(pid), startTime)
+	if err != nil || legacyFrame == nil {
+		Inc("lights_divergence_legacy_missing")
+		return
+	}
+
+	projected := projectProposalToLegacy(obs.Proposal, *legacyFrame)
+	if framesMatch(projected, *legacyFrame) {
+		Inc("lights_divergence_total", "matched=1")
+		return
+	}
+
+	_, _ = d.divergences.Insert(store.FrameDivergence{
+		SessionID:          obs.SessionID,
+		TraceID:            obs.TraceID,
+		EventID:            obs.SpanID,
+		ObservedGeneration: obs.ObservedGeneration,
+		OldStateRef:        mustJSON(legacyFrame),
+		ProposalStateRef:   mustJSON(projected),
+		DiffSummary:        humanDiff(*legacyFrame, projected),
+		Matched:            false,
+		ReasonCode:         obs.ReasonCode,
+		CreatedAt:          d.now().UnixNano(),
+	})
+	Inc("lights_divergence_total", "matched=0")
+}
+
+// projectProposalToLegacy overlays a StateProposal onto a copy of the
+// legacy Frame, producing the "what legacy should look like if we accepted
+// this proposal" projection. Only status + end lifecycle fields are
+// overlaid in Phase 1; subagent / proxy projection requires Phase-2 frame
+// schema changes (D5.2 / Non-Goals).
+//
+// SuggestStatus is mapped directly to Frame.Status as an agent.Status
+// (strings are interchangeable via the Status type alias). EndLifecycle
+// triggers a terminal "ended" status.
+func projectProposalToLegacy(proposal observation.StateProposal, legacy store.Frame) store.Frame {
+	projected := legacy
+	if proposal.EndLifecycle {
+		projected.Status = agentpkg.Status("ended")
+		return projected
+	}
+	if proposal.SuggestStatus != "" {
+		projected.Status = agentpkg.Status(proposal.SuggestStatus)
+	}
+	return projected
+}
+
+// framesMatch reports whether two frames agree on the fields the divergence
+// writer cares about (status, end lifecycle derived from ended state).
+// Identity fields (pane_id, pid, start_time) are skipped because the
+// writer already queried by identity; trace_id / updated_at would create
+// spurious mismatches.
+func framesMatch(a, b store.Frame) bool {
+	return a.Status == b.Status
+}
+
+// humanDiff produces a compact, human-readable diff summary for a
+// FrameDivergence.DiffSummary column. Phase 1 only surfaces the fields
+// framesMatch considers, plus agent_type for context. Output fits on one
+// line.
+func humanDiff(old, proposed store.Frame) string {
+	return fmt.Sprintf("status: %q->%q", string(old.Status), string(proposed.Status))
+}
+
+// actorKindOf extracts the actor kind prefix from an ActorID
+// ("primary:cc" → "primary", "subagent:task-1" → "subagent",
+// "proxy:foo" → "proxy"). Unknown prefixes return "unknown" so metric
+// cardinality stays bounded.
+func actorKindOf(actorID string) string {
+	switch {
+	case strings.HasPrefix(actorID, "primary:"):
+		return "primary"
+	case strings.HasPrefix(actorID, "subagent:"):
+		return "subagent"
+	case strings.HasPrefix(actorID, "proxy:"):
+		return "proxy"
+	default:
+		return "unknown"
+	}
+}
+
+// evidenceString scans ev for the first EvidenceRef whose Key matches and
+// whose Value is a string. Returns (value, true) on hit; ("", false)
+// otherwise — callers use the boolean to drive the identity-triple gate.
+func evidenceString(ev []observation.EvidenceRef, key string) (string, bool) {
+	for _, e := range ev {
+		if e.Key != key {
+			continue
+		}
+		if s, ok := e.Value.(string); ok {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+// evidenceInt64 scans ev for the first EvidenceRef whose Key matches and
+// whose Value is convertible to int64 (int, int32, int64, float64 for
+// JSON-round-tripped numerics). Returns (value, true) on hit; (0, false)
+// otherwise.
+func evidenceInt64(ev []observation.EvidenceRef, key string) (int64, bool) {
+	for _, e := range ev {
+		if e.Key != key {
+			continue
+		}
+		switch v := e.Value.(type) {
+		case int64:
+			return v, true
+		case int:
+			return int64(v), true
+		case int32:
+			return int64(v), true
+		case float64:
+			return int64(v), true
+		}
+	}
+	return 0, false
+}
+
+// mustJSON marshals v to json.RawMessage; on error it returns the bytes
+// "null" so the divergence row's NOT NULL constraint is never violated.
+// The error is silently dropped — divergence writes are observability
+// only and a marshalling failure should not cascade.
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return json.RawMessage("null")
+	}
+	return b
 }
 
 // extractProbeID returns the value of the Evidence entry with Key "probe_id"

--- a/internal/module/agent/arbitrator/apply.go
+++ b/internal/module/agent/arbitrator/apply.go
@@ -142,15 +142,19 @@ func (d *applyDeps) apply(obs observation.Observation) {
 // checkGenerationGate guards against stale-generation observations and
 // routes SessionStart through applySessionStart. Returns true when apply
 // should proceed to step 2.
+//
+// Reads the current generation through GenerationOf so the RWMutex
+// protection covers cross-goroutine readers (Arbitrator.CurrentGeneration
+// producers) that may be racing against the apply writer.
 func (d *applyDeps) checkGenerationGate(obs observation.Observation) bool {
-	sg := d.frames.getOrCreateSession(obs.SessionID)
+	current := d.frames.GenerationOf(obs.SessionID)
 	switch {
-	case obs.ObservedGeneration < sg.Generation:
+	case obs.ObservedGeneration < current:
 		d.emitRejectedTrace(obs, ReasonStaleGeneration, "observation from older generation")
 		return false
-	case obs.ObservedGeneration == sg.Generation:
+	case obs.ObservedGeneration == current:
 		return true
-	default: // obs.ObservedGeneration > sg.Generation
+	default: // obs.ObservedGeneration > current
 		if obs.SourceKind == observation.SourceHook && obs.Action == actionSessionStart {
 			d.applySessionStart(obs)
 			// SessionStart is fully handled by the helper; do not fall
@@ -166,11 +170,15 @@ func (d *applyDeps) checkGenerationGate(obs observation.Observation) bool {
 // generation, ends old-gen actors, clears stale pending observations,
 // rotates the trace_id watermark, consumes any published arbmode pending,
 // and emits a synthetic boundary trace.
+//
+// All frameState mutations (read oldGen, end old-gen actors, advance
+// generation) go through locked frameState methods. GenerationOf is read
+// before the end-old-gen path so the oldGen snapshot is consistent with the
+// value that forceEndOldGenActors will filter on.
 func (d *applyDeps) applySessionStart(obs observation.Observation) {
 	sid := obs.SessionID
 	newGen := obs.ObservedGeneration
-	sg := d.frames.getOrCreateSession(sid)
-	oldGen := sg.Generation
+	oldGen := d.frames.GenerationOf(sid)
 	now := d.now()
 
 	// Steps 2-3 — end old-gen actors (clears WatcherTokens in the process).
@@ -185,7 +193,7 @@ func (d *applyDeps) applySessionStart(obs observation.Observation) {
 	})
 
 	// Step 1 — bump generation after stashing oldGen side-effects.
-	sg.Generation = newGen
+	d.frames.SetGeneration(sid, newGen)
 
 	// Step 5 — mint the new generation's trace_id. The returned id becomes
 	// the authoritative tag for every boundary-synthesis event emitted for

--- a/internal/module/agent/arbitrator/apply_test.go
+++ b/internal/module/agent/arbitrator/apply_test.go
@@ -2,12 +2,15 @@ package arbitrator
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
+	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/module/agent/arbmode"
 	"github.com/wake/purdex/internal/module/agent/observation"
+	"github.com/wake/purdex/internal/store"
 )
 
 // ----- Test fakes ----------------------------------------------------------
@@ -117,21 +120,75 @@ func (f *fakeArbmode) Snapshot() arbmode.Snapshot {
 
 func (f *fakeArbmode) ApplyAtSessionStart() { f.applyAtStartCalls++ }
 
+// ----- Divergence + legacy frames fakes (T5) ------------------------------
+
+// fakeDivergencesWriter records every Insert call so tests can assert both
+// the call count (primary-only gate passes) and the row shape (Matched,
+// DiffSummary, OldStateRef, ProposalStateRef). The fake never returns an
+// error; tests that want to simulate store failures can swap in a custom
+// DivergencesWriter.
+type fakeDivergencesWriter struct {
+	inserts []store.FrameDivergence
+	nextErr error
+}
+
+func (f *fakeDivergencesWriter) Insert(row store.FrameDivergence) (int64, error) {
+	f.inserts = append(f.inserts, row)
+	if f.nextErr != nil {
+		return 0, f.nextErr
+	}
+	return int64(len(f.inserts)), nil
+}
+
+// fakeLegacyFramesView lets tests pre-seed the frame state the divergence
+// writer will compare against. Key is the (paneID, pid, startTime) triple
+// serialized via fakeLegacyKey so tests can use struct literals.
+type fakeLegacyFramesView struct {
+	frames map[fakeLegacyKey]*store.Frame
+	err    error
+}
+
+type fakeLegacyKey struct {
+	PaneID    string
+	PID       int
+	StartTime string
+}
+
+func (f *fakeLegacyFramesView) set(paneID string, pid int, startTime string, frame *store.Frame) {
+	if f.frames == nil {
+		f.frames = make(map[fakeLegacyKey]*store.Frame)
+	}
+	f.frames[fakeLegacyKey{PaneID: paneID, PID: pid, StartTime: startTime}] = frame
+}
+
+func (f *fakeLegacyFramesView) GetByIdentity(paneID string, pid int, startTime string) (*store.Frame, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if fr, ok := f.frames[fakeLegacyKey{PaneID: paneID, PID: pid, StartTime: startTime}]; ok {
+		return fr, nil
+	}
+	return nil, nil
+}
+
 // ----- Test harness --------------------------------------------------------
 
 // applyHarness builds a fully-wired applyDeps with sensible defaults for
 // passthrough-mode tests. Individual tests can override fields on the
 // returned struct before invoking apply.
 type applyHarness struct {
-	deps       *applyDeps
-	now        time.Time
-	trace      *fakeTraceSubmitter
-	minter     *fakeMinter
-	arbmodeFk  *fakeArbmode
-	stormGuard *hookStormGuard
-	idem       *idemCache
-	pending    *pendingStore
-	frames     *frameState
+	deps         *applyDeps
+	now          time.Time
+	trace        *fakeTraceSubmitter
+	minter       *fakeMinter
+	arbmodeFk    *fakeArbmode
+	stormGuard   *hookStormGuard
+	idem         *idemCache
+	pending      *pendingStore
+	frames       *frameState
+	sampler      *sampler
+	divergences  *fakeDivergencesWriter
+	legacyFrames *fakeLegacyFramesView
 }
 
 func newApplyHarness(t *testing.T) *applyHarness {
@@ -146,6 +203,9 @@ func newApplyHarness(t *testing.T) *applyHarness {
 	h.idem = newIdemCache(func() time.Time { return h.now })
 	h.pending = newPendingStore()
 	h.frames = newFrameState()
+	h.sampler = newSampler()
+	h.divergences = &fakeDivergencesWriter{}
+	h.legacyFrames = &fakeLegacyFramesView{}
 	h.deps = &applyDeps{
 		frames:          h.frames,
 		pending:         h.pending,
@@ -154,6 +214,9 @@ func newApplyHarness(t *testing.T) *applyHarness {
 		minter:          h.minter,
 		arbmode:         h.arbmodeFk,
 		traceSubmit:     h.trace,
+		sampler:         h.sampler,
+		divergences:     h.divergences,
+		legacyFrames:    h.legacyFrames,
 		now:             func() time.Time { return h.now },
 		pendingDeadline: 200 * time.Millisecond,
 		perSessionCap:   8,
@@ -1160,22 +1223,23 @@ func TestApply_AuthoritativeMode_DoesNotAdvancePrimary(t *testing.T) {
 	}
 }
 
-// ----- C1: Boundary trace carries newly minted trace_id -------------------
+// ----- C1: Boundary trace carries adopted trace_id ------------------------
 
-// TestApplySessionStart_BoundaryTraceUsesNewlyMintedTraceID verifies that
-// the synthetic session.generation_advanced boundary trace is tagged with
-// the trace_id returned from minter.Mint for the new generation — NOT the
-// incoming obs.TraceID, which belongs to the prior (pre-advance) chain.
-// An empty TraceID would make validateLightsRow reject the whole batch
-// during flush.
-func TestApplySessionStart_BoundaryTraceUsesNewlyMintedTraceID(t *testing.T) {
+// TestApplySessionStart_BoundaryTraceUsesAdoptedTraceID verifies that the
+// synthetic session.generation_advanced boundary trace is tagged with the
+// trace_id returned from minter.AdoptTraceID — which, for a fresh
+// (session, gen) slot, equals the seed taken from obs.TraceID (a
+// provisional UUID minted hook-side, per D1.2). Prior to PR-1b-1c the
+// boundary id came from minter.Mint, but T5 rewired the binding so the
+// hook-provided id is authoritative and Observation.TraceID / hook chain
+// trace_id / boundary trace_id all correlate without a registry round-trip.
+func TestApplySessionStart_BoundaryTraceUsesAdoptedTraceID(t *testing.T) {
 	h := newApplyHarness(t)
-	h.minter.nextMintID = "NEW_UUID_FROM_MINTER"
 	h.frames.getOrCreateSession("s1").Generation = 3
 
-	// Incoming hook carries a stale trace_id from the old chain.
+	// Incoming hook carries a provisional UUID (hook-side mint from T6).
 	obs := h.obsBuilder().withSession("s1", 4).hook().withAction(actionSessionStart).
-		withTrace("STALE_TRACE_FROM_OLD_GEN").build()
+		withTrace("HOOK_PROVISIONAL_UUID").build()
 	h.deps.apply(obs)
 
 	var boundary *TraceRecord
@@ -1188,8 +1252,8 @@ func TestApplySessionStart_BoundaryTraceUsesNewlyMintedTraceID(t *testing.T) {
 	if boundary == nil {
 		t.Fatalf("boundary trace missing; records=%+v", h.trace.records)
 	}
-	if boundary.TraceID != "NEW_UUID_FROM_MINTER" {
-		t.Errorf("boundary TraceID = %q, want NEW_UUID_FROM_MINTER (from minter.Mint, not obs.TraceID)",
+	if boundary.TraceID != "HOOK_PROVISIONAL_UUID" {
+		t.Errorf("boundary TraceID = %q, want HOOK_PROVISIONAL_UUID (adopted from obs.TraceID)",
 			boundary.TraceID)
 	}
 	if boundary.SpanID == "" {
@@ -1288,5 +1352,517 @@ func TestEmitTrace_GeneratesStableSpanIDWhenMissing(t *testing.T) {
 	}
 	if h.trace.records[0].SpanID == "" {
 		t.Error("emitRejectedTrace must back-fill empty obs.SpanID with a fresh UUID")
+	}
+}
+
+// ======================================================================
+// T5 (PR-1b-1c) — Apply pipeline expansion
+// ======================================================================
+
+// roleResolutionEv is a small helper that builds the canonical EvidenceRef
+// carrying role_resolution. Used throughout the T5 test suite to avoid
+// repeating the key name.
+func roleResolutionEv(state observation.RoleResolutionState) observation.EvidenceRef {
+	return observation.EvidenceRef{Key: observation.EvidenceKeyRoleResolution, Value: state}
+}
+
+// identityTripleEv produces the {pid, pane_id, start_time} evidence triple
+// that the divergence writer gate requires (D5.2 / P0-5). The pid type is
+// int64 so evidenceInt64 extraction hits the canonical path.
+func identityTripleEv(paneID string, pid int64, startTime string) []observation.EvidenceRef {
+	return []observation.EvidenceRef{
+		{Key: "pid", Value: pid},
+		{Key: "pane_id", Value: paneID},
+		{Key: "start_time", Value: startTime},
+	}
+}
+
+// ----- Role-based pending routing (D4.2) ----------------------------------
+
+// TestApply_HookRoleResolutionMissing_NotPending verifies a hook observation
+// with no role_resolution evidence key falls through route-to-pending (goes
+// the normal reject path instead of stashing). The observation lands at
+// source-priority or later steps; we assert pending remains empty.
+func TestApply_HookRoleResolutionMissing_NotPending(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("a1").withSuggest("active").withSeq(1).build()
+	// No role_resolution key anywhere in Evidence.
+
+	h.deps.apply(obs)
+
+	if h.pending.count() != 0 {
+		t.Errorf("pending count = %d, want 0 (no role_resolution -> no pending)", h.pending.count())
+	}
+}
+
+// TestApply_HookRetryableUnresolved_CreatesFirstPendingEntry_NoRetryScheduled
+// verifies the RoleRetryableUnresolved branch stashes observation into
+// pending and NEVER schedules a timer-based retry (Non-Goals).
+func TestApply_HookRetryableUnresolved_CreatesFirstPendingEntry_NoRetryScheduled(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("a1").withSuggest("active").withSeq(1).
+		withEvidence(roleResolutionEv(observation.RoleRetryableUnresolved)).build()
+
+	h.deps.apply(obs)
+
+	key := observation.ActorKey{SessionID: "s1", Generation: 1, ActorID: "a1"}
+	if !h.pending.isPending(key) {
+		t.Fatalf("pending entry missing after RoleRetryableUnresolved observation")
+	}
+	entry := h.pending.entries[key]
+	if len(entry.Observations) != 1 {
+		t.Errorf("pending entry observations = %d, want 1", len(entry.Observations))
+	}
+	// Non-Goals: no retryTick / retryCh / timer. The stash path is silent —
+	// no trace records should be emitted.
+	if len(h.trace.records) != 0 {
+		t.Errorf("pending stash must not emit trace; got %d records", len(h.trace.records))
+	}
+}
+
+// TestApply_HookTerminalUnresolved_EmitsTraceOnly_NotPending verifies the
+// RoleTerminalUnresolved branch emits one trace (reason=RoleTerminalUnresolved)
+// and does NOT add the observation to pending.
+func TestApply_HookTerminalUnresolved_EmitsTraceOnly_NotPending(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("a1").withSuggest("active").withSeq(1).
+		withEvidence(roleResolutionEv(observation.RoleTerminalUnresolved)).build()
+
+	h.deps.apply(obs)
+
+	if h.pending.count() != 0 {
+		t.Errorf("pending count = %d, want 0 (terminal must drop)", h.pending.count())
+	}
+	terminalRejects := h.trace.byReason("RoleTerminalUnresolved")
+	if len(terminalRejects) != 1 {
+		t.Fatalf("RoleTerminalUnresolved traces = %d, want 1; got %+v", len(terminalRejects), h.trace.records)
+	}
+}
+
+// TestApply_HookResolved_WhilePending_TriggersTryPromoteToActorNow verifies
+// that a RoleResolved observation arriving while the actor has a pending
+// entry triggers immediate promotion (no wait for reconcile tick).
+func TestApply_HookResolved_WhilePending_TriggersTryPromoteToActorNow(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+
+	// Seed a pending entry with a Retryable observation.
+	retryObs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("a1").withSuggest("active").withSeq(1).
+		withEvidence(roleResolutionEv(observation.RoleRetryableUnresolved)).build()
+	h.deps.apply(retryObs)
+
+	key := observation.ActorKey{SessionID: "s1", Generation: 1, ActorID: "a1"}
+	if !h.pending.isPending(key) {
+		t.Fatalf("seed Retryable obs did not create pending entry")
+	}
+
+	// Now send a Resolved observation — should promote immediately.
+	h.trace.records = nil
+	resolvedObs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("a1").withSuggest("active").withSeq(2).
+		withEvidence(roleResolutionEv(observation.RoleResolved)).build()
+	h.deps.apply(resolvedObs)
+
+	if h.pending.isPending(key) {
+		t.Errorf("pending entry still exists after Resolved promotion; want cleared")
+	}
+	accepted := h.trace.byPhase(observation.PhaseProposed)
+	if len(accepted) != 1 {
+		t.Errorf("expected 1 accepted trace after promote; got %d records=%+v", len(accepted), h.trace.records)
+	}
+}
+
+// ----- tryPromoteFromEntry contract (D4.3) --------------------------------
+
+// TestApply_TryPromoteFromEntry_NoPositiveSignal_ReturnsFalse_WaitsForDeadline
+// verifies that an entry containing only RoleRetryableUnresolved observations
+// is not promoted — it stays pending until deadline drop.
+func TestApply_TryPromoteFromEntry_NoPositiveSignal_ReturnsFalse_WaitsForDeadline(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+
+	// Build an entry with only Retryable observations.
+	key := observation.ActorKey{SessionID: "s1", Generation: 1, ActorID: "a1"}
+	for i := 0; i < 3; i++ {
+		obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+			withActor("a1").withSuggest("active").withSeq(int64(i + 1)).
+			withEvidence(roleResolutionEv(observation.RoleRetryableUnresolved)).build()
+		h.pending.addPending(obs, h.now, h.deps.pendingDeadline, h.deps.perSessionCap, h.deps.perEntryObsCap, nil)
+	}
+
+	entry := h.pending.entries[key]
+	if entry == nil {
+		t.Fatalf("seed failed")
+	}
+
+	promoted := h.deps.tryPromoteFromEntry(entry)
+	if promoted {
+		t.Errorf("tryPromoteFromEntry = true, want false (no RoleResolved obs in entry)")
+	}
+	// Still pending.
+	if !h.pending.isPending(key) {
+		t.Errorf("entry removed despite no positive signal")
+	}
+}
+
+// TestApply_TryPromoteFromEntry_HasResolvedObs_Promotes verifies that an
+// entry containing at least one RoleResolved observation is promoted by
+// running apply steps 5-9.
+func TestApply_TryPromoteFromEntry_HasResolvedObs_Promotes(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+	key := observation.ActorKey{SessionID: "s1", Generation: 1, ActorID: "a1"}
+
+	// Seed: Retryable first, then Resolved.
+	retryObs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("a1").withSuggest("active").withSeq(1).
+		withEvidence(roleResolutionEv(observation.RoleRetryableUnresolved)).build()
+	resolvedObs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("a1").withSuggest("active").withSeq(2).
+		withEvidence(roleResolutionEv(observation.RoleResolved)).build()
+	h.pending.addPending(retryObs, h.now, h.deps.pendingDeadline, h.deps.perSessionCap, h.deps.perEntryObsCap, nil)
+	h.pending.addPending(resolvedObs, h.now, h.deps.pendingDeadline, h.deps.perSessionCap, h.deps.perEntryObsCap, nil)
+
+	entry := h.pending.entries[key]
+	promoted := h.deps.tryPromoteFromEntry(entry)
+	if !promoted {
+		t.Errorf("tryPromoteFromEntry = false, want true (Resolved present)")
+	}
+	accepted := h.trace.byPhase(observation.PhaseProposed)
+	if len(accepted) != 1 {
+		t.Errorf("accepted trace count = %d, want 1 after promotion", len(accepted))
+	}
+}
+
+// TestApply_TryPromoteFromEntry_ResolvedButNoProposal_ReturnsFalse verifies
+// that a Resolved observation with no meaningful proposal (empty
+// SuggestStatus and EndLifecycle=false) does NOT promote the entry.
+func TestApply_TryPromoteFromEntry_ResolvedButNoProposal_ReturnsFalse(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+	key := observation.ActorKey{SessionID: "s1", Generation: 1, ActorID: "a1"}
+
+	// Resolved but proposal is empty.
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("a1").withSeq(1).
+		withEvidence(roleResolutionEv(observation.RoleResolved)).build()
+	// obs.Proposal.SuggestStatus defaults to "" and EndLifecycle=false.
+	h.pending.addPending(obs, h.now, h.deps.pendingDeadline, h.deps.perSessionCap, h.deps.perEntryObsCap, nil)
+
+	entry := h.pending.entries[key]
+	promoted := h.deps.tryPromoteFromEntry(entry)
+	if promoted {
+		t.Errorf("tryPromoteFromEntry = true, want false (Resolved but no proposal)")
+	}
+}
+
+// ----- Gen gate (D1.3) ----------------------------------------------------
+
+// TestApply_GenGate_ObservedEqualCurrent_NotSessionStart_AppliesNormally
+// documents that generation == current proceeds to normal apply without
+// triggering the SessionStart helper or any mint/adopt.
+func TestApply_GenGate_ObservedEqualCurrent_NotSessionStart_AppliesNormally(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 2
+
+	obs := h.obsBuilder().withSession("s1", 2).hook().withAction("PostToolUse").
+		withActor("a1").withSuggest("active").withSeq(1).build()
+	h.deps.apply(obs)
+
+	if len(h.minter.mintCalls) != 0 || len(h.minter.adoptCalls) != 0 {
+		t.Errorf("same-gen apply must not mint/adopt; mint=%d adopt=%d",
+			len(h.minter.mintCalls), len(h.minter.adoptCalls))
+	}
+	if len(h.trace.byPhase(observation.PhaseProposed)) != 1 {
+		t.Errorf("same-gen apply did not accept; records=%+v", h.trace.records)
+	}
+}
+
+// TestApply_GenGate_ObservedGreaterCurrent_SessionStart_RunsHelper_Adopts
+// verifies that obs.Gen > current + Action == SessionStart triggers
+// AdoptTraceID with the observation's trace_id as seed.
+func TestApply_GenGate_ObservedGreaterCurrent_SessionStart_RunsHelper_Adopts(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 0
+
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction(actionSessionStart).
+		withTrace("HOOK_PROVISIONAL_UUID").build()
+	h.deps.apply(obs)
+
+	if len(h.minter.adoptCalls) != 1 {
+		t.Fatalf("AdoptTraceID calls = %d, want 1", len(h.minter.adoptCalls))
+	}
+	if h.minter.adoptCalls[0].seed != "HOOK_PROVISIONAL_UUID" {
+		t.Errorf("adopt seed = %q, want HOOK_PROVISIONAL_UUID", h.minter.adoptCalls[0].seed)
+	}
+	if h.minter.adoptCalls[0].sessionID != "s1" || h.minter.adoptCalls[0].generation != 1 {
+		t.Errorf("adopt args = %+v, want {s1, 1}", h.minter.adoptCalls[0])
+	}
+	// SessionStart must not call Mint (adopt supersedes it).
+	if len(h.minter.mintCalls) != 0 {
+		t.Errorf("SessionStart called Mint %d times, want 0 (AdoptTraceID replaces it)", len(h.minter.mintCalls))
+	}
+}
+
+// TestApply_GenGate_ObservedGreaterCurrent_NotSessionStart_Rejects verifies
+// that obs.Gen > current + Action != SessionStart is rejected with
+// ObservedGenerationAhead (i.e. UnauthorizedGenerationBump reason code in
+// this codebase's enum).
+func TestApply_GenGate_ObservedGreaterCurrent_NotSessionStart_Rejects(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 0
+
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("a1").withSuggest("active").withSeq(1).build()
+	h.deps.apply(obs)
+
+	rej := h.trace.byReason(ReasonUnauthorizedGenerationBump)
+	if len(rej) != 1 {
+		t.Errorf("ObservedGenerationAhead / UnauthorizedGenerationBump rejects = %d, want 1", len(rej))
+	}
+}
+
+// ----- SessionStart AdoptTraceID (D1.2) -----------------------------------
+
+// TestApply_SessionStart_AdoptTraceID_UsesObservationSeed verifies the
+// boundary synthetic trace uses the seed returned from AdoptTraceID (which
+// equals obs.TraceID when the seed is non-empty and the key is new).
+func TestApply_SessionStart_AdoptTraceID_UsesObservationSeed(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 0
+
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction(actionSessionStart).
+		withTrace("ADOPT_ME").build()
+	h.deps.apply(obs)
+
+	var boundary *TraceRecord
+	for i, r := range h.trace.records {
+		if r.SourceKind == observation.SourceSynthetic && r.Action == actionSessionGenerationAdvanced {
+			boundary = &h.trace.records[i]
+			break
+		}
+	}
+	if boundary == nil {
+		t.Fatalf("boundary trace missing; records=%+v", h.trace.records)
+	}
+	if boundary.TraceID != "ADOPT_ME" {
+		t.Errorf("boundary trace_id = %q, want ADOPT_ME (adopted seed)", boundary.TraceID)
+	}
+}
+
+// TestApply_SessionStart_AdoptTraceID_Idempotent_WhenReplayed verifies that
+// two AdoptTraceID calls with the same (sid, gen) but different seeds
+// return the first seed — the second is discarded. We invoke AdoptTraceID
+// directly on the real registry to exercise the idempotent contract at
+// the source (the fake echoes seed, so it cannot demonstrate idempotency).
+func TestApply_SessionStart_AdoptTraceID_Idempotent_WhenReplayed(t *testing.T) {
+	minter, _ := observation.NewTraceIDRegistry()
+
+	first := minter.AdoptTraceID("s1", 1, "FIRST_SEED")
+	second := minter.AdoptTraceID("s1", 1, "SECOND_SEED")
+
+	if first != "FIRST_SEED" {
+		t.Errorf("first adopt = %q, want FIRST_SEED", first)
+	}
+	if second != "FIRST_SEED" {
+		t.Errorf("second adopt (replay) = %q, want FIRST_SEED (idempotent; second seed discarded)", second)
+	}
+}
+
+// ----- Divergence writer primary-only (D5.2) ------------------------------
+
+// TestApply_Passthrough_DivergenceWritten_WhenLegacyDiffers_Primary verifies
+// the happy path: primary actor + identity triple present + legacy frame
+// exists + proposal diverges from legacy → one Insert with Matched=false.
+func TestApply_Passthrough_DivergenceWritten_WhenLegacyDiffers_Primary(t *testing.T) {
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+
+	// Seed a legacy frame (status=idle) so the passthrough proposal
+	// (status=active) diverges.
+	legacyFrame := &store.Frame{
+		PaneID:           "pane-1",
+		PID:              4321,
+		ProcessStartTime: "2026-04-22T00:00:00Z",
+		AgentType:        "cc",
+		Status:           agentpkg.StatusIdle,
+	}
+	h.legacyFrames.set("pane-1", 4321, "2026-04-22T00:00:00Z", legacyFrame)
+
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("primary:cc").withSuggest("active").withSeq(1).
+		withEvidence(identityTripleEv("pane-1", 4321, "2026-04-22T00:00:00Z")...).build()
+	obs.TraceID = "trace-xyz"
+	obs.SpanID = "span-abc"
+
+	h.deps.apply(obs)
+
+	if len(h.divergences.inserts) != 1 {
+		t.Fatalf("divergences.Insert calls = %d, want 1", len(h.divergences.inserts))
+	}
+	row := h.divergences.inserts[0]
+	if row.Matched {
+		t.Errorf("divergence Matched = true, want false (status differs)")
+	}
+	if row.SessionID != "s1" || row.TraceID != "trace-xyz" || row.EventID != "span-abc" {
+		t.Errorf("divergence identity fields = (sid=%q trace=%q event=%q), want (s1, trace-xyz, span-abc)",
+			row.SessionID, row.TraceID, row.EventID)
+	}
+	if row.ObservedGeneration != 1 {
+		t.Errorf("ObservedGeneration = %d, want 1", row.ObservedGeneration)
+	}
+	if row.DiffSummary == "" {
+		t.Error("DiffSummary empty; expected non-empty humanDiff summary")
+	}
+	// OldStateRef / ProposalStateRef should be valid JSON.
+	if !json.Valid(row.OldStateRef) {
+		t.Errorf("OldStateRef not valid JSON: %s", row.OldStateRef)
+	}
+	if !json.Valid(row.ProposalStateRef) {
+		t.Errorf("ProposalStateRef not valid JSON: %s", row.ProposalStateRef)
+	}
+}
+
+// TestApply_Passthrough_DivergenceSkipped_WhenActorIsSubagent_MetricIncremented
+// verifies non-primary actors are gated out and the divergence skip metric
+// fires with actor_kind=subagent.
+func TestApply_Passthrough_DivergenceSkipped_WhenActorIsSubagent_MetricIncremented(t *testing.T) {
+	ResetForTesting()
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("subagent:task-1").withSuggest("active").withSeq(1).
+		withEvidence(identityTripleEv("pane-1", 4321, "2026-04-22T00:00:00Z")...).build()
+
+	h.deps.apply(obs)
+
+	if len(h.divergences.inserts) != 0 {
+		t.Errorf("Insert calls = %d, want 0 (subagent must be skipped)", len(h.divergences.inserts))
+	}
+	got := Value("lights_divergence_non_primary_skipped", "actor_kind=subagent")
+	if got != 1 {
+		t.Errorf("lights_divergence_non_primary_skipped{actor_kind=subagent} = %d, want 1", got)
+	}
+}
+
+// TestApply_Passthrough_DivergenceSkipped_WhenIdentityTripleMissing_MetricIncremented
+// verifies the identity-triple gate skips divergence writes and bumps the
+// appropriate metric when pane_id/pid/start_time is missing.
+func TestApply_Passthrough_DivergenceSkipped_WhenIdentityTripleMissing_MetricIncremented(t *testing.T) {
+	ResetForTesting()
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+
+	// pid + start_time present, but pane_id missing.
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("primary:cc").withSuggest("active").withSeq(1).
+		withEvidence(
+			observation.EvidenceRef{Key: "pid", Value: int64(4321)},
+			observation.EvidenceRef{Key: "start_time", Value: "2026-04-22T00:00:00Z"},
+		).build()
+
+	h.deps.apply(obs)
+
+	if len(h.divergences.inserts) != 0 {
+		t.Errorf("Insert calls = %d, want 0 (identity triple missing)", len(h.divergences.inserts))
+	}
+	got := Value("lights_divergence_identity_missing", "source=hook")
+	if got != 1 {
+		t.Errorf("lights_divergence_identity_missing{source=hook} = %d, want 1", got)
+	}
+}
+
+// TestApply_Passthrough_NoDivergenceWrite_WhenMatches verifies a matching
+// projection does NOT insert a row; only the matched=1 metric bumps.
+func TestApply_Passthrough_NoDivergenceWrite_WhenMatches(t *testing.T) {
+	ResetForTesting()
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+
+	// Seed legacy frame with status already active → projection will match.
+	legacyFrame := &store.Frame{
+		PaneID:           "pane-1",
+		PID:              4321,
+		ProcessStartTime: "2026-04-22T00:00:00Z",
+		AgentType:        "cc",
+		Status:           agentpkg.Status("active"),
+	}
+	h.legacyFrames.set("pane-1", 4321, "2026-04-22T00:00:00Z", legacyFrame)
+
+	obs := h.obsBuilder().withSession("s1", 1).hook().withAction("PostToolUse").
+		withActor("primary:cc").withSuggest("active").withSeq(1).
+		withEvidence(identityTripleEv("pane-1", 4321, "2026-04-22T00:00:00Z")...).build()
+
+	h.deps.apply(obs)
+
+	if len(h.divergences.inserts) != 0 {
+		t.Errorf("matching projection must not insert row; got %d inserts", len(h.divergences.inserts))
+	}
+	if got := Value("lights_divergence_total", "matched=1"); got != 1 {
+		t.Errorf("lights_divergence_total{matched=1} = %d, want 1", got)
+	}
+}
+
+// ----- Sampler wiring (D7) ------------------------------------------------
+
+// TestApply_Sampler_Sweep_DropsNineInTen_PerSession verifies the sampler is
+// invoked on emit: 10 sweep proposals in one session produce exactly 1
+// trace row (first emits, subsequent 9 drop). A second session's sweep
+// sequence starts fresh (independent counter).
+func TestApply_Sampler_Sweep_DropsNineInTen_PerSession(t *testing.T) {
+	ResetForTesting()
+	h := newApplyHarness(t)
+	h.frames.getOrCreateSession("s1").Generation = 1
+	h.frames.getOrCreateSession("s2").Generation = 1
+
+	// 10 sweep proposals on session s1 against fresh actors (unique ActorID
+	// so idempotency + pending routing do not interfere).
+	for i := 0; i < 10; i++ {
+		obs := h.obsBuilder().withSession("s1", 1).sweep().withAction("scan").
+			withActor("a" + itoa(i)).withSuggest("waiting").withSeq(int64(i + 1)).
+			withEvidence(roleResolutionEv(observation.RoleResolved)).build()
+		h.deps.apply(obs)
+	}
+
+	s1Sweep := 0
+	for _, r := range h.trace.records {
+		if r.SessionID == "s1" && r.SourceKind == observation.SourceSweep {
+			s1Sweep++
+		}
+	}
+	if s1Sweep != 1 {
+		t.Errorf("s1 sweep emitted traces = %d, want 1 (1-in-10 sampling)", s1Sweep)
+	}
+	// sampled_dropped metric should reflect 9 drops for s1 sweep.
+	if got := Value("lights_trace_sampled_dropped",
+		"phase=proposed", "session=s1", "source=sweep"); got != 9 {
+		t.Errorf("lights_trace_sampled_dropped{s1,sweep,proposed} = %d, want 9", got)
+	}
+
+	// Now fire 1 sweep on s2 — should emit (independent counter).
+	obs := h.obsBuilder().withSession("s2", 1).sweep().withAction("scan").
+		withActor("b0").withSuggest("waiting").withSeq(1).
+		withEvidence(roleResolutionEv(observation.RoleResolved)).build()
+	h.deps.apply(obs)
+
+	s2Sweep := 0
+	for _, r := range h.trace.records {
+		if r.SessionID == "s2" && r.SourceKind == observation.SourceSweep {
+			s2Sweep++
+		}
+	}
+	if s2Sweep != 1 {
+		t.Errorf("s2 first sweep did not emit; s2 sweep traces = %d, want 1 (cross-session independence)", s2Sweep)
 	}
 }

--- a/internal/module/agent/arbitrator/apply_test.go
+++ b/internal/module/agent/arbitrator/apply_test.go
@@ -42,17 +42,27 @@ func (f *fakeTraceSubmitter) byReason(code string) []TraceRecord {
 	return out
 }
 
-// fakeMinter records Mint + PruneSessionBefore calls for SessionStart tests.
+// fakeMinter records Mint + AdoptTraceID + PruneSessionBefore calls for
+// SessionStart tests. AdoptTraceID is added in PR-1b-1c (T1); existing tests
+// only exercise Mint, but the interface now includes Adopt, so the fake
+// satisfies both contracts.
 type fakeMinter struct {
-	mintCalls          []mintCall
-	pruneBeforeCalls   []pruneBeforeCall
-	pruneSessionCalls  []string
-	nextMintID         string
+	mintCalls         []mintCall
+	adoptCalls        []adoptCall
+	pruneBeforeCalls  []pruneBeforeCall
+	pruneSessionCalls []string
+	nextMintID        string
 }
 
 type mintCall struct {
 	sessionID  string
 	generation int64
+}
+
+type adoptCall struct {
+	sessionID  string
+	generation int64
+	seed       string
 }
 
 type pruneBeforeCall struct {
@@ -66,6 +76,18 @@ func (m *fakeMinter) Mint(sessionID string, generation int64) string {
 		return m.nextMintID
 	}
 	return "mint-" + sessionID
+}
+
+// AdoptTraceID echoes the seed when non-empty (fake idempotency is not
+// exercised by existing apply tests — 1b-1c T5 will cover that). When seed
+// is empty, degrade to Mint so the contract round-trips the no-empty-id
+// guarantee.
+func (m *fakeMinter) AdoptTraceID(sessionID string, generation int64, seed string) string {
+	m.adoptCalls = append(m.adoptCalls, adoptCall{sessionID, generation, seed})
+	if seed != "" {
+		return seed
+	}
+	return m.Mint(sessionID, generation)
 }
 
 func (m *fakeMinter) PruneSessionBefore(sessionID string, generation int64) int {

--- a/internal/module/agent/arbitrator/arbitrator.go
+++ b/internal/module/agent/arbitrator/arbitrator.go
@@ -33,6 +33,16 @@ type Options struct {
 	Lookup          observation.TraceIDLookup
 	Arbmode         ArbmodeView
 	TraceWriter     TraceSubmitter
+	// Divergences is the write-side for frame_divergences rows (D5.2).
+	// When nil (legacy tests, early bring-up) the divergence path is
+	// skipped silently — it is observability-only and Phase 2's authoritative
+	// mode will cover the write semantics.
+	Divergences DivergencesWriter
+	// LegacyFrames reads current legacy frame state by (pane_id, pid,
+	// start_time) so the divergence writer can project the proposal onto
+	// the same identity tuple before comparing. Nil → divergence path is
+	// skipped identically to a nil Divergences.
+	LegacyFrames    LegacyFramesView
 	InChCap         int
 	PendingDeadline time.Duration
 	PerSessionCap   int
@@ -108,6 +118,9 @@ func NewArbitrator(opts Options) *Arbitrator {
 		minter:          opts.Minter,
 		arbmode:         opts.Arbmode,
 		traceSubmit:     opts.TraceWriter,
+		sampler:         newSampler(),
+		divergences:     opts.Divergences,
+		legacyFrames:    opts.LegacyFrames,
 		now:             opts.Now,
 		pendingDeadline: opts.PendingDeadline,
 		perSessionCap:   opts.PerSessionCap,
@@ -152,11 +165,13 @@ func NewArbitrator(opts Options) *Arbitrator {
 	}
 
 	flushPendingDue := func(now time.Time) {
-		// PR-1b-1b wires only the skeleton + happy path. tryPromote is a stub
-		// that always returns false so pending entries fall through to the
-		// drop path (emitting a PidTreeUnresolvable trace per entry). The
-		// authoritative promote logic lands in PR-1b-1c.
-		tryPromote := func(_ *PendingEntry) bool { return false }
+		// PR-1b-1c: real tryPromote — scans the entry's observations for
+		// a positive role_resolution signal + valid proposal and runs
+		// apply steps 5-9 on the winner. Deadline drops still emit the
+		// PidTreeUnresolvable trace per observation (unchanged contract).
+		tryPromote := func(entry *PendingEntry) bool {
+			return a.deps.tryPromoteFromEntry(entry)
+		}
 		emitOnDrop := func(entry *PendingEntry, reason string) {
 			for _, pObs := range entry.Observations {
 				a.deps.emitRejectedTrace(pObs, reason, "pending entry dropped without promotion")

--- a/internal/module/agent/arbitrator/arbitrator.go
+++ b/internal/module/agent/arbitrator/arbitrator.go
@@ -184,6 +184,20 @@ func (a *Arbitrator) InCh() chan<- observation.Observation {
 	return a.inCh
 }
 
+// CurrentGeneration returns the generation currently associated with
+// sessionID, or 0 if the session has not yet been observed through
+// SessionStart. Callers invoke this from producer goroutines (hook /
+// probe / sweep / Module) concurrently with the Arbitrator Run goroutine;
+// the implementation reads frameState.sessions under mu.RLock so the value
+// is consistent with the last completed apply step.
+//
+// Plan D10 (P0-6) mandates RWMutex over atomic.Int64 here so every field
+// on sessionGen shares a single invariant owner — callers must not assume
+// any other frameState field (Actors, WatcherTokens) can be read lock-free.
+func (a *Arbitrator) CurrentGeneration(sessionID string) int64 {
+	return a.deps.frames.GenerationOf(sessionID)
+}
+
 // InChForTesting returns the bidirectional input channel. Test-only — exposes
 // the receive side so admission tests can drain without starting the Run
 // goroutine. Never call from production code.

--- a/internal/module/agent/arbitrator/current_generation_test.go
+++ b/internal/module/agent/arbitrator/current_generation_test.go
@@ -1,0 +1,250 @@
+package arbitrator
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+// newCancelableCtx is a tiny helper that returns a background context plus
+// its cancel. Named so the signal in current_generation_test.go is readable
+// (context.WithCancel inlined everywhere buries the intent).
+func newCancelableCtx() (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.Background())
+}
+
+// runInGoroutine starts arb.Run in a goroutine and returns a channel that
+// closes when Run exits. Callers should cancel the ctx and then receive on
+// the returned channel to wait for graceful shutdown.
+func runInGoroutine(arb *Arbitrator, ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		arb.Run(ctx)
+		close(done)
+	}()
+	return done
+}
+
+// waitForSubmit polls cap until at least n records have been submitted or
+// timeout expires. Failure message names the caller's expectation so
+// CurrentGeneration tests do not need their own retry loop.
+func waitForSubmit(t *testing.T, cap *captureTraceSubmitter, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cap.count() >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("waitForSubmit: want >= %d records within %v, got %d", n, timeout, cap.count())
+}
+
+// actorStatus is a test-only helper that reads the actor's Status under the
+// frameState's read lock. Used by TestFrameState_RWMutex_WriteExcludesReads
+// to prove reads block while a writer holds the lock.
+func (f *frameState) actorStatus(key observation.ActorKey) string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	sess, ok := f.sessions[key.SessionID]
+	if !ok {
+		return ""
+	}
+	a, ok := sess.Actors[key]
+	if !ok {
+		return ""
+	}
+	return a.Status
+}
+
+// TestArbitrator_CurrentGeneration_UnknownSession_ReturnsZero locks the
+// contract that an unknown session reads as generation 0 (matching the
+// "not-yet-SessionStart" default). Callers (hook path ObservedGeneration
+// calculations) rely on this to decide whether to push generation forward.
+func TestArbitrator_CurrentGeneration_UnknownSession_ReturnsZero(t *testing.T) {
+	cap := &captureTraceSubmitter{}
+	arb := NewArbitrator(newArbOptionsForTest(cap))
+
+	if got := arb.CurrentGeneration("nobody-home"); got != 0 {
+		t.Fatalf("CurrentGeneration(unknown) = %d, want 0", got)
+	}
+}
+
+// TestArbitrator_CurrentGeneration_AfterSessionStart_ReturnsNewGen verifies
+// that once the Arbitrator goroutine processes a SessionStart observation
+// (which bumps frameState.sessions[sid].Generation), CurrentGeneration
+// reflects the new value.
+func TestArbitrator_CurrentGeneration_AfterSessionStart_ReturnsNewGen(t *testing.T) {
+	cap := &captureTraceSubmitter{}
+	opts := newArbOptionsForTest(cap)
+	opts.ReconcileEvery = time.Hour // keep the ticker out of the way
+	arb := NewArbitrator(opts)
+
+	// Start Run so the single-owner goroutine processes inCh.
+	ctx, cancel := newCancelableCtx()
+	doneCh := runInGoroutine(arb, ctx)
+
+	now := time.Now()
+	arb.InCh() <- makeSessionStart("sess-curgen", 7, now)
+
+	// Wait for the boundary trace as a signal that apply finished advancing
+	// the generation.
+	waitForSubmit(t, cap, 1, 500*time.Millisecond)
+
+	got := arb.CurrentGeneration("sess-curgen")
+	if got != 7 {
+		t.Fatalf("CurrentGeneration after SessionStart gen=7 = %d, want 7", got)
+	}
+
+	cancel()
+	<-doneCh
+}
+
+// TestArbitrator_CurrentGeneration_ConcurrentRead_NoRace spins many reader
+// goroutines calling CurrentGeneration while the Arbitrator Run goroutine
+// processes SessionStart observations (which mutate frameState.sessions).
+// Under -race, this must complete without a data race report.
+func TestArbitrator_CurrentGeneration_ConcurrentRead_NoRace(t *testing.T) {
+	cap := &captureTraceSubmitter{}
+	opts := newArbOptionsForTest(cap)
+	opts.InChCap = 1024
+	opts.ReconcileEvery = time.Hour
+	arb := NewArbitrator(opts)
+
+	ctx, cancel := newCancelableCtx()
+	doneCh := runInGoroutine(arb, ctx)
+
+	const readers = 8
+	const readsPerReader = 500
+	const writes = 200
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for n := 0; n < readsPerReader && !stop.Load(); n++ {
+				_ = arb.CurrentGeneration("sess-race")
+			}
+		}()
+	}
+
+	now := time.Now()
+	for g := int64(1); g <= writes; g++ {
+		arb.InCh() <- makeSessionStart("sess-race", g, now)
+	}
+
+	// Let readers keep going until the writer channel drains. We poll the
+	// capture until we observe >= writes records (each SessionStart emits
+	// exactly one synthetic boundary trace).
+	waitForSubmit(t, cap, writes, 2*time.Second)
+	stop.Store(true)
+	wg.Wait()
+
+	cancel()
+	<-doneCh
+}
+
+// TestFrameState_RWMutex_MultipleReadersConcurrent verifies multiple
+// concurrent RLock-based readers (CurrentGeneration + allActiveActors) can
+// run in parallel without blocking each other. Failure is "timeout" — if
+// RWMutex were downgraded to a plain Mutex this test would serialize the
+// readers and exceed the generous deadline.
+func TestFrameState_RWMutex_MultipleReadersConcurrent(t *testing.T) {
+	fs := newFrameState()
+
+	// Seed a handful of sessions so readers have something to scan.
+	for i := 0; i < 16; i++ {
+		sid := "sess-multi-" + string(rune('a'+i))
+		sg := fs.getOrCreateSession(sid)
+		// Write Generation via the locked API so this test doubles as a
+		// sanity check that SetGeneration exists and round-trips.
+		fs.SetGeneration(sid, int64(i+1))
+		if sg == nil {
+			t.Fatal("getOrCreateSession returned nil")
+		}
+	}
+
+	const readers = 16
+	const readsPerReader = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	start := time.Now()
+	for r := 0; r < readers; r++ {
+		go func(r int) {
+			defer wg.Done()
+			for n := 0; n < readsPerReader; n++ {
+				sid := "sess-multi-" + string(rune('a'+(r%16)))
+				_ = fs.GenerationOf(sid)
+			}
+		}(r)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Fatalf("concurrent readers took too long (%v); RWMutex likely serialized them", elapsed)
+	}
+}
+
+// TestFrameState_RWMutex_WriteExcludesReads verifies that a pending writer
+// forces readers to wait (mutex exclusion). We use a channel-synchronized
+// writer that parks inside the critical section via upsertActor's closure
+// so we can assert readers observe a stable state before the writer
+// releases the lock.
+func TestFrameState_RWMutex_WriteExcludesReads(t *testing.T) {
+	fs := newFrameState()
+	key := observation.ActorKey{SessionID: "sess-excl", Generation: 1, ActorID: "a1"}
+	// Seed so upsertActor's write path definitely enters the lock.
+	fs.upsertActor(key, func(a *actorSummary) { a.Status = "initial" })
+
+	writerEntered := make(chan struct{})
+	writerRelease := make(chan struct{})
+	writerDone := make(chan struct{})
+
+	// Writer goroutine parks inside upsertActor's closure (which runs
+	// under Lock) until writerRelease is signalled.
+	go func() {
+		defer close(writerDone)
+		fs.upsertActor(key, func(a *actorSummary) {
+			close(writerEntered)
+			<-writerRelease
+			a.Status = "updated"
+		})
+	}()
+
+	// Wait until writer has the lock.
+	<-writerEntered
+
+	// Reader goroutine must block on RLock until writer releases.
+	readerDone := make(chan string, 1)
+	go func() {
+		readerDone <- fs.actorStatus(key)
+	}()
+
+	// Give the reader a chance to try and block.
+	select {
+	case s := <-readerDone:
+		t.Fatalf("reader observed status=%q before writer released; RWMutex does not exclude reads during write", s)
+	case <-time.After(30 * time.Millisecond):
+		// Expected: reader is blocked on RLock.
+	}
+
+	// Release writer; reader should then observe "updated".
+	close(writerRelease)
+	<-writerDone
+
+	select {
+	case s := <-readerDone:
+		if s != "updated" {
+			t.Fatalf("reader observed status=%q after writer release, want updated", s)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("reader did not unblock after writer released lock")
+	}
+}

--- a/internal/module/agent/arbitrator/frame_state.go
+++ b/internal/module/agent/arbitrator/frame_state.go
@@ -1,21 +1,35 @@
 package arbitrator
 
 import (
+	"sync"
 	"time"
 
 	"github.com/wake/purdex/internal/module/agent/observation"
 )
 
-// frameState is the single-writer in-memory projection of the Lights frame.
-// It is owned exclusively by the Arbitrator goroutine; there is no locking.
-// Concurrent access from other goroutines is a programming error.
+// frameState is the in-memory projection of the Lights frame.
+//
+// The Arbitrator Run goroutine is the authoritative single writer; all
+// mutating paths (apply pipeline, SessionStart helpers) hold mu.Lock. Other
+// goroutines — hook/probe/sweep producers calling Arbitrator.CurrentGeneration,
+// the reconciler closure reading allActiveActors — take mu.RLock.
+//
+// Every field on sessionGen and every field on actorSummary is guarded by
+// the same mu. This keeps the invariant simple (one mutex per frameState,
+// never any nested locking) and, crucially, prevents the mixed atomic +
+// unlocked-map model a previous revision considered: that model would force
+// later maintainers to track which reader paths were legal lock-free, and
+// the race detector's happens-before analysis would not catch a missed
+// upgrade cleanly. See plan D10 (P0-6) for the decision rationale.
 type frameState struct {
+	mu       sync.RWMutex
 	sessions map[string]*sessionGen
 }
 
 // sessionGen tracks a session's current generation plus every actor ever
 // observed in it (including ended ones — see allActiveActors for the live
-// view).
+// view). All fields are guarded by frameState.mu; callers must not read or
+// write them outside a frameState method.
 type sessionGen struct {
 	Generation int64
 	Actors     map[observation.ActorKey]*actorSummary
@@ -24,6 +38,14 @@ type sessionGen struct {
 // actorSummary is the per-actor projection used by the Arbitrator's apply
 // pipeline. Fields are plain values so individual step functions can mutate
 // them through a single `update` closure passed to upsertActor.
+//
+// Fields are guarded by frameState.mu; the upsertActor closure runs under
+// the write lock, so individual step functions read/write freely inside it.
+// Pointers returned from actor() belong to the same protected allocation —
+// the Arbitrator single-owner goroutine reads them without extra locking
+// because only that goroutine mutates actor state; cross-goroutine reads
+// that need actor fields must go through helpers (e.g. allActiveActorsView)
+// that take the lock and snapshot the data they need.
 //
 // LastAcceptedSource / LastAcceptedStatus record the source-kind and
 // SuggestStatus of the most recently accepted Observation for this actor.
@@ -41,9 +63,11 @@ type actorSummary struct {
 	LastAcceptedStatus string
 }
 
-// GetLastActivity satisfies the reconcile package's actorLivenessView contract.
-// Task 6 supplies allActiveActorsView as the adapter from the concrete actor
-// map to the read-only projection reconcile consumes.
+// GetLastActivity satisfies the reconcile package's actorLivenessView
+// contract. It returns the plain-value LastActivity and performs no locking
+// because the returned pointer is captured inside a frameState.mu-locked
+// snapshot by allActiveActorsView; calling it on a raw *actorSummary
+// obtained outside that snapshot would race.
 func (a *actorSummary) GetLastActivity() time.Time {
 	return a.LastActivity
 }
@@ -56,8 +80,25 @@ func newFrameState() *frameState {
 }
 
 // getOrCreateSession returns the sessionGen for sessionID, creating a
-// zero-value entry (Generation=0) on first access.
+// zero-value entry (Generation=0) on first access. Takes mu.Lock because the
+// map itself may be mutated.
+//
+// Callers must NOT retain the returned pointer across goroutine boundaries —
+// the pointer is protected by frameState.mu, and fields must only be read or
+// written through the other frameState methods (all of which re-acquire
+// mu). Apply pipeline code uses the pointer while holding its own
+// implicit single-owner invariant; cross-goroutine reads (CurrentGeneration,
+// allActiveActorsView) take the lock themselves.
 func (f *frameState) getOrCreateSession(sessionID string) *sessionGen {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.getOrCreateSessionLocked(sessionID)
+}
+
+// getOrCreateSessionLocked is the lock-free variant used by other frameState
+// methods that already hold mu. It must never be called from outside this
+// file.
+func (f *frameState) getOrCreateSessionLocked(sessionID string) *sessionGen {
 	if s, ok := f.sessions[sessionID]; ok {
 		return s
 	}
@@ -69,6 +110,29 @@ func (f *frameState) getOrCreateSession(sessionID string) *sessionGen {
 	return s
 }
 
+// GenerationOf returns the current generation for sessionID, or 0 if the
+// session is unknown. Takes mu.RLock so cross-goroutine producers (hook /
+// probe / sweep) can read safely while the Arbitrator Run goroutine runs
+// apply() under mu.Lock.
+func (f *frameState) GenerationOf(sessionID string) int64 {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if s, ok := f.sessions[sessionID]; ok {
+		return s.Generation
+	}
+	return 0
+}
+
+// SetGeneration overwrites the generation for sessionID, creating the
+// session's entry if necessary. Takes mu.Lock. Used by the apply pipeline
+// (SessionStart helper) and by tests that seed state before invoking apply.
+func (f *frameState) SetGeneration(sessionID string, generation int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s := f.getOrCreateSessionLocked(sessionID)
+	s.Generation = generation
+}
+
 // forceEndOldGenActors ends every actor in the given session whose
 // ActorKey.Generation matches oldGen and whose EndedAt is still nil. Each
 // ended actor has its EndedAt set to now, EndedReason set to
@@ -77,6 +141,8 @@ func (f *frameState) getOrCreateSession(sessionID string) *sessionGen {
 // Returns the slice of ActorKeys that were actually ended by this call
 // (already-ended actors are skipped).
 func (f *frameState) forceEndOldGenActors(sessionID string, oldGen int64, now time.Time) []observation.ActorKey {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	sess, ok := f.sessions[sessionID]
 	if !ok {
 		return nil
@@ -105,9 +171,13 @@ func (f *frameState) forceEndOldGenActors(sessionID string, oldGen int64, now ti
 // pointer to the (new or existing) summary so callers can set whichever
 // fields they need in one shot.
 //
-// Panics if update is nil — callers should always pass a closure.
+// Holds mu.Lock for the duration of the closure — callers must keep the
+// closure short (no channel sends, no unrelated work) to avoid starving
+// readers. Panics if update is nil.
 func (f *frameState) upsertActor(key observation.ActorKey, update func(*actorSummary)) {
-	sess := f.getOrCreateSession(key.SessionID)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	sess := f.getOrCreateSessionLocked(key.SessionID)
 	a, ok := sess.Actors[key]
 	if !ok {
 		a = &actorSummary{
@@ -124,6 +194,8 @@ func (f *frameState) upsertActor(key observation.ActorKey, update func(*actorSum
 // actor identified by key. No-op if the actor does not exist (callers that
 // care should upsertActor first).
 func (f *frameState) rotateWatcherToken(key observation.ActorKey, probeID, newToken string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	sess, ok := f.sessions[key.SessionID]
 	if !ok {
 		return
@@ -145,6 +217,8 @@ func (f *frameState) rotateWatcherToken(key observation.ActorKey, probeID, newTo
 //
 // No-op if key's actor does not exist.
 func (f *frameState) setPrimary(key observation.ActorKey, now time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	sess, ok := f.sessions[key.SessionID]
 	if !ok {
 		return
@@ -174,7 +248,14 @@ func (f *frameState) setPrimary(key observation.ActorKey, now time.Time) {
 // allActiveActors returns a map of every actor that is (a) not ended, and
 // (b) in the current generation of its session. Callers must treat the
 // returned map as read-only (it is a freshly-allocated snapshot).
+//
+// Takes mu.RLock. The returned map keys are safe to retain but callers must
+// not dereference the pointer values outside the read critical section —
+// actorSummary fields may be mutated by subsequent apply calls under
+// mu.Lock. If you need field data beyond the lock, copy it before returning.
 func (f *frameState) allActiveActors() map[observation.ActorKey]*actorSummary {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	out := make(map[observation.ActorKey]*actorSummary)
 	for _, sess := range f.sessions {
 		for key, a := range sess.Actors {
@@ -191,7 +272,14 @@ func (f *frameState) allActiveActors() map[observation.ActorKey]*actorSummary {
 }
 
 // actor returns the actorSummary for key (if any) and whether it was found.
+// Takes mu.RLock. See the actorSummary doc comment regarding pointer
+// lifetime — the returned pointer is only safe to inspect from the
+// single-owner apply goroutine (which serializes its own reads against its
+// own writes); cross-goroutine callers should use allActiveActorsView or
+// copy the fields they need while the lock is held.
 func (f *frameState) actor(key observation.ActorKey) (*actorSummary, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	sess, ok := f.sessions[key.SessionID]
 	if !ok {
 		return nil, false
@@ -206,6 +294,8 @@ func (f *frameState) actor(key observation.ActorKey) (*actorSummary, bool) {
 // the soon-to-be-displaced primary before calling setPrimary (so it can emit
 // the synthetic "replaced_by_new_primary" trace against the displaced key).
 func (f *frameState) findPrimary(sessionID string) (observation.ActorKey, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	sess, ok := f.sessions[sessionID]
 	if !ok {
 		return observation.ActorKey{}, false
@@ -226,8 +316,9 @@ func (f *frameState) findPrimary(sessionID string) (observation.ActorKey, bool) 
 
 // allActiveActorsView adapts allActiveActors() into a map of read-only
 // projections, satisfying the actorLivenessView contract used by reconcile.
-// The returned map is a fresh allocation; callers may retain it past the
-// next mutation of frameState.
+// The returned map is a fresh allocation; callers may retain the map itself
+// but must not retain or dereference the interface values past the next
+// frameState mutation.
 func (f *frameState) allActiveActorsView() map[observation.ActorKey]actorLivenessView {
 	active := f.allActiveActors()
 	out := make(map[observation.ActorKey]actorLivenessView, len(active))

--- a/internal/module/agent/arbitrator/sampler.go
+++ b/internal/module/agent/arbitrator/sampler.go
@@ -1,0 +1,77 @@
+package arbitrator
+
+import (
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+// sampler is the trace-emit reducer used by the apply pipeline to cut the
+// volume of low-signal proposed traces (sweep / synthetic) to 1-in-10 per
+// session+source, while preserving every committed trace and every hook/probe
+// proposed trace.
+//
+// Single-owner contract: sampler is called only from the apply pipeline, which
+// is itself driven by a single goroutine (the Arbitrator Run loop). There is
+// NO internal mutex; concurrent use from multiple goroutines is a caller bug
+// and will race. See D7 of docs/superpowers/plans/2026-04-22-lights-system/
+// pr-1b-1c.md for the broader contract.
+type sampler struct {
+	// counts[sessionID][sourceKind] — monotonic invocation counter for sampled
+	// source kinds (SourceSweep / SourceSynthetic, PhaseProposed only). The
+	// modulo-10 decision is made on the value BEFORE increment, so the first
+	// call (c = 0) always emits and every 10th call thereafter emits.
+	//
+	// Counter is per-session so that a chatty session cannot starve other
+	// sessions' sweep traces; ClearSession recycles a session's counter when
+	// its generation advances.
+	counts map[string]map[observation.SourceKind]int
+}
+
+// newSampler returns an empty sampler. Caller must ensure single-goroutine
+// invocation for the sampler's lifetime.
+func newSampler() *sampler {
+	return &sampler{
+		counts: make(map[string]map[observation.SourceKind]int),
+	}
+}
+
+// ShouldEmit reports whether a trace for the given (session, source, phase)
+// tuple should be emitted by the apply pipeline.
+//
+// Rules:
+//   - PhaseCommitted → always emit (fast path; counter untouched).
+//   - PhaseProposed + source != sweep/synthetic → always emit (hook/probe/
+//     reconcile proposals are high-signal; counter untouched).
+//   - PhaseProposed + sweep/synthetic → emit the 1st, 11th, 21st ... call
+//     (c % 10 == 0, evaluated BEFORE increment), drop all others.
+//
+// Callers serialize all invocations (single-goroutine owner). No locking.
+func (s *sampler) ShouldEmit(
+	sessionID string,
+	source observation.SourceKind,
+	phase observation.ObsPhase,
+) bool {
+	// Committed is always emitted, regardless of source.
+	if phase == observation.PhaseCommitted {
+		return true
+	}
+	// Only sweep / synthetic proposals are sampled; everything else emits.
+	if source != observation.SourceSweep && source != observation.SourceSynthetic {
+		return true
+	}
+
+	sessCounts, ok := s.counts[sessionID]
+	if !ok {
+		sessCounts = make(map[observation.SourceKind]int)
+		s.counts[sessionID] = sessCounts
+	}
+	c := sessCounts[source]
+	sessCounts[source] = c + 1
+	return c%10 == 0
+}
+
+// ClearSession reclaims the per-session counter map for sessionID. Called by
+// the SessionStart helper when a session's generation advances, so post-restart
+// sweeps start fresh (first sweep always emits). No-op if sessionID is unknown.
+func (s *sampler) ClearSession(sessionID string) {
+	delete(s.counts, sessionID)
+}

--- a/internal/module/agent/arbitrator/sampler_test.go
+++ b/internal/module/agent/arbitrator/sampler_test.go
@@ -1,0 +1,152 @@
+package arbitrator
+
+import (
+	"testing"
+
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+// Sampler is the trace-emit reducer inside the apply pipeline. It is owned by
+// a single goroutine (the Arbitrator Run loop) and therefore intentionally
+// carries no mutex. Tests here assert only the ShouldEmit contract under
+// serialized calls — concurrent-access coverage is the apply pipeline's job
+// (Stage 2 T5), per D7 of the PR-1b-1c plan.
+
+// TestSampler_Committed_AlwaysEmits verifies that PhaseCommitted always emits
+// regardless of source — even sweep/synthetic, which are sampled 1-in-10 when
+// proposed. Runs 20 iterations per sampled source to ensure the committed-fast-path
+// bypasses the counter entirely.
+func TestSampler_Committed_AlwaysEmits(t *testing.T) {
+	s := newSampler()
+	sources := []observation.SourceKind{
+		observation.SourceHook,
+		observation.SourceProbe,
+		observation.SourceSweep,
+		observation.SourceSynthetic,
+		observation.SourceReconcile,
+	}
+	for _, src := range sources {
+		for i := 0; i < 20; i++ {
+			if !s.ShouldEmit("sess-A", src, observation.PhaseCommitted) {
+				t.Errorf("ShouldEmit(sess-A, %q, committed) iter %d = false; want true", src, i)
+			}
+		}
+	}
+}
+
+// TestSampler_Proposed_Hook_AlwaysEmits verifies that SourceHook + PhaseProposed
+// always emits (hook proposals are not sampled).
+func TestSampler_Proposed_Hook_AlwaysEmits(t *testing.T) {
+	s := newSampler()
+	for i := 0; i < 20; i++ {
+		if !s.ShouldEmit("sess-A", observation.SourceHook, observation.PhaseProposed) {
+			t.Errorf("ShouldEmit(sess-A, hook, proposed) iter %d = false; want true", i)
+		}
+	}
+}
+
+// TestSampler_Proposed_Probe_AlwaysEmits verifies that SourceProbe + PhaseProposed
+// always emits (probe proposals are not sampled).
+func TestSampler_Proposed_Probe_AlwaysEmits(t *testing.T) {
+	s := newSampler()
+	for i := 0; i < 20; i++ {
+		if !s.ShouldEmit("sess-A", observation.SourceProbe, observation.PhaseProposed) {
+			t.Errorf("ShouldEmit(sess-A, probe, proposed) iter %d = false; want true", i)
+		}
+	}
+}
+
+// TestSampler_Proposed_Sweep_1In10 verifies that SourceSweep + PhaseProposed is
+// sampled 1-in-10: the 1st, 11th, 21st ... calls emit; all others drop.
+func TestSampler_Proposed_Sweep_1In10(t *testing.T) {
+	s := newSampler()
+	// Iterations 1..30 — call indices 0..29.
+	for i := 0; i < 30; i++ {
+		got := s.ShouldEmit("sess-A", observation.SourceSweep, observation.PhaseProposed)
+		want := i%10 == 0 // 1st (i=0), 11th (i=10), 21st (i=20) emit
+		if got != want {
+			t.Errorf("ShouldEmit(sess-A, sweep, proposed) iter %d = %v; want %v", i, got, want)
+		}
+	}
+}
+
+// TestSampler_Proposed_Synthetic_1In10 verifies the same 1-in-10 sampling for
+// SourceSynthetic + PhaseProposed.
+func TestSampler_Proposed_Synthetic_1In10(t *testing.T) {
+	s := newSampler()
+	for i := 0; i < 30; i++ {
+		got := s.ShouldEmit("sess-A", observation.SourceSynthetic, observation.PhaseProposed)
+		want := i%10 == 0
+		if got != want {
+			t.Errorf("ShouldEmit(sess-A, synthetic, proposed) iter %d = %v; want %v", i, got, want)
+		}
+	}
+}
+
+// TestSampler_CrossSession_IndependentCounters verifies that per-session counters
+// do not interfere: session A may have burned 9 sweeps (all dropped after the
+// first emit) but session B's first sweep must still emit, since B's counter
+// starts from 0.
+func TestSampler_CrossSession_IndependentCounters(t *testing.T) {
+	s := newSampler()
+
+	// Session A: 9 proposed sweeps.
+	// Call 1 (i=0) emits; calls 2..9 (i=1..8) drop.
+	for i := 0; i < 9; i++ {
+		got := s.ShouldEmit("sess-A", observation.SourceSweep, observation.PhaseProposed)
+		want := i == 0
+		if got != want {
+			t.Errorf("sess-A iter %d = %v; want %v", i, got, want)
+		}
+	}
+
+	// Session B: first sweep should emit (independent counter).
+	if !s.ShouldEmit("sess-B", observation.SourceSweep, observation.PhaseProposed) {
+		t.Error("sess-B first sweep = false; want true (per-session counters must be independent)")
+	}
+
+	// Session B's second sweep should drop (i=1 → 1%10 != 0).
+	if s.ShouldEmit("sess-B", observation.SourceSweep, observation.PhaseProposed) {
+		t.Error("sess-B second sweep = true; want false")
+	}
+
+	// Session A's 10th call (i=9) should still drop.
+	if s.ShouldEmit("sess-A", observation.SourceSweep, observation.PhaseProposed) {
+		t.Error("sess-A 10th sweep = true; want false (counter is 9, 9%10 != 0)")
+	}
+
+	// Session A's 11th call (i=10) should emit.
+	if !s.ShouldEmit("sess-A", observation.SourceSweep, observation.PhaseProposed) {
+		t.Error("sess-A 11th sweep = false; want true (counter is 10, 10%10 == 0)")
+	}
+}
+
+// TestSampler_ClearSession_ResetsCounts verifies that ClearSession reclaims the
+// per-session counter map so the next ShouldEmit for that session starts at 0
+// (and therefore emits).
+func TestSampler_ClearSession_ResetsCounts(t *testing.T) {
+	s := newSampler()
+
+	// Burn 5 sweeps on session A.
+	// Call 1 (i=0) emits, calls 2..5 drop.
+	for i := 0; i < 5; i++ {
+		got := s.ShouldEmit("sess-A", observation.SourceSweep, observation.PhaseProposed)
+		want := i == 0
+		if got != want {
+			t.Errorf("pre-clear iter %d = %v; want %v", i, got, want)
+		}
+	}
+
+	// Clear session A — counter map for sess-A should be reclaimed.
+	s.ClearSession("sess-A")
+
+	// Next call on sess-A should emit (counter restarted from 0).
+	if !s.ShouldEmit("sess-A", observation.SourceSweep, observation.PhaseProposed) {
+		t.Error("post-clear first sweep = false; want true (ClearSession should reset counter)")
+	}
+
+	// Second post-clear call should drop (counter is 1).
+	if s.ShouldEmit("sess-A", observation.SourceSweep, observation.PhaseProposed) {
+		t.Error("post-clear second sweep = true; want false")
+	}
+}

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -14,6 +14,7 @@ import (
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/agent/arbitrator"
 	"github.com/wake/purdex/internal/module/session"
 )
 
@@ -82,7 +83,13 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	trace := beginHookTrace(m.traceSink, req)
+	// PR-1b-1c: compute the observedGeneration for this hook invocation
+	// BEFORE opening the trace collector so the trigger step's trace_id can
+	// resolve against the (session, gen) registry from the first append.
+	observedGen := m.computeObservedGen(req)
+	sessionCode := m.resolveSessionCode(req.TmuxSession)
+
+	trace := beginHookTrace(m.traceSink, req, m.traceLookup, sessionCode, observedGen)
 	traceFinished := false
 	defer func() {
 		if !traceFinished {
@@ -90,7 +97,28 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	if decision := verifyEventFn(m, req); !decision.Accepted {
+	decision := verifyEventFn(m, req)
+
+	// Dual-write boundary (plan D1.1): build + submit the Observation after
+	// verify resolves, for BOTH accept and reject branches. Legacy frame /
+	// broadcast / trace path below continues unchanged.
+	startTime := m.resolveStartTime(req)
+	obs := buildHookObservation(
+		sessionCode,
+		req.TmuxPaneID,
+		int64(req.SenderPID),
+		startTime,
+		int64(req.SenderPID),
+		req.AgentType,
+		req.EventName,
+		observedGen,
+		decision.Accepted,
+		decision.Reason,
+		time.Now(),
+	)
+	m.SubmitObservation(obs)
+
+	if !decision.Accepted {
 		trace.Verify(req, "rejected", decision.Reason, map[string]any{"decision": "rejected", "reason": decision.Reason})
 		trace.Finish("completed", "verify_rejected")
 		traceFinished = true
@@ -243,6 +271,47 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// computeObservedGen derives the ObservedGeneration for a hook observation
+// (plan D1.3). SessionStart advances the generation by one relative to the
+// current Arbitrator view; every other event reads the current generation
+// unchanged. Returns 0 when the Arbitrator is not wired (degraded path); the
+// downstream apply pipeline is a no-op in that mode.
+func (m *Module) computeObservedGen(req EventRequest) int64 {
+	if m.arbitrator == nil {
+		return 0
+	}
+	sid := m.resolveSessionCode(req.TmuxSession)
+	cur := m.arbitrator.CurrentGeneration(sid)
+	if req.EventName == "SessionStart" {
+		return cur + 1
+	}
+	return cur
+}
+
+// resolveStartTime returns the process start_time that goes into Observation
+// evidence (plan D1.4). The hook request's own SenderStartTime is the
+// preferred source; when it is empty (SenderUncertain == true), we fall back
+// to FramesStore.FindByPanePID(pane, pid). A final miss returns "" so the
+// builder can map it to "unknown". Fallback paths increment
+// lights_hook_identity_unknown so the divergence writer can monitor how often
+// hook producers ship without a ProcessStartTime.
+func (m *Module) resolveStartTime(req EventRequest) string {
+	if req.SenderStartTime != "" {
+		return req.SenderStartTime
+	}
+	// Fallback paths: metric fires regardless of whether the FramesStore
+	// lookup succeeds (the hook request itself was the deficient source).
+	arbitrator.Inc("lights_hook_identity_unknown", "event="+req.EventName)
+	if m.frames == nil {
+		return ""
+	}
+	frame, err := m.frames.FindByPanePID(req.TmuxPaneID, req.SenderPID)
+	if err != nil || frame == nil {
+		return ""
+	}
+	return frame.ProcessStartTime
 }
 
 // buildNormalized creates a NormalizedEvent from the derive result and current state.

--- a/internal/module/agent/handler_observation_test.go
+++ b/internal/module/agent/handler_observation_test.go
@@ -1,0 +1,508 @@
+package agent
+
+// T6 tests (plan D1.1 / D1.2 / D1.3 / D1.4 / D9) — hook path dual-write wiring.
+//
+// Each test uses a Module wired with a real Arbitrator (InCh only, no Run
+// goroutine) so the test can pull observations off InCh and assert shape. The
+// Module also keeps the legacy frame / broadcast / trace path so we can assert
+// that dual-write does not regress existing behavior.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/agent/arbitrator"
+	"github.com/wake/purdex/internal/module/agent/arbmode"
+	"github.com/wake/purdex/internal/module/agent/observation"
+	"github.com/wake/purdex/internal/module/session"
+	"github.com/wake/purdex/internal/store"
+	"github.com/wake/purdex/internal/tmux"
+)
+
+// newHookObsModule returns a Module wired for hook-path dual-write tests:
+// real AgentEventStore + Arbitrator (InCh buffered, no Run goroutine), verify
+// stubbed to accept by default, session provider + tmux wired so the legacy
+// broadcast path runs through.
+func newHookObsModule(t *testing.T, inChCap int) *Module {
+	t.Helper()
+	arbitrator.ResetForTesting()
+
+	events, err := store.OpenAgentEvent(":memory:")
+	if err != nil {
+		t.Fatalf("open agent event store: %v", err)
+	}
+	t.Cleanup(func() { events.Close() })
+
+	m := New(events)
+	m.registry = agentpkg.NewRegistry()
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive: func(string, json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning}
+		},
+	})
+
+	// Default stubs (mirrors newTestModule).
+	origVerify := verifyEventFn
+	verifyEventFn = func(*Module, EventRequest) verifyDecision { return verifyDecision{Accepted: true} }
+	t.Cleanup(func() { verifyEventFn = origVerify })
+	origReadProcessInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1, ExePath: "/usr/local/bin/claude", Argv: []string{"claude"}}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origReadProcessInfo })
+	origProcessStartTime := processStartTimeFn
+	processStartTimeFn = func(pid int) (string, error) {
+		return "Sun Apr 20 01:30:00 2026", nil
+	}
+	t.Cleanup(func() { processStartTimeFn = origProcessStartTime })
+	origIsPidAlive := isPidAliveFn
+	isPidAliveFn = func(pid int) bool { return true }
+	t.Cleanup(func() { isPidAliveFn = origIsPidAlive })
+	if m.traceSink != nil {
+		t.Cleanup(func() { m.traceSink.Close() })
+	}
+
+	// Wire Arbitrator (no Run) + shared trace-id registry.
+	minter, lookup := observation.NewTraceIDRegistry()
+	m.traceMinter = minter
+	m.traceLookup = lookup
+	m.arbmodeMgr = arbmode.NewManager("", "")
+	m.arbitrator = arbitrator.NewArbitrator(arbitrator.Options{
+		Minter:      minter,
+		Lookup:      lookup,
+		Arbmode:     m.arbmodeMgr,
+		TraceWriter: &nopTraceSubmitter{},
+		InChCap:     inChCap,
+	})
+
+	// Session + tmux + core wiring so the legacy broadcast path is fully alive.
+	fake := tmux.NewFakeExecutor()
+	fake.SetPaneSessionName("%7", "work")
+	m.tmux = fake
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
+	m.sessions = &fakeSessionProvider{
+		sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}},
+	}
+
+	return m
+}
+
+func drainObservation(t *testing.T, m *Module, timeout time.Duration) observation.Observation {
+	t.Helper()
+	select {
+	case obs := <-m.arbitrator.InChForTesting():
+		return obs
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for observation on InCh")
+		return observation.Observation{}
+	}
+}
+
+func assertEvidence(t *testing.T, obs observation.Observation, key string, want any) {
+	t.Helper()
+	for _, ev := range obs.Evidence {
+		if ev.Key == key {
+			if ev.Value != want {
+				t.Fatalf("evidence[%s] = %v (%T), want %v (%T)", key, ev.Value, ev.Value, want, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("evidence[%s] missing; evidence=%+v", key, obs.Evidence)
+}
+
+func postHookEvent(t *testing.T, m *Module, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+	return w
+}
+
+// 1. Accept branch submits observation with Phase=Committed.
+func TestHandleEvent_Accept_SubmitsObservation(t *testing.T) {
+	m := newHookObsModule(t, 8)
+
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"PostToolUse",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`
+	w := postHookEvent(t, m, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	obs := drainObservation(t, m, 100*time.Millisecond)
+
+	if obs.Phase != observation.PhaseCommitted {
+		t.Fatalf("Phase = %q, want %q (accepted must commit)", obs.Phase, observation.PhaseCommitted)
+	}
+	if obs.SourceKind != observation.SourceHook {
+		t.Fatalf("SourceKind = %q, want %q", obs.SourceKind, observation.SourceHook)
+	}
+	if obs.Action != "PostToolUse" {
+		t.Fatalf("Action = %q, want PostToolUse", obs.Action)
+	}
+	if obs.SessionID != "code-work" {
+		t.Fatalf("SessionID = %q, want code-work (resolved from tmux name)", obs.SessionID)
+	}
+	if obs.TraceID == "" {
+		t.Fatalf("TraceID must be non-empty (provisional UUID mint)")
+	}
+	// Identity triple + event_name + role_resolution all present.
+	assertEvidence(t, obs, "pid", int64(1234))
+	assertEvidence(t, obs, "pane_id", "%7")
+	assertEvidence(t, obs, "event_name", "PostToolUse")
+	assertEvidence(t, obs, observation.EvidenceKeyRoleResolution, observation.RoleResolved)
+}
+
+// 2. Reject branch submits observation with Phase=Proposed and role_resolution.
+func TestHandleEvent_Reject_SubmitsObservation(t *testing.T) {
+	m := newHookObsModule(t, 8)
+	verifyEventFn = func(*Module, EventRequest) verifyDecision {
+		return verifyDecision{Accepted: false, Reason: "identify_mismatch"}
+	}
+
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"Stop",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`
+	w := postHookEvent(t, m, body)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 (reject branch)", w.Code)
+	}
+
+	obs := drainObservation(t, m, 100*time.Millisecond)
+	if obs.Phase != observation.PhaseProposed {
+		t.Fatalf("Phase = %q, want proposed", obs.Phase)
+	}
+	if obs.SourceKind != observation.SourceHook {
+		t.Fatalf("SourceKind = %q, want hook", obs.SourceKind)
+	}
+	// identify_mismatch is retryable per builder.
+	assertEvidence(t, obs, observation.EvidenceKeyRoleResolution, observation.RoleRetryableUnresolved)
+	assertEvidence(t, obs, "verify_reason", "identify_mismatch")
+}
+
+// 3. SessionStart bumps generation by +1.
+func TestHandleEvent_SessionStart_ObservationObservedGenerationIsCurrentPlusOne(t *testing.T) {
+	m := newHookObsModule(t, 8)
+
+	// Arbitrator starts with gen=0 for unknown session.
+	if got := m.arbitrator.CurrentGeneration("code-work"); got != 0 {
+		t.Fatalf("CurrentGeneration = %d, want 0 for unknown session", got)
+	}
+
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"SessionStart",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`
+	w := postHookEvent(t, m, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	obs := drainObservation(t, m, 100*time.Millisecond)
+	if obs.Action != "SessionStart" {
+		t.Fatalf("Action = %q, want SessionStart", obs.Action)
+	}
+	if obs.ObservedGeneration != 1 {
+		t.Fatalf("ObservedGeneration = %d, want 1 (current=0 +1)", obs.ObservedGeneration)
+	}
+	if obs.Proposal.ActorKey.Generation != 1 {
+		t.Fatalf("Proposal.ActorKey.Generation = %d, want 1", obs.Proposal.ActorKey.Generation)
+	}
+}
+
+// 4. Non-SessionStart uses current generation unchanged.
+func TestHandleEvent_NonSessionStart_ObservationObservedGenerationIsCurrent(t *testing.T) {
+	m := newHookObsModule(t, 8)
+
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"UserPromptSubmit",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`
+	w := postHookEvent(t, m, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+
+	obs := drainObservation(t, m, 100*time.Millisecond)
+	if obs.ObservedGeneration != 0 {
+		t.Fatalf("ObservedGeneration = %d, want 0 (current generation for unknown session)", obs.ObservedGeneration)
+	}
+}
+
+// 5. Provisional TraceID is non-empty — bypasses builder.Build validation.
+func TestHandleEvent_ProvisionalTraceID_NonEmpty(t *testing.T) {
+	m := newHookObsModule(t, 8)
+
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"PostToolUse",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`
+	if w := postHookEvent(t, m, body); w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	obs := drainObservation(t, m, 100*time.Millisecond)
+	if obs.TraceID == "" {
+		t.Fatalf("TraceID must never be empty — builder validation would reject")
+	}
+}
+
+// 6. Identity-triple start_time backfilled from FramesStore when hook req is
+// missing it. (SenderUncertain=true makes SenderStartTime optional; our
+// resolver should then try FramesStore.FindByPanePID.)
+func TestHandleEvent_IdentityTriple_StartTimeBackfilled_WhenReqMissing(t *testing.T) {
+	m := newHookObsModule(t, 8)
+	// Verify must accept uncertain events for this test so we exercise the
+	// backfill branch without verify-layer rejection.
+	verifyEventFn = func(*Module, EventRequest) verifyDecision { return verifyDecision{Accepted: true} }
+
+	// Seed a frame with a known start time for (pane %7, pid 1234).
+	const seedStart = "Mon Apr 21 03:00:00 2026"
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%7",
+		AgentType:        "cc",
+		PID:              1234,
+		PPID:             100,
+		ProcessStartTime: seedStart,
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        1,
+		LastSeenAt:       1,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("seed frame: %v", err)
+	}
+
+	// sender_uncertain=true + no sender_start_time → backfill should kick in.
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"PostToolUse",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_uncertain":true
+	}`
+	if w := postHookEvent(t, m, body); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	obs := drainObservation(t, m, 100*time.Millisecond)
+	assertEvidence(t, obs, "start_time", seedStart)
+}
+
+// 7. Identity-triple start_time falls back to "unknown" if FramesStore also has nothing.
+func TestHandleEvent_IdentityTriple_StartTimeUnknown_WhenFrameNotFound(t *testing.T) {
+	m := newHookObsModule(t, 8)
+	verifyEventFn = func(*Module, EventRequest) verifyDecision { return verifyDecision{Accepted: true} }
+
+	// No frame seeded → FindByPanePID returns nil → resolver must yield ""
+	// which the builder maps to "unknown".
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"PostToolUse",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":9999,
+		"sender_uncertain":true
+	}`
+	arbitrator.ResetForTesting() // clear any prior identity_unknown counter
+	if w := postHookEvent(t, m, body); w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	obs := drainObservation(t, m, 100*time.Millisecond)
+	assertEvidence(t, obs, "start_time", "unknown")
+
+	// Metric fires on fallback path regardless of whether start_time ended up
+	// "unknown" or resolved via FramesStore — both take the non-req path.
+	if got := arbitrator.Value("lights_hook_identity_unknown", "event=PostToolUse"); got != 1 {
+		t.Fatalf("lights_hook_identity_unknown{event=PostToolUse} = %d, want 1", got)
+	}
+}
+
+// 8. hookTraceCollector uses traceLookup.Get when available.
+func TestHookTraceCollector_TraceIDFromLookup_WhenAvailable(t *testing.T) {
+	m := newHookObsModule(t, 8)
+
+	// Pre-populate lookup with a trace_id for (code-work, gen=0) — the
+	// non-SessionStart hook should pick it up instead of chain_id fallback.
+	const wantTID = "11111111-2222-3333-4444-555555555555"
+	got := m.traceMinter.AdoptTraceID("code-work", 0, wantTID)
+	if got != wantTID {
+		t.Fatalf("AdoptTraceID returned %q, want %q (precondition)", got, wantTID)
+	}
+
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"UserPromptSubmit",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`
+	if w := postHookEvent(t, m, body); w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	// drain obs
+	_ = drainObservation(t, m, 100*time.Millisecond)
+
+	// Wait for the trace to hit the DB (collector.Finish enqueues async).
+	m.traceSink.FlushForTest()
+
+	page, err := m.traces.ListChains(store.TraceListFilter{TmuxSession: "work", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListChains: %v", err)
+	}
+	if len(page.Chains) != 1 {
+		t.Fatalf("len(Chains) = %d, want 1", len(page.Chains))
+	}
+	record, err := m.traces.GetChainRecord(page.Chains[0].ChainID)
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	for i, step := range record.Steps {
+		if step.TraceID != wantTID {
+			t.Fatalf("step %d TraceID = %q, want %q (from lookup)", i, step.TraceID, wantTID)
+		}
+	}
+}
+
+// 9. hookTraceCollector falls back to chain_id when lookup misses; metric fires.
+func TestHookTraceCollector_TraceIDFallsBackToChainID_WhenMinterNotYetCalled(t *testing.T) {
+	m := newHookObsModule(t, 8)
+
+	// No AdoptTraceID call → lookup miss for (code-work, 0).
+	arbitrator.ResetForTesting()
+
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"UserPromptSubmit",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`
+	if w := postHookEvent(t, m, body); w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	_ = drainObservation(t, m, 100*time.Millisecond)
+	m.traceSink.FlushForTest()
+
+	page, err := m.traces.ListChains(store.TraceListFilter{TmuxSession: "work", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListChains: %v", err)
+	}
+	if len(page.Chains) != 1 {
+		t.Fatalf("len(Chains) = %d, want 1", len(page.Chains))
+	}
+	record, err := m.traces.GetChainRecord(page.Chains[0].ChainID)
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	for i, step := range record.Steps {
+		if step.TraceID != record.Chain.ChainID {
+			t.Fatalf("step %d TraceID = %q, want chain_id %q (fallback)", i, step.TraceID, record.Chain.ChainID)
+		}
+	}
+
+	if got := arbitrator.Value("lights_hook_trace_id_fallback"); got < 1 {
+		t.Fatalf("lights_hook_trace_id_fallback counter = %d, want >= 1", got)
+	}
+}
+
+// 10. D9: SubmitObservation drop (inCh full) leaves legacy broadcast + trace intact.
+func TestHandleEvent_SubmitObservationDrop_LegacyPathStillRuns(t *testing.T) {
+	m := newHookObsModule(t, 1)
+	// Saturate InCh so the committed observation has to fall through the
+	// 100ms blocking retry before dropping.
+	fillInCh(t, m, 1)
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	body := `{
+		"tmux_session":"work",
+		"tmux_pane_id":"%7",
+		"event_name":"UserPromptSubmit",
+		"raw_event":{},
+		"agent_type":"cc",
+		"sender_pid":1234,
+		"sender_start_time":"Sun Apr 20 01:30:00 2026"
+	}`
+	w := postHookEvent(t, m, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (legacy path unaffected by submit drop)", w.Code)
+	}
+
+	// Legacy broadcast must still fire for the session.
+	select {
+	case msg := <-sub.SendCh():
+		var env struct {
+			Type    string `json:"type"`
+			Session string `json:"session"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		if env.Type != "hook" {
+			t.Fatalf("broadcast type = %q, want hook", env.Type)
+		}
+		if env.Session != "code-work" {
+			t.Fatalf("broadcast session = %q, want code-work", env.Session)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("legacy hook broadcast missing after submit drop")
+	}
+
+	// Legacy trace chain must still land in the DB.
+	m.traceSink.FlushForTest()
+	page, err := m.traces.ListChains(store.TraceListFilter{TmuxSession: "work", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListChains: %v", err)
+	}
+	if len(page.Chains) == 0 {
+		t.Fatalf("legacy hook trace missing after submit drop")
+	}
+
+	// Metric fires because the committed observation ended up dropped.
+	if got := arbitrator.Value("lights_arb_in_dropped", "priority=committed"); got != 1 {
+		t.Fatalf("lights_arb_in_dropped{priority=committed} = %d, want 1 (drop expected)", got)
+	}
+}

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -78,26 +78,46 @@ type Module struct {
 	traceWriter *arbitrator.TraceWriter
 	arbCancel   context.CancelFunc
 	arbDone     chan struct{}
+
+	// PR-1b-1c T7: divergenceStore is the shared store exposed to the
+	// Arbitrator's apply pipeline (nil-tolerant when the store isn't
+	// available). Initialised in New; nil in the degraded path.
+	divergenceStore *store.DivergenceStore
+
+	// PR-1b-1c T7: probe Watcher registry — per (sessionName, probe.Kind).
+	// Writes happen from probe wiring points (manageActivityWatch, probe
+	// session teardown, Module.Stop). Reads happen from the same callsites
+	// plus probeOnOutcome closures captured by Watcher goroutines.
+	watchersMu     sync.Mutex
+	watchers       map[watcherKey]probe.Watcher
+	watchersCtx    context.Context
+	watchersCancel context.CancelFunc
 }
 
 // New creates a new agent Module backed by the given AgentEventStore.
 func New(events *store.AgentEventStore) *Module {
 	var frames *store.FramesStore
 	var traces *store.TraceStore
+	var divergences *store.DivergenceStore
 	if events != nil {
 		frames, _ = events.Frames()
 		traces, _ = events.Traces()
+		// Divergences is nil-tolerant throughout the apply pipeline; a
+		// migration failure here must not block the rest of Init.
+		divergences, _ = events.Divergences()
 	}
 	m := &Module{
 		events:          events,
 		frames:          frames,
 		traces:          traces,
+		divergenceStore: divergences,
 		registry:        agentpkg.NewRegistry(),
 		currentStatus:   make(map[string]agentpkg.Status),
 		subagents:       make(map[string][]string),
 		activeWatchers:  make(map[string]string),
 		statusSnapshots: make(map[string]statusSnapshot),
 		testObservers:   make(map[string]*testObserver),
+		watchers:        make(map[watcherKey]probe.Watcher),
 	}
 	if traces != nil {
 		m.traceSink = newHookTraceSink(traces)
@@ -158,12 +178,25 @@ func (m *Module) Init(c *core.Core) error {
 			Store: m.traces,
 			Now:   time.Now,
 		})
+		// PR-1b-1c T7: wire the divergence writer + legacy-frames view.
+		// Both are nil-tolerant in the apply pipeline (D5.2) — we pass
+		// whatever the event store exposes.
+		var divWriter arbitrator.DivergencesWriter
+		if m.divergenceStore != nil {
+			divWriter = m.divergenceStore
+		}
+		var legacyFrames arbitrator.LegacyFramesView
+		if m.frames != nil {
+			legacyFrames = m.frames
+		}
 		m.arbitrator = arbitrator.NewArbitrator(arbitrator.Options{
-			Minter:      m.traceMinter,
-			Lookup:      m.traceLookup,
-			Arbmode:     m.arbmodeMgr,
-			TraceWriter: m.traceWriter,
-			Now:         time.Now,
+			Minter:       m.traceMinter,
+			Lookup:       m.traceLookup,
+			Arbmode:      m.arbmodeMgr,
+			TraceWriter:  m.traceWriter,
+			Divergences:  divWriter,
+			LegacyFrames: legacyFrames,
+			Now:          time.Now,
 		})
 	}
 
@@ -288,6 +321,10 @@ func (m *Module) Stop(_ context.Context) error {
 	if m.prober != nil {
 		m.prober.StopAllWatches()
 	}
+	// PR-1b-1c T7: stop every Module-managed probe Watcher and cancel the
+	// shared context.
+	m.stopAllWatchers()
+	m.cancelWatchersContext()
 	m.mu.Lock()
 	m.activeWatchers = make(map[string]string)
 	m.mu.Unlock()

--- a/internal/module/agent/monitor.go
+++ b/internal/module/agent/monitor.go
@@ -8,6 +8,13 @@ import (
 	"github.com/wake/purdex/internal/store"
 )
 
+// monitorSchemaVersion is stamped on every chain summary response. SPA
+// consumers pin this value to detect store rollback: if the daemon is
+// downgraded to a pre-Lights build the field either disappears or returns a
+// lower version, and the SPA can warn instead of silently rendering a
+// degraded envelope. Keep in sync with spec §3.5 / plan PR-1b-1c D6.
+const monitorSchemaVersion = "1.0.0-lights-1b"
+
 type MonitorChainSummary struct {
 	ChainID          string `json:"chain_id"`
 	StartedAt        int64  `json:"started_at"`
@@ -23,6 +30,10 @@ type MonitorChainSummary struct {
 	LatestDecision   string `json:"latest_decision"`
 	LatestStepReason string `json:"latest_step_reason"`
 	StepCount        int    `json:"step_count"`
+	// SchemaVersion is always monitorSchemaVersion; a missing / older value
+	// signals the daemon was rolled back and the 22-field envelope below is
+	// not trustworthy (defender recommendation, PR-1b-1c D6).
+	SchemaVersion string `json:"schema_version"`
 }
 
 type MonitorStep struct {
@@ -39,10 +50,40 @@ type MonitorStep struct {
 	EventName     string `json:"event_name"`
 	Decision      string `json:"decision"`
 	Reason        string `json:"reason"`
-	PayloadJSON   string `json:"payload_json"`
-	BeforeJSON    string `json:"before_json"`
-	AfterJSON     string `json:"after_json"`
-	CreatedAt     int64  `json:"created_at"`
+	// Legacy non-omitempty JSON fields — monitorRawJSON normalises empty
+	// store values to the literal string "null" so SPA consumers can rely
+	// on the field existing on every step.
+	PayloadJSON string `json:"payload_json"`
+	BeforeJSON  string `json:"before_json"`
+	AfterJSON   string `json:"after_json"`
+	CreatedAt   int64  `json:"created_at"`
+
+	// Lights envelope fields (spec §3.5 / PR-1b-0). All carry omitempty so
+	// legacy (non-Lights) rows continue to project the exact shape the
+	// earlier Monitor API contract promised. JSON fields use
+	// json.RawMessage so they project as structured JSON, not double-encoded
+	// strings, and default to absent (not "null") on empty rows.
+	SourceKind         string          `json:"source_kind,omitempty"`
+	Action             string          `json:"action,omitempty"`
+	ReasonCode         string          `json:"reason_code,omitempty"`
+	Outcome            string          `json:"outcome,omitempty"`
+	ScenarioKey        string          `json:"scenario_key,omitempty"`
+	ObservedGeneration int64           `json:"observed_generation,omitempty"`
+	DecisionPorts      json.RawMessage `json:"decision_ports,omitempty"`
+	Phase              string          `json:"phase,omitempty"`
+	Status             string          `json:"status,omitempty"`
+	WatcherToken       string          `json:"watcher_token,omitempty"`
+	TraceID            string          `json:"trace_id,omitempty"`
+	ReasonText         string          `json:"reason_text,omitempty"`
+	Attrs              json.RawMessage `json:"attrs,omitempty"`
+	InputRefs          json.RawMessage `json:"input_refs,omitempty"`
+	OutputRefs         json.RawMessage `json:"output_refs,omitempty"`
+	StateBeforeRef     string          `json:"state_before_ref,omitempty"`
+	StateAfterRef      string          `json:"state_after_ref,omitempty"`
+	EvidenceRefs       json.RawMessage `json:"evidence_refs,omitempty"`
+	StartedAt          int64           `json:"started_at,omitempty"`
+	EndedAt            int64           `json:"ended_at,omitempty"`
+	OtelKind           string          `json:"otel_kind,omitempty"`
 }
 
 type MonitorStepNode struct {
@@ -235,10 +276,15 @@ func monitorChainSummaryFromStore(chain store.TraceChain) MonitorChainSummary {
 		LatestDecision:   chain.LatestDecision,
 		LatestStepReason: chain.LatestStepReason,
 		StepCount:        chain.StepCount,
+		SchemaVersion:    monitorSchemaVersion,
 	}
 }
 
 func monitorStepFromStore(step store.TraceStep) MonitorStep {
+	watcher := ""
+	if step.WatcherToken != nil {
+		watcher = *step.WatcherToken
+	}
 	return MonitorStep{
 		StepID:        step.StepID,
 		ChainID:       step.ChainID,
@@ -257,6 +303,32 @@ func monitorStepFromStore(step store.TraceStep) MonitorStep {
 		BeforeJSON:    monitorRawJSON(step.BeforeJSON),
 		AfterJSON:     monitorRawJSON(step.AfterJSON),
 		CreatedAt:     step.CreatedAt,
+		// Lights envelope — empty values pass through as zero-value and are
+		// elided by omitempty so legacy rows keep their prior JSON shape.
+		// JSON fields stay as RawMessage (not renormalised to "null") so
+		// consumers see structured JSON when populated and a missing key
+		// when not.
+		SourceKind:         step.SourceKind,
+		Action:             step.Action,
+		ReasonCode:         step.ReasonCode,
+		Outcome:            step.Outcome,
+		ScenarioKey:        step.ScenarioKey,
+		ObservedGeneration: step.ObservedGeneration,
+		DecisionPorts:      step.DecisionPorts,
+		Phase:              step.Phase,
+		Status:             step.Status,
+		WatcherToken:       watcher,
+		TraceID:            step.TraceID,
+		ReasonText:         step.ReasonText,
+		Attrs:              step.Attrs,
+		InputRefs:          step.InputRefs,
+		OutputRefs:         step.OutputRefs,
+		StateBeforeRef:     step.StateBeforeRef,
+		StateAfterRef:      step.StateAfterRef,
+		EvidenceRefs:       step.EvidenceRefs,
+		StartedAt:          step.StartedAt,
+		EndedAt:            step.EndedAt,
+		OtelKind:           step.OTelKind,
 	}
 }
 

--- a/internal/module/agent/monitor_test.go
+++ b/internal/module/agent/monitor_test.go
@@ -289,3 +289,420 @@ func TestHandleMonitorProjection_ReturnsTypedSummary(t *testing.T) {
 		t.Fatalf("LatestChainID = %q, want chain-latest", body.Projection.LatestChainID)
 	}
 }
+
+// TestMonitorStep_IncludesAllEnvelopeFields verifies monitorStepFromStore
+// copies every PR-1b-0 envelope field from store.TraceStep onto MonitorStep
+// and that the JSON shape (field names + `omitempty` semantics) round-trips
+// through encoding/json unchanged. Spec §3.5 / plan PR-1b-1c D6.
+func TestMonitorStep_IncludesAllEnvelopeFields(t *testing.T) {
+	watcher := "w-1"
+	storeStep := store.TraceStep{
+		StepID:             "step-envelope",
+		ChainID:            "chain-envelope",
+		Seq:                1,
+		Kind:               "apply",
+		TmuxSession:        "work",
+		PaneID:             "%1",
+		AgentType:          "codex",
+		EventName:          "UserPromptSubmit",
+		Decision:           "committed",
+		Reason:             "arb_apply",
+		PayloadJSON:        json.RawMessage(`{"k":"v"}`),
+		BeforeJSON:         json.RawMessage(`{"before":true}`),
+		AfterJSON:          json.RawMessage(`{"after":true}`),
+		CreatedAt:          1000,
+		SourceKind:         "hook",
+		Action:             "frame_enter",
+		ReasonCode:         "hook_pre",
+		Outcome:            "committed",
+		ScenarioKey:        "codex:UserPromptSubmit",
+		ObservedGeneration: 42,
+		DecisionPorts:      json.RawMessage(`[{"name":"frame_enter"}]`),
+		Phase:              "committed",
+		Status:             "active",
+		WatcherToken:       &watcher,
+		TraceID:            "trace-xyz",
+		ReasonText:         "hook pre accepted",
+		Attrs:              json.RawMessage(`{"a":1}`),
+		InputRefs:          json.RawMessage(`["ref-in"]`),
+		OutputRefs:         json.RawMessage(`["ref-out"]`),
+		StateBeforeRef:     "frame-before",
+		StateAfterRef:      "frame-after",
+		EvidenceRefs:       json.RawMessage(`["ev-1"]`),
+		StartedAt:          900,
+		EndedAt:            1100,
+		OTelKind:           "INTERNAL",
+	}
+
+	ms := monitorStepFromStore(storeStep)
+	raw, err := json.Marshal(ms)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	wantStrings := map[string]string{
+		"source_kind":      "hook",
+		"action":           "frame_enter",
+		"reason_code":      "hook_pre",
+		"outcome":          "committed",
+		"scenario_key":     "codex:UserPromptSubmit",
+		"phase":            "committed",
+		"status":           "active",
+		"watcher_token":    "w-1",
+		"trace_id":         "trace-xyz",
+		"reason_text":      "hook pre accepted",
+		"state_before_ref": "frame-before",
+		"state_after_ref":  "frame-after",
+		"otel_kind":        "INTERNAL",
+	}
+	for k, v := range wantStrings {
+		gv, ok := got[k]
+		if !ok {
+			t.Fatalf("missing field %s in JSON: %s", k, string(raw))
+		}
+		if gv != v {
+			t.Fatalf("%s = %v, want %q", k, gv, v)
+		}
+	}
+
+	wantNumbers := map[string]float64{
+		"observed_generation": 42,
+		"started_at":          900,
+		"ended_at":            1100,
+	}
+	for k, v := range wantNumbers {
+		gv, ok := got[k]
+		if !ok {
+			t.Fatalf("missing numeric field %s in JSON: %s", k, string(raw))
+		}
+		if fv, ok := gv.(float64); !ok || fv != v {
+			t.Fatalf("%s = %v, want %v", k, gv, v)
+		}
+	}
+
+	// JSON raw fields must round-trip as parsed JSON (not double-encoded
+	// strings) so SPA consumers can read them without a second parse.
+	wantJSON := map[string]string{
+		"decision_ports": `[{"name":"frame_enter"}]`,
+		"attrs":          `{"a":1}`,
+		"input_refs":     `["ref-in"]`,
+		"output_refs":    `["ref-out"]`,
+		"evidence_refs":  `["ev-1"]`,
+	}
+	for k, want := range wantJSON {
+		gv, ok := got[k]
+		if !ok {
+			t.Fatalf("missing JSON field %s in JSON: %s", k, string(raw))
+		}
+		reMarshal, err := json.Marshal(gv)
+		if err != nil {
+			t.Fatalf("remarshal %s: %v", k, err)
+		}
+		if string(reMarshal) != want {
+			t.Fatalf("%s = %s, want %s", k, string(reMarshal), want)
+		}
+	}
+}
+
+// TestMonitorStep_NormalizeEmptyJSON_ToNull verifies that when the store
+// returns an empty/nil json.RawMessage for payload/before/after, the Monitor
+// API normalises the value to the JSON string "null" (existing behaviour of
+// monitorRawJSON). New RawMessage envelope fields stay omitted via omitempty
+// so they do not appear in the response at all (consumer-friendly default).
+func TestMonitorStep_NormalizeEmptyJSON_ToNull(t *testing.T) {
+	step := store.TraceStep{
+		StepID:      "empty",
+		ChainID:     "chain-empty",
+		Seq:         1,
+		Kind:        "trigger",
+		TmuxSession: "work",
+		PaneID:      "%1",
+		// All envelope + legacy JSON fields left nil.
+	}
+
+	ms := monitorStepFromStore(step)
+	if ms.PayloadJSON != "null" {
+		t.Fatalf("PayloadJSON = %q, want %q", ms.PayloadJSON, "null")
+	}
+	if ms.BeforeJSON != "null" {
+		t.Fatalf("BeforeJSON = %q, want %q", ms.BeforeJSON, "null")
+	}
+	if ms.AfterJSON != "null" {
+		t.Fatalf("AfterJSON = %q, want %q", ms.AfterJSON, "null")
+	}
+
+	raw, err := json.Marshal(ms)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	// Legacy JSON fields are non-omitempty strings — they must appear as
+	// "null" so SPA consumers can rely on the field existing.
+	for _, field := range []string{"payload_json", "before_json", "after_json"} {
+		v, ok := got[field]
+		if !ok {
+			t.Fatalf("field %s missing from JSON (want present=\"null\"): %s", field, string(raw))
+		}
+		if v != "null" {
+			t.Fatalf("%s = %v, want \"null\"", field, v)
+		}
+	}
+
+	// New RawMessage envelope fields carry omitempty and must be absent
+	// when the source step has nothing to surface — they would otherwise
+	// leak a bare "null" into every legacy (non-Lights) row.
+	for _, field := range []string{
+		"decision_ports", "attrs", "input_refs", "output_refs", "evidence_refs",
+	} {
+		if _, ok := got[field]; ok {
+			t.Fatalf("empty envelope field %s should be omitted; JSON = %s", field, string(raw))
+		}
+	}
+
+	// Likewise, scalar envelope strings/ints stay absent when unset.
+	for _, field := range []string{
+		"source_kind", "action", "reason_code", "outcome", "scenario_key",
+		"observed_generation", "phase", "status", "watcher_token",
+		"trace_id", "reason_text", "state_before_ref", "state_after_ref",
+		"started_at", "ended_at", "otel_kind",
+	} {
+		if _, ok := got[field]; ok {
+			t.Fatalf("empty envelope field %s should be omitted; JSON = %s", field, string(raw))
+		}
+	}
+}
+
+// TestMonitorChainSummary_IncludesSchemaVersion confirms chain summary
+// responses stamp schema_version = "1.0.0-lights-1b" so the SPA can detect a
+// store rollback (defender recommendation in PR-1b-1c plan D6).
+func TestMonitorChainSummary_IncludesSchemaVersion(t *testing.T) {
+	m := newTestModule(t)
+	if err := m.traces.SaveChain(store.TraceRecord{
+		Chain: store.TraceChain{
+			ChainID:     "chain-sv",
+			StartedAt:   200,
+			CompletedAt: 210,
+			TmuxSession: "work",
+			PaneID:      "%1",
+		},
+	}); err != nil {
+		t.Fatalf("SaveChain: %v", err)
+	}
+
+	// /chains list endpoint
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/monitor/chains?session=work", nil)
+	w := httptest.NewRecorder()
+	m.handleMonitorChains(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200", w.Code)
+	}
+	var listBody struct {
+		Chains []struct {
+			SchemaVersion string `json:"schema_version"`
+			ChainID       string `json:"chain_id"`
+		} `json:"chains"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("list Unmarshal: %v", err)
+	}
+	if len(listBody.Chains) != 1 {
+		t.Fatalf("len(listBody.Chains) = %d, want 1", len(listBody.Chains))
+	}
+	if listBody.Chains[0].SchemaVersion != "1.0.0-lights-1b" {
+		t.Fatalf("list schema_version = %q, want %q", listBody.Chains[0].SchemaVersion, "1.0.0-lights-1b")
+	}
+
+	// /chains/{id} detail endpoint
+	req = httptest.NewRequest(http.MethodGet, "/api/agent/monitor/chains/chain-sv", nil)
+	req.SetPathValue("id", "chain-sv")
+	w = httptest.NewRecorder()
+	m.handleMonitorChain(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("detail status = %d, want 200", w.Code)
+	}
+	var detailBody struct {
+		Chain struct {
+			SchemaVersion string `json:"schema_version"`
+			ChainID       string `json:"chain_id"`
+		} `json:"chain"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &detailBody); err != nil {
+		t.Fatalf("detail Unmarshal: %v", err)
+	}
+	if detailBody.Chain.SchemaVersion != "1.0.0-lights-1b" {
+		t.Fatalf("detail schema_version = %q, want %q", detailBody.Chain.SchemaVersion, "1.0.0-lights-1b")
+	}
+	if detailBody.Chain.ChainID != "chain-sv" {
+		t.Fatalf("detail chain_id = %q, want chain-sv", detailBody.Chain.ChainID)
+	}
+}
+
+// TestMonitorProjection_UnchangedShape is a regression covering the existing
+// non-envelope fields on MonitorStep and MonitorProjectionSummary — none of
+// those names or types may change as part of T9.
+func TestMonitorProjection_UnchangedShape(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%1", "work")
+	m.tmux = fakeTmux
+
+	if _, err := m.frames.Upsert(store.Frame{
+		FrameID:          "frame-regression",
+		PaneID:           "%1",
+		AgentType:        "codex",
+		PID:              2001,
+		PPID:             1,
+		ProcessStartTime: "Sun Apr 20 01:30:00 2026",
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        100,
+		LastSeenAt:       110,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+	if err := m.traces.SaveChain(store.TraceRecord{
+		Chain: store.TraceChain{
+			ChainID:          "chain-regression",
+			StartedAt:        100,
+			CompletedAt:      120,
+			TerminalStatus:   "completed",
+			TerminalReason:   "emit_broadcasted",
+			TmuxSession:      "work",
+			PaneID:           "%1",
+			RootAgentType:    "codex",
+			RootEventName:    "UserPromptSubmit",
+			RootReason:       "hook_post",
+			LatestStepKind:   "emit",
+			LatestDecision:   "broadcasted",
+			LatestStepReason: "session_code_resolved",
+		},
+		Steps: []store.TraceStep{
+			{
+				StepID:      "reg-1",
+				ChainID:     "chain-regression",
+				Seq:         1,
+				Kind:        "trigger",
+				TmuxSession: "work",
+				PaneID:      "%1",
+				AgentType:   "codex",
+				EventName:   "UserPromptSubmit",
+				Decision:    "received",
+				Reason:      "hook_post",
+				PayloadJSON: json.RawMessage(`{"prompt":"hi"}`),
+				CreatedAt:   100,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("SaveChain: %v", err)
+	}
+
+	// projection endpoint
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/monitor/projection?session=work", nil)
+	w := httptest.NewRecorder()
+	m.handleMonitorProjection(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("projection status = %d, want 200", w.Code)
+	}
+	var proj struct {
+		Projection struct {
+			TmuxSession    string `json:"tmux_session"`
+			PaneID         string `json:"pane_id"`
+			PrimaryFrameID string `json:"primary_frame_id"`
+			TopFrameID     string `json:"top_frame_id"`
+			TopAgentType   string `json:"top_agent_type"`
+			LatestChainID  string `json:"latest_chain_id"`
+		} `json:"projection"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &proj); err != nil {
+		t.Fatalf("projection Unmarshal: %v", err)
+	}
+	if proj.Projection.TmuxSession != "work" ||
+		proj.Projection.PaneID != "%1" ||
+		proj.Projection.PrimaryFrameID != "frame-regression" ||
+		proj.Projection.TopFrameID != "frame-regression" ||
+		proj.Projection.TopAgentType != "codex" ||
+		proj.Projection.LatestChainID != "chain-regression" {
+		t.Fatalf("projection shape regressed: %+v", proj.Projection)
+	}
+
+	// detail endpoint — step level legacy shape still present
+	req = httptest.NewRequest(http.MethodGet, "/api/agent/monitor/chains/chain-regression", nil)
+	req.SetPathValue("id", "chain-regression")
+	w = httptest.NewRecorder()
+	m.handleMonitorChain(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("detail status = %d, want 200", w.Code)
+	}
+	var detail struct {
+		Chain struct {
+			ChainID          string `json:"chain_id"`
+			StartedAt        int64  `json:"started_at"`
+			TerminalStatus   string `json:"terminal_status"`
+			LatestStepKind   string `json:"latest_step_kind"`
+			LatestDecision   string `json:"latest_decision"`
+			LatestStepReason string `json:"latest_step_reason"`
+			StepCount        int    `json:"step_count"`
+		} `json:"chain"`
+		StepTree []struct {
+			Step struct {
+				StepID      string `json:"step_id"`
+				ChainID     string `json:"chain_id"`
+				Seq         int    `json:"seq"`
+				Kind        string `json:"kind"`
+				TmuxSession string `json:"tmux_session"`
+				PaneID      string `json:"pane_id"`
+				AgentType   string `json:"agent_type"`
+				EventName   string `json:"event_name"`
+				Decision    string `json:"decision"`
+				Reason      string `json:"reason"`
+				PayloadJSON string `json:"payload_json"`
+				BeforeJSON  string `json:"before_json"`
+				AfterJSON   string `json:"after_json"`
+				CreatedAt   int64  `json:"created_at"`
+			} `json:"step"`
+		} `json:"step_tree"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("detail Unmarshal: %v", err)
+	}
+	// SaveChain / normalizeTraceRecord overwrites latest_* from the last
+	// step when present; we assert against the post-normalize values which
+	// mirror the single step we wrote above.
+	if detail.Chain.ChainID != "chain-regression" ||
+		detail.Chain.TerminalStatus != "completed" ||
+		detail.Chain.LatestStepKind != "trigger" ||
+		detail.Chain.LatestDecision != "received" ||
+		detail.Chain.LatestStepReason != "hook_post" ||
+		detail.Chain.StepCount != 1 {
+		t.Fatalf("chain summary shape regressed: %+v", detail.Chain)
+	}
+	if len(detail.StepTree) != 1 {
+		t.Fatalf("len(StepTree) = %d, want 1", len(detail.StepTree))
+	}
+	step := detail.StepTree[0].Step
+	if step.StepID != "reg-1" ||
+		step.ChainID != "chain-regression" ||
+		step.Seq != 1 ||
+		step.Kind != "trigger" ||
+		step.TmuxSession != "work" ||
+		step.PaneID != "%1" ||
+		step.AgentType != "codex" ||
+		step.EventName != "UserPromptSubmit" ||
+		step.Decision != "received" ||
+		step.Reason != "hook_post" ||
+		step.PayloadJSON != `{"prompt":"hi"}` ||
+		step.BeforeJSON != "null" ||
+		step.AfterJSON != "null" ||
+		step.CreatedAt != 100 {
+		t.Fatalf("step legacy shape regressed: %+v", step)
+	}
+}

--- a/internal/module/agent/observation/role_resolution.go
+++ b/internal/module/agent/observation/role_resolution.go
@@ -1,0 +1,86 @@
+package observation
+
+// EvidenceKeyRoleResolution is the canonical EvidenceRef.Key under which
+// observation producers publish the role-resolution state. The apply pipeline
+// routes pending-production and promote decisions off this typed signal,
+// replacing the earlier verify_reason string-matching contract (P1-8 / D4.1).
+const EvidenceKeyRoleResolution = "role_resolution"
+
+// RoleResolutionState is the typed contract for "can the actor role be
+// determined for this observation?". It replaces implicit verify_reason
+// regex-scanning at the apply layer.
+//
+// Producers (hook / probe / sweep builders, added in T4) MUST attach an
+// EvidenceRef with Key == EvidenceKeyRoleResolution and Value set to one of
+// the three canonical values below. The apply pipeline (T5) reads it via
+// RoleResolutionFromEvidence.
+type RoleResolutionState string
+
+const (
+	// RoleResolved indicates the actor role is positively determined for this
+	// observation. Apply pipeline may proceed toward promotion.
+	RoleResolved RoleResolutionState = "RoleResolved"
+
+	// RoleRetryableUnresolved indicates the role could not be determined but
+	// a later observation may succeed (e.g. pane_unresolvable,
+	// sender_uncertain, identify_mismatch). Apply pipeline routes the
+	// observation to pending and waits for a follow-up.
+	RoleRetryableUnresolved RoleResolutionState = "RoleRetryableUnresolved"
+
+	// RoleTerminalUnresolved indicates the role cannot be determined and
+	// retry is pointless (e.g. session_not_found, sweep reports frame
+	// identity missing). Apply pipeline drops the observation.
+	RoleTerminalUnresolved RoleResolutionState = "RoleTerminalUnresolved"
+)
+
+// isValidRoleResolutionState reports whether s is one of the three canonical
+// enum values. Used as the internal allow-list for RoleResolutionFromEvidence.
+func isValidRoleResolutionState(s RoleResolutionState) bool {
+	switch s {
+	case RoleResolved, RoleRetryableUnresolved, RoleTerminalUnresolved:
+		return true
+	}
+	return false
+}
+
+// RoleResolutionFromEvidence scans ev for the first EvidenceRef whose Key
+// matches EvidenceKeyRoleResolution and returns its parsed enum value plus a
+// boolean ok flag.
+//
+// Behavior:
+//   - Key absent → ("", false).
+//   - Key present, Value is a string equal to one of the canonical enum
+//     values → (enum, true).
+//   - Key present, Value is already a RoleResolutionState whose underlying
+//     string is one of the canonical values → (enum, true).
+//   - Key present but Value is the wrong type (int, bool, nil, struct, bytes,
+//     …) or an unrecognized string → ("", false).
+//   - Multiple matching entries → the first one wins; subsequent duplicates
+//     are ignored (producers should not emit duplicates, but apply-layer
+//     behavior must be deterministic).
+func RoleResolutionFromEvidence(ev []EvidenceRef) (RoleResolutionState, bool) {
+	for _, ref := range ev {
+		if ref.Key != EvidenceKeyRoleResolution {
+			continue
+		}
+
+		// First matching key wins. Type-switch on the Value; reject anything
+		// that is not a canonical enum value.
+		switch v := ref.Value.(type) {
+		case RoleResolutionState:
+			if isValidRoleResolutionState(v) {
+				return v, true
+			}
+			return "", false
+		case string:
+			s := RoleResolutionState(v)
+			if isValidRoleResolutionState(s) {
+				return s, true
+			}
+			return "", false
+		default:
+			return "", false
+		}
+	}
+	return "", false
+}

--- a/internal/module/agent/observation/role_resolution_test.go
+++ b/internal/module/agent/observation/role_resolution_test.go
@@ -1,0 +1,199 @@
+package observation_test
+
+import (
+	"testing"
+
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+// TestRoleResolutionFromEvidence_Resolved verifies that a string-valued
+// role_resolution entry with the "RoleResolved" value returns the typed
+// enum plus ok=true.
+func TestRoleResolutionFromEvidence_Resolved(t *testing.T) {
+	ev := []observation.EvidenceRef{
+		{Key: observation.EvidenceKeyRoleResolution, Value: "RoleResolved"},
+	}
+
+	state, ok := observation.RoleResolutionFromEvidence(ev)
+	if !ok {
+		t.Fatalf("ok = false; want true")
+	}
+	if state != observation.RoleResolved {
+		t.Errorf("state = %q; want %q", state, observation.RoleResolved)
+	}
+}
+
+// TestRoleResolutionFromEvidence_RetryableUnresolved verifies the retryable
+// enum round-trips through a string evidence value.
+func TestRoleResolutionFromEvidence_RetryableUnresolved(t *testing.T) {
+	ev := []observation.EvidenceRef{
+		{Key: "pid", Value: int64(42)},
+		{Key: observation.EvidenceKeyRoleResolution, Value: "RoleRetryableUnresolved"},
+	}
+
+	state, ok := observation.RoleResolutionFromEvidence(ev)
+	if !ok {
+		t.Fatalf("ok = false; want true")
+	}
+	if state != observation.RoleRetryableUnresolved {
+		t.Errorf("state = %q; want %q", state, observation.RoleRetryableUnresolved)
+	}
+}
+
+// TestRoleResolutionFromEvidence_TerminalUnresolved verifies the terminal
+// enum round-trips through a string evidence value.
+func TestRoleResolutionFromEvidence_TerminalUnresolved(t *testing.T) {
+	ev := []observation.EvidenceRef{
+		{Key: observation.EvidenceKeyRoleResolution, Value: "RoleTerminalUnresolved"},
+	}
+
+	state, ok := observation.RoleResolutionFromEvidence(ev)
+	if !ok {
+		t.Fatalf("ok = false; want true")
+	}
+	if state != observation.RoleTerminalUnresolved {
+		t.Errorf("state = %q; want %q", state, observation.RoleTerminalUnresolved)
+	}
+}
+
+// TestRoleResolutionFromEvidence_MissingKey_ReturnsFalse verifies that
+// evidence without the role_resolution key returns ("", false).
+func TestRoleResolutionFromEvidence_MissingKey_ReturnsFalse(t *testing.T) {
+	ev := []observation.EvidenceRef{
+		{Key: "pid", Value: int64(42)},
+		{Key: "verify_reason", Value: "ok"},
+	}
+
+	state, ok := observation.RoleResolutionFromEvidence(ev)
+	if ok {
+		t.Fatalf("ok = true; want false")
+	}
+	if state != "" {
+		t.Errorf("state = %q; want empty", state)
+	}
+}
+
+// TestRoleResolutionFromEvidence_InvalidEnum_ReturnsFalse verifies that a
+// string value that is not one of the three canonical enum values returns
+// ("", false).
+func TestRoleResolutionFromEvidence_InvalidEnum_ReturnsFalse(t *testing.T) {
+	ev := []observation.EvidenceRef{
+		{Key: observation.EvidenceKeyRoleResolution, Value: "RoleFoo"},
+	}
+
+	state, ok := observation.RoleResolutionFromEvidence(ev)
+	if ok {
+		t.Fatalf("ok = true; want false")
+	}
+	if state != "" {
+		t.Errorf("state = %q; want empty", state)
+	}
+}
+
+// TestRoleResolutionFromEvidence_InvalidValueType_ReturnsFalse verifies that
+// non-string / non-RoleResolutionState value types (int, bool, struct, nil)
+// are rejected with ("", false).
+func TestRoleResolutionFromEvidence_InvalidValueType_ReturnsFalse(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{name: "int", value: 42},
+		{name: "int64", value: int64(42)},
+		{name: "bool", value: true},
+		{name: "nil", value: nil},
+		{name: "struct", value: struct{ X int }{X: 1}},
+		{name: "bytes", value: []byte("RoleResolved")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := []observation.EvidenceRef{
+				{Key: observation.EvidenceKeyRoleResolution, Value: tc.value},
+			}
+
+			state, ok := observation.RoleResolutionFromEvidence(ev)
+			if ok {
+				t.Fatalf("ok = true; want false")
+			}
+			if state != "" {
+				t.Errorf("state = %q; want empty", state)
+			}
+		})
+	}
+}
+
+// TestRoleResolutionFromEvidence_AcceptRoleResolutionStateType verifies that
+// evidence values whose concrete type is already RoleResolutionState (not
+// plain string) are recognized. Builders on the producer side may use the
+// typed enum directly.
+func TestRoleResolutionFromEvidence_AcceptRoleResolutionStateType(t *testing.T) {
+	cases := []struct {
+		name string
+		in   observation.RoleResolutionState
+		want observation.RoleResolutionState
+	}{
+		{name: "Resolved", in: observation.RoleResolved, want: observation.RoleResolved},
+		{name: "Retryable", in: observation.RoleRetryableUnresolved, want: observation.RoleRetryableUnresolved},
+		{name: "Terminal", in: observation.RoleTerminalUnresolved, want: observation.RoleTerminalUnresolved},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := []observation.EvidenceRef{
+				{Key: observation.EvidenceKeyRoleResolution, Value: tc.in},
+			}
+
+			state, ok := observation.RoleResolutionFromEvidence(ev)
+			if !ok {
+				t.Fatalf("ok = false; want true")
+			}
+			if state != tc.want {
+				t.Errorf("state = %q; want %q", state, tc.want)
+			}
+		})
+	}
+}
+
+// TestRoleResolutionFromEvidence_EmptyEvidence_ReturnsFalse verifies that
+// both nil and empty slices return ("", false).
+func TestRoleResolutionFromEvidence_EmptyEvidence_ReturnsFalse(t *testing.T) {
+	cases := []struct {
+		name string
+		ev   []observation.EvidenceRef
+	}{
+		{name: "nil", ev: nil},
+		{name: "empty", ev: []observation.EvidenceRef{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state, ok := observation.RoleResolutionFromEvidence(tc.ev)
+			if ok {
+				t.Fatalf("ok = true; want false")
+			}
+			if state != "" {
+				t.Errorf("state = %q; want empty", state)
+			}
+		})
+	}
+}
+
+// TestRoleResolutionFromEvidence_FirstKeyWins verifies that when multiple
+// role_resolution entries are present, the first one is returned (apply
+// pipeline must not rely on duplicates, but a stable deterministic behavior
+// is required).
+func TestRoleResolutionFromEvidence_FirstKeyWins(t *testing.T) {
+	ev := []observation.EvidenceRef{
+		{Key: observation.EvidenceKeyRoleResolution, Value: "RoleResolved"},
+		{Key: observation.EvidenceKeyRoleResolution, Value: "RoleTerminalUnresolved"},
+	}
+
+	state, ok := observation.RoleResolutionFromEvidence(ev)
+	if !ok {
+		t.Fatalf("ok = false; want true")
+	}
+	if state != observation.RoleResolved {
+		t.Errorf("state = %q; want %q (first-wins)", state, observation.RoleResolved)
+	}
+}

--- a/internal/module/agent/observation/trace_id.go
+++ b/internal/module/agent/observation/trace_id.go
@@ -18,11 +18,31 @@ type TraceIDKey struct {
 // TraceIDMinter is the write-side view of the trace-id registry. It is owned
 // by components that advance generations — SessionStart handling in the
 // Arbitrator (PR-1b-1b) mints a new id on start and prunes prior generations
-// on generation advance.
+// on generation advance. PR-1b-1c adds AdoptTraceID so the hook/arbitrator
+// handshake can tunnel a provisional UUID all the way from the hook handler
+// into the (session, gen) registry slot, binding Observation.TraceID and
+// the per-generation public trace_id to the same uuid for correlation.
 type TraceIDMinter interface {
 	// Mint returns the trace_id for (sessionID, generation). See
 	// traceIDRegistry.Mint for repeat-mint and watermark semantics.
 	Mint(sessionID string, generation int64) string
+
+	// AdoptTraceID populates the (sessionID, generation) slot with seed
+	// when the key is absent and returns seed. When the key already holds
+	// a value (from a prior Mint or Adopt), the existing value is returned
+	// and seed is discarded — this idempotent contract protects replay
+	// paths (duplicate SessionStart fan-out) from splitting the trace.
+	//
+	// If seed is the empty string, the call degrades to Mint: a fresh
+	// UUIDv4 is generated, stored, and returned. The degradation exists
+	// because downstream TraceWriter batches reject rows with empty
+	// TraceID; returning "" here would turn a caller bug into a batch
+	// flush failure.
+	//
+	// If generation is below the per-session watermark set by
+	// PruneSessionBefore, AdoptTraceID refuses to populate the key and
+	// returns "". This mirrors Mint's stale-generation rejection.
+	AdoptTraceID(sessionID string, generation int64, seed string) string
 
 	// PruneSessionBefore deletes entries with generation < threshold for the
 	// session and advances the per-session watermark. Returns number of
@@ -130,6 +150,45 @@ func (r *traceIDRegistry) Get(sessionID string, generation int64) (string, bool)
 
 	id, ok := r.cache[key]
 	return id, ok
+}
+
+// AdoptTraceID see TraceIDMinter.AdoptTraceID for the full contract. This
+// is the concrete implementation; it acquires mu.Lock because each branch
+// may mutate r.cache.
+func (r *traceIDRegistry) AdoptTraceID(sessionID string, generation int64, seed string) string {
+	key := TraceIDKey{SessionID: sessionID, Generation: generation}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Reject stale adopts for generations that have already been pruned —
+	// mirrors Mint. An empty return signals the caller must discard and
+	// not propagate the id.
+	if floor, ok := r.watermark[sessionID]; ok && generation < floor {
+		log.Printf("[agent][observation] stale adopt rejected: session=%q generation=%d watermark=%d",
+			sessionID, generation, floor)
+		return ""
+	}
+
+	// Idempotent branch: existing value wins, seed is discarded.
+	if existing, ok := r.cache[key]; ok {
+		return existing
+	}
+
+	// Empty-seed fallback: generate a fresh UUID so callers never receive
+	// an empty TraceID (which would poison validateLightsRow downstream).
+	// Log a warning because an empty seed indicates an upstream builder
+	// missed its uuid.NewString() step.
+	if seed == "" {
+		id := uuid.NewString()
+		r.cache[key] = id
+		log.Printf("[agent][observation] AdoptTraceID received empty seed: session=%q generation=%d; falling back to mint (id=%s)",
+			sessionID, generation, id)
+		return id
+	}
+
+	r.cache[key] = seed
+	return seed
 }
 
 // PruneSessionBefore deletes entries where SessionID == sessionID AND

--- a/internal/module/agent/observation/trace_id_test.go
+++ b/internal/module/agent/observation/trace_id_test.go
@@ -391,6 +391,132 @@ func TestTraceIDRegistry_PruneSession_ResetsWatermark(t *testing.T) {
 	}
 }
 
+// TestTraceIDRegistry_AdoptTraceID_NewPair_UsesSeed verifies that when the
+// (sessionID, generation) key is absent and seed is non-empty, AdoptTraceID
+// writes seed into the registry and returns it verbatim. A subsequent Get
+// must observe the same value (shared state with the Lookup view).
+func TestTraceIDRegistry_AdoptTraceID_NewPair_UsesSeed(t *testing.T) {
+	minter, lookup := observation.NewTraceIDRegistry()
+
+	seed := "seed-uuid-1234"
+	got := minter.AdoptTraceID("s-adopt-new", 1, seed)
+	if got != seed {
+		t.Fatalf("AdoptTraceID on new pair = %q, want seed %q", got, seed)
+	}
+
+	back, ok := lookup.Get("s-adopt-new", 1)
+	if !ok {
+		t.Fatal("Lookup miss after AdoptTraceID; registry was not populated")
+	}
+	if back != seed {
+		t.Fatalf("Lookup returned %q after adopt; want %q", back, seed)
+	}
+}
+
+// TestTraceIDRegistry_AdoptTraceID_ExistingPair_ReturnsOld verifies adoption
+// is idempotent: if the key already has a value, AdoptTraceID returns the
+// existing value and discards seed. This is the replay-safety contract —
+// repeated SessionStart attempts (or duplicate hook fan-out) must not rotate
+// the (session, gen) trace_id.
+func TestTraceIDRegistry_AdoptTraceID_ExistingPair_ReturnsOld(t *testing.T) {
+	minter, lookup := observation.NewTraceIDRegistry()
+
+	first := minter.AdoptTraceID("s-adopt-exist", 2, "original-seed")
+	if first != "original-seed" {
+		t.Fatalf("first adopt = %q, want original-seed", first)
+	}
+
+	second := minter.AdoptTraceID("s-adopt-exist", 2, "different-seed")
+	if second != first {
+		t.Fatalf("repeat adopt rotated trace_id: first=%q second=%q", first, second)
+	}
+
+	got, _ := lookup.Get("s-adopt-exist", 2)
+	if got != first {
+		t.Fatalf("Lookup after repeat adopt = %q, want %q (registry mutated)", got, first)
+	}
+}
+
+// TestTraceIDRegistry_AdoptTraceID_ExistingViaMint_ReturnsMinted verifies the
+// interop contract: if the key was already populated by Mint (legacy path),
+// AdoptTraceID must treat it as existing and return the minted id verbatim.
+// This protects sessions that were started pre-1b-1c adopt path from having
+// their trace_id overwritten if an adopt call reaches the minter afterwards.
+func TestTraceIDRegistry_AdoptTraceID_ExistingViaMint_ReturnsMinted(t *testing.T) {
+	minter, _ := observation.NewTraceIDRegistry()
+
+	minted := minter.Mint("s-adopt-mint", 3)
+	if minted == "" {
+		t.Fatal("Mint returned empty id on fresh registry")
+	}
+	adopted := minter.AdoptTraceID("s-adopt-mint", 3, "some-seed")
+	if adopted != minted {
+		t.Fatalf("AdoptTraceID over minted key = %q, want %q (must not rotate)", adopted, minted)
+	}
+}
+
+// TestTraceIDRegistry_AdoptTraceID_EmptySeed_FallsBackToMint locks the
+// decision for the empty-seed edge case: AdoptTraceID degrades to Mint and
+// returns a fresh UUIDv4, so callers with a malformed seed never get an
+// empty string back (empty TraceID poisons the downstream TraceWriter
+// batch via validateLightsRow). Subsequent adopts for the same key must
+// then be idempotent against that generated id.
+func TestTraceIDRegistry_AdoptTraceID_EmptySeed_FallsBackToMint(t *testing.T) {
+	buf := captureTraceIDLog(t)
+	minter, lookup := observation.NewTraceIDRegistry()
+
+	got := minter.AdoptTraceID("s-adopt-empty", 4, "")
+	if got == "" {
+		t.Fatal("AdoptTraceID with empty seed must not return empty string")
+	}
+	if _, err := uuid.Parse(got); err != nil {
+		t.Fatalf("empty-seed fallback must return valid UUIDv4, got %q: %v", got, err)
+	}
+
+	back, ok := lookup.Get("s-adopt-empty", 4)
+	if !ok || back != got {
+		t.Fatalf("Lookup after empty-seed adopt = (%q,%v), want (%q,true)", back, ok, got)
+	}
+
+	// Idempotency against the generated value: a second adopt (with any
+	// seed) must return the same id.
+	again := minter.AdoptTraceID("s-adopt-empty", 4, "late-seed")
+	if again != got {
+		t.Fatalf("repeat adopt after empty-seed fallback = %q, want %q", again, got)
+	}
+
+	// The fallback path must leave a warning crumb so operators can trace
+	// why a provisional seed went missing.
+	if !strings.Contains(buf.String(), "empty seed") {
+		t.Fatalf("expected 'empty seed' warning in log, got: %q", buf.String())
+	}
+}
+
+// TestTraceIDRegistry_AdoptTraceID_BelowWatermark_ReturnsEmpty locks the
+// defensive contract: if generation is below the per-session watermark set
+// by a prior PruneSessionBefore, AdoptTraceID refuses to populate the key
+// and returns "". This mirrors Mint's behaviour — a stale hook replay must
+// not revive a retired (session, gen) slot.
+func TestTraceIDRegistry_AdoptTraceID_BelowWatermark_ReturnsEmpty(t *testing.T) {
+	buf := captureTraceIDLog(t)
+	minter, lookup := observation.NewTraceIDRegistry()
+
+	minter.Mint("s-adopt-wm", 1)
+	minter.Mint("s-adopt-wm", 2)
+	minter.PruneSessionBefore("s-adopt-wm", 3) // watermark = 3
+
+	got := minter.AdoptTraceID("s-adopt-wm", 1, "stale-seed")
+	if got != "" {
+		t.Fatalf("stale adopt below watermark = %q, want empty string", got)
+	}
+	if _, ok := lookup.Get("s-adopt-wm", 1); ok {
+		t.Error("stale adopt should not populate registry")
+	}
+	if !strings.Contains(buf.String(), "stale") {
+		t.Fatalf("expected stale rejection in log, got: %q", buf.String())
+	}
+}
+
 // TestTraceIDRegistry_Concurrent_Race exercises Mint and PruneSessionBefore
 // concurrently to surface data races under -race. A panic or race report is
 // the failure signal.

--- a/internal/module/agent/observation_builders.go
+++ b/internal/module/agent/observation_builders.go
@@ -1,0 +1,278 @@
+package agent
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/wake/purdex/internal/module/agent/observation"
+	"github.com/wake/purdex/internal/store"
+)
+
+// observation_builders.go defines three pure helper builders that convert
+// hook / probe / sweep inputs into observation.Observation values. They are
+// side-effect free and do no I/O; callers (wired in Stage 3: handler.go /
+// module.go / sweep.go) are responsible for resolving any state (e.g. the
+// current generation or process start_time from FramesStore) and passing it
+// in.
+//
+// Design contract (pr-1b-1c §D1.4 / §D2.3 / §D3 / §D4.1):
+//   - Every builder mints a fresh provisional UUID for Observation.TraceID so
+//     observation.Builder.Build validation never trips on empty trace_id; the
+//     Arbitrator adopts the hook-produced seed for (session, generation) only
+//     on SessionStart via AdoptTraceID.
+//   - Every builder emits the identity triple {pid, pane_id, start_time} in
+//     Evidence (required by §D5.2 divergence writer) plus the role_resolution
+//     state constant (required by §D4.1 apply-layer routing).
+//   - Builders are pure functions — no store reads, no clock reads beyond the
+//     caller-supplied now.
+
+// hookRetryableReasons are verify decisions that allow the apply pipeline to
+// route the observation into the pending window for a retry. A later
+// observation with RoleResolved may promote the actor.
+var hookRetryableReasons = map[string]struct{}{
+	"pane_unresolvable": {},
+	"sender_uncertain":  {},
+	"identify_mismatch": {},
+}
+
+// buildHookObservation constructs a SourceHook observation.
+//
+// Callers must pre-compute:
+//   - observedGeneration: SessionStart -> CurrentGeneration(sessionCode)+1;
+//     other events -> CurrentGeneration(sessionCode).
+//   - startTime: frame.ProcessStartTime resolved from req or FramesStore;
+//     pass "" if completely unresolvable — builder maps it to "unknown" so
+//     evidence always carries a non-empty string for the divergence writer.
+//   - accepted / rejectReason from verifyEventFn.
+func buildHookObservation(
+	sessionCode string,
+	paneID string,
+	pid int64,
+	startTime string,
+	senderPID int64,
+	agentType string,
+	eventName string,
+	observedGeneration int64,
+	accepted bool,
+	rejectReason string,
+	now time.Time,
+) observation.Observation {
+	actorKey := observation.ActorKey{
+		SessionID:  sessionCode,
+		Generation: observedGeneration,
+		ActorID:    "primary:" + agentType,
+	}
+
+	// Lifecycle hint — hooks only drive SessionStart -> active and
+	// SessionEnd -> ended; other event names defer to downstream projection.
+	proposal := observation.StateProposal{ActorKey: actorKey}
+	switch eventName {
+	case "SessionStart":
+		proposal.SuggestStatus = "active"
+	case "SessionEnd":
+		proposal.SuggestStatus = "ended"
+		proposal.EndLifecycle = true
+		proposal.EndReason = "session_end"
+	}
+
+	phase := observation.PhaseCommitted
+	if !accepted {
+		phase = observation.PhaseProposed
+	}
+
+	// Hook evidence contract per §D1.4: identity triple + event_name, plus
+	// sender_pid when distinct from pid (aids multi-sender debugging), plus
+	// role_resolution enum (replaces legacy verify_reason string matching at
+	// apply layer — verify_reason itself is retained for trace debugging when
+	// the observation was rejected).
+	startEvidence := startTime
+	if startEvidence == "" {
+		startEvidence = "unknown"
+	}
+
+	evidence := make([]observation.EvidenceRef, 0, 8)
+	evidence = append(evidence,
+		observation.EvidenceRef{Key: "pid", Value: pid},
+		observation.EvidenceRef{Key: "pane_id", Value: paneID},
+		observation.EvidenceRef{Key: "start_time", Value: startEvidence},
+		observation.EvidenceRef{Key: "event_name", Value: eventName},
+	)
+	if senderPID != pid {
+		evidence = append(evidence, observation.EvidenceRef{Key: "sender_pid", Value: senderPID})
+	}
+
+	role := observation.RoleResolved
+	if !accepted {
+		if _, ok := hookRetryableReasons[rejectReason]; ok {
+			role = observation.RoleRetryableUnresolved
+		} else {
+			role = observation.RoleTerminalUnresolved
+		}
+		evidence = append(evidence, observation.EvidenceRef{Key: "verify_reason", Value: rejectReason})
+	}
+	evidence = append(evidence, observation.EvidenceRef{
+		Key:   observation.EvidenceKeyRoleResolution,
+		Value: role,
+	})
+
+	return observation.Observation{
+		TraceID:            uuid.NewString(),
+		SessionID:          sessionCode,
+		ObservedGeneration: observedGeneration,
+		SourceKind:         observation.SourceHook,
+		Action:             eventName,
+		Phase:              phase,
+		Proposal:           proposal,
+		Evidence:           evidence,
+		ObservedAt:         now,
+		Seq:                now.UnixNano(),
+	}
+}
+
+// probeOutcomeSuggestStatus maps a probe outcome to a legacy projection
+// status hint. Outcomes not in the table fall through to empty SuggestStatus,
+// letting downstream projection decide.
+func probeOutcomeSuggestStatus(outcome string) string {
+	switch outcome {
+	case "dead":
+		return "ended"
+	case "active":
+		return "active"
+	case "idle":
+		return "waiting"
+	case "ready":
+		return "ready"
+	case "error":
+		return "error"
+	}
+	return ""
+}
+
+// buildProbeObservation constructs a SourceProbe observation.
+//
+// Callers must pre-resolve observedGeneration (probes never advance gen;
+// pass CurrentGeneration(sessionCode)) and the identity triple.
+func buildProbeObservation(
+	sessionCode string,
+	paneID string,
+	pid int64,
+	startTime string,
+	agentType string,
+	observedGeneration int64,
+	probeID string,
+	probeToken string,
+	probeKind string,
+	probeOutcome string,
+	now time.Time,
+) observation.Observation {
+	actorKey := observation.ActorKey{
+		SessionID:  sessionCode,
+		Generation: observedGeneration,
+		ActorID:    "primary:" + agentType,
+	}
+	proposal := observation.StateProposal{
+		ActorKey:      actorKey,
+		SuggestStatus: probeOutcomeSuggestStatus(probeOutcome),
+	}
+	if probeOutcome == "dead" {
+		proposal.EndLifecycle = true
+		proposal.EndReason = "probe_dead"
+	}
+
+	// Probe role default = Resolved; identify_mismatch (or any outcome that
+	// explicitly names identity trouble) shifts to Retryable so apply routes
+	// through pending.
+	role := observation.RoleResolved
+	if probeOutcome == "identify_mismatch" || probeOutcome == "sender_uncertain" {
+		role = observation.RoleRetryableUnresolved
+	}
+
+	evidence := []observation.EvidenceRef{
+		{Key: "pid", Value: pid},
+		{Key: "pane_id", Value: paneID},
+		{Key: "start_time", Value: startTime},
+		{Key: "probe_id", Value: probeID},
+		{Key: "probe_kind", Value: probeKind},
+		{Key: "probe_outcome", Value: probeOutcome},
+		{Key: observation.EvidenceKeyRoleResolution, Value: role},
+	}
+
+	return observation.Observation{
+		TraceID:            uuid.NewString(),
+		SessionID:          sessionCode,
+		ObservedGeneration: observedGeneration,
+		SourceKind:         observation.SourceProbe,
+		WatcherToken:       probeToken,
+		Action:             "probe." + probeKind + "." + probeOutcome,
+		Phase:              observation.PhaseProposed,
+		Proposal:           proposal,
+		Evidence:           evidence,
+		ObservedAt:         now,
+		Seq:                now.UnixNano(),
+	}
+}
+
+// buildSweepObservation constructs a SourceSweep observation.
+//
+// sweep never advances generation; callers pass the current
+// CurrentGeneration(frame.SessionCode) — since Frame does not carry a
+// SessionCode field, the sweep wiring in Stage 3 is expected to resolve it
+// via the pane->session mapping and pass observedGeneration in.
+//
+// If frame.ProcessStartTime == "" the builder tags the observation
+// RoleTerminalUnresolved — sweep has nothing to verify against and the
+// observation is dropped by apply.
+func buildSweepObservation(
+	frame store.Frame,
+	reason string,
+	observedGeneration int64,
+	now time.Time,
+) observation.Observation {
+	// Frame.PID is int; preserve value as int64 so evidence always emits
+	// int64 regardless of frame field type (divergence writer type-asserts
+	// to int64).
+	pid := int64(frame.PID)
+
+	actorKey := observation.ActorKey{
+		// SessionID intentionally left empty here — Frame has no session
+		// identity; caller wiring in Stage 3 (sweep.go) may attach the
+		// resolved session after lookup. The actor key collapses to zero
+		// ActorKey if ActorID is empty (frame has AgentType==""), which the
+		// observation.Builder validation tolerates.
+		Generation: observedGeneration,
+		ActorID:    "primary:" + frame.AgentType,
+	}
+	proposal := observation.StateProposal{
+		ActorKey:      actorKey,
+		SuggestStatus: "ended",
+		EndLifecycle:  true,
+		EndReason:     reason,
+	}
+
+	role := observation.RoleResolved
+	if frame.ProcessStartTime == "" {
+		role = observation.RoleTerminalUnresolved
+	}
+
+	evidence := []observation.EvidenceRef{
+		{Key: "pid", Value: pid},
+		{Key: "pane_id", Value: frame.PaneID},
+		{Key: "start_time", Value: frame.ProcessStartTime},
+		{Key: "reason", Value: reason},
+		{Key: "frame_id", Value: frame.FrameID},
+		{Key: observation.EvidenceKeyRoleResolution, Value: role},
+	}
+
+	return observation.Observation{
+		TraceID:            uuid.NewString(),
+		ObservedGeneration: observedGeneration,
+		SourceKind:         observation.SourceSweep,
+		Action:             "sweep.frame_cleared",
+		Phase:              observation.PhaseProposed,
+		Proposal:           proposal,
+		Evidence:           evidence,
+		ObservedAt:         now,
+		Seq:                now.UnixNano(),
+	}
+}

--- a/internal/module/agent/observation_builders_test.go
+++ b/internal/module/agent/observation_builders_test.go
@@ -1,0 +1,401 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wake/purdex/internal/module/agent/observation"
+	"github.com/wake/purdex/internal/store"
+)
+
+// --- helpers -----------------------------------------------------------------
+
+func fixedNow() time.Time {
+	return time.Date(2026, 4, 22, 12, 0, 0, 123456789, time.UTC)
+}
+
+// findEvidence returns the first EvidenceRef with key k or (zero, false).
+func findEvidence(ev []observation.EvidenceRef, k string) (observation.EvidenceRef, bool) {
+	for _, ref := range ev {
+		if ref.Key == k {
+			return ref, true
+		}
+	}
+	return observation.EvidenceRef{}, false
+}
+
+// evidenceString pulls a string value from the evidence slice.
+func evidenceString(t *testing.T, ev []observation.EvidenceRef, k string) string {
+	t.Helper()
+	ref, ok := findEvidence(ev, k)
+	if !ok {
+		t.Fatalf("evidence key %q missing; keys=%v", k, evidenceKeys(ev))
+	}
+	s, ok := ref.Value.(string)
+	if !ok {
+		t.Fatalf("evidence key %q: want string, got %T (%v)", k, ref.Value, ref.Value)
+	}
+	return s
+}
+
+// evidenceInt64 pulls an int64 value from the evidence slice.
+func evidenceInt64(t *testing.T, ev []observation.EvidenceRef, k string) int64 {
+	t.Helper()
+	ref, ok := findEvidence(ev, k)
+	if !ok {
+		t.Fatalf("evidence key %q missing; keys=%v", k, evidenceKeys(ev))
+	}
+	switch v := ref.Value.(type) {
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	default:
+		t.Fatalf("evidence key %q: want int/int64, got %T (%v)", k, ref.Value, ref.Value)
+		return 0
+	}
+}
+
+func evidenceKeys(ev []observation.EvidenceRef) []string {
+	keys := make([]string, 0, len(ev))
+	for _, ref := range ev {
+		keys = append(keys, ref.Key)
+	}
+	return keys
+}
+
+func assertIdentityTriple(t *testing.T, ev []observation.EvidenceRef, wantPID int64, wantPane, wantStart string) {
+	t.Helper()
+	if got := evidenceInt64(t, ev, "pid"); got != wantPID {
+		t.Errorf("evidence.pid = %d, want %d", got, wantPID)
+	}
+	if got := evidenceString(t, ev, "pane_id"); got != wantPane {
+		t.Errorf("evidence.pane_id = %q, want %q", got, wantPane)
+	}
+	if got := evidenceString(t, ev, "start_time"); got != wantStart {
+		t.Errorf("evidence.start_time = %q, want %q", got, wantStart)
+	}
+}
+
+func assertRoleResolution(t *testing.T, ev []observation.EvidenceRef, want observation.RoleResolutionState) {
+	t.Helper()
+	state, ok := observation.RoleResolutionFromEvidence(ev)
+	if !ok {
+		t.Fatalf("role_resolution missing or invalid; evidence keys=%v", evidenceKeys(ev))
+	}
+	if state != want {
+		t.Errorf("role_resolution = %q, want %q", state, want)
+	}
+}
+
+// --- hook builder ------------------------------------------------------------
+
+func TestBuildHookObservation_FullShape_IncludesIdentityTriple_AndRoleResolution(t *testing.T) {
+	now := fixedNow()
+	obs := buildHookObservation(
+		"sess-a", "%1", 4242, "1700000000.00",
+		4242, "cc", "PostToolUse",
+		3,    // observedGeneration
+		true, // accepted
+		"",
+		now,
+	)
+
+	if obs.TraceID == "" {
+		t.Fatal("TraceID must not be empty")
+	}
+	if obs.SourceKind != observation.SourceHook {
+		t.Errorf("SourceKind = %q, want %q", obs.SourceKind, observation.SourceHook)
+	}
+	if obs.Action != "PostToolUse" {
+		t.Errorf("Action = %q, want PostToolUse", obs.Action)
+	}
+	if obs.Phase != observation.PhaseCommitted {
+		t.Errorf("Phase = %q, want PhaseCommitted", obs.Phase)
+	}
+	if obs.SessionID != "sess-a" {
+		t.Errorf("SessionID = %q, want sess-a", obs.SessionID)
+	}
+	if obs.ObservedGeneration != 3 {
+		t.Errorf("ObservedGeneration = %d, want 3", obs.ObservedGeneration)
+	}
+	if obs.Proposal.ActorKey.SessionID != "sess-a" ||
+		obs.Proposal.ActorKey.Generation != 3 ||
+		obs.Proposal.ActorKey.ActorID != "primary:cc" {
+		t.Errorf("ActorKey = %+v, want {sess-a, 3, primary:cc}", obs.Proposal.ActorKey)
+	}
+	if !obs.ObservedAt.Equal(now) {
+		t.Errorf("ObservedAt = %v, want %v", obs.ObservedAt, now)
+	}
+	if obs.Seq != now.UnixNano() {
+		t.Errorf("Seq = %d, want %d", obs.Seq, now.UnixNano())
+	}
+
+	assertIdentityTriple(t, obs.Evidence, 4242, "%1", "1700000000.00")
+	assertRoleResolution(t, obs.Evidence, observation.RoleResolved)
+
+	if got := evidenceString(t, obs.Evidence, "event_name"); got != "PostToolUse" {
+		t.Errorf("evidence.event_name = %q, want PostToolUse", got)
+	}
+}
+
+func TestBuildHookObservation_ProvisionalTraceID_NonEmpty(t *testing.T) {
+	obs := buildHookObservation(
+		"sess-b", "%2", 1, "st", 1, "cc", "PreToolUse",
+		0, true, "", fixedNow(),
+	)
+	if obs.TraceID == "" {
+		t.Fatal("TraceID empty — builder would be rejected by observation.Builder validation")
+	}
+	// different calls must yield different provisional UUIDs
+	obs2 := buildHookObservation(
+		"sess-b", "%2", 1, "st", 1, "cc", "PreToolUse",
+		0, true, "", fixedNow(),
+	)
+	if obs.TraceID == obs2.TraceID {
+		t.Errorf("two hook observations share TraceID %q — should be independent UUIDs", obs.TraceID)
+	}
+}
+
+func TestBuildHookObservation_SessionStart_SuggestStatusActive(t *testing.T) {
+	obs := buildHookObservation(
+		"sess-c", "%3", 11, "st", 11, "cc", "SessionStart",
+		5, true, "", fixedNow(),
+	)
+	if obs.Proposal.SuggestStatus != "active" {
+		t.Errorf("SessionStart SuggestStatus = %q, want active", obs.Proposal.SuggestStatus)
+	}
+	if obs.Proposal.EndLifecycle {
+		t.Errorf("SessionStart EndLifecycle = true, want false")
+	}
+}
+
+func TestBuildHookObservation_SessionEnd_EndLifecycleTrue(t *testing.T) {
+	obs := buildHookObservation(
+		"sess-d", "%4", 77, "st", 77, "cc", "SessionEnd",
+		2, true, "", fixedNow(),
+	)
+	if !obs.Proposal.EndLifecycle {
+		t.Errorf("SessionEnd EndLifecycle = false, want true")
+	}
+	if obs.Proposal.EndReason != "session_end" {
+		t.Errorf("SessionEnd EndReason = %q, want session_end", obs.Proposal.EndReason)
+	}
+	if obs.Proposal.SuggestStatus != "ended" {
+		t.Errorf("SessionEnd SuggestStatus = %q, want ended", obs.Proposal.SuggestStatus)
+	}
+}
+
+func TestBuildHookObservation_VerifyFailed_RoleResolutionRetryable(t *testing.T) {
+	retryableReasons := []string{"pane_unresolvable", "sender_uncertain", "identify_mismatch"}
+	for _, reason := range retryableReasons {
+		t.Run(reason, func(t *testing.T) {
+			obs := buildHookObservation(
+				"sess-e", "%5", 99, "st", 99, "cc", "PostToolUse",
+				1, false, reason, fixedNow(),
+			)
+			if obs.Phase != observation.PhaseProposed {
+				t.Errorf("reject Phase = %q, want PhaseProposed", obs.Phase)
+			}
+			assertRoleResolution(t, obs.Evidence, observation.RoleRetryableUnresolved)
+			if got := evidenceString(t, obs.Evidence, "verify_reason"); got != reason {
+				t.Errorf("evidence.verify_reason = %q, want %q", got, reason)
+			}
+		})
+	}
+}
+
+func TestBuildHookObservation_VerifyFailed_RoleResolutionTerminal_IfTerminalReason(t *testing.T) {
+	terminalReasons := []string{"session_not_found", "", "unknown_wacky_reason"}
+	for _, reason := range terminalReasons {
+		t.Run(reason, func(t *testing.T) {
+			obs := buildHookObservation(
+				"sess-f", "%6", 13, "st", 13, "cc", "PostToolUse",
+				1, false, reason, fixedNow(),
+			)
+			assertRoleResolution(t, obs.Evidence, observation.RoleTerminalUnresolved)
+		})
+	}
+}
+
+func TestBuildHookObservation_StartTimeUnknown_WhenCallerPassesEmpty(t *testing.T) {
+	obs := buildHookObservation(
+		"sess-g", "%7", 21, "", // caller couldn't resolve start_time
+		21, "cc", "PostToolUse",
+		1, true, "", fixedNow(),
+	)
+	if got := evidenceString(t, obs.Evidence, "start_time"); got != "unknown" {
+		t.Errorf("hook empty start_time should map to \"unknown\", got %q", got)
+	}
+}
+
+func TestBuildHookObservation_SenderPID_EmittedWhenDifferentFromPID(t *testing.T) {
+	obs := buildHookObservation(
+		"sess-h", "%8", 10, "st",
+		200, // senderPID != pid
+		"cc", "PostToolUse", 1, true, "", fixedNow(),
+	)
+	if v := evidenceInt64(t, obs.Evidence, "sender_pid"); v != 200 {
+		t.Errorf("sender_pid = %d, want 200", v)
+	}
+
+	// when sender_pid == pid, builder may omit (not required); but if present must equal.
+	obs2 := buildHookObservation(
+		"sess-h", "%8", 10, "st",
+		10, // senderPID == pid
+		"cc", "PostToolUse", 1, true, "", fixedNow(),
+	)
+	if ref, ok := findEvidence(obs2.Evidence, "sender_pid"); ok {
+		if v, _ := ref.Value.(int64); v != 10 {
+			t.Errorf("sender_pid when equal: got %v, want 10", ref.Value)
+		}
+	}
+}
+
+// --- probe builder -----------------------------------------------------------
+
+func TestBuildProbeObservation_OutcomeMapping_DeadToEnded(t *testing.T) {
+	now := fixedNow()
+	obs := buildProbeObservation(
+		"sess-p", "%9", 55, "st",
+		"cc", 7,
+		"probe-liveness-1", "tok-abc",
+		"liveness", "dead",
+		now,
+	)
+	if obs.SourceKind != observation.SourceProbe {
+		t.Errorf("SourceKind = %q, want SourceProbe", obs.SourceKind)
+	}
+	if obs.WatcherToken != "tok-abc" {
+		t.Errorf("WatcherToken = %q, want tok-abc", obs.WatcherToken)
+	}
+	if obs.Phase != observation.PhaseProposed {
+		t.Errorf("Phase = %q, want PhaseProposed", obs.Phase)
+	}
+	if obs.Action != "probe.liveness.dead" {
+		t.Errorf("Action = %q, want probe.liveness.dead", obs.Action)
+	}
+	if obs.Proposal.SuggestStatus != "ended" {
+		t.Errorf("dead SuggestStatus = %q, want ended", obs.Proposal.SuggestStatus)
+	}
+	if !obs.Proposal.EndLifecycle {
+		t.Errorf("dead EndLifecycle = false, want true")
+	}
+	if obs.Proposal.EndReason != "probe_dead" {
+		t.Errorf("dead EndReason = %q, want probe_dead", obs.Proposal.EndReason)
+	}
+	if obs.Proposal.ActorKey.ActorID != "primary:cc" {
+		t.Errorf("ActorKey.ActorID = %q, want primary:cc", obs.Proposal.ActorKey.ActorID)
+	}
+	if obs.TraceID == "" {
+		t.Fatal("TraceID must not be empty")
+	}
+}
+
+func TestBuildProbeObservation_OutcomeMapping_IdentifyMismatch_RoleRetryable(t *testing.T) {
+	obs := buildProbeObservation(
+		"sess-p", "%9", 55, "st",
+		"cc", 1,
+		"probe-1", "tok-1",
+		"liveness", "identify_mismatch",
+		fixedNow(),
+	)
+	assertRoleResolution(t, obs.Evidence, observation.RoleRetryableUnresolved)
+}
+
+func TestBuildProbeObservation_WatcherTokenSet_IdentityTriplePresent(t *testing.T) {
+	obs := buildProbeObservation(
+		"sess-p2", "%10", 300, "1700000111.11",
+		"codex", 2,
+		"probe-activity-7", "tok-xyz",
+		"activity", "active",
+		fixedNow(),
+	)
+	if obs.WatcherToken != "tok-xyz" {
+		t.Errorf("WatcherToken = %q, want tok-xyz", obs.WatcherToken)
+	}
+	assertIdentityTriple(t, obs.Evidence, 300, "%10", "1700000111.11")
+	assertRoleResolution(t, obs.Evidence, observation.RoleResolved)
+
+	if got := evidenceString(t, obs.Evidence, "probe_id"); got != "probe-activity-7" {
+		t.Errorf("probe_id = %q", got)
+	}
+	if got := evidenceString(t, obs.Evidence, "probe_kind"); got != "activity" {
+		t.Errorf("probe_kind = %q", got)
+	}
+	if got := evidenceString(t, obs.Evidence, "probe_outcome"); got != "active" {
+		t.Errorf("probe_outcome = %q", got)
+	}
+	// active -> SuggestStatus "active"; no EndLifecycle.
+	if obs.Proposal.SuggestStatus != "active" {
+		t.Errorf("active SuggestStatus = %q, want active", obs.Proposal.SuggestStatus)
+	}
+	if obs.Proposal.EndLifecycle {
+		t.Errorf("active EndLifecycle = true, want false")
+	}
+}
+
+// --- sweep builder -----------------------------------------------------------
+
+func TestBuildSweepObservation_PidDead_ProposalEndLifecycle_IdentityTriplePresent_RoleResolved(t *testing.T) {
+	now := fixedNow()
+	frame := store.Frame{
+		FrameID:          "frame-1",
+		PaneID:           "%11",
+		PID:              999,
+		ProcessStartTime: "1700000222.22",
+		AgentType:        "cc",
+	}
+	obs := buildSweepObservation(frame, "pid_dead", 4, now)
+
+	if obs.SourceKind != observation.SourceSweep {
+		t.Errorf("SourceKind = %q, want SourceSweep", obs.SourceKind)
+	}
+	if obs.Action != "sweep.frame_cleared" {
+		t.Errorf("Action = %q, want sweep.frame_cleared", obs.Action)
+	}
+	if obs.Phase != observation.PhaseProposed {
+		t.Errorf("Phase = %q, want PhaseProposed", obs.Phase)
+	}
+	if !obs.Proposal.EndLifecycle {
+		t.Errorf("sweep EndLifecycle = false, want true")
+	}
+	if obs.Proposal.EndReason != "pid_dead" {
+		t.Errorf("EndReason = %q, want pid_dead", obs.Proposal.EndReason)
+	}
+	if obs.Proposal.ActorKey.ActorID != "primary:cc" {
+		t.Errorf("ActorKey.ActorID = %q, want primary:cc", obs.Proposal.ActorKey.ActorID)
+	}
+	if obs.ObservedGeneration != 4 {
+		t.Errorf("ObservedGeneration = %d, want 4", obs.ObservedGeneration)
+	}
+	if obs.TraceID == "" {
+		t.Fatal("TraceID must not be empty")
+	}
+	assertIdentityTriple(t, obs.Evidence, 999, "%11", "1700000222.22")
+	assertRoleResolution(t, obs.Evidence, observation.RoleResolved)
+
+	if got := evidenceString(t, obs.Evidence, "reason"); got != "pid_dead" {
+		t.Errorf("evidence.reason = %q, want pid_dead", got)
+	}
+	if got := evidenceString(t, obs.Evidence, "frame_id"); got != "frame-1" {
+		t.Errorf("evidence.frame_id = %q, want frame-1", got)
+	}
+}
+
+func TestBuildSweepObservation_FrameMissingStartTime_RoleTerminalUnresolved(t *testing.T) {
+	frame := store.Frame{
+		FrameID:          "frame-2",
+		PaneID:           "%12",
+		PID:              321,
+		ProcessStartTime: "", // identity missing
+		AgentType:        "cc",
+	}
+	obs := buildSweepObservation(frame, "pid_reused", 2, fixedNow())
+	assertRoleResolution(t, obs.Evidence, observation.RoleTerminalUnresolved)
+
+	// identity triple still emitted (empty string for start_time, since it's missing)
+	if got := evidenceString(t, obs.Evidence, "start_time"); got != "" {
+		t.Errorf("sweep empty start_time should remain \"\", got %q", got)
+	}
+}

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -71,10 +71,26 @@ func (m *Module) clearFrame(frame store.Frame, reason string) error {
 	if m.frames == nil {
 		return nil
 	}
+	// PR-1b-1c T8 / D3: emit a SourceSweep observation before the legacy
+	// clearFrame path runs. buildSweepObservation is pure; caller is
+	// responsible for (a) resolving the session code since store.Frame has
+	// no SessionCode field, and (b) passing the arbitrator's current
+	// generation — sweep never advances gen. On a nil arbitrator (degraded
+	// path) or a saturated input channel, SubmitObservation drops
+	// silently so the legacy clearFrame sequence below still runs
+	// (§D9 fail-open contract).
+	sessionName, code := m.resolvePaneSession(frame.PaneID)
+	var observedGen int64
+	if m.arbitrator != nil {
+		observedGen = m.arbitrator.CurrentGeneration(code)
+	}
+	obs := buildSweepObservation(frame, reason, observedGen, time.Now())
+	obs.SessionID = code
+	m.SubmitObservation(obs)
+
 	if err := m.frames.Delete(frame.FrameID); err != nil {
 		return err
 	}
-	sessionName, code := m.resolvePaneSession(frame.PaneID)
 	if sessionName != "" && m.events != nil {
 		if err := m.events.Delete(sessionName); err != nil {
 			return err

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -1,11 +1,15 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/module/agent/arbitrator"
+	"github.com/wake/purdex/internal/module/agent/arbmode"
+	"github.com/wake/purdex/internal/module/agent/observation"
 	"github.com/wake/purdex/internal/module/session"
 	"github.com/wake/purdex/internal/store"
 	"github.com/wake/purdex/internal/tmux"
@@ -19,6 +23,45 @@ func newSweepTestModule(t *testing.T) *Module {
 	m.tmux = fakeTmux
 	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "work-code", Name: "work"}}}
 	return m
+}
+
+// attachTestArbitrator attaches a lightweight Arbitrator + minter so sweep
+// wiring tests (PR-1b-1c T8) can observe SubmitObservation output without
+// running the full apply pipeline goroutine. inChCap controls the input
+// channel capacity; tests may read from InChForTesting() to snoop the
+// observation, or pre-fill the channel to force a submit drop.
+func attachTestArbitrator(t *testing.T, m *Module, inChCap int) {
+	t.Helper()
+	arbitrator.ResetForTesting()
+	minter, _ := observation.NewTraceIDRegistry()
+	m.traceMinter = minter
+	m.arbmodeMgr = arbmode.NewManager("", "")
+	m.arbitrator = arbitrator.NewArbitrator(arbitrator.Options{
+		Minter:      minter,
+		Arbmode:     m.arbmodeMgr,
+		TraceWriter: &sweepNopTraceSubmitter{},
+		InChCap:     inChCap,
+	})
+}
+
+// sweepNopTraceSubmitter satisfies arbitrator.TraceSubmitter for sweep tests.
+type sweepNopTraceSubmitter struct{}
+
+func (*sweepNopTraceSubmitter) Submit(arbitrator.TraceRecord) {}
+func (*sweepNopTraceSubmitter) Shutdown(_ context.Context) error {
+	return nil
+}
+
+// sweepEvidenceValue returns the Value for the first evidence entry matching
+// key, or nil if none. Named with a sweep prefix so it doesn't collide with
+// T6's evidenceValue(obs, key) (any, bool) helper in handler_observation_test.go.
+func sweepEvidenceValue(obs observation.Observation, key string) interface{} {
+	for _, e := range obs.Evidence {
+		if e.Key == key {
+			return e.Value
+		}
+	}
+	return nil
 }
 
 func TestSweep_ClearsDeadFramesByPid(t *testing.T) {
@@ -282,5 +325,311 @@ func TestSweep_ClearingFramePreservesSiblings(t *testing.T) {
 	}
 	if len(frames) != 1 || frames[0].AgentType != "cc" {
 		t.Fatalf("frames = %+v, want only cc sibling preserved", frames)
+	}
+}
+
+// ----------------------------------------------------------------------
+// PR-1b-1c T8: sweep path observation wiring
+// ----------------------------------------------------------------------
+
+// readSweepObservation drains one observation from the arbitrator's input
+// channel, waiting up to 500ms. Returns the observation or t.Fatal on
+// timeout.
+func readSweepObservation(t *testing.T, m *Module) observation.Observation {
+	t.Helper()
+	select {
+	case obs := <-m.arbitrator.InChForTesting():
+		return obs
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("no observation enqueued on arbitrator InCh within 500ms")
+		return observation.Observation{}
+	}
+}
+
+func TestSweep_PidDead_SubmitsObservation_BeforeClearFrame_IdentityTriplePresent_RoleResolved(t *testing.T) {
+	m := newSweepTestModule(t)
+	attachTestArbitrator(t, m, 8)
+
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              12345,
+		PPID:             1,
+		ProcessStartTime: "Sun Apr 20 01:30:00 2026",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+	origAlive := isPidAliveFn
+	isPidAliveFn = func(pid int) bool { return false }
+	t.Cleanup(func() { isPidAliveFn = origAlive })
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	obs := readSweepObservation(t, m)
+
+	// SourceKind + phase + action
+	if obs.SourceKind != observation.SourceSweep {
+		t.Errorf("SourceKind = %q, want %q", obs.SourceKind, observation.SourceSweep)
+	}
+	if obs.Phase != observation.PhaseProposed {
+		t.Errorf("Phase = %q, want %q", obs.Phase, observation.PhaseProposed)
+	}
+	if obs.Action != "sweep.frame_cleared" {
+		t.Errorf("Action = %q, want sweep.frame_cleared", obs.Action)
+	}
+
+	// Proposal carries EndLifecycle + reason = pid_dead
+	if !obs.Proposal.EndLifecycle {
+		t.Errorf("Proposal.EndLifecycle = false, want true")
+	}
+	if obs.Proposal.EndReason != "pid_dead" {
+		t.Errorf("Proposal.EndReason = %q, want pid_dead", obs.Proposal.EndReason)
+	}
+
+	// Identity triple
+	if got := sweepEvidenceValue(obs, "pid"); got != int64(12345) {
+		t.Errorf("evidence[pid] = %v (%T), want int64(12345)", got, got)
+	}
+	if got := sweepEvidenceValue(obs, "pane_id"); got != "%5" {
+		t.Errorf("evidence[pane_id] = %v, want %%5", got)
+	}
+	if got := sweepEvidenceValue(obs, "start_time"); got != "Sun Apr 20 01:30:00 2026" {
+		t.Errorf("evidence[start_time] = %v, want Sun Apr 20 01:30:00 2026", got)
+	}
+	if got := sweepEvidenceValue(obs, "reason"); got != "pid_dead" {
+		t.Errorf("evidence[reason] = %v, want pid_dead", got)
+	}
+
+	// Role resolution = RoleResolved (identity triple all present)
+	if got := sweepEvidenceValue(obs, observation.EvidenceKeyRoleResolution); got != observation.RoleResolved {
+		t.Errorf("evidence[role_resolution] = %v, want RoleResolved", got)
+	}
+
+	// clearFrame actually ran — frame removed from store
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0 (clearFrame must have run)", len(frames))
+	}
+}
+
+func TestSweep_PidReused_SubmitsObservationWithReusedReason(t *testing.T) {
+	m := newSweepTestModule(t)
+	attachTestArbitrator(t, m, 8)
+
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "A",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	isPidAliveFn = func(pid int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) { return "B", nil }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	obs := readSweepObservation(t, m)
+
+	if obs.Proposal.EndReason != "pid_reused" {
+		t.Errorf("Proposal.EndReason = %q, want pid_reused", obs.Proposal.EndReason)
+	}
+	if got := sweepEvidenceValue(obs, "reason"); got != "pid_reused" {
+		t.Errorf("evidence[reason] = %v, want pid_reused", got)
+	}
+	if got := sweepEvidenceValue(obs, observation.EvidenceKeyRoleResolution); got != observation.RoleResolved {
+		t.Errorf("evidence[role_resolution] = %v, want RoleResolved", got)
+	}
+
+	// clearFrame ran
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0", len(frames))
+	}
+}
+
+func TestSweep_FrameIdentityMissing_RoleTerminalUnresolved(t *testing.T) {
+	// A frame with empty ProcessStartTime reaches clearFrame (e.g. via
+	// dedicated paths that don't require the sweep identity check). We call
+	// clearFrame directly with reason="pid_dead" — the observation must be
+	// tagged RoleTerminalUnresolved by the T4 builder because start_time is
+	// empty.
+	m := newSweepTestModule(t)
+	attachTestArbitrator(t, m, 8)
+
+	frame := store.Frame{
+		FrameID:          "frame-identity-missing",
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              99999,
+		PPID:             1,
+		ProcessStartTime: "", // identity missing
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}
+	if _, err := m.frames.Upsert(frame); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	if err := m.clearFrame(frame, "pid_dead"); err != nil {
+		t.Fatalf("clearFrame: %v", err)
+	}
+
+	obs := readSweepObservation(t, m)
+
+	if got := sweepEvidenceValue(obs, observation.EvidenceKeyRoleResolution); got != observation.RoleTerminalUnresolved {
+		t.Errorf("evidence[role_resolution] = %v, want RoleTerminalUnresolved (empty start_time)", got)
+	}
+}
+
+func TestSweep_SubmitFails_ClearFrameStillRuns(t *testing.T) {
+	// Saturate the arbitrator input channel so a SubmitObservation call for
+	// a PhaseProposed (sweep) observation drops on the fast-path. clearFrame
+	// must still run and delete the frame — D9 fail-open contract.
+	m := newSweepTestModule(t)
+	attachTestArbitrator(t, m, 1)
+
+	// Fill the channel so proposed (sweep) observations drop immediately.
+	ch := m.arbitrator.InChForTesting()
+	ch <- observation.Observation{SessionID: "filler", Phase: observation.PhaseProposed}
+
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              12345,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+	origAlive := isPidAliveFn
+	isPidAliveFn = func(pid int) bool { return false }
+	t.Cleanup(func() { isPidAliveFn = origAlive })
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	// clearFrame still ran — frame gone.
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0 (clearFrame must survive submit drop)", len(frames))
+	}
+
+	// And the drop metric incremented — observation never reached Run.
+	if got := arbitrator.Value("lights_arb_in_dropped", "priority=proposed"); got == 0 {
+		t.Fatalf("lights_arb_in_dropped{priority=proposed} = 0, want >=1 (submit must have dropped)")
+	}
+}
+
+func TestSweep_ObservationHasSessionCode(t *testing.T) {
+	// Frame has no SessionCode field; T8 wiring must populate
+	// Observation.SessionID by resolving pane -> session name -> session code
+	// via resolvePaneSession.
+	m := newSweepTestModule(t)
+	attachTestArbitrator(t, m, 8)
+
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              12345,
+		PPID:             1,
+		ProcessStartTime: "alive",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+	origAlive := isPidAliveFn
+	isPidAliveFn = func(pid int) bool { return false }
+	t.Cleanup(func() { isPidAliveFn = origAlive })
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	obs := readSweepObservation(t, m)
+	if obs.SessionID != "work-code" {
+		t.Fatalf("Observation.SessionID = %q, want %q (resolved from pane %%5 -> session 'work' -> code 'work-code')",
+			obs.SessionID, "work-code")
+	}
+}
+
+func TestSweep_ObservedGenerationIsCurrentGen_NotAdvanced(t *testing.T) {
+	// Sweep never advances generation. The builder must emit
+	// observedGeneration == arbitrator.CurrentGeneration(sessionCode).
+	// For a session that never had a SessionStart, CurrentGeneration == 0.
+	m := newSweepTestModule(t)
+	attachTestArbitrator(t, m, 8)
+
+	if got := m.arbitrator.CurrentGeneration("work-code"); got != 0 {
+		t.Fatalf("precondition: CurrentGeneration(work-code) = %d, want 0", got)
+	}
+
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              12345,
+		PPID:             1,
+		ProcessStartTime: "alive",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+	origAlive := isPidAliveFn
+	isPidAliveFn = func(pid int) bool { return false }
+	t.Cleanup(func() { isPidAliveFn = origAlive })
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	obs := readSweepObservation(t, m)
+	if obs.ObservedGeneration != 0 {
+		t.Fatalf("ObservedGeneration = %d, want 0 (sweep does not advance gen)", obs.ObservedGeneration)
+	}
+
+	// CurrentGeneration must not have moved either.
+	if got := m.arbitrator.CurrentGeneration("work-code"); got != 0 {
+		t.Fatalf("post: CurrentGeneration(work-code) = %d, want 0 (sweep must not advance gen)", got)
 	}
 }

--- a/internal/module/agent/trace.go
+++ b/internal/module/agent/trace.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/wake/purdex/internal/module/agent/arbitrator"
+	"github.com/wake/purdex/internal/module/agent/observation"
 	"github.com/wake/purdex/internal/store"
 )
 
@@ -81,9 +83,20 @@ type hookTraceCollector struct {
 	frameStepID      string
 	projectionStepID string
 	finished         bool
+
+	// traceLookup + sessionCode + observedGeneration wire the chain trace_id
+	// to the shared (session, generation) → trace_id registry (plan D1.2 /
+	// issue #568). When lookup hits, every step reuses the adopted trace_id;
+	// on miss, the chain_id fallback fires once and lights_hook_trace_id_fallback
+	// is incremented. Fields remain zero when the module has no Arbitrator
+	// wired (degraded path); the collector then always falls back to chain_id.
+	traceLookup        observation.TraceIDLookup
+	sessionCode        string
+	observedGeneration int64
+	fallbackCounted    bool
 }
 
-func beginHookTrace(sink *hookTraceSink, req EventRequest) *hookTraceCollector {
+func beginHookTrace(sink *hookTraceSink, req EventRequest, lookup observation.TraceIDLookup, sessionCode string, observedGen int64) *hookTraceCollector {
 	if sink == nil {
 		return nil
 	}
@@ -98,7 +111,10 @@ func beginHookTrace(sink *hookTraceSink, req EventRequest) *hookTraceCollector {
 			RootEventName: req.EventName,
 			RootReason:    "hook_post",
 		},
-		nextSeq: 1,
+		nextSeq:            1,
+		traceLookup:        lookup,
+		sessionCode:        sessionCode,
+		observedGeneration: observedGen,
 	}
 	collector.triggerStepID = collector.append(traceStepInput{
 		Kind:      "trigger",
@@ -109,6 +125,27 @@ func beginHookTrace(sink *hookTraceSink, req EventRequest) *hookTraceCollector {
 		Payload:   req,
 	})
 	return collector
+}
+
+// resolveTraceID returns the shared (session, generation) trace_id when the
+// collector has been wired to the trace-id lookup; otherwise it falls back to
+// the chain_id and increments lights_hook_trace_id_fallback. The fallback is
+// counted once per collector so a single hook invocation with many steps does
+// not spam the counter.
+func (c *hookTraceCollector) resolveTraceID() string {
+	if c == nil {
+		return ""
+	}
+	if c.traceLookup != nil && c.sessionCode != "" {
+		if tid, ok := c.traceLookup.Get(c.sessionCode, c.observedGeneration); ok && tid != "" {
+			return tid
+		}
+	}
+	if !c.fallbackCounted {
+		c.fallbackCounted = true
+		arbitrator.Inc("lights_hook_trace_id_fallback")
+	}
+	return c.chain.ChainID
 }
 
 // traceStepInput carries the optional fields for a single trace step; zero
@@ -200,10 +237,12 @@ func (c *hookTraceCollector) append(in traceStepInput) string {
 		decisionPorts = "[]"
 	}
 	// PR-1b-0: trace_id defaults to chain_id (one hook invocation = one
-	// generation's trace); PR-1b-1 Observation path will mint its own.
+	// generation's trace); PR-1b-1c wires the shared (session, gen) →
+	// trace_id registry lookup and only falls back to chain_id on miss
+	// (transient bootstrap window — metric-only, #568).
 	traceID := in.TraceID
 	if traceID == "" {
-		traceID = c.chain.ChainID
+		traceID = c.resolveTraceID()
 	}
 	reasonText := in.ReasonText
 	if reasonText == "" {

--- a/internal/module/agent/watchers.go
+++ b/internal/module/agent/watchers.go
@@ -1,0 +1,243 @@
+package agent
+
+import (
+	"context"
+	"time"
+
+	"github.com/wake/purdex/internal/agent/probe"
+	"github.com/wake/purdex/internal/module/agent/observation"
+)
+
+// watcherKey scopes a Module-managed probe Watcher to (sessionName, kind).
+// sessionName (tmux session name) is used because probe targets are already
+// keyed by tmux target; the module code translates to session code only
+// when submitting the observation.
+type watcherKey struct {
+	sessionName string
+	kind        probe.Kind
+}
+
+// registerWatcher stores w under (sessionName, kind). A previous watcher
+// under the same key is Stop()'d so we never leak goroutines across
+// replacements. Safe to call concurrently.
+func (m *Module) registerWatcher(sessionName string, kind probe.Kind, w probe.Watcher) {
+	m.watchersMu.Lock()
+	if m.watchers == nil {
+		m.watchers = make(map[watcherKey]probe.Watcher)
+	}
+	key := watcherKey{sessionName: sessionName, kind: kind}
+	prev, ok := m.watchers[key]
+	m.watchers[key] = w
+	m.watchersMu.Unlock()
+	if ok && prev != nil {
+		prev.Stop()
+	}
+}
+
+// takeWatcher removes and returns the watcher registered for (sessionName,
+// kind). The caller is responsible for calling Stop(). Returns (nil, false)
+// when no watcher was registered.
+func (m *Module) takeWatcher(sessionName string, kind probe.Kind) (probe.Watcher, bool) {
+	m.watchersMu.Lock()
+	defer m.watchersMu.Unlock()
+	key := watcherKey{sessionName: sessionName, kind: kind}
+	w, ok := m.watchers[key]
+	if !ok {
+		return nil, false
+	}
+	delete(m.watchers, key)
+	return w, true
+}
+
+// stopWatchersForSession stops every watcher registered under sessionName.
+// Used on session teardown so no probe goroutine outlives the session.
+// Returns the number of watchers actually stopped.
+func (m *Module) stopWatchersForSession(sessionName string) int {
+	m.watchersMu.Lock()
+	keys := make([]watcherKey, 0, len(m.watchers))
+	for k := range m.watchers {
+		if k.sessionName == sessionName {
+			keys = append(keys, k)
+		}
+	}
+	victims := make([]probe.Watcher, 0, len(keys))
+	for _, k := range keys {
+		if w := m.watchers[k]; w != nil {
+			victims = append(victims, w)
+		}
+		delete(m.watchers, k)
+	}
+	m.watchersMu.Unlock()
+
+	for _, w := range victims {
+		w.Stop()
+	}
+	return len(victims)
+}
+
+// stopAllWatchers stops every Module-managed Watcher.
+func (m *Module) stopAllWatchers() {
+	m.watchersMu.Lock()
+	victims := make([]probe.Watcher, 0, len(m.watchers))
+	for _, w := range m.watchers {
+		if w != nil {
+			victims = append(victims, w)
+		}
+	}
+	m.watchers = nil
+	m.watchersMu.Unlock()
+
+	for _, w := range victims {
+		w.Stop()
+	}
+}
+
+// probeOnOutcome returns a probe.Callback that, on every Watcher firing,
+// builds a probe Observation via buildProbeObservation and submits it to
+// the Arbitrator input channel through Module.SubmitObservation.
+//
+// Identity triple resolution: probe targets are tmux sessions, which may
+// host multiple panes. We select the TopFrame of the matching
+// SessionProjection so the observation carries a self-consistent
+// (pane_id, pid, start_time). If no frame exists for the session the
+// callback drops the event silently.
+func (m *Module) probeOnOutcome(sessionName, agentType string, kind probe.Kind) probe.Callback {
+	return func(outcome probe.Outcome, token string, evidence []probe.EvidenceRef) {
+		if m.arbitrator == nil {
+			return
+		}
+		sessionCode := m.resolveSessionCode(sessionName)
+		if sessionCode == "" {
+			return
+		}
+		projection, err := m.projectionForSession(sessionName)
+		if err != nil || projection == nil || projection.TopFrame == nil {
+			return
+		}
+		frame := projection.TopFrame
+
+		observedGen := m.arbitrator.CurrentGeneration(sessionCode)
+		probeID := extractProbeID(evidence)
+
+		obs := buildProbeObservation(
+			sessionCode,
+			frame.PaneID,
+			int64(frame.PID),
+			frame.ProcessStartTime,
+			agentType,
+			observedGen,
+			probeID,
+			token,
+			string(kind),
+			string(outcome),
+			time.Now(),
+		)
+
+		obs.Evidence = mergeProbeEvidence(obs.Evidence, evidence)
+
+		m.SubmitObservation(obs)
+	}
+}
+
+// extractProbeID pulls the probe_id tag the probe watcher minted. Returns
+// "" when not found; buildProbeObservation tolerates the empty string.
+func extractProbeID(ev []probe.EvidenceRef) string {
+	for _, e := range ev {
+		if e.Key == "probe_id" {
+			if s, ok := e.Value.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// mergeProbeEvidence appends non-duplicate probe.EvidenceRef entries onto
+// the builder's observation.EvidenceRef slice. Duplicate keys are skipped
+// so the builder's canonical identity+role emission cannot be shadowed.
+func mergeProbeEvidence(existing []observation.EvidenceRef, extras []probe.EvidenceRef) []observation.EvidenceRef {
+	if len(extras) == 0 {
+		return existing
+	}
+	seen := make(map[string]struct{}, len(existing))
+	for _, e := range existing {
+		seen[e.Key] = struct{}{}
+	}
+	out := existing
+	for _, ex := range extras {
+		if _, ok := seen[ex.Key]; ok {
+			continue
+		}
+		out = append(out, observation.EvidenceRef{Key: ex.Key, Value: ex.Value})
+		seen[ex.Key] = struct{}{}
+	}
+	return out
+}
+
+// getWatchersContext returns the context all Module-managed watchers are
+// parented to. Created lazily so tests bypassing Start can still construct
+// watchers.
+func (m *Module) getWatchersContext() context.Context {
+	m.watchersMu.Lock()
+	defer m.watchersMu.Unlock()
+	if m.watchersCtx == nil {
+		m.watchersCtx, m.watchersCancel = context.WithCancel(context.Background())
+	}
+	return m.watchersCtx
+}
+
+// cancelWatchersContext cancels every Module-managed watcher's parent
+// context.
+func (m *Module) cancelWatchersContext() {
+	m.watchersMu.Lock()
+	cancel := m.watchersCancel
+	m.watchersCancel = nil
+	m.watchersCtx = nil
+	m.watchersMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// startLivenessWatcher spins up a liveness probe Watcher for the given
+// session and registers it under the Module's watcher map.
+func (m *Module) startLivenessWatcher(sessionName, agentType string) probe.Watcher {
+	if m.prober == nil {
+		return nil
+	}
+	ctx := m.getWatchersContext()
+	w := probe.StartLiveness(ctx, probe.Spec{
+		Target:    sessionName + ":",
+		AgentType: agentType,
+	}, m.prober.IsAliveFor, m.probeOnOutcome(sessionName, agentType, probe.KindLiveness))
+	m.registerWatcher(sessionName, probe.KindLiveness, w)
+	return w
+}
+
+// startActivityWatcher spins up an activity probe Watcher.
+func (m *Module) startActivityWatcher(sessionName, agentType string) probe.Watcher {
+	if m.prober == nil {
+		return nil
+	}
+	ctx := m.getWatchersContext()
+	w := probe.StartActivity(ctx, probe.Spec{
+		Target:    sessionName + ":",
+		AgentType: agentType,
+	}, m.prober.StartWatch, m.prober.StopWatch, m.probeOnOutcome(sessionName, agentType, probe.KindActivity))
+	m.registerWatcher(sessionName, probe.KindActivity, w)
+	return w
+}
+
+// startReadinessWatcher spins up a readiness probe Watcher.
+func (m *Module) startReadinessWatcher(sessionName, agentType string) probe.Watcher {
+	if m.prober == nil {
+		return nil
+	}
+	ctx := m.getWatchersContext()
+	w := probe.StartReadiness(ctx, probe.Spec{
+		Target:    sessionName + ":",
+		AgentType: agentType,
+	}, m.prober.CheckReadiness, m.probeOnOutcome(sessionName, agentType, probe.KindReadiness))
+	m.registerWatcher(sessionName, probe.KindReadiness, w)
+	return w
+}

--- a/internal/module/agent/watchers_test.go
+++ b/internal/module/agent/watchers_test.go
@@ -1,0 +1,325 @@
+package agent
+
+// T7 tests (plan D2.1 / D2.2 / D2.3 / D2.4) — Module-side probe Watcher
+// management + probe callback observation build + teardown.
+//
+// The tests exercise probeOnOutcome directly (pushing synthetic
+// outcome+token+evidence) rather than going through probe.Start* — that
+// layer is covered by probe/watchers_test.go. This keeps the module-layer
+// tests decoupled from the probe package's internal goroutine scheduling.
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/probe"
+	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/agent/arbitrator"
+	"github.com/wake/purdex/internal/module/agent/arbmode"
+	"github.com/wake/purdex/internal/module/agent/observation"
+	"github.com/wake/purdex/internal/module/session"
+	"github.com/wake/purdex/internal/store"
+	"github.com/wake/purdex/internal/tmux"
+)
+
+// fakeModuleWatcher satisfies probe.Watcher for module-layer tests.
+// We intentionally do not re-use probe.StartLiveness here — the module
+// tests need a Watcher that records Stop() deterministically without
+// spinning a goroutine.
+type fakeModuleWatcher struct {
+	tokenValue string
+	stopped    atomic.Bool
+}
+
+func newFakeWatcher(id string) *fakeModuleWatcher {
+	return &fakeModuleWatcher{tokenValue: "tok-" + id}
+}
+
+func (f *fakeModuleWatcher) Token() string { return f.tokenValue }
+func (f *fakeModuleWatcher) Rotate() string {
+	f.tokenValue = f.tokenValue + "-rot"
+	return f.tokenValue
+}
+func (f *fakeModuleWatcher) Stop() { f.stopped.Store(true) }
+
+// newProbeObsModule builds a Module wired for probe-path dual-write tests:
+// real AgentEventStore so FramesStore is live, Arbitrator with a buffered
+// InCh (no Run goroutine) so the test can pull submitted observations.
+func newProbeObsModule(t *testing.T, inChCap int) *Module {
+	t.Helper()
+	arbitrator.ResetForTesting()
+
+	events, err := store.OpenAgentEvent(":memory:")
+	if err != nil {
+		t.Fatalf("open agent event store: %v", err)
+	}
+	t.Cleanup(func() { events.Close() })
+
+	m := New(events)
+	m.registry = agentpkg.NewRegistry()
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive: func(string, json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning}
+		},
+	})
+
+	minter, lookup := observation.NewTraceIDRegistry()
+	m.traceMinter = minter
+	m.traceLookup = lookup
+	m.arbmodeMgr = arbmode.NewManager("", "")
+	m.arbitrator = arbitrator.NewArbitrator(arbitrator.Options{
+		Minter:      minter,
+		Lookup:      lookup,
+		Arbmode:     m.arbmodeMgr,
+		TraceWriter: &nopTraceSubmitter{},
+		InChCap:     inChCap,
+	})
+
+	fake := tmux.NewFakeExecutor()
+	fake.SetPaneSessionName("%7", "work")
+	m.tmux = fake
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
+	m.sessions = &fakeSessionProvider{
+		sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}},
+	}
+
+	return m
+}
+
+// seedFrame inserts one frame that maps back to session "work" via pane %7.
+func seedFrame(t *testing.T, m *Module) store.Frame {
+	t.Helper()
+	frame := store.Frame{
+		PaneID:           "%7",
+		AgentType:        "cc",
+		PID:              12345,
+		PPID:             1,
+		ProcessStartTime: "Sun Apr 20 01:30:00 2026",
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        time.Now().UnixNano(),
+		LastSeenAt:       time.Now().UnixNano(),
+		Verified:         true,
+	}
+	stored, err := m.frames.Upsert(frame)
+	if err != nil {
+		t.Fatalf("seed frame: %v", err)
+	}
+	return stored
+}
+
+// drainProbeObs pulls one observation off the arbitrator's InCh with a
+// bounded wait. Fails the test on timeout so tests stay deterministic.
+func drainProbeObs(t *testing.T, m *Module, timeout time.Duration) observation.Observation {
+	t.Helper()
+	select {
+	case obs := <-m.arbitrator.InChForTesting():
+		return obs
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for probe observation on InCh")
+		return observation.Observation{}
+	}
+}
+
+// findObsEvidence returns (value, true) when obs carries evidence under key.
+func findObsEvidence(obs observation.Observation, key string) (any, bool) {
+	for _, e := range obs.Evidence {
+		if e.Key == key {
+			return e.Value, true
+		}
+	}
+	return nil, false
+}
+
+// TestModule_ProbeCallback_SubmitsObservation_WithIdentityTriple_AndRoleResolved
+// verifies the probeOnOutcome callback builds an Observation that carries
+// the identity triple + role_resolution=RoleResolved.
+func TestModule_ProbeCallback_SubmitsObservation_WithIdentityTriple_AndRoleResolved(t *testing.T) {
+	m := newProbeObsModule(t, 8)
+	seeded := seedFrame(t, m)
+
+	cb := m.probeOnOutcome("work", "cc", probe.KindLiveness)
+	cb(probe.OutcomeAlive, "tok-A", []probe.EvidenceRef{
+		{Key: "probe_id", Value: "p-1"},
+		{Key: "probe_kind", Value: string(probe.KindLiveness)},
+	})
+
+	obs := drainProbeObs(t, m, 500*time.Millisecond)
+
+	if obs.SessionID != "code-work" {
+		t.Fatalf("SessionID = %q, want %q", obs.SessionID, "code-work")
+	}
+	if obs.SourceKind != observation.SourceProbe {
+		t.Fatalf("SourceKind = %q, want probe", obs.SourceKind)
+	}
+	if obs.Phase != observation.PhaseProposed {
+		t.Fatalf("Phase = %q, want proposed", obs.Phase)
+	}
+	if obs.WatcherToken != "tok-A" {
+		t.Fatalf("WatcherToken = %q, want tok-A", obs.WatcherToken)
+	}
+	// Identity triple: pid / pane_id / start_time.
+	if v, ok := findObsEvidence(obs, "pid"); !ok || v != int64(seeded.PID) {
+		t.Fatalf("evidence[pid] = %v ok=%v, want %d", v, ok, seeded.PID)
+	}
+	if v, ok := findObsEvidence(obs, "pane_id"); !ok || v != seeded.PaneID {
+		t.Fatalf("evidence[pane_id] = %v ok=%v, want %q", v, ok, seeded.PaneID)
+	}
+	if v, ok := findObsEvidence(obs, "start_time"); !ok || v != seeded.ProcessStartTime {
+		t.Fatalf("evidence[start_time] = %v ok=%v, want %q", v, ok, seeded.ProcessStartTime)
+	}
+	// role_resolution — alive outcome → RoleResolved (not Retryable).
+	if v, ok := findObsEvidence(obs, observation.EvidenceKeyRoleResolution); !ok {
+		t.Fatalf("evidence[%s] missing; evidence=%+v", observation.EvidenceKeyRoleResolution, obs.Evidence)
+	} else if v != observation.RoleResolved {
+		t.Fatalf("evidence[%s] = %v, want %v", observation.EvidenceKeyRoleResolution, v, observation.RoleResolved)
+	}
+}
+
+// TestModule_ProbeLivenessDead_SubmitsEndLifecycleObservation: dead outcome
+// maps to SuggestStatus=ended + EndLifecycle=true (via T4 builder contract).
+func TestModule_ProbeLivenessDead_SubmitsEndLifecycleObservation(t *testing.T) {
+	m := newProbeObsModule(t, 8)
+	seedFrame(t, m)
+
+	cb := m.probeOnOutcome("work", "cc", probe.KindLiveness)
+	cb(probe.OutcomeDead, "tok-A", []probe.EvidenceRef{
+		{Key: "probe_id", Value: "p-1"},
+		{Key: "probe_kind", Value: string(probe.KindLiveness)},
+	})
+
+	obs := drainProbeObs(t, m, 500*time.Millisecond)
+
+	if obs.Proposal.SuggestStatus != "ended" {
+		t.Fatalf("SuggestStatus = %q, want ended", obs.Proposal.SuggestStatus)
+	}
+	if !obs.Proposal.EndLifecycle {
+		t.Fatalf("EndLifecycle = false, want true")
+	}
+	if obs.Proposal.EndReason != "probe_dead" {
+		t.Fatalf("EndReason = %q, want probe_dead", obs.Proposal.EndReason)
+	}
+}
+
+// TestModule_SessionTeardown_StopsAllWatchers: registerWatcher +
+// stopWatchersForSession stops exactly the watchers registered under the
+// given session. Uses a trivial fake Watcher so we can observe Stop calls
+// without the probe goroutine.
+func TestModule_SessionTeardown_StopsAllWatchers(t *testing.T) {
+	m := newProbeObsModule(t, 8)
+
+	wA := newFakeWatcher("a")
+	wB := newFakeWatcher("b")
+	wC := newFakeWatcher("c")
+
+	m.registerWatcher("work", probe.KindLiveness, wA)
+	m.registerWatcher("work", probe.KindActivity, wB)
+	m.registerWatcher("other", probe.KindLiveness, wC)
+
+	n := m.stopWatchersForSession("work")
+	if n != 2 {
+		t.Fatalf("stopWatchersForSession returned %d, want 2", n)
+	}
+	if !wA.stopped.Load() {
+		t.Fatal("watcher A (work/liveness) should be stopped")
+	}
+	if !wB.stopped.Load() {
+		t.Fatal("watcher B (work/activity) should be stopped")
+	}
+	if wC.stopped.Load() {
+		t.Fatal("watcher C (other/liveness) should NOT be stopped")
+	}
+	if _, ok := m.takeWatcher("work", probe.KindLiveness); ok {
+		t.Fatal("takeWatcher(work, liveness) should return not-found after teardown")
+	}
+	if _, ok := m.takeWatcher("other", probe.KindLiveness); !ok {
+		t.Fatal("takeWatcher(other, liveness) should still return the surviving watcher")
+	}
+}
+
+// TestModule_StopAllWatchers_StopsEveryWatcher exercises the Module.Stop
+// codepath without booting the full Start/Stop lifecycle. Mirrors the
+// teardown contract at plan D2.4.
+func TestModule_StopAllWatchers_StopsEveryWatcher(t *testing.T) {
+	m := newProbeObsModule(t, 8)
+
+	w1 := newFakeWatcher("1")
+	w2 := newFakeWatcher("2")
+	m.registerWatcher("work", probe.KindLiveness, w1)
+	m.registerWatcher("other", probe.KindReadiness, w2)
+
+	m.stopAllWatchers()
+
+	if !w1.stopped.Load() || !w2.stopped.Load() {
+		t.Fatalf("expected both watchers stopped; w1=%v w2=%v", w1.stopped.Load(), w2.stopped.Load())
+	}
+}
+
+// TestModule_RegisterWatcher_ReplacesPrevious: a second registration for
+// the same (sessionName, kind) stops the previous Watcher.
+func TestModule_RegisterWatcher_ReplacesPrevious(t *testing.T) {
+	m := newProbeObsModule(t, 8)
+	first := newFakeWatcher("first")
+	second := newFakeWatcher("second")
+
+	m.registerWatcher("work", probe.KindLiveness, first)
+	m.registerWatcher("work", probe.KindLiveness, second)
+
+	if !first.stopped.Load() {
+		t.Fatal("replaced watcher was not stopped")
+	}
+	if second.stopped.Load() {
+		t.Fatal("replacement watcher was stopped prematurely")
+	}
+}
+
+// TestModule_ProbeOutdatedToken_RejectsAtArbitratorWatcherCheck: after
+// Rotate()-like flow (direct rotateWatcherToken) an observation submitted
+// with the old token fails the apply pipeline's watcher check, whereas
+// one with the current token passes. The test exercises the apply
+// pipeline directly through the module-side SubmitObservation and a
+// synchronous Arbitrator drain (we don't call Run; we pull observations
+// and apply them through the deps fixture because apply_test.go covers
+// the deps fixture shape). Here we re-use apply_test's expectations:
+// apply pipeline is a separate test surface, but module-level tests
+// still need to confirm the module submits observations carrying the
+// correct WatcherToken so the apply check receives the authoritative
+// value. That's all the module layer can verify without spinning the
+// Run goroutine.
+func TestModule_ProbeOutdatedToken_RejectsAtArbitratorWatcherCheck(t *testing.T) {
+	m := newProbeObsModule(t, 8)
+	seedFrame(t, m)
+
+	// Build two callbacks scoped to the same session to simulate token
+	// rotation at the probe layer: old callback uses "tok-A", new callback
+	// uses "tok-B". The module is agnostic to rotation — it just tags
+	// whatever token the Watcher hands it. We assert both observations
+	// reach InCh with their respective tokens; the apply pipeline's
+	// checkWatcher gate is exercised in apply_test.go.
+	cb := m.probeOnOutcome("work", "cc", probe.KindLiveness)
+	cb(probe.OutcomeAlive, "tok-A", []probe.EvidenceRef{{Key: "probe_id", Value: "p-1"}})
+	cb(probe.OutcomeDead, "tok-B", []probe.EvidenceRef{{Key: "probe_id", Value: "p-1"}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	seen := map[string]bool{}
+	for len(seen) < 2 {
+		select {
+		case obs := <-m.arbitrator.InChForTesting():
+			seen[obs.WatcherToken] = true
+		case <-ctx.Done():
+			t.Fatalf("expected two observations with tokens tok-A and tok-B; got=%v", seen)
+		}
+	}
+	if !seen["tok-A"] {
+		t.Fatal("missing observation with token tok-A")
+	}
+	if !seen["tok-B"] {
+		t.Fatal("missing observation with token tok-B")
+	}
+}

--- a/spa/src/lib/host-api.ts
+++ b/spa/src/lib/host-api.ts
@@ -230,6 +230,9 @@ export interface AgentMonitorChainSummary {
   latest_decision: string
   latest_step_reason: string
   step_count: number
+  // Lights envelope (PR-1b-0, #569); expected value e.g. "1.0.0-lights-1b".
+  // Optional to stay compatible with older daemons that omit the field.
+  schema_version?: string
 }
 
 export interface AgentMonitorStep {
@@ -250,6 +253,31 @@ export interface AgentMonitorStep {
   before_json: string
   after_json: string
   created_at: number
+  // Lights envelope (PR-1b-0, #569) — all optional because backend uses
+  // `omitempty` and older daemons will not send them. JSON-valued fields
+  // are typed as `unknown` intentionally; consumers must narrow before use
+  // (no `any` to avoid type erosion across the codebase).
+  source_kind?: string
+  action?: string
+  reason_code?: string
+  outcome?: string
+  scenario_key?: string
+  observed_generation?: number
+  decision_ports?: unknown
+  phase?: string
+  status?: string
+  watcher_token?: string
+  trace_id?: string
+  reason_text?: string
+  attrs?: unknown
+  input_refs?: unknown
+  output_refs?: unknown
+  state_before_ref?: unknown
+  state_after_ref?: unknown
+  evidence_refs?: unknown
+  started_at?: number
+  ended_at?: number
+  otel_kind?: string
 }
 
 export interface AgentMonitorStepNode {


### PR DESCRIPTION
## Summary

- **Hook / probe / sweep dual-write** to Arbitrator observation channel. Legacy frame path remains authoritative (PR stays passthrough; Phase 2 will flip to authoritative).
- **frame_divergences** table now receives rows on primary-only proposal ↔ legacy-frame mismatch, with identity triple `{pid, pane_id, start_time}` gating and metric counters for all skip reasons.
- **Pending production entry** via typed `role_resolution` evidence key (`RoleResolved` / `RoleRetryableUnresolved` / `RoleTerminalUnresolved`). Promote on positive signal (immediate `tryPromoteToActorNow` when Resolved observation arrives while pending). **No retry scheduler** — pending driven by deadline flush + coalescing promote only (follow-up tracked for a later PR).
- **SessionStart trace_id adoption**: hook produces a provisional UUID per observation; Arbitrator adopts it via new `TraceIDMinter.AdoptTraceID(sid, gen, seed)` (idempotent). Completes **#568** end-to-end trace_id correlation.
- **Monitor API envelope** (`MonitorStep` + `MonitorChainSummary`) passes PR-1b-0's 22 envelope fields plus a fixed `schema_version: \"1.0.0-lights-1b\"` for SPA rollback detection. Completes **#569** backend and frontend.
- **probe package** gains a stateful Watcher API (`Start` returning `Watcher` with `Token` / `Rotate` / `Stop`); legacy sync callbacks preserved. Module wires per-session watchers and stops them on teardown. Closes **#584** pending production entry.

Closes #568, #569, #584.

### Architecture touch-points

- `frameState` switched from single-goroutine-owner to RWMutex: writers `Lock`, readers (`CurrentGeneration`, etc.) `RLock`. No `atomic.Int64` mixing.
- `apply.go` gen gate rewritten: `obs.gen > current + SessionStart` drives generation; `> current` non-SessionStart rejects `ObservedGenerationAhead`; `==` applies normally; `<` rejects stale.
- Sampler (per-session, single-goroutine) wired before `emitAcceptedTrace` only; rejected / boundary / synthetic traces bypass sampling (diagnostic signal preserved).
- Divergence writer is nil-tolerant on deps; Module injects real `DivergenceStore` + `FramesStore` at construction.

### Scope guard

- Frame schema unchanged (stays Phase 2 PR-2a).
- Authoritative mode still fail-closed in Phase 1 (PR-2b flips it).
- Legacy direct-write paths untouched (PR-2c removes them).

## Test plan

- [x] `go test -race -count=1 ./...` — 26 packages green (incl. stream 71s).
- [x] `go test -race -count=3 ./internal/module/agent/... ./internal/module/agent/observation/... ./internal/module/agent/arbitrator/... ./internal/store/...` — green.
- [x] `go vet ./...` / `go build ./...` — clean.
- [x] `cd spa && pnpm run lint` — 0 errors (2 pre-existing warnings in EditorPane.tsx unrelated to this PR).
- [x] `cd spa && pnpm run build` — green (tsc + vite).
- [x] `cd spa && npx vitest run` — 2506 pass; 3 pre-existing failures in `spa/src/lib/sync/contributors/hosts.test.ts` (token preservation) unrelated to this PR.
- [ ] Manual smoke: launch daemon, trigger SessionStart + PostToolUse hooks, confirm `/api/agent/monitor/chains` returns envelope fields with non-empty trace_id + schema_version, inspect `frame_divergences` row count.
- [ ] Manual smoke: flip `AGENT_ARB_MODE=authoritative`, trigger hook, confirm fail-closed reject (`AuthoritativeNotSupportedPhase1`) and no divergence rows.

## Known follow-up (not in this PR)

- Pending retry scheduler (active re-verify with exponential backoff) — deferred to a later PR.
- Subagent / proxy divergence projection — requires Phase 2 PR-2a frame schema upgrade.
- 3 pre-existing SPA vitest failures in `sync/contributors/hosts.test.ts` — untouched by this PR; should be triaged separately.