### PR TITLE
feat(spa): add untitled editor document flow

### DIFF
--- a/spa/src/components/RenamePopover.tsx
+++ b/spa/src/components/RenamePopover.tsx
@@ -6,6 +6,8 @@ import { isValidSessionName } from '../lib/session-name'
 interface Props {
   anchorRect: DOMRect
   currentName: string
+  initialValue?: string
+  allowUnchangedSubmit?: boolean
   onConfirm: (name: string) => Promise<void>
   onCancel: () => void
   error?: string
@@ -17,9 +19,9 @@ interface Props {
 const POPOVER_WIDTH = 240
 const PADDING = 4
 
-export function RenamePopover({ anchorRect, currentName, onConfirm, onCancel, error, onClearError, placeholder, validateName }: Props) {
+export function RenamePopover({ anchorRect, currentName, initialValue, allowUnchangedSubmit = false, onConfirm, onCancel, error, onClearError, placeholder, validateName }: Props) {
   const t = useI18nStore((s) => s.t)
-  const [draft, setDraft] = useState(currentName)
+  const [draft, setDraft] = useState(initialValue ?? currentName)
   const [submitting, setSubmitting] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -71,7 +73,7 @@ export function RenamePopover({ anchorRect, currentName, onConfirm, onCancel, er
     if (e.key === 'Enter') {
       e.preventDefault()
       const trimmed = draft.trim()
-      if (!trimmed || trimmed === currentName || submitting || validationError) return
+      if (!trimmed || (!allowUnchangedSubmit && trimmed === currentName) || submitting || validationError) return
       setSubmitting(true)
       onConfirm(trimmed).finally(() => setSubmitting(false))
     }

--- a/spa/src/components/editor/EditorNewTabSection.test.tsx
+++ b/spa/src/components/editor/EditorNewTabSection.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorNewTabSection } from './EditorNewTabSection'
+import { useEditorStore } from '../../stores/useEditorStore'
+import { useTabStore } from '../../stores/useTabStore'
+
+const getFsBackendMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../lib/fs-backend', () => ({
+  getFsBackend: getFsBackendMock,
+}))
+
+describe('EditorNewTabSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useEditorStore.getState().clearAllBuffers()
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+  })
+
+  it('creates an untitled markdown document without writing to backend', async () => {
+    const backend = {
+      list: vi.fn(async () => []),
+      write: vi.fn(),
+    }
+    const onSelect = vi.fn()
+    getFsBackendMock.mockReturnValue(backend)
+
+    render(<EditorNewTabSection onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Markdown' }))
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith({
+        kind: 'editor',
+        source: { type: 'inapp' },
+        filePath: 'untitled:Untitled',
+        untitled: {
+          name: 'Untitled',
+          suggestedExtension: '.md',
+          hasBeenRenamed: false,
+        },
+      })
+    })
+
+    expect(backend.write).not.toHaveBeenCalled()
+  })
+
+  it('uses the next readable untitled name when a draft with the same template exists', async () => {
+    const backend = {
+      list: vi.fn(async () => []),
+    }
+    const onSelect = vi.fn()
+    getFsBackendMock.mockReturnValue(backend)
+
+    useTabStore.setState({
+      tabs: {
+        'tab-1': {
+          id: 'tab-1',
+          pinned: false,
+          locked: false,
+          createdAt: 1,
+          layout: {
+            type: 'leaf',
+            pane: {
+              id: 'pane-1',
+              content: {
+                kind: 'editor',
+                source: { type: 'inapp' },
+                filePath: 'untitled:Untitled',
+                untitled: {
+                  name: 'Untitled',
+                  suggestedExtension: '.txt',
+                  hasBeenRenamed: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      tabOrder: ['tab-1'],
+      activeTabId: 'tab-1',
+      visitHistory: [],
+    })
+
+    render(<EditorNewTabSection onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'New File' }))
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith({
+        kind: 'editor',
+        source: { type: 'inapp' },
+        filePath: 'untitled:Untitled-1',
+        untitled: {
+          name: 'Untitled-1',
+          suggestedExtension: '.txt',
+          hasBeenRenamed: false,
+        },
+      })
+    })
+  })
+})

--- a/spa/src/components/editor/EditorNewTabSection.tsx
+++ b/spa/src/components/editor/EditorNewTabSection.tsx
@@ -1,8 +1,9 @@
 import { useCallback } from 'react'
 import { FilePlus, FileText } from '@phosphor-icons/react'
-import { generateId } from '../../lib/id'
 import { getFsBackend } from '../../lib/fs-backend'
+import { scanPaneTree } from '../../lib/pane-tree'
 import { useI18nStore } from '../../stores/useI18nStore'
+import { useTabStore } from '../../stores/useTabStore'
 import type { PaneContent } from '../../types/tab'
 import type { FileSource } from '../../types/fs'
 
@@ -12,38 +13,77 @@ interface Props {
 
 export function EditorNewTabSection({ onSelect }: Props) {
   const t = useI18nStore((s) => s.t)
-  const createFile = useCallback(async (ext: string) => {
-    const id = generateId()
-    const filePath = `/buffer/${id}.${ext}`
+
+  const nextUntitledName = useCallback(async (suggestedExtension: '.txt' | '.md') => {
+    const source: FileSource = { type: 'inapp' }
+    const backend = getFsBackend(source)
+    if (!backend) return null
+
+    const usedFilenames = new Set<string>()
+
+    for (const tab of Object.values(useTabStore.getState().tabs)) {
+      scanPaneTree(tab.layout, (pane) => {
+        if (pane.content.kind !== 'editor' || pane.content.source.type !== 'inapp') return
+        if (pane.content.untitled) {
+          const suffix = pane.content.untitled.hasBeenRenamed ? '' : pane.content.untitled.suggestedExtension
+          usedFilenames.add(`${pane.content.untitled.name}${suffix}`)
+          return
+        }
+        const path = pane.content.filePath
+        if (path.startsWith('/buffer/')) {
+          usedFilenames.add(path.slice('/buffer/'.length))
+        }
+      })
+    }
+
+    const entries = await backend.list('/buffer')
+    for (const entry of entries) {
+      if (!entry.isDir) usedFilenames.add(entry.name)
+    }
+
+    let n = 0
+    let name = 'Untitled'
+    while (usedFilenames.has(`${name}${suggestedExtension}`)) {
+      n += 1
+      name = `Untitled-${n}`
+    }
+
+    return name
+  }, [])
+
+  const createFile = useCallback(async (suggestedExtension: '.txt' | '.md') => {
     const source: FileSource = { type: 'inapp' }
 
-    const backend = getFsBackend(source)
-    if (!backend) {
+    const name = await nextUntitledName(suggestedExtension)
+    if (!name) {
       console.error('[editor] InApp backend not available')
       return
     }
-    try {
-      await backend.write(filePath, new TextEncoder().encode(''))
-    } catch (err) {
-      console.error('[editor] Failed to create file:', err)
-      return
-    }
 
-    onSelect({ kind: 'editor', source, filePath } as PaneContent)
-  }, [onSelect])
+    onSelect({
+      kind: 'editor',
+      source,
+      filePath: `untitled:${name}`,
+      untitled: {
+        name,
+        suggestedExtension,
+        hasBeenRenamed: false,
+      },
+    } as PaneContent)
+  }, [nextUntitledName, onSelect])
 
   return (
     <div className="flex gap-2">
       <button
         className="flex items-center gap-2 px-4 py-2 rounded-lg border border-border-subtle bg-surface-secondary hover:bg-surface-hover text-text-primary text-sm transition-colors"
-        onClick={() => createFile('txt')}
+        onClick={() => createFile('.txt')}
       >
         <FilePlus size={16} />
         {t('editor.new_file')}
       </button>
       <button
         className="flex items-center gap-2 px-4 py-2 rounded-lg border border-border-subtle bg-surface-secondary hover:bg-surface-hover text-text-primary text-sm transition-colors"
-        onClick={() => createFile('md')}
+        onClick={() => createFile('.md')}
       >
         <FileText size={16} />
         {t('editor.new_markdown')}

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -11,6 +11,8 @@ import { EditorStatusBar } from './EditorStatusBar'
 import { RenamePopover } from '../RenamePopover'
 import { findPane } from '../../lib/pane-tree'
 import type { FileSource } from '../../types/fs'
+import type { EditorBufferMetadata, EditorLanguageSource } from '../../stores/useEditorStore'
+import type { UntitledDocumentState } from '../../types/tab'
 
 const TiptapEditor = lazy(() =>
   import('./TiptapEditor').then((m) => ({ default: m.TiptapEditor }))
@@ -31,6 +33,47 @@ function detectLanguage(filePath: string): string {
     java: 'java', c: 'c', cpp: 'cpp', h: 'c', hpp: 'cpp',
   }
   return map[ext] ?? 'plaintext'
+}
+
+function detectLanguageSource(source: FileSource, filePath: string): EditorLanguageSource {
+  if (source.type === 'inapp' && /^\/buffer\/Untitled(?:-\d+)?\./.test(filePath)) {
+    return 'template'
+  }
+  return 'extension'
+}
+
+function isUntitledPath(filePath: string): boolean {
+  return filePath.startsWith('untitled:')
+}
+
+function untitledSuggestedName(untitled: UntitledDocumentState): string {
+  return untitled.hasBeenRenamed ? untitled.name : `${untitled.name}${untitled.suggestedExtension}`
+}
+
+function untitledStoragePath(name: string): string {
+  return `/buffer/${name}`
+}
+
+function displayName(filePath: string, untitled?: UntitledDocumentState): string {
+  return untitled?.name ?? fileName(filePath)
+}
+
+function renamePath(filePath: string, nextName: string, untitled?: UntitledDocumentState): string {
+  return untitled ? `untitled:${nextName}` : siblingPath(filePath, nextName)
+}
+
+function createMetadata(source: FileSource, filePath: string, untitled?: UntitledDocumentState): Pick<EditorBufferMetadata, 'language' | 'languageSource' | 'untitled'> {
+  const resolvedPath = untitled
+    ? untitledStoragePath(untitledSuggestedName(untitled))
+    : filePath
+
+  return {
+    language: detectLanguage(resolvedPath),
+    languageSource: !untitled || untitled.hasBeenRenamed
+      ? detectLanguageSource(source, resolvedPath)
+      : 'template',
+    untitled,
+  }
 }
 
 function fileName(filePath: string): string {
@@ -59,14 +102,6 @@ function renameWarningMessage(error: unknown): string {
   return 'Rename failed'
 }
 
-function sameSource(a: FileSource, b: FileSource): boolean {
-  if (a.type !== b.type) return false
-  if (a.type === 'daemon' && b.type === 'daemon') {
-    return a.hostId === b.hostId
-  }
-  return true
-}
-
 function sourceIdentity(source: FileSource): string {
   return source.type === 'daemon' ? `daemon:${source.hostId}` : source.type
 }
@@ -75,18 +110,24 @@ function sourceIdentity(source: FileSource): string {
 export function EditorPane({ pane, isActive }: PaneRendererProps) {
   const content = pane.content
   if (content.kind !== 'editor') return null
-  return <EditorPaneInner paneId={pane.id} source={content.source} filePath={content.filePath} isActive={isActive} />
+  return <EditorPaneInner paneId={pane.id} source={content.source} filePath={content.filePath} untitled={content.untitled} isActive={isActive} />
 }
 
-function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: string; source: FileSource; filePath: string; isActive: boolean }) {
+function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { paneId: string; source: FileSource; filePath: string; untitled?: UntitledDocumentState; isActive: boolean }) {
   const key = bufferKey(source, filePath)
   const sourceId = sourceIdentity(source)
+  const isUntitled = isUntitledPath(filePath)
+  const currentName = displayName(filePath, untitled)
   const buffer = useEditorStore((s) => s.buffers[key])
   const paneState = useEditorStore((s) => s.paneStates[paneId])
-  const isMarkdown = filePath.endsWith('.md') || filePath.endsWith('.mdx')
+  const isMarkdown = buffer?.language === 'markdown'
   const editorMode = paneState?.editorMode ?? 'raw'
+  const effectiveEditorMode = isMarkdown ? editorMode : 'raw'
   const showDiff = paneState?.showDiff ?? false
+  const canSave = buffer ? (buffer.isDirty || !buffer.lastStat) : false
   const [renameAnchorRect, setRenameAnchorRect] = useState<DOMRect | null>(null)
+  const [renameMode, setRenameMode] = useState<'rename' | 'save'>('rename')
+  const [renameInitialValue, setRenameInitialValue] = useState<string>()
   const [renameWarning, setRenameWarning] = useState<string>()
 
   const handleCursorChange = useCallback((line: number, column: number) => {
@@ -106,10 +147,21 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
     setRenameWarning(undefined)
   }, [filePath])
 
+  useEffect(() => {
+    if (!isMarkdown && editorMode !== 'raw') {
+      useEditorStore.getState().setEditorMode(paneId, 'raw')
+    }
+  }, [editorMode, isMarkdown, paneId])
+
   // Load file on mount, cleanup buffer on unmount
   useEffect(() => {
     let stale = false
     if (useEditorStore.getState().buffers[key]) return // already loaded
+    if (isUntitled) {
+      useEditorStore.getState().openBuffer(key, '', createMetadata(source, filePath, untitled))
+      return
+    }
+
     const backend = getFsBackend(source)
     if (!backend) return
 
@@ -117,20 +169,20 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
       .then((data) => {
         if (stale) return
         const text = new TextDecoder().decode(data)
-        const lang = detectLanguage(filePath)
+        const metadata = createMetadata(source, filePath, untitled)
         return backend.stat(filePath).then((stat) => {
           if (stale) return
-          useEditorStore.getState().openBuffer(key, text, lang, { mtime: stat.mtime, size: stat.size })
+          useEditorStore.getState().openBuffer(key, text, metadata, { mtime: stat.mtime, size: stat.size })
         })
       })
       .catch(() => {
         if (stale) return
         // New file — open empty buffer
-        useEditorStore.getState().openBuffer(key, '', detectLanguage(filePath))
+        useEditorStore.getState().openBuffer(key, '', createMetadata(source, filePath, untitled))
       })
 
     return () => { stale = true }
-  }, [filePath, key, sourceId])
+  }, [filePath, isUntitled, key, sourceId, source, untitled])
 
   // Cleanup pane state only when the pane is truly gone, not just hidden by tab switching.
   useEffect(() => {
@@ -140,7 +192,7 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
         .find(Boolean)
       const stillSameEditor = currentPane?.content.kind === 'editor' &&
         currentPane.content.filePath === filePath &&
-        sameSource(currentPane.content.source, source)
+        sourceIdentity(currentPane.content.source) === sourceId
       if (!stillSameEditor) {
         useEditorStore.getState().closePane(paneId, key)
       }
@@ -150,6 +202,7 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
   // Detect external file changes when tab becomes active
   useEffect(() => {
     if (!isActive) return
+    if (isUntitled) return
 
     const buf = useEditorStore.getState().buffers[key]
     if (!buf) return
@@ -177,11 +230,61 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
       })
       .catch(() => {}) // File may have been deleted
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-check on tab activation, not on source/filePath change
-  }, [isActive, key])
+  }, [isActive, isUntitled, key, source])
 
-  const handleSave = useCallback(async () => {
+  const saveUntitledBuffer = useCallback(async (name: string) => {
     const buf = useEditorStore.getState().buffers[key]
-    if (!buf || !buf.isDirty) return
+    const backend = getFsBackend(source)
+    if (!buf || !backend || !untitled) return
+
+    const trimmedName = name.trim()
+    if (isInvalidRename(trimmedName)) {
+      setRenameWarning('Invalid file name')
+      return
+    }
+
+    const nextPath = untitledStoragePath(trimmedName)
+    const nextKey = bufferKey(source, nextPath)
+    if (nextKey !== key && useEditorStore.getState().buffers[nextKey]) {
+      setRenameWarning('File already exists')
+      return
+    }
+
+    try {
+      const encoded = new TextEncoder().encode(buf.content)
+      await backend.write(nextPath, encoded)
+      const newStat = await backend.stat(nextPath)
+      const nextMetadata = buf.languageSource === 'manual'
+        ? { language: buf.language, languageSource: 'manual' as const, untitled: undefined }
+        : { ...createMetadata(source, nextPath), untitled: undefined }
+      useTabStore.getState().renameEditorPanes(source, filePath, nextPath)
+      useEditorStore.getState().renameBuffer(key, nextKey, nextMetadata)
+      useEditorStore.getState().markSaved(nextKey, { mtime: newStat.mtime, size: newStat.size })
+      useEditorStore.getState().setShowDiff(paneId, false)
+      setRenameAnchorRect(null)
+      setRenameInitialValue(undefined)
+      setRenameWarning(undefined)
+    } catch (err) {
+      console.error('[editor] Save failed:', err)
+    }
+  }, [filePath, key, paneId, source, untitled])
+
+  const handleSave = useCallback(async (anchorRect?: DOMRect) => {
+    const buf = useEditorStore.getState().buffers[key]
+    if (!buf || (!buf.isDirty && buf.lastStat)) return
+    if (buf.untitled) {
+      if (!buf.untitled.hasBeenRenamed) {
+        if (!anchorRect) return
+        setRenameMode('save')
+        setRenameAnchorRect(anchorRect)
+        setRenameInitialValue(untitledSuggestedName(buf.untitled))
+        setRenameWarning(undefined)
+        return
+      }
+      await saveUntitledBuffer(buf.untitled.name)
+      return
+    }
+
     const backend = getFsBackend(source)
     if (!backend) return
     try {
@@ -193,29 +296,55 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
     } catch (err) {
       console.error('[editor] Save failed:', err)
     }
-  }, [filePath, key, paneId, source])
+  }, [filePath, key, paneId, saveUntitledBuffer, source])
 
   const handleRenameSubmit = useCallback(async (nextName: string) => {
-    const backend = getFsBackend(source)
-    if (!backend) return
+    const currentBuffer = useEditorStore.getState().buffers[key]
+    if (!currentBuffer) return
+
+    if (renameMode === 'save') {
+      await saveUntitledBuffer(nextName)
+      return
+    }
 
     if (isInvalidRename(nextName)) {
       setRenameWarning('Invalid file name')
       return
     }
 
-    if (nextName === fileName(filePath)) {
+    if (nextName === currentName) {
       setRenameAnchorRect(null)
+      setRenameInitialValue(undefined)
       setRenameWarning(undefined)
       return
     }
 
-    const nextPath = siblingPath(filePath, nextName)
+    const nextPath = renamePath(filePath, nextName, currentBuffer.untitled)
     const nextKey = bufferKey(source, nextPath)
     if (nextKey !== key && useEditorStore.getState().buffers[nextKey]) {
       setRenameWarning('File already exists')
       return
     }
+
+    if (currentBuffer.untitled) {
+      const nextUntitled: UntitledDocumentState = {
+        ...currentBuffer.untitled,
+        name: nextName,
+        hasBeenRenamed: true,
+      }
+      useTabStore.getState().renameEditorPanes(source, filePath, nextPath, { untitled: nextUntitled })
+      const nextMetadata = currentBuffer.languageSource === 'manual'
+        ? { language: currentBuffer.language, languageSource: 'manual' as const, untitled: nextUntitled }
+        : createMetadata(source, nextPath, nextUntitled)
+      useEditorStore.getState().renameBuffer(key, nextKey, nextMetadata)
+      setRenameAnchorRect(null)
+      setRenameInitialValue(undefined)
+      setRenameWarning(undefined)
+      return
+    }
+
+    const backend = getFsBackend(source)
+    if (!backend) return
 
     if (!isCaseOnlyRename(filePath, nextPath)) {
       try {
@@ -228,15 +357,21 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
     }
 
     try {
-      await backend.rename(filePath, nextPath)
+      if (currentBuffer?.lastStat) {
+        await backend.rename(filePath, nextPath)
+      }
       useTabStore.getState().renameEditorPanes(source, filePath, nextPath)
-      useEditorStore.getState().renameBuffer(key, nextKey, detectLanguage(nextPath))
+      const nextMetadata = currentBuffer?.languageSource === 'manual'
+        ? { language: currentBuffer.language, languageSource: 'manual' as const }
+        : createMetadata(source, nextPath)
+      useEditorStore.getState().renameBuffer(key, nextKey, nextMetadata)
       setRenameAnchorRect(null)
+      setRenameInitialValue(undefined)
       setRenameWarning(undefined)
     } catch (error) {
       setRenameWarning(renameWarningMessage(error))
     }
-  }, [filePath, key, source])
+  }, [currentName, filePath, key, renameMode, saveUntitledBuffer, source])
 
   if (!buffer) {
     return <div className="flex-1 flex items-center justify-center text-text-muted text-xs">Loading...</div>
@@ -245,13 +380,18 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
   return (
     <div className="h-full w-full flex flex-col overflow-hidden">
       <EditorToolbar
+        source={source}
         filePath={filePath}
+        displayPath={untitled ? untitled.name : undefined}
         isDirty={buffer.isDirty}
+        canSave={canSave}
         showDiff={showDiff}
         onSave={handleSave}
         onDiff={() => useEditorStore.getState().setShowDiff(paneId, !showDiff)}
         onRenameStart={(anchorRect) => {
+          setRenameMode('rename')
           setRenameAnchorRect(anchorRect)
+          setRenameInitialValue(undefined)
           setRenameWarning(undefined)
         }}
       />
@@ -262,7 +402,7 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
             modified={buffer.content}
             language={buffer.language}
           />
-        ) : editorMode === 'raw' ? (
+        ) : effectiveEditorMode === 'raw' ? (
           <MonacoWrapper
             key={buffer.modelId}
             content={buffer.content}
@@ -290,17 +430,27 @@ function EditorPaneInner({ paneId, source, filePath, isActive }: { paneId: strin
         source={source}
         line={paneState?.cursorPosition.line ?? 1}
         column={paneState?.cursorPosition.column ?? 1}
+        language={buffer.language}
+        eol={buffer.eol}
+        encoding={buffer.encoding}
         isMarkdown={isMarkdown}
-        editorMode={editorMode}
-        onModeChange={(mode) => useEditorStore.getState().setEditorMode(paneId, mode)}
+        editorMode={effectiveEditorMode}
+        onLanguageChange={(language) => useEditorStore.getState().setBufferLanguage(key, language)}
+        onModeChange={(mode) => {
+          if (!isMarkdown && mode === 'wysiwyg') return
+          useEditorStore.getState().setEditorMode(paneId, mode)
+        }}
       />
       {renameAnchorRect && (
         <RenamePopover
           anchorRect={renameAnchorRect}
-          currentName={fileName(filePath)}
+          currentName={currentName}
+          initialValue={renameInitialValue}
+          allowUnchangedSubmit={renameMode === 'save'}
           onConfirm={handleRenameSubmit}
           onCancel={() => {
             setRenameAnchorRect(null)
+            setRenameInitialValue(undefined)
             setRenameWarning(undefined)
           }}
           error={renameWarning}

--- a/spa/src/components/editor/EditorStatusBar.test.tsx
+++ b/spa/src/components/editor/EditorStatusBar.test.tsx
@@ -12,21 +12,27 @@ describe('EditorStatusBar', () => {
     }
   })
 
-  it('shows Purdex badge for in-app editor', () => {
+  it('shows plain Purdex text for in-app editor', () => {
     render(
       <EditorStatusBar
         source={{ type: 'inapp' }}
         line={17}
         column={25}
-        isMarkdown={true}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
         editorMode="raw"
         onModeChange={() => {}}
+        onLanguageChange={() => {}}
       />,
     )
 
-    const badge = screen.getByText('Purdex')
-    expect(badge.className).toContain('violet')
-    expect(screen.getByText('Ln 17, Col 25')).toBeInTheDocument()
+    const source = screen.getByText('Purdex')
+    const position = screen.getByText('Ln 17, Col 25')
+
+    expect(source).toHaveClass('text-text-secondary', 'select-none')
+    expect(position).toHaveClass('text-text-secondary', 'select-none')
   })
 
   it('shows daemon host name on the left', () => {
@@ -36,46 +42,152 @@ describe('EditorStatusBar', () => {
         source={{ type: 'daemon', hostId }}
         line={3}
         column={9}
-        isMarkdown={true}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
         editorMode="raw"
         onModeChange={() => {}}
+        onLanguageChange={() => {}}
       />,
     )
 
     expect(screen.getByText('mlab')).toBeInTheDocument()
   })
 
-  it('uses Source / Live Preview labels and switches modes from the menu', () => {
+  it('shows document metadata values in the status bar', () => {
+    render(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        language="markdown"
+        eol="crlf"
+        encoding="utf8"
+        isMarkdown
+        editorMode="raw"
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('UTF-8')).toBeInTheDocument()
+    expect(screen.getByText('CRLF')).toBeInTheDocument()
+    expect(screen.getByTitle('Select language')).toHaveTextContent('Markdown')
+  })
+
+  it('uses Source / Live Mode labels and switches modes from the menu', () => {
     const onModeChange = vi.fn()
     render(
       <EditorStatusBar
         source={{ type: 'inapp' }}
         line={1}
         column={1}
-        isMarkdown={true}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
         editorMode="raw"
         onModeChange={onModeChange}
+        onLanguageChange={() => {}}
       />,
     )
 
     fireEvent.click(screen.getByTitle('Toggle editor mode'))
-    fireEvent.click(screen.getByText('Live Preview'))
+    fireEvent.click(screen.getByRole('button', { name: 'Live Mode' }))
 
     expect(onModeChange).toHaveBeenCalledWith('wysiwyg')
   })
 
-  it('does not show mode switcher for non-markdown files', () => {
+  it('keeps the mode selector for non-markdown files and disables Live Mode', () => {
     render(
       <EditorStatusBar
         source={{ type: 'local' }}
         line={8}
         column={4}
+        language="plaintext"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown={false}
+        editorMode="raw"
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByTitle('Toggle editor mode')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle('Toggle editor mode'))
+
+    expect(screen.getByRole('button', { name: 'Source ✓' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Live Mode' })).toBeDisabled()
+    expect(screen.getByText('Ln 8, Col 4')).toBeInTheDocument()
+  })
+
+  it('switches the language from the selector', () => {
+    const onLanguageChange = vi.fn()
+
+    render(
+      <EditorStatusBar
+        source={{ type: 'local' }}
+        line={8}
+        column={4}
+        language="plaintext"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown={false}
+        editorMode="raw"
+        onModeChange={() => {}}
+        onLanguageChange={onLanguageChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByTitle('Select language'))
+    fireEvent.click(screen.getByRole('button', { name: 'Markdown' }))
+
+    expect(onLanguageChange).toHaveBeenCalledWith('markdown')
+  })
+
+  it('keeps cursor info and selectors inside the same block flex container', () => {
+    render(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
+        editorMode="raw"
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    const controls = screen.getByText('Ln 1, Col 1').parentElement
+
+    expect(controls?.tagName).toBe('DIV')
+    expect(controls).toHaveClass('ml-auto')
+    expect(controls).toContainElement(screen.getByTitle('Toggle editor mode'))
+    expect(controls).toContainElement(screen.getByTitle('Select language'))
+  })
+
+  it('keeps cursor info and hides selectors only when changes are unavailable', () => {
+    render(
+      <EditorStatusBar
+        source={{ type: 'local' }}
+        line={8}
+        column={4}
+        language="plaintext"
+        eol="lf"
+        encoding="utf8"
         isMarkdown={false}
         editorMode="raw"
       />,
     )
 
     expect(screen.queryByTitle('Toggle editor mode')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Select language')).not.toBeInTheDocument()
     expect(screen.getByText('Ln 8, Col 4')).toBeInTheDocument()
   })
 })

--- a/spa/src/components/editor/EditorStatusBar.tsx
+++ b/spa/src/components/editor/EditorStatusBar.tsx
@@ -3,82 +3,151 @@ import { CaretUp } from '@phosphor-icons/react'
 import { useClickOutside } from '../../hooks/useClickOutside'
 import { useHostStore } from '../../stores/useHostStore'
 import type { FileSource } from '../../types/fs'
+import type { EditorEol, EditorEncoding } from '../../stores/useEditorStore'
 
 interface Props {
   source: FileSource
   line: number
   column: number
+  language: string
+  eol: EditorEol
+  encoding: EditorEncoding
   isMarkdown: boolean
   editorMode: 'raw' | 'wysiwyg'
   onModeChange?: (mode: 'raw' | 'wysiwyg') => void
+  onLanguageChange?: (language: string) => void
 }
 
-const EDITOR_MODE_COLORS = 'bg-blue-900/40 text-blue-400 border-blue-700/50'
-const INAPP_BADGE_COLORS = 'bg-violet-900/40 text-violet-300 border-violet-700/50'
+const EDITOR_MODE_COLORS = 'bg-[rgba(31,46,163,0.18)] text-blue-400 shadow-[0_0_18px_rgba(47,100,255,0.18)] hover:bg-[rgba(42,61,196,0.24)]'
+const EDITOR_MODE_BUTTON_STYLE = {
+  borderColor: 'color-mix(in oklab, var(--color-blue-400) 50%, transparent)',
+}
 
-function sourceLabel(source: FileSource, hosts: Record<string, { name: string }>): { label: string; badgeClass?: string } {
+const LANGUAGE_OPTIONS = [
+  { value: 'plaintext', label: 'Plain Text' },
+  { value: 'markdown', label: 'Markdown' },
+  { value: 'typescript', label: 'TypeScript' },
+  { value: 'typescriptreact', label: 'TypeScript React' },
+  { value: 'javascript', label: 'JavaScript' },
+  { value: 'javascriptreact', label: 'JavaScript React' },
+  { value: 'json', label: 'JSON' },
+  { value: 'html', label: 'HTML' },
+  { value: 'css', label: 'CSS' },
+  { value: 'yaml', label: 'YAML' },
+  { value: 'go', label: 'Go' },
+  { value: 'python', label: 'Python' },
+  { value: 'rust', label: 'Rust' },
+  { value: 'shell', label: 'Shell' },
+]
+
+function sourceLabel(source: FileSource, hosts: Record<string, { name: string }>): string {
   switch (source.type) {
     case 'inapp':
-      return { label: 'Purdex', badgeClass: INAPP_BADGE_COLORS }
+      return 'Purdex'
     case 'local':
-      return { label: 'Local' }
+      return 'Local'
     case 'daemon':
-      return { label: hosts[source.hostId]?.name ?? 'Unknown' }
+      return hosts[source.hostId]?.name ?? 'Unknown'
   }
 }
 
-export function EditorStatusBar({ source, line, column, isMarkdown, editorMode, onModeChange }: Props) {
-  const [menuOpen, setMenuOpen] = useState(false)
-  const menuRef = useRef<HTMLDivElement>(null)
+function languageLabel(language: string): string {
+  return LANGUAGE_OPTIONS.find((option) => option.value === language)?.label ?? language
+}
+
+export function EditorStatusBar({ source, line, column, language, eol, encoding, isMarkdown, editorMode, onModeChange, onLanguageChange }: Props) {
+  const [modeMenuOpen, setModeMenuOpen] = useState(false)
+  const [languageMenuOpen, setLanguageMenuOpen] = useState(false)
+  const modeMenuRef = useRef<HTMLDivElement>(null)
+  const languageMenuRef = useRef<HTMLDivElement>(null)
   const hosts = useHostStore((s) => s.hosts)
-  const closeMenu = useCallback(() => setMenuOpen(false), [])
-  useClickOutside(menuRef, closeMenu)
+  const closeModeMenu = useCallback(() => setModeMenuOpen(false), [])
+  const closeLanguageMenu = useCallback(() => setLanguageMenuOpen(false), [])
+  useClickOutside(modeMenuRef, closeModeMenu)
+  useClickOutside(languageMenuRef, closeLanguageMenu)
 
   useEffect(() => {
-    if (!menuOpen) return
+    if (!modeMenuOpen && !languageMenuOpen) return
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeMenu()
+      if (e.key === 'Escape') {
+        closeModeMenu()
+        closeLanguageMenu()
+      }
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [menuOpen, closeMenu])
+  }, [modeMenuOpen, languageMenuOpen, closeLanguageMenu, closeModeMenu])
 
-  const currentModeLabel = editorMode === 'raw' ? 'Source' : 'Live Preview'
+  const currentModeLabel = editorMode === 'raw' ? 'Source' : 'Live Mode'
   const currentSource = sourceLabel(source, hosts)
+  const currentLanguageLabel = languageLabel(language)
+  const canUseLiveMode = isMarkdown || language === 'markdown'
 
   return (
     <div className="h-6 bg-surface-secondary border-t border-border-subtle flex items-center px-3 text-[10px] text-text-muted gap-3 flex-shrink-0 relative z-10">
-      {currentSource.badgeClass ? (
-        <span className={`px-[7px] rounded-[3px] border text-[10px] leading-4 ${currentSource.badgeClass}`}>
-          {currentSource.label}
-        </span>
-      ) : (
-        <span className="text-text-secondary select-none">{currentSource.label}</span>
-      )}
-      <span className="ml-auto flex items-center gap-3">
-        <span>Ln {line}, Col {column}</span>
-        {isMarkdown && onModeChange && (
-          <div className="relative" ref={menuRef}>
+      <span className="text-text-secondary select-none">{currentSource}</span>
+      <div className="ml-auto flex items-center gap-3">
+        <span className="text-text-secondary select-none">Ln {line}, Col {column}</span>
+        <span className="text-text-secondary select-none">{eol.toUpperCase()}</span>
+        <span className="text-text-secondary select-none">{encoding.toUpperCase().replace('UTF8', 'UTF-8')}</span>
+        {onLanguageChange && (
+          <div className="relative" ref={languageMenuRef}>
             <button
+              type="button"
+              title="Select language"
+              onClick={() => setLanguageMenuOpen((value) => !value)}
+              className="flex items-center gap-1 px-2 py-0.5 rounded border border-border-subtle text-[10px] text-text-secondary hover:bg-surface-hover transition-colors"
+            >
+              {currentLanguageLabel}
+              <CaretUp size={10} className={`transition-transform ${languageMenuOpen ? '' : 'rotate-180'}`} />
+            </button>
+            {languageMenuOpen && (
+              <div className="absolute bottom-full right-0 mb-1 bg-surface-elevated border border-border-default rounded-md shadow-lg py-1 min-w-[160px] max-h-60 overflow-y-auto">
+                {LANGUAGE_OPTIONS.map((option) => (
+                  <button
+                    type="button"
+                    key={option.value}
+                    onClick={() => {
+                      onLanguageChange(option.value)
+                      setLanguageMenuOpen(false)
+                    }}
+                    className={`w-full px-3 py-1 text-left text-[10px] transition-colors hover:bg-surface-hover ${option.value === language ? 'text-white' : 'text-text-secondary'}`}
+                  >
+                    {option.label} {option.value === language && '\u2713'}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {onModeChange && (
+          <div className="relative" ref={modeMenuRef}>
+            <button
+              type="button"
               title="Toggle editor mode"
-              onClick={() => setMenuOpen((v) => !v)}
+              onClick={() => setModeMenuOpen((value) => !value)}
               className={`flex items-center gap-1 px-2 py-0.5 rounded border text-[10px] cursor-pointer transition-colors ${EDITOR_MODE_COLORS}`}
+              style={EDITOR_MODE_BUTTON_STYLE}
             >
               {currentModeLabel}
-              <CaretUp size={10} className={`transition-transform ${menuOpen ? '' : 'rotate-180'}`} />
+              <CaretUp size={10} className={`transition-transform ${modeMenuOpen ? '' : 'rotate-180'}`} />
             </button>
-            {menuOpen && (
+            {modeMenuOpen && (
               <div className="absolute bottom-full right-0 mb-1 bg-surface-elevated border border-border-default rounded-md shadow-lg py-1 min-w-[120px]">
                 {(['raw', 'wysiwyg'] as const).map((mode) => {
-                  const label = mode === 'raw' ? 'Source' : 'Live Preview'
+                  const label = mode === 'raw' ? 'Source' : 'Live Mode'
+                  const disabled = mode === 'wysiwyg' && !canUseLiveMode
                   return (
                     <button
+                      type="button"
                       key={mode}
+                      disabled={disabled}
                       onClick={() => {
+                        if (disabled) return
                         onModeChange(mode)
-                        setMenuOpen(false)
+                        setModeMenuOpen(false)
                       }}
-                      className={`w-full px-3 py-1 text-left text-[10px] cursor-pointer transition-colors hover:bg-surface-hover ${mode === editorMode ? 'text-white' : 'text-text-secondary'}`}
+                      className={`w-full px-3 py-1 text-left text-[10px] transition-colors ${disabled ? 'cursor-not-allowed text-text-muted/60' : 'cursor-pointer hover:bg-surface-hover'} ${mode === editorMode ? 'text-white' : disabled ? '' : 'text-text-secondary'}`}
                     >
                       {label} {mode === editorMode && '\u2713'}
                     </button>
@@ -88,7 +157,7 @@ export function EditorStatusBar({ source, line, column, isMarkdown, editorMode, 
             )}
           </div>
         )}
-      </span>
+      </div>
     </div>
   )
 }

--- a/spa/src/components/editor/EditorToolbar.test.tsx
+++ b/spa/src/components/editor/EditorToolbar.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { EditorToolbar } from './EditorToolbar'
+
+describe('EditorToolbar', () => {
+  it('shows a Purdex prefix and hides the buffer segment for in-app paths', () => {
+    const { container } = render(
+      <EditorToolbar
+        source={{ type: 'inapp' }}
+        filePath="/buffer/example.md"
+        isDirty={false}
+        onSave={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Purdex')).toBeInTheDocument()
+    expect(container.querySelector('img')).toHaveAttribute('src', '/icons/logo-transparent.png')
+    expect(screen.queryByText('buffer')).not.toBeInTheDocument()
+    expect(screen.getByText('example.md')).toBeInTheDocument()
+  })
+
+  it('keeps filename double click rename affordance for in-app buffers', () => {
+    const onRenameStart = vi.fn()
+
+    render(
+      <EditorToolbar
+        source={{ type: 'inapp' }}
+        filePath="/buffer/example.md"
+        isDirty={false}
+        onSave={() => {}}
+        onRenameStart={onRenameStart}
+      />,
+    )
+
+    fireEvent.doubleClick(screen.getByRole('button', { name: 'example.md' }))
+
+    expect(onRenameStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a root slash prefix for non in-app paths', () => {
+    const { container } = render(
+      <EditorToolbar
+        source={{ type: 'local' }}
+        filePath="/notes/example.md"
+        isDirty={false}
+        onSave={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText('Purdex')).not.toBeInTheDocument()
+    expect(container.textContent).toContain('/notes/example.md')
+  })
+
+  it('uses tighter spacing for the breadcrumb row', () => {
+    render(
+      <EditorToolbar
+        source={{ type: 'inapp' }}
+        filePath="/buffer/project/example.md"
+        isDirty={false}
+        onSave={() => {}}
+      />,
+    )
+
+    expect(screen.getByTitle('/buffer/project/example.md').className).toContain('gap-0.5')
+  })
+})

--- a/spa/src/components/editor/EditorToolbar.tsx
+++ b/spa/src/components/editor/EditorToolbar.tsx
@@ -1,26 +1,47 @@
 import { FloppyDisk, GitDiff } from '@phosphor-icons/react'
+import type { FileSource } from '../../types/fs'
 
 interface Props {
+  source: FileSource
   filePath: string
+  displayPath?: string
   isDirty: boolean
+  canSave?: boolean
   showDiff?: boolean
-  onSave: () => void
+  onSave: (anchorRect?: DOMRect) => void
   onDiff?: () => void
   onRenameStart?: (anchorRect: DOMRect) => void
 }
 
-export function EditorToolbar({ filePath, isDirty, showDiff, onSave, onDiff, onRenameStart }: Props) {
-  const segments = filePath.split('/').filter(Boolean)
+export function EditorToolbar({ source, filePath, displayPath, isDirty, canSave, showDiff, onSave, onDiff, onRenameStart }: Props) {
+  const pathForDisplay = displayPath ?? filePath
+  const rawSegments = pathForDisplay.split('/').filter(Boolean)
+  const showInAppPrefix = source.type === 'inapp'
+  const segments = showInAppPrefix && rawSegments[0] === 'buffer' ? rawSegments.slice(1) : rawSegments
+  const saveEnabled = canSave ?? isDirty
 
   return (
-    <div className="flex items-start justify-between gap-3 px-3 py-1 border-b border-border-subtle bg-surface-secondary">
+    <div className="flex items-start justify-between gap-2 px-3 py-1 border-b border-border-subtle bg-surface-secondary">
       <div className="min-w-0 flex items-center gap-2 text-xs text-text-secondary">
-        <div className="min-w-0 flex items-center gap-1 overflow-hidden" title={filePath}>
-            {filePath.startsWith('/') && <span className="shrink-0 text-text-muted">/</span>}
+        <div className="min-w-0 flex items-center gap-0.5 overflow-hidden" title={pathForDisplay}>
+            {showInAppPrefix ? (
+              <>
+                <span className="shrink-0 flex items-center gap-0.5 text-text-primary">
+                  <img
+                    src="/icons/logo-transparent.png"
+                    alt=""
+                    aria-hidden="true"
+                    className="h-3.5 w-3.5 shrink-0 brightness-0 invert opacity-95"
+                  />
+                  <span className="shrink-0">Purdex</span>
+                </span>
+                <span className="shrink-0 text-text-muted">/</span>
+              </>
+            ) : filePath.startsWith('/') ? <span className="shrink-0 text-text-muted">/</span> : null}
             {segments.map((segment, index) => {
               const isLast = index === segments.length - 1
               return (
-                <div key={`${segment}-${index}`} className="min-w-0 flex items-center gap-1">
+                <div key={`${segment}-${index}`} className="min-w-0 flex items-center gap-0.5">
                   {index > 0 && <span className="shrink-0 text-text-muted">/</span>}
                   {isLast && onRenameStart ? (
                     <button
@@ -37,7 +58,7 @@ export function EditorToolbar({ filePath, isDirty, showDiff, onSave, onDiff, onR
               )
             })}
         </div>
-        {isDirty && <span className="text-accent-base" title="Unsaved changes">●</span>}
+        {saveEnabled && <span className="text-accent-base" title="Unsaved changes">●</span>}
       </div>
       <div className="flex items-center gap-1 pt-0.5">
         {isDirty && onDiff && (
@@ -50,8 +71,8 @@ export function EditorToolbar({ filePath, isDirty, showDiff, onSave, onDiff, onR
           </button>
         )}
         <button
-          onClick={onSave}
-          disabled={!isDirty}
+          onClick={(event) => onSave(event.currentTarget.getBoundingClientRect())}
+          disabled={!saveEnabled}
           className="p-1 rounded hover:bg-surface-hover text-text-secondary disabled:opacity-30 transition-colors"
           title="Save (⌘S)"
         >

--- a/spa/src/components/editor/TiptapEditor.test.tsx
+++ b/spa/src/components/editor/TiptapEditor.test.tsx
@@ -52,16 +52,16 @@ describe('TiptapEditor', () => {
     )
   })
 
-  it('keeps a visible focus style on the editable root', () => {
+  it('suppresses the editable focus outline to avoid a bottom accent line', () => {
     render(<TiptapEditor content="# Hello" isActive={false} onChange={() => {}} onSave={() => {}} />)
 
     expect(screen.getByTestId('editor-content')).toHaveAttribute(
       'data-editor-class',
-      expect.not.stringContaining('focus:outline-none'),
+      expect.stringContaining('focus:outline-none'),
     )
     expect(screen.getByTestId('editor-content')).toHaveAttribute(
       'data-editor-class',
-      expect.stringContaining('focus-visible:outline'),
+      expect.not.stringContaining('focus-visible:outline'),
     )
   })
 

--- a/spa/src/components/editor/TiptapEditor.tsx
+++ b/spa/src/components/editor/TiptapEditor.tsx
@@ -32,7 +32,7 @@ export function TiptapEditor({ content, isActive, onChange, onSave }: Props) {
     },
     editorProps: {
       attributes: {
-        class: 'tiptap-editor prose prose-invert prose-sm max-w-none min-h-full px-4 py-4 focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent-base',
+        class: 'tiptap-editor prose prose-invert prose-sm max-w-none min-h-full px-4 py-4 focus:outline-none',
       },
       handleKeyDown: (_view, event) => {
         if ((event.metaKey || event.ctrlKey) && event.key === 's') {

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -7,6 +7,7 @@ import type { Pane } from '../../../types/tab'
 import type { FsBackend } from '../../../lib/fs-backend'
 
 const getFsBackendMock = vi.hoisted(() => vi.fn())
+const editorStatusBarMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../lib/fs-backend', () => ({
   getFsBackend: getFsBackendMock,
@@ -21,7 +22,23 @@ vi.mock('../DiffView', () => ({
 }))
 
 vi.mock('../EditorStatusBar', () => ({
-  EditorStatusBar: () => <div data-testid="editor-status-bar" />,
+  EditorStatusBar: (props: { language: string; eol: 'lf' | 'crlf'; encoding: 'utf8'; isMarkdown: boolean; editorMode: 'raw' | 'wysiwyg' }) => {
+    editorStatusBarMock(props)
+    return (
+      <div
+        data-testid="editor-status-bar"
+        data-language={props.language}
+        data-eol={props.eol}
+        data-encoding={props.encoding}
+        data-is-markdown={props.isMarkdown ? 'true' : 'false'}
+        data-editor-mode={props.editorMode}
+      />
+    )
+  },
+}))
+
+vi.mock('../TiptapEditor', () => ({
+  TiptapEditor: () => <div data-testid="tiptap-editor" />,
 }))
 
 function createPane(filePath = '/notes/editor.md', paneId = 'pane-editor'): Pane {
@@ -31,6 +48,22 @@ function createPane(filePath = '/notes/editor.md', paneId = 'pane-editor'): Pane
       kind: 'editor',
       source: { type: 'inapp' },
       filePath,
+    },
+  }
+}
+
+function createUntitledPane(name = 'Untitled', suggestedExtension: '.txt' | '.md' = '.md', paneId = 'pane-editor'): Pane {
+  return {
+    id: paneId,
+    content: {
+      kind: 'editor',
+      source: { type: 'inapp' },
+      filePath: `untitled:${name}`,
+      untitled: {
+        name,
+        suggestedExtension,
+        hasBeenRenamed: false,
+      },
     },
   }
 }
@@ -176,6 +209,59 @@ describe('EditorPane', () => {
     rerender(<EditorPane pane={pane} isActive />)
 
     expect(screen.getByTestId('monaco-wrapper')).toHaveAttribute('data-active', 'true')
+  })
+
+  it('keeps non-markdown files in source mode even if the pane state was previously live mode', async () => {
+    const pane = createPane('/notes/plain.txt', 'pane-txt')
+    const backend = createBackend()
+    backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 11,
+      mtime: 123,
+    })
+    getFsBackendMock.mockReturnValue(backend)
+
+    useEditorStore.getState().attachPane(pane.id, getBufferKey('/notes/plain.txt'))
+    useEditorStore.getState().setEditorMode(pane.id, 'wysiwyg')
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/plain.txt')]).toBeDefined()
+    })
+
+    expect(screen.getByTestId('monaco-wrapper')).toBeInTheDocument()
+    expect(screen.queryByTestId('tiptap-editor')).not.toBeInTheDocument()
+    expect(screen.getByTestId('editor-status-bar')).toHaveAttribute('data-is-markdown', 'false')
+    expect(screen.getByTestId('editor-status-bar')).toHaveAttribute('data-editor-mode', 'raw')
+  })
+
+  it('uses buffer metadata instead of the file extension to allow markdown live mode', async () => {
+    const pane = createPane('/notes/plain.txt', 'pane-manual-markdown')
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+
+    useEditorStore.getState().openBuffer(getBufferKey('/notes/plain.txt'), '# hello', {
+      language: 'markdown',
+      languageSource: 'manual',
+      eol: 'lf',
+      encoding: 'utf8',
+    })
+    useEditorStore.getState().attachPane(pane.id, getBufferKey('/notes/plain.txt'))
+    useEditorStore.getState().setEditorMode(pane.id, 'wysiwyg')
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tiptap-editor')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByTestId('monaco-wrapper')).not.toBeInTheDocument()
+    expect(screen.getByTestId('editor-status-bar')).toHaveAttribute('data-language', 'markdown')
+    expect(screen.getByTestId('editor-status-bar')).toHaveAttribute('data-is-markdown', 'true')
+    expect(screen.getByTestId('editor-status-bar')).toHaveAttribute('data-editor-mode', 'wysiwyg')
   })
 
   it('cleans up pane state when the pane is reused for non-editor content', async () => {
@@ -389,7 +475,7 @@ describe('EditorPane', () => {
       .mockRejectedValueOnce(new Error('not found'))
     getFsBackendMock.mockReturnValue(backend)
     registerTabPane(pane)
-    useEditorStore.getState().openBuffer(getBufferKey('/notes/taken.md'), 'draft', 'markdown')
+    useEditorStore.getState().openBuffer(getBufferKey('/notes/taken.md'), 'draft', { language: 'markdown' })
     useEditorStore.getState().attachPane('pane-other', getBufferKey('/notes/taken.md'))
 
     render(<EditorPane pane={pane} isActive />)
@@ -507,6 +593,146 @@ describe('EditorPane', () => {
     await waitFor(() => {
       expect(useEditorStore.getState().buffers[getBufferKey('/notes/example.md')]?.language).toBe('markdown')
     })
+  })
+
+  it('renames an untitled buffer without calling backend rename', async () => {
+    const pane = createUntitledPane('Untitled', '.md', 'pane-unsaved-rename')
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+    registerTabPane(pane)
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('untitled:Untitled')]).toBeDefined()
+    })
+
+    fireEvent.doubleClick(screen.getByText('Untitled'))
+    fireEvent.change(screen.getByDisplayValue('Untitled'), { target: { value: 'notes.txt' } })
+    fireEvent.keyDown(screen.getByDisplayValue('notes.txt'), { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('untitled:notes.txt')]).toBeDefined()
+    })
+
+    expect(backend.rename).not.toHaveBeenCalled()
+    expect(useEditorStore.getState().buffers[getBufferKey('untitled:Untitled')]).toBeUndefined()
+    expect(useEditorStore.getState().buffers[getBufferKey('untitled:notes.txt')]).toMatchObject({
+      language: 'plaintext',
+      languageSource: 'extension',
+      lastStat: null,
+      untitled: {
+        name: 'notes.txt',
+        suggestedExtension: '.md',
+        hasBeenRenamed: true,
+      },
+    })
+  })
+
+  it('prompts for a file name before first save of an unrenamed untitled document', async () => {
+    const pane = createUntitledPane('Untitled', '.md', 'pane-save-prompt')
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('untitled:Untitled')]).toBeDefined()
+    })
+
+    fireEvent.click(screen.getByTitle('Save (⌘S)'))
+
+    expect(screen.getByDisplayValue('Untitled.md')).toBeInTheDocument()
+    expect(backend.write).not.toHaveBeenCalled()
+  })
+
+  it('saves an untitled document to in-app after confirming the suggested name', async () => {
+    const pane = createUntitledPane('Untitled', '.md', 'pane-save-untitled')
+    const backend = createBackend()
+    backend.write.mockResolvedValue(undefined)
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 0,
+      mtime: 456,
+    })
+    getFsBackendMock.mockReturnValue(backend)
+    registerTabPane(pane)
+
+    render(<EditorPane pane={pane} isActive />)
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().buffers[getBufferKey('untitled:Untitled')]).toBeDefined()
+    })
+
+    fireEvent.click(screen.getByTitle('Save (⌘S)'))
+    fireEvent.keyDown(screen.getByDisplayValue('Untitled.md'), { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(backend.write).toHaveBeenCalledWith('/buffer/Untitled.md', new TextEncoder().encode(''))
+    })
+
+    expect(useEditorStore.getState().buffers[getBufferKey('/buffer/Untitled.md')]).toMatchObject({
+      lastStat: { mtime: 456, size: 0 },
+      untitled: undefined,
+    })
+  })
+
+  it('saves a renamed untitled document directly to in-app without prompting', async () => {
+    const pane = createUntitledPane('notes.txt', '.txt', 'pane-save-renamed')
+    const backend = createBackend()
+    backend.write.mockResolvedValue(undefined)
+    backend.stat.mockResolvedValue({
+      isFile: true,
+      isDirectory: false,
+      size: 5,
+      mtime: 456,
+    })
+    getFsBackendMock.mockReturnValue(backend)
+    registerTabPane({
+      ...pane,
+      content: {
+        kind: 'editor',
+        source: { type: 'inapp' },
+        filePath: 'untitled:notes.txt',
+        untitled: {
+          name: 'notes.txt',
+          suggestedExtension: '.txt',
+          hasBeenRenamed: true,
+        },
+      },
+    })
+    useEditorStore.getState().openBuffer(getBufferKey('untitled:notes.txt'), 'hello', {
+      language: 'plaintext',
+      languageSource: 'extension',
+      untitled: {
+        name: 'notes.txt',
+        suggestedExtension: '.txt',
+        hasBeenRenamed: true,
+      },
+    })
+
+    render(<EditorPane pane={{
+      ...pane,
+      content: {
+        kind: 'editor',
+        source: { type: 'inapp' },
+        filePath: 'untitled:notes.txt',
+        untitled: {
+          name: 'notes.txt',
+          suggestedExtension: '.txt',
+          hasBeenRenamed: true,
+        },
+      },
+    }} isActive />)
+
+    fireEvent.click(screen.getByTitle('Save (⌘S)'))
+
+    await waitFor(() => {
+      expect(backend.write).toHaveBeenCalledWith('/buffer/notes.txt', new TextEncoder().encode('hello'))
+    })
+
+    expect(screen.queryByDisplayValue('notes.txt')).not.toBeInTheDocument()
   })
 
   it('saves dirty content and marks the buffer clean on success', async () => {

--- a/spa/src/lib/pane-labels.ts
+++ b/spa/src/lib/pane-labels.ts
@@ -44,7 +44,7 @@ export function getPaneLabel(
     case 'memory-monitor':
       return t('monitor.title')
     case 'editor': {
-      const name = content.filePath.split('/').pop() ?? content.filePath
+      const name = content.untitled?.name ?? (content.filePath.split('/').pop() ?? content.filePath)
       return content.diff ? `${name} (Diff)` : name
     }
     case 'image-preview':

--- a/spa/src/stores/useEditorStore.test.ts
+++ b/spa/src/stores/useEditorStore.test.ts
@@ -7,7 +7,7 @@ describe('useEditorStore', () => {
   })
 
   it('keeps shared buffer state separate from pane-local view state', () => {
-    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
+    useEditorStore.getState().openBuffer('key1', 'hello', { language: 'typescript' })
     useEditorStore.getState().attachPane('pane-a', 'key1')
     useEditorStore.getState().attachPane('pane-b', 'key1')
 
@@ -32,7 +32,7 @@ describe('useEditorStore', () => {
   })
 
   it('only closes a shared buffer when the last pane detaches', () => {
-    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
+    useEditorStore.getState().openBuffer('key1', 'hello', { language: 'typescript' })
     useEditorStore.getState().attachPane('pane-a', 'key1')
     useEditorStore.getState().attachPane('pane-b', 'key1')
 
@@ -44,8 +44,8 @@ describe('useEditorStore', () => {
   })
 
   it('switching a pane to another buffer resets pane-local state and releases the old buffer', () => {
-    useEditorStore.getState().openBuffer('key-a', 'A', 'typescript')
-    useEditorStore.getState().openBuffer('key-b', 'B', 'markdown')
+    useEditorStore.getState().openBuffer('key-a', 'A', { language: 'typescript' })
+    useEditorStore.getState().openBuffer('key-b', 'B', { language: 'markdown' })
     useEditorStore.getState().attachPane('pane-a', 'key-a')
     useEditorStore.getState().setEditorMode('pane-a', 'wysiwyg')
     useEditorStore.getState().setShowDiff('pane-a', true)
@@ -63,23 +63,120 @@ describe('useEditorStore', () => {
   })
 
   it('renames a shared buffer key and preserves model identity', () => {
-    useEditorStore.getState().openBuffer('old-key', 'hello', 'typescript')
+    useEditorStore.getState().openBuffer('old-key', 'hello', { language: 'typescript' })
     useEditorStore.getState().attachPane('pane-a', 'old-key')
 
     const modelId = useEditorStore.getState().buffers['old-key']?.modelId
-    useEditorStore.getState().renameBuffer('old-key', 'new-key', 'markdown')
+    useEditorStore.getState().renameBuffer('old-key', 'new-key', {
+      language: 'markdown',
+      languageSource: 'extension',
+    })
 
     expect(useEditorStore.getState().buffers['old-key']).toBeUndefined()
     expect(useEditorStore.getState().buffers['new-key']).toMatchObject({
       content: 'hello',
       modelId,
       language: 'markdown',
+      languageSource: 'extension',
     })
     expect(useEditorStore.getState().paneStates['pane-a']?.bufferKey).toBe('new-key')
   })
 
+  it('stores document metadata when opening a buffer', () => {
+    useEditorStore.getState().openBuffer('key1', 'hello\r\nworld', {
+      language: 'typescript',
+      languageSource: 'extension',
+    })
+
+    expect(useEditorStore.getState().buffers['key1']).toMatchObject({
+      language: 'typescript',
+      languageSource: 'extension',
+      eol: 'crlf',
+      encoding: 'utf8',
+    })
+  })
+
+  it('stores untitled document state when opening a buffer', () => {
+    useEditorStore.getState().openBuffer('key1', '', {
+      language: 'markdown',
+      languageSource: 'template',
+      untitled: {
+        name: 'Untitled',
+        suggestedExtension: '.md',
+        hasBeenRenamed: false,
+      },
+    })
+
+    expect(useEditorStore.getState().buffers['key1']?.untitled).toEqual({
+      name: 'Untitled',
+      suggestedExtension: '.md',
+      hasBeenRenamed: false,
+    })
+  })
+
+  it('allows manual language changes without changing content state', () => {
+    useEditorStore.getState().openBuffer('key1', 'hello', { language: 'typescript' })
+
+    useEditorStore.getState().setBufferLanguage('key1', 'markdown')
+
+    expect(useEditorStore.getState().buffers['key1']).toMatchObject({
+      language: 'markdown',
+      languageSource: 'manual',
+      content: 'hello',
+      savedContent: 'hello',
+      isDirty: false,
+    })
+  })
+
+  it('preserves manual language when a buffer is renamed', () => {
+    useEditorStore.getState().openBuffer('old-key', 'hello', {
+      language: 'markdown',
+      languageSource: 'manual',
+    })
+
+    useEditorStore.getState().renameBuffer('old-key', 'new-key', {
+      language: 'markdown',
+      languageSource: 'manual',
+    })
+
+    expect(useEditorStore.getState().buffers['new-key']).toMatchObject({
+      language: 'markdown',
+      languageSource: 'manual',
+    })
+  })
+
+  it('updates untitled state when a buffer is renamed', () => {
+    useEditorStore.getState().openBuffer('untitled:Untitled', '', {
+      language: 'plaintext',
+      languageSource: 'template',
+      untitled: {
+        name: 'Untitled',
+        suggestedExtension: '.txt',
+        hasBeenRenamed: false,
+      },
+    })
+
+    useEditorStore.getState().renameBuffer('untitled:Untitled', 'untitled:notes.txt', {
+      language: 'plaintext',
+      languageSource: 'extension',
+      untitled: {
+        name: 'notes.txt',
+        suggestedExtension: '.txt',
+        hasBeenRenamed: true,
+      },
+    })
+
+    expect(useEditorStore.getState().buffers['untitled:notes.txt']).toMatchObject({
+      untitled: {
+        name: 'notes.txt',
+        suggestedExtension: '.txt',
+        hasBeenRenamed: true,
+      },
+    })
+  })
+
   it('opens a buffer with content', () => {
-    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
+    useEditorStore.getState().openBuffer('key1', 'hello', { language: 'typescript' })
     const buf = useEditorStore.getState().buffers['key1']
     expect(buf).toBeDefined()
     expect(buf.content).toBe('hello')
@@ -89,7 +186,7 @@ describe('useEditorStore', () => {
   })
 
   it('updateContent marks buffer as dirty', () => {
-    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
+    useEditorStore.getState().openBuffer('key1', 'hello', { language: 'typescript' })
     useEditorStore.getState().updateContent('key1', 'hello world')
     const buf = useEditorStore.getState().buffers['key1']
     expect(buf.content).toBe('hello world')
@@ -97,7 +194,7 @@ describe('useEditorStore', () => {
   })
 
   it('markSaved clears dirty flag', () => {
-    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
+    useEditorStore.getState().openBuffer('key1', 'hello', { language: 'typescript' })
     useEditorStore.getState().updateContent('key1', 'changed')
     useEditorStore.getState().markSaved('key1')
     const buf = useEditorStore.getState().buffers['key1']
@@ -106,22 +203,23 @@ describe('useEditorStore', () => {
   })
 
   it('closeBuffer removes the buffer', () => {
-    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
+    useEditorStore.getState().openBuffer('key1', 'hello', { language: 'typescript' })
     useEditorStore.getState().closeBuffer('key1')
     expect(useEditorStore.getState().buffers['key1']).toBeUndefined()
   })
 
   it('reloadBuffer replaces content without marking dirty', () => {
-    useEditorStore.getState().openBuffer('key1', 'old', 'typescript')
+    useEditorStore.getState().openBuffer('key1', 'old', { language: 'typescript' })
     useEditorStore.getState().reloadBuffer('key1', 'new')
     const buf = useEditorStore.getState().buffers['key1']
     expect(buf.content).toBe('new')
     expect(buf.savedContent).toBe('new')
     expect(buf.isDirty).toBe(false)
+    expect(buf.eol).toBe('lf')
   })
 
   it('updateCursor stores cursor position', () => {
-    useEditorStore.getState().openBuffer('key1', '', 'plaintext')
+    useEditorStore.getState().openBuffer('key1', '', { language: 'plaintext' })
     useEditorStore.getState().attachPane('pane-a', 'key1')
     useEditorStore.getState().updateCursor('pane-a', 10, 5)
     const pane = useEditorStore.getState().paneStates['pane-a']
@@ -129,7 +227,7 @@ describe('useEditorStore', () => {
   })
 
   it('markSaved updates lastStat when stat is provided', () => {
-    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript')
+    useEditorStore.getState().openBuffer('key1', 'hello', { language: 'typescript' })
     const stat = { mtime: 2000, size: 50 }
     useEditorStore.getState().markSaved('key1', stat)
     const buf = useEditorStore.getState().buffers['key1']
@@ -138,7 +236,7 @@ describe('useEditorStore', () => {
 
   it('markSaved preserves existing lastStat when no stat provided', () => {
     const initialStat = { mtime: 1000, size: 30 }
-    useEditorStore.getState().openBuffer('key1', 'hello', 'typescript', initialStat)
+    useEditorStore.getState().openBuffer('key1', 'hello', { language: 'typescript' }, initialStat)
     useEditorStore.getState().markSaved('key1')
     const buf = useEditorStore.getState().buffers['key1']
     expect(buf.lastStat).toEqual({ mtime: 1000, size: 30 })

--- a/spa/src/stores/useEditorStore.ts
+++ b/spa/src/stores/useEditorStore.ts
@@ -1,14 +1,25 @@
 // spa/src/stores/useEditorStore.ts
 import { create } from 'zustand'
 import type { editor } from 'monaco-editor'
+import type { UntitledDocumentState } from '../types/tab'
 
 export type EditorMode = 'raw' | 'wysiwyg'
+export type EditorLanguageSource = 'extension' | 'template' | 'manual'
+export type EditorEol = 'lf' | 'crlf'
+export type EditorEncoding = 'utf8'
 
-export interface EditorBuffer {
+export interface EditorBufferMetadata {
+  language: string
+  languageSource: EditorLanguageSource
+  eol: EditorEol
+  encoding: EditorEncoding
+  untitled?: UntitledDocumentState
+}
+
+export interface EditorBuffer extends EditorBufferMetadata {
   content: string
   savedContent: string
   isDirty: boolean
-  language: string
   lastStat: { mtime: number; size: number } | null
   modelId: string
 }
@@ -24,11 +35,12 @@ export interface EditorPaneState {
 interface EditorState {
   buffers: Record<string, EditorBuffer>
   paneStates: Record<string, EditorPaneState>
-  openBuffer: (key: string, content: string, language: string, stat?: { mtime: number; size: number }) => void
+  openBuffer: (key: string, content: string, metadata: Partial<EditorBufferMetadata> & Pick<EditorBufferMetadata, 'language'>, stat?: { mtime: number; size: number }) => void
   attachPane: (paneId: string, bufferKey: string) => void
   updateContent: (key: string, content: string) => void
   markSaved: (key: string, stat?: { mtime: number; size: number }) => void
-  renameBuffer: (oldKey: string, newKey: string, language?: string) => void
+  renameBuffer: (oldKey: string, newKey: string, metadata?: Partial<EditorBufferMetadata>) => void
+  setBufferLanguage: (key: string, language: string) => void
   closeBuffer: (key: string) => void
   closePane: (paneId: string, expectedBufferKey?: string) => void
   reloadBuffer: (key: string, content: string, stat?: { mtime: number; size: number }) => void
@@ -57,11 +69,25 @@ function createModelId(): string {
   return modelId
 }
 
+function detectEol(content: string): EditorEol {
+  return content.includes('\r\n') ? 'crlf' : 'lf'
+}
+
+function normalizeMetadata(content: string, metadata: Partial<EditorBufferMetadata> & Pick<EditorBufferMetadata, 'language'>): EditorBufferMetadata {
+  return {
+    language: metadata.language,
+    languageSource: metadata.languageSource ?? 'extension',
+    eol: metadata.eol ?? detectEol(content),
+    encoding: metadata.encoding ?? 'utf8',
+    untitled: metadata.untitled,
+  }
+}
+
 export const useEditorStore = create<EditorState>()((set) => ({
   buffers: {},
   paneStates: {},
 
-  openBuffer: (key, content, language, stat) => set((s) => {
+  openBuffer: (key, content, metadata, stat) => set((s) => {
     if (s.buffers[key]) return s
     return {
       buffers: {
@@ -70,7 +96,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
           content,
           savedContent: content,
           isDirty: false,
-          language,
+          ...normalizeMetadata(content, metadata),
           lastStat: stat ?? null,
           modelId: createModelId(),
         },
@@ -118,6 +144,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
           ...buf,
           content,
           isDirty: content !== buf.savedContent,
+          eol: detectEol(content),
         },
       },
     }
@@ -139,7 +166,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
     }
   }),
 
-  renameBuffer: (oldKey, newKey, language) => set((s) => {
+  renameBuffer: (oldKey, newKey, metadata) => set((s) => {
     const buffer = s.buffers[oldKey]
     if (!buffer || oldKey === newKey) return s
 
@@ -156,15 +183,30 @@ export const useEditorStore = create<EditorState>()((set) => ({
         ...restBuffers,
         [newKey]: {
           ...buffer,
-          language: language ?? buffer.language,
+          ...metadata,
         },
       },
       paneStates,
     }
   }),
 
+  setBufferLanguage: (key, language) => set((s) => {
+    const buffer = s.buffers[key]
+    if (!buffer) return s
+    return {
+      buffers: {
+        ...s.buffers,
+        [key]: {
+          ...buffer,
+          language,
+          languageSource: 'manual',
+        },
+      },
+    }
+  }),
+
   closeBuffer: (key) => set((s) => {
-    const { [key]: _removed, ...rest } = s.buffers  
+    const { [key]: _removed, ...rest } = s.buffers
     return { buffers: rest }
   }),
 
@@ -197,6 +239,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
           content,
           savedContent: content,
           isDirty: false,
+          eol: detectEol(content),
           lastStat: stat ?? buf.lastStat,
         },
       },

--- a/spa/src/stores/useTabStore.ts
+++ b/spa/src/stores/useTabStore.ts
@@ -6,6 +6,7 @@ import { createTab } from '../types/tab'
 import { getPrimaryPane, findPane, updatePaneInLayout, splitAtPane, removePane, applyLayoutPattern } from '../lib/pane-tree'
 import { contentMatches } from '../lib/pane-utils'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
+import type { UntitledDocumentState } from '../types/tab'
 
 // --- Persist migration helpers ---
 // These functions handle legacy persisted data whose shape no longer matches
@@ -74,7 +75,13 @@ function sourceMatches(a: FileSource, b: FileSource): boolean {
   return true
 }
 
-function renameEditorPanesInLayout(layout: PaneLayout, source: FileSource, oldPath: string, newPath: string): PaneLayout {
+function renameEditorPanesInLayout(
+  layout: PaneLayout,
+  source: FileSource,
+  oldPath: string,
+  newPath: string,
+  options?: { untitled?: UntitledDocumentState },
+): PaneLayout {
   if (layout.type === 'leaf') {
     const content = layout.pane.content
     if (content.kind === 'editor' && content.filePath === oldPath && sourceMatches(content.source, source)) {
@@ -82,14 +89,18 @@ function renameEditorPanesInLayout(layout: PaneLayout, source: FileSource, oldPa
         type: 'leaf',
         pane: {
           ...layout.pane,
-          content: { ...content, filePath: newPath },
+          content: {
+            ...content,
+            filePath: newPath,
+            ...(options?.untitled === undefined ? { untitled: undefined } : { untitled: options.untitled }),
+          },
         },
       }
     }
     return layout
   }
 
-  const children = layout.children.map((child) => renameEditorPanesInLayout(child, source, oldPath, newPath))
+  const children = layout.children.map((child) => renameEditorPanesInLayout(child, source, oldPath, newPath, options))
   return children.some((child, index) => child !== layout.children[index])
     ? { ...layout, children }
     : layout
@@ -107,7 +118,7 @@ interface TabState {
   setActiveTab: (id: string | null) => void
   setViewMode: (tabId: string, paneId: string, mode: 'terminal' | 'stream') => void
   setPaneContent: (tabId: string, paneId: string, content: PaneContent) => void
-  renameEditorPanes: (source: FileSource, oldPath: string, newPath: string) => void
+  renameEditorPanes: (source: FileSource, oldPath: string, newPath: string, options?: { untitled?: UntitledDocumentState }) => void
   splitPane: (tabId: string, paneId: string, direction: 'h' | 'v', content: PaneContent) => void
   closePane: (tabId: string, paneId: string) => void
   resizePanes: (tabId: string, splitId: string, sizes: number[]) => void
@@ -232,12 +243,12 @@ export const useTabStore = create<TabState>()(
           return { tabs: { ...state.tabs, [tabId]: { ...tab, layout: newLayout } } }
         }),
 
-      renameEditorPanes: (source, oldPath, newPath) =>
+      renameEditorPanes: (source, oldPath, newPath, options) =>
         set((state) => {
           let changed = false
           const tabs = { ...state.tabs }
           for (const [tabId, tab] of Object.entries(state.tabs)) {
-            const newLayout = renameEditorPanesInLayout(tab.layout, source, oldPath, newPath)
+            const newLayout = renameEditorPanesInLayout(tab.layout, source, oldPath, newPath, options)
             if (newLayout !== tab.layout) {
               tabs[tabId] = { ...tab, layout: newLayout }
               changed = true

--- a/spa/src/types/tab.ts
+++ b/spa/src/types/tab.ts
@@ -27,6 +27,12 @@ export interface Pane {
 // === Pane Content (discriminated union) ===
 export type TerminatedReason = 'session-closed' | 'tmux-restarted' | 'host-removed'
 
+export interface UntitledDocumentState {
+  name: string
+  suggestedExtension: '.txt' | '.md'
+  hasBeenRenamed: boolean
+}
+
 export type PaneContent =
   | { kind: 'new-tab' }
   | { kind: 'tmux-session'; hostId: string; sessionCode: string; mode: 'terminal' | 'stream'; cachedName: string; tmuxInstance: string; terminated?: TerminatedReason }
@@ -36,7 +42,7 @@ export type PaneContent =
   | { kind: 'settings'; scope: 'global' | { workspaceId: string } }
   | { kind: 'browser'; url: string }
   | { kind: 'memory-monitor' }
-  | { kind: 'editor'; source: FileSource; filePath: string; diff?: { against: 'saved' | string } }
+  | { kind: 'editor'; source: FileSource; filePath: string; untitled?: UntitledDocumentState; diff?: { against: 'saved' | string } }
   | { kind: 'image-preview'; source: FileSource; filePath: string }
   | { kind: 'pdf-preview'; source: FileSource; filePath: string }
 


### PR DESCRIPTION
## Summary
- keep new in-app editor tabs on independent `untitled:` URIs until their first save so rename and save flows no longer depend on a persisted buffer path
- preserve editor document metadata in the store and route untitled rename/save transitions through pane and buffer key migration instead of backend file renames
- update editor toolbar/status UI and related tests to cover untitled naming, first-save prompting, language metadata, and in-app display behavior

## Verification
- `pnpm --prefix spa exec vitest run src/stores/useEditorStore.test.ts src/components/editor/__tests__/EditorPane.test.tsx src/components/editor/EditorStatusBar.test.tsx src/components/editor/EditorToolbar.test.tsx src/components/editor/EditorNewTabSection.test.tsx`
- `pnpm --prefix spa run lint`
- `pnpm --prefix spa run build`