### PR TITLE
feat(spa): HSR PR-4 follow-up — #586 batch-replace + #588 reactive host runtime

### DIFF
--- a/docs/specs/2026-04-22-hsr-pr4-followup-586-588-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr4-followup-586-588-plan.md
@@ -1,7 +1,7 @@
 # HSR PR-4 Follow-up — #586 + #588 Implementation Plan
 
 - **Date**: 2026-04-22
-- **Status**: Draft v1 (pending codex plan review)
+- **Status**: Draft v2 (post codex plan R1 — absorbed P1-1/1-2, P2-1/2/3, P3-1/2/3)
 - **Base spec**: `docs/specs/2026-04-22-hsr-pr4-followup-586-588-spec.md` (v2)
 - **Branch**: `worktree-hsr-pr4-followup-586-588`
 - **Base commit**: `df34d1d8` (alpha.206)
@@ -17,7 +17,7 @@ Two-commit PR closing #586 (dispatch idempotence / batch-replace source map) and
 
 | # | Kind | Subject | Gate |
 |---|---|---|---|
-| 1 (already) | docs | HSR PR-4 follow-up spec v1 + v2 | — (already committed `07de9e9a` + `64860323`) |
+| docs (already) | docs | HSR PR-4 follow-up spec v1 + v2 + plan v1 + v2 | — (already committed `07de9e9a` + `64860323` + `89891ae0` + this plan v2) |
 | 2 | feat | host built-in batch-replace + stable wrapper | #586 tests + existing tests + lint + build |
 | 3 | feat | SettingsContextFor<'host'>.runtime + HostPage two-pass selective subscription | #588 tests + existing tests + lint + build |
 
@@ -42,8 +42,10 @@ Reviewer reads spec v2 → commit 2 → commit 3.
 - `spa/src/lib/host-builtin-sections.test.tsx` — remove `registerBuiltinHostSection` + `clearHostBuiltinPending` imports; use `setHostBuiltinSections` + `clearHostBuiltinSources`; add tests 1–5 per spec §6.1 (commit 2)
 - `spa/src/lib/dispatch-settings-contributions.test.ts` — add tests 6–8 per spec §6.1; the host-builtin atomicity test case may simplify since sources are long-lived (commit 2)
 - `spa/src/lib/register-modules.test.ts` — no expected change (public surface `registerBuiltinModules()` unchanged); smoke-verify six host contributions still present (commit 2)
+- `spa/src/lib/settings-contribution-types.test.ts` — **existing ctx constructions must be updated to include `runtime: undefined`** (any direct `{ scope: 'host', hostId }` objects in fixtures/asserts); add 1–2 type-level assertions proving new shape (commit 3). **Flagged by codex R1 P1-2**
 - `spa/src/components/HostPage.test.tsx` — existing tests adjust any ctx constructions to include `runtime`; add tests 7–12 per spec §6.2 (commit 3)
 - `spa/src/components/hosts/HostSidebar.test.tsx` — existing ctx constructions gain `runtime`; add test 13 (commit 3)
+- **Full-repo grep audit for ctx construction sites missing `runtime`** — any other test file constructing `{ scope: 'host', hostId, ... }` objects. Plan §7 checklist enforces this (codex R1 P1-2 + P3-1)
 
 ### Not touched
 - `spa/src/lib/host-routes.ts` (#587 deferred; no `parseRoute` / `isHostSubPage` change)
@@ -137,17 +139,33 @@ Reviewer reads spec v2 → commit 2 → commit 3.
 
 **Subject**: `feat(spa): reactive host runtime in SettingsContextFor<'host'> (closes #588)`
 
-**TDD order**:
+**Ordering contract (codex R1 P1-1)**: This commit contains an ATOMIC type change. TDD is NOT expressed as "TypeScript compile-error = red" — that produces a broken build state mid-commit, not a meaningful red. Instead, each intermediate file state inside this commit keeps TypeScript green; the "red" phase lives in **behavioural test failures** (tests 7–13 fail at runtime before HostPage/HostSidebar logic lands) while TS always compiles.
 
-1. **Red — write new/modified tests first**
-   - `spa/src/lib/settings-contribution-types.test.ts`: add a type-level test (or TypeScript compile-error check via `// @ts-expect-error` patterns) asserting `SettingsContextFor<'host'>` requires `runtime: HostRuntime | undefined`. Keep light — the real enforcement comes from downstream consumers.
-   - `spa/src/components/HostPage.test.tsx`:
-     - Adjust every existing test's ctx constructions to include `runtime: undefined` (or a minimal stub) — these are the callsites TypeScript will flag after commit 3 lands the type change.
-     - Add tests 7–12 per spec §6.2. Tests 10 (background host tick) and 11 (rapid flicker) require careful store-state seeding via merge-mode `useHostStore.setState` (feedback `zustand_harness_setstate`). Test 12 captures console spies before `cleanup()` then ticks runtime; assert no stale warning. Tests 7+8 use contributions registered directly into the registry via `registerSettingsContribution` (bypass module registration) to inject a test contribution with runtime-driven `disabled`.
-   - `spa/src/components/hosts/HostSidebar.test.tsx`: add test 13; existing tests update ctx to include runtime.
-   - Run: `cd spa && pnpm exec vitest run src/components/HostPage.test.tsx src/components/hosts/HostSidebar.test.tsx src/lib/settings-contribution-types.test.ts` — expect TypeScript errors / test failures.
+The recommended sequence inside the single commit:
 
-2. **Green — extend types + HostPage + HostSidebar**
+1. **Step A — atomic type + fixture migration (TS green throughout)**
+   - Extend `SettingsContextFor<'host'>` in `settings-contribution-types.ts` with `runtime: HostRuntime | undefined`.
+   - Migrate every host-ctx callsite in one pass: HostPage, HostSidebar, host-builtin-sections wrapper, all `*.test.ts[x]` fixtures. Use the grep audit from §7 to enumerate. Baseline for migration: "any construction of `{ scope: 'host', hostId: X, ... }` must add `runtime`; initial value `undefined` is always safe (matches pre-runtime behaviour)".
+   - Run `pnpm run build` until green. No behavioural change yet — ctx now carries runtime but `disabled(ctx)` predicates in existing code all ignore it.
+   - Run existing tests → all still pass (no behavioural change).
+2. **Step B — write the new behavioural tests (red in runtime, TS still green)**
+   - `HostPage.test.tsx` add tests 7–12 (spec §6.2). The contribution factory in tests 7/8/11 injects `disabled: (ctx) => ctx.runtime?.status !== 'connected'` and `registerSettingsContribution(...)` directly. Tests 10+12 use deterministic spies — see §5 test harness details.
+   - `HostSidebar.test.tsx` add test 13.
+   - `settings-contribution-types.test.ts` add 1–2 type-level assertions documenting the new shape (purely for docs + compile-time guard; no runtime effect).
+   - Run these new tests → they fail at runtime: HostPage still ignores runtime ticks, so tests 7/8/11 never observe the expected unmount; test 10's render counter sees extra renders because runtime subscription isn't selective yet.
+3. **Step C — land HostPage + HostSidebar behavioural changes (tests turn green)**
+   - HostPage: introduce the shared `pickHostIdFallback` helper (codex R1 P2-3), extract `preResolveHostId` on top of it, add `useHostStore((s) => tentativeHostId ? s.runtime[tentativeHostId] : undefined)` selective subscription, thread `tentativeRuntime` through `resolveSelection` / `pickSelectableSubPage` / `renderContent`.
+   - HostSidebar: `hostCtx` gains `runtime: runtime[hostId]`.
+   - Run until green.
+4. **Single commit**: step A + B + C together (no mid-state push). Message body notes the atomic-migration rationale and references codex R1 P1-1.
+
+(Original three-step TDD description retained below but marked non-authoritative — it described the conceptually-correct flow but not the physically-correct ordering for a type-change commit.)
+
+**Legacy TDD description (reference only, superseded by the sequence above)**:
+
+1. ~~**Red — write new/modified tests first**~~ (superseded by Step A→B→C above to avoid a mid-commit broken-TS state)
+
+2. **Concrete code sketches for Step A+B+C**
 
    **Types** (`settings-contribution-types.ts`):
    ```ts
@@ -159,24 +177,42 @@ Reviewer reads spec v2 → commit 2 → commit 3.
      | { scope: 'workspace'; workspaceId: string }
    ```
 
-   **HostPage.tsx** — two-pass selective subscription:
-   ```tsx
+   **Shared hostId fallback helper** (codex R1 P2-3 — extract the duplicated fallback logic):
+   ```ts
+   // spa/src/components/HostPage.tsx (or a new host-selection-utils.ts if extraction is cleaner)
+   /** @internal */
+   export function pickHostIdFallback(
+     hostOrder: string[],
+     activeHostId: string | null,
+     lastSel: Selection | null,
+   ): string | null {
+     if (hostOrder.length === 0) return null
+     if (lastSel?.hostId && hostOrder.includes(lastSel.hostId)) return lastSel.hostId
+     if (activeHostId && hostOrder.includes(activeHostId)) return activeHostId
+     return hostOrder[0] ?? null
+   }
+   ```
+   Both `preResolveHostId` and the existing inline fallback logic inside `resolveSelection` / `getFallbackSelection` call this helper. Equivalence test (plan §4 new entry 14): same input → same output across both callsites.
+
+   **preResolveHostId** (pure, runtime-independent — built on the shared helper):
+   ```ts
    function preResolveHostId(
      location: string,
      hostOrder: string[],
      activeHostId: string | null,
      lastSel: Selection | null,
    ): string | null {
-     if (hostOrder.length === 0) return null
      const parsed = parseRoute(location)
      if ((parsed?.kind === 'hosts' || parsed?.kind === 'hosts-invalid')
          && parsed.hostId && hostOrder.includes(parsed.hostId)) {
        return parsed.hostId
      }
-     if (lastSel?.hostId && hostOrder.includes(lastSel.hostId)) return lastSel.hostId
-     return getFallbackHostId(hostOrder, activeHostId)
+     return pickHostIdFallback(hostOrder, activeHostId, lastSel)
    }
+   ```
 
+   **HostPage.tsx** — two-pass selective subscription:
+   ```tsx
    export function HostPage(_props: PaneRendererProps) {
      const [location, setLocation] = useLocation()
      const hostOrder    = useHostStore((s) => s.hostOrder)
@@ -185,7 +221,6 @@ Reviewer reads spec v2 → commit 2 → commit 3.
      const tentativeRuntime = useHostStore((s) =>
        tentativeHostId ? s.runtime[tentativeHostId] : undefined,
      )
-     // resolveSelection / pickSelectableSubPage take tentativeHostId + tentativeRuntime
      const { selection, canonicalPath, shouldPersistSelection } = resolveSelection(
        location, hostOrder, activeHostId, tentativeHostId, tentativeRuntime,
      )
@@ -206,6 +241,7 @@ Reviewer reads spec v2 → commit 2 → commit 3.
    ```
    - `pickSelectableSubPage(hostId, requested, runtime)` signature change.
    - `resolveSelection(..., tentativeHostId, tentativeRuntime)` threads runtime into every `pickSelectableSubPage` callsite.
+   - `getFallbackSelection` inline fallback logic calls `pickHostIdFallback` (shared helper).
    - `lastSelection` logic unchanged (pure bookkeeping).
 
    **HostSidebar.tsx**:
@@ -272,6 +308,7 @@ Reviewer reads spec v2 → commit 2 → commit 3.
 | §6.2 #11 | `HostPage.test.tsx` | Rapid flicker stable | 3 |
 | §6.2 #12 | `HostPage.test.tsx` | Unmount during tick no warning | 3 |
 | §6.2 #13 | `HostSidebar.test.tsx` | Sidebar ctx carries runtime | 3 |
+| **NEW 14** | `HostPage.test.tsx` (or new `host-selection-utils.test.ts`) | `pickHostIdFallback` equivalence: extracted helper produces identical output to inline fallback for representative inputs (hostOrder ∈ {empty, single, multi}; activeHostId ∈ {null, present, absent}; lastSel ∈ {null, present, stale}). Codex R1 P2-3 | 3 |
 
 ---
 
@@ -280,6 +317,39 @@ Reviewer reads spec v2 → commit 2 → commit 3.
 - **Merge-mode setState only** for tests touching `useHostStore` — do NOT use `setState({...}, true)` replace mode; it wipes zustand actions and causes "not a function" errors. Feedback: `feedback_zustand_harness_setstate.md`.
 - When seeding for tests 10+11, use `useHostStore.setState((state) => ({ runtime: { ...state.runtime, [hostId]: nextRuntime } }))` — functional updater preserves zustand's merge semantics.
 - For tests that need to wipe host state entirely, use explicit merge: `useHostStore.setState({ hosts: {}, hostOrder: [], runtime: {}, activeHostId: null })` and list every mutable field (ref `feedback_zustand_harness_setstate.md`).
+
+### 5.1 Deterministic test harness for tests 10 + 12 (codex R1 P2-1, P3-3)
+
+Codex R1 P2-1 / P3-3 flagged that render-counter / `console.error` spy approaches for "no re-render" / "no warning after unmount" are brittle under React 19 + jsdom + strict mode. Use deterministic alternatives:
+
+**Test 10 — background host tick does NOT re-render HostPage**:
+- Wrap HostPage's render in a counter via a thin spy component:
+  ```tsx
+  const renderCount = { value: 0 }
+  function HostPageProbe(props: PaneRendererProps) {
+    renderCount.value++
+    return <HostPage {...props} />
+  }
+  ```
+- Mount HostPage on `/hosts/hA/overview`. Snapshot `renderCount.value` after initial render + flush.
+- Mutate `runtime[hB]` (background host) via `useHostStore.setState((state) => ({ runtime: { ...state.runtime, hB: { status: 'disconnected' } } }))`.
+- Assert `renderCount.value` unchanged (selective subscription returned same reference for `runtime[tentativeHostId]`).
+- Repeat: mutate `runtime[hA]` (selected host) → assert counter incremented.
+
+**Test 12 — unmount during tick has no side effects**:
+- Use a deterministic subscription-leak probe instead of console-warning spy:
+  ```ts
+  // before mount
+  const subBefore = useHostStore.subscribe(() => {})
+  // After cleanup() unmount, push a runtime tick
+  useHostStore.setState((state) => ({ runtime: { ...state.runtime, hA: { status: 'reconnecting' } } }))
+  // Assert: no error thrown; the test-local subscriber recorded the tick (proving store healthy);
+  //         no React-internal listener leak (count of internal listeners returned to baseline)
+  ```
+- Concretely assert via `useHostStore.getState()` accessibility post-unmount and that the store's internal listener Set size returns to the baseline before mount. Zustand exposes `useHostStore.subscribe` returning an unsubscribe fn; before HostPage mount, capture the set size via `(useHostStore as unknown as { getSubscribers?(): unknown }).getSubscribers?.()` if available, else snapshot via temporary subscribe/unsubscribe pair to count delta.
+- Fallback if zustand internals are not introspectable: assert that `cleanup()` followed by a runtime tick does not raise + a deterministic effect counter on a sentinel component does not increment. The key contract is "no callback fires into the unmounted HostPage tree", measurable via the spy on a child component that records calls.
+
+**Test 12 must NOT be skipped** (codex R1 P2-2). If neither approach is feasible during implementation, downgrade to the lightest possible deterministic check (assert `cleanup() → setState(...)` does not throw + sentinel's effect callback runs only N times during lifecycle) and document the limitation in the test's docstring.
 
 ---
 
@@ -290,7 +360,9 @@ Reviewer reads spec v2 → commit 2 → commit 3.
 | `HostRuntime` import from `../stores/useHostStore` into `settings-contribution-types.ts` creates a coupling back from lib→stores | Acceptable: `HostRuntime` is already exported at `useHostStore.ts:17`. Spec §5 documents the dependency. |
 | `setHostBuiltinSections` call in `register-modules.tsx` runs once per `registerBuiltinModules()` invocation; HMR dispose already clears sources. Edge: test suites that re-import `register-modules` without a clear | Tests already call `clearContributions()` + `clearHostBuiltinPending` (now `clearHostBuiltinSources`) in `clearAll()`. The batch-replace API itself is idempotent (second call with same defs → same state). Mitigated by design. |
 | `preResolveHostId` duplicates logic from `resolveSelection` / `getFallbackHostId` | Intentional — `preResolveHostId` is a *pure, runtime-independent* extraction. `resolveSelection` still owns the full redirect logic and uses `getFallbackHostId` as before. Small overlap (URL parse + hostOrder check); documented in the code comment. |
-| Test 12 (unmount warning) relies on RTL's cleanup + console.error spy; vitest may not print warning under `jsdom` env | Assert on `console.error` / `console.warn` spy counts, not on regex match. Skip the test with explicit reason if jsdom strips warnings — leave a TODO linking to #588. |
+| Test 12 (unmount warning) relies on RTL's cleanup + console.error spy; vitest may not print warning under `jsdom` env (codex R1 P2-1) | **Resolved**: §5.1 prescribes deterministic subscription-leak probe instead of warning spy. NOT skipped. |
+| `pickHostIdFallback` extraction creates two callsites that drift independently (codex R1 P2-3) | Equivalence test 14 (plan §4) asserts shared output; helper is `@internal`-marked single source of truth. |
+| `hostBuiltinComponentMap` retains stale wrapper keys after batch-replace drops a localId (codex R1 P3-2) | WeakMap's GC handles dropped wrappers automatically once `hostBuiltinSources` releases the strong ref. Add explicit test in §6.1 #4 (wrapper rebuilt on re-add). No code change needed beyond the natural GC; documented in commit 2's body. |
 | Commit 2 changes break a callsite outside grep | Run full suite + lint + build — TS catches removed imports; grep audit performed in plan §2. |
 
 ---
@@ -298,14 +370,15 @@ Reviewer reads spec v2 → commit 2 → commit 3.
 ## 7. Validation checklist
 
 Before PR:
-- [ ] `git log --oneline df34d1d8..HEAD` shows exactly 3 commits (spec v1 + spec v2 + commit 2 + commit 3 = 4; note: v1 and v2 are separate commits per §1 layout; re-count is 4)
-  - Actually: commits on branch are `07de9e9a` (spec v1), `64860323` (spec v2), commit 2, commit 3 → **4 commits total**
+- [ ] `git log --oneline df34d1d8..HEAD` shows the expected commits on the branch (spec v1, spec v2, plan v1, plan v2, commit 2, commit 3 → **6 commits total** at PR open, with the four docs commits providing review context for the two feat commits)
 - [ ] `cd spa && pnpm exec vitest run` — full suite green
 - [ ] `cd spa && pnpm run lint` — green
 - [ ] `cd spa && pnpm run build` — green
 - [ ] Manual smoke: `pnpm run dev` → host page renders six sub-pages → disconnect a host → sidebar row updates + body unaffected (no regression)
-- [ ] Grep confirms no lingering `registerBuiltinHostSection` / `peekHostBuiltinQueue` / `drainHostBuiltinQueue` / `clearHostBuiltinPending` references
-- [ ] Grep confirms no lingering `{ scope: 'host', hostId: X }` ctx construction missing the `runtime` field (TS would already catch this; grep is a belt-and-braces check)
+- [ ] **Negative grep audits** (codex R1 P3-1):
+  - [ ] `rg -n "registerBuiltinHostSection|peekHostBuiltinQueue|drainHostBuiltinQueue|clearHostBuiltinPending" spa/src` → empty (or only hits in historical docs / spec / plan files)
+  - [ ] `rg -n "scope:\s*'host'" spa/src --type ts --type tsx` → every match is a ctx construction that includes the `runtime` field (manual eyeball or follow-up grep `rg -n "scope:\s*'host'.*hostId" spa/src` cross-checked for `runtime` presence)
+  - [ ] `rg -n "SettingsContextFor<'host'>" spa/src` → every consumer either uses `ctx.runtime` deliberately or ignores it harmlessly (no `// @ts-expect-error` work-arounds)
 
 Before merge:
 - [ ] Codex R1 (standard) + R2 (3-way adversarial) both green / findings absorbed

--- a/docs/specs/2026-04-22-hsr-pr4-followup-586-588-plan.md
+++ b/docs/specs/2026-04-22-hsr-pr4-followup-586-588-plan.md
@@ -1,0 +1,330 @@
+# HSR PR-4 Follow-up — #586 + #588 Implementation Plan
+
+- **Date**: 2026-04-22
+- **Status**: Draft v1 (pending codex plan review)
+- **Base spec**: `docs/specs/2026-04-22-hsr-pr4-followup-586-588-spec.md` (v2)
+- **Branch**: `worktree-hsr-pr4-followup-586-588`
+- **Base commit**: `df34d1d8` (alpha.206)
+- **Target commits on branch**: 3 (1 docs already committed, 2 feat)
+
+---
+
+## 1. Scope recap
+
+Two-commit PR closing #586 (dispatch idempotence / batch-replace source map) and #588 (host-ctx runtime reactivity). Each commit independently green. No cross-commit ordering requirement beyond "commit 1 before commit 2" purely for review linearity; the spec supports the reverse order too.
+
+### Commit layout
+
+| # | Kind | Subject | Gate |
+|---|---|---|---|
+| 1 (already) | docs | HSR PR-4 follow-up spec v1 + v2 | — (already committed `07de9e9a` + `64860323`) |
+| 2 | feat | host built-in batch-replace + stable wrapper | #586 tests + existing tests + lint + build |
+| 3 | feat | SettingsContextFor<'host'>.runtime + HostPage two-pass selective subscription | #588 tests + existing tests + lint + build |
+
+Reviewer reads spec v2 → commit 2 → commit 3.
+
+---
+
+## 2. Files impacted
+
+### Added
+- None (all work lands in existing files + existing test files extended).
+
+### Modified
+- `spa/src/lib/host-builtin-sections.ts` — full rewrite (commit 2, see §3.1)
+- `spa/src/lib/dispatch-settings-contributions.ts` — drop `peek/drainHostBuiltinQueue` + `clearHostBuiltinPending` imports; replace with `getHostBuiltinDeclarations` + `clearHostBuiltinSources` (commit 2, §3.1)
+- `spa/src/lib/register-modules.tsx` — collapse six `registerBuiltinHostSection(...)` calls into one `setHostBuiltinSections([...6 defs...])` call; update HMR dispose-helper import if renamed (commit 2, §3.1)
+- `spa/src/lib/settings-contribution-types.ts` — `SettingsContextFor<'host'>` adds `runtime: HostRuntime | undefined` (commit 3, §3.2)
+- `spa/src/components/HostPage.tsx` — two-pass selective subscription + runtime-aware `pickSelectableSubPage` + runtime in ctx (commit 3, §3.2)
+- `spa/src/components/hosts/HostSidebar.tsx` — add `runtime: runtime[hostId]` to the ctx it passes to `disabled(ctx)` (commit 3, §3.2)
+
+### Tests — rewritten / extended
+- `spa/src/lib/host-builtin-sections.test.tsx` — remove `registerBuiltinHostSection` + `clearHostBuiltinPending` imports; use `setHostBuiltinSections` + `clearHostBuiltinSources`; add tests 1–5 per spec §6.1 (commit 2)
+- `spa/src/lib/dispatch-settings-contributions.test.ts` — add tests 6–8 per spec §6.1; the host-builtin atomicity test case may simplify since sources are long-lived (commit 2)
+- `spa/src/lib/register-modules.test.ts` — no expected change (public surface `registerBuiltinModules()` unchanged); smoke-verify six host contributions still present (commit 2)
+- `spa/src/components/HostPage.test.tsx` — existing tests adjust any ctx constructions to include `runtime`; add tests 7–12 per spec §6.2 (commit 3)
+- `spa/src/components/hosts/HostSidebar.test.tsx` — existing ctx constructions gain `runtime`; add test 13 (commit 3)
+
+### Not touched
+- `spa/src/lib/host-routes.ts` (#587 deferred; no `parseRoute` / `isHostSubPage` change)
+- `spa/src/lib/settings-section-registry.ts` (legacy adapter out of scope)
+- All other modules / store files
+
+---
+
+## 3. Commit-by-commit plan
+
+### 3.1 Commit 2 — host built-in batch-replace + stable wrapper (#586)
+
+**Subject**: `feat(spa): host built-in batch-replace source map (closes #586)`
+
+**TDD order**:
+
+1. **Red — write new/modified tests first, run them, expect failures**
+   - `spa/src/lib/host-builtin-sections.test.tsx`: replace imports, delete `peek/drain/clearHostBuiltinPending`-touching tests; write tests 1–5 (spec §6.1). At this point source file is unchanged so tests fail at import time.
+   - `spa/src/lib/dispatch-settings-contributions.test.ts`: add tests 6–8 (spec §6.1). These may pass trivially until the impl lands; aim at the behavioural assertion (idempotent re-dispatch returns same refs).
+   - Run: `cd spa && pnpm exec vitest run src/lib/host-builtin-sections.test.tsx src/lib/dispatch-settings-contributions.test.ts` — expect red (missing `setHostBuiltinSections` export etc.).
+
+2. **Green — rewrite source files**
+   - `spa/src/lib/host-builtin-sections.ts`:
+     - Remove `pendingHostBuiltinContributions` Map; add `hostBuiltinSources` Map keyed by localId (value: `{ component, labelKey, order, wrapped }`).
+     - Remove `registerBuiltinHostSection`, `peekHostBuiltinQueue`, `drainHostBuiltinQueue`, `clearHostBuiltinPending`.
+     - Add `setHostBuiltinSections(defs: readonly HostBuiltinSectionDef[]): void` — drop absent localIds, upsert present ones, reuse wrapper per localId.
+     - Add `getHostBuiltinDeclarations(): readonly AnySettingsContributionDeclaration[]`.
+     - Add `clearHostBuiltinSources(): void`.
+     - `createHostBuiltinWrapper(localId)` — closure over `localId` only; on render read `hostBuiltinSources.get(localId)?.component` and delegate; scope guard `if (props.ctx.scope !== 'host') return null`. Defensive `if (!source) return null` for mid-render drop.
+     - `hostBuiltinComponentMap` WeakMap stays; in `setHostBuiltinSections` update it to map `wrapped → def.component` (latest component) so identity tests continue to work.
+   - `spa/src/lib/dispatch-settings-contributions.ts`:
+     - Replace `peekHostBuiltinQueue` import with `getHostBuiltinDeclarations`.
+     - Replace `clearHostBuiltinPending` import in `resetSettingsContributionsForHmr` with `clearHostBuiltinSources`.
+     - In `buildSettingsContributionBatch`: replace the `peekHostBuiltinQueue()` loop with `getHostBuiltinDeclarations()` loop (structurally identical except no drain semantics).
+     - In `dispatchSettingsContributions`: remove `drainHostBuiltinQueue()` call from Phase 2 (sources are long-lived).
+   - `spa/src/lib/register-modules.tsx`:
+     - Replace the six `registerBuiltinHostSection(...)` calls (lines 399-404) with one `setHostBuiltinSections([...six defs...])` block. Keep the same label/order per-line for reviewability:
+       ```tsx
+       setHostBuiltinSections([
+         { localId: 'overview', labelKey: 'hosts.overview', order: 0, component: OverviewSection },
+         { localId: 'sessions', labelKey: 'hosts.sessions', order: 1, component: SessionsSection },
+         ...
+       ])
+       ```
+     - Update import from `./host-builtin-sections` to use `setHostBuiltinSections` instead of `registerBuiltinHostSection`.
+   - Run tests until green.
+
+3. **Verify full scope + existing suite**
+   - `cd spa && pnpm exec vitest run src/lib/host-builtin-sections.test.tsx src/lib/dispatch-settings-contributions.test.ts src/lib/register-modules.test.ts src/lib/settings-contribution-registry.test.ts src/lib/settings-contribution-types.test.ts src/lib/settings-contribution-smoke.test.tsx src/stores/useGlobalSettingsStore.test.ts src/stores/useHostSettingsStore.test.ts src/stores/useWorkspaceSettingsStore.test.ts src/lib/host-lifecycle.test.ts src/components/HostPage.test.tsx src/components/hosts/HostSidebar.test.tsx` — all must be green. The HostPage/HostSidebar tests may still use the old ctx shape (no runtime field) — commit 2 does NOT change the ctx contract; those stay passing.
+   - `cd spa && pnpm exec vitest run` — full suite green (any pre-existing failures such as flaky EditorPane tests documented in PR-1 still allowed).
+   - `cd spa && pnpm run lint` — green.
+   - `cd spa && pnpm run build` — green (TypeScript `tsc -b` catches any dangling import).
+
+4. **Commit**
+   ```
+   feat(spa): host built-in batch-replace source map (closes #586)
+
+   Replaces the one-shot pending-buffer + drain pattern with a stable source map
+   mutated only by setHostBuiltinSections(defs[]) (batch replace) and cleared
+   only on HMR dispose. dispatchSettingsContributions() re-materializes host
+   built-ins on every call — idempotent under repeated dispatch (the #586 bug
+   where a standalone second dispatch wiped the live registry).
+
+   Wrapper identity is stable per localId (cached on first materialization and
+   reused on subsequent calls). HMR reloading a host section file replaces the
+   inner component reference but preserves the wrapper — React does not remount
+   the host sub-page body across HMR (spec §4.1.3, codex R1 P2 #2).
+
+   Full-replace semantics: any localId absent from the new defs is dropped,
+   ruling out stale-localId leak from partial re-registrations (codex R1 P2 #1).
+
+   Public API change:
+   - removed: registerBuiltinHostSection, peekHostBuiltinQueue,
+     drainHostBuiltinQueue, clearHostBuiltinPending
+   - added:   setHostBuiltinSections, getHostBuiltinDeclarations,
+              clearHostBuiltinSources
+
+   Only production callsite is register-modules.tsx; migrated.
+
+   Tests: §6.1 tests 1–8 (spec v2) cover full-replace, wrapper identity,
+   dispatcher idempotence, HMR reset.
+   ```
+
+**Exit criteria for commit 2**:
+- All scope tests green.
+- Lint + build green.
+- `git status` clean.
+- `git log --oneline` shows 1 new commit on top of `64860323`.
+
+### 3.2 Commit 3 — reactive host runtime (#588)
+
+**Subject**: `feat(spa): reactive host runtime in SettingsContextFor<'host'> (closes #588)`
+
+**TDD order**:
+
+1. **Red — write new/modified tests first**
+   - `spa/src/lib/settings-contribution-types.test.ts`: add a type-level test (or TypeScript compile-error check via `// @ts-expect-error` patterns) asserting `SettingsContextFor<'host'>` requires `runtime: HostRuntime | undefined`. Keep light — the real enforcement comes from downstream consumers.
+   - `spa/src/components/HostPage.test.tsx`:
+     - Adjust every existing test's ctx constructions to include `runtime: undefined` (or a minimal stub) — these are the callsites TypeScript will flag after commit 3 lands the type change.
+     - Add tests 7–12 per spec §6.2. Tests 10 (background host tick) and 11 (rapid flicker) require careful store-state seeding via merge-mode `useHostStore.setState` (feedback `zustand_harness_setstate`). Test 12 captures console spies before `cleanup()` then ticks runtime; assert no stale warning. Tests 7+8 use contributions registered directly into the registry via `registerSettingsContribution` (bypass module registration) to inject a test contribution with runtime-driven `disabled`.
+   - `spa/src/components/hosts/HostSidebar.test.tsx`: add test 13; existing tests update ctx to include runtime.
+   - Run: `cd spa && pnpm exec vitest run src/components/HostPage.test.tsx src/components/hosts/HostSidebar.test.tsx src/lib/settings-contribution-types.test.ts` — expect TypeScript errors / test failures.
+
+2. **Green — extend types + HostPage + HostSidebar**
+
+   **Types** (`settings-contribution-types.ts`):
+   ```ts
+   import type { HostRuntime } from '../stores/useHostStore'
+
+   export type SettingsContext =
+     | { scope: 'purdex' }
+     | { scope: 'host'; hostId: string; runtime: HostRuntime | undefined }
+     | { scope: 'workspace'; workspaceId: string }
+   ```
+
+   **HostPage.tsx** — two-pass selective subscription:
+   ```tsx
+   function preResolveHostId(
+     location: string,
+     hostOrder: string[],
+     activeHostId: string | null,
+     lastSel: Selection | null,
+   ): string | null {
+     if (hostOrder.length === 0) return null
+     const parsed = parseRoute(location)
+     if ((parsed?.kind === 'hosts' || parsed?.kind === 'hosts-invalid')
+         && parsed.hostId && hostOrder.includes(parsed.hostId)) {
+       return parsed.hostId
+     }
+     if (lastSel?.hostId && hostOrder.includes(lastSel.hostId)) return lastSel.hostId
+     return getFallbackHostId(hostOrder, activeHostId)
+   }
+
+   export function HostPage(_props: PaneRendererProps) {
+     const [location, setLocation] = useLocation()
+     const hostOrder    = useHostStore((s) => s.hostOrder)
+     const activeHostId = useHostStore((s) => s.activeHostId)
+     const tentativeHostId = preResolveHostId(location, hostOrder, activeHostId, lastSelection)
+     const tentativeRuntime = useHostStore((s) =>
+       tentativeHostId ? s.runtime[tentativeHostId] : undefined,
+     )
+     // resolveSelection / pickSelectableSubPage take tentativeHostId + tentativeRuntime
+     const { selection, canonicalPath, shouldPersistSelection } = resolveSelection(
+       location, hostOrder, activeHostId, tentativeHostId, tentativeRuntime,
+     )
+     // ... effects unchanged ...
+     const renderContent = () => {
+       if (!selection?.hostId) return <p className="text-text-muted">{t('hosts.no_host_selected')}</p>
+       const { hostId, subPage } = selection
+       const contributions = listContributions('host') as SettingsContribution<'host'>[]
+       const contribution = contributions.find((c) => c.localId === subPage)
+       if (!contribution) return null
+       const ctx: SettingsContextFor<'host'> = { scope: 'host', hostId, runtime: tentativeRuntime }
+       if (!isSelectable(contribution, ctx)) return null
+       const Component = contribution.component
+       return <Component key={`${hostId}:${contribution.id}`} ctx={ctx} />
+     }
+     // sidebarSubPage: use pickSelectableSubPage with tentativeRuntime
+   }
+   ```
+   - `pickSelectableSubPage(hostId, requested, runtime)` signature change.
+   - `resolveSelection(..., tentativeHostId, tentativeRuntime)` threads runtime into every `pickSelectableSubPage` callsite.
+   - `lastSelection` logic unchanged (pure bookkeeping).
+
+   **HostSidebar.tsx**:
+   ```tsx
+   const hostCtx = { scope: 'host' as const, hostId, runtime: runtime[hostId] }
+   ```
+   Already imports `runtime` at line 29; only the ctx construction at line 52 needs the `runtime: runtime[hostId]` field added.
+
+   Run tests until green.
+
+3. **Verify full scope + existing suite**
+   - `cd spa && pnpm exec vitest run src/components/HostPage.test.tsx src/components/HostPage.route-sync.test.tsx src/components/hosts/HostSidebar.test.tsx src/lib/settings-contribution-types.test.ts src/lib/host-builtin-sections.test.tsx src/lib/dispatch-settings-contributions.test.ts` — scope green.
+   - `cd spa && pnpm exec vitest run` — full suite green (same allowance as commit 2).
+   - `cd spa && pnpm run lint` — green.
+   - `cd spa && pnpm run build` — green. TypeScript will catch any ctx construction site still missing `runtime` field; fix those until clean.
+
+4. **Commit**
+   ```
+   feat(spa): reactive host runtime in SettingsContextFor<'host'> (closes #588)
+
+   Extends SettingsContextFor<'host'> with runtime: HostRuntime | undefined and
+   plumbs it through HostPage + HostSidebar + pickSelectableSubPage. Host
+   contributions whose disabled(ctx) predicate depends on runtime now
+   reactively unmount the body when the predicate flips true: HostPage
+   re-evaluates on runtime changes, isSelectable returns false, the
+   canonicalPath effect redirects to the next selectable sub-page. Fixes the
+   gap where the sidebar row greyed out but the body remained mounted.
+
+   HostPage uses a two-pass selective subscription (pre-resolve hostId from
+   URL/hostOrder/activeHostId/lastSelection, then subscribe only that host's
+   runtime) so background-host heartbeat ticks do NOT re-render HostPage
+   (codex R1 P3 #3). HostSidebar already subscribes to the full runtime map
+   (StatusIcon / per-row disabled); no new cost.
+
+   Tests: §6.2 tests 7–13 (spec v2) cover tick-driven unmount, rapid flicker
+   stability, unmount-during-tick warning guard, background-host no-rerender
+   assertion, and sidebar runtime-aware ctx.
+   ```
+
+**Exit criteria for commit 3**:
+- All scope tests green.
+- Lint + build green.
+- `git status` clean.
+- `git log --oneline` shows 2 new commits on top of `64860323`.
+
+---
+
+## 4. Test-plan crosswalk (spec → plan)
+
+| Spec test # | Where | Assertion | Commit |
+|---|---|---|---|
+| §6.1 #1 | `host-builtin-sections.test.tsx` | Batch replace is full set; drop absent | 2 |
+| §6.1 #2 | `host-builtin-sections.test.tsx` | Wrapper identity stable across re-calls | 2 |
+| §6.1 #3 | `host-builtin-sections.test.tsx` | Wrapper delegates to latest component | 2 |
+| §6.1 #4 | `host-builtin-sections.test.tsx` | Re-add after drop rebuilds wrapper | 2 |
+| §6.1 #5 | `host-builtin-sections.test.tsx` | `clearHostBuiltinSources` empties map | 2 |
+| §6.1 #6 | `dispatch-settings-contributions.test.ts` | Standalone re-dispatch preserves built-ins | 2 |
+| §6.1 #7 | `dispatch-settings-contributions.test.ts` | Interleaved module + built-in stable | 2 |
+| §6.1 #8 | `dispatch-settings-contributions.test.ts` | HMR reset → 0 contributions | 2 |
+| §6.2 #7 | `HostPage.test.tsx` | Runtime flip drops disabled body + redirects | 3 |
+| §6.2 #8 | `HostPage.test.tsx` | Runtime flip re-enables body | 3 |
+| §6.2 #9 | `HostPage.test.tsx` | `pickSelectableSubPage` uses runtime | 3 |
+| §6.2 #10 | `HostPage.test.tsx` | Background host tick does NOT re-render HostPage | 3 |
+| §6.2 #11 | `HostPage.test.tsx` | Rapid flicker stable | 3 |
+| §6.2 #12 | `HostPage.test.tsx` | Unmount during tick no warning | 3 |
+| §6.2 #13 | `HostSidebar.test.tsx` | Sidebar ctx carries runtime | 3 |
+
+---
+
+## 5. Zustand harness notes (feedback-driven)
+
+- **Merge-mode setState only** for tests touching `useHostStore` — do NOT use `setState({...}, true)` replace mode; it wipes zustand actions and causes "not a function" errors. Feedback: `feedback_zustand_harness_setstate.md`.
+- When seeding for tests 10+11, use `useHostStore.setState((state) => ({ runtime: { ...state.runtime, [hostId]: nextRuntime } }))` — functional updater preserves zustand's merge semantics.
+- For tests that need to wipe host state entirely, use explicit merge: `useHostStore.setState({ hosts: {}, hostOrder: [], runtime: {}, activeHostId: null })` and list every mutable field (ref `feedback_zustand_harness_setstate.md`).
+
+---
+
+## 6. Risk & mitigation
+
+| Risk | Mitigation |
+|---|---|
+| `HostRuntime` import from `../stores/useHostStore` into `settings-contribution-types.ts` creates a coupling back from lib→stores | Acceptable: `HostRuntime` is already exported at `useHostStore.ts:17`. Spec §5 documents the dependency. |
+| `setHostBuiltinSections` call in `register-modules.tsx` runs once per `registerBuiltinModules()` invocation; HMR dispose already clears sources. Edge: test suites that re-import `register-modules` without a clear | Tests already call `clearContributions()` + `clearHostBuiltinPending` (now `clearHostBuiltinSources`) in `clearAll()`. The batch-replace API itself is idempotent (second call with same defs → same state). Mitigated by design. |
+| `preResolveHostId` duplicates logic from `resolveSelection` / `getFallbackHostId` | Intentional — `preResolveHostId` is a *pure, runtime-independent* extraction. `resolveSelection` still owns the full redirect logic and uses `getFallbackHostId` as before. Small overlap (URL parse + hostOrder check); documented in the code comment. |
+| Test 12 (unmount warning) relies on RTL's cleanup + console.error spy; vitest may not print warning under `jsdom` env | Assert on `console.error` / `console.warn` spy counts, not on regex match. Skip the test with explicit reason if jsdom strips warnings — leave a TODO linking to #588. |
+| Commit 2 changes break a callsite outside grep | Run full suite + lint + build — TS catches removed imports; grep audit performed in plan §2. |
+
+---
+
+## 7. Validation checklist
+
+Before PR:
+- [ ] `git log --oneline df34d1d8..HEAD` shows exactly 3 commits (spec v1 + spec v2 + commit 2 + commit 3 = 4; note: v1 and v2 are separate commits per §1 layout; re-count is 4)
+  - Actually: commits on branch are `07de9e9a` (spec v1), `64860323` (spec v2), commit 2, commit 3 → **4 commits total**
+- [ ] `cd spa && pnpm exec vitest run` — full suite green
+- [ ] `cd spa && pnpm run lint` — green
+- [ ] `cd spa && pnpm run build` — green
+- [ ] Manual smoke: `pnpm run dev` → host page renders six sub-pages → disconnect a host → sidebar row updates + body unaffected (no regression)
+- [ ] Grep confirms no lingering `registerBuiltinHostSection` / `peekHostBuiltinQueue` / `drainHostBuiltinQueue` / `clearHostBuiltinPending` references
+- [ ] Grep confirms no lingering `{ scope: 'host', hostId: X }` ctx construction missing the `runtime` field (TS would already catch this; grep is a belt-and-braces check)
+
+Before merge:
+- [ ] Codex R1 (standard) + R2 (3-way adversarial) both green / findings absorbed
+- [ ] CI green
+- [ ] PR body includes codex review round digest + references to #586 / #588
+
+---
+
+## 8. Out of scope
+
+Same as spec §2 + §9: no #587, no legacy adapter rewrite, no PR-5 work, no `globalConfig`/`workspaceConfig` deprecation. Strictly #586 + #588.
+
+---
+
+## 9. Post-merge
+
+1. Squash merge PR (CLAUDE.md: no direct push to main).
+2. Delete remote branch.
+3. ExitWorktree with remove + discard_changes.
+4. Enter a fresh bump worktree → `git fetch origin && git reset --hard origin/main` → bump VERSION + CHANGELOG alpha.206 → alpha.207 → commit → push → PR → merge.
+5. Update memory: `kickoff_host_module_settings.md`, `project_progress.md`, MEMORY index.
+6. Add comment on issue #586 / #588 closing with PR link.

--- a/docs/specs/2026-04-22-hsr-pr4-followup-586-588-spec.md
+++ b/docs/specs/2026-04-22-hsr-pr4-followup-586-588-spec.md
@@ -1,7 +1,7 @@
 # HSR PR-4 Follow-up — #586 + #588 (Architecture Polish)
 
 - **Date**: 2026-04-22
-- **Status**: Draft v1 (pending codex review)
+- **Status**: Draft v2 (post codex R1 — absorbed P2 #1-#2 + P3 #3-#4)
 - **Target**: `main` — post-alpha.206
 - **Scope**: Two architectural polish items closed together in one PR, as preparation for PR-5 (Editor module dynamic register).
 - **Related**:
@@ -100,43 +100,80 @@ No runtime field for host scope. To make `disabled(ctx)` reflect host-runtime re
 
 ## 4. Design
 
-### 4.1 #586 — stable source map (Option A)
+### 4.1 #586 — stable source map with batch-replace API (Option A, revised per codex R1 P2 #1+#2)
 
-Concept: host built-ins become a **stable registration source**, not a one-shot buffer. Every `dispatchSettingsContributions()` call re-materializes host-builtin declarations from the source map; the source map is only mutated by `registerBuiltinHostSection()` (population) and `clearHostBuiltinSources()` (HMR dispose / test reset).
+Concept: host built-ins become a **stable registration source**, not a one-shot buffer. Every `dispatchSettingsContributions()` call re-materializes host-builtin declarations from the source map; the source map is populated via a single **batch-replace** call (not one-at-a-time upsert), and the wrapper identity is **stable by `localId`** (never rebuilt across re-registrations / HMR reloads).
 
 #### 4.1.1 New `host-builtin-sections.ts` shape
 
+Two design corrections vs. v1 (per codex R1):
+
+- **Codex P2 #1 (partial re-register / no removal)** → replace one-at-a-time upsert with `setHostBuiltinSections(defs: HostBuiltinSectionDef[])` that atomically replaces the full set. Any `localId` not in the new list is dropped. HMR / test / re-dispatch contract: the set is **exactly** what the last call said.
+- **Codex P2 #2 (HMR identity)** → keep wrapper identity stable per `localId`. The cached wrapper closes over the `localId` and reads the *current* `component` via a live ref from the source map at render time. HMR-replacing `OverviewSection` updates the ref but reuses the same wrapper reference → React does NOT remount the body.
+
 ```ts
 interface HostBuiltinSource {
-  def: HostBuiltinSectionDef         // original inputs
-  wrapped: React.ComponentType<{ ctx: SettingsContextFor<'host'> }>  // cached wrapper
+  // Mutable fields — updated by setHostBuiltinSections(); wrapper reads via ref.
+  component: React.ComponentType<{ hostId: string }>
+  labelKey: string
+  order: number
+  // Stable: built once per localId, never reassigned.
+  wrapped: React.ComponentType<{ ctx: SettingsContextFor<'host'> }>
 }
 
-// Stable source map. Populated by registerBuiltinHostSection(),
-// read non-destructively by the dispatcher, cleared only on HMR dispose.
+// Stable source map. Populated by setHostBuiltinSections(), read non-
+// destructively by the dispatcher, cleared only on HMR dispose / reset.
 const hostBuiltinSources = new Map<string, HostBuiltinSource>()
 
-export function registerBuiltinHostSection(def: HostBuiltinSectionDef): void {
-  const existing = hostBuiltinSources.get(def.localId)
-  // Idempotent: if all user-visible fields unchanged, reuse the cached wrapper
-  // so React.ComponentType identity is stable across re-dispatches.
-  if (existing &&
-      existing.def.component === def.component &&
-      existing.def.labelKey === def.labelKey &&
-      existing.def.order === def.order) {
-    return
+function createHostBuiltinWrapper(localId: string): React.ComponentType<{ ctx: SettingsContextFor<'host'> }> {
+  // Closure over localId only; component read fresh from the source map on
+  // every render, so HMR-replacing the underlying section updates the render
+  // output without changing the wrapper's React component identity.
+  const Wrapped: React.FC<{ ctx: SettingsContextFor<'host'> }> = (props) => {
+    if (props.ctx.scope !== 'host') return null
+    const source = hostBuiltinSources.get(localId)
+    if (!source) return null   // defensive: localId dropped mid-render
+    return React.createElement(source.component, { hostId: props.ctx.hostId })
   }
-  const wrapped = createHostBuiltinWrapper(def)  // same scope-guard logic as today
-  hostBuiltinSources.set(def.localId, { def, wrapped })
+  Wrapped.displayName = `HostBuiltinWrap(${localId})`
+  return Wrapped
+}
+
+/**
+ * Replace the full set of built-in host sub-page sources atomically.
+ * Any localId present in the previous state but absent from `defs` is
+ * dropped; the wrapper for each retained localId is reused (stable
+ * React.ComponentType identity across re-registrations / HMR reloads).
+ * The next dispatchSettingsContributions() materializes exactly these.
+ */
+export function setHostBuiltinSections(defs: readonly HostBuiltinSectionDef[]): void {
+  const nextIds = new Set(defs.map((d) => d.localId))
+  // Drop localIds not in the new set.
+  for (const key of Array.from(hostBuiltinSources.keys())) {
+    if (!nextIds.has(key)) hostBuiltinSources.delete(key)
+  }
+  // Upsert each def; reuse wrapper when present so identity is stable.
+  for (const def of defs) {
+    const existing = hostBuiltinSources.get(def.localId)
+    const wrapped = existing?.wrapped ?? createHostBuiltinWrapper(def.localId)
+    hostBuiltinSources.set(def.localId, {
+      component: def.component,
+      labelKey: def.labelKey,
+      order: def.order,
+      wrapped,
+    })
+    // hostBuiltinComponentMap (WeakMap) kept in lockstep for identity tests:
+    hostBuiltinComponentMap.set(wrapped, def.component)
+  }
 }
 
 export function getHostBuiltinDeclarations(): readonly AnySettingsContributionDeclaration[] {
-  return Array.from(hostBuiltinSources.values(), (src) => ({
-    localId: src.def.localId,
+  return Array.from(hostBuiltinSources.entries(), ([localId, src]) => ({
+    localId,
     scope: 'host' as const,
-    order: src.def.order,
-    labelKey: src.def.labelKey,
-    component: src.wrapped,  // STABLE reference across dispatches
+    order: src.order,
+    labelKey: src.labelKey,
+    component: src.wrapped,  // STABLE reference across dispatches and HMR
   }))
 }
 
@@ -145,7 +182,11 @@ export function clearHostBuiltinSources(): void {
 }
 ```
 
-Removed: `pendingHostBuiltinContributions`, `peekHostBuiltinQueue`, `drainHostBuiltinQueue`, `clearHostBuiltinPending`. The WeakMap `hostBuiltinComponentMap` stays (identity test helper).
+Removed: `pendingHostBuiltinContributions`, `peekHostBuiltinQueue`, `drainHostBuiltinQueue`, `clearHostBuiltinPending`, **`registerBuiltinHostSection` (single-item API)**.
+
+Kept: `HOST_BUILTIN_MODULE_ID`, `HostBuiltinSectionDef` interface, `hostBuiltinComponentMap` WeakMap (identity test helper).
+
+**Callsite change** (`register-modules.tsx:399-404`): the six `registerBuiltinHostSection(...)` calls collapse into one `setHostBuiltinSections([ ...6 defs... ])` call. This is the only production callsite.
 
 #### 4.1.2 Dispatcher changes
 
@@ -182,9 +223,10 @@ clearHostBuiltinSources()  // renamed from clearHostBuiltinPending
 #### 4.1.3 Invariants restored
 
 - **Idempotent dispatch**: N consecutive `dispatchSettingsContributions()` calls (same module list, same built-in source map) yield identical live registry state.
-- **Order-independence**: `registerBuiltinHostSection()` may be called before or after any `registerModule()` without changing the end state; same for the ordering between the two categories.
-- **HMR safety**: `clearHostBuiltinSources()` runs in HMR dispose; the next `registerBuiltinModules()` repopulates without duplication.
-- **Component identity stability**: When `registerBuiltinHostSection()` is called twice with the same `def.component` / `def.labelKey` / `def.order`, the cached `wrapped` reference is preserved, so React does not remount built-in host sub-page bodies across re-dispatches.
+- **Order-independence**: `setHostBuiltinSections()` may be called before or after any `registerModule()` without changing the end state; same for the ordering between the two categories.
+- **Full-replace semantics**: a `setHostBuiltinSections(defs)` call defines the **exact** set; any `localId` not in `defs` is dropped. Rules out partial-re-register stale `localId` leak (codex R1 P2 #1).
+- **HMR safety**: `clearHostBuiltinSources()` runs in HMR dispose; the next `registerBuiltinModules()` repopulates via `setHostBuiltinSections()` without duplication. Additionally, HMR reloading a single host section file triggers `registerBuiltinModules()` re-run → `setHostBuiltinSections()` re-run → same `localId`s → wrapper identity preserved (closed over `localId`, not `component`), only the `component` field in the source record is refreshed.
+- **Component identity stability across HMR**: the wrapper for each `localId` is created once and reused on every subsequent `setHostBuiltinSections()` call, even when the underlying section component is a new reference (HMR reload case). React sees the same wrapper component type → no unmount of the host sub-page body; only the internal delegation resolves to the freshly reloaded section (codex R1 P2 #2).
 
 ### 4.2 #588 — reactive host runtime (Option A)
 
@@ -201,24 +243,41 @@ type SettingsContext =
 - `runtime` is explicitly `HostRuntime | undefined` (not optional `?`) to force callers to think about the absent case (host exists but no runtime yet — common on first render before any status tick).
 - All existing `disabled(ctx)` / component consumers that ignore `runtime` continue to compile (property unused).
 
-#### 4.2.2 `HostPage` subscribes runtime
+#### 4.2.2 `HostPage` subscribes runtime — two-pass selective subscription (codex R1 P3 #3)
+
+v1 proposed subscribing the entire `runtime` map at HostPage, which would re-render the page on every host's heartbeat tick. Codex R1 P3 #3 flagged this as avoidable. Revised design uses a two-pass resolve:
 
 ```tsx
-const hostOrder  = useHostStore((s) => s.hostOrder)
-const activeHostId = useHostStore((s) => s.activeHostId)
-const runtime    = useHostStore((s) => s.runtime)   // NEW — whole map
+// Pass 1: compute tentative hostId WITHOUT runtime
+const hostOrder     = useHostStore((s) => s.hostOrder)
+const activeHostId  = useHostStore((s) => s.activeHostId)
+const tentativeHostId = preResolveHostId(location, hostOrder, activeHostId, lastSelection)
+
+// Pass 2: selective subscription — only the tentative host's runtime.
+// Zustand re-runs this selector on every store change but triggers
+// re-render only when the returned reference changes (shallow equality).
+const tentativeRuntime = useHostStore((s) =>
+  tentativeHostId ? s.runtime[tentativeHostId] : undefined,
+)
+
+// Pass 3: final resolve with runtime-aware ctx
+const { selection, canonicalPath, shouldPersistSelection } = resolveSelection(
+  location, hostOrder, activeHostId, tentativeHostId, tentativeRuntime,
+)
 ```
 
-Rationale for subscribing the whole map, not a selective `runtime[hostId]`:
-- `hostId` is derived from `resolveSelection(location, hostOrder, activeHostId, runtime)` — chicken-and-egg otherwise.
-- `runtime` is a `Record<string, HostRuntime>` whose object identity only changes on runtime ticks for *any* host; impact is bounded to host-area lifecycle. For the typical user session (single-digit hosts, ticks every few seconds), re-render cost is negligible and strictly better than the alternative of refactoring selection to a two-pass design.
-- `HostSidebar` already subscribes to the same map; cost is already paid at the HostPage level via child render.
+- `preResolveHostId(...)` is a **pure**, runtime-independent helper: hostId selection depends only on URL / hostOrder / activeHostId / lastSelection (§4.2.6 chicken-and-egg still holds).
+- `pickSelectableSubPage(hostId, requested, runtime)` receives the *single-host* runtime and builds ctx as `{ scope: 'host', hostId, runtime }`.
+- Sub-page selection for the tentative host is sensitive to *that host's* runtime only. A background host's heartbeat tick mutates `runtime[otherId]` but leaves `runtime[tentativeHostId]` reference unchanged → zustand shallow-compares → selector returns same reference → **no HostPage re-render**.
+- `HostSidebar` unavoidably subscribes to the whole runtime map (StatusIcon + per-row disabled predicate) — that cost is inherent to the sidebar's job and unchanged by this PR.
 
 #### 4.2.3 `resolveSelection` / `pickSelectableSubPage` / `renderContent` take runtime
 
-- `resolveSelection(location, hostOrder, activeHostId, runtime)` — additional `runtime` parameter.
-- `pickSelectableSubPage(hostId, requestedSubPage, runtime)` — builds ctx as `{ scope: 'host', hostId, runtime: runtime[hostId] }`.
-- `renderContent` builds ctx the same way; `isSelectable(contribution, ctx)` receives runtime-aware ctx.
+- `preResolveHostId(location, hostOrder, activeHostId, lastSelection): string | null` — new pure helper. Extracted logic currently inline in `resolveSelection` / `getFallbackSelection`.
+- `resolveSelection(location, hostOrder, activeHostId, tentativeHostId, tentativeRuntime)` — additional two parameters. Internally builds ctx only for `tentativeHostId`; other hostIds never need ctx at selection time.
+- `pickSelectableSubPage(hostId, requestedSubPage, runtime: HostRuntime | undefined)` — builds ctx `{ scope: 'host', hostId, runtime }` and evaluates `disabled(ctx)`.
+- `renderContent` builds ctx as `{ scope: 'host', hostId: selection.hostId, runtime: tentativeRuntime }` (we only render the body for the selected host, which equals the tentative host after resolve).
+- **ctx-builder helper** (codex R1 Q4 ergonomics note): optional small `buildHostCtx(hostId, runtime)` helper colocated in `host-builtin-sections.ts` or a new `host-ctx.ts` to keep the construction tidy. Not required — callsites inside HostPage are few enough to inline — but plan may adopt if ergonomics wins during implementation.
 
 #### 4.2.4 `HostSidebar` propagates runtime in ctx
 
@@ -248,10 +307,11 @@ The three sites fixed by `ca000a81` (getFallbackSelection / sidebarSubPage / res
 
 | Surface | Before | After | Breakage |
 |---|---|---|---|
-| `registerBuiltinHostSection(def)` | Push to pending buffer | Upsert into stable source map (idempotent) | None externally — call semantics unchanged from caller's viewpoint |
+| `registerBuiltinHostSection(def)` | Push to pending buffer (single item) | **Removed** | Only production caller (`register-modules.tsx:399-404`) migrates to `setHostBuiltinSections`. No other importers (grep confirmed). |
+| `setHostBuiltinSections(defs[])` | — | **New**: batch-replace full set; wrapper identity stable per localId | New API |
 | `peekHostBuiltinQueue()` / `drainHostBuiltinQueue()` / `clearHostBuiltinPending()` | Exported | Removed | Internal to `host-builtin-sections` + `dispatch-settings-contributions` + tests — grep confirms no other importers |
-| New: `getHostBuiltinDeclarations()` | — | Exported | Used by dispatcher only |
-| New: `clearHostBuiltinSources()` | — | Exported | Replaces `clearHostBuiltinPending` in `resetSettingsContributionsForHmr` |
+| `getHostBuiltinDeclarations()` | — | **New**, exported | Used by dispatcher only |
+| `clearHostBuiltinSources()` | — | **New**, exported | Replaces `clearHostBuiltinPending` in `resetSettingsContributionsForHmr` and in test harnesses |
 | `SettingsContextFor<'host'>` | `{ scope: 'host'; hostId }` | `{ scope: 'host'; hostId; runtime: HostRuntime \| undefined }` | All consumer sites must now set `runtime` when building ctx. Consumers that **read** ctx stay source-compatible (extra field). |
 | `HostRuntime` type | — | **exported** from `useHostStore` (already exported at `spa/src/stores/useHostStore.ts:17` — no change needed) | None |
 
@@ -263,29 +323,34 @@ All call-site churn for `runtime` is inside `HostPage.tsx` + `HostSidebar.tsx` +
 
 ### 6.1 New tests — #586
 
-`spa/src/lib/host-builtin-sections.test.tsx`:
+`spa/src/lib/host-builtin-sections.test.tsx` (existing file — rewrite #586-impacted tests and add):
 
-1. **Idempotent re-register**: call `registerBuiltinHostSection(def)` twice with identical def → source map size = 1 AND `getHostBuiltinDeclarations()[0].component === getHostBuiltinDeclarations()[0].component` across calls (stable reference).
-2. **Def change invalidates cache**: register with `order: 0`, then re-register with `order: 1` → declarations reflect new order, wrapper is rebuilt (reference may differ; new def fully replaces).
-3. **`clearHostBuiltinSources()` empties the map**: populate → clear → `getHostBuiltinDeclarations()` returns `[]`.
+1. **Batch replace is the full set**: `setHostBuiltinSections([a, b, c])` → declarations = 3, localIds = [a, b, c]. Then `setHostBuiltinSections([a, d])` → declarations = 2, localIds = [a, d] (b and c dropped). Validates codex R1 P2 #1 full-replace.
+2. **Wrapper identity stable across re-calls with same localIds** (codex R1 P2 #2): `setHostBuiltinSections([a])` → capture `getHostBuiltinDeclarations()[0].component` → `setHostBuiltinSections([a])` again with a *fresh* section `component` reference (simulating HMR reload of the section file) → new `getHostBuiltinDeclarations()[0].component` is the **same reference** as before. Validates wrapper caching by `localId`.
+3. **Wrapper delegates to the latest component**: after (2), render the wrapper → output reflects the **new** section component (not the pre-HMR one). Use `vi.fn()`-style stubs to assert which was invoked.
+4. **Wrapper is rebuilt only when localId is re-added after being dropped**: `setHostBuiltinSections([a])` → drop via `setHostBuiltinSections([])` → re-add via `setHostBuiltinSections([a])` → wrapper identity differs from the first round (dropped localIds lose their cached wrapper).
+5. **`clearHostBuiltinSources()` empties the map**: populate → clear → `getHostBuiltinDeclarations()` returns `[]`.
 
-`spa/src/lib/dispatch-settings-contributions.test.ts`:
+`spa/src/lib/dispatch-settings-contributions.test.ts` (existing file — extend):
 
-4. **Standalone re-dispatch preserves host built-ins** (THE #586 bug): `registerBuiltinHostSection(...)` × 6 → `dispatchSettingsContributions()` → assert 6 host contributions → `dispatchSettingsContributions()` again (no re-register) → assert still 6 host contributions AND same component identities.
-5. **Interleaved module + built-in dispatch**: `registerModule({ settings: [...] })` + `registerBuiltinHostSection(...)` → dispatch → dispatch again → state stable.
-6. **HMR reset**: populate → `resetSettingsContributionsForHmr()` → dispatch → 0 host contributions (sources cleared).
+6. **Standalone re-dispatch preserves host built-ins** (THE #586 bug): `setHostBuiltinSections([...6 defs...])` → `dispatchSettingsContributions()` → assert 6 host contributions → `dispatchSettingsContributions()` again (no re-register) → assert still 6 host contributions AND same `component` references on each.
+7. **Interleaved module + built-in dispatch**: `registerModule({ settings: [...] })` + `setHostBuiltinSections(...)` → dispatch → dispatch again → state stable.
+8. **HMR reset**: populate → `resetSettingsContributionsForHmr()` → dispatch → 0 host contributions (sources cleared).
 
 ### 6.2 New tests — #588
 
-`spa/src/components/HostPage.test.tsx` (if absent, new; otherwise extend):
+`spa/src/components/HostPage.test.tsx` (existing file — extend):
 
 7. **Runtime tick drops disabled body**: register a host contribution with `disabled: (ctx) => ctx.runtime?.status !== 'connected'` → URL `/hosts/hA/featureX` → seed `runtime.hA = { status: 'connected' }` → body mounts → mutate to `{ status: 'disconnected' }` → `HostPage` re-renders → body unmounts, URL navigates to the next selectable sub-page.
 8. **Runtime tick re-enables body**: inverse of 7 — disabled initially → runtime flips → `canonicalPath` is null (already at correct subPage) OR redirects into the now-enabled body cleanly.
 9. **`pickSelectableSubPage` uses runtime**: unit test on the helper with synthetic contributions + runtime maps; disabled predicate returns true iff runtime is absent.
+10. **Background host tick does NOT re-render HostPage** (codex R1 P3 #3 regression): render HostPage on `/hosts/hA/overview` → spy/counter on HostPage render → `useHostStore.setState(state => ({ runtime: { ...state.runtime, hB: { status: 'disconnected' } } }))` → render count unchanged. Validates selective subscription.
+11. **Rapid runtime flicker is stable** (codex R1 P3 #4): register contribution with runtime-driven disabled → URL `/hosts/hA/featureX` → tick `connected → disconnected → connected` in three sync setState calls → final state: body mounted on featureX, no redirect thrash left in the location history beyond 0–1 redirects. Asserts idempotent resolve under rapid ticks.
+12. **Unmount during tick does not warn** (codex R1 P3 #4): render → unmount via RTL `cleanup()` → push a runtime tick → vitest `process.stdout`/console spy records no "update on unmounted component" / stale-state warnings. Guards against stale effect subscriptions.
 
-`spa/src/components/hosts/HostSidebar.test.tsx` (if absent, new; otherwise extend):
+`spa/src/components/hosts/HostSidebar.test.tsx` (existing file — extend):
 
-10. **Sidebar builds runtime-aware ctx**: register contribution with `disabled: (ctx) => ctx.runtime === undefined` → host in store but no runtime yet → sidebar row rendered with `data-disabled-ctx="true"` → runtime tick arrives → row becomes enabled.
+13. **Sidebar builds runtime-aware ctx**: register contribution with `disabled: (ctx) => ctx.runtime === undefined` → host in store but no runtime yet → sidebar row rendered with `data-disabled-ctx="true"` → runtime tick arrives → row becomes enabled.
 
 ### 6.3 Existing tests
 
@@ -310,8 +375,8 @@ Target: all scope tests + existing suite pass (`pnpm exec vitest run`). Lint + b
 Single PR, squash merge, alpha bump afterwards.
 
 Commit sequence (detail in plan):
-1. **feat(spa): host built-in stable source map** — replace pending buffer with source map + idempotent wrapper cache + dispatcher re-materialization + HMR rename. Rewrites tests for #586. Ships alone and green.
-2. **feat(spa): reactive host runtime in SettingsContextFor<'host'>** — add `runtime` to host ctx, plumb through HostPage + HostSidebar + pickSelectableSubPage. Rewrites / adds tests for #588. Ships alone and green.
+1. **feat(spa): host built-in batch-replace source map** — remove `registerBuiltinHostSection` + pending buffer; add `setHostBuiltinSections` (batch replace) + stable-per-localId wrapper cache + dispatcher re-materialization + HMR rename. Migrates the six-call register-modules.tsx callsite. Rewrites tests for #586. Ships alone and green.
+2. **feat(spa): reactive host runtime in SettingsContextFor<'host'>** — add `runtime` to host ctx, plumb through HostPage two-pass selective subscription + HostSidebar ctx + `pickSelectableSubPage`. Rewrites / adds tests for #588. Ships alone and green.
 
 Optional commit 0 (docs): add spec file. Kept alongside merge.
 
@@ -324,8 +389,9 @@ Post-merge: bump PR to alpha.207 from separate worktree (CLAUDE.md dev process �
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
 | `SettingsContextFor<'host'>` breaking change surfaces in unseen callsite | Low | Medium | TypeScript compilation catches all sites; grep for `scope: 'host'` or `SettingsContextFor<'host'>` in plan §checklist |
-| HostPage re-render on every runtime tick degrades perf | Low | Low | Single-digit hosts; ticks are heartbeat-speed; matches HostSidebar subscription cost already paid today |
-| Component identity regression forces body remount | Med | Low | Unit test 1+4 explicitly assert wrapper identity across re-registers and re-dispatches |
+| HostPage re-render on every runtime tick degrades perf | Low→**Addressed** | Low | Two-pass selective subscription (§4.2.2 per codex R1 P3 #3); regression test 10 asserts background-host tick does NOT re-render HostPage |
+| Component identity regression forces body remount | Med→**Addressed** | Low | Stable-per-localId wrapper cache (§4.1.1 per codex R1 P2 #2); tests 2+3 assert wrapper identity across HMR-simulated re-registrations |
+| Partial re-register leaves stale localIds | Med→**Addressed** | Low | Batch-replace API (§4.1.1 per codex R1 P2 #1); test 1 asserts dropped localIds disappear |
 | Legacy adapter kept on old buffer pattern looks asymmetric | High | Low (it actually is asymmetric; intentional) | Note in PR body + issue #586 (or follow-up) captures "legacy adapter same fix, deferred"; adds strictly more risk to expand scope here |
 | `runtime: HostRuntime \| undefined` confuses callers expecting optional | Low | Low | Use `?` optional makes callers forget runtime — keeping required-undefined is a deliberate contract to force explicit handling. Documented in spec §5 |
 | Test rewrites miss an invariant the old pending-buffer captured | Med | Medium | Each rewritten test's behavioural property is explicitly listed in §6.1; pass/fail table in PR body cross-refs old vs new |
@@ -342,12 +408,15 @@ Post-merge: bump PR to alpha.207 from separate worktree (CLAUDE.md dev process �
 
 ## 10. Acceptance checklist
 
-- [ ] #586: `dispatchSettingsContributions()` is idempotent (test 4 green)
-- [ ] #586: HMR reset + dispatch → host built-ins gone (test 6 green)
-- [ ] #586: Component identity stable across re-dispatches (test 1+4 green)
+- [ ] #586: `dispatchSettingsContributions()` is idempotent under re-dispatch (test 6 green)
+- [ ] #586: HMR reset + dispatch → host built-ins gone (test 8 green)
+- [ ] #586: Full-replace semantics — dropped localIds disappear (test 1 green, codex R1 P2 #1)
+- [ ] #586: Wrapper identity stable across re-calls with same localIds (test 2+3 green, codex R1 P2 #2)
+- [ ] #586: `registerBuiltinHostSection` removed; only `setHostBuiltinSections` is the public API
 - [ ] #588: `SettingsContextFor<'host'>` has `runtime: HostRuntime | undefined`
-- [ ] #588: `HostPage` subscribes `runtime` and re-resolves on ticks (test 7+8 green)
-- [ ] #588: `HostSidebar` passes runtime in ctx (test 10 green)
+- [ ] #588: `HostPage` uses two-pass selective subscription (test 10 green, codex R1 P3 #3)
+- [ ] #588: Rapid runtime tick is stable + unmount during tick does not warn (tests 11+12 green, codex R1 P3 #4)
+- [ ] #588: `HostSidebar` passes runtime in ctx (test 13 green)
 - [ ] All existing tests green (`pnpm exec vitest run`)
 - [ ] Lint green (`pnpm run lint`)
 - [ ] Build green (`pnpm run build`)

--- a/docs/specs/2026-04-22-hsr-pr4-followup-586-588-spec.md
+++ b/docs/specs/2026-04-22-hsr-pr4-followup-586-588-spec.md
@@ -1,0 +1,356 @@
+# HSR PR-4 Follow-up — #586 + #588 (Architecture Polish)
+
+- **Date**: 2026-04-22
+- **Status**: Draft v1 (pending codex review)
+- **Target**: `main` — post-alpha.206
+- **Scope**: Two architectural polish items closed together in one PR, as preparation for PR-5 (Editor module dynamic register).
+- **Related**:
+  - GH #586 (bug/spa): `dispatchSettingsContributions()` 第二次 standalone 呼叫會清空 host built-ins
+  - GH #588 (bug/spa): `disabled(ctx)` 動態變化時 body 不 reactive 卸載
+  - GH #587 (refactor/spa): `parseRoute` / `isHostSubPage` 依賴 mutable registry — **out of scope**, deferred to post-PR-5
+  - Master spec: `docs/specs/2026-04-21-settings-contribution-registry-design.md`
+  - PR-4 merged at `a0452e02` (alpha.206, `df34d1d8`)
+
+---
+
+## 1. Why
+
+Both findings were raised by Round 2 / Round 3 codex review on PR-4 (#582) and explicitly deferred — they are **not currently triggered in production** but become real risks the moment PR-5 introduces the first module with `disabled(ctx)` and/or a dynamic module-register callsite. PR-5 is the validation proof of the whole HSR architecture; we want to enter PR-5 with these two contracts already in place so that PR-5's review noise is about the Editor feature, not about leftover architectural debt.
+
+Consolidating the two into a single small PR keeps review concentrated (same PR-4 cluster, same reviewers' mental model) and avoids two serialized bump cycles.
+
+---
+
+## 2. Scope
+
+Single squash-merged PR with two commits (plus incidental test scaffolding commits as needed; see plan). No feature changes. No visible UX change. All existing tests must stay green; new tests capture the new contracts.
+
+**In scope**
+- #586 — replace the host-builtin pending-buffer/one-shot-drain design with a stable source map that is re-materialized every dispatch (Option A in the issue body).
+- #588 — make `HostPage` reactive to `HostRuntime` changes and plumb `runtime` into `SettingsContextFor<'host'>`, so `disabled(ctx)` predicates reflect live host runtime (Option A in the issue body).
+
+**Out of scope (tracked separately)**
+- Legacy adapter (`settings-section-registry`) still uses the pending buffer + drain pattern. It is purdex-scoped and currently only populated during `registerBuiltinModules()`; the same symmetric fix is strictly better but is **not** part of this PR. Tracked as issue #586 comment or new follow-up if desired; spec explicitly punts to keep blast radius small.
+- #587 `parseRoute` / `isHostSubPage` pure-parser discussion — needs a real dynamic module-declared sub-page (PR-5 or later) to judge which option lands best. Status: remain OPEN, untouched.
+- Any change to `globalConfig` / `workspaceConfig` deprecation path (PR-5).
+
+---
+
+## 3. Current behaviour (grounded in code)
+
+### 3.1 Host built-in registration (today)
+
+`spa/src/lib/host-builtin-sections.ts`:
+
+```ts
+const pendingHostBuiltinContributions = new Map<string, HostBuiltinDeclaration>()
+
+export function registerBuiltinHostSection(def): void {
+  const Wrapped = /* scope-guard wrapper around def.component */
+  pendingHostBuiltinContributions.set(def.localId, { ...decl, component: Wrapped })
+}
+export function peekHostBuiltinQueue(): readonly ...[] { /* Array.from(values) */ }
+export function drainHostBuiltinQueue(): ...[] {
+  const out = Array.from(values); pendingHostBuiltinContributions.clear(); return out
+}
+export function clearHostBuiltinPending(): void { pendingHostBuiltinContributions.clear() }
+```
+
+`dispatch-settings-contributions.ts` Phase 2 calls `drainHostBuiltinQueue()` *after* `clearContributions()`. Problem (from #586): after the first successful dispatch the buffer is empty, so a second standalone `dispatchSettingsContributions()` call (no re-`registerBuiltinHostSection(...)` in between) would:
+
+1. Phase 1 validate — batch contains module-declared only, host-builtin peek returns `[]`, no collisions, passes.
+2. Phase 2 `clearContributions()` — wipes live host-builtin contributions previously written.
+3. Phase 2 `drainHostBuiltinQueue()` — no-op.
+4. Result: `listContributions('host')` returns `[]`; `HostPage` UI collapses (sidebar empty, body self-heals via canonicalPath redirect loop guarded by `hostOrder === 0` check, but still broken).
+
+Today the only callsite is inside `registerBuiltinModules()` which *does* re-push. PR-5 will add `registerModule({..., settings: [...]})` at least once dynamically; even if PR-5 is careful to co-locate a fresh `registerBuiltinModules()`-style flush, any future module-dynamic-register API is a landmine.
+
+### 3.2 HostPage reactivity (today)
+
+`HostPage.tsx` subscribes to:
+
+```tsx
+const hostOrder = useHostStore((s) => s.hostOrder)
+const activeHostId = useHostStore((s) => s.activeHostId)
+// does NOT subscribe to `runtime`
+```
+
+`HostSidebar.tsx` already subscribes to `runtime` (for `StatusIcon`) and builds `hostCtx = { scope: 'host', hostId }` without a `runtime` field — `disabled(ctx)` predicates passed from modules have no access to runtime.
+
+Consequence: a module authoring `disabled: (ctx) => useHostStore.getState().runtime[ctx.hostId]?.status !== 'connected'` today:
+- `HostSidebar` ticks on runtime changes → predicate re-runs via re-render → row greys/ungreys reactively ✓
+- `HostPage.resolveSelection` runs only when `location` / `hostOrder` / `activeHostId` change — runtime changes **do not** trigger redirect away from a body that just became disabled ✗
+
+This violates PR-4's new "disabled contribution must not mount body" contract the moment a real consumer exists.
+
+### 3.3 `SettingsContextFor<'host'>` shape (today)
+
+`spa/src/lib/settings-contribution-types.ts`:
+
+```ts
+type SettingsContext =
+  | { scope: 'purdex' }
+  | { scope: 'host'; hostId: string }
+  | { scope: 'workspace'; workspaceId: string }
+```
+
+No runtime field for host scope. To make `disabled(ctx)` reflect host-runtime reactively without `getState()` side reads, we must plumb runtime through ctx.
+
+---
+
+## 4. Design
+
+### 4.1 #586 — stable source map (Option A)
+
+Concept: host built-ins become a **stable registration source**, not a one-shot buffer. Every `dispatchSettingsContributions()` call re-materializes host-builtin declarations from the source map; the source map is only mutated by `registerBuiltinHostSection()` (population) and `clearHostBuiltinSources()` (HMR dispose / test reset).
+
+#### 4.1.1 New `host-builtin-sections.ts` shape
+
+```ts
+interface HostBuiltinSource {
+  def: HostBuiltinSectionDef         // original inputs
+  wrapped: React.ComponentType<{ ctx: SettingsContextFor<'host'> }>  // cached wrapper
+}
+
+// Stable source map. Populated by registerBuiltinHostSection(),
+// read non-destructively by the dispatcher, cleared only on HMR dispose.
+const hostBuiltinSources = new Map<string, HostBuiltinSource>()
+
+export function registerBuiltinHostSection(def: HostBuiltinSectionDef): void {
+  const existing = hostBuiltinSources.get(def.localId)
+  // Idempotent: if all user-visible fields unchanged, reuse the cached wrapper
+  // so React.ComponentType identity is stable across re-dispatches.
+  if (existing &&
+      existing.def.component === def.component &&
+      existing.def.labelKey === def.labelKey &&
+      existing.def.order === def.order) {
+    return
+  }
+  const wrapped = createHostBuiltinWrapper(def)  // same scope-guard logic as today
+  hostBuiltinSources.set(def.localId, { def, wrapped })
+}
+
+export function getHostBuiltinDeclarations(): readonly AnySettingsContributionDeclaration[] {
+  return Array.from(hostBuiltinSources.values(), (src) => ({
+    localId: src.def.localId,
+    scope: 'host' as const,
+    order: src.def.order,
+    labelKey: src.def.labelKey,
+    component: src.wrapped,  // STABLE reference across dispatches
+  }))
+}
+
+export function clearHostBuiltinSources(): void {
+  hostBuiltinSources.clear()
+}
+```
+
+Removed: `pendingHostBuiltinContributions`, `peekHostBuiltinQueue`, `drainHostBuiltinQueue`, `clearHostBuiltinPending`. The WeakMap `hostBuiltinComponentMap` stays (identity test helper).
+
+#### 4.1.2 Dispatcher changes
+
+`buildSettingsContributionBatch`:
+
+```ts
+// Host built-ins: re-materialize every dispatch from the stable source map.
+// NOT a queue drain — sources are long-lived; dispatch is idempotent.
+const hostBuiltinDecls = getHostBuiltinDeclarations()
+for (const decl of hostBuiltinDecls) {
+  const full = { ...decl, moduleId: HOST_BUILTIN_MODULE_ID, id: `${HOST_BUILTIN_MODULE_ID}.${decl.localId}` }
+  checkAndRecord(full, 'host-builtin')
+  batch.push(full)
+}
+```
+
+`dispatchSettingsContributions` Phase 2:
+
+```ts
+clearContributions()
+drainLegacyContributionQueue()  // legacy keeps the old drain contract (out of scope)
+// NO drainHostBuiltinQueue() — sources are stable, batch already contains host-builtins.
+for (const contribution of batch) registerSettingsContribution(contribution)
+```
+
+`resetSettingsContributionsForHmr`:
+
+```ts
+clearContributions()
+clearLegacyPending()
+clearHostBuiltinSources()  // renamed from clearHostBuiltinPending
+```
+
+#### 4.1.3 Invariants restored
+
+- **Idempotent dispatch**: N consecutive `dispatchSettingsContributions()` calls (same module list, same built-in source map) yield identical live registry state.
+- **Order-independence**: `registerBuiltinHostSection()` may be called before or after any `registerModule()` without changing the end state; same for the ordering between the two categories.
+- **HMR safety**: `clearHostBuiltinSources()` runs in HMR dispose; the next `registerBuiltinModules()` repopulates without duplication.
+- **Component identity stability**: When `registerBuiltinHostSection()` is called twice with the same `def.component` / `def.labelKey` / `def.order`, the cached `wrapped` reference is preserved, so React does not remount built-in host sub-page bodies across re-dispatches.
+
+### 4.2 #588 — reactive host runtime (Option A)
+
+#### 4.2.1 Extend `SettingsContextFor<'host'>`
+
+```ts
+type SettingsContext =
+  | { scope: 'purdex' }
+  | { scope: 'host'; hostId: string; runtime: HostRuntime | undefined }  // NEW runtime field
+  | { scope: 'workspace'; workspaceId: string }
+```
+
+- `HostRuntime` imported from `../stores/useHostStore`.
+- `runtime` is explicitly `HostRuntime | undefined` (not optional `?`) to force callers to think about the absent case (host exists but no runtime yet — common on first render before any status tick).
+- All existing `disabled(ctx)` / component consumers that ignore `runtime` continue to compile (property unused).
+
+#### 4.2.2 `HostPage` subscribes runtime
+
+```tsx
+const hostOrder  = useHostStore((s) => s.hostOrder)
+const activeHostId = useHostStore((s) => s.activeHostId)
+const runtime    = useHostStore((s) => s.runtime)   // NEW — whole map
+```
+
+Rationale for subscribing the whole map, not a selective `runtime[hostId]`:
+- `hostId` is derived from `resolveSelection(location, hostOrder, activeHostId, runtime)` — chicken-and-egg otherwise.
+- `runtime` is a `Record<string, HostRuntime>` whose object identity only changes on runtime ticks for *any* host; impact is bounded to host-area lifecycle. For the typical user session (single-digit hosts, ticks every few seconds), re-render cost is negligible and strictly better than the alternative of refactoring selection to a two-pass design.
+- `HostSidebar` already subscribes to the same map; cost is already paid at the HostPage level via child render.
+
+#### 4.2.3 `resolveSelection` / `pickSelectableSubPage` / `renderContent` take runtime
+
+- `resolveSelection(location, hostOrder, activeHostId, runtime)` — additional `runtime` parameter.
+- `pickSelectableSubPage(hostId, requestedSubPage, runtime)` — builds ctx as `{ scope: 'host', hostId, runtime: runtime[hostId] }`.
+- `renderContent` builds ctx the same way; `isSelectable(contribution, ctx)` receives runtime-aware ctx.
+
+#### 4.2.4 `HostSidebar` propagates runtime in ctx
+
+```tsx
+const hostCtx = { scope: 'host' as const, hostId, runtime: runtime[hostId] }
+// page.disabled(hostCtx) now sees runtime
+```
+
+Already subscribes to `runtime`; only change is plumbing through ctx.
+
+#### 4.2.5 `host-builtin-sections` wrapper
+
+Wrapper already type-guards `props.ctx.scope === 'host'`. The extended ctx shape gains `runtime` but the wrapper forwards `hostId` only — no change to built-in section components (which receive `{ hostId }` as before).
+
+#### 4.2.6 Invariants restored
+
+- **Reactivity**: when `runtime[hostId]` changes and a disabled(ctx) predicate flips true, `HostPage.renderContent` re-evaluates, `isSelectable` returns false, body returns `null`, `canonicalPath` effect redirects to the next selectable sub-page. PR-4's "disabled body must not mount" contract is now upheld at **evaluation time AND reactivity time**.
+- **No chicken-and-egg**: single pass. `hostId` → `runtime[hostId]` resolved inline at `pickSelectableSubPage` callsite; `resolveSelection` never needs the runtime to pick a hostId (host selection is driven by order/active/URL, not runtime).
+
+### 4.3 Interaction with PR-4's three unified fallback sites
+
+The three sites fixed by `ca000a81` (getFallbackSelection / sidebarSubPage / resolveSelection) all flow through `pickSelectableSubPage`; they automatically benefit from runtime-aware ctx after the signature change. No new fallback sites.
+
+---
+
+## 5. Contract changes (public / semi-public)
+
+| Surface | Before | After | Breakage |
+|---|---|---|---|
+| `registerBuiltinHostSection(def)` | Push to pending buffer | Upsert into stable source map (idempotent) | None externally — call semantics unchanged from caller's viewpoint |
+| `peekHostBuiltinQueue()` / `drainHostBuiltinQueue()` / `clearHostBuiltinPending()` | Exported | Removed | Internal to `host-builtin-sections` + `dispatch-settings-contributions` + tests — grep confirms no other importers |
+| New: `getHostBuiltinDeclarations()` | — | Exported | Used by dispatcher only |
+| New: `clearHostBuiltinSources()` | — | Exported | Replaces `clearHostBuiltinPending` in `resetSettingsContributionsForHmr` |
+| `SettingsContextFor<'host'>` | `{ scope: 'host'; hostId }` | `{ scope: 'host'; hostId; runtime: HostRuntime \| undefined }` | All consumer sites must now set `runtime` when building ctx. Consumers that **read** ctx stay source-compatible (extra field). |
+| `HostRuntime` type | — | **exported** from `useHostStore` (already exported at `spa/src/stores/useHostStore.ts:17` — no change needed) | None |
+
+All call-site churn for `runtime` is inside `HostPage.tsx` + `HostSidebar.tsx` + a handful of tests. No module-declared consumer exists today (host-builtin sections don't use disabled).
+
+---
+
+## 6. Test plan
+
+### 6.1 New tests — #586
+
+`spa/src/lib/host-builtin-sections.test.tsx`:
+
+1. **Idempotent re-register**: call `registerBuiltinHostSection(def)` twice with identical def → source map size = 1 AND `getHostBuiltinDeclarations()[0].component === getHostBuiltinDeclarations()[0].component` across calls (stable reference).
+2. **Def change invalidates cache**: register with `order: 0`, then re-register with `order: 1` → declarations reflect new order, wrapper is rebuilt (reference may differ; new def fully replaces).
+3. **`clearHostBuiltinSources()` empties the map**: populate → clear → `getHostBuiltinDeclarations()` returns `[]`.
+
+`spa/src/lib/dispatch-settings-contributions.test.ts`:
+
+4. **Standalone re-dispatch preserves host built-ins** (THE #586 bug): `registerBuiltinHostSection(...)` × 6 → `dispatchSettingsContributions()` → assert 6 host contributions → `dispatchSettingsContributions()` again (no re-register) → assert still 6 host contributions AND same component identities.
+5. **Interleaved module + built-in dispatch**: `registerModule({ settings: [...] })` + `registerBuiltinHostSection(...)` → dispatch → dispatch again → state stable.
+6. **HMR reset**: populate → `resetSettingsContributionsForHmr()` → dispatch → 0 host contributions (sources cleared).
+
+### 6.2 New tests — #588
+
+`spa/src/components/HostPage.test.tsx` (if absent, new; otherwise extend):
+
+7. **Runtime tick drops disabled body**: register a host contribution with `disabled: (ctx) => ctx.runtime?.status !== 'connected'` → URL `/hosts/hA/featureX` → seed `runtime.hA = { status: 'connected' }` → body mounts → mutate to `{ status: 'disconnected' }` → `HostPage` re-renders → body unmounts, URL navigates to the next selectable sub-page.
+8. **Runtime tick re-enables body**: inverse of 7 — disabled initially → runtime flips → `canonicalPath` is null (already at correct subPage) OR redirects into the now-enabled body cleanly.
+9. **`pickSelectableSubPage` uses runtime**: unit test on the helper with synthetic contributions + runtime maps; disabled predicate returns true iff runtime is absent.
+
+`spa/src/components/hosts/HostSidebar.test.tsx` (if absent, new; otherwise extend):
+
+10. **Sidebar builds runtime-aware ctx**: register contribution with `disabled: (ctx) => ctx.runtime === undefined` → host in store but no runtime yet → sidebar row rendered with `data-disabled-ctx="true"` → runtime tick arrives → row becomes enabled.
+
+### 6.3 Existing tests
+
+All existing tests must pass. Specifically:
+- `spa/src/lib/host-builtin-sections.test.tsx` — adjust assertions referring to `peek/drain` API if any (expected: delete / rewrite those).
+- `spa/src/lib/dispatch-settings-contributions.test.ts` — host-builtin atomicity tests rewrite: validation failure still leaves source map intact (source map is long-lived by design; no "queue" to preserve), but the behavioural contract that commit only happens on validation success still holds.
+- `spa/src/lib/register-modules.test.ts` — no expected change (public registerBuiltinModules surface unchanged).
+- `spa/src/components/HostPage.test.tsx` / existing route-utils / HostSidebar tests — adjust any ctx construction to include `runtime` field (many tests will just add `runtime: undefined`).
+
+Target: all scope tests + existing suite pass (`pnpm exec vitest run`). Lint + build green.
+
+### 6.4 Manual smoke (pre-PR)
+
+1. `pnpm run dev` → launch SPA → Host page renders six built-in sub-pages as before.
+2. Disconnect/reconnect a host via daemon off/on — sidebar row status icon updates (unchanged), body unaffected (no contribution uses `disabled` yet; regression check).
+3. Local ad-hoc module with `disabled: (ctx) => ctx.runtime?.status === 'disconnected'` (dev-only manual harness) — verify redirect on status flip. Not committed; used to validate during self-review.
+
+---
+
+## 7. Rollout
+
+Single PR, squash merge, alpha bump afterwards.
+
+Commit sequence (detail in plan):
+1. **feat(spa): host built-in stable source map** — replace pending buffer with source map + idempotent wrapper cache + dispatcher re-materialization + HMR rename. Rewrites tests for #586. Ships alone and green.
+2. **feat(spa): reactive host runtime in SettingsContextFor<'host'>** — add `runtime` to host ctx, plumb through HostPage + HostSidebar + pickSelectableSubPage. Rewrites / adds tests for #588. Ships alone and green.
+
+Optional commit 0 (docs): add spec file. Kept alongside merge.
+
+Post-merge: bump PR to alpha.207 from separate worktree (CLAUDE.md dev process §9). Update `project_progress.md`, `kickoff_host_module_settings.md`, MEMORY index.
+
+---
+
+## 8. Risks & mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `SettingsContextFor<'host'>` breaking change surfaces in unseen callsite | Low | Medium | TypeScript compilation catches all sites; grep for `scope: 'host'` or `SettingsContextFor<'host'>` in plan §checklist |
+| HostPage re-render on every runtime tick degrades perf | Low | Low | Single-digit hosts; ticks are heartbeat-speed; matches HostSidebar subscription cost already paid today |
+| Component identity regression forces body remount | Med | Low | Unit test 1+4 explicitly assert wrapper identity across re-registers and re-dispatches |
+| Legacy adapter kept on old buffer pattern looks asymmetric | High | Low (it actually is asymmetric; intentional) | Note in PR body + issue #586 (or follow-up) captures "legacy adapter same fix, deferred"; adds strictly more risk to expand scope here |
+| `runtime: HostRuntime \| undefined` confuses callers expecting optional | Low | Low | Use `?` optional makes callers forget runtime — keeping required-undefined is a deliberate contract to force explicit handling. Documented in spec §5 |
+| Test rewrites miss an invariant the old pending-buffer captured | Med | Medium | Each rewritten test's behavioural property is explicitly listed in §6.1; pass/fail table in PR body cross-refs old vs new |
+
+---
+
+## 9. Out-of-scope / follow-ups
+
+- **#587** (parseRoute / isHostSubPage purity) — unchanged OPEN; revisit after PR-5 lands a real dynamic module-declared subPage.
+- **Legacy adapter same treatment** — the `_builtin.legacy-section` adapter still uses pending buffer + drain. Strictly symmetric fix applies, but no live callsite forces the issue today. Deferred; note in issue #586 after merge.
+- **`ModuleDefinition.settings` dynamic register API** — PR-5 will land the first real module-dynamic register path. If it chooses to call `dispatchSettingsContributions()` externally, the #586 fix in this PR directly protects it.
+
+---
+
+## 10. Acceptance checklist
+
+- [ ] #586: `dispatchSettingsContributions()` is idempotent (test 4 green)
+- [ ] #586: HMR reset + dispatch → host built-ins gone (test 6 green)
+- [ ] #586: Component identity stable across re-dispatches (test 1+4 green)
+- [ ] #588: `SettingsContextFor<'host'>` has `runtime: HostRuntime | undefined`
+- [ ] #588: `HostPage` subscribes `runtime` and re-resolves on ticks (test 7+8 green)
+- [ ] #588: `HostSidebar` passes runtime in ctx (test 10 green)
+- [ ] All existing tests green (`pnpm exec vitest run`)
+- [ ] Lint green (`pnpm run lint`)
+- [ ] Build green (`pnpm run build`)
+- [ ] No changes to `host-routes.ts` (#587 deferred)
+- [ ] No changes to legacy-section adapter
+- [ ] PR body includes the two-issue cluster summary + codex review round digest

--- a/spa/src/components/HostPage.test.tsx
+++ b/spa/src/components/HostPage.test.tsx
@@ -63,12 +63,13 @@ vi.mock('./hosts/AddHostDialog', () => ({
   AddHostDialog: (props: { onClose: () => void }) => <div data-testid="add-host-dialog" onClick={props.onClose} />,
 }))
 
+import React from 'react'
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { Router } from 'wouter'
 import { memoryLocation } from 'wouter/memory-location'
-import { HostPage, resetLastHostSelection } from './HostPage'
-import { useHostStore } from '../stores/useHostStore'
+import { HostPage, pickHostIdFallback, resetLastHostSelection } from './HostPage'
+import { useHostStore, type HostRuntime } from '../stores/useHostStore'
 import {
   clearContributions,
   listContributions,
@@ -548,5 +549,292 @@ describe('HostPage (registry-driven, §3.1)', () => {
     // URL settles on overview (or the first selectable in the canonicalized path)
     const lastPath = currentPath(mem)
     expect(lastPath).toBe('/hosts/hA/overview')
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// #588 — reactive host runtime in SettingsContextFor<'host'>
+// Spec §6.2 tests 7–12 + plan §4 test 14 (pickHostIdFallback equivalence).
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#588 — reactive host runtime', () => {
+  // Re-seed with HOST_A as the single host so URL paths /hosts/${HOST_A}/...
+  // resolve cleanly (outer seedHosts() seeds 'test-host' + 'second-host').
+  // For tests that need a second host (Test 10: background tick on SECOND_HOST_ID),
+  // set up explicitly inside the test.
+  beforeEach(() => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+        [SECOND_HOST_ID]: { id: SECOND_HOST_ID, name: 'Second Host', ip: '5.6.7.8', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_A, SECOND_HOST_ID],
+      activeHostId: HOST_A,
+      runtime: {},
+    })
+  })
+
+  function setHostRuntime(hostId: string, runtime: HostRuntime | undefined) {
+    act(() => {
+      useHostStore.setState((state) => {
+        const next = { ...state.runtime }
+        if (runtime === undefined) delete next[hostId]
+        else next[hostId] = runtime
+        return { runtime: next }
+      })
+    })
+  }
+
+  // Test 7 — runtime tick that flips disabled(ctx) drops the body and redirects.
+  it('Test 7 — runtime tick that flips disabled(ctx) drops body and redirects', () => {
+    const FeatureBody = () => <div data-testid="feature-x-body">FX</div>
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.feature-x',
+      localId: 'feature-x',
+      scope: 'host',
+      order: 100,
+      labelKey: 'feature-x',
+      component: FeatureBody,
+      disabled: (ctx: SettingsContextFor<'host'>) => ctx.runtime?.status !== 'connected',
+    })
+
+    setHostRuntime(HOST_A, { status: 'connected' })
+
+    const { mem, rerender } = renderHostPage(`/hosts/${HOST_A}/feature-x`)
+    expect(screen.getByTestId('feature-x-body')).toBeInTheDocument()
+    expect(currentPath(mem)).toBe(`/hosts/${HOST_A}/feature-x`)
+
+    // Flip runtime → disabled becomes true → body unmounts + URL canonicalizes away.
+    setHostRuntime(HOST_A, { status: 'disconnected' })
+    rerender(
+      <Router hook={mem.hook}>
+        <HostPage pane={hostPane} isActive />
+      </Router>,
+    )
+
+    expect(screen.queryByTestId('feature-x-body')).not.toBeInTheDocument()
+    expect(currentPath(mem)).toBe(`/hosts/${HOST_A}/overview`)
+  })
+
+  // Test 8 — runtime tick that flips disabled(ctx) re-enables the body cleanly.
+  it('Test 8 — runtime tick re-enables a previously disabled contribution', () => {
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.feature-y',
+      localId: 'feature-y',
+      scope: 'host',
+      order: 100,
+      labelKey: 'feature-y',
+      component: () => <div data-testid="feature-y-body">FY</div>,
+      disabled: (ctx: SettingsContextFor<'host'>) => ctx.runtime?.status !== 'connected',
+    })
+
+    // Initially disconnected → URL points at feature-y but disabled → redirects to overview.
+    setHostRuntime(HOST_A, { status: 'disconnected' })
+    const { mem, rerender } = renderHostPage(`/hosts/${HOST_A}/feature-y`)
+    expect(screen.queryByTestId('feature-y-body')).not.toBeInTheDocument()
+    expect(currentPath(mem)).toBe(`/hosts/${HOST_A}/overview`)
+
+    // Flip to connected — the user can now navigate to feature-y and body mounts.
+    setHostRuntime(HOST_A, { status: 'connected' })
+    act(() => { mem.navigate(`/hosts/${HOST_A}/feature-y`) })
+    rerender(
+      <Router hook={mem.hook}>
+        <HostPage pane={hostPane} isActive />
+      </Router>,
+    )
+
+    expect(screen.getByTestId('feature-y-body')).toBeInTheDocument()
+    expect(currentPath(mem)).toBe(`/hosts/${HOST_A}/feature-y`)
+  })
+
+  // Test 9 — pickSelectableSubPage uses runtime: directly observe behaviour through
+  // the rendered selection (no helper export required).
+  it('Test 9 — disabled contribution NOT chosen as fallback when runtime makes it disabled', () => {
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.runtime-gate',
+      localId: 'runtime-gate',
+      scope: 'host',
+      order: 0,  // would be FIRST if not gated
+      labelKey: 'runtime-gate',
+      component: () => <div data-testid="rg-body">RG</div>,
+      disabled: (ctx: SettingsContextFor<'host'>) => ctx.runtime === undefined,
+    })
+
+    // No runtime tick yet → runtime-gate disabled → bare /hosts must NOT pick runtime-gate.
+    setHostRuntime(HOST_A, undefined)
+    const { mem } = renderHostPage('/hosts')
+    expect(screen.queryByTestId('rg-body')).not.toBeInTheDocument()
+    // Falls through to first selectable (overview is order=0 but registered later;
+    // runtime-gate at order=0 should beat overview but is disabled, so overview wins).
+    expect(currentPath(mem)).toBe(`/hosts/${HOST_A}/overview`)
+  })
+
+  // Test 10 — background host tick does NOT re-render HostPage (selective subscription).
+  // Uses React.Profiler to count actual reconciliation work in the HostPage subtree —
+  // probe-wrapper-only counters don't capture re-renders triggered by HostPage's
+  // own internal store subscriptions (parent doesn't re-execute).
+  it('Test 10 — background host runtime tick does NOT re-render HostPage', () => {
+    const onRender = vi.fn()
+
+    setHostRuntime(HOST_A, { status: 'connected' })
+    const mem = memoryLocation({ path: `/hosts/${HOST_A}/overview`, record: true })
+    render(
+      <Router hook={mem.hook}>
+        <React.Profiler id="hostpage-test10" onRender={onRender}>
+          <HostPage pane={hostPane} isActive />
+        </React.Profiler>
+      </Router>,
+    )
+    const baseline = onRender.mock.calls.length
+    expect(baseline).toBeGreaterThan(0)
+
+    // Mutate runtime for the OTHER host (background tick) — selective
+    // subscription returns the same runtime[hA] reference; shallow compare
+    // skips a re-render.
+    setHostRuntime(SECOND_HOST_ID, { status: 'reconnecting' })
+    expect(onRender.mock.calls.length).toBe(baseline)
+
+    // Sanity: tick the SELECTED host's runtime — re-render expected.
+    setHostRuntime(HOST_A, { status: 'reconnecting' })
+    expect(onRender.mock.calls.length).toBeGreaterThan(baseline)
+  })
+
+  // Test 11 — rapid runtime flicker is stable (idempotent resolve under successive ticks).
+  // Once the URL has been canonicalized away from a disabled sub-page during
+  // the disconnected window, re-enabling the runtime does NOT auto-restore
+  // the original sub-page (that's a real navigation, not a state reversal).
+  // The crucial invariant is convergence — no infinite redirect loop, no
+  // unbounded history growth.
+  it('Test 11 — rapid runtime flicker converges without thrash', () => {
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.feature-flick',
+      localId: 'feature-flick',
+      scope: 'host',
+      order: 100,
+      labelKey: 'feature-flick',
+      component: () => <div data-testid="flick-body">FLICK</div>,
+      disabled: (ctx: SettingsContextFor<'host'>) => ctx.runtime?.status !== 'connected',
+    })
+
+    setHostRuntime(HOST_A, { status: 'connected' })
+    const { mem, rerender } = renderHostPage(`/hosts/${HOST_A}/feature-flick`)
+    expect(screen.getByTestId('flick-body')).toBeInTheDocument()
+    const initialHistoryLen = mem.history.length
+
+    // Three sync ticks: connected → disconnected → connected.
+    setHostRuntime(HOST_A, { status: 'disconnected' })
+    setHostRuntime(HOST_A, { status: 'connected' })
+    rerender(
+      <Router hook={mem.hook}>
+        <HostPage pane={hostPane} isActive />
+      </Router>,
+    )
+
+    // Convergence: history grew by a small bounded number (canonical redirect
+    // away from disabled feature-flick + maybe one settle), nowhere near a loop.
+    expect(mem.history.length - initialHistoryLen).toBeLessThan(5)
+
+    // After re-connecting, the user CAN navigate back to feature-flick and
+    // the body now mounts (proves the contribution is enabled again).
+    act(() => { mem.navigate(`/hosts/${HOST_A}/feature-flick`) })
+    rerender(
+      <Router hook={mem.hook}>
+        <HostPage pane={hostPane} isActive />
+      </Router>,
+    )
+    expect(screen.getByTestId('flick-body')).toBeInTheDocument()
+  })
+
+  // Test 12 — unmount during tick has no observable side effects (deterministic
+  // subscription-leak probe per codex R1 P2-1: no console warning spy).
+  it('Test 12 — runtime tick AFTER unmount does not throw and store stays healthy', () => {
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.umt',
+      localId: 'umt',
+      scope: 'host',
+      order: 100,
+      labelKey: 'umt',
+      component: () => <div data-testid="umt-body">UMT</div>,
+      disabled: (ctx: SettingsContextFor<'host'>) => ctx.runtime?.status !== 'connected',
+    })
+
+    setHostRuntime(HOST_A, { status: 'connected' })
+    const { unmount } = renderHostPage(`/hosts/${HOST_A}/umt`)
+    expect(screen.getByTestId('umt-body')).toBeInTheDocument()
+
+    // Independent probe subscriber — survives the unmount and proves the store
+    // still dispatches updates afterwards.
+    let probeTicks = 0
+    const unsubProbe = useHostStore.subscribe(() => { probeTicks++ })
+
+    unmount()
+    cleanup()
+
+    // No exception expected from a tick after unmount.
+    expect(() => setHostRuntime(HOST_A, { status: 'reconnecting' })).not.toThrow()
+    expect(probeTicks).toBeGreaterThanOrEqual(1)
+
+    unsubProbe()
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Test 14 — pickHostIdFallback equivalence (plan §4 row 14 / codex R1 P2-3).
+// Asserts the shared helper covers the fallback semantics used by both the
+// pre-resolve pass and resolveSelection's getFallbackSelection.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('Test 14 — pickHostIdFallback (shared helper)', () => {
+  it('returns null when hostOrder is empty', () => {
+    expect(pickHostIdFallback([], null, null)).toBeNull()
+    expect(pickHostIdFallback([], 'anything', { hostId: 'anything' })).toBeNull()
+  })
+
+  it('prefers lastSel.hostId when present in hostOrder', () => {
+    expect(pickHostIdFallback(['a', 'b'], null, { hostId: 'b' })).toBe('b')
+    expect(pickHostIdFallback(['a', 'b'], 'a', { hostId: 'b' })).toBe('b')
+  })
+
+  it('skips lastSel.hostId when not in hostOrder, falls to activeHostId', () => {
+    expect(pickHostIdFallback(['a', 'b'], 'a', { hostId: 'stale' })).toBe('a')
+  })
+
+  it('falls back to hostOrder[0] when neither lastSel nor activeHostId are valid', () => {
+    expect(pickHostIdFallback(['a', 'b'], null, null)).toBe('a')
+    expect(pickHostIdFallback(['a', 'b'], 'stale', { hostId: 'stale' })).toBe('a')
+  })
+
+  it('treats activeHostId=null as no preference', () => {
+    expect(pickHostIdFallback(['a'], null, null)).toBe('a')
+  })
+
+  // Equivalence: the inline fallback path inside resolveSelection used the same
+  // ordering — capture key cases via the public renderHostPage so any drift
+  // would surface here instead of silently diverging.
+  it('renders the same hostId as preResolveHostId when no URL host is provided (smoke)', () => {
+    useHostStore.setState({
+      hosts: {
+        a: { id: 'a', name: 'A', ip: '1.1.1.1', port: 7860, order: 0 },
+        b: { id: 'b', name: 'B', ip: '2.2.2.2', port: 7860, order: 1 },
+      },
+      hostOrder: ['a', 'b'],
+      activeHostId: 'b',
+      runtime: {},
+    })
+
+    // No URL hostId → activeHostId='b' → preResolveHostId picks 'b' → resolveSelection
+    // also picks 'b' (lastSelection cleared by beforeEach).
+    const mem = memoryLocation({ path: '/hosts', record: true })
+    render(
+      <Router hook={mem.hook}>
+        <HostPage pane={hostPane} isActive />
+      </Router>,
+    )
+    expect(screen.getByTestId('host-sidebar')).toHaveAttribute('data-host', 'b')
   })
 })

--- a/spa/src/components/HostPage.test.tsx
+++ b/spa/src/components/HostPage.test.tsx
@@ -816,6 +816,63 @@ describe('Test 14 — pickHostIdFallback (shared helper)', () => {
   // Equivalence: the inline fallback path inside resolveSelection used the same
   // ordering — capture key cases via the public renderHostPage so any drift
   // would surface here instead of silently diverging.
+  // R1 standard P2 — hidden HostPage (isActive=false) does not subscribe to
+  // runtime, so background heartbeat ticks do not re-render the inactive pane.
+  it('R1 P2 regression — inactive HostPage does NOT re-render on runtime tick', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+      },
+      hostOrder: [HOST_A],
+      activeHostId: HOST_A,
+      runtime: {},
+    })
+
+    const onRender = vi.fn()
+    const mem = memoryLocation({ path: `/hosts/${HOST_A}/overview`, record: true })
+    render(
+      <Router hook={mem.hook}>
+        <React.Profiler id="hostpage-inactive" onRender={onRender}>
+          <HostPage pane={hostPane} isActive={false} />
+        </React.Profiler>
+      </Router>,
+    )
+    const baseline = onRender.mock.calls.length
+
+    // Tick the SELECTED host's runtime — inactive HostPage's selector returns
+    // undefined regardless, so no re-render.
+    act(() => {
+      useHostStore.setState((state) => ({
+        runtime: { ...state.runtime, [HOST_A]: { status: 'reconnecting' } },
+      }))
+    })
+    expect(onRender.mock.calls.length).toBe(baseline)
+  })
+
+  // R1 standard P2 — inactive HostPage does NOT race the active one to push
+  // canonical-path redirects.
+  it('R1 P2 regression — inactive HostPage does NOT navigate on canonicalPath', () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
+      },
+      hostOrder: [HOST_A],
+      activeHostId: HOST_A,
+      runtime: {},
+    })
+
+    // URL points at a sub-page that the active resolve would canonicalize away.
+    const mem = memoryLocation({ path: `/hosts/${HOST_A}/nonexistent`, record: true })
+    const before = mem.history.length
+    render(
+      <Router hook={mem.hook}>
+        <HostPage pane={hostPane} isActive={false} />
+      </Router>,
+    )
+    // Inactive — no redirect performed.
+    expect(mem.history.length).toBe(before)
+  })
+
   it('renders the same hostId as preResolveHostId when no URL host is provided (smoke)', () => {
     useHostStore.setState({
       hosts: {

--- a/spa/src/components/HostPage.test.tsx
+++ b/spa/src/components/HostPage.test.tsx
@@ -816,37 +816,67 @@ describe('Test 14 — pickHostIdFallback (shared helper)', () => {
   // Equivalence: the inline fallback path inside resolveSelection used the same
   // ordering — capture key cases via the public renderHostPage so any drift
   // would surface here instead of silently diverging.
-  // R1 standard P2 — hidden HostPage (isActive=false) does not subscribe to
-  // runtime, so background heartbeat ticks do not re-render the inactive pane.
-  it('R1 P2 regression — inactive HostPage does NOT re-render on runtime tick', () => {
+  // R3 attacker P1 — inactive HostPage does NOT write back to module-scoped
+  // lastSelection.  When two HostPage instances coexist (one active, one
+  // hidden via TabContent visibility:hidden) the inactive one runs the same
+  // selection pipeline with fabricated runtime=undefined and would otherwise
+  // push a fallback selection (overview) into lastSelection, polluting the
+  // active instance's next resolve.
+  it('R3 P1 regression — inactive HostPage does NOT pollute lastSelection (dual-instance)', () => {
     useHostStore.setState({
       hosts: {
         [HOST_A]: { id: HOST_A, name: 'Host A', ip: '1.2.3.4', port: 7860, order: 0 },
       },
       hostOrder: [HOST_A],
       activeHostId: HOST_A,
-      runtime: {},
+      runtime: { [HOST_A]: { status: 'connected' } },
     })
 
-    const onRender = vi.fn()
-    const mem = memoryLocation({ path: `/hosts/${HOST_A}/overview`, record: true })
-    render(
-      <Router hook={mem.hook}>
-        <React.Profiler id="hostpage-inactive" onRender={onRender}>
-          <HostPage pane={hostPane} isActive={false} />
-        </React.Profiler>
+    // Register a runtime-gated contribution that the active instance is on.
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.gated',
+      localId: 'gated',
+      scope: 'host',
+      order: 100,
+      labelKey: 'gated',
+      component: () => <div data-testid="gated-body">GATED</div>,
+      disabled: (ctx) => ctx.runtime?.status !== 'connected',
+    })
+
+    // Mount the ACTIVE instance on /hosts/hA/gated — body mounts, lastSelection
+    // gets {hA, gated}.
+    const memActive = memoryLocation({ path: `/hosts/${HOST_A}/gated`, record: true })
+    const active = render(
+      <Router hook={memActive.hook}>
+        <HostPage pane={hostPane} isActive />
       </Router>,
     )
-    const baseline = onRender.mock.calls.length
+    expect(screen.getByTestId('gated-body')).toBeInTheDocument()
+    active.unmount()
 
-    // Tick the SELECTED host's runtime — inactive HostPage's selector returns
-    // undefined regardless, so no re-render.
-    act(() => {
-      useHostStore.setState((state) => ({
-        runtime: { ...state.runtime, [HOST_A]: { status: 'reconnecting' } },
-      }))
-    })
-    expect(onRender.mock.calls.length).toBe(baseline)
+    // Now mount a HIDDEN HostPage — it sees runtime=undefined (gate),
+    // resolves to fallback (overview).  Its useEffect MUST NOT write
+    // lastSelection back to overview.
+    const memHidden = memoryLocation({ path: `/hosts/${HOST_A}/gated`, record: true })
+    const hidden = render(
+      <Router hook={memHidden.hook}>
+        <HostPage pane={hostPane} isActive={false} />
+      </Router>,
+    )
+    hidden.unmount()
+
+    // Re-mount an active instance on bare /hosts — lastSelection should
+    // still point at 'gated' (set by the first active mount), NOT 'overview'
+    // (which the hidden instance would have written without the gate).
+    const memActive2 = memoryLocation({ path: '/hosts', record: true })
+    render(
+      <Router hook={memActive2.hook}>
+        <HostPage pane={hostPane} isActive />
+      </Router>,
+    )
+    // gated body re-mounts because lastSelection is preserved.
+    expect(screen.getByTestId('gated-body')).toBeInTheDocument()
   })
 
   // R1 standard P2 — inactive HostPage does NOT race the active one to push

--- a/spa/src/components/HostPage.tsx
+++ b/spa/src/components/HostPage.tsx
@@ -121,21 +121,25 @@ function pickSelectableSubPage(
 }
 
 /**
- * `tentativeHostId` and `tentativeRuntime` are the result of the pre-resolve
- * pass + selective subscription.  This second pass picks the final hostId and
- * sub-page using the same shared fallback helper for consistency.
+ * Builds a sub-page selection for a fallback hostId derived from the
+ * render-local snapshot of `lastSelection`.  Both `lastSel` and
+ * `tentativeRuntime` come from the caller so this function never reads
+ * the module-scoped `lastSelection` directly — that's the R2 attacker A2
+ * fix: a single render must use one consistent snapshot to avoid
+ * cross-instance contamination from concurrent HostPage renders.
  */
 function getFallbackSelection(
   hostOrder: string[],
   activeHostId: string | null,
+  lastSel: Selection | null,
   tentativeRuntime: HostRuntime | undefined,
 ): Selection | null {
-  const hostId = pickHostIdFallback(hostOrder, activeHostId, lastSelection)
+  const hostId = pickHostIdFallback(hostOrder, activeHostId, lastSel)
   if (!hostId) return null
 
   return {
     hostId,
-    subPage: pickSelectableSubPage(hostId, lastSelection?.subPage, tentativeRuntime),
+    subPage: pickSelectableSubPage(hostId, lastSel?.subPage, tentativeRuntime),
   }
 }
 
@@ -143,7 +147,9 @@ function resolveSelection(
   location: string,
   hostOrder: string[],
   activeHostId: string | null,
+  tentativeHostId: string | null,
   tentativeRuntime: HostRuntime | undefined,
+  lastSel: Selection | null,
 ) {
   const parsed = parseRoute(location)
   const isHostRoute = parsed?.kind === 'hosts' || parsed?.kind === 'hosts-invalid'
@@ -156,7 +162,7 @@ function resolveSelection(
     }
   }
 
-  const fallbackSelection = getFallbackSelection(hostOrder, activeHostId, tentativeRuntime)
+  const fallbackSelection = getFallbackSelection(hostOrder, activeHostId, lastSel, tentativeRuntime)
   if (!fallbackSelection) {
     return {
       selection: null,
@@ -165,18 +171,20 @@ function resolveSelection(
     }
   }
 
-  // The runtime we use to evaluate sub-page disabled() predicates is the
-  // tentative-host runtime — the final selected hostId equals tentativeHostId
-  // when the URL/lastSelection is valid; if we fall back to a different host
-  // (rare: tentativeHostId not in hostOrder) the fallback ctx will be evaluated
-  // against tentativeRuntime, which is acceptable since selection rarely
-  // changes mid-resolve.
-  const evalRuntime = tentativeRuntime
+  // R2 attacker A2 — `tentativeRuntime` is the runtime *of the tentative
+  // hostId only*.  When the final resolvedHostId differs from tentativeHostId
+  // (e.g. URL hostId not in hostOrder, or fallback paths), evaluating
+  // `disabled(ctx)` with the wrong host's runtime would mis-select sub-pages.
+  // Be conservative: pass undefined runtime to pickSelectableSubPage in that
+  // case, so disabled() predicates that gate on runtime fall through to the
+  // "no info yet" branch instead of using stale data from another host.
+  const evalRuntimeFor = (hostId: string): HostRuntime | undefined =>
+    hostId === tentativeHostId ? tentativeRuntime : undefined
 
   if (parsed?.kind === 'hosts') {
     if (parsed.hostId && parsed.subPage) {
       const resolvedHostId = hostOrder.includes(parsed.hostId) ? parsed.hostId : fallbackSelection.hostId
-      const resolvedSubPage = pickSelectableSubPage(resolvedHostId, parsed.subPage, evalRuntime)
+      const resolvedSubPage = pickSelectableSubPage(resolvedHostId, parsed.subPage, evalRuntimeFor(resolvedHostId))
       const needsHostRedirect = resolvedHostId !== parsed.hostId
       const needsSubPageRedirect = resolvedSubPage !== parsed.subPage
       const needsRedirect = needsHostRedirect || needsSubPageRedirect
@@ -196,9 +204,9 @@ function resolveSelection(
       }
     }
 
-    if (lastSelection) {
-      const hostId = hostOrder.includes(lastSelection.hostId) ? lastSelection.hostId : fallbackSelection.hostId
-      const subPage = pickSelectableSubPage(hostId, lastSelection.subPage, evalRuntime)
+    if (lastSel) {
+      const hostId = hostOrder.includes(lastSel.hostId) ? lastSel.hostId : fallbackSelection.hostId
+      const subPage = pickSelectableSubPage(hostId, lastSel.subPage, evalRuntimeFor(hostId))
       const selection = { hostId, subPage }
       return { selection, canonicalPath: buildHostPath(selection), shouldPersistSelection: true }
     }
@@ -215,7 +223,7 @@ function resolveSelection(
     const rawSubPage = parsed.subPage && isHostSubPage(parsed.subPage) ? parsed.subPage : null
     const selection = {
       hostId,
-      subPage: pickSelectableSubPage(hostId, rawSubPage, evalRuntime),
+      subPage: pickSelectableSubPage(hostId, rawSubPage, evalRuntimeFor(hostId)),
     }
 
     return {
@@ -225,10 +233,10 @@ function resolveSelection(
     }
   }
 
-  // Non-host route: keep lastSelection if available, clamped to live registry.
-  if (lastSelection) {
-    const hostId = hostOrder.includes(lastSelection.hostId) ? lastSelection.hostId : fallbackSelection.hostId
-    const subPage = pickSelectableSubPage(hostId, lastSelection.subPage, evalRuntime)
+  // Non-host route: keep lastSel if available, clamped to live registry.
+  if (lastSel) {
+    const hostId = hostOrder.includes(lastSel.hostId) ? lastSel.hostId : fallbackSelection.hostId
+    const subPage = pickSelectableSubPage(hostId, lastSel.subPage, evalRuntimeFor(hostId))
     return {
       selection: { hostId, subPage },
       canonicalPath: null as string | null,
@@ -250,30 +258,39 @@ export function resetLastHostSelection() {
 }
 
 
-export function HostPage(_props: PaneRendererProps) {
+export function HostPage({ isActive }: PaneRendererProps) {
   const [location, setLocation] = useLocation()
   const hostOrder = useHostStore((s) => s.hostOrder)
   const activeHostId = useHostStore((s) => s.activeHostId)
   const [showAddHost, setShowAddHost] = useState(false)
   const t = useI18nStore((s) => s.t)
 
+  // R2 attacker A2 fix — snapshot module-scoped lastSelection ONCE per render
+  // and pass it to every helper.  preResolveHostId, resolveSelection, and
+  // getFallbackSelection all consume this snapshot, so a render uses one
+  // consistent view even if a concurrent HostPage instance's effect mutates
+  // the module-scoped value mid-flight.
+  const lastSelSnapshot = lastSelection
+
   // Pass 1: pre-resolve a tentative hostId without observing runtime.
-  const tentativeHostId = preResolveHostId(location, hostOrder, activeHostId, lastSelection)
+  const tentativeHostId = preResolveHostId(location, hostOrder, activeHostId, lastSelSnapshot)
 
   // Pass 2: SELECTIVE runtime subscription — only the tentative host's
-  // runtime triggers re-renders.  Background host heartbeat ticks mutate
-  // `runtime[otherId]` but the selector returns the same `runtime[tentativeHostId]`
-  // reference, so zustand's shallow compare skips a re-render.
+  // runtime triggers re-renders.  R1 standard P2 fix — `isActive` gates
+  // the subscription so hidden HostPage instances (TabContent keeps
+  // non-active panes mounted with `visibility: hidden`) do not re-render
+  // on background-host heartbeat ticks.  Selector returns undefined when
+  // inactive; resolveSelection then evaluates with no runtime info, which
+  // is safe because the inactive page is not user-visible anyway.
   const tentativeRuntime = useHostStore((s) =>
-    tentativeHostId ? s.runtime[tentativeHostId] : undefined,
+    isActive && tentativeHostId ? s.runtime[tentativeHostId] : undefined,
   )
 
   // Pass 3: full resolve with runtime-aware ctx for disabled() predicates.
-  // tentativeHostId already drove the selective subscription above; resolveSelection
-  // re-derives the final hostId from URL/order/active and uses tentativeRuntime
-  // for ctx-aware sub-page selection.
+  // resolveSelection only assigns runtime to a host's ctx when the resolved
+  // hostId equals tentativeHostId, otherwise it passes undefined (R2 A2).
   const { selection, canonicalPath, shouldPersistSelection } = resolveSelection(
-    location, hostOrder, activeHostId, tentativeRuntime,
+    location, hostOrder, activeHostId, tentativeHostId, tentativeRuntime, lastSelSnapshot,
   )
 
   useEffect(() => {
@@ -281,10 +298,14 @@ export function HostPage(_props: PaneRendererProps) {
   }, [selection, shouldPersistSelection])
 
   useEffect(() => {
+    // R1 standard P2 fix — only the active HostPage may push canonical-path
+    // redirects.  Hidden instances must not race the active one to
+    // setLocation, which would otherwise navigate the user mid-interaction.
+    if (!isActive) return
     if (canonicalPath && canonicalPath !== location) {
       setLocation(canonicalPath, { replace: true })
     }
-  }, [canonicalPath, location, setLocation])
+  }, [isActive, canonicalPath, location, setLocation])
 
   const renderContent = () => {
     if (!selection?.hostId) {

--- a/spa/src/components/HostPage.tsx
+++ b/spa/src/components/HostPage.tsx
@@ -5,7 +5,7 @@ import { encodeHostRouteId, isHostSubPage, type HostSubPage } from '../lib/host-
 import { parseRoute } from '../lib/route-utils'
 import { listContributions } from '../lib/settings-contribution-registry'
 import type { SettingsContribution, SettingsContextFor } from '../lib/settings-contribution-types'
-import { useHostStore } from '../stores/useHostStore'
+import { useHostStore, type HostRuntime } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { HostSidebar } from './hosts/HostSidebar'
 import { AddHostDialog } from './hosts/AddHostDialog'
@@ -23,9 +23,61 @@ function buildHostPath({ hostId, subPage }: Selection) {
   return `/hosts/${encodeHostRouteId(hostId)}/${subPage}`
 }
 
-function getFallbackHostId(hostOrder: string[], activeHostId: string | null) {
+/**
+ * Single source of truth for host-id fallback ordering across both the
+ * runtime-independent pre-resolve path (`preResolveHostId`) and the
+ * full resolve path (`getFallbackSelection` / `resolveSelection`).
+ *
+ * Order:
+ *   1. lastSelection.hostId (if still in hostOrder)
+ *   2. activeHostId (if still in hostOrder)
+ *   3. hostOrder[0]
+ *
+ * Returning null only when hostOrder is empty.
+ *
+ * Extracting this helper guarantees both callsites agree on fallback
+ * semantics; equivalence regression covered by host-selection-utils tests.
+ *
+ * @internal
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function pickHostIdFallback(
+  hostOrder: string[],
+  activeHostId: string | null,
+  lastSel: { hostId: string } | null,
+): string | null {
+  if (hostOrder.length === 0) return null
+  if (lastSel?.hostId && hostOrder.includes(lastSel.hostId)) return lastSel.hostId
   if (activeHostId && hostOrder.includes(activeHostId)) return activeHostId
   return hostOrder[0] ?? null
+}
+
+/**
+ * Pure, runtime-independent first pass that picks the tentative hostId we
+ * are about to render.  Used to drive a SELECTIVE runtime subscription —
+ * only the runtime for this hostId is observed by HostPage, so background
+ * host heartbeat ticks do NOT trigger HostPage re-renders.
+ *
+ * Selection priority:
+ *   1. URL hostId (when /hosts/:id/... and :id is in hostOrder)
+ *   2. shared fallback (lastSel → activeHostId → hostOrder[0])
+ */
+function preResolveHostId(
+  location: string,
+  hostOrder: string[],
+  activeHostId: string | null,
+  lastSel: Selection | null,
+): string | null {
+  if (hostOrder.length === 0) return null
+  const parsed = parseRoute(location)
+  if (
+    (parsed?.kind === 'hosts' || parsed?.kind === 'hosts-invalid') &&
+    parsed.hostId &&
+    hostOrder.includes(parsed.hostId)
+  ) {
+    return parsed.hostId
+  }
+  return pickHostIdFallback(hostOrder, activeHostId, lastSel)
 }
 
 /**
@@ -41,20 +93,22 @@ function isSelectable(
 }
 
 /**
- * Given a target `hostId` and an optional `requestedSubPage`, return the best
- * selectable subPage:
+ * Given a target `hostId` + its `runtime` snapshot and an optional
+ * `requestedSubPage`, return the best selectable subPage.  ctx-aware
+ * via the runtime field so disabled(ctx) predicates can gate on runtime.
  *
  * 1. If `requestedSubPage` is provided, exists in the registry AND is
- *    selectable for `hostId` → return it as-is.
- * 2. Otherwise return the first contribution that is selectable for `hostId`.
- * 3. Ultimate safety net: return `'overview'` literal if the registry is empty
- *    or every contribution is disabled.
- *
- * Replaces `getFallbackSubPage()` — strict superset that also checks
- * `disabled(ctx)`.
+ *    selectable for `(hostId, runtime)` → return it as-is.
+ * 2. Otherwise return the first contribution that is selectable.
+ * 3. Ultimate safety net: return `'overview'` literal if the registry is
+ *    empty or every contribution is disabled.
  */
-function pickSelectableSubPage(hostId: string, requestedSubPage: string | null | undefined): HostSubPage {
-  const ctx: SettingsContextFor<'host'> = { scope: 'host', hostId }
+function pickSelectableSubPage(
+  hostId: string,
+  requestedSubPage: string | null | undefined,
+  runtime: HostRuntime | undefined,
+): HostSubPage {
+  const ctx: SettingsContextFor<'host'> = { scope: 'host', hostId, runtime }
   const contributions = listContributions('host') as SettingsContribution<'host'>[]
 
   if (requestedSubPage) {
@@ -66,17 +120,31 @@ function pickSelectableSubPage(hostId: string, requestedSubPage: string | null |
   return (first?.localId ?? 'overview') as HostSubPage
 }
 
-function getFallbackSelection(hostOrder: string[], activeHostId: string | null): Selection | null {
-  const hostId = getFallbackHostId(hostOrder, activeHostId)
+/**
+ * `tentativeHostId` and `tentativeRuntime` are the result of the pre-resolve
+ * pass + selective subscription.  This second pass picks the final hostId and
+ * sub-page using the same shared fallback helper for consistency.
+ */
+function getFallbackSelection(
+  hostOrder: string[],
+  activeHostId: string | null,
+  tentativeRuntime: HostRuntime | undefined,
+): Selection | null {
+  const hostId = pickHostIdFallback(hostOrder, activeHostId, lastSelection)
   if (!hostId) return null
 
   return {
     hostId,
-    subPage: pickSelectableSubPage(hostId, lastSelection?.subPage),
+    subPage: pickSelectableSubPage(hostId, lastSelection?.subPage, tentativeRuntime),
   }
 }
 
-function resolveSelection(location: string, hostOrder: string[], activeHostId: string | null) {
+function resolveSelection(
+  location: string,
+  hostOrder: string[],
+  activeHostId: string | null,
+  tentativeRuntime: HostRuntime | undefined,
+) {
   const parsed = parseRoute(location)
   const isHostRoute = parsed?.kind === 'hosts' || parsed?.kind === 'hosts-invalid'
 
@@ -88,7 +156,7 @@ function resolveSelection(location: string, hostOrder: string[], activeHostId: s
     }
   }
 
-  const fallbackSelection = getFallbackSelection(hostOrder, activeHostId)
+  const fallbackSelection = getFallbackSelection(hostOrder, activeHostId, tentativeRuntime)
   if (!fallbackSelection) {
     return {
       selection: null,
@@ -97,10 +165,18 @@ function resolveSelection(location: string, hostOrder: string[], activeHostId: s
     }
   }
 
+  // The runtime we use to evaluate sub-page disabled() predicates is the
+  // tentative-host runtime — the final selected hostId equals tentativeHostId
+  // when the URL/lastSelection is valid; if we fall back to a different host
+  // (rare: tentativeHostId not in hostOrder) the fallback ctx will be evaluated
+  // against tentativeRuntime, which is acceptable since selection rarely
+  // changes mid-resolve.
+  const evalRuntime = tentativeRuntime
+
   if (parsed?.kind === 'hosts') {
     if (parsed.hostId && parsed.subPage) {
       const resolvedHostId = hostOrder.includes(parsed.hostId) ? parsed.hostId : fallbackSelection.hostId
-      const resolvedSubPage = pickSelectableSubPage(resolvedHostId, parsed.subPage)
+      const resolvedSubPage = pickSelectableSubPage(resolvedHostId, parsed.subPage, evalRuntime)
       const needsHostRedirect = resolvedHostId !== parsed.hostId
       const needsSubPageRedirect = resolvedSubPage !== parsed.subPage
       const needsRedirect = needsHostRedirect || needsSubPageRedirect
@@ -122,7 +198,7 @@ function resolveSelection(location: string, hostOrder: string[], activeHostId: s
 
     if (lastSelection) {
       const hostId = hostOrder.includes(lastSelection.hostId) ? lastSelection.hostId : fallbackSelection.hostId
-      const subPage = pickSelectableSubPage(hostId, lastSelection.subPage)
+      const subPage = pickSelectableSubPage(hostId, lastSelection.subPage, evalRuntime)
       const selection = { hostId, subPage }
       return { selection, canonicalPath: buildHostPath(selection), shouldPersistSelection: true }
     }
@@ -139,7 +215,7 @@ function resolveSelection(location: string, hostOrder: string[], activeHostId: s
     const rawSubPage = parsed.subPage && isHostSubPage(parsed.subPage) ? parsed.subPage : null
     const selection = {
       hostId,
-      subPage: pickSelectableSubPage(hostId, rawSubPage),
+      subPage: pickSelectableSubPage(hostId, rawSubPage, evalRuntime),
     }
 
     return {
@@ -152,7 +228,7 @@ function resolveSelection(location: string, hostOrder: string[], activeHostId: s
   // Non-host route: keep lastSelection if available, clamped to live registry.
   if (lastSelection) {
     const hostId = hostOrder.includes(lastSelection.hostId) ? lastSelection.hostId : fallbackSelection.hostId
-    const subPage = pickSelectableSubPage(hostId, lastSelection.subPage)
+    const subPage = pickSelectableSubPage(hostId, lastSelection.subPage, evalRuntime)
     return {
       selection: { hostId, subPage },
       canonicalPath: null as string | null,
@@ -173,14 +249,32 @@ export function resetLastHostSelection() {
   lastSelection = null
 }
 
- 
+
 export function HostPage(_props: PaneRendererProps) {
   const [location, setLocation] = useLocation()
   const hostOrder = useHostStore((s) => s.hostOrder)
   const activeHostId = useHostStore((s) => s.activeHostId)
   const [showAddHost, setShowAddHost] = useState(false)
   const t = useI18nStore((s) => s.t)
-  const { selection, canonicalPath, shouldPersistSelection } = resolveSelection(location, hostOrder, activeHostId)
+
+  // Pass 1: pre-resolve a tentative hostId without observing runtime.
+  const tentativeHostId = preResolveHostId(location, hostOrder, activeHostId, lastSelection)
+
+  // Pass 2: SELECTIVE runtime subscription — only the tentative host's
+  // runtime triggers re-renders.  Background host heartbeat ticks mutate
+  // `runtime[otherId]` but the selector returns the same `runtime[tentativeHostId]`
+  // reference, so zustand's shallow compare skips a re-render.
+  const tentativeRuntime = useHostStore((s) =>
+    tentativeHostId ? s.runtime[tentativeHostId] : undefined,
+  )
+
+  // Pass 3: full resolve with runtime-aware ctx for disabled() predicates.
+  // tentativeHostId already drove the selective subscription above; resolveSelection
+  // re-derives the final hostId from URL/order/active and uses tentativeRuntime
+  // for ctx-aware sub-page selection.
+  const { selection, canonicalPath, shouldPersistSelection } = resolveSelection(
+    location, hostOrder, activeHostId, tentativeRuntime,
+  )
 
   useEffect(() => {
     if (shouldPersistSelection && selection) lastSelection = selection
@@ -204,7 +298,7 @@ export function HostPage(_props: PaneRendererProps) {
       // Return null here; the canonicalPath effect will navigate away.
       return null
     }
-    const ctx: SettingsContextFor<'host'> = { scope: 'host', hostId }
+    const ctx: SettingsContextFor<'host'> = { scope: 'host', hostId, runtime: tentativeRuntime }
     // F7 + A.1: disabled contributions must not mount their body component.
     // `isSelectable` is the single predicate; resolveSelection already redirected
     // away, so this is a last-resort guard.
@@ -222,7 +316,7 @@ export function HostPage(_props: PaneRendererProps) {
   // switch.
   const sidebarHostId = selection?.hostId ?? lastSelection?.hostId ?? ''
   const sidebarSubPage = sidebarHostId
-    ? pickSelectableSubPage(sidebarHostId, selection?.subPage ?? lastSelection?.subPage)
+    ? pickSelectableSubPage(sidebarHostId, selection?.subPage ?? lastSelection?.subPage, tentativeRuntime)
     : (listContributions('host')[0]?.localId ?? 'overview') as HostSubPage
 
   return (

--- a/spa/src/components/HostPage.tsx
+++ b/spa/src/components/HostPage.tsx
@@ -276,14 +276,25 @@ export function HostPage({ isActive }: PaneRendererProps) {
   const tentativeHostId = preResolveHostId(location, hostOrder, activeHostId, lastSelSnapshot)
 
   // Pass 2: SELECTIVE runtime subscription — only the tentative host's
-  // runtime triggers re-renders.  R1 standard P2 fix — `isActive` gates
-  // the subscription so hidden HostPage instances (TabContent keeps
-  // non-active panes mounted with `visibility: hidden`) do not re-render
-  // on background-host heartbeat ticks.  Selector returns undefined when
-  // inactive; resolveSelection then evaluates with no runtime info, which
-  // is safe because the inactive page is not user-visible anyway.
+  // runtime triggers re-renders.  Background-host heartbeat ticks mutate
+  // `runtime[otherId]` but the selector returns the same
+  // `runtime[tentativeHostId]` reference, so zustand's shallow compare
+  // skips a re-render.
+  //
+  // R3 defender high #2 reversal — earlier `isActive` gate fabricated
+  // `runtime: undefined` for hidden HostPage instances, but TabContent
+  // keep-alive means hidden panes still render their bodies.  Forcing
+  // undefined runtime would mis-evaluate `disabled(ctx)` for runtime-
+  // gated contributions and either keep a should-be-disabled body
+  // mounted (when the predicate treats undefined as "not yet known")
+  // OR unmount a should-be-enabled body (when it treats undefined as
+  // disabled), violating PR-4's "disabled contribution body must not
+  // mount" contract in either direction.  Real runtime is the only safe
+  // input for hidden panes.  R1 standard P2's "hidden tabs re-render
+  // on tick" cost is acceptable: this selector already filters to the
+  // tentative host's runtime only, so background hosts don't trigger.
   const tentativeRuntime = useHostStore((s) =>
-    isActive && tentativeHostId ? s.runtime[tentativeHostId] : undefined,
+    tentativeHostId ? s.runtime[tentativeHostId] : undefined,
   )
 
   // Pass 3: full resolve with runtime-aware ctx for disabled() predicates.
@@ -294,8 +305,17 @@ export function HostPage({ isActive }: PaneRendererProps) {
   )
 
   useEffect(() => {
+    // R3 attacker P1 — only the active HostPage may write back to the module-
+    // scoped lastSelection.  Inactive instances run the same selection
+    // pipeline with a fabricated `runtime: undefined` (R1 P2 gate above), so
+    // their computed selection may be a fallback to overview that does not
+    // reflect the real user choice.  Without this gate, a hidden HostPage
+    // would overwrite lastSelection and pollute the active instance's next
+    // resolve — visible as the user's working sub-page collapsing to
+    // overview after switching tabs.
+    if (!isActive) return
     if (shouldPersistSelection && selection) lastSelection = selection
-  }, [selection, shouldPersistSelection])
+  }, [isActive, selection, shouldPersistSelection])
 
   useEffect(() => {
     // R1 standard P2 fix — only the active HostPage may push canonical-path

--- a/spa/src/components/hosts/HostSidebar.test.tsx
+++ b/spa/src/components/hosts/HostSidebar.test.tsx
@@ -248,4 +248,38 @@ describe('HostSidebar', () => {
     fireEvent.click(disabledButton)
     expect(defaultProps.onSelect).not.toHaveBeenCalled()
   })
+
+  // Test 13 (#588 spec §6.2 #13): sidebar passes runtime[hostId] in ctx so
+  // disabled(ctx) predicates can react to live host runtime.
+  it('Test 13: sidebar builds runtime-aware ctx — runtime tick flips disabled', () => {
+    const RuntimeGated = () => null
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.runtime-gated',
+      localId: 'runtime-gated',
+      scope: 'host',
+      order: 100,
+      labelKey: 'runtime-gated',
+      component: RuntimeGated,
+      // disabled when no runtime observed yet.
+      disabled: (ctx) => ctx.runtime === undefined,
+    })
+
+    // Initially no runtime[HOST_ID] — row disabled.
+    const { rerender } = render(<HostSidebar {...defaultProps} />)
+    expect(document.querySelectorAll('[data-disabled-ctx="true"]').length).toBeGreaterThan(0)
+
+    // Tick runtime — re-render sidebar; disabled row count drops by one.
+    useHostStore.setState((state) => ({
+      runtime: { ...state.runtime, [HOST_ID]: { status: 'connected' } },
+    }))
+    rerender(<HostSidebar {...defaultProps} />)
+    // The runtime-gated row no longer matches data-disabled-ctx="true".
+    const disabledNow = Array.from(
+      document.querySelectorAll('[data-disabled-ctx="true"]'),
+    ) as HTMLElement[]
+    for (const el of disabledNow) {
+      expect(el.textContent).not.toContain('runtime-gated')
+    }
+  })
 })

--- a/spa/src/components/hosts/HostSidebar.test.tsx
+++ b/spa/src/components/hosts/HostSidebar.test.tsx
@@ -177,7 +177,13 @@ describe('HostSidebar', () => {
     expect(sessionsButtons.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('preserves current subPage when expanding a collapsed host', () => {
+  it('expanding a different collapsed host picks first selectable sub-page for that host (R2 D2)', () => {
+    // R2 defender D2 fix — when expanding a different host we must NOT carry
+    // over the current host's selectedSubPage; that would briefly navigate
+    // into the new host's sub-page even when it is disabled for that host
+    // (visible blank-and-redirect under runtime-gated modules).  Instead
+    // pick the first selectable sub-page for the target host using its
+    // own runtime.
     useHostStore.setState({
       hosts: {
         [HOST_ID]: { id: HOST_ID, name: 'Test Host', ip: '1.2.3.4', port: 7860, order: 0 },
@@ -186,12 +192,24 @@ describe('HostSidebar', () => {
       hostOrder: [HOST_ID, HOST_B],
       runtime: {},
     })
-    // Current selectedSubPage is 'hooks'
+    // Current selectedSubPage is 'hooks' for HOST_ID; built-ins have no
+    // disabled() predicates, so the first selectable for HOST_B is 'overview'.
     render(<HostSidebar {...defaultProps} selectedSubPage="hooks" />)
 
-    // Click collapsed HOST_B — should call onSelect with 'hooks', not 'overview'
     fireEvent.click(screen.getByText('Second Host'))
-    expect(defaultProps.onSelect).toHaveBeenCalledWith(HOST_B, 'hooks')
+    expect(defaultProps.onSelect).toHaveBeenCalledWith(HOST_B, 'overview')
+  })
+
+  it('clicking the currently selected host preserves selectedSubPage (no per-target rewrite)', () => {
+    // When clicking the SAME host that is already selected, the existing
+    // selectedSubPage stays — D2 only kicks in for cross-host expansion.
+    render(<HostSidebar {...defaultProps} selectedSubPage="hooks" />)
+
+    fireEvent.click(screen.getByText('Test Host'))
+    // Same-host click while already expanded → no onSelect (collapse instead)
+    // — but the test setup leaves the host expanded so clicking it again
+    // collapses without calling onSelect.  Assert no spurious onSelect call.
+    expect(defaultProps.onSelect).not.toHaveBeenCalled()
   })
 
   it('auto-expands new selectedHostId on prop change (e.g. host deletion fallback)', () => {

--- a/spa/src/components/hosts/HostSidebar.test.tsx
+++ b/spa/src/components/hosts/HostSidebar.test.tsx
@@ -177,13 +177,11 @@ describe('HostSidebar', () => {
     expect(sessionsButtons.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('expanding a different collapsed host picks first selectable sub-page for that host (R2 D2)', () => {
-    // R2 defender D2 fix — when expanding a different host we must NOT carry
-    // over the current host's selectedSubPage; that would briefly navigate
-    // into the new host's sub-page even when it is disabled for that host
-    // (visible blank-and-redirect under runtime-gated modules).  Instead
-    // pick the first selectable sub-page for the target host using its
-    // own runtime.
+  it('expanding a different collapsed host preserves selectedSubPage when still selectable for target (R3 P1)', () => {
+    // R3 standard P1 — D2 was over-aggressive (always picked first selectable
+    // for target host).  Correct behaviour: preserve the user's current
+    // selectedSubPage when it is still selectable on the target host;
+    // only fallback to first-selectable when it would be disabled.
     useHostStore.setState({
       hosts: {
         [HOST_ID]: { id: HOST_ID, name: 'Test Host', ip: '1.2.3.4', port: 7860, order: 0 },
@@ -192,11 +190,43 @@ describe('HostSidebar', () => {
       hostOrder: [HOST_ID, HOST_B],
       runtime: {},
     })
-    // Current selectedSubPage is 'hooks' for HOST_ID; built-ins have no
-    // disabled() predicates, so the first selectable for HOST_B is 'overview'.
+    // No disabled predicates → 'hooks' is selectable for both hosts.
     render(<HostSidebar {...defaultProps} selectedSubPage="hooks" />)
 
     fireEvent.click(screen.getByText('Second Host'))
+    expect(defaultProps.onSelect).toHaveBeenCalledWith(HOST_B, 'hooks')
+  })
+
+  it('expanding a different collapsed host picks first selectable when current sub-page is disabled for target (R2 D2)', () => {
+    // R2 defender D2 fix path — when current selectedSubPage IS disabled for
+    // the target host, fall back to the target host's first selectable
+    // sub-page rather than navigating into a known-disabled URL.
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Test Host', ip: '1.2.3.4', port: 7860, order: 0 },
+        [HOST_B]: { id: HOST_B, name: 'Second Host', ip: '5.6.7.8', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, HOST_B],
+      runtime: { [HOST_ID]: { status: 'connected' } },
+    })
+
+    // Register a contribution that is disabled when runtime is undefined
+    // (i.e. for HOST_B which has no runtime yet).  selectedSubPage points at it.
+    registerSettingsContribution({
+      moduleId: 'fakemod',
+      id: 'fakemod.gated',
+      localId: 'gated',
+      scope: 'host',
+      order: 100,
+      labelKey: 'gated',
+      component: () => null,
+      disabled: (ctx) => ctx.runtime === undefined,
+    })
+
+    render(<HostSidebar {...defaultProps} selectedSubPage="gated" />)
+
+    fireEvent.click(screen.getByText('Second Host'))
+    // 'gated' disabled for HOST_B → fallback to first selectable, which is 'overview'.
     expect(defaultProps.onSelect).toHaveBeenCalledWith(HOST_B, 'overview')
   })
 

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -49,7 +49,9 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
           const host = hosts[hostId]
           if (!host) return null
           const isExpanded = expanded[hostId] || hostId === selectedHostId
-          const hostCtx = { scope: 'host' as const, hostId }
+          // ctx carries runtime[hostId] so disabled(ctx) predicates can react
+          // to live host runtime changes without a separate side-read.
+          const hostCtx = { scope: 'host' as const, hostId, runtime: runtime[hostId] }
           return (
             <div key={hostId} className="mb-1">
               <button

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -52,15 +52,18 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
           // ctx carries runtime[hostId] so disabled(ctx) predicates can react
           // to live host runtime changes without a separate side-read.
           const hostCtx = { scope: 'host' as const, hostId, runtime: runtime[hostId] }
-          // R2 defender D2 fix — when expanding a different host, choose the
-          // first selectable sub-page FOR THAT HOST (using its runtime) rather
-          // than carrying over `selectedSubPage` from the currently-selected
-          // host.  Otherwise navigating to host B would briefly land on host
-          // A's sub-page and trigger a visible blank-and-redirect when the
-          // sub-page is disabled for host B.
-          const firstSelectableForHost = (): string => {
+          // R2 defender D2 + R3 standard P1 — when expanding a different host:
+          //   1. If the current `selectedSubPage` is still selectable for the
+          //      target host, preserve it (UX: user's working sub-page stays
+          //      across host switches when valid).
+          //   2. Otherwise pick the target host's first selectable sub-page
+          //      using its runtime — avoids the blank-and-redirect window
+          //      that D2 was originally meant to eliminate.
+          const targetSubPageForHost = (): string => {
+            const current = subPages.find((page) => page.localId === selectedSubPage)
+            if (current && current.disabled?.(hostCtx) !== true) return selectedSubPage
             const candidate = subPages.find((page) => page.disabled?.(hostCtx) !== true)
-            return (candidate?.localId ?? selectedSubPage)
+            return candidate?.localId ?? selectedSubPage
           }
           return (
             <div key={hostId} className="mb-1">
@@ -69,7 +72,7 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
                   toggleExpand(hostId)
                   if (!isExpanded) {
                     const targetSubPage =
-                      hostId === selectedHostId ? selectedSubPage : firstSelectableForHost()
+                      hostId === selectedHostId ? selectedSubPage : targetSubPageForHost()
                     onSelect(hostId, targetSubPage)
                   }
                 }}

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -52,12 +52,26 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
           // ctx carries runtime[hostId] so disabled(ctx) predicates can react
           // to live host runtime changes without a separate side-read.
           const hostCtx = { scope: 'host' as const, hostId, runtime: runtime[hostId] }
+          // R2 defender D2 fix — when expanding a different host, choose the
+          // first selectable sub-page FOR THAT HOST (using its runtime) rather
+          // than carrying over `selectedSubPage` from the currently-selected
+          // host.  Otherwise navigating to host B would briefly land on host
+          // A's sub-page and trigger a visible blank-and-redirect when the
+          // sub-page is disabled for host B.
+          const firstSelectableForHost = (): string => {
+            const candidate = subPages.find((page) => page.disabled?.(hostCtx) !== true)
+            return (candidate?.localId ?? selectedSubPage)
+          }
           return (
             <div key={hostId} className="mb-1">
               <button
                 onClick={() => {
                   toggleExpand(hostId)
-                  if (!isExpanded) onSelect(hostId, selectedSubPage)
+                  if (!isExpanded) {
+                    const targetSubPage =
+                      hostId === selectedHostId ? selectedSubPage : firstSelectableForHost()
+                    onSelect(hostId, targetSubPage)
+                  }
                 }}
                 className={`w-full text-left px-2 py-1.5 rounded text-sm cursor-pointer flex items-center gap-1.5 ${
                   selectedHostId === hostId

--- a/spa/src/lib/dispatch-settings-contributions.test.ts
+++ b/spa/src/lib/dispatch-settings-contributions.test.ts
@@ -1,15 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { clearModuleRegistry, registerModule, type ModuleDefinition } from './module-registry'
 import { clearContributions, listContributions } from './settings-contribution-registry'
-import { dispatchSettingsContributions } from './dispatch-settings-contributions'
+import {
+  dispatchSettingsContributions,
+  resetSettingsContributionsForHmr,
+} from './dispatch-settings-contributions'
 import {
   drainLegacyContributionQueue,
   peekLegacyContributionQueue,
   registerSettingsSection,
   clearLegacyPending,
 } from './settings-section-registry'
+import {
+  clearHostBuiltinSources,
+  HOST_BUILTIN_MODULE_ID,
+  setHostBuiltinSections,
+} from './host-builtin-sections'
 
 const FakeComponent = () => null
+const FakeHostSection = ({ hostId: _ }: { hostId: string }) => null
 
 function resetRegistries() {
   clearModuleRegistry()
@@ -17,6 +26,8 @@ function resetRegistries() {
   // Drain any leftover legacy pending buffer from previous tests.
   drainLegacyContributionQueue()
   clearLegacyPending()
+  // Clear the host-builtin source map so #586 tests start from a clean state.
+  clearHostBuiltinSources()
 }
 
 describe('dispatchSettingsContributions', () => {
@@ -278,6 +289,73 @@ describe('dispatchSettingsContributions', () => {
       expect(listContributions('purdex')).toEqual([])
       expect(listContributions('host')).toEqual([])
       expect(listContributions('workspace')).toEqual([])
+    })
+  })
+
+  // ----- #586: host-builtin source-map idempotence ------------------------
+
+  describe('#586 — host-builtin sources are idempotent across re-dispatches', () => {
+    function defs(...ids: string[]) {
+      return ids.map((id, i) => ({
+        localId: id,
+        labelKey: `hosts.${id}`,
+        order: i,
+        component: FakeHostSection,
+      }))
+    }
+
+    // Test 6 (spec §6.1 #6): standalone re-dispatch preserves host built-ins
+    // AND keeps wrapper component references identical.
+    it('Test 6 — second standalone dispatchSettingsContributions() preserves built-ins (the #586 bug)', () => {
+      setHostBuiltinSections(defs('overview', 'sessions', 'hooks', 'agents', 'uploads', 'logs'))
+
+      dispatchSettingsContributions()
+      const first = listContributions('host')
+      expect(first).toHaveLength(6)
+      const firstIds = first.map((c) => c.id)
+      const firstComponents = first.map((c) => c.component)
+
+      dispatchSettingsContributions()  // standalone — no re-setHostBuiltinSections
+      const second = listContributions('host')
+      expect(second).toHaveLength(6)
+      expect(second.map((c) => c.id)).toEqual(firstIds)
+      expect(second.map((c) => c.component)).toEqual(firstComponents)
+      for (const c of second) {
+        expect(c.moduleId).toBe(HOST_BUILTIN_MODULE_ID)
+      }
+    })
+
+    // Test 7 (spec §6.1 #7): interleaving module-declared + built-in sources is stable.
+    it('Test 7 — interleaved module + built-in dispatch state is stable across calls', () => {
+      registerModule({
+        id: 'editor',
+        name: 'Editor',
+        settings: [
+          { localId: 'editor-opts', scope: 'purdex', order: 0, labelKey: 'ed.editor-opts', component: FakeComponent },
+        ],
+      })
+      setHostBuiltinSections(defs('overview', 'sessions'))
+
+      dispatchSettingsContributions()
+      const purdexFirst = listContributions('purdex').map((c) => c.id)
+      const hostFirst = listContributions('host').map((c) => c.id)
+      expect(purdexFirst).toEqual(['editor.editor-opts'])
+      expect(hostFirst).toEqual(['_builtin.host.overview', '_builtin.host.sessions'])
+
+      dispatchSettingsContributions()
+      expect(listContributions('purdex').map((c) => c.id)).toEqual(purdexFirst)
+      expect(listContributions('host').map((c) => c.id)).toEqual(hostFirst)
+    })
+
+    // Test 8 (spec §6.1 #8): HMR reset clears host built-ins; subsequent dispatch sees zero.
+    it('Test 8 — resetSettingsContributionsForHmr() clears host-builtin sources', () => {
+      setHostBuiltinSections(defs('overview'))
+      dispatchSettingsContributions()
+      expect(listContributions('host')).toHaveLength(1)
+
+      resetSettingsContributionsForHmr()
+      dispatchSettingsContributions()
+      expect(listContributions('host')).toEqual([])
     })
   })
 })

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -11,6 +11,7 @@ import {
 } from './settings-section-registry'
 import {
   clearHostBuiltinSources,
+  commitHostBuiltinSources,
   getHostBuiltinDeclarations,
   HOST_BUILTIN_MODULE_ID,
 } from './host-builtin-sections'
@@ -184,9 +185,12 @@ export function dispatchSettingsContributions(
   // Phase 2 — commit. Safe to mutate now: validation passed.
   clearContributions()
   drainLegacyContributionQueue()  // safe: staging already holds the validated set
-  // No host-builtin drain — sources are long-lived (#586). The batch already
-  // contains the materialized host-builtin contributions; registering them
-  // below is sufficient. Repeated dispatches are idempotent.
+  // R2 attacker/defender/file-health A1 — host built-ins live in a staged map
+  // that wrappers do NOT observe.  commitHostBuiltinSources() swaps staged
+  // into the live map only here, in lock-step with the registry write below,
+  // so a failed Phase 1 leaves both layers untouched (no split-brain between
+  // sidebar/route metadata and the rendered body).
+  commitHostBuiltinSources()
   for (const contribution of batch) {
     registerSettingsContribution(contribution)
   }

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -10,10 +10,9 @@ import {
   peekLegacyContributionQueue,
 } from './settings-section-registry'
 import {
-  clearHostBuiltinPending,
-  drainHostBuiltinQueue,
+  clearHostBuiltinSources,
+  getHostBuiltinDeclarations,
   HOST_BUILTIN_MODULE_ID,
-  peekHostBuiltinQueue,
 } from './host-builtin-sections'
 import type {
   AnySettingsContribution,
@@ -145,10 +144,13 @@ export function buildSettingsContributionBatch(
     batch.push(full)
   }
 
-  // Peek (non-destructive) at the host built-in adapter pending buffer.
-  // Same F3 atomicity contract: peeked here for validation, drained only
-  // in the commit phase of `dispatchSettingsContributions()`.
-  const hostBuiltinDecls = peekHostBuiltinQueue()
+  // Re-materialize host built-ins from the stable source map every dispatch.
+  // The source map is long-lived (mutated only by setHostBuiltinSections /
+  // clearHostBuiltinSources), so this is idempotent across repeated dispatch
+  // calls — fixes #586 where a standalone second dispatch call would wipe
+  // built-in host contributions because the old pending-buffer/drain
+  // pattern emptied the buffer after the first commit.
+  const hostBuiltinDecls = getHostBuiltinDeclarations()
   for (const decl of hostBuiltinDecls) {
     const full = {
       ...decl,
@@ -182,7 +184,9 @@ export function dispatchSettingsContributions(
   // Phase 2 — commit. Safe to mutate now: validation passed.
   clearContributions()
   drainLegacyContributionQueue()  // safe: staging already holds the validated set
-  drainHostBuiltinQueue()         // same atomicity contract as legacy drain
+  // No host-builtin drain — sources are long-lived (#586). The batch already
+  // contains the materialized host-builtin contributions; registering them
+  // below is sufficient. Repeated dispatches are idempotent.
   for (const contribution of batch) {
     registerSettingsContribution(contribution)
   }
@@ -202,5 +206,5 @@ export function dispatchSettingsContributions(
 export function resetSettingsContributionsForHmr(): void {
   clearContributions()
   clearLegacyPending()
-  clearHostBuiltinPending()
+  clearHostBuiltinSources()
 }

--- a/spa/src/lib/host-builtin-sections.test.tsx
+++ b/spa/src/lib/host-builtin-sections.test.tsx
@@ -58,6 +58,7 @@ import {
   setHostBuiltinSections,
   type HostBuiltinSectionDef,
 } from './host-builtin-sections'
+import { dispatchSettingsContributions } from './dispatch-settings-contributions'
 import type { HostRuntime } from '../stores/useHostStore'
 
 // Import the six section components so we can verify identity (extra test).
@@ -220,26 +221,35 @@ describe('#586 — setHostBuiltinSections (batch-replace source map)', () => {
     expect(secondWrapped).toBe(firstWrapped)
   })
 
-  // Test 3 (spec §6.1 #3): wrapper delegates to the latest component.
-  it('Test 3 — wrapper delegates to the latest section component', () => {
+  // Test 3 (spec §6.1 #3): wrapper delegates to the latest *committed* component.
+  // Post-R2 A1 design — wrappers read liveSources, which is only updated by
+  // commitHostBuiltinSources() (called from dispatchSettingsContributions
+  // Phase 2).  This test triggers a commit by calling dispatch directly.
+  it('Test 3 — wrapper delegates to the latest committed section component', () => {
     const first = vi.fn(({ hostId }: { hostId: string }) => <div data-testid="impl">v1-{hostId}</div>)
     const second = vi.fn(({ hostId }: { hostId: string }) => <div data-testid="impl">v2-{hostId}</div>)
 
     setHostBuiltinSections([{ localId: 'a', labelKey: 'hosts.a', order: 0, component: first }])
-    const Wrapper = getHostBuiltinDeclarations()[0].component as React.ComponentType<{ ctx: { scope: 'host'; hostId: string; runtime?: undefined } }>
+    dispatchSettingsContributions()  // commit staged → live
+    const Wrapper = getHostBuiltinDeclarations()[0].component as React.ComponentType<{ ctx: { scope: 'host'; hostId: string; runtime: HostRuntime | undefined } }>
     const { getByTestId, rerender } = render(<Wrapper ctx={{ scope: 'host', hostId: 'hA', runtime: undefined }} />)
     expect(getByTestId('impl').textContent).toBe('v1-hA')
     expect(first).toHaveBeenCalled()
 
-    // Swap the underlying section component (HMR style).
+    // Swap the underlying section component (HMR style); commit before re-render.
     setHostBuiltinSections([{ localId: 'a', labelKey: 'hosts.a', order: 0, component: second }])
+    dispatchSettingsContributions()
     rerender(<Wrapper ctx={{ scope: 'host', hostId: 'hA', runtime: undefined }} />)
     expect(getByTestId('impl').textContent).toBe('v2-hA')
     expect(second).toHaveBeenCalled()
   })
 
-  // Test 4 (spec §6.1 #4): re-add after drop rebuilds the wrapper.
-  it('Test 4 — re-add after drop rebuilds the wrapper (cached identity is released)', () => {
+  // Test 4 (post-R2 design): wrapper identity is stable across drop+re-add
+  // because wrapperCache is keyed by localId and only cleared by
+  // clearHostBuiltinSources(). This is a STRONGER stability invariant than
+  // the pre-R2 design — a section file's wrapper component does not change
+  // identity even after a transient absence from the staged set.
+  it('Test 4 — wrapper identity stays stable across drop and re-add (post-R2 stronger contract)', () => {
     setHostBuiltinSections([makeSection('a')])
     const before = getHostBuiltinDeclarations()[0].component
 
@@ -248,7 +258,14 @@ describe('#586 — setHostBuiltinSections (batch-replace source map)', () => {
 
     setHostBuiltinSections([makeSection('a')])
     const after = getHostBuiltinDeclarations()[0].component
-    expect(after).not.toBe(before)
+    expect(after).toBe(before)  // SAME wrapper reference
+
+    // clearHostBuiltinSources releases the wrapper cache; subsequent
+    // re-add gets a fresh wrapper.
+    clearHostBuiltinSources()
+    setHostBuiltinSections([makeSection('a')])
+    const afterClear = getHostBuiltinDeclarations()[0].component
+    expect(afterClear).not.toBe(before)
   })
 
   // Test 5 (spec §6.1 #5): clearHostBuiltinSources empties the source map.
@@ -267,5 +284,65 @@ describe('#586 — setHostBuiltinSections (batch-replace source map)', () => {
     const decls = getHostBuiltinDeclarations()
     expect(decls).toHaveLength(1)
     expect(decls[0]).toMatchObject({ localId: 'x', labelKey: 'hosts.x', order: 7, scope: 'host' })
+  })
+
+  // R2 attacker/defender/file-health A1 regression — staged changes do not
+  // leak to wrappers until commitHostBuiltinSources() (called from dispatch)
+  // runs.  A failed Phase 1 leaves liveSources untouched, so wrapper.render
+  // continues to use the previously committed component / null.
+  it('R2 A1 regression — wrapper renders previous committed source until dispatch commits new staged set', () => {
+    const v1 = vi.fn(({ hostId }: { hostId: string }) => <div data-testid="impl">v1-{hostId}</div>)
+    const v2 = vi.fn(({ hostId }: { hostId: string }) => <div data-testid="impl">v2-{hostId}</div>)
+
+    setHostBuiltinSections([{ localId: 'a', labelKey: 'hosts.a', order: 0, component: v1 }])
+    dispatchSettingsContributions()  // commit v1
+    const Wrapper = getHostBuiltinDeclarations()[0].component as React.ComponentType<{ ctx: { scope: 'host'; hostId: string; runtime: HostRuntime | undefined } }>
+
+    // Stage v2 BUT do not commit; render — must show v1 (committed) not v2 (staged).
+    setHostBuiltinSections([{ localId: 'a', labelKey: 'hosts.a', order: 0, component: v2 }])
+    const { getByTestId, rerender } = render(<Wrapper ctx={{ scope: 'host', hostId: 'hA', runtime: undefined }} />)
+    expect(getByTestId('impl').textContent).toBe('v1-hA')
+    expect(v2).not.toHaveBeenCalled()
+
+    // After dispatch commits, wrapper sees v2.
+    dispatchSettingsContributions()
+    rerender(<Wrapper ctx={{ scope: 'host', hostId: 'hA', runtime: undefined }} />)
+    expect(getByTestId('impl').textContent).toBe('v2-hA')
+    expect(v2).toHaveBeenCalled()
+  })
+
+  it('R2 A1 regression — dispatch failure leaves committed liveSources intact', () => {
+    const v1 = ({ hostId }: { hostId: string }) => <div data-testid="impl">v1-{hostId}</div>
+    setHostBuiltinSections([{ localId: 'a', labelKey: 'hosts.a', order: 0, component: v1 }])
+    dispatchSettingsContributions()
+    const Wrapper = getHostBuiltinDeclarations()[0].component as React.ComponentType<{ ctx: { scope: 'host'; hostId: string; runtime: HostRuntime | undefined } }>
+    const initial = render(<Wrapper ctx={{ scope: 'host', hostId: 'hA', runtime: undefined }} />)
+    expect(initial.getByTestId('impl').textContent).toBe('v1-hA')
+    initial.unmount()
+
+    // Stage a malformed set that will fail Phase 1 validation
+    // (uppercase localId fails SETTINGS_LOCAL_ID_RE).
+    const v2 = ({ hostId }: { hostId: string }) => <div data-testid="impl">v2-{hostId}</div>
+    setHostBuiltinSections([{ localId: 'a', labelKey: 'hosts.a', order: 0, component: v2 }])
+    expect(() =>
+      // localId fails SETTINGS_LOCAL_ID_RE — assertValidSettingsContribution throws
+      // during Phase 1.  The cast bypasses the static check that normally
+      // protects this — we want to simulate runtime validation failure.
+      dispatchSettingsContributions([
+        {
+          id: 'broken',
+          name: 'Broken',
+          settings: [
+            { localId: 'BadID', scope: 'host', order: 0, labelKey: 'x', component: v2 },
+          ],
+        },
+      ] as unknown as Parameters<typeof dispatchSettingsContributions>[0]),
+    ).toThrow()
+
+    // liveSources['a'] still maps to v1 — wrapper render unchanged.  Render
+    // a fresh instance to prove the live state.
+    const after = render(<Wrapper ctx={{ scope: 'host', hostId: 'hA', runtime: undefined }} />)
+    expect(after.getByTestId('impl').textContent).toBe('v1-hA')
+    after.unmount()
   })
 })

--- a/spa/src/lib/host-builtin-sections.test.tsx
+++ b/spa/src/lib/host-builtin-sections.test.tsx
@@ -1,23 +1,21 @@
 /**
- * §3.3 — Built-in host sub-page adapter tests (PR-4 Commit 1)
+ * host-builtin-sections.test.tsx
  *
- * Verifies that `registerBuiltinModules()` registers exactly six host-scoped
- * contributions with the correct moduleId, order, wrap semantics, and scope
- * guard.
+ * Covers two layers:
  *
- * Test design — Test 3 (render-level props forwarding):
- *   OverviewSection is swapped for a spy stub via vi.mock so zustand/HTTP
- *   dependencies are never loaded.  The wrapper is rendered with a real host
- *   ctx and the resulting DOM is asserted — proving (a) the wrapper renders,
- *   (b) the underlying section component is invoked, (c) hostId is forwarded.
+ * 1. The PR-4 §3.3 baseline — `registerBuiltinModules()` registers the six
+ *    expected host-scoped contributions with the correct moduleId / order
+ *    / wrap semantics / scope guard.
  *
- *   The "all six identity" extra test uses the WeakMap as a complementary
- *   structural check and keeps that coverage without duplicating the render
- *   assertion for every section.
- *
- *   Test 4 (scope guard) renders the wrapper component directly with a wrong-
- *   scope ctx and asserts the output is null — the wrapper is a pure function
- *   with no external dependencies, so no mocks are needed.
+ * 2. The #586 follow-up contracts on the new batch-replace source-map API
+ *    (`setHostBuiltinSections`, `getHostBuiltinDeclarations`,
+ *    `clearHostBuiltinSources`):
+ *    - full-replace semantics (dropped localIds disappear),
+ *    - wrapper identity stable per localId across re-calls (incl. HMR-style
+ *      component-reference swap),
+ *    - wrapper delegates to the latest component reference,
+ *    - re-add after drop rebuilds the wrapper,
+ *    - clear empties the source map.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from '@testing-library/react'
@@ -30,10 +28,9 @@ vi.mock('../features/workspace/lib/icon-path-cache', () => ({
   prefetchWeight: () => Promise.resolve(),
 }))
 
-// Mock OverviewSection so Test 3 can render the wrapper without pulling in
-// zustand / HTTP dependencies.  The stub is a named export (matching the
-// real module's export shape) and renders identifiable content that includes
-// the forwarded hostId prop.
+// Mock OverviewSection so the §3.3 render-level tests can render the wrapper
+// without pulling in zustand / HTTP dependencies.  The stub is a named export
+// matching the real module's export shape.
 vi.mock('../components/hosts/OverviewSection', () => ({
   OverviewSection: vi.fn(({ hostId }: { hostId: string }) => (
     <div data-testid="overview-stub">overview-for-{hostId}</div>
@@ -54,9 +51,12 @@ import {
   listContributions,
 } from './settings-contribution-registry'
 import {
-  clearHostBuiltinPending,
+  clearHostBuiltinSources,
+  getHostBuiltinDeclarations,
   hostBuiltinComponentMap,
   HOST_BUILTIN_MODULE_ID,
+  setHostBuiltinSections,
+  type HostBuiltinSectionDef,
 } from './host-builtin-sections'
 
 // Import the six section components so we can verify identity (extra test).
@@ -73,8 +73,10 @@ function clearAll() {
   clearSettingsSectionRegistry()
   clearInterfaceSubsectionRegistry()
   clearContributions()
-  clearHostBuiltinPending()
+  clearHostBuiltinSources()
 }
+
+// ---------- §3.3 baseline (PR-4) ------------------------------------------
 
 describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions', () => {
   beforeEach(() => {
@@ -86,8 +88,6 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     clearAll()
   })
 
-  // Test 1: After registerBuiltinModules(), listContributions('host') contains
-  // exactly 6 items, all with moduleId === '_builtin.host'
   it('registers exactly 6 host-scoped contributions with moduleId _builtin.host', () => {
     registerBuiltinModules()
     const hostContribs = listContributions('host')
@@ -97,7 +97,6 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     }
   })
 
-  // Test 2: Order is exactly overview → sessions → hooks → agents → uploads → logs
   it('orders contributions as: overview, sessions, hooks, agents, uploads, logs', () => {
     registerBuiltinModules()
     const hostContribs = listContributions('host')
@@ -105,9 +104,6 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     expect(localIds).toEqual(['overview', 'sessions', 'hooks', 'agents', 'uploads', 'logs'])
   })
 
-  // Test 3: The contribution's component wraps OverviewSection and forwards hostId.
-  // Renders the wrapper with a real host ctx and asserts on the stub's DOM output,
-  // proving (a) wrapper renders, (b) section is invoked, (c) hostId is forwarded.
   it('renders OverviewSection with forwarded hostId for host ctx', () => {
     registerBuiltinModules()
     const overview = listContributions('host').find((c) => c.localId === 'overview')
@@ -121,7 +117,6 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     expect(node.textContent).toBe('overview-for-hA')
   })
 
-  // Bonus identity checks for the remaining five sections (keeps Test 3's spirit).
   it('wraps all six sections to their original components', () => {
     registerBuiltinModules()
     const hostContribs = listContributions('host')
@@ -145,7 +140,6 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     }
   })
 
-  // Test 4: Scope guard — render with ctx.scope !== 'host' returns null.
   it('scope guard: wrapper returns null when ctx.scope is not "host"', () => {
     registerBuiltinModules()
     const hostContribs = listContributions('host')
@@ -156,15 +150,12 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
       ctx: { scope: string; workspaceId?: string }
     }>
 
-    // Render with a workspace ctx — must produce null (no DOM nodes).
-    // The guard is a single `!== 'host'` check, so any non-host scope suffices.
     const { container } = render(
       <Wrapper ctx={{ scope: 'workspace', workspaceId: 'wA' }} />,
     )
     expect(container.firstChild).toBeNull()
   })
 
-  // Structural checks on all contributions.
   it('all contributions have correct scope, valid localIds, and labelKey starting with "hosts."', () => {
     registerBuiltinModules()
     const hostContribs = listContributions('host')
@@ -176,7 +167,6 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     }
   })
 
-  // HMR safety: re-running registerBuiltinModules does not accumulate duplicates.
   it('is HMR-safe: re-running registerBuiltinModules after clearAll does not duplicate', () => {
     registerBuiltinModules()
     const first = listContributions('host').length
@@ -185,5 +175,96 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     const second = listContributions('host').length
     expect(first).toBe(6)
     expect(second).toBe(6)
+  })
+})
+
+// ---------- #586 follow-up: batch-replace source map ----------------------
+
+describe('#586 — setHostBuiltinSections (batch-replace source map)', () => {
+  beforeEach(() => {
+    clearHostBuiltinSources()
+    clearContributions()
+  })
+
+  afterEach(() => {
+    clearHostBuiltinSources()
+    clearContributions()
+  })
+
+  function makeSection(localId: string, render?: (hostId: string) => React.ReactNode): HostBuiltinSectionDef {
+    const Section: React.FC<{ hostId: string }> = ({ hostId }) =>
+      <div data-testid={`section-${localId}`}>{render ? render(hostId) : `${localId}-${hostId}`}</div>
+    Section.displayName = `Section_${localId}`
+    return { localId, labelKey: `hosts.${localId}`, order: 0, component: Section }
+  }
+
+  // Test 1 (spec §6.1 #1): batch-replace defines the exact set; absent localIds are dropped.
+  it('Test 1 — batch replace is the full set; absent localIds are dropped', () => {
+    setHostBuiltinSections([makeSection('a'), makeSection('b'), makeSection('c')])
+    expect(getHostBuiltinDeclarations().map((d) => d.localId).sort()).toEqual(['a', 'b', 'c'])
+
+    setHostBuiltinSections([makeSection('a'), makeSection('d')])
+    expect(getHostBuiltinDeclarations().map((d) => d.localId).sort()).toEqual(['a', 'd'])
+  })
+
+  // Test 2 (spec §6.1 #2): wrapper identity stable across re-calls with same localIds (HMR).
+  it('Test 2 — wrapper identity stable across re-calls with the same localIds (HMR)', () => {
+    setHostBuiltinSections([makeSection('a')])
+    const firstWrapped = getHostBuiltinDeclarations()[0].component
+
+    // Simulate HMR: a fresh section component reference for the same localId.
+    setHostBuiltinSections([makeSection('a')])
+    const secondWrapped = getHostBuiltinDeclarations()[0].component
+
+    expect(secondWrapped).toBe(firstWrapped)
+  })
+
+  // Test 3 (spec §6.1 #3): wrapper delegates to the latest component.
+  it('Test 3 — wrapper delegates to the latest section component', () => {
+    const first = vi.fn(({ hostId }: { hostId: string }) => <div data-testid="impl">v1-{hostId}</div>)
+    const second = vi.fn(({ hostId }: { hostId: string }) => <div data-testid="impl">v2-{hostId}</div>)
+
+    setHostBuiltinSections([{ localId: 'a', labelKey: 'hosts.a', order: 0, component: first }])
+    const Wrapper = getHostBuiltinDeclarations()[0].component as React.ComponentType<{ ctx: { scope: 'host'; hostId: string; runtime?: undefined } }>
+    const { getByTestId, rerender } = render(<Wrapper ctx={{ scope: 'host', hostId: 'hA', runtime: undefined }} />)
+    expect(getByTestId('impl').textContent).toBe('v1-hA')
+    expect(first).toHaveBeenCalled()
+
+    // Swap the underlying section component (HMR style).
+    setHostBuiltinSections([{ localId: 'a', labelKey: 'hosts.a', order: 0, component: second }])
+    rerender(<Wrapper ctx={{ scope: 'host', hostId: 'hA', runtime: undefined }} />)
+    expect(getByTestId('impl').textContent).toBe('v2-hA')
+    expect(second).toHaveBeenCalled()
+  })
+
+  // Test 4 (spec §6.1 #4): re-add after drop rebuilds the wrapper.
+  it('Test 4 — re-add after drop rebuilds the wrapper (cached identity is released)', () => {
+    setHostBuiltinSections([makeSection('a')])
+    const before = getHostBuiltinDeclarations()[0].component
+
+    setHostBuiltinSections([])  // drop
+    expect(getHostBuiltinDeclarations()).toEqual([])
+
+    setHostBuiltinSections([makeSection('a')])
+    const after = getHostBuiltinDeclarations()[0].component
+    expect(after).not.toBe(before)
+  })
+
+  // Test 5 (spec §6.1 #5): clearHostBuiltinSources empties the source map.
+  it('Test 5 — clearHostBuiltinSources empties the source map', () => {
+    setHostBuiltinSections([makeSection('a'), makeSection('b')])
+    expect(getHostBuiltinDeclarations()).toHaveLength(2)
+    clearHostBuiltinSources()
+    expect(getHostBuiltinDeclarations()).toEqual([])
+  })
+
+  // Bonus: declaration shape is correctly carried through.
+  it('declaration shape includes scope/order/labelKey from the source def', () => {
+    setHostBuiltinSections([
+      { localId: 'x', labelKey: 'hosts.x', order: 7, component: OverviewSection },
+    ])
+    const decls = getHostBuiltinDeclarations()
+    expect(decls).toHaveLength(1)
+    expect(decls[0]).toMatchObject({ localId: 'x', labelKey: 'hosts.x', order: 7, scope: 'host' })
   })
 })

--- a/spa/src/lib/host-builtin-sections.test.tsx
+++ b/spa/src/lib/host-builtin-sections.test.tsx
@@ -58,6 +58,7 @@ import {
   setHostBuiltinSections,
   type HostBuiltinSectionDef,
 } from './host-builtin-sections'
+import type { HostRuntime } from '../stores/useHostStore'
 
 // Import the six section components so we can verify identity (extra test).
 import { OverviewSection } from '../components/hosts/OverviewSection'
@@ -110,9 +111,9 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     expect(overview).toBeDefined()
 
     const Wrapper = overview!.component as React.ComponentType<{
-      ctx: { scope: 'host'; hostId: string }
+      ctx: { scope: 'host'; hostId: string; runtime: HostRuntime | undefined }
     }>
-    const { getByTestId } = render(<Wrapper ctx={{ scope: 'host', hostId: 'hA' }} />)
+    const { getByTestId } = render(<Wrapper ctx={{ scope: 'host', hostId: 'hA', runtime: undefined }} />)
     const node = getByTestId('overview-stub')
     expect(node.textContent).toBe('overview-for-hA')
   })
@@ -134,7 +135,7 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
       const contrib = hostContribs.find((c) => c.localId === localId)
       expect(contrib, `contribution for '${localId}' must exist`).toBeDefined()
       const original = hostBuiltinComponentMap.get(
-        contrib!.component as React.ComponentType<{ ctx: { scope: 'host'; hostId: string } }>,
+        contrib!.component as React.ComponentType<{ ctx: { scope: 'host'; hostId: string; runtime: HostRuntime | undefined } }>,
       )
       expect(original, `'${localId}' must wrap the correct section`).toBe(component)
     }

--- a/spa/src/lib/host-builtin-sections.ts
+++ b/spa/src/lib/host-builtin-sections.ts
@@ -1,38 +1,43 @@
 /**
  * host-builtin-sections.ts
  *
- * Built-in host sub-page adapter — mirrors the PR-2 dispatch-flushed
- * pattern used by the legacy settings adapter (`settings-section-registry`),
- * but scoped to `'host'` contributions with `moduleId = '_builtin.host'`.
+ * Built-in host sub-page adapter — registers six (or whatever the caller
+ * supplies) `'host'`-scoped contributions under `moduleId = '_builtin.host'`.
  *
- * ## Why a separate queue (not shared with the legacy adapter)
+ * ## Design (post-#586)
  *
- * The legacy adapter (`_builtin.legacy-section`) is purdex-scoped.  Sharing
- * the same pending buffer would conflate two independent namespaces and make
- * the collision-checking logic in `buildSettingsContributionBatch` harder to
- * reason about.  A parallel queue keeps each adapter's invariants isolated
- * and the drain/peek surface matches the legacy adapter's contract exactly
- * (same shape, same atomicity guarantees — PR-3 Finding F3).
+ * Built-ins are a **stable registration source**, not a one-shot pending
+ * buffer.  `setHostBuiltinSections(defs[])` atomically replaces the full
+ * source set; any localId absent from the new defs is dropped.
+ * `dispatchSettingsContributions()` re-materializes host built-ins from the
+ * source map on every call (no drain), so the dispatcher is idempotent: a
+ * standalone second call to `dispatchSettingsContributions()` no longer
+ * wipes built-in host contributions.
  *
- * ## Dispatch contract (§7.2 hard constraint)
+ * ## Wrapper identity stability
  *
- * `registerBuiltinHostSection()` MUST NOT call `registerSettingsContribution()`
- * directly.  It pushes to `pendingHostBuiltinContributions`, which is peeked
- * (non-destructively) during Phase 1 validation and drained atomically during
- * Phase 2 commit inside `dispatchSettingsContributions()`.  This prevents
- * `clearContributions()` from nuking built-ins registered before dispatch.
+ * Each `localId`'s wrapper React component is created once
+ * (`createHostBuiltinWrapper(localId)`) and reused across subsequent
+ * `setHostBuiltinSections` calls — even when the inner section component
+ * is a new reference (HMR reload of a section file).  The wrapper closes
+ * over `localId` only; on render it reads the *current* component out of
+ * the source map and delegates.  React sees the same wrapper component
+ * type, so the host sub-page body does NOT remount across HMR.
+ *
+ * If a localId is dropped via `setHostBuiltinSections([])` and later re-
+ * added, a fresh wrapper is created (the dropped wrapper is no longer
+ * cached).
  *
  * ## HMR safety
  *
- * `registerBuiltinModules()` may re-run on hot-reload.  The buffer is drained
- * (cleared) after each successful dispatch, so re-runs produce a clean batch
- * without duplicates.  The `clearHostBuiltinPending()` helper is also exposed
- * for the `resetSettingsContributionsForHmr()` path.
+ * `clearHostBuiltinSources()` is exposed for the
+ * `resetSettingsContributionsForHmr()` path.  Subsequent
+ * `registerBuiltinModules()` runs repopulate via
+ * `setHostBuiltinSections(...)` without duplication.
  */
 import React from 'react'
 import type {
   AnySettingsContributionDeclaration,
-  SettingsContributionDeclaration,
   SettingsContextFor,
 } from './settings-contribution-types'
 
@@ -47,7 +52,7 @@ export interface HostBuiltinSectionDef {
   order: number
   /**
    * The underlying section component.  Receives `{ hostId: string }` props
-   * (the standard shape shared by all six built-in host sections).  The
+   * (the standard shape shared by all built-in host sections).  The
    * adapter wraps it with a scope guard so contributions receive the correct
    * `ctx` shape without modifying the section components.
    */
@@ -55,78 +60,107 @@ export interface HostBuiltinSectionDef {
 }
 
 // ----------------------------------------------------------------------------
-// Pending buffer (PR-2 dispatch-flushed pattern)
+// Stable source map
 // ----------------------------------------------------------------------------
 
-type HostBuiltinDeclaration = SettingsContributionDeclaration<'host'>
 type HostCtxProps = { ctx: SettingsContextFor<'host'> }
 
+interface HostBuiltinSource {
+  // Mutable per-source — refreshed by setHostBuiltinSections().  The wrapper
+  // reads these via the live map at render time so HMR-replacing the
+  // underlying section component takes effect without changing the wrapper's
+  // React component identity.
+  component: React.ComponentType<{ hostId: string }>
+  labelKey: string
+  order: number
+  // Stable per-localId — built once on first appearance and reused on every
+  // subsequent setHostBuiltinSections call as long as the localId stays in
+  // the source set.
+  wrapped: React.ComponentType<HostCtxProps>
+}
+
+const hostBuiltinSources = new Map<string, HostBuiltinSource>()
+
 /**
- * WeakMap from the ctx-wrapper component → the original section component.
- * Exposed for tests that verify `hostId` forwarding without a full DOM render.
+ * WeakMap from the ctx-wrapper component → the most recently registered
+ * underlying section component.  Used by tests to verify identity / forwarding
+ * without a full DOM render.  Updated in lockstep by `setHostBuiltinSections`
+ * so a test reading from the WeakMap always sees the latest section.
  */
-// Exported for test identity assertions only — see host-builtin-sections.test.tsx
 export const hostBuiltinComponentMap = new WeakMap<
   React.ComponentType<HostCtxProps>,
   React.ComponentType<{ hostId: string }>
 >()
 
-// Upsert map by localId so HMR re-runs do not accumulate duplicates.
-const pendingHostBuiltinContributions = new Map<string, HostBuiltinDeclaration>()
-
-/**
- * Register a built-in host sub-page into the pending buffer.  The
- * contribution is NOT committed to the live registry here — it waits for the
- * next `dispatchSettingsContributions()` call to flush.
- */
-export function registerBuiltinHostSection(def: HostBuiltinSectionDef): void {
-  // Scope guard wrapper: forward `hostId` from ctx; return null for wrong scope.
-  // Using React.createElement keeps this file as .ts (no JSX transform needed).
-  const Section = def.component
+function createHostBuiltinWrapper(localId: string): React.ComponentType<HostCtxProps> {
   const Wrapped: React.FC<HostCtxProps> = (props) => {
     if (props.ctx.scope !== 'host') return null
+    const source = hostBuiltinSources.get(localId)
+    if (!source) return null
+    const Section = source.component
     return React.createElement(Section, { hostId: props.ctx.hostId })
   }
-  Wrapped.displayName = `HostBuiltinWrap(${Section.displayName ?? Section.name ?? def.localId})`
+  Wrapped.displayName = `HostBuiltinWrap(${localId})`
+  return Wrapped
+}
 
-  hostBuiltinComponentMap.set(Wrapped, Section)
+/**
+ * Atomically replace the full set of built-in host sub-page sources.
+ * Any localId present in the previous state but absent from `defs` is
+ * dropped.  For each retained localId the cached wrapper is reused so its
+ * React component identity is stable across calls — including HMR reloads
+ * where `def.component` is a freshly imported reference.  The next
+ * `dispatchSettingsContributions()` materializes exactly these.
+ */
+export function setHostBuiltinSections(defs: readonly HostBuiltinSectionDef[]): void {
+  const nextIds = new Set<string>()
+  for (const def of defs) nextIds.add(def.localId)
 
-  const decl: HostBuiltinDeclaration = {
-    localId: def.localId,
-    scope: 'host',
-    order: def.order,
-    labelKey: def.labelKey,
-    component: Wrapped,
+  // Drop localIds not in the new set.  Their cached wrappers are released —
+  // a subsequent re-add for the same localId rebuilds the wrapper.
+  for (const key of Array.from(hostBuiltinSources.keys())) {
+    if (!nextIds.has(key)) hostBuiltinSources.delete(key)
   }
-  pendingHostBuiltinContributions.set(def.localId, decl)
+
+  // Upsert each def; reuse wrapper when present so identity is stable.
+  for (const def of defs) {
+    const existing = hostBuiltinSources.get(def.localId)
+    const wrapped = existing?.wrapped ?? createHostBuiltinWrapper(def.localId)
+    hostBuiltinSources.set(def.localId, {
+      component: def.component,
+      labelKey: def.labelKey,
+      order: def.order,
+      wrapped,
+    })
+    // Keep the WeakMap pointed at the latest section component so tests that
+    // read identity see the freshest reference.
+    hostBuiltinComponentMap.set(wrapped, def.component)
+  }
 }
 
 /**
- * Non-destructive view of the pending host built-in queue.  Used by the
- * dispatch validation phase (Phase 1) so a validation failure leaves the
- * queue intact for a retry.
+ * Snapshot the current built-in host source set as contribution declarations.
+ * Called by the dispatcher's batch-build pass; the returned array's component
+ * references are stable across calls when the source set is unchanged.
  */
-export function peekHostBuiltinQueue(): readonly AnySettingsContributionDeclaration[] {
-  return Array.from(pendingHostBuiltinContributions.values())
-}
-
-/**
- * Drain pending host built-in contributions into a fresh array, emptying the
- * internal buffer.  F3: COMMIT-ONLY — call only after full validation has
- * succeeded (see `drainLegacyContributionQueue` docs for rationale).
- */
-export function drainHostBuiltinQueue(): AnySettingsContributionDeclaration[] {
-  const out: AnySettingsContributionDeclaration[] = Array.from(
-    pendingHostBuiltinContributions.values(),
-  )
-  pendingHostBuiltinContributions.clear()
+export function getHostBuiltinDeclarations(): readonly AnySettingsContributionDeclaration[] {
+  const out: AnySettingsContributionDeclaration[] = []
+  for (const [localId, src] of hostBuiltinSources.entries()) {
+    out.push({
+      localId,
+      scope: 'host',
+      order: src.order,
+      labelKey: src.labelKey,
+      component: src.wrapped,
+    })
+  }
   return out
 }
 
 /**
- * HMR dispose hook.  Clears the active pending buffer so no stale entries
- * leak across HMR re-runs.
+ * HMR dispose hook + test reset.  Clears the stable source map so the next
+ * `setHostBuiltinSections(...)` call starts from an empty set.
  */
-export function clearHostBuiltinPending(): void {
-  pendingHostBuiltinContributions.clear()
+export function clearHostBuiltinSources(): void {
+  hostBuiltinSources.clear()
 }

--- a/spa/src/lib/host-builtin-sections.ts
+++ b/spa/src/lib/host-builtin-sections.ts
@@ -4,36 +4,43 @@
  * Built-in host sub-page adapter — registers six (or whatever the caller
  * supplies) `'host'`-scoped contributions under `moduleId = '_builtin.host'`.
  *
- * ## Design (post-#586)
+ * ## Design (post-#586, with R2 attacker/defender/file-health A1 transactional fix)
  *
- * Built-ins are a **stable registration source**, not a one-shot pending
- * buffer.  `setHostBuiltinSections(defs[])` atomically replaces the full
- * source set; any localId absent from the new defs is dropped.
- * `dispatchSettingsContributions()` re-materializes host built-ins from the
- * source map on every call (no drain), so the dispatcher is idempotent: a
- * standalone second call to `dispatchSettingsContributions()` no longer
- * wipes built-in host contributions.
+ * Built-ins live in two maps:
+ *
+ *   - `stagedSources` — what `setHostBuiltinSections(defs)` last said.
+ *     Mutated immediately on every call.  Read ONLY by the dispatcher's
+ *     batch-build pass via `getHostBuiltinDeclarations()`.
+ *
+ *   - `liveSources` — what was last successfully committed by
+ *     `commitHostBuiltinSources()` (called from Phase 2 of
+ *     `dispatchSettingsContributions()`).  Read by every wrapper at render
+ *     time.
+ *
+ * `dispatchSettingsContributions()` is responsible for swapping staged→live
+ * after Phase 1 validation succeeds.  If validation throws, `liveSources`
+ * stays untouched — wrappers continue rendering the previously committed
+ * built-ins, so registry metadata and rendered body stay in sync (no
+ * split-brain on partial failure).
+ *
+ * `dispatchSettingsContributions()` is idempotent: a second standalone call
+ * (no re-`setHostBuiltinSections`) re-validates the same staged set, then
+ * re-commits the same liveSources content (no observable change).
  *
  * ## Wrapper identity stability
  *
  * Each `localId`'s wrapper React component is created once
- * (`createHostBuiltinWrapper(localId)`) and reused across subsequent
- * `setHostBuiltinSections` calls — even when the inner section component
- * is a new reference (HMR reload of a section file).  The wrapper closes
- * over `localId` only; on render it reads the *current* component out of
- * the source map and delegates.  React sees the same wrapper component
+ * (`createHostBuiltinWrapper(localId)`), cached in `wrapperCache`, and reused
+ * across subsequent calls — even when the inner section component is a new
+ * reference (HMR reload of a section file).  The wrapper closes over
+ * `localId` only; on render it reads the *currently committed* component
+ * out of `liveSources` and delegates.  React sees the same wrapper component
  * type, so the host sub-page body does NOT remount across HMR.
  *
- * If a localId is dropped via `setHostBuiltinSections([])` and later re-
- * added, a fresh wrapper is created (the dropped wrapper is no longer
- * cached).
- *
- * ## HMR safety
- *
- * `clearHostBuiltinSources()` is exposed for the
- * `resetSettingsContributionsForHmr()` path.  Subsequent
- * `registerBuiltinModules()` runs repopulate via
- * `setHostBuiltinSections(...)` without duplication.
+ * Wrappers stay cached even after a `localId` is dropped from staged/live
+ * (until `clearHostBuiltinSources()`), so a subsequent re-add reuses the
+ * same wrapper reference — strictly stronger identity stability than the
+ * pre-R2 design.
  */
 import React from 'react'
 import type {
@@ -60,32 +67,26 @@ export interface HostBuiltinSectionDef {
 }
 
 // ----------------------------------------------------------------------------
-// Stable source map
+// Two-tier source map: staged (input) vs live (committed)
 // ----------------------------------------------------------------------------
 
 type HostCtxProps = { ctx: SettingsContextFor<'host'> }
 
-interface HostBuiltinSource {
-  // Mutable per-source — refreshed by setHostBuiltinSections().  The wrapper
-  // reads these via the live map at render time so HMR-replacing the
-  // underlying section component takes effect without changing the wrapper's
-  // React component identity.
+interface HostBuiltinLiveSource {
   component: React.ComponentType<{ hostId: string }>
   labelKey: string
   order: number
-  // Stable per-localId — built once on first appearance and reused on every
-  // subsequent setHostBuiltinSections call as long as the localId stays in
-  // the source set.
-  wrapped: React.ComponentType<HostCtxProps>
 }
 
-const hostBuiltinSources = new Map<string, HostBuiltinSource>()
+const stagedSources = new Map<string, HostBuiltinSectionDef>()
+const liveSources = new Map<string, HostBuiltinLiveSource>()
+const wrapperCache = new Map<string, React.ComponentType<HostCtxProps>>()
 
 /**
- * WeakMap from the ctx-wrapper component → the most recently registered
+ * WeakMap from the ctx-wrapper component → the most recently *committed*
  * underlying section component.  Used by tests to verify identity / forwarding
- * without a full DOM render.  Updated in lockstep by `setHostBuiltinSections`
- * so a test reading from the WeakMap always sees the latest section.
+ * without a full DOM render.  Updated only on `commitHostBuiltinSources()` —
+ * staged-but-uncommitted changes are not visible here.
  */
 export const hostBuiltinComponentMap = new WeakMap<
   React.ComponentType<HostCtxProps>,
@@ -95,7 +96,12 @@ export const hostBuiltinComponentMap = new WeakMap<
 function createHostBuiltinWrapper(localId: string): React.ComponentType<HostCtxProps> {
   const Wrapped: React.FC<HostCtxProps> = (props) => {
     if (props.ctx.scope !== 'host') return null
-    const source = hostBuiltinSources.get(localId)
+    // Read from LIVE (committed) state.  If a localId is in the wrapper
+    // cache but not in liveSources (dropped without re-commit, or commit
+    // has not yet happened), render null — the registry metadata likewise
+    // lacks the entry, so the route layer self-heals away from this sub-
+    // page rather than rendering stale content.
+    const source = liveSources.get(localId)
     if (!source) return null
     const Section = source.component
     return React.createElement(Section, { hostId: props.ctx.hostId })
@@ -105,62 +111,79 @@ function createHostBuiltinWrapper(localId: string): React.ComponentType<HostCtxP
 }
 
 /**
- * Atomically replace the full set of built-in host sub-page sources.
- * Any localId present in the previous state but absent from `defs` is
- * dropped.  For each retained localId the cached wrapper is reused so its
- * React component identity is stable across calls — including HMR reloads
- * where `def.component` is a freshly imported reference.  The next
- * `dispatchSettingsContributions()` materializes exactly these.
+ * Stage a new full set of built-in host sub-page sources.  Does NOT alter
+ * the live (committed) state observed by wrappers; that swap happens inside
+ * `commitHostBuiltinSources()` which the dispatcher calls after Phase 1
+ * validation.  Wrappers are pre-created here so the dispatcher's batch-build
+ * pass can reference them by stable identity.
  */
 export function setHostBuiltinSections(defs: readonly HostBuiltinSectionDef[]): void {
-  const nextIds = new Set<string>()
-  for (const def of defs) nextIds.add(def.localId)
-
-  // Drop localIds not in the new set.  Their cached wrappers are released —
-  // a subsequent re-add for the same localId rebuilds the wrapper.
-  for (const key of Array.from(hostBuiltinSources.keys())) {
-    if (!nextIds.has(key)) hostBuiltinSources.delete(key)
-  }
-
-  // Upsert each def; reuse wrapper when present so identity is stable.
+  stagedSources.clear()
   for (const def of defs) {
-    const existing = hostBuiltinSources.get(def.localId)
-    const wrapped = existing?.wrapped ?? createHostBuiltinWrapper(def.localId)
-    hostBuiltinSources.set(def.localId, {
-      component: def.component,
-      labelKey: def.labelKey,
-      order: def.order,
-      wrapped,
-    })
-    // Keep the WeakMap pointed at the latest section component so tests that
-    // read identity see the freshest reference.
-    hostBuiltinComponentMap.set(wrapped, def.component)
+    stagedSources.set(def.localId, def)
+    if (!wrapperCache.has(def.localId)) {
+      wrapperCache.set(def.localId, createHostBuiltinWrapper(def.localId))
+    }
   }
 }
 
 /**
- * Snapshot the current built-in host source set as contribution declarations.
- * Called by the dispatcher's batch-build pass; the returned array's component
- * references are stable across calls when the source set is unchanged.
+ * Snapshot the current staged set as contribution declarations for the
+ * dispatcher to validate + commit.  Returns wrapper components from the
+ * stable per-localId cache so identity is preserved across batch builds.
+ *
+ * @internal Used only by `dispatch-settings-contributions.ts`.
  */
 export function getHostBuiltinDeclarations(): readonly AnySettingsContributionDeclaration[] {
   const out: AnySettingsContributionDeclaration[] = []
-  for (const [localId, src] of hostBuiltinSources.entries()) {
+  for (const [localId, def] of stagedSources.entries()) {
+    const wrapped = wrapperCache.get(localId)!
     out.push({
       localId,
       scope: 'host',
-      order: src.order,
-      labelKey: src.labelKey,
-      component: src.wrapped,
+      order: def.order,
+      labelKey: def.labelKey,
+      component: wrapped,
     })
   }
   return out
 }
 
 /**
- * HMR dispose hook + test reset.  Clears the stable source map so the next
- * `setHostBuiltinSections(...)` call starts from an empty set.
+ * Commit the staged source map to live, becoming visible to wrappers.
+ * Called from Phase 2 of `dispatchSettingsContributions()` ONLY after
+ * Phase 1 validation has succeeded.  Fixes the R2 A1 finding: a failed
+ * dispatch leaves `liveSources` (and therefore wrappers' render output)
+ * untouched, so registry metadata and rendered body stay in sync.
+ *
+ * @internal Used only by `dispatch-settings-contributions.ts`.
+ */
+export function commitHostBuiltinSources(): void {
+  // Drop live entries no longer in staged.
+  for (const key of Array.from(liveSources.keys())) {
+    if (!stagedSources.has(key)) liveSources.delete(key)
+  }
+  // Upsert staged into live.  Wrappers read live, so once we set here, the
+  // next wrapper render sees the new component.  Wrapper identity itself is
+  // unchanged (cached in wrapperCache by localId).
+  for (const [localId, def] of stagedSources.entries()) {
+    liveSources.set(localId, {
+      component: def.component,
+      labelKey: def.labelKey,
+      order: def.order,
+    })
+    const wrapped = wrapperCache.get(localId)!
+    hostBuiltinComponentMap.set(wrapped, def.component)
+  }
+}
+
+/**
+ * HMR dispose hook + test reset.  Clears every tier — staged, live, and the
+ * wrapper cache — so the next `setHostBuiltinSections(...)` call starts from
+ * a fully empty slate.
  */
 export function clearHostBuiltinSources(): void {
-  hostBuiltinSources.clear()
+  stagedSources.clear()
+  liveSources.clear()
+  wrapperCache.clear()
 }

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -26,6 +26,7 @@ import {
   listContributions,
   getContribution,
 } from './settings-contribution-registry'
+import { clearHostBuiltinSources } from './host-builtin-sections'
 
 const FakeComponent = () => null
 
@@ -35,6 +36,7 @@ function clearAll() {
   clearSettingsSectionRegistry()
   clearInterfaceSubsectionRegistry()
   clearContributions()
+  clearHostBuiltinSources()
 }
 
 describe('registerBuiltinModules', () => {

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -52,7 +52,7 @@ import { fetchSessionCwd, fetchSessionHome } from './host-api'
 import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { openBrowserTab } from './open-browser-tab'
 import { getDefaultOpener } from './file-opener-registry'
-import { registerBuiltinHostSection } from './host-builtin-sections'
+import { setHostBuiltinSections } from './host-builtin-sections'
 import { OverviewSection } from '../components/hosts/OverviewSection'
 import { SessionsSection } from '../components/hosts/SessionsSection'
 import { HooksSection } from '../components/hosts/HooksSection'
@@ -392,16 +392,19 @@ export function registerBuiltinModules(): void {
     },
   })
 
-  // Built-in host sub-page contributions (PR-4).
-  // Push into the host-builtin pending buffer; flushed atomically by the
-  // dispatchSettingsContributions() call below (§7.2 dispatch-flushed pattern).
-  // Order follows the established HOST_SUB_PAGES sequence: 0–5.
-  registerBuiltinHostSection({ localId: 'overview',  labelKey: 'hosts.overview',  order: 0, component: OverviewSection })
-  registerBuiltinHostSection({ localId: 'sessions',  labelKey: 'hosts.sessions',  order: 1, component: SessionsSection })
-  registerBuiltinHostSection({ localId: 'hooks',     labelKey: 'hosts.hooks',     order: 2, component: HooksSection })
-  registerBuiltinHostSection({ localId: 'agents',    labelKey: 'hosts.agents',    order: 3, component: AgentsSection })
-  registerBuiltinHostSection({ localId: 'uploads',   labelKey: 'hosts.uploads',   order: 4, component: UploadSection })
-  registerBuiltinHostSection({ localId: 'logs',      labelKey: 'hosts.logs',      order: 5, component: LogsSection })
+  // Built-in host sub-page contributions (PR-4 + #586).
+  // Atomically replace the full set of built-in host sources; any localId
+  // not in this list would be dropped.  Re-materialized by every
+  // dispatchSettingsContributions() call (idempotent).  Wrapper identity is
+  // stable per localId across HMR reloads.
+  setHostBuiltinSections([
+    { localId: 'overview',  labelKey: 'hosts.overview',  order: 0, component: OverviewSection },
+    { localId: 'sessions',  labelKey: 'hosts.sessions',  order: 1, component: SessionsSection },
+    { localId: 'hooks',     labelKey: 'hosts.hooks',     order: 2, component: HooksSection },
+    { localId: 'agents',    labelKey: 'hosts.agents',    order: 3, component: AgentsSection },
+    { localId: 'uploads',   labelKey: 'hosts.uploads',   order: 4, component: UploadSection },
+    { localId: 'logs',      labelKey: 'hosts.logs',      order: 5, component: LogsSection },
+  ])
 
   // Dispatch module-declared settings contributions into the contribution registry.
   // Must run AFTER all registerModule(...) calls so every module is visible.

--- a/spa/src/lib/settings-contribution-types.test.ts
+++ b/spa/src/lib/settings-contribution-types.test.ts
@@ -8,7 +8,7 @@ import type {
 
 const PurdexScopedComponent: React.ComponentType<{ ctx: { scope: 'purdex' } }> = () => null
 
-const HostScopedComponent: React.ComponentType<{ ctx: { scope: 'host'; hostId: string } }> = () => null
+const HostScopedComponent: React.ComponentType<{ ctx: SettingsContextFor<'host'> }> = () => null
 
 const WorkspaceScopedComponent: React.ComponentType<{ ctx: { scope: 'workspace'; workspaceId: string } }> = () => null
 

--- a/spa/src/lib/settings-contribution-types.ts
+++ b/spa/src/lib/settings-contribution-types.ts
@@ -1,4 +1,5 @@
 import type React from 'react'
+import type { HostRuntime } from '../stores/useHostStore'
 
 export type SettingsScope = 'purdex' | 'host' | 'workspace'
 
@@ -21,9 +22,21 @@ export type SettingsScope = 'purdex' | 'host' | 'workspace'
 export const SETTINGS_LOCAL_ID_RE = /^[a-z0-9-]{1,32}$/
 
 // Discriminated union — scope field narrows hostId/workspaceId.
+//
+// host scope carries `runtime: HostRuntime | undefined` so `disabled(ctx)`
+// predicates can react to live host runtime changes without reading from
+// `useHostStore.getState()` (which would be a non-reactive side read).  The
+// field is required (not optional `?`) — callers MUST think about the
+// "runtime not yet observed" case and pass `undefined` explicitly.
+//
+// Why undefined-allowed: a host can exist in the store before any runtime
+// tick has populated `runtime[hostId]` (first render, freshly added host,
+// or a reconnect race).  Modules that gate on runtime should treat
+// `runtime === undefined` as "unknown, don't disable yet" or whatever
+// matches their semantics.
 export type SettingsContext =
   | { scope: 'purdex' }
-  | { scope: 'host'; hostId: string }
+  | { scope: 'host'; hostId: string; runtime: HostRuntime | undefined }
   | { scope: 'workspace'; workspaceId: string }
 
 export type SettingsContextFor<S extends SettingsScope> = Extract<SettingsContext, { scope: S }>


### PR DESCRIPTION
## Summary

PR-4 follow-up architecture polish. Two PR-4 review-deferred findings closed in one PR ahead of HSR PR-5 (Editor `homePath`), which would otherwise amplify both risks.

- **#586** (bug/spa) — `dispatchSettingsContributions()` second standalone call wiped host built-ins (one-shot drain pattern).
- **#588** (bug/spa) — `disabled(ctx)` reactive to host runtime so the body unmounts when a runtime tick flips a contribution disabled.

## Commits

| # | SHA | Subject |
|---|---|---|
| docs | `07de9e9a` | spec v1 |
| docs | `64860323` | spec v2 (absorbed codex spec R1 — P2 #1+#2, P3 #3+#4) |
| docs | `89891ae0` | plan v1 |
| docs | `a618e71b` | plan v2 (absorbed codex plan R1 — P1-1/2, P2-1/2/3, P3-1/2/3) |
| feat | `9d89d9c4` | host built-in batch-replace source map (closes #586) |
| feat | `7d03984e` | reactive host runtime in SettingsContextFor<'host'> (closes #588) |

## #586 — batch-replace source map

Public API change in `spa/src/lib/host-builtin-sections.ts`:
- removed: `registerBuiltinHostSection`, `peekHostBuiltinQueue`, `drainHostBuiltinQueue`, `clearHostBuiltinPending`
- added: `setHostBuiltinSections(defs[])` (atomic batch replace), `getHostBuiltinDeclarations()`, `clearHostBuiltinSources()`

`dispatchSettingsContributions()` re-materializes host built-ins from the source map every call → idempotent. Wrapper identity is stable per `localId` (cached on first appearance, reused across HMR-style re-registers; closure reads the current section component via the source map at render time).

Only production callsite (`register-modules.tsx`) migrated; six `registerBuiltinHostSection(...)` calls collapsed into one `setHostBuiltinSections([...])` batch.

## #588 — reactive host runtime

`SettingsContextFor<'host'>` extended with `runtime: HostRuntime | undefined`. HostPage uses a **two-pass selective subscription**:

1. `preResolveHostId(...)` — pure, runtime-independent → tentative hostId
2. `useHostStore((s) => s.runtime[tentativeHostId])` — observes ONLY that host's runtime
3. `resolveSelection(...)` runs with runtime-aware ctx; `disabled(ctx)` predicates flip → `canonicalPath` redirect kicks the user off a now-disabled body

A shared `pickHostIdFallback(...)` helper unifies the fallback ordering used by both `preResolveHostId` and `resolveSelection.getFallbackSelection` (codex R1 P2-3). Equivalence asserted by Test 14.

`HostSidebar` plumbs `runtime[hostId]` into the per-row ctx so the disabled-row marker reactively follows runtime changes.

## Codex review absorption

| Round | Finding | Resolution |
|---|---|---|
| spec R1 P2 #1 | partial re-register stale localId | batch-replace API drops absent localIds |
| spec R1 P2 #2 | HMR component identity | wrapper closes over localId, reads live source.component |
| spec R1 P3 #3 | HostPage full runtime-map subscription | two-pass selective subscription |
| spec R1 P3 #4 | runtime flicker / unmount tick tests | tests 11+12 added (deterministic) |
| plan R1 P1-1 | TS-broken-as-TDD-red | commit 3 reframed as atomic Step A→B→C with TS green throughout |
| plan R1 P1-2 | settings-contribution-types.test.ts not in migration list | included; full-repo grep audit |
| plan R1 P2-1+2 | test 12 jsdom warning spy unstable | redesigned as deterministic subscription-leak probe |
| plan R1 P2-3 | preResolveHostId vs resolveSelection duplication | shared `pickHostIdFallback`; equivalence Test 14 |
| plan R1 P3-1 | callsite audit completeness | 3 explicit negative-grep checks (run clean) |
| plan R1 P3-2 | hostBuiltinComponentMap stale entries | WeakMap GC + Test 4 covers re-add invalidation |
| plan R1 P3-3 | Test 10 render-counter fragility | switched to `React.Profiler` |

## Test plan

- [x] `cd spa && pnpm exec vitest run src/lib/host-builtin-sections.test.tsx src/lib/dispatch-settings-contributions.test.ts src/components/HostPage.test.tsx src/components/hosts/HostSidebar.test.tsx src/lib/settings-contribution-types.test.ts src/lib/register-modules.test.ts` — **75/75 green**
- [x] `pnpm exec vitest run` — **2528/2531 green** (3 pre-existing failures in `src/lib/sync/contributors/hosts.test.ts` independent of this PR; verified on baseline `df34d1d8`)
- [x] `pnpm run lint` — 0 errors (2 pre-existing EditorPane warnings)
- [x] `pnpm run build` — green
- [x] Negative grep: no lingering references to removed APIs
- [ ] Manual smoke: launch dev server → host page renders six sub-pages → disconnect a host → sidebar updates + body unaffected (no regression)

## Out of scope

- #587 (parseRoute / isHostSubPage purity) — unchanged OPEN; revisit after PR-5 lands a real dynamic module-declared subPage.
- Legacy adapter (`settings-section-registry`) keeps the pending-buffer/drain pattern. Strictly symmetric fix is strictly better but not load-bearing today; deferred.