### PR TITLE
fix(spa): focus WYSIWYG editor from empty clicks

### DIFF
--- a/spa/src/components/editor/TiptapEditor.test.tsx
+++ b/spa/src/components/editor/TiptapEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TiptapEditor } from './TiptapEditor'
 
@@ -71,6 +71,16 @@ describe('TiptapEditor', () => {
     focusSpy.mockClear()
 
     rerender(<TiptapEditor content="# Hello" isActive={true} onChange={() => {}} onSave={() => {}} />)
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('focuses the editable content when clicking empty editor space', () => {
+    render(<TiptapEditor content="# Hello" isActive={false} onChange={() => {}} onSave={() => {}} />)
+
+    focusSpy.mockClear()
+
+    fireEvent.mouseDown(screen.getByTestId('tiptap-scroll-root'))
 
     expect(focusSpy).toHaveBeenCalledTimes(1)
   })

--- a/spa/src/components/editor/TiptapEditor.tsx
+++ b/spa/src/components/editor/TiptapEditor.tsx
@@ -13,6 +13,11 @@ interface Props {
 export function TiptapEditor({ content, isActive, onChange, onSave }: Props) {
   const onSaveRef = useRef(onSave)
   const containerRef = useRef<HTMLDivElement>(null)
+
+  const focusEditable = () => {
+    containerRef.current?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus()
+  }
+
   useEffect(() => {
     onSaveRef.current = onSave
   }, [onSave])
@@ -57,13 +62,21 @@ export function TiptapEditor({ content, isActive, onChange, onSave }: Props) {
 
   useEffect(() => {
     if (!isActive) return
-    containerRef.current?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus()
+    focusEditable()
   }, [isActive])
 
   if (!editor) return null
 
   return (
-    <div ref={containerRef} data-testid="tiptap-scroll-root" className="h-full min-h-0 overflow-auto">
+    <div
+      ref={containerRef}
+      data-testid="tiptap-scroll-root"
+      className="h-full min-h-0 overflow-auto"
+      onMouseDown={(event) => {
+        if ((event.target as HTMLElement).closest('[contenteditable="true"]')) return
+        focusEditable()
+      }}
+    >
       <div className="min-h-full [&_.tiptap-editor]:min-h-full [&_.tiptap-editor]:cursor-text">
         <EditorContent editor={editor} />
       </div>


### PR DESCRIPTION
## Summary
- focus the Live Mode editable element when users click empty space inside the WYSIWYG editor canvas
- keep direct clicks inside the contenteditable root unchanged while making the whole scroll area behave like one editor surface
- add a regression test that covers empty-space clicks in `TiptapEditor`

## Verification
- `pnpm --prefix spa exec vitest run src/components/editor/TiptapEditor.test.tsx`
- `pnpm --prefix spa run lint`