### PR TITLE
fix(agent): preserve symlink invocation path for versioned CLI binaries

### DIFF
--- a/internal/agent/normalize_executable_path_test.go
+++ b/internal/agent/normalize_executable_path_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNormalizeExecutablePath_PreservesSymlinkInvocationPath ensures the
+// symlink path is returned as-is. Claude Code 2.1.113+ ships as a symlink
+// (~/.local/bin/claude) pointing to a versioned Mach-O binary
+// (~/.local/share/claude/versions/<X.Y.Z>). Resolving the symlink would make
+// basename the version string instead of "claude", breaking agent Identify.
+func TestNormalizeExecutablePath_PreservesSymlinkInvocationPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "versioned-target")
+	if err := os.WriteFile(target, []byte{}, 0755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "invocation-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := normalizeExecutablePath(link)
+	if err != nil {
+		t.Fatalf("normalizeExecutablePath: %v", err)
+	}
+	if got != link {
+		t.Fatalf("normalizeExecutablePath(%q) = %q, want %q (symlink preserved)", link, got, link)
+	}
+}

--- a/internal/agent/process_info.go
+++ b/internal/agent/process_info.go
@@ -69,9 +69,6 @@ func normalizeExecutablePath(raw string) (string, error) {
 			}
 		}
 	}
-	if resolved, err := filepath.EvalSymlinks(raw); err == nil {
-		raw = resolved
-	}
 	if abs, err := filepath.Abs(raw); err == nil {
 		raw = abs
 	}

--- a/internal/agent/process_info_darwin_test.go
+++ b/internal/agent/process_info_darwin_test.go
@@ -6,8 +6,8 @@ func TestProcessInfo_ReadsCurrentProcess(t *testing.T) {
 	testProcessInfoReadsCurrentProcess(t)
 }
 
-func TestProcessInfo_ResolvesSymlinks(t *testing.T) {
-	testProcessInfoResolvesSymlinks(t)
+func TestProcessInfo_PreservesSymlinkInvocationPath(t *testing.T) {
+	testProcessInfoPreservesSymlinkInvocationPath(t)
 }
 
 func TestProcessInfo_MissingProcess(t *testing.T) {

--- a/internal/agent/process_info_linux_test.go
+++ b/internal/agent/process_info_linux_test.go
@@ -6,8 +6,8 @@ func TestProcessInfo_ReadsCurrentProcess(t *testing.T) {
 	testProcessInfoReadsCurrentProcess(t)
 }
 
-func TestProcessInfo_ResolvesSymlinks(t *testing.T) {
-	testProcessInfoResolvesSymlinks(t)
+func TestProcessInfo_PreservesSymlinkInvocationPath(t *testing.T) {
+	testProcessInfoPreservesSymlinkInvocationPath(t)
 }
 
 func TestProcessInfo_MissingProcess(t *testing.T) {

--- a/internal/agent/process_info_test.go
+++ b/internal/agent/process_info_test.go
@@ -37,7 +37,7 @@ func testProcessInfoReadsCurrentProcess(t *testing.T) {
 	}
 }
 
-func testProcessInfoResolvesSymlinks(t *testing.T) {
+func testProcessInfoPreservesSymlinkInvocationPath(t *testing.T) {
 	t.Helper()
 
 	if os.Getenv("GO_WANT_PROCESS_INFO_HELPER") == "1" {
@@ -48,10 +48,6 @@ func testProcessInfoResolvesSymlinks(t *testing.T) {
 	exe, err := os.Executable()
 	if err != nil {
 		t.Fatalf("os.Executable: %v", err)
-	}
-	resolvedExe, err := filepath.EvalSymlinks(exe)
-	if err != nil {
-		t.Fatalf("EvalSymlinks(%q): %v", exe, err)
 	}
 	linkPath := filepath.Join(t.TempDir(), "process-info-helper")
 	if err := os.Symlink(exe, linkPath); err != nil {
@@ -72,8 +68,8 @@ func testProcessInfoResolvesSymlinks(t *testing.T) {
 	for {
 		info, err := agent.ReadProcessInfo(cmd.Process.Pid)
 		if err == nil {
-			if info.ExePath != resolvedExe {
-				t.Fatalf("ExePath = %q, want %q", info.ExePath, resolvedExe)
+			if info.ExePath != linkPath {
+				t.Fatalf("ExePath = %q, want %q (symlink invocation path preserved)", info.ExePath, linkPath)
 			}
 			if len(info.Argv) == 0 {
 				t.Fatal("Argv should not be empty for helper process")


### PR DESCRIPTION
## Summary

- Claude Code 2.1.113+ ships as a symlink (`~/.local/bin/claude`) pointing to a versioned Mach-O binary (`~/.local/share/claude/versions/<X.Y.Z>`). `normalizeExecutablePath` used to `EvalSymlinks`, turning `ExePath` into the versioned target and making `cc.Provider.Identify` see basename `"2.1.117"` instead of `"claude"` — every cc hook was rejected with `identify_mismatch`.
- Spoofing defense still holds via `pidAncestorIncludesFn` at `internal/module/agent/verify.go:63`, which verifies the sender PID is in the target pane's process tree (stronger than binary path matching).

## Test plan

- [x] `go test ./...` — all green
- [x] New unit test `TestNormalizeExecutablePath_PreservesSymlinkInvocationPath` (pure function + temp symlink)
- [x] Renamed integration test `TestProcessInfo_ResolvesSymlinks` → `TestProcessInfo_PreservesSymlinkInvocationPath` with assertion flipped
- [ ] After merge + bump: rebuild daemon, restart, reload SPA — verify real cc sessions pass verify (trace `terminal_reason=completed`, not `verify_rejected`)