### PR TITLE
feat(spa): HSR PR-5 — Editor homePath first module user + #540 immutable snapshot + deprecation warn

### DIFF
--- a/spa/src/components/SessionPaneContent.test.tsx
+++ b/spa/src/components/SessionPaneContent.test.tsx
@@ -5,11 +5,17 @@ import { useHostStore } from '../stores/useHostStore'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useTabStore } from '../stores/useTabStore'
 import { useConfigStore } from '../stores/useConfigStore'
-import type { Pane, Tab } from '../types/tab'
+import { useWorkspaceStore } from '../features/workspace/store'
+import type { Pane, Tab, Workspace } from '../types/tab'
 import type { ConfigData } from '../lib/host-api'
 
+const terminalViewProps = vi.hoisted(() => ({ last: undefined as Record<string, unknown> | undefined }))
+
 vi.mock('./TerminalView', () => ({
-  default: () => <div data-testid="terminal-view" />,
+  default: (props: Record<string, unknown>) => {
+    terminalViewProps.last = props
+    return <div data-testid="terminal-view" />
+  },
 }))
 
 vi.mock('./ConversationView', () => ({
@@ -52,8 +58,18 @@ function setupTabStore(pane: Pane) {
   })
 }
 
+function makeWorkspace(id: string, tabs: string[]): Workspace {
+  return {
+    id,
+    name: id,
+    tabs,
+    activeTabId: tabs[0] ?? null,
+  }
+}
+
 beforeEach(() => {
   cleanup()
+  terminalViewProps.last = undefined
   useHostStore.setState({
     hosts: { [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 } },
     hostOrder: [HOST_ID],
@@ -71,6 +87,7 @@ beforeEach(() => {
   })
   useConfigStore.setState({ config: defaultConfig })
   useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+  useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: null })
 })
 
 describe('SessionPaneContent', () => {
@@ -109,6 +126,41 @@ describe('SessionPaneContent', () => {
     render(<SessionPaneContent pane={pane} isActive={true} />)
     expect(screen.getByTestId('terminated-pane')).toBeInTheDocument()
     expect(screen.getByText('Terminated: session-closed')).toBeInTheDocument()
+  })
+
+  describe('TerminalView workspaceId plumbing (PR-5)', () => {
+    it('passes workspaceId when pane belongs to a workspace tab', () => {
+      const pane = makePane()
+      setupTabStore(pane)
+      useWorkspaceStore.setState({
+        workspaces: [makeWorkspace('wsA', ['tab-1'])],
+        activeWorkspaceId: 'wsA',
+      })
+      render(<SessionPaneContent pane={pane} isActive={true} />)
+      expect(terminalViewProps.last?.workspaceId).toBe('wsA')
+    })
+
+    it('passes undefined workspaceId for standalone tab (not in any workspace)', () => {
+      const pane = makePane()
+      setupTabStore(pane)
+      useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: null })
+      render(<SessionPaneContent pane={pane} isActive={true} />)
+      expect(terminalViewProps.last?.workspaceId).toBeUndefined()
+    })
+
+    it('uses link-source workspace, not active workspace (multi-workspace isolation)', () => {
+      const pane = makePane()
+      setupTabStore(pane)
+      useWorkspaceStore.setState({
+        workspaces: [
+          makeWorkspace('wsA', []),
+          makeWorkspace('wsB', ['tab-1']),
+        ],
+        activeWorkspaceId: 'wsA',
+      })
+      render(<SessionPaneContent pane={pane} isActive={true} />)
+      expect(terminalViewProps.last?.workspaceId).toBe('wsB')
+    })
   })
 
   it('does not render TerminalView when terminated', () => {

--- a/spa/src/components/SessionPaneContent.tsx
+++ b/spa/src/components/SessionPaneContent.tsx
@@ -6,6 +6,7 @@ import { useSessionStore } from '../stores/useSessionStore'
 import { useStreamStore } from '../stores/useStreamStore'
 import { useConfigStore } from '../stores/useConfigStore'
 import { useTabStore } from '../stores/useTabStore'
+import { useWorkspaceStore } from '../features/workspace/store'
 import { handoff, fetchWsTicket } from '../lib/host-api'
 import { useHostStore } from '../stores/useHostStore'
 import { findPane } from '../lib/pane-tree'
@@ -60,6 +61,12 @@ export function SessionPaneContent({ pane, isActive }: PaneRendererProps) {
     return ''
   })
 
+  // Link-source workspace for terminal link openers (PR-5): use the workspace
+  // that owns this tab, not active workspace. `undefined` for standalone tabs.
+  const workspaceId = useWorkspaceStore((s) =>
+    tabId ? s.findWorkspaceByTab(tabId)?.id : undefined,
+  ) ?? undefined
+
   if (content.kind === 'tmux-session' && content.terminated) {
     return <TerminatedPane content={content} tabId={tabId} paneId={pane.id} />
   }
@@ -85,6 +92,7 @@ export function SessionPaneContent({ pane, isActive }: PaneRendererProps) {
       visible={isActive}
       hostId={hostId}
       sessionCode={sessionCode}
+      workspaceId={workspaceId}
       getTicket={() => fetchWsTicket(hostId)}
     />
   )

--- a/spa/src/components/TerminalView.test.tsx
+++ b/spa/src/components/TerminalView.test.tsx
@@ -203,6 +203,45 @@ describe('TerminalView', () => {
     expect(termInstance.registerLinkProvider).toHaveBeenCalledTimes(1)
   })
 
+  describe('linkContext (PR-5)', () => {
+    it('passes workspaceId through linkContext', async () => {
+      const mod = await import('../hooks/useTerminal')
+      const spy = vi.spyOn(mod, 'useTerminal')
+      try {
+        render(
+          <TerminalView
+            wsUrl="ws://localhost:7860/ws/terminal/test"
+            hostId="h1"
+            sessionCode="s1"
+            workspaceId="wsA"
+          />,
+        )
+        const opts = spy.mock.calls[0]?.[0]
+        expect(opts?.linkContext).toEqual({ hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' })
+      } finally {
+        spy.mockRestore()
+      }
+    })
+
+    it('omits workspaceId when prop not supplied', async () => {
+      const mod = await import('../hooks/useTerminal')
+      const spy = vi.spyOn(mod, 'useTerminal')
+      try {
+        render(
+          <TerminalView
+            wsUrl="ws://localhost:7860/ws/terminal/test"
+            hostId="h1"
+            sessionCode="s1"
+          />,
+        )
+        const opts = spy.mock.calls[0]?.[0]
+        expect(opts?.linkContext).toEqual({ hostId: 'h1', sessionCode: 's1', workspaceId: undefined })
+      } finally {
+        spy.mockRestore()
+      }
+    })
+  })
+
   describe('drag-drop', () => {
     const HOST = 'test-host'
     const SESSION = 'dev001'

--- a/spa/src/components/TerminalView.tsx
+++ b/spa/src/components/TerminalView.tsx
@@ -16,16 +16,17 @@ interface Props {
   connectingMessage?: string
   hostId?: string
   sessionCode?: string
+  workspaceId?: string
   getTicket?: () => Promise<string>
 }
 
-export default function TerminalView({ wsUrl, visible = true, connectingMessage, hostId, sessionCode, getTicket }: Props) {
+export default function TerminalView({ wsUrl, visible = true, connectingMessage, hostId, sessionCode, workspaceId, getTicket }: Props) {
   const setOscTitle = useAgentStore((s) => s.setOscTitle)
   const handleTitle = useCallback((title: string) => {
     if (hostId && sessionCode) setOscTitle(hostId, sessionCode, title)
   }, [hostId, sessionCode, setOscTitle])
 
-  const linkContext = useMemo(() => ({ hostId, sessionCode }), [hostId, sessionCode])
+  const linkContext = useMemo(() => ({ hostId, sessionCode, workspaceId }), [hostId, sessionCode, workspaceId])
   const { termRef, fitAddonRef, containerRef } = useTerminal({ linkContext, onTitle: handleTitle })
   const [ready, setReady] = useState(false)
   const [disconnected, setDisconnected] = useState(false)

--- a/spa/src/components/editor/EditorHomePathHostSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.test.tsx
@@ -82,4 +82,30 @@ describe('EditorHomePathHostSection', () => {
     expect(input.value).toBe('')
     expect(useHostSettingsStore.getState().get('h1', 'editor')).toBeUndefined()
   })
+
+  it('Clear only drops homePath, preserving sibling editor settings (R2 codex)', () => {
+    useHostSettingsStore.getState().set('h1', 'editor', {
+      homePath: '/home/y',
+      wrap: true,
+      tabSize: 4,
+    })
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    fireEvent.click(screen.getByRole('button', { name: /clear|清除/i }))
+    expect(useHostSettingsStore.getState().get('h1', 'editor')).toEqual({
+      wrap: true,
+      tabSize: 4,
+    })
+  })
+
+  it('Blur-to-empty only drops homePath, preserving sibling editor settings (R2 codex)', () => {
+    useHostSettingsStore.getState().set('h1', 'editor', {
+      homePath: '/home/y',
+      wrap: true,
+    })
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+    expect(useHostSettingsStore.getState().get('h1', 'editor')).toEqual({ wrap: true })
+  })
 })

--- a/spa/src/components/editor/EditorHomePathHostSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.test.tsx
@@ -136,4 +136,20 @@ describe('EditorHomePathHostSection', () => {
     // commit detects the no-op against live store and leaves state alone
     expect(useHostSettingsStore.getState().get('h1', 'editor')).toEqual({ homePath: '/home/new' })
   })
+
+  it('focus-without-edit + external sync + blur pulls in the new value (R3 codex)', () => {
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/old' })
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.focus(input)
+    // External update during focus, no user typing
+    act(() => {
+      useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/external' })
+    })
+    fireEvent.blur(input)
+    // Store keeps the external value (no clobber)
+    expect(useHostSettingsStore.getState().get('h1', 'editor')).toEqual({ homePath: '/home/external' })
+    // Input also reflects the external value
+    expect(input.value).toBe('/home/external')
+  })
 })

--- a/spa/src/components/editor/EditorHomePathHostSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.test.tsx
@@ -61,4 +61,25 @@ describe('EditorHomePathHostSection', () => {
     const { container } = render(<EditorHomePathHostSection ctx={wrongCtx} />)
     expect(container.innerHTML).toBe('')
   })
+
+  it('normalizes trailing whitespace back to the input on blur (R1 codex)', () => {
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/y' })
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    // User adds a trailing space — same trimmed value, still a no-op commit
+    fireEvent.change(input, { target: { value: '/home/y ' } })
+    fireEvent.blur(input)
+    // Store is unchanged and the UI reflects the trimmed value
+    expect(useHostSettingsStore.getState().get('h1', 'editor')).toEqual({ homePath: '/home/y' })
+    expect(input.value).toBe('/home/y')
+  })
+
+  it('normalizes pure-whitespace input to empty on blur when nothing is stored', () => {
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.blur(input)
+    expect(input.value).toBe('')
+    expect(useHostSettingsStore.getState().get('h1', 'editor')).toBeUndefined()
+  })
 })

--- a/spa/src/components/editor/EditorHomePathHostSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react'
 
 vi.mock('../../lib/storage/sync', () => ({
   syncManager: { register: vi.fn(), notify: vi.fn(), destroy: vi.fn() },
@@ -107,5 +107,33 @@ describe('EditorHomePathHostSection', () => {
     fireEvent.change(input, { target: { value: '' } })
     fireEvent.blur(input)
     expect(useHostSettingsStore.getState().get('h1', 'editor')).toEqual({ wrap: true })
+  })
+
+  it('does not clobber the draft while focused when store syncs externally (R2 codex)', () => {
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/old' })
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '/home/draft' } })
+    // External write (simulates BroadcastChannel sync)
+    act(() => {
+      useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/external' })
+    })
+    expect(input.value).toBe('/home/draft')
+  })
+
+  it('commit() reads the latest store value, not the render-time snapshot (R2 codex)', () => {
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/old' })
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '/home/new' } })
+    // Another session writes the same value concurrently
+    act(() => {
+      useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/new' })
+    })
+    fireEvent.blur(input)
+    // commit detects the no-op against live store and leaves state alone
+    expect(useHostSettingsStore.getState().get('h1', 'editor')).toEqual({ homePath: '/home/new' })
   })
 })

--- a/spa/src/components/editor/EditorHomePathHostSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+vi.mock('../../lib/storage/sync', () => ({
+  syncManager: { register: vi.fn(), notify: vi.fn(), destroy: vi.fn() },
+  createSyncManager: vi.fn(),
+}))
+
+import { EditorHomePathHostSection } from './EditorHomePathHostSection'
+import { useHostSettingsStore } from '../../stores/useHostSettingsStore'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
+
+const ctx: SettingsContextFor<'host'> = { scope: 'host', hostId: 'h1', runtime: undefined }
+
+beforeEach(() => {
+  cleanup()
+  localStorage.clear()
+  useHostSettingsStore.setState({ hosts: {} })
+})
+
+describe('EditorHomePathHostSection', () => {
+  it('renders placeholder when no value is stored', () => {
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    expect(input.value).toBe('')
+  })
+
+  it('renders stored value', () => {
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/y' })
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    expect(input.value).toBe('/home/y')
+  })
+
+  it('writes to host store on change (commit on blur)', () => {
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '/home/foo' } })
+    fireEvent.blur(input)
+    expect(useHostSettingsStore.getState().get('h1', 'editor')).toEqual({ homePath: '/home/foo' })
+  })
+
+  it('Clear button removes stored homePath', () => {
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/y' })
+    render(<EditorHomePathHostSection ctx={ctx} />)
+    fireEvent.click(screen.getByRole('button', { name: /clear|清除/i }))
+    const after = useHostSettingsStore.getState().get('h1', 'editor')
+    expect(after?.homePath).toBeUndefined()
+  })
+
+  it('isolates writes between hosts', () => {
+    render(<EditorHomePathHostSection ctx={{ scope: 'host', hostId: 'h1', runtime: undefined }} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '/home/foo' } })
+    fireEvent.blur(input)
+    expect(useHostSettingsStore.getState().get('h2', 'editor')).toBeUndefined()
+  })
+
+  it('renders null when ctx.scope is not host', () => {
+    const wrongCtx = { scope: 'workspace', workspaceId: 'wsA' } as unknown as SettingsContextFor<'host'>
+    const { container } = render(<EditorHomePathHostSection ctx={wrongCtx} />)
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/spa/src/components/editor/EditorHomePathHostSection.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.tsx
@@ -23,6 +23,10 @@ function Body({ hostId }: { hostId: string }) {
 
   const commit = () => {
     const trimmed = draft.trim()
+    // Reflect normalization in the input even when the trimmed value matches
+    // the stored one — otherwise trailing whitespace lingers in the UI while
+    // persisted state is clean.
+    if (trimmed !== draft) setDraft(trimmed)
     if (trimmed === storedStr) return
     if (trimmed === '') {
       useHostSettingsStore.getState().clearModule(hostId, 'editor')

--- a/spa/src/components/editor/EditorHomePathHostSection.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useId } from 'react'
+import { useState, useEffect, useId, useRef } from 'react'
 import { useHostSettingsStore } from '../../stores/useHostSettingsStore'
 import { useI18nStore } from '../../stores/useI18nStore'
 import type { SettingsContextFor } from '../../lib/settings-contribution-types'
@@ -18,8 +18,17 @@ function Body({ hostId }: { hostId: string }) {
   const storedStr = typeof stored === 'string' ? stored : ''
   const [draft, setDraft] = useState(storedStr)
   const inputId = useId()
+  const focusedRef = useRef(false)
 
-  useEffect(() => { setDraft(storedStr) }, [storedStr])
+  // R2 codex: skip the sync while the user is editing so an external store
+  // update (e.g. BroadcastChannel from another window) can't clobber the
+  // in-progress draft. Focused edits reconcile against the latest store
+  // value in commit(), which re-reads getState() at blur.
+  useEffect(() => {
+    if (focusedRef.current) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setDraft(storedStr)
+  }, [storedStr])
 
   const commit = () => {
     const trimmed = draft.trim()
@@ -27,7 +36,11 @@ function Body({ hostId }: { hostId: string }) {
     // the stored one — otherwise trailing whitespace lingers in the UI while
     // persisted state is clean.
     if (trimmed !== draft) setDraft(trimmed)
-    if (trimmed === storedStr) return
+    // Re-read the latest stored value — the snapshot captured at render can
+    // be stale if the store changed during editing (R2 codex).
+    const live = useHostSettingsStore.getState().hosts[hostId]?.editor?.homePath
+    const liveStr = typeof live === 'string' ? live : ''
+    if (trimmed === liveStr) return
     if (trimmed === '') {
       // R2 codex: only drop the homePath key — `clearModule` would wipe any
       // sibling editor settings (wrap / tabSize / ...) stored in the same bucket.
@@ -55,7 +68,8 @@ function Body({ hostId }: { hostId: string }) {
           placeholder={t('editor.settings.home_path.placeholder')}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
-          onBlur={commit}
+          onFocus={() => { focusedRef.current = true }}
+          onBlur={() => { focusedRef.current = false; commit() }}
           onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
           className="flex-1 px-3 py-2 rounded-md bg-surface-muted text-text-primary border border-border-subtle focus:border-accent focus:outline-none text-sm"
         />

--- a/spa/src/components/editor/EditorHomePathHostSection.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.tsx
@@ -29,7 +29,9 @@ function Body({ hostId }: { hostId: string }) {
     if (trimmed !== draft) setDraft(trimmed)
     if (trimmed === storedStr) return
     if (trimmed === '') {
-      useHostSettingsStore.getState().clearModule(hostId, 'editor')
+      // R2 codex: only drop the homePath key — `clearModule` would wipe any
+      // sibling editor settings (wrap / tabSize / ...) stored in the same bucket.
+      useHostSettingsStore.getState().removeKey(hostId, 'editor', 'homePath')
       return
     }
     useHostSettingsStore.getState().set(hostId, 'editor', { homePath: trimmed })
@@ -37,7 +39,7 @@ function Body({ hostId }: { hostId: string }) {
 
   const clear = () => {
     setDraft('')
-    useHostSettingsStore.getState().clearModule(hostId, 'editor')
+    useHostSettingsStore.getState().removeKey(hostId, 'editor', 'homePath')
   }
 
   return (

--- a/spa/src/components/editor/EditorHomePathHostSection.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.tsx
@@ -19,6 +19,7 @@ function Body({ hostId }: { hostId: string }) {
   const [draft, setDraft] = useState(storedStr)
   const inputId = useId()
   const focusedRef = useRef(false)
+  const dirtyRef = useRef(false)
 
   // R2 codex: skip the sync while the user is editing so an external store
   // update (e.g. BroadcastChannel from another window) can't clobber the
@@ -29,6 +30,21 @@ function Body({ hostId }: { hostId: string }) {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setDraft(storedStr)
   }, [storedStr])
+
+  const handleBlur = () => {
+    focusedRef.current = false
+    if (!dirtyRef.current) {
+      // R3 codex: focus-without-edit must not push the stale draft back to
+      // the store. If the store changed during the focus window (e.g.
+      // another window wrote via BroadcastChannel), pull the latest value
+      // into the input instead of clobbering it.
+      const live = useHostSettingsStore.getState().hosts[hostId]?.editor?.homePath
+      setDraft(typeof live === 'string' ? live : '')
+      return
+    }
+    dirtyRef.current = false
+    commit()
+  }
 
   const commit = () => {
     const trimmed = draft.trim()
@@ -52,6 +68,7 @@ function Body({ hostId }: { hostId: string }) {
 
   const clear = () => {
     setDraft('')
+    dirtyRef.current = false
     useHostSettingsStore.getState().removeKey(hostId, 'editor', 'homePath')
   }
 
@@ -67,9 +84,9 @@ function Body({ hostId }: { hostId: string }) {
           aria-label={t('editor.settings.home_path.host')}
           placeholder={t('editor.settings.home_path.placeholder')}
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => { setDraft(e.target.value); dirtyRef.current = true }}
           onFocus={() => { focusedRef.current = true }}
-          onBlur={() => { focusedRef.current = false; commit() }}
+          onBlur={handleBlur}
           onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
           className="flex-1 px-3 py-2 rounded-md bg-surface-muted text-text-primary border border-border-subtle focus:border-accent focus:outline-none text-sm"
         />

--- a/spa/src/components/editor/EditorHomePathHostSection.tsx
+++ b/spa/src/components/editor/EditorHomePathHostSection.tsx
@@ -1,0 +1,67 @@
+import { useState, useEffect, useId } from 'react'
+import { useHostSettingsStore } from '../../stores/useHostSettingsStore'
+import { useI18nStore } from '../../stores/useI18nStore'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
+
+interface Props {
+  ctx: SettingsContextFor<'host'>
+}
+
+export function EditorHomePathHostSection({ ctx }: Props) {
+  if (ctx.scope !== 'host') return null
+  return <Body hostId={ctx.hostId} />
+}
+
+function Body({ hostId }: { hostId: string }) {
+  const t = useI18nStore((s) => s.t)
+  const stored = useHostSettingsStore((s) => s.hosts[hostId]?.editor?.homePath)
+  const storedStr = typeof stored === 'string' ? stored : ''
+  const [draft, setDraft] = useState(storedStr)
+  const inputId = useId()
+
+  useEffect(() => { setDraft(storedStr) }, [storedStr])
+
+  const commit = () => {
+    const trimmed = draft.trim()
+    if (trimmed === storedStr) return
+    if (trimmed === '') {
+      useHostSettingsStore.getState().clearModule(hostId, 'editor')
+      return
+    }
+    useHostSettingsStore.getState().set(hostId, 'editor', { homePath: trimmed })
+  }
+
+  const clear = () => {
+    setDraft('')
+    useHostSettingsStore.getState().clearModule(hostId, 'editor')
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs text-text-muted">
+        {t('editor.settings.home_path.description')}
+      </p>
+      <div className="flex gap-2">
+        <input
+          id={inputId}
+          type="text"
+          aria-label={t('editor.settings.home_path.host')}
+          placeholder={t('editor.settings.home_path.placeholder')}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+          className="flex-1 px-3 py-2 rounded-md bg-surface-muted text-text-primary border border-border-subtle focus:border-accent focus:outline-none text-sm"
+        />
+        <button
+          type="button"
+          onClick={clear}
+          disabled={storedStr === ''}
+          className="px-3 py-2 rounded-md border border-border-subtle text-sm text-text-secondary hover:bg-surface-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+        >
+          {t('editor.settings.home_path.clear')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
@@ -81,4 +81,30 @@ describe('EditorHomePathWorkspaceSection', () => {
     expect(input.value).toBe('')
     expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toBeUndefined()
   })
+
+  it('Clear only drops homePath, preserving sibling editor settings (R2 codex)', () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', {
+      homePath: '/Users/x',
+      wrap: true,
+      tabSize: 4,
+    })
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    fireEvent.click(screen.getByRole('button', { name: /clear|清除/i }))
+    expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toEqual({
+      wrap: true,
+      tabSize: 4,
+    })
+  })
+
+  it('Blur-to-empty only drops homePath, preserving sibling editor settings (R2 codex)', () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', {
+      homePath: '/Users/x',
+      wrap: true,
+    })
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+    expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toEqual({ wrap: true })
+  })
 })

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
@@ -62,4 +62,23 @@ describe('EditorHomePathWorkspaceSection', () => {
     const { container } = render(<EditorHomePathWorkspaceSection ctx={wrongCtx} />)
     expect(container.innerHTML).toBe('')
   })
+
+  it('normalizes trailing whitespace back to the input on blur (R1 codex)', () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/x' })
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '/Users/x ' } })
+    fireEvent.blur(input)
+    expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toEqual({ homePath: '/Users/x' })
+    expect(input.value).toBe('/Users/x')
+  })
+
+  it('normalizes pure-whitespace input to empty on blur when nothing is stored', () => {
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.blur(input)
+    expect(input.value).toBe('')
+    expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toBeUndefined()
+  })
 })

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
@@ -132,4 +132,17 @@ describe('EditorHomePathWorkspaceSection', () => {
     fireEvent.blur(input)
     expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toEqual({ homePath: '/Users/new' })
   })
+
+  it('focus-without-edit + external sync + blur pulls in the new value (R3 codex)', () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/old' })
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.focus(input)
+    act(() => {
+      useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/external' })
+    })
+    fireEvent.blur(input)
+    expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toEqual({ homePath: '/Users/external' })
+    expect(input.value).toBe('/Users/external')
+  })
 })

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react'
 
 vi.mock('../../lib/storage/sync', () => ({
   syncManager: { register: vi.fn(), notify: vi.fn(), destroy: vi.fn() },
@@ -106,5 +106,30 @@ describe('EditorHomePathWorkspaceSection', () => {
     fireEvent.change(input, { target: { value: '' } })
     fireEvent.blur(input)
     expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toEqual({ wrap: true })
+  })
+
+  it('does not clobber the draft while focused when store syncs externally (R2 codex)', () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/old' })
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '/Users/draft' } })
+    act(() => {
+      useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/external' })
+    })
+    expect(input.value).toBe('/Users/draft')
+  })
+
+  it('commit() reads the latest store value, not the render-time snapshot (R2 codex)', () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/old' })
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '/Users/new' } })
+    act(() => {
+      useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/new' })
+    })
+    fireEvent.blur(input)
+    expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toEqual({ homePath: '/Users/new' })
   })
 })

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+vi.mock('../../lib/storage/sync', () => ({
+  syncManager: { register: vi.fn(), notify: vi.fn(), destroy: vi.fn() },
+  createSyncManager: vi.fn(),
+}))
+
+import { EditorHomePathWorkspaceSection } from './EditorHomePathWorkspaceSection'
+import { useWorkspaceSettingsStore } from '../../stores/useWorkspaceSettingsStore'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
+
+const ctx: SettingsContextFor<'workspace'> = { scope: 'workspace', workspaceId: 'wsA' }
+
+beforeEach(() => {
+  cleanup()
+  localStorage.clear()
+  useWorkspaceSettingsStore.setState({ workspaces: {} })
+})
+
+describe('EditorHomePathWorkspaceSection', () => {
+  it('renders placeholder when no value is stored', () => {
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    expect(input.value).toBe('')
+    expect(input.placeholder.length).toBeGreaterThan(0)
+  })
+
+  it('renders stored value', () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/x' })
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    expect(input.value).toBe('/Users/x')
+  })
+
+  it('writes to workspace store on change (commit on blur)', () => {
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '/Users/foo' } })
+    fireEvent.blur(input)
+    expect(useWorkspaceSettingsStore.getState().get('wsA', 'editor')).toEqual({ homePath: '/Users/foo' })
+  })
+
+  it('Clear button removes stored homePath', () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/x' })
+    render(<EditorHomePathWorkspaceSection ctx={ctx} />)
+    fireEvent.click(screen.getByRole('button', { name: /clear|清除/i }))
+    const after = useWorkspaceSettingsStore.getState().get('wsA', 'editor')
+    expect(after?.homePath).toBeUndefined()
+  })
+
+  it('isolates writes between workspaces', () => {
+    render(<EditorHomePathWorkspaceSection ctx={{ scope: 'workspace', workspaceId: 'wsA' }} />)
+    const input = screen.getByLabelText(/home path/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '/Users/foo' } })
+    fireEvent.blur(input)
+    expect(useWorkspaceSettingsStore.getState().get('wsB', 'editor')).toBeUndefined()
+  })
+
+  it('renders null when ctx.scope is not workspace', () => {
+    const wrongCtx = { scope: 'host', hostId: 'h1', runtime: undefined } as unknown as SettingsContextFor<'workspace'>
+    const { container } = render(<EditorHomePathWorkspaceSection ctx={wrongCtx} />)
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useId } from 'react'
+import { useState, useEffect, useId, useRef } from 'react'
 import { useWorkspaceSettingsStore } from '../../stores/useWorkspaceSettingsStore'
 import { useI18nStore } from '../../stores/useI18nStore'
 import type { SettingsContextFor } from '../../lib/settings-contribution-types'
@@ -18,8 +18,17 @@ function Body({ workspaceId }: { workspaceId: string }) {
   const storedStr = typeof stored === 'string' ? stored : ''
   const [draft, setDraft] = useState(storedStr)
   const inputId = useId()
+  const focusedRef = useRef(false)
 
-  useEffect(() => { setDraft(storedStr) }, [storedStr])
+  // R2 codex: skip the sync while the user is editing so an external store
+  // update (e.g. BroadcastChannel from another window) can't clobber the
+  // in-progress draft. Focused edits reconcile against the latest store
+  // value in commit(), which re-reads getState() at blur.
+  useEffect(() => {
+    if (focusedRef.current) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setDraft(storedStr)
+  }, [storedStr])
 
   const commit = () => {
     const trimmed = draft.trim()
@@ -27,7 +36,11 @@ function Body({ workspaceId }: { workspaceId: string }) {
     // the stored one — otherwise trailing whitespace lingers in the UI while
     // persisted state is clean.
     if (trimmed !== draft) setDraft(trimmed)
-    if (trimmed === storedStr) return
+    // Re-read the latest stored value — the snapshot captured at render can
+    // be stale if the store changed during editing (R2 codex).
+    const live = useWorkspaceSettingsStore.getState().workspaces[workspaceId]?.editor?.homePath
+    const liveStr = typeof live === 'string' ? live : ''
+    if (trimmed === liveStr) return
     if (trimmed === '') {
       // R2 codex: only drop the homePath key — `clearModule` would wipe any
       // sibling editor settings (wrap / tabSize / ...) stored in the same bucket.
@@ -55,7 +68,8 @@ function Body({ workspaceId }: { workspaceId: string }) {
           placeholder={t('editor.settings.home_path.placeholder')}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
-          onBlur={commit}
+          onFocus={() => { focusedRef.current = true }}
+          onBlur={() => { focusedRef.current = false; commit() }}
           onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
           className="flex-1 px-3 py-2 rounded-md bg-surface-muted text-text-primary border border-border-subtle focus:border-accent focus:outline-none text-sm"
         />

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
@@ -1,0 +1,67 @@
+import { useState, useEffect, useId } from 'react'
+import { useWorkspaceSettingsStore } from '../../stores/useWorkspaceSettingsStore'
+import { useI18nStore } from '../../stores/useI18nStore'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
+
+interface Props {
+  ctx: SettingsContextFor<'workspace'>
+}
+
+export function EditorHomePathWorkspaceSection({ ctx }: Props) {
+  if (ctx.scope !== 'workspace') return null
+  return <Body workspaceId={ctx.workspaceId} />
+}
+
+function Body({ workspaceId }: { workspaceId: string }) {
+  const t = useI18nStore((s) => s.t)
+  const stored = useWorkspaceSettingsStore((s) => s.workspaces[workspaceId]?.editor?.homePath)
+  const storedStr = typeof stored === 'string' ? stored : ''
+  const [draft, setDraft] = useState(storedStr)
+  const inputId = useId()
+
+  useEffect(() => { setDraft(storedStr) }, [storedStr])
+
+  const commit = () => {
+    const trimmed = draft.trim()
+    if (trimmed === storedStr) return
+    if (trimmed === '') {
+      useWorkspaceSettingsStore.getState().clearModule(workspaceId, 'editor')
+      return
+    }
+    useWorkspaceSettingsStore.getState().set(workspaceId, 'editor', { homePath: trimmed })
+  }
+
+  const clear = () => {
+    setDraft('')
+    useWorkspaceSettingsStore.getState().clearModule(workspaceId, 'editor')
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs text-text-muted">
+        {t('editor.settings.home_path.description')}
+      </p>
+      <div className="flex gap-2">
+        <input
+          id={inputId}
+          type="text"
+          aria-label={t('editor.settings.home_path.workspace')}
+          placeholder={t('editor.settings.home_path.placeholder')}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+          className="flex-1 px-3 py-2 rounded-md bg-surface-muted text-text-primary border border-border-subtle focus:border-accent focus:outline-none text-sm"
+        />
+        <button
+          type="button"
+          onClick={clear}
+          disabled={storedStr === ''}
+          className="px-3 py-2 rounded-md border border-border-subtle text-sm text-text-secondary hover:bg-surface-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+        >
+          {t('editor.settings.home_path.clear')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
@@ -29,7 +29,9 @@ function Body({ workspaceId }: { workspaceId: string }) {
     if (trimmed !== draft) setDraft(trimmed)
     if (trimmed === storedStr) return
     if (trimmed === '') {
-      useWorkspaceSettingsStore.getState().clearModule(workspaceId, 'editor')
+      // R2 codex: only drop the homePath key — `clearModule` would wipe any
+      // sibling editor settings (wrap / tabSize / ...) stored in the same bucket.
+      useWorkspaceSettingsStore.getState().removeKey(workspaceId, 'editor', 'homePath')
       return
     }
     useWorkspaceSettingsStore.getState().set(workspaceId, 'editor', { homePath: trimmed })
@@ -37,7 +39,7 @@ function Body({ workspaceId }: { workspaceId: string }) {
 
   const clear = () => {
     setDraft('')
-    useWorkspaceSettingsStore.getState().clearModule(workspaceId, 'editor')
+    useWorkspaceSettingsStore.getState().removeKey(workspaceId, 'editor', 'homePath')
   }
 
   return (

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
@@ -23,6 +23,10 @@ function Body({ workspaceId }: { workspaceId: string }) {
 
   const commit = () => {
     const trimmed = draft.trim()
+    // Reflect normalization in the input even when the trimmed value matches
+    // the stored one — otherwise trailing whitespace lingers in the UI while
+    // persisted state is clean.
+    if (trimmed !== draft) setDraft(trimmed)
     if (trimmed === storedStr) return
     if (trimmed === '') {
       useWorkspaceSettingsStore.getState().clearModule(workspaceId, 'editor')

--- a/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
+++ b/spa/src/components/editor/EditorHomePathWorkspaceSection.tsx
@@ -19,6 +19,7 @@ function Body({ workspaceId }: { workspaceId: string }) {
   const [draft, setDraft] = useState(storedStr)
   const inputId = useId()
   const focusedRef = useRef(false)
+  const dirtyRef = useRef(false)
 
   // R2 codex: skip the sync while the user is editing so an external store
   // update (e.g. BroadcastChannel from another window) can't clobber the
@@ -29,6 +30,21 @@ function Body({ workspaceId }: { workspaceId: string }) {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setDraft(storedStr)
   }, [storedStr])
+
+  const handleBlur = () => {
+    focusedRef.current = false
+    if (!dirtyRef.current) {
+      // R3 codex: focus-without-edit must not push the stale draft back to
+      // the store. If the store changed during the focus window (e.g.
+      // another window wrote via BroadcastChannel), pull the latest value
+      // into the input instead of clobbering it.
+      const live = useWorkspaceSettingsStore.getState().workspaces[workspaceId]?.editor?.homePath
+      setDraft(typeof live === 'string' ? live : '')
+      return
+    }
+    dirtyRef.current = false
+    commit()
+  }
 
   const commit = () => {
     const trimmed = draft.trim()
@@ -52,6 +68,7 @@ function Body({ workspaceId }: { workspaceId: string }) {
 
   const clear = () => {
     setDraft('')
+    dirtyRef.current = false
     useWorkspaceSettingsStore.getState().removeKey(workspaceId, 'editor', 'homePath')
   }
 
@@ -67,9 +84,9 @@ function Body({ workspaceId }: { workspaceId: string }) {
           aria-label={t('editor.settings.home_path.workspace')}
           placeholder={t('editor.settings.home_path.placeholder')}
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => { setDraft(e.target.value); dirtyRef.current = true }}
           onFocus={() => { focusedRef.current = true }}
-          onBlur={() => { focusedRef.current = false; commit() }}
+          onBlur={handleBlur}
           onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
           className="flex-1 px-3 py-2 rounded-md bg-surface-muted text-text-primary border border-border-subtle focus:border-accent focus:outline-none text-sm"
         />

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -251,4 +251,10 @@ export function resetSettingsContributionsForHmr(): void {
   clearContributions()
   clearLegacyPending()
   clearHostBuiltinSources()
+  // R2 codex: also clear the deprecation-warn dedupe set. Without this, a
+  // module author who temporarily removed and then re-added a legacy
+  // `globalConfig` / `workspaceConfig` declaration during an HMR session
+  // would never see the warning again — the dedupe key persists across
+  // reloads even though the rest of the registry is freshly rebuilt.
+  warnedDeprecationKeys.clear()
 }

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -213,11 +213,6 @@ export function buildSettingsContributionBatch(
 export function dispatchSettingsContributions(
   modules: ModuleDefinition[] = getModules(),
 ): void {
-  // PR-5 deprecation warnings: detect legacy API usage before validation.
-  // Runs only when Phase 1 succeeds (wrapped below) to avoid noise on
-  // validation failures that would otherwise be retried.
-  warnLegacyConfigDeprecations(modules)
-
   // Phase 1 — validate without mutating. Throws on any collision (F1) or
   // invariant violation. The legacy queue is peeked, not drained.
   const batch = buildSettingsContributionBatch(modules)
@@ -234,6 +229,11 @@ export function dispatchSettingsContributions(
   for (const contribution of batch) {
     registerSettingsContribution(contribution)
   }
+
+  // PR-5 deprecation warnings: emit only after a successful dispatch so a
+  // validation-failed pass doesn't silently burn the dedupe key for the
+  // successful retry.
+  warnLegacyConfigDeprecations(modules)
 }
 
 /**

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -25,6 +25,41 @@ import type {
 // moduleId. Centralized so PR-3/4 can reuse the same pattern.
 const LEGACY_SECTION_MODULE_ID = '_builtin.legacy-section'
 
+// PR-5 deprecation: module authors using `globalConfig` / `workspaceConfig`
+// should migrate to `settings: [{ scope, localId }]`. `files` is exempt until
+// the files owner completes its refactor.
+const DEPRECATED_LEGACY_CONFIG_EXEMPT: ReadonlySet<string> = new Set(['files'])
+const warnedDeprecationKeys = new Set<string>()
+
+function warnLegacyConfigDeprecations(modules: readonly ModuleDefinition[]): void {
+  for (const m of modules) {
+    if (DEPRECATED_LEGACY_CONFIG_EXEMPT.has(m.id)) continue
+    if (m.globalConfig && m.globalConfig.length > 0) {
+      const key = `${m.id}:global`
+      if (!warnedDeprecationKeys.has(key)) {
+        warnedDeprecationKeys.add(key)
+        console.warn(
+          `[module] ${m.id} uses deprecated globalConfig; migrate to settings: [{ scope: 'purdex', localId }]`,
+        )
+      }
+    }
+    if (m.workspaceConfig && m.workspaceConfig.length > 0) {
+      const key = `${m.id}:workspace`
+      if (!warnedDeprecationKeys.has(key)) {
+        warnedDeprecationKeys.add(key)
+        console.warn(
+          `[module] ${m.id} uses deprecated workspaceConfig; migrate to settings: [{ scope: 'workspace', localId }]`,
+        )
+      }
+    }
+  }
+}
+
+// Test-only reset — exposed so dedupe state doesn't leak across test cases.
+export function resetDeprecationWarningsForTest(): void {
+  warnedDeprecationKeys.clear()
+}
+
 function assertNoLegacyScopeConflict(module: ModuleDefinition): void {
   const settings = module.settings
   if (!settings || settings.length === 0) return
@@ -178,6 +213,11 @@ export function buildSettingsContributionBatch(
 export function dispatchSettingsContributions(
   modules: ModuleDefinition[] = getModules(),
 ): void {
+  // PR-5 deprecation warnings: detect legacy API usage before validation.
+  // Runs only when Phase 1 succeeds (wrapped below) to avoid noise on
+  // validation failures that would otherwise be retried.
+  warnLegacyConfigDeprecations(modules)
+
   // Phase 1 — validate without mutating. Throws on any collision (F1) or
   // invariant violation. The legacy queue is peeked, not drained.
   const batch = buildSettingsContributionBatch(modules)

--- a/spa/src/lib/editor-home-resolver.test.ts
+++ b/spa/src/lib/editor-home-resolver.test.ts
@@ -65,13 +65,14 @@ describe('resolveEditorHomePath', () => {
     expect(out).toBeNull()
   })
 
-  it('returns null when fetchPaneHome rejects', async () => {
+  it('propagates fetchPaneHome rejection so callers can warn with context', async () => {
     const deps = makeDeps({ fetchPaneHome: vi.fn(async () => { throw new Error('boom') }) })
-    const out = await resolveEditorHomePath(
-      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' },
-      deps,
-    )
-    expect(out).toBeNull()
+    await expect(
+      resolveEditorHomePath(
+        { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' },
+        deps,
+      ),
+    ).rejects.toThrow('boom')
   })
 
   it('treats empty workspace string as unset and falls through to host', async () => {

--- a/spa/src/lib/editor-home-resolver.test.ts
+++ b/spa/src/lib/editor-home-resolver.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../lib/storage/sync', () => ({
+  syncManager: { register: vi.fn(), notify: vi.fn(), destroy: vi.fn() },
+  createSyncManager: vi.fn(),
+}))
+
+import { resolveEditorHomePath, type EditorHomeResolverDeps } from './editor-home-resolver'
+import { useHostSettingsStore } from '../stores/useHostSettingsStore'
+import { useWorkspaceSettingsStore } from '../stores/useWorkspaceSettingsStore'
+
+function makeDeps(over?: Partial<EditorHomeResolverDeps>): EditorHomeResolverDeps {
+  return {
+    fetchPaneHome: vi.fn(async () => ''),
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  useHostSettingsStore.setState({ hosts: {} })
+  useWorkspaceSettingsStore.setState({ workspaces: {} })
+})
+
+describe('resolveEditorHomePath', () => {
+  it('prefers workspace value when workspaceId set and workspace has value', async () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/ws' })
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/Users/host' })
+    const deps = makeDeps({ fetchPaneHome: vi.fn(async () => '/Users/shell') })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' },
+      deps,
+    )
+    expect(out).toBe('/Users/ws')
+    expect(deps.fetchPaneHome).not.toHaveBeenCalled()
+  })
+
+  it('falls through to host when workspace is empty', async () => {
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/Users/host' })
+    const deps = makeDeps({ fetchPaneHome: vi.fn(async () => '/Users/shell') })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' },
+      deps,
+    )
+    expect(out).toBe('/Users/host')
+    expect(deps.fetchPaneHome).not.toHaveBeenCalled()
+  })
+
+  it('falls through to fetchPaneHome when workspace and host empty', async () => {
+    const deps = makeDeps({ fetchPaneHome: vi.fn(async () => '/Users/shell') })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' },
+      deps,
+    )
+    expect(out).toBe('/Users/shell')
+    expect(deps.fetchPaneHome).toHaveBeenCalledWith('h1', 's1', undefined)
+  })
+
+  it('returns null when all three layers yield nothing (fetchPaneHome returns empty)', async () => {
+    const deps = makeDeps({ fetchPaneHome: vi.fn(async () => '') })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' },
+      deps,
+    )
+    expect(out).toBeNull()
+  })
+
+  it('returns null when fetchPaneHome rejects', async () => {
+    const deps = makeDeps({ fetchPaneHome: vi.fn(async () => { throw new Error('boom') }) })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' },
+      deps,
+    )
+    expect(out).toBeNull()
+  })
+
+  it('treats empty workspace string as unset and falls through to host', async () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '' })
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/Users/host' })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' },
+      makeDeps(),
+    )
+    expect(out).toBe('/Users/host')
+  })
+
+  it('skips workspace layer when workspaceId is undefined (standalone pane)', async () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/ws' })
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/Users/host' })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: undefined },
+      makeDeps(),
+    )
+    expect(out).toBe('/Users/host')
+  })
+
+  it('Finding 4 regression: wrong workspaceId reads that workspace (not the populated one)', async () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/ws-a' })
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/Users/host' })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsB' },
+      makeDeps(),
+    )
+    expect(out).toBe('/Users/host')
+  })
+
+  it('honours AbortSignal: does not call fetchPaneHome when aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const deps = makeDeps({ fetchPaneHome: vi.fn(async () => '/Users/shell') })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA', signal: controller.signal },
+      deps,
+    )
+    expect(out).toBeNull()
+    expect(deps.fetchPaneHome).not.toHaveBeenCalled()
+  })
+
+  it('treats non-absolute workspace/host values as invalid (fallthrough)', async () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: 'relative/ws' })
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: 'relative/host' })
+    const deps = makeDeps({ fetchPaneHome: vi.fn(async () => '/Users/shell') })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA' },
+      deps,
+    )
+    expect(out).toBe('/Users/shell')
+  })
+
+  it('requires hostId: returns null without it', async () => {
+    const out = await resolveEditorHomePath(
+      { hostId: undefined, sessionCode: 's1', workspaceId: 'wsA' },
+      makeDeps(),
+    )
+    expect(out).toBeNull()
+  })
+
+  it('requires sessionCode for fetchPaneHome: returns null if no host/workspace value and sessionCode missing', async () => {
+    const deps = makeDeps({ fetchPaneHome: vi.fn(async () => '/Users/shell') })
+    const out = await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: undefined, workspaceId: 'wsA' },
+      deps,
+    )
+    expect(out).toBeNull()
+    expect(deps.fetchPaneHome).not.toHaveBeenCalled()
+  })
+
+  it('passes abort signal through to fetchPaneHome', async () => {
+    const controller = new AbortController()
+    const deps = makeDeps({ fetchPaneHome: vi.fn(async () => '/Users/shell') })
+    await resolveEditorHomePath(
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'wsA', signal: controller.signal },
+      deps,
+    )
+    expect(deps.fetchPaneHome).toHaveBeenCalledWith('h1', 's1', controller.signal)
+  })
+})

--- a/spa/src/lib/editor-home-resolver.ts
+++ b/spa/src/lib/editor-home-resolver.ts
@@ -1,0 +1,60 @@
+import { useHostSettingsStore } from '../stores/useHostSettingsStore'
+import { useWorkspaceSettingsStore } from '../stores/useWorkspaceSettingsStore'
+
+export interface EditorHomeResolverCtx {
+  hostId?: string
+  sessionCode?: string
+  workspaceId?: string
+  signal?: AbortSignal
+}
+
+export interface EditorHomeResolverDeps {
+  fetchPaneHome(hostId: string, sessionCode: string, signal?: AbortSignal): Promise<string>
+}
+
+function readAbsoluteHomePath(payload: Record<string, unknown> | undefined): string | null {
+  if (!payload) return null
+  const value = payload.homePath
+  if (typeof value !== 'string') return null
+  if (!value.startsWith('/')) return null
+  return value
+}
+
+/**
+ * Resolve the "home" path Editor should use when opening a tilde-prefixed
+ * terminal link. Layered fallback: workspace settings → host settings →
+ * pane shell (`fetchPaneHome`). Returns null when no layer yields a value
+ * or the request has been aborted.
+ *
+ * Callers must pass the link-source `workspaceId` (from
+ * `LinkContext.workspaceId`), not active workspace id. `workspaceId` may be
+ * undefined for panes not attached to any workspace — the workspace layer
+ * is skipped in that case.
+ */
+export async function resolveEditorHomePath(
+  ctx: EditorHomeResolverCtx,
+  deps: EditorHomeResolverDeps,
+): Promise<string | null> {
+  if (ctx.signal?.aborted) return null
+  if (!ctx.hostId) return null
+
+  if (ctx.workspaceId) {
+    const payload = useWorkspaceSettingsStore.getState().get(ctx.workspaceId, 'editor')
+    const ws = readAbsoluteHomePath(payload)
+    if (ws) return ws
+  }
+
+  const hostPayload = useHostSettingsStore.getState().get(ctx.hostId, 'editor')
+  const host = readAbsoluteHomePath(hostPayload)
+  if (host) return host
+
+  if (!ctx.sessionCode) return null
+  if (ctx.signal?.aborted) return null
+  try {
+    const shell = await deps.fetchPaneHome(ctx.hostId, ctx.sessionCode, ctx.signal)
+    if (shell && shell.startsWith('/')) return shell
+    return null
+  } catch {
+    return null
+  }
+}

--- a/spa/src/lib/editor-home-resolver.ts
+++ b/spa/src/lib/editor-home-resolver.ts
@@ -50,11 +50,7 @@ export async function resolveEditorHomePath(
 
   if (!ctx.sessionCode) return null
   if (ctx.signal?.aborted) return null
-  try {
-    const shell = await deps.fetchPaneHome(ctx.hostId, ctx.sessionCode, ctx.signal)
-    if (shell && shell.startsWith('/')) return shell
-    return null
-  } catch {
-    return null
-  }
+  const shell = await deps.fetchPaneHome(ctx.hostId, ctx.sessionCode, ctx.signal)
+  if (shell && shell.startsWith('/')) return shell
+  return null
 }

--- a/spa/src/lib/host-builtin-sections.test.tsx
+++ b/spa/src/lib/host-builtin-sections.test.tsx
@@ -90,19 +90,17 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     clearAll()
   })
 
-  it('registers exactly 6 host-scoped contributions with moduleId _builtin.host', () => {
+  it('registers 6 built-in host-scoped contributions with moduleId _builtin.host', () => {
     registerBuiltinModules()
     const hostContribs = listContributions('host')
-    expect(hostContribs).toHaveLength(6)
-    for (const c of hostContribs) {
-      expect(c.moduleId).toBe(HOST_BUILTIN_MODULE_ID)
-    }
+    const builtinContribs = hostContribs.filter((c) => c.moduleId === HOST_BUILTIN_MODULE_ID)
+    expect(builtinContribs).toHaveLength(6)
   })
 
-  it('orders contributions as: overview, sessions, hooks, agents, uploads, logs', () => {
+  it('orders built-in contributions as: overview, sessions, hooks, agents, uploads, logs', () => {
     registerBuiltinModules()
-    const hostContribs = listContributions('host')
-    const localIds = hostContribs.map((c) => c.localId)
+    const builtinContribs = listContributions('host').filter((c) => c.moduleId === HOST_BUILTIN_MODULE_ID)
+    const localIds = builtinContribs.map((c) => c.localId)
     expect(localIds).toEqual(['overview', 'sessions', 'hooks', 'agents', 'uploads', 'logs'])
   })
 
@@ -158,23 +156,23 @@ describe('§3.3 — registerBuiltinModules: built-in host sub-page contributions
     expect(container.firstChild).toBeNull()
   })
 
-  it('all contributions have correct scope, valid localIds, and labelKey starting with "hosts."', () => {
+  it('built-in contributions have correct scope, valid localIds, and labelKey starting with "hosts."', () => {
     registerBuiltinModules()
-    const hostContribs = listContributions('host')
+    const builtinContribs = listContributions('host').filter((c) => c.moduleId === HOST_BUILTIN_MODULE_ID)
 
-    for (const c of hostContribs) {
+    for (const c of builtinContribs) {
       expect(c.scope).toBe('host')
       expect(c.id).toBe(`${HOST_BUILTIN_MODULE_ID}.${c.localId}`)
       expect(c.labelKey).toMatch(/^hosts\./)
     }
   })
 
-  it('is HMR-safe: re-running registerBuiltinModules after clearAll does not duplicate', () => {
+  it('is HMR-safe: re-running registerBuiltinModules after clearAll keeps built-in count stable', () => {
     registerBuiltinModules()
-    const first = listContributions('host').length
+    const first = listContributions('host').filter((c) => c.moduleId === HOST_BUILTIN_MODULE_ID).length
     clearAll()
     registerBuiltinModules()
-    const second = listContributions('host').length
+    const second = listContributions('host').filter((c) => c.moduleId === HOST_BUILTIN_MODULE_ID).length
     expect(first).toBe(6)
     expect(second).toBe(6)
   })

--- a/spa/src/lib/module-registry.ts
+++ b/spa/src/lib/module-registry.ts
@@ -70,7 +70,9 @@ export interface ModuleDefinition {
   name: string
   panes?: PaneDefinition[]
   views?: ViewDefinition[]
+  /** @deprecated Use `settings: [{ scope: 'workspace', localId }]` instead. Will be removed after the files module migrates. */
   workspaceConfig?: ConfigDef[]
+  /** @deprecated Use `settings: [{ scope: 'purdex', localId }]` instead. Will be removed after all consumers migrate. */
   globalConfig?: ConfigDef[]
   commands?: CommandContribution[]
   settings?: AnySettingsContributionDeclaration[]

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -21,6 +21,7 @@ import {
 } from './settings-section-registry'
 import { clearInterfaceSubsectionRegistry, getInterfaceSubsections } from './interface-subsection-registry'
 import { registerBuiltinModules, dispatchSettingsContributions } from './register-modules'
+import { resetDeprecationWarningsForTest } from './dispatch-settings-contributions'
 import {
   clearContributions,
   listContributions,
@@ -393,5 +394,79 @@ describe('registerBuiltinModules → new contribution registry (PR-2)', () => {
       expect(legacyView).toContain(id)
     }
     expect(legacyView).not.toContain('workspace')
+  })
+})
+
+describe('ModuleDefinition.globalConfig / workspaceConfig deprecation (PR-5)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    clearAll()
+    resetDeprecationWarningsForTest()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    clearAll()
+  })
+
+  it('warns when a non-files module uses globalConfig', () => {
+    registerModule({
+      id: 'fakemod',
+      name: 'Fake',
+      globalConfig: [{ key: 'x', type: 'string', label: 'x' }],
+    })
+    dispatchSettingsContributions()
+    const msgs = (warnSpy.mock.calls as unknown[][]).map((c) => String(c[0]))
+    expect(msgs.some((m: string) => m.includes('fakemod') && m.includes('deprecated'))).toBe(true)
+  })
+
+  it('warns when a non-files module uses workspaceConfig', () => {
+    registerModule({
+      id: 'fakews',
+      name: 'Fake WS',
+      workspaceConfig: [{ key: 'x', type: 'string', label: 'x' }],
+    })
+    dispatchSettingsContributions()
+    const msgs = (warnSpy.mock.calls as unknown[][]).map((c) => String(c[0]))
+    expect(msgs.some((m: string) => m.includes('fakews') && m.includes('deprecated'))).toBe(true)
+  })
+
+  it('does NOT warn for files module (exempted during transition)', () => {
+    registerModule({
+      id: 'files',
+      name: 'Files',
+      workspaceConfig: [{ key: 'projectPath', type: 'string', label: '專案路徑' }],
+    })
+    dispatchSettingsContributions()
+    const msgs = (warnSpy.mock.calls as unknown[][]).map((c) => String(c[0]))
+    expect(msgs.some((m: string) => m.includes('files') && m.includes('deprecated'))).toBe(false)
+  })
+
+  it('does NOT warn for modules using new `settings` field', () => {
+    registerModule({
+      id: 'newmod',
+      name: 'New',
+      settings: [
+        { localId: 'x', scope: 'purdex', order: 0, labelKey: 'x', component: FakeComponent },
+      ],
+    })
+    dispatchSettingsContributions()
+    const msgs = (warnSpy.mock.calls as unknown[][]).map((c) => String(c[0]))
+    expect(msgs.some((m: string) => m.includes('newmod') && m.includes('deprecated'))).toBe(false)
+  })
+
+  it('de-dupes: repeated dispatch for the same module/scope warns only once', () => {
+    registerModule({
+      id: 'dedupe',
+      name: 'Dedupe',
+      globalConfig: [{ key: 'x', type: 'string', label: 'x' }],
+    })
+    dispatchSettingsContributions()
+    dispatchSettingsContributions()
+    dispatchSettingsContributions()
+    const hits = (warnSpy.mock.calls as unknown[][]).filter((c) => String(c[0]).includes('dedupe')).length
+    expect(hits).toBe(1)
   })
 })

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -469,4 +469,37 @@ describe('ModuleDefinition.globalConfig / workspaceConfig deprecation (PR-5)', (
     const hits = (warnSpy.mock.calls as unknown[][]).filter((c) => String(c[0]).includes('dedupe')).length
     expect(hits).toBe(1)
   })
+
+  it('defers the warning until after a successful dispatch (R1 codex)', () => {
+    // Module with I1 violation: both globalConfig AND settings[scope='purdex']
+    registerModule({
+      id: 'retrymod',
+      name: 'Retry',
+      globalConfig: [{ key: 'x', type: 'string', label: 'x' }],
+      settings: [
+        { localId: 'x', scope: 'purdex', order: 0, labelKey: 'x', component: FakeComponent },
+      ],
+    })
+    expect(() => dispatchSettingsContributions()).toThrow()
+    const beforeHits = (warnSpy.mock.calls as unknown[][]).filter(
+      (c) => String(c[0]).includes('retrymod') && String(c[0]).includes('deprecated'),
+    ).length
+    // Prior to the fix, the warn ran BEFORE validation and burnt the dedupe
+    // key even on failed dispatches — the retry would then observe no warn.
+    // With the fix, the failed dispatch emits nothing.
+    expect(beforeHits).toBe(0)
+
+    // Author fixes the conflict and retries. The retry is the first
+    // successful dispatch, so it should emit the deprecation warning.
+    registerModule({
+      id: 'retrymod',
+      name: 'Retry',
+      globalConfig: [{ key: 'x', type: 'string', label: 'x' }],
+    })
+    dispatchSettingsContributions()
+    const afterHits = (warnSpy.mock.calls as unknown[][]).filter(
+      (c) => String(c[0]).includes('retrymod') && String(c[0]).includes('deprecated'),
+    ).length
+    expect(afterHits).toBe(1)
+  })
 })

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -21,7 +21,7 @@ import {
 } from './settings-section-registry'
 import { clearInterfaceSubsectionRegistry, getInterfaceSubsections } from './interface-subsection-registry'
 import { registerBuiltinModules, dispatchSettingsContributions } from './register-modules'
-import { resetDeprecationWarningsForTest } from './dispatch-settings-contributions'
+import { resetDeprecationWarningsForTest, resetSettingsContributionsForHmr } from './dispatch-settings-contributions'
 import {
   clearContributions,
   listContributions,
@@ -468,6 +468,32 @@ describe('ModuleDefinition.globalConfig / workspaceConfig deprecation (PR-5)', (
     dispatchSettingsContributions()
     const hits = (warnSpy.mock.calls as unknown[][]).filter((c) => String(c[0]).includes('dedupe')).length
     expect(hits).toBe(1)
+  })
+
+  it('HMR reset clears the dedupe set so warnings re-emit after reload (R2 codex)', () => {
+    registerModule({
+      id: 'hmrmod',
+      name: 'HMR Mod',
+      globalConfig: [{ key: 'x', type: 'string', label: 'x' }],
+    })
+    dispatchSettingsContributions()
+    const firstHits = (warnSpy.mock.calls as unknown[][]).filter(
+      (c) => String(c[0]).includes('hmrmod') && String(c[0]).includes('deprecated'),
+    ).length
+    expect(firstHits).toBe(1)
+
+    // Simulate HMR dispose + re-register from the rebuilt module graph
+    resetSettingsContributionsForHmr()
+    registerModule({
+      id: 'hmrmod',
+      name: 'HMR Mod',
+      globalConfig: [{ key: 'x', type: 'string', label: 'x' }],
+    })
+    dispatchSettingsContributions()
+    const afterHmrHits = (warnSpy.mock.calls as unknown[][]).filter(
+      (c) => String(c[0]).includes('hmrmod') && String(c[0]).includes('deprecated'),
+    ).length
+    expect(afterHmrHits).toBe(2)
   })
 
   it('defers the warning until after a successful dispatch (R1 codex)', () => {

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -36,6 +36,8 @@ import { ImagePreviewPane } from '../components/editor/ImagePreviewPane'
 import { PdfPreviewPane } from '../components/editor/PdfPreviewPane'
 import { EditorNewTabSection } from '../components/editor/EditorNewTabSection'
 import { BufferListSection } from '../components/editor/BufferListSection'
+import { EditorHomePathWorkspaceSection } from '../components/editor/EditorHomePathWorkspaceSection'
+import { EditorHomePathHostSection } from '../components/editor/EditorHomePathHostSection'
 import { InAppBackend } from './fs-backend-inapp'
 import { DaemonBackend } from './fs-backend-daemon'
 import { LocalBackend } from './fs-backend-local'
@@ -173,6 +175,22 @@ export function registerBuiltinModules(): void {
       { kind: 'editor', component: EditorPane },
       { kind: 'image-preview', component: ImagePreviewPane },
       { kind: 'pdf-preview', component: PdfPreviewPane },
+    ],
+    settings: [
+      {
+        localId: 'workspace-home-path',
+        scope: 'workspace',
+        order: 0,
+        labelKey: 'editor.settings.home_path.workspace',
+        component: EditorHomePathWorkspaceSection,
+      },
+      {
+        localId: 'host-home-path',
+        scope: 'host',
+        order: 100,
+        labelKey: 'editor.settings.home_path.host',
+        component: EditorHomePathHostSection,
+      },
     ],
   })
 

--- a/spa/src/lib/terminal-link/openers/file-path.test.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.test.ts
@@ -81,6 +81,56 @@ describe('file-path opener', () => {
     expect(deps.insertTab).not.toHaveBeenCalled()
   })
 
+  it('inserts into link-source workspace when ctx.workspaceId is set (R2 codex)', async () => {
+    const deps = makeDeps()
+    const o = createFilePathOpener(deps)
+    await o.open(
+      fileToken,
+      { hostId: 'h1', workspaceId: 'ws-source' },
+      new MouseEvent('click'),
+    )
+    expect(deps.insertTab).toHaveBeenCalledWith('tab-1', 'ws-source')
+  })
+
+  it('prefers link-source workspace even when active workspace changes mid-await (R2 codex)', async () => {
+    const deps = makeDeps()
+    // Simulate an active-workspace switch racing the tilde resolve
+    deps.fetchPaneHome.mockImplementationOnce(async () => {
+      deps.getActiveWorkspaceId.mockReturnValue('ws-after')
+      return '/home/user'
+    })
+    const o = createFilePathOpener(deps)
+    await o.open(
+      { ...fileToken, text: '~/x.ts', meta: { path: '~/x.ts' } },
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'ws-source' },
+      new MouseEvent('click'),
+    )
+    expect(deps.insertTab).toHaveBeenCalledWith('tab-1', 'ws-source')
+  })
+
+  it('prefers link-source workspace when active changes during cwd resolve for relative paths (R2 codex)', async () => {
+    const deps = makeDeps()
+    deps.fetchPaneCwd.mockImplementationOnce(async () => {
+      deps.getActiveWorkspaceId.mockReturnValue('ws-after')
+      return '/home/user/proj'
+    })
+    const o = createFilePathOpener(deps)
+    await o.open(
+      { ...fileToken, text: 'rel.ts', meta: { path: 'rel.ts' } },
+      { hostId: 'h1', sessionCode: 's1', workspaceId: 'ws-source' },
+      new MouseEvent('click'),
+    )
+    expect(deps.insertTab).toHaveBeenCalledWith('tab-1', 'ws-source')
+  })
+
+  it('no-op when ctx.workspaceId undefined and active workspace is null (R2 codex)', async () => {
+    const deps = makeDeps()
+    deps.getActiveWorkspaceId.mockReturnValue(null)
+    const o = createFilePathOpener(deps)
+    await o.open(fileToken, { hostId: 'h1' /* no workspaceId */ }, new MouseEvent('click'))
+    expect(deps.insertTab).not.toHaveBeenCalled()
+  })
+
   it('no-op when direct open without meta.path (canOpen bypass)', async () => {
     const deps = makeDeps()
     const o = createFilePathOpener(deps)

--- a/spa/src/lib/terminal-link/openers/file-path.test.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.test.ts
@@ -131,6 +131,24 @@ describe('file-path opener', () => {
     expect(deps.insertTab).not.toHaveBeenCalled()
   })
 
+  it('standalone pane reads active workspace AFTER async resolve (R3 codex)', async () => {
+    const deps = makeDeps()
+    // The fetch flips the live active workspace. A standalone pane (no
+    // ctx.workspaceId) should land in the post-resolve active workspace,
+    // not the click-time snapshot.
+    deps.fetchPaneCwd.mockImplementationOnce(async () => {
+      deps.getActiveWorkspaceId.mockReturnValue('ws-after')
+      return '/home/user/proj'
+    })
+    const o = createFilePathOpener(deps)
+    await o.open(
+      { ...fileToken, text: 'rel.ts', meta: { path: 'rel.ts' } },
+      { hostId: 'h1', sessionCode: 's1' /* no workspaceId */ },
+      new MouseEvent('click'),
+    )
+    expect(deps.insertTab).toHaveBeenCalledWith('tab-1', 'ws-after')
+  })
+
   it('no-op when direct open without meta.path (canOpen bypass)', async () => {
     const deps = makeDeps()
     const o = createFilePathOpener(deps)

--- a/spa/src/lib/terminal-link/openers/file-path.test.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createFilePathOpener } from './file-path'
 import type { LinkToken } from '../types'
 import type { FileOpener } from '../../file-opener-registry'
+import { useHostSettingsStore } from '../../../stores/useHostSettingsStore'
+import { useWorkspaceSettingsStore } from '../../../stores/useWorkspaceSettingsStore'
 
 const fileToken: LinkToken = {
   type: 'file',
@@ -358,5 +360,98 @@ describe('file-path opener — tilde path home resolution', () => {
 
     const createContentCalls = (deps.fakeOpener.createContent as ReturnType<typeof vi.fn>).mock.calls
     expect(createContentCalls[0][1].path).toBe('/Users/foo.ts')
+  })
+})
+
+describe('file-path opener — tilde path layered resolve (PR-5)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    useHostSettingsStore.setState({ hosts: {} })
+    useWorkspaceSettingsStore.setState({ workspaces: {} })
+  })
+  afterEach(() => vi.useRealTimers())
+
+  const tildeToken: LinkToken = {
+    type: 'file',
+    text: '~/foo.ts',
+    range: { startCol: 0, endCol: 8 },
+    meta: { path: '~/foo.ts' },
+  }
+
+  it('workspace override: uses workspace homePath over host and pane shell', async () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/x' })
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/Users/host' })
+    const deps = makeDeps()
+    deps.fetchPaneHome.mockResolvedValueOnce('/Users/shell')
+    const o = createFilePathOpener(deps)
+
+    await o.open(tildeToken, { hostId: 'h1', sessionCode: 'c1', workspaceId: 'wsA' }, new MouseEvent('click'))
+
+    const createContentCalls = (deps.fakeOpener.createContent as ReturnType<typeof vi.fn>).mock.calls
+    expect(createContentCalls[0][1].path).toBe('/Users/x/foo.ts')
+    expect(deps.fetchPaneHome).not.toHaveBeenCalled()
+  })
+
+  it('host override: uses host homePath when workspace empty', async () => {
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/y' })
+    const deps = makeDeps()
+    deps.fetchPaneHome.mockResolvedValueOnce('/Users/shell')
+    const o = createFilePathOpener(deps)
+
+    await o.open(tildeToken, { hostId: 'h1', sessionCode: 'c1', workspaceId: 'wsA' }, new MouseEvent('click'))
+
+    const createContentCalls = (deps.fakeOpener.createContent as ReturnType<typeof vi.fn>).mock.calls
+    expect(createContentCalls[0][1].path).toBe('/home/y/foo.ts')
+    expect(deps.fetchPaneHome).not.toHaveBeenCalled()
+  })
+
+  it('all layers empty + fetchPaneHome rejects: opens raw ~/foo.ts as new buffer', async () => {
+    const deps = makeDeps()
+    deps.fetchPaneHome.mockRejectedValueOnce(new Error('boom'))
+    const o = createFilePathOpener(deps)
+
+    await o.open(tildeToken, { hostId: 'h1', sessionCode: 'c1', workspaceId: 'wsA' }, new MouseEvent('click'))
+
+    const createContentCalls = (deps.fakeOpener.createContent as ReturnType<typeof vi.fn>).mock.calls
+    expect(createContentCalls[0][1].path).toBe('~/foo.ts')
+    expect(deps.openSingletonTab).toHaveBeenCalled()
+  })
+
+  it('multi-workspace: reads link-source workspace (wsB), not active (wsA)', async () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/x' })
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/host' })
+    const deps = makeDeps()
+    const o = createFilePathOpener(deps)
+
+    await o.open(tildeToken, { hostId: 'h1', sessionCode: 'c1', workspaceId: 'wsB' }, new MouseEvent('click'))
+
+    const createContentCalls = (deps.fakeOpener.createContent as ReturnType<typeof vi.fn>).mock.calls
+    expect(createContentCalls[0][1].path).toBe('/home/host/foo.ts')
+    expect(deps.fetchPaneHome).not.toHaveBeenCalled()
+  })
+
+  it('standalone pane (workspaceId undefined): skips workspace layer', async () => {
+    useWorkspaceSettingsStore.getState().set('wsA', 'editor', { homePath: '/Users/x' })
+    useHostSettingsStore.getState().set('h1', 'editor', { homePath: '/home/host' })
+    const deps = makeDeps()
+    const o = createFilePathOpener(deps)
+
+    await o.open(tildeToken, { hostId: 'h1', sessionCode: 'c1' }, new MouseEvent('click'))
+
+    const createContentCalls = (deps.fakeOpener.createContent as ReturnType<typeof vi.fn>).mock.calls
+    expect(createContentCalls[0][1].path).toBe('/home/host/foo.ts')
+    expect(deps.fetchPaneHome).not.toHaveBeenCalled()
+  })
+
+  it('fallback to fetchPaneHome still works (PR #530 regression)', async () => {
+    const deps = makeDeps()
+    deps.fetchPaneHome.mockResolvedValueOnce('/Users/wake')
+    const o = createFilePathOpener(deps)
+
+    await o.open(tildeToken, { hostId: 'h1', sessionCode: 'c1', workspaceId: 'wsA' }, new MouseEvent('click'))
+
+    const createContentCalls = (deps.fakeOpener.createContent as ReturnType<typeof vi.fn>).mock.calls
+    expect(createContentCalls[0][1].path).toBe('/Users/wake/foo.ts')
   })
 })

--- a/spa/src/lib/terminal-link/openers/file-path.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.ts
@@ -2,6 +2,7 @@ import type { LinkOpener } from '../types'
 import type { FileInfo, FileSource } from '../../../types/fs'
 import type { PaneContent } from '../../../types/tab'
 import type { FileOpener } from '../../file-opener-registry'
+import { resolveEditorHomePath } from '../../editor-home-resolver'
 
 export interface FilePathOpenerDeps {
   getDefaultOpener(file: FileInfo): FileOpener | null
@@ -97,10 +98,18 @@ export function createFilePathOpener(deps: FilePathOpenerDeps): LinkOpener {
         const timeoutId = setTimeout(() => controller.abort(), 5000)
         let home: string | null = null
         try {
-          home = await deps.fetchPaneHome(ctx.hostId, ctx.sessionCode, controller.signal)
+          home = await resolveEditorHomePath(
+            {
+              hostId: ctx.hostId,
+              sessionCode: ctx.sessionCode,
+              workspaceId: ctx.workspaceId,
+              signal: controller.signal,
+            },
+            { fetchPaneHome: deps.fetchPaneHome },
+          )
         } catch (err) {
           const reason = (err as Error)?.name === 'AbortError' ? 'timeout' : (err as Error)?.message ?? String(err)
-          console.warn(`[file-path] home fetch failed (${reason}) for host=${ctx.hostId} session=${ctx.sessionCode} path=${rawPath}; opening as new buffer`)
+          console.warn(`[file-path] home resolve failed (${reason}) for host=${ctx.hostId} session=${ctx.sessionCode} path=${rawPath}; opening as new buffer`)
         } finally {
           clearTimeout(timeoutId)
         }

--- a/spa/src/lib/terminal-link/openers/file-path.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.ts
@@ -91,6 +91,15 @@ export function createFilePathOpener(deps: FilePathOpenerDeps): LinkOpener {
       if (typeof rawPath !== 'string') return
       if (!ctx.hostId) return
 
+      // R2 codex: snapshot the tab's target workspace before any await.
+      // Prefer the link-source workspace from LinkContext (plumbed through
+      // SessionPaneContent) so a workspace switch during async path / home
+      // resolution can't place the tab into the wrong workspace. Only fall
+      // back to live active workspace for standalone panes (ctx.workspaceId
+      // undefined).
+      const targetWorkspaceId = ctx.workspaceId ?? deps.getActiveWorkspaceId()
+      if (!targetWorkspaceId) return
+
       let path = rawPath
       if (path.startsWith('~/')) {
         if (!ctx.sessionCode) return
@@ -149,10 +158,8 @@ export function createFilePathOpener(deps: FilePathOpenerDeps): LinkOpener {
       if (!opener) return
       const source: FileSource = { type: 'daemon', hostId: ctx.hostId }
       const content = opener.createContent(source, file)
-      const wsId = deps.getActiveWorkspaceId()
-      if (!wsId) return
       const tabId = deps.openSingletonTab(content)
-      deps.insertTab(tabId, wsId)
+      deps.insertTab(tabId, targetWorkspaceId)
     },
   }
 }

--- a/spa/src/lib/terminal-link/openers/file-path.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.ts
@@ -91,14 +91,12 @@ export function createFilePathOpener(deps: FilePathOpenerDeps): LinkOpener {
       if (typeof rawPath !== 'string') return
       if (!ctx.hostId) return
 
-      // R2 codex: snapshot the tab's target workspace before any await.
-      // Prefer the link-source workspace from LinkContext (plumbed through
-      // SessionPaneContent) so a workspace switch during async path / home
-      // resolution can't place the tab into the wrong workspace. Only fall
-      // back to live active workspace for standalone panes (ctx.workspaceId
-      // undefined).
-      const targetWorkspaceId = ctx.workspaceId ?? deps.getActiveWorkspaceId()
-      if (!targetWorkspaceId) return
+      // R2 + R3 codex: snapshot the link-source workspace from LinkContext
+      // before any await so workspace-owned panes preserve isolation across
+      // a mid-flight switch. Standalone panes (ctx.workspaceId undefined)
+      // legitimately follow the user's current focus, so we *defer* the
+      // active-workspace read until after the async resolve below.
+      const sourceWorkspaceId = ctx.workspaceId
 
       let path = rawPath
       if (path.startsWith('~/')) {
@@ -158,6 +156,8 @@ export function createFilePathOpener(deps: FilePathOpenerDeps): LinkOpener {
       if (!opener) return
       const source: FileSource = { type: 'daemon', hostId: ctx.hostId }
       const content = opener.createContent(source, file)
+      const targetWorkspaceId = sourceWorkspaceId ?? deps.getActiveWorkspaceId()
+      if (!targetWorkspaceId) return
       const tabId = deps.openSingletonTab(content)
       deps.insertTab(tabId, targetWorkspaceId)
     },

--- a/spa/src/lib/terminal-link/types.ts
+++ b/spa/src/lib/terminal-link/types.ts
@@ -26,9 +26,19 @@ export interface LinkToken {
   meta?: Record<string, unknown>
 }
 
+/**
+ * Context injected when a terminal link is dispatched to an opener.
+ *
+ * - `workspaceId` must be the workspace that **owns the link-source pane**,
+ *   not `activeWorkspaceId`. For terminal link usage it is resolved by
+ *   `SessionPaneContent` via `useWorkspaceStore.findWorkspaceByTab(tabId)`
+ *   and passed into `TerminalView` as a prop. Panes not attached to any
+ *   workspace (standalone tabs) leave this `undefined`.
+ */
 export interface LinkContext {
   hostId?: string
   sessionCode?: string
+  workspaceId?: string
 }
 
 export interface LinkMatcher {

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -416,6 +416,11 @@
   "editor.provider_label": "Editor",
   "editor.new_file": "New File",
   "editor.new_markdown": "New Markdown",
+  "editor.settings.home_path.workspace": "Home Path (Workspace)",
+  "editor.settings.home_path.host": "Home Path (Host)",
+  "editor.settings.home_path.description": "Tilde-prefixed paths (~/foo) in terminal links expand against this directory. Workspace overrides host; empty falls back to pane shell.",
+  "editor.settings.home_path.placeholder": "Auto-detect from pane shell",
+  "editor.settings.home_path.clear": "Clear",
 
   "monitor.provider_label": "Memory Monitor",
   "monitor.requires_app": "Requires desktop app",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -416,6 +416,11 @@
   "editor.provider_label": "編輯器",
   "editor.new_file": "新增檔案",
   "editor.new_markdown": "新增 Markdown",
+  "editor.settings.home_path.workspace": "家目錄（Workspace）",
+  "editor.settings.home_path.host": "家目錄（Host）",
+  "editor.settings.home_path.description": "終端機連結中的 ~/foo 會以此目錄展開。Workspace 優先於 Host，未設定則回退到 pane shell。",
+  "editor.settings.home_path.placeholder": "自動偵測 pane shell",
+  "editor.settings.home_path.clear": "清除",
 
   "monitor.provider_label": "記憶體監控",
   "monitor.requires_app": "需要安裝桌面版本",

--- a/spa/src/stores/settings-store-shape.test.ts
+++ b/spa/src/stores/settings-store-shape.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sanitizeFlatModuleMap, sanitizeScopedModuleMap } from './settings-store-shape'
+import { deepFreeze, sanitizeFlatModuleMap, sanitizeScopedModuleMap } from './settings-store-shape'
 
 // Finding C: malformed persisted JSON like `{"__proto__":{"x":1}}` parses into
 // a regular object where `__proto__` / `constructor` / `prototype` are *own*
@@ -78,5 +78,54 @@ describe('sanitizeScopedModuleMap — prototype pollution hardening', () => {
     expect(healed['host-1']).toEqual({ editor: { tabSize: 2 } })
     expect(healed['host-2']).toEqual({ editor: { tabSize: 4 } })
     expect(Object.prototype.hasOwnProperty.call(healed['host-2'], 'constructor')).toBe(false)
+  })
+})
+
+describe('deepFreeze', () => {
+  it('returns primitives and null untouched', () => {
+    expect(deepFreeze(null)).toBe(null)
+    expect(deepFreeze(undefined)).toBe(undefined)
+    expect(deepFreeze(42)).toBe(42)
+    expect(deepFreeze('x')).toBe('x')
+  })
+
+  it('freezes the top-level object', () => {
+    const frozen = deepFreeze({ a: 1 })
+    expect(Object.isFrozen(frozen)).toBe(true)
+  })
+
+  it('freezes nested objects so deep mutation throws in strict mode', () => {
+    const frozen = deepFreeze({ outer: { inner: { x: 1 } } })
+    expect(Object.isFrozen(frozen.outer)).toBe(true)
+    expect(Object.isFrozen(frozen.outer.inner)).toBe(true)
+    expect(() => {
+      ;(frozen.outer.inner as { x: number }).x = 999
+    }).toThrow()
+  })
+
+  it('detaches the returned graph from the input (no ref sharing)', () => {
+    const source = { nested: { x: 1 } }
+    const frozen = deepFreeze(source)
+    expect(frozen).not.toBe(source)
+    expect(frozen.nested).not.toBe(source.nested)
+    // Source stays mutable (we only freeze the returned copy)
+    source.nested.x = 2
+    expect(source.nested.x).toBe(2)
+    expect(frozen.nested.x).toBe(1)
+  })
+
+  it('freezes arrays and array items', () => {
+    const frozen = deepFreeze({ list: [{ a: 1 }, { a: 2 }] })
+    expect(Object.isFrozen(frozen.list)).toBe(true)
+    expect(Object.isFrozen(frozen.list[0])).toBe(true)
+    expect(() => {
+      ;(frozen.list as unknown as { a: number }[])[0].a = 999
+    }).toThrow()
+  })
+
+  it('passes already-frozen inputs through without re-cloning', () => {
+    const input = Object.freeze({ a: 1 })
+    const result = deepFreeze(input)
+    expect(result).toBe(input)
   })
 })

--- a/spa/src/stores/settings-store-shape.test.ts
+++ b/spa/src/stores/settings-store-shape.test.ts
@@ -142,7 +142,23 @@ describe('deepFreeze', () => {
     const frozen = deepFreeze(a)
     expect(Object.isFrozen(frozen)).toBe(true)
     expect(frozen.name).toBe('root')
-    // Cycle is preserved by short-circuiting on revisit
-    expect(frozen.self).toBeDefined()
+    // Cycle resolves to the frozen clone (self-reference preserved + frozen)
+    expect(frozen.self).toBe(frozen)
+    expect(Object.isFrozen(frozen.self!)).toBe(true)
+  })
+
+  it('aliased subgraphs resolve to the same frozen clone, not the mutable original (R3 codex)', () => {
+    const shared = { count: 1 }
+    const input = { a: shared, b: shared }
+    const frozen = deepFreeze(input)
+    // Both slots point to the SAME frozen clone — no mutable original leak
+    expect(frozen.a).toBe(frozen.b)
+    expect(Object.isFrozen(frozen.a)).toBe(true)
+    expect(frozen.a).not.toBe(shared)
+    expect(() => {
+      ;(frozen.b as { count: number }).count = 999
+    }).toThrow()
+    // The original `shared` stays mutable (we only froze the clone)
+    expect(shared.count).toBe(1)
   })
 })

--- a/spa/src/stores/settings-store-shape.test.ts
+++ b/spa/src/stores/settings-store-shape.test.ts
@@ -123,9 +123,26 @@ describe('deepFreeze', () => {
     }).toThrow()
   })
 
-  it('passes already-frozen inputs through without re-cloning', () => {
-    const input = Object.freeze({ a: 1 })
-    const result = deepFreeze(input)
-    expect(result).toBe(input)
+  it('still deep-freezes a shallow-frozen container (no short-circuit on Object.isFrozen)', () => {
+    // Regression (R2 codex): prior impl bailed early on Object.isFrozen(input),
+    // leaving any mutable nested refs intact and still shared with the caller.
+    const shallow = Object.freeze({ nested: { x: 1 } })
+    const result = deepFreeze(shallow)
+    expect(Object.isFrozen(result.nested)).toBe(true)
+    expect(result.nested).not.toBe(shallow.nested)
+    expect(() => {
+      ;(result.nested as { x: number }).x = 999
+    }).toThrow()
+  })
+
+  it('survives cyclic inputs without stack overflow', () => {
+    type Node = { name: string; self?: Node }
+    const a: Node = { name: 'root' }
+    a.self = a
+    const frozen = deepFreeze(a)
+    expect(Object.isFrozen(frozen)).toBe(true)
+    expect(frozen.name).toBe('root')
+    // Cycle is preserved by short-circuiting on revisit
+    expect(frozen.self).toBeDefined()
   })
 })

--- a/spa/src/stores/settings-store-shape.ts
+++ b/spa/src/stores/settings-store-shape.ts
@@ -41,16 +41,19 @@ export function sanitizeScopedModuleMap(value: unknown): ScopedModuleMap {
 }
 
 // Recursively clone + freeze so `get()` consumers can't bypass persist/sync
-// via `snapshot.nested.x = ...`. Primitives and already-frozen refs pass
-// through untouched; plain objects and arrays are shallow-cloned so the
-// returned graph is detached from store-internal state.
-export function deepFreeze<T>(value: T): T {
+// via `snapshot.nested.x = ...`. We never short-circuit on `Object.isFrozen`:
+// a shallow-frozen input (e.g. `Object.freeze({ nested: {...} })`) would still
+// leak a mutable nested ref — the whole point is that the *returned* graph is
+// fully frozen regardless of input shape. A WeakSet breaks cycles so exotic
+// payloads can't blow the stack.
+export function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
   if (value === null || typeof value !== 'object') return value
-  if (Object.isFrozen(value)) return value
+  if (seen.has(value as object)) return value as T
+  seen.add(value as object)
   const clone: unknown = Array.isArray(value)
-    ? (value as unknown[]).map((item) => deepFreeze(item))
+    ? (value as unknown[]).map((item) => deepFreeze(item, seen))
     : Object.fromEntries(
-        Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, deepFreeze(v)]),
+        Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, deepFreeze(v, seen)]),
       )
   return Object.freeze(clone) as T
 }

--- a/spa/src/stores/settings-store-shape.ts
+++ b/spa/src/stores/settings-store-shape.ts
@@ -44,16 +44,31 @@ export function sanitizeScopedModuleMap(value: unknown): ScopedModuleMap {
 // via `snapshot.nested.x = ...`. We never short-circuit on `Object.isFrozen`:
 // a shallow-frozen input (e.g. `Object.freeze({ nested: {...} })`) would still
 // leak a mutable nested ref — the whole point is that the *returned* graph is
-// fully frozen regardless of input shape. A WeakSet breaks cycles so exotic
-// payloads can't blow the stack.
-export function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
+// fully frozen regardless of input shape. The WeakMap maps each original
+// object to its frozen clone, so cycles AND alias graphs (e.g. the same
+// nested object referenced from two parent slots) both resolve to the
+// frozen clone instead of leaking the original mutable ref.
+export function deepFreeze<T>(value: T, seen: WeakMap<object, unknown> = new WeakMap()): T {
   if (value === null || typeof value !== 'object') return value
-  if (seen.has(value as object)) return value as T
-  seen.add(value as object)
-  const clone: unknown = Array.isArray(value)
-    ? (value as unknown[]).map((item) => deepFreeze(item, seen))
-    : Object.fromEntries(
-        Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, deepFreeze(v, seen)]),
-      )
+  const cached = seen.get(value as object)
+  if (cached !== undefined) return cached as T
+
+  const clone: unknown = Array.isArray(value) ? [] : {}
+  // Register before recursing so cycles and aliases see this clone instead of
+  // the original mutable ref.
+  seen.set(value as object, clone)
+
+  if (Array.isArray(value)) {
+    const arr = clone as unknown[]
+    for (let i = 0; i < (value as unknown[]).length; i++) {
+      arr[i] = deepFreeze((value as unknown[])[i], seen)
+    }
+  } else {
+    const obj = clone as Record<string, unknown>
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      obj[k] = deepFreeze(v, seen)
+    }
+  }
+
   return Object.freeze(clone) as T
 }

--- a/spa/src/stores/settings-store-shape.ts
+++ b/spa/src/stores/settings-store-shape.ts
@@ -39,3 +39,18 @@ export function sanitizeScopedModuleMap(value: unknown): ScopedModuleMap {
   }
   return healed
 }
+
+// Recursively clone + freeze so `get()` consumers can't bypass persist/sync
+// via `snapshot.nested.x = ...`. Primitives and already-frozen refs pass
+// through untouched; plain objects and arrays are shallow-cloned so the
+// returned graph is detached from store-internal state.
+export function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value
+  if (Object.isFrozen(value)) return value
+  const clone: unknown = Array.isArray(value)
+    ? (value as unknown[]).map((item) => deepFreeze(item))
+    : Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, deepFreeze(v)]),
+      )
+  return Object.freeze(clone) as T
+}

--- a/spa/src/stores/useGlobalSettingsStore.test.ts
+++ b/spa/src/stores/useGlobalSettingsStore.test.ts
@@ -135,6 +135,19 @@ describe('useGlobalSettingsStore', () => {
       set('editor', { homePath: '/Users/y' })
       expect(get('editor')).toEqual({ homePath: '/Users/y' })
     })
+
+    it('guards against nested mutation (deep freeze)', () => {
+      const { set, get } = useGlobalSettingsStore.getState()
+      set('editor', { config: { nested: { deep: 'original' } } })
+      const snapshot = get('editor') as { config: { nested: { deep: string } } }
+      expect(Object.isFrozen(snapshot.config)).toBe(true)
+      expect(Object.isFrozen(snapshot.config.nested)).toBe(true)
+      expect(() => {
+        snapshot.config.nested.deep = 'hacked'
+      }).toThrow()
+      // Store state is unchanged
+      expect(get('editor')).toEqual({ config: { nested: { deep: 'original' } } })
+    })
   })
 
   it('resets a non-object modules root during rehydrate', async () => {

--- a/spa/src/stores/useGlobalSettingsStore.test.ts
+++ b/spa/src/stores/useGlobalSettingsStore.test.ts
@@ -150,6 +150,31 @@ describe('useGlobalSettingsStore', () => {
     })
   })
 
+  describe('removeKey', () => {
+    it('drops a single key and preserves siblings', () => {
+      const { set, removeKey, get } = useGlobalSettingsStore.getState()
+      set('editor', { homePath: '/Users/x', wrap: true, tabSize: 4 })
+      removeKey('editor', 'homePath')
+      expect(get('editor')).toEqual({ wrap: true, tabSize: 4 })
+    })
+
+    it('removes the whole module bucket when the last key is dropped', () => {
+      const { set, removeKey, get } = useGlobalSettingsStore.getState()
+      set('editor', { homePath: '/Users/x' })
+      removeKey('editor', 'homePath')
+      expect(get('editor')).toBeUndefined()
+    })
+
+    it('is a no-op when the module or key is absent', () => {
+      const { removeKey, get } = useGlobalSettingsStore.getState()
+      removeKey('nope', 'any')
+      expect(get('nope')).toBeUndefined()
+      useGlobalSettingsStore.getState().set('editor', { wrap: true })
+      removeKey('editor', 'homePath')
+      expect(get('editor')).toEqual({ wrap: true })
+    })
+  })
+
   it('resets a non-object modules root during rehydrate', async () => {
     localStorage.setItem(
       STORAGE_KEYS.GLOBAL_SETTINGS,

--- a/spa/src/stores/useGlobalSettingsStore.test.ts
+++ b/spa/src/stores/useGlobalSettingsStore.test.ts
@@ -110,6 +110,33 @@ describe('useGlobalSettingsStore', () => {
     expect(useGlobalSettingsStore.getState().get('valid')).toBeUndefined()
   })
 
+  describe('immutability (#540)', () => {
+    it('get() returns a frozen snapshot', () => {
+      const { set, get } = useGlobalSettingsStore.getState()
+      set('editor', { homePath: '/Users/x' })
+      const snapshot = get('editor')!
+      expect(Object.isFrozen(snapshot)).toBe(true)
+    })
+
+    it('mutating the returned snapshot does not leak into store state', () => {
+      const { set, get } = useGlobalSettingsStore.getState()
+      set('editor', { homePath: '/Users/x' })
+      const snapshot = get('editor')!
+      expect(() => {
+        ;(snapshot as Record<string, unknown>).homePath = '/hacked'
+      }).toThrow()
+      expect(get('editor')).toEqual({ homePath: '/Users/x' })
+    })
+
+    it('set() still patches after prior get() returned frozen snapshot', () => {
+      const { set, get } = useGlobalSettingsStore.getState()
+      set('editor', { homePath: '/Users/x' })
+      void get('editor')
+      set('editor', { homePath: '/Users/y' })
+      expect(get('editor')).toEqual({ homePath: '/Users/y' })
+    })
+  })
+
   it('resets a non-object modules root during rehydrate', async () => {
     localStorage.setItem(
       STORAGE_KEYS.GLOBAL_SETTINGS,

--- a/spa/src/stores/useGlobalSettingsStore.ts
+++ b/spa/src/stores/useGlobalSettingsStore.ts
@@ -9,6 +9,7 @@ interface GlobalSettingsState {
   modules: Record<string, ModulePayload>
   get: (moduleId: string) => ModulePayload | undefined
   set: (moduleId: string, patch: ModulePayload) => void
+  removeKey: (moduleId: string, key: string) => void
   clear: (moduleId?: string) => void
 }
 
@@ -32,6 +33,20 @@ export const useGlobalSettingsStore = create<GlobalSettingsState>()(
             },
           },
         })),
+
+      removeKey: (moduleId, key) =>
+        set((state) => {
+          const current = state.modules[moduleId]
+          if (!current || !(key in current)) return state
+          const { [key]: _omit, ...rest } = current
+          void _omit
+          if (Object.keys(rest).length === 0) {
+            const next = { ...state.modules }
+            delete next[moduleId]
+            return { modules: next }
+          }
+          return { modules: { ...state.modules, [moduleId]: rest } }
+        }),
 
       clear: (moduleId) =>
         set((state) => {

--- a/spa/src/stores/useGlobalSettingsStore.ts
+++ b/spa/src/stores/useGlobalSettingsStore.ts
@@ -17,7 +17,10 @@ export const useGlobalSettingsStore = create<GlobalSettingsState>()(
     (set, get) => ({
       modules: {},
 
-      get: (moduleId) => get().modules[moduleId],
+      get: (moduleId) => {
+        const payload = get().modules[moduleId]
+        return payload ? Object.freeze({ ...payload }) : undefined
+      },
 
       set: (moduleId, patch) =>
         set((state) => ({

--- a/spa/src/stores/useGlobalSettingsStore.ts
+++ b/spa/src/stores/useGlobalSettingsStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
-import { sanitizeFlatModuleMap } from './settings-store-shape'
+import { deepFreeze, sanitizeFlatModuleMap } from './settings-store-shape'
 
 type ModulePayload = Record<string, unknown>
 
@@ -19,7 +19,7 @@ export const useGlobalSettingsStore = create<GlobalSettingsState>()(
 
       get: (moduleId) => {
         const payload = get().modules[moduleId]
-        return payload ? Object.freeze({ ...payload }) : undefined
+        return payload ? deepFreeze(payload) : undefined
       },
 
       set: (moduleId, patch) =>

--- a/spa/src/stores/useHostSettingsStore.test.ts
+++ b/spa/src/stores/useHostSettingsStore.test.ts
@@ -117,6 +117,33 @@ describe('useHostSettingsStore', () => {
     expect(useHostSettingsStore.getState().get('hostA', 'files')).toBeUndefined()
   })
 
+  describe('immutability (#540)', () => {
+    it('get() returns a frozen snapshot', () => {
+      const { set, get } = useHostSettingsStore.getState()
+      set('hostA', 'editor', { homePath: '/home/x' })
+      const snapshot = get('hostA', 'editor')!
+      expect(Object.isFrozen(snapshot)).toBe(true)
+    })
+
+    it('mutating the returned snapshot does not leak into store state', () => {
+      const { set, get } = useHostSettingsStore.getState()
+      set('hostA', 'editor', { homePath: '/home/x' })
+      const snapshot = get('hostA', 'editor')!
+      expect(() => {
+        ;(snapshot as Record<string, unknown>).homePath = '/hacked'
+      }).toThrow()
+      expect(get('hostA', 'editor')).toEqual({ homePath: '/home/x' })
+    })
+
+    it('set() still patches after prior get() returned frozen snapshot', () => {
+      const { set, get } = useHostSettingsStore.getState()
+      set('hostA', 'editor', { homePath: '/home/x' })
+      void get('hostA', 'editor')
+      set('hostA', 'editor', { homePath: '/home/y' })
+      expect(get('hostA', 'editor')).toEqual({ homePath: '/home/y' })
+    })
+  })
+
   it('resets a non-object hosts root during rehydrate', async () => {
     localStorage.setItem(
       STORAGE_KEYS.HOST_SETTINGS,

--- a/spa/src/stores/useHostSettingsStore.test.ts
+++ b/spa/src/stores/useHostSettingsStore.test.ts
@@ -156,6 +156,40 @@ describe('useHostSettingsStore', () => {
     })
   })
 
+  describe('removeKey', () => {
+    it('drops a single key and preserves siblings under the same module', () => {
+      const { set, removeKey, get } = useHostSettingsStore.getState()
+      set('hostA', 'editor', { homePath: '/home/x', wrap: true, tabSize: 4 })
+      removeKey('hostA', 'editor', 'homePath')
+      expect(get('hostA', 'editor')).toEqual({ wrap: true, tabSize: 4 })
+    })
+
+    it('removes the whole module bucket when the last key is dropped', () => {
+      const { set, removeKey, get } = useHostSettingsStore.getState()
+      set('hostA', 'editor', { homePath: '/home/x' })
+      removeKey('hostA', 'editor', 'homePath')
+      expect(get('hostA', 'editor')).toBeUndefined()
+    })
+
+    it('leaves other modules under the same host alone', () => {
+      const { set, removeKey, get } = useHostSettingsStore.getState()
+      set('hostA', 'editor', { homePath: '/home/x' })
+      set('hostA', 'files', { projectPath: '/home/proj' })
+      removeKey('hostA', 'editor', 'homePath')
+      expect(get('hostA', 'editor')).toBeUndefined()
+      expect(get('hostA', 'files')).toEqual({ projectPath: '/home/proj' })
+    })
+
+    it('is a no-op when host, module, or key is absent', () => {
+      const { set, removeKey, get } = useHostSettingsStore.getState()
+      removeKey('missingHost', 'editor', 'homePath')
+      expect(get('missingHost', 'editor')).toBeUndefined()
+      set('hostA', 'editor', { wrap: true })
+      removeKey('hostA', 'editor', 'homePath')
+      expect(get('hostA', 'editor')).toEqual({ wrap: true })
+    })
+  })
+
   it('resets a non-object hosts root during rehydrate', async () => {
     localStorage.setItem(
       STORAGE_KEYS.HOST_SETTINGS,

--- a/spa/src/stores/useHostSettingsStore.test.ts
+++ b/spa/src/stores/useHostSettingsStore.test.ts
@@ -142,6 +142,18 @@ describe('useHostSettingsStore', () => {
       set('hostA', 'editor', { homePath: '/home/y' })
       expect(get('hostA', 'editor')).toEqual({ homePath: '/home/y' })
     })
+
+    it('guards against nested mutation (deep freeze)', () => {
+      const { set, get } = useHostSettingsStore.getState()
+      set('hostA', 'editor', { config: { nested: { deep: 'original' } } })
+      const snapshot = get('hostA', 'editor') as { config: { nested: { deep: string } } }
+      expect(Object.isFrozen(snapshot.config)).toBe(true)
+      expect(Object.isFrozen(snapshot.config.nested)).toBe(true)
+      expect(() => {
+        snapshot.config.nested.deep = 'hacked'
+      }).toThrow()
+      expect(get('hostA', 'editor')).toEqual({ config: { nested: { deep: 'original' } } })
+    })
   })
 
   it('resets a non-object hosts root during rehydrate', async () => {

--- a/spa/src/stores/useHostSettingsStore.ts
+++ b/spa/src/stores/useHostSettingsStore.ts
@@ -10,6 +10,7 @@ interface HostSettingsState {
   hosts: Record<string, HostSlot>
   get: (hostId: string, moduleId: string) => ModulePayload | undefined
   set: (hostId: string, moduleId: string, patch: ModulePayload) => void
+  removeKey: (hostId: string, moduleId: string, key: string) => void
   clearHost: (hostId: string) => void
   clearModule: (hostId: string, moduleId: string) => void
 }
@@ -39,6 +40,22 @@ export const useHostSettingsStore = create<HostSettingsState>()(
               },
             },
           }
+        }),
+
+      removeKey: (hostId, moduleId, key) =>
+        set((state) => {
+          const currentHost = state.hosts[hostId]
+          const currentModule = currentHost?.[moduleId]
+          if (!currentHost || !currentModule || !(key in currentModule)) return state
+          const { [key]: _omit, ...rest } = currentModule
+          void _omit
+          const nextHost = { ...currentHost }
+          if (Object.keys(rest).length === 0) {
+            delete nextHost[moduleId]
+          } else {
+            nextHost[moduleId] = rest
+          }
+          return { hosts: { ...state.hosts, [hostId]: nextHost } }
         }),
 
       clearHost: (hostId) =>

--- a/spa/src/stores/useHostSettingsStore.ts
+++ b/spa/src/stores/useHostSettingsStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
-import { sanitizeScopedModuleMap } from './settings-store-shape'
+import { deepFreeze, sanitizeScopedModuleMap } from './settings-store-shape'
 
 type ModulePayload = Record<string, unknown>
 type HostSlot = Record<string, ModulePayload>
@@ -21,7 +21,7 @@ export const useHostSettingsStore = create<HostSettingsState>()(
 
       get: (hostId, moduleId) => {
         const payload = get().hosts[hostId]?.[moduleId]
-        return payload ? Object.freeze({ ...payload }) : undefined
+        return payload ? deepFreeze(payload) : undefined
       },
 
       set: (hostId, moduleId, patch) =>

--- a/spa/src/stores/useHostSettingsStore.ts
+++ b/spa/src/stores/useHostSettingsStore.ts
@@ -19,7 +19,10 @@ export const useHostSettingsStore = create<HostSettingsState>()(
     (set, get) => ({
       hosts: {},
 
-      get: (hostId, moduleId) => get().hosts[hostId]?.[moduleId],
+      get: (hostId, moduleId) => {
+        const payload = get().hosts[hostId]?.[moduleId]
+        return payload ? Object.freeze({ ...payload }) : undefined
+      },
 
       set: (hostId, moduleId, patch) =>
         set((state) => {

--- a/spa/src/stores/useWorkspaceSettingsStore.test.ts
+++ b/spa/src/stores/useWorkspaceSettingsStore.test.ts
@@ -142,6 +142,18 @@ describe('useWorkspaceSettingsStore', () => {
       set('wsA', 'editor', { homePath: '/Users/y' })
       expect(get('wsA', 'editor')).toEqual({ homePath: '/Users/y' })
     })
+
+    it('guards against nested mutation (deep freeze)', () => {
+      const { set, get } = useWorkspaceSettingsStore.getState()
+      set('wsA', 'editor', { config: { nested: { deep: 'original' } } })
+      const snapshot = get('wsA', 'editor') as { config: { nested: { deep: string } } }
+      expect(Object.isFrozen(snapshot.config)).toBe(true)
+      expect(Object.isFrozen(snapshot.config.nested)).toBe(true)
+      expect(() => {
+        snapshot.config.nested.deep = 'hacked'
+      }).toThrow()
+      expect(get('wsA', 'editor')).toEqual({ config: { nested: { deep: 'original' } } })
+    })
   })
 
   it('resets a non-object workspaces root during rehydrate', async () => {

--- a/spa/src/stores/useWorkspaceSettingsStore.test.ts
+++ b/spa/src/stores/useWorkspaceSettingsStore.test.ts
@@ -156,6 +156,40 @@ describe('useWorkspaceSettingsStore', () => {
     })
   })
 
+  describe('removeKey', () => {
+    it('drops a single key and preserves siblings under the same module', () => {
+      const { set, removeKey, get } = useWorkspaceSettingsStore.getState()
+      set('wsA', 'editor', { homePath: '/Users/x', wrap: true, tabSize: 4 })
+      removeKey('wsA', 'editor', 'homePath')
+      expect(get('wsA', 'editor')).toEqual({ wrap: true, tabSize: 4 })
+    })
+
+    it('removes the whole module bucket when the last key is dropped', () => {
+      const { set, removeKey, get } = useWorkspaceSettingsStore.getState()
+      set('wsA', 'editor', { homePath: '/Users/x' })
+      removeKey('wsA', 'editor', 'homePath')
+      expect(get('wsA', 'editor')).toBeUndefined()
+    })
+
+    it('leaves other modules under the same workspace alone', () => {
+      const { set, removeKey, get } = useWorkspaceSettingsStore.getState()
+      set('wsA', 'editor', { homePath: '/Users/x' })
+      set('wsA', 'files', { projectPath: '/Users/proj' })
+      removeKey('wsA', 'editor', 'homePath')
+      expect(get('wsA', 'editor')).toBeUndefined()
+      expect(get('wsA', 'files')).toEqual({ projectPath: '/Users/proj' })
+    })
+
+    it('is a no-op when workspace, module, or key is absent', () => {
+      const { set, removeKey, get } = useWorkspaceSettingsStore.getState()
+      removeKey('missingWs', 'editor', 'homePath')
+      expect(get('missingWs', 'editor')).toBeUndefined()
+      set('wsA', 'editor', { wrap: true })
+      removeKey('wsA', 'editor', 'homePath')
+      expect(get('wsA', 'editor')).toEqual({ wrap: true })
+    })
+  })
+
   it('resets a non-object workspaces root during rehydrate', async () => {
     localStorage.setItem(
       STORAGE_KEYS.WORKSPACE_SETTINGS,

--- a/spa/src/stores/useWorkspaceSettingsStore.test.ts
+++ b/spa/src/stores/useWorkspaceSettingsStore.test.ts
@@ -117,6 +117,33 @@ describe('useWorkspaceSettingsStore', () => {
     expect(useWorkspaceSettingsStore.getState().get('wsA', 'files')).toBeUndefined()
   })
 
+  describe('immutability (#540)', () => {
+    it('get() returns a frozen snapshot', () => {
+      const { set, get } = useWorkspaceSettingsStore.getState()
+      set('wsA', 'editor', { homePath: '/Users/x' })
+      const snapshot = get('wsA', 'editor')!
+      expect(Object.isFrozen(snapshot)).toBe(true)
+    })
+
+    it('mutating the returned snapshot does not leak into store state', () => {
+      const { set, get } = useWorkspaceSettingsStore.getState()
+      set('wsA', 'editor', { homePath: '/Users/x' })
+      const snapshot = get('wsA', 'editor')!
+      expect(() => {
+        ;(snapshot as Record<string, unknown>).homePath = '/hacked'
+      }).toThrow()
+      expect(get('wsA', 'editor')).toEqual({ homePath: '/Users/x' })
+    })
+
+    it('set() still patches after prior get() returned frozen snapshot', () => {
+      const { set, get } = useWorkspaceSettingsStore.getState()
+      set('wsA', 'editor', { homePath: '/Users/x' })
+      void get('wsA', 'editor')
+      set('wsA', 'editor', { homePath: '/Users/y' })
+      expect(get('wsA', 'editor')).toEqual({ homePath: '/Users/y' })
+    })
+  })
+
   it('resets a non-object workspaces root during rehydrate', async () => {
     localStorage.setItem(
       STORAGE_KEYS.WORKSPACE_SETTINGS,

--- a/spa/src/stores/useWorkspaceSettingsStore.ts
+++ b/spa/src/stores/useWorkspaceSettingsStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
-import { sanitizeScopedModuleMap } from './settings-store-shape'
+import { deepFreeze, sanitizeScopedModuleMap } from './settings-store-shape'
 
 type ModulePayload = Record<string, unknown>
 type WorkspaceSlot = Record<string, ModulePayload>
@@ -21,7 +21,7 @@ export const useWorkspaceSettingsStore = create<WorkspaceSettingsState>()(
 
       get: (workspaceId, moduleId) => {
         const payload = get().workspaces[workspaceId]?.[moduleId]
-        return payload ? Object.freeze({ ...payload }) : undefined
+        return payload ? deepFreeze(payload) : undefined
       },
 
       set: (workspaceId, moduleId, patch) =>

--- a/spa/src/stores/useWorkspaceSettingsStore.ts
+++ b/spa/src/stores/useWorkspaceSettingsStore.ts
@@ -10,6 +10,7 @@ interface WorkspaceSettingsState {
   workspaces: Record<string, WorkspaceSlot>
   get: (workspaceId: string, moduleId: string) => ModulePayload | undefined
   set: (workspaceId: string, moduleId: string, patch: ModulePayload) => void
+  removeKey: (workspaceId: string, moduleId: string, key: string) => void
   clearWorkspace: (workspaceId: string) => void
   clearModule: (workspaceId: string, moduleId: string) => void
 }
@@ -39,6 +40,22 @@ export const useWorkspaceSettingsStore = create<WorkspaceSettingsState>()(
               },
             },
           }
+        }),
+
+      removeKey: (workspaceId, moduleId, key) =>
+        set((state) => {
+          const currentWorkspace = state.workspaces[workspaceId]
+          const currentModule = currentWorkspace?.[moduleId]
+          if (!currentWorkspace || !currentModule || !(key in currentModule)) return state
+          const { [key]: _omit, ...rest } = currentModule
+          void _omit
+          const nextWorkspace = { ...currentWorkspace }
+          if (Object.keys(rest).length === 0) {
+            delete nextWorkspace[moduleId]
+          } else {
+            nextWorkspace[moduleId] = rest
+          }
+          return { workspaces: { ...state.workspaces, [workspaceId]: nextWorkspace } }
         }),
 
       clearWorkspace: (workspaceId) =>

--- a/spa/src/stores/useWorkspaceSettingsStore.ts
+++ b/spa/src/stores/useWorkspaceSettingsStore.ts
@@ -19,7 +19,10 @@ export const useWorkspaceSettingsStore = create<WorkspaceSettingsState>()(
     (set, get) => ({
       workspaces: {},
 
-      get: (workspaceId, moduleId) => get().workspaces[workspaceId]?.[moduleId],
+      get: (workspaceId, moduleId) => {
+        const payload = get().workspaces[workspaceId]?.[moduleId]
+        return payload ? Object.freeze({ ...payload }) : undefined
+      },
 
       set: (workspaceId, moduleId, patch) =>
         set((state) => {


### PR DESCRIPTION
## Summary

HSR 系列最後一棒。Editor module 透過新 `ModuleDefinition.settings` 宣告 `workspace-home-path` + `host-home-path` 兩個 contribution，作為整套 registry + 三層 store 架構的 **real module validation proof**。同時收斂 #540（三層 store `get()` immutable snapshot）與決策 3b（舊 `globalConfig`/`workspaceConfig` deprecation warning）。

- Editor tilde path 層疊 resolve：workspace settings → host settings → pane shell fallback（Layer 3 PR #530 既有）
- LinkContext 擴 `workspaceId?`，由 `SessionPaneContent` 用 `findWorkspaceByTab()` 查後以 prop 傳入 `TerminalView`（**非** active workspace — multi-workspace inactive pane 正確性）
- Closes #540（三層 store frozen snapshot；R2/R3 收斂後改為 deep-clone + freeze + WeakMap alias/cycle 安全）
- Deprecation warn 對非 `files` module 使用舊 `globalConfig`/`workspaceConfig`，module-scope de-dupe 避免 HMR 噪音

## Commits（PR-5 6 + R1 3 + R2 5 + R3 3 = 17 commits，每 commit 獨立可綠）

### Plan §8 主體
| # | SHA | Subject |
|---|-----|---------|
| 1 | `e9c3e84a` | refactor(spa): settings stores return frozen immutable snapshot (#540) |
| 2 | `ddb9d624` | feat(spa): LinkContext carries link-source workspaceId (plumbing) |
| 3 | `7f55f7d2` | feat(spa): editor-home-resolver with layered workspace → host → pane-shell resolve |
| 4 | `1a060441` | feat(spa): terminal-link opener uses editor-home-resolver for tilde paths |
| 5 | `b6d60455` | feat(spa): Editor module declares homePath contributions (workspace + host) |
| 6 | `eace64fc` | refactor(spa): deprecate ModuleDefinition.globalConfig / workspaceConfig |

### R1 codex 修補
| # | SHA | Subject |
|---|-----|---------|
| 7 | `0ae4a3ab` | fix(spa): deep freeze settings store snapshot (R1 codex) |
| 8 | `f32b7129` | fix(spa): warn legacy config only after successful dispatch (R1 codex) |
| 9 | `4eaf0aa3` | fix(spa): normalize draft on blur in editor home path sections (R1 codex) |

### R2 三路對抗修補
| # | SHA | Subject |
|---|-----|---------|
| 10 | `cf118a91` | fix(spa): deepFreeze must not pass-through shallow-frozen containers (R2 codex) |
| 11 | `69403b8e` | fix(spa): clear editor homePath must preserve sibling module keys (R2 codex) |
| 12 | `427ef6c8` | fix(spa): capture link-source workspace before await for tab placement (R2 codex) |
| 13 | `73051930` | fix(spa): home path input resists external store updates while focused (R2 codex) |
| 14 | `d04bd947` | fix(spa): HMR reset clears legacy config warn dedupe (R2 codex) |

### R3 standard 修補
| # | SHA | Subject |
|---|-----|---------|
| 15 | `70f42e87` | fix(spa): deepFreeze must use clone-map for cycles and aliases (R3 codex) |
| 16 | `92fccbb8` | fix(spa): standalone panes defer active workspace read until after resolve (R3 codex) |
| 17 | `b451cba9` | fix(spa): focus-without-edit must not roll back external store updates (R3 codex) |

## 與 plan 的偏離

| 偏離 | Plan | 實際 | 原因 |
|---|---|---|---|
| localId 命名 | `workspaceHomePath` / `hostHomePath`（camelCase） | `workspace-home-path` / `host-home-path`（kebab-case） | `SETTINGS_LOCAL_ID_RE = /^[a-z0-9-]{1,32}$/` 禁 camelCase |
| Editor host contribution `order` | `0` | `100` | order=0 會排進 6 個 built-in 之前並破壞 `HostPage.test.tsx T3` |
| Resolver 對 fetch error 的處理 | §3.3 「fetchPaneHome reject → 回 null」 | resolver re-throw，opener try/catch 並 warn | 保留 PR #530 的 diagnostic warn contract |
| `host-builtin-sections.test.tsx` assertion | 未明列 | 「6 個 host-scoped」改為「6 個 moduleId === HOST_BUILTIN_MODULE_ID」 | editor.host-home-path 進場後 host-scoped 總數變 7 |

## Codex review 收斂軌跡（4 輪）

| Round | Findings | Severity peak |
|---|---|---|
| R1 standard | 3 | P2 deepFreeze shallow / P3 warn 順序 / P3 blur 不 normalize |
| R2 attacker | 4 | 2 HIGH（workspace race / deepFreeze cycle）+ 2 MED（draft race / HMR reset） |
| R2 defender | 3 | 2 HIGH（同 workspace race / clearModule wipe）+ 1 MED（deepFreeze pass-through） |
| R2 file-health | 3 | 2 HIGH（同上）+ 1 MED（deepFreeze pass-through） |
| R3 standard | 3 | 全 P2（focus-without-edit / standalone defer / deepFreeze alias） |
| R4 standard | 2 | 1 P2 + 1 P3 — **schema 決策外，建 issue #607 #608 追蹤** |

R1→R4 嚴重性收斂：HIGH/P1 (3) → P2 (1)。Per `feedback_codex_review_termination.md` 「no critical/P1 + known issues 追蹤即可 ship」。

## Known follow-ups（建 issue 追蹤）

- #540 ✅ 本 PR closes
- **#607**（R4-F1 P2）— editor-home-resolver workspace 層 mixed-host 不分 host scope（plan §1 假設 single-host workspace）
- **#608**（R4-F2 P3）— file-path opener 在 workspace 刪除中的 orphan tab race
- 既有延後不動：#538 / #541 / #563 / #574 / #587 / #596 / #597 / #598

## 測試

- 新增 ~75 個 PR-5 測試（store immutability 13 / removeKey 12 / plumbing 5 / resolver 13 / opener layer 12 / section 18 / deprecation 7）全綠
- 完整 suite：**2644 passed / 3 failed**（3 failing 全在 `src/lib/sync/contributors/hosts.test.ts`，pre-existing on main，與 PR-5 無關）
- `cd spa && pnpm run lint` 綠
- `cd spa && pnpm run build` 綠

## HSR 系列全貌

- PR-1 ✅ #542 → alpha.199（registry core + 三層 store）
- PR-2 ✅ #558 → alpha.202（Purdex shell + legacy adapter）
- PR-3 ✅ #573 → alpha.203（Workspace shell）
- PR-4 ✅ #582 + follow-up #593 → alpha.206/209（Host shell + 反應式 host runtime）
- **PR-5（本 PR）** — Editor real-module validation

## Test Plan

- [ ] `cd spa && pnpm exec vitest run`（預期 2644 passed）
- [ ] `cd spa && pnpm run lint`
- [ ] `cd spa && pnpm run build`
- [ ] 手動：workspace settings 填 `/tmp/foo` → 點 `~/x` 開 `/tmp/foo/x`
- [ ] 手動：清 workspace、host 填 `/home/bar` → 點 `~/y` 開 `/home/bar/y`
- [ ] 手動：三層皆空 → 依 pane shell fallback 行為（PR #530 回歸）
- [ ] 手動：multi-workspace — 非 active workspace 的 pane 點 `~/x` 用對的 workspace 值