### PR TITLE
feat(agent): Lights rebuild — Phase 0 Status alignment skeleton

### DIFF
--- a/docs/research/2026-04-22-lights-rebuild-discussion.md
+++ b/docs/research/2026-04-22-lights-rebuild-discussion.md
@@ -261,3 +261,101 @@ bloat 圖：
 - bloat 最壞：形狀押錯，骨架 + 已對齊的 agent 都要改（乘法工作）
 
 **結論**：縮減版不是「不足」而是「留白」；bloat 圖不是「足夠小」而是「早期快照」。選擇取決於對 Phase 2-5 形狀的信心 — 若不確定則留白優於預設。
+
+---
+
+## 2026-04-23 補二：發現 TraceStore + Monitor API 完整存在（關鍵 reality check）
+
+### 發現
+
+1. **`internal/store/trace.go`** — 完整 `TraceStore`，含 `TraceChain` + `TraceStep` schema：
+   - `TraceStep` 欄位：Kind、TmuxSession、PaneID、AgentType、FrameID、ParentFrameID、EventName、Decision、Reason、PayloadJSON、BeforeJSON、AfterJSON、CreatedAt
+   - 每個 hook 進來會寫三階段 trace（verify / derive / apply）
+   - `handleEvent` 在 `handler.go:85` 已接 `beginHookTrace`
+
+2. **`internal/module/agent/monitor.go`** — 完整 Monitor HTTP API：
+   - `GET /api/agent/monitor/chains`（list with filter）
+   - `GET /api/agent/monitor/chains/{id}`（full chain + step tree）
+   - `GET /api/agent/monitor/projection`（current projection）
+   - `buildStepTree` 已組成 parent-child 樹
+
+### 對前面評估的修正
+
+先前誤差表 #12/#13 評估為：
+- 判斷點資料蒐集 — 已有（輕描淡寫）
+- Dev Inspector — 全缺（大誤差）
+
+**實際上**：
+- 判斷點資料蒐集 — ✅ **完整存表含 before/after snapshot，結構完整**
+- Dev Inspector — **中小誤差**：資料 + API 都在，只缺 SPA UI
+
+### bloat vs tightened 的重新評估
+
+bloat 版聲稱的 6 個價值主張中，5 個與 TraceStore/Monitor API 重疊或可從 trace 導出：
+
+| bloat 賣點 | TraceStore 是否已涵蓋 |
+|---|---|
+| Transition 型別一等公民 | ✅ TraceStep 即具象化 transition |
+| Inspector 友善結構 | ✅ Monitor API + buildStepTree |
+| Coverage 從 handler 推導 | ✅ 可 SQL 查 agent_trace_steps |
+| Unknown event typed path | 近似 ✅ — 只要加 `reason="event_not_in_catalog"` 即可 |
+| Phase 2 actor 延伸點 | ✅ ParentFrameID 已在每個 step |
+| Phase 5 Inspector 資料 | ✅ Monitor API 三 endpoint 齊備 |
+
+bloat 版獨特價值剩下兩個（皆非 TraceStore 可替代）：
+1. Runtime 派發結構（switch → registry）— 美學差異，功能等價
+2. 統一 hook + probe runtime 觸發 — trace 層下游已可統一呈現，runtime 不統一未造成實際問題
+
+### 結果
+
+- **bloat 版 85% 與現有 infra 重疊或平行**，實質變成「在 runtime 層建一套 TraceStore 的 in-memory 鏡像」
+- **兩套事實表示**（runtime Transition struct vs 持久化 TraceStep）演化時要同步 — bug 會長在接縫處
+- **tightened 版補在剛好缺的那塊**（agent 對齊宣告），其他層交給現有 infra
+
+### 重新框架（取代原本「留白 vs 押注」）
+
+```
+tightened = 補上對齊宣告 + TraceStore 繼續當 SOT + Phase 2-5 以 trace data 驅動
+bloat     = 忽略已有 TraceStore，建一套平行 runtime 結構（重建輪子）
+```
+
+「押注 vs 留白」是在**真空推斷**的前提下才成立；實際上 Phase 2-5 需求可由 trace data 觀察推導，不是押注。
+
+### Phase 2-5 的資料驅動路徑（不用猜）
+
+| Phase | 可查詢 | 預期看到 |
+|---|---|---|
+| Phase 2 proxy agent | `SELECT * FROM agent_trace_steps WHERE pane_id = ? AND created_at > ?` | 同 pane 短時間內跨 agent_type 的 hook pattern |
+| Phase 3 daemon 後啟動 | `WHERE reason = 'frame_missing'` | 發生比例 + pattern |
+| Phase 4 probe 誤判 | `WHERE kind = 'probe:activity' ... JOIN 下一個 hook_post` | probe 觸發後是否被 hook 矯正 |
+| Phase 5 Inspector | Monitor API 三 endpoint + step tree | 結構已在，只需 SPA UI |
+
+### 最終結論
+
+**tightened 不只是「比較小」，而是「與現有 infrastructure 最匹配」**。bloat 在發現 TraceStore 之前是個合理考慮，發現 TraceStore 之後是明顯 over-engineering — 因為它提議的結構大部分已經以不同形式存在於系統中。
+
+---
+
+## 約束 bloat 版（bounded bloat）評估
+
+### 機制列舉（可限制 bloat 成長）
+
+1. **結構約束**：單檔限制、LOC 預算、禁用介面/泛型、重用既有 registry
+2. **語意約束**：硬編碼設計決策並爆黑板、禁用 config flag / mode 切換
+3. **時間約束**：sunset clause（Phase 3 時重新檢視，無用就刪）、consumer-driven 開發
+4. **文化約束**：預先聲明拒絕的「自然下一步」列表
+
+### 核心問題
+
+bounded bloat 的本質是：
+- 現在不明原因先長大 + 用約束延後問題
+- 需求到了，約束還是要解開
+- value prop 建立在「約束能擋住 + 約束將來可撤」— 兩條都不是真正的 value
+
+相較之下：
+- **需求到了才長大** = 健康演化
+- **現在先長，之後受約束** = 延後的 over-engineering
+
+### 結論
+
+bounded bloat 不是比 tightened 好的折衷，是「延後 over-engineering 的變形」。**不採用**。

--- a/docs/research/2026-04-22-lights-rebuild-discussion.md
+++ b/docs/research/2026-04-22-lights-rebuild-discussion.md
@@ -1,0 +1,176 @@
+# 燈號系統重建 — 討論記錄
+
+**Date**: 2026-04-22
+**Status**: 討論中（尚未定稿為 spec）
+**Context**: Lights 子系統在 2026-04-22 全部 revert（PR #594），回到 legacy 實作。重新以小步快跑方式規劃對齊。
+
+本文件是討論過程的記錄，**不是正式 spec**。若要進入實作，每個 Phase 需另寫正式 design spec 並經 codex review。
+
+---
+
+## 使用者提出的目標架構
+
+### 1. Agent type
+影響顯示 icon，需支援 **cc / codex / opencode**。
+
+### 2. 主狀態
+- `idle`（啟動、執行完畢…）
+- `running`（執行中，如 cc UserPromptSubmit）
+- `waiting`（permission / question）
+- `closed`（session end）
+
+### 3. 副狀態：unread
+執行完畢時的 hook 產生。
+
+### 4. 副狀態：subagent
+兩種情境：
+
+- **(1) 自呼叫的 subagent**（如 cc 自己觸發 subagent hook）
+  需對齊進出的 subagent uid，避免遺留燈號。
+
+- **(2) proxy agent**（如 cc 中呼叫 codex）
+  此時 codex 自身的 hook 也會被觸發；需視為 parent agent 的 subagent，不是獨立 parent。
+
+### 處理原則
+
+1. **Hook 觸發 → 沒有 parent 時，hook 訊號決定 agent type 基準**
+   - 例外破口：daemon 在 agent 之後啟動，此時 agent proxy agent，判定點誤把 subagent 視為 parent。
+
+2. **Hook 缺乏的部分：**
+   - (1) **沒有變化永遠比錯誤變化好** — 無法偵測的事件 / unknown 事件一律追蹤傳遞但不處理（保留資料以後使用）。
+   - (2) **事件的事件**（before_idle / after_idle）讓 probe 可以導入輔助事件修正。
+     - 範例：cc 在 question 後即使使用者已輸入也不觸發 hook → 持續黃燈。
+       → 在 ask 事件後啟動 probe 監控畫面變化 → 一旦發生變化恢復執行中。
+
+3. **Probe 兩個維度：**
+   - [1] 統一所有 agent 可用的偵測行為（畫面變化中、畫面停止、彩虹字判斷）。
+   - [2] 依據各家 agent 模組各自實作的特殊 probe。
+
+### 資料蒐集
+每個判斷點需作資料蒐集，後台 development 區可監測所有事件變化，核對是否判斷正確。
+
+---
+
+## 現況探索摘要
+
+### Backend 已存在
+
+| 元件 | 位置 | 狀態 |
+|---|---|---|
+| `AgentProvider` interface | `internal/agent/provider.go` | ✅ |
+| cc / codex / opencode provider | `internal/agent/{cc,codex,opencode}/` | 三家都註冊 |
+| Probe：Liveness / Activity / Readiness | `internal/agent/probe/` | ✅ 含 `activity.go` 的 screen-hash diff + `shell_prompt.go` |
+| `frame_ops.go` — Frame + ParentFrameID + Subagents | `internal/module/agent/frame_ops.go` | Subagents 是 `[]string` |
+| Hook ingest `/api/agent/event` | `internal/module/agent/handler.go:68` | ✅ |
+| Trace pipeline `beginHookTrace` / `TraceStore` | `internal/module/agent/trace.go` | ✅ 記錄 verify/derive/apply |
+| Probe 已掛到 status 轉移 | `internal/module/agent/module.go:410` `manageActivityWatch` | 進入 waiting/running/idle 即啟動 watcher |
+
+### SPA 已存在
+
+| 元件 | 位置 | 狀態 |
+|---|---|---|
+| `useAgentStore` | `spa/src/stores/useAgentStore.ts` | 含 statuses / agentTypes / models / subagents / unread / oscTitles / ccStatus |
+| `TabStatusIndicator` | `spa/src/components/TabStatusIndicator.tsx` | 含 breathe / error diamond |
+| `TabIcon` 組合器 | `spa/src/components/TabIcon.tsx` | 整合 icon + status + unread + SubagentDots |
+| `getAgentIcon()` | `spa/src/lib/agent-icons.tsx` | cc ✅ / codex ✅ / **opencode ❌** |
+| CC / Codex icon variant | Settings UI | ✅ |
+
+### 各 agent DeriveStatus 覆蓋率
+
+| Event | CC | Codex | OpenCode |
+|---|:-:|:-:|:-:|
+| SessionStart | ✅ | ✅ | ✅ |
+| UserPromptSubmit | ✅ | ✅ | ✅ |
+| Notification | ✅ | ❌ | ❌ |
+| PermissionRequest | ✅ | ❌ | ✅ |
+| Stop | ✅ | ✅ | ✅ |
+| StopFailure | ✅ | ❌ | ✅ |
+| SessionEnd | ✅ | ❌ | ✅ |
+| SubagentStart/Stop | ✅ | ❌ | ✅ |
+
+---
+
+## 目標 vs 現況誤差表
+
+| # | 需求項目 | 現況 | 誤差 |
+|---|---|---|---|
+| 1 | **Type：cc / codex / opencode icon** | cc ✅、codex ✅、opencode ❌ | 小 — 補一個 svg |
+| 2 | **主狀態：idle / running / waiting / closed** | `StatusRunning / Waiting / Idle / Error / Clear`（多 error） | 對齊（多 error bonus） |
+| 3 | **副狀態：unread** | `useAgentStore.unread` + SPA pip/dots 完整 | 已實作 |
+| 4 | **副狀態：subagent (1) 自呼叫 uid 配對** | `frame.Subagents []string` append/remove by agent_id | 中 — 無 type、無 startedAt、未離場無 sweep |
+| 5 | **副狀態：subagent (2) proxy agent** | 同 pane 不同 agent_type 會建獨立 frame | **大 — 架構未設計 proxy 情境** |
+| 6 | **原則 1：沒 parent 時以 hook agent_type 為基準** | 一律以 `req.AgentType` 為基準，有 `FindByPanePID` 找 parent | 精神對齊，但**無顯式「沒 parent」判斷路徑** |
+| 7 | **原則 1 例外：daemon 後啟動誤把 subagent 當 parent** | 完全未處理 | **大** |
+| 8 | **原則 2(1)：未知事件追蹤不處理** | `Valid=false` 早退丟掉 | 中 — 精神對齊但**未追蹤 raw payload** |
+| 9 | **原則 2(2)：before/after_idle 事件 bus** | 無形式化 event bus；probe 是 one-shot | 中 — 功能對齊但設計模式不同 |
+| 10 | **Probe 維度 [1]：畫面變化 + shell_prompt + 彩虹字** | hash diff ✅ + shell_prompt ✅ + **彩虹字 ❌** | 中上對齊 — 彩虹字缺 |
+| 11 | **Probe 維度 [2]：各 agent 專屬 readiness** | `internal/agent/*/readiness.go` 全家都有 | 對齊 |
+| 12 | **判斷點資料蒐集（後端）** | `TraceStore` + `beginHookTrace` 三階段 | 已有 |
+| 13 | **後台 Development Inspector UI** | `/api/dev/*` 只有 build/update/rebuild | **大 — 全缺** |
+
+### 量級總結
+
+- **對齊**：主狀態、unread、probe 基礎設施、per-agent readiness、後端 trace
+- **小誤差（1–3 檔）**：opencode icon、彩虹字、未知事件追蹤記錄
+- **中誤差**：subagent 結構升級、before/after_idle event bus 形式化、daemon 後啟動補回
+- **大誤差**：proxy agent 模型、Dev Inspector UI
+
+**整體誤差沒有想像大**。上次 Lights 膨脹是想重建整個 arbitrator / trace envelope 抽象層，但現有 trace + probe + frame 已涵蓋約 70% 需求。真正從零做的只有 proxy agent 模型 + Dev Inspector UI。
+
+---
+
+## Phase 拆法（使用者選擇層層對齊；Inspector 置後）
+
+每個 Phase 獨立 PR、獨立 merge、獨立 bump alpha。每個 Phase 先寫正式 spec + codex review 再進實作。
+
+### Phase 1 — L2 狀態層對齊
+- Codex `DeriveStatus` 補齊（Notification / PermissionRequest / Subagent / SessionEnd / StopFailure）
+- OpenCode brand icon 補上
+- 未知事件 / `Valid=false`：從「丟棄」改「追蹤不處理」（存 raw payload 到 trace，不動狀態）
+- **觸及**：3 個 `status.go` + `agent-icons.tsx` + handler 的 `Valid=false` 分支
+- **風險**：低（加法為主）
+
+### Phase 2 — L3 Subagent 模型升級
+- `frame.Subagents: []string` → `[]SubagentRef{ID, Type, StartedAt}`
+- Proxy agent 判斷：同 pane 有現存 parent frame 時，**不同 agent_type 的 hook 掛進 parent 當 subagent**（非建新 frame）
+- SPA `subagents` store 升級顯示 type
+- **觸及**：frame_ops.go + store schema + useAgentStore + SubagentDots
+- **風險**：中（動 DB schema，alpha 階段無 migration）
+
+### Phase 3 — L1 邊界補強
+- daemon 後啟動補回機制：hook 進來時若無 frame，用 tmux process tree + existing sessions 推回 frame 樹
+- 「沒有 parent 時以 hook agent_type 為基準」顯式化為判斷分支
+- **觸及**：frame_ops.go 的 `FindByPanePID` 路徑 + 新補回 helper
+- **風險**：中（邊界情況多）
+
+### Phase 4 — L4 Probe 補強（可選）
+- 彩虹字 / spinner 偵測加入 `activity.go`（避免 CC question 後使用者打字誤判 running）
+- before_idle / after_idle event bus 形式化 — **Phase 1-3 走完後若發現需要才做**；若現有 one-shot watcher 夠用則砍掉（避免再次膨脹）
+- **觸及**：probe/activity.go + 可能 module.go
+- **風險**：低-中
+
+### Phase 5 — L6 Dev Inspector
+- Settings → Development 加 Event / Trace / Frame Inspector 面板
+- 消費現有 `TraceStore` + 新 `/api/dev/events` endpoint
+- **觸及**：dev module 新 handler + 新 SPA 頁
+- **風險**：低（純讀取側）
+- **不為前四個 Phase 預設 schema**，等前面穩定後依真實需求設計
+
+---
+
+## 原則（避免重蹈膨脹覆轍）
+
+1. 每個 Phase 獨立 PR、獨立 merge、獨立 bump alpha
+2. 每個 Phase 先寫 spec + codex review（依 CLAUDE.md 開發流程）
+3. Phase 4 的 event bus 標「可選」，不預先實作抽象層
+4. Inspector 置後，不為前 Phase 挖坑
+5. 能走現有基礎設施就不新增模組（trace / probe / frame 已涵蓋 70%）
+
+---
+
+## Open Questions（尚待討論）
+
+- Phase 2 是否拆 2a（schema 升級）+ 2b（proxy agent 邏輯）？使用者表示「到時候再拆」。
+- Phase 4 event bus 是否真的需要？待 Phase 1-3 完成後評估。
+- Phase 5 Inspector 的觀察粒度（per-event / per-transition / per-frame）待設計。
+- proxy agent 判定條件細節：同 pane + 不同 agent_type 即算？還是需加時間窗 / PPID 驗證？

--- a/docs/research/2026-04-22-lights-rebuild-discussion.md
+++ b/docs/research/2026-04-22-lights-rebuild-discussion.md
@@ -359,3 +359,106 @@ bounded bloat 的本質是：
 ### 結論
 
 bounded bloat 不是比 tightened 好的折衷，是「延後 over-engineering 的變形」。**不採用**。
+
+---
+
+## tightened 對三個需求的支援驗證
+
+### 需求 1：Status 作為唯一對齊，agent 各自註冊實作
+
+直接由 tightened 提供：
+
+```go
+// 骨架側
+type StatusSupporter interface {
+    SupportedStatuses() []Status
+}
+
+// agent 側（各自實作）
+func (p *Provider) SupportedStatuses() []agent.Status { ... }
+// hook → status 邏輯仍在既有 deriveXxxStatus()
+```
+
+✅ 直接對應。
+
+### 需求 2：Subagent parent/child + proxy 識別
+
+**不在 tightened 骨架範圍，但骨架不擋擴充路徑。** 屬 frame 層，Phase 2 處理。
+
+Phase 2 擴充草圖：
+```go
+// internal/store/frame.go —— 升級
+type SubagentRef struct {
+    ID        string
+    Type      string  // NEW
+    StartedAt int64   // NEW
+    IsProxy   bool    // NEW
+}
+type Frame struct {
+    ...
+    Subagents []SubagentRef  // 升級自 []string
+}
+
+// internal/module/agent/frame_ops.go —— proxy 偵測分支（新增）
+// 當同 pane 已有 frame + 新 hook 的 agent_type 不同 → 視為 proxy subagent
+// 附加到 parent.Subagents，不建新 frame
+```
+
+骨架的 `StatusSupporter` 完全未碰。parent/child 靠既有 `ParentFrameID` + 新加的 `Type`/`IsProxy`。
+
+### 需求 3：Probe 輔助註冊 status，不破壞式
+
+**不在 tightened 骨架範圍，但骨架不擋擴充路徑。** 屬 probe 層，Phase 4 處理。
+
+Phase 4 擴充草圖：
+```go
+// 新增 optional interface（骨架延伸，不動既有）
+type ProbeIntentProvider interface {
+    ProbeIntents() []ProbeIntent
+}
+type ProbeIntent struct {
+    OnEntry  Status
+    Detector ProbeFunc
+    OnSignal func(Signal) Status
+}
+
+// module.go：附加檢查，既有 manageActivityWatch 預設路徑完全保留
+if provider, ok := m.getProvider(agentType).(ProbeIntentProvider); ok {
+    for _, intent := range provider.ProbeIntents() {
+        if intent.OnEntry == newStatus {
+            m.prober.StartWithIntent(session, intent)
+        }
+    }
+}
+```
+
+沒實作 `ProbeIntentProvider` 的 agent 行為和現在一模一樣（不破壞）。
+
+### 三需求匯總
+
+| 需求 | tightened 直接支援 | 擴充方式 | 動到骨架 |
+|---|---|---|---|
+| Status 對齊 | ✅ | Phase 0 骨架 + Phase 1 各 agent 實作 | — |
+| Subagent parent/child + proxy | ❌（留空間） | Phase 2：frame model + frame_ops proxy 分支 | 否 |
+| Probe 輔助（不破壞） | ❌（留空間） | Phase 4：optional `ProbeIntentProvider` interface | 否 |
+
+### 架構哲學差別（總結）
+
+| bloat 哲學 | tightened 哲學 |
+|---|---|
+| 統一 hook + probe + status 於 Transition 型別 | 三者獨立演化 |
+| 一個 registry 管所有註冊 | 每個 concern 有自己的 interface |
+| 緊耦合換 coherent 抽象 | 鬆耦合換 independent evolvability |
+
+TraceStore 當跨 concern 的共同事實 SOT；runtime 層保持 concern 獨立。Inspector（Phase 5）由 trace 跨 concern 拼接呈現，而不是由 runtime 結構強制統一。
+
+### tightened 明確不提供的（trade-off 誠實列出）
+
+- 三個 concern 在 runtime 層的「統一註冊 API」
+- 「一處修改影響多處」的 coherent 擴充體驗
+- runtime 層的 Transition 型別作為 Inspector timeline 的單一事實源（改由 TraceStep 擔任）
+
+這些是 tightened 刻意放棄的，換取：
+- 每個 Phase 可獨立 PR、獨立 merge、獨立 rollback
+- 跨 Phase bug 不連動
+- 設計失誤只影響該 Phase 的 layer，不會溢出到骨架

--- a/docs/research/2026-04-22-lights-rebuild-discussion.md
+++ b/docs/research/2026-04-22-lights-rebuild-discussion.md
@@ -174,3 +174,90 @@
 - Phase 4 event bus 是否真的需要？待 Phase 1-3 完成後評估。
 - Phase 5 Inspector 的觀察粒度（per-event / per-transition / per-frame）待設計。
 - proxy agent 判定條件細節：同 pane + 不同 agent_type 即算？還是需加時間窗 / PPID 驗證？
+
+---
+
+## 2026-04-23 補：骨架範圍收斂過程
+
+### 迭代軌跡
+
+1. **第一版**：提議完整骨架 — Status FSM (資料化) + Hook Handler Registry + State Entry Probe Registry + Combined Coverage。使用者質疑「是否又膨脹成前次 Lights」。
+2. **第二版（bloat 圖）**：
+   ```
+   Status FSM（骨架）—— states + transitions
+     ├─ 註冊 A：Hook Handler (hook, agent) → transition
+     └─ 註冊 B：State Entry Probe (state, agent) → auxiliary signal → transition
+   ```
+   使用者再次質疑膨脹；也質疑「事件骨架」的必要性（各 agent 的 hook 本就不同，canonical event 強加 CC 的 ontology 給其他 agent）。
+3. **第三版（縮減版）**：放棄 canonical event 層。骨架僅保留：
+   - `Status` enum（已存在）
+   - 各 agent 顯式宣告 `SupportedStatuses() []Status`（由使用者拍板：顯式優於隱式）
+   - `Coverage(registry) []CoverageRow` helper
+   - 現有 `DeriveStatus` switch 與 `manageActivityWatch` 保持不變（不 refactor）
+
+### 尺寸差距（bloat vs 縮減）
+
+| 指標 | bloat 圖 | 縮減版 | 倍數 |
+|---|---|---|---|
+| 新骨架檔行數 | ~250 | ~35 | 7× |
+| 新增測試行數 | ~200 | ~30 | 7× |
+| 既有檔案 refactor | ~90 行 | 0 行 | ∞ |
+| 新資料結構 | 7 個 | 1 個（CoverageRow） | 7→1 |
+| 新增方法 | ~10 個 | 1 個（`SupportedStatuses`） | 10→1 |
+
+### 與 Reverted Lights 的 pattern 比對
+
+Reverted Lights（2026-04-22 全撤 ~9000 行）：
+- L1 trace envelope / divergences table
+- L2 observation types
+- L3 arbitrator goroutine（單寫者）
+- L4 admission + 9-step apply pipeline
+
+bloat 圖：
+- L1 Status FSM 資料化
+- L2 Hook Handler registry
+- L3 State Entry Probe registry
+- L4 Combined coverage 推導
+
+**結構 pattern 同型**：兩者都以「把 working imperative code 轉成 declarative data + registry」為動機，且自然延伸路徑相似（priority / lifecycle / conflict resolution / 統一介面）。尺寸差 15× 僅為早期快照，動力學上 bloat 圖具備長大為 Lights 的壓力。
+
+**縮減版打斷了五個典型 bloat pattern**：
+1. 不把 working code 變 data
+2. 不新增 parallel registry
+3. 不以統一抽象覆蓋多種 case（probe 留原位）
+4. 不 refactor 既有 working code
+5. 不預埋 config flag / mode 切換
+
+### 決議
+
+- **Phase 0（骨架）= 縮減版**
+- 各 agent `SupportedStatuses()` 實作 = Phase 1
+- Probe formalization = Phase 4（可選）
+- 每個 Phase 先寫正式 spec + codex review 再實作
+
+### 正反評價（2026-04-23 新增）
+
+**縮減版的不足**：
+- 只答「誰支援什麼」，不答「怎麼達成」— 覆蓋率缺口需看 source 才知道 root cause
+- 無法形式化「未知事件追蹤不處理」原則，該原則得另行 hack 進 handler.go
+- Inspector (Phase 5) 只拿得到 declaration 矩陣，hook → transition 歷史仍要靠 `TraceStore` 原生資料
+- declaration 與實作可能漂移（需額外測試驗證；縮減版未納入）
+- Phase 2 subagent / proxy 情境零結構支持
+
+**bloat 圖的優勢**：
+- coverage 可從 handler 推導，對齊 declaration-vs-impl
+- hook / probe 產生的 transition 在 Inspector 呈現統一
+- 「未知事件」有天然型別路徑（`Lookup` sentinel），非 `Valid=false` overload
+- Phase 2 subagent 可在 `Transition` 延伸 actor 欄位
+- 支援 "declared-but-WIP" 狀態（如 codex 打算支援 waiting，未實作）
+
+**bloat 圖的成本**：
+- 1 PR ~550 行 refactor，touching `handleEvent` + `manageActivityWatch`
+- 具備同 Reverted Lights 的自然延伸動力（priority / lifecycle / conflict …）
+- 延伸形狀是押注 Phase 2-5 的實際需求，押錯則骨架要改 + agent 註冊跟著改（乘法工作）
+
+**縮減版的風險不對稱**：
+- 最壞：Phase 2-5 才發現需要結構，回頭補（增量工作）
+- bloat 最壞：形狀押錯，骨架 + 已對齊的 agent 都要改（乘法工作）
+
+**結論**：縮減版不是「不足」而是「留白」；bloat 圖不是「足夠小」而是「早期快照」。選擇取決於對 Phase 2-5 形狀的信心 — 若不確定則留白優於預設。

--- a/docs/specs/2026-04-23-lights-rebuild-phase-0-plan.md
+++ b/docs/specs/2026-04-23-lights-rebuild-phase-0-plan.md
@@ -1,0 +1,136 @@
+# Phase 0 TDD Plan — Status 對齊骨架
+
+- **Date**: 2026-04-23
+- **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §4
+- **Worktree**: `lights-rebuild-spec`（branch `worktree-lights-rebuild-spec`）
+- **範圍**：新增 `StatusSupporter` optional interface + `Coverage` helper + TDD 測試；零改動既有程式碼
+
+## 1. 契約鎖定
+
+本節鎖定所有行為細節，避免實作期再決策。
+
+### 1.1 `StatusSupporter` interface（`internal/agent/provider.go`）
+
+- 位置：與既有 `HookInstaller` / `StatuslineInstaller` 同一「Optional capabilities」區塊
+- 唯一方法：`SupportedStatuses()` 回傳 `[]Status`
+- Optional：不實作者為合法（等同「未宣告」）
+- 宣告空 slice 合法：代表 provider 主動宣告「我不支援任何 Status」，與「未實作 interface」不同
+- Provider 實作回傳的 slice，Coverage 需 defensive copy（避免 provider 後續 mutate）
+
+### 1.2 `CoverageRow` 型別（`internal/agent/coverage.go`）
+
+三欄位：
+
+| 欄位 | 型別 | 語意 |
+|---|---|---|
+| `AgentType` | `string` | provider 的 `Type()` 回傳值 |
+| `Declares` | `bool` | provider 是否實作 `StatusSupporter`（type assertion 結果） |
+| `Declared` | `[]Status` | 若 `Declares=true`，為 `SupportedStatuses()` 回傳值的 copy；若 `Declares=false`，為 `nil` |
+
+### 1.3 `Coverage(r *Registry) []CoverageRow`
+
+- 呼叫 `r.All()` 取得所有 provider
+- 對每個 provider 做 type assertion 判斷是否實作 `StatusSupporter`
+- 輸出順序：以 `AgentType` 字母序（ASCII）排序；重複 AgentType 保留 registration 順序作為 tie-breaker（不預期會發生，但不 panic）
+- 空 registry 回傳 `nil`（不是 empty slice） — 與 Go 慣例對齊，`len()` 皆為 0
+- 非 thread-safe 假設：呼叫期間 registry 不會被 mutate（與 `Registry.All()` 相同約束）
+
+### 1.4 零改動邊界
+
+以下檔案在 Phase 0 **不得觸碰**（違反即視為超出 Phase 0 範圍）：
+
+- `internal/agent/{cc,codex,opencode}/*.go`（含 `provider.go` / `status.go` / `readiness.go`）
+- `internal/agent/probe/*.go`
+- `internal/agent/registry.go`、`status.go`、`hook_version*.go`、`process_info*.go`
+- `internal/module/**`、`internal/store/**`
+- `spa/**`
+
+## 2. 測試案例清單
+
+全部放在新檔 `internal/agent/coverage_test.go`（package `agent_test`，與 `registry_test.go` 同模式）。
+
+共用 stub：`supporterStub` — 實作 `StatusSupporter` 的 fake provider；無 `StatusSupporter` 的 case 可直接重用既有 `fakeProvider`（或在本檔另開最小 stub）。
+
+| # | 名稱 | 情境 | 斷言 |
+|---|---|---|---|
+| T1 | `TestCoverageEmpty` | `NewRegistry()` 未註冊任何 provider | `Coverage(r)` 回傳 nil 且 `len()==0` |
+| T2 | `TestCoverageNoStatusSupporter` | 註冊一個未實作 `StatusSupporter` 的 provider | 單列 row，`Declares=false`、`Declared==nil`、`AgentType` 正確 |
+| T3 | `TestCoverageWithStatusSupporter` | 註冊一個實作 `StatusSupporter` 的 provider，宣告 `[Running, Idle]` | 單列 row，`Declares=true`、`Declared` 元素 = `[Running, Idle]`、`AgentType` 正確 |
+| T4 | `TestCoverageDeclaredIsCopy` | provider 回傳 slice 後，呼叫端 mutate `row.Declared` | provider 內部 slice 未被影響（defensive copy 驗證） |
+| T5 | `TestCoverageEmptyDeclaration` | provider 實作 `StatusSupporter` 但回傳空 slice | `Declares=true`、`Declared` 為空 slice（非 nil）（若改為允許 nil 可調整此斷言，本 plan 偏向「空 slice，明確表達『宣告了沒有』」） |
+| T6 | `TestCoverageSortedByAgentType` | 註冊三個 provider，註冊順序 `cc` → `codex` → `opencode`（字母序恰好一致）；另加一個反序案例 `zed` → `abc` → `mid` | 回傳順序為字母序 `abc, mid, zed` |
+| T7 | `TestCoverageMixed` | 同時註冊 `StatusSupporter` 實作者 + 非實作者 | 兩列 row 各自 `Declares` 標記正確、排序正確 |
+
+### 2.1 T5 邊界決議
+
+實作 `StatusSupporter` 但回傳 nil：在 `Coverage` 內統一 normalize 為空 slice（`[]Status{}`），使 `Declares=true && Declared==nil` 不會出現 — 消除呼叫端判斷歧義。
+
+## 3. TDD 執行順序
+
+兩個 commit（邏輯分離、方便 review）：
+
+### Commit 1 — `feat(agent): add StatusSupporter optional interface`
+
+- 改動：`internal/agent/provider.go` 加 `StatusSupporter` interface（含 doc comment 說明 optional）
+- 無獨立測試（interface 本身無行為，由 Commit 2 的 Coverage 測試間接覆蓋）
+- 驗收：`go build ./...` 綠、`go vet ./...` 無 warning
+
+### Commit 2 — `feat(agent): add Coverage helper for Status declaration matrix`
+
+TDD 循序：
+
+1. **紅**：新增 `coverage_test.go`，寫 T1（`TestCoverageEmpty`） → 執行失敗（`coverage.go` 尚不存在）
+2. **綠**：建 `coverage.go`，最小實作：`Coverage` 回傳 nil → T1 綠
+3. **紅**：加 T2（未實作 provider） → 失敗
+4. **綠**：`Coverage` 走 `r.All()`、無 type assertion 檢查，填 `AgentType` + `Declares=false` + `Declared=nil` → T2 綠
+5. **紅**：加 T3（實作 provider） → 失敗
+6. **綠**：加 type assertion + 呼叫 `SupportedStatuses()` + defensive copy → T3 綠
+7. **紅**：加 T4（defensive copy） → 應綠（已在 6 實作）；若未綠，補 copy 邏輯
+8. **紅**：加 T5（空 slice normalize） → 根據實作可能綠或需補 normalize
+9. **紅**：加 T6（排序穩定）+ T7（混合） → 失敗
+10. **綠**：加 `sort.Slice` 按 `AgentType` 字母序 → T6 + T7 綠
+11. **refactor**：抽取 `classify(provider)` helper 若有助於可讀性；否則保持內聯
+
+驗收：
+- `go test ./internal/agent/...` 全綠（新增 7 個測試 + 既有測試）
+- `go vet ./...` 無 warning
+- `go build ./...` 綠
+
+## 4. 實作檔案預估
+
+| 檔案 | 動作 | 預估行數 |
+|---|---|---|
+| `internal/agent/provider.go` | 加 `StatusSupporter` interface + doc comment | +6 |
+| `internal/agent/coverage.go` | 新檔：`CoverageRow` + `Coverage()` + normalize | ~35 |
+| `internal/agent/coverage_test.go` | 新檔：T1–T7 + stub | ~100 |
+| **合計** | | **~140 行** |
+
+（超出 spec 原本估的 ~75 行，原因是測試涵蓋率加厚 + stub 樣板 — 仍在 Phase 0 範圍內合理。）
+
+## 5. 不做項目清單（防自動擴展）
+
+以下在 subagent 執行期間若出現衝動，一律拒絕：
+
+- 不幫任何 provider 實作 `SupportedStatuses()`（留 Phase 1）
+- 不新增 `/api/agent/monitor/coverage` endpoint（留 Phase 5）
+- 不寫 Coverage 結果的 JSON 序列化（留 Phase 5）
+- 不加 drift 測試（留 Phase 1）
+- 不 refactor `registry.go` / `provider.go` 既有部分
+- 不把 `HookInstaller` / `StatuslineInstaller` 包成通用 optional capability 抽象
+
+## 6. Subagent 開發指引
+
+- **cwd 強制前綴**：每個 Bash 指令以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-rebuild-spec && ` 開頭（依 `feedback_subagent_cwd_enforcement.md`）
+- **分支**：已在 `worktree-lights-rebuild-spec`，不另切
+- **Commit message 格式**：Conventional Commits，結尾加 `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+- **不 push**：由主 session 負責 push + PR（Task 3）
+- **回報**：完成後回報 commit hash 列表 + `git log --oneline -3` 輸出 + `go test ./internal/agent/...` 最後輸出摘要
+
+## 7. 驗收清單（完整 Phase 0）
+
+- [ ] 兩個 commit 符合上述 message 規範
+- [ ] `go build ./...` 綠
+- [ ] `go test ./internal/agent/...` 綠（新增 7 個測試全通過）
+- [ ] `go vet ./...` 無 warning
+- [ ] `git diff main..HEAD` 只涉及三個檔案（`provider.go` / `coverage.go` / `coverage_test.go`）
+- [ ] `Coverage()` 對空 registry 回傳 nil、對未實作 provider 標 `Declares=false`、對實作 provider 標 `Declares=true` 且 `Declared` 為 defensive copy

--- a/docs/specs/2026-04-23-lights-rebuild-phase-0-plan.md
+++ b/docs/specs/2026-04-23-lights-rebuild-phase-0-plan.md
@@ -31,7 +31,8 @@
 
 - 呼叫 `r.All()` 取得所有 provider
 - 對每個 provider 做 type assertion 判斷是否實作 `StatusSupporter`
-- 輸出順序：以 `AgentType` 字母序（ASCII）排序；重複 AgentType 保留 registration 順序作為 tie-breaker（不預期會發生，但不 panic）
+- 輸出順序：**保留 registry 註冊順序**（`Registry.All()` 原序）— 該順序已帶 `Claim` 優先權語意；Coverage 重排會丟失資訊。需要字母序的消費端（例：Phase 5 Inspector UI）自行排序
+- 重複 `AgentType`：不合併、不去重；兩列並存並保留註冊順序（罕見但支援，利於後續 diagnose provider shadowing）
 - 空 registry 回傳 `nil`（不是 empty slice） — 與 Go 慣例對齊，`len()` 皆為 0
 - 非 thread-safe 假設：呼叫期間 registry 不會被 mutate（與 `Registry.All()` 相同約束）
 
@@ -58,8 +59,9 @@
 | T3 | `TestCoverageWithStatusSupporter` | 註冊一個實作 `StatusSupporter` 的 provider，宣告 `[Running, Idle]` | 單列 row，`Declares=true`、`Declared` 元素 = `[Running, Idle]`、`AgentType` 正確 |
 | T4 | `TestCoverageDeclaredIsCopy` | provider 回傳 slice 後，呼叫端 mutate `row.Declared` | provider 內部 slice 未被影響（defensive copy 驗證） |
 | T5 | `TestCoverageEmptyDeclaration` | provider 實作 `StatusSupporter` 但回傳空 slice | `Declares=true`、`Declared` 為空 slice（非 nil）（若改為允許 nil 可調整此斷言，本 plan 偏向「空 slice，明確表達『宣告了沒有』」） |
-| T6 | `TestCoverageSortedByAgentType` | 註冊三個 provider，註冊順序 `cc` → `codex` → `opencode`（字母序恰好一致）；另加一個反序案例 `zed` → `abc` → `mid` | 回傳順序為字母序 `abc, mid, zed` |
-| T7 | `TestCoverageMixed` | 同時註冊 `StatusSupporter` 實作者 + 非實作者 | 兩列 row 各自 `Declares` 標記正確、排序正確 |
+| T6 | `TestCoverageRegistrationOrder` | 反字母序註冊 `zed` → `abc` → `mid` | 回傳順序保持註冊順序 `zed, abc, mid`（非重排） |
+| T7 | `TestCoverageDuplicateAgentType` | 同 `AgentType` 註冊兩次：第一次含 `StatusSupporter` 宣告、第二次為裸 provider | 兩列 row 都存在且保留註冊順序；`Declares` 各自正確（不合併、不去重、不重排） |
+| T8 | `TestCoverageMixed` | 同時註冊 `StatusSupporter` 實作者 + 非實作者 | 兩列 row 各自 `Declares` 標記正確、順序跟隨註冊 |
 
 ### 2.1 T5 邊界決議
 
@@ -87,12 +89,11 @@ TDD 循序：
 6. **綠**：加 type assertion + 呼叫 `SupportedStatuses()` + defensive copy → T3 綠
 7. **紅**：加 T4（defensive copy） → 應綠（已在 6 實作）；若未綠，補 copy 邏輯
 8. **紅**：加 T5（空 slice normalize） → 根據實作可能綠或需補 normalize
-9. **紅**：加 T6（排序穩定）+ T7（混合） → 失敗
-10. **綠**：加 `sort.Slice` 按 `AgentType` 字母序 → T6 + T7 綠
-11. **refactor**：抽取 `classify(provider)` helper 若有助於可讀性；否則保持內聯
+9. **紅**：加 T6（註冊順序）+ T7（重複 AgentType）+ T8（混合） → 應綠（若 Coverage 走 `r.All()` 原序即自然成立）
+10. **refactor**：抽取 `classify(provider)` helper 若有助於可讀性；否則保持內聯
 
 驗收：
-- `go test ./internal/agent/...` 全綠（新增 7 個測試 + 既有測試）
+- `go test ./internal/agent/...` 全綠（新增 8 個測試 T1–T8 + 既有測試）
 - `go vet ./...` 無 warning
 - `go build ./...` 綠
 
@@ -102,8 +103,8 @@ TDD 循序：
 |---|---|---|
 | `internal/agent/provider.go` | 加 `StatusSupporter` interface + doc comment | +6 |
 | `internal/agent/coverage.go` | 新檔：`CoverageRow` + `Coverage()` + normalize | ~35 |
-| `internal/agent/coverage_test.go` | 新檔：T1–T7 + stub | ~100 |
-| **合計** | | **~140 行** |
+| `internal/agent/coverage_test.go` | 新檔：T1–T8 + stub | ~180 |
+| **合計** | | **~220 行** |
 
 （超出 spec 原本估的 ~75 行，原因是測試涵蓋率加厚 + stub 樣板 — 仍在 Phase 0 範圍內合理。）
 
@@ -128,9 +129,13 @@ TDD 循序：
 
 ## 7. 驗收清單（完整 Phase 0）
 
-- [ ] 兩個 commit 符合上述 message 規範
+- [ ] Commits 符合上述 message 規範（Phase 0 PR 最終含：interface commit + Coverage helper commit + spec/plan docs commit + 後續 review fix commits）
 - [ ] `go build ./...` 綠
-- [ ] `go test ./internal/agent/...` 綠（新增 7 個測試全通過）
+- [ ] `go test ./internal/agent/...` 綠（新增 8 個測試 T1–T8 全通過）
 - [ ] `go vet ./...` 無 warning
-- [ ] `git diff main..HEAD` 只涉及三個檔案（`provider.go` / `coverage.go` / `coverage_test.go`）
-- [ ] `Coverage()` 對空 registry 回傳 nil、對未實作 provider 標 `Declares=false`、對實作 provider 標 `Declares=true` 且 `Declared` 為 defensive copy
+- [ ] PR 對 `origin/main` 的 diff 涉及：3 個 code 檔（`provider.go` / `coverage.go` / `coverage_test.go`）+ 3 份設計文件（discussion / spec / plan）；所有其他路徑不得出現
+- [ ] `Coverage()` 對空 registry 回傳 nil、對未實作 provider 標 `Declares=false`、對實作 provider 標 `Declares=true` 且 `Declared` 為 defensive copy、輸出順序保持 registry 註冊順序
+
+## 8. 歷史事實註記（Retrospective）
+
+本 plan 原寫於 TDD 執行**並行期間**（spec + plan + subagent 實作同一 session 內進行），實際 commit 歷史呈現的順序為：code commits 在前、spec/plan docs commit 在後。plan §3 的「兩個 commit」切分描述設計意圖，不代表實際 HEAD 重建為先 docs 後 code 的嚴格線性歷史。若需要形式化的 spec → plan → implementation 歷史，在 Phase 1 起改為：先 commit + push spec/plan 佔位檔、再派 subagent 補 code。Phase 0 不做事後 rebase（避免改動已 push 的 PR hash 影響 review continuity）。

--- a/docs/specs/2026-04-23-lights-rebuild-spec.md
+++ b/docs/specs/2026-04-23-lights-rebuild-spec.md
@@ -1,0 +1,322 @@
+# Lights Rebuild Spec
+
+- **Date**: 2026-04-23
+- **Worktree**: `lights-rebuild-spec`（branch `worktree-lights-rebuild-spec`）
+- **Context**: `docs/research/2026-04-22-lights-rebuild-discussion.md`（需求蒐集、現況盤點、骨架尺寸收斂過程、TraceStore reality check、tightened 決議）
+
+## 1. 背景
+
+Lights 子系統曾於 2026-04-22 回退一版 ~9000 行的膨脹重構。本 spec 採 **tightened 路線**：骨架最小、其他層沿用既有 infra（TraceStore / Monitor API / frame_ops / probe），分六個獨立 PR 小步推進。每 Phase 獨立 spec 節、獨立 merge、獨立 bump alpha、獨立 codex 兩輪 review。
+
+## 2. 核心概念
+
+### 2.1 Status 對齊矩陣
+
+貫穿全 spec 的共用宣告資料。不是新 runtime 結構，是**宣告層查詢結果**，回答：
+
+> 每一個已註冊的 agent provider，宣告自己支援哪些 `agent.Status`（running / waiting / idle / error / clear）？
+
+由 Phase 0 建立骨架、Phase 1 填滿、Phase 5 呈現於 Inspector。其他 Phase 不修改它。
+
+### 2.2 Probe 生命週期（現況）
+
+系統已存在三層 probe，本 spec 的修改僅在指定 Phase，其餘保持現況：
+
+| Probe 層 | 啟動條件（出場） | 退場條件 |
+|---|---|---|
+| **Liveness**（`IsAliveFor`） | 按需同步呼叫 — 用於 sweep、provider.IsAlive、無持續生命週期 | 單次呼叫即結束 |
+| **Activity**（`StartWatch`） | hook 處理完且 `result.Valid=true`，且新 status ∈ {waiting, running, idle} → 啟動前先停舊 watcher | (a) 下一個 hook 觸發 `manageActivityWatch` 時被停 (b) 一次 callback 觸發後自然結束（one-shot 設計） (c) session 改名 (d) daemon shutdown |
+| **Readiness**（`CheckReadiness`） | **模組層目前無 callsite**（已註冊、未被呼叫） | — |
+
+Activity probe callback（`onActivityDetected`）將 signal 映射為 status：
+- `Running` / `Idle` → 更新 status
+- `ShellPrompt` + top frame PID 已死 → 觸發 `sweepOnce`、不更新 status
+- `ShellPrompt` + top frame PID 存活 → 更新為 Idle
+- 受 Error Guard 保護：不覆蓋 `StatusError`
+- 完成後 broadcast `probe:activity` normalized event
+
+Readiness callsite 缺失處理方向在 Open Questions 第 1 題，本 spec 預設**不主動修復**，由 Phase 4b 視需要整合。
+
+### 2.3 TraceStore 作為跨 concern 的事實 SOT
+
+三個 concern（hook → status、frame model、probe）在 runtime 層保持獨立演化；TraceStore 提供統一的歷史事實紀錄；Phase 5 Inspector 由 trace 跨 concern 拼接呈現，而不由 runtime 強制統一。
+
+## 3. Phase Roadmap
+
+| Phase | 範圍 | 風險 | 依賴 |
+|---|---|---|---|
+| 0 | Status 對齊骨架 | 低 | — |
+| 1 | L2 狀態層對齊（宣告 + codex 事件補齊 + opencode icon + 未知事件追蹤） | 低 | Phase 0 |
+| 2 | L3 Subagent 結構升級 + proxy 偵測 + frame idle sweep | 中 | Phase 1 |
+| 3 | L1 邊界補強（daemon 後啟動補回 + 沒 parent 以 agent_type 為基準顯式化） | 中 | Phase 2 |
+| 4a | Activity probe 內部強化（彩虹字 / spinner） | 低 | Phase 3 |
+| 4b | 可選 `ProbeIntentProvider`（依 Phase 1-3 觀察決定是否做） | 中 | Phase 4a |
+| 5 | Dev Inspector UI | 低 | Phase 4 |
+
+每 Phase 節固定四段：**目的 / 改動觸及 / 驗收條件 / 備註**。
+
+---
+
+## 4. Phase 0 — Status 對齊骨架
+
+### 目的
+
+補上 agent 層「誰宣告支援哪些 Status」的宣告介面與查詢 helper，作為 Phase 1 的著力點。骨架完成時宣告矩陣為空（三家尚未實作），這正是 Phase 1 起點。
+
+### 改動觸及
+
+- `internal/agent/provider.go`：新增 optional capability interface `StatusSupporter`
+  - 契約：`SupportedStatuses()` 回傳 Status slice
+  - 設計同型於既有 `HookInstaller` / `StatuslineInstaller`（optional，type assertion 判斷）
+- `internal/agent/coverage.go`（新檔）：`CoverageRow` 型別 + `Coverage(Registry)` helper
+  - `CoverageRow` 欄位：agent type、是否宣告（布林）、宣告內容（Status slice，未宣告時為 nil）
+  - `Coverage` 掃 registry 所有 provider，以 agent type 字母序回傳 row slice
+- `internal/agent/coverage_test.go`（新檔）：TDD 測試，涵蓋空 registry、未實作 provider、實作 provider 三情境 + 排序穩定性
+- 零改動：既有 provider / handler / module / probe / store
+
+### 驗收條件
+
+- `go build ./...` 與 `go test ./internal/agent/...` 綠
+- PR diff 僅涉及上述三檔
+- Coverage 對未實作 `StatusSupporter` 的 provider 回傳明確「未宣告」標記，不是 nil 歧義
+
+### 備註
+
+`SupportedStatuses()` 刻意不在 Phase 0 於任一 provider 實作 — 保持骨架純度，避免 Phase 0 與 Phase 1 責任混淆。
+
+---
+
+## 5. Phase 1 — L2 狀態層對齊
+
+### 目的
+
+填滿 Phase 0 的對齊矩陣、補齊 codex 事件覆蓋、補 opencode icon、把未知事件從丟棄改為追蹤不處理。一次對齊「說好支援的」與「實際實作的」。
+
+### 改動觸及
+
+- 三家 provider（`cc` / `codex` / `opencode`）實作 `SupportedStatuses()`
+- `internal/agent/codex/status.go` 補齊五個事件的 DeriveStatus：
+  - `Notification`、`PermissionRequest`、`SubagentStart/Stop`、`SessionEnd`、`StopFailure`
+  - 對照 cc 的既有 mapping 為參考
+- `spa/src/lib/agent-icons.tsx` 補 opencode brand icon
+- `internal/module/agent/handler.go` 的 `Valid=false` 早退分支改寫：
+  - 新行為：寫一筆 trace step，kind 維持 verify 層，reason 標示 `event_not_in_catalog`，payload 保留 raw
+  - 不更新 status（保留「追蹤不處理」精神）
+- 新增 declared-vs-implemented drift 測試：
+  - 對每個 provider，驗證 `SupportedStatuses()` 宣告的每個 Status 都能由其 `DeriveStatus` 在某 event 下實際產出
+  - 使用 table-driven 格式 + 現有 cc hook fixture 集合
+
+### 驗收條件
+
+- Coverage 回傳三 row 皆為「已宣告」，且 drift 測試全綠
+- codex 五個事件在對應 hook fixture 下產出預期 status
+- opencode icon 在 SPA TabIcon 顯示正確（手動驗證：啟動 opencode session 看 tab）
+- 未知事件可由 `SELECT ... FROM agent_trace_steps WHERE reason = 'event_not_in_catalog'` 查到
+- `pnpm run lint && pnpm run build` 綠、`go test ./...` 綠
+
+### 備註
+
+drift 測試是宣告驅動的 — 若未來 provider 宣告 `StatusWaiting` 但沒實作對應產出路徑，測試應失敗。這彌補了 tightened 骨架的留白 trade-off。
+
+---
+
+## 6. Phase 2 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
+
+### 目的
+
+三件事一起做：
+1. `frame.Subagents` 從字串 ID list 升級為結構化 ref（含 Type、StartedAt、IsProxy）
+2. 偵測同 pane 內跨 agent type 的 proxy 情境，掛進 parent 的 Subagents 而非建新 frame
+3. 清理殭屍 frame（實際觀察：codex-companion 不 auto exit，幾小時內會累積）
+
+### 改動觸及
+
+- `internal/store/frame.go`
+  - `SubagentRef` 欄位擴充：agent ID（既有）+ agent type + started at + is proxy（新增三項）
+  - `Frame.Subagents` 欄位型別同步升級為 `[]SubagentRef`
+  - alpha 階段允許直接破壞式升級，不寫 migration（依靠重建 DB）
+- `internal/module/agent/frame_ops.go`
+  - 新增 proxy 偵測分支，條件為：
+    - 同 pane 已存在一個 parent frame
+    - 新 hook 的 agent_type 與該 parent 不同
+  - 命中時將 ref 附加到 parent.Subagents 並標 `IsProxy=true`，不建新 frame
+- Frame idle sweep：
+  - 既有 `sweepOnce` 路徑補一條「無 hook 活動超過閾值」規則
+  - 閾值預設 1 小時，以 Configurable const 表達（非 runtime flag）
+  - 清除 frame 時，若該 session 有 active activity watcher，同步呼叫 `StopWatch`
+- `spa/src/stores/useAgentStore.ts` subagents 欄位升級為結構化型別
+- `spa/src/components/SubagentDots.tsx` 依 agent type 顯示顏色 / 圖示差異
+
+### 驗收條件
+
+- 手動場景：單一 pane 內 cc → `/codex:*` 啟動 codex，codex frame 以 proxy 掛進 cc parent 的 Subagents，非獨立 frame
+- 殭屍清理：手造超過閾值的閒置 frame，sweep 執行後 frame 被清除且有 log
+- SPA SubagentDots 可視覺區分 proxy vs native subagent
+- `go test ./...` 全綠；`frame_ops` 新路徑有 table-driven 測試（native subagent / proxy / 跨 pane 不算 proxy 三情境）
+
+### 備註
+
+sweep 與 activity watcher 職責切分：
+- sweep 清的是**frame 狀態**（stale data）
+- activity watcher 清的是**watcher 自己**（one-shot 自然退場）
+- 兩者有重疊時（sweep 清了一個有 watcher 的 frame），sweep 呼叫 `StopWatch` 處理，避免 orphan watcher
+
+---
+
+## 7. Phase 3 — L1 邊界補強
+
+### 目的
+
+處理兩個邊界：
+1. daemon 後啟動時，既有 tmux session 內的 frame 樹無法由 live hook 重建 — 需用 tmux process tree + existing sessions 推回
+2.「沒有 parent 時以 hook agent_type 為基準」的精神目前隱含在 fallback，需顯式化為具名分支（方便 trace + Inspector 呈現）
+
+### 改動觸及
+
+- `internal/module/agent/frame_ops.go`
+  - `FindByPanePID` 路徑新增「無 frame 命中」的補回分支
+  - 補回 helper：走 tmux process tree + existing sessions，推斷 agent_type + parent 關係，建立 frame 樹
+  - 補回時一併寫入 Phase 2 升級後的 SubagentRef 新欄位（Type / StartedAt / IsProxy）
+- 顯式 `no-parent` 判斷分支：進入前寫一筆 trace step，reason 標示 `no_parent_fallback`，利於 Inspector 統計
+
+### 驗收條件
+
+- daemon 重啟後在既有 session 觸發 hook，frame 樹重建、subagent 不漏
+- `no_parent_fallback` trace step 在對應情境可查
+- 手動測試清單（daemon 重啟 / 中途接回 / 冷啟動三情境）逐項通過，附 log 截圖於 PR
+- `go test ./...` 綠，補回路徑有 table-driven 測試
+
+### 備註
+
+本 Phase 依賴 Phase 2 的 `SubagentRef` 結構 — 補回時需一併填新欄位。Phase 2 未 merge 前不可開工。
+
+---
+
+## 8. Phase 4 — Probe 延伸
+
+Phase 4 分兩小步，4b 是條件執行（依 Phase 1-3 的實際觀察決定）：
+
+### 8.1 Phase 4a — Activity probe 內部強化（彩虹字 / spinner）
+
+#### 目的
+
+activity probe 目前靠畫面 hash diff 判定，但 cc 提問後若使用者在鍵盤打字 / spinner 畫面仍會被判為 Running（反之使用者停頓時可能誤判 Idle）。本 Phase 在既有 activity probe 的畫面判定中加入字元層偵測，**不改變 probe 出場條件**。
+
+#### 改動觸及
+
+- `internal/agent/probe/activity.go`
+  - 在畫面 hash diff 之外新增字元層辨識：
+    - 彩虹 ANSI 序列（指示 codex / cc 進行中）
+    - 常見 spinner 字元（braille 系列 `⠋⠙⠹...` 與旋轉系列 `/─\|`）
+  - 命中時 signal 維持 `Running` 語意，但避免 3 次穩定穩定計數被誤判觸發 `Idle`
+- `internal/agent/probe/activity_test.go` 擴充：兩種字元樣式 + 純靜態畫面的對照測試
+
+#### 驗收條件
+
+- 彩虹字 / spinner 情境下 probe 不把畫面判為 idle
+- 既有 activity probe 測試全綠
+- 效能：字元偵測在現有 probe 週期（500ms）內可吸收、不新增 goroutine
+
+#### 備註
+
+本 Phase 僅動 activity probe 內部判定邏輯，**不改** `manageActivityWatch` 的出場條件（仍是 hook 後 + status ∈ {waiting, running, idle}）。
+
+### 8.2 Phase 4b — 可選 `ProbeIntentProvider`（條件執行）
+
+#### 目的
+
+讓 agent 宣告自己期望的 probe 觸發條件與 signal mapping，讓 probe 出場條件**從寫死擴充為 agent 驅動**，並順便整合 readiness（解決現況 callsite 缺失）。僅在 Phase 1-3 過程中出現明確需求時執行。
+
+#### 改動觸及
+
+- `internal/agent/provider.go` 新增 optional interface `ProbeIntentProvider`
+  - 契約：`ProbeIntents()` 回傳 ProbeIntent slice
+  - ProbeIntent 三欄位（表格描述，非 code）：
+
+    | 欄位 | 語意 |
+    |---|---|
+    | `on_entry_status` | 進入哪個 Status 時啟動此 intent |
+    | `detector` | agent 自訂的偵測器（tmux pane 內容 → signal） |
+    | `on_signal` | signal 對應到 Status 的 mapping |
+- `internal/module/agent/module.go` 的 `manageActivityWatch`：
+  - 既有預設路徑完全保留（未實作 `ProbeIntentProvider` 的 agent 行為不變）
+  - 若 agent 實作 `ProbeIntentProvider`，於 status 變更時檢查並啟動對應 intent
+- 整合 readiness：cc 的 `CheckReadiness`（看 Allow/Deny / ❯ 提示）以 `ProbeIntent` 形式表達為「進入 waiting 時檢查 permission prompt pattern」
+
+#### 驗收條件
+
+- 至少一家 provider 使用 `ProbeIntentProvider`（建議 cc，整合現有 readiness）
+- drift 測試：宣告 intent vs 實際 probe 呼叫路徑
+- 未使用 `ProbeIntentProvider` 的 agent 行為完全不變（regression 測試覆蓋既有 Phase 1 場景）
+
+#### 備註
+
+執行門檻：Phase 1-3 結束後查 `agent_trace_steps`，若發現以下任一情境頻繁出現，才執行 Phase 4b：
+- 彩虹字強化（4a）仍無法覆蓋的誤判
+- 多 agent 需要差異化 probe 策略
+- readiness callsite 缺失成為實際 bug
+
+否則 readiness 現況問題另開 gh issue 追蹤，Phase 4 在 4a 後結案。
+
+---
+
+## 9. Phase 5 — Dev Inspector UI
+
+### 目的
+
+Settings → Development 區塊新增 Event / Trace / Frame / Coverage 四視圖 Inspector，消費既有 `/api/agent/monitor/chains`、`/chains/{id}`、`/projection` 三 endpoint，並新增 Coverage 矩陣視圖消費 Phase 0 的 `Coverage()` 結果。後端資料已齊，本 Phase 純讀取側。
+
+### 改動觸及
+
+- 新增 `/api/agent/monitor/coverage` endpoint：將 `Coverage()` 結果 JSON 化（欄位命名以 Phase 0 結構為準）
+- SPA 新增 Inspector 面板：
+  - **Chain List** — 依時間 / agent type / pane / reason 過濾
+  - **Chain Detail** — `buildStepTree` 父子樹呈現 verify / derive / apply 三階段 step，可展開原始 payload
+  - **Projection** — 目前 frame + subagent 即時快照
+  - **Coverage Matrix** — 每 agent 宣告 vs 實際產出比對，高亮缺口（drift 測試失敗情境也會在此一眼可見）
+- Settings 導航加入 Development → Inspector 入口
+- 手動測試清單：cc / codex / opencode 各觸發一次 hook，驗證四視圖資料一致
+
+### 驗收條件
+
+- 三 endpoint + Coverage endpoint 在 Inspector 內正常顯示、篩選條件生效
+- Coverage Matrix 高亮 drift（Phase 1 drift 測試若失敗也能在 UI 識別）
+- `pnpm run lint && pnpm run build` 綠
+- 效能：首次載入 < 500ms、切換 chain < 100ms
+
+### 備註
+
+Inspector 僅讀取不 mutation。若 Phase 2-4 在 Inspector 設計期間仍變動 frame / probe 結構，以最終形態為準，不預先鎖死 UI schema。
+
+---
+
+## 10. 跨 Phase 驗收策略
+
+- **PR 策略**：每 Phase 一個 PR；CLAUDE.md 規定的 TDD + 兩輪 codex review（標準 + 3 parallel 攻防體質）流程全數適用
+- **Bump 策略**：每 Phase merge 後獨立 bump alpha PR，`VERSION` / `package.json` / `spa/package.json` 三處同步
+- **Known issues 管理**：review 問題以「信心 / 關聯 / 複雜」三維度彙整；低關聯 + 中高複雜可延後成 gh issue（label 按 CLAUDE.md 兩維度：type 必選一、scope 可多選）
+- **Worktree 使用**：Phase 0 使用現有 `lights-rebuild-spec`；Phase 1+ 各自另起 worktree 避免 diff 混淆
+- **Phase 4 條件判斷**：4a 為必做；4b 僅在 Phase 1-3 過程中出現明確需求時執行，否則 Phase 4 於 4a 結案、Readiness callsite 缺失另開 issue
+
+## 11. Open Questions
+
+1. **Readiness 模組層無 callsite 如何處理** — 選項：(a) Phase 4b 整合（現 spec 預設）(b) Phase 1 補齊整合 (c) 明確標註本次不處理、開 issue 追蹤
+2. **Phase 2 是否拆 2a（schema 升級）+ 2b（proxy + sweep）** — 依 review 負擔決定，到時再拆
+3. **Phase 4b 條件是否成立** — 以 Phase 1–3 的 trace 資料為判斷依據，非預設
+4. **Phase 5 Inspector 觀察粒度** — 先以 chain（既有 `TraceChain`）為單位；per-event / per-transition 作為後續迭代
+5. **Proxy 判定條件是否加時間窗 / PPID 驗證** — Phase 2 初版僅 pane + agent_type；若 Phase 3 揭露誤判再強化
+6. **Frame idle sweep 閾值** — 初值 1 小時；以實際觀察校準
+
+## 12. 相關檔案速查
+
+- **Status**：`internal/agent/status.go`
+- **Registry**：`internal/agent/registry.go`
+- **Provider**：`internal/agent/{cc,codex,opencode}/provider.go`、`.../status.go`、`.../readiness.go`
+- **Probe**：`internal/agent/probe/{activity,liveness,readiness,shell_prompt,probe}.go`
+- **Frame**：`internal/store/frame.go`、`internal/module/agent/frame_ops.go`
+- **Hook ingest**：`internal/module/agent/handler.go`
+- **Trace**：`internal/store/trace.go`、`internal/module/agent/trace.go`
+- **Monitor API**：`internal/module/agent/monitor.go`
+- **Module lifecycle**：`internal/module/agent/module.go`（含 `manageActivityWatch` / `onActivityDetected` / `sweepOnce`）
+- **SPA state**：`spa/src/stores/useAgentStore.ts`
+- **SPA 視覺**：`spa/src/components/{TabIcon,TabStatusIndicator,SubagentDots}.tsx`、`spa/src/lib/agent-icons.tsx`

--- a/docs/specs/2026-04-23-lights-rebuild-spec.md
+++ b/docs/specs/2026-04-23-lights-rebuild-spec.md
@@ -264,11 +264,12 @@ activity probe 目前靠畫面 hash diff 判定，但 cc 提問後若使用者�
 
 ### 目的
 
-Settings → Development 區塊新增 Event / Trace / Frame / Coverage 四視圖 Inspector，消費既有 `/api/agent/monitor/chains`、`/chains/{id}`、`/projection` 三 endpoint，並新增 Coverage 矩陣視圖消費 Phase 0 的 `Coverage()` 結果。後端資料已齊，本 Phase 純讀取側。
+Settings → Development 區塊新增 Event / Trace / Frame / Coverage 四視圖 Inspector。Chain / Projection 三視圖消費**既有** `/api/agent/monitor/chains` / `/chains/{id}` / `/projection` endpoint；Coverage 視圖需要**新增一個** `/api/agent/monitor/coverage` 唯讀 endpoint 將 Phase 0 `Coverage()` 結果序列化（現有 Monitor API 沒有此路徑）。本 Phase 主體為 SPA UI，backend 改動限縮於一個無邏輯的 JSON serializer handler + 對應單元測試。
 
 ### 改動觸及
 
-- 新增 `/api/agent/monitor/coverage` endpoint：將 `Coverage()` 結果 JSON 化（欄位命名以 Phase 0 結構為準）
+- 新增 `/api/agent/monitor/coverage` endpoint：將 `Coverage()` 結果 JSON 化（欄位命名以 Phase 0 `CoverageRow` 結構為準；`Status` 以現有 string 常數 marshal；無 query / filter 參數）
+- Handler 單元測試：涵蓋空 registry、單一 declared / not-declared provider、混合情境 — 與 Phase 0 `coverage_test.go` 對齊
 - SPA 新增 Inspector 面板：
   - **Chain List** — 依時間 / agent type / pane / reason 過濾
   - **Chain Detail** — `buildStepTree` 父子樹呈現 verify / derive / apply 三階段 step，可展開原始 payload

--- a/internal/agent/coverage.go
+++ b/internal/agent/coverage.go
@@ -1,7 +1,5 @@
 package agent
 
-import "sort"
-
 // CoverageRow describes a single provider's Status declaration state.
 type CoverageRow struct {
 	AgentType string
@@ -10,10 +8,12 @@ type CoverageRow struct {
 }
 
 // Coverage produces a matrix of each registered provider's declared Status
-// support, sorted by AgentType. Providers not implementing StatusSupporter
-// are reported with Declares=false and Declared=nil. Providers implementing
-// it have Declared normalized to a non-nil defensive copy (even for empty
-// declarations). Returns nil for an empty registry.
+// support, preserving the registry's registration order (which carries the
+// Claim-priority semantics defined by Registry). Providers not implementing
+// StatusSupporter are reported with Declares=false and Declared=nil.
+// Providers implementing it have Declared normalized to a non-nil defensive
+// copy (even for empty declarations). Returns nil for an empty registry.
+// Callers that need alphabetic display order should sort the result themselves.
 func Coverage(r *Registry) []CoverageRow {
 	providers := r.All()
 	if len(providers) == 0 {
@@ -33,8 +33,5 @@ func Coverage(r *Registry) []CoverageRow {
 		}
 		rows = append(rows, row)
 	}
-	sort.SliceStable(rows, func(i, j int) bool {
-		return rows[i].AgentType < rows[j].AgentType
-	})
 	return rows
 }

--- a/internal/agent/coverage.go
+++ b/internal/agent/coverage.go
@@ -1,0 +1,40 @@
+package agent
+
+import "sort"
+
+// CoverageRow describes a single provider's Status declaration state.
+type CoverageRow struct {
+	AgentType string
+	Declares  bool
+	Declared  []Status
+}
+
+// Coverage produces a matrix of each registered provider's declared Status
+// support, sorted by AgentType. Providers not implementing StatusSupporter
+// are reported with Declares=false and Declared=nil. Providers implementing
+// it have Declared normalized to a non-nil defensive copy (even for empty
+// declarations). Returns nil for an empty registry.
+func Coverage(r *Registry) []CoverageRow {
+	providers := r.All()
+	if len(providers) == 0 {
+		return nil
+	}
+	rows := make([]CoverageRow, 0, len(providers))
+	for _, p := range providers {
+		row := CoverageRow{AgentType: p.Type()}
+		if ss, ok := p.(StatusSupporter); ok {
+			row.Declares = true
+			src := ss.SupportedStatuses()
+			// Normalize nil to empty slice + defensive copy so callers cannot
+			// mutate the provider's internal slice.
+			dst := make([]Status, len(src))
+			copy(dst, src)
+			row.Declared = dst
+		}
+		rows = append(rows, row)
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].AgentType < rows[j].AgentType
+	})
+	return rows
+}

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -1,0 +1,162 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+)
+
+// supporterStub implements agent.AgentProvider and agent.StatusSupporter.
+type supporterStub struct {
+	fakeProvider
+	supported []agent.Status
+}
+
+func (s *supporterStub) SupportedStatuses() []agent.Status { return s.supported }
+
+func TestCoverageEmpty(t *testing.T) {
+	r := agent.NewRegistry()
+	rows := agent.Coverage(r)
+	if rows != nil {
+		t.Fatalf("expected nil for empty registry, got %#v", rows)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected len==0, got %d", len(rows))
+	}
+}
+
+func TestCoverageNoStatusSupporter(t *testing.T) {
+	r := agent.NewRegistry()
+	r.Register(&fakeProvider{agentType: "cc"})
+
+	rows := agent.Coverage(r)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	row := rows[0]
+	if row.AgentType != "cc" {
+		t.Fatalf("expected AgentType=cc, got %q", row.AgentType)
+	}
+	if row.Declares {
+		t.Fatalf("expected Declares=false, got true")
+	}
+	if row.Declared != nil {
+		t.Fatalf("expected Declared=nil, got %#v", row.Declared)
+	}
+}
+
+func TestCoverageWithStatusSupporter(t *testing.T) {
+	r := agent.NewRegistry()
+	r.Register(&supporterStub{
+		fakeProvider: fakeProvider{agentType: "cc"},
+		supported:    []agent.Status{agent.StatusRunning, agent.StatusIdle},
+	})
+
+	rows := agent.Coverage(r)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	row := rows[0]
+	if row.AgentType != "cc" {
+		t.Fatalf("expected AgentType=cc, got %q", row.AgentType)
+	}
+	if !row.Declares {
+		t.Fatalf("expected Declares=true, got false")
+	}
+	if len(row.Declared) != 2 {
+		t.Fatalf("expected 2 statuses, got %d", len(row.Declared))
+	}
+	if row.Declared[0] != agent.StatusRunning || row.Declared[1] != agent.StatusIdle {
+		t.Fatalf("expected [Running, Idle], got %#v", row.Declared)
+	}
+}
+
+func TestCoverageDeclaredIsCopy(t *testing.T) {
+	internal := []agent.Status{agent.StatusRunning, agent.StatusIdle}
+	stub := &supporterStub{
+		fakeProvider: fakeProvider{agentType: "cc"},
+		supported:    internal,
+	}
+	r := agent.NewRegistry()
+	r.Register(stub)
+
+	rows := agent.Coverage(r)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	// Mutate the returned slice; provider's internal slice must not change.
+	rows[0].Declared[0] = agent.StatusError
+
+	if stub.supported[0] != agent.StatusRunning {
+		t.Fatalf("provider's internal slice was mutated: %#v", stub.supported)
+	}
+}
+
+func TestCoverageEmptyDeclaration(t *testing.T) {
+	r := agent.NewRegistry()
+	r.Register(&supporterStub{
+		fakeProvider: fakeProvider{agentType: "cc"},
+		supported:    nil, // provider returns nil
+	})
+
+	rows := agent.Coverage(r)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	row := rows[0]
+	if !row.Declares {
+		t.Fatalf("expected Declares=true, got false")
+	}
+	if row.Declared == nil {
+		t.Fatalf("expected Declared to be non-nil empty slice, got nil")
+	}
+	if len(row.Declared) != 0 {
+		t.Fatalf("expected empty Declared, got %#v", row.Declared)
+	}
+}
+
+func TestCoverageSortedByAgentType(t *testing.T) {
+	r := agent.NewRegistry()
+	// Register in reverse alphabetical order to ensure sort is exercised.
+	r.Register(&fakeProvider{agentType: "zed"})
+	r.Register(&fakeProvider{agentType: "abc"})
+	r.Register(&fakeProvider{agentType: "mid"})
+
+	rows := agent.Coverage(r)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+	want := []string{"abc", "mid", "zed"}
+	for i, w := range want {
+		if rows[i].AgentType != w {
+			t.Fatalf("row %d: expected AgentType=%q, got %q", i, w, rows[i].AgentType)
+		}
+	}
+}
+
+func TestCoverageMixed(t *testing.T) {
+	r := agent.NewRegistry()
+	r.Register(&supporterStub{
+		fakeProvider: fakeProvider{agentType: "cc"},
+		supported:    []agent.Status{agent.StatusRunning},
+	})
+	r.Register(&fakeProvider{agentType: "codex"})
+
+	rows := agent.Coverage(r)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	// Sorted: cc < codex
+	if rows[0].AgentType != "cc" || rows[1].AgentType != "codex" {
+		t.Fatalf("expected order [cc, codex], got [%q, %q]", rows[0].AgentType, rows[1].AgentType)
+	}
+	if !rows[0].Declares {
+		t.Fatalf("expected cc Declares=true")
+	}
+	if rows[1].Declares {
+		t.Fatalf("expected codex Declares=false")
+	}
+	if rows[1].Declared != nil {
+		t.Fatalf("expected codex Declared=nil, got %#v", rows[1].Declared)
+	}
+}

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -115,9 +115,11 @@ func TestCoverageEmptyDeclaration(t *testing.T) {
 	}
 }
 
-func TestCoverageSortedByAgentType(t *testing.T) {
+func TestCoverageRegistrationOrder(t *testing.T) {
 	r := agent.NewRegistry()
-	// Register in reverse alphabetical order to ensure sort is exercised.
+	// Register in reverse alphabetical order; Coverage must preserve the
+	// registry's registration order (which carries Claim-priority semantics),
+	// not re-sort alphabetically.
 	r.Register(&fakeProvider{agentType: "zed"})
 	r.Register(&fakeProvider{agentType: "abc"})
 	r.Register(&fakeProvider{agentType: "mid"})
@@ -126,11 +128,38 @@ func TestCoverageSortedByAgentType(t *testing.T) {
 	if len(rows) != 3 {
 		t.Fatalf("expected 3 rows, got %d", len(rows))
 	}
-	want := []string{"abc", "mid", "zed"}
+	want := []string{"zed", "abc", "mid"}
 	for i, w := range want {
 		if rows[i].AgentType != w {
 			t.Fatalf("row %d: expected AgentType=%q, got %q", i, w, rows[i].AgentType)
 		}
+	}
+}
+
+func TestCoverageDuplicateAgentType(t *testing.T) {
+	// Two providers sharing the same AgentType (e.g. a plugin shadowing a
+	// built-in). Coverage must preserve both rows in their registration order
+	// so downstream diagnostics can see the shadow, instead of collapsing or
+	// re-sorting them.
+	r := agent.NewRegistry()
+	r.Register(&supporterStub{
+		fakeProvider: fakeProvider{agentType: "cc"},
+		supported:    []agent.Status{agent.StatusRunning},
+	})
+	r.Register(&fakeProvider{agentType: "cc"}) // duplicate, registered second
+
+	rows := agent.Coverage(r)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows (duplicates preserved), got %d", len(rows))
+	}
+	if rows[0].AgentType != "cc" || rows[1].AgentType != "cc" {
+		t.Fatalf("expected both rows to be AgentType=cc, got [%q, %q]", rows[0].AgentType, rows[1].AgentType)
+	}
+	if !rows[0].Declares {
+		t.Fatalf("expected first-registered cc to keep Declares=true")
+	}
+	if rows[1].Declares {
+		t.Fatalf("expected second-registered cc to keep Declares=false (registration order, no rewrite)")
 	}
 }
 
@@ -146,7 +175,7 @@ func TestCoverageMixed(t *testing.T) {
 	if len(rows) != 2 {
 		t.Fatalf("expected 2 rows, got %d", len(rows))
 	}
-	// Sorted: cc < codex
+	// Registration order: cc first, codex second (not alphabetic guarantee).
 	if rows[0].AgentType != "cc" || rows[1].AgentType != "codex" {
 		t.Fatalf("expected order [cc, codex], got [%q, %q]", rows[0].AgentType, rows[1].AgentType)
 	}

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -84,6 +84,15 @@ type StreamCapable interface {
 	ResumeCommand(state SessionState) string
 }
 
+// StatusSupporter is an optional capability for providers to declare which
+// Status values they can emit. Providers that do not implement this interface
+// are treated as "not declared" by the Coverage helper. Returning an empty
+// slice is a valid declaration meaning "supports no Status values" and is
+// distinct from not implementing the interface at all.
+type StatusSupporter interface {
+	SupportedStatuses() []Status
+}
+
 // SessionState holds agent session state for stream handoff.
 type SessionState struct {
 	SessionID string


### PR DESCRIPTION
## Summary

Lights 子系統 rebuild 系列的 Phase 0。導入最小骨架讓後續 Phase 可對齊 agent Status：

- 新 optional interface `StatusSupporter`（`SupportedStatuses() []Status`）— 與既有 `HookInstaller` / `StatuslineInstaller` 同型
- 新 `Coverage(Registry)` helper 產出 agent 宣告矩陣（`[]CoverageRow`）— 字母序排序、`Declared` defensive copy、nil → `[]Status{}` normalize
- 零改動既有 provider / handler / module / probe（刻意讓 Phase 0 只建骨架、Phase 1 才填入各 agent 實作）
- 附帶完整 tightened 版 Lights rebuild spec（六 Phase roadmap）+ Phase 0 TDD plan 文件

## Context docs

- `docs/research/2026-04-22-lights-rebuild-discussion.md` — 需求 / 現況盤點 / 骨架尺寸收斂 / TraceStore reality check / tightened 決議
- `docs/specs/2026-04-23-lights-rebuild-spec.md` — 六 Phase 整合 spec
- `docs/specs/2026-04-23-lights-rebuild-phase-0-plan.md` — Phase 0 TDD plan + 契約鎖定

## Commits

| hash | 動作 |
|---|---|
| `8516bc0a` → `2ddfe39f` | Discussion 文件（4 個增量 commit） |
| `3865ce3e` | Spec + Phase 0 plan |
| `ec8160b9` | 加 `StatusSupporter` interface |
| `cd87e2e9` | 加 Coverage helper + 7 個 TDD 測試 |

## Test plan

- [x] `go build ./...` 綠
- [x] `go vet ./...` 無 warning
- [x] `go test ./internal/agent/...` 綠（新 7 個測試 T1-T7 + 既有 7 個全通過）
- [x] PR diff 僅涉及骨架三檔 + 三份設計文件（1133 行新增，零刪除）
- [ ] Codex 兩輪 review（R1 標準；R2 三 parallel 攻擊/防守/體質）— 主 session 接手

## 範圍邊界

本 PR **刻意不做**（留給後續 Phase）：
- 三家 provider 實作 `SupportedStatuses()` — Phase 1
- declared-vs-implemented drift 測試 — Phase 1
- `/api/agent/monitor/coverage` endpoint + JSON 序列化 — Phase 5
- Subagent 結構升級 / Proxy 偵測 / Frame idle sweep — Phase 2