### PR TITLE
feat(agent): Lights rebuild — Phase 1 L2 status alignment

### DIFF
--- a/docs/specs/2026-04-23-lights-rebuild-phase-1-plan.md
+++ b/docs/specs/2026-04-23-lights-rebuild-phase-1-plan.md
@@ -1,0 +1,298 @@
+# Phase 1 TDD Plan — L2 狀態層對齊
+
+- **Date**: 2026-04-23
+- **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §5
+- **Worktree**: `lights-phase-1`（branch `worktree-lights-phase-1`）
+- **依賴**: Phase 0（merged at `03925b1b`）— `StatusSupporter` interface + `Coverage()` helper 已就緒
+- **範圍**：三家 provider 實作 `SupportedStatuses()` + codex 補齊 5 個事件 + opencode brand icon + 未知事件追蹤 + drift 測試
+
+## 1. 契約鎖定
+
+本節鎖定全 Phase 行為，避免實作期再決策。
+
+### 1.1 SupportedStatuses() 宣告矩陣
+
+每家 provider 在 `provider.go` 加 `SupportedStatuses()` 方法。宣告原則：**只列出該 provider `DeriveStatus` 在當前實作下可能 emit（且 `Valid=true`）的 Status 值**。Phase 1 結束時，drift 測試確保宣告 = 實作。
+
+| Provider | 宣告 Statuses | 來源（DeriveStatus 中的 case → emit Status） |
+|---|---|---|
+| `cc` | `Running, Waiting, Idle, Error, Clear` | `UserPromptSubmit→Running` / `Notification(permission_prompt|elicitation_dialog)→Waiting` / `PermissionRequest→Waiting` / `SessionStart, Notification(idle_prompt|auth_success), Stop→Idle` / `StopFailure→Error` / `SessionEnd→Clear` |
+| `codex` | `Running, Waiting, Idle, Error, Clear` | Phase 1 補齊後：`UserPromptSubmit→Running` / `Notification, PermissionRequest→Waiting` / `SessionStart, Notification(idle), Stop→Idle` / `StopFailure→Error` / `SessionEnd→Clear` |
+| `opencode` | `Running, Waiting, Idle, Error, Clear` | 既有：`UserPromptSubmit→Running` / `PermissionRequest→Waiting` / `SessionStart, Stop→Idle` / `StopFailure→Error` / `SessionEnd→Clear` |
+
+**不宣告的 Status 不得出現在 DeriveStatus emit 路徑中**。SubagentStart/Stop 在三家皆 `Valid=true` 但 `Status==""`，不影響宣告矩陣（drift 測試只看「宣告 vs 實際 emit 的非空 Status」）。
+
+defensive copy 慣例：實作回傳 fresh slice（每次新 alloc），避免 `Coverage()` 重複 copy 與消費端誤 mutate。
+
+### 1.2 Codex DeriveStatus 補齊
+
+對照 cc 的既有 mapping，codex `status.go` 新增 5 個 case（保持與 cc 同型 + opencode 已示範的 detail 抽取）：
+
+| Event | Status | Detail 抽取 |
+|---|---|---|
+| `Notification` | `notification_type=permission_prompt|elicitation_dialog → Waiting`；`idle_prompt|auth_success → Idle`；其他 → `Valid=false` | `{notification_type, message}` |
+| `PermissionRequest` | `Waiting` | `{tool_name}` |
+| `SubagentStart` / `SubagentStop` | `Valid=true`、`Status=""` | `{agent_id}` |
+| `SessionEnd` | `Clear` | — |
+| `StopFailure` | `Error` | `{error_details, error}` |
+
+設計原則：codex 的 hook 事件 schema 對齊 cc（皆走 pdx hook CLI）— 直接複用 cc 的 raw key 名（`notification_type`, `tool_name`, `agent_id`, `error`, `error_details`）。Detail 欄位選擇與 opencode 對齊 `detailSubset()` 風格（只挑指定 keys）— 但 codex 沿用 cc 的 inline `map[string]any{key: raw[key]}` 寫法保持與既有檔案一致（一個 helper 抽不抽，留 follow-up issue 評估）。
+
+**既有事件不動**：SessionStart / UserPromptSubmit / Stop 三個既有 case 保持原樣（Phase 0 不改之原則延續）。
+
+### 1.3 OpenCode Brand Icon
+
+`spa/src/lib/agent-icons.tsx` 加入 opencode brand icon。前置探查（subagent 第一步必做）：
+
+1. `ls node_modules/@lobehub/icons-static-svg/icons/ | grep -i opencode` 確認是否有官方 svg
+2. 若有：以 `wrapSvg(OpenCodeSvg)` 模式接入；若無：以 `?` Phosphor icon fallback（與 codex 的 `OpenAiLogo` 結構同型）
+
+`getAgentIcon('opencode', options)` 從回傳 `undefined` 改為回傳 `AgentIconComponent`。`GetAgentIconOptions` 是否需新增 `opencodeVariant` 欄位由 subagent 視 svg 數量決定：單一 svg → 不加；兩個變體（如品牌 vs 簡化）→ 加。**預設只加單一品牌 icon，不引入 variant 抽象**（避免 Phase 1 範圍蔓延）。
+
+導出位置：與 `CC_ICON_VARIANTS` / `CODEX_ICON_VARIANTS` 對齊（若有 variant 才 export，無則跳過）。Settings 預覽不在 Phase 1 範圍。
+
+### 1.4 未知事件追蹤（handler.go）
+
+**現況**：`provider.DeriveStatus` 回傳 `Valid=false` 時，handler.go 沒有顯式 early-return；事件落入後續 frame/projection/broadcast 流程，僅靠分支內的 `result.Valid` guard 抑制 status 更新與 activity watch。結果是「未知事件 silently 走完管線」。
+
+**新行為**：在 `provider.DeriveStatus` 回傳後立即檢查 `result.Valid`：
+
+- `result.Valid == false` → 寫一筆 trace step（`kind="verify"`、`decision="skipped"`、`reason="event_not_in_catalog"`、`payload=raw req`）→ `trace.Finish("completed", "event_not_in_catalog")` → 200 OK 回 `{"status":"ok","reason":"event_not_in_catalog"}` → return（**不走 frame / projection / broadcast / activity watch**）
+- `result.Valid == true` → 維持現有流程
+
+trace 寫入路徑：擴充 `hookTraceCollector` 加 `Catalog(req EventRequest, eventName, reason string)` 方法（與 `Verify` 同樣 kind="verify"，但 decision="skipped" 表達 catalog miss）。或直接複用 `Verify(req, "skipped", "event_not_in_catalog", nil)`。
+
+**選擇**：複用 `Verify(...)`，無需新方法（kind 一致即可），但 parent 必為 triggerStepID（與 verify 早退路徑同型）。注意 `Verify` 內部會把 step 串到 `triggerStepID` 並更新 `verifyStepID` — catalog miss 走這條也 OK，因為 catalog miss 後 trace 立即 Finish，verifyStepID 不會被後續 frame/projection/emit 用到。
+
+trace 必須在 catalog miss 分支顯式 `trace.Finish("completed", "event_not_in_catalog")` + 設 `traceFinished=true`，確保 defer 不重複 Finish。
+
+**錯誤回應**：catalog miss 不算 error — 回 200 OK 與 `{"status":"ok","reason":"event_not_in_catalog"}`，與既有 verify_rejected（202 Accepted）區分（verify_rejected 是真的拒絕、catalog miss 是「收到但不認識」）。Hook CLI 端不需特殊處理（既有非 200 才 retry）。
+
+### 1.5 Drift 測試
+
+新檔 `internal/agent/drift_test.go`（package `agent_test`），對每家 provider 驗證宣告 = 實作：
+
+- 表驅動：`{provider, event_name, raw_event, expected_status}` fixture 集合，覆蓋 §1.1 表格中每個 emit 路徑
+- 對 `Coverage()` 的每一 row：
+  - 取出 `Declared` slice → 形成 `declaredSet`
+  - 對該 provider 跑所有 fixture → 收集 `emittedSet`（filter `Valid==true && Status!=""`）
+  - 斷言：`declaredSet == emittedSet`（雙向 — 不能有未宣告的 emit、也不能有宣告但無實作的 emit）
+
+fixture 來源：直接寫 inline（不複用 cc 的 hook payload fixture，避免跨 package 依賴）。每個事件以最小可代表 raw payload 表達（例 `Notification` 兩種 `notification_type` 各一筆覆蓋 Waiting + Idle）。
+
+實作進路：
+- 在測試檔內建一個 `providerFixtures` map：`map[string][]eventCase{eventName, rawJSON, expectedStatus}`（key 為 agent type）
+- 註冊三家 provider → 跑 `Coverage(r)` → 對每 row run fixtures → 比對 set
+
+**驗證 OFF-BY-ONE**：fixture 必須覆蓋每家 provider 宣告的**所有** Status（包含 cc 的 `Notification(idle_prompt)→Idle` 這種 sub-branch）。否則 drift 漏網 → false negative。Plan §3 的 TDD 紅綠循環會強制這點。
+
+### 1.6 零改動邊界
+
+以下檔案 Phase 1 **不得觸碰**：
+
+- `internal/agent/provider.go`、`registry.go`、`status.go`、`coverage.go`（Phase 0 已完成）
+- `internal/agent/{cc,codex,opencode}/hooks.go`（Codex 的 hook 安裝清單**不更新**，補齊 hook installer 是另一個 phase 的事）
+- `internal/agent/{cc,opencode}/status.go`（只動 codex/status.go）
+- `internal/agent/probe/**`
+- `internal/store/**`（trace 寫入經 collector，不改 store schema）
+- `internal/module/**` 除 `handler.go` 與必要的測試補強外不動
+- `spa/**` 除 `agent-icons.tsx` 外不動
+
+## 2. 測試案例清單
+
+按檔案組織：
+
+### 2.1 Coverage 宣告測試（既有 + 新增）
+
+`internal/agent/coverage_test.go` 既有 8 case 不動。Phase 1 補一個整合 case：
+
+| # | 名稱 | 情境 | 斷言 |
+|---|---|---|---|
+| C1 | `TestCoverageRealProviders` | 註冊真實 cc / codex / opencode provider | 三 row 皆 `Declares=true`、`Declared` 非空、皆包含 `Running, Waiting, Idle, Error, Clear` |
+
+（不取代既有 stub-based 測試 — stub 測試守的是 `Coverage()` 邏輯本身，real-provider 測試守的是「真實 provider 已實作 interface」。）
+
+### 2.2 Provider SupportedStatuses 單元測試
+
+各 provider 的 `provider_test.go` 加：
+
+| # | 檔案 | 名稱 | 斷言 |
+|---|---|---|---|
+| P1 | `cc/provider_test.go` | `TestCCSupportedStatuses` | 回傳 `[Running, Waiting, Idle, Error, Clear]`（順序由實作決定，斷言用 set 比對） |
+| P2 | `codex/provider_test.go` | `TestCodexSupportedStatuses` | 同上 |
+| P3 | `opencode/provider_test.go` | `TestOpenCodeSupportedStatuses` | 同上（注意 opencode 沒有現成 `provider_test.go` — 需新建） |
+| P4 | 三家任一 | `TestSupportedStatusesReturnsFreshSlice` | 連續呼叫兩次回傳 slice 必為**不同 backing array**（mutate 第一次回傳不影響第二次） |
+
+P4 只需在一家驗（cc 即可），三家用同樣的「直接 return literal」implementation pattern → 自然成立。
+
+### 2.3 Codex DeriveStatus 5 個新事件測試
+
+`codex/status_test.go` 新增：
+
+| # | 名稱 | event / raw | 斷言 |
+|---|---|---|---|
+| CD1 | `TestCodexDeriveStatus_NotificationPermission` | `Notification` / `{notification_type:"permission_prompt"}` | `Valid=true, Status=Waiting, Detail.notification_type=="permission_prompt"` |
+| CD2 | `TestCodexDeriveStatus_NotificationIdle` | `Notification` / `{notification_type:"idle_prompt"}` | `Valid=true, Status=Idle` |
+| CD3 | `TestCodexDeriveStatus_NotificationUnknown` | `Notification` / `{notification_type:"weird"}` | `Valid=false`（與 cc 一致 — 未知 notification_type 視為 invalid） |
+| CD4 | `TestCodexDeriveStatus_PermissionRequest` | `PermissionRequest` / `{tool_name:"Bash"}` | `Valid=true, Status=Waiting, Detail.tool_name=="Bash"` |
+| CD5 | `TestCodexDeriveStatus_SubagentStart` | `SubagentStart` / `{agent_id:"abc"}` | `Valid=true, Status=="", Detail.agent_id=="abc"` |
+| CD6 | `TestCodexDeriveStatus_SubagentStop` | `SubagentStop` / `{agent_id:"xyz"}` | 同 CD5（Status="") |
+| CD7 | `TestCodexDeriveStatus_SessionEnd` | `SessionEnd` / `{}` | `Valid=true, Status=Clear` |
+| CD8 | `TestCodexDeriveStatus_StopFailure` | `StopFailure` / `{error:"OOM"}` | `Valid=true, Status=Error, Detail.error=="OOM"` |
+
+**移除**：既有 `TestCodexDeriveStatus_UnknownEvent`（line 37）測 `Notification` 為 invalid — 此 case 在 Phase 1 後 `Notification` 已被識別。改用 `{event:"FutureEvent"}` 作為新的 unknown event smoke test。
+
+### 2.4 Drift 測試（新檔）
+
+`internal/agent/drift_test.go`：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| D1 | `TestDriftDeclaredEqualsEmitted` | 對三家 provider，`declaredSet == emittedSet` |
+| D2 | `TestDriftFixtureCoverageNonEmpty` | 防呆：每家 provider 的 fixture set 非空（避免有人 commit 一個空 fixture 然後 D1 假綠） |
+
+D1 實作要點：
+- 共用 `providerCases` table（map[agentType] → []case）
+- 取 `Coverage(r)` 的每 row → 與 fixtures 比對
+- 失敗訊息列出 declared / emitted set diff（方便 debug）
+
+### 2.5 Handler Catalog Miss 測試
+
+`internal/module/agent/handler_test.go` 加：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| H1 | `TestHandleEvent_CatalogMiss_WritesTraceAndReturnsOK` | 註冊 cc provider，POST 不認識的 event → response 200 + body `{"status":"ok","reason":"event_not_in_catalog"}` + trace chain 含 `verify` step with `decision=skipped, reason=event_not_in_catalog` + 無 frame/projection/emit step |
+| H2 | `TestHandleEvent_CatalogMiss_NoStatusUpdate` | 同情境，`m.currentStatus[session]` 不變、`m.subagents[session]` 不變、無 broadcast |
+| H3 | `TestHandleEvent_CatalogMiss_NoActivityWatch` | 同情境，`prober` 的 `StartWatch` 不被呼叫（用 mock 或計數器） |
+
+H1/H2/H3 共用 setup：建一個 minimal Module（依 trace_test.go pattern），bypass verify（`verifyEventFn = always_accept`），mock prober，POST event → 斷言。
+
+## 3. TDD 執行順序
+
+Subagent 嚴格按以下順序執行；每個 step 一個 commit，commit message 用 Conventional Commits + `Co-Authored-By: Claude Opus 4.7 (1M context)`。
+
+### Commit 1 — `feat(agent/cc): declare SupportedStatuses`
+- 紅：寫 P1 → 失敗（cc.Provider 無 method）
+- 綠：在 `internal/agent/cc/provider.go` 加 `SupportedStatuses()` return literal slice
+- 跑 `go test ./internal/agent/cc/...` 綠
+
+### Commit 2 — `feat(agent/opencode): declare SupportedStatuses`
+- 紅：建 `internal/agent/opencode/provider_test.go` 寫 P3 → 失敗
+- 綠：加 method
+- 跑 `go test ./internal/agent/opencode/...` 綠
+
+### Commit 3 — `feat(agent/codex): expand DeriveStatus to cover 5 events`
+- 紅：寫 CD1-CD8 → 失敗（每個新 case）
+- 綠：擴 `codex/status.go` 加 5 case + 修 unknown event smoke test
+- 跑 `go test ./internal/agent/codex/...` 綠
+- **不**在這個 commit 加 `SupportedStatuses` — 留 Commit 4
+
+### Commit 4 — `feat(agent/codex): declare SupportedStatuses`
+- 紅：寫 P2 → 失敗
+- 綠：加 method
+- 跑 `go test ./internal/agent/codex/...` 綠
+
+（Commit 3/4 切分原因：DeriveStatus 補齊與宣告分離，方便 review 各看一塊；若 reviewer 要驗「宣告 = 真實實作」可看到 Commit 3 → 4 的 diff 是對應的。）
+
+### Commit 5 — `test(agent): add coverage real-provider integration test`
+- 紅：寫 C1（用真 provider 註冊 registry） → 應綠（前 4 commit 已實作）
+- 此 commit 是「verification」性質 commit — 確保整合層綠
+
+### Commit 6 — `test(agent): add declared-vs-emitted drift test`
+- 紅：寫 D1 + D2 → 應綠（fixture 對齊 §1.1 表格）
+- 若 D1 紅：補 fixture 或修 provider declaration（直到對齊）
+
+### Commit 7 — `feat(agent): track unknown events as catalog miss`
+- 紅：寫 H1-H3 → 失敗（handler 仍走後續流程）
+- 綠：在 `handler.go` 的 `provider.DeriveStatus` 後加 `if !result.Valid` early-return + trace.Verify(...) + Finish + 200 OK response
+- 跑 `go test ./internal/module/agent/...` 綠
+
+### Commit 8 — `feat(spa): add OpenCode brand icon`
+- 探：`ls spa/node_modules/@lobehub/icons-static-svg/icons/ | grep -i opencode`
+- 改：`spa/src/lib/agent-icons.tsx`
+- 跑 `cd spa && npx vitest run` 綠（無新測試 — icon 是純元件，靠 lint + build 把關）
+- 跑 `cd spa && pnpm run lint && pnpm run build` 綠
+
+### Commit 9 — `docs: phase 1 plan retrospective notes`（可選）
+若 §3 順序與實際執行有偏差，補一段歷史事實註記（仿 Phase 0 plan §8）。
+
+## 4. 實作檔案預估
+
+| 檔案 | 動作 | 預估行數 |
+|---|---|---|
+| `internal/agent/cc/provider.go` | +`SupportedStatuses()` | +5 |
+| `internal/agent/codex/provider.go` | +`SupportedStatuses()` | +5 |
+| `internal/agent/codex/status.go` | +5 case + helper | +35 |
+| `internal/agent/codex/status_test.go` | +CD1-CD8、修 unknown smoke | +60 |
+| `internal/agent/opencode/provider.go` | +`SupportedStatuses()` | +5 |
+| `internal/agent/opencode/provider_test.go` | 新檔 +P3 | +25 |
+| `internal/agent/cc/provider_test.go` | +P1 + P4 | +30 |
+| `internal/agent/codex/provider_test.go` | +P2 | +15 |
+| `internal/agent/coverage_test.go` | +C1 | +35 |
+| `internal/agent/drift_test.go` | 新檔 +D1 + D2 | +130 |
+| `internal/module/agent/handler.go` | catalog miss early-return | +20 |
+| `internal/module/agent/handler_test.go` | +H1-H3 | +120 |
+| `spa/src/lib/agent-icons.tsx` | +opencode icon | +5 |
+| `docs/specs/2026-04-23-lights-rebuild-phase-1-plan.md` | 本檔 | +250 |
+| **合計** | | **~740 行**（含 plan 文件） |
+
+## 5. 不做項目清單（防自動擴展）
+
+以下衝動一律拒絕 — 由 subagent 在 PR description / commit message 中**明確聲明拒絕**：
+
+- 不更新 `codexHookEvents` 清單加入新 5 個事件（hook installer 是 separate concern，等 codex CLI / proxy 路徑成熟）
+- 不寫 OpenCode icon 的 variant 系統（單一 brand icon 即可，預設無 variant）
+- 不抽 `detailSubset()` helper 到 `internal/agent` 共用（codex 沿用既有 inline 寫法）
+- 不調整 cc / opencode 既有 DeriveStatus（即使發現可優化）
+- 不加 `/api/agent/monitor/coverage` endpoint（留 Phase 5）
+- 不改 trace.go schema（catalog miss 走既有 verify-kind 通道）
+- 不引入 `Catalog()` 新 collector method（複用 `Verify()`）
+- 不重整 `handler.go`（catalog miss 是局部增加，不順手 refactor）
+- 不加 SubagentStart/Stop 的 Status（cc/opencode 既有設計 Status="" 表 detail-only — codex 沿用）
+
+## 6. Subagent 開發指引
+
+- **cwd 強制前綴**：每個 Bash 指令以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-phase-1 && ` 開頭（依 `feedback_subagent_cwd_enforcement.md`）
+- **分支**：已在 `worktree-lights-phase-1`，不另切；不 push（主 session 負責）
+- **Commit message 格式**：Conventional Commits + 結尾加 `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+- **TDD 嚴格紅綠**：每個 commit 內先寫測試跑紅再實作跑綠 — 不可批次寫完所有 test + 一次實作
+- **回報**：完成後回報 commit hash 列表 + `git log --oneline -10` + `go test ./internal/agent/... ./internal/module/agent/...` 完整輸出 + `pnpm install` 與 `cd spa && pnpm run lint && pnpm run build` 結果
+- **Codex sandbox 限制**：Codex sandbox 無網路 — subagent 在 worktree 內執行 `pnpm install`（依 `feedback_codex_sandbox_no_install.md`）。若失敗，由主 session 接手手動跑
+
+## 7. 驗收清單（完整 Phase 1）
+
+- [ ] 9 個 commits 符合上述 message 規範（Commit 9 可選）
+- [ ] `go build ./...` 綠
+- [ ] `go test ./...` 綠（覆蓋新增 P1-P4 / CD1-CD8 / C1 / D1-D2 / H1-H3 共 18 個測試）
+- [ ] `go vet ./...` 無 warning
+- [ ] `cd spa && pnpm run lint && pnpm run build` 綠
+- [ ] `cd spa && npx vitest run` 綠
+- [ ] PR diff 涉及檔案：§4 表格列出的 13 個檔 + plan 文件，**其餘不得出現**
+- [ ] PR description 含「不做項目」§5 的明確聲明
+- [ ] 三家 provider 在 `Coverage()` 回傳 `Declares=true`、`Declared` 非空、覆蓋 §1.1 表格 status set
+- [ ] codex `DeriveStatus` 對 5 個新 event 產出 §1.2 表格 status / detail
+- [ ] handler 對 `Valid=false` 早退寫 trace + 回 200 OK `event_not_in_catalog`
+- [ ] OpenCode 在 SPA TabIcon 顯示 brand icon（手動驗證寫進 PR description checklist）
+
+## 8. 風險與緩解
+
+| 風險 | 機率 | 影響 | 緩解 |
+|---|---|---|---|
+| codex hook 不會 emit 新 5 事件 | 高 | DeriveStatus 寫了沒人觸發 | 接受 — 為未來 codex 版本鋪路；drift 測試保證宣告與實作一致 |
+| `@lobehub/icons-static-svg` 無 opencode svg | 中 | icon fallback 需另尋 | subagent 第一步探查；若無，用 `?` Phosphor icon + 註記 follow-up issue 待官方 svg |
+| handler catalog miss 改動破壞既有 contract | 低 | 已 deploy 的 hook CLI client 收到 200 OK 但 status reason 改變 | hook CLI 既有非 200 才 retry — 200 OK 視為「事件已收到」即可，reason 是 informational |
+| drift 測試 fixture 不完整導致 D1 假綠 | 中 | 宣告/實作 mismatch 漏網 | D2 守 fixture 非空；§1.5 強調 fixture 必須覆蓋每個宣告 status 的所有 emit 路徑 |
+| codex Notification 行為與 cc 不一致 | 中 | 假設 codex hook payload schema 對齊 cc 實際不同 | Phase 1 假設一致（單一 pdx hook CLI）；若 Phase 2-3 觀察到 schema 不同，另起 issue |
+
+## 9. 兩輪 Codex Review 預期 focus
+
+**第一輪（標準）**：
+- Drift test 是否真能抓到漏網（試把 cc/codex/opencode 任一 declared status 拿掉一個，drift 應紅）
+- Handler catalog miss early-return 是否影響既有測試（回歸 `handler_test.go` 全套）
+- OpenCode icon 是否在三個 ccVariant × 兩個 codexVariant 組合下都不衝突
+
+**第二輪 3 parallel**：
+- **攻擊**：catalog miss 路徑 race / panic / SubagentStart 走到 catalog miss（不可能）/ trace finish 雙呼叫
+- **防守**：宣告矩陣與 Phase 0 `Coverage()` 契約一致性、drift 測試的 fixture 覆蓋是否真完整、codex 5 個新 case 對照 cc 是否漏 corner（如 `Notification` 的 `auth_success`）
+- **體質**：`drift_test.go` 是否過大（>200 行考慮拆 fixture 到獨立檔）、`handler.go` catalog miss 邏輯是否該抽 helper、`agent-icons.tsx` 是否該按 agent type 拆檔

--- a/internal/agent/cc/provider.go
+++ b/internal/agent/cc/provider.go
@@ -58,6 +58,20 @@ func (p *Provider) DeriveStatus(eventName string, rawEvent json.RawMessage) agen
 	return deriveCCStatus(eventName, rawEvent)
 }
 
+// SupportedStatuses declares the Status values cc.Provider's DeriveStatus may
+// emit. Returns a fresh slice on each call so callers cannot mutate provider
+// internal state. See coverage.go for the contract; drift_test.go enforces
+// the declaration matches the actual emit paths.
+func (p *Provider) SupportedStatuses() []agent.Status {
+	return []agent.Status{
+		agent.StatusRunning,
+		agent.StatusWaiting,
+		agent.StatusIdle,
+		agent.StatusError,
+		agent.StatusClear,
+	}
+}
+
 func (p *Provider) IsAlive(tmuxTarget string) bool {
 	if p.prober == nil {
 		return false

--- a/internal/agent/cc/provider_test.go
+++ b/internal/agent/cc/provider_test.go
@@ -51,3 +51,52 @@ func TestCCProvider_Identify_Negative(t *testing.T) {
 		t.Fatal("Identify should reject codex process")
 	}
 }
+
+// TestCCSupportedStatuses asserts cc.Provider implements StatusSupporter and
+// declares the full Phase 1 status set: Running, Waiting, Idle, Error, Clear.
+// Order is implementation-defined; we compare as a set.
+func TestCCSupportedStatuses(t *testing.T) {
+	var p any = cc.NewProvider(nil, nil, nil, nil)
+	ss, ok := p.(agent.StatusSupporter)
+	if !ok {
+		t.Fatal("cc.Provider must implement agent.StatusSupporter")
+	}
+	got := ss.SupportedStatuses()
+	want := map[agent.Status]bool{
+		agent.StatusRunning: true,
+		agent.StatusWaiting: true,
+		agent.StatusIdle:    true,
+		agent.StatusError:   true,
+		agent.StatusClear:   true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("SupportedStatuses len = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	seen := make(map[agent.Status]bool, len(got))
+	for _, s := range got {
+		if seen[s] {
+			t.Fatalf("SupportedStatuses contains duplicate %q (got %v)", s, got)
+		}
+		seen[s] = true
+		if !want[s] {
+			t.Fatalf("SupportedStatuses contains unexpected %q (got %v)", s, got)
+		}
+	}
+}
+
+// TestSupportedStatusesReturnsFreshSlice guards the defensive-copy convention
+// (per plan §1.1): mutating a returned slice must not affect a subsequent
+// call. Verified on cc; codex/opencode follow the same literal-return pattern.
+func TestSupportedStatusesReturnsFreshSlice(t *testing.T) {
+	p := cc.NewProvider(nil, nil, nil, nil)
+	ss := any(p).(agent.StatusSupporter)
+	first := ss.SupportedStatuses()
+	if len(first) == 0 {
+		t.Fatal("SupportedStatuses returned empty slice")
+	}
+	first[0] = agent.Status("__mutated__")
+	second := ss.SupportedStatuses()
+	if second[0] == "__mutated__" {
+		t.Fatalf("SupportedStatuses shares backing array between calls: %v", second)
+	}
+}

--- a/internal/agent/cc/status.go
+++ b/internal/agent/cc/status.go
@@ -13,7 +13,7 @@ func deriveCCStatus(eventName string, rawEvent json.RawMessage) agent.DeriveResu
 	switch eventName {
 	case "SessionStart":
 		if raw["source"] == "compact" {
-			return agent.DeriveResult{Valid: false}
+			return agent.DeriveResult{Valid: false, Reason: "compact_ignored"}
 		}
 		return agent.DeriveResult{
 			Valid:  true,
@@ -36,7 +36,7 @@ func deriveCCStatus(eventName string, rawEvent json.RawMessage) agent.DeriveResu
 		case "idle_prompt", "auth_success":
 			status = agent.StatusIdle
 		default:
-			return agent.DeriveResult{Valid: false}
+			return agent.DeriveResult{Valid: false, Reason: "notification_unknown_type"}
 		}
 		return agent.DeriveResult{
 			Valid:  true,

--- a/internal/agent/cc/status_test.go
+++ b/internal/agent/cc/status_test.go
@@ -26,6 +26,29 @@ func TestCCDeriveStatus_SessionStartCompact(t *testing.T) {
 	if r.Valid {
 		t.Fatal("compact SessionStart should be ignored")
 	}
+	if r.Reason != "compact_ignored" {
+		t.Fatalf("expected reason=compact_ignored, got %q", r.Reason)
+	}
+}
+
+func TestCCDeriveStatus_NotificationUnknownTypeReason(t *testing.T) {
+	r := deriveViaProvider("Notification", map[string]any{"notification_type": "weird"})
+	if r.Valid {
+		t.Fatal("unknown notification_type should be invalid")
+	}
+	if r.Reason != "notification_unknown_type" {
+		t.Fatalf("expected reason=notification_unknown_type, got %q", r.Reason)
+	}
+}
+
+func TestCCDeriveStatus_UnknownEventEmptyReason(t *testing.T) {
+	r := deriveViaProvider("FutureEvent", map[string]any{})
+	if r.Valid {
+		t.Fatal("unknown event should be invalid")
+	}
+	if r.Reason != "" {
+		t.Fatalf("expected empty Reason for unknown event name, got %q", r.Reason)
+	}
 }
 
 func TestCCDeriveStatus_UserPromptSubmit(t *testing.T) {

--- a/internal/agent/codex/provider.go
+++ b/internal/agent/codex/provider.go
@@ -40,6 +40,19 @@ func (p *Provider) DeriveStatus(eventName string, rawEvent json.RawMessage) agen
 	return deriveCodexStatus(eventName, rawEvent)
 }
 
+// SupportedStatuses declares the Status values codex.Provider's DeriveStatus
+// may emit after the Phase 1 expansion (Commit 3 brought codex to parity
+// with cc). Returns a fresh slice each call.
+func (p *Provider) SupportedStatuses() []agent.Status {
+	return []agent.Status{
+		agent.StatusRunning,
+		agent.StatusWaiting,
+		agent.StatusIdle,
+		agent.StatusError,
+		agent.StatusClear,
+	}
+}
+
 func (p *Provider) IsAlive(tmuxTarget string) bool {
 	return false // Deprecated: agent module uses prober.IsAliveFor directly
 }

--- a/internal/agent/codex/provider_test.go
+++ b/internal/agent/codex/provider_test.go
@@ -51,3 +51,35 @@ func TestCodexProvider_Identify_Negative(t *testing.T) {
 		t.Fatal("Identify should reject claude process")
 	}
 }
+
+// TestCodexSupportedStatuses asserts codex.Provider implements
+// StatusSupporter and declares the same Phase 1 status set as cc/opencode
+// post-DeriveStatus expansion (Commit 3).
+func TestCodexSupportedStatuses(t *testing.T) {
+	var p any = codex.NewProvider()
+	ss, ok := p.(agent.StatusSupporter)
+	if !ok {
+		t.Fatal("codex.Provider must implement agent.StatusSupporter")
+	}
+	got := ss.SupportedStatuses()
+	want := map[agent.Status]bool{
+		agent.StatusRunning: true,
+		agent.StatusWaiting: true,
+		agent.StatusIdle:    true,
+		agent.StatusError:   true,
+		agent.StatusClear:   true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("SupportedStatuses len = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	seen := make(map[agent.Status]bool, len(got))
+	for _, s := range got {
+		if seen[s] {
+			t.Fatalf("SupportedStatuses contains duplicate %q (got %v)", s, got)
+		}
+		seen[s] = true
+		if !want[s] {
+			t.Fatalf("SupportedStatuses contains unexpected %q (got %v)", s, got)
+		}
+	}
+}

--- a/internal/agent/codex/status.go
+++ b/internal/agent/codex/status.go
@@ -7,13 +7,77 @@ import (
 )
 
 func deriveCodexStatus(eventName string, rawEvent json.RawMessage) agent.DeriveResult {
+	var raw map[string]any
+	_ = json.Unmarshal(rawEvent, &raw)
+
 	switch eventName {
 	case "SessionStart":
 		return agent.DeriveResult{Valid: true, Status: agent.StatusIdle}
+
 	case "UserPromptSubmit":
 		return agent.DeriveResult{Valid: true, Status: agent.StatusRunning}
+
+	case "Notification":
+		// Mirror cc/status.go subtype mapping; codex hooks share the pdx
+		// hook CLI schema, so notification_type values align.
+		nt := strVal(raw, "notification_type")
+		var status agent.Status
+		switch nt {
+		case "permission_prompt", "elicitation_dialog":
+			status = agent.StatusWaiting
+		case "idle_prompt", "auth_success":
+			status = agent.StatusIdle
+		default:
+			return agent.DeriveResult{Valid: false}
+		}
+		return agent.DeriveResult{
+			Valid:  true,
+			Status: status,
+			Detail: map[string]any{
+				"notification_type": nt,
+				"message":           raw["message"],
+			},
+		}
+
+	case "PermissionRequest":
+		return agent.DeriveResult{
+			Valid:  true,
+			Status: agent.StatusWaiting,
+			Detail: map[string]any{
+				"tool_name": raw["tool_name"],
+			},
+		}
+
 	case "Stop":
 		return agent.DeriveResult{Valid: true, Status: agent.StatusIdle}
+
+	case "StopFailure":
+		return agent.DeriveResult{
+			Valid:  true,
+			Status: agent.StatusError,
+			Detail: map[string]any{
+				"error_details": raw["error_details"],
+				"error":         raw["error"],
+			},
+		}
+
+	case "SessionEnd":
+		return agent.DeriveResult{Valid: true, Status: agent.StatusClear}
+
+	case "SubagentStart", "SubagentStop":
+		// Detail-only event: Valid=true, Status="" (mirrors cc/opencode).
+		return agent.DeriveResult{
+			Valid:  true,
+			Detail: map[string]any{"agent_id": raw["agent_id"]},
+		}
 	}
+
 	return agent.DeriveResult{Valid: false}
+}
+
+func strVal(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
 }

--- a/internal/agent/codex/status.go
+++ b/internal/agent/codex/status.go
@@ -28,7 +28,7 @@ func deriveCodexStatus(eventName string, rawEvent json.RawMessage) agent.DeriveR
 		case "idle_prompt", "auth_success":
 			status = agent.StatusIdle
 		default:
-			return agent.DeriveResult{Valid: false}
+			return agent.DeriveResult{Valid: false, Reason: "notification_unknown_type"}
 		}
 		return agent.DeriveResult{
 			Valid:  true,

--- a/internal/agent/codex/status_test.go
+++ b/internal/agent/codex/status_test.go
@@ -13,6 +13,11 @@ func deriveViaProvider(eventName string) agent.DeriveResult {
 	return p.DeriveStatus(eventName, json.RawMessage(`{}`))
 }
 
+func deriveWithRaw(eventName, rawJSON string) agent.DeriveResult {
+	p := codex.NewProvider()
+	return p.DeriveStatus(eventName, json.RawMessage(rawJSON))
+}
+
 func TestCodexDeriveStatus_SessionStart(t *testing.T) {
 	r := deriveViaProvider("SessionStart")
 	if !r.Valid || r.Status != agent.StatusIdle {
@@ -34,9 +39,128 @@ func TestCodexDeriveStatus_Stop(t *testing.T) {
 	}
 }
 
+// TestCodexDeriveStatus_UnknownEvent is the post-Phase-1 smoke test for
+// unknown events. Notification is now a known event (see CD1-CD3), so we
+// switch to a synthetic future-event name that no provider claims.
 func TestCodexDeriveStatus_UnknownEvent(t *testing.T) {
-	r := deriveViaProvider("Notification")
+	r := deriveViaProvider("FutureEvent")
 	if r.Valid {
-		t.Fatal("Codex should not handle Notification")
+		t.Fatal("Codex should not handle unknown future events")
+	}
+}
+
+// CD1: Notification(permission_prompt) → Waiting + detail
+func TestCodexDeriveStatus_NotificationPermission(t *testing.T) {
+	r := deriveWithRaw("Notification", `{"notification_type":"permission_prompt","message":"hi"}`)
+	if !r.Valid {
+		t.Fatalf("expected Valid, got %+v", r)
+	}
+	if r.Status != agent.StatusWaiting {
+		t.Fatalf("status = %q, want waiting", r.Status)
+	}
+	if r.Detail["notification_type"] != "permission_prompt" {
+		t.Fatalf("detail.notification_type = %v, want permission_prompt", r.Detail["notification_type"])
+	}
+	if r.Detail["message"] != "hi" {
+		t.Fatalf("detail.message = %v, want hi", r.Detail["message"])
+	}
+}
+
+// CD1b: Notification(elicitation_dialog) → Waiting (mirrors cc)
+func TestCodexDeriveStatus_NotificationElicitation(t *testing.T) {
+	r := deriveWithRaw("Notification", `{"notification_type":"elicitation_dialog"}`)
+	if !r.Valid || r.Status != agent.StatusWaiting {
+		t.Fatalf("expected waiting, got %+v", r)
+	}
+}
+
+// CD2: Notification(idle_prompt) → Idle
+func TestCodexDeriveStatus_NotificationIdle(t *testing.T) {
+	r := deriveWithRaw("Notification", `{"notification_type":"idle_prompt"}`)
+	if !r.Valid || r.Status != agent.StatusIdle {
+		t.Fatalf("expected idle, got %+v", r)
+	}
+}
+
+// CD2b: Notification(auth_success) → Idle (mirrors cc)
+func TestCodexDeriveStatus_NotificationAuthSuccess(t *testing.T) {
+	r := deriveWithRaw("Notification", `{"notification_type":"auth_success"}`)
+	if !r.Valid || r.Status != agent.StatusIdle {
+		t.Fatalf("expected idle, got %+v", r)
+	}
+}
+
+// CD3: Notification(unknown subtype) → Valid=false (mirrors cc)
+func TestCodexDeriveStatus_NotificationUnknown(t *testing.T) {
+	r := deriveWithRaw("Notification", `{"notification_type":"weird"}`)
+	if r.Valid {
+		t.Fatalf("expected Valid=false for unknown notification subtype, got %+v", r)
+	}
+}
+
+// CD4: PermissionRequest → Waiting + detail.tool_name
+func TestCodexDeriveStatus_PermissionRequest(t *testing.T) {
+	r := deriveWithRaw("PermissionRequest", `{"tool_name":"Bash"}`)
+	if !r.Valid {
+		t.Fatalf("expected Valid, got %+v", r)
+	}
+	if r.Status != agent.StatusWaiting {
+		t.Fatalf("status = %q, want waiting", r.Status)
+	}
+	if r.Detail["tool_name"] != "Bash" {
+		t.Fatalf("detail.tool_name = %v, want Bash", r.Detail["tool_name"])
+	}
+}
+
+// CD5: SubagentStart → Valid=true, Status="" (detail-only), detail.agent_id
+func TestCodexDeriveStatus_SubagentStart(t *testing.T) {
+	r := deriveWithRaw("SubagentStart", `{"agent_id":"abc"}`)
+	if !r.Valid {
+		t.Fatalf("expected Valid, got %+v", r)
+	}
+	if r.Status != "" {
+		t.Fatalf("status = %q, want empty (detail-only event)", r.Status)
+	}
+	if r.Detail["agent_id"] != "abc" {
+		t.Fatalf("detail.agent_id = %v, want abc", r.Detail["agent_id"])
+	}
+}
+
+// CD6: SubagentStop → Valid=true, Status=""
+func TestCodexDeriveStatus_SubagentStop(t *testing.T) {
+	r := deriveWithRaw("SubagentStop", `{"agent_id":"xyz"}`)
+	if !r.Valid {
+		t.Fatalf("expected Valid, got %+v", r)
+	}
+	if r.Status != "" {
+		t.Fatalf("status = %q, want empty (detail-only event)", r.Status)
+	}
+	if r.Detail["agent_id"] != "xyz" {
+		t.Fatalf("detail.agent_id = %v, want xyz", r.Detail["agent_id"])
+	}
+}
+
+// CD7: SessionEnd → Clear
+func TestCodexDeriveStatus_SessionEnd(t *testing.T) {
+	r := deriveWithRaw("SessionEnd", `{}`)
+	if !r.Valid || r.Status != agent.StatusClear {
+		t.Fatalf("expected clear, got %+v", r)
+	}
+}
+
+// CD8: StopFailure → Error + detail.error
+func TestCodexDeriveStatus_StopFailure(t *testing.T) {
+	r := deriveWithRaw("StopFailure", `{"error":"OOM","error_details":"out of memory"}`)
+	if !r.Valid {
+		t.Fatalf("expected Valid, got %+v", r)
+	}
+	if r.Status != agent.StatusError {
+		t.Fatalf("status = %q, want error", r.Status)
+	}
+	if r.Detail["error"] != "OOM" {
+		t.Fatalf("detail.error = %v, want OOM", r.Detail["error"])
+	}
+	if r.Detail["error_details"] != "out of memory" {
+		t.Fatalf("detail.error_details = %v, want 'out of memory'", r.Detail["error_details"])
 	}
 }

--- a/internal/agent/codex/status_test.go
+++ b/internal/agent/codex/status_test.go
@@ -90,11 +90,27 @@ func TestCodexDeriveStatus_NotificationAuthSuccess(t *testing.T) {
 	}
 }
 
-// CD3: Notification(unknown subtype) → Valid=false (mirrors cc)
+// CD3: Notification(unknown subtype) → Valid=false + Reason=notification_unknown_type
+// (so handler can distinguish payload-schema drift from truly unknown event names).
 func TestCodexDeriveStatus_NotificationUnknown(t *testing.T) {
 	r := deriveWithRaw("Notification", `{"notification_type":"weird"}`)
 	if r.Valid {
 		t.Fatalf("expected Valid=false for unknown notification subtype, got %+v", r)
+	}
+	if r.Reason != "notification_unknown_type" {
+		t.Fatalf("expected reason=notification_unknown_type, got %q", r.Reason)
+	}
+}
+
+// Truly unknown event names (not in catalog) must leave Reason empty so the
+// handler can fall back to the generic "event_not_in_catalog" classification.
+func TestCodexDeriveStatus_UnknownEventEmptyReason(t *testing.T) {
+	r := deriveViaProvider("FutureMysteryEvent")
+	if r.Valid {
+		t.Fatalf("expected Valid=false, got %+v", r)
+	}
+	if r.Reason != "" {
+		t.Fatalf("expected empty Reason for unknown event name, got %q", r.Reason)
 	}
 }
 

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/cc"
+	"github.com/wake/purdex/internal/agent/codex"
+	"github.com/wake/purdex/internal/agent/opencode"
 )
 
 // supporterStub implements agent.AgentProvider and agent.StatusSupporter.
@@ -160,6 +163,49 @@ func TestCoverageDuplicateAgentType(t *testing.T) {
 	}
 	if rows[1].Declares {
 		t.Fatalf("expected second-registered cc to keep Declares=false (registration order, no rewrite)")
+	}
+}
+
+// TestCoverageRealProviders is the integration check that the three
+// production providers (cc, codex, opencode) all implement StatusSupporter
+// and declare the Phase 1 status set. The other Coverage tests use stubs
+// to guard the helper logic; this one guards the wire-up to real providers.
+func TestCoverageRealProviders(t *testing.T) {
+	r := agent.NewRegistry()
+	r.Register(cc.NewProvider(nil, nil, nil, nil))
+	r.Register(codex.NewProvider())
+	r.Register(opencode.NewProvider())
+
+	rows := agent.Coverage(r)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+
+	required := []agent.Status{
+		agent.StatusRunning,
+		agent.StatusWaiting,
+		agent.StatusIdle,
+		agent.StatusError,
+		agent.StatusClear,
+	}
+	for _, row := range rows {
+		if !row.Declares {
+			t.Errorf("provider %q: Declares=false, want true", row.AgentType)
+			continue
+		}
+		if len(row.Declared) == 0 {
+			t.Errorf("provider %q: Declared is empty", row.AgentType)
+			continue
+		}
+		set := make(map[agent.Status]bool, len(row.Declared))
+		for _, s := range row.Declared {
+			set[s] = true
+		}
+		for _, want := range required {
+			if !set[want] {
+				t.Errorf("provider %q: missing required Status %q (declared=%v)", row.AgentType, want, row.Declared)
+			}
+		}
 	}
 }
 

--- a/internal/agent/drift_test.go
+++ b/internal/agent/drift_test.go
@@ -12,58 +12,69 @@ import (
 )
 
 // driftFixture is one event input case used by the drift test.
+//
+// wantStatus is the Status this fixture is designed to provoke (or "" if the
+// event is detail-only such as SubagentStart/Stop). wantValid encodes the
+// expected Valid bit; non-mappable cases (e.g. cc compact SessionStart) live
+// in cc-specific tests, not here.
+//
+// Per-fixture assertion is required (Phase 1 review finding): set-equality
+// alone cannot detect the deletion of a polymorphic sub-branch like
+// Notification(elicitation_dialog), because Waiting is still emitted via
+// other branches. Each fixture must independently match its wantStatus.
 type driftFixture struct {
-	eventName string
-	rawJSON   string
+	eventName  string
+	rawJSON    string
+	wantStatus agent.Status // empty for detail-only events
+	wantValid  bool         // currently always true; placeholder for future negative fixtures
 }
 
 // providerFixtures enumerates representative event payloads for each provider
 // such that the union of `DeriveStatus(...)` results covers EVERY Status the
-// provider declares via SupportedStatuses. Per Phase 1 plan §1.5: fixtures
-// MUST cover each declared Status's emit path (including sub-branches like
-// Notification(idle_prompt) → Idle), or D1 produces a false positive.
+// provider declares via SupportedStatuses. Per Phase 1 plan §1.5 + the codex
+// review finding: every emit path AND sub-branch is asserted individually.
 //
-// SubagentStart/Stop are intentionally included for cc/opencode (and codex
-// post-Phase-1) — they Valid=true with Status="" and are filtered from the
-// emittedSet, so they document the catalog without polluting the comparison.
+// SubagentStart/Stop are intentionally included for cc/codex/opencode —
+// they Valid=true with Status="" and are filtered from the emittedSet so they
+// document the catalog without polluting the set-equality comparison.
 var providerFixtures = map[string][]driftFixture{
 	"cc": {
-		{"SessionStart", `{}`},                                  // → Idle
-		{"UserPromptSubmit", `{}`},                              // → Running
-		{"Notification", `{"notification_type":"permission_prompt"}`}, // → Waiting
-		{"Notification", `{"notification_type":"elicitation_dialog"}`}, // → Waiting (sub-branch)
-		{"Notification", `{"notification_type":"idle_prompt"}`},  // → Idle (sub-branch)
-		{"Notification", `{"notification_type":"auth_success"}`}, // → Idle (sub-branch)
-		{"PermissionRequest", `{"tool_name":"Bash"}`},           // → Waiting
-		{"Stop", `{}`},                                          // → Idle
-		{"StopFailure", `{"error":"x"}`},                        // → Error
-		{"SessionEnd", `{}`},                                    // → Clear
-		{"SubagentStart", `{"agent_id":"a"}`},                   // Valid=true, Status="" (filtered)
-		{"SubagentStop", `{"agent_id":"a"}`},                    // Valid=true, Status="" (filtered)
+		{"SessionStart", `{}`, agent.StatusIdle, true},
+		{"UserPromptSubmit", `{}`, agent.StatusRunning, true},
+		{"Notification", `{"notification_type":"permission_prompt"}`, agent.StatusWaiting, true},
+		{"Notification", `{"notification_type":"elicitation_dialog"}`, agent.StatusWaiting, true},
+		{"Notification", `{"notification_type":"idle_prompt"}`, agent.StatusIdle, true},
+		{"Notification", `{"notification_type":"auth_success"}`, agent.StatusIdle, true},
+		{"PermissionRequest", `{"tool_name":"Bash"}`, agent.StatusWaiting, true},
+		{"Stop", `{}`, agent.StatusIdle, true},
+		{"StopFailure", `{"error":"x"}`, agent.StatusError, true},
+		{"SessionEnd", `{}`, agent.StatusClear, true},
+		{"SubagentStart", `{"agent_id":"a"}`, "", true}, // Valid=true, Status="" (filtered)
+		{"SubagentStop", `{"agent_id":"a"}`, "", true},  // Valid=true, Status="" (filtered)
 	},
 	"codex": {
-		{"SessionStart", `{}`},                                  // → Idle
-		{"UserPromptSubmit", `{}`},                              // → Running
-		{"Notification", `{"notification_type":"permission_prompt"}`}, // → Waiting
-		{"Notification", `{"notification_type":"elicitation_dialog"}`}, // → Waiting
-		{"Notification", `{"notification_type":"idle_prompt"}`},  // → Idle
-		{"Notification", `{"notification_type":"auth_success"}`}, // → Idle
-		{"PermissionRequest", `{"tool_name":"Bash"}`},           // → Waiting
-		{"Stop", `{}`},                                          // → Idle
-		{"StopFailure", `{"error":"x"}`},                        // → Error
-		{"SessionEnd", `{}`},                                    // → Clear
-		{"SubagentStart", `{"agent_id":"a"}`},                   // Valid=true, Status=""
-		{"SubagentStop", `{"agent_id":"a"}`},                    // Valid=true, Status=""
+		{"SessionStart", `{}`, agent.StatusIdle, true},
+		{"UserPromptSubmit", `{}`, agent.StatusRunning, true},
+		{"Notification", `{"notification_type":"permission_prompt"}`, agent.StatusWaiting, true},
+		{"Notification", `{"notification_type":"elicitation_dialog"}`, agent.StatusWaiting, true},
+		{"Notification", `{"notification_type":"idle_prompt"}`, agent.StatusIdle, true},
+		{"Notification", `{"notification_type":"auth_success"}`, agent.StatusIdle, true},
+		{"PermissionRequest", `{"tool_name":"Bash"}`, agent.StatusWaiting, true},
+		{"Stop", `{}`, agent.StatusIdle, true},
+		{"StopFailure", `{"error":"x"}`, agent.StatusError, true},
+		{"SessionEnd", `{}`, agent.StatusClear, true},
+		{"SubagentStart", `{"agent_id":"a"}`, "", true},
+		{"SubagentStop", `{"agent_id":"a"}`, "", true},
 	},
 	"opencode": {
-		{"SessionStart", `{}`},                                  // → Idle
-		{"UserPromptSubmit", `{}`},                              // → Running
-		{"PermissionRequest", `{"request_type":"tool"}`},        // → Waiting
-		{"Stop", `{}`},                                          // → Idle
-		{"StopFailure", `{"error":"x"}`},                        // → Error
-		{"SessionEnd", `{}`},                                    // → Clear
-		{"SubagentStart", `{"agent_id":"a"}`},                   // Valid=true, Status=""
-		{"SubagentStop", `{"agent_id":"a"}`},                    // Valid=true, Status=""
+		{"SessionStart", `{}`, agent.StatusIdle, true},
+		{"UserPromptSubmit", `{}`, agent.StatusRunning, true},
+		{"PermissionRequest", `{"request_type":"tool"}`, agent.StatusWaiting, true},
+		{"Stop", `{}`, agent.StatusIdle, true},
+		{"StopFailure", `{"error":"x"}`, agent.StatusError, true},
+		{"SessionEnd", `{}`, agent.StatusClear, true},
+		{"SubagentStart", `{"agent_id":"a"}`, "", true},
+		{"SubagentStop", `{"agent_id":"a"}`, "", true},
 	},
 }
 
@@ -87,11 +98,18 @@ func statusSetSorted(set map[agent.Status]bool) []string {
 }
 
 // TestDriftDeclaredEqualsEmitted asserts that, for every registered provider,
-// the set of statuses returned by SupportedStatuses() is exactly equal to the
-// set of statuses actually emitted (Valid=true, Status!="") when DeriveStatus
-// is called against the per-provider fixture catalog. Bidirectional check:
-// drift in either direction (declared-but-never-emitted, emitted-but-not-
-// declared) fails the test.
+// EVERY fixture independently produces its declared (wantValid, wantStatus)
+// AND the union of emitted statuses exactly equals SupportedStatuses().
+//
+// Per-fixture assertion (not just set equality) is the load-bearing change
+// from the codex review: deleting one polymorphic Notification sub-branch
+// (e.g. "elicitation_dialog" → Waiting) would not change the set
+// {Waiting,Idle,Running,Error,Clear} because Waiting is still produced by
+// other branches. Per-fixture assertion catches that exact regression.
+//
+// Set-equality is kept as a complementary safeguard for the inverse
+// direction — emitting a status that no fixture covers, or declaring one
+// no fixture exercises.
 func TestDriftDeclaredEqualsEmitted(t *testing.T) {
 	r := driftRegistry()
 	rows := agent.Coverage(r)
@@ -117,15 +135,22 @@ func TestDriftDeclaredEqualsEmitted(t *testing.T) {
 			}
 
 			emittedSet := make(map[agent.Status]bool)
-			for _, fx := range fixtures {
+			for i, fx := range fixtures {
 				result := provider.DeriveStatus(fx.eventName, json.RawMessage(fx.rawJSON))
-				if !result.Valid {
+				// Per-fixture assertion — each branch independently verified.
+				if result.Valid != fx.wantValid {
+					t.Errorf("provider %q fixture[%d] %s %s: Valid=%v, want %v",
+						row.AgentType, i, fx.eventName, fx.rawJSON, result.Valid, fx.wantValid)
 					continue
 				}
-				if result.Status == "" {
+				if result.Status != fx.wantStatus {
+					t.Errorf("provider %q fixture[%d] %s %s: Status=%q, want %q",
+						row.AgentType, i, fx.eventName, fx.rawJSON, result.Status, fx.wantStatus)
 					continue
 				}
-				emittedSet[result.Status] = true
+				if result.Valid && result.Status != "" {
+					emittedSet[result.Status] = true
+				}
 			}
 
 			if !setsEqual(declaredSet, emittedSet) {

--- a/internal/agent/drift_test.go
+++ b/internal/agent/drift_test.go
@@ -1,0 +1,183 @@
+package agent_test
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/cc"
+	"github.com/wake/purdex/internal/agent/codex"
+	"github.com/wake/purdex/internal/agent/opencode"
+)
+
+// driftFixture is one event input case used by the drift test.
+type driftFixture struct {
+	eventName string
+	rawJSON   string
+}
+
+// providerFixtures enumerates representative event payloads for each provider
+// such that the union of `DeriveStatus(...)` results covers EVERY Status the
+// provider declares via SupportedStatuses. Per Phase 1 plan §1.5: fixtures
+// MUST cover each declared Status's emit path (including sub-branches like
+// Notification(idle_prompt) → Idle), or D1 produces a false positive.
+//
+// SubagentStart/Stop are intentionally included for cc/opencode (and codex
+// post-Phase-1) — they Valid=true with Status="" and are filtered from the
+// emittedSet, so they document the catalog without polluting the comparison.
+var providerFixtures = map[string][]driftFixture{
+	"cc": {
+		{"SessionStart", `{}`},                                  // → Idle
+		{"UserPromptSubmit", `{}`},                              // → Running
+		{"Notification", `{"notification_type":"permission_prompt"}`}, // → Waiting
+		{"Notification", `{"notification_type":"elicitation_dialog"}`}, // → Waiting (sub-branch)
+		{"Notification", `{"notification_type":"idle_prompt"}`},  // → Idle (sub-branch)
+		{"Notification", `{"notification_type":"auth_success"}`}, // → Idle (sub-branch)
+		{"PermissionRequest", `{"tool_name":"Bash"}`},           // → Waiting
+		{"Stop", `{}`},                                          // → Idle
+		{"StopFailure", `{"error":"x"}`},                        // → Error
+		{"SessionEnd", `{}`},                                    // → Clear
+		{"SubagentStart", `{"agent_id":"a"}`},                   // Valid=true, Status="" (filtered)
+		{"SubagentStop", `{"agent_id":"a"}`},                    // Valid=true, Status="" (filtered)
+	},
+	"codex": {
+		{"SessionStart", `{}`},                                  // → Idle
+		{"UserPromptSubmit", `{}`},                              // → Running
+		{"Notification", `{"notification_type":"permission_prompt"}`}, // → Waiting
+		{"Notification", `{"notification_type":"elicitation_dialog"}`}, // → Waiting
+		{"Notification", `{"notification_type":"idle_prompt"}`},  // → Idle
+		{"Notification", `{"notification_type":"auth_success"}`}, // → Idle
+		{"PermissionRequest", `{"tool_name":"Bash"}`},           // → Waiting
+		{"Stop", `{}`},                                          // → Idle
+		{"StopFailure", `{"error":"x"}`},                        // → Error
+		{"SessionEnd", `{}`},                                    // → Clear
+		{"SubagentStart", `{"agent_id":"a"}`},                   // Valid=true, Status=""
+		{"SubagentStop", `{"agent_id":"a"}`},                    // Valid=true, Status=""
+	},
+	"opencode": {
+		{"SessionStart", `{}`},                                  // → Idle
+		{"UserPromptSubmit", `{}`},                              // → Running
+		{"PermissionRequest", `{"request_type":"tool"}`},        // → Waiting
+		{"Stop", `{}`},                                          // → Idle
+		{"StopFailure", `{"error":"x"}`},                        // → Error
+		{"SessionEnd", `{}`},                                    // → Clear
+		{"SubagentStart", `{"agent_id":"a"}`},                   // Valid=true, Status=""
+		{"SubagentStop", `{"agent_id":"a"}`},                    // Valid=true, Status=""
+	},
+}
+
+// driftRegistry builds a fresh registry with all three real providers in the
+// production registration order.
+func driftRegistry() *agent.Registry {
+	r := agent.NewRegistry()
+	r.Register(cc.NewProvider(nil, nil, nil, nil))
+	r.Register(codex.NewProvider())
+	r.Register(opencode.NewProvider())
+	return r
+}
+
+func statusSetSorted(set map[agent.Status]bool) []string {
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, string(s))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestDriftDeclaredEqualsEmitted asserts that, for every registered provider,
+// the set of statuses returned by SupportedStatuses() is exactly equal to the
+// set of statuses actually emitted (Valid=true, Status!="") when DeriveStatus
+// is called against the per-provider fixture catalog. Bidirectional check:
+// drift in either direction (declared-but-never-emitted, emitted-but-not-
+// declared) fails the test.
+func TestDriftDeclaredEqualsEmitted(t *testing.T) {
+	r := driftRegistry()
+	rows := agent.Coverage(r)
+	if len(rows) == 0 {
+		t.Fatal("no coverage rows — registry empty")
+	}
+
+	for _, row := range rows {
+		row := row
+		t.Run(row.AgentType, func(t *testing.T) {
+			provider, ok := r.Get(row.AgentType)
+			if !ok {
+				t.Fatalf("registry.Get(%q) failed", row.AgentType)
+			}
+			fixtures, ok := providerFixtures[row.AgentType]
+			if !ok {
+				t.Fatalf("no driftFixture entry for provider %q — add fixtures or remove provider", row.AgentType)
+			}
+
+			declaredSet := make(map[agent.Status]bool, len(row.Declared))
+			for _, s := range row.Declared {
+				declaredSet[s] = true
+			}
+
+			emittedSet := make(map[agent.Status]bool)
+			for _, fx := range fixtures {
+				result := provider.DeriveStatus(fx.eventName, json.RawMessage(fx.rawJSON))
+				if !result.Valid {
+					continue
+				}
+				if result.Status == "" {
+					continue
+				}
+				emittedSet[result.Status] = true
+			}
+
+			if !setsEqual(declaredSet, emittedSet) {
+				t.Fatalf("drift for provider %q: declared=%v, emitted=%v\n"+
+					"  declared-not-emitted (fix: add fixture covering this status, or remove from declaration): %v\n"+
+					"  emitted-not-declared (fix: add to SupportedStatuses, or remove from DeriveStatus): %v",
+					row.AgentType,
+					statusSetSorted(declaredSet),
+					statusSetSorted(emittedSet),
+					statusSetSorted(diffSet(declaredSet, emittedSet)),
+					statusSetSorted(diffSet(emittedSet, declaredSet)),
+				)
+			}
+		})
+	}
+}
+
+// TestDriftFixtureCoverageNonEmpty guards against an empty fixture set silently
+// producing emitted=empty == declared=empty (false positive in D1). Every
+// registered provider must have a non-empty fixture entry.
+func TestDriftFixtureCoverageNonEmpty(t *testing.T) {
+	r := driftRegistry()
+	for _, row := range agent.Coverage(r) {
+		fixtures, ok := providerFixtures[row.AgentType]
+		if !ok {
+			t.Errorf("provider %q has no fixture entry in providerFixtures", row.AgentType)
+			continue
+		}
+		if len(fixtures) == 0 {
+			t.Errorf("provider %q has empty fixture slice", row.AgentType)
+		}
+	}
+}
+
+func setsEqual(a, b map[agent.Status]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+func diffSet(a, b map[agent.Status]bool) map[agent.Status]bool {
+	out := make(map[agent.Status]bool)
+	for k := range a {
+		if !b[k] {
+			out[k] = true
+		}
+	}
+	return out
+}

--- a/internal/agent/opencode/provider.go
+++ b/internal/agent/opencode/provider.go
@@ -40,6 +40,19 @@ func (p *Provider) DeriveStatus(eventName string, rawEvent json.RawMessage) agen
 	return deriveOpenCodeStatus(eventName, rawEvent)
 }
 
+// SupportedStatuses declares the Status values opencode.Provider's
+// DeriveStatus may emit. Returns a fresh slice on each call (defensive copy
+// per Phase 1 plan §1.1). Drift test enforces declaration matches emit.
+func (p *Provider) SupportedStatuses() []agent.Status {
+	return []agent.Status{
+		agent.StatusRunning,
+		agent.StatusWaiting,
+		agent.StatusIdle,
+		agent.StatusError,
+		agent.StatusClear,
+	}
+}
+
 func (p *Provider) IsAlive(tmuxTarget string) bool {
 	return false
 }

--- a/internal/agent/opencode/provider_test.go
+++ b/internal/agent/opencode/provider_test.go
@@ -1,0 +1,39 @@
+package opencode_test
+
+import (
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/opencode"
+)
+
+// TestOpenCodeSupportedStatuses asserts opencode.Provider implements
+// StatusSupporter and declares the Phase 1 status set.
+func TestOpenCodeSupportedStatuses(t *testing.T) {
+	var p any = opencode.NewProvider()
+	ss, ok := p.(agent.StatusSupporter)
+	if !ok {
+		t.Fatal("opencode.Provider must implement agent.StatusSupporter")
+	}
+	got := ss.SupportedStatuses()
+	want := map[agent.Status]bool{
+		agent.StatusRunning: true,
+		agent.StatusWaiting: true,
+		agent.StatusIdle:    true,
+		agent.StatusError:   true,
+		agent.StatusClear:   true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("SupportedStatuses len = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	seen := make(map[agent.Status]bool, len(got))
+	for _, s := range got {
+		if seen[s] {
+			t.Fatalf("SupportedStatuses contains duplicate %q (got %v)", s, got)
+		}
+		seen[s] = true
+		if !want[s] {
+			t.Fatalf("SupportedStatuses contains unexpected %q (got %v)", s, got)
+		}
+	}
+}

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -89,6 +89,15 @@ type StreamCapable interface {
 // are treated as "not declared" by the Coverage helper. Returning an empty
 // slice is a valid declaration meaning "supports no Status values" and is
 // distinct from not implementing the interface at all.
+//
+// Scope: this declares the full status set DeriveStatus is *capable* of
+// returning, independent of which hook events the agent's hook installer
+// currently wires. Declaration may legitimately exceed the installer's
+// current event coverage (e.g. when the provider is preparing for a future
+// CLI version, or when events arrive via proxy / parent agents). The drift
+// test (internal/agent/drift_test.go) keeps DeriveStatus implementations
+// honest against this declaration; alignment with the hook installer event
+// catalog is a separate concern tracked by per-agent installer phases.
 type StatusSupporter interface {
 	SupportedStatuses() []Status
 }

--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -17,6 +17,14 @@ type DeriveResult struct {
 	Valid  bool           // false = event should be ignored
 	Model  string         // extracted model name (if any)
 	Detail map[string]any // event-specific data for frontend notifications
+	// Reason explains why Valid=false. Empty means truly unknown event name
+	// ("event_not_in_catalog"). Non-empty signals a known event whose payload
+	// cannot be mapped to a Status (e.g. "compact_ignored" for the cc
+	// SessionStart compact subtype, or "notification_unknown_type" for an
+	// unrecognized notification_type subtype). Handler uses this to keep
+	// trace observability for known-but-unmappable events instead of folding
+	// them into the generic catalog miss bucket. Ignored when Valid=true.
+	Reason string
 }
 
 // NormalizedEvent is broadcast to WS subscribers.

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -113,6 +113,26 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		result = provider.DeriveStatus(req.EventName, req.RawEvent)
 	}
 
+	// Catalog miss: provider rejected the event (Valid=false) — record it as
+	// a verify-kind trace step (decision=skipped, reason=event_not_in_catalog)
+	// and return 200 OK without running any frame / projection / broadcast /
+	// activity-watch logic. catalog miss is "received but not recognized";
+	// distinct from verify_rejected (202 Accepted, identity / staleness fail).
+	// The hook CLI treats anything but non-200 as success, so 200 here means
+	// "no retry needed". Per Phase 1 plan §1.4 — this branch is the explicit
+	// early return previously missing from the pipeline.
+	if !result.Valid {
+		trace.Verify(req, "skipped", "event_not_in_catalog", nil)
+		trace.Finish("completed", "event_not_in_catalog")
+		traceFinished = true
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"status": "ok",
+			"reason": "event_not_in_catalog",
+		})
+		return
+	}
+
 	// Error guard: when in error state, only whitelisted events can clear it
 	if result.Valid && result.Status != "" && result.Status != agentpkg.StatusError {
 		m.mu.Lock()

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -156,9 +156,12 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		m.mu.Unlock()
 		if current == agentpkg.StatusError {
 			canClear := req.EventName == "UserPromptSubmit" || req.EventName == "SessionStart"
-			if req.AgentType == "opencode" {
-				canClear = canClear || req.EventName == "SessionEnd"
-			} else {
+			// SessionEnd carries StatusClear and unconditionally tears down
+			// session state — it must always pass the error guard or the
+			// session would stay stuck red after a StopFailure followed by a
+			// real session shutdown.
+			canClear = canClear || req.EventName == "SessionEnd"
+			if req.AgentType != "opencode" {
 				canClear = canClear || req.EventName == "Stop"
 			}
 			if !canClear {

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -113,22 +113,38 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		result = provider.DeriveStatus(req.EventName, req.RawEvent)
 	}
 
-	// Catalog miss: provider rejected the event (Valid=false) — record it as
-	// a verify-kind trace step (decision=skipped, reason=event_not_in_catalog)
-	// and return 200 OK without running any frame / projection / broadcast /
-	// activity-watch logic. catalog miss is "received but not recognized";
-	// distinct from verify_rejected (202 Accepted, identity / staleness fail).
-	// The hook CLI treats anything but non-200 as success, so 200 here means
-	// "no retry needed". Per Phase 1 plan §1.4 — this branch is the explicit
-	// early return previously missing from the pipeline.
+	// Invalid result: provider returned Valid=false. Two sub-classes:
+	//   - Reason=="" → truly unknown event name → "event_not_in_catalog"
+	//   - Reason!="" → known event but payload not mappable → use that reason
+	//     (e.g. "compact_ignored", "notification_unknown_type")
+	//
+	// Both branches:
+	//   - record a verify-kind trace step (decision=skipped) with the chosen reason
+	//   - clear any legacy agent_events row so replay/snapshot don't surface
+	//     stale state on top of an unprocessed event (matches the cleanup the
+	//     valid path performs at line ~163)
+	//   - return 200 OK with the reason in the body
+	//   - skip frame / projection / broadcast / activity-watch
+	//
+	// 200 (vs verify_rejected's 202) signals "received and acknowledged, no retry".
+	// Hook CLI only retries on non-2xx.
 	if !result.Valid {
-		trace.Verify(req, "skipped", "event_not_in_catalog", nil)
-		trace.Finish("completed", "event_not_in_catalog")
+		reason := result.Reason
+		if reason == "" {
+			reason = "event_not_in_catalog"
+		}
+		trace.Verify(req, "skipped", reason, nil)
+		if req.TmuxSession != "" && m.events != nil {
+			if err := m.events.Delete(req.TmuxSession); err != nil {
+				log.Printf("[agent] clear legacy event on invalid result: %v", err)
+			}
+		}
+		trace.Finish("completed", reason)
 		traceFinished = true
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{
 			"status": "ok",
-			"reason": "event_not_in_catalog",
+			"reason": reason,
 		})
 		return
 	}

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -1319,6 +1319,150 @@ func TestHandleAgentStatusTestPrefixWithoutObserverFallsThroughToProduction(t *t
 	}
 }
 
+// --- Phase 1: Catalog miss (Valid=false → early-return + trace) ---
+
+// catalogMissModule wires up a Module + cc provider + tmux + sessions + core
+// in the minimum configuration required to exercise the catalog-miss path
+// end-to-end (including trace persistence and broadcast suppression).
+func catalogMissModule(t *testing.T) *Module {
+	t.Helper()
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.prober = probe.New(fakeTmux)
+	m.registry.Register(agentcc.NewProvider(nil, nil, nil, nil))
+	return m
+}
+
+func catalogMissRequest() *http.Request {
+	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":36649,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"FutureMysteryEvent","raw_event":{"foo":"bar"},"agent_type":"cc"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// H1: catalog miss returns 200 with explicit reason and the trace chain
+// records a verify-kind step with decision=skipped, reason=event_not_in_catalog.
+// It must NOT contain frame / projection / emit steps.
+func TestHandleEvent_CatalogMiss_WritesTraceAndReturnsOK(t *testing.T) {
+	m := catalogMissModule(t)
+	w := httptest.NewRecorder()
+	m.handleEvent(w, catalogMissRequest())
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s), want 200", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("status field = %q, want ok", resp["status"])
+	}
+	if resp["reason"] != "event_not_in_catalog" {
+		t.Errorf("reason field = %q, want event_not_in_catalog", resp["reason"])
+	}
+
+	page := waitForTraceChains(t, m, "work", 1)
+	if len(page.Chains) != 1 {
+		t.Fatalf("len(page.Chains) = %d, want 1", len(page.Chains))
+	}
+	chain := page.Chains[0]
+	if chain.TerminalStatus != "completed" {
+		t.Errorf("TerminalStatus = %q, want completed", chain.TerminalStatus)
+	}
+	if chain.TerminalReason != "event_not_in_catalog" {
+		t.Errorf("TerminalReason = %q, want event_not_in_catalog", chain.TerminalReason)
+	}
+	if chain.LatestStepKind != "verify" {
+		t.Errorf("LatestStepKind = %q, want verify (catalog miss reuses verify kind)", chain.LatestStepKind)
+	}
+	if chain.LatestDecision != "skipped" {
+		t.Errorf("LatestDecision = %q, want skipped", chain.LatestDecision)
+	}
+
+	record, err := m.traces.GetChainRecord(chain.ChainID)
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	// Expect exactly: trigger + verify(accepted) + verify(skipped, catalog).
+	// Frame / projection / emit MUST NOT appear.
+	for _, step := range record.Steps {
+		switch step.Kind {
+		case "frame", "projection", "emit":
+			t.Errorf("unexpected step kind %q in catalog-miss chain (steps=%+v)", step.Kind, record.Steps)
+		}
+	}
+	// Find the catalog-miss step explicitly.
+	var foundCatalog bool
+	for _, step := range record.Steps {
+		if step.Kind == "verify" && step.Decision == "skipped" && step.Reason == "event_not_in_catalog" {
+			foundCatalog = true
+		}
+	}
+	if !foundCatalog {
+		t.Errorf("no verify-step with decision=skipped reason=event_not_in_catalog (steps=%+v)", record.Steps)
+	}
+}
+
+// H2: catalog miss must not mutate currentStatus / subagents / broadcast.
+func TestHandleEvent_CatalogMiss_NoStatusUpdate(t *testing.T) {
+	m := catalogMissModule(t)
+	// Seed pre-existing state to verify it's untouched.
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.subagents["work"] = []string{"existing-sub"}
+	m.mu.Unlock()
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	w := httptest.NewRecorder()
+	m.handleEvent(w, catalogMissRequest())
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	m.mu.Lock()
+	gotStatus := m.currentStatus["work"]
+	gotSubs := append([]string(nil), m.subagents["work"]...)
+	m.mu.Unlock()
+	if gotStatus != agentpkg.StatusRunning {
+		t.Errorf("currentStatus = %q, want running (catalog miss must not mutate)", gotStatus)
+	}
+	if len(gotSubs) != 1 || gotSubs[0] != "existing-sub" {
+		t.Errorf("subagents = %v, want [existing-sub]", gotSubs)
+	}
+
+	select {
+	case msg := <-sub.SendCh():
+		t.Errorf("unexpected broadcast on catalog miss: %s", string(msg))
+	case <-time.After(50 * time.Millisecond):
+		// expected — no broadcast
+	}
+}
+
+// H3: catalog miss must not start an activity watcher.
+func TestHandleEvent_CatalogMiss_NoActivityWatch(t *testing.T) {
+	m := catalogMissModule(t)
+	w := httptest.NewRecorder()
+	m.handleEvent(w, catalogMissRequest())
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	m.mu.Lock()
+	_, watching := m.activeWatchers["work"]
+	m.mu.Unlock()
+	if watching {
+		t.Error("catalog miss should not start an activity watcher")
+	}
+}
+
 func TestHandleStatuslineSetup_RemoveBroadcastsCleared(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	agentcc "github.com/wake/purdex/internal/agent/cc"
+	agentcodex "github.com/wake/purdex/internal/agent/codex"
 	"github.com/wake/purdex/internal/agent/opencode"
 	"github.com/wake/purdex/internal/agent/probe"
 	"github.com/wake/purdex/internal/core"
@@ -1494,6 +1495,51 @@ func TestHandleEvent_InvalidWithReason_UsesProviderReason(t *testing.T) {
 	chain := page.Chains[0]
 	if chain.TerminalReason != "compact_ignored" {
 		t.Errorf("TerminalReason = %q, want compact_ignored", chain.TerminalReason)
+	}
+}
+
+// H_ErrorGuardCodexSessionEnd: when codex enters StatusError (e.g. via
+// StopFailure), a subsequent SessionEnd must be allowed to clear the error
+// state. Without the guard exception, codex sessions would stay stuck red
+// even after the real session terminates, defeating the cleanup purpose of
+// the new SessionEnd→Clear mapping. Mirrors opencode's existing exception.
+func TestHandleEvent_CodexSessionEndClearsErrorGuard(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.prober = probe.New(fakeTmux)
+	m.registry.Register(agentcodex.NewProvider())
+	// Stub identify to accept codex events through verify.
+	origRead := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1, ExePath: "/usr/local/bin/codex", Argv: []string{"codex"}}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origRead })
+
+	// Seed Error state for the session (e.g. from a prior StopFailure).
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusError
+	m.mu.Unlock()
+
+	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":36649,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionEnd","raw_event":{},"agent_type":"codex"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s), want 200", w.Code, w.Body.String())
+	}
+	// After Clear, the session entry should have been removed from
+	// currentStatus (StatusClear handler at handler.go:~210 deletes it).
+	m.mu.Lock()
+	_, stillPresent := m.currentStatus["work"]
+	m.mu.Unlock()
+	if stillPresent {
+		t.Errorf("currentStatus[\"work\"] should have been cleared by SessionEnd, but error guard blocked it")
 	}
 }
 

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -1463,6 +1463,72 @@ func TestHandleEvent_CatalogMiss_NoActivityWatch(t *testing.T) {
 	}
 }
 
+// H4: when provider returns Valid=false with a non-empty Reason (known event
+// with unmappable payload — e.g. cc SessionStart{source:compact}), the handler
+// must surface that reason rather than mislabeling it as event_not_in_catalog.
+// Without this distinction every Claude Code session compaction would write
+// false-positive catalog-miss trace rows.
+func TestHandleEvent_InvalidWithReason_UsesProviderReason(t *testing.T) {
+	m := catalogMissModule(t)
+	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":36649,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{"source":"compact"},"agent_type":"cc"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s), want 200", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["reason"] != "compact_ignored" {
+		t.Errorf("reason field = %q, want compact_ignored (provider's reason should pass through)", resp["reason"])
+	}
+
+	page := waitForTraceChains(t, m, "work", 1)
+	if len(page.Chains) != 1 {
+		t.Fatalf("len(page.Chains) = %d, want 1", len(page.Chains))
+	}
+	chain := page.Chains[0]
+	if chain.TerminalReason != "compact_ignored" {
+		t.Errorf("TerminalReason = %q, want compact_ignored", chain.TerminalReason)
+	}
+}
+
+// H5: any invalid result (including known-but-unmappable like compact) must
+// clear the legacy agent_events row for the session so replay/snapshot logic
+// does not later resurface a stale event on top of one we already chose to
+// skip. This is the regression flagged by the codex attack-view review:
+// catalog-miss early-return previously skipped m.events.Delete entirely.
+func TestHandleEvent_InvalidResult_ClearsLegacyEventRow(t *testing.T) {
+	m := catalogMissModule(t)
+
+	// Seed a stale legacy row for this session.
+	if err := m.events.Set("work", "OldEvent", json.RawMessage(`{"old":"row"}`), "cc", 0); err != nil {
+		t.Fatalf("seed legacy event: %v", err)
+	}
+	// Sanity: row exists.
+	if ev, _ := m.events.Get("work"); ev == nil {
+		t.Fatal("seed failed: legacy row missing")
+	}
+
+	w := httptest.NewRecorder()
+	m.handleEvent(w, catalogMissRequest())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	ev, err := m.events.Get("work")
+	if err != nil {
+		t.Fatalf("events.Get: %v", err)
+	}
+	if ev != nil {
+		t.Errorf("legacy row should be cleared on invalid result, got %+v", ev)
+	}
+}
+
 func TestHandleStatuslineSetup_RemoveBroadcastsCleared(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/spa/src/lib/agent-icons.tsx
+++ b/spa/src/lib/agent-icons.tsx
@@ -4,6 +4,7 @@ import { OpenAiLogo } from '@phosphor-icons/react'
 import ClaudeCodeBotSvg from '@lobehub/icons-static-svg/icons/claudecode.svg?react'
 import ClaudeStarSvg from '@lobehub/icons-static-svg/icons/claude.svg?react'
 import CodexLobeSvg from '@lobehub/icons-static-svg/icons/codex.svg?react'
+import OpenCodeSvg from '@lobehub/icons-static-svg/icons/opencode.svg?react'
 import type { CcIconVariant, CodexIconVariant } from '../stores/useUISettingsStore'
 
 type SvgComponent = ComponentType<SVGProps<SVGSVGElement>>
@@ -30,6 +31,10 @@ const CODEX_VARIANTS: Record<CodexIconVariant, AgentIconComponent> = {
   codex: wrapSvg(CodexLobeSvg),
 }
 
+// Single brand icon for opencode (no variant system — plan §5 explicitly
+// rejects introducing opencodeVariant for a single official svg).
+const OPENCODE_ICON: AgentIconComponent = wrapSvg(OpenCodeSvg)
+
 export interface GetAgentIconOptions {
   ccVariant: CcIconVariant
   codexVariant: CodexIconVariant
@@ -40,6 +45,7 @@ export interface GetAgentIconOptions {
 export function getAgentIcon(agentType: string, options: GetAgentIconOptions): AgentIconComponent | undefined {
   if (agentType === 'cc') return CC_VARIANTS[options.ccVariant]
   if (agentType === 'codex') return CODEX_VARIANTS[options.codexVariant]
+  if (agentType === 'opencode') return OPENCODE_ICON
   return undefined
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of the Lights Rebuild (`docs/specs/2026-04-23-lights-rebuild-spec.md` §5):

- **Three providers declare `SupportedStatuses()`** — `cc` / `codex` / `opencode` each return `[Running, Waiting, Idle, Error, Clear]`.
- **Codex `DeriveStatus` expansion** — adds 5 events: `Notification` (permission/elicitation→Waiting, idle/auth_success→Idle), `PermissionRequest` (Waiting), `SubagentStart`/`SubagentStop` (detail-only), `SessionEnd` (Clear), `StopFailure` (Error).
- **OpenCode brand icon** — `@lobehub/icons-static-svg/icons/opencode.svg` wired via existing `wrapSvg(...)` pattern.
- **Unknown-event tracking** — `handler.go` adds explicit early-return when `provider.DeriveStatus` returns `Valid=false`: writes a `kind=verify, decision=skipped, reason=event_not_in_catalog` trace step, returns 200 OK with `{"status":"ok","reason":"event_not_in_catalog"}`, skips frame/projection/broadcast/activity-watch.
- **Drift test** — `internal/agent/drift_test.go` enforces `declaredSet == emittedSet` per provider via table-driven fixture; `D2` guards against false-green from empty fixtures.

## Plan

`docs/specs/2026-04-23-lights-rebuild-phase-1-plan.md` (commit `e6c1eca5`).

## Don't-do list (explicitly honored — plan §5)

- ❌ `codexHookEvents` not updated (hook installer remains 3-event; CLI must catch up before installing)
- ❌ No `opencodeVariant` system (single brand icon)
- ❌ No `detailSubset()` extraction to shared package
- ❌ No cc/opencode `DeriveStatus` changes
- ❌ No `/api/agent/monitor/coverage` endpoint (Phase 5)
- ❌ No trace schema change (catalog miss reuses verify kind)
- ❌ No `Catalog()` collector method (reuses `Verify`)
- ❌ No `handler.go` refactor
- ❌ No SubagentStart/Stop Status emission (Detail-only, like cc/opencode)

## Files changed (13)

| File | Change |
|---|---|
| `internal/agent/cc/provider.go` | +`SupportedStatuses()` |
| `internal/agent/cc/provider_test.go` | +P1 + P4 |
| `internal/agent/codex/provider.go` | +`SupportedStatuses()` |
| `internal/agent/codex/provider_test.go` | +P2 |
| `internal/agent/codex/status.go` | +5 event cases |
| `internal/agent/codex/status_test.go` | +CD1–CD8 + extra notification fixtures |
| `internal/agent/coverage_test.go` | +C1 (real-provider integration) |
| `internal/agent/drift_test.go` | new — D1 + D2 |
| `internal/agent/opencode/provider.go` | +`SupportedStatuses()` |
| `internal/agent/opencode/provider_test.go` | new — P3 |
| `internal/module/agent/handler.go` | catalog-miss early-return |
| `internal/module/agent/handler_test.go` | +H1–H3 |
| `spa/src/lib/agent-icons.tsx` | +OpenCode icon |

## Test plan

- [x] `go build ./...` — green
- [x] `go vet ./...` — no warnings
- [x] `go test ./internal/agent/... ./internal/module/agent/...` — green (covers P1–P4, CD1–CD8, C1, D1–D2, H1–H3)
- [x] `cd spa && pnpm run lint` — clean
- [x] `cd spa && pnpm run build` — built in ~700ms (chunk-size warning pre-existing)
- [x] `cd spa && npx vitest run` — 252/253 files pass; 3 pre-existing failures in `src/lib/sync/contributors/hosts.test.ts` (unrelated to Phase 1, last touched in `60b0999c`/`b2d2ec4a` on main)
- [ ] **Manual** — start opencode session, verify TabIcon shows brand icon
- [ ] **Manual** — POST unknown-event hook, verify trace chain has `verify`/`skipped`/`event_not_in_catalog` step + 200 OK response

## Codex review plan

Two rounds will run after this PR opens (per CLAUDE.md):
1. Standard `/codex:review --base origin/main`
2. 3 parallel `/codex:adversarial-review` (attack / defense / file-quality)

Findings will be aggregated into a confidence × relevance × complexity table; high-priority items fixed in this PR, deferred items filed as gh issues.

🤖 Generated with [Claude Code](https://claude.ai/code)