### PR TITLE
feat(agent): Lights rebuild — Hook events declaration (#613) + §2.4 guardrails

### DIFF
--- a/docs/specs/2026-04-23-hook-events-declaration-plan.md
+++ b/docs/specs/2026-04-23-hook-events-declaration-plan.md
@@ -1,0 +1,464 @@
+# Hook Events Declaration TDD Plan — `HookInstaller.Events()`
+
+- **Date**: 2026-04-23
+- **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §2.4.3（三家 Agent 事件對齊策略）+ §12 檔案速查
+- **Related issue**: #613（codex installer alignment）
+- **Worktree**: `lights-hook-events-declaration`（branch `worktree-lights-hook-events-declaration`，後續開 worktree 時建立）
+- **依賴**: Phase 0 (`StatusSupporter` + `Coverage`) + Phase 1 (三家 `SupportedStatuses()` + codex 5 事件 + drift test) — 皆已 merged
+- **是否開新 Phase**：**否**。§2.4.3 明確以「併入 issue #613 擴展（`HookInstaller.Events()`）」作自然解，不佔 Phase 編號
+
+## 0. 動機與一句話目標
+
+把 `HookInstaller` 介面擴充一個宣告方法 `Events()`，讓「installer 裝什麼事件」「`DeriveStatus` 認識什麼事件」「每個事件能 emit 什麼 Status」「Inspector 要顯示什麼」**共用同一筆宣告**。同時把 `SupportedStatuses()` 從硬編碼改為從 `Events()` 的 `EmitsStatus` union 自動 derive，徹底消除宣告 drift 的源頭。
+
+這次 PR **只收斂宣告層**（build-time 可查），不動 runtime 的 handler / probe / frame / broadcast 流程。符合 §2.4.1「build-time 可做、runtime 不做」判準。
+
+## 1. 契約鎖定
+
+本節鎖定全部行為細節，subagent 實作期不需再決策。
+
+### 1.1 `HookEventSpec` 宣告結構
+
+新型別，放在 `internal/agent/provider.go`（與 `HookInstaller` 同一「Optional capabilities」區塊），欄位：
+
+```
+HookEventSpec:
+  Name         : string       -- 事件名稱，如 "Notification"；與 hook JSON 的 event_name / pdx hook CLI subcommand 一致
+  EmitsStatus  : []Status     -- 該事件透過 DeriveStatus 可能產生的非空 Status slice；空 slice 合法（detail-only，如 SubagentStart/Stop）
+  Description  : string       -- 一句話人讀說明，給 Inspector UI 顯示；英文；末尾不加句號
+```
+
+**語意規則**：
+
+- `EmitsStatus` 是**非空 Status 集合**（`Status != ""`）；若事件 `DeriveStatus` 永遠回 `Valid=true, Status=""`（detail-only），`EmitsStatus = []agent.Status{}`（空 slice，非 nil）
+- `EmitsStatus` 允許重複避免 subagent 煩惱去重（drift 測試以 set 比對；實際建議三家都寫 unique，但不強制）
+- `EmitsStatus` 對 polymorphic branch（如 cc `Notification`）列出**所有 sub-branch 可能 Status 的聯集**（例：`{Waiting, Idle}`）
+- `Description` 語言：**英文**（與既有 hook event name 同語系，便於 Inspector UI 不做 i18n 先行）；長度建議 < 70 字；不加句號；不使用 emoji
+
+### 1.2 `HookInstaller.Events()` 介面擴充
+
+`HookInstaller` 增加方法（虛擬碼）：
+
+```
+HookInstaller (interface):
+  InstallHooks(pdxPath string) error          -- existing
+  RemoveHooks(pdxPath string) error           -- existing
+  CheckHooks() (HookStatus, error)            -- existing
+  Events() []HookEventSpec                    -- NEW, required for all HookInstaller implementors
+```
+
+**`Events()` 是 required**（非 optional）。一旦實作 `HookInstaller`，必須同時實作 `Events()` — 這讓宣告與安裝綁在同一個 interface，避免第四個 provider 日後只裝不宣告。
+
+**語意**：回傳此 provider 的 hook installer 安裝的**所有事件 + 各自能 emit 的 Status + 描述**。回傳 slice 為 fresh copy（defensive — 比照 Phase 1 `SupportedStatuses()` 慣例），元素順序與 installer 安裝順序一致（與現有 `ccHookEvents` / `codexHookEvents` / `opencodeHookEvents` var 順序對齊）。
+
+### 1.3 `*HookEvents` package var 的去留
+
+現況三家各自有 `ccHookEvents` / `codexHookEvents` / `opencodeHookEvents` 字串 slice，被 `InstallHooks` / `CheckHooks` / `writeManagedPlugin` 迭代。
+
+**決議**：**刪除**三個 package var；改由 `Events()` 作為單一真相來源（SSoT）。內部使用端（`mergeClaudeHooks` / `mergeCodexHooks` / opencode plugin 模板）改為：
+
+- 定義 package-private helper：`eventNames() []string { return map(p.Events(), spec -> spec.Name) }`（虛擬碼）
+- installer / check 迴圈從 `for _, event := range ccHookEvents` 改為 `for _, event := range p.eventNames()`
+- opencode 的 `writeManagedPlugin` / `renderManagedPlugin` 若需要事件清單（看檔案內實作），同樣走 helper；若 template 檔是固定字串就保持原狀，只要 `CheckHooks` 用 helper 即可
+
+**為什麼 SSoT 在 `Events()`**：多個來源註定 drift（Phase 1 已證明 `SupportedStatuses` 硬編碼的維護成本）；package var 與 `Events()` 並存 = 第二個真相源。
+
+**例外**：const 型 version 字串（`ccHooksSupportedVersion` / `codexHooksSupportedVersion`）**不動**，仍為 package const — 它們不是事件宣告。
+
+### 1.4 三家 `Events()` 宣告內容
+
+#### cc（9 事件）
+
+| Name                | EmitsStatus                                        | Description                                                  |
+|---------------------|----------------------------------------------------|--------------------------------------------------------------|
+| `SessionStart`      | `[Idle]`                                           | Claude Code session started (non-compact source)             |
+| `UserPromptSubmit`  | `[Running]`                                        | User submitted a prompt to the agent                         |
+| `SubagentStart`     | `[]` (detail-only)                                 | Nested sub-agent task dispatched                             |
+| `SubagentStop`      | `[]` (detail-only)                                 | Nested sub-agent task completed                              |
+| `Stop`              | `[Idle]`                                           | Agent finished responding and is idle                        |
+| `StopFailure`       | `[Error]`                                          | Agent stopped due to an error                                |
+| `Notification`      | `[Waiting, Idle]`                                  | Permission/elicitation prompt, idle prompt, or auth success  |
+| `PermissionRequest` | `[Waiting]`                                        | Tool permission request awaiting user approval               |
+| `SessionEnd`        | `[Clear]`                                          | Claude Code session ended                                    |
+
+`Notification` 的 sub-branch 邏輯（`permission_prompt` / `elicitation_dialog` → Waiting；`idle_prompt` / `auth_success` → Idle；其他 → Valid=false）由 `deriveCCStatus` 實作內部處理；`EmitsStatus` 只列聯集。
+
+#### codex（擴展：3 事件 → 9 事件；對齊 cc）
+
+**重點**：本 PR 擴展 codex installer 清單從目前的 3 個（`SessionStart` / `UserPromptSubmit` / `Stop`）到 9 個，對齊 cc 與 codex `deriveCodexStatus` 已支援的完整集合（Phase 1 已讓 codex `DeriveStatus` 認識 9 個事件，installer 端尚未跟進 — 即 issue #613 alignment gap）。
+
+擴展後：
+
+| Name                | EmitsStatus          | Description                                                  |
+|---------------------|----------------------|--------------------------------------------------------------|
+| `SessionStart`      | `[Idle]`             | Codex session started                                        |
+| `UserPromptSubmit`  | `[Running]`          | User submitted a prompt                                      |
+| `SubagentStart`     | `[]` (detail-only)   | Nested sub-agent task dispatched                             |
+| `SubagentStop`      | `[]` (detail-only)   | Nested sub-agent task completed                              |
+| `Stop`              | `[Idle]`             | Agent finished responding and is idle                        |
+| `StopFailure`       | `[Error]`            | Agent stopped due to an error                                |
+| `Notification`      | `[Waiting, Idle]`    | Permission/elicitation/idle prompt notifications             |
+| `PermissionRequest` | `[Waiting]`          | Tool permission request awaiting user approval               |
+| `SessionEnd`        | `[Clear]`            | Codex session ended                                          |
+
+**擴展 vs 現況對照**（issue #613 alignment 的核心）：
+
+```
+Before (installer writes to ~/.codex/hooks.json):   [SessionStart, UserPromptSubmit, Stop]            -- 3
+After  (installer writes 9 events):                 [SessionStart, UserPromptSubmit, SubagentStart,
+                                                     SubagentStop, Stop, StopFailure, Notification,
+                                                     PermissionRequest, SessionEnd]                   -- 9
+
+Before (DeriveStatus knows):    9 events (Phase 1 completed)
+After:                          9 events                 -- unchanged, already aligned
+```
+
+實際 codex CLI 當前版本可能不會 emit 新增的 6 個事件（proxy 路徑或未來 CLI 才會）— 這**不是問題**，§8 風險表已接受此設計原則（drift test 保證宣告與 `DeriveStatus` 實測一致；未來 CLI / proxy 發生即用）。
+
+#### opencode（8 事件，沿用現況）
+
+| Name                | EmitsStatus          | Description                                                  |
+|---------------------|----------------------|--------------------------------------------------------------|
+| `SessionStart`      | `[Idle]`             | OpenCode session started                                     |
+| `UserPromptSubmit`  | `[Running]`          | User submitted a prompt                                      |
+| `SubagentStart`     | `[]` (detail-only)   | Nested sub-agent task dispatched                             |
+| `SubagentStop`      | `[]` (detail-only)   | Nested sub-agent task completed                              |
+| `PermissionRequest` | `[Waiting]`          | Tool permission request awaiting user approval               |
+| `Stop`              | `[Idle]`             | Agent finished responding and is idle                        |
+| `StopFailure`       | `[Error]`            | Agent stopped due to an error                                |
+| `SessionEnd`        | `[Clear]`            | OpenCode session ended                                       |
+
+### 1.5 `SupportedStatuses()` 改為 derive
+
+三家 `provider.go` 現況是硬編碼 `return []Status{Running, Waiting, Idle, Error, Clear}`（Phase 1 commit 寫死）。改為：
+
+```
+SupportedStatuses():
+  union = {}
+  for each spec in Events():
+    for each status in spec.EmitsStatus:
+      union[status] = true
+  return sorted(union)    -- sorted by Status string for deterministic output
+```
+
+實作時抽一個 package-level helper（在 `internal/agent/` 主 package，非 provider 子 package），例如：
+
+```
+DeriveSupportedStatuses(events []HookEventSpec) []Status
+```
+
+三家各自的 `SupportedStatuses()` 變為：
+
+```
+p.SupportedStatuses() -> return DeriveSupportedStatuses(p.Events())
+```
+
+**排序策略**：helper 對 Status 字串做 lexicographic sort，確保 `SupportedStatuses()` 回傳確定性順序。Phase 1 的硬編碼順序（Running, Waiting, Idle, Error, Clear）會改變 — 調查現況所有 callers 對順序的依賴（預期：無 — 用 set 語意）並在 §8 標示風險。
+
+### 1.6 Drift 測試三向升級
+
+現況 `internal/agent/drift_test.go` 做兩件事：per-fixture 斷言 + `declared vs emitted` set 比較。升級後做**三向斷言**：
+
+1. **宣告集**：`union(Events().EmitsStatus)` — 由 `Events()` derive
+2. **實測集**：對 `Events()` 每個 `Name`，以 fixture 驅動 `DeriveStatus`，收集 `Valid=true && Status!=""` 的 Status
+3. **derive 集**：`SupportedStatuses()` 的回傳（現在也是 derived，應與宣告集相等）
+
+三者需**兩兩相等**（等價於三集合相等）。任一不一致即 fail，錯誤訊息列出差集（哪個 Status 在哪個集合存在、另兩個缺）。
+
+per-fixture 斷言（Phase 1 的 codex review 堅持的反退化保險）**保留**：`providerFixtures` map 仍列每個事件的 raw payload + `wantStatus`，確保「刪除 Notification 某個 sub-branch」能被抓到（set 比對單獨做不到，Phase 1 已證明）。
+
+**新增檢查**：每個 `Events()` 的 `Name` 必須在 `providerFixtures` 出現至少一次（確保宣告的事件都有實測；現況 Phase 1 fixture 已覆蓋 cc/codex 9 事件與 opencode 8 事件，本 PR 驗證這點為強制）。
+
+### 1.7 Hooks installer 內部使用
+
+**cc (`mergeClaudeHooks`)**：迭代從 `ccHookEvents` 改為 `p.eventNames()`（或直接 `for _, spec := range p.Events() { event := spec.Name; ... }`）。`filterOutPdx` + `makePdxEntry` 不動（只動 iteration source）。
+
+**codex (`mergeCodexHooks`)**：同上；迭代從 `codexHookEvents` 改為 `p.eventNames()`。由於 codex 事件數從 3 擴到 9，安裝效果變化：用戶首次跑 `InstallHooks` 會把 6 個新事件寫入 `~/.codex/hooks.json`；既有用戶重跑（`pdx install cc/codex` 或等價 CLI）時 6 新事件也會被補入（`filterOutPdxCodex` + append 的既有邏輯自然處理）。
+
+**opencode (`writeManagedPlugin` + `CheckHooks`)**：`CheckHooks` 的事件迴圈從 `opencodeHookEvents` 改為 `p.eventNames()`。`writeManagedPlugin` 若模板為字串常數包含硬編碼事件列表則保持（模板內容不動，除非 `renderManagedPlugin` 內有迴圈 — 進 subagent 實作時視 `plugin_template.go` 內容決定是否改）。本 PR 不動 opencode plugin_template 的字串模板（§1.8 零改動邊界）。
+
+**`CheckHooks` 三家**：事件迴圈同樣改走 `p.eventNames()`。
+
+### 1.8 零改動邊界
+
+本 PR **不得觸碰**：
+
+- `internal/agent/registry.go`、`internal/agent/coverage.go`（Coverage helper 已是通用，`Events()` 擴充透過 `HookInstaller` 入口，不動 Coverage）
+- `internal/agent/status.go`（Status enum 不變）
+- `internal/agent/probe/**`（probe 層完全獨立）
+- `internal/agent/hook_version*.go` / `process_info*.go`
+- `internal/module/agent/handler.go` 的流程邏輯（catalog-miss 早退是 Phase 1 既有能力，本 PR 不重構）
+- `internal/module/**` 除了必要的測試（預期為零 — 本 PR 不改 module 層）
+- `internal/store/**`
+- `internal/agent/opencode/plugin_template.go` 的字串模板（事件名稱若在模板內是硬編碼字串則沿用；只動 CheckHooks iteration）
+- `spa/**`（Inspector UI 是後續工作，本 PR 不動）
+- `/api/agent/monitor/events` endpoint — **不新增**（留 Phase 5）
+
+## 2. 測試案例清單
+
+按檔案組織；全部描述以文字表達，不含 Go。
+
+### 2.1 三家 `Events()` 單元測試
+
+| # | 檔案 | 名稱 | 斷言 |
+|---|---|---|---|
+| E1 | `cc/hooks_test.go`（或新檔 `cc/events_test.go`） | `TestCCEvents_Count` | `len(Events()) == 9` |
+| E2 | 同上 | `TestCCEvents_NamesMatchExpected` | Events 的 Name set 為 §1.4 cc 9 項 |
+| E3 | 同上 | `TestCCEvents_EmitsStatusForNotification` | `Notification` 項 `EmitsStatus` set 為 `{Waiting, Idle}` |
+| E4 | 同上 | `TestCCEvents_DetailOnlyHaveEmptyEmitsStatus` | `SubagentStart` 與 `SubagentStop` 的 `EmitsStatus` 長度為 0（非 nil — 空 slice） |
+| E5 | 同上 | `TestCCEvents_DescriptionsNonEmpty` | 每項 Description 長度 > 0 且無 emoji |
+| E6 | 同上 | `TestCCEvents_FreshSliceDefensiveCopy` | 連續呼叫兩次 Events 回傳不同 backing array；mutate 第一次結果不影響第二次 |
+| E7 | `codex/events_test.go` | `TestCodexEvents_ExpandedTo9` | `len(Events()) == 9`；Name set 為 §1.4 codex 9 項（**對應 issue #613 擴展驗證**） |
+| E8 | 同上 | `TestCodexEvents_EmitsStatusForNotification` | 同 E3 |
+| E9 | 同上 | `TestCodexEvents_DetailOnlyHaveEmptyEmitsStatus` | 同 E4 |
+| E10 | `opencode/events_test.go` | `TestOpenCodeEvents_Count` | `len(Events()) == 8` |
+| E11 | 同上 | `TestOpenCodeEvents_NamesMatchExpected` | Name set 為 §1.4 opencode 8 項 |
+
+### 2.2 `SupportedStatuses` derive 測試
+
+| # | 檔案 | 名稱 | 斷言 |
+|---|---|---|---|
+| S1 | `internal/agent/supported_statuses_test.go`（新檔，package `agent_test`） | `TestDeriveSupportedStatuses_UnionAndSort` | 輸入 spec list 包含 `{EmitsStatus:[Running,Waiting]}` + `{EmitsStatus:[Idle]}` + `{EmitsStatus:[]}` → 回傳 `[Idle, Running, Waiting]`（lex sort） |
+| S2 | 同上 | `TestDeriveSupportedStatuses_DedupesDuplicates` | 同一 Status 在多 spec 出現 → union 後只出現一次 |
+| S3 | 同上 | `TestDeriveSupportedStatuses_EmptyInput` | 空 spec list → 回傳 empty slice（長度 0 但非 nil，統一行為） |
+| S4 | 三家 `provider_test.go` | `TestCC/Codex/OpenCodeSupportedStatuses_DerivesFromEvents` | 斷言 `SupportedStatuses()` 回傳 set 與 `union(Events().EmitsStatus)` set 相等（兩 line assertion 證 derive 正確） |
+
+### 2.3 Installer iteration 測試
+
+| # | 檔案 | 名稱 | 斷言 |
+|---|---|---|---|
+| I1 | `cc/hooks_test.go` | `TestCCInstallHooks_WritesAllEventsFromEventsList` | 對 temp settings.json 跑 `InstallHooks` → 讀回 JSON → `hooks` 物件 key set 等於 `Events()` 的 Name set（動態驗證，不硬編碼 9） |
+| I2 | `cc/hooks_test.go` | `TestCCCheckHooks_ReportsAllEventsFromEventsList` | 寫一個缺 `Notification` 的 settings.json → `CheckHooks()` 的 `Events` map key set 包含 Events Name set；`Notification` 的 `Installed=false` |
+| I3 | `codex/hooks_test.go` | `TestCodexInstallHooks_Writes9EventsAfterExpansion` | 跑 `InstallHooks` → 讀 hooks.json → 寫入 key set 等於擴展後的 9 個；**特別驗證 `SessionEnd` / `Notification` / `PermissionRequest` 已被寫入**（明確的 regression guard，對應 issue #613 修復） |
+| I4 | `codex/hooks_test.go` | `TestCodexCheckHooks_ReportsAll9Events` | 同 I2，key set 為擴展後 9 項 |
+| I5 | `opencode/hooks_test.go` | `TestOpenCodeCheckHooks_ReportsAll8EventsFromEventsList` | `CheckHooks()` 的 `Events` map key set 等於 `Events()` 的 Name set |
+
+Note: I3 / I4 是 issue #613 的核心 regression guard — 任何未來讓 codex installer 倒退回 3 事件的改動會被抓到。
+
+### 2.4 Drift 測試升級
+
+改 `internal/agent/drift_test.go`：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| D1' | `TestDriftThreeWayEquality`（改名自 `TestDriftDeclaredEqualsEmitted`） | 對三家 provider：`declaredSet`（從 Events union）== `emittedSet`（fixture 驅動 DeriveStatus）== `supportedSet`（`SupportedStatuses()` 回傳）；錯誤訊息列出三集合差異 |
+| D2 | `TestDriftFixtureCoverageNonEmpty` | 不變（防呆：fixture 非空） |
+| D3 | `TestDriftFixtureCoversAllEvents` | 每家 provider 的 `Events()` 所有 Name 都在 `providerFixtures` 出現至少一次（新增防呆；對應 §1.6 新增檢查） |
+
+### 2.5 Registry / Coverage 整合測試
+
+`internal/agent/coverage_test.go` 現有 C1（Phase 1 `TestCoverageRealProviders`）**不動**。新增（同檔）：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| C2 | `TestCoverageDeclaredMatchesEventsUnion` | 對三家 provider，`CoverageRow.Declared` set 與 `union(Events().EmitsStatus)` set 相等（跨檔契約驗證） |
+
+### 2.6 Handler 相關 regression
+
+無需新增測試。本 PR 不動 handler；既有 `internal/module/agent/handler_test.go` 全套應保持綠，作為 regression guard（subagent 必須跑 `go test ./internal/module/agent/...` 並確認綠）。
+
+## 3. TDD 執行順序
+
+嚴格紅綠，每個 commit 先紅後綠；不可批次寫完全部 test 再一次實作。預期 10 commits（包含 docs）。
+
+### Commit 1 — `feat(agent): add HookEventSpec type + Events() to HookInstaller`
+
+- 紅：在 `internal/agent/provider.go` 寫 `HookEventSpec` + 擴 `HookInstaller`（加 `Events() []HookEventSpec`）；三家 provider 尚未補 `Events()` → `go build ./...` **紅**
+- 綠：同 commit 內給三家加最小 stub（`Events() []HookEventSpec { return nil }`）；build 恢復綠
+- 注意：此 commit 故意不跑單元測試（stub 不測）；目的是讓 interface 擴充可以被其他 commit 依賴。Commit message 明確說明「stub，後續 commits 填實際內容」
+- 同 commit 增加 doc comment：`Events()` 是 SSoT，比 `SupportedStatuses()` / installer var 更權威
+
+### Commit 2 — `feat(agent): add DeriveSupportedStatuses helper + tests`
+
+- 紅：新檔 `internal/agent/supported_statuses.go` 空 + 新檔 `internal/agent/supported_statuses_test.go` 寫 S1 / S2 / S3 → 紅
+- 綠：實作 helper（union → sort）
+- 驗證：`go test ./internal/agent/... -run DeriveSupportedStatuses` 綠
+
+### Commit 3 — `feat(agent/cc): implement Events() + derive SupportedStatuses`
+
+- 紅：新檔 `cc/events_test.go` 寫 E1-E6 → 紅（stub 回 nil）；`cc/provider_test.go` 改寫 S4 cc 部分 → 紅
+- 綠：
+  - 在 `cc/hooks.go`（或新檔 `cc/events.go`，視可讀性）實作 `Events()` 回傳 9 個 `HookEventSpec`
+  - 修 `cc/provider.go` 的 `SupportedStatuses()` 改為 `DeriveSupportedStatuses(p.Events())`
+  - **刪除 `ccHookEvents` package var**；`mergeClaudeHooks` / `CheckHooks` iteration 改走 `p.eventNames()` helper（private method）
+- 驗證：`go test ./internal/agent/cc/...` 綠（含既有 installer / check 測試 regression）
+- 規模：~60-90 行變更（events.go 新增 + 刪 var + 改 iteration）
+
+### Commit 4 — `feat(agent/opencode): implement Events() + derive SupportedStatuses`
+
+- 同 Commit 3 模式，改 opencode
+- 紅：`opencode/events_test.go` E10 / E11 + provider_test S4 opencode 部分
+- 綠：實作 `Events()` 8 項 + 刪 `opencodeHookEvents` var + `CheckHooks` 用 helper + `SupportedStatuses` 改 derive
+- 注意：`plugin_template.go` 的字串模板若含硬編碼事件列表，**不改**；只動 `CheckHooks` iteration
+- 驗證：`go test ./internal/agent/opencode/...` 綠
+
+### Commit 5 — `feat(agent/codex): expand installer to 9 events via Events()`
+
+- 這是 issue #613 的**正體修復** commit。分兩步：
+- 紅 step A：`codex/events_test.go` 寫 E7 / E8 / E9 → 紅（stub 回 nil）
+- 紅 step B：`codex/hooks_test.go` 寫 I3 / I4 → 紅（installer 仍只寫 3 事件）
+- 綠：
+  - 實作 `codex.Provider.Events()` 回傳 9 項
+  - **刪除 `codexHookEvents` package var**；`mergeCodexHooks` / `CheckHooks` iteration 改走 helper
+  - 修 `SupportedStatuses` 改 derive
+- 驗證：`go test ./internal/agent/codex/...` 綠；手動檢查 diff 確認 6 個新事件（`SubagentStart/Stop` / `StopFailure` / `Notification` / `PermissionRequest` / `SessionEnd`）確實進入 installer 寫出的 JSON
+- Commit message 主體明確提到 close issue #613
+
+### Commit 6 — `test(agent): upgrade drift test to three-way equality`
+
+- 紅：改 `drift_test.go` D1 → D1'（加 supportedSet 斷言）；新增 D3 → 若 Commit 3/4/5 的 `Events()` 與現有 providerFixtures 都對齊，應直接綠；若否，修 fixture 或 Events()
+- 綠：三向等價 + fixture-covers-all-events 皆綠
+- 驗證：故意臨時把 cc `Events()` 的 `Notification` EmitsStatus 砍一個（本機試，不 commit）→ D1' 應紅；還原後綠
+
+### Commit 7 — `test(agent): add Coverage × Events cross-contract test`
+
+- 紅：`coverage_test.go` 加 C2 → 應綠（前面 commits 已對齊）
+- 此 commit 為 verification 性質（無邏輯變更），確保 Coverage 與 Events 契約跨檔穩定
+- 若 C2 紅，回頭修（不該發生）
+
+### Commit 8 — `refactor(agent): tighten Events doc comments + eventNames helper consistency`
+
+- 純 doc / refactor commit（可選）：統一三家的 `eventNames()` helper 命名、補 doc comment
+- 若 Commit 3/4/5 寫得夠乾淨，此 commit 可略
+- 驗證：`go vet ./...` 無 warning；`go test ./...` 綠
+
+### Commit 9 — `docs: add hook-events-declaration plan`
+
+- 本 plan 檔進 repo
+- 不改 code
+
+### Commit 10 — `docs(spec): mark §2.4.3 event alignment resolved via Events() PR`
+
+- 改 `docs/specs/2026-04-23-lights-rebuild-spec.md` §2.4.3 加一行註記：「已於 PR #<num> 實作完成」
+- 或是在 PR merge 後另開 bump PR 帶這行 — 子任務範圍內視情況而定；本 plan 建議**放入本 PR**，保留設計脈絡
+- 若主 session 要求 bump PR 帶，Commit 10 可略
+
+## 4. 實作檔案預估
+
+| 檔案 | 動作 | 預估行數 |
+|---|---|---|
+| `internal/agent/provider.go` | +`HookEventSpec` struct + 擴 `HookInstaller`；doc comments | +25 |
+| `internal/agent/supported_statuses.go` | 新檔：`DeriveSupportedStatuses` helper | +20 |
+| `internal/agent/supported_statuses_test.go` | 新檔：S1-S3 | +60 |
+| `internal/agent/coverage_test.go` | +C2 | +20 |
+| `internal/agent/drift_test.go` | D1→D1' 升級 + D3 新增 | +40 / -10 |
+| `internal/agent/cc/events.go`（或嵌入 hooks.go） | 新增 `Events()` + `eventNames()` helper | +60 |
+| `internal/agent/cc/hooks.go` | 刪 `ccHookEvents` var；iteration 改 helper | +5 / -5 |
+| `internal/agent/cc/provider.go` | `SupportedStatuses` 改 derive | +2 / -7 |
+| `internal/agent/cc/events_test.go` | 新檔：E1-E6 | +120 |
+| `internal/agent/cc/provider_test.go` | +S4 cc | +15 |
+| `internal/agent/cc/hooks_test.go` | +I1 / I2 | +60 |
+| `internal/agent/codex/events.go`（或嵌入 hooks.go） | 新增 `Events()` + helper | +60 |
+| `internal/agent/codex/hooks.go` | 刪 `codexHookEvents` var；iteration 改 helper | +5 / -6 |
+| `internal/agent/codex/provider.go` | `SupportedStatuses` 改 derive | +2 / -7 |
+| `internal/agent/codex/events_test.go` | 新檔：E7-E9 | +90 |
+| `internal/agent/codex/provider_test.go` | +S4 codex | +15 |
+| `internal/agent/codex/hooks_test.go` | +I3 / I4（issue #613 regression guard） | +80 |
+| `internal/agent/opencode/events.go`（或嵌入 hooks.go） | 新增 `Events()` + helper | +60 |
+| `internal/agent/opencode/hooks.go` | 刪 `opencodeHookEvents` var；iteration 改 helper | +5 / -5 |
+| `internal/agent/opencode/provider.go` | `SupportedStatuses` 改 derive | +2 / -7 |
+| `internal/agent/opencode/events_test.go` | 新檔：E10-E11 | +70 |
+| `internal/agent/opencode/provider_test.go` | +S4 opencode | +15 |
+| `internal/agent/opencode/hooks_test.go` | +I5 | +30 |
+| `docs/specs/2026-04-23-hook-events-declaration-plan.md` | 本檔 | +320 |
+| `docs/specs/2026-04-23-lights-rebuild-spec.md` | §2.4.3 註記（Commit 10） | +3 |
+| **合計** | | **~1200 行**（含 plan / spec 更新 + 大量測試） |
+
+## 5. 不做項目清單（防自動擴展）
+
+以下衝動一律拒絕；subagent 如遇到念頭請在 PR description 明確聲明拒絕：
+
+1. **不新增 `/api/agent/monitor/events` endpoint**（留 Phase 5）
+2. **不動 SPA**（Inspector UI 是後續工作）
+3. **不動 probe 層**（`internal/agent/probe/**`）
+4. **不重構 `handler.go` 流程邏輯**（catalog-miss 早退是 Phase 1 既有能力）
+5. **不移除 `StatusSupporter` interface**（保留作為通用宣告入口；只是實作改為 derive — 移除會影響 Phase 5 Inspector 與 Coverage row 的契約）
+6. **不動 `coverage.go` 的 `Coverage` helper**（Events 擴充透過 `HookInstaller` 入口，Coverage 不新增欄位）
+7. **不在 `HookEventSpec` 嵌入 probe intents**（那是 Phase 4b `ProbeIntentProvider`；混進 Hook 宣告會讓兩個分散概念被錯誤耦合）
+8. **不 refactor `mergeClaudeHooks` / `mergeCodexHooks`** 成跨家共用 helper（Phase 1 spec §2.4.4 明示 Policy 分散）
+9. **不動 `opencode/plugin_template.go` 的字串模板**（即使模板內硬編碼事件列表；模板是 runtime artifact，不是宣告 SSoT）
+10. **不幫 codex 補 proxy 路徑的事件接收實作**（這是 runtime 工作，留未來 phase）
+11. **不重命名既有 `HookInstaller` 為 `HookProvider`**（即使加了 `Events()` 讓它更像 provider）— rename 是純 churn
+12. **不新增 `HookEventSpec.Optional`** 欄位或類似（YAGNI）
+13. **不引入 `internal/agent/events_catalog.go` 或類似 central lookup**（§2.4.1 黃線：runtime 收斂 = 膨脹）
+14. **不加 hook event 的 i18n 支援**（Description 固定英文）
+
+## 6. Subagent 開發指引
+
+- **cwd 強制前綴**：每個 Bash 指令以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-hook-events-declaration && ` 為前綴（依 `feedback_subagent_cwd_enforcement.md`）。worktree 名稱由主 session 開 worktree 時確認；本 plan 假設為 `lights-hook-events-declaration`
+- **分支**：進入後不另切；不 push（主 session 負責）
+- **Commit message 格式**：Conventional Commits + 結尾加 `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+- **TDD 嚴格紅綠**：每個 commit 內先寫測試跑紅再實作跑綠；不可批次寫完所有 test 再一次實作
+- **刪除 `*HookEvents` var 時**：用 `grep -rn "ccHookEvents\|codexHookEvents\|opencodeHookEvents" internal/` 確認無其他引用（預期三家各 1 檔 3 處 usage：install / remove / check）
+- **回報格式**：
+  - Commit hash 列（`git log --oneline -12`）
+  - `go build ./...` / `go vet ./...` 輸出摘要
+  - `go test ./internal/agent/... ./internal/module/agent/...` 結果摘要（測試數量 + PASS/FAIL）
+  - SPA 不需跑（本 PR 不動 SPA）
+- **不要執行 `pnpm install` 或 `pnpm run build/lint`**（本 PR 不動 SPA）
+- **Codex sandbox 限制**：本 PR 全 Go 改動，無 SPA 依賴，sandbox 網路限制不影響
+
+## 7. 驗收清單
+
+- [ ] 9-10 個 commits 符合 Conventional Commits + Co-Authored-By
+- [ ] `go build ./...` 綠
+- [ ] `go vet ./...` 無 warning
+- [ ] `go test ./...` 綠（新增 E1-E11、S1-S4（三家各一）、I1-I5、D1'、D3、C2 共約 24 個測試點）
+- [ ] 既有測試 0 regression（特別：`handler_test.go` / `coverage_test.go` C1 / `drift_test.go` D2）
+- [ ] 三家 `HookInstaller` 都實作 `Events()` 且欄位符合 §1.4 表格
+- [ ] 三家 `*HookEvents` package var 皆已刪除
+- [ ] 三家 `SupportedStatuses()` 實作已改為 `DeriveSupportedStatuses(p.Events())`
+- [ ] codex installer 實際寫出 9 個事件到 `~/.codex/hooks.json`（手動整合測：跑 `bin/pdx` install → 讀檔確認 key set 為 9 項）
+- [ ] drift test 對三向等價（declared / emitted / supported）皆綠
+- [ ] drift test 能抓到「砍掉 cc `Notification` 其中一個 EmitsStatus」的人為 regression（手動實驗記錄在 PR description）
+- [ ] PR diff 只觸及 §4 表格列出的檔案；無計畫外檔案變動（特別是 `handler.go` / SPA / probe）
+- [ ] PR description 列出「不做項目」§5 的明確聲明
+- [ ] Close issue #613（PR description 用 `Closes #613` 關鍵字）
+- [ ] Spec §2.4.3 已更新註記（Commit 10，或獨立 PR）
+
+## 8. 風險與緩解
+
+| 風險 | 機率 | 影響 | 緩解 |
+|---|---|---|---|
+| codex CLI 當前版本不會發出新增的 6 事件 | 高 | Installer 裝了沒人觸發 | 接受 — 為 proxy 路徑與未來 CLI 鋪路；drift test + per-fixture 測保證宣告與 DeriveStatus 一致；issue #613 的語意就是「為不一致鋪路」而非「等 CLI 才裝」 |
+| `SupportedStatuses()` 從硬編碼改 derive 後回傳順序改變 | 低 | 若有 caller 依賴順序則破壞 | Commit 2 的 helper sort lex；調查現況 callers — 掃 `grep -rn "SupportedStatuses" internal/ spa/` 確認消費端只用 set 語意（無 order 依賴）；記錄調查結果於 PR description |
+| `*HookEvents` package var 刪除後有外部依賴 | 低 | Build 失敗 | 範圍僅 purdex repo 內 package internal，`grep -rn` 可在 commit 前掃清；同 repo 內改動可原子化 |
+| drift test 升級後過渡期：per-fixture + 三向等價同時跑 | 低 | 錯誤訊息膨脹、實作期紅得看不懂 | 錯誤訊息必須分層顯示（per-fixture 先；set diff 後）；fail 訊息附修復建議（「加 fixture / 改 Events / 改 SupportedStatuses」三路徑） |
+| codex installer 擴展後，既有用戶 `~/.codex/hooks.json` 殘留舊 3-event 狀態 | 中 | 用戶需重跑 `pdx install codex` | 設計上 `mergeCodexHooks` 的 `filterOutPdxCodex` + append 對任何事件都能增量更新；用戶重跑 install 自然補齊 6 新事件；記錄於 PR description 的 Manual test plan |
+| `Events()` 成為第四個 provider 新手陷阱（忘記實作） | 低 | 新 provider PR 爆 build error | `Events()` 是 required 方法，type checker 強制；build error 本身就是提醒；Commit 1 的 doc comment 也說明 |
+| `Notification` 的 `auth_success` / `idle_prompt` sub-branch 被程式碼 reviewer 遺忘 | 中 | `EmitsStatus` 漏列某 Status | drift test 已有 per-fixture 對這 4 個 Notification sub-type 各一筆（Phase 1 codex review 堅持的保險）；Commit 6 升級時確保 fixture 不動 |
+| PR 過大（~1200 行）影響 review | 中 | review 疲勞 / 漏 review | 10 commits 按領域切分（core helper → cc → opencode → codex → drift → docs）；每 commit 可獨立 review；PR description 提供「建議 review 順序」 |
+
+## 9. 兩輪 Codex Review 預期 focus
+
+### 第一輪（標準 code review 跨模型差異化檢查）
+
+- 三家 `Events()` 表格的 `EmitsStatus` 是否漏 cc `Notification` 四個 sub-type 對應 Status（Waiting / Idle）；`EmitsStatus` 是否正確處理為 set-semantics
+- `DeriveSupportedStatuses` 的 sort 策略是否 deterministic（lex sort Status 字串 vs 其他排序鍵）
+- `Events()` 回傳 slice 的 defensive copy 是否一致（三家實作為同型）
+- codex installer 擴展的向後相容：既有用戶升級後 `~/.codex/hooks.json` 變動行為
+- `*HookEvents` var 刪除後，build 是否真的全綠（跨 package 引用掃乾淨）
+- Description 語氣一致性（英文、無句號、無 emoji、長度合理）
+
+### 第二輪 3 parallel
+
+- **攻擊方**（找 bug / 安全 / race）：
+  - `Events()` 空回傳情境（provider 忘了實作、stub 漏補）
+  - `Events()` 返回順序 non-deterministic 情境（map iteration 洩漏）
+  - `SupportedStatuses` 併發呼叫（derive helper thread-safety — 應是 pure function，但驗證）
+  - codex 擴展事件後的舊用戶 hooks.json 解析 edge case（legacy format 共存）
+  - `eventNames()` helper 洩漏內部 slice（defensive copy 漏）
+
+- **防守方**（驗證設計合理性 / 架構一致性 / API 邊界）：
+  - 與 §2.4 架構護欄的一致性（`Events()` 是否真的只在宣告層、沒變 runtime catalog lookup）
+  - `HookEventSpec` 欄位集 vs 未來 probe intents 是否有耦合風險（應完全獨立）
+  - `SupportedStatuses` 改 derive 是否破壞 Phase 1 Inspector-ready 假設
+  - `HookInstaller.Events()` required vs `StatusSupporter` 仍 optional 的不對稱是否合理
+  - drift test 三向等價的錯誤訊息設計（診斷性 vs 詳盡度）
+
+- **檔案體質**（過大檔案 / SRP 違反 / 職責不清）：
+  - `provider.go` 加 `HookEventSpec` 後是否過大（考慮拆到 `internal/agent/hook_events.go` 獨立檔）
+  - 三家 `events.go` 是否該獨立檔案（vs 嵌入 `hooks.go`）— 本 plan 傾向獨立檔，理由：`Events()` 是宣告 SSoT，獨立檔利於 reviewer 一目了然
+  - 三家 `events_test.go` 是否過大（E1-E6 / E7-E9 / E10-E11）
+  - `eventNames()` helper 命名與位置（private method on Provider vs package-level function）
+  - drift_test.go 擴充後是否超過 300 行、fixture 是否該拆 `drift_fixtures.go`

--- a/docs/specs/2026-04-23-hook-events-fix-plan.md
+++ b/docs/specs/2026-04-23-hook-events-fix-plan.md
@@ -1,0 +1,385 @@
+# Hook Events PR #616 Fix Plan
+
+- **Date**: 2026-04-23
+- **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §2.4（架構護欄）
+- **Parent plan**: `docs/specs/2026-04-23-hook-events-declaration-plan.md`（既有，11 commits merged 進本分支）
+- **Worktree**: `lights-spec-guardrails`（branch `worktree-lights-spec-guardrails`，PR #616）
+- **依賴**: Phase 1 merged at alpha.215（§5 L2 對齊完成）；Events() SSoT 已在本分支建立
+- **範圍**: 修四路 codex review 攻擊/防守/體質視角提出的 4 個 findings（2 HIGH + 2 MED），讓 Events() SSoT 主張在 codex 與 opencode 端真正成立，且不因升級誤判既有安裝
+
+## 1. 契約鎖定
+
+本節鎖定全 Fix 行為，避免實作期再決策。
+
+### 1.1 HookEventSpec 新增 FutureOnly 欄位
+
+`internal/agent/provider.go` `HookEventSpec` 結構加一個 `FutureOnly bool`：
+
+```
+type HookEventSpec struct {
+    Name        string
+    EmitsStatus []Status
+    Description string
+    FutureOnly  bool // 此 event 已在 spec 中宣告，但當前 CLI 版本未必會 emit
+}
+```
+
+**語意**：
+
+- `FutureOnly=false`（預設）— 當前 CLI 會 emit 此 event；installer 安裝、CheckHooks 嚴格檢查 missing、drift test 要求 fixture 覆蓋、SupportedStatuses derive 會納入 EmitsStatus
+- `FutureOnly=true` — installer 仍安裝（為 CLI 升級鋪路），但 runtime 未必收得到；CheckHooks 對此 event missing **不標 issue、不計入 allInstalled**；drift test **不要求** fixture；SupportedStatuses derive 時**跳過**其 EmitsStatus
+
+**不把語意等同於「CLI 永遠不會支援」**：只表達「目前 build-time 信心不足，把它從對外 capability 宣告裡隔離」。後續 CLI 驗證通過後翻成 false 即可。
+
+### 1.2 DeriveSupportedStatuses 過濾 FutureOnly
+
+`internal/agent/supported_statuses.go` `DeriveSupportedStatuses` 對 FutureOnly spec **跳過**其 EmitsStatus：
+
+```
+for _, spec := range specs {
+    if spec.FutureOnly {
+        continue
+    }
+    for _, s := range spec.EmitsStatus { ... }
+}
+```
+
+排序與去重邏輯不變；空輸入仍回非 nil empty slice；deterministic lexicographic 排序不變。
+
+**影響**：codex 6 個 FutureOnly event 的 5 個 status（Waiting/Error/Clear/加 Notification idle 分支的 Idle 重複/PermissionRequest 的 Waiting 重複）— 其實經過各自 emits 表 intersection 後，codex SupportedStatuses 會收斂到「Running+Idle」（由 UserPromptSubmit+SessionStart/Stop 兩個非 FutureOnly event 貢獻）。
+
+### 1.3 三家 provider FutureOnly 標記矩陣
+
+| Provider | Event | FutureOnly | 理由 |
+|---|---|---|---|
+| cc | 全部 9 個 | false | cc CLI 實際會 emit 全部 9 個（此版本 plugin 驗證過） |
+| codex | SessionStart / UserPromptSubmit / Stop | false | 主線 codex CLI hooks 長期支援這 3 個（既有 3-event 安裝） |
+| codex | SubagentStart / SubagentStop / StopFailure / Notification / PermissionRequest / SessionEnd | **true** | codex CLI 目前不保證 emit；但 DeriveStatus 已能解析；installer 安裝為未來鋪路 |
+| opencode | 全部 8 個 | false | plugin template 實際會 emit 全部 8 個（§1.5 後 template 從 Events 生成） |
+
+codex 3-FutureOnly 後，**SupportedStatuses=[Idle, Running]**；drift test 對這 2 個 status 做 per-event 強相等；6 個 FutureOnly event 跳過 fixture 檢查。
+
+**不做 per-CLI-version gate**：版本探測與動態 FutureOnly 翻轉留給未來 phase；此 PR 的 FutureOnly 是 build-time 靜態標記。
+
+### 1.4 codex CheckHooks 對 FutureOnly missing 不報問題
+
+`internal/agent/codex/hooks.go` CheckHooks 改動：
+
+- 遍歷仍用 `p.eventNames()`（維持 9 個 event 全部檢查與寫入 `Events` map）
+- **但**對 `spec.FutureOnly=true` 的 event，若 `hooks.json` 缺該 key 或 pdx command 不在：
+  - `events[eventName] = HookEventInfo{Installed: false}`（仍如實記錄實況）
+  - **不 append issue**
+  - **不設 `allInstalled = false`**
+- 非 FutureOnly event 維持現有嚴格檢查（missing → issue + allInstalled=false）
+
+遍歷時需要每個 event name 配對其 spec（取得 FutureOnly bit）：用 `p.Events()` 取 `[]HookEventSpec`（或建一個 `eventSpecs()` 私有 helper 回傳已定義的 `codexEventSpecs` slice 以避免 defensive copy 開銷；兩者擇一，不影響對外契約）。
+
+**3-event legacy 使用者**：升級後 hooks.json 仍只有 `SessionStart/UserPromptSubmit/Stop`。其他 6 個 FutureOnly 為 missing（依 §1.4 不標 issue、不計 allInstalled）。只要 3 個非 FutureOnly event 都 installed → `allInstalled=true`。不需要額外 legacy fallback 分支 — FutureOnly 語意已自然覆蓋此 case。
+
+**主線使用者（新安裝 9 event）**：9 個都 installed → `allInstalled=true`、issues 空；FutureOnly event 依然 `Installed=true`（因為 installer 有寫）。
+
+**部分受損**：若 3 個非 FutureOnly 缺其中一個 → `allInstalled=false` + 該 event issue（與現行一致）；FutureOnly 缺失不影響 overall 判定。
+
+### 1.5 opencode renderManagedPlugin 從 Events 生成
+
+這是 Finding #2（防守 HIGH + 體質 MED）的核心：**不讓 template 與 opencodeEventSpecs 成為兩份平行 SSoT**。
+
+`internal/agent/opencode/plugin_template.go` 改動：
+
+- `renderManagedPlugin(pdxPath string) string` **改簽名** 加入 `specs []agent.HookEventSpec` 第二參數（或在函式內讀 `opencodeEventSpecs` — 同套件內 package 級變數，直接讀即可避免 caller 端傳遞）
+- 函式內部從 `opencodeEventSpecs` 動態生成：
+  - plugin JS 的 `emit('<Name>', payload)` 字串依 specs 順序產出
+  - event type mapping（`session.created → SessionStart`、`permission.asked → PermissionRequest`、…）仍保留在 Go 側「OpenCode 原生 event → pdx event name」的轉譯表，因為這是從 opencode runtime 事件語言到 pdx hook 語言的獨立概念
+  - **但**：`emit('<pdx event name>', ...)` 呼叫的 pdx event name 必須出現在 `opencodeEventSpecs` 的 `Name` 集合內 — 生成時以 specs Name 為白名單；若 mapping 表宣告了 specs 沒有的 event，生成時跳過並在測試層抓出（§2.5 D6）
+
+**實作策略**（擇 A）：
+
+- **策略 A**（優先）：template 保留固定 switch/case 結構（因為每個 opencode 原生 event 的 payload 轉譯 JS 邏輯不同），但 template 渲染前 **先檢查每個 emit 的 pdx event 是否在 `opencodeEventSpecs` 集合內**；否則 panic（「contract violation: template emits undeclared event」）。渲染出的 JS 字串保持與目前一致（避免 churn），但運行時 emit 的 event set 受 specs 檢查守護。
+- **策略 B**（若 A 太鬆）：把 template 裡的 switch/case 完全從 specs driven — 但 payload 轉譯邏輯會被 codegen 化，churn 大。**本 PR 不選**。
+
+**選擇策略 A**：改動小、風險低、仍解決 SSoT 核心論點（specs 宣告什麼，template 就能 emit 什麼；不能 emit specs 裡沒有的 event）。
+
+**配合測試**：`plugin_template_test.go` 新增 D5（見 §2.5）驗證「template 字串實際 emit 的 event name」⊆ `opencodeEventSpecs.Name`，且強相等（不能少也不能多）。測試用 regex `/emit\(['"]([A-Za-z]+)['"]/g` 從渲染出的 JS 字串抓 event name。
+
+### 1.6 opencode CheckHooks 對齊新驗證
+
+`internal/agent/opencode/hooks.go` CheckHooks 目前邏輯：檔案存在 + managed marker → 全部 event 標 `Installed=true`。這是 Finding #2 的假綠燈根源。
+
+**新邏輯**：
+
+1. 讀檔、驗 marker（不變）
+2. 用 §1.5 同一套 regex 從檔案內容抓實際 emit 的 event name set
+3. 對每個 `opencodeEventSpecs` event：
+   - 若該 event name 在 emit set 中 → `Installed=true, Command=pluginPath`
+   - 否則 → `Installed=false`，push issue `<event> emit missing in plugin`
+4. `allInstalled = (每個 non-FutureOnly event 都 installed)` — opencode 當前無 FutureOnly event（§1.3），等同「全部 event 都 installed」
+
+**regex 位置**：在 plugin_template.go 暴露一個 `extractEmittedEvents(body string) []string` helper，CheckHooks 與測試共用。單一正規來源避免 drift。
+
+### 1.7 drift test per-event 強相等 + FutureOnly skip
+
+`internal/agent/drift_test.go` 改動核心是把 provider 級 union 比對升級為 per-event 強相等：
+
+**既有 TestDriftThreeWayEquality**：保留（provider 級三向 — Events union vs DeriveStatus union vs SupportedStatuses），但遍歷 fixtures 前**濾掉 FutureOnly spec 對應的 fixture**（若 fixture table 誤放 FutureOnly event fixture → D6 再報，不在此測試）。
+
+具體 FutureOnly 處理：
+- declaredSet 遍歷 `installer.Events()` 時跳過 `spec.FutureOnly=true`
+- 對 fixtures 的 emit 判斷不變（emitted 只管 Valid=true && Status != ""）
+- supportedSet 因 SupportedStatuses 已由 DeriveSupportedStatuses 自動濾 FutureOnly → 自然三向相等
+
+**新增 TestDriftPerEventEmitsStatusMatch**：對每個 non-FutureOnly spec，取該 event name 對應所有 fixture，跑 DeriveStatus，收集 emit status set（Valid=true && Status != ""），斷言 **emit set == spec.EmitsStatus set**（雙向相等）。抓「單一 event 過度宣告」漏網。
+
+**新增 TestDriftFixtureOnlyCoversNonFutureOnly**：駐點防呆 — `providerFixtures` 不應為 FutureOnly event 寫 fixture（避免測試假綠 / fixture 過期）。遍歷 fixtures，對每個 fixture `eventName`，若對應 spec `FutureOnly=true` → `t.Errorf`。這保證 FutureOnly event 不會在日後變回 non-FutureOnly 時，fixture 還在但其實驗的是 mock 資料。
+
+**既有 TestDriftFixtureCoversAllEvents**：改為只要求 **non-FutureOnly** event 都有 fixture；FutureOnly event 跳過此斷言。
+
+**既有 TestDriftFixtureCoverageNonEmpty**：不動。
+
+`providerFixtures` 內容：
+- cc 12 個 fixture 不動
+- codex **移除** 6 個 FutureOnly event 的 fixture（Notification 4 支 + PermissionRequest 1 + SubagentStart 1 + SubagentStop 1 + StopFailure 1 + SessionEnd 1 共 9 個？需逐項對照現有列表）
+- opencode 不動（當前無 FutureOnly event）
+
+**codex fixture 精準列表**：
+
+非 FutureOnly（保留）：
+- `SessionStart`, `UserPromptSubmit`, `Stop` — 3 fixture
+
+FutureOnly（移除）：
+- `Notification` 4 支 + `PermissionRequest` + `SubagentStart` + `SubagentStop` + `StopFailure` + `SessionEnd` — 共 9 fixture
+
+移除後 codex fixture 只剩 3 支；drift per-event 對 3 個 non-FutureOnly 強相等。
+
+### 1.8 opencode events.go 對 status 補齊
+
+Finding 沒直接要求，但既然 §1.5-1.6 做 plugin emit ↔ specs 對齊，必須檢查 opencode template 實際 emit 的 pdx event 是否全部在 `opencodeEventSpecs` 內。
+
+檢查現況（從 `plugin_template.go` renderManagedPlugin 靜態分析）：
+- template emit: `SessionStart`, `PermissionRequest`, `StopFailure`, `Stop`, `SessionEnd`, `UserPromptSubmit`, `SubagentStart`, `SubagentStop` — 共 8 個
+- `opencodeEventSpecs` Name 集合：`SessionStart`, `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `PermissionRequest`, `Stop`, `StopFailure`, `SessionEnd` — 共 8 個
+
+**相等**。§1.5 runtime 檢查生效時不會 panic。
+
+### 1.9 零改動邊界
+
+以下檔案 Fix **不得觸碰**：
+
+- `internal/agent/registry.go`, `status.go`, `coverage.go`, `hook_version.go`, `process_info*.go`
+- `internal/agent/cc/**` 除非為配合 `supported_statuses` 介面升級而被動調整（不預期）
+- `internal/agent/opencode/status.go`, `provider.go`, `readiness.go`（僅動 `hooks.go`, `plugin_template.go`, `events.go` 可能需改 FutureOnly=false 顯式標記 — 若預設值即 false 也可不改）
+- `internal/agent/codex/status.go`, `provider.go`, `readiness.go`（僅動 `hooks.go`, `events.go`）
+- `internal/agent/probe/**`
+- `internal/store/**`
+- `internal/module/**`
+- `spa/**`
+
+不新增 API endpoint、不改 registry、不引入 agent 版本探測。
+
+## 2. 測試案例清單
+
+按檔案組織：
+
+### 2.1 FutureOnly 欄位單元測試（provider-level）
+
+`internal/agent/supported_statuses_test.go` 既有 case 不變，新增：
+
+| # | 名稱 | 情境 | 斷言 |
+|---|---|---|---|
+| S1 | `TestDeriveSupportedStatuses_SkipsFutureOnly` | specs 含 1 個 FutureOnly + 2 個 non-FutureOnly | 回傳只含 non-FutureOnly 的 EmitsStatus union |
+| S2 | `TestDeriveSupportedStatuses_AllFutureOnly` | 全部 spec FutureOnly=true | 回傳空 slice（非 nil） |
+| S3 | `TestDeriveSupportedStatuses_FutureOnlyEmptyEmits` | FutureOnly=true + EmitsStatus=nil | 回傳空 slice（與 §1.2 語意一致，不 panic） |
+
+### 2.2 codex Events 與 CheckHooks FutureOnly 行為
+
+`internal/agent/codex/events_test.go` 新增：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| CE1 | `TestCodexEventsFutureOnlyFlags` | 3 個非 FutureOnly（SessionStart/UserPromptSubmit/Stop）+ 6 個 FutureOnly，一一 assert `spec.FutureOnly` |
+| CE2 | `TestCodexEventsDefensiveCopyPreservesFutureOnly` | 取兩次 `Events()`、mutate 第一次的 FutureOnly → 第二次不受影響 |
+
+`internal/agent/codex/hooks_test.go` 新增（用既有 writing temp hooks.json + pdx path 的 helper 模式）：
+
+| # | 名稱 | 情境 | 斷言 |
+|---|---|---|---|
+| CH1 | `TestCheckHooks_LegacyThreeEvent_ReportsInstalled` | hooks.json 僅 SessionStart/UserPromptSubmit/Stop 且 pdx command 正確 | `allInstalled=true`、`Issues` 不含 FutureOnly event missing、6 個 FutureOnly 的 `Events` map entry 為 `Installed=false` |
+| CH2 | `TestCheckHooks_NineEvent_FullyInstalled_NoIssues` | hooks.json 含完整 9 個 event 且 pdx command 正確 | `allInstalled=true`、`Issues=[]`、9 個 event map entry `Installed=true` |
+| CH3 | `TestCheckHooks_LegacyThreeEvent_MissingRequired_StillFailsForThat` | hooks.json 缺 SessionStart（只剩 2 個）+ 6 FutureOnly 缺 | `allInstalled=false`、`Issues` 含 SessionStart missing、FutureOnly missing 不入 Issues |
+| CH4 | `TestCheckHooks_PartialFutureOnly_DoesNotTaintOverall` | hooks.json 3 非 FutureOnly + 3 FutureOnly（其他 3 FutureOnly 缺） | `allInstalled=true`、`Issues=[]`、3 缺的 FutureOnly `Installed=false` |
+
+### 2.3 opencode template 與 CheckHooks 對齊
+
+`internal/agent/opencode/plugin_template_test.go` 新增：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| PT1 | `TestExtractEmittedEvents` | helper `extractEmittedEvents` 從 template body 正確抽出 8 個 event name（順序可變） |
+| PT2 | `TestRenderManagedPlugin_OnlyEmitsDeclaredEvents` | `renderManagedPlugin("/p")` 回傳 body 的 emit set ⊆ `opencodeEventSpecs.Name` 且強相等 |
+| PT3 | `TestRenderManagedPlugin_PanicsOnMismatch` | 臨時注入 mock `opencodeEventSpecs` 缺一 event（例移除 `Stop`）→ render 時 panic（契約違反） |
+
+PT3 若用 init-time 注入困難（const-like slice），改用 `validateSpecsCoverEmitted(body, specs) error` 直接跑 negative case 測試即可，不需改 render 流程。
+
+`internal/agent/opencode/hooks_test.go` 新增：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| OH1 | `TestCheckHooks_ValidPlugin_PerEventInstalled` | 用 `writeManagedPlugin` 寫合法 template → CheckHooks 每個 event `Installed=true`、Issues=[] |
+| OH2 | `TestCheckHooks_HandEditedPlugin_EventMissing` | 寫一份含 marker 但移除某 `emit('Stop', ...)` 的 body → CheckHooks 該 event `Installed=false` 且 Issues 含 `Stop emit missing` |
+| OH3 | `TestCheckHooks_UnmanagedPlugin_ReturnsUnmanaged` | 既有行為保留：不帶 marker → Installed=false + Issues |
+
+### 2.4 drift test 升級
+
+`internal/agent/drift_test.go` 改動：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| D3（修改） | `TestDriftThreeWayEquality` | declaredSet/supportedSet 遍歷跳過 FutureOnly；emit 行為不變；三向相等對 non-FutureOnly |
+| D4（修改） | `TestDriftFixtureCoversAllEvents` | 只要求 non-FutureOnly event 有 fixture；FutureOnly skip |
+| D5（新增） | `TestDriftPerEventEmitsStatusMatch` | 對每個 non-FutureOnly spec，fixture emit set == spec.EmitsStatus（雙向強相等） |
+| D6（新增） | `TestDriftFixturesDoNotCoverFutureOnly` | 反向防呆：fixture 中若出現 FutureOnly event 名 → t.Errorf |
+
+### 2.5 cc/opencode SupportedStatuses 不變（回歸保險）
+
+既有 `cc/provider_test.go` `TestCCSupportedStatuses` 應仍回傳 5 個 Status — 補斷言確認新增 FutureOnly 不影響 cc（全為 false）。若既有測試已明列 5 個 status → 無須改。
+
+`opencode/provider_test.go` `TestOpenCodeSupportedStatuses` 同理，5 status 不變。
+
+`codex/provider_test.go` `TestCodexSupportedStatuses` 需改：**從 5 status 改為 2 status**（Idle + Running），因 6 個 FutureOnly event 的 Waiting/Error/Clear 被濾掉。這是 FutureOnly 的直接後果。commit 順序需要先 landing FutureOnly 欄位與 codex 標記才跑這個斷言更新。
+
+## 3. TDD 執行順序
+
+嚴格紅綠，每個 step 一個 commit；commit message 用 Conventional Commits + `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`。
+
+### Commit 1 — `feat(agent): add FutureOnly bit to HookEventSpec`
+- 紅：寫 S1/S2/S3 → 失敗（DeriveSupportedStatuses 未濾）
+- 綠：加欄位 + 改 `DeriveSupportedStatuses` skip FutureOnly
+- 跑 `go test ./internal/agent/...` 綠
+
+### Commit 2 — `feat(agent/codex): mark 6 future-only events`
+- 紅：寫 CE1 → 失敗（6 個 event 尚未標 FutureOnly）
+- 綠：在 `codexEventSpecs` 6 個 event 上加 `FutureOnly: true`
+- 同步：`codex/provider_test.go` `TestCodexSupportedStatuses` 從 5 status 改為 2 status（斷言 supported == {Idle, Running}）
+- 跑 `go test ./internal/agent/codex/...` 綠
+
+**備註**：寫 CE2 放在同 commit 測 defensive copy 保留 FutureOnly bit。
+
+### Commit 3 — `feat(agent/codex): skip FutureOnly missing in CheckHooks`
+- 紅：寫 CH1/CH2/CH3/CH4 → 失敗（CheckHooks 仍嚴格判所有 event missing）
+- 綠：CheckHooks 內部先取 specs（含 FutureOnly bit），對 FutureOnly missing 不 issue + 不計 allInstalled
+- 跑 `go test ./internal/agent/codex/...` 綠
+
+### Commit 4 — `test(agent): upgrade drift test to per-event + FutureOnly skip`
+- 紅：寫 D5（per-event 強相等）+ D6（FutureOnly skip）→ 失敗（D6 若舊 fixture 還含 codex FutureOnly event fixture）
+- 修：`providerFixtures` 移除 codex 6 個 FutureOnly event fixture；`TestDriftThreeWayEquality` 的 declaredSet/supportedSet 迴圈跳過 FutureOnly；`TestDriftFixtureCoversAllEvents` 只要求 non-FutureOnly 有 fixture
+- 綠：三個測試 + D5/D6 都過
+- 跑 `go test ./internal/agent/...` 綠
+
+### Commit 5 — `refactor(agent/opencode): extract emitted events from template`
+- 紅：寫 PT1 → 失敗（extractEmittedEvents 不存在）
+- 綠：在 `plugin_template.go` 加 `extractEmittedEvents(body string) []string` helper（正規 `emit\(['"](\w+)['"]`）
+- 跑 `go test ./internal/agent/opencode/...` 綠
+
+### Commit 6 — `feat(agent/opencode): validate template emits declared events`
+- 紅：寫 PT2 + PT3（驗證 helper + negative case）→ 失敗
+- 綠：加 `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error`；`renderManagedPlugin` 最後呼叫 validate，若 error → panic with 契約違反訊息
+- 跑 `go test ./internal/agent/opencode/...` 綠
+
+### Commit 7 — `feat(agent/opencode): CheckHooks verifies per-event emit`
+- 紅：寫 OH1/OH2/OH3 → 失敗（CheckHooks 仍假綠回填）
+- 綠：CheckHooks 讀檔後呼叫 `extractEmittedEvents`，對每個 spec 檢查其 Name 是否在 emit set；missing 標 Installed=false + push issue
+- 跑 `go test ./internal/agent/opencode/...` 綠
+
+### Commit 8 — `docs: hook events fix plan retrospective（可選）`
+若 §3 順序與實際有偏差，補歷史註記。
+
+**Commit 順序原理**：
+- Commit 1 建欄位 + 介面；所有後續 commit 依賴這個
+- Commit 2-3 完成 codex 側（事件標記 + CheckHooks 行為）
+- Commit 4 升級 drift test 保護這些新行為
+- Commit 5-7 完成 opencode 側（extraction helper → validate → CheckHooks per-event）
+- 每個 commit 完成後 `go build ./... && go test ./... && go vet ./...` 全綠
+
+## 4. 實作檔案預估
+
+| 檔案 | 動作 | 預估行數 |
+|---|---|---|
+| `internal/agent/provider.go` | +`FutureOnly bool` 欄位 + 註解 | +8 |
+| `internal/agent/supported_statuses.go` | skip FutureOnly | +3 |
+| `internal/agent/supported_statuses_test.go` | +S1/S2/S3 | +40 |
+| `internal/agent/codex/events.go` | 6 event 加 `FutureOnly: true` | +6 |
+| `internal/agent/codex/events_test.go` | +CE1/CE2 | +40 |
+| `internal/agent/codex/hooks.go` | CheckHooks FutureOnly 分支 | +15 |
+| `internal/agent/codex/hooks_test.go` | +CH1/CH2/CH3/CH4 | +90 |
+| `internal/agent/codex/provider_test.go` | 改 supported 斷言（5→2） | ~5 |
+| `internal/agent/opencode/plugin_template.go` | +`extractEmittedEvents` + `validateSpecsCoverEmitted` + render panic | +35 |
+| `internal/agent/opencode/plugin_template_test.go` | +PT1/PT2/PT3 | +60 |
+| `internal/agent/opencode/hooks.go` | CheckHooks per-event emit check | +20 |
+| `internal/agent/opencode/hooks_test.go` | +OH1/OH2/OH3 | +70 |
+| `internal/agent/drift_test.go` | +D5/D6 + D3/D4 FutureOnly skip + fixture 精修 | +60 |
+| `docs/specs/2026-04-23-hook-events-fix-plan.md` | 本檔 | +300 |
+| **合計** | | **~760 行**（含 plan 文件） |
+
+## 5. 不做項目清單（防自動擴展）
+
+以下衝動一律拒絕 — subagent 不得擴張：
+
+- **不探測 codex CLI 實際版本** — FutureOnly 是 build-time 靜態標記，非 runtime gate
+- **不引入 `/api/hooks/codex/capability` endpoint** — 宣告與檢測分離，Inspector 另行處理
+- **不重寫 opencode template 為完全 codegen** — 策略 A（保留固定 switch/case + 運行時檢查）即可
+- **不把 cc 任何 event 標為 FutureOnly** — cc 驗證過全部 9 個會 emit
+- **不改 `SpecStringSlice` 或其他宣告 helper**（若存在）— 不在本 PR scope
+- **不調整 `Coverage()` 簽名或回傳欄位** — Phase 0 契約不動
+- **不重命名任何既有測試** — 只加新 case 或微調（例 codex supported 斷言 status 列表）
+- **不改 SPA 任何檔案** — 本 PR 全 Go 側
+- **不 force push / rebase** — 分支已 push 11 commits + PR，保留全歷史
+- **不合併 fix commits** — 分 7 commits 便於 reviewer 逐步追蹤
+- **不順手修其他 finding** — 四路 review 只有這 4 個 finding，不額外添加
+
+## 6. Subagent 開發指引
+
+- **cwd 強制前綴**：每個 Bash 指令以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-spec-guardrails && ` 開頭（依 `feedback_subagent_cwd_enforcement.md`）
+- **分支**：已在 `worktree-lights-spec-guardrails`，不另切；**不 push**（主 session 負責）
+- **Commit message 格式**：Conventional Commits + 結尾 `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+- **TDD 嚴格紅綠**：每 commit 內先寫測試跑紅再實作跑綠，不可批次寫完所有 test + 一次實作
+- **每 commit 完成後**：跑 `go build ./... && go test ./... && go vet ./...` 全綠才進下一個
+- **回報**：完成時給 commit hash 列表 + `git log --oneline -15` + 最終 `go test ./...` 完整輸出
+- **Codex sandbox 限制**：不需跑 SPA（本 PR 全 Go 側）— 但仍保留 `feedback_codex_sandbox_no_install.md` 準則以防 subagent 誤觸 spa
+
+## 7. 驗收清單
+
+- [ ] 7 個 commits 符合上述 message 規範（Commit 8 可選）
+- [ ] `go build ./...` 綠
+- [ ] `go test ./...` 全綠（包含新增 S1-S3、CE1-CE2、CH1-CH4、PT1-PT3、OH1-OH3、D5-D6 共 16 個測試 case）
+- [ ] `go vet ./...` 無 warning
+- [ ] PR diff 只涉及 §4 表格列出的 13 個檔 + plan 文件，**其餘不得出現**
+- [ ] codex `SupportedStatuses()` 回傳 `[Idle, Running]`（2 個，非 5 個）
+- [ ] opencode `CheckHooks()` 對「手動改過、少一個 emit」的 plugin 正確標 `Installed=false` + issue
+- [ ] codex `CheckHooks()` 對「只安裝舊 3 event 的 legacy hooks.json」回 `allInstalled=true` 且 Issues 不含 FutureOnly event missing
+- [ ] drift test 對「若把 codex `Stop` 的 `EmitsStatus` 改為 `[Idle, Clear]`」應紅（per-event 強相等觸發）
+
+## 8. 風險與緩解
+
+| 風險 | 機率 | 影響 | 緩解 |
+|---|---|---|---|
+| FutureOnly 語意誤解為「CLI 永不支援」 | 中 | 未來翻 false 時遺漏檢查 | 在 `HookEventSpec` struct 註解與 plan §1.1 顯式說明「build-time 信心不足」；留 TODO 於 codex events.go 指向未來 enable 路徑 |
+| `extractEmittedEvents` regex 遇到 JS 註解內 `emit('XXX')` 誤判 | 低 | CheckHooks 假陽性 | regex 加 word boundary；template 內不寫註解帶 emit 字串；PT1 測試覆蓋一個 edge case（如 body 含 `// emit('Foo')` 註解，確認不被抽出） |
+| opencode CheckHooks 因檔案 IO error 在 race 下假綠 | 低 | 罕見 race 掩蓋 | 維持既有 `os.ReadFile` 錯誤處理，不動；此 PR 不引入新 race |
+| codex provider_test supported 斷言從 5→2 可能讓 reviewer 誤以為退步 | 中 | review 釋疑成本 | PR description 顯式說明：「2 是當前 CLI 真實可 emit 集合；FutureOnly 6 event 翻 false 後自然恢復 5」 |
+| drift fixture 移除 codex 6 個 FutureOnly fixture 後，日後翻 false 時 fixture 需補回 | 低 | 後續 phase 會遇 | commit 4 在 drift_test.go 頂端留註解：「FutureOnly event fixture 未列出；翻 false 時補回 §1.1 曾列出的對應 DeriveStatus case」 |
+| 某 finding 在實作中發現新子問題 | 中 | scope 膨脹 | 遵 §5 不做項目；發現新問題開 gh issue 延後，不納入本 PR |
+
+## 9. 第 3 輪 Codex Review 預期 focus
+
+**Focus text 骨架**（實際派發時可微調，確保 codex 能讀到「本輪修哪些」）：
+
+- 本輪修復 PR #616 第 2 輪 3 路 review 的 4 findings：
+  1. codex CheckHooks 對 3-event legacy 使用者誤判（透過 FutureOnly 自然處理）
+  2. opencode renderManagedPlugin 與 CheckHooks 的假綠燈（透過 extractEmittedEvents + validate）
+  3. codex future-only events 混入 current capability（透過 FutureOnly 欄位 + SupportedStatuses skip）
+  4. drift test per-event 盲點（透過 TestDriftPerEventEmitsStatusMatch + FutureOnly skip）
+- 請驗收：
+  - 攻擊：FutureOnly 翻譯正確（邊界 / race / 誤用）；extractEmittedEvents regex 假陽性
+  - 防守：SSoT 收斂是否真成立（opencode template + specs + CheckHooks 三向一致）；codex FutureOnly 語意是否對外清楚
+  - 體質：fix plan 拆的 7 commits 是否職責清晰；drift_test 新增 D5/D6 是否過大（>250 行考慮拆）；hooks.go 是否應該把 FutureOnly check 抽 helper
+
+**第 3 輪仍需 4 路**（標準 + 攻擊 + 防守 + 體質），不縮減 — 修復後再驗 SSoT 主張確實落地。

--- a/docs/specs/2026-04-23-hook-events-fix-plan.md
+++ b/docs/specs/2026-04-23-hook-events-fix-plan.md
@@ -1,7 +1,7 @@
 # Hook Events PR #616 Fix Plan
 
 - **Date**: 2026-04-23
-- **Version**: v3（依 plan codex review `review-mobsgj0y-rgwbdv`(v1 判) + `review-mobsrf0q-47acc5`(v2 判) 共 7 點 finding 全採納重寫）
+- **Version**: v4（v1 review 4 + v2 review 3 + v3 review 2 — 共 9 個 findings 全採納；v3 review `review-mobt3cru-xq3lyg` 確認前 7 個已覆蓋，新增 2 個 runtime 安全 finding）
 - **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §2.4（架構護欄）
 - **Parent plan**: `docs/specs/2026-04-23-hook-events-declaration-plan.md`（既有，11 commits merged 進本分支）
 - **Worktree**: `lights-spec-guardrails`（branch `worktree-lights-spec-guardrails`，PR #616）
@@ -30,6 +30,15 @@
 | Commit 2 只在 `codexEventSpecs` 標 FutureOnly，宣稱無消費者讀取 → 綠 | Commit 2 同時更新三家 `Events()` defensive copy 帶上 `FutureOnly: spec.FutureOnly`；否則 CE1/CE2 在 commit 2 紅 | 既有 `Events()` 是手寫 field-by-field copy，不會自動帶新欄位 |
 
 核心哲學修正：**opencode plugin 是 atomic managed file，非 per-event 配置**。byte-exact 比對符合 plugin 實際語意，且消除整類 false-green 路徑。
+
+### v3 → v4（codex review `review-mobt3cru-xq3lyg` 2 findings 採納；前 7 findings 已確認覆蓋）
+
+| v3 設計 | v4 更正 | 依據 |
+|---|---|---|
+| `renderManagedPlugin` 在 template/specs 不一致時 panic | **移除 runtime panic**；template/specs parity 改為 **test-only** 斷言（`TestTemplateSpecsParity`） | `renderManagedPlugin` 被 `writeManagedPlugin`（Install 路徑）與 `CheckHooks`（byte-compare）同時呼叫；runtime panic 會把 build-time 契約錯誤升級成可見程序終止 |
+| `extractPdxPath` 直接把 regex 擷取結果重用 | 抓完整 `"..."` quoted literal → `strconv.Unquote(quoted)` 還原後才 pass 給 `renderManagedPlugin` | `renderManagedPlugin` 用 `%q` 寫 pdxPath；regex 抓到的是已 escape 的 JS 源碼；直接 round-trip 含反斜線路徑會二次 escape 假紅 |
+
+核心哲學修正：**契約 drift 是 build-time 問題，test 層面防禦已足；runtime 不做永不恢復的 panic**。
 
 ## 1. 契約鎖定
 
@@ -128,21 +137,22 @@ codex `SupportedStatuses()` **維持 5 status**（Idle/Running/Waiting/Error/Cle
 
 **部分損壞**：若有 FutureOnly key 被手動改壞 → `Issues` 顯化 warning + allInstalled=false（避免假綠燈）。
 
-### 1.5 opencode renderManagedPlugin — 契約即 SSoT（render-time validation 擋漂移）
+### 1.5 opencode renderManagedPlugin — 契約即 SSoT（test-only parity check）
 
 Finding #2（PR #616 第 2 輪防守 HIGH + 體質 MED）核心：不讓 template 與 `opencodeEventSpecs` 成為兩份平行 SSoT。
 
-策略：template 保留固定 switch/case 結構；**render 時以 `validateSpecsCoverEmitted` 強制檢查** template emit set == `opencodeEventSpecs.Name` set。build-time 契約檢查；runtime 不經這條路徑。
+策略（v4 收斂）：template 保留固定 switch/case 結構；**契約檢查只在 test 層面執行**；`renderManagedPlugin` **不做任何 runtime validation、不 panic**，純粹 render 字串後返回。
 
 具體：
 
-- `renderManagedPlugin(pdxPath string) string` 維持原簽名；函式尾部呼叫 `validateSpecsCoverEmitted(body, opencodeEventSpecs)` — template 字串 emit 的 event name 與 specs 不等 → `panic("contract violation: template emits: <A,B>; specs declare: <C,D>")` 
-- `extractEmittedEvents(body string) []string` — regex `emit\(['"](\w+)['"]` 從 body 抽出 emit 的 event names（**只用於 render-time contract check，不用於 CheckHooks 健康判定**）
-- `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error` — 強等：`set(extractEmittedEvents(body)) == set(specs.Name)`；任何一側 superset 都回 error
+- `renderManagedPlugin(pdxPath string) string` — 維持原簽名、原行為；**不呼叫 validate、不 panic**
+- `extractEmittedEvents(body string) []string` — regex `emit\(['"](\w+)['"]` 從 body 抽出 emit 的 event names。**只由測試使用**
+- `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error` — 強等：`set(extractEmittedEvents(body)) == set(specs.Name)`；任何一側 superset 都回 error。**只由測試使用**
+- **測試層強制 parity**：在 `plugin_template_test.go` 增加 `TestTemplateSpecsParity`，對 `renderManagedPlugin("/fake")` 的結果跑 `validateSpecsCoverEmitted`，不等則 test fail
 
-**為什麼 render panic 而非 error**：render 函式原簽名回 string，加 error 改呼叫點。panic 只在 build 測試階段觸發（因為 template 是 const-like），release path 不爆。
+**為什麼移除 runtime panic**（v4 決定）：`renderManagedPlugin` 被 `writeManagedPlugin`（Install 路徑）和 `CheckHooks`（byte-compare 重新 render）呼叫；runtime panic 會把 build-time 契約錯誤升級成可見程序終止。test-only 防線已足以擋下 drift — 測試通過表示 specs 與 template 對齊，合併後不可能出現 mismatched 版本。
 
-**`extractEmittedEvents` 的角色限制（v3 收斂）**：**僅用於 build-time 契約驗證**。任何 runtime 健康檢查（CheckHooks）都不讀此 regex — 改用 §1.6 的 byte-exact 比對。regex 對註解、字串常量、dead code、人為改壞的 JS 無法區分「可執行 emit」與「看起來像 emit 的文字」。
+**`extractEmittedEvents` 角色**：**僅供測試使用**。runtime 健康檢查（CheckHooks）走 §1.6 的 byte-exact 比對。regex 對 JS 靜態分析不可靠，本就不適合 runtime。
 
 **配合測試**（§2.3 PT1-PT5）驗證。
 
@@ -161,7 +171,22 @@ Finding #2（PR #616 第 2 輪防守 HIGH + 體質 MED）核心：不讓 templat
    - 不等 → `Installed=false`；issue 含 `plugin body differs from managed template (run reinstall)`；**所有 event `Installed=false`**（因為整份 plugin 視為不可信）
 6. 若 marker 不存在 → 既有 unmanaged 行為保留
 
-**新 helper**：`extractPdxPath(body string) (string, bool)` — 從受管 body 抽 pdxPath。regex `const pdxPath = "([^"]+)"`（單一行，單一出現位置）。若抽不到 → 當成 byte-mismatch。
+**新 helper**：`extractPdxPath(body string) (string, bool)` — 從受管 body 抽 pdxPath。
+
+**關鍵**：template 以 `%q` 寫 pdxPath，反斜線、引號、非 ASCII 都已被 Go 字串 escape。regex 必須抓**完整 quoted literal**（含前後雙引號），再用 `strconv.Unquote` 還原成原始路徑：
+
+1. regex `const pdxPath = (\"(?:[^\"\\\\]|\\\\.)*\")` — 捕獲含跳脫處理的完整 `"..."` 字串（包含外層雙引號），支援 `\\` `\"` `\n` 等 escape sequence
+2. 對捕獲結果呼叫 `strconv.Unquote(quoted)` — Go string quoting 規則與 `%q` 對稱，含 `\`、`\"`、Unicode escape 都能還原
+3. `Unquote` 失敗（格式錯誤或找不到匹配）→ 回 `("", false)` → CheckHooks 視為 byte-mismatch
+
+**為什麼不能直接用 regex `"([^"]+)"` 抓內容**：該 regex 會在遇到 `\"` 時提早結束，抽到殘缺字串；再 render 會二次 escape 假紅。
+
+**測試覆蓋**（PT6 擴充）：round-trip 必須對以下路徑全綠：
+- 空白：`/path with spaces/pdx`
+- 反斜線（Windows-style）：`C:\Users\foo\pdx.exe`
+- 雙引號（罕見但合法）：`/weird"path/pdx`
+- 非 ASCII：`/使用者/pdx`
+- 控制字元不測試（install 路徑不會產生）
 
 **為什麼不 per-event**：opencode plugin 是單檔 JavaScript，switch/case 結構內任何改動都可能影響其他 event（例 shared state `activeSubagents`、`suppressIdleForSession`）。將 plugin 視為「有 marker + byte-equal」二元狀態符合其語意：要嘛 pdx 受管、要嘛使用者自行負責。
 
@@ -258,8 +283,9 @@ F2 是防呆測試，鎖定「DeriveSupportedStatuses 不因 FutureOnly 過濾�
 | PT2 | `TestValidateSpecsCoverEmitted_Equal` | `validateSpecsCoverEmitted(body, opencodeEventSpecs)` 對真 template body 回 nil |
 | PT3 | `TestValidateSpecsCoverEmitted_EmitNotInSpec` | synthetic body 含 `emit('Fake')` + specs 無 Fake → error |
 | PT4 | `TestValidateSpecsCoverEmitted_SpecNotInEmit` | synthetic body 缺某 event + specs 含它 → error |
-| PT5 | `TestRenderManagedPlugin_ProducesValidBody` | `renderManagedPlugin("/p")` 不 panic；結果 body 含 marker + 對齊 specs |
-| PT6 | `TestExtractPdxPath_RoundtripFromRender` | `renderManagedPlugin(p)` 後 `extractPdxPath(body)` 回 `p`（byte-exact 比對基石） |
+| PT5 | `TestRenderManagedPlugin_ProducesValidBody` | `renderManagedPlugin("/p")` 不 panic；結果 body 含 marker |
+| PT6 | `TestExtractPdxPath_RoundtripEscapedLiterals` | 對下列 pdxPath 驗證 `render → extract → equals input`：`/path with spaces/pdx`、`C:\Users\foo\pdx.exe`、`/weird"path/pdx`、`/使用者/pdx` |
+| PT7 | `TestTemplateSpecsParity` | 對 `renderManagedPlugin("/fake")` 呼叫 `validateSpecsCoverEmitted(body, opencodeEventSpecs)` → nil（build-time contract guard）|
 
 ### 2.4 opencode hooks CheckHooks — byte-exact template 比對
 
@@ -331,14 +357,17 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 ### Commit 5 — `refactor(agent/opencode): extract emitted events + pdx path helpers`
 - 紅：寫 PT1 + PT6 → 失敗（helpers 不存在）
 - 綠：`plugin_template.go` 加
-  - `extractEmittedEvents(body string) []string`（regex `emit\(['"](\w+)['"]`）
-  - `extractPdxPath(body string) (string, bool)`（regex `const pdxPath = "([^"]+)"`）
+  - `extractEmittedEvents(body string) []string`（regex `emit\(['"](\w+)['"]`）— **僅供測試**
+  - `extractPdxPath(body string) (string, bool)` — regex 抓完整 quoted literal `const pdxPath = (\"(?:[^\"\\\\]|\\\\.)*\")`，用 `strconv.Unquote` 還原（§1.6 細節）
+- PT6 必須覆蓋 space / backslash / quote / 非 ASCII 四種 escape round-trip
 - 跑 `go test ./internal/agent/opencode/...` 綠
 
-### Commit 6 — `feat(agent/opencode): render-time contract validation`
-- 紅：寫 PT2 + PT3 + PT4 + PT5 → 失敗
-- 綠：加 `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error`；`renderManagedPlugin` 結尾呼叫 validate，mismatch panic
-- PT5 確認常態 template 不 panic
+### Commit 6 — `test(agent/opencode): template ↔ specs parity (test-only)`
+- 紅：寫 PT2 + PT3 + PT4 + PT5 + PT7 → 失敗
+- 綠：
+  1. 加 `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error`（package-internal，**僅供測試使用**）
+  2. **`renderManagedPlugin` 不動**（不呼叫 validate、不 panic）
+  3. PT7 在 test 層跑 parity check — 即 build-time guard（若 template/specs 漂移 → 測試紅，阻止 merge）
 - 跑 `go test ./internal/agent/opencode/...` 綠
 
 ### Commit 7 — `feat(agent/opencode): byte-exact CheckHooks against managed template`
@@ -375,8 +404,8 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 | `internal/agent/codex/hooks.go` | CheckHooks 三態決策 + `checkCodexEvent` helper | +40 |
 | `internal/agent/codex/hooks_test.go` | +CH1-CH6 | +140 |
 | `internal/agent/opencode/events.go` | Events() defensive copy 加 `FutureOnly: spec.FutureOnly` | +1 |
-| `internal/agent/opencode/plugin_template.go` | +`extractEmittedEvents` + `extractPdxPath` + `validateSpecsCoverEmitted` + render panic | +45 |
-| `internal/agent/opencode/plugin_template_test.go` | +PT1-PT6 | +95 |
+| `internal/agent/opencode/plugin_template.go` | +`extractEmittedEvents` + `extractPdxPath` (含 Unquote) + `validateSpecsCoverEmitted`（**無 runtime panic**） | +50 |
+| `internal/agent/opencode/plugin_template_test.go` | +PT1-PT7（PT6 escape round-trip / PT7 parity） | +120 |
 | `internal/agent/opencode/hooks.go` | CheckHooks byte-exact template 比對 | +30 |
 | `internal/agent/opencode/hooks_test.go` | +OH1-OH5 | +100 |
 | `internal/agent/drift_test.go` | +D5（無 fixture 刪除、無 FutureOnly skip） | +45 |
@@ -393,7 +422,9 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 - **不改 codex `provider_test.go` SupportedStatuses 斷言**（仍 5 status）
 - **不探測 codex CLI 版本** — FutureOnly 是 build-time 靜態標記
 - **不引入 `/api/hooks/codex/capability` endpoint**
-- **不重寫 opencode template 為完全 codegen**（v3 確認：template 保固定結構 + render-time validate）
+- **不重寫 opencode template 為完全 codegen**（v3 確認：template 保固定結構 + **test-only** parity validate，v4 移除 runtime panic）
+- **renderManagedPlugin 不做 runtime validation / panic**（v4：contract drift 由測試層防禦，runtime 純 render）
+- **不用 naive regex `"([^"]+)"` 抓 pdxPath**（v4：必抓完整 quoted literal + strconv.Unquote）
 - **不對 opencode CheckHooks 做 per-event extraction**（v3 決定：byte-exact template 比對）
 - **不接受 codex absent 定義包含空陣列**（v3 嚴格限：`_, ok := hooks[key]; ok == false` 才是 absent）
 - **不把 cc 任何 event 標為 FutureOnly**
@@ -419,7 +450,7 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 
 - [ ] 7 個 commits 符合上述 message 規範
 - [ ] `go build ./...` 綠
-- [ ] `go test ./...` 全綠（含 F1-F2 / CE1-CE2 / CH1-CH6 / D5 / PT1-PT6 / OH1-OH5 共 22 個新測試）
+- [ ] `go test ./...` 全綠（含 F1-F2 / CE1-CE2 / CH1-CH6 / D5 / PT1-PT7 / OH1-OH5 共 23 個新測試）
 - [ ] `go vet ./...` 無 warning
 - [ ] PR diff 僅涉及 §4 表格列出的 14 個檔 + plan 文件，**其餘不得出現**
 - [ ] codex `SupportedStatuses()` 仍回傳 5 個 Status（不動）
@@ -428,7 +459,8 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 - [ ] codex `CheckHooks()` 對「FutureOnly key 存在但 command 錯誤」回 `allInstalled=false` + warning issue
 - [ ] codex `CheckHooks()` 對「FutureOnly key 存在 entries 為 []」歸 broken 而非 absent（**v3 新驗收點**）
 - [ ] opencode `CheckHooks()` 對**任何**手改過的 plugin（包含註解變動）回 `Installed=false` + `plugin body differs` issue（byte-exact）
-- [ ] opencode `renderManagedPlugin` 對人為構造的不合法 specs/body 會 panic（僅在 mock 下 — 真 runtime 不 panic）
+- [ ] opencode `renderManagedPlugin` **不 panic**（任何路徑）；template/specs parity 由 `TestTemplateSpecsParity` test-only guard
+- [ ] opencode `extractPdxPath` 對含 space/backslash/quote/非 ASCII 的路徑能 round-trip（PT6）
 - [ ] drift per-event 斷言（D5）對每個 provider/spec 覆蓋正確
 
 ## 8. 風險與緩解
@@ -440,7 +472,8 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 | `extractEmittedEvents` regex 對 CheckHooks 的假綠風險 | **已消除** | n/a | v3 決定：`extractEmittedEvents` 只用於 render-time contract check；CheckHooks 走 byte-exact |
 | opencode byte-exact 太嚴格：使用者若自行 patch plugin 會立刻回 unmanaged | 中 | UX | 這是預期行為 — plugin 是 pdx 受管原子檔。若有合法 customization 需求，未來另開 `unmanaged` 模式 |
 | `extractPdxPath` regex 遇到 odd-formed pdxPath 抽不到 | 低 | CheckHooks fallback unmanaged | OH5 覆蓋此 case；fallback 回 unmanaged 而非 panic |
-| opencode render panic 在 production 路徑誤觸 | 低 | Install 失敗 | template 是 const-like 字串；panic 只在 specs/template 不同步時發生；PT5 常態 smoke test |
+| opencode render panic 在 production 路徑誤觸 | **已消除** | n/a | v4：renderManagedPlugin 不 panic；contract drift 由 TestTemplateSpecsParity test-only guard |
+| `extractPdxPath` 對特殊字元路徑 round-trip 失敗 | **已消除** | n/a | v4：strconv.Unquote 處理完整 quoted literal；PT6 覆蓋 4 種 escape case |
 | drift fixtures 保留後，若 FutureOnly event 在 DeriveStatus 邏輯日後被刪除但 fixture 沒刪 | 低 | 測試失敗警告到位 | D5 per-event 強相等會紅，指向確切 spec/event；是有益的警告 |
 | commit 4 D5 對既有 spec/fixture 跑起來紅（有過度宣告） | 中 | 需額外修 spec 或 fixture | 先跑一次 D5 preview；若紅先修 spec 再加 D5 斷言 |
 | 三家 `Events()` defensive copy 改動 commit 1 執行時漏改某家 | 中 | commit 2 紅（CE1/CE2） | Commit 1 明列 3 個檔案 + 紅綠 TDD 會立即暴露 |

--- a/docs/specs/2026-04-23-hook-events-fix-plan.md
+++ b/docs/specs/2026-04-23-hook-events-fix-plan.md
@@ -1,11 +1,25 @@
 # Hook Events PR #616 Fix Plan
 
 - **Date**: 2026-04-23
+- **Version**: v2（依 plan codex review `review-mobsgj0y-rgwbdv` 四點 finding 全採納重寫）
 - **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §2.4（架構護欄）
 - **Parent plan**: `docs/specs/2026-04-23-hook-events-declaration-plan.md`（既有，11 commits merged 進本分支）
 - **Worktree**: `lights-spec-guardrails`（branch `worktree-lights-spec-guardrails`，PR #616）
 - **依賴**: Phase 1 merged at alpha.215（§5 L2 對齊完成）；Events() SSoT 已在本分支建立
 - **範圍**: 修四路 codex review 攻擊/防守/體質視角提出的 4 個 findings（2 HIGH + 2 MED），讓 Events() SSoT 主張在 codex 與 opencode 端真正成立，且不因升級誤判既有安裝
+
+## 0. v1 → v2 重寫重點
+
+Plan v1 被 codex review `review-mobsgj0y-rgwbdv` 判 needs-attention（2 HIGH + 2 MED finding）。v2 全數採納：
+
+| v1 設計 | v2 更正 | 依據 |
+|---|---|---|
+| `FutureOnly` 過濾 `SupportedStatuses()`（codex 5→2 status） | `SupportedStatuses()` 完全不碰 FutureOnly，保留為 parser capability 宣告（codex 仍 5 status） | `StatusSupporter` 介面註解明定「獨立於 installer 當前覆蓋」；過濾會打破 proxy/未來 CLI 路徑的假陰性 |
+| CheckHooks 對 FutureOnly missing 一律靜默 | 區分三態：absent（tolerated）/ present-but-broken（warning + blocks allInstalled）/ valid（pass） | 防止「已配置但損壞」被混成「未安裝但可接受」 |
+| drift fixtures 移除 codex 6 個 FutureOnly event 的 9 筆資料 | **保留全部 fixtures**；parser contract 仍持續測；另拆 capability 面向 | DeriveStatus 解析能力不應因 installer 面向而失去回歸保護 |
+| Commit 順序: SupportedStatuses 收斂（2）→ drift 升級（4），中間 commit 紅 | drift 測試升級放在 SupportedStatuses 語意切換之前；**每 commit 真正全綠** | 自相矛盾：原 plan 同時要求每 commit 全綠 + 中間依賴後續 commit 補洞 |
+
+核心哲學修正：**`FutureOnly` 只影響 installer/checker 面向，不影響 DeriveStatus 能力宣告面向**。兩個面向獨立。
 
 ## 1. 契約鎖定
 
@@ -13,199 +27,197 @@
 
 ### 1.1 HookEventSpec 新增 FutureOnly 欄位
 
-`internal/agent/provider.go` `HookEventSpec` 結構加一個 `FutureOnly bool`：
+`internal/agent/provider.go` `HookEventSpec` 結構加 `FutureOnly bool`：
 
 ```
 type HookEventSpec struct {
     Name        string
     EmitsStatus []Status
     Description string
-    FutureOnly  bool // 此 event 已在 spec 中宣告，但當前 CLI 版本未必會 emit
+    FutureOnly  bool // Installer/checker 面向標記；不影響 DeriveStatus 能力宣告
 }
 ```
 
-**語意**：
+**語意（v2 收斂版）**：
 
-- `FutureOnly=false`（預設）— 當前 CLI 會 emit 此 event；installer 安裝、CheckHooks 嚴格檢查 missing、drift test 要求 fixture 覆蓋、SupportedStatuses derive 會納入 EmitsStatus
-- `FutureOnly=true` — installer 仍安裝（為 CLI 升級鋪路），但 runtime 未必收得到；CheckHooks 對此 event missing **不標 issue、不計入 allInstalled**；drift test **不要求** fixture；SupportedStatuses derive 時**跳過**其 EmitsStatus
+- **FutureOnly 只影響 installer / checker 面向**：CheckHooks 對缺省 key 的寬鬆判定、installer 後續可能的「若 CLI 版本不支援則略過」策略（本 PR 不實作動態 gate）
+- **不影響 DeriveStatus 能力宣告**：`SupportedStatuses()` / `DeriveSupportedStatuses` 不讀此欄位，codex 仍宣告 5 個 status（Idle/Running/Waiting/Error/Clear）
+- **不影響 drift 測試的 parser 契約**：fixture 保留完整，`DeriveStatus` 所有解析路徑持續測
+- **預設 false**：`FutureOnly=false` 表示 installer 把此 event 當 required（missing = issue）。在 cc 與 opencode 所有 events 均為 false；僅 codex 6 個 event 顯式設 true
 
-**不把語意等同於「CLI 永遠不會支援」**：只表達「目前 build-time 信心不足，把它從對外 capability 宣告裡隔離」。後續 CLI 驗證通過後翻成 false 即可。
+**不把語意等同於「CLI 永遠不會支援」**：只表達「installer 已寫入但 runtime 可能不 emit；checker 對此 missing 不當 bug」。
 
-### 1.2 DeriveSupportedStatuses 過濾 FutureOnly
+**Inspector UI 未來如何呈現**：未來若想區分「declared」與「currently reliable」，可以讀 `Events()` 中每個 spec 的 `FutureOnly` bit 自行決定顯示；不耦合進 `SupportedStatuses()`。
 
-`internal/agent/supported_statuses.go` `DeriveSupportedStatuses` 對 FutureOnly spec **跳過**其 EmitsStatus：
+### 1.2 DeriveSupportedStatuses 不動
+
+`internal/agent/supported_statuses.go` **不改**。仍為：
 
 ```
 for _, spec := range specs {
-    if spec.FutureOnly {
-        continue
-    }
     for _, s := range spec.EmitsStatus { ... }
 }
 ```
 
-排序與去重邏輯不變；空輸入仍回非 nil empty slice；deterministic lexicographic 排序不變。
+不過濾 FutureOnly。codex `SupportedStatuses()` 結果不變。
 
-**影響**：codex 6 個 FutureOnly event 的 5 個 status（Waiting/Error/Clear/加 Notification idle 分支的 Idle 重複/PermissionRequest 的 Waiting 重複）— 其實經過各自 emits 表 intersection 後，codex SupportedStatuses 會收斂到「Running+Idle」（由 UserPromptSubmit+SessionStart/Stop 兩個非 FutureOnly event 貢獻）。
+v1 原本的 S1/S2/S3「skip FutureOnly」測試**移除**。改用 trivial 測試確認「新欄位預設 false + 通過 defensive copy」（§2.1）。
 
 ### 1.3 三家 provider FutureOnly 標記矩陣
 
 | Provider | Event | FutureOnly | 理由 |
 |---|---|---|---|
-| cc | 全部 9 個 | false | cc CLI 實際會 emit 全部 9 個（此版本 plugin 驗證過） |
-| codex | SessionStart / UserPromptSubmit / Stop | false | 主線 codex CLI hooks 長期支援這 3 個（既有 3-event 安裝） |
-| codex | SubagentStart / SubagentStop / StopFailure / Notification / PermissionRequest / SessionEnd | **true** | codex CLI 目前不保證 emit；但 DeriveStatus 已能解析；installer 安裝為未來鋪路 |
-| opencode | 全部 8 個 | false | plugin template 實際會 emit 全部 8 個（§1.5 後 template 從 Events 生成） |
+| cc | 全部 9 個 | false | cc CLI 實際會 emit 全部 9 個 |
+| codex | SessionStart / UserPromptSubmit / Stop | false | 主線 codex CLI hooks 長期支援 |
+| codex | SubagentStart / SubagentStop / StopFailure / Notification / PermissionRequest / SessionEnd | **true** | codex CLI 目前不保證 emit；DeriveStatus 已能解析；installer 仍安裝為鋪路 |
+| opencode | 全部 8 個 | false | plugin template 實際會 emit 全部 8 個 |
 
-codex 3-FutureOnly 後，**SupportedStatuses=[Idle, Running]**；drift test 對這 2 個 status 做 per-event 強相等；6 個 FutureOnly event 跳過 fixture 檢查。
+codex `SupportedStatuses()` **維持 5 status**（Idle/Running/Waiting/Error/Clear），因為 §1.2 決定不過濾。
 
-**不做 per-CLI-version gate**：版本探測與動態 FutureOnly 翻轉留給未來 phase；此 PR 的 FutureOnly 是 build-time 靜態標記。
+**不做 per-CLI-version gate**：版本探測與動態 FutureOnly 翻轉留給未來 phase。
 
-### 1.4 codex CheckHooks 對 FutureOnly missing 不報問題
+### 1.4 codex CheckHooks 三態判定
 
-`internal/agent/codex/hooks.go` CheckHooks 改動：
+`internal/agent/codex/hooks.go` `CheckHooks` 核心改動：對每個 event 依 FutureOnly 與現況分三態處理。
 
-- 遍歷仍用 `p.eventNames()`（維持 9 個 event 全部檢查與寫入 `Events` map）
-- **但**對 `spec.FutureOnly=true` 的 event，若 `hooks.json` 缺該 key 或 pdx command 不在：
-  - `events[eventName] = HookEventInfo{Installed: false}`（仍如實記錄實況）
-  - **不 append issue**
-  - **不設 `allInstalled = false`**
-- 非 FutureOnly event 維持現有嚴格檢查（missing → issue + allInstalled=false）
+對每個 event，讀 `hooks.json` 對應 key 得到狀態：
+- **State A: absent** — hooks.json 無此 event key（或 entries 為空）
+- **State B: present-but-broken** — key 存在但找不到正確 pdx command（例：legacy direct-entry、command 不正確、或已被人為改壞）
+- **State C: valid** — key 存在且 pdx command 正確
 
-遍歷時需要每個 event name 配對其 spec（取得 FutureOnly bit）：用 `p.Events()` 取 `[]HookEventSpec`（或建一個 `eventSpecs()` 私有 helper 回傳已定義的 `codexEventSpecs` slice 以避免 defensive copy 開銷；兩者擇一，不影響對外契約）。
+決策表：
 
-**3-event legacy 使用者**：升級後 hooks.json 仍只有 `SessionStart/UserPromptSubmit/Stop`。其他 6 個 FutureOnly 為 missing（依 §1.4 不標 issue、不計 allInstalled）。只要 3 個非 FutureOnly event 都 installed → `allInstalled=true`。不需要額外 legacy fallback 分支 — FutureOnly 語意已自然覆蓋此 case。
+| FutureOnly | State | `events[name].Installed` | `Issues` | 影響 `allInstalled` |
+|---|---|---|---|---|
+| false | A (absent) | false | append `<name> hook not installed` | **是**（blocks） |
+| false | B (broken) | false | append `<name> hook: pdx command not found` | **是**（blocks） |
+| false | C (valid) | true | — | 不影響 |
+| **true** | A (absent) | false | **不 append**（legacy tolerance） | **否**（不 blocks） |
+| **true** | B (broken) | false | **append warning** `<name> hook: pdx command malformed (FutureOnly event has existing hook entry but pdx path incorrect — run install to repair)` | **是**（blocks） |
+| **true** | C (valid) | true | — | 不影響 |
 
-**主線使用者（新安裝 9 event）**：9 個都 installed → `allInstalled=true`、issues 空；FutureOnly event 依然 `Installed=true`（因為 installer 有寫）。
+核心原則：
+- **FutureOnly absent** → 是「legacy 尚未升級」或「runtime 未必需要」的寬鬆態，完全靜默
+- **FutureOnly present-but-broken** → 已配置卻壞掉，是確實的 bug，必須顯化並 block（避免「綠燈但實際壞」）
+- **FutureOnly valid** → 已升級完成，與 non-FutureOnly 同等認定
 
-**部分受損**：若 3 個非 FutureOnly 缺其中一個 → `allInstalled=false` + 該 event issue（與現行一致）；FutureOnly 缺失不影響 overall 判定。
+實作：遍歷 `p.Events()`（取得含 FutureOnly bit 的 spec slice），而非 `p.eventNames()`。對每個 spec：
+1. 查 hooks[spec.Name] 現況
+2. `hasLegacyPdxDirectCodexEntry` → broken 分支
+3. `findPdxCommandInCodex` → valid 分支（有 command）或 broken 分支（key 存在但無 pdx command）
+4. key 不存在 → absent 分支
+5. 依 spec.FutureOnly 與 state 查表套用決策
+
+**3-event legacy 使用者**（升級後）：SessionStart/UserPromptSubmit/Stop = valid（state C），6 個 FutureOnly = absent（state A）→ Issues 空、allInstalled=true。
+
+**主線使用者**（完整 9 event 新安裝）：全部 valid → Installed=true、Issues=[]。
+
+**部分損壞**：若有 FutureOnly key 被手動改壞 → `Issues` 顯化 warning + allInstalled=false（避免假綠燈）。
 
 ### 1.5 opencode renderManagedPlugin 從 Events 生成
 
-這是 Finding #2（防守 HIGH + 體質 MED）的核心：**不讓 template 與 opencodeEventSpecs 成為兩份平行 SSoT**。
+Finding #2（PR #616 第 2 輪防守 HIGH + 體質 MED）核心：不讓 template 與 `opencodeEventSpecs` 成為兩份平行 SSoT。
 
-`internal/agent/opencode/plugin_template.go` 改動：
+策略 A（選用）：template 保留固定 switch/case 結構，**但渲染時驗證** template 實際 emit 的 pdx event set ⊆ `opencodeEventSpecs.Name` 集合。
 
-- `renderManagedPlugin(pdxPath string) string` **改簽名** 加入 `specs []agent.HookEventSpec` 第二參數（或在函式內讀 `opencodeEventSpecs` — 同套件內 package 級變數，直接讀即可避免 caller 端傳遞）
-- 函式內部從 `opencodeEventSpecs` 動態生成：
-  - plugin JS 的 `emit('<Name>', payload)` 字串依 specs 順序產出
-  - event type mapping（`session.created → SessionStart`、`permission.asked → PermissionRequest`、…）仍保留在 Go 側「OpenCode 原生 event → pdx event name」的轉譯表，因為這是從 opencode runtime 事件語言到 pdx hook 語言的獨立概念
-  - **但**：`emit('<pdx event name>', ...)` 呼叫的 pdx event name 必須出現在 `opencodeEventSpecs` 的 `Name` 集合內 — 生成時以 specs Name 為白名單；若 mapping 表宣告了 specs 沒有的 event，生成時跳過並在測試層抓出（§2.5 D6）
+具體：
 
-**實作策略**（擇 A）：
+- `renderManagedPlugin(pdxPath string) string` 維持原簽名；函式尾部呼叫 `validateSpecsCoverEmitted(body, opencodeEventSpecs)` — 若 template 字串 emit 的 event name 不在 specs 內 → `panic("contract violation: template emits undeclared event: ...")` 
+- `extractEmittedEvents(body string) []string` — 用 regex `emit\(['"](\w+)['"]` 從 body 抽出 emit 的 event names
+- `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error` — 強等：`set(extractEmittedEvents(body)) == set(specs.Name)`；任何一側 superset 都回 error
 
-- **策略 A**（優先）：template 保留固定 switch/case 結構（因為每個 opencode 原生 event 的 payload 轉譯 JS 邏輯不同），但 template 渲染前 **先檢查每個 emit 的 pdx event 是否在 `opencodeEventSpecs` 集合內**；否則 panic（「contract violation: template emits undeclared event」）。渲染出的 JS 字串保持與目前一致（避免 churn），但運行時 emit 的 event set 受 specs 檢查守護。
-- **策略 B**（若 A 太鬆）：把 template 裡的 switch/case 完全從 specs driven — 但 payload 轉譯邏輯會被 codegen 化，churn 大。**本 PR 不選**。
+**為什麼 panic 而非 error**：render 函式原簽名回 string，加 error 會改呼叫點。panic 只會在 build 測試階段觸發（因為 template 是 const-like 字串），release path 不會 runtime 爆。
 
-**選擇策略 A**：改動小、風險低、仍解決 SSoT 核心論點（specs 宣告什麼，template 就能 emit 什麼；不能 emit specs 裡沒有的 event）。
+**配合測試**（§2.3 PT1-PT3）驗證：
+- PT1：`extractEmittedEvents` 正確從 sample body 抽出 event names
+- PT2：`renderManagedPlugin("/p")` 產出的 body emit set == `opencodeEventSpecs.Name` set
+- PT3：用 synthetic specs（例移除 `Stop`）餵 `validateSpecsCoverEmitted` → return error（不經 renderManagedPlugin，避免要 mock package var）
 
-**配合測試**：`plugin_template_test.go` 新增 D5（見 §2.5）驗證「template 字串實際 emit 的 event name」⊆ `opencodeEventSpecs.Name`，且強相等（不能少也不能多）。測試用 regex `/emit\(['"]([A-Za-z]+)['"]/g` 從渲染出的 JS 字串抓 event name。
+### 1.6 opencode CheckHooks per-event emit 驗證
 
-### 1.6 opencode CheckHooks 對齊新驗證
-
-`internal/agent/opencode/hooks.go` CheckHooks 目前邏輯：檔案存在 + managed marker → 全部 event 標 `Installed=true`。這是 Finding #2 的假綠燈根源。
-
-**新邏輯**：
+`internal/agent/opencode/hooks.go` `CheckHooks` 對齊 §1.5 extraction 成為 per-event 驗證：
 
 1. 讀檔、驗 marker（不變）
-2. 用 §1.5 同一套 regex 從檔案內容抓實際 emit 的 event name set
+2. 呼叫 `extractEmittedEvents(string(data))` 取 emit set
 3. 對每個 `opencodeEventSpecs` event：
-   - 若該 event name 在 emit set 中 → `Installed=true, Command=pluginPath`
-   - 否則 → `Installed=false`，push issue `<event> emit missing in plugin`
-4. `allInstalled = (每個 non-FutureOnly event 都 installed)` — opencode 當前無 FutureOnly event（§1.3），等同「全部 event 都 installed」
+   - event name ∈ emit set → `Installed=true, Command=pluginPath`
+   - event name ∉ emit set → `Installed=false`，push `<name> emit missing in plugin` 
+4. opencode 當前無 FutureOnly event（§1.3），`allInstalled = (全部 events Installed=true)`
+5. 若 emit set 含有 specs 沒有的 event name（template 動到但 specs 沒補） → 加 issue `unexpected emit '<name>' not in catalog` + 不影響 allInstalled（此路徑 render 階段已 panic 擋掉，但 CheckHooks 對人為改動的 plugin 檔案仍做防禦）
 
-**regex 位置**：在 plugin_template.go 暴露一個 `extractEmittedEvents(body string) []string` helper，CheckHooks 與測試共用。單一正規來源避免 drift。
+### 1.7 drift test per-event 強相等 + parser contract 保留
 
-### 1.7 drift test per-event 強相等 + FutureOnly skip
+`internal/agent/drift_test.go` 改動原則（v2 收斂）：
 
-`internal/agent/drift_test.go` 改動核心是把 provider 級 union 比對升級為 per-event 強相等：
+- **保留所有既有 fixture**（含 codex 6 個 FutureOnly event 的 9 筆）— parser contract 不退化
+- **新增 per-event 強相等斷言**：抓單一 event 過度宣告（Finding #4）
+- **所有斷言涵蓋 FutureOnly event**：SupportedStatuses 未過濾，declaredSet 也不過濾，所以三向相等天然包含 FutureOnly
+- **不新增 D6 防呆**（v1 曾提議「fixture 不得含 FutureOnly」）— v2 移除該設計；FutureOnly fixture 是刻意的 parser contract 保護
 
-**既有 TestDriftThreeWayEquality**：保留（provider 級三向 — Events union vs DeriveStatus union vs SupportedStatuses），但遍歷 fixtures 前**濾掉 FutureOnly spec 對應的 fixture**（若 fixture table 誤放 FutureOnly event fixture → D6 再報，不在此測試）。
+具體改動：
 
-具體 FutureOnly 處理：
-- declaredSet 遍歷 `installer.Events()` 時跳過 `spec.FutureOnly=true`
-- 對 fixtures 的 emit 判斷不變（emitted 只管 Valid=true && Status != ""）
-- supportedSet 因 SupportedStatuses 已由 DeriveSupportedStatuses 自動濾 FutureOnly → 自然三向相等
+- `TestDriftThreeWayEquality` — **不動**。仍驗三向相等；codex declared/emitted/supported 皆為 5 status set。
+- `TestDriftFixtureCoversAllEvents` — **不動**。要求所有 `Events()` event 都有 fixture（含 FutureOnly）。
+- `TestDriftFixtureCoverageNonEmpty` — **不動**。
+- **新增 `TestDriftPerEventEmitsStatusMatch`**：對每個 provider 的每個 spec（含 FutureOnly），取該 event name 的所有 fixtures，跑 DeriveStatus 收集 `emitSet`（Valid=true && Status != ""），斷言 `emitSet == set(spec.EmitsStatus)`（雙向強相等）。抓單一 event 的 EmitsStatus 過度或不足宣告。
 
-**新增 TestDriftPerEventEmitsStatusMatch**：對每個 non-FutureOnly spec，取該 event name 對應所有 fixture，跑 DeriveStatus，收集 emit status set（Valid=true && Status != ""），斷言 **emit set == spec.EmitsStatus set**（雙向相等）。抓「單一 event 過度宣告」漏網。
+`providerFixtures` **不變**（v1 曾計畫移除 codex 9 筆 FutureOnly fixture；v2 撤回）。
 
-**新增 TestDriftFixtureOnlyCoversNonFutureOnly**：駐點防呆 — `providerFixtures` 不應為 FutureOnly event 寫 fixture（避免測試假綠 / fixture 過期）。遍歷 fixtures，對每個 fixture `eventName`，若對應 spec `FutureOnly=true` → `t.Errorf`。這保證 FutureOnly event 不會在日後變回 non-FutureOnly 時，fixture 還在但其實驗的是 mock 資料。
+**驗收 D5 有效性**：人為測試把 codex `Stop` spec 的 `EmitsStatus` 從 `[Idle]` 改為 `[Idle, Clear]` → `TestDriftPerEventEmitsStatusMatch` 應紅（Stop fixture 只 emit Idle，spec 多宣告 Clear）。
 
-**既有 TestDriftFixtureCoversAllEvents**：改為只要求 **non-FutureOnly** event 都有 fixture；FutureOnly event 跳過此斷言。
+### 1.8 opencode events.go 對齊 sanity check
 
-**既有 TestDriftFixtureCoverageNonEmpty**：不動。
+從 `plugin_template.go` renderManagedPlugin 靜態分析：
+- template emit: `SessionStart`, `PermissionRequest`, `StopFailure`, `Stop`, `SessionEnd`, `UserPromptSubmit`, `SubagentStart`, `SubagentStop`（8 個）
+- `opencodeEventSpecs.Name`：同上 8 個
 
-`providerFixtures` 內容：
-- cc 12 個 fixture 不動
-- codex **移除** 6 個 FutureOnly event 的 fixture（Notification 4 支 + PermissionRequest 1 + SubagentStart 1 + SubagentStop 1 + StopFailure 1 + SessionEnd 1 共 9 個？需逐項對照現有列表）
-- opencode 不動（當前無 FutureOnly event）
-
-**codex fixture 精準列表**：
-
-非 FutureOnly（保留）：
-- `SessionStart`, `UserPromptSubmit`, `Stop` — 3 fixture
-
-FutureOnly（移除）：
-- `Notification` 4 支 + `PermissionRequest` + `SubagentStart` + `SubagentStop` + `StopFailure` + `SessionEnd` — 共 9 fixture
-
-移除後 codex fixture 只剩 3 支；drift per-event 對 3 個 non-FutureOnly 強相等。
-
-### 1.8 opencode events.go 對 status 補齊
-
-Finding 沒直接要求，但既然 §1.5-1.6 做 plugin emit ↔ specs 對齊，必須檢查 opencode template 實際 emit 的 pdx event 是否全部在 `opencodeEventSpecs` 內。
-
-檢查現況（從 `plugin_template.go` renderManagedPlugin 靜態分析）：
-- template emit: `SessionStart`, `PermissionRequest`, `StopFailure`, `Stop`, `SessionEnd`, `UserPromptSubmit`, `SubagentStart`, `SubagentStop` — 共 8 個
-- `opencodeEventSpecs` Name 集合：`SessionStart`, `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `PermissionRequest`, `Stop`, `StopFailure`, `SessionEnd` — 共 8 個
-
-**相等**。§1.5 runtime 檢查生效時不會 panic。
+**相等**。§1.5 validate 不會 panic。
 
 ### 1.9 零改動邊界
 
 以下檔案 Fix **不得觸碰**：
 
 - `internal/agent/registry.go`, `status.go`, `coverage.go`, `hook_version.go`, `process_info*.go`
-- `internal/agent/cc/**` 除非為配合 `supported_statuses` 介面升級而被動調整（不預期）
-- `internal/agent/opencode/status.go`, `provider.go`, `readiness.go`（僅動 `hooks.go`, `plugin_template.go`, `events.go` 可能需改 FutureOnly=false 顯式標記 — 若預設值即 false 也可不改）
-- `internal/agent/codex/status.go`, `provider.go`, `readiness.go`（僅動 `hooks.go`, `events.go`）
+- `internal/agent/supported_statuses.go`（v2 移除修改此檔的計畫）
+- `internal/agent/cc/**` 全部（cc 所有 event FutureOnly=false 由預設值保證 — 可不顯式標）
+- `internal/agent/opencode/status.go`, `provider.go`, `readiness.go`, `events.go`（opencode events 無 FutureOnly 標記 — 預設 false）
+- `internal/agent/codex/status.go`, `provider.go`, `readiness.go`, `provider_test.go`（v1 要求 codex supported 測試 5→2 — v2 撤回，provider_test 不動）
 - `internal/agent/probe/**`
-- `internal/store/**`
-- `internal/module/**`
-- `spa/**`
-
-不新增 API endpoint、不改 registry、不引入 agent 版本探測。
+- `internal/store/**`, `internal/module/**`, `spa/**`
 
 ## 2. 測試案例清單
 
-按檔案組織：
+### 2.1 FutureOnly 欄位單元測試
 
-### 2.1 FutureOnly 欄位單元測試（provider-level）
+`internal/agent/supported_statuses_test.go` 既有 case 不變。**不新增**「skip FutureOnly」測試（v2 移除）。
 
-`internal/agent/supported_statuses_test.go` 既有 case 不變，新增：
+`internal/agent/provider_test.go`（若不存在則在 `supported_statuses_test.go` 加）新增：
 
-| # | 名稱 | 情境 | 斷言 |
-|---|---|---|---|
-| S1 | `TestDeriveSupportedStatuses_SkipsFutureOnly` | specs 含 1 個 FutureOnly + 2 個 non-FutureOnly | 回傳只含 non-FutureOnly 的 EmitsStatus union |
-| S2 | `TestDeriveSupportedStatuses_AllFutureOnly` | 全部 spec FutureOnly=true | 回傳空 slice（非 nil） |
-| S3 | `TestDeriveSupportedStatuses_FutureOnlyEmptyEmits` | FutureOnly=true + EmitsStatus=nil | 回傳空 slice（與 §1.2 語意一致，不 panic） |
+| # | 名稱 | 斷言 |
+|---|---|---|
+| F1 | `TestHookEventSpecFutureOnlyDefaultsToFalse` | 宣告一個不指定 FutureOnly 的 HookEventSpec → `FutureOnly=false` |
+| F2 | `TestDeriveSupportedStatusesIgnoresFutureOnlyBit` | specs 含 FutureOnly=true + EmitsStatus=[Waiting] → Waiting 仍出現在結果（防止未來被誤加過濾 logic） |
 
-### 2.2 codex Events 與 CheckHooks FutureOnly 行為
+F2 是防呆測試，鎖定「DeriveSupportedStatuses 不因 FutureOnly 過濾」的契約。
+
+### 2.2 codex Events 欄位與 CheckHooks FutureOnly 行為
 
 `internal/agent/codex/events_test.go` 新增：
 
 | # | 名稱 | 斷言 |
 |---|---|---|
-| CE1 | `TestCodexEventsFutureOnlyFlags` | 3 個非 FutureOnly（SessionStart/UserPromptSubmit/Stop）+ 6 個 FutureOnly，一一 assert `spec.FutureOnly` |
+| CE1 | `TestCodexEventsFutureOnlyFlags` | 3 個非 FutureOnly（SessionStart/UserPromptSubmit/Stop）+ 6 個 FutureOnly，一一 assert `spec.FutureOnly` bit |
 | CE2 | `TestCodexEventsDefensiveCopyPreservesFutureOnly` | 取兩次 `Events()`、mutate 第一次的 FutureOnly → 第二次不受影響 |
 
-`internal/agent/codex/hooks_test.go` 新增（用既有 writing temp hooks.json + pdx path 的 helper 模式）：
+`internal/agent/codex/hooks_test.go` 新增（用既有 writing temp hooks.json + pdx path 的 helper 模式；若 helper 不存在則仿 cc 的 pattern）：
 
 | # | 名稱 | 情境 | 斷言 |
 |---|---|---|---|
-| CH1 | `TestCheckHooks_LegacyThreeEvent_ReportsInstalled` | hooks.json 僅 SessionStart/UserPromptSubmit/Stop 且 pdx command 正確 | `allInstalled=true`、`Issues` 不含 FutureOnly event missing、6 個 FutureOnly 的 `Events` map entry 為 `Installed=false` |
-| CH2 | `TestCheckHooks_NineEvent_FullyInstalled_NoIssues` | hooks.json 含完整 9 個 event 且 pdx command 正確 | `allInstalled=true`、`Issues=[]`、9 個 event map entry `Installed=true` |
-| CH3 | `TestCheckHooks_LegacyThreeEvent_MissingRequired_StillFailsForThat` | hooks.json 缺 SessionStart（只剩 2 個）+ 6 FutureOnly 缺 | `allInstalled=false`、`Issues` 含 SessionStart missing、FutureOnly missing 不入 Issues |
-| CH4 | `TestCheckHooks_PartialFutureOnly_DoesNotTaintOverall` | hooks.json 3 非 FutureOnly + 3 FutureOnly（其他 3 FutureOnly 缺） | `allInstalled=true`、`Issues=[]`、3 缺的 FutureOnly `Installed=false` |
+| CH1 | `TestCheckHooks_LegacyThreeEvent_ReportsInstalled` | hooks.json 僅 SessionStart/UserPromptSubmit/Stop valid（FutureOnly 6 absent） | `allInstalled=true`、`Issues=[]`、6 個 FutureOnly `Events` map entry `Installed=false` |
+| CH2 | `TestCheckHooks_NineEvent_FullyInstalled_NoIssues` | hooks.json 9 events 全 valid | `allInstalled=true`、`Issues=[]`、9 個 entry `Installed=true` |
+| CH3 | `TestCheckHooks_RequiredEventMissing_Blocks` | 只有 2 個 required event valid（缺 SessionStart） | `allInstalled=false`、Issues 含 `SessionStart hook not installed` |
+| CH4 | `TestCheckHooks_FutureOnlyBroken_WarnsAndBlocks` | hooks.json 3 required valid + 1 FutureOnly（Notification）key 存在但 command 錯誤 | `allInstalled=false`、Issues 含 `Notification hook: pdx command malformed...`、Notification Installed=false |
+| CH5 | `TestCheckHooks_FutureOnlyAbsent_DoesNotBlock` | hooks.json 3 required valid + 3 FutureOnly absent + 3 FutureOnly valid | `allInstalled=true`、Issues=[]、3 absent entries Installed=false、3 valid entries Installed=true |
 
 ### 2.3 opencode template 與 CheckHooks 對齊
 
@@ -213,173 +225,183 @@ Finding 沒直接要求，但既然 §1.5-1.6 做 plugin emit ↔ specs 對齊�
 
 | # | 名稱 | 斷言 |
 |---|---|---|
-| PT1 | `TestExtractEmittedEvents` | helper `extractEmittedEvents` 從 template body 正確抽出 8 個 event name（順序可變） |
-| PT2 | `TestRenderManagedPlugin_OnlyEmitsDeclaredEvents` | `renderManagedPlugin("/p")` 回傳 body 的 emit set ⊆ `opencodeEventSpecs.Name` 且強相等 |
-| PT3 | `TestRenderManagedPlugin_PanicsOnMismatch` | 臨時注入 mock `opencodeEventSpecs` 缺一 event（例移除 `Stop`）→ render 時 panic（契約違反） |
+| PT1 | `TestExtractEmittedEvents` | helper 從 sample body 正確抽出 event names（含 regex corner：字串插值前後空白、單引號 vs 雙引號、兩個 emit 同行） |
+| PT2 | `TestValidateSpecsCoverEmitted_Equal` | `validateSpecsCoverEmitted(body, opencodeEventSpecs)` 對真 template body 回 nil |
+| PT3 | `TestValidateSpecsCoverEmitted_EmitNotInSpec` | synthetic body 含 `emit('Fake')` + specs 無 Fake → error |
+| PT4 | `TestValidateSpecsCoverEmitted_SpecNotInEmit` | synthetic body 缺某 event + specs 含它 → error |
+| PT5 | `TestRenderManagedPlugin_ProducesValidBody` | `renderManagedPlugin("/p")` 不 panic；結果 body 含 marker + 8 個 event emit |
 
-PT3 若用 init-time 注入困難（const-like slice），改用 `validateSpecsCoverEmitted(body, specs) error` 直接跑 negative case 測試即可，不需改 render 流程。
+### 2.4 opencode hooks CheckHooks per-event emit
 
 `internal/agent/opencode/hooks_test.go` 新增：
 
 | # | 名稱 | 斷言 |
 |---|---|---|
 | OH1 | `TestCheckHooks_ValidPlugin_PerEventInstalled` | 用 `writeManagedPlugin` 寫合法 template → CheckHooks 每個 event `Installed=true`、Issues=[] |
-| OH2 | `TestCheckHooks_HandEditedPlugin_EventMissing` | 寫一份含 marker 但移除某 `emit('Stop', ...)` 的 body → CheckHooks 該 event `Installed=false` 且 Issues 含 `Stop emit missing` |
+| OH2 | `TestCheckHooks_HandEditedPlugin_EventMissing` | 寫一份含 marker 但移除某 `emit('Stop',` 的 body → CheckHooks 該 event `Installed=false`、Issues 含 `Stop emit missing in plugin` |
 | OH3 | `TestCheckHooks_UnmanagedPlugin_ReturnsUnmanaged` | 既有行為保留：不帶 marker → Installed=false + Issues |
+| OH4 | `TestCheckHooks_UnexpectedEmitInPlugin_Flagged` | 寫一份含 marker + 額外 `emit('Fake', ...)` 的 body → Issues 含 `unexpected emit 'Fake' not in catalog`、allInstalled 不因此 false（現有 8 個 event 仍 valid） |
 
-### 2.4 drift test 升級
+OH4 測 §1.6 對「template 動到、specs 沒補」的防禦路徑。
 
-`internal/agent/drift_test.go` 改動：
+### 2.5 drift test per-event 強相等
+
+`internal/agent/drift_test.go` 新增：
 
 | # | 名稱 | 斷言 |
 |---|---|---|
-| D3（修改） | `TestDriftThreeWayEquality` | declaredSet/supportedSet 遍歷跳過 FutureOnly；emit 行為不變；三向相等對 non-FutureOnly |
-| D4（修改） | `TestDriftFixtureCoversAllEvents` | 只要求 non-FutureOnly event 有 fixture；FutureOnly skip |
-| D5（新增） | `TestDriftPerEventEmitsStatusMatch` | 對每個 non-FutureOnly spec，fixture emit set == spec.EmitsStatus（雙向強相等） |
-| D6（新增） | `TestDriftFixturesDoNotCoverFutureOnly` | 反向防呆：fixture 中若出現 FutureOnly event 名 → t.Errorf |
+| D5 | `TestDriftPerEventEmitsStatusMatch` | 對每個 provider 的每個 spec：取該 event 的 fixtures → emitSet == set(spec.EmitsStatus) |
 
-### 2.5 cc/opencode SupportedStatuses 不變（回歸保險）
+D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）。**無 D6**（v1 的 FutureOnly fixture 禁令移除）。
 
-既有 `cc/provider_test.go` `TestCCSupportedStatuses` 應仍回傳 5 個 Status — 補斷言確認新增 FutureOnly 不影響 cc（全為 false）。若既有測試已明列 5 個 status → 無須改。
-
-`opencode/provider_test.go` `TestOpenCodeSupportedStatuses` 同理，5 status 不變。
-
-`codex/provider_test.go` `TestCodexSupportedStatuses` 需改：**從 5 status 改為 2 status**（Idle + Running），因 6 個 FutureOnly event 的 Waiting/Error/Clear 被濾掉。這是 FutureOnly 的直接後果。commit 順序需要先 landing FutureOnly 欄位與 codex 標記才跑這個斷言更新。
+既有 D1/D2/D3/D4 不動。`providerFixtures` 不變。
 
 ## 3. TDD 執行順序
 
 嚴格紅綠，每個 step 一個 commit；commit message 用 Conventional Commits + `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`。
 
+**關鍵**：每 commit 完跑 `go build ./... && go test ./... && go vet ./...` **必須全綠**。v2 下這可滿足，因為：
+- DeriveSupportedStatuses 不變 → codex SupportedStatuses 仍 5 status → drift ThreeWayEquality 不會因 FutureOnly 標記而破
+- fixtures 不移除 → parser drift 不退化
+- CheckHooks 內部行為變化只影響 codex/hooks_test.go 本身
+
 ### Commit 1 — `feat(agent): add FutureOnly bit to HookEventSpec`
-- 紅：寫 S1/S2/S3 → 失敗（DeriveSupportedStatuses 未濾）
-- 綠：加欄位 + 改 `DeriveSupportedStatuses` skip FutureOnly
-- 跑 `go test ./internal/agent/...` 綠
+- 紅：寫 F1 + F2 → 失敗（F1 編譯錯 / F2 尚未驗證）
+- 綠：`provider.go` 加 `FutureOnly bool` 欄位 + 註解（§1.1）；`DeriveSupportedStatuses` **不動**；F1/F2 綠
+- 檢驗：cc / codex / opencode `Events()` 的 defensive copy 需保留 FutureOnly bit（目前 three-field literal copy 自動涵蓋 struct 所有欄位 — 確認一下）
+- 跑 `go test ./internal/agent/...` 全綠
 
 ### Commit 2 — `feat(agent/codex): mark 6 future-only events`
-- 紅：寫 CE1 → 失敗（6 個 event 尚未標 FutureOnly）
-- 綠：在 `codexEventSpecs` 6 個 event 上加 `FutureOnly: true`
-- 同步：`codex/provider_test.go` `TestCodexSupportedStatuses` 從 5 status 改為 2 status（斷言 supported == {Idle, Running}）
+- 紅：寫 CE1 → 失敗（欄位未標 true）
+- 綠：`codex/events.go` 把 SubagentStart / SubagentStop / StopFailure / Notification / PermissionRequest / SessionEnd 六個 event 加 `FutureOnly: true`
+- 補：CE2（defensive copy 保留 FutureOnly bit）
+- 跑 `go test ./internal/agent/codex/...` 綠（現有 `TestCodexSupportedStatuses` 不動，仍 5 status — v2 下不需改）
+- 跑 `go test ./internal/agent/...` 全綠（drift 三向相等仍成立）
+
+### Commit 3 — `feat(agent/codex): three-state CheckHooks with FutureOnly awareness`
+- 紅：寫 CH1-CH5 → 失敗（CheckHooks 尚未 aware）
+- 綠：`codex/hooks.go` 改 CheckHooks 遍歷用 `p.Events()`（取得 FutureOnly bit），決策表依 §1.4 實作三態
+- 留意：`hasLegacyPdxDirectCodexEntry` / `findPdxCommandInCodex` 已區分 broken state，主要改動是「broken + FutureOnly → warning issue + block」（以前並無 FutureOnly 概念，所有 broken 都 block）
 - 跑 `go test ./internal/agent/codex/...` 綠
 
-**備註**：寫 CE2 放在同 commit 測 defensive copy 保留 FutureOnly bit。
-
-### Commit 3 — `feat(agent/codex): skip FutureOnly missing in CheckHooks`
-- 紅：寫 CH1/CH2/CH3/CH4 → 失敗（CheckHooks 仍嚴格判所有 event missing）
-- 綠：CheckHooks 內部先取 specs（含 FutureOnly bit），對 FutureOnly missing 不 issue + 不計 allInstalled
-- 跑 `go test ./internal/agent/codex/...` 綠
-
-### Commit 4 — `test(agent): upgrade drift test to per-event + FutureOnly skip`
-- 紅：寫 D5（per-event 強相等）+ D6（FutureOnly skip）→ 失敗（D6 若舊 fixture 還含 codex FutureOnly event fixture）
-- 修：`providerFixtures` 移除 codex 6 個 FutureOnly event fixture；`TestDriftThreeWayEquality` 的 declaredSet/supportedSet 迴圈跳過 FutureOnly；`TestDriftFixtureCoversAllEvents` 只要求 non-FutureOnly 有 fixture
-- 綠：三個測試 + D5/D6 都過
+### Commit 4 — `test(agent): per-event drift assertion`
+- 紅：寫 D5 → 對既有 spec/fixture 跑起來可能紅（若有 over-declaration）或直接綠
+- 綠：若紅，修 spec 或 fixture 對齊（最可能 case：cc 的 `Notification` EmitsStatus `[Waiting, Idle]` 對 fixtures 的 4 筆全綠 — 應直接綠）
 - 跑 `go test ./internal/agent/...` 綠
 
-### Commit 5 — `refactor(agent/opencode): extract emitted events from template`
-- 紅：寫 PT1 → 失敗（extractEmittedEvents 不存在）
-- 綠：在 `plugin_template.go` 加 `extractEmittedEvents(body string) []string` helper（正規 `emit\(['"](\w+)['"]`）
+### Commit 5 — `refactor(agent/opencode): extract emitted events helper`
+- 紅：寫 PT1 → 失敗（helper 不存在）
+- 綠：`plugin_template.go` 加 `extractEmittedEvents(body string) []string`
 - 跑 `go test ./internal/agent/opencode/...` 綠
 
 ### Commit 6 — `feat(agent/opencode): validate template emits declared events`
-- 紅：寫 PT2 + PT3（驗證 helper + negative case）→ 失敗
-- 綠：加 `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error`；`renderManagedPlugin` 最後呼叫 validate，若 error → panic with 契約違反訊息
+- 紅：寫 PT2 + PT3 + PT4 + PT5 → 失敗
+- 綠：加 `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error`；`renderManagedPlugin` 結尾呼叫 validate，mismatch panic
+- PT5 確認正常 template 不 panic
 - 跑 `go test ./internal/agent/opencode/...` 綠
 
 ### Commit 7 — `feat(agent/opencode): CheckHooks verifies per-event emit`
-- 紅：寫 OH1/OH2/OH3 → 失敗（CheckHooks 仍假綠回填）
-- 綠：CheckHooks 讀檔後呼叫 `extractEmittedEvents`，對每個 spec 檢查其 Name 是否在 emit set；missing 標 Installed=false + push issue
+- 紅：寫 OH1 + OH2 + OH3 + OH4 → 失敗（CheckHooks 仍假綠回填）
+- 綠：`opencode/hooks.go` CheckHooks 依 §1.6 改寫：讀檔 → extract → per-event 檢查 + 超集防禦
 - 跑 `go test ./internal/agent/opencode/...` 綠
 
 ### Commit 8 — `docs: hook events fix plan retrospective（可選）`
 若 §3 順序與實際有偏差，補歷史註記。
 
-**Commit 順序原理**：
-- Commit 1 建欄位 + 介面；所有後續 commit 依賴這個
-- Commit 2-3 完成 codex 側（事件標記 + CheckHooks 行為）
-- Commit 4 升級 drift test 保護這些新行為
-- Commit 5-7 完成 opencode 側（extraction helper → validate → CheckHooks per-event）
-- 每個 commit 完成後 `go build ./... && go test ./... && go vet ./...` 全綠
+**Commit 綠燈分析**：
+- Commit 1 → DeriveSupportedStatuses 不變；codex SupportedStatuses 5 status 不變；drift 測試仍綠
+- Commit 2 → 只是在 event spec 上加 FutureOnly bit；無消費者讀取 → 所有行為不變
+- Commit 3 → CheckHooks 行為變，但只影響 `codex/hooks_test.go` 與新增 CH1-CH5
+- Commit 4 → D5 新增；既有 D1/D2/D3/D4 + fixtures 不變
+- Commit 5/6/7 → opencode package 內部
+- **每一 commit 後全套 go test 綠**
 
 ## 4. 實作檔案預估
 
 | 檔案 | 動作 | 預估行數 |
 |---|---|---|
 | `internal/agent/provider.go` | +`FutureOnly bool` 欄位 + 註解 | +8 |
-| `internal/agent/supported_statuses.go` | skip FutureOnly | +3 |
-| `internal/agent/supported_statuses_test.go` | +S1/S2/S3 | +40 |
+| `internal/agent/supported_statuses_test.go` 或 `provider_test.go` | +F1/F2 | +25 |
 | `internal/agent/codex/events.go` | 6 event 加 `FutureOnly: true` | +6 |
 | `internal/agent/codex/events_test.go` | +CE1/CE2 | +40 |
-| `internal/agent/codex/hooks.go` | CheckHooks FutureOnly 分支 | +15 |
-| `internal/agent/codex/hooks_test.go` | +CH1/CH2/CH3/CH4 | +90 |
-| `internal/agent/codex/provider_test.go` | 改 supported 斷言（5→2） | ~5 |
-| `internal/agent/opencode/plugin_template.go` | +`extractEmittedEvents` + `validateSpecsCoverEmitted` + render panic | +35 |
-| `internal/agent/opencode/plugin_template_test.go` | +PT1/PT2/PT3 | +60 |
-| `internal/agent/opencode/hooks.go` | CheckHooks per-event emit check | +20 |
-| `internal/agent/opencode/hooks_test.go` | +OH1/OH2/OH3 | +70 |
-| `internal/agent/drift_test.go` | +D5/D6 + D3/D4 FutureOnly skip + fixture 精修 | +60 |
-| `docs/specs/2026-04-23-hook-events-fix-plan.md` | 本檔 | +300 |
-| **合計** | | **~760 行**（含 plan 文件） |
+| `internal/agent/codex/hooks.go` | CheckHooks 三態決策 | +25 |
+| `internal/agent/codex/hooks_test.go` | +CH1-CH5 | +120 |
+| `internal/agent/opencode/plugin_template.go` | +`extractEmittedEvents` + `validateSpecsCoverEmitted` + render panic | +40 |
+| `internal/agent/opencode/plugin_template_test.go` | +PT1-PT5 | +80 |
+| `internal/agent/opencode/hooks.go` | CheckHooks per-event emit + unexpected defense | +25 |
+| `internal/agent/opencode/hooks_test.go` | +OH1-OH4 | +90 |
+| `internal/agent/drift_test.go` | +D5（無 fixture 刪除、無 FutureOnly skip） | +45 |
+| `docs/specs/2026-04-23-hook-events-fix-plan.md` | 本檔 v2 | +400 |
+| **合計** | | **~900 行**（含 plan 文件） |
 
 ## 5. 不做項目清單（防自動擴展）
 
-以下衝動一律拒絕 — subagent 不得擴張：
+以下衝動一律拒絕：
 
-- **不探測 codex CLI 實際版本** — FutureOnly 是 build-time 靜態標記，非 runtime gate
-- **不引入 `/api/hooks/codex/capability` endpoint** — 宣告與檢測分離，Inspector 另行處理
-- **不重寫 opencode template 為完全 codegen** — 策略 A（保留固定 switch/case + 運行時檢查）即可
-- **不把 cc 任何 event 標為 FutureOnly** — cc 驗證過全部 9 個會 emit
-- **不改 `SpecStringSlice` 或其他宣告 helper**（若存在）— 不在本 PR scope
-- **不調整 `Coverage()` 簽名或回傳欄位** — Phase 0 契約不動
-- **不重命名任何既有測試** — 只加新 case 或微調（例 codex supported 斷言 status 列表）
-- **不改 SPA 任何檔案** — 本 PR 全 Go 側
-- **不 force push / rebase** — 分支已 push 11 commits + PR，保留全歷史
+- **不過濾 FutureOnly 於 `SupportedStatuses()` 或 `DeriveSupportedStatuses`** — v2 核心決定；F2 測試鎖定此契約
+- **不移除任何既有 fixture** — parser contract 必須持續測
+- **不新增「fixture 禁含 FutureOnly」測試** — v1 D6 移除
+- **不改 codex `provider_test.go` SupportedStatuses 斷言**（仍 5 status）
+- **不探測 codex CLI 版本** — FutureOnly 是 build-time 靜態標記
+- **不引入 `/api/hooks/codex/capability` endpoint**
+- **不重寫 opencode template 為完全 codegen**
+- **不把 cc 任何 event 標為 FutureOnly**
+- **不調整 `Coverage()` 簽名或回傳欄位**
+- **不改 SPA 任何檔案**
+- **不 force push / rebase** — 保留全歷史
 - **不合併 fix commits** — 分 7 commits 便於 reviewer 逐步追蹤
-- **不順手修其他 finding** — 四路 review 只有這 4 個 finding，不額外添加
+- **不順手修其他 finding** — 四路 review 只有這 4 個 finding
 
 ## 6. Subagent 開發指引
 
-- **cwd 強制前綴**：每個 Bash 指令以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-spec-guardrails && ` 開頭（依 `feedback_subagent_cwd_enforcement.md`）
+- **cwd 強制前綴**：每個 Bash 指令以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-spec-guardrails && ` 開頭
 - **分支**：已在 `worktree-lights-spec-guardrails`，不另切；**不 push**（主 session 負責）
 - **Commit message 格式**：Conventional Commits + 結尾 `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
-- **TDD 嚴格紅綠**：每 commit 內先寫測試跑紅再實作跑綠，不可批次寫完所有 test + 一次實作
-- **每 commit 完成後**：跑 `go build ./... && go test ./... && go vet ./...` 全綠才進下一個
-- **回報**：完成時給 commit hash 列表 + `git log --oneline -15` + 最終 `go test ./...` 完整輸出
-- **Codex sandbox 限制**：不需跑 SPA（本 PR 全 Go 側）— 但仍保留 `feedback_codex_sandbox_no_install.md` 準則以防 subagent 誤觸 spa
+- **TDD 嚴格紅綠**：每 commit 內先寫測試跑紅再實作跑綠；不可批次寫完所有 test + 一次實作
+- **每 commit 完成後**：跑 `go build ./... && go test ./... && go vet ./...` 全綠才進下一個；**不可中間紅燈**
+- **關鍵抽 helper 點**：
+  - codex `CheckHooks`：建議新增私有 `checkCodexEvent(spec HookEventSpec, rawEntries any) (HookEventInfo, issues []string, block bool)` helper 把三態判定抽出，避免 CheckHooks 變 60+ 行巨型函式
+  - opencode `CheckHooks`：`extractEmittedEvents` + `validateSpecsCoverEmitted` 都已是 helper
+- **回報**：完成時給 commit hash 列表 + `git log --oneline -15` + 最終 `go test ./...` 完整輸出 + `go vet ./...` 無 warning 確認
 
 ## 7. 驗收清單
 
-- [ ] 7 個 commits 符合上述 message 規範（Commit 8 可選）
+- [ ] 7 個 commits 符合上述 message 規範
 - [ ] `go build ./...` 綠
-- [ ] `go test ./...` 全綠（包含新增 S1-S3、CE1-CE2、CH1-CH4、PT1-PT3、OH1-OH3、D5-D6 共 16 個測試 case）
+- [ ] `go test ./...` 全綠（含 F1-F2 / CE1-CE2 / CH1-CH5 / D5 / PT1-PT5 / OH1-OH4 共 19 個新測試）
 - [ ] `go vet ./...` 無 warning
-- [ ] PR diff 只涉及 §4 表格列出的 13 個檔 + plan 文件，**其餘不得出現**
-- [ ] codex `SupportedStatuses()` 回傳 `[Idle, Running]`（2 個，非 5 個）
-- [ ] opencode `CheckHooks()` 對「手動改過、少一個 emit」的 plugin 正確標 `Installed=false` + issue
-- [ ] codex `CheckHooks()` 對「只安裝舊 3 event 的 legacy hooks.json」回 `allInstalled=true` 且 Issues 不含 FutureOnly event missing
-- [ ] drift test 對「若把 codex `Stop` 的 `EmitsStatus` 改為 `[Idle, Clear]`」應紅（per-event 強相等觸發）
+- [ ] PR diff 僅涉及 §4 表格列出的 12 個檔 + plan 文件，**其餘不得出現**
+- [ ] codex `SupportedStatuses()` 仍回傳 5 個 Status（不動）
+- [ ] codex `Events()` 中 6 個 FutureOnly event 的 bit 為 true，其餘 false
+- [ ] codex `CheckHooks()` 對 legacy 3-event hooks.json 回 `allInstalled=true` + Issues=[]
+- [ ] codex `CheckHooks()` 對「FutureOnly key 存在但 command 錯誤」回 `allInstalled=false` + warning issue
+- [ ] opencode `CheckHooks()` 對手改過、少 emit 的 plugin 正確標 `Installed=false` + issue
+- [ ] opencode `renderManagedPlugin` 對人為構造的不合法 specs/body 會 panic（僅在 mock 下 — 真 runtime 不 panic）
+- [ ] drift per-event 斷言（D5）對每個 provider/spec 覆蓋正確
 
 ## 8. 風險與緩解
 
 | 風險 | 機率 | 影響 | 緩解 |
 |---|---|---|---|
-| FutureOnly 語意誤解為「CLI 永不支援」 | 中 | 未來翻 false 時遺漏檢查 | 在 `HookEventSpec` struct 註解與 plan §1.1 顯式說明「build-time 信心不足」；留 TODO 於 codex events.go 指向未來 enable 路徑 |
-| `extractEmittedEvents` regex 遇到 JS 註解內 `emit('XXX')` 誤判 | 低 | CheckHooks 假陽性 | regex 加 word boundary；template 內不寫註解帶 emit 字串；PT1 測試覆蓋一個 edge case（如 body 含 `// emit('Foo')` 註解，確認不被抽出） |
-| opencode CheckHooks 因檔案 IO error 在 race 下假綠 | 低 | 罕見 race 掩蓋 | 維持既有 `os.ReadFile` 錯誤處理，不動；此 PR 不引入新 race |
-| codex provider_test supported 斷言從 5→2 可能讓 reviewer 誤以為退步 | 中 | review 釋疑成本 | PR description 顯式說明：「2 是當前 CLI 真實可 emit 集合；FutureOnly 6 event 翻 false 後自然恢復 5」 |
-| drift fixture 移除 codex 6 個 FutureOnly fixture 後，日後翻 false 時 fixture 需補回 | 低 | 後續 phase 會遇 | commit 4 在 drift_test.go 頂端留註解：「FutureOnly event fixture 未列出；翻 false 時補回 §1.1 曾列出的對應 DeriveStatus case」 |
-| 某 finding 在實作中發現新子問題 | 中 | scope 膨脹 | 遵 §5 不做項目；發現新問題開 gh issue 延後，不納入本 PR |
+| FutureOnly 語意仍可能被後續開發者誤用為 SupportedStatuses 過濾 | 中 | 未來 regression | F2 測試鎖定契約；`provider.go` FutureOnly 欄位註解明寫「不影響 DeriveStatus 能力宣告」 |
+| CheckHooks 三態決策複雜度累積 | 低 | 新增 FutureOnly 時 regression | 抽 `checkCodexEvent` helper；CH1-CH5 覆蓋所有交叉組合 |
+| `extractEmittedEvents` regex 遇到 JS 註解誤判 | 低 | CheckHooks 假陽性 | PT1 測 edge case（註解、插值、單雙引號） |
+| opencode render panic 在 production 路徑誤觸 | 低 | Install 失敗 | template 是 const-like 字串；panic 只在 specs/template 不同步時發生；PT5 常態 smoke test |
+| drift fixtures 保留後，若 FutureOnly event 在 DeriveStatus 邏輯日後被刪除但 fixture 沒刪 | 低 | 測試失敗警告到位 | D5 per-event 強相等會紅，指向確切 spec/event；是有益的警告 |
+| commit 4 D5 對既有 spec/fixture 跑起來紅（有過度宣告） | 中 | 需額外修 spec 或 fixture | 先跑一次 D5 preview；若紅先修 spec 再加 D5 斷言 |
 
 ## 9. 第 3 輪 Codex Review 預期 focus
 
-**Focus text 骨架**（實際派發時可微調，確保 codex 能讀到「本輪修哪些」）：
+**Focus text 骨架**（派發時套 4 findings + v2 設計決策）：
 
-- 本輪修復 PR #616 第 2 輪 3 路 review 的 4 findings：
-  1. codex CheckHooks 對 3-event legacy 使用者誤判（透過 FutureOnly 自然處理）
-  2. opencode renderManagedPlugin 與 CheckHooks 的假綠燈（透過 extractEmittedEvents + validate）
-  3. codex future-only events 混入 current capability（透過 FutureOnly 欄位 + SupportedStatuses skip）
-  4. drift test per-event 盲點（透過 TestDriftPerEventEmitsStatusMatch + FutureOnly skip）
+- 本輪修復 PR #616 第 2 輪 3 路 review 的 4 findings（+ plan review 4 points）：
+  1. codex CheckHooks 對 3-event legacy 使用者誤判（透過 FutureOnly + 三態判定）
+  2. opencode renderManagedPlugin 與 CheckHooks 的假綠燈（透過 extractEmittedEvents + validate + CheckHooks per-event）
+  3. codex future-only events 混入 current capability（透過 FutureOnly bit，**但不影響 SupportedStatuses**；留給 Inspector UI 自行判讀）
+  4. drift test per-event 盲點（透過 D5 per-event 強相等）
 - 請驗收：
-  - 攻擊：FutureOnly 翻譯正確（邊界 / race / 誤用）；extractEmittedEvents regex 假陽性
-  - 防守：SSoT 收斂是否真成立（opencode template + specs + CheckHooks 三向一致）；codex FutureOnly 語意是否對外清楚
-  - 體質：fix plan 拆的 7 commits 是否職責清晰；drift_test 新增 D5/D6 是否過大（>250 行考慮拆）；hooks.go 是否應該把 FutureOnly check 抽 helper
+  - 攻擊：FutureOnly 三態決策的邊界（absent/broken/valid × required/optional）；extractEmittedEvents regex 假陽性；opencode render panic 是否能在 release path 誤觸
+  - 防守：SSoT 主張是否仍成立（FutureOnly 不削減 SupportedStatuses，那 Inspector 要怎麼知道 codex 目前只能 emit 哪些？— plan 有無明確交代 future 路徑）
+  - 體質：fix plan 拆的 7 commits 是否職責清晰；drift_test 新 D5 是否過大；hooks.go `checkCodexEvent` helper 是否正確抽出三態判定
 
-**第 3 輪仍需 4 路**（標準 + 攻擊 + 防守 + 體質），不縮減 — 修復後再驗 SSoT 主張確實落地。
+第 3 輪仍需 4 路（標準 + 攻擊 + 防守 + 體質）。

--- a/docs/specs/2026-04-23-hook-events-fix-plan.md
+++ b/docs/specs/2026-04-23-hook-events-fix-plan.md
@@ -1,16 +1,16 @@
 # Hook Events PR #616 Fix Plan
 
 - **Date**: 2026-04-23
-- **Version**: v2（依 plan codex review `review-mobsgj0y-rgwbdv` 四點 finding 全採納重寫）
+- **Version**: v3（依 plan codex review `review-mobsgj0y-rgwbdv`(v1 判) + `review-mobsrf0q-47acc5`(v2 判) 共 7 點 finding 全採納重寫）
 - **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §2.4（架構護欄）
 - **Parent plan**: `docs/specs/2026-04-23-hook-events-declaration-plan.md`（既有，11 commits merged 進本分支）
 - **Worktree**: `lights-spec-guardrails`（branch `worktree-lights-spec-guardrails`，PR #616）
 - **依賴**: Phase 1 merged at alpha.215（§5 L2 對齊完成）；Events() SSoT 已在本分支建立
 - **範圍**: 修四路 codex review 攻擊/防守/體質視角提出的 4 個 findings（2 HIGH + 2 MED），讓 Events() SSoT 主張在 codex 與 opencode 端真正成立，且不因升級誤判既有安裝
 
-## 0. v1 → v2 重寫重點
+## 0. 迭代歷史 — v1 → v2 → v3
 
-Plan v1 被 codex review `review-mobsgj0y-rgwbdv` 判 needs-attention（2 HIGH + 2 MED finding）。v2 全數採納：
+### v1 → v2（codex review `review-mobsgj0y-rgwbdv` 4 findings 採納）
 
 | v1 設計 | v2 更正 | 依據 |
 |---|---|---|
@@ -20,6 +20,16 @@ Plan v1 被 codex review `review-mobsgj0y-rgwbdv` 判 needs-attention（2 HIGH +
 | Commit 順序: SupportedStatuses 收斂（2）→ drift 升級（4），中間 commit 紅 | drift 測試升級放在 SupportedStatuses 語意切換之前；**每 commit 真正全綠** | 自相矛盾：原 plan 同時要求每 commit 全綠 + 中間依賴後續 commit 補洞 |
 
 核心哲學修正：**`FutureOnly` 只影響 installer/checker 面向，不影響 DeriveStatus 能力宣告面向**。兩個面向獨立。
+
+### v2 → v3（codex review `review-mobsrf0q-47acc5` 3 findings 採納）
+
+| v2 設計 | v3 更正 | 依據 |
+|---|---|---|
+| State A 定義：「key 不存在 **或 entries 為空**」 | State A 嚴格限為「key 不存在」；entries 空/型別錯/無合法 pdx command → State B (broken) | `mergeCodexHooks` remove 路徑會留下 `hooks[event]=[]`；若歸 absent 則 FutureOnly 會假綠 |
+| opencode CheckHooks 用 `extractEmittedEvents` regex + per-event Installed map | **byte-exact template 比對**：從檔案抽 pdxPath，重新 render 後與檔案 byte-equal 比對；不一致 → 整個 unmanaged | regex 會被註解、字串常量、dead code 騙過；plugin 是 pdx 全權受管的原子檔，不應支援 per-event 健康判定 |
+| Commit 2 只在 `codexEventSpecs` 標 FutureOnly，宣稱無消費者讀取 → 綠 | Commit 2 同時更新三家 `Events()` defensive copy 帶上 `FutureOnly: spec.FutureOnly`；否則 CE1/CE2 在 commit 2 紅 | 既有 `Events()` 是手寫 field-by-field copy，不會自動帶新欄位 |
+
+核心哲學修正：**opencode plugin 是 atomic managed file，非 per-event 配置**。byte-exact 比對符合 plugin 實際語意，且消除整類 false-green 路徑。
 
 ## 1. 契約鎖定
 
@@ -81,9 +91,9 @@ codex `SupportedStatuses()` **維持 5 status**（Idle/Running/Waiting/Error/Cle
 `internal/agent/codex/hooks.go` `CheckHooks` 核心改動：對每個 event 依 FutureOnly 與現況分三態處理。
 
 對每個 event，讀 `hooks.json` 對應 key 得到狀態：
-- **State A: absent** — hooks.json 無此 event key（或 entries 為空）
-- **State B: present-but-broken** — key 存在但找不到正確 pdx command（例：legacy direct-entry、command 不正確、或已被人為改壞）
-- **State C: valid** — key 存在且 pdx command 正確
+- **State A: absent** — hooks.json **無此 event key**（`hooks` map 中該 key 完全不存在）。**僅此一情形**
+- **State B: present-but-broken** — key 存在但任一條件不成立：entries 為空陣列 `[]`、entries 型別非陣列、legacy direct-entry 格式、command 找不到、command 不含合法 pdx path
+- **State C: valid** — key 存在、entries 為 matcher-group 陣列、至少一組有合法 pdx command
 
 決策表：
 
@@ -101,12 +111,16 @@ codex `SupportedStatuses()` **維持 5 status**（Idle/Running/Waiting/Error/Cle
 - **FutureOnly present-but-broken** → 已配置卻壞掉，是確實的 bug，必須顯化並 block（避免「綠燈但實際壞」）
 - **FutureOnly valid** → 已升級完成，與 non-FutureOnly 同等認定
 
-實作：遍歷 `p.Events()`（取得含 FutureOnly bit 的 spec slice），而非 `p.eventNames()`。對每個 spec：
-1. 查 hooks[spec.Name] 現況
-2. `hasLegacyPdxDirectCodexEntry` → broken 分支
-3. `findPdxCommandInCodex` → valid 分支（有 command）或 broken 分支（key 存在但無 pdx command）
-4. key 不存在 → absent 分支
-5. 依 spec.FutureOnly 與 state 查表套用決策
+實作：遍歷 `p.Events()`（取得含 FutureOnly bit 的 spec slice）。對每個 spec：
+
+1. **Absent check**: `_, keyExists := hooks[spec.Name]` — 若 `keyExists == false` → State A，查表決策
+2. Key 存在進一步判斷：
+   - `hasLegacyPdxDirectCodexEntry(entries)` → State B (broken)
+   - `findPdxCommandInCodex(entries)` → 空字串 → State B (broken)
+   - command 非空且為 pdx → State C (valid)
+3. 依 spec.FutureOnly 與 state 查表套用決策
+
+**關鍵**：**必須用 `keyExists`（map 的雙回傳值）判斷 absent**，不能用「entries 是否為空」— 空陣列 `[]` 是可落地狀態（`mergeCodexHooks` 移除路徑會留下），歸 broken 方能讓 FutureOnly 顯化。
 
 **3-event legacy 使用者**（升級後）：SessionStart/UserPromptSubmit/Stop = valid（state C），6 個 FutureOnly = absent（state A）→ Issues 空、allInstalled=true。
 
@@ -114,36 +128,50 @@ codex `SupportedStatuses()` **維持 5 status**（Idle/Running/Waiting/Error/Cle
 
 **部分損壞**：若有 FutureOnly key 被手動改壞 → `Issues` 顯化 warning + allInstalled=false（避免假綠燈）。
 
-### 1.5 opencode renderManagedPlugin 從 Events 生成
+### 1.5 opencode renderManagedPlugin — 契約即 SSoT（render-time validation 擋漂移）
 
 Finding #2（PR #616 第 2 輪防守 HIGH + 體質 MED）核心：不讓 template 與 `opencodeEventSpecs` 成為兩份平行 SSoT。
 
-策略 A（選用）：template 保留固定 switch/case 結構，**但渲染時驗證** template 實際 emit 的 pdx event set ⊆ `opencodeEventSpecs.Name` 集合。
+策略：template 保留固定 switch/case 結構；**render 時以 `validateSpecsCoverEmitted` 強制檢查** template emit set == `opencodeEventSpecs.Name` set。build-time 契約檢查；runtime 不經這條路徑。
 
 具體：
 
-- `renderManagedPlugin(pdxPath string) string` 維持原簽名；函式尾部呼叫 `validateSpecsCoverEmitted(body, opencodeEventSpecs)` — 若 template 字串 emit 的 event name 不在 specs 內 → `panic("contract violation: template emits undeclared event: ...")` 
-- `extractEmittedEvents(body string) []string` — 用 regex `emit\(['"](\w+)['"]` 從 body 抽出 emit 的 event names
+- `renderManagedPlugin(pdxPath string) string` 維持原簽名；函式尾部呼叫 `validateSpecsCoverEmitted(body, opencodeEventSpecs)` — template 字串 emit 的 event name 與 specs 不等 → `panic("contract violation: template emits: <A,B>; specs declare: <C,D>")` 
+- `extractEmittedEvents(body string) []string` — regex `emit\(['"](\w+)['"]` 從 body 抽出 emit 的 event names（**只用於 render-time contract check，不用於 CheckHooks 健康判定**）
 - `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error` — 強等：`set(extractEmittedEvents(body)) == set(specs.Name)`；任何一側 superset 都回 error
 
-**為什麼 panic 而非 error**：render 函式原簽名回 string，加 error 會改呼叫點。panic 只會在 build 測試階段觸發（因為 template 是 const-like 字串），release path 不會 runtime 爆。
+**為什麼 render panic 而非 error**：render 函式原簽名回 string，加 error 改呼叫點。panic 只在 build 測試階段觸發（因為 template 是 const-like），release path 不爆。
 
-**配合測試**（§2.3 PT1-PT3）驗證：
-- PT1：`extractEmittedEvents` 正確從 sample body 抽出 event names
-- PT2：`renderManagedPlugin("/p")` 產出的 body emit set == `opencodeEventSpecs.Name` set
-- PT3：用 synthetic specs（例移除 `Stop`）餵 `validateSpecsCoverEmitted` → return error（不經 renderManagedPlugin，避免要 mock package var）
+**`extractEmittedEvents` 的角色限制（v3 收斂）**：**僅用於 build-time 契約驗證**。任何 runtime 健康檢查（CheckHooks）都不讀此 regex — 改用 §1.6 的 byte-exact 比對。regex 對註解、字串常量、dead code、人為改壞的 JS 無法區分「可執行 emit」與「看起來像 emit 的文字」。
 
-### 1.6 opencode CheckHooks per-event emit 驗證
+**配合測試**（§2.3 PT1-PT5）驗證。
 
-`internal/agent/opencode/hooks.go` `CheckHooks` 對齊 §1.5 extraction 成為 per-event 驗證：
+### 1.6 opencode CheckHooks — byte-exact template 比對
 
-1. 讀檔、驗 marker（不變）
-2. 呼叫 `extractEmittedEvents(string(data))` 取 emit set
-3. 對每個 `opencodeEventSpecs` event：
-   - event name ∈ emit set → `Installed=true, Command=pluginPath`
-   - event name ∉ emit set → `Installed=false`，push `<name> emit missing in plugin` 
-4. opencode 當前無 FutureOnly event（§1.3），`allInstalled = (全部 events Installed=true)`
-5. 若 emit set 含有 specs 沒有的 event name（template 動到但 specs 沒補） → 加 issue `unexpected emit '<name>' not in catalog` + 不影響 allInstalled（此路徑 render 階段已 panic 擋掉，但 CheckHooks 對人為改動的 plugin 檔案仍做防禦）
+`internal/agent/opencode/hooks.go` `CheckHooks` 策略（v3 重新設計）：
+
+**Plugin 是 pdx 全權受管的原子 artifact，非 per-event 配置檔**。CheckHooks 採「template body byte-exact」語意：
+
+1. 讀檔（不變）
+2. 驗 marker（不變）
+3. 從檔案抽 `pdxPath`（template 內有 `const pdxPath = "..."` 可用 regex `const pdxPath = "([^"]+)"` 抽出）
+4. 以抽出的 pdxPath 重新 render template → `expected`
+5. **byte-exact 比較** `data == expected`：
+   - 相等 → `Installed=true`；每個 `opencodeEventSpecs` event 的 `events[name] = {Installed: true, Command: pluginPath}`；`Issues=[]`
+   - 不等 → `Installed=false`；issue 含 `plugin body differs from managed template (run reinstall)`；**所有 event `Installed=false`**（因為整份 plugin 視為不可信）
+6. 若 marker 不存在 → 既有 unmanaged 行為保留
+
+**新 helper**：`extractPdxPath(body string) (string, bool)` — 從受管 body 抽 pdxPath。regex `const pdxPath = "([^"]+)"`（單一行，單一出現位置）。若抽不到 → 當成 byte-mismatch。
+
+**為什麼不 per-event**：opencode plugin 是單檔 JavaScript，switch/case 結構內任何改動都可能影響其他 event（例 shared state `activeSubagents`、`suppressIdleForSession`）。將 plugin 視為「有 marker + byte-equal」二元狀態符合其語意：要嘛 pdx 受管、要嘛使用者自行負責。
+
+**效果**：完全消除 regex-based 假綠燈：
+- 註解內 `emit('Fake')` → 改動 → byte-mismatch → unmanaged
+- dead code 分支 → 改動 → byte-mismatch
+- 人為改 `switch` 邏輯但保留 emit string → byte-mismatch
+- 完全合法 pdx 受管 body → byte-equal → all installed
+
+**測試簡化**（§2.4 OH1-OH3）— v2 的 OH4 (unexpected emit) 不再需要（byte-exact 覆蓋全部異動 case）。
 
 ### 1.7 drift test per-event 強相等 + parser contract 保留
 
@@ -218,31 +246,34 @@ F2 是防呆測試，鎖定「DeriveSupportedStatuses 不因 FutureOnly 過濾�
 | CH3 | `TestCheckHooks_RequiredEventMissing_Blocks` | 只有 2 個 required event valid（缺 SessionStart） | `allInstalled=false`、Issues 含 `SessionStart hook not installed` |
 | CH4 | `TestCheckHooks_FutureOnlyBroken_WarnsAndBlocks` | hooks.json 3 required valid + 1 FutureOnly（Notification）key 存在但 command 錯誤 | `allInstalled=false`、Issues 含 `Notification hook: pdx command malformed...`、Notification Installed=false |
 | CH5 | `TestCheckHooks_FutureOnlyAbsent_DoesNotBlock` | hooks.json 3 required valid + 3 FutureOnly absent + 3 FutureOnly valid | `allInstalled=true`、Issues=[]、3 absent entries Installed=false、3 valid entries Installed=true |
+| CH6 | `TestCheckHooks_FutureOnlyEmptyArray_ClassifiesAsBroken` | hooks.json 3 required valid + 1 FutureOnly key 存在但 entries `[]`（空陣列） | `allInstalled=false`、Issues 含 `<name> hook: pdx command malformed...`、該 event `Installed=false`（不能因空陣列歸 absent 假綠） |
 
-### 2.3 opencode template 與 CheckHooks 對齊
+### 2.3 opencode template render-time contract validation
 
-`internal/agent/opencode/plugin_template_test.go` 新增：
+`internal/agent/opencode/plugin_template_test.go` 新增（只測 build-time 契約，不測 runtime 健康）：
 
 | # | 名稱 | 斷言 |
 |---|---|---|
-| PT1 | `TestExtractEmittedEvents` | helper 從 sample body 正確抽出 event names（含 regex corner：字串插值前後空白、單引號 vs 雙引號、兩個 emit 同行） |
+| PT1 | `TestExtractEmittedEvents` | helper 從 sample body 正確抽出 event names（含 regex corner：單引號、雙引號、多行、插值） |
 | PT2 | `TestValidateSpecsCoverEmitted_Equal` | `validateSpecsCoverEmitted(body, opencodeEventSpecs)` 對真 template body 回 nil |
 | PT3 | `TestValidateSpecsCoverEmitted_EmitNotInSpec` | synthetic body 含 `emit('Fake')` + specs 無 Fake → error |
 | PT4 | `TestValidateSpecsCoverEmitted_SpecNotInEmit` | synthetic body 缺某 event + specs 含它 → error |
-| PT5 | `TestRenderManagedPlugin_ProducesValidBody` | `renderManagedPlugin("/p")` 不 panic；結果 body 含 marker + 8 個 event emit |
+| PT5 | `TestRenderManagedPlugin_ProducesValidBody` | `renderManagedPlugin("/p")` 不 panic；結果 body 含 marker + 對齊 specs |
+| PT6 | `TestExtractPdxPath_RoundtripFromRender` | `renderManagedPlugin(p)` 後 `extractPdxPath(body)` 回 `p`（byte-exact 比對基石） |
 
-### 2.4 opencode hooks CheckHooks per-event emit
+### 2.4 opencode hooks CheckHooks — byte-exact template 比對
 
-`internal/agent/opencode/hooks_test.go` 新增：
+`internal/agent/opencode/hooks_test.go` 新增（v3 簡化：plugin 是 atomic managed file）：
 
 | # | 名稱 | 斷言 |
 |---|---|---|
-| OH1 | `TestCheckHooks_ValidPlugin_PerEventInstalled` | 用 `writeManagedPlugin` 寫合法 template → CheckHooks 每個 event `Installed=true`、Issues=[] |
-| OH2 | `TestCheckHooks_HandEditedPlugin_EventMissing` | 寫一份含 marker 但移除某 `emit('Stop',` 的 body → CheckHooks 該 event `Installed=false`、Issues 含 `Stop emit missing in plugin` |
-| OH3 | `TestCheckHooks_UnmanagedPlugin_ReturnsUnmanaged` | 既有行為保留：不帶 marker → Installed=false + Issues |
-| OH4 | `TestCheckHooks_UnexpectedEmitInPlugin_Flagged` | 寫一份含 marker + 額外 `emit('Fake', ...)` 的 body → Issues 含 `unexpected emit 'Fake' not in catalog`、allInstalled 不因此 false（現有 8 個 event 仍 valid） |
+| OH1 | `TestCheckHooks_ValidPlugin_AllInstalled` | 用 `writeManagedPlugin` 寫合法 template → CheckHooks 所有 event `Installed=true`、Issues=[] |
+| OH2 | `TestCheckHooks_HandEditedPlugin_Unmanaged` | 寫一份含 marker 但改動一個字（例移除某 `emit('Stop',`） → CheckHooks **整個 plugin** `Installed=false`、Issues 含 `plugin body differs from managed template`、**所有 event `Installed=false`** |
+| OH3 | `TestCheckHooks_UnmanagedPlugin_NoMarker` | 既有行為保留：不帶 marker → Installed=false + Issues `plugin file exists but is unmanaged` |
+| OH4 | `TestCheckHooks_CommentEditInPlugin_DetectedViaByteCompare` | 寫合法 template 後**只加一行註解** → byte-mismatch → Installed=false（驗證 regex 假綠盲點已由 byte-exact 覆蓋） |
+| OH5 | `TestCheckHooks_ExtractPdxPathFails_FallsBackToUnmanaged` | 寫檔案含 marker 但 `const pdxPath` 被改壞（regex 抽不到）→ CheckHooks 不 panic、回 Installed=false + issue |
 
-OH4 測 §1.6 對「template 動到、specs 沒補」的防禦路徑。
+**刪除**：v2 OH4 (per-event unexpected emit detection) — byte-exact 已天然覆蓋。
 
 ### 2.5 drift test per-event 強相等
 
@@ -265,23 +296,31 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 - fixtures 不移除 → parser drift 不退化
 - CheckHooks 內部行為變化只影響 codex/hooks_test.go 本身
 
-### Commit 1 — `feat(agent): add FutureOnly bit to HookEventSpec`
-- 紅：寫 F1 + F2 → 失敗（F1 編譯錯 / F2 尚未驗證）
-- 綠：`provider.go` 加 `FutureOnly bool` 欄位 + 註解（§1.1）；`DeriveSupportedStatuses` **不動**；F1/F2 綠
-- 檢驗：cc / codex / opencode `Events()` 的 defensive copy 需保留 FutureOnly bit（目前 three-field literal copy 自動涵蓋 struct 所有欄位 — 確認一下）
+### Commit 1 — `feat(agent): add FutureOnly bit to HookEventSpec and defensive copies`
+- 紅：寫 F1 + F2 + CE2 的 defensive copy 預斷言 → 失敗
+- 綠：
+  1. `provider.go` 加 `FutureOnly bool` 欄位 + 註解（§1.1）
+  2. `DeriveSupportedStatuses` **不動**
+  3. **三家 `Events()` defensive copy 同步加 `FutureOnly: spec.FutureOnly`**：
+     - `cc/events.go` Events()
+     - `codex/events.go` Events()
+     - `opencode/events.go` Events()
+  4. F1/F2 綠；defensive copy 預檢查：既有測試（若有直接讀 `Events()` 的）不受影響（因為此 commit 尚未標任何 FutureOnly=true，所有 bit 仍預設 false）
 - 跑 `go test ./internal/agent/...` 全綠
 
+**為什麼 Commit 1 就改三家 `Events()`**：v2 Commit 2 宣稱「只標 `codexEventSpecs` 就綠」是錯的 — `Events()` 是手寫 field copy，若不先補 FutureOnly 傳遞，Commit 2 的 CE1/CE2 會直接紅（spec 欄位有但 copy 沒帶 → 測試測到的是 copy 後的 struct，會看到 false）。Commit 1 一併處理。
+
 ### Commit 2 — `feat(agent/codex): mark 6 future-only events`
-- 紅：寫 CE1 → 失敗（欄位未標 true）
-- 綠：`codex/events.go` 把 SubagentStart / SubagentStop / StopFailure / Notification / PermissionRequest / SessionEnd 六個 event 加 `FutureOnly: true`
-- 補：CE2（defensive copy 保留 FutureOnly bit）
-- 跑 `go test ./internal/agent/codex/...` 綠（現有 `TestCodexSupportedStatuses` 不動，仍 5 status — v2 下不需改）
-- 跑 `go test ./internal/agent/...` 全綠（drift 三向相等仍成立）
+- 紅：寫 CE1 → 失敗（6 個 event 尚未設 `FutureOnly: true`）
+- 綠：`codex/events.go` 把 SubagentStart / SubagentStop / StopFailure / Notification / PermissionRequest / SessionEnd 六個加 `FutureOnly: true`
+- 補：CE2 完整實作（defensive copy mutate 後獨立性；依賴 Commit 1 已修好的 copy）
+- 跑 `go test ./internal/agent/codex/...` 綠
+- 跑 `go test ./internal/agent/...` 全綠（drift 三向相等仍成立：SupportedStatuses 不讀 FutureOnly）
 
 ### Commit 3 — `feat(agent/codex): three-state CheckHooks with FutureOnly awareness`
-- 紅：寫 CH1-CH5 → 失敗（CheckHooks 尚未 aware）
-- 綠：`codex/hooks.go` 改 CheckHooks 遍歷用 `p.Events()`（取得 FutureOnly bit），決策表依 §1.4 實作三態
-- 留意：`hasLegacyPdxDirectCodexEntry` / `findPdxCommandInCodex` 已區分 broken state，主要改動是「broken + FutureOnly → warning issue + block」（以前並無 FutureOnly 概念，所有 broken 都 block）
+- 紅：寫 CH1-CH6 → 失敗（CheckHooks 尚未 aware）
+- 綠：`codex/hooks.go` 改 CheckHooks 遍歷用 `p.Events()`（取得 FutureOnly bit），決策表依 §1.4 三態（**嚴格以 `_, keyExists := hooks[spec.Name]` 判 absent；entries 空陣列歸 broken**）
+- 建議抽 helper `checkCodexEvent(spec HookEventSpec, rawEntries any, keyExists bool) (HookEventInfo, []string, bool /*blocks*/)` 便於單點測試（CH1-CH6 可呼叫或仍走 CheckHooks 整體 — subagent 依測試可讀性擇一）
 - 跑 `go test ./internal/agent/codex/...` 綠
 
 ### Commit 4 — `test(agent): per-event drift assertion`
@@ -289,32 +328,40 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 - 綠：若紅，修 spec 或 fixture 對齊（最可能 case：cc 的 `Notification` EmitsStatus `[Waiting, Idle]` 對 fixtures 的 4 筆全綠 — 應直接綠）
 - 跑 `go test ./internal/agent/...` 綠
 
-### Commit 5 — `refactor(agent/opencode): extract emitted events helper`
-- 紅：寫 PT1 → 失敗（helper 不存在）
-- 綠：`plugin_template.go` 加 `extractEmittedEvents(body string) []string`
+### Commit 5 — `refactor(agent/opencode): extract emitted events + pdx path helpers`
+- 紅：寫 PT1 + PT6 → 失敗（helpers 不存在）
+- 綠：`plugin_template.go` 加
+  - `extractEmittedEvents(body string) []string`（regex `emit\(['"](\w+)['"]`）
+  - `extractPdxPath(body string) (string, bool)`（regex `const pdxPath = "([^"]+)"`）
 - 跑 `go test ./internal/agent/opencode/...` 綠
 
-### Commit 6 — `feat(agent/opencode): validate template emits declared events`
+### Commit 6 — `feat(agent/opencode): render-time contract validation`
 - 紅：寫 PT2 + PT3 + PT4 + PT5 → 失敗
 - 綠：加 `validateSpecsCoverEmitted(body string, specs []HookEventSpec) error`；`renderManagedPlugin` 結尾呼叫 validate，mismatch panic
-- PT5 確認正常 template 不 panic
+- PT5 確認常態 template 不 panic
 - 跑 `go test ./internal/agent/opencode/...` 綠
 
-### Commit 7 — `feat(agent/opencode): CheckHooks verifies per-event emit`
-- 紅：寫 OH1 + OH2 + OH3 + OH4 → 失敗（CheckHooks 仍假綠回填）
-- 綠：`opencode/hooks.go` CheckHooks 依 §1.6 改寫：讀檔 → extract → per-event 檢查 + 超集防禦
+### Commit 7 — `feat(agent/opencode): byte-exact CheckHooks against managed template`
+- 紅：寫 OH1 + OH2 + OH3 + OH4 + OH5 → 失敗（CheckHooks 仍用舊邏輯）
+- 綠：`opencode/hooks.go` CheckHooks 依 §1.6 改寫：
+  1. 讀檔 + 驗 marker（既有）
+  2. `extractPdxPath(body)` — 若抽不到 → unmanaged 風格 issue
+  3. `expected := renderManagedPlugin(pdxPath)`
+  4. `bytes.Equal(data, []byte(expected))` → 所有 event Installed=true 或全部 Installed=false + `plugin body differs from managed template` issue
+- 刪除舊 per-event extraction 用於 CheckHooks 的程式路徑（若 Commit 5 有順手掛到 CheckHooks，在此 commit 明確清除）
 - 跑 `go test ./internal/agent/opencode/...` 綠
 
 ### Commit 8 — `docs: hook events fix plan retrospective（可選）`
 若 §3 順序與實際有偏差，補歷史註記。
 
-**Commit 綠燈分析**：
-- Commit 1 → DeriveSupportedStatuses 不變；codex SupportedStatuses 5 status 不變；drift 測試仍綠
-- Commit 2 → 只是在 event spec 上加 FutureOnly bit；無消費者讀取 → 所有行為不變
-- Commit 3 → CheckHooks 行為變，但只影響 `codex/hooks_test.go` 與新增 CH1-CH5
+**Commit 綠燈分析**（v3 收斂）：
+- Commit 1 → 加 FutureOnly 欄位 + 三家 `Events()` defensive copy 同步；DeriveSupportedStatuses 不變；codex SupportedStatuses 5 status 不變；drift 測試仍綠。F1/F2 綠
+- Commit 2 → 6 個 codex event 標 FutureOnly=true；無消費者讀取（CheckHooks 要等 Commit 3、drift 不過濾、SupportedStatuses 不讀）→ 所有既有測試行為不變；CE1/CE2 綠（Commit 1 已補好 defensive copy 傳遞）
+- Commit 3 → CheckHooks 三態行為變，但只影響 `codex/hooks_test.go`；新增 CH1-CH6 綠
 - Commit 4 → D5 新增；既有 D1/D2/D3/D4 + fixtures 不變
-- Commit 5/6/7 → opencode package 內部
-- **每一 commit 後全套 go test 綠**
+- Commit 5/6 → opencode helpers + render-time validation；runtime 路徑不變
+- Commit 7 → opencode CheckHooks 替換；OH1-OH5 綠
+- **每一 commit 後全套 go test 綠**（v3 已驗證依賴鏈封閉）
 
 ## 4. 實作檔案預估
 
@@ -322,17 +369,19 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 |---|---|---|
 | `internal/agent/provider.go` | +`FutureOnly bool` 欄位 + 註解 | +8 |
 | `internal/agent/supported_statuses_test.go` 或 `provider_test.go` | +F1/F2 | +25 |
-| `internal/agent/codex/events.go` | 6 event 加 `FutureOnly: true` | +6 |
+| `internal/agent/cc/events.go` | Events() defensive copy 加 `FutureOnly: spec.FutureOnly` | +1 |
+| `internal/agent/codex/events.go` | 6 event 加 `FutureOnly: true` + Events() defensive copy 同步 | +7 |
 | `internal/agent/codex/events_test.go` | +CE1/CE2 | +40 |
-| `internal/agent/codex/hooks.go` | CheckHooks 三態決策 | +25 |
-| `internal/agent/codex/hooks_test.go` | +CH1-CH5 | +120 |
-| `internal/agent/opencode/plugin_template.go` | +`extractEmittedEvents` + `validateSpecsCoverEmitted` + render panic | +40 |
-| `internal/agent/opencode/plugin_template_test.go` | +PT1-PT5 | +80 |
-| `internal/agent/opencode/hooks.go` | CheckHooks per-event emit + unexpected defense | +25 |
-| `internal/agent/opencode/hooks_test.go` | +OH1-OH4 | +90 |
+| `internal/agent/codex/hooks.go` | CheckHooks 三態決策 + `checkCodexEvent` helper | +40 |
+| `internal/agent/codex/hooks_test.go` | +CH1-CH6 | +140 |
+| `internal/agent/opencode/events.go` | Events() defensive copy 加 `FutureOnly: spec.FutureOnly` | +1 |
+| `internal/agent/opencode/plugin_template.go` | +`extractEmittedEvents` + `extractPdxPath` + `validateSpecsCoverEmitted` + render panic | +45 |
+| `internal/agent/opencode/plugin_template_test.go` | +PT1-PT6 | +95 |
+| `internal/agent/opencode/hooks.go` | CheckHooks byte-exact template 比對 | +30 |
+| `internal/agent/opencode/hooks_test.go` | +OH1-OH5 | +100 |
 | `internal/agent/drift_test.go` | +D5（無 fixture 刪除、無 FutureOnly skip） | +45 |
-| `docs/specs/2026-04-23-hook-events-fix-plan.md` | 本檔 v2 | +400 |
-| **合計** | | **~900 行**（含 plan 文件） |
+| `docs/specs/2026-04-23-hook-events-fix-plan.md` | 本檔 v3 | +480 |
+| **合計** | | **~1050 行**（含 plan 文件） |
 
 ## 5. 不做項目清單（防自動擴展）
 
@@ -344,13 +393,15 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 - **不改 codex `provider_test.go` SupportedStatuses 斷言**（仍 5 status）
 - **不探測 codex CLI 版本** — FutureOnly 是 build-time 靜態標記
 - **不引入 `/api/hooks/codex/capability` endpoint**
-- **不重寫 opencode template 為完全 codegen**
+- **不重寫 opencode template 為完全 codegen**（v3 確認：template 保固定結構 + render-time validate）
+- **不對 opencode CheckHooks 做 per-event extraction**（v3 決定：byte-exact template 比對）
+- **不接受 codex absent 定義包含空陣列**（v3 嚴格限：`_, ok := hooks[key]; ok == false` 才是 absent）
 - **不把 cc 任何 event 標為 FutureOnly**
 - **不調整 `Coverage()` 簽名或回傳欄位**
 - **不改 SPA 任何檔案**
 - **不 force push / rebase** — 保留全歷史
 - **不合併 fix commits** — 分 7 commits 便於 reviewer 逐步追蹤
-- **不順手修其他 finding** — 四路 review 只有這 4 個 finding
+- **不順手修其他 finding** — 只修原 4 findings + v2/v3 延伸的 7 findings 全部列出；其餘盲點開 gh issue 延後
 
 ## 6. Subagent 開發指引
 
@@ -368,14 +419,15 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 
 - [ ] 7 個 commits 符合上述 message 規範
 - [ ] `go build ./...` 綠
-- [ ] `go test ./...` 全綠（含 F1-F2 / CE1-CE2 / CH1-CH5 / D5 / PT1-PT5 / OH1-OH4 共 19 個新測試）
+- [ ] `go test ./...` 全綠（含 F1-F2 / CE1-CE2 / CH1-CH6 / D5 / PT1-PT6 / OH1-OH5 共 22 個新測試）
 - [ ] `go vet ./...` 無 warning
-- [ ] PR diff 僅涉及 §4 表格列出的 12 個檔 + plan 文件，**其餘不得出現**
+- [ ] PR diff 僅涉及 §4 表格列出的 14 個檔 + plan 文件，**其餘不得出現**
 - [ ] codex `SupportedStatuses()` 仍回傳 5 個 Status（不動）
-- [ ] codex `Events()` 中 6 個 FutureOnly event 的 bit 為 true，其餘 false
+- [ ] codex `Events()` 中 6 個 FutureOnly event 的 bit 為 true，其餘 false；defensive copy 保留 bit（mutate 第一次不影響第二次）
 - [ ] codex `CheckHooks()` 對 legacy 3-event hooks.json 回 `allInstalled=true` + Issues=[]
 - [ ] codex `CheckHooks()` 對「FutureOnly key 存在但 command 錯誤」回 `allInstalled=false` + warning issue
-- [ ] opencode `CheckHooks()` 對手改過、少 emit 的 plugin 正確標 `Installed=false` + issue
+- [ ] codex `CheckHooks()` 對「FutureOnly key 存在 entries 為 []」歸 broken 而非 absent（**v3 新驗收點**）
+- [ ] opencode `CheckHooks()` 對**任何**手改過的 plugin（包含註解變動）回 `Installed=false` + `plugin body differs` issue（byte-exact）
 - [ ] opencode `renderManagedPlugin` 對人為構造的不合法 specs/body 會 panic（僅在 mock 下 — 真 runtime 不 panic）
 - [ ] drift per-event 斷言（D5）對每個 provider/spec 覆蓋正確
 
@@ -384,11 +436,14 @@ D5 天然覆蓋 FutureOnly event（因為 fixtures 與 declaredSet 都包含）�
 | 風險 | 機率 | 影響 | 緩解 |
 |---|---|---|---|
 | FutureOnly 語意仍可能被後續開發者誤用為 SupportedStatuses 過濾 | 中 | 未來 regression | F2 測試鎖定契約；`provider.go` FutureOnly 欄位註解明寫「不影響 DeriveStatus 能力宣告」 |
-| CheckHooks 三態決策複雜度累積 | 低 | 新增 FutureOnly 時 regression | 抽 `checkCodexEvent` helper；CH1-CH5 覆蓋所有交叉組合 |
-| `extractEmittedEvents` regex 遇到 JS 註解誤判 | 低 | CheckHooks 假陽性 | PT1 測 edge case（註解、插值、單雙引號） |
+| CheckHooks 三態決策複雜度累積 | 低 | 新增 FutureOnly 時 regression | 抽 `checkCodexEvent` helper；CH1-CH6 覆蓋所有交叉組合 |
+| `extractEmittedEvents` regex 對 CheckHooks 的假綠風險 | **已消除** | n/a | v3 決定：`extractEmittedEvents` 只用於 render-time contract check；CheckHooks 走 byte-exact |
+| opencode byte-exact 太嚴格：使用者若自行 patch plugin 會立刻回 unmanaged | 中 | UX | 這是預期行為 — plugin 是 pdx 受管原子檔。若有合法 customization 需求，未來另開 `unmanaged` 模式 |
+| `extractPdxPath` regex 遇到 odd-formed pdxPath 抽不到 | 低 | CheckHooks fallback unmanaged | OH5 覆蓋此 case；fallback 回 unmanaged 而非 panic |
 | opencode render panic 在 production 路徑誤觸 | 低 | Install 失敗 | template 是 const-like 字串；panic 只在 specs/template 不同步時發生；PT5 常態 smoke test |
 | drift fixtures 保留後，若 FutureOnly event 在 DeriveStatus 邏輯日後被刪除但 fixture 沒刪 | 低 | 測試失敗警告到位 | D5 per-event 強相等會紅，指向確切 spec/event；是有益的警告 |
 | commit 4 D5 對既有 spec/fixture 跑起來紅（有過度宣告） | 中 | 需額外修 spec 或 fixture | 先跑一次 D5 preview；若紅先修 spec 再加 D5 斷言 |
+| 三家 `Events()` defensive copy 改動 commit 1 執行時漏改某家 | 中 | commit 2 紅（CE1/CE2） | Commit 1 明列 3 個檔案 + 紅綠 TDD 會立即暴露 |
 
 ## 9. 第 3 輪 Codex Review 預期 focus
 

--- a/docs/specs/2026-04-23-lights-rebuild-spec.md
+++ b/docs/specs/2026-04-23-lights-rebuild-spec.md
@@ -76,6 +76,7 @@ Readiness callsite 缺失處理方向在 Open Questions 第 1 題，本 spec 預
 
 - **Status 宣告**：Phase 1 做完（drift_test 守住）
 - **事件集合自洽**（installer 裝幾個 vs DeriveStatus 支援幾個 vs Inspector 宣告幾個）：併入 issue #613 擴展（`HookInstaller.Events()`）自然解，不開獨立 phase
+  - **更新 2026-04-23**：已於 Events() PR 實作完成（plan 檔 `docs/specs/2026-04-23-hook-events-declaration-plan.md`）；cc/codex/opencode 三家共享 `HookEventSpec` 宣告，codex installer 從 3 事件擴展到 9 事件，`SupportedStatuses()` 改由 `Events()` derive，drift test 升級為三向等價
 - **DeriveStatus 行為**：drift test 已守
 
 #### 2.4.4 Policy 分散 + Plumbing 共用 的完整長相

--- a/docs/specs/2026-04-23-lights-rebuild-spec.md
+++ b/docs/specs/2026-04-23-lights-rebuild-spec.md
@@ -353,7 +353,7 @@ Inspector 僅讀取不 mutation。若 Phase 2-4 在 Inspector 設計期間仍變
 - **Bump 策略**：每 Phase merge 後獨立 bump alpha PR，`VERSION` / `package.json` / `spa/package.json` 三處同步
 - **Known issues 管理**：review 問題以「信心 / 關聯 / 複雜」三維度彙整；低關聯 + 中高複雜可延後成 gh issue（label 按 CLAUDE.md 兩維度：type 必選一、scope 可多選）
 - **Worktree 使用**：Phase 0 使用現有 `lights-rebuild-spec`；Phase 1+ 各自另起 worktree 避免 diff 混淆
-- **Phase 4 條件判斷**：4a 為必做；4b 僅在 Phase 1-3 過程中出現明確需求時執行，否則 Phase 4 於 4a 結案、Readiness callsite 缺失另開 issue
+- **Phase 4 執行策略**：4a 為必做；4b 於 Phase 3 完成後、Phase 5 之前執行（延後必做，見 §2.4.2、§8.2）；Readiness callsite 缺失於 4b 一併解決
 
 ## 11. Open Questions
 

--- a/docs/specs/2026-04-23-lights-rebuild-spec.md
+++ b/docs/specs/2026-04-23-lights-rebuild-spec.md
@@ -8,6 +8,8 @@
 
 Lights 子系統曾於 2026-04-22 回退一版 ~9000 行的膨脹重構。本 spec 採 **tightened 路線**：骨架最小、其他層沿用既有 infra（TraceStore / Monitor API / frame_ops / probe），分六個獨立 PR 小步推進。每 Phase 獨立 spec 節、獨立 merge、獨立 bump alpha、獨立 codex 兩輪 review。
 
+**2026-04-23 更新**：Phase 0/1 完成後討論 Phase 2 前的架構對齊，新增 §2.4「Architecture Guardrails」作為後續開發護欄；§8.2 Phase 4b 由條件執行升級為延後必做；§11 Open Question 3 已決議。
+
 ## 2. 核心概念
 
 ### 2.1 Status 對齊矩陣
@@ -41,6 +43,65 @@ Readiness callsite 缺失處理方向在 Open Questions 第 1 題，本 spec 預
 
 三個 concern（hook → status、frame model、probe）在 runtime 層保持獨立演化；TraceStore 提供統一的歷史事實紀錄；Phase 5 Inspector 由 trace 跨 concern 拼接呈現，而不由 runtime 強制統一。
 
+### 2.4 Architecture Guardrails
+
+本節鎖定 Phase 2-5 開發必須遵守的架構原則，防止向中央化收斂造成膨脹。護欄於 2026-04-23 討論定案，適用整份 spec。
+
+#### 2.4.1 中央 vs 分散判準
+
+收斂對象決定是否膨脹：
+
+| 收斂對象 | 膨脹 | 範例 |
+|---|---|---|
+| **宣告層**（build-time 可查、runtime 仍分散） | 不膨脹 | `Events() []HookEventSpec`、`Coverage()`、Inspector UI |
+| **實作層**（runtime 要跑過中央物件） | 嚴重膨脹 | 中央 FSM、共用 event resolver、統一 transition table |
+
+提案遇到「抽取 / 統一 / 收斂」衝動時，問：「這個收斂在 build time 還是 runtime 時起作用？」build-time 可做、runtime 不做。
+
+#### 2.4.2 Hook 與 Probe 架構同型
+
+兩類本質同型，都是「policy 分散 + plumbing 共用 + 宣告對齊」：
+
+| | Hook | Probe |
+|---|---|---|
+| 共用層 | plumbing（handler / broadcast / trace） | engine（hash diff / pane read / signal transport） |
+| 宣告層 | `Events() []HookEventSpec`（issue #613 擴展） | `ProbeIntents() []ProbeIntent`（§8.2） |
+| per-agent 差異 | 事件集合、payload schema | 何時啟 / 看什麼 / signal→status 映射、特徵辨識 |
+
+**Hook + Probe 衝突解法**：hook 時間窗 —— 加 `lastHookAt[session]` timestamp，probe callback 檢查距離 lastHook 是否 < graceWindow（例 2 秒），太近跳過。邏輯為「hook 權威、probe 推論」的冷卻窗，非絕對壓過。約 20 行改動，獨立小 PR，排 Phase 4a 前後均可。
+
+#### 2.4.3 三家 Agent 事件對齊策略
+
+三家事件集合差異（cc 9 / codex 3 / opencode 8）**不是 bug，是 CLI 客觀限制** —— 分散架構不強制行為一致。對齊分三層：
+
+- **Status 宣告**：Phase 1 做完（drift_test 守住）
+- **事件集合自洽**（installer 裝幾個 vs DeriveStatus 支援幾個 vs Inspector 宣告幾個）：併入 issue #613 擴展（`HookInstaller.Events()`）自然解，不開獨立 phase
+- **DeriveStatus 行為**：drift test 已守
+
+#### 2.4.4 Policy 分散 + Plumbing 共用 的完整長相
+
+分散架構不是「只有宣告對齊」，完整結構如下：
+
+| 層次 | 分散 or 共用 | 誰提供 |
+|---|---|---|
+| Policy（event→status、狀態判讀） | **分散** | 各家 `status.go` switch |
+| 宣告對齊 | **共用** | `SupportedStatuses` / `Events` / `Coverage` / drift test |
+| Plumbing（invalid 早退、error guard、broadcast schema） | **共用** | `handler.go` / `NormalizedEvent` |
+| Probe engine（Activity / Liveness 畫面偵測） | **共用** | `probe.Prober` |
+| Observability（trace / frame / projection） | **共用** | `TraceStore` / `frame_ops` |
+
+關鍵區別：**Policy 共用化 = 中央化 = 膨脹**（硬塞各家差異進統一模型）；**Plumbing 共用化 = 正常分層**（不膨脹）。
+
+#### 2.4.5 Bloat 警覺詞
+
+以下三個詞出現在討論或提案中時立刻警戒並回到 §2.4.1 判準：
+
+- **Central FSM** / **Central State Machine**
+- **Event catalog**
+- **Transition registry**
+
+前例：2026-04-22 Reverted Lights（9000 行）vs tightened 骨架（~65 行），15× bloat。詳細五大 bloat 徵兆見記憶檔 `feedback_skeleton_convergence.md`：把 working code 變 data / parallel registry / 統一抽象 / refactor working code / config flag。
+
 ## 3. Phase Roadmap
 
 | Phase | 範圍 | 風險 | 依賴 |
@@ -50,7 +111,7 @@ Readiness callsite 缺失處理方向在 Open Questions 第 1 題，本 spec 預
 | 2 | L3 Subagent 結構升級 + proxy 偵測 + frame idle sweep | 中 | Phase 1 |
 | 3 | L1 邊界補強（daemon 後啟動補回 + 沒 parent 以 agent_type 為基準顯式化） | 中 | Phase 2 |
 | 4a | Activity probe 內部強化（彩虹字 / spinner） | 低 | Phase 3 |
-| 4b | 可選 `ProbeIntentProvider`（依 Phase 1-3 觀察決定是否做） | 中 | Phase 4a |
+| 4b | `ProbeIntentProvider` + 前置 probe audit（延後必做） | 中 | Phase 4a |
 | 5 | Dev Inspector UI | 低 | Phase 4 |
 
 每 Phase 節固定四段：**目的 / 改動觸及 / 驗收條件 / 備註**。
@@ -221,11 +282,11 @@ activity probe 目前靠畫面 hash diff 判定，但 cc 提問後若使用者�
 
 本 Phase 僅動 activity probe 內部判定邏輯，**不改** `manageActivityWatch` 的出場條件（仍是 hook 後 + status ∈ {waiting, running, idle}）。
 
-### 8.2 Phase 4b — 可選 `ProbeIntentProvider`（條件執行）
+### 8.2 Phase 4b — `ProbeIntentProvider`（延後必做）
 
 #### 目的
 
-讓 agent 宣告自己期望的 probe 觸發條件與 signal mapping，讓 probe 出場條件**從寫死擴充為 agent 驅動**，並順便整合 readiness（解決現況 callsite 缺失）。僅在 Phase 1-3 過程中出現明確需求時執行。
+讓 agent 宣告自己期望的 probe 觸發條件與 signal mapping，讓 probe 出場條件**從寫死擴充為 agent 驅動**，並順便整合 readiness（解決現況 callsite 缺失）。**執行時機**：Phase 3 完成後、Phase 5 之前。先做前置 audit（查 `agent_trace_steps` 找出三家在哪些 status 轉換缺乏 hook 訊息、需要 probe 補位），再設計 ProbeIntent 結構。
 
 #### 改動觸及
 
@@ -251,12 +312,7 @@ activity probe 目前靠畫面 hash diff 判定，但 cc 提問後若使用者�
 
 #### 備註
 
-執行門檻：Phase 1-3 結束後查 `agent_trace_steps`，若發現以下任一情境頻繁出現，才執行 Phase 4b：
-- 彩虹字強化（4a）仍無法覆蓋的誤判
-- 多 agent 需要差異化 probe 策略
-- readiness callsite 缺失成為實際 bug
-
-否則 readiness 現況問題另開 gh issue 追蹤，Phase 4 在 4a 後結案。
+**執行依據**：2026-04-23 討論確認 probe per-agent 差異（cc readiness 真實 / codex stub / opencode 無 readiness）是客觀事實，不是 hypothetical —— Phase 4b 為延後必做，不再是條件執行。readiness 現況問題（§2.2 表格 Open Question 1）在 Phase 4b 一併解決。
 
 ---
 
@@ -303,7 +359,7 @@ Inspector 僅讀取不 mutation。若 Phase 2-4 在 Inspector 設計期間仍變
 
 1. **Readiness 模組層無 callsite 如何處理** — 選項：(a) Phase 4b 整合（現 spec 預設）(b) Phase 1 補齊整合 (c) 明確標註本次不處理、開 issue 追蹤
 2. **Phase 2 是否拆 2a（schema 升級）+ 2b（proxy + sweep）** — 依 review 負擔決定，到時再拆
-3. **Phase 4b 條件是否成立** — 以 Phase 1–3 的 trace 資料為判斷依據，非預設
+3. **Phase 4b 前置 audit 範圍** — ✅ 2026-04-23 已決議升級為延後必做（見 §2.4.2、§8.2）；尚待確認的是 audit 具體範圍（每家 agent 各取多少 trace / 以哪些 status 切換為重點）。由 Phase 3 完成時再定
 4. **Phase 5 Inspector 觀察粒度** — 先以 chain（既有 `TraceChain`）為單位；per-event / per-transition 作為後續迭代
 5. **Proxy 判定條件是否加時間窗 / PPID 驗證** — Phase 2 初版僅 pane + agent_type；若 Phase 3 揭露誤判再強化
 6. **Frame idle sweep 閾值** — 初值 1 小時；以實際觀察校準

--- a/internal/agent/cc/events.go
+++ b/internal/agent/cc/events.go
@@ -70,6 +70,7 @@ func (p *Provider) Events() []agent.HookEventSpec {
 			Name:        spec.Name,
 			EmitsStatus: append([]agent.Status(nil), spec.EmitsStatus...),
 			Description: spec.Description,
+			FutureOnly:  spec.FutureOnly,
 		}
 		// Ensure a detail-only spec round-trips as an explicit empty slice,
 		// not nil — callers distinguish "explicitly empty" from "unknown".

--- a/internal/agent/cc/events.go
+++ b/internal/agent/cc/events.go
@@ -1,0 +1,98 @@
+package cc
+
+import "github.com/wake/purdex/internal/agent"
+
+// ccEventSpecs is the declarative hook event catalog for Claude Code. It is
+// the single source of truth for installer iteration (mergeClaudeHooks /
+// CheckHooks), SupportedStatuses derivation, and future Inspector UI.
+// Ordering matches the installer's emit order and plan §1.4 cc table.
+//
+// EmitsStatus semantics:
+//   - Detail-only events (SubagentStart/Stop) declare an empty slice — they
+//     produce Valid=true with Status="" at runtime.
+//   - Polymorphic events (Notification) declare the union across sub-branches
+//     (permission_prompt / elicitation_dialog → Waiting; idle_prompt /
+//     auth_success → Idle). Drift test pins each sub-branch separately.
+var ccEventSpecs = []agent.HookEventSpec{
+	{
+		Name:        "SessionStart",
+		EmitsStatus: []agent.Status{agent.StatusIdle},
+		Description: "Claude Code session started (non-compact source)",
+	},
+	{
+		Name:        "UserPromptSubmit",
+		EmitsStatus: []agent.Status{agent.StatusRunning},
+		Description: "User submitted a prompt to the agent",
+	},
+	{
+		Name:        "SubagentStart",
+		EmitsStatus: []agent.Status{},
+		Description: "Nested sub-agent task dispatched",
+	},
+	{
+		Name:        "SubagentStop",
+		EmitsStatus: []agent.Status{},
+		Description: "Nested sub-agent task completed",
+	},
+	{
+		Name:        "Stop",
+		EmitsStatus: []agent.Status{agent.StatusIdle},
+		Description: "Agent finished responding and is idle",
+	},
+	{
+		Name:        "StopFailure",
+		EmitsStatus: []agent.Status{agent.StatusError},
+		Description: "Agent stopped due to an error",
+	},
+	{
+		Name:        "Notification",
+		EmitsStatus: []agent.Status{agent.StatusWaiting, agent.StatusIdle},
+		Description: "Permission/elicitation prompt, idle prompt, or auth success",
+	},
+	{
+		Name:        "PermissionRequest",
+		EmitsStatus: []agent.Status{agent.StatusWaiting},
+		Description: "Tool permission request awaiting user approval",
+	},
+	{
+		Name:        "SessionEnd",
+		EmitsStatus: []agent.Status{agent.StatusClear},
+		Description: "Claude Code session ended",
+	},
+}
+
+// Events returns a fresh copy of the cc hook event catalog on every call so
+// consumers cannot mutate the package-internal spec slice.
+func (p *Provider) Events() []agent.HookEventSpec {
+	out := make([]agent.HookEventSpec, len(ccEventSpecs))
+	for i, spec := range ccEventSpecs {
+		out[i] = agent.HookEventSpec{
+			Name:        spec.Name,
+			EmitsStatus: append([]agent.Status(nil), spec.EmitsStatus...),
+			Description: spec.Description,
+		}
+		// Ensure a detail-only spec round-trips as an explicit empty slice,
+		// not nil — callers distinguish "explicitly empty" from "unknown".
+		if out[i].EmitsStatus == nil {
+			out[i].EmitsStatus = []agent.Status{}
+		}
+	}
+	return out
+}
+
+// eventNames returns the ordered event Name list for installer / check
+// iteration, derived from ccEventSpecs so there is no parallel SSoT.
+func (p *Provider) eventNames() []string {
+	return ccEventNames()
+}
+
+// ccEventNames is the package-level helper used by mergeClaudeHooks (a free
+// function, not a method). Keeping both entry points routes through the same
+// ccEventSpecs slice so the Events SSoT cannot drift.
+func ccEventNames() []string {
+	out := make([]string, 0, len(ccEventSpecs))
+	for _, spec := range ccEventSpecs {
+		out = append(out, spec.Name)
+	}
+	return out
+}

--- a/internal/agent/cc/events_test.go
+++ b/internal/agent/cc/events_test.go
@@ -1,0 +1,150 @@
+package cc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+)
+
+// expectedCCEventNames lists the 9 hook events cc's installer wires. Kept as
+// a fixed slice to guard against silent drift in Events() ordering/contents.
+// Order matches plan §1.4 cc table, which mirrors the installer's emit order.
+var expectedCCEventNames = []string{
+	"SessionStart",
+	"UserPromptSubmit",
+	"SubagentStart",
+	"SubagentStop",
+	"Stop",
+	"StopFailure",
+	"Notification",
+	"PermissionRequest",
+	"SessionEnd",
+}
+
+// TestCCEvents_Count locks the declared event count at 9 (plan §1.4).
+func TestCCEvents_Count(t *testing.T) {
+	p := NewProvider(nil, nil, nil, nil)
+	events := p.Events()
+	if len(events) != 9 {
+		t.Fatalf("cc Events count = %d, want 9 (plan §1.4)", len(events))
+	}
+}
+
+// TestCCEvents_NamesMatchExpected asserts the Event Name set matches §1.4.
+func TestCCEvents_NamesMatchExpected(t *testing.T) {
+	p := NewProvider(nil, nil, nil, nil)
+	events := p.Events()
+
+	got := make(map[string]bool, len(events))
+	for _, e := range events {
+		if got[e.Name] {
+			t.Errorf("cc Events contains duplicate Name %q", e.Name)
+		}
+		got[e.Name] = true
+	}
+	want := make(map[string]bool, len(expectedCCEventNames))
+	for _, n := range expectedCCEventNames {
+		want[n] = true
+	}
+	for n := range want {
+		if !got[n] {
+			t.Errorf("cc Events missing required Name %q", n)
+		}
+	}
+	for n := range got {
+		if !want[n] {
+			t.Errorf("cc Events contains unexpected Name %q", n)
+		}
+	}
+}
+
+// TestCCEvents_EmitsStatusForNotification asserts cc Notification is declared
+// to emit the Waiting/Idle union covering its polymorphic sub-branches
+// (permission_prompt / elicitation_dialog → Waiting; idle_prompt /
+// auth_success → Idle) per plan §1.4.
+func TestCCEvents_EmitsStatusForNotification(t *testing.T) {
+	p := NewProvider(nil, nil, nil, nil)
+	var spec *agent.HookEventSpec
+	for i := range p.Events() {
+		if p.Events()[i].Name == "Notification" {
+			s := p.Events()[i]
+			spec = &s
+			break
+		}
+	}
+	if spec == nil {
+		t.Fatal("cc Events missing Notification entry")
+	}
+	got := make(map[agent.Status]bool, len(spec.EmitsStatus))
+	for _, s := range spec.EmitsStatus {
+		got[s] = true
+	}
+	for _, want := range []agent.Status{agent.StatusWaiting, agent.StatusIdle} {
+		if !got[want] {
+			t.Errorf("cc Notification EmitsStatus missing %q (got %v)", want, spec.EmitsStatus)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("cc Notification EmitsStatus = %v, want exactly {Waiting, Idle}", spec.EmitsStatus)
+	}
+}
+
+// TestCCEvents_DetailOnlyHaveEmptyEmitsStatus enforces detail-only events
+// (SubagentStart/Stop) declare EmitsStatus as an empty slice — not nil — so
+// drift tooling and Inspector UI can distinguish "explicitly empty" from
+// "unknown".
+func TestCCEvents_DetailOnlyHaveEmptyEmitsStatus(t *testing.T) {
+	p := NewProvider(nil, nil, nil, nil)
+	for _, e := range p.Events() {
+		if e.Name != "SubagentStart" && e.Name != "SubagentStop" {
+			continue
+		}
+		if e.EmitsStatus == nil {
+			t.Errorf("cc %s EmitsStatus is nil; want non-nil empty slice", e.Name)
+		}
+		if len(e.EmitsStatus) != 0 {
+			t.Errorf("cc %s EmitsStatus = %v, want empty", e.Name, e.EmitsStatus)
+		}
+	}
+}
+
+// TestCCEvents_DescriptionsNonEmpty enforces every event has a short English
+// human-readable description without emoji (plan §1.1).
+func TestCCEvents_DescriptionsNonEmpty(t *testing.T) {
+	p := NewProvider(nil, nil, nil, nil)
+	for _, e := range p.Events() {
+		if strings.TrimSpace(e.Description) == "" {
+			t.Errorf("cc %s Description is empty", e.Name)
+			continue
+		}
+		for _, r := range e.Description {
+			if r >= 0x1F300 && r <= 0x1FAFF {
+				t.Errorf("cc %s Description contains emoji rune %U: %q", e.Name, r, e.Description)
+				break
+			}
+		}
+	}
+}
+
+// TestCCEvents_FreshSliceDefensiveCopy guards the defensive-copy convention:
+// each Events() call must return an independent backing array so consumers
+// cannot mutate provider-internal state.
+func TestCCEvents_FreshSliceDefensiveCopy(t *testing.T) {
+	p := NewProvider(nil, nil, nil, nil)
+	first := p.Events()
+	if len(first) == 0 {
+		t.Fatal("cc Events returned empty slice")
+	}
+	first[0].Name = "__mutated__"
+	if len(first[0].EmitsStatus) > 0 {
+		first[0].EmitsStatus[0] = agent.Status("__mutated__")
+	}
+	second := p.Events()
+	if second[0].Name == "__mutated__" {
+		t.Errorf("cc Events shares backing array; second call first Name mutated to %q", second[0].Name)
+	}
+	if len(second[0].EmitsStatus) > 0 && second[0].EmitsStatus[0] == "__mutated__" {
+		t.Errorf("cc Events shares EmitsStatus backing array across calls")
+	}
+}

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -10,11 +10,6 @@ import (
 	"github.com/wake/purdex/internal/agent"
 )
 
-var ccHookEvents = []string{
-	"SessionStart", "UserPromptSubmit", "SubagentStart", "SubagentStop",
-	"Stop", "StopFailure", "Notification", "PermissionRequest", "SessionEnd",
-}
-
 const ccHooksSupportedVersion = "2.1.114"
 
 func (p *Provider) InstallHooks(pdxPath string) error {
@@ -31,14 +26,6 @@ func (p *Provider) RemoveHooks(pdxPath string) error {
 		return fmt.Errorf("cannot determine home directory: %w", err)
 	}
 	return mergeClaudeHooks(settingsPath, pdxPath, true)
-}
-
-// Events returns the hook event declarations for Claude Code. Stub; filled in
-// a later commit (HookInstaller.Events() plan §3 Commit 3). Returning nil
-// keeps the HookInstaller contract satisfied while the declaration content
-// is built up in a dedicated commit with its own tests.
-func (p *Provider) Events() []agent.HookEventSpec {
-	return nil
 }
 
 func (p *Provider) CheckHooks() (agent.HookStatus, error) {
@@ -63,10 +50,11 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		return agent.HookStatus{}, fmt.Errorf("parse settings.json: %w", err)
 	}
 	hooks, _ := settings["hooks"].(map[string]any)
-	events := make(map[string]agent.HookEventInfo, len(ccHookEvents))
+	eventNames := p.eventNames()
+	events := make(map[string]agent.HookEventInfo, len(eventNames))
 	var issues []string
 	allInstalled := true
-	for _, eventName := range ccHookEvents {
+	for _, eventName := range eventNames {
 		entries, ok := hooks[eventName]
 		if !ok {
 			events[eventName] = agent.HookEventInfo{Installed: false}
@@ -108,7 +96,7 @@ func mergeClaudeHooks(path, pdxPath string, remove bool) error {
 	if hooks == nil {
 		hooks = make(map[string]any)
 	}
-	for _, event := range ccHookEvents {
+	for _, event := range ccEventNames() {
 		entries := toEntrySlice(hooks[event])
 		entries = filterOutPdx(entries)
 		if !remove {

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -50,33 +50,64 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		return agent.HookStatus{}, fmt.Errorf("parse settings.json: %w", err)
 	}
 	hooks, _ := settings["hooks"].(map[string]any)
-	eventNames := p.eventNames()
-	events := make(map[string]agent.HookEventInfo, len(eventNames))
+	specs := p.Events()
+	events := make(map[string]agent.HookEventInfo, len(specs))
 	var issues []string
+	var upgrades []string
 	allInstalled := true
-	for _, eventName := range eventNames {
-		entries, ok := hooks[eventName]
-		if !ok {
-			events[eventName] = agent.HookEventInfo{Installed: false}
-			issues = append(issues, eventName+" hook not installed")
+	for _, spec := range specs {
+		entries, keyExists := hooks[spec.Name]
+		if !keyExists {
+			events[spec.Name] = agent.HookEventInfo{Installed: false, FutureOnly: spec.FutureOnly}
+			if spec.FutureOnly {
+				upgrades = append(upgrades, spec.Name)
+				continue
+			}
+			issues = append(issues, spec.Name+" hook not installed")
 			allInstalled = false
 			continue
 		}
 		command := findPdxCommand(entries)
-		events[eventName] = agent.HookEventInfo{Installed: command != "", Command: command}
+		events[spec.Name] = agent.HookEventInfo{
+			Installed:  command != "",
+			Command:    command,
+			FutureOnly: spec.FutureOnly,
+		}
 		if command == "" {
-			issues = append(issues, eventName+" hook: pdx command not found")
+			issues = append(issues, spec.Name+" hook: pdx command not found")
 			allInstalled = false
 		}
 	}
+	managed := ccHooksManaged(hooks, specs)
 	return agent.HookStatus{
-		Installed:        allInstalled,
-		Events:           events,
-		Issues:           issues,
-		AgentVersion:     agentVersion,
-		SupportedVersion: ccHooksSupportedVersion,
-		ExceedsSupport:   agent.CompareHookAgentVersions(agentVersion, ccHooksSupportedVersion) > 0,
+		Installed:         allInstalled,
+		Managed:           managed,
+		UpgradesAvailable: upgrades,
+		Events:            events,
+		Issues:            issues,
+		AgentVersion:      agentVersion,
+		SupportedVersion:  ccHooksSupportedVersion,
+		ExceedsSupport:    agent.CompareHookAgentVersions(agentVersion, ccHooksSupportedVersion) > 0,
 	}, nil
+}
+
+// ccHooksManaged reports whether settings.json has any pdx-owned hook
+// entry across the declared event set. Parallel to codex.codexHooksManaged
+// — keeps Managed/Installed distinct so the UI Remove button stays
+// enabled on drifted-but-managed state (Finding #2).
+func ccHooksManaged(hooks map[string]any, specs []agent.HookEventSpec) bool {
+	for _, spec := range specs {
+		entries, ok := hooks[spec.Name].([]any)
+		if !ok {
+			continue
+		}
+		for _, entry := range entries {
+			if entryIsPdx(entry) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func mergeClaudeHooks(path, pdxPath string, remove bool) error {

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -33,6 +33,14 @@ func (p *Provider) RemoveHooks(pdxPath string) error {
 	return mergeClaudeHooks(settingsPath, pdxPath, true)
 }
 
+// Events returns the hook event declarations for Claude Code. Stub; filled in
+// a later commit (HookInstaller.Events() plan §3 Commit 3). Returning nil
+// keeps the HookInstaller contract satisfied while the declaration content
+// is built up in a dedicated commit with its own tests.
+func (p *Provider) Events() []agent.HookEventSpec {
+	return nil
+}
+
 func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 	settingsPath, err := ccSettingsPath()
 	if err != nil {

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -77,7 +77,7 @@ func TestMergeClaudeHooks_EmptyFile(t *testing.T) {
 	settings := readSettings(t, path)
 	hooks := hooksMap(t, settings)
 
-	for _, event := range ccHookEvents {
+	for _, event := range expectedCCEventNames {
 		entries, ok := hooks[event]
 		if !ok {
 			t.Errorf("event %s not found in hooks", event)
@@ -88,8 +88,8 @@ func TestMergeClaudeHooks_EmptyFile(t *testing.T) {
 			t.Errorf("event %s has no entries", event)
 		}
 	}
-	if len(hooks) != len(ccHookEvents) {
-		t.Errorf("expected %d hook events, got %d", len(ccHookEvents), len(hooks))
+	if len(hooks) != len(expectedCCEventNames) {
+		t.Errorf("expected %d hook events, got %d", len(expectedCCEventNames), len(hooks))
 	}
 }
 
@@ -108,7 +108,7 @@ func TestMergeClaudeHooks_Idempotent(t *testing.T) {
 	settings := readSettings(t, path)
 	hooks := hooksMap(t, settings)
 
-	for _, event := range ccHookEvents {
+	for _, event := range expectedCCEventNames {
 		entries, ok := hooks[event].([]any)
 		if !ok {
 			t.Fatalf("event %s: not an array", event)
@@ -222,7 +222,7 @@ func TestMergeClaudeHooks_RemoveMode(t *testing.T) {
 	settings = readSettings(t, path)
 	hooks = hooksMap(t, settings)
 
-	for _, event := range ccHookEvents {
+	for _, event := range expectedCCEventNames {
 		entries, _ := hooks[event].([]any)
 		for _, e := range entries {
 			if entryIsPdx(e) {
@@ -268,7 +268,7 @@ func TestMergeClaudeHooks_DifferentPathReplaces(t *testing.T) {
 	settings := readSettings(t, path)
 	hooks := hooksMap(t, settings)
 
-	for _, event := range ccHookEvents {
+	for _, event := range expectedCCEventNames {
 		entries, _ := hooks[event].([]any)
 		pdxCount := 0
 		hasNewPath := false
@@ -302,6 +302,88 @@ func TestMergeClaudeHooks_DifferentPathReplaces(t *testing.T) {
 		if hasOldPath {
 			t.Errorf("event %s: old pdx path still present", event)
 		}
+	}
+}
+
+// ---- InstallHooks / CheckHooks use Events() as SSoT ----
+
+// TestCCInstallHooks_WritesAllEventsFromEventsList drives mergeClaudeHooks and
+// asserts the written settings.json has one key per Event from Events() —
+// i.e. the installer no longer relies on the legacy ccHookEvents var.
+func TestCCInstallHooks_WritesAllEventsFromEventsList(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(dir, "settings.json")
+
+	if err := mergeClaudeHooks(path, "/usr/local/bin/pdx", false); err != nil {
+		t.Fatalf("mergeClaudeHooks: %v", err)
+	}
+
+	settings := readSettings(t, path)
+	hooks := hooksMap(t, settings)
+
+	p := NewProvider(nil, nil, nil, nil)
+	events := p.Events()
+	if len(events) == 0 {
+		t.Fatal("cc Events() returned empty; installer iteration would be vacuous")
+	}
+	for _, e := range events {
+		entries, ok := hooks[e.Name]
+		if !ok {
+			t.Errorf("event %s (from Events()) not found in written hooks", e.Name)
+			continue
+		}
+		arr, ok := entries.([]any)
+		if !ok || len(arr) == 0 {
+			t.Errorf("event %s: no entries written", e.Name)
+		}
+	}
+	if len(hooks) != len(events) {
+		t.Errorf("settings.json hooks len=%d, want %d (one per Events())", len(hooks), len(events))
+	}
+}
+
+// TestCCCheckHooks_ReportsAllEventsFromEventsList writes a settings.json that
+// deliberately omits Notification and asserts CheckHooks reports the full
+// Events() key set, with Notification.Installed=false.
+func TestCCCheckHooks_ReportsAllEventsFromEventsList(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	settingsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settingsDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+
+	// Write an install-complete settings.json then strip Notification out.
+	if err := mergeClaudeHooks(settingsPath, "/usr/local/bin/pdx", false); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+	settings := readSettings(t, settingsPath)
+	hooks := hooksMap(t, settings)
+	delete(hooks, "Notification")
+	settings["hooks"] = hooks
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		t.Fatalf("write stripped: %v", err)
+	}
+
+	p := NewProvider(nil, nil, nil, nil)
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	for _, e := range p.Events() {
+		if _, ok := status.Events[e.Name]; !ok {
+			t.Errorf("CheckHooks.Events missing key %q (from Events())", e.Name)
+		}
+	}
+	if status.Events["Notification"].Installed {
+		t.Error("Notification must be reported Installed=false after deletion")
+	}
+	if status.Installed {
+		t.Error("Installed must be false when any event is missing")
 	}
 }
 

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -387,6 +387,95 @@ func TestCCCheckHooks_ReportsAllEventsFromEventsList(t *testing.T) {
 	}
 }
 
+// TestCCCheckHooks_ManagedReflectsPdxEntries asserts HookStatus.Managed
+// is true when any pdx command is present (even broken) and false
+// otherwise. Finding #2: UI Remove button must stay enabled for
+// drifted-but-managed state.
+func TestCCCheckHooks_ManagedReflectsPdxEntries(t *testing.T) {
+	t.Run("pdx entry present", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		settingsPath := filepath.Join(home, ".claude", "settings.json")
+		if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := mergeClaudeHooks(settingsPath, "/usr/local/bin/pdx", false); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+		p := NewProvider(nil, nil, nil, nil)
+		status, err := p.CheckHooks()
+		if err != nil {
+			t.Fatalf("CheckHooks: %v", err)
+		}
+		if !status.Managed {
+			t.Fatal("pdx entries present: Managed=false, want true")
+		}
+	})
+	t.Run("no pdx entries", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		settingsPath := filepath.Join(home, ".claude", "settings.json")
+		if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		bare := map[string]any{
+			"hooks": map[string]any{
+				"SessionStart": []any{
+					map[string]any{
+						"hooks": []any{
+							map[string]any{
+								"type":    "command",
+								"command": "/usr/bin/notify-me start",
+							},
+						},
+					},
+				},
+			},
+		}
+		data, _ := json.MarshalIndent(bare, "", "  ")
+		if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		p := NewProvider(nil, nil, nil, nil)
+		status, err := p.CheckHooks()
+		if err != nil {
+			t.Fatalf("CheckHooks: %v", err)
+		}
+		if status.Managed {
+			t.Fatal("no pdx entries: Managed=true, want false")
+		}
+	})
+}
+
+// TestCCCheckHooks_UpgradesAvailableEmptyForFullFutureOnlyFalse asserts
+// cc has no FutureOnly events in its current catalog → UpgradesAvailable
+// must be empty on a fresh install and HookEventInfo.FutureOnly must be
+// false for every event.
+func TestCCCheckHooks_UpgradesAvailableEmptyForFullFutureOnlyFalse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := mergeClaudeHooks(settingsPath, "/usr/local/bin/pdx", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	p := NewProvider(nil, nil, nil, nil)
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if len(status.UpgradesAvailable) != 0 {
+		t.Errorf("cc UpgradesAvailable=%v, want empty", status.UpgradesAvailable)
+	}
+	for name, info := range status.Events {
+		if info.FutureOnly {
+			t.Errorf("cc event %q FutureOnly=true, want false", name)
+		}
+	}
+}
+
 // ---- atomic write: no .tmp file left after success ----
 
 func TestMergeClaudeHooks_AtomicWrite_NoTmpLeft(t *testing.T) {

--- a/internal/agent/cc/provider.go
+++ b/internal/agent/cc/provider.go
@@ -59,17 +59,12 @@ func (p *Provider) DeriveStatus(eventName string, rawEvent json.RawMessage) agen
 }
 
 // SupportedStatuses declares the Status values cc.Provider's DeriveStatus may
-// emit. Returns a fresh slice on each call so callers cannot mutate provider
-// internal state. See coverage.go for the contract; drift_test.go enforces
-// the declaration matches the actual emit paths.
+// emit, derived from Events().EmitsStatus. Events() is the single source of
+// truth; this shim exists so the StatusSupporter contract (Phase 1) keeps
+// working. Return order is lexicographic for determinism (see
+// DeriveSupportedStatuses). drift_test.go enforces declaration ↔ emit parity.
 func (p *Provider) SupportedStatuses() []agent.Status {
-	return []agent.Status{
-		agent.StatusRunning,
-		agent.StatusWaiting,
-		agent.StatusIdle,
-		agent.StatusError,
-		agent.StatusClear,
-	}
+	return agent.DeriveSupportedStatuses(p.Events())
 }
 
 func (p *Provider) IsAlive(tmuxTarget string) bool {

--- a/internal/agent/cc/provider_test.go
+++ b/internal/agent/cc/provider_test.go
@@ -84,6 +84,39 @@ func TestCCSupportedStatuses(t *testing.T) {
 	}
 }
 
+// TestCCSupportedStatuses_DerivesFromEvents asserts the post-Commit-3
+// invariant that SupportedStatuses is computed from Events().EmitsStatus
+// union rather than a hard-coded literal. Compared as sets.
+func TestCCSupportedStatuses_DerivesFromEvents(t *testing.T) {
+	p := cc.NewProvider(nil, nil, nil, nil)
+	ss := any(p).(agent.StatusSupporter)
+	got := ss.SupportedStatuses()
+
+	gotSet := make(map[agent.Status]bool, len(got))
+	for _, s := range got {
+		gotSet[s] = true
+	}
+	wantSet := make(map[agent.Status]bool)
+	for _, e := range p.Events() {
+		for _, s := range e.EmitsStatus {
+			wantSet[s] = true
+		}
+	}
+	if len(gotSet) != len(wantSet) {
+		t.Fatalf("SupportedStatuses=%v, events union=%v (len mismatch)", got, wantSet)
+	}
+	for s := range wantSet {
+		if !gotSet[s] {
+			t.Errorf("SupportedStatuses missing %q (from events union)", s)
+		}
+	}
+	for s := range gotSet {
+		if !wantSet[s] {
+			t.Errorf("SupportedStatuses contains %q not in events union", s)
+		}
+	}
+}
+
 // TestSupportedStatusesReturnsFreshSlice guards the defensive-copy convention
 // (per plan §1.1): mutating a returned slice must not affect a subsequent
 // call. Verified on cc; codex/opencode follow the same literal-return pattern.

--- a/internal/agent/codex/events.go
+++ b/internal/agent/codex/events.go
@@ -71,6 +71,7 @@ func (p *Provider) Events() []agent.HookEventSpec {
 			Name:        spec.Name,
 			EmitsStatus: append([]agent.Status(nil), spec.EmitsStatus...),
 			Description: spec.Description,
+			FutureOnly:  spec.FutureOnly,
 		}
 		if out[i].EmitsStatus == nil {
 			out[i].EmitsStatus = []agent.Status{}

--- a/internal/agent/codex/events.go
+++ b/internal/agent/codex/events.go
@@ -1,0 +1,96 @@
+package codex
+
+import "github.com/wake/purdex/internal/agent"
+
+// codexEventSpecs is the declarative hook event catalog for Codex. It
+// expands the previous 3-event installer (SessionStart, UserPromptSubmit,
+// Stop) to the full 9-event set (issue #613 / plan §1.4), reaching parity
+// with cc and with codex DeriveStatus, which has supported all 9 events
+// since Phase 1.
+//
+// The 6 newly-added events (SubagentStart, SubagentStop, StopFailure,
+// Notification, PermissionRequest, SessionEnd) may not be emitted by the
+// current codex CLI in every path. Declaring them is intentional per plan
+// §8 risk table: it rigs the installer so proxy paths and future CLI
+// versions land on ready infrastructure, and the drift test pins
+// Events() ↔ DeriveStatus parity either way.
+var codexEventSpecs = []agent.HookEventSpec{
+	{
+		Name:        "SessionStart",
+		EmitsStatus: []agent.Status{agent.StatusIdle},
+		Description: "Codex session started",
+	},
+	{
+		Name:        "UserPromptSubmit",
+		EmitsStatus: []agent.Status{agent.StatusRunning},
+		Description: "User submitted a prompt",
+	},
+	{
+		Name:        "SubagentStart",
+		EmitsStatus: []agent.Status{},
+		Description: "Nested sub-agent task dispatched",
+	},
+	{
+		Name:        "SubagentStop",
+		EmitsStatus: []agent.Status{},
+		Description: "Nested sub-agent task completed",
+	},
+	{
+		Name:        "Stop",
+		EmitsStatus: []agent.Status{agent.StatusIdle},
+		Description: "Agent finished responding and is idle",
+	},
+	{
+		Name:        "StopFailure",
+		EmitsStatus: []agent.Status{agent.StatusError},
+		Description: "Agent stopped due to an error",
+	},
+	{
+		Name:        "Notification",
+		EmitsStatus: []agent.Status{agent.StatusWaiting, agent.StatusIdle},
+		Description: "Permission/elicitation/idle prompt notifications",
+	},
+	{
+		Name:        "PermissionRequest",
+		EmitsStatus: []agent.Status{agent.StatusWaiting},
+		Description: "Tool permission request awaiting user approval",
+	},
+	{
+		Name:        "SessionEnd",
+		EmitsStatus: []agent.Status{agent.StatusClear},
+		Description: "Codex session ended",
+	},
+}
+
+// Events returns a fresh defensive copy of the codex hook event catalog on
+// every call.
+func (p *Provider) Events() []agent.HookEventSpec {
+	out := make([]agent.HookEventSpec, len(codexEventSpecs))
+	for i, spec := range codexEventSpecs {
+		out[i] = agent.HookEventSpec{
+			Name:        spec.Name,
+			EmitsStatus: append([]agent.Status(nil), spec.EmitsStatus...),
+			Description: spec.Description,
+		}
+		if out[i].EmitsStatus == nil {
+			out[i].EmitsStatus = []agent.Status{}
+		}
+	}
+	return out
+}
+
+// eventNames returns the ordered event Name list for installer / check
+// iteration, derived from codexEventSpecs so there is no parallel SSoT.
+func (p *Provider) eventNames() []string {
+	return codexEventNames()
+}
+
+// codexEventNames is the package-level helper used by mergeCodexHooks (a
+// free function, not a method).
+func codexEventNames() []string {
+	out := make([]string, 0, len(codexEventSpecs))
+	for _, spec := range codexEventSpecs {
+		out = append(out, spec.Name)
+	}
+	return out
+}

--- a/internal/agent/codex/events.go
+++ b/internal/agent/codex/events.go
@@ -29,11 +29,13 @@ var codexEventSpecs = []agent.HookEventSpec{
 		Name:        "SubagentStart",
 		EmitsStatus: []agent.Status{},
 		Description: "Nested sub-agent task dispatched",
+		FutureOnly:  true,
 	},
 	{
 		Name:        "SubagentStop",
 		EmitsStatus: []agent.Status{},
 		Description: "Nested sub-agent task completed",
+		FutureOnly:  true,
 	},
 	{
 		Name:        "Stop",
@@ -44,21 +46,25 @@ var codexEventSpecs = []agent.HookEventSpec{
 		Name:        "StopFailure",
 		EmitsStatus: []agent.Status{agent.StatusError},
 		Description: "Agent stopped due to an error",
+		FutureOnly:  true,
 	},
 	{
 		Name:        "Notification",
 		EmitsStatus: []agent.Status{agent.StatusWaiting, agent.StatusIdle},
 		Description: "Permission/elicitation/idle prompt notifications",
+		FutureOnly:  true,
 	},
 	{
 		Name:        "PermissionRequest",
 		EmitsStatus: []agent.Status{agent.StatusWaiting},
 		Description: "Tool permission request awaiting user approval",
+		FutureOnly:  true,
 	},
 	{
 		Name:        "SessionEnd",
 		EmitsStatus: []agent.Status{agent.StatusClear},
 		Description: "Codex session ended",
+		FutureOnly:  true,
 	},
 }
 

--- a/internal/agent/codex/events_test.go
+++ b/internal/agent/codex/events_test.go
@@ -119,3 +119,4 @@ func TestCodexEvents_DescriptionsNonEmpty(t *testing.T) {
 		}
 	}
 }
+

--- a/internal/agent/codex/events_test.go
+++ b/internal/agent/codex/events_test.go
@@ -102,6 +102,77 @@ func TestCodexEvents_DetailOnlyHaveEmptyEmitsStatus(t *testing.T) {
 	}
 }
 
+// TestCodexEventsFutureOnlyFlags is the fix-plan §2.2 CE1 assertion: codex
+// Events() declares exactly 3 non-FutureOnly events (SessionStart,
+// UserPromptSubmit, Stop — the pre-expansion 3-event installer set that
+// the codex CLI reliably emits today) and the remaining 6 events as
+// FutureOnly=true. See plan §1.3 for the matrix.
+func TestCodexEventsFutureOnlyFlags(t *testing.T) {
+	wantFutureOnly := map[string]bool{
+		"SessionStart":      false,
+		"UserPromptSubmit":  false,
+		"Stop":              false,
+		"SubagentStart":     true,
+		"SubagentStop":      true,
+		"StopFailure":       true,
+		"Notification":      true,
+		"PermissionRequest": true,
+		"SessionEnd":        true,
+	}
+	p := codex.NewProvider()
+	events := p.Events()
+	got := make(map[string]bool, len(events))
+	for _, e := range events {
+		got[e.Name] = e.FutureOnly
+	}
+	for name, want := range wantFutureOnly {
+		if g, ok := got[name]; !ok {
+			t.Errorf("codex Events missing %q", name)
+		} else if g != want {
+			t.Errorf("codex Events %q FutureOnly = %v, want %v", name, g, want)
+		}
+	}
+	if len(events) != len(wantFutureOnly) {
+		t.Fatalf("codex Events count = %d, want %d", len(events), len(wantFutureOnly))
+	}
+}
+
+// TestCodexEventsDefensiveCopyPreservesFutureOnly is the fix-plan §2.2 CE2
+// assertion: Events() returns a fresh copy on every call including the
+// FutureOnly bit. Mutating the returned slice's FutureOnly field must not
+// leak into the next Events() call — the installer-facing flag must survive
+// the defensive copy just like EmitsStatus does.
+func TestCodexEventsDefensiveCopyPreservesFutureOnly(t *testing.T) {
+	p := codex.NewProvider()
+	first := p.Events()
+	if len(first) == 0 {
+		t.Fatal("codex Events returned empty slice")
+	}
+	idx := -1
+	for i, e := range first {
+		if e.FutureOnly {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatal("codex Events has no FutureOnly=true spec; cannot exercise defensive copy")
+	}
+	originalName := first[idx].Name
+	first[idx].FutureOnly = false
+
+	second := p.Events()
+	for _, e := range second {
+		if e.Name == originalName {
+			if !e.FutureOnly {
+				t.Fatalf("codex Events second call spec %q FutureOnly = false, want true (defensive copy failed)", e.Name)
+			}
+			return
+		}
+	}
+	t.Fatalf("codex Events second call missing %q", originalName)
+}
+
 // TestCodexEvents_DescriptionsNonEmpty asserts descriptions are non-empty
 // and emoji-free.
 func TestCodexEvents_DescriptionsNonEmpty(t *testing.T) {

--- a/internal/agent/codex/events_test.go
+++ b/internal/agent/codex/events_test.go
@@ -1,0 +1,121 @@
+package codex_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/codex"
+)
+
+// expectedCodexEventNames is the post-expansion 9-event list (plan §1.4,
+// issue #613). Pre-expansion codex only installed {SessionStart,
+// UserPromptSubmit, Stop}; this PR brings the installer up to the full set
+// DeriveStatus has already supported since Phase 1.
+var expectedCodexEventNames = []string{
+	"SessionStart",
+	"UserPromptSubmit",
+	"SubagentStart",
+	"SubagentStop",
+	"Stop",
+	"StopFailure",
+	"Notification",
+	"PermissionRequest",
+	"SessionEnd",
+}
+
+// TestCodexEvents_ExpandedTo9 is the core issue #613 assertion — codex
+// Events() now declares 9 events, matching cc.
+func TestCodexEvents_ExpandedTo9(t *testing.T) {
+	p := codex.NewProvider()
+	events := p.Events()
+	if len(events) != 9 {
+		t.Fatalf("codex Events count = %d, want 9 (issue #613 installer expansion)", len(events))
+	}
+
+	got := make(map[string]bool, len(events))
+	for _, e := range events {
+		if got[e.Name] {
+			t.Errorf("codex Events contains duplicate Name %q", e.Name)
+		}
+		got[e.Name] = true
+	}
+	want := make(map[string]bool, len(expectedCodexEventNames))
+	for _, n := range expectedCodexEventNames {
+		want[n] = true
+	}
+	for n := range want {
+		if !got[n] {
+			t.Errorf("codex Events missing required Name %q (post-expansion)", n)
+		}
+	}
+	for n := range got {
+		if !want[n] {
+			t.Errorf("codex Events contains unexpected Name %q", n)
+		}
+	}
+}
+
+// TestCodexEvents_EmitsStatusForNotification asserts codex Notification is
+// declared to emit {Waiting, Idle} matching cc.
+func TestCodexEvents_EmitsStatusForNotification(t *testing.T) {
+	p := codex.NewProvider()
+	var spec *agent.HookEventSpec
+	for _, e := range p.Events() {
+		if e.Name == "Notification" {
+			ec := e
+			spec = &ec
+			break
+		}
+	}
+	if spec == nil {
+		t.Fatal("codex Events missing Notification entry")
+	}
+	got := make(map[agent.Status]bool, len(spec.EmitsStatus))
+	for _, s := range spec.EmitsStatus {
+		got[s] = true
+	}
+	for _, want := range []agent.Status{agent.StatusWaiting, agent.StatusIdle} {
+		if !got[want] {
+			t.Errorf("codex Notification EmitsStatus missing %q (got %v)", want, spec.EmitsStatus)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("codex Notification EmitsStatus = %v, want exactly {Waiting, Idle}", spec.EmitsStatus)
+	}
+}
+
+// TestCodexEvents_DetailOnlyHaveEmptyEmitsStatus enforces empty-slice
+// semantics for detail-only SubagentStart/Stop.
+func TestCodexEvents_DetailOnlyHaveEmptyEmitsStatus(t *testing.T) {
+	p := codex.NewProvider()
+	for _, e := range p.Events() {
+		if e.Name != "SubagentStart" && e.Name != "SubagentStop" {
+			continue
+		}
+		if e.EmitsStatus == nil {
+			t.Errorf("codex %s EmitsStatus is nil; want non-nil empty slice", e.Name)
+		}
+		if len(e.EmitsStatus) != 0 {
+			t.Errorf("codex %s EmitsStatus = %v, want empty", e.Name, e.EmitsStatus)
+		}
+	}
+}
+
+// TestCodexEvents_DescriptionsNonEmpty asserts descriptions are non-empty
+// and emoji-free.
+func TestCodexEvents_DescriptionsNonEmpty(t *testing.T) {
+	p := codex.NewProvider()
+	for _, e := range p.Events() {
+		if strings.TrimSpace(e.Description) == "" {
+			t.Errorf("codex %s Description is empty", e.Name)
+			continue
+		}
+		for _, r := range e.Description {
+			if r >= 0x1F300 && r <= 0x1FAFF {
+				t.Errorf("codex %s Description contains emoji rune %U: %q", e.Name, r, e.Description)
+				break
+			}
+		}
+	}
+}

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -53,28 +53,14 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		return agent.HookStatus{}, fmt.Errorf("parse hooks.json: %w", err)
 	}
 	hooks, _ := hooksFile["hooks"].(map[string]any)
-	eventNames := p.eventNames()
-	events := make(map[string]agent.HookEventInfo, len(eventNames))
+	events := make(map[string]agent.HookEventInfo, len(codexEventSpecs))
 	var issues []string
 	allInstalled := true
-	for _, eventName := range eventNames {
-		entries, ok := hooks[eventName]
-		if !ok {
-			events[eventName] = agent.HookEventInfo{Installed: false}
-			issues = append(issues, eventName+" hook not installed")
-			allInstalled = false
-			continue
-		}
-		if hasLegacyPdxDirectCodexEntry(entries) {
-			events[eventName] = agent.HookEventInfo{Installed: false}
-			issues = append(issues, eventName+" hook uses legacy format; reinstall required")
-			allInstalled = false
-			continue
-		}
-		command := findPdxCommandInCodex(entries)
-		events[eventName] = agent.HookEventInfo{Installed: command != "", Command: command}
-		if command == "" {
-			issues = append(issues, eventName+" hook: pdx command not found")
+	for _, spec := range p.Events() {
+		info, addIssues, blocks := checkCodexEvent(spec, hooks)
+		events[spec.Name] = info
+		issues = append(issues, addIssues...)
+		if blocks {
 			allInstalled = false
 		}
 	}
@@ -86,6 +72,52 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		SupportedVersion: codexHooksSupportedVersion,
 		ExceedsSupport:   agent.CompareHookAgentVersions(agentVersion, codexHooksSupportedVersion) > 0,
 	}, nil
+}
+
+// checkCodexEvent classifies a single hook event as absent / broken / valid
+// per fix-plan §1.4 and applies the FutureOnly-aware decision table. It
+// takes the full hooks map so absent vs present-but-empty can be told apart
+// via the double-return form `entries, ok := hooks[spec.Name]` — a value of
+// `[]any{}` (what mergeCodexHooks leaves behind when the last pdx entry is
+// removed) must be classified as broken, not absent.
+//
+// Returns:
+//   - HookEventInfo for events[spec.Name]
+//   - zero or more Issue strings to append
+//   - whether this event blocks allInstalled
+func checkCodexEvent(spec agent.HookEventSpec, hooks map[string]any) (agent.HookEventInfo, []string, bool) {
+	entries, keyExists := hooks[spec.Name]
+	// State A — absent (strict: key not present in map).
+	if !keyExists {
+		info := agent.HookEventInfo{Installed: false}
+		if spec.FutureOnly {
+			// Tolerated legacy: no issue, does not block.
+			return info, nil, false
+		}
+		return info, []string{spec.Name + " hook not installed"}, true
+	}
+	// Legacy direct-entry shape is its own signal (present but uses the
+	// pre-0.121 shape pdx installer no longer writes).
+	if hasLegacyPdxDirectCodexEntry(entries) {
+		return agent.HookEventInfo{Installed: false},
+			[]string{spec.Name + " hook uses legacy format; reinstall required"},
+			true
+	}
+	// Find a pdx command inside the matcher-group list. Empty entries, wrong
+	// shape, or no pdx command all collapse to command == "" here → State B.
+	command := findPdxCommandInCodex(entries)
+	if command == "" {
+		if spec.FutureOnly {
+			return agent.HookEventInfo{Installed: false},
+				[]string{spec.Name + " hook: pdx command malformed (FutureOnly event has existing hook entry but pdx path incorrect — run install to repair)"},
+				true
+		}
+		return agent.HookEventInfo{Installed: false},
+			[]string{spec.Name + " hook: pdx command not found"},
+			true
+	}
+	// State C — valid.
+	return agent.HookEventInfo{Installed: true, Command: command}, nil, false
 }
 
 func mergeCodexHooks(path, pdxPath string, remove bool) error {

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -36,6 +36,13 @@ func (p *Provider) RemoveHooks(pdxPath string) error {
 	return mergeCodexHooks(hooksPath, pdxPath, true)
 }
 
+// Events returns the hook event declarations for Codex. Stub; filled in a
+// later commit (HookInstaller.Events() plan §3 Commit 5 — the issue #613
+// installer expansion from 3 events to 9).
+func (p *Provider) Events() []agent.HookEventSpec {
+	return nil
+}
+
 func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -10,12 +10,6 @@ import (
 	"github.com/wake/purdex/internal/agent"
 )
 
-var codexHookEvents = []string{
-	"SessionStart",
-	"UserPromptSubmit",
-	"Stop",
-}
-
 const codexHooksSupportedVersion = "0.121.0"
 
 func (p *Provider) InstallHooks(pdxPath string) error {
@@ -34,13 +28,6 @@ func (p *Provider) RemoveHooks(pdxPath string) error {
 	}
 	hooksPath := filepath.Join(home, ".codex", "hooks.json")
 	return mergeCodexHooks(hooksPath, pdxPath, true)
-}
-
-// Events returns the hook event declarations for Codex. Stub; filled in a
-// later commit (HookInstaller.Events() plan §3 Commit 5 — the issue #613
-// installer expansion from 3 events to 9).
-func (p *Provider) Events() []agent.HookEventSpec {
-	return nil
 }
 
 func (p *Provider) CheckHooks() (agent.HookStatus, error) {
@@ -66,10 +53,11 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		return agent.HookStatus{}, fmt.Errorf("parse hooks.json: %w", err)
 	}
 	hooks, _ := hooksFile["hooks"].(map[string]any)
-	events := make(map[string]agent.HookEventInfo, len(codexHookEvents))
+	eventNames := p.eventNames()
+	events := make(map[string]agent.HookEventInfo, len(eventNames))
 	var issues []string
 	allInstalled := true
-	for _, eventName := range codexHookEvents {
+	for _, eventName := range eventNames {
 		entries, ok := hooks[eventName]
 		if !ok {
 			events[eventName] = agent.HookEventInfo{Installed: false}
@@ -117,7 +105,7 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 	if hooks == nil {
 		hooks = make(map[string]any)
 	}
-	for _, event := range codexHookEvents {
+	for _, event := range codexEventNames() {
 		entries := filterOutPdxCodex(hooks[event])
 		if !remove {
 			entries = append(entries, map[string]any{

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -53,25 +53,73 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		return agent.HookStatus{}, fmt.Errorf("parse hooks.json: %w", err)
 	}
 	hooks, _ := hooksFile["hooks"].(map[string]any)
-	events := make(map[string]agent.HookEventInfo, len(codexEventSpecs))
+	specs := p.Events()
+	events := make(map[string]agent.HookEventInfo, len(specs))
 	var issues []string
+	var upgrades []string
 	allInstalled := true
-	for _, spec := range p.Events() {
+	for _, spec := range specs {
 		info, addIssues, blocks := checkCodexEvent(spec, hooks)
+		// Propagate the FutureOnly bit to HookEventInfo so the UI can
+		// render "tolerated absent" vs "required missing" distinctly.
+		info.FutureOnly = spec.FutureOnly
 		events[spec.Name] = info
 		issues = append(issues, addIssues...)
 		if blocks {
 			allInstalled = false
 		}
+		if spec.FutureOnly && !info.Installed {
+			// Tolerated-absent FutureOnly → advertise as available upgrade.
+			if _, keyExists := hooks[spec.Name]; !keyExists {
+				upgrades = append(upgrades, spec.Name)
+			}
+		}
 	}
+	managed := codexHooksManaged(hooks, specs)
 	return agent.HookStatus{
-		Installed:        allInstalled,
-		Events:           events,
-		Issues:           issues,
-		AgentVersion:     agentVersion,
-		SupportedVersion: codexHooksSupportedVersion,
-		ExceedsSupport:   agent.CompareHookAgentVersions(agentVersion, codexHooksSupportedVersion) > 0,
+		Installed:         allInstalled,
+		Managed:           managed,
+		UpgradesAvailable: upgrades,
+		Events:            events,
+		Issues:            issues,
+		AgentVersion:      agentVersion,
+		SupportedVersion:  codexHooksSupportedVersion,
+		ExceedsSupport:    agent.CompareHookAgentVersions(agentVersion, codexHooksSupportedVersion) > 0,
 	}, nil
+}
+
+// codexHooksManaged reports whether hooks.json contains any pdx-owned
+// entry (per-event matcher-group shape OR legacy direct-entry shape).
+// Distinct from CheckHooks.Installed: a drifted-but-pdx-owned state has
+// Managed=true and Installed=false, which the UI needs so the Remove
+// button stays enabled.
+func codexHooksManaged(hooks map[string]any, specs []agent.HookEventSpec) bool {
+	for _, spec := range specs {
+		entries, ok := hooks[spec.Name]
+		if !ok {
+			continue
+		}
+		if hasLegacyPdxDirectCodexEntry(entries) {
+			return true
+		}
+		for _, groupEntry := range codexMatcherGroups(entries) {
+			group, ok := groupEntry.(map[string]any)
+			if !ok {
+				continue
+			}
+			for _, entry := range toCodexEntrySlice(group["hooks"]) {
+				m, ok := entry.(map[string]any)
+				if !ok {
+					continue
+				}
+				cmd, _ := m["command"].(string)
+				if isPdxCommandCodex(cmd) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // checkCodexEvent classifies a single hook event as absent / broken / valid

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -236,9 +236,10 @@ func isPdxCommandCodex(cmd string) bool {
 
 // isPdxCommandCodexForEvent reports whether cmd is a well-formed pdx hook
 // command for the given event name. Rules (all must hold):
-//  1. The first non-empty token, stripped of a leading/trailing ", has
-//     basename "pdx" (covers "/abs/path/pdx", "pdx", and the quoted forms
-//     mergeCodexHooks writes).
+//  1. The first non-empty token, stripped of surrounding quotes, has
+//     basename "pdx" (covers "/abs/path/pdx", "pdx", the quoted forms
+//     mergeCodexHooks writes, and paths containing spaces such as
+//     "/Applications/Purdex Beta/pdx").
 //  2. Some later token equals "hook".
 //  3. Two consecutive tokens "--agent" "codex" appear after "hook".
 //  4. The final non-empty token equals eventName exactly.
@@ -246,19 +247,16 @@ func isPdxCommandCodex(cmd string) bool {
 // A non-pdx third-party command, a pdx command targeting a different
 // agent, or a copy of a pdx command whose event-name tail does not
 // match the key it is filed under, all return false. Token splitting
-// uses strings.Fields; the current installer only emits simple double-
-// quoted paths ("/abs/pdx"), so the Fields-then-trim-quotes approach
-// is sufficient for the on-disk shapes we own. A path containing a
-// literal space would still round-trip because Fields splits on any
-// run of whitespace — such a path would already fail on the installer
-// write side (no shell quoting), and the managed installer output we
-// need to validate never contains one.
+// is quote-aware (see tokenizeCodexCommand) so double-quoted paths
+// with literal spaces round-trip correctly — the installer emits
+// "<pdxPath>" hook --agent codex <event>, where pdxPath may contain
+// spaces on macOS app-bundle layouts.
 func isPdxCommandCodexForEvent(cmd string, eventName string) bool {
-	tokens := strings.Fields(cmd)
+	tokens := tokenizeCodexCommand(cmd)
 	if len(tokens) == 0 {
 		return false
 	}
-	first := strings.Trim(tokens[0], `"`)
+	first := tokens[0]
 	if first == "" {
 		return false
 	}
@@ -278,8 +276,51 @@ func isPdxCommandCodexForEvent(cmd string, eventName string) bool {
 	if !hasHook || !hasAgentCodex {
 		return false
 	}
-	tail := strings.Trim(tokens[len(tokens)-1], `"`)
-	return tail == eventName
+	return tokens[len(tokens)-1] == eventName
+}
+
+// tokenizeCodexCommand splits a codex hook command string into tokens,
+// respecting single and double quotes. Whitespace inside a quoted run
+// is preserved; quote characters themselves are stripped. This lets
+// the installer's output "<pdxPath>" hook --agent codex <event>
+// round-trip correctly when pdxPath contains spaces (e.g. macOS
+// "/Applications/Purdex Beta/pdx"). Escape sequences are not
+// interpreted — the installer never emits them.
+func tokenizeCodexCommand(cmd string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inQuote := false
+	var quoteChar byte
+	flush := func() {
+		if cur.Len() > 0 {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+		}
+	}
+	for i := 0; i < len(cmd); i++ {
+		c := cmd[i]
+		if inQuote {
+			if c == quoteChar {
+				inQuote = false
+				quoteChar = 0
+				continue
+			}
+			cur.WriteByte(c)
+			continue
+		}
+		if c == '"' || c == '\'' {
+			inQuote = true
+			quoteChar = c
+			continue
+		}
+		if c == ' ' || c == '\t' || c == '\n' {
+			flush()
+			continue
+		}
+		cur.WriteByte(c)
+	}
+	flush()
+	return tokens
 }
 
 // findPdxCommandInCodexForEvent walks the matcher-group list and returns the

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -103,9 +103,12 @@ func checkCodexEvent(spec agent.HookEventSpec, hooks map[string]any) (agent.Hook
 			[]string{spec.Name + " hook uses legacy format; reinstall required"},
 			true
 	}
-	// Find a pdx command inside the matcher-group list. Empty entries, wrong
-	// shape, or no pdx command all collapse to command == "" here → State B.
-	command := findPdxCommandInCodex(entries)
+	// Find a pdx command inside the matcher-group list that passes strict
+	// per-event validation (tokenized binary / --agent codex / matching event
+	// name tail). Empty entries, wrong shape, wrong agent, wrong event-name
+	// tail all collapse to command == "" here → State B. Substring matches
+	// alone no longer qualify: PR #616 review Finding #1.
+	command := findPdxCommandInCodexForEvent(entries, spec.Name)
 	if command == "" {
 		if spec.FutureOnly {
 			return agent.HookEventInfo{Installed: false},
@@ -171,13 +174,71 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 	return nil
 }
 
+// isPdxCommandCodex is the relaxed shape check used by filter / legacy
+// detection paths where we only need to know "does this look like any pdx
+// hook command?" — e.g. when mergeCodexHooks strips all pdx entries before
+// rewriting, or when hasLegacyPdxDirectCodexEntry tags the pre-0.121
+// direct-entry shape. Per-event health assertions must not use this; see
+// isPdxCommandCodexForEvent (PR #616 review Finding #1).
 func isPdxCommandCodex(cmd string) bool {
 	// Match both quoted ("/path/pdx" hook) and unquoted (/path/pdx hook) forms.
 	normalized := strings.ReplaceAll(cmd, `"`, "")
 	return strings.Contains(normalized, "pdx hook")
 }
 
-func findPdxCommandInCodex(entries any) string {
+// isPdxCommandCodexForEvent reports whether cmd is a well-formed pdx hook
+// command for the given event name. Rules (all must hold):
+//  1. The first non-empty token, stripped of a leading/trailing ", has
+//     basename "pdx" (covers "/abs/path/pdx", "pdx", and the quoted forms
+//     mergeCodexHooks writes).
+//  2. Some later token equals "hook".
+//  3. Two consecutive tokens "--agent" "codex" appear after "hook".
+//  4. The final non-empty token equals eventName exactly.
+//
+// A non-pdx third-party command, a pdx command targeting a different
+// agent, or a copy of a pdx command whose event-name tail does not
+// match the key it is filed under, all return false. Token splitting
+// uses strings.Fields; the current installer only emits simple double-
+// quoted paths ("/abs/pdx"), so the Fields-then-trim-quotes approach
+// is sufficient for the on-disk shapes we own. A path containing a
+// literal space would still round-trip because Fields splits on any
+// run of whitespace — such a path would already fail on the installer
+// write side (no shell quoting), and the managed installer output we
+// need to validate never contains one.
+func isPdxCommandCodexForEvent(cmd string, eventName string) bool {
+	tokens := strings.Fields(cmd)
+	if len(tokens) == 0 {
+		return false
+	}
+	first := strings.Trim(tokens[0], `"`)
+	if first == "" {
+		return false
+	}
+	if filepath.Base(first) != "pdx" {
+		return false
+	}
+	hasHook := false
+	hasAgentCodex := false
+	for i := 1; i < len(tokens); i++ {
+		if tokens[i] == "hook" {
+			hasHook = true
+		}
+		if tokens[i] == "--agent" && i+1 < len(tokens) && tokens[i+1] == "codex" {
+			hasAgentCodex = true
+		}
+	}
+	if !hasHook || !hasAgentCodex {
+		return false
+	}
+	tail := strings.Trim(tokens[len(tokens)-1], `"`)
+	return tail == eventName
+}
+
+// findPdxCommandInCodexForEvent walks the matcher-group list and returns the
+// first command that passes isPdxCommandCodexForEvent for the given event
+// name. Empty return means no qualifying command was found → checkCodexEvent
+// classifies the event as broken.
+func findPdxCommandInCodexForEvent(entries any, eventName string) string {
 	for _, groupEntry := range codexMatcherGroups(entries) {
 		group, ok := groupEntry.(map[string]any)
 		if !ok {
@@ -189,7 +250,7 @@ func findPdxCommandInCodex(entries any) string {
 				continue
 			}
 			cmd, _ := m["command"].(string)
-			if isPdxCommandCodex(cmd) {
+			if isPdxCommandCodexForEvent(cmd, eventName) {
 				return cmd
 			}
 		}

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -739,6 +739,147 @@ func TestCheckHooks_FutureOnlyAbsent_DoesNotBlock(t *testing.T) {
 	}
 }
 
+// CH10 — HookStatus.Managed reflects "is there any pdx-managed artifact in
+// hooks.json?": present for even a single broken pdx entry, absent when
+// no pdx entries exist. PR #616 review Finding #2: UI Remove button must
+// stay enabled for drifted-but-managed state.
+func TestCheckHooks_Managed_ReflectsArtifactPresence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Legacy direct-entry shape (broken, pdx-owned) → Managed=true.
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart": []any{
+			map[string]any{
+				"type":    "command",
+				"command": `"/usr/local/bin/pdx" hook --agent codex SessionStart`,
+				"timeout": 5,
+			},
+		},
+	})
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatal("legacy direct entry: allInstalled=true, want false")
+	}
+	if !status.Managed {
+		t.Fatal("legacy direct entry present: Managed=false, want true")
+	}
+}
+
+// CH11 — Managed=false when hooks.json has no pdx entries anywhere.
+func TestCheckHooks_Managed_FalseWhenNoPdxEntries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart": []any{
+			map[string]any{
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": "/usr/bin/notify-me start",
+						"timeout": 5,
+					},
+				},
+			},
+		},
+	})
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Managed {
+		t.Fatal("no pdx entries: Managed=true, want false")
+	}
+}
+
+// CH12 — UpgradesAvailable lists FutureOnly events absent from hooks.json
+// when the overall install is otherwise valid (legacy 3-event user).
+// Finding #4: UI must be able to surface "6 new events available" even
+// though Installed=true.
+func TestCheckHooks_UpgradesAvailable_PopulatedForLegacyCodex(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":             []any{pdxGroupEntry("Stop")},
+	})
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if !status.Installed {
+		t.Fatalf("legacy 3-event: Installed=false, Issues=%v", status.Issues)
+	}
+	want := map[string]bool{
+		"SubagentStart":     true,
+		"SubagentStop":      true,
+		"StopFailure":       true,
+		"Notification":      true,
+		"PermissionRequest": true,
+		"SessionEnd":        true,
+	}
+	if len(status.UpgradesAvailable) != len(want) {
+		t.Fatalf("UpgradesAvailable=%v, want %d entries", status.UpgradesAvailable, len(want))
+	}
+	for _, name := range status.UpgradesAvailable {
+		if !want[name] {
+			t.Errorf("unexpected upgrade name %q", name)
+		}
+	}
+}
+
+// CH13 — UpgradesAvailable is empty once every FutureOnly event is
+// installed.
+func TestCheckHooks_UpgradesAvailable_EmptyOnFullInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	full := map[string]any{}
+	for _, name := range expectedCodexInstallerNames {
+		full[name] = []any{pdxGroupEntry(name)}
+	}
+	writeHooksFile(t, home, full)
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if len(status.UpgradesAvailable) != 0 {
+		t.Fatalf("full install: UpgradesAvailable=%v, want empty", status.UpgradesAvailable)
+	}
+}
+
+// CH14 — per-event HookEventInfo carries FutureOnly bit for the UI to
+// distinguish "tolerated absent" from "missing installer-required event".
+func TestCheckHooks_EventInfoCarriesFutureOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	full := map[string]any{}
+	for _, name := range expectedCodexInstallerNames {
+		full[name] = []any{pdxGroupEntry(name)}
+	}
+	writeHooksFile(t, home, full)
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	requiredFalse := []string{"SessionStart", "UserPromptSubmit", "Stop"}
+	for _, name := range requiredFalse {
+		if status.Events[name].FutureOnly {
+			t.Errorf("event %q FutureOnly=true, want false", name)
+		}
+	}
+	futureOnly := []string{"SubagentStart", "SubagentStop", "StopFailure", "Notification", "PermissionRequest", "SessionEnd"}
+	for _, name := range futureOnly {
+		if !status.Events[name].FutureOnly {
+			t.Errorf("event %q FutureOnly=false, want true", name)
+		}
+	}
+}
+
 // CH7 — cross-event mis-filing: a valid-looking pdx command for the Stop
 // event is copied into the Notification key (e.g. user hand-edit or
 // legacy tooling). The substring-only check `strings.Contains(cmd,

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -961,6 +962,11 @@ func TestIsPdxCommandCodexForEvent(t *testing.T) {
 		{`pdx hook --agent codex SessionStart`, "SessionStart"},
 		{`/usr/local/bin/pdx hook --agent codex UserPromptSubmit`, "UserPromptSubmit"},
 		{`"/usr/local/bin/pdx" hook --agent codex Notification`, "Notification"},
+		// Round-3 review E2: spaces inside a quoted path must not
+		// break the match. Macs installing Purdex as an app bundle
+		// end up with a pdxPath like /Applications/Purdex Beta/pdx.
+		{`"/Applications/Purdex Beta/pdx" hook --agent codex Stop`, "Stop"},
+		{`"/path with two  spaces/pdx" hook --agent codex SessionEnd`, "SessionEnd"},
 	}
 	for _, tc := range positive {
 		if !isPdxCommandCodexForEvent(tc.cmd, tc.event) {
@@ -981,6 +987,31 @@ func TestIsPdxCommandCodexForEvent(t *testing.T) {
 	for _, tc := range negative {
 		if isPdxCommandCodexForEvent(tc.cmd, tc.event) {
 			t.Errorf("expected invalid for %q / event=%s (%s)", tc.cmd, tc.event, tc.reason)
+		}
+	}
+}
+
+// Round-3 review E2: quote-aware tokenizer must preserve spaces inside
+// quoted runs so installer output for app-bundle pdxPaths is accepted
+// by isPdxCommandCodexForEvent. strings.Fields collapses runs of
+// whitespace regardless of surrounding quotes and cannot be used.
+func TestTokenizeCodexCommand(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{`pdx hook --agent codex Stop`, []string{"pdx", "hook", "--agent", "codex", "Stop"}},
+		{`"/abs/pdx" hook --agent codex Stop`, []string{"/abs/pdx", "hook", "--agent", "codex", "Stop"}},
+		{`"/Applications/Purdex Beta/pdx" hook --agent codex Stop`, []string{"/Applications/Purdex Beta/pdx", "hook", "--agent", "codex", "Stop"}},
+		{`"/path with two  spaces/pdx" hook --agent codex SessionEnd`, []string{"/path with two  spaces/pdx", "hook", "--agent", "codex", "SessionEnd"}},
+		{`'/single quoted/pdx' hook --agent codex Stop`, []string{"/single quoted/pdx", "hook", "--agent", "codex", "Stop"}},
+		{``, nil},
+		{`   `, nil},
+	}
+	for _, tc := range cases {
+		got := tokenizeCodexCommand(tc.in)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("tokenizeCodexCommand(%q) = %#v, want %#v", tc.in, got, tc.want)
 		}
 	}
 }

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -739,6 +739,111 @@ func TestCheckHooks_FutureOnlyAbsent_DoesNotBlock(t *testing.T) {
 	}
 }
 
+// CH7 — cross-event mis-filing: a valid-looking pdx command for the Stop
+// event is copied into the Notification key (e.g. user hand-edit or
+// legacy tooling). The substring-only check `strings.Contains(cmd,
+// "pdx hook")` classifies this as valid; strict per-event tokenization
+// must reject it and report the event broken. This is the Finding #1
+// regression guard.
+func TestCheckHooks_WrongEventNameCommand_ClassifiesAsBroken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":             []any{pdxGroupEntry("Stop")},
+		// Notification key with a pdx command whose event-name token is
+		// "Stop" — must be classified as broken for Notification, not valid.
+		"Notification": []any{pdxGroupEntry("Stop")},
+	})
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatal("wrong-event-name command: allInstalled=true, want false")
+	}
+	if status.Events["Notification"].Installed {
+		t.Fatal("Notification Installed=true, want false (command tail is 'Stop', not 'Notification')")
+	}
+	if !issuesContain(status.Issues, "Notification hook: pdx command malformed") {
+		t.Fatalf("wrong-event-name: issues=%v, want malformed warning", status.Issues)
+	}
+}
+
+// CH8 — wrong agent in command: Notification key contains a command
+// that targets --agent cc instead of --agent codex. Must be classified
+// as broken. Also Finding #1 regression guard.
+func TestCheckHooks_WrongAgentCommand_ClassifiesAsBroken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":             []any{pdxGroupEntry("Stop")},
+		"Notification": []any{
+			map[string]any{
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": `"/usr/local/bin/pdx" hook --agent cc Notification`,
+						"timeout": 5,
+					},
+				},
+			},
+		},
+	})
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatal("wrong-agent command: allInstalled=true, want false")
+	}
+	if status.Events["Notification"].Installed {
+		t.Fatal("Notification Installed=true, want false (--agent cc, not codex)")
+	}
+	if !issuesContain(status.Issues, "Notification hook: pdx command malformed") {
+		t.Fatalf("wrong-agent: issues=%v, want malformed warning", status.Issues)
+	}
+}
+
+// CH9 — unit coverage of the new per-event command validator. Positive
+// cases: unquoted abs-path pdx, quoted abs-path pdx, bare pdx. Negative
+// cases: missing --agent codex, wrong event-name tail, non-pdx binary.
+func TestIsPdxCommandCodexForEvent(t *testing.T) {
+	positive := []struct {
+		cmd, event string
+	}{
+		{`pdx hook --agent codex SessionStart`, "SessionStart"},
+		{`/usr/local/bin/pdx hook --agent codex UserPromptSubmit`, "UserPromptSubmit"},
+		{`"/usr/local/bin/pdx" hook --agent codex Notification`, "Notification"},
+	}
+	for _, tc := range positive {
+		if !isPdxCommandCodexForEvent(tc.cmd, tc.event) {
+			t.Errorf("expected valid for %q / event=%s", tc.cmd, tc.event)
+		}
+	}
+
+	negative := []struct {
+		cmd, event string
+		reason     string
+	}{
+		{`pdx hook codex SessionStart`, "SessionStart", "missing --agent codex"},
+		{`pdx hook --agent codex Stop`, "Notification", "wrong event-name tail"},
+		{`/usr/local/bin/pdx hook --agent cc Notification`, "Notification", "wrong agent"},
+		{`other-tool hook --agent codex Stop`, "Stop", "non-pdx binary"},
+		{`"/usr/local/bin/pdx" hook --agent codex`, "Stop", "missing event name"},
+	}
+	for _, tc := range negative {
+		if isPdxCommandCodexForEvent(tc.cmd, tc.event) {
+			t.Errorf("expected invalid for %q / event=%s (%s)", tc.cmd, tc.event, tc.reason)
+		}
+	}
+}
+
 // CH6 — the strict-absent distinction (plan §1.4): a FutureOnly event with
 // an empty entry array (hooks[event]=[]) is classified as broken, not
 // absent, because mergeCodexHooks' remove path can legitimately leave []

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -111,7 +111,7 @@ func TestMergeCodexHooks_EmptyFile(t *testing.T) {
 	m := readHooksFile(t, path)
 	hooks := hooksSection(t, m)
 
-	for _, event := range codexHookEvents {
+	for _, event := range expectedCodexInstallerNames {
 		entries, ok := hooks[event]
 		if !ok {
 			t.Errorf("event %s not found", event)
@@ -128,8 +128,8 @@ func TestMergeCodexHooks_EmptyFile(t *testing.T) {
 			t.Errorf("event %s has no hook handlers", event)
 		}
 	}
-	if len(hooks) != len(codexHookEvents) {
-		t.Errorf("expected %d hook events, got %d", len(codexHookEvents), len(hooks))
+	if len(hooks) != len(expectedCodexInstallerNames) {
+		t.Errorf("expected %d hook events, got %d", len(expectedCodexInstallerNames), len(hooks))
 	}
 }
 
@@ -148,7 +148,7 @@ func TestMergeCodexHooks_Idempotent(t *testing.T) {
 	m := readHooksFile(t, path)
 	hooks := hooksSection(t, m)
 
-	for _, event := range codexHookEvents {
+	for _, event := range expectedCodexInstallerNames {
 		pdxCount := 0
 		for _, groupEntry := range codexMatcherGroups(hooks[event]) {
 			group, _ := groupEntry.(map[string]any)
@@ -265,7 +265,7 @@ func TestMergeCodexHooks_RemoveMode(t *testing.T) {
 	m = readHooksFile(t, path)
 	hooks = hooksSection(t, m)
 
-	for _, event := range codexHookEvents {
+	for _, event := range expectedCodexInstallerNames {
 		for _, groupEntry := range codexMatcherGroups(hooks[event]) {
 			group, _ := groupEntry.(map[string]any)
 			for _, hookEntry := range toCodexEntrySlice(group["hooks"]) {
@@ -298,6 +298,103 @@ func TestMergeCodexHooks_RemoveMode(t *testing.T) {
 	}
 	if !found {
 		t.Error("non-pdx hook was incorrectly removed")
+	}
+}
+
+// expectedCodexInstallerNames is the post-expansion 9-event installer set
+// (plan §1.4 / issue #613). Shared across TestMergeCodexHooks_* so the
+// installer tests migrate off codexHookEvents cleanly.
+var expectedCodexInstallerNames = []string{
+	"SessionStart",
+	"UserPromptSubmit",
+	"SubagentStart",
+	"SubagentStop",
+	"Stop",
+	"StopFailure",
+	"Notification",
+	"PermissionRequest",
+	"SessionEnd",
+}
+
+// TestCodexInstallHooks_Writes9EventsAfterExpansion is the primary issue
+// #613 regression guard: installer must write the full 9-event set,
+// especially the 6 newly added (SubagentStart/Stop, StopFailure,
+// Notification, PermissionRequest, SessionEnd). Any future change that
+// shrinks the installer back to the pre-expansion 3-event set trips here.
+func TestCodexInstallHooks_Writes9EventsAfterExpansion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+
+	if err := mergeCodexHooks(path, "/usr/local/bin/pdx", false); err != nil {
+		t.Fatalf("mergeCodexHooks: %v", err)
+	}
+
+	m := readHooksFile(t, path)
+	hooks := hooksSection(t, m)
+
+	if len(hooks) != 9 {
+		t.Errorf("codex installer wrote %d events, want 9 (issue #613 expansion)", len(hooks))
+	}
+
+	wantExpanded := []string{
+		"SubagentStart",
+		"SubagentStop",
+		"StopFailure",
+		"Notification",
+		"PermissionRequest",
+		"SessionEnd",
+	}
+	for _, name := range wantExpanded {
+		if _, ok := hooks[name]; !ok {
+			t.Errorf("expanded event %q not written to hooks.json (issue #613 regression)", name)
+		}
+	}
+	for _, name := range expectedCodexInstallerNames {
+		entries, ok := hooks[name]
+		if !ok {
+			t.Errorf("event %q not written to hooks.json", name)
+			continue
+		}
+		groups := codexMatcherGroups(entries)
+		if len(groups) == 0 {
+			t.Errorf("event %q has no matcher groups", name)
+		}
+	}
+}
+
+// TestCodexCheckHooks_ReportsAll9Events asserts CheckHooks sees every event
+// in the expanded set.
+func TestCodexCheckHooks_ReportsAll9Events(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := mergeCodexHooks(hooksPath, "/usr/local/bin/pdx", false); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if len(status.Events) != 9 {
+		t.Errorf("CheckHooks reported %d events, want 9", len(status.Events))
+	}
+	for _, name := range expectedCodexInstallerNames {
+		info, ok := status.Events[name]
+		if !ok {
+			t.Errorf("CheckHooks.Events missing key %q", name)
+			continue
+		}
+		if !info.Installed {
+			t.Errorf("event %q: Installed=false after fresh install", name)
+		}
+	}
+	if !status.Installed {
+		t.Errorf("Installed=false after full install, issues=%v", status.Issues)
 	}
 }
 
@@ -384,13 +481,19 @@ func TestCheckHooks_ThirdPartyLegacyEntryDoesNotTriggerReinstall(t *testing.T) {
 		"command": "/usr/bin/notify-me start",
 		"timeout": 5,
 	}
-	mixed := map[string]any{
-		"hooks": map[string]any{
-			"SessionStart":     []any{pdxGroup("SessionStart"), thirdPartyLegacy},
-			"UserPromptSubmit": []any{pdxGroup("UserPromptSubmit")},
-			"Stop":             []any{pdxGroup("Stop")},
-		},
+	// Post-expansion: installer writes 9 events (issue #613), so the fixture
+	// must cover all 9 to keep the test focused on the third-party coexistence
+	// assertion rather than tripping on the expansion itself.
+	hooksSect := map[string]any{
+		"SessionStart": []any{pdxGroup("SessionStart"), thirdPartyLegacy},
 	}
+	for _, name := range expectedCodexInstallerNames {
+		if name == "SessionStart" {
+			continue
+		}
+		hooksSect[name] = []any{pdxGroup(name)}
+	}
+	mixed := map[string]any{"hooks": hooksSect}
 	data, _ := json.MarshalIndent(mixed, "", "  ")
 	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
 		t.Fatalf("write: %v", err)

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -510,3 +510,261 @@ func TestCheckHooks_ThirdPartyLegacyEntryDoesNotTriggerReinstall(t *testing.T) {
 		t.Fatal("SessionStart should be installed despite coexisting third-party legacy entry")
 	}
 }
+
+// ---- fix-plan §1.4 / §2.2 CheckHooks three-state tests (CH1-CH6) ----
+//
+// The fix-plan §1.4 decision table partitions every declared event into
+// three states — absent / present-but-broken / valid — and applies a
+// FutureOnly-aware policy:
+//
+//	| FutureOnly | state          | Installed | Issues append           | blocks allInstalled |
+//	|------------|----------------|-----------|-------------------------|---------------------|
+//	| false      | absent         | false     | "<name> hook not installed" | yes             |
+//	| false      | broken         | false     | "<name> hook: pdx command not found" | yes    |
+//	| false      | valid          | true      | —                       | no                  |
+//	| true       | absent         | false     | (tolerated, silent)     | no                  |
+//	| true       | broken         | false     | "<name> hook: pdx command malformed …" | yes  |
+//	| true       | valid          | true      | —                       | no                  |
+//
+// State A (absent) is defined strictly as "key not present in hooks map"
+// (plan §1.4). An empty array value ([]) is State B (broken) because the
+// mergeCodexHooks remove path leaves hooks[event]=[] behind — treating it
+// as absent would silently hide a real uninstall event for a FutureOnly
+// hook.
+
+// pdxGroupEntry builds a correctly-installed matcher-group entry for an
+// event name, matching the shape mergeCodexHooks writes.
+func pdxGroupEntry(event string) map[string]any {
+	return map[string]any{
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": `"/usr/local/bin/pdx" hook --agent codex ` + event,
+				"timeout": 5,
+			},
+		},
+	}
+}
+
+// writeHooksFile serialises a hooks-section map to hooks.json under the
+// given HOME, creating parent dirs as needed.
+func writeHooksFile(t *testing.T, home string, hooksSect map[string]any) {
+	t.Helper()
+	path := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, err := json.MarshalIndent(map[string]any{"hooks": hooksSect}, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// issuesContain reports whether any issue contains the given substring.
+func issuesContain(issues []string, substr string) bool {
+	for _, iss := range issues {
+		if strings.Contains(iss, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// CH1 — legacy 3-event user (pre-expansion install): the three required
+// events are valid; the six FutureOnly events have no key in hooks.json.
+// allInstalled must remain true and Issues must be empty.
+func TestCheckHooks_LegacyThreeEvent_ReportsInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":             []any{pdxGroupEntry("Stop")},
+	})
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if !status.Installed {
+		t.Fatalf("legacy 3-event user: allInstalled=false, Issues=%v", status.Issues)
+	}
+	if len(status.Issues) != 0 {
+		t.Fatalf("legacy 3-event user: Issues=%v, want empty", status.Issues)
+	}
+	futureOnly := []string{
+		"SubagentStart", "SubagentStop", "StopFailure",
+		"Notification", "PermissionRequest", "SessionEnd",
+	}
+	for _, name := range futureOnly {
+		info, ok := status.Events[name]
+		if !ok {
+			t.Errorf("status.Events missing FutureOnly event %q", name)
+			continue
+		}
+		if info.Installed {
+			t.Errorf("FutureOnly event %q Installed=true, want false (absent)", name)
+		}
+	}
+}
+
+// CH2 — full 9-event install: every event valid, no issues.
+func TestCheckHooks_NineEvent_FullyInstalled_NoIssues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	full := map[string]any{}
+	for _, name := range expectedCodexInstallerNames {
+		full[name] = []any{pdxGroupEntry(name)}
+	}
+	writeHooksFile(t, home, full)
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if !status.Installed {
+		t.Fatalf("full 9-event install: allInstalled=false, Issues=%v", status.Issues)
+	}
+	if len(status.Issues) != 0 {
+		t.Fatalf("full 9-event install: Issues=%v, want empty", status.Issues)
+	}
+	for _, name := range expectedCodexInstallerNames {
+		info := status.Events[name]
+		if !info.Installed {
+			t.Errorf("event %q Installed=false after full install", name)
+		}
+	}
+}
+
+// CH3 — required event missing (here SessionStart is absent): must block
+// allInstalled and surface a "hook not installed" issue.
+func TestCheckHooks_RequiredEventMissing_Blocks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":             []any{pdxGroupEntry("Stop")},
+	})
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatal("missing required SessionStart: allInstalled=true, want false")
+	}
+	if !issuesContain(status.Issues, "SessionStart hook not installed") {
+		t.Fatalf("missing required SessionStart: issues=%v", status.Issues)
+	}
+}
+
+// CH4 — FutureOnly key present but pdx command missing (user manually
+// replaced the pdx entry with something else): classify as broken, emit a
+// "malformed" warning, and block allInstalled. The 3 required events are
+// valid and do not by themselves unblock.
+func TestCheckHooks_FutureOnlyBroken_WarnsAndBlocks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":             []any{pdxGroupEntry("Stop")},
+		"Notification": []any{
+			map[string]any{
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": "/usr/bin/notify-me not-pdx",
+						"timeout": 5,
+					},
+				},
+			},
+		},
+	})
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatal("FutureOnly broken: allInstalled=true, want false")
+	}
+	if !issuesContain(status.Issues, "Notification hook: pdx command malformed") {
+		t.Fatalf("FutureOnly broken: issues=%v, want malformed warning for Notification", status.Issues)
+	}
+	if status.Events["Notification"].Installed {
+		t.Fatal("Notification Installed=true, want false")
+	}
+}
+
+// CH5 — the mixed-tolerance case: 3 required valid, 3 FutureOnly absent,
+// 3 FutureOnly valid. allInstalled stays true because absent FutureOnly is
+// the "legacy user, no need to reinstall" tolerance case.
+func TestCheckHooks_FutureOnlyAbsent_DoesNotBlock(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":             []any{pdxGroupEntry("Stop")},
+		// 3 FutureOnly valid
+		"StopFailure":       []any{pdxGroupEntry("StopFailure")},
+		"Notification":      []any{pdxGroupEntry("Notification")},
+		"PermissionRequest": []any{pdxGroupEntry("PermissionRequest")},
+		// SubagentStart / SubagentStop / SessionEnd intentionally absent.
+	})
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if !status.Installed {
+		t.Fatalf("mixed FutureOnly absent/valid: allInstalled=false, Issues=%v", status.Issues)
+	}
+	if len(status.Issues) != 0 {
+		t.Fatalf("mixed FutureOnly absent/valid: Issues=%v, want empty", status.Issues)
+	}
+	for _, absent := range []string{"SubagentStart", "SubagentStop", "SessionEnd"} {
+		if status.Events[absent].Installed {
+			t.Errorf("absent FutureOnly %q Installed=true, want false", absent)
+		}
+	}
+	for _, valid := range []string{"StopFailure", "Notification", "PermissionRequest"} {
+		if !status.Events[valid].Installed {
+			t.Errorf("valid FutureOnly %q Installed=false, want true", valid)
+		}
+	}
+}
+
+// CH6 — the strict-absent distinction (plan §1.4): a FutureOnly event with
+// an empty entry array (hooks[event]=[]) is classified as broken, not
+// absent, because mergeCodexHooks' remove path can legitimately leave []
+// behind — treating it as absent would hide a real FutureOnly uninstall
+// event as a silent "legacy user" false-green.
+func TestCheckHooks_FutureOnlyEmptyArray_ClassifiesAsBroken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":             []any{pdxGroupEntry("Stop")},
+		"Notification":     []any{}, // present key, empty array — must be broken not absent
+	})
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatal("FutureOnly empty-array: allInstalled=true, want false")
+	}
+	if !issuesContain(status.Issues, "Notification hook: pdx command malformed") {
+		t.Fatalf("FutureOnly empty-array: issues=%v, want malformed warning", status.Issues)
+	}
+	if status.Events["Notification"].Installed {
+		t.Fatal("Notification Installed=true, want false (empty array = broken)")
+	}
+}

--- a/internal/agent/codex/provider.go
+++ b/internal/agent/codex/provider.go
@@ -41,16 +41,11 @@ func (p *Provider) DeriveStatus(eventName string, rawEvent json.RawMessage) agen
 }
 
 // SupportedStatuses declares the Status values codex.Provider's DeriveStatus
-// may emit after the Phase 1 expansion (Commit 3 brought codex to parity
-// with cc). Returns a fresh slice each call.
+// may emit, derived from Events().EmitsStatus. Events() is the SSoT after the
+// issue #613 installer expansion; this shim keeps the StatusSupporter
+// contract (Phase 1) working. Return order is lexicographic for determinism.
 func (p *Provider) SupportedStatuses() []agent.Status {
-	return []agent.Status{
-		agent.StatusRunning,
-		agent.StatusWaiting,
-		agent.StatusIdle,
-		agent.StatusError,
-		agent.StatusClear,
-	}
+	return agent.DeriveSupportedStatuses(p.Events())
 }
 
 func (p *Provider) IsAlive(tmuxTarget string) bool {

--- a/internal/agent/codex/provider_test.go
+++ b/internal/agent/codex/provider_test.go
@@ -52,6 +52,39 @@ func TestCodexProvider_Identify_Negative(t *testing.T) {
 	}
 }
 
+// TestCodexSupportedStatuses_DerivesFromEvents asserts the post-Commit-5
+// invariant that SupportedStatuses is computed from Events().EmitsStatus
+// union rather than a hard-coded literal.
+func TestCodexSupportedStatuses_DerivesFromEvents(t *testing.T) {
+	p := codex.NewProvider()
+	ss := any(p).(agent.StatusSupporter)
+	got := ss.SupportedStatuses()
+
+	gotSet := make(map[agent.Status]bool, len(got))
+	for _, s := range got {
+		gotSet[s] = true
+	}
+	wantSet := make(map[agent.Status]bool)
+	for _, e := range p.Events() {
+		for _, s := range e.EmitsStatus {
+			wantSet[s] = true
+		}
+	}
+	if len(gotSet) != len(wantSet) {
+		t.Fatalf("SupportedStatuses=%v, events union=%v (len mismatch)", got, wantSet)
+	}
+	for s := range wantSet {
+		if !gotSet[s] {
+			t.Errorf("SupportedStatuses missing %q (from events union)", s)
+		}
+	}
+	for s := range gotSet {
+		if !wantSet[s] {
+			t.Errorf("SupportedStatuses contains %q not in events union", s)
+		}
+	}
+}
+
 // TestCodexSupportedStatuses asserts codex.Provider implements
 // StatusSupporter and declares the same Phase 1 status set as cc/opencode
 // post-DeriveStatus expansion (Commit 3).

--- a/internal/agent/coverage_test.go
+++ b/internal/agent/coverage_test.go
@@ -209,6 +209,64 @@ func TestCoverageRealProviders(t *testing.T) {
 	}
 }
 
+// TestCoverageDeclaredMatchesEventsUnion is the cross-contract check that
+// a provider's Coverage row `Declared` set equals its Events().EmitsStatus
+// union, for every real provider. Phase 1 expressed the same relationship
+// via hard-coded literals; post-Events()-SSoT both sides derive from
+// Events(), so this test locks in the "Events is the single source of
+// truth" invariant across the Coverage and Events contracts.
+func TestCoverageDeclaredMatchesEventsUnion(t *testing.T) {
+	r := agent.NewRegistry()
+	r.Register(cc.NewProvider(nil, nil, nil, nil))
+	r.Register(codex.NewProvider())
+	r.Register(opencode.NewProvider())
+
+	rows := agent.Coverage(r)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+
+	for _, row := range rows {
+		provider, ok := r.Get(row.AgentType)
+		if !ok {
+			t.Errorf("registry.Get(%q) failed", row.AgentType)
+			continue
+		}
+		installer, ok := provider.(agent.HookInstaller)
+		if !ok {
+			t.Errorf("provider %q: missing HookInstaller — cannot reach Events()", row.AgentType)
+			continue
+		}
+
+		declaredSet := make(map[agent.Status]bool, len(row.Declared))
+		for _, s := range row.Declared {
+			declaredSet[s] = true
+		}
+
+		unionSet := make(map[agent.Status]bool)
+		for _, spec := range installer.Events() {
+			for _, s := range spec.EmitsStatus {
+				unionSet[s] = true
+			}
+		}
+
+		if len(declaredSet) != len(unionSet) {
+			t.Errorf("provider %q: Coverage.Declared set size %d != Events union size %d (Declared=%v)",
+				row.AgentType, len(declaredSet), len(unionSet), row.Declared)
+		}
+		for s := range declaredSet {
+			if !unionSet[s] {
+				t.Errorf("provider %q: Coverage declares %q but Events() union does not include it", row.AgentType, s)
+			}
+		}
+		for s := range unionSet {
+			if !declaredSet[s] {
+				t.Errorf("provider %q: Events() union includes %q but Coverage does not declare it", row.AgentType, s)
+			}
+		}
+	}
+}
+
 func TestCoverageMixed(t *testing.T) {
 	r := agent.NewRegistry()
 	r.Register(&supporterStub{

--- a/internal/agent/drift_test.go
+++ b/internal/agent/drift_test.go
@@ -244,6 +244,84 @@ func TestDriftFixtureCoverageNonEmpty(t *testing.T) {
 	}
 }
 
+// TestDriftPerEventEmitsStatusMatch is the fix-plan §2.5 D5 assertion:
+// for every provider × every declared event × every fixture of that event,
+// the set of Status values DeriveStatus actually returns must equal the
+// spec's EmitsStatus set (bidirectional strong equality).
+//
+// Why set-equality per-event and not aggregate: the aggregate test
+// (TestDriftThreeWayEquality) unions across events and therefore cannot
+// detect a single event that over-declares EmitsStatus while another event
+// happens to cover the over-declared Status. Example failure mode this
+// guards: marking Stop's EmitsStatus as [Idle, Clear] — aggregate still
+// matches because SessionEnd emits Clear — but no Stop fixture ever emits
+// Clear, so the declaration is a lie. D5 catches it because Stop's emitSet
+// would be {Idle}, not equal to {Idle, Clear}.
+//
+// Detail-only events (EmitsStatus = []) are checked: no fixture of that
+// event may emit a non-empty Status.
+//
+// FutureOnly events are covered naturally — their EmitsStatus is declared,
+// providerFixtures has their fixtures, and the per-event set-equality fires
+// either way. This is deliberate per plan §2.5 (no "D6 fixture-must-not-
+// include-FutureOnly" guard): FutureOnly is an installer/checker-facet bit
+// only, not a DeriveStatus-capability filter.
+func TestDriftPerEventEmitsStatusMatch(t *testing.T) {
+	r := driftRegistry()
+	for _, row := range agent.Coverage(r) {
+		row := row
+		t.Run(row.AgentType, func(t *testing.T) {
+			provider, ok := r.Get(row.AgentType)
+			if !ok {
+				t.Fatalf("registry.Get(%q) failed", row.AgentType)
+			}
+			installer, ok := provider.(agent.HookInstaller)
+			if !ok {
+				t.Fatalf("provider %q does not implement HookInstaller", row.AgentType)
+			}
+			fixturesByEvent := make(map[string][]driftFixture)
+			for _, fx := range providerFixtures[row.AgentType] {
+				fixturesByEvent[fx.eventName] = append(fixturesByEvent[fx.eventName], fx)
+			}
+			for _, spec := range installer.Events() {
+				spec := spec
+				t.Run(spec.Name, func(t *testing.T) {
+					fxs, ok := fixturesByEvent[spec.Name]
+					if !ok || len(fxs) == 0 {
+						t.Fatalf("provider %q event %q has no fixture", row.AgentType, spec.Name)
+					}
+					// Declared set (from the spec).
+					declared := make(map[agent.Status]bool, len(spec.EmitsStatus))
+					for _, s := range spec.EmitsStatus {
+						declared[s] = true
+					}
+					// Emitted set (from every fixture).
+					emitted := make(map[agent.Status]bool)
+					for _, fx := range fxs {
+						result := provider.DeriveStatus(fx.eventName, json.RawMessage(fx.rawJSON))
+						if result.Valid && result.Status != "" {
+							emitted[result.Status] = true
+						}
+					}
+					if !setsEqual(declared, emitted) {
+						t.Fatalf("provider %q event %q emits-status mismatch:\n"+
+							"  declared: %v\n"+
+							"  emitted:  %v\n"+
+							"  declared-not-emitted (remove from EmitsStatus or add a fixture): %v\n"+
+							"  emitted-not-declared (add to EmitsStatus or fix DeriveStatus):   %v",
+							row.AgentType, spec.Name,
+							statusSetSorted(declared),
+							statusSetSorted(emitted),
+							statusSetSorted(diffSet(declared, emitted)),
+							statusSetSorted(diffSet(emitted, declared)),
+						)
+					}
+				})
+			}
+		})
+	}
+}
+
 func setsEqual(a, b map[agent.Status]bool) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/agent/drift_test.go
+++ b/internal/agent/drift_test.go
@@ -97,20 +97,24 @@ func statusSetSorted(set map[agent.Status]bool) []string {
 	return out
 }
 
-// TestDriftDeclaredEqualsEmitted asserts that, for every registered provider,
-// EVERY fixture independently produces its declared (wantValid, wantStatus)
-// AND the union of emitted statuses exactly equals SupportedStatuses().
+// TestDriftThreeWayEquality asserts that, for every registered provider,
+// three sets of Status values are pairwise equal:
 //
-// Per-fixture assertion (not just set equality) is the load-bearing change
-// from the codex review: deleting one polymorphic Notification sub-branch
-// (e.g. "elicitation_dialog" → Waiting) would not change the set
-// {Waiting,Idle,Running,Error,Clear} because Waiting is still produced by
-// other branches. Per-fixture assertion catches that exact regression.
+//  1. declaredSet — union of Events().EmitsStatus
+//  2. emittedSet  — actually produced by DeriveStatus on the provider's
+//     fixtures (Valid=true, Status != "")
+//  3. supportedSet — returned by SupportedStatuses()
 //
-// Set-equality is kept as a complementary safeguard for the inverse
-// direction — emitting a status that no fixture covers, or declaring one
-// no fixture exercises.
-func TestDriftDeclaredEqualsEmitted(t *testing.T) {
+// This is the post-`Events()-SSoT` upgrade of the prior two-way drift test
+// (TestDriftDeclaredEqualsEmitted). SupportedStatuses is now derived from
+// Events() via DeriveSupportedStatuses, so in steady state 1 == 3 by
+// construction; the assertion still fires if anyone re-introduces a
+// hard-coded SupportedStatuses literal that disagrees with Events().
+//
+// Per-fixture assertion is retained (Phase 1 review finding): set-equality
+// alone cannot catch the deletion of a polymorphic Notification sub-branch
+// because other branches keep the aggregate Status set intact.
+func TestDriftThreeWayEquality(t *testing.T) {
 	r := driftRegistry()
 	rows := agent.Coverage(r)
 	if len(rows) == 0 {
@@ -129,11 +133,25 @@ func TestDriftDeclaredEqualsEmitted(t *testing.T) {
 				t.Fatalf("no driftFixture entry for provider %q — add fixtures or remove provider", row.AgentType)
 			}
 
-			declaredSet := make(map[agent.Status]bool, len(row.Declared))
+			// supportedSet comes from StatusSupporter (via Coverage row).
+			supportedSet := make(map[agent.Status]bool, len(row.Declared))
 			for _, s := range row.Declared {
-				declaredSet[s] = true
+				supportedSet[s] = true
 			}
 
+			// declaredSet comes from the Events() EmitsStatus union.
+			declaredSet := make(map[agent.Status]bool)
+			installer, ok := provider.(agent.HookInstaller)
+			if !ok {
+				t.Fatalf("provider %q does not implement HookInstaller — Events() unavailable", row.AgentType)
+			}
+			for _, spec := range installer.Events() {
+				for _, s := range spec.EmitsStatus {
+					declaredSet[s] = true
+				}
+			}
+
+			// emittedSet comes from DeriveStatus driven by fixtures.
 			emittedSet := make(map[agent.Status]bool)
 			for i, fx := range fixtures {
 				result := provider.DeriveStatus(fx.eventName, json.RawMessage(fx.rawJSON))
@@ -153,18 +171,59 @@ func TestDriftDeclaredEqualsEmitted(t *testing.T) {
 				}
 			}
 
-			if !setsEqual(declaredSet, emittedSet) {
-				t.Fatalf("drift for provider %q: declared=%v, emitted=%v\n"+
-					"  declared-not-emitted (fix: add fixture covering this status, or remove from declaration): %v\n"+
-					"  emitted-not-declared (fix: add to SupportedStatuses, or remove from DeriveStatus): %v",
+			// Report any pair-wise mismatch with three-way diagnostic context.
+			if !setsEqual(declaredSet, emittedSet) ||
+				!setsEqual(declaredSet, supportedSet) ||
+				!setsEqual(emittedSet, supportedSet) {
+				t.Fatalf("drift for provider %q three-way mismatch:\n"+
+					"  declared (from Events().EmitsStatus union): %v\n"+
+					"  emitted (from DeriveStatus fixtures):       %v\n"+
+					"  supported (from SupportedStatuses()):       %v\n"+
+					"  declared-not-emitted (fix: add fixture, or remove from Events().EmitsStatus): %v\n"+
+					"  emitted-not-declared (fix: add to Events().EmitsStatus, or remove from DeriveStatus): %v\n"+
+					"  declared-not-supported (fix: SupportedStatuses no longer derives from Events()): %v\n"+
+					"  supported-not-declared (fix: reverse of the previous row): %v",
 					row.AgentType,
 					statusSetSorted(declaredSet),
 					statusSetSorted(emittedSet),
+					statusSetSorted(supportedSet),
 					statusSetSorted(diffSet(declaredSet, emittedSet)),
 					statusSetSorted(diffSet(emittedSet, declaredSet)),
+					statusSetSorted(diffSet(declaredSet, supportedSet)),
+					statusSetSorted(diffSet(supportedSet, declaredSet)),
 				)
 			}
 		})
+	}
+}
+
+// TestDriftFixtureCoversAllEvents asserts every Events() event for each
+// provider appears in providerFixtures at least once. Guards the SSoT
+// invariant that declared hook events all have executable coverage, so
+// "declared but untested" events cannot silently accumulate.
+func TestDriftFixtureCoversAllEvents(t *testing.T) {
+	r := driftRegistry()
+	for _, row := range agent.Coverage(r) {
+		provider, ok := r.Get(row.AgentType)
+		if !ok {
+			t.Errorf("registry.Get(%q) failed", row.AgentType)
+			continue
+		}
+		installer, ok := provider.(agent.HookInstaller)
+		if !ok {
+			continue
+		}
+		fixtures := providerFixtures[row.AgentType]
+		covered := make(map[string]bool, len(fixtures))
+		for _, fx := range fixtures {
+			covered[fx.eventName] = true
+		}
+		for _, spec := range installer.Events() {
+			if !covered[spec.Name] {
+				t.Errorf("provider %q: Events() declares %q but providerFixtures has no entry (add a fixture or remove from Events())",
+					row.AgentType, spec.Name)
+			}
+		}
 	}
 }
 

--- a/internal/agent/opencode/events.go
+++ b/internal/agent/opencode/events.go
@@ -63,6 +63,7 @@ func (p *Provider) Events() []agent.HookEventSpec {
 			Name:        spec.Name,
 			EmitsStatus: append([]agent.Status(nil), spec.EmitsStatus...),
 			Description: spec.Description,
+			FutureOnly:  spec.FutureOnly,
 		}
 		if out[i].EmitsStatus == nil {
 			out[i].EmitsStatus = []agent.Status{}

--- a/internal/agent/opencode/events.go
+++ b/internal/agent/opencode/events.go
@@ -1,0 +1,88 @@
+package opencode
+
+import "github.com/wake/purdex/internal/agent"
+
+// opencodeEventSpecs is the declarative hook event catalog for OpenCode. It
+// is the single source of truth for CheckHooks iteration, SupportedStatuses
+// derivation, and future Inspector UI. The managed plugin template
+// (plugin_template.go) wires the same events on the JS side; ordering here
+// matches the plan §1.4 opencode table.
+//
+// Note: writeManagedPlugin/renderManagedPlugin write a fixed-string plugin
+// body; this plan's zero-change boundary (§1.7 / §1.8) keeps that template
+// untouched. Only the Go-side iteration (CheckHooks) migrates to Events().
+var opencodeEventSpecs = []agent.HookEventSpec{
+	{
+		Name:        "SessionStart",
+		EmitsStatus: []agent.Status{agent.StatusIdle},
+		Description: "OpenCode session started",
+	},
+	{
+		Name:        "UserPromptSubmit",
+		EmitsStatus: []agent.Status{agent.StatusRunning},
+		Description: "User submitted a prompt",
+	},
+	{
+		Name:        "SubagentStart",
+		EmitsStatus: []agent.Status{},
+		Description: "Nested sub-agent task dispatched",
+	},
+	{
+		Name:        "SubagentStop",
+		EmitsStatus: []agent.Status{},
+		Description: "Nested sub-agent task completed",
+	},
+	{
+		Name:        "PermissionRequest",
+		EmitsStatus: []agent.Status{agent.StatusWaiting},
+		Description: "Tool permission request awaiting user approval",
+	},
+	{
+		Name:        "Stop",
+		EmitsStatus: []agent.Status{agent.StatusIdle},
+		Description: "Agent finished responding and is idle",
+	},
+	{
+		Name:        "StopFailure",
+		EmitsStatus: []agent.Status{agent.StatusError},
+		Description: "Agent stopped due to an error",
+	},
+	{
+		Name:        "SessionEnd",
+		EmitsStatus: []agent.Status{agent.StatusClear},
+		Description: "OpenCode session ended",
+	},
+}
+
+// Events returns a fresh defensive copy of the opencode hook event catalog
+// on every call.
+func (p *Provider) Events() []agent.HookEventSpec {
+	out := make([]agent.HookEventSpec, len(opencodeEventSpecs))
+	for i, spec := range opencodeEventSpecs {
+		out[i] = agent.HookEventSpec{
+			Name:        spec.Name,
+			EmitsStatus: append([]agent.Status(nil), spec.EmitsStatus...),
+			Description: spec.Description,
+		}
+		if out[i].EmitsStatus == nil {
+			out[i].EmitsStatus = []agent.Status{}
+		}
+	}
+	return out
+}
+
+// eventNames returns the ordered event Name list for CheckHooks iteration.
+func (p *Provider) eventNames() []string {
+	return opencodeEventNames()
+}
+
+// opencodeEventNames is the package-level helper. Kept in parallel with the
+// provider-method form for parity with cc/codex; any future free function in
+// this package routes through the same spec slice.
+func opencodeEventNames() []string {
+	out := make([]string, 0, len(opencodeEventSpecs))
+	for _, spec := range opencodeEventSpecs {
+		out = append(out, spec.Name)
+	}
+	return out
+}

--- a/internal/agent/opencode/events_test.go
+++ b/internal/agent/opencode/events_test.go
@@ -1,0 +1,115 @@
+package opencode_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/opencode"
+)
+
+// expectedOpenCodeEventNames lists the 8 hook events opencode's plugin wires
+// (plan §1.4). Ordering matches the plan table.
+var expectedOpenCodeEventNames = []string{
+	"SessionStart",
+	"UserPromptSubmit",
+	"SubagentStart",
+	"SubagentStop",
+	"PermissionRequest",
+	"Stop",
+	"StopFailure",
+	"SessionEnd",
+}
+
+// TestOpenCodeEvents_Count locks the declared event count at 8 (plan §1.4).
+func TestOpenCodeEvents_Count(t *testing.T) {
+	p := opencode.NewProvider()
+	events := p.Events()
+	if len(events) != 8 {
+		t.Fatalf("opencode Events count = %d, want 8 (plan §1.4)", len(events))
+	}
+}
+
+// TestOpenCodeEvents_NamesMatchExpected asserts the Event Name set.
+func TestOpenCodeEvents_NamesMatchExpected(t *testing.T) {
+	p := opencode.NewProvider()
+	events := p.Events()
+
+	got := make(map[string]bool, len(events))
+	for _, e := range events {
+		if got[e.Name] {
+			t.Errorf("opencode Events contains duplicate Name %q", e.Name)
+		}
+		got[e.Name] = true
+	}
+	want := make(map[string]bool, len(expectedOpenCodeEventNames))
+	for _, n := range expectedOpenCodeEventNames {
+		want[n] = true
+	}
+	for n := range want {
+		if !got[n] {
+			t.Errorf("opencode Events missing required Name %q", n)
+		}
+	}
+	for n := range got {
+		if !want[n] {
+			t.Errorf("opencode Events contains unexpected Name %q", n)
+		}
+	}
+}
+
+// TestOpenCodeEvents_DetailOnlyHaveEmptyEmitsStatus guards the empty-slice
+// convention for detail-only SubagentStart/Stop.
+func TestOpenCodeEvents_DetailOnlyHaveEmptyEmitsStatus(t *testing.T) {
+	p := opencode.NewProvider()
+	for _, e := range p.Events() {
+		if e.Name != "SubagentStart" && e.Name != "SubagentStop" {
+			continue
+		}
+		if e.EmitsStatus == nil {
+			t.Errorf("opencode %s EmitsStatus is nil; want non-nil empty slice", e.Name)
+		}
+		if len(e.EmitsStatus) != 0 {
+			t.Errorf("opencode %s EmitsStatus = %v, want empty", e.Name, e.EmitsStatus)
+		}
+	}
+}
+
+// TestOpenCodeEvents_DescriptionsNonEmpty asserts every Description is
+// non-empty and emoji-free.
+func TestOpenCodeEvents_DescriptionsNonEmpty(t *testing.T) {
+	p := opencode.NewProvider()
+	for _, e := range p.Events() {
+		if strings.TrimSpace(e.Description) == "" {
+			t.Errorf("opencode %s Description is empty", e.Name)
+			continue
+		}
+		for _, r := range e.Description {
+			if r >= 0x1F300 && r <= 0x1FAFF {
+				t.Errorf("opencode %s Description contains emoji rune %U: %q", e.Name, r, e.Description)
+				break
+			}
+		}
+	}
+}
+
+// TestOpenCodeEvents_FreshSliceDefensiveCopy guards the defensive-copy
+// convention.
+func TestOpenCodeEvents_FreshSliceDefensiveCopy(t *testing.T) {
+	p := opencode.NewProvider()
+	first := p.Events()
+	if len(first) == 0 {
+		t.Fatal("opencode Events returned empty slice")
+	}
+	first[0].Name = "__mutated__"
+	if len(first[0].EmitsStatus) > 0 {
+		first[0].EmitsStatus[0] = agent.Status("__mutated__")
+	}
+	second := p.Events()
+	if second[0].Name == "__mutated__" {
+		t.Errorf("opencode Events shares backing array; second call first Name mutated to %q", second[0].Name)
+	}
+	if len(second[0].EmitsStatus) > 0 && second[0].EmitsStatus[0] == "__mutated__" {
+		t.Errorf("opencode Events shares EmitsStatus backing array across calls")
+	}
+}

--- a/internal/agent/opencode/hooks.go
+++ b/internal/agent/opencode/hooks.go
@@ -9,17 +9,6 @@ import (
 	"github.com/wake/purdex/internal/agent"
 )
 
-var opencodeHookEvents = []string{
-	"SessionStart",
-	"UserPromptSubmit",
-	"SubagentStart",
-	"SubagentStop",
-	"PermissionRequest",
-	"Stop",
-	"StopFailure",
-	"SessionEnd",
-}
-
 func (p *Provider) InstallHooks(pdxPath string) error {
 	pluginPath, err := opencodePluginPath()
 	if err != nil {
@@ -49,12 +38,6 @@ func (p *Provider) RemoveHooks(_ string) error {
 	return nil
 }
 
-// Events returns the hook event declarations for OpenCode. Stub; filled in a
-// later commit (HookInstaller.Events() plan §3 Commit 4).
-func (p *Provider) Events() []agent.HookEventSpec {
-	return nil
-}
-
 func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 	pluginPath, err := opencodePluginPath()
 	if err != nil {
@@ -81,8 +64,9 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 			AgentVersion: agentVersion,
 		}, nil
 	}
-	events := make(map[string]agent.HookEventInfo, len(opencodeHookEvents))
-	for _, event := range opencodeHookEvents {
+	eventNames := p.eventNames()
+	events := make(map[string]agent.HookEventInfo, len(eventNames))
+	for _, event := range eventNames {
 		events[event] = agent.HookEventInfo{Installed: true, Command: pluginPath}
 	}
 	return agent.HookStatus{Installed: true, Events: events, Issues: []string{}, AgentVersion: agentVersion}, nil

--- a/internal/agent/opencode/hooks.go
+++ b/internal/agent/opencode/hooks.go
@@ -10,6 +10,24 @@ import (
 	"github.com/wake/purdex/internal/agent"
 )
 
+// resolveCanonicalPdxPath returns the daemon's own executable path with
+// symlinks resolved — the single trusted pdxPath CheckHooks renders the
+// managed template against. The second return reports whether resolution
+// succeeded; callers must treat false as "body differs" rather than
+// falling back to the on-disk literal (PR #616 review Finding #3). It is
+// a package-level var so tests can stub without touching os.Executable.
+var resolveCanonicalPdxPath = func() (string, bool) {
+	exe, err := os.Executable()
+	if err != nil || exe == "" {
+		return "", false
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil || resolved == "" {
+		return "", false
+	}
+	return resolved, true
+}
+
 func (p *Provider) InstallHooks(pdxPath string) error {
 	pluginPath, err := opencodePluginPath()
 	if err != nil {
@@ -66,29 +84,30 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		}, nil
 	}
 
-	// Plan §1.6: the opencode plugin is a single pdx-managed artifact, not
-	// a per-event configuration. CheckHooks succeeds only when the on-disk
-	// body byte-matches the rendered template for the pdxPath literal the
-	// file itself carries. Any deviation (comment, whitespace, dead code,
-	// broken switch/case) collapses every declared event to Installed=false
-	// — "managed body drifted, reinstall" is a uniform signal that matches
-	// the plugin's all-or-nothing semantics.
+	// Plan §1.6 + PR #616 review Finding #3: the opencode plugin is a
+	// single pdx-managed artifact. CheckHooks renders the expected template
+	// against the trusted runtime canonical pdxPath (daemon's own
+	// os.Executable, symlinks resolved) — never against the literal the
+	// file itself carries, which would make path-only edits silently pass
+	// their own round-trip. Any deviation (comment, whitespace, dead code,
+	// broken switch/case, tampered pdxPath literal) collapses every
+	// declared event to Installed=false — "managed body drifted,
+	// reinstall" matches the plugin's all-or-nothing semantics.
 	specs := p.Events()
-	pdxPath, ok := extractPdxPath(string(data))
-	if !ok {
-		events := make(map[string]agent.HookEventInfo, len(specs))
+	trustedPath, resolved := resolveCanonicalPdxPath()
+	events := make(map[string]agent.HookEventInfo, len(specs))
+	if !resolved {
 		for _, spec := range specs {
 			events[spec.Name] = agent.HookEventInfo{Installed: false, Command: pluginPath}
 		}
 		return agent.HookStatus{
 			Installed:    false,
 			Events:       events,
-			Issues:       []string{"plugin body differs from managed template (run reinstall)"},
+			Issues:       []string{"plugin body differs from managed template (cannot resolve canonical pdx path — run reinstall)"},
 			AgentVersion: agentVersion,
 		}, nil
 	}
-	expected := renderManagedPlugin(pdxPath)
-	events := make(map[string]agent.HookEventInfo, len(specs))
+	expected := renderManagedPlugin(trustedPath)
 	if !bytes.Equal(data, []byte(expected)) {
 		for _, spec := range specs {
 			events[spec.Name] = agent.HookEventInfo{Installed: false, Command: pluginPath}
@@ -96,7 +115,7 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		return agent.HookStatus{
 			Installed:    false,
 			Events:       events,
-			Issues:       []string{"plugin body differs from managed template (run reinstall)"},
+			Issues:       []string{"plugin body differs from managed template (pdx binary may have moved or file was edited — run reinstall)"},
 			AgentVersion: agentVersion,
 		}, nil
 	}

--- a/internal/agent/opencode/hooks.go
+++ b/internal/agent/opencode/hooks.go
@@ -49,6 +49,12 @@ func (p *Provider) RemoveHooks(_ string) error {
 	return nil
 }
 
+// Events returns the hook event declarations for OpenCode. Stub; filled in a
+// later commit (HookInstaller.Events() plan §3 Commit 4).
+func (p *Provider) Events() []agent.HookEventSpec {
+	return nil
+}
+
 func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 	pluginPath, err := opencodePluginPath()
 	if err != nil {

--- a/internal/agent/opencode/hooks.go
+++ b/internal/agent/opencode/hooks.go
@@ -78,6 +78,7 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 	if !isManagedPlugin(data) {
 		return agent.HookStatus{
 			Installed:    false,
+			Managed:      false,
 			Events:       map[string]agent.HookEventInfo{},
 			Issues:       []string{"plugin file exists but is unmanaged"},
 			AgentVersion: agentVersion,
@@ -98,10 +99,13 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 	events := make(map[string]agent.HookEventInfo, len(specs))
 	if !resolved {
 		for _, spec := range specs {
-			events[spec.Name] = agent.HookEventInfo{Installed: false, Command: pluginPath}
+			events[spec.Name] = agent.HookEventInfo{Installed: false, Command: pluginPath, FutureOnly: spec.FutureOnly}
 		}
+		// Managed=true: the marker is present, we just can't verify body.
+		// UI Remove button must stay enabled.
 		return agent.HookStatus{
 			Installed:    false,
+			Managed:      true,
 			Events:       events,
 			Issues:       []string{"plugin body differs from managed template (cannot resolve canonical pdx path — run reinstall)"},
 			AgentVersion: agentVersion,
@@ -110,19 +114,20 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 	expected := renderManagedPlugin(trustedPath)
 	if !bytes.Equal(data, []byte(expected)) {
 		for _, spec := range specs {
-			events[spec.Name] = agent.HookEventInfo{Installed: false, Command: pluginPath}
+			events[spec.Name] = agent.HookEventInfo{Installed: false, Command: pluginPath, FutureOnly: spec.FutureOnly}
 		}
 		return agent.HookStatus{
 			Installed:    false,
+			Managed:      true,
 			Events:       events,
 			Issues:       []string{"plugin body differs from managed template (pdx binary may have moved or file was edited — run reinstall)"},
 			AgentVersion: agentVersion,
 		}, nil
 	}
 	for _, spec := range specs {
-		events[spec.Name] = agent.HookEventInfo{Installed: true, Command: pluginPath}
+		events[spec.Name] = agent.HookEventInfo{Installed: true, Command: pluginPath, FutureOnly: spec.FutureOnly}
 	}
-	return agent.HookStatus{Installed: true, Events: events, Issues: []string{}, AgentVersion: agentVersion}, nil
+	return agent.HookStatus{Installed: true, Managed: true, Events: events, Issues: []string{}, AgentVersion: agentVersion}, nil
 }
 
 func opencodePluginPath() (string, error) {

--- a/internal/agent/opencode/hooks.go
+++ b/internal/agent/opencode/hooks.go
@@ -1,6 +1,7 @@
 package opencode
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -64,10 +65,43 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 			AgentVersion: agentVersion,
 		}, nil
 	}
-	eventNames := p.eventNames()
-	events := make(map[string]agent.HookEventInfo, len(eventNames))
-	for _, event := range eventNames {
-		events[event] = agent.HookEventInfo{Installed: true, Command: pluginPath}
+
+	// Plan §1.6: the opencode plugin is a single pdx-managed artifact, not
+	// a per-event configuration. CheckHooks succeeds only when the on-disk
+	// body byte-matches the rendered template for the pdxPath literal the
+	// file itself carries. Any deviation (comment, whitespace, dead code,
+	// broken switch/case) collapses every declared event to Installed=false
+	// — "managed body drifted, reinstall" is a uniform signal that matches
+	// the plugin's all-or-nothing semantics.
+	specs := p.Events()
+	pdxPath, ok := extractPdxPath(string(data))
+	if !ok {
+		events := make(map[string]agent.HookEventInfo, len(specs))
+		for _, spec := range specs {
+			events[spec.Name] = agent.HookEventInfo{Installed: false, Command: pluginPath}
+		}
+		return agent.HookStatus{
+			Installed:    false,
+			Events:       events,
+			Issues:       []string{"plugin body differs from managed template (run reinstall)"},
+			AgentVersion: agentVersion,
+		}, nil
+	}
+	expected := renderManagedPlugin(pdxPath)
+	events := make(map[string]agent.HookEventInfo, len(specs))
+	if !bytes.Equal(data, []byte(expected)) {
+		for _, spec := range specs {
+			events[spec.Name] = agent.HookEventInfo{Installed: false, Command: pluginPath}
+		}
+		return agent.HookStatus{
+			Installed:    false,
+			Events:       events,
+			Issues:       []string{"plugin body differs from managed template (run reinstall)"},
+			AgentVersion: agentVersion,
+		}, nil
+	}
+	for _, spec := range specs {
+		events[spec.Name] = agent.HookEventInfo{Installed: true, Command: pluginPath}
 	}
 	return agent.HookStatus{Installed: true, Events: events, Issues: []string{}, AgentVersion: agentVersion}, nil
 }

--- a/internal/agent/opencode/hooks_export_test.go
+++ b/internal/agent/opencode/hooks_export_test.go
@@ -1,0 +1,16 @@
+package opencode
+
+import "testing"
+
+// SetResolveCanonicalPdxPathForTesting overrides the canonical pdx path
+// resolver for the duration of t. The previous implementation is restored
+// via t.Cleanup. Exported purely so the _test package can drive the
+// Finding #3 path-only-edit regression from outside the package. Kept in
+// a *_test.go file so the testing dependency stays out of production
+// binaries.
+func SetResolveCanonicalPdxPathForTesting(t *testing.T, fn func() (string, bool)) {
+	t.Helper()
+	prev := resolveCanonicalPdxPath
+	resolveCanonicalPdxPath = fn
+	t.Cleanup(func() { resolveCanonicalPdxPath = prev })
+}

--- a/internal/agent/opencode/hooks_test.go
+++ b/internal/agent/opencode/hooks_test.go
@@ -96,6 +96,187 @@ func TestOpenCodeCheckHooks_ReportsAll8EventsFromEventsList(t *testing.T) {
 	}
 }
 
+// ---- fix-plan §2.4 byte-exact CheckHooks tests (OH1-OH5) ----
+//
+// The v3 plan redesigns opencode CheckHooks as "plugin is pdx-managed
+// atomic artifact" rather than per-event health: byte-exact comparison
+// against renderManagedPlugin(pdxPath). Any deviation — even a comment
+// line — collapses the entire plugin to Installed=false. That matches
+// the plugin's actual semantics (shared state across events means per-
+// event judgement is unsafe) and closes all regex-based false-green
+// routes the v2 plan tried to patch.
+
+// OH1 — plugin written by writeManagedPlugin reports every declared event
+// as Installed=true and no Issues.
+func TestCheckHooks_ValidPlugin_AllInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if !status.Installed {
+		t.Fatalf("valid plugin: Installed=false, Issues=%v", status.Issues)
+	}
+	if len(status.Issues) != 0 {
+		t.Fatalf("valid plugin: Issues=%v, want empty", status.Issues)
+	}
+	for _, spec := range p.Events() {
+		if info, ok := status.Events[spec.Name]; !ok {
+			t.Errorf("status.Events missing %q", spec.Name)
+		} else if !info.Installed {
+			t.Errorf("event %q Installed=false", spec.Name)
+		}
+	}
+}
+
+// OH2 — plugin with the marker intact but a single deleted emit() call
+// must be rejected. All event infos collapse to Installed=false because
+// the plugin is no longer pdx-managed content.
+func TestCheckHooks_HandEditedPlugin_Unmanaged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	data, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("read plugin: %v", err)
+	}
+	// Remove the Stop emit call.
+	edited := strings.Replace(string(data), "await emit('Stop',", "// await emit('Stop',", 1)
+	if edited == string(data) {
+		t.Fatal("test setup: failed to mutate template (Stop emit not found)")
+	}
+	if err := os.WriteFile(pluginPath, []byte(edited), 0644); err != nil {
+		t.Fatalf("write edit: %v", err)
+	}
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatalf("hand-edited plugin: Installed=true, want false")
+	}
+	joined := strings.Join(status.Issues, " | ")
+	if !strings.Contains(joined, "plugin body differs from managed template") {
+		t.Fatalf("hand-edited plugin: issues=%v, want 'plugin body differs from managed template'", status.Issues)
+	}
+	for _, spec := range p.Events() {
+		if info, ok := status.Events[spec.Name]; ok && info.Installed {
+			t.Errorf("event %q Installed=true after byte-mismatch, want false", spec.Name)
+		}
+	}
+}
+
+// OH3 — existing behaviour preserved: plugin file without the managed
+// marker is reported as unmanaged.
+func TestCheckHooks_UnmanagedPlugin_NoMarker(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("export const Existing = async () => ({})\n"), 0644); err != nil {
+		t.Fatalf("write unmanaged: %v", err)
+	}
+
+	status, err := opencode.NewProvider().CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatalf("unmanaged: Installed=true, want false")
+	}
+	if !strings.Contains(strings.Join(status.Issues, " | "), "unmanaged") {
+		t.Fatalf("unmanaged: issues=%v, want 'unmanaged'", status.Issues)
+	}
+}
+
+// OH4 — a comment-only edit is still a byte-mismatch. Regex-based
+// extraction would have missed this (the comment does not contain an
+// emit() call), but byte-exact comparison catches it uniformly. This is
+// the test that replaces v2's per-event unexpected-emit test.
+func TestCheckHooks_CommentEditInPlugin_DetectedViaByteCompare(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	data, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("read plugin: %v", err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("// added by user\n"+string(data)), 0644); err != nil {
+		t.Fatalf("write edit: %v", err)
+	}
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatalf("comment-edit: Installed=true, want false (byte-exact must reject)")
+	}
+}
+
+// OH5 — plugin with marker present but pdxPath literal corrupted. The
+// extractPdxPath helper must fail cleanly (no panic) and CheckHooks must
+// fall back to a "body differs" issue rather than crashing.
+func TestCheckHooks_ExtractPdxPathFails_FallsBackToUnmanaged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	data, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("read plugin: %v", err)
+	}
+	// Remove the entire pdxPath line — extractPdxPath must no longer match.
+	broken := strings.Replace(string(data), `const pdxPath = "/usr/local/bin/pdx"`, `const pdxPath = /* corrupt */`, 1)
+	if broken == string(data) {
+		t.Fatal("test setup: pdxPath line not found")
+	}
+	if err := os.WriteFile(pluginPath, []byte(broken), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("CheckHooks panicked: %v", r)
+		}
+	}()
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatalf("corrupt pdxPath: Installed=true, want false")
+	}
+	if len(status.Issues) == 0 {
+		t.Fatal("corrupt pdxPath: expected at least one issue")
+	}
+}
+
 func TestOpenCodeHooks_UnmanagedFileRejected(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/agent/opencode/hooks_test.go
+++ b/internal/agent/opencode/hooks_test.go
@@ -414,6 +414,103 @@ func TestCheckHooks_CanonicalResolveFails_ReportsBodyDiffers(t *testing.T) {
 	}
 }
 
+// TestOpenCodeCheckHooks_ManagedReflectsMarker asserts HookStatus.Managed
+// is driven by marker presence, not by byte-match. Finding #2: UI Remove
+// button must stay enabled for drifted-but-managed opencode plugin.
+func TestOpenCodeCheckHooks_ManagedReflectsMarker(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	data, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("read plugin: %v", err)
+	}
+	// Drift the body by prepending a comment — marker remains, byte-match fails.
+	if err := os.WriteFile(pluginPath, []byte("// user note\n"+string(data)), 0644); err != nil {
+		t.Fatalf("write drift: %v", err)
+	}
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatal("drifted managed plugin: Installed=true, want false")
+	}
+	if !status.Managed {
+		t.Fatal("drifted managed plugin: Managed=false, want true (marker present)")
+	}
+}
+
+// TestOpenCodeCheckHooks_ManagedFalseWhenUnmanagedOrAbsent covers the
+// two Managed=false cases: no file at all, and a file that pre-dates
+// pdx (marker absent).
+func TestOpenCodeCheckHooks_ManagedFalseWhenUnmanagedOrAbsent(t *testing.T) {
+	t.Run("absent file", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		status, err := opencode.NewProvider().CheckHooks()
+		if err != nil {
+			t.Fatalf("CheckHooks: %v", err)
+		}
+		if status.Managed {
+			t.Fatal("absent file: Managed=true, want false")
+		}
+	})
+	t.Run("unmanaged file", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+		if err := os.MkdirAll(filepath.Dir(pluginPath), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(pluginPath, []byte("export const Existing = () => ({})\n"), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		status, err := opencode.NewProvider().CheckHooks()
+		if err != nil {
+			t.Fatalf("CheckHooks: %v", err)
+		}
+		if status.Managed {
+			t.Fatal("unmanaged file: Managed=true, want false")
+		}
+	})
+}
+
+// TestOpenCodeCheckHooks_UpgradesAvailableAlwaysEmpty asserts opencode
+// has no FutureOnly events in its current catalog, so UpgradesAvailable
+// is empty on every valid install.
+func TestOpenCodeCheckHooks_UpgradesAvailableAlwaysEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if len(status.UpgradesAvailable) != 0 {
+		t.Errorf("opencode UpgradesAvailable=%v, want empty", status.UpgradesAvailable)
+	}
+	for _, info := range status.Events {
+		if info.FutureOnly {
+			t.Errorf("opencode event info.FutureOnly=true, want false for every spec")
+		}
+	}
+}
+
 func TestOpenCodeHooks_UnmanagedFileRejected(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/agent/opencode/hooks_test.go
+++ b/internal/agent/opencode/hooks_test.go
@@ -9,9 +9,23 @@ import (
 	"github.com/wake/purdex/internal/agent/opencode"
 )
 
+// pinCanonicalPdxPath anchors the canonical pdx path resolver to the
+// install-time literal so test installs and byte-exact checks render
+// the same managed template body. Without this stub the resolver would
+// fall back to the test binary's executable path and every valid-plugin
+// assertion would drift — intentional for Finding #3 but not what the
+// legacy install/check contract tests are exercising.
+func pinCanonicalPdxPath(t *testing.T, path string) {
+	t.Helper()
+	opencode.SetResolveCanonicalPdxPathForTesting(t, func() (string, bool) {
+		return path, true
+	})
+}
+
 func TestOpenCodeHooks_InstallCheckRemove(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
 
 	p := opencode.NewProvider()
 	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
@@ -67,6 +81,7 @@ func TestOpenCodeHooks_InstallCheckRemove(t *testing.T) {
 func TestOpenCodeCheckHooks_ReportsAll8EventsFromEventsList(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
 
 	p := opencode.NewProvider()
 	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
@@ -111,6 +126,7 @@ func TestOpenCodeCheckHooks_ReportsAll8EventsFromEventsList(t *testing.T) {
 func TestCheckHooks_ValidPlugin_AllInstalled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
 
 	p := opencode.NewProvider()
 	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
@@ -141,6 +157,7 @@ func TestCheckHooks_ValidPlugin_AllInstalled(t *testing.T) {
 func TestCheckHooks_HandEditedPlugin_Unmanaged(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
 
 	p := opencode.NewProvider()
 	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
@@ -211,6 +228,7 @@ func TestCheckHooks_UnmanagedPlugin_NoMarker(t *testing.T) {
 func TestCheckHooks_CommentEditInPlugin_DetectedViaByteCompare(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
 
 	p := opencode.NewProvider()
 	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
@@ -234,12 +252,15 @@ func TestCheckHooks_CommentEditInPlugin_DetectedViaByteCompare(t *testing.T) {
 	}
 }
 
-// OH5 — plugin with marker present but pdxPath literal corrupted. The
-// extractPdxPath helper must fail cleanly (no panic) and CheckHooks must
-// fall back to a "body differs" issue rather than crashing.
-func TestCheckHooks_ExtractPdxPathFails_FallsBackToUnmanaged(t *testing.T) {
+// OH5 — plugin with marker present but the corrupted body no longer
+// byte-matches the managed template rendered from the trusted canonical
+// pdx path. CheckHooks must fall back to a "body differs" issue without
+// panicking. Replaces the v4 "extractPdxPath failure" test: pdxPath
+// extraction is no longer on the health path after Finding #3.
+func TestCheckHooks_CorruptPdxPathLine_ReportsBodyDiffers(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
 
 	p := opencode.NewProvider()
 	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
@@ -250,7 +271,8 @@ func TestCheckHooks_ExtractPdxPathFails_FallsBackToUnmanaged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read plugin: %v", err)
 	}
-	// Remove the entire pdxPath line — extractPdxPath must no longer match.
+	// Remove the entire pdxPath line; body must drift from the expected
+	// managed template regardless of the trusted pdxPath we render.
 	broken := strings.Replace(string(data), `const pdxPath = "/usr/local/bin/pdx"`, `const pdxPath = /* corrupt */`, 1)
 	if broken == string(data) {
 		t.Fatal("test setup: pdxPath line not found")
@@ -274,6 +296,121 @@ func TestCheckHooks_ExtractPdxPathFails_FallsBackToUnmanaged(t *testing.T) {
 	}
 	if len(status.Issues) == 0 {
 		t.Fatal("corrupt pdxPath: expected at least one issue")
+	}
+}
+
+// OH6 — path-only edit: a user edits only the pdxPath literal in an
+// otherwise-untouched managed plugin (e.g. to point at a tampered
+// binary). v4 extracted the literal from the file itself and rendered
+// expected with the same path → byte-exact self-round-trip → false
+// green. v5 (Finding #3) resolves the canonical pdx path from the
+// runtime (os.Executable + EvalSymlinks), so a path-only edit drifts
+// from the trusted render and CheckHooks must report the file as
+// drifted.
+func TestCheckHooks_PathOnlyEdit_DetectsAsDrifted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	data, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("read plugin: %v", err)
+	}
+	// Swap in a different — attacker-controlled — pdx path literal.
+	tampered := strings.Replace(
+		string(data),
+		`const pdxPath = "/usr/local/bin/pdx"`,
+		`const pdxPath = "/fake/malicious/pdx"`,
+		1,
+	)
+	if tampered == string(data) {
+		t.Fatal("test setup: original pdxPath literal not found")
+	}
+	if err := os.WriteFile(pluginPath, []byte(tampered), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Pin the canonical resolver to the real install-time path so expected
+	// render matches the untampered template — the drift is the on-disk
+	// pdxPath, not the check baseline.
+	opencode.SetResolveCanonicalPdxPathForTesting(t, func() (string, bool) {
+		return "/usr/local/bin/pdx", true
+	})
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatalf("path-only edit: Installed=true, want false (Finding #3)")
+	}
+	if !strings.Contains(strings.Join(status.Issues, " | "), "plugin body differs from managed template") {
+		t.Fatalf("path-only edit: issues=%v, want 'plugin body differs from managed template'", status.Issues)
+	}
+}
+
+// OH7 — canonical path trust loop: when canonical resolver reports the
+// same path the file already carries, an untouched managed plugin
+// byte-matches the expected render and CheckHooks must report all
+// events installed.
+func TestCheckHooks_TrustsCanonicalPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+
+	opencode.SetResolveCanonicalPdxPathForTesting(t, func() (string, bool) {
+		return "/usr/local/bin/pdx", true
+	})
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if !status.Installed {
+		t.Fatalf("trusted canonical path: Installed=false, Issues=%v", status.Issues)
+	}
+}
+
+// OH8 — canonical resolver failure fallback: when os.Executable or
+// EvalSymlinks fails (e.g. daemon launched from an unusual path), the
+// checker must surface a body-differs issue rather than crash or
+// silently pass. Replaces OH5's panic-safety role.
+func TestCheckHooks_CanonicalResolveFails_ReportsBodyDiffers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+
+	opencode.SetResolveCanonicalPdxPathForTesting(t, func() (string, bool) {
+		return "", false
+	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("CheckHooks panicked: %v", r)
+		}
+	}()
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatalf("resolve-fail: Installed=true, want false")
+	}
+	if !strings.Contains(strings.Join(status.Issues, " | "), "plugin body differs from managed template") {
+		t.Fatalf("resolve-fail: issues=%v, want 'plugin body differs from managed template'", status.Issues)
 	}
 }
 

--- a/internal/agent/opencode/hooks_test.go
+++ b/internal/agent/opencode/hooks_test.go
@@ -61,6 +61,41 @@ func TestOpenCodeHooks_InstallCheckRemove(t *testing.T) {
 	}
 }
 
+// TestOpenCodeCheckHooks_ReportsAll8EventsFromEventsList asserts CheckHooks
+// reports one Events entry per HookEventSpec — i.e. the check path reads from
+// Events() rather than a legacy opencodeHookEvents slice.
+func TestOpenCodeCheckHooks_ReportsAll8EventsFromEventsList(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := opencode.NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+
+	events := p.Events()
+	if len(events) == 0 {
+		t.Fatal("opencode Events() returned empty; CheckHooks iteration would be vacuous")
+	}
+	if len(status.Events) != len(events) {
+		t.Errorf("status.Events len=%d, want %d (one per Events())", len(status.Events), len(events))
+	}
+	for _, e := range events {
+		info, ok := status.Events[e.Name]
+		if !ok {
+			t.Errorf("status.Events missing key %q (from Events())", e.Name)
+			continue
+		}
+		if !info.Installed {
+			t.Errorf("event %q: Installed=false after fresh install", e.Name)
+		}
+	}
+}
+
 func TestOpenCodeHooks_UnmanagedFileRejected(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/agent/opencode/plugin_template.go
+++ b/internal/agent/opencode/plugin_template.go
@@ -3,7 +3,11 @@ package opencode
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
+	"strings"
+
+	"github.com/wake/purdex/internal/agent"
 )
 
 const managedMarker = "pdx-managed:opencode-hooks:v1"
@@ -238,6 +242,48 @@ func extractEmittedEvents(body string) []string {
 		out = append(out, name)
 	}
 	return out
+}
+
+// validateSpecsCoverEmitted enforces bidirectional parity between the
+// event names a managed plugin body emits and the HookEventSpec slice
+// driving Go-side installer / checker / Inspector paths. A superset on
+// either side yields an error. Scoped to test layer (plan §1.5): runtime
+// never calls this — a build-time drift blocks merge via
+// TestTemplateSpecsParity (PT7) rather than panicking production code.
+func validateSpecsCoverEmitted(body string, specs []agent.HookEventSpec) error {
+	emitted := make(map[string]bool)
+	for _, name := range extractEmittedEvents(body) {
+		emitted[name] = true
+	}
+	declared := make(map[string]bool, len(specs))
+	for _, spec := range specs {
+		declared[spec.Name] = true
+	}
+	var missingInSpec []string
+	for name := range emitted {
+		if !declared[name] {
+			missingInSpec = append(missingInSpec, name)
+		}
+	}
+	var missingInEmit []string
+	for name := range declared {
+		if !emitted[name] {
+			missingInEmit = append(missingInEmit, name)
+		}
+	}
+	if len(missingInSpec) == 0 && len(missingInEmit) == 0 {
+		return nil
+	}
+	sort.Strings(missingInSpec)
+	sort.Strings(missingInEmit)
+	var parts []string
+	if len(missingInSpec) > 0 {
+		parts = append(parts, fmt.Sprintf("template emits %v but specs do not declare them", missingInSpec))
+	}
+	if len(missingInEmit) > 0 {
+		parts = append(parts, fmt.Sprintf("specs declare %v but template never emits them", missingInEmit))
+	}
+	return fmt.Errorf("template/specs parity: %s", strings.Join(parts, "; "))
 }
 
 // extractPdxPath pulls the pdxPath literal out of a managed plugin body

--- a/internal/agent/opencode/plugin_template.go
+++ b/internal/agent/opencode/plugin_template.go
@@ -1,6 +1,10 @@
 package opencode
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
 
 const managedMarker = "pdx-managed:opencode-hooks:v1"
 
@@ -196,6 +200,60 @@ export const PurdexOpenCodeHooks = async () => {
   }
 }
 `, managedMarker, pdxPath)
+}
+
+// emittedEventPattern matches `emit('Name', …)` / `emit("Name", …)` inside
+// the plugin body. Strictly used by test-layer parity checks (plan §1.5):
+// runtime health goes through byte-exact template comparison, so this
+// regex's well-known blind spots (comment strings, dead code) never reach
+// production judgement. Keeping the expression scoped to the single
+// emit() call shape keeps the helper understandable for that test-only
+// role.
+var emittedEventPattern = regexp.MustCompile(`emit\(['"](\w+)['"]`)
+
+// pdxPathLiteralPattern captures the complete quoted Go string literal
+// that renderManagedPlugin writes with %q. The [^"\\]|\\. alternation
+// covers escaped quotes and backslashes, which a naive `"([^"]+)"` regex
+// would otherwise cut short. The capture intentionally includes the
+// enclosing double quotes so strconv.Unquote can consume it verbatim
+// (plan §1.6 / v4 findings).
+var pdxPathLiteralPattern = regexp.MustCompile(`const pdxPath = ("(?:[^"\\]|\\.)*")`)
+
+// extractEmittedEvents returns every event name that the given body
+// invokes emit() with. Order preserves first appearance. Test-only helper
+// per plan §1.5 — do not wire it into CheckHooks.
+func extractEmittedEvents(body string) []string {
+	matches := emittedEventPattern.FindAllStringSubmatch(body, -1)
+	seen := make(map[string]bool, len(matches))
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		name := m[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out
+}
+
+// extractPdxPath pulls the pdxPath literal out of a managed plugin body
+// and unescapes it to the original path string. Returns ok=false on any
+// failure (literal not found, malformed escape) so CheckHooks can fall
+// back to the unmanaged path rather than panic (v4 plan §1.6).
+func extractPdxPath(body string) (string, bool) {
+	m := pdxPathLiteralPattern.FindStringSubmatch(body)
+	if len(m) < 2 {
+		return "", false
+	}
+	unquoted, err := strconv.Unquote(m[1])
+	if err != nil {
+		return "", false
+	}
+	return unquoted, true
 }
 
 func firstString(values map[string]any, keys ...string) string {

--- a/internal/agent/opencode/plugin_template_test.go
+++ b/internal/agent/opencode/plugin_template_test.go
@@ -126,6 +126,64 @@ func TestPluginState_SuppressIdleAfterError(t *testing.T) {
 	}
 }
 
+// TestExtractEmittedEvents is the fix-plan §2.3 PT1 assertion: the helper
+// reliably pulls event names from emit('...') and emit("...") calls in a
+// synthetic body, including across multiple lines and with incidental
+// whitespace. This helper is test-only (plan §1.5); it underwrites the
+// template/specs parity check, not runtime health.
+func TestExtractEmittedEvents(t *testing.T) {
+	body := `
+  await emit('SessionStart', {foo: 1})
+  await emit("UserPromptSubmit",
+    {bar: 2})
+  await emit('Stop', {})
+  // not captured: commented out. // await emit('Ignored', {})
+`
+	got := extractEmittedEvents(body)
+	want := map[string]bool{"SessionStart": true, "UserPromptSubmit": true, "Stop": true, "Ignored": true}
+	// We deliberately include 'Ignored' from a comment — regex-based extraction
+	// is known to see through comments. That is fine because this helper is
+	// only used against the real template body where no such comments exist,
+	// and PT2-PT4 tests assert the spec-side parity that would surface a
+	// mismatch if such a ghost emit ever shipped.
+	gotSet := make(map[string]bool, len(got))
+	for _, n := range got {
+		gotSet[n] = true
+	}
+	for n := range want {
+		if !gotSet[n] {
+			t.Errorf("extractEmittedEvents missing %q; got %v", n, got)
+		}
+	}
+}
+
+// TestExtractPdxPath_RoundtripEscapedLiterals is the fix-plan §2.3 PT6
+// assertion: renderManagedPlugin writes pdxPath with %q (complete with
+// escapes for backslash/quote/unicode/…) and extractPdxPath must be able
+// to round-trip it. Using a naive regex (e.g. `"([^"]+)"`) would stop at
+// the first escaped quote and then double-escape when re-rendered,
+// producing a byte-mismatch on perfectly managed plugins — the v4 plan
+// specifically calls this out.
+func TestExtractPdxPath_RoundtripEscapedLiterals(t *testing.T) {
+	cases := []string{
+		"/path with spaces/pdx",
+		`C:\Users\foo\pdx.exe`,
+		`/weird"path/pdx`,
+		"/使用者/pdx",
+	}
+	for _, input := range cases {
+		body := renderManagedPlugin(input)
+		got, ok := extractPdxPath(body)
+		if !ok {
+			t.Errorf("extractPdxPath failed for %q", input)
+			continue
+		}
+		if got != input {
+			t.Errorf("extractPdxPath(%q) round-trip = %q", input, got)
+		}
+	}
+}
+
 func TestRenderManagedPlugin_UsesInputModelAndSessionScopedSubagentKeys(t *testing.T) {
 	rendered := renderManagedPlugin("/usr/local/bin/pdx")
 	if !strings.Contains(rendered, "const model = input.model") {

--- a/internal/agent/opencode/plugin_template_test.go
+++ b/internal/agent/opencode/plugin_template_test.go
@@ -3,6 +3,8 @@ package opencode
 import (
 	"strings"
 	"testing"
+
+	"github.com/wake/purdex/internal/agent"
 )
 
 func TestPluginState_TaskStartMapsSubagentStart(t *testing.T) {
@@ -123,6 +125,70 @@ func TestPluginState_SuppressIdleAfterError(t *testing.T) {
 	}
 	if event.Name != "Stop" {
 		t.Fatalf("event name = %q, want Stop", event.Name)
+	}
+}
+
+// TestValidateSpecsCoverEmitted_Equal is the fix-plan §2.3 PT2 assertion:
+// the real rendered body and opencodeEventSpecs agree on the event set.
+// Together with PT7 this is the build-time contract guard that keeps the
+// JS template and Go-side specs from drifting apart (plan §1.5 — runtime
+// is deliberately not involved).
+func TestValidateSpecsCoverEmitted_Equal(t *testing.T) {
+	body := renderManagedPlugin("/fake/pdx")
+	if err := validateSpecsCoverEmitted(body, opencodeEventSpecs); err != nil {
+		t.Fatalf("validateSpecsCoverEmitted for the real template must be nil; got %v", err)
+	}
+}
+
+// TestValidateSpecsCoverEmitted_EmitNotInSpec is the fix-plan §2.3 PT3
+// assertion: a template that emits an event not listed in specs must
+// error. Failure mode this catches: someone adding a new emit() without
+// updating opencodeEventSpecs.
+func TestValidateSpecsCoverEmitted_EmitNotInSpec(t *testing.T) {
+	body := renderManagedPlugin("/fake/pdx") + "\nawait emit('Ghost', {})\n"
+	if err := validateSpecsCoverEmitted(body, opencodeEventSpecs); err == nil {
+		t.Fatal("expected error for emit-not-in-spec; got nil")
+	}
+}
+
+// TestValidateSpecsCoverEmitted_SpecNotInEmit is the fix-plan §2.3 PT4
+// assertion: a specs list that declares an event the template never
+// emits must error. Failure mode this catches: removing an emit without
+// updating opencodeEventSpecs.
+func TestValidateSpecsCoverEmitted_SpecNotInEmit(t *testing.T) {
+	body := renderManagedPlugin("/fake/pdx")
+	extended := append([]agent.HookEventSpec(nil), opencodeEventSpecs...)
+	extended = append(extended, agent.HookEventSpec{Name: "Phantom"})
+	if err := validateSpecsCoverEmitted(body, extended); err == nil {
+		t.Fatal("expected error for spec-not-in-emit; got nil")
+	}
+}
+
+// TestRenderManagedPlugin_ProducesValidBody is the fix-plan §2.3 PT5
+// assertion: rendering does not panic and the body contains the managed
+// marker that CheckHooks keys off of.
+func TestRenderManagedPlugin_ProducesValidBody(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("renderManagedPlugin panicked: %v", r)
+		}
+	}()
+	body := renderManagedPlugin("/fake/pdx")
+	if !strings.Contains(body, managedMarker) {
+		t.Fatalf("rendered body missing managed marker %q", managedMarker)
+	}
+}
+
+// TestTemplateSpecsParity is the fix-plan §2.3 PT7 build-time contract
+// guard. If the template emits X and specs do not declare X (or vice
+// versa) this test fails and blocks the merge — so commits never ship an
+// inconsistent pair. Per v4 plan §1.5 this replaces a runtime panic that
+// would have punished every CheckHooks / Install call for a build-time
+// drift; contract enforcement belongs at test layer.
+func TestTemplateSpecsParity(t *testing.T) {
+	body := renderManagedPlugin("/fake/pdx")
+	if err := validateSpecsCoverEmitted(body, opencodeEventSpecs); err != nil {
+		t.Fatalf("template/specs parity drifted: %v", err)
 	}
 }
 

--- a/internal/agent/opencode/provider.go
+++ b/internal/agent/opencode/provider.go
@@ -41,16 +41,11 @@ func (p *Provider) DeriveStatus(eventName string, rawEvent json.RawMessage) agen
 }
 
 // SupportedStatuses declares the Status values opencode.Provider's
-// DeriveStatus may emit. Returns a fresh slice on each call (defensive copy
-// per Phase 1 plan §1.1). Drift test enforces declaration matches emit.
+// DeriveStatus may emit, derived from Events().EmitsStatus. Events() is the
+// SSoT; this shim keeps the StatusSupporter contract (Phase 1) working.
+// Return order is lexicographic for determinism.
 func (p *Provider) SupportedStatuses() []agent.Status {
-	return []agent.Status{
-		agent.StatusRunning,
-		agent.StatusWaiting,
-		agent.StatusIdle,
-		agent.StatusError,
-		agent.StatusClear,
-	}
+	return agent.DeriveSupportedStatuses(p.Events())
 }
 
 func (p *Provider) IsAlive(tmuxTarget string) bool {

--- a/internal/agent/opencode/provider_test.go
+++ b/internal/agent/opencode/provider_test.go
@@ -7,6 +7,39 @@ import (
 	"github.com/wake/purdex/internal/agent/opencode"
 )
 
+// TestOpenCodeSupportedStatuses_DerivesFromEvents asserts the post-Commit-4
+// invariant that SupportedStatuses is computed from Events().EmitsStatus
+// union rather than a hard-coded literal.
+func TestOpenCodeSupportedStatuses_DerivesFromEvents(t *testing.T) {
+	p := opencode.NewProvider()
+	ss := any(p).(agent.StatusSupporter)
+	got := ss.SupportedStatuses()
+
+	gotSet := make(map[agent.Status]bool, len(got))
+	for _, s := range got {
+		gotSet[s] = true
+	}
+	wantSet := make(map[agent.Status]bool)
+	for _, e := range p.Events() {
+		for _, s := range e.EmitsStatus {
+			wantSet[s] = true
+		}
+	}
+	if len(gotSet) != len(wantSet) {
+		t.Fatalf("SupportedStatuses=%v, events union=%v (len mismatch)", got, wantSet)
+	}
+	for s := range wantSet {
+		if !gotSet[s] {
+			t.Errorf("SupportedStatuses missing %q (from events union)", s)
+		}
+	}
+	for s := range gotSet {
+		if !wantSet[s] {
+			t.Errorf("SupportedStatuses contains %q not in events union", s)
+		}
+	}
+}
+
 // TestOpenCodeSupportedStatuses asserts opencode.Provider implements
 // StatusSupporter and declares the Phase 1 status set.
 func TestOpenCodeSupportedStatuses(t *testing.T) {

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -58,10 +58,21 @@ type HookInstaller interface {
 //     events (e.g. cc Notification) list the union of every sub-branch.
 //   - Description: short English sentence for Inspector display. No trailing
 //     period, no emoji; keep it under roughly 70 characters.
+//   - FutureOnly: installer/checker-facet flag ONLY. When true, the hook is
+//     declared (installer writes it, DeriveStatus parses it) but the current
+//     CLI path is not guaranteed to emit it; CheckHooks therefore tolerates
+//     an absent hooks.json entry (legacy user who installed before the
+//     expansion) while still surfacing present-but-broken entries. The flag
+//     does NOT affect DeriveStatus-capability declarations:
+//     DeriveSupportedStatuses (and thus StatusSupporter.SupportedStatuses)
+//     unions every spec's EmitsStatus regardless of FutureOnly — proxy paths
+//     and future CLI versions may legitimately emit the event. Default false
+//     means "installer-required; missing is an issue". See fix plan §1.1.
 type HookEventSpec struct {
 	Name        string
 	EmitsStatus []Status
 	Description string
+	FutureOnly  bool
 }
 
 // HookStatus reports the installation state of hooks for an agent.

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -76,19 +76,33 @@ type HookEventSpec struct {
 }
 
 // HookStatus reports the installation state of hooks for an agent.
+//
+// Managed and UpgradesAvailable are the Finding #2 / #4 contract
+// extensions (PR #616 review): the SPA needs to distinguish (a) "pdx
+// left artifacts on disk" from "all required events are installed"
+// so the Remove button stays enabled on drifted-but-managed state,
+// and (b) "install is valid but 6 new FutureOnly events are
+// available" so the Install button / upgrade hint is not dead.
 type HookStatus struct {
-	Installed        bool                     `json:"installed"`
-	Events           map[string]HookEventInfo `json:"events"`
-	Issues           []string                 `json:"issues"`
-	AgentVersion     string                   `json:"agentVersion,omitempty"`
-	SupportedVersion string                   `json:"supportedVersion,omitempty"`
-	ExceedsSupport   bool                     `json:"exceedsSupport,omitempty"`
+	Installed         bool                     `json:"installed"`
+	Managed           bool                     `json:"managed"`
+	UpgradesAvailable []string                 `json:"upgradesAvailable,omitempty"`
+	Events            map[string]HookEventInfo `json:"events"`
+	Issues            []string                 `json:"issues"`
+	AgentVersion      string                   `json:"agentVersion,omitempty"`
+	SupportedVersion  string                   `json:"supportedVersion,omitempty"`
+	ExceedsSupport    bool                     `json:"exceedsSupport,omitempty"`
 }
 
 // HookEventInfo describes the state of a single hook event.
+//
+// FutureOnly mirrors HookEventSpec.FutureOnly so the UI can render
+// "tolerated absent" (grey FutureOnly badge, no red error) vs
+// "missing installer-required event" (hard red).
 type HookEventInfo struct {
-	Installed bool   `json:"installed"`
-	Command   string `json:"command"`
+	Installed  bool   `json:"installed"`
+	Command    string `json:"command"`
+	FutureOnly bool   `json:"futureOnly,omitempty"`
 }
 
 // StatuslineInstaller manages CC's statusLine.command in ~/.claude/settings.json.

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -31,10 +31,37 @@ type HookEvent struct {
 // --- Optional capabilities ---
 
 // HookInstaller can install/remove/check hook configurations for a specific agent.
+//
+// Events() is the single source of truth (SSoT) for the hook event catalog:
+// installer iteration, CheckHooks reporting, SupportedStatuses derivation, and
+// future Inspector UI all read from the same declaration. It supersedes any
+// package-local *HookEvents slice; do not introduce a parallel string list.
+// Any new HookInstaller implementation is required to implement Events().
 type HookInstaller interface {
 	InstallHooks(pdxPath string) error
 	RemoveHooks(pdxPath string) error
 	CheckHooks() (HookStatus, error)
+	Events() []HookEventSpec
+}
+
+// HookEventSpec declares one hook event the installer wires, the Status set
+// DeriveStatus may emit from that event, and a short human-readable blurb for
+// the Inspector UI. It is the build-time declaration contract; runtime hook
+// handling stays per-agent (policy dispersal, plumbing shared).
+//
+// Fields:
+//   - Name: matches the hook JSON event_name / pdx hook CLI subcommand.
+//   - EmitsStatus: non-empty Status values (Status != "") that DeriveStatus
+//     may return for this event across all sub-branches. Empty slice (not nil)
+//     means the event is detail-only (DeriveStatus returns Valid=true with
+//     Status=""); SubagentStart/Stop are the canonical examples. Polymorphic
+//     events (e.g. cc Notification) list the union of every sub-branch.
+//   - Description: short English sentence for Inspector display. No trailing
+//     period, no emoji; keep it under roughly 70 characters.
+type HookEventSpec struct {
+	Name        string
+	EmitsStatus []Status
+	Description string
 }
 
 // HookStatus reports the installation state of hooks for an agent.

--- a/internal/agent/supported_statuses.go
+++ b/internal/agent/supported_statuses.go
@@ -1,0 +1,37 @@
+package agent
+
+import "sort"
+
+// DeriveSupportedStatuses computes the lexicographically sorted union of
+// HookEventSpec.EmitsStatus across a slice of specs. It is the helper that
+// backs each provider's SupportedStatuses() implementation once the event
+// catalog (HookInstaller.Events()) becomes the single source of truth for
+// which Status values DeriveStatus may emit.
+//
+// Invariants:
+//   - Empty-status specs (detail-only events such as SubagentStart/Stop)
+//     contribute nothing to the union.
+//   - A Status appearing in multiple specs, or repeated within a single spec,
+//     is collapsed to one occurrence.
+//   - Returns a non-nil empty slice for empty input. Callers can treat the
+//     result as a freshly-allocated slice safe to hand to external consumers.
+//   - Ordering is lexicographic on the underlying Status string so callers
+//     that compare results (drift test, Inspector UI) get deterministic
+//     output independent of spec ordering.
+func DeriveSupportedStatuses(specs []HookEventSpec) []Status {
+	set := make(map[Status]struct{})
+	for _, spec := range specs {
+		for _, s := range spec.EmitsStatus {
+			if s == "" {
+				continue
+			}
+			set[s] = struct{}{}
+		}
+	}
+	out := make([]Status, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return string(out[i]) < string(out[j]) })
+	return out
+}

--- a/internal/agent/supported_statuses_test.go
+++ b/internal/agent/supported_statuses_test.go
@@ -1,0 +1,62 @@
+package agent_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+)
+
+// TestDeriveSupportedStatuses_UnionAndSort builds the status union from a
+// heterogeneous HookEventSpec slice (including a detail-only event with
+// empty EmitsStatus) and asserts lexicographic Status-string ordering for
+// deterministic output.
+func TestDeriveSupportedStatuses_UnionAndSort(t *testing.T) {
+	specs := []agent.HookEventSpec{
+		{Name: "A", EmitsStatus: []agent.Status{agent.StatusRunning, agent.StatusWaiting}},
+		{Name: "B", EmitsStatus: []agent.Status{agent.StatusIdle}},
+		{Name: "C", EmitsStatus: []agent.Status{}}, // detail-only, should contribute nothing
+	}
+	got := agent.DeriveSupportedStatuses(specs)
+	want := []agent.Status{agent.StatusIdle, agent.StatusRunning, agent.StatusWaiting}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DeriveSupportedStatuses = %v, want %v (lex-sorted union)", got, want)
+	}
+}
+
+// TestDeriveSupportedStatuses_DedupesDuplicates asserts that a Status
+// appearing in multiple specs (and/or multiple times within one spec) is
+// collapsed to a single occurrence in the output.
+func TestDeriveSupportedStatuses_DedupesDuplicates(t *testing.T) {
+	specs := []agent.HookEventSpec{
+		{Name: "A", EmitsStatus: []agent.Status{agent.StatusWaiting, agent.StatusWaiting}},
+		{Name: "B", EmitsStatus: []agent.Status{agent.StatusWaiting, agent.StatusIdle}},
+		{Name: "C", EmitsStatus: []agent.Status{agent.StatusIdle}},
+	}
+	got := agent.DeriveSupportedStatuses(specs)
+	want := []agent.Status{agent.StatusIdle, agent.StatusWaiting}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DeriveSupportedStatuses = %v, want %v (deduped)", got, want)
+	}
+}
+
+// TestDeriveSupportedStatuses_EmptyInput asserts the helper returns an empty
+// but non-nil slice for an empty spec list, matching the defensive-copy
+// convention used by Coverage (nil declarations normalise to empty slice).
+func TestDeriveSupportedStatuses_EmptyInput(t *testing.T) {
+	got := agent.DeriveSupportedStatuses(nil)
+	if got == nil {
+		t.Fatal("DeriveSupportedStatuses(nil) returned nil; want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("DeriveSupportedStatuses(nil) len = %d, want 0", len(got))
+	}
+
+	got = agent.DeriveSupportedStatuses([]agent.HookEventSpec{})
+	if got == nil {
+		t.Fatal("DeriveSupportedStatuses([]) returned nil; want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("DeriveSupportedStatuses([]) len = %d, want 0", len(got))
+	}
+}

--- a/internal/agent/supported_statuses_test.go
+++ b/internal/agent/supported_statuses_test.go
@@ -60,3 +60,32 @@ func TestDeriveSupportedStatuses_EmptyInput(t *testing.T) {
 		t.Fatalf("DeriveSupportedStatuses([]) len = %d, want 0", len(got))
 	}
 }
+
+// TestHookEventSpecFutureOnlyDefaultsToFalse is the fix-plan §2.1 F1 guard:
+// a HookEventSpec literal that omits FutureOnly must observe the zero value
+// (false). This pins the "FutureOnly is an installer/checker bit layered on
+// top of the existing declaration; pre-existing specs remain required" rule
+// so a future rename/retype cannot silently flip the default.
+func TestHookEventSpecFutureOnlyDefaultsToFalse(t *testing.T) {
+	spec := agent.HookEventSpec{Name: "X"}
+	if spec.FutureOnly {
+		t.Fatalf("HookEventSpec zero-value FutureOnly = true, want false")
+	}
+}
+
+// TestDeriveSupportedStatusesIgnoresFutureOnlyBit is the fix-plan §2.1 F2
+// contract lock: DeriveSupportedStatuses must NOT filter out FutureOnly
+// specs. FutureOnly is an installer/checker-facet flag only; the
+// DeriveStatus-capability facet (StatusSupporter.SupportedStatuses, which
+// this helper backs) remains the full declared union. Tripping this test
+// means somebody wired FutureOnly into SupportedStatuses filtering — plan
+// §1.2 forbids it (see the comment on HookEventSpec.FutureOnly).
+func TestDeriveSupportedStatusesIgnoresFutureOnlyBit(t *testing.T) {
+	specs := []agent.HookEventSpec{
+		{Name: "Future", EmitsStatus: []agent.Status{agent.StatusWaiting}, FutureOnly: true},
+	}
+	got := agent.DeriveSupportedStatuses(specs)
+	if len(got) != 1 || got[0] != agent.StatusWaiting {
+		t.Fatalf("DeriveSupportedStatuses = %v, want [Waiting] (FutureOnly must not filter)", got)
+	}
+}

--- a/spa/src/components/hosts/HookModuleCard.test.tsx
+++ b/spa/src/components/hosts/HookModuleCard.test.tsx
@@ -9,6 +9,7 @@ const HOST_ID = 'test-host'
 
 const OK_STATUS: HookModuleStatus = {
   installed: true,
+  managed: true,
   events: { SessionStart: { installed: true }, Stop: { installed: true } },
   issues: [],
   agentVersion: '0.121.0',
@@ -17,11 +18,44 @@ const OK_STATUS: HookModuleStatus = {
 
 const NOT_INSTALLED: HookModuleStatus = {
   installed: false,
+  managed: false,
   events: { SessionStart: { installed: false } },
   issues: ['SessionStart hook not installed'],
   agentVersion: '0.122.0',
   supportedVersion: '0.121.0',
   exceedsSupport: true,
+}
+
+// LEGACY_WITH_UPGRADES: the Finding #4 case — installed=true but 6
+// FutureOnly events are declared-but-absent. Install button must stay
+// enabled so the user can add them; Remove stays enabled because
+// managed=true.
+const LEGACY_WITH_UPGRADES: HookModuleStatus = {
+  installed: true,
+  managed: true,
+  upgradesAvailable: ['SubagentStart', 'SubagentStop', 'StopFailure', 'Notification', 'PermissionRequest', 'SessionEnd'],
+  events: {
+    SessionStart: { installed: true },
+    UserPromptSubmit: { installed: true },
+    Stop: { installed: true },
+    SubagentStart: { installed: false, futureOnly: true },
+    SubagentStop: { installed: false, futureOnly: true },
+    StopFailure: { installed: false, futureOnly: true },
+    Notification: { installed: false, futureOnly: true },
+    PermissionRequest: { installed: false, futureOnly: true },
+    SessionEnd: { installed: false, futureOnly: true },
+  },
+  issues: [],
+}
+
+// DRIFTED_MANAGED: the Finding #2 case — pdx artifact is on disk
+// (managed=true) but the install is not valid. Install is enabled
+// (retry / repair); Remove stays enabled.
+const DRIFTED_MANAGED: HookModuleStatus = {
+  installed: false,
+  managed: true,
+  events: { SessionStart: { installed: false } },
+  issues: ['plugin body differs from managed template (run reinstall)'],
 }
 
 function mockModule(overrides?: Partial<HookModule>): HookModule {
@@ -111,6 +145,48 @@ describe('HookModuleCard', () => {
     await waitForLoaded()
     expect(screen.getByRole('button', { name: /Install/i })).toBeDisabled()
     expect(screen.getByRole('button', { name: /Remove/i })).not.toBeDisabled()
+  })
+
+  // Finding #4: legacy codex user with FutureOnly upgrades available.
+  // Install must stay enabled so the upgrade path works; Remove stays
+  // enabled because managed=true.
+  it('keeps Install enabled and shows upgrade hint when upgrades are available', async () => {
+    const mod = mockModule({ fetchStatus: () => Promise.resolve(LEGACY_WITH_UPGRADES) })
+    render(<HookModuleCard module={mod} hostId={HOST_ID} refreshKey={0} />)
+    await waitForLoaded()
+    expect(screen.getByRole('button', { name: /Install/i })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /Remove/i })).not.toBeDisabled()
+    expect(screen.getByText(/6.*升級|6.*upgrade|hook_upgrade_available/i)).toBeInTheDocument()
+  })
+
+  // Finding #2: drifted but pdx-managed state. Install is enabled for
+  // repair and Remove stays enabled because managed=true.
+  it('keeps Remove enabled when managed=true even if installed=false', async () => {
+    const mod = mockModule({ fetchStatus: () => Promise.resolve(DRIFTED_MANAGED) })
+    render(<HookModuleCard module={mod} hostId={HOST_ID} refreshKey={0} />)
+    await waitForLoaded()
+    expect(screen.getByRole('button', { name: /Remove/i })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /Install/i })).not.toBeDisabled()
+  })
+
+  // Complement: not installed AND not managed → Remove disabled
+  // (nothing to remove), Install enabled.
+  it('disables Remove when managed=false', async () => {
+    const mod = mockModule({ fetchStatus: () => Promise.resolve(NOT_INSTALLED) })
+    render(<HookModuleCard module={mod} hostId={HOST_ID} refreshKey={0} />)
+    await waitForLoaded()
+    expect(screen.getByRole('button', { name: /Remove/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Install/i })).not.toBeDisabled()
+  })
+
+  // Per-event FutureOnly rendering: grey neutral badge, not red.
+  it('renders FutureOnly label for tolerated-absent events', async () => {
+    const mod = mockModule({ fetchStatus: () => Promise.resolve(LEGACY_WITH_UPGRADES) })
+    render(<HookModuleCard module={mod} hostId={HOST_ID} refreshKey={0} />)
+    await waitForLoaded()
+    // Count of FutureOnly labels should match the 6 FutureOnly events.
+    const labels = screen.getAllByText(/FutureOnly/i)
+    expect(labels.length).toBeGreaterThanOrEqual(6)
   })
 
   it('calls setup on button click', async () => {

--- a/spa/src/components/hosts/HookModuleCard.test.tsx
+++ b/spa/src/components/hosts/HookModuleCard.test.tsx
@@ -58,6 +58,21 @@ const DRIFTED_MANAGED: HookModuleStatus = {
   issues: ['plugin body differs from managed template (run reinstall)'],
 }
 
+// LEGACY_NO_MANAGED_FIELD: Round-3 review E1 — modules predating the
+// managed field (e.g. tmux /api/hooks/tmux/status) omit it entirely.
+// Remove must fall back to `installed` so existing UX is preserved.
+const LEGACY_NO_MANAGED_FIELD_INSTALLED: HookModuleStatus = {
+  installed: true,
+  events: { SessionStart: { installed: true } },
+  issues: [],
+}
+
+const LEGACY_NO_MANAGED_FIELD_UNINSTALLED: HookModuleStatus = {
+  installed: false,
+  events: { SessionStart: { installed: false } },
+  issues: ['SessionStart hook not installed'],
+}
+
 function mockModule(overrides?: Partial<HookModule>): HookModule {
   return {
     id: 'test',
@@ -173,6 +188,23 @@ describe('HookModuleCard', () => {
   // (nothing to remove), Install enabled.
   it('disables Remove when managed=false', async () => {
     const mod = mockModule({ fetchStatus: () => Promise.resolve(NOT_INSTALLED) })
+    render(<HookModuleCard module={mod} hostId={HOST_ID} refreshKey={0} />)
+    await waitForLoaded()
+    expect(screen.getByRole('button', { name: /Remove/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Install/i })).not.toBeDisabled()
+  })
+
+  // Round-3 review E1: legacy modules (tmux) omit the managed field.
+  // Remove must fall back to `installed` so existing Remove UX works.
+  it('falls back to installed for Remove when managed field absent (installed=true)', async () => {
+    const mod = mockModule({ fetchStatus: () => Promise.resolve(LEGACY_NO_MANAGED_FIELD_INSTALLED) })
+    render(<HookModuleCard module={mod} hostId={HOST_ID} refreshKey={0} />)
+    await waitForLoaded()
+    expect(screen.getByRole('button', { name: /Remove/i })).not.toBeDisabled()
+  })
+
+  it('falls back to installed for Remove when managed field absent (installed=false)', async () => {
+    const mod = mockModule({ fetchStatus: () => Promise.resolve(LEGACY_NO_MANAGED_FIELD_UNINSTALLED) })
     render(<HookModuleCard module={mod} hostId={HOST_ID} refreshKey={0} />)
     await waitForLoaded()
     expect(screen.getByRole('button', { name: /Remove/i })).toBeDisabled()

--- a/spa/src/components/hosts/HookModuleCard.tsx
+++ b/spa/src/components/hosts/HookModuleCard.tsx
@@ -157,8 +157,10 @@ export function HookModuleCard({ module, hostId, refreshKey }: Props) {
           // Remove is enabled whenever there is a pdx artifact on disk,
           // not only when installed=true. Finding #2: drifted-but-
           // managed state (opencode plugin body mismatch, stale codex
-          // legacy entry) still needs to be removable.
-          disabled={isOffline || loading || !status?.managed}
+          // legacy entry) still needs to be removable. Modules that
+          // pre-date the managed field (e.g. tmux /api/hooks/tmux/status)
+          // fall back to `installed` so existing Remove UX stays intact.
+          disabled={isOffline || loading || !(status?.managed ?? status?.installed)}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs bg-red-500/10 text-red-400 border border-red-500/30 cursor-pointer disabled:opacity-50"
         >
           <Trash size={14} />

--- a/spa/src/components/hosts/HookModuleCard.tsx
+++ b/spa/src/components/hosts/HookModuleCard.tsx
@@ -85,22 +85,42 @@ export function HookModuleCard({ module, hostId, refreshKey }: Props) {
         </div>
       )}
 
+      {status && status.upgradesAvailable && status.upgradesAvailable.length > 0 && (
+        <div className="flex items-center gap-1 text-xs text-amber-400 mb-3">
+          <WarningCircle size={12} />
+          <span>{t('hosts.hook_upgrade_available', { n: status.upgradesAvailable.length })}</span>
+        </div>
+      )}
+
       {status && eventEntries.length > 0 && (
         <div className="space-y-1 mb-3">
-          {eventEntries.map(([event, detail]) => (
-            <div key={event} className="flex items-center gap-3 text-xs py-1">
-              <span className="text-text-secondary w-40 shrink-0 font-mono">{event}</span>
-              <span className={`inline-flex items-center gap-1 ${detail.installed ? 'text-green-400' : 'text-text-muted'}`}>
-                {detail.installed ? <CheckCircle size={12} /> : <XCircle size={12} />}
-                {detail.installed ? t('hosts.installed') : t('hosts.not_installed')}
-              </span>
-              {lastTrigger?.[event] && (
-                <span className="text-text-muted ml-auto">
-                  {formatRelativeTime(lastTrigger[event], t)}
-                </span>
-              )}
-            </div>
-          ))}
+          {eventEntries.map(([event, detail]) => {
+            // FutureOnly + not installed → neutral "FutureOnly" badge
+            // (tolerated absent). Avoids the red-light pressure Finding #4
+            // warned about for pre-expansion users.
+            const isToleratedFutureOnly = detail.futureOnly && !detail.installed
+            return (
+              <div key={event} className="flex items-center gap-3 text-xs py-1">
+                <span className="text-text-secondary w-40 shrink-0 font-mono">{event}</span>
+                {isToleratedFutureOnly ? (
+                  <span className="inline-flex items-center gap-1 text-text-muted">
+                    <WarningCircle size={12} />
+                    FutureOnly
+                  </span>
+                ) : (
+                  <span className={`inline-flex items-center gap-1 ${detail.installed ? 'text-green-400' : 'text-text-muted'}`}>
+                    {detail.installed ? <CheckCircle size={12} /> : <XCircle size={12} />}
+                    {detail.installed ? t('hosts.installed') : t('hosts.not_installed')}
+                  </span>
+                )}
+                {lastTrigger?.[event] && (
+                  <span className="text-text-muted ml-auto">
+                    {formatRelativeTime(lastTrigger[event], t)}
+                  </span>
+                )}
+              </div>
+            )
+          })}
         </div>
       )}
 
@@ -118,7 +138,15 @@ export function HookModuleCard({ module, hostId, refreshKey }: Props) {
       <div className="flex gap-2">
         <button
           onClick={() => setup('install')}
-          disabled={isOffline || loading || !!status?.installed}
+          // Install is disabled only when the install is fully complete
+          // (installed=true AND no FutureOnly upgrades pending). Finding
+          // #4: legacy 3-event users must still be able to trigger an
+          // upgrade even while installed=true.
+          disabled={
+            isOffline ||
+            loading ||
+            (!!status?.installed && !(status?.upgradesAvailable && status.upgradesAvailable.length > 0))
+          }
           className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs bg-accent text-white cursor-pointer disabled:opacity-50"
         >
           <DownloadSimple size={14} />
@@ -126,7 +154,11 @@ export function HookModuleCard({ module, hostId, refreshKey }: Props) {
         </button>
         <button
           onClick={() => setup('remove')}
-          disabled={isOffline || loading || !status?.installed}
+          // Remove is enabled whenever there is a pdx artifact on disk,
+          // not only when installed=true. Finding #2: drifted-but-
+          // managed state (opencode plugin body mismatch, stale codex
+          // legacy entry) still needs to be removable.
+          disabled={isOffline || loading || !status?.managed}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs bg-red-500/10 text-red-400 border border-red-500/30 cursor-pointer disabled:opacity-50"
         >
           <Trash size={14} />

--- a/spa/src/lib/hook-modules.ts
+++ b/spa/src/lib/hook-modules.ts
@@ -6,10 +6,25 @@ import type { NormalizedEvent } from '../stores/useAgentStore'
 export interface HookModuleEvent {
   installed: boolean
   command?: string | null
+  futureOnly?: boolean
 }
 
 export interface HookModuleStatus {
   installed: boolean
+  /**
+   * Managed is true when the host has pdx-owned artifacts on disk even
+   * if the install has drifted. Drives whether the Remove button is
+   * enabled (Finding #2).
+   */
+  managed?: boolean
+  /**
+   * UpgradesAvailable lists declared-but-not-installed FutureOnly
+   * events. Non-empty while installed=true means "install is valid
+   * but new events are available" — drives the Upgrade hint and
+   * keeps the Install button enabled on legacy pre-expansion users
+   * (Finding #4).
+   */
+  upgradesAvailable?: string[]
   events: Record<string, HookModuleEvent>
   issues?: string[]
   agentVersion?: string

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -573,6 +573,7 @@
   "hosts.hook_just_now": "just now",
   "hosts.hook_minutes_ago": "{{n}}m ago",
   "hosts.hook_hours_ago": "{{n}}h ago",
+  "hosts.hook_upgrade_available": "{{n}} new events available — run install to upgrade",
   "hosts.refresh": "Refresh",
   "hosts.clear_all": "Clear All",
   "hosts.confirm_clear_all": "Are you sure you want to delete all upload files?",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -573,6 +573,7 @@
   "hosts.hook_just_now": "剛剛",
   "hosts.hook_minutes_ago": "{{n}} 分鐘前",
   "hosts.hook_hours_ago": "{{n}} 小時前",
+  "hosts.hook_upgrade_available": "{{n}} 個新事件可升級（重新執行安裝即可）",
   "hosts.refresh": "重新整理",
   "hosts.clear_all": "全部清除",
   "hosts.confirm_clear_all": "確定要刪除所有上傳檔案嗎？",


### PR DESCRIPTION
## Summary

三合一 PR（spec guardrails + TDD plan + Events() 實作），封裝 2026-04-23 Lights rebuild Phase 1 後的架構討論結論與 issue #613 的根因修復。

- **架構護欄**（docs）：spec §2.4 新增五節 Architecture Guardrails（central vs distributed、hook/probe symmetry、alignment strategy、distributed topology、bloat red flags），§8.2 Phase 4b 從「條件執行」升級為「延後必做」，§10/§11 對齊
- **TDD plan**（docs）：`docs/specs/2026-04-23-hook-events-declaration-plan.md` 新增，464 行、純文字（無 Go 程式碼）
- **實作**（code）：`HookInstaller.Events() []HookEventSpec` 作為 hook 事件 + status 映射 + 說明的 single source of truth；三家 provider 實作 Events() 並刪除 `*HookEvents` package var；`SupportedStatuses()` 改由 Events 的 EmitsStatus union derive；drift test 升級為三向等價；codex installer 從 3 事件擴展到 9 事件

Closes #613

## Scope 細分

| 區塊 | 檔案 | 改動 |
|---|---|---|
| spec guardrails | `docs/specs/2026-04-23-lights-rebuild-spec.md` | +64 / -11 |
| TDD plan | `docs/specs/2026-04-23-hook-events-declaration-plan.md` | +464（新檔） |
| interface | `internal/agent/provider.go` | +27 |
| helper | `internal/agent/supported_statuses.go/_test.go` | +99（新檔） |
| cc provider | `cc/{events,events_test,hooks,hooks_test,provider,provider_test}.go` | +402 / -22 |
| codex provider | `codex/{events,events_test,hooks,hooks_test,provider,provider_test}.go` | +401 / -22 |
| opencode provider | `opencode/{events,events_test,hooks,hooks_test,provider,provider_test}.go` | +284 / -22 |
| drift test 升級 | `internal/agent/drift_test.go` | +64 / -16 |
| coverage cross-contract test | `internal/agent/coverage_test.go` | +58 |

合計 **24 檔 / +1290 / -93**，對齊 plan §4 預估。

## 本 PR 不做項目（plan §5 聲明）

- 不加 `/api/agent/monitor/events` endpoint（留 Phase 5）
- 不改 SPA（Inspector UI 是後續工作）
- 不改 `handler.go` 流程邏輯
- 不改 probe 層（probe declaration 是 Phase 4b）
- 不動 `coverage.go` Coverage helper
- 不在 Events 嵌 probe intents
- 不 refactor hooks merge logic
- 不動 opencode plugin_template.go
- 不幫 codex 補 proxy 路徑事件接收
- 不加 daemon 啟動時自動偵測 installer 遺漏

## Test plan

- [x] `go test ./...` 綠（23 packages）
- [x] `go vet ./...` 無 warning
- [x] `go build ./...` 綠
- [x] drift test per-fixture + 三向等價斷言雙重守護
- [x] Events × hook install/check 迴圈契約測試（I1-I5）
- [ ] 手動：跑 `bin/pdx` install codex → 讀 `~/.codex/hooks.json` 確認 9 key（install 後驗證事件清單完整）
- [ ] 手動：opencode hook 無 Notification 確認（DeriveStatus 也無 → Events 宣告也無 → drift 綠）

## 執行過程中發現的 plan 缺陷（已在實作吸收、記錄供 reviewer 參考）

1. **E6 emoji-range 測試**：`strings.ContainsAny` 把 `-` 當字元而非 range，實作改用 rune loop + 範圍比較
2. **codex `TestCheckHooks_ThirdPartyLegacyEntryDoesNotTriggerReinstall`**：fixture 只含 3 事件，installer 擴展後需同步更新為 9 事件（plan §1.7 零改動邊界未列此測試）
3. **`mergeClaudeHooks` / `mergeCodexHooks` 是 package-level function**（非 method），plan §1.7 pseudo-code `p.eventNames()` 不能直接套用；實作補 `<agent>EventNames()` package-level helper 連回 SSoT
4. **三向 drift test 對「同 Status 多路徑」偵測有限**：若從某單一 event 刪除一個 Status、該 Status 仍由其他 event 宣告 + DeriveStatus 仍會產生，三向 set 都不變 — 靠 per-fixture 斷言補（plan §9 有暗示）

## Commits 順序

1. `43313a3a` docs(lights): §2.4 architecture guardrails + Phase 4b 升級
2. `d937d9c7` docs(lights): §10 Phase 4 execution strategy 對齊
3. `4bc0ef45` docs(lights): TDD plan for HookInstaller.Events() declaration
4. `bfaee55b` feat(agent): add HookEventSpec type + Events() to HookInstaller
5. `c79570cc` feat(agent): add DeriveSupportedStatuses helper + tests
6. `13338581` feat(agent/cc): implement Events() + derive SupportedStatuses
7. `c6a59e1c` feat(agent/opencode): implement Events() + derive SupportedStatuses
8. `fe653215` feat(agent/codex): expand installer to 9 events via Events()
9. `d782cd5a` test(agent): upgrade drift test to three-way equality
10. `0a7aecae` test(agent): add Coverage × Events cross-contract test
11. `793b6f69` docs(spec): mark §2.4.3 event alignment resolved via Events() PR