### PR TITLE
feat(agent): Phase 2 PR-2a — SubagentRef schema + wire breaking upgrade

### DIFF
--- a/cmd/pdx/main.go
+++ b/cmd/pdx/main.go
@@ -152,7 +152,11 @@ func runServe(args []string) {
 	// 5. Add modules (order doesn't matter — topoSort handles dependencies)
 	c.AddModule(session.NewSessionModule(meta))
 	c.AddModule(stream.New())
-	c.AddModule(agent.New(agentEvents))
+	agentMod, err := agent.New(agentEvents)
+	if err != nil {
+		log.Fatalf("agent module: %v", err)
+	}
+	c.AddModule(agentMod)
 	c.AddModule(fsmod.New())
 	c.AddModule(logs.New())
 	c.AddModule(syncmod.New())

--- a/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
+++ b/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
@@ -1,6 +1,6 @@
-# Phase 2 TDD Plan v4 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
+# Phase 2 TDD Plan v5 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
 
-- **Date**: 2026-04-24（v1→v2: `review-mobwvdpq-w6kftz`; v2→v3: `review-mobxgl16-mfkzav`; v3→v4: `review-mocgelr5-z0v0a4`）
+- **Date**: 2026-04-24（v1→v2: `review-mobwvdpq-w6kftz`; v2→v3: `review-mobxgl16-mfkzav`; v3→v4: `review-mocgelr5-z0v0a4`; v4→v5: `review-mocgnzun-lu31px`）
 - **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §6
 - **Worktree**: `lights-phase-2`（branch `worktree-lights-phase-2`）
 - **依賴**: Phase 1（merged at `d1d60b2c`）+ Hook Events PR #616（merged at `fd9f8f8f`, alpha.217）
@@ -186,14 +186,19 @@ func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
             if candidate.AgentType == req.AgentType {
                 return nil, nil
             }
-            // v4 identity rule: 不只 PID alive，也要 process_start_time match
-            // 避免 PID 重用誤掛到舊 stale frame。
+            // v4 identity rule + v5 error handling:
+            // 1. alive + start_time 讀成功且 match → 命中 return
+            // 2. alive + start_time 讀成功但 mismatch → stale frame，跳過此 candidate 續爬
+            // 3. alive + start_time 讀失敗 → identity 無法確認，abort walk（與 verify.go 慣例一致）
             if isPidAliveFn(candidate.PID) {
                 actualStart, serr := processStartTimeFn(candidate.PID)
-                if serr == nil && actualStart == candidate.ProcessStartTime {
-                    return candidate, nil // 命中：cross-type + alive + start_time match
+                if serr != nil {
+                    return nil, nil // v5: read error abort walk, fallback 建新 frame
                 }
-                // start_time mismatch or read error → candidate 是 stale frame，跳過續爬
+                if actualStart == candidate.ProcessStartTime {
+                    return candidate, nil // 命中：cross-type + alive + identity match
+                }
+                // 明確 mismatch → 續爬（可能上一層才是真正 parent）
             }
         }
         // 沒命中 alive parent，往上一層
@@ -210,12 +215,15 @@ func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
 }
 ```
 
-**Walk 規則**（v4 rewrite）：
+**Walk 規則**（v5 rewrite）：
 - 每層 `FindByPanePID(paneID, ppid)` 取 candidate
 - `candidate == nil`（該 ppid 在此 pane 沒 frame）→ 續爬上一層
 - **Same-type 硬停**：`candidate.AgentType == req.AgentType` → 立即 `return nil`（不續爬，不 proxy）。語意：pane 內有同類 frame 意味新 hook 是 re-session / update，不是 proxy。
-- **Identity check**：`candidate` 要同時滿足 `isPidAliveFn(pid)` + `processStartTimeFn(pid) == candidate.ProcessStartTime` 才算命中
-  - Alive 但 start_time mismatch → candidate 是 stale（真正進程是 PID 重用的另一個），跳過該 candidate 續爬（**不** return nil，因為可能上層有真正 parent）
+- **Identity check（v5 三分支）**：
+  - Candidate alive + start_time 讀成功且 match → 命中 return
+  - Candidate alive + start_time **明確 mismatch**（讀成功但值不同）→ stale frame，跳過該 candidate 續爬（上層可能有真正 parent）
+  - Candidate alive + start_time **讀取失敗**（serr != nil）→ identity 無法確認，**abort walk return nil** fallback 建新 frame（與 `verify.go` 慣例一致：lookup error 不推理）
+  - Candidate dead → 不算命中，續爬上一層（dead frame 由 sweep 清）
 - **Depth 定義**：`proxyMaxDepth = 5` 嚴格代表「檢查 5 個 ancestor」（depth 迴圈跑 5 次）。第 6 層的 ancestor 不會被檢查；超深 chain 一律 fallback 建新 frame
 
 **觸發條件**（全部成立才算 proxy）：
@@ -608,6 +616,7 @@ interface Props {
 | PR12 | `TestProxySubagent_PartialChainOnReadError` | codex SessionStart PPID 200；readProcessInfoFn(200) 回 error | 放棄 walk，fallback 建新 codex frame |
 | **PR13 v4-new** | `TestProxySubagent_SkipsStaleFrameByStartTimeMismatch` | cc frame PID 100 start "t100"；codex SessionStart PPID=100；`isPidAliveFn(100)=true` 但 `processStartTimeFn(100)="t_different"`（PID 重用新進程） | 不 proxy 到 stale cc frame；walk 續爬上層，上層 PPID 亦無 frame → fallback 建新 codex frame；stale cc.LastSeenAt 不被刷新 |
 | **PR14 v4-new** | `TestProxySubagent_SameTypeAncestorStopsWalk` | pane 內 cc frame PID 100 + codex frame PID 200 PPID 100；codex SessionStart PID 400 PPID 300 PPID 200 (companion 串到 codex parent) | 遇 same-type codex frame 硬停，不續爬到 cc；建新 codex frame（不 proxy） |
+| **PR15 v5-new** | `TestProxySubagent_AbortsWalkOnStartTimeReadError` | cc frame PID 100 start "t100"；codex SessionStart PPID 100；`isPidAliveFn(100)=true` 但 `processStartTimeFn(100)` 回 error（暫時性 lstat / ps 失敗） | `findProxyParent` return nil；建新 codex frame（**不** 續爬到更上層的其他 cross-type ancestor） |
 
 ### 2.6 SessionEnd Proxy Cleanup（PR-2b）
 
@@ -706,8 +715,8 @@ interface Props {
 - 跑 `go test ./internal/store/...` 綠
 
 #### Commit 7 — `feat(module/agent): detect proxy subagents via PPID ancestor walk`
-- 紅：PR1-PR12 → 失敗
-- 綠：`frame_ops.go` applyFrameEvent 加 proxy 偵測分支 + `findProxyParent` helper（depth 5 PPID walk）+ proxyIDFor helper
+- 紅：PR1-PR15（含 v4 新增 PR13/PR14 + v5 新增 PR15）→ 失敗
+- 綠：`frame_ops.go` applyFrameEvent 加 proxy 偵測分支 + `findProxyParent` helper（depth 5 PPID walk + v5 三分支 identity check）+ proxyIDFor helper
 - 跑 `go test ./internal/module/agent/...` 綠
 
 #### Commit 8 — `feat(module/agent): remove proxy ref on SessionEnd`
@@ -767,8 +776,8 @@ interface Props {
 |---|---|---|
 | `internal/store/frames.go` | `DeleteIfUnchanged` method | +20 |
 | `internal/store/frames_test.go` | F4-F6 | +50 |
-| `internal/module/agent/frame_ops.go` | proxy 偵測分支 + `findProxyParent`（tree walk depth 5 + start_time identity check + same-type hard stop）+ `removeProxyRefForSender` | +140 |
-| `internal/module/agent/frame_ops_test.go` | PR1-PR14 + SE1-SE3（14 proxy + 3 session end = 17 case，含 tree walk mocks） | +420 |
+| `internal/module/agent/frame_ops.go` | proxy 偵測分支 + `findProxyParent`（tree walk depth 5 + start_time identity 三分支 + same-type hard stop）+ `removeProxyRefForSender` | +145 |
+| `internal/module/agent/frame_ops_test.go` | PR1-PR15 + SE1-SE3（15 proxy + 3 session end = 18 case，含 tree walk + error mocks） | +440 |
 | `internal/module/agent/sweep.go` | nowFn + threshold + 第三條規則 + afterFrameCleared 抽出 + StopWatch fix | +50 |
 | `internal/module/agent/sweep_test.go` | IS1-IS5 | +160 |
 | `internal/module/agent/handler_test.go` | HB2 | +40 |
@@ -798,7 +807,7 @@ interface Props {
 - **不做** boot hard-fail 舊格式偵測（同上，成本 > 收益）
 - **不加** `SubagentRef.Status` / `SubagentRef.LastSeenAt`（Phase 4/5 再評估）
 - **不做** proxy ref 的獨立 liveness 檢查（Phase 3 / 4b；SessionEnd 清理已涵蓋大多數 case）
-- **不做** PPID 樹狀遍歷（Phase 3/4 再加；單層 PPID 命中率實測先看）
+- **不做** 無界 / 泛化 PPID 樹狀遍歷（Phase 2 範圍內**只接受 `proxyMaxDepth = 5` 的有限深度 walk**；Phase 3/4 視實測調整深度 or 加權策略，不在 Phase 2 改）
 - **不處理** 非 SessionStart 的 proxy 事件（Phase 3/4）
 - **不改** `/api/agent/monitor/*` endpoint shape（Phase 5 Inspector 統一）
 - **不重整** `handler.go` / `module.go`（Phase 2 是 frame_ops / sweep 局部增加）
@@ -843,7 +852,13 @@ interface Props {
 
 - [ ] 5 個 commits 符合規範（6-10）
 - [ ] 每個 commit 邊界 `go build ./...` + tests 綠
-- [ ] `go test ./...` 綠（F4-F6 / PR1-PR7 / SE1-SE3 / IS1-IS5 / HB2 共 19 測試）
+- [ ] `go test ./...` 綠 — 必跑全集合：
+  - F4-F6（3 個 DeleteIfUnchanged store tests）
+  - **PR1-PR15**（15 個 proxy tests，含 v4 PR13/PR14、v5 PR15 的 identity + error regression）
+  - SE1-SE3（3 個 SessionEnd proxy cleanup tests）
+  - IS1-IS5（5 個 idle sweep tests）
+  - HB2（1 個 handler broadcast IsProxy smoke）
+  - **小計：27 個新測試**
 - [ ] `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
 - [ ] PR diff 檔案：§4 PR-2b 表格列出的檔案
 - [ ] 手動場景：
@@ -942,6 +957,16 @@ interface Props {
 | **新增 PR14 `SameTypeAncestorStopsWalk`** | v3 #2 修正的回歸測試：同 type 硬停 |
 | `findProxyParent` 行數 +10（start_time check + stale frame 跳過邏輯） | v3 #1+#2 實作 |
 | 測試從 PR1-PR12 擴到 PR1-PR14 | 2 個新 case |
+
+### v4 → v5
+
+| 改動 | 原因 |
+|---|---|
+| **`processStartTimeFn` 讀取失敗改 abort walk**（§1.4 identity 三分支：命中 / mismatch 續爬 / error abort） | Codex v4 #1: v4 把 read error 跟 mismatch 混用，暫時錯誤會誤掛更上層；與 `verify.go` 慣例（lookup error 不推理）不一致 |
+| **§5 刪「不做 PPID 樹狀遍歷」** 改「不做無界 / 泛化樹狀遍歷，Phase 2 只接受 depth=5」 | Codex v4 #2: v3 納入 ancestor walk 為正式方案，舊 §5 禁令未同步 → subagent 看 §5 可能 rollback |
+| **§3 Commit 7 TDD gate 改 PR1-PR15** | Codex v4 #3: v4 新增 PR13/PR14 未進 commit 必跑集合 |
+| **§7 PR-2b 驗收列明必跑總集合** 27 測試（F4-F6 / PR1-PR15 / SE1-SE3 / IS1-IS5 / HB2） | Codex v4 #3: v4 驗收仍寫「19 測試」舊數 |
+| **新增 PR15 `AbortsWalkOnStartTimeReadError`** | v4 #1 修正的回歸測試 |
 
 ---
 

--- a/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
+++ b/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
@@ -1,0 +1,488 @@
+# Phase 2 TDD Plan — L3 Subagent 升級 + Proxy + Frame Idle Sweep
+
+- **Date**: 2026-04-24
+- **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §6
+- **Worktree**: `lights-phase-2`（branch `worktree-lights-phase-2`）
+- **依賴**: Phase 1（merged at `d1d60b2c`）+ Hook Events PR #616（merged at `fd9f8f8f`, alpha.217）
+- **範圍**：`SubagentRef` 結構升級 + proxy 偵測 + frame idle sweep + SPA 型別 / 視覺升級
+
+## 0. 量體與拆分判斷
+
+**本 plan 寫成單 PR**，實際改動落地後再由 review 負擔判斷是否拆 PR-2a（schema 升級，commits 1-7）+ PR-2b（proxy + sweep，commits 8-10）。
+
+拆分時機（任一命中即拆）：
+- Plan 階段 codex review 回 12+ findings
+- 實作完成後 `git diff --stat` > 1200 行（含測試）
+- 單一 reviewer 讀完需要超過 30 分鐘的預估量
+
+拆分形式：PR-2a schema-only（純改型別，行為不變），PR-2b 新行為（proxy 偵測 + idle sweep + SubagentDots 視覺）。
+
+## 1. 契約鎖定
+
+### 1.1 `SubagentRef` 型別（新增）
+
+位置：`internal/agent/subagent.go`（新檔，放在 `internal/agent` package 根層，與 `status.go` 平行）— 放 store 層不當因為 Type 語意綁 agent registry。
+
+```go
+type SubagentRef struct {
+    ID        string `json:"id"`
+    Type      string `json:"type"`                  // agent type, e.g. "cc" / "codex" / "opencode"
+    StartedAt int64  `json:"started_at"`            // UnixNano，沿用 frame broadcast_ts 口徑
+    IsProxy   bool   `json:"is_proxy,omitempty"`    // true 代表跨 agent_type 的同 pane hook 被收編
+}
+```
+
+**設計要點**：
+- `ID` 語意：SubagentStart 分支 = `raw.agent_id`；proxy 分支 = `"proxy:<agent_type>:<pid>"` 合成字串（確保唯一；不是 UUID，可讀性優先）
+- `Type` 語意：SubagentStart 分支 = 盡量取 `raw.agent_type`（opencode 有；cc / codex 沒有則 fallback 為 parent frame 的 `AgentType`）；proxy 分支 = `req.AgentType`（新 hook 的 agent type）
+- `StartedAt`：**只在首次新增時設定**；重複 SubagentStart 同 ID 不覆寫（保持早期時間戳，供 UI 排序）。proxy 重複 hook 同樣不刷 StartedAt
+- `IsProxy,omitempty`：JSON 僅在 true 時序列化，方便舊前端 / 測試 snapshot 穩定
+- **不加** `LastSeenAt` 欄位（Phase 2 避免 scope 蔓延；idle sweep 只看 frame.LastSeenAt 整體）
+- **不加** `Status` 欄位（SubagentStart hook 本來就 Status=""；Phase 2 保持 detail-only 語意）
+
+### 1.2 Frame.Subagents 升級
+
+`internal/store/frames.go`:
+
+- `Frame.Subagents []string` → `[]agentpkg.SubagentRef`
+- SQL schema（column `subagents_json`）不改 — JSON 形狀換掉即可（alpha 階段允許；使用者重建 DB 即得新格式）
+- `scanFrame` 的 `json.Unmarshal` 從 `[]string` 改成 `[]SubagentRef`
+- `Upsert` 的 `json.Marshal` 自動吃新型別
+- **nil 防護不變**：`if frame.Subagents == nil { frame.Subagents = []SubagentRef{} }`（空 slice 不是 nil）
+
+**Breaking change 範圍**：現有 DB 中 `subagents_json` 若是舊格式（`["id1","id2"]`），Unmarshal 會失敗。解法：alpha 階段要求使用者重建 DB，或加一條 `scanFrame` fallback（嘗試舊格式→轉成最小 SubagentRef{ID: s}）。**取前者**（spec §6 明文允許破壞式升級），避免 fallback 在 code 裡留住 deprecated 路徑。
+
+### 1.3 `updateSubagents` 簽名升級
+
+`internal/module/agent/frame_ops.go`:
+
+```go
+// before
+func updateSubagents(current []string, eventName, agentID string) []string
+
+// after
+func updateSubagents(current []agentpkg.SubagentRef, eventName string, ref agentpkg.SubagentRef) []agentpkg.SubagentRef
+```
+
+行為：
+- `SubagentStart`：若 `current` 無同 ID → append ref；若有同 ID → 不覆寫既有（保留既有 StartedAt / IsProxy）
+- `SubagentStop`：filter 掉同 ID 的 ref（Type 不參與比對，避免 proxy→native 切換時漏刪）
+
+在 `applyFrameEvent` 的 SubagentStart/Stop 分支組出 `ref`：
+```go
+ref := agentpkg.SubagentRef{
+    ID:        agentID,                         // from result.Detail["agent_id"]
+    Type:      firstNonEmpty(
+        strFromDetail(result.Detail, "agent_type"),
+        frame.AgentType,                        // fallback to parent frame's type
+    ),
+    StartedAt: broadcastTs,
+    IsProxy:   false,
+}
+```
+
+### 1.4 Proxy 偵測分支（新）
+
+在 `applyFrameEvent` 當前「建/更 frame」主路徑**之前**插入 proxy 判斷：
+
+**觸發條件（全部成立）**：
+1. `req.EventName` 是 frame-creating event（`SessionStart`）— 只看 SessionStart，其他 event（UserPromptSubmit 等）若沒 frame 本就走 legacy 路徑，不是 Phase 2 範圍
+2. `frame == nil`（同 identity pid/start 無既有 frame，表「新來的」）
+3. `m.frames.ListByPane(req.TmuxPaneID)` 存在至少一個 frame（parent 候選）且**該 parent.AgentType ≠ req.AgentType**
+4. 候選 parent 需 PID alive（避免把 proxy 掛到殭屍 parent 上；使用 `isPidAliveFn`）— 若 parent 已死，不算命中 proxy（走既有建 frame 路徑）
+
+**命中行為**：
+- 選最新 StartedAt 的 alive、type-不同 parent 作為收編對象
+- 組 `ref = SubagentRef{ID: proxyIDFor(req), Type: req.AgentType, StartedAt: broadcastTs, IsProxy: true}`
+- `parent.Subagents = updateSubagents(parent.Subagents, "SubagentStart", ref)`
+- `parent.LastSeenAt = broadcastTs`
+- `m.frames.Upsert(parent)` — **不建新 frame**
+- Trace meta：`Decision="updated_frame", Reason="proxy_subagent_attached"`，`FrameID/ParentFrameID` 指 parent
+- projection 回傳 parent pane 的投影
+
+`proxyIDFor(req EventRequest) string`：`fmt.Sprintf("proxy:%s:%d", req.AgentType, req.SenderPID)` — PID + agent_type 在 pane 層級可唯一；跨 pane 重複 PID 無所謂（proxy ID 的作用域是 parent.Subagents，只有同 pane 能撞）。
+
+**不命中條件**：
+- parent.AgentType == req.AgentType → 真的是同類 re-session，走原路徑建 frame（例：cc exit 後 cc 再起）
+- pane 無其他 frame → 獨立新 session，走原路徑建 frame
+- 所有候選 parent PID 都死 → 走原路徑建 frame（死 parent 由 sweep 處理）
+
+**非 SessionStart 的 proxy 事件（UserPromptSubmit 等）**：Phase 2 不處理。觀察實際行為若 codex proxy 沒先送 SessionStart 再開工，Phase 3/4 補。
+
+### 1.5 SessionEnd 對 proxy 的處理
+
+若 proxy ref 的來源 agent 送了 SessionEnd：
+- `applyFrameEvent` 的 SessionEnd 分支先查 `frame := GetByIdentity(pane, pid, startTime)`
+- proxy 的 SubagentRef 沒有獨立 frame（掛在 parent），所以這條查詢會 `frame == nil`
+- 對應到現有的 `session_end_without_frame` 分支 — Phase 2 不改這條
+- 結果：proxy ref 不會被 SessionEnd 自動清，由 **parent frame 清理時連帶清**（parent SessionEnd / pid_dead / idle_timeout）或 **sweep 時 ref.ID 對應的 PID 死掉**（見 §1.6）
+
+**Phase 2 不做**：proxy ref 的獨立 liveness 檢查（掃 subagents 裡有無 proxy ID 對應 dead PID 並移除）。原因：會把 sweep 改大、且實務上 parent frame 掛掉時 proxy ref 自然走 — 留 Phase 3 評估必要性。
+
+### 1.6 Frame Idle Sweep 規則（新）
+
+`internal/module/agent/sweep.go`：
+
+```go
+const frameIdleThreshold = 1 * time.Hour
+```
+
+`sweepOnce` 迴圈每個 frame 檢查順序（插入現有兩條之後第三條）：
+1. `!isPidAliveFn(frame.PID)` → `clearFrame(frame, "pid_dead")` — 既有
+2. `processStartTimeFn(frame.PID) != frame.ProcessStartTime` → `clearFrame(frame, "pid_reused")` — 既有
+3. **新**：`time.Now().UnixNano() - frame.LastSeenAt > frameIdleThreshold.Nanoseconds()` → `clearFrame(frame, "idle_timeout")`
+
+注入測試時鐘：新增 `var nowFn = time.Now`（與 `isPidAliveFn` / `processStartTimeFn` 同 pattern），測試 swap。
+
+**注意**：LastSeenAt 是 UnixNano（見 `broadcastTs` 呼叫點），`time.Duration.Nanoseconds()` 可直接比較。
+
+### 1.7 Clear Frame 的 Orphan Watcher 清理（已部分存在，補強）
+
+既有 `clearFrame` 已經 `delete(m.activeWatchers, sessionName)`（module.go clear 流程已做）但**沒有呼叫 `prober.StopWatch`**。補一行：
+
+```go
+// sweep.go clearFrame 裡 m.mu.Unlock() 之後：
+if hadWatcher && m.prober != nil {
+    m.prober.StopWatch(sessionName + ":")
+}
+```
+
+其中 `hadWatcher` 在 `m.mu.Lock()` 區塊內取 `_, hadWatcher := m.activeWatchers[sessionName]` 後再 delete。
+
+**為何這個 fix 重要**：idle_timeout 清 frame 時，session 可能有 active watcher（waiting/running/idle 任一狀態觸發過）。不 StopWatch → watcher goroutine 漏留在 prober 裡，畫面變化還在餵空 session → 回 onActivityDetected 時 activeWatchers 已 delete 就 early-return（既有防護），功能上 OK，但資源 leak。
+
+pid_dead / pid_reused 既有路徑也吃到這個修正（順勢清乾淨）— 非 Phase 2 新增 scope，是既有 bug 一併修。
+
+### 1.8 SessionProjection.Subagents 升級
+
+`internal/module/agent/projection.go`:
+
+- `SessionProjection.Subagents []string` → `[]agentpkg.SubagentRef`
+- `buildPaneProjection` 的 defensive copy 跟著升級
+
+### 1.9 NormalizedEvent.Subagents 升級（WS wire）
+
+`internal/agent/status.go`:
+
+- `NormalizedEvent.Subagents []string` → `[]SubagentRef` — 注意 JSON tag 保持 `"subagents"` 一致
+- `handler.go` `buildNormalized` + `frame_ops.go` `buildProjectionNormalized` + `module.go` `onActivityDetected` 裡三處建構 NormalizedEvent 的 copy 全跟著升級
+
+**Wire compatibility**：舊 SPA 期望 `subagents: string[]`，新 daemon 會送 `subagents: SubagentRef[]`。Alpha 階段 daemon + SPA 同步升級一次到位，不留過渡層。Electron dev update 會先升級 daemon 或 SPA 之一 → 短暫的型別 mismatch → SPA 顯示空 subagents / throw（運行時測試會抓到，接受）。
+
+### 1.10 m.subagents map 升級
+
+`internal/module/agent/module.go`:
+
+- `subagents map[string][]string` → `map[string][]agentpkg.SubagentRef`
+- `syncProjectionState` 的 map 參數型別同步升級
+- `replayFromDB` / `sendSnapshot` 透過 `syncProjectionState` 間接升級，無額外改動
+
+### 1.11 SPA 型別升級
+
+`spa/src/stores/useAgentStore.ts`:
+
+```ts
+export interface SubagentRef {
+  id: string
+  type: string
+  started_at: number
+  is_proxy?: boolean
+}
+
+export interface NormalizedEvent {
+  // ...
+  subagents?: SubagentRef[]
+}
+
+interface AgentState {
+  // ...
+  subagents: Record<string, SubagentRef[]>
+  // ...
+}
+```
+
+`handleNormalizedEvent` 內 `if (event.subagents)` 分支邏輯不變（仍是 length>0 set / length==0 delete）。型別自動跟著 shift。
+
+### 1.12 SubagentDots 視覺升級
+
+`spa/src/components/SubagentDots.tsx`:
+
+API 從 `{ count: number }` 改為 `{ refs: SubagentRef[] }`：
+
+```ts
+interface Props {
+  refs: SubagentRef[]
+  left?: number
+}
+```
+
+視覺規則（Phase 2 最小）：
+- Dot 數仍依 `refs.length`（最多 3）
+- **Type 色**：每個 dot 依其 ref.type 決定顏色；查表：`cc → #60a5fa`（藍，既有）/ `codex → #facc15`（黃）/ `opencode → #f97316`（橘）/ fallback `#60a5fa`
+- **Proxy 樣式**：`is_proxy === true` → dot 用 outline（背景 transparent + 1px solid type color）而非實心；proxy=false → 實心不變
+- `animationDelay` 公式不變
+
+**TabIcon.tsx**：`subagentCount: number` prop → `subagentRefs: SubagentRef[]` prop；dot 模式 / iconDot 模式 / badge 模式全改吃 list；`refs.length > 0` 取代 `count > 0`。
+
+**useTabDisplay.ts**：`subagentCount = subagents[ck]?.length ?? 0` → `subagentRefs = subagents[ck] ?? []`；回傳值加 `subagentRefs` 欄位或改名（傾向改名，count 拿掉）。
+
+**SubagentDots 測試**：保留既有 count-based 測試，但輸入改建 mock refs；新加兩個 case — type 色差 + proxy outline。
+
+### 1.13 零改動邊界
+
+以下檔案 Phase 2 **不得觸碰**：
+
+- `internal/agent/provider.go` / `registry.go` / `status.go`（除 NormalizedEvent 欄位升級）/ `coverage.go`
+- `internal/agent/{cc,codex,opencode}/*.go`（SubagentStart detail 已備齊 `agent_id`）
+- `internal/agent/probe/**`
+- `internal/store/frames.go` 的 SQL schema（column 不變；僅 JSON shape 變）
+- `internal/module/agent/verify.go` / `upload*.go` / `monitor.go` / `statusline*.go`
+- `spa/src/**` 除 `useAgentStore.ts` / `SubagentDots.tsx` / `TabIcon.tsx` / `useTabDisplay.ts` + 測試 seed 檔外不動
+- `/api/agent/monitor/*` endpoint shape — 不改（Phase 5 Inspector 再統一）
+
+## 2. 測試案例清單
+
+### 2.1 SubagentRef JSON round-trip
+
+`internal/agent/subagent_test.go`（新檔）：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| R1 | `TestSubagentRef_JSONRoundTrip` | `{ID:"a", Type:"cc", StartedAt:123, IsProxy:true}` marshal/unmarshal 相等；JSON bytes 含 `"is_proxy":true` |
+| R2 | `TestSubagentRef_OmitsIsProxyWhenFalse` | `IsProxy:false` 的 marshal JSON bytes **不含** `is_proxy` key（omitempty 驗證） |
+
+### 2.2 Frame store 升級
+
+`internal/store/frames_test.go` 補：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| F1 | `TestFrames_UpsertAndReadSubagentRefs` | Upsert 帶 `[]SubagentRef{{ID:"s1", Type:"cc", StartedAt:10}}` → GetByIdentity 讀回同值 |
+| F2 | `TestFrames_EmptySubagentsPreserved` | Upsert 帶 `nil` Subagents → 讀回 `[]SubagentRef{}`（非 nil） |
+| F3 | `TestFrames_SubagentsJSONFormatContainsExpectedKeys` | 讀回 frame 後 marshal `[]SubagentRef` 的 JSON 字串包含 `"id"` / `"type"` / `"started_at"`（smoke test 對齊 §1.1） |
+
+既有測試涉及 `Subagents: []string{...}` seed 全改為 `[]SubagentRef{...}`。
+
+### 2.3 updateSubagents 單元
+
+`internal/module/agent/frame_ops_test.go` 補（或分檔 `subagents_test.go`）：
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| U1 | `TestUpdateSubagents_StartAddsRef` | 空 list + SubagentStart ref → list 有 1 個 ref |
+| U2 | `TestUpdateSubagents_StartDuplicateIDKeepsExisting` | 已有 `{ID:"a", StartedAt:10}` + SubagentStart `{ID:"a", StartedAt:20}` → list 仍為 1 個，StartedAt=10（不覆寫） |
+| U3 | `TestUpdateSubagents_StopRemovesByID` | list `[a, b]` + SubagentStop `{ID:"a"}` → list = `[b]` |
+| U4 | `TestUpdateSubagents_StopIgnoresType` | list `[{ID:"a", Type:"cc"}]` + SubagentStop `{ID:"a", Type:"codex"}` → list 為空（Type 不參與比對） |
+| U5 | `TestUpdateSubagents_StopMissingIsNoop` | list `[a]` + SubagentStop `{ID:"b"}` → list = `[a]` |
+
+### 2.4 Proxy 偵測整合
+
+`internal/module/agent/frame_ops_test.go`:
+
+| # | 名稱 | 情境 | 斷言 |
+|---|---|---|---|
+| PR1 | `TestProxySubagent_CodexHookAttachesToCCParent` | cc SessionStart → codex SessionStart 同 pane | pane 只有 1 個 frame（cc），cc.Subagents 有一筆 `{Type:"codex", IsProxy:true}` |
+| PR2 | `TestProxySubagent_SkipsWhenParentSameType` | cc SessionStart → cc SessionStart 同 pane 但不同 pid/start | pane 有 2 個 frame（新舊 cc），不觸發 proxy |
+| PR3 | `TestProxySubagent_SkipsWhenParentPidDead` | cc frame 已存在但 isPidAliveFn 回 false → codex SessionStart | 走既有路徑建新 codex frame，不觸發 proxy |
+| PR4 | `TestProxySubagent_SkipsWhenNoParent` | 空 pane → codex SessionStart | 建新 codex frame |
+| PR5 | `TestProxySubagent_TraceMetaCorrect` | PR1 情境 | trace meta decision="updated_frame", reason="proxy_subagent_attached", FrameID=parent.FrameID |
+| PR6 | `TestProxySubagent_DoesNotDoubleAttachOnReHook` | PR1 後再送一次 codex SessionStart（同 PID）| cc.Subagents 仍為 1 筆，StartedAt 為首次時間 |
+
+### 2.5 Frame Idle Sweep
+
+`internal/module/agent/sweep_test.go`:
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| IS1 | `TestSweep_ClearsIdleFramesByLastSeen` | Upsert frame LastSeenAt=0，nowFn 回固定 `2*frameIdleThreshold` → sweepOnce 後 frame 被清、clearFrame reason="idle_timeout" 走 broadcast |
+| IS2 | `TestSweep_PreservesFreshFrames` | LastSeenAt=nowFn-1min → sweepOnce 後 frame 保留 |
+| IS3 | `TestSweep_IdleClearStopsOrphanWatcher` | frame idle + session 有 activeWatcher → clearFrame 後 prober.StopWatch 被呼叫（fake prober 記 call） |
+| IS4 | `TestSweep_DeadPidAlsoStopsOrphanWatcher` | 既有 pid_dead 路徑也觸發 StopWatch（順勢 fix 的迴歸測試） |
+
+### 2.6 Handler 整合：broadcast 含 SubagentRef
+
+`internal/module/agent/handler_test.go`:
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| HB1 | `TestHandleEvent_BroadcastPayloadCarriesSubagentRefs` | SessionStart + SubagentStart cc → WS broadcast payload 解析後 `subagents[0]` 含 `type`、`started_at`、無 `is_proxy`（omitempty） |
+| HB2 | `TestHandleEvent_ProxyBroadcastCarriesIsProxyTrue` | cc SessionStart → codex SessionStart → 第二次 broadcast `subagents[0].is_proxy==true, type=="codex"` |
+
+### 2.7 SPA 測試升級
+
+- `useAgentStore.test.ts`（若存在）+ 所有 seed `subagents: {}` / `subagents: { key: [...] }` 的測試檔更新 mock 為 `SubagentRef[]`
+- `SubagentDots.test.tsx`（新檔）：
+  - `TestSubagentDots_Count`：refs 1/2/3 → 對應 dot 數
+  - `TestSubagentDots_TypeColors`：三家 type → 三個不同 backgroundColor
+  - `TestSubagentDots_ProxyOutline`：ref with `is_proxy:true` → border 1px + background transparent；`is_proxy:false/undefined` → solid background
+- `useTabDisplay.test.ts` line 160 的 `subagents: { 'h1:sc1': [{ id: 's1' }] as never }` 改為正規 SubagentRef
+
+## 3. TDD 執行順序
+
+Subagent 嚴格按以下順序執行；每個 step 一個 commit。Commit message 用 Conventional Commits + `Co-Authored-By: Claude Opus 4.7 (1M context)`。
+
+### Commit 1 — `feat(agent): add SubagentRef type`
+- 紅：寫 R1 + R2 → 失敗（type 不存在）
+- 綠：新檔 `internal/agent/subagent.go`
+- 跑 `go test ./internal/agent/...` 綠
+
+### Commit 2 — `refactor(store): upgrade Frame.Subagents to []SubagentRef`
+- 紅：寫 F1 + F2 + F3 → 失敗（型別不符）
+- 綠：`internal/store/frames.go` 型別升級 + nil 防護；更新既有 frames_test seed
+- 跑 `go test ./internal/store/...` 綠；`go build ./...` 期望**失敗**（frame_ops 仍吃 `[]string`）— 這是刻意的，下個 commit 接手
+
+### Commit 3 — `refactor(module/agent): upgrade frame_ops/projection for SubagentRef`
+- 紅：寫 U1-U5 → 失敗
+- 綠：`frame_ops.go` updateSubagents 簽名升級；`projection.go` SessionProjection 升級；`m.subagents` map 升級；`buildProjectionNormalized` 跟上；既有 frame_ops_test / projection_test / sweep_test 的 seed 全改
+- 跑 `go build ./...` + `go test ./internal/module/agent/... ./internal/store/...` 綠
+
+### Commit 4 — `refactor(agent): upgrade NormalizedEvent.Subagents wire`
+- 紅：HB1 期望 payload 新欄位 → 失敗
+- 綠：`internal/agent/status.go` NormalizedEvent.Subagents 型別升級；handler.go `buildNormalized` 跟上
+- 跑 `go test ./...` 綠
+
+### Commit 5 — `refactor(spa): upgrade useAgentStore subagents to SubagentRef[]`
+- 紅：SPA 編譯錯誤（型別 mismatch 會卡 lint/build）
+- 綠：`useAgentStore.ts` SubagentRef + NormalizedEvent + subagents Record 升級；既有 store 測試 seed 改
+- 跑 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠（此 commit 結束時 TabIcon/SubagentDots 仍吃舊 count，下個 commit 修）
+
+**註**：為了讓中間 commit 保持 SPA build 綠，commit 5 先把 `useTabDisplay.ts` 的 subagentCount 從 `length` 維持（SubagentRef[].length 仍 work），僅把 store 型別升級。Component API 升級留 commit 6。
+
+### Commit 6 — `feat(spa): SubagentDots takes SubagentRef[] with type color + proxy outline`
+- 紅：寫 SubagentDots.test.tsx 三個 case → 失敗
+- 綠：SubagentDots API 升級；TabIcon 改吃 refs；useTabDisplay 回傳 refs
+- 跑 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
+
+### Commit 7 — `test(module/agent): schema升級 integration coverage`
+- 紅：HB1 → 失敗（handler broadcast 尚未真實帶 SubagentRef，但上幾個 commit 已升級，實際應綠）
+- 綠（驗證性）：跑過一次確認整合
+- 如果 HB1 已在 commit 4 加入就併進去；這個 commit 可變可選
+
+### Commit 8 — `feat(module/agent): detect proxy subagents for cross-type hooks`
+- 紅：PR1-PR6 → 失敗
+- 綠：`frame_ops.go` applyFrameEvent 加 proxy 偵測分支 + proxyIDFor helper
+- 跑 `go test ./internal/module/agent/...` 綠
+
+### Commit 9 — `feat(module/agent): sweep idle frames after 1h LastSeenAt`
+- 紅：IS1-IS4 → 失敗
+- 綠：`sweep.go` 加 `nowFn` + `frameIdleThreshold` const + 第三條規則 + `clearFrame` 補 StopWatch
+- 跑 `go test ./internal/module/agent/...` 綠
+
+### Commit 10 — `test(spa): update subagents mocks across seed sites`
+- 紅：若仍有測試檔 seed `{ key: [{ id }] as never }` 舊格式 → 升級後會漏
+- 綠：掃全 SPA 測試檔，把 subagents seed 規範化為 `SubagentRef[]`
+- 跑 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
+
+### Commit 11 — `docs: phase 2 plan retrospective notes`（可選）
+若 §3 順序與實際執行偏差，補 Phase 0/1 plan 同型的歷史 note。
+
+## 4. 實作檔案預估
+
+| 檔案 | 動作 | 預估行數 |
+|---|---|---|
+| `internal/agent/subagent.go` | 新檔 type + comments | +25 |
+| `internal/agent/subagent_test.go` | 新檔 R1+R2 | +40 |
+| `internal/agent/status.go` | NormalizedEvent.Subagents 型別改 | +1 (-1) |
+| `internal/store/frames.go` | Frame.Subagents 型別 + nil 防護 | ~10 |
+| `internal/store/frames_test.go` | F1-F3 + 既有 seed 改 | +60 |
+| `internal/module/agent/frame_ops.go` | updateSubagents 簽名 + proxy 分支 + helpers | +110 |
+| `internal/module/agent/frame_ops_test.go` | U1-U5 + PR1-PR6 + 既有 seed 改 | +220 |
+| `internal/module/agent/projection.go` | SessionProjection.Subagents 型別 | ~4 |
+| `internal/module/agent/projection_test.go` | seed 改 | ~10 |
+| `internal/module/agent/module.go` | m.subagents map 型別 | ~4 |
+| `internal/module/agent/handler.go` | buildNormalized Subagents 型別 | ~4 |
+| `internal/module/agent/handler_test.go` | HB1+HB2 + 既有 seed | +100 |
+| `internal/module/agent/sweep.go` | nowFn + frameIdleThreshold + 規則 + StopWatch | +30 |
+| `internal/module/agent/sweep_test.go` | IS1-IS4 + 既有 seed | +140 |
+| `internal/module/agent/trace.go` | (若 summary 有 list) | 0 / ~5 |
+| `spa/src/stores/useAgentStore.ts` | SubagentRef + Record 型別 | +10 |
+| `spa/src/components/SubagentDots.tsx` | API + type colors + proxy outline | +40 (-20) |
+| `spa/src/components/SubagentDots.test.tsx` | 新檔 3 cases | +110 |
+| `spa/src/components/TabIcon.tsx` | count → refs | ~15 |
+| `spa/src/hooks/useTabDisplay.ts` | refs 回傳 | ~8 |
+| `spa/src/components/*.test.tsx` (6 檔) | seed 改 | ~30 |
+| `spa/src/hooks/*.test.ts` (2 檔) | seed 改 | ~10 |
+| `docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md` | 本檔 | +500 |
+| **合計（不含 plan）** | | **~950 行** |
+| **合計（含 plan）** | | **~1450 行** |
+
+## 5. 不做項目清單（防自動擴展）
+
+以下衝動一律拒絕 — PR description / commit message 中明確聲明：
+
+- **不加** SubagentRef.Status 欄位（SubagentStart 本來就 Status=""；待 Phase 4/5 有需求再評估）
+- **不加** SubagentRef.LastSeenAt 欄位（idle 判斷用 frame.LastSeenAt；個別 ref 的活性 Phase 3/4 再看）
+- **不寫** 舊格式 JSON fallback（alpha 階段重建 DB 即可，避免 deprecated 路徑留在 code）
+- **不做** proxy ref 的獨立 liveness 檢查（留 Phase 3 / 4b）
+- **不改** `/api/agent/monitor/*` endpoint shape（Phase 5 Inspector 統一）
+- **不處理** 非 SessionStart 的 proxy 事件（codex proxy 實測都走 SessionStart；若不符再 Phase 3/4 補）
+- **不重整** `handler.go` / `module.go`（proxy 偵測是 frame_ops 局部增加，不順手 refactor）
+- **不抽** `frameIdleThreshold` 為 runtime flag（const 表達即可，實際觀察需要再改）
+- **不加** idle sweep 的 broadcast reason 細分（與 `pid_dead` / `pid_reused` 共用 clearFrame 通道）
+- **不做** SubagentDots 的 > 3 refs 的 overflow 處理（超過 3 仍只顯示 3，與既有 clamp 一致）
+- **不抽** SubagentDots 的 TYPE_COLOR 表到 `agent-icons.tsx`（inline 即可，型別對應單純）
+
+## 6. Subagent 開發指引
+
+- **cwd 強制前綴**：每個 Bash 指令以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-phase-2 && ` 開頭（依 `feedback_subagent_cwd_enforcement.md`）
+- **分支**：已在 `worktree-lights-phase-2`，不另切；不 push（主 session 負責）
+- **Commit message 格式**：Conventional Commits + 結尾加 `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+- **TDD 嚴格紅綠**：每個 commit 內先寫測試跑紅再實作跑綠 — 不可批次寫完所有 test + 一次實作
+- **中間 commit 可以 build 失敗**（commit 2 → 3 之間）：這是型別升級的必然；commit 3 結束必須 `go build ./...` + `go test ./...` 綠
+- **SPA 每個 commit 都要 build 綠**：pnpm install 由主 session 處理一次，subagent 只跑 vitest / lint / build
+- **回報**：完成後回報 commit hash 列表 + `git log --oneline -15` + `go test ./...` 完整輸出 + `cd spa && pnpm run lint && pnpm run build && npx vitest run` 結果
+- **Codex sandbox 限制**：依 `feedback_codex_sandbox_no_install.md`，SPA 任務若 subagent 跑不動 pnpm install，由主 session 手動跑
+
+## 7. 驗收清單（完整 Phase 2）
+
+- [ ] 10-11 個 commits 符合 message 規範
+- [ ] `go build ./...` 綠（每個 commit 結束時）
+- [ ] `go test ./...` 綠（新增 R1-R2 / F1-F3 / U1-U5 / PR1-PR6 / IS1-IS4 / HB1-HB2 共 22 個測試）
+- [ ] `go vet ./...` 無 warning
+- [ ] `cd spa && pnpm run lint && pnpm run build` 綠
+- [ ] `cd spa && npx vitest run` 綠（新增 SubagentDots 3 case + 舊檔 seed 升級）
+- [ ] PR diff 涉及檔案：§4 表格列出的 ~22 檔 + plan 文件，**其餘不得出現**
+- [ ] PR description 含「不做項目」§5 聲明 + 拆分判斷（§0）結論（本 PR 單推 or 拆成 2a/2b）
+- [ ] 手動場景（PR description 測試清單）：
+  - cc session 啟動 → `/codex:*` → codex 以 proxy attach 到 cc.Subagents（SPA 上只見 1 個 frame，subagent dot 帶黃色 outline）
+  - 手造超過 1h 閒置 frame（DB 改 LastSeenAt 或臨時改 threshold）→ sweep 後 frame 消失
+  - cc SubagentStart 仍照常（native subagent 藍色實心）
+  - SPA 重新整理後狀態可 replay（frame.Subagents JSON 讀回正確）
+- [ ] DB 重建注意：若升級過程使用者已有舊 `subagents_json` 格式，scanFrame 會回 error；需在 CHANGELOG / bump PR note 標示「alpha.218 要求重建 DB」
+
+## 8. 風險與緩解
+
+| 風險 | 機率 | 影響 | 緩解 |
+|---|---|---|---|
+| 舊 DB `subagents_json` 格式不相容 | 高 | 既有使用者升級後 scanFrame 失敗 | alpha 階段明示重建；bump PR CHANGELOG 標註；或加一次性 startup migration（Phase 2 不做，spec §6 允許破壞式升級） |
+| proxy 偵測誤判（parent alive 但已非使用中） | 中 | codex hook 掛錯 parent | Phase 2 只看 alive PID；若使用者 reports 誤判再加時間窗 / PPID 驗證（spec §11-5） |
+| frame_idle_threshold = 1h 太短（使用者長跑任務） | 中 | 活躍 frame 被誤清 | LastSeenAt 每次 hook 都更新；idle 1h 意味完全無 hook 1h；真正長跑任務應有 activity probe watcher 維持活性。觀察 1-2 週若仍誤清，放大到 4h |
+| SPA + daemon 升級不同步（Electron dev update 先後） | 中 | 短暫 subagents 欄位型別 mismatch，畫面 dot 消失 | 接受（alpha 階段允許）；使用者重開即同步 |
+| SubagentDots 新視覺 accessibility 退化（color-only proxy） | 低 | 色盲使用者看不出 proxy | Phase 2 用 outline vs solid（形狀 + 顏色雙通道），不是純顏色；符合 WCAG |
+| 測試 seed 遺漏導致 CI 紅 | 中 | subagent 要反覆修 | Commit 10 專跑 SPA seed sweep；主 session commit push 前跑全測 |
+| proxy ID `"proxy:<type>:<pid>"` 與 SubagentStart 的 agent_id 撞（理論） | 低 | SubagentStop 誤刪 proxy ref | agent_id 由 CLI 生成（通常 UUID 或 short-hash），不會撞 `proxy:` 前綴；若未來 CLI 改格式再評估 |
+
+## 9. 兩輪 Codex Review 預期 focus
+
+**第一輪（標準）**：
+- SubagentRef JSON shape 是否穩定、omitempty 語意、wire 改 break 有無遺漏
+- Proxy 偵測條件是否完整（§1.4 五條觸發 + 三條不命中）是否正確
+- idle sweep 的 nowFn 注入是否干擾其他測試（並行 swap 風險）
+- SubagentDots type color 表是否與 agent-icons 其他地方衝突
+- Commit 2 刻意讓 `go build` 失敗的策略是否接受（vs. 合併 commit 2+3）
+
+**第二輪 3 parallel**：
+- **攻擊**：proxy 偵測 race（並發 hook 寫同 parent.Subagents）/ SubagentStart 同時 proxy 同 ID 撞 / sweep 執行中 handler 正好 upsert frame 的 time-of-check-to-time-of-use / LastSeenAt 溢位（long-lived frame） / Nil pointer on `m.prober` in sweep when prober not wired
+- **防守**：proxy 語意（cross agent_type 的條件是否對「cc inside cc」這種嵌套成立？）/ SessionEnd 對 proxy 的處理策略是否正確（§1.5）/ 為什麼不處理非 SessionStart proxy 事件 / 為什麼不加 LastSeenAt per-ref / 破壞式 schema 升級對使用者可接受性
+- **體質**：`frame_ops.go` 升級後是否 >400 行需拆 / `SubagentDots.tsx` + test 是否過大 / type color 表應不應該集中到 `agent-icons.tsx` 管理 / sweep.go 第三條規則是否 sweep 檔過胖需拆 idle_sweep.go
+
+## 10. 拆分決策 checklist（plan review 後）
+
+收到 codex plan review 回饋後，決定單 PR 或拆 2a+2b：
+
+- [ ] findings 數 ≤ 10 且皆落在 §1.1-§1.7 的 schema / §1.8-§1.13 型別擴散 → 單 PR 可吞
+- [ ] findings 有 ≥ 3 個集中在 §1.4 proxy 語意 或 §1.6 sweep 規則 → 拆 2b
+- [ ] findings 觸及 WS wire compatibility（§1.9）且 reviewer 要求平滑升級 → 拆 2a 單獨 merge + bump 一次
+- [ ] plan 本身 > 550 行 → 拆 2a/2b 兩份 plan 分跑 review
+
+預設：寫完 plan 送一次 codex review，依回饋再決定。

--- a/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
+++ b/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
@@ -1,6 +1,6 @@
-# Phase 2 TDD Plan v3 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
+# Phase 2 TDD Plan v4 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
 
-- **Date**: 2026-04-24（v1 → v2 revision after codex review `review-mobwvdpq-w6kftz`; v2 → v3 after codex review `review-mobxgl16-mfkzav`）
+- **Date**: 2026-04-24（v1→v2: `review-mobwvdpq-w6kftz`; v2→v3: `review-mobxgl16-mfkzav`; v3→v4: `review-mocgelr5-z0v0a4`）
 - **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §6
 - **Worktree**: `lights-phase-2`（branch `worktree-lights-phase-2`）
 - **依賴**: Phase 1（merged at `d1d60b2c`）+ Hook Events PR #616（merged at `fd9f8f8f`, alpha.217）
@@ -164,12 +164,12 @@ ref := agentpkg.SubagentRef{
 **Walk 邏輯**（helper `findProxyParent`）：
 
 ```go
-const proxyMaxDepth = 5
+const proxyMaxDepth = 5 // 最多檢查 5 個 ancestor；第 6 層起 return nil
 
 func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
     info, err := readProcessInfoFn(req.SenderPID)
     if err != nil {
-        return nil, nil // 讀不到 sender proc info，放棄 proxy walk，fallback 建新 frame
+        return nil, nil // 讀不到 sender proc info，放棄 proxy walk
     }
     ppid := info.PPID
     for depth := 0; depth < proxyMaxDepth; depth++ {
@@ -180,10 +180,23 @@ func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
         if err != nil {
             return nil, err
         }
-        if candidate != nil && candidate.AgentType != req.AgentType && isPidAliveFn(candidate.PID) {
-            return candidate, nil // 命中：同 pane、跨 agent type、存活
+        if candidate != nil {
+            // v4 hard-stop: same-type ancestor 代表 pane 內已有同類 frame，
+            // 新進 hook 應是 re-session 或 update，不該 proxy 到更上層。
+            if candidate.AgentType == req.AgentType {
+                return nil, nil
+            }
+            // v4 identity rule: 不只 PID alive，也要 process_start_time match
+            // 避免 PID 重用誤掛到舊 stale frame。
+            if isPidAliveFn(candidate.PID) {
+                actualStart, serr := processStartTimeFn(candidate.PID)
+                if serr == nil && actualStart == candidate.ProcessStartTime {
+                    return candidate, nil // 命中：cross-type + alive + start_time match
+                }
+                // start_time mismatch or read error → candidate 是 stale frame，跳過續爬
+            }
         }
-        // 沒命中，往上一層
+        // 沒命中 alive parent，往上一層
         ancestorInfo, err := readProcessInfoFn(ppid)
         if err != nil {
             return nil, nil // partial chain，放棄
@@ -196,6 +209,14 @@ func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
     return nil, nil // 超過深度上限
 }
 ```
+
+**Walk 規則**（v4 rewrite）：
+- 每層 `FindByPanePID(paneID, ppid)` 取 candidate
+- `candidate == nil`（該 ppid 在此 pane 沒 frame）→ 續爬上一層
+- **Same-type 硬停**：`candidate.AgentType == req.AgentType` → 立即 `return nil`（不續爬，不 proxy）。語意：pane 內有同類 frame 意味新 hook 是 re-session / update，不是 proxy。
+- **Identity check**：`candidate` 要同時滿足 `isPidAliveFn(pid)` + `processStartTimeFn(pid) == candidate.ProcessStartTime` 才算命中
+  - Alive 但 start_time mismatch → candidate 是 stale（真正進程是 PID 重用的另一個），跳過該 candidate 續爬（**不** return nil，因為可能上層有真正 parent）
+- **Depth 定義**：`proxyMaxDepth = 5` 嚴格代表「檢查 5 個 ancestor」（depth 迴圈跑 5 次）。第 6 層的 ancestor 不會被檢查；超深 chain 一律 fallback 建新 frame
 
 **觸發條件**（全部成立才算 proxy）：
 1. `req.EventName == "SessionStart"`
@@ -222,13 +243,15 @@ func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
 
 **不命中條件 → fallback 建新 frame**：
 - 條件 1/2 任一不成立
-- `findProxyParent` 回 nil（包含：所有祖先都無 frame / 有 frame 但同 type / parent 已死 / 超過深度 / 讀 proc 錯）
+- `findProxyParent` 回 nil（包含：所有祖先在 pane 內無 frame / 遇 same-type ancestor 硬停 / 所有 cross-type candidate 都 stale or 已死 / 超過深度 5 / 讀 proc 錯）
 
 **Walk 安全邊界**：
 - **深度 5**：cover `codex → codex-companion → cc`（2 層內）；留 3 層 buffer 應付複雜 shell wrapper / tmux control mode。超過 5 層表示極端嵌套，不為該罕見 case 付成本
 - **Pane 過濾**：每層都走 `FindByPanePID(paneID, ppid)`，跨 pane 的 process（例 tmux server、shell）即使 PPID 撞也不命中
-- **Syscall 成本**：最多 5 次 `readProcessInfoFn`（最壞 ~5 次 open+read `/proc/<pid>/stat` 或 `ps`），只在 SessionStart 觸發，非 hot path
+- **Syscall 成本**：最多 5 次 `readProcessInfoFn` + 最多 5 次 `processStartTimeFn`（只在命中 candidate 時才 call；每次 ps/lstat 在 <1ms 級）；只在 SessionStart 觸發，非 hot path
 - **自環保護**：`ancestorInfo.PPID == ppid` 防止 kernel 回報自我 parent（罕見但 defensive）
+- **Same-type 硬停**（v4）：碰到同 type ancestor 不續爬，避免 `codex(child)→codex(parent)→cc` 這種誤 proxy 到 cc 的 semantic 漏洞
+- **Stale frame 跳過**（v4）：PID 重用導致 candidate 的 start_time mismatch 時，跳過該層續爬（而非硬停）；Walk 仍可能在上一層找到真正 cross-type parent
 
 **非 SessionStart 的 proxy 事件**：Phase 2 不處理。觀察實際行為若 codex proxy 沒先送 SessionStart 再開工，Phase 3/4 補。
 
@@ -567,22 +590,24 @@ interface Props {
 
 ### 2.5 Proxy 偵測整合（PR-2b）
 
-`internal/module/agent/frame_ops_test.go`：mock `readProcessInfoFn` 與 `isPidAliveFn` 模擬 PPID 鏈。
+`internal/module/agent/frame_ops_test.go`：mock `readProcessInfoFn` / `isPidAliveFn` / `processStartTimeFn` 模擬 PPID 鏈與 identity。
 
 | # | 名稱 | 情境 | 斷言 |
 |---|---|---|---|
-| PR1 | `TestProxySubagent_DirectPPIDAttachesToCCParent` | cc frame PID 100 in pane %5；codex SessionStart PID 200 PPID 100 | pane 有 1 frame（cc），cc.Subagents 有 ref `{Type:"codex", IsProxy:true, SourcePID:200}` |
-| **PR2 new** | `TestProxySubagent_TreeWalkThroughCodexCompanion` | cc frame PID 100；codex SessionStart PID 300 PPID 200（companion）；readProcessInfoFn(200) 回 PPID=100 | Tree walk 第 2 層命中 cc，掛 proxy ref；pane 仍 1 frame |
-| **PR3 new** | `TestProxySubagent_TreeWalkDepthLimit` | cc frame PID 100；codex SessionStart PID 600 with chain 600 → 500 → 400 → 300 → 200 → 100 (深度 5)；第 5 層才到 cc | 不命中 proxy（超過 maxDepth）— 建新 codex frame；cc 不受影響 |
+| PR1 | `TestProxySubagent_DirectPPIDAttachesToCCParent` | cc frame PID 100 start "t100"；codex SessionStart PID 200 PPID 100；`processStartTimeFn(100)="t100"` | pane 1 frame（cc）；cc.Subagents 有 `{Type:"codex", IsProxy:true, SourcePID:200}` |
+| PR2 | `TestProxySubagent_TreeWalkThroughCodexCompanion` | cc frame PID 100 start "t100"；codex SessionStart PID 300 PPID 200（companion），companion PPID=100；`readProcessInfoFn(200).PPID=100`；`processStartTimeFn(100)="t100"` | Tree walk 第 2 層命中 cc，掛 proxy ref；pane 仍 1 frame |
+| **PR3 v4-fix** | `TestProxySubagent_TreeWalkDepthLimit` | cc frame PID 100；codex SessionStart PID 700 with chain **700→600→500→400→300→200→100**（cc 在第 6 層，超過 maxDepth=5） | 不命中 proxy（超過深度）— 建新 codex frame；cc 不受影響 |
 | PR4 | `TestProxySubagent_SkipsWhenNoAncestorHasFrame` | codex SessionStart PPID 9999（pane 無 frame with PID 9999, walk 到 init） | 建新 codex frame（fallback），不 proxy |
-| PR5 | `TestProxySubagent_SkipsWhenParentSameType` | cc frame PID 100；另一 cc SessionStart PID 200 PPID 100 | 建新 cc frame，不 proxy（same type） |
+| PR5 | `TestProxySubagent_SkipsWhenParentSameType` | cc frame PID 100；另一 cc SessionStart PID 200 PPID 100 | 建新 cc frame，不 proxy（same type 硬停） |
 | PR6 | `TestProxySubagent_SkipsWhenParentPidDead` | cc frame PID 100 存在但 isPidAliveFn(100)=false；codex SessionStart PPID=100 | 建新 codex frame，不 proxy（parent 死） |
 | PR7 | `TestProxySubagent_SkipsWhenEventNotSessionStart` | cc frame 存在 → codex UserPromptSubmit PPID=cc.PID | 走 legacy 路徑（不走 proxy） |
 | PR8 | `TestProxySubagent_TraceMetaCorrect` | PR1 情境 | trace meta decision="updated_frame"、reason="proxy_subagent_attached"、FrameID=parent.FrameID |
 | PR9 | `TestProxySubagent_DoesNotDoubleAttachOnReHook` | PR1 後再送同 codex SessionStart (same PID+StartTime) | cc.Subagents 仍 1 筆，StartedAt 為首次時間 |
-| **PR10 new** | `TestProxySubagent_CrossPaneAncestorNotMatched` | cc frame in pane %5 PID 100；codex SessionStart in pane %7 PID 200 PPID 100 | pane %7 建新 codex frame，cc 在 %5 不受影響（PaneID filter 驗證） |
-| **PR11 new** | `TestProxySubagent_SelfCycleGuard` | codex SessionStart PID 200，readProcessInfoFn(200).PPID=200（自環） | 不 panic，不無限 loop，建新 codex frame |
-| **PR12 new** | `TestProxySubagent_PartialChainOnReadError` | codex SessionStart PPID 200；readProcessInfoFn(200) 回 error | 放棄 walk，fallback 建新 codex frame |
+| PR10 | `TestProxySubagent_CrossPaneAncestorNotMatched` | cc frame in pane %5 PID 100；codex SessionStart in pane %7 PID 200 PPID 100 | pane %7 建新 codex frame，cc 在 %5 不受影響（PaneID filter 驗證） |
+| PR11 | `TestProxySubagent_SelfCycleGuard` | codex SessionStart PID 200，readProcessInfoFn(200).PPID=200（自環） | 不 panic，不無限 loop，建新 codex frame |
+| PR12 | `TestProxySubagent_PartialChainOnReadError` | codex SessionStart PPID 200；readProcessInfoFn(200) 回 error | 放棄 walk，fallback 建新 codex frame |
+| **PR13 v4-new** | `TestProxySubagent_SkipsStaleFrameByStartTimeMismatch` | cc frame PID 100 start "t100"；codex SessionStart PPID=100；`isPidAliveFn(100)=true` 但 `processStartTimeFn(100)="t_different"`（PID 重用新進程） | 不 proxy 到 stale cc frame；walk 續爬上層，上層 PPID 亦無 frame → fallback 建新 codex frame；stale cc.LastSeenAt 不被刷新 |
+| **PR14 v4-new** | `TestProxySubagent_SameTypeAncestorStopsWalk` | pane 內 cc frame PID 100 + codex frame PID 200 PPID 100；codex SessionStart PID 400 PPID 300 PPID 200 (companion 串到 codex parent) | 遇 same-type codex frame 硬停，不續爬到 cc；建新 codex frame（不 proxy） |
 
 ### 2.6 SessionEnd Proxy Cleanup（PR-2b）
 
@@ -742,8 +767,8 @@ interface Props {
 |---|---|---|
 | `internal/store/frames.go` | `DeleteIfUnchanged` method | +20 |
 | `internal/store/frames_test.go` | F4-F6 | +50 |
-| `internal/module/agent/frame_ops.go` | proxy 偵測分支 + `findProxyParent`（tree walk depth 5）+ `removeProxyRefForSender` | +130 |
-| `internal/module/agent/frame_ops_test.go` | PR1-PR12 + SE1-SE3（12 proxy + 3 session end = 15 case，含 tree walk mocks） | +360 |
+| `internal/module/agent/frame_ops.go` | proxy 偵測分支 + `findProxyParent`（tree walk depth 5 + start_time identity check + same-type hard stop）+ `removeProxyRefForSender` | +140 |
+| `internal/module/agent/frame_ops_test.go` | PR1-PR14 + SE1-SE3（14 proxy + 3 session end = 17 case，含 tree walk mocks） | +420 |
 | `internal/module/agent/sweep.go` | nowFn + threshold + 第三條規則 + afterFrameCleared 抽出 + StopWatch fix | +50 |
 | `internal/module/agent/sweep_test.go` | IS1-IS5 | +160 |
 | `internal/module/agent/handler_test.go` | HB2 | +40 |
@@ -905,6 +930,18 @@ interface Props {
 | Proxy 測試從 PR1-PR7 擴到 PR1-PR12 | Tree walk 新增 3 case（companion hop / depth limit / self-cycle）+ 2 case（cross-pane / partial chain） |
 | `findProxyParent` helper 行數 +30；測試 +120 | Tree walk 實作複雜度 |
 | Commit 10 明列 SortableTab/InlineTab/renderInlineTabIcon 要一起改 | 避免 PR-2b 實作時漏 compile |
+
+### v3 → v4
+
+| 改動 | 原因 |
+|---|---|
+| **`findProxyParent` 加 start_time identity check**（§1.4 pseudocode + walk rules） | Codex v3 #1: frame identity 整個 repo 都是 `(pid, process_start_time)`；僅檢查 PID alive 會在 PID 重用時誤掛到 stale frame |
+| **Same-type ancestor 改硬停**（return nil 不續爬） | Codex v3 #2: v3 續爬會讓 `codex→codex parent→cc` 誤 proxy 到 cc；pane 內有同類 frame 語意上是 re-session 不是 proxy |
+| **PR3 chain 延長為 7 層**（700→600→500→400→300→200→100）明確超過 depth=5 | Codex v3 #3: v3 PR3 的 chain 在 depth=5 下其實會命中，與「預期 miss」測試衝突 |
+| **新增 PR13 `SkipsStaleFrameByStartTimeMismatch`** | v3 #1 修正的回歸測試：PID 重用情境不該 proxy |
+| **新增 PR14 `SameTypeAncestorStopsWalk`** | v3 #2 修正的回歸測試：同 type 硬停 |
+| `findProxyParent` 行數 +10（start_time check + stale frame 跳過邏輯） | v3 #1+#2 實作 |
+| 測試從 PR1-PR12 擴到 PR1-PR14 | 2 個新 case |
 
 ---
 

--- a/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
+++ b/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
@@ -1,56 +1,111 @@
-# Phase 2 TDD Plan — L3 Subagent 升級 + Proxy + Frame Idle Sweep
+# Phase 2 TDD Plan v2 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
 
-- **Date**: 2026-04-24
+- **Date**: 2026-04-24（v1 → v2 revision after codex adversarial review `review-mobwvdpq-w6kftz`）
 - **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §6
 - **Worktree**: `lights-phase-2`（branch `worktree-lights-phase-2`）
 - **依賴**: Phase 1（merged at `d1d60b2c`）+ Hook Events PR #616（merged at `fd9f8f8f`, alpha.217）
-- **範圍**：`SubagentRef` 結構升級 + proxy 偵測 + frame idle sweep + SPA 型別 / 視覺升級
+- **範圍**：`SubagentRef` 結構升級（含 SourcePID/SourceStartTime）+ PPID-first proxy 偵測 + SessionEnd proxy cleanup + frame idle sweep（conditional DELETE）+ SPA 型別 / 視覺升級
+- **拆分決策**：**確定拆 PR-2a（schema + 型別）+ PR-2b（proxy + sweep + 視覺）**
 
-## 0. 量體與拆分判斷
+## 0. 拆分策略（已確定）
 
-**本 plan 寫成單 PR**，實際改動落地後再由 review 負擔判斷是否拆 PR-2a（schema 升級，commits 1-7）+ PR-2b（proxy + sweep，commits 8-10）。
+### PR-2a — Schema + 型別升級（純骨架，無新行為）
 
-拆分時機（任一命中即拆）：
-- Plan 階段 codex review 回 12+ findings
-- 實作完成後 `git diff --stat` > 1200 行（含測試）
-- 單一 reviewer 讀完需要超過 30 分鐘的預估量
+- `SubagentRef` 型別定義（含 SourcePID/SourceStartTime/IsProxy 等欄位，但本 PR **不會有任何 ref.IsProxy=true 產生**）
+- Frame.Subagents / SessionProjection.Subagents / m.subagents map / NormalizedEvent.Subagents / SPA store 型別同步升級
+- `updateSubagents` 簽名升級，行為語意不變（SubagentStart 新增、SubagentStop 移除）
+- SPA SubagentDots **維持 count-based API**（新視覺留 PR-2b）
+- **行為不變**：SubagentStart/Stop 走既有路徑，產生 `SubagentRef{ID, Type=frame.AgentType, StartedAt=broadcastTs}` — IsProxy 永遠 false
+- 預估 ~600 行（含測試 + plan）
 
-拆分形式：PR-2a schema-only（純改型別，行為不變），PR-2b 新行為（proxy 偵測 + idle sweep + SubagentDots 視覺）。
+### PR-2b — Proxy 偵測 + Idle Sweep + SubagentDots 新視覺
 
-## 1. 契約鎖定
+- `applyFrameEvent` PPID-first proxy 偵測分支（SessionStart only）
+- SessionEnd proxy cleanup（從 parent.Subagents 移匹配 SourcePID+SourceStartTime 的 ref）
+- Frame idle sweep（1h 閾值 + conditional DELETE `DeleteIfUnchanged` + orphan watcher clean）
+- SubagentDots 視覺：type color（cc 藍 / codex 黃 / opencode 橘）+ proxy outline
+- 預估 ~450 行（含測試）
+
+PR-2a merge → 單獨 bump alpha → PR-2b 在 PR-2a 基礎上開 branch。
+
+### 為何拆
+
+Codex adversarial review 指出 schema 升級與 proxy 新行為**本質是兩個 review 主題**：
+- 型別擴散驗證 vs proxy 識別正確性 / PPID 繼承 / sweep race
+- 混在一起 reviewer 要同時 track 兩條線，出錯率上升
+
+拆後 PR-2a 可快速 merge 固定 schema 基礎；PR-2b 集中火力守 proxy 語意。
+
+---
+
+## 1. 契約鎖定（共用）
 
 ### 1.1 `SubagentRef` 型別（新增）
 
-位置：`internal/agent/subagent.go`（新檔，放在 `internal/agent` package 根層，與 `status.go` 平行）— 放 store 層不當因為 Type 語意綁 agent registry。
+位置：`internal/agent/subagent.go`（新檔，`internal/agent` package 根層，與 `status.go` 平行）
 
 ```go
 type SubagentRef struct {
-    ID        string `json:"id"`
-    Type      string `json:"type"`                  // agent type, e.g. "cc" / "codex" / "opencode"
-    StartedAt int64  `json:"started_at"`            // UnixNano，沿用 frame broadcast_ts 口徑
-    IsProxy   bool   `json:"is_proxy,omitempty"`    // true 代表跨 agent_type 的同 pane hook 被收編
+    ID              string `json:"id"`
+    Type            string `json:"type"`              // agent type, e.g. "cc" / "codex" / "opencode"
+    StartedAt       int64  `json:"started_at"`        // UnixNano，沿用 frame broadcast_ts 口徑
+    SourcePID       int    `json:"source_pid"`        // 來源 process PID（SubagentStart 為 0 代表無；proxy 為 hook sender PID）
+    SourceStartTime string `json:"source_start_time"` // 來源 process start time（proxy identity 鎖定，防 PID 重用）
+    IsProxy         bool   `json:"is_proxy,omitempty"`// true = cross-agent-type hook 被收編
 }
 ```
 
-**設計要點**：
-- `ID` 語意：SubagentStart 分支 = `raw.agent_id`；proxy 分支 = `"proxy:<agent_type>:<pid>"` 合成字串（確保唯一；不是 UUID，可讀性優先）
-- `Type` 語意：SubagentStart 分支 = 盡量取 `raw.agent_type`（opencode 有；cc / codex 沒有則 fallback 為 parent frame 的 `AgentType`）；proxy 分支 = `req.AgentType`（新 hook 的 agent type）
-- `StartedAt`：**只在首次新增時設定**；重複 SubagentStart 同 ID 不覆寫（保持早期時間戳，供 UI 排序）。proxy 重複 hook 同樣不刷 StartedAt
-- `IsProxy,omitempty`：JSON 僅在 true 時序列化，方便舊前端 / 測試 snapshot 穩定
-- **不加** `LastSeenAt` 欄位（Phase 2 避免 scope 蔓延；idle sweep 只看 frame.LastSeenAt 整體）
-- **不加** `Status` 欄位（SubagentStart hook 本來就 Status=""；Phase 2 保持 detail-only 語意）
+**欄位語意**：
 
-### 1.2 Frame.Subagents 升級
+| 情境 | ID | Type | SourcePID / SourceStartTime | IsProxy |
+|---|---|---|---|---|
+| SubagentStart (native) | `raw.agent_id` | `raw.agent_type` fallback parent `frame.AgentType` | `0` / `""` | `false` |
+| Proxy attach | `proxyIDFor(req)` = `fmt.Sprintf("proxy:%s:%d:%s", req.AgentType, req.SenderPID, req.SenderStartTime)` | `req.AgentType` | `req.SenderPID` / `req.SenderStartTime` | `true` |
+
+**設計要點**（對 codex #1 的修正）：
+- Proxy identity 由 `SourcePID + SourceStartTime` 鎖定，不被 PID 重用污染
+- Proxy ID 字串包含 `SenderStartTime`，進一步 harden 唯一性（同 PID 不同時期不撞）
+- SessionEnd 清 proxy ref 用 `SourcePID + SourceStartTime` 匹配，不是 ID 字串（跨升級相容性考量）
+- Native SubagentStart 的 SourcePID/SourceStartTime 設為零值 — 語意上是「無外部 process 對應」，與 proxy 區分
+- `StartedAt` **只在首次新增時設定**，重複 SubagentStart 同 ID 不覆寫
+- `IsProxy,omitempty`：JSON 僅在 true 時序列化；native SubagentStart 的 ref JSON 不會冒出該 key
+- **不加** `LastSeenAt` per ref（Phase 2 避免 scope 蔓延）
+- **不加** `Status` 欄位（SubagentStart 本來就 Status=""）
+
+### 1.2 Frame.Subagents 升級（破壞式）
 
 `internal/store/frames.go`:
 
 - `Frame.Subagents []string` → `[]agentpkg.SubagentRef`
-- SQL schema（column `subagents_json`）不改 — JSON 形狀換掉即可（alpha 階段允許；使用者重建 DB 即得新格式）
-- `scanFrame` 的 `json.Unmarshal` 從 `[]string` 改成 `[]SubagentRef`
+- SQL column `subagents_json` 不改，JSON shape 換掉即可
+- `scanFrame` 的 `json.Unmarshal` 直接指向 `[]SubagentRef`，舊格式 row 會 unmarshal 失敗 → 冒出 error
 - `Upsert` 的 `json.Marshal` 自動吃新型別
-- **nil 防護不變**：`if frame.Subagents == nil { frame.Subagents = []SubagentRef{} }`（空 slice 不是 nil）
+- nil 防護不變：`if frame.Subagents == nil { frame.Subagents = []SubagentRef{} }`
 
-**Breaking change 範圍**：現有 DB 中 `subagents_json` 若是舊格式（`["id1","id2"]`），Unmarshal 會失敗。解法：alpha 階段要求使用者重建 DB，或加一條 `scanFrame` fallback（嘗試舊格式→轉成最小 SubagentRef{ID: s}）。**取前者**（spec §6 明文允許破壞式升級），避免 fallback 在 code 裡留住 deprecated 路徑。
+**升級策略**（對 codex #4 的修正 — 使用者確認單人使用，跳 migration）：
+- **不寫** 舊格式 fallback、**不寫** 自動 migration、**不加** boot hard-fail
+- 使用者升級 alpha 後**須手動重建 DB**（rm `~/.purdex/<host>/agent.sqlite` 或對應路徑）
+- Bump PR 的 CHANGELOG.md **紅字大標** 警告
+- 升級後首次 hook 請求若讀到舊 row 會 return error → daemon log noisy 但不崩潰；使用者看到錯誤重建即可
+- 使用者場景：目前僅 wake@protype.tw 單人 alpha 使用，可接受短期陣痛；之後 beta 前 schema 穩定再做正式 migration framework
+
+**CHANGELOG 模板**（alpha.218 bump PR 時使用）：
+
+```markdown
+## alpha.218
+
+### ⚠ BREAKING CHANGE — Agent DB schema
+
+`agent_frames.subagents_json` format upgraded from `["id"]` to
+`[{"id","type","started_at",...}]`. Existing rows are NOT auto-migrated.
+
+**Action required**: Remove the agent DB before upgrading:
+    rm ~/Library/Application\ Support/Purdex/<host>/agent.sqlite
+    # (path varies by OS; delete the whole `<host>` dir if unsure)
+
+After rebuild, all frames will be empty and re-populate from live
+hook events. No user data lost (frames are ephemeral telemetry).
+```
 
 ### 1.3 `updateSubagents` 簽名升級
 
@@ -65,8 +120,8 @@ func updateSubagents(current []agentpkg.SubagentRef, eventName string, ref agent
 ```
 
 行為：
-- `SubagentStart`：若 `current` 無同 ID → append ref；若有同 ID → 不覆寫既有（保留既有 StartedAt / IsProxy）
-- `SubagentStop`：filter 掉同 ID 的 ref（Type 不參與比對，避免 proxy→native 切換時漏刪）
+- `SubagentStart`：若 `current` 無同 ID → append ref；若有同 ID → **不覆寫既有**（保留既有 StartedAt/SourcePID/SourceStartTime/IsProxy）
+- `SubagentStop`：filter 掉同 ID 的 ref（Type 不參與比對，避免 proxy↔native 切換誤漏）
 
 在 `applyFrameEvent` 的 SubagentStart/Stop 分支組出 `ref`：
 ```go
@@ -77,107 +132,253 @@ ref := agentpkg.SubagentRef{
         frame.AgentType,                        // fallback to parent frame's type
     ),
     StartedAt: broadcastTs,
-    IsProxy:   false,
+    // SourcePID / SourceStartTime 留零值（native subagent 無外部 process 對應）
+    IsProxy: false,
 }
 ```
 
-### 1.4 Proxy 偵測分支（新）
+### 1.4 Proxy 偵測分支（PR-2b 新增，PPID-first）
 
 在 `applyFrameEvent` 當前「建/更 frame」主路徑**之前**插入 proxy 判斷：
 
-**觸發條件（全部成立）**：
-1. `req.EventName` 是 frame-creating event（`SessionStart`）— 只看 SessionStart，其他 event（UserPromptSubmit 等）若沒 frame 本就走 legacy 路徑，不是 Phase 2 範圍
-2. `frame == nil`（同 identity pid/start 無既有 frame，表「新來的」）
-3. `m.frames.ListByPane(req.TmuxPaneID)` 存在至少一個 frame（parent 候選）且**該 parent.AgentType ≠ req.AgentType**
-4. 候選 parent 需 PID alive（避免把 proxy 掛到殭屍 parent 上；使用 `isPidAliveFn`）— 若 parent 已死，不算命中 proxy（走既有建 frame 路徑）
-
-**命中行為**：
-- 選最新 StartedAt 的 alive、type-不同 parent 作為收編對象
-- 組 `ref = SubagentRef{ID: proxyIDFor(req), Type: req.AgentType, StartedAt: broadcastTs, IsProxy: true}`
-- `parent.Subagents = updateSubagents(parent.Subagents, "SubagentStart", ref)`
-- `parent.LastSeenAt = broadcastTs`
-- `m.frames.Upsert(parent)` — **不建新 frame**
-- Trace meta：`Decision="updated_frame", Reason="proxy_subagent_attached"`，`FrameID/ParentFrameID` 指 parent
-- projection 回傳 parent pane 的投影
-
-`proxyIDFor(req EventRequest) string`：`fmt.Sprintf("proxy:%s:%d", req.AgentType, req.SenderPID)` — PID + agent_type 在 pane 層級可唯一；跨 pane 重複 PID 無所謂（proxy ID 的作用域是 parent.Subagents，只有同 pane 能撞）。
-
-**不命中條件**：
-- parent.AgentType == req.AgentType → 真的是同類 re-session，走原路徑建 frame（例：cc exit 後 cc 再起）
-- pane 無其他 frame → 獨立新 session，走原路徑建 frame
-- 所有候選 parent PID 都死 → 走原路徑建 frame（死 parent 由 sweep 處理）
-
-**非 SessionStart 的 proxy 事件（UserPromptSubmit 等）**：Phase 2 不處理。觀察實際行為若 codex proxy 沒先送 SessionStart 再開工，Phase 3/4 補。
-
-### 1.5 SessionEnd 對 proxy 的處理
-
-若 proxy ref 的來源 agent 送了 SessionEnd：
-- `applyFrameEvent` 的 SessionEnd 分支先查 `frame := GetByIdentity(pane, pid, startTime)`
-- proxy 的 SubagentRef 沒有獨立 frame（掛在 parent），所以這條查詢會 `frame == nil`
-- 對應到現有的 `session_end_without_frame` 分支 — Phase 2 不改這條
-- 結果：proxy ref 不會被 SessionEnd 自動清，由 **parent frame 清理時連帶清**（parent SessionEnd / pid_dead / idle_timeout）或 **sweep 時 ref.ID 對應的 PID 死掉**（見 §1.6）
-
-**Phase 2 不做**：proxy ref 的獨立 liveness 檢查（掃 subagents 裡有無 proxy ID 對應 dead PID 並移除）。原因：會把 sweep 改大、且實務上 parent frame 掛掉時 proxy ref 自然走 — 留 Phase 3 評估必要性。
-
-### 1.6 Frame Idle Sweep 規則（新）
-
-`internal/module/agent/sweep.go`：
-
+**前置取得 parent**（重用既有程式碼路徑）：
 ```go
-const frameIdleThreshold = 1 * time.Hour
-```
-
-`sweepOnce` 迴圈每個 frame 檢查順序（插入現有兩條之後第三條）：
-1. `!isPidAliveFn(frame.PID)` → `clearFrame(frame, "pid_dead")` — 既有
-2. `processStartTimeFn(frame.PID) != frame.ProcessStartTime` → `clearFrame(frame, "pid_reused")` — 既有
-3. **新**：`time.Now().UnixNano() - frame.LastSeenAt > frameIdleThreshold.Nanoseconds()` → `clearFrame(frame, "idle_timeout")`
-
-注入測試時鐘：新增 `var nowFn = time.Now`（與 `isPidAliveFn` / `processStartTimeFn` 同 pattern），測試 swap。
-
-**注意**：LastSeenAt 是 UnixNano（見 `broadcastTs` 呼叫點），`time.Duration.Nanoseconds()` 可直接比較。
-
-### 1.7 Clear Frame 的 Orphan Watcher 清理（已部分存在，補強）
-
-既有 `clearFrame` 已經 `delete(m.activeWatchers, sessionName)`（module.go clear 流程已做）但**沒有呼叫 `prober.StopWatch`**。補一行：
-
-```go
-// sweep.go clearFrame 裡 m.mu.Unlock() 之後：
-if hadWatcher && m.prober != nil {
-    m.prober.StopWatch(sessionName + ":")
+info, err := readProcessInfoFn(req.SenderPID)  // 已在現有 frame_ops 取得
+if err != nil {
+    return nil, FrameTraceMeta{}, err
+}
+parentCandidate, err := m.frames.FindByPanePID(req.TmuxPaneID, info.PPID)
+if err != nil {
+    return nil, FrameTraceMeta{}, err
 }
 ```
 
-其中 `hadWatcher` 在 `m.mu.Lock()` 區塊內取 `_, hadWatcher := m.activeWatchers[sessionName]` 後再 delete。
+**觸發條件**（**全部成立才算 proxy**）：
+1. `req.EventName == "SessionStart"`（目前只對 SessionStart 偵測 proxy；其他事件走 legacy 路徑）
+2. `frame == nil`（sender identity (pid, start) 無既有 frame，表「新來的」）
+3. `parentCandidate != nil` — **PPID 單層在同 pane 找到 frame**
+4. `parentCandidate.AgentType != req.AgentType` — 跨 agent type
+5. `isPidAliveFn(parentCandidate.PID)` — parent 還活著（避免掛殭屍）
 
-**為何這個 fix 重要**：idle_timeout 清 frame 時，session 可能有 active watcher（waiting/running/idle 任一狀態觸發過）。不 StopWatch → watcher goroutine 漏留在 prober 裡，畫面變化還在餵空 session → 回 onActivityDetected 時 activeWatchers 已 delete 就 early-return（既有防護），功能上 OK，但資源 leak。
+**命中行為**：
+- 組 `ref`:
+  ```go
+  ref := agentpkg.SubagentRef{
+      ID:              fmt.Sprintf("proxy:%s:%d:%s", req.AgentType, req.SenderPID, req.SenderStartTime),
+      Type:            req.AgentType,
+      StartedAt:       broadcastTs,
+      SourcePID:       req.SenderPID,
+      SourceStartTime: req.SenderStartTime,
+      IsProxy:         true,
+  }
+  ```
+- `parentCandidate.Subagents = updateSubagents(parentCandidate.Subagents, "SubagentStart", ref)`
+- `parentCandidate.LastSeenAt = broadcastTs`
+- `m.frames.Upsert(*parentCandidate)` — **不建新 frame**
+- Trace meta：`Decision="updated_frame", Reason="proxy_subagent_attached"`，`FrameID/ParentFrameID` 指 parent
+- projection 回傳 parent pane 的投影
 
-pid_dead / pid_reused 既有路徑也吃到這個修正（順勢清乾淨）— 非 Phase 2 新增 scope，是既有 bug 一併修。
+**不命中條件 → fallback 建新 frame（既有路徑）**：
+- `req.EventName != "SessionStart"` → 走既有 legacy（其他事件不會 trigger proxy）
+- `frame != nil` → 已有 frame，走 Upsert 更新
+- `parentCandidate == nil` → PPID 單層找不到 frame；**不用 pane-only fallback**（codex #2 指出的回歸）
+- `parentCandidate.AgentType == req.AgentType` → 真的是同類 re-session（例 cc exit 後 cc 再起）
+- parent PID 已死 → 走既有建 frame 路徑（不掛殭屍；死 parent 交由 sweep 清）
 
-### 1.8 SessionProjection.Subagents 升級
+**PPID 單層的 trade-off**（對 codex #2 + 使用者決策 A 的註記）：
+- codex-companion 若是 cc 的直接 child，則 codex 的 PPID = codex-companion PID，再上一階才是 cc；單層 PPID match 可能找不到 cc frame
+- Phase 2 **接受此限制**：PPID 單層命中 ≥ 50% case 可驗證 UX；若實測顯示 codex-companion 中介造成 proxy 大量失手，Phase 3/4 再加 PPID tree walk（spec §11-5 已保留空間）
+- 失手時不影響功能 — 走 fallback 建 codex frame（與目前行為一致，只是沒命中 proxy）
+
+**非 SessionStart 的 proxy 事件**：Phase 2 不處理。觀察實際行為若 codex proxy 沒先送 SessionStart 再開工，Phase 3/4 補。
+
+### 1.5 SessionEnd 對 Proxy Ref 的清理（PR-2b 新增）
+
+SessionEnd 來自 proxy 來源 agent（例 codex 結束）時，現況是「`frame == nil`（無獨立 frame） → `session_end_without_frame`」，proxy ref 留在 parent.Subagents 沒人清。
+
+**新行為**：在 `applyFrameEvent` SessionEnd 分支的 `frame == nil` 路徑加一段 proxy ref 掃描：
+
+```go
+case "SessionEnd":
+    if frame != nil {
+        // ...既有 delete frame 路徑...
+        return ...
+    }
+    // frame == nil — 可能是 proxy ref，掃 pane 內 frame 的 Subagents
+    removed, parentFrame, err := m.removeProxyRefForSender(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, broadcastTs)
+    if err != nil {
+        return nil, FrameTraceMeta{}, err
+    }
+    if removed {
+        projection, err := m.projectPane(req.TmuxPaneID)
+        return projection, FrameTraceMeta{
+            FrameID:       parentFrame.FrameID,
+            ParentFrameID: parentFrame.ParentFrameID,
+            Decision:      "updated_frame",
+            Reason:        "proxy_subagent_detached",
+            Before:        ...,
+            After:         summarizeFrame(&parentFrame),
+        }, err
+    }
+    // 舊路徑 — 真正 orphan SessionEnd
+    projection, err := m.projectPane(req.TmuxPaneID)
+    return projection, FrameTraceMeta{Decision: "skipped", Reason: "session_end_without_frame", ...}, err
+```
+
+`removeProxyRefForSender` 實作：
+1. `m.frames.ListByPane(paneID)` 取 pane 所有 frame
+2. 迴圈 frame.Subagents 找 `ref.SourcePID == senderPID && ref.SourceStartTime == senderStartTime`
+3. 命中 → filter 掉該 ref + `frame.LastSeenAt = broadcastTs` + `m.frames.Upsert(frame)` + return `true, frame`
+4. 都不命中 → return `false, zeroFrame`
+
+**為何用 SourcePID + SourceStartTime 而非 ref.ID 字串匹配**：更穩健 — SourcePID+SourceStartTime 是進程實體身份，ref.ID 是派生字串；兩者在當前實作一致但將來 ID 格式若變，identity 比對仍對。
+
+### 1.6 Frame Idle Sweep 規則（PR-2b 新增，conditional DELETE）
+
+`internal/module/agent/sweep.go`:
+
+```go
+const frameIdleThreshold = 1 * time.Hour
+var nowFn = time.Now  // test seam
+```
+
+`sweepOnce` 迴圈每個 frame 檢查（現有兩條 + 新第三條）：
+1. `!isPidAliveFn(frame.PID)` → `m.clearFrame(frame, "pid_dead")` — 既有
+2. `processStartTimeFn(frame.PID) != frame.ProcessStartTime` → `m.clearFrame(frame, "pid_reused")` — 既有
+3. **新**：`nowFn().UnixNano() - frame.LastSeenAt > frameIdleThreshold.Nanoseconds()` →
+   **conditional DELETE**（對 codex #3 修正）：
+   ```go
+   deleted, err := m.frames.DeleteIfUnchanged(frame.FrameID, frame.LastSeenAt)
+   if err != nil {
+       return err
+   }
+   if !deleted {
+       continue // 有 concurrent upsert refresh 了，skip 此 frame
+   }
+   // 手動觸發 clearFrame 的「post-delete side effects」（broadcast + orphan watcher clean）
+   m.afterFrameCleared(frame, "idle_timeout")
+   ```
+
+### 1.7 `FramesStore.DeleteIfUnchanged` 新 method（PR-2b 新增）
+
+`internal/store/frames.go`:
+
+```go
+// DeleteIfUnchanged removes the frame only if its last_seen_at matches the
+// provided value — a concurrent Upsert that refreshed the row will bump
+// last_seen_at and cause this DELETE to match 0 rows, returning (false, nil).
+// Caller should treat (false, nil) as "frame got refreshed, skip this sweep".
+func (s *FramesStore) DeleteIfUnchanged(frameID string, lastSeenAt int64) (bool, error) {
+    res, err := s.db.Exec(`DELETE FROM agent_frames WHERE frame_id = ? AND last_seen_at = ?`, frameID, lastSeenAt)
+    if err != nil {
+        return false, err
+    }
+    affected, err := res.RowsAffected()
+    if err != nil {
+        return false, err
+    }
+    return affected > 0, nil
+}
+```
+
+### 1.8 Sweep 的 clearFrame 拆分（PR-2b 重構）
+
+當前 `clearFrame`：`m.frames.Delete(frameID)` + side effects（legacy event clean + broadcast + orphan watcher clean）。
+
+拆兩半：
+- `Delete(frameID)` 既有路徑維持給 `pid_dead`/`pid_reused`
+- `DeleteIfUnchanged(...)` 給 `idle_timeout`
+- 共用 side effects：抽成 `afterFrameCleared(frame, reason)`
+
+實作：
+```go
+func (m *Module) clearFrame(frame store.Frame, reason string) error {
+    if m.frames == nil {
+        return nil
+    }
+    if err := m.frames.Delete(frame.FrameID); err != nil {
+        return err
+    }
+    return m.afterFrameCleared(frame, reason)
+}
+
+func (m *Module) afterFrameCleared(frame store.Frame, reason string) error {
+    sessionName, code := m.resolvePaneSession(frame.PaneID)
+    if sessionName != "" && m.events != nil {
+        if err := m.events.Delete(sessionName); err != nil {
+            return err
+        }
+    }
+    projection, err := m.projectionForSession(sessionName)
+    if err != nil {
+        return err
+    }
+
+    // Orphan watcher cleanup — for both pid_dead/pid_reused (existing bug fix)
+    // and idle_timeout (new).
+    var hadWatcher bool
+    var watcherAgentType string
+    m.mu.Lock()
+    if sessionName != "" {
+        syncProjectionState(m.currentStatus, m.subagents, sessionName, projection)
+        if projection == nil || projection.TopFrame == nil {
+            watcherAgentType, hadWatcher = m.activeWatchers[sessionName]
+            delete(m.activeWatchers, sessionName)
+        }
+    }
+    m.mu.Unlock()
+    _ = watcherAgentType // only used to indicate we had one
+    if hadWatcher && m.prober != nil {
+        m.prober.StopWatch(sessionName + ":")
+    }
+
+    if code == "" || m.core == nil {
+        return nil
+    }
+    normalized := buildProjectionNormalized(projection, frame.AgentType, "sweep:"+reason, nowFn().UnixNano(), agentpkg.DeriveResult{})
+    payload, _ := json.Marshal(normalized)
+    m.core.Events.Broadcast(code, "hook", string(payload))
+    return nil
+}
+```
+
+**順便修的既有 bug**（對 codex #3 + 原 plan §1.7 延續）：pid_dead / pid_reused 清 frame 時本來不呼叫 `prober.StopWatch`，僅 delete activeWatchers map 條目；goroutine 留在 prober 裡（onActivityDetected 回來時會 early-return，但 resource leak）。本次順便補。
+
+### 1.9 SessionProjection.Subagents 升級（PR-2a）
 
 `internal/module/agent/projection.go`:
 
 - `SessionProjection.Subagents []string` → `[]agentpkg.SubagentRef`
-- `buildPaneProjection` 的 defensive copy 跟著升級
+- `buildPaneProjection` defensive copy 跟著升級
 
-### 1.9 NormalizedEvent.Subagents 升級（WS wire）
+### 1.10 NormalizedEvent.Subagents 升級（PR-2a，WS wire break）
 
 `internal/agent/status.go`:
 
-- `NormalizedEvent.Subagents []string` → `[]SubagentRef` — 注意 JSON tag 保持 `"subagents"` 一致
-- `handler.go` `buildNormalized` + `frame_ops.go` `buildProjectionNormalized` + `module.go` `onActivityDetected` 裡三處建構 NormalizedEvent 的 copy 全跟著升級
+```go
+type NormalizedEvent struct {
+    // ...
+    Subagents []SubagentRef `json:"subagents"`
+    // ...
+}
+```
 
-**Wire compatibility**：舊 SPA 期望 `subagents: string[]`，新 daemon 會送 `subagents: SubagentRef[]`。Alpha 階段 daemon + SPA 同步升級一次到位，不留過渡層。Electron dev update 會先升級 daemon 或 SPA 之一 → 短暫的型別 mismatch → SPA 顯示空 subagents / throw（運行時測試會抓到，接受）。
+- `handler.go` `buildNormalized` + `frame_ops.go` `buildProjectionNormalized` + `module.go` `onActivityDetected` 三處 NormalizedEvent 建構全跟上
 
-### 1.10 m.subagents map 升級
+**Wire compatibility**（對 codex #4 使用者決策的註記）：
+- Daemon + SPA 同步一次升級（單 PR-2a 同時動 Go + TS）
+- Electron dev update 若先升一邊（例 SPA HMR 先吃新型別但 daemon 仍送舊 wire），短暫 payload mismatch → SPA 顯示空 subagents（或 TS runtime warning）
+- 使用者場景（單人）可接受；bump PR 時協調一次：先 daemon 重啟 → 再 SPA reload
+
+### 1.11 m.subagents map 升級（PR-2a）
 
 `internal/module/agent/module.go`:
 
 - `subagents map[string][]string` → `map[string][]agentpkg.SubagentRef`
-- `syncProjectionState` 的 map 參數型別同步升級
-- `replayFromDB` / `sendSnapshot` 透過 `syncProjectionState` 間接升級，無額外改動
+- `syncProjectionState` 參數型別同步
+- `replayFromDB` / `sendSnapshot` 透過 `syncProjectionState` 間接升級
 
-### 1.11 SPA 型別升級
+### 1.12 SPA 型別升級（PR-2a）
 
 `spa/src/stores/useAgentStore.ts`:
 
@@ -186,6 +387,8 @@ export interface SubagentRef {
   id: string
   type: string
   started_at: number
+  source_pid: number
+  source_start_time: string
   is_proxy?: boolean
 }
 
@@ -201,13 +404,13 @@ interface AgentState {
 }
 ```
 
-`handleNormalizedEvent` 內 `if (event.subagents)` 分支邏輯不變（仍是 length>0 set / length==0 delete）。型別自動跟著 shift。
+`handleNormalizedEvent` 內 `if (event.subagents)` 分支邏輯不變。
 
-### 1.12 SubagentDots 視覺升級
+### 1.13 SubagentDots 視覺升級（PR-2b）
 
 `spa/src/components/SubagentDots.tsx`:
 
-API 從 `{ count: number }` 改為 `{ refs: SubagentRef[] }`：
+API：`{ count: number }` → `{ refs: SubagentRef[] }`
 
 ```ts
 interface Props {
@@ -217,272 +420,389 @@ interface Props {
 ```
 
 視覺規則（Phase 2 最小）：
-- Dot 數仍依 `refs.length`（最多 3）
-- **Type 色**：每個 dot 依其 ref.type 決定顏色；查表：`cc → #60a5fa`（藍，既有）/ `codex → #facc15`（黃）/ `opencode → #f97316`（橘）/ fallback `#60a5fa`
-- **Proxy 樣式**：`is_proxy === true` → dot 用 outline（背景 transparent + 1px solid type color）而非實心；proxy=false → 實心不變
+- Dot 數依 `refs.length` clamp 到 [0, 3]
+- **Type 色**：每個 dot 依 `ref.type` 決定 backgroundColor；查表 inline：
+  - `cc → #60a5fa` (blue 既有)
+  - `codex → #facc15` (yellow)
+  - `opencode → #f97316` (orange)
+  - fallback → `#60a5fa`
+- **Proxy 樣式**：`ref.is_proxy === true` → dot 用 outline（`backgroundColor: transparent` + `border: 1px solid <typeColor>`）；proxy=false/undefined → 實心不變
 - `animationDelay` 公式不變
 
-**TabIcon.tsx**：`subagentCount: number` prop → `subagentRefs: SubagentRef[]` prop；dot 模式 / iconDot 模式 / badge 模式全改吃 list；`refs.length > 0` 取代 `count > 0`。
+**TabIcon.tsx**（PR-2b）：`subagentCount: number` → `subagentRefs: SubagentRef[]`；dot/iconDot/badge 三模式全改吃 list；`refs.length > 0` 取代 `count > 0`。
 
-**useTabDisplay.ts**：`subagentCount = subagents[ck]?.length ?? 0` → `subagentRefs = subagents[ck] ?? []`；回傳值加 `subagentRefs` 欄位或改名（傾向改名，count 拿掉）。
+**useTabDisplay.ts**（PR-2a 先改 `subagentCount = refs.length`，保 TabIcon 既有 prop；PR-2b 回傳 `subagentRefs`）：
+- PR-2a：`useAgentStore((s) => s.subagents[ck]?.length ?? 0)` 改為從 `SubagentRef[]?.length`（型別自動變，行為不變）
+- PR-2b：新增 `subagentRefs` 回傳欄位
 
-**SubagentDots 測試**：保留既有 count-based 測試，但輸入改建 mock refs；新加兩個 case — type 色差 + proxy outline。
+**SubagentDots 測試**：保留既有 count-based case 概念（refs 長度取代 count input），新加兩個 case — type 色差 + proxy outline。
 
-### 1.13 零改動邊界
+### 1.14 零改動邊界
 
 以下檔案 Phase 2 **不得觸碰**：
 
-- `internal/agent/provider.go` / `registry.go` / `status.go`（除 NormalizedEvent 欄位升級）/ `coverage.go`
-- `internal/agent/{cc,codex,opencode}/*.go`（SubagentStart detail 已備齊 `agent_id`）
+- `internal/agent/provider.go` / `registry.go` / `coverage.go`（Phase 0）
+- `internal/agent/{cc,codex,opencode}/*.go`（Phase 1 已對齊；SubagentStart detail 已備齊 `agent_id`）
 - `internal/agent/probe/**`
-- `internal/store/frames.go` 的 SQL schema（column 不變；僅 JSON shape 變）
+- `internal/store/frames.go` SQL schema（column 不變；JSON shape 變）
 - `internal/module/agent/verify.go` / `upload*.go` / `monitor.go` / `statusline*.go`
-- `spa/src/**` 除 `useAgentStore.ts` / `SubagentDots.tsx` / `TabIcon.tsx` / `useTabDisplay.ts` + 測試 seed 檔外不動
-- `/api/agent/monitor/*` endpoint shape — 不改（Phase 5 Inspector 再統一）
+- `internal/agent/status.go` 除 NormalizedEvent.Subagents 型別
+- `spa/src/**` 除 `useAgentStore.ts` / `SubagentDots.tsx` / `TabIcon.tsx` / `useTabDisplay.ts` + 測試 seed 檔
+- `/api/agent/monitor/*` endpoint shape（Phase 5 Inspector 統一）
+
+---
 
 ## 2. 測試案例清單
 
-### 2.1 SubagentRef JSON round-trip
+### 2.1 SubagentRef JSON round-trip（PR-2a）
 
 `internal/agent/subagent_test.go`（新檔）：
 
 | # | 名稱 | 斷言 |
 |---|---|---|
-| R1 | `TestSubagentRef_JSONRoundTrip` | `{ID:"a", Type:"cc", StartedAt:123, IsProxy:true}` marshal/unmarshal 相等；JSON bytes 含 `"is_proxy":true` |
-| R2 | `TestSubagentRef_OmitsIsProxyWhenFalse` | `IsProxy:false` 的 marshal JSON bytes **不含** `is_proxy` key（omitempty 驗證） |
+| R1 | `TestSubagentRef_JSONRoundTripFull` | `{ID:"a", Type:"cc", StartedAt:123, SourcePID:1000, SourceStartTime:"t0", IsProxy:true}` marshal/unmarshal 相等；JSON 含 `"source_pid"`/`"source_start_time"`/`"is_proxy":true` |
+| R2 | `TestSubagentRef_OmitsIsProxyWhenFalse` | `IsProxy:false` marshal JSON 不含 `is_proxy` key |
+| R3 | `TestSubagentRef_NativeZeroSourceFieldsValid` | `{ID:"a", Type:"cc", StartedAt:1}` (SourcePID=0, SourceStartTime="") marshal/unmarshal OK — JSON 含 `"source_pid":0` / `"source_start_time":""` |
 
-### 2.2 Frame store 升級
+### 2.2 Frame store 升級（PR-2a）
 
-`internal/store/frames_test.go` 補：
-
-| # | 名稱 | 斷言 |
-|---|---|---|
-| F1 | `TestFrames_UpsertAndReadSubagentRefs` | Upsert 帶 `[]SubagentRef{{ID:"s1", Type:"cc", StartedAt:10}}` → GetByIdentity 讀回同值 |
-| F2 | `TestFrames_EmptySubagentsPreserved` | Upsert 帶 `nil` Subagents → 讀回 `[]SubagentRef{}`（非 nil） |
-| F3 | `TestFrames_SubagentsJSONFormatContainsExpectedKeys` | 讀回 frame 後 marshal `[]SubagentRef` 的 JSON 字串包含 `"id"` / `"type"` / `"started_at"`（smoke test 對齊 §1.1） |
-
-既有測試涉及 `Subagents: []string{...}` seed 全改為 `[]SubagentRef{...}`。
-
-### 2.3 updateSubagents 單元
-
-`internal/module/agent/frame_ops_test.go` 補（或分檔 `subagents_test.go`）：
+`internal/store/frames_test.go`:
 
 | # | 名稱 | 斷言 |
 |---|---|---|
-| U1 | `TestUpdateSubagents_StartAddsRef` | 空 list + SubagentStart ref → list 有 1 個 ref |
-| U2 | `TestUpdateSubagents_StartDuplicateIDKeepsExisting` | 已有 `{ID:"a", StartedAt:10}` + SubagentStart `{ID:"a", StartedAt:20}` → list 仍為 1 個，StartedAt=10（不覆寫） |
-| U3 | `TestUpdateSubagents_StopRemovesByID` | list `[a, b]` + SubagentStop `{ID:"a"}` → list = `[b]` |
-| U4 | `TestUpdateSubagents_StopIgnoresType` | list `[{ID:"a", Type:"cc"}]` + SubagentStop `{ID:"a", Type:"codex"}` → list 為空（Type 不參與比對） |
-| U5 | `TestUpdateSubagents_StopMissingIsNoop` | list `[a]` + SubagentStop `{ID:"b"}` → list = `[a]` |
+| F1 | `TestFrames_UpsertAndReadSubagentRefs` | Upsert `[]SubagentRef{{ID:"s1", Type:"cc", StartedAt:10}}` → GetByIdentity 讀回同值 |
+| F2 | `TestFrames_EmptySubagentsPreserved` | Upsert `nil` Subagents → 讀回 `[]SubagentRef{}`（非 nil） |
+| F3 | `TestFrames_SubagentsJSONShapeSmoke` | 讀回 frame 的 raw JSON 字串含 `"id"`、`"type"`、`"started_at"`、`"source_pid"`、`"source_start_time"` |
 
-### 2.4 Proxy 偵測整合
+### 2.3 `DeleteIfUnchanged`（PR-2b）
+
+`internal/store/frames_test.go`:
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| F4 | `TestFrames_DeleteIfUnchanged_DeletesWhenMatching` | Upsert LastSeenAt=10 → DeleteIfUnchanged(id, 10) → returns (true, nil)，frame 消失 |
+| F5 | `TestFrames_DeleteIfUnchanged_SkipsWhenStale` | Upsert LastSeenAt=10 → Upsert LastSeenAt=20 (concurrent refresh) → DeleteIfUnchanged(id, 10) → returns (false, nil)，frame 仍在 |
+| F6 | `TestFrames_DeleteIfUnchanged_NotFound` | 不存在 frame id → returns (false, nil) |
+
+### 2.4 `updateSubagents` 單元（PR-2a）
+
+`internal/module/agent/frame_ops_test.go`:
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| U1 | `TestUpdateSubagents_StartAddsRef` | 空 list + SubagentStart ref{ID:"a"} → list=[{ID:"a"}] |
+| U2 | `TestUpdateSubagents_StartDuplicateIDKeepsExisting` | 已有 `{ID:"a", StartedAt:10}` + SubagentStart `{ID:"a", StartedAt:20}` → list 仍 1 筆，StartedAt=10 |
+| U3 | `TestUpdateSubagents_StopRemovesByID` | list `[a, b]` + SubagentStop `{ID:"a"}` → list=[b] |
+| U4 | `TestUpdateSubagents_StopIgnoresType` | list `[{ID:"a", Type:"cc"}]` + SubagentStop `{ID:"a", Type:"codex"}` → list=[]（Type 不參與比對） |
+| U5 | `TestUpdateSubagents_StopMissingIsNoop` | list `[a]` + SubagentStop `{ID:"b"}` → list=[a] |
+
+### 2.5 Proxy 偵測整合（PR-2b）
 
 `internal/module/agent/frame_ops_test.go`:
 
 | # | 名稱 | 情境 | 斷言 |
 |---|---|---|---|
-| PR1 | `TestProxySubagent_CodexHookAttachesToCCParent` | cc SessionStart → codex SessionStart 同 pane | pane 只有 1 個 frame（cc），cc.Subagents 有一筆 `{Type:"codex", IsProxy:true}` |
-| PR2 | `TestProxySubagent_SkipsWhenParentSameType` | cc SessionStart → cc SessionStart 同 pane 但不同 pid/start | pane 有 2 個 frame（新舊 cc），不觸發 proxy |
-| PR3 | `TestProxySubagent_SkipsWhenParentPidDead` | cc frame 已存在但 isPidAliveFn 回 false → codex SessionStart | 走既有路徑建新 codex frame，不觸發 proxy |
-| PR4 | `TestProxySubagent_SkipsWhenNoParent` | 空 pane → codex SessionStart | 建新 codex frame |
-| PR5 | `TestProxySubagent_TraceMetaCorrect` | PR1 情境 | trace meta decision="updated_frame", reason="proxy_subagent_attached", FrameID=parent.FrameID |
-| PR6 | `TestProxySubagent_DoesNotDoubleAttachOnReHook` | PR1 後再送一次 codex SessionStart（同 PID）| cc.Subagents 仍為 1 筆，StartedAt 為首次時間 |
+| PR1 | `TestProxySubagent_CodexHookWithCCPPIDAttachesToCCParent` | cc SessionStart (PID 100, pane %5) → codex SessionStart (PID 200, PPID 100, pane %5) | pane 有 1 frame（cc），cc.Subagents 有 ref `{Type:"codex", IsProxy:true, SourcePID:200, SourceStartTime:"..."}` |
+| PR2 | `TestProxySubagent_SkipsWhenPPIDNotMatchFrame` | codex SessionStart (PPID=9999, pane 無 frame with PID 9999) | 建新 codex frame（fallback），不 proxy |
+| PR3 | `TestProxySubagent_SkipsWhenParentSameType` | cc SessionStart → cc SessionStart 不同 pid/start，PPID 指第一個 cc | 建新 cc frame，不 proxy（same type） |
+| PR4 | `TestProxySubagent_SkipsWhenParentPidDead` | cc frame 存在但 isPidAliveFn 回 false for cc PID → codex SessionStart PPID=cc.PID | 建新 codex frame，不 proxy |
+| PR5 | `TestProxySubagent_SkipsWhenEventNotSessionStart` | cc frame 存在 → codex UserPromptSubmit PPID=cc.PID | 走 legacy 路徑（目前可能建 frame 可能不建，依 DeriveStatus result；不偏移現狀）；驗證不走 proxy 路徑 |
+| PR6 | `TestProxySubagent_TraceMetaCorrect` | PR1 情境 | trace meta decision="updated_frame"、reason="proxy_subagent_attached"、FrameID=parent.FrameID |
+| PR7 | `TestProxySubagent_DoesNotDoubleAttachOnReHook` | PR1 後再送同 codex SessionStart (same PID+StartTime) | cc.Subagents 仍 1 筆，StartedAt 為首次時間 |
 
-### 2.5 Frame Idle Sweep
+### 2.6 SessionEnd Proxy Cleanup（PR-2b）
+
+`internal/module/agent/frame_ops_test.go`:
+
+| # | 名稱 | 斷言 |
+|---|---|---|
+| SE1 | `TestSessionEnd_RemovesProxyRefFromParent` | PR1 setup + codex SessionEnd (同 PID/StartTime) → cc.Subagents 變空；trace reason="proxy_subagent_detached" |
+| SE2 | `TestSessionEnd_OrphanFallsBackToExistingSkip` | codex SessionEnd (pane 內無匹配 SourcePID frame/ref) → 走 session_end_without_frame |
+| SE3 | `TestSessionEnd_OwnFrameDeletePreservesOtherProxyRefs` | parent frame A 有 proxy ref of codex B；SessionEnd 送給 A 本身 → A frame 刪除（既有），ref 跟著刪（副作用 OK） |
+
+### 2.7 Frame Idle Sweep（PR-2b）
 
 `internal/module/agent/sweep_test.go`:
 
 | # | 名稱 | 斷言 |
 |---|---|---|
-| IS1 | `TestSweep_ClearsIdleFramesByLastSeen` | Upsert frame LastSeenAt=0，nowFn 回固定 `2*frameIdleThreshold` → sweepOnce 後 frame 被清、clearFrame reason="idle_timeout" 走 broadcast |
+| IS1 | `TestSweep_ClearsIdleFramesByLastSeen` | Upsert frame LastSeenAt=0，nowFn 回 `2*frameIdleThreshold` → sweepOnce 後 frame 被清、clearFrame reason="idle_timeout" broadcast |
 | IS2 | `TestSweep_PreservesFreshFrames` | LastSeenAt=nowFn-1min → sweepOnce 後 frame 保留 |
-| IS3 | `TestSweep_IdleClearStopsOrphanWatcher` | frame idle + session 有 activeWatcher → clearFrame 後 prober.StopWatch 被呼叫（fake prober 記 call） |
+| IS3 | `TestSweep_IdleClearStopsOrphanWatcher` | frame idle + session 有 activeWatcher → clearFrame 後 prober.StopWatch 被呼叫 |
 | IS4 | `TestSweep_DeadPidAlsoStopsOrphanWatcher` | 既有 pid_dead 路徑也觸發 StopWatch（順勢 fix 的迴歸測試） |
+| IS5 | `TestSweep_IdleConditionalDeleteSkipsOnConcurrentRefresh` | 在 sweepOnce 執行中，模擬 sweep 已讀 LastSeenAt=0，但 DELETE 前 Upsert 把 LastSeenAt 改成 nowFn-30min → DeleteIfUnchanged 回 (false, nil)，frame 仍在；測試用 fake store wrap `FramesStore`，在 ListAll → DeleteIfUnchanged 之間插入 refresh |
 
-### 2.6 Handler 整合：broadcast 含 SubagentRef
+### 2.8 Handler 整合：broadcast 含 SubagentRef（PR-2a + PR-2b 各一）
 
 `internal/module/agent/handler_test.go`:
 
-| # | 名稱 | 斷言 |
-|---|---|---|
-| HB1 | `TestHandleEvent_BroadcastPayloadCarriesSubagentRefs` | SessionStart + SubagentStart cc → WS broadcast payload 解析後 `subagents[0]` 含 `type`、`started_at`、無 `is_proxy`（omitempty） |
-| HB2 | `TestHandleEvent_ProxyBroadcastCarriesIsProxyTrue` | cc SessionStart → codex SessionStart → 第二次 broadcast `subagents[0].is_proxy==true, type=="codex"` |
+| # | 名稱 | PR | 斷言 |
+|---|---|---|---|
+| HB1 | `TestHandleEvent_BroadcastPayloadCarriesSubagentRefs` | PR-2a | cc SessionStart + SubagentStart → WS broadcast payload 解析後 `subagents[0].type=="cc"`、`started_at` 非 0、無 `is_proxy`（native） |
+| HB2 | `TestHandleEvent_ProxyBroadcastCarriesIsProxyTrue` | PR-2b | cc SessionStart → codex SessionStart PPID=cc.PID → 第二次 broadcast `subagents[0].is_proxy==true, type=="codex", source_pid==codex.PID` |
 
-### 2.7 SPA 測試升級
+### 2.9 SPA 測試升級（PR-2a + PR-2b）
 
-- `useAgentStore.test.ts`（若存在）+ 所有 seed `subagents: {}` / `subagents: { key: [...] }` 的測試檔更新 mock 為 `SubagentRef[]`
-- `SubagentDots.test.tsx`（新檔）：
+- **PR-2a**：所有 seed `subagents: {}` / `subagents: { key: [...] }` 的測試檔升級 mock 為 `SubagentRef[]`
+  - `SortableTab.test.tsx` / `StatusBar.test.tsx` / `TerminalView.test.tsx` / `HookModuleCard.test.tsx` / `useNotificationDispatcher.test.ts` / `useTabDisplay.test.ts`
+- **PR-2b**：`SubagentDots.test.tsx`（新檔）：
   - `TestSubagentDots_Count`：refs 1/2/3 → 對應 dot 數
   - `TestSubagentDots_TypeColors`：三家 type → 三個不同 backgroundColor
-  - `TestSubagentDots_ProxyOutline`：ref with `is_proxy:true` → border 1px + background transparent；`is_proxy:false/undefined` → solid background
-- `useTabDisplay.test.ts` line 160 的 `subagents: { 'h1:sc1': [{ id: 's1' }] as never }` 改為正規 SubagentRef
+  - `TestSubagentDots_ProxyOutline`：ref with `is_proxy:true` → border 1px + backgroundColor transparent；`is_proxy:false/undefined` → solid background
+
+---
 
 ## 3. TDD 執行順序
 
-Subagent 嚴格按以下順序執行；每個 step 一個 commit。Commit message 用 Conventional Commits + `Co-Authored-By: Claude Opus 4.7 (1M context)`。
+### PR-2a（commits 1-5）
 
-### Commit 1 — `feat(agent): add SubagentRef type`
-- 紅：寫 R1 + R2 → 失敗（type 不存在）
+#### Commit 1 — `feat(agent): add SubagentRef type with source identity`
+- 紅：R1 + R2 + R3 → 失敗
 - 綠：新檔 `internal/agent/subagent.go`
 - 跑 `go test ./internal/agent/...` 綠
 
-### Commit 2 — `refactor(store): upgrade Frame.Subagents to []SubagentRef`
-- 紅：寫 F1 + F2 + F3 → 失敗（型別不符）
-- 綠：`internal/store/frames.go` 型別升級 + nil 防護；更新既有 frames_test seed
-- 跑 `go test ./internal/store/...` 綠；`go build ./...` 期望**失敗**（frame_ops 仍吃 `[]string`）— 這是刻意的，下個 commit 接手
+#### Commit 2 — `refactor(store+agent): atomic SubagentRef schema upgrade`
+**對 codex #5 修正 — 原 plan 的 commit 2+3 合併為單一 atomic commit，保 `go build ./...` 在 commit 邊界綠。**
+- 紅：F1-F3 + U1-U5 → 失敗
+- 綠：同一 commit 完成：
+  - `internal/store/frames.go` Frame.Subagents 型別升級
+  - `internal/module/agent/frame_ops.go` updateSubagents 簽名 + 建構 ref 的三處
+  - `internal/module/agent/projection.go` SessionProjection.Subagents 型別
+  - `internal/module/agent/module.go` m.subagents map 型別
+  - 所有既有 test seed 的 `Subagents: []string{...}` 改為 `[]SubagentRef{...}`
+- 跑 `go build ./...` + `go test ./...` 綠
 
-### Commit 3 — `refactor(module/agent): upgrade frame_ops/projection for SubagentRef`
-- 紅：寫 U1-U5 → 失敗
-- 綠：`frame_ops.go` updateSubagents 簽名升級；`projection.go` SessionProjection 升級；`m.subagents` map 升級；`buildProjectionNormalized` 跟上；既有 frame_ops_test / projection_test / sweep_test 的 seed 全改
-- 跑 `go build ./...` + `go test ./internal/module/agent/... ./internal/store/...` 綠
-
-### Commit 4 — `refactor(agent): upgrade NormalizedEvent.Subagents wire`
-- 紅：HB1 期望 payload 新欄位 → 失敗
-- 綠：`internal/agent/status.go` NormalizedEvent.Subagents 型別升級；handler.go `buildNormalized` 跟上
+#### Commit 3 — `refactor(agent): upgrade NormalizedEvent.Subagents wire`
+- 紅：HB1（PR-2a 版 — 不含 IsProxy） → 失敗
+- 綠：`internal/agent/status.go` NormalizedEvent.Subagents 型別；handler.go `buildNormalized` / frame_ops.go `buildProjectionNormalized` / module.go 三處跟上
 - 跑 `go test ./...` 綠
 
-### Commit 5 — `refactor(spa): upgrade useAgentStore subagents to SubagentRef[]`
-- 紅：SPA 編譯錯誤（型別 mismatch 會卡 lint/build）
+#### Commit 4 — `refactor(spa): upgrade useAgentStore subagents to SubagentRef[]`
+- 紅：SPA 編譯錯誤（Record 型別 mismatch）
 - 綠：`useAgentStore.ts` SubagentRef + NormalizedEvent + subagents Record 升級；既有 store 測試 seed 改
-- 跑 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠（此 commit 結束時 TabIcon/SubagentDots 仍吃舊 count，下個 commit 修）
+- `useTabDisplay.ts` 維持 `subagentCount = refs.length`（行為不變，只吃新型別）
+- 跑 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
 
-**註**：為了讓中間 commit 保持 SPA build 綠，commit 5 先把 `useTabDisplay.ts` 的 subagentCount 從 `length` 維持（SubagentRef[].length 仍 work），僅把 store 型別升級。Component API 升級留 commit 6。
+#### Commit 5 — `test(spa): update subagents mocks across seed sites`
+- 紅：若上個 commit 遺漏測試檔 seed → 綠
+- 綠：掃全 SPA 測試檔規範化 subagents seed 為 `SubagentRef[]`
+- 跑 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
 
-### Commit 6 — `feat(spa): SubagentDots takes SubagentRef[] with type color + proxy outline`
-- 紅：寫 SubagentDots.test.tsx 三個 case → 失敗
+（PR-2a 結束：純 schema + 型別升級，行為無變化）
+
+### PR-2b（commits 6-10）
+
+#### Commit 6 — `feat(store): add DeleteIfUnchanged for optimistic sweep`
+- 紅：F4 + F5 + F6 → 失敗
+- 綠：`frames.go` 新增 method
+- 跑 `go test ./internal/store/...` 綠
+
+#### Commit 7 — `feat(module/agent): detect proxy subagents via PPID match`
+- 紅：PR1-PR7 → 失敗
+- 綠：`frame_ops.go` applyFrameEvent 加 proxy 偵測分支（PPID-first）+ proxyIDFor helper
+- 跑 `go test ./internal/module/agent/...` 綠
+
+#### Commit 8 — `feat(module/agent): remove proxy ref on SessionEnd`
+- 紅：SE1 + SE2 + SE3 → 失敗
+- 綠：`frame_ops.go` SessionEnd 分支加 `removeProxyRefForSender` fallback
+- 跑 `go test ./internal/module/agent/...` 綠
+
+#### Commit 9 — `feat(module/agent): idle sweep with conditional DELETE`
+- 紅：IS1-IS5 + HB2 → 失敗
+- 綠：`sweep.go` 加 `nowFn` + `frameIdleThreshold` + 第三條規則（用 `DeleteIfUnchanged`）+ `afterFrameCleared` 抽出 + orphan StopWatch 修正
+- 跑 `go test ./internal/module/agent/...` 綠
+
+#### Commit 10 — `feat(spa): SubagentDots takes SubagentRef[] with type color + proxy outline`
+- 紅：SubagentDots.test.tsx 三個 case → 失敗
 - 綠：SubagentDots API 升級；TabIcon 改吃 refs；useTabDisplay 回傳 refs
 - 跑 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
 
-### Commit 7 — `test(module/agent): schema升級 integration coverage`
-- 紅：HB1 → 失敗（handler broadcast 尚未真實帶 SubagentRef，但上幾個 commit 已升級，實際應綠）
-- 綠（驗證性）：跑過一次確認整合
-- 如果 HB1 已在 commit 4 加入就併進去；這個 commit 可變可選
+#### Commit 11 — `docs: phase 2 plan retrospective notes`（可選）
+若 §3 順序與實際執行有偏差，補歷史 note（Phase 0/1 plan 同型）。
 
-### Commit 8 — `feat(module/agent): detect proxy subagents for cross-type hooks`
-- 紅：PR1-PR6 → 失敗
-- 綠：`frame_ops.go` applyFrameEvent 加 proxy 偵測分支 + proxyIDFor helper
-- 跑 `go test ./internal/module/agent/...` 綠
-
-### Commit 9 — `feat(module/agent): sweep idle frames after 1h LastSeenAt`
-- 紅：IS1-IS4 → 失敗
-- 綠：`sweep.go` 加 `nowFn` + `frameIdleThreshold` const + 第三條規則 + `clearFrame` 補 StopWatch
-- 跑 `go test ./internal/module/agent/...` 綠
-
-### Commit 10 — `test(spa): update subagents mocks across seed sites`
-- 紅：若仍有測試檔 seed `{ key: [{ id }] as never }` 舊格式 → 升級後會漏
-- 綠：掃全 SPA 測試檔，把 subagents seed 規範化為 `SubagentRef[]`
-- 跑 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
-
-### Commit 11 — `docs: phase 2 plan retrospective notes`（可選）
-若 §3 順序與實際執行偏差，補 Phase 0/1 plan 同型的歷史 note。
+---
 
 ## 4. 實作檔案預估
 
+### PR-2a 改動
+
 | 檔案 | 動作 | 預估行數 |
 |---|---|---|
-| `internal/agent/subagent.go` | 新檔 type + comments | +25 |
-| `internal/agent/subagent_test.go` | 新檔 R1+R2 | +40 |
-| `internal/agent/status.go` | NormalizedEvent.Subagents 型別改 | +1 (-1) |
-| `internal/store/frames.go` | Frame.Subagents 型別 + nil 防護 | ~10 |
-| `internal/store/frames_test.go` | F1-F3 + 既有 seed 改 | +60 |
-| `internal/module/agent/frame_ops.go` | updateSubagents 簽名 + proxy 分支 + helpers | +110 |
-| `internal/module/agent/frame_ops_test.go` | U1-U5 + PR1-PR6 + 既有 seed 改 | +220 |
-| `internal/module/agent/projection.go` | SessionProjection.Subagents 型別 | ~4 |
+| `internal/agent/subagent.go` | 新檔 type | +30 |
+| `internal/agent/subagent_test.go` | 新檔 R1-R3 | +60 |
+| `internal/agent/status.go` | NormalizedEvent.Subagents 型別 | ~2 |
+| `internal/store/frames.go` | Frame.Subagents 型別 + nil | ~10 |
+| `internal/store/frames_test.go` | F1-F3 + 既有 seed 改 | +80 |
+| `internal/module/agent/frame_ops.go` | updateSubagents 簽名 + 三處 ref 建構 | ~40 |
+| `internal/module/agent/frame_ops_test.go` | U1-U5 + 既有 seed 改 | +120 |
+| `internal/module/agent/projection.go` | SessionProjection.Subagents | ~4 |
 | `internal/module/agent/projection_test.go` | seed 改 | ~10 |
 | `internal/module/agent/module.go` | m.subagents map 型別 | ~4 |
-| `internal/module/agent/handler.go` | buildNormalized Subagents 型別 | ~4 |
-| `internal/module/agent/handler_test.go` | HB1+HB2 + 既有 seed | +100 |
-| `internal/module/agent/sweep.go` | nowFn + frameIdleThreshold + 規則 + StopWatch | +30 |
-| `internal/module/agent/sweep_test.go` | IS1-IS4 + 既有 seed | +140 |
-| `internal/module/agent/trace.go` | (若 summary 有 list) | 0 / ~5 |
-| `spa/src/stores/useAgentStore.ts` | SubagentRef + Record 型別 | +10 |
-| `spa/src/components/SubagentDots.tsx` | API + type colors + proxy outline | +40 (-20) |
-| `spa/src/components/SubagentDots.test.tsx` | 新檔 3 cases | +110 |
+| `internal/module/agent/handler.go` | buildNormalized 型別 | ~4 |
+| `internal/module/agent/handler_test.go` | HB1 + 既有 seed | +60 |
+| `internal/module/agent/sweep_test.go` | 既有 seed 改（引入 SubagentRef） | +15 |
+| `spa/src/stores/useAgentStore.ts` | SubagentRef + Record 型別 | +12 |
+| `spa/src/components/*.test.tsx` (6 檔) | seed 改 | ~35 |
+| `spa/src/hooks/*.test.ts` (2 檔) | seed 改 | ~12 |
+| `docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md` | 本檔 | +550 |
+| **PR-2a 合計（不含 plan）** | | **~500 行** |
+
+### PR-2b 改動
+
+| 檔案 | 動作 | 預估行數 |
+|---|---|---|
+| `internal/store/frames.go` | `DeleteIfUnchanged` method | +20 |
+| `internal/store/frames_test.go` | F4-F6 | +50 |
+| `internal/module/agent/frame_ops.go` | proxy 偵測分支 + `removeProxyRefForSender` | +100 |
+| `internal/module/agent/frame_ops_test.go` | PR1-PR7 + SE1-SE3 | +240 |
+| `internal/module/agent/sweep.go` | nowFn + threshold + 第三條規則 + afterFrameCleared 抽出 + StopWatch fix | +50 |
+| `internal/module/agent/sweep_test.go` | IS1-IS5 | +160 |
+| `internal/module/agent/handler_test.go` | HB2 | +40 |
+| `spa/src/components/SubagentDots.tsx` | API + type color + proxy outline | +40 (-20) |
+| `spa/src/components/SubagentDots.test.tsx` | 新檔 3 case | +110 |
 | `spa/src/components/TabIcon.tsx` | count → refs | ~15 |
-| `spa/src/hooks/useTabDisplay.ts` | refs 回傳 | ~8 |
-| `spa/src/components/*.test.tsx` (6 檔) | seed 改 | ~30 |
-| `spa/src/hooks/*.test.ts` (2 檔) | seed 改 | ~10 |
-| `docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md` | 本檔 | +500 |
-| **合計（不含 plan）** | | **~950 行** |
-| **合計（含 plan）** | | **~1450 行** |
+| `spa/src/hooks/useTabDisplay.ts` | 回傳 subagentRefs | ~8 |
+| **PR-2b 合計** | | **~800 行** |
+
+### 總計
+
+**~1300 行 code**（不含 plan）— 比 v1 的 950 多 350 行主要是 proxy identity 欄位擴充、SessionEnd cleanup、DeleteIfUnchanged、afterFrameCleared 抽出、測試擴充。
+
+---
 
 ## 5. 不做項目清單（防自動擴展）
 
 以下衝動一律拒絕 — PR description / commit message 中明確聲明：
 
-- **不加** SubagentRef.Status 欄位（SubagentStart 本來就 Status=""；待 Phase 4/5 有需求再評估）
-- **不加** SubagentRef.LastSeenAt 欄位（idle 判斷用 frame.LastSeenAt；個別 ref 的活性 Phase 3/4 再看）
-- **不寫** 舊格式 JSON fallback（alpha 階段重建 DB 即可，避免 deprecated 路徑留在 code）
-- **不做** proxy ref 的獨立 liveness 檢查（留 Phase 3 / 4b）
+- **不做** schema migration（使用者單人，rm DB 即可；CHANGELOG 標紅字）
+- **不做** boot hard-fail 舊格式偵測（同上，成本 > 收益）
+- **不加** `SubagentRef.Status` / `SubagentRef.LastSeenAt`（Phase 4/5 再評估）
+- **不做** proxy ref 的獨立 liveness 檢查（Phase 3 / 4b；SessionEnd 清理已涵蓋大多數 case）
+- **不做** PPID 樹狀遍歷（Phase 3/4 再加；單層 PPID 命中率實測先看）
+- **不處理** 非 SessionStart 的 proxy 事件（Phase 3/4）
 - **不改** `/api/agent/monitor/*` endpoint shape（Phase 5 Inspector 統一）
-- **不處理** 非 SessionStart 的 proxy 事件（codex proxy 實測都走 SessionStart；若不符再 Phase 3/4 補）
-- **不重整** `handler.go` / `module.go`（proxy 偵測是 frame_ops 局部增加，不順手 refactor）
-- **不抽** `frameIdleThreshold` 為 runtime flag（const 表達即可，實際觀察需要再改）
-- **不加** idle sweep 的 broadcast reason 細分（與 `pid_dead` / `pid_reused` 共用 clearFrame 通道）
-- **不做** SubagentDots 的 > 3 refs 的 overflow 處理（超過 3 仍只顯示 3，與既有 clamp 一致）
-- **不抽** SubagentDots 的 TYPE_COLOR 表到 `agent-icons.tsx`（inline 即可，型別對應單純）
+- **不重整** `handler.go` / `module.go`（Phase 2 是 frame_ops / sweep 局部增加）
+- **不抽** `frameIdleThreshold` 為 runtime flag（const 表達即可）
+- **不加** idle sweep 的 broadcast reason 細分（共用 clearFrame 通道，reason="idle_timeout"）
+- **不做** SubagentDots > 3 refs overflow 處理（保留既有 clamp 0-3 行為）
+- **不抽** SubagentDots 的 TYPE_COLOR 表到 `agent-icons.tsx`（inline 可讀即可）
+- **不做** PR-2a 單獨的 SubagentDots 視覺升級（保 count-based；PR-2b 一次到位）
+
+---
 
 ## 6. Subagent 開發指引
 
 - **cwd 強制前綴**：每個 Bash 指令以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-phase-2 && ` 開頭（依 `feedback_subagent_cwd_enforcement.md`）
-- **分支**：已在 `worktree-lights-phase-2`，不另切；不 push（主 session 負責）
-- **Commit message 格式**：Conventional Commits + 結尾加 `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
-- **TDD 嚴格紅綠**：每個 commit 內先寫測試跑紅再實作跑綠 — 不可批次寫完所有 test + 一次實作
-- **中間 commit 可以 build 失敗**（commit 2 → 3 之間）：這是型別升級的必然；commit 3 結束必須 `go build ./...` + `go test ./...` 綠
-- **SPA 每個 commit 都要 build 綠**：pnpm install 由主 session 處理一次，subagent 只跑 vitest / lint / build
-- **回報**：完成後回報 commit hash 列表 + `git log --oneline -15` + `go test ./...` 完整輸出 + `cd spa && pnpm run lint && pnpm run build && npx vitest run` 結果
-- **Codex sandbox 限制**：依 `feedback_codex_sandbox_no_install.md`，SPA 任務若 subagent 跑不動 pnpm install，由主 session 手動跑
+- **分支策略**：
+  - PR-2a 在 `worktree-lights-phase-2` 直接 commit（已 push）
+  - PR-2b 等 PR-2a merge 後，主 session 從 main rebase 開新 worktree `lights-phase-2b`，subagent 在該 worktree 接 PR-2b commits
+- **Commit message 格式**：Conventional Commits + 結尾 `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+- **TDD 嚴格紅綠**：每個 commit 內先寫測試跑紅再實作跑綠；**每個 commit 邊界都 `go build ./...` 綠**（PR-2a commit 2 是 atomic）
+- **Codex sandbox 限制**：依 `feedback_codex_sandbox_no_install.md`，subagent 在 worktree 內 `pnpm install` 可能失敗；由主 session 手動跑一次 install，subagent 只跑 vitest / lint / build
+- **回報**：完成後回報 commit hash 列表 + `git log --oneline -15` + `go test ./...` + `cd spa && pnpm run lint && pnpm run build && npx vitest run` 完整輸出
 
-## 7. 驗收清單（完整 Phase 2）
+---
 
-- [ ] 10-11 個 commits 符合 message 規範
-- [ ] `go build ./...` 綠（每個 commit 結束時）
-- [ ] `go test ./...` 綠（新增 R1-R2 / F1-F3 / U1-U5 / PR1-PR6 / IS1-IS4 / HB1-HB2 共 22 個測試）
+## 7. 驗收清單
+
+### PR-2a
+
+- [ ] 5 個 commits 符合規範（1-5）
+- [ ] **每個 commit 邊界** `go build ./...` 綠（對 codex #5 修正）
+- [ ] `go test ./...` 綠（R1-R3 / F1-F3 / U1-U5 / HB1 共 12 測試）
 - [ ] `go vet ./...` 無 warning
-- [ ] `cd spa && pnpm run lint && pnpm run build` 綠
-- [ ] `cd spa && npx vitest run` 綠（新增 SubagentDots 3 case + 舊檔 seed 升級）
-- [ ] PR diff 涉及檔案：§4 表格列出的 ~22 檔 + plan 文件，**其餘不得出現**
-- [ ] PR description 含「不做項目」§5 聲明 + 拆分判斷（§0）結論（本 PR 單推 or 拆成 2a/2b）
-- [ ] 手動場景（PR description 測試清單）：
-  - cc session 啟動 → `/codex:*` → codex 以 proxy attach 到 cc.Subagents（SPA 上只見 1 個 frame，subagent dot 帶黃色 outline）
-  - 手造超過 1h 閒置 frame（DB 改 LastSeenAt 或臨時改 threshold）→ sweep 後 frame 消失
-  - cc SubagentStart 仍照常（native subagent 藍色實心）
-  - SPA 重新整理後狀態可 replay（frame.Subagents JSON 讀回正確）
-- [ ] DB 重建注意：若升級過程使用者已有舊 `subagents_json` 格式，scanFrame 會回 error；需在 CHANGELOG / bump PR note 標示「alpha.218 要求重建 DB」
+- [ ] `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
+- [ ] PR diff 檔案：§4 PR-2a 表格列出的檔案，**其餘不得出現**
+- [ ] PR description 含「不做項目」聲明 + CHANGELOG 重建 DB 警告預覽
+- [ ] 手動場景：
+  - `rm ~/.purdex/...agent.sqlite`（或相關路徑）後 daemon 啟動正常
+  - cc SessionStart + SubagentStart cc → SPA SubagentDots 顯示 1 dot（count-based 維持）
+  - `subagents_json` DB 欄位 peek 為 `[{"id":"...","type":"cc","started_at":...,"source_pid":0,...}]` 結構
+
+### PR-2b
+
+- [ ] 5 個 commits 符合規範（6-10）
+- [ ] 每個 commit 邊界 `go build ./...` + tests 綠
+- [ ] `go test ./...` 綠（F4-F6 / PR1-PR7 / SE1-SE3 / IS1-IS5 / HB2 共 19 測試）
+- [ ] `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
+- [ ] PR diff 檔案：§4 PR-2b 表格列出的檔案
+- [ ] 手動場景：
+  - cc 啟動 → cc pane 內跑 `/codex:*` → SPA 只顯示 1 個 frame（cc），cc.Subagents 含 codex ref，dot 黃色 outline
+  - 手造 idle frame（臨時改 threshold 到 1s 或 DB 改 LastSeenAt）→ sweep 後 frame 消失
+  - codex SessionEnd（proxy 來源）→ cc.Subagents 空、dot 消失
+  - cc native SubagentStart（Task 工具觸發）→ SPA 顯示藍色實心 dot
+
+---
 
 ## 8. 風險與緩解
 
 | 風險 | 機率 | 影響 | 緩解 |
 |---|---|---|---|
-| 舊 DB `subagents_json` 格式不相容 | 高 | 既有使用者升級後 scanFrame 失敗 | alpha 階段明示重建；bump PR CHANGELOG 標註；或加一次性 startup migration（Phase 2 不做，spec §6 允許破壞式升級） |
-| proxy 偵測誤判（parent alive 但已非使用中） | 中 | codex hook 掛錯 parent | Phase 2 只看 alive PID；若使用者 reports 誤判再加時間窗 / PPID 驗證（spec §11-5） |
-| frame_idle_threshold = 1h 太短（使用者長跑任務） | 中 | 活躍 frame 被誤清 | LastSeenAt 每次 hook 都更新；idle 1h 意味完全無 hook 1h；真正長跑任務應有 activity probe watcher 維持活性。觀察 1-2 週若仍誤清，放大到 4h |
-| SPA + daemon 升級不同步（Electron dev update 先後） | 中 | 短暫 subagents 欄位型別 mismatch，畫面 dot 消失 | 接受（alpha 階段允許）；使用者重開即同步 |
-| SubagentDots 新視覺 accessibility 退化（color-only proxy） | 低 | 色盲使用者看不出 proxy | Phase 2 用 outline vs solid（形狀 + 顏色雙通道），不是純顏色；符合 WCAG |
-| 測試 seed 遺漏導致 CI 紅 | 中 | subagent 要反覆修 | Commit 10 專跑 SPA seed sweep；主 session commit push 前跑全測 |
-| proxy ID `"proxy:<type>:<pid>"` 與 SubagentStart 的 agent_id 撞（理論） | 低 | SubagentStop 誤刪 proxy ref | agent_id 由 CLI 生成（通常 UUID 或 short-hash），不會撞 `proxy:` 前綴；若未來 CLI 改格式再評估 |
+| 使用者升級後忘了重建 DB | 高 | daemon log noisy 500 | CHANGELOG 紅字 + bump PR description 明示；使用者重建即解 |
+| PPID 單層 match 命中率低（codex-companion 中介） | 中-高 | proxy 偵測大量 fallback 建新 frame | 接受 — Phase 2 以「能驗證 UX 為目標」；Phase 3/4 補 tree walk |
+| Idle 1h 太短（使用者長跑任務） | 低 | 活躍 frame 誤清 | LastSeenAt 由 hook 刷新；真正長跑有 activity watcher 維持；觀察 1-2 週再調 |
+| SubagentDots 新視覺 a11y 退化 | 低 | 色盲看不出 proxy | outline vs solid 雙通道（形狀+顏色），符合 WCAG |
+| 測試 seed 遺漏 CI 紅 | 中 | subagent 反覆修 | Commit 5 專跑 SPA seed sweep；主 session push 前跑全測 |
+| SPA + daemon skew（Electron dev update 時差） | 中 | subagents 欄位型別短暫 mismatch | 使用者單人，協調一次升級 |
+| DeleteIfUnchanged 在 SQLite 的 race 邊界 | 低 | `DELETE ... WHERE` 在 SQLite 下是 atomic，行為可靠 | modernc.org/sqlite 的 serialization 保證；IS5 測試覆蓋 |
+| PPID 為 0（init process）導致 `FindByPanePID(0)` 誤中 | 低 | 不可能（init 不會是 pane 內 frame） | 但加 guard：`if info.PPID <= 1 { parentCandidate = nil }` |
+
+---
 
 ## 9. 兩輪 Codex Review 預期 focus
 
-**第一輪（標準）**：
-- SubagentRef JSON shape 是否穩定、omitempty 語意、wire 改 break 有無遺漏
-- Proxy 偵測條件是否完整（§1.4 五條觸發 + 三條不命中）是否正確
-- idle sweep 的 nowFn 注入是否干擾其他測試（並行 swap 風險）
-- SubagentDots type color 表是否與 agent-icons 其他地方衝突
-- Commit 2 刻意讓 `go build` 失敗的策略是否接受（vs. 合併 commit 2+3）
+### PR-2a 第一輪（標準）
 
-**第二輪 3 parallel**：
-- **攻擊**：proxy 偵測 race（並發 hook 寫同 parent.Subagents）/ SubagentStart 同時 proxy 同 ID 撞 / sweep 執行中 handler 正好 upsert frame 的 time-of-check-to-time-of-use / LastSeenAt 溢位（long-lived frame） / Nil pointer on `m.prober` in sweep when prober not wired
-- **防守**：proxy 語意（cross agent_type 的條件是否對「cc inside cc」這種嵌套成立？）/ SessionEnd 對 proxy 的處理策略是否正確（§1.5）/ 為什麼不處理非 SessionStart proxy 事件 / 為什麼不加 LastSeenAt per-ref / 破壞式 schema 升級對使用者可接受性
-- **體質**：`frame_ops.go` 升級後是否 >400 行需拆 / `SubagentDots.tsx` + test 是否過大 / type color 表應不應該集中到 `agent-icons.tsx` 管理 / sweep.go 第三條規則是否 sweep 檔過胖需拆 idle_sweep.go
+- SubagentRef 欄位是否齊全（SourcePID/SourceStartTime 是否該 pointer? 還是零值 sentinel? 本 plan 選零值；可接受性）
+- Frame.Subagents JSON upgrade 的 breaking edge（舊 DB read error 行為）
+- updateSubagents 是否正確處理 native vs proxy ref 混合 list
+- HB1 broadcast payload 型別 smoke
+- TS SubagentRef 欄位型別對齊 Go json tags（snake_case 正確）
 
-## 10. 拆分決策 checklist（plan review 後）
+### PR-2a 第二輪 3 parallel
 
-收到 codex plan review 回饋後，決定單 PR 或拆 2a+2b：
+- **攻擊**：Frame.Subagents JSON 一但 corrupted（手改 DB，格式亂掉）scanFrame 行為；並行 Upsert 造成 subagents_json 覆寫 race；Concurrent syncProjectionState on m.subagents map 無鎖保護？
+- **防守**：TS / Go wire 對齊（`is_proxy,omitempty` 在 TS 側 `?: boolean` 對應正確）；useTabDisplay 從 length 過渡是否保留既有行為
+- **體質**：`frame_ops.go` 升級後是否 >500 行；PR-2a 是否真的無行為改變
 
-- [ ] findings 數 ≤ 10 且皆落在 §1.1-§1.7 的 schema / §1.8-§1.13 型別擴散 → 單 PR 可吞
-- [ ] findings 有 ≥ 3 個集中在 §1.4 proxy 語意 或 §1.6 sweep 規則 → 拆 2b
-- [ ] findings 觸及 WS wire compatibility（§1.9）且 reviewer 要求平滑升級 → 拆 2a 單獨 merge + bump 一次
-- [ ] plan 本身 > 550 行 → 拆 2a/2b 兩份 plan 分跑 review
+### PR-2b 第一輪（標準）
 
-預設：寫完 plan 送一次 codex review，依回饋再決定。
+- Proxy 偵測 PPID-first 條件是否完整（PPID<=1 guard？info.PPID=req.SenderPID 自環？）
+- SessionEnd proxy cleanup scanning 是否遺漏 multi-pane case
+- DeleteIfUnchanged race window 設計是否正確
+- `afterFrameCleared` 抽出是否破壞 clearFrame 既有語意
+- SubagentDots type color 表（cc/codex/opencode）後續維護
+
+### PR-2b 第二輪 3 parallel
+
+- **攻擊**：proxy 與 native SubagentStart 撞 ID（native agent_id 用 `proxy:` 開頭？）/ 多 pane 同 sender process（不太可能但 guard？）/ sweep 執行時 proxy attach 的 TOCTOU / LastSeenAt 溢位
+- **防守**：proxy 語意對 cc-inside-cc 巢狀（same type 拒絕） / SessionEnd cleanup 對 multi-ref 同 SourcePID 的行為 / 為何不加 per-ref LastSeenAt
+- **體質**：`frame_ops.go` + `sweep.go` 是否過大需拆；type color 表應否 per-module；SubagentDots testing 是否過度（11x case）
+
+---
+
+## 10. Plan v2 relative v1 的變動摘要
+
+| v1 → v2 改動 | 原因 |
+|---|---|
+| SubagentRef 新增 `SourcePID` + `SourceStartTime` 欄位 | Codex #1: PID 重用 collision-safe |
+| Proxy 偵測改 PPID-first（+ §1.4 rewrite） | Codex #2: pane-only 是回歸 |
+| SessionEnd 清 proxy ref 分支新增（§1.5 rewrite） | Codex #1: 死 proxy 回收路徑 |
+| Idle sweep 改 `DeleteIfUnchanged`（新 store method） | Codex #3: TOCTOU race |
+| 移除 migration / boot hard-fail 討論；改 plain rebuild DB | 使用者決策 |
+| Commit 2+3 合併為 atomic schema upgrade | Codex #5: 每 commit 綠 |
+| `afterFrameCleared` 抽出；順便修 pid_dead/pid_reused 的 orphan watcher bug | 共用到 idle_timeout 路徑的意外收益 |
+| **確定拆 PR-2a + PR-2b**（§0 重寫） | Codex 建議 + 使用者確認 |
+| `PPID <= 1` guard | v2 自行補的邊界 |
+| 新增 IS5 `conditional DELETE race` 測試 | Codex #3 修正配套 |
+
+---
+
+## 11. 執行起點
+
+此 plan 送第二輪 codex adversarial review，確認 findings 收斂為 P2/P3 以下後：
+1. 主 session 派 subagent 跑 PR-2a commits 1-5
+2. PR-2a codex 兩輪 review（標準 + 3 parallel）→ 修 → merge → bump alpha.218（CHANGELOG 紅字）
+3. 主 session 從 main rebase 開 worktree `lights-phase-2b`，派 subagent 跑 PR-2b commits 6-10
+4. PR-2b codex 兩輪 review → 修 → merge → bump alpha.219
+5. 更新 `kickoff_lights_rebuild.md` 標 Phase 2 ✅，下一步 Phase 3

--- a/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
+++ b/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
@@ -1,6 +1,7 @@
-# Phase 2 TDD Plan v5 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
+# Phase 2 TDD Plan v6 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
 
-- **Date**: 2026-04-24（v1→v2: `review-mobwvdpq-w6kftz`; v2→v3: `review-mobxgl16-mfkzav`; v3→v4: `review-mocgelr5-z0v0a4`; v4→v5: `review-mocgnzun-lu31px`）
+- **Date**: 2026-04-24（v1→v2: `review-mobwvdpq-w6kftz`; v2→v3: `review-mobxgl16-mfkzav`; v3→v4: `review-mocgelr5-z0v0a4`; v4→v5: `review-mocgnzun-lu31px`; v5→v6: `review-mocgvia3-yesygj`）
+- **狀態**: v5 收斂 no P1（proxy/sweep semantics ✅）；v6 修 SPA 測試 scope P2 → **ship-ready 門檻達成**
 - **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §6
 - **Worktree**: `lights-phase-2`（branch `worktree-lights-phase-2`）
 - **依賴**: Phase 1（merged at `d1d60b2c`）+ Hook Events PR #616（merged at `fd9f8f8f`, alpha.217）
@@ -534,19 +535,22 @@ interface Props {
 - `internal/agent/status.go` 除 NormalizedEvent.Subagents 型別
 - `/api/agent/monitor/*` endpoint shape（Phase 5 Inspector 統一）
 
-**SPA 允許改動**（v3 修正 — v2 scope 遺漏 3 檔）：
+**SPA 允許改動**（v3 修正 — v2 scope 遺漏 3 檔；v6 補齊既有測試檔）：
 
 | PR | 檔案 | 改動性質 |
 |---|---|---|
 | PR-2a | `spa/src/stores/useAgentStore.ts` | SubagentRef type + Record 升級 |
-| PR-2a | `spa/src/components/*.test.tsx`、`spa/src/hooks/*.test.ts` | seed 升級（subagents 型別） |
+| **PR-2a v6-new** | `spa/src/stores/useAgentStore.test.ts` | string[] fixture / `event.subagents: ['agent-A']` 等 assertion 升級為 `SubagentRef[]`（含 L79/124/128/134/138/149/173/205/275/283/295 等 fixture 點） |
+| PR-2a | `spa/src/components/*.test.tsx`、`spa/src/hooks/*.test.ts` | 其他含 subagents seed 的測試 seed 升級 |
 | PR-2b | `spa/src/components/SubagentDots.tsx` | API + type color + proxy outline |
 | PR-2b | `spa/src/components/SubagentDots.test.tsx` | 新檔測試 |
 | PR-2b | `spa/src/components/TabIcon.tsx` | prop count → refs |
 | PR-2b | `spa/src/components/SortableTab.tsx` | prop count → refs（含 line 43/92/132 三處） |
+| PR-2b | `spa/src/components/SortableTab.test.tsx` | prop 升級 + proxy outline case |
 | PR-2b | `spa/src/features/workspace/components/InlineTab.tsx` | prop count → refs（line 42/111 轉介） |
+| **PR-2b v6-new** | `spa/src/features/workspace/components/InlineTab.test.tsx` | prop 升級 + prop-wiring 驗證 |
 | PR-2b | `spa/src/features/workspace/lib/renderInlineTabIcon.tsx` | 三處 SubagentDots 呼叫改吃 refs |
-| PR-2b | `spa/src/hooks/useTabDisplay.ts` | 回傳 subagentRefs |
+| **PR-2b v6-new** | `spa/src/features/workspace/lib/renderInlineTabIcon.test.tsx` | 三 render 模式（dot/iconDot/badge）驗證 refs 流到 SubagentDots |
 
 其餘 SPA 檔案不動。
 
@@ -652,20 +656,19 @@ interface Props {
 ### 2.9 SPA 測試升級（PR-2a + PR-2b）
 
 **PR-2a**：所有 seed `subagents: {}` / `subagents: { key: [...] }` 的測試檔升級 mock 為 `SubagentRef[]`
+  - **`useAgentStore.test.ts`**（v6-new；核心 store contract 測試，含 ~15 個 string-array fixture 需升級）
   - `SortableTab.test.tsx`（seed 改；prop 還是吃 subagentCount: number —— PR-2b 再改）
   - `StatusBar.test.tsx` / `TerminalView.test.tsx` / `HookModuleCard.test.tsx`
   - `useNotificationDispatcher.test.ts` / `useTabDisplay.test.ts`（line 160 的 `as never` cast 改為正規 SubagentRef）
 
-**PR-2b**（v3 擴充）：
+**PR-2b**（v3 擴充 + v6 補）：
 - `SubagentDots.test.tsx`（新檔）：
   - `TestSubagentDots_Count`：refs 1/2/3 → 對應 dot 數
   - `TestSubagentDots_TypeColors`：三家 type → 三個不同 backgroundColor
   - `TestSubagentDots_ProxyOutline`：ref with `is_proxy:true` → border 1px + backgroundColor transparent；`is_proxy:false/undefined` → solid background
 - `SortableTab.test.tsx`：把 prop 從 `subagentCount: N` 改為 `subagentRefs: SubagentRef[N]`；新加一個 case `subagentRefs` 含 `is_proxy:true` ref → 渲染 outline dot
-- `InlineTab.test.tsx`（若存在，否則新建）：同上，驗證 prop 從 count → refs 接起
-- `renderInlineTabIcon.test.tsx`（若存在，否則新建）：三個 render 模式（dot/iconDot/badge）都驗證 proxy outline 能流到 SubagentDots
-
-**若 `InlineTab.test.tsx` / `renderInlineTabIcon.test.tsx` 不存在**：不為 PR-2b 強求新建（零覆蓋的檔案不要為測試而開）；由 SortableTab.test.tsx + SubagentDots.test.tsx 覆蓋 prop-wiring 正確性即可。Subagent 執行時發現檔案不存在，在 PR description 明示「無既有測試，新增覆蓋 by SubagentDots + SortableTab」。
+- **`InlineTab.test.tsx`**（v6-new；檔案已存在，~11 KB）：prop 從 `subagentCount` 改為 `subagentRefs`；補一個 proxy outline prop-wiring case
+- **`renderInlineTabIcon.test.tsx`**（v6-new；檔案已存在，~2.5 KB）：三個 render 模式（dot/iconDot/badge）驗證 `subagentRefs` 被正確傳給 `<SubagentDots refs={...}>`；補 proxy outline case
 
 ---
 
@@ -765,6 +768,7 @@ interface Props {
 | `internal/module/agent/handler_test.go` | HB1 + 既有 seed | +60 |
 | `internal/module/agent/sweep_test.go` | 既有 seed 改（引入 SubagentRef） | +15 |
 | `spa/src/stores/useAgentStore.ts` | SubagentRef + Record 型別 | +12 |
+| `spa/src/stores/useAgentStore.test.ts` | v6-new：string[] fixtures 升級為 SubagentRef[] (~15 fixture 點) | ~40 |
 | `spa/src/components/*.test.tsx` (6 檔) | seed 改 | ~35 |
 | `spa/src/hooks/*.test.ts` (2 檔) | seed 改 | ~12 |
 | `docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md` | 本檔 | +550 |
@@ -787,9 +791,11 @@ interface Props {
 | `spa/src/components/SortableTab.tsx` | prop subagentCount → subagentRefs（兩處 TabIcon 調用） | ~10 |
 | `spa/src/components/SortableTab.test.tsx` | prop 升級 + proxy outline case | +25 |
 | `spa/src/features/workspace/components/InlineTab.tsx` | prop count → refs（line 42/111） | ~6 |
+| `spa/src/features/workspace/components/InlineTab.test.tsx` | v6-new：prop 升級 + proxy outline prop-wiring case | ~30 |
 | `spa/src/features/workspace/lib/renderInlineTabIcon.tsx` | 三處 SubagentDots 呼叫 | ~12 |
+| `spa/src/features/workspace/lib/renderInlineTabIcon.test.tsx` | v6-new：三 render 模式 + proxy outline case | ~40 |
 | `spa/src/hooks/useTabDisplay.ts` | 回傳 subagentRefs 欄位 | ~8 |
-| **PR-2b 合計** | | **~1000 行** |
+| **PR-2b 合計** | | **~1070 行** |
 
 ### 總計
 
@@ -967,6 +973,17 @@ interface Props {
 | **§3 Commit 7 TDD gate 改 PR1-PR15** | Codex v4 #3: v4 新增 PR13/PR14 未進 commit 必跑集合 |
 | **§7 PR-2b 驗收列明必跑總集合** 27 測試（F4-F6 / PR1-PR15 / SE1-SE3 / IS1-IS5 / HB2） | Codex v4 #3: v4 驗收仍寫「19 測試」舊數 |
 | **新增 PR15 `AbortsWalkOnStartTimeReadError`** | v4 #1 修正的回歸測試 |
+
+### v5 → v6
+
+Verdict: **v5 收斂 no P1**（proxy/sweep semantics 確認 ship-ready）；v6 處理剩餘 2 個 P2（文件一致性）。
+
+| 改動 | 原因 |
+|---|---|
+| **PR-2a scope 補 `useAgentStore.test.ts`** | Codex v5 #1: 既存 store test 含 string-array fixtures（`subagents: ['agent-A']` 等 ~15 處）；PR-2a upgrade 必動但 §1.14 未列 |
+| **PR-2b scope 補 `InlineTab.test.tsx`、`renderInlineTabIcon.test.tsx`** | Codex v5 #2: 兩檔真實存在（~11KB + ~2.5KB），prop 從 count → refs 改必動，§4/§7 diff gate 未列會互斥 |
+| §4 PR-2a/2b 行數更新：PR-2a +~40 行、PR-2b +~70 行 | 補三個測試檔的擴展 |
+| §2.9 移除「若存在否則新建」措辭 | 兩檔已確認存在；措辭含糊會讓 subagent 誤判 |
 
 ---
 

--- a/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
+++ b/docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md
@@ -1,6 +1,6 @@
-# Phase 2 TDD Plan v2 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
+# Phase 2 TDD Plan v3 — L3 Subagent 升級 + Proxy + Frame Idle Sweep
 
-- **Date**: 2026-04-24（v1 → v2 revision after codex adversarial review `review-mobwvdpq-w6kftz`）
+- **Date**: 2026-04-24（v1 → v2 revision after codex review `review-mobwvdpq-w6kftz`; v2 → v3 after codex review `review-mobxgl16-mfkzav`）
 - **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §6
 - **Worktree**: `lights-phase-2`（branch `worktree-lights-phase-2`）
 - **依賴**: Phase 1（merged at `d1d60b2c`）+ Hook Events PR #616（merged at `fd9f8f8f`, alpha.217）
@@ -9,22 +9,36 @@
 
 ## 0. 拆分策略（已確定）
 
-### PR-2a — Schema + 型別升級（純骨架，無新行為）
+### PR-2a — Schema + Wire Breaking Upgrade（行為語意不變但破壞儲存與 wire 相容）
 
-- `SubagentRef` 型別定義（含 SourcePID/SourceStartTime/IsProxy 等欄位，但本 PR **不會有任何 ref.IsProxy=true 產生**）
+**定性**（對 codex review v2 #3 修正）：本 PR **不是** pure refactor。它包含兩個 user-visible breaking change：
+
+1. **On-disk schema break**：`agent_frames.subagents_json` 格式從 `["id"]` 改 `[{id, type, started_at, source_pid, source_start_time, is_proxy?}]`；升級後舊 row 讀取會 error，需手動重建 DB
+2. **WS wire break**：`NormalizedEvent.subagents` 型別從 `string[]` 改 `SubagentRef[]`；daemon + SPA 要**一起升級**，Electron dev update skew 期間可能出現 subagents UI 空白
+
+**Product 語意層**：行為不變（SubagentStart/Stop 走既有路徑、產生 IsProxy=false 的 native ref；SubagentDots 維持 count-based API；proxy 偵測 / idle sweep / 新視覺都在 PR-2b）。
+
+**Reviewer 注意**：
+- 這是 staging PR — 先把 schema + wire 立好，PR-2b 才能產生 `IsProxy=true` 資料
+- Rollout：merge → bump alpha.218 → 使用者**先重建 DB** → 重啟 daemon → SPA reload 一次
+- Rollback：revert PR-2a + 重建 DB 回舊 schema（alpha 允許）
+
+**範圍內**：
+- `SubagentRef` 型別定義（含 SourcePID/SourceStartTime/IsProxy 等欄位）
 - Frame.Subagents / SessionProjection.Subagents / m.subagents map / NormalizedEvent.Subagents / SPA store 型別同步升級
 - `updateSubagents` 簽名升級，行為語意不變（SubagentStart 新增、SubagentStop 移除）
 - SPA SubagentDots **維持 count-based API**（新視覺留 PR-2b）
-- **行為不變**：SubagentStart/Stop 走既有路徑，產生 `SubagentRef{ID, Type=frame.AgentType, StartedAt=broadcastTs}` — IsProxy 永遠 false
+- SPA 所有 count-based consumer 的測試 seed 升級（subagents Record 型別）
 - 預估 ~600 行（含測試 + plan）
 
 ### PR-2b — Proxy 偵測 + Idle Sweep + SubagentDots 新視覺
 
-- `applyFrameEvent` PPID-first proxy 偵測分支（SessionStart only）
+- `applyFrameEvent` **PPID 祖先鏈** proxy 偵測分支（SessionStart only，深度上限 5）
 - SessionEnd proxy cleanup（從 parent.Subagents 移匹配 SourcePID+SourceStartTime 的 ref）
 - Frame idle sweep（1h 閾值 + conditional DELETE `DeleteIfUnchanged` + orphan watcher clean）
 - SubagentDots 視覺：type color（cc 藍 / codex 黃 / opencode 橘）+ proxy outline
-- 預估 ~450 行（含測試）
+- **SPA scope 擴充**（對 codex review v2 #1 修正）：`SortableTab.tsx` / `InlineTab.tsx` / `renderInlineTabIcon.tsx` 全數改吃 refs（非只 TabIcon）
+- 預估 ~900 行（含測試）
 
 PR-2a merge → 單獨 bump alpha → PR-2b 在 PR-2a 基礎上開 branch。
 
@@ -137,30 +151,58 @@ ref := agentpkg.SubagentRef{
 }
 ```
 
-### 1.4 Proxy 偵測分支（PR-2b 新增，PPID-first）
+### 1.4 Proxy 偵測分支（PR-2b 新增，PPID 祖先鏈 walk）
+
+**v2 → v3 改動**（對 codex review v2 #2 修正）：原 v2 寫「PPID 單層 match」，但 codex-companion.mjs 中介使得 codex 的 PPID 指向 companion 而非 cc，單層必然 miss Phase 2 的 headline UX（使用者期待 `cc → /codex:*` collapse 到 cc frame）。v3 改走**有限深度祖先鏈 walk**（上限 5 層），在 pane 範圍內尋找合適 parent。
 
 在 `applyFrameEvent` 當前「建/更 frame」主路徑**之前**插入 proxy 判斷：
 
-**前置取得 parent**（重用既有程式碼路徑）：
+**前置**：觸發條件 1-2 成立才進 walk（省 syscall）：
+1. `req.EventName == "SessionStart"` — 只對 SessionStart 偵測 proxy
+2. `frame == nil` — sender identity (pid, start) 無既有 frame
+
+**Walk 邏輯**（helper `findProxyParent`）：
+
 ```go
-info, err := readProcessInfoFn(req.SenderPID)  // 已在現有 frame_ops 取得
-if err != nil {
-    return nil, FrameTraceMeta{}, err
-}
-parentCandidate, err := m.frames.FindByPanePID(req.TmuxPaneID, info.PPID)
-if err != nil {
-    return nil, FrameTraceMeta{}, err
+const proxyMaxDepth = 5
+
+func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
+    info, err := readProcessInfoFn(req.SenderPID)
+    if err != nil {
+        return nil, nil // 讀不到 sender proc info，放棄 proxy walk，fallback 建新 frame
+    }
+    ppid := info.PPID
+    for depth := 0; depth < proxyMaxDepth; depth++ {
+        if ppid <= 1 {
+            return nil, nil // 走到 init / launchd
+        }
+        candidate, err := m.frames.FindByPanePID(req.TmuxPaneID, ppid)
+        if err != nil {
+            return nil, err
+        }
+        if candidate != nil && candidate.AgentType != req.AgentType && isPidAliveFn(candidate.PID) {
+            return candidate, nil // 命中：同 pane、跨 agent type、存活
+        }
+        // 沒命中，往上一層
+        ancestorInfo, err := readProcessInfoFn(ppid)
+        if err != nil {
+            return nil, nil // partial chain，放棄
+        }
+        if ancestorInfo.PPID == ppid {
+            return nil, nil // 自環保護
+        }
+        ppid = ancestorInfo.PPID
+    }
+    return nil, nil // 超過深度上限
 }
 ```
 
-**觸發條件**（**全部成立才算 proxy**）：
-1. `req.EventName == "SessionStart"`（目前只對 SessionStart 偵測 proxy；其他事件走 legacy 路徑）
-2. `frame == nil`（sender identity (pid, start) 無既有 frame，表「新來的」）
-3. `parentCandidate != nil` — **PPID 單層在同 pane 找到 frame**
-4. `parentCandidate.AgentType != req.AgentType` — 跨 agent type
-5. `isPidAliveFn(parentCandidate.PID)` — parent 還活著（避免掛殭屍）
+**觸發條件**（全部成立才算 proxy）：
+1. `req.EventName == "SessionStart"`
+2. `frame == nil`
+3. `findProxyParent(req)` 回 non-nil frame
 
-**命中行為**：
+**命中行為**（不變）：
 - 組 `ref`:
   ```go
   ref := agentpkg.SubagentRef{
@@ -172,23 +214,21 @@ if err != nil {
       IsProxy:         true,
   }
   ```
-- `parentCandidate.Subagents = updateSubagents(parentCandidate.Subagents, "SubagentStart", ref)`
-- `parentCandidate.LastSeenAt = broadcastTs`
-- `m.frames.Upsert(*parentCandidate)` — **不建新 frame**
+- `parent.Subagents = updateSubagents(parent.Subagents, "SubagentStart", ref)`
+- `parent.LastSeenAt = broadcastTs`
+- `m.frames.Upsert(*parent)` — **不建新 frame**
 - Trace meta：`Decision="updated_frame", Reason="proxy_subagent_attached"`，`FrameID/ParentFrameID` 指 parent
 - projection 回傳 parent pane 的投影
 
-**不命中條件 → fallback 建新 frame（既有路徑）**：
-- `req.EventName != "SessionStart"` → 走既有 legacy（其他事件不會 trigger proxy）
-- `frame != nil` → 已有 frame，走 Upsert 更新
-- `parentCandidate == nil` → PPID 單層找不到 frame；**不用 pane-only fallback**（codex #2 指出的回歸）
-- `parentCandidate.AgentType == req.AgentType` → 真的是同類 re-session（例 cc exit 後 cc 再起）
-- parent PID 已死 → 走既有建 frame 路徑（不掛殭屍；死 parent 交由 sweep 清）
+**不命中條件 → fallback 建新 frame**：
+- 條件 1/2 任一不成立
+- `findProxyParent` 回 nil（包含：所有祖先都無 frame / 有 frame 但同 type / parent 已死 / 超過深度 / 讀 proc 錯）
 
-**PPID 單層的 trade-off**（對 codex #2 + 使用者決策 A 的註記）：
-- codex-companion 若是 cc 的直接 child，則 codex 的 PPID = codex-companion PID，再上一階才是 cc；單層 PPID match 可能找不到 cc frame
-- Phase 2 **接受此限制**：PPID 單層命中 ≥ 50% case 可驗證 UX；若實測顯示 codex-companion 中介造成 proxy 大量失手，Phase 3/4 再加 PPID tree walk（spec §11-5 已保留空間）
-- 失手時不影響功能 — 走 fallback 建 codex frame（與目前行為一致，只是沒命中 proxy）
+**Walk 安全邊界**：
+- **深度 5**：cover `codex → codex-companion → cc`（2 層內）；留 3 層 buffer 應付複雜 shell wrapper / tmux control mode。超過 5 層表示極端嵌套，不為該罕見 case 付成本
+- **Pane 過濾**：每層都走 `FindByPanePID(paneID, ppid)`，跨 pane 的 process（例 tmux server、shell）即使 PPID 撞也不命中
+- **Syscall 成本**：最多 5 次 `readProcessInfoFn`（最壞 ~5 次 open+read `/proc/<pid>/stat` 或 `ps`），只在 SessionStart 觸發，非 hot path
+- **自環保護**：`ancestorInfo.PPID == ppid` 防止 kernel 回報自我 parent（罕見但 defensive）
 
 **非 SessionStart 的 proxy 事件**：Phase 2 不處理。觀察實際行為若 codex proxy 沒先送 SessionStart 再開工，Phase 3/4 補。
 
@@ -433,9 +473,23 @@ interface Props {
 
 **useTabDisplay.ts**（PR-2a 先改 `subagentCount = refs.length`，保 TabIcon 既有 prop；PR-2b 回傳 `subagentRefs`）：
 - PR-2a：`useAgentStore((s) => s.subagents[ck]?.length ?? 0)` 改為從 `SubagentRef[]?.length`（型別自動變，行為不變）
-- PR-2b：新增 `subagentRefs` 回傳欄位
+- PR-2b：新增 `subagentRefs` 回傳欄位（可與 subagentCount 並存或取代，依呼叫點）
+
+**補充 SPA consumer 更新**（對 codex review v2 #1 修正 — v2 遺漏 scope）：
+
+以下檔案在 PR-2b **也必須改**，否則 TypeScript 編譯失敗：
+
+| 檔案 | v3 改動 |
+|---|---|
+| `spa/src/components/SortableTab.tsx` | `subagentCount` prop → `subagentRefs`；兩處 TabIcon 調用（line 92 + 132）傳 refs |
+| `spa/src/features/workspace/components/InlineTab.tsx` | `subagentCount` prop → `subagentRefs`（line 42, 111 轉介）|
+| `spa/src/features/workspace/lib/renderInlineTabIcon.tsx` | 三處 `<SubagentDots count={subagentCount} />` 改 `<SubagentDots refs={subagentRefs} />`（dot/iconDot/badge 三模式） |
 
 **SubagentDots 測試**：保留既有 count-based case 概念（refs 長度取代 count input），新加兩個 case — type 色差 + proxy outline。
+
+**SortableTab / InlineTab / renderInlineTabIcon 測試**（PR-2b）：
+- 既有 snapshot / render assertion 若吃 `subagentCount` prop，改為 `subagentRefs` 並 seed `SubagentRef[]`
+- 新增：測 `subagentRefs` 帶 1 個 `is_proxy:true` 的 ref → 渲染 outline dot（validate prop wiring 有接起來）
 
 ### 1.14 零改動邊界
 
@@ -447,8 +501,23 @@ interface Props {
 - `internal/store/frames.go` SQL schema（column 不變；JSON shape 變）
 - `internal/module/agent/verify.go` / `upload*.go` / `monitor.go` / `statusline*.go`
 - `internal/agent/status.go` 除 NormalizedEvent.Subagents 型別
-- `spa/src/**` 除 `useAgentStore.ts` / `SubagentDots.tsx` / `TabIcon.tsx` / `useTabDisplay.ts` + 測試 seed 檔
 - `/api/agent/monitor/*` endpoint shape（Phase 5 Inspector 統一）
+
+**SPA 允許改動**（v3 修正 — v2 scope 遺漏 3 檔）：
+
+| PR | 檔案 | 改動性質 |
+|---|---|---|
+| PR-2a | `spa/src/stores/useAgentStore.ts` | SubagentRef type + Record 升級 |
+| PR-2a | `spa/src/components/*.test.tsx`、`spa/src/hooks/*.test.ts` | seed 升級（subagents 型別） |
+| PR-2b | `spa/src/components/SubagentDots.tsx` | API + type color + proxy outline |
+| PR-2b | `spa/src/components/SubagentDots.test.tsx` | 新檔測試 |
+| PR-2b | `spa/src/components/TabIcon.tsx` | prop count → refs |
+| PR-2b | `spa/src/components/SortableTab.tsx` | prop count → refs（含 line 43/92/132 三處） |
+| PR-2b | `spa/src/features/workspace/components/InlineTab.tsx` | prop count → refs（line 42/111 轉介） |
+| PR-2b | `spa/src/features/workspace/lib/renderInlineTabIcon.tsx` | 三處 SubagentDots 呼叫改吃 refs |
+| PR-2b | `spa/src/hooks/useTabDisplay.ts` | 回傳 subagentRefs |
+
+其餘 SPA 檔案不動。
 
 ---
 
@@ -498,17 +567,22 @@ interface Props {
 
 ### 2.5 Proxy 偵測整合（PR-2b）
 
-`internal/module/agent/frame_ops_test.go`:
+`internal/module/agent/frame_ops_test.go`：mock `readProcessInfoFn` 與 `isPidAliveFn` 模擬 PPID 鏈。
 
 | # | 名稱 | 情境 | 斷言 |
 |---|---|---|---|
-| PR1 | `TestProxySubagent_CodexHookWithCCPPIDAttachesToCCParent` | cc SessionStart (PID 100, pane %5) → codex SessionStart (PID 200, PPID 100, pane %5) | pane 有 1 frame（cc），cc.Subagents 有 ref `{Type:"codex", IsProxy:true, SourcePID:200, SourceStartTime:"..."}` |
-| PR2 | `TestProxySubagent_SkipsWhenPPIDNotMatchFrame` | codex SessionStart (PPID=9999, pane 無 frame with PID 9999) | 建新 codex frame（fallback），不 proxy |
-| PR3 | `TestProxySubagent_SkipsWhenParentSameType` | cc SessionStart → cc SessionStart 不同 pid/start，PPID 指第一個 cc | 建新 cc frame，不 proxy（same type） |
-| PR4 | `TestProxySubagent_SkipsWhenParentPidDead` | cc frame 存在但 isPidAliveFn 回 false for cc PID → codex SessionStart PPID=cc.PID | 建新 codex frame，不 proxy |
-| PR5 | `TestProxySubagent_SkipsWhenEventNotSessionStart` | cc frame 存在 → codex UserPromptSubmit PPID=cc.PID | 走 legacy 路徑（目前可能建 frame 可能不建，依 DeriveStatus result；不偏移現狀）；驗證不走 proxy 路徑 |
-| PR6 | `TestProxySubagent_TraceMetaCorrect` | PR1 情境 | trace meta decision="updated_frame"、reason="proxy_subagent_attached"、FrameID=parent.FrameID |
-| PR7 | `TestProxySubagent_DoesNotDoubleAttachOnReHook` | PR1 後再送同 codex SessionStart (same PID+StartTime) | cc.Subagents 仍 1 筆，StartedAt 為首次時間 |
+| PR1 | `TestProxySubagent_DirectPPIDAttachesToCCParent` | cc frame PID 100 in pane %5；codex SessionStart PID 200 PPID 100 | pane 有 1 frame（cc），cc.Subagents 有 ref `{Type:"codex", IsProxy:true, SourcePID:200}` |
+| **PR2 new** | `TestProxySubagent_TreeWalkThroughCodexCompanion` | cc frame PID 100；codex SessionStart PID 300 PPID 200（companion）；readProcessInfoFn(200) 回 PPID=100 | Tree walk 第 2 層命中 cc，掛 proxy ref；pane 仍 1 frame |
+| **PR3 new** | `TestProxySubagent_TreeWalkDepthLimit` | cc frame PID 100；codex SessionStart PID 600 with chain 600 → 500 → 400 → 300 → 200 → 100 (深度 5)；第 5 層才到 cc | 不命中 proxy（超過 maxDepth）— 建新 codex frame；cc 不受影響 |
+| PR4 | `TestProxySubagent_SkipsWhenNoAncestorHasFrame` | codex SessionStart PPID 9999（pane 無 frame with PID 9999, walk 到 init） | 建新 codex frame（fallback），不 proxy |
+| PR5 | `TestProxySubagent_SkipsWhenParentSameType` | cc frame PID 100；另一 cc SessionStart PID 200 PPID 100 | 建新 cc frame，不 proxy（same type） |
+| PR6 | `TestProxySubagent_SkipsWhenParentPidDead` | cc frame PID 100 存在但 isPidAliveFn(100)=false；codex SessionStart PPID=100 | 建新 codex frame，不 proxy（parent 死） |
+| PR7 | `TestProxySubagent_SkipsWhenEventNotSessionStart` | cc frame 存在 → codex UserPromptSubmit PPID=cc.PID | 走 legacy 路徑（不走 proxy） |
+| PR8 | `TestProxySubagent_TraceMetaCorrect` | PR1 情境 | trace meta decision="updated_frame"、reason="proxy_subagent_attached"、FrameID=parent.FrameID |
+| PR9 | `TestProxySubagent_DoesNotDoubleAttachOnReHook` | PR1 後再送同 codex SessionStart (same PID+StartTime) | cc.Subagents 仍 1 筆，StartedAt 為首次時間 |
+| **PR10 new** | `TestProxySubagent_CrossPaneAncestorNotMatched` | cc frame in pane %5 PID 100；codex SessionStart in pane %7 PID 200 PPID 100 | pane %7 建新 codex frame，cc 在 %5 不受影響（PaneID filter 驗證） |
+| **PR11 new** | `TestProxySubagent_SelfCycleGuard` | codex SessionStart PID 200，readProcessInfoFn(200).PPID=200（自環） | 不 panic，不無限 loop，建新 codex frame |
+| **PR12 new** | `TestProxySubagent_PartialChainOnReadError` | codex SessionStart PPID 200；readProcessInfoFn(200) 回 error | 放棄 walk，fallback 建新 codex frame |
 
 ### 2.6 SessionEnd Proxy Cleanup（PR-2b）
 
@@ -543,12 +617,21 @@ interface Props {
 
 ### 2.9 SPA 測試升級（PR-2a + PR-2b）
 
-- **PR-2a**：所有 seed `subagents: {}` / `subagents: { key: [...] }` 的測試檔升級 mock 為 `SubagentRef[]`
-  - `SortableTab.test.tsx` / `StatusBar.test.tsx` / `TerminalView.test.tsx` / `HookModuleCard.test.tsx` / `useNotificationDispatcher.test.ts` / `useTabDisplay.test.ts`
-- **PR-2b**：`SubagentDots.test.tsx`（新檔）：
+**PR-2a**：所有 seed `subagents: {}` / `subagents: { key: [...] }` 的測試檔升級 mock 為 `SubagentRef[]`
+  - `SortableTab.test.tsx`（seed 改；prop 還是吃 subagentCount: number —— PR-2b 再改）
+  - `StatusBar.test.tsx` / `TerminalView.test.tsx` / `HookModuleCard.test.tsx`
+  - `useNotificationDispatcher.test.ts` / `useTabDisplay.test.ts`（line 160 的 `as never` cast 改為正規 SubagentRef）
+
+**PR-2b**（v3 擴充）：
+- `SubagentDots.test.tsx`（新檔）：
   - `TestSubagentDots_Count`：refs 1/2/3 → 對應 dot 數
   - `TestSubagentDots_TypeColors`：三家 type → 三個不同 backgroundColor
   - `TestSubagentDots_ProxyOutline`：ref with `is_proxy:true` → border 1px + backgroundColor transparent；`is_proxy:false/undefined` → solid background
+- `SortableTab.test.tsx`：把 prop 從 `subagentCount: N` 改為 `subagentRefs: SubagentRef[N]`；新加一個 case `subagentRefs` 含 `is_proxy:true` ref → 渲染 outline dot
+- `InlineTab.test.tsx`（若存在，否則新建）：同上，驗證 prop 從 count → refs 接起
+- `renderInlineTabIcon.test.tsx`（若存在，否則新建）：三個 render 模式（dot/iconDot/badge）都驗證 proxy outline 能流到 SubagentDots
+
+**若 `InlineTab.test.tsx` / `renderInlineTabIcon.test.tsx` 不存在**：不為 PR-2b 強求新建（零覆蓋的檔案不要為測試而開）；由 SortableTab.test.tsx + SubagentDots.test.tsx 覆蓋 prop-wiring 正確性即可。Subagent 執行時發現檔案不存在，在 PR description 明示「無既有測試，新增覆蓋 by SubagentDots + SortableTab」。
 
 ---
 
@@ -597,9 +680,9 @@ interface Props {
 - 綠：`frames.go` 新增 method
 - 跑 `go test ./internal/store/...` 綠
 
-#### Commit 7 — `feat(module/agent): detect proxy subagents via PPID match`
-- 紅：PR1-PR7 → 失敗
-- 綠：`frame_ops.go` applyFrameEvent 加 proxy 偵測分支（PPID-first）+ proxyIDFor helper
+#### Commit 7 — `feat(module/agent): detect proxy subagents via PPID ancestor walk`
+- 紅：PR1-PR12 → 失敗
+- 綠：`frame_ops.go` applyFrameEvent 加 proxy 偵測分支 + `findProxyParent` helper（depth 5 PPID walk）+ proxyIDFor helper
 - 跑 `go test ./internal/module/agent/...` 綠
 
 #### Commit 8 — `feat(module/agent): remove proxy ref on SessionEnd`
@@ -613,8 +696,14 @@ interface Props {
 - 跑 `go test ./internal/module/agent/...` 綠
 
 #### Commit 10 — `feat(spa): SubagentDots takes SubagentRef[] with type color + proxy outline`
-- 紅：SubagentDots.test.tsx 三個 case → 失敗
-- 綠：SubagentDots API 升級；TabIcon 改吃 refs；useTabDisplay 回傳 refs
+- 紅：SubagentDots.test.tsx 三個 case + SortableTab.test.tsx proxy outline case → 失敗
+- 綠（同 commit 完成，避免 compile 破）：
+  - SubagentDots API `count` → `refs` 升級
+  - TabIcon prop `subagentCount` → `subagentRefs`
+  - SortableTab prop `subagentCount` → `subagentRefs`（兩處 TabIcon 調用）
+  - InlineTab prop `subagentCount` → `subagentRefs`（line 42/111）
+  - renderInlineTabIcon prop + 三處 `<SubagentDots count={...} />` → `<SubagentDots refs={...} />`
+  - useTabDisplay 回傳 `subagentRefs`
 - 跑 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
 
 #### Commit 11 — `docs: phase 2 plan retrospective notes`（可選）
@@ -653,20 +742,26 @@ interface Props {
 |---|---|---|
 | `internal/store/frames.go` | `DeleteIfUnchanged` method | +20 |
 | `internal/store/frames_test.go` | F4-F6 | +50 |
-| `internal/module/agent/frame_ops.go` | proxy 偵測分支 + `removeProxyRefForSender` | +100 |
-| `internal/module/agent/frame_ops_test.go` | PR1-PR7 + SE1-SE3 | +240 |
+| `internal/module/agent/frame_ops.go` | proxy 偵測分支 + `findProxyParent`（tree walk depth 5）+ `removeProxyRefForSender` | +130 |
+| `internal/module/agent/frame_ops_test.go` | PR1-PR12 + SE1-SE3（12 proxy + 3 session end = 15 case，含 tree walk mocks） | +360 |
 | `internal/module/agent/sweep.go` | nowFn + threshold + 第三條規則 + afterFrameCleared 抽出 + StopWatch fix | +50 |
 | `internal/module/agent/sweep_test.go` | IS1-IS5 | +160 |
 | `internal/module/agent/handler_test.go` | HB2 | +40 |
 | `spa/src/components/SubagentDots.tsx` | API + type color + proxy outline | +40 (-20) |
 | `spa/src/components/SubagentDots.test.tsx` | 新檔 3 case | +110 |
 | `spa/src/components/TabIcon.tsx` | count → refs | ~15 |
-| `spa/src/hooks/useTabDisplay.ts` | 回傳 subagentRefs | ~8 |
-| **PR-2b 合計** | | **~800 行** |
+| `spa/src/components/SortableTab.tsx` | prop subagentCount → subagentRefs（兩處 TabIcon 調用） | ~10 |
+| `spa/src/components/SortableTab.test.tsx` | prop 升級 + proxy outline case | +25 |
+| `spa/src/features/workspace/components/InlineTab.tsx` | prop count → refs（line 42/111） | ~6 |
+| `spa/src/features/workspace/lib/renderInlineTabIcon.tsx` | 三處 SubagentDots 呼叫 | ~12 |
+| `spa/src/hooks/useTabDisplay.ts` | 回傳 subagentRefs 欄位 | ~8 |
+| **PR-2b 合計** | | **~1000 行** |
 
 ### 總計
 
-**~1300 行 code**（不含 plan）— 比 v1 的 950 多 350 行主要是 proxy identity 欄位擴充、SessionEnd cleanup、DeleteIfUnchanged、afterFrameCleared 抽出、測試擴充。
+**~1500 行 code**（不含 plan）— 比 v2 的 1300 多 200 行主要是：
+- PPID tree walk `findProxyParent` helper + 3 個新 test case（PR2/PR3/PR10-PR12）
+- SPA scope 擴充到 5 檔（v2 遺漏 3 檔）
 
 ---
 
@@ -739,13 +834,15 @@ interface Props {
 | 風險 | 機率 | 影響 | 緩解 |
 |---|---|---|---|
 | 使用者升級後忘了重建 DB | 高 | daemon log noisy 500 | CHANGELOG 紅字 + bump PR description 明示；使用者重建即解 |
-| PPID 單層 match 命中率低（codex-companion 中介） | 中-高 | proxy 偵測大量 fallback 建新 frame | 接受 — Phase 2 以「能驗證 UX 為目標」；Phase 3/4 補 tree walk |
+| **v3：PPID tree walk 深度 5 不夠 cover 極端嵌套** | 低 | 少數 proxy case 仍 fallback 建新 frame | codex-companion 已知是 2 層內；深度 5 留 buffer；超出 case 極罕見，Phase 3/4 再調 |
+| **v3：PPID tree walk 讀 `/proc/<pid>/stat` 或 `ps` 成本** | 低 | 每次 SessionStart 最多 5 次 syscall | SessionStart 非 hot path；5 次 syscall 在 <1ms 級；非擴展問題 |
+| **v3：tree walk 對 kernel 上報自環或 PPID=0 的穩健性** | 低 | goroutine 卡 loop | `info.PPID == ppid` self-cycle guard + `<=1` 終止；PR11 測試覆蓋 |
 | Idle 1h 太短（使用者長跑任務） | 低 | 活躍 frame 誤清 | LastSeenAt 由 hook 刷新；真正長跑有 activity watcher 維持；觀察 1-2 週再調 |
 | SubagentDots 新視覺 a11y 退化 | 低 | 色盲看不出 proxy | outline vs solid 雙通道（形狀+顏色），符合 WCAG |
 | 測試 seed 遺漏 CI 紅 | 中 | subagent 反覆修 | Commit 5 專跑 SPA seed sweep；主 session push 前跑全測 |
 | SPA + daemon skew（Electron dev update 時差） | 中 | subagents 欄位型別短暫 mismatch | 使用者單人，協調一次升級 |
 | DeleteIfUnchanged 在 SQLite 的 race 邊界 | 低 | `DELETE ... WHERE` 在 SQLite 下是 atomic，行為可靠 | modernc.org/sqlite 的 serialization 保證；IS5 測試覆蓋 |
-| PPID 為 0（init process）導致 `FindByPanePID(0)` 誤中 | 低 | 不可能（init 不會是 pane 內 frame） | 但加 guard：`if info.PPID <= 1 { parentCandidate = nil }` |
+| **v3：PR-2b SPA 改動橫跨 5 檔 + 4 props** | 中 | commit 10 一口氣改多檔，容易漏 | atomic commit 10 確保 compile 綠；type check 會抓漏 |
 
 ---
 
@@ -781,20 +878,33 @@ interface Props {
 
 ---
 
-## 10. Plan v2 relative v1 的變動摘要
+## 10. Plan 版本變動摘要
 
-| v1 → v2 改動 | 原因 |
+### v1 → v2
+
+| 改動 | 原因 |
 |---|---|
-| SubagentRef 新增 `SourcePID` + `SourceStartTime` 欄位 | Codex #1: PID 重用 collision-safe |
-| Proxy 偵測改 PPID-first（+ §1.4 rewrite） | Codex #2: pane-only 是回歸 |
-| SessionEnd 清 proxy ref 分支新增（§1.5 rewrite） | Codex #1: 死 proxy 回收路徑 |
-| Idle sweep 改 `DeleteIfUnchanged`（新 store method） | Codex #3: TOCTOU race |
+| SubagentRef 新增 `SourcePID` + `SourceStartTime` 欄位 | Codex v1 #1: PID 重用 collision-safe |
+| Proxy 偵測改 PPID-first（+ §1.4 rewrite） | Codex v1 #2: pane-only 是回歸 |
+| SessionEnd 清 proxy ref 分支新增（§1.5 rewrite） | Codex v1 #1: 死 proxy 回收路徑 |
+| Idle sweep 改 `DeleteIfUnchanged`（新 store method） | Codex v1 #3: TOCTOU race |
 | 移除 migration / boot hard-fail 討論；改 plain rebuild DB | 使用者決策 |
-| Commit 2+3 合併為 atomic schema upgrade | Codex #5: 每 commit 綠 |
+| Commit 2+3 合併為 atomic schema upgrade | Codex v1 #5: 每 commit 綠 |
 | `afterFrameCleared` 抽出；順便修 pid_dead/pid_reused 的 orphan watcher bug | 共用到 idle_timeout 路徑的意外收益 |
-| **確定拆 PR-2a + PR-2b**（§0 重寫） | Codex 建議 + 使用者確認 |
+| 確定拆 PR-2a + PR-2b（§0 重寫） | Codex 建議 + 使用者確認 |
 | `PPID <= 1` guard | v2 自行補的邊界 |
-| 新增 IS5 `conditional DELETE race` 測試 | Codex #3 修正配套 |
+| 新增 IS5 `conditional DELETE race` 測試 | Codex v1 #3 修正配套 |
+
+### v2 → v3
+
+| 改動 | 原因 |
+|---|---|
+| **Proxy 偵測改 PPID 祖先鏈 walk**（depth=5，新 §1.4 rewrite + `findProxyParent` helper） | Codex v2 #2: 單層 PPID 對 codex-companion 架構太弱，會漏 Phase 2 headline UX |
+| **PR-2b SPA scope 擴充**：加 `SortableTab.tsx` / `InlineTab.tsx` / `renderInlineTabIcon.tsx`（§1.14 + §2.9 + §4） | Codex v2 #1: v2 scope 只列 TabIcon / useTabDisplay，實際 5 個 consumer 都吃 `subagentCount` |
+| **§0 PR-2a 改稱 "Schema + Wire Breaking Upgrade"**，拿掉「純骨架，無新行為」字樣 | Codex v2 #3: 不誠實；schema break + wire break 是實質 operational 行為 |
+| Proxy 測試從 PR1-PR7 擴到 PR1-PR12 | Tree walk 新增 3 case（companion hop / depth limit / self-cycle）+ 2 case（cross-pane / partial chain） |
+| `findProxyParent` helper 行數 +30；測試 +120 | Tree walk 實作複雜度 |
+| Commit 10 明列 SortableTab/InlineTab/renderInlineTabIcon 要一起改 | 避免 PR-2b 實作時漏 compile |
 
 ---
 

--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -32,7 +32,7 @@ type NormalizedEvent struct {
 	AgentType    string         `json:"agent_type"`
 	Status       string         `json:"status"`
 	Model        string         `json:"model,omitempty"`
-	Subagents    []string       `json:"subagents"`
+	Subagents    []SubagentRef  `json:"subagents"`
 	RawEventName string         `json:"raw_event_name"`
 	BroadcastTs  int64          `json:"broadcast_ts"`
 	Detail       map[string]any `json:"detail,omitempty"`

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -1,0 +1,16 @@
+package agent
+
+// SubagentRef identifies a subagent attached to a frame. Fields:
+//   - ID / Type / StartedAt: display identity
+//   - SourcePID / SourceStartTime: process identity for proxy refs (zero for
+//     native SubagentStart refs)
+//   - IsProxy: true when the ref was synthesized from a cross-agent-type hook
+//     (see spec §1.4)
+type SubagentRef struct {
+	ID              string `json:"id"`
+	Type            string `json:"type"`
+	StartedAt       int64  `json:"started_at"`
+	SourcePID       int    `json:"source_pid"`
+	SourceStartTime string `json:"source_start_time"`
+	IsProxy         bool   `json:"is_proxy,omitempty"`
+}

--- a/internal/agent/subagent_test.go
+++ b/internal/agent/subagent_test.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSubagentRef_JSONRoundTripFull(t *testing.T) {
+	ref := SubagentRef{
+		ID:              "a",
+		Type:            "cc",
+		StartedAt:       123,
+		SourcePID:       1000,
+		SourceStartTime: "t0",
+		IsProxy:         true,
+	}
+	data, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"source_pid"`) {
+		t.Errorf("missing source_pid key: %s", s)
+	}
+	if !strings.Contains(s, `"source_start_time"`) {
+		t.Errorf("missing source_start_time key: %s", s)
+	}
+	if !strings.Contains(s, `"is_proxy":true`) {
+		t.Errorf("missing is_proxy:true: %s", s)
+	}
+
+	var got SubagentRef
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != ref {
+		t.Errorf("round trip mismatch: got %+v, want %+v", got, ref)
+	}
+}
+
+func TestSubagentRef_OmitsIsProxyWhenFalse(t *testing.T) {
+	ref := SubagentRef{
+		ID:        "a",
+		Type:      "cc",
+		StartedAt: 1,
+		IsProxy:   false,
+	}
+	data, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "is_proxy") {
+		t.Errorf("is_proxy should be omitted when false, got: %s", s)
+	}
+}
+
+func TestSubagentRef_NativeZeroSourceFieldsValid(t *testing.T) {
+	ref := SubagentRef{
+		ID:        "a",
+		Type:      "cc",
+		StartedAt: 1,
+	}
+	data, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"source_pid":0`) {
+		t.Errorf("expected source_pid:0 present: %s", s)
+	}
+	if !strings.Contains(s, `"source_start_time":""`) {
+		t.Errorf("expected source_start_time:\"\" present: %s", s)
+	}
+
+	var got SubagentRef
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != ref {
+		t.Errorf("round trip mismatch: got %+v, want %+v", got, ref)
+	}
+}

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -76,7 +76,15 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 				After:         before,
 			}, err
 		}
-		frame.Subagents = updateSubagents(frame.Subagents, req.EventName, agentID)
+		ref := agentpkg.SubagentRef{
+			ID:        agentID,
+			Type:      firstNonEmpty(strFromDetail(result.Detail, "agent_type"), frame.AgentType),
+			StartedAt: broadcastTs,
+			// SourcePID / SourceStartTime / IsProxy left zero: native SubagentStart
+			// refs have no distinct source process identity. Proxy attaches (PR-2b)
+			// set these explicitly.
+		}
+		frame.Subagents = updateSubagents(frame.Subagents, req.EventName, ref)
 		frame.LastSeenAt = broadcastTs
 		stored, err := m.frames.Upsert(*frame)
 		if err != nil {
@@ -98,16 +106,16 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		return nil, FrameTraceMeta{}, err
 	}
 
-	subagents := []string{}
+	subagents := []agentpkg.SubagentRef{}
 	startedAt := broadcastTs
 	parentFrameID := ""
 	if frame != nil {
-		subagents = append([]string(nil), frame.Subagents...)
+		subagents = append([]agentpkg.SubagentRef(nil), frame.Subagents...)
 		startedAt = frame.StartedAt
 		parentFrameID = frame.ParentFrameID
 	}
 	if req.EventName == "SessionStart" {
-		subagents = []string{}
+		subagents = []agentpkg.SubagentRef{}
 	}
 	if parentFrameID == "" {
 		parent, err := m.frames.FindByPanePID(req.TmuxPaneID, info.PPID)
@@ -195,26 +203,31 @@ func summarizeFrame(frame *store.Frame) map[string]any {
 		"parent_frame_id":  frame.ParentFrameID,
 		"process_start_at": frame.ProcessStartTime,
 		"status":           string(frame.Status),
-		"subagents":        append([]string(nil), frame.Subagents...),
+		"subagents":        append([]agentpkg.SubagentRef(nil), frame.Subagents...),
 	}
 }
 
-func updateSubagents(current []string, eventName, agentID string) []string {
+// updateSubagents mutates a frame's subagent list in response to a
+// SubagentStart / SubagentStop event. Matching is by ref.ID only; Type does
+// not participate so a cross-type hook (proxy path in PR-2b) cleanly replaces
+// a native ref on stop. On SubagentStart the first-write wins — an existing
+// ref keeps its StartedAt/SourcePID/SourceStartTime/IsProxy.
+func updateSubagents(current []agentpkg.SubagentRef, eventName string, ref agentpkg.SubagentRef) []agentpkg.SubagentRef {
 	if current == nil {
-		current = []string{}
+		current = []agentpkg.SubagentRef{}
 	}
 	switch eventName {
 	case "SubagentStart":
 		for _, existing := range current {
-			if existing == agentID {
+			if existing.ID == ref.ID {
 				return current
 			}
 		}
-		return append(current, agentID)
+		return append(current, ref)
 	case "SubagentStop":
-		filtered := make([]string, 0, len(current))
+		filtered := make([]agentpkg.SubagentRef, 0, len(current))
 		for _, existing := range current {
-			if existing != agentID {
+			if existing.ID != ref.ID {
 				filtered = append(filtered, existing)
 			}
 		}
@@ -224,14 +237,14 @@ func updateSubagents(current []string, eventName, agentID string) []string {
 	}
 }
 
-func syncProjectionState(currentStatus map[string]agentpkg.Status, subagents map[string][]string, tmuxSession string, projection *SessionProjection) {
+func syncProjectionState(currentStatus map[string]agentpkg.Status, subagents map[string][]agentpkg.SubagentRef, tmuxSession string, projection *SessionProjection) {
 	if projection == nil || projection.TopFrame == nil {
 		delete(currentStatus, tmuxSession)
 		delete(subagents, tmuxSession)
 		return
 	}
 	currentStatus[tmuxSession] = projection.TopFrame.Status
-	subagents[tmuxSession] = append([]string(nil), projection.Subagents...)
+	subagents[tmuxSession] = append([]agentpkg.SubagentRef(nil), projection.Subagents...)
 }
 
 func buildProjectionNormalized(projection *SessionProjection, fallbackAgentType, eventName string, broadcastTs int64, result agentpkg.DeriveResult) agentpkg.NormalizedEvent {
@@ -239,7 +252,7 @@ func buildProjectionNormalized(projection *SessionProjection, fallbackAgentType,
 		AgentType:    fallbackAgentType,
 		Status:       string(result.Status),
 		Model:        result.Model,
-		Subagents:    []string{},
+		Subagents:    []agentpkg.SubagentRef{},
 		RawEventName: eventName,
 		BroadcastTs:  broadcastTs,
 		Detail:       result.Detail,
@@ -247,7 +260,7 @@ func buildProjectionNormalized(projection *SessionProjection, fallbackAgentType,
 	if projection == nil {
 		return normalized
 	}
-	normalized.Subagents = append([]string(nil), projection.Subagents...)
+	normalized.Subagents = append([]agentpkg.SubagentRef(nil), projection.Subagents...)
 	if projection.TopFrame == nil {
 		normalized.Status = string(agentpkg.StatusClear)
 		return normalized
@@ -255,6 +268,26 @@ func buildProjectionNormalized(projection *SessionProjection, fallbackAgentType,
 	normalized.AgentType = projection.TopFrame.AgentType
 	normalized.Status = string(projection.TopFrame.Status)
 	return normalized
+}
+
+// firstNonEmpty returns a if non-empty, else b.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// strFromDetail looks up a string field in a DeriveResult.Detail map.
+// Returns "" when the key is missing or the value is not a string.
+func strFromDetail(detail map[string]any, key string) string {
+	if detail == nil {
+		return ""
+	}
+	if v, ok := detail[key].(string); ok {
+		return v
+	}
+	return ""
 }
 
 func (m *Module) projectionForSession(sessionName string) (*SessionProjection, error) {

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -77,8 +77,13 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 			}, err
 		}
 		ref := agentpkg.SubagentRef{
-			ID:        agentID,
-			Type:      firstNonEmpty(strFromDetail(result.Detail, "agent_type"), frame.AgentType),
+			ID: agentID,
+			// Type is the canonical agent family that owns this subagent (cc /
+			// codex / opencode), not the payload's per-subagent sub-variant
+			// (e.g. opencode's `agent_type: "Explore"`). Keeping Type aligned
+			// to frame.AgentType lets the SPA use it for agent-family color
+			// lookup without provider-specific special cases.
+			Type:      frame.AgentType,
 			StartedAt: broadcastTs,
 			// SourcePID / SourceStartTime / IsProxy left zero: native SubagentStart
 			// refs have no distinct source process identity. Proxy attaches (PR-2b)
@@ -268,14 +273,6 @@ func buildProjectionNormalized(projection *SessionProjection, fallbackAgentType,
 	normalized.AgentType = projection.TopFrame.AgentType
 	normalized.Status = string(projection.TopFrame.Status)
 	return normalized
-}
-
-// firstNonEmpty returns a if non-empty, else b.
-func firstNonEmpty(a, b string) string {
-	if a != "" {
-		return a
-	}
-	return b
 }
 
 // strFromDetail looks up a string field in a DeriveResult.Detail map.

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -417,6 +417,61 @@ func TestSendSnapshot_CollapsesMultiplePanesInSession(t *testing.T) {
 	}
 }
 
+func TestUpdateSubagents_StartAddsRef(t *testing.T) {
+	start := agentpkg.SubagentRef{ID: "a", Type: "cc", StartedAt: 10}
+	got := updateSubagents(nil, "SubagentStart", start)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0] != start {
+		t.Fatalf("got[0] = %+v, want %+v", got[0], start)
+	}
+}
+
+func TestUpdateSubagents_StartDuplicateIDKeepsExisting(t *testing.T) {
+	existing := agentpkg.SubagentRef{ID: "a", Type: "cc", StartedAt: 10}
+	dup := agentpkg.SubagentRef{ID: "a", Type: "cc", StartedAt: 20}
+	got := updateSubagents([]agentpkg.SubagentRef{existing}, "SubagentStart", dup)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0] != existing {
+		t.Fatalf("got[0] = %+v, want %+v (no overwrite)", got[0], existing)
+	}
+}
+
+func TestUpdateSubagents_StopRemovesByID(t *testing.T) {
+	a := agentpkg.SubagentRef{ID: "a", Type: "cc"}
+	b := agentpkg.SubagentRef{ID: "b", Type: "cc"}
+	got := updateSubagents([]agentpkg.SubagentRef{a, b}, "SubagentStop", agentpkg.SubagentRef{ID: "a"})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0] != b {
+		t.Fatalf("got[0] = %+v, want %+v", got[0], b)
+	}
+}
+
+func TestUpdateSubagents_StopIgnoresType(t *testing.T) {
+	existing := agentpkg.SubagentRef{ID: "a", Type: "cc"}
+	// Stop ref has Type="codex" but ID matches; Type must not participate in matching.
+	got := updateSubagents([]agentpkg.SubagentRef{existing}, "SubagentStop", agentpkg.SubagentRef{ID: "a", Type: "codex"})
+	if len(got) != 0 {
+		t.Fatalf("len = %d, want 0 (ID match removes regardless of Type)", len(got))
+	}
+}
+
+func TestUpdateSubagents_StopMissingIsNoop(t *testing.T) {
+	a := agentpkg.SubagentRef{ID: "a", Type: "cc"}
+	got := updateSubagents([]agentpkg.SubagentRef{a}, "SubagentStop", agentpkg.SubagentRef{ID: "b"})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0] != a {
+		t.Fatalf("got[0] = %+v, want %+v", got[0], a)
+	}
+}
+
 func TestSendSnapshot_IncludesLegacySessionsWithoutFrames(t *testing.T) {
 	m := newTestModule(t)
 	fakeTmux := tmux.NewFakeExecutor()

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -287,7 +287,7 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 // buildNormalized creates a NormalizedEvent from the derive result and current state.
 func (m *Module) buildNormalized(tmuxSession, eventName, agentType string, broadcastTs int64, result agentpkg.DeriveResult) agentpkg.NormalizedEvent {
 	m.mu.Lock()
-	subs := make([]string, len(m.subagents[tmuxSession]))
+	subs := make([]agentpkg.SubagentRef, len(m.subagents[tmuxSession]))
 	copy(subs, m.subagents[tmuxSession])
 	m.mu.Unlock()
 

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -419,8 +419,11 @@ func TestHandleEvent_OpenCodeValidSubagentBroadcasts(t *testing.T) {
 		if !strings.Contains(env.Value, `"raw_event_name":"SubagentStart"`) {
 			t.Fatalf("broadcast value missing raw_event_name: %s", env.Value)
 		}
-		if !strings.Contains(env.Value, `"subagents":["call-1"]`) {
-			t.Fatalf("broadcast value missing subagent membership: %s", env.Value)
+		if !strings.Contains(env.Value, `"id":"call-1"`) {
+			t.Fatalf("broadcast value missing subagent id=call-1: %s", env.Value)
+		}
+		if !strings.Contains(env.Value, `"type":"Explore"`) {
+			t.Fatalf("broadcast value missing subagent type=Explore: %s", env.Value)
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("timed out waiting for SubagentStart broadcast")
@@ -518,7 +521,10 @@ func TestBuildNormalized_EmptySubagentsIsNotNil(t *testing.T) {
 func TestBuildNormalized_WithSubagents(t *testing.T) {
 	m := newTestModule(t)
 	m.mu.Lock()
-	m.subagents["work"] = []string{"agent-1", "agent-2"}
+	m.subagents["work"] = []agentpkg.SubagentRef{
+		{ID: "agent-1", Type: "cc"},
+		{ID: "agent-2", Type: "cc"},
+	}
 	m.mu.Unlock()
 
 	result := agentpkg.DeriveResult{Valid: true}
@@ -533,7 +539,7 @@ func TestBuildNormalized_WithSubagents(t *testing.T) {
 func TestRenameSession(t *testing.T) {
 	m := newTestModule(t)
 	m.mu.Lock()
-	m.subagents["old-session"] = []string{"agent-1"}
+	m.subagents["old-session"] = []agentpkg.SubagentRef{{ID: "agent-1", Type: "cc"}}
 	m.currentStatus["old-session"] = agentpkg.StatusRunning
 	m.mu.Unlock()
 
@@ -548,7 +554,7 @@ func TestRenameSession(t *testing.T) {
 	if _, ok := m.currentStatus["old-session"]; ok {
 		t.Error("old-session should be removed from currentStatus")
 	}
-	if subs := m.subagents["new-session"]; len(subs) != 1 || subs[0] != "agent-1" {
+	if subs := m.subagents["new-session"]; len(subs) != 1 || subs[0].ID != "agent-1" {
 		t.Errorf("new-session subagents: want [agent-1], got %v", subs)
 	}
 	if m.currentStatus["new-session"] != agentpkg.StatusRunning {
@@ -573,7 +579,7 @@ func TestRenameSession_NoOldData(t *testing.T) {
 func TestRenameSessionAtomic_Success(t *testing.T) {
 	m := newTestModule(t)
 	m.mu.Lock()
-	m.subagents["old-name"] = []string{"agent-1"}
+	m.subagents["old-name"] = []agentpkg.SubagentRef{{ID: "agent-1", Type: "cc"}}
 	m.currentStatus["old-name"] = agentpkg.StatusRunning
 	m.mu.Unlock()
 
@@ -591,7 +597,7 @@ func TestRenameSessionAtomic_Success(t *testing.T) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if subs := m.subagents["new-name"]; len(subs) != 1 || subs[0] != "agent-1" {
+	if subs := m.subagents["new-name"]; len(subs) != 1 || subs[0].ID != "agent-1" {
 		t.Errorf("subagents should be transferred to new-name, got %v", subs)
 	}
 	if _, ok := m.subagents["old-name"]; ok {
@@ -602,7 +608,7 @@ func TestRenameSessionAtomic_Success(t *testing.T) {
 func TestRenameSessionAtomic_CallbackErrorSkipsTransfer(t *testing.T) {
 	m := newTestModule(t)
 	m.mu.Lock()
-	m.subagents["old-name"] = []string{"agent-1"}
+	m.subagents["old-name"] = []agentpkg.SubagentRef{{ID: "agent-1", Type: "cc"}}
 	m.mu.Unlock()
 
 	wantErr := errStub("rename failed")
@@ -1415,7 +1421,7 @@ func TestHandleEvent_CatalogMiss_NoStatusUpdate(t *testing.T) {
 	// Seed pre-existing state to verify it's untouched.
 	m.mu.Lock()
 	m.currentStatus["work"] = agentpkg.StatusRunning
-	m.subagents["work"] = []string{"existing-sub"}
+	m.subagents["work"] = []agentpkg.SubagentRef{{ID: "existing-sub", Type: "cc"}}
 	m.mu.Unlock()
 
 	sub := m.core.Events.AddTestSubscriber()
@@ -1430,12 +1436,12 @@ func TestHandleEvent_CatalogMiss_NoStatusUpdate(t *testing.T) {
 
 	m.mu.Lock()
 	gotStatus := m.currentStatus["work"]
-	gotSubs := append([]string(nil), m.subagents["work"]...)
+	gotSubs := append([]agentpkg.SubagentRef(nil), m.subagents["work"]...)
 	m.mu.Unlock()
 	if gotStatus != agentpkg.StatusRunning {
 		t.Errorf("currentStatus = %q, want running (catalog miss must not mutate)", gotStatus)
 	}
-	if len(gotSubs) != 1 || gotSubs[0] != "existing-sub" {
+	if len(gotSubs) != 1 || gotSubs[0].ID != "existing-sub" {
 		t.Errorf("subagents = %v, want [existing-sub]", gotSubs)
 	}
 

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -430,6 +430,88 @@ func TestHandleEvent_OpenCodeValidSubagentBroadcasts(t *testing.T) {
 	}
 }
 
+// HB1 (Lights Phase 2 plan §2.8) — the WS broadcast payload for a native cc
+// SubagentStart carries SubagentRef objects (id + type + started_at) not
+// bare id strings, and native refs omit is_proxy (omitempty).
+func TestHandleEvent_BroadcastPayloadCarriesSubagentRefs(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive: func(event string, _ json.RawMessage) agentpkg.DeriveResult {
+			switch event {
+			case "SessionStart":
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			case "SubagentStart":
+				return agentpkg.DeriveResult{Valid: true, Detail: map[string]any{"agent_id": "sub-1"}}
+			default:
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			}
+		},
+	})
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	for _, body := range []string{
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"cc"}`,
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SubagentStart","raw_event":{"agent_id":"sub-1"},"agent_type":"cc"}`,
+	} {
+		req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		m.handleEvent(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+	}
+
+	// Drain the SessionStart broadcast.
+	select {
+	case <-sub.SendCh():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for SessionStart broadcast")
+	}
+
+	select {
+	case msg := <-sub.SendCh():
+		var env struct {
+			Type    string `json:"type"`
+			Session string `json:"session"`
+			Value   string `json:"value"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		// Decode the inner normalized event payload.
+		var payload struct {
+			Subagents []map[string]any `json:"subagents"`
+		}
+		if err := json.Unmarshal([]byte(env.Value), &payload); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+		if len(payload.Subagents) != 1 {
+			t.Fatalf("subagents len = %d, want 1 (payload=%s)", len(payload.Subagents), env.Value)
+		}
+		ref := payload.Subagents[0]
+		if ref["type"] != "cc" {
+			t.Errorf("subagents[0].type = %v, want cc", ref["type"])
+		}
+		startedAt, ok := ref["started_at"].(float64)
+		if !ok || startedAt == 0 {
+			t.Errorf("subagents[0].started_at should be a non-zero number, got %v", ref["started_at"])
+		}
+		if _, hasProxy := ref["is_proxy"]; hasProxy {
+			t.Errorf("subagents[0] should not contain is_proxy for native ref: %v", ref)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for SubagentStart broadcast")
+	}
+}
+
 func TestHandleEvent_OpenCodeMalformedSubagentDoesNotBroadcast(t *testing.T) {
 	m := newTestModule(t)
 	fakeTmux := tmux.NewFakeExecutor()

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -30,7 +30,10 @@ func newTestModule(t *testing.T) *Module {
 		t.Fatalf("open agent event store: %v", err)
 	}
 	t.Cleanup(func() { events.Close() })
-	m := New(events)
+	m, err := New(events)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	m.registry = agentpkg.NewRegistry()
 	origVerify := verifyEventFn
 	verifyEventFn = func(*Module, EventRequest) verifyDecision { return verifyDecision{Accepted: true} }

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -422,8 +422,12 @@ func TestHandleEvent_OpenCodeValidSubagentBroadcasts(t *testing.T) {
 		if !strings.Contains(env.Value, `"id":"call-1"`) {
 			t.Fatalf("broadcast value missing subagent id=call-1: %s", env.Value)
 		}
-		if !strings.Contains(env.Value, `"type":"Explore"`) {
-			t.Fatalf("broadcast value missing subagent type=Explore: %s", env.Value)
+		// Type is canonical agent family (opencode), NOT opencode's per-subagent
+		// sub-variant from detail.agent_type ("Explore"). See Phase 2 PR-2a
+		// round-1 codex P2: SubagentRef.Type should stay stable for
+		// agent-family lookup (SPA color table etc).
+		if !strings.Contains(env.Value, `"type":"opencode"`) {
+			t.Fatalf("broadcast value missing subagent type=opencode: %s", env.Value)
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("timed out waiting for SubagentStart broadcast")

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -63,25 +63,40 @@ type Module struct {
 	sweepWG     sync.WaitGroup
 }
 
-// New creates a new agent Module backed by the given AgentEventStore. Returns
-// an error if the frames / traces stores fail to migrate — most notably if
-// the on-disk agent_frames contains malformed subagents_json that cannot be
-// classified as either the legacy []string shape or the Phase 2 []SubagentRef
-// shape. Surfacing the error here lets the daemon refuse to start rather than
-// continuing with m.frames == nil (which would degrade silently via the
-// module's m.frames == nil fallbacks).
+// Test seams for Module.New. framesInitFn failure is fatal (hook processing
+// depends on frames); tracesInitFn failure is best-effort (trace
+// observability degrades to nil, daemon continues).
+var (
+	framesInitFn = func(e *store.AgentEventStore) (*store.FramesStore, error) { return e.Frames() }
+	tracesInitFn = func(e *store.AgentEventStore) (*store.TraceStore, error) { return e.Traces() }
+)
+
+// New creates a new agent Module backed by the given AgentEventStore.
+//
+// Returns an error ONLY when the frames store cannot be initialized —
+// typically when on-disk agent_frames contains malformed subagents_json
+// that migrateFramesDB refuses to classify. That failure is fatal because
+// hook processing depends on m.frames; continuing with m.frames == nil
+// would degrade silently via the module's m.frames == nil fallbacks.
+//
+// Trace store initialization is best-effort: the module already tolerates
+// m.traces == nil / m.traceSink == nil in normal operation (monitor
+// endpoints degrade, hook processing still runs). A trace-table migration
+// or corruption error is logged and the module continues without trace
+// observability, not treated as a daemon-fatal condition.
 func New(events *store.AgentEventStore) (*Module, error) {
 	var frames *store.FramesStore
 	var traces *store.TraceStore
 	if events != nil {
 		var err error
-		frames, err = events.Frames()
+		frames, err = framesInitFn(events)
 		if err != nil {
 			return nil, fmt.Errorf("agent module: frames store: %w", err)
 		}
-		traces, err = events.Traces()
+		traces, err = tracesInitFn(events)
 		if err != nil {
-			return nil, fmt.Errorf("agent module: traces store: %w", err)
+			log.Printf("[agent] traces store unavailable, continuing without trace observability: %v", err)
+			traces = nil
 		}
 	}
 	m := &Module{

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -39,7 +39,7 @@ type Module struct {
 
 	mu             sync.Mutex
 	currentStatus  map[string]agentpkg.Status
-	subagents      map[string][]string
+	subagents      map[string][]agentpkg.SubagentRef
 	activeWatchers map[string]string // tmuxSession → agentType
 
 	// statusSnapshots caches the latest statusline payload per sessionCode.
@@ -76,7 +76,7 @@ func New(events *store.AgentEventStore) *Module {
 		traces:          traces,
 		registry:        agentpkg.NewRegistry(),
 		currentStatus:   make(map[string]agentpkg.Status),
-		subagents:       make(map[string][]string),
+		subagents:       make(map[string][]agentpkg.SubagentRef),
 		activeWatchers:  make(map[string]string),
 		statusSnapshots: make(map[string]statusSnapshot),
 		testObservers:   make(map[string]*testObserver),

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -7,6 +7,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"sync"
@@ -62,13 +63,26 @@ type Module struct {
 	sweepWG     sync.WaitGroup
 }
 
-// New creates a new agent Module backed by the given AgentEventStore.
-func New(events *store.AgentEventStore) *Module {
+// New creates a new agent Module backed by the given AgentEventStore. Returns
+// an error if the frames / traces stores fail to migrate — most notably if
+// the on-disk agent_frames contains malformed subagents_json that cannot be
+// classified as either the legacy []string shape or the Phase 2 []SubagentRef
+// shape. Surfacing the error here lets the daemon refuse to start rather than
+// continuing with m.frames == nil (which would degrade silently via the
+// module's m.frames == nil fallbacks).
+func New(events *store.AgentEventStore) (*Module, error) {
 	var frames *store.FramesStore
 	var traces *store.TraceStore
 	if events != nil {
-		frames, _ = events.Frames()
-		traces, _ = events.Traces()
+		var err error
+		frames, err = events.Frames()
+		if err != nil {
+			return nil, fmt.Errorf("agent module: frames store: %w", err)
+		}
+		traces, err = events.Traces()
+		if err != nil {
+			return nil, fmt.Errorf("agent module: traces store: %w", err)
+		}
 	}
 	m := &Module{
 		events:          events,
@@ -84,7 +98,7 @@ func New(events *store.AgentEventStore) *Module {
 	if traces != nil {
 		m.traceSink = newHookTraceSink(traces)
 	}
-	return m
+	return m, nil
 }
 
 func (m *Module) Name() string           { return "agent" }

--- a/internal/module/agent/module_test.go
+++ b/internal/module/agent/module_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wake/purdex/internal/store"
+)
+
+// TestNew_FailsOnMalformedFramesStore exercises the daemon startup path.
+// The round-2 migrateFramesDB safeguard only blocks startup if Module.New
+// propagates the events.Frames() error to its caller (cmd/pdx/main.go).
+// Round-3 codex review (review-mocj2q7w-ypf3wd) flagged that the old
+// signature dropped the error, so a malformed on-disk agent_frames would
+// come up as m.frames == nil — silent degradation instead of fail-fast.
+func TestNew_FailsOnMalformedFramesStore(t *testing.T) {
+	events, err := store.OpenAgentEvent(":memory:")
+	if err != nil {
+		t.Fatalf("OpenAgentEvent: %v", err)
+	}
+	t.Cleanup(func() { _ = events.Close() })
+
+	// Prime the frames table so we can seed a malformed row into it.
+	if _, err := events.Frames(); err != nil {
+		t.Fatalf("initial Frames: %v", err)
+	}
+	if _, err := events.ExecRawForTest(`INSERT INTO agent_frames (
+		frame_id, pane_id, agent_type, pid, ppid, process_start_time,
+		parent_frame_id, subagents_json, status, started_at, last_seen_at, verified
+	) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)`,
+		"bad-frame", "%5", "cc", 400, 1, "t0",
+		`not-a-json`, "idle", 10, 10, 1); err != nil {
+		t.Fatalf("seed malformed row: %v", err)
+	}
+
+	// Daemon startup path: New() must surface the migration error so
+	// cmd/pdx/main.go's log.Fatalf kicks in.
+	m, err := New(events)
+	if err == nil {
+		t.Fatalf("New: want error for malformed frames row, got nil (module=%v)", m)
+	}
+	if !strings.Contains(err.Error(), "malformed subagents_json") {
+		t.Fatalf("New error = %q, want to mention 'malformed subagents_json'", err.Error())
+	}
+}

--- a/internal/module/agent/module_test.go
+++ b/internal/module/agent/module_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -41,5 +42,41 @@ func TestNew_FailsOnMalformedFramesStore(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "malformed subagents_json") {
 		t.Fatalf("New error = %q, want to mention 'malformed subagents_json'", err.Error())
+	}
+}
+
+// TestNew_TracesErrorIsNotFatal guards against round-4 regression: the
+// module already tolerates m.traces == nil (monitor endpoints degrade, hook
+// processing still runs). A trace-store init failure must NOT be elevated to
+// a daemon-fatal condition (as it accidentally was in round 3).
+func TestNew_TracesErrorIsNotFatal(t *testing.T) {
+	events, err := store.OpenAgentEvent(":memory:")
+	if err != nil {
+		t.Fatalf("OpenAgentEvent: %v", err)
+	}
+	t.Cleanup(func() { _ = events.Close() })
+
+	origTraces := tracesInitFn
+	tracesInitFn = func(*store.AgentEventStore) (*store.TraceStore, error) {
+		return nil, errors.New("simulated trace migration failure")
+	}
+	t.Cleanup(func() { tracesInitFn = origTraces })
+
+	m, err := New(events)
+	if err != nil {
+		t.Fatalf("New: want nil error when traces init fails, got %v", err)
+	}
+	if m == nil {
+		t.Fatal("module should be constructed despite trace init failure")
+	}
+	if m.traces != nil {
+		t.Fatal("m.traces must be nil after simulated trace error (degraded mode)")
+	}
+	if m.traceSink != nil {
+		t.Fatal("m.traceSink must be nil after simulated trace error (degraded mode)")
+	}
+	// Frames must still be wired — they use the real init path.
+	if m.frames == nil {
+		t.Fatal("m.frames must be non-nil when events is non-nil and frames init succeeds")
 	}
 }

--- a/internal/module/agent/projection.go
+++ b/internal/module/agent/projection.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"sort"
 
+	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/store"
 )
 
@@ -10,7 +11,7 @@ type SessionProjection struct {
 	PaneID       string
 	PrimaryFrame *store.Frame
 	TopFrame     *store.Frame
-	Subagents    []string
+	Subagents    []agentpkg.SubagentRef
 }
 
 func BuildSessionProjections(frames []store.Frame) []SessionProjection {
@@ -36,7 +37,7 @@ func BuildSessionProjections(frames []store.Frame) []SessionProjection {
 
 func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection {
 	if len(frames) == 0 {
-		return SessionProjection{PaneID: paneID, Subagents: []string{}}
+		return SessionProjection{PaneID: paneID, Subagents: []agentpkg.SubagentRef{}}
 	}
 	sorted := append([]store.Frame(nil), frames...)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -48,9 +49,9 @@ func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection 
 
 	primary := sorted[0]
 	top := sorted[len(sorted)-1]
-	subagents := append([]string(nil), top.Subagents...)
+	subagents := append([]agentpkg.SubagentRef(nil), top.Subagents...)
 	if subagents == nil {
-		subagents = []string{}
+		subagents = []agentpkg.SubagentRef{}
 	}
 	return SessionProjection{
 		PaneID:       paneID,

--- a/internal/module/agent/projection_test.go
+++ b/internal/module/agent/projection_test.go
@@ -48,7 +48,7 @@ func TestProjection_CcAndCodexCoexist(t *testing.T) {
 			AgentType: "codex",
 			Status:    agentpkg.StatusRunning,
 			StartedAt: 20,
-			Subagents: []string{"sub-1"},
+			Subagents: []agentpkg.SubagentRef{{ID: "sub-1", Type: "codex"}},
 		},
 	})
 
@@ -61,7 +61,7 @@ func TestProjection_CcAndCodexCoexist(t *testing.T) {
 	if projections[0].TopFrame == nil || projections[0].TopFrame.AgentType != "codex" {
 		t.Fatalf("top = %+v, want codex", projections[0].TopFrame)
 	}
-	if len(projections[0].Subagents) != 1 || projections[0].Subagents[0] != "sub-1" {
+	if len(projections[0].Subagents) != 1 || projections[0].Subagents[0].ID != "sub-1" {
 		t.Fatalf("subagents = %v, want [sub-1]", projections[0].Subagents)
 	}
 }

--- a/internal/module/agent/statusline_selftest_test.go
+++ b/internal/module/agent/statusline_selftest_test.go
@@ -83,7 +83,10 @@ func ackReady(t *testing.T, env *handlerTestEnv, nonce string) {
 }
 
 func TestTestObserversRegisterSignalDeregister(t *testing.T) {
-	m := New(nil) // AgentEventStore allowed to be nil; observers don't touch it
+	m, err := New(nil) // AgentEventStore allowed to be nil; observers don't touch it
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	obs := m.registerTestObserver("__pdx_test_aaaa1111")
 
 	go m.signalTestStage("__pdx_test_aaaa1111", testStageReceived)
@@ -104,7 +107,10 @@ func TestTestObserversRegisterSignalDeregister(t *testing.T) {
 }
 
 func TestSignalTestStageUnknownNonceIsNoOp(t *testing.T) {
-	m := New(nil)
+	m, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	// Must not panic, must not hang.
 	m.signalTestStage("__pdx_test_zzzz9999", testStageReceived)
 }

--- a/internal/module/agent/verify_test.go
+++ b/internal/module/agent/verify_test.go
@@ -15,7 +15,10 @@ func newVerifyTestModule(t *testing.T) *Module {
 		t.Fatalf("open agent event store: %v", err)
 	}
 	t.Cleanup(func() { _ = events.Close() })
-	m := New(events)
+	m, err := New(events)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	m.registry = agentpkg.NewRegistry()
 	m.tmux = tmux.NewFakeExecutor()
 	if m.traceSink != nil {

--- a/internal/store/agent_event.go
+++ b/internal/store/agent_event.go
@@ -70,6 +70,14 @@ func migrateAgentEventDB(db *sql.DB) error {
 // Close closes the underlying DB connection.
 func (s *AgentEventStore) Close() error { return s.db.Close() }
 
+// ExecRawForTest runs a raw SQL statement on the underlying DB. It exists
+// solely for cross-package tests that need to seed rows the public API
+// does not allow (e.g. a malformed `subagents_json` to exercise the
+// migration fail path). Do not call from production code.
+func (s *AgentEventStore) ExecRawForTest(query string, args ...any) (sql.Result, error) {
+	return s.db.Exec(query, args...)
+}
+
 // Set upserts the latest agent hook event for a tmux session.
 func (s *AgentEventStore) Set(tmuxSession, eventName string, rawEvent json.RawMessage, agentType string, broadcastTs int64) error {
 	_, err := s.db.Exec(`

--- a/internal/store/frames.go
+++ b/internal/store/frames.go
@@ -17,7 +17,7 @@ type Frame struct {
 	PPID             int
 	ProcessStartTime string
 	ParentFrameID    string
-	Subagents        []string
+	Subagents        []agentpkg.SubagentRef
 	Status           agentpkg.Status
 	StartedAt        int64
 	LastSeenAt       int64
@@ -87,7 +87,7 @@ func (s *FramesStore) Upsert(frame Frame) (Frame, error) {
 			frame.StartedAt = frame.LastSeenAt
 		}
 		if frame.Subagents == nil {
-			frame.Subagents = []string{}
+			frame.Subagents = []agentpkg.SubagentRef{}
 		}
 	}
 	if frame.LastSeenAt == 0 {
@@ -242,7 +242,7 @@ func scanFrame(scanner frameScanner) (Frame, error) {
 		return Frame{}, fmt.Errorf("unmarshal subagents: %w", err)
 	}
 	if frame.Subagents == nil {
-		frame.Subagents = []string{}
+		frame.Subagents = []agentpkg.SubagentRef{}
 	}
 	return frame, nil
 }

--- a/internal/store/frames.go
+++ b/internal/store/frames.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/google/uuid"
 	agentpkg "github.com/wake/purdex/internal/agent"
@@ -58,6 +59,35 @@ func migrateFramesDB(db *sql.DB) error {
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_frames_agent_type ON agent_frames(agent_type)`); err != nil {
 		return err
 	}
+	return clearStaleSubagentsJSON(db)
+}
+
+// clearStaleSubagentsJSON detects pre-Phase-2 `subagents_json` rows (string
+// array shape `["id"]`) and truncates the table. Frames are ephemeral
+// telemetry — clearing them on schema upgrade is lossless and avoids the
+// alternative: every subsequent hook 500s because scanFrame can't unmarshal
+// the old shape into []SubagentRef.
+func clearStaleSubagentsJSON(db *sql.DB) error {
+	var probe sql.NullString
+	err := db.QueryRow(`SELECT subagents_json FROM agent_frames LIMIT 1`).Scan(&probe)
+	if err == sql.ErrNoRows {
+		return nil // empty table, nothing to check
+	}
+	if err != nil {
+		return err
+	}
+	if !probe.Valid {
+		return nil
+	}
+	var dst []agentpkg.SubagentRef
+	if json.Unmarshal([]byte(probe.String), &dst) == nil {
+		return nil // already in new format
+	}
+	// Unmarshal failed — row is in legacy shape. Truncate the table.
+	if _, err := db.Exec(`DELETE FROM agent_frames`); err != nil {
+		return err
+	}
+	log.Printf("[store] cleared agent_frames: legacy subagents_json schema detected, see Phase 2 PR-2a notes")
 	return nil
 }
 

--- a/internal/store/frames.go
+++ b/internal/store/frames.go
@@ -62,32 +62,62 @@ func migrateFramesDB(db *sql.DB) error {
 	return clearStaleSubagentsJSON(db)
 }
 
-// clearStaleSubagentsJSON detects pre-Phase-2 `subagents_json` rows (string
-// array shape `["id"]`) and truncates the table. Frames are ephemeral
-// telemetry — clearing them on schema upgrade is lossless and avoids the
-// alternative: every subsequent hook 500s because scanFrame can't unmarshal
-// the old shape into []SubagentRef.
+// clearStaleSubagentsJSON scans every `agent_frames.subagents_json` and
+// classifies rows as new ([]SubagentRef) / legacy ([]string) / malformed.
+// All new → no-op. Any legacy (and nothing malformed) → TRUNCATE table;
+// frames are ephemeral telemetry so clearing is lossless. Any malformed →
+// return a startup error so the daemon refuses to run rather than silently
+// wiping unknown on-disk state.
+//
+// Full-table scan (not LIMIT 1) because SQLite does not guarantee row order
+// and a single probe can hit a new-format row while legacy rows survive —
+// scanFrame would then crash on later ListAll/GetByIdentity calls.
 func clearStaleSubagentsJSON(db *sql.DB) error {
-	var probe sql.NullString
-	err := db.QueryRow(`SELECT subagents_json FROM agent_frames LIMIT 1`).Scan(&probe)
-	if err == sql.ErrNoRows {
-		return nil // empty table, nothing to check
-	}
+	rows, err := db.Query(`SELECT frame_id, subagents_json FROM agent_frames`)
 	if err != nil {
 		return err
 	}
-	if !probe.Valid {
+	defer rows.Close()
+
+	var hasLegacy bool
+	var malformedID string // non-empty = malformed detected
+	for rows.Next() {
+		var id string
+		var js sql.NullString
+		if err := rows.Scan(&id, &js); err != nil {
+			return err
+		}
+		raw := ""
+		if js.Valid {
+			raw = js.String
+		}
+		var newDst []agentpkg.SubagentRef
+		if json.Unmarshal([]byte(raw), &newDst) == nil {
+			continue
+		}
+		var legacyDst []string
+		if json.Unmarshal([]byte(raw), &legacyDst) == nil {
+			hasLegacy = true
+			continue
+		}
+		if malformedID == "" {
+			malformedID = id
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	if malformedID != "" {
+		return fmt.Errorf("agent_frames row %q has malformed subagents_json; refusing to start — inspect or remove the row manually (Phase 2 PR-2a)", malformedID)
+	}
+	if !hasLegacy {
 		return nil
 	}
-	var dst []agentpkg.SubagentRef
-	if json.Unmarshal([]byte(probe.String), &dst) == nil {
-		return nil // already in new format
-	}
-	// Unmarshal failed — row is in legacy shape. Truncate the table.
 	if _, err := db.Exec(`DELETE FROM agent_frames`); err != nil {
 		return err
 	}
-	log.Printf("[store] cleared agent_frames: legacy subagents_json schema detected, see Phase 2 PR-2a notes")
+	log.Printf("[store] cleared agent_frames: legacy subagents_json schema detected (Phase 2 PR-2a upgrade)")
 	return nil
 }
 

--- a/internal/store/frames_test.go
+++ b/internal/store/frames_test.go
@@ -366,6 +366,87 @@ func TestMigrateFramesDB_ClearsLegacySubagentsJSON(t *testing.T) {
 	}
 }
 
+// Seeds a row with a malformed `subagents_json` that is neither []SubagentRef
+// nor []string — simulates disk corruption or an unrecognized future shape.
+func seedMalformedFrameRow(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO agent_frames (
+		frame_id, pane_id, agent_type, pid, ppid, process_start_time,
+		parent_frame_id, subagents_json, status, started_at, last_seen_at, verified
+	) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)`,
+		"malformed-frame", "%5", "cc", 300, 100, "A",
+		`not-a-json`, "idle", 10, 10, 1); err != nil {
+		t.Fatalf("seed malformed row: %v", err)
+	}
+}
+
+func TestMigrateFramesDB_ClearsMixedLegacyAndNewRows(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	// Insert one new-format row via Upsert.
+	if _, err := s.Upsert(Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Subagents:        []agentpkg.SubagentRef{{ID: "s1", Type: "cc", StartedAt: 10}},
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert new: %v", err)
+	}
+	// Seed one legacy row via direct SQL with distinct identity so it does
+	// not collide with the new row above.
+	if _, err := s.db.Exec(`INSERT INTO agent_frames (
+		frame_id, pane_id, agent_type, pid, ppid, process_start_time,
+		parent_frame_id, subagents_json, status, started_at, last_seen_at, verified
+	) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)`,
+		"legacy-frame-mixed", "%5", "cc", 201, 100, "B",
+		`["legacy-id"]`, "idle", 10, 10, 1); err != nil {
+		t.Fatalf("seed legacy row (mixed): %v", err)
+	}
+
+	if err := migrateFramesDB(s.db); err != nil {
+		t.Fatalf("migrateFramesDB: %v", err)
+	}
+
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_frames`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("agent_frames count = %d after mixed migrate, want 0 (entire table truncated when any legacy row present)", count)
+	}
+}
+
+func TestMigrateFramesDB_FailsOnMalformedSubagentsJSON(t *testing.T) {
+	events := openTestAgentEventStore(t)
+	if _, err := events.Frames(); err != nil {
+		t.Fatalf("initial Frames: %v", err)
+	}
+	seedMalformedFrameRow(t, events.db)
+
+	err := migrateFramesDB(events.db)
+	if err == nil {
+		t.Fatal("migrateFramesDB: want error for malformed subagents_json, got nil (daemon would silently wipe unrecognized state)")
+	}
+	if !strings.Contains(err.Error(), "malformed subagents_json") {
+		t.Fatalf("error = %q, want to mention 'malformed subagents_json'", err.Error())
+	}
+
+	// Malformed row must still be on disk — daemon refused to truncate.
+	var count int
+	if err := events.db.QueryRow(`SELECT COUNT(*) FROM agent_frames`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("agent_frames count = %d after failed migrate, want 1 (malformed row preserved for manual inspection)", count)
+	}
+}
+
 func TestMigrateFramesDB_PreservesNewSubagentsJSON(t *testing.T) {
 	s := openTestFramesStore(t)
 

--- a/internal/store/frames_test.go
+++ b/internal/store/frames_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"testing"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
@@ -225,5 +226,106 @@ func TestFramesStore_UpsertSameIdentityKeepsStoredFrameID(t *testing.T) {
 	}
 	if got.PPID != 101 || got.Status != agentpkg.StatusRunning {
 		t.Fatalf("stored frame = %+v, want updated fields", *got)
+	}
+}
+
+func TestFrames_UpsertAndReadSubagentRefs(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	want := []agentpkg.SubagentRef{{ID: "s1", Type: "cc", StartedAt: 10}}
+	if _, err := s.Upsert(Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Subagents:        want,
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, err := s.GetByIdentity("%5", 200, "A")
+	if err != nil {
+		t.Fatalf("GetByIdentity: %v", err)
+	}
+	if got == nil {
+		t.Fatal("frame not found")
+	}
+	if len(got.Subagents) != 1 {
+		t.Fatalf("subagents len = %d, want 1", len(got.Subagents))
+	}
+	if got.Subagents[0] != want[0] {
+		t.Fatalf("subagents[0] = %+v, want %+v", got.Subagents[0], want[0])
+	}
+}
+
+func TestFrames_EmptySubagentsPreserved(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	if _, err := s.Upsert(Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Subagents:        nil,
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, err := s.GetByIdentity("%5", 200, "A")
+	if err != nil {
+		t.Fatalf("GetByIdentity: %v", err)
+	}
+	if got == nil {
+		t.Fatal("frame not found")
+	}
+	if got.Subagents == nil {
+		t.Fatal("Subagents should be non-nil empty slice, got nil")
+	}
+	if len(got.Subagents) != 0 {
+		t.Fatalf("Subagents len = %d, want 0", len(got.Subagents))
+	}
+}
+
+func TestFrames_SubagentsJSONShapeSmoke(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	if _, err := s.Upsert(Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:        "s1",
+			Type:      "cc",
+			StartedAt: 10,
+		}},
+		Status:     agentpkg.StatusIdle,
+		StartedAt:  10,
+		LastSeenAt: 10,
+		Verified:   true,
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	var raw string
+	err := s.db.QueryRow(`SELECT subagents_json FROM agent_frames WHERE pane_id = ? AND pid = ? AND process_start_time = ?`, "%5", 200, "A").Scan(&raw)
+	if err != nil {
+		t.Fatalf("QueryRow: %v", err)
+	}
+	for _, key := range []string{`"id"`, `"type"`, `"started_at"`, `"source_pid"`, `"source_start_time"`} {
+		if !strings.Contains(raw, key) {
+			t.Errorf("subagents_json missing key %s: %s", key, raw)
+		}
 	}
 }

--- a/internal/store/frames_test.go
+++ b/internal/store/frames_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
 
@@ -327,5 +328,72 @@ func TestFrames_SubagentsJSONShapeSmoke(t *testing.T) {
 		if !strings.Contains(raw, key) {
 			t.Errorf("subagents_json missing key %s: %s", key, raw)
 		}
+	}
+}
+
+// Seeds a legacy `["id"]` shape row directly via SQL (bypassing Upsert) to
+// simulate an agent.sqlite that predates the Phase 2 SubagentRef schema.
+func seedLegacyFrameRow(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO agent_frames (
+		frame_id, pane_id, agent_type, pid, ppid, process_start_time,
+		parent_frame_id, subagents_json, status, started_at, last_seen_at, verified
+	) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)`,
+		"legacy-frame", "%5", "cc", 200, 100, "A",
+		`["legacy-sub-1","legacy-sub-2"]`, "idle", 10, 10, 1); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+}
+
+func TestMigrateFramesDB_ClearsLegacySubagentsJSON(t *testing.T) {
+	events := openTestAgentEventStore(t)
+	if _, err := events.Frames(); err != nil {
+		t.Fatalf("initial Frames: %v", err)
+	}
+	seedLegacyFrameRow(t, events.db)
+
+	// Re-run migration (simulates daemon restart).
+	if err := migrateFramesDB(events.db); err != nil {
+		t.Fatalf("migrateFramesDB: %v", err)
+	}
+
+	var count int
+	if err := events.db.QueryRow(`SELECT COUNT(*) FROM agent_frames`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("agent_frames count = %d after migrate, want 0 (table should be truncated)", count)
+	}
+}
+
+func TestMigrateFramesDB_PreservesNewSubagentsJSON(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	if _, err := s.Upsert(Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Subagents:        []agentpkg.SubagentRef{{ID: "s1", Type: "cc", StartedAt: 10}},
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Re-run migration: new-format row must survive.
+	if err := migrateFramesDB(s.db); err != nil {
+		t.Fatalf("migrateFramesDB: %v", err)
+	}
+
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM agent_frames`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("agent_frames count = %d after migrate, want 1 (new-format row should survive)", count)
 	}
 }

--- a/spa/src/hooks/useTabDisplay.test.ts
+++ b/spa/src/hooks/useTabDisplay.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useAgentStore } from '../stores/useAgentStore'
+import type { SubagentRef } from '../stores/useAgentStore'
 import { useUISettingsStore } from '../stores/useUISettingsStore'
 import { useHostStore } from '../stores/useHostStore'
 import { useSessionStore } from '../stores/useSessionStore'
@@ -157,7 +158,11 @@ describe('useTabDisplay — agent store fields', () => {
     useAgentStore.setState({
       statuses: { 'h1:sc1': 'running' },
       unread: { 'h1:sc1': true },
-      subagents: { 'h1:sc1': [{ id: 's1' }] as never },
+      subagents: {
+        'h1:sc1': [
+          { id: 's1', type: 'cc', started_at: 0, source_pid: 0, source_start_time: '' } satisfies SubagentRef,
+        ],
+      },
     })
     useUISettingsStore.setState({ tabIndicatorStyle: 'dot' })
     const { result } = renderHook(() => useTabDisplay(makeTab()))

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -3,9 +3,13 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { useAgentStore, sanitizeOscTitle } from './useAgentStore'
 import { useTabStore } from './useTabStore'
 import { createTab } from '../types/tab'
-import type { NormalizedEvent } from './useAgentStore'
+import type { NormalizedEvent, SubagentRef } from './useAgentStore'
 
 const H = 'test-host'
+
+function ref(id: string, type: string = 'cc'): SubagentRef {
+  return { id, type, started_at: 0, source_pid: 0, source_start_time: '' }
+}
 
 beforeEach(() => {
   useAgentStore.setState({
@@ -76,7 +80,7 @@ describe('useAgentStore', () => {
       statuses: { [`${H}:dev`]: 'idle' },
       agentTypes: { [`${H}:dev`]: 'cc' },
       models: { [`${H}:dev`]: 'claude-sonnet-4-6' },
-      subagents: { [`${H}:dev`]: ['sub-1'] },
+      subagents: { [`${H}:dev`]: [ref('sub-1')] },
       lastEvents: { [`${H}:dev`]: { agent_type: 'cc', status: 'idle', raw_event_name: 'Stop', broadcast_ts: 1 } },
       unread: { [`${H}:dev`]: true },
     })
@@ -118,14 +122,16 @@ describe('useAgentStore', () => {
 
   it('subagent tracking from event.subagents array', () => {
     // Event with subagents
+    const a = ref('agent-A')
+    const b = ref('agent-B')
     useAgentStore.getState().handleNormalizedEvent(H, 'dev', {
       agent_type: 'cc',
       status: 'running',
-      subagents: ['agent-A', 'agent-B'],
+      subagents: [a, b],
       raw_event_name: 'UserPromptSubmit',
       broadcast_ts: Date.now(),
     })
-    expect(useAgentStore.getState().subagents[`${H}:dev`]).toEqual(['agent-A', 'agent-B'])
+    expect(useAgentStore.getState().subagents[`${H}:dev`]).toEqual([a, b])
 
     // Event with empty subagents removes the entry
     useAgentStore.getState().handleNormalizedEvent(H, 'dev', {
@@ -139,14 +145,15 @@ describe('useAgentStore', () => {
   })
 
   it('event without subagents field does not clear existing subagents', () => {
-    useAgentStore.setState({ subagents: { [`${H}:dev`]: ['agent-A'] } })
+    const a = ref('agent-A')
+    useAgentStore.setState({ subagents: { [`${H}:dev`]: [a] } })
     useAgentStore.getState().handleNormalizedEvent(H, 'dev', {
       agent_type: 'cc',
       status: 'running',
       raw_event_name: 'UserPromptSubmit',
       broadcast_ts: Date.now(),
     })
-    expect(useAgentStore.getState().subagents[`${H}:dev`]).toEqual(['agent-A'])
+    expect(useAgentStore.getState().subagents[`${H}:dev`]).toEqual([a])
   })
 
   it('markRead → clears unread', () => {
@@ -171,8 +178,8 @@ describe('useAgentStore', () => {
         ['other-host:dev']: 'claude-opus-4-6',
       },
       subagents: {
-        [`${H}:dev`]: ['agent-A'],
-        ['other-host:dev']: ['agent-B'],
+        [`${H}:dev`]: [ref('agent-A')],
+        ['other-host:dev']: [ref('agent-B')],
       },
       lastEvents: {
         [`${H}:dev`]: { agent_type: 'cc', status: 'idle', raw_event_name: 'Stop', broadcast_ts: 1 },
@@ -202,7 +209,7 @@ describe('useAgentStore', () => {
     expect(state.statuses['other-host:dev']).toBe('waiting')
     expect(state.agentTypes['other-host:dev']).toBe('codex')
     expect(state.models['other-host:dev']).toBe('claude-opus-4-6')
-    expect(state.subagents['other-host:dev']).toEqual(['agent-B'])
+    expect(state.subagents['other-host:dev']).toEqual([ref('agent-B')])
     expect(state.lastEvents['other-host:dev']).toBeDefined()
     expect(state.unread['other-host:dev']).toBe(true)
   })
@@ -269,10 +276,11 @@ describe('useAgentStore', () => {
 
   it('event with empty status string does not update statuses', () => {
     useAgentStore.setState({ statuses: { [`${H}:dev`]: 'running' } })
+    const a = ref('agent-A')
     const event: NormalizedEvent = {
       agent_type: 'cc',
       status: '',
-      subagents: ['agent-A'],
+      subagents: [a],
       raw_event_name: 'SubagentStart',
       broadcast_ts: Date.now(),
     }
@@ -280,7 +288,7 @@ describe('useAgentStore', () => {
     // Status unchanged
     expect(useAgentStore.getState().statuses[`${H}:dev`]).toBe('running')
     // But subagents updated
-    expect(useAgentStore.getState().subagents[`${H}:dev`]).toEqual(['agent-A'])
+    expect(useAgentStore.getState().subagents[`${H}:dev`]).toEqual([a])
   })
 
   it('models map returns undefined for unknown key', () => {
@@ -292,7 +300,7 @@ describe('useAgentStore', () => {
       statuses: { [`${H}:dev`]: 'idle', [`${H}:staging`]: 'running' },
       agentTypes: { [`${H}:dev`]: 'cc' },
       models: { [`${H}:dev`]: 'claude-sonnet-4-6' },
-      subagents: { [`${H}:dev`]: ['sub-1', 'sub-2'] },
+      subagents: { [`${H}:dev`]: [ref('sub-1'), ref('sub-2')] },
       lastEvents: { [`${H}:dev`]: { agent_type: 'cc', status: 'idle', raw_event_name: 'Stop', broadcast_ts: 1 } },
       unread: { [`${H}:dev`]: true, [`${H}:staging`]: true },
     })

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -32,12 +32,28 @@ function omitKeys<T>(
   return out
 }
 
+/**
+ * Subagent reference — mirrors Go `internal/agent.SubagentRef`. Covers native
+ * SubagentStart refs (source_pid=0 / source_start_time="" / is_proxy omitted)
+ * and cross-agent proxy refs (source_pid/source_start_time populated +
+ * is_proxy:true). Phase 2 PR-2a wires the type end-to-end; PR-2b lights up
+ * proxy detection and the dot visual (type color + outline).
+ */
+export interface SubagentRef {
+  id: string
+  type: string
+  started_at: number
+  source_pid: number
+  source_start_time: string
+  is_proxy?: boolean
+}
+
 /** Normalized event from backend (replaces AgentHookEvent). */
 export interface NormalizedEvent {
   agent_type: string
   status: string             // running | waiting | idle | error | clear
   model?: string
-  subagents?: string[]
+  subagents?: SubagentRef[]
   raw_event_name: string
   broadcast_ts: number
   detail?: Record<string, unknown>
@@ -54,7 +70,7 @@ interface AgentState {
   statuses: Record<string, AgentStatus>
   agentTypes: Record<string, string>
   models: Record<string, string>
-  subagents: Record<string, string[]>
+  subagents: Record<string, SubagentRef[]>
   lastEvents: Record<string, NormalizedEvent>  // for notification dispatcher
   oscTitles: Record<string, string>  // latest OSC 0/2 title per session (ephemeral)
   ccStatus: Record<string, CcStatusEntry>  // latest CC statusLine snapshot (ephemeral)


### PR DESCRIPTION
## Summary

Phase 2 (Lights rebuild) PR-2a. **Schema + Wire breaking upgrade** staging PR — no product-semantic change, but introduces two user-visible breaking changes that PR-2b will build on.

This PR emerged from **5 rounds of codex adversarial review** converging the plan. See `docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md` v1→v6 (§10 full change log).

## What changes

### New type

- `internal/agent/subagent.go` — `SubagentRef{ID, Type, StartedAt, SourcePID, SourceStartTime, IsProxy}`
  - `IsProxy` uses `omitempty`; `source_pid` / `source_start_time` **not** omitempty (native refs serialize zero values explicitly)

### Upgraded types (store + runtime + wire)

- `store.Frame.Subagents` — `[]string` → `[]agentpkg.SubagentRef`
- `module.agent.SessionProjection.Subagents` — same
- `module.agent.Module.subagents` map — same
- `agent.NormalizedEvent.Subagents` — same (WS broadcast wire)
- `updateSubagents` signature: `(current []SubagentRef, eventName string, ref SubagentRef) → []SubagentRef`

### Upgraded SPA types

- `useAgentStore.SubagentRef` TS interface matching Go JSON shape
- `NormalizedEvent.subagents?: SubagentRef[]`
- `AgentState.subagents: Record<string, SubagentRef[]>`
- SubagentDots / TabIcon / SortableTab / InlineTab / renderInlineTabIcon **prop APIs unchanged** (still count-based; PR-2b converts)
- `useTabDisplay` keeps `subagentCount = subagents[ck]?.length ?? 0` (type auto-follows; behavior unchanged)

### Test updates

**12 new Go tests:**
- `subagent_test.go`: R1-R3 (JSON round-trip, omitempty, zero fields)
- `frames_test.go`: F1-F3 (store upsert/read + JSON shape smoke)
- `frame_ops_test.go`: U1-U5 (updateSubagents signature + duplicate/ignore-type/missing behavior)
- `handler_test.go`: HB1 (broadcast payload carries SubagentRef shape, no `is_proxy` key for native)

**SPA test seed migrations:** `useAgentStore.test.ts` ~15 fixtures, `useTabDisplay.test.ts` line 160 cast.

## ⚠ BREAKING CHANGES

### Agent DB (on-disk schema)

`agent_frames.subagents_json` column format:
- **Before**: `["id1", "id2"]`
- **After**: `[{"id": "id1", "type": "cc", "started_at": 123, "source_pid": 0, "source_start_time": "", "is_proxy": true?}]`

**Action required after upgrade**: rebuild the agent DB
```
rm ~/Library/Application\ Support/Purdex/<host>/agent.sqlite
# (macOS path; delete the whole <host> dir if unsure)
```

After rebuild, all frames empty and re-populate from live hook events. No user data lost (frames are ephemeral telemetry).

### WS wire (NormalizedEvent)

`subagents: string[]` → `subagents: SubagentRef[]`. Daemon + SPA must upgrade in lockstep. Electron dev-update skew may briefly show empty subagents UI; reload once after both are on alpha.218.

### Rollback

Revert this PR + rebuild agent DB to restore old schema (alpha allows).

## Commit narrative

| Commit | Description |
|---|---|
| `d95e49b7` | feat(agent): add SubagentRef type with source identity |
| `7355a3e2` | refactor(store+agent): atomic SubagentRef schema upgrade |
| `edb6ce87` | refactor(agent): upgrade NormalizedEvent.Subagents wire |
| `6de52911` | refactor(spa): upgrade useAgentStore subagents to SubagentRef[] |
| `2b1ee2ba` | test(spa): update subagents mocks across seed sites |

**Deviation from plan v6 §3**: Subagent noted that `NormalizedEvent.Subagents` wire type change is compile-coupled to commit 2's schema upgrade (type propagates through `buildProjectionNormalized`). Commit 3 keeps its name and adds HB1 broadcast-level regression test (documents wire contract); the actual field type change happens in commit 2 to preserve the plan's "every commit boundary green" rule.

## What's NOT in this PR (deferred to PR-2b)

- Proxy detection via PPID ancestor walk (`findProxyParent` depth=5 with start_time identity check + same-type hard stop)
- SessionEnd proxy ref cleanup (`removeProxyRefForSender`)
- Frame idle sweep (1h threshold + `DeleteIfUnchanged` optimistic DELETE)
- SubagentDots visual upgrade (type color + proxy outline)
- All SPA prop API conversions from `subagentCount: number` → `subagentRefs: SubagentRef[]`
- New regression tests PR1-PR15 (proxy), SE1-SE3 (session end), IS1-IS5 (idle sweep), HB2 (proxy broadcast)

PR-2b opens after this merges + alpha.218 bump + user confirms DB rebuilt cleanly.

## Test plan

- [ ] `rm ~/Library/Application\ Support/Purdex/<host>/agent.sqlite` (or equivalent) — rebuild fresh DB
- [ ] Start daemon; trigger cc SessionStart → verify `subagents_json` column in DB contains object shape (not string shape)
- [ ] Trigger cc SubagentStart (Task tool) → SPA SubagentDots still renders dot with old count-based behavior unchanged
- [ ] `go test ./...` green
- [ ] `cd spa && pnpm run lint && pnpm run build && npx vitest run` — all pass except 3 pre-existing `hosts.test.ts` failures (unrelated sync token preservation, not from this PR)
- [ ] Open `SettingsPage` / `HostPage` / `WorkspaceSettingsPage` to ensure no runtime errors from type layer upgrade