### PR TITLE
feat(agent): Phase 2 PR-2b — proxy detection + idle sweep + SubagentDots visual

### DIFF
--- a/docs/specs/2026-04-24-lights-rebuild-phase-2b-plan.md
+++ b/docs/specs/2026-04-24-lights-rebuild-phase-2b-plan.md
@@ -1,15 +1,27 @@
 # Phase 2 PR-2b Delta Plan — Proxy + Idle Sweep + SubagentDots 視覺
 
-Baseline：`1.0.0-alpha.218`（main @ PR-2a #622 squash `8bf955e7` + bump #624 `6b461c1b`）。
+Baseline：`1.0.0-alpha.219`（main @ `8d96bd4c`；Editor restructure PR #623 已 merged 於 alpha.219）。
 Worktree：`.claude/worktrees/lights-phase-2b`（branch `worktree-lights-phase-2b`）。
+PR-2b merge 後預計 bump **alpha.220**。
 
 ---
 
 ## 0. 這份 plan 的定位（必讀）
 
-整個 Phase 2 的契約與 TDD 步驟 **已在 PR-2a plan 內完整定義**（經 5 輪 plan review + 4 輪 code review 收斂）。PR-2b 大量 reference 該文件：
+### 0.1 施工前必讀順序（Reading Order）
 
-**契約源文件**：`docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md`（v6, 997 行）
+整個 Phase 2 的契約與 TDD 步驟 **已在 PR-2a plan 內完整定義**（經 5 輪 plan review + 4 輪 code review 收斂）。**此 delta plan 不自含 hard contracts** — subagent 開工前必須：
+
+1. **先讀 v6 plan** @ `docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md`（997 行）的 §0 / §1.4 / §1.5 / §1.6 / §1.7 / §1.8 / §1.13 / §2.3 / §2.5 / §2.6 / §2.7 / §2.8 / §2.9 / §3 commits 6-10 / §4 PR-2b 表 / §5 / §7 PR-2b / §8 / §9 PR-2b — 這是**主 contract 源**，所有 pseudo-code、測試矩陣、命名、SQL 都在那裡
+2. **再讀本 delta plan**（274 行）— 記錄 v6 **不知道** 的四類事實：
+   - PR-2a 落地後實際 line 座標 / 檔案大小（§1）
+   - PR-2a 4 輪 code review 的 3 個教訓對 PR-2b 的延伸 impact（§3）
+   - v6 plan 本身有的小 omission（§1.6 的 useTabDisplay.ts）
+   - PR-2b 開工順序決策（subagentCount 保留、commit atomicity）
+
+每個 commit 開工前，subagent 應**先重讀對應 v6 章節**（本 delta §2 逐 commit 給 reference），再施工。
+
+### 0.2 契約源文件索引
 
 | 主題 | 源章節 |
 |---|---|
@@ -112,7 +124,7 @@ grep 當前 head（@ `6b461c1b`），v6 plan §1.14 表格列出的座標與實�
 v6 §1.14 SPA 允許改動表把 **`useTabDisplay.ts` 回傳擴充 `subagentRefs`** 歸為 PR-2b 改動（§1.13 段落確實提到），但 §1.14 的大表只列了下游 consumer 沒列 `useTabDisplay.ts` 自己。
 
 **PR-2b 實際要改**：
-- `spa/src/hooks/useTabDisplay.ts` — 加 `subagentRefs: SubagentRef[]` 回傳欄位（derive from `s.subagents[ck] ?? []`）。`subagentCount` 保留（後續 cleanup 時再決定是否移除；本 PR-2b 不碰，避免 scope 蔓延）
+- `spa/src/hooks/useTabDisplay.ts` — 加 `subagentRefs: SubagentRef[]` 回傳欄位（derive from `s.subagents[ck] ?? []`）；`subagentCount` **保留**（避免 scope 蔓延；後續 cleanup PR 另辦，不在本 PR-2b 範圍）
 - 若 useTabDisplay 的 TypeScript 型別 export 被其他檔案 import，連帶加 `subagentRefs` 欄位
 
 ### 1.7 PR-2a 新增的 test seams（對 PR-2b 測試有幫助，可選用）
@@ -172,8 +184,8 @@ PR-2a R2 + R4 code review 修復中引入：
     3. `SortableTab.tsx` prop rename + 兩處 TabIcon 呼叫（line 92, 132）
     4. `InlineTab.tsx` prop rename（line 42 destructure, line 111 轉介）
     5. `renderInlineTabIcon.tsx` prop rename + 三處 SubagentDots 呼叫
-    6. `useTabDisplay.ts` 擴充 `subagentRefs` 回傳（derive from `s.subagents[ck] ?? []`）
-  - **`subagentCount` 保留否**：建議**移除**（PR-2a 後 useTabDisplay 仍 export `subagentCount`，但 consumer 都 rename 吃 `subagentRefs`，`subagentCount` orphan；`refs.length` 一行取代）— PR-2b 連帶 clean up 避免死 field
+    6. `useTabDisplay.ts` 擴充 `subagentRefs` 回傳（derive from `s.subagents[ck] ?? []`）；**`subagentCount` 保留不動**（consumer rename 後仍 orphan 但不在本 PR 清）
+  - **`subagentCount` 最終決策（保留）**：PR-2b 不刪 useTabDisplay 的 `subagentCount` return field，即使 consumer 都已 rename。刪除動作留給後續 cleanup PR（可能與 `dropSubagentDotsCountAPI` / `useTabDisplay.subagentCount` deprecation 一起辦）。理由：避免 PR-2b scope 從 UI wiring 擴散到 hook 介面 breaking；reviewer 對 scope 的判準一致
   - **TYPE_COLOR 位置**：v6 §5 「不做」已寫不抽到 `agent-icons.tsx`，**在 SubagentDots.tsx 內 inline const table**：
     ```ts
     const TYPE_COLOR: Record<string, string> = {
@@ -214,7 +226,7 @@ PR-2a 4 輪 code review 修掉的問題中，**三項對 PR-2b 有延伸 impact*
 
 - **Schema**：PR-2a 已立 `subagents_json` JSON shape（`SubagentRef[]`）；PR-2b 寫入帶 `IsProxy=true` 的 ref 時 **沿用同 shape**，migrateFramesDB 的三態偵測仍能 pass new schema
 - **Wire**：PR-2a 已升級 `NormalizedEvent.Subagents` 為 `[]SubagentRef`；PR-2b 的 proxy ref 與 native ref **wire 型別一致**，SPA 不需再改 parse 邏輯（只改 render）
-- **Bump 版本**：PR-2b merge 後 bump `alpha.219`；CHANGELOG 標「proxy 偵測 + idle sweep 啟用」但**不需**標 schema breaking（已在 alpha.218 入過）
+- **Bump 版本**：PR-2b merge 後 bump `alpha.220`（baseline 已是 alpha.219）；CHANGELOG 標「proxy 偵測 + idle sweep 啟用」但**不需**標 schema breaking（已在 alpha.218 入過）
 
 ---
 
@@ -234,11 +246,19 @@ v6 §8 的風險清單仍全部適用。PR-2a 落地後新增兩條觀察：
 照 v6 §7 PR-2b 段執行，總結如下：
 
 - [ ] 5 個 commits（6-10）符合規範，每個 commit 邊界 `go build ./...` + tests 綠
-- [ ] `go test ./...` 綠；必跑 **27 個新測試**：F4-F6 / PR1-PR15 / SE1-SE3 / IS1-IS5 / HB2
+- [ ] Go 側 `go test ./...` 綠；必跑 **27 個新 Go 測試**：
+  - `internal/store/frames_test.go`：F4 / F5 / F6（DeleteIfUnchanged）
+  - `internal/module/agent/frame_ops_test.go`：PR1-PR15（15 個 proxy 偵測 case）+ SE1 / SE2 / SE3（3 個 SessionEnd cleanup）
+  - `internal/module/agent/sweep_test.go`：IS1 / IS2 / IS3 / IS4 / IS5（5 個 idle sweep case）
+  - `internal/module/agent/handler_test.go`：HB2（1 個 broadcast IsProxy smoke）
 - [ ] `go vet ./...` 無 warning
-- [ ] `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
+- [ ] SPA 側 `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠；PR-2b 必跑 / 必加 SPA 測試（對應 v6 §2.9 PR-2b 段 + §4 PR-2b SPA 表）：
+  - **新檔** `spa/src/components/SubagentDots.test.tsx`：3 case — count（1/2/3 refs → dot 數）、type color（cc 藍 / codex 黃 / opencode 橘）、proxy outline（`is_proxy:true` → transparent bg + 1px border；`false/undefined` → solid bg）
+  - `spa/src/components/SortableTab.test.tsx`：既有 case `subagentCount: N` prop 升級為 `subagentRefs: SubagentRef[N]`；新加一個 case — `subagentRefs` 含 `is_proxy:true` ref → 渲染 outline dot（prop-wiring 驗證）
+  - `spa/src/features/workspace/components/InlineTab.test.tsx`：prop `subagentCount` → `subagentRefs` 升級；新加 proxy outline prop-wiring case
+  - `spa/src/features/workspace/lib/renderInlineTabIcon.test.tsx`：三個 render 模式（dot/iconDot/badge）驗證 `subagentRefs` 正確 forward 給 `<SubagentDots refs={...} />`；補 proxy outline case
 - [ ] PR diff 檔案：v6 §4 PR-2b 表格 + 本 delta §1.6（useTabDisplay.ts）列出的檔案；**其餘不得出現**
-- [ ] PR description 含 v6 §5「不做項目」聲明
+- [ ] PR description 含 v6 §5「不做項目」聲明 + §8 Open Question 1（proxy ID collision）的 PR description preemptive answer
 - [ ] 手動場景 4 項：
   - cc 啟動 → cc pane 內跑 `/codex:*` → SPA 只顯示 1 個 frame（cc），cc.Subagents 含 codex ref，SubagentDots 黃色 outline
   - 手造 idle frame（臨時改 threshold 到 1s 或 DB 改 LastSeenAt）→ sweep 後 frame 消失、broadcast reason `sweep:idle_timeout`
@@ -269,6 +289,7 @@ v6 §8 的風險清單仍全部適用。PR-2a 落地後新增兩條觀察：
 
 ## 8. Open Questions
 
-1. **`subagentCount` 是否完全移除**：本 delta §2 Commit 10 建議 `useTabDisplay.ts` 不再 return `subagentCount`；如果 reviewer 覺得 breaking 太大或有 external consumer 讀這欄位，改為 deprecated 保留（兩路都可）
-2. **proxy ref 的 agent_id collision**：v6 §9 PR-2b R2 攻擊預期有這問題 — 當 native SubagentStart 的 `agent_id` 字串碰巧開頭是 `proxy:`（非常罕見但非零機率）時，SessionEnd 的 `removeProxyRefForSender` 會不會誤刪？**不會**，因為 matching key 是 `SourcePID+SourceStartTime`（native ref 這兩欄為 0/空），不是 ID 字串。此答案寫進 PR description 防 R2 重問
-3. **dev update skew 期間 SPA 若吃到舊 daemon（alpha.218）送的 native-only subagents，新 SubagentDots 渲染**：fallback color 行為正確（`TYPE_COLOR[ref.type] ?? cc`），proxy 欄位 undefined 走 solid dot；不需額外 guard
+1. **proxy ref 的 agent_id collision**：v6 §9 PR-2b R2 攻擊預期有這問題 — 當 native SubagentStart 的 `agent_id` 字串碰巧開頭是 `proxy:`（非常罕見但非零機率）時，SessionEnd 的 `removeProxyRefForSender` 會不會誤刪？**不會**，因為 matching key 是 `SourcePID+SourceStartTime`（native ref 這兩欄為 0/空），不是 ID 字串。此答案寫進 PR description 防 R2 重問
+2. **dev update skew 期間 SPA 若吃到舊 daemon（alpha.219）送的 native-only subagents，新 SubagentDots 渲染**：fallback color 行為正確（`TYPE_COLOR[ref.type] ?? cc`），proxy 欄位 undefined 走 solid dot；不需額外 guard
+
+（原 Open Question 1「subagentCount 是否移除」已在 §1.6 + §2 Commit 10 確定為**保留**，不再 open）

--- a/docs/specs/2026-04-24-lights-rebuild-phase-2b-plan.md
+++ b/docs/specs/2026-04-24-lights-rebuild-phase-2b-plan.md
@@ -1,0 +1,274 @@
+# Phase 2 PR-2b Delta Plan — Proxy + Idle Sweep + SubagentDots 視覺
+
+Baseline：`1.0.0-alpha.218`（main @ PR-2a #622 squash `8bf955e7` + bump #624 `6b461c1b`）。
+Worktree：`.claude/worktrees/lights-phase-2b`（branch `worktree-lights-phase-2b`）。
+
+---
+
+## 0. 這份 plan 的定位（必讀）
+
+整個 Phase 2 的契約與 TDD 步驟 **已在 PR-2a plan 內完整定義**（經 5 輪 plan review + 4 輪 code review 收斂）。PR-2b 大量 reference 該文件：
+
+**契約源文件**：`docs/specs/2026-04-23-lights-rebuild-phase-2-plan.md`（v6, 997 行）
+
+| 主題 | 源章節 |
+|---|---|
+| PR-2a/2b 拆分策略 | §0 |
+| `SubagentRef` 型別 | §1.1（**已在 PR-2a 落地，勿重新定義**） |
+| Proxy 偵測 PPID 祖先鏈 walk（depth=5 + same-type hard-stop + start_time identity 三分支） | **§1.4** |
+| SessionEnd proxy cleanup | **§1.5** |
+| Frame idle sweep（1h + conditional DELETE） | **§1.6** |
+| `FramesStore.DeleteIfUnchanged` 新 method | **§1.7** |
+| `clearFrame` 拆分 + `afterFrameCleared` + orphan watcher fix | **§1.8** |
+| SubagentDots API 升級（`count` → `refs`）+ type color + proxy outline | **§1.13** |
+| 測試清單 F4-F6 / PR1-PR15 / SE1-SE3 / IS1-IS5 / HB2 | **§2.3, §2.5-2.9** |
+| Commit 6-10 TDD 執行順序 | **§3（PR-2b 段）** |
+| 行數預估 | §4（PR-2b 表） |
+| 不做項目 | §5 |
+| 驗收清單 | §7（PR-2b 段） |
+| 風險清單 | §8 |
+| Review focus 預期 | §9（PR-2b 段） |
+
+**本 delta plan 的範圍**：只記錄 PR-2a 落地**之後**才確定的事，不重寫 v6 已鎖的契約。
+
+---
+
+## 1. PR-2a 落地狀態 vs v6 plan 假設（對照）
+
+PR-2a 於 2026-04-24 squash-merged。以下為 PR-2b 需要鉤入的實際 landing state，**與 v6 plan 假設對照**，確認 §1.4-1.8 / §1.13 可直接施工無 drift。
+
+### 1.1 `internal/agent/subagent.go`（16 行，PR-2a 新檔）
+
+型別與 v6 §1.1 完全一致：
+
+```go
+type SubagentRef struct {
+    ID              string `json:"id"`
+    Type            string `json:"type"`
+    StartedAt       int64  `json:"started_at"`
+    SourcePID       int    `json:"source_pid"`
+    SourceStartTime string `json:"source_start_time"`
+    IsProxy         bool   `json:"is_proxy,omitempty"`
+}
+```
+
+**落地註解要點**（PR-2a R1 review fix）：
+- `Type` 固定取 `frame.AgentType`（canonical agent family：cc / codex / opencode），**不吃** `detail.agent_type`（opencode 的 per-subagent sub-variant 如 `"Explore"`）
+- PR-2b proxy ref 組 `Type` 時同樣用 `req.AgentType`（sender agent family），**不是** parent.AgentType
+
+### 1.2 `internal/module/agent/frame_ops.go`（378 行，PR-2a 擴到此規模）
+
+**v6 §1.4 要求**：PR-2b 在 `applyFrameEvent` 的 **SessionStart 分支、建新 frame 之前** 插入 proxy 判斷。
+
+**實際落地結構**：`applyFrameEvent` 目前有三個明確分支：
+1. `SessionEnd` — line 35-56（`frame != nil` 刪除 vs `frame == nil` → `session_end_without_frame`）
+2. `SubagentStart` / `SubagentStop` — line 57-107（必須 `frame != nil` 否則 `frame_missing`）
+3. **其餘（SessionStart + 一般 hook 更新）** — line 109-176（`readProcessInfoFn` → `FindByPanePID(paneID, info.PPID)` single-layer parent lookup → `frames.Upsert`）
+
+**PR-2b 插入點**（v6 §1.4 命中行為）：
+- 在 line 109 `readProcessInfoFn(req.SenderPID)` **之前** 插 proxy fast-path
+- 觸發條件：`req.EventName == "SessionStart"` && `frame == nil`
+- 命中 → call `m.findProxyParent(req)` → `updateSubagents(parent.Subagents, "SubagentStart", proxyRef)` + `m.frames.Upsert(*parent)`，**早 return** trace meta `decision="updated_frame", reason="proxy_subagent_attached"`
+- 不命中 → fall through 原 line 109+ legacy 建新 frame 路徑
+
+**既有 single-layer parent lookup**（line 125-133）**保留不動** — 它是 non-proxy 的 `parent_frame_found` / `parent_frame_missing` 分支，與 proxy 偵測正交（proxy 命中時直接 early-return）。
+
+**SessionEnd proxy cleanup 插入點**（v6 §1.5）：
+- 改動現有 line 50-56 的 `frame == nil` 路徑
+- 先 call `m.removeProxyRefForSender(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, broadcastTs)`
+- 命中（`removed=true`）→ 新 trace meta `decision="updated_frame", reason="proxy_subagent_detached"`
+- 不命中 → fall through 原 `session_end_without_frame` 路徑
+
+### 1.3 `internal/module/agent/sweep.go`（103 行，PR-2a 未動）
+
+現況與 v6 §1.8 描述完全一致：
+- `sweepOnce`（line 39-68）有兩條規則（`pid_dead` / `pid_reused`）
+- `clearFrame`（line 70-103）為單一路徑，混合 Delete + side effects
+
+**PR-2b 改動**（v6 §1.6, §1.8）：
+- `sweepOnce` 加第三條：`nowFn().UnixNano() - frame.LastSeenAt > frameIdleThreshold.Nanoseconds()` → `DeleteIfUnchanged`（conditional，concurrent refresh 時 skip）
+- `clearFrame` 拆出 `afterFrameCleared(frame, reason)`（broadcast + legacy event clean + orphan watcher StopWatch）
+- 新增 `nowFn = time.Now`（test seam）
+- **順便修既有 bug**：pid_dead / pid_reused 路徑目前（line 91）只 `delete(m.activeWatchers, sessionName)` 但沒 `m.prober.StopWatch(sessionName + ":")` → goroutine leak；PR-2b 順手補，新增 IS4 regression test
+
+### 1.4 `internal/store/frames.go`（322 行）
+
+v6 §1.7 `DeleteIfUnchanged` 為新 method，落地前不存在。落地後 method 座標建議：放在現有 `Delete(frameID string) error` 鄰近，共用同款 SQL pattern。
+
+### 1.5 SPA consumer 檔案（實際 line 位置確認）
+
+grep 當前 head（@ `6b461c1b`），v6 plan §1.14 表格列出的座標與實際一致：
+
+| 檔案 | prop declaration | SubagentDots 呼叫 |
+|---|---|---|
+| `spa/src/components/TabIcon.tsx` (95 行) | line 29 `subagentCount: number` | line 59 / 70 / 92（dot/iconDot/badge）|
+| `spa/src/components/SortableTab.tsx` (166 行) | line 43 prop destructure | TabIcon 調用 @ line 92 / 132 |
+| `spa/src/features/workspace/components/InlineTab.tsx` (158 行) | line 42 prop destructure | line 111 轉介給 renderInlineTabIcon |
+| `spa/src/features/workspace/lib/renderInlineTabIcon.tsx` (96 行) | line 11 prop decl / line 35 destructure | line 58 / 72 / 93（三模式）|
+| `spa/src/hooks/useTabDisplay.ts` | line 27 return `subagentCount: number` / line 52 derive | line 83 return field |
+
+### 1.6 Plan v6 §1.14 漏列項（delta 補齊）
+
+v6 §1.14 SPA 允許改動表把 **`useTabDisplay.ts` 回傳擴充 `subagentRefs`** 歸為 PR-2b 改動（§1.13 段落確實提到），但 §1.14 的大表只列了下游 consumer 沒列 `useTabDisplay.ts` 自己。
+
+**PR-2b 實際要改**：
+- `spa/src/hooks/useTabDisplay.ts` — 加 `subagentRefs: SubagentRef[]` 回傳欄位（derive from `s.subagents[ck] ?? []`）。`subagentCount` 保留（後續 cleanup 時再決定是否移除；本 PR-2b 不碰，避免 scope 蔓延）
+- 若 useTabDisplay 的 TypeScript 型別 export 被其他檔案 import，連帶加 `subagentRefs` 欄位
+
+### 1.7 PR-2a 新增的 test seams（對 PR-2b 測試有幫助，可選用）
+
+PR-2a R2 + R4 code review 修復中引入：
+
+| Seam | 位置 | PR-2b 用途 |
+|---|---|---|
+| `store.AgentEventStore.ExecRawForTest(q, args...)` | `internal/store/agent_event.go` | 跨 package 測試 seed（目前 PR-2b 測試不需，仍可用）|
+| `framesInitFn` / `tracesInitFn` | `internal/module/agent/module.go` | `Module.New` 測試注入（PR-2b 的 proxy/sweep 測試可照舊用 subagent fixture 直接 seed，不需）|
+
+---
+
+## 2. PR-2b 施工項目（reference v6 §1.4-§1.8, §1.13）
+
+以下以 commit 為單位對照 v6 §3，只列 delta / 補充。契約細節**以 v6 為準**。
+
+### Commit 6 — `feat(store): add DeleteIfUnchanged for optimistic sweep`
+- 契約：v6 §1.7
+- 測試：v6 §2.3（F4/F5/F6）
+- Delta：無
+
+### Commit 7 — `feat(module/agent): detect proxy subagents via PPID ancestor walk`
+- 契約：v6 §1.4（含 v4 same-type hard-stop、v5 start_time error abort walk 三分支）
+- 測試：v6 §2.5（PR1-PR15 共 15 測試）
+- Delta：
+  - **插入點**：`applyFrameEvent` line 109 `readProcessInfoFn` 之前（§1.2 描述）
+  - **proxy ID 字串**：v6 §1.4 寫 `fmt.Sprintf("proxy:%s:%d:%s", req.AgentType, req.SenderPID, req.SenderStartTime)` — 沿用
+  - **Type 欄位 canonical rule**：PR-2a R1 已確立 `Type = frame.AgentType`；PR-2b proxy ref 的 `Type = req.AgentType`（新進 hook 的 sender agent family，**非** parent 的 type）— v6 §1.4 命中行為 code block 已寫對
+  - **test seam 取名**：`readProcessInfoFn` / `isPidAliveFn` / `processStartTimeFn` 已是 module-level 變數可直接替換；不需另開 seam
+  - **Trace meta 欄位**：`Before`/`After` 兩者都 `summarizeFrame(parent)` 前後值，**不要** 用 proxy ref 自己的 map
+
+### Commit 8 — `feat(module/agent): remove proxy ref on SessionEnd`
+- 契約：v6 §1.5
+- 測試：v6 §2.6（SE1/SE2/SE3）
+- Delta：
+  - **`removeProxyRefForSender` helper 位置**：放 `frame_ops.go` 內部 method，private
+  - **scan 範圍**：`m.frames.ListByPane(req.TmuxPaneID)` + inner loop `frame.Subagents` — v6 §1.5 已明確
+  - **matching key**：`ref.SourcePID == req.SenderPID && ref.SourceStartTime == req.SenderStartTime`，**不** 吃 `ref.ID` 字串（穩健性）
+
+### Commit 9 — `feat(module/agent): idle sweep with conditional DELETE`
+- 契約：v6 §1.6 + §1.8
+- 測試：v6 §2.7（IS1-IS5）+ §2.8（HB2）
+- Delta：
+  - **`afterFrameCleared` 職責**：原 `clearFrame` line 77-102 的 side effects 整塊搬過去（保順序）— session_name / code resolve → event Delete → projection → syncProjectionState → activeWatchers cleanup → **新增 StopWatch** → broadcast
+  - **StopWatch bug fix 涵蓋路徑**：不只新 `idle_timeout`，pid_dead / pid_reused 都走同一條 `afterFrameCleared` 所以三路徑都修到
+  - **broadcast reason 字串**：`"sweep:" + reason`（`"sweep:pid_dead"` / `"sweep:pid_reused"` / `"sweep:idle_timeout"`）— 保既有格式，reviewer 不會看到 hook event_name 被「換皮」
+  - **`nowFn` 導入但不 re-export**：module 內 private 變數，test 用 `nowFn = func() time.Time { return fakeNow }` 覆寫
+
+### Commit 10 — `feat(spa): SubagentDots takes SubagentRef[] with type color + proxy outline`
+- 契約：v6 §1.13
+- 測試：v6 §2.9 PR-2b 段
+- Delta：
+  - **atomic commit**：TypeScript 型別的 prop rename 必須一次改完所有 consumer，否則 compile 破。Commit 10 改動：
+    1. `SubagentDots.tsx` API `{count}` → `{refs}`
+    2. `TabIcon.tsx` prop `subagentCount: number` → `subagentRefs: SubagentRef[]`（3 處 render）
+    3. `SortableTab.tsx` prop rename + 兩處 TabIcon 呼叫（line 92, 132）
+    4. `InlineTab.tsx` prop rename（line 42 destructure, line 111 轉介）
+    5. `renderInlineTabIcon.tsx` prop rename + 三處 SubagentDots 呼叫
+    6. `useTabDisplay.ts` 擴充 `subagentRefs` 回傳（derive from `s.subagents[ck] ?? []`）
+  - **`subagentCount` 保留否**：建議**移除**（PR-2a 後 useTabDisplay 仍 export `subagentCount`，但 consumer 都 rename 吃 `subagentRefs`，`subagentCount` orphan；`refs.length` 一行取代）— PR-2b 連帶 clean up 避免死 field
+  - **TYPE_COLOR 位置**：v6 §5 「不做」已寫不抽到 `agent-icons.tsx`，**在 SubagentDots.tsx 內 inline const table**：
+    ```ts
+    const TYPE_COLOR: Record<string, string> = {
+      cc: '#60a5fa',
+      codex: '#facc15',
+      opencode: '#f97316',
+    }
+    const colorFor = (type: string) => TYPE_COLOR[type] ?? TYPE_COLOR.cc
+    ```
+  - **Proxy outline 實作**：
+    ```ts
+    const dotStyle = (ref: SubagentRef): CSSProperties => {
+      const color = colorFor(ref.type)
+      return ref.is_proxy
+        ? { backgroundColor: 'transparent', border: `1px solid ${color}` }
+        : { backgroundColor: color }
+    }
+    ```
+
+### Commit 11（可選）— `docs: phase 2 plan retrospective notes`
+若 §3 順序與實際執行有偏差（例 IS4 拆出 commit / proxy ID 公式微調），補 retrospective note。
+
+---
+
+## 3. PR-2a code review 教訓對 PR-2b 的 impact
+
+PR-2a 4 輪 code review 修掉的問題中，**三項對 PR-2b 有延伸 impact**：
+
+| PR-2a finding | Fix commit | PR-2b 延伸 |
+|---|---|---|
+| R1 P1：legacy DB 全域 hook 500（handler 沒早退 invalid result） | `67745bdc` | Proxy 偵測的 early-return 要走 handler 能消化的 trace meta shape；不要塞 malformed decision 字串 |
+| R2 P1：`LIMIT 1` probe miss mixed table（migration 不能只看一列判型別） | `2efec87b` | 新測試 IS5 用 fake store wrap `FramesStore` 模擬 concurrent refresh — fake store 必須掃全表行為一致（不是 `LIMIT 1` probe） |
+| R3→R4 P1：`Module.New` frames err 吞 vs traces err best-effort 的區別 | `72e2f840`+`74796145` | `sweep.go` 新 `DeleteIfUnchanged` 回 `(false, nil)` 時 **不是 error** 要 `continue`；不要 wrap 成 `return err`（否則 sweep 遇 concurrent 就當掉） |
+
+---
+
+## 4. PR-2b 與 PR-2a 的 wire / schema 面向（不用動）
+
+- **Schema**：PR-2a 已立 `subagents_json` JSON shape（`SubagentRef[]`）；PR-2b 寫入帶 `IsProxy=true` 的 ref 時 **沿用同 shape**，migrateFramesDB 的三態偵測仍能 pass new schema
+- **Wire**：PR-2a 已升級 `NormalizedEvent.Subagents` 為 `[]SubagentRef`；PR-2b 的 proxy ref 與 native ref **wire 型別一致**，SPA 不需再改 parse 邏輯（只改 render）
+- **Bump 版本**：PR-2b merge 後 bump `alpha.219`；CHANGELOG 標「proxy 偵測 + idle sweep 啟用」但**不需**標 schema breaking（已在 alpha.218 入過）
+
+---
+
+## 5. 風險補充（vs v6 §8）
+
+v6 §8 的風險清單仍全部適用。PR-2a 落地後新增兩條觀察：
+
+| 新風險 | 機率 | 影響 | 緩解 |
+|---|---|---|---|
+| `frame_ops.go` 施工後 >500 行（目前 378 + ~145 估 = ~520） | 中 | Review R2 體質檢查會警告 | 可接受；若 reviewer 強烈要求，拆 `proxy.go` + `frame_ops.go`（private helper 搬過去不換 receiver）但不在本 PR 預先拆 |
+| sweepOnce 新加 `idle_timeout` 第三條規則的位置 | 低 | 若放在第一條規則（pid check）之前會錯過 dead/reused 的提前清理 | 保第三條位置（v6 §1.6 已寫），IS1-IS5 測試覆蓋 |
+
+---
+
+## 6. 驗收 checklist（PR-2b）
+
+照 v6 §7 PR-2b 段執行，總結如下：
+
+- [ ] 5 個 commits（6-10）符合規範，每個 commit 邊界 `go build ./...` + tests 綠
+- [ ] `go test ./...` 綠；必跑 **27 個新測試**：F4-F6 / PR1-PR15 / SE1-SE3 / IS1-IS5 / HB2
+- [ ] `go vet ./...` 無 warning
+- [ ] `cd spa && pnpm run lint && pnpm run build && npx vitest run` 綠
+- [ ] PR diff 檔案：v6 §4 PR-2b 表格 + 本 delta §1.6（useTabDisplay.ts）列出的檔案；**其餘不得出現**
+- [ ] PR description 含 v6 §5「不做項目」聲明
+- [ ] 手動場景 4 項：
+  - cc 啟動 → cc pane 內跑 `/codex:*` → SPA 只顯示 1 個 frame（cc），cc.Subagents 含 codex ref，SubagentDots 黃色 outline
+  - 手造 idle frame（臨時改 threshold 到 1s 或 DB 改 LastSeenAt）→ sweep 後 frame 消失、broadcast reason `sweep:idle_timeout`
+  - codex SessionEnd（proxy 來源）→ cc.Subagents 空、dot 消失
+  - cc native SubagentStart（Task 工具觸發）→ SPA 顯示藍色實心 dot
+
+---
+
+## 7. Review cadence 預期
+
+### PR-2b plan review（本檔）
+
+**目標**：1-2 輪收斂（因為契約已在 PR-2a v6 定過）
+- **Round 1**：標準 review — 重點檢 delta plan 是否有漏 v6 plan 已鎖的 contract、是否誤改 contract
+- **Round 2**（若需要）：3-parallel — 防守方可能挑 delta 章節編排、攻擊方挑 proxy ID collision / stale watcher edge case
+
+### PR-2b code review
+
+**目標**：2-4 輪收斂（proxy 語意 + sweep race 是重點）
+- **R1 標準**：proxy 偵測 PPID walk 的邊界條件（info 讀 error / self-cycle / depth+1 超界）、`DeleteIfUnchanged` race window、`afterFrameCleared` 抽出後 clearFrame 語意等價
+- **R2 3-parallel**：
+  - **攻擊**：proxy ID 與 native SubagentStart 撞（native agent_id 若開頭為 `proxy:` 會誤判？）、 同 pane 多 sender process、sweep 執行中 attach 的 TOCTOU
+  - **防守**：SubagentDots type color table 的可維護性、為何不加 per-ref LastSeenAt
+  - **體質**：`frame_ops.go` >500 行、SubagentDots tests 是否過度（11+ case）
+- **R3-R4 sanity**：收斂剩餘 P1
+
+---
+
+## 8. Open Questions
+
+1. **`subagentCount` 是否完全移除**：本 delta §2 Commit 10 建議 `useTabDisplay.ts` 不再 return `subagentCount`；如果 reviewer 覺得 breaking 太大或有 external consumer 讀這欄位，改為 deprecated 保留（兩路都可）
+2. **proxy ref 的 agent_id collision**：v6 §9 PR-2b R2 攻擊預期有這問題 — 當 native SubagentStart 的 `agent_id` 字串碰巧開頭是 `proxy:`（非常罕見但非零機率）時，SessionEnd 的 `removeProxyRefForSender` 會不會誤刪？**不會**，因為 matching key 是 `SourcePID+SourceStartTime`（native ref 這兩欄為 0/空），不是 ID 字串。此答案寫進 PR description 防 R2 重問
+3. **dev update skew 期間 SPA 若吃到舊 daemon（alpha.218）送的 native-only subagents，新 SubagentDots 渲染**：fallback color 行為正確（`TYPE_COLOR[ref.type] ?? cc`），proxy 欄位 undefined 走 solid dot；不需額外 guard

--- a/internal/agent/probe/activity.go
+++ b/internal/agent/probe/activity.go
@@ -47,6 +47,16 @@ func (p *Prober) StopAllWatches() {
 	p.watcherMu.Unlock()
 }
 
+// HasWatcher reports whether a watcher is currently registered for the given
+// target. Intended for tests that verify StopWatch was invoked as part of
+// cleanup paths (frame sweep, session rename, etc).
+func (p *Prober) HasWatcher(target string) bool {
+	p.watcherMu.Lock()
+	defer p.watcherMu.Unlock()
+	_, ok := p.watchers[target]
+	return ok
+}
+
 func (p *Prober) activityLoop(ctx context.Context, id *struct{}, target string, cb ActivityCallback) {
 	defer func() {
 		p.watcherMu.Lock()

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -1,11 +1,19 @@
 package agent
 
 import (
+	"fmt"
 	"sort"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/store"
 )
+
+// proxyMaxDepth caps the PPID ancestor walk during proxy subagent detection.
+// 5 is enough to cover observed layouts like codex → codex-companion → cc
+// (2 hops) with 3 hops of buffer for shell/tmux wrappers; beyond that we
+// fall back to creating a new frame rather than paying unbounded syscall
+// cost on a genuinely deep chain.
+const proxyMaxDepth = 5
 
 type FrameTraceMeta struct {
 	FrameID       string
@@ -104,6 +112,46 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 			Before:        before,
 			After:         summarizeFrame(&stored),
 		}, err
+	}
+
+	// Proxy subagent fast-path (Phase 2 PR-2b, plan §1.4): when a SessionStart
+	// arrives from a sender that has no existing frame of its own and a PPID
+	// ancestor walk locates an alive cross-type parent in the same pane, we
+	// collapse the event into a proxy ref attached to that parent rather than
+	// creating a standalone frame. Observed in practice for codex spawned from
+	// inside a cc session via codex-companion: cc owns the UX, codex should
+	// show as a dot on cc's tab, not as a separate lit-up frame.
+	if req.EventName == "SessionStart" && frame == nil {
+		parent, perr := m.findProxyParent(req)
+		if perr != nil {
+			return nil, FrameTraceMeta{}, perr
+		}
+		if parent != nil {
+			parentBefore := summarizeFrame(parent)
+			ref := agentpkg.SubagentRef{
+				ID:              fmt.Sprintf("proxy:%s:%d:%s", req.AgentType, req.SenderPID, req.SenderStartTime),
+				Type:            req.AgentType,
+				StartedAt:       broadcastTs,
+				SourcePID:       req.SenderPID,
+				SourceStartTime: req.SenderStartTime,
+				IsProxy:         true,
+			}
+			parent.Subagents = updateSubagents(parent.Subagents, "SubagentStart", ref)
+			parent.LastSeenAt = broadcastTs
+			stored, err := m.frames.Upsert(*parent)
+			if err != nil {
+				return nil, FrameTraceMeta{}, err
+			}
+			projection, err := m.projectPane(req.TmuxPaneID)
+			return projection, FrameTraceMeta{
+				FrameID:       stored.FrameID,
+				ParentFrameID: stored.ParentFrameID,
+				Decision:      "updated_frame",
+				Reason:        "proxy_subagent_attached",
+				Before:        parentBefore,
+				After:         summarizeFrame(&stored),
+			}, err
+		}
 	}
 
 	info, err := readProcessInfoFn(req.SenderPID)
@@ -375,4 +423,69 @@ func projectionSortGreater(candidate, current SessionProjection) bool {
 		return candidate.TopFrame.StartedAt > current.TopFrame.StartedAt
 	}
 	return candidate.TopFrame.FrameID > current.TopFrame.FrameID
+}
+
+// findProxyParent walks the sender's PPID ancestor chain (capped at
+// proxyMaxDepth) looking for an alive, identity-verified, cross-type frame in
+// the same pane. See plan §1.4 for full contract.
+//
+// Returns (parent, nil) when a proxy candidate is found; (nil, nil) when the
+// walk should not proxy-attach (no ancestor has a frame / same-type hard
+// stop / all cross-type candidates stale or dead / depth exceeded / proc info
+// or start_time read errors that make identity unverifiable). Non-nil error
+// is returned only when the frames store fails.
+func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
+	if m.frames == nil {
+		return nil, nil
+	}
+	info, err := readProcessInfoFn(req.SenderPID)
+	if err != nil {
+		return nil, nil
+	}
+	ppid := info.PPID
+	for depth := 0; depth < proxyMaxDepth; depth++ {
+		if ppid <= 1 {
+			return nil, nil
+		}
+		candidate, err := m.frames.FindByPanePID(req.TmuxPaneID, ppid)
+		if err != nil {
+			return nil, err
+		}
+		if candidate != nil {
+			// Same-type ancestor: pane already has a frame of our agent_type,
+			// meaning this SessionStart is a re-session / update of that frame
+			// — not a cross-type proxy. Hard-stop the walk (don't continue to
+			// some cross-type grandparent that would be a semantic mismatch).
+			if candidate.AgentType == req.AgentType {
+				return nil, nil
+			}
+			if isPidAliveFn(candidate.PID) {
+				actualStart, serr := processStartTimeFn(candidate.PID)
+				if serr != nil {
+					// v5 rule: identity unverifiable → abort walk (consistent
+					// with verify.go's "lookup error → don't infer" convention).
+					// Prevents mis-attaching to an outer cross-type ancestor
+					// when the immediate candidate's start_time is transiently
+					// unreadable.
+					return nil, nil
+				}
+				if actualStart == candidate.ProcessStartTime {
+					return candidate, nil
+				}
+				// Identity mismatch (PID reused) → stale frame; continue walk
+				// to look for a real parent further up.
+			}
+			// Dead candidate: also continue walk; sweep will clear it.
+		}
+		// No frame at this PID — walk one more level up.
+		ancestorInfo, err := readProcessInfoFn(ppid)
+		if err != nil {
+			return nil, nil
+		}
+		if ancestorInfo.PPID == ppid {
+			return nil, nil
+		}
+		ppid = ancestorInfo.PPID
+	}
+	return nil, nil
 }

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -125,11 +125,27 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 			// refs have no distinct source process identity. Proxy attaches (PR-2b)
 			// set these explicitly.
 		}
-		frame.Subagents = updateSubagents(frame.Subagents, req.EventName, ref)
-		frame.LastSeenAt = broadcastTs
-		stored, err := m.frames.Upsert(*frame)
-		if err != nil {
-			return nil, FrameTraceMeta{}, err
+		// Optimistic-concurrency native mutation (#632 continuation):
+		// two cc SubagentStarts from a concurrent Task-tool dispatch can
+		// land in near-simultaneously; the same read-modify-write race
+		// that motivated the proxy atomic fix applies here. Delegate to
+		// the shared helper that reloads + re-merges on UpsertIfUnchanged
+		// conflict.
+		applied, stored, merr := m.mutateSubagentsWithRetry(*frame, req.EventName, ref, broadcastTs)
+		if merr != nil {
+			return nil, FrameTraceMeta{}, merr
+		}
+		if !applied {
+			// Frame was deleted mid-flight (concurrent sweep / SessionEnd).
+			// Report frame_missing so downstream treats this like the
+			// frame == nil branch above.
+			projection, perr := m.projectPane(req.TmuxPaneID)
+			return projection, FrameTraceMeta{
+				Decision: "skipped",
+				Reason:   "frame_missing",
+				Before:   before,
+				After:    map[string]any{},
+			}, perr
 		}
 		projection, err := m.projectPane(req.TmuxPaneID)
 		return projection, FrameTraceMeta{
@@ -538,16 +554,25 @@ func subagentsContainProxySender(refs []agentpkg.SubagentRef, senderPID int, sen
 	return false
 }
 
-// attachProxyRefWithRetry mutates parent.Subagents to include ref, persists
-// via UpsertIfUnchanged, and reloads + re-merges on concurrent-write
-// conflicts. Returns (true, stored, nil) when the ref is persisted;
-// (false, zeroFrame, nil) when the parent row was deleted mid-flight and
-// the caller should fall back to the legacy create-new-frame path.
-func (m *Module) attachProxyRefWithRetry(parent store.Frame, ref agentpkg.SubagentRef, broadcastTs int64) (bool, store.Frame, error) {
-	current := parent
+// mutateSubagentsWithRetry applies an updateSubagents mutation
+// (SubagentStart add or SubagentStop remove) to frame.Subagents under
+// optimistic concurrency. Each attempt re-merges via updateSubagents on top
+// of the current baseline and issues UpsertIfUnchanged; on conflict it
+// reloads via GetByIdentity and retries, bounded by proxyUpsertMaxAttempts.
+//
+// Returns (true, stored, nil) when the mutation is persisted;
+// (false, zeroFrame, nil) when the frame was deleted mid-flight (caller
+// decides whether to fall back, continue scanning, or report frame_missing).
+// A non-nil error is only returned for storage failures or exhausted retries.
+//
+// Serves both native SubagentStart/Stop (from hook events) and proxy
+// attach (via attachProxyRefWithRetry). All three paths share the same
+// subagents_json read-modify-write cycle and would race without this helper.
+func (m *Module) mutateSubagentsWithRetry(frame store.Frame, eventName string, ref agentpkg.SubagentRef, broadcastTs int64) (bool, store.Frame, error) {
+	current := frame
 	for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
 		expected := current.LastSeenAt
-		current.Subagents = updateSubagents(current.Subagents, "SubagentStart", ref)
+		current.Subagents = updateSubagents(current.Subagents, eventName, ref)
 		current.LastSeenAt = broadcastTs
 		ok, stored, err := m.frames.UpsertIfUnchanged(current, expected)
 		if err != nil {
@@ -556,18 +581,24 @@ func (m *Module) attachProxyRefWithRetry(parent store.Frame, ref agentpkg.Subage
 		if ok {
 			return true, stored, nil
 		}
-		reloaded, err := m.frames.GetByIdentity(parent.PaneID, parent.PID, parent.ProcessStartTime)
+		reloaded, err := m.frames.GetByIdentity(frame.PaneID, frame.PID, frame.ProcessStartTime)
 		if err != nil {
 			return false, store.Frame{}, err
 		}
 		if reloaded == nil {
-			// Parent was deleted by a concurrent sweep or SessionEnd. The
-			// caller falls back to building a standalone frame.
 			return false, store.Frame{}, nil
 		}
 		current = *reloaded
 	}
-	return false, store.Frame{}, fmt.Errorf("proxy attach: exceeded %d retries for frame %s", proxyUpsertMaxAttempts, parent.FrameID)
+	return false, store.Frame{}, fmt.Errorf("subagent mutation %s: exceeded %d retries for frame %s", eventName, proxyUpsertMaxAttempts, frame.FrameID)
+}
+
+// attachProxyRefWithRetry is a thin wrapper over mutateSubagentsWithRetry
+// specialized for the proxy-attach path. Kept as a separate helper so the
+// caller at applyFrameEvent reads as "attach proxy ref" rather than
+// "SubagentStart mutation on the parent".
+func (m *Module) attachProxyRefWithRetry(parent store.Frame, ref agentpkg.SubagentRef, broadcastTs int64) (bool, store.Frame, error) {
+	return m.mutateSubagentsWithRetry(parent, "SubagentStart", ref, broadcastTs)
 }
 
 // detachProxyRefWithRetry mirrors attachProxyRefWithRetry for the SessionEnd

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -281,10 +281,16 @@ func summarizeFrame(frame *store.Frame) map[string]any {
 }
 
 // updateSubagents mutates a frame's subagent list in response to a
-// SubagentStart / SubagentStop event. Matching is by ref.ID only; Type does
-// not participate so a cross-type hook (proxy path in PR-2b) cleanly replaces
-// a native ref on stop. On SubagentStart the first-write wins — an existing
-// ref keeps its StartedAt/SourcePID/SourceStartTime/IsProxy.
+// SubagentStart / SubagentStop event. On SubagentStart the first-write wins;
+// an existing ref keeps its StartedAt/SourcePID/SourceStartTime/IsProxy.
+//
+// Identity key is kind-aware (R2 fix): proxy refs identify by
+// (SourcePID, SourceStartTime) — the sender process — while native refs
+// identify by ID (the agent_id string supplied by the provider). Cross-kind
+// refs (one proxy, one native) never match even if ID strings coincide.
+// This isolates namespaces so a native ref whose agent_id happens to collide
+// with a synthesized proxy ID cannot shadow or evict a proxy ref, and vice
+// versa.
 func updateSubagents(current []agentpkg.SubagentRef, eventName string, ref agentpkg.SubagentRef) []agentpkg.SubagentRef {
 	if current == nil {
 		current = []agentpkg.SubagentRef{}
@@ -292,7 +298,7 @@ func updateSubagents(current []agentpkg.SubagentRef, eventName string, ref agent
 	switch eventName {
 	case "SubagentStart":
 		for _, existing := range current {
-			if existing.ID == ref.ID {
+			if subagentRefMatches(existing, ref) {
 				return current
 			}
 		}
@@ -300,7 +306,7 @@ func updateSubagents(current []agentpkg.SubagentRef, eventName string, ref agent
 	case "SubagentStop":
 		filtered := make([]agentpkg.SubagentRef, 0, len(current))
 		for _, existing := range current {
-			if existing.ID != ref.ID {
+			if !subagentRefMatches(existing, ref) {
 				filtered = append(filtered, existing)
 			}
 		}
@@ -308,6 +314,20 @@ func updateSubagents(current []agentpkg.SubagentRef, eventName string, ref agent
 	default:
 		return current
 	}
+}
+
+// subagentRefMatches returns true when two refs identify the same subagent.
+// Proxy refs compare by (SourcePID, SourceStartTime); native refs compare by
+// ID. Cross-kind (one proxy, one native) is never a match — preserves the
+// isolation between the two namespaces (see updateSubagents doc).
+func subagentRefMatches(a, b agentpkg.SubagentRef) bool {
+	if a.IsProxy != b.IsProxy {
+		return false
+	}
+	if a.IsProxy {
+		return a.SourcePID == b.SourcePID && a.SourceStartTime == b.SourceStartTime
+	}
+	return a.ID == b.ID
 }
 
 func syncProjectionState(currentStatus map[string]agentpkg.Status, subagents map[string][]agentpkg.SubagentRef, tmuxSession string, projection *SessionProjection) {

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -420,14 +420,12 @@ func (m *Module) setProjectionTopStatus(sessionName string, status agentpkg.Stat
 	if err != nil || projection == nil || projection.TopFrame == nil {
 		return projection, err
 	}
-	frame := *projection.TopFrame
-	frame.Status = status
-	// Refresh LastSeenAt so probe-driven status transitions count as "recent
-	// activity" for the idle sweep rule (sweep.go frameIdleThreshold). Without
-	// this bump, a live agent at a shell prompt that emits no hooks for 1h
-	// would be mis-classified as idle and have its frame silently deleted.
-	frame.LastSeenAt = time.Now().UnixNano()
-	if _, err := m.frames.Upsert(frame); err != nil {
+	// Narrow update only status + last_seen_at (#632 R7): a whole-frame
+	// Upsert from this path would round-trip a stale Subagents baseline
+	// and clobber concurrent proxy/native attach/detach mutations on the
+	// same row. Probe-driven status transitions have no business changing
+	// Subagents — decouple the columns at the SQL layer.
+	if err := m.frames.UpdateStatusAndLastSeen(projection.TopFrame.FrameID, status, time.Now().UnixNano()); err != nil {
 		return nil, err
 	}
 	return m.projectionForSession(sessionName)

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -55,6 +55,25 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 				After:         map[string]any{},
 			}, err
 		}
+		// frame == nil: sender has no frame of its own. This is either a
+		// genuine orphan SessionEnd, or the SessionEnd of a process that was
+		// previously proxy-attached to another frame (Phase 2 PR-2b §1.5).
+		// Probe the pane's frames for a matching proxy ref and detach it.
+		removed, parentFrame, parentBefore, parentAfter, err := m.removeProxyRefForSender(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, broadcastTs)
+		if err != nil {
+			return nil, FrameTraceMeta{}, err
+		}
+		if removed {
+			projection, perr := m.projectPane(req.TmuxPaneID)
+			return projection, FrameTraceMeta{
+				FrameID:       parentFrame.FrameID,
+				ParentFrameID: parentFrame.ParentFrameID,
+				Decision:      "updated_frame",
+				Reason:        "proxy_subagent_detached",
+				Before:        parentBefore,
+				After:         parentAfter,
+			}, perr
+		}
 		projection, err := m.projectPane(req.TmuxPaneID)
 		return projection, FrameTraceMeta{
 			Decision: "skipped",
@@ -423,6 +442,50 @@ func projectionSortGreater(candidate, current SessionProjection) bool {
 		return candidate.TopFrame.StartedAt > current.TopFrame.StartedAt
 	}
 	return candidate.TopFrame.FrameID > current.TopFrame.FrameID
+}
+
+// removeProxyRefForSender scans the pane's frames for a proxy SubagentRef
+// whose SourcePID+SourceStartTime match the sender that is emitting SessionEnd,
+// filters it out, refreshes the owning frame's LastSeenAt and persists via
+// Upsert. Matching is by identity fields (SourcePID+SourceStartTime), not by
+// ref.ID string, so the detach remains robust across potential future ID
+// format changes.
+//
+// Returns (removed, ownerFrameAfter, ownerBefore, ownerAfter, err):
+//   - removed=true with ownerFrameAfter populated when a ref was detached.
+//   - removed=false, zeroFrame, nil, nil, nil when nothing matched.
+func (m *Module) removeProxyRefForSender(paneID string, senderPID int, senderStartTime string, broadcastTs int64) (bool, store.Frame, any, any, error) {
+	if m.frames == nil {
+		return false, store.Frame{}, nil, nil, nil
+	}
+	frames, err := m.frames.ListByPane(paneID)
+	if err != nil {
+		return false, store.Frame{}, nil, nil, err
+	}
+	for _, frame := range frames {
+		hit := -1
+		for i, ref := range frame.Subagents {
+			if ref.SourcePID == senderPID && ref.SourceStartTime == senderStartTime {
+				hit = i
+				break
+			}
+		}
+		if hit < 0 {
+			continue
+		}
+		before := summarizeFrame(&frame)
+		filtered := make([]agentpkg.SubagentRef, 0, len(frame.Subagents)-1)
+		filtered = append(filtered, frame.Subagents[:hit]...)
+		filtered = append(filtered, frame.Subagents[hit+1:]...)
+		frame.Subagents = filtered
+		frame.LastSeenAt = broadcastTs
+		stored, err := m.frames.Upsert(frame)
+		if err != nil {
+			return false, store.Frame{}, nil, nil, err
+		}
+		return true, stored, before, summarizeFrame(&stored), nil
+	}
+	return false, store.Frame{}, nil, nil, nil
 }
 
 // findProxyParent walks the sender's PPID ancestor chain (capped at

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -541,13 +541,12 @@ func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
 			return nil, err
 		}
 		if candidate != nil {
-			// Same-type ancestor: pane already has a frame of our agent_type,
-			// meaning this SessionStart is a re-session / update of that frame
-			// — not a cross-type proxy. Hard-stop the walk (don't continue to
-			// some cross-type grandparent that would be a semantic mismatch).
-			if candidate.AgentType == req.AgentType {
-				return nil, nil
-			}
+			// Liveness + identity gating applies to BOTH same-type and
+			// cross-type candidates (R3 fix). A stale same-type frame (PID
+			// reused, or process dead) is leftover data, not a real
+			// "re-session of an existing live sibling"; it must not
+			// hard-stop the walk or we'd strand a legitimate proxy attach
+			// to a live cross-type ancestor above it.
 			if isPidAliveFn(candidate.PID) {
 				actualStart, serr := processStartTimeFn(candidate.PID)
 				if serr != nil {
@@ -559,10 +558,21 @@ func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
 					return nil, nil
 				}
 				if actualStart == candidate.ProcessStartTime {
+					// Live + identity-verified candidate.
+					if candidate.AgentType == req.AgentType {
+						// Same-type live ancestor: pane already owns a live
+						// frame of our agent_type, so this SessionStart is a
+						// re-session / update of that frame — not a cross-type
+						// proxy. Hard-stop the walk here (don't continue to a
+						// cross-type grandparent that would be semantically wrong).
+						return nil, nil
+					}
+					// Cross-type live ancestor: this is our proxy parent.
 					return candidate, nil
 				}
 				// Identity mismatch (PID reused) → stale frame; continue walk
-				// to look for a real parent further up.
+				// to look for a real parent further up. Applies to both
+				// same-type and cross-type.
 			}
 			// Dead candidate: also continue walk; sweep will clear it.
 		}

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -16,6 +16,14 @@ import (
 // cost on a genuinely deep chain.
 const proxyMaxDepth = 5
 
+// proxyUpsertMaxAttempts caps optimistic-concurrency retries when two
+// near-simultaneous proxy attaches (or detaches) race on the same parent
+// frame's subagents list. Each attempt reloads the parent row, re-merges
+// the ref through updateSubagents, and re-issues UpsertIfUnchanged. After
+// exhausting attempts the caller surfaces an error — production scenarios
+// that hit this limit are genuine hot loops, not ordinary concurrency.
+const proxyUpsertMaxAttempts = 3
+
 type FrameTraceMeta struct {
 	FrameID       string
 	ParentFrameID string
@@ -156,21 +164,29 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 				SourceStartTime: req.SenderStartTime,
 				IsProxy:         true,
 			}
-			parent.Subagents = updateSubagents(parent.Subagents, "SubagentStart", ref)
-			parent.LastSeenAt = broadcastTs
-			stored, err := m.frames.Upsert(*parent)
-			if err != nil {
-				return nil, FrameTraceMeta{}, err
+			// Optimistic-concurrency attach: read-modify-write on the parent
+			// row is racy when two proxy SessionStarts land on the same
+			// parent simultaneously (issue #632). UpsertIfUnchanged +
+			// reload-on-conflict serializes the writes without a lock; the
+			// retry loop merges both refs before persistence.
+			attached, stored, aerr := m.attachProxyRefWithRetry(*parent, ref, broadcastTs)
+			if aerr != nil {
+				return nil, FrameTraceMeta{}, aerr
 			}
-			projection, err := m.projectPane(req.TmuxPaneID)
-			return projection, FrameTraceMeta{
-				FrameID:       stored.FrameID,
-				ParentFrameID: stored.ParentFrameID,
-				Decision:      "updated_frame",
-				Reason:        "proxy_subagent_attached",
-				Before:        parentBefore,
-				After:         summarizeFrame(&stored),
-			}, err
+			if attached {
+				projection, err := m.projectPane(req.TmuxPaneID)
+				return projection, FrameTraceMeta{
+					FrameID:       stored.FrameID,
+					ParentFrameID: stored.ParentFrameID,
+					Decision:      "updated_frame",
+					Reason:        "proxy_subagent_attached",
+					Before:        parentBefore,
+					After:         summarizeFrame(&stored),
+				}, err
+			}
+			// Parent vanished mid-flight (swept or deleted by concurrent
+			// SessionEnd). Fall through to the legacy create-new-frame path
+			// so the sender still gets represented somewhere.
 		}
 	}
 
@@ -489,29 +505,113 @@ func (m *Module) removeProxyRefForSender(paneID string, senderPID int, senderSta
 		return false, store.Frame{}, nil, nil, err
 	}
 	for _, frame := range frames {
+		if !subagentsContainProxySender(frame.Subagents, senderPID, senderStartTime) {
+			continue
+		}
+		before := summarizeFrame(&frame)
+		// Optimistic-concurrency detach: see attachProxyRefWithRetry doc.
+		// #632 — the scan/list/update triplet is racy if two SessionEnds (or
+		// a SessionEnd concurrent with a SessionStart) land on the same
+		// parent. Reload + filter + UpsertIfUnchanged with retry.
+		detached, stored, derr := m.detachProxyRefWithRetry(frame, senderPID, senderStartTime, broadcastTs)
+		if derr != nil {
+			return false, store.Frame{}, nil, nil, derr
+		}
+		if detached {
+			return true, stored, before, summarizeFrame(&stored), nil
+		}
+		// Frame vanished or its ref was already removed by a concurrent
+		// writer. Continue scanning other frames in the pane — a different
+		// owner may still carry our sender's proxy ref.
+	}
+	return false, store.Frame{}, nil, nil, nil
+}
+
+// subagentsContainProxySender is a side-effect-free check used to short-
+// circuit frames that don't need the read-modify-write retry loop.
+func subagentsContainProxySender(refs []agentpkg.SubagentRef, senderPID int, senderStartTime string) bool {
+	for _, ref := range refs {
+		if ref.IsProxy && ref.SourcePID == senderPID && ref.SourceStartTime == senderStartTime {
+			return true
+		}
+	}
+	return false
+}
+
+// attachProxyRefWithRetry mutates parent.Subagents to include ref, persists
+// via UpsertIfUnchanged, and reloads + re-merges on concurrent-write
+// conflicts. Returns (true, stored, nil) when the ref is persisted;
+// (false, zeroFrame, nil) when the parent row was deleted mid-flight and
+// the caller should fall back to the legacy create-new-frame path.
+func (m *Module) attachProxyRefWithRetry(parent store.Frame, ref agentpkg.SubagentRef, broadcastTs int64) (bool, store.Frame, error) {
+	current := parent
+	for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
+		expected := current.LastSeenAt
+		current.Subagents = updateSubagents(current.Subagents, "SubagentStart", ref)
+		current.LastSeenAt = broadcastTs
+		ok, stored, err := m.frames.UpsertIfUnchanged(current, expected)
+		if err != nil {
+			return false, store.Frame{}, err
+		}
+		if ok {
+			return true, stored, nil
+		}
+		reloaded, err := m.frames.GetByIdentity(parent.PaneID, parent.PID, parent.ProcessStartTime)
+		if err != nil {
+			return false, store.Frame{}, err
+		}
+		if reloaded == nil {
+			// Parent was deleted by a concurrent sweep or SessionEnd. The
+			// caller falls back to building a standalone frame.
+			return false, store.Frame{}, nil
+		}
+		current = *reloaded
+	}
+	return false, store.Frame{}, fmt.Errorf("proxy attach: exceeded %d retries for frame %s", proxyUpsertMaxAttempts, parent.FrameID)
+}
+
+// detachProxyRefWithRetry mirrors attachProxyRefWithRetry for the SessionEnd
+// cleanup path: reload parent, filter out the matching proxy ref, persist
+// via UpsertIfUnchanged, retry on conflict. Returns (false, zeroFrame, nil)
+// when the frame was already gone or its ref was already cleaned up by a
+// concurrent writer (caller continues scanning other frames in the pane).
+func (m *Module) detachProxyRefWithRetry(owner store.Frame, senderPID int, senderStartTime string, broadcastTs int64) (bool, store.Frame, error) {
+	current := owner
+	for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
 		hit := -1
-		for i, ref := range frame.Subagents {
-			if ref.SourcePID == senderPID && ref.SourceStartTime == senderStartTime {
+		for i, ref := range current.Subagents {
+			if ref.IsProxy && ref.SourcePID == senderPID && ref.SourceStartTime == senderStartTime {
 				hit = i
 				break
 			}
 		}
 		if hit < 0 {
-			continue
+			// Ref already removed by a concurrent writer.
+			return false, store.Frame{}, nil
 		}
-		before := summarizeFrame(&frame)
-		filtered := make([]agentpkg.SubagentRef, 0, len(frame.Subagents)-1)
-		filtered = append(filtered, frame.Subagents[:hit]...)
-		filtered = append(filtered, frame.Subagents[hit+1:]...)
-		frame.Subagents = filtered
-		frame.LastSeenAt = broadcastTs
-		stored, err := m.frames.Upsert(frame)
+		expected := current.LastSeenAt
+		filtered := make([]agentpkg.SubagentRef, 0, len(current.Subagents)-1)
+		filtered = append(filtered, current.Subagents[:hit]...)
+		filtered = append(filtered, current.Subagents[hit+1:]...)
+		current.Subagents = filtered
+		current.LastSeenAt = broadcastTs
+		ok, stored, err := m.frames.UpsertIfUnchanged(current, expected)
 		if err != nil {
-			return false, store.Frame{}, nil, nil, err
+			return false, store.Frame{}, err
 		}
-		return true, stored, before, summarizeFrame(&stored), nil
+		if ok {
+			return true, stored, nil
+		}
+		reloaded, err := m.frames.GetByIdentity(owner.PaneID, owner.PID, owner.ProcessStartTime)
+		if err != nil {
+			return false, store.Frame{}, err
+		}
+		if reloaded == nil {
+			return false, store.Frame{}, nil
+		}
+		current = *reloaded
 	}
-	return false, store.Frame{}, nil, nil, nil
+	return false, store.Frame{}, fmt.Errorf("proxy detach: exceeded %d retries for frame %s", proxyUpsertMaxAttempts, owner.FrameID)
 }
 
 // findProxyParent walks the sender's PPID ancestor chain (capped at

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/store"
@@ -369,6 +370,11 @@ func (m *Module) setProjectionTopStatus(sessionName string, status agentpkg.Stat
 	}
 	frame := *projection.TopFrame
 	frame.Status = status
+	// Refresh LastSeenAt so probe-driven status transitions count as "recent
+	// activity" for the idle sweep rule (sweep.go frameIdleThreshold). Without
+	// this bump, a live agent at a shell prompt that emits no hooks for 1h
+	// would be mis-classified as idle and have its frame silently deleted.
+	frame.LastSeenAt = time.Now().UnixNano()
 	if _, err := m.frames.Upsert(frame); err != nil {
 		return nil, err
 	}

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -211,16 +211,11 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		return nil, FrameTraceMeta{}, err
 	}
 
-	subagents := []agentpkg.SubagentRef{}
 	startedAt := broadcastTs
 	parentFrameID := ""
 	if frame != nil {
-		subagents = append([]agentpkg.SubagentRef(nil), frame.Subagents...)
 		startedAt = frame.StartedAt
 		parentFrameID = frame.ParentFrameID
-	}
-	if req.EventName == "SessionStart" {
-		subagents = []agentpkg.SubagentRef{}
 	}
 	if parentFrameID == "" {
 		parent, err := m.frames.FindByPanePID(req.TmuxPaneID, info.PPID)
@@ -240,22 +235,60 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		status = agentpkg.StatusIdle
 	}
 
-	stored, err := m.frames.Upsert(store.Frame{
-		FrameID:          frameID(frame),
-		PaneID:           req.TmuxPaneID,
-		AgentType:        req.AgentType,
-		PID:              req.SenderPID,
-		PPID:             info.PPID,
-		ProcessStartTime: req.SenderStartTime,
-		ParentFrameID:    parentFrameID,
-		Subagents:        subagents,
-		Status:           status,
-		StartedAt:        startedAt,
-		LastSeenAt:       broadcastTs,
-		Verified:         true,
-	})
-	if err != nil {
-		return nil, FrameTraceMeta{}, err
+	var stored store.Frame
+	if frame != nil {
+		// Existing frame: narrow column update (#632 R8). Writing the full
+		// frame would round-trip a stale Subagents baseline and clobber
+		// concurrent proxy/native attach/detach mutations on the same row.
+		// Subagents changes flow through mutateSubagentsWithRetry /
+		// attachProxyRefWithRetry / removeProxyRefForSender, not here.
+		//
+		// Exception: SessionStart on an existing frame intentionally resets
+		// the subagent list (old session's refs no longer apply). Use the
+		// reset variant so subagents_json = '[]' lands in the same SQL.
+		updated := *frame
+		updated.AgentType = req.AgentType
+		updated.PPID = info.PPID
+		updated.ParentFrameID = parentFrameID
+		updated.Status = status
+		updated.LastSeenAt = broadcastTs
+		updated.Verified = true
+		var updateErr error
+		if req.EventName == "SessionStart" {
+			updateErr = m.frames.UpdateHookPathAndResetSubagents(updated)
+		} else {
+			updateErr = m.frames.UpdateHookPath(updated)
+		}
+		if updateErr != nil {
+			return nil, FrameTraceMeta{}, updateErr
+		}
+		reloaded, err := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
+		if err != nil {
+			return nil, FrameTraceMeta{}, err
+		}
+		if reloaded == nil {
+			return nil, FrameTraceMeta{}, nil
+		}
+		stored = *reloaded
+	} else {
+		// New frame: insert via Upsert. No existing subagents to clobber;
+		// start the row with an empty list.
+		stored, err = m.frames.Upsert(store.Frame{
+			PaneID:           req.TmuxPaneID,
+			AgentType:        req.AgentType,
+			PID:              req.SenderPID,
+			PPID:             info.PPID,
+			ProcessStartTime: req.SenderStartTime,
+			ParentFrameID:    parentFrameID,
+			Subagents:        []agentpkg.SubagentRef{},
+			Status:           status,
+			StartedAt:        startedAt,
+			LastSeenAt:       broadcastTs,
+			Verified:         true,
+		})
+		if err != nil {
+			return nil, FrameTraceMeta{}, err
+		}
 	}
 	projection, err := m.projectPane(req.TmuxPaneID)
 	reason := "parent_frame_missing"

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -817,10 +817,29 @@ func TestProxySubagent_SkipsWhenParentSameType(t *testing.T) {
 	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
 
 	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
 	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
 		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
 	}
-	t.Cleanup(func() { readProcessInfoFn = origInfo })
+	// R4 fix: force the same-type ancestor to be live + identity-verified so
+	// the hard-stop gate is exercised on its actual rule (live same-type
+	// ancestor → re-session) rather than incidentally passing through
+	// dead-skip+walk-up. Without these stubs the candidate's PID 100 would
+	// be dead under the real isPidAliveFn and the test would mask regressions
+	// in the hard-stop ordering.
+	isPidAliveFn = func(pid int) bool { return pid == 100 }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
 
 	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 200, SenderStartTime: "t200"}
 	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
@@ -1113,6 +1132,8 @@ func TestProxySubagent_SameTypeAncestorStopsWalk(t *testing.T) {
 	seedFrame(t, m, "%5", "codex", 200, "t200", 20)
 
 	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
 	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
 		switch pid {
 		case 400:
@@ -1124,7 +1145,27 @@ func TestProxySubagent_SameTypeAncestorStopsWalk(t *testing.T) {
 		}
 		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
 	}
-	t.Cleanup(func() { readProcessInfoFn = origInfo })
+	// R4 fix: force the same-type codex ancestor (PID 200) to be live +
+	// identity-verified so the hard-stop gate triggers on its real rule
+	// (live same-type → re-session) rather than walking past on a dead
+	// candidate. Without these stubs PR14 would incidentally pass by
+	// walking 200 (dead) → 100 (dead) → exhausted, which does not actually
+	// verify the same-type hard-stop.
+	isPidAliveFn = func(pid int) bool { return pid == 200 || pid == 100 }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 200:
+			return "t200", nil
+		case 100:
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
 
 	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 400, SenderStartTime: "t400"}
 	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
@@ -1132,7 +1173,7 @@ func TestProxySubagent_SameTypeAncestorStopsWalk(t *testing.T) {
 		t.Fatalf("applyFrameEvent: %v", err)
 	}
 	if meta.Reason == "proxy_subagent_attached" {
-		t.Fatalf("walk should halt at same-type codex ancestor, not reach cc; meta=%+v", meta)
+		t.Fatalf("walk should halt at live same-type codex ancestor, not reach cc; meta=%+v", meta)
 	}
 }
 

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -588,6 +588,71 @@ func TestSubagentStart_ConcurrentNativeStartsBothLand(t *testing.T) {
 	_ = parent
 }
 
+// HookRace1 — #632 R8 regression: applyFrameEvent's existing-frame status
+// update path (non-SessionEnd / non-SubagentStart / non-SubagentStop hook
+// events like UserPromptSubmit) uses narrow UpdateHookPath that does not
+// touch subagents_json. A concurrent proxy attach in flight does not lose
+// its ref to the hook handler's stale baseline.
+func TestHookStatusUpdate_DoesNotClobberConcurrentSubagents(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	// First, attach a proxy ref to the cc parent (via applyFrameEvent's
+	// proxy fast-path so we exercise the real attachProxyRefWithRetry).
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "t100", nil }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	req1 := EventRequest{
+		TmuxSession: "work", TmuxPaneID: "%5",
+		EventName: "SessionStart", AgentType: "codex",
+		SenderPID: 200, SenderStartTime: "t200",
+	}
+	if _, _, err := m.applyFrameEvent(req1, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("proxy attach: %v", err)
+	}
+
+	// Confirm cc parent now owns 1 proxy ref.
+	mid, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if len(mid.Subagents) != 1 || !mid.Subagents[0].IsProxy {
+		t.Fatalf("setup: expected 1 proxy ref on cc parent; got %+v", mid.Subagents)
+	}
+
+	// Now fire a general-hook status transition on cc itself (not SessionStart
+	// / not SubagentStart-Stop / not SessionEnd). The request carries cc's
+	// own identity so applyFrameEvent's frame != nil branch triggers on the
+	// stale cc row that does NOT have the proxy ref.
+	req2 := EventRequest{
+		TmuxSession: "work", TmuxPaneID: "%5",
+		EventName: "UserPromptSubmit", AgentType: "cc",
+		SenderPID: 100, SenderStartTime: "t100",
+	}
+	if _, _, err := m.applyFrameEvent(req2, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning}, 200); err != nil {
+		t.Fatalf("hook status update: %v", err)
+	}
+
+	// The proxy ref attached above must still be on cc (UpdateHookPath did
+	// not touch subagents_json). Status and LastSeenAt should have moved.
+	final, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if len(final.Subagents) != 1 || !final.Subagents[0].IsProxy {
+		t.Fatalf("proxy ref clobbered by hook status update; got %+v (#632 R8 regression)", final.Subagents)
+	}
+	if final.Status != agentpkg.StatusRunning {
+		t.Fatalf("Status = %q, want Running", final.Status)
+	}
+	_ = parent
+}
+
 func TestSendSnapshot_IncludesLegacySessionsWithoutFrames(t *testing.T) {
 	m := newTestModule(t)
 	fakeTmux := tmux.NewFakeExecutor()

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -472,6 +472,43 @@ func TestUpdateSubagents_StopMissingIsNoop(t *testing.T) {
 	}
 }
 
+// U6 — R2 regression: a native subagent whose provider-supplied agent_id
+// happens to equal a synthesized proxy ID must NOT collide with a proxy ref
+// of the same ID string on the same list. Identity is kind-aware: proxy
+// matches by SourcePID+SourceStartTime, native matches by ID, cross-kind
+// never matches.
+func TestUpdateSubagents_ProxyNativeIDNamespacesAreIsolated(t *testing.T) {
+	// A native ref with a pathologically-shaped ID that happens to match
+	// the proxy ID synthesis pattern proxy:<type>:<pid>:<start_time>.
+	native := agentpkg.SubagentRef{ID: "proxy:cc:200:t200", Type: "cc"}
+	list := []agentpkg.SubagentRef{native}
+
+	// A real proxy SessionStart synthesizes the same-shaped ID but sets
+	// IsProxy=true + source identity fields. It must NOT be shadowed by the
+	// native ref already present — append expected.
+	proxy := agentpkg.SubagentRef{
+		ID:              "proxy:cc:200:t200",
+		Type:            "cc",
+		SourcePID:       200,
+		SourceStartTime: "t200",
+		IsProxy:         true,
+	}
+	afterStart := updateSubagents(list, "SubagentStart", proxy)
+	if len(afterStart) != 2 {
+		t.Fatalf("proxy SubagentStart with same ID as native should append cross-kind; got %d refs, want 2: %+v", len(afterStart), afterStart)
+	}
+
+	// A native SubagentStop with the same ID must remove only the native
+	// ref, not evict the proxy.
+	afterStop := updateSubagents(afterStart, "SubagentStop", native)
+	if len(afterStop) != 1 {
+		t.Fatalf("native SubagentStop removed wrong count; got %d, want 1: %+v", len(afterStop), afterStop)
+	}
+	if !afterStop[0].IsProxy {
+		t.Fatalf("native Stop evicted proxy ref (kind-isolation broken); got %+v", afterStop[0])
+	}
+}
+
 func TestSendSnapshot_IncludesLegacySessionsWithoutFrames(t *testing.T) {
 	m := newTestModule(t)
 	fakeTmux := tmux.NewFakeExecutor()

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -1145,3 +1145,117 @@ var errFake = fakeErr("fake read error")
 type fakeErr string
 
 func (e fakeErr) Error() string { return string(e) }
+
+// ---------------------------------------------------------------------------
+// SessionEnd proxy cleanup (Phase 2 PR-2b, plan §1.5 + §2.6)
+// ---------------------------------------------------------------------------
+
+// SE1 — codex SessionEnd with no frame of its own removes the proxy ref from
+// its cc parent and emits a proxy_subagent_detached trace.
+func TestSessionEnd_RemovesProxyRefFromParent(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) { return "t100", nil }
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	// First: proxy attach.
+	startReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	if _, meta, err := m.applyFrameEvent(startReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("attach: %v", err)
+	} else if meta.Reason != "proxy_subagent_attached" {
+		t.Fatalf("attach reason = %q", meta.Reason)
+	}
+
+	// Then: SessionEnd with same identity — should remove the ref.
+	endReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionEnd", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(endReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusClear}, 200)
+	if err != nil {
+		t.Fatalf("applyFrameEvent SessionEnd: %v", err)
+	}
+	if meta.Decision != "updated_frame" || meta.Reason != "proxy_subagent_detached" {
+		t.Fatalf("trace meta = %q/%q, want updated_frame/proxy_subagent_detached", meta.Decision, meta.Reason)
+	}
+	if meta.FrameID != parent.FrameID {
+		t.Fatalf("FrameID = %q, want parent %q", meta.FrameID, parent.FrameID)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("Subagents = %+v, want empty", frames[0].Subagents)
+	}
+}
+
+// SE2 — orphan SessionEnd (no matching ref) falls back to legacy skip path.
+func TestSessionEnd_OrphanFallsBackToExistingSkip(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	// No proxy ref attached.
+
+	endReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionEnd", AgentType: "codex", SenderPID: 999, SenderStartTime: "t999"}
+	_, meta, err := m.applyFrameEvent(endReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusClear}, 200)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "session_end_without_frame" {
+		t.Fatalf("reason = %q, want session_end_without_frame (orphan fallback)", meta.Reason)
+	}
+}
+
+// SE3 — SessionEnd on a frame that owns its own identity deletes the frame
+// (the owning frame delete removes any proxy refs it was carrying, which is
+// fine as a side effect).
+func TestSessionEnd_OwnFrameDeletePreservesOtherProxyRefs(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) { return "t100", nil }
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	startReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	if _, _, err := m.applyFrameEvent(startReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("proxy attach: %v", err)
+	}
+
+	// Now SessionEnd on cc itself (the owning frame).
+	endReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionEnd", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	_, meta, err := m.applyFrameEvent(endReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusClear}, 300)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Decision != "deleted_frame" || meta.Reason != "session_end" {
+		t.Fatalf("trace meta = %q/%q, want deleted_frame/session_end", meta.Decision, meta.Reason)
+	}
+	if meta.FrameID != parent.FrameID {
+		t.Fatalf("FrameID = %q, want parent %q", meta.FrameID, parent.FrameID)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0 (cc frame deleted)", len(frames))
+	}
+}

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -1183,6 +1183,65 @@ type fakeErr string
 
 func (e fakeErr) Error() string { return string(e) }
 
+// PR16 — R3 regression: a stale same-type ancestor (dead process, or PID
+// reused with mismatched start_time) must NOT hard-stop the walk. The walk
+// must continue upward to locate a live cross-type parent. Before R3 fix,
+// the same-type check fired before the liveness/identity gate, erroneously
+// aborting the walk for leftover data that sweep had not yet cleared.
+func TestProxySubagent_StaleSameTypeAncestorDoesNotBlockWalk(t *testing.T) {
+	m := newProxyTestModule(t)
+	// Live cc frame at PID 100.
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	// Stale codex frame at PID 200 — row still in DB but process is dead.
+	seedFrame(t, m, "%5", "codex", 200, "t200_old", 5)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 400:
+			return agentpkg.ProcessInfo{PID: 400, PPID: 200}, nil
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 1}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(pid int) bool {
+		// Stale codex PID 200 dead; live cc PID 100 alive.
+		return pid == 100
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	req := EventRequest{
+		TmuxSession:     "work",
+		TmuxPaneID:      "%5",
+		EventName:       "SessionStart",
+		AgentType:       "codex",
+		SenderPID:       400,
+		SenderStartTime: "t400",
+	}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "proxy_subagent_attached" {
+		t.Fatalf("walk should skip dead stale codex and proxy-attach to live cc; got reason=%q meta=%+v", meta.Reason, meta)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // SessionEnd proxy cleanup (Phase 2 PR-2b, plan §1.5 + §2.6)
 // ---------------------------------------------------------------------------

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -552,3 +552,596 @@ func TestSendSnapshot_IncludesLegacySessionsWithoutFrames(t *testing.T) {
 	case <-time.After(20 * time.Millisecond):
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Proxy subagent detection (Phase 2 PR-2b, plan §1.4 + §2.5)
+// ---------------------------------------------------------------------------
+
+// newProxyTestModule sets up a module with a fake tmux, session provider and
+// registered cc/codex providers so each proxy test can tailor the PPID chain
+// and liveness seams independently.
+func newProxyTestModule(t *testing.T) *Module {
+	t.Helper()
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "work-code", Name: "work"}}}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive:   func(string, json.RawMessage) agentpkg.DeriveResult { return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle} },
+	})
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "codex",
+		derive:   func(string, json.RawMessage) agentpkg.DeriveResult { return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle} },
+	})
+	return m
+}
+
+func seedFrame(t *testing.T, m *Module, paneID, agentType string, pid int, startTime string, lastSeenAt int64) store.Frame {
+	t.Helper()
+	f, err := m.frames.Upsert(store.Frame{
+		PaneID:           paneID,
+		AgentType:        agentType,
+		PID:              pid,
+		PPID:             1,
+		ProcessStartTime: startTime,
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        lastSeenAt,
+		LastSeenAt:       lastSeenAt,
+		Verified:         true,
+	})
+	if err != nil {
+		t.Fatalf("seed frame %s pid=%d: %v", agentType, pid, err)
+	}
+	return f
+}
+
+// PR1 — direct PPID hit attaches proxy ref to cc parent.
+func TestProxySubagent_DirectPPIDAttachesToCCParent(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	req := EventRequest{
+		TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart",
+		AgentType: "codex", SenderPID: 200, SenderStartTime: "t200",
+	}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "proxy_subagent_attached" {
+		t.Fatalf("reason = %q, want proxy_subagent_attached (meta=%+v)", meta.Reason, meta)
+	}
+	if meta.Decision != "updated_frame" {
+		t.Fatalf("decision = %q, want updated_frame", meta.Decision)
+	}
+	if meta.FrameID != parent.FrameID {
+		t.Fatalf("FrameID = %q, want parent %q", meta.FrameID, parent.FrameID)
+	}
+
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (no standalone codex frame)", len(frames))
+	}
+	if frames[0].AgentType != "cc" {
+		t.Fatalf("remaining frame.AgentType = %q, want cc", frames[0].AgentType)
+	}
+	if len(frames[0].Subagents) != 1 {
+		t.Fatalf("parent.Subagents len = %d, want 1 (proxy ref attached)", len(frames[0].Subagents))
+	}
+	ref := frames[0].Subagents[0]
+	if ref.Type != "codex" || !ref.IsProxy || ref.SourcePID != 200 || ref.SourceStartTime != "t200" {
+		t.Fatalf("proxy ref = %+v, want type=codex is_proxy source_pid=200 source_start_time=t200", ref)
+	}
+}
+
+// PR2 — tree walk through codex-companion to cc.
+func TestProxySubagent_TreeWalkThroughCodexCompanion(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 300:
+			return agentpkg.ProcessInfo{PID: 300, PPID: 200}, nil
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 1}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 300, SenderStartTime: "t300"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 200)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "proxy_subagent_attached" {
+		t.Fatalf("reason = %q, want proxy_subagent_attached", meta.Reason)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (tree walk collapses codex into cc)", len(frames))
+	}
+}
+
+// PR3 — chain depth 6 exceeds proxyMaxDepth=5 → fallback.
+func TestProxySubagent_TreeWalkDepthLimit(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	// chain: 700→600→500→400→300→200→100(cc)
+	chain := map[int]int{700: 600, 600: 500, 500: 400, 400: 300, 300: 200, 200: 100, 100: 1}
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if ppid, ok := chain[pid]; ok {
+			return agentpkg.ProcessInfo{PID: pid, PPID: ppid}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 700, SenderStartTime: "t700"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("proxy attached but chain exceeds depth 5: %+v", meta)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frame count = %d, want 2 (cc + new codex frame; proxy not applied)", len(frames))
+	}
+}
+
+// PR4 — walk reaches init without frame; fallback new frame.
+func TestProxySubagent_SkipsWhenNoAncestorHasFrame(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid <= 1 {
+			return agentpkg.ProcessInfo{PID: pid, PPID: 0}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 9999, SenderStartTime: "t9999"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("should not proxy when no ancestor has a frame; meta=%+v", meta)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "codex" {
+		t.Fatalf("frames = %+v, want single new codex frame", frames)
+	}
+}
+
+// PR5 — same-type ancestor hard stop.
+func TestProxySubagent_SkipsWhenParentSameType(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("should not proxy cc→cc (same-type hard stop); meta=%+v", meta)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frame count = %d, want 2 (two cc frames, no proxy)", len(frames))
+	}
+}
+
+// PR6 — dead parent doesn't count; walk continues (and falls back here).
+func TestProxySubagent_SkipsWhenParentPidDead(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(pid int) bool { return pid != 100 } // cc parent dead
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("should not proxy onto dead cc frame; meta=%+v", meta)
+	}
+}
+
+// PR7 — non-SessionStart events skip proxy path.
+func TestProxySubagent_SkipsWhenEventNotSessionStart(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "UserPromptSubmit", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("non-SessionStart must not trigger proxy path; meta=%+v", meta)
+	}
+}
+
+// PR8 — trace meta decision/reason/FrameID + before/after snapshots.
+func TestProxySubagent_TraceMetaCorrect(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) { return "t100", nil }
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Decision != "updated_frame" || meta.Reason != "proxy_subagent_attached" {
+		t.Fatalf("trace meta = %q/%q, want updated_frame/proxy_subagent_attached", meta.Decision, meta.Reason)
+	}
+	if meta.FrameID != parent.FrameID {
+		t.Fatalf("FrameID = %q, want parent %q", meta.FrameID, parent.FrameID)
+	}
+	beforeMap, ok := meta.Before.(map[string]any)
+	if !ok {
+		t.Fatalf("Before = %T, want map[string]any", meta.Before)
+	}
+	beforeSubs, _ := beforeMap["subagents"].([]agentpkg.SubagentRef)
+	if len(beforeSubs) != 0 {
+		t.Fatalf("Before.subagents len = %d, want 0 (pre-attach)", len(beforeSubs))
+	}
+	afterMap, ok := meta.After.(map[string]any)
+	if !ok {
+		t.Fatalf("After = %T, want map[string]any", meta.After)
+	}
+	afterSubs, _ := afterMap["subagents"].([]agentpkg.SubagentRef)
+	if len(afterSubs) != 1 {
+		t.Fatalf("After.subagents len = %d, want 1 (post-attach)", len(afterSubs))
+	}
+}
+
+// PR9 — re-hook with same PID+StartTime is idempotent (first-write wins).
+func TestProxySubagent_DoesNotDoubleAttachOnReHook(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) { return "t100", nil }
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	for i := 0; i < 2; i++ {
+		_, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, int64(100+i))
+		if err != nil {
+			t.Fatalf("applyFrameEvent #%d: %v", i, err)
+		}
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+	if len(frames[0].Subagents) != 1 {
+		t.Fatalf("Subagents len = %d, want 1 (no double attach)", len(frames[0].Subagents))
+	}
+	if frames[0].Subagents[0].StartedAt != 100 {
+		t.Fatalf("StartedAt = %d, want 100 (first-write wins)", frames[0].Subagents[0].StartedAt)
+	}
+}
+
+// PR10 — pane filter: cross-pane PPID must not match.
+func TestProxySubagent_CrossPaneAncestorNotMatched(t *testing.T) {
+	m := newProxyTestModule(t)
+	m.tmux.(*tmux.FakeExecutor).SetPaneSessionName("%7", "work2")
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	req := EventRequest{TmuxSession: "work2", TmuxPaneID: "%7", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("cross-pane PPID should not match; meta=%+v", meta)
+	}
+	framesP5, _ := m.frames.ListByPane("%5")
+	if len(framesP5) != 1 || len(framesP5[0].Subagents) != 0 {
+		t.Fatalf("pane %%5 frames = %+v, want undisturbed cc", framesP5)
+	}
+	framesP7, _ := m.frames.ListByPane("%7")
+	if len(framesP7) != 1 || framesP7[0].AgentType != "codex" {
+		t.Fatalf("pane %%7 frames = %+v, want new codex frame", framesP7)
+	}
+}
+
+// PR11 — self-cycle PPID == PID must not loop.
+func TestProxySubagent_SelfCycleGuard(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 300}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: pid}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	done := make(chan struct{})
+	go func() {
+		_, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+		if err != nil {
+			t.Errorf("applyFrameEvent: %v", err)
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("applyFrameEvent hung on self-cycle")
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "codex" {
+		t.Fatalf("frames = %+v, want single codex (no proxy due to self-cycle guard)", frames)
+	}
+}
+
+// PR12 — ancestor process read error → partial chain, fallback.
+func TestProxySubagent_PartialChainOnReadError(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 300}, nil
+		}
+		return agentpkg.ProcessInfo{}, errFake
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("read error should abort walk; meta=%+v", meta)
+	}
+}
+
+// PR13 — stale frame (PID reused) skipped by start-time mismatch.
+func TestProxySubagent_SkipsStaleFrameByStartTimeMismatch(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t_different", nil
+		}
+		return "other", nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	beforeParent, _ := m.frames.GetByIdentity("%5", 100, "t100")
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("stale (start-time mismatch) parent should not proxy-attach; meta=%+v", meta)
+	}
+	afterParent, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if afterParent == nil {
+		t.Fatal("stale cc frame went missing (should remain for sweep)")
+	}
+	if afterParent.LastSeenAt != beforeParent.LastSeenAt {
+		t.Fatalf("stale cc.LastSeenAt = %d, want unchanged %d", afterParent.LastSeenAt, beforeParent.LastSeenAt)
+	}
+}
+
+// PR14 — same-type ancestor (codex) in chain halts walk before cc.
+func TestProxySubagent_SameTypeAncestorStopsWalk(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	seedFrame(t, m, "%5", "codex", 200, "t200", 20)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 400:
+			return agentpkg.ProcessInfo{PID: 400, PPID: 300}, nil
+		case 300:
+			return agentpkg.ProcessInfo{PID: 300, PPID: 200}, nil
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 400, SenderStartTime: "t400"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("walk should halt at same-type codex ancestor, not reach cc; meta=%+v", meta)
+	}
+}
+
+// PR15 — start-time read error aborts walk (does NOT fall through to outer cross-type ancestor).
+func TestProxySubagent_AbortsWalkOnStartTimeReadError(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	seedFrame(t, m, "%5", "cc", 50, "t50", 5)
+
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 50}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "", errFake
+		}
+		return "other", nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "proxy_subagent_attached" {
+		t.Fatalf("start_time read error should abort walk (not fall through to outer cc frame); meta=%+v", meta)
+	}
+}
+
+var errFake = fakeErr("fake read error")
+
+type fakeErr string
+
+func (e fakeErr) Error() string { return string(e) }

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -509,6 +509,85 @@ func TestUpdateSubagents_ProxyNativeIDNamespacesAreIsolated(t *testing.T) {
 	}
 }
 
+// U7 — #632 extended: native SubagentStart path also uses the atomic
+// mutate-with-retry helper, so two concurrent hook-driven Task tool
+// dispatches that attach different agent_ids to the same cc frame both
+// land. Same race shape as PR17 but through the SubagentStart event path
+// rather than the proxy fast-path.
+func TestSubagentStart_ConcurrentNativeStartsBothLand(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	// Start #1: native SubagentStart with agent_id "s1".
+	req1 := EventRequest{
+		TmuxSession: "work", TmuxPaneID: "%5",
+		EventName: "SubagentStart", AgentType: "cc",
+		SenderPID: 100, SenderStartTime: "t100",
+	}
+	result1 := agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning, Detail: map[string]any{"agent_id": "s1"}}
+	_, meta1, err := m.applyFrameEvent(req1, result1, 100)
+	if err != nil {
+		t.Fatalf("start #1: %v", err)
+	}
+	if meta1.Reason != "subagent_membership_changed" {
+		t.Fatalf("start #1 reason = %q, want subagent_membership_changed", meta1.Reason)
+	}
+
+	// Simulate a concurrent racer write (e.g. a probe-driven LastSeenAt
+	// bump or another SubagentStart that landed first but hasn't been
+	// observed by request #2's read yet).
+	racer := agentpkg.SubagentRef{ID: "racer", Type: "cc", StartedAt: 150}
+	cur, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil {
+		t.Fatalf("racer baseline read: %v", err)
+	}
+	cur.Subagents = append(cur.Subagents, racer)
+	cur.LastSeenAt = 180
+	if _, err := m.frames.Upsert(*cur); err != nil {
+		t.Fatalf("racer Upsert: %v", err)
+	}
+
+	// Start #2: native SubagentStart with agent_id "s2". applyFrameEvent's
+	// earlier GetByIdentity read still sees the pre-racer baseline; the
+	// atomic retry loop must reload, observe racer + s1, append s2, persist.
+	req2 := EventRequest{
+		TmuxSession: "work", TmuxPaneID: "%5",
+		EventName: "SubagentStart", AgentType: "cc",
+		SenderPID: 100, SenderStartTime: "t100",
+	}
+	result2 := agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning, Detail: map[string]any{"agent_id": "s2"}}
+	_, meta2, err := m.applyFrameEvent(req2, result2, 200)
+	if err != nil {
+		t.Fatalf("start #2: %v", err)
+	}
+	if meta2.Reason != "subagent_membership_changed" {
+		t.Fatalf("start #2 reason = %q, want subagent_membership_changed", meta2.Reason)
+	}
+
+	// All three refs should coexist on the parent: s1 from start #1,
+	// racer from the injected concurrent write, s2 from start #2.
+	final, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil {
+		t.Fatalf("final read: %v", err)
+	}
+	if final == nil {
+		t.Fatal("parent vanished")
+	}
+	ids := make(map[string]bool)
+	for _, ref := range final.Subagents {
+		ids[ref.ID] = true
+	}
+	for _, want := range []string{"s1", "s2", "racer"} {
+		if !ids[want] {
+			t.Fatalf("Subagents missing ID=%q; parent=%+v", want, final.Subagents)
+		}
+	}
+	if len(final.Subagents) != 3 {
+		t.Fatalf("Subagents len = %d, want 3; parent=%+v", len(final.Subagents), final.Subagents)
+	}
+	_ = parent
+}
+
 func TestSendSnapshot_IncludesLegacySessionsWithoutFrames(t *testing.T) {
 	m := newTestModule(t)
 	fakeTmux := tmux.NewFakeExecutor()

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -1283,6 +1283,116 @@ func TestProxySubagent_StaleSameTypeAncestorDoesNotBlockWalk(t *testing.T) {
 	}
 }
 
+// PR17 — #632 regression: two concurrent proxy SessionStarts that target the
+// same parent frame must both land. The first attach wins the initial
+// UpsertIfUnchanged; the second observes the freshened last_seen_at, reloads,
+// re-merges its ref through updateSubagents, and persists — yielding a
+// parent with both proxy refs attached.
+//
+// We drive the race by intercepting the store's UpsertIfUnchanged on the
+// FIRST attempt of attach #2: before attempt #2 issues its UPDATE, a
+// simulated concurrent writer bumps the parent's LastSeenAt. That write
+// invalidates attempt #2's baseline and triggers the retry-with-reload
+// branch; attempt #3 merges and succeeds.
+func TestProxySubagent_ConcurrentAttachesBothLand(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "t100", nil }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// Attach #1: codex PID 200, start t200.
+	req1 := EventRequest{
+		TmuxSession: "work", TmuxPaneID: "%5",
+		EventName: "SessionStart", AgentType: "codex",
+		SenderPID: 200, SenderStartTime: "t200",
+	}
+	_, meta1, err := m.applyFrameEvent(req1, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("attach #1 applyFrameEvent: %v", err)
+	}
+	if meta1.Reason != "proxy_subagent_attached" {
+		t.Fatalf("attach #1 reason = %q, want proxy_subagent_attached", meta1.Reason)
+	}
+
+	// Concurrency race injection: before attach #2's UpsertIfUnchanged sees
+	// the DB, a third writer (e.g. another proxy attach in-flight, or a
+	// probe-driven LastSeenAt refresh) lands. We simulate this by directly
+	// poking the DB between attach #2's read and write — the read happens in
+	// applyFrameEvent's frame lookup / findProxyParent, and we install a
+	// hook via UpsertIfUnchanged timing using race-injector: mutate the row
+	// in a goroutine between request #2's findProxyParent and its write.
+	//
+	// Simpler approach: directly bump the DB row via a synthetic Upsert
+	// before calling applyFrameEvent #2. Then verify attach #2 retries
+	// (visible via post-state: parent has BOTH s1 from attach #1 AND the
+	// injected racer's ref AND attach #2's ref; all three survive).
+	racer := agentpkg.SubagentRef{
+		ID: "racer:codex:999:t999", Type: "codex", StartedAt: 150,
+		SourcePID: 999, SourceStartTime: "t999", IsProxy: true,
+	}
+	cur, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil {
+		t.Fatalf("racer baseline read: %v", err)
+	}
+	cur.Subagents = append(cur.Subagents, racer)
+	cur.LastSeenAt = 180
+	if _, err := m.frames.Upsert(*cur); err != nil {
+		t.Fatalf("racer Upsert: %v", err)
+	}
+
+	// Attach #2: different codex, PID 300, start t300. This request's
+	// findProxyParent returned the parent with attach #1's ref BEFORE the
+	// racer write; the retry branch reloads and merges without losing the
+	// racer ref.
+	req2 := EventRequest{
+		TmuxSession: "work", TmuxPaneID: "%5",
+		EventName: "SessionStart", AgentType: "codex",
+		SenderPID: 300, SenderStartTime: "t300",
+	}
+	_, meta2, err := m.applyFrameEvent(req2, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 200)
+	if err != nil {
+		t.Fatalf("attach #2 applyFrameEvent: %v", err)
+	}
+	if meta2.Reason != "proxy_subagent_attached" {
+		t.Fatalf("attach #2 reason = %q, want proxy_subagent_attached", meta2.Reason)
+	}
+
+	// All three refs survived the read-modify-write cycle.
+	final, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil {
+		t.Fatalf("final read: %v", err)
+	}
+	if final == nil {
+		t.Fatal("parent vanished")
+	}
+	have := make(map[int]bool)
+	for _, ref := range final.Subagents {
+		have[ref.SourcePID] = true
+	}
+	for _, want := range []int{200, 300, 999} {
+		if !have[want] {
+			t.Fatalf("Subagents missing SourcePID=%d; parent=%+v", want, final.Subagents)
+		}
+	}
+	if len(final.Subagents) != 3 {
+		t.Fatalf("Subagents len = %d, want 3 (both attaches + racer); parent=%+v", len(final.Subagents), final.Subagents)
+	}
+
+	_ = parent // suppress unused warning
+}
+
 // ---------------------------------------------------------------------------
 // SessionEnd proxy cleanup (Phase 2 PR-2b, plan §1.5 + §2.6)
 // ---------------------------------------------------------------------------

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -1732,3 +1732,98 @@ func TestHandleStatuslineSetup_RemoveBroadcastsCleared(t *testing.T) {
 		t.Error("agent.status.cleared broadcast not seen")
 	}
 }
+
+// HB2 (Lights Phase 2 plan §2.8) — after cc SessionStart and a codex
+// SessionStart whose PPID resolves to the cc frame, the subsequent broadcast
+// payload must contain a SubagentRef with is_proxy=true, type="codex",
+// source_pid=<codex.PID>.
+func TestHandleEvent_ProxyBroadcastCarriesIsProxyTrue(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive:   func(string, json.RawMessage) agentpkg.DeriveResult { return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle} },
+	})
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "codex",
+		derive:   func(string, json.RawMessage) agentpkg.DeriveResult { return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle} },
+	})
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	// Shape the probe seams so PPID walk hits the cc frame.
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 300 {
+			return agentpkg.ProcessInfo{PID: 300, PPID: 200}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	processStartTimeFn = func(int) (string, error) { return "Sun Apr 20 01:30:00 2026", nil }
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	// cc SessionStart first.
+	for _, body := range []string{
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"cc"}`,
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":300,"sender_start_time":"Sun Apr 20 01:35:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"codex"}`,
+	} {
+		req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		m.handleEvent(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body=%s)", w.Code, w.Body.String())
+		}
+	}
+
+	// Drain cc SessionStart broadcast.
+	select {
+	case <-sub.SendCh():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for cc SessionStart broadcast")
+	}
+
+	// Second broadcast is the proxy attach.
+	select {
+	case msg := <-sub.SendCh():
+		var env struct {
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		var payload struct {
+			Subagents []map[string]any `json:"subagents"`
+		}
+		if err := json.Unmarshal([]byte(env.Value), &payload); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+		if len(payload.Subagents) != 1 {
+			t.Fatalf("subagents len = %d, want 1 (payload=%s)", len(payload.Subagents), env.Value)
+		}
+		ref := payload.Subagents[0]
+		if ref["is_proxy"] != true {
+			t.Errorf("subagents[0].is_proxy = %v, want true", ref["is_proxy"])
+		}
+		if ref["type"] != "codex" {
+			t.Errorf("subagents[0].type = %v, want codex", ref["type"])
+		}
+		srcPID, _ := ref["source_pid"].(float64)
+		if int(srcPID) != 300 {
+			t.Errorf("subagents[0].source_pid = %v, want 300", ref["source_pid"])
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for proxy broadcast")
+	}
+}

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -9,9 +9,20 @@ import (
 	"github.com/wake/purdex/internal/store"
 )
 
+// frameIdleThreshold is how long a frame can sit without a LastSeenAt refresh
+// before sweepOnce marks it idle and attempts an optimistic DELETE. Hook
+// traffic continuously bumps LastSeenAt, so a live session will never cross
+// this threshold; crossing it is a strong signal the agent process has
+// silently exited without emitting SessionEnd (e.g. SIGKILL / crash).
+const frameIdleThreshold = 1 * time.Hour
+
 var (
 	sweepInterval = 2 * time.Second
 	sweepOnceFn   = func(m *Module) { _ = m.sweepOnce() }
+	// nowFn is the time-seam used by idle_timeout checks. Tests override to
+	// simulate time-travel without having to fabricate past LastSeenAt values
+	// that interact awkwardly with the SQLite column types.
+	nowFn = time.Now
 )
 
 func (m *Module) startSweep() {
@@ -62,11 +73,35 @@ func (m *Module) sweepOnce() error {
 			if err := m.clearFrame(frame, "pid_reused"); err != nil {
 				return err
 			}
+			continue
+		}
+		// Idle timeout: alive process + identity-verified, but LastSeenAt
+		// hasn't been refreshed by any hook for frameIdleThreshold. Use
+		// DeleteIfUnchanged (optimistic concurrency) so a concurrent hook
+		// Upsert that just refreshed the row is not clobbered by our stale
+		// baseline.
+		if nowFn().UnixNano()-frame.LastSeenAt > frameIdleThreshold.Nanoseconds() {
+			deleted, err := m.frames.DeleteIfUnchanged(frame.FrameID, frame.LastSeenAt)
+			if err != nil {
+				return err
+			}
+			if !deleted {
+				// Concurrent refresh raced us — the row is still live.
+				// Not an error; skip this frame this round.
+				continue
+			}
+			if err := m.afterFrameCleared(frame, "idle_timeout"); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
+// clearFrame is the eager delete path used for pid_dead / pid_reused sweeps
+// (and any other call site that wants an unconditional frame removal).
+// For the new idle_timeout path, sweepOnce calls DeleteIfUnchanged directly
+// and then afterFrameCleared for the shared cleanup work.
 func (m *Module) clearFrame(frame store.Frame, reason string) error {
 	if m.frames == nil {
 		return nil
@@ -74,6 +109,14 @@ func (m *Module) clearFrame(frame store.Frame, reason string) error {
 	if err := m.frames.Delete(frame.FrameID); err != nil {
 		return err
 	}
+	return m.afterFrameCleared(frame, reason)
+}
+
+// afterFrameCleared handles the post-delete side effects shared by every
+// sweep reason: legacy agent_events cleanup, in-memory projection sync,
+// orphan Activity watcher stop (bug fix: previously only pid_dead/pid_reused
+// paths forgot to call StopWatch; now centralized), and WS broadcast.
+func (m *Module) afterFrameCleared(frame store.Frame, reason string) error {
 	sessionName, code := m.resolvePaneSession(frame.PaneID)
 	if sessionName != "" && m.events != nil {
 		if err := m.events.Delete(sessionName); err != nil {
@@ -84,19 +127,25 @@ func (m *Module) clearFrame(frame store.Frame, reason string) error {
 	if err != nil {
 		return err
 	}
+
+	var hadWatcher bool
 	m.mu.Lock()
 	if sessionName != "" {
 		syncProjectionState(m.currentStatus, m.subagents, sessionName, projection)
 		if projection == nil || projection.TopFrame == nil {
+			_, hadWatcher = m.activeWatchers[sessionName]
 			delete(m.activeWatchers, sessionName)
 		}
 	}
 	m.mu.Unlock()
+	if hadWatcher && m.prober != nil {
+		m.prober.StopWatch(sessionName + ":")
+	}
 
 	if code == "" || m.core == nil {
 		return nil
 	}
-	normalized := buildProjectionNormalized(projection, frame.AgentType, "sweep:"+reason, time.Now().UnixNano(), agentpkg.DeriveResult{})
+	normalized := buildProjectionNormalized(projection, frame.AgentType, "sweep:"+reason, nowFn().UnixNano(), agentpkg.DeriveResult{})
 	payload, _ := json.Marshal(normalized)
 	m.core.Events.Broadcast(code, "hook", string(payload))
 	return nil

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -496,6 +496,58 @@ func TestSweep_IdleConditionalDeleteSkipsOnConcurrentRefresh(t *testing.T) {
 	}
 }
 
+// IS6 — probe-driven status transitions (setProjectionTopStatus) refresh
+// LastSeenAt so the idle rule does not mis-classify a live agent at a shell
+// prompt as idle. R1 regression: v6 plan assumed hook traffic was the only
+// LastSeenAt source, but probe activity is the normal signal for
+// waiting/running/idle while hooks may be silent for > 1h.
+func TestSweep_PreservesLiveFrameAfterProbeActivity(t *testing.T) {
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        0,
+		LastSeenAt:       0, // stale baseline — > 1h in the past from sweep's POV
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	probeTime := time.Now().UnixNano()
+	if _, err := m.setProjectionTopStatus("work", agentpkg.StatusIdle); err != nil {
+		t.Fatalf("setProjectionTopStatus: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "live", nil }
+	// Sweep 30 min after probe activity — well within the 1h idle threshold.
+	nowFn = func() time.Time { return time.Unix(0, probeTime+int64(30*time.Minute)) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (probe-bumped LastSeenAt keeps frame alive)", len(frames))
+	}
+	if frames[0].LastSeenAt < probeTime {
+		t.Fatalf("LastSeenAt = %d, want >= %d (setProjectionTopStatus should have bumped it)", frames[0].LastSeenAt, probeTime)
+	}
+}
+
 func TestSweep_ClearingFramePreservesSiblings(t *testing.T) {
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -548,6 +548,72 @@ func TestSweep_PreservesLiveFrameAfterProbeActivity(t *testing.T) {
 	}
 }
 
+// IS7 — R7 regression: setProjectionTopStatus does narrow column update
+// (status + last_seen_at only), so probe-driven status transitions do not
+// clobber concurrent Subagents mutations on the same row. Before the narrow
+// update fix, status updates round-tripped a stale Subagents baseline and
+// could overwrite refs added by concurrent proxy/native attaches.
+func TestSetProjectionTopStatus_DoesNotClobberConcurrentSubagents(t *testing.T) {
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Subagents:        []agentpkg.SubagentRef{{ID: "a", Type: "cc", StartedAt: 10}},
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert baseline: %v", err)
+	}
+
+	// Simulate a concurrent subagents mutation landing on the row after the
+	// probe callback has already read the projection but before its status
+	// write. Under the old whole-frame Upsert path, the probe callback's
+	// stale Subagents baseline would clobber this write.
+	racerBaseline, _ := m.frames.GetByIdentity("%5", 200, "live")
+	racerBaseline.Subagents = append(racerBaseline.Subagents,
+		agentpkg.SubagentRef{ID: "b", Type: "cc", StartedAt: 20},
+		agentpkg.SubagentRef{ID: "c", Type: "cc", StartedAt: 30})
+	racerBaseline.LastSeenAt = 30
+	if _, err := m.frames.Upsert(*racerBaseline); err != nil {
+		t.Fatalf("racer Upsert: %v", err)
+	}
+
+	// Probe callback fires. setProjectionTopStatus reads the (now-stale)
+	// projection, but under the narrow-update fix it only writes status +
+	// last_seen_at — the subagents_json column is untouched.
+	if _, err := m.setProjectionTopStatus("work", agentpkg.StatusIdle); err != nil {
+		t.Fatalf("setProjectionTopStatus: %v", err)
+	}
+
+	final, err := m.frames.GetByIdentity("%5", 200, "live")
+	if err != nil {
+		t.Fatalf("final read: %v", err)
+	}
+	if final == nil {
+		t.Fatal("frame vanished")
+	}
+	if final.Status != agentpkg.StatusIdle {
+		t.Fatalf("Status = %q, want Idle", final.Status)
+	}
+	if len(final.Subagents) != 3 {
+		t.Fatalf("Subagents len = %d, want 3 (concurrent writer's refs preserved); got %+v", len(final.Subagents), final.Subagents)
+	}
+	ids := make(map[string]bool)
+	for _, ref := range final.Subagents {
+		ids[ref.ID] = true
+	}
+	for _, want := range []string{"a", "b", "c"} {
+		if !ids[want] {
+			t.Fatalf("Subagents missing ID=%q; subagents_json was clobbered by status write", want)
+		}
+	}
+}
+
 func TestSweep_ClearingFramePreservesSiblings(t *testing.T) {
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -2,10 +2,13 @@ package agent
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/probe"
+	"github.com/wake/purdex/internal/core"
 	"github.com/wake/purdex/internal/module/session"
 	"github.com/wake/purdex/internal/store"
 	"github.com/wake/purdex/internal/tmux"
@@ -79,11 +82,16 @@ func TestSweep_PreservesLiveFrames(t *testing.T) {
 	}
 	origAlive := isPidAliveFn
 	origStart := processStartTimeFn
+	origNow := nowFn
 	isPidAliveFn = func(pid int) bool { return true }
 	processStartTimeFn = func(pid int) (string, error) { return "live", nil }
+	// Pin "now" close to LastSeenAt so the idle_timeout rule does not fire
+	// on fixture frames using a simple sentinel LastSeenAt value.
+	nowFn = func() time.Time { return time.Unix(0, 10) }
 	t.Cleanup(func() {
 		isPidAliveFn = origAlive
 		processStartTimeFn = origStart
+		nowFn = origNow
 	})
 
 	if err := m.sweepOnce(); err != nil {
@@ -212,11 +220,14 @@ func TestSweep_DoesNotMassDeleteOnTmuxOutage(t *testing.T) {
 	}
 	origAlive := isPidAliveFn
 	origStart := processStartTimeFn
+	origNow := nowFn
 	isPidAliveFn = func(pid int) bool { return true }
 	processStartTimeFn = func(pid int) (string, error) { return "live", nil }
+	nowFn = func() time.Time { return time.Unix(0, 10) }
 	t.Cleanup(func() {
 		isPidAliveFn = origAlive
 		processStartTimeFn = origStart
+		nowFn = origNow
 	})
 
 	if err := m.sweepOnce(); err != nil {
@@ -228,6 +239,260 @@ func TestSweep_DoesNotMassDeleteOnTmuxOutage(t *testing.T) {
 	}
 	if len(frames) != 1 {
 		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Idle sweep (Phase 2 PR-2b, plan §1.6 + §1.8 + §2.7)
+// ---------------------------------------------------------------------------
+
+// IS1 — frame idle past threshold is cleared with broadcast reason=sweep:idle_timeout.
+func TestSweep_ClearsIdleFramesByLastSeen(t *testing.T) {
+	m := newSweepTestModule(t)
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: m.tmux}
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	// Seed frame with LastSeenAt=0; fake nowFn returns 2×threshold so the
+	// elapsed delta > threshold triggers the idle_timeout rule.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        0,
+		LastSeenAt:       0,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "live", nil }
+	nowFn = func() time.Time { return time.Unix(0, int64(2*frameIdleThreshold)) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0 (idle frame should be cleared)", len(frames))
+	}
+
+	// Drain broadcast with reason=sweep:idle_timeout (inside escaped payload).
+	select {
+	case msg := <-sub.SendCh():
+		if !strings.Contains(string(msg), `sweep:idle_timeout`) {
+			t.Fatalf("broadcast = %s, want reason sweep:idle_timeout", msg)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for idle_timeout broadcast")
+	}
+}
+
+// IS2 — fresh frame (LastSeenAt within threshold) is preserved.
+func TestSweep_PreservesFreshFrames(t *testing.T) {
+	m := newSweepTestModule(t)
+
+	// Pretend "now" is 1h — fresh frame LastSeenAt at now-1min (delta < threshold).
+	fakeNow := int64(60 * time.Minute)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        fakeNow - int64(time.Minute),
+		LastSeenAt:       fakeNow - int64(time.Minute),
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "live", nil }
+	nowFn = func() time.Time { return time.Unix(0, fakeNow) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (fresh frame preserved)", len(frames))
+	}
+}
+
+// IS3 — idle sweep also stops the orphan activity watcher.
+func TestSweep_IdleClearStopsOrphanWatcher(t *testing.T) {
+	m := newSweepTestModule(t)
+	m.prober = probe.New(m.tmux)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        0,
+		LastSeenAt:       0,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	// Register an active watcher for this session (simulating an in-flight
+	// Activity probe left over from a running/waiting status).
+	m.activeWatchers["work"] = "cc"
+	m.prober.StartWatch("work:", func(string, probe.ActivitySignal) {})
+	t.Cleanup(func() { m.prober.StopAllWatches() })
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "live", nil }
+	nowFn = func() time.Time { return time.Unix(0, int64(2*frameIdleThreshold)) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	if _, ok := m.activeWatchers["work"]; ok {
+		t.Fatal("activeWatchers[work] should be cleared after idle_timeout sweep")
+	}
+	if m.prober.HasWatcher("work:") {
+		t.Fatal("prober watcher for work: should be stopped after idle_timeout sweep")
+	}
+}
+
+// IS4 — pid_dead path also stops the orphan watcher (regression for the
+// pre-PR-2b bug that only deleted the map entry).
+func TestSweep_DeadPidAlsoStopsOrphanWatcher(t *testing.T) {
+	m := newSweepTestModule(t)
+	m.prober = probe.New(m.tmux)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	m.activeWatchers["work"] = "cc"
+	m.prober.StartWatch("work:", func(string, probe.ActivitySignal) {})
+	t.Cleanup(func() { m.prober.StopAllWatches() })
+
+	origAlive := isPidAliveFn
+	isPidAliveFn = func(int) bool { return false } // dead
+	t.Cleanup(func() { isPidAliveFn = origAlive })
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	if _, ok := m.activeWatchers["work"]; ok {
+		t.Fatal("activeWatchers[work] should be cleared after pid_dead sweep")
+	}
+	if m.prober.HasWatcher("work:") {
+		t.Fatal("prober watcher should be stopped after pid_dead sweep (StopWatch leak fix)")
+	}
+}
+
+// IS5 — concurrent refresh between ListAll and DeleteIfUnchanged causes the
+// optimistic sweep to skip the frame rather than clobber the refreshed row.
+func TestSweep_IdleConditionalDeleteSkipsOnConcurrentRefresh(t *testing.T) {
+	m := newSweepTestModule(t)
+
+	// The frame starts idle (LastSeenAt=0). sweepOnce() will read the list
+	// first, then iterate. We simulate a concurrent hook refresh by bumping
+	// LastSeenAt between ListAll and the DELETE — achieved by swapping nowFn
+	// to run an Upsert on first call.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        0,
+		LastSeenAt:       0,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "live", nil }
+	// First call (isPidAliveFn before idle check) reads the baseline now; we
+	// piggyback on nowFn to force a concurrent Upsert before the DELETE runs.
+	var raced bool
+	nowFn = func() time.Time {
+		if !raced {
+			raced = true
+			// Simulate concurrent hook refresh before our sweep DELETE.
+			_, _ = m.frames.Upsert(store.Frame{
+				PaneID:           "%5",
+				AgentType:        "cc",
+				PID:              200,
+				PPID:             1,
+				ProcessStartTime: "live",
+				Status:           agentpkg.StatusIdle,
+				StartedAt:        0,
+				LastSeenAt:       int64(30 * time.Minute),
+				Verified:         true,
+			})
+		}
+		return time.Unix(0, int64(2*frameIdleThreshold))
+	}
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (DeleteIfUnchanged should skip on refresh)", len(frames))
+	}
+	if frames[0].LastSeenAt != int64(30*time.Minute) {
+		t.Fatalf("LastSeenAt = %d, want refreshed value (concurrent Upsert preserved)", frames[0].LastSeenAt)
 	}
 }
 
@@ -261,6 +526,7 @@ func TestSweep_ClearingFramePreservesSiblings(t *testing.T) {
 	}
 	origAlive := isPidAliveFn
 	origStart := processStartTimeFn
+	origNow := nowFn
 	isPidAliveFn = func(pid int) bool { return pid != 300 }
 	processStartTimeFn = func(pid int) (string, error) {
 		if pid == 200 {
@@ -268,9 +534,11 @@ func TestSweep_ClearingFramePreservesSiblings(t *testing.T) {
 		}
 		return "B", nil
 	}
+	nowFn = func() time.Time { return time.Unix(0, 20) }
 	t.Cleanup(func() {
 		isPidAliveFn = origAlive
 		processStartTimeFn = origStart
+		nowFn = origNow
 	})
 
 	if err := m.sweepOnce(); err != nil {

--- a/internal/store/frames.go
+++ b/internal/store/frames.go
@@ -256,6 +256,22 @@ func (s *FramesStore) Delete(frameID string) error {
 	return err
 }
 
+// DeleteIfUnchanged removes the frame only if its last_seen_at matches the
+// provided value — a concurrent Upsert that refreshed the row will bump
+// last_seen_at and cause this DELETE to match 0 rows, returning (false, nil).
+// Caller should treat (false, nil) as "frame got refreshed, skip this sweep".
+func (s *FramesStore) DeleteIfUnchanged(frameID string, lastSeenAt int64) (bool, error) {
+	res, err := s.db.Exec(`DELETE FROM agent_frames WHERE frame_id = ? AND last_seen_at = ?`, frameID, lastSeenAt)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
 func collectFrames(rows *sql.Rows) ([]Frame, error) {
 	var frames []Frame
 	for rows.Next() {

--- a/internal/store/frames.go
+++ b/internal/store/frames.go
@@ -272,6 +272,60 @@ func (s *FramesStore) DeleteIfUnchanged(frameID string, lastSeenAt int64) (bool,
 	return affected > 0, nil
 }
 
+// UpsertIfUnchanged updates an existing frame atomically, returning
+// (false, zeroFrame, nil) if the row's last_seen_at no longer matches
+// expectedLastSeenAt — i.e. a concurrent writer changed the row between our
+// read and write. Used by subagents-mutation paths (proxy attach / detach /
+// SubagentStart / SubagentStop) to serialize read-modify-write cycles.
+//
+// Unlike Upsert, this is update-only: the frame must already exist and
+// frame.FrameID must be set. Caller retries by reloading the row, re-merging
+// the subagents list against the new baseline, and calling again.
+func (s *FramesStore) UpsertIfUnchanged(frame Frame, expectedLastSeenAt int64) (bool, Frame, error) {
+	if frame.FrameID == "" {
+		return false, Frame{}, fmt.Errorf("UpsertIfUnchanged: frame.FrameID required")
+	}
+	if frame.Subagents == nil {
+		frame.Subagents = []agentpkg.SubagentRef{}
+	}
+	subagentsJSON, err := json.Marshal(frame.Subagents)
+	if err != nil {
+		return false, Frame{}, fmt.Errorf("marshal subagents: %w", err)
+	}
+	res, err := s.db.Exec(`
+		UPDATE agent_frames SET
+			agent_type = ?,
+			ppid = ?,
+			parent_frame_id = ?,
+			subagents_json = ?,
+			status = ?,
+			started_at = ?,
+			last_seen_at = ?,
+			verified = ?
+		WHERE frame_id = ? AND last_seen_at = ?
+	`, frame.AgentType, frame.PPID, nullString(frame.ParentFrameID),
+		string(subagentsJSON), string(frame.Status), frame.StartedAt, frame.LastSeenAt,
+		boolToInt(frame.Verified), frame.FrameID, expectedLastSeenAt)
+	if err != nil {
+		return false, Frame{}, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, Frame{}, err
+	}
+	if affected == 0 {
+		return false, Frame{}, nil
+	}
+	stored, err := s.GetByIdentity(frame.PaneID, frame.PID, frame.ProcessStartTime)
+	if err != nil {
+		return false, Frame{}, err
+	}
+	if stored == nil {
+		return false, Frame{}, sql.ErrNoRows
+	}
+	return true, *stored, nil
+}
+
 func collectFrames(rows *sql.Rows) ([]Frame, error) {
 	var frames []Frame
 	for rows.Next() {

--- a/internal/store/frames.go
+++ b/internal/store/frames.go
@@ -295,6 +295,71 @@ func (s *FramesStore) UpdateStatusAndLastSeen(frameID string, status agentpkg.St
 	return nil
 }
 
+// UpdateHookPath updates the columns that a general-hook status transition
+// (applyFrameEvent's frame != nil branch for non-SessionEnd/SubagentStart/
+// SubagentStop events) needs to touch on an existing frame — everything
+// except started_at and, crucially, subagents_json. Leaving subagents_json
+// out of the SQL prevents a hook handler's stale baseline from clobbering
+// concurrent proxy/native subagent mutations on the same row (#632 R8).
+// Returns sql.ErrNoRows if the frame does not exist.
+func (s *FramesStore) UpdateHookPath(frame Frame) error {
+	res, err := s.db.Exec(`
+		UPDATE agent_frames SET
+			agent_type = ?,
+			ppid = ?,
+			parent_frame_id = ?,
+			status = ?,
+			last_seen_at = ?,
+			verified = ?
+		WHERE frame_id = ?
+	`, frame.AgentType, frame.PPID, nullString(frame.ParentFrameID),
+		string(frame.Status), frame.LastSeenAt, boolToInt(frame.Verified), frame.FrameID)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// UpdateHookPathAndResetSubagents is UpdateHookPath plus an explicit
+// subagents_json = '[]' write, used only by SessionStart on an existing
+// frame where the intent is to wipe the previous session's ref list.
+// Race semantics under concurrent attach are "SessionStart wins" — the
+// new session's empty list overwrites any in-flight attach; the attach's
+// sender will emit its own SubagentStart afterward if still relevant.
+// Returns sql.ErrNoRows if the frame does not exist.
+func (s *FramesStore) UpdateHookPathAndResetSubagents(frame Frame) error {
+	res, err := s.db.Exec(`
+		UPDATE agent_frames SET
+			agent_type = ?,
+			ppid = ?,
+			parent_frame_id = ?,
+			subagents_json = '[]',
+			status = ?,
+			last_seen_at = ?,
+			verified = ?
+		WHERE frame_id = ?
+	`, frame.AgentType, frame.PPID, nullString(frame.ParentFrameID),
+		string(frame.Status), frame.LastSeenAt, boolToInt(frame.Verified), frame.FrameID)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
 // UpsertIfUnchanged updates an existing frame atomically, returning
 // (false, zeroFrame, nil) if the row's last_seen_at no longer matches
 // expectedLastSeenAt — i.e. a concurrent writer changed the row between our

--- a/internal/store/frames.go
+++ b/internal/store/frames.go
@@ -272,6 +272,29 @@ func (s *FramesStore) DeleteIfUnchanged(frameID string, lastSeenAt int64) (bool,
 	return affected > 0, nil
 }
 
+// UpdateStatusAndLastSeen updates only the status + last_seen_at columns of
+// the frame identified by frameID. Narrow by design: probe-driven status
+// transitions must not round-trip through a whole-frame write because doing
+// so would clobber concurrent Subagents mutations (see #632 R7). Returns
+// sql.ErrNoRows if the frame does not exist.
+func (s *FramesStore) UpdateStatusAndLastSeen(frameID string, status agentpkg.Status, lastSeenAt int64) error {
+	res, err := s.db.Exec(`
+		UPDATE agent_frames SET status = ?, last_seen_at = ?
+		WHERE frame_id = ?
+	`, string(status), lastSeenAt, frameID)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
 // UpsertIfUnchanged updates an existing frame atomically, returning
 // (false, zeroFrame, nil) if the row's last_seen_at no longer matches
 // expectedLastSeenAt — i.e. a concurrent writer changed the row between our

--- a/internal/store/frames_test.go
+++ b/internal/store/frames_test.go
@@ -447,6 +447,107 @@ func TestMigrateFramesDB_FailsOnMalformedSubagentsJSON(t *testing.T) {
 	}
 }
 
+func TestFrames_DeleteIfUnchanged_DeletesWhenMatching(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	frame, err := s.Upsert(Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	deleted, err := s.DeleteIfUnchanged(frame.FrameID, 10)
+	if err != nil {
+		t.Fatalf("DeleteIfUnchanged: %v", err)
+	}
+	if !deleted {
+		t.Fatal("DeleteIfUnchanged returned (false, nil); want (true, nil) for matching last_seen_at")
+	}
+
+	got, err := s.GetByIdentity("%5", 200, "A")
+	if err != nil {
+		t.Fatalf("GetByIdentity: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("frame still present after DeleteIfUnchanged: %+v", *got)
+	}
+}
+
+func TestFrames_DeleteIfUnchanged_SkipsWhenStale(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	frame, err := s.Upsert(Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Simulate concurrent refresh: LastSeenAt bumped from 10 to 20 before our DELETE runs.
+	if _, err := s.Upsert(Frame{
+		FrameID:          frame.FrameID,
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       20,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert refresh: %v", err)
+	}
+
+	deleted, err := s.DeleteIfUnchanged(frame.FrameID, 10)
+	if err != nil {
+		t.Fatalf("DeleteIfUnchanged: %v", err)
+	}
+	if deleted {
+		t.Fatal("DeleteIfUnchanged returned true for stale last_seen_at; want false (concurrent refresh)")
+	}
+
+	got, err := s.GetByIdentity("%5", 200, "A")
+	if err != nil {
+		t.Fatalf("GetByIdentity: %v", err)
+	}
+	if got == nil {
+		t.Fatal("frame missing after skip; want preserved")
+	}
+	if got.LastSeenAt != 20 {
+		t.Fatalf("LastSeenAt = %d, want 20", got.LastSeenAt)
+	}
+}
+
+func TestFrames_DeleteIfUnchanged_NotFound(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	deleted, err := s.DeleteIfUnchanged("no-such-frame", 10)
+	if err != nil {
+		t.Fatalf("DeleteIfUnchanged: %v", err)
+	}
+	if deleted {
+		t.Fatal("DeleteIfUnchanged returned true for missing frame; want false")
+	}
+}
+
 func TestMigrateFramesDB_PreservesNewSubagentsJSON(t *testing.T) {
 	s := openTestFramesStore(t)
 

--- a/internal/store/frames_test.go
+++ b/internal/store/frames_test.go
@@ -548,6 +548,125 @@ func TestFrames_DeleteIfUnchanged_NotFound(t *testing.T) {
 	}
 }
 
+// F7 — UpsertIfUnchanged updates atomically when last_seen_at matches.
+func TestFrames_UpsertIfUnchanged_UpdatesWhenMatching(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	stored, err := s.Upsert(Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Subagents:        []agentpkg.SubagentRef{{ID: "s1", Type: "cc", StartedAt: 10}},
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	stored.Subagents = append(stored.Subagents, agentpkg.SubagentRef{ID: "s2", Type: "codex", StartedAt: 20})
+	stored.LastSeenAt = 20
+	ok, got, err := s.UpsertIfUnchanged(stored, 10)
+	if err != nil {
+		t.Fatalf("UpsertIfUnchanged: %v", err)
+	}
+	if !ok {
+		t.Fatal("UpsertIfUnchanged returned false with matching baseline; want true")
+	}
+	if len(got.Subagents) != 2 {
+		t.Fatalf("Subagents len = %d, want 2 (s1 + s2 merged atomically)", len(got.Subagents))
+	}
+	if got.LastSeenAt != 20 {
+		t.Fatalf("LastSeenAt = %d, want 20 (refreshed)", got.LastSeenAt)
+	}
+}
+
+// F8 — UpsertIfUnchanged returns (false, zero, nil) when a concurrent writer
+// has moved last_seen_at past the provided baseline.
+func TestFrames_UpsertIfUnchanged_SkipsWhenStale(t *testing.T) {
+	s := openTestFramesStore(t)
+
+	stored, err := s.Upsert(Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "A",
+		Subagents:        []agentpkg.SubagentRef{{ID: "s1", Type: "cc", StartedAt: 10}},
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Simulate a concurrent writer bumping last_seen_at to 30.
+	racer := stored
+	racer.LastSeenAt = 30
+	racer.Subagents = append(racer.Subagents, agentpkg.SubagentRef{ID: "racer", Type: "codex", StartedAt: 25})
+	if _, err := s.Upsert(racer); err != nil {
+		t.Fatalf("racer Upsert: %v", err)
+	}
+
+	// Our baseline is still 10; UpsertIfUnchanged should refuse.
+	stored.Subagents = append(stored.Subagents, agentpkg.SubagentRef{ID: "stale", Type: "opencode", StartedAt: 15})
+	stored.LastSeenAt = 20
+	ok, got, err := s.UpsertIfUnchanged(stored, 10)
+	if err != nil {
+		t.Fatalf("UpsertIfUnchanged: %v", err)
+	}
+	if ok {
+		t.Fatal("UpsertIfUnchanged returned true with stale baseline; want false")
+	}
+	if got.FrameID != "" {
+		t.Fatalf("stored.FrameID = %q, want zero Frame (stale)", got.FrameID)
+	}
+
+	// Verify the racer's write is still in the DB, not clobbered.
+	row, err := s.GetByIdentity("%5", 200, "A")
+	if err != nil {
+		t.Fatalf("GetByIdentity: %v", err)
+	}
+	if row == nil {
+		t.Fatal("frame missing")
+	}
+	if row.LastSeenAt != 30 {
+		t.Fatalf("LastSeenAt = %d, want 30 (racer preserved)", row.LastSeenAt)
+	}
+	// Racer's subagent list had 2 entries (s1 + racer). Our stale write
+	// should not have clobbered them with our (s1 + stale) version.
+	if len(row.Subagents) != 2 {
+		t.Fatalf("Subagents len = %d, want 2 (racer version preserved)", len(row.Subagents))
+	}
+	foundRacer := false
+	for _, ref := range row.Subagents {
+		if ref.ID == "racer" {
+			foundRacer = true
+		}
+		if ref.ID == "stale" {
+			t.Fatal("stale write clobbered racer (UpsertIfUnchanged invariant violated)")
+		}
+	}
+	if !foundRacer {
+		t.Fatal("racer ref missing from DB after UpsertIfUnchanged conflict")
+	}
+}
+
+// F9 — UpsertIfUnchanged requires frame.FrameID; rejects zero-ID insert path.
+func TestFrames_UpsertIfUnchanged_RejectsEmptyFrameID(t *testing.T) {
+	s := openTestFramesStore(t)
+	_, _, err := s.UpsertIfUnchanged(Frame{PaneID: "%5", PID: 100, ProcessStartTime: "A"}, 0)
+	if err == nil {
+		t.Fatal("UpsertIfUnchanged with empty FrameID should error; got nil")
+	}
+}
+
 func TestMigrateFramesDB_PreservesNewSubagentsJSON(t *testing.T) {
 	s := openTestFramesStore(t)
 

--- a/spa/src/components/SortableTab.test.tsx
+++ b/spa/src/components/SortableTab.test.tsx
@@ -240,6 +240,32 @@ describe('SortableTab renderTabIcon modes', () => {
     expect(screen.getByTestId('tab-status-error')).toBeTruthy()
   })
 
+  it('dot mode + proxy subagent: SubagentDots renders outlined dot (prop-wiring)', () => {
+    // Seed a proxy SubagentRef on this session. Tests that the
+    // subagentRefs prop chain (useTabDisplay → SortableTab → TabIcon →
+    // SubagentDots) is intact end-to-end.
+    seedAgent('dot')
+    useAgentStore.setState({
+      subagents: {
+        'h1:sc1': [
+          {
+            id: 'proxy:codex:200:t200',
+            type: 'codex',
+            started_at: 0,
+            source_pid: 200,
+            source_start_time: 't200',
+            is_proxy: true,
+          },
+        ],
+      },
+    } as never)
+    const { container } = render(<SortableTab {...defaultProps} />)
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
+    expect(dot).toBeTruthy()
+    expect(dot.getAttribute('data-is-proxy')).toBe('true')
+    expect(dot.getAttribute('data-subagent-type')).toBe('codex')
+  })
+
   it('terminated session: no status dot even when agent event exists', () => {
     seedAgent('badge')
     const terminatedTab: Tab = createTab(

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -40,7 +40,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
     IconComponent,
     agentStatus,
     isUnread,
-    subagentCount,
+    subagentRefs,
     tabIndicatorStyle,
     isHostOffline,
   } = useTabDisplay(tab)
@@ -89,7 +89,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
             : 'text-text-muted hover:text-text-primary bg-surface-secondary hover:bg-surface-hover border border-transparent'
         }`}
       >
-        <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={isActive} iconSize={14} subagentCount={subagentCount} isUnread={isUnread} />
+        <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={isActive} iconSize={14} subagentRefs={subagentRefs} isUnread={isUnread} />
         {tab.locked && <Lock size={10} className="absolute bottom-0.5 right-0.5" />}
         {!isActive && isUnread && shouldShowGlobalUnreadPip(tabIndicatorStyle, agentStatus) && (
           <span className="absolute -top-[4px] -right-[4px] w-2 h-2 rounded-full z-20"
@@ -129,7 +129,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
           : 'text-text-muted hover:text-text-primary bg-surface-secondary hover:bg-surface-hover border border-transparent'
       }`}
     >
-      <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={isActive} iconSize={14} subagentCount={subagentCount} isUnread={isUnread} />
+      <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={isActive} iconSize={14} subagentRefs={subagentRefs} isUnread={isUnread} />
       <span className="overflow-hidden flex-1 min-w-0 text-left">{label}</span>
       <HoverTooltip placement="top">{label}</HoverTooltip>
       {isHostOffline && <WifiSlash size={12} className="text-red-400 flex-shrink-0" />}

--- a/spa/src/components/SubagentDots.test.tsx
+++ b/spa/src/components/SubagentDots.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { SubagentDots } from './SubagentDots'
+import type { SubagentRef } from '../stores/useAgentStore'
+
+function makeRef(partial: Partial<SubagentRef>): SubagentRef {
+  return {
+    id: partial.id ?? 'r1',
+    type: partial.type ?? 'cc',
+    started_at: partial.started_at ?? 0,
+    source_pid: partial.source_pid ?? 0,
+    source_start_time: partial.source_start_time ?? '',
+    is_proxy: partial.is_proxy,
+  }
+}
+
+describe('SubagentDots', () => {
+  it('renders one dot per ref up to 3', () => {
+    const refs = [1, 2, 3].map((i) => makeRef({ id: `r${i}` }))
+    const { container } = render(<SubagentDots refs={refs} />)
+    expect(container.querySelectorAll('[data-testid="subagent-dot"]').length).toBe(3)
+  })
+
+  it('renders 0 dots when refs is empty', () => {
+    const { container } = render(<SubagentDots refs={[]} />)
+    expect(container.querySelectorAll('[data-testid="subagent-dot"]').length).toBe(0)
+  })
+
+  it('colors dots by ref.type — cc blue / codex yellow / opencode orange', () => {
+    const refs = [
+      makeRef({ id: 'a', type: 'cc' }),
+      makeRef({ id: 'b', type: 'codex' }),
+      makeRef({ id: 'c', type: 'opencode' }),
+    ]
+    const { container } = render(<SubagentDots refs={refs} />)
+    const dots = Array.from(container.querySelectorAll<HTMLElement>('[data-testid="subagent-dot"]'))
+    expect(dots.length).toBe(3)
+    // rgb() form — jsdom normalizes hex to rgb.
+    expect(dots[0].style.backgroundColor).toBe('rgb(96, 165, 250)') // #60a5fa
+    expect(dots[1].style.backgroundColor).toBe('rgb(250, 204, 21)') // #facc15
+    expect(dots[2].style.backgroundColor).toBe('rgb(249, 115, 22)') // #f97316
+  })
+
+  it('unknown type falls back to cc blue', () => {
+    const refs = [makeRef({ id: 'x', type: 'unknown-future-agent' })]
+    const { container } = render(<SubagentDots refs={refs} />)
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
+    expect(dot.style.backgroundColor).toBe('rgb(96, 165, 250)')
+  })
+
+  it('proxy ref renders as hollow outline (transparent bg + 1px border in type color)', () => {
+    const refs = [makeRef({ id: 'p', type: 'codex', is_proxy: true })]
+    const { container } = render(<SubagentDots refs={refs} />)
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
+    expect(dot.getAttribute('data-is-proxy')).toBe('true')
+    expect(dot.style.backgroundColor).toBe('transparent')
+    expect(dot.style.border).toBe('1px solid rgb(250, 204, 21)')
+  })
+
+  it('non-proxy (is_proxy=false or undefined) renders solid bg, no border', () => {
+    const refs = [makeRef({ id: 'n', type: 'codex', is_proxy: false })]
+    const { container } = render(<SubagentDots refs={refs} />)
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
+    expect(dot.getAttribute('data-is-proxy')).toBe('false')
+    expect(dot.style.backgroundColor).toBe('rgb(250, 204, 21)')
+    expect(dot.style.border).toBe('')
+  })
+})

--- a/spa/src/components/SubagentDots.tsx
+++ b/spa/src/components/SubagentDots.tsx
@@ -1,14 +1,40 @@
 // spa/src/components/SubagentDots.tsx
-import { useMemo } from 'react'
+import { useMemo, type CSSProperties } from 'react'
+import type { SubagentRef } from '../stores/useAgentStore'
 
 interface Props {
-  count: number
+  refs: SubagentRef[]
   // Literal `left` value (in px) overriding the default calc(50% + offset).
   // Used by badge mode to nudge dots outside the icon box.
   left?: number
 }
 
-const COLOR = '#60a5fa'
+// Phase 2 PR-2b: dot color per agent family, derived inline (plan §5 — don't
+// abstract the palette elsewhere until a second consumer needs it).
+// Fallback to the cc blue keeps legacy / unknown types visible.
+const TYPE_COLOR: Record<string, string> = {
+  cc: '#60a5fa',
+  codex: '#facc15',
+  opencode: '#f97316',
+}
+const FALLBACK_COLOR = TYPE_COLOR.cc
+const colorFor = (type: string) => TYPE_COLOR[type] ?? FALLBACK_COLOR
+
+// Proxy refs (cross-agent hook collapsed onto a parent frame) render as a
+// hollow ring — transparent background + 1px ring in the type color — to
+// distinguish from native subagents (solid fill of the same color).
+const dotStyle = (ref: SubagentRef): CSSProperties => {
+  const color = colorFor(ref.type)
+  if (ref.is_proxy) {
+    return {
+      backgroundColor: 'transparent',
+      border: `1px solid ${color}`,
+      boxSizing: 'border-box',
+    }
+  }
+  return { backgroundColor: color }
+}
+
 const DOT_SIZES: Record<number, number> = { 1: 4, 2: 3.5, 3: 3 }
 
 // Vertical line positions to the left of the icon center.
@@ -18,8 +44,8 @@ const ARC_POSITIONS: Record<number, [number, number][]> = {
   3: [[-9, -5.5], [-9, 0], [-9, 5.5]],
 }
 
-export function SubagentDots({ count, left: leftOverride }: Props) {
-  const clamped = Math.min(Math.max(count, 0), 3)
+export function SubagentDots({ refs, left: leftOverride }: Props) {
+  const clamped = Math.min(Math.max(refs.length, 0), 3)
 
   // Recalculate phase offset when dot count changes so all dots restart
   // with correctly synchronized animation phases.  When count stays the
@@ -30,24 +56,31 @@ export function SubagentDots({ count, left: leftOverride }: Props) {
   if (clamped <= 0) return null
   const positions = ARC_POSITIONS[clamped]
   const dotSize = DOT_SIZES[clamped]
+  const visibleRefs = refs.slice(0, clamped)
 
   return (
     <>
-      {positions.map(([left, top], i) => (
-        <span
-          key={`${clamped}-${i}`}
-          className="absolute rounded-full animate-breathe"
-          style={{
-            width: dotSize,
-            height: dotSize,
-            backgroundColor: COLOR,
-            left: leftOverride !== undefined ? `${leftOverride}px` : `calc(50% + ${left}px)`,
-            top: `calc(50% + ${top}px)`,
-            transform: 'translate(-50%, -50%)',
-            animationDelay: `${i * 0.3 - (phaseOffset / 1000) % 2}s`,
-          }}
-        />
-      ))}
+      {positions.map(([left, top], i) => {
+        const ref = visibleRefs[i]
+        return (
+          <span
+            key={`${clamped}-${i}`}
+            data-testid="subagent-dot"
+            data-subagent-type={ref.type}
+            data-is-proxy={ref.is_proxy ? 'true' : 'false'}
+            className="absolute rounded-full animate-breathe"
+            style={{
+              width: dotSize,
+              height: dotSize,
+              ...dotStyle(ref),
+              left: leftOverride !== undefined ? `${leftOverride}px` : `calc(50% + ${left}px)`,
+              top: `calc(50% + ${top}px)`,
+              transform: 'translate(-50%, -50%)',
+              animationDelay: `${i * 0.3 - (phaseOffset / 1000) % 2}s`,
+            }}
+          />
+        )
+      })}
     </>
   )
 }

--- a/spa/src/components/TabIcon.tsx
+++ b/spa/src/components/TabIcon.tsx
@@ -1,5 +1,5 @@
 // spa/src/components/TabIcon.tsx
-import type { AgentStatus } from '../stores/useAgentStore'
+import type { AgentStatus, SubagentRef } from '../stores/useAgentStore'
 import type { TabIndicatorStyle } from '../stores/useUISettingsStore'
 import { TabStatusIndicator } from './TabStatusIndicator'
 import { SubagentDots } from './SubagentDots'
@@ -26,7 +26,7 @@ interface Props {
   tabIndicatorStyle: TabIndicatorStyle
   isActive: boolean
   iconSize: number
-  subagentCount: number
+  subagentRefs: SubagentRef[]
   isUnread: boolean
 }
 
@@ -36,7 +36,7 @@ export function TabIcon({
   tabIndicatorStyle,
   isActive,
   iconSize,
-  subagentCount,
+  subagentRefs,
   isUnread,
 }: Props) {
   const iconBox = (
@@ -56,7 +56,7 @@ export function TabIcon({
       <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0 ml-[1.5px] lowdpi:ml-px">
         <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
         {showDotUnreadPip && <UnreadPip />}
-        {subagentCount > 0 && <SubagentDots count={subagentCount} />}
+        {subagentRefs.length > 0 && <SubagentDots refs={subagentRefs} />}
       </span>
     )
   }
@@ -67,7 +67,7 @@ export function TabIcon({
         <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
           <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
           {showDotUnreadPip && <UnreadPip />}
-          {subagentCount > 0 && <SubagentDots count={subagentCount} />}
+          {subagentRefs.length > 0 && <SubagentDots refs={subagentRefs} />}
         </span>
         {IconComponent && <IconComponent size={iconSize} className="flex-shrink-0" />}
       </span>
@@ -89,7 +89,7 @@ export function TabIcon({
         isActive={isActive}
         isUnread={isUnread && !isActive}
       />
-      {subagentCount > 0 && <SubagentDots count={subagentCount} left={-4} />}
+      {subagentRefs.length > 0 && <SubagentDots refs={subagentRefs} left={-4} />}
     </span>
   )
 }

--- a/spa/src/features/workspace/components/InlineTab.test.tsx
+++ b/spa/src/features/workspace/components/InlineTab.test.tsx
@@ -156,6 +156,41 @@ describe('InlineTab — close button visibility', () => {
   })
 })
 
+describe('InlineTab — subagent dots (prop wiring)', () => {
+  it('renders outlined proxy dot when subagents contains an is_proxy ref', () => {
+    useUISettingsStore.setState({ tabIndicatorStyle: 'dot' })
+    useAgentStore.setState({
+      statuses: { 'h1:S1': 'running' },
+      subagents: {
+        'h1:S1': [
+          {
+            id: 'proxy:codex:200:t200',
+            type: 'codex',
+            started_at: 0,
+            source_pid: 200,
+            source_start_time: 't200',
+            is_proxy: true,
+          },
+        ],
+      },
+    } as never)
+    const { container } = render(
+      <InlineTab
+        tab={baseTab}
+        isActive={false}
+        onSelect={() => {}}
+        onClose={() => {}}
+        onMiddleClick={() => {}}
+        onContextMenu={() => {}}
+      />,
+    )
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')
+    expect(dot).toBeTruthy()
+    expect(dot!.getAttribute('data-is-proxy')).toBe('true')
+    expect(dot!.getAttribute('data-subagent-type')).toBe('codex')
+  })
+})
+
 describe('InlineTab — unread dot', () => {
   it('shows unread dot when unread and not active', () => {
     useAgentStore.setState({ unread: { 'h1:S1': true } })

--- a/spa/src/features/workspace/components/InlineTab.tsx
+++ b/spa/src/features/workspace/components/InlineTab.tsx
@@ -39,7 +39,7 @@ export function InlineTab({
     IconComponent,
     agentStatus,
     isUnread,
-    subagentCount,
+    subagentRefs,
     tabIndicatorStyle,
     isHostOffline,
   } = useTabDisplay(tab)
@@ -108,7 +108,7 @@ export function InlineTab({
         agentStatus,
         tabIndicatorStyle,
         isActive,
-        subagentCount,
+        subagentRefs,
         isUnread,
       })}
       <span data-testid="inline-tab-title" className="flex-1 truncate">

--- a/spa/src/features/workspace/lib/renderInlineTabIcon.test.tsx
+++ b/spa/src/features/workspace/lib/renderInlineTabIcon.test.tsx
@@ -2,6 +2,20 @@ import { describe, it, expect } from 'vitest'
 import { render } from '@testing-library/react'
 import { Terminal } from '@phosphor-icons/react'
 import { renderInlineTabIcon } from './renderInlineTabIcon'
+import type { SubagentRef } from '../../../stores/useAgentStore'
+
+const EMPTY: SubagentRef[] = []
+
+function makeRef(partial: Partial<SubagentRef>): SubagentRef {
+  return {
+    id: partial.id ?? 'r1',
+    type: partial.type ?? 'cc',
+    started_at: partial.started_at ?? 0,
+    source_pid: partial.source_pid ?? 0,
+    source_start_time: partial.source_start_time ?? '',
+    is_proxy: partial.is_proxy,
+  }
+}
 
 describe('renderInlineTabIcon', () => {
   it("renders icon-only when style='icon'", () => {
@@ -11,7 +25,7 @@ describe('renderInlineTabIcon', () => {
         agentStatus: 'running',
         tabIndicatorStyle: 'icon',
         isActive: false,
-        subagentCount: 0,
+        subagentRefs: EMPTY,
       }),
     )
     expect(container.querySelector('svg')).toBeInTheDocument()
@@ -25,7 +39,7 @@ describe('renderInlineTabIcon', () => {
         agentStatus: 'running',
         tabIndicatorStyle: 'dot',
         isActive: false,
-        subagentCount: 0,
+        subagentRefs: EMPTY,
       }),
     )
     expect(container.querySelector('svg')).toBeNull()
@@ -39,7 +53,7 @@ describe('renderInlineTabIcon', () => {
         agentStatus: 'running',
         tabIndicatorStyle: 'iconDot',
         isActive: false,
-        subagentCount: 0,
+        subagentRefs: EMPTY,
       }),
     )
     expect(container.querySelector('svg')).toBeInTheDocument()
@@ -53,7 +67,7 @@ describe('renderInlineTabIcon', () => {
         agentStatus: 'running',
         tabIndicatorStyle: 'badge',
         isActive: false,
-        subagentCount: 0,
+        subagentRefs: EMPTY,
       }),
     )
     expect(container.querySelector('svg')).toBeInTheDocument()
@@ -67,10 +81,68 @@ describe('renderInlineTabIcon', () => {
         agentStatus: undefined,
         tabIndicatorStyle: 'badge',
         isActive: false,
-        subagentCount: 0,
+        subagentRefs: EMPTY,
       }),
     )
     expect(container.querySelector('svg')).toBeInTheDocument()
     expect(container.querySelector('[data-testid="inline-tab-dot-overlay"]')).toBeNull()
+  })
+
+  it('dot mode forwards subagentRefs to SubagentDots', () => {
+    const refs = [makeRef({ id: 'a', type: 'cc' })]
+    const { container } = render(
+      renderInlineTabIcon({
+        IconComponent: Terminal,
+        agentStatus: 'running',
+        tabIndicatorStyle: 'dot',
+        isActive: false,
+        subagentRefs: refs,
+      }),
+    )
+    expect(container.querySelector('[data-testid="subagent-dot"]')).toBeInTheDocument()
+  })
+
+  it('iconDot mode forwards subagentRefs to SubagentDots', () => {
+    const refs = [makeRef({ id: 'a', type: 'cc' })]
+    const { container } = render(
+      renderInlineTabIcon({
+        IconComponent: Terminal,
+        agentStatus: 'running',
+        tabIndicatorStyle: 'iconDot',
+        isActive: false,
+        subagentRefs: refs,
+      }),
+    )
+    expect(container.querySelector('[data-testid="subagent-dot"]')).toBeInTheDocument()
+  })
+
+  it('badge mode forwards subagentRefs to SubagentDots', () => {
+    const refs = [makeRef({ id: 'a', type: 'cc' })]
+    const { container } = render(
+      renderInlineTabIcon({
+        IconComponent: Terminal,
+        agentStatus: 'running',
+        tabIndicatorStyle: 'badge',
+        isActive: false,
+        subagentRefs: refs,
+      }),
+    )
+    expect(container.querySelector('[data-testid="subagent-dot"]')).toBeInTheDocument()
+  })
+
+  it('proxy ref renders outlined dot (end-to-end prop flow)', () => {
+    const refs = [makeRef({ id: 'p', type: 'codex', is_proxy: true })]
+    const { container } = render(
+      renderInlineTabIcon({
+        IconComponent: Terminal,
+        agentStatus: 'running',
+        tabIndicatorStyle: 'dot',
+        isActive: false,
+        subagentRefs: refs,
+      }),
+    )
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
+    expect(dot.getAttribute('data-is-proxy')).toBe('true')
+    expect(dot.getAttribute('data-subagent-type')).toBe('codex')
   })
 })

--- a/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
+++ b/spa/src/features/workspace/lib/renderInlineTabIcon.tsx
@@ -1,4 +1,4 @@
-import type { AgentStatus } from '../../../stores/useAgentStore'
+import type { AgentStatus, SubagentRef } from '../../../stores/useAgentStore'
 import type { TabIndicatorStyle } from '../../../stores/useUISettingsStore'
 import { TabStatusIndicator } from '../../../components/TabStatusIndicator'
 import { SubagentDots } from '../../../components/SubagentDots'
@@ -8,7 +8,7 @@ interface Params {
   agentStatus: AgentStatus | undefined
   tabIndicatorStyle: TabIndicatorStyle
   isActive: boolean
-  subagentCount: number
+  subagentRefs: SubagentRef[]
   isUnread?: boolean
 }
 
@@ -32,7 +32,7 @@ export function renderInlineTabIcon({
   agentStatus,
   tabIndicatorStyle,
   isActive,
-  subagentCount,
+  subagentRefs,
   isUnread = false,
 }: Params) {
   // icon-only OR no agent event → plain icon slot
@@ -55,7 +55,7 @@ export function renderInlineTabIcon({
       >
         <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
         {showDotUnreadPip && UNREAD_PIP}
-        {subagentCount > 0 && <SubagentDots count={subagentCount} />}
+        {subagentRefs.length > 0 && <SubagentDots refs={subagentRefs} />}
       </span>
     )
   }
@@ -69,7 +69,7 @@ export function renderInlineTabIcon({
         >
           <TabStatusIndicator status={agentStatus} mode="replace" isActive={isActive} />
           {showDotUnreadPip && UNREAD_PIP}
-          {subagentCount > 0 && <SubagentDots count={subagentCount} />}
+          {subagentRefs.length > 0 && <SubagentDots refs={subagentRefs} />}
         </span>
         {IconComponent && <IconComponent size={ICON_SIZE} className="flex-shrink-0" />}
       </span>
@@ -90,7 +90,7 @@ export function renderInlineTabIcon({
         isActive={isActive}
         isUnread={isUnread && !isActive}
       />
-      {subagentCount > 0 && <SubagentDots count={subagentCount} left={-4} />}
+      {subagentRefs.length > 0 && <SubagentDots refs={subagentRefs} left={-4} />}
     </span>
   )
 }

--- a/spa/src/hooks/useTabDisplay.ts
+++ b/spa/src/hooks/useTabDisplay.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from 'react'
 import type { Tab } from '../types/tab'
-import type { AgentStatus } from '../stores/useAgentStore'
+import type { AgentStatus, SubagentRef } from '../stores/useAgentStore'
 import type { TabIndicatorStyle } from '../stores/useUISettingsStore'
 import { useAgentStore } from '../stores/useAgentStore'
 import { useUISettingsStore } from '../stores/useUISettingsStore'
@@ -16,6 +16,7 @@ import { ICON_MAP } from '../components/tab-icon-map'
 import type { Session } from '../lib/host-api'
 
 const EMPTY_SESSIONS: Session[] = []
+const EMPTY_SUBAGENT_REFS: SubagentRef[] = []
 
 export type TabIconComponent = ComponentType<{ size: number; className?: string }>
 
@@ -25,6 +26,7 @@ export interface TabDisplayData {
   agentStatus: AgentStatus | undefined
   isUnread: boolean
   subagentCount: number
+  subagentRefs: SubagentRef[]
   tabIndicatorStyle: TabIndicatorStyle
   isHostOffline: boolean
   isTerminated: boolean
@@ -49,7 +51,8 @@ export function useTabDisplay(tab: Tab): TabDisplayData {
 
   const agentStatus = useAgentStore((s) => (ck ? s.statuses[ck] : undefined))
   const isUnread = useAgentStore((s) => (ck ? !!s.unread[ck] : false))
-  const subagentCount = useAgentStore((s) => (ck ? (s.subagents[ck]?.length ?? 0) : 0))
+  const subagentRefs = useAgentStore((s) => (ck ? (s.subagents[ck] ?? EMPTY_SUBAGENT_REFS) : EMPTY_SUBAGENT_REFS))
+  const subagentCount = subagentRefs.length
   const agentType = useAgentStore((s) => (ck ? s.agentTypes[ck] : undefined))
   const tabIndicatorStyle = useUISettingsStore((s) => s.tabIndicatorStyle)
   const ccIconVariant = useUISettingsStore((s) => s.ccIconVariant)
@@ -81,6 +84,7 @@ export function useTabDisplay(tab: Tab): TabDisplayData {
     agentStatus,
     isUnread,
     subagentCount,
+    subagentRefs,
     tabIndicatorStyle,
     isHostOffline,
     isTerminated,


### PR DESCRIPTION
## Summary

Phase 2 PR-2b — 完成 Lights rebuild Phase 2 剩餘範圍（PR-2a schema + wire 已於 alpha.218 merged）。單一 PR，commits 6-10 + 4 輪 review fix，~1700 行 code + 42 新測試（29 Go + 12 SPA + 1 regression）。

- **PPID 祖先鏈 proxy 偵測**（depth=5 + live-only same-type hard-stop + start_time identity 三分支）：cc pane 跑 `/codex:*` 不再建獨立 codex frame，而是掛進 cc.Subagents 標 `IsProxy=true`
- **SessionEnd proxy cleanup**：proxy 來源 agent 結束時從 parent 移除 ref
- **Idle sweep**（1h + conditional DELETE）：無 hook 活動 1h 的 frame 被 sweep 清；用 `DeleteIfUnchanged` 防 concurrent refresh 被 clobber；probe-driven status transitions（`setProjectionTopStatus`）同時刷新 `LastSeenAt` 避免誤清 live frame
- **`clearFrame` 拆出 `afterFrameCleared`** + **orphan StopWatch bug fix**（pid_dead / pid_reused / idle_timeout 三路徑統一 side effects pipeline）
- **Kind-aware subagent identity**：`updateSubagents` 比對時 proxy 用 `(SourcePID, SourceStartTime)`、native 用 `ID`，跨 kind 永不 match — 防止 proxy ID 合成字串與 native agent_id 撞
- **SubagentDots** API 從 `{count}` 升 `{refs}`：每 dot 依 agent type 上色（cc 藍 / codex 黃 / opencode 橘），proxy ref 渲染 hollow ring outline，native ref 保 solid fill

## Reviewer routing（按 Codex B 建議）

**後端 reviewer → commits 6-9 + fix commits**（~1400 行 Go，5 檔實作 + 4 檔測試）：
- `c7ee9a99` commit 6 — `DeleteIfUnchanged` store method（F4-F6，3 tests）
- `13e31816` commit 7 — proxy PPID walk `findProxyParent` + fast-path（PR1-PR15，15 tests）
- `735fa9c8` commit 8 — `removeProxyRefForSender` + SessionEnd cleanup（SE1-SE3，3 tests）
- `8f989353` commit 9 — idle sweep 第三條規則 + `afterFrameCleared` 抽出 + orphan StopWatch fix + probe `HasWatcher` test helper（IS1-IS5 + HB2，6 tests）
- `f26888a9` R1 fix — `setProjectionTopStatus` bumps `LastSeenAt`（IS6，1 test）
- `9f29e123` R2 fix — kind-aware `subagentRefMatches`（U6，1 test）
- `c46de72b` R3 fix — same-type hard-stop 後置於 alive+identity gate（PR16，1 test）
- `16485c44` R4 fix — PR5/PR14 stub 修正（test-only）

**SPA reviewer → commit 10**（~400 行 TSX）：
- `a6adb2af` commit 10 — SubagentDots `count → refs` + TYPE_COLOR + proxy outline + 5 consumer props 同步（TabIcon / SortableTab / InlineTab / renderInlineTabIcon / useTabDisplay）+ 12 新 SPA tests

**共同 reviewer 看 2 個真實場景**（手動驗收）：
- cc 啟動 → pane 內跑 `/codex:*` → SPA 只顯示 1 個 frame（cc），SubagentDots 上有 1 個黃色 outline dot（代表 proxy codex）；DB peek `subagents_json` 欄位可看到 `[{"type":"codex","is_proxy":true,"source_pid":...}]`
- 手造 idle frame（臨時降 `frameIdleThreshold` 或 SQL 改 `LastSeenAt`）→ sweep 2s 後 frame 消失，log reason=`idle_timeout`

## Preemptive answers（R1-R5 已驗證的攻擊向量）

- **Q: proxy ref 的 ID 字串開頭 "proxy:" 會不會跟 native agent_id 撞？** A: 不會（R2 fix 後）。`updateSubagents` / `removeProxyRefForSender` 都 kind-aware：proxy 比 `(SourcePID, SourceStartTime)`，native 比 `ID`，`IsProxy` 不同永不 match
- **Q: Dev update skew — SPA 先升級吃到舊 daemon（alpha.219）送的 native-only subagents 怎麼辦？** A: `TYPE_COLOR[ref.type] ?? cc` fallback；`is_proxy` 欄位 undefined 走 solid dot
- **Q: `DeleteIfUnchanged` 回 `(false, nil)` 處理？** A: `continue`，不 `return err`（PR-2a R3/R4 教訓）
- **Q: Idle sweep 誤刪 live frame（1h 無 hook 但 probe 活動中）？** A: 不會（R1 fix 後）。`setProjectionTopStatus` 在 probe 活動轉 Status 同時 bump `LastSeenAt`
- **Q: Stale same-type ancestor 阻斷 proxy walk？** A: 不會（R3 fix 後）。same-type hard-stop 只對 live + identity-verified 同 type ancestor 觸發；dead 或 PID 重用的 stale 同 type frame 走 skip+walk-up

## 不做（plan v6 §5 + delta §2 Commit 10）

- 不做 schema migration（PR-2a 已處理）
- 不移除 `useTabDisplay.subagentCount` return（deferred cleanup）
- 不抽 TYPE_COLOR 到 `agent-icons.tsx`
- 不做 idle sweep 的 per-ref LastSeenAt
- 不超過 `proxyMaxDepth = 5`

## Known issue（deferred，不阻 merge）

- #632 — Proxy attach/detach 非 atomic：兩個並發 SessionStart 掛到同一 parent 的 pane 可能互相覆寫 subagents list（最後寫者 wins）。P2，user-facing glitch（dot 漏顯），實際機率低。建議 fix：加 `UpsertIfUnchanged` optimistic concurrency helper + bounded retry

## Test plan

- [x] Go 全 package 綠；29 新 Go tests 全綠（PR1-PR16 / F4-F6 / SE1-SE3 / IS1-IS6 / HB2 / U6）
- [x] `go vet ./...` 無 warning
- [x] SPA lint clean / tsc+vite build clean
- [x] SPA vitest 2753 passed / 3 pre-existing hosts.test.ts failures（baseline，不阻擋；Phase 2 新增的 53 tests 全綠）
- [x] 5 輪 codex review（R1 standard + R2 adversarial 3-parallel + R3/R4/R5 sanity）收斂：R1 1 P2 / R2 1 P1-級 / R3 1 P1-級 / R4 test-only / R5 1 P2 deferred（#632）
- [ ] 手動驗收 2 真實場景（merge 前由 reviewer 驗）

Merge 後 bump alpha.220。