### PR TITLE
fix(spa): restore tab bar shrink behavior

### DIFF
--- a/spa/src/components/SortableTab.test.tsx
+++ b/spa/src/components/SortableTab.test.tsx
@@ -91,6 +91,23 @@ describe('SortableTab', () => {
     expect(event.defaultPrevented).toBe(true)
   })
 
+  it('does not render a bright border on active tabs', () => {
+    const { container } = render(<SortableTab {...defaultProps} isActive />)
+    const el = container.querySelector('[data-tab-id="t1"]')!
+
+    expect(el.className).not.toContain('border-accent-muted')
+    expect(el.className).toContain('border-transparent')
+  })
+
+  it('does not render a bright border on active pinned tabs', () => {
+    const pinnedTab = makeTestTab('t1', { pinned: true })
+    const { container } = render(<SortableTab {...defaultProps} tab={pinnedTab} isActive pinned />)
+    const el = container.querySelector('[data-tab-id="t1"]')!
+
+    expect(el.className).not.toContain('border-accent-muted')
+    expect(el.className).toContain('border-transparent')
+  })
+
   it('does not call preventDefault on inactive tab pointerDown', () => {
     const { container } = render(<SortableTab {...defaultProps} isActive={false} />)
     const el = container.querySelector('[data-tab-id="t1"]')!

--- a/spa/src/components/SortableTab.tsx
+++ b/spa/src/components/SortableTab.tsx
@@ -85,7 +85,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
         onContextMenu={handleContextMenu}
         className={`group relative flex items-center justify-center w-9 rounded-[6px] cursor-pointer transition-colors duration-150 ease-out ${
           isActive
-            ? 'text-white bg-surface-active border border-accent-muted'
+            ? 'text-white bg-surface-active border border-transparent'
             : 'text-text-muted hover:text-text-primary bg-surface-secondary hover:bg-surface-hover border border-transparent'
         }`}
       >
@@ -125,7 +125,7 @@ export function SortableTab({ tab, isActive, pinned, onSelect, onClose, onMiddle
       onContextMenu={handleContextMenu}
       className={`group relative flex items-center gap-1.5 pl-2 pr-1 text-xs whitespace-nowrap cursor-pointer transition-colors duration-150 ease-out rounded-[6px] ${
         isActive
-          ? 'text-white bg-surface-active border border-accent-muted'
+          ? 'text-white bg-surface-active border border-transparent'
           : 'text-text-muted hover:text-text-primary bg-surface-secondary hover:bg-surface-hover border border-transparent'
       }`}
     >

--- a/spa/src/components/TabBar.test.tsx
+++ b/spa/src/components/TabBar.test.tsx
@@ -6,6 +6,23 @@ import type { Tab } from '../types/tab'
 import { registerModule, clearModuleRegistry } from '../lib/module-registry'
 import { useSessionStore } from '../stores/useSessionStore'
 
+const scrollOverflowState = vi.hoisted(() => ({
+  canScrollLeft: false,
+  canScrollRight: false,
+  scrollLeft: vi.fn(),
+  scrollRight: vi.fn(),
+}))
+
+vi.mock('../hooks/useScrollOverflow', () => ({
+  useScrollOverflow: () => ({
+    containerRef: { current: null },
+    canScrollLeft: scrollOverflowState.canScrollLeft,
+    canScrollRight: scrollOverflowState.canScrollRight,
+    scrollLeft: scrollOverflowState.scrollLeft,
+    scrollRight: scrollOverflowState.scrollRight,
+  }),
+}))
+
 beforeEach(() => {
   cleanup()
   clearModuleRegistry()
@@ -13,6 +30,10 @@ beforeEach(() => {
   registerModule({ id: 'dashboard', name: 'Dashboard', panes: [{ kind: 'dashboard', component: () => null }] })
   // Provide sessions keyed by hostId for SortableTab's label lookups
   useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
+  scrollOverflowState.canScrollLeft = false
+  scrollOverflowState.canScrollRight = false
+  scrollOverflowState.scrollLeft.mockClear()
+  scrollOverflowState.scrollRight.mockClear()
 })
 
 const defaultHandlers = {
@@ -147,5 +168,33 @@ describe('TabBar', () => {
     // No pinned/normal zone divider (h-4 height, distinct from tab separators which are h-3.5)
     const zoneDividers = container.querySelectorAll('.w-px.h-4.bg-border-default')
     expect(zoneDividers.length).toBe(0)
+  })
+
+  it('lets normal tabs shrink before the scroller overflows', () => {
+    const { container } = render(<TabBar tabs={mockTabs} activeTabId="t1" {...defaultHandlers} />)
+    const scroller = container.querySelector('.overflow-x-auto.scrollbar-hide')!
+    const strip = scroller.firstElementChild as HTMLElement
+
+    expect(strip.className).toContain('flex-1')
+    expect(strip.className).toContain('min-w-0')
+    expect(strip.style.minWidth).toBe('')
+    expect(strip.style.maxWidth).toBe('max-content')
+  })
+
+  it('renders right scroll control with a fade area and opaque button', () => {
+    scrollOverflowState.canScrollRight = true
+
+    const { container } = render(<TabBar tabs={mockTabs} activeTabId="t1" {...defaultHandlers} />)
+    const fade = container.querySelector('[data-testid="tab-scroll-right-fade"]')!
+    const gradient = container.querySelector('[data-testid="tab-scroll-right-gradient"]')!
+    const button = fade.querySelector('button')!
+
+    expect(fade.className).toContain('w-16')
+    expect(fade.className).toContain('pointer-events-none')
+    expect(gradient.className).toContain('bg-gradient-to-r')
+    expect(gradient.className).toContain('from-transparent')
+    expect(gradient.className).toContain('to-surface-secondary')
+    expect(button.className).toContain('bg-surface-secondary')
+    expect(button.className).toContain('pointer-events-auto')
   })
 })

--- a/spa/src/components/TabBar.tsx
+++ b/spa/src/components/TabBar.tsx
@@ -119,16 +119,19 @@ export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, o
         {/* Normal zone with overflow arrows */}
         <div className="relative flex-1 min-w-0 h-full">
           {canScrollLeft && (
-            <button
-              onClick={scrollLeft}
-              className="absolute left-0 top-0 bottom-0 z-10 w-8 flex items-center justify-center bg-gradient-to-r from-surface-secondary to-transparent cursor-pointer"
-              aria-label={t('nav.scroll_left')}
-            >
-              <CaretLeft size={14} className="text-text-secondary" />
-            </button>
+            <div data-testid="tab-scroll-left-fade" className="absolute left-0 top-0 bottom-0 z-10 w-16 flex justify-start pointer-events-none">
+              <button
+                onClick={scrollLeft}
+                className="w-8 h-full flex items-center justify-center bg-surface-secondary cursor-pointer pointer-events-auto"
+                aria-label={t('nav.scroll_left')}
+              >
+                <CaretLeft size={14} className="text-text-secondary" />
+              </button>
+              <div data-testid="tab-scroll-left-gradient" className="w-8 h-full bg-gradient-to-r from-surface-secondary to-transparent" />
+            </div>
           )}
           <div ref={normalZoneRef} className="flex items-center h-full overflow-x-auto scrollbar-hide">
-            <div ref={normalTabsRef} className="flex items-center h-full" style={{ minWidth: 'min-content' }}>
+            <div ref={normalTabsRef} className="flex items-center h-full flex-1 min-w-0" style={{ maxWidth: 'max-content' }}>
               <SortableContext items={normalIds} strategy={horizontalListSortingStrategy}>
                 {normalTabs.map((tab, i) => (
                   <Fragment key={tab.id}>
@@ -159,13 +162,16 @@ export function TabBar({ tabs, activeTabId, onSelectTab, onCloseTab, onAddTab, o
             </button>
           </div>
           {canScrollRight && (
-            <button
-              onClick={scrollRight}
-              className="absolute right-0 top-0 bottom-0 z-10 w-8 flex items-center justify-center bg-gradient-to-l from-surface-secondary to-transparent cursor-pointer"
-              aria-label={t('nav.scroll_right')}
-            >
-              <CaretRight size={14} className="text-text-secondary" />
-            </button>
+            <div data-testid="tab-scroll-right-fade" className="absolute right-0 top-0 bottom-0 z-10 w-16 flex justify-end pointer-events-none">
+              <div data-testid="tab-scroll-right-gradient" className="w-8 h-full bg-gradient-to-r from-transparent to-surface-secondary" />
+              <button
+                onClick={scrollRight}
+                className="w-8 h-full flex items-center justify-center bg-surface-secondary cursor-pointer pointer-events-auto"
+                aria-label={t('nav.scroll_right')}
+              >
+                <CaretRight size={14} className="text-text-secondary" />
+              </button>
+            </div>
           )}
         </div>
       </DndContext>


### PR DESCRIPTION
## Summary
- Restore normal tab strip shrink behavior before horizontal overflow.
- Split tab scroll controls into gradient fade and opaque button zones.
- Remove active tab accent borders that appeared as uneven bright top lines.

## Tests
- pnpm --prefix spa exec vitest run src/components/TabBar.test.tsx src/components/SortableTab.test.tsx