### PR TITLE
feat(agent): Phase 3 — daemon restart frame recovery + no_parent_fallback

### DIFF
--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-plan.md
@@ -1,0 +1,339 @@
+# Phase 3 TDD Plan — L1 邊界補強
+
+- **Date**: 2026-04-25
+- **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §7
+- **Worktree**: `lights-phase-3`（branch `worktree-lights-phase-3`）
+- **Baseline**: `1.0.0-alpha.221`（main @ `2633b88d`，Phase 2 PR-2b merged）
+- **依賴**: Phase 2 PR-2b ✅（`SubagentRef` 結構 + `findProxyParent` PPID walk + `cachedDescendants` + `Prober.Identify` 已就緒）
+- **範圍**：`applyFrameEvent` fallback chain 末端補回 + `no_parent_fallback` reason 顯式化
+- **預估**：單 PR ~430 行 net（~80 prod + 250 test + 100 整合測試）
+
+---
+
+## 0. 設計依據
+
+### 0.1 Codex 架構諮詢結論（採納）
+
+委派 codex high-effort architectural consulting（job `af47a0fd51ca6667e`，2026-04-25）。**採納**項目：
+
+| Codex 結論 | 本 plan 採納方式 |
+|---|---|
+| Q1：採 hook-triggered lazy rebuild，與 PR-2b `findProxyParent` 同型 | §1.2 主路徑 |
+| Q2：類比 K8s controller reconciliation / Chrome DevTools target discovery「重連先 enumerate 再接 event」 | §0.2 思想框架 |
+| Q4：stale 判 `pane + PID + startTime + descendants`（後半，descendants check） | §1.3 lazy rebuild 用 descendants 做 process 推斷 |
+| Q5：`no_parent_fallback` trace 是未來 reparent / diagnostics / recovery quality 的資料邊界 | §1.4 reason 升格為一級 trace 標記，預留 Phase 4/5 reparent 入口 |
+
+### 0.2 Codex 結論延後 / 不採納項目（含理由）
+
+| Codex 結論 | 不採理由 |
+|---|---|
+| Q1：UI 引入 `unreconciled` 狀態 | SPA 工作；目前無 Inspector view 消費，YAGNI；frame.Subagents=[] 已天然代表「不確定」 |
+| Q3：SPA on-demand inventory 第四方案 | Phase 5 Inspector 範圍；無 SPA query 端口 |
+| Q4 前半：首 hook 順帶掃同 session 所有 pane inventory | 無消費端；inventory 概念需要新 frame 占位狀態，擴大 backend scope 而 SPA 端用不到 |
+| `ListPanesForSession` tmux helper | 無消費端（hook 來了表示 pane 在運作，無需 daemon 驗證）；待 inventory feature 真做時再加 |
+
+### 0.3 設計核心思想
+
+採 **K8s reconciliation 對照組**：hook event = `watch event`、`cachedDescendants + Prober.Identify` = `live state read`、目前 fallback chain 失敗就 Upsert = `create-on-miss`。Phase 3 在「都未命中」與「Upsert 新 frame」之間插一條「先嘗試 process tree rebuild」的 reconciliation step，把 daemon downtime 期間遺失的 frame 識別補回。
+
+**未補回 = no_parent_fallback**：明確標記，等 Phase 4/5 的 reparent loop / Inspector 消費。
+
+---
+
+## 1. 契約鎖定
+
+### 1.1 `applyFrameEvent` 既有 fallback chain（PR-2b 後現況）
+
+`internal/module/agent/frame_ops.go:36-310` 的查找順序：
+
+1. **Line 45** — `GetByIdentity(paneID, senderPID, senderStartTime)` — 命中：直接走 existing-frame 路徑（line 239-272）
+2. **Line 51-159** — Event-name 三分支：`SessionEnd` / `SubagentStart`+`Stop` / 其餘
+3. **Line 168-207** — SessionStart 且 frame==nil：`findProxyParent` PPID walk → 命中掛 proxy / 未命中 fall through
+4. **Line 209-228** — `readProcessInfoFn(senderPID)` → `FindByPanePID(paneID, info.PPID)` legacy parent lookup → 命中：parentFrameID=parent.FrameID / 未命中：parentFrameID=""
+5. **Line 273-292** — frame==nil：`Upsert` 新 frame（subagents=[]）
+6. **Line 294-309** — Trace meta：parentFrameID!="" → reason=`parent_frame_found`；否則 reason=`parent_frame_missing`
+
+**Phase 3 插入點**：在 step 4 與 step 5 之間（line 228 之後、line 273 之前）插入 lazy rebuild。step 6 的 reason 同時升級。
+
+### 1.2 Lazy rebuild — `tryRebuildFromProcessTree` 新 helper
+
+**簽名**（位置：`internal/module/agent/frame_ops.go`，與 `findProxyParent` 同檔）：
+
+```go
+// tryRebuildFromProcessTree attempts to recover a frame after daemon restart
+// by inspecting the pane's live process tree. Triggered when the standard
+// lookup chain (GetByIdentity → findProxyParent → FindByPanePID) all miss
+// on a SessionStart, indicating either a fresh start or a daemon-downtime
+// recovery scenario.
+//
+// Behavior:
+//   - Walk pane PID tree via cachedDescendants(panePID) (250ms cache)
+//   - For each descendant PID, call provider.Identify per registered agent type
+//   - First match wins (registry order)
+//   - Match → return constructed Frame fields; caller persists via Upsert
+//   - No match → return (nil, false, nil); caller falls through to no_parent_fallback
+//   - Any error during process scan → return (nil, false, err); caller surfaces
+//
+// Subagent list is intentionally NOT rebuilt — left as []. Subsequent
+// SubagentStart hooks will populate refs naturally (kept simple per plan §1.3).
+func (m *Module) tryRebuildFromProcessTree(req EventRequest, info ProcessInfo) (rebuilt *RebuildResult, ok bool, err error)
+
+type RebuildResult struct {
+    AgentType string  // detected agent family
+    PID       int     // matched descendant PID (= req.SenderPID for happy path)
+    PPID      int     // info.PPID (kept consistent with caller)
+}
+```
+
+**呼叫點**（line 228 之後插入）：
+
+```go
+// pseudo-code
+if frame == nil && parentFrameID == "" {
+    rebuilt, ok, rerr := m.tryRebuildFromProcessTree(req, info)
+    if rerr != nil {
+        // fail-soft: log + fall through to no_parent_fallback
+        m.logger.Warn("rebuild_from_process_tree_failed", "err", rerr, "pane", req.TmuxPaneID)
+    }
+    if ok {
+        // Use rebuilt.AgentType in subsequent Upsert; mark trace as rebuilt
+        // (req.AgentType still wins for the actual hook event's agent_type;
+        // RebuildResult only confirms an alive process matches that family.)
+        rebuiltMatched = true  // signals trace meta below
+    }
+}
+```
+
+**重要決策**（與 codex Q4 對齊）：
+- **first-match-wins**：registry 註冊順序決定優先序（cc / codex / opencode 三家同時跑時取第一命中）。實際情境下三家很少在同 pane tree 共存，但需文件化。
+- **不重建 SubagentRef**：`Frame.Subagents=[]`（見 §1.3）。
+- **rebuild 命中 ≠ 取代 hook event AgentType**：`req.AgentType` 仍是事實源（hook 帶來的權威），rebuild 只**證實**「process tree 中確實有該家 agent alive」、給 trace 標記用。若 rebuilt.AgentType ≠ req.AgentType（罕見）優先信 req（hook 是 source of truth）。
+
+### 1.3 SubagentRef rebuild 策略 — **不重建**
+
+理由：
+- pane PID tree 的 descendants 是「目前活著的 process」，無法分辨 cc 主進程、subagent 進程、或無關子進程
+- subagent 識別需要 process 命名/啟動 pattern，這層複雜度遠超 Phase 3
+- Phase 2 PR-2b 的 `SubagentStart`/`Stop` hook 機制已就位 — rebuild 後新 subagent 的 hook 會正常累積，不會永久缺失
+- frame.Subagents=[] 的天然語意正是「unreconciled」（codex Q1 暗示，但不需新增 SPA state）
+
+**驗收**：rebuild 後第一個 SubagentStart hook 進來會正確走 `mutateSubagentsWithRetry`，subagent list 自動補齊。Phase 3 測試需 cover 此 path（見 §2.1 R6）。
+
+### 1.4 `no_parent_fallback` reason 升級
+
+**現況**（line 294-297）：
+
+```go
+reason := "parent_frame_missing"
+if stored.ParentFrameID != "" {
+    reason = "parent_frame_found"
+}
+```
+
+**Phase 3 改為**：
+
+```go
+reason := "no_parent_fallback"  // 升級：明確標記「降階用 hook event agent_type 為基準」
+if stored.ParentFrameID != "" {
+    reason = "parent_frame_found"
+} else if rebuiltMatched {
+    reason = "daemon_restart_recovery"  // rebuild 命中
+}
+```
+
+三態 reason：
+- `parent_frame_found` — legacy lookup 命中（line 220-228）
+- `daemon_restart_recovery` — Item A rebuild 命中
+- `no_parent_fallback` — 都未命中，降階用 hook agent_type 為基準（即原 `parent_frame_missing`）
+
+**不新增 trace step**：採 reason-rename 方案（不擴 step 數）。理由：
+- 既有 frame-kind step 已有 `reason` 欄位，Inspector group by 已能達成統計
+- Trace step 數每 hook 已 5+，避免膨脹
+- 「進入前寫一筆 trace step」spec 用語可解讀為「frame trace step 那一筆」（決策即 step）
+
+若後續 Inspector / reparent loop 需要更細粒度（例如分「主動 fallback」vs「rebuild 失敗後 fallback」），追加 step 屬 Phase 4/5 演進，本 phase 不超前。
+
+### 1.5 Trace 寫入路徑
+
+無需動 collector。`applyFrameEvent` 已回傳 `FrameTraceMeta.Reason` 字串，handler.go 的 `c.Frame(req, meta)` 自動寫入 trace step。
+
+**handler-side 影響**：handler.go 對 `meta.Reason == "parent_frame_missing"` 沒有特殊邏輯（只是傳到 trace），改名後既有 handler 路徑零影響。**但需 grep 全 codebase 確認無 hardcoded 字串依賴**（測試 / SPA / 文件）。
+
+### 1.6 零改動邊界
+
+以下 Phase 3 **不得觸碰**：
+
+- `internal/agent/provider.go` / `registry.go` / `coverage.go`（Phase 0）
+- `internal/agent/{cc,codex,opencode}/status.go`（Phase 1）
+- `internal/agent/{cc,codex,opencode}/hooks.go`（Hook Events #616 已收）
+- `internal/agent/probe/**`（lazy rebuild 透過 `Prober.Identify` + `cachedDescendants` 既有 API；新 helper 不入 probe package）
+- `internal/agent/subagent.go`（PR-2a SubagentRef，不動）
+- `internal/store/frames.go`（PR-2b 已加 `DeleteIfUnchanged` / `UpsertIfUnchanged` / narrow updates；Phase 3 不擴 schema）
+- `internal/store/trace.go`（trace step 結構不動）
+- `internal/module/agent/sweep.go`（idle sweep 規則不動）
+- `internal/tmux/executor.go`（無 `ListPanesForSession`，YAGNI）
+- `spa/**`（純 backend phase）
+
+---
+
+## 2. 測試案例清單
+
+### 2.1 `internal/module/agent/frame_ops_test.go`（Phase 3 新增）
+
+| # | 名稱 | 情境 | 斷言 |
+|---|---|---|---|
+| R1 | `TestRebuildFromProcessTree_HitFirstMatch` | descendants=[100,200,300]，stub Identify 在 PID=200 命中 cc | 回傳 `RebuildResult{AgentType:"cc",PID:200,...}`、`ok=true` |
+| R2 | `TestRebuildFromProcessTree_NoMatch` | descendants=[100,200]，stub Identify 全部不命中 | 回傳 `(nil, false, nil)` |
+| R3 | `TestRebuildFromProcessTree_DescendantsError` | `cachedDescendants` 回 err | 回傳 `(nil, false, err)`，err 非 nil |
+| R4 | `TestRebuildFromProcessTree_RegistryOrder` | 同 PID 同時被 cc 和 codex 識別，cc 註冊在前 | 取 cc（first-match-wins） |
+| R5 | `TestApplyFrameEvent_RebuildHit_TraceReason` | mock rebuild 命中 + 既有 lookup chain 全失敗 | trace meta `Reason="daemon_restart_recovery"`，新 frame 建出 |
+| R6 | `TestApplyFrameEvent_RebuildHit_ThenSubagentStart` | rebuild 後立即進來 SubagentStart | subagent 正確累積（驗證 rebuild 後 native path 不壞） |
+| N1 | `TestApplyFrameEvent_NoParentFallback_TraceReason` | rebuild 未命中 + 既有 lookup chain 全失敗 | trace meta `Reason="no_parent_fallback"`（取代既有 `parent_frame_missing` 測試） |
+| N2 | `TestApplyFrameEvent_ParentFrameFound_Unchanged` | legacy `FindByPanePID` 命中 | trace meta `Reason="parent_frame_found"`（regression guard） |
+| N3 | `TestApplyFrameEvent_RebuildSkipped_WhenParentFound` | parent 命中時不呼叫 rebuild helper | spy verify `tryRebuildFromProcessTree` call count == 0 |
+
+### 2.2 整合測試（端到端，`handler_test.go` 或新檔）
+
+模擬 spec §7 三情境：
+
+| # | 名稱 | 情境 | 斷言 |
+|---|---|---|---|
+| I1 | `TestHandleEvent_ColdStart_RebuildRecovers` | 空 frames table + alive process tree（stub Identify 命中） + SessionStart hook | DB 多一 row、reason=`daemon_restart_recovery`、SPA broadcast `NormalizedEvent` 帶新 frame_id |
+| I2 | `TestHandleEvent_DaemonRestart_RebuildRecoversForExistingPane` | 模擬 daemon 重啟（frames table reset） + 既有 pane 內 hook | rebuild 命中 + frame 重建、subagents=[] |
+| I3 | `TestHandleEvent_MidConnectionGone_NoParentFallback` | frames 空 + Identify 全不命中 + SessionStart hook | reason=`no_parent_fallback`、frame 仍建（用 hook agent_type） |
+
+### 2.3 Drift / regression guard
+
+- **PR-2b PPID proxy walk regression**：保證 SessionStart 走 `findProxyParent` 命中時**不**進入 rebuild 分支（rebuild 在 fallback 末端，proxy walk 是 fallback 前段）。新增 R7 `TestApplyFrameEvent_ProxyHit_SkipsRebuild`。
+- **既有 reason 字串依賴**：實作 commit 1 跑 `grep -rn "parent_frame_missing"` 確認 codebase 無依賴字串（測試以外）；如有需同步更新。
+
+---
+
+## 3. TDD Commit 順序
+
+| # | Commit | 範圍 | 紅綠循環 |
+|---|---|---|---|
+| 1 | `feat(agent): tryRebuildFromProcessTree helper + Identify dispatch` | 新 helper + RebuildResult struct + R1-R4 + R7 | R1-R4 + R7 紅 → 實作 → 綠 |
+| 2 | `feat(agent): wire rebuild into applyFrameEvent fallback chain` | applyFrameEvent 插入 + R5/R6/N3 + I1/I2 整合測試 | 紅 → 實作（含 stub provider 註冊 hooks）→ 綠 |
+| 3 | `refactor(agent): no_parent_fallback reason explicit` | 既有 reason 改字串 + N1/N2 + I3 + grep guard | N1/N2/I3 紅 → 改字串 + 既有 `parent_frame_missing` 測試重命名 → 綠 |
+
+**Commit 1 → Commit 2 dependency**：commit 1 落地後 helper 存在但未接線；commit 2 接 wiring。中間 main 可保持 build green（helper 有 unit test 但 applyFrameEvent 未叫）。
+
+**Commit 3 獨立**：可單獨 review，與 commit 1/2 無 code 依賴（純字串改名 + 測試）。但放最後因為 N1 測試的命名假設 commit 1/2 已落地（rebuild reason `daemon_restart_recovery` 已存在）。
+
+---
+
+## 4. 行數預估
+
+| 項目 | 估計行數 |
+|---|---|
+| `frame_ops.go` — `tryRebuildFromProcessTree` + `RebuildResult` + applyFrameEvent insertion | +90 / -3 |
+| `frame_ops_test.go` — R1-R7 + N1-N3 | +280 |
+| `handler_test.go` — I1-I3 | +120 |
+| 整合測試 helper（stub Prober + descendants） | +50 |
+| 文件（本 plan） | ~600 |
+| **Total code 淨增** | **~540** |
+| **Total（含 plan）** | **~1140** |
+
+---
+
+## 5. 不做（明列）
+
+- ❌ SPA 端 `unreconciled` state UI（Phase 5 Inspector 範圍）
+- ❌ SPA on-demand inventory query / dev panel session list（Phase 5）
+- ❌ `tmux.ListPanesForSession` helper（無消費端，YAGNI）
+- ❌ 既有 frame 的 stale check（Phase 4/5；Phase 2 idle sweep 部分覆蓋）
+- ❌ SubagentRef rebuild（lazy 由後續 SubagentStart hook 補齊）
+- ❌ Periodic poll reconciliation（無需求；hook event 已是事件驅動）
+- ❌ Reparent loop（reason=`no_parent_fallback` 已鋪資料邊界，loop 本身待 Phase 5）
+- ❌ 同 session 跨 pane inventory 廉價掃（Codex Q4 前半，無消費端不做）
+- ❌ 新增 trace step type / collector method（reason 字串升級已足）
+- ❌ 改 `frame.Subagents=[]` 的天然語意（不引入 unreconciled bit）
+
+---
+
+## 6. 風險與護欄
+
+### 6.1 `Prober.Identify` 跨 provider 順序
+
+**風險**：cc / codex / opencode 三家若同時 match 同 PID（例如 cc 內呼 codex），rebuild 取的不一定是 hook event 的真正 owner。
+
+**護欄**：
+- registry 註冊順序文件化（首登記者優先）；本 phase 不改既有註冊順序
+- Rebuild 結果僅用於 trace 標記 + 證實 process tree 中該家 agent alive；frame.AgentType 仍取 `req.AgentType`（hook event 是 SOT）
+- 若 rebuilt.AgentType ≠ req.AgentType（mismatch），記入 trace meta `reason="daemon_restart_recovery_mismatch"`（**追加分支**）— Phase 3 觀察用，未來資料統計足夠多再決定行為
+
+### 6.2 `cachedDescendants` 250ms cache 可能 stale
+
+**風險**：rebuild 觸發瞬間，descendants cache 仍是 daemon 啟動前的（理論上應為空，但 cache 存在的情況下…）
+
+**評估**：daemon 啟動時 cache 為空（map init），首次 `cachedDescendants` 必走實際 query；250ms 後續 hook 命中 cache 也是「已 alive」的最新 snapshot。Phase 3 不需特殊處理。
+
+### 6.3 Rebuild 失敗 fail-soft
+
+**風險**：`cachedDescendants` 系統呼叫失敗 / Identify panic / 其他 process 操作異常。
+
+**護欄**：
+- helper 簽名包含 err 回傳；caller 收到 err **不返錯**，僅 `m.logger.Warn` 後 fall through 到 `no_parent_fallback`
+- 任何 panic 在 helper 內 recover（defer 包），保證 hook 路徑不中斷
+- Test R3 驗證 err path
+
+### 6.4 Reason 字串改名的 grep 依賴
+
+**風險**：`parent_frame_missing` 字串可能被 SPA / 測試 / 其他 daemon 模組依賴。
+
+**護欄**：commit 3 第一步先跑 `grep -rn "parent_frame_missing"`，列出所有依賴點同步更新或論述為何不需動。
+
+### 6.5 Phase 2 PR-2b 行為 0 regression
+
+**風險**：插入點在 PR-2b proxy walk **之後**，但需確認 R5（rebuild）/ N1（no_parent_fallback）測試不破壞既有 PPID proxy 邏輯。
+
+**護欄**：R7 顯式驗證「proxy 命中時 rebuild 不被呼叫」（spy 計數 == 0）。同時 commit 2 跑全套 PR-2b 既有測試確保 0 regression。
+
+---
+
+## 7. 驗收清單
+
+- [ ] `go build ./...` 綠
+- [ ] `go vet ./...` 無 warning
+- [ ] `go test ./...` 全綠（含新增 R1-R7、N1-N3、I1-I3）
+- [ ] PR-2a/2b 既有測試 0 regression（28 + 29 = 57 既有 case 全綠）
+- [ ] `grep -rn "parent_frame_missing"` 結果空（commit 3 後）
+- [ ] 手動測試（reviewer 驗）：
+  - daemon 重啟 → 既有 cc session pane 按 enter → SPA 顯示 frame
+  - daemon 重啟 → cc 內 `/codex:*` proxy 仍正確掛回 cc.Subagents
+  - SQL `select decision, reason, count(*) from agent_trace_steps where kind='frame' group by 1,2` 可看到三態 reason
+- [ ] PR description 列三情境 manual verification 結果
+
+---
+
+## 8. Review focus 預期（Round 1 standard）
+
+可能被抓到（已預先處理）：
+- ✅ rebuild fail-soft 不吞錯（log + fall through，§6.3）
+- ✅ Identify 跨 provider 順序文件化（§6.1）
+- ✅ reason 改名 grep guard（§6.4 + commit 3 第一步）
+- ✅ SubagentRef 不重建決策論述（§1.3）
+- ✅ Phase 2 0 regression 顯式驗證（R7）
+
+可能被抓到（待 review 看）：
+- rebuild 命中時 `RebuildResult.AgentType` 與 `req.AgentType` mismatch 的處理是否完整（§6.1 提到追加 trace reason，但細節留 review）
+- I1/I2/I3 測試的 stub Prober 是否真實 emulate 了 daemon 重啟條件（測試 fixture 的真實度）
+- `Prober.Identify` 是否被 export 到 module package（package boundary）
+
+---
+
+## 9. 相關檔案速查
+
+- 主改動：`internal/module/agent/frame_ops.go`（applyFrameEvent + 新 helper）
+- 主測試：`internal/module/agent/frame_ops_test.go` + `handler_test.go`
+- 既有依賴：
+  - `internal/agent/probe/probe.go` — `Prober.Identify(agentType, pid)`
+  - `internal/agent/probe/liveness.go` — `cachedDescendants(target, panePID)` + `ProcessStartTime` + `IsPidAlive`
+  - `internal/agent/registry.go` — provider 註冊順序
+  - `internal/store/frames.go` — `Upsert` / `GetByIdentity` / `FindByPanePID`
+  - `internal/module/agent/trace.go` — `hookTraceCollector.Frame()` 自動寫 reason
+- Spec / Discussion：
+  - `docs/specs/2026-04-23-lights-rebuild-spec.md` §7
+  - `docs/research/2026-04-22-lights-rebuild-discussion.md`（架構討論）
+- Codex consulting：job `af47a0fd51ca6667e`（2026-04-25 high-effort architectural review）

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-plan.md
@@ -1,12 +1,13 @@
 # Phase 3 TDD Plan — L1 邊界補強
 
 - **Date**: 2026-04-25
+- **Version**: v2（v1 → v2 經 1 輪 codex plan review，2 P2/P3 finding 全採納）
 - **Spec**: `docs/specs/2026-04-23-lights-rebuild-spec.md` §7
 - **Worktree**: `lights-phase-3`（branch `worktree-lights-phase-3`）
 - **Baseline**: `1.0.0-alpha.221`（main @ `2633b88d`，Phase 2 PR-2b merged）
-- **依賴**: Phase 2 PR-2b ✅（`SubagentRef` 結構 + `findProxyParent` PPID walk + `cachedDescendants` + `Prober.Identify` 已就緒）
+- **依賴**: Phase 2 PR-2b ✅（`SubagentRef` 結構 + `findProxyParent` PPID walk + `Prober.IsAliveFor` 已就緒；本 phase 新增 `Prober.FirstAliveAgentInTree` public method）
 - **範圍**：`applyFrameEvent` fallback chain 末端補回 + `no_parent_fallback` reason 顯式化
-- **預估**：單 PR ~430 行 net（~80 prod + 250 test + 100 整合測試）
+- **預估**：單 PR ~580 行 net（~120 prod 含新 Prober method + 280 test + 120 整合測試 + 50 helper fixture）
 
 ---
 
@@ -34,9 +35,18 @@
 
 ### 0.3 設計核心思想
 
-採 **K8s reconciliation 對照組**：hook event = `watch event`、`cachedDescendants + Prober.Identify` = `live state read`、目前 fallback chain 失敗就 Upsert = `create-on-miss`。Phase 3 在「都未命中」與「Upsert 新 frame」之間插一條「先嘗試 process tree rebuild」的 reconciliation step，把 daemon downtime 期間遺失的 frame 識別補回。
+採 **K8s reconciliation 對照組**：hook event = `watch event`、Prober tree query = `live state read`、目前 fallback chain 失敗就 Upsert = `create-on-miss`。Phase 3 在「都未命中」與「Upsert 新 frame」之間插一條「先嘗試 process tree rebuild」的 reconciliation step，把 daemon downtime 期間遺失的 frame 識別補回。
 
 **未補回 = no_parent_fallback**：明確標記，等 Phase 4/5 的 reparent loop / Inspector 消費。
+
+### 0.4 Plan v1 → v2 review 軌跡
+
+Codex plan review round 1（job 由 `node codex-companion.mjs review --base origin/main --scope branch` 派發）抓到 2 個 finding，全採納：
+
+| # | 嚴重 | 內容 | v2 fix |
+|---|---|---|---|
+| 1 | P2 | v1 §1.2 寫「直接呼叫 `cachedDescendants` / `Prober.Identify`」— 但 `cachedDescendants` 是 probe package 私有 method、`Prober` **沒有** `Identify`（只有 `RegisterIdentifier` + `IsAliveFor`，`Identify` 是 provider 層）。照 v1 實作會卡在 package boundary。 | 新增 `Prober.FirstAliveAgentInTree(target)` public method（與 `IsAliveFor(agentType, target)` 同型結構，內部用既有 `cachedDescendants` + `identifiers` map）；§1.6 邊界改寫為「probe package 允許新 export method，不改既有 API」 |
+| 2 | P3 | v1 §6.1 引入第四態 reason `daemon_restart_recovery_mismatch`，但 §1.4 三態鎖定 + 測試矩陣只覆蓋三態 — 內部 contract 矛盾 | 刪除第四態。本 phase 信任 hook event AgentType 為 SOT；rebuild 命中只證實「該家 agent 有 alive process」。Mismatch 罕見 corner case 留 Phase 4/5 處理 |
 
 ---
 
@@ -55,59 +65,91 @@
 
 **Phase 3 插入點**：在 step 4 與 step 5 之間（line 228 之後、line 273 之前）插入 lazy rebuild。step 6 的 reason 同時升級。
 
-### 1.2 Lazy rebuild — `tryRebuildFromProcessTree` 新 helper
+### 1.2 Lazy rebuild — 新 Prober method + frame_ops 接線
 
-**簽名**（位置：`internal/module/agent/frame_ops.go`，與 `findProxyParent` 同檔）：
+#### 1.2.1 新 Prober method `FirstAliveAgentInTree`
+
+**位置**：`internal/agent/probe/probe.go`（與 `IsAliveFor` 同檔，liveness.go 也可，依現有 method group 而定）
+
+**簽名**：
 
 ```go
-// tryRebuildFromProcessTree attempts to recover a frame after daemon restart
-// by inspecting the pane's live process tree. Triggered when the standard
-// lookup chain (GetByIdentity → findProxyParent → FindByPanePID) all miss
-// on a SessionStart, indicating either a fresh start or a daemon-downtime
-// recovery scenario.
+// FirstAliveAgentInTree walks the tmux target's pane PID descendant tree
+// and returns the agent type of the first descendant matched by any
+// registered identifier (in registry insertion order). Returns
+// ("", 0, nil) when no descendant matches any identifier.
 //
-// Behavior:
-//   - Walk pane PID tree via cachedDescendants(panePID) (250ms cache)
-//   - For each descendant PID, call provider.Identify per registered agent type
-//   - First match wins (registry order)
-//   - Match → return constructed Frame fields; caller persists via Upsert
-//   - No match → return (nil, false, nil); caller falls through to no_parent_fallback
-//   - Any error during process scan → return (nil, false, err); caller surfaces
+// Honors the same 250ms descendant cache as IsAliveFor (delegates to
+// cachedDescendants internally).
 //
-// Subagent list is intentionally NOT rebuilt — left as []. Subsequent
-// SubagentStart hooks will populate refs naturally (kept simple per plan §1.3).
-func (m *Module) tryRebuildFromProcessTree(req EventRequest, info ProcessInfo) (rebuilt *RebuildResult, ok bool, err error)
-
-type RebuildResult struct {
-    AgentType string  // detected agent family
-    PID       int     // matched descendant PID (= req.SenderPID for happy path)
-    PPID      int     // info.PPID (kept consistent with caller)
-}
+// Used by frame_ops.tryRebuildFromProcessTree (Phase 3) to recover frame
+// agent_type after daemon restart, when the hook event's lookup chain
+// (GetByIdentity → findProxyParent → FindByPanePID) all miss.
+func (p *Prober) FirstAliveAgentInTree(target string) (agentType string, matchedPID int, err error)
 ```
 
-**呼叫點**（line 228 之後插入）：
+**內部實作**（pseudo）：
+1. `panePID, _ := p.tmux.PanePID(target)` — 取 pane root PID
+2. `descendants, err := p.cachedDescendants(target, panePID)` — 既有私有 method
+3. iterate registered identifiers（有序 — see §1.2.3）→ 對每個 desc PID 跑 identify → 第一命中即返
+4. 全不命中 → 回 `("", 0, nil)`
+
+#### 1.2.2 frame_ops `tryRebuildFromProcessTree` helper
+
+**位置**：`internal/module/agent/frame_ops.go`（與 `findProxyParent` 同檔）
+
+**簽名**：
+
+```go
+// tryRebuildFromProcessTree attempts to recover a frame after daemon
+// restart by inspecting the pane's live process tree via the Prober.
+// Triggered when the standard lookup chain (GetByIdentity →
+// findProxyParent → FindByPanePID) all miss on a SessionStart.
+//
+// Behavior:
+//   - Delegates to prober.FirstAliveAgentInTree(target)
+//   - Match → return (agentType, true, nil); caller marks trace
+//     reason="daemon_restart_recovery"
+//   - No match → return ("", false, nil); caller falls through to
+//     no_parent_fallback
+//   - Any error → return ("", false, err); caller logs + falls through
+//     to no_parent_fallback (fail-soft, see §6.3)
+//
+// Subagent list intentionally NOT rebuilt — left []. Subsequent
+// SubagentStart hooks populate refs naturally (see §1.3).
+func (m *Module) tryRebuildFromProcessTree(req EventRequest) (matchedAgentType string, ok bool, err error)
+```
+
+#### 1.2.3 Registry 註冊順序保證
+
+`FirstAliveAgentInTree` 第一命中規則需要穩定的 identifier 順序。Go map iteration 是無序的，故 `Prober.identifiers` 不能直接用 `range map`。
+
+**實作要求**：`Prober` 需維護 identifier insertion order — 加 `identifierOrder []string` slice 在 `RegisterIdentifier` 時 append；`FirstAliveAgentInTree` 用 slice 順序 iterate。
+
+**測試覆蓋**：R4 顯式驗證 cc 註冊在前 → 同 PID 取 cc。
+
+#### 1.2.4 `applyFrameEvent` 接線（line 228 之後插入）
 
 ```go
 // pseudo-code
+rebuiltMatched := false
 if frame == nil && parentFrameID == "" {
-    rebuilt, ok, rerr := m.tryRebuildFromProcessTree(req, info)
+    matchedType, ok, rerr := m.tryRebuildFromProcessTree(req)
     if rerr != nil {
         // fail-soft: log + fall through to no_parent_fallback
         m.logger.Warn("rebuild_from_process_tree_failed", "err", rerr, "pane", req.TmuxPaneID)
     }
     if ok {
-        // Use rebuilt.AgentType in subsequent Upsert; mark trace as rebuilt
-        // (req.AgentType still wins for the actual hook event's agent_type;
-        // RebuildResult only confirms an alive process matches that family.)
-        rebuiltMatched = true  // signals trace meta below
+        rebuiltMatched = true  // signals trace meta below (§1.4)
+        _ = matchedType        // not consumed by Upsert; req.AgentType is SOT (see below)
     }
 }
 ```
 
-**重要決策**（與 codex Q4 對齊）：
-- **first-match-wins**：registry 註冊順序決定優先序（cc / codex / opencode 三家同時跑時取第一命中）。實際情境下三家很少在同 pane tree 共存，但需文件化。
-- **不重建 SubagentRef**：`Frame.Subagents=[]`（見 §1.3）。
-- **rebuild 命中 ≠ 取代 hook event AgentType**：`req.AgentType` 仍是事實源（hook 帶來的權威），rebuild 只**證實**「process tree 中確實有該家 agent alive」、給 trace 標記用。若 rebuilt.AgentType ≠ req.AgentType（罕見）優先信 req（hook 是 source of truth）。
+**重要決策**：
+- **first-match-wins**：registry 註冊順序（§1.2.3）
+- **不重建 SubagentRef**：`Frame.Subagents=[]`（§1.3）
+- **rebuild 命中 ≠ 取代 hook event AgentType**：`req.AgentType` 是 SOT；rebuild 只**證實**「process tree 中該家 agent alive」、給 trace 標記用。`matchedAgentType` 在本 phase 不寫入 frame（故變數丟棄）— 若未來需要追蹤 mismatch 再從 `_` 接出來。Phase 3 不處理 mismatch（v1→v2 codex P3 fix 後簡化）。
 
 ### 1.3 SubagentRef rebuild 策略 — **不重建**
 
@@ -166,7 +208,7 @@ if stored.ParentFrameID != "" {
 - `internal/agent/provider.go` / `registry.go` / `coverage.go`（Phase 0）
 - `internal/agent/{cc,codex,opencode}/status.go`（Phase 1）
 - `internal/agent/{cc,codex,opencode}/hooks.go`（Hook Events #616 已收）
-- `internal/agent/probe/**`（lazy rebuild 透過 `Prober.Identify` + `cachedDescendants` 既有 API；新 helper 不入 probe package）
+- `internal/agent/{cc,codex,opencode}/provider.go` 的 `Identify` method 簽名（既有，不改）
 - `internal/agent/subagent.go`（PR-2a SubagentRef，不動）
 - `internal/store/frames.go`（PR-2b 已加 `DeleteIfUnchanged` / `UpsertIfUnchanged` / narrow updates；Phase 3 不擴 schema）
 - `internal/store/trace.go`（trace step 結構不動）
@@ -174,38 +216,53 @@ if stored.ParentFrameID != "" {
 - `internal/tmux/executor.go`（無 `ListPanesForSession`，YAGNI）
 - `spa/**`（純 backend phase）
 
+**有限改動（明列）**：
+- `internal/agent/probe/probe.go` — 加 `FirstAliveAgentInTree` public method（§1.2.1）+ `identifierOrder` slice 維護註冊順序（§1.2.3）；既有 `RegisterIdentifier` / `IsAliveFor` / `cachedDescendants` 行為**不變**
+- `internal/module/agent/frame_ops.go` — 加 `tryRebuildFromProcessTree` helper + `applyFrameEvent` line 228 後插入點（§1.2.2 + §1.2.4）；line 294-297 reason 改字串（§1.4）
+
 ---
 
 ## 2. 測試案例清單
 
-### 2.1 `internal/module/agent/frame_ops_test.go`（Phase 3 新增）
+### 2.1 `internal/agent/probe/probe_test.go`（新 method 單元測試）
 
 | # | 名稱 | 情境 | 斷言 |
 |---|---|---|---|
-| R1 | `TestRebuildFromProcessTree_HitFirstMatch` | descendants=[100,200,300]，stub Identify 在 PID=200 命中 cc | 回傳 `RebuildResult{AgentType:"cc",PID:200,...}`、`ok=true` |
-| R2 | `TestRebuildFromProcessTree_NoMatch` | descendants=[100,200]，stub Identify 全部不命中 | 回傳 `(nil, false, nil)` |
-| R3 | `TestRebuildFromProcessTree_DescendantsError` | `cachedDescendants` 回 err | 回傳 `(nil, false, err)`，err 非 nil |
-| R4 | `TestRebuildFromProcessTree_RegistryOrder` | 同 PID 同時被 cc 和 codex 識別，cc 註冊在前 | 取 cc（first-match-wins） |
+| P1 | `TestFirstAliveAgentInTree_HitFirstMatch` | stub tmux PanePID + descendants=[100,200,300]，stub identifier 在 PID=200 命中 cc | 回傳 `("cc", 200, nil)` |
+| P2 | `TestFirstAliveAgentInTree_NoMatch` | descendants=[100,200]，所有 identifier 全部不命中 | 回傳 `("", 0, nil)` |
+| P3 | `TestFirstAliveAgentInTree_DescendantsError` | tmux PanePID 失敗 / descendants query err | 回傳 `("", 0, err)` |
+| P4 | `TestFirstAliveAgentInTree_RegistryOrder` | cc 與 codex 都能識別同 PID=200，cc 先註冊 | 取 cc |
+| P5 | `TestRegisterIdentifier_PreservesOrder` | 註冊 codex/cc/opencode 三家 | iteration 順序為註冊順序（驗證 `identifierOrder` slice 機制） |
+
+### 2.2 `internal/module/agent/frame_ops_test.go`（Phase 3 新增）
+
+| # | 名稱 | 情境 | 斷言 |
+|---|---|---|---|
+| R1 | `TestTryRebuildFromProcessTree_Hit` | stub `Prober.FirstAliveAgentInTree` 回 `("cc", 200, nil)` | helper 回傳 `("cc", true, nil)` |
+| R2 | `TestTryRebuildFromProcessTree_Miss` | stub 回 `("", 0, nil)` | helper 回傳 `("", false, nil)` |
+| R3 | `TestTryRebuildFromProcessTree_Error` | stub 回 err | helper 回傳 `("", false, err)`，err 非 nil |
 | R5 | `TestApplyFrameEvent_RebuildHit_TraceReason` | mock rebuild 命中 + 既有 lookup chain 全失敗 | trace meta `Reason="daemon_restart_recovery"`，新 frame 建出 |
 | R6 | `TestApplyFrameEvent_RebuildHit_ThenSubagentStart` | rebuild 後立即進來 SubagentStart | subagent 正確累積（驗證 rebuild 後 native path 不壞） |
+| R7 | `TestApplyFrameEvent_ProxyHit_SkipsRebuild` | SessionStart 走 `findProxyParent` 命中 | rebuild helper call count == 0（PR-2b proxy 路徑優先） |
+| R8 | `TestApplyFrameEvent_RebuildErrorFailsSoft` | rebuild 回 err | trace meta `Reason="no_parent_fallback"`（fail-soft，不返錯） |
 | N1 | `TestApplyFrameEvent_NoParentFallback_TraceReason` | rebuild 未命中 + 既有 lookup chain 全失敗 | trace meta `Reason="no_parent_fallback"`（取代既有 `parent_frame_missing` 測試） |
 | N2 | `TestApplyFrameEvent_ParentFrameFound_Unchanged` | legacy `FindByPanePID` 命中 | trace meta `Reason="parent_frame_found"`（regression guard） |
 | N3 | `TestApplyFrameEvent_RebuildSkipped_WhenParentFound` | parent 命中時不呼叫 rebuild helper | spy verify `tryRebuildFromProcessTree` call count == 0 |
 
-### 2.2 整合測試（端到端，`handler_test.go` 或新檔）
+### 2.3 整合測試（端到端，`handler_test.go` 或新檔）
 
 模擬 spec §7 三情境：
 
 | # | 名稱 | 情境 | 斷言 |
 |---|---|---|---|
-| I1 | `TestHandleEvent_ColdStart_RebuildRecovers` | 空 frames table + alive process tree（stub Identify 命中） + SessionStart hook | DB 多一 row、reason=`daemon_restart_recovery`、SPA broadcast `NormalizedEvent` 帶新 frame_id |
+| I1 | `TestHandleEvent_ColdStart_RebuildRecovers` | 空 frames table + stub `FirstAliveAgentInTree` 命中 + SessionStart hook | DB 多一 row、reason=`daemon_restart_recovery`、SPA broadcast `NormalizedEvent` 帶新 frame_id |
 | I2 | `TestHandleEvent_DaemonRestart_RebuildRecoversForExistingPane` | 模擬 daemon 重啟（frames table reset） + 既有 pane 內 hook | rebuild 命中 + frame 重建、subagents=[] |
-| I3 | `TestHandleEvent_MidConnectionGone_NoParentFallback` | frames 空 + Identify 全不命中 + SessionStart hook | reason=`no_parent_fallback`、frame 仍建（用 hook agent_type） |
+| I3 | `TestHandleEvent_MidConnectionGone_NoParentFallback` | frames 空 + stub 全不命中 + SessionStart hook | reason=`no_parent_fallback`、frame 仍建（用 hook agent_type） |
 
-### 2.3 Drift / regression guard
+### 2.4 Regression guard
 
-- **PR-2b PPID proxy walk regression**：保證 SessionStart 走 `findProxyParent` 命中時**不**進入 rebuild 分支（rebuild 在 fallback 末端，proxy walk 是 fallback 前段）。新增 R7 `TestApplyFrameEvent_ProxyHit_SkipsRebuild`。
-- **既有 reason 字串依賴**：實作 commit 1 跑 `grep -rn "parent_frame_missing"` 確認 codebase 無依賴字串（測試以外）；如有需同步更新。
+- **PR-2b PPID proxy walk regression**：R7 顯式驗證 SessionStart 走 `findProxyParent` 命中時**不**進入 rebuild 分支
+- **既有 reason 字串依賴**：commit 3 第一步跑 `grep -rn "parent_frame_missing"` 確認 codebase 無依賴字串（測試以外）；如有需同步更新
 
 ---
 
@@ -213,13 +270,18 @@ if stored.ParentFrameID != "" {
 
 | # | Commit | 範圍 | 紅綠循環 |
 |---|---|---|---|
-| 1 | `feat(agent): tryRebuildFromProcessTree helper + Identify dispatch` | 新 helper + RebuildResult struct + R1-R4 + R7 | R1-R4 + R7 紅 → 實作 → 綠 |
-| 2 | `feat(agent): wire rebuild into applyFrameEvent fallback chain` | applyFrameEvent 插入 + R5/R6/N3 + I1/I2 整合測試 | 紅 → 實作（含 stub provider 註冊 hooks）→ 綠 |
-| 3 | `refactor(agent): no_parent_fallback reason explicit` | 既有 reason 改字串 + N1/N2 + I3 + grep guard | N1/N2/I3 紅 → 改字串 + 既有 `parent_frame_missing` 測試重命名 → 綠 |
+| 1 | `feat(probe): FirstAliveAgentInTree + ordered identifiers` | 新 Prober method + `identifierOrder` slice + P1-P5 | P1-P5 紅 → 實作 → 綠 |
+| 2 | `feat(agent): tryRebuildFromProcessTree helper` | frame_ops helper（不接線）+ R1-R3 | R1-R3 紅 → 實作 → 綠 |
+| 3 | `feat(agent): wire rebuild into applyFrameEvent fallback chain` | applyFrameEvent 插入 + R5/R6/R7/R8/N3 + I1/I2 整合測試 | 紅 → 實作 → 綠 |
+| 4 | `refactor(agent): no_parent_fallback reason explicit` | 既有 reason 改字串 + N1/N2 + I3 + grep guard | N1/N2/I3 紅 → 改字串 + 既有 `parent_frame_missing` 測試重命名 → 綠 |
 
-**Commit 1 → Commit 2 dependency**：commit 1 落地後 helper 存在但未接線；commit 2 接 wiring。中間 main 可保持 build green（helper 有 unit test 但 applyFrameEvent 未叫）。
+**Commit chain dependency**：
+- Commit 1 落地：probe API ready，frame_ops 尚未消費，main build green
+- Commit 2 落地：helper 存在但未接線，main build green（helper 有 unit test 但 applyFrameEvent 未叫）
+- Commit 3 落地：wiring 完成，daemon_restart_recovery 路徑通
+- Commit 4 落地：reason rename + 既有 testname 同步
 
-**Commit 3 獨立**：可單獨 review，與 commit 1/2 無 code 依賴（純字串改名 + 測試）。但放最後因為 N1 測試的命名假設 commit 1/2 已落地（rebuild reason `daemon_restart_recovery` 已存在）。
+每 commit 後跑全套 `go test ./...` 確保 0 regression。
 
 ---
 
@@ -227,13 +289,15 @@ if stored.ParentFrameID != "" {
 
 | 項目 | 估計行數 |
 |---|---|
-| `frame_ops.go` — `tryRebuildFromProcessTree` + `RebuildResult` + applyFrameEvent insertion | +90 / -3 |
-| `frame_ops_test.go` — R1-R7 + N1-N3 | +280 |
+| `probe.go` — `FirstAliveAgentInTree` + `identifierOrder` 維護 | +50 / -2 |
+| `probe_test.go` — P1-P5 | +120 |
+| `frame_ops.go` — `tryRebuildFromProcessTree` + applyFrameEvent insertion + reason rename | +70 / -5 |
+| `frame_ops_test.go` — R1-R3, R5-R8, N1-N3 | +280 |
 | `handler_test.go` — I1-I3 | +120 |
-| 整合測試 helper（stub Prober + descendants） | +50 |
-| 文件（本 plan） | ~600 |
-| **Total code 淨增** | **~540** |
-| **Total（含 plan）** | **~1140** |
+| 整合測試 helper（stub Prober interface） | +50 |
+| 文件（本 plan v2） | ~700 |
+| **Total code 淨增** | **~690** |
+| **Total（含 plan）** | **~1390** |
 
 ---
 
@@ -254,14 +318,15 @@ if stored.ParentFrameID != "" {
 
 ## 6. 風險與護欄
 
-### 6.1 `Prober.Identify` 跨 provider 順序
+### 6.1 `FirstAliveAgentInTree` 跨 provider 順序
 
 **風險**：cc / codex / opencode 三家若同時 match 同 PID（例如 cc 內呼 codex），rebuild 取的不一定是 hook event 的真正 owner。
 
 **護欄**：
-- registry 註冊順序文件化（首登記者優先）；本 phase 不改既有註冊順序
+- `Prober.identifierOrder` slice 維護註冊順序（§1.2.3），保證 iteration deterministic
+- 既有 module init 註冊順序保持不變（cc → codex → opencode；本 phase 不改）
 - Rebuild 結果僅用於 trace 標記 + 證實 process tree 中該家 agent alive；frame.AgentType 仍取 `req.AgentType`（hook event 是 SOT）
-- 若 rebuilt.AgentType ≠ req.AgentType（mismatch），記入 trace meta `reason="daemon_restart_recovery_mismatch"`（**追加分支**）— Phase 3 觀察用，未來資料統計足夠多再決定行為
+- **不追蹤 mismatch**（v1→v2 codex P3 fix 後簡化）：若 `matchedAgentType ≠ req.AgentType`，本 phase 信任 hook event、丟棄 rebuild 結果中的 type 資訊；mismatch corner case 留 Phase 4/5 處理（Inspector 出現後再評估資料統計需求）
 
 ### 6.2 `cachedDescendants` 250ms cache 可能 stale
 
@@ -310,30 +375,40 @@ if stored.ParentFrameID != "" {
 ## 8. Review focus 預期（Round 1 standard）
 
 可能被抓到（已預先處理）：
-- ✅ rebuild fail-soft 不吞錯（log + fall through，§6.3）
-- ✅ Identify 跨 provider 順序文件化（§6.1）
-- ✅ reason 改名 grep guard（§6.4 + commit 3 第一步）
+- ✅ rebuild fail-soft 不吞錯（log + fall through，§6.3 + R8 測試）
+- ✅ Identifier 跨 provider 順序穩定性（§1.2.3 + §6.1 + P5 測試）
+- ✅ reason 改名 grep guard（§6.4 + commit 4 第一步）
 - ✅ SubagentRef 不重建決策論述（§1.3）
 - ✅ Phase 2 0 regression 顯式驗證（R7）
+- ✅ Package boundary 修正（§1.6 「有限改動」+ §1.2.1 新 public method；v1→v2 codex P2 fix）
+- ✅ Mismatch reason 不引入第四態（§6.1 + v1→v2 codex P3 fix）
 
 可能被抓到（待 review 看）：
-- rebuild 命中時 `RebuildResult.AgentType` 與 `req.AgentType` mismatch 的處理是否完整（§6.1 提到追加 trace reason，但細節留 review）
 - I1/I2/I3 測試的 stub Prober 是否真實 emulate 了 daemon 重啟條件（測試 fixture 的真實度）
-- `Prober.Identify` 是否被 export 到 module package（package boundary）
+- `Prober.FirstAliveAgentInTree` 介面 vs frame_ops 透過 interface 抽象（dependency inversion 是否需做）
+- `identifierOrder` slice 與 `identifiers` map 雙寫的並發安全（既有 RegisterIdentifier 是否有 mutex）
 
 ---
 
 ## 9. 相關檔案速查
 
-- 主改動：`internal/module/agent/frame_ops.go`（applyFrameEvent + 新 helper）
-- 主測試：`internal/module/agent/frame_ops_test.go` + `handler_test.go`
-- 既有依賴：
-  - `internal/agent/probe/probe.go` — `Prober.Identify(agentType, pid)`
-  - `internal/agent/probe/liveness.go` — `cachedDescendants(target, panePID)` + `ProcessStartTime` + `IsPidAlive`
+- 主改動：
+  - `internal/agent/probe/probe.go`（新 `FirstAliveAgentInTree` + `identifierOrder`）
+  - `internal/module/agent/frame_ops.go`（applyFrameEvent insertion + helper + reason rename）
+- 主測試：
+  - `internal/agent/probe/probe_test.go`（P1-P5）
+  - `internal/module/agent/frame_ops_test.go`（R1-R3, R5-R8, N1-N3）
+  - `internal/module/agent/handler_test.go`（I1-I3）
+- 既有依賴（不改）：
+  - `internal/agent/probe/probe.go` — `RegisterIdentifier` / `IsAliveFor` 既有行為不變
+  - `internal/agent/probe/liveness.go` — `cachedDescendants(target, panePID)` 私有 method 透過新 public method 走
+  - `internal/agent/{cc,codex,opencode}/provider.go` — `Identify(ProcessInfo) bool` 既有
   - `internal/agent/registry.go` — provider 註冊順序
   - `internal/store/frames.go` — `Upsert` / `GetByIdentity` / `FindByPanePID`
   - `internal/module/agent/trace.go` — `hookTraceCollector.Frame()` 自動寫 reason
 - Spec / Discussion：
   - `docs/specs/2026-04-23-lights-rebuild-spec.md` §7
   - `docs/research/2026-04-22-lights-rebuild-discussion.md`（架構討論）
-- Codex consulting：job `af47a0fd51ca6667e`（2026-04-25 high-effort architectural review）
+- Codex consulting：
+  - architectural review job `af47a0fd51ca6667e`（2026-04-25 high-effort）— 設計依據
+  - plan v1 review job — 抓 P2 package boundary + P3 reason contract，全採納（§0.4）

--- a/internal/agent/probe/liveness.go
+++ b/internal/agent/probe/liveness.go
@@ -40,7 +40,23 @@ var (
 // non-first sibling. ActivePanePID uses `tmux display-message -p -t <target>
 // '#{pane_pid}'`, which honors pane id targets exactly. (PR #638 codex
 // review round 1 P2 fix.)
-func (p *Prober) FirstAliveAgentInTree(target string) (string, int, error) {
+//
+// Panic safety: provider Identify functions are user-supplied; a panic from
+// readProcessInfoFn or identify() is caught at the per-call boundary and
+// treated as a no-match for that PID (walk continues to other PIDs and other
+// identifiers). The outer function is also wrapped in a top-level recover
+// that converts any uncaught panic into an error so the caller (Phase 3
+// rebuild path) can fail-soft to no_parent_fallback rather than crashing the
+// hook handler. (PR #638 codex review round 2 #2 fix.)
+func (p *Prober) FirstAliveAgentInTree(target string) (matchedType string, matchedPID int, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			matchedType = ""
+			matchedPID = 0
+			err = fmt.Errorf("FirstAliveAgentInTree panic: %v", r)
+		}
+	}()
+
 	if p.tmux == nil {
 		return "", 0, nil
 	}
@@ -89,22 +105,42 @@ func (p *Prober) FirstAliveAgentInTree(target string) (string, int, error) {
 	// Iterate identifiers in registration order; for each, scan all candidates
 	// and return on first match. Guarantees deterministic first-match-wins
 	// when multiple identifiers recognize the same PID.
+	//
+	// Per-call panic recovery: identify() is user-supplied (provider plugin),
+	// and readProcessInfoFn touches /proc — both can panic in pathological
+	// inputs. Catching here lets the walk continue to other PIDs / agent
+	// types instead of crashing the hook handler.
 	for _, agentType := range order {
 		identify, ok := identifiers[agentType]
 		if !ok || identify == nil {
 			continue
 		}
 		for _, pid := range candidates {
-			info, infoErr := readProcessInfoFn(pid)
-			if infoErr != nil {
-				continue
-			}
-			if identify(info) {
+			if matched := safeIdentifyPID(identify, pid); matched {
 				return agentType, pid, nil
 			}
 		}
 	}
 	return "", 0, nil
+}
+
+// safeIdentifyPID runs readProcessInfoFn + identify under a recover so a
+// panic in either is treated as a no-match for this PID. Returns false on
+// any error or panic; true only when identify(info) returns true.
+func safeIdentifyPID(identify IdentifyFunc, pid int) (matched bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Panic during identify or process info read — treat as no-match
+			// and let the outer walk try the next PID/identifier. Logged at
+			// the rebuild caller boundary, not here, to avoid spamming.
+			matched = false
+		}
+	}()
+	info, infoErr := readProcessInfoFn(pid)
+	if infoErr != nil {
+		return false
+	}
+	return identify(info)
 }
 
 // IsAliveFor checks whether the tmux target's pane PID tree contains a process

--- a/internal/agent/probe/liveness.go
+++ b/internal/agent/probe/liveness.go
@@ -32,12 +32,20 @@ var (
 // agent_type after daemon restart, when the hook event's lookup chain
 // (GetByIdentity → findProxyParent → FindByPanePID) all miss; the caller is
 // expected to fail-soft on errors.
+//
+// Pane PID resolution: uses ActivePanePID rather than PanePID. PanePID is
+// implemented via `tmux list-panes -t <target>`, which resolves a pane id
+// target (e.g. `%5`) to its containing window and then returns the FIRST
+// pane's PID — wrong for multi-pane windows where the hook came from a
+// non-first sibling. ActivePanePID uses `tmux display-message -p -t <target>
+// '#{pane_pid}'`, which honors pane id targets exactly. (PR #638 codex
+// review round 1 P2 fix.)
 func (p *Prober) FirstAliveAgentInTree(target string) (string, int, error) {
 	if p.tmux == nil {
 		return "", 0, nil
 	}
 
-	panePIDRaw, err := p.tmux.PanePID(target)
+	panePIDRaw, err := p.tmux.ActivePanePID(target)
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/agent/probe/liveness.go
+++ b/internal/agent/probe/liveness.go
@@ -18,6 +18,87 @@ var (
 	listProcessTreeFn = listProcessTree
 )
 
+// FirstAliveAgentInTree walks the tmux target's pane PID descendant tree and
+// returns the agent type of the first descendant matched by any registered
+// identifier (iterated in registry insertion order). Returns ("", 0, nil) when
+// no descendant matches any identifier.
+//
+// Honors the same 250ms descendant cache as IsAliveFor (delegates to
+// cachedDescendants internally).
+//
+// Errors (tmux PanePID failure, pane PID parse failure, descendants query
+// failure) are propagated to the caller — unlike IsAliveFor which swallows
+// them. Used by frame_ops.tryRebuildFromProcessTree (Phase 3) to recover frame
+// agent_type after daemon restart, when the hook event's lookup chain
+// (GetByIdentity → findProxyParent → FindByPanePID) all miss; the caller is
+// expected to fail-soft on errors.
+func (p *Prober) FirstAliveAgentInTree(target string) (string, int, error) {
+	if p.tmux == nil {
+		return "", 0, nil
+	}
+
+	panePIDRaw, err := p.tmux.PanePID(target)
+	if err != nil {
+		return "", 0, err
+	}
+	panePID, err := strconv.Atoi(strings.TrimSpace(panePIDRaw))
+	if err != nil {
+		return "", 0, fmt.Errorf("parse pane pid %q: %w", panePIDRaw, err)
+	}
+	if panePID <= 0 {
+		return "", 0, fmt.Errorf("invalid pane pid %d", panePID)
+	}
+
+	p.livenessMu.Lock()
+	p.pruneExpiredDescendantCacheLocked(p.now())
+	p.livenessMu.Unlock()
+
+	descendants, err := p.cachedDescendants(target, panePID)
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Snapshot ordered identifiers under registry lock to avoid holding the
+	// lock while running user-supplied identify funcs.
+	p.registryMu.RLock()
+	order := append([]string(nil), p.identifierOrder...)
+	identifiers := make(map[string]IdentifyFunc, len(p.identifiers))
+	for k, v := range p.identifiers {
+		identifiers[k] = v
+	}
+	p.registryMu.RUnlock()
+
+	if len(order) == 0 {
+		return "", 0, nil
+	}
+
+	// Candidate PIDs: panePID first, then its recursive descendants (matches
+	// IsAliveFor behavior).
+	candidates := make([]int, 0, len(descendants)+1)
+	candidates = append(candidates, panePID)
+	candidates = append(candidates, descendants...)
+
+	// Iterate identifiers in registration order; for each, scan all candidates
+	// and return on first match. Guarantees deterministic first-match-wins
+	// when multiple identifiers recognize the same PID.
+	for _, agentType := range order {
+		identify, ok := identifiers[agentType]
+		if !ok || identify == nil {
+			continue
+		}
+		for _, pid := range candidates {
+			info, infoErr := readProcessInfoFn(pid)
+			if infoErr != nil {
+				continue
+			}
+			if identify(info) {
+				return agentType, pid, nil
+			}
+		}
+	}
+	return "", 0, nil
+}
+
 // IsAliveFor checks whether the tmux target's pane PID tree contains a process
 // identified as the given agent type.
 func (p *Prober) IsAliveFor(agentType, target string) bool {

--- a/internal/agent/probe/liveness_test.go
+++ b/internal/agent/probe/liveness_test.go
@@ -318,6 +318,42 @@ func TestFirstAliveAgentInTree_RegistryOrder(t *testing.T) {
 	}
 }
 
+// TestFirstAliveAgentInTree_UsesActivePanePID is a regression guard for
+// PR #638 codex review round 1 P2: FirstAliveAgentInTree must resolve the
+// pane PID via ActivePanePID (which uses `tmux display-message` and honors
+// pane id targets exactly) rather than PanePID (which uses `tmux list-panes`
+// that resolves a pane id target to its containing window and returns the
+// FIRST listed pane — wrong for multi-pane windows where the hook came from
+// a non-first sibling pane).
+//
+// Setup: distinct PanePID (100) and ActivePanePID (200) for the same target.
+// Identifier matches PID 200 only. If the implementation regresses to PanePID,
+// it will probe pid=100 (sibling pane), find no match, and return ("", 0, nil).
+func TestFirstAliveAgentInTree_UsesActivePanePID(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	fake.SetPanePID("%5", "100")       // would-be wrong PID (list-panes first row sibling)
+	fake.SetActivePanePID("%5", "200") // correct PID (display-message of pane %5)
+	p := New(fake)
+	p.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool {
+		return info.PID == 200
+	})
+	stubLivenessSeams(t)
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, ExePath: "/bin/irrelevant"}, nil
+	}
+	listProcessTreeFn = func() (map[int][]int, error) {
+		return map[int][]int{200: {}}, nil
+	}
+
+	agentType, pid, err := p.FirstAliveAgentInTree("%5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agentType != "cc" || pid != 200 {
+		t.Fatalf("expected (cc, 200, nil) proving ActivePanePID path; got (%q, %d, %v) — regression to PanePID would yield (\"\", 0, nil)", agentType, pid, err)
+	}
+}
+
 func TestRegisterIdentifier_PreservesOrder(t *testing.T) {
 	p := New(tmux.NewFakeExecutor())
 	p.RegisterIdentifier("codex", func(info agentpkg.ProcessInfo) bool { return false })

--- a/internal/agent/probe/liveness_test.go
+++ b/internal/agent/probe/liveness_test.go
@@ -208,3 +208,142 @@ func TestRegisterIdentifier_ReplacesExisting(t *testing.T) {
 		t.Fatal("expected alive after identifier replacement")
 	}
 }
+
+// --- FirstAliveAgentInTree tests (Phase 3 Commit 1) ---
+
+func TestFirstAliveAgentInTree_HitFirstMatch(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	fake.SetPanePID("sess:", "100")
+	p := New(fake)
+	p.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool {
+		return info.ExePath == "/usr/local/bin/claude"
+	})
+	stubLivenessSeams(t)
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, ExePath: "/bin/zsh"}, nil
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, ExePath: "/usr/local/bin/claude"}, nil
+		case 300:
+			return agentpkg.ProcessInfo{PID: 300, ExePath: "/bin/cat"}, nil
+		default:
+			return agentpkg.ProcessInfo{}, fmt.Errorf("unexpected pid %d", pid)
+		}
+	}
+	listProcessTreeFn = func() (map[int][]int, error) {
+		return map[int][]int{100: {200, 300}}, nil
+	}
+
+	agentType, pid, err := p.FirstAliveAgentInTree("sess:")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agentType != "cc" || pid != 200 {
+		t.Fatalf("expected (cc, 200, nil), got (%q, %d, %v)", agentType, pid, err)
+	}
+}
+
+func TestFirstAliveAgentInTree_NoMatch(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	fake.SetPanePID("sess:", "100")
+	p := New(fake)
+	p.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool {
+		return info.ExePath == "/usr/local/bin/claude"
+	})
+	stubLivenessSeams(t)
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, ExePath: "/bin/zsh"}, nil
+	}
+	listProcessTreeFn = func() (map[int][]int, error) {
+		return map[int][]int{100: {200}}, nil
+	}
+
+	agentType, pid, err := p.FirstAliveAgentInTree("sess:")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agentType != "" || pid != 0 {
+		t.Fatalf("expected (\"\", 0, nil), got (%q, %d, %v)", agentType, pid, err)
+	}
+}
+
+func TestFirstAliveAgentInTree_DescendantsError(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	fake.SetPanePID("sess:", "100")
+	p := New(fake)
+	p.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool { return true })
+	stubLivenessSeams(t)
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, ExePath: "/bin/zsh"}, nil
+	}
+	listProcessTreeFn = func() (map[int][]int, error) {
+		return nil, fmt.Errorf("ps failed")
+	}
+
+	agentType, pid, err := p.FirstAliveAgentInTree("sess:")
+	if err == nil {
+		t.Fatal("expected error from descendants query failure")
+	}
+	if agentType != "" || pid != 0 {
+		t.Fatalf("expected (\"\", 0, err), got (%q, %d, %v)", agentType, pid, err)
+	}
+}
+
+func TestFirstAliveAgentInTree_RegistryOrder(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	fake.SetPanePID("sess:", "100")
+	p := New(fake)
+	// Both cc and codex identifiers match PID 200; cc registered first.
+	p.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool {
+		return info.PID == 200
+	})
+	p.RegisterIdentifier("codex", func(info agentpkg.ProcessInfo) bool {
+		return info.PID == 200
+	})
+	stubLivenessSeams(t)
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, ExePath: "/bin/irrelevant"}, nil
+	}
+	listProcessTreeFn = func() (map[int][]int, error) {
+		return map[int][]int{100: {200}}, nil
+	}
+
+	agentType, pid, err := p.FirstAliveAgentInTree("sess:")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agentType != "cc" || pid != 200 {
+		t.Fatalf("expected (cc, 200, nil) due to registration order, got (%q, %d, %v)", agentType, pid, err)
+	}
+}
+
+func TestRegisterIdentifier_PreservesOrder(t *testing.T) {
+	p := New(tmux.NewFakeExecutor())
+	p.RegisterIdentifier("codex", func(info agentpkg.ProcessInfo) bool { return false })
+	p.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool { return false })
+	p.RegisterIdentifier("opencode", func(info agentpkg.ProcessInfo) bool { return false })
+
+	want := []string{"codex", "cc", "opencode"}
+	got := p.identifierOrderSnapshot()
+	if len(got) != len(want) {
+		t.Fatalf("expected %d identifiers, got %d (%v)", len(want), len(got), got)
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Fatalf("expected order[%d]=%q, got %q (full: %v)", i, name, got[i], got)
+		}
+	}
+
+	// Re-register existing identifier: order must not change.
+	p.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool { return false })
+	got = p.identifierOrderSnapshot()
+	if len(got) != len(want) {
+		t.Fatalf("re-register should not grow order; got %v", got)
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Fatalf("re-register changed order at [%d]: expected %q got %q (full: %v)", i, name, got[i], got)
+		}
+	}
+}

--- a/internal/agent/probe/liveness_test.go
+++ b/internal/agent/probe/liveness_test.go
@@ -2,6 +2,7 @@ package probe
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -351,6 +352,71 @@ func TestFirstAliveAgentInTree_UsesActivePanePID(t *testing.T) {
 	}
 	if agentType != "cc" || pid != 200 {
 		t.Fatalf("expected (cc, 200, nil) proving ActivePanePID path; got (%q, %d, %v) — regression to PanePID would yield (\"\", 0, nil)", agentType, pid, err)
+	}
+}
+
+// TestFirstAliveAgentInTree_IdentifierPanic_RecoveredAsNoMatch verifies that
+// a panic from a provider's Identify function is caught at the per-call
+// boundary (safeIdentifyPID) and treated as a no-match — the walk continues
+// to other PIDs and other identifiers, rather than crashing through to the
+// hook handler. Regression guard for PR #638 codex review round 2 #2.
+func TestFirstAliveAgentInTree_IdentifierPanic_RecoveredAsNoMatch(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	fake.SetPanePID("sess:", "100")
+	p := New(fake)
+	// First identifier panics on every PID; should not crash, walk continues.
+	p.RegisterIdentifier("buggy", func(info agentpkg.ProcessInfo) bool {
+		panic("simulated provider Identify panic")
+	})
+	// Second identifier matches PID=200 — must still be reachable after
+	// the buggy identifier panics on all PIDs.
+	p.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool {
+		return info.PID == 200
+	})
+	stubLivenessSeams(t)
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid}, nil
+	}
+	listProcessTreeFn = func() (map[int][]int, error) {
+		return map[int][]int{100: {200}}, nil
+	}
+
+	agentType, pid, err := p.FirstAliveAgentInTree("sess:")
+	if err != nil {
+		t.Fatalf("unexpected error after identifier panic: %v", err)
+	}
+	if agentType != "cc" || pid != 200 {
+		t.Fatalf("expected (cc, 200, nil) — walk should continue past panicking identifier; got (%q, %d, %v)", agentType, pid, err)
+	}
+}
+
+// TestFirstAliveAgentInTree_TopLevelPanic_BecomesError verifies the outer
+// defer recover converts an uncaught panic (e.g. from cachedDescendants
+// internals) into an error so the rebuild caller can fail-soft instead of
+// panicking through to the hook handler. Regression guard for PR #638
+// codex review round 2 #2 (outer boundary).
+func TestFirstAliveAgentInTree_TopLevelPanic_BecomesError(t *testing.T) {
+	fake := tmux.NewFakeExecutor()
+	fake.SetPanePID("sess:", "100")
+	p := New(fake)
+	p.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool { return false })
+	stubLivenessSeams(t)
+	// listProcessTreeFn panics — bypasses the per-call safeIdentifyPID
+	// recovery and would crash the hook handler without the outer defer.
+	listProcessTreeFn = func() (map[int][]int, error) {
+		panic("simulated process tree query panic")
+	}
+
+	agentType, pid, err := p.FirstAliveAgentInTree("sess:")
+	if err == nil {
+		t.Fatal("expected error from top-level panic recovery")
+	}
+	if agentType != "" || pid != 0 {
+		t.Fatalf("expected (\"\", 0, err); got (%q, %d, %v)", agentType, pid, err)
+	}
+	// err message should mention panic for caller diagnostics
+	if !strings.Contains(err.Error(), "panic") {
+		t.Errorf("expected error message to mention panic, got %q", err.Error())
 	}
 }
 

--- a/internal/agent/probe/probe.go
+++ b/internal/agent/probe/probe.go
@@ -36,9 +36,10 @@ type IdentifyFunc func(agent.ProcessInfo) bool
 type Prober struct {
 	tmux tmux.Executor
 
-	registryMu  sync.RWMutex
-	identifiers map[string]IdentifyFunc     // agentType → identify
-	readiness   map[string]ReadinessChecker // agentType → checker
+	registryMu      sync.RWMutex
+	identifiers     map[string]IdentifyFunc     // agentType → identify
+	identifierOrder []string                    // insertion order of identifier registrations (FirstAliveAgentInTree relies on this for deterministic first-match; Go map iteration is unordered)
+	readiness       map[string]ReadinessChecker // agentType → checker
 
 	livenessMu      sync.Mutex
 	descendantCache map[string]descendantCacheEntry // target → recursive descendant snapshot
@@ -67,8 +68,20 @@ func New(tmux tmux.Executor) *Prober {
 
 func (p *Prober) RegisterIdentifier(agentType string, identify IdentifyFunc) {
 	p.registryMu.Lock()
+	if _, exists := p.identifiers[agentType]; !exists {
+		p.identifierOrder = append(p.identifierOrder, agentType)
+	}
 	p.identifiers[agentType] = identify
 	p.registryMu.Unlock()
+}
+
+// identifierOrderSnapshot returns a copy of the registered identifier names in
+// insertion order. Used by tests and by FirstAliveAgentInTree to iterate
+// deterministically.
+func (p *Prober) identifierOrderSnapshot() []string {
+	p.registryMu.RLock()
+	defer p.registryMu.RUnlock()
+	return append([]string(nil), p.identifierOrder...)
 }
 
 // RegisterReadiness registers a ReadinessChecker for a given agent type.

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -676,6 +676,44 @@ func (m *Module) detachProxyRefWithRetry(owner store.Frame, senderPID int, sende
 	return false, store.Frame{}, fmt.Errorf("proxy detach: exceeded %d retries for frame %s", proxyUpsertMaxAttempts, owner.FrameID)
 }
 
+// firstAliveAgentInTreeFn is the test seam that indirects
+// Prober.FirstAliveAgentInTree so tryRebuildFromProcessTree can be exercised
+// without a wired-up prober (m.prober is nil in newTestModule). Mirrors the
+// pattern of readProcessInfoFn / isPidAliveFn / processStartTimeFn declared in
+// verify.go — unit tests override the package-level variable and restore it
+// via t.Cleanup.
+var firstAliveAgentInTreeFn = func(m *Module, target string) (string, int, error) {
+	if m == nil || m.prober == nil {
+		return "", 0, nil
+	}
+	return m.prober.FirstAliveAgentInTree(target)
+}
+
+// tryRebuildFromProcessTree attempts to recover a frame after daemon restart
+// by inspecting the pane's live process tree via the Prober. Triggered when
+// the standard lookup chain (GetByIdentity → findProxyParent → FindByPanePID)
+// all miss on a SessionStart (Phase 3 plan §1.2.2).
+//
+// Behavior:
+//   - Delegates to prober.FirstAliveAgentInTree(req.TmuxPaneID)
+//   - Match → returns (agentType, true, nil)
+//   - No match → returns ("", false, nil)
+//   - Any error → returns ("", false, err); caller is expected to fail-soft
+//
+// Unwired in Commit 2: applyFrameEvent does not yet call this helper — that
+// wiring lands in Commit 3, which also introduces the reason_code contract
+// for the rebuild path.
+func (m *Module) tryRebuildFromProcessTree(req EventRequest) (string, bool, error) {
+	agentType, _, err := firstAliveAgentInTreeFn(m, req.TmuxPaneID)
+	if err != nil {
+		return "", false, err
+	}
+	if agentType == "" {
+		return "", false, nil
+	}
+	return agentType, true, nil
+}
+
 // findProxyParent walks the sender's PPID ancestor chain (capped at
 // proxyMaxDepth) looking for an alive, identity-verified, cross-type frame in
 // the same pane. See plan §1.4 for full contract.

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"log"
 	"sort"
 	"time"
 
@@ -227,6 +228,31 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		}
 	}
 
+	// Phase 3 Commit 3 — daemon-restart recovery (plan §1.2.4 / §1.4):
+	// When the standard lookup chain (GetByIdentity → findProxyParent →
+	// FindByPanePID) all miss on a hook event, fall back to inspecting the
+	// pane's live process tree via the Prober. A hit means "some agent we
+	// know is alive somewhere under this pane" — enough to recover frame
+	// state lost to a daemon restart without trusting the hook event blindly
+	// (the hook's AgentType remains the SOT; rebuild only marks the trace
+	// reason so the Inspector can distinguish recovered frames from fresh
+	// ones).
+	//
+	// Fail-soft: a probe error must not abort the hook. Log and fall through
+	// to the legacy no-parent path (reason="parent_frame_missing" today;
+	// renamed to "no_parent_fallback" in Commit 4).
+	rebuiltMatched := false
+	if frame == nil && parentFrameID == "" {
+		matchedType, ok, rerr := m.tryRebuildFromProcessTree(req)
+		if rerr != nil {
+			log.Printf("[agent] rebuild_from_process_tree_failed: pane=%s err=%v", req.TmuxPaneID, rerr)
+		}
+		if ok {
+			rebuiltMatched = true
+			_ = matchedType // req.AgentType is SOT; matched type is diagnostic only
+		}
+	}
+
 	status := result.Status
 	if status == "" && frame != nil {
 		status = frame.Status
@@ -291,9 +317,15 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		}
 	}
 	projection, err := m.projectPane(req.TmuxPaneID)
+	// Phase 3 Commit 3 — three-state reason (plan §1.4):
+	//   parent_frame_found       → legacy lookup hit (line 220-228)
+	//   daemon_restart_recovery  → rebuild via process tree hit
+	//   parent_frame_missing     → fallback (renamed to no_parent_fallback in Commit 4)
 	reason := "parent_frame_missing"
 	if stored.ParentFrameID != "" {
 		reason = "parent_frame_found"
+	} else if rebuiltMatched {
+		reason = "daemon_restart_recovery"
 	}
 	decision := "created_frame"
 	if frame != nil {

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -239,8 +239,7 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 	// ones).
 	//
 	// Fail-soft: a probe error must not abort the hook. Log and fall through
-	// to the legacy no-parent path (reason="parent_frame_missing" today;
-	// renamed to "no_parent_fallback" in Commit 4).
+	// to the降階 no-parent path (reason="no_parent_fallback", see plan §1.4).
 	rebuiltMatched := false
 	if frame == nil && parentFrameID == "" {
 		matchedType, ok, rerr := m.tryRebuildFromProcessTree(req)
@@ -317,11 +316,13 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		}
 	}
 	projection, err := m.projectPane(req.TmuxPaneID)
-	// Phase 3 Commit 3 — three-state reason (plan §1.4):
+	// Phase 3 — three-state reason (plan §1.4):
 	//   parent_frame_found       → legacy lookup hit (line 220-228)
-	//   daemon_restart_recovery  → rebuild via process tree hit
-	//   parent_frame_missing     → fallback (renamed to no_parent_fallback in Commit 4)
-	reason := "parent_frame_missing"
+	//   daemon_restart_recovery  → rebuild via process tree hit (commit 3)
+	//   no_parent_fallback       → all lookups + rebuild missed; frame still
+	//                              created using req.AgentType as SOT (commit 4).
+	// The Inspector uses these to distinguish recovered frames from降階 ones.
+	reason := "no_parent_fallback"
 	if stored.ParentFrameID != "" {
 		reason = "parent_frame_found"
 	} else if rebuiltMatched {

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -32,6 +32,18 @@ type FrameTraceMeta struct {
 	Reason        string
 	Before        any
 	After         any
+	// MatchedAgentType is set on the daemon_restart_recovery path when
+	// tryRebuildFromProcessTree confirms an alive agent in the pane process
+	// tree. Empty otherwise. Carries the agent family that the live process
+	// matched, which may differ from req.AgentType (the hook event's
+	// declared agent_type) — divergence is the diagnostic signal Phase 3
+	// rebuild path is meant to surface.
+	//
+	// PR #638 codex review round 2 #3 fix: previously the matched type was
+	// dropped silently (`_ = matchedType`), making rebuild trace unable to
+	// distinguish "rebuild confirmed hook owner" vs "rebuild only saw a
+	// different agent in the same pane (e.g. cc parent of a codex hook)".
+	MatchedAgentType string
 }
 
 func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult, broadcastTs int64) (*SessionProjection, FrameTraceMeta, error) {
@@ -241,6 +253,7 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 	// Fail-soft: a probe error must not abort the hook. Log and fall through
 	// to the降階 no-parent path (reason="no_parent_fallback", see plan §1.4).
 	rebuiltMatched := false
+	rebuiltAgentType := ""
 	if frame == nil && parentFrameID == "" {
 		matchedType, ok, rerr := m.tryRebuildFromProcessTree(req)
 		if rerr != nil {
@@ -248,7 +261,13 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		}
 		if ok {
 			rebuiltMatched = true
-			_ = matchedType // req.AgentType is SOT; matched type is diagnostic only
+			// req.AgentType remains the SOT for frame.AgentType (the hook
+			// event is authoritative). matchedType is preserved separately
+			// for trace diagnostics — divergence (e.g. cc pane with codex
+			// hook) is the signal Inspector / Phase 5 reparent uses to
+			// triage suspected proxy collapse failures. (PR #638 codex
+			// review round 2 #3 fix.)
+			rebuiltAgentType = matchedType
 		}
 	}
 
@@ -333,12 +352,13 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		decision = "updated_frame"
 	}
 	return projection, FrameTraceMeta{
-		FrameID:       stored.FrameID,
-		ParentFrameID: stored.ParentFrameID,
-		Decision:      decision,
-		Reason:        reason,
-		Before:        before,
-		After:         summarizeFrame(&stored),
+		FrameID:          stored.FrameID,
+		ParentFrameID:    stored.ParentFrameID,
+		Decision:         decision,
+		Reason:           reason,
+		Before:           before,
+		After:            summarizeFrame(&stored),
+		MatchedAgentType: rebuiltAgentType,
 	}, err
 }
 

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -1741,4 +1741,224 @@ var errProbeFailure = errorString("probe tree query failed")
 
 type errorString string
 
+// ---------------------------------------------------------------------------
+// Rebuild wiring into applyFrameEvent (Phase 3 Commit 3, plan §1.2.4 / §1.4)
+// ---------------------------------------------------------------------------
+//
+// Tests override firstAliveAgentInTreeFn directly (same pattern as the
+// helper-level tests above) and arrange the standard lookup chain to miss so
+// the rebuild fallback is the only path that can satisfy the event.
+
+// R5 — rebuild命中、既有 lookup chain 全 miss → trace reason daemon_restart_recovery.
+func TestApplyFrameEvent_RebuildHit_TraceReason(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	// Arrange proc info so readProcessInfoFn returns a PPID that doesn't
+	// resolve to any seeded frame (FindByPanePID miss). No frames seeded →
+	// GetByIdentity miss + findProxyParent miss (no ancestor frame).
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "cc", 200, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 500)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "daemon_restart_recovery" {
+		t.Fatalf("reason = %q, want daemon_restart_recovery (meta=%+v)", meta.Reason, meta)
+	}
+	if meta.Decision != "created_frame" {
+		t.Fatalf("decision = %q, want created_frame", meta.Decision)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (new frame created post-rebuild)", len(frames))
+	}
+	if frames[0].AgentType != "cc" {
+		t.Fatalf("AgentType = %q, want cc (req.AgentType is SOT)", frames[0].AgentType)
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("Subagents = %+v, want empty (rebuild does not restore refs)", frames[0].Subagents)
+	}
+}
+
+// R6 — rebuild 命中 → 接著 SubagentStart 仍正確累積 ref（驗證 native path 不壞）.
+func TestApplyFrameEvent_RebuildHit_ThenSubagentStart(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "cc", 200, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	startReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 200, SenderStartTime: "t200"}
+	if _, meta, err := m.applyFrameEvent(startReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 500); err != nil {
+		t.Fatalf("rebuild SessionStart: %v", err)
+	} else if meta.Reason != "daemon_restart_recovery" {
+		t.Fatalf("rebuild SessionStart reason = %q, want daemon_restart_recovery", meta.Reason)
+	}
+
+	// After rebuild frame exists with subagents=[]; SubagentStart should
+	// append a native ref via mutateSubagentsWithRetry (happy path).
+	subReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SubagentStart", AgentType: "cc", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(subReq, agentpkg.DeriveResult{Valid: true, Detail: map[string]any{"agent_id": "sub-1"}}, 600)
+	if err != nil {
+		t.Fatalf("SubagentStart: %v", err)
+	}
+	if meta.Decision != "updated_frame" || meta.Reason != "subagent_membership_changed" {
+		t.Fatalf("SubagentStart meta = %q/%q, want updated_frame/subagent_membership_changed", meta.Decision, meta.Reason)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+	if len(frames[0].Subagents) != 1 {
+		t.Fatalf("Subagents len = %d, want 1 (native ref accumulated after rebuild)", len(frames[0].Subagents))
+	}
+	if frames[0].Subagents[0].ID != "sub-1" {
+		t.Fatalf("Subagents[0].ID = %q, want sub-1", frames[0].Subagents[0].ID)
+	}
+}
+
+// R7 — SessionStart 走 findProxyParent 命中 → rebuild 不被呼叫（spy guard）.
+func TestApplyFrameEvent_ProxyHit_SkipsRebuild(t *testing.T) {
+	m := newProxyTestModule(t)
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origStart := processStartTimeFn
+	origAlive := isPidAliveFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		processStartTimeFn = origStart
+		isPidAliveFn = origAlive
+	})
+
+	origSeam := firstAliveAgentInTreeFn
+	rebuildCalls := 0
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		rebuildCalls++
+		return "cc", 200, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "proxy_subagent_attached" {
+		t.Fatalf("reason = %q, want proxy_subagent_attached (PR-2b path)", meta.Reason)
+	}
+	if rebuildCalls != 0 {
+		t.Fatalf("rebuild seam called %d times, want 0 (proxy hit should short-circuit)", rebuildCalls)
+	}
+}
+
+// R8 — rebuild err → fail-soft → falls through to parent_frame_missing reason.
+func TestApplyFrameEvent_RebuildErrorFailsSoft(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "", 0, errProbeFailure
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 500)
+	if err != nil {
+		t.Fatalf("applyFrameEvent err = %v, want nil (fail-soft)", err)
+	}
+	// Commit 3 stage: reason is still "parent_frame_missing"; commit 4
+	// renames this to "no_parent_fallback".
+	if meta.Reason != "parent_frame_missing" {
+		t.Fatalf("reason = %q, want parent_frame_missing (rebuild err → fail-soft)", meta.Reason)
+	}
+	if meta.Decision != "created_frame" {
+		t.Fatalf("decision = %q, want created_frame", meta.Decision)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (fallback path still creates frame)", len(frames))
+	}
+}
+
+// N3 — parent 命中時 rebuild helper 不被呼叫（spy guard for FindByPanePID hit）.
+func TestApplyFrameEvent_RebuildSkipped_WhenParentFound(t *testing.T) {
+	m := newProxyTestModule(t)
+	// Seed a cc parent frame with PID 100.
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	// readProcessInfo returns PPID=100 so FindByPanePID(%5, 100) hits the
+	// seeded frame. Liveness stubs don't matter for FindByPanePID path.
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		// sender pid 300 maps up to cc parent via PPID chain.
+		if pid == 300 {
+			return agentpkg.ProcessInfo{PID: 300, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	// processStartTime/isPidAlive not overridden because we want findProxyParent
+	// to miss on liveness (parent.PID 100 is not alive under default stubs in
+	// newTestModule: isPidAliveFn=true but processStartTimeFn returns the
+	// default "Sun Apr 20 01:30:00 2026" which != seed "t100"). So proxy path
+	// bails, and we land in the non-proxy FindByPanePID lookup at line 221-228.
+
+	origSeam := firstAliveAgentInTreeFn
+	rebuildCalls := 0
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		rebuildCalls++
+		return "", 0, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 300, SenderStartTime: "t300"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 500)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "parent_frame_found" {
+		t.Fatalf("reason = %q, want parent_frame_found (FindByPanePID hit)", meta.Reason)
+	}
+	if rebuildCalls != 0 {
+		t.Fatalf("rebuild seam called %d times, want 0 (parent found short-circuits)", rebuildCalls)
+	}
+}
+
 func (e errorString) Error() string { return string(e) }

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -1791,6 +1791,73 @@ func TestApplyFrameEvent_RebuildHit_TraceReason(t *testing.T) {
 	}
 }
 
+// R9 — rebuild 命中時 meta.MatchedAgentType 設為 prober 回的 agent type
+// （等於 req.AgentType 的同家情境）。PR #638 codex review round 2 #3 fix
+// 的 unit-level guard：previously matchedType 被丟棄；現在保留進 trace
+// payload 給 Inspector / Phase 5 reparent 用。
+func TestApplyFrameEvent_RebuildHit_MetaIncludesMatchedAgentType(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "cc", 200, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 500)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.MatchedAgentType != "cc" {
+		t.Fatalf("MatchedAgentType = %q, want cc (rebuild matched cc, same family as hook)", meta.MatchedAgentType)
+	}
+	if meta.Reason != "daemon_restart_recovery" {
+		t.Fatalf("reason = %q, want daemon_restart_recovery", meta.Reason)
+	}
+}
+
+// R10 — rebuild 命中時 matched type 與 hook event AgentType 不同（mismatch
+// 場景，e.g. cc pane 跑 codex hook 但只 cc alive）。frame.AgentType 仍取
+// req.AgentType（hook event 是 SOT），但 meta.MatchedAgentType 帶 rebuild
+// 看到的真實 type — 給 Inspector / Phase 5 reparent loop 觸發 proxy collapse
+// 補正用。PR #638 codex review round 2 #3 fix 的 mismatch 路徑 guard。
+func TestApplyFrameEvent_RebuildHit_MismatchedTypePreservedInMeta(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		// rebuild 看到 pane 內 cc alive，但 hook event 是 codex（典型 mismatch）
+		return "cc", 200, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 300, SenderStartTime: "t300"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 500)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.MatchedAgentType != "cc" {
+		t.Fatalf("MatchedAgentType = %q, want cc (preserved diagnostic, even when ≠ req.AgentType)", meta.MatchedAgentType)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "codex" {
+		t.Fatalf("frame.AgentType = %v, want codex (req.AgentType remains SOT despite mismatch)", frames)
+	}
+}
+
 // R6 — rebuild 命中 → 接著 SubagentStart 仍正確累積 ref（驗證 native path 不壞）.
 func TestApplyFrameEvent_RebuildHit_ThenSubagentStart(t *testing.T) {
 	m := newProxyTestModule(t)

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -1650,3 +1650,95 @@ func TestSessionEnd_OwnFrameDeletePreservesOtherProxyRefs(t *testing.T) {
 		t.Fatalf("frame count = %d, want 0 (cc frame deleted)", len(frames))
 	}
 }
+
+// --- tryRebuildFromProcessTree tests (Phase 3 Commit 2) ---
+//
+// The helper delegates to Prober.FirstAliveAgentInTree via the
+// firstAliveAgentInTreeFn seam (sibling of readProcessInfoFn / isPidAliveFn /
+// processStartTimeFn in verify.go). Tests override the seam directly, so they
+// don't need m.prober to be wired up — same pattern as every other frame_ops
+// test that stubs a probe-layer dependency.
+
+func TestTryRebuildFromProcessTree_Hit(t *testing.T) {
+	m := newTestModule(t)
+
+	origSeam := firstAliveAgentInTreeFn
+	var gotTarget string
+	firstAliveAgentInTreeFn = func(_ *Module, target string) (string, int, error) {
+		gotTarget = target
+		return "cc", 200, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxPaneID: "%5", SenderPID: 200, SenderStartTime: "t200"}
+	agentType, ok, err := m.tryRebuildFromProcessTree(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if agentType != "cc" {
+		t.Fatalf("agentType = %q, want cc", agentType)
+	}
+	if gotTarget != "%5" {
+		t.Fatalf("seam target = %q, want %%5 (pane id)", gotTarget)
+	}
+}
+
+func TestTryRebuildFromProcessTree_Miss(t *testing.T) {
+	m := newTestModule(t)
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "", 0, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxPaneID: "%5", SenderPID: 200, SenderStartTime: "t200"}
+	agentType, ok, err := m.tryRebuildFromProcessTree(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("ok = true, want false (no match)")
+	}
+	if agentType != "" {
+		t.Fatalf("agentType = %q, want empty", agentType)
+	}
+}
+
+func TestTryRebuildFromProcessTree_Error(t *testing.T) {
+	m := newTestModule(t)
+
+	origSeam := firstAliveAgentInTreeFn
+	wantErr := errProbeFailure
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "", 0, wantErr
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxPaneID: "%5", SenderPID: 200, SenderStartTime: "t200"}
+	agentType, ok, err := m.tryRebuildFromProcessTree(req)
+	if err == nil {
+		t.Fatalf("err = nil, want non-nil")
+	}
+	if err != wantErr {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if ok {
+		t.Fatalf("ok = true, want false on error")
+	}
+	if agentType != "" {
+		t.Fatalf("agentType = %q, want empty on error", agentType)
+	}
+}
+
+// errProbeFailure is a sentinel used by TestTryRebuildFromProcessTree_Error to
+// verify that the helper propagates the probe's error verbatim (caller
+// fail-soft).
+var errProbeFailure = errorString("probe tree query failed")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -1881,7 +1881,9 @@ func TestApplyFrameEvent_ProxyHit_SkipsRebuild(t *testing.T) {
 	}
 }
 
-// R8 — rebuild err → fail-soft → falls through to parent_frame_missing reason.
+// R8 — rebuild err → fail-soft → falls through to no_parent_fallback reason.
+// (Commit 4 renamed the terminal fallback reason to make the降階 explicit;
+// see plan §1.4 for the three-state contract.)
 func TestApplyFrameEvent_RebuildErrorFailsSoft(t *testing.T) {
 	m := newProxyTestModule(t)
 
@@ -1902,10 +1904,8 @@ func TestApplyFrameEvent_RebuildErrorFailsSoft(t *testing.T) {
 	if err != nil {
 		t.Fatalf("applyFrameEvent err = %v, want nil (fail-soft)", err)
 	}
-	// Commit 3 stage: reason is still "parent_frame_missing"; commit 4
-	// renames this to "no_parent_fallback".
-	if meta.Reason != "parent_frame_missing" {
-		t.Fatalf("reason = %q, want parent_frame_missing (rebuild err → fail-soft)", meta.Reason)
+	if meta.Reason != "no_parent_fallback" {
+		t.Fatalf("reason = %q, want no_parent_fallback (rebuild err → fail-soft)", meta.Reason)
 	}
 	if meta.Decision != "created_frame" {
 		t.Fatalf("decision = %q, want created_frame", meta.Decision)
@@ -1913,6 +1913,50 @@ func TestApplyFrameEvent_RebuildErrorFailsSoft(t *testing.T) {
 	frames, _ := m.frames.ListByPane("%5")
 	if len(frames) != 1 {
 		t.Fatalf("frame count = %d, want 1 (fallback path still creates frame)", len(frames))
+	}
+}
+
+// N1 (Commit 4) — rebuild returns silent miss ("", 0, nil): all lookup and
+// rebuild paths miss without error → trace reason = no_parent_fallback.
+// Distinguishes the "probe succeeded but found no alive agent" path from the
+// "probe errored out" path (R8). Both end in the same降階 reason, but via
+// different code branches — N1 is the dominant production path when a daemon
+// restart hits a pane whose agent has genuinely exited before the hook fires.
+func TestApplyFrameEvent_NoParentFallback_TraceReason(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "", 0, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 500)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "no_parent_fallback" {
+		t.Fatalf("reason = %q, want no_parent_fallback (silent rebuild miss)", meta.Reason)
+	}
+	if meta.Decision != "created_frame" {
+		t.Fatalf("decision = %q, want created_frame", meta.Decision)
+	}
+	if meta.ParentFrameID != "" {
+		t.Fatalf("ParentFrameID = %q, want empty (降階 path has no parent)", meta.ParentFrameID)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (fallback still creates frame)", len(frames))
+	}
+	if frames[0].AgentType != "cc" {
+		t.Fatalf("AgentType = %q, want cc (req.AgentType is SOT)", frames[0].AgentType)
 	}
 }
 

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -2204,3 +2204,74 @@ func TestHandleEvent_DaemonRestart_RebuildRecoversForExistingPane(t *testing.T) 
 		t.Errorf("Subagents[0].ID = %q, want sub-1", framesAfter[0].Subagents[0].ID)
 	}
 }
+
+// I3 (Commit 4) — Mid-connection gone integration: frames table is empty and
+// the rebuild seam returns a silent miss ("", 0, nil). The handler still
+// accepts the SessionStart hook and creates a frame using req.AgentType as
+// the SOT, but the trace chain records reason="no_parent_fallback" to mark
+// the降階 path explicitly. Complements I1/I2 (rebuild hit → daemon_restart_
+// recovery) by exercising the cold-path fallback end-to-end through the
+// HTTP handler.
+func TestHandleEvent_MidConnectionGone_NoParentFallback(t *testing.T) {
+	m := rebuildIntegrationModule(t)
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "", 0, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"cc"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body=%s), want 200", w.Code, w.Body.String())
+	}
+
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (降階 still creates frame from hook)", len(frames))
+	}
+	if frames[0].AgentType != "cc" {
+		t.Errorf("AgentType = %q, want cc (hook event AgentType is SOT on降階)", frames[0].AgentType)
+	}
+	if frames[0].ParentFrameID != "" {
+		t.Errorf("ParentFrameID = %q, want empty (no_parent_fallback has no parent)", frames[0].ParentFrameID)
+	}
+
+	page := waitForTraceChains(t, m, "work", 1)
+	if len(page.Chains) != 1 {
+		t.Fatalf("chain count = %d, want 1", len(page.Chains))
+	}
+	record, err := m.traces.GetChainRecord(page.Chains[0].ChainID)
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	var frameStep *store.TraceStep
+	for i := range record.Steps {
+		if record.Steps[i].Kind == "frame" {
+			frameStep = &record.Steps[i]
+			break
+		}
+	}
+	if frameStep == nil {
+		t.Fatalf("no frame-kind step in chain (steps=%+v)", record.Steps)
+	}
+	if frameStep.Reason != "no_parent_fallback" {
+		t.Errorf("frame step reason = %q, want no_parent_fallback", frameStep.Reason)
+	}
+	if frameStep.Decision != "created_frame" {
+		t.Errorf("frame step decision = %q, want created_frame", frameStep.Decision)
+	}
+	if frameStep.FrameID != frames[0].FrameID {
+		t.Errorf("frame step FrameID = %q, want %q", frameStep.FrameID, frames[0].FrameID)
+	}
+	if frameStep.ParentFrameID != "" {
+		t.Errorf("frame step ParentFrameID = %q, want empty", frameStep.ParentFrameID)
+	}
+}

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -2036,3 +2036,171 @@ func TestHandleEvent_ProxyBroadcastCarriesIsProxyTrue(t *testing.T) {
 		t.Fatal("timed out waiting for proxy broadcast")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Rebuild wiring — handler-level integration (Phase 3 Commit 3, plan §2.3)
+// ---------------------------------------------------------------------------
+
+// rebuildIntegrationModule sets up the minimum wiring required to exercise the
+// rebuild fallback end-to-end through handleEvent: cc provider, fake tmux +
+// session provider, broadcaster, prober (so the unit-level seam path mirrors
+// production).
+func rebuildIntegrationModule(t *testing.T) *Module {
+	t.Helper()
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.prober = probe.New(fakeTmux)
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive:   func(string, json.RawMessage) agentpkg.DeriveResult { return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle} },
+	})
+	return m
+}
+
+// I1 — Cold-start handler integration: empty frames table + rebuild stub hit +
+// SessionStart hook → DB gets a new frame row + reason=daemon_restart_recovery
+// recorded in the chain + broadcast carries the new frame_id (subagents empty).
+func TestHandleEvent_ColdStart_RebuildRecovers(t *testing.T) {
+	m := rebuildIntegrationModule(t)
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "cc", 200, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	// newTestModule stubs readProcessInfoFn to return PPID=1, so the default
+	// lookup chain misses naturally: GetByIdentity → nil (empty DB),
+	// findProxyParent → nil (no ancestor frame), FindByPanePID(pane, 1) → nil.
+
+	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"cc"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body=%s), want 200", w.Code, w.Body.String())
+	}
+
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (rebuild created new frame)", len(frames))
+	}
+	if frames[0].AgentType != "cc" {
+		t.Errorf("AgentType = %q, want cc", frames[0].AgentType)
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Errorf("Subagents = %+v, want empty (rebuild does not restore refs)", frames[0].Subagents)
+	}
+
+	page := waitForTraceChains(t, m, "work", 1)
+	if len(page.Chains) != 1 {
+		t.Fatalf("chain count = %d, want 1", len(page.Chains))
+	}
+	record, err := m.traces.GetChainRecord(page.Chains[0].ChainID)
+	if err != nil {
+		t.Fatalf("GetChainRecord: %v", err)
+	}
+	var frameStep *store.TraceStep
+	for i := range record.Steps {
+		if record.Steps[i].Kind == "frame" {
+			frameStep = &record.Steps[i]
+			break
+		}
+	}
+	if frameStep == nil {
+		t.Fatalf("no frame-kind step in chain (steps=%+v)", record.Steps)
+	}
+	if frameStep.Reason != "daemon_restart_recovery" {
+		t.Errorf("frame step reason = %q, want daemon_restart_recovery", frameStep.Reason)
+	}
+	if frameStep.Decision != "created_frame" {
+		t.Errorf("frame step decision = %q, want created_frame", frameStep.Decision)
+	}
+	if frameStep.FrameID != frames[0].FrameID {
+		t.Errorf("frame step FrameID = %q, want %q", frameStep.FrameID, frames[0].FrameID)
+	}
+}
+
+// I2 — Daemon restart simulation: a pane's hook fires after the frames table
+// was wiped (simulated by not pre-seeding anything) and the rebuild seam
+// confirms the agent is alive. Like I1 but emphasizes the "existing pane"
+// semantics — the frame gets rebuilt with subagents=[] regardless of whatever
+// refs existed pre-restart.
+func TestHandleEvent_DaemonRestart_RebuildRecoversForExistingPane(t *testing.T) {
+	m := rebuildIntegrationModule(t)
+
+	origSeam := firstAliveAgentInTreeFn
+	firstAliveAgentInTreeFn = func(_ *Module, _ string) (string, int, error) {
+		return "cc", 200, nil
+	}
+	t.Cleanup(func() { firstAliveAgentInTreeFn = origSeam })
+
+	// Fire SessionStart for an "existing" pane (daemon restart scenario:
+	// pane was already running cc, the daemon came back up, hook arrives).
+	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SessionStart","raw_event":{},"agent_type":"cc"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body=%s), want 200", w.Code, w.Body.String())
+	}
+
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (rebuild recovered the pane)", len(frames))
+	}
+	rebuiltFrameID := frames[0].FrameID
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("Subagents = %+v, want empty after rebuild (refs re-accumulate via hooks)", frames[0].Subagents)
+	}
+
+	// Now a SubagentStart hook arrives post-rebuild — ref must accumulate.
+	subBody := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"SubagentStart","raw_event":{},"agent_type":"cc"}`
+	// Need a provider that emits agent_id for SubagentStart.
+	m.registry = agentpkg.NewRegistry()
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive: func(event string, _ json.RawMessage) agentpkg.DeriveResult {
+			if event == "SubagentStart" {
+				return agentpkg.DeriveResult{Valid: true, Detail: map[string]any{"agent_id": "sub-1"}}
+			}
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+		},
+	})
+	subReq := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(subBody))
+	subReq.Header.Set("Content-Type", "application/json")
+	subW := httptest.NewRecorder()
+	m.handleEvent(subW, subReq)
+	if subW.Code != http.StatusOK {
+		t.Fatalf("SubagentStart status = %d (body=%s), want 200", subW.Code, subW.Body.String())
+	}
+
+	framesAfter, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane after SubagentStart: %v", err)
+	}
+	if len(framesAfter) != 1 {
+		t.Fatalf("frame count = %d, want 1 (no duplicate frames)", len(framesAfter))
+	}
+	if framesAfter[0].FrameID != rebuiltFrameID {
+		t.Errorf("FrameID changed after SubagentStart: %q → %q", rebuiltFrameID, framesAfter[0].FrameID)
+	}
+	if len(framesAfter[0].Subagents) != 1 {
+		t.Fatalf("Subagents len = %d, want 1 (native ref accumulated)", len(framesAfter[0].Subagents))
+	}
+	if framesAfter[0].Subagents[0].ID != "sub-1" {
+		t.Errorf("Subagents[0].ID = %q, want sub-1", framesAfter[0].Subagents[0].ID)
+	}
+}

--- a/internal/module/agent/trace.go
+++ b/internal/module/agent/trace.go
@@ -170,6 +170,25 @@ func (c *hookTraceCollector) Frame(req EventRequest, meta FrameTraceMeta) {
 	if c == nil || meta.Decision == "" {
 		return
 	}
+	// Phase 3: when daemon_restart_recovery hits, merge matched_agent_type
+	// into the `after` payload so Inspector / Phase 5 reparent can detect
+	// divergence between hook event AgentType (req.AgentType) and the
+	// agent family the live process tree confirmed (meta.MatchedAgentType).
+	// Equal values mean rebuild confirmed the hook owner; divergent values
+	// mean the pane has a different alive agent (e.g. cc parent of a codex
+	// hook) — diagnostic signal for proxy collapse failures.
+	// (PR #638 codex review round 2 #3 fix.)
+	after := meta.After
+	if meta.MatchedAgentType != "" {
+		if afterMap, ok := after.(map[string]any); ok {
+			merged := make(map[string]any, len(afterMap)+1)
+			for k, v := range afterMap {
+				merged[k] = v
+			}
+			merged["matched_agent_type"] = meta.MatchedAgentType
+			after = merged
+		}
+	}
 	c.frameStepID = c.append(
 		c.verifyStepID,
 		"frame",
@@ -181,7 +200,7 @@ func (c *hookTraceCollector) Frame(req EventRequest, meta FrameTraceMeta) {
 		meta.Reason,
 		req,
 		meta.Before,
-		meta.After,
+		after,
 	)
 }
 


### PR DESCRIPTION
## Summary

Lights rebuild Phase 3（spec §7 L1 邊界補強）。`applyFrameEvent` fallback chain 末端補回 + `no_parent_fallback` reason 顯式化。單 PR / 6 commits（2 plan docs + 4 TDD code）/ 7 code files / +1313 net。

## Phase 3 兩件事

### A. Daemon 後啟動補回（hook-triggered lazy rebuild）

當 hook event 進來但 `GetByIdentity → findProxyParent → FindByPanePID` 全失敗時，從 pane PID descendant tree 推回 agent_type，避免 daemon 重啟後既有 cc/codex/opencode session 在 SPA 顯示空白。

- 新 `Prober.FirstAliveAgentInTree(target)` public method（與 `IsAliveFor` 同型）— 內部 `cachedDescendants` + ordered identifier iteration
- 新 `Prober.identifierOrder []string` slice — 註冊順序穩定（Go map iteration 無序），first-match-wins 規則 deterministic
- `mutateSubagentsWithRetry` 共用 lock 安全：snapshot pattern（rlock 取 order + identifier map → unlock → 跑 user identify funcs，避免持鎖外呼）
- 新 `Module.tryRebuildFromProcessTree(req)` helper — 委派 Prober；fail-soft（err 不阻 hook）
- `applyFrameEvent` line 228 後接線：rebuild 命中 → trace reason `daemon_restart_recovery`；不重建 SubagentRef（`Subagents=[]`，由後續 SubagentStart hook 自然累積）；rebuild 信任 hook event AgentType 為 SOT，丟棄 matched type

### B. `no_parent_fallback` reason 顯式化

frame fallback chain 末端「降階用 hook event agent_type 為基準」原本隱含為 reason `parent_frame_missing`。升級為 `no_parent_fallback`，為 Phase 4/5 reparent loop / Inspector 鋪資料邊界。

三態 reason 完整定義：
- `parent_frame_found` — legacy `FindByPanePID` 命中
- `daemon_restart_recovery` — Phase 3 rebuild 命中
- `no_parent_fallback` — 都未命中、降階用 hook agent_type

## Plan & Review 軌跡

- **Architectural consulting**（job `af47a0fd51ca6667e`，high-effort）— 確立 hook-triggered lazy rebuild 對齊 K8s controller reconciliation / Chrome DevTools target discovery「重連先 enumerate 再接 event」pattern；採 Q4 stale 判定 `pane+PID+startTime+descendants`；採 Q5 `no_parent_fallback` trace 升格為 future reparent 資料邊界；不採 Q1 SPA unreconciled state（Phase 5）/ Q3 SPA on-demand inventory（Phase 5）/ Q4 同 session 廉價掃（YAGNI 無消費端）
- **Plan review round 1** — codex 抓 P2（package boundary：`cachedDescendants` 私有 + `Prober.Identify` 不存在）+ P3（reason contract 矛盾），全採納修進 v2
- **Plan review round 2** — 0 findings，ship-ready

## TDD Commits（4 棒）

| # | Commit | 範圍 | 測試 |
|---|---|---|---|
| 1 | `feat(probe): FirstAliveAgentInTree + ordered identifiers` | Prober 新 method + identifierOrder slice + snapshot lock | P1-P5 |
| 2 | `feat(agent): tryRebuildFromProcessTree helper (unwired)` | frame_ops helper + test seam pkg-level var（沿用 verify.go pattern） | R1-R3 |
| 3 | `feat(agent): wire rebuild into applyFrameEvent fallback chain` | applyFrameEvent insertion + 三態 reason（含 daemon_restart_recovery） + log.Printf fail-soft | R5/R6/R7/R8/N3 + I1/I2 |
| 4 | `refactor(agent): no_parent_fallback reason explicit` | reason 字串改名 + grep guard（production code 無殘留） | N1/N2/I3 |

## Tests

- 18 新測試：probe P1-P5 / frame_ops R1-R3 + R5-R8 + N1-N3 / handler_test.go I1-I3
- `go build/vet/test ./...` 全綠（23 packages，含 stream 70s）
- PR-2b proxy walk 路徑 0 regression（R7 spy guard call count == 0）
- grep `'\"parent_frame_missing\"'` production code 空（commit 4 grep guard）

## Reviewer 重點

- §1.2.3 `identifierOrder` 與 `identifiers` map 雙寫的 mutex 設計（`registryMu` 共用、snapshot pattern 避免 user func 持鎖）
- §1.2.4 接線位置在 PR-2b proxy walk **之後**（line 228 後）— 確保 proxy 命中時 rebuild 不被呼叫（R7 spy 守）
- §1.4 三態 reason 完整定義 + commit 3 與 commit 4 的 reason rename 拆分（commit 3 階段 reason 仍為 parent_frame_missing，commit 4 才 rename — 每 commit main 綠）
- §6.1 mismatch 不追蹤決策（codex P3 簡化）
- §6.3 fail-soft：rebuild err 走 `log.Printf` warn + fall through，不返錯
- I1/I2/I3 整合測試 stub 真實度（透過 `firstAliveAgentInTreeFn` pkg-level seam override）

## Manual verification（merge 前由 reviewer 跑）

- daemon 重啟 → 既有 cc session pane 按 enter → SPA 顯示 frame
- daemon 重啟 + cc 內 `/codex:*` → proxy 仍正確掛回 cc.Subagents（PR-2b 路徑不破）
- SQL `select decision, reason, count(*) from agent_trace_steps where kind='frame' group by 1,2` 可看到三態 reason

## 不做（明列）

- ❌ SPA `unreconciled` state UI（Phase 5）
- ❌ SPA on-demand inventory query（Phase 5）
- ❌ `tmux.ListPanesForSession` helper（YAGNI）
- ❌ 既有 frame stale check（Phase 4/5）
- ❌ SubagentRef rebuild（lazy 由 hook 補）
- ❌ Periodic poll reconciliation
- ❌ Reparent loop（reason `no_parent_fallback` 已鋪資料邊界，loop 留 Phase 5）

## Plan ref

`docs/specs/2026-04-25-lights-rebuild-phase-3-plan.md`

## Test plan

- [x] `go build/vet/test ./...` 全綠（23 packages）
- [x] 18 新測試全綠
- [x] PR-2b 既有測試 0 regression
- [x] grep guard 確認 production code 無 `parent_frame_missing` 殘留
- [x] Plan review round 1 收斂（P2/P3）+ round 2 0 findings
- [ ] 手動驗收 3 情境（merge 前 reviewer 跑）
- [ ] Codex code review round 1（PR 開後派發）