### PR TITLE
fix(spa): keep activity bar home fixed

### DIFF
--- a/spa/src/components/HoverTooltip.test.tsx
+++ b/spa/src/components/HoverTooltip.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { HoverTooltip } from './HoverTooltip'
 
 describe('HoverTooltip', () => {
@@ -13,36 +13,37 @@ describe('HoverTooltip', () => {
     expect(screen.getByText('Hello world')).toBeInTheDocument()
   })
 
-  it('supports placement=top (absolute bottom-full)', () => {
+  it('supports placement=top', () => {
     render(
       <div className="relative group">
         <HoverTooltip placement="top">top tip</HoverTooltip>
       </div>
     )
     const el = screen.getByText('top tip')
-    expect(el.className).toContain('bottom-full')
+    expect(el).toHaveAttribute('data-placement', 'top')
   })
 
-  it('defaults to placement=right (absolute left-full)', () => {
+  it('defaults to placement=right', () => {
     render(
       <div className="relative group">
         <HoverTooltip>r tip</HoverTooltip>
       </div>
     )
     const el = screen.getByText('r tip')
-    expect(el.className).toContain('left-full')
+    expect(el).toHaveAttribute('data-placement', 'right')
   })
 
-  it('includes fade-on-hover classes (opacity-0 + group-hover:opacity-100 + transition-opacity)', () => {
+  it('includes fade classes and becomes visible when parent is hovered', () => {
     render(
-      <div className="relative group">
+      <div data-testid="trigger" className="relative group">
         <HoverTooltip>fade</HoverTooltip>
       </div>
     )
     const el = screen.getByText('fade')
     expect(el.className).toMatch(/\bopacity-0\b/)
-    expect(el.className).toMatch(/\bgroup-hover:opacity-100\b/)
     expect(el.className).toMatch(/\btransition-opacity\b/)
+    fireEvent.mouseEnter(screen.getByTestId('trigger'))
+    expect(el.className).toMatch(/\bopacity-100\b/)
   })
 
   it('has role="tooltip" for screen readers', () => {
@@ -52,5 +53,21 @@ describe('HoverTooltip', () => {
       </div>
     )
     expect(screen.getByText('a11y').getAttribute('role')).toBe('tooltip')
+  })
+
+  it('renders through document.body so overflow ancestors cannot clip it', () => {
+    const { container } = render(
+      <div className="overflow-x-auto">
+        <div data-testid="trigger" className="relative group">
+          <HoverTooltip>portal tip</HoverTooltip>
+        </div>
+      </div>
+    )
+    const tooltip = screen.getByText('portal tip')
+    expect(container.contains(tooltip)).toBe(false)
+    expect(document.body.contains(tooltip)).toBe(true)
+    fireEvent.mouseEnter(screen.getByTestId('trigger'))
+    expect(tooltip.className).toContain('fixed')
+    expect(tooltip.className).toContain('opacity-100')
   })
 })

--- a/spa/src/components/HoverTooltip.tsx
+++ b/spa/src/components/HoverTooltip.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react'
+import { useCallback, useLayoutEffect, useState, type CSSProperties, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 
 export type HoverTooltipPlacement = 'top' | 'right'
 
@@ -8,23 +9,81 @@ interface Props {
   'data-testid'?: string
 }
 
-const PLACEMENTS: Record<HoverTooltipPlacement, string> = {
-  right: 'left-full ml-2 top-1/2 -translate-y-1/2',
-  top: 'bottom-full mb-2 left-1/2 -translate-x-1/2',
-}
+const HOVER_TOOLTIP_OFFSET = 8
 
-// HoverTooltip is a CSS-only tooltip that fades in when its parent has the
-// `.group` class and the user hovers. Extracted from the ActivityBarNarrow
-// ws-tooltip pattern; parent MUST have `class="relative group"`.
 export function HoverTooltip({ children, placement = 'right', 'data-testid': testId }: Props) {
-  const pos = PLACEMENTS[placement]
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null)
+  const [visible, setVisible] = useState(false)
+  const [style, setStyle] = useState<CSSProperties>({ top: 0, left: 0 })
+
+  const updatePosition = useCallback(() => {
+    if (!anchor) return
+    const rect = anchor.getBoundingClientRect()
+    if (placement === 'top') {
+      setStyle({
+        left: rect.left + rect.width / 2,
+        top: rect.top - HOVER_TOOLTIP_OFFSET,
+        transform: 'translate(-50%, -100%)',
+      })
+      return
+    }
+    setStyle({
+      left: rect.right + HOVER_TOOLTIP_OFFSET,
+      top: rect.top + rect.height / 2,
+      transform: 'translateY(-50%)',
+    })
+  }, [anchor, placement])
+
+  useLayoutEffect(() => {
+    if (!anchor) return
+    const show = () => {
+      updatePosition()
+      setVisible(true)
+    }
+    const hide = () => setVisible(false)
+    anchor.addEventListener('mouseenter', show)
+    anchor.addEventListener('mouseleave', hide)
+    anchor.addEventListener('focusin', show)
+    anchor.addEventListener('focusout', hide)
+    return () => {
+      anchor.removeEventListener('mouseenter', show)
+      anchor.removeEventListener('mouseleave', hide)
+      anchor.removeEventListener('focusin', show)
+      anchor.removeEventListener('focusout', hide)
+    }
+  }, [anchor, updatePosition])
+
+  useLayoutEffect(() => {
+    if (!visible) return
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
+    }
+  }, [visible, updatePosition])
+
+  const setMarkerRef = useCallback((node: HTMLSpanElement | null) => {
+    setAnchor(node?.parentElement ?? null)
+  }, [])
+  const marker = <span ref={setMarkerRef} hidden />
+  if (typeof document === 'undefined') return marker
+
   return (
-    <span
-      role="tooltip"
-      data-testid={testId}
-      className={`pointer-events-none absolute ${pos} whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg opacity-0 group-hover:opacity-100 transition-opacity z-50`}
-    >
-      {children}
-    </span>
+    <>
+      {marker}
+      {createPortal(
+        <span
+          role="tooltip"
+          data-testid={testId}
+          data-placement={placement}
+          className={`pointer-events-none fixed whitespace-nowrap rounded bg-surface-secondary border border-border-default px-2 py-1 text-xs text-text-primary shadow-lg transition-opacity z-50 ${visible ? 'opacity-100' : 'opacity-0'}`}
+          style={style}
+        >
+          {children}
+        </span>,
+        document.body,
+      )}
+    </>
   )
 }

--- a/spa/src/features/workspace/components/ActivityBarNarrow.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBarNarrow.test.tsx
@@ -19,4 +19,29 @@ describe('ActivityBarNarrow', () => {
     )
     expect(screen.getByTitle(/home/i)).toBeInTheDocument()
   })
+
+  it('keeps Home outside the workspace scroll region', () => {
+    const { container } = render(
+      <ActivityBarNarrow
+        workspaces={[
+          { id: 'w1', name: 'Purdex', tabs: [], activeTabId: null },
+          { id: 'w2', name: 'Client A', tabs: [], activeTabId: null },
+        ]}
+        activeWorkspaceId="w1"
+        activeStandaloneTabId={null}
+        onSelectWorkspace={() => {}}
+        onSelectHome={() => {}}
+        standaloneTabIds={[]}
+        onAddWorkspace={() => {}}
+        onOpenHosts={() => {}}
+        onOpenSettings={() => {}}
+      />,
+    )
+
+    const workspaceScroll = screen.getByTestId('activity-bar-workspace-scroll')
+    expect(workspaceScroll).toHaveClass('overflow-y-auto')
+    expect(screen.getByTitle(/home/i).closest('[data-testid="activity-bar-workspace-scroll"]')).toBeNull()
+    expect(container.querySelector('[data-testid="activity-bar-workspace-separator"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="activity-bar-workspace-separator"]')?.closest('[data-testid="activity-bar-workspace-scroll"]')).toBeNull()
+  })
 })

--- a/spa/src/features/workspace/components/ActivityBarNarrow.tsx
+++ b/spa/src/features/workspace/components/ActivityBarNarrow.tsx
@@ -133,8 +133,8 @@ export function ActivityBarNarrow({
   const isHomeActive = !activeWorkspaceId
   const showHomeBadge = (!isHomeActive || !!activeStandaloneTabId) && homeUnreadCount > 0
   return (
-    <div className="group/narrow-bar relative hidden lg:flex">
-      <div className="w-11 flex flex-col items-center bg-surface-tertiary border-r border-border-subtle py-2 px-px gap-2.5 flex-shrink-0">
+    <div className="group/narrow-bar relative hidden min-h-0 lg:flex">
+      <div className="w-11 flex min-h-0 flex-col items-center bg-surface-tertiary border-r border-border-subtle py-2 px-px gap-2.5 flex-shrink-0 overflow-hidden">
       {/* Home — standalone tabs */}
       <div className="relative group">
         {homeStatus && (!isHomeActive || !!activeStandaloneTabId) && (
@@ -173,27 +173,33 @@ export function ActivityBarNarrow({
         )}
       </div>
 
-      {workspaces.length > 0 && <div className="w-5 h-px bg-border-default my-0.5" />}
+      {workspaces.length > 0 && <div data-testid="activity-bar-workspace-separator" className="w-5 h-px bg-border-default my-0.5 shrink-0" />}
 
       {/* Workspaces — sortable */}
-      <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVertical]} onDragEnd={handleDragEnd}>
-        <SortableContext items={wsIds} strategy={verticalListSortingStrategy}>
-          <div ref={wsZoneRef} className="flex flex-col items-center gap-2.5">
-            {workspaces.map((ws) => (
-              <SortableWorkspaceButton
-                key={ws.id}
-                workspace={ws}
-                isActive={activeWorkspaceId === ws.id && !activeStandaloneTabId}
-                onSelect={onSelectWorkspace}
-                onContextMenu={onContextMenuWorkspace}
-              />
-            ))}
-          </div>
-        </SortableContext>
-      </DndContext>
+      <div
+        ref={wsZoneRef}
+        data-testid="activity-bar-workspace-scroll"
+        className="activity-bar-workspace-scroll min-h-0 w-full flex-1 overflow-x-hidden overflow-y-auto overscroll-contain py-px"
+      >
+        <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVertical]} onDragEnd={handleDragEnd}>
+          <SortableContext items={wsIds} strategy={verticalListSortingStrategy}>
+            <div className="flex flex-col items-center gap-2.5">
+              {workspaces.map((ws) => (
+                <SortableWorkspaceButton
+                  key={ws.id}
+                  workspace={ws}
+                  isActive={activeWorkspaceId === ws.id && !activeStandaloneTabId}
+                  onSelect={onSelectWorkspace}
+                  onContextMenu={onContextMenuWorkspace}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </div>
 
       {/* Add + Settings */}
-      <div className="mt-auto flex flex-col items-center gap-2 pb-1">
+      <div className="flex shrink-0 flex-col items-center gap-2 pb-1">
         <button
           title={t('nav.new_workspace')}
           onClick={onAddWorkspace}

--- a/spa/src/features/workspace/components/ActivityBarWide.test.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.test.tsx
@@ -68,6 +68,32 @@ describe('ActivityBarWide', () => {
     const handle = document.querySelector('[data-testid="activity-bar-resize"]')
     expect(handle).toBeInTheDocument()
   })
+
+  it('scrolls only the workspace region and keeps the divider fixed below Home', () => {
+    const { container } = render(
+      <ActivityBarWide
+        workspaces={[ws('w1', 'Purdex'), ws('w2', 'Client A')]}
+        activeWorkspaceId="w1"
+        activeStandaloneTabId={null}
+        onSelectWorkspace={() => {}}
+        onSelectHome={() => {}}
+        standaloneTabIds={[]}
+        onAddWorkspace={() => {}}
+        onOpenHosts={() => {}}
+        onOpenSettings={() => {}}
+      />,
+    )
+
+    const workspaceScroll = screen.getByTestId('activity-bar-workspace-scroll')
+    expect(workspaceScroll).toHaveClass('overflow-y-auto')
+    expect(screen.getByTestId('home-header').closest('[data-testid="activity-bar-workspace-scroll"]')).toBeNull()
+    expect(screen.getByTestId('ws-header-w1').closest('[data-testid="activity-bar-workspace-scroll"]')).toBe(workspaceScroll)
+    expect(container.querySelector('[data-testid="activity-bar-workspace-separator"]')?.closest('[data-testid="activity-bar-workspace-scroll"]')).toBeNull()
+
+    const activityBarRoot = workspaceScroll.closest('[data-testid="activity-bar-wide"]')
+    expect(activityBarRoot).not.toHaveClass('overflow-y-auto')
+    expect(activityBarRoot).toHaveClass('overflow-hidden')
+  })
 })
 
 describe('ActivityBarWide Phase 2 — inline tabs', () => {

--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -258,7 +258,8 @@ export function ActivityBarWide(props: ActivityBarProps) {
   return (
     <>
       <div
-        className="hidden lg:flex flex-col bg-surface-tertiary border-r border-border-subtle py-2 gap-0.5 flex-shrink-0 overflow-y-auto"
+        data-testid="activity-bar-wide"
+        className="hidden min-h-0 flex-col bg-surface-tertiary border-r border-border-subtle py-2 gap-0.5 flex-shrink-0 overflow-hidden lg:flex"
         style={{ width: renderedSize }}
       >
         <DndContext
@@ -282,35 +283,40 @@ export function ActivityBarWide(props: ActivityBarProps) {
           />
 
           {workspaces.length > 0 && (
-            <div className="mx-3 my-1 h-px bg-border-default" />
+            <div data-testid="activity-bar-workspace-separator" className="mx-3 my-1 h-px shrink-0 bg-border-default" />
           )}
 
-          <SortableContext items={wsIds} strategy={verticalListSortingStrategy}>
-            <div className="flex flex-col gap-0.5">
-              {workspaces.map((ws) => (
-                <WorkspaceRow
-                  key={ws.id}
-                  workspace={ws}
-                  isActive={
-                    activeWorkspaceId === ws.id && !activeStandaloneTabId
-                  }
-                  tabsById={tabsById}
-                  activeTabId={activeTabId}
-                  onSelectWorkspace={onSelectWorkspace}
-                  onContextMenuWorkspace={onContextMenuWorkspace}
-                  onSelectTab={selectTab}
-                  onCloseTab={closeTab}
-                  onMiddleClickTab={middleClickTab}
-                  onContextMenuTab={contextMenuTab}
-                  onRenameTab={renameTab}
-                  onAddTabToWorkspace={addTabToWs}
-                />
-              ))}
-            </div>
-          </SortableContext>
+          <div
+            data-testid="activity-bar-workspace-scroll"
+            className="activity-bar-workspace-scroll min-h-0 flex-1 overflow-y-auto overscroll-contain py-0.5"
+          >
+            <SortableContext items={wsIds} strategy={verticalListSortingStrategy}>
+              <div className="flex flex-col gap-0.5">
+                {workspaces.map((ws) => (
+                  <WorkspaceRow
+                    key={ws.id}
+                    workspace={ws}
+                    isActive={
+                      activeWorkspaceId === ws.id && !activeStandaloneTabId
+                    }
+                    tabsById={tabsById}
+                    activeTabId={activeTabId}
+                    onSelectWorkspace={onSelectWorkspace}
+                    onContextMenuWorkspace={onContextMenuWorkspace}
+                    onSelectTab={selectTab}
+                    onCloseTab={closeTab}
+                    onMiddleClickTab={middleClickTab}
+                    onContextMenuTab={contextMenuTab}
+                    onRenameTab={renameTab}
+                    onAddTabToWorkspace={addTabToWs}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </div>
         </DndContext>
 
-        <div className="mt-auto flex flex-col gap-1 px-2 pb-1 pt-2">
+        <div className="flex shrink-0 flex-col gap-1 px-2 pb-1 pt-2">
           <button
             title={t('nav.new_workspace')}
             onClick={onAddWorkspace}

--- a/spa/src/features/workspace/components/InlineTab.test.tsx
+++ b/spa/src/features/workspace/components/InlineTab.test.tsx
@@ -382,11 +382,7 @@ describe('InlineTab — statusline display', () => {
       />,
     )
     const tooltip = screen.getByTestId('inline-tab-tooltip')
-    // placement=right uses left-full (mirrors ActivityBarNarrow pattern).
-    // placement=top would use bottom-full, which can be clipped by the sidebar's
-    // vertical scroll container near the top edge.
-    expect(tooltip.className).toContain('left-full')
-    expect(tooltip.className).not.toContain('bottom-full')
+    expect(tooltip).toHaveAttribute('data-placement', 'right')
   })
 })
 

--- a/spa/src/index.css
+++ b/spa/src/index.css
@@ -30,6 +30,28 @@ button:disabled {
   display: none;
 }
 
+/* Activity bar workspace lists scroll independently from Home and footer actions. */
+.activity-bar-workspace-scroll {
+  scrollbar-color: color-mix(in srgb, var(--accent) 42%, transparent) transparent;
+  scrollbar-width: thin;
+}
+.activity-bar-workspace-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+.activity-bar-workspace-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.activity-bar-workspace-scroll::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 38%, transparent);
+  background-clip: content-box;
+  border: 2px solid transparent;
+  border-radius: 999px;
+}
+.activity-bar-workspace-scroll::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--accent) 58%, transparent);
+  background-clip: content-box;
+}
+
 /* Breathe animation for agent status dots — fade via opacity so the dot
    doesn't show a coloured block against icons or contrasting tab backgrounds. */
 @keyframes breathe {


### PR DESCRIPTION
## Summary
- Keep Home, the workspace divider, and footer actions fixed while only the workspace list scrolls in narrow and wide activity bars.
- Style the workspace scrollbar with Purdex theme tokens.
- Render tab tooltips through a body portal so top and activity-bar tab labels are not clipped by overflow containers.

## Verification
- pnpm --prefix spa exec vitest run src/components/HoverTooltip.test.tsx src/components/SortableTab.test.tsx src/features/workspace/components/InlineTab.test.tsx src/features/workspace/components/ActivityBar.test.tsx src/features/workspace/components/ActivityBarNarrow.test.tsx src/features/workspace/components/ActivityBarWide.test.tsx
- pnpm --prefix spa run lint
- pnpm --prefix spa run build