### PR TITLE
feat(agent): Phase 3.5a — cold-start proxy canonicalization (race fix + projection dedup + SessionEnd cleanup)

### DIFF
--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,9 +1,14 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v9 / Hybrid B+)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v10 / Hybrid B+)
 
 Baseline：`1.0.0-alpha.225`（main @ `92fb5d05`，Phase 3 已 merged）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`，已 rebase 上 `92fb5d05`）。
 Phase 3 PR #638：✅ squash-merged at `92fb5d05`（2026-04-26）。
 Bump 策略：本 PR 系列 + Phase 3 一起 bump **alpha.226**（注意：alpha.225 已被 parallel session 為 SPA tooltip 功能 PR #643 占用，與 Phase 3 無關）。
+
+**v9 → v10 由 PR-3.5a 第三輪 codex review 收斂**（§13；2 unique finding 全採納）：
+
+- **R1 high / round 3** — round 2 #Q1 fix（projection dedup 把 stateful child 留 visible）仍丟資訊：child 留 visible 後依 `StartedAt` 選 TopFrame，輸出只取單一 frame 的 `Subagents` 上 wire — child 較新→ parent 的 IsProxy ref 丟，parent 較新→ child 的 native ref 丟。**v10 修法**（C18）：dedup hide claimed standalones uniformly（不再 gate `len==0`），但 hide 階段把 stateful child 的 Subagents collect 起來，最後 merge 進 `projection.Subagents`（用既有 `subagentRefMatches` kind-aware identity dedup 避免重複）。最終 wire 同時保留 parent 的 IsProxy ref 與 child 的 native ref。PD4 改寫對齊新行為，新增 PD6（parent older）/ PD7（parent newer 平衡）/ PD8（merge dedup 邊界）。
+- **R2 medium / round 3** — round 2 #O3 fix（per-ref fail-safe in pruneDeadProxyRefs）被 sweepOnce 上層繞過：當 owner 自己的 `processStartTimeFn(frame.PID)` 回 error，原本 bare `continue` 把 frame 丟出 survivors → pane 不進 `pruneDeadProxyRefs` → 即便 proxy source 確認 dead 也清不到。**v10 修法**（C19）：owner read error 時把 frame 加入 survivors（保守視為仍存活，不觸發 pid_reused destructive cleanup），讓 pane 仍進 prune；per-ref fail-safe 自己決定是否 detach。新增 IT13d（read error 仍 prune dead source）/ IT14c（read error 不 destructive delete owner）。
 
 **v8 → v9 由 PR-3.5a 第二輪 codex review（standard + adversarial 三視角）收斂**（§13；5 unique finding 全採納）：
 
@@ -634,6 +639,8 @@ var (
 | IT18 | `existing_frame_session_start_skips_dead_proxy_during_reset` (v5 I1 negative) | (a) cc frame 已存在含 codex proxy ref，但 codex 進程已死（isPidAliveFn = false）；(b) cc SessionStart | reset 後 cc.Subagents 不含該 dead proxy ref（preserve 不通過 identity gate）|
 | IT19 | `existing_frame_session_start_skips_pid_reused_proxy` (v5 I1 negative) | (a) cc frame 含 codex proxy；(b) codex PID 已被 OS reuse（actualStart != ref.SourceStartTime）；(c) cc SessionStart | reset 後不 preserve 該 stale proxy（identity 不過 gate）|
 | IT20 | `existing_frame_session_start_preserves_concurrently_attached_proxy` (v6 J1) | (a) cc frame 已存在 + 一個 codex proxy ref；(b) cc SessionStart filter-merge attempt 1 — 同時 mock UpsertIfUnchanged 第 1 次回 conflict（模擬並發 child SessionStart 在 attempt 1 之間 attach 第二個 opencode proxy 並刪除其 standalone）；(c) attempt 2 reload 看到兩個 IsProxy ref，filter 通過 gate，UpsertIfUnchanged 成功 | cc.Subagents 含 codex 與 opencode 兩個 proxy ref；無 ref 在 race window 中遺失 |
+| IT13d | `sweep_prune_runs_when_owner_start_time_read_errors` (v10 R2) | (a) cc owner PID 200 with stale codex IsProxy ref（SourcePID 300 confirmed dead）；(b) `processStartTimeFn(200)` 回 transient error；(c) sweepOnce 跑 | pane 仍進 prune；codex IsProxy ref 被 detach；MetricSweepPrunedProxy +1 |
+| IT14c | `sweep_owner_read_error_preserves_frame` (v10 R2 boundary) | (a) cc owner PID 200, ProcessStartTime "A"；(b) `processStartTimeFn(200)` 持續 transient error；(c) sweepOnce 跑 | owner frame 完整保留（不被誤砍 pid_reused）；ProcessStartTime 仍 "A" |
 
 ### 3.2 Unit 測試
 
@@ -647,13 +654,18 @@ var (
 | RC4 | `canonicalizeDescendantsAfterUpsert_skips_same_type` |
 | RC5 | `canonicalizeDescendantsAfterUpsert_skips_pid_reuse_via_identity_gate` |
 
-`projection_test.go` 加 `PD1`-`PD3`：
+`projection_test.go` 加 `PD1`-`PD8`：
 
 | # | 名稱 |
 |---|---|
 | PD1 | `buildPaneProjection_dedup_excludes_proxy_claimed_standalone` |
 | PD2 | `buildPaneProjection_fallback_when_all_frames_claimed` |
 | PD3 | `buildPaneProjection_no_proxy_refs_unchanged_behavior` |
+| PD4 | `dedup_keeps_claimed_standalone_with_native_subagents`（v9 Q1，**v10 R1 改寫**：claimed child 仍 hide，但 Subagents merge 進 projection；TopFrame = parent + Subagents 含 proxy ref + merged native ref） |
+| PD5 | `dedup_still_hides_empty_standalone`（v9 Q1 boundary） |
+| PD6 | `dedup_merges_hidden_stateful_child_subagents`（v10 R1：parent older, child newer with native, hide + merge）|
+| PD7 | `dedup_merges_hidden_stateful_child_subagents_parent_newer`（v10 R1 對稱：parent newer, child older with native, merge 仍 run）|
+| PD8 | `dedup_merge_avoids_duplicate_proxy_ref`（v10 R1 boundary：same proxy identity 兩側都有 → merge dedup 後只一個 entry）|
 
 ### 3.3 不加的測試
 
@@ -866,25 +878,25 @@ func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 | `frame_ops.go` pidIsAncestorOfWithCap | ~20 行 |
 | `frame_ops.go` SessionEnd proxy cleanup | ~10 行（既有 case 改 4 行）|
 | `frame_ops.go` 接線 §2.2.1 + §2.2.2（v6 filter-merge-retry）| ~85 行 |
-| `projection.go` dedup | ~40 行 |
-| `sweep.go` canonicalizePane + findCanonicalAncestor + pruneDeadProxyRefs | ~140 行 |
+| `projection.go` dedup（含 v10 R1 hide-and-merge）| ~70 行 |
+| `sweep.go` canonicalizePane + findCanonicalAncestor + pruneDeadProxyRefs（含 v10 R2 owner-read-error survivor）| ~155 行 |
 | `frame_ops_test.go` RC1-RC5 unit | ~150 行 |
-| `projection_test.go` PD1-PD3 | ~80 行 |
-| `module_test.go` / new file IT1-IT20 integration | ~830-930 行 |
-| `sweep_test.go` 加 sweep canonicalize/prune 測試 | ~120 行 |
-| Plan docs（此檔 v6） | ~895 行 |
-| **總 net code（不含 plan docs）** | **~1620-1720 行** |
+| `projection_test.go` PD1-PD8 | ~280 行 |
+| `module_test.go` / new file IT1-IT22 + IT13d/IT14c integration | ~1000-1100 行 |
+| `sweep_test.go` 加 sweep canonicalize/prune/owner-read-error 測試 | ~250 行 |
+| Plan docs（此檔 v10） | ~1090 行 |
+| **總 net code（不含 plan docs）** | **~1820-1920 行** |
 
-v6 LOC 比 v5（~1595-1695）+25：filter-merge-retry +10 行（取代三步法）+ IT20 約 +30 行。設計複雜度反而降低 — 三步法非原子→單一 retry loop，與 PR-2b 既有 retry pattern 同型，認知負擔小。
+v10 LOC 比 v9（~1790-1890）+30：projection.go +20 行（hide + merge collect），sweep.go +12 行（owner-read-error 改 survivor + 註解），新增 PD6/PD7/PD8 + IT13d/IT14c 測試 +200 行；PD4 改寫並非新增。
 
 ---
 
 ## 8. 驗收 / Ship 條件
 
-- 所有 **IT1-IT22 + IT21b + IT22b + IT22c + IT13/IT13b/IT13c + IT14/IT14b** + RC1-RC5 + PD1-PD5 + 既有測試全綠（IT17-IT22, IT21b/IT22b/IT22c/IT13c/IT14b/PD4/PD5 為 race-fix regression guards 不可跳過 — codex round 6 K1 + round 2 v9 fix）
+- 所有 **IT1-IT22 + IT21b + IT22b + IT22c + IT13/IT13b/IT13c/IT13d + IT14/IT14b/IT14c** + RC1-RC5 + PD1-PD8 + 既有測試全綠（IT17-IT22, IT21b/IT22b/IT22c/IT13c/IT13d/IT14b/IT14c/PD4-PD8 為 race-fix regression guards 不可跳過 — codex round 6 K1 + round 2 v9 fix + round 3 v10 fix）
 - `go build/vet/test ./...` 23 packages 全綠
 - SPA 無變更
-- 委派 codex round 2（v8）+ round 2 second wave（v9）review 收斂；採納或合理 deferred all findings
+- 委派 codex round 2（v8）+ round 2 second wave（v9）+ round 3（v10）review 收斂；採納或合理 deferred all findings
 - Phase 3 PR #638 merged 後 rebase Phase 3.5 到 main
 
 ---
@@ -962,6 +974,7 @@ PR-3.5a 跑過兩輪 codex review 收斂後：
 | PR-3.5a code review round 2（adversarial 三視角）| attack mofcj6pe-pxh09c / defend mofcjln6-f0hq8x / health mofcjerd-sm4p6m | needs-attention | M4 medium reconcile partial trace 反 projection / M3 high filter-merge 丟 native concurrent / M2 high descendant scan fold 有狀態 candidate / L1 high SessionEnd delete-first 留 orphan / N1 high dedup 信任 IsProxy（過嚴 deferred）| v8 採納 4/5（M4/M3/M2/L1 fix + sweep prune 從 PR-3.5b 移進 PR-3.5a）；N1 deferred 開 follow-up issue |
 | PR-3.5a 第二輪 code review round 1（standard）| (round 2 standard) | (review) | 標準 cross-model 二意見（v8 patch 後）| findings 併入 round 2 adversarial 彙整 |
 | PR-3.5a 第二輪 code review round 2（adversarial 三視角）| attack / defend / health（round 2）| needs-attention | O1 high filter-merge prevWrittenNativeIDs 多 retry 下 regress 丟 native / Q1 high projection dedup 隱藏 stateful child（partial+並發 SubagentStart）/ O2 medium descendant scan candidate guard 過寬把 stale-only IsProxy 算 state / O3 medium pruneDeadProxyRefs read-error 時 fail-destructive / P1 medium prune detach 後不 broadcast | **v9 全採納**：C13 initialNativeIDs baseline + IT21b / C14 dedup len==0 guard + PD4/PD5 / C15 candidate state classification + IT22b/IT22c / C16 prune fail-safe + IT14b / C17 broadcastProxyPruned + IT13c |
+| PR-3.5a 第三輪 code review round 3 | (round 3) | needs-attention | R1 high projection dedup Q1 fix 仍丟資訊（child 留 visible 後 TopFrame 選一→另一邊 Subagents 丟）／ R2 medium sweepOnce owner-identity read error 時 bare continue 把 frame 丟出 survivors → pane 不進 prune → O3 fail-safe 被繞過 | **v10 全採納**：C18 dedup hide-and-merge + PD4 改寫 + PD6/PD7/PD8 / C19 owner-read-error 加入 survivors + IT13d/IT14c |
 
 ---
 

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,4 +1,4 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v10 / Hybrid B+)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v11 / Hybrid B+)
 
 Baseline：`1.0.0-alpha.225`（main @ `92fb5d05`，Phase 3 已 merged）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`，已 rebase 上 `92fb5d05`）。
@@ -654,7 +654,7 @@ var (
 | RC4 | `canonicalizeDescendantsAfterUpsert_skips_same_type` |
 | RC5 | `canonicalizeDescendantsAfterUpsert_skips_pid_reuse_via_identity_gate` |
 
-`projection_test.go` 加 `PD1`-`PD8`：
+`projection_test.go` 加 `PD1`-`PD9`：
 
 | # | 名稱 |
 |---|---|
@@ -666,6 +666,7 @@ var (
 | PD6 | `dedup_merges_hidden_stateful_child_subagents`（v10 R1：parent older, child newer with native, hide + merge）|
 | PD7 | `dedup_merges_hidden_stateful_child_subagents_parent_newer`（v10 R1 對稱：parent newer, child older with native, merge 仍 run）|
 | PD8 | `dedup_merge_avoids_duplicate_proxy_ref`（v10 R1 boundary：same proxy identity 兩側都有 → merge dedup 後只一個 entry）|
+| PD9 | `cross_frame_native_id_collision_preserved`（v11 S1：cc 與 codex 各自的 native ref 同 ID 不同 Type，merge 不可誤砍 → 兩條 native ref + proxy ref 三條全留；驗 owner-aware dedup）|
 
 ### 3.3 不加的測試
 
@@ -975,6 +976,8 @@ PR-3.5a 跑過兩輪 codex review 收斂後：
 | PR-3.5a 第二輪 code review round 1（standard）| (round 2 standard) | (review) | 標準 cross-model 二意見（v8 patch 後）| findings 併入 round 2 adversarial 彙整 |
 | PR-3.5a 第二輪 code review round 2（adversarial 三視角）| attack / defend / health（round 2）| needs-attention | O1 high filter-merge prevWrittenNativeIDs 多 retry 下 regress 丟 native / Q1 high projection dedup 隱藏 stateful child（partial+並發 SubagentStart）/ O2 medium descendant scan candidate guard 過寬把 stale-only IsProxy 算 state / O3 medium pruneDeadProxyRefs read-error 時 fail-destructive / P1 medium prune detach 後不 broadcast | **v9 全採納**：C13 initialNativeIDs baseline + IT21b / C14 dedup len==0 guard + PD4/PD5 / C15 candidate state classification + IT22b/IT22c / C16 prune fail-safe + IT14b / C17 broadcastProxyPruned + IT13c |
 | PR-3.5a 第三輪 code review round 3 | (round 3) | needs-attention | R1 high projection dedup Q1 fix 仍丟資訊（child 留 visible 後 TopFrame 選一→另一邊 Subagents 丟）／ R2 medium sweepOnce owner-identity read error 時 bare continue 把 frame 丟出 survivors → pane 不進 prune → O3 fail-safe 被繞過 | **v10 全採納**：C18 dedup hide-and-merge + PD4 改寫 + PD6/PD7/PD8 / C19 owner-read-error 加入 survivors + IT13d/IT14c |
+| PR-3.5a code review round 4（adversarial sanity）| review-mofh79kq-djlhr3 | needs-attention | S1 high R1 merge dedup 用 `subagentRefMatches`（native by ID-only），跨 frame 不同 agent family 的 native ID collision 被誤判 duplicate → 隱藏 child 的 native ref 從 wire 輸出消失 | **v11 採納**：merge 改 owner-aware inline dedup（proxy by `SourcePID+SourceStartTime`、native by `Type+ID`）；新增 PD9 守規。`subagentRefMatches` 語義不變（within-frame caller in `frame_ops.go` 不受影響）|
+| PR-3.5a code review round 5（待執行）| — | — | v11 patch（C21 fix + C22 docs）後再跑一輪 sanity；預期收斂無 high finding 進 ship | — |
 
 ---
 

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,9 +1,17 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v7 / Hybrid B+)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v8 / Hybrid B+)
 
 Baseline：`1.0.0-alpha.225`（main @ `92fb5d05`，Phase 3 已 merged）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`，已 rebase 上 `92fb5d05`）。
 Phase 3 PR #638：✅ squash-merged at `92fb5d05`（2026-04-26）。
 Bump 策略：本 PR 系列 + Phase 3 一起 bump **alpha.226**（注意：alpha.225 已被 parallel session 為 SPA tooltip 功能 PR #643 占用，與 Phase 3 無關）。
+
+**v7 → v8 由 PR-3.5a 兩輪 codex review 收斂**（§13；5 finding 採納 / 1 deferred 開 follow-up）：
+
+- **M4 medium / round PR-2 attack** — `reconcileCreatedFrameAsProxy` partial 路徑回 `canonicalized=false` 走 `created_frame` trace（child 視角），但 projection_dedup 顯示 parent + proxy ref → trace ≠ projection。**v8 修法**：partial 仍回 `canonicalized=true`，caller 走 `updated_frame / post_upsert_canonicalization_self` 與 projection 一致；metric 仍 +1。
+- **M3 high / round PR-2 attack** — filter-merge-retry「只保留 IsProxy」filter 在 conflict reload 時把並發 SubagentStart attach 的 native ref 一併 drop。**v8 修法**：改 prune-stale-IsProxy 語意；attempt 0 仍 reset baseline native（SessionStart 主語意），attempt N>0 透過 `prevWrittenNativeIDs` 區分 baseline vs concurrent attach，concurrent 保留 baseline 清掉。
+- **M2 high / round PR-2 attack** — `canonicalizeDescendantsAfterUpsert` scan 直接 fold 任何 cross-type live PPID-descendant；若 candidate 已累積 native subagent / 自己 IsProxy ref，DELETE 會靜默吞掉。**v8 修法**：scan 跳過 `len(candidate.Subagents) > 0` 的 candidate（race-window standalone 必為空）。
+- **L1 high / round PR-2 attack** — SessionEnd 走 delete-first + best-effort detach；detach 失敗（storage / retry exhaust / daemon crash 中段）→ child 沒了 + parent 留 stale proxy ref → 永久 lit dot；PR-3.5a 無 sweep prune 兜底。**v8 修法**：(a) SessionEnd 改 detach-first + propagate（detach error 不 delete）；(b) `pruneDeadProxyRefs` 從 PR-3.5b 移進 PR-3.5a sweep.go（sweepOnce 第三 pass）。
+- **N1 high / round PR-2 attack（deferred）** — projection_dedup 信任 IsProxy claim 隱藏 standalone；codex 擔心 PID 重用 race。實作已用 (PID, StartTime) identity 比對防 PID reuse（startTime 是 jiffies precision 不會 collision），且 dedup 在 hot-path read 加 syscall 影響 perf。**不修，open follow-up**：PR-3.5b `pruneDeadProxyRefs` + 本 PR sweep 兜底已涵蓋 90% 場景；hot-path liveness 升級交給 metric 觸發。
 
 **v6 → v7 由 codex round 6 收斂**（§13；1 high doc-gate finding 採納）：
 
@@ -942,6 +950,8 @@ PR-3.5a 跑過兩輪 codex review 收斂後：
 | Plan v4 round 4（adversarial）| inline | needs-attention | I1 high existing-frame reset 清掉 live proxy / I2 medium SLO 不可量測 | v5 全採納（§2.2.2 preserve live proxies + IT17/IT18/IT19；§2.6 移除 SLO 聲明，改三 evidence point；§0.2 設計論證重整）|
 | Plan v5 round 5（adversarial）| inline | needs-attention | J1 high snapshot/reset/re-attach 三步非原子，並發 attach 在 race window 內被抹除 | v6 採納（§2.2.2 改為 filter-merge-retry pattern，取代三步法；新 IT20 守規）|
 | Plan v6 round 6（adversarial）| review-mof9wjzs-7q8wrs | needs-attention | K1 high §8 ship gate 漏列 IT17-IT20（含 J1 regression test）+ IT17 描述沿用 v5 已移除路徑 | v7 採納（純文檔修；§8 改 IT1-IT20 全綠 + IT17 描述更新）。**設計層面六輪後完整收斂 — round 6 無架構/race/邏輯 finding**；依 feedback_codex_review_termination.md 進實作 |
+| PR-3.5a code review round 1（standard）| mofcixya-889fj5 | (review) | 標準 cross-model 二意見 | findings 併入 round 2 彙整 |
+| PR-3.5a code review round 2（adversarial 三視角）| attack mofcj6pe-pxh09c / defend mofcjln6-f0hq8x / health mofcjerd-sm4p6m | needs-attention | M4 medium reconcile partial trace 反 projection / M3 high filter-merge 丟 native concurrent / M2 high descendant scan fold 有狀態 candidate / L1 high SessionEnd delete-first 留 orphan / N1 high dedup 信任 IsProxy（過嚴 deferred）| v8 採納 4/5（M4/M3/M2/L1 fix + sweep prune 從 PR-3.5b 移進 PR-3.5a）；N1 deferred 開 follow-up issue |
 
 ---
 
@@ -949,28 +959,29 @@ PR-3.5a 跑過兩輪 codex review 收斂後：
 
 v7 規模相對 kickoff 原始設計擴張 ~7-10 倍（150-250 LOC → 1620-1720 LOC），單 PR review 負擔過大。設計分層天然可拆 — 依 **user-visible correctness 邊界** 切兩 PR：
 
-### PR-3.5a「Cold-start race fix + projection dedup + SessionEnd cleanup」
+### PR-3.5a「Cold-start race fix + projection dedup + SessionEnd cleanup + sweep prune」
 
-**目標**：消除 user-visible incorrectness。SPA 永遠看到正確的 frame collapse（並發冷啟動下也是）；codex SessionEnd 不留 orphan lit dot。**獨立可 ship，無需依賴 PR-3.5b**。
+**目標**：消除 user-visible incorrectness。SPA 永遠看到正確的 frame collapse（並發冷啟動下也是）；codex SessionEnd 不留 orphan lit dot；sweep eventual-consistency 兜底 SessionEnd 漏網場景。**獨立可 ship，無需依賴 PR-3.5b**。
 
-**範圍**（commits 6/7/8/9/10/11）：
+**範圍**（commits 6/7/8/9/10/11/12 + v8 fix commits）：
 
 - `internal/agent/metrics.go`（新檔）— 4 個 expvar counter
 - `internal/module/agent/frame_ops.go`：
   - `pidIsAncestorOfWithCap` helper
-  - `canonicalizeDescendantsAfterUpsert`（含 identity gate）
-  - `reconcileCreatedFrameAsProxy`（best-effort，無 rollback）
+  - `canonicalizeDescendantsAfterUpsert`（含 identity gate **+ v8 M2 candidate-with-subagents skip**）
+  - `reconcileCreatedFrameAsProxy`（best-effort，無 rollback；**v8 M4 partial 回 canonicalized=true**）
   - applyFrameEvent §2.2.1 接線（new-frame post-Upsert）
-  - applyFrameEvent §2.2.2 接線（existing-frame **filter-merge-retry**）
-  - applyFrameEvent SessionEnd hot-path proxy cleanup（§2.3）
+  - applyFrameEvent §2.2.2 接線（existing-frame **filter-merge-retry + v8 M3 prune-stale-IsProxy + prevWrittenNativeIDs**）
+  - applyFrameEvent SessionEnd **detach-first + propagate**（§2.3 + v8 L1）
 - `internal/module/agent/projection.go`：`buildPaneProjection` dedup（§2.4）
+- `internal/module/agent/sweep.go`：`pruneDeadProxyRefs` + sweepOnce 第三 pass（§4.3，**v8 L1 從 PR-3.5b 移進 PR-3.5a**）
 
 **測試**（必跑 ship gate）：
 
 - Unit：RC1-RC5 + PD1-PD3
-- Integration：IT1-IT9, IT11, IT12, IT15-IT20（**IT4 + IT5 + IT12 + IT17/IT18/IT19/IT20 是 race-fix regression guards 不可跳**）
+- Integration：IT1-IT9, IT11, IT12, IT13, IT13b, IT14, IT15-IT22（**IT4 + IT5 + IT12 + IT13/IT14 + IT17-IT22 是 race-fix regression guards 不可跳**）
 
-**LOC 預估**：~850-950 行 net（含 ~17 個 IT）
+**LOC 預估**：~1100-1200 行 net（含 ~21 個 IT；v8 比 v7 PR-3.5a 多 ~250 LOC：sweep prune + IT13/IT13b/IT14/IT21/IT22）
 
 **為什麼 SessionEnd cleanup + projection dedup 必須在 PR-3.5a 而不能延到 3.5b**：
 
@@ -978,21 +989,20 @@ v7 規模相對 kickoff 原始設計擴張 ~7-10 倍（150-250 LOC → 1620-1720
 - SessionEnd cleanup 處理「source 死後 parent 仍含 proxy ref → 永久 lit dot」 — projection_dedup 對此**無能為力**（沒有 standalone 可 hide），必須走 detach
 - 兩者缺一，PR-3.5a 出貨就有 user-visible bug
 
-### PR-3.5b「Sweep defensive layer」
+### PR-3.5b「Sweep canonicalize layer」
 
-**目標**：背景 eventual-consistency repair，補 PR-3.5a hot path 漏網的 partial state（DeleteIfUnchanged failure / existing-descendant 漏網 / daemon crash 中 SessionEnd 等）。**Defense-in-depth；user-visible correctness 已由 3.5a 保證**，3.5b 是穩健性升級。
+**目標**：背景 eventual-consistency repair，補 PR-3.5a hot path 漏網的 partial state（DeleteIfUnchanged failure / existing-descendant 漏網等）。**Defense-in-depth；user-visible correctness 已由 3.5a 保證 + sweep prune 已在 3.5a**，3.5b 是穩健性升級。
 
-**範圍**（commits 12/13）：
+**範圍**（commit 12 — sweep canonicalize；prune 在 v8 L1 修法中已移進 3.5a）：
 
 - `internal/module/agent/sweep.go`：
   - `canonicalizePane`（含 candidate identity gate，§4.2）
   - `findCanonicalAncestor`
-  - `pruneDeadProxyRefs`（§4.3）
-  - sweepOnce 加第三 pass
+  - sweepOnce 加 canonicalize pass
 
-**測試**：Integration IT10, IT13, IT14 + sweep-specific tests
+**測試**：Integration IT10 + sweep-specific tests
 
-**LOC 預估**：~300-400 行 net
+**LOC 預估**：~150-250 行 net（v8 比 v7 PR-3.5b 少 ~100-150 LOC：prune + IT13/IT14 已移進 PR-3.5a）
 
 **Ship 時機選擇**：
 - 立即接 3.5a 後出貨（保守）
@@ -1038,14 +1048,15 @@ v7 規模相對 kickoff 原始設計擴張 ~7-10 倍（150-250 LOC → 1620-1720
 | 10 | SessionEnd hot-path proxy cleanup | 3.5a |
 | 11 | buildPaneProjection dedup | 3.5a |
 | 12 | sweep canonicalizePane | 3.5b |
-| 13 | sweep pruneDeadProxyRefs | 3.5b |
-| 14 | integration tests | **拆**：IT1-9/11/12/15-20 進 3.5a；IT10/13/14 進 3.5b |
+| 13 | sweep pruneDeadProxyRefs | **3.5a**（v8 L1 fix；從 3.5b 移進）|
+| 14 | integration tests | **拆**：IT1-9/11/12/13/13b/14/15-22 進 3.5a；IT10 進 3.5b |
+| C8-C12 | v8 fix commits（M4/M3/M2/L1 + sweep prune）| 3.5a |
 
 §8 ship gate 對應 PR：
 
-- **PR-3.5a ship gate**：IT1-IT9, IT11, IT12, IT15-IT20 + RC1-RC5 + PD1-PD3 全綠 + go build/vet/test 全綠 + SPA 無變更 + codex 兩輪 review 收斂
-- **PR-3.5b ship gate**：IT10, IT13, IT14 + sweep-specific tests 全綠 + 不 regress 3.5a 既有測試
+- **PR-3.5a ship gate**：IT1-IT9, IT11, IT12, IT13, IT13b, IT14, IT15-IT22 + RC1-RC5 + PD1-PD3 全綠 + go build/vet/test 全綠 + SPA 無變更 + codex 兩輪 review 收斂
+- **PR-3.5b ship gate**：IT10 + sweep-specific tests 全綠 + 不 regress 3.5a 既有測試
 
 §7 LOC 預估維持（總和），但分 PR：
-- 3.5a：~850-950 LOC + plan docs
-- 3.5b：~300-400 LOC
+- 3.5a：~1100-1200 LOC + plan docs（v8 含 sweep prune + 5 IT 新增）
+- 3.5b：~150-250 LOC（v8 只剩 canonicalizePane）

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -940,3 +940,107 @@ PR 跑過 codex round 4 review 收斂後：
 | Plan v4 round 4（adversarial）| inline | needs-attention | I1 high existing-frame reset 清掉 live proxy / I2 medium SLO 不可量測 | v5 全採納（§2.2.2 preserve live proxies + IT17/IT18/IT19；§2.6 移除 SLO 聲明，改三 evidence point；§0.2 設計論證重整）|
 | Plan v5 round 5（adversarial）| inline | needs-attention | J1 high snapshot/reset/re-attach 三步非原子，並發 attach 在 race window 內被抹除 | v6 採納（§2.2.2 改為 filter-merge-retry pattern，取代三步法；新 IT20 守規）|
 | Plan v6 round 6（adversarial）| review-mof9wjzs-7q8wrs | needs-attention | K1 high §8 ship gate 漏列 IT17-IT20（含 J1 regression test）+ IT17 描述沿用 v5 已移除路徑 | v7 採納（純文檔修；§8 改 IT1-IT20 全綠 + IT17 描述更新）。**設計層面六輪後完整收斂 — round 6 無架構/race/邏輯 finding**；依 feedback_codex_review_termination.md 進實作 |
+
+---
+
+## 14. Delivery plan：2-PR split（kickoff scope vs v7 規模對齊）
+
+v7 規模相對 kickoff 原始設計擴張 ~7-10 倍（150-250 LOC → 1620-1720 LOC），單 PR review 負擔過大。設計分層天然可拆 — 依 **user-visible correctness 邊界** 切兩 PR：
+
+### PR-3.5a「Cold-start race fix + projection dedup + SessionEnd cleanup」
+
+**目標**：消除 user-visible incorrectness。SPA 永遠看到正確的 frame collapse（並發冷啟動下也是）；codex SessionEnd 不留 orphan lit dot。**獨立可 ship，無需依賴 PR-3.5b**。
+
+**範圍**（commits 6/7/8/9/10/11）：
+
+- `internal/agent/metrics.go`（新檔）— 4 個 expvar counter
+- `internal/module/agent/frame_ops.go`：
+  - `pidIsAncestorOfWithCap` helper
+  - `canonicalizeDescendantsAfterUpsert`（含 identity gate）
+  - `reconcileCreatedFrameAsProxy`（best-effort，無 rollback）
+  - applyFrameEvent §2.2.1 接線（new-frame post-Upsert）
+  - applyFrameEvent §2.2.2 接線（existing-frame **filter-merge-retry**）
+  - applyFrameEvent SessionEnd hot-path proxy cleanup（§2.3）
+- `internal/module/agent/projection.go`：`buildPaneProjection` dedup（§2.4）
+
+**測試**（必跑 ship gate）：
+
+- Unit：RC1-RC5 + PD1-PD3
+- Integration：IT1-IT9, IT11, IT12, IT15-IT20（**IT4 + IT5 + IT12 + IT17/IT18/IT19/IT20 是 race-fix regression guards 不可跳**）
+
+**LOC 預估**：~850-950 行 net（含 ~17 個 IT）
+
+**為什麼 SessionEnd cleanup + projection dedup 必須在 PR-3.5a 而不能延到 3.5b**：
+
+- projection_dedup 處理「parent 含 proxy ref + child standalone」雙顯示，是 hot-path canonicalization 的 user-visible 必要兜底
+- SessionEnd cleanup 處理「source 死後 parent 仍含 proxy ref → 永久 lit dot」 — projection_dedup 對此**無能為力**（沒有 standalone 可 hide），必須走 detach
+- 兩者缺一，PR-3.5a 出貨就有 user-visible bug
+
+### PR-3.5b「Sweep defensive layer」
+
+**目標**：背景 eventual-consistency repair，補 PR-3.5a hot path 漏網的 partial state（DeleteIfUnchanged failure / existing-descendant 漏網 / daemon crash 中 SessionEnd 等）。**Defense-in-depth；user-visible correctness 已由 3.5a 保證**，3.5b 是穩健性升級。
+
+**範圍**（commits 12/13）：
+
+- `internal/module/agent/sweep.go`：
+  - `canonicalizePane`（含 candidate identity gate，§4.2）
+  - `findCanonicalAncestor`
+  - `pruneDeadProxyRefs`（§4.3）
+  - sweepOnce 加第三 pass
+
+**測試**：Integration IT10, IT13, IT14 + sweep-specific tests
+
+**LOC 預估**：~300-400 行 net
+
+**Ship 時機選擇**：
+- 立即接 3.5a 後出貨（保守）
+- 觀察 3.5a metric `partial_canonicalization_created` rate；如低於 SLO 可延後
+- 不 ship 也是合法決策（3.5a 已 user-correct，3.5b 是優化）
+
+### Release 策略（取代 §12）
+
+| 階段 | 動作 |
+|---|---|
+| 1 | Phase 3 PR #638 merge（不 bump） |
+| 2 | Rebase **PR-3.5a** 到 main（解 applyFrameEvent + SessionEnd 衝突）|
+| 3 | PR-3.5a 開 PR + 兩輪 codex review + merge（不 bump） |
+| 4 | 開 bump PR alpha.225（涵蓋 Phase 3 + Phase 3.5a）|
+| 5 | Bump merge → main @ alpha.225 |
+| 6 | （依 metric 與優先級決定）開 **PR-3.5b** + review + merge → bump alpha.226 |
+| 7 | ExitWorktree 清 `lights-phase-3-5`（PR-3.5b 完成後）|
+| 8 | 更新 kickoff：標 Phase 3 + Phase 3.5（a/b 個別狀態）|
+
+### Branch 策略
+
+`worktree-lights-phase-3-5` 同 worktree 連續開兩 PR：
+
+- PR-3.5a branch：可沿用既有 `worktree-lights-phase-3-5`，head reset 到 v7 docs commit `cbd66c3c` 後直接做 PR-3.5a 實作 commits
+- PR-3.5b branch：merged PR-3.5a 後，rebase fresh main，新 commits
+
+或起新 branch `worktree-lights-phase-3-5b` for 3.5b — 兩種都可，視 PR-3.5a 實作完成時 main 進度而定。
+
+### 對 v7 plan 的 §6/§7/§8 影響
+
+§6 commits 表的對應 PR boundary：
+
+| # | Commit | PR |
+|---|---|---|
+| 1-5c | docs commits（v1-v7）| 3.5a 帶 |
+| 6 | metrics counters | 3.5a |
+| 7 | pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert | 3.5a |
+| 8 | reconcileCreatedFrameAsProxy | 3.5a |
+| 9 | wire bidirectional + filter-merge-retry | 3.5a |
+| 10 | SessionEnd hot-path proxy cleanup | 3.5a |
+| 11 | buildPaneProjection dedup | 3.5a |
+| 12 | sweep canonicalizePane | 3.5b |
+| 13 | sweep pruneDeadProxyRefs | 3.5b |
+| 14 | integration tests | **拆**：IT1-9/11/12/15-20 進 3.5a；IT10/13/14 進 3.5b |
+
+§8 ship gate 對應 PR：
+
+- **PR-3.5a ship gate**：IT1-IT9, IT11, IT12, IT15-IT20 + RC1-RC5 + PD1-PD3 全綠 + go build/vet/test 全綠 + SPA 無變更 + codex 兩輪 review 收斂
+- **PR-3.5b ship gate**：IT10, IT13, IT14 + sweep-specific tests 全綠 + 不 regress 3.5a 既有測試
+
+§7 LOC 預估維持（總和），但分 PR：
+- 3.5a：~850-950 LOC + plan docs
+- 3.5b：~300-400 LOC

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,0 +1,351 @@
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization
+
+Baseline：`1.0.0-alpha.224`（main @ `75b4d166`）。
+Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`）。
+Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 → rebase 3.5 → 一次 bump alpha.225）。
+
+---
+
+## 0. 來龍去脈（必讀）
+
+### 0.1 修什麼
+
+**Race 來源**：Phase 2 PR-2b 的 `findProxyParent`（`internal/module/agent/frame_ops.go:688`）只做 *pre-Upsert* PPID 走訪，無 post-Upsert 收斂。當兩個跨型別 SessionStart 在同一 pane 並發冷啟動（典型場景：daemon restart 後 cc + codex proxy 同時來），兩邊 walk 各自 miss → 各自 `Upsert` → 結果是兩個獨立 frame，PR-2b 的 proxy collapse 失效。
+
+**最容易觸發的場景**（Phase 3 codex round 2 finding #1 提出）：daemon restart → cc 與 codex proxy 同時冷啟動 → cc 的 Upsert 與 codex 的 `findProxyParent` walk 交錯 → walk 在「cc Upsert 之前」執行 → codex 永久變成獨立 frame。Phase 3 加上 `tryRebuildFromProcessTree` 後 race window 變大，但 race 本身在 alpha.221 PR-2b 落地起就存在。
+
+### 0.2 設計來源
+
+Codex architectural consulting `task-modcbbhg-auxa36`（high-effort）採方案 **B'：post-Upsert canonicalization by ancestry**，捨棄 per-pane mutex / pane-level claim table / SQL UNIQUE / delay window 等 hack。
+
+核心 invariant（**單向**，破解 secondary race）：
+
+- Descendant **可**轉 proxy（被收編到 ancestor 的 SubagentRef 列表）
+- Ancestor **不可**轉 descendant
+- PID / `started_at` / frame_id 只在多個 ancestor candidate tie-break 時用，**不能**反過來定義 parent 語義
+
+由此，cc + codex 並發冷啟動的 reconcile 階段保證收斂：
+
+| Frame | reconcile 走 PPID 鏈往上找 | 動作 |
+|---|---|---|
+| cc 自己（cc 為頂層） | 找不到 codex（codex 不是 cc 的 ancestor） | no-op |
+| codex（codex 為 cc descendant） | 找到 cc | attach codex 為 cc 的 proxy ref + delete 自己 standalone frame |
+
+兩邊同時跑也不互換，因為「ancestor 不可轉 descendant」這條規則不對稱。
+
+### 0.3 與 Phase 3 的關係
+
+- **獨立但相關**：race 本身不依賴 Phase 3 的 `daemon_restart_recovery` 程式碼，而是 PR-2b（alpha.221）就存在的舊洞
+- **接線位置同檔**：Phase 3 與 Phase 3.5 都動 `applyFrameEvent`（前者加 fallback chain rebuild，後者加 post-Upsert reconcile）— rebase 時可能在 fallback chain 區段衝突
+- **獨立 PR**：依 kickoff 「切 Phase 3.5 獨立 PR」決策；Phase 3 PR #638 merge 後 rebase Phase 3.5
+
+---
+
+## 1. 既有原語（沿用，無新 store API）
+
+PR-2b 已備齊所有需要的原語：
+
+| 原語 | 位置 | 用途 |
+|---|---|---|
+| `findProxyParent(req)` | `frame_ops.go:688` | PPID 鏈走訪 + same-pane + live + identity-verified + cross-type 篩選；**reconcile 直接重用** |
+| `attachProxyRefWithRetry(parent, ref, broadcastTs)` | `frame_ops.go:631` | optimistic concurrency attach（retry on conflict via `mutateSubagentsWithRetry`） |
+| `FramesStore.DeleteIfUnchanged(frameID, lastSeenAt)` | `internal/store/frames.go:263` | atomic delete（last_seen_at unchanged 才刪）|
+| `SubagentRef{ID, Type, StartedAt, SourcePID, SourceStartTime, IsProxy}` | `internal/agent/subagent.go` | proxy ref 型別（PR-2a 落地） |
+| Proxy ID 格式 `proxy:%s:%d:%s`（agentType, pid, startTime） | `frame_ops.go:176`（applyFrameEvent 既有用法） | reconcile 必須沿用同格式以與 PR-2b 同型 |
+
+**沒有**新 store method、沒有新型別、沒有新 SQL。整個改動限於 `frame_ops.go` 加一個 helper + 接線一行。
+
+---
+
+## 2. 設計細節
+
+### 2.1 `reconcileCreatedFrameAsProxy` helper
+
+```go
+// reconcileCreatedFrameAsProxy attempts to canonicalize a freshly-created
+// SessionStart frame against an alive cross-type ancestor whose own frame
+// landed in the database after this sender's findProxyParent walk completed
+// (race window closed by post-Upsert reconcile).
+//
+// Returns:
+//   - attached=true, parentStored populated when canonicalization succeeded
+//     (parent has new proxy ref + child frame either deleted or left for
+//     next-cycle cleanup if DeleteIfUnchanged conflicted).
+//   - attached=false, zeroFrame, nil when no cross-type ancestor exists
+//     (legitimate standalone frame — leave as-is).
+//
+// Single-direction rule (B' design): only walks UP from sender's PPID. The
+// just-created frame at sender PID is never in the walk path, so reconcile
+// cannot canonicalize itself away.
+//
+// Failure modes:
+//   - findProxyParent error → propagate (storage failure).
+//   - attachProxyRefWithRetry returns attached=false (parent vanished) → no-op
+//     (next sweep / next hook canonicalizes).
+//   - DeleteIfUnchanged returns deleted=false (child row was modified by a
+//     concurrent writer between Upsert and delete) → log + leave (parent has
+//     proxy ref, child remains; next reconcile or sweep cleans up).
+func (m *Module) reconcileCreatedFrameAsProxy(
+    stored store.Frame,
+    req EventRequest,
+    broadcastTs int64,
+) (bool, store.Frame, error) {
+    parent, err := m.findProxyParent(req)
+    if err != nil {
+        return false, store.Frame{}, err
+    }
+    if parent == nil {
+        return false, store.Frame{}, nil
+    }
+    ref := agentpkg.SubagentRef{
+        ID:              fmt.Sprintf("proxy:%s:%d:%s", req.AgentType, req.SenderPID, req.SenderStartTime),
+        Type:            req.AgentType,
+        StartedAt:       broadcastTs,
+        SourcePID:       req.SenderPID,
+        SourceStartTime: req.SenderStartTime,
+        IsProxy:         true,
+    }
+    attached, parentStored, aerr := m.attachProxyRefWithRetry(*parent, ref, broadcastTs)
+    if aerr != nil {
+        return false, store.Frame{}, aerr
+    }
+    if !attached {
+        // Parent vanished mid-flight; leave standalone for next cycle.
+        return false, store.Frame{}, nil
+    }
+    // Atomic delete: only if child's last_seen_at unchanged since Upsert.
+    // Failure (deleted=false) means a concurrent writer touched the row
+    // (probe status update, another reconcile, idle sweep). Don't retry —
+    // idempotent canonicalization can resume from sweep / next hook.
+    deleted, derr := m.frames.DeleteIfUnchanged(stored.FrameID, stored.LastSeenAt)
+    if derr != nil {
+        return false, store.Frame{}, derr
+    }
+    if !deleted {
+        log.Printf("phase3.5: reconcile attached proxy ref but child frame %s delete lost race; left for next canonicalization", stored.FrameID)
+    }
+    return true, parentStored, nil
+}
+```
+
+**為什麼 reconcile 直接呼 `findProxyParent` 就夠**：
+
+`findProxyParent` 在 line 169（pre-Upsert）跑過一次 — 那是 race window 的「太早」端，當時 cc 的 frame 還沒入庫所以 walk miss。reconcile 在 post-Upsert 跑同一個 walk — 此時 race window 的「另一端」cc 的 Upsert 已完成（並發 Upsert 之間 SQLite 的 row-level 順序保證了至少一邊看到對方），所以 walk 會找到 cc。重用既有 walk 邏輯避免兩套 walk drift。
+
+**為什麼不用擔心找到自己**：walk 從 `info.PPID`（sender PID 的 parent）開始，sender PID 本身不在 walk path 內。除非 sender PID == sender PPID（不可能），不然不會踩到自己剛 Upsert 的 frame。
+
+### 2.2 接線（applyFrameEvent）
+
+在新 frame 的 `Upsert` 成功後（`frame_ops.go:286-292` 之後、`projectPane` 之前）插入：
+
+```go
+} else {
+    // New frame: insert via Upsert. ...
+    stored, err = m.frames.Upsert(store.Frame{...})
+    if err != nil {
+        return nil, FrameTraceMeta{}, err
+    }
+
+    // Phase 3.5: post-Upsert canonicalization by ancestry.
+    // Closes the race window between findProxyParent's pre-Upsert walk and
+    // the cross-type ancestor's own SessionStart Upsert. Only fires for
+    // SessionStart (the event with proxy semantics in PR-2b).
+    if req.EventName == "SessionStart" {
+        canonicalized, parentStored, rerr := m.reconcileCreatedFrameAsProxy(stored, req, broadcastTs)
+        if rerr != nil {
+            return nil, FrameTraceMeta{}, rerr
+        }
+        if canonicalized {
+            projection, err := m.projectPane(req.TmuxPaneID)
+            return projection, FrameTraceMeta{
+                FrameID:       parentStored.FrameID,
+                ParentFrameID: parentStored.ParentFrameID,
+                Decision:      "updated_frame",
+                Reason:        "post_upsert_canonicalization",
+                Before:        before,
+                After:         summarizeFrame(&parentStored),
+            }, err
+        }
+    }
+}
+```
+
+**為什麼只在 SessionStart 觸發**：proxy 收編語義來自 session 邊界（PR-2b 已限定 line 168 fast-path 為 `SessionStart && frame == nil`）。其他 event（Notification / ToolUse 等）若在 frame == nil 路徑建 frame（少見邊界情境），由下一次 SessionStart 或 sweep canonicalize；不在 Phase 3.5 的 race scope 內。
+
+**為什麼 `Before` 沿用原 before**：原 before（line 49 `summarizeFrame(frame)`）是 `frame == nil` 的空 map — 與 reconcile 「我本來不存在」的語義一致。`After` 是 parent 的新狀態（多了一個 proxy ref）。
+
+### 2.3 Trace decision 詞彙
+
+| 決策 | Reason | 觸發 |
+|---|---|---|
+| `updated_frame` | `proxy_subagent_attached` | PR-2b pre-Upsert proxy fast-path（既有，不改）|
+| `created_frame` | `parent_frame_found` / `parent_frame_missing` | 一般 new frame 路徑（既有，不改）|
+| `updated_frame` | `post_upsert_canonicalization` | **Phase 3.5 新**，reconcile 成功收編 |
+
+不引入第四 reason（如 `created_then_canonicalized_failed_to_delete`）— delete 失敗是 fail-soft，trace 仍顯示 `post_upsert_canonicalization` 反映 canonical 結果（parent 視角）；child 殘留為非觀察事件，由 log + 下次 reconcile/sweep 處理。
+
+---
+
+## 3. 測試矩陣（race interleavings）
+
+新增測試在 `internal/module/agent/frame_ops_test.go`，命名 `RC1`-`RC8`（Race Canonicalization）。沿用 PR-2b 的 fixture 與 process tree mocking 慣例（`readProcessInfoFn` / `isPidAliveFn` / `processStartTimeFn` 注入）。
+
+| # | 名稱 | 場景 | 預期 |
+|---|---|---|---|
+| RC1 | `concurrent_cold_start_codex_then_cc` | 序列：codex SessionStart Upsert → cc SessionStart Upsert（codex walk 在 cc Upsert 前完成，pre-Upsert findProxyParent miss）；codex post-Upsert reconcile 跑 | 1 個 cc frame，subagents 含 codex proxy ref（IsProxy=true, SourcePID=codex.PID）；codex frame 已刪 |
+| RC2 | `concurrent_cold_start_cc_then_codex` | 序列反過來：cc Upsert 先、codex Upsert 後 | cc reconcile no-op（找不到自己的 ancestor）；codex reconcile 找到 cc → attach + delete 自己 |
+| RC3 | `concurrent_cold_start_three_way` | cc + codex + opencode 同 pane 並發冷啟動，process tree：opencode → opencode-companion → codex → codex-companion → cc | 1 個 cc frame，subagents 含 codex proxy ref + opencode proxy ref；codex/opencode standalone frame 都已刪 |
+| RC4 | `reconcile_no_ancestor_noop` | 單一 SessionStart，PPID 鏈無跨型別 frame | 無 reconcile 動作（attached=false）；standalone frame 保留 |
+| RC5 | `reconcile_attach_race_lost` | reconcile 走到 attachProxyRefWithRetry，但 parent 在 retry 期間被刪（mock UpsertIfUnchanged 持續回 false 直到耗盡 retry） | reconcile 回 attached=false；standalone frame 保留；無 panic |
+| RC6 | `reconcile_delete_race_lost` | attach 成功，但 child frame 在 attach 期間被 probe status update 改了 last_seen_at，DeleteIfUnchanged 回 false | parent 含新 proxy ref；child frame 仍存在；trace decision = `updated_frame` reason `post_upsert_canonicalization`（不 fail）|
+| RC7 | `non_session_start_no_reconcile` | Notification event 在 frame == nil 路徑建 frame | reconcile 不觸發（frame 殘留 standalone）— 防止 reason 用錯路徑 |
+| RC8 | `findproxyparent_storage_error` | reconcile 內 findProxyParent 回 storage error | applyFrameEvent 整體錯誤 propagate（與既有 storage error 一致）|
+
+**Race 模擬技巧**（沿用 PR-2b mutateSubagentsWithRetry 測試模式）：
+
+- 不需要真正 goroutine：依賴 `findProxyParent` / `attachProxyRefWithRetry` / `DeleteIfUnchanged` 的 mock + 預設順序就能模擬 interleaving
+- RC1/RC2/RC3 用 in-process 順序：先把 cc 的 frame `Upsert` 進 store，再呼 codex 的 `applyFrameEvent`（findProxyParent 在 line 169 走 — 已能找到 cc 但 PR-2b path 設定為 `req.EventName == "SessionStart" && frame == nil` 才走）
+
+  **關鍵 mock 設定**：必須讓 line 169 的 pre-Upsert findProxyParent miss，line 286 的 post-Upsert reconcile 才會 hit。做法是 mock `m.frames.FindByPanePID` 第一次回 nil（模擬 cc 還沒 Upsert）、第二次回 cc frame。沿用 `framesStub` 既有的 call counter pattern（PR-2b RP1-RP15 已用過此 pattern）。
+
+- RC5 mock `attachProxyRefWithRetry` 內部的 UpsertIfUnchanged 持續 false（已有 PR17 RACE regression test 同型）
+
+### 3.1 整合測試（可選，但建議）
+
+`module_test.go` 加 `TestApplyFrameEvent_PostUpsertCanonicalization` 系列：用真 sqlite store + 模擬 race 順序 + 斷言 final state。確保 store / handler / projection 三層 wiring 正確。
+
+如果加會落在 `TestApplyFrameEvent_*` series 末尾（按時間先後）。**否則 race interleaving 測試已足夠 cover Helper 邏輯，可不加 integration**。施工時若 unit 測試容易寫就跳過 integration，沒必要重複。
+
+### 3.2 不加的測試
+
+- ❌ goroutine race detector 測試 — 太脆，現有 in-process interleaving 模擬已足夠
+- ❌ Phase 3 daemon_restart_recovery 路徑測試 — 那是 Phase 3 scope；rebase 後若需要 cross-feature 測試另開 issue
+
+---
+
+## 4. Sweep canonicalization（**不做** — 延後）
+
+Codex consulting 提到「optional：sweep.go 加 lightweight canonicalization pass」作為 defensive layer。本 PR **不做**：
+
+- reconcile 已在每個 SessionStart 後做收斂；正常流程下不會殘留 mismatch
+- 唯一漏網場景：reconcile attach 成功 + delete race 失敗（RC6） — child 殘留到下次 reconcile/sweep；下次 codex SessionStart 進 applyFrameEvent 時 `frame != nil`（GetByIdentity 命中既有 child），走 `frame != nil` UpdateHookPath 路徑 — 不會再嘗試 reconcile
+- 因此確實有「殭屍 standalone frame 直到 idle sweep（1h）」的漏網期；但 idle sweep 已存在（PR-2b §1.6），1h 後會清除
+- 加 sweep canonicalization 會把 ancestor walk 跑進 sweep loop（O(n) 變 O(n × walk depth)），增加 sweep 成本；先觀察 RC6 在 prod 是否真的發生再決定
+
+如果 reviewer 強烈要求：開 follow-up issue 不在本 PR 處理。
+
+---
+
+## 5. 不做（明列）
+
+- ❌ per-pane mutex / pane-level claim table（違背 PR-2b 無 lock atomic RMW 哲學）
+- ❌ SQL UNIQUE constraint on `(pane_id, agent_type)`（cc + codex proxy 同 pane 是合法狀態）
+- ❌ delay window / SessionStart deadline（hack，影響 hook latency）
+- ❌ 引入第四 trace reason `created_then_canonicalized_failed_to_delete`（fail-soft 本身不是觀察點）
+- ❌ Sweep canonicalization pass（§4）
+- ❌ 對 non-SessionStart event 觸發 reconcile（不在 Phase 3.5 race scope）
+- ❌ 修 Phase 3 fallback chain race（那條獨立路徑由 Phase 3 PR #638 處理）
+- ❌ rebuild Inspector / SPA 變更（Phase 5 才做）
+
+---
+
+## 6. Commit 順序（TDD）
+
+| # | Commit | 範圍 | 測試 |
+|---|---|---|---|
+| 1 | `feat(agent): reconcileCreatedFrameAsProxy helper (unwired)` | helper 新 method + sig + walk reuse + delete + log | RC1（helper 直呼，不過 applyFrameEvent）|
+| 2 | `feat(agent): wire reconcile into applyFrameEvent post-Upsert` | line 286 後接線 + EventName guard + trace reason `post_upsert_canonicalization` | RC2 / RC3 / RC4 / RC7 / RC8 |
+| 3 | `test(agent): reconcile race-loss interleavings` | RC5 + RC6 race 模擬 | RC5 / RC6 |
+| 4 | `docs: Phase 3.5 plan v1` | 此 plan 檔本身（已先 commit 過 placeholder 的話 amend；否則放最後）| — |
+
+**Commit 1 unwired 模式**沿用 Phase 3 commit `f109b258`（`tryRebuildFromProcessTree helper (unwired)`）— 先讓 helper 測試獨立綠，再 commit 2 接線後測 wiring。降低 review 對 wire-and-test 同 commit 的審讀負擔。
+
+**Commit 4 docs 位置**：依 kickoff 「先 commit docs placeholder → 再開工」原則，docs 應在 commit 1 之前。實作上：commit 1 = `docs: Phase 3.5 plan v1`，commit 2 = helper（unwired），commit 3 = wiring，commit 4 = race tests。重新編號：
+
+| # | Commit | 範圍 |
+|---|---|---|
+| 1 | `docs: Phase 3.5 plan v1 — cold-start proxy canonicalization` | 此 plan 檔 |
+| 2 | `feat(agent): reconcileCreatedFrameAsProxy helper (unwired)` | helper + RC1 |
+| 3 | `feat(agent): wire reconcile into applyFrameEvent post-Upsert` | wiring + RC2/RC3/RC4/RC7/RC8 |
+| 4 | `test(agent): reconcile race-loss interleavings` | RC5/RC6 |
+
+如果 plan v1 codex 審後改 v2，docs commit 補一個 `docs: Phase 3.5 plan v2 — codex round 1 fixes` 在 v1 之上、helper 之前（與 Phase 3 plan v1→v2 流程同型）。
+
+---
+
+## 7. 行數預估
+
+| 區塊 | 估計 |
+|---|---|
+| `frame_ops.go` reconcile helper | ~50 行 |
+| `frame_ops.go` 接線 + trace meta | ~25 行 |
+| `frame_ops_test.go` RC1-RC8 | ~250-350 行（依 fixture 重用程度）|
+| `module_test.go` integration（**可選**）| 0 或 ~80 行 |
+| Plan docs | ~330 行（此檔）|
+| **總 net code（不含 plan docs）** | **~325-425 行** |
+
+落在「中 PR」邊界（PR-2b 是 ~+1700 行 net）。Review 負擔比 PR-2b 小很多 — 修一個有 codex consulting backing 的單點 race，無新型別、無新 store API、無 SPA 變更。
+
+---
+
+## 8. 驗收 / Ship 條件
+
+- 所有 RC1-RC8 + 既有 frame_ops_test 全綠
+- `go build ./... && go vet ./... && go test ./...` 23 packages 全綠
+- SPA 無變更（無需跑 spa lint/test，但 PR description 註明「SPA unchanged」便於 review router）
+- 委派 codex 兩輪 review 收斂（標準 + adversarial 三視角）；重大 finding 全採納或開 follow-up issue
+- Phase 3 PR #638 merged 後 rebase 本 PR 到 main，`applyFrameEvent` 衝突解到 Phase 3 fallback chain 之上、本 PR reconcile 接線之下
+
+---
+
+## 9. 風險清單
+
+| # | 風險 | 緩解 |
+|---|---|---|
+| R1 | reconcile 找錯 ancestor（同 pane 但邏輯上不該收編，例如 user 手動 spawn 的 cc + codex 並非 parent-child 關係） | `findProxyParent` 已要求 PPID 鏈確切 ancestor + same-pane + live + identity-verified；reuse 同邏輯保護不變 |
+| R2 | reconcile 與 idle sweep 競爭：sweep 正在刪 parent，reconcile 同時 attach | `attachProxyRefWithRetry` 內部 `UpsertIfUnchanged` 已 cover：sweep delete 後 attach 回 attached=false（parent 不存在）→ reconcile 回 false → standalone 保留 |
+| R3 | reconcile 與 SubagentStart hook 競爭：cc 的 SubagentStart 同時在改 cc.Subagents | `attachProxyRefWithRetry` 用 `mutateSubagentsWithRetry` 共享 retry 機制；兩個並發 mutation 會收斂到 final state（PR-2b R6 已驗）|
+| R4 | DeleteIfUnchanged 的 `deleted=false` 殘留累積 | 同 §4 分析：常態下不發生；發生時 idle sweep 1h 兜底；極端情境下次 SessionStart 不會再嘗試 reconcile（frame != nil 走 update path）— 接受此漏網期 |
+| R5 | `findProxyParent` walk 在 reconcile 階段成本（每個新 frame 都 walk）| walk depth 上限 5；現代機器一次 walk < 1ms；SessionStart 頻率不高（每個 user-initiated session）— 可忽略 |
+| R6 | rebase Phase 3 後 applyFrameEvent 衝突 | Phase 3 改 fallback chain（line 220 區塊），Phase 3.5 改 new-frame Upsert 後（line 286 區塊）；位置不同，git rebase 應可機械處理；極端衝突由施工者手動解 |
+
+---
+
+## 10. Codex review focus 預期
+
+施工後委派 codex 兩輪 review 時的具體 focus 文字建議：
+
+**第一輪（標準 review）**：
+> Phase 3.5 — post-Upsert proxy canonicalization. 修 PR-2b 的 cold-start race。重點檢查：
+> 1. `reconcileCreatedFrameAsProxy` 對 `findProxyParent` 的重用是否會拿到自己的 frame（自我收編）
+> 2. `DeleteIfUnchanged` 失敗時的後續一致性（standalone 殘留 + parent 已含 proxy ref 的偏差是否會造成 SPA 顯示異常）
+> 3. trace meta 的 `Before` / `After` 表達在 reconcile 成功後是否與既有 trace step 慣例一致
+> 4. Phase 3.5 與 Phase 3 fallback chain 的互動（rebase 後接線位置會不會造成同 SessionStart 雙觸發）
+
+**第二輪（adversarial 三視角）**：
+- **攻擊方**：找 race interleaving 的死角；`findProxyParent` 在 reconcile 階段是否有可能返回剛被另一邊 reconcile 收編走的 ghost ancestor；DeleteIfUnchanged 與 idle sweep / probe status update 的競賽角度
+- **防守方**：B' 單向收斂規則的論證是否在所有 ancestor 拓撲下都成立；`findProxyParent` 重用 vs. 重寫的 trade-off
+- **檔案體質**：`frame_ops.go` 已 752 行，加 ~75 行後是否觸及 SRP 邊界；reconcile 是否該抽到獨立檔（如 `frame_canonicalize.go`）
+
+---
+
+## 11. Open questions（plan review 會解）
+
+1. 是否該把 reconcile 同步擴展到 non-SessionStart 路徑？（plan 目前不擴展，等 review 質疑再說）
+2. 是否需要 sweep canonicalization 作為 defensive layer？（plan §4 不做，等 review 投票）
+3. trace decision 是否該新增 `created_then_canonicalized` 與 `updated_frame` 區分？（plan 採 `updated_frame` + reason 區分，因為 final state 是 parent updated）
+4. `reconcileCreatedFrameAsProxy` 是否該抽到獨立檔？（plan 留在 `frame_ops.go`，理由：frame_ops 已是同檔的 race 修復集合）
+
+---
+
+## 12. 結束條件
+
+PR 跑過兩輪 codex review 收斂後：
+
+1. Phase 3 PR #638 merge 到 main（不 bump）
+2. Rebase 本 PR 到 main（解 applyFrameEvent 衝突）
+3. 本 PR merge 到 main（不 bump）
+4. 開 bump PR 把 VERSION + package.json + spa/package.json 同步到 alpha.225 + CHANGELOG 條目（涵蓋 Phase 3 + Phase 3.5）
+5. Bump merge → main @ alpha.225
+6. ExitWorktree 清掉 `lights-phase-3-5` worktree
+7. 更新 kickoff_lights_rebuild.md：標 Phase 3 + Phase 3.5 ✅ at alpha.225；下一步 Phase 4 probe audit

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,104 +1,95 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v3)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v4 / Hybrid B+)
 
 Baseline：`1.0.0-alpha.224`（main @ `75b4d166`）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`）。
 Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 → rebase 3.5 → 一次 bump alpha.225）。
 
-**v1 → v2 由 codex adversarial round 1 收斂**（§13；3 finding 全採納）：F1 ancestor-late race → bidirectional / F2 partial delete → retry + rollback / F3 mock test → integration ship gate。
+**v3 → v4 由兩 codex 平行架構 consulting 收斂**（§13；採 Side B Hybrid B+，捨棄 Side A SQL transaction）：
 
-**v2 → v3 由 codex adversarial round 2 收斂**（§13；3 finding 全採納）：
-- G1 high — rollback 也會失敗，仍殘留雙顯示 → **sweep canonicalization 納入本 PR**（§4 重新定位）+ **rollback 失敗 propagate error + trace 標 `partial_canonicalization`**（§2.1.1）
-- G2 high — descendant scan 缺 identity gate（PID reuse 誤抓） → 加 **`processStartTimeFn` 比對**（§2.1.2）
-- G3 medium — existing descendant 路徑永久漏網 → **sweep canonicalization 兜底**（§4）+ IT10 補測試（§3.1）
+> 三輪 codex review 都抓到同類 partial-state finding（F2 → G1 → H1）= meta-drift signal（feedback_codex_meta_drift_signal.md）。停止 patch，派 high-effort consulting。Side A 提議 SQL transaction 根除 attach+delete partial 物理層；Side B 用 evidence-based reasoning 證明 partial 是 ephemeral telemetry 的合法狀態，sweep recovery 是 2s（不是 1h），projection 層 dedup 即可隱藏 user-visible 差異。
+
+**v4 設計典範轉移**（不是再加 patch）：
+
+| 層 | v3 路線 | **v4 路線** |
+|---|---|---|
+| Hot-path 一致性 | rollback 強制保證 final state 一致；rollback 失敗 propagate error + partial trace | **接受 partial state 為合法**；rollback 移除；trace 簡化 |
+| User-visible | 依賴 rollback + sweep 兜底；trace partial signal 作觀察 | **Projection 層 dedup** 隱藏 partial；DB 一致性 = 軟標準 |
+| SessionEnd | 依賴 sweep 收 partial（v3 漏：child 退出後 parent 殘留 proxy ref 永久不清） | **SessionEnd hot path 也清 parent proxy ref** + sweep prune dead proxy refs |
+| Sweep 兜底 | canonicalizePane 補 standalone child（缺 candidate identity gate）| canonicalizePane 加 candidate identity gate（修 v3 H2 同類 bug）+ pruneDeadProxyRefs（修 Side B 抓的 SessionEnd 殘留洞）|
+| Trace | 加 `partial_canonicalization` reason（v3 H3：handler.go err path 不會寫入）| **移除** partial reason（projection 看不到 partial → 不需 trace；順便解 H3）|
+| Observability | partial trace（不可寫入）| **expvar 計數器**：partial_canonicalization_created / projection_dedup_hidden / sweep_canonicalized / sweep_pruned_proxy |
 
 ---
 
-## 0. 來龍去脈（必讀）
+## 0. 來龍去脈
 
 ### 0.1 修什麼
 
-**Race 來源**：Phase 2 PR-2b 的 `findProxyParent`（`internal/module/agent/frame_ops.go:688`）只做 *pre-Upsert* PPID 走訪，無 post-Upsert 收斂。當兩個跨型別 SessionStart 在同一 pane 並發冷啟動（典型場景：daemon restart 後 cc + codex proxy 同時來），兩邊 walk 各自 miss → 各自 `Upsert` → 結果是兩個獨立 frame，PR-2b 的 proxy collapse 失效。
+**Race 來源**（不變）：Phase 2 PR-2b 的 `findProxyParent` 只做 *pre-Upsert* PPID 走訪。並發冷啟動的兩個跨型別 SessionStart 可能各自 walk-miss → 各自 Upsert → 兩個獨立 frame，PR-2b proxy collapse 失效。
 
-**最容易觸發的場景**（Phase 3 codex round 2 finding #1 提出）：daemon restart → cc 與 codex proxy 同時冷啟動。Phase 3 加上 `tryRebuildFromProcessTree` 後 race window 變大，但 race 本身在 alpha.221 PR-2b 落地起就存在。
+**最容易觸發的場景**（不變）：daemon restart 後 cc + codex proxy 同時冷啟動。Phase 3 加 `tryRebuildFromProcessTree` 後 race window 變大，但 race 本身在 alpha.221 PR-2b 落地起就存在。
 
-### 0.2 設計來源 + v1→v2 演進
+### 0.2 設計哲學（v4 核心轉折）
 
-Codex architectural consulting `task-modcbbhg-auxa36`（high-effort）採方案 **B'：post-Upsert canonicalization by ancestry**，捨棄 per-pane mutex / pane-level claim table / SQL UNIQUE / delay window 等 hack。
+`agent_frames` 表是 **ephemeral telemetry**（store migration 註解明確說 legacy 偵測時可 lossless clear `internal/store/frames.go:65`）。它不是 durable domain state，row-level 跨表強一致性標準過高。
 
-**v1 設計**：descendant SessionStart Upsert 後做 reconcile（往上 walk 找 ancestor 收編自己）。
+**partial state 在這張表是合法的中間狀態**，只要：
+1. **User-visible（projection / SPA）永遠看不到 partial** — projection 層 dedup
+2. **Eventual consistency 在 bounded time** — sweep 2s 一輪即收斂
+3. **Observable** — metric 計數器顯示 partial 發生率，超 SLO 才升級到強一致設計
 
-**v1 漏洞**（codex F1）：descendant 先到 → walk miss → Upsert → reconcile 仍 miss（ancestor 還沒 Upsert）→ ancestor 後到 → 依「ancestor 不可轉 descendant」規則不會收編 descendant → 兩個 frame 永久殘留。
+依此設計分四層：
 
-**v2 修正**：Bidirectional canonicalization。SessionStart 做兩個動作（不衝突 secondary race，因為遵守相同單向規則）：
-
-| Side | 動作 | Walk 方向 |
+| 層 | 職責 | 實作 |
 |---|---|---|
-| Self-as-descendant（reconcile） | 找 cross-type ancestor，attach 自己為 ancestor 的 proxy + delete 自己 | 從 self 往上 walk PPID |
-| Self-as-ancestor（descendant scan） | 掃同 pane 其他 standalone frames，PPID 鏈經過 self 且跨型別的 → attach 為 self 的 proxy + delete 該 frame | 從每個 candidate 往上 walk PPID 找 self.PID |
-
-兩個動作都遵守單向規則（ancestor 收編 descendant，descendant 變 proxy，從不反向），不會引入 secondary race。例：cc + codex 並發冷啟動：
-
-| 順序 | descendant reconcile | ancestor descendant-scan | 結果 |
-|---|---|---|---|
-| descendant first（codex Upsert，cc 還沒到） | codex walk no ancestor → no-op | （cc 還沒 SessionStart） | codex standalone |
-| ↓ cc Upsert 後 | (cc 沒 ancestor，self-reconcile no-op) | cc scan 找到 codex（PPID 鏈經過 cc）→ attach + delete codex | 1 cc frame + codex proxy ✓ |
-| ancestor first（cc Upsert，codex 還沒到） | cc walk no ancestor → no-op | cc scan，pane 內無其他 frame → no-op | cc standalone |
-| ↓ codex Upsert 後 | codex walk 找到 cc → attach + delete codex | (codex 沒 descendant，scan 無動作) | 1 cc frame + codex proxy ✓ |
-| 完全並發（混合 Upsert）| 兩邊都做：先到的 reconcile 可能 miss，後到的 reconcile 找到 ancestor + scan 收編 race window 內進來的 standalone | 兜底所有 ordering | final 1 cc frame ✓ |
+| **Hot path** | best-effort canonicalization；失敗不 retry/rollback；繼續 | `reconcileCreatedFrameAsProxy` + `canonicalizeDescendantsAfterUpsert` + SessionEnd `removeProxyRefForSender` |
+| **Projection** | 隱藏 partial（**唯一 strongly consistent 邊界**）| `buildPaneProjection` dedup：parent.Subagents 含 IsProxy + (SourcePID, SourceStartTime) → 排除 matching standalone frame |
+| **Sweep** | bounded-time recovery（2s 一輪）| `canonicalizePane` 補 hot-path 漏網 + `pruneDeadProxyRefs` 清死 proxy ref |
+| **Observability** | partial 發生率可量化 | expvar counters |
 
 ### 0.3 與 Phase 3 的關係
 
-- **獨立但相關**：race 本身不依賴 Phase 3 的 `daemon_restart_recovery` 程式碼，而是 PR-2b（alpha.221）就存在的舊洞
-- **接線位置同檔**：Phase 3 與 Phase 3.5 都動 `applyFrameEvent`（前者加 fallback chain rebuild，後者加 post-Upsert + post-Update reconcile）— rebase 時可能在 fallback chain 區段衝突
-- **獨立 PR**：依 kickoff 「切 Phase 3.5 獨立 PR」決策；Phase 3 PR #638 merge 後 rebase Phase 3.5
+不變：獨立 PR；rebase 順序 Phase 3 → Phase 3.5；衝突點在 `applyFrameEvent` 不同區塊。
 
 ---
 
 ## 1. 既有原語（沿用，無新 store API）
 
-PR-2b 已備齊所有需要的原語：
-
 | 原語 | 位置 | 用途 |
 |---|---|---|
-| `findProxyParent(req)` | `frame_ops.go:688` | PPID 鏈走訪 + same-pane + live + identity-verified + cross-type 篩選；reconcile 直接重用 |
+| `findProxyParent(req)` | `frame_ops.go:688` | PPID 鏈走訪 + same-pane + live + identity-verified + cross-type；reconcile 重用 |
 | `attachProxyRefWithRetry(parent, ref, broadcastTs)` | `frame_ops.go:631` | optimistic concurrency attach |
-| `detachProxyRefWithRetry(owner, senderPID, senderStartTime, broadcastTs)` | `frame_ops.go:640` | optimistic concurrency detach（**v2 新用於 rollback**）|
-| `FramesStore.DeleteIfUnchanged(frameID, lastSeenAt)` | `internal/store/frames.go:263` | atomic delete |
-| `FramesStore.ListByPane(paneID)` | 既有 | descendant scan 用 |
-| `FramesStore.GetByIdentity(paneID, pid, startTime)` | 既有 | 重 reload child for retry |
+| `detachProxyRefWithRetry(owner, senderPID, senderStartTime, broadcastTs)` | `frame_ops.go:640` | optimistic concurrency detach |
+| `removeProxyRefForSender(...)` | `frame_ops.go:546` | SessionEnd path 既有 proxy detach；v4 也用於 hot-path proxy cleanup |
+| `FramesStore.DeleteIfUnchanged` | `internal/store/frames.go:263` | atomic delete |
+| `FramesStore.ListByPane` / `GetByIdentity` | 既有 | scan + reload |
 | `SubagentRef{...}` | `internal/agent/subagent.go` | proxy ref 型別（PR-2a）|
-| Proxy ID 格式 `proxy:%s:%d:%s` | `frame_ops.go:176` 既有 | reconcile 必須沿用同格式 |
+| Proxy ID 格式 `proxy:%s:%d:%s` | `frame_ops.go:176` | reconcile / scan / sweep 一致 |
 
-**沒有**新 store method、沒有新型別、沒有新 SQL。
+**沒有**新 store method、沒有新型別、沒有 SQL transaction。
 
 ---
 
 ## 2. 設計細節
 
-### 2.1 Helper 二件
+### 2.1 Hot-path helpers（簡化自 v3，移除 rollback）
 
 #### 2.1.1 `reconcileCreatedFrameAsProxy`（self-as-descendant）
 
 ```go
-const reconcileDeleteMaxAttempts = 3
-
 // reconcileCreatedFrameAsProxy attempts to canonicalize a freshly-created
 // SessionStart frame against an alive cross-type ancestor. If found, attaches
-// proxy ref to ancestor + deletes self's standalone frame.
+// proxy ref to ancestor + best-effort deletes self's standalone frame.
 //
-// Bounded retry on delete (v2 F2): if DeleteIfUnchanged returns deleted=false
-// (concurrent writer touched child row, e.g. probe status update), reload
-// child + retry up to reconcileDeleteMaxAttempts. If all retries fail, ROLLBACK
-// the proxy attach via detachProxyRefWithRetry — final state is consistent
-// (parent has no proxy + child still standalone) rather than the inconsistent
-// (parent has proxy + child still standalone) double-display.
+// v4 design: best-effort. If DeleteIfUnchanged fails (concurrent writer
+// touched child row), increment partial counter and return; sweep
+// canonicalize will retry within 2s (sweepInterval). projection_dedup
+// hides the partial state from SPA in the meantime.
 //
-// Returns (canonicalized, parentStored, err):
-//   - canonicalized=true with parentStored populated when attach + delete both
-//     succeeded.
-//   - canonicalized=false, zeroFrame, nil when no ancestor found, parent
-//     vanished mid-attach, or delete-retry exhausted and rollback succeeded.
-//   - non-nil error only for storage failures.
+// Returns (canonicalized=true, parentStored, nil) when attach + delete
+// both succeeded. Returns (false, zero, nil) for: no ancestor / parent
+// vanished mid-attach / partial state (attach succeeded, delete failed —
+// counted in metrics, repaired by sweep). Storage errors propagate.
 func (m *Module) reconcileCreatedFrameAsProxy(
     stored store.Frame,
     req EventRequest,
@@ -126,112 +117,66 @@ func (m *Module) reconcileCreatedFrameAsProxy(
     if !attached {
         return false, store.Frame{}, nil
     }
-    // Bounded delete retry with reload: child's last_seen_at could have
-    // moved if probe status update / SubagentStart hit between attach and
-    // delete. Reload via GetByIdentity each retry.
-    childPaneID := stored.PaneID
-    childPID := stored.PID
-    childStartTime := stored.ProcessStartTime
-    expectedLastSeen := stored.LastSeenAt
-    for attempt := 0; attempt < reconcileDeleteMaxAttempts; attempt++ {
-        deleted, derr := m.frames.DeleteIfUnchanged(stored.FrameID, expectedLastSeen)
-        if derr != nil {
-            return false, store.Frame{}, derr
-        }
-        if deleted {
-            return true, parentStored, nil
-        }
-        reloaded, rerr := m.frames.GetByIdentity(childPaneID, childPID, childStartTime)
-        if rerr != nil {
-            return false, store.Frame{}, rerr
-        }
-        if reloaded == nil {
-            // Already gone (concurrent SessionEnd / sweep). Treat as success.
-            return true, parentStored, nil
-        }
-        expectedLastSeen = reloaded.LastSeenAt
+    deleted, derr := m.frames.DeleteIfUnchanged(stored.FrameID, stored.LastSeenAt)
+    if derr != nil {
+        return false, store.Frame{}, derr
     }
-    // Bounded retry exhausted: try rollback the proxy attach. Rollback can
-    // itself fail (storage error or its own retry exhaustion under sustained
-    // contention) — propagate that as a partial-state observable signal
-    // rather than swallowing it (codex round 2 G1 fix). The sweep
-    // canonicalization pass (§4) is the unconditional defensive layer that
-    // eventually repairs partial states regardless of which path failed.
-    rollback, _, rerr := m.detachProxyRefWithRetry(parentStored, req.SenderPID, req.SenderStartTime, broadcastTs)
-    if rerr != nil {
-        log.Printf("phase3.5: reconcile rollback FAILED for child frame %s parent %s: %v — sweep canonicalize will repair", stored.FrameID, parentStored.FrameID, rerr)
-        return false, store.Frame{}, fmt.Errorf("phase3.5 reconcile partial state: attach succeeded, delete retry exhausted, rollback errored: %w", rerr)
-    }
-    if !rollback {
-        // Detach completed without error but didn't find the ref to remove —
-        // either parent vanished or another writer beat us to it. Final
-        // state: child standalone, parent has no inconsistent ref. Trace
-        // marks partial so observability captures the path.
-        log.Printf("phase3.5: reconcile delete-retry exhausted, rollback no-op (parent gone) for child %s", stored.FrameID)
+    if !deleted {
+        // Partial state: parent has proxy + child still standalone.
+        // Acceptable transient — projection_dedup hides; sweep canonicalize
+        // (2s loop) repairs. Increment metric for observability.
+        metricPartialCanonicalizationCreated.Add(1)
+        log.Printf("phase3.5: reconcile partial state child %s parent %s (sweep will repair within 2s)", stored.FrameID, parentStored.FrameID)
         return false, store.Frame{}, nil
     }
-    log.Printf("phase3.5: reconcile delete-retry exhausted for child frame %s; rolled back proxy attach on parent %s", stored.FrameID, parentStored.FrameID)
-    return false, store.Frame{}, nil
+    return true, parentStored, nil
 }
 ```
 
-#### 2.1.2 `canonicalizeDescendantsAfterUpsert`（self-as-ancestor — v2 新增）
+**為什麼移除 v2/v3 的 retry + rollback**：
+
+- Side B consulting evidence：sweep 2s loop + projection dedup → partial 容忍度從「分鐘級」降「秒級且不可見」
+- 三輪 codex review 都抓 partial state finding 不是 race 本身嚴重，而是「v1/v2/v3 把 ephemeral 表當 durable 標準」 — 修法是調標準，不是加 patch
+- 移除 rollback → caller 邏輯簡化、無需 partial trace（H3 自然消失）、無需 propagate partial error（user-visible 已被 dedup 隱藏）
+
+#### 2.1.2 `canonicalizeDescendantsAfterUpsert`（self-as-ancestor）
 
 ```go
-// canonicalizeDescendantsAfterUpsert scans the pane for standalone frames
-// whose PPID chain passes through self.PID and folds them as proxy refs on
-// self, deleting their standalone rows. Closes the ancestor-late race window
-// (codex F1): descendant's pre-Upsert walk + post-Upsert reconcile both miss
-// because ancestor wasn't in the store yet — when ancestor's SessionStart
-// finally arrives, descendant scan picks them up.
+// canonicalizeDescendantsAfterUpsert scans pane for standalone cross-type
+// descendants whose PPID chain passes through self.PID + identity-verified
+// alive, and folds them as proxy refs on self.
 //
-// Direction-safe: only attaches descendants to self (single-direction rule);
-// never converts self into someone's descendant. Symmetric with reconcile-as-
-// descendant — together they bracket all cold-start interleavings.
-//
-// Per-candidate failures (attach race lost / delete race lost / individual
-// PPID walk error) are logged and skipped; canonicalization is best-effort
-// and idempotent across SessionStart cycles. Storage errors abort the scan.
+// v4: identity gate (alive + processStartTimeFn match) prevents PID-reuse
+// stale row pollution (codex round 2 G2 + same logic applied to sweep H2).
+// Best-effort delete; partial state acceptable (sweep + projection_dedup).
 func (m *Module) canonicalizeDescendantsAfterUpsert(
     self store.Frame,
     broadcastTs int64,
-) error {
+) (store.Frame, error) {
     if m.frames == nil {
-        return nil
+        return self, nil
     }
     frames, err := m.frames.ListByPane(self.PaneID)
     if err != nil {
-        return err
+        return self, err
     }
+    current := self
     for _, candidate := range frames {
-        if candidate.FrameID == self.FrameID {
+        if candidate.FrameID == current.FrameID {
             continue
         }
-        if candidate.AgentType == self.AgentType {
-            // Same-type sibling: not a proxy candidate per PR-2b semantics.
+        if candidate.AgentType == current.AgentType {
             continue
         }
-        if !pidIsAncestorOfWithCap(candidate.PID, self.PID, proxyMaxDepth) {
+        if !pidIsAncestorOfWithCap(candidate.PID, current.PID, proxyMaxDepth) {
             continue
         }
-        // Identity gate (codex round 2 G2 fix): align with findProxyParent's
-        // alive + start_time identity verification. Without start_time check,
-        // a PID-reused stale row would be folded onto self with the OLD
-        // ProcessStartTime, producing a stale proxy ref AND deleting the
-        // (already-stale) row. Reads the live OS process's start_time and
-        // compares against the candidate row's stored ProcessStartTime;
-        // mismatch (or read error) → skip, leave for sweep to clean up.
+        // Identity gate (PR-2b alignment + v3 G2 + sweep H2 unification).
         if !isPidAliveFn(candidate.PID) {
             continue
         }
         actualStart, sterr := processStartTimeFn(candidate.PID)
-        if sterr != nil {
-            // Identity unverifiable → don't infer (consistent with verify.go
-            // / findProxyParent convention).
-            continue
-        }
-        if actualStart != candidate.ProcessStartTime {
-            // PID reuse — stale row; sweep will clear by liveness later.
+        if sterr != nil || actualStart != candidate.ProcessStartTime {
             continue
         }
         ref := agentpkg.SubagentRef{
@@ -242,31 +187,30 @@ func (m *Module) canonicalizeDescendantsAfterUpsert(
             SourceStartTime: candidate.ProcessStartTime,
             IsProxy:         true,
         }
-        attached, parentStored, aerr := m.attachProxyRefWithRetry(self, ref, broadcastTs)
+        attached, parentStored, aerr := m.attachProxyRefWithRetry(current, ref, broadcastTs)
         if aerr != nil {
-            return aerr
+            return current, aerr
         }
         if !attached {
-            // Self vanished (extreme); abort scan — caller's projection will
-            // refresh on next ListByPane anyway.
-            return nil
+            return current, nil
         }
-        // Bounded delete retry mirrors §2.1.1; on failure rollback this single
-        // proxy ref. Don't abort the whole scan — other candidates may still
-        // canonicalize cleanly.
-        if !m.deleteWithRetryOrRollback(candidate, parentStored, broadcastTs) {
-            log.Printf("phase3.5: descendant scan rolled back proxy %s on parent %s (delete race lost)", ref.ID, self.FrameID)
-            continue
+        deleted, derr := m.frames.DeleteIfUnchanged(candidate.FrameID, candidate.LastSeenAt)
+        if derr != nil {
+            return parentStored, derr
         }
-        // Refresh self for next iteration (subagents list grew).
-        self = parentStored
+        if !deleted {
+            metricPartialCanonicalizationCreated.Add(1)
+            log.Printf("phase3.5: descendant scan partial state child %s parent %s", candidate.FrameID, parentStored.FrameID)
+            // Continue scanning others; this candidate retries in sweep.
+        }
+        current = parentStored
     }
-    return nil
+    return current, nil
 }
 
 // pidIsAncestorOfWithCap walks descendant's PPID chain (capped at depth)
-// looking for ancestorPID. Returns true on hit, false on miss / depth
-// exhaustion / process info error / loop detection (PPID == PID).
+// looking for ancestorPID. Returns true on hit, false on miss / depth /
+// info error / loop detection (PPID == PID).
 func pidIsAncestorOfWithCap(descendantPID, ancestorPID, maxDepth int) bool {
     current := descendantPID
     for depth := 0; depth < maxDepth; depth++ {
@@ -284,44 +228,9 @@ func pidIsAncestorOfWithCap(descendantPID, ancestorPID, maxDepth int) bool {
     }
     return false
 }
-
-// deleteWithRetryOrRollback factors the bounded delete + rollback pattern
-// shared by reconcile and descendant-scan. Returns true on successful delete
-// (or already-gone), false on rolled-back attach (caller should treat the
-// proxy ref as not-applied).
-func (m *Module) deleteWithRetryOrRollback(
-    candidate store.Frame,
-    parent store.Frame,
-    broadcastTs int64,
-) bool {
-    expectedLastSeen := candidate.LastSeenAt
-    for attempt := 0; attempt < reconcileDeleteMaxAttempts; attempt++ {
-        deleted, err := m.frames.DeleteIfUnchanged(candidate.FrameID, expectedLastSeen)
-        if err != nil {
-            return false
-        }
-        if deleted {
-            return true
-        }
-        reloaded, rerr := m.frames.GetByIdentity(candidate.PaneID, candidate.PID, candidate.ProcessStartTime)
-        if rerr != nil || reloaded == nil {
-            return reloaded == nil  // gone is success
-        }
-        expectedLastSeen = reloaded.LastSeenAt
-    }
-    rollback, _, _ := m.detachProxyRefWithRetry(parent, candidate.PID, candidate.ProcessStartTime, broadcastTs)
-    _ = rollback  // even if rollback also lost, final state is "no proxy + child standalone" once concurrent writers settle
-    return false
-}
 ```
 
-**為什麼 walk 設計仍 reuse `findProxyParent`**：reconcile-as-descendant 走 sender 的 PPID 鏈，跟 PR-2b 既有 `findProxyParent` 完全同型。重用避免兩套 walk drift。
-
-**為什麼 descendant scan 不重用 `findProxyParent`**：descendant scan 的 walk 起點是 *candidate*（standalone frame）的 PID，目標是看 PPID 鏈是否經過 self。findProxyParent 的目標是「找 ancestor」 — 語義不同。新抽 `pidIsAncestorOfWithCap` 是專注的 yes/no 查詢，比硬塞 findProxyParent 加旗標更乾淨。
-
-### 2.2 接線（applyFrameEvent）
-
-兩個 wiring point — SessionStart 命中 frame == nil（新建）與 frame != nil（既有 reset）。
+### 2.2 接線（applyFrameEvent，兩個 wire site）
 
 #### 2.2.1 New frame 路徑（line 286-292 之後）
 
@@ -332,9 +241,8 @@ func (m *Module) deleteWithRetryOrRollback(
         return nil, FrameTraceMeta{}, err
     }
 
-    // Phase 3.5: bidirectional canonicalization.
+    // Phase 3.5: bidirectional canonicalization (best-effort).
     if req.EventName == "SessionStart" {
-        // Self-as-descendant: try collapse into ancestor.
         canonicalized, parentStored, rerr := m.reconcileCreatedFrameAsProxy(stored, req, broadcastTs)
         if rerr != nil {
             return nil, FrameTraceMeta{}, rerr
@@ -350,14 +258,12 @@ func (m *Module) deleteWithRetryOrRollback(
                 After:         summarizeFrame(&parentStored),
             }, err
         }
-        // Self-as-ancestor: try collapse standalone descendants into self.
-        if cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs); cerr != nil {
+        // self stays standalone or partial: try descendant scan.
+        updated, cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs)
+        if cerr != nil {
             return nil, FrameTraceMeta{}, cerr
         }
-        // Reload self in case descendant scan attached refs.
-        if reloaded, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime); rerr == nil && reloaded != nil {
-            stored = *reloaded
-        }
+        stored = updated
     }
 }
 ```
@@ -370,145 +276,295 @@ if req.EventName == "SessionStart" {
 } else {
     updateErr = m.frames.UpdateHookPath(updated)
 }
-if updateErr != nil {
-    return nil, FrameTraceMeta{}, updateErr
-}
+if updateErr != nil { return nil, FrameTraceMeta{}, updateErr }
 reloaded, err := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
-if err != nil {
-    return nil, FrameTraceMeta{}, err
-}
-if reloaded == nil {
-    return nil, FrameTraceMeta{}, nil
-}
+if err != nil { return nil, FrameTraceMeta{}, err }
+if reloaded == nil { return nil, FrameTraceMeta{}, nil }
 stored = *reloaded
 
-// Phase 3.5: existing-frame SessionStart also runs descendant-scan. The
-// race window here: this frame existed (e.g. cc was running before daemon
-// restart, cc's frame survived rebuild via Phase 3 tryRebuildFromProcessTree)
-// while a concurrent SessionStart from a descendant landed standalone
-// because the rebuild raced. Reset already cleared subagents, so attach
-// scan is safe.
-//
-// Note: self-as-descendant reconcile is NOT run here. An existing frame
-// is already a stable identity; collapsing it post-hoc into another
-// ancestor would orphan the user's session. Only descendant-scan applies.
+// Phase 3.5: existing-frame SessionStart runs descendant-scan only (no
+// self-reconcile — existing frame is stable identity, collapsing into
+// ancestor would orphan user's session).
 if req.EventName == "SessionStart" {
-    if cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs); cerr != nil {
+    updated, cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs)
+    if cerr != nil {
         return nil, FrameTraceMeta{}, cerr
     }
-    if reloaded2, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime); rerr == nil && reloaded2 != nil {
-        stored = *reloaded2
+    stored = updated
+}
+```
+
+### 2.3 SessionEnd proxy cleanup（v4 新，修 Side B 抓的 SessionEnd 漏洞）
+
+**問題**：當 partial state 已存在（parent 含 proxy ref + child standalone frame），child 進入 `SessionEnd` 時：
+
+- 既有 `applyFrameEvent` 命中 child frame（GetByIdentity 找到）→ 走 line 53-65 `Delete(frame.FrameID)` 後 return
+- **不會執行 line 70 的 `removeProxyRefForSender`**（那只在 frame == nil 時走）
+- 結果：child frame 沒了，但 parent 上的 proxy ref 永久殘留 → SPA 顯示假 dot
+
+**修法**：SessionEnd 命中 child frame 時，刪 frame 後再 best-effort 清同 pane 上對應的 proxy ref：
+
+```go
+case "SessionEnd":
+    if frame != nil {
+        if err := m.frames.Delete(frame.FrameID); err != nil {
+            return nil, FrameTraceMeta{}, err
+        }
+        // v4: best-effort proxy cleanup for partial state where this
+        // frame was simultaneously a standalone row AND a proxy ref on
+        // an ancestor (cold-start race partial). Without this, parent's
+        // proxy ref outlives child SessionEnd permanently.
+        _, _, _, _, _ = m.removeProxyRefForSender(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, broadcastTs)
+        projection, err := m.projectPane(req.TmuxPaneID)
+        return projection, FrameTraceMeta{
+            FrameID:       frame.FrameID,
+            ParentFrameID: frame.ParentFrameID,
+            Decision:      "deleted_frame",
+            Reason:        "session_end",
+            Before:        before,
+            After:         map[string]any{},
+        }, err
+    }
+    // ... existing frame == nil path unchanged
+```
+
+**為什麼忽略 removeProxyRefForSender 結果**：partial state 是少數情況；nil/false 是常態（沒有殘留 proxy）。錯誤情境由 sweep `pruneDeadProxyRefs` 兜底（§4）。
+
+### 2.4 Projection layer dedup（v4 新核心）
+
+**`buildPaneProjection` 的當前邏輯**（`projection.go:38`）：
+
+```go
+sorted := frames sorted by StartedAt
+top := sorted[len(sorted)-1]   // 最後 StartedAt 的 frame
+subagents := top.Subagents
+return SessionProjection{TopFrame: &top, Subagents: subagents}
+```
+
+**問題**：partial state 下，pane 內可能有：
+- frame_cc（StartedAt = T1，Subagents 含 codex proxy ref）
+- frame_codex_standalone（StartedAt = T2 > T1，因為它 race 後到的，Subagents 空）
+
+排序後 top = frame_codex_standalone → SPA 看到 codex 是 primary，不見 cc + codex proxy 的正確 collapse。
+
+**v4 dedup**：buildPaneProjection 排序前，先掃所有 frame 的 Subagents 收集 proxy 標記的 (SourcePID, SourceStartTime)，然後排除 matching frame：
+
+```go
+func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection {
+    if len(frames) == 0 {
+        return SessionProjection{PaneID: paneID, Subagents: []agentpkg.SubagentRef{}}
+    }
+
+    // v4 dedup: collect proxy-claimed senders so we exclude their standalone
+    // frame rows from TopFrame selection. Avoids partial-state visibility
+    // where a SessionStart racer landed standalone but is also already
+    // attached as a proxy ref on the canonical parent (cold-start race).
+    type claim struct {
+        pid       int
+        startTime string
+    }
+    claimed := make(map[claim]bool)
+    for _, frame := range frames {
+        for _, ref := range frame.Subagents {
+            if ref.IsProxy {
+                claimed[claim{ref.SourcePID, ref.SourceStartTime}] = true
+            }
+        }
+    }
+
+    visible := make([]store.Frame, 0, len(frames))
+    var hidden int
+    for _, frame := range frames {
+        if claimed[claim{frame.PID, frame.ProcessStartTime}] {
+            hidden++
+            continue
+        }
+        visible = append(visible, frame)
+    }
+    if hidden > 0 {
+        metricProjectionDedupHidden.Add(int64(hidden))
+    }
+    if len(visible) == 0 {
+        // All frames are claimed — extreme edge case where pane has only
+        // proxy-attached frames and no canonical owner. Fall back to
+        // unfiltered selection (avoid dropping pane entirely).
+        visible = frames
+    }
+
+    sorted := append([]store.Frame(nil), visible...)
+    sort.Slice(sorted, func(i, j int) bool {
+        if sorted[i].StartedAt == sorted[j].StartedAt {
+            return sorted[i].FrameID < sorted[j].FrameID
+        }
+        return sorted[i].StartedAt < sorted[j].StartedAt
+    })
+
+    primary := sorted[0]
+    top := sorted[len(sorted)-1]
+    subagents := append([]agentpkg.SubagentRef(nil), top.Subagents...)
+    if subagents == nil {
+        subagents = []agentpkg.SubagentRef{}
+    }
+    return SessionProjection{
+        PaneID:       paneID,
+        PrimaryFrame: &primary,
+        TopFrame:     &top,
+        Subagents:    subagents,
     }
 }
 ```
 
-**為什麼 existing frame 不做 self-as-descendant**：existing frame 走進這條路徑時，frame 已是 stable 識別（先前的 SessionStart 建立）。再 collapse 進 ancestor 會把使用者已認知的 session 突然變成另一個 frame 的 sub-dot，UX 撕裂。
-**為什麼 existing frame 仍做 descendant-scan**：daemon restart 後 Phase 3 `tryRebuildFromProcessTree` 可能把 ancestor frame 重建成 existing，若 race window 期間 descendant 已 standalone，這是唯一收編機會。
+**為什麼 fallback to unfiltered**：理論上 pane 內所有 frame 都是別人的 proxy 是不可能（總有一個 canonical），但若發生（極端 cycle），不能讓 pane 直接消失於 projection。fallback 保底 + metric 累加異常觀察。
 
-### 2.3 Trace decision 詞彙
+**為什麼 dedup 在 daemon 不在 SPA**（Side B 修正點）：SPA `useAgentStore` 只收 NormalizedEvent，沒有完整 frame list 與 PID graph，無法 dedup；必須在 daemon `buildPaneProjection`。
+
+### 2.5 Trace decision 詞彙（v4 簡化）
 
 | 決策 | Reason | 觸發 |
 |---|---|---|
 | `updated_frame` | `proxy_subagent_attached` | PR-2b pre-Upsert proxy fast-path（既有，不改）|
 | `created_frame` | `parent_frame_found` / `parent_frame_missing` | 一般 new frame 路徑（既有，不改）|
-| `updated_frame` | `post_upsert_canonicalization_self` | **v2 新**，self 變 proxy 收編成功 |
-| `created_frame` | `parent_frame_found` / `parent_frame_missing`（沿用） + log line | **v3** rollback 成功 / no-op 後（child standalone、parent 不含 proxy）|
-| `partial_canonicalization` | `partial_canonicalization` | **v3 新**，applyFrameEvent 仍回 `created_frame` decision，但 reason 升 `partial_canonicalization`；同時整體 applyFrameEvent 回 error 觸發 handler 重試/log；sweep 兜底|
-| 沿用原 trace | 原 reason | descendant scan 不改 trace（scan 是 side effect of attaching descendants；主決策仍是「建/更新此 frame」）|
+| `updated_frame` | `post_upsert_canonicalization_self` | self-as-descendant reconcile 收編成功（v2 引入，v4 保留）|
 
-descendant scan 不改 trace 的原因：scan 把其他 frame 收編進來，但本 SessionStart 的主語義仍是「建立或更新 self」 — trace 應反映 self 視角。被收編的 descendant 留在 reconcile-as-descendant 那條路徑的 trace（前一次 SessionStart 留下的 created_frame trace）。
+**v3 的 `partial_canonicalization` reason 移除**：
 
-### 2.4 Wire compatibility
+- 原意是 rollback 失敗時觀察 partial — v4 移除 rollback，分支不存在
+- handler.go err path 不會呼 `trace.Frame` 寫入（v3 H3）— 結構性無法消費
+- 替代：partial 透過 expvar metric 觀察（§2.6），不污染 trace
 
-不改 NormalizedEvent / SubagentRef / projection wire schema。SPA 看到的最終結果：parent.subagents 列表多一個 IsProxy=true 的 ref，跟 PR-2b 既有 proxy attach 完全同型。
+descendant scan 收編 standalone children 不改 trace（與 v3 一致）— scan 是 self 視角的 side effect，主決策仍是「建/更新此 frame」。
+
+### 2.6 Metrics（v4 新）
+
+用 Go stdlib `expvar`（無新依賴；既有 daemon 若無 expvar 啟動則 graceful degrade，僅內部變數）：
+
+```go
+package agent
+
+import "expvar"
+
+var (
+    metricPartialCanonicalizationCreated = expvar.NewInt("purdex_phase35_partial_canonicalization_created_total")
+    metricProjectionDedupHidden          = expvar.NewInt("purdex_phase35_projection_dedup_hidden_total")
+    metricSweepCanonicalized             = expvar.NewInt("purdex_phase35_sweep_canonicalized_total")
+    metricSweepPrunedProxy               = expvar.NewInt("purdex_phase35_sweep_pruned_proxy_total")
+)
+```
+
+**SLO 觀察點**：
+- partial_canonicalization_created：partial state 發生率；超過 1/1000 SessionStart 升級到強一致設計
+- projection_dedup_hidden：dedup 實際生效次數；應趨近 partial_canonicalization 數
+- sweep_canonicalized / sweep_pruned_proxy：sweep 兜底頻次；持續高表示 hot-path 失敗率高
+
+不依賴 expvar handler 暴露；本 PR 不掛 metrics endpoint，留 follow-up issue（觀察先在 daemon 內測量）。
+
+### 2.7 Wire compatibility
+
+不改 NormalizedEvent / SubagentRef / projection wire schema。SPA 看到的最終結果與既有 PR-2b proxy attach 完全同型。
 
 ---
 
 ## 3. 測試矩陣
 
-### 3.1 Integration 測試（**必要 ship gate** — v2 升級自 optional）
+### 3.1 Integration 測試（必要 ship gate）
 
-新增 `internal/module/agent/canonicalize_test.go`（或加進 `module_test.go` 末尾），用真 sqlite store + 真 process info mock + 真 sequence ordering，覆蓋下列 scenarios。
-
-**Test harness**：沿用 `module_test.go` 的 `newTestModule(t)` pattern + `readProcessInfoFn` global injection（PR-2b 既有），不開 goroutine。每個 case 直接呼 `m.applyFrameEvent` 兩到三次模擬不同到達順序。
+新增 `internal/module/agent/canonicalize_test.go`（或加進 `module_test.go` 末尾）：
 
 | # | 名稱 | Sequence | 預期 final state |
 |---|---|---|---|
-| IT1 | `descendant_then_ancestor_canonicalizes_via_descendant_scan` | (a) codex SessionStart applyFrameEvent — pane 內無 frame → standalone codex frame；(b) cc SessionStart applyFrameEvent — pane 內有 codex standalone → cc Upsert + descendant scan 找到 codex（PPID 鏈經過 cc）→ attach + delete codex | 1 cc frame，cc.Subagents 含 codex proxy ref；codex frame 已刪 |
-| IT2 | `ancestor_then_descendant_canonicalizes_via_self_reconcile` | (a) cc SessionStart — standalone cc；(b) codex SessionStart — pre-Upsert findProxyParent 找到 cc → 走 PR-2b fast-path attach + 不建 codex frame **(this is the existing PR-2b path, sanity check)** | 1 cc frame，cc.Subagents 含 codex proxy ref |
-| IT3 | `concurrent_with_descendant_pre_walk_miss_reconcile_hits` | (a) codex applyFrameEvent — mock `findProxyParent` pre-walk 第 1 次 call 回 nil（cc 未入庫）→ codex Upsert standalone；模擬 cc 同時 Upsert 完成；codex 內 reconcile 跑 post-Upsert findProxyParent 第 2 次 call 回 cc → attach codex 為 cc proxy + delete codex | 1 cc frame + codex proxy ref |
-| IT4 | `concurrent_descendant_post_reconcile_also_misses_recovered_by_ancestor_scan` | (a) codex applyFrameEvent，mock 兩次 findProxyParent 都 miss（cc Upsert 真的還沒到）→ codex standalone 殘留；(b) cc applyFrameEvent → cc Upsert + descendant scan 收編 codex | 1 cc frame + codex proxy ref（cover ancestor-late race，F1 fix 的核心驗證） |
-| IT5 | `delete_race_lost_then_rollback_keeps_consistency` | mock `DeleteIfUnchanged` 持續回 deleted=false（child last_seen_at 持續變動，模擬 probe status update）；reconcile 走 3 次 retry 後 rollback proxy ref | parent 不含 codex proxy ref（rollback 成功）；codex frame 仍 standalone；trace decision = `created_frame`（沒升級 canonicalization）；無雙顯示資料 |
-| IT6 | `descendant_scan_partial_failure_skips_one_continues_others` | pane 內有兩個 standalone descendants（codex + opencode）；mock `DeleteIfUnchanged` 對 codex 持續失敗、對 opencode 成功；cc SessionStart descendant scan | cc.Subagents 含 opencode proxy ref（成功）；codex 仍 standalone（rollback）；scan 不因 codex 失敗中止 |
-| IT7 | `existing_frame_session_start_runs_descendant_scan_only` | (a) cc SessionStart 建 frame；(b) codex 在 race window 內 standalone 進場；(c) cc SessionStart 又來一次（reset，frame != nil 路徑）→ UpdateHookPathAndResetSubagents 清 subagents（PR-2b 既有 `[]`）+ descendant scan 重新收編 codex | cc.Subagents 含 codex proxy ref（reset 後又 re-collapse） |
-| IT8 | `non_session_start_event_does_not_trigger_canonicalization` | codex Notification 在 frame == nil 路徑建 frame（少見邊界） | reconcile + descendant scan 都不觸發；trace decision/reason 沿用既有 `created_frame` 路徑；scan side-effects 不殘留 |
-| IT9 | `findproxyparent_storage_error_aborts_apply` | reconcile 內 `findProxyParent` mock 回 storage error | applyFrameEvent 整體錯誤 propagate（既有 storage error 一致）|
-| IT10 | `existing_descendant_session_start_swept_canonicalizes_via_sweep` (G3) | (a) cc SessionStart 建 frame；(b) codex 在 race window 內 standalone（applyFrameEvent 走完）；(c) codex 又一個 SessionStart（frame != nil existing path → §2.2.2 不做 self-reconcile，已禁）；(d) 觸發 sweep canonicalization | sweep 後 cc.Subagents 含 codex proxy ref；codex frame 已刪 |
-| IT11 | `descendant_scan_skips_pid_reuse_stale_row` (G2) | pane 內有 codex stale standalone（PID 已被 OS reuse 為他者，actualStart != stored.ProcessStartTime）；cc SessionStart descendant scan | scan 跳過 stale candidate（identity gate 擋住）；不收編；stale row 留給 sweep 清 |
-| IT12 | `rollback_failure_propagates_error_observable` (G1) | reconcile 走到 rollback path，mock detachProxyRefWithRetry 回 storage error | applyFrameEvent 回 error；hot path 不 hide 不一致；sweep canonicalization 跑後 final state 收斂 |
+| IT1 | `descendant_then_ancestor_canonicalizes_via_descendant_scan` | (a) codex SessionStart → standalone codex；(b) cc SessionStart → cc Upsert + descendant scan 收編 codex | 1 cc frame + codex proxy；codex frame 已刪；projection top = cc |
+| IT2 | `ancestor_then_descendant_canonicalizes_via_pr2b_fast_path` | (a) cc SessionStart；(b) codex SessionStart → pre-Upsert findProxyParent 找到 cc → 既有 fast-path | 1 cc frame + codex proxy（sanity check）|
+| IT3 | `concurrent_descendant_first_then_reconcile_hits_post_upsert` | codex applyFrameEvent，mock pre-walk miss + post reconcile hit 模擬 race | 1 cc frame + codex proxy via reconcile |
+| IT4 | `concurrent_descendant_post_reconcile_also_misses_recovered_by_ancestor_scan` | codex 兩次 walk 都 miss → standalone；cc applyFrameEvent → descendant scan 收編 | 1 cc frame + codex proxy（**核心 ancestor-late race 驗證**）|
+| IT5 | `partial_state_hidden_by_projection_dedup` | DB 直接塞 parent（含 codex proxy ref）+ codex standalone frame；call `buildPaneProjection` | TopFrame = parent（不是 codex）；dedup metric +1 |
+| IT6 | `descendant_scan_partial_skip_does_not_block_others` | pane 內兩 standalone（codex + opencode）；mock `DeleteIfUnchanged` codex 失敗 / opencode 成功；cc descendant scan | cc.Subagents 含 opencode proxy（成功）+ codex proxy（partial，next sweep 修）；codex standalone 仍在 |
+| IT7 | `existing_frame_session_start_runs_descendant_scan_only` | (a) cc SessionStart 建 frame；(b) codex 在 race window 內 standalone；(c) cc SessionStart 又一次 → reset 後 descendant scan 收編 codex | cc.Subagents 含 codex proxy |
+| IT8 | `non_session_start_event_no_canonicalization` | codex Notification 在 frame == nil 路徑建 frame | reconcile + scan 都不觸發；trace 沿用 created_frame |
+| IT9 | `findproxyparent_storage_error_aborts_apply` | reconcile 內 storage error | applyFrameEvent error propagate |
+| IT10 | `existing_descendant_session_start_canonicalized_via_sweep` | (a) cc 已存在；(b) codex standalone（race 留下）；(c) codex SessionStart 又來（existing path → 不 self-reconcile）；(d) sweep canonicalize 一輪 | sweep 後 cc.Subagents 含 codex proxy；codex standalone 已刪 |
+| IT11 | `descendant_scan_skips_pid_reuse_stale` | pane 內 codex stale standalone（PID reuse, actualStart != stored.ProcessStartTime）；cc SessionStart descendant scan | scan skip stale candidate（identity gate）；不收編；stale row 留給 sweep |
+| IT12 | `session_end_clears_parent_proxy_ref` (v4 新，Side B 抓的洞) | (a) partial 狀態：cc.Subagents 含 codex proxy + codex standalone frame；(b) codex SessionEnd | cc.Subagents 不含 codex proxy（hot path 清乾淨）；codex frame 已刪 |
+| IT13 | `sweep_prune_dead_proxy_ref_when_source_process_dead` (v4 新) | cc.Subagents 含 codex proxy（SourcePID 已死，process not alive）；no standalone frame for codex；sweep 跑一輪 | cc.Subagents 不含 codex proxy（pruneDeadProxyRefs 偵測 dead PID 後 detach）|
+| IT14 | `sweep_prune_dead_proxy_ref_when_pid_reused` (v4 新) | cc.Subagents 含 codex proxy（SourcePID alive 但 actualStart != ref.SourceStartTime — PID reuse）；sweep | cc.Subagents 不含 codex proxy（identity mismatch 視為 dead）|
+| IT15 | `partial_metric_increments_on_partial_state` (v4 新) | mock DeleteIfUnchanged 持續失敗；reconcile 走 partial path | metricPartialCanonicalizationCreated 對應 +1；trace decision 仍 `created_frame`（無 partial reason）|
+| IT16 | `projection_dedup_metric_increments` (v4 新) | DB 多個 partial state；多 paneID call buildPaneProjection | metricProjectionDedupHidden 累加 |
 
-**為什麼 IT4 是核心驗證**：直接針對 codex F1 finding 的 ancestor-late interleaving。若 IT4 過綠則 v2 雙向設計成立。
+### 3.2 Unit 測試
 
-### 3.2 Unit 測試（補充覆蓋 helper）
+`frame_ops_test.go` 加 `RC1`-`RC5`：
 
-`frame_ops_test.go` 加 `RC1`-`RC4` 為 helper-level unit test（mock-driven，補 IT1-IT9 沒覆蓋的 helper edge case）：
+| # | 名稱 |
+|---|---|
+| RC1 | `pidIsAncestorOfWithCap_depth_exhaustion` |
+| RC2 | `pidIsAncestorOfWithCap_loop_detection_ppid_eq_pid` |
+| RC3 | `pidIsAncestorOfWithCap_process_info_error` |
+| RC4 | `canonicalizeDescendantsAfterUpsert_skips_same_type` |
+| RC5 | `canonicalizeDescendantsAfterUpsert_skips_pid_reuse_via_identity_gate` |
 
-| # | 名稱 | 場景 |
-|---|---|---|
-| RC1 | `pidIsAncestorOfWithCap_depth_exhaustion` | 走 PPID 鏈超過 maxDepth 仍未找到 → false |
-| RC2 | `pidIsAncestorOfWithCap_loop_detection` | PPID == PID → false（防 init process） |
-| RC3 | `pidIsAncestorOfWithCap_process_info_error` | readProcessInfoFn err → false |
-| RC4 | `canonicalizeDescendantsAfterUpsert_skips_same_type` | pane 內有 same-type standalone → 不收編 |
+`projection_test.go` 加 `PD1`-`PD3`：
+
+| # | 名稱 |
+|---|---|
+| PD1 | `buildPaneProjection_dedup_excludes_proxy_claimed_standalone` |
+| PD2 | `buildPaneProjection_fallback_when_all_frames_claimed` |
+| PD3 | `buildPaneProjection_no_proxy_refs_unchanged_behavior` |
 
 ### 3.3 不加的測試
 
-- ❌ goroutine race detector 測試 — 太脆，integration 順序模擬已足夠
-- ❌ Phase 3 daemon_restart_recovery 路徑測試 — 那是 Phase 3 scope；rebase 後若需要 cross-feature 測試另開 issue
-- ❌ 三方 + race 排列組合（cc + codex + opencode + race） — IT3/IT4 + descendant scan 邏輯已 cover 雙方收斂；三方無新規則
+- ❌ goroutine race detector — integration 順序模擬已足夠
+- ❌ Phase 3 daemon_restart_recovery 路徑測試 — Phase 3 scope
+- ❌ rollback retry exhaustion path（v3 有過，v4 已移除 rollback）
+- ❌ partial_canonicalization trace 寫入測試（v4 已移除該 reason）
 
 ---
 
-## 4. Sweep canonicalization（**v3 納入本 PR** — 兜底 G1 + G3）
+## 4. Sweep 兩 pass（canonicalize + prune）
 
-v2 假設「rollback 已兜底所以 sweep 不需要」— codex round 2 G1 + G3 揭穿這個論證的兩個漏洞：
+### 4.1 Recovery bound 是 2s（v3 文檔修正）
 
-- **G1**：rollback 自身可能失敗（`detachProxyRefWithRetry` storage error / retry exhaustion）→ 仍殘留 parent 含 proxy + child standalone
-- **G3**：existing descendant 走 SessionStart existing path 時 self-reconcile 被禁，descendant-scan 已在 ancestor 的 SessionStart 跑過一次但不會再跑 → 永久 standalone
+`sweep.go:20` `sweepInterval = 2 * time.Second`（不是 1h）。`frameIdleThreshold = 1h` 是另一個概念（無 hook 活動的 frame 多久後刪），不是 sweep 頻率。
 
-兩個漏網路徑都需要 background loop 兜底。**v3 在 sweep 加 lightweight canonicalization pass**：
+partial state 的最壞 user-visible 觀察延遲是「partial 發生 → 下次 sweep 跑」≤ 2s（且該觀察被 projection_dedup 隱藏，所以 SPA 永遠看不到）。
+
+### 4.2 `canonicalizePane` pass
+
+`internal/module/agent/sweep.go` `sweepOnce` 在現有 dead-frame + idle-timeout 兩 pass 後加第三 pass：
 
 ```go
-// canonicalizePane is invoked by sweepOnce per live pane, after the existing
-// dead-frame and idle-timeout passes. Walks the pane's standalone frames,
-// for each one walks its PPID chain (capped at proxyMaxDepth) looking for a
-// same-pane + alive + identity-verified + cross-type ancestor frame. If
-// found, attaches a proxy ref + DeleteIfUnchanged the standalone row.
-//
-// Cost analysis: O(F × D × C) per pane per sweep cycle, where F = standalone
-// frames in pane (≤10 typical), D = walk depth (≤5), C = ListByPane cost.
-// Sweep runs at low frequency (default 1h interval matches idle sweep), so
-// the absolute cost is negligible.
-//
-// Idempotent: each call is independent of prior. Failures (attach race lost,
-// delete race lost, identity unverifiable) are skipped silently — next
-// sweep cycle retries.
-//
-// This is the unconditional defensive layer that ensures eventual
-// canonicalization regardless of which pre-Upsert / post-Upsert / rollback
-// path failed earlier.
-func (m *Module) canonicalizePane(paneID string, broadcastTs int64) error {
+func (m *Module) sweepOnce() error {
+    // ... existing dead-frame + idle-timeout passes ...
+
+    panes := uniquePaneIDsFromFrames(allFrames)
+    broadcastTs := nowFn().UnixNano()
+    for _, paneID := range panes {
+        m.canonicalizePane(paneID, broadcastTs)
+        m.pruneDeadProxyRefs(paneID, broadcastTs)
+    }
+    return nil
+}
+```
+
+`canonicalizePane`：
+
+```go
+func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
     frames, err := m.frames.ListByPane(paneID)
     if err != nil {
-        return err
+        return
     }
-    // Build a self-frame map keyed by PID for ancestor lookup.
     framesByPID := make(map[int]store.Frame, len(frames))
     for _, frame := range frames {
         framesByPID[frame.PID] = frame
     }
     for _, candidate := range frames {
-        // Walk candidate's PPID chain looking for a cross-type live
-        // ancestor that is also a frame in this pane.
+        // v4 candidate identity gate (修 v3 H2 同類 bug)
+        if !isPidAliveFn(candidate.PID) {
+            continue
+        }
+        actualStart, sterr := processStartTimeFn(candidate.PID)
+        if sterr != nil || actualStart != candidate.ProcessStartTime {
+            continue
+        }
         ancestor, found := m.findCanonicalAncestor(candidate, framesByPID)
         if !found {
             continue
@@ -525,18 +581,16 @@ func (m *Module) canonicalizePane(paneID string, broadcastTs int64) error {
         if aerr != nil || !attached {
             continue
         }
-        // Best-effort delete; rollback on full failure as in §2.1.1
-        if !m.deleteWithRetryOrRollback(candidate, parentStored, broadcastTs) {
-            log.Printf("phase3.5 sweep: canonicalize partial — child %s under parent %s; next cycle retries", candidate.FrameID, parentStored.FrameID)
+        deleted, _ := m.frames.DeleteIfUnchanged(candidate.FrameID, candidate.LastSeenAt)
+        if deleted {
+            metricSweepCanonicalized.Add(1)
         }
+        // not deleted: partial — next sweep tick (2s) tries again. No
+        // rollback needed; projection_dedup hides; eventual consistent.
+        _ = parentStored
     }
-    return nil
 }
 
-// findCanonicalAncestor walks candidate's PPID chain looking for a
-// cross-type alive identity-verified frame in the same pane. Returns
-// (frame, true) on hit; (zero, false) on miss / depth exhaust / identity
-// unverifiable.
 func (m *Module) findCanonicalAncestor(candidate store.Frame, framesByPID map[int]store.Frame) (store.Frame, bool) {
     info, err := readProcessInfoFn(candidate.PID)
     if err != nil {
@@ -550,7 +604,6 @@ func (m *Module) findCanonicalAncestor(candidate store.Frame, framesByPID map[in
         ancestor, ok := framesByPID[ppid]
         if ok {
             if ancestor.AgentType == candidate.AgentType {
-                // Same-type ancestor: hard-stop (PR-2b semantics).
                 return store.Frame{}, false
             }
             if isPidAliveFn(ancestor.PID) {
@@ -559,7 +612,6 @@ func (m *Module) findCanonicalAncestor(candidate store.Frame, framesByPID map[in
                     return ancestor, true
                 }
             }
-            // Stale ancestor row; continue walking up
         }
         ancestorInfo, err := readProcessInfoFn(ppid)
         if err != nil {
@@ -574,49 +626,84 @@ func (m *Module) findCanonicalAncestor(candidate store.Frame, framesByPID map[in
 }
 ```
 
-**Wire 進 sweepOnce**：sweep.go 在現有 dead-frame + idle-timeout 兩 pass 後加第三 pass：
+### 4.3 `pruneDeadProxyRefs` pass（v4 新，修 SessionEnd 漏網）
 
 ```go
-// In sweepOnce after existing passes:
-panes := uniquePaneIDsFromFrames(allFrames)
-broadcastTs := time.Now().UnixNano()
-for _, paneID := range panes {
-    if cerr := m.canonicalizePane(paneID, broadcastTs); cerr != nil {
-        log.Printf("phase3.5 sweep canonicalize pane %s: %v", paneID, cerr)
+// pruneDeadProxyRefs detaches IsProxy SubagentRefs whose source process
+// is gone or has been replaced (PID reuse). Without this, a partial-state
+// SessionEnd path that skipped the hot-path cleanup leaves a stale proxy
+// ref permanently lit on the parent.
+//
+// v4 design: this is the SessionEnd defensive fallback. Hot path
+// (§2.3) covers the common case; this covers all permutations including
+// daemon crash mid-SessionEnd, hot-path removeProxyRefForSender failure,
+// or proxies whose source died via signal without emitting SessionEnd.
+func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
+    frames, err := m.frames.ListByPane(paneID)
+    if err != nil {
+        return
+    }
+    for _, frame := range frames {
+        for _, ref := range frame.Subagents {
+            if !ref.IsProxy {
+                continue
+            }
+            if isPidAliveFn(ref.SourcePID) {
+                actualStart, sterr := processStartTimeFn(ref.SourcePID)
+                if sterr == nil && actualStart == ref.SourceStartTime {
+                    continue  // proxy source still alive + identity match — keep
+                }
+            }
+            // Source dead or PID reused — detach.
+            detached, _, derr := m.detachProxyRefWithRetry(frame, ref.SourcePID, ref.SourceStartTime, broadcastTs)
+            if derr == nil && detached {
+                metricSweepPrunedProxy.Add(1)
+            }
+        }
     }
 }
 ```
 
-**Sweep 與 hot-path canonicalization 的關係**：hot path（reconcile + descendant scan）目標是 SPA 即時看到正確 collapse；sweep 是兜底（hot path 失敗、existing descendant 漏網、cold-start race window 殘留）。雙層防禦不衝突，sweep 的 `attachProxyRefWithRetry` 與 hot path 共享同一 RMW 路徑，並發安全。
+### 4.4 Sweep 與 hot-path 不衝突
+
+兩層共用 `attachProxyRefWithRetry` / `detachProxyRefWithRetry` / `DeleteIfUnchanged` — 同一 RMW 路徑，`UpsertIfUnchanged` 在並發下 retry 即可。Sweep 不上鎖、不擋 hot-path、partial 由 dedup 在 projection 層隱藏。
 
 ---
 
 ## 5. 不做（明列）
 
+- ❌ SQL transaction（Side A 建議；Side B 證據壓倒，標準對 ephemeral 表過高）
 - ❌ per-pane mutex / pane-level claim table（違背 PR-2b 無 lock atomic RMW 哲學）
 - ❌ SQL UNIQUE constraint on `(pane_id, agent_type)`（cc + codex proxy 同 pane 是合法）
 - ❌ delay window / SessionStart deadline（hack，影響 hook latency）
-- ❌ 對 non-SessionStart event 觸發 hot-path canonicalization（IT8 守此邊界；sweep 兜底）
-- ❌ 修 Phase 3 fallback chain race（那條獨立路徑由 Phase 3 PR #638 處理）
-- ❌ rebuild Inspector / SPA 變更（Phase 5 才做）
-- ❌ 對 existing frame 路徑做 self-as-descendant reconcile（§2.2.2 解釋；sweep 兜底）
+- ❌ rollback proxy attach 在 hot path（v2/v3 加 → v4 移除；partial 為合法狀態）
+- ❌ partial_canonicalization trace reason（v3 加 → v4 移除；無法消費）
+- ❌ existing frame self-as-descendant reconcile（§2.2.2）
+- ❌ 對 non-SessionStart event 觸發 hot-path canonicalization（IT8 守邊界）
+- ❌ Metrics endpoint exposure（本 PR 內部 expvar；endpoint follow-up）
+- ❌ SPA-side dedup（dedup 在 daemon projection 統一處理；SPA 無資訊做 dedup）
+- ❌ 修 Phase 3 fallback chain race（Phase 3 PR #638 處理）
+- ❌ rebuild Inspector / SPA 變更（Phase 5）
 
 ---
 
 ## 6. Commit 順序（TDD）
 
-| # | Commit | 範圍 |
-|---|---|---|
-| 1 | `docs: Phase 3.5 plan v1 — cold-start proxy canonicalization` | 已 commit `bb382870` |
-| 2 | `docs: Phase 3.5 plan v2 — bidirectional + retry/rollback` | 已 commit `dd29be46` |
-| 3 | `docs: Phase 3.5 plan v3 — sweep canonicalize + identity gate + rollback observability` | 此檔（codex round 2 fixes）|
-| 4 | `feat(agent): pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert with identity gate (unwired)` | helper + RC1-RC4 + RC5 PID-reuse skip |
-| 5 | `feat(agent): reconcileCreatedFrameAsProxy with bounded retry + rollback + error propagation (unwired)` | reconcile helper（含 §2.1.1 retry + rollback + propagation）+ deleteWithRetryOrRollback shared helper |
-| 6 | `feat(agent): wire bidirectional canonicalization into applyFrameEvent` | §2.2.1 + §2.2.2 接線 + trace meta（含 partial_canonicalization）|
-| 7 | `feat(agent): sweep canonicalizePane defensive layer` | §4 sweep 第三 pass + findCanonicalAncestor + IT10/IT12 sweep 觀察測試 |
-| 8 | `test(agent): integration tests for cold-start race canonicalization` | IT1-IT12 用真 sqlite |
-
-**Unwired 模式**（commits 3 + 4）沿用 Phase 3 commit `f109b258`，降低 review 對 wire-and-test 同 commit 的審讀負擔。
+| # | Commit |
+|---|---|
+| 1 | `docs: Phase 3.5 plan v1 — cold-start proxy canonicalization` ✅ `bb382870` |
+| 2 | `docs: Phase 3.5 plan v2 — bidirectional + retry/rollback` ✅ `dd29be46` |
+| 3 | `docs: Phase 3.5 plan v3 — sweep canonicalize + identity gate` ✅ `148a2309` |
+| 4 | `docs: Phase 3.5 plan v4 — Hybrid B+ (consulting-driven redesign)` 此檔 |
+| 5 | `feat(agent): metrics counters for phase 3.5 canonicalization observability` | metric 4 個 + import 註冊 |
+| 6 | `feat(agent): pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert with identity gate (unwired)` | helper + RC1-RC5 unit |
+| 7 | `feat(agent): reconcileCreatedFrameAsProxy best-effort (unwired)` | reconcile helper（無 rollback）|
+| 8 | `feat(agent): wire bidirectional canonicalization into applyFrameEvent` | §2.2.1 + §2.2.2 |
+| 9 | `feat(agent): SessionEnd hot-path proxy cleanup` | §2.3 + IT12 |
+| 10 | `feat(agent): buildPaneProjection dedup proxy-claimed standalone frames` | §2.4 + PD1-PD3 + IT5 |
+| 11 | `feat(agent): sweep canonicalizePane with candidate identity gate` | §4.2 + IT10 |
+| 12 | `feat(agent): sweep pruneDeadProxyRefs` | §4.3 + IT13 / IT14 |
+| 13 | `test(agent): integration tests for cold-start race canonicalization end-to-end` | IT1-IT11 + IT15 / IT16 用真 sqlite |
 
 ---
 
@@ -624,29 +711,32 @@ for _, paneID := range panes {
 
 | 區塊 | 估計 |
 |---|---|
-| `frame_ops.go` reconcileCreatedFrameAsProxy（含 retry/rollback/propagate） | ~85 行 |
+| metrics.go 4 counter + import | ~25 行 |
+| `frame_ops.go` reconcile（無 rollback） | ~50 行 |
 | `frame_ops.go` canonicalizeDescendantsAfterUpsert（含 identity gate） | ~85 行 |
 | `frame_ops.go` pidIsAncestorOfWithCap | ~20 行 |
-| `frame_ops.go` deleteWithRetryOrRollback shared helper | ~30 行 |
-| `frame_ops.go` 接線 §2.2.1 + §2.2.2 + trace（含 partial_canonicalization） | ~55 行 |
-| `sweep.go` canonicalizePane + findCanonicalAncestor | ~110 行 |
+| `frame_ops.go` SessionEnd proxy cleanup | ~10 行（既有 case 改 4 行）|
+| `frame_ops.go` 接線 §2.2.1 + §2.2.2 | ~40 行 |
+| `projection.go` dedup | ~40 行 |
+| `sweep.go` canonicalizePane + findCanonicalAncestor + pruneDeadProxyRefs | ~140 行 |
 | `frame_ops_test.go` RC1-RC5 unit | ~150 行 |
-| `module_test.go` / new file IT1-IT12 integration | ~600-700 行 |
-| `sweep_test.go` 加 sweep canonicalize 測試 | ~100 行 |
-| Plan docs（此檔 v3） | ~700 行 |
-| **總 net code（不含 plan docs）** | **~1235-1335 行** |
+| `projection_test.go` PD1-PD3 | ~80 行 |
+| `module_test.go` / new file IT1-IT16 integration | ~700-800 行 |
+| `sweep_test.go` 加 sweep canonicalize/prune 測試 | ~120 行 |
+| Plan docs（此檔 v4） | ~720 行 |
+| **總 net code（不含 plan docs）** | **~1460-1560 行** |
 
-落在「中-大 PR」邊界（PR-2b 是 ~+1700 行 net）。Sweep 第三 pass + IT10-IT12 把 v2 估計（~815-915）拉到 ~1235-1335。Review 負擔依然比 PR-2b 小但接近邊界 — 修一個有 codex consulting backing 的單點 race，但因兩輪收斂後加上必要 defense-in-depth。
+v4 LOC 比 v3 估計（~1235-1335）略升 ~200，主要在 IT12-IT16 + sweep prune。但移除了 rollback 分支 + partial trace 邏輯，淨複雜度比 v3 低（更多直線、更少分支與失敗路徑）。
 
 ---
 
 ## 8. 驗收 / Ship 條件
 
-- 所有 IT1-IT9 + RC1-RC4 + 既有 frame_ops_test 全綠
-- `go build ./... && go vet ./... && go test ./...` 23 packages 全綠
+- 所有 IT1-IT16 + RC1-RC5 + PD1-PD3 + 既有測試全綠
+- `go build/vet/test ./...` 23 packages 全綠
 - SPA 無變更
-- 委派 codex 兩輪 review 收斂（標準 + adversarial 三視角）；high finding 全採納或開 follow-up issue
-- Phase 3 PR #638 merged 後 rebase 本 PR 到 main，`applyFrameEvent` 衝突解到 Phase 3 fallback chain 之上、本 PR canonicalization 接線之下
+- 委派 codex round 4 review 收斂；採納或合理 deferred all findings
+- Phase 3 PR #638 merged 後 rebase Phase 3.5 到 main
 
 ---
 
@@ -654,63 +744,65 @@ for _, paneID := range panes {
 
 | # | 風險 | 緩解 |
 |---|---|---|
-| R1 | descendant scan 找錯 ancestor（PPID 鏈經過 self 但邏輯上不該收編，例：user 手動 spawn 兩個獨立 cc + codex 巧合 PPID 共用） | 同 pane + 跨型別 + identity-verified（同 PR-2b findProxyParent 規則）；極小機率假陽性，由 next sweep / 使用者 SessionEnd 自然修復 |
-| R2 | reconcile 與 idle sweep 競爭：sweep 正在刪 parent | `attachProxyRefWithRetry` 內部 `UpsertIfUnchanged` cover：sweep delete 後 attach 回 false → reconcile 回 false → standalone 保留 |
-| R3 | reconcile/scan 與 SubagentStart hook 競爭 | `attachProxyRefWithRetry` 用 `mutateSubagentsWithRetry` 共享 retry，PR-2b R6 已驗 |
-| R4 | rollback detach 也失敗（極端）| log + 接受；下次 SessionStart 仍會 re-attempt（雙向設計保證每次 SessionStart 都是新嘗試）|
-| R5 | descendant scan 走 ListByPane O(n) + 每個 candidate walk O(depth) | proxyMaxDepth=5 + pane 內 frame 數一般 < 10；現代機器一次 scan < 5ms；SessionStart 頻率不高（user-initiated session）|
-| R6 | rebase Phase 3 後 applyFrameEvent 衝突 | Phase 3 改 fallback chain（line 220 區塊），Phase 3.5 改 new-frame Upsert 後 + existing-frame Update 後（line 286 + line 272 區塊）；位置不同，git rebase 應可機械處理；極端衝突由施工者手動解 |
-| R7 | descendant scan 的 ListByPane 與接線同事務未同步 | 接受 eventual consistency：scan 看到 standalone snapshot，attach 用 UpsertIfUnchanged。中間有新 standalone 進場 → 下次 SessionStart 才 canonicalize。可接受 |
+| R1 | Projection dedup 把不該 hide 的 frame hide 掉（false positive）| Identity 用 (PID, ProcessStartTime) 比對；只 hide standalone PID 等於 proxy 的 SourcePID — 同 process；理論上不可能 false positive |
+| R2 | `pruneDeadProxyRefs` 把 alive 但 startTime 讀錯的 proxy 誤砍 | identity gate fail-safe：read error → skip（不砍）；只在 actualStart != ref.SourceStartTime 確定 mismatch 才砍 |
+| R3 | Sweep canonicalize 走 ListByPane O(n) per pane per 2s | proxyMaxDepth=5 + pane frame 數一般 < 10；2s 一輪總成本 < 50ms；可接受 |
+| R4 | rebase Phase 3 後 applyFrameEvent 衝突 | Phase 3 改 fallback chain（line 220 區塊），Phase 3.5 改 new-frame Upsert 後 + existing-frame Update 後 + SessionEnd（line 286 + 272 + 53）；位置不同；極端衝突手動解 |
+| R5 | metric 累加在熱 path 影響 latency | expvar.Int.Add 是 atomic，sub-microsecond；可忽略 |
+| R6 | partial state 在 metric SLO 突破時要升級為強一致 | metric 已埋；超過 1/1000 的話開 follow-up phase 升級到 Side A SQL transaction |
+| R7 | dedup 邏輯改 buildPaneProjection 影響既有 BuildSessionProjections / projectPane / projectionForSession 所有 caller | dedup 是純 frame filter；caller 看到的 SessionProjection 結構不變；既有測試（projection_test.go）守 regression |
 
 ---
 
 ## 10. Codex review focus 預期
 
-施工後委派 codex 兩輪 review 時的 focus 文字建議：
+施工後委派 codex round 4 review focus：
 
-**第一輪（標準 review）**：
-> Phase 3.5 v2 — bidirectional canonicalization + retry/rollback。修 PR-2b 的 cold-start race。重點檢查：
-> 1. v2 雙向設計的單向規則論證是否封閉（self-as-descendant + self-as-ancestor 兩條路徑會否互相觸發 secondary race）
-> 2. `reconcileCreatedFrameAsProxy` 的 bounded retry + rollback 在所有失敗組合下是否確保 final state 一致
-> 3. `canonicalizeDescendantsAfterUpsert` 的 `pidIsAncestorOfWithCap` walk 是否會誤抓 grandparent 的 sibling 等非真 ancestor
-> 4. existing frame 路徑只跑 descendant-scan 不跑 self-reconcile 的判斷是否正確（SessionStart reset 後是否該重新 evaluate ancestry）
-> 5. trace meta 在 IT4/IT5/IT6 各路徑下是否與 reviewer 對 SPA 顯示的預期吻合
-> 6. IT 測試是否確實用真 sqlite（不退化成 mock-driven）
+**第一輪（standard）**：
+> Phase 3.5 v4 — Hybrid B+ design。三輪 review + 兩 codex consulting 後選 Side B（accept partial state + projection dedup + sweep eventual consistency）。重點審：
+> 1. Projection dedup 是否會 hide 該顯示的 frame（false positive）— 特別當 proxy ref 自己是 stale 時
+> 2. SessionEnd hot-path proxy cleanup 是否與既有 frame == nil path 重複觸發 removeProxyRefForSender
+> 3. sweep `pruneDeadProxyRefs` identity gate 與 hot-path identity gate 的細節是否一致
+> 4. partial 用 metric 替代 trace 的觀察性是否充分（無 SLO 累積機制）
+> 5. v4 移除 rollback / partial trace / IT12 後是否仍 cover 所有 v1/v2/v3 修過的 scenario
+> 6. fallback「all frames claimed」邊界是否真的 unreachable，還是 v4 還沒抓到
 
 **第二輪（adversarial 三視角）**：
-- **攻擊方**：尋找 race interleaving 死角；雙向設計是否有「scan + reconcile 同一 SessionStart 同時撞 attach」的內部 race；rollback detach 失敗後的二階段一致性
-- **防守方**：v2 `pidIsAncestorOfWithCap` 與 `findProxyParent` 邏輯重複是否是好分離還是該合併
-- **檔案體質**：`frame_ops.go` 752 → ~975 行後是否觸發 SRP；是否該抽 `canonicalize.go`
+- **攻擊方**：projection dedup race（buildPaneProjection 與 attachProxyRefWithRetry 同時跑）；SessionEnd 與 sweep 同時 detach 同一 proxy 的競賽；metric counter 在 daemon restart 後 reset 對 SLO 的影響
+- **防守方**：v4 與 v3 的 partial state 處理路線是真分層 vs 偽 patch 的判斷
+- **檔案體質**：projection.go 62 → ~100 行 OK；frame_ops.go 752 → ~900 行；sweep.go 152 → ~290 行 — 三檔同步加大時是否該重組
 
 ---
 
-## 11. Open questions（plan v2 review 會解）
+## 11. Open questions
 
-1. v2 雙向設計後，是否仍需把 `reconcileCreatedFrameAsProxy` 和 `canonicalizeDescendantsAfterUpsert` 的接線同放在 frame == nil 路徑，還是該分到不同 phase？（plan 採同 wire site，理由：兩個是同一 SessionStart 的 self 視角兩面）
-2. `pidIsAncestorOfWithCap` 是否該抽到獨立 `process_tree.go` 檔（process tree util 集中）？（plan 留在 frame_ops.go，因為它是 race fix 的內部 helper，獨立檔太重）
-3. existing frame 路徑的 scan 觸發位置在 `UpdateHookPathAndResetSubagents` 之後 — 若 reset 失敗則整個 SessionStart 失敗，scan 不跑；OK？（plan 採此設計：reset 失敗本就要回錯）
-4. IT4 的 mock 設計（兩次 findProxyParent miss）是否能完整模擬「ancestor 真的還沒入庫」場景？或需要在 sqlite 層直接控制 ListByPane 結果？（plan 用第二種，更接近真 race）
+1. metrics endpoint exposure：本 PR 內部 expvar，外部 monitoring/debug 接 follow-up phase？採納
+2. partial state SLO 累積觸發升級到 SQL tx 的閾值（v4 暫定 1/1000）— 是否該寫進 spec？暫不寫，metric 觀察期再決定
+3. v4 `pruneDeadProxyRefs` 與 `idleSweep` 的責任邊界：dead-PID frame 由 idle sweep 清，dead-PID proxy 由 prune 清；是否該合併？採目前分開設計，責任清晰
 
 ---
 
 ## 12. 結束條件
 
-PR 跑過兩輪 codex review 收斂後：
+PR 跑過 codex round 4 review 收斂後：
 
 1. Phase 3 PR #638 merge 到 main（不 bump）
-2. Rebase 本 PR 到 main（解 applyFrameEvent 衝突）
+2. Rebase 本 PR 到 main（解 applyFrameEvent + SessionEnd 衝突）
 3. 本 PR merge 到 main（不 bump）
-4. 開 bump PR 把 VERSION + package.json + spa/package.json 同步到 alpha.225 + CHANGELOG 條目（涵蓋 Phase 3 + Phase 3.5）
+4. 開 bump PR alpha.225 + CHANGELOG
 5. Bump merge → main @ alpha.225
 6. ExitWorktree 清掉 `lights-phase-3-5` worktree
-7. 更新 kickoff_lights_rebuild.md：標 Phase 3 + Phase 3.5 ✅ at alpha.225；下一步 Phase 4 probe audit
+7. 更新 kickoff_lights_rebuild.md：標 Phase 3 + Phase 3.5 ✅ at alpha.225
 
 ---
 
-## 13. Codex review 軌跡
+## 13. Codex review + consulting 軌跡
 
 | Round | Job | Verdict | Findings | Resolution |
 |---|---|---|---|---|
-| Plan v1 round 1（adversarial）| 內聯 | needs-attention | F1 ancestor-late / F2 partial delete / F3 mock test | v2 全採納 |
-| Plan v2 round 2（adversarial）| 內聯 | needs-attention | G1 high rollback 也會失敗 / G2 high descendant scan 缺 identity gate / G3 medium existing descendant 漏網 | v3 全採納（§4 sweep 納入 / §2.1.2 identity gate / §2.1.1 propagate error；IT10-IT12 補測試）|
-| Plan v3 round 3 | (待執行) | (pending) | — | — |
+| Plan v1 round 1（adversarial）| inline | needs-attention | F1 ancestor-late / F2 partial delete / F3 mock test | v2 全採納 |
+| Plan v2 round 2（adversarial）| inline | needs-attention | G1 rollback 也會失敗 / G2 descendant scan 缺 identity / G3 existing descendant 漏網 | v3 全採納 |
+| Plan v3 round 3（adversarial）| inline | needs-attention | H1 rollback helper 同類 partial / H2 sweep 缺 identity / H3 partial trace 不會寫入 | **三輪 partial state meta-drift signal 觸發** → consulting |
+| Side A consulting | task-moeupstr-z0oilf | (technical spec) | 提議 SQL transaction 根除 partial 物理層 | 不採納（標準對 ephemeral 表過高），但細節（BEGIN IMMEDIATE / busy code / FK）保留參考 |
+| Side B consulting | task-moeuqbnn-jart97 | (adversarial argument) | 證據壓倒：sweep 2s 不是 1h / agent_frames 是 ephemeral / projection 是 user-visible 邊界 / SessionEnd 漏 cleanup proxy | **採納為 v4 核心**（Hybrid B+）|
+| Plan v4 round 4 | (待執行) | (pending) | — | — |

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,13 +1,15 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v2)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v3)
 
 Baseline：`1.0.0-alpha.224`（main @ `75b4d166`）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`）。
 Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 → rebase 3.5 → 一次 bump alpha.225）。
 
-**v1 → v2 由 codex adversarial round 1 收斂**（job 在 §13；3 個 high/medium findings 全採納）：
-- F1 high — ancestor-late interleaving（單向 reconcile 不夠）→ 升 **bidirectional canonicalization**（§2.1.2）
-- F2 high — DeleteIfUnchanged 失敗造成 SPA 雙顯示 → 加 **bounded retry + rollback**（§2.1.1）
-- F3 medium — mock 測試掩蓋 race → integration test 從 optional 升 **必要 ship gate**（§3.1）
+**v1 → v2 由 codex adversarial round 1 收斂**（§13；3 finding 全採納）：F1 ancestor-late race → bidirectional / F2 partial delete → retry + rollback / F3 mock test → integration ship gate。
+
+**v2 → v3 由 codex adversarial round 2 收斂**（§13；3 finding 全採納）：
+- G1 high — rollback 也會失敗，仍殘留雙顯示 → **sweep canonicalization 納入本 PR**（§4 重新定位）+ **rollback 失敗 propagate error + trace 標 `partial_canonicalization`**（§2.1.1）
+- G2 high — descendant scan 缺 identity gate（PID reuse 誤抓） → 加 **`processStartTimeFn` 比對**（§2.1.2）
+- G3 medium — existing descendant 路徑永久漏網 → **sweep canonicalization 兜底**（§4）+ IT10 補測試（§3.1）
 
 ---
 
@@ -149,19 +151,24 @@ func (m *Module) reconcileCreatedFrameAsProxy(
         }
         expectedLastSeen = reloaded.LastSeenAt
     }
-    // All retries failed: rollback the proxy attach so we don't leave the
-    // inconsistent (parent has proxy + child still standalone) state visible
-    // to SPA. After rollback, child is canonical standalone (will be picked
-    // up by ancestor-side descendant scan on next SessionStart, or by sweep).
+    // Bounded retry exhausted: try rollback the proxy attach. Rollback can
+    // itself fail (storage error or its own retry exhaustion under sustained
+    // contention) — propagate that as a partial-state observable signal
+    // rather than swallowing it (codex round 2 G1 fix). The sweep
+    // canonicalization pass (§4) is the unconditional defensive layer that
+    // eventually repairs partial states regardless of which path failed.
     rollback, _, rerr := m.detachProxyRefWithRetry(parentStored, req.SenderPID, req.SenderStartTime, broadcastTs)
     if rerr != nil {
-        return false, store.Frame{}, rerr
+        log.Printf("phase3.5: reconcile rollback FAILED for child frame %s parent %s: %v — sweep canonicalize will repair", stored.FrameID, parentStored.FrameID, rerr)
+        return false, store.Frame{}, fmt.Errorf("phase3.5 reconcile partial state: attach succeeded, delete retry exhausted, rollback errored: %w", rerr)
     }
     if !rollback {
-        // Detach also lost (extreme: parent vanished between attach and
-        // detach). Final state: parent gone (sweep cleared) or its proxy
-        // already removed by another writer; child standalone — also
-        // consistent. Fall through to canonicalized=false trace.
+        // Detach completed without error but didn't find the ref to remove —
+        // either parent vanished or another writer beat us to it. Final
+        // state: child standalone, parent has no inconsistent ref. Trace
+        // marks partial so observability captures the path.
+        log.Printf("phase3.5: reconcile delete-retry exhausted, rollback no-op (parent gone) for child %s", stored.FrameID)
+        return false, store.Frame{}, nil
     }
     log.Printf("phase3.5: reconcile delete-retry exhausted for child frame %s; rolled back proxy attach on parent %s", stored.FrameID, parentStored.FrameID)
     return false, store.Frame{}, nil
@@ -207,9 +214,24 @@ func (m *Module) canonicalizeDescendantsAfterUpsert(
         if !pidIsAncestorOfWithCap(candidate.PID, self.PID, proxyMaxDepth) {
             continue
         }
-        // Identity verify candidate is alive (else it's stale and will be
-        // swept; not worth proxy'ing a dead frame onto self).
+        // Identity gate (codex round 2 G2 fix): align with findProxyParent's
+        // alive + start_time identity verification. Without start_time check,
+        // a PID-reused stale row would be folded onto self with the OLD
+        // ProcessStartTime, producing a stale proxy ref AND deleting the
+        // (already-stale) row. Reads the live OS process's start_time and
+        // compares against the candidate row's stored ProcessStartTime;
+        // mismatch (or read error) → skip, leave for sweep to clean up.
         if !isPidAliveFn(candidate.PID) {
+            continue
+        }
+        actualStart, sterr := processStartTimeFn(candidate.PID)
+        if sterr != nil {
+            // Identity unverifiable → don't infer (consistent with verify.go
+            // / findProxyParent convention).
+            continue
+        }
+        if actualStart != candidate.ProcessStartTime {
+            // PID reuse — stale row; sweep will clear by liveness later.
             continue
         }
         ref := agentpkg.SubagentRef{
@@ -390,6 +412,8 @@ if req.EventName == "SessionStart" {
 | `updated_frame` | `proxy_subagent_attached` | PR-2b pre-Upsert proxy fast-path（既有，不改）|
 | `created_frame` | `parent_frame_found` / `parent_frame_missing` | 一般 new frame 路徑（既有，不改）|
 | `updated_frame` | `post_upsert_canonicalization_self` | **v2 新**，self 變 proxy 收編成功 |
+| `created_frame` | `parent_frame_found` / `parent_frame_missing`（沿用） + log line | **v3** rollback 成功 / no-op 後（child standalone、parent 不含 proxy）|
+| `partial_canonicalization` | `partial_canonicalization` | **v3 新**，applyFrameEvent 仍回 `created_frame` decision，但 reason 升 `partial_canonicalization`；同時整體 applyFrameEvent 回 error 觸發 handler 重試/log；sweep 兜底|
 | 沿用原 trace | 原 reason | descendant scan 不改 trace（scan 是 side effect of attaching descendants；主決策仍是「建/更新此 frame」）|
 
 descendant scan 不改 trace 的原因：scan 把其他 frame 收編進來，但本 SessionStart 的主語義仍是「建立或更新 self」 — trace 應反映 self 視角。被收編的 descendant 留在 reconcile-as-descendant 那條路徑的 trace（前一次 SessionStart 留下的 created_frame trace）。
@@ -419,6 +443,9 @@ descendant scan 不改 trace 的原因：scan 把其他 frame 收編進來，但
 | IT7 | `existing_frame_session_start_runs_descendant_scan_only` | (a) cc SessionStart 建 frame；(b) codex 在 race window 內 standalone 進場；(c) cc SessionStart 又來一次（reset，frame != nil 路徑）→ UpdateHookPathAndResetSubagents 清 subagents（PR-2b 既有 `[]`）+ descendant scan 重新收編 codex | cc.Subagents 含 codex proxy ref（reset 後又 re-collapse） |
 | IT8 | `non_session_start_event_does_not_trigger_canonicalization` | codex Notification 在 frame == nil 路徑建 frame（少見邊界） | reconcile + descendant scan 都不觸發；trace decision/reason 沿用既有 `created_frame` 路徑；scan side-effects 不殘留 |
 | IT9 | `findproxyparent_storage_error_aborts_apply` | reconcile 內 `findProxyParent` mock 回 storage error | applyFrameEvent 整體錯誤 propagate（既有 storage error 一致）|
+| IT10 | `existing_descendant_session_start_swept_canonicalizes_via_sweep` (G3) | (a) cc SessionStart 建 frame；(b) codex 在 race window 內 standalone（applyFrameEvent 走完）；(c) codex 又一個 SessionStart（frame != nil existing path → §2.2.2 不做 self-reconcile，已禁）；(d) 觸發 sweep canonicalization | sweep 後 cc.Subagents 含 codex proxy ref；codex frame 已刪 |
+| IT11 | `descendant_scan_skips_pid_reuse_stale_row` (G2) | pane 內有 codex stale standalone（PID 已被 OS reuse 為他者，actualStart != stored.ProcessStartTime）；cc SessionStart descendant scan | scan 跳過 stale candidate（identity gate 擋住）；不收編；stale row 留給 sweep 清 |
+| IT12 | `rollback_failure_propagates_error_observable` (G1) | reconcile 走到 rollback path，mock detachProxyRefWithRetry 回 storage error | applyFrameEvent 回 error；hot path 不 hide 不一致；sweep canonicalization 跑後 final state 收斂 |
 
 **為什麼 IT4 是核心驗證**：直接針對 codex F1 finding 的 ancestor-late interleaving。若 IT4 過綠則 v2 雙向設計成立。
 
@@ -441,15 +468,126 @@ descendant scan 不改 trace 的原因：scan 把其他 frame 收編進來，但
 
 ---
 
-## 4. Sweep canonicalization（**仍不做** — rollback 已兜底）
+## 4. Sweep canonicalization（**v3 納入本 PR** — 兜底 G1 + G3）
 
-v1 plan 因為 delete 失敗只 log 而漏網，需要 sweep 補；v2 用 bounded retry + rollback 後，**delete 失敗永遠不會留下「parent 含 proxy + child standalone」的雙顯示狀態**：
+v2 假設「rollback 已兜底所以 sweep 不需要」— codex round 2 G1 + G3 揭穿這個論證的兩個漏洞：
 
-- delete 成功 → child 沒了 ✓
-- delete 失敗 + rollback 成功 → parent 不含 proxy + child 還在 → 下次 SessionStart descendant-scan 重新嘗試收編
-- delete 失敗 + rollback 失敗（極端）→ 兩邊都 race 輸；下次 SessionStart 仍會重新 attempt
+- **G1**：rollback 自身可能失敗（`detachProxyRefWithRetry` storage error / retry exhaustion）→ 仍殘留 parent 含 proxy + child standalone
+- **G3**：existing descendant 走 SessionStart existing path 時 self-reconcile 被禁，descendant-scan 已在 ancestor 的 SessionStart 跑過一次但不會再跑 → 永久 standalone
 
-故 sweep canonicalization 在本 PR 不需要。如果 reviewer 強烈要求作 defense-in-depth：開 follow-up issue，定 SLO 後再決定是否 backport。
+兩個漏網路徑都需要 background loop 兜底。**v3 在 sweep 加 lightweight canonicalization pass**：
+
+```go
+// canonicalizePane is invoked by sweepOnce per live pane, after the existing
+// dead-frame and idle-timeout passes. Walks the pane's standalone frames,
+// for each one walks its PPID chain (capped at proxyMaxDepth) looking for a
+// same-pane + alive + identity-verified + cross-type ancestor frame. If
+// found, attaches a proxy ref + DeleteIfUnchanged the standalone row.
+//
+// Cost analysis: O(F × D × C) per pane per sweep cycle, where F = standalone
+// frames in pane (≤10 typical), D = walk depth (≤5), C = ListByPane cost.
+// Sweep runs at low frequency (default 1h interval matches idle sweep), so
+// the absolute cost is negligible.
+//
+// Idempotent: each call is independent of prior. Failures (attach race lost,
+// delete race lost, identity unverifiable) are skipped silently — next
+// sweep cycle retries.
+//
+// This is the unconditional defensive layer that ensures eventual
+// canonicalization regardless of which pre-Upsert / post-Upsert / rollback
+// path failed earlier.
+func (m *Module) canonicalizePane(paneID string, broadcastTs int64) error {
+    frames, err := m.frames.ListByPane(paneID)
+    if err != nil {
+        return err
+    }
+    // Build a self-frame map keyed by PID for ancestor lookup.
+    framesByPID := make(map[int]store.Frame, len(frames))
+    for _, frame := range frames {
+        framesByPID[frame.PID] = frame
+    }
+    for _, candidate := range frames {
+        // Walk candidate's PPID chain looking for a cross-type live
+        // ancestor that is also a frame in this pane.
+        ancestor, found := m.findCanonicalAncestor(candidate, framesByPID)
+        if !found {
+            continue
+        }
+        ref := agentpkg.SubagentRef{
+            ID:              fmt.Sprintf("proxy:%s:%d:%s", candidate.AgentType, candidate.PID, candidate.ProcessStartTime),
+            Type:            candidate.AgentType,
+            StartedAt:       broadcastTs,
+            SourcePID:       candidate.PID,
+            SourceStartTime: candidate.ProcessStartTime,
+            IsProxy:         true,
+        }
+        attached, parentStored, aerr := m.attachProxyRefWithRetry(ancestor, ref, broadcastTs)
+        if aerr != nil || !attached {
+            continue
+        }
+        // Best-effort delete; rollback on full failure as in §2.1.1
+        if !m.deleteWithRetryOrRollback(candidate, parentStored, broadcastTs) {
+            log.Printf("phase3.5 sweep: canonicalize partial — child %s under parent %s; next cycle retries", candidate.FrameID, parentStored.FrameID)
+        }
+    }
+    return nil
+}
+
+// findCanonicalAncestor walks candidate's PPID chain looking for a
+// cross-type alive identity-verified frame in the same pane. Returns
+// (frame, true) on hit; (zero, false) on miss / depth exhaust / identity
+// unverifiable.
+func (m *Module) findCanonicalAncestor(candidate store.Frame, framesByPID map[int]store.Frame) (store.Frame, bool) {
+    info, err := readProcessInfoFn(candidate.PID)
+    if err != nil {
+        return store.Frame{}, false
+    }
+    ppid := info.PPID
+    for depth := 0; depth < proxyMaxDepth; depth++ {
+        if ppid <= 1 {
+            return store.Frame{}, false
+        }
+        ancestor, ok := framesByPID[ppid]
+        if ok {
+            if ancestor.AgentType == candidate.AgentType {
+                // Same-type ancestor: hard-stop (PR-2b semantics).
+                return store.Frame{}, false
+            }
+            if isPidAliveFn(ancestor.PID) {
+                actualStart, sterr := processStartTimeFn(ancestor.PID)
+                if sterr == nil && actualStart == ancestor.ProcessStartTime {
+                    return ancestor, true
+                }
+            }
+            // Stale ancestor row; continue walking up
+        }
+        ancestorInfo, err := readProcessInfoFn(ppid)
+        if err != nil {
+            return store.Frame{}, false
+        }
+        if ancestorInfo.PPID == ppid {
+            return store.Frame{}, false
+        }
+        ppid = ancestorInfo.PPID
+    }
+    return store.Frame{}, false
+}
+```
+
+**Wire 進 sweepOnce**：sweep.go 在現有 dead-frame + idle-timeout 兩 pass 後加第三 pass：
+
+```go
+// In sweepOnce after existing passes:
+panes := uniquePaneIDsFromFrames(allFrames)
+broadcastTs := time.Now().UnixNano()
+for _, paneID := range panes {
+    if cerr := m.canonicalizePane(paneID, broadcastTs); cerr != nil {
+        log.Printf("phase3.5 sweep canonicalize pane %s: %v", paneID, cerr)
+    }
+}
+```
+
+**Sweep 與 hot-path canonicalization 的關係**：hot path（reconcile + descendant scan）目標是 SPA 即時看到正確 collapse；sweep 是兜底（hot path 失敗、existing descendant 漏網、cold-start race window 殘留）。雙層防禦不衝突，sweep 的 `attachProxyRefWithRetry` 與 hot path 共享同一 RMW 路徑，並發安全。
 
 ---
 
@@ -458,11 +596,10 @@ v1 plan 因為 delete 失敗只 log 而漏網，需要 sweep 補；v2 用 bounde
 - ❌ per-pane mutex / pane-level claim table（違背 PR-2b 無 lock atomic RMW 哲學）
 - ❌ SQL UNIQUE constraint on `(pane_id, agent_type)`（cc + codex proxy 同 pane 是合法）
 - ❌ delay window / SessionStart deadline（hack，影響 hook latency）
-- ❌ Sweep canonicalization pass（§4）
-- ❌ 對 non-SessionStart event 觸發 canonicalization（IT8 守此邊界）
+- ❌ 對 non-SessionStart event 觸發 hot-path canonicalization（IT8 守此邊界；sweep 兜底）
 - ❌ 修 Phase 3 fallback chain race（那條獨立路徑由 Phase 3 PR #638 處理）
 - ❌ rebuild Inspector / SPA 變更（Phase 5 才做）
-- ❌ 對 existing frame 路徑做 self-as-descendant reconcile（§2.2.2 解釋）
+- ❌ 對 existing frame 路徑做 self-as-descendant reconcile（§2.2.2 解釋；sweep 兜底）
 
 ---
 
@@ -471,11 +608,13 @@ v1 plan 因為 delete 失敗只 log 而漏網，需要 sweep 補；v2 用 bounde
 | # | Commit | 範圍 |
 |---|---|---|
 | 1 | `docs: Phase 3.5 plan v1 — cold-start proxy canonicalization` | 已 commit `bb382870` |
-| 2 | `docs: Phase 3.5 plan v2 — bidirectional + retry/rollback (codex round 1 fixes)` | 此檔 |
-| 3 | `feat(agent): pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert (unwired)` | 兩個新 helper + RC1-RC4 unit |
-| 4 | `feat(agent): reconcileCreatedFrameAsProxy with bounded retry + rollback (unwired)` | reconcile helper（含 §2.1.1 retry/rollback）+ deleteWithRetryOrRollback shared helper |
-| 5 | `feat(agent): wire bidirectional canonicalization into applyFrameEvent` | §2.2.1 + §2.2.2 接線 + trace meta |
-| 6 | `test(agent): integration tests for cold-start race canonicalization` | IT1-IT9 用真 sqlite |
+| 2 | `docs: Phase 3.5 plan v2 — bidirectional + retry/rollback` | 已 commit `dd29be46` |
+| 3 | `docs: Phase 3.5 plan v3 — sweep canonicalize + identity gate + rollback observability` | 此檔（codex round 2 fixes）|
+| 4 | `feat(agent): pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert with identity gate (unwired)` | helper + RC1-RC4 + RC5 PID-reuse skip |
+| 5 | `feat(agent): reconcileCreatedFrameAsProxy with bounded retry + rollback + error propagation (unwired)` | reconcile helper（含 §2.1.1 retry + rollback + propagation）+ deleteWithRetryOrRollback shared helper |
+| 6 | `feat(agent): wire bidirectional canonicalization into applyFrameEvent` | §2.2.1 + §2.2.2 接線 + trace meta（含 partial_canonicalization）|
+| 7 | `feat(agent): sweep canonicalizePane defensive layer` | §4 sweep 第三 pass + findCanonicalAncestor + IT10/IT12 sweep 觀察測試 |
+| 8 | `test(agent): integration tests for cold-start race canonicalization` | IT1-IT12 用真 sqlite |
 
 **Unwired 模式**（commits 3 + 4）沿用 Phase 3 commit `f109b258`，降低 review 對 wire-and-test 同 commit 的審讀負擔。
 
@@ -485,17 +624,19 @@ v1 plan 因為 delete 失敗只 log 而漏網，需要 sweep 補；v2 用 bounde
 
 | 區塊 | 估計 |
 |---|---|
-| `frame_ops.go` reconcileCreatedFrameAsProxy（含 retry/rollback） | ~75 行 |
-| `frame_ops.go` canonicalizeDescendantsAfterUpsert | ~70 行 |
+| `frame_ops.go` reconcileCreatedFrameAsProxy（含 retry/rollback/propagate） | ~85 行 |
+| `frame_ops.go` canonicalizeDescendantsAfterUpsert（含 identity gate） | ~85 行 |
 | `frame_ops.go` pidIsAncestorOfWithCap | ~20 行 |
 | `frame_ops.go` deleteWithRetryOrRollback shared helper | ~30 行 |
-| `frame_ops.go` 接線 § 2.2.1 + §2.2.2 + trace | ~50 行 |
-| `frame_ops_test.go` RC1-RC4 unit | ~120 行 |
-| `module_test.go` / new file IT1-IT9 integration | ~450-550 行 |
-| Plan docs（此檔 v2） | ~430 行 |
-| **總 net code（不含 plan docs）** | **~815-915 行** |
+| `frame_ops.go` 接線 §2.2.1 + §2.2.2 + trace（含 partial_canonicalization） | ~55 行 |
+| `sweep.go` canonicalizePane + findCanonicalAncestor | ~110 行 |
+| `frame_ops_test.go` RC1-RC5 unit | ~150 行 |
+| `module_test.go` / new file IT1-IT12 integration | ~600-700 行 |
+| `sweep_test.go` 加 sweep canonicalize 測試 | ~100 行 |
+| Plan docs（此檔 v3） | ~700 行 |
+| **總 net code（不含 plan docs）** | **~1235-1335 行** |
 
-落在「中-大 PR」邊界（PR-2b 是 ~+1700 行 net）。Review 負擔比 PR-2b 小但比 v1 estimate（~325-425 行）翻倍 — 主要在 integration 測試。
+落在「中-大 PR」邊界（PR-2b 是 ~+1700 行 net）。Sweep 第三 pass + IT10-IT12 把 v2 估計（~815-915）拉到 ~1235-1335。Review 負擔依然比 PR-2b 小但接近邊界 — 修一個有 codex consulting backing 的單點 race，但因兩輪收斂後加上必要 defense-in-depth。
 
 ---
 
@@ -570,5 +711,6 @@ PR 跑過兩輪 codex review 收斂後：
 
 | Round | Job | Verdict | Findings | Resolution |
 |---|---|---|---|---|
-| Plan v1 round 1（adversarial） | 在 §0 摘要的 adversarial run（內聯結果，無 background job ID）| needs-attention | F1 high ancestor-late race / F2 high delete-race 雙顯示 / F3 medium mock test 不足 | v2 全採納（§0.2 / §2.1.1+2.1.2 / §3.1 升 ship gate）|
-| Plan v2 round 2 | (待執行) | (pending) | — | — |
+| Plan v1 round 1（adversarial）| 內聯 | needs-attention | F1 ancestor-late / F2 partial delete / F3 mock test | v2 全採納 |
+| Plan v2 round 2（adversarial）| 內聯 | needs-attention | G1 high rollback 也會失敗 / G2 high descendant scan 缺 identity gate / G3 medium existing descendant 漏網 | v3 全採納（§4 sweep 納入 / §2.1.2 identity gate / §2.1.1 propagate error；IT10-IT12 補測試）|
+| Plan v3 round 3 | (待執行) | (pending) | — | — |

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,8 +1,13 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v2)
 
 Baseline：`1.0.0-alpha.224`（main @ `75b4d166`）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`）。
 Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 → rebase 3.5 → 一次 bump alpha.225）。
+
+**v1 → v2 由 codex adversarial round 1 收斂**（job 在 §13；3 個 high/medium findings 全採納）：
+- F1 high — ancestor-late interleaving（單向 reconcile 不夠）→ 升 **bidirectional canonicalization**（§2.1.2）
+- F2 high — DeleteIfUnchanged 失敗造成 SPA 雙顯示 → 加 **bounded retry + rollback**（§2.1.1）
+- F3 medium — mock 測試掩蓋 race → integration test 從 optional 升 **必要 ship gate**（§3.1）
 
 ---
 
@@ -12,31 +17,37 @@ Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 
 
 **Race 來源**：Phase 2 PR-2b 的 `findProxyParent`（`internal/module/agent/frame_ops.go:688`）只做 *pre-Upsert* PPID 走訪，無 post-Upsert 收斂。當兩個跨型別 SessionStart 在同一 pane 並發冷啟動（典型場景：daemon restart 後 cc + codex proxy 同時來），兩邊 walk 各自 miss → 各自 `Upsert` → 結果是兩個獨立 frame，PR-2b 的 proxy collapse 失效。
 
-**最容易觸發的場景**（Phase 3 codex round 2 finding #1 提出）：daemon restart → cc 與 codex proxy 同時冷啟動 → cc 的 Upsert 與 codex 的 `findProxyParent` walk 交錯 → walk 在「cc Upsert 之前」執行 → codex 永久變成獨立 frame。Phase 3 加上 `tryRebuildFromProcessTree` 後 race window 變大，但 race 本身在 alpha.221 PR-2b 落地起就存在。
+**最容易觸發的場景**（Phase 3 codex round 2 finding #1 提出）：daemon restart → cc 與 codex proxy 同時冷啟動。Phase 3 加上 `tryRebuildFromProcessTree` 後 race window 變大，但 race 本身在 alpha.221 PR-2b 落地起就存在。
 
-### 0.2 設計來源
+### 0.2 設計來源 + v1→v2 演進
 
 Codex architectural consulting `task-modcbbhg-auxa36`（high-effort）採方案 **B'：post-Upsert canonicalization by ancestry**，捨棄 per-pane mutex / pane-level claim table / SQL UNIQUE / delay window 等 hack。
 
-核心 invariant（**單向**，破解 secondary race）：
+**v1 設計**：descendant SessionStart Upsert 後做 reconcile（往上 walk 找 ancestor 收編自己）。
 
-- Descendant **可**轉 proxy（被收編到 ancestor 的 SubagentRef 列表）
-- Ancestor **不可**轉 descendant
-- PID / `started_at` / frame_id 只在多個 ancestor candidate tie-break 時用，**不能**反過來定義 parent 語義
+**v1 漏洞**（codex F1）：descendant 先到 → walk miss → Upsert → reconcile 仍 miss（ancestor 還沒 Upsert）→ ancestor 後到 → 依「ancestor 不可轉 descendant」規則不會收編 descendant → 兩個 frame 永久殘留。
 
-由此，cc + codex 並發冷啟動的 reconcile 階段保證收斂：
+**v2 修正**：Bidirectional canonicalization。SessionStart 做兩個動作（不衝突 secondary race，因為遵守相同單向規則）：
 
-| Frame | reconcile 走 PPID 鏈往上找 | 動作 |
+| Side | 動作 | Walk 方向 |
 |---|---|---|
-| cc 自己（cc 為頂層） | 找不到 codex（codex 不是 cc 的 ancestor） | no-op |
-| codex（codex 為 cc descendant） | 找到 cc | attach codex 為 cc 的 proxy ref + delete 自己 standalone frame |
+| Self-as-descendant（reconcile） | 找 cross-type ancestor，attach 自己為 ancestor 的 proxy + delete 自己 | 從 self 往上 walk PPID |
+| Self-as-ancestor（descendant scan） | 掃同 pane 其他 standalone frames，PPID 鏈經過 self 且跨型別的 → attach 為 self 的 proxy + delete 該 frame | 從每個 candidate 往上 walk PPID 找 self.PID |
 
-兩邊同時跑也不互換，因為「ancestor 不可轉 descendant」這條規則不對稱。
+兩個動作都遵守單向規則（ancestor 收編 descendant，descendant 變 proxy，從不反向），不會引入 secondary race。例：cc + codex 並發冷啟動：
+
+| 順序 | descendant reconcile | ancestor descendant-scan | 結果 |
+|---|---|---|---|
+| descendant first（codex Upsert，cc 還沒到） | codex walk no ancestor → no-op | （cc 還沒 SessionStart） | codex standalone |
+| ↓ cc Upsert 後 | (cc 沒 ancestor，self-reconcile no-op) | cc scan 找到 codex（PPID 鏈經過 cc）→ attach + delete codex | 1 cc frame + codex proxy ✓ |
+| ancestor first（cc Upsert，codex 還沒到） | cc walk no ancestor → no-op | cc scan，pane 內無其他 frame → no-op | cc standalone |
+| ↓ codex Upsert 後 | codex walk 找到 cc → attach + delete codex | (codex 沒 descendant，scan 無動作) | 1 cc frame + codex proxy ✓ |
+| 完全並發（混合 Upsert）| 兩邊都做：先到的 reconcile 可能 miss，後到的 reconcile 找到 ancestor + scan 收編 race window 內進來的 standalone | 兜底所有 ordering | final 1 cc frame ✓ |
 
 ### 0.3 與 Phase 3 的關係
 
 - **獨立但相關**：race 本身不依賴 Phase 3 的 `daemon_restart_recovery` 程式碼，而是 PR-2b（alpha.221）就存在的舊洞
-- **接線位置同檔**：Phase 3 與 Phase 3.5 都動 `applyFrameEvent`（前者加 fallback chain rebuild，後者加 post-Upsert reconcile）— rebase 時可能在 fallback chain 區段衝突
+- **接線位置同檔**：Phase 3 與 Phase 3.5 都動 `applyFrameEvent`（前者加 fallback chain rebuild，後者加 post-Upsert + post-Update reconcile）— rebase 時可能在 fallback chain 區段衝突
 - **獨立 PR**：依 kickoff 「切 Phase 3.5 獨立 PR」決策；Phase 3 PR #638 merge 後 rebase Phase 3.5
 
 ---
@@ -47,44 +58,45 @@ PR-2b 已備齊所有需要的原語：
 
 | 原語 | 位置 | 用途 |
 |---|---|---|
-| `findProxyParent(req)` | `frame_ops.go:688` | PPID 鏈走訪 + same-pane + live + identity-verified + cross-type 篩選；**reconcile 直接重用** |
-| `attachProxyRefWithRetry(parent, ref, broadcastTs)` | `frame_ops.go:631` | optimistic concurrency attach（retry on conflict via `mutateSubagentsWithRetry`） |
-| `FramesStore.DeleteIfUnchanged(frameID, lastSeenAt)` | `internal/store/frames.go:263` | atomic delete（last_seen_at unchanged 才刪）|
-| `SubagentRef{ID, Type, StartedAt, SourcePID, SourceStartTime, IsProxy}` | `internal/agent/subagent.go` | proxy ref 型別（PR-2a 落地） |
-| Proxy ID 格式 `proxy:%s:%d:%s`（agentType, pid, startTime） | `frame_ops.go:176`（applyFrameEvent 既有用法） | reconcile 必須沿用同格式以與 PR-2b 同型 |
+| `findProxyParent(req)` | `frame_ops.go:688` | PPID 鏈走訪 + same-pane + live + identity-verified + cross-type 篩選；reconcile 直接重用 |
+| `attachProxyRefWithRetry(parent, ref, broadcastTs)` | `frame_ops.go:631` | optimistic concurrency attach |
+| `detachProxyRefWithRetry(owner, senderPID, senderStartTime, broadcastTs)` | `frame_ops.go:640` | optimistic concurrency detach（**v2 新用於 rollback**）|
+| `FramesStore.DeleteIfUnchanged(frameID, lastSeenAt)` | `internal/store/frames.go:263` | atomic delete |
+| `FramesStore.ListByPane(paneID)` | 既有 | descendant scan 用 |
+| `FramesStore.GetByIdentity(paneID, pid, startTime)` | 既有 | 重 reload child for retry |
+| `SubagentRef{...}` | `internal/agent/subagent.go` | proxy ref 型別（PR-2a）|
+| Proxy ID 格式 `proxy:%s:%d:%s` | `frame_ops.go:176` 既有 | reconcile 必須沿用同格式 |
 
-**沒有**新 store method、沒有新型別、沒有新 SQL。整個改動限於 `frame_ops.go` 加一個 helper + 接線一行。
+**沒有**新 store method、沒有新型別、沒有新 SQL。
 
 ---
 
 ## 2. 設計細節
 
-### 2.1 `reconcileCreatedFrameAsProxy` helper
+### 2.1 Helper 二件
+
+#### 2.1.1 `reconcileCreatedFrameAsProxy`（self-as-descendant）
 
 ```go
+const reconcileDeleteMaxAttempts = 3
+
 // reconcileCreatedFrameAsProxy attempts to canonicalize a freshly-created
-// SessionStart frame against an alive cross-type ancestor whose own frame
-// landed in the database after this sender's findProxyParent walk completed
-// (race window closed by post-Upsert reconcile).
+// SessionStart frame against an alive cross-type ancestor. If found, attaches
+// proxy ref to ancestor + deletes self's standalone frame.
 //
-// Returns:
-//   - attached=true, parentStored populated when canonicalization succeeded
-//     (parent has new proxy ref + child frame either deleted or left for
-//     next-cycle cleanup if DeleteIfUnchanged conflicted).
-//   - attached=false, zeroFrame, nil when no cross-type ancestor exists
-//     (legitimate standalone frame — leave as-is).
+// Bounded retry on delete (v2 F2): if DeleteIfUnchanged returns deleted=false
+// (concurrent writer touched child row, e.g. probe status update), reload
+// child + retry up to reconcileDeleteMaxAttempts. If all retries fail, ROLLBACK
+// the proxy attach via detachProxyRefWithRetry — final state is consistent
+// (parent has no proxy + child still standalone) rather than the inconsistent
+// (parent has proxy + child still standalone) double-display.
 //
-// Single-direction rule (B' design): only walks UP from sender's PPID. The
-// just-created frame at sender PID is never in the walk path, so reconcile
-// cannot canonicalize itself away.
-//
-// Failure modes:
-//   - findProxyParent error → propagate (storage failure).
-//   - attachProxyRefWithRetry returns attached=false (parent vanished) → no-op
-//     (next sweep / next hook canonicalizes).
-//   - DeleteIfUnchanged returns deleted=false (child row was modified by a
-//     concurrent writer between Upsert and delete) → log + leave (parent has
-//     proxy ref, child remains; next reconcile or sweep cleans up).
+// Returns (canonicalized, parentStored, err):
+//   - canonicalized=true with parentStored populated when attach + delete both
+//     succeeded.
+//   - canonicalized=false, zeroFrame, nil when no ancestor found, parent
+//     vanished mid-attach, or delete-retry exhausted and rollback succeeded.
+//   - non-nil error only for storage failures.
 func (m *Module) reconcileCreatedFrameAsProxy(
     stored store.Frame,
     req EventRequest,
@@ -110,47 +122,197 @@ func (m *Module) reconcileCreatedFrameAsProxy(
         return false, store.Frame{}, aerr
     }
     if !attached {
-        // Parent vanished mid-flight; leave standalone for next cycle.
         return false, store.Frame{}, nil
     }
-    // Atomic delete: only if child's last_seen_at unchanged since Upsert.
-    // Failure (deleted=false) means a concurrent writer touched the row
-    // (probe status update, another reconcile, idle sweep). Don't retry —
-    // idempotent canonicalization can resume from sweep / next hook.
-    deleted, derr := m.frames.DeleteIfUnchanged(stored.FrameID, stored.LastSeenAt)
-    if derr != nil {
-        return false, store.Frame{}, derr
+    // Bounded delete retry with reload: child's last_seen_at could have
+    // moved if probe status update / SubagentStart hit between attach and
+    // delete. Reload via GetByIdentity each retry.
+    childPaneID := stored.PaneID
+    childPID := stored.PID
+    childStartTime := stored.ProcessStartTime
+    expectedLastSeen := stored.LastSeenAt
+    for attempt := 0; attempt < reconcileDeleteMaxAttempts; attempt++ {
+        deleted, derr := m.frames.DeleteIfUnchanged(stored.FrameID, expectedLastSeen)
+        if derr != nil {
+            return false, store.Frame{}, derr
+        }
+        if deleted {
+            return true, parentStored, nil
+        }
+        reloaded, rerr := m.frames.GetByIdentity(childPaneID, childPID, childStartTime)
+        if rerr != nil {
+            return false, store.Frame{}, rerr
+        }
+        if reloaded == nil {
+            // Already gone (concurrent SessionEnd / sweep). Treat as success.
+            return true, parentStored, nil
+        }
+        expectedLastSeen = reloaded.LastSeenAt
     }
-    if !deleted {
-        log.Printf("phase3.5: reconcile attached proxy ref but child frame %s delete lost race; left for next canonicalization", stored.FrameID)
+    // All retries failed: rollback the proxy attach so we don't leave the
+    // inconsistent (parent has proxy + child still standalone) state visible
+    // to SPA. After rollback, child is canonical standalone (will be picked
+    // up by ancestor-side descendant scan on next SessionStart, or by sweep).
+    rollback, _, rerr := m.detachProxyRefWithRetry(parentStored, req.SenderPID, req.SenderStartTime, broadcastTs)
+    if rerr != nil {
+        return false, store.Frame{}, rerr
     }
-    return true, parentStored, nil
+    if !rollback {
+        // Detach also lost (extreme: parent vanished between attach and
+        // detach). Final state: parent gone (sweep cleared) or its proxy
+        // already removed by another writer; child standalone — also
+        // consistent. Fall through to canonicalized=false trace.
+    }
+    log.Printf("phase3.5: reconcile delete-retry exhausted for child frame %s; rolled back proxy attach on parent %s", stored.FrameID, parentStored.FrameID)
+    return false, store.Frame{}, nil
 }
 ```
 
-**為什麼 reconcile 直接呼 `findProxyParent` 就夠**：
+#### 2.1.2 `canonicalizeDescendantsAfterUpsert`（self-as-ancestor — v2 新增）
 
-`findProxyParent` 在 line 169（pre-Upsert）跑過一次 — 那是 race window 的「太早」端，當時 cc 的 frame 還沒入庫所以 walk miss。reconcile 在 post-Upsert 跑同一個 walk — 此時 race window 的「另一端」cc 的 Upsert 已完成（並發 Upsert 之間 SQLite 的 row-level 順序保證了至少一邊看到對方），所以 walk 會找到 cc。重用既有 walk 邏輯避免兩套 walk drift。
+```go
+// canonicalizeDescendantsAfterUpsert scans the pane for standalone frames
+// whose PPID chain passes through self.PID and folds them as proxy refs on
+// self, deleting their standalone rows. Closes the ancestor-late race window
+// (codex F1): descendant's pre-Upsert walk + post-Upsert reconcile both miss
+// because ancestor wasn't in the store yet — when ancestor's SessionStart
+// finally arrives, descendant scan picks them up.
+//
+// Direction-safe: only attaches descendants to self (single-direction rule);
+// never converts self into someone's descendant. Symmetric with reconcile-as-
+// descendant — together they bracket all cold-start interleavings.
+//
+// Per-candidate failures (attach race lost / delete race lost / individual
+// PPID walk error) are logged and skipped; canonicalization is best-effort
+// and idempotent across SessionStart cycles. Storage errors abort the scan.
+func (m *Module) canonicalizeDescendantsAfterUpsert(
+    self store.Frame,
+    broadcastTs int64,
+) error {
+    if m.frames == nil {
+        return nil
+    }
+    frames, err := m.frames.ListByPane(self.PaneID)
+    if err != nil {
+        return err
+    }
+    for _, candidate := range frames {
+        if candidate.FrameID == self.FrameID {
+            continue
+        }
+        if candidate.AgentType == self.AgentType {
+            // Same-type sibling: not a proxy candidate per PR-2b semantics.
+            continue
+        }
+        if !pidIsAncestorOfWithCap(candidate.PID, self.PID, proxyMaxDepth) {
+            continue
+        }
+        // Identity verify candidate is alive (else it's stale and will be
+        // swept; not worth proxy'ing a dead frame onto self).
+        if !isPidAliveFn(candidate.PID) {
+            continue
+        }
+        ref := agentpkg.SubagentRef{
+            ID:              fmt.Sprintf("proxy:%s:%d:%s", candidate.AgentType, candidate.PID, candidate.ProcessStartTime),
+            Type:            candidate.AgentType,
+            StartedAt:       broadcastTs,
+            SourcePID:       candidate.PID,
+            SourceStartTime: candidate.ProcessStartTime,
+            IsProxy:         true,
+        }
+        attached, parentStored, aerr := m.attachProxyRefWithRetry(self, ref, broadcastTs)
+        if aerr != nil {
+            return aerr
+        }
+        if !attached {
+            // Self vanished (extreme); abort scan — caller's projection will
+            // refresh on next ListByPane anyway.
+            return nil
+        }
+        // Bounded delete retry mirrors §2.1.1; on failure rollback this single
+        // proxy ref. Don't abort the whole scan — other candidates may still
+        // canonicalize cleanly.
+        if !m.deleteWithRetryOrRollback(candidate, parentStored, broadcastTs) {
+            log.Printf("phase3.5: descendant scan rolled back proxy %s on parent %s (delete race lost)", ref.ID, self.FrameID)
+            continue
+        }
+        // Refresh self for next iteration (subagents list grew).
+        self = parentStored
+    }
+    return nil
+}
 
-**為什麼不用擔心找到自己**：walk 從 `info.PPID`（sender PID 的 parent）開始，sender PID 本身不在 walk path 內。除非 sender PID == sender PPID（不可能），不然不會踩到自己剛 Upsert 的 frame。
+// pidIsAncestorOfWithCap walks descendant's PPID chain (capped at depth)
+// looking for ancestorPID. Returns true on hit, false on miss / depth
+// exhaustion / process info error / loop detection (PPID == PID).
+func pidIsAncestorOfWithCap(descendantPID, ancestorPID, maxDepth int) bool {
+    current := descendantPID
+    for depth := 0; depth < maxDepth; depth++ {
+        info, err := readProcessInfoFn(current)
+        if err != nil {
+            return false
+        }
+        if info.PPID == ancestorPID {
+            return true
+        }
+        if info.PPID <= 1 || info.PPID == current {
+            return false
+        }
+        current = info.PPID
+    }
+    return false
+}
+
+// deleteWithRetryOrRollback factors the bounded delete + rollback pattern
+// shared by reconcile and descendant-scan. Returns true on successful delete
+// (or already-gone), false on rolled-back attach (caller should treat the
+// proxy ref as not-applied).
+func (m *Module) deleteWithRetryOrRollback(
+    candidate store.Frame,
+    parent store.Frame,
+    broadcastTs int64,
+) bool {
+    expectedLastSeen := candidate.LastSeenAt
+    for attempt := 0; attempt < reconcileDeleteMaxAttempts; attempt++ {
+        deleted, err := m.frames.DeleteIfUnchanged(candidate.FrameID, expectedLastSeen)
+        if err != nil {
+            return false
+        }
+        if deleted {
+            return true
+        }
+        reloaded, rerr := m.frames.GetByIdentity(candidate.PaneID, candidate.PID, candidate.ProcessStartTime)
+        if rerr != nil || reloaded == nil {
+            return reloaded == nil  // gone is success
+        }
+        expectedLastSeen = reloaded.LastSeenAt
+    }
+    rollback, _, _ := m.detachProxyRefWithRetry(parent, candidate.PID, candidate.ProcessStartTime, broadcastTs)
+    _ = rollback  // even if rollback also lost, final state is "no proxy + child standalone" once concurrent writers settle
+    return false
+}
+```
+
+**為什麼 walk 設計仍 reuse `findProxyParent`**：reconcile-as-descendant 走 sender 的 PPID 鏈，跟 PR-2b 既有 `findProxyParent` 完全同型。重用避免兩套 walk drift。
+
+**為什麼 descendant scan 不重用 `findProxyParent`**：descendant scan 的 walk 起點是 *candidate*（standalone frame）的 PID，目標是看 PPID 鏈是否經過 self。findProxyParent 的目標是「找 ancestor」 — 語義不同。新抽 `pidIsAncestorOfWithCap` 是專注的 yes/no 查詢，比硬塞 findProxyParent 加旗標更乾淨。
 
 ### 2.2 接線（applyFrameEvent）
 
-在新 frame 的 `Upsert` 成功後（`frame_ops.go:286-292` 之後、`projectPane` 之前）插入：
+兩個 wiring point — SessionStart 命中 frame == nil（新建）與 frame != nil（既有 reset）。
+
+#### 2.2.1 New frame 路徑（line 286-292 之後）
 
 ```go
 } else {
-    // New frame: insert via Upsert. ...
     stored, err = m.frames.Upsert(store.Frame{...})
     if err != nil {
         return nil, FrameTraceMeta{}, err
     }
 
-    // Phase 3.5: post-Upsert canonicalization by ancestry.
-    // Closes the race window between findProxyParent's pre-Upsert walk and
-    // the cross-type ancestor's own SessionStart Upsert. Only fires for
-    // SessionStart (the event with proxy semantics in PR-2b).
+    // Phase 3.5: bidirectional canonicalization.
     if req.EventName == "SessionStart" {
+        // Self-as-descendant: try collapse into ancestor.
         canonicalized, parentStored, rerr := m.reconcileCreatedFrameAsProxy(stored, req, broadcastTs)
         if rerr != nil {
             return nil, FrameTraceMeta{}, rerr
@@ -161,18 +323,65 @@ func (m *Module) reconcileCreatedFrameAsProxy(
                 FrameID:       parentStored.FrameID,
                 ParentFrameID: parentStored.ParentFrameID,
                 Decision:      "updated_frame",
-                Reason:        "post_upsert_canonicalization",
+                Reason:        "post_upsert_canonicalization_self",
                 Before:        before,
                 After:         summarizeFrame(&parentStored),
             }, err
+        }
+        // Self-as-ancestor: try collapse standalone descendants into self.
+        if cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs); cerr != nil {
+            return nil, FrameTraceMeta{}, cerr
+        }
+        // Reload self in case descendant scan attached refs.
+        if reloaded, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime); rerr == nil && reloaded != nil {
+            stored = *reloaded
         }
     }
 }
 ```
 
-**為什麼只在 SessionStart 觸發**：proxy 收編語義來自 session 邊界（PR-2b 已限定 line 168 fast-path 為 `SessionStart && frame == nil`）。其他 event（Notification / ToolUse 等）若在 frame == nil 路徑建 frame（少見邊界情境），由下一次 SessionStart 或 sweep canonicalize；不在 Phase 3.5 的 race scope 內。
+#### 2.2.2 Existing frame 路徑（line 256-272 之後）
 
-**為什麼 `Before` 沿用原 before**：原 before（line 49 `summarizeFrame(frame)`）是 `frame == nil` 的空 map — 與 reconcile 「我本來不存在」的語義一致。`After` 是 parent 的新狀態（多了一個 proxy ref）。
+```go
+if req.EventName == "SessionStart" {
+    updateErr = m.frames.UpdateHookPathAndResetSubagents(updated)
+} else {
+    updateErr = m.frames.UpdateHookPath(updated)
+}
+if updateErr != nil {
+    return nil, FrameTraceMeta{}, updateErr
+}
+reloaded, err := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
+if err != nil {
+    return nil, FrameTraceMeta{}, err
+}
+if reloaded == nil {
+    return nil, FrameTraceMeta{}, nil
+}
+stored = *reloaded
+
+// Phase 3.5: existing-frame SessionStart also runs descendant-scan. The
+// race window here: this frame existed (e.g. cc was running before daemon
+// restart, cc's frame survived rebuild via Phase 3 tryRebuildFromProcessTree)
+// while a concurrent SessionStart from a descendant landed standalone
+// because the rebuild raced. Reset already cleared subagents, so attach
+// scan is safe.
+//
+// Note: self-as-descendant reconcile is NOT run here. An existing frame
+// is already a stable identity; collapsing it post-hoc into another
+// ancestor would orphan the user's session. Only descendant-scan applies.
+if req.EventName == "SessionStart" {
+    if cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs); cerr != nil {
+        return nil, FrameTraceMeta{}, cerr
+    }
+    if reloaded2, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime); rerr == nil && reloaded2 != nil {
+        stored = *reloaded2
+    }
+}
+```
+
+**為什麼 existing frame 不做 self-as-descendant**：existing frame 走進這條路徑時，frame 已是 stable 識別（先前的 SessionStart 建立）。再 collapse 進 ancestor 會把使用者已認知的 session 突然變成另一個 frame 的 sub-dot，UX 撕裂。
+**為什麼 existing frame 仍做 descendant-scan**：daemon restart 後 Phase 3 `tryRebuildFromProcessTree` 可能把 ancestor frame 重建成 existing，若 race window 期間 descendant 已 standalone，這是唯一收編機會。
 
 ### 2.3 Trace decision 詞彙
 
@@ -180,96 +389,95 @@ func (m *Module) reconcileCreatedFrameAsProxy(
 |---|---|---|
 | `updated_frame` | `proxy_subagent_attached` | PR-2b pre-Upsert proxy fast-path（既有，不改）|
 | `created_frame` | `parent_frame_found` / `parent_frame_missing` | 一般 new frame 路徑（既有，不改）|
-| `updated_frame` | `post_upsert_canonicalization` | **Phase 3.5 新**，reconcile 成功收編 |
+| `updated_frame` | `post_upsert_canonicalization_self` | **v2 新**，self 變 proxy 收編成功 |
+| 沿用原 trace | 原 reason | descendant scan 不改 trace（scan 是 side effect of attaching descendants；主決策仍是「建/更新此 frame」）|
 
-不引入第四 reason（如 `created_then_canonicalized_failed_to_delete`）— delete 失敗是 fail-soft，trace 仍顯示 `post_upsert_canonicalization` 反映 canonical 結果（parent 視角）；child 殘留為非觀察事件，由 log + 下次 reconcile/sweep 處理。
+descendant scan 不改 trace 的原因：scan 把其他 frame 收編進來，但本 SessionStart 的主語義仍是「建立或更新 self」 — trace 應反映 self 視角。被收編的 descendant 留在 reconcile-as-descendant 那條路徑的 trace（前一次 SessionStart 留下的 created_frame trace）。
+
+### 2.4 Wire compatibility
+
+不改 NormalizedEvent / SubagentRef / projection wire schema。SPA 看到的最終結果：parent.subagents 列表多一個 IsProxy=true 的 ref，跟 PR-2b 既有 proxy attach 完全同型。
 
 ---
 
-## 3. 測試矩陣（race interleavings）
+## 3. 測試矩陣
 
-新增測試在 `internal/module/agent/frame_ops_test.go`，命名 `RC1`-`RC8`（Race Canonicalization）。沿用 PR-2b 的 fixture 與 process tree mocking 慣例（`readProcessInfoFn` / `isPidAliveFn` / `processStartTimeFn` 注入）。
+### 3.1 Integration 測試（**必要 ship gate** — v2 升級自 optional）
 
-| # | 名稱 | 場景 | 預期 |
+新增 `internal/module/agent/canonicalize_test.go`（或加進 `module_test.go` 末尾），用真 sqlite store + 真 process info mock + 真 sequence ordering，覆蓋下列 scenarios。
+
+**Test harness**：沿用 `module_test.go` 的 `newTestModule(t)` pattern + `readProcessInfoFn` global injection（PR-2b 既有），不開 goroutine。每個 case 直接呼 `m.applyFrameEvent` 兩到三次模擬不同到達順序。
+
+| # | 名稱 | Sequence | 預期 final state |
 |---|---|---|---|
-| RC1 | `concurrent_cold_start_codex_then_cc` | 序列：codex SessionStart Upsert → cc SessionStart Upsert（codex walk 在 cc Upsert 前完成，pre-Upsert findProxyParent miss）；codex post-Upsert reconcile 跑 | 1 個 cc frame，subagents 含 codex proxy ref（IsProxy=true, SourcePID=codex.PID）；codex frame 已刪 |
-| RC2 | `concurrent_cold_start_cc_then_codex` | 序列反過來：cc Upsert 先、codex Upsert 後 | cc reconcile no-op（找不到自己的 ancestor）；codex reconcile 找到 cc → attach + delete 自己 |
-| RC3 | `concurrent_cold_start_three_way` | cc + codex + opencode 同 pane 並發冷啟動，process tree：opencode → opencode-companion → codex → codex-companion → cc | 1 個 cc frame，subagents 含 codex proxy ref + opencode proxy ref；codex/opencode standalone frame 都已刪 |
-| RC4 | `reconcile_no_ancestor_noop` | 單一 SessionStart，PPID 鏈無跨型別 frame | 無 reconcile 動作（attached=false）；standalone frame 保留 |
-| RC5 | `reconcile_attach_race_lost` | reconcile 走到 attachProxyRefWithRetry，但 parent 在 retry 期間被刪（mock UpsertIfUnchanged 持續回 false 直到耗盡 retry） | reconcile 回 attached=false；standalone frame 保留；無 panic |
-| RC6 | `reconcile_delete_race_lost` | attach 成功，但 child frame 在 attach 期間被 probe status update 改了 last_seen_at，DeleteIfUnchanged 回 false | parent 含新 proxy ref；child frame 仍存在；trace decision = `updated_frame` reason `post_upsert_canonicalization`（不 fail）|
-| RC7 | `non_session_start_no_reconcile` | Notification event 在 frame == nil 路徑建 frame | reconcile 不觸發（frame 殘留 standalone）— 防止 reason 用錯路徑 |
-| RC8 | `findproxyparent_storage_error` | reconcile 內 findProxyParent 回 storage error | applyFrameEvent 整體錯誤 propagate（與既有 storage error 一致）|
+| IT1 | `descendant_then_ancestor_canonicalizes_via_descendant_scan` | (a) codex SessionStart applyFrameEvent — pane 內無 frame → standalone codex frame；(b) cc SessionStart applyFrameEvent — pane 內有 codex standalone → cc Upsert + descendant scan 找到 codex（PPID 鏈經過 cc）→ attach + delete codex | 1 cc frame，cc.Subagents 含 codex proxy ref；codex frame 已刪 |
+| IT2 | `ancestor_then_descendant_canonicalizes_via_self_reconcile` | (a) cc SessionStart — standalone cc；(b) codex SessionStart — pre-Upsert findProxyParent 找到 cc → 走 PR-2b fast-path attach + 不建 codex frame **(this is the existing PR-2b path, sanity check)** | 1 cc frame，cc.Subagents 含 codex proxy ref |
+| IT3 | `concurrent_with_descendant_pre_walk_miss_reconcile_hits` | (a) codex applyFrameEvent — mock `findProxyParent` pre-walk 第 1 次 call 回 nil（cc 未入庫）→ codex Upsert standalone；模擬 cc 同時 Upsert 完成；codex 內 reconcile 跑 post-Upsert findProxyParent 第 2 次 call 回 cc → attach codex 為 cc proxy + delete codex | 1 cc frame + codex proxy ref |
+| IT4 | `concurrent_descendant_post_reconcile_also_misses_recovered_by_ancestor_scan` | (a) codex applyFrameEvent，mock 兩次 findProxyParent 都 miss（cc Upsert 真的還沒到）→ codex standalone 殘留；(b) cc applyFrameEvent → cc Upsert + descendant scan 收編 codex | 1 cc frame + codex proxy ref（cover ancestor-late race，F1 fix 的核心驗證） |
+| IT5 | `delete_race_lost_then_rollback_keeps_consistency` | mock `DeleteIfUnchanged` 持續回 deleted=false（child last_seen_at 持續變動，模擬 probe status update）；reconcile 走 3 次 retry 後 rollback proxy ref | parent 不含 codex proxy ref（rollback 成功）；codex frame 仍 standalone；trace decision = `created_frame`（沒升級 canonicalization）；無雙顯示資料 |
+| IT6 | `descendant_scan_partial_failure_skips_one_continues_others` | pane 內有兩個 standalone descendants（codex + opencode）；mock `DeleteIfUnchanged` 對 codex 持續失敗、對 opencode 成功；cc SessionStart descendant scan | cc.Subagents 含 opencode proxy ref（成功）；codex 仍 standalone（rollback）；scan 不因 codex 失敗中止 |
+| IT7 | `existing_frame_session_start_runs_descendant_scan_only` | (a) cc SessionStart 建 frame；(b) codex 在 race window 內 standalone 進場；(c) cc SessionStart 又來一次（reset，frame != nil 路徑）→ UpdateHookPathAndResetSubagents 清 subagents（PR-2b 既有 `[]`）+ descendant scan 重新收編 codex | cc.Subagents 含 codex proxy ref（reset 後又 re-collapse） |
+| IT8 | `non_session_start_event_does_not_trigger_canonicalization` | codex Notification 在 frame == nil 路徑建 frame（少見邊界） | reconcile + descendant scan 都不觸發；trace decision/reason 沿用既有 `created_frame` 路徑；scan side-effects 不殘留 |
+| IT9 | `findproxyparent_storage_error_aborts_apply` | reconcile 內 `findProxyParent` mock 回 storage error | applyFrameEvent 整體錯誤 propagate（既有 storage error 一致）|
 
-**Race 模擬技巧**（沿用 PR-2b mutateSubagentsWithRetry 測試模式）：
+**為什麼 IT4 是核心驗證**：直接針對 codex F1 finding 的 ancestor-late interleaving。若 IT4 過綠則 v2 雙向設計成立。
 
-- 不需要真正 goroutine：依賴 `findProxyParent` / `attachProxyRefWithRetry` / `DeleteIfUnchanged` 的 mock + 預設順序就能模擬 interleaving
-- RC1/RC2/RC3 用 in-process 順序：先把 cc 的 frame `Upsert` 進 store，再呼 codex 的 `applyFrameEvent`（findProxyParent 在 line 169 走 — 已能找到 cc 但 PR-2b path 設定為 `req.EventName == "SessionStart" && frame == nil` 才走）
+### 3.2 Unit 測試（補充覆蓋 helper）
 
-  **關鍵 mock 設定**：必須讓 line 169 的 pre-Upsert findProxyParent miss，line 286 的 post-Upsert reconcile 才會 hit。做法是 mock `m.frames.FindByPanePID` 第一次回 nil（模擬 cc 還沒 Upsert）、第二次回 cc frame。沿用 `framesStub` 既有的 call counter pattern（PR-2b RP1-RP15 已用過此 pattern）。
+`frame_ops_test.go` 加 `RC1`-`RC4` 為 helper-level unit test（mock-driven，補 IT1-IT9 沒覆蓋的 helper edge case）：
 
-- RC5 mock `attachProxyRefWithRetry` 內部的 UpsertIfUnchanged 持續 false（已有 PR17 RACE regression test 同型）
+| # | 名稱 | 場景 |
+|---|---|---|
+| RC1 | `pidIsAncestorOfWithCap_depth_exhaustion` | 走 PPID 鏈超過 maxDepth 仍未找到 → false |
+| RC2 | `pidIsAncestorOfWithCap_loop_detection` | PPID == PID → false（防 init process） |
+| RC3 | `pidIsAncestorOfWithCap_process_info_error` | readProcessInfoFn err → false |
+| RC4 | `canonicalizeDescendantsAfterUpsert_skips_same_type` | pane 內有 same-type standalone → 不收編 |
 
-### 3.1 整合測試（可選，但建議）
+### 3.3 不加的測試
 
-`module_test.go` 加 `TestApplyFrameEvent_PostUpsertCanonicalization` 系列：用真 sqlite store + 模擬 race 順序 + 斷言 final state。確保 store / handler / projection 三層 wiring 正確。
-
-如果加會落在 `TestApplyFrameEvent_*` series 末尾（按時間先後）。**否則 race interleaving 測試已足夠 cover Helper 邏輯，可不加 integration**。施工時若 unit 測試容易寫就跳過 integration，沒必要重複。
-
-### 3.2 不加的測試
-
-- ❌ goroutine race detector 測試 — 太脆，現有 in-process interleaving 模擬已足夠
+- ❌ goroutine race detector 測試 — 太脆，integration 順序模擬已足夠
 - ❌ Phase 3 daemon_restart_recovery 路徑測試 — 那是 Phase 3 scope；rebase 後若需要 cross-feature 測試另開 issue
+- ❌ 三方 + race 排列組合（cc + codex + opencode + race） — IT3/IT4 + descendant scan 邏輯已 cover 雙方收斂；三方無新規則
 
 ---
 
-## 4. Sweep canonicalization（**不做** — 延後）
+## 4. Sweep canonicalization（**仍不做** — rollback 已兜底）
 
-Codex consulting 提到「optional：sweep.go 加 lightweight canonicalization pass」作為 defensive layer。本 PR **不做**：
+v1 plan 因為 delete 失敗只 log 而漏網，需要 sweep 補；v2 用 bounded retry + rollback 後，**delete 失敗永遠不會留下「parent 含 proxy + child standalone」的雙顯示狀態**：
 
-- reconcile 已在每個 SessionStart 後做收斂；正常流程下不會殘留 mismatch
-- 唯一漏網場景：reconcile attach 成功 + delete race 失敗（RC6） — child 殘留到下次 reconcile/sweep；下次 codex SessionStart 進 applyFrameEvent 時 `frame != nil`（GetByIdentity 命中既有 child），走 `frame != nil` UpdateHookPath 路徑 — 不會再嘗試 reconcile
-- 因此確實有「殭屍 standalone frame 直到 idle sweep（1h）」的漏網期；但 idle sweep 已存在（PR-2b §1.6），1h 後會清除
-- 加 sweep canonicalization 會把 ancestor walk 跑進 sweep loop（O(n) 變 O(n × walk depth)），增加 sweep 成本；先觀察 RC6 在 prod 是否真的發生再決定
+- delete 成功 → child 沒了 ✓
+- delete 失敗 + rollback 成功 → parent 不含 proxy + child 還在 → 下次 SessionStart descendant-scan 重新嘗試收編
+- delete 失敗 + rollback 失敗（極端）→ 兩邊都 race 輸；下次 SessionStart 仍會重新 attempt
 
-如果 reviewer 強烈要求：開 follow-up issue 不在本 PR 處理。
+故 sweep canonicalization 在本 PR 不需要。如果 reviewer 強烈要求作 defense-in-depth：開 follow-up issue，定 SLO 後再決定是否 backport。
 
 ---
 
 ## 5. 不做（明列）
 
 - ❌ per-pane mutex / pane-level claim table（違背 PR-2b 無 lock atomic RMW 哲學）
-- ❌ SQL UNIQUE constraint on `(pane_id, agent_type)`（cc + codex proxy 同 pane 是合法狀態）
+- ❌ SQL UNIQUE constraint on `(pane_id, agent_type)`（cc + codex proxy 同 pane 是合法）
 - ❌ delay window / SessionStart deadline（hack，影響 hook latency）
-- ❌ 引入第四 trace reason `created_then_canonicalized_failed_to_delete`（fail-soft 本身不是觀察點）
 - ❌ Sweep canonicalization pass（§4）
-- ❌ 對 non-SessionStart event 觸發 reconcile（不在 Phase 3.5 race scope）
+- ❌ 對 non-SessionStart event 觸發 canonicalization（IT8 守此邊界）
 - ❌ 修 Phase 3 fallback chain race（那條獨立路徑由 Phase 3 PR #638 處理）
 - ❌ rebuild Inspector / SPA 變更（Phase 5 才做）
+- ❌ 對 existing frame 路徑做 self-as-descendant reconcile（§2.2.2 解釋）
 
 ---
 
 ## 6. Commit 順序（TDD）
 
-| # | Commit | 範圍 | 測試 |
-|---|---|---|---|
-| 1 | `feat(agent): reconcileCreatedFrameAsProxy helper (unwired)` | helper 新 method + sig + walk reuse + delete + log | RC1（helper 直呼，不過 applyFrameEvent）|
-| 2 | `feat(agent): wire reconcile into applyFrameEvent post-Upsert` | line 286 後接線 + EventName guard + trace reason `post_upsert_canonicalization` | RC2 / RC3 / RC4 / RC7 / RC8 |
-| 3 | `test(agent): reconcile race-loss interleavings` | RC5 + RC6 race 模擬 | RC5 / RC6 |
-| 4 | `docs: Phase 3.5 plan v1` | 此 plan 檔本身（已先 commit 過 placeholder 的話 amend；否則放最後）| — |
-
-**Commit 1 unwired 模式**沿用 Phase 3 commit `f109b258`（`tryRebuildFromProcessTree helper (unwired)`）— 先讓 helper 測試獨立綠，再 commit 2 接線後測 wiring。降低 review 對 wire-and-test 同 commit 的審讀負擔。
-
-**Commit 4 docs 位置**：依 kickoff 「先 commit docs placeholder → 再開工」原則，docs 應在 commit 1 之前。實作上：commit 1 = `docs: Phase 3.5 plan v1`，commit 2 = helper（unwired），commit 3 = wiring，commit 4 = race tests。重新編號：
-
 | # | Commit | 範圍 |
 |---|---|---|
-| 1 | `docs: Phase 3.5 plan v1 — cold-start proxy canonicalization` | 此 plan 檔 |
-| 2 | `feat(agent): reconcileCreatedFrameAsProxy helper (unwired)` | helper + RC1 |
-| 3 | `feat(agent): wire reconcile into applyFrameEvent post-Upsert` | wiring + RC2/RC3/RC4/RC7/RC8 |
-| 4 | `test(agent): reconcile race-loss interleavings` | RC5/RC6 |
+| 1 | `docs: Phase 3.5 plan v1 — cold-start proxy canonicalization` | 已 commit `bb382870` |
+| 2 | `docs: Phase 3.5 plan v2 — bidirectional + retry/rollback (codex round 1 fixes)` | 此檔 |
+| 3 | `feat(agent): pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert (unwired)` | 兩個新 helper + RC1-RC4 unit |
+| 4 | `feat(agent): reconcileCreatedFrameAsProxy with bounded retry + rollback (unwired)` | reconcile helper（含 §2.1.1 retry/rollback）+ deleteWithRetryOrRollback shared helper |
+| 5 | `feat(agent): wire bidirectional canonicalization into applyFrameEvent` | §2.2.1 + §2.2.2 接線 + trace meta |
+| 6 | `test(agent): integration tests for cold-start race canonicalization` | IT1-IT9 用真 sqlite |
 
-如果 plan v1 codex 審後改 v2，docs commit 補一個 `docs: Phase 3.5 plan v2 — codex round 1 fixes` 在 v1 之上、helper 之前（與 Phase 3 plan v1→v2 流程同型）。
+**Unwired 模式**（commits 3 + 4）沿用 Phase 3 commit `f109b258`，降低 review 對 wire-and-test 同 commit 的審讀負擔。
 
 ---
 
@@ -277,24 +485,27 @@ Codex consulting 提到「optional：sweep.go 加 lightweight canonicalization p
 
 | 區塊 | 估計 |
 |---|---|
-| `frame_ops.go` reconcile helper | ~50 行 |
-| `frame_ops.go` 接線 + trace meta | ~25 行 |
-| `frame_ops_test.go` RC1-RC8 | ~250-350 行（依 fixture 重用程度）|
-| `module_test.go` integration（**可選**）| 0 或 ~80 行 |
-| Plan docs | ~330 行（此檔）|
-| **總 net code（不含 plan docs）** | **~325-425 行** |
+| `frame_ops.go` reconcileCreatedFrameAsProxy（含 retry/rollback） | ~75 行 |
+| `frame_ops.go` canonicalizeDescendantsAfterUpsert | ~70 行 |
+| `frame_ops.go` pidIsAncestorOfWithCap | ~20 行 |
+| `frame_ops.go` deleteWithRetryOrRollback shared helper | ~30 行 |
+| `frame_ops.go` 接線 § 2.2.1 + §2.2.2 + trace | ~50 行 |
+| `frame_ops_test.go` RC1-RC4 unit | ~120 行 |
+| `module_test.go` / new file IT1-IT9 integration | ~450-550 行 |
+| Plan docs（此檔 v2） | ~430 行 |
+| **總 net code（不含 plan docs）** | **~815-915 行** |
 
-落在「中 PR」邊界（PR-2b 是 ~+1700 行 net）。Review 負擔比 PR-2b 小很多 — 修一個有 codex consulting backing 的單點 race，無新型別、無新 store API、無 SPA 變更。
+落在「中-大 PR」邊界（PR-2b 是 ~+1700 行 net）。Review 負擔比 PR-2b 小但比 v1 estimate（~325-425 行）翻倍 — 主要在 integration 測試。
 
 ---
 
 ## 8. 驗收 / Ship 條件
 
-- 所有 RC1-RC8 + 既有 frame_ops_test 全綠
+- 所有 IT1-IT9 + RC1-RC4 + 既有 frame_ops_test 全綠
 - `go build ./... && go vet ./... && go test ./...` 23 packages 全綠
-- SPA 無變更（無需跑 spa lint/test，但 PR description 註明「SPA unchanged」便於 review router）
-- 委派 codex 兩輪 review 收斂（標準 + adversarial 三視角）；重大 finding 全採納或開 follow-up issue
-- Phase 3 PR #638 merged 後 rebase 本 PR 到 main，`applyFrameEvent` 衝突解到 Phase 3 fallback chain 之上、本 PR reconcile 接線之下
+- SPA 無變更
+- 委派 codex 兩輪 review 收斂（標準 + adversarial 三視角）；high finding 全採納或開 follow-up issue
+- Phase 3 PR #638 merged 後 rebase 本 PR 到 main，`applyFrameEvent` 衝突解到 Phase 3 fallback chain 之上、本 PR canonicalization 接線之下
 
 ---
 
@@ -302,39 +513,42 @@ Codex consulting 提到「optional：sweep.go 加 lightweight canonicalization p
 
 | # | 風險 | 緩解 |
 |---|---|---|
-| R1 | reconcile 找錯 ancestor（同 pane 但邏輯上不該收編，例如 user 手動 spawn 的 cc + codex 並非 parent-child 關係） | `findProxyParent` 已要求 PPID 鏈確切 ancestor + same-pane + live + identity-verified；reuse 同邏輯保護不變 |
-| R2 | reconcile 與 idle sweep 競爭：sweep 正在刪 parent，reconcile 同時 attach | `attachProxyRefWithRetry` 內部 `UpsertIfUnchanged` 已 cover：sweep delete 後 attach 回 attached=false（parent 不存在）→ reconcile 回 false → standalone 保留 |
-| R3 | reconcile 與 SubagentStart hook 競爭：cc 的 SubagentStart 同時在改 cc.Subagents | `attachProxyRefWithRetry` 用 `mutateSubagentsWithRetry` 共享 retry 機制；兩個並發 mutation 會收斂到 final state（PR-2b R6 已驗）|
-| R4 | DeleteIfUnchanged 的 `deleted=false` 殘留累積 | 同 §4 分析：常態下不發生；發生時 idle sweep 1h 兜底；極端情境下次 SessionStart 不會再嘗試 reconcile（frame != nil 走 update path）— 接受此漏網期 |
-| R5 | `findProxyParent` walk 在 reconcile 階段成本（每個新 frame 都 walk）| walk depth 上限 5；現代機器一次 walk < 1ms；SessionStart 頻率不高（每個 user-initiated session）— 可忽略 |
-| R6 | rebase Phase 3 後 applyFrameEvent 衝突 | Phase 3 改 fallback chain（line 220 區塊），Phase 3.5 改 new-frame Upsert 後（line 286 區塊）；位置不同，git rebase 應可機械處理；極端衝突由施工者手動解 |
+| R1 | descendant scan 找錯 ancestor（PPID 鏈經過 self 但邏輯上不該收編，例：user 手動 spawn 兩個獨立 cc + codex 巧合 PPID 共用） | 同 pane + 跨型別 + identity-verified（同 PR-2b findProxyParent 規則）；極小機率假陽性，由 next sweep / 使用者 SessionEnd 自然修復 |
+| R2 | reconcile 與 idle sweep 競爭：sweep 正在刪 parent | `attachProxyRefWithRetry` 內部 `UpsertIfUnchanged` cover：sweep delete 後 attach 回 false → reconcile 回 false → standalone 保留 |
+| R3 | reconcile/scan 與 SubagentStart hook 競爭 | `attachProxyRefWithRetry` 用 `mutateSubagentsWithRetry` 共享 retry，PR-2b R6 已驗 |
+| R4 | rollback detach 也失敗（極端）| log + 接受；下次 SessionStart 仍會 re-attempt（雙向設計保證每次 SessionStart 都是新嘗試）|
+| R5 | descendant scan 走 ListByPane O(n) + 每個 candidate walk O(depth) | proxyMaxDepth=5 + pane 內 frame 數一般 < 10；現代機器一次 scan < 5ms；SessionStart 頻率不高（user-initiated session）|
+| R6 | rebase Phase 3 後 applyFrameEvent 衝突 | Phase 3 改 fallback chain（line 220 區塊），Phase 3.5 改 new-frame Upsert 後 + existing-frame Update 後（line 286 + line 272 區塊）；位置不同，git rebase 應可機械處理；極端衝突由施工者手動解 |
+| R7 | descendant scan 的 ListByPane 與接線同事務未同步 | 接受 eventual consistency：scan 看到 standalone snapshot，attach 用 UpsertIfUnchanged。中間有新 standalone 進場 → 下次 SessionStart 才 canonicalize。可接受 |
 
 ---
 
 ## 10. Codex review focus 預期
 
-施工後委派 codex 兩輪 review 時的具體 focus 文字建議：
+施工後委派 codex 兩輪 review 時的 focus 文字建議：
 
 **第一輪（標準 review）**：
-> Phase 3.5 — post-Upsert proxy canonicalization. 修 PR-2b 的 cold-start race。重點檢查：
-> 1. `reconcileCreatedFrameAsProxy` 對 `findProxyParent` 的重用是否會拿到自己的 frame（自我收編）
-> 2. `DeleteIfUnchanged` 失敗時的後續一致性（standalone 殘留 + parent 已含 proxy ref 的偏差是否會造成 SPA 顯示異常）
-> 3. trace meta 的 `Before` / `After` 表達在 reconcile 成功後是否與既有 trace step 慣例一致
-> 4. Phase 3.5 與 Phase 3 fallback chain 的互動（rebase 後接線位置會不會造成同 SessionStart 雙觸發）
+> Phase 3.5 v2 — bidirectional canonicalization + retry/rollback。修 PR-2b 的 cold-start race。重點檢查：
+> 1. v2 雙向設計的單向規則論證是否封閉（self-as-descendant + self-as-ancestor 兩條路徑會否互相觸發 secondary race）
+> 2. `reconcileCreatedFrameAsProxy` 的 bounded retry + rollback 在所有失敗組合下是否確保 final state 一致
+> 3. `canonicalizeDescendantsAfterUpsert` 的 `pidIsAncestorOfWithCap` walk 是否會誤抓 grandparent 的 sibling 等非真 ancestor
+> 4. existing frame 路徑只跑 descendant-scan 不跑 self-reconcile 的判斷是否正確（SessionStart reset 後是否該重新 evaluate ancestry）
+> 5. trace meta 在 IT4/IT5/IT6 各路徑下是否與 reviewer 對 SPA 顯示的預期吻合
+> 6. IT 測試是否確實用真 sqlite（不退化成 mock-driven）
 
 **第二輪（adversarial 三視角）**：
-- **攻擊方**：找 race interleaving 的死角；`findProxyParent` 在 reconcile 階段是否有可能返回剛被另一邊 reconcile 收編走的 ghost ancestor；DeleteIfUnchanged 與 idle sweep / probe status update 的競賽角度
-- **防守方**：B' 單向收斂規則的論證是否在所有 ancestor 拓撲下都成立；`findProxyParent` 重用 vs. 重寫的 trade-off
-- **檔案體質**：`frame_ops.go` 已 752 行，加 ~75 行後是否觸及 SRP 邊界；reconcile 是否該抽到獨立檔（如 `frame_canonicalize.go`）
+- **攻擊方**：尋找 race interleaving 死角；雙向設計是否有「scan + reconcile 同一 SessionStart 同時撞 attach」的內部 race；rollback detach 失敗後的二階段一致性
+- **防守方**：v2 `pidIsAncestorOfWithCap` 與 `findProxyParent` 邏輯重複是否是好分離還是該合併
+- **檔案體質**：`frame_ops.go` 752 → ~975 行後是否觸發 SRP；是否該抽 `canonicalize.go`
 
 ---
 
-## 11. Open questions（plan review 會解）
+## 11. Open questions（plan v2 review 會解）
 
-1. 是否該把 reconcile 同步擴展到 non-SessionStart 路徑？（plan 目前不擴展，等 review 質疑再說）
-2. 是否需要 sweep canonicalization 作為 defensive layer？（plan §4 不做，等 review 投票）
-3. trace decision 是否該新增 `created_then_canonicalized` 與 `updated_frame` 區分？（plan 採 `updated_frame` + reason 區分，因為 final state 是 parent updated）
-4. `reconcileCreatedFrameAsProxy` 是否該抽到獨立檔？（plan 留在 `frame_ops.go`，理由：frame_ops 已是同檔的 race 修復集合）
+1. v2 雙向設計後，是否仍需把 `reconcileCreatedFrameAsProxy` 和 `canonicalizeDescendantsAfterUpsert` 的接線同放在 frame == nil 路徑，還是該分到不同 phase？（plan 採同 wire site，理由：兩個是同一 SessionStart 的 self 視角兩面）
+2. `pidIsAncestorOfWithCap` 是否該抽到獨立 `process_tree.go` 檔（process tree util 集中）？（plan 留在 frame_ops.go，因為它是 race fix 的內部 helper，獨立檔太重）
+3. existing frame 路徑的 scan 觸發位置在 `UpdateHookPathAndResetSubagents` 之後 — 若 reset 失敗則整個 SessionStart 失敗，scan 不跑；OK？（plan 採此設計：reset 失敗本就要回錯）
+4. IT4 的 mock 設計（兩次 findProxyParent miss）是否能完整模擬「ancestor 真的還沒入庫」場景？或需要在 sqlite 層直接控制 ListByPane 結果？（plan 用第二種，更接近真 race）
 
 ---
 
@@ -349,3 +563,12 @@ PR 跑過兩輪 codex review 收斂後：
 5. Bump merge → main @ alpha.225
 6. ExitWorktree 清掉 `lights-phase-3-5` worktree
 7. 更新 kickoff_lights_rebuild.md：標 Phase 3 + Phase 3.5 ✅ at alpha.225；下一步 Phase 4 probe audit
+
+---
+
+## 13. Codex review 軌跡
+
+| Round | Job | Verdict | Findings | Resolution |
+|---|---|---|---|---|
+| Plan v1 round 1（adversarial） | 在 §0 摘要的 adversarial run（內聯結果，無 background job ID）| needs-attention | F1 high ancestor-late race / F2 high delete-race 雙顯示 / F3 medium mock test 不足 | v2 全採納（§0.2 / §2.1.1+2.1.2 / §3.1 升 ship gate）|
+| Plan v2 round 2 | (待執行) | (pending) | — | — |

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,8 +1,12 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v5 / Hybrid B+)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v6 / Hybrid B+)
 
 Baseline：`1.0.0-alpha.224`（main @ `75b4d166`）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`）。
 Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 → rebase 3.5 → 一次 bump alpha.225）。
+
+**v5 → v6 由 codex round 5 收斂**（§13；1 high finding 採納）：
+
+- **J1 high** — v5 §2.2.2「snapshot live proxies → reset → re-attach」三步非原子，並發 child SessionStart attach 新 proxy + 刪 child standalone 後，我的 reset 把新 proxy 也清掉、re-attach 只還原舊 ref → 新 proxy 永久消失。**v6 修法**：合併成單一 **filter-merge-retry pattern**（與 PR-2b `mutateSubagentsWithRetry` 同型，但語意是 filter 而非 add），消除中間態 race window。新 IT20 守規。
 
 **v4 → v5 由 codex round 4 收斂**（§13；2 finding 全採納）：
 
@@ -276,73 +280,132 @@ func pidIsAncestorOfWithCap(descendantPID, ancestorPID, maxDepth int) bool {
 }
 ```
 
-#### 2.2.2 Existing frame 路徑（line 256-272 之後）
+#### 2.2.2 Existing frame 路徑（line 256-272 區）
 
-**v5 I1 fix**：reset 前 snapshot 仍 live identity-verified IsProxy refs，reset 後 re-attach。reset 的原意是「old session's native subagent refs no longer apply」，但 cross-type IsProxy refs 指向同 pane 內仍 live 的 OS process — 不該在 parent's session-restart 時失蹤（descendant 沒 standalone 可補回）。
+**v6 J1 fix**：替換「snapshot → reset → re-attach」三步非原子序列為**單一 filter-merge-retry pattern**。
+
+語意：SessionStart 對 existing frame 的 reset 不該清掉「同 pane 仍 live 的 cross-type IsProxy refs」（v5 I1）。但三步法在 snapshot 後、reset 前的 race window 內，並發 child SessionStart 可能新 attach proxy 後被 reset 抹除（v5 J1）。
+
+修法 — 在 retry loop 內 filter live IsProxy + 寫入：每次 retry 重讀 subagents（包含 race window 內的並發 attach），filter 後 UpsertIfUnchanged。concurrent attach 會 bump frame.LastSeenAt → 我的 IfUnchanged 看到 mismatch → reload → 新一輪 filter 保留新 ref → 收斂。**全程無中間態暴露**。
 
 ```go
-// v5 I1: snapshot live IsProxy refs BEFORE reset. The store-level reset
-// clears subagents_json wholesale; live cross-type proxies pointing to OS
-// processes that still exist must survive the parent's SessionStart
-// restart. Without this, an already-canonicalized proxy ref from a prior
-// race window vanishes from projection — descendant scan can't recover
-// it because the standalone child frame was deleted at canonicalize time.
-var preservedProxies []agentpkg.SubagentRef
-if req.EventName == "SessionStart" && frame != nil {
-    for _, ref := range frame.Subagents {
-        if !ref.IsProxy {
-            continue
-        }
-        if !isPidAliveFn(ref.SourcePID) {
-            continue
-        }
-        actualStart, sterr := processStartTimeFn(ref.SourcePID)
-        if sterr != nil || actualStart != ref.SourceStartTime {
-            continue
-        }
-        preservedProxies = append(preservedProxies, ref)
-    }
-}
-
-if req.EventName == "SessionStart" {
-    updateErr = m.frames.UpdateHookPathAndResetSubagents(updated)
 } else {
-    updateErr = m.frames.UpdateHookPath(updated)
-}
-if updateErr != nil { return nil, FrameTraceMeta{}, updateErr }
+    // SessionStart on existing frame: filter-merge-retry to preserve
+    // live identity-verified IsProxy refs across reset semantics. Other
+    // events use the existing UpdateHookPath narrow update.
+    if req.EventName == "SessionStart" {
+        // v6 J1 fix: replace "snapshot live proxies → bulk reset → re-attach"
+        // (v5) which had a race window between snapshot and reset (concurrent
+        // child SessionStart's attach + delete would be lost). Filter-merge-
+        // retry reads frame.Subagents on every retry, so concurrent attach
+        // is naturally preserved (next reload includes the new ref).
+        var success bool
+        for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
+            filtered := []agentpkg.SubagentRef{}
+            for _, ref := range frame.Subagents {
+                if !ref.IsProxy {
+                    continue
+                }
+                if !isPidAliveFn(ref.SourcePID) {
+                    continue
+                }
+                actualStart, sterr := processStartTimeFn(ref.SourcePID)
+                if sterr != nil || actualStart != ref.SourceStartTime {
+                    continue
+                }
+                filtered = append(filtered, ref)
+            }
 
-reloaded, err := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
-if err != nil { return nil, FrameTraceMeta{}, err }
-if reloaded == nil { return nil, FrameTraceMeta{}, nil }
-stored = *reloaded
+            candidate := *frame
+            candidate.AgentType = req.AgentType
+            candidate.PPID = info.PPID
+            candidate.ParentFrameID = parentFrameID
+            candidate.Status = status
+            candidate.LastSeenAt = broadcastTs
+            candidate.Verified = true
+            candidate.Subagents = filtered
 
-// v5 I1: re-attach preserved proxies via existing helper (atomic retry,
-// merge-aware via updateSubagents). StartedAt refreshed to broadcastTs to
-// reflect that they survived this SessionStart cycle.
-for _, ref := range preservedProxies {
-    ref.StartedAt = broadcastTs
-    attached, parentStored, aerr := m.attachProxyRefWithRetry(stored, ref, broadcastTs)
-    if aerr != nil { return nil, FrameTraceMeta{}, aerr }
-    if attached {
-        stored = parentStored
+            ok, written, err := m.frames.UpsertIfUnchanged(candidate, frame.LastSeenAt)
+            if err != nil {
+                return nil, FrameTraceMeta{}, err
+            }
+            if ok {
+                stored = written
+                success = true
+                break
+            }
+            // Conflict: concurrent writer touched the row (proxy attach,
+            // SubagentStart hook, probe status update). Reload + retry —
+            // re-read includes any new IsProxy ref the racer added, and
+            // next iteration's filter preserves it.
+            reloaded, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
+            if rerr != nil {
+                return nil, FrameTraceMeta{}, rerr
+            }
+            if reloaded == nil {
+                // Frame deleted mid-flight. Treat as frame_missing (caller
+                // path will project pane and emit skipped trace).
+                projection, perr := m.projectPane(req.TmuxPaneID)
+                return projection, FrameTraceMeta{
+                    Decision: "skipped",
+                    Reason:   "frame_missing",
+                    Before:   before,
+                    After:    map[string]any{},
+                }, perr
+            }
+            frame = reloaded
+        }
+        if !success {
+            return nil, FrameTraceMeta{}, fmt.Errorf("session_start filter-merge: exceeded %d retries for frame %s", proxyUpsertMaxAttempts, frame.FrameID)
+        }
+    } else {
+        // Non-SessionStart existing frame: original narrow update path
+        // (PR-2b R8 — don't round-trip subagents).
+        updated := *frame
+        updated.AgentType = req.AgentType
+        updated.PPID = info.PPID
+        updated.ParentFrameID = parentFrameID
+        updated.Status = status
+        updated.LastSeenAt = broadcastTs
+        updated.Verified = true
+        if err := m.frames.UpdateHookPath(updated); err != nil {
+            return nil, FrameTraceMeta{}, err
+        }
+        reloaded, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
+        if rerr != nil {
+            return nil, FrameTraceMeta{}, rerr
+        }
+        if reloaded == nil {
+            return nil, FrameTraceMeta{}, nil
+        }
+        stored = *reloaded
     }
-}
 
-// Phase 3.5: descendant scan (catches any cold-start race window children
-// whose SessionStart raced with this existing-frame's SessionStart).
-if req.EventName == "SessionStart" {
-    updated, cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs)
-    if cerr != nil {
-        return nil, FrameTraceMeta{}, cerr
+    // Phase 3.5: descendant scan after successful filter-merge or narrow
+    // update. Catches any cold-start race window children whose
+    // SessionStart raced with this existing-frame's SessionStart.
+    if req.EventName == "SessionStart" {
+        updated, cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs)
+        if cerr != nil {
+            return nil, FrameTraceMeta{}, cerr
+        }
+        stored = updated
     }
-    stored = updated
 }
 ```
 
-**為什麼 re-attach 而不是「reset 不清 IsProxy」**：
+**為什麼用 UpsertIfUnchanged 而非 narrow update + reset helper**：
 
-- store-level `UpdateHookPathAndResetSubagents` 是 narrow update 設計（PR-2b R8）— 改它的語意（conditional reset）會把 store 層拉進 IsProxy semantics，違反 narrow update 哲學
-- 在 module 接線層做 snapshot + re-attach 保留 store-level cleanliness；attachProxyRefWithRetry 的 RMW retry 邏輯也直接重用
+- v5 I1 fix 原本嘗試在 narrow update 邊界外做 snapshot + re-attach；J1 揭示三步法的非原子性根本問題
+- v6 採 UpsertIfUnchanged 寫整個 frame（含 subagents），但因為 subagents 是「filtered live IsProxy」**有意決策值**，不是「stale baseline」 — 不違反 PR-2b R8 narrow update 哲學（避免 round-trip stale subagents）。我們是**主動決定**這個值，並透過 IfUnchanged 確保決策對應的 baseline 沒被搶先改
+- 該 store-level helper `UpdateHookPathAndResetSubagents` 在 v6 SessionStart existing-frame 路徑不再使用；non-SessionStart 路徑沿用 `UpdateHookPath` 不變（narrow column update）
+- 仍在 module 層解決，store layer 介面不擴展（不加新 helper）
+
+**對既有 helper 的影響**：
+
+- `UpdateHookPathAndResetSubagents` 在 v6 後**仍存在**（store-level helper 不變），但 SessionStart existing-frame 路徑不再呼叫它
+- 若仍有其他呼叫者（grep 確認只有 frame_ops.go SessionStart 路徑用），可在 v6 commit 9 把它從 store API 移除作為 cleanup；不確定的話留著無害
+- 接線 commit 9 的 unwired-then-wired 模式仍維持：commit 9 同時完成 §2.2.1 + §2.2.2 接線
 
 ### 2.3 SessionEnd proxy cleanup（v4 新，修 Side B 抓的 SessionEnd 漏洞）
 
@@ -549,6 +612,7 @@ var (
 | IT17 | `existing_frame_session_start_preserves_live_proxy_refs` (v5 I1) | (a) cc frame 已存在且 cc.Subagents 含 codex proxy ref（live + identity verified）；(b) cc 又收 SessionStart（existing path）→ pre-reset snapshot + reset + re-attach；(c) 之後 codex 進程仍 alive，無新 SessionStart | cc.Subagents 仍含 codex proxy ref（StartedAt 刷新到本次 broadcastTs）；projection dedup 也仍工作 |
 | IT18 | `existing_frame_session_start_skips_dead_proxy_during_reset` (v5 I1 negative) | (a) cc frame 已存在含 codex proxy ref，但 codex 進程已死（isPidAliveFn = false）；(b) cc SessionStart | reset 後 cc.Subagents 不含該 dead proxy ref（preserve 不通過 identity gate）|
 | IT19 | `existing_frame_session_start_skips_pid_reused_proxy` (v5 I1 negative) | (a) cc frame 含 codex proxy；(b) codex PID 已被 OS reuse（actualStart != ref.SourceStartTime）；(c) cc SessionStart | reset 後不 preserve 該 stale proxy（identity 不過 gate）|
+| IT20 | `existing_frame_session_start_preserves_concurrently_attached_proxy` (v6 J1) | (a) cc frame 已存在 + 一個 codex proxy ref；(b) cc SessionStart filter-merge attempt 1 — 同時 mock UpsertIfUnchanged 第 1 次回 conflict（模擬並發 child SessionStart 在 attempt 1 之間 attach 第二個 opencode proxy 並刪除其 standalone）；(c) attempt 2 reload 看到兩個 IsProxy ref，filter 通過 gate，UpsertIfUnchanged 成功 | cc.Subagents 含 codex 與 opencode 兩個 proxy ref；無 ref 在 race window 中遺失 |
 
 ### 3.2 Unit 測試
 
@@ -756,11 +820,12 @@ func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 | 2 | `docs: Phase 3.5 plan v2 — bidirectional + retry/rollback` ✅ `dd29be46` |
 | 3 | `docs: Phase 3.5 plan v3 — sweep canonicalize + identity gate` ✅ `148a2309` |
 | 4 | `docs: Phase 3.5 plan v4 — Hybrid B+ (consulting-driven redesign)` ✅ `a338f6d3` |
-| 5 | `docs: Phase 3.5 plan v5 — preserve live proxies + honest metrics` 此檔 |
+| 5 | `docs: Phase 3.5 plan v5 — preserve live proxies + honest metrics` ✅ `285599e4` |
+| 5b | `docs: Phase 3.5 plan v6 — filter-merge-retry (codex round 5 J1 fix)` 此檔 |
 | 6 | `feat(agent): metrics counters for phase 3.5 canonicalization observability` | metric 4 個 + import 註冊（無 endpoint） |
 | 7 | `feat(agent): pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert with identity gate (unwired)` | helper + RC1-RC5 unit |
 | 8 | `feat(agent): reconcileCreatedFrameAsProxy best-effort (unwired)` | reconcile helper（無 rollback）|
-| 9 | `feat(agent): wire bidirectional canonicalization + preserve live proxies into applyFrameEvent` | §2.2.1 + §2.2.2（含 v5 I1 preserve）+ IT17/IT18/IT19 |
+| 9 | `feat(agent): wire bidirectional canonicalization + filter-merge-retry into applyFrameEvent` | §2.2.1 + §2.2.2（**v6 filter-merge-retry**，取代 v5 三步 snapshot + reset + re-attach）+ IT17/IT18/IT19/IT20 |
 | 10 | `feat(agent): SessionEnd hot-path proxy cleanup` | §2.3 + IT12 |
 | 11 | `feat(agent): buildPaneProjection dedup proxy-claimed standalone frames` | §2.4 + PD1-PD3 + IT5 |
 | 12 | `feat(agent): sweep canonicalizePane with candidate identity gate` | §4.2 + IT10 |
@@ -778,17 +843,17 @@ func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 | `frame_ops.go` canonicalizeDescendantsAfterUpsert（含 identity gate） | ~85 行 |
 | `frame_ops.go` pidIsAncestorOfWithCap | ~20 行 |
 | `frame_ops.go` SessionEnd proxy cleanup | ~10 行（既有 case 改 4 行）|
-| `frame_ops.go` 接線 §2.2.1 + §2.2.2（含 v5 preserve live proxies）| ~75 行 |
+| `frame_ops.go` 接線 §2.2.1 + §2.2.2（v6 filter-merge-retry）| ~85 行 |
 | `projection.go` dedup | ~40 行 |
 | `sweep.go` canonicalizePane + findCanonicalAncestor + pruneDeadProxyRefs | ~140 行 |
 | `frame_ops_test.go` RC1-RC5 unit | ~150 行 |
 | `projection_test.go` PD1-PD3 | ~80 行 |
-| `module_test.go` / new file IT1-IT19 integration | ~800-900 行 |
+| `module_test.go` / new file IT1-IT20 integration | ~830-930 行 |
 | `sweep_test.go` 加 sweep canonicalize/prune 測試 | ~120 行 |
-| Plan docs（此檔 v5） | ~870 行 |
-| **總 net code（不含 plan docs）** | **~1595-1695 行** |
+| Plan docs（此檔 v6） | ~895 行 |
+| **總 net code（不含 plan docs）** | **~1620-1720 行** |
 
-v5 LOC 比 v4（~1460-1560）+135：preserve live proxies wiring（~35 行）+ IT17/IT18/IT19（~100 行）。但複雜度仍比 v3 低（單一 best-effort 路徑 + projection dedup boundary，不是 retry/rollback/propagate maze）。
+v6 LOC 比 v5（~1595-1695）+25：filter-merge-retry +10 行（取代三步法）+ IT20 約 +30 行。設計複雜度反而降低 — 三步法非原子→單一 retry loop，與 PR-2b 既有 retry pattern 同型，認知負擔小。
 
 ---
 
@@ -868,4 +933,5 @@ PR 跑過 codex round 4 review 收斂後：
 | Side A consulting | task-moeupstr-z0oilf | (technical spec) | 提議 SQL transaction 根除 partial 物理層 | 不採納（標準對 ephemeral 表過高），但細節（BEGIN IMMEDIATE / busy code / FK）保留參考 |
 | Side B consulting | task-moeuqbnn-jart97 | (adversarial argument) | 證據壓倒：sweep 2s 不是 1h / agent_frames 是 ephemeral / projection 是 user-visible 邊界 / SessionEnd 漏 cleanup proxy | **採納為 v4 核心**（Hybrid B+）|
 | Plan v4 round 4（adversarial）| inline | needs-attention | I1 high existing-frame reset 清掉 live proxy / I2 medium SLO 不可量測 | v5 全採納（§2.2.2 preserve live proxies + IT17/IT18/IT19；§2.6 移除 SLO 聲明，改三 evidence point；§0.2 設計論證重整）|
-| Plan v5 round 5 | (待執行) | (pending) | — | — |
+| Plan v5 round 5（adversarial）| inline | needs-attention | J1 high snapshot/reset/re-attach 三步非原子，並發 attach 在 race window 內被抹除 | v6 採納（§2.2.2 改為 filter-merge-retry pattern，取代三步法；新 IT20 守規）|
+| Plan v6 round 6 | (待執行) | (pending) | — | — |

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,8 +1,13 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v4 / Hybrid B+)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v5 / Hybrid B+)
 
 Baseline：`1.0.0-alpha.224`（main @ `75b4d166`）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`）。
 Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 → rebase 3.5 → 一次 bump alpha.225）。
+
+**v4 → v5 由 codex round 4 收斂**（§13；2 finding 全採納）：
+
+- **I1 high** — existing-frame SessionStart 的 reset 把已成功 canonicalize 的 live proxy ref 清掉，descendant scan 無 standalone 可補回 → 永久漏顯 → §2.2.2 加 **pre-reset snapshot + re-attach live proxies**（identity gate 通過的才保留）；新增 IT17 守規
+- **I2 medium** — v4 §2.6 聲稱 SLO 1/1000 觸發升級到 SQL tx，但 expvar 不接 endpoint + 無 denominator + daemon restart 歸零 → **觀察前提塌陷** → §2.6 改寫誠實版（in-process counter foundation；SLO 量測為 follow-up）；§0.2 設計論證改為三 evidence point（不再依賴「observable 為 ship gate」）
 
 **v3 → v4 由兩 codex 平行架構 consulting 收斂**（§13；採 Side B Hybrid B+，捨棄 Side A SQL transaction）：
 
@@ -33,19 +38,22 @@ Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 
 
 `agent_frames` 表是 **ephemeral telemetry**（store migration 註解明確說 legacy 偵測時可 lossless clear `internal/store/frames.go:65`）。它不是 durable domain state，row-level 跨表強一致性標準過高。
 
-**partial state 在這張表是合法的中間狀態**，只要：
-1. **User-visible（projection / SPA）永遠看不到 partial** — projection 層 dedup
-2. **Eventual consistency 在 bounded time** — sweep 2s 一輪即收斂
-3. **Observable** — metric 計數器顯示 partial 發生率，超 SLO 才升級到強一致設計
+**partial state 在這張表是合法的中間狀態**，依三 evidence point（不依賴 SLO 量測，因 v5 I2 揭穿本 PR 內 SLO 不可量測）：
+
+1. **Ephemeral telemetry 性質** — `agent_frames` 表 store migration 註解明確說 legacy 偵測時可 lossless clear（`internal/store/frames.go:65`），表本身不是 durable invariant
+2. **User-visible（projection / SPA）永遠看不到 partial** — projection 層 dedup（§2.4）
+3. **Eventual consistency 在 bounded time** — sweep 2s 一輪即收斂（`sweep.go:20` `sweepInterval = 2 * time.Second`，user-visible 觀察延遲 ≤ 2s）
+
+Metrics 是 in-process 觀察基礎，**不是 ship gate**，也不是「partial state 接受性」的依據（前述三 evidence point 才是）。SLO-based 升級到強一致（Side A SQL transaction）是 follow-up phase 的決策，需先補上 metrics endpoint + denominator 才有量測前提。
 
 依此設計分四層：
 
 | 層 | 職責 | 實作 |
 |---|---|---|
-| **Hot path** | best-effort canonicalization；失敗不 retry/rollback；繼續 | `reconcileCreatedFrameAsProxy` + `canonicalizeDescendantsAfterUpsert` + SessionEnd `removeProxyRefForSender` |
+| **Hot path** | best-effort canonicalization；失敗不 retry/rollback；繼續 | `reconcileCreatedFrameAsProxy` + `canonicalizeDescendantsAfterUpsert` + SessionEnd `removeProxyRefForSender` + **existing-frame SessionStart preserve live proxies**（v5 I1 fix）|
 | **Projection** | 隱藏 partial（**唯一 strongly consistent 邊界**）| `buildPaneProjection` dedup：parent.Subagents 含 IsProxy + (SourcePID, SourceStartTime) → 排除 matching standalone frame |
 | **Sweep** | bounded-time recovery（2s 一輪）| `canonicalizePane` 補 hot-path 漏網 + `pruneDeadProxyRefs` 清死 proxy ref |
-| **Observability** | partial 發生率可量化 | expvar counters |
+| **Observability**（in-process）| partial 發生率累計（daemon run 內）| expvar counters；**endpoint exposure 為 follow-up，本 PR 不掛 ship gate**（v5 I2 fix）|
 
 ### 0.3 與 Phase 3 的關係
 
@@ -270,21 +278,58 @@ func pidIsAncestorOfWithCap(descendantPID, ancestorPID, maxDepth int) bool {
 
 #### 2.2.2 Existing frame 路徑（line 256-272 之後）
 
+**v5 I1 fix**：reset 前 snapshot 仍 live identity-verified IsProxy refs，reset 後 re-attach。reset 的原意是「old session's native subagent refs no longer apply」，但 cross-type IsProxy refs 指向同 pane 內仍 live 的 OS process — 不該在 parent's session-restart 時失蹤（descendant 沒 standalone 可補回）。
+
 ```go
+// v5 I1: snapshot live IsProxy refs BEFORE reset. The store-level reset
+// clears subagents_json wholesale; live cross-type proxies pointing to OS
+// processes that still exist must survive the parent's SessionStart
+// restart. Without this, an already-canonicalized proxy ref from a prior
+// race window vanishes from projection — descendant scan can't recover
+// it because the standalone child frame was deleted at canonicalize time.
+var preservedProxies []agentpkg.SubagentRef
+if req.EventName == "SessionStart" && frame != nil {
+    for _, ref := range frame.Subagents {
+        if !ref.IsProxy {
+            continue
+        }
+        if !isPidAliveFn(ref.SourcePID) {
+            continue
+        }
+        actualStart, sterr := processStartTimeFn(ref.SourcePID)
+        if sterr != nil || actualStart != ref.SourceStartTime {
+            continue
+        }
+        preservedProxies = append(preservedProxies, ref)
+    }
+}
+
 if req.EventName == "SessionStart" {
     updateErr = m.frames.UpdateHookPathAndResetSubagents(updated)
 } else {
     updateErr = m.frames.UpdateHookPath(updated)
 }
 if updateErr != nil { return nil, FrameTraceMeta{}, updateErr }
+
 reloaded, err := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
 if err != nil { return nil, FrameTraceMeta{}, err }
 if reloaded == nil { return nil, FrameTraceMeta{}, nil }
 stored = *reloaded
 
-// Phase 3.5: existing-frame SessionStart runs descendant-scan only (no
-// self-reconcile — existing frame is stable identity, collapsing into
-// ancestor would orphan user's session).
+// v5 I1: re-attach preserved proxies via existing helper (atomic retry,
+// merge-aware via updateSubagents). StartedAt refreshed to broadcastTs to
+// reflect that they survived this SessionStart cycle.
+for _, ref := range preservedProxies {
+    ref.StartedAt = broadcastTs
+    attached, parentStored, aerr := m.attachProxyRefWithRetry(stored, ref, broadcastTs)
+    if aerr != nil { return nil, FrameTraceMeta{}, aerr }
+    if attached {
+        stored = parentStored
+    }
+}
+
+// Phase 3.5: descendant scan (catches any cold-start race window children
+// whose SessionStart raced with this existing-frame's SessionStart).
 if req.EventName == "SessionStart" {
     updated, cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs)
     if cerr != nil {
@@ -293,6 +338,11 @@ if req.EventName == "SessionStart" {
     stored = updated
 }
 ```
+
+**為什麼 re-attach 而不是「reset 不清 IsProxy」**：
+
+- store-level `UpdateHookPathAndResetSubagents` 是 narrow update 設計（PR-2b R8）— 改它的語意（conditional reset）會把 store 層拉進 IsProxy semantics，違反 narrow update 哲學
+- 在 module 接線層做 snapshot + re-attach 保留 store-level cleanliness；attachProxyRefWithRetry 的 RMW retry 邏輯也直接重用
 
 ### 2.3 SessionEnd proxy cleanup（v4 新，修 Side B 抓的 SessionEnd 漏洞）
 
@@ -434,9 +484,9 @@ func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection 
 
 descendant scan 收編 standalone children 不改 trace（與 v3 一致）— scan 是 self 視角的 side effect，主決策仍是「建/更新此 frame」。
 
-### 2.6 Metrics（v4 新）
+### 2.6 Metrics（v5 誠實版 — 移除 SLO 聲明）
 
-用 Go stdlib `expvar`（無新依賴；既有 daemon 若無 expvar 啟動則 graceful degrade，僅內部變數）：
+用 Go stdlib `expvar` 累積 in-process counter（無新依賴；不掛 metrics endpoint，不在本 PR 範圍）：
 
 ```go
 package agent
@@ -451,12 +501,20 @@ var (
 )
 ```
 
-**SLO 觀察點**：
-- partial_canonicalization_created：partial state 發生率；超過 1/1000 SessionStart 升級到強一致設計
-- projection_dedup_hidden：dedup 實際生效次數；應趨近 partial_canonicalization 數
-- sweep_canonicalized / sweep_pruned_proxy：sweep 兜底頻次；持續高表示 hot-path 失敗率高
+**用途（in-process only）**：
 
-不依賴 expvar handler 暴露；本 PR 不掛 metrics endpoint，留 follow-up issue（觀察先在 daemon 內測量）。
+- daemon 開發 / debug 期間可用 `runtime.ReadMemStats` 等 in-process 機制 inspect counter，或在單元/整合測試直接 `metric.Value()` 斷言
+- 提供 future endpoint exposure 的 instrumentation 基礎（counter 已埋好，只需接 `expvar.Handler()` 或 Prometheus exporter）
+
+**v5 I2 揭穿的限制**（誠實寫明）：
+
+- ❌ **無 metrics endpoint**：本 PR 不掛 `/debug/vars` 或 Prometheus exporter；外部監控無法讀取
+- ❌ **無 SessionStart denominator**：counter 是絕對值，不是 ratio；無法直接算 partial rate
+- ❌ **daemon restart 歸零**：expvar 是 in-process variable，不持久化；長期 SLO 觀察需另外加 persisted counter（不在本 PR）
+
+**因此 v5 不主張**「partial 發生率超 1/1000 觸發升級到 SQL transaction」這類 SLO 聲明。partial state 接受性的論證走 §0.2 三 evidence point（ephemeral 性質 + projection dedup + sweep 2s），與 metrics 量測無關。
+
+**Follow-up issue（建議）**：補上 metrics endpoint + SessionStart denominator + 持久化 counter，是觀察 partial 真實發生率所必須。本 PR 留 instrumentation 鉤子但不承諾 SLO 量測機制。
 
 ### 2.7 Wire compatibility
 
@@ -488,6 +546,9 @@ var (
 | IT14 | `sweep_prune_dead_proxy_ref_when_pid_reused` (v4 新) | cc.Subagents 含 codex proxy（SourcePID alive 但 actualStart != ref.SourceStartTime — PID reuse）；sweep | cc.Subagents 不含 codex proxy（identity mismatch 視為 dead）|
 | IT15 | `partial_metric_increments_on_partial_state` (v4 新) | mock DeleteIfUnchanged 持續失敗；reconcile 走 partial path | metricPartialCanonicalizationCreated 對應 +1；trace decision 仍 `created_frame`（無 partial reason）|
 | IT16 | `projection_dedup_metric_increments` (v4 新) | DB 多個 partial state；多 paneID call buildPaneProjection | metricProjectionDedupHidden 累加 |
+| IT17 | `existing_frame_session_start_preserves_live_proxy_refs` (v5 I1) | (a) cc frame 已存在且 cc.Subagents 含 codex proxy ref（live + identity verified）；(b) cc 又收 SessionStart（existing path）→ pre-reset snapshot + reset + re-attach；(c) 之後 codex 進程仍 alive，無新 SessionStart | cc.Subagents 仍含 codex proxy ref（StartedAt 刷新到本次 broadcastTs）；projection dedup 也仍工作 |
+| IT18 | `existing_frame_session_start_skips_dead_proxy_during_reset` (v5 I1 negative) | (a) cc frame 已存在含 codex proxy ref，但 codex 進程已死（isPidAliveFn = false）；(b) cc SessionStart | reset 後 cc.Subagents 不含該 dead proxy ref（preserve 不通過 identity gate）|
+| IT19 | `existing_frame_session_start_skips_pid_reused_proxy` (v5 I1 negative) | (a) cc frame 含 codex proxy；(b) codex PID 已被 OS reuse（actualStart != ref.SourceStartTime）；(c) cc SessionStart | reset 後不 preserve 該 stale proxy（identity 不過 gate）|
 
 ### 3.2 Unit 測試
 
@@ -694,16 +755,17 @@ func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 | 1 | `docs: Phase 3.5 plan v1 — cold-start proxy canonicalization` ✅ `bb382870` |
 | 2 | `docs: Phase 3.5 plan v2 — bidirectional + retry/rollback` ✅ `dd29be46` |
 | 3 | `docs: Phase 3.5 plan v3 — sweep canonicalize + identity gate` ✅ `148a2309` |
-| 4 | `docs: Phase 3.5 plan v4 — Hybrid B+ (consulting-driven redesign)` 此檔 |
-| 5 | `feat(agent): metrics counters for phase 3.5 canonicalization observability` | metric 4 個 + import 註冊 |
-| 6 | `feat(agent): pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert with identity gate (unwired)` | helper + RC1-RC5 unit |
-| 7 | `feat(agent): reconcileCreatedFrameAsProxy best-effort (unwired)` | reconcile helper（無 rollback）|
-| 8 | `feat(agent): wire bidirectional canonicalization into applyFrameEvent` | §2.2.1 + §2.2.2 |
-| 9 | `feat(agent): SessionEnd hot-path proxy cleanup` | §2.3 + IT12 |
-| 10 | `feat(agent): buildPaneProjection dedup proxy-claimed standalone frames` | §2.4 + PD1-PD3 + IT5 |
-| 11 | `feat(agent): sweep canonicalizePane with candidate identity gate` | §4.2 + IT10 |
-| 12 | `feat(agent): sweep pruneDeadProxyRefs` | §4.3 + IT13 / IT14 |
-| 13 | `test(agent): integration tests for cold-start race canonicalization end-to-end` | IT1-IT11 + IT15 / IT16 用真 sqlite |
+| 4 | `docs: Phase 3.5 plan v4 — Hybrid B+ (consulting-driven redesign)` ✅ `a338f6d3` |
+| 5 | `docs: Phase 3.5 plan v5 — preserve live proxies + honest metrics` 此檔 |
+| 6 | `feat(agent): metrics counters for phase 3.5 canonicalization observability` | metric 4 個 + import 註冊（無 endpoint） |
+| 7 | `feat(agent): pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert with identity gate (unwired)` | helper + RC1-RC5 unit |
+| 8 | `feat(agent): reconcileCreatedFrameAsProxy best-effort (unwired)` | reconcile helper（無 rollback）|
+| 9 | `feat(agent): wire bidirectional canonicalization + preserve live proxies into applyFrameEvent` | §2.2.1 + §2.2.2（含 v5 I1 preserve）+ IT17/IT18/IT19 |
+| 10 | `feat(agent): SessionEnd hot-path proxy cleanup` | §2.3 + IT12 |
+| 11 | `feat(agent): buildPaneProjection dedup proxy-claimed standalone frames` | §2.4 + PD1-PD3 + IT5 |
+| 12 | `feat(agent): sweep canonicalizePane with candidate identity gate` | §4.2 + IT10 |
+| 13 | `feat(agent): sweep pruneDeadProxyRefs` | §4.3 + IT13 / IT14 |
+| 14 | `test(agent): integration tests for cold-start race canonicalization end-to-end` | IT1-IT11 + IT15 / IT16 用真 sqlite |
 
 ---
 
@@ -716,17 +778,17 @@ func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 | `frame_ops.go` canonicalizeDescendantsAfterUpsert（含 identity gate） | ~85 行 |
 | `frame_ops.go` pidIsAncestorOfWithCap | ~20 行 |
 | `frame_ops.go` SessionEnd proxy cleanup | ~10 行（既有 case 改 4 行）|
-| `frame_ops.go` 接線 §2.2.1 + §2.2.2 | ~40 行 |
+| `frame_ops.go` 接線 §2.2.1 + §2.2.2（含 v5 preserve live proxies）| ~75 行 |
 | `projection.go` dedup | ~40 行 |
 | `sweep.go` canonicalizePane + findCanonicalAncestor + pruneDeadProxyRefs | ~140 行 |
 | `frame_ops_test.go` RC1-RC5 unit | ~150 行 |
 | `projection_test.go` PD1-PD3 | ~80 行 |
-| `module_test.go` / new file IT1-IT16 integration | ~700-800 行 |
+| `module_test.go` / new file IT1-IT19 integration | ~800-900 行 |
 | `sweep_test.go` 加 sweep canonicalize/prune 測試 | ~120 行 |
-| Plan docs（此檔 v4） | ~720 行 |
-| **總 net code（不含 plan docs）** | **~1460-1560 行** |
+| Plan docs（此檔 v5） | ~870 行 |
+| **總 net code（不含 plan docs）** | **~1595-1695 行** |
 
-v4 LOC 比 v3 估計（~1235-1335）略升 ~200，主要在 IT12-IT16 + sweep prune。但移除了 rollback 分支 + partial trace 邏輯，淨複雜度比 v3 低（更多直線、更少分支與失敗路徑）。
+v5 LOC 比 v4（~1460-1560）+135：preserve live proxies wiring（~35 行）+ IT17/IT18/IT19（~100 行）。但複雜度仍比 v3 低（單一 best-effort 路徑 + projection dedup boundary，不是 retry/rollback/propagate maze）。
 
 ---
 
@@ -805,4 +867,5 @@ PR 跑過 codex round 4 review 收斂後：
 | Plan v3 round 3（adversarial）| inline | needs-attention | H1 rollback helper 同類 partial / H2 sweep 缺 identity / H3 partial trace 不會寫入 | **三輪 partial state meta-drift signal 觸發** → consulting |
 | Side A consulting | task-moeupstr-z0oilf | (technical spec) | 提議 SQL transaction 根除 partial 物理層 | 不採納（標準對 ephemeral 表過高），但細節（BEGIN IMMEDIATE / busy code / FK）保留參考 |
 | Side B consulting | task-moeuqbnn-jart97 | (adversarial argument) | 證據壓倒：sweep 2s 不是 1h / agent_frames 是 ephemeral / projection 是 user-visible 邊界 / SessionEnd 漏 cleanup proxy | **採納為 v4 核心**（Hybrid B+）|
-| Plan v4 round 4 | (待執行) | (pending) | — | — |
+| Plan v4 round 4（adversarial）| inline | needs-attention | I1 high existing-frame reset 清掉 live proxy / I2 medium SLO 不可量測 | v5 全採納（§2.2.2 preserve live proxies + IT17/IT18/IT19；§2.6 移除 SLO 聲明，改三 evidence point；§0.2 設計論證重整）|
+| Plan v5 round 5 | (待執行) | (pending) | — | — |

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,11 +1,19 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v8 / Hybrid B+)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v9 / Hybrid B+)
 
 Baseline：`1.0.0-alpha.225`（main @ `92fb5d05`，Phase 3 已 merged）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`，已 rebase 上 `92fb5d05`）。
 Phase 3 PR #638：✅ squash-merged at `92fb5d05`（2026-04-26）。
 Bump 策略：本 PR 系列 + Phase 3 一起 bump **alpha.226**（注意：alpha.225 已被 parallel session 為 SPA tooltip 功能 PR #643 占用，與 Phase 3 無關）。
 
-**v7 → v8 由 PR-3.5a 兩輪 codex review 收斂**（§13；5 finding 採納 / 1 deferred 開 follow-up）：
+**v8 → v9 由 PR-3.5a 第二輪 codex review（standard + adversarial 三視角）收斂**（§13；5 unique finding 全採納）：
+
+- **O1 high / round 2 attack** — filter-merge `prevWrittenNativeIDs` 在多 retry 下 regress：attempt 1 preserved 的 native ref 被寫進 prev → attempt 2 把它當 baseline drop。**v9 修法**（C13）：改用 **`initialNativeIDs` baseline**（loop 前 snapshot frame.Subagents 中的 native ID set），整個 retry 期間 immutable；任何 reload 後出現但不在 baseline 的 native 視為 concurrent attach，**永遠保留**。`prevWrittenNativeIDs` 機制移除。新增 IT21b 守規（2 conflict + 2 concurrent native）。
+- **Q1 high / round 2 health** — projection dedup 隱藏 stateful child：reconcile partial（attach OK + delete fail）+ 並發 SubagentStart 給 child 加 native → child 留下且有 native subagent → dedup hide → SPA 看不到 child native。**v9 修法**（C14）：dedup hide 加 `len(frame.Subagents) == 0` guard；非空保留 visible（child 的 native subagent 不能消失於 SPA）。新增 PD4（stateful 保留）/ PD5（empty 仍 hide）。
+- **O2 medium / round 2 defend** — `canonicalizeDescendantsAfterUpsert` candidate guard `len(Subagents) > 0` 太寬：stale-only dead IsProxy ref 也算 state 阻 fold；hot-path 漏網無 sweep canonicalize 兜底。**v9 修法**（C15）：分類掃 candidate.Subagents — 含 native ref 或 live identity-verified IsProxy → skip（保護 state）；只含 stale dead/PID-reuse IsProxy → 視同 race-window standalone，**允許 fold**；read error 防禦性 skip。新增 IT22b（fold stale-only）/ IT22c（skip live IsProxy 負例）。
+- **O3 medium / round 2 attack** — `pruneDeadProxyRefs` `processStartTimeFn` 回 error 時 detach（fail-destructive）— 暫時 /proc 讀失敗會誤砍 live proxy。**v9 修法**（C16）：fail-safe；只在 `isPidAlive == false` 或 `actualStart != ref.SourceStartTime` confirmed mismatch 才 detach；read error → continue（保留 ref，下次 sweep 再嘗試）。新增 IT14b 守規。
+- **P1 medium / round 2 health** — `pruneDeadProxyRefs` detach 成功後不 broadcast projection — `m.subagents` / `currentStatus` 不同步，SPA 看不到修正直到下個無關 hook。**v9 修法**（C17）：新增 `broadcastProxyPruned` helper（mirror `afterFrameCleared` 路徑），偵測到至少一個 detach 後在 pane 維度發出一次 `sweep:proxy_pruned` 廣播；多個 stale ref 在同 pane 自動 coalesce。新增 IT13c 守規。
+
+**v7 → v8 由 PR-3.5a 第一輪 codex review 收斂**（§13；5 finding 採納 / 1 deferred 開 follow-up）：
 
 - **M4 medium / round PR-2 attack** — `reconcileCreatedFrameAsProxy` partial 路徑回 `canonicalized=false` 走 `created_frame` trace（child 視角），但 projection_dedup 顯示 parent + proxy ref → trace ≠ projection。**v8 修法**：partial 仍回 `canonicalized=true`，caller 走 `updated_frame / post_upsert_canonicalization_self` 與 projection 一致；metric 仍 +1。
 - **M3 high / round PR-2 attack** — filter-merge-retry「只保留 IsProxy」filter 在 conflict reload 時把並發 SubagentStart attach 的 native ref 一併 drop。**v8 修法**：改 prune-stale-IsProxy 語意；attempt 0 仍 reset baseline native（SessionStart 主語意），attempt N>0 透過 `prevWrittenNativeIDs` 區分 baseline vs concurrent attach，concurrent 保留 baseline 清掉。
@@ -873,10 +881,10 @@ v6 LOC 比 v5（~1595-1695）+25：filter-merge-retry +10 行（取代三步法�
 
 ## 8. 驗收 / Ship 條件
 
-- 所有 **IT1-IT20** + RC1-RC5 + PD1-PD3 + 既有測試全綠（IT17-IT20 為 v5/v6 race-fix regression guards，不可跳過 — codex round 6 K1）
+- 所有 **IT1-IT22 + IT21b + IT22b + IT22c + IT13/IT13b/IT13c + IT14/IT14b** + RC1-RC5 + PD1-PD5 + 既有測試全綠（IT17-IT22, IT21b/IT22b/IT22c/IT13c/IT14b/PD4/PD5 為 race-fix regression guards 不可跳過 — codex round 6 K1 + round 2 v9 fix）
 - `go build/vet/test ./...` 23 packages 全綠
 - SPA 無變更
-- 委派 codex round 4 review 收斂；採納或合理 deferred all findings
+- 委派 codex round 2（v8）+ round 2 second wave（v9）review 收斂；採納或合理 deferred all findings
 - Phase 3 PR #638 merged 後 rebase Phase 3.5 到 main
 
 ---
@@ -952,6 +960,8 @@ PR-3.5a 跑過兩輪 codex review 收斂後：
 | Plan v6 round 6（adversarial）| review-mof9wjzs-7q8wrs | needs-attention | K1 high §8 ship gate 漏列 IT17-IT20（含 J1 regression test）+ IT17 描述沿用 v5 已移除路徑 | v7 採納（純文檔修；§8 改 IT1-IT20 全綠 + IT17 描述更新）。**設計層面六輪後完整收斂 — round 6 無架構/race/邏輯 finding**；依 feedback_codex_review_termination.md 進實作 |
 | PR-3.5a code review round 1（standard）| mofcixya-889fj5 | (review) | 標準 cross-model 二意見 | findings 併入 round 2 彙整 |
 | PR-3.5a code review round 2（adversarial 三視角）| attack mofcj6pe-pxh09c / defend mofcjln6-f0hq8x / health mofcjerd-sm4p6m | needs-attention | M4 medium reconcile partial trace 反 projection / M3 high filter-merge 丟 native concurrent / M2 high descendant scan fold 有狀態 candidate / L1 high SessionEnd delete-first 留 orphan / N1 high dedup 信任 IsProxy（過嚴 deferred）| v8 採納 4/5（M4/M3/M2/L1 fix + sweep prune 從 PR-3.5b 移進 PR-3.5a）；N1 deferred 開 follow-up issue |
+| PR-3.5a 第二輪 code review round 1（standard）| (round 2 standard) | (review) | 標準 cross-model 二意見（v8 patch 後）| findings 併入 round 2 adversarial 彙整 |
+| PR-3.5a 第二輪 code review round 2（adversarial 三視角）| attack / defend / health（round 2）| needs-attention | O1 high filter-merge prevWrittenNativeIDs 多 retry 下 regress 丟 native / Q1 high projection dedup 隱藏 stateful child（partial+並發 SubagentStart）/ O2 medium descendant scan candidate guard 過寬把 stale-only IsProxy 算 state / O3 medium pruneDeadProxyRefs read-error 時 fail-destructive / P1 medium prune detach 後不 broadcast | **v9 全採納**：C13 initialNativeIDs baseline + IT21b / C14 dedup len==0 guard + PD4/PD5 / C15 candidate state classification + IT22b/IT22c / C16 prune fail-safe + IT14b / C17 broadcastProxyPruned + IT13c |
 
 ---
 
@@ -963,25 +973,25 @@ v7 規模相對 kickoff 原始設計擴張 ~7-10 倍（150-250 LOC → 1620-1720
 
 **目標**：消除 user-visible incorrectness。SPA 永遠看到正確的 frame collapse（並發冷啟動下也是）；codex SessionEnd 不留 orphan lit dot；sweep eventual-consistency 兜底 SessionEnd 漏網場景。**獨立可 ship，無需依賴 PR-3.5b**。
 
-**範圍**（commits 6/7/8/9/10/11/12 + v8 fix commits）：
+**範圍**（commits 6/7/8/9/10/11/12 + v8 fix commits + v9 fix commits C13-C17）：
 
 - `internal/agent/metrics.go`（新檔）— 4 個 expvar counter
 - `internal/module/agent/frame_ops.go`：
   - `pidIsAncestorOfWithCap` helper
-  - `canonicalizeDescendantsAfterUpsert`（含 identity gate **+ v8 M2 candidate-with-subagents skip**）
+  - `canonicalizeDescendantsAfterUpsert`（含 identity gate **+ v9 O2 candidate state classification（native / live IsProxy / stale IsProxy 分類）**；舊 v8 M2 `len > 0` guard 已被 v9 取代）
   - `reconcileCreatedFrameAsProxy`（best-effort，無 rollback；**v8 M4 partial 回 canonicalized=true**）
   - applyFrameEvent §2.2.1 接線（new-frame post-Upsert）
-  - applyFrameEvent §2.2.2 接線（existing-frame **filter-merge-retry + v8 M3 prune-stale-IsProxy + prevWrittenNativeIDs**）
+  - applyFrameEvent §2.2.2 接線（existing-frame **filter-merge-retry + v9 O1 initialNativeIDs baseline**；舊 v8 M3 `prevWrittenNativeIDs` 機制已被 v9 取代）
   - applyFrameEvent SessionEnd **detach-first + propagate**（§2.3 + v8 L1）
-- `internal/module/agent/projection.go`：`buildPaneProjection` dedup（§2.4）
-- `internal/module/agent/sweep.go`：`pruneDeadProxyRefs` + sweepOnce 第三 pass（§4.3，**v8 L1 從 PR-3.5b 移進 PR-3.5a**）
+- `internal/module/agent/projection.go`：`buildPaneProjection` dedup（§2.4）**+ v9 Q1 stateful-child guard（`len(frame.Subagents) == 0` 才 hide）**
+- `internal/module/agent/sweep.go`：`pruneDeadProxyRefs` + sweepOnce 第三 pass（§4.3，**v8 L1 從 PR-3.5b 移進 PR-3.5a**）**+ v9 O3 fail-safe（read-error 時 keep）+ v9 P1 broadcastProxyPruned（detach 後 emit `sweep:proxy_pruned` 廣播）**
 
 **測試**（必跑 ship gate）：
 
-- Unit：RC1-RC5 + PD1-PD3
-- Integration：IT1-IT9, IT11, IT12, IT13, IT13b, IT14, IT15-IT22（**IT4 + IT5 + IT12 + IT13/IT14 + IT17-IT22 是 race-fix regression guards 不可跳**）
+- Unit：RC1-RC5 + PD1-PD5（v9 加 PD4/PD5）
+- Integration：IT1-IT9, IT11, IT12, IT13, IT13b, **IT13c**, IT14, **IT14b**, IT15-IT22, **IT21b**, **IT22b**, **IT22c**（**IT4 + IT5 + IT12 + IT13/IT14 + IT17-IT22 + v9 新增 IT21b/IT22b/IT22c/IT13c/IT14b 是 race-fix regression guards 不可跳**）
 
-**LOC 預估**：~1100-1200 行 net（含 ~21 個 IT；v8 比 v7 PR-3.5a 多 ~250 LOC：sweep prune + IT13/IT13b/IT14/IT21/IT22）
+**LOC 預估**：~1300-1400 行 net（v9 比 v8 多 ~200 LOC：5 finding 修法 + IT13c/IT14b/IT21b/IT22b/IT22c/PD4/PD5）
 
 **為什麼 SessionEnd cleanup + projection dedup 必須在 PR-3.5a 而不能延到 3.5b**：
 

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,9 +1,13 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v11 / Hybrid B+)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v12 / Hybrid B+)
 
 Baseline：`1.0.0-alpha.225`（main @ `92fb5d05`，Phase 3 已 merged）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`，已 rebase 上 `92fb5d05`）。
 Phase 3 PR #638：✅ squash-merged at `92fb5d05`（2026-04-26）。
 Bump 策略：本 PR 系列 + Phase 3 一起 bump **alpha.226**（注意：alpha.225 已被 parallel session 為 SPA tooltip 功能 PR #643 占用，與 Phase 3 無關）。
+
+**v11 → v12 由 PR-3.5a 第五輪 codex review 收斂**（§13；1 high finding 採納）：
+
+- **T1 high / round 5** — v11 SessionStart filter-merge `initialNativeIDs` baseline 用 ID-only 識別。Native IDs 是 provider-supplied strings；SessionStart reset 並發 SubagentStart 若新 native ref reused 舊 session 同 ID，新 ref 會被 baseline match 誤當「舊 session 殘留」silently drop → 使用者新 spawn 的 subagent 靜默消失。**v12 修法**（C23）：baseline 改為 `(Type, ID, StartedAt)` 三元組；新 SubagentStart 的 StartedAt 是 fresh broadcastTs，與 baseline ref 不同 → 不會被誤當 baseline drop。新增 IT21c 守規（baseline native call-1 + 並發 SubagentStart 同 ID 不同 StartedAt）。**Round 5 是 PR-3.5a 最後一輪 review**（trend：round 4 → 5 各 1 high finding，per `feedback_codex_review_termination.md` 進 ship；不再 review）。
 
 **v9 → v10 由 PR-3.5a 第三輪 codex review 收斂**（§13；2 unique finding 全採納）：
 
@@ -894,10 +898,10 @@ v10 LOC 比 v9（~1790-1890）+30：projection.go +20 行（hide + merge collect
 
 ## 8. 驗收 / Ship 條件
 
-- 所有 **IT1-IT22 + IT21b + IT22b + IT22c + IT13/IT13b/IT13c/IT13d + IT14/IT14b/IT14c** + RC1-RC5 + PD1-PD8 + 既有測試全綠（IT17-IT22, IT21b/IT22b/IT22c/IT13c/IT13d/IT14b/IT14c/PD4-PD8 為 race-fix regression guards 不可跳過 — codex round 6 K1 + round 2 v9 fix + round 3 v10 fix）
+- 所有 **IT1-IT22 + IT21b + IT21c + IT22b + IT22c + IT13/IT13b/IT13c/IT13d + IT14/IT14b/IT14c** + RC1-RC5 + PD1-PD9 + 既有測試全綠（IT17-IT22, IT21b/IT21c/IT22b/IT22c/IT13c/IT13d/IT14b/IT14c/PD4-PD9 為 race-fix regression guards 不可跳過 — codex round 6 K1 + round 2 v9 fix + round 3 v10 fix + round 4 v11 fix + round 5 v12 fix）
 - `go build/vet/test ./...` 23 packages 全綠
 - SPA 無變更
-- 委派 codex round 2（v8）+ round 2 second wave（v9）+ round 3（v10）review 收斂；採納或合理 deferred all findings
+- 委派 codex round 2（v8）+ round 2 second wave（v9）+ round 3（v10）+ round 4（v11）+ round 5（v12）review 收斂；採納或合理 deferred all findings；round 5 為最後一輪（trend：round 4 / round 5 各 1 high finding；per `feedback_codex_review_termination.md` 進 ship）
 - Phase 3 PR #638 merged 後 rebase Phase 3.5 到 main
 
 ---
@@ -977,7 +981,9 @@ PR-3.5a 跑過兩輪 codex review 收斂後：
 | PR-3.5a 第二輪 code review round 2（adversarial 三視角）| attack / defend / health（round 2）| needs-attention | O1 high filter-merge prevWrittenNativeIDs 多 retry 下 regress 丟 native / Q1 high projection dedup 隱藏 stateful child（partial+並發 SubagentStart）/ O2 medium descendant scan candidate guard 過寬把 stale-only IsProxy 算 state / O3 medium pruneDeadProxyRefs read-error 時 fail-destructive / P1 medium prune detach 後不 broadcast | **v9 全採納**：C13 initialNativeIDs baseline + IT21b / C14 dedup len==0 guard + PD4/PD5 / C15 candidate state classification + IT22b/IT22c / C16 prune fail-safe + IT14b / C17 broadcastProxyPruned + IT13c |
 | PR-3.5a 第三輪 code review round 3 | (round 3) | needs-attention | R1 high projection dedup Q1 fix 仍丟資訊（child 留 visible 後 TopFrame 選一→另一邊 Subagents 丟）／ R2 medium sweepOnce owner-identity read error 時 bare continue 把 frame 丟出 survivors → pane 不進 prune → O3 fail-safe 被繞過 | **v10 全採納**：C18 dedup hide-and-merge + PD4 改寫 + PD6/PD7/PD8 / C19 owner-read-error 加入 survivors + IT13d/IT14c |
 | PR-3.5a code review round 4（adversarial sanity）| review-mofh79kq-djlhr3 | needs-attention | S1 high R1 merge dedup 用 `subagentRefMatches`（native by ID-only），跨 frame 不同 agent family 的 native ID collision 被誤判 duplicate → 隱藏 child 的 native ref 從 wire 輸出消失 | **v11 採納**：merge 改 owner-aware inline dedup（proxy by `SourcePID+SourceStartTime`、native by `Type+ID`）；新增 PD9 守規。`subagentRefMatches` 語義不變（within-frame caller in `frame_ops.go` 不受影響）|
-| PR-3.5a code review round 5（待執行）| — | — | v11 patch（C21 fix + C22 docs）後再跑一輪 sanity；預期收斂無 high finding 進 ship | — |
+| PR-3.5a code review round 5（adversarial sanity）| review-mofi1dy2-ppe860 | needs-attention | T1 high SessionStart filter-merge `initialNativeIDs` baseline 用 ID-only 識別，並發 SubagentStart 同 ID 不同 StartedAt 被誤當 baseline drop → 使用者新 spawn subagent 靜默消失 | **v12 採納**：baseline 改 `(Type, ID, StartedAt)` 三元組；新增 IT21c 守規。**Round 5 為 PR-3.5a 最後一輪 review**（trend：round 4 → 5 各 1 high finding；per `feedback_codex_review_termination.md` convergence pattern 進 ship；不再 review）|
+
+**PR-3.5a review 累計**：5 輪 standard + adversarial review；landed findings：v8 (4)+ v9 (5) + v10 (2) + v11 (1) + v12 (1) = 13 採納 / deferred follow-up：N1（hot-path liveness syscall 成本）+ IT12b 衍生 store interface abstraction 需求。Ship-ready @ v12。
 
 ---
 

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,8 +1,12 @@
-# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v6 / Hybrid B+)
+# Phase 3.5 Plan — Cold-start Proxy Canonicalization (v7 / Hybrid B+)
 
 Baseline：`1.0.0-alpha.224`（main @ `75b4d166`）。
 Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`）。
 Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 → rebase 3.5 → 一次 bump alpha.225）。
+
+**v6 → v7 由 codex round 6 收斂**（§13；1 high doc-gate finding 採納）：
+
+- **K1 high** — §8 ship gate 寫「IT1-IT16 全綠」但 v5/v6 加了 IT17-IT20 沒同步，實作者照原 gate 可跳過 IT20（J1 regression test）→ race 可悄悄回歸；同時 IT17 描述沿用 v5 已被 v6 移除的「snapshot + reset + re-attach」語意。**v7 修法**：§8 改 IT1-IT20 全綠 + 更新 IT17 描述為 filter-merge-retry 語意。**設計層面六輪後完整收斂**（round 6 無任何架構/race/邏輯 finding）。
 
 **v5 → v6 由 codex round 5 收斂**（§13；1 high finding 採納）：
 
@@ -609,7 +613,7 @@ var (
 | IT14 | `sweep_prune_dead_proxy_ref_when_pid_reused` (v4 新) | cc.Subagents 含 codex proxy（SourcePID alive 但 actualStart != ref.SourceStartTime — PID reuse）；sweep | cc.Subagents 不含 codex proxy（identity mismatch 視為 dead）|
 | IT15 | `partial_metric_increments_on_partial_state` (v4 新) | mock DeleteIfUnchanged 持續失敗；reconcile 走 partial path | metricPartialCanonicalizationCreated 對應 +1；trace decision 仍 `created_frame`（無 partial reason）|
 | IT16 | `projection_dedup_metric_increments` (v4 新) | DB 多個 partial state；多 paneID call buildPaneProjection | metricProjectionDedupHidden 累加 |
-| IT17 | `existing_frame_session_start_preserves_live_proxy_refs` (v5 I1) | (a) cc frame 已存在且 cc.Subagents 含 codex proxy ref（live + identity verified）；(b) cc 又收 SessionStart（existing path）→ pre-reset snapshot + reset + re-attach；(c) 之後 codex 進程仍 alive，無新 SessionStart | cc.Subagents 仍含 codex proxy ref（StartedAt 刷新到本次 broadcastTs）；projection dedup 也仍工作 |
+| IT17 | `existing_frame_session_start_preserves_live_proxy_refs` (v5 I1 / v6 filter-merge) | (a) cc frame 已存在且 cc.Subagents 含 codex proxy ref（live + identity verified）；(b) cc 又收 SessionStart（existing path）→ filter-merge-retry pattern：filter 通過 identity gate 的 IsProxy 直接寫進 UpsertIfUnchanged；(c) 之後 codex 進程仍 alive，無新 SessionStart | cc.Subagents 仍含 codex proxy ref（subagents_json 含此 ref，新 LastSeenAt = broadcastTs）；projection dedup 仍工作 |
 | IT18 | `existing_frame_session_start_skips_dead_proxy_during_reset` (v5 I1 negative) | (a) cc frame 已存在含 codex proxy ref，但 codex 進程已死（isPidAliveFn = false）；(b) cc SessionStart | reset 後 cc.Subagents 不含該 dead proxy ref（preserve 不通過 identity gate）|
 | IT19 | `existing_frame_session_start_skips_pid_reused_proxy` (v5 I1 negative) | (a) cc frame 含 codex proxy；(b) codex PID 已被 OS reuse（actualStart != ref.SourceStartTime）；(c) cc SessionStart | reset 後不 preserve 該 stale proxy（identity 不過 gate）|
 | IT20 | `existing_frame_session_start_preserves_concurrently_attached_proxy` (v6 J1) | (a) cc frame 已存在 + 一個 codex proxy ref；(b) cc SessionStart filter-merge attempt 1 — 同時 mock UpsertIfUnchanged 第 1 次回 conflict（模擬並發 child SessionStart 在 attempt 1 之間 attach 第二個 opencode proxy 並刪除其 standalone）；(c) attempt 2 reload 看到兩個 IsProxy ref，filter 通過 gate，UpsertIfUnchanged 成功 | cc.Subagents 含 codex 與 opencode 兩個 proxy ref；無 ref 在 race window 中遺失 |
@@ -821,7 +825,8 @@ func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 | 3 | `docs: Phase 3.5 plan v3 — sweep canonicalize + identity gate` ✅ `148a2309` |
 | 4 | `docs: Phase 3.5 plan v4 — Hybrid B+ (consulting-driven redesign)` ✅ `a338f6d3` |
 | 5 | `docs: Phase 3.5 plan v5 — preserve live proxies + honest metrics` ✅ `285599e4` |
-| 5b | `docs: Phase 3.5 plan v6 — filter-merge-retry (codex round 5 J1 fix)` 此檔 |
+| 5b | `docs: Phase 3.5 plan v6 — filter-merge-retry (codex round 5 J1 fix)` ✅ `d47d367d` |
+| 5c | `docs: Phase 3.5 plan v7 — ship gate IT1-IT20 + IT17 wording (codex round 6 K1 fix)` 此檔 |
 | 6 | `feat(agent): metrics counters for phase 3.5 canonicalization observability` | metric 4 個 + import 註冊（無 endpoint） |
 | 7 | `feat(agent): pidIsAncestorOfWithCap + canonicalizeDescendantsAfterUpsert with identity gate (unwired)` | helper + RC1-RC5 unit |
 | 8 | `feat(agent): reconcileCreatedFrameAsProxy best-effort (unwired)` | reconcile helper（無 rollback）|
@@ -859,7 +864,7 @@ v6 LOC 比 v5（~1595-1695）+25：filter-merge-retry +10 行（取代三步法�
 
 ## 8. 驗收 / Ship 條件
 
-- 所有 IT1-IT16 + RC1-RC5 + PD1-PD3 + 既有測試全綠
+- 所有 **IT1-IT20** + RC1-RC5 + PD1-PD3 + 既有測試全綠（IT17-IT20 為 v5/v6 race-fix regression guards，不可跳過 — codex round 6 K1）
 - `go build/vet/test ./...` 23 packages 全綠
 - SPA 無變更
 - 委派 codex round 4 review 收斂；採納或合理 deferred all findings
@@ -934,4 +939,4 @@ PR 跑過 codex round 4 review 收斂後：
 | Side B consulting | task-moeuqbnn-jart97 | (adversarial argument) | 證據壓倒：sweep 2s 不是 1h / agent_frames 是 ephemeral / projection 是 user-visible 邊界 / SessionEnd 漏 cleanup proxy | **採納為 v4 核心**（Hybrid B+）|
 | Plan v4 round 4（adversarial）| inline | needs-attention | I1 high existing-frame reset 清掉 live proxy / I2 medium SLO 不可量測 | v5 全採納（§2.2.2 preserve live proxies + IT17/IT18/IT19；§2.6 移除 SLO 聲明，改三 evidence point；§0.2 設計論證重整）|
 | Plan v5 round 5（adversarial）| inline | needs-attention | J1 high snapshot/reset/re-attach 三步非原子，並發 attach 在 race window 內被抹除 | v6 採納（§2.2.2 改為 filter-merge-retry pattern，取代三步法；新 IT20 守規）|
-| Plan v6 round 6 | (待執行) | (pending) | — | — |
+| Plan v6 round 6（adversarial）| review-mof9wjzs-7q8wrs | needs-attention | K1 high §8 ship gate 漏列 IT17-IT20（含 J1 regression test）+ IT17 描述沿用 v5 已移除路徑 | v7 採納（純文檔修；§8 改 IT1-IT20 全綠 + IT17 描述更新）。**設計層面六輪後完整收斂 — round 6 無架構/race/邏輯 finding**；依 feedback_codex_review_termination.md 進實作 |

--- a/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
+++ b/docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md
@@ -1,8 +1,9 @@
 # Phase 3.5 Plan — Cold-start Proxy Canonicalization (v7 / Hybrid B+)
 
-Baseline：`1.0.0-alpha.224`（main @ `75b4d166`）。
-Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`）。
-Branch base：`origin/main`（與 Phase 3 PR #638 並行；merge 順序 Phase 3 → rebase 3.5 → 一次 bump alpha.225）。
+Baseline：`1.0.0-alpha.225`（main @ `92fb5d05`，Phase 3 已 merged）。
+Worktree：`.claude/worktrees/lights-phase-3-5`（branch `worktree-lights-phase-3-5`，已 rebase 上 `92fb5d05`）。
+Phase 3 PR #638：✅ squash-merged at `92fb5d05`（2026-04-26）。
+Bump 策略：本 PR 系列 + Phase 3 一起 bump **alpha.226**（注意：alpha.225 已被 parallel session 為 SPA tooltip 功能 PR #643 占用，與 Phase 3 無關）。
 
 **v6 → v7 由 codex round 6 收斂**（§13；1 high doc-gate finding 採納）：
 
@@ -65,7 +66,7 @@ Metrics 是 in-process 觀察基礎，**不是 ship gate**，也不是「partial
 
 ### 0.3 與 Phase 3 的關係
 
-不變：獨立 PR；rebase 順序 Phase 3 → Phase 3.5；衝突點在 `applyFrameEvent` 不同區塊。
+Phase 3 PR #638 已 merged at `92fb5d05`（2026-04-26）。Phase 3.5 worktree 已 rebase 上新 main，docs commits replay 無衝突（docs-only 不動 code）。後續 3.5a 實作 commits 起於 alpha.225 era main，接線位置（applyFrameEvent fallback chain 由 Phase 3 加在 line ~228 後；Phase 3.5 接線在 new-frame Upsert 後 line ~286 + existing-frame Update 後 line ~272 + SessionEnd line ~53）— 區塊不同，無衝突。
 
 ---
 
@@ -879,7 +880,7 @@ v6 LOC 比 v5（~1595-1695）+25：filter-merge-retry +10 行（取代三步法�
 | R1 | Projection dedup 把不該 hide 的 frame hide 掉（false positive）| Identity 用 (PID, ProcessStartTime) 比對；只 hide standalone PID 等於 proxy 的 SourcePID — 同 process；理論上不可能 false positive |
 | R2 | `pruneDeadProxyRefs` 把 alive 但 startTime 讀錯的 proxy 誤砍 | identity gate fail-safe：read error → skip（不砍）；只在 actualStart != ref.SourceStartTime 確定 mismatch 才砍 |
 | R3 | Sweep canonicalize 走 ListByPane O(n) per pane per 2s | proxyMaxDepth=5 + pane frame 數一般 < 10；2s 一輪總成本 < 50ms；可接受 |
-| R4 | rebase Phase 3 後 applyFrameEvent 衝突 | Phase 3 改 fallback chain（line 220 區塊），Phase 3.5 改 new-frame Upsert 後 + existing-frame Update 後 + SessionEnd（line 286 + 272 + 53）；位置不同；極端衝突手動解 |
+| R4 | ~~rebase Phase 3 後 applyFrameEvent 衝突~~ | ✅ 已解決：Phase 3 merged at `92fb5d05`（2026-04-26），Phase 3.5 worktree rebase 完成 docs commits 無衝突。3.5a 實作開工後接線位置（line 286 / 272 / 53）與 Phase 3 fallback chain（line ~228）區塊不同 — 預期無衝突 |
 | R5 | metric 累加在熱 path 影響 latency | expvar.Int.Add 是 atomic，sub-microsecond；可忽略 |
 | R6 | partial state 在 metric SLO 突破時要升級為強一致 | metric 已埋；超過 1/1000 的話開 follow-up phase 升級到 Side A SQL transaction |
 | R7 | dedup 邏輯改 buildPaneProjection 影響既有 BuildSessionProjections / projectPane / projectionForSession 所有 caller | dedup 是純 frame filter；caller 看到的 SessionProjection 結構不變；既有測試（projection_test.go）守 regression |
@@ -916,15 +917,16 @@ v6 LOC 比 v5（~1595-1695）+25：filter-merge-retry +10 行（取代三步法�
 
 ## 12. 結束條件
 
-PR 跑過 codex round 4 review 收斂後：
+PR-3.5a 跑過兩輪 codex review 收斂後：
 
-1. Phase 3 PR #638 merge 到 main（不 bump）
-2. Rebase 本 PR 到 main（解 applyFrameEvent + SessionEnd 衝突）
-3. 本 PR merge 到 main（不 bump）
-4. 開 bump PR alpha.225 + CHANGELOG
-5. Bump merge → main @ alpha.225
-6. ExitWorktree 清掉 `lights-phase-3-5` worktree
-7. 更新 kickoff_lights_rebuild.md：標 Phase 3 + Phase 3.5 ✅ at alpha.225
+1. Phase 3 PR #638 merge 到 main ✅ 完成（`92fb5d05`）
+2. Rebase 本 PR 到 main ✅ 完成（docs-only rebase 無衝突）
+3. 本 PR-3.5a merge 到 main（不 bump）
+4. 開 bump PR alpha.226 + CHANGELOG（涵蓋 Phase 3 + Phase 3.5a）
+5. Bump merge → main @ alpha.226
+6. PR-3.5b 視 metric 決定 ship 時機（可延後）
+7. ExitWorktree 清掉 `lights-phase-3-5` worktree（最後 PR 完成後）
+8. 更新 kickoff_lights_rebuild.md：標 Phase 3 ✅ + Phase 3.5a/b 個別狀態
 
 ---
 
@@ -999,16 +1001,19 @@ v7 規模相對 kickoff 原始設計擴張 ~7-10 倍（150-250 LOC → 1620-1720
 
 ### Release 策略（取代 §12）
 
-| 階段 | 動作 |
-|---|---|
-| 1 | Phase 3 PR #638 merge（不 bump） |
-| 2 | Rebase **PR-3.5a** 到 main（解 applyFrameEvent + SessionEnd 衝突）|
-| 3 | PR-3.5a 開 PR + 兩輪 codex review + merge（不 bump） |
-| 4 | 開 bump PR alpha.225（涵蓋 Phase 3 + Phase 3.5a）|
-| 5 | Bump merge → main @ alpha.225 |
-| 6 | （依 metric 與優先級決定）開 **PR-3.5b** + review + merge → bump alpha.226 |
-| 7 | ExitWorktree 清 `lights-phase-3-5`（PR-3.5b 完成後）|
-| 8 | 更新 kickoff：標 Phase 3 + Phase 3.5（a/b 個別狀態）|
+| 階段 | 動作 | 狀態 |
+|---|---|---|
+| 1 | Phase 3 PR #638 squash merge（不 bump） | ✅ 完成（`92fb5d05`，2026-04-26）|
+| 2 | Rebase Phase 3.5 worktree onto new main | ✅ 完成（8 docs commits replay 無衝突）|
+| 3 | PR-3.5a TDD 實作 + push | ⏳ pending（subagent driven）|
+| 4 | PR-3.5a 開 PR + 兩輪 codex review + merge（不 bump） | ⏳ pending |
+| 5 | 開 bump PR **alpha.226**（涵蓋 Phase 3 + Phase 3.5a） | ⏳ pending |
+| 6 | Bump merge → main @ alpha.226 | ⏳ pending |
+| 7 | （依 metric 與優先級決定）開 **PR-3.5b** + review + merge → bump alpha.227 | optional |
+| 8 | ExitWorktree 清 `lights-phase-3-5`（最後 PR 完成後） | optional |
+| 9 | 更新 kickoff：標 Phase 3 + Phase 3.5（a/b 個別狀態） | pending |
+
+**注意 alpha 編號變化**：原 plan §14 寫「bump alpha.225」是 v7 撰寫時 main 在 alpha.224；rebase 後發現 alpha.225 已被 parallel session（PR #643 SPA tooltip）占用，本 PR 系列改 bump alpha.226。此屬 main 並發前進的常態，依 `feedback_concurrent_session_safety.md` 不假設 branch 穩定。
 
 ### Branch 策略
 

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -1,0 +1,39 @@
+// Package agent — Phase 3.5 in-process observability counters.
+//
+// These counters expose canonicalization and projection-dedup activity for
+// debugging cold-start race resolution. They are accumulated per daemon
+// process via stdlib expvar (atomic, sub-microsecond add cost) and are not
+// wired to a metrics endpoint in this PR — see plan §2.6.
+//
+// Limitations (honest by design):
+//   - No HTTP exposure: callers reach them via expvar.Get(name) in process.
+//   - No SessionStart denominator: counters are absolute, not ratios.
+//   - daemon restart resets to zero: not a long-term SLO substrate.
+//
+// PR-3.5a callers increment partial / dedup counters. Sweep counters land in
+// PR-3.5b but the variables are declared here so the four telemetry surfaces
+// stay co-located (one file, one entry point for any future endpoint).
+package agent
+
+import "expvar"
+
+// MetricPartialCanonicalizationCreated tallies hot-path canonicalization
+// attempts that left a partial state behind (proxy ref attached on the
+// ancestor but the descendant's standalone frame DELETE failed under
+// optimistic-concurrency conflict). Sweep canonicalize repairs within 2s;
+// projection_dedup hides from SPA in the meantime.
+var MetricPartialCanonicalizationCreated = expvar.NewInt("purdex_phase35_partial_canonicalization_created_total")
+
+// MetricProjectionDedupHidden counts standalone frames hidden by
+// buildPaneProjection because an ancestor frame in the same pane carries
+// a matching IsProxy ref. Each hidden frame is +1.
+var MetricProjectionDedupHidden = expvar.NewInt("purdex_phase35_projection_dedup_hidden_total")
+
+// MetricSweepCanonicalized counts standalone frames that the sweep
+// canonicalizePane pass folded into ancestor proxy refs. Incremented in
+// PR-3.5b sweep work.
+var MetricSweepCanonicalized = expvar.NewInt("purdex_phase35_sweep_canonicalized_total")
+
+// MetricSweepPrunedProxy counts dead/PID-reused proxy refs detached by the
+// sweep pruneDeadProxyRefs pass. Incremented in PR-3.5b sweep work.
+var MetricSweepPrunedProxy = expvar.NewInt("purdex_phase35_sweep_pruned_proxy_total")

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -301,32 +301,45 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		// Subagents changes flow through mutateSubagentsWithRetry /
 		// attachProxyRefWithRetry / removeProxyRefForSender, not here.
 		//
-		// Exception: SessionStart on an existing frame must reset the
-		// previous session's refs while preserving any IsProxy ref whose
-		// SourcePID is still alive + identity-verified. Phase 3.5 plan
-		// §2.2.2 (v6 J1) replaces the old "snapshot → reset → re-attach"
-		// three-step pattern (race window between steps could lose a
-		// concurrently-attached proxy) with a single filter-merge-retry:
-		// each attempt re-reads frame.Subagents (so any concurrent attach
-		// is naturally preserved), filters via the live identity gate,
-		// and writes via UpsertIfUnchanged. A conflict reload picks up
-		// the newer ref before the next filter pass.
+		// Exception: SessionStart on an existing frame must prune any
+		// stale IsProxy refs (source process dead or PID-reused) while
+		// preserving everything else — including concurrently-attached
+		// native SubagentStart refs (IsProxy=false) that landed between
+		// attempts. Phase 3.5 plan §2.2.2 (v6 J1, v8 M3) replaces the
+		// old "snapshot → reset → re-attach" three-step pattern (race
+		// window between steps could lose a concurrently-attached
+		// proxy) with a single filter-merge-retry: each attempt
+		// re-reads frame.Subagents (so any concurrent attach is
+		// naturally preserved), prunes stale IsProxy via the live
+		// identity gate, and writes via UpsertIfUnchanged. A conflict
+		// reload picks up the newer ref before the next prune pass.
 		if req.EventName == "SessionStart" {
 			var success bool
 			for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
-				filtered := make([]agentpkg.SubagentRef, 0, len(frame.Subagents))
+				// v8 M3 fix (codex round PR-2 attack): the loop must
+				// PRUNE stale IsProxy refs while preserving every other
+				// ref. The previous "keep only live IsProxy" filter
+				// dropped concurrently-attached native SubagentStart
+				// refs (IsProxy=false) on every conflict reload, so a
+				// SubagentStart that landed between attempt N's read
+				// and attempt N+1's reload would silently disappear.
+				// Native refs have no separate source identity to
+				// verify (the agent's own process is alive — we just
+				// hit GetByIdentity on it); only IsProxy refs need the
+				// liveness gate because their source is a separate
+				// child process.
+				pruned := make([]agentpkg.SubagentRef, 0, len(frame.Subagents))
 				for _, ref := range frame.Subagents {
-					if !ref.IsProxy {
-						continue
+					if ref.IsProxy {
+						if !isPidAliveFn(ref.SourcePID) {
+							continue
+						}
+						actualStart, sterr := processStartTimeFn(ref.SourcePID)
+						if sterr != nil || actualStart != ref.SourceStartTime {
+							continue
+						}
 					}
-					if !isPidAliveFn(ref.SourcePID) {
-						continue
-					}
-					actualStart, sterr := processStartTimeFn(ref.SourcePID)
-					if sterr != nil || actualStart != ref.SourceStartTime {
-						continue
-					}
-					filtered = append(filtered, ref)
+					pruned = append(pruned, ref)
 				}
 
 				candidate := *frame
@@ -336,7 +349,7 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 				candidate.Status = status
 				candidate.LastSeenAt = broadcastTs
 				candidate.Verified = true
-				candidate.Subagents = filtered
+				candidate.Subagents = pruned
 
 				ok, written, uerr := m.frames.UpsertIfUnchanged(candidate, frame.LastSeenAt)
 				if uerr != nil {

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -287,33 +287,110 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		// Subagents changes flow through mutateSubagentsWithRetry /
 		// attachProxyRefWithRetry / removeProxyRefForSender, not here.
 		//
-		// Exception: SessionStart on an existing frame intentionally resets
-		// the subagent list (old session's refs no longer apply). Use the
-		// reset variant so subagents_json = '[]' lands in the same SQL.
-		updated := *frame
-		updated.AgentType = req.AgentType
-		updated.PPID = info.PPID
-		updated.ParentFrameID = parentFrameID
-		updated.Status = status
-		updated.LastSeenAt = broadcastTs
-		updated.Verified = true
-		var updateErr error
+		// Exception: SessionStart on an existing frame must reset the
+		// previous session's refs while preserving any IsProxy ref whose
+		// SourcePID is still alive + identity-verified. Phase 3.5 plan
+		// §2.2.2 (v6 J1) replaces the old "snapshot → reset → re-attach"
+		// three-step pattern (race window between steps could lose a
+		// concurrently-attached proxy) with a single filter-merge-retry:
+		// each attempt re-reads frame.Subagents (so any concurrent attach
+		// is naturally preserved), filters via the live identity gate,
+		// and writes via UpsertIfUnchanged. A conflict reload picks up
+		// the newer ref before the next filter pass.
 		if req.EventName == "SessionStart" {
-			updateErr = m.frames.UpdateHookPathAndResetSubagents(updated)
+			var success bool
+			for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
+				filtered := make([]agentpkg.SubagentRef, 0, len(frame.Subagents))
+				for _, ref := range frame.Subagents {
+					if !ref.IsProxy {
+						continue
+					}
+					if !isPidAliveFn(ref.SourcePID) {
+						continue
+					}
+					actualStart, sterr := processStartTimeFn(ref.SourcePID)
+					if sterr != nil || actualStart != ref.SourceStartTime {
+						continue
+					}
+					filtered = append(filtered, ref)
+				}
+
+				candidate := *frame
+				candidate.AgentType = req.AgentType
+				candidate.PPID = info.PPID
+				candidate.ParentFrameID = parentFrameID
+				candidate.Status = status
+				candidate.LastSeenAt = broadcastTs
+				candidate.Verified = true
+				candidate.Subagents = filtered
+
+				ok, written, uerr := m.frames.UpsertIfUnchanged(candidate, frame.LastSeenAt)
+				if uerr != nil {
+					return nil, FrameTraceMeta{}, uerr
+				}
+				if ok {
+					stored = written
+					success = true
+					break
+				}
+				// Conflict — concurrent writer touched the row (proxy
+				// attach, SubagentStart hook, probe status update).
+				// Reload + retry; the new read includes any IsProxy ref
+				// the racer added so the next filter pass preserves it.
+				reloaded, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
+				if rerr != nil {
+					return nil, FrameTraceMeta{}, rerr
+				}
+				if reloaded == nil {
+					// Frame deleted mid-flight. Treat as frame_missing.
+					projection, perr := m.projectPane(req.TmuxPaneID)
+					return projection, FrameTraceMeta{
+						Decision: "skipped",
+						Reason:   "frame_missing",
+						Before:   before,
+						After:    map[string]any{},
+					}, perr
+				}
+				frame = reloaded
+			}
+			if !success {
+				return nil, FrameTraceMeta{}, fmt.Errorf("session_start filter-merge: exceeded %d retries for frame %s", proxyUpsertMaxAttempts, frame.FrameID)
+			}
 		} else {
-			updateErr = m.frames.UpdateHookPath(updated)
+			// Non-SessionStart existing-frame path: original narrow
+			// column update (#632 R8 — don't round-trip subagents).
+			updated := *frame
+			updated.AgentType = req.AgentType
+			updated.PPID = info.PPID
+			updated.ParentFrameID = parentFrameID
+			updated.Status = status
+			updated.LastSeenAt = broadcastTs
+			updated.Verified = true
+			if err := m.frames.UpdateHookPath(updated); err != nil {
+				return nil, FrameTraceMeta{}, err
+			}
+			reloaded, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
+			if rerr != nil {
+				return nil, FrameTraceMeta{}, rerr
+			}
+			if reloaded == nil {
+				return nil, FrameTraceMeta{}, nil
+			}
+			stored = *reloaded
 		}
-		if updateErr != nil {
-			return nil, FrameTraceMeta{}, updateErr
+
+		// Phase 3.5 §2.2.2 — descendant scan after successful filter-
+		// merge. Catches any cold-start race where a child's
+		// SessionStart raced this existing-frame's SessionStart and
+		// landed standalone instead of being collapsed via PR-2b's
+		// pre-Upsert proxy fast-path.
+		if req.EventName == "SessionStart" {
+			updated, cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs)
+			if cerr != nil {
+				return nil, FrameTraceMeta{}, cerr
+			}
+			stored = updated
 		}
-		reloaded, err := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
-		if err != nil {
-			return nil, FrameTraceMeta{}, err
-		}
-		if reloaded == nil {
-			return nil, FrameTraceMeta{}, nil
-		}
-		stored = *reloaded
 	} else {
 		// New frame: insert via Upsert. No existing subagents to clobber;
 		// start the row with an empty list.
@@ -332,6 +409,38 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		})
 		if err != nil {
 			return nil, FrameTraceMeta{}, err
+		}
+
+		// Phase 3.5 §2.2.1 — bidirectional canonicalization (best-effort).
+		// On a SessionStart we just created a standalone frame for, try
+		// once more (post-Upsert) to fold either:
+		//   (a) self into an alive cross-type ancestor (reconcile, plan
+		//       §2.1.1), or
+		//   (b) any standalone cross-type descendants whose SessionStart
+		//       raced ours and landed before our PPID-walk could see us
+		//       as an ancestor (descendant scan, plan §2.1.2).
+		if req.EventName == "SessionStart" {
+			canonicalized, parentStored, rerr := m.reconcileCreatedFrameAsProxy(stored, req, broadcastTs)
+			if rerr != nil {
+				return nil, FrameTraceMeta{}, rerr
+			}
+			if canonicalized {
+				projection, perr := m.projectPane(req.TmuxPaneID)
+				return projection, FrameTraceMeta{
+					FrameID:       parentStored.FrameID,
+					ParentFrameID: parentStored.ParentFrameID,
+					Decision:      "updated_frame",
+					Reason:        "post_upsert_canonicalization_self",
+					Before:        before,
+					After:         summarizeFrame(&parentStored),
+				}, perr
+			}
+			// self stays standalone (or partial); try descendant scan.
+			updated, cerr := m.canonicalizeDescendantsAfterUpsert(stored, broadcastTs)
+			if cerr != nil {
+				return nil, FrameTraceMeta{}, cerr
+			}
+			stored = updated
 		}
 	}
 	projection, err := m.projectPane(req.TmuxPaneID)

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -767,6 +767,121 @@ func (m *Module) tryRebuildFromProcessTree(req EventRequest) (string, bool, erro
 	return agentType, true, nil
 }
 
+// pidIsAncestorOfWithCap walks descendantPID's PPID chain (capped at
+// maxDepth) looking for ancestorPID. Returns true on hit; false on miss,
+// depth exhaustion, readProcessInfoFn error, or self-loop (info.PPID ==
+// info.PID).
+//
+// Used by canonicalizeDescendantsAfterUpsert to confirm a candidate
+// descendant frame's process actually descends from self.PID before
+// folding it into a proxy ref. Mirrors findProxyParent's PPID walk
+// semantics but starts from descendant↑ rather than self↑.
+//
+// Phase 3.5 plan §2.1.2.
+func pidIsAncestorOfWithCap(descendantPID, ancestorPID, maxDepth int) bool {
+	current := descendantPID
+	for depth := 0; depth < maxDepth; depth++ {
+		info, err := readProcessInfoFn(current)
+		if err != nil {
+			return false
+		}
+		if info.PPID == ancestorPID {
+			return true
+		}
+		if info.PPID <= 1 || info.PPID == current {
+			return false
+		}
+		current = info.PPID
+	}
+	return false
+}
+
+// canonicalizeDescendantsAfterUpsert scans self.PaneID for standalone
+// cross-type descendants whose live PPID chain passes through self.PID and
+// whose stored ProcessStartTime matches the live process's actual start
+// time, folding each as a proxy ref on self. Plan §2.1.2.
+//
+// Best-effort delete: when DeleteIfUnchanged returns (false, nil) due to a
+// concurrent writer touching the candidate row, the partial state (ref
+// attached on self + standalone candidate still present) is acceptable —
+// projection-layer dedup hides it from SPA, sweep canonicalizePane
+// retries within 2s. Increments MetricPartialCanonicalizationCreated.
+//
+// Identity gate (alive + processStartTimeFn match) prevents PID-reuse
+// stale rows from polluting self.Subagents (codex round 2 G2; same logic
+// landed in PR-2b findProxyParent). Same-AgentType candidates are skipped
+// — proxy refs are cross-type-only by definition.
+//
+// Returns the latest stored self frame (carrying all successful folds);
+// callers replace their local copy with this value because each
+// attachProxyRefWithRetry can bump self.LastSeenAt. Storage errors
+// propagate as a non-nil error and abort further folds — the partial
+// progress is left for sweep.
+func (m *Module) canonicalizeDescendantsAfterUpsert(self store.Frame, broadcastTs int64) (store.Frame, error) {
+	if m.frames == nil {
+		return self, nil
+	}
+	frames, err := m.frames.ListByPane(self.PaneID)
+	if err != nil {
+		return self, err
+	}
+	current := self
+	for _, candidate := range frames {
+		if candidate.FrameID == current.FrameID {
+			continue
+		}
+		if candidate.AgentType == current.AgentType {
+			continue
+		}
+		if !pidIsAncestorOfWithCap(candidate.PID, current.PID, proxyMaxDepth) {
+			continue
+		}
+		// Identity gate (PR-2b alignment + plan §2.1.2). Mirrors
+		// findProxyParent's "live + start_time match" check on the
+		// other end of the walk — keeps both sides of canonicalization
+		// honest about which candidates count as alive descendants.
+		if !isPidAliveFn(candidate.PID) {
+			continue
+		}
+		actualStart, sterr := processStartTimeFn(candidate.PID)
+		if sterr != nil || actualStart != candidate.ProcessStartTime {
+			continue
+		}
+		ref := agentpkg.SubagentRef{
+			ID:              fmt.Sprintf("proxy:%s:%d:%s", candidate.AgentType, candidate.PID, candidate.ProcessStartTime),
+			Type:            candidate.AgentType,
+			StartedAt:       broadcastTs,
+			SourcePID:       candidate.PID,
+			SourceStartTime: candidate.ProcessStartTime,
+			IsProxy:         true,
+		}
+		attached, parentStored, aerr := m.attachProxyRefWithRetry(current, ref, broadcastTs)
+		if aerr != nil {
+			return current, aerr
+		}
+		if !attached {
+			// Self frame vanished mid-flight (sweep / SessionEnd).
+			// Stop folding — caller will project the pane and surface
+			// frame_missing.
+			return current, nil
+		}
+		deleted, derr := m.frames.DeleteIfUnchanged(candidate.FrameID, candidate.LastSeenAt)
+		if derr != nil {
+			return parentStored, derr
+		}
+		if !deleted {
+			// Partial state: proxy attached on self + candidate row
+			// still standalone. Acceptable transient — projection
+			// dedup hides from SPA, sweep canonicalize repairs within
+			// 2s. Continue scanning other candidates.
+			agentpkg.MetricPartialCanonicalizationCreated.Add(1)
+			log.Printf("phase3.5: descendant scan partial state child %s parent %s (sweep will repair within 2s)", candidate.FrameID, parentStored.FrameID)
+		}
+		current = parentStored
+	}
+	return current, nil
+}
+
 // findProxyParent walks the sender's PPID ancestor chain (capped at
 // proxyMaxDepth) looking for an alive, identity-verified, cross-type frame in
 // the same pane. See plan §1.4 for full contract.

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -945,15 +945,18 @@ func (m *Module) reconcileCreatedFrameAsProxy(stored store.Frame, req EventReque
 	}
 	if !deleted {
 		// Partial state: parent has the proxy ref, self still
-		// standalone. Acceptable — projection dedup hides; sweep
-		// repairs within 2s. Increment metric and report
-		// canonicalized=false so caller emits the standard
-		// created_frame trace (the proxy attach is a side effect
-		// the trace surfaces via parent's own next event, not via
-		// this hook's decision string).
+		// standalone. Acceptable transient — projection dedup hides
+		// the orphan child from SPA, sweep canonicalize repairs
+		// within 2s. v8 M4 fix (codex round PR-2 attack): we still
+		// report canonicalized=true here so the caller emits an
+		// updated_frame / post_upsert_canonicalization_self trace
+		// that matches what the SPA actually sees (parent + proxy
+		// ref). Reporting canonicalized=false would have routed the
+		// caller to the standalone created_frame trace, diverging
+		// from projection (trace ≠ projection). Metric still +1 to
+		// surface partial-state rate via expvar.
 		agentpkg.MetricPartialCanonicalizationCreated.Add(1)
 		log.Printf("phase3.5: reconcile partial state child %s parent %s (sweep will repair within 2s)", stored.FrameID, parentStored.FrameID)
-		return false, store.Frame{}, nil
 	}
 	return true, parentStored, nil
 }

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -315,22 +315,26 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		// reload picks up the newer ref before the next prune pass.
 		if req.EventName == "SessionStart" {
 			var success bool
+			// prevWrittenNativeIDs tracks native ref IDs we wrote in the
+			// most recent attempt's candidate.Subagents. nil at attempt 0
+			// — SessionStart's primary semantic is "reset previous
+			// session's native subagent state", so the baseline native
+			// refs read into frame.Subagents must be dropped. From
+			// attempt 1 onward (after IfUnchanged conflict + reload), a
+			// native ref appearing in the reloaded baseline that is NOT
+			// in prevWrittenNativeIDs is a concurrent SubagentStart that
+			// landed between attempts — preserve it (v8 M3, codex round
+			// PR-2 attack). Native refs already in prevWrittenNativeIDs
+			// were carried by us across attempts and are still subject
+			// to the SessionStart reset (they shouldn't accumulate).
+			var prevWrittenNativeIDs map[string]struct{}
 			for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
-				// v8 M3 fix (codex round PR-2 attack): the loop must
-				// PRUNE stale IsProxy refs while preserving every other
-				// ref. The previous "keep only live IsProxy" filter
-				// dropped concurrently-attached native SubagentStart
-				// refs (IsProxy=false) on every conflict reload, so a
-				// SubagentStart that landed between attempt N's read
-				// and attempt N+1's reload would silently disappear.
-				// Native refs have no separate source identity to
-				// verify (the agent's own process is alive — we just
-				// hit GetByIdentity on it); only IsProxy refs need the
-				// liveness gate because their source is a separate
-				// child process.
 				pruned := make([]agentpkg.SubagentRef, 0, len(frame.Subagents))
 				for _, ref := range frame.Subagents {
 					if ref.IsProxy {
+						// IsProxy refs survive SessionStart reset when
+						// their source process is alive + identity
+						// matches (PR-2b proxy-collapse semantics).
 						if !isPidAliveFn(ref.SourcePID) {
 							continue
 						}
@@ -338,8 +342,18 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 						if sterr != nil || actualStart != ref.SourceStartTime {
 							continue
 						}
+						pruned = append(pruned, ref)
+						continue
 					}
-					pruned = append(pruned, ref)
+					// Native ref: keep only if it appeared between
+					// attempts (concurrent SubagentStart). At attempt 0
+					// prevWrittenNativeIDs is nil, so SessionStart's
+					// reset semantic cleanly drops every native baseline.
+					if prevWrittenNativeIDs != nil {
+						if _, seen := prevWrittenNativeIDs[ref.ID]; !seen {
+							pruned = append(pruned, ref)
+						}
+					}
 				}
 
 				candidate := *frame
@@ -362,8 +376,16 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 				}
 				// Conflict — concurrent writer touched the row (proxy
 				// attach, SubagentStart hook, probe status update).
-				// Reload + retry; the new read includes any IsProxy ref
-				// the racer added so the next filter pass preserves it.
+				// Record what we attempted to write so the next prune
+				// pass can distinguish concurrent attaches (kept) from
+				// stale baseline native refs (dropped). Then reload +
+				// retry.
+				prevWrittenNativeIDs = make(map[string]struct{}, len(pruned))
+				for _, ref := range pruned {
+					if !ref.IsProxy {
+						prevWrittenNativeIDs[ref.ID] = struct{}{}
+					}
+				}
 				reloaded, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
 				if rerr != nil {
 					return nil, FrameTraceMeta{}, rerr
@@ -1041,6 +1063,21 @@ func (m *Module) canonicalizeDescendantsAfterUpsert(self store.Frame, broadcastT
 			continue
 		}
 		if !pidIsAncestorOfWithCap(candidate.PID, current.PID, proxyMaxDepth) {
+			continue
+		}
+		// v8 M2 fix (codex round PR-2 attack): skip a candidate that
+		// has accumulated its own subagent state (native SubagentStart
+		// refs from hooks, or its own IsProxy refs from being a parent
+		// in another canonicalization). Folding such a candidate would
+		// silently drop those refs — DeleteIfUnchanged below removes
+		// the candidate row outright, taking subagent state with it.
+		// Race-window standalones that motivate this scan have empty
+		// Subagents (a fresh SessionStart row), so guarding on
+		// len > 0 cleanly separates "race artifact safe to fold"
+		// from "live frame that owns state we must not lose". Sweep
+		// canonicalize (PR-3.5b) handles the stateful-candidate case
+		// out-of-band by reconciling refs across siblings.
+		if len(candidate.Subagents) > 0 {
 			continue
 		}
 		// Identity gate (PR-2b alignment + plan §2.1.2). Mirrors

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -25,6 +25,18 @@ const proxyMaxDepth = 5
 // that hit this limit are genuine hot loops, not ordinary concurrency.
 const proxyUpsertMaxAttempts = 3
 
+// nativeBaselineKey identifies a native (IsProxy=false) subagent ref for the
+// SessionStart filter-merge baseline (Phase 3.5 plan §2.2.2 v12 T1 fix). The
+// triple (Type, ID, StartedAt) survives ID collision between an old-session
+// baseline ref and a concurrent SubagentStart that happens to reuse the
+// same ID — the new ref's StartedAt is a fresh broadcastTs distinct from
+// any baseline ref, so the new ref doesn't match baseline and is preserved.
+type nativeBaselineKey struct {
+	typ       string
+	id        string
+	startedAt int64
+}
+
 type FrameTraceMeta struct {
 	FrameID       string
 	ParentFrameID string
@@ -316,15 +328,15 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		// reload picks up the newer ref before the next prune pass.
 		if req.EventName == "SessionStart" {
 			var success bool
-			// initialNativeIDs is the BASELINE native ref ID set captured
-			// before the retry loop. SessionStart's reset semantic drops
-			// the old session's native subagent state, which the cc
-			// hook saw at attempt 0 entry. Any native ref appearing in
-			// the reloaded baseline on a later retry that is NOT in
-			// initialNativeIDs is — by construction — a concurrent
-			// SubagentStart that landed AFTER our baseline snapshot
-			// (post our SessionStart). Such refs belong to the new
-			// session and must be preserved across all retries.
+			// initialNativeBaseline is the BASELINE native ref identity
+			// set captured before the retry loop. SessionStart's reset
+			// semantic drops the old session's native subagent state,
+			// which the cc hook saw at attempt 0 entry. Any native ref
+			// appearing in the reloaded baseline on a later retry that
+			// is NOT in initialNativeBaseline is — by construction — a
+			// concurrent SubagentStart that landed AFTER our baseline
+			// snapshot (post our SessionStart). Such refs belong to
+			// the new session and must be preserved across all retries.
 			//
 			// Codex round 2 #O1 fix: the previous prevWrittenNativeIDs
 			// approach regressed across multiple conflicts — a native
@@ -332,10 +344,22 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 			// itself, so attempt 2 dropped it as a "carried-forward
 			// baseline native". Snapshotting an immutable baseline
 			// before the loop sidesteps the regression entirely.
-			initialNativeIDs := make(map[string]struct{}, len(frame.Subagents))
+			//
+			// Codex round 5 #T1 fix: the v11 baseline used ID-only
+			// identity. Native IDs are provider-supplied strings and
+			// cross-session ID reuse is provider-dependent (cc/codex
+			// tend toward UUID-like, opencode may be more deterministic),
+			// so a SessionStart racing a concurrent SubagentStart whose
+			// new native ref reused an old-session ID would silently
+			// drop the new ref — classified as baseline by ID alone.
+			// Track baseline by (Type, ID, StartedAt) instead: the new
+			// SubagentStart's StartedAt will be a fresh broadcastTs
+			// distinct from any baseline ref, so the new ref survives
+			// the filter even when its ID collides with a baseline ref.
+			initialNativeBaseline := make(map[nativeBaselineKey]struct{}, len(frame.Subagents))
 			for _, ref := range frame.Subagents {
 				if !ref.IsProxy {
-					initialNativeIDs[ref.ID] = struct{}{}
+					initialNativeBaseline[nativeBaselineKey{ref.Type, ref.ID, ref.StartedAt}] = struct{}{}
 				}
 			}
 			for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
@@ -359,7 +383,10 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 					// baseline (SessionStart reset semantic for old
 					// session refs). Otherwise (appeared after baseline
 					// snapshot via concurrent SubagentStart) preserve.
-					if _, baseline := initialNativeIDs[ref.ID]; !baseline {
+					// Identity is (Type, ID, StartedAt) — a concurrent
+					// SubagentStart reusing an old-session ID will have
+					// a fresh StartedAt and will not match baseline.
+					if _, baseline := initialNativeBaseline[nativeBaselineKey{ref.Type, ref.ID, ref.StartedAt}]; !baseline {
 						pruned = append(pruned, ref)
 					}
 				}

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -1068,19 +1068,44 @@ func (m *Module) canonicalizeDescendantsAfterUpsert(self store.Frame, broadcastT
 		if !pidIsAncestorOfWithCap(candidate.PID, current.PID, proxyMaxDepth) {
 			continue
 		}
-		// v8 M2 fix (codex round PR-2 attack): skip a candidate that
-		// has accumulated its own subagent state (native SubagentStart
-		// refs from hooks, or its own IsProxy refs from being a parent
-		// in another canonicalization). Folding such a candidate would
-		// silently drop those refs — DeleteIfUnchanged below removes
-		// the candidate row outright, taking subagent state with it.
-		// Race-window standalones that motivate this scan have empty
-		// Subagents (a fresh SessionStart row), so guarding on
-		// len > 0 cleanly separates "race artifact safe to fold"
-		// from "live frame that owns state we must not lose". Sweep
-		// canonicalize (PR-3.5b) handles the stateful-candidate case
-		// out-of-band by reconciling refs across siblings.
-		if len(candidate.Subagents) > 0 {
+		// Codex round 2 #O2 refinement: protect candidates that own
+		// LIVE state (native refs or live identity-verified IsProxy
+		// refs) from being folded. The original v8 M2 guard (len > 0)
+		// over-protected — a candidate carrying ONLY stale dead/PID-
+		// reused IsProxy refs is still a race-window artifact safe
+		// to fold (the stale ref would be reaped by sweep prune
+		// anyway, and dropping it along with the candidate row is
+		// equivalent). Distinguishing these classes lets the hot-path
+		// fold race-window standalones even when sweep prune has not
+		// yet cleared their stale leftovers.
+		hasOwnedState := false
+		for _, ref := range candidate.Subagents {
+			if !ref.IsProxy {
+				// Native ref → real owned state.
+				hasOwnedState = true
+				break
+			}
+			// IsProxy: live + identity-verified counts as owned;
+			// dead/PID-reused is stale and safe to drop with the fold.
+			if !isPidAliveFn(ref.SourcePID) {
+				continue
+			}
+			actualStart, sterr := processStartTimeFn(ref.SourcePID)
+			if sterr != nil {
+				// Read error → defensive; treat as owned (don't drop
+				// state on uncertainty). Mirrors findProxyParent's
+				// "lookup error → don't infer" convention.
+				hasOwnedState = true
+				break
+			}
+			if actualStart != ref.SourceStartTime {
+				continue // PID reuse; stale
+			}
+			// Live + identity-verified IsProxy → owned.
+			hasOwnedState = true
+			break
+		}
+		if hasOwnedState {
 			continue
 		}
 		// Identity gate (PR-2b alignment + plan §2.1.2). Mirrors

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -67,6 +67,20 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 			if err := m.frames.Delete(frame.FrameID); err != nil {
 				return nil, FrameTraceMeta{}, err
 			}
+			// Phase 3.5 §2.3 — best-effort proxy cleanup for the
+			// partial-state case where this frame was simultaneously a
+			// standalone row AND attached as a proxy ref on an ancestor
+			// (cold-start race partial that hot-path canonicalize +
+			// projection dedup left in place). Without this, the
+			// ancestor's proxy ref outlives the child's SessionEnd
+			// permanently — projection dedup cannot fix it because
+			// there's no standalone frame left to hide behind, so the
+			// ancestor would show a stale lit dot.
+			//
+			// Errors / no-match are ignored — sweep pruneDeadProxyRefs
+			// (PR-3.5b) covers the daemon-crash / removeProxyRef-failure
+			// permutations.
+			_, _, _, _, _ = m.removeProxyRefForSender(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, broadcastTs)
 			projection, err := m.projectPane(req.TmuxPaneID)
 			return projection, FrameTraceMeta{
 				FrameID:       frame.FrameID,

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -767,6 +767,74 @@ func (m *Module) tryRebuildFromProcessTree(req EventRequest) (string, bool, erro
 	return agentType, true, nil
 }
 
+// reconcileCreatedFrameAsProxy attempts to canonicalize a freshly-created
+// SessionStart frame against an alive cross-type ancestor. If
+// findProxyParent locates a candidate, attaches a proxy ref to the
+// ancestor + best-effort deletes self's standalone row.
+//
+// Best-effort delete: if DeleteIfUnchanged fails because a concurrent
+// writer touched the child row (sweep tick, SubagentStart hook, etc.),
+// MetricPartialCanonicalizationCreated +1 and we return — sweep
+// canonicalize will retry within sweepInterval=2s and projection-layer
+// dedup hides the partial state from SPA in the meantime. Plan §2.1.1.
+//
+// Returns:
+//
+//	(true, parentStored, nil)  — attach + delete both succeeded; caller
+//	                             should project the pane and emit a
+//	                             post_upsert_canonicalization_self trace.
+//	(false, zero, nil)         — no ancestor / parent vanished
+//	                             mid-attach / partial state (attach
+//	                             succeeded, delete failed; counted in
+//	                             metrics, repaired by sweep).
+//	(false, zero, err)         — storage failure; caller propagates.
+//
+// Unlike v2/v3 of this design there is no rollback path: partial state
+// is treated as a legal transient (see plan §0.2 evidence points).
+func (m *Module) reconcileCreatedFrameAsProxy(stored store.Frame, req EventRequest, broadcastTs int64) (bool, store.Frame, error) {
+	parent, err := m.findProxyParent(req)
+	if err != nil {
+		return false, store.Frame{}, err
+	}
+	if parent == nil {
+		return false, store.Frame{}, nil
+	}
+	ref := agentpkg.SubagentRef{
+		ID:              fmt.Sprintf("proxy:%s:%d:%s", req.AgentType, req.SenderPID, req.SenderStartTime),
+		Type:            req.AgentType,
+		StartedAt:       broadcastTs,
+		SourcePID:       req.SenderPID,
+		SourceStartTime: req.SenderStartTime,
+		IsProxy:         true,
+	}
+	attached, parentStored, aerr := m.attachProxyRefWithRetry(*parent, ref, broadcastTs)
+	if aerr != nil {
+		return false, store.Frame{}, aerr
+	}
+	if !attached {
+		// Parent vanished mid-flight (concurrent SessionEnd / sweep).
+		// Caller falls back to leaving self standalone.
+		return false, store.Frame{}, nil
+	}
+	deleted, derr := m.frames.DeleteIfUnchanged(stored.FrameID, stored.LastSeenAt)
+	if derr != nil {
+		return false, store.Frame{}, derr
+	}
+	if !deleted {
+		// Partial state: parent has the proxy ref, self still
+		// standalone. Acceptable — projection dedup hides; sweep
+		// repairs within 2s. Increment metric and report
+		// canonicalized=false so caller emits the standard
+		// created_frame trace (the proxy attach is a side effect
+		// the trace surfaces via parent's own next event, not via
+		// this hook's decision string).
+		agentpkg.MetricPartialCanonicalizationCreated.Add(1)
+		log.Printf("phase3.5: reconcile partial state child %s parent %s (sweep will repair within 2s)", stored.FrameID, parentStored.FrameID)
+		return false, store.Frame{}, nil
+	}
+	return true, parentStored, nil
+}
+
 // pidIsAncestorOfWithCap walks descendantPID's PPID chain (capped at
 // maxDepth) looking for ancestorPID. Returns true on hit; false on miss,
 // depth exhaustion, readProcessInfoFn error, or self-loop (info.PPID ==

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -316,19 +316,28 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 		// reload picks up the newer ref before the next prune pass.
 		if req.EventName == "SessionStart" {
 			var success bool
-			// prevWrittenNativeIDs tracks native ref IDs we wrote in the
-			// most recent attempt's candidate.Subagents. nil at attempt 0
-			// — SessionStart's primary semantic is "reset previous
-			// session's native subagent state", so the baseline native
-			// refs read into frame.Subagents must be dropped. From
-			// attempt 1 onward (after IfUnchanged conflict + reload), a
-			// native ref appearing in the reloaded baseline that is NOT
-			// in prevWrittenNativeIDs is a concurrent SubagentStart that
-			// landed between attempts — preserve it (v8 M3, codex round
-			// PR-2 attack). Native refs already in prevWrittenNativeIDs
-			// were carried by us across attempts and are still subject
-			// to the SessionStart reset (they shouldn't accumulate).
-			var prevWrittenNativeIDs map[string]struct{}
+			// initialNativeIDs is the BASELINE native ref ID set captured
+			// before the retry loop. SessionStart's reset semantic drops
+			// the old session's native subagent state, which the cc
+			// hook saw at attempt 0 entry. Any native ref appearing in
+			// the reloaded baseline on a later retry that is NOT in
+			// initialNativeIDs is — by construction — a concurrent
+			// SubagentStart that landed AFTER our baseline snapshot
+			// (post our SessionStart). Such refs belong to the new
+			// session and must be preserved across all retries.
+			//
+			// Codex round 2 #O1 fix: the previous prevWrittenNativeIDs
+			// approach regressed across multiple conflicts — a native
+			// preserved at attempt 1 was recorded in prevWrittenNativeIDs
+			// itself, so attempt 2 dropped it as a "carried-forward
+			// baseline native". Snapshotting an immutable baseline
+			// before the loop sidesteps the regression entirely.
+			initialNativeIDs := make(map[string]struct{}, len(frame.Subagents))
+			for _, ref := range frame.Subagents {
+				if !ref.IsProxy {
+					initialNativeIDs[ref.ID] = struct{}{}
+				}
+			}
 			for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
 				pruned := make([]agentpkg.SubagentRef, 0, len(frame.Subagents))
 				for _, ref := range frame.Subagents {
@@ -346,14 +355,12 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 						pruned = append(pruned, ref)
 						continue
 					}
-					// Native ref: keep only if it appeared between
-					// attempts (concurrent SubagentStart). At attempt 0
-					// prevWrittenNativeIDs is nil, so SessionStart's
-					// reset semantic cleanly drops every native baseline.
-					if prevWrittenNativeIDs != nil {
-						if _, seen := prevWrittenNativeIDs[ref.ID]; !seen {
-							pruned = append(pruned, ref)
-						}
+					// Native ref: drop if it was in the initial
+					// baseline (SessionStart reset semantic for old
+					// session refs). Otherwise (appeared after baseline
+					// snapshot via concurrent SubagentStart) preserve.
+					if _, baseline := initialNativeIDs[ref.ID]; !baseline {
+						pruned = append(pruned, ref)
 					}
 				}
 
@@ -377,16 +384,11 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 				}
 				// Conflict — concurrent writer touched the row (proxy
 				// attach, SubagentStart hook, probe status update).
-				// Record what we attempted to write so the next prune
-				// pass can distinguish concurrent attaches (kept) from
-				// stale baseline native refs (dropped). Then reload +
-				// retry.
-				prevWrittenNativeIDs = make(map[string]struct{}, len(pruned))
-				for _, ref := range pruned {
-					if !ref.IsProxy {
-						prevWrittenNativeIDs[ref.ID] = struct{}{}
-					}
-				}
+				// Reload and retry; initialNativeIDs is UNCHANGED across
+				// retries, so any native ID appearing in the reloaded
+				// baseline that is not in initialNativeIDs is a true
+				// concurrent attach and gets preserved by the next
+				// filter pass.
 				reloaded, rerr := m.frames.GetByIdentity(req.TmuxPaneID, req.SenderPID, req.SenderStartTime)
 				if rerr != nil {
 					return nil, FrameTraceMeta{}, rerr

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -64,23 +64,24 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 	switch req.EventName {
 	case "SessionEnd":
 		if frame != nil {
+			// Phase 3.5 §2.3 (v8 L1 fix, codex round PR-2 attack):
+			// detach-first ordering. The previous delete-first +
+			// best-effort detach left a permanent orphan whenever
+			// removeProxyRefForSender failed (storage error, retry
+			// exhaustion, daemon crash mid-handler) — the child row
+			// was gone so projection_dedup could no longer hide the
+			// ancestor's stale proxy ref, and PR-3.5a ships without
+			// pruneDeadProxyRefs. By detaching first and propagating
+			// the error before Delete, a hook handler failure leaves
+			// the DB in a recoverable state (child row + parent ref
+			// both still present; sweep canonicalize / next
+			// SessionEnd retry can fix it).
+			if _, _, _, _, derr := m.removeProxyRefForSender(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, broadcastTs); derr != nil {
+				return nil, FrameTraceMeta{}, derr
+			}
 			if err := m.frames.Delete(frame.FrameID); err != nil {
 				return nil, FrameTraceMeta{}, err
 			}
-			// Phase 3.5 §2.3 — best-effort proxy cleanup for the
-			// partial-state case where this frame was simultaneously a
-			// standalone row AND attached as a proxy ref on an ancestor
-			// (cold-start race partial that hot-path canonicalize +
-			// projection dedup left in place). Without this, the
-			// ancestor's proxy ref outlives the child's SessionEnd
-			// permanently — projection dedup cannot fix it because
-			// there's no standalone frame left to hide behind, so the
-			// ancestor would show a stale lit dot.
-			//
-			// Errors / no-match are ignored — sweep pruneDeadProxyRefs
-			// (PR-3.5b) covers the daemon-crash / removeProxyRef-failure
-			// permutations.
-			_, _, _, _, _ = m.removeProxyRefForSender(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, broadcastTs)
 			projection, err := m.projectPane(req.TmuxPaneID)
 			return projection, FrameTraceMeta{
 				FrameID:       frame.FrameID,

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -3117,6 +3117,141 @@ func TestPhase35_IT21b_ExistingFrameSessionStartPreservesNativeAcrossMultiConfli
 	}
 }
 
+// IT21c — existing_frame SessionStart preserves a concurrent SubagentStart
+// whose native ID HAPPENS TO COLLIDE with an old-session baseline native ID.
+// Codex round 5 #T1 regression guard: the v11 initialNativeIDs baseline used
+// ID-only identity, so a SessionStart reset racing with a concurrent
+// SubagentStart whose new native ref reuses an old-session ID would silently
+// drop the new ref — classified as baseline old-session state by ID match
+// alone. Native IDs are provider-supplied strings; cross-session ID reuse
+// is provider-dependent (cc/codex tend toward UUID-like, opencode may be
+// more deterministic). The fix is to track baseline by (Type, ID, StartedAt)
+// — the new SubagentStart's StartedAt will be a fresh broadcastTs distinct
+// from baseline refs, so the new ref doesn't match baseline and survives
+// filter-merge.
+//
+// Setup:
+//   - cc seeded with baseline native {ID:"call-1", Type:"cc", StartedAt:5}
+//     plus an IsProxy ref (PID 200) that drives the per-attempt seam.
+//   - attempt 0: processStartTimeFn(200) injects a NEW SubagentStart with
+//     SAME ID "call-1" but distinct StartedAt 65, then bumps LastSeenAt
+//     to force IfUnchanged conflict.
+//   - attempt 1: filter pass should preserve the new {ID:"call-1",
+//     StartedAt:65} ref while still dropping the baseline {ID:"call-1",
+//     StartedAt:5} ref. IfUnchanged write succeeds.
+//
+// Assertions: final.Subagents contains the new ref (ID="call-1",
+// StartedAt=65); the baseline ref (ID="call-1", StartedAt=5) is dropped;
+// codex IsProxy ref preserved.
+func TestPhase35_IT21c_ExistingFrameSessionStartPreservesNewNativeWithReusedID(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{
+		{
+			ID:        "call-1",
+			Type:      "cc",
+			StartedAt: 5,
+		},
+		{
+			ID:              "proxy:codex:200:t200",
+			Type:            "codex",
+			SourcePID:       200,
+			SourceStartTime: "t200",
+			IsProxy:         true,
+		},
+	}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed cc + baseline native + codex proxy: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// Per-attempt seam: each call to processStartTimeFn(200) corresponds to
+	// one filter pass for the codex IsProxy ref. After attempt 0 only,
+	// inject a new SubagentStart with SAME ID "call-1" but distinct
+	// StartedAt 65, and bump LastSeenAt to force IfUnchanged conflict.
+	// Attempt 1's filter must preserve the new ref despite ID collision
+	// with baseline.
+	attempt := 0
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		if pid != 200 {
+			return "other", nil
+		}
+		attempt++
+		if attempt == 1 {
+			racer, _ := m.frames.GetByIdentity("%5", 100, "t100")
+			if racer != nil {
+				// Concurrent SubagentStart with ID colliding against the
+				// baseline ID "call-1", but distinct StartedAt 65 (fresh
+				// broadcastTs). With T1 fix, baseline is keyed by (Type,
+				// ID, StartedAt) so this new ref does NOT match baseline.
+				racer.Subagents = append(racer.Subagents, agentpkg.SubagentRef{
+					ID:        "call-1",
+					Type:      "cc",
+					StartedAt: 65,
+				})
+				racer.LastSeenAt = 60
+				if _, err := m.frames.Upsert(*racer); err != nil {
+					t.Fatalf("concurrent inject attempt=%d: %v", attempt, err)
+				}
+			}
+		}
+		return "t200", nil
+	}
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+
+	if attempt < 2 {
+		t.Fatalf("filter-merge ran only %d attempts, expected at least 2 (1 conflict + final success)", attempt)
+	}
+
+	final, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if final == nil {
+		t.Fatalf("cc frame disappeared")
+	}
+
+	hasNewNative := false           // ID="call-1", StartedAt=65 (NEW concurrent SubagentStart)
+	hasBaselineNative := false      // ID="call-1", StartedAt=5  (OLD baseline — must be dropped)
+	hasCodexProxy := false
+	for _, ref := range final.Subagents {
+		switch {
+		case !ref.IsProxy && ref.ID == "call-1" && ref.StartedAt == 65:
+			hasNewNative = true
+		case !ref.IsProxy && ref.ID == "call-1" && ref.StartedAt == 5:
+			hasBaselineNative = true
+		case ref.IsProxy && ref.SourcePID == 200:
+			hasCodexProxy = true
+		}
+	}
+	if !hasNewNative {
+		t.Fatalf("new SubagentStart ref (ID=call-1, StartedAt=65) missing from %+v — T1 regression: ID-only baseline dropped concurrent native that reused old-session ID", final.Subagents)
+	}
+	if hasBaselineNative {
+		t.Fatalf("baseline native (ID=call-1, StartedAt=5) still present in %+v — SessionStart reset must drop initial natives", final.Subagents)
+	}
+	if !hasCodexProxy {
+		t.Fatalf("codex IsProxy ref missing from %+v — proxy preservation regression", final.Subagents)
+	}
+}
+
 // IT1 — descendant_then_ancestor_canonicalizes_via_descendant_scan.
 // codex SessionStart lands first (no cc parent yet → standalone codex).
 // cc SessionStart lands second (new-frame Upsert + descendant scan finds

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -2622,6 +2622,56 @@ func TestPhase35_IT20_ExistingFrameSessionStartPreservesConcurrentlyAttachedProx
 	}
 }
 
+// IT12 — session_end_clears_parent_proxy_ref (plan §2.3 / Side B SessionEnd
+// hot-path cleanup). Partial state: cc parent has codex proxy ref +
+// codex standalone frame. codex SessionEnd must delete its own frame AND
+// detach the proxy ref from cc — projection dedup can't help here (no
+// standalone left to hide behind once the child SessionEnd is processed).
+func TestPhase35_IT12_SessionEndClearsParentProxyRef(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	// Seed cc parent with a codex proxy ref AND a codex standalone frame
+	// (the partial state cold-start race could leave behind).
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:codex:200:t200",
+		Type:            "codex",
+		StartedAt:       50,
+		SourcePID:       200,
+		SourceStartTime: "t200",
+		IsProxy:         true,
+	}}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed cc + proxy: %v", err)
+	}
+	codexStandalone := seedFrame(t, m, "%5", "codex", 200, "t200", 60)
+
+	// codex SessionEnd: own-frame delete path + new §2.3 proxy cleanup.
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionEnd", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusClear}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Decision != "deleted_frame" || meta.Reason != "session_end" {
+		t.Fatalf("meta = %+v, want deleted_frame / session_end", meta)
+	}
+
+	// codex standalone gone.
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (codex deleted)", len(frames))
+	}
+	if frames[0].AgentType != "cc" {
+		t.Fatalf("remaining AgentType = %q, want cc", frames[0].AgentType)
+	}
+	// Proxy ref also removed from cc.
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("cc.Subagents = %+v, want empty (proxy detached by SessionEnd hot-path)", frames[0].Subagents)
+	}
+	_ = codexStandalone
+}
+
 // RC4b — positive case: live identity-verified cross-type descendant under
 // self.PID is folded into a proxy ref + standalone deleted.
 func TestCanonicalizeDescendantsAfterUpsert_FoldsLiveCrossTypeDescendant(t *testing.T) {

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -2216,6 +2216,412 @@ func TestCanonicalizeDescendantsAfterUpsert_SkipsPidReuseViaIdentityGate(t *test
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Phase 3.5 PR-3.5a — Integration tests for cold-start race canonicalization
+// (plan §3.1)
+// ---------------------------------------------------------------------------
+
+// IT3 — concurrent_descendant_first_then_reconcile_hits_post_upsert.
+// codex applyFrameEvent: pre-walk findProxyParent misses (cc not yet
+// visible to walk; readProcessInfoFn returns dud PPID on calls 1+2),
+// then reconcile post-Upsert hits (cc visible on call 3+; readProcessInfoFn
+// returns PPID=100 with cc seeded). Verifies the §2.2.1 reconcile path
+// is wired and emits post_upsert_canonicalization_self.
+func TestPhase35_IT3_PreWalkMiss_PostReconcileHit(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	// Counter swaps PPID for codex sender (PID=200) so PR-2b's findProxyParent
+	// (calls 1+2: pre-walk + line-222 info read) sees PPID=999 = no parent
+	// in DB, fall-through to new-frame Upsert. Then post-Upsert reconcile's
+	// findProxyParent (call 3+) sees PPID=100 = cc → fold.
+	calls := 0
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			calls++
+			if calls <= 2 {
+				return agentpkg.ProcessInfo{PID: 200, PPID: 999}, nil
+			}
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "post_upsert_canonicalization_self" {
+		t.Fatalf("reason = %q, want post_upsert_canonicalization_self", meta.Reason)
+	}
+	if meta.Decision != "updated_frame" {
+		t.Fatalf("decision = %q, want updated_frame", meta.Decision)
+	}
+	if meta.FrameID != parent.FrameID {
+		t.Fatalf("FrameID = %q, want parent %q", meta.FrameID, parent.FrameID)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (codex folded into cc)", len(frames))
+	}
+	if frames[0].AgentType != "cc" {
+		t.Fatalf("remaining AgentType = %q, want cc", frames[0].AgentType)
+	}
+	if len(frames[0].Subagents) != 1 || frames[0].Subagents[0].SourcePID != 200 {
+		t.Fatalf("cc.Subagents = %+v, want 1 codex proxy ref", frames[0].Subagents)
+	}
+}
+
+// IT4 — concurrent_descendant_post_reconcile_also_misses_recovered_by_ancestor_scan.
+// Core ancestor-late race: codex SessionStart races first, both pre-walk and
+// post-walk miss → standalone codex frame. Then cc SessionStart fires —
+// new-frame post-Upsert descendant scan must locate codex and fold it.
+func TestPhase35_IT4_AncestorLateRecoveredByDescendantScan(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	// codex sender PID=200 PPID=100; cc sender PID=100 PPID=1.
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 1}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// Step (a): codex SessionStart with cc not yet in DB → pre-walk misses
+	// (FindByPanePID(100) = nil), reconcile post-walk also misses (same
+	// reason), new standalone codex created.
+	req1 := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	if _, _, err := m.applyFrameEvent(req1, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("codex applyFrameEvent: %v", err)
+	}
+	mid, _ := m.frames.ListByPane("%5")
+	if len(mid) != 1 || mid[0].AgentType != "codex" {
+		t.Fatalf("after codex SessionStart: frames=%+v, want 1 standalone codex", mid)
+	}
+
+	// Step (b): cc SessionStart — new-frame Upsert + descendant scan must
+	// find codex (PPID 200→100) + fold.
+	req2 := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(req2, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 200); err != nil {
+		t.Fatalf("cc applyFrameEvent: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (codex folded into cc); frames=%+v", len(frames), frames)
+	}
+	if frames[0].AgentType != "cc" {
+		t.Fatalf("remaining AgentType = %q, want cc", frames[0].AgentType)
+	}
+	if len(frames[0].Subagents) != 1 {
+		t.Fatalf("cc.Subagents = %+v, want 1 codex proxy ref", frames[0].Subagents)
+	}
+	ref := frames[0].Subagents[0]
+	if !ref.IsProxy || ref.Type != "codex" || ref.SourcePID != 200 || ref.SourceStartTime != "t200" {
+		t.Fatalf("ref = %+v, want codex proxy SourcePID=200 t200", ref)
+	}
+}
+
+// IT17 — existing_frame SessionStart preserves a live identity-verified
+// IsProxy ref via filter-merge-retry (plan §2.2.2 v6 J1).
+func TestPhase35_IT17_ExistingFrameSessionStartPreservesLiveProxyRef(t *testing.T) {
+	m := newProxyTestModule(t)
+	// Seed cc parent with an existing codex IsProxy ref.
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:codex:200:t200",
+		Type:            "codex",
+		StartedAt:       50,
+		SourcePID:       200,
+		SourceStartTime: "t200",
+		IsProxy:         true,
+	}}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed proxy ref: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// cc SessionStart on existing cc frame (same PID + start_time) — exists
+	// path triggers filter-merge-retry. Live + identity-verified codex ref
+	// must survive the reset.
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+
+	final, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if final == nil {
+		t.Fatalf("cc frame disappeared")
+	}
+	if len(final.Subagents) != 1 {
+		t.Fatalf("Subagents = %+v, want 1 (live codex proxy preserved)", final.Subagents)
+	}
+	ref := final.Subagents[0]
+	if !ref.IsProxy || ref.SourcePID != 200 || ref.SourceStartTime != "t200" {
+		t.Fatalf("ref = %+v, want codex proxy alive 200 t200", ref)
+	}
+	if final.LastSeenAt != 100 {
+		t.Fatalf("LastSeenAt = %d, want 100 (broadcastTs)", final.LastSeenAt)
+	}
+}
+
+// IT18 — existing_frame SessionStart filter-merge drops a proxy ref whose
+// SourcePID is dead (isPidAliveFn=false). Plan §2.2.2 negative case.
+func TestPhase35_IT18_ExistingFrameSessionStartSkipsDeadProxy(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:codex:200:t200",
+		Type:            "codex",
+		SourcePID:       200,
+		SourceStartTime: "t200",
+		IsProxy:         true,
+	}}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	// Codex PID 200 is dead.
+	isPidAliveFn = func(pid int) bool { return pid != 200 }
+	processStartTimeFn = func(pid int) (string, error) { return "t100", nil }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	final, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if final == nil {
+		t.Fatalf("cc frame disappeared")
+	}
+	if len(final.Subagents) != 0 {
+		t.Fatalf("Subagents = %+v, want empty (dead proxy dropped)", final.Subagents)
+	}
+}
+
+// IT19 — existing_frame SessionStart filter-merge drops a proxy ref whose
+// SourcePID is alive but stored start_time mismatches actualStart (PID
+// reused). Plan §2.2.2 negative case.
+func TestPhase35_IT19_ExistingFrameSessionStartSkipsPidReusedProxy(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:codex:200:stale-t200",
+		Type:            "codex",
+		SourcePID:       200,
+		SourceStartTime: "stale-t200",
+		IsProxy:         true,
+	}}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	// PID 200 alive but start_time changed (reused).
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 {
+			return "fresh-t200", nil
+		}
+		return "t100", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	final, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if final == nil {
+		t.Fatalf("cc frame disappeared")
+	}
+	if len(final.Subagents) != 0 {
+		t.Fatalf("Subagents = %+v, want empty (PID-reused proxy dropped)", final.Subagents)
+	}
+}
+
+// IT20 — filter-merge-retry preserves a proxy ref attached concurrently
+// during attempt 1 (race window between read and UpsertIfUnchanged).
+// Plan §2.2.2 v6 J1 regression guard.
+//
+// Setup: cc frame seeded with codex proxy ref at LastSeenAt=50.
+// applyFrameEvent's GetByIdentity reads frame at 50. processStartTimeFn
+// is hooked so that the FIRST call (during attempt 1's filter pass) writes
+// a concurrent opencode proxy ref into the row, bumping LastSeenAt to 60.
+// attempt 1's UpsertIfUnchanged(expected=50) then conflicts; reload picks
+// up both refs at LastSeenAt=60; attempt 2 filters both refs (alive),
+// IfUnchanged(expected=60) succeeds. Both refs survive — J1 violated
+// would have lost the opencode ref.
+func TestPhase35_IT20_ExistingFrameSessionStartPreservesConcurrentlyAttachedProxy(t *testing.T) {
+	m := newProxyTestModule(t)
+	// Seed cc with one codex proxy ref at LastSeenAt=50.
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:codex:200:t200",
+		Type:            "codex",
+		SourcePID:       200,
+		SourceStartTime: "t200",
+		IsProxy:         true,
+	}}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed cc + codex ref: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	// First call to processStartTimeFn(200) — happens during attempt 1's
+	// filter pass — triggers the concurrent attach side effect (+
+	// LastSeenAt bump to 60). Subsequent calls return start_time normally.
+	concurrentInjected := false
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 && !concurrentInjected {
+			concurrentInjected = true
+			racer, _ := m.frames.GetByIdentity("%5", 100, "t100")
+			if racer != nil {
+				racer.Subagents = append(racer.Subagents, agentpkg.SubagentRef{
+					ID:              "proxy:opencode:300:t300",
+					Type:            "opencode",
+					SourcePID:       300,
+					SourceStartTime: "t300",
+					IsProxy:         true,
+				})
+				racer.LastSeenAt = 60
+				if _, err := m.frames.Upsert(*racer); err != nil {
+					t.Fatalf("concurrent inject: %v", err)
+				}
+			}
+			return "t200", nil
+		}
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		case 300:
+			return "t300", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+
+	if !concurrentInjected {
+		t.Fatalf("concurrent inject hook never fired — filter-merge loop didn't run")
+	}
+
+	final, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if final == nil {
+		t.Fatalf("cc frame disappeared")
+	}
+	if len(final.Subagents) != 2 {
+		t.Fatalf("Subagents count = %d, want 2 (both proxies preserved across retry); refs=%+v", len(final.Subagents), final.Subagents)
+	}
+	ids := map[int]bool{}
+	for _, ref := range final.Subagents {
+		ids[ref.SourcePID] = true
+	}
+	if !ids[200] || !ids[300] {
+		t.Fatalf("ref SourcePIDs=%v, want both 200 and 300", ids)
+	}
+	if final.LastSeenAt != 100 {
+		t.Fatalf("LastSeenAt = %d, want 100 (broadcastTs from final write)", final.LastSeenAt)
+	}
+}
+
 // RC4b — positive case: live identity-verified cross-type descendant under
 // self.PID is folded into a proxy ref + standalone deleted.
 func TestCanonicalizeDescendantsAfterUpsert_FoldsLiveCrossTypeDescendant(t *testing.T) {

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -2073,3 +2073,195 @@ func TestApplyFrameEvent_RebuildSkipped_WhenParentFound(t *testing.T) {
 }
 
 func (e errorString) Error() string { return string(e) }
+
+// ---------------------------------------------------------------------------
+// Phase 3.5 PR-3.5a — Cold-start race canonicalization helpers
+// (plan §2.1.2 + §2.1.1 / §3.2 unit tests RC1-RC5)
+// ---------------------------------------------------------------------------
+
+// RC1 — pidIsAncestorOfWithCap returns false when the walk runs past
+// proxyMaxDepth before hitting the candidate ancestor.
+func TestPidIsAncestorOfWithCap_DepthExhaustion(t *testing.T) {
+	origInfo := readProcessInfoFn
+	// Each PID's PPID is one less, forming a long chain: 100→99→98→...→1.
+	// Looking for ancestorPID=1 starting at descendantPID=100 needs 99 hops
+	// — far exceeds proxyMaxDepth=5.
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: pid - 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	if pidIsAncestorOfWithCap(100, 1, proxyMaxDepth) {
+		t.Fatalf("expected false (depth exhausted before reaching ancestor)")
+	}
+}
+
+// RC2 — pidIsAncestorOfWithCap returns false when readProcessInfoFn returns
+// a self-loop (info.PPID == info.PID), preventing infinite walk.
+func TestPidIsAncestorOfWithCap_LoopDetectionPpidEqPid(t *testing.T) {
+	origInfo := readProcessInfoFn
+	// Descendant 200's parent is itself — loop guard must short-circuit.
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 200}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	if pidIsAncestorOfWithCap(200, 100, proxyMaxDepth) {
+		t.Fatalf("expected false (PPID == PID self-loop)")
+	}
+}
+
+// RC3 — pidIsAncestorOfWithCap returns false when readProcessInfoFn errors
+// out partway through the walk.
+func TestPidIsAncestorOfWithCap_ProcessInfoError(t *testing.T) {
+	origInfo := readProcessInfoFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{}, errProbeFailure
+	}
+	t.Cleanup(func() { readProcessInfoFn = origInfo })
+
+	if pidIsAncestorOfWithCap(200, 100, proxyMaxDepth) {
+		t.Fatalf("expected false (read error mid-walk)")
+	}
+}
+
+// RC4 — canonicalizeDescendantsAfterUpsert skips candidates whose AgentType
+// matches self.AgentType (same-type frames are not proxy-attachment subjects).
+func TestCanonicalizeDescendantsAfterUpsert_SkipsSameType(t *testing.T) {
+	m := newProxyTestModule(t)
+	// Self = cc PID 100. Candidate = cc PID 200 (same agent_type).
+	self := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	seedFrame(t, m, "%5", "cc", 200, "t200", 11)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	// 200's PPID = 100 — would normally pass ancestor check.
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 {
+			return "t200", nil
+		}
+		return "t100", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	updated, err := m.canonicalizeDescendantsAfterUpsert(self, 100)
+	if err != nil {
+		t.Fatalf("canonicalizeDescendantsAfterUpsert: %v", err)
+	}
+	if len(updated.Subagents) != 0 {
+		t.Fatalf("self.Subagents = %+v, want empty (same-type candidate skipped)", updated.Subagents)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frame count = %d, want 2 (no fold for same-type)", len(frames))
+	}
+}
+
+// RC5 — canonicalizeDescendantsAfterUpsert skips a candidate whose stored
+// ProcessStartTime no longer matches the live actualStart (PID reused).
+func TestCanonicalizeDescendantsAfterUpsert_SkipsPidReuseViaIdentityGate(t *testing.T) {
+	m := newProxyTestModule(t)
+	// Self = cc PID 100; descendant codex PID 200 stored with start_time
+	// "stale-t200" but live process at PID 200 reports "fresh-t200".
+	self := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	seedFrame(t, m, "%5", "codex", 200, "stale-t200", 11)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 {
+			return "fresh-t200", nil // mismatch with stored "stale-t200"
+		}
+		return "t100", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	updated, err := m.canonicalizeDescendantsAfterUpsert(self, 100)
+	if err != nil {
+		t.Fatalf("canonicalizeDescendantsAfterUpsert: %v", err)
+	}
+	if len(updated.Subagents) != 0 {
+		t.Fatalf("self.Subagents = %+v, want empty (identity gate fails)", updated.Subagents)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frame count = %d, want 2 (stale candidate left for sweep)", len(frames))
+	}
+}
+
+// RC4b — positive case: live identity-verified cross-type descendant under
+// self.PID is folded into a proxy ref + standalone deleted.
+func TestCanonicalizeDescendantsAfterUpsert_FoldsLiveCrossTypeDescendant(t *testing.T) {
+	m := newProxyTestModule(t)
+	self := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	candidate := seedFrame(t, m, "%5", "codex", 200, "t200", 11)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	updated, err := m.canonicalizeDescendantsAfterUpsert(self, 100)
+	if err != nil {
+		t.Fatalf("canonicalizeDescendantsAfterUpsert: %v", err)
+	}
+	if len(updated.Subagents) != 1 {
+		t.Fatalf("self.Subagents = %+v, want 1 proxy ref", updated.Subagents)
+	}
+	ref := updated.Subagents[0]
+	if !ref.IsProxy || ref.Type != "codex" || ref.SourcePID != 200 || ref.SourceStartTime != "t200" {
+		t.Fatalf("ref = %+v, want codex IsProxy=true source_pid=200 source_start_time=t200", ref)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (codex folded + deleted)", len(frames))
+	}
+	_ = candidate
+}

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -2622,6 +2622,112 @@ func TestPhase35_IT20_ExistingFrameSessionStartPreservesConcurrentlyAttachedProx
 	}
 }
 
+// IT21 — existing_frame SessionStart preserves a concurrently-attached
+// native subagent ref (IsProxy=false) across the filter-merge retry. Plan
+// §2.2.2 v8 M3 regression guard: the previous "keep only IsProxy" filter
+// dropped ALL native refs, so a SubagentStart that landed between
+// applyFrameEvent's GetByIdentity and the IfUnchanged conflict's reload
+// would silently disappear when attempt 2 re-filtered the reloaded
+// baseline.
+//
+// Setup mirrors IT20: cc frame seeded with one codex IsProxy ref at
+// LastSeenAt=50; processStartTimeFn(200)'s first call (during attempt 1's
+// prune pass) injects a concurrent native SubagentStart-style ref into
+// the row at LastSeenAt=60. attempt 1's IfUnchanged(expected=50) then
+// conflicts; reload picks up codex IsProxy + new native ref at 60;
+// attempt 2's prune pass keeps both (codex passes identity gate, native
+// is preserved by the new pruning semantics). IfUnchanged(expected=60)
+// succeeds. Both refs survive — M3 violated would have lost the native.
+func TestPhase35_IT21_ExistingFrameSessionStartPreservesConcurrentNativeSubagent(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:codex:200:t200",
+		Type:            "codex",
+		SourcePID:       200,
+		SourceStartTime: "t200",
+		IsProxy:         true,
+	}}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed cc + codex proxy: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	concurrentInjected := false
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 && !concurrentInjected {
+			concurrentInjected = true
+			racer, _ := m.frames.GetByIdentity("%5", 100, "t100")
+			if racer != nil {
+				// Native ref (IsProxy=false) — simulating a concurrent
+				// SubagentStart hook landing on cc's row.
+				racer.Subagents = append(racer.Subagents, agentpkg.SubagentRef{
+					ID:        "task-abc",
+					Type:      "cc",
+					StartedAt: 60,
+				})
+				racer.LastSeenAt = 60
+				if _, err := m.frames.Upsert(*racer); err != nil {
+					t.Fatalf("concurrent native inject: %v", err)
+				}
+			}
+			return "t200", nil
+		}
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+
+	if !concurrentInjected {
+		t.Fatalf("concurrent native inject hook never fired — filter-merge loop didn't run")
+	}
+
+	final, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if final == nil {
+		t.Fatalf("cc frame disappeared")
+	}
+	if len(final.Subagents) != 2 {
+		t.Fatalf("Subagents count = %d, want 2 (codex proxy + native task ref preserved); refs=%+v", len(final.Subagents), final.Subagents)
+	}
+	hasCodexProxy := false
+	hasNative := false
+	for _, ref := range final.Subagents {
+		if ref.IsProxy && ref.SourcePID == 200 {
+			hasCodexProxy = true
+		}
+		if !ref.IsProxy && ref.ID == "task-abc" {
+			hasNative = true
+		}
+	}
+	if !hasCodexProxy {
+		t.Fatalf("codex proxy ref missing from %+v", final.Subagents)
+	}
+	if !hasNative {
+		t.Fatalf("native task ref missing from %+v — M3 regression: native refs dropped by filter", final.Subagents)
+	}
+}
+
 // IT1 — descendant_then_ancestor_canonicalizes_via_descendant_scan.
 // codex SessionStart lands first (no cc parent yet → standalone codex).
 // cc SessionStart lands second (new-frame Upsert + descendant scan finds

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -3146,22 +3146,24 @@ func TestPhase35_IT15_PartialMetricIncrementsOnPartialState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("applyFrameEvent: %v", err)
 	}
-	// Partial path returns canonicalized=false → caller falls through to
-	// descendant scan (no candidates) → emits a created_frame trace
-	// (no partial reason — plan §2.5 dropped partial_canonicalization).
-	if meta.Decision != "created_frame" {
-		t.Fatalf("decision = %q, want created_frame (partial path falls through)", meta.Decision)
+	// v8 M4 fix: partial path now reports canonicalized=true so the
+	// caller emits the updated_frame / post_upsert_canonicalization_self
+	// trace consistent with what the SPA actually sees (projection dedup
+	// hides the orphan child; user-visible state is parent + proxy ref).
+	// Reporting created_frame would have desynced trace from projection.
+	if meta.Decision != "updated_frame" {
+		t.Fatalf("decision = %q, want updated_frame (partial reports canonicalized=true so trace matches projection)", meta.Decision)
 	}
-	if meta.Reason == "post_upsert_canonicalization_self" {
-		t.Fatalf("reason = %q, must not claim canonicalize success on partial", meta.Reason)
+	if meta.Reason != "post_upsert_canonicalization_self" {
+		t.Fatalf("reason = %q, want post_upsert_canonicalization_self", meta.Reason)
 	}
 
 	if delta := agentpkg.MetricPartialCanonicalizationCreated.Value() - startMetric; delta < 1 {
-		t.Fatalf("MetricPartialCanonicalizationCreated delta = %d, want >= 1", delta)
+		t.Fatalf("MetricPartialCanonicalizationCreated delta = %d, want >= 1 (partial state metric still increments)", delta)
 	}
 
 	// Final state: parent has codex proxy ref (partial); codex standalone
-	// row remains.
+	// row remains. Sweep canonicalize (PR-3.5b) repairs within 2s.
 	frames, _ := m.frames.ListByPane("%5")
 	if len(frames) != 2 {
 		t.Fatalf("frames count = %d, want 2 (parent + standalone partial)", len(frames))

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -2297,6 +2297,142 @@ func TestPhase35_IT22_DescendantScanSkipsCandidateWithSubagents(t *testing.T) {
 	}
 }
 
+// IT22b — codex round 2 #O2 fix: descendant scan FOLDS a candidate whose
+// only Subagents are stale dead IsProxy refs. The previous len > 0 guard
+// over-protected: a candidate carrying a single dead-source IsProxy (e.g.
+// a stale ref left over from PR-2b's filter-merge missing a hook race)
+// still represents a race-window standalone whose own state is empty
+// (the dead IsProxy doesn't represent live state — sweep prune would
+// remove it). Folding such a candidate is safe because the dead ref is
+// dropped along with the candidate row.
+func TestPhase35_IT22b_DescendantScanFoldsCandidateWithOnlyStaleProxyRef(t *testing.T) {
+	m := newProxyTestModule(t)
+	self := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	candidate := seedFrame(t, m, "%5", "codex", 200, "t200", 11)
+	// Candidate has only a STALE dead IsProxy ref (source PID 999 is
+	// dead). No native refs, no live identity-verified IsProxy refs.
+	candidate.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:opencode:999:t999-dead",
+		Type:            "opencode",
+		SourcePID:       999,
+		SourceStartTime: "t999-dead",
+		IsProxy:         true,
+	}}
+	candidate.LastSeenAt = 12
+	if _, err := m.frames.Upsert(candidate); err != nil {
+		t.Fatalf("seed candidate with stale dead proxy: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	// PID 999 (the stale ref's source) is DEAD. Self (100) and candidate
+	// (200) are alive.
+	isPidAliveFn = func(pid int) bool {
+		return pid != 999
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	updated, err := m.canonicalizeDescendantsAfterUpsert(self, 100)
+	if err != nil {
+		t.Fatalf("canonicalizeDescendantsAfterUpsert: %v", err)
+	}
+	// candidate should be folded: cc.Subagents now contains a codex IsProxy
+	// ref (the stale opencode ref is gone, dropped along with the
+	// candidate frame).
+	if len(updated.Subagents) != 1 {
+		t.Fatalf("self.Subagents = %+v, want 1 codex IsProxy ref (candidate folded; stale opencode dropped)", updated.Subagents)
+	}
+	ref := updated.Subagents[0]
+	if !ref.IsProxy || ref.SourcePID != 200 {
+		t.Fatalf("ref = %+v, want codex IsProxy SourcePID=200", ref)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].FrameID != self.FrameID {
+		t.Fatalf("frames = %+v, want only cc surviving (codex deleted by fold)", frames)
+	}
+}
+
+// IT22c — codex round 2 #O2 fix (negative case): descendant scan still
+// SKIPS a candidate carrying a live identity-verified IsProxy ref. The
+// live IsProxy represents real owned state — folding would lose it.
+func TestPhase35_IT22c_DescendantScanSkipsCandidateWithLiveProxyRef(t *testing.T) {
+	m := newProxyTestModule(t)
+	self := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	candidate := seedFrame(t, m, "%5", "codex", 200, "t200", 11)
+	// Candidate has a LIVE identity-verified IsProxy ref (source PID 300
+	// is alive + start_time matches).
+	candidate.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:opencode:300:t300",
+		Type:            "opencode",
+		SourcePID:       300,
+		SourceStartTime: "t300",
+		IsProxy:         true,
+	}}
+	candidate.LastSeenAt = 12
+	if _, err := m.frames.Upsert(candidate); err != nil {
+		t.Fatalf("seed candidate with live proxy: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		case 300:
+			return "t300", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	updated, err := m.canonicalizeDescendantsAfterUpsert(self, 100)
+	if err != nil {
+		t.Fatalf("canonicalizeDescendantsAfterUpsert: %v", err)
+	}
+	if len(updated.Subagents) != 0 {
+		t.Fatalf("self.Subagents = %+v, want empty (candidate skipped — owns live IsProxy state)", updated.Subagents)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frame count = %d, want 2 (candidate not folded)", len(frames))
+	}
+}
+
 // codex applyFrameEvent: pre-walk findProxyParent misses (cc not yet
 // visible to walk; readProcessInfoFn returns dud PPID on calls 1+2),
 // then reconcile post-Upsert hits (cc visible on call 3+; readProcessInfoFn

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -2622,6 +2622,611 @@ func TestPhase35_IT20_ExistingFrameSessionStartPreservesConcurrentlyAttachedProx
 	}
 }
 
+// IT1 — descendant_then_ancestor_canonicalizes_via_descendant_scan.
+// codex SessionStart lands first (no cc parent yet → standalone codex).
+// cc SessionStart lands second (new-frame Upsert + descendant scan finds
+// codex via PPID 200 → 100 + folds it). Verifies plan §2.2.1 descendant
+// scan path on the new-frame branch.
+func TestPhase35_IT1_DescendantThenAncestorCanonicalizesViaDescendantScan(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 1}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// codex first → standalone (no cc parent yet).
+	codexReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	if _, _, err := m.applyFrameEvent(codexReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 50); err != nil {
+		t.Fatalf("codex apply: %v", err)
+	}
+	mid, _ := m.frames.ListByPane("%5")
+	if len(mid) != 1 || mid[0].AgentType != "codex" {
+		t.Fatalf("after codex SessionStart: frames=%+v, want 1 standalone codex", mid)
+	}
+
+	// cc next → Upsert + descendant scan folds codex.
+	ccReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(ccReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("cc apply: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("final frames = %+v, want 1 cc", frames)
+	}
+	if len(frames[0].Subagents) != 1 || frames[0].Subagents[0].SourcePID != 200 {
+		t.Fatalf("cc.Subagents = %+v, want 1 codex proxy", frames[0].Subagents)
+	}
+
+	// projection top must be cc.
+	proj, _ := m.projectPane("%5")
+	if proj == nil || proj.TopFrame == nil || proj.TopFrame.AgentType != "cc" {
+		t.Fatalf("projection top = %+v, want cc", proj)
+	}
+}
+
+// IT2 — ancestor_then_descendant via PR-2b fast-path. cc first creates a
+// frame; codex follows under cc's PPID chain → existing pre-Upsert
+// findProxyParent fast-path collapses codex into a proxy ref. Sanity
+// check that PR-3.5a wiring did not regress PR-2b behavior.
+func TestPhase35_IT2_AncestorThenDescendantUsesPR2bFastPath(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 1}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// cc first.
+	ccReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(ccReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 50); err != nil {
+		t.Fatalf("cc apply: %v", err)
+	}
+
+	// codex → PR-2b fast-path collapses.
+	codexReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(codexReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("codex apply: %v", err)
+	}
+	if meta.Reason != "proxy_subagent_attached" {
+		t.Fatalf("reason = %q, want proxy_subagent_attached (PR-2b fast-path)", meta.Reason)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("frames = %+v, want 1 cc", frames)
+	}
+	if len(frames[0].Subagents) != 1 || frames[0].Subagents[0].SourcePID != 200 {
+		t.Fatalf("Subagents = %+v, want 1 codex proxy", frames[0].Subagents)
+	}
+}
+
+// IT6 — descendant_scan_partial_skip_does_not_block_others. Two standalone
+// children (codex + opencode); concurrent writer bumps codex's LastSeenAt
+// during the scan so DeleteIfUnchanged for codex fails (partial state) but
+// opencode's delete succeeds. cc's descendant scan attaches both proxy
+// refs but only deletes opencode's standalone row.
+func TestPhase35_IT6_DescendantScanPartialDoesNotBlockOthers(t *testing.T) {
+	m := newProxyTestModule(t)
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "opencode",
+		derive:   func(string, json.RawMessage) agentpkg.DeriveResult { return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle} },
+	})
+
+	// Seed two standalone children directly (skip applyFrameEvent paths so
+	// state is exactly: cc not in DB yet, codex + opencode standalone).
+	codex := seedFrame(t, m, "%5", "codex", 200, "t200", 11)
+	openc := seedFrame(t, m, "%5", "opencode", 300, "t300", 12)
+	_ = codex
+	_ = openc
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200, 300:
+			return agentpkg.ProcessInfo{PID: pid, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 1}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	// Hook on processStartTimeFn(200) → bump codex's LastSeenAt to force
+	// its DeleteIfUnchanged to fail. Fires once per applyFrameEvent run.
+	bumped := false
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			if !bumped {
+				bumped = true
+				cur, _ := m.frames.GetByIdentity("%5", 200, "t200")
+				if cur != nil {
+					cur.LastSeenAt = 999
+					if _, err := m.frames.Upsert(*cur); err != nil {
+						t.Fatalf("bump codex: %v", err)
+					}
+				}
+			}
+			return "t200", nil
+		case 300:
+			return "t300", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	startMetric := agentpkg.MetricPartialCanonicalizationCreated.Value()
+	ccReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(ccReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 200); err != nil {
+		t.Fatalf("cc apply: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	// Expect: cc + codex standalone (delete failed). opencode folded + deleted.
+	if len(frames) != 2 {
+		t.Fatalf("frames count = %d, want 2 (cc + codex partial); frames=%+v", len(frames), frames)
+	}
+	var ccFrame *store.Frame
+	for i := range frames {
+		if frames[i].AgentType == "cc" {
+			ccFrame = &frames[i]
+		}
+	}
+	if ccFrame == nil {
+		t.Fatalf("no cc frame found")
+	}
+	// cc.Subagents must contain BOTH codex (partial — proxy attached, child
+	// not yet deleted) and opencode proxy refs.
+	pids := map[int]bool{}
+	for _, ref := range ccFrame.Subagents {
+		pids[ref.SourcePID] = true
+	}
+	if !pids[200] || !pids[300] {
+		t.Fatalf("cc.Subagents SourcePIDs = %v, want both 200 + 300", pids)
+	}
+
+	// Partial metric must have incremented at least once for codex.
+	if delta := agentpkg.MetricPartialCanonicalizationCreated.Value() - startMetric; delta < 1 {
+		t.Fatalf("MetricPartialCanonicalizationCreated delta = %d, want >= 1 (codex partial)", delta)
+	}
+}
+
+// IT7 — existing_frame_session_start_runs_descendant_scan_only.
+// (a) cc creates frame; (b) codex lands standalone (race); (c) cc gets
+// SessionStart again — existing-frame filter-merge path runs descendant
+// scan and folds codex.
+func TestPhase35_IT7_ExistingFrameSessionStartDescendantScan(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 1}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// (a) cc SessionStart.
+	ccReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(ccReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 50); err != nil {
+		t.Fatalf("cc apply 1: %v", err)
+	}
+
+	// (b) Inject codex standalone directly (simulating cold-start race that
+	// raced past PR-2b's pre-walk in real conditions).
+	codex := seedFrame(t, m, "%5", "codex", 200, "t200", 60)
+	_ = codex
+
+	// (c) cc SessionStart again (existing frame). Filter-merge path +
+	// descendant scan should fold codex.
+	if _, _, err := m.applyFrameEvent(ccReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("cc apply 2: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("frames = %+v, want 1 cc", frames)
+	}
+	if len(frames[0].Subagents) != 1 || frames[0].Subagents[0].SourcePID != 200 {
+		t.Fatalf("Subagents = %+v, want 1 codex proxy ref", frames[0].Subagents)
+	}
+}
+
+// IT8 — non_session_start_event_no_canonicalization. Notification event
+// in frame == nil path goes through legacy create-frame behavior;
+// reconcile + descendant scan are gated on req.EventName == "SessionStart"
+// so they must NOT trigger.
+func TestPhase35_IT8_NonSessionStartEventNoCanonicalization(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	// Seed cc parent so a candidate ancestor exists in the pane.
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// codex Notification (non-SessionStart). Should hit fallback create-
+	// frame and emit created_frame trace; no canonicalization.
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "Notification", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Decision != "created_frame" {
+		t.Fatalf("decision = %q, want created_frame", meta.Decision)
+	}
+	if meta.Reason == "post_upsert_canonicalization_self" {
+		t.Fatalf("reason = %q, must not be canonicalization for non-SessionStart", meta.Reason)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frames count = %d, want 2 (cc + standalone codex)", len(frames))
+	}
+}
+
+// IT9 — filter-merge-retry exhaustion aborts applyFrameEvent. Storage
+// errors and exhausted-retry both surface to the caller as a non-nil
+// error from applyFrameEvent. We exercise the exhausted-retry surface
+// (mutateSubagentsWithRetry / filter-merge-retry caller) because the
+// concrete sqlite path can be triggered without a store interface seam.
+//
+// Setup: cc frame with one live codex proxy ref. processStartTimeFn(200)
+// is hooked to bump cc's LastSeenAt on every call — fires once per
+// filter-merge attempt's filter pass — so each UpsertIfUnchanged sees
+// its expected LastSeenAt was already mutated by the bump that just ran
+// during the same attempt's filter scan. Three attempts conflict back-
+// to-back → exhausted error → applyFrameEvent propagates.
+func TestPhase35_IT9_FilterMergeExhaustedRetryAbortsApply(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:codex:200:t200",
+		Type:            "codex",
+		SourcePID:       200,
+		SourceStartTime: "t200",
+		IsProxy:         true,
+	}}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed cc + ref: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	// Every call to processStartTimeFn(200) bumps cc's row — fires on each
+	// filter pass, so each attempt's UpsertIfUnchanged conflicts.
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 {
+			cur, _ := m.frames.GetByIdentity("%5", 100, "t100")
+			if cur != nil {
+				cur.LastSeenAt = cur.LastSeenAt + 1
+				if _, err := m.frames.Upsert(*cur); err != nil {
+					t.Fatalf("bump cc: %v", err)
+				}
+			}
+			return "t200", nil
+		}
+		return "t100", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// cc SessionStart on existing cc frame triggers filter-merge-retry.
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	_, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err == nil {
+		t.Fatalf("expected exhausted-retry error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("error = %v, want 'exceeded' retry message", err)
+	}
+}
+
+// IT11 — descendant_scan_skips_pid_reuse_stale at end-to-end level.
+// pane has a stale codex standalone (PID reused; actualStart != stored).
+// cc SessionStart's descendant scan must skip it (identity gate fails),
+// leave the row for sweep, and not fold a stale ref.
+func TestPhase35_IT11_DescendantScanSkipsPidReuseStale(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	// Seed stale codex with stored start_time "stale-t200".
+	seedFrame(t, m, "%5", "codex", 200, "stale-t200", 11)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 1}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	// PID 200 alive, but actualStart = "fresh-t200" ≠ stored "stale-t200".
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "fresh-t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	ccReq := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(ccReq, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("cc apply: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frames count = %d, want 2 (cc + stale codex left for sweep)", len(frames))
+	}
+	var ccFrame *store.Frame
+	for i := range frames {
+		if frames[i].AgentType == "cc" {
+			ccFrame = &frames[i]
+		}
+	}
+	if ccFrame == nil {
+		t.Fatalf("no cc frame found")
+	}
+	if len(ccFrame.Subagents) != 0 {
+		t.Fatalf("cc.Subagents = %+v, want empty (stale candidate skipped by identity gate)", ccFrame.Subagents)
+	}
+}
+
+// IT15 — partial_metric_increments_on_partial_state. mock DeleteIfUnchanged
+// (via LastSeenAt bump hook) → reconcile partial path runs in the new-
+// frame branch, MetricPartialCanonicalizationCreated +1.
+func TestPhase35_IT15_PartialMetricIncrementsOnPartialState(t *testing.T) {
+	m := newProxyTestModule(t)
+	// Seed cc parent so reconcile finds an ancestor.
+	seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: pidPPIDForIT15()}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	// Hook on processStartTimeFn(100) — fires inside reconcile's
+	// findProxyParent identity gate AFTER the codex standalone has been
+	// Upserted but BEFORE DeleteIfUnchanged. Bump codex's LastSeenAt to
+	// force the IfUnchanged delete to fail (partial state).
+	bumped := false
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			if !bumped {
+				bumped = true
+				cur, _ := m.frames.GetByIdentity("%5", 200, "t200")
+				if cur != nil {
+					cur.LastSeenAt = 999
+					if _, err := m.frames.Upsert(*cur); err != nil {
+						t.Fatalf("bump codex: %v", err)
+					}
+				}
+			}
+			return "t100", nil
+		}
+		if pid == 200 {
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		phase35IT15Reset()
+	})
+
+	startMetric := agentpkg.MetricPartialCanonicalizationCreated.Value()
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "codex", SenderPID: 200, SenderStartTime: "t200"}
+	_, meta, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	// Partial path returns canonicalized=false → caller falls through to
+	// descendant scan (no candidates) → emits a created_frame trace
+	// (no partial reason — plan §2.5 dropped partial_canonicalization).
+	if meta.Decision != "created_frame" {
+		t.Fatalf("decision = %q, want created_frame (partial path falls through)", meta.Decision)
+	}
+	if meta.Reason == "post_upsert_canonicalization_self" {
+		t.Fatalf("reason = %q, must not claim canonicalize success on partial", meta.Reason)
+	}
+
+	if delta := agentpkg.MetricPartialCanonicalizationCreated.Value() - startMetric; delta < 1 {
+		t.Fatalf("MetricPartialCanonicalizationCreated delta = %d, want >= 1", delta)
+	}
+
+	// Final state: parent has codex proxy ref (partial); codex standalone
+	// row remains.
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frames count = %d, want 2 (parent + standalone partial)", len(frames))
+	}
+}
+
+// IT15 PPID toggle: same pattern as IT3/IT9 — calls 1+2 return 999, then
+// 100. Lets PR-2b pre-walk miss while reconcile post-walk hits cc.
+var phase35IT15Calls int
+
+func pidPPIDForIT15() int {
+	phase35IT15Calls++
+	if phase35IT15Calls <= 2 {
+		return 999
+	}
+	return 100
+}
+
+func phase35IT15Reset() { phase35IT15Calls = 0 }
+
+// IT16 — projection_dedup_metric_increments across multiple panes.
+func TestPhase35_IT16_ProjectionDedupMetricIncrements(t *testing.T) {
+	m := newProxyTestModule(t)
+
+	// Pane %5: cc with codex proxy ref + codex standalone (partial).
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:codex:200:t200",
+		Type:            "codex",
+		SourcePID:       200,
+		SourceStartTime: "t200",
+		IsProxy:         true,
+	}}
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed pane 1: %v", err)
+	}
+	seedFrame(t, m, "%5", "codex", 200, "t200", 50)
+
+	// Pane %6: codex with cc proxy ref + cc standalone (partial).
+	parent2 := seedFrame(t, m, "%6", "codex", 400, "t400", 10)
+	parent2.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:cc:300:t300",
+		Type:            "cc",
+		SourcePID:       300,
+		SourceStartTime: "t300",
+		IsProxy:         true,
+	}}
+	if _, err := m.frames.Upsert(parent2); err != nil {
+		t.Fatalf("seed pane 2: %v", err)
+	}
+	seedFrame(t, m, "%6", "cc", 300, "t300", 50)
+
+	startMetric := agentpkg.MetricProjectionDedupHidden.Value()
+	if _, err := m.projectPane("%5"); err != nil {
+		t.Fatalf("projectPane %%5: %v", err)
+	}
+	if _, err := m.projectPane("%6"); err != nil {
+		t.Fatalf("projectPane %%6: %v", err)
+	}
+	delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric
+	if delta != 2 {
+		t.Fatalf("MetricProjectionDedupHidden delta = %d, want +2 (one per pane)", delta)
+	}
+}
+
 // IT12 — session_end_clears_parent_proxy_ref (plan §2.3 / Side B SessionEnd
 // hot-path cleanup). Partial state: cc parent has codex proxy ref +
 // codex standalone frame. codex SessionEnd must delete its own frame AND

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -2222,6 +2222,81 @@ func TestCanonicalizeDescendantsAfterUpsert_SkipsPidReuseViaIdentityGate(t *test
 // ---------------------------------------------------------------------------
 
 // IT3 — concurrent_descendant_first_then_reconcile_hits_post_upsert.
+// IT22 — descendant scan skips a candidate that has accumulated its own
+// subagent state (native SubagentRef from a SubagentStart hook, or its own
+// IsProxy ref). Plan §2.1.2 v8 M2 regression guard: previously the scan
+// folded any cross-type live PPID-descendant unconditionally, so a codex
+// frame that had already attached its own task ref would be DELETE'd in
+// the fold, silently losing that ref. Race-window standalones safe to
+// fold have empty Subagents; len(candidate.Subagents) > 0 is the signal
+// the candidate owns state we must preserve.
+func TestPhase35_IT22_DescendantScanSkipsCandidateWithSubagents(t *testing.T) {
+	m := newProxyTestModule(t)
+	self := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	candidate := seedFrame(t, m, "%5", "codex", 200, "t200", 11)
+	// Candidate has its own native subagent ref (e.g. from a previous
+	// SubagentStart hook landing on the codex frame).
+	candidate.Subagents = []agentpkg.SubagentRef{{
+		ID:        "task-codex-1",
+		Type:      "codex",
+		StartedAt: 12,
+	}}
+	candidate.LastSeenAt = 12
+	if _, err := m.frames.Upsert(candidate); err != nil {
+		t.Fatalf("seed candidate with subagents: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	// PPID chain would otherwise fold codex into cc.
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	updated, err := m.canonicalizeDescendantsAfterUpsert(self, 100)
+	if err != nil {
+		t.Fatalf("canonicalizeDescendantsAfterUpsert: %v", err)
+	}
+	if len(updated.Subagents) != 0 {
+		t.Fatalf("self.Subagents = %+v, want empty (candidate skipped because it owns subagent state)", updated.Subagents)
+	}
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frame count = %d, want 2 (candidate not folded); frames=%+v", len(frames), frames)
+	}
+	var preservedCodex *store.Frame
+	for i := range frames {
+		if frames[i].AgentType == "codex" {
+			preservedCodex = &frames[i]
+		}
+	}
+	if preservedCodex == nil {
+		t.Fatalf("codex frame deleted; frames=%+v", frames)
+	}
+	if len(preservedCodex.Subagents) != 1 || preservedCodex.Subagents[0].ID != "task-codex-1" {
+		t.Fatalf("codex.Subagents = %+v, want preserved native task ref", preservedCodex.Subagents)
+	}
+}
+
 // codex applyFrameEvent: pre-walk findProxyParent misses (cc not yet
 // visible to walk; readProcessInfoFn returns dud PPID on calls 1+2),
 // then reconcile post-Upsert hits (cc visible on call 3+; readProcessInfoFn

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -2803,6 +2803,184 @@ func TestPhase35_IT21_ExistingFrameSessionStartPreservesConcurrentNativeSubagent
 	}
 }
 
+// IT21b — existing_frame SessionStart preserves natives that arrive across
+// MULTIPLE conflict retries. Codex round 2 #O1 regression guard: the
+// prevWrittenNativeIDs strategy (v8 M3) preserved natives that appeared
+// after attempt 0 once, but then recorded them in prevWrittenNativeIDs
+// itself — so a second IfUnchanged conflict (e.g. probe status update +
+// another concurrent attach) caused attempt 2 to "drop" what attempt 1
+// had just preserved, racing the native into oblivion. The fix is the
+// initialNativeIDs baseline: snapshot the BASELINE native ID set before
+// the retry loop and only drop those across all retries; any native
+// appearing in a reloaded frame after baseline snapshot is unconditionally
+// concurrent and preserved.
+//
+// Setup — three concurrent attaches across two conflicts:
+//   - cc seeded with one BASELINE native (baseline-task-1) at LastSeenAt=50
+//   - attempt 0 conflict (mock — bump LastSeenAt to 60 + add concurrent-task-1)
+//   - attempt 1 conflict (mock — bump LastSeenAt to 70 + add concurrent-task-2)
+//   - attempt 2 succeeds
+//
+// Assertions: final.Subagents contains concurrent-task-1 + concurrent-task-2;
+// baseline-task-1 is dropped (SessionStart reset semantic).
+func TestPhase35_IT21b_ExistingFrameSessionStartPreservesNativeAcrossMultiConflict(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:        "baseline-task-1",
+		Type:      "cc",
+		StartedAt: 5,
+	}}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed cc + baseline native: %v", err)
+	}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	// We don't have IsProxy refs in this test, so the filter loop's
+	// processStartTimeFn calls only happen for non-existent IsProxy refs
+	// (zero in baseline). Drive the conflict via a counter on a different
+	// seam: each attempt's UpsertIfUnchanged will reload, and we use a
+	// counter to simulate concurrent natives appearing during reload via
+	// readProcessInfoFn (but readProcessInfoFn is also called once before
+	// the loop). Instead, drive the race via a per-attempt counter on
+	// processStartTimeFn — but we have no IsProxy refs to trigger it.
+	//
+	// Simpler approach: inject natives BEFORE applyFrameEvent's first
+	// reload by piggy-backing on isPidAliveFn (called for every IsProxy
+	// in the loop — but we have no IsProxy refs). Final approach: use
+	// readProcessInfoFn (called once before the loop) to set up a
+	// counter-driven concurrent inject directly via a side channel.
+	//
+	// Cleanest: put the inject in a custom seam. Since we don't have an
+	// existing per-attempt seam to hook for native-only frames, we'll
+	// instead use TWO IsProxy refs in the baseline (which will be kept
+	// across conflicts because they pass identity check) to drive the
+	// processStartTimeFn count, and the seeded native (baseline-task-1)
+	// to verify reset semantic.
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	// Reseed with two IsProxy refs (PIDs 200, 300) so processStartTimeFn
+	// is called at least twice per filter pass — gives us a counter to
+	// drive concurrent inject across attempts.
+	parent.Subagents = []agentpkg.SubagentRef{
+		{
+			ID:        "baseline-task-1",
+			Type:      "cc",
+			StartedAt: 5,
+		},
+		{
+			ID:              "proxy:codex:200:t200",
+			Type:            "codex",
+			SourcePID:       200,
+			SourceStartTime: "t200",
+			IsProxy:         true,
+		},
+	}
+	parent.LastSeenAt = 50
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+
+	// Counter on processStartTimeFn(200): each invocation corresponds to
+	// one filter pass. Inject concurrent natives BEFORE the IfUnchanged
+	// write at the END of attempts 0 and 1 — but processStartTimeFn runs
+	// at the START of each attempt's filter pass. Instead use a hook on
+	// each call AFTER the filter pass: rely on the fact that each attempt
+	// calls processStartTimeFn(200) exactly once (the lone IsProxy in the
+	// reloaded baseline). For each call N (1-indexed), at the END of the
+	// callback inject the racer that conflicts THIS attempt's write.
+	attempt := 0
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		if pid != 200 {
+			return "other", nil
+		}
+		// Each call indicates we're in attempt N's filter pass for the
+		// codex IsProxy ref. After returning, applyFrameEvent will issue
+		// IfUnchanged. To force a conflict, mutate the row right now —
+		// the LastSeenAt bump invalidates the optimistic write.
+		attempt++
+		if attempt <= 2 {
+			racer, _ := m.frames.GetByIdentity("%5", 100, "t100")
+			if racer != nil {
+				newID := "concurrent-task-" + map[int]string{1: "1", 2: "2"}[attempt]
+				racer.Subagents = append(racer.Subagents, agentpkg.SubagentRef{
+					ID:        newID,
+					Type:      "cc",
+					StartedAt: int64(60 + 10*attempt),
+				})
+				racer.LastSeenAt = int64(50 + 10*attempt)
+				if _, err := m.frames.Upsert(*racer); err != nil {
+					t.Fatalf("concurrent inject attempt=%d: %v", attempt, err)
+				}
+			}
+		}
+		return "t200", nil
+	}
+
+	req := EventRequest{TmuxSession: "work", TmuxPaneID: "%5", EventName: "SessionStart", AgentType: "cc", SenderPID: 100, SenderStartTime: "t100"}
+	if _, _, err := m.applyFrameEvent(req, agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}, 100); err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+
+	if attempt < 3 {
+		t.Fatalf("filter-merge ran only %d attempts, expected at least 3 (2 conflicts + final success)", attempt)
+	}
+
+	final, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if final == nil {
+		t.Fatalf("cc frame disappeared")
+	}
+	hasBaseline := false
+	hasConcurrent1 := false
+	hasConcurrent2 := false
+	hasCodexProxy := false
+	for _, ref := range final.Subagents {
+		switch {
+		case !ref.IsProxy && ref.ID == "baseline-task-1":
+			hasBaseline = true
+		case !ref.IsProxy && ref.ID == "concurrent-task-1":
+			hasConcurrent1 = true
+		case !ref.IsProxy && ref.ID == "concurrent-task-2":
+			hasConcurrent2 = true
+		case ref.IsProxy && ref.SourcePID == 200:
+			hasCodexProxy = true
+		}
+	}
+	if hasBaseline {
+		t.Fatalf("baseline-task-1 still present in %+v — SessionStart reset must drop initial natives", final.Subagents)
+	}
+	if !hasConcurrent1 {
+		t.Fatalf("concurrent-task-1 missing from %+v — multi-conflict regression: attempt 2's filter dropped it (initialNativeIDs baseline broken)", final.Subagents)
+	}
+	if !hasConcurrent2 {
+		t.Fatalf("concurrent-task-2 missing from %+v — last-conflict native wasn't preserved", final.Subagents)
+	}
+	if !hasCodexProxy {
+		t.Fatalf("codex IsProxy ref missing from %+v — proxy preservation regression", final.Subagents)
+	}
+}
+
 // IT1 — descendant_then_ancestor_canonicalizes_via_descendant_scan.
 // codex SessionStart lands first (no cc parent yet → standalone codex).
 // cc SessionStart lands second (new-frame Upsert + descendant scan finds

--- a/internal/module/agent/projection.go
+++ b/internal/module/agent/projection.go
@@ -65,8 +65,20 @@ func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection 
 	var hidden int
 	for _, frame := range frames {
 		if claimed[claim{frame.PID, frame.ProcessStartTime}] {
-			hidden++
-			continue
+			// Codex round 2 #Q1: dedup hides race-window standalones
+			// (no own state) so SPA sees the canonical parent + proxy
+			// ref. But if a partial canonicalization (parent attached
+			// proxy ref + DeleteIfUnchanged failed) is followed by a
+			// concurrent SubagentStart on the still-standalone child,
+			// the child has accumulated its own native ref. Hiding
+			// such a frame would erase that ref from projection — the
+			// parent's IsProxy ref aggregates the child as a single
+			// dot, not a fan-out. Keep stateful children visible
+			// until sweep canonicalize (PR-3.5b) migrates the refs.
+			if len(frame.Subagents) == 0 {
+				hidden++
+				continue
+			}
 		}
 		visible = append(visible, frame)
 	}

--- a/internal/module/agent/projection.go
+++ b/internal/module/agent/projection.go
@@ -122,16 +122,39 @@ func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection 
 		subagents = []agentpkg.SubagentRef{}
 	}
 	// R1 merge: append refs from hidden stateful children that aren't
-	// already represented in TopFrame.Subagents. Dedup uses the kind-
-	// aware identity matcher (proxy refs by SourcePID+SourceStartTime,
-	// native by ID; cross-kind never matches) so we never double-list
-	// the same logical subagent.
+	// already represented in TopFrame.Subagents.
+	//
+	// Codex round 4 #S1: dedup must be owner-aware here because frames
+	// being merged come from different agent families. subagentRefMatches
+	// compares native refs by ID alone (correct WITHIN a frame, where the
+	// same agent family doesn't generate colliding IDs), but cross-frame
+	// native IDs are independent ID spaces — cc's "call-1" and codex's
+	// "call-1" are distinct subagents. Inline owner-aware dedup:
+	//   - Proxy refs: dedup by (SourcePID, SourceStartTime). IsProxy
+	//     claims target the SAME source process across frames, so the
+	//     identity carries across the frame boundary.
+	//   - Native refs: dedup by (Type, ID). Different Type means a
+	//     different agent family, hence a different ID space.
+	// subagentRefMatches semantics are unchanged — within-frame callers
+	// in frame_ops.go (SubagentStart/Stop on a single frame) never see a
+	// cross-family collision because each frame belongs to one family.
 	for _, refFromHidden := range mergedFromHidden {
 		duplicate := false
 		for _, existing := range subagents {
-			if subagentRefMatches(existing, refFromHidden) {
-				duplicate = true
-				break
+			if refFromHidden.IsProxy {
+				if existing.IsProxy &&
+					existing.SourcePID == refFromHidden.SourcePID &&
+					existing.SourceStartTime == refFromHidden.SourceStartTime {
+					duplicate = true
+					break
+				}
+			} else {
+				if !existing.IsProxy &&
+					existing.Type == refFromHidden.Type &&
+					existing.ID == refFromHidden.ID {
+					duplicate = true
+					break
+				}
 			}
 		}
 		if !duplicate {

--- a/internal/module/agent/projection.go
+++ b/internal/module/agent/projection.go
@@ -63,22 +63,31 @@ func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection 
 
 	visible := make([]store.Frame, 0, len(frames))
 	var hidden int
+	// Codex round 3 #R1: collect Subagents from claimed-and-stateful
+	// frames so their refs survive into the projection even though the
+	// child frame is suppressed by dedup. Without this, the partial-
+	// canonicalization race (reconcileCreatedFrameAsProxy attached the
+	// child as proxy on parent then DeleteIfUnchanged failed) followed
+	// by a concurrent SubagentStart on the child leaves wire-format
+	// dropping either the parent's proxy ref (if child becomes Top) or
+	// the child's native ref (if parent becomes Top). Merging into
+	// output preserves both on the canonical parent's subagents list
+	// until sweep canonicalize (PR-3.5b) migrates the refs.
+	var mergedFromHidden []agentpkg.SubagentRef
 	for _, frame := range frames {
 		if claimed[claim{frame.PID, frame.ProcessStartTime}] {
-			// Codex round 2 #Q1: dedup hides race-window standalones
-			// (no own state) so SPA sees the canonical parent + proxy
-			// ref. But if a partial canonicalization (parent attached
-			// proxy ref + DeleteIfUnchanged failed) is followed by a
-			// concurrent SubagentStart on the still-standalone child,
-			// the child has accumulated its own native ref. Hiding
-			// such a frame would erase that ref from projection — the
-			// parent's IsProxy ref aggregates the child as a single
-			// dot, not a fan-out. Keep stateful children visible
-			// until sweep canonicalize (PR-3.5b) migrates the refs.
+			// Race-window standalone with no own state: hide entirely.
 			if len(frame.Subagents) == 0 {
 				hidden++
 				continue
 			}
+			// Stateful claimed child: hide the frame from visible
+			// TopFrame selection BUT merge its Subagents into the
+			// output. Suppresses visual duplication while preserving
+			// subagent state on wire.
+			mergedFromHidden = append(mergedFromHidden, frame.Subagents...)
+			hidden++
+			continue
 		}
 		visible = append(visible, frame)
 	}
@@ -92,6 +101,10 @@ func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection 
 		// projection avoids dropping the pane entirely; sweep prune
 		// would otherwise repair via pruneDeadProxyRefs (PR-3.5b).
 		visible = frames
+		// In the fallback path, the merged-hidden refs are already
+		// represented on the visible frames themselves (visible == frames),
+		// so skip merging to avoid double-listing.
+		mergedFromHidden = nil
 	}
 
 	sorted := append([]store.Frame(nil), visible...)
@@ -107,6 +120,23 @@ func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection 
 	subagents := append([]agentpkg.SubagentRef(nil), top.Subagents...)
 	if subagents == nil {
 		subagents = []agentpkg.SubagentRef{}
+	}
+	// R1 merge: append refs from hidden stateful children that aren't
+	// already represented in TopFrame.Subagents. Dedup uses the kind-
+	// aware identity matcher (proxy refs by SourcePID+SourceStartTime,
+	// native by ID; cross-kind never matches) so we never double-list
+	// the same logical subagent.
+	for _, refFromHidden := range mergedFromHidden {
+		duplicate := false
+		for _, existing := range subagents {
+			if subagentRefMatches(existing, refFromHidden) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			subagents = append(subagents, refFromHidden)
+		}
 	}
 	return SessionProjection{
 		PaneID:       paneID,

--- a/internal/module/agent/projection.go
+++ b/internal/module/agent/projection.go
@@ -39,7 +39,50 @@ func buildPaneProjection(paneID string, frames []store.Frame) SessionProjection 
 	if len(frames) == 0 {
 		return SessionProjection{PaneID: paneID, Subagents: []agentpkg.SubagentRef{}}
 	}
-	sorted := append([]store.Frame(nil), frames...)
+
+	// Phase 3.5 §2.4 — dedup: collect (SourcePID, SourceStartTime) keys
+	// from every frame's IsProxy refs and exclude any standalone frame
+	// in the pane that matches one of those keys. This hides the
+	// partial-state visibility where a SessionStart racer landed
+	// standalone but is also already attached as a proxy ref on the
+	// canonical parent (cold-start race; hot-path canonicalize left
+	// behind a partial state). Avoids the SPA seeing two competing
+	// frames for the same proxy-collapsed agent.
+	type claim struct {
+		pid       int
+		startTime string
+	}
+	claimed := make(map[claim]bool)
+	for _, frame := range frames {
+		for _, ref := range frame.Subagents {
+			if ref.IsProxy {
+				claimed[claim{ref.SourcePID, ref.SourceStartTime}] = true
+			}
+		}
+	}
+
+	visible := make([]store.Frame, 0, len(frames))
+	var hidden int
+	for _, frame := range frames {
+		if claimed[claim{frame.PID, frame.ProcessStartTime}] {
+			hidden++
+			continue
+		}
+		visible = append(visible, frame)
+	}
+	if hidden > 0 {
+		agentpkg.MetricProjectionDedupHidden.Add(int64(hidden))
+	}
+	if len(visible) == 0 {
+		// Defensive: every frame in the pane was claimed by a proxy
+		// ref (extreme edge case — pane has only proxy-attached frames
+		// and no canonical owner). Falling back to the unfiltered
+		// projection avoids dropping the pane entirely; sweep prune
+		// would otherwise repair via pruneDeadProxyRefs (PR-3.5b).
+		visible = frames
+	}
+
+	sorted := append([]store.Frame(nil), visible...)
 	sort.Slice(sorted, func(i, j int) bool {
 		if sorted[i].StartedAt == sorted[j].StartedAt {
 			return sorted[i].FrameID < sorted[j].FrameID

--- a/internal/module/agent/projection_test.go
+++ b/internal/module/agent/projection_test.go
@@ -172,6 +172,129 @@ func TestProjection_NoProxyRefsUnchangedBehavior(t *testing.T) {
 	}
 }
 
+// PD4 — codex round 2 #Q1 fix: projection dedup keeps a claimed standalone
+// VISIBLE when it has accumulated its own native subagent state. Hiding
+// such a frame would erase the child's native subagents from the SPA,
+// because the parent's IsProxy ref aggregates the child as a single dot
+// without that child's own subagent fan-out. The race scenario:
+//
+//   1. cc + codex SessionStart race → standalone codex created
+//   2. cc reconcile attaches IsProxy ref to cc but the DeleteIfUnchanged
+//      against the codex row fails (concurrent writer)
+//   3. A SubagentStart hook for codex arrives and writes a native ref
+//      into codex.Subagents
+//   4. Sweep canonicalize would normally repair this but until it runs,
+//      hiding codex would drop the SPA's view of the codex native ref
+//
+// Fix: dedup hide is gated on len(frame.Subagents) == 0. A claimed
+// standalone with refs of its own stays visible (sweep canonicalizePane
+// in PR-3.5b will migrate the refs and remove the parent's stale claim).
+func TestProjection_DedupKeepsClaimedStandaloneWithNativeSubagents(t *testing.T) {
+	startMetric := agentpkg.MetricProjectionDedupHidden.Value()
+	projection := buildPaneProjection("%5", []store.Frame{
+		{
+			FrameID:          "cc-1",
+			PaneID:           "%5",
+			AgentType:        "cc",
+			PID:              100,
+			ProcessStartTime: "t100",
+			StartedAt:        10,
+			Subagents: []agentpkg.SubagentRef{{
+				ID:              "proxy:codex:200:t200",
+				Type:            "codex",
+				SourcePID:       200,
+				SourceStartTime: "t200",
+				IsProxy:         true,
+			}},
+		},
+		{
+			FrameID:          "codex-standalone-with-state",
+			PaneID:           "%5",
+			AgentType:        "codex",
+			PID:              200,
+			ProcessStartTime: "t200",
+			StartedAt:        20,
+			// Codex frame has own native subagent (post-partial-state
+			// concurrent SubagentStart)
+			Subagents: []agentpkg.SubagentRef{{
+				ID:        "task-codex-1",
+				Type:      "codex",
+				StartedAt: 30,
+			}},
+		},
+	})
+
+	// Both frames must be visible: cc with its proxy claim, codex with
+	// its native task ref.
+	if projection.TopFrame == nil {
+		t.Fatalf("TopFrame is nil — codex with state should remain visible")
+	}
+	// Build a pane lookup to verify both frames are present in projection.
+	frames := []store.Frame{}
+	if projection.PrimaryFrame != nil {
+		frames = append(frames, *projection.PrimaryFrame)
+	}
+	if projection.TopFrame != nil && (projection.PrimaryFrame == nil || projection.TopFrame.FrameID != projection.PrimaryFrame.FrameID) {
+		frames = append(frames, *projection.TopFrame)
+	}
+	hasCC := false
+	hasCodex := false
+	for _, f := range frames {
+		if f.FrameID == "cc-1" {
+			hasCC = true
+		}
+		if f.FrameID == "codex-standalone-with-state" {
+			hasCodex = true
+		}
+	}
+	if !hasCC || !hasCodex {
+		t.Fatalf("projection frames hasCC=%v hasCodex=%v, want both visible — Q1 regression: codex with native ref hidden", hasCC, hasCodex)
+	}
+	delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric
+	if delta != 0 {
+		t.Fatalf("MetricProjectionDedupHidden delta = %d, want 0 (stateful child must not be hidden)", delta)
+	}
+}
+
+// PD5 — guard the existing PD1 case still hides empty-Subagents standalone.
+// Together with PD4 these establish the gate boundary at len > 0.
+func TestProjection_DedupStillHidesEmptyStandalone(t *testing.T) {
+	startMetric := agentpkg.MetricProjectionDedupHidden.Value()
+	projection := buildPaneProjection("%5", []store.Frame{
+		{
+			FrameID:          "cc-1",
+			PaneID:           "%5",
+			AgentType:        "cc",
+			PID:              100,
+			ProcessStartTime: "t100",
+			StartedAt:        10,
+			Subagents: []agentpkg.SubagentRef{{
+				ID:              "proxy:codex:200:t200",
+				Type:            "codex",
+				SourcePID:       200,
+				SourceStartTime: "t200",
+				IsProxy:         true,
+			}},
+		},
+		{
+			FrameID:          "codex-empty",
+			PaneID:           "%5",
+			AgentType:        "codex",
+			PID:              200,
+			ProcessStartTime: "t200",
+			StartedAt:        20,
+			// No own subagents — race-window standalone safe to hide
+		},
+	})
+	if projection.TopFrame == nil || projection.TopFrame.FrameID != "cc-1" {
+		t.Fatalf("TopFrame = %+v, want cc-1 (empty standalone must still be hidden)", projection.TopFrame)
+	}
+	delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric
+	if delta != 1 {
+		t.Fatalf("MetricProjectionDedupHidden delta = %d, want +1 (empty standalone hidden)", delta)
+	}
+}
+
 // IT5 — projection dedup hides a standalone frame whose proxy ref already
 // lives on the canonical parent (plan §3.1).
 func TestProjection_IT5_PartialStateHiddenByProjectionDedup(t *testing.T) {

--- a/internal/module/agent/projection_test.go
+++ b/internal/module/agent/projection_test.go
@@ -478,6 +478,62 @@ func TestProjection_DedupMergeAvoidsDuplicateProxyRef(t *testing.T) {
 	}
 }
 
+// PD9 — codex round 4 #S1: cross-frame native ID collision must NOT be
+// treated as duplicate. Different agent families generate native IDs
+// independently (e.g. cc's "call-1" vs codex's "call-1" are distinct
+// subagents in independent ID spaces). The merge dedup must compare
+// (Type, ID) for natives, not ID alone, otherwise the hidden child's
+// native ref is silently dropped from the wire output.
+func TestBuildPaneProjection_PD9_CrossFrameNativeIDCollisionPreserved(t *testing.T) {
+	parent := store.Frame{
+		FrameID: "frame-cc-1", PaneID: "%1", AgentType: "cc",
+		PID: 100, ProcessStartTime: "T1", StartedAt: 200,
+		Subagents: []agentpkg.SubagentRef{
+			// cc has its own native call-1
+			{ID: "call-1", Type: "cc", IsProxy: false},
+			// cc also claims codex (race-window proxy attach happened)
+			{ID: "proxy:codex:200:T2", Type: "codex", IsProxy: true,
+				SourcePID: 200, SourceStartTime: "T2"},
+		},
+	}
+	child := store.Frame{
+		FrameID: "frame-codex-1", PaneID: "%1", AgentType: "codex",
+		PID: 200, ProcessStartTime: "T2", StartedAt: 100,
+		Subagents: []agentpkg.SubagentRef{
+			// codex has its own native call-1 — same ID as cc's but different Type
+			{ID: "call-1", Type: "codex", IsProxy: false},
+		},
+	}
+	projection := buildPaneProjection("%1", []store.Frame{parent, child})
+	if projection.TopFrame == nil || projection.TopFrame.FrameID != "frame-cc-1" {
+		t.Fatalf("expected cc as TopFrame, got %v", projection.TopFrame)
+	}
+	// Both native refs must survive into projection.Subagents
+	var ccCallSeen, codexCallSeen, proxySeen bool
+	for _, ref := range projection.Subagents {
+		switch {
+		case !ref.IsProxy && ref.Type == "cc" && ref.ID == "call-1":
+			ccCallSeen = true
+		case !ref.IsProxy && ref.Type == "codex" && ref.ID == "call-1":
+			codexCallSeen = true
+		case ref.IsProxy && ref.SourcePID == 200 && ref.SourceStartTime == "T2":
+			proxySeen = true
+		}
+	}
+	if !ccCallSeen {
+		t.Errorf("cc native call-1 missing from projection.Subagents: %+v", projection.Subagents)
+	}
+	if !codexCallSeen {
+		t.Errorf("codex native call-1 dropped by cross-frame ID dedup (S1 regression): %+v", projection.Subagents)
+	}
+	if !proxySeen {
+		t.Errorf("proxy ref missing from projection.Subagents: %+v", projection.Subagents)
+	}
+	if len(projection.Subagents) != 3 {
+		t.Errorf("expected 3 refs (cc native, codex native, proxy), got %d: %+v", len(projection.Subagents), projection.Subagents)
+	}
+}
+
 // IT5 — projection dedup hides a standalone frame whose proxy ref already
 // lives on the canonical parent (plan §3.1).
 func TestProjection_IT5_PartialStateHiddenByProjectionDedup(t *testing.T) {

--- a/internal/module/agent/projection_test.go
+++ b/internal/module/agent/projection_test.go
@@ -172,23 +172,25 @@ func TestProjection_NoProxyRefsUnchangedBehavior(t *testing.T) {
 	}
 }
 
-// PD4 — codex round 2 #Q1 fix: projection dedup keeps a claimed standalone
-// VISIBLE when it has accumulated its own native subagent state. Hiding
-// such a frame would erase the child's native subagents from the SPA,
-// because the parent's IsProxy ref aggregates the child as a single dot
-// without that child's own subagent fan-out. The race scenario:
+// PD4 — codex round 3 #R1 fix supersedes round 2 #Q1: dedup HIDES a
+// claimed stateful child (uniformly, regardless of own state) BUT merges
+// its Subagents into the projection.Subagents output so the SPA still
+// sees the child's native refs on the canonical parent's subagents list.
+// Q1 kept the child visible — that produced TopFrame ambiguity (older
+// parent vs newer child winning Top by StartedAt) and dropped either
+// the parent's IsProxy ref or the child's native ref depending on
+// selection. R1 picks one canonical owner (the unclaimed parent) and
+// preserves both refs by merging.
 //
+// Race scenario unchanged from Q1 trail:
 //   1. cc + codex SessionStart race → standalone codex created
 //   2. cc reconcile attaches IsProxy ref to cc but the DeleteIfUnchanged
 //      against the codex row fails (concurrent writer)
 //   3. A SubagentStart hook for codex arrives and writes a native ref
 //      into codex.Subagents
-//   4. Sweep canonicalize would normally repair this but until it runs,
-//      hiding codex would drop the SPA's view of the codex native ref
 //
-// Fix: dedup hide is gated on len(frame.Subagents) == 0. A claimed
-// standalone with refs of its own stays visible (sweep canonicalizePane
-// in PR-3.5b will migrate the refs and remove the parent's stale claim).
+// Result: TopFrame == cc; Subagents = [cc's IsProxy codex ref,
+// child's native task-codex-1 ref] (both preserved on wire).
 func TestProjection_DedupKeepsClaimedStandaloneWithNativeSubagents(t *testing.T) {
 	startMetric := agentpkg.MetricProjectionDedupHidden.Value()
 	projection := buildPaneProjection("%5", []store.Frame{
@@ -224,35 +226,30 @@ func TestProjection_DedupKeepsClaimedStandaloneWithNativeSubagents(t *testing.T)
 		},
 	})
 
-	// Both frames must be visible: cc with its proxy claim, codex with
-	// its native task ref.
-	if projection.TopFrame == nil {
-		t.Fatalf("TopFrame is nil — codex with state should remain visible")
+	// R1: cc is the canonical owner (unclaimed); codex is hidden but
+	// its native ref is merged into projection.Subagents.
+	if projection.TopFrame == nil || projection.TopFrame.FrameID != "cc-1" {
+		t.Fatalf("TopFrame = %+v, want cc-1 (R1: claimed child hidden uniformly)", projection.TopFrame)
 	}
-	// Build a pane lookup to verify both frames are present in projection.
-	frames := []store.Frame{}
-	if projection.PrimaryFrame != nil {
-		frames = append(frames, *projection.PrimaryFrame)
+	if projection.PrimaryFrame == nil || projection.PrimaryFrame.FrameID != "cc-1" {
+		t.Fatalf("PrimaryFrame = %+v, want cc-1", projection.PrimaryFrame)
 	}
-	if projection.TopFrame != nil && (projection.PrimaryFrame == nil || projection.TopFrame.FrameID != projection.PrimaryFrame.FrameID) {
-		frames = append(frames, *projection.TopFrame)
-	}
-	hasCC := false
-	hasCodex := false
-	for _, f := range frames {
-		if f.FrameID == "cc-1" {
-			hasCC = true
+	hasProxy := false
+	hasNative := false
+	for _, ref := range projection.Subagents {
+		if ref.IsProxy && ref.SourcePID == 200 && ref.SourceStartTime == "t200" {
+			hasProxy = true
 		}
-		if f.FrameID == "codex-standalone-with-state" {
-			hasCodex = true
+		if !ref.IsProxy && ref.ID == "task-codex-1" {
+			hasNative = true
 		}
 	}
-	if !hasCC || !hasCodex {
-		t.Fatalf("projection frames hasCC=%v hasCodex=%v, want both visible — Q1 regression: codex with native ref hidden", hasCC, hasCodex)
+	if !hasProxy || !hasNative {
+		t.Fatalf("Subagents = %+v, want both proxy(codex:200:t200) and native(task-codex-1) — R1 merge missing", projection.Subagents)
 	}
 	delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric
-	if delta != 0 {
-		t.Fatalf("MetricProjectionDedupHidden delta = %d, want 0 (stateful child must not be hidden)", delta)
+	if delta != 1 {
+		t.Fatalf("MetricProjectionDedupHidden delta = %d, want +1 (claimed stateful child hidden under R1)", delta)
 	}
 }
 
@@ -292,6 +289,192 @@ func TestProjection_DedupStillHidesEmptyStandalone(t *testing.T) {
 	delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric
 	if delta != 1 {
 		t.Fatalf("MetricProjectionDedupHidden delta = %d, want +1 (empty standalone hidden)", delta)
+	}
+}
+
+// PD6 — codex round 3 #R1: dedup merges a hidden stateful child's
+// Subagents into the projection output even when the parent is the
+// older frame (parent.StartedAt < child.StartedAt — child would have
+// won TopFrame without dedup). The merge moves the child's native ref
+// onto the canonical parent's subagents list so wire output keeps both
+// the parent's IsProxy ref and the child's native ref.
+func TestProjection_DedupMergesHiddenStatefulChildSubagents(t *testing.T) {
+	startMetric := agentpkg.MetricProjectionDedupHidden.Value()
+	projection := buildPaneProjection("%5", []store.Frame{
+		{
+			FrameID:          "cc-1",
+			PaneID:           "%5",
+			AgentType:        "cc",
+			PID:              100,
+			ProcessStartTime: "t100",
+			StartedAt:        10, // older
+			Subagents: []agentpkg.SubagentRef{{
+				ID:              "proxy:codex:200:t200",
+				Type:            "codex",
+				SourcePID:       200,
+				SourceStartTime: "t200",
+				IsProxy:         true,
+			}},
+		},
+		{
+			FrameID:          "codex-1",
+			PaneID:           "%5",
+			AgentType:        "codex",
+			PID:              200,
+			ProcessStartTime: "t200",
+			StartedAt:        20, // newer — would win Top without dedup
+			Subagents: []agentpkg.SubagentRef{{
+				ID:        "task-1",
+				Type:      "codex",
+				StartedAt: 30,
+			}},
+		},
+	})
+
+	if projection.TopFrame == nil || projection.TopFrame.FrameID != "cc-1" {
+		t.Fatalf("TopFrame = %+v, want cc-1 (claimed child hidden, parent canonical)", projection.TopFrame)
+	}
+	if len(projection.Subagents) != 2 {
+		t.Fatalf("Subagents count = %d, want 2 (proxy + merged native)", len(projection.Subagents))
+	}
+	hasProxy := false
+	hasNative := false
+	for _, ref := range projection.Subagents {
+		if ref.IsProxy && ref.SourcePID == 200 && ref.SourceStartTime == "t200" {
+			hasProxy = true
+		}
+		if !ref.IsProxy && ref.ID == "task-1" {
+			hasNative = true
+		}
+	}
+	if !hasProxy || !hasNative {
+		t.Fatalf("Subagents = %+v, want both proxy and merged native(task-1)", projection.Subagents)
+	}
+	if delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric; delta != 1 {
+		t.Fatalf("MetricProjectionDedupHidden delta = %d, want +1", delta)
+	}
+}
+
+// PD7 — codex round 3 #R1: dedup merges hidden stateful child's
+// subagents even when the parent is newer. Reverse-StartedAt of PD6:
+// parent.StartedAt > child.StartedAt — without dedup the parent would
+// already have been Top, but the child carries its own native ref. R1
+// merges the child's ref onto the parent's projection.Subagents list
+// even though the parent's selection wasn't ambiguous.
+//
+// This guards the merge logic against a "hide-only-if-overruled"
+// shortcut. Claimed standalones are hidden uniformly; merge runs
+// uniformly. The final state matches PD6.
+func TestProjection_DedupMergesHiddenStatefulChildSubagents_ParentNewer(t *testing.T) {
+	startMetric := agentpkg.MetricProjectionDedupHidden.Value()
+	projection := buildPaneProjection("%5", []store.Frame{
+		{
+			FrameID:          "cc-1",
+			PaneID:           "%5",
+			AgentType:        "cc",
+			PID:              100,
+			ProcessStartTime: "t100",
+			StartedAt:        20, // newer
+			Subagents: []agentpkg.SubagentRef{{
+				ID:              "proxy:codex:200:t200",
+				Type:            "codex",
+				SourcePID:       200,
+				SourceStartTime: "t200",
+				IsProxy:         true,
+			}},
+		},
+		{
+			FrameID:          "codex-1",
+			PaneID:           "%5",
+			AgentType:        "codex",
+			PID:              200,
+			ProcessStartTime: "t200",
+			StartedAt:        10, // older
+			Subagents: []agentpkg.SubagentRef{{
+				ID:        "task-1",
+				Type:      "codex",
+				StartedAt: 30,
+			}},
+		},
+	})
+
+	if projection.TopFrame == nil || projection.TopFrame.FrameID != "cc-1" {
+		t.Fatalf("TopFrame = %+v, want cc-1", projection.TopFrame)
+	}
+	if len(projection.Subagents) != 2 {
+		t.Fatalf("Subagents count = %d, want 2 (proxy + merged native)", len(projection.Subagents))
+	}
+	hasProxy := false
+	hasNative := false
+	for _, ref := range projection.Subagents {
+		if ref.IsProxy && ref.SourcePID == 200 && ref.SourceStartTime == "t200" {
+			hasProxy = true
+		}
+		if !ref.IsProxy && ref.ID == "task-1" {
+			hasNative = true
+		}
+	}
+	if !hasProxy || !hasNative {
+		t.Fatalf("Subagents = %+v, want both proxy and merged native(task-1)", projection.Subagents)
+	}
+	if delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric; delta != 1 {
+		t.Fatalf("MetricProjectionDedupHidden delta = %d, want +1", delta)
+	}
+}
+
+// PD8 — codex round 3 #R1 boundary: dedup merge avoids double-listing
+// a SubagentRef that already lives on the parent under the same kind-
+// aware identity. If a hidden child's Subagents list contains a proxy
+// ref pointing to the same source as one already on the parent (an
+// unusual but possible state e.g. mirrored after a cycle), the merge
+// must dedup by subagentRefMatches and not produce two entries.
+func TestProjection_DedupMergeAvoidsDuplicateProxyRef(t *testing.T) {
+	projection := buildPaneProjection("%5", []store.Frame{
+		{
+			FrameID:          "cc-1",
+			PaneID:           "%5",
+			AgentType:        "cc",
+			PID:              100,
+			ProcessStartTime: "t100",
+			StartedAt:        10,
+			Subagents: []agentpkg.SubagentRef{{
+				ID:              "proxy:codex:200:t200",
+				Type:            "codex",
+				SourcePID:       200,
+				SourceStartTime: "t200",
+				IsProxy:         true,
+			}},
+		},
+		{
+			FrameID:          "codex-1",
+			PaneID:           "%5",
+			AgentType:        "codex",
+			PID:              200,
+			ProcessStartTime: "t200",
+			StartedAt:        20,
+			// Same proxy identity as parent's ref (cross-listed state).
+			Subagents: []agentpkg.SubagentRef{{
+				ID:              "proxy:codex:200:t200",
+				Type:            "codex",
+				SourcePID:       200,
+				SourceStartTime: "t200",
+				IsProxy:         true,
+			}},
+		},
+	})
+
+	if projection.TopFrame == nil || projection.TopFrame.FrameID != "cc-1" {
+		t.Fatalf("TopFrame = %+v, want cc-1", projection.TopFrame)
+	}
+	// Only one proxy ref to (200, t200) should appear — not two.
+	matches := 0
+	for _, ref := range projection.Subagents {
+		if ref.IsProxy && ref.SourcePID == 200 && ref.SourceStartTime == "t200" {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("proxy(200,t200) count = %d, want 1 (merge must dedup by identity)", matches)
 	}
 }
 

--- a/internal/module/agent/projection_test.go
+++ b/internal/module/agent/projection_test.go
@@ -66,6 +66,143 @@ func TestProjection_CcAndCodexCoexist(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Phase 3.5 PR-3.5a — buildPaneProjection dedup (plan §2.4 / §3.2 PD1-PD3)
+// ---------------------------------------------------------------------------
+
+// PD1 — buildPaneProjection excludes a standalone frame whose
+// (PID, ProcessStartTime) matches an IsProxy ref carried by another frame
+// in the same pane (cold-start race partial state).
+func TestProjection_DedupExcludesProxyClaimedStandalone(t *testing.T) {
+	startMetric := agentpkg.MetricProjectionDedupHidden.Value()
+	projection := buildPaneProjection("%5", []store.Frame{
+		{
+			FrameID:          "cc-1",
+			PaneID:           "%5",
+			AgentType:        "cc",
+			PID:              100,
+			ProcessStartTime: "t100",
+			StartedAt:        10,
+			Subagents: []agentpkg.SubagentRef{{
+				ID:              "proxy:codex:200:t200",
+				Type:            "codex",
+				SourcePID:       200,
+				SourceStartTime: "t200",
+				IsProxy:         true,
+			}},
+		},
+		{
+			FrameID:          "codex-standalone",
+			PaneID:           "%5",
+			AgentType:        "codex",
+			PID:              200,
+			ProcessStartTime: "t200",
+			StartedAt:        20, // newer — without dedup would win TopFrame
+		},
+	})
+
+	if projection.TopFrame == nil || projection.TopFrame.FrameID != "cc-1" {
+		t.Fatalf("TopFrame = %+v, want cc-1 (codex standalone hidden by dedup)", projection.TopFrame)
+	}
+	if projection.PrimaryFrame == nil || projection.PrimaryFrame.FrameID != "cc-1" {
+		t.Fatalf("PrimaryFrame = %+v, want cc-1", projection.PrimaryFrame)
+	}
+	delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric
+	if delta != 1 {
+		t.Fatalf("MetricProjectionDedupHidden delta = %d, want +1", delta)
+	}
+}
+
+// PD2 — when every frame in the pane is claimed by some proxy ref (extreme
+// edge case, e.g. cycle), buildPaneProjection falls back to the unfiltered
+// list rather than dropping the pane projection entirely.
+func TestProjection_FallbackWhenAllFramesClaimed(t *testing.T) {
+	projection := buildPaneProjection("%5", []store.Frame{
+		{
+			FrameID:          "a",
+			PaneID:           "%5",
+			AgentType:        "cc",
+			PID:              100,
+			ProcessStartTime: "t100",
+			StartedAt:        10,
+			// a claims b
+			Subagents: []agentpkg.SubagentRef{{
+				ID:              "proxy:codex:200:t200",
+				Type:            "codex",
+				SourcePID:       200,
+				SourceStartTime: "t200",
+				IsProxy:         true,
+			}},
+		},
+		{
+			FrameID:          "b",
+			PaneID:           "%5",
+			AgentType:        "codex",
+			PID:              200,
+			ProcessStartTime: "t200",
+			StartedAt:        20,
+			// b claims a (cycle)
+			Subagents: []agentpkg.SubagentRef{{
+				ID:              "proxy:cc:100:t100",
+				Type:            "cc",
+				SourcePID:       100,
+				SourceStartTime: "t100",
+				IsProxy:         true,
+			}},
+		},
+	})
+
+	if projection.TopFrame == nil {
+		t.Fatalf("TopFrame is nil — fallback should keep pane visible")
+	}
+}
+
+// PD3 — without IsProxy refs in the pane, dedup logic is a no-op and the
+// existing buildPaneProjection behavior is preserved.
+func TestProjection_NoProxyRefsUnchangedBehavior(t *testing.T) {
+	projection := buildPaneProjection("%5", []store.Frame{
+		{FrameID: "a", PaneID: "%5", AgentType: "cc", PID: 100, ProcessStartTime: "t100", StartedAt: 10},
+		{FrameID: "b", PaneID: "%5", AgentType: "codex", PID: 200, ProcessStartTime: "t200", StartedAt: 20},
+	})
+	if projection.PrimaryFrame == nil || projection.PrimaryFrame.FrameID != "a" {
+		t.Fatalf("Primary = %+v, want a", projection.PrimaryFrame)
+	}
+	if projection.TopFrame == nil || projection.TopFrame.FrameID != "b" {
+		t.Fatalf("Top = %+v, want b", projection.TopFrame)
+	}
+}
+
+// IT5 — projection dedup hides a standalone frame whose proxy ref already
+// lives on the canonical parent (plan §3.1).
+func TestProjection_IT5_PartialStateHiddenByProjectionDedup(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrame(t, m, "%5", "cc", 100, "t100", 10)
+	parent.Subagents = []agentpkg.SubagentRef{{
+		ID:              "proxy:codex:200:t200",
+		Type:            "codex",
+		SourcePID:       200,
+		SourceStartTime: "t200",
+		IsProxy:         true,
+	}}
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed parent + ref: %v", err)
+	}
+	seedFrame(t, m, "%5", "codex", 200, "t200", 50) // partial state row
+
+	startMetric := agentpkg.MetricProjectionDedupHidden.Value()
+	proj, err := m.projectPane("%5")
+	if err != nil {
+		t.Fatalf("projectPane: %v", err)
+	}
+	if proj.TopFrame == nil || proj.TopFrame.AgentType != "cc" {
+		t.Fatalf("TopFrame = %+v, want cc (codex standalone hidden)", proj.TopFrame)
+	}
+	delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric
+	if delta != 1 {
+		t.Fatalf("MetricProjectionDedupHidden delta = %d, want +1", delta)
+	}
+}
+
 func TestLiveFrameProjections_PreservesFrameOnLookupError(t *testing.T) {
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -55,6 +55,7 @@ func (m *Module) sweepOnce() error {
 	if err != nil {
 		return err
 	}
+	survivors := make([]store.Frame, 0, len(frames))
 	for _, frame := range frames {
 		if !frame.Verified {
 			continue
@@ -88,14 +89,88 @@ func (m *Module) sweepOnce() error {
 			if !deleted {
 				// Concurrent refresh raced us — the row is still live.
 				// Not an error; skip this frame this round.
+				survivors = append(survivors, frame)
 				continue
 			}
 			if err := m.afterFrameCleared(frame, "idle_timeout"); err != nil {
 				return err
 			}
+			continue
 		}
+		survivors = append(survivors, frame)
+	}
+	// Phase 3.5 §4.3 — pruneDeadProxyRefs (lifted from PR-3.5b into
+	// PR-3.5a per v8 L1 fix). Detach IsProxy SubagentRefs whose source
+	// process is gone or has been replaced (PID reuse). Without this,
+	// any hot-path SessionEnd that skipped the detach (storage error,
+	// daemon crash mid-handler, removeProxyRefForSender exhaustion)
+	// leaves a stale proxy ref permanently lit on the parent —
+	// projection_dedup cannot hide it because there is no standalone
+	// child frame to hide behind.
+	panes := uniquePaneIDs(survivors)
+	broadcastTs := nowFn().UnixNano()
+	for _, paneID := range panes {
+		m.pruneDeadProxyRefs(paneID, broadcastTs)
 	}
 	return nil
+}
+
+// uniquePaneIDs collects distinct pane IDs from a frame slice in the order
+// they first appear. Used by sweepOnce to drive the pruneDeadProxyRefs pass
+// without re-listing per-pane.
+func uniquePaneIDs(frames []store.Frame) []string {
+	seen := make(map[string]struct{}, len(frames))
+	out := make([]string, 0, len(frames))
+	for _, f := range frames {
+		if _, ok := seen[f.PaneID]; ok {
+			continue
+		}
+		seen[f.PaneID] = struct{}{}
+		out = append(out, f.PaneID)
+	}
+	return out
+}
+
+// pruneDeadProxyRefs detaches IsProxy SubagentRefs from every frame in the
+// pane whose source process is gone or has been replaced (PID reuse). The
+// hot-path SessionEnd handler is now detach-first + propagate (frame_ops.go,
+// v8 L1), but a daemon crash mid-handler — or a removeProxyRefForSender
+// retry exhaustion that the caller logs and continues past — can still
+// leave a stale IsProxy ref on a parent. Without this sweep pass that ref
+// would never be reaped: projection_dedup can't hide it because the
+// standalone child it claimed is gone, so the parent shows a permanent
+// lit dot.
+//
+// Errors from detachProxyRefWithRetry are logged via the metric increment
+// failing (no-op) and otherwise swallowed — the next sweep tick (2s) gets
+// another shot, consistent with sweepOnce's other best-effort passes.
+func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
+	if m.frames == nil {
+		return
+	}
+	frames, err := m.frames.ListByPane(paneID)
+	if err != nil {
+		return
+	}
+	for _, frame := range frames {
+		for _, ref := range frame.Subagents {
+			if !ref.IsProxy {
+				continue
+			}
+			if isPidAliveFn(ref.SourcePID) {
+				actualStart, sterr := processStartTimeFn(ref.SourcePID)
+				if sterr == nil && actualStart == ref.SourceStartTime {
+					// Source still alive + identity-verified — keep.
+					continue
+				}
+			}
+			// Source dead, identity unreadable, or PID reused → detach.
+			detached, _, derr := m.detachProxyRefWithRetry(frame, ref.SourcePID, ref.SourceStartTime, broadcastTs)
+			if derr == nil && detached {
+				agentpkg.MetricSweepPrunedProxy.Add(1)
+			}
+		}
+	}
 }
 
 // clearFrame is the eager delete path used for pid_dead / pid_reused sweeps

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -157,14 +157,27 @@ func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 			if !ref.IsProxy {
 				continue
 			}
-			if isPidAliveFn(ref.SourcePID) {
+			// Codex round 2 #O3 fix: detach only on CONFIRMED staleness.
+			// Read errors from processStartTimeFn (transient /proc
+			// failure / platform probe issue) must not destructively
+			// reap a possibly-live proxy ref. Fail-safe: keep the ref,
+			// retry next sweep tick (2s).
+			var shouldPrune bool
+			if !isPidAliveFn(ref.SourcePID) {
+				shouldPrune = true // confirmed dead source
+			} else {
 				actualStart, sterr := processStartTimeFn(ref.SourcePID)
-				if sterr == nil && actualStart == ref.SourceStartTime {
-					// Source still alive + identity-verified — keep.
+				if sterr != nil {
+					// Read error → keep, retry next sweep.
 					continue
 				}
+				if actualStart != ref.SourceStartTime {
+					shouldPrune = true // confirmed PID reuse
+				}
 			}
-			// Source dead, identity unreadable, or PID reused → detach.
+			if !shouldPrune {
+				continue // alive + identity-verified
+			}
 			detached, _, derr := m.detachProxyRefWithRetry(frame, ref.SourcePID, ref.SourceStartTime, broadcastTs)
 			if derr == nil && detached {
 				agentpkg.MetricSweepPrunedProxy.Add(1)

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -144,6 +144,14 @@ func uniquePaneIDs(frames []store.Frame) []string {
 // Errors from detachProxyRefWithRetry are logged via the metric increment
 // failing (no-op) and otherwise swallowed — the next sweep tick (2s) gets
 // another shot, consistent with sweepOnce's other best-effort passes.
+//
+// Codex round 2 #P1 fix: after at least one successful detach in the pane,
+// emit a "hook" broadcast with reason=sweep:proxy_pruned so SPA + in-memory
+// state (m.subagents / m.currentStatus) reflect the change immediately.
+// Mirrors the afterFrameCleared broadcast that pid_dead/pid_reused/idle_timeout
+// already emit. Per-pane (not per-detach) so multiple stale refs in the same
+// pane coalesce into one broadcast — matches afterFrameCleared's per-frame
+// granularity.
 func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 	if m.frames == nil {
 		return
@@ -152,6 +160,8 @@ func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 	if err != nil {
 		return
 	}
+	detachedAny := false
+	var anyOwner store.Frame
 	for _, frame := range frames {
 		for _, ref := range frame.Subagents {
 			if !ref.IsProxy {
@@ -181,9 +191,44 @@ func (m *Module) pruneDeadProxyRefs(paneID string, broadcastTs int64) {
 			detached, _, derr := m.detachProxyRefWithRetry(frame, ref.SourcePID, ref.SourceStartTime, broadcastTs)
 			if derr == nil && detached {
 				agentpkg.MetricSweepPrunedProxy.Add(1)
+				if !detachedAny {
+					anyOwner = frame
+					detachedAny = true
+				}
 			}
 		}
 	}
+	if detachedAny {
+		m.broadcastProxyPruned(anyOwner)
+	}
+}
+
+// broadcastProxyPruned emits a "hook" broadcast with reason=sweep:proxy_pruned
+// after pruneDeadProxyRefs detached at least one stale ref in a pane. Mirrors
+// afterFrameCleared's broadcast path so SPA + m.subagents / m.currentStatus
+// stay in sync with storage without waiting for an unrelated hook.
+//
+// Best-effort: errors from projection / broadcast resolution are logged via
+// metric (no-op) and otherwise swallowed — the next sweep tick (2s) will
+// re-emit if any stale refs remain. Consistent with sweepOnce's other
+// best-effort passes. Codex round 2 #P1 fix.
+func (m *Module) broadcastProxyPruned(reference store.Frame) {
+	sessionName, code := m.resolvePaneSession(reference.PaneID)
+	projection, err := m.projectionForSession(sessionName)
+	if err != nil {
+		return
+	}
+	if sessionName != "" {
+		m.mu.Lock()
+		syncProjectionState(m.currentStatus, m.subagents, sessionName, projection)
+		m.mu.Unlock()
+	}
+	if code == "" || m.core == nil {
+		return
+	}
+	normalized := buildProjectionNormalized(projection, reference.AgentType, "sweep:proxy_pruned", nowFn().UnixNano(), agentpkg.DeriveResult{})
+	payload, _ := json.Marshal(normalized)
+	m.core.Events.Broadcast(code, "hook", string(payload))
 }
 
 // clearFrame is the eager delete path used for pid_dead / pid_reused sweeps

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -68,6 +68,18 @@ func (m *Module) sweepOnce() error {
 		}
 		startTime, err := processStartTimeFn(frame.PID)
 		if err != nil {
+			// Codex round 3 #R2 fix: identity unverifiable for this
+			// frame's owner — keep it as a survivor so the pane still
+			// enters pruneDeadProxyRefs below. Previously this branch
+			// did a bare `continue`, which bypassed the prune pass for
+			// every pane whose owner identity read transiently failed,
+			// defeating round 2 #O3's per-ref fail-safe at the pane
+			// level. Treating the frame as a survivor here is conserva-
+			// tive (don't trigger destructive pid_reused cleanup on a
+			// read error) and consistent with pruneDeadProxyRefs's own
+			// fail-safe, which only detaches refs on CONFIRMED dead /
+			// reused source.
+			survivors = append(survivors, frame)
 			continue
 		}
 		if startTime != frame.ProcessStartTime {

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -802,6 +802,77 @@ func TestSweep_PruneDeadProxyRefs_KeepsLiveProxy(t *testing.T) {
 	}
 }
 
+// IT13c — codex round 2 #P1 fix: sweep pruneDeadProxyRefs broadcasts a
+// projection update after detaching a stale proxy ref. Previously the
+// detach was visible in storage but m.subagents/m.currentStatus and the
+// SPA stayed stale until an unrelated hook fired. Sweep prune now emits
+// "hook" payload with reason=sweep:proxy_pruned (matching the existing
+// idle_timeout / pid_dead broadcast pattern in afterFrameCleared).
+func TestSweep_PruneDeadProxyRefs_BroadcastsProjectionAfterDetach(t *testing.T) {
+	m := newSweepTestModule(t)
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: m.tmux}
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "A",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:              "proxy:codex:300:dead-t300",
+			Type:            "codex",
+			SourcePID:       300,
+			SourceStartTime: "dead-t300",
+			IsProxy:         true,
+		}},
+		Status:     agentpkg.StatusIdle,
+		StartedAt:  10,
+		LastSeenAt: 10,
+		Verified:   true,
+	}); err != nil {
+		t.Fatalf("Upsert cc + dead proxy ref: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(pid int) bool { return pid == 200 }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 {
+			return "A", nil
+		}
+		return "", nil
+	}
+	nowFn = func() time.Time { return time.Unix(0, 20) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	// Verify storage: proxy ref detached.
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || len(frames[0].Subagents) != 0 {
+		t.Fatalf("frames = %+v, want cc with empty subagents (detach storage step)", frames)
+	}
+
+	// Verify broadcast: payload contains reason=sweep:proxy_pruned.
+	select {
+	case msg := <-sub.SendCh():
+		if !strings.Contains(string(msg), "sweep:proxy_pruned") {
+			t.Fatalf("broadcast payload = %s, want reason sweep:proxy_pruned (P1 broadcast missing)", msg)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for sweep:proxy_pruned broadcast — P1 fix missing")
+	}
+}
+
 // IT14b — codex round 2 #O3 fix: sweep pruneDeadProxyRefs preserves a
 // proxy ref when processStartTimeFn returns an error (transient /proc
 // read failure / platform probe issue). Previously the fall-through

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -1002,3 +1002,126 @@ func TestSweep_PruneDeadProxyRefs_DetachesPidReused(t *testing.T) {
 		t.Fatalf("MetricSweepPrunedProxy delta = %d, want 1", delta)
 	}
 }
+
+// IT13d — codex round 3 #R2 fix: when sweepOnce's owner-identity read
+// (processStartTimeFn for the FRAME's own PID) returns an error, the
+// frame must still flow into the survivors list so its pane reaches
+// pruneDeadProxyRefs. Previously a bare `continue` skipped the entire
+// pane's prune pass, leaving any stale proxy refs lit until a sweep
+// tick happened to land while the owner's /proc read succeeded.
+//
+// Scenario: cc owner at PID 200 with a stale codex proxy ref pointing
+// to PID 300 (confirmed dead source). processStartTimeFn(200) returns
+// a transient error; processStartTimeFn(300) is irrelevant because the
+// per-ref fail-safe (#O3) already gates on isPidAliveFn(300) first.
+// Expected: pane still enters prune; stale codex ref detached.
+func TestSweep_PruneRunsWhenOwnerStartTimeReadErrors(t *testing.T) {
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "A",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:              "proxy:codex:300:dead-t300",
+			Type:            "codex",
+			SourcePID:       300,
+			SourceStartTime: "dead-t300",
+			IsProxy:         true,
+		}},
+		Status:     agentpkg.StatusIdle,
+		StartedAt:  10,
+		LastSeenAt: 10,
+		Verified:   true,
+	}); err != nil {
+		t.Fatalf("Upsert cc + dead proxy ref: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	// Owner (PID 200) alive; proxy source (PID 300) confirmed dead.
+	isPidAliveFn = func(pid int) bool { return pid == 200 }
+	// Owner identity read errors transiently; proxy source read is
+	// short-circuited by the alive check in pruneDeadProxyRefs.
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 {
+			return "", errStub("owner /proc transient")
+		}
+		return "", nil
+	}
+	nowFn = func() time.Time { return time.Unix(0, 20) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	startMetric := agentpkg.MetricSweepPrunedProxy.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (owner preserved on read error)", len(frames))
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("cc.Subagents = %+v, want empty — R2 regression: prune skipped because owner read errored", frames[0].Subagents)
+	}
+	if delta := agentpkg.MetricSweepPrunedProxy.Value() - startMetric; delta != 1 {
+		t.Fatalf("MetricSweepPrunedProxy delta = %d, want 1 (prune ran despite owner read error)", delta)
+	}
+}
+
+// IT14c — codex round 3 #R2 boundary: owner read error must not
+// destructively delete the owner frame as a "pid_reused" cleanup. A
+// transient /proc failure for the owner's PID returns ("", err), and
+// the previous bare-continue path silently skipped the frame this round
+// without any cleanup — equally important is that the new survivor
+// path also doesn't trigger pid_reused (which compares startTime to
+// frame.ProcessStartTime). Verifies the owner row is intact after the
+// sweep.
+func TestSweep_OwnerReadErrorPreservesFrame(t *testing.T) {
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "A",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) {
+		return "", errStub("owner /proc transient")
+	}
+	nowFn = func() time.Time { return time.Unix(0, 20) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (owner read error must not delete)", len(frames))
+	}
+	if frames[0].ProcessStartTime != "A" {
+		t.Fatalf("ProcessStartTime = %q, want A (frame untouched)", frames[0].ProcessStartTime)
+	}
+}

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -670,3 +670,198 @@ func TestSweep_ClearingFramePreservesSiblings(t *testing.T) {
 		t.Fatalf("frames = %+v, want only cc sibling preserved", frames)
 	}
 }
+
+// IT13 — sweep pruneDeadProxyRefs detaches a proxy ref whose source
+// process is dead. Plan §4.3 (lifted from PR-3.5b into PR-3.5a per v8 L1
+// fix). Hot-path SessionEnd is now detach-first + propagate, but a
+// daemon crash between the detach and Delete — or a removeProxyRef
+// retry exhaustion that the caller logged and continued past — would
+// still leave a stale proxy ref permanently lit on the parent without
+// this sweep pass.
+func TestSweep_PruneDeadProxyRefs_DetachesDeadSource(t *testing.T) {
+	m := newSweepTestModule(t)
+	// cc parent alive at PID 200 with a codex IsProxy ref whose source
+	// (PID 300) is dead. No standalone codex frame — projection_dedup
+	// can't help.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "A",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:              "proxy:codex:300:dead-t300",
+			Type:            "codex",
+			SourcePID:       300,
+			SourceStartTime: "dead-t300",
+			IsProxy:         true,
+		}},
+		Status:     agentpkg.StatusIdle,
+		StartedAt:  10,
+		LastSeenAt: 10,
+		Verified:   true,
+	}); err != nil {
+		t.Fatalf("Upsert cc + dead proxy ref: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(pid int) bool { return pid == 200 }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 {
+			return "A", nil
+		}
+		return "", nil
+	}
+	nowFn = func() time.Time { return time.Unix(0, 20) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	startMetric := agentpkg.MetricSweepPrunedProxy.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("frames = %+v, want cc parent preserved", frames)
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("cc.Subagents = %+v, want empty (dead proxy detached)", frames[0].Subagents)
+	}
+	if delta := agentpkg.MetricSweepPrunedProxy.Value() - startMetric; delta != 1 {
+		t.Fatalf("MetricSweepPrunedProxy delta = %d, want 1", delta)
+	}
+}
+
+// IT13b — sweep pruneDeadProxyRefs preserves a proxy ref whose source is
+// alive and identity-verified. Negative case for the prune pass.
+func TestSweep_PruneDeadProxyRefs_KeepsLiveProxy(t *testing.T) {
+	m := newSweepTestModule(t)
+	// cc parent at PID 200 with codex IsProxy whose source (PID 300) is
+	// alive + start_time matches.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "A",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:              "proxy:codex:300:t300",
+			Type:            "codex",
+			SourcePID:       300,
+			SourceStartTime: "t300",
+			IsProxy:         true,
+		}},
+		Status:     agentpkg.StatusIdle,
+		StartedAt:  10,
+		LastSeenAt: 10,
+		Verified:   true,
+	}); err != nil {
+		t.Fatalf("Upsert cc + live proxy ref: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 200:
+			return "A", nil
+		case 300:
+			return "t300", nil
+		}
+		return "", nil
+	}
+	nowFn = func() time.Time { return time.Unix(0, 20) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	startMetric := agentpkg.MetricSweepPrunedProxy.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+	if len(frames[0].Subagents) != 1 || frames[0].Subagents[0].SourcePID != 300 {
+		t.Fatalf("cc.Subagents = %+v, want live codex proxy preserved", frames[0].Subagents)
+	}
+	if delta := agentpkg.MetricSweepPrunedProxy.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepPrunedProxy delta = %d, want 0 (live proxy kept)", delta)
+	}
+}
+
+// IT14 — sweep pruneDeadProxyRefs detaches a proxy ref whose source PID
+// has been reused (alive but stored start_time mismatches actualStart).
+// Plan §4.3 PID-reuse case.
+func TestSweep_PruneDeadProxyRefs_DetachesPidReused(t *testing.T) {
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "A",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:              "proxy:codex:300:stale-t300",
+			Type:            "codex",
+			SourcePID:       300,
+			SourceStartTime: "stale-t300",
+			IsProxy:         true,
+		}},
+		Status:     agentpkg.StatusIdle,
+		StartedAt:  10,
+		LastSeenAt: 10,
+		Verified:   true,
+	}); err != nil {
+		t.Fatalf("Upsert cc + pid-reused proxy ref: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(int) bool { return true }
+	// PID 300 alive but identity changed.
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 200:
+			return "A", nil
+		case 300:
+			return "fresh-t300", nil
+		}
+		return "", nil
+	}
+	nowFn = func() time.Time { return time.Unix(0, 20) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	startMetric := agentpkg.MetricSweepPrunedProxy.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("cc.Subagents = %+v, want empty (pid-reused proxy detached)", frames[0].Subagents)
+	}
+	if delta := agentpkg.MetricSweepPrunedProxy.Value() - startMetric; delta != 1 {
+		t.Fatalf("MetricSweepPrunedProxy delta = %d, want 1", delta)
+	}
+}

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -802,6 +802,72 @@ func TestSweep_PruneDeadProxyRefs_KeepsLiveProxy(t *testing.T) {
 	}
 }
 
+// IT14b — codex round 2 #O3 fix: sweep pruneDeadProxyRefs preserves a
+// proxy ref when processStartTimeFn returns an error (transient /proc
+// read failure / platform probe issue). Previously the fall-through
+// after a `sterr != nil` test detached the ref — fail-destructive,
+// could falsely reap a live proxy whose start_time read transiently
+// failed. Fail-safe: only detach on CONFIRMED dead source or CONFIRMED
+// identity mismatch. Read error → keep, retry next sweep.
+func TestSweep_PruneDeadProxyRefs_KeepsProxyOnStartTimeError(t *testing.T) {
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "A",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:              "proxy:codex:300:t300",
+			Type:            "codex",
+			SourcePID:       300,
+			SourceStartTime: "t300",
+			IsProxy:         true,
+		}},
+		Status:     agentpkg.StatusIdle,
+		StartedAt:  10,
+		LastSeenAt: 10,
+		Verified:   true,
+	}); err != nil {
+		t.Fatalf("Upsert cc + proxy ref: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	// PID 300 alive, but processStartTimeFn returns transient error.
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 {
+			return "A", nil
+		}
+		// PID 300 (the proxy's source): transient read error.
+		return "", errStub("ps transient failure")
+	}
+	nowFn = func() time.Time { return time.Unix(0, 20) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	startMetric := agentpkg.MetricSweepPrunedProxy.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+	if len(frames[0].Subagents) != 1 || frames[0].Subagents[0].SourcePID != 300 {
+		t.Fatalf("cc.Subagents = %+v, want proxy preserved on read error (fail-safe)", frames[0].Subagents)
+	}
+	if delta := agentpkg.MetricSweepPrunedProxy.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepPrunedProxy delta = %d, want 0 (read error must not detach)", delta)
+	}
+}
+
 // IT14 — sweep pruneDeadProxyRefs detaches a proxy ref whose source PID
 // has been reused (alive but stored start_time mismatches actualStart).
 // Plan §4.3 PID-reuse case.


### PR DESCRIPTION
## Summary

Phase 3.5a fixes the cold-start race left by PR-2b (alpha.221): when two cross-type SessionStarts arrive concurrently in the same pane (typical: daemon restart cc + codex proxy spawn at once), `findProxyParent`'s pre-Upsert PPID walk can miss on both sides, leaving two standalone frames where there should be one canonical parent + proxy ref.

Hybrid B+ design (consulting-driven, see plan §0.2): accept partial DB state as legal for ephemeral telemetry table (`agent_frames` migration explicitly allows lossless clear), hide partial via daemon-side **projection dedup** (only strongly-consistent boundary to user), repair via sweep within 2s (PR-3.5b — separate PR), observe via in-process expvar metrics.

This PR is **PR-3.5a only** — hot-path race fix + projection dedup + SessionEnd cleanup. PR-3.5b (sweep canonicalize + prune dead proxy refs) follows separately. Per plan §14, splitting by user-visible correctness boundary; 3.5a alone is user-correct, 3.5b is defense-in-depth.

## What's in PR-3.5a

- **`internal/agent/metrics.go`** (new) — 4 expvar counters for in-process partial-state observability (no endpoint exposure; follow-up issue)
- **`internal/module/agent/frame_ops.go`**:
  - `pidIsAncestorOfWithCap` walks descendant's PPID chain looking for ancestor PID (capped at proxyMaxDepth=5)
  - `canonicalizeDescendantsAfterUpsert` (self-as-ancestor): scans pane for cross-type live identity-verified standalone descendants whose PPID chain passes through self, folds them as proxy refs + best-effort deletes their standalone rows
  - `reconcileCreatedFrameAsProxy` (self-as-descendant): post-Upsert ancestor walk + attach proxy ref + best-effort delete of own standalone frame; **no rollback** (partial state legal, sweep repairs)
  - `applyFrameEvent` wiring §2.2.1 (new-frame post-Upsert: reconcile then descendant-scan) + §2.2.2 (existing-frame **filter-merge-retry** pattern, replaces v5's three-step snapshot+reset+re-attach which had concurrent-attach race) + §2.3 (SessionEnd hot-path proxy cleanup: best-effort `removeProxyRefForSender` after frame delete)
- **`internal/module/agent/projection.go`**:
  - `buildPaneProjection` dedup: parent.Subagents containing IsProxy + (SourcePID, SourceStartTime) → exclude matching standalone frame from TopFrame selection (SPA never sees partial)
  - Fallback to unfiltered when all frames are claimed (extreme edge case)

## Plan trail

Plan iteration: v1 → v7, six rounds of codex adversarial review + two parallel architectural consultings (Side A SQL transaction vs Side B Hybrid B+). v3 → v4 was a paradigm shift (accept partial state instead of patch-over-patch retry/rollback chains) after three rounds flagged the same partial-state meta-drift. Round 6 confirmed design convergence (only doc-gate finding remaining). See `docs/specs/2026-04-25-lights-rebuild-phase-3-5-plan.md` §13 for full review trail.

## Test plan

- [x] **Unit tests**: RC1-RC5 (pidIsAncestorOfWithCap edge cases + canonicalizeDescendants identity gate / same-type skip) + PD1-PD3 (projection dedup edge cases)
- [x] **Integration tests** (real sqlite): IT1-IT9 + IT11 + IT12 + IT15-IT20
  - IT1/IT2: descendant-then-ancestor + ancestor-then-descendant ordering
  - IT3: pre-walk miss + post-Upsert reconcile hit (race interleaving)
  - IT4: ancestor-late race **(core J1 / F1 regression guard)**
  - IT5: partial-state hidden by projection dedup
  - IT6: descendant-scan partial-skip doesn't block others
  - IT7: existing-frame SessionStart preserves live proxy refs (filter-merge-retry)
  - IT8: non-SessionStart event no canonicalization
  - IT9: retry exhaustion error propagates (replaces sqlite-injection IT9 — same surface, no store interface seam needed)
  - IT11: descendant scan skips PID-reuse stale row (G2 regression guard)
  - IT12: SessionEnd clears parent proxy ref **(Side B-discovered SessionEnd ghost dot bug)**
  - IT15: partial metric increments on partial state
  - IT16: projection dedup metric increments
  - IT17/IT18/IT19/IT20: filter-merge-retry preserves live proxies / dead source skip / pid-reuse skip / **concurrent attach during retry preserved (J1 regression guard)**
- [x] `go build ./... && go vet ./... && go test ./...` — all 23 packages green
- [x] No SPA changes (projection dedup is daemon-side only)
- [ ] Manual smoke: daemon restart cc + codex test in real pane (post-merge)

## Codex review request

Two rounds per project convention:
1. Standard review (cross-model second opinion on design + implementation correctness)
2. Adversarial 3-parallel (attack / defend / file health)

Focus areas:
- §2.2.2 filter-merge-retry pattern correctness vs PR-2b's mutateSubagentsWithRetry shape
- IT4 ancestor-late race coverage (the core regression guard)
- IT20 concurrent-attach-during-retry test design (mock fidelity to real race)
- SessionEnd ordering: delete-first vs detach-first trade-off
- IT9 redesign (retry-exhaustion vs sqlite-injection — same surface, acceptable?)
- Identity gates consistency across reconcile / canonicalize-descendants / filter-merge / SessionEnd cleanup

## Known limitations / follow-ups

- **PR-3.5b (sweep canonicalizePane + pruneDeadProxyRefs)**: pure defense-in-depth, Phase 3.5a alone leaves zombies that idle sweep (1h) eventually clears; PR-3.5b makes that 2s. Ship timing flexible per metric SLO.
- **Metrics endpoint exposure**: not in this PR (follow-up issue) — counters in-process only.
- **Mock store interface seam**: would enable cleaner sqlite-error injection tests; subagent flagged as candidate follow-up issue.

## Pre-merge

- Phase 3 PR #638 already merged at `92fb5d05` ✅
- Bump strategy: alpha.226 covers Phase 3 + this PR (alpha.225 was bumped by parallel session for unrelated SPA tooltip PR #643)

🤖 Generated with [Claude Code](https://claude.com/claude-code)