### PR TITLE
Fix agent hook install and cleanup correctness

### DIFF
--- a/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
+++ b/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
@@ -64,6 +64,7 @@ Therefore this PR must not touch:
 - `internal/module/agent/frame_ops.go`
 - `internal/module/agent/frame_ops_test.go`
 - `internal/module/agent/handler_test.go`
+- `internal/module/agent/trace.go`
 
 This hotfix may modify only:
 
@@ -83,6 +84,7 @@ This hotfix may modify only:
 - `internal/agent/opencode/hooks_test.go`
 - `internal/agent/opencode/plugin_template.go`
 - `internal/agent/opencode/plugin_template_test.go`
+- `internal/agent/opencode/testdata/opencode-1.14.23-*`
 - `internal/agent/opencode/status.go`
 - `internal/agent/opencode/status_test.go`
 - `spa/src/lib/agent-icons.test.tsx`
@@ -174,6 +176,8 @@ This hotfix adds only icon registry tests. Rendering pipeline changes are out of
 
 Add a lightweight classification field to hook declarations without introducing a central runtime dispatcher. Raw `HookEventSpec.Handling` must not be read directly by installer/checker code; consumers use the helper functions below so zero-value legacy specs remain safe.
 
+`HookInstaller.Events()` becomes the provider's classified upstream hook catalog. It is no longer synonymous with the installable subset. Installer/checker/template consumers must derive installable events through `IsInstallableHookSpec`.
+
 Proposed extension in `internal/agent/provider.go`:
 
 ```go
@@ -182,8 +186,8 @@ type HookHandling string
 const (
     HookHandlingStatus     HookHandling = "status"      // may emit non-empty Status
     HookHandlingDetail     HookHandling = "detail"      // Valid=true, Status="" detail-only
-    HookHandlingIgnored    HookHandling = "ignored"     // known upstream event, intentionally not installed/parsed
-    HookHandlingUnsupported HookHandling = "unsupported" // known upstream event not supported by this Purdex version
+    HookHandlingIgnored    HookHandling = "ignored"     // current upstream event intentionally irrelevant to status/detail behavior
+    HookHandlingUnsupported HookHandling = "unsupported" // current upstream event that may be relevant but is not safely parsed/installed yet
 )
 
 type HookEventSpec struct {
@@ -207,11 +211,21 @@ Rules:
 - `EffectiveHookHandling` maps empty `Handling` to `status` when `EmitsStatus` is non-empty.
 - `EffectiveHookHandling` maps empty `Handling` to `detail` when `EmitsStatus` is empty. This preserves existing SubagentStart/Stop behavior during migration.
 - Upstream events Purdex chooses not to install use `ignored` or `unsupported`.
+- Newly added upstream non-installable specs must set `Handling` explicitly to `ignored` or `unsupported`; they must not rely on the empty-to-`detail` migration default.
+- Ignored/unsupported specs must have empty `EmitsStatus`. If a future event should contribute status, it must be promoted to `status` handling with parser/install support.
 - `SupportedStatuses()` continues to union only `EmitsStatus`.
 - `IsInstallableHookSpec` returns true only for effective `status` and `detail`.
 - `InstallHooks` installs only installable events unless a provider explicitly decides otherwise.
-- `CheckHooks` reports installed state only for installable events; ignored/unsupported events can be exposed later to Inspector but must not block install completeness.
+- `CheckHooks.Events` contains installable specs only in this hotfix. Ignored/unsupported events remain in `Provider.Events()` for catalog/tests and can be exposed later to Inspector, but must not block install completeness.
 - Template/spec parity checks compare template emissions against installable specs only.
+- Each provider's `Events()` defensive copy must preserve `Handling`; otherwise ignored/unsupported specs can incorrectly fall back to `detail` and become installable.
+
+Stale ignored/unsupported artifacts already present on disk:
+
+- Install must never add Purdex commands for ignored/unsupported events.
+- CheckHooks must not include ignored/unsupported events in install completeness and must not report them as missing or broken.
+- `Managed=true` may be based on any Purdex-owned artifact, including stale ignored/unsupported entries, so users can run remove.
+- RemoveHooks must remove stale Purdex-owned ignored/unsupported commands while preserving third-party entries.
 
 Derived predicate table:
 
@@ -238,7 +252,9 @@ Keep current installed set as-is:
 - `PermissionRequest`
 - `SessionEnd`
 
-Add explicit known-but-not-installed declarations for current documented hook events such as:
+Add an exact version-pinned upstream catalog table before implementation. The table must include every current documented upstream event name, source URL or runtime/source provenance, `Handling`, `FutureOnly`, normalized Purdex event name when installable, and reason when non-installable. Tests must compare the full event-name set exactly against that table.
+
+Initial Claude Code non-installed candidates to verify and classify include:
 
 - `PreToolUse`
 - `PostToolUse`
@@ -278,7 +294,9 @@ FutureOnly tolerated-absent set remains parser-capable and opportunistically ins
 
 Installer behavior remains broad: Purdex writes all installable status/detail Codex events (the 4 required events plus the 5 FutureOnly events). `FutureOnly` changes checker tolerance, not whether reinstall can seed the hook entry.
 
-Add explicit known ignored/unsupported entries for current documented events that Purdex does not install yet:
+Add an exact Codex `0.124.0` upstream catalog table before implementation. The table must include every current documented upstream event name, source URL or runtime/source provenance, `Handling`, `FutureOnly`, normalized Purdex event name when installable, and reason when non-installable. Tests must compare the full event-name set exactly against that table.
+
+Initial known ignored/unsupported candidates to verify and classify:
 
 - `PreToolUse`
 - `PostToolUse`
@@ -297,6 +315,8 @@ Keep currently intended normalized events:
 - `UserPromptSubmit` from the current prompt/message event after verification
 - `SubagentStart` / `SubagentStop` from `tool.execute.before/after` task calls
 
+Add an exact OpenCode `1.14.23` plugin event table before implementation. The table must include every current documented/runtime plugin event key, source URL or runtime/source provenance, `Handling`, normalized Purdex event name when installable, payload paths consumed by the template, and reason when non-installable. Tests must compare the full event-key set exactly against that table.
+
 Explicitly document all current OpenCode plugin events not installed/mapped as ignored/unsupported.
 
 OpenCode template/spec parity and CheckHooks event installation must use only `IsInstallableHookSpec(spec) == true`. Ignored/unsupported OpenCode upstream events must appear in the catalog but must not be expected in the managed plugin body and must not be marked installed by `CheckHooks`.
@@ -306,9 +326,11 @@ OpenCode template/spec parity and CheckHooks event installation must use only `I
 Install:
 
 - Ensure `~/.codex/config.toml` exists.
-- Preserve all existing config content as much as practical.
+- Preserve existing TOML semantic keys/values; comments, formatting, and ordering are not guaranteed.
 - Ensure `[features].codex_hooks = true`.
-- Then write `~/.codex/hooks.json`.
+- Parse both existing `config.toml` and `hooks.json` before writing either file; missing files are treated as empty config/hook maps.
+- If either parse fails, return before writing; both files must remain byte-for-byte unchanged.
+- After successful parse, write `config.toml`, then write `hooks.json`.
 
 Check:
 
@@ -342,15 +364,25 @@ Claude checker should mirror Codex per-event validation:
 
 `filterOutPdx` should remove only commands that are valid Purdex hook commands for `cc`, not arbitrary `pdx hook --agent codex` commands.
 
+For checker validation, event matching is per-key strict: the final command token must equal the settings event key. For remove/reinstall filtering, remove any well-formed `pdx hook --agent cc <supported-event>` entry even if it is currently filed under the wrong Claude event key; this cleans stale Purdex-owned commands while preserving non-cc commands.
+
 ### 2.6 OpenCode Version Status
 
 Add `opencodeHooksSupportedVersion = "1.14.23"` and return `SupportedVersion` / `ExceedsSupport` in all `CheckHooks` paths for parity with cc/codex.
 
 ### 2.7 OpenCode Mapping Verification Gate
 
-Before changing `renderManagedPlugin`, capture or verify the current OpenCode `1.14.23` prompt/message event contract. The implementation commit must name the exact event key and payload fields in this plan or a retrospective note before production code changes.
+Before changing `renderManagedPlugin`, capture or verify every OpenCode `1.14.23` event key and payload path consumed by the managed template, including `session.*`, `permission.asked`, `question.asked` if kept, prompt/message events, `tool.execute.before`, and `tool.execute.after`.
 
-If no stable current prompt event is confirmed, keep the production template unchanged in this hotfix and limit OpenCode changes to catalog classification, version reporting, and tests that document the uncertainty.
+The verification commit must add a checked-in provenance artifact under `internal/agent/opencode/testdata/opencode-1.14.23-*` with:
+
+- exact `opencode --version` output
+- source/docs URL and commit/tag, or a captured runtime trace
+- exact event keys consumed by `renderManagedPlugin`
+- minimal JSON payload fixtures containing every field the template reads
+- tests that fail if the fixtures no longer support the template mapping
+
+If any template-consumed event lacks stable verification, keep the production template unchanged in this hotfix and limit OpenCode changes to catalog classification, version reporting, and tests that document the uncertainty.
 
 ---
 
@@ -371,11 +403,14 @@ Tests:
 |---|---|---|
 | HC1 | `TestEffectiveHookHandlingDefaults` | empty handling + non-empty `EmitsStatus` derives `status`; empty handling + empty `EmitsStatus` derives `detail` |
 | HC1b | `TestIsInstallableHookSpec` | `status/detail` are installable; `ignored/unsupported` are not |
-| HC2 | `TestSupportedStatusesIgnoresIgnoredHooks` | ignored/unsupported hooks with empty `EmitsStatus` do not affect status set |
-| HC3 | `TestCCEventsClassifyKnownUpstreamHooks` | documented non-installed cc hooks exist and are `ignored` / `unsupported` |
-| HC4 | `TestCodexEventsClassifyCurrentDocs` | `PermissionRequest` is non-FutureOnly; `PreToolUse`/`PostToolUse` are explicitly classified |
+| HC2 | `TestNonInstallableHookSpecsMustNotEmitStatus` | provider catalog tests fail if any ignored/unsupported spec has non-empty `EmitsStatus` |
+| HC3 | `TestCCEventsClassifyKnownUpstreamHooks` | full documented cc hook set matches the checked-in version-pinned catalog table |
+| HC3b | `TestProviderEventsPreserveHandling` | ignored/unsupported specs round-trip through each provider `Events()` defensive copy |
+| HC4 | `TestCodexEventsClassifyCurrentDocs` | `PreToolUse`/`PostToolUse` and all current documented non-installed Codex events are explicitly classified |
 | HC5 | `TestOpenCodeEventsClassifyPluginSurface` | OpenCode plugin docs events not mapped are explicitly classified |
-| HC6 | `TestInstallableEventNamesStayStable` | installable sets remain cc=9, codex=9, opencode=8 before provider-specific changes |
+| HC6 | `TestInstallableEventNamesStayStable` | installable sets remain cc=9, codex=9, opencode=8 after upstream catalog expansion |
+| HC6b | `TestInstallableFilteringUsesHandling` | synthetic ignored/unsupported specs are excluded from event-name helpers, checker completeness, and OpenCode template parity |
+| HC7 | `TestStaleNonInstallablePdxArtifactsDoNotBlockInstall` | stale Purdex-owned ignored/unsupported entries set `Managed=true`, do not affect `Installed`, and are removed by remove |
 
 ### 3.2 Codex Feature Flag Tests
 
@@ -389,6 +424,7 @@ Tests:
 | CF2 | `TestCodexInstallHooks_PreservesExistingConfig` | unrelated TOML keys survive install |
 | CF2b | `TestCodexInstallHooks_MergesExistingFeaturesTable` | existing `[features]` entries survive and `codex_hooks` flips true |
 | CF2c | `TestCodexInstallHooks_MalformedConfigReturnsError` | malformed TOML returns error and does not overwrite file |
+| CF2d | `TestCodexInstallHooks_ParseFailureDoesNotPartiallyWrite` | malformed `config.toml` or `hooks.json` leaves both files byte-for-byte unchanged |
 | CF3 | `TestCodexCheckHooks_FeatureFlagMissingBlocks` | valid hooks.json + missing flag => `Installed=false`, `Managed=true`, issue present |
 | CF4 | `TestCodexCheckHooks_FeatureFlagFalseBlocks` | `codex_hooks=false` blocks install completeness |
 | CF5 | `TestCodexRemoveHooks_DoesNotDisableFeatureFlag` | remove leaves `codex_hooks=true` unchanged |
@@ -407,6 +443,8 @@ Tests:
 | CP4 | `TestMergeCodexHooks_RemoveDeletesEmptyEventKeys` | remove deletes keys with no remaining third-party hooks |
 | CP5 | `TestCheckHooks_AfterPurdexRemoveFutureOnlyAbsentDoesNotWarn` | installer remove no longer creates empty-array broken warnings |
 
+CP2, CP3, and CP5 fixtures must include `features.codex_hooks=true` unless the test is specifically about feature flag handling.
+
 ### 3.4 Claude Strict Checker Tests
 
 File: `internal/agent/cc/hooks_test.go`
@@ -420,6 +458,7 @@ Tests:
 | CS3 | `TestCCCheckHooks_QuotedPathWithSpacesValid` | `"/Applications/Purdex Beta/pdx" hook --agent cc Stop` passes |
 | CS4 | `TestMergeClaudeHooks_DoesNotRemoveOtherAgentPdxHook` | remove keeps `--agent codex` command in Claude settings |
 | CS5 | `TestMergeClaudeHooks_ReplacesOnlyCcPdxEntries` | reinstall replaces old cc pdx path but preserves third-party and non-cc pdx hooks |
+| CS6 | `TestMergeClaudeHooks_RemovesWrongEventCcPdxEntry` | remove/reinstall deletes well-formed `--agent cc` commands even when filed under the wrong event key |
 
 ### 3.5 OpenCode Plugin Mapping / Version Tests
 
@@ -433,11 +472,11 @@ Tests:
 
 | ID | Test | Red Assertion |
 |---|---|---|
-| OC1 | `TestOpenCodePluginTemplate_UsesCurrentPromptEvent` | template uses the verified current event for prompt/running transition, not stale API |
-| OC1a | `TestOpenCodePromptEventContractDocumented` | test fixture names the current verified prompt/message event and required payload fields |
+| OC1 | `TestOpenCodePluginTemplate_UsesVerifiedEvents` | template uses verified current event keys and payload paths, not stale API assumptions |
+| OC1a | `TestOpenCodeTemplateEventContractsDocumented` | checked-in provenance fixture names every consumed OpenCode event key and payload field |
 | OC2 | `TestTemplateSpecsParity` | emitted template events match installable specs only |
 | OC3 | `TestOpenCodeEvents_ClassifiesCurrentPluginEvents` | current documented OpenCode plugin events are classified |
-| OC4 | `TestOpenCodeCheckHooks_ReportsSupportedVersion` | status includes `SupportedVersion=1.14.23` |
+| OC4 | `TestOpenCodeCheckHooks_ReportsSupportedVersion` | table tests every `CheckHooks` return path includes `SupportedVersion=1.14.23` |
 | OC5 | `TestOpenCodeCheckHooks_ExceedsSupport` | version comparison warning works when detected version is greater |
 
 ### 3.6 OpenCode Icon Guard Test
@@ -461,12 +500,13 @@ OI1/OI2 are coverage guards on the current baseline; they are allowed to pass im
 
 Red:
 
-- HC1-HC2 fail.
+- HC1-HC1b fail.
 
 Green:
 
 - Add `HookHandling` field/types.
 - Add `EffectiveHookHandling` and `IsInstallableHookSpec` in `internal/agent/provider.go`.
+- Update `HookInstaller.Events` and `HookEventSpec` comments to say `Events()` returns the classified upstream catalog, not the installable subset.
 - Keep existing provider event declarations unchanged.
 - Ensure `SupportedStatuses` tests stay green and use effective handling only where classification matters.
 
@@ -478,14 +518,15 @@ Run:
 
 Red:
 
-- HC6 fails.
-- Existing exact catalog/template/checker tests fail if they read raw catalog size after ignored/unsupported entries are introduced.
+- HC6b fails.
+- Synthetic ignored/unsupported specs fail installer-name filtering and OpenCode template parity filtering until consumers use `IsInstallableHookSpec`.
 
 Green:
 
 - Migrate cc/codex/opencode event-name helpers, installers, checkers, and OpenCode template/spec parity to `IsInstallableHookSpec`.
 - Split tests into full upstream catalog assertions and installable set assertions.
 - Preserve installable sets before provider-specific changes: cc=9, codex=9, opencode=8.
+- Do not add upstream ignored/unsupported declarations in this commit.
 
 Run:
 
@@ -495,12 +536,16 @@ Run:
 
 Red:
 
-- HC3-HC5 fail.
+- HC2-HC6 and HC7 fail.
 
 Green:
 
 - Add known upstream ignored/unsupported declarations for cc/codex/opencode.
+- Add exact version-pinned provider catalog tables and full catalog set assertions.
+- Copy `Handling` through every provider `Events()` defensive copy.
+- Assert every newly added non-installable declaration has explicit `ignored`/`unsupported` handling and empty `EmitsStatus`.
 - Keep ignored/unsupported entries out of install completeness and OpenCode template parity.
+- Define and test stale ignored/unsupported Purdex-owned artifacts: they do not affect `Installed`, may make `Managed=true`, and are removed by remove.
 - Keep runtime status derivation unchanged for installable status/detail events.
 
 Run:
@@ -511,12 +556,13 @@ Run:
 
 Red:
 
-- CF1-CF5 and CF2b-CF2c fail.
+- CF1-CF5 and CF2b-CF2d fail.
 - CP1-CP3 fail.
 
 Green:
 
 - Add TOML read/write helpers for `~/.codex/config.toml`.
+- Preflight-parse both `config.toml` and `hooks.json`; any parse failure leaves both files byte-for-byte unchanged.
 - Install enables `features.codex_hooks`.
 - Check blocks when feature flag missing/false.
 - Preserve TOML semantic keys while accepting formatting/comment/order rewrites.
@@ -537,6 +583,7 @@ Green:
 
 - `mergeCodexHooks(remove=true)` deletes event key when no entries remain.
 - Preserve third-party matcher groups.
+- Ensure CP5 fixtures include `features.codex_hooks=true` so the test isolates empty-key behavior.
 - Keep CheckHooks strict present-but-empty behavior for manually broken files.
 
 Run:
@@ -547,13 +594,14 @@ Run:
 
 Red:
 
-- CS1-CS5 fail.
+- CS1-CS6 fail.
 
 Green:
 
 - Add quote-aware tokenizer / per-event validator for cc.
 - Use strict validator for `CheckHooks`.
 - Use cc-scoped filtering for install/remove.
+- Remove stale well-formed `--agent cc` Purdex commands even when filed under the wrong event key.
 
 Run:
 
@@ -568,29 +616,31 @@ Red:
 Green:
 
 - Add supported version reporting for OpenCode.
+- Cover every `CheckHooks` return path: missing plugin, unmanaged plugin, path resolution failure, managed body drift, and fully installed.
 
 Run:
 
 - `go test ./internal/agent/opencode ./internal/agent -count=1`
 
-### Commit 5b — `test(agent/opencode): document prompt event contract`
+### Commit 5b — `test(agent/opencode): document template event contracts`
 
 Red:
 
-- OC1a fails until a current OpenCode `1.14.23` prompt/message event key and required payload fields are documented from source/runtime verification.
+- OC1a fails until current OpenCode `1.14.23` event keys and required payload fields for every template-consumed event are documented from source/runtime verification.
 
 Green:
 
-- Add a fixture or test note naming the verified event contract.
+- Add checked-in provenance under `internal/agent/opencode/testdata/opencode-1.14.23-*` with version output, source/docs URL or runtime trace, event keys, and minimal payload fixtures.
+- Add fixture-driven tests for every event key and payload path consumed by `renderManagedPlugin`.
 - Do not change `renderManagedPlugin` unless the verified contract proves `chat.message` is stale.
 
 Run:
 
 - `go test ./internal/agent/opencode -count=1`
 
-### Commit 5c — `fix(agent/opencode): refresh plugin prompt mapping`
+### Commit 5c — `fix(agent/opencode): refresh plugin event mapping`
 
-Only needed if Commit 5b proves the existing `chat.message` mapping is stale.
+Only needed if Commit 5b proves any existing managed template event key or payload path is stale.
 
 Red:
 
@@ -599,7 +649,7 @@ Red:
 
 Green:
 
-- Update prompt/running event mapping to the verified current event and payload contract.
+- Update event mappings to the verified current event and payload contract.
 - Keep template/spec parity scoped to installable specs.
 
 Run:
@@ -634,10 +684,12 @@ Run:
 ## 5. Acceptance Criteria
 
 - Codex install/check cannot report green unless `features.codex_hooks=true` and required current events are valid.
+- Codex install preflights both config and hooks files; malformed input leaves both files unchanged.
 - Codex `PermissionRequest` is required, not FutureOnly.
 - Codex remove does not leave empty event keys that Purdex itself later reports as broken.
 - Claude CheckHooks rejects wrong-agent and wrong-event `pdx hook` commands.
-- OpenCode plugin event mapping is verified against current OpenCode docs/runtime shape.
+- Ignored/unsupported hook declarations never enter install completeness, but stale Purdex-owned entries can be removed safely.
+- OpenCode plugin event mapping is verified against current OpenCode docs/runtime shape with checked-in provenance fixtures.
 - OpenCode CheckHooks reports version support fields like cc/codex.
 - OpenCode icon registry has explicit tests.
 - No files under `internal/module/agent/*`, `internal/agent/probe/*`, `internal/store/*`, or tab rendering are modified.
@@ -646,7 +698,7 @@ Run:
 
 ## 6. Risks
 
-- TOML round-trip may rewrite user formatting in `~/.codex/config.toml`. Keep helper minimal and document this if unavoidable.
+- TOML round-trip may rewrite user formatting in `~/.codex/config.toml`; semantic keys/values are preserved, but comments/order are not guaranteed.
 - Full upstream hook catalog classification may grow long. Keep it declarative and provider-local; do not add a central runtime dispatcher.
-- OpenCode prompt event mapping may require runtime verification if docs do not identify a direct replacement for `chat.message`. If uncertain, split into a smaller PR that only adds tests and version reporting first.
+- OpenCode event mapping may require runtime verification if docs do not identify stable event keys and payload paths. If uncertain, split into a smaller PR that only adds tests and version reporting first.
 - Existing tests may assume exactly 9 cc / 9 codex / 8 opencode events. Update those tests to count installed events separately from known upstream declarations.

--- a/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
+++ b/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
@@ -1,0 +1,652 @@
+# Agent Hooks Hotfix TDD Plan — Catalog + Install Correctness + OpenCode Icon Guard
+
+- **Date**: 2026-04-25
+- **Status**: Draft plan
+- **Worktree**: `.claude/worktrees/agent-hooks-hotfix-plan`（branch `worktree-agent-hooks-hotfix-plan`）
+- **Baseline**: `origin/main @ 75b4d166` (`1.0.0-alpha.224`)
+- **Related specs**:
+  - `docs/specs/2026-04-23-lights-rebuild-spec.md` §2.4 Architecture Guardrails
+  - `docs/specs/2026-04-23-hook-events-declaration-plan.md`
+  - `docs/specs/2026-04-23-hook-events-fix-plan.md`
+- **Scope**: provider-level hook catalog/install/check correctness + OpenCode icon test coverage
+- **Non-goal**: do not change light rebuild runtime frame/projection/probe logic
+
+---
+
+## 0. Spec Reconfirmation
+
+### 0.1 Architecture Guardrails Still Apply
+
+This hotfix keeps the current architecture:
+
+- Hook policy stays distributed per provider (`internal/agent/{cc,codex,opencode}`).
+- Shared plumbing (`internal/module/agent/*`) is not touched.
+- Build-time declarations are allowed; runtime central FSM / transition registry is not.
+- `HookEventSpec` remains the SSoT for Purdex-managed hook declarations.
+
+### 0.2 Why This Is Independent From Lights Rebuild
+
+Lights rebuild handles events **after** Purdex receives a verified hook:
+
+```text
+agent hook emits
+  -> pdx hook
+  -> /api/agent/event
+  -> verifyEvent
+  -> provider.DeriveStatus
+  -> frame/projection/light state
+```
+
+This hotfix handles the provider boundary **before** that path:
+
+```text
+agent documented hook surface
+  -> Purdex hook catalog
+  -> installer/checker writes/validates agent config
+  -> pdx hook can actually emit into Purdex
+```
+
+Therefore this PR must not touch:
+
+- `internal/module/agent/*`
+- `internal/agent/probe/*`
+- `internal/store/*`
+- tab rendering / SubagentDots / light projection UI files
+
+### 0.3 File Conflict Boundary
+
+`lights-phase-3` currently modifies:
+
+- `docs/specs/2026-04-25-lights-rebuild-phase-3-plan.md`
+- `internal/agent/probe/liveness.go`
+- `internal/agent/probe/liveness_test.go`
+- `internal/agent/probe/probe.go`
+- `internal/module/agent/frame_ops.go`
+- `internal/module/agent/frame_ops_test.go`
+- `internal/module/agent/handler_test.go`
+
+This hotfix may modify only:
+
+- `internal/agent/provider.go`
+- `internal/agent/supported_statuses_test.go`
+- `internal/agent/cc/events.go`
+- `internal/agent/cc/events_test.go`
+- `internal/agent/cc/hooks.go`
+- `internal/agent/cc/hooks_test.go`
+- `internal/agent/codex/events.go`
+- `internal/agent/codex/events_test.go`
+- `internal/agent/codex/hooks.go`
+- `internal/agent/codex/hooks_test.go`
+- `internal/agent/opencode/events.go`
+- `internal/agent/opencode/events_test.go`
+- `internal/agent/opencode/hooks.go`
+- `internal/agent/opencode/hooks_test.go`
+- `internal/agent/opencode/plugin_template.go`
+- `internal/agent/opencode/plugin_template_test.go`
+- `internal/agent/opencode/status.go`
+- `internal/agent/opencode/status_test.go`
+- `spa/src/lib/agent-icons.test.tsx`
+
+`spa/src/lib/agent-icons.tsx` is already implemented on `main`; only test coverage is expected.
+
+---
+
+## 1. Problems To Fix
+
+### 1.1 Hook Catalog Means “Known Upstream Hook”, Not Only “Installable Event”
+
+Current `HookEventSpec` records the Purdex-managed installable event subset. That is insufficient for inspection and drift prevention because agents expose hooks that Purdex may intentionally ignore or not install.
+
+Required clarification:
+
+- Every upstream hook event that is relevant for the current supported agent versions must be explicitly classified.
+- Classification does not mean every event emits a `Status`.
+- Classification must distinguish installable status events, installable detail-only events, ignored upstream events, and unsupported upstream events.
+- Existing installer/checker behavior must continue to operate on the **installable subset** only.
+
+### 1.2 Codex Hooks Require Feature Flag
+
+Codex docs for the current CLI require:
+
+```toml
+[features]
+codex_hooks = true
+```
+
+Current installer writes `~/.codex/hooks.json` only. This can produce a false-green status: Purdex says hooks are installed, but Codex does not load them.
+
+### 1.3 Codex `PermissionRequest` Is No Longer FutureOnly
+
+Local checked version: `codex-cli 0.124.0`.
+
+Current docs list `PermissionRequest` as a current supported hook. Existing code still marks it `FutureOnly: true`, so missing `PermissionRequest` is tolerated when it should block install completeness.
+
+### 1.4 Codex Remove Leaves Empty Hook Keys
+
+`mergeCodexHooks(..., remove=true)` can leave:
+
+```json
+{ "hooks": { "PermissionRequest": [] } }
+```
+
+`CheckHooks` intentionally treats a present empty array as broken. Purdex remove should not create the same broken state it later reports as a problem.
+
+### 1.5 Claude CheckHooks Is Too Loose
+
+Codex already validates command shape per event:
+
+- binary basename is `pdx`
+- command includes `hook`
+- `--agent codex`
+- final event token matches the config key
+
+Claude currently only finds a command containing `pdx hook`. It can mark a wrong-agent or wrong-event command as installed.
+
+### 1.6 OpenCode Plugin Mapping Needs Current-Docs Guard
+
+OpenCode `1.14.23` docs list plugin events such as:
+
+- `session.created`
+- `session.idle`
+- `session.error`
+- `session.deleted`
+- `permission.asked`
+- `tool.execute.before`
+- `tool.execute.after`
+- many message/file/todo/server events
+
+Current Purdex plugin maps a selected subset and includes `chat.message`. The public plugin docs do not list `chat.message` in the current event table, so this must be verified against the current OpenCode runtime or source before changing production code. If `chat.message` is stale, `UserPromptSubmit` / running transitions may not emit.
+
+### 1.7 OpenCode Icon Is Implemented But Untested
+
+`spa/src/lib/agent-icons.tsx` already imports `opencode.svg` and returns it for `agentType === "opencode"`. Missing UI icon reports should be treated as either:
+
+- missing test coverage, or
+- `agentTypes[ck]` never becoming `opencode` because hooks are not emitted/installed.
+
+This hotfix adds only icon registry tests. Rendering pipeline changes are out of scope.
+
+---
+
+## 2. Contract Changes
+
+### 2.1 Hook Classification
+
+Add a lightweight classification field to hook declarations without introducing a central runtime dispatcher. Raw `HookEventSpec.Handling` must not be read directly by installer/checker code; consumers use the helper functions below so zero-value legacy specs remain safe.
+
+Proposed extension in `internal/agent/provider.go`:
+
+```go
+type HookHandling string
+
+const (
+    HookHandlingStatus     HookHandling = "status"      // may emit non-empty Status
+    HookHandlingDetail     HookHandling = "detail"      // Valid=true, Status="" detail-only
+    HookHandlingIgnored    HookHandling = "ignored"     // known upstream event, intentionally not installed/parsed
+    HookHandlingUnsupported HookHandling = "unsupported" // known upstream event not supported by this Purdex version
+)
+
+type HookEventSpec struct {
+    Name        string
+    EmitsStatus []Status
+    Description string
+    FutureOnly  bool
+    Handling    HookHandling
+}
+```
+
+Required helpers in `internal/agent/provider.go`:
+
+```go
+func EffectiveHookHandling(spec HookEventSpec) HookHandling
+func IsInstallableHookSpec(spec HookEventSpec) bool
+```
+
+Rules:
+
+- `EffectiveHookHandling` maps empty `Handling` to `status` when `EmitsStatus` is non-empty.
+- `EffectiveHookHandling` maps empty `Handling` to `detail` when `EmitsStatus` is empty. This preserves existing SubagentStart/Stop behavior during migration.
+- Upstream events Purdex chooses not to install use `ignored` or `unsupported`.
+- `SupportedStatuses()` continues to union only `EmitsStatus`.
+- `IsInstallableHookSpec` returns true only for effective `status` and `detail`.
+- `InstallHooks` installs only installable events unless a provider explicitly decides otherwise.
+- `CheckHooks` reports installed state only for installable events; ignored/unsupported events can be exposed later to Inspector but must not block install completeness.
+- Template/spec parity checks compare template emissions against installable specs only.
+
+Derived predicate table:
+
+| Effective handling | Installed by installer | Blocks `Installed=true` when missing | Contributes `SupportedStatuses` | Runtime parser required |
+|---|---:|---:|---:|---:|
+| `status` | yes | yes unless `FutureOnly` tolerated absent | yes | yes |
+| `detail` | yes | yes unless `FutureOnly` tolerated absent | no | yes |
+| `ignored` | no | no | no | no |
+| `unsupported` | no | no | no | no |
+
+### 2.2 Provider Catalog Updates
+
+#### Claude Code
+
+Keep current installed set as-is:
+
+- `SessionStart`
+- `UserPromptSubmit`
+- `SubagentStart`
+- `SubagentStop`
+- `Stop`
+- `StopFailure`
+- `Notification`
+- `PermissionRequest`
+- `SessionEnd`
+
+Add explicit known-but-not-installed declarations for current documented hook events such as:
+
+- `PreToolUse`
+- `PostToolUse`
+- `PostToolUseFailure`
+- `PermissionDenied`
+- `UserPromptExpansion`
+- `PostToolBatch`
+- `TaskCreated`
+- `TaskCompleted`
+- `PreCompact`
+- `PostCompact`
+- `ConfigChange`
+- `CwdChanged`
+- `FileChanged`
+- `WorktreeCreate`
+- `WorktreeRemove`
+- other documented lifecycle events not currently installed
+
+These must not change current status behavior.
+
+#### Codex
+
+Required set after this hotfix (`Installed=true` blocks when absent/broken):
+
+- `SessionStart`
+- `UserPromptSubmit`
+- `PermissionRequest`
+- `Stop`
+
+FutureOnly tolerated-absent set remains parser-capable and opportunistically installed, but missing entries do not block `Installed=true`:
+
+- `SubagentStart`
+- `SubagentStop`
+- `StopFailure`
+- `Notification`
+- `SessionEnd`
+
+Installer behavior remains broad: Purdex writes all installable status/detail Codex events (the 4 required events plus the 5 FutureOnly events). `FutureOnly` changes checker tolerance, not whether reinstall can seed the hook entry.
+
+Add explicit known ignored/unsupported entries for current documented events that Purdex does not install yet:
+
+- `PreToolUse`
+- `PostToolUse`
+
+Do not add runtime status behavior for `PreToolUse` / `PostToolUse` in this PR.
+
+#### OpenCode
+
+Keep currently intended normalized events:
+
+- `SessionStart` from `session.created`
+- `PermissionRequest` from `permission.asked` / `question.asked` if still valid
+- `StopFailure` from `session.error`
+- `Stop` from `session.idle`
+- `SessionEnd` from `session.deleted`
+- `UserPromptSubmit` from the current prompt/message event after verification
+- `SubagentStart` / `SubagentStop` from `tool.execute.before/after` task calls
+
+Explicitly document all current OpenCode plugin events not installed/mapped as ignored/unsupported.
+
+OpenCode template/spec parity and CheckHooks event installation must use only `IsInstallableHookSpec(spec) == true`. Ignored/unsupported OpenCode upstream events must appear in the catalog but must not be expected in the managed plugin body and must not be marked installed by `CheckHooks`.
+
+### 2.3 Codex Feature Flag Contract
+
+Install:
+
+- Ensure `~/.codex/config.toml` exists.
+- Preserve all existing config content as much as practical.
+- Ensure `[features].codex_hooks = true`.
+- Then write `~/.codex/hooks.json`.
+
+Check:
+
+- Missing or false `features.codex_hooks` blocks `Installed`.
+- Existing valid hooks with missing feature flag should be `Managed=true, Installed=false`.
+- Issue message should be explicit: `codex hooks feature flag disabled; run install to enable features.codex_hooks`.
+- Accepted TOML preservation contract: semantic keys must survive, but formatting, comments, and key order may be rewritten by the TOML encoder.
+
+Remove:
+
+- Remove Purdex hook entries from `hooks.json`.
+- Do not disable `features.codex_hooks`; users may rely on other hooks.
+
+### 2.4 Codex Remove Contract
+
+After remove:
+
+- If an event has no remaining entries, delete that event key from `hooks`.
+- If `hooks` becomes empty, keeping `{ "hooks": {} }` is acceptable.
+- Third-party matcher groups remain.
+
+### 2.5 Claude Strict Command Contract
+
+Claude checker should mirror Codex per-event validation:
+
+- Tokenize quote-aware.
+- First token basename must be `pdx`.
+- Later token `hook` must exist.
+- `--agent cc` must exist.
+- Final non-empty token must equal the event key.
+
+`filterOutPdx` should remove only commands that are valid Purdex hook commands for `cc`, not arbitrary `pdx hook --agent codex` commands.
+
+### 2.6 OpenCode Version Status
+
+Add `opencodeHooksSupportedVersion = "1.14.23"` and return `SupportedVersion` / `ExceedsSupport` in all `CheckHooks` paths for parity with cc/codex.
+
+### 2.7 OpenCode Mapping Verification Gate
+
+Before changing `renderManagedPlugin`, capture or verify the current OpenCode `1.14.23` prompt/message event contract. The implementation commit must name the exact event key and payload fields in this plan or a retrospective note before production code changes.
+
+If no stable current prompt event is confirmed, keep the production template unchanged in this hotfix and limit OpenCode changes to catalog classification, version reporting, and tests that document the uncertainty.
+
+---
+
+## 3. TDD Test Matrix
+
+### 3.1 Hook Classification Tests
+
+File candidates:
+
+- `internal/agent/cc/events_test.go`
+- `internal/agent/codex/events_test.go`
+- `internal/agent/opencode/events_test.go`
+- `internal/agent/supported_statuses_test.go`
+
+Tests:
+
+| ID | Test | Red Assertion |
+|---|---|---|
+| HC1 | `TestEffectiveHookHandlingDefaults` | empty handling + non-empty `EmitsStatus` derives `status`; empty handling + empty `EmitsStatus` derives `detail` |
+| HC1b | `TestIsInstallableHookSpec` | `status/detail` are installable; `ignored/unsupported` are not |
+| HC2 | `TestSupportedStatusesIgnoresIgnoredHooks` | ignored/unsupported hooks with empty `EmitsStatus` do not affect status set |
+| HC3 | `TestCCEventsClassifyKnownUpstreamHooks` | documented non-installed cc hooks exist and are `ignored` / `unsupported` |
+| HC4 | `TestCodexEventsClassifyCurrentDocs` | `PermissionRequest` is non-FutureOnly; `PreToolUse`/`PostToolUse` are explicitly classified |
+| HC5 | `TestOpenCodeEventsClassifyPluginSurface` | OpenCode plugin docs events not mapped are explicitly classified |
+| HC6 | `TestInstallableEventNamesStayStable` | installable sets remain cc=9, codex=9, opencode=8 before provider-specific changes |
+
+### 3.2 Codex Feature Flag Tests
+
+File: `internal/agent/codex/hooks_test.go`
+
+Tests:
+
+| ID | Test | Red Assertion |
+|---|---|---|
+| CF1 | `TestCodexInstallHooks_EnablesFeatureFlag` | after install, `~/.codex/config.toml` has `[features].codex_hooks = true` |
+| CF2 | `TestCodexInstallHooks_PreservesExistingConfig` | unrelated TOML keys survive install |
+| CF2b | `TestCodexInstallHooks_MergesExistingFeaturesTable` | existing `[features]` entries survive and `codex_hooks` flips true |
+| CF2c | `TestCodexInstallHooks_MalformedConfigReturnsError` | malformed TOML returns error and does not overwrite file |
+| CF3 | `TestCodexCheckHooks_FeatureFlagMissingBlocks` | valid hooks.json + missing flag => `Installed=false`, `Managed=true`, issue present |
+| CF4 | `TestCodexCheckHooks_FeatureFlagFalseBlocks` | `codex_hooks=false` blocks install completeness |
+| CF5 | `TestCodexRemoveHooks_DoesNotDisableFeatureFlag` | remove leaves `codex_hooks=true` unchanged |
+
+### 3.3 Codex FutureOnly / Remove Tests
+
+File: `internal/agent/codex/hooks_test.go`, `internal/agent/codex/events_test.go`
+
+Tests:
+
+| ID | Test | Red Assertion |
+|---|---|---|
+| CP1 | `TestCodexEventsPermissionRequestRequired` | `PermissionRequest.FutureOnly == false` |
+| CP2 | `TestCheckHooks_PermissionRequestMissingBlocks` | missing `PermissionRequest` blocks `Installed` |
+| CP3 | `TestCheckHooks_UpgradesAvailableDoesNotIncludePermissionRequest` | legacy hooks list excludes `PermissionRequest` from upgrades and reports issue instead |
+| CP4 | `TestMergeCodexHooks_RemoveDeletesEmptyEventKeys` | remove deletes keys with no remaining third-party hooks |
+| CP5 | `TestCheckHooks_AfterPurdexRemoveFutureOnlyAbsentDoesNotWarn` | installer remove no longer creates empty-array broken warnings |
+
+### 3.4 Claude Strict Checker Tests
+
+File: `internal/agent/cc/hooks_test.go`
+
+Tests:
+
+| ID | Test | Red Assertion |
+|---|---|---|
+| CS1 | `TestCCCheckHooks_WrongAgentCommandNotInstalled` | `pdx hook --agent codex SessionStart` under cc key is not installed |
+| CS2 | `TestCCCheckHooks_WrongEventCommandNotInstalled` | `pdx hook --agent cc Stop` under `SessionStart` key is not installed |
+| CS3 | `TestCCCheckHooks_QuotedPathWithSpacesValid` | `"/Applications/Purdex Beta/pdx" hook --agent cc Stop` passes |
+| CS4 | `TestMergeClaudeHooks_DoesNotRemoveOtherAgentPdxHook` | remove keeps `--agent codex` command in Claude settings |
+| CS5 | `TestMergeClaudeHooks_ReplacesOnlyCcPdxEntries` | reinstall replaces old cc pdx path but preserves third-party and non-cc pdx hooks |
+
+### 3.5 OpenCode Plugin Mapping / Version Tests
+
+Files:
+
+- `internal/agent/opencode/plugin_template_test.go`
+- `internal/agent/opencode/hooks_test.go`
+- `internal/agent/opencode/events_test.go`
+
+Tests:
+
+| ID | Test | Red Assertion |
+|---|---|---|
+| OC1 | `TestOpenCodePluginTemplate_UsesCurrentPromptEvent` | template uses the verified current event for prompt/running transition, not stale API |
+| OC1a | `TestOpenCodePromptEventContractDocumented` | test fixture names the current verified prompt/message event and required payload fields |
+| OC2 | `TestTemplateSpecsParity` | emitted template events match installable specs only |
+| OC3 | `TestOpenCodeEvents_ClassifiesCurrentPluginEvents` | current documented OpenCode plugin events are classified |
+| OC4 | `TestOpenCodeCheckHooks_ReportsSupportedVersion` | status includes `SupportedVersion=1.14.23` |
+| OC5 | `TestOpenCodeCheckHooks_ExceedsSupport` | version comparison warning works when detected version is greater |
+
+### 3.6 OpenCode Icon Guard Test
+
+File: `spa/src/lib/agent-icons.test.tsx`
+
+Tests:
+
+| ID | Test | Red Assertion |
+|---|---|---|
+| OI1 | `returns opencode icon for opencode agent type` | `getAgentIcon('opencode', ...)` returns a defined component |
+| OI2 | `opencode icon is independent of cc/codex variants` | component identity stable across cc/codex variant combinations |
+
+OI1/OI2 are coverage guards on the current baseline; they are allowed to pass immediately because production icon support already exists.
+
+---
+
+## 4. TDD Commit Plan
+
+### Commit 1a — `feat(agent): add hook handling helpers`
+
+Red:
+
+- HC1-HC2 fail.
+
+Green:
+
+- Add `HookHandling` field/types.
+- Add `EffectiveHookHandling` and `IsInstallableHookSpec` in `internal/agent/provider.go`.
+- Keep existing provider event declarations unchanged.
+- Ensure `SupportedStatuses` tests stay green and use effective handling only where classification matters.
+
+Run:
+
+- `go test ./internal/agent/... -count=1`
+
+### Commit 1b — `fix(agent): scope hook installers to installable specs`
+
+Red:
+
+- HC6 fails.
+- Existing exact catalog/template/checker tests fail if they read raw catalog size after ignored/unsupported entries are introduced.
+
+Green:
+
+- Migrate cc/codex/opencode event-name helpers, installers, checkers, and OpenCode template/spec parity to `IsInstallableHookSpec`.
+- Split tests into full upstream catalog assertions and installable set assertions.
+- Preserve installable sets before provider-specific changes: cc=9, codex=9, opencode=8.
+
+Run:
+
+- `go test ./internal/agent/... -count=1`
+
+### Commit 1c — `feat(agent): classify upstream hook catalog`
+
+Red:
+
+- HC3-HC5 fail.
+
+Green:
+
+- Add known upstream ignored/unsupported declarations for cc/codex/opencode.
+- Keep ignored/unsupported entries out of install completeness and OpenCode template parity.
+- Keep runtime status derivation unchanged for installable status/detail events.
+
+Run:
+
+- `go test ./internal/agent/... -count=1`
+
+### Commit 2 — `fix(agent/codex): require hooks feature flag and current PermissionRequest`
+
+Red:
+
+- CF1-CF5 and CF2b-CF2c fail.
+- CP1-CP3 fail.
+
+Green:
+
+- Add TOML read/write helpers for `~/.codex/config.toml`.
+- Install enables `features.codex_hooks`.
+- Check blocks when feature flag missing/false.
+- Preserve TOML semantic keys while accepting formatting/comment/order rewrites.
+- `PermissionRequest.FutureOnly=false`.
+- Update `codexHooksSupportedVersion` to `0.124.0`.
+
+Run:
+
+- `go test ./internal/agent/codex ./internal/agent -count=1`
+
+### Commit 3 — `fix(agent/codex): remove empty hook keys on uninstall`
+
+Red:
+
+- CP4-CP5 fail.
+
+Green:
+
+- `mergeCodexHooks(remove=true)` deletes event key when no entries remain.
+- Preserve third-party matcher groups.
+- Keep CheckHooks strict present-but-empty behavior for manually broken files.
+
+Run:
+
+- `go test ./internal/agent/codex -count=1`
+
+### Commit 4 — `fix(agent/cc): validate hooks by agent and event`
+
+Red:
+
+- CS1-CS5 fail.
+
+Green:
+
+- Add quote-aware tokenizer / per-event validator for cc.
+- Use strict validator for `CheckHooks`.
+- Use cc-scoped filtering for install/remove.
+
+Run:
+
+- `go test ./internal/agent/cc -count=1`
+
+### Commit 5a — `fix(agent/opencode): report hook support version`
+
+Red:
+
+- OC4-OC5 fail.
+
+Green:
+
+- Add supported version reporting for OpenCode.
+
+Run:
+
+- `go test ./internal/agent/opencode ./internal/agent -count=1`
+
+### Commit 5b — `test(agent/opencode): document prompt event contract`
+
+Red:
+
+- OC1a fails until a current OpenCode `1.14.23` prompt/message event key and required payload fields are documented from source/runtime verification.
+
+Green:
+
+- Add a fixture or test note naming the verified event contract.
+- Do not change `renderManagedPlugin` unless the verified contract proves `chat.message` is stale.
+
+Run:
+
+- `go test ./internal/agent/opencode -count=1`
+
+### Commit 5c — `fix(agent/opencode): refresh plugin prompt mapping`
+
+Only needed if Commit 5b proves the existing `chat.message` mapping is stale.
+
+Red:
+
+- OC1 fails.
+- OC2 fails if template/spec parity is not scoped to installable specs.
+
+Green:
+
+- Update prompt/running event mapping to the verified current event and payload contract.
+- Keep template/spec parity scoped to installable specs.
+
+Run:
+
+- `go test ./internal/agent/opencode ./internal/agent -count=1`
+
+### Commit 6 — `test(spa): guard opencode agent icon`
+
+Coverage baseline:
+
+- OI1-OI2 may already pass on the current baseline because OpenCode production icon support exists.
+
+Implementation:
+
+- Add coverage-only tests for OpenCode icon lookup and identity behavior.
+- Do not touch tab rendering.
+
+Run:
+
+- `pnpm --prefix spa exec vitest run src/lib/agent-icons.test.tsx`
+
+### Final Verification
+
+Run:
+
+- `go test ./internal/agent/... -count=1`
+- `pnpm --prefix spa exec vitest run src/lib/agent-icons.test.tsx`
+- Optional full checks before PR: `make test`, `pnpm --prefix spa run lint`, `pnpm --prefix spa run build`
+
+---
+
+## 5. Acceptance Criteria
+
+- Codex install/check cannot report green unless `features.codex_hooks=true` and required current events are valid.
+- Codex `PermissionRequest` is required, not FutureOnly.
+- Codex remove does not leave empty event keys that Purdex itself later reports as broken.
+- Claude CheckHooks rejects wrong-agent and wrong-event `pdx hook` commands.
+- OpenCode plugin event mapping is verified against current OpenCode docs/runtime shape.
+- OpenCode CheckHooks reports version support fields like cc/codex.
+- OpenCode icon registry has explicit tests.
+- No files under `internal/module/agent/*`, `internal/agent/probe/*`, `internal/store/*`, or tab rendering are modified.
+
+---
+
+## 6. Risks
+
+- TOML round-trip may rewrite user formatting in `~/.codex/config.toml`. Keep helper minimal and document this if unavoidable.
+- Full upstream hook catalog classification may grow long. Keep it declarative and provider-local; do not add a central runtime dispatcher.
+- OpenCode prompt event mapping may require runtime verification if docs do not identify a direct replacement for `chat.message`. If uncertain, split into a smaller PR that only adds tests and version reporting first.
+- Existing tests may assume exactly 9 cc / 9 codex / 8 opencode events. Update those tests to count installed events separately from known upstream declarations.

--- a/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
+++ b/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
@@ -227,6 +227,14 @@ Stale ignored/unsupported artifacts already present on disk:
 - `Managed=true` may be based on any Purdex-owned artifact, including stale ignored/unsupported entries, so users can run remove.
 - RemoveHooks must remove stale Purdex-owned ignored/unsupported commands while preserving third-party entries.
 
+Purdex ownership for cleanup is provider-local and explicit:
+
+- Remove/managed detection may scan all configured hook keys, including keys not present in the current installable set.
+- A command is Purdex-owned only when its tokenized shape targets this provider and its event token is in that provider's owned cleanup set.
+- The owned cleanup set includes currently installable events plus any historically installed Purdex events that were later retired.
+- Unknown event tokens are preserved by default, even when they use `pdx hook --agent <provider>`, because they may be user-authored, future upstream events, or third-party integrations.
+- If a future Purdex release removes an event from installable handling, it must keep the event in the owned cleanup set so uninstall can clean artifacts from older Purdex versions.
+
 Derived predicate table:
 
 | Effective handling | Installed by installer | Blocks `Installed=true` when missing | Contributes `SupportedStatuses` | Runtime parser required |

--- a/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
+++ b/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
@@ -335,10 +335,11 @@ Install:
 
 - Ensure `~/.codex/config.toml` exists.
 - Preserve existing TOML semantic keys/values; comments, formatting, and ordering are not guaranteed.
+- Preserve an existing `config.toml` file mode; new config files default to owner-readable/writeable (`0600`).
 - Ensure `[features].codex_hooks = true`.
 - Parse both existing `config.toml` and `hooks.json` before writing either file; missing files are treated as empty config/hook maps.
 - If either parse fails, return before writing; both files must remain byte-for-byte unchanged.
-- After successful parse, write `config.toml`, then write `hooks.json`.
+- After successful parse, write `hooks.json` before enabling `config.toml`; hook write failure must leave `config.toml` byte-for-byte unchanged so failed install cannot enable `features.codex_hooks` without current Purdex hooks.
 
 Check:
 

--- a/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
+++ b/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
@@ -702,3 +702,53 @@ Run:
 - Full upstream hook catalog classification may grow long. Keep it declarative and provider-local; do not add a central runtime dispatcher.
 - OpenCode event mapping may require runtime verification if docs do not identify stable event keys and payload paths. If uncertain, split into a smaller PR that only adds tests and version reporting first.
 - Existing tests may assume exactly 9 cc / 9 codex / 8 opencode events. Update those tests to count installed events separately from known upstream declarations.
+
+---
+
+## 7. Review-Sized PR Slicing
+
+Codex review found that the foundation PR could still ship false-green Codex hook state if Codex current-runtime correctness stayed deferred. The review-sized split is therefore adjusted as follows:
+
+### PR 1 — Hook Foundation + Codex Current Correctness
+
+Include:
+
+- Commit 1a hook handling helpers.
+- Commit 1b installable-subset filtering for installers/checkers/template parity.
+- Owner-scoped cleanup for cc/codex Purdex hook artifacts so remove does not delete other-provider hooks.
+- Codex `features.codex_hooks=true` install/check gating with parse-before-write preflight.
+- Codex `PermissionRequest` requiredness and supported version update.
+- Codex remove empty-key cleanup for owned installable and stale/retired Codex hook entries.
+
+Rationale:
+
+- These changes share the same user-visible contract: `CheckHooks.Installed=true` must mean the agent will actually load and emit Purdex hooks.
+- The size is still reviewable because it is limited to `internal/agent/provider.go`, provider hook code/tests, and this plan document.
+- It remains outside lights runtime/probe/module files.
+
+### PR 2 — Upstream Catalog Classification
+
+Include:
+
+- Exact version-pinned cc/codex/opencode upstream catalog tables.
+- Real ignored/unsupported declarations and full catalog set assertions.
+- Provider catalog validation that newly added non-installable upstream entries must explicitly set `Handling` and must not emit statuses.
+
+### PR 3 — Remaining Claude Strictness, If Needed
+
+Include only behavior not already covered by PR 1 owner-scoped cleanup/checker strictness, such as additional reinstall/remove edge cases that are not required for installable-subset safety.
+
+### PR 4 — OpenCode Version + Event Contract
+
+Include:
+
+- OpenCode supported-version reporting.
+- Checked-in OpenCode event contract provenance fixtures for every template-consumed event.
+
+### PR 5 — OpenCode Mapping Refresh, Conditional
+
+Only create this PR if PR 4 proves an existing managed template event key or payload path is stale. Keep it separate because it can affect lights frame/projection behavior.
+
+### PR 6 — OpenCode Icon Guard
+
+Coverage-only SPA test. May be bundled with PR 4 if review load is low; otherwise keep as a small test-only PR.

--- a/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
+++ b/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
@@ -367,13 +367,13 @@ Claude checker should mirror Codex per-event validation:
 
 - Tokenize quote-aware.
 - First token basename must be `pdx`.
-- Later token `hook` must exist.
+- The first `pdx` subcommand token must be `hook`; wrapper-like commands such as `pdx exec hook ...` are not Purdex-owned hook commands.
 - `--agent cc` must exist.
 - Final non-empty token must equal the event key.
 
 `filterOutPdx` should remove only commands that are valid Purdex hook commands for `cc`, not arbitrary `pdx hook --agent codex` commands.
 
-For checker validation, event matching is per-key strict: the final command token must equal the settings event key. For remove/reinstall filtering, remove any well-formed `pdx hook --agent cc <supported-event>` entry even if it is currently filed under the wrong Claude event key; this cleans stale Purdex-owned commands while preserving non-cc commands.
+For checker validation, event matching is per-key strict: the final command token must equal the settings event key. For remove/reinstall filtering, remove any well-formed `pdx hook --agent cc <owned-cleanup-event>` entry even if it is currently filed under the wrong Claude event key; this cleans stale Purdex-owned commands while preserving non-cc commands and unknown cc event tokens.
 
 ### 2.6 OpenCode Version Status
 
@@ -419,7 +419,9 @@ Tests:
 | HC5 | `TestOpenCodeEventsClassifyPluginSurface` | OpenCode plugin docs events not mapped are explicitly classified |
 | HC6 | `TestInstallableEventNamesStayStable` | installable sets remain cc=9, codex=9, opencode=8 after upstream catalog expansion |
 | HC6b | `TestInstallableFilteringUsesHandling` | synthetic ignored/unsupported specs are excluded from event-name helpers, checker completeness, and OpenCode template parity |
-| HC7 | `TestStaleNonInstallablePdxArtifactsDoNotBlockInstall` | stale Purdex-owned ignored/unsupported entries set `Managed=true`, do not affect `Installed`, and are removed by remove |
+| HC7 | `TestStaleNonInstallablePdxArtifactsDoNotBlockInstall` | stale Purdex-owned retired entries set `Managed=true`, do not affect `Installed`, and are removed by remove |
+| HC7a | `TestUnknownProviderPdxArtifactsArePreserved` | unknown event tokens using `pdx hook --agent <provider>` are not treated as Purdex-owned and survive remove |
+| HC7b | `TestOwnedArtifactsUnderUnknownKeysAreRemoved` | known owned event tokens are removable even when filed under an unknown hook key |
 
 ### 3.2 Codex Feature Flag Tests
 
@@ -434,6 +436,9 @@ Tests:
 | CF2b | `TestCodexInstallHooks_MergesExistingFeaturesTable` | existing `[features]` entries survive and `codex_hooks` flips true |
 | CF2c | `TestCodexInstallHooks_MalformedConfigReturnsError` | malformed TOML returns error and does not overwrite file |
 | CF2d | `TestCodexInstallHooks_ParseFailureDoesNotPartiallyWrite` | malformed `config.toml` or `hooks.json` leaves both files byte-for-byte unchanged |
+| CF2e | `TestCodexInstallHooks_PreservesExistingConfigMode` | existing `config.toml` mode, e.g. `0600`, is preserved after install |
+| CF2f | `TestCodexInstallHooks_HooksWriteFailureLeavesConfigUnchanged` | hooks write failure returns error and leaves `config.toml` byte-for-byte unchanged |
+| CF2g | `TestCodexInstallHooks_NewConfigUsesOwnerOnlyMode` | newly-created `config.toml` is written with `0600` permissions |
 | CF3 | `TestCodexCheckHooks_FeatureFlagMissingBlocks` | valid hooks.json + missing flag => `Installed=false`, `Managed=true`, issue present |
 | CF4 | `TestCodexCheckHooks_FeatureFlagFalseBlocks` | `codex_hooks=false` blocks install completeness |
 | CF5 | `TestCodexRemoveHooks_DoesNotDisableFeatureFlag` | remove leaves `codex_hooks=true` unchanged |
@@ -451,6 +456,9 @@ Tests:
 | CP3 | `TestCheckHooks_UpgradesAvailableDoesNotIncludePermissionRequest` | legacy hooks list excludes `PermissionRequest` from upgrades and reports issue instead |
 | CP4 | `TestMergeCodexHooks_RemoveDeletesEmptyEventKeys` | remove deletes keys with no remaining third-party hooks |
 | CP5 | `TestCheckHooks_AfterPurdexRemoveFutureOnlyAbsentDoesNotWarn` | installer remove no longer creates empty-array broken warnings |
+| CP6 | `TestCodexRemoveHooks_PreservesUnknownEventTokens` | `pdx hook --agent codex Bogus` survives remove and does not set `Managed=true` |
+| CP7 | `TestCodexRemoveHooks_RemovesOwnedEventUnderUnknownKey` | `pdx hook --agent codex SessionStart` under an unknown hooks key is removed |
+| CP8 | `TestIsPdxCommandCodexForEvent_RequiresHookSubcommand` | `pdx exec hook --agent codex SessionStart` is rejected |
 
 CP2, CP3, and CP5 fixtures must include `features.codex_hooks=true` unless the test is specifically about feature flag handling.
 
@@ -468,6 +476,9 @@ Tests:
 | CS4 | `TestMergeClaudeHooks_DoesNotRemoveOtherAgentPdxHook` | remove keeps `--agent codex` command in Claude settings |
 | CS5 | `TestMergeClaudeHooks_ReplacesOnlyCcPdxEntries` | reinstall replaces old cc pdx path but preserves third-party and non-cc pdx hooks |
 | CS6 | `TestMergeClaudeHooks_RemovesWrongEventCcPdxEntry` | remove/reinstall deletes well-formed `--agent cc` commands even when filed under the wrong event key |
+| CS7 | `TestCCCheckHooks_ManagedReflectsOwnedPdxUnderUnknownKey` | known owned cc event token under an unknown hook key sets `Managed=true` |
+| CS8 | `TestIsPdxCommand_RequiresHookSubcommand` | `pdx exec hook --agent cc SessionStart` is rejected |
+| CS9 | `TestMergeClaudeHooks_RemovesOwnedPdxUnderUnknownKey` | remove deletes known owned cc event tokens even when stored under an unknown settings key |
 
 ### 3.5 OpenCode Plugin Mapping / Version Tests
 
@@ -541,11 +552,13 @@ Run:
 
 - `go test ./internal/agent/... -count=1`
 
-### Commit 1c — `feat(agent): classify upstream hook catalog`
+### PR 2 Commit 1 — `feat(agent): classify upstream hook catalog`
+
+Deferred to PR 2. Do not execute this before PR 1's Codex current correctness and explicit cleanup ownership commits; otherwise cleanup tests either cannot pass or risk conflating the full catalog with Purdex ownership.
 
 Red:
 
-- HC2-HC6 and HC7 fail.
+- HC2-HC6 fail.
 
 Green:
 
@@ -554,7 +567,8 @@ Green:
 - Copy `Handling` through every provider `Events()` defensive copy.
 - Assert every newly added non-installable declaration has explicit `ignored`/`unsupported` handling and empty `EmitsStatus`.
 - Keep ignored/unsupported entries out of install completeness and OpenCode template parity.
-- Define and test stale ignored/unsupported Purdex-owned artifacts: they do not affect `Installed`, may make `Managed=true`, and are removed by remove.
+- If classification introduces historically installed retired events, add their tokens to the provider owned cleanup sets introduced in Commit 2b.
+- Keep unknown ignored/unsupported upstream event tokens out of cleanup ownership unless they are explicitly documented as historically installed by Purdex.
 - Keep runtime status derivation unchanged for installable status/detail events.
 
 Run:
@@ -565,14 +579,16 @@ Run:
 
 Red:
 
-- CF1-CF5 and CF2b-CF2d fail.
+- CF1-CF5 and CF2b-CF2g fail.
 - CP1-CP3 fail.
 
 Green:
 
 - Add TOML read/write helpers for `~/.codex/config.toml`.
 - Preflight-parse both `config.toml` and `hooks.json`; any parse failure leaves both files byte-for-byte unchanged.
-- Install enables `features.codex_hooks`.
+- Preserve existing `config.toml` file mode; new files default to `0600` and are covered by a dedicated test.
+- Install writes `hooks.json` before enabling `features.codex_hooks`, so hook write failure leaves config unchanged.
+- Install enables `features.codex_hooks` only after hook write succeeds.
 - Check blocks when feature flag missing/false.
 - Preserve TOML semantic keys while accepting formatting/comment/order rewrites.
 - `PermissionRequest.FutureOnly=false`.
@@ -581,6 +597,26 @@ Green:
 Run:
 
 - `go test ./internal/agent/codex ./internal/agent -count=1`
+
+### Commit 2b — `fix(agent): harden hook cleanup ownership`
+
+Red:
+
+- HC7-HC7b fail.
+- CP6-CP8 fail.
+- CS7-CS9 fail.
+
+Green:
+
+- Add explicit provider-local owned cleanup sets for cc and Codex, separate from the full provider catalog.
+- Use owned cleanup sets for `Managed` and remove; unknown event tokens remain user/third-party-owned by default.
+- Scan all configured hook keys on remove/managed detection, then decide ownership from tokenized command shape plus owned event token.
+- Require `hook` as the first `pdx` subcommand for cc and Codex command recognition.
+- Preserve other-provider `pdx hook` entries and unknown same-provider event tokens.
+
+Run:
+
+- `go test ./internal/agent/cc ./internal/agent/codex -count=1`
 
 ### Commit 3 — `fix(agent/codex): remove empty hook keys on uninstall`
 
@@ -694,10 +730,13 @@ Run:
 
 - Codex install/check cannot report green unless `features.codex_hooks=true` and required current events are valid.
 - Codex install preflights both config and hooks files; malformed input leaves both files unchanged.
+- Codex install preserves existing `config.toml` permissions and does not enable `features.codex_hooks` if hooks write fails.
 - Codex `PermissionRequest` is required, not FutureOnly.
 - Codex remove does not leave empty event keys that Purdex itself later reports as broken.
 - Claude CheckHooks rejects wrong-agent and wrong-event `pdx hook` commands.
-- Ignored/unsupported hook declarations never enter install completeness, but stale Purdex-owned entries can be removed safely.
+- Hook command matching requires `hook` as the first `pdx` subcommand; wrapper-like commands such as `pdx exec hook ...` are not Purdex-owned hook commands.
+- Ignored/unsupported hook declarations never enter install completeness.
+- Cleanup ownership is provider-local and explicit: owned current/retired event tokens are removable across all configured hook keys, while unknown same-provider tokens are preserved.
 - OpenCode plugin event mapping is verified against current OpenCode docs/runtime shape with checked-in provenance fixtures.
 - OpenCode CheckHooks reports version support fields like cc/codex.
 - OpenCode icon registry has explicit tests.
@@ -708,7 +747,9 @@ Run:
 ## 6. Risks
 
 - TOML round-trip may rewrite user formatting in `~/.codex/config.toml`; semantic keys/values are preserved, but comments/order are not guaranteed.
+- Codex install writes `hooks.json` before config to avoid feature-flag false enablement. If config write fails after hooks write succeeds, the next check reports repairable state instead of falsely reporting installed hooks as active.
 - Full upstream hook catalog classification may grow long. Keep it declarative and provider-local; do not add a central runtime dispatcher.
+- Provider owned cleanup allowlists must be maintained when Purdex retires an event. Removing a historically installed event from the installable set must not remove it from the cleanup set unless a migration intentionally abandons cleanup.
 - OpenCode event mapping may require runtime verification if docs do not identify stable event keys and payload paths. If uncertain, split into a smaller PR that only adds tests and version reporting first.
 - Existing tests may assume exactly 9 cc / 9 codex / 8 opencode events. Update those tests to count installed events separately from known upstream declarations.
 
@@ -724,8 +765,10 @@ Include:
 
 - Commit 1a hook handling helpers.
 - Commit 1b installable-subset filtering for installers/checkers/template parity.
-- Owner-scoped cleanup for cc/codex Purdex hook artifacts so remove does not delete other-provider hooks.
+- Explicit owner-scoped cleanup for cc/codex Purdex hook artifacts so remove scans all configured keys but only deletes provider-owned current/retired event tokens.
+- Unknown same-provider event tokens are preserved by default to avoid deleting user-authored, future upstream, or third-party hook entries.
 - Codex `features.codex_hooks=true` install/check gating with parse-before-write preflight.
+- Codex install preserves config file mode and writes hooks before enabling the feature flag to avoid partial false activation.
 - Codex `PermissionRequest` requiredness and supported version update.
 - Codex remove empty-key cleanup for owned installable and stale/retired Codex hook entries.
 

--- a/internal/agent/cc/events.go
+++ b/internal/agent/cc/events.go
@@ -71,6 +71,7 @@ func (p *Provider) Events() []agent.HookEventSpec {
 			EmitsStatus: append([]agent.Status(nil), spec.EmitsStatus...),
 			Description: spec.Description,
 			FutureOnly:  spec.FutureOnly,
+			Handling:    spec.Handling,
 		}
 		// Ensure a detail-only spec round-trips as an explicit empty slice,
 		// not nil — callers distinguish "explicitly empty" from "unknown".
@@ -81,8 +82,8 @@ func (p *Provider) Events() []agent.HookEventSpec {
 	return out
 }
 
-// eventNames returns the ordered event Name list for installer / check
-// iteration, derived from ccEventSpecs so there is no parallel SSoT.
+// eventNames returns the ordered installable event Name list for installer /
+// check iteration, derived from ccEventSpecs so there is no parallel SSoT.
 func (p *Provider) eventNames() []string {
 	return ccEventNames()
 }
@@ -93,6 +94,9 @@ func (p *Provider) eventNames() []string {
 func ccEventNames() []string {
 	out := make([]string, 0, len(ccEventSpecs))
 	for _, spec := range ccEventSpecs {
+		if !agent.IsInstallableHookSpec(spec) {
+			continue
+		}
 		out = append(out, spec.Name)
 	}
 	return out

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -123,12 +123,9 @@ func mergeClaudeHooks(path, pdxPath string, remove bool) error {
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
-	var hooks map[string]any
-	if h, ok := settings["hooks"]; ok {
-		hooks, _ = h.(map[string]any)
-	}
-	if hooks == nil {
-		hooks = make(map[string]any)
+	hooks, err := claudeHooksMapForMerge(settings)
+	if err != nil {
+		return err
 	}
 	if remove {
 		for event, existing := range hooks {
@@ -162,6 +159,18 @@ func mergeClaudeHooks(path, pdxPath string, remove bool) error {
 	}
 	settings["hooks"] = hooks
 	return writeClaudeSettings(path, settings)
+}
+
+func claudeHooksMapForMerge(settings map[string]any) (map[string]any, error) {
+	h, ok := settings["hooks"]
+	if !ok || h == nil {
+		return make(map[string]any), nil
+	}
+	hooks, ok := h.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("claude hooks root has unsupported value shape")
+	}
+	return hooks, nil
 }
 
 func validateClaudeInstallableHookShapes(hooks map[string]any) error {

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -146,6 +146,9 @@ func mergeClaudeHooks(path, pdxPath string, remove bool) error {
 		settings["hooks"] = hooks
 		return writeClaudeSettings(path, settings)
 	}
+	if err := validateClaudeInstallableHookShapes(hooks); err != nil {
+		return err
+	}
 	for _, spec := range ccEventSpecs {
 		installable := agent.IsInstallableHookSpec(spec)
 		if !installable {
@@ -159,6 +162,22 @@ func mergeClaudeHooks(path, pdxPath string, remove bool) error {
 	}
 	settings["hooks"] = hooks
 	return writeClaudeSettings(path, settings)
+}
+
+func validateClaudeInstallableHookShapes(hooks map[string]any) error {
+	for _, spec := range ccEventSpecs {
+		if !agent.IsInstallableHookSpec(spec) {
+			continue
+		}
+		value, ok := hooks[spec.Name]
+		if !ok || value == nil {
+			continue
+		}
+		if _, ok := value.([]any); !ok {
+			return fmt.Errorf("claude hook %s has unsupported value shape", spec.Name)
+		}
+	}
+	return nil
 }
 
 func writeClaudeSettings(path string, settings map[string]any) error {

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -98,17 +98,14 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 }
 
 // ccHooksManaged reports whether settings.json has any pdx-owned hook
-// entry across the declared event set. Parallel to codex.codexHooksManaged
+// entry across any configured hook key. Parallel to codex.codexHooksManaged
 // — keeps Managed/Installed distinct so the UI Remove button stays
 // enabled on drifted-but-managed state (Finding #2).
 func ccHooksManaged(hooks map[string]any, specs []agent.HookEventSpec) bool {
-	for _, spec := range specs {
-		entries, ok := hooks[spec.Name].([]any)
-		if !ok {
-			continue
-		}
-		for _, entry := range entries {
-			if entryIsPdx(entry) {
+	owned := ccOwnedCleanupEventNames()
+	for _, entries := range hooks {
+		for _, entry := range toEntrySlice(entries) {
+			if entryIsPdxCCKnownEvent(entry, owned) {
 				return true
 			}
 		}
@@ -133,33 +130,34 @@ func mergeClaudeHooks(path, pdxPath string, remove bool) error {
 	if hooks == nil {
 		hooks = make(map[string]any)
 	}
-	for _, spec := range ccEventSpecs {
-		installable := agent.IsInstallableHookSpec(spec)
-		if !remove && !installable {
-			continue
-		}
-		event := spec.Name
-		if remove && !installable {
-			existing, ok := hooks[event]
-			if !ok {
-				continue
-			}
+	if remove {
+		for event, existing := range hooks {
 			entries := filterOutPdx(toEntrySlice(existing))
 			if len(entries) == 0 {
 				delete(hooks, event)
 			} else {
 				hooks[event] = entries
 			}
+		}
+		settings["hooks"] = hooks
+		return writeClaudeSettings(path, settings)
+	}
+	for _, spec := range ccEventSpecs {
+		installable := agent.IsInstallableHookSpec(spec)
+		if !installable {
 			continue
 		}
+		event := spec.Name
 		entries := toEntrySlice(hooks[event])
 		entries = filterOutPdx(entries)
-		if !remove {
-			entries = append(entries, makePdxEntry(pdxPath, "cc", event))
-		}
+		entries = append(entries, makePdxEntry(pdxPath, "cc", event))
 		hooks[event] = entries
 	}
 	settings["hooks"] = hooks
+	return writeClaudeSettings(path, settings)
+}
+
+func writeClaudeSettings(path string, settings map[string]any) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("create directory: %w", err)
 	}
@@ -239,7 +237,7 @@ func filterOutPdx(entries []any) []any {
 }
 
 func filterOutPdxKnownCCEvents(entries []any) []any {
-	known := ccKnownEventNames()
+	known := ccOwnedCleanupEventNames()
 	result := []any{}
 	for _, e := range entries {
 		if !entryIsPdxCCKnownEvent(e, known) {
@@ -250,7 +248,7 @@ func filterOutPdxKnownCCEvents(entries []any) []any {
 }
 
 func entryIsPdx(entry any) bool {
-	return entryIsPdxCCKnownEvent(entry, ccKnownEventNames())
+	return entryIsPdxCCKnownEvent(entry, ccOwnedCleanupEventNames())
 }
 
 func entryIsPdxCCKnownEvent(entry any, known map[string]bool) bool {
@@ -299,17 +297,16 @@ func isPdxCommandCC(cmd string, eventOK func(string) bool) bool {
 	if len(tokens) == 0 || filepath.Base(tokens[0]) != "pdx" {
 		return false
 	}
-	hasHook := false
 	hasAgentCC := false
-	for i := 1; i < len(tokens); i++ {
-		if tokens[i] == "hook" {
-			hasHook = true
-		}
+	if len(tokens) < 2 || tokens[1] != "hook" {
+		return false
+	}
+	for i := 2; i < len(tokens); i++ {
 		if tokens[i] == "--agent" && i+1 < len(tokens) && tokens[i+1] == "cc" {
 			hasAgentCC = true
 		}
 	}
-	return hasHook && hasAgentCC && eventOK(tokens[len(tokens)-1])
+	return hasAgentCC && eventOK(tokens[len(tokens)-1])
 }
 
 func tokenizeCCCommand(cmd string) []string {
@@ -355,4 +352,18 @@ func ccKnownEventNames() map[string]bool {
 		known[spec.Name] = true
 	}
 	return known
+}
+
+func ccOwnedCleanupEventNames() map[string]bool {
+	return map[string]bool{
+		"SessionStart":      true,
+		"UserPromptSubmit":  true,
+		"SubagentStart":     true,
+		"SubagentStop":      true,
+		"Stop":              true,
+		"StopFailure":       true,
+		"Notification":      true,
+		"PermissionRequest": true,
+		"SessionEnd":        true,
+	}
 }

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -134,10 +134,24 @@ func mergeClaudeHooks(path, pdxPath string, remove bool) error {
 		hooks = make(map[string]any)
 	}
 	for _, spec := range ccEventSpecs {
-		if !remove && !agent.IsInstallableHookSpec(spec) {
+		installable := agent.IsInstallableHookSpec(spec)
+		if !remove && !installable {
 			continue
 		}
 		event := spec.Name
+		if remove && !installable {
+			existing, ok := hooks[event]
+			if !ok {
+				continue
+			}
+			entries := filterOutPdx(toEntrySlice(existing))
+			if len(entries) == 0 {
+				delete(hooks, event)
+			} else {
+				hooks[event] = entries
+			}
+			continue
+		}
 		entries := toEntrySlice(hooks[event])
 		entries = filterOutPdx(entries)
 		if !remove {

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -73,7 +73,7 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 			allInstalled = false
 			continue
 		}
-		command := findPdxCommand(entries)
+		command := findPdxCommandForEvent(entries, spec.Name)
 		events[spec.Name] = agent.HookEventInfo{
 			Installed:  command != "",
 			Command:    command,
@@ -190,6 +190,10 @@ func makePdxEntry(pdxPath, agentType, event string) map[string]any {
 }
 
 func findPdxCommand(entries any) string {
+	return findPdxCommandForEvent(entries, "")
+}
+
+func findPdxCommandForEvent(entries any, eventName string) string {
 	arr, ok := entries.([]any)
 	if !ok {
 		return ""
@@ -209,7 +213,10 @@ func findPdxCommand(entries any) string {
 				continue
 			}
 			cmd, _ := hookMap["command"].(string)
-			if strings.Contains(strings.ReplaceAll(cmd, `"`, ""), "pdx hook") {
+			if eventName != "" && isPdxCommandForCCEvent(cmd, eventName) {
+				return cmd
+			}
+			if eventName == "" && isPdxCommand(cmd) {
 				return cmd
 			}
 		}
@@ -228,9 +235,14 @@ func toEntrySlice(v any) []any {
 }
 
 func filterOutPdx(entries []any) []any {
+	return filterOutPdxKnownCCEvents(entries)
+}
+
+func filterOutPdxKnownCCEvents(entries []any) []any {
+	known := ccKnownEventNames()
 	result := []any{}
 	for _, e := range entries {
-		if !entryIsPdx(e) {
+		if !entryIsPdxCCKnownEvent(e, known) {
 			result = append(result, e)
 		}
 	}
@@ -238,6 +250,10 @@ func filterOutPdx(entries []any) []any {
 }
 
 func entryIsPdx(entry any) bool {
+	return entryIsPdxCCKnownEvent(entry, ccKnownEventNames())
+}
+
+func entryIsPdxCCKnownEvent(entry any, known map[string]bool) bool {
 	m, ok := entry.(map[string]any)
 	if !ok {
 		return false
@@ -259,7 +275,7 @@ func entryIsPdx(entry any) bool {
 		if !ok {
 			continue
 		}
-		if isPdxCommand(cmd) {
+		if isPdxCommandCCKnownEvent(cmd, known) {
 			return true
 		}
 	}
@@ -267,11 +283,76 @@ func entryIsPdx(entry any) bool {
 }
 
 func isPdxCommand(cmd string) bool {
-	if strings.Contains(cmd, `/pdx" hook`) || strings.HasPrefix(cmd, `"pdx" hook`) {
-		return true
+	return isPdxCommandCCKnownEvent(cmd, ccKnownEventNames())
+}
+
+func isPdxCommandForCCEvent(cmd string, eventName string) bool {
+	return isPdxCommandCC(cmd, func(got string) bool { return got == eventName })
+}
+
+func isPdxCommandCCKnownEvent(cmd string, known map[string]bool) bool {
+	return isPdxCommandCC(cmd, func(eventName string) bool { return known[eventName] })
+}
+
+func isPdxCommandCC(cmd string, eventOK func(string) bool) bool {
+	tokens := tokenizeCCCommand(cmd)
+	if len(tokens) == 0 || filepath.Base(tokens[0]) != "pdx" {
+		return false
 	}
-	if strings.Contains(cmd, `/pdx hook`) || strings.HasPrefix(cmd, `pdx hook`) {
-		return true
+	hasHook := false
+	hasAgentCC := false
+	for i := 1; i < len(tokens); i++ {
+		if tokens[i] == "hook" {
+			hasHook = true
+		}
+		if tokens[i] == "--agent" && i+1 < len(tokens) && tokens[i+1] == "cc" {
+			hasAgentCC = true
+		}
 	}
-	return false
+	return hasHook && hasAgentCC && eventOK(tokens[len(tokens)-1])
+}
+
+func tokenizeCCCommand(cmd string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inQuote := false
+	var quoteChar byte
+	flush := func() {
+		if cur.Len() > 0 {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+		}
+	}
+	for i := 0; i < len(cmd); i++ {
+		c := cmd[i]
+		if inQuote {
+			if c == quoteChar {
+				inQuote = false
+				quoteChar = 0
+				continue
+			}
+			cur.WriteByte(c)
+			continue
+		}
+		if c == '"' || c == '\'' {
+			inQuote = true
+			quoteChar = c
+			continue
+		}
+		if c == ' ' || c == '\t' || c == '\n' {
+			flush()
+			continue
+		}
+		cur.WriteByte(c)
+	}
+	flush()
+	return tokens
+}
+
+func ccKnownEventNames() map[string]bool {
+	known := make(map[string]bool, len(ccEventSpecs))
+	for _, spec := range ccEventSpecs {
+		known[spec.Name] = true
+	}
+	return known
 }

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -50,7 +50,13 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		return agent.HookStatus{}, fmt.Errorf("parse settings.json: %w", err)
 	}
 	hooks, _ := settings["hooks"].(map[string]any)
-	specs := p.Events()
+	allSpecs := p.Events()
+	specs := make([]agent.HookEventSpec, 0, len(allSpecs))
+	for _, spec := range allSpecs {
+		if agent.IsInstallableHookSpec(spec) {
+			specs = append(specs, spec)
+		}
+	}
 	events := make(map[string]agent.HookEventInfo, len(specs))
 	var issues []string
 	var upgrades []string
@@ -78,7 +84,7 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 			allInstalled = false
 		}
 	}
-	managed := ccHooksManaged(hooks, specs)
+	managed := ccHooksManaged(hooks, allSpecs)
 	return agent.HookStatus{
 		Installed:         allInstalled,
 		Managed:           managed,
@@ -127,7 +133,11 @@ func mergeClaudeHooks(path, pdxPath string, remove bool) error {
 	if hooks == nil {
 		hooks = make(map[string]any)
 	}
-	for _, event := range ccEventNames() {
+	for _, spec := range ccEventSpecs {
+		if !remove && !agent.IsInstallableHookSpec(spec) {
+			continue
+		}
+		event := spec.Name
 		entries := toEntrySlice(hooks[event])
 		entries = filterOutPdx(entries)
 		if !remove {

--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -132,7 +132,11 @@ func mergeClaudeHooks(path, pdxPath string, remove bool) error {
 	}
 	if remove {
 		for event, existing := range hooks {
-			entries := filterOutPdx(toEntrySlice(existing))
+			entries, ok := existing.([]any)
+			if !ok {
+				continue
+			}
+			entries = filterOutPdx(entries)
 			if len(entries) == 0 {
 				delete(hooks, event)
 			} else {

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -305,6 +305,23 @@ func TestMergeClaudeHooks_PreservesUnknownNonArrayHookValues(t *testing.T) {
 	}
 }
 
+func TestMergeClaudeHooks_UnsupportedInstallableHookShapeReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	originalSettings := []byte(`{"hooks":{"SessionStart":"custom-scalar","Stop":{"custom":true}}}`)
+	if err := os.WriteFile(path, originalSettings, 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	if err := mergeClaudeHooks(path, "/usr/local/bin/pdx", false); err == nil {
+		t.Fatal("mergeClaudeHooks install succeeded with unsupported installable hook value shape")
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != string(originalSettings) {
+		t.Fatalf("settings changed after unsupported hook shape; got %q", got)
+	}
+}
+
 func TestMergeClaudeHooks_PreservesWrapperLikePdxCommand(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -326,14 +326,14 @@ func TestCCInstallHooks_WritesAllEventsFromEventsList(t *testing.T) {
 	hooks := hooksMap(t, settings)
 
 	p := NewProvider(nil, nil, nil, nil)
-	events := p.Events()
+	events := installableCCEvents(p.Events())
 	if len(events) == 0 {
 		t.Fatal("cc Events() returned empty; installer iteration would be vacuous")
 	}
 	for _, e := range events {
 		entries, ok := hooks[e.Name]
 		if !ok {
-			t.Errorf("event %s (from Events()) not found in written hooks", e.Name)
+			t.Errorf("event %s (from installable Events()) not found in written hooks", e.Name)
 			continue
 		}
 		arr, ok := entries.([]any)
@@ -342,8 +342,18 @@ func TestCCInstallHooks_WritesAllEventsFromEventsList(t *testing.T) {
 		}
 	}
 	if len(hooks) != len(events) {
-		t.Errorf("settings.json hooks len=%d, want %d (one per Events())", len(hooks), len(events))
+		t.Errorf("settings.json hooks len=%d, want %d (one per installable Events())", len(hooks), len(events))
 	}
+}
+
+func installableCCEvents(events []agent.HookEventSpec) []agent.HookEventSpec {
+	out := make([]agent.HookEventSpec, 0, len(events))
+	for _, event := range events {
+		if agent.IsInstallableHookSpec(event) {
+			out = append(out, event)
+		}
+	}
+	return out
 }
 
 func TestCCInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
@@ -391,11 +401,33 @@ func TestCCInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 			t.Errorf("CheckHooks.Events included non-installable event %q", name)
 		}
 	}
+	if !status.Installed || !status.Managed || len(status.Issues) != 0 {
+		t.Fatalf("clean install with non-installable specs status=%+v, want installed managed with no issues", status)
+	}
+
+	settings := readSettings(t, installedPath)
+	installedHooks := hooksMap(t, settings)
+	installedHooks["IgnoredSynthetic"] = []any{makePdxEntry("/usr/local/bin/pdx", "cc", "IgnoredSynthetic")}
+	settings["hooks"] = installedHooks
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(installedPath, data, 0644); err != nil {
+		t.Fatalf("write stale installed settings: %v", err)
+	}
+	status, err = NewProvider(nil, nil, nil, nil).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks stale non-installable: %v", err)
+	}
+	if !status.Installed || !status.Managed || len(status.Issues) != 0 {
+		t.Fatalf("stale non-installable hook status=%+v, want installed managed with no issues", status)
+	}
 
 	staleSettingsPath := filepath.Join(dir, "stale-settings.json")
 	stale := map[string]any{
 		"hooks": map[string]any{
-			"IgnoredSynthetic": []any{makePdxEntry("/usr/local/bin/pdx", "cc", "IgnoredSynthetic")},
+			"IgnoredSynthetic": []any{
+				makePdxEntry("/usr/local/bin/pdx", "cc", "IgnoredSynthetic"),
+				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "/usr/bin/notify ignored"}}},
+			},
 		},
 	}
 	staleData, _ := json.MarshalIndent(stale, "", "  ")
@@ -406,10 +438,25 @@ func TestCCInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 		t.Fatalf("remove stale non-installable hook: %v", err)
 	}
 	staleHooks := hooksMap(t, readSettings(t, staleSettingsPath))
-	for _, entry := range toEntrySlice(staleHooks["IgnoredSynthetic"]) {
+	staleEntries := toEntrySlice(staleHooks["IgnoredSynthetic"])
+	if len(staleEntries) != 1 {
+		t.Fatalf("remove kept %d non-installable third-party entries, want 1", len(staleEntries))
+	}
+	for _, entry := range staleEntries {
 		if entryIsPdx(entry) {
 			t.Fatalf("remove left stale non-installable pdx entry: %#v", entry)
 		}
+	}
+	absentSettingsPath := filepath.Join(dir, "absent-settings.json")
+	if err := os.WriteFile(absentSettingsPath, []byte(`{"hooks":{}}`), 0644); err != nil {
+		t.Fatalf("write absent settings: %v", err)
+	}
+	if err := mergeClaudeHooks(absentSettingsPath, "/usr/local/bin/pdx", true); err != nil {
+		t.Fatalf("remove absent non-installable hook: %v", err)
+	}
+	absentHooks := hooksMap(t, readSettings(t, absentSettingsPath))
+	if _, ok := absentHooks["IgnoredSynthetic"]; ok {
+		t.Fatal("remove created absent non-installable key IgnoredSynthetic")
 	}
 }
 
@@ -443,7 +490,7 @@ func TestCCCheckHooks_ReportsAllEventsFromEventsList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CheckHooks: %v", err)
 	}
-	for _, e := range p.Events() {
+	for _, e := range installableCCEvents(p.Events()) {
 		if _, ok := status.Events[e.Name]; !ok {
 			t.Errorf("CheckHooks.Events missing key %q (from Events())", e.Name)
 		}

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -426,6 +426,7 @@ func TestCCInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 		"hooks": map[string]any{
 			"IgnoredSynthetic": []any{
 				makePdxEntry("/usr/local/bin/pdx", "cc", "IgnoredSynthetic"),
+				makePdxEntry("/usr/local/bin/pdx", "codex", "IgnoredSynthetic"),
 				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "/usr/bin/notify ignored"}}},
 			},
 		},
@@ -439,13 +440,20 @@ func TestCCInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 	}
 	staleHooks := hooksMap(t, readSettings(t, staleSettingsPath))
 	staleEntries := toEntrySlice(staleHooks["IgnoredSynthetic"])
-	if len(staleEntries) != 1 {
-		t.Fatalf("remove kept %d non-installable third-party entries, want 1", len(staleEntries))
+	if len(staleEntries) != 2 {
+		t.Fatalf("remove kept %d non-installable third-party entries, want 2", len(staleEntries))
 	}
+	foundCodexPdx := false
 	for _, entry := range staleEntries {
 		if entryIsPdx(entry) {
 			t.Fatalf("remove left stale non-installable pdx entry: %#v", entry)
 		}
+		if commandEntryContains(entry, "--agent codex") {
+			foundCodexPdx = true
+		}
+	}
+	if !foundCodexPdx {
+		t.Fatal("remove dropped non-cc pdx hook under non-installable key")
 	}
 	absentSettingsPath := filepath.Join(dir, "absent-settings.json")
 	if err := os.WriteFile(absentSettingsPath, []byte(`{"hooks":{}}`), 0644); err != nil {
@@ -458,6 +466,28 @@ func TestCCInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 	if _, ok := absentHooks["IgnoredSynthetic"]; ok {
 		t.Fatal("remove created absent non-installable key IgnoredSynthetic")
 	}
+}
+
+func commandEntryContains(entry any, needle string) bool {
+	m, ok := entry.(map[string]any)
+	if !ok {
+		return false
+	}
+	arr, ok := m["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, hook := range arr {
+		hm, ok := hook.(map[string]any)
+		if !ok {
+			continue
+		}
+		cmd, _ := hm["command"].(string)
+		if strings.Contains(cmd, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // TestCCCheckHooks_ReportsAllEventsFromEventsList writes a settings.json that
@@ -500,6 +530,45 @@ func TestCCCheckHooks_ReportsAllEventsFromEventsList(t *testing.T) {
 	}
 	if status.Installed {
 		t.Error("Installed must be false when any event is missing")
+	}
+}
+
+func TestCCCheckHooks_WrongAgentOrEventCommandNotInstalled(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{name: "wrong agent", command: `"/usr/local/bin/pdx" hook --agent codex SessionStart`},
+		{name: "wrong event", command: `"/usr/local/bin/pdx" hook --agent cc Stop`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			settingsPath := filepath.Join(home, ".claude", "settings.json")
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			settings := map[string]any{
+				"hooks": map[string]any{
+					"SessionStart": []any{map[string]any{"hooks": []any{map[string]any{"type": "command", "command": tt.command}}}},
+				},
+			}
+			data, _ := json.MarshalIndent(settings, "", "  ")
+			if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+				t.Fatalf("write settings: %v", err)
+			}
+			status, err := NewProvider(nil, nil, nil, nil).CheckHooks()
+			if err != nil {
+				t.Fatalf("CheckHooks: %v", err)
+			}
+			if status.Events["SessionStart"].Installed {
+				t.Fatalf("SessionStart Installed=true for %s command", tt.name)
+			}
+			if status.Installed {
+				t.Fatal("overall Installed=true with invalid SessionStart command")
+			}
+		})
 	}
 }
 

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -252,6 +252,65 @@ func TestMergeClaudeHooks_RemoveMode(t *testing.T) {
 	}
 }
 
+func TestMergeClaudeHooks_RemovesOwnedPdxUnderUnknownKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	settings := map[string]any{
+		"hooks": map[string]any{
+			"UnknownHookKey": []any{makePdxEntry("/usr/local/bin/pdx", "cc", "SessionStart")},
+		},
+	}
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	if err := mergeClaudeHooks(path, "/usr/local/bin/pdx", true); err != nil {
+		t.Fatalf("mergeClaudeHooks remove: %v", err)
+	}
+	hooks := hooksMap(t, readSettings(t, path))
+	if _, ok := hooks["UnknownHookKey"]; ok {
+		t.Fatal("remove left owned Claude event under unknown hook key")
+	}
+}
+
+func TestMergeClaudeHooks_PreservesWrapperLikePdxCommand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	settings := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{"hooks": []any{map[string]any{"type": "command", "command": `pdx exec hook --agent cc SessionStart`}}}},
+		},
+	}
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	status, err := NewProvider(nil, nil, nil, nil).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Managed {
+		t.Fatal("wrapper-like pdx command: Managed=true, want false")
+	}
+	if err := mergeClaudeHooks(path, "/usr/local/bin/pdx", true); err != nil {
+		t.Fatalf("mergeClaudeHooks remove: %v", err)
+	}
+	hooks := hooksMap(t, readSettings(t, path))
+	entries := toEntrySlice(hooks["SessionStart"])
+	if len(entries) != 1 {
+		t.Fatalf("remove kept %d entries, want wrapper-like command preserved", len(entries))
+	}
+	if findPdxCommandForEvent(entries, "SessionStart") != "" {
+		t.Fatal("wrapper-like pdx command became valid per-event hook command")
+	}
+}
+
 // ---- mergeClaudeHooks: different path replaces old pdx entry ----
 
 func TestMergeClaudeHooks_DifferentPathReplaces(t *testing.T) {

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/wake/purdex/internal/agent"
 )
 
 func contains(s, sub string) bool { return strings.Contains(s, sub) }
@@ -341,6 +343,73 @@ func TestCCInstallHooks_WritesAllEventsFromEventsList(t *testing.T) {
 	}
 	if len(hooks) != len(events) {
 		t.Errorf("settings.json hooks len=%d, want %d (one per Events())", len(hooks), len(events))
+	}
+}
+
+func TestCCInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
+	original := ccEventSpecs
+	ccEventSpecs = append(append([]agent.HookEventSpec(nil), ccEventSpecs...),
+		agent.HookEventSpec{Name: "IgnoredSynthetic", Handling: agent.HookHandlingIgnored, Description: "Ignored synthetic hook"},
+		agent.HookEventSpec{Name: "UnsupportedSynthetic", Handling: agent.HookHandlingUnsupported, Description: "Unsupported synthetic hook"},
+	)
+	t.Cleanup(func() { ccEventSpecs = original })
+
+	for _, name := range ccEventNames() {
+		if name == "IgnoredSynthetic" || name == "UnsupportedSynthetic" {
+			t.Fatalf("ccEventNames included non-installable spec %q", name)
+		}
+	}
+
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	if err := mergeClaudeHooks(settingsPath, "/usr/local/bin/pdx", false); err != nil {
+		t.Fatalf("mergeClaudeHooks: %v", err)
+	}
+	hooks := hooksMap(t, readSettings(t, settingsPath))
+	for _, name := range []string{"IgnoredSynthetic", "UnsupportedSynthetic"} {
+		if _, ok := hooks[name]; ok {
+			t.Errorf("mergeClaudeHooks wrote non-installable event %q", name)
+		}
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	installedPath := filepath.Join(claudeDir, "settings.json")
+	if err := mergeClaudeHooks(installedPath, "/usr/local/bin/pdx", false); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+	status, err := NewProvider(nil, nil, nil, nil).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	for _, name := range []string{"IgnoredSynthetic", "UnsupportedSynthetic"} {
+		if _, ok := status.Events[name]; ok {
+			t.Errorf("CheckHooks.Events included non-installable event %q", name)
+		}
+	}
+
+	staleSettingsPath := filepath.Join(dir, "stale-settings.json")
+	stale := map[string]any{
+		"hooks": map[string]any{
+			"IgnoredSynthetic": []any{makePdxEntry("/usr/local/bin/pdx", "cc", "IgnoredSynthetic")},
+		},
+	}
+	staleData, _ := json.MarshalIndent(stale, "", "  ")
+	if err := os.WriteFile(staleSettingsPath, staleData, 0644); err != nil {
+		t.Fatalf("write stale settings: %v", err)
+	}
+	if err := mergeClaudeHooks(staleSettingsPath, "/usr/local/bin/pdx", true); err != nil {
+		t.Fatalf("remove stale non-installable hook: %v", err)
+	}
+	staleHooks := hooksMap(t, readSettings(t, staleSettingsPath))
+	for _, entry := range toEntrySlice(staleHooks["IgnoredSynthetic"]) {
+		if entryIsPdx(entry) {
+			t.Fatalf("remove left stale non-installable pdx entry: %#v", entry)
+		}
 	}
 }
 

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -2,6 +2,7 @@ package cc
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -319,6 +320,27 @@ func TestMergeClaudeHooks_UnsupportedInstallableHookShapeReturnsError(t *testing
 	got, _ := os.ReadFile(path)
 	if string(got) != string(originalSettings) {
 		t.Fatalf("settings changed after unsupported hook shape; got %q", got)
+	}
+}
+
+func TestMergeClaudeHooks_UnsupportedHooksRootReturnsError(t *testing.T) {
+	for _, remove := range []bool{false, true} {
+		t.Run(fmt.Sprintf("remove=%v", remove), func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "settings.json")
+			originalSettings := []byte(`{"hooks":"custom-root"}`)
+			if err := os.WriteFile(path, originalSettings, 0644); err != nil {
+				t.Fatalf("write settings: %v", err)
+			}
+
+			if err := mergeClaudeHooks(path, "/usr/local/bin/pdx", remove); err == nil {
+				t.Fatal("mergeClaudeHooks succeeded with unsupported hooks root shape")
+			}
+			got, _ := os.ReadFile(path)
+			if string(got) != string(originalSettings) {
+				t.Fatalf("settings changed after unsupported hooks root; got %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -274,6 +274,37 @@ func TestMergeClaudeHooks_RemovesOwnedPdxUnderUnknownKey(t *testing.T) {
 	}
 }
 
+func TestMergeClaudeHooks_PreservesUnknownNonArrayHookValues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	wantObject := map[string]any{"custom": true}
+	settings := map[string]any{
+		"hooks": map[string]any{
+			"UnknownObject": wantObject,
+			"SessionStart":  "custom-scalar",
+			"OwnedKey":      []any{makePdxEntry("/usr/local/bin/pdx", "cc", "SessionStart")},
+		},
+	}
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	if err := mergeClaudeHooks(path, "/usr/local/bin/pdx", true); err != nil {
+		t.Fatalf("mergeClaudeHooks remove: %v", err)
+	}
+	hooks := hooksMap(t, readSettings(t, path))
+	if got, ok := hooks["UnknownObject"].(map[string]any); !ok || got["custom"] != true {
+		t.Fatalf("remove changed unknown object hook value: %#v", hooks["UnknownObject"])
+	}
+	if hooks["SessionStart"] != "custom-scalar" {
+		t.Fatalf("remove changed unknown scalar hook value: %#v", hooks["SessionStart"])
+	}
+	if _, ok := hooks["OwnedKey"]; ok {
+		t.Fatal("remove left owned array hook key")
+	}
+}
+
 func TestMergeClaudeHooks_PreservesWrapperLikePdxCommand(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -34,6 +34,7 @@ func TestIsPdxCommand_Negative(t *testing.T) {
 		`/usr/bin/bash -c "echo hello"`,
 		``,
 		`pdx-ng hook something`,
+		`pdx exec hook --agent cc SessionStart`,
 	}
 	for _, cmd := range cases {
 		if isPdxCommand(cmd) {
@@ -424,6 +425,7 @@ func TestCCInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 	staleSettingsPath := filepath.Join(dir, "stale-settings.json")
 	stale := map[string]any{
 		"hooks": map[string]any{
+			"Bogus": []any{makePdxEntry("/usr/local/bin/pdx", "cc", "SessionStart")},
 			"IgnoredSynthetic": []any{
 				makePdxEntry("/usr/local/bin/pdx", "cc", "IgnoredSynthetic"),
 				makePdxEntry("/usr/local/bin/pdx", "codex", "IgnoredSynthetic"),
@@ -439,18 +441,28 @@ func TestCCInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 		t.Fatalf("remove stale non-installable hook: %v", err)
 	}
 	staleHooks := hooksMap(t, readSettings(t, staleSettingsPath))
-	staleEntries := toEntrySlice(staleHooks["IgnoredSynthetic"])
-	if len(staleEntries) != 2 {
-		t.Fatalf("remove kept %d non-installable third-party entries, want 2", len(staleEntries))
+	if _, ok := staleHooks["Bogus"]; ok {
+		t.Fatal("remove left owned cc hook filed under unknown key Bogus")
 	}
+	staleEntries := toEntrySlice(staleHooks["IgnoredSynthetic"])
+	if len(staleEntries) != 3 {
+		t.Fatalf("remove kept %d non-owned/third-party entries, want 3", len(staleEntries))
+	}
+	foundSyntheticCCPdx := false
 	foundCodexPdx := false
 	for _, entry := range staleEntries {
 		if entryIsPdx(entry) {
-			t.Fatalf("remove left stale non-installable pdx entry: %#v", entry)
+			t.Fatalf("remove left owned pdx entry: %#v", entry)
+		}
+		if commandEntryContains(entry, "--agent cc IgnoredSynthetic") {
+			foundSyntheticCCPdx = true
 		}
 		if commandEntryContains(entry, "--agent codex") {
 			foundCodexPdx = true
 		}
+	}
+	if !foundSyntheticCCPdx {
+		t.Fatal("remove dropped non-owned synthetic cc hook under non-installable key")
 	}
 	if !foundCodexPdx {
 		t.Fatal("remove dropped non-cc pdx hook under non-installable key")
@@ -628,6 +640,30 @@ func TestCCCheckHooks_ManagedReflectsPdxEntries(t *testing.T) {
 		}
 		if status.Managed {
 			t.Fatal("no pdx entries: Managed=true, want false")
+		}
+	})
+	t.Run("owned pdx under unknown key", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		settingsPath := filepath.Join(home, ".claude", "settings.json")
+		if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		settings := map[string]any{
+			"hooks": map[string]any{
+				"Bogus": []any{makePdxEntry("/usr/local/bin/pdx", "cc", "SessionStart")},
+			},
+		}
+		data, _ := json.MarshalIndent(settings, "", "  ")
+		if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		status, err := NewProvider(nil, nil, nil, nil).CheckHooks()
+		if err != nil {
+			t.Fatalf("CheckHooks: %v", err)
+		}
+		if !status.Managed {
+			t.Fatal("owned pdx under unknown key: Managed=false, want true")
 		}
 	})
 }

--- a/internal/agent/codex/events.go
+++ b/internal/agent/codex/events.go
@@ -58,7 +58,6 @@ var codexEventSpecs = []agent.HookEventSpec{
 		Name:        "PermissionRequest",
 		EmitsStatus: []agent.Status{agent.StatusWaiting},
 		Description: "Tool permission request awaiting user approval",
-		FutureOnly:  true,
 	},
 	{
 		Name:        "SessionEnd",

--- a/internal/agent/codex/events.go
+++ b/internal/agent/codex/events.go
@@ -78,6 +78,7 @@ func (p *Provider) Events() []agent.HookEventSpec {
 			EmitsStatus: append([]agent.Status(nil), spec.EmitsStatus...),
 			Description: spec.Description,
 			FutureOnly:  spec.FutureOnly,
+			Handling:    spec.Handling,
 		}
 		if out[i].EmitsStatus == nil {
 			out[i].EmitsStatus = []agent.Status{}
@@ -86,8 +87,8 @@ func (p *Provider) Events() []agent.HookEventSpec {
 	return out
 }
 
-// eventNames returns the ordered event Name list for installer / check
-// iteration, derived from codexEventSpecs so there is no parallel SSoT.
+// eventNames returns the ordered installable event Name list for installer /
+// check iteration, derived from codexEventSpecs so there is no parallel SSoT.
 func (p *Provider) eventNames() []string {
 	return codexEventNames()
 }
@@ -97,6 +98,9 @@ func (p *Provider) eventNames() []string {
 func codexEventNames() []string {
 	out := make([]string, 0, len(codexEventSpecs))
 	for _, spec := range codexEventSpecs {
+		if !agent.IsInstallableHookSpec(spec) {
+			continue
+		}
 		out = append(out, spec.Name)
 	}
 	return out

--- a/internal/agent/codex/events_test.go
+++ b/internal/agent/codex/events_test.go
@@ -102,11 +102,9 @@ func TestCodexEvents_DetailOnlyHaveEmptyEmitsStatus(t *testing.T) {
 	}
 }
 
-// TestCodexEventsFutureOnlyFlags is the fix-plan §2.2 CE1 assertion: codex
-// Events() declares exactly 3 non-FutureOnly events (SessionStart,
-// UserPromptSubmit, Stop — the pre-expansion 3-event installer set that
-// the codex CLI reliably emits today) and the remaining 6 events as
-// FutureOnly=true. See plan §1.3 for the matrix.
+// TestCodexEventsFutureOnlyFlags asserts Codex current required events are not
+// FutureOnly while parser-capable events that are not guaranteed in current
+// installs remain tolerated absent.
 func TestCodexEventsFutureOnlyFlags(t *testing.T) {
 	wantFutureOnly := map[string]bool{
 		"SessionStart":      false,
@@ -116,7 +114,7 @@ func TestCodexEventsFutureOnlyFlags(t *testing.T) {
 		"SubagentStop":      true,
 		"StopFailure":       true,
 		"Notification":      true,
-		"PermissionRequest": true,
+		"PermissionRequest": false,
 		"SessionEnd":        true,
 	}
 	p := codex.NewProvider()
@@ -190,4 +188,3 @@ func TestCodexEvents_DescriptionsNonEmpty(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -118,7 +118,9 @@ func installCodexHooks(configPath, hooksPath, pdxPath string) error {
 		return err
 	}
 	setCodexHooksFeature(config)
-	mergeCodexHooksFile(hooksFile, pdxPath, false)
+	if err := mergeCodexHooksFile(hooksFile, pdxPath, false); err != nil {
+		return err
+	}
 	if err := writeCodexHooksFile(hooksPath, hooksFile); err != nil {
 		return err
 	}
@@ -214,14 +216,16 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 			return err
 		}
 	}
-	mergeCodexHooksFile(hooksFile, pdxPath, remove)
+	if err := mergeCodexHooksFile(hooksFile, pdxPath, remove); err != nil {
+		return err
+	}
 	return writeCodexHooksFile(path, hooksFile)
 }
 
 func validateCodexInstallableHookShapes(hooksFile map[string]any) error {
-	hooks, _ := hooksFile["hooks"].(map[string]any)
-	if hooks == nil {
-		return nil
+	hooks, err := codexHooksMapForMerge(hooksFile)
+	if err != nil {
+		return err
 	}
 	for _, spec := range codexEventSpecs {
 		if !agent.IsInstallableHookSpec(spec) {
@@ -238,13 +242,22 @@ func validateCodexInstallableHookShapes(hooksFile map[string]any) error {
 	return nil
 }
 
-func mergeCodexHooksFile(hooksFile map[string]any, pdxPath string, remove bool) {
-	var hooks map[string]any
-	if h, ok := hooksFile["hooks"]; ok {
-		hooks, _ = h.(map[string]any)
+func codexHooksMapForMerge(hooksFile map[string]any) (map[string]any, error) {
+	h, ok := hooksFile["hooks"]
+	if !ok || h == nil {
+		return make(map[string]any), nil
 	}
-	if hooks == nil {
-		hooks = make(map[string]any)
+	hooks, ok := h.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("codex hooks root has unsupported value shape")
+	}
+	return hooks, nil
+}
+
+func mergeCodexHooksFile(hooksFile map[string]any, pdxPath string, remove bool) error {
+	hooks, err := codexHooksMapForMerge(hooksFile)
+	if err != nil {
+		return err
 	}
 	if remove {
 		for event, existing := range hooks {
@@ -259,7 +272,7 @@ func mergeCodexHooksFile(hooksFile map[string]any, pdxPath string, remove bool) 
 			}
 		}
 		hooksFile["hooks"] = hooks
-		return
+		return nil
 	}
 	for _, spec := range codexEventSpecs {
 		installable := agent.IsInstallableHookSpec(spec)
@@ -280,6 +293,7 @@ func mergeCodexHooksFile(hooksFile map[string]any, pdxPath string, remove bool) 
 		hooks[event] = entries
 	}
 	hooksFile["hooks"] = hooks
+	return nil
 
 }
 

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -119,7 +119,7 @@ func codexHooksManaged(hooks map[string]any, specs []agent.HookEventSpec) bool {
 					continue
 				}
 				cmd, _ := m["command"].(string)
-				if isPdxCommandCodex(cmd) {
+				if isPdxCommandCodexOwned(cmd) {
 					return true
 				}
 			}
@@ -131,9 +131,8 @@ func codexHooksManaged(hooks map[string]any, specs []agent.HookEventSpec) bool {
 // checkCodexEvent classifies a single hook event as absent / broken / valid
 // per fix-plan §1.4 and applies the FutureOnly-aware decision table. It
 // takes the full hooks map so absent vs present-but-empty can be told apart
-// via the double-return form `entries, ok := hooks[spec.Name]` — a value of
-// `[]any{}` (what mergeCodexHooks leaves behind when the last pdx entry is
-// removed) must be classified as broken, not absent.
+// via the double-return form `entries, ok := hooks[spec.Name]` — a hand-edited
+// value of `[]any{}` must be classified as broken, not absent.
 //
 // Returns:
 //   - HookEventInfo for events[spec.Name]
@@ -225,7 +224,11 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 				},
 			})
 		}
-		hooks[event] = entries
+		if remove && len(entries) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = entries
+		}
 	}
 	hooksFile["hooks"] = hooks
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
@@ -432,10 +435,7 @@ func filterOutPdxCodex(entries any) []any {
 }
 
 func filterOutPdxCodexKnownEvents(entries any) []any {
-	known := codexKnownEventNames()
-	return filterOutPdxCodexWithPredicate(entries, func(cmd string) bool {
-		return isPdxCommandCodexKnownEvent(cmd, known)
-	})
+	return filterOutPdxCodexWithPredicate(entries, isPdxCommandCodexOwned)
 }
 
 func filterOutPdxCodexWithPredicate(entries any, isOwned func(string) bool) []any {
@@ -483,6 +483,10 @@ func filterOutPdxCodexWithPredicate(entries any, isOwned func(string) bool) []an
 }
 
 func isPdxCommandCodexKnownEvent(cmd string, known map[string]bool) bool {
+	return isPdxCommandCodexOwned(cmd) && known[lastCodexCommandToken(cmd)]
+}
+
+func isPdxCommandCodexOwned(cmd string) bool {
 	tokens := tokenizeCodexCommand(cmd)
 	if len(tokens) == 0 || filepath.Base(tokens[0]) != "pdx" {
 		return false
@@ -497,7 +501,15 @@ func isPdxCommandCodexKnownEvent(cmd string, known map[string]bool) bool {
 			hasAgentCodex = true
 		}
 	}
-	return hasHook && hasAgentCodex && known[tokens[len(tokens)-1]]
+	return hasHook && hasAgentCodex
+}
+
+func lastCodexCommandToken(cmd string) string {
+	tokens := tokenizeCodexCommand(cmd)
+	if len(tokens) == 0 {
+		return ""
+	}
+	return tokens[len(tokens)-1]
 }
 
 func codexKnownEventNames() map[string]bool {

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -220,6 +220,9 @@ func mergeCodexHooksFile(hooksFile map[string]any, pdxPath string, remove bool) 
 	}
 	if remove {
 		for event, existing := range hooks {
+			if _, ok := existing.([]any); !ok {
+				continue
+			}
 			entries := filterOutPdxCodexKnownEvents(existing)
 			if len(entries) == 0 {
 				delete(hooks, event)
@@ -567,16 +570,19 @@ func filterOutPdxCodexWithPredicate(entries any, isOwned func(string) bool) []an
 				if isOwned(cmd) {
 					continue
 				}
-				result = append(result, map[string]any{
-					"hooks": []any{cloneCodexMap(group)},
-				})
+				result = append(result, entry)
 				continue
 			}
 			result = append(result, entry)
 			continue
 		}
 		var kept []any
-		for _, hookEntry := range toCodexEntrySlice(group["hooks"]) {
+		hooks, ok := group["hooks"].([]any)
+		if !ok {
+			result = append(result, entry)
+			continue
+		}
+		for _, hookEntry := range hooks {
 			m, ok := hookEntry.(map[string]any)
 			if !ok {
 				kept = append(kept, hookEntry)

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -1,16 +1,18 @@
 package codex
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/wake/purdex/internal/agent"
 )
 
-const codexHooksSupportedVersion = "0.121.0"
+const codexHooksSupportedVersion = "0.124.0"
 
 func (p *Provider) InstallHooks(pdxPath string) error {
 	home, err := os.UserHomeDir()
@@ -18,7 +20,8 @@ func (p *Provider) InstallHooks(pdxPath string) error {
 		return fmt.Errorf("cannot determine home directory: %w", err)
 	}
 	hooksPath := filepath.Join(home, ".codex", "hooks.json")
-	return mergeCodexHooks(hooksPath, pdxPath, false)
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	return installCodexHooks(configPath, hooksPath, pdxPath)
 }
 
 func (p *Provider) RemoveHooks(pdxPath string) error {
@@ -82,6 +85,14 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		}
 	}
 	managed := codexHooksManaged(hooks, allSpecs)
+	featureEnabled, err := codexHooksFeatureEnabled(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		return agent.HookStatus{}, err
+	}
+	if !featureEnabled {
+		allInstalled = false
+		issues = append(issues, "codex hooks feature flag disabled; run install to enable features.codex_hooks")
+	}
 	return agent.HookStatus{
 		Installed:         allInstalled,
 		Managed:           managed,
@@ -94,17 +105,30 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 	}, nil
 }
 
+func installCodexHooks(configPath, hooksPath, pdxPath string) error {
+	config, err := readCodexConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", configPath, err)
+	}
+	hooksFile, err := readCodexHooksFile(hooksPath)
+	if err != nil {
+		return err
+	}
+	setCodexHooksFeature(config)
+	mergeCodexHooksFile(hooksFile, pdxPath, false)
+	if err := writeCodexConfig(configPath, config); err != nil {
+		return err
+	}
+	return writeCodexHooksFile(hooksPath, hooksFile)
+}
+
 // codexHooksManaged reports whether hooks.json contains any pdx-owned
 // entry (per-event matcher-group shape OR legacy direct-entry shape).
 // Distinct from CheckHooks.Installed: a drifted-but-pdx-owned state has
 // Managed=true and Installed=false, which the UI needs so the Remove
 // button stays enabled.
-func codexHooksManaged(hooks map[string]any, specs []agent.HookEventSpec) bool {
-	for _, spec := range specs {
-		entries, ok := hooks[spec.Name]
-		if !ok {
-			continue
-		}
+func codexHooksManaged(hooks map[string]any, _ []agent.HookEventSpec) bool {
+	for _, entries := range hooks {
 		if hasLegacyPdxDirectCodexEntry(entries) {
 			return true
 		}
@@ -177,15 +201,15 @@ func checkCodexEvent(spec agent.HookEventSpec, hooks map[string]any) (agent.Hook
 }
 
 func mergeCodexHooks(path, pdxPath string, remove bool) error {
-	hooksFile := make(map[string]any)
-	data, err := os.ReadFile(path)
-	if err == nil {
-		if err := json.Unmarshal(data, &hooksFile); err != nil {
-			return fmt.Errorf("parse %s: %w", path, err)
-		}
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("read %s: %w", path, err)
+	hooksFile, err := readCodexHooksFile(path)
+	if err != nil {
+		return err
 	}
+	mergeCodexHooksFile(hooksFile, pdxPath, remove)
+	return writeCodexHooksFile(path, hooksFile)
+}
+
+func mergeCodexHooksFile(hooksFile map[string]any, pdxPath string, remove bool) {
 	var hooks map[string]any
 	if h, ok := hooksFile["hooks"]; ok {
 		hooks, _ = h.(map[string]any)
@@ -193,44 +217,56 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 	if hooks == nil {
 		hooks = make(map[string]any)
 	}
-	for _, spec := range codexEventSpecs {
-		installable := agent.IsInstallableHookSpec(spec)
-		if !remove && !installable {
-			continue
-		}
-		event := spec.Name
-		if remove && !installable {
-			existing, ok := hooks[event]
-			if !ok {
-				continue
-			}
+	if remove {
+		for event, existing := range hooks {
 			entries := filterOutPdxCodexKnownEvents(existing)
 			if len(entries) == 0 {
 				delete(hooks, event)
 			} else {
 				hooks[event] = entries
 			}
+		}
+		hooksFile["hooks"] = hooks
+		return
+	}
+	for _, spec := range codexEventSpecs {
+		installable := agent.IsInstallableHookSpec(spec)
+		if !installable {
 			continue
 		}
+		event := spec.Name
 		entries := filterOutPdxCodexKnownEvents(hooks[event])
-		if !remove {
-			entries = append(entries, map[string]any{
-				"hooks": []any{
-					map[string]any{
-						"type":    "command",
-						"command": fmt.Sprintf(`"%s" hook --agent codex %s`, pdxPath, event),
-						"timeout": 5,
-					},
+		entries = append(entries, map[string]any{
+			"hooks": []any{
+				map[string]any{
+					"type":    "command",
+					"command": fmt.Sprintf(`"%s" hook --agent codex %s`, pdxPath, event),
+					"timeout": 5,
 				},
-			})
-		}
-		if remove && len(entries) == 0 {
-			delete(hooks, event)
-		} else {
-			hooks[event] = entries
-		}
+			},
+		})
+		hooks[event] = entries
 	}
 	hooksFile["hooks"] = hooks
+
+}
+
+func readCodexHooksFile(path string) (map[string]any, error) {
+	hooksFile := make(map[string]any)
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(data, &hooksFile); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		return hooksFile, nil
+	}
+	if os.IsNotExist(err) {
+		return hooksFile, nil
+	}
+	return nil, fmt.Errorf("read %s: %w", path, err)
+}
+
+func writeCodexHooksFile(path string, hooksFile map[string]any) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("create directory: %w", err)
 	}
@@ -247,6 +283,62 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 		return fmt.Errorf("rename: %w", err)
 	}
 	return nil
+}
+
+func readCodexConfig(path string) (map[string]any, error) {
+	config := make(map[string]any)
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if _, err := toml.Decode(string(data), &config); err != nil {
+			return nil, err
+		}
+		return config, nil
+	}
+	if os.IsNotExist(err) {
+		return config, nil
+	}
+	return nil, err
+}
+
+func writeCodexConfig(path string, config map[string]any) error {
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(config); err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename config: %w", err)
+	}
+	return nil
+}
+
+func setCodexHooksFeature(config map[string]any) {
+	features, _ := config["features"].(map[string]any)
+	if features == nil {
+		features = make(map[string]any)
+	}
+	features["codex_hooks"] = true
+	config["features"] = features
+}
+
+func codexHooksFeatureEnabled(path string) (bool, error) {
+	config, err := readCodexConfig(path)
+	if err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	features, _ := config["features"].(map[string]any)
+	if features == nil {
+		return false, nil
+	}
+	enabled, _ := features["codex_hooks"].(bool)
+	return enabled, nil
 }
 
 // isPdxCommandCodex is the relaxed shape check used by filter / legacy
@@ -415,7 +507,7 @@ func hasLegacyPdxDirectCodexEntry(v any) bool {
 			continue
 		}
 		cmd, _ := m["command"].(string)
-		if isPdxCommandCodex(cmd) {
+		if isPdxCommandCodexOwned(cmd) {
 			return true
 		}
 	}

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -53,7 +53,13 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 		return agent.HookStatus{}, fmt.Errorf("parse hooks.json: %w", err)
 	}
 	hooks, _ := hooksFile["hooks"].(map[string]any)
-	specs := p.Events()
+	allSpecs := p.Events()
+	specs := make([]agent.HookEventSpec, 0, len(allSpecs))
+	for _, spec := range allSpecs {
+		if agent.IsInstallableHookSpec(spec) {
+			specs = append(specs, spec)
+		}
+	}
 	events := make(map[string]agent.HookEventInfo, len(specs))
 	var issues []string
 	var upgrades []string
@@ -75,7 +81,7 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 			}
 		}
 	}
-	managed := codexHooksManaged(hooks, specs)
+	managed := codexHooksManaged(hooks, allSpecs)
 	return agent.HookStatus{
 		Installed:         allInstalled,
 		Managed:           managed,
@@ -188,7 +194,11 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 	if hooks == nil {
 		hooks = make(map[string]any)
 	}
-	for _, event := range codexEventNames() {
+	for _, spec := range codexEventSpecs {
+		if !remove && !agent.IsInstallableHookSpec(spec) {
+			continue
+		}
+		event := spec.Name
 		entries := filterOutPdxCodex(hooks[event])
 		if !remove {
 			entries = append(entries, map[string]any{

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -114,6 +114,9 @@ func installCodexHooks(configPath, hooksPath, pdxPath string) error {
 	if err != nil {
 		return err
 	}
+	if err := validateCodexInstallableHookShapes(hooksFile); err != nil {
+		return err
+	}
 	setCodexHooksFeature(config)
 	mergeCodexHooksFile(hooksFile, pdxPath, false)
 	if err := writeCodexHooksFile(hooksPath, hooksFile); err != nil {
@@ -206,8 +209,33 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 	if err != nil {
 		return err
 	}
+	if !remove {
+		if err := validateCodexInstallableHookShapes(hooksFile); err != nil {
+			return err
+		}
+	}
 	mergeCodexHooksFile(hooksFile, pdxPath, remove)
 	return writeCodexHooksFile(path, hooksFile)
+}
+
+func validateCodexInstallableHookShapes(hooksFile map[string]any) error {
+	hooks, _ := hooksFile["hooks"].(map[string]any)
+	if hooks == nil {
+		return nil
+	}
+	for _, spec := range codexEventSpecs {
+		if !agent.IsInstallableHookSpec(spec) {
+			continue
+		}
+		value, ok := hooks[spec.Name]
+		if !ok || value == nil {
+			continue
+		}
+		if _, ok := value.([]any); !ok {
+			return fmt.Errorf("codex hook %s has unsupported value shape", spec.Name)
+		}
+	}
+	return nil
 }
 
 func mergeCodexHooksFile(hooksFile map[string]any, pdxPath string, remove bool) {

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -205,7 +205,7 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 			if !ok {
 				continue
 			}
-			entries := filterOutPdxCodex(existing)
+			entries := filterOutPdxCodexKnownEvents(existing)
 			if len(entries) == 0 {
 				delete(hooks, event)
 			} else {
@@ -213,7 +213,7 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 			}
 			continue
 		}
-		entries := filterOutPdxCodex(hooks[event])
+		entries := filterOutPdxCodexKnownEvents(hooks[event])
 		if !remove {
 			entries = append(entries, map[string]any{
 				"hooks": []any{
@@ -428,6 +428,17 @@ func cloneCodexMap(src map[string]any) map[string]any {
 }
 
 func filterOutPdxCodex(entries any) []any {
+	return filterOutPdxCodexWithPredicate(entries, isPdxCommandCodex)
+}
+
+func filterOutPdxCodexKnownEvents(entries any) []any {
+	known := codexKnownEventNames()
+	return filterOutPdxCodexWithPredicate(entries, func(cmd string) bool {
+		return isPdxCommandCodexKnownEvent(cmd, known)
+	})
+}
+
+func filterOutPdxCodexWithPredicate(entries any, isOwned func(string) bool) []any {
 	var result []any
 	for _, entry := range toCodexEntrySlice(entries) {
 		group, ok := entry.(map[string]any)
@@ -438,7 +449,7 @@ func filterOutPdxCodex(entries any) []any {
 		if _, ok := group["hooks"]; !ok {
 			if _, ok := group["type"]; ok {
 				cmd, _ := group["command"].(string)
-				if isPdxCommandCodex(cmd) {
+				if isOwned(cmd) {
 					continue
 				}
 				result = append(result, map[string]any{
@@ -457,7 +468,7 @@ func filterOutPdxCodex(entries any) []any {
 				continue
 			}
 			cmd, _ := m["command"].(string)
-			if !isPdxCommandCodex(cmd) {
+			if !isOwned(cmd) {
 				kept = append(kept, hookEntry)
 			}
 		}
@@ -469,4 +480,30 @@ func filterOutPdxCodex(entries any) []any {
 		result = append(result, cloned)
 	}
 	return result
+}
+
+func isPdxCommandCodexKnownEvent(cmd string, known map[string]bool) bool {
+	tokens := tokenizeCodexCommand(cmd)
+	if len(tokens) == 0 || filepath.Base(tokens[0]) != "pdx" {
+		return false
+	}
+	hasHook := false
+	hasAgentCodex := false
+	for i := 1; i < len(tokens); i++ {
+		if tokens[i] == "hook" {
+			hasHook = true
+		}
+		if tokens[i] == "--agent" && i+1 < len(tokens) && tokens[i+1] == "codex" {
+			hasAgentCodex = true
+		}
+	}
+	return hasHook && hasAgentCodex && known[tokens[len(tokens)-1]]
+}
+
+func codexKnownEventNames() map[string]bool {
+	known := make(map[string]bool, len(codexEventSpecs))
+	for _, spec := range codexEventSpecs {
+		known[spec.Name] = true
+	}
+	return known
 }

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -116,10 +116,10 @@ func installCodexHooks(configPath, hooksPath, pdxPath string) error {
 	}
 	setCodexHooksFeature(config)
 	mergeCodexHooksFile(hooksFile, pdxPath, false)
-	if err := writeCodexConfig(configPath, config); err != nil {
+	if err := writeCodexHooksFile(hooksPath, hooksFile); err != nil {
 		return err
 	}
-	return writeCodexHooksFile(hooksPath, hooksFile)
+	return writeCodexConfig(configPath, config)
 }
 
 // codexHooksManaged reports whether hooks.json contains any pdx-owned
@@ -309,15 +309,33 @@ func writeCodexConfig(path string, config map[string]any) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("create config directory: %w", err)
 	}
+	mode, err := existingFileMode(path, 0600)
+	if err != nil {
+		return fmt.Errorf("stat config: %w", err)
+	}
 	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(tmpPath, buf.Bytes(), mode); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		os.Remove(tmpPath)
 		return fmt.Errorf("rename config: %w", err)
 	}
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("chmod config: %w", err)
+	}
 	return nil
+}
+
+func existingFileMode(path string, defaultMode os.FileMode) (os.FileMode, error) {
+	info, err := os.Stat(path)
+	if err == nil {
+		return info.Mode().Perm(), nil
+	}
+	if os.IsNotExist(err) {
+		return defaultMode, nil
+	}
+	return 0, err
 }
 
 func setCodexHooksFeature(config map[string]any) {
@@ -349,9 +367,7 @@ func codexHooksFeatureEnabled(path string) (bool, error) {
 // direct-entry shape. Per-event health assertions must not use this; see
 // isPdxCommandCodexForEvent (PR #616 review Finding #1).
 func isPdxCommandCodex(cmd string) bool {
-	// Match both quoted ("/path/pdx" hook) and unquoted (/path/pdx hook) forms.
-	normalized := strings.ReplaceAll(cmd, `"`, "")
-	return strings.Contains(normalized, "pdx hook")
+	return isPdxCommandCodexOwned(cmd)
 }
 
 // isPdxCommandCodexForEvent reports whether cmd is a well-formed pdx hook
@@ -360,7 +376,7 @@ func isPdxCommandCodex(cmd string) bool {
 //     basename "pdx" (covers "/abs/path/pdx", "pdx", the quoted forms
 //     mergeCodexHooks writes, and paths containing spaces such as
 //     "/Applications/Purdex Beta/pdx").
-//  2. Some later token equals "hook".
+//  2. The first subcommand token equals "hook".
 //  3. Two consecutive tokens "--agent" "codex" appear after "hook".
 //  4. The final non-empty token equals eventName exactly.
 //
@@ -383,17 +399,16 @@ func isPdxCommandCodexForEvent(cmd string, eventName string) bool {
 	if filepath.Base(first) != "pdx" {
 		return false
 	}
-	hasHook := false
 	hasAgentCodex := false
-	for i := 1; i < len(tokens); i++ {
-		if tokens[i] == "hook" {
-			hasHook = true
-		}
+	if len(tokens) < 2 || tokens[1] != "hook" {
+		return false
+	}
+	for i := 2; i < len(tokens); i++ {
 		if tokens[i] == "--agent" && i+1 < len(tokens) && tokens[i+1] == "codex" {
 			hasAgentCodex = true
 		}
 	}
-	if !hasHook || !hasAgentCodex {
+	if !hasAgentCodex {
 		return false
 	}
 	return tokens[len(tokens)-1] == eventName
@@ -595,17 +610,16 @@ func isPdxCommandCodexOwned(cmd string) bool {
 	if len(tokens) == 0 || filepath.Base(tokens[0]) != "pdx" {
 		return false
 	}
-	hasHook := false
 	hasAgentCodex := false
-	for i := 1; i < len(tokens); i++ {
-		if tokens[i] == "hook" {
-			hasHook = true
-		}
+	if len(tokens) < 2 || tokens[1] != "hook" {
+		return false
+	}
+	for i := 2; i < len(tokens); i++ {
 		if tokens[i] == "--agent" && i+1 < len(tokens) && tokens[i+1] == "codex" {
 			hasAgentCodex = true
 		}
 	}
-	return hasHook && hasAgentCodex
+	return hasAgentCodex
 }
 
 func lastCodexCommandToken(cmd string) string {
@@ -625,5 +639,15 @@ func codexKnownEventNames() map[string]bool {
 }
 
 func codexOwnedCleanupEventNames() map[string]bool {
-	return codexKnownEventNames()
+	return map[string]bool{
+		"SessionStart":      true,
+		"UserPromptSubmit":  true,
+		"SubagentStart":     true,
+		"SubagentStop":      true,
+		"Stop":              true,
+		"StopFailure":       true,
+		"Notification":      true,
+		"PermissionRequest": true,
+		"SessionEnd":        true,
+	}
 }

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -195,10 +195,24 @@ func mergeCodexHooks(path, pdxPath string, remove bool) error {
 		hooks = make(map[string]any)
 	}
 	for _, spec := range codexEventSpecs {
-		if !remove && !agent.IsInstallableHookSpec(spec) {
+		installable := agent.IsInstallableHookSpec(spec)
+		if !remove && !installable {
 			continue
 		}
 		event := spec.Name
+		if remove && !installable {
+			existing, ok := hooks[event]
+			if !ok {
+				continue
+			}
+			entries := filterOutPdxCodex(existing)
+			if len(entries) == 0 {
+				delete(hooks, event)
+			} else {
+				hooks[event] = entries
+			}
+			continue
+		}
 		entries := filterOutPdxCodex(hooks[event])
 		if !remove {
 			entries = append(entries, map[string]any{

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -128,8 +128,9 @@ func installCodexHooks(configPath, hooksPath, pdxPath string) error {
 // Managed=true and Installed=false, which the UI needs so the Remove
 // button stays enabled.
 func codexHooksManaged(hooks map[string]any, _ []agent.HookEventSpec) bool {
+	owned := codexOwnedCleanupEventNames()
 	for _, entries := range hooks {
-		if hasLegacyPdxDirectCodexEntry(entries) {
+		if hasLegacyPdxDirectCodexEntryOwned(entries, owned) {
 			return true
 		}
 		for _, groupEntry := range codexMatcherGroups(entries) {
@@ -143,7 +144,7 @@ func codexHooksManaged(hooks map[string]any, _ []agent.HookEventSpec) bool {
 					continue
 				}
 				cmd, _ := m["command"].(string)
-				if isPdxCommandCodexOwned(cmd) {
+				if isPdxCommandCodexOwnedEvent(cmd, owned) {
 					return true
 				}
 			}
@@ -495,6 +496,10 @@ func codexMatcherGroups(v any) []any {
 // of a third-party legacy entry alongside a correctly-installed pdx matcher
 // group is not a pdx reinstall trigger and must not report false.
 func hasLegacyPdxDirectCodexEntry(v any) bool {
+	return hasLegacyPdxDirectCodexEntryOwned(v, codexOwnedCleanupEventNames())
+}
+
+func hasLegacyPdxDirectCodexEntryOwned(v any, owned map[string]bool) bool {
 	for _, entry := range toCodexEntrySlice(v) {
 		m, ok := entry.(map[string]any)
 		if !ok {
@@ -507,7 +512,7 @@ func hasLegacyPdxDirectCodexEntry(v any) bool {
 			continue
 		}
 		cmd, _ := m["command"].(string)
-		if isPdxCommandCodexOwned(cmd) {
+		if isPdxCommandCodexOwnedEvent(cmd, owned) {
 			return true
 		}
 	}
@@ -527,7 +532,10 @@ func filterOutPdxCodex(entries any) []any {
 }
 
 func filterOutPdxCodexKnownEvents(entries any) []any {
-	return filterOutPdxCodexWithPredicate(entries, isPdxCommandCodexOwned)
+	owned := codexOwnedCleanupEventNames()
+	return filterOutPdxCodexWithPredicate(entries, func(cmd string) bool {
+		return isPdxCommandCodexOwnedEvent(cmd, owned)
+	})
 }
 
 func filterOutPdxCodexWithPredicate(entries any, isOwned func(string) bool) []any {
@@ -578,6 +586,10 @@ func isPdxCommandCodexKnownEvent(cmd string, known map[string]bool) bool {
 	return isPdxCommandCodexOwned(cmd) && known[lastCodexCommandToken(cmd)]
 }
 
+func isPdxCommandCodexOwnedEvent(cmd string, owned map[string]bool) bool {
+	return isPdxCommandCodexOwned(cmd) && owned[lastCodexCommandToken(cmd)]
+}
+
 func isPdxCommandCodexOwned(cmd string) bool {
 	tokens := tokenizeCodexCommand(cmd)
 	if len(tokens) == 0 || filepath.Base(tokens[0]) != "pdx" {
@@ -610,4 +622,8 @@ func codexKnownEventNames() map[string]bool {
 		known[spec.Name] = true
 	}
 	return known
+}
+
+func codexOwnedCleanupEventNames() map[string]bool {
+	return codexKnownEventNames()
 }

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -380,7 +380,7 @@ func TestCodexInstallHooks_EnablesFeatureFlagAndPreservesConfig(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	existing := "model = \"gpt-5\"\n\n[features]\nother = true\ncodex_hooks = false\n"
-	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(existing), 0600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -397,6 +397,13 @@ func TestCodexInstallHooks_EnablesFeatureFlagAndPreservesConfig(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("config.toml missing %q after install:\n%s", want, text)
 		}
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("config.toml mode=%#o, want 0600", got)
 	}
 }
 
@@ -450,6 +457,35 @@ func TestCodexInstallHooks_ParseFailureDoesNotPartiallyWrite(t *testing.T) {
 		gotHooks, _ := os.ReadFile(hooksPath)
 		if string(gotConfig) != string(originalConfig) || string(gotHooks) != string(badHooks) {
 			t.Fatalf("files changed after malformed hooks; config=%q hooks=%q", gotConfig, gotHooks)
+		}
+	})
+
+	t.Run("hooks write failure leaves config unchanged", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		configPath := filepath.Join(home, ".codex", "config.toml")
+		hooksPath := filepath.Join(home, ".codex", "hooks.json")
+		codexDir := filepath.Dir(configPath)
+		if err := os.MkdirAll(codexDir, 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		originalConfig := []byte("model = \"gpt-5\"\n")
+		if err := os.WriteFile(configPath, originalConfig, 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		if err := os.WriteFile(hooksPath, []byte(`{"hooks":{}}`), 0644); err != nil {
+			t.Fatalf("write hooks: %v", err)
+		}
+		if err := os.Chmod(codexDir, 0500); err != nil {
+			t.Fatalf("chmod codex dir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(codexDir, 0700) })
+		if err := (&Provider{}).InstallHooks("/usr/local/bin/pdx"); err == nil {
+			t.Fatal("InstallHooks succeeded with unwritable hooks directory")
+		}
+		gotConfig, _ := os.ReadFile(configPath)
+		if string(gotConfig) != string(originalConfig) {
+			t.Fatalf("config changed after hooks write failure; got %q", gotConfig)
 		}
 	})
 }
@@ -540,19 +576,23 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 		t.Fatal("remove left owned installable event SessionStart")
 	}
 	staleGroups := codexMatcherGroups(staleHooks["IgnoredSynthetic"])
-	if len(staleGroups) != 3 {
-		t.Fatalf("remove kept %d unknown/third-party groups, want 3", len(staleGroups))
+	if len(staleGroups) != 4 {
+		t.Fatalf("remove kept %d unknown/third-party groups, want 4", len(staleGroups))
 	}
+	foundSyntheticCodexPdx := false
 	foundCCPdx := false
 	foundUnknownCodexPdx := false
-	knownCodexEvents := codexKnownEventNames()
+	ownedCodexEvents := codexOwnedCleanupEventNames()
 	for _, groupEntry := range staleGroups {
 		group, _ := groupEntry.(map[string]any)
 		for _, hookEntry := range toCodexEntrySlice(group["hooks"]) {
 			m, _ := hookEntry.(map[string]any)
 			cmd, _ := m["command"].(string)
-			if isPdxCommandCodexKnownEvent(cmd, knownCodexEvents) {
-				t.Fatalf("remove left stale non-installable pdx entry: %#v", hookEntry)
+			if isPdxCommandCodexOwnedEvent(cmd, ownedCodexEvents) {
+				t.Fatalf("remove left owned pdx entry: %#v", hookEntry)
+			}
+			if strings.Contains(cmd, "--agent codex IgnoredSynthetic") {
+				foundSyntheticCodexPdx = true
 			}
 			if strings.Contains(cmd, "--agent cc") {
 				foundCCPdx = true
@@ -561,6 +601,9 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 				foundUnknownCodexPdx = true
 			}
 		}
+	}
+	if !foundSyntheticCodexPdx {
+		t.Fatal("remove dropped non-owned synthetic Codex pdx hook under non-installable key")
 	}
 	if !foundCCPdx {
 		t.Fatal("remove dropped non-codex pdx hook under non-installable key")
@@ -1334,6 +1377,7 @@ func TestIsPdxCommandCodexForEvent(t *testing.T) {
 		{`/usr/local/bin/pdx hook --agent cc Notification`, "Notification", "wrong agent"},
 		{`other-tool hook --agent codex Stop`, "Stop", "non-pdx binary"},
 		{`"/usr/local/bin/pdx" hook --agent codex`, "Stop", "missing event name"},
+		{`pdx exec hook --agent codex SessionStart`, "SessionStart", "hook is not first subcommand"},
 	}
 	for _, tc := range negative {
 		if isPdxCommandCodexForEvent(tc.cmd, tc.event) {

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -519,6 +519,7 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 	staleHooksPath := filepath.Join(dir, "stale-hooks.json")
 	stale := map[string]any{
 		"hooks": map[string]any{
+			"SessionStart": []any{pdxGroupEntry("SessionStart")},
 			"IgnoredSynthetic": []any{
 				pdxGroupEntry("IgnoredSynthetic"),
 				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": `"/usr/local/bin/pdx" hook --agent codex Bogus`, "timeout": 5}}},
@@ -535,11 +536,15 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 		t.Fatalf("remove stale non-installable hook: %v", err)
 	}
 	staleHooks := hooksSection(t, readHooksFile(t, staleHooksPath))
+	if _, ok := staleHooks["SessionStart"]; ok {
+		t.Fatal("remove left owned installable event SessionStart")
+	}
 	staleGroups := codexMatcherGroups(staleHooks["IgnoredSynthetic"])
-	if len(staleGroups) != 2 {
-		t.Fatalf("remove kept %d non-installable third-party groups, want 2", len(staleGroups))
+	if len(staleGroups) != 3 {
+		t.Fatalf("remove kept %d unknown/third-party groups, want 3", len(staleGroups))
 	}
 	foundCCPdx := false
+	foundUnknownCodexPdx := false
 	knownCodexEvents := codexKnownEventNames()
 	for _, groupEntry := range staleGroups {
 		group, _ := groupEntry.(map[string]any)
@@ -552,10 +557,16 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 			if strings.Contains(cmd, "--agent cc") {
 				foundCCPdx = true
 			}
+			if strings.Contains(cmd, "--agent codex Bogus") {
+				foundUnknownCodexPdx = true
+			}
 		}
 	}
 	if !foundCCPdx {
 		t.Fatal("remove dropped non-codex pdx hook under non-installable key")
+	}
+	if !foundUnknownCodexPdx {
+		t.Fatal("remove dropped unknown Codex pdx hook under non-installable key")
 	}
 	absentHooksPath := filepath.Join(dir, "absent-hooks.json")
 	if err := os.WriteFile(absentHooksPath, []byte(`{"hooks":{}}`), 0644); err != nil {
@@ -1102,7 +1113,7 @@ func TestCheckHooks_Managed_FalseForOtherAgentPdxEntry(t *testing.T) {
 	}
 }
 
-func TestCodexRemoveHooks_RemovesOwnedRetiredEventKey(t *testing.T) {
+func TestCodexRemoveHooks_PreservesUnknownRetiredEventKey(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	hooksPath := filepath.Join(home, ".codex", "hooks.json")
@@ -1123,15 +1134,15 @@ func TestCodexRemoveHooks_RemovesOwnedRetiredEventKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CheckHooks: %v", err)
 	}
-	if !status.Managed {
-		t.Fatal("retired codex pdx entry: Managed=false, want true")
+	if status.Managed {
+		t.Fatal("unknown codex pdx entry: Managed=true, want false")
 	}
 	if err := (&Provider{}).RemoveHooks("/usr/local/bin/pdx"); err != nil {
 		t.Fatalf("RemoveHooks: %v", err)
 	}
 	hooks := hooksSection(t, readHooksFile(t, hooksPath))
-	if _, ok := hooks["RetiredEvent"]; ok {
-		t.Fatal("RemoveHooks left retired owned Codex hook key")
+	if _, ok := hooks["RetiredEvent"]; !ok {
+		t.Fatal("RemoveHooks removed unknown Codex hook key")
 	}
 }
 

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -526,6 +526,35 @@ func TestCodexInstallHooks_ParseFailureDoesNotPartiallyWrite(t *testing.T) {
 			t.Fatalf("files changed after unsupported hook shape; config=%q hooks=%q", gotConfig, gotHooks)
 		}
 	})
+
+	t.Run("unsupported hooks root leaves files unchanged", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		configPath := filepath.Join(home, ".codex", "config.toml")
+		hooksPath := filepath.Join(home, ".codex", "hooks.json")
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		originalConfig := []byte("model = \"gpt-5\"\n")
+		originalHooks := []byte(`{"hooks":"custom-root"}`)
+		if err := os.WriteFile(configPath, originalConfig, 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		if err := os.WriteFile(hooksPath, originalHooks, 0644); err != nil {
+			t.Fatalf("write hooks: %v", err)
+		}
+		if err := (&Provider{}).InstallHooks("/usr/local/bin/pdx"); err == nil {
+			t.Fatal("InstallHooks succeeded with unsupported hooks root shape")
+		}
+		if err := (&Provider{}).RemoveHooks("/usr/local/bin/pdx"); err == nil {
+			t.Fatal("RemoveHooks succeeded with unsupported hooks root shape")
+		}
+		gotConfig, _ := os.ReadFile(configPath)
+		gotHooks, _ := os.ReadFile(hooksPath)
+		if string(gotConfig) != string(originalConfig) || string(gotHooks) != string(originalHooks) {
+			t.Fatalf("files changed after unsupported hooks root; config=%q hooks=%q", gotConfig, gotHooks)
+		}
+	})
 }
 
 func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -51,7 +51,7 @@ func TestFilterOutPdxCodex_MatchesAndPreserves(t *testing.T) {
 	}
 }
 
-func TestFilterOutPdxCodex_LegacyDirectEntryMigrated(t *testing.T) {
+func TestFilterOutPdxCodex_NonOwnedDirectEntryPreserved(t *testing.T) {
 	entries := []any{
 		map[string]any{
 			"type":    "command",
@@ -60,13 +60,8 @@ func TestFilterOutPdxCodex_LegacyDirectEntryMigrated(t *testing.T) {
 		},
 	}
 	result := filterOutPdxCodex(entries)
-	if len(result) != 1 {
-		t.Fatalf("expected 1 matcher group after migration, got %d", len(result))
-	}
-	group, _ := result[0].(map[string]any)
-	hookEntries := toCodexEntrySlice(group["hooks"])
-	if len(hookEntries) != 1 {
-		t.Fatalf("expected 1 migrated hook entry, got %d", len(hookEntries))
+	if !reflect.DeepEqual(result, entries) {
+		t.Fatalf("non-owned direct entry changed; got %#v want %#v", result, entries)
 	}
 }
 
@@ -494,12 +489,11 @@ func TestCodexInstallHooks_ParseFailureDoesNotPartiallyWrite(t *testing.T) {
 		if err := os.WriteFile(hooksPath, []byte(`{"hooks":{}}`), 0644); err != nil {
 			t.Fatalf("write hooks: %v", err)
 		}
-		if err := os.Chmod(codexDir, 0500); err != nil {
-			t.Fatalf("chmod codex dir: %v", err)
+		if err := os.Mkdir(hooksPath+".tmp", 0755); err != nil {
+			t.Fatalf("mkdir hooks temp collision: %v", err)
 		}
-		t.Cleanup(func() { _ = os.Chmod(codexDir, 0700) })
 		if err := (&Provider{}).InstallHooks("/usr/local/bin/pdx"); err == nil {
-			t.Fatal("InstallHooks succeeded with unwritable hooks directory")
+			t.Fatal("InstallHooks succeeded with hooks temp path blocked by directory")
 		}
 		gotConfig, _ := os.ReadFile(configPath)
 		if string(gotConfig) != string(originalConfig) {
@@ -1204,6 +1198,77 @@ func TestCodexRemoveHooks_PreservesUnknownRetiredEventKey(t *testing.T) {
 	hooks := hooksSection(t, readHooksFile(t, hooksPath))
 	if _, ok := hooks["RetiredEvent"]; !ok {
 		t.Fatal("RemoveHooks removed unknown Codex hook key")
+	}
+}
+
+func TestCodexRemoveHooks_PreservesUnknownNonArrayHookValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	wantObject := map[string]any{"custom": true}
+	data, _ := json.MarshalIndent(map[string]any{
+		"hooks": map[string]any{
+			"UnknownObject": wantObject,
+			"SessionStart":  "custom-scalar",
+			"OwnedKey":      []any{pdxGroupEntry("SessionStart")},
+		},
+	}, "", "  ")
+	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+
+	if err := (&Provider{}).RemoveHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("RemoveHooks: %v", err)
+	}
+	hooks := hooksSection(t, readHooksFile(t, hooksPath))
+	if !reflect.DeepEqual(hooks["UnknownObject"], wantObject) {
+		t.Fatalf("RemoveHooks changed unknown object hook value: %#v", hooks["UnknownObject"])
+	}
+	if hooks["SessionStart"] != "custom-scalar" {
+		t.Fatalf("RemoveHooks changed unknown scalar hook value: %#v", hooks["SessionStart"])
+	}
+	if _, ok := hooks["OwnedKey"]; ok {
+		t.Fatal("RemoveHooks left owned array hook key")
+	}
+}
+
+func TestCodexMergeHooks_PreservesNonOwnedDirectEntryShape(t *testing.T) {
+	for _, remove := range []bool{false, true} {
+		t.Run(fmt.Sprintf("remove=%v", remove), func(t *testing.T) {
+			dir := t.TempDir()
+			hooksPath := filepath.Join(dir, "hooks.json")
+			direct := map[string]any{"type": "command", "command": "/usr/bin/notify third-party", "timeout": float64(5)}
+			data, _ := json.MarshalIndent(map[string]any{
+				"hooks": map[string]any{
+					"SessionStart": []any{direct},
+				},
+			}, "", "  ")
+			if err := os.WriteFile(hooksPath, data, 0644); err != nil {
+				t.Fatalf("write hooks: %v", err)
+			}
+
+			if err := mergeCodexHooks(hooksPath, "/usr/local/bin/pdx", remove); err != nil {
+				t.Fatalf("mergeCodexHooks: %v", err)
+			}
+			hooks := hooksSection(t, readHooksFile(t, hooksPath))
+			entries := toCodexEntrySlice(hooks["SessionStart"])
+			foundDirect := false
+			for _, entry := range entries {
+				m, _ := entry.(map[string]any)
+				if _, hasHooks := m["hooks"]; hasHooks {
+					continue
+				}
+				if reflect.DeepEqual(m, direct) {
+					foundDirect = true
+				}
+			}
+			if !foundDirect {
+				t.Fatalf("mergeCodexHooks changed non-owned direct entry shape: %#v", entries)
+			}
+		})
 	}
 }
 

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -500,6 +500,32 @@ func TestCodexInstallHooks_ParseFailureDoesNotPartiallyWrite(t *testing.T) {
 			t.Fatalf("config changed after hooks write failure; got %q", gotConfig)
 		}
 	})
+
+	t.Run("unsupported installable hook shape leaves files unchanged", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		configPath := filepath.Join(home, ".codex", "config.toml")
+		hooksPath := filepath.Join(home, ".codex", "hooks.json")
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		originalConfig := []byte("model = \"gpt-5\"\n")
+		originalHooks := []byte(`{"hooks":{"SessionStart":"custom-scalar","Stop":{"custom":true}}}`)
+		if err := os.WriteFile(configPath, originalConfig, 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		if err := os.WriteFile(hooksPath, originalHooks, 0644); err != nil {
+			t.Fatalf("write hooks: %v", err)
+		}
+		if err := (&Provider{}).InstallHooks("/usr/local/bin/pdx"); err == nil {
+			t.Fatal("InstallHooks succeeded with unsupported installable hook value shape")
+		}
+		gotConfig, _ := os.ReadFile(configPath)
+		gotHooks, _ := os.ReadFile(hooksPath)
+		if string(gotConfig) != string(originalConfig) || string(gotHooks) != string(originalHooks) {
+			t.Fatalf("files changed after unsupported hook shape; config=%q hooks=%q", gotConfig, gotHooks)
+		}
+	})
 }
 
 func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -269,6 +269,12 @@ func TestMergeCodexHooks_RemoveMode(t *testing.T) {
 	hooks = hooksSection(t, m)
 
 	for _, event := range expectedCodexInstallerNames {
+		if event != "SessionStart" {
+			if _, ok := hooks[event]; ok {
+				t.Errorf("event %s: remove left empty event key", event)
+			}
+			continue
+		}
 		for _, groupEntry := range codexMatcherGroups(hooks[event]) {
 			group, _ := groupEntry.(map[string]any)
 			for _, hookEntry := range toCodexEntrySlice(group["hooks"]) {
@@ -431,6 +437,7 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 		"hooks": map[string]any{
 			"IgnoredSynthetic": []any{
 				pdxGroupEntry("IgnoredSynthetic"),
+				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": `"/usr/local/bin/pdx" hook --agent codex Bogus`, "timeout": 5}}},
 				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": `"/usr/local/bin/pdx" hook --agent cc IgnoredSynthetic`, "timeout": 5}}},
 				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "/usr/bin/notify ignored", "timeout": 5}}},
 			},
@@ -908,6 +915,31 @@ func TestCheckHooks_Managed_FalseWhenNoPdxEntries(t *testing.T) {
 	}
 	if status.Managed {
 		t.Fatal("no pdx entries: Managed=true, want false")
+	}
+}
+
+func TestCheckHooks_Managed_FalseForOtherAgentPdxEntry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart": []any{
+			map[string]any{
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": `"/usr/local/bin/pdx" hook --agent cc SessionStart`,
+						"timeout": 5,
+					},
+				},
+			},
+		},
+	})
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Managed {
+		t.Fatal("other-agent pdx entry: Managed=true, want false")
 	}
 }
 

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -431,6 +431,7 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 		"hooks": map[string]any{
 			"IgnoredSynthetic": []any{
 				pdxGroupEntry("IgnoredSynthetic"),
+				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": `"/usr/local/bin/pdx" hook --agent cc IgnoredSynthetic`, "timeout": 5}}},
 				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "/usr/bin/notify ignored", "timeout": 5}}},
 			},
 		},
@@ -444,18 +445,26 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 	}
 	staleHooks := hooksSection(t, readHooksFile(t, staleHooksPath))
 	staleGroups := codexMatcherGroups(staleHooks["IgnoredSynthetic"])
-	if len(staleGroups) != 1 {
-		t.Fatalf("remove kept %d non-installable third-party groups, want 1", len(staleGroups))
+	if len(staleGroups) != 2 {
+		t.Fatalf("remove kept %d non-installable third-party groups, want 2", len(staleGroups))
 	}
+	foundCCPdx := false
+	knownCodexEvents := codexKnownEventNames()
 	for _, groupEntry := range staleGroups {
 		group, _ := groupEntry.(map[string]any)
 		for _, hookEntry := range toCodexEntrySlice(group["hooks"]) {
 			m, _ := hookEntry.(map[string]any)
 			cmd, _ := m["command"].(string)
-			if isPdxCommandCodex(cmd) {
+			if isPdxCommandCodexKnownEvent(cmd, knownCodexEvents) {
 				t.Fatalf("remove left stale non-installable pdx entry: %#v", hookEntry)
 			}
+			if strings.Contains(cmd, "--agent cc") {
+				foundCCPdx = true
+			}
 		}
+	}
+	if !foundCCPdx {
+		t.Fatal("remove dropped non-codex pdx hook under non-installable key")
 	}
 	absentHooksPath := filepath.Join(dir, "absent-hooks.json")
 	if err := os.WriteFile(absentHooksPath, []byte(`{"hooks":{}}`), 0644); err != nil {

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -371,6 +372,88 @@ func TestCodexInstallHooks_Writes9EventsAfterExpansion(t *testing.T) {
 	}
 }
 
+func TestCodexInstallHooks_EnablesFeatureFlagAndPreservesConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	existing := "model = \"gpt-5\"\n\n[features]\nother = true\ncodex_hooks = false\n"
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := (&Provider{}).InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{`model = "gpt-5"`, "other = true", "codex_hooks = true"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("config.toml missing %q after install:\n%s", want, text)
+		}
+	}
+}
+
+func TestCodexInstallHooks_ParseFailureDoesNotPartiallyWrite(t *testing.T) {
+	t.Run("malformed config leaves hooks unchanged", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		configPath := filepath.Join(home, ".codex", "config.toml")
+		hooksPath := filepath.Join(home, ".codex", "hooks.json")
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		badConfig := []byte("[features\ncodex_hooks = false\n")
+		originalHooks := []byte(`{"hooks":{"SessionStart":[]}}`)
+		if err := os.WriteFile(configPath, badConfig, 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		if err := os.WriteFile(hooksPath, originalHooks, 0644); err != nil {
+			t.Fatalf("write hooks: %v", err)
+		}
+		if err := (&Provider{}).InstallHooks("/usr/local/bin/pdx"); err == nil {
+			t.Fatal("InstallHooks succeeded with malformed config")
+		}
+		gotConfig, _ := os.ReadFile(configPath)
+		gotHooks, _ := os.ReadFile(hooksPath)
+		if string(gotConfig) != string(badConfig) || string(gotHooks) != string(originalHooks) {
+			t.Fatalf("files changed after malformed config; config=%q hooks=%q", gotConfig, gotHooks)
+		}
+	})
+
+	t.Run("malformed hooks leaves config unchanged", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		configPath := filepath.Join(home, ".codex", "config.toml")
+		hooksPath := filepath.Join(home, ".codex", "hooks.json")
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		originalConfig := []byte("model = \"gpt-5\"\n")
+		badHooks := []byte(`{"hooks":`)
+		if err := os.WriteFile(configPath, originalConfig, 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		if err := os.WriteFile(hooksPath, badHooks, 0644); err != nil {
+			t.Fatalf("write hooks: %v", err)
+		}
+		if err := (&Provider{}).InstallHooks("/usr/local/bin/pdx"); err == nil {
+			t.Fatal("InstallHooks succeeded with malformed hooks")
+		}
+		gotConfig, _ := os.ReadFile(configPath)
+		gotHooks, _ := os.ReadFile(hooksPath)
+		if string(gotConfig) != string(originalConfig) || string(gotHooks) != string(badHooks) {
+			t.Fatalf("files changed after malformed hooks; config=%q hooks=%q", gotConfig, gotHooks)
+		}
+	})
+}
+
 func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 	original := codexEventSpecs
 	codexEventSpecs = append(append([]agent.HookEventSpec(nil), codexEventSpecs...),
@@ -403,6 +486,7 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 	if err := mergeCodexHooks(homeHooksPath, "/usr/local/bin/pdx", false); err != nil {
 		t.Fatalf("seed install: %v", err)
 	}
+	writeCodexFeatureFlag(t, home, true)
 	status, err := (&Provider{}).CheckHooks()
 	if err != nil {
 		t.Fatalf("CheckHooks: %v", err)
@@ -499,6 +583,7 @@ func TestCodexCheckHooks_ReportsAll9Events(t *testing.T) {
 	if err := mergeCodexHooks(hooksPath, "/usr/local/bin/pdx", false); err != nil {
 		t.Fatalf("seed install: %v", err)
 	}
+	writeCodexFeatureFlag(t, home, true)
 
 	status, err := (&Provider{}).CheckHooks()
 	if err != nil {
@@ -519,6 +604,68 @@ func TestCodexCheckHooks_ReportsAll9Events(t *testing.T) {
 	}
 	if !status.Installed {
 		t.Errorf("Installed=false after full install, issues=%v", status.Issues)
+	}
+}
+
+func TestCodexCheckHooks_FeatureFlagMissingOrFalseBlocks(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		writeFlag bool
+		value     bool
+	}{
+		{name: "missing"},
+		{name: "false", writeFlag: true, value: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			hooksPath := filepath.Join(home, ".codex", "hooks.json")
+			if err := mergeCodexHooks(hooksPath, "/usr/local/bin/pdx", false); err != nil {
+				t.Fatalf("seed install: %v", err)
+			}
+			if tt.writeFlag {
+				writeCodexFeatureFlag(t, home, tt.value)
+			}
+			status, err := (&Provider{}).CheckHooks()
+			if err != nil {
+				t.Fatalf("CheckHooks: %v", err)
+			}
+			if status.Installed {
+				t.Fatal("Installed=true with codex hooks feature flag disabled")
+			}
+			if !status.Managed {
+				t.Fatal("Managed=false with valid hooks but disabled feature flag")
+			}
+			if !issuesContain(status.Issues, "codex hooks feature flag disabled") {
+				t.Fatalf("issues=%v, want feature flag disabled issue", status.Issues)
+			}
+		})
+	}
+}
+
+func TestCodexCheckHooks_PermissionRequestMissingBlocks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeHooksFile(t, home, map[string]any{
+		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":             []any{pdxGroupEntry("Stop")},
+	})
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Installed {
+		t.Fatal("Installed=true with missing PermissionRequest")
+	}
+	if !issuesContain(status.Issues, "PermissionRequest hook not installed") {
+		t.Fatalf("issues=%v, want missing PermissionRequest issue", status.Issues)
+	}
+	for _, name := range status.UpgradesAvailable {
+		if name == "PermissionRequest" {
+			t.Fatalf("PermissionRequest appeared in UpgradesAvailable: %v", status.UpgradesAvailable)
+		}
 	}
 }
 
@@ -560,6 +707,7 @@ func TestCheckHooks_LegacyDirectEntryReportedUninstalled(t *testing.T) {
 	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
+	writeCodexFeatureFlag(t, dir, true)
 
 	status, err := (&Provider{}).CheckHooks()
 	if err != nil {
@@ -622,6 +770,7 @@ func TestCheckHooks_ThirdPartyLegacyEntryDoesNotTriggerReinstall(t *testing.T) {
 	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
+	writeCodexFeatureFlag(t, dir, true)
 
 	status, err := (&Provider{}).CheckHooks()
 	if err != nil {
@@ -685,6 +834,19 @@ func writeHooksFile(t *testing.T, home string, hooksSect map[string]any) {
 	if err := os.WriteFile(path, data, 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
+	writeCodexFeatureFlag(t, home, true)
+}
+
+func writeCodexFeatureFlag(t *testing.T, home string, enabled bool) {
+	t.Helper()
+	path := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	data := []byte(fmt.Sprintf("[features]\ncodex_hooks = %t\n", enabled))
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 }
 
 // issuesContain reports whether any issue contains the given substring.
@@ -697,16 +859,16 @@ func issuesContain(issues []string, substr string) bool {
 	return false
 }
 
-// CH1 — legacy 3-event user (pre-expansion install): the three required
-// events are valid; the six FutureOnly events have no key in hooks.json.
+// CH1 — current required events are valid; FutureOnly events have no key in hooks.json.
 // allInstalled must remain true and Issues must be empty.
 func TestCheckHooks_LegacyThreeEvent_ReportsInstalled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	writeHooksFile(t, home, map[string]any{
-		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
-		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
-		"Stop":             []any{pdxGroupEntry("Stop")},
+		"SessionStart":      []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit":  []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":              []any{pdxGroupEntry("Stop")},
+		"PermissionRequest": []any{pdxGroupEntry("PermissionRequest")},
 	})
 
 	status, err := (&Provider{}).CheckHooks()
@@ -719,10 +881,7 @@ func TestCheckHooks_LegacyThreeEvent_ReportsInstalled(t *testing.T) {
 	if len(status.Issues) != 0 {
 		t.Fatalf("legacy 3-event user: Issues=%v, want empty", status.Issues)
 	}
-	futureOnly := []string{
-		"SubagentStart", "SubagentStop", "StopFailure",
-		"Notification", "PermissionRequest", "SessionEnd",
-	}
+	futureOnly := []string{"SubagentStart", "SubagentStop", "StopFailure", "Notification", "SessionEnd"}
 	for _, name := range futureOnly {
 		info, ok := status.Events[name]
 		if !ok {
@@ -943,17 +1102,51 @@ func TestCheckHooks_Managed_FalseForOtherAgentPdxEntry(t *testing.T) {
 	}
 }
 
+func TestCodexRemoveHooks_RemovesOwnedRetiredEventKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, _ := json.MarshalIndent(map[string]any{
+		"hooks": map[string]any{
+			"RetiredEvent": []any{pdxGroupEntry("RetiredEvent")},
+		},
+	}, "", "  ")
+	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+	writeCodexFeatureFlag(t, home, true)
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if !status.Managed {
+		t.Fatal("retired codex pdx entry: Managed=false, want true")
+	}
+	if err := (&Provider{}).RemoveHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("RemoveHooks: %v", err)
+	}
+	hooks := hooksSection(t, readHooksFile(t, hooksPath))
+	if _, ok := hooks["RetiredEvent"]; ok {
+		t.Fatal("RemoveHooks left retired owned Codex hook key")
+	}
+}
+
 // CH12 — UpgradesAvailable lists FutureOnly events absent from hooks.json
-// when the overall install is otherwise valid (legacy 3-event user).
-// Finding #4: UI must be able to surface "6 new events available" even
+// when the overall install is otherwise valid.
+// Finding #4: UI must be able to surface new events available even
 // though Installed=true.
 func TestCheckHooks_UpgradesAvailable_PopulatedForLegacyCodex(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	writeHooksFile(t, home, map[string]any{
-		"SessionStart":     []any{pdxGroupEntry("SessionStart")},
-		"UserPromptSubmit": []any{pdxGroupEntry("UserPromptSubmit")},
-		"Stop":             []any{pdxGroupEntry("Stop")},
+		"SessionStart":      []any{pdxGroupEntry("SessionStart")},
+		"UserPromptSubmit":  []any{pdxGroupEntry("UserPromptSubmit")},
+		"Stop":              []any{pdxGroupEntry("Stop")},
+		"PermissionRequest": []any{pdxGroupEntry("PermissionRequest")},
 	})
 	status, err := (&Provider{}).CheckHooks()
 	if err != nil {
@@ -963,12 +1156,11 @@ func TestCheckHooks_UpgradesAvailable_PopulatedForLegacyCodex(t *testing.T) {
 		t.Fatalf("legacy 3-event: Installed=false, Issues=%v", status.Issues)
 	}
 	want := map[string]bool{
-		"SubagentStart":     true,
-		"SubagentStop":      true,
-		"StopFailure":       true,
-		"Notification":      true,
-		"PermissionRequest": true,
-		"SessionEnd":        true,
+		"SubagentStart": true,
+		"SubagentStop":  true,
+		"StopFailure":   true,
+		"Notification":  true,
+		"SessionEnd":    true,
 	}
 	if len(status.UpgradesAvailable) != len(want) {
 		t.Fatalf("UpgradesAvailable=%v, want %d entries", status.UpgradesAvailable, len(want))
@@ -1015,13 +1207,13 @@ func TestCheckHooks_EventInfoCarriesFutureOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CheckHooks: %v", err)
 	}
-	requiredFalse := []string{"SessionStart", "UserPromptSubmit", "Stop"}
+	requiredFalse := []string{"SessionStart", "UserPromptSubmit", "Stop", "PermissionRequest"}
 	for _, name := range requiredFalse {
 		if status.Events[name].FutureOnly {
 			t.Errorf("event %q FutureOnly=true, want false", name)
 		}
 	}
-	futureOnly := []string{"SubagentStart", "SubagentStop", "StopFailure", "Notification", "PermissionRequest", "SessionEnd"}
+	futureOnly := []string{"SubagentStart", "SubagentStop", "StopFailure", "Notification", "SessionEnd"}
 	for _, name := range futureOnly {
 		if !status.Events[name].FutureOnly {
 			t.Errorf("event %q FutureOnly=false, want true", name)

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/wake/purdex/internal/agent"
 )
 
 // ---- filterOutPdxCodex ----
@@ -359,6 +361,74 @@ func TestCodexInstallHooks_Writes9EventsAfterExpansion(t *testing.T) {
 		groups := codexMatcherGroups(entries)
 		if len(groups) == 0 {
 			t.Errorf("event %q has no matcher groups", name)
+		}
+	}
+}
+
+func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
+	original := codexEventSpecs
+	codexEventSpecs = append(append([]agent.HookEventSpec(nil), codexEventSpecs...),
+		agent.HookEventSpec{Name: "IgnoredSynthetic", Handling: agent.HookHandlingIgnored, Description: "Ignored synthetic hook"},
+		agent.HookEventSpec{Name: "UnsupportedSynthetic", Handling: agent.HookHandlingUnsupported, Description: "Unsupported synthetic hook"},
+	)
+	t.Cleanup(func() { codexEventSpecs = original })
+
+	for _, name := range codexEventNames() {
+		if name == "IgnoredSynthetic" || name == "UnsupportedSynthetic" {
+			t.Fatalf("codexEventNames included non-installable spec %q", name)
+		}
+	}
+
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+	if err := mergeCodexHooks(hooksPath, "/usr/local/bin/pdx", false); err != nil {
+		t.Fatalf("mergeCodexHooks: %v", err)
+	}
+	hooks := hooksSection(t, readHooksFile(t, hooksPath))
+	for _, name := range []string{"IgnoredSynthetic", "UnsupportedSynthetic"} {
+		if _, ok := hooks[name]; ok {
+			t.Errorf("mergeCodexHooks wrote non-installable event %q", name)
+		}
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	homeHooksPath := filepath.Join(home, ".codex", "hooks.json")
+	if err := mergeCodexHooks(homeHooksPath, "/usr/local/bin/pdx", false); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	for _, name := range []string{"IgnoredSynthetic", "UnsupportedSynthetic"} {
+		if _, ok := status.Events[name]; ok {
+			t.Errorf("CheckHooks.Events included non-installable event %q", name)
+		}
+	}
+
+	staleHooksPath := filepath.Join(dir, "stale-hooks.json")
+	stale := map[string]any{
+		"hooks": map[string]any{
+			"IgnoredSynthetic": []any{pdxGroupEntry("IgnoredSynthetic")},
+		},
+	}
+	staleData, _ := json.MarshalIndent(stale, "", "  ")
+	if err := os.WriteFile(staleHooksPath, staleData, 0644); err != nil {
+		t.Fatalf("write stale hooks: %v", err)
+	}
+	if err := mergeCodexHooks(staleHooksPath, "/usr/local/bin/pdx", true); err != nil {
+		t.Fatalf("remove stale non-installable hook: %v", err)
+	}
+	staleHooks := hooksSection(t, readHooksFile(t, staleHooksPath))
+	for _, groupEntry := range codexMatcherGroups(staleHooks["IgnoredSynthetic"]) {
+		group, _ := groupEntry.(map[string]any)
+		for _, hookEntry := range toCodexEntrySlice(group["hooks"]) {
+			m, _ := hookEntry.(map[string]any)
+			cmd, _ := m["command"].(string)
+			if isPdxCommandCodex(cmd) {
+				t.Fatalf("remove left stale non-installable pdx entry: %#v", hookEntry)
+			}
 		}
 	}
 }

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -406,11 +406,33 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 			t.Errorf("CheckHooks.Events included non-installable event %q", name)
 		}
 	}
+	if !status.Installed || !status.Managed || len(status.Issues) != 0 {
+		t.Fatalf("clean install with non-installable specs status=%+v, want installed managed with no issues", status)
+	}
+
+	installedFile := readHooksFile(t, homeHooksPath)
+	installedHooks := hooksSection(t, installedFile)
+	installedHooks["IgnoredSynthetic"] = []any{pdxGroupEntry("IgnoredSynthetic")}
+	installedFile["hooks"] = installedHooks
+	installedData, _ := json.MarshalIndent(installedFile, "", "  ")
+	if err := os.WriteFile(homeHooksPath, installedData, 0644); err != nil {
+		t.Fatalf("write stale installed hooks: %v", err)
+	}
+	status, err = (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks stale non-installable: %v", err)
+	}
+	if !status.Installed || !status.Managed || len(status.Issues) != 0 {
+		t.Fatalf("stale non-installable hook status=%+v, want installed managed with no issues", status)
+	}
 
 	staleHooksPath := filepath.Join(dir, "stale-hooks.json")
 	stale := map[string]any{
 		"hooks": map[string]any{
-			"IgnoredSynthetic": []any{pdxGroupEntry("IgnoredSynthetic")},
+			"IgnoredSynthetic": []any{
+				pdxGroupEntry("IgnoredSynthetic"),
+				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "/usr/bin/notify ignored", "timeout": 5}}},
+			},
 		},
 	}
 	staleData, _ := json.MarshalIndent(stale, "", "  ")
@@ -421,7 +443,11 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 		t.Fatalf("remove stale non-installable hook: %v", err)
 	}
 	staleHooks := hooksSection(t, readHooksFile(t, staleHooksPath))
-	for _, groupEntry := range codexMatcherGroups(staleHooks["IgnoredSynthetic"]) {
+	staleGroups := codexMatcherGroups(staleHooks["IgnoredSynthetic"])
+	if len(staleGroups) != 1 {
+		t.Fatalf("remove kept %d non-installable third-party groups, want 1", len(staleGroups))
+	}
+	for _, groupEntry := range staleGroups {
 		group, _ := groupEntry.(map[string]any)
 		for _, hookEntry := range toCodexEntrySlice(group["hooks"]) {
 			m, _ := hookEntry.(map[string]any)
@@ -430,6 +456,17 @@ func TestCodexInstallHooks_ExcludesNonInstallableSpecs(t *testing.T) {
 				t.Fatalf("remove left stale non-installable pdx entry: %#v", hookEntry)
 			}
 		}
+	}
+	absentHooksPath := filepath.Join(dir, "absent-hooks.json")
+	if err := os.WriteFile(absentHooksPath, []byte(`{"hooks":{}}`), 0644); err != nil {
+		t.Fatalf("write absent hooks: %v", err)
+	}
+	if err := mergeCodexHooks(absentHooksPath, "/usr/local/bin/pdx", true); err != nil {
+		t.Fatalf("remove absent non-installable hook: %v", err)
+	}
+	absentHooks := hooksSection(t, readHooksFile(t, absentHooksPath))
+	if _, ok := absentHooks["IgnoredSynthetic"]; ok {
+		t.Fatal("remove created absent non-installable key IgnoredSynthetic")
 	}
 }
 

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -407,6 +407,24 @@ func TestCodexInstallHooks_EnablesFeatureFlagAndPreservesConfig(t *testing.T) {
 	}
 }
 
+func TestCodexInstallHooks_NewConfigUsesOwnerOnlyMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(home, ".codex", "config.toml")
+
+	if err := (&Provider{}).InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("new config.toml mode=%#o, want 0600", got)
+	}
+}
+
 func TestCodexInstallHooks_ParseFailureDoesNotPartiallyWrite(t *testing.T) {
 	t.Run("malformed config leaves hooks unchanged", func(t *testing.T) {
 		home := t.TempDir()
@@ -1189,6 +1207,52 @@ func TestCodexRemoveHooks_PreservesUnknownRetiredEventKey(t *testing.T) {
 	}
 }
 
+func TestCodexRemoveHooks_RemovesOwnedEventUnderUnknownKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, _ := json.MarshalIndent(map[string]any{
+		"hooks": map[string]any{
+			"UnknownHookKey": []any{
+				pdxGroupEntry("SessionStart"),
+				pdxGroupEntry("Bogus"),
+			},
+		},
+	}, "", "  ")
+	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+
+	if err := (&Provider{}).RemoveHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("RemoveHooks: %v", err)
+	}
+	hooks := hooksSection(t, readHooksFile(t, hooksPath))
+	groups := codexMatcherGroups(hooks["UnknownHookKey"])
+	if len(groups) != 1 {
+		t.Fatalf("RemoveHooks kept %d groups under unknown hook key, want 1 unknown token", len(groups))
+	}
+	if findPdxCommandInCodexForEvent(groups, "SessionStart") != "" {
+		t.Fatal("RemoveHooks left owned Codex event under unknown hook key")
+	}
+	foundUnknown := false
+	for _, groupEntry := range groups {
+		group, _ := groupEntry.(map[string]any)
+		for _, hookEntry := range toCodexEntrySlice(group["hooks"]) {
+			m, _ := hookEntry.(map[string]any)
+			cmd, _ := m["command"].(string)
+			if strings.Contains(cmd, "--agent codex Bogus") {
+				foundUnknown = true
+			}
+		}
+	}
+	if !foundUnknown {
+		t.Fatal("RemoveHooks dropped unknown Codex event token under unknown hook key")
+	}
+}
+
 // CH12 — UpgradesAvailable lists FutureOnly events absent from hooks.json
 // when the overall install is otherwise valid.
 // Finding #4: UI must be able to surface new events available even
@@ -1383,6 +1447,44 @@ func TestIsPdxCommandCodexForEvent(t *testing.T) {
 		if isPdxCommandCodexForEvent(tc.cmd, tc.event) {
 			t.Errorf("expected invalid for %q / event=%s (%s)", tc.cmd, tc.event, tc.reason)
 		}
+	}
+}
+
+func TestCodexRemoveHooks_PreservesWrapperLikePdxCommand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, _ := json.MarshalIndent(map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{"hooks": []any{map[string]any{"type": "command", "command": `pdx exec hook --agent codex SessionStart`, "timeout": 5}}},
+			},
+		},
+	}, "", "  ")
+	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+
+	status, err := (&Provider{}).CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	if status.Managed {
+		t.Fatal("wrapper-like pdx command: Managed=true, want false")
+	}
+	if err := (&Provider{}).RemoveHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("RemoveHooks: %v", err)
+	}
+	hooks := hooksSection(t, readHooksFile(t, hooksPath))
+	groups := codexMatcherGroups(hooks["SessionStart"])
+	if len(groups) != 1 {
+		t.Fatalf("RemoveHooks kept %d groups, want wrapper-like command preserved", len(groups))
+	}
+	if findPdxCommandInCodexForEvent(groups, "SessionStart") != "" {
+		t.Fatal("wrapper-like pdx command became valid per-event hook command")
 	}
 }
 

--- a/internal/agent/drift_test.go
+++ b/internal/agent/drift_test.go
@@ -219,8 +219,11 @@ func TestDriftFixtureCoversAllEvents(t *testing.T) {
 			covered[fx.eventName] = true
 		}
 		for _, spec := range installer.Events() {
+			if !agent.IsInstallableHookSpec(spec) {
+				continue
+			}
 			if !covered[spec.Name] {
-				t.Errorf("provider %q: Events() declares %q but providerFixtures has no entry (add a fixture or remove from Events())",
+				t.Errorf("provider %q: installable Events() declares %q but providerFixtures has no entry (add a fixture or make the spec non-installable)",
 					row.AgentType, spec.Name)
 			}
 		}
@@ -284,6 +287,9 @@ func TestDriftPerEventEmitsStatusMatch(t *testing.T) {
 				fixturesByEvent[fx.eventName] = append(fixturesByEvent[fx.eventName], fx)
 			}
 			for _, spec := range installer.Events() {
+				if !agent.IsInstallableHookSpec(spec) {
+					continue
+				}
 				spec := spec
 				t.Run(spec.Name, func(t *testing.T) {
 					fxs, ok := fixturesByEvent[spec.Name]

--- a/internal/agent/opencode/events.go
+++ b/internal/agent/opencode/events.go
@@ -64,6 +64,7 @@ func (p *Provider) Events() []agent.HookEventSpec {
 			EmitsStatus: append([]agent.Status(nil), spec.EmitsStatus...),
 			Description: spec.Description,
 			FutureOnly:  spec.FutureOnly,
+			Handling:    spec.Handling,
 		}
 		if out[i].EmitsStatus == nil {
 			out[i].EmitsStatus = []agent.Status{}
@@ -72,7 +73,7 @@ func (p *Provider) Events() []agent.HookEventSpec {
 	return out
 }
 
-// eventNames returns the ordered event Name list for CheckHooks iteration.
+// eventNames returns the ordered installable event Name list for CheckHooks iteration.
 func (p *Provider) eventNames() []string {
 	return opencodeEventNames()
 }
@@ -83,6 +84,9 @@ func (p *Provider) eventNames() []string {
 func opencodeEventNames() []string {
 	out := make([]string, 0, len(opencodeEventSpecs))
 	for _, spec := range opencodeEventSpecs {
+		if !agent.IsInstallableHookSpec(spec) {
+			continue
+		}
 		out = append(out, spec.Name)
 	}
 	return out

--- a/internal/agent/opencode/hooks.go
+++ b/internal/agent/opencode/hooks.go
@@ -94,7 +94,13 @@ func (p *Provider) CheckHooks() (agent.HookStatus, error) {
 	// broken switch/case, tampered pdxPath literal) collapses every
 	// declared event to Installed=false — "managed body drifted,
 	// reinstall" matches the plugin's all-or-nothing semantics.
-	specs := p.Events()
+	allSpecs := p.Events()
+	specs := make([]agent.HookEventSpec, 0, len(allSpecs))
+	for _, spec := range allSpecs {
+		if agent.IsInstallableHookSpec(spec) {
+			specs = append(specs, spec)
+		}
+	}
 	trustedPath, resolved := resolveCanonicalPdxPath()
 	events := make(map[string]agent.HookEventInfo, len(specs))
 	if !resolved {

--- a/internal/agent/opencode/hooks_test.go
+++ b/internal/agent/opencode/hooks_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/agent/opencode"
 )
 
@@ -92,12 +93,12 @@ func TestOpenCodeCheckHooks_ReportsAll8EventsFromEventsList(t *testing.T) {
 		t.Fatalf("CheckHooks: %v", err)
 	}
 
-	events := p.Events()
+	events := installableOpenCodeEvents(p.Events())
 	if len(events) == 0 {
 		t.Fatal("opencode Events() returned empty; CheckHooks iteration would be vacuous")
 	}
 	if len(status.Events) != len(events) {
-		t.Errorf("status.Events len=%d, want %d (one per Events())", len(status.Events), len(events))
+		t.Errorf("status.Events len=%d, want %d (one per installable Events())", len(status.Events), len(events))
 	}
 	for _, e := range events {
 		info, ok := status.Events[e.Name]
@@ -109,6 +110,16 @@ func TestOpenCodeCheckHooks_ReportsAll8EventsFromEventsList(t *testing.T) {
 			t.Errorf("event %q: Installed=false after fresh install", e.Name)
 		}
 	}
+}
+
+func installableOpenCodeEvents(events []agent.HookEventSpec) []agent.HookEventSpec {
+	out := make([]agent.HookEventSpec, 0, len(events))
+	for _, event := range events {
+		if agent.IsInstallableHookSpec(event) {
+			out = append(out, event)
+		}
+	}
+	return out
 }
 
 // ---- fix-plan §2.4 byte-exact CheckHooks tests (OH1-OH5) ----
@@ -142,7 +153,7 @@ func TestCheckHooks_ValidPlugin_AllInstalled(t *testing.T) {
 	if len(status.Issues) != 0 {
 		t.Fatalf("valid plugin: Issues=%v, want empty", status.Issues)
 	}
-	for _, spec := range p.Events() {
+	for _, spec := range installableOpenCodeEvents(p.Events()) {
 		if info, ok := status.Events[spec.Name]; !ok {
 			t.Errorf("status.Events missing %q", spec.Name)
 		} else if !info.Installed {
@@ -188,7 +199,7 @@ func TestCheckHooks_HandEditedPlugin_Unmanaged(t *testing.T) {
 	if !strings.Contains(joined, "plugin body differs from managed template") {
 		t.Fatalf("hand-edited plugin: issues=%v, want 'plugin body differs from managed template'", status.Issues)
 	}
-	for _, spec := range p.Events() {
+	for _, spec := range installableOpenCodeEvents(p.Events()) {
 		if info, ok := status.Events[spec.Name]; ok && info.Installed {
 			t.Errorf("event %q Installed=true after byte-mismatch, want false", spec.Name)
 		}

--- a/internal/agent/opencode/plugin_template.go
+++ b/internal/agent/opencode/plugin_template.go
@@ -257,6 +257,9 @@ func validateSpecsCoverEmitted(body string, specs []agent.HookEventSpec) error {
 	}
 	declared := make(map[string]bool, len(specs))
 	for _, spec := range specs {
+		if !agent.IsInstallableHookSpec(spec) {
+			continue
+		}
 		declared[spec.Name] = true
 	}
 	var missingInSpec []string

--- a/internal/agent/opencode/plugin_template_test.go
+++ b/internal/agent/opencode/plugin_template_test.go
@@ -1,6 +1,8 @@
 package opencode
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -161,6 +163,54 @@ func TestValidateSpecsCoverEmitted_SpecNotInEmit(t *testing.T) {
 	extended = append(extended, agent.HookEventSpec{Name: "Phantom"})
 	if err := validateSpecsCoverEmitted(body, extended); err == nil {
 		t.Fatal("expected error for spec-not-in-emit; got nil")
+	}
+}
+
+func TestValidateSpecsCoverEmitted_IgnoresNonInstallableSpecs(t *testing.T) {
+	body := renderManagedPlugin("/fake/pdx")
+	extended := append([]agent.HookEventSpec(nil), opencodeEventSpecs...)
+	extended = append(extended,
+		agent.HookEventSpec{Name: "IgnoredSynthetic", Handling: agent.HookHandlingIgnored, Description: "Ignored synthetic hook"},
+		agent.HookEventSpec{Name: "UnsupportedSynthetic", Handling: agent.HookHandlingUnsupported, Description: "Unsupported synthetic hook"},
+	)
+	if err := validateSpecsCoverEmitted(body, extended); err != nil {
+		t.Fatalf("validateSpecsCoverEmitted should ignore non-installable specs; got %v", err)
+	}
+}
+
+func TestOpenCodeCheckHooks_ExcludesNonInstallableSpecs(t *testing.T) {
+	original := opencodeEventSpecs
+	opencodeEventSpecs = append(append([]agent.HookEventSpec(nil), opencodeEventSpecs...),
+		agent.HookEventSpec{Name: "IgnoredSynthetic", Handling: agent.HookHandlingIgnored, Description: "Ignored synthetic hook"},
+		agent.HookEventSpec{Name: "UnsupportedSynthetic", Handling: agent.HookHandlingUnsupported, Description: "Unsupported synthetic hook"},
+	)
+	t.Cleanup(func() { opencodeEventSpecs = original })
+
+	for _, name := range opencodeEventNames() {
+		if name == "IgnoredSynthetic" || name == "UnsupportedSynthetic" {
+			t.Fatalf("opencodeEventNames included non-installable spec %q", name)
+		}
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	SetResolveCanonicalPdxPathForTesting(t, func() (string, bool) { return "/usr/local/bin/pdx", true })
+	p := NewProvider()
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks: %v", err)
+	}
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "pdx-agent-hooks.js")
+	if _, err := os.Stat(pluginPath); err != nil {
+		t.Fatalf("expected managed plugin at %s: %v", pluginPath, err)
+	}
+	for _, name := range []string{"IgnoredSynthetic", "UnsupportedSynthetic"} {
+		if _, ok := status.Events[name]; ok {
+			t.Errorf("CheckHooks.Events included non-installable event %q", name)
+		}
 	}
 }
 

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -33,12 +33,12 @@ type HookEvent struct {
 // HookInstaller can install/remove/check hook configurations for a specific agent.
 //
 // Events() is the single source of truth (SSoT) for the provider's classified
-// upstream hook event catalog. It supersedes any package-local *HookEvents
-// slice; do not introduce a parallel string list. Installer iteration,
-// CheckHooks reporting, and template parity must derive their installable
-// subset with IsInstallableHookSpec rather than assuming every catalog entry is
-// wired. SupportedStatuses derivation still reads the same declaration. Any
-// new HookInstaller implementation is required to implement Events().
+// hook event catalog. It supersedes any package-local *HookEvents slice; do not
+// introduce a parallel string list. Installer iteration, CheckHooks reporting,
+// and template parity must derive their installable subset with
+// IsInstallableHookSpec rather than assuming every catalog entry is wired.
+// SupportedStatuses derivation still reads the same declaration. Any new
+// HookInstaller implementation is required to implement Events().
 type HookInstaller interface {
 	InstallHooks(pdxPath string) error
 	RemoveHooks(pdxPath string) error

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -32,11 +32,13 @@ type HookEvent struct {
 
 // HookInstaller can install/remove/check hook configurations for a specific agent.
 //
-// Events() is the single source of truth (SSoT) for the hook event catalog:
-// installer iteration, CheckHooks reporting, SupportedStatuses derivation, and
-// future Inspector UI all read from the same declaration. It supersedes any
-// package-local *HookEvents slice; do not introduce a parallel string list.
-// Any new HookInstaller implementation is required to implement Events().
+// Events() is the single source of truth (SSoT) for the provider's classified
+// upstream hook event catalog. It supersedes any package-local *HookEvents
+// slice; do not introduce a parallel string list. Installer iteration,
+// CheckHooks reporting, and template parity must derive their installable
+// subset with IsInstallableHookSpec rather than assuming every catalog entry is
+// wired. SupportedStatuses derivation still reads the same declaration. Any
+// new HookInstaller implementation is required to implement Events().
 type HookInstaller interface {
 	InstallHooks(pdxPath string) error
 	RemoveHooks(pdxPath string) error
@@ -44,10 +46,10 @@ type HookInstaller interface {
 	Events() []HookEventSpec
 }
 
-// HookEventSpec declares one hook event the installer wires, the Status set
-// DeriveStatus may emit from that event, and a short human-readable blurb for
-// the Inspector UI. It is the build-time declaration contract; runtime hook
-// handling stays per-agent (policy dispersal, plumbing shared).
+// HookEventSpec declares one upstream hook event, the Status set DeriveStatus
+// may emit from that event when it is installable, and a short human-readable
+// blurb for the Inspector UI. It is the build-time declaration contract;
+// runtime hook handling stays per-agent (policy dispersal, plumbing shared).
 //
 // Fields:
 //   - Name: matches the hook JSON event_name / pdx hook CLI subcommand.
@@ -68,11 +70,45 @@ type HookInstaller interface {
 //     unions every spec's EmitsStatus regardless of FutureOnly — proxy paths
 //     and future CLI versions may legitimately emit the event. Default false
 //     means "installer-required; missing is an issue". See fix plan §1.1.
+//   - Handling: classifies whether this catalog entry is installed/parsed.
+//     Empty values preserve the legacy defaults via EffectiveHookHandling:
+//     specs with EmitsStatus default to status, and empty-status specs default
+//     to detail. Newly added non-installable upstream entries must set this
+//     explicitly to ignored or unsupported.
+type HookHandling string
+
+const (
+	HookHandlingStatus      HookHandling = "status"
+	HookHandlingDetail      HookHandling = "detail"
+	HookHandlingIgnored     HookHandling = "ignored"
+	HookHandlingUnsupported HookHandling = "unsupported"
+)
+
 type HookEventSpec struct {
 	Name        string
 	EmitsStatus []Status
 	Description string
 	FutureOnly  bool
+	Handling    HookHandling
+}
+
+func EffectiveHookHandling(spec HookEventSpec) HookHandling {
+	if spec.Handling != "" {
+		return spec.Handling
+	}
+	if len(spec.EmitsStatus) > 0 {
+		return HookHandlingStatus
+	}
+	return HookHandlingDetail
+}
+
+func IsInstallableHookSpec(spec HookEventSpec) bool {
+	switch EffectiveHookHandling(spec) {
+	case HookHandlingStatus, HookHandlingDetail:
+		return true
+	default:
+		return false
+	}
 }
 
 // HookStatus reports the installation state of hooks for an agent.

--- a/internal/agent/supported_statuses_test.go
+++ b/internal/agent/supported_statuses_test.go
@@ -73,6 +73,71 @@ func TestHookEventSpecFutureOnlyDefaultsToFalse(t *testing.T) {
 	}
 }
 
+func TestEffectiveHookHandlingDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		spec agent.HookEventSpec
+		want agent.HookHandling
+	}{
+		{
+			name: "explicit status wins",
+			spec: agent.HookEventSpec{Handling: agent.HookHandlingStatus},
+			want: agent.HookHandlingStatus,
+		},
+		{
+			name: "explicit detail wins",
+			spec: agent.HookEventSpec{Handling: agent.HookHandlingDetail, EmitsStatus: []agent.Status{agent.StatusRunning}},
+			want: agent.HookHandlingDetail,
+		},
+		{
+			name: "empty handling with status defaults status",
+			spec: agent.HookEventSpec{EmitsStatus: []agent.Status{agent.StatusRunning}},
+			want: agent.HookHandlingStatus,
+		},
+		{
+			name: "empty handling with empty statuses defaults detail",
+			spec: agent.HookEventSpec{EmitsStatus: []agent.Status{}},
+			want: agent.HookHandlingDetail,
+		},
+		{
+			name: "empty handling with nil statuses defaults detail",
+			spec: agent.HookEventSpec{},
+			want: agent.HookHandlingDetail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agent.EffectiveHookHandling(tt.spec); got != tt.want {
+				t.Fatalf("EffectiveHookHandling(%+v) = %q, want %q", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInstallableHookSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		spec agent.HookEventSpec
+		want bool
+	}{
+		{name: "explicit status", spec: agent.HookEventSpec{Handling: agent.HookHandlingStatus}, want: true},
+		{name: "explicit detail", spec: agent.HookEventSpec{Handling: agent.HookHandlingDetail}, want: true},
+		{name: "default status", spec: agent.HookEventSpec{EmitsStatus: []agent.Status{agent.StatusRunning}}, want: true},
+		{name: "default detail", spec: agent.HookEventSpec{}, want: true},
+		{name: "ignored", spec: agent.HookEventSpec{Handling: agent.HookHandlingIgnored}, want: false},
+		{name: "unsupported", spec: agent.HookEventSpec{Handling: agent.HookHandlingUnsupported}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agent.IsInstallableHookSpec(tt.spec); got != tt.want {
+				t.Fatalf("IsInstallableHookSpec(%+v) = %v, want %v", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestDeriveSupportedStatusesIgnoresFutureOnlyBit is the fix-plan §2.1 F2
 // contract lock: DeriveSupportedStatuses must NOT filter out FutureOnly
 // specs. FutureOnly is an installer/checker-facet flag only; the


### PR DESCRIPTION
## Summary
- Add HookHandling helpers and scope hook install/check/template completeness to installable events.
- Fix Codex hook activation correctness: require features.codex_hooks, update current PermissionRequest handling, and preserve config permissions.
- Harden cc/Codex cleanup ownership so remove scans safely, preserves unknown/user-owned shapes, and rejects unsupported install shapes before writing.

## Verification
- go test ./internal/agent/cc ./internal/agent/codex -count=1
- go test ./internal/agent/... -count=1
- Codex standard review: no findings
- Codex focused adversarial review: approve / no material findings

## Scope Notes
- PR 1 includes hook foundation plus Codex current-runtime correctness to avoid false-green installed state.
- Upstream full catalog classification and OpenCode mapping refresh remain deferred to follow-up PRs.