### PR TITLE
feat(agent): Phase 3.5b — sweep canonicalize defense-in-depth

### DIFF
--- a/docs/specs/2026-04-26-lights-rebuild-phase-3-5b-plan.md
+++ b/docs/specs/2026-04-26-lights-rebuild-phase-3-5b-plan.md
@@ -1,0 +1,406 @@
+# Lights Rebuild — Phase 3.5b Plan v1
+
+**Status**: Draft, pending codex review
+**Scope**: Sweep canonicalize defense-in-depth layer
+**Base**: `main` @ alpha.226 (`78ae7273`)
+**Branch**: `worktree-lights-phase-3-5b`
+**Predecessor**: PR-3.5a (#644) — see `2026-04-25-lights-rebuild-phase-3-5-plan.md` v12
+
+---
+
+## 0. 來龍去脈
+
+PR-3.5a 已在 alpha.226 落地 cold-start race fix + projection dedup + SessionEnd cleanup + sweep `pruneDeadProxyRefs`。User-visible correctness 已保證；DB-level partial state 由 `pruneDeadProxyRefs` 在 2s 內 detach 死 ref。
+
+但 PR-3.5a 沒處理一種 partial state：**standalone child frame 未被 fold 進 ancestor**。發生情境：
+
+1. Hot-path `reconcileCreatedFrameAsProxy` 跑了 `attachProxyRefWithRetry` → 成功（parent 已含 proxy ref），但接著 `DeleteIfUnchanged(child)` 失敗（concurrent refresh 撞 LastSeenAt baseline）→ 留下 child standalone frame
+2. Hot-path `canonicalizeDescendantsAfterUpsert` 跑時 child 的 PPID 鏈 readProcessInfoFn transient error → skip → child 留 standalone
+3. SessionStart 進 existing-frame path（v12 §2.2.2），這條路徑**不**對自己跑 self-as-descendant reconcile（避免 reset 衝突），standalone descendant 留下不收
+
+projection dedup 在這些情境**已經**可以 hide 給 SPA 看（PR-3.5a §2.4）— 用戶層無感知。但 DB 層 standalone frame 持續存在直到：
+- child 自己 SessionEnd → frame 被 delete
+- child PID 死 → sweep `pid_dead` clear
+- 1h idle timeout → sweep `idle_timeout` clear
+- 直到此之前，DB 真實 row 數比 user-visible 多 → expvar 觀察 `partial_canonicalization_created` 計數會持續累加
+
+PR-3.5b = 補一個 sweep pass 在 2s 內把這種 standalone child frame fold 進 ancestor。
+
+**Defense-in-depth**：user-visible correctness 已由 PR-3.5a 保證；3.5b 是 DB-level eventual consistency，讓 partial 不在 DB 層長期殘留。
+
+---
+
+## 1. Scope
+
+### In scope
+
+- `internal/module/agent/sweep.go`：
+  - `canonicalizePane(paneID, broadcastTs)` — 新 func，掃 pane 的 standalone live frame，找到 cross-type live identity-verified ancestor，attach proxy ref + DeleteIfUnchanged 自身 standalone row
+  - `findCanonicalAncestor(candidate, framesByPID)` — 新 helper，PPID 鏈走 `proxyMaxDepth` 找 cross-type ancestor frame
+  - `sweepOnce` 第三 pass：在現有 `pruneDeadProxyRefs` 之前加 `canonicalizePane` call（順序：canonicalize → prune，讓新 attached ref 在同 tick 可被 prune 驗證 — 雖然剛 attach 的識別不會觸發 prune，但邏輯上 canonicalize 先建立的 ref 是 hot-path 模擬，由 prune 守衛）
+- 對應 metric：`MetricSweepCanonicalized`（已宣告於 `internal/agent/metrics.go:35`，目前無 caller，3.5b 接上）
+- 對應 broadcast：成功 attach + delete 後 emit `sweep:proxy_canonicalized` hook 廣播，讓 SPA + `m.subagents` / `m.currentStatus` 同步（pattern 仿 `pruneDeadProxyRefs` 的 `broadcastProxyPruned`）
+- 測試：IT10 + 補擴展矩陣（見 §3）
+
+### Out of scope
+
+- ❌ 改 `pruneDeadProxyRefs`（PR-3.5a 已 ship-ready）
+- ❌ 改 hot-path `reconcileCreatedFrameAsProxy` / `canonicalizeDescendantsAfterUpsert` / projection dedup（PR-3.5a 範圍）
+- ❌ 新 store API（沿用既有 `ListByPane` / `DeleteIfUnchanged` / `attachProxyRefWithRetry`）
+- ❌ 新 SubagentRef field
+- ❌ 新 trace decision reason
+- ❌ Phase 4 probe 補強
+
+---
+
+## 2. 設計
+
+### 2.1 sweepOnce wire site
+
+現有 `sweepOnce`（sweep.go:50-128）已在最後做 `pruneDeadProxyRefs` 的 per-pane loop。改成：
+
+```go
+panes := uniquePaneIDs(survivors)
+broadcastTs := nowFn().UnixNano()
+for _, paneID := range panes {
+    m.canonicalizePane(paneID, broadcastTs)   // PR-3.5b 新加
+    m.pruneDeadProxyRefs(paneID, broadcastTs) // PR-3.5a 既有
+}
+```
+
+順序 rationale：
+
+- canonicalize 先 → 建立合法 proxy ref + 刪 standalone child
+- prune 後 → 對同 pane 的所有 ref 跑 dead/reused 檢查；剛 attach 的 ref 因為 source live + identity-verified 會被 prune 保留（identity gate 一致）
+- 反過來（prune 先 / canonicalize 後）也可（兩 pass 各自 identity-gated 不衝突），但 canonicalize-先序更直覺：先把 partial 修成 canonical，再驗 canonical 健康
+
+### 2.2 canonicalizePane
+
+```go
+// canonicalizePane folds standalone live cross-type child frames into
+// their canonical ancestor proxy ref within the same pane. Defense-in-
+// depth backstop for PR-3.5a hot-path canonicalization paths that left
+// a partial state (DeleteIfUnchanged failure / readProcessInfoFn
+// transient error / existing-frame SessionStart path that does not run
+// self-as-descendant reconcile).
+//
+// User-visible correctness is already guaranteed by projection dedup
+// (PR-3.5a §2.4) — this pass closes the DB-level eventual consistency
+// loop in ≤ 2s instead of waiting for the child's own SessionEnd /
+// pid_dead / 1h idle timeout.
+//
+// Single-direction rule (matches hot path): descendant becomes proxy of
+// ancestor; ancestor is never reverted to descendant. Identity gate
+// applied to BOTH candidate and ancestor — stale (PID-reused) frames
+// never participate, leaving them for pid_reused cleanup elsewhere.
+//
+// Best-effort: any storage error / failed gate / failed Upsert / failed
+// DeleteIfUnchanged makes this candidate skip; next sweep tick (2s)
+// retries. No rollback on partial.
+func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
+    if m.frames == nil {
+        return
+    }
+    frames, err := m.frames.ListByPane(paneID)
+    if err != nil {
+        return
+    }
+    framesByPID := make(map[int]store.Frame, len(frames))
+    for _, frame := range frames {
+        framesByPID[frame.PID] = frame
+    }
+    canonicalizedAny := false
+    var anyAncestor store.Frame
+    for _, candidate := range frames {
+        // Candidate identity gate — stale (dead PID / PID-reuse) frames
+        // skip canonicalize; pid_dead / pid_reused passes handle them.
+        if !isPidAliveFn(candidate.PID) {
+            continue
+        }
+        actualStart, sterr := processStartTimeFn(candidate.PID)
+        if sterr != nil || actualStart != candidate.ProcessStartTime {
+            continue
+        }
+        ancestor, found := m.findCanonicalAncestor(candidate, framesByPID)
+        if !found {
+            continue
+        }
+        ref := agentpkg.SubagentRef{
+            ID:              fmt.Sprintf("proxy:%s:%d:%s", candidate.AgentType, candidate.PID, candidate.ProcessStartTime),
+            Type:            candidate.AgentType,
+            StartedAt:       broadcastTs,
+            SourcePID:       candidate.PID,
+            SourceStartTime: candidate.ProcessStartTime,
+            IsProxy:         true,
+        }
+        attached, parentStored, aerr := m.attachProxyRefWithRetry(ancestor, ref, broadcastTs)
+        if aerr != nil || !attached {
+            continue
+        }
+        deleted, _ := m.frames.DeleteIfUnchanged(candidate.FrameID, candidate.LastSeenAt)
+        if !deleted {
+            // Partial — concurrent refresh / hot-path won the race. Next
+            // sweep tick re-evaluates. Projection dedup already hides
+            // this for SPA. No rollback.
+            continue
+        }
+        agentpkg.MetricSweepCanonicalized.Add(1)
+        canonicalizedAny = true
+        anyAncestor = parentStored
+    }
+    if canonicalizedAny {
+        m.broadcastProxyCanonicalized(anyAncestor)
+    }
+}
+```
+
+設計細節：
+
+1. **Candidate identity gate**：dead PID / PID-reuse → skip。理由：candidate 不健康時不應該被 attach 成 proxy ref；交給 `pid_dead` / `pid_reused` 主 sweep pass 清掉本體。
+2. **Ancestor identity gate（在 `findCanonicalAncestor` 內）**：ancestor 也必須 live + identity-verified。理由：避免把 child 收編到一個 stale parent，造成新一輪 partial。
+3. **Same-type skip**：candidate.AgentType == ancestor.AgentType → not a valid proxy relationship（cc 之上不該掛 cc proxy；cross-type 才有意義，e.g. cc ancestor + codex descendant）。
+4. **DeleteIfUnchanged failure → partial（不 rollback）**：hot path 同樣語意；下次 tick 再試；projection dedup 期間隱藏。
+5. **Broadcast**：per-pane 而非 per-attach（與 `broadcastProxyPruned` granularity 對稱）；多個 ref 同 pane 收編合併成一次廣播。
+
+### 2.3 findCanonicalAncestor
+
+```go
+// findCanonicalAncestor walks descendant's PPID chain looking for a
+// cross-type frame in the same pane that is live and identity-verified.
+// Caps walk at proxyMaxDepth (5) to bound syscall cost. Returns the
+// frame and true on success.
+//
+// Returns false when:
+//   - readProcessInfoFn errors mid-walk (transient — next sweep tick retries)
+//   - PPID hits init (<=1) or self-loop (PPID == current PID)
+//   - depth exhausted without finding a frame in the pane
+//   - the matched ancestor is same-type as candidate (not a proxy relationship)
+//   - the matched ancestor fails identity gate (dead / PID-reused)
+//
+// Note: framesByPID is keyed by PID, not (PID, paneID), but caller
+// passes only frames from a single pane (ListByPane), so cross-pane
+// collision is impossible.
+func (m *Module) findCanonicalAncestor(candidate store.Frame, framesByPID map[int]store.Frame) (store.Frame, bool) {
+    info, err := readProcessInfoFn(candidate.PID)
+    if err != nil {
+        return store.Frame{}, false
+    }
+    ppid := info.PPID
+    for depth := 0; depth < proxyMaxDepth; depth++ {
+        if ppid <= 1 {
+            return store.Frame{}, false
+        }
+        ancestor, ok := framesByPID[ppid]
+        if ok {
+            if ancestor.AgentType == candidate.AgentType {
+                // Same-type — not a proxy relationship. Caller skips
+                // (returning false here is conservative; a same-type
+                // ancestor in chain means we're "inside" the same agent
+                // tree and won't find a different cross-type ancestor
+                // higher up either, by design).
+                return store.Frame{}, false
+            }
+            if isPidAliveFn(ancestor.PID) {
+                actualStart, sterr := processStartTimeFn(ancestor.PID)
+                if sterr == nil && actualStart == ancestor.ProcessStartTime {
+                    return ancestor, true
+                }
+            }
+            // Ancestor matched in pane but failed identity gate — keep
+            // walking; a deeper ancestor might still match.
+        }
+        ancestorInfo, err := readProcessInfoFn(ppid)
+        if err != nil {
+            return store.Frame{}, false
+        }
+        if ancestorInfo.PPID == ppid {
+            return store.Frame{}, false
+        }
+        ppid = ancestorInfo.PPID
+    }
+    return store.Frame{}, false
+}
+```
+
+### 2.4 broadcastProxyCanonicalized
+
+對稱 `broadcastProxyPruned` (sweep.go:227)：
+
+```go
+// broadcastProxyCanonicalized emits a "hook" broadcast with reason=
+// sweep:proxy_canonicalized after canonicalizePane attached at least one
+// proxy ref + deleted at least one standalone child in a pane. Mirrors
+// broadcastProxyPruned so SPA + m.subagents / m.currentStatus stay in
+// sync without waiting for an unrelated hook.
+//
+// Best-effort: errors swallowed (next sweep tick re-evaluates). Single
+// reference frame param picks any owner that successfully attached this
+// tick — projection rebuild does not depend on which.
+func (m *Module) broadcastProxyCanonicalized(reference store.Frame) {
+    // Implementation pattern mirrors broadcastProxyPruned: project pane,
+    // build NormalizedEvent with reason=sweep:proxy_canonicalized, push
+    // through dispatchHook... (verify exact wiring against existing
+    // broadcastProxyPruned at sweep.go:227 during impl).
+}
+```
+
+> **Implementation note**：`broadcastProxyPruned` 完整 body 在 sweep.go:218+，TDD 階段 read 一次照 pattern 寫 `broadcastProxyCanonicalized`。可能可以抽 helper（`broadcastSweepHook(reference, reason string)`），但避免在 3.5b 拓展 scope — 先 duplicate，commit 結束附 simplifier 做共通化。
+
+### 2.5 不新增 trace reason
+
+Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費端無法區別 hot-path vs sweep canonicalization，broadcast reason 已足夠）。3.5b 沿用此決策。
+
+### 2.6 Wire compatibility
+
+無 schema 變更；無新 SubagentRef field；無 SPA 變更；無新 store API。
+
+---
+
+## 3. 測試矩陣
+
+新測試一律加進 `internal/module/agent/sweep_test.go`（PR-3.5a 已建檔），與 `pruneDeadProxyRefs` 既有測試同檔案。
+
+### 3.1 Integration（必要 ship gate）
+
+| # | 名稱 | Sequence | 預期 final state |
+|---|---|---|---|
+| **IT10** | `sweep_canonicalizes_standalone_descendant_into_ancestor` | (a) cc frame；(b) codex standalone frame（race 留下，PPID 鏈通到 cc PID）；(c) sweepOnce 跑一輪 | cc.Subagents 含 codex IsProxy ref；codex standalone 已刪；MetricSweepCanonicalized +1 |
+| **IT10b** | `sweep_canonicalize_skips_pid_reuse_candidate` | codex standalone 但 actualStart != ProcessStartTime（PID 重用）；cc 健康；sweep 跑 | candidate 被 candidate identity gate skip；cc.Subagents 不變；codex standalone 留給 pid_reused pass；MetricSweepCanonicalized 不變 |
+| **IT10c** | `sweep_canonicalize_skips_dead_candidate` | codex standalone 但 PID 已死；cc 健康；sweep 跑 | candidate gate skip；cc.Subagents 不變；codex standalone 由 pid_dead pass 清；MetricSweepCanonicalized 不變 |
+| **IT10d** | `sweep_canonicalize_skips_when_ancestor_dead` | codex standalone live + identity-verified；cc frame 在 framesByPID 但 cc.PID 已死；sweep | candidate 跑 findCanonicalAncestor → ancestor identity gate skip → candidate 不被 fold；MetricSweepCanonicalized 不變；cc 由 pid_dead pass 清 |
+| **IT10e** | `sweep_canonicalize_skips_same_type_ancestor` | 兩個 cc standalone（race 留下，後者 PPID 鏈到前者）；sweep | findCanonicalAncestor 命中 same-type → return false；不 fold；MetricSweepCanonicalized 不變（這是 plan §4.2 設計：same-type 不是 proxy 關係）|
+| **IT10f** | `sweep_canonicalize_skips_when_no_ancestor_in_pane` | codex standalone live；pane 內無其他 frame（PPID 鏈不指向任何 frame.PID）；sweep | findCanonicalAncestor 走完鏈無 match → return false；codex frame 留存；MetricSweepCanonicalized 不變 |
+| **IT10g** | `sweep_canonicalize_partial_when_delete_unchanged_fails` | (a) cc frame；(b) codex standalone；(c) mock `DeleteIfUnchanged` 對該 codex frame 回 deleted=false（concurrent refresh 撞 LastSeenAt baseline）；sweep | cc.Subagents 已含 codex IsProxy ref（attach 成功）；codex standalone 仍在；MetricSweepCanonicalized **不增加**（per plan：成功 = attach + delete 兩者皆成）；下次 tick 再試 |
+| **IT10h** | `sweep_canonicalize_partial_when_attach_fails` | (a) cc frame；(b) codex standalone；(c) mock `attachProxyRefWithRetry` 回 attached=false（retry 耗盡）；sweep | cc.Subagents 不含 codex；codex standalone 仍在；MetricSweepCanonicalized 不變；下次 tick 再試 |
+| **IT10i** | `sweep_canonicalize_then_prune_same_tick` | (a) cc frame.Subagents 含 stale codex IsProxy ref（SourcePID 已死）；(b) opencode standalone live + PPID 通到 cc；sweep 跑一輪 | canonicalize 先：cc.Subagents 加 opencode IsProxy；opencode standalone 刪。prune 後：cc.Subagents 移除 stale codex IsProxy。最終 cc.Subagents = [opencode IsProxy]；MetricSweepCanonicalized +1 + MetricSweepPrunedProxy +1 |
+| **IT10j** | `sweep_canonicalize_emits_broadcast_when_any_succeeded` | 同 IT10 setup；驗 broadcast 通道有收到 reason=`sweep:proxy_canonicalized` 一次 | broadcast 觀察通道 +1（per-pane，不是 per-attach）|
+| **IT10k** | `sweep_canonicalize_no_broadcast_when_nothing_succeeded` | 全部 candidate skip / partial；sweep | 無 `sweep:proxy_canonicalized` broadcast |
+| **IT10l** | `sweep_canonicalize_cross_pane_isolation` | pane A 有 standalone codex 可 fold 進 cc；pane B 有 standalone codex 但 ancestor 不在；sweep | pane A canonicalize 成功；pane B 不影響；MetricSweepCanonicalized +1 |
+| **IT10m** | `sweep_canonicalize_skips_already_proxied_candidate` | codex 既有 standalone frame（live）但同時 cc.Subagents 已含 codex IsProxy ref（hot-path 半成品 — attach 成 + delete 失敗的歷史 partial）；sweep | findCanonicalAncestor 找到 cc → attach 重試 → `attachProxyRefWithRetry` 內 RMW 看到既有 ref（同 SourcePID + SourceStartTime + IsProxy）需要驗：mutateSubagentsWithRetry 對 SubagentStart 用 updateSubagents replace by match → 不重複 → DeleteIfUnchanged 嘗試刪 standalone → 成 → cc.Subagents 仍只有一條 codex IsProxy；MetricSweepCanonicalized +1（這是 PR-3.5a partial recovery 的核心場景）|
+
+### 3.2 Unit
+
+`sweep_test.go` 加 `RC6`-`RC9`：
+
+| # | 名稱 |
+|---|---|
+| **RC6** | `findCanonicalAncestor_walks_to_cross_type_match` |
+| **RC7** | `findCanonicalAncestor_returns_false_on_same_type_immediate_match` |
+| **RC8** | `findCanonicalAncestor_returns_false_on_dead_ancestor_identity_gate` |
+| **RC9** | `findCanonicalAncestor_returns_false_on_depth_exhaustion` |
+| **RC10** | `findCanonicalAncestor_returns_false_on_loop_detection_ppid_eq_pid` |
+| **RC11** | `findCanonicalAncestor_returns_false_on_readProcessInfo_transient_error` |
+
+### 3.3 不加的測試
+
+- ❌ Goroutine race detector — IT 順序模擬 + identity gate 一致性已足
+- ❌ Sweep tick interval 變動測試（sweepInterval 是 PR-3.5a constant，不在 3.5b scope）
+- ❌ Phase 3 Prober 互動測試（Phase 3 scope）
+- ❌ projection dedup 路徑（PR-3.5a 已涵蓋；3.5b 不變更 projection）
+
+### 3.4 Test scaffolding 預期
+
+- 3.5a 既有的 `sweep_test.go` 已建立 `pruneDeadProxyRefs` 測試 + mock 注入機制（`isPidAliveFn` / `processStartTimeFn` / `readProcessInfoFn`）。沿用。
+- 預期需要 mock seam 注入 `attachProxyRefWithRetry` / `DeleteIfUnchanged` 的失敗路徑（IT10g, IT10h）。檢查現有 sweep_test.go 看是否已有 helper；若無，加 minimum mock seam（不引入新 store interface — 透過 fake `framesStore` 實作既有 method 即可）。
+
+---
+
+## 4. Commit 順序（TDD）
+
+每個 commit 獨立、test-first、可獨立 review。
+
+| # | Type | 說明 |
+|---|---|---|
+| 1 | docs | 本 plan v1 docs commit |
+| 2 | test | 加 IT10 + IT10b/c/d/e/f（純 candidate/ancestor identity gate path）；compile 失敗（caller 未實作）|
+| 3 | feat | 實作 `findCanonicalAncestor`（IT10b-f + RC6-RC11 全綠；canonicalizePane 仍未實作 → IT10 仍紅）|
+| 4 | feat | 實作 `canonicalizePane` 主 body（不含 broadcast）+ sweepOnce wire；IT10/IT10g/IT10h/IT10i/IT10l/IT10m 綠 |
+| 5 | feat | 加 `broadcastProxyCanonicalized` + canonicalizePane call 它；IT10j/IT10k 綠 |
+| 6 | docs | plan v2（如 codex review 有調整）|
+
+> Commit 2-3 拆原因：identity gate 邏輯獨立（plan v12 §4.2 內 candidate gate 與 findCanonicalAncestor 各自有 gate），先把 ancestor walk 與 unit test 鎖定，再接 canonicalize 主 flow。
+
+---
+
+## 5. 不做（明列 boundary）
+
+- ❌ 改 `pruneDeadProxyRefs` 行為
+- ❌ 改 hot-path canonicalize / reconcile 路徑
+- ❌ 新 SubagentRef 欄位
+- ❌ 新 trace decision reason（plan v12 §2.5 決策延用）
+- ❌ projection layer 變更
+- ❌ `frameIdleThreshold` / `sweepInterval` 調整
+- ❌ Phase 4 probe 補強
+
+---
+
+## 6. Ship gate
+
+| 檢查 | 要求 |
+|---|---|
+| `go build ./... && go vet ./... && go test ./...` | 全綠 |
+| 23 packages 總體 | 0 regression |
+| IT10/IT10b-m + RC6-RC11 | 全綠 |
+| MetricSweepCanonicalized | 觀察 +1 在預期 case |
+| Codex review | 一輪標準 cross-model（3.5a 5 輪 review 已涵蓋 §4.2 設計，3.5b 為實作 + 測試擴展，一輪足夠 — 如 round 1 verdict !== clean 才 escalate）|
+
+---
+
+## 7. Risk
+
+| Risk | 機率 | 緩解 |
+|---|---|---|
+| 同 sweep tick canonicalize 與 prune 互踩（先 attach 的 ref 立即被 prune）| **低** | identity gate 一致 — canonicalize 剛 attach 的 ref 是 live + identity-verified；prune 識別為「healthy proxy」會跳過。IT10i 守 |
+| `framesByPID` map 依 PID 但 cross-pane PID 重複（OS PID 不保證 pane-unique）| **不存在** | `ListByPane` 限制 frames 同一 pane；map cross-pane collision 不可能 |
+| `findCanonicalAncestor` 同 PID 出現兩次的 PPID loop（除 self-loop 外的長 loop）| **低** | depth cap = 5；self-loop 偵測；其他長 loop 在 depth 內自然耗盡 |
+| canonicalizePane 與 hot-path `reconcileCreatedFrameAsProxy` 並發 → 雙方都試 attach 同 ref | **可控** | `mutateSubagentsWithRetry` 內 RMW 對 same-identity ref 是 idempotent（match 就 replace 不重複）；雙方 DeleteIfUnchanged 對同 frame 一邊成功一邊失敗 — 都符合既有語意，partial 由下一 tick 修復 |
+| broadcast 風暴（每 2s 一次）| **低** | 只在「成功 attach + delete 至少一次」才 broadcast；穩態下 partial 為 0，broadcast 為 0 |
+| 新 helper `broadcastProxyCanonicalized` 與 `broadcastProxyPruned` 重複| **預期** | 先 duplicate（避免 3.5b 拓展 scope），commit 結束附 simplifier 做 helper 抽出。或 codex review 建議共通化再做 |
+
+---
+
+## 8. LOC 預估
+
+| 區塊 | LOC |
+|---|---|
+| `canonicalizePane` body | ~50 |
+| `findCanonicalAncestor` body | ~40 |
+| `broadcastProxyCanonicalized` body | ~25 |
+| sweepOnce wire（1 行 + 註解） | ~5 |
+| Tests（IT10×13 + RC6-11×6） | ~400-500 |
+| Plan docs（本檔） | ~400 |
+| **Net code（不含 plan docs / tests）** | **~120** |
+| **Net code + tests** | **~600** |
+
+對齊 plan v12 §14 預估「~150-250 LOC net 不含 tests」— 落在範圍。
+
+---
+
+## 9. Codex review focus 預期
+
+一輪標準 review，重點：
+
+1. canonicalize → prune 順序在同 tick 是否 sound（IT10i 是核心）
+2. `findCanonicalAncestor` same-type early return 是否過於保守（會不會漏 fold 跨 same-type 中介的 cross-type 深 ancestor）
+3. broadcast per-pane granularity 是否與 SPA 端 m.subagents / m.currentStatus 同步邏輯相容
+4. partial state（attach 成 + delete 失敗）的 metric 計數是否誤導（IT10g 設計選擇）
+5. RC6-RC11 unit 測試 coverage 是否漏邊角
+
+---
+
+## 10. 結束條件
+
+- ship gate（§6）全綠
+- codex round 1 review 收斂（無 critical/high/medium）
+- main rebase clean
+- bump alpha.227（PR-3.5b 單獨 bump，與 3.5a 切開以便 metric 觀察）
+
+---
+
+## 11. 文獻
+
+- `2026-04-25-lights-rebuild-phase-3-5-plan.md` v12 — 5 輪 codex review，§4.2 設計母本
+- `2026-04-23-lights-rebuild-spec.md` — Phase 3.5 整體 spec
+- PR #644 — PR-3.5a merged at `fdac21c9`
+- `kickoff_lights_rebuild.md` — Hybrid B+ 設計典範
+- `feedback_codex_review_termination.md` — 一輪 review 終止條件

--- a/docs/specs/2026-04-26-lights-rebuild-phase-3-5b-plan.md
+++ b/docs/specs/2026-04-26-lights-rebuild-phase-3-5b-plan.md
@@ -1,12 +1,19 @@
-# Lights Rebuild — Phase 3.5b Plan v2
+# Lights Rebuild — Phase 3.5b Plan v3
 
-**Status**: Draft, codex round 1 passed (1 high finding 採納)
+**Status**: Draft, pending codex round 3
 **Round 1**: needs-attention — high (canonicalizePane 漏 hasOwnedState 守衛 → child 自己的 native subagent state 被砍)
-**Round 1 fix**: §2.2 加 candidate state classifier（mirror `canonicalizeDescendantsAfterUpsert` frame_ops.go:1098-1137）+ IT10n/IT10o/IT10p 新增驗證（stateful native skip / stale-only IsProxy fold OK / live IsProxy skip）+ RC12/RC13 unit
+**Round 1 fix（v2）**: §2.2 加 candidate state classifier（mirror `canonicalizeDescendantsAfterUpsert` frame_ops.go:1098-1137）+ IT10n/IT10o/IT10p 新增驗證
+**Round 2**: needs-attention — high (IT10n 漏掉 round 1 原始時序 — attach 成功 + DeleteIfUnchanged 失敗 + 後續 native SubagentStart 三步序列；ship gate §6 沒納入 v2 新增 IT/RC)
+**Round 2 fix（v3）**: §3.1 IT10n 重寫為 round 1 原始時序組合 IT10m partial state（pre-existing parent proxy + child standalone with bumped LastSeenAt + native ref）；§6 ship gate 擴到 IT10/IT10b-p + RC6-RC16 全綠
 **Round 1 verbatim** (`019dc937-beb0-7a83-a02b-42679ad4fbc1`):
 
 > high — canonicalizePane can erase stateful child subagents during partial recovery (§2.2 lines 114-140). Plan §2.2 folds any live candidate with a canonical ancestor, then deletes the candidate row after attach. There is no candidate-owned-state guard before lines 136-140. This is unsafe for the exact partial state created when attach succeeds and DeleteIfUnchanged fails because the child was concurrently refreshed by SubagentStart: PR-3.5a projection currently hides that standalone child while merging its Subagents, but this sweep would attach only a proxy ref to the ancestor and then delete the child row, losing native child refs. Existing hot-path canonicalizeDescendantsAfterUpsert has an owned-state classification for this class of bug; the sweep plan does not carry it over, and IT10g/IT10m do not cover a stateful child with native refs.
 > Recommendation: Add an owned-state check before attach/delete, mirroring the existing hot-path rule: skip candidates with native refs or live identity-verified IsProxy refs, allow only empty or stale-only proxy candidates. Alternatively, explicitly migrate candidate.Subagents into the ancestor with owner-aware dedup before DeleteIfUnchanged. Add an IT case for attach-success/delete-failure followed by a native SubagentStart on the child, proving sweep preserves the native ref after recovery.
+
+**Round 2 verbatim** (`019dc93d-7f4e-7892-bdf6-45779388604f`):
+
+> high — Round 1 data-loss regression is not actually gated by the v2 plan (§3.1 359-431). §3.1 的 IT10n 只預先放一個帶 native ref 的 standalone child，沒有同時建立 round 1 high 的關鍵 partial state：ancestor 已經有 child 的 proxy ref，child 因 DeleteIfUnchanged 失敗仍存在，接著 child 收到 native SubagentStart。這會驗到 candidateHasOwnedState 的基本 guard，但沒有證明 sweep 在 attach-success/delete-failure 的既有 parent proxy 狀態下保留 child native state。更嚴重的是 §6 ship gate 仍只要求 IT10/IT10b-m + RC6-RC11，漏掉 v2 新增的 IT10n/o/p 與 RC12-RC16；實作即使沒有跑 round 1 closure tests 也能照 plan 過 gate。
+> Recommendation: 把 IT10n 改成組合 IT10m 的 already-proxied partial：cc.Subagents 先含 codex IsProxy，codex standalone 的 LastSeenAt 模擬被 SubagentStart bump 並含 native ref；sweep 後 assert codex row/native ref 保留、parent proxy 不重複、MetricSweepCanonicalized 不增。同步把 §6 ship gate 改為要求 IT10/IT10b-p + RC6-RC16 全綠。
 **Scope**: Sweep canonicalize defense-in-depth layer
 **Base**: `main` @ alpha.226 (`78ae7273`)
 **Branch**: `worktree-lights-phase-3-5b`
@@ -356,7 +363,7 @@ Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費
 | **IT10k** | `sweep_canonicalize_no_broadcast_when_nothing_succeeded` | 全部 candidate skip / partial；sweep | 無 `sweep:proxy_canonicalized` broadcast |
 | **IT10l** | `sweep_canonicalize_cross_pane_isolation` | pane A 有 standalone codex 可 fold 進 cc；pane B 有 standalone codex 但 ancestor 不在；sweep | pane A canonicalize 成功；pane B 不影響；MetricSweepCanonicalized +1 |
 | **IT10m** | `sweep_canonicalize_skips_already_proxied_candidate` | codex 既有 standalone frame（live）但同時 cc.Subagents 已含 codex IsProxy ref（hot-path 半成品 — attach 成 + delete 失敗的歷史 partial）；sweep | findCanonicalAncestor 找到 cc → attach 重試 → `attachProxyRefWithRetry` 內 RMW 看到既有 ref（同 SourcePID + SourceStartTime + IsProxy）需要驗：mutateSubagentsWithRetry 對 SubagentStart 用 updateSubagents replace by match → 不重複 → DeleteIfUnchanged 嘗試刪 standalone → 成 → cc.Subagents 仍只有一條 codex IsProxy；MetricSweepCanonicalized +1（這是 PR-3.5a partial recovery 的核心場景）|
-| **IT10n** (v2) | `sweep_canonicalize_skips_candidate_with_native_subagent` | (a) cc frame；(b) codex standalone live + identity-verified；(c) codex.Subagents 含 native task SubagentStart ref（IsProxy=false，模擬 race window 期間 codex 收 SubagentStart 事件後尚未被收編）；sweep | candidate hasOwnedState → skip；codex standalone 仍在；codex.Subagents 仍含 native ref；MetricSweepCanonicalized 不變；projection dedup 期間繼續 hide + merge（PR-3.5a 既有行為）|
+| **IT10n** (v3 重寫) | `sweep_canonicalize_preserves_child_native_after_partial_recovery` | **Round 1 high 原始時序的精準回歸 guard**：(a) cc frame；(b) codex standalone live + identity-verified（PR-3.5a hot-path attach 成功後的 partial）；(c) cc.Subagents 已含 codex IsProxy ref（hot-path 的 successful attach）；(d) codex frame.LastSeenAt 被後續 SubagentStart 事件 bump 過（DeleteIfUnchanged failed 的原因）；(e) codex.Subagents 含 native task SubagentStart ref（IsProxy=false）；(f) sweep 跑 | candidate hasOwnedState=true（native ref 觸發）→ skip；codex standalone 列保留；codex.Subagents 的 native ref 保留；cc.Subagents 仍只一條 codex IsProxy（不重複 attach）；**MetricSweepCanonicalized 不變**（gated case 不算 progress）；projection dedup 在後續 read 時繼續 hide codex standalone 並 merge native ref 進 cc projection（PR-3.5a 既有行為延續）|
 | **IT10o** (v2) | `sweep_canonicalize_folds_candidate_with_only_stale_proxy` | codex standalone live + identity-verified；codex.Subagents 含 IsProxy ref 但 SourcePID 已死（stale）；sweep | candidate hasOwnedState=false（stale-only proxy 不算 owned）→ fold；codex standalone 已刪；cc.Subagents 含 codex IsProxy；stale proxy 跟 codex frame 一起消失（與 sweep prune 等效）；MetricSweepCanonicalized +1 |
 | **IT10p** (v2) | `sweep_canonicalize_skips_candidate_with_live_proxy` | codex standalone；codex.Subagents 含一個 IsProxy ref（SourcePID 對應某 opencode live 進程，identity verified — 表示 codex 自己當 ancestor 收編了 opencode）；sweep | candidate hasOwnedState=true（live IsProxy）→ skip；保 codex 自己作為某 sub-tree 的 ancestor 角色不被砍 |
 
@@ -428,9 +435,11 @@ Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費
 |---|---|
 | `go build ./... && go vet ./... && go test ./...` | 全綠 |
 | 23 packages 總體 | 0 regression |
-| IT10/IT10b-m + RC6-RC11 | 全綠 |
-| MetricSweepCanonicalized | 觀察 +1 在預期 case |
-| Codex review | 一輪標準 cross-model（3.5a 5 輪 review 已涵蓋 §4.2 設計，3.5b 為實作 + 測試擴展，一輪足夠 — 如 round 1 verdict !== clean 才 escalate）|
+| **IT10 + IT10b-IT10p（共 16 條 integration tests）** | **全綠**（v3 round 2 fix — 含 round 1 closure regression guard IT10n）|
+| **RC6-RC16（共 11 條 unit tests）** | **全綠**（v3 round 2 fix — 含 candidateHasOwnedState 完整覆蓋 RC12-RC16）|
+| MetricSweepCanonicalized | 觀察 +1 在預期 case；IT10g/IT10h/IT10n 確認**不**增（partial / gated case）|
+| MetricSweepPrunedProxy | 既有 PR-3.5a 行為不 regress |
+| Codex review | round 1 (high → fixed v2) + round 2 (high → fixed v3) → round 3 verdict 是 clean / nit-only 即可 ship；如再有 high/medium 繼續迭代直到收斂（per `feedback_codex_review_termination.md`）|
 
 ---
 

--- a/docs/specs/2026-04-26-lights-rebuild-phase-3-5b-plan.md
+++ b/docs/specs/2026-04-26-lights-rebuild-phase-3-5b-plan.md
@@ -1,10 +1,23 @@
-# Lights Rebuild — Phase 3.5b Plan v3
+# Lights Rebuild — Phase 3.5b Plan v4 (ship-ready snapshot)
 
-**Status**: Draft, pending codex round 3
-**Round 1**: needs-attention — high (canonicalizePane 漏 hasOwnedState 守衛 → child 自己的 native subagent state 被砍)
-**Round 1 fix（v2）**: §2.2 加 candidate state classifier（mirror `canonicalizeDescendantsAfterUpsert` frame_ops.go:1098-1137）+ IT10n/IT10o/IT10p 新增驗證
-**Round 2**: needs-attention — high (IT10n 漏掉 round 1 原始時序 — attach 成功 + DeleteIfUnchanged 失敗 + 後續 native SubagentStart 三步序列；ship gate §6 沒納入 v2 新增 IT/RC)
-**Round 2 fix（v3）**: §3.1 IT10n 重寫為 round 1 原始時序組合 IT10m partial state（pre-existing parent proxy + child standalone with bumped LastSeenAt + native ref）；§6 ship gate 擴到 IT10/IT10b-p + RC6-RC16 全綠
+**Status**: Ship-ready post-implementation (v4 reflects PR-level review rounds 1-4 outcomes)
+**Plan rounds (pre-impl)**:
+- Round 1: needs-attention — 1 high (canonicalizePane 漏 hasOwnedState 守衛 → v2 fix)
+- Round 2: needs-attention — 1 high (IT10n 漏 round 1 原始時序 + ship gate 沒納入 v2 IT/RC → v3 fix)
+- Round 3: **approve** — clean, ship-ready
+
+**PR rounds (post-impl, against PR #650)**:
+- Round 1 (standard): clean
+- Round 2 (3-parallel adversarial):
+  - Attacker high (F1) — sweep.go: ancestor can die between identity gate and DeleteIfUnchanged → live child row deleted into dead parent. **Fixed** in `3c4ebd07` (post-attach revalidation; later refined as F4)
+  - Defender high (F2) — sweep.go: owned-state candidate skipped forever; defender's transient-error path never converges. **Fixed** in `38eef1a6` (reorg main loop into 4 cases: silent-skip / delete-only / attach-only F2 recovery / attach+delete main path)
+  - File-health medium (F3) — sweep_test.go: canonicalizeWired/broadcastWired skip gates left in final diff as foot-gun. **Fixed** in `a2aafdf2` (removed flags + skipUntil helpers + all skipUntil calls)
+- Round 3 (closure verification): high (F4) — F1 only protected attach branch; F2's delete-only branch bypasses revalidation, reopening data-loss class. **Fixed** in `f46f616c` (hoisted revalidation to common pre-delete point covering BOTH paths)
+- Round 4 (closure verification): medium — plan ship gate stale (this v4 update closes it)
+
+**Convergence signal**: 3 plan rounds + 4 PR rounds = 7 total review passes. Findings count: 1 high (R1) → 1 high (R2 plan) → 0 (R3 plan approve) → 1 high (R1 PR clean) → 3 R2 PR (1 attacker + 1 defender + 1 file-health) → 1 high (R3 PR closure F4) → 1 medium (R4 PR closure plan drift). Diminishing severity past R2 PR; R3+R4 are review-driven refinements + doc cleanup.
+
+> **Note on §2.2 / §2.2.1 / §2.3 / §2.4 below**: these sections describe the v3 design baseline as reviewed/approved by plan rounds 1-3. The shipped code in `sweep.go` after F1/F2/F4 reorganizes the main loop into the 4-case branching documented in commit `38eef1a6`. Read commits `3c4ebd07` / `38eef1a6` / `a2aafdf2` / `f46f616c` for the post-review impl deltas. Plan §2.2 is preserved as the design source-of-truth at design time, not the merged shape.
 **Round 1 verbatim** (`019dc937-beb0-7a83-a02b-42679ad4fbc1`):
 
 > high — canonicalizePane can erase stateful child subagents during partial recovery (§2.2 lines 114-140). Plan §2.2 folds any live candidate with a canonical ancestor, then deletes the candidate row after attach. There is no candidate-owned-state guard before lines 136-140. This is unsafe for the exact partial state created when attach succeeds and DeleteIfUnchanged fails because the child was concurrently refreshed by SubagentStart: PR-3.5a projection currently hides that standalone child while merging its Subagents, but this sweep would attach only a proxy ref to the ancestor and then delete the child row, losing native child refs. Existing hot-path canonicalizeDescendantsAfterUpsert has an owned-state classification for this class of bug; the sweep plan does not carry it over, and IT10g/IT10m do not cover a stateful child with native refs.
@@ -435,11 +448,13 @@ Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費
 |---|---|
 | `go build ./... && go vet ./... && go test ./...` | 全綠 |
 | 23 packages 總體 | 0 regression |
-| **IT10 + IT10b-IT10p（共 16 條 integration tests）** | **全綠**（v3 round 2 fix — 含 round 1 closure regression guard IT10n）|
-| **RC6-RC16（共 11 條 unit tests）** | **全綠**（v3 round 2 fix — 含 candidateHasOwnedState 完整覆蓋 RC12-RC16）|
-| MetricSweepCanonicalized | 觀察 +1 在預期 case；IT10g/IT10h/IT10n 確認**不**增（partial / gated case）|
+| **IT10 + IT10b-IT10s（共 19 條 integration tests）** | **全綠**（v4 round 4 fix — 含 R1 plan high closure IT10n + R2 PR F1/F2 closure IT10q/IT10r + R3 PR F4 closure IT10s）|
+| **RC6-RC16（共 11 條 unit tests）** | **全綠**（含 candidateHasOwnedState 完整覆蓋 RC12-RC16）|
+| **總計 30 個 PR-3.5b 測試** | 無 skip，全綠 |
+| MetricSweepCanonicalized | 觀察 +1 在預期 case；IT10g/h/n/q/r/s 確認**不**增（partial / gated / silent-skip case）|
+| MetricPartialCanonicalizationCreated | 觀察 +1 在 deliberate-partial cases（F1/F4 ancestor 死亡 revalidation; F2 attach-only owned-state 保留）|
 | MetricSweepPrunedProxy | 既有 PR-3.5a 行為不 regress |
-| Codex review | round 1 (high → fixed v2) + round 2 (high → fixed v3) → round 3 verdict 是 clean / nit-only 即可 ship；如再有 high/medium 繼續迭代直到收斂（per `feedback_codex_review_termination.md`）|
+| Codex review | 4 輪 PR 評審收斂（R1 standard clean → R2 三角度 3 findings F1/F2/F3 → R3 closure F4 high → R4 closure 1 medium plan drift）；無 critical/P1 殘留；多輪 high 嚴重性遞減符合 `feedback_codex_review_termination.md` 終止條件 |
 
 ---
 
@@ -455,6 +470,9 @@ Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費
 | 新 helper `broadcastProxyCanonicalized` 與 `broadcastProxyPruned` 重複| **預期** | 先 duplicate（避免 3.5b 拓展 scope），commit 結束附 simplifier 做 helper 抽出。或 codex review 建議共通化再做 |
 | **v2 新增**：sweep 砍掉 child 自己的 native subagent state（codex round 1 high）| **已修** | §2.2.1 抽 `candidateHasOwnedState` 共享 helper；hot-path 與 sweep 編譯期保證語意一致；IT10n/IT10o/IT10p 三個 IT 守 |
 | **v2 新增**：抽 helper 改動 hot-path 既有檔案（違反「out of scope: 改 hot-path」）| **可控** | pure refactor，0 行為變更；hot-path 既有 test（PR-3.5a R2 #O2 specifically tests stale-only proxy fold + native ref skip）是 baseline 守衛；diff 是「移動命名」可一目了然 |
+| **v4 新增 (R2 PR attacker)**：ancestor 在 findCanonicalAncestor 與 DeleteIfUnchanged 之間死亡，導致 live child 被刪進 dead parent | **已修** F4 | sweep.go 將 isPidAliveFn + processStartTimeFn 重驗 hoist 到 delete 共同前置點，覆蓋 attach-then-delete 與 delete-only 兩條路徑；IT10q + IT10s regression guard |
+| **v4 新增 (R2 PR defender)**：owned-state child 與 hot-path 失敗的 ancestor 從 v3 早 skip → DB partial 永不收斂 | **已修** F2 | sweep.go reorg 為 4-case branching；attach-only recovery 在無 ref 時將 proxy ref 上去（projection_dedup 可隱藏 + merge）；IT10r regression guard |
+| **v4 新增 (R2 PR file-health)**：TDD intermediate skip gates `canonicalizeWired` / `broadcastWired` 留在 final diff 成 foot-gun | **已修** F3 | 移除 vars + skipUntil helpers + skipUntil calls；30 個 PR-3.5b 測試無條件全跑 |
 
 ---
 

--- a/docs/specs/2026-04-26-lights-rebuild-phase-3-5b-plan.md
+++ b/docs/specs/2026-04-26-lights-rebuild-phase-3-5b-plan.md
@@ -1,6 +1,12 @@
-# Lights Rebuild — Phase 3.5b Plan v1
+# Lights Rebuild — Phase 3.5b Plan v2
 
-**Status**: Draft, pending codex review
+**Status**: Draft, codex round 1 passed (1 high finding 採納)
+**Round 1**: needs-attention — high (canonicalizePane 漏 hasOwnedState 守衛 → child 自己的 native subagent state 被砍)
+**Round 1 fix**: §2.2 加 candidate state classifier（mirror `canonicalizeDescendantsAfterUpsert` frame_ops.go:1098-1137）+ IT10n/IT10o/IT10p 新增驗證（stateful native skip / stale-only IsProxy fold OK / live IsProxy skip）+ RC12/RC13 unit
+**Round 1 verbatim** (`019dc937-beb0-7a83-a02b-42679ad4fbc1`):
+
+> high — canonicalizePane can erase stateful child subagents during partial recovery (§2.2 lines 114-140). Plan §2.2 folds any live candidate with a canonical ancestor, then deletes the candidate row after attach. There is no candidate-owned-state guard before lines 136-140. This is unsafe for the exact partial state created when attach succeeds and DeleteIfUnchanged fails because the child was concurrently refreshed by SubagentStart: PR-3.5a projection currently hides that standalone child while merging its Subagents, but this sweep would attach only a proxy ref to the ancestor and then delete the child row, losing native child refs. Existing hot-path canonicalizeDescendantsAfterUpsert has an owned-state classification for this class of bug; the sweep plan does not carry it over, and IT10g/IT10m do not cover a stateful child with native refs.
+> Recommendation: Add an owned-state check before attach/delete, mirroring the existing hot-path rule: skip candidates with native refs or live identity-verified IsProxy refs, allow only empty or stale-only proxy candidates. Alternatively, explicitly migrate candidate.Subagents into the ancestor with owner-aware dedup before DeleteIfUnchanged. Add an IT case for attach-success/delete-failure followed by a native SubagentStart on the child, proving sweep preserves the native ref after recovery.
 **Scope**: Sweep canonicalize defense-in-depth layer
 **Base**: `main` @ alpha.226 (`78ae7273`)
 **Branch**: `worktree-lights-phase-3-5b`
@@ -38,6 +44,8 @@ PR-3.5b = 補一個 sweep pass 在 2s 內把這種 standalone child frame fold �
   - `canonicalizePane(paneID, broadcastTs)` — 新 func，掃 pane 的 standalone live frame，找到 cross-type live identity-verified ancestor，attach proxy ref + DeleteIfUnchanged 自身 standalone row
   - `findCanonicalAncestor(candidate, framesByPID)` — 新 helper，PPID 鏈走 `proxyMaxDepth` 找 cross-type ancestor frame
   - `sweepOnce` 第三 pass：在現有 `pruneDeadProxyRefs` 之前加 `canonicalizePane` call（順序：canonicalize → prune，讓新 attached ref 在同 tick 可被 prune 驗證 — 雖然剛 attach 的識別不會觸發 prune，但邏輯上 canonicalize 先建立的 ref 是 hot-path 模擬，由 prune 守衛）
+- `internal/module/agent/frame_ops.go`：
+  - **v2**：抽出 `candidateHasOwnedState(candidate store.Frame) bool` helper（既有 `canonicalizeDescendantsAfterUpsert` 內 in-line block 1098-1137 改 call helper；零行為變更）— 共享給 sweep canonicalizePane 用，編譯期保證 hot-path 與 sweep 兩處 owned-state 語意一致
 - 對應 metric：`MetricSweepCanonicalized`（已宣告於 `internal/agent/metrics.go:35`，目前無 caller，3.5b 接上）
 - 對應 broadcast：成功 attach + delete 後 emit `sweep:proxy_canonicalized` hook 廣播，讓 SPA + `m.subagents` / `m.currentStatus` 同步（pattern 仿 `pruneDeadProxyRefs` 的 `broadcastProxyPruned`）
 - 測試：IT10 + 補擴展矩陣（見 §3）
@@ -45,7 +53,8 @@ PR-3.5b = 補一個 sweep pass 在 2s 內把這種 standalone child frame fold �
 ### Out of scope
 
 - ❌ 改 `pruneDeadProxyRefs`（PR-3.5a 已 ship-ready）
-- ❌ 改 hot-path `reconcileCreatedFrameAsProxy` / `canonicalizeDescendantsAfterUpsert` / projection dedup（PR-3.5a 範圍）
+- ❌ 改 hot-path `reconcileCreatedFrameAsProxy` / `canonicalizeDescendantsAfterUpsert` 行為（v2 注：抽 helper 是 pure refactor 不算行為變更，hot-path 既有 test 是 baseline 守衛）
+- ❌ 改 projection dedup（PR-3.5a 範圍）
 - ❌ 新 store API（沿用既有 `ListByPane` / `DeleteIfUnchanged` / `attachProxyRefWithRetry`）
 - ❌ 新 SubagentRef field
 - ❌ 新 trace decision reason
@@ -121,6 +130,24 @@ func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
         if sterr != nil || actualStart != candidate.ProcessStartTime {
             continue
         }
+        // v2 round-1 fix — protect candidates that own LIVE state.
+        // Mirrors hot-path canonicalizeDescendantsAfterUpsert
+        // hasOwnedState classifier (frame_ops.go:1098-1137):
+        //   - any native ref (IsProxy=false) → owned (real subagent state)
+        //   - any live identity-verified IsProxy ref → owned
+        //   - read-error during identity check → defensive treat as owned
+        //   - empty Subagents OR only stale (dead/PID-reused) IsProxy
+        //     refs → safe to fold; stale refs would be reaped by sweep
+        //     prune anyway, and dropping them with the row is equivalent.
+        //
+        // Without this guard, sweep would erase native refs accumulated
+        // by SubagentStart events arriving on the child between hot-path
+        // attach and a failed DeleteIfUnchanged — projection_dedup merges
+        // them into parent's projection at read time, but only because
+        // the child row still exists. Deleting the row loses them.
+        if candidateHasOwnedState(candidate) {
+            continue
+        }
         ancestor, found := m.findCanonicalAncestor(candidate, framesByPID)
         if !found {
             continue
@@ -161,6 +188,58 @@ func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
 3. **Same-type skip**：candidate.AgentType == ancestor.AgentType → not a valid proxy relationship（cc 之上不該掛 cc proxy；cross-type 才有意義，e.g. cc ancestor + codex descendant）。
 4. **DeleteIfUnchanged failure → partial（不 rollback）**：hot path 同樣語意；下次 tick 再試；projection dedup 期間隱藏。
 5. **Broadcast**：per-pane 而非 per-attach（與 `broadcastProxyPruned` granularity 對稱）；多個 ref 同 pane 收編合併成一次廣播。
+
+### 2.2.1 candidateHasOwnedState (v2 新)
+
+```go
+// candidateHasOwnedState classifies whether a frame carries live state
+// that must be preserved during canonicalization. Returns true when the
+// frame has any native (IsProxy=false) subagent ref OR any live
+// identity-verified IsProxy ref. Returns true conservatively on a
+// processStartTime read error to avoid dropping state on uncertainty.
+//
+// Used by both hot-path canonicalizeDescendantsAfterUpsert and sweep
+// canonicalizePane to decide whether folding a candidate as a proxy
+// ref of an ancestor (and deleting its row) is safe.
+//
+// A candidate carrying ONLY stale (dead PID / PID-reused) IsProxy refs
+// is considered free of owned state — those refs would be reaped by
+// pruneDeadProxyRefs anyway, so dropping them with the row is
+// equivalent to letting prune detach them later.
+func candidateHasOwnedState(candidate store.Frame) bool {
+    for _, ref := range candidate.Subagents {
+        if !ref.IsProxy {
+            return true // native ref → real owned state
+        }
+        if !isPidAliveFn(ref.SourcePID) {
+            continue // stale (dead PID); reapable
+        }
+        actualStart, sterr := processStartTimeFn(ref.SourcePID)
+        if sterr != nil {
+            return true // read error → defensive
+        }
+        if actualStart != ref.SourceStartTime {
+            continue // PID reuse; stale
+        }
+        return true // live + identity-verified IsProxy → owned
+    }
+    return false
+}
+```
+
+**Scope decision — duplicate vs extract**:
+
+PR-3.5a 的 `canonicalizeDescendantsAfterUpsert` 把同樣邏輯內聯在 frame_ops.go:1098-1137。本 plan 選擇**抽出共享 helper**（而非另寫一份），理由：
+
+1. 兩處語意必須完全一致（任何 drift 都會造成 hot-path 與 sweep partial-state 收斂行為不同 → debug 噩夢）。共享 helper 用編譯期保證一致。
+2. 抽 helper 是 pure refactor（無行為變更）— 既有 hot-path test 既能保護重構，也能驗證 helper。
+3. helper 體積 ~25 行；不增加新 abstraction，只是命名一個既有概念。
+4. 違反 §1 「out of scope: 改 hot-path canonicalize」？— 嚴格說屬重構（move-and-rename 既有 in-line block）；以下兩個保護降低風險：
+   - hot-path test 是綠色 baseline；本 commit 只做名字搬家不改邏輯
+   - 抽出後 hot-path call site `if hasOwnedState { ... }` 改成 `if candidateHasOwnedState(candidate) { continue }`，diff 一小塊明顯
+5. 替代方案（duplicate）成本：~25 LOC 重複 + 未來 round 維護兩份 + 隱性同步義務 — net-negative。
+
+**Where to place**：`frame_ops.go` 既有 `pidIsAncestorOfWithCap` helper 在 1040+ 已建立 helper section pattern；接著加 `candidateHasOwnedState` 為下一個 helper。`canonicalizeDescendantsAfterUpsert` 既有 in-line block 改 call helper。
 
 ### 2.3 findCanonicalAncestor
 
@@ -277,6 +356,9 @@ Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費
 | **IT10k** | `sweep_canonicalize_no_broadcast_when_nothing_succeeded` | 全部 candidate skip / partial；sweep | 無 `sweep:proxy_canonicalized` broadcast |
 | **IT10l** | `sweep_canonicalize_cross_pane_isolation` | pane A 有 standalone codex 可 fold 進 cc；pane B 有 standalone codex 但 ancestor 不在；sweep | pane A canonicalize 成功；pane B 不影響；MetricSweepCanonicalized +1 |
 | **IT10m** | `sweep_canonicalize_skips_already_proxied_candidate` | codex 既有 standalone frame（live）但同時 cc.Subagents 已含 codex IsProxy ref（hot-path 半成品 — attach 成 + delete 失敗的歷史 partial）；sweep | findCanonicalAncestor 找到 cc → attach 重試 → `attachProxyRefWithRetry` 內 RMW 看到既有 ref（同 SourcePID + SourceStartTime + IsProxy）需要驗：mutateSubagentsWithRetry 對 SubagentStart 用 updateSubagents replace by match → 不重複 → DeleteIfUnchanged 嘗試刪 standalone → 成 → cc.Subagents 仍只有一條 codex IsProxy；MetricSweepCanonicalized +1（這是 PR-3.5a partial recovery 的核心場景）|
+| **IT10n** (v2) | `sweep_canonicalize_skips_candidate_with_native_subagent` | (a) cc frame；(b) codex standalone live + identity-verified；(c) codex.Subagents 含 native task SubagentStart ref（IsProxy=false，模擬 race window 期間 codex 收 SubagentStart 事件後尚未被收編）；sweep | candidate hasOwnedState → skip；codex standalone 仍在；codex.Subagents 仍含 native ref；MetricSweepCanonicalized 不變；projection dedup 期間繼續 hide + merge（PR-3.5a 既有行為）|
+| **IT10o** (v2) | `sweep_canonicalize_folds_candidate_with_only_stale_proxy` | codex standalone live + identity-verified；codex.Subagents 含 IsProxy ref 但 SourcePID 已死（stale）；sweep | candidate hasOwnedState=false（stale-only proxy 不算 owned）→ fold；codex standalone 已刪；cc.Subagents 含 codex IsProxy；stale proxy 跟 codex frame 一起消失（與 sweep prune 等效）；MetricSweepCanonicalized +1 |
+| **IT10p** (v2) | `sweep_canonicalize_skips_candidate_with_live_proxy` | codex standalone；codex.Subagents 含一個 IsProxy ref（SourcePID 對應某 opencode live 進程，identity verified — 表示 codex 自己當 ancestor 收編了 opencode）；sweep | candidate hasOwnedState=true（live IsProxy）→ skip；保 codex 自己作為某 sub-tree 的 ancestor 角色不被砍 |
 
 ### 3.2 Unit
 
@@ -290,6 +372,11 @@ Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費
 | **RC9** | `findCanonicalAncestor_returns_false_on_depth_exhaustion` |
 | **RC10** | `findCanonicalAncestor_returns_false_on_loop_detection_ppid_eq_pid` |
 | **RC11** | `findCanonicalAncestor_returns_false_on_readProcessInfo_transient_error` |
+| **RC12** (v2) | `candidateHasOwnedState_native_ref_returns_true` |
+| **RC13** (v2) | `candidateHasOwnedState_live_proxy_returns_true` |
+| **RC14** (v2) | `candidateHasOwnedState_only_stale_proxy_returns_false` |
+| **RC15** (v2) | `candidateHasOwnedState_proxy_read_error_treats_as_owned` |
+| **RC16** (v2) | `candidateHasOwnedState_empty_subagents_returns_false` |
 
 ### 3.3 不加的測試
 
@@ -311,14 +398,15 @@ Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費
 
 | # | Type | 說明 |
 |---|---|---|
-| 1 | docs | 本 plan v1 docs commit |
-| 2 | test | 加 IT10 + IT10b/c/d/e/f（純 candidate/ancestor identity gate path）；compile 失敗（caller 未實作）|
-| 3 | feat | 實作 `findCanonicalAncestor`（IT10b-f + RC6-RC11 全綠；canonicalizePane 仍未實作 → IT10 仍紅）|
-| 4 | feat | 實作 `canonicalizePane` 主 body（不含 broadcast）+ sweepOnce wire；IT10/IT10g/IT10h/IT10i/IT10l/IT10m 綠 |
-| 5 | feat | 加 `broadcastProxyCanonicalized` + canonicalizePane call 它；IT10j/IT10k 綠 |
-| 6 | docs | plan v2（如 codex review 有調整）|
+| 1 | docs | plan v1 → v2（v2 含 round 1 high finding 修法）|
+| 2 | refactor | 抽 `candidateHasOwnedState` 從 `canonicalizeDescendantsAfterUpsert` in-line block 變共享 helper（pure refactor，0 行為變更；hot-path 既有 test 是 baseline 守衛）+ RC12-RC16 unit |
+| 3 | test | 加 IT10 + IT10b/c/d/e/f + IT10n/o/p（identity gate + owned-state path）；compile 失敗（caller 未實作）|
+| 4 | feat | 實作 `findCanonicalAncestor`（RC6-RC11 全綠；IT10 系列仍紅 — canonicalizePane 未實作）|
+| 5 | feat | 實作 `canonicalizePane` 主 body（不含 broadcast）+ sweepOnce wire；IT10/IT10b-i/IT10l/IT10m/IT10n/IT10o/IT10p 綠 |
+| 6 | feat | 加 `broadcastProxyCanonicalized` + canonicalizePane call 它；IT10j/IT10k 綠 |
+| 7 | docs | plan v3（如 codex round 2 有 finding 才補）|
 
-> Commit 2-3 拆原因：identity gate 邏輯獨立（plan v12 §4.2 內 candidate gate 與 findCanonicalAncestor 各自有 gate），先把 ancestor walk 與 unit test 鎖定，再接 canonicalize 主 flow。
+> **v2 Commit 順序變動**：原 v1 commit 2-5 拆 5 步，v2 把 helper 抽出 commit 提到最前（commit 2）— 理由：helper 抽出是 pure refactor 與 hot-path 既有 test 一起維持綠；後續 commit 3-6 才碰 sweep 新 surface area。每個 commit 仍可獨立 build / test。
 
 ---
 
@@ -356,6 +444,8 @@ Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費
 | canonicalizePane 與 hot-path `reconcileCreatedFrameAsProxy` 並發 → 雙方都試 attach 同 ref | **可控** | `mutateSubagentsWithRetry` 內 RMW 對 same-identity ref 是 idempotent（match 就 replace 不重複）；雙方 DeleteIfUnchanged 對同 frame 一邊成功一邊失敗 — 都符合既有語意，partial 由下一 tick 修復 |
 | broadcast 風暴（每 2s 一次）| **低** | 只在「成功 attach + delete 至少一次」才 broadcast；穩態下 partial 為 0，broadcast 為 0 |
 | 新 helper `broadcastProxyCanonicalized` 與 `broadcastProxyPruned` 重複| **預期** | 先 duplicate（避免 3.5b 拓展 scope），commit 結束附 simplifier 做 helper 抽出。或 codex review 建議共通化再做 |
+| **v2 新增**：sweep 砍掉 child 自己的 native subagent state（codex round 1 high）| **已修** | §2.2.1 抽 `candidateHasOwnedState` 共享 helper；hot-path 與 sweep 編譯期保證語意一致；IT10n/IT10o/IT10p 三個 IT 守 |
+| **v2 新增**：抽 helper 改動 hot-path 既有檔案（違反「out of scope: 改 hot-path」）| **可控** | pure refactor，0 行為變更；hot-path 既有 test（PR-3.5a R2 #O2 specifically tests stale-only proxy fold + native ref skip）是 baseline 守衛；diff 是「移動命名」可一目了然 |
 
 ---
 
@@ -363,16 +453,17 @@ Plan v12 §2.5 已決定 sweep canonicalize 不寫獨立 trace decision（消費
 
 | 區塊 | LOC |
 |---|---|
-| `canonicalizePane` body | ~50 |
+| `candidateHasOwnedState` 抽 helper（v2，淨 0 行為變更，純命名搬家）| ~25（其中 ~20 是 docstring/comment）|
+| `canonicalizePane` body | ~55（v2 +5 一行 helper call + 註解）|
 | `findCanonicalAncestor` body | ~40 |
 | `broadcastProxyCanonicalized` body | ~25 |
 | sweepOnce wire（1 行 + 註解） | ~5 |
-| Tests（IT10×13 + RC6-11×6） | ~400-500 |
-| Plan docs（本檔） | ~400 |
-| **Net code（不含 plan docs / tests）** | **~120** |
-| **Net code + tests** | **~600** |
+| Tests（IT10×16 + RC6-RC16×11）| ~600-700 |
+| Plan docs（本檔 v2） | ~520 |
+| **Net code（不含 plan docs / tests）** | **~150** |
+| **Net code + tests** | **~800** |
 
-對齊 plan v12 §14 預估「~150-250 LOC net 不含 tests」— 落在範圍。
+對齊 plan v12 §14 預估「~150-250 LOC net 不含 tests」— 落在範圍 lower bound。
 
 ---
 

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -1055,6 +1055,49 @@ func pidIsAncestorOfWithCap(descendantPID, ancestorPID, maxDepth int) bool {
 	return false
 }
 
+// candidateHasOwnedState reports whether a frame carries live state that
+// must be preserved during canonicalization. Returns true when the frame
+// has any native (IsProxy=false) subagent ref OR any live identity-
+// verified IsProxy ref. Returns true conservatively on a
+// processStartTime read error to avoid dropping state on uncertainty.
+//
+// Used by both hot-path canonicalizeDescendantsAfterUpsert and sweep
+// canonicalizePane (PR-3.5b §2.2.1) to decide whether folding a
+// candidate as a proxy ref of an ancestor (and deleting its row) is
+// safe. Sharing one classifier ensures both call sites cannot drift on
+// the owned-state semantics — any change here lands in both at once.
+//
+// A candidate carrying ONLY stale (dead PID / PID-reused) IsProxy refs
+// is considered free of owned state — those refs would be reaped by
+// pruneDeadProxyRefs anyway, so dropping them with the row is
+// equivalent to letting prune detach them later.
+func candidateHasOwnedState(candidate store.Frame) bool {
+	for _, ref := range candidate.Subagents {
+		if !ref.IsProxy {
+			// Native ref → real owned state.
+			return true
+		}
+		// IsProxy: live + identity-verified counts as owned;
+		// dead/PID-reused is stale and safe to drop with the fold.
+		if !isPidAliveFn(ref.SourcePID) {
+			continue
+		}
+		actualStart, sterr := processStartTimeFn(ref.SourcePID)
+		if sterr != nil {
+			// Read error → defensive; treat as owned (don't drop
+			// state on uncertainty). Mirrors findProxyParent's
+			// "lookup error → don't infer" convention.
+			return true
+		}
+		if actualStart != ref.SourceStartTime {
+			continue // PID reuse; stale
+		}
+		// Live + identity-verified IsProxy → owned.
+		return true
+	}
+	return false
+}
+
 // canonicalizeDescendantsAfterUpsert scans self.PaneID for standalone
 // cross-type descendants whose live PPID chain passes through self.PID and
 // whose stored ProcessStartTime matches the live process's actual start
@@ -1105,34 +1148,12 @@ func (m *Module) canonicalizeDescendantsAfterUpsert(self store.Frame, broadcastT
 		// equivalent). Distinguishing these classes lets the hot-path
 		// fold race-window standalones even when sweep prune has not
 		// yet cleared their stale leftovers.
-		hasOwnedState := false
-		for _, ref := range candidate.Subagents {
-			if !ref.IsProxy {
-				// Native ref → real owned state.
-				hasOwnedState = true
-				break
-			}
-			// IsProxy: live + identity-verified counts as owned;
-			// dead/PID-reused is stale and safe to drop with the fold.
-			if !isPidAliveFn(ref.SourcePID) {
-				continue
-			}
-			actualStart, sterr := processStartTimeFn(ref.SourcePID)
-			if sterr != nil {
-				// Read error → defensive; treat as owned (don't drop
-				// state on uncertainty). Mirrors findProxyParent's
-				// "lookup error → don't infer" convention.
-				hasOwnedState = true
-				break
-			}
-			if actualStart != ref.SourceStartTime {
-				continue // PID reuse; stale
-			}
-			// Live + identity-verified IsProxy → owned.
-			hasOwnedState = true
-			break
-		}
-		if hasOwnedState {
+		//
+		// PR-3.5b §2.2.1: classifier extracted as candidateHasOwnedState
+		// so sweep canonicalizePane shares the exact same semantics —
+		// any drift between the two would create different fold
+		// decisions for identical candidate states.
+		if candidateHasOwnedState(candidate) {
 			continue
 		}
 		// Identity gate (PR-2b alignment + plan §2.1.2). Mirrors

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -3958,3 +3958,154 @@ func TestCanonicalizeDescendantsAfterUpsert_FoldsLiveCrossTypeDescendant(t *test
 	}
 	_ = candidate
 }
+
+// ---------------------------------------------------------------------------
+// PR-3.5b §3.2 — candidateHasOwnedState unit tests (RC12-RC16).
+//
+// Pure classifier — exercises the four code paths in the helper:
+//   - native ref (IsProxy=false) → owned
+//   - live + identity-verified IsProxy → owned
+//   - only stale (dead PID / PID-reused) IsProxy → not owned
+//   - processStartTime read error on a live IsProxy → defensively owned
+//   - empty subagents → not owned
+//
+// Each case overrides isPidAliveFn / processStartTimeFn package-level
+// seams (already used by hot-path tests above) to drive the helper's
+// branches without going through the database. Helper is invoked
+// directly so the failing test pinpoints classification, not
+// canonicalize integration.
+// ---------------------------------------------------------------------------
+
+// RC12 — candidate carrying a native (IsProxy=false) ref → owned.
+func TestCandidateHasOwnedState_NativeRefReturnsTrue(t *testing.T) {
+	candidate := store.Frame{
+		Subagents: []agentpkg.SubagentRef{{
+			ID:      "task-1",
+			Type:    "cc",
+			IsProxy: false,
+		}},
+	}
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "live", nil }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+	if !candidateHasOwnedState(candidate) {
+		t.Fatal("candidateHasOwnedState = false, want true (native ref must be treated as owned state)")
+	}
+}
+
+// RC13 — candidate carrying a live + identity-verified IsProxy ref → owned.
+func TestCandidateHasOwnedState_LiveProxyReturnsTrue(t *testing.T) {
+	candidate := store.Frame{
+		Subagents: []agentpkg.SubagentRef{{
+			ID:              "proxy:opencode:300:t300",
+			Type:            "opencode",
+			SourcePID:       300,
+			SourceStartTime: "t300",
+			IsProxy:         true,
+		}},
+	}
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	isPidAliveFn = func(pid int) bool { return pid == 300 }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 300 {
+			return "t300", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+	if !candidateHasOwnedState(candidate) {
+		t.Fatal("candidateHasOwnedState = false, want true (live identity-verified IsProxy must count as owned)")
+	}
+}
+
+// RC14 — candidate carrying ONLY stale IsProxy refs (dead PID and PID-
+// reused) → not owned (sweep prune would reap them anyway).
+func TestCandidateHasOwnedState_OnlyStaleProxyReturnsFalse(t *testing.T) {
+	candidate := store.Frame{
+		Subagents: []agentpkg.SubagentRef{
+			{
+				ID:              "proxy:opencode:888:dead",
+				Type:            "opencode",
+				SourcePID:       888,
+				SourceStartTime: "dead-t888",
+				IsProxy:         true,
+			},
+			{
+				ID:              "proxy:opencode:889:reused",
+				Type:            "opencode",
+				SourcePID:       889,
+				SourceStartTime: "stale-t889",
+				IsProxy:         true,
+			},
+		},
+	}
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	// 888 is dead; 889 is alive but identity changed.
+	isPidAliveFn = func(pid int) bool { return pid == 889 }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 889 {
+			return "fresh-t889", nil
+		}
+		return "", nil
+	}
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+	if candidateHasOwnedState(candidate) {
+		t.Fatal("candidateHasOwnedState = true, want false (only stale IsProxy refs — sweep prune would reap them)")
+	}
+}
+
+// RC15 — processStartTime read error on a live IsProxy → defensively
+// treated as owned (don't drop state on uncertainty).
+func TestCandidateHasOwnedState_ProxyReadErrorTreatsAsOwned(t *testing.T) {
+	candidate := store.Frame{
+		Subagents: []agentpkg.SubagentRef{{
+			ID:              "proxy:opencode:300:t300",
+			Type:            "opencode",
+			SourcePID:       300,
+			SourceStartTime: "t300",
+			IsProxy:         true,
+		}},
+	}
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) {
+		return "", errStub("ps transient failure")
+	}
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+	if !candidateHasOwnedState(candidate) {
+		t.Fatal("candidateHasOwnedState = false, want true (read error must defensively treat as owned)")
+	}
+}
+
+// RC16 — empty subagents list → not owned (nothing to preserve).
+func TestCandidateHasOwnedState_EmptySubagentsReturnsFalse(t *testing.T) {
+	candidate := store.Frame{}
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "live", nil }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+	if candidateHasOwnedState(candidate) {
+		t.Fatal("candidateHasOwnedState = true, want false (empty subagents — no state to preserve)")
+	}
+}

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -211,6 +211,36 @@ func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
 		if aerr != nil || !attached {
 			continue
 		}
+		// Review F1 (round 2 attacker) — revalidate ancestor identity
+		// AFTER attach, BEFORE delete. findCanonicalAncestor only
+		// proves the ancestor was live at classification time; the
+		// ancestor PID may die between then and this point. Without
+		// this gate, we would attach a proxy ref onto a dead parent
+		// and then delete the live child row, severing the only DB
+		// link to the live child until its next hook event (the dead
+		// parent gets cleared on the next sweep tick along with all
+		// its Subagents).
+		//
+		// On revalidation failure: leave the proxy ref attached
+		// (idempotent next tick if the parent is gone; harmless if
+		// somehow still alive) and skip delete. The standalone child
+		// row stays and continues to serve until either it is
+		// canonicalized into a healthier ancestor next tick or the
+		// parent is cleared and the ref vanishes with it. Mirrors the
+		// "no rollback on partial" Hybrid B+ rule.
+		if !isPidAliveFn(parentStored.PID) {
+			agentpkg.MetricPartialCanonicalizationCreated.Add(1)
+			canonicalizedAny = true
+			anyAncestor = parentStored
+			continue
+		}
+		actualAncestorStart, ancestorErr := processStartTimeFn(parentStored.PID)
+		if ancestorErr != nil || actualAncestorStart != parentStored.ProcessStartTime {
+			agentpkg.MetricPartialCanonicalizationCreated.Add(1)
+			canonicalizedAny = true
+			anyAncestor = parentStored
+			continue
+		}
 		deleted, _ := m.frames.DeleteIfUnchanged(candidate.FrameID, candidate.LastSeenAt)
 		if !deleted {
 			// Partial — concurrent refresh / hot-path won the race.

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -127,6 +127,62 @@ func (m *Module) sweepOnce() error {
 	return nil
 }
 
+// findCanonicalAncestor walks descendant's PPID chain looking for a
+// cross-type frame in the same pane that is live and identity-verified.
+// Caps walk at proxyMaxDepth (5) to bound syscall cost.
+//
+// Returns (frame, true) on a successful match. Returns (zero, false)
+// when:
+//   - readProcessInfoFn errors mid-walk (transient — next sweep tick retries)
+//   - PPID hits init (<=1) or self-loop (PPID == current PID)
+//   - depth exhausted without finding a frame in the pane
+//   - a same-type ancestor is encountered (cross-type-only proxy semantics;
+//     a same-type ancestor in chain means we're "inside" the same agent
+//     tree and won't find a different cross-type ancestor higher up either,
+//     by design — mirrors findProxyParent's same-type hard-stop)
+//   - the matched ancestor fails identity gate (dead PID / PID-reused)
+//
+// Note: framesByPID is keyed by PID, not (PID, paneID), but caller passes
+// only frames from a single pane (ListByPane), so cross-pane PID
+// collision is impossible.
+func (m *Module) findCanonicalAncestor(candidate store.Frame, framesByPID map[int]store.Frame) (store.Frame, bool) {
+	info, err := readProcessInfoFn(candidate.PID)
+	if err != nil {
+		return store.Frame{}, false
+	}
+	ppid := info.PPID
+	for depth := 0; depth < proxyMaxDepth; depth++ {
+		if ppid <= 1 {
+			return store.Frame{}, false
+		}
+		ancestor, ok := framesByPID[ppid]
+		if ok {
+			if ancestor.AgentType == candidate.AgentType {
+				// Same-type — not a proxy relationship. Hard-stop the
+				// walk (mirrors findProxyParent semantics).
+				return store.Frame{}, false
+			}
+			if isPidAliveFn(ancestor.PID) {
+				actualStart, sterr := processStartTimeFn(ancestor.PID)
+				if sterr == nil && actualStart == ancestor.ProcessStartTime {
+					return ancestor, true
+				}
+			}
+			// Ancestor matched in pane but failed identity gate — keep
+			// walking; a deeper ancestor might still match.
+		}
+		ancestorInfo, err := readProcessInfoFn(ppid)
+		if err != nil {
+			return store.Frame{}, false
+		}
+		if ancestorInfo.PPID == ppid {
+			return store.Frame{}, false
+		}
+		ppid = ancestorInfo.PPID
+	}
+	return store.Frame{}, false
+}
+
 // uniquePaneIDs collects distinct pane IDs from a frame slice in the order
 // they first appear. Used by sweepOnce to drive the pruneDeadProxyRefs pass
 // without re-listing per-pane.

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -224,11 +224,38 @@ func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
 		canonicalizedAny = true
 		anyAncestor = parentStored
 	}
-	// Broadcast wiring lands in commit 8 (broadcastProxyCanonicalized).
-	// Until then this is a no-op except for storage + metric.
 	if canonicalizedAny {
-		_ = anyAncestor
+		m.broadcastProxyCanonicalized(anyAncestor)
 	}
+}
+
+// broadcastProxyCanonicalized emits a "hook" broadcast with reason=
+// sweep:proxy_canonicalized after canonicalizePane attached at least
+// one proxy ref + deleted at least one standalone child in a pane.
+// Mirrors broadcastProxyPruned so SPA + m.subagents / m.currentStatus
+// stay in sync without waiting for an unrelated hook.
+//
+// Best-effort: errors swallowed (next sweep tick re-evaluates).
+// Per-pane (not per-attach) so multiple folds in the same pane
+// coalesce into one broadcast — matches broadcastProxyPruned's
+// granularity. PR-3.5b §2.4.
+func (m *Module) broadcastProxyCanonicalized(reference store.Frame) {
+	sessionName, code := m.resolvePaneSession(reference.PaneID)
+	projection, err := m.projectionForSession(sessionName)
+	if err != nil {
+		return
+	}
+	if sessionName != "" {
+		m.mu.Lock()
+		syncProjectionState(m.currentStatus, m.subagents, sessionName, projection)
+		m.mu.Unlock()
+	}
+	if code == "" || m.core == nil {
+		return
+	}
+	normalized := buildProjectionNormalized(projection, reference.AgentType, "sweep:proxy_canonicalized", nowFn().UnixNano(), agentpkg.DeriveResult{})
+	payload, _ := json.Marshal(normalized)
+	m.core.Events.Broadcast(code, "hook", string(payload))
 }
 
 // findCanonicalAncestor walks descendant's PPID chain looking for a

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
@@ -122,9 +123,112 @@ func (m *Module) sweepOnce() error {
 	panes := uniquePaneIDs(survivors)
 	broadcastTs := nowFn().UnixNano()
 	for _, paneID := range panes {
+		// PR-3.5b §2.1 — canonicalize first so newly-attached proxy
+		// refs land before pruneDeadProxyRefs validates this pane's
+		// proxy refs. Both passes are identity-gated (live + start_time
+		// match), so a freshly attached canonical ref is recognized as
+		// healthy by prune in the same tick. Reverse order would also
+		// work but canonicalize-first is the natural narrative: fix
+		// partials, then verify pane health.
+		m.canonicalizePane(paneID, broadcastTs)
 		m.pruneDeadProxyRefs(paneID, broadcastTs)
 	}
 	return nil
+}
+
+// canonicalizePane folds standalone live cross-type child frames into
+// their canonical ancestor's proxy ref within the same pane. Defense-
+// in-depth backstop for PR-3.5a hot-path canonicalization paths that
+// left a partial state (DeleteIfUnchanged failure / readProcessInfoFn
+// transient error / existing-frame SessionStart path that does not run
+// self-as-descendant reconcile).
+//
+// User-visible correctness is already guaranteed by projection dedup
+// (PR-3.5a §2.4) — this pass closes the DB-level eventual consistency
+// loop in ≤ 2s instead of waiting for the child's own SessionEnd /
+// pid_dead / 1h idle timeout.
+//
+// Single-direction rule (matches hot path): descendant becomes proxy
+// of ancestor; ancestor is never reverted to descendant. Identity gate
+// applied to BOTH candidate and ancestor — stale (PID-reused) frames
+// never participate, leaving them for pid_reused / pid_dead cleanup.
+//
+// Owned-state guard: candidates carrying native subagent refs or live
+// identity-verified IsProxy refs are preserved (folding would lose
+// state). See candidateHasOwnedState in frame_ops.go for the full
+// classifier shared with the hot path. The round 1 high finding
+// (sweep erasing child native state during partial recovery) is
+// gated by this guard; IT10n is the regression test.
+//
+// Best-effort: any storage error / failed gate / failed Upsert / failed
+// DeleteIfUnchanged makes this candidate skip; next sweep tick (2s)
+// retries. No rollback on partial.
+func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
+	if m.frames == nil {
+		return
+	}
+	frames, err := m.frames.ListByPane(paneID)
+	if err != nil {
+		return
+	}
+	framesByPID := make(map[int]store.Frame, len(frames))
+	for _, frame := range frames {
+		framesByPID[frame.PID] = frame
+	}
+	canonicalizedAny := false
+	var anyAncestor store.Frame
+	for _, candidate := range frames {
+		// Candidate identity gate — stale (dead PID / PID-reuse) frames
+		// skip canonicalize; pid_dead / pid_reused passes handle them.
+		if !isPidAliveFn(candidate.PID) {
+			continue
+		}
+		actualStart, sterr := processStartTimeFn(candidate.PID)
+		if sterr != nil || actualStart != candidate.ProcessStartTime {
+			continue
+		}
+		// PR-3.5b §2.2.1 — protect candidates that own LIVE state.
+		// Mirrors hot-path canonicalizeDescendantsAfterUpsert via the
+		// shared candidateHasOwnedState helper (frame_ops.go) so any
+		// drift between hot-path and sweep is impossible at compile
+		// time.
+		if candidateHasOwnedState(candidate) {
+			continue
+		}
+		ancestor, found := m.findCanonicalAncestor(candidate, framesByPID)
+		if !found {
+			continue
+		}
+		ref := agentpkg.SubagentRef{
+			ID:              fmt.Sprintf("proxy:%s:%d:%s", candidate.AgentType, candidate.PID, candidate.ProcessStartTime),
+			Type:            candidate.AgentType,
+			StartedAt:       broadcastTs,
+			SourcePID:       candidate.PID,
+			SourceStartTime: candidate.ProcessStartTime,
+			IsProxy:         true,
+		}
+		attached, parentStored, aerr := m.attachProxyRefWithRetry(ancestor, ref, broadcastTs)
+		if aerr != nil || !attached {
+			continue
+		}
+		deleted, _ := m.frames.DeleteIfUnchanged(candidate.FrameID, candidate.LastSeenAt)
+		if !deleted {
+			// Partial — concurrent refresh / hot-path won the race.
+			// Next sweep tick re-evaluates. Projection dedup already
+			// hides this for SPA. No rollback. Per plan: success =
+			// attach + delete both, so MetricSweepCanonicalized is
+			// NOT incremented in the partial case.
+			continue
+		}
+		agentpkg.MetricSweepCanonicalized.Add(1)
+		canonicalizedAny = true
+		anyAncestor = parentStored
+	}
+	// Broadcast wiring lands in commit 8 (broadcastProxyCanonicalized).
+	// Until then this is a no-op except for storage + metric.
+	if canonicalizedAny {
+		_ = anyAncestor
+	}
 }
 
 // findCanonicalAncestor walks descendant's PPID chain looking for a

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -240,31 +240,6 @@ func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
 				continue
 			}
 			parentStored = ps
-			// Review F1 (round 2 attacker) — revalidate ancestor identity
-			// AFTER attach, BEFORE delete. findCanonicalAncestor only
-			// proves the ancestor was live at classification time; the
-			// ancestor PID may die between then and this point. Without
-			// this gate, we would attach a proxy ref onto a dead parent
-			// and then delete the live child row, severing the only DB
-			// link to the live child until its next hook event.
-			//
-			// On revalidation failure: leave the proxy ref attached
-			// (the dead parent is cleared on the next sweep tick along
-			// with all its Subagents) and skip delete. Mirrors the
-			// "no rollback on partial" Hybrid B+ rule.
-			if !isPidAliveFn(parentStored.PID) {
-				agentpkg.MetricPartialCanonicalizationCreated.Add(1)
-				canonicalizedAny = true
-				anyAncestor = parentStored
-				continue
-			}
-			actualAncestorStart, ancestorErr := processStartTimeFn(parentStored.PID)
-			if ancestorErr != nil || actualAncestorStart != parentStored.ProcessStartTime {
-				agentpkg.MetricPartialCanonicalizationCreated.Add(1)
-				canonicalizedAny = true
-				anyAncestor = parentStored
-				continue
-			}
 		}
 		if ownedState {
 			// Review F2 — deliberate partial: attach succeeded (or was
@@ -272,6 +247,36 @@ func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
 			// state we must not lose. Skip delete; projection_dedup
 			// hides + merges this child's Subagents into the parent
 			// projection at read time.
+			agentpkg.MetricPartialCanonicalizationCreated.Add(1)
+			canonicalizedAny = true
+			anyAncestor = parentStored
+			continue
+		}
+		// Review F1 + F4 (round 2 attacker / round 3 closure) —
+		// revalidate ancestor identity BEFORE delete. findCanonicalAncestor
+		// only proves the ancestor was live at classification time; the
+		// ancestor PID may die between then and this point. Without
+		// this gate, we would delete the live candidate row into a
+		// dead parent (whose next sweep tick clears it along with all
+		// its Subagents, severing the only DB link to the live
+		// candidate). Hoisted to the common pre-delete point so BOTH
+		// the attach-then-delete branch (parent missing ref) AND the
+		// delete-only branch (parent already has matching ref via a
+		// prior partial recovery) share the same protection. Round 3
+		// caught the original F1 patch missing this delete-only path.
+		//
+		// On revalidation failure: leave the proxy ref attached (the
+		// dead parent is cleared on the next sweep tick along with all
+		// its Subagents) and skip delete. Mirrors the "no rollback on
+		// partial" Hybrid B+ rule.
+		if !isPidAliveFn(parentStored.PID) {
+			agentpkg.MetricPartialCanonicalizationCreated.Add(1)
+			canonicalizedAny = true
+			anyAncestor = parentStored
+			continue
+		}
+		actualAncestorStart, ancestorErr := processStartTimeFn(parentStored.PID)
+		if ancestorErr != nil || actualAncestorStart != parentStored.ProcessStartTime {
 			agentpkg.MetricPartialCanonicalizationCreated.Add(1)
 			canonicalizedAny = true
 			anyAncestor = parentStored

--- a/internal/module/agent/sweep.go
+++ b/internal/module/agent/sweep.go
@@ -187,55 +187,91 @@ func (m *Module) canonicalizePane(paneID string, broadcastTs int64) {
 		if sterr != nil || actualStart != candidate.ProcessStartTime {
 			continue
 		}
-		// PR-3.5b §2.2.1 — protect candidates that own LIVE state.
-		// Mirrors hot-path canonicalizeDescendantsAfterUpsert via the
-		// shared candidateHasOwnedState helper (frame_ops.go) so any
-		// drift between hot-path and sweep is impossible at compile
-		// time.
-		if candidateHasOwnedState(candidate) {
-			continue
-		}
 		ancestor, found := m.findCanonicalAncestor(candidate, framesByPID)
 		if !found {
 			continue
 		}
-		ref := agentpkg.SubagentRef{
-			ID:              fmt.Sprintf("proxy:%s:%d:%s", candidate.AgentType, candidate.PID, candidate.ProcessStartTime),
-			Type:            candidate.AgentType,
-			StartedAt:       broadcastTs,
-			SourcePID:       candidate.PID,
-			SourceStartTime: candidate.ProcessStartTime,
-			IsProxy:         true,
-		}
-		attached, parentStored, aerr := m.attachProxyRefWithRetry(ancestor, ref, broadcastTs)
-		if aerr != nil || !attached {
-			continue
-		}
-		// Review F1 (round 2 attacker) — revalidate ancestor identity
-		// AFTER attach, BEFORE delete. findCanonicalAncestor only
-		// proves the ancestor was live at classification time; the
-		// ancestor PID may die between then and this point. Without
-		// this gate, we would attach a proxy ref onto a dead parent
-		// and then delete the live child row, severing the only DB
-		// link to the live child until its next hook event (the dead
-		// parent gets cleared on the next sweep tick along with all
-		// its Subagents).
+		// Review F2 (round 2 defender) — owned-state classification
+		// happens AFTER ancestor lookup so we can branch on whether
+		// the parent already claims this candidate via a matching
+		// proxy ref.
 		//
-		// On revalidation failure: leave the proxy ref attached
-		// (idempotent next tick if the parent is gone; harmless if
-		// somehow still alive) and skip delete. The standalone child
-		// row stays and continues to serve until either it is
-		// canonicalized into a healthier ancestor next tick or the
-		// parent is cleared and the ref vanishes with it. Mirrors the
-		// "no rollback on partial" Hybrid B+ rule.
-		if !isPidAliveFn(parentStored.PID) {
-			agentpkg.MetricPartialCanonicalizationCreated.Add(1)
-			canonicalizedAny = true
-			anyAncestor = parentStored
+		// Four cases:
+		//
+		//  parent has ref + owned state    → silent skip (already
+		//                                   canonical at projection
+		//                                   layer; nothing to do; no
+		//                                   broadcast spam every tick)
+		//  parent has ref + no owned state → delete-only path (the
+		//                                   row was a partial leftover
+		//                                   from a successful hot-path
+		//                                   attach + failed delete;
+		//                                   sweep finishes the cleanup)
+		//  parent missing ref + owned state    → attach-only recovery
+		//                                       (the F2 case; closes
+		//                                       round 2 defender high.
+		//                                       Without this, an owned-
+		//                                       state child whose hot
+		//                                       path failed to attach
+		//                                       would never converge —
+		//                                       projection_dedup needs
+		//                                       a proxy ref on the
+		//                                       parent to hide the
+		//                                       child)
+		//  parent missing ref + no owned state → attach + delete (main
+		//                                       canonicalization path)
+		parentHasMatchingProxy := subagentsContainProxySender(ancestor.Subagents, candidate.PID, candidate.ProcessStartTime)
+		ownedState := candidateHasOwnedState(candidate)
+		if parentHasMatchingProxy && ownedState {
 			continue
 		}
-		actualAncestorStart, ancestorErr := processStartTimeFn(parentStored.PID)
-		if ancestorErr != nil || actualAncestorStart != parentStored.ProcessStartTime {
+		parentStored := ancestor
+		if !parentHasMatchingProxy {
+			ref := agentpkg.SubagentRef{
+				ID:              fmt.Sprintf("proxy:%s:%d:%s", candidate.AgentType, candidate.PID, candidate.ProcessStartTime),
+				Type:            candidate.AgentType,
+				StartedAt:       broadcastTs,
+				SourcePID:       candidate.PID,
+				SourceStartTime: candidate.ProcessStartTime,
+				IsProxy:         true,
+			}
+			attached, ps, aerr := m.attachProxyRefWithRetry(ancestor, ref, broadcastTs)
+			if aerr != nil || !attached {
+				continue
+			}
+			parentStored = ps
+			// Review F1 (round 2 attacker) — revalidate ancestor identity
+			// AFTER attach, BEFORE delete. findCanonicalAncestor only
+			// proves the ancestor was live at classification time; the
+			// ancestor PID may die between then and this point. Without
+			// this gate, we would attach a proxy ref onto a dead parent
+			// and then delete the live child row, severing the only DB
+			// link to the live child until its next hook event.
+			//
+			// On revalidation failure: leave the proxy ref attached
+			// (the dead parent is cleared on the next sweep tick along
+			// with all its Subagents) and skip delete. Mirrors the
+			// "no rollback on partial" Hybrid B+ rule.
+			if !isPidAliveFn(parentStored.PID) {
+				agentpkg.MetricPartialCanonicalizationCreated.Add(1)
+				canonicalizedAny = true
+				anyAncestor = parentStored
+				continue
+			}
+			actualAncestorStart, ancestorErr := processStartTimeFn(parentStored.PID)
+			if ancestorErr != nil || actualAncestorStart != parentStored.ProcessStartTime {
+				agentpkg.MetricPartialCanonicalizationCreated.Add(1)
+				canonicalizedAny = true
+				anyAncestor = parentStored
+				continue
+			}
+		}
+		if ownedState {
+			// Review F2 — deliberate partial: attach succeeded (or was
+			// already there), but the candidate carries owned native
+			// state we must not lose. Skip delete; projection_dedup
+			// hides + merges this child's Subagents into the parent
+			// projection at read time.
 			agentpkg.MetricPartialCanonicalizationCreated.Add(1)
 			canonicalizedAny = true
 			anyAncestor = parentStored

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -1141,36 +1141,6 @@ func TestSweep_OwnerReadErrorPreservesFrame(t *testing.T) {
 // freshly-introduced symbol.
 // ---------------------------------------------------------------------------
 
-// canonicalizeWired / broadcastWired are TDD gates flipped to true as
-// commits 7/8 implement canonicalizePane + broadcast. Until then,
-// IT10/IT10b-IT10p integration tests skip via skipUntilCanonicalizeWired
-// / skipUntilBroadcastWired so the test file compiles and the suite
-// stays green.
-//
-// commit 7 flips canonicalizeWired (canonicalizePane + sweep wire);
-// commit 8 flips broadcastWired (broadcastProxyCanonicalized). Both
-// helpers reduce to no-ops once their gate is true and disappear from
-// the diff at the squash level — fewer per-test t.Skip edits to revert
-// across commits.
-var (
-	canonicalizeWired = true
-	broadcastWired    = true
-)
-
-func skipUntilCanonicalizeWired(t *testing.T) {
-	t.Helper()
-	if !canonicalizeWired {
-		t.Skip("PR-3.5b commit 7+: canonicalizePane not yet wired")
-	}
-}
-
-func skipUntilBroadcastWired(t *testing.T) {
-	t.Helper()
-	if !broadcastWired {
-		t.Skip("PR-3.5b commit 8: broadcastProxyCanonicalized not yet wired")
-	}
-}
-
 // installSweepCanonicalSeams sets up the standard seam overrides for
 // IT10 tests: every PID in the alivePIDs/startTimes maps is alive and
 // identity-verified, every other PID is dead. nowFn is pinned close to
@@ -1219,7 +1189,6 @@ func installSweepCanonicalSeams(t *testing.T, alivePIDs map[int]bool, startTimes
 // chain reaches cc) → after sweep: cc.Subagents has codex IsProxy ref;
 // codex frame deleted; MetricSweepCanonicalized +1.
 func TestSweep_CanonicalizesStandaloneDescendantIntoAncestor(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -1266,7 +1235,6 @@ func TestSweep_CanonicalizesStandaloneDescendantIntoAncestor(t *testing.T) {
 // IT10b — candidate identity gate: PID-reused candidate → skip; cc
 // untouched; pid_reused pass cleans the codex frame.
 func TestSweep_CanonicalizeSkipsPidReuseCandidate(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -1310,7 +1278,6 @@ func TestSweep_CanonicalizeSkipsPidReuseCandidate(t *testing.T) {
 // IT10c — candidate identity gate: dead PID candidate → skip; pid_dead
 // pass clears it.
 func TestSweep_CanonicalizeSkipsDeadCandidate(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -1355,7 +1322,6 @@ func TestSweep_CanonicalizeSkipsDeadCandidate(t *testing.T) {
 // is dead → findCanonicalAncestor identity gate skips → no fold; cc is
 // cleared by pid_dead pass.
 func TestSweep_CanonicalizeSkipsWhenAncestorDead(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -1400,7 +1366,6 @@ func TestSweep_CanonicalizeSkipsWhenAncestorDead(t *testing.T) {
 // where the second's PPID chain reaches the first → findCanonicalAncestor
 // returns false (cc → cc is not a proxy relationship); both frames stay.
 func TestSweep_CanonicalizeSkipsSameTypeAncestor(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -1445,7 +1410,6 @@ func TestSweep_CanonicalizeSkipsSameTypeAncestor(t *testing.T) {
 // IT10f — no ancestor frame in the pane: PPID chain walks to init
 // without finding a frame; candidate left alone.
 func TestSweep_CanonicalizeSkipsWhenNoAncestorInPane(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 999,
@@ -1487,7 +1451,6 @@ func TestSweep_CanonicalizeSkipsWhenNoAncestorInPane(t *testing.T) {
 // gate) so when sweep later issues DeleteIfUnchanged with the original
 // LastSeenAt it returns false.
 func TestSweep_CanonicalizePartialWhenDeleteUnchangedFails(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -1590,7 +1553,6 @@ func TestSweep_CanonicalizePartialWhenDeleteUnchangedFails(t *testing.T) {
 // attachProxyRefWithRetry's first UpsertIfUnchanged. The reload via
 // GetByIdentity returns nil → attached=false.
 func TestSweep_CanonicalizePartialWhenAttachFails(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	cc, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -1668,7 +1630,6 @@ func TestSweep_CanonicalizePartialWhenAttachFails(t *testing.T) {
 // Same tick: canonicalize attaches opencode IsProxy → prune detaches
 // stale codex IsProxy. Final cc.Subagents = [opencode IsProxy].
 func TestSweep_CanonicalizeThenPruneSameTick(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -1724,7 +1685,6 @@ func TestSweep_CanonicalizeThenPruneSameTick(t *testing.T) {
 // IT10j — successful canonicalize emits broadcast with reason=
 // sweep:proxy_canonicalized. Verifies broadcast wiring (commit 8).
 func TestSweep_CanonicalizeEmitsBroadcastWhenAnySucceeded(t *testing.T) {
-	skipUntilBroadcastWired(t)
 	m := newSweepTestModule(t)
 	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: m.tmux}
 	sub := m.core.Events.AddTestSubscriber()
@@ -1772,7 +1732,6 @@ func TestSweep_CanonicalizeEmitsBroadcastWhenAnySucceeded(t *testing.T) {
 
 // IT10k — no successful canonicalize → no broadcast emitted.
 func TestSweep_CanonicalizeNoBroadcastWhenNothingSucceeded(t *testing.T) {
-	skipUntilBroadcastWired(t)
 	m := newSweepTestModule(t)
 	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: m.tmux}
 	sub := m.core.Events.AddTestSubscriber()
@@ -1816,7 +1775,6 @@ func TestSweep_CanonicalizeNoBroadcastWhenNothingSucceeded(t *testing.T) {
 // Each pane is canonicalized independently; pane B does not see pane
 // A's ancestor and vice-versa.
 func TestSweep_CanonicalizeCrossPaneIsolation(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	fakeTmux, _ := m.tmux.(*tmux.FakeExecutor)
 	fakeTmux.SetPaneSessionName("%6", "work2")
@@ -1879,7 +1837,6 @@ func TestSweep_CanonicalizeCrossPaneIsolation(t *testing.T) {
 // the standalone row. Final state: cc.Subagents has exactly 1 codex
 // IsProxy ref (no duplicate), codex standalone deleted.
 func TestSweep_CanonicalizeSkipsAlreadyProxiedCandidate(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -1947,7 +1904,6 @@ func TestSweep_CanonicalizeSkipsAlreadyProxiedCandidate(t *testing.T) {
 // the cc projection at read time, hiding the standalone child without
 // data loss.
 func TestSweep_CanonicalizePreservesChildNativeAfterPartialRecovery(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	// (a) cc frame with codex IsProxy already attached.
 	if _, err := m.frames.Upsert(store.Frame{
@@ -2025,7 +1981,6 @@ func TestSweep_CanonicalizePreservesChildNativeAfterPartialRecovery(t *testing.T
 // (stale ref dropped along with the row; equivalent to sweep prune
 // detaching it then sweep folding next tick).
 func TestSweep_CanonicalizeFoldsCandidateWithOnlyStaleProxy(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
@@ -2315,7 +2270,6 @@ func TestFindCanonicalAncestor_ReturnsFalseOnReadProcessInfoTransientError(t *te
 // skipped. The candidate is itself acting as ancestor for some other
 // sub-tree; folding it would lose that role.
 func TestSweep_CanonicalizeSkipsCandidateWithLiveProxy(t *testing.T) {
-	skipUntilCanonicalizeWired(t)
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
 		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -1732,6 +1732,118 @@ func TestSweep_CanonicalizeSkipsDeleteWhenAncestorDiesPostAttach(t *testing.T) {
 	}
 }
 
+// IT10s (review F4 — round 3 closure) — already-proxied delete-only
+// path: when the parent already has a matching IsProxy ref AND the
+// candidate carries no owned state, the F2 reorganization routes
+// straight to DeleteIfUnchanged without going through the attach
+// branch where the F1 post-attach revalidation lives. Same data-loss
+// hazard as F1 reopens through the new path: ancestor can die between
+// findCanonicalAncestor and DeleteIfUnchanged, leaving the live
+// candidate row deleted into a dead parent that the next sweep tick
+// will clear (taking the proxy ref with it).
+//
+// Race trick mirrors IT10q: count isPidAliveFn(ancestor) calls and
+// flip false on the 4th call — the call introduced only by the F4
+// hoisted revalidation. Without F4 the 4th call never runs and the
+// codex row is incorrectly deleted.
+func TestSweep_CanonicalizeSkipsDeleteWhenAncestorDiesPostMatchCheck(t *testing.T) {
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:        "proxy:codex:200:t200",
+			Type:      "codex",
+			StartedAt: 30,
+			SourcePID: 200, SourceStartTime: "t200",
+			IsProxy: true,
+		}},
+		Status: agentpkg.StatusIdle, StartedAt: 30, LastSeenAt: 80, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc with pre-existing proxy: %v", err)
+	}
+	codex, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 51, LastSeenAt: 51, Verified: true,
+	})
+	if err != nil {
+		t.Fatalf("Upsert codex orphan: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origInfo := readProcessInfoFn
+	origNow := nowFn
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		readProcessInfoFn = origInfo
+		nowFn = origNow
+	})
+
+	pid100AliveCalls := 0
+	isPidAliveFn = func(pid int) bool {
+		switch pid {
+		case 100:
+			pid100AliveCalls++
+			// Calls 1-3: survivor pass + cc-as-candidate gate +
+			// findCanonicalAncestor. Call 4 (only reachable via
+			// F4 hoisted revalidation) reports cc dead.
+			return pid100AliveCalls < 4
+		case 200:
+			return true
+		}
+		return false
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "", errStub("ps unknown pid")
+	}
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		ppid := 1
+		if pid == 200 {
+			ppid = 100
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: ppid}, nil
+	}
+	nowFn = func() time.Time { return time.Unix(0, 100) }
+
+	startSweep := agentpkg.MetricSweepCanonicalized.Value()
+	startPartial := agentpkg.MetricPartialCanonicalizationCreated.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	var ccRow, codexRow *store.Frame
+	for i := range frames {
+		switch frames[i].AgentType {
+		case "cc":
+			ccRow = &frames[i]
+		case "codex":
+			codexRow = &frames[i]
+		}
+	}
+	if codexRow == nil || codexRow.FrameID != codex.FrameID {
+		t.Fatalf("codex row missing or replaced; want preserved live row, got frames = %+v", frames)
+	}
+	if ccRow == nil || len(ccRow.Subagents) != 1 || !ccRow.Subagents[0].IsProxy || ccRow.Subagents[0].SourcePID != 200 {
+		t.Fatalf("cc row = %+v, want pre-existing IsProxy ref intact", ccRow)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startSweep; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (delete skipped because ancestor died after match-check)", delta)
+	}
+	if delta := agentpkg.MetricPartialCanonicalizationCreated.Value() - startPartial; delta != 1 {
+		t.Fatalf("MetricPartialCanonicalizationCreated delta = %d, want 1 (deliberate partial — F4 hoisted revalidation)", delta)
+	}
+}
+
 // IT10i — canonicalize → prune ordering in the same tick. cc has a
 // stale codex IsProxy ref AND a live opencode descendant standalone.
 // Same tick: canonicalize attaches opencode IsProxy → prune detaches

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -2067,6 +2067,248 @@ func TestSweep_CanonicalizeFoldsCandidateWithOnlyStaleProxy(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// PR-3.5b §3.2 — findCanonicalAncestor unit tests (RC6-RC11).
+//
+// Pure helper — no DB I/O. Each test seeds a framesByPID map and
+// exercises one return path: cross-type match, same-type hard-stop,
+// dead/PID-reused identity gate fail-safe, depth exhaustion, self-loop
+// detection, and readProcessInfoFn transient error.
+// ---------------------------------------------------------------------------
+
+func newCanonicalAncestorTestModule(t *testing.T) *Module {
+	t.Helper()
+	return newSweepTestModule(t)
+}
+
+// RC6 — happy path: descendant walks one PPID hop, finds cross-type
+// ancestor frame in pane, ancestor passes identity gate → returns (frame, true).
+func TestFindCanonicalAncestor_WalksToCrossTypeMatch(t *testing.T) {
+	m := newCanonicalAncestorTestModule(t)
+	cc := store.Frame{
+		FrameID: "cc-1", PaneID: "%5", AgentType: "cc",
+		PID: 100, PPID: 1, ProcessStartTime: "t100",
+	}
+	candidate := store.Frame{
+		FrameID: "codex-1", PaneID: "%5", AgentType: "codex",
+		PID: 200, PPID: 100, ProcessStartTime: "t200",
+	}
+	framesByPID := map[int]store.Frame{100: cc, 200: candidate}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 100 {
+			return "t100", nil
+		}
+		return "other", nil
+	}
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	ancestor, ok := m.findCanonicalAncestor(candidate, framesByPID)
+	if !ok || ancestor.PID != 100 || ancestor.AgentType != "cc" {
+		t.Fatalf("findCanonicalAncestor = (%+v, %v), want cc PID=100", ancestor, ok)
+	}
+}
+
+// RC7 — same-type immediate match → returns false (not a proxy
+// relationship; mirrors findProxyParent hard-stop).
+func TestFindCanonicalAncestor_ReturnsFalseOnSameTypeImmediateMatch(t *testing.T) {
+	m := newCanonicalAncestorTestModule(t)
+	parent := store.Frame{
+		FrameID: "cc-1", PaneID: "%5", AgentType: "cc",
+		PID: 100, PPID: 1, ProcessStartTime: "t100",
+	}
+	candidate := store.Frame{
+		FrameID: "cc-2", PaneID: "%5", AgentType: "cc",
+		PID: 200, PPID: 100, ProcessStartTime: "t200",
+	}
+	framesByPID := map[int]store.Frame{100: parent, 200: candidate}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		if pid == 200 {
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "t100", nil }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	if _, ok := m.findCanonicalAncestor(candidate, framesByPID); ok {
+		t.Fatal("findCanonicalAncestor = true, want false (same-type ancestor must hard-stop)")
+	}
+}
+
+// RC8 — ancestor PID dead → identity gate fail-safe; helper continues
+// walking (next ppid hop). When chain exhausts without finding a live
+// match, returns false.
+func TestFindCanonicalAncestor_ReturnsFalseOnDeadAncestorIdentityGate(t *testing.T) {
+	m := newCanonicalAncestorTestModule(t)
+	cc := store.Frame{
+		FrameID: "cc-1", PaneID: "%5", AgentType: "cc",
+		PID: 100, PPID: 1, ProcessStartTime: "t100",
+	}
+	candidate := store.Frame{
+		FrameID: "codex-1", PaneID: "%5", AgentType: "codex",
+		PID: 200, PPID: 100, ProcessStartTime: "t200",
+	}
+	framesByPID := map[int]store.Frame{100: cc, 200: candidate}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 100}, nil
+		case 100:
+			return agentpkg.ProcessInfo{PID: 100, PPID: 1}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	// PID 100 (cc) is DEAD.
+	isPidAliveFn = func(pid int) bool { return pid != 100 }
+	processStartTimeFn = func(int) (string, error) { return "t100", nil }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	if _, ok := m.findCanonicalAncestor(candidate, framesByPID); ok {
+		t.Fatal("findCanonicalAncestor = true, want false (dead ancestor identity gate must skip)")
+	}
+}
+
+// RC9 — depth exhaustion: long PPID chain with no frame match within
+// proxyMaxDepth → false.
+func TestFindCanonicalAncestor_ReturnsFalseOnDepthExhaustion(t *testing.T) {
+	m := newCanonicalAncestorTestModule(t)
+	candidate := store.Frame{
+		FrameID: "codex-1", PaneID: "%5", AgentType: "codex",
+		PID: 200, PPID: 1000, ProcessStartTime: "t200",
+	}
+	// PPID chain: 200 → 1000 → 1001 → 1002 → 1003 → 1004 → 1005 (still
+	// no frame in pane; depth cap stops after 5 hops).
+	framesByPID := map[int]store.Frame{200: candidate}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 1000}, nil
+		case 1000:
+			return agentpkg.ProcessInfo{PID: 1000, PPID: 1001}, nil
+		case 1001:
+			return agentpkg.ProcessInfo{PID: 1001, PPID: 1002}, nil
+		case 1002:
+			return agentpkg.ProcessInfo{PID: 1002, PPID: 1003}, nil
+		case 1003:
+			return agentpkg.ProcessInfo{PID: 1003, PPID: 1004}, nil
+		case 1004:
+			return agentpkg.ProcessInfo{PID: 1004, PPID: 1005}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: pid + 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "irrelevant", nil }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	if _, ok := m.findCanonicalAncestor(candidate, framesByPID); ok {
+		t.Fatal("findCanonicalAncestor = true, want false (depth exhausted)")
+	}
+}
+
+// RC10 — self-loop: ancestor's PPID equals its own PID → false.
+func TestFindCanonicalAncestor_ReturnsFalseOnLoopDetectionPpidEqPid(t *testing.T) {
+	m := newCanonicalAncestorTestModule(t)
+	candidate := store.Frame{
+		FrameID: "codex-1", PaneID: "%5", AgentType: "codex",
+		PID: 200, PPID: 1000, ProcessStartTime: "t200",
+	}
+	framesByPID := map[int]store.Frame{200: candidate}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		switch pid {
+		case 200:
+			return agentpkg.ProcessInfo{PID: 200, PPID: 1000}, nil
+		case 1000:
+			// Self-loop: PPID == PID.
+			return agentpkg.ProcessInfo{PID: 1000, PPID: 1000}, nil
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: 1}, nil
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "irrelevant", nil }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	if _, ok := m.findCanonicalAncestor(candidate, framesByPID); ok {
+		t.Fatal("findCanonicalAncestor = true, want false (self-loop must abort walk)")
+	}
+}
+
+// RC11 — readProcessInfoFn returns transient error → false (caller
+// retries next sweep tick).
+func TestFindCanonicalAncestor_ReturnsFalseOnReadProcessInfoTransientError(t *testing.T) {
+	m := newCanonicalAncestorTestModule(t)
+	candidate := store.Frame{
+		FrameID: "codex-1", PaneID: "%5", AgentType: "codex",
+		PID: 200, PPID: 100, ProcessStartTime: "t200",
+	}
+	framesByPID := map[int]store.Frame{200: candidate}
+
+	origInfo := readProcessInfoFn
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		return agentpkg.ProcessInfo{}, errStub("proc transient")
+	}
+	isPidAliveFn = func(int) bool { return true }
+	processStartTimeFn = func(int) (string, error) { return "irrelevant", nil }
+	t.Cleanup(func() {
+		readProcessInfoFn = origInfo
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+	})
+
+	if _, ok := m.findCanonicalAncestor(candidate, framesByPID); ok {
+		t.Fatal("findCanonicalAncestor = true, want false (transient read error must abort)")
+	}
+}
+
 // IT10p — candidate carrying a LIVE identity-verified IsProxy ref is
 // skipped. The candidate is itself acting as ancestor for some other
 // sub-tree; folding it would lose that role.

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -1154,7 +1154,7 @@ func TestSweep_OwnerReadErrorPreservesFrame(t *testing.T) {
 // across commits.
 var (
 	canonicalizeWired = true
-	broadcastWired    = false
+	broadcastWired    = true
 )
 
 func skipUntilCanonicalizeWired(t *testing.T) {

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -1125,3 +1125,994 @@ func TestSweep_OwnerReadErrorPreservesFrame(t *testing.T) {
 		t.Fatalf("ProcessStartTime = %q, want A (frame untouched)", frames[0].ProcessStartTime)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PR-3.5b §3.1 — sweep canonicalizePane (defense-in-depth backstop for
+// hot-path canonicalization paths that left a partial state).
+//
+// IT10/IT10b-IT10p: integration tests driven through m.sweepOnce(). When
+// they're committed (commit 5 of the PR), canonicalizePane does not yet
+// exist; tests are therefore guarded with t.Skip("PR-3.5b commit 7: ...")
+// so the test file compiles and the suite stays green. Skips are removed
+// in commits 7 and 8 once canonicalizePane and broadcast are implemented.
+//
+// RC6-RC11: findCanonicalAncestor unit tests are added in commit 6 along
+// with the helper itself, so they don't need t.Skip — they target a
+// freshly-introduced symbol.
+// ---------------------------------------------------------------------------
+
+// canonicalizeWired / broadcastWired are TDD gates flipped to true as
+// commits 7/8 implement canonicalizePane + broadcast. Until then,
+// IT10/IT10b-IT10p integration tests skip via skipUntilCanonicalizeWired
+// / skipUntilBroadcastWired so the test file compiles and the suite
+// stays green.
+//
+// commit 7 flips canonicalizeWired (canonicalizePane + sweep wire);
+// commit 8 flips broadcastWired (broadcastProxyCanonicalized). Both
+// helpers reduce to no-ops once their gate is true and disappear from
+// the diff at the squash level — fewer per-test t.Skip edits to revert
+// across commits.
+var (
+	canonicalizeWired = false
+	broadcastWired    = false
+)
+
+func skipUntilCanonicalizeWired(t *testing.T) {
+	t.Helper()
+	if !canonicalizeWired {
+		t.Skip("PR-3.5b commit 7+: canonicalizePane not yet wired")
+	}
+}
+
+func skipUntilBroadcastWired(t *testing.T) {
+	t.Helper()
+	if !broadcastWired {
+		t.Skip("PR-3.5b commit 8: broadcastProxyCanonicalized not yet wired")
+	}
+}
+
+// installSweepCanonicalSeams sets up the standard seam overrides for
+// IT10 tests: every PID in the alivePIDs/startTimes maps is alive and
+// identity-verified, every other PID is dead. nowFn is pinned close to
+// the seeded LastSeenAt so the idle_timeout rule does not fire on
+// fixture frames. PPID for any PID not in ppids is 1 (init) — caller
+// passes only the PIDs that need a non-trivial chain.
+//
+// Returns a cleanup that restores all seams; caller wires it through
+// t.Cleanup so each test gets isolated state.
+func installSweepCanonicalSeams(t *testing.T, alivePIDs map[int]bool, startTimes map[int]string, ppids map[int]int) {
+	t.Helper()
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origInfo := readProcessInfoFn
+	origNow := nowFn
+
+	isPidAliveFn = func(pid int) bool {
+		return alivePIDs[pid]
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		st, ok := startTimes[pid]
+		if !ok {
+			return "", errStub("ps unknown pid")
+		}
+		return st, nil
+	}
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		ppid := 1
+		if v, ok := ppids[pid]; ok {
+			ppid = v
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: ppid}, nil
+	}
+	nowFn = func() time.Time { return time.Unix(0, 100) }
+
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		readProcessInfoFn = origInfo
+		nowFn = origNow
+	})
+}
+
+// IT10 — sweep canonicalizes a standalone live cross-type descendant
+// into its ancestor's proxy ref. cc parent + codex standalone (PPID
+// chain reaches cc) → after sweep: cc.Subagents has codex IsProxy ref;
+// codex frame deleted; MetricSweepCanonicalized +1.
+func TestSweep_CanonicalizesStandaloneDescendantIntoAncestor(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex standalone: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: true},
+		map[int]string{100: "t100", 200: "t200"},
+		map[int]int{200: 100, 100: 1},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("frames = %+v, want only cc remaining (codex folded into proxy ref)", frames)
+	}
+	if len(frames[0].Subagents) != 1 {
+		t.Fatalf("cc.Subagents = %+v, want 1 codex IsProxy ref", frames[0].Subagents)
+	}
+	ref := frames[0].Subagents[0]
+	if !ref.IsProxy || ref.SourcePID != 200 || ref.Type != "codex" {
+		t.Fatalf("ref = %+v, want codex IsProxy SourcePID=200", ref)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 1 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 1", delta)
+	}
+}
+
+// IT10b — candidate identity gate: PID-reused candidate → skip; cc
+// untouched; pid_reused pass cleans the codex frame.
+func TestSweep_CanonicalizeSkipsPidReuseCandidate(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200-stale", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex stale: %v", err)
+	}
+
+	// PID 200 alive but identity changed → pid_reused pass clears it.
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: true},
+		map[int]string{100: "t100", 200: "t200-fresh"},
+		map[int]int{200: 100},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("frames = %+v, want only cc (codex pid_reused-cleared, never canonicalized)", frames)
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("cc.Subagents = %+v, want empty (pid-reused candidate must not be canonicalized)", frames[0].Subagents)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (gated)", delta)
+	}
+}
+
+// IT10c — candidate identity gate: dead PID candidate → skip; pid_dead
+// pass clears it.
+func TestSweep_CanonicalizeSkipsDeadCandidate(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex dead: %v", err)
+	}
+
+	// PID 200 dead → pid_dead pass clears it.
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: false},
+		map[int]string{100: "t100", 200: "t200"},
+		map[int]int{200: 100},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("frames = %+v, want only cc remaining (codex pid_dead-cleared)", frames)
+	}
+	if len(frames[0].Subagents) != 0 {
+		t.Fatalf("cc.Subagents = %+v, want empty (dead candidate must not be canonicalized)", frames[0].Subagents)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (gated)", delta)
+	}
+}
+
+// IT10d — ancestor identity gate: candidate live but ancestor (cc) PID
+// is dead → findCanonicalAncestor identity gate skips → no fold; cc is
+// cleared by pid_dead pass.
+func TestSweep_CanonicalizeSkipsWhenAncestorDead(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex: %v", err)
+	}
+
+	// cc (PID 100) dead, codex (200) alive.
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: false, 200: true},
+		map[int]string{100: "t100", 200: "t200"},
+		map[int]int{200: 100},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	// cc cleared by pid_dead. Codex remains standalone (no ancestor to
+	// fold into; ancestor identity gate kept candidate from being
+	// attached to a dead frame about to be removed).
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "codex" {
+		t.Fatalf("frames = %+v, want only codex (cc pid_dead-cleared, codex left for next tick)", frames)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (ancestor dead gated)", delta)
+	}
+}
+
+// IT10e — same-type ancestor short-circuit: two cc standalone frames
+// where the second's PPID chain reaches the first → findCanonicalAncestor
+// returns false (cc → cc is not a proxy relationship); both frames stay.
+func TestSweep_CanonicalizeSkipsSameTypeAncestor(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc-1: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 110, PPID: 100,
+		ProcessStartTime: "t110", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc-2: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 110: true},
+		map[int]string{100: "t100", 110: "t110"},
+		map[int]int{110: 100},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frames = %+v, want 2 (same-type ancestor not a proxy relationship)", frames)
+	}
+	for _, f := range frames {
+		if len(f.Subagents) != 0 {
+			t.Fatalf("frame %s Subagents = %+v, want empty (same-type fold suppressed)", f.FrameID, f.Subagents)
+		}
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (same-type)", delta)
+	}
+}
+
+// IT10f — no ancestor frame in the pane: PPID chain walks to init
+// without finding a frame; candidate left alone.
+func TestSweep_CanonicalizeSkipsWhenNoAncestorInPane(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 999,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex: %v", err)
+	}
+
+	// PPID chain: 200 → 999 → 1 (init). Neither 999 nor 1 has a frame
+	// in the pane.
+	installSweepCanonicalSeams(t,
+		map[int]bool{200: true, 999: true},
+		map[int]string{200: "t200", 999: "t999"},
+		map[int]int{200: 999, 999: 1},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "codex" {
+		t.Fatalf("frames = %+v, want codex preserved (no ancestor)", frames)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0", delta)
+	}
+}
+
+// IT10g — partial: DeleteIfUnchanged fails (concurrent refresh bumps
+// LastSeenAt baseline). Attach succeeds → cc.Subagents has codex IsProxy
+// ref; codex standalone remains; metric NOT incremented (per plan: success
+// = attach + delete both).
+//
+// Race trick: bump candidate LastSeenAt via Upsert during the
+// processStartTimeFn callback for PID 200 (called by candidate identity
+// gate) so when sweep later issues DeleteIfUnchanged with the original
+// LastSeenAt it returns false.
+func TestSweep_CanonicalizePartialWhenDeleteUnchangedFails(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	codex, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	})
+	if err != nil {
+		t.Fatalf("Upsert codex: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origInfo := readProcessInfoFn
+	origNow := nowFn
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		readProcessInfoFn = origInfo
+		nowFn = origNow
+	})
+
+	isPidAliveFn = func(pid int) bool { return pid == 100 || pid == 200 }
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		ppid := 1
+		if pid == 200 {
+			ppid = 100
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: ppid}, nil
+	}
+	// On the candidate's second start_time read (the one inside
+	// canonicalizePane after sweepOnce's main loop already saw it),
+	// race a concurrent refresh that bumps codex.LastSeenAt — defeating
+	// DeleteIfUnchanged's optimistic check.
+	bumped := false
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			if !bumped {
+				bumped = true
+				// Upsert a new codex row with bumped LastSeenAt.
+				_, _ = m.frames.Upsert(store.Frame{
+					FrameID:          codex.FrameID,
+					PaneID:           "%5",
+					AgentType:        "codex",
+					PID:              200,
+					PPID:             100,
+					ProcessStartTime: "t200",
+					Status:           agentpkg.StatusRunning,
+					StartedAt:        50,
+					LastSeenAt:       80, // bumped
+					Verified:         true,
+				})
+			}
+			return "t200", nil
+		}
+		return "", errStub("ps unknown pid")
+	}
+	nowFn = func() time.Time { return time.Unix(0, 100) }
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frames = %+v, want 2 (partial: attach success, delete failure)", frames)
+	}
+	var ccRow *store.Frame
+	for i := range frames {
+		if frames[i].AgentType == "cc" {
+			ccRow = &frames[i]
+		}
+	}
+	if ccRow == nil || len(ccRow.Subagents) != 1 || !ccRow.Subagents[0].IsProxy {
+		t.Fatalf("cc row = %+v, want exactly 1 IsProxy ref attached", ccRow)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (partial → not counted)", delta)
+	}
+}
+
+// IT10h — partial: attach fails because ancestor vanishes mid-attach
+// (concurrent SessionEnd / sweep). codex frame remains; cc deleted; no
+// fold metric increment.
+//
+// Race trick: in processStartTimeFn for ancestor (PID 100) — called by
+// findCanonicalAncestor's identity gate — delete cc row before
+// attachProxyRefWithRetry's first UpsertIfUnchanged. The reload via
+// GetByIdentity returns nil → attached=false.
+func TestSweep_CanonicalizePartialWhenAttachFails(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	cc, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	})
+	if err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origInfo := readProcessInfoFn
+	origNow := nowFn
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		readProcessInfoFn = origInfo
+		nowFn = origNow
+	})
+
+	isPidAliveFn = func(pid int) bool { return pid == 100 || pid == 200 }
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		ppid := 1
+		if pid == 200 {
+			ppid = 100
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: ppid}, nil
+	}
+	// On the second processStartTimeFn(100) call (findCanonicalAncestor
+	// identity gate, after candidate's own gate already ran on PID 200),
+	// delete cc row so attachProxyRefWithRetry's UpsertIfUnchanged
+	// detects a missing row and returns attached=false.
+	pid100Calls := 0
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			pid100Calls++
+			if pid100Calls == 1 {
+				// findCanonicalAncestor's identity gate. Race: delete
+				// cc row before attachProxyRefWithRetry can run.
+				_ = m.frames.Delete(cc.FrameID)
+			}
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "", errStub("ps unknown pid")
+	}
+	nowFn = func() time.Time { return time.Unix(0, 100) }
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "codex" {
+		t.Fatalf("frames = %+v, want only codex (cc deleted mid-attach; partial → no rollback)", frames)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (attach failed)", delta)
+	}
+}
+
+// IT10i — canonicalize → prune ordering in the same tick. cc has a
+// stale codex IsProxy ref AND a live opencode descendant standalone.
+// Same tick: canonicalize attaches opencode IsProxy → prune detaches
+// stale codex IsProxy. Final cc.Subagents = [opencode IsProxy].
+func TestSweep_CanonicalizeThenPruneSameTick(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100",
+		Subagents: []agentpkg.SubagentRef{{
+			ID: "proxy:codex:300:dead", Type: "codex",
+			SourcePID: 300, SourceStartTime: "dead-t300", IsProxy: true,
+		}},
+		Status: agentpkg.StatusIdle, StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc + stale ref: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "opencode", PID: 400, PPID: 100,
+		ProcessStartTime: "t400", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert opencode standalone: %v", err)
+	}
+
+	// PIDs alive: 100 (cc), 400 (opencode); PID 300 (stale source) DEAD.
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 400: true, 300: false},
+		map[int]string{100: "t100", 400: "t400", 300: "ignored"},
+		map[int]int{400: 100},
+	)
+
+	startCan := agentpkg.MetricSweepCanonicalized.Value()
+	startPrune := agentpkg.MetricSweepPrunedProxy.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("frames = %+v, want only cc (opencode folded)", frames)
+	}
+	if len(frames[0].Subagents) != 1 {
+		t.Fatalf("cc.Subagents = %+v, want exactly 1 (stale codex pruned, opencode attached)", frames[0].Subagents)
+	}
+	ref := frames[0].Subagents[0]
+	if ref.SourcePID != 400 || ref.Type != "opencode" {
+		t.Fatalf("ref = %+v, want opencode IsProxy SourcePID=400 (stale codex 300 should be pruned)", ref)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startCan; delta != 1 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 1", delta)
+	}
+	if delta := agentpkg.MetricSweepPrunedProxy.Value() - startPrune; delta != 1 {
+		t.Fatalf("MetricSweepPrunedProxy delta = %d, want 1", delta)
+	}
+}
+
+// IT10j — successful canonicalize emits broadcast with reason=
+// sweep:proxy_canonicalized. Verifies broadcast wiring (commit 8).
+func TestSweep_CanonicalizeEmitsBroadcastWhenAnySucceeded(t *testing.T) {
+	skipUntilBroadcastWired(t)
+	m := newSweepTestModule(t)
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: m.tmux}
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: true},
+		map[int]string{100: "t100", 200: "t200"},
+		map[int]int{200: 100},
+	)
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	// Look through the broadcast channel for the canonicalized event.
+	deadline := time.After(200 * time.Millisecond)
+	gotCanonicalized := false
+	for !gotCanonicalized {
+		select {
+		case msg := <-sub.SendCh():
+			if strings.Contains(string(msg), "sweep:proxy_canonicalized") {
+				gotCanonicalized = true
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for sweep:proxy_canonicalized broadcast")
+		}
+	}
+}
+
+// IT10k — no successful canonicalize → no broadcast emitted.
+func TestSweep_CanonicalizeNoBroadcastWhenNothingSucceeded(t *testing.T) {
+	skipUntilBroadcastWired(t)
+	m := newSweepTestModule(t)
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: m.tmux}
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	// Single isolated codex frame; PPID chain doesn't reach any pane
+	// frame → findCanonicalAncestor false → no fold → no broadcast.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 999,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{200: true, 999: true},
+		map[int]string{200: "t200", 999: "t999"},
+		map[int]int{200: 999, 999: 1},
+	)
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	// Drain channel briefly; assert no proxy_canonicalized broadcast.
+	timeout := time.After(80 * time.Millisecond)
+	for {
+		select {
+		case msg := <-sub.SendCh():
+			if strings.Contains(string(msg), "sweep:proxy_canonicalized") {
+				t.Fatalf("unexpected broadcast: %s", msg)
+			}
+		case <-timeout:
+			return
+		}
+	}
+}
+
+// IT10l — cross-pane isolation: pane A foldable; pane B not foldable.
+// Each pane is canonicalized independently; pane B does not see pane
+// A's ancestor and vice-versa.
+func TestSweep_CanonicalizeCrossPaneIsolation(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	fakeTmux, _ := m.tmux.(*tmux.FakeExecutor)
+	fakeTmux.SetPaneSessionName("%6", "work2")
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{
+		{Code: "work-code", Name: "work"},
+		{Code: "work2-code", Name: "work2"},
+	}}
+
+	// Pane A: cc + codex foldable.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc paneA: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex paneA: %v", err)
+	}
+	// Pane B: lone codex; no ancestor frame in pane.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%6", AgentType: "codex", PID: 300, PPID: 999,
+		ProcessStartTime: "t300", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex paneB: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: true, 300: true, 999: true},
+		map[int]string{100: "t100", 200: "t200", 300: "t300", 999: "t999"},
+		map[int]int{200: 100, 300: 999, 999: 1},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	paneA, _ := m.frames.ListByPane("%5")
+	if len(paneA) != 1 || paneA[0].AgentType != "cc" || len(paneA[0].Subagents) != 1 {
+		t.Fatalf("paneA = %+v, want cc with 1 codex IsProxy ref", paneA)
+	}
+	paneB, _ := m.frames.ListByPane("%6")
+	if len(paneB) != 1 || paneB[0].AgentType != "codex" {
+		t.Fatalf("paneB = %+v, want codex untouched (no ancestor)", paneB)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 1 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 1 (pane A only)", delta)
+	}
+}
+
+// IT10m — already-proxied historical partial: hot-path attached the
+// proxy ref then DeleteIfUnchanged failed long ago. Sweep re-attaches
+// idempotently (mutateSubagentsWithRetry replace by match), then deletes
+// the standalone row. Final state: cc.Subagents has exactly 1 codex
+// IsProxy ref (no duplicate), codex standalone deleted.
+func TestSweep_CanonicalizeSkipsAlreadyProxiedCandidate(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:        "proxy:codex:200:t200",
+			Type:      "codex",
+			StartedAt: 50,
+			SourcePID: 200, SourceStartTime: "t200",
+			IsProxy: true,
+		}},
+		Status: agentpkg.StatusIdle, StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc with pre-existing proxy: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex orphan: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: true},
+		map[int]string{100: "t100", 200: "t200"},
+		map[int]int{200: 100},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("frames = %+v, want only cc remaining (codex re-canonicalized)", frames)
+	}
+	if len(frames[0].Subagents) != 1 {
+		t.Fatalf("cc.Subagents = %+v, want exactly 1 (idempotent re-attach, no duplicate)", frames[0].Subagents)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 1 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 1", delta)
+	}
+}
+
+// IT10n — round 1 high regression guard (v3): sweep must NOT erase a
+// child's native subagent state during partial recovery.
+//
+// Scenario (recreating the original round 1 high data-loss path):
+//   (a) cc frame with codex IsProxy already attached (hot-path success)
+//   (b) codex standalone row still present (hot-path DeleteIfUnchanged
+//       failed in the past)
+//   (c) codex.Subagents has a native ref (subsequent SubagentStart on
+//       child landed before sweep)
+//   (d) codex.LastSeenAt was bumped by that SubagentStart so the
+//       hot-path's saved baseline would not match
+//
+// Without candidateHasOwnedState(), sweep would attach a duplicate codex
+// IsProxy ref to cc (or no-op via idempotent retry) and then delete
+// the codex row — losing the native ref. With the guard, candidate skips,
+// codex row + native ref preserved, no re-attach, metric unchanged.
+//
+// Projection_dedup (PR-3.5a) continues to merge codex's native into
+// the cc projection at read time, hiding the standalone child without
+// data loss.
+func TestSweep_CanonicalizePreservesChildNativeAfterPartialRecovery(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	// (a) cc frame with codex IsProxy already attached.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:        "proxy:codex:200:t200",
+			Type:      "codex",
+			StartedAt: 30,
+			SourcePID: 200, SourceStartTime: "t200",
+			IsProxy: true,
+		}},
+		Status: agentpkg.StatusIdle, StartedAt: 30, LastSeenAt: 80, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc + existing codex IsProxy: %v", err)
+	}
+	// (b)+(c)+(d) codex standalone row still present, with native ref,
+	// LastSeenAt bumped past hot-path baseline.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:        "task-1",
+			Type:      "codex",
+			StartedAt: 70,
+			IsProxy:   false, // NATIVE — must be preserved
+		}},
+		Status: agentpkg.StatusRunning, StartedAt: 50, LastSeenAt: 80, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex + native ref + bumped LastSeenAt: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: true},
+		map[int]string{100: "t100", 200: "t200"},
+		map[int]int{200: 100},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frames = %+v, want 2 (codex row preserved, candidate has owned native state)", frames)
+	}
+	var cc, codex *store.Frame
+	for i := range frames {
+		switch frames[i].AgentType {
+		case "cc":
+			cc = &frames[i]
+		case "codex":
+			codex = &frames[i]
+		}
+	}
+	if cc == nil || codex == nil {
+		t.Fatalf("frames = %+v, missing cc or codex", frames)
+	}
+	if len(cc.Subagents) != 1 {
+		t.Fatalf("cc.Subagents = %+v, want exactly 1 codex IsProxy (no duplicate from re-attach)", cc.Subagents)
+	}
+	if !cc.Subagents[0].IsProxy || cc.Subagents[0].SourcePID != 200 {
+		t.Fatalf("cc.Subagents[0] = %+v, want codex IsProxy SourcePID=200", cc.Subagents[0])
+	}
+	if len(codex.Subagents) != 1 || codex.Subagents[0].IsProxy || codex.Subagents[0].ID != "task-1" {
+		t.Fatalf("codex.Subagents = %+v, want native task-1 preserved (round 1 high guard)", codex.Subagents)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (gated case must not count as progress)", delta)
+	}
+}
+
+// IT10o — candidate carrying ONLY stale (dead) IsProxy refs is folded
+// (stale ref dropped along with the row; equivalent to sweep prune
+// detaching it then sweep folding next tick).
+func TestSweep_CanonicalizeFoldsCandidateWithOnlyStaleProxy(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200",
+		Subagents: []agentpkg.SubagentRef{{
+			ID: "proxy:opencode:888:dead", Type: "opencode",
+			SourcePID: 888, SourceStartTime: "dead", IsProxy: true,
+		}},
+		Status: agentpkg.StatusRunning, StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex with only-stale proxy: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: true, 888: false},
+		map[int]string{100: "t100", 200: "t200", 888: "ignored"},
+		map[int]int{200: 100},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 1 || frames[0].AgentType != "cc" {
+		t.Fatalf("frames = %+v, want only cc (codex folded)", frames)
+	}
+	if len(frames[0].Subagents) != 1 || frames[0].Subagents[0].SourcePID != 200 {
+		t.Fatalf("cc.Subagents = %+v, want codex IsProxy SourcePID=200", frames[0].Subagents)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 1 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 1", delta)
+	}
+}
+
+// IT10p — candidate carrying a LIVE identity-verified IsProxy ref is
+// skipped. The candidate is itself acting as ancestor for some other
+// sub-tree; folding it would lose that role.
+func TestSweep_CanonicalizeSkipsCandidateWithLiveProxy(t *testing.T) {
+	skipUntilCanonicalizeWired(t)
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200",
+		Subagents: []agentpkg.SubagentRef{{
+			ID: "proxy:opencode:300:t300", Type: "opencode",
+			SourcePID: 300, SourceStartTime: "t300", IsProxy: true,
+		}},
+		Status: agentpkg.StatusRunning, StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex with live proxy: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: true, 300: true},
+		map[int]string{100: "t100", 200: "t200", 300: "t300"},
+		map[int]int{200: 100},
+	)
+
+	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frames = %+v, want 2 (codex preserved as sub-ancestor)", frames)
+	}
+	for _, f := range frames {
+		if f.AgentType == "cc" && len(f.Subagents) != 0 {
+			t.Fatalf("cc.Subagents = %+v, want empty (codex must not be folded — owns live IsProxy)", f.Subagents)
+		}
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (gated)", delta)
+	}
+}

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -1625,6 +1625,113 @@ func TestSweep_CanonicalizePartialWhenAttachFails(t *testing.T) {
 	}
 }
 
+// IT10q (review F1 — round 2 attacker) — ancestor dies between
+// findCanonicalAncestor's identity gate and DeleteIfUnchanged. Without
+// the post-attach revalidation, sweep would attach codex IsProxy on
+// cc (succeeds), then delete the live codex standalone row, leaving
+// the live codex process with NO DB representation until its next
+// hook event (the dead cc row is cleared on the next sweep tick along
+// with its Subagents, severing the only link).
+//
+// Race trick: count isPidAliveFn(100) calls. Without F1 fix, exactly
+// three calls happen — sweepOnce survivor (1), candidate=cc gate (2),
+// findCanonicalAncestor when iterating codex (3). With F1 fix, the
+// post-attach revalidation adds a 4th call. Returning false on the
+// 4th call simulates cc dying after attach succeeded but before the
+// candidate row was deleted; sweep must skip delete and leave the
+// codex row standing.
+func TestSweep_CanonicalizeSkipsDeleteWhenAncestorDiesPostAttach(t *testing.T) {
+	m := newSweepTestModule(t)
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100", Status: agentpkg.StatusIdle,
+		StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	codex, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200", Status: agentpkg.StatusRunning,
+		StartedAt: 51, LastSeenAt: 51, Verified: true,
+	})
+	if err != nil {
+		t.Fatalf("Upsert codex: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origInfo := readProcessInfoFn
+	origNow := nowFn
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		readProcessInfoFn = origInfo
+		nowFn = origNow
+	})
+
+	pid100AliveCalls := 0
+	isPidAliveFn = func(pid int) bool {
+		switch pid {
+		case 100:
+			pid100AliveCalls++
+			// First three calls (survivor pass + cc-as-candidate gate +
+			// findCanonicalAncestor for codex) say alive. The 4th call
+			// — only reachable with the F1 post-attach revalidation —
+			// reports cc as dead.
+			return pid100AliveCalls < 4
+		case 200:
+			return true
+		}
+		return false
+	}
+	processStartTimeFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "t100", nil
+		case 200:
+			return "t200", nil
+		}
+		return "", errStub("ps unknown pid")
+	}
+	readProcessInfoFn = func(pid int) (agentpkg.ProcessInfo, error) {
+		ppid := 1
+		if pid == 200 {
+			ppid = 100
+		}
+		return agentpkg.ProcessInfo{PID: pid, PPID: ppid}, nil
+	}
+	nowFn = func() time.Time { return time.Unix(0, 100) }
+
+	startSweep := agentpkg.MetricSweepCanonicalized.Value()
+	startPartial := agentpkg.MetricPartialCanonicalizationCreated.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	var ccRow, codexRow *store.Frame
+	for i := range frames {
+		switch frames[i].AgentType {
+		case "cc":
+			ccRow = &frames[i]
+		case "codex":
+			codexRow = &frames[i]
+		}
+	}
+	if codexRow == nil || codexRow.FrameID != codex.FrameID {
+		t.Fatalf("codex row missing or replaced; want preserved live row, got frames = %+v", frames)
+	}
+	if ccRow == nil || len(ccRow.Subagents) != 1 || !ccRow.Subagents[0].IsProxy || ccRow.Subagents[0].SourcePID != 200 {
+		t.Fatalf("cc row = %+v, want exactly 1 IsProxy ref attached pre-revalidation", ccRow)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startSweep; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (delete skipped because ancestor died)", delta)
+	}
+	if delta := agentpkg.MetricPartialCanonicalizationCreated.Value() - startPartial; delta != 1 {
+		t.Fatalf("MetricPartialCanonicalizationCreated delta = %d, want 1 (deliberate partial — ancestor died post-attach)", delta)
+	}
+}
+
 // IT10i — canonicalize → prune ordering in the same tick. cc has a
 // stale codex IsProxy ref AND a live opencode descendant standalone.
 // Same tick: canonicalize attaches opencode IsProxy → prune detaches

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -1153,7 +1153,7 @@ func TestSweep_OwnerReadErrorPreservesFrame(t *testing.T) {
 // the diff at the squash level — fewer per-test t.Skip edits to revert
 // across commits.
 var (
-	canonicalizeWired = false
+	canonicalizeWired = true
 	broadcastWired    = false
 )
 
@@ -1524,19 +1524,21 @@ func TestSweep_CanonicalizePartialWhenDeleteUnchangedFails(t *testing.T) {
 		}
 		return agentpkg.ProcessInfo{PID: pid, PPID: ppid}, nil
 	}
-	// On the candidate's second start_time read (the one inside
-	// canonicalizePane after sweepOnce's main loop already saw it),
-	// race a concurrent refresh that bumps codex.LastSeenAt — defeating
-	// DeleteIfUnchanged's optimistic check.
-	bumped := false
+	// processStartTimeFn(200) is called at least twice: once by
+	// sweepOnce's main loop (frame identity gate), once by
+	// canonicalizePane (candidate identity gate). Race on the SECOND
+	// call: bump codex.LastSeenAt so canonicalizePane's later
+	// DeleteIfUnchanged sees a stale baseline and returns false.
+	pid200Calls := 0
 	processStartTimeFn = func(pid int) (string, error) {
 		switch pid {
 		case 100:
 			return "t100", nil
 		case 200:
-			if !bumped {
-				bumped = true
-				// Upsert a new codex row with bumped LastSeenAt.
+			pid200Calls++
+			if pid200Calls == 2 {
+				// Concurrent refresh — bump codex.LastSeenAt before
+				// canonicalizePane's DeleteIfUnchanged runs.
 				_, _ = m.frames.Upsert(store.Frame{
 					FrameID:          codex.FrameID,
 					PaneID:           "%5",

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -2084,6 +2084,87 @@ func TestSweep_CanonicalizePreservesChildNativeAfterPartialRecovery(t *testing.T
 	}
 }
 
+// IT10r (review F2 — round 2 defender) — owned-state candidate with NO
+// existing parent proxy ref. The hot path failed to attach (e.g.
+// readProcessInfoFn transient error during PPID walk) and the child
+// then accumulated owned native state. Without this recovery path,
+// candidateHasOwnedState would early-skip and the partial would
+// persist forever: parent has no proxy ref to claim the child, so
+// projection_dedup cannot hide it; the child would render as a
+// separate top-frame indefinitely.
+//
+// Recovery: idempotently attach proxy ref on ancestor (enables
+// projection_dedup at next read) but skip delete (preserves owned
+// native state). MetricPartialCanonicalizationCreated +1 marks the
+// deliberate partial; MetricSweepCanonicalized stays unchanged
+// (semantics: only fully canonicalized rows count).
+func TestSweep_CanonicalizeAttachesAncestorProxyForOwnedStateCandidate(t *testing.T) {
+	m := newSweepTestModule(t)
+	// cc frame with EMPTY Subagents — hot path failed to attach.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "cc", PID: 100, PPID: 1,
+		ProcessStartTime: "t100",
+		Status:           agentpkg.StatusIdle, StartedAt: 50, LastSeenAt: 50, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert cc: %v", err)
+	}
+	// codex standalone, owned native subagent state.
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID: "%5", AgentType: "codex", PID: 200, PPID: 100,
+		ProcessStartTime: "t200",
+		Subagents: []agentpkg.SubagentRef{{
+			ID:        "task-defender-1",
+			Type:      "codex",
+			StartedAt: 70,
+			IsProxy:   false, // NATIVE — must be preserved
+		}},
+		Status: agentpkg.StatusRunning, StartedAt: 51, LastSeenAt: 51, Verified: true,
+	}); err != nil {
+		t.Fatalf("Upsert codex + native ref: %v", err)
+	}
+
+	installSweepCanonicalSeams(t,
+		map[int]bool{100: true, 200: true},
+		map[int]string{100: "t100", 200: "t200"},
+		map[int]int{200: 100},
+	)
+
+	startSweep := agentpkg.MetricSweepCanonicalized.Value()
+	startPartial := agentpkg.MetricPartialCanonicalizationCreated.Value()
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	frames, _ := m.frames.ListByPane("%5")
+	if len(frames) != 2 {
+		t.Fatalf("frames = %+v, want 2 (codex row preserved with owned state)", frames)
+	}
+	var cc, codex *store.Frame
+	for i := range frames {
+		switch frames[i].AgentType {
+		case "cc":
+			cc = &frames[i]
+		case "codex":
+			codex = &frames[i]
+		}
+	}
+	if cc == nil || codex == nil {
+		t.Fatalf("frames = %+v, missing cc or codex", frames)
+	}
+	if len(cc.Subagents) != 1 || !cc.Subagents[0].IsProxy || cc.Subagents[0].SourcePID != 200 {
+		t.Fatalf("cc.Subagents = %+v, want exactly 1 codex IsProxy (newly attached by F2)", cc.Subagents)
+	}
+	if len(codex.Subagents) != 1 || codex.Subagents[0].IsProxy || codex.Subagents[0].ID != "task-defender-1" {
+		t.Fatalf("codex.Subagents = %+v, want native task-defender-1 preserved (owned state)", codex.Subagents)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startSweep; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (delete deliberately skipped)", delta)
+	}
+	if delta := agentpkg.MetricPartialCanonicalizationCreated.Value() - startPartial; delta != 1 {
+		t.Fatalf("MetricPartialCanonicalizationCreated delta = %d, want 1 (deliberate partial: attach without delete)", delta)
+	}
+}
+
 // IT10o — candidate carrying ONLY stale (dead) IsProxy refs is folded
 // (stale ref dropped along with the row; equivalent to sweep prune
 // detaching it then sweep folding next tick).
@@ -2374,8 +2455,20 @@ func TestFindCanonicalAncestor_ReturnsFalseOnReadProcessInfoTransientError(t *te
 }
 
 // IT10p — candidate carrying a LIVE identity-verified IsProxy ref is
-// skipped. The candidate is itself acting as ancestor for some other
-// sub-tree; folding it would lose that role.
+// preserved as a frame (the candidate itself is acting as ancestor for
+// some other sub-tree; folding its row would lose that role) BUT the
+// canonical proxy ref is still attached on the higher ancestor so the
+// pane projection consolidates the whole tree under one top frame.
+//
+// Round 2 defender (review F2) reorganization: owned-state guard no
+// longer early-skips before findCanonicalAncestor. Instead, when a
+// canonical ancestor exists AND the candidate carries owned state,
+// sweep idempotently attaches the proxy ref on the ancestor (so
+// projection_dedup can hide + merge the candidate at read time) and
+// skips delete (so the candidate's owned state is preserved). Net
+// effect for IT10p: cc gains a codex IsProxy ref; codex row stays put
+// with its opencode IsProxy ref intact; projection sees a single cc
+// top frame with [codex IsProxy + opencode IsProxy] merged refs.
 func TestSweep_CanonicalizeSkipsCandidateWithLiveProxy(t *testing.T) {
 	m := newSweepTestModule(t)
 	if _, err := m.frames.Upsert(store.Frame{
@@ -2392,7 +2485,7 @@ func TestSweep_CanonicalizeSkipsCandidateWithLiveProxy(t *testing.T) {
 			ID: "proxy:opencode:300:t300", Type: "opencode",
 			SourcePID: 300, SourceStartTime: "t300", IsProxy: true,
 		}},
-		Status: agentpkg.StatusRunning, StartedAt: 50, LastSeenAt: 50, Verified: true,
+		Status: agentpkg.StatusRunning, StartedAt: 51, LastSeenAt: 51, Verified: true,
 	}); err != nil {
 		t.Fatalf("Upsert codex with live proxy: %v", err)
 	}
@@ -2403,7 +2496,8 @@ func TestSweep_CanonicalizeSkipsCandidateWithLiveProxy(t *testing.T) {
 		map[int]int{200: 100},
 	)
 
-	startMetric := agentpkg.MetricSweepCanonicalized.Value()
+	startSweep := agentpkg.MetricSweepCanonicalized.Value()
+	startPartial := agentpkg.MetricPartialCanonicalizationCreated.Value()
 	if err := m.sweepOnce(); err != nil {
 		t.Fatalf("sweepOnce: %v", err)
 	}
@@ -2412,12 +2506,28 @@ func TestSweep_CanonicalizeSkipsCandidateWithLiveProxy(t *testing.T) {
 	if len(frames) != 2 {
 		t.Fatalf("frames = %+v, want 2 (codex preserved as sub-ancestor)", frames)
 	}
-	for _, f := range frames {
-		if f.AgentType == "cc" && len(f.Subagents) != 0 {
-			t.Fatalf("cc.Subagents = %+v, want empty (codex must not be folded — owns live IsProxy)", f.Subagents)
+	var cc, codex *store.Frame
+	for i := range frames {
+		switch frames[i].AgentType {
+		case "cc":
+			cc = &frames[i]
+		case "codex":
+			codex = &frames[i]
 		}
 	}
-	if delta := agentpkg.MetricSweepCanonicalized.Value() - startMetric; delta != 0 {
-		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (gated)", delta)
+	if cc == nil || codex == nil {
+		t.Fatalf("frames = %+v, missing cc or codex", frames)
+	}
+	if len(cc.Subagents) != 1 || !cc.Subagents[0].IsProxy || cc.Subagents[0].SourcePID != 200 {
+		t.Fatalf("cc.Subagents = %+v, want exactly 1 codex IsProxy attached by F2 attach-only recovery", cc.Subagents)
+	}
+	if len(codex.Subagents) != 1 || !codex.Subagents[0].IsProxy || codex.Subagents[0].SourcePID != 300 {
+		t.Fatalf("codex.Subagents = %+v, want preserved opencode IsProxy (sub-tree role intact)", codex.Subagents)
+	}
+	if delta := agentpkg.MetricSweepCanonicalized.Value() - startSweep; delta != 0 {
+		t.Fatalf("MetricSweepCanonicalized delta = %d, want 0 (delete deliberately skipped)", delta)
+	}
+	if delta := agentpkg.MetricPartialCanonicalizationCreated.Value() - startPartial; delta != 1 {
+		t.Fatalf("MetricPartialCanonicalizationCreated delta = %d, want 1 (deliberate partial: attach without delete)", delta)
 	}
 }


### PR DESCRIPTION
## Summary

PR-3.5b 接 PR-3.5a (#644 / alpha.226)：sweep 加第三 pass `canonicalizePane`，把 PR-3.5a hot-path 漏網的 standalone descendant frame 在 2s 內 fold 進 cross-type ancestor proxy ref，補完 DB-level eventual consistency。

**Defense-in-depth**：user-visible correctness 已由 PR-3.5a projection dedup 保證；3.5b 只是把 DB 層 partial state 的存活時間從「等 SessionEnd / 1h idle / pid_dead」縮到「下次 sweep tick ≤ 2s」。

## Hybrid B+ 設計典範延續

| 層 | 職責 | PR |
|---|---|---|
| Hot path | best-effort canonicalization；失敗不 retry/rollback | 3.5a |
| Projection | 隱藏 partial（**唯一 strongly consistent 邊界**） | 3.5a |
| **Sweep** | **bounded-time recovery（2s）** | **3.5a prune + 3.5b canonicalize** |
| Observability | partial 發生率 expvar | 3.5a + 3.5b 接 MetricSweepCanonicalized |

## What's in PR-3.5b

- `internal/module/agent/frame_ops.go`：抽出 `candidateHasOwnedState(candidate)` 共享 helper（mirror hot-path inline block 1098-1137；pure refactor 0 行為變更）
- `internal/module/agent/sweep.go`：
  - `canonicalizePane(paneID, broadcastTs)` — 主 fold pass（含 candidate identity gate + owned-state guard + cross-type-only rule + best-effort attach + DeleteIfUnchanged）
  - `findCanonicalAncestor(candidate, framesByPID)` — PPID 鏈走 `proxyMaxDepth=5` 找 cross-type live identity-verified ancestor frame
  - `broadcastProxyCanonicalized` — per-pane broadcast pattern（仿 `broadcastProxyPruned`）
  - `sweepOnce` 第三 pass：每 pane `canonicalizePane` 跑在 `pruneDeadProxyRefs` 之前
- `internal/agent/metrics.go` — `MetricSweepCanonicalized` 接上 caller（PR-3.5a 已宣告但無 caller）

## Plan trail

5 docs commits + plan v1→v3 經 3 輪 codex 審閱：

| Round | Job | Verdict | Findings |
|---|---|---|---|
| 1 plan | `019dc937-beb0-7a83-a02b-42679ad4fbc1` | needs-attention | 1 high — canonicalizePane 漏 hasOwnedState 守衛 → child native subagent state 被砍 |
| 2 plan | `019dc93d-7f4e-7892-bdf6-45779388604f` | needs-attention | 1 high — IT10n setup 沒覆蓋 round 1 原始時序 + ship gate 沒納入 v2 新增 IT/RC |
| 3 plan | `019dc940-c833-7931-85c0-79d5f92ffc9d` | **approve** | clean — ship-ready |

Plan v3 在 `docs/specs/2026-04-26-lights-rebuild-phase-3-5b-plan.md`。

## Test plan

**所有 27 個 PR-3.5b 測試全綠，無 skip：**

- **Integration（16）**：IT10 + IT10b/c/d/e/f（identity gate 系列）+ IT10g/h（partial recovery）+ IT10i（canonicalize→prune 同 tick interaction，**核心 regression guard**）+ IT10j/k（broadcast）+ IT10l（cross-pane isolation）+ IT10m（already-proxied）+ **IT10n（round 1 high precision regression guard — 6-step temporal sequence）** + IT10o（stale-only proxy fold OK）+ IT10p（live IsProxy skip）
- **Unit（11）**：RC6-RC11 (`findCanonicalAncestor`) + **RC12-RC16 (`candidateHasOwnedState`)**

完整 ship gate（plan §6）：

- [x] `go build ./... && go vet ./...` — exit 0
- [x] `go test ./...` — 23 packages 全綠
- [x] IT10 + IT10b-IT10p + RC6-RC16 全綠（27/27 no skip）
- [x] MetricSweepCanonicalized 觀察 +1 在預期 case；IT10g/h/n 確認**不**增（partial / gated case）
- [x] MetricSweepPrunedProxy PR-3.5a 既有行為不 regress
- [ ] Manual smoke：daemon restart cc + codex 並發 cold-start，partial 場景下 sweep 在 2s 內收編 standalone descendant

## Out of scope

- Phase 4 probe 補強
- Projection layer 變更
- Store API 新增
- SPA 任何變更

## Codex review request

兩輪 per project convention：
1. Round 1 standard cross-model
2. Round 2 3-parallel adversarial（attacker / defender / file-health）

Focus areas：
- §2.2.1 `candidateHasOwnedState` helper extraction byte-equivalence vs frame_ops.go:1098-1137 baseline
- IT10n round-1-high regression scenario fidelity（the test that closes the data-loss bug class）
- IT10i canonicalize-then-prune-same-tick interaction（new pass ordering correctness）
- Mock seam strategy：`processStartTimeFn` 內部 race trick 取代 store interface mock（IT10g/h fakes_test pattern carry-over from PR-3.5a sweep test scaffolding）
- LOC budget vs plan §8 預估（150 net code，實際 155 含 broadcast 25 LOC）

## Pre-merge

- main @ alpha.226 已含 PR-3.5a (#644) ✅
- Bump 策略：3.5b 單獨 bump alpha.227（與 3.5a 切開以便 metric 觀察 partial rate 變化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)