### PR TITLE
chore(dev): rename PDX_DEV_UPDATE env var to PDX_DEV_MODE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 - SPA dev server 會把 `/api` 與 `/ws` proxy 到 `localhost:7860`；只跑前端時，daemon 也要在本機 `7860`。
 - `spa/scripts/generate-icon-data.mjs` 會重建 `spa/public/icons/*.json` 與 `spa/src/features/workspace/generated/icon-meta.json`；這些是產物，不要手改。
 - `out/` 與 `dist/` 都是建置輸出，不要手改。
-- Dev update 是雙重 gate：daemon 端要 `config.Dev.Update=true`，而且 `PDX_DEV_UPDATE=1` 也必須存在，`/api/dev/*` 路由與 Electron preload API 才會真的露出。
+- Dev update 是雙重 gate：daemon 端要 `config.Dev.Update=true`，而且 `PDX_DEV_MODE=1` 也必須存在，`/api/dev/*` 路由與 Electron preload API 才會真的露出。
 - `VERSION` 是版本 SOT；bump 時同步 `package.json` 與 `spa/package.json`。`electron.vite.config.ts` 和 `internal/module/dev` 都直接讀這個檔。
 - Locale 變更要同時更新 `spa/src/locales/en.json` 與 `spa/src/locales/zh-TW.json`；repo 內有 completeness tests 會檢查兩邊 key set。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **Electron 打包**：`pnpm run electron:build` → `dist/mac/`（x64）+ `dist/mac-arm64/`（ARM）
 - **SPA 更新**：`.app` 啟動時偵測 Mini dev server，可達則 `loadURL`（HMR 即時），不可達則 fallback 到 bundled renderer
-- **Electron 更新**：daemon `/api/dev/update/check` + `/api/dev/update/download`，Settings → Development 頁面操作（需 `PDX_DEV_UPDATE=1`）
+- **Electron 更新**：daemon `/api/dev/update/check` + `/api/dev/update/download`，Settings → Development 頁面操作（需 `PDX_DEV_MODE=1`）
 - **跨機開發**：Mini（100.64.0.2）編譯，Air 執行 `.app`，SPA 改動即時生效，Electron 改動透過 dev update 機制
 
 ### Dev Update 注意事項

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -119,8 +119,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     rename: (from: string, to: string) => ipcRenderer.invoke('fs:rename', from, to),
   },
 
-  // Dev Update (only exposed when PDX_DEV_UPDATE=1)
-  ...(process.env.PDX_DEV_UPDATE ? {
+  // Dev Update (only exposed when PDX_DEV_MODE=1)
+  ...(process.env.PDX_DEV_MODE ? {
     getAppInfo: () => ipcRenderer.invoke('dev:app-info'),
     checkUpdate: (daemonUrl: string, token?: string) => ipcRenderer.invoke('dev:check-update', daemonUrl, token),
     applyUpdate: (daemonUrl: string, token?: string) => ipcRenderer.invoke('dev:apply-update', daemonUrl, token),

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -31,7 +31,7 @@ export function getAppInfo(): AppInfo {
     version: typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'unknown',
     electronHash: typeof __ELECTRON_HASH__ !== 'undefined' ? __ELECTRON_HASH__ : 'unknown',
     spaHash: typeof __SPA_HASH__ !== 'undefined' ? __SPA_HASH__ : 'unknown',
-    devUpdateEnabled: !!process.env.PDX_DEV_UPDATE,
+    devUpdateEnabled: !!process.env.PDX_DEV_MODE,
   }
 }
 

--- a/internal/module/dev/daemon_test.go
+++ b/internal/module/dev/daemon_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHandleDaemonCheck_ReturnsHashes(t *testing.T) {
-	t.Setenv("PDX_DEV_UPDATE", "1")
+	t.Setenv("PDX_DEV_MODE", "1")
 	m := New(".") // repoRoot = cwd (git worktree)
 	mux := http.NewServeMux()
 	m.RegisterRoutes(mux)
@@ -38,7 +38,7 @@ func TestHandleDaemonCheck_ReturnsHashes(t *testing.T) {
 }
 
 func TestHandleDaemonRebuild_BuildsInTempRepo(t *testing.T) {
-	t.Setenv("PDX_DEV_UPDATE", "1")
+	t.Setenv("PDX_DEV_MODE", "1")
 	dir := t.TempDir()
 	// Minimal go module that builds at ./cmd/pdx.
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n\ngo 1.21\n"), 0644); err != nil {
@@ -79,7 +79,7 @@ func TestHandleDaemonRebuild_BuildsInTempRepo(t *testing.T) {
 }
 
 func TestHandleDaemonRebuild_ExecsRebuiltBinary(t *testing.T) {
-	t.Setenv("PDX_DEV_UPDATE", "1")
+	t.Setenv("PDX_DEV_MODE", "1")
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n\ngo 1.21\n"), 0644); err != nil {
 		t.Fatal(err)
@@ -136,7 +136,7 @@ func TestHandleDaemonRebuild_ConcurrentReturns409(t *testing.T) {
 }
 
 func TestHandleDaemonRebuild_BuildFailureEmitsError(t *testing.T) {
-	t.Setenv("PDX_DEV_UPDATE", "1")
+	t.Setenv("PDX_DEV_MODE", "1")
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n\ngo 1.21\n"), 0644); err != nil {
 		t.Fatal(err)
@@ -159,7 +159,7 @@ func TestHandleDaemonRebuild_BuildFailureEmitsError(t *testing.T) {
 }
 
 func TestHandleDaemonRebuild_RenameFailureEmitsError(t *testing.T) {
-	t.Setenv("PDX_DEV_UPDATE", "1")
+	t.Setenv("PDX_DEV_MODE", "1")
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n\ngo 1.21\n"), 0644); err != nil {
 		t.Fatal(err)
@@ -204,7 +204,7 @@ func TestHandleDaemonCheck_AvailableFlag(t *testing.T) {
 	defer func() { BakedInHash = old }()
 
 	BakedInHash = "definitely-not-a-real-hash-0000"
-	t.Setenv("PDX_DEV_UPDATE", "1")
+	t.Setenv("PDX_DEV_MODE", "1")
 	m := New(".")
 	mux := http.NewServeMux()
 	m.RegisterRoutes(mux)

--- a/internal/module/dev/module.go
+++ b/internal/module/dev/module.go
@@ -159,11 +159,11 @@ func (m *DevModule) defaultBuild(session *BuildSession) error {
 func (m *DevModule) RegisterRoutes(mux *http.ServeMux) {
 	// Two-layer gate. Layer 1 (config.Dev.Update in main.go) decides whether
 	// to instantiate this module at all — when false, DevModule isn't even
-	// constructed. Layer 2 (PDX_DEV_UPDATE=1 env var, below) gates route
+	// constructed. Layer 2 (PDX_DEV_MODE=1 env var, below) gates route
 	// registration so operators can run the module without exposing the dev
 	// endpoints (useful for staging or partial rollouts). Both must be set
 	// to serve /api/dev/* requests.
-	if os.Getenv("PDX_DEV_UPDATE") != "1" {
+	if os.Getenv("PDX_DEV_MODE") != "1" {
 		return
 	}
 	mux.HandleFunc("GET /api/dev/update/check", m.handleCheck)
@@ -174,8 +174,8 @@ func (m *DevModule) RegisterRoutes(mux *http.ServeMux) {
 }
 
 func (m *DevModule) Start(_ context.Context) error {
-	if os.Getenv("PDX_DEV_UPDATE") != "1" {
-		log.Println("[dev] update endpoints disabled (requires config.Dev.Update=true AND PDX_DEV_UPDATE=1)")
+	if os.Getenv("PDX_DEV_MODE") != "1" {
+		log.Println("[dev] update endpoints disabled (requires config.Dev.Update=true AND PDX_DEV_MODE=1)")
 		return nil
 	}
 	log.Println("[dev] update endpoints enabled")

--- a/internal/module/dev/module_test.go
+++ b/internal/module/dev/module_test.go
@@ -175,7 +175,7 @@ func TestDefaultBuild_WrapsStepErrorWithLabel(t *testing.T) {
 }
 
 func TestRegisterRoutes_DisabledByDefault(t *testing.T) {
-	t.Setenv("PDX_DEV_UPDATE", "")
+	t.Setenv("PDX_DEV_MODE", "")
 	m := &DevModule{}
 	mux := http.NewServeMux()
 	m.RegisterRoutes(mux)
@@ -190,7 +190,7 @@ func TestRegisterRoutes_DisabledByDefault(t *testing.T) {
 }
 
 func TestRegisterRoutes_EnabledWithEnv(t *testing.T) {
-	t.Setenv("PDX_DEV_UPDATE", "1")
+	t.Setenv("PDX_DEV_MODE", "1")
 	m := &DevModule{}
 	mux := http.NewServeMux()
 	m.RegisterRoutes(mux)


### PR DESCRIPTION
## Summary

Generalize the dev mode env flag from `PDX_DEV_UPDATE` to `PDX_DEV_MODE` to host future dev observation features (e.g., Phase 4a graceWindow logging).

Pure search & replace across **live** code + docs. **Historical** CHANGELOG entries and archived `docs/superpowers/plans|specs/2026-04-18-*` are intentionally preserved as immutable historical record.

`config.Dev.Update` config field is unchanged — it specifically gates the update feature, only the env var was generalized.

## Scope

- `internal/module/dev/module.go` — env check (×2) + log message (×1) + comment (×1)
- `internal/module/dev/module_test.go` — `t.Setenv` (×2)
- `internal/module/dev/daemon_test.go` — `t.Setenv` (×6)
- `electron/preload.ts` — `process.env` access (×1) + comment (×1)
- `electron/updater.ts` — `process.env` access (×1)
- `CLAUDE.md` + `AGENTS.md` — docs (×1 each)

CHANGELOG entry will be added in the follow-up bump PR (alpha.229).

## Why this PR shape

- Alpha-stage repo, no backwards-compat concern — direct rename per maintainer instruction
- Trivial mechanical change → single-round codex standard review (skip the 3-parallel adversarial round; nothing for attackers to find in a string rename)
- No flag-overlap period; existing `PDX_DEV_UPDATE` is now dead (any local dev shell setting it will silently disable dev module routes — acceptable, dev users will see the rename in CLAUDE.md/AGENTS.md)

## Test plan

- [x] `go test ./internal/module/dev/...` — green
- [x] `grep PDX_DEV_UPDATE` across live tree — only historical archives left (intentional)
- [ ] Local `pnpm run electron:build` on Mini before merge (Electron rename is pure string-literal swap; no possible TS error, but smoke test recommended)