### PR TITLE
test(spa): guard opencode agent icon

### DIFF
--- a/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
+++ b/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
@@ -841,4 +841,37 @@ Only create this PR if issue #658 or another mechanically verified source/runtim
 
 ### PR 6 — OpenCode Icon Guard
 
-Coverage-only SPA test. May be bundled with PR 4 if review load is low; otherwise keep as a small test-only PR.
+Coverage-only SPA test.
+
+Scope:
+
+- Add explicit coverage that `getAgentIcon('opencode', ...)` returns a defined icon component.
+- Add coverage that the OpenCode icon component is stable across the full cc/Codex icon variant option matrix because OpenCode has no variant setting.
+- Do not change production icon code in PR 6. If the guard fails on the current baseline, stop and split a separate fix.
+- Do not add `opencodeVariant` or settings UI.
+- Do not touch tab rendering, workspace projection, daemon hook code, or generated icon metadata.
+
+Implementation files:
+
+- `spa/src/lib/agent-icons.test.tsx`
+
+Plan file:
+
+- `docs/specs/2026-04-25-agent-hooks-hotfix-plan.md`
+
+Test IDs:
+
+| ID | Test | Assertion |
+|---|---|---|
+| OI1 | `returns opencode icon for opencode agent type` | `getAgentIcon('opencode', ...)` returns a defined component |
+| OI2 | `opencode icon ignores cc and codex variants` | OpenCode icon component identity is stable across the 2x2 cc/Codex variant matrix |
+
+TDD note:
+
+- This is a coverage guard for already-shipped production behavior, so OI1/OI2 are allowed to pass immediately on `origin/main`.
+- If either test fails, do not fix production in PR 6; stop and decide whether to open a separate production fix PR.
+
+Verification:
+
+- `pnpm --prefix spa exec vitest run src/lib/agent-icons.test.tsx`
+- `git diff --check`

--- a/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
+++ b/docs/specs/2026-04-25-agent-hooks-hotfix-plan.md
@@ -845,7 +845,7 @@ Coverage-only SPA test.
 
 Scope:
 
-- Add explicit coverage that `getAgentIcon('opencode', ...)` returns a defined icon component.
+- Add explicit coverage that `getAgentIcon('opencode', ...)` returns the OpenCode icon component, not only any defined component.
 - Add coverage that the OpenCode icon component is stable across the full cc/Codex icon variant option matrix because OpenCode has no variant setting.
 - Do not change production icon code in PR 6. If the guard fails on the current baseline, stop and split a separate fix.
 - Do not add `opencodeVariant` or settings UI.
@@ -863,7 +863,7 @@ Test IDs:
 
 | ID | Test | Assertion |
 |---|---|---|
-| OI1 | `returns opencode icon for opencode agent type` | `getAgentIcon('opencode', ...)` returns a defined component |
+| OI1 | `returns opencode icon for opencode agent type` | `getAgentIcon('opencode', ...)` renders a mocked OpenCode SVG marker and is distinct from cc/Codex variants |
 | OI2 | `opencode icon ignores cc and codex variants` | OpenCode icon component identity is stable across the 2x2 cc/Codex variant matrix |
 
 TDD note:

--- a/spa/src/lib/agent-icons.test.tsx
+++ b/spa/src/lib/agent-icons.test.tsx
@@ -26,6 +26,18 @@ describe('getAgentIcon', () => {
     expect(CODEX_ICON_VARIANTS.openai).not.toBe(CODEX_ICON_VARIANTS.codex)
   })
 
+  it('returns opencode icon for opencode agent type', () => {
+    expect(getAgentIcon('opencode', { ccVariant: 'bot', codexVariant: 'openai' })).toBeDefined()
+  })
+
+  it('opencode icon ignores cc and codex variants', () => {
+    const icon = getAgentIcon('opencode', { ccVariant: 'bot', codexVariant: 'openai' })
+
+    expect(getAgentIcon('opencode', { ccVariant: 'bot', codexVariant: 'codex' })).toBe(icon)
+    expect(getAgentIcon('opencode', { ccVariant: 'star', codexVariant: 'openai' })).toBe(icon)
+    expect(getAgentIcon('opencode', { ccVariant: 'star', codexVariant: 'codex' })).toBe(icon)
+  })
+
   it('codex branch ignores ccVariant and respects codexVariant', () => {
     const withBot = getAgentIcon('codex', { ccVariant: 'bot', codexVariant: 'codex' })
     const withStar = getAgentIcon('codex', { ccVariant: 'star', codexVariant: 'codex' })

--- a/spa/src/lib/agent-icons.test.tsx
+++ b/spa/src/lib/agent-icons.test.tsx
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
 import { getAgentIcon, CC_ICON_VARIANTS, CODEX_ICON_VARIANTS } from './agent-icons'
+
+vi.mock('@lobehub/icons-static-svg/icons/opencode.svg?react', () => ({
+  default: (props: import('react').SVGProps<SVGSVGElement>) => (
+    <svg data-testid="opencode-svg-marker" {...props} />
+  ),
+}))
 
 describe('getAgentIcon', () => {
   it('returns bot variant for cc when ccVariant=bot', () => {
@@ -27,15 +34,34 @@ describe('getAgentIcon', () => {
   })
 
   it('returns opencode icon for opencode agent type', () => {
-    expect(getAgentIcon('opencode', { ccVariant: 'bot', codexVariant: 'openai' })).toBeDefined()
+    const Icon = getAgentIcon('opencode', { ccVariant: 'bot', codexVariant: 'openai' })
+
+    expect(Icon).toBeDefined()
+    expect(Icon).not.toBe(CC_ICON_VARIANTS.bot)
+    expect(Icon).not.toBe(CC_ICON_VARIANTS.star)
+    expect(Icon).not.toBe(CODEX_ICON_VARIANTS.openai)
+    expect(Icon).not.toBe(CODEX_ICON_VARIANTS.codex)
+
+    const { container } = render(Icon ? <Icon size={16} /> : null)
+    expect(container.querySelector('[data-testid="opencode-svg-marker"]')).toBeTruthy()
   })
 
   it('opencode icon ignores cc and codex variants', () => {
     const icon = getAgentIcon('opencode', { ccVariant: 'bot', codexVariant: 'openai' })
+    const matrix = [
+      { ccVariant: 'bot', codexVariant: 'openai' },
+      { ccVariant: 'bot', codexVariant: 'codex' },
+      { ccVariant: 'star', codexVariant: 'openai' },
+      { ccVariant: 'star', codexVariant: 'codex' },
+    ] as const
 
-    expect(getAgentIcon('opencode', { ccVariant: 'bot', codexVariant: 'codex' })).toBe(icon)
-    expect(getAgentIcon('opencode', { ccVariant: 'star', codexVariant: 'openai' })).toBe(icon)
-    expect(getAgentIcon('opencode', { ccVariant: 'star', codexVariant: 'codex' })).toBe(icon)
+    for (const options of matrix) {
+      const Icon = getAgentIcon('opencode', options)
+      expect(Icon).toBe(icon)
+
+      const { container } = render(Icon ? <Icon size={16} /> : null)
+      expect(container.querySelector('[data-testid="opencode-svg-marker"]')).toBeTruthy()
+    }
   })
 
   it('codex branch ignores ccVariant and respects codexVariant', () => {


### PR DESCRIPTION
## Summary

- Add the PR6 plan for the OpenCode icon guard.
- Add focused tests that verify `getAgentIcon('opencode')` renders the OpenCode SVG marker.
- Verify the OpenCode icon is stable across the full cc/Codex variant matrix and distinct from cc/Codex variants.

## Verification

- `pnpm --prefix spa exec vitest run src/lib/agent-icons.test.tsx`
- `git diff --check origin/main...HEAD`
- Codex standard review: no actionable findings
- Codex focused re-review: attack/defense/file-health all approve