### PR TITLE
Phase 4a PR-4a-1: probe primitive + cc + helper + dev log

### DIFF
--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.7 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.8 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.7（Round 7 codex review fix — 1 P2 + 1 P3 採納）
+**Status**: draft v1.8（Round 8 codex review fix — 1 P2 + 1 P3 採納）
 
 ## v1.x 演進
 
@@ -14,6 +14,7 @@
 | v1.5 | R5 codex review fix（1 P2 internal-inconsistency）：plan §1.2 列「Slice 8（清舊 onActivityDetected / shouldWatchActivity / ActivitySignal enum 解讀）— 留 PR-4a-2」與 §1.1 / §2.4.2 衝突（後者要求本 PR 必移除 `ActivitySignal` 等舊 API 否則無法 compile）。釐清：本 PR 必清 `ActivitySignal` enum + legacy `StartWatch` API + `activityLoop` + `onActivityDetected`（compile 必要）；保留 `shouldWatchActivity`（wrapper 仍用的政策函式）；PR-4a-2 範圍縮為「Slice 5/6 codex/opencode profile 接 primitive」+「**視需要** refactor `shouldWatchActivity`」 |
 | v1.6 | R6 codex review fix（2 P2 internal-consistency）：(1) §1.1 Slice 3 摘要還寫「`stopProbeWatch` 含 activeWatchers map cleanup」與 R3 修法（orchestrator 不碰 activeWatchers）矛盾；改正為「停止 prober watcher」並引向 §2.3.1 R3 fix；(2) Commit 5 TDD 清單只列 CC1-CC5，漏掉 CC6 (R2 fix #1 + R3 deadlock-freedom regression)；補入 written-first 清單 |
 | v1.7 | R7 codex review fix（1 P2 + 1 P3）：(1) §2.3.3 startWatch pseudo-code 用未定義 `target`，既有 callsite 都是 `session + ":"` 形式；明寫 `target := session + ":"` 在 startWatch / stopWatch contract，避免 implementer 編譯失敗或 bare-session 啟 watcher；(2) §2.4.4 標題寫「測試（5 tests）」但表格列 CC1-CC6 共 6 個；改為「測試（6 tests — R2 +CC6）」 |
+| v1.8 | R8 codex review fix（1 P2 + 1 P3）：(1) §2.3.3 startWatch pseudo-code 仍用未定義 `agentProvider` 變數 + `defaultProbeProfile` 為 unqualified type；補完整 provider lookup（registry → agentType → provider）+ 改 `agentpkg.ProbeProfile` qualified 命名；(2) §2.1.6 標題「測試（7 tests — R1 +PR2b）」與 §3 矩陣（8 tests）+ 表內列出 8 個 testID 不符；改為「測試（8 tests — R1 +PR2b / R2 +PR4b）」 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -248,7 +249,7 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 - `activityLoop` 內部 method — 改成 `watchLoop`
 - `hashCapture` 內部 method — 改成支援 captureFn closure 的版本
 
-#### 2.1.6 測試（7 tests — R1 +1 PR2b）
+#### 2.1.6 測試（8 tests — R1 +PR2b / R2 +PR4b）
 
 | Test | 重點 |
 |------|------|
@@ -337,14 +338,25 @@ type ProbeProfile struct {
 var defaultProbeProfile = ProbeProfile{TopLines: 10, IdleStableTicks: 3}
 ```
 
-orchestrator `startWatch` 邏輯（R7 fix — 顯式組 tmux target）：
+orchestrator `startWatch` 邏輯（R7 fix — 顯式組 tmux target；R8 fix — 完整 provider lookup + qualified type）：
 ```go
+// defaultProbeProfile is a package-level constant (defined in
+// internal/module/agent, not internal/agent). Uses agentpkg-qualified
+// ProbeProfile to match its definition site.
+var defaultProbeProfile = agentpkg.ProbeProfile{TopLines: 10, IdleStableTicks: 3}
+
 func (o *probeOrchestrator) startWatch(session, agentType string) {
     target := session + ":"  // tmux target convention; matches existing callsite
+
+    // R8 fix: resolve provider from registry; assert ProbeProfileProvider.
+    // Module field m.registry is *agentpkg.Registry (per module.go:34).
     profile := defaultProbeProfile
-    if pp, ok := agentProvider.(agentpkg.ProbeProfileProvider); ok {
-        profile = pp.ProbeProfile()
+    if provider, ok := o.parent.registry.Get(agentType); ok {
+        if pp, ok := provider.(agentpkg.ProbeProfileProvider); ok {
+            profile = pp.ProbeProfile()
+        }
     }
+
     opts := probe.WatchOptions{
         TopLines:        profile.TopLines,        // 0 = full screen
         IdleStableTicks: profile.IdleStableTicks, // 0 = default 3 (handled by watchLoop)
@@ -352,6 +364,10 @@ func (o *probeOrchestrator) startWatch(session, agentType string) {
     o.parent.prober.Watch(target, opts, o.makeCallback(session, agentType))
 }
 ```
+
+**Caller 端 contract**（R7 fix）：caller 傳 `session`（無 ":" 後綴），orchestrator 自己加 ":" 變成 tmux target；對齊既有 `m.prober.StartWatch(session+":", ...)` 慣例。
+
+**Registry lookup contract**（R8 fix）：orchestrator 透過 `o.parent.registry.Get(agentType)` 取得 `agentpkg.Provider`；type-assert `agentpkg.ProbeProfileProvider`；agentType 不存在或不實作介面 → fallback 到 `defaultProbeProfile`。`Registry.Get` 需確認簽名（若返回 `(Provider, bool)` 則照 §2.3.3 寫；若是 `Provider` + nil-check 則 implementer 對應調整）— 此 contract 由 implementer 在 Commit 3 對齊既有 `internal/agent/Registry` API。
 
 對應 `stopWatch`：
 ```go

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.6 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.7 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.6（Round 6 codex review fix — 2 P2 internal-consistency findings 採納）
+**Status**: draft v1.7（Round 7 codex review fix — 1 P2 + 1 P3 採納）
 
 ## v1.x 演進
 
@@ -13,6 +13,7 @@
 | v1.4 | R4 codex review fix（1 P2 stale-callback guard）：legacy `onActivityDetected` (module.go:473) 開頭檢查 `activeWatchers[session]` 不存在則 return，這個 stale-callback guard v1.3 plan 漏搬。新 watch-loop-owned watcher fire callback 多次（不像 legacy fire 一次就退），**此 guard 比 legacy 更必要** — stopWatch / rename race 中 in-flight callback 會在 watcher 已停的情況下繼續更新 status / broadcast。`interpretScreenEvent` 開頭加 `currentAgent, active := m.activeWatchers[session]; if !active \|\| currentAgent != agentType { return }`；新增 OR6 regression test |
 | v1.5 | R5 codex review fix（1 P2 internal-inconsistency）：plan §1.2 列「Slice 8（清舊 onActivityDetected / shouldWatchActivity / ActivitySignal enum 解讀）— 留 PR-4a-2」與 §1.1 / §2.4.2 衝突（後者要求本 PR 必移除 `ActivitySignal` 等舊 API 否則無法 compile）。釐清：本 PR 必清 `ActivitySignal` enum + legacy `StartWatch` API + `activityLoop` + `onActivityDetected`（compile 必要）；保留 `shouldWatchActivity`（wrapper 仍用的政策函式）；PR-4a-2 範圍縮為「Slice 5/6 codex/opencode profile 接 primitive」+「**視需要** refactor `shouldWatchActivity`」 |
 | v1.6 | R6 codex review fix（2 P2 internal-consistency）：(1) §1.1 Slice 3 摘要還寫「`stopProbeWatch` 含 activeWatchers map cleanup」與 R3 修法（orchestrator 不碰 activeWatchers）矛盾；改正為「停止 prober watcher」並引向 §2.3.1 R3 fix；(2) Commit 5 TDD 清單只列 CC1-CC5，漏掉 CC6 (R2 fix #1 + R3 deadlock-freedom regression)；補入 written-first 清單 |
+| v1.7 | R7 codex review fix（1 P2 + 1 P3）：(1) §2.3.3 startWatch pseudo-code 用未定義 `target`，既有 callsite 都是 `session + ":"` 形式；明寫 `target := session + ":"` 在 startWatch / stopWatch contract，避免 implementer 編譯失敗或 bare-session 啟 watcher；(2) §2.4.4 標題寫「測試（5 tests）」但表格列 CC1-CC6 共 6 個；改為「測試（6 tests — R2 +CC6）」 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -336,18 +337,31 @@ type ProbeProfile struct {
 var defaultProbeProfile = ProbeProfile{TopLines: 10, IdleStableTicks: 3}
 ```
 
-orchestrator `startWatch` 邏輯：
+orchestrator `startWatch` 邏輯（R7 fix — 顯式組 tmux target）：
 ```go
-profile := defaultProbeProfile
-if pp, ok := agentProvider.(agentpkg.ProbeProfileProvider); ok {
-    profile = pp.ProbeProfile()
+func (o *probeOrchestrator) startWatch(session, agentType string) {
+    target := session + ":"  // tmux target convention; matches existing callsite
+    profile := defaultProbeProfile
+    if pp, ok := agentProvider.(agentpkg.ProbeProfileProvider); ok {
+        profile = pp.ProbeProfile()
+    }
+    opts := probe.WatchOptions{
+        TopLines:        profile.TopLines,        // 0 = full screen
+        IdleStableTicks: profile.IdleStableTicks, // 0 = default 3 (handled by watchLoop)
+    }
+    o.parent.prober.Watch(target, opts, o.makeCallback(session, agentType))
 }
-opts := probe.WatchOptions{
-    TopLines:        profile.TopLines,        // 0 = full screen
-    IdleStableTicks: profile.IdleStableTicks, // 0 = default 3 (handled by watchLoop)
-}
-o.parent.prober.Watch(target, opts, o.makeCallback(session, agentType))
 ```
+
+對應 `stopWatch`：
+```go
+func (o *probeOrchestrator) stopWatch(session string) {
+    target := session + ":"  // R7 fix — same target convention
+    o.parent.prober.StopWatch(target)
+}
+```
+
+**Caller 端 contract**（R7 fix）：caller 傳 `session`（無 ":" 後綴），orchestrator 自己加 ":" 變成 tmux target；對齊既有 `m.prober.StartWatch(session+":", ...)` 慣例。
 
 #### 2.3.4 stale-callback guard（R4 fix） + graceWindow 解讀
 
@@ -492,7 +506,7 @@ if agentType, ok := m.activeWatchers[oldName]; ok {
 
 `internal/module/agent/handler.go` 的 hook entry path（具體位置實作時定）：每個有效 hook 處理完前 call `m.probeOrch.recordHookAt(session)`，讓接下來 graceWindow 啟動。
 
-#### 2.4.4 測試（5 tests）
+#### 2.4.4 測試（6 tests — R2 +CC6）
 
 | Test | 重點 |
 |------|------|

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.12 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.13 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.12（Round 12 codex review fix — 1 P1 substantive 採納）
+**Status**: draft v1.13（Round 13 codex review fix — 1 P1 + 1 P2 採納）
 
 ## v1.x 演進
 
@@ -19,6 +19,7 @@
 | v1.10 | R10 codex review fix（2 P2 — R9-propagation gaps）：(1) §2.1.3 watchLoop pseudo-code 啟動描述只 branch `opts.TopLines`，沒處理新加的 `opts.BottomLines`；implementer 照寫，default profile `{BottomLines: 10}` 會 fallback 到 full pane capture，破壞 G5 parity；補成三分支（TopLines / BottomLines / 全零=full pane）；(2) §2.3.3 殘留 v1.8 stale 宣告 `var defaultProbeProfile = ProbeProfile{TopLines: 10, IdleStableTicks: 3}`，與下一段 R9 fix 的 `{BottomLines: 10}` 互斥同存；移除 stale 宣告 |
 | v1.11 | R11 codex review fix（1 P2 substantive + 1 P2 editorial）：(1) **substantive** — 新 watch-loop-owned watcher 對 spinner / elapsed-timer 每 tick fire ScreenChanged；orchestrator 每 500ms 重廣播 Running，違反 G5 parity（legacy fires once 後退出）。對稱於 R1 fix #2 的 `stableEmitted`，加 `changedEmitted` flag — 每次 stable→changed transition fire ScreenChanged 一次，下次 ScreenStable fire 後重新 arm；新增 PR1b 測試覆蓋連續 changed 無重發；(2) **editorial** — OR2 default profile fallback 期待還寫 `{TopLines: 10, IdleStableTicks: 3}`，與 R9/R10 default `{BottomLines: 10}` 矛盾；修為 `{BottomLines: 10, IdleStableTicks: 3}` |
 | v1.12 | R12 codex review fix（1 P1 substantive — graceWindow / changedEmitted 互動 bug）：場景：hook 觸發 → orchestrator.recordHookAt → graceWindow 2s 內 watcher fire ScreenChanged → probe 已 set `changedEmitted=true` 但 orchestrator suppress 廣播；若 pane 之後持續 changing（spinner / elapsed timer），watch loop 不會見到 ScreenStable transition → `changedEmitted` 永不 reset → 後續 ScreenChanged 不再 fire → 狀態永遠停在 hook-derived。修法：probe 加 `RearmChanged(target string)` + `RearmStable(target string)` 公開 API（symmetric 對稱），orchestrator 在 graceWindow suppress 時呼叫 `RearmChanged` 讓 probe 下次 diff 重新 emit；新增 PR4c + OR3b regression test |
+| v1.13 | R13 codex review fix（1 P1 + 1 P2）：(1) **P1** — v1.12 watchLoop pseudo 是 `cb() → changedEmitted=true`，但 cb 同步呼叫 `RearmChanged` 會 `Store(false)`，下一行又覆蓋成 `true` → R12 fix 失效。修為「先 set flag，再 call cb」順序（symmetric 對 stableEmitted 也修）；明列 watch loop **必須** 用 set-before-cb 順序，禁止 set-after-cb 實作；(2) **P2** — PR3 `TestWatch_DoesNotExitOnCallback` v1 期待「一次 ScreenChanged 後再注入 diff 再 fire ScreenChanged」與 R11 changedEmitted 行為矛盾（同一 changing run 不再 fire）。改寫為 PR3 `TestWatch_LoopContinuesAcrossTransitions`：驗證 changed → stable → changed 完整 cycle，watcher 不退出；single-cycle continuous diff 由 PR1b 覆蓋 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -255,8 +256,12 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
       if !ok: continue (skip tick, don't fire false event)
       if hash(current) != hash(baseline):
         if !changedEmitted:
-          cb(ScreenChanged{Content: current})
+          // R13 fix: set flag BEFORE cb to survive synchronous Rearm
+          // calls in the callback (orchestrator graceWindow → RearmChanged).
+          // If cb's RearmChanged sets changedEmitted=false, that wins
+          // (intended); set-after-cb would silently overwrite Rearm.
           changedEmitted = true
+          cb(ScreenChanged{Content: current})
         stableEmitted = false  // change re-arms stable for next cycle
         baseline = current
         stableCount = 0
@@ -264,11 +269,14 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
       // hash unchanged
       stableCount++
       if !stableEmitted && stableCount >= idleStableTicks:
-        cb(ScreenStable{Content: current})
+        // R13 fix (symmetric): set flag BEFORE cb (same reason as above).
         stableEmitted = true
         changedEmitted = false  // R11 fix: stable re-arms changed for next cycle
+        cb(ScreenStable{Content: current})
         // do NOT reset stableCount; do NOT re-emit ScreenStable until next change
   ```
+
+**R13 fix 順序約束**：watch loop **必須**用 set-emit-flag-before-cb 順序。set-after-cb 路徑禁止 — 會與 callback 同步呼叫 `RearmChanged` / `RearmStable` 互覆蓋（callback 設為 false → loop 設回 true → R12 修的 stuck-status bug 復現）。本約束適用兩個 emit 點。
 - **關鍵差異 vs legacy `activityLoop`**：watcher 不退出；可發多次 ScreenChanged + ScreenStable transitions；callback 不擁有 watcher 生命週期；同一 stable run 不會重發 ScreenStable；同一 changing run 不會重發 ScreenChanged
 - **R1 fix #2 rationale**：legacy `activityLoop` 自動退出後不存在 repeated emission 問題；新 watch-loop-owned 設計若不加 `stableEmitted` flag，idle pane 會每 N ticks 重發 ScreenStable → orchestrator 對應重發 StatusIdle broadcast → metrics counter 無限累積 + log 噴 + WS 客戶端收 idle 風暴。`stableEmitted` 確保「stable run 視為一個 transition，到下次 change 才再 arm」
 - **R11 fix rationale**：對稱於 R1 fix #2 — spinner / elapsed-timer 場景每 tick hash diff，若不加 `changedEmitted` flag，新 watch-loop-owned 會每 500ms fire ScreenChanged → orchestrator 重廣播 StatusRunning → 同樣 ws/metrics 風暴；違反 G5 default-profile parity（legacy fire once 後退出，behavior 上 Running 只廣播一次）。雙 flag 形成「changed↔stable 兩 transition，各 arm/disarm 對方」狀態機，每個 transition 各自只 fire 一次
@@ -322,7 +330,7 @@ select <-rearmStable:  stableEmitted = false; continue
 | PR1b `TestWatch_ChangedEmittedOnceUntilNextStable`（**R11 fix #1 regression**）| 注入連續 6 次不同 capture（baseline + 5 diff）— 驗證 ScreenChanged 只 fire 1 次（changedEmitted 後續 tick 抑制）；接著注入 4 次同 capture → ScreenStable fire；再注入 1 次 diff → ScreenChanged 再 fire 1 次（stable→changed re-arm）|
 | PR2 `TestWatch_FiresStableAfterNIdenticalSamples` | 連續 4 次同 capture，驗證單次 ScreenStable callback（baseline + 3 stable ticks）|
 | PR2b `TestWatch_StableEmittedOnceUntilNextChange`（**R1 fix #2 regression**）| 注入 6 次同 capture（baseline + 5 stable）— 驗證 ScreenStable 只 fire 1 次；接著注入 diff → ScreenChanged fire；再注入 4 同 → ScreenStable 再 fire 1 次（changed→stable 切換才 re-arm）|
-| PR3 `TestWatch_DoesNotExitOnCallback` | 一次 ScreenChanged callback 後再注入 diff，驗證再發 ScreenChanged（loop 持續）|
+| PR3 `TestWatch_LoopContinuesAcrossTransitions`（**R13 fix — 重寫**）| 注入 changed → 4 stable → diff 完整 cycle（baseline + diff → ScreenChanged + 4 同 → ScreenStable + diff → ScreenChanged 再 fire）；驗證 watcher 不退出、stable 與 changed 都各 fire 兩次（兩次 transition）；single-cycle continuous-diff 不重發 由 PR1b 覆蓋 |
 | PR4 `TestWatch_StopWatch_CancelsLoop` | StopWatch 後 capture mock 不再被 call、HasWatcher false |
 | PR4b `TestWatch_BaselineFailure_CleansMapEntry`（**R2 fix #2 regression**）| capture mock 對 first call 回 err；驗證 `Watch` 啟動後 200ms 內 `HasWatcher(target) == false`（goroutine 自己清 entry）|
 | PR4c `TestWatch_RearmChanged_AllowsReEmission`（**R12 fix regression**）| 注入 1 次 diff → ScreenChanged fire；不等 ScreenStable，直接 call `RearmChanged(target)`；再注入 1 次 diff → ScreenChanged 再 fire；symmetric for RearmStable |

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.13 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.14 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.13（Round 13 codex review fix — 1 P1 + 1 P2 採納）
+**Status**: draft v1.14（Round 14 codex review fix — 2 P2 substantive 採納）
 
 ## v1.x 演進
 
@@ -20,6 +20,7 @@
 | v1.11 | R11 codex review fix（1 P2 substantive + 1 P2 editorial）：(1) **substantive** — 新 watch-loop-owned watcher 對 spinner / elapsed-timer 每 tick fire ScreenChanged；orchestrator 每 500ms 重廣播 Running，違反 G5 parity（legacy fires once 後退出）。對稱於 R1 fix #2 的 `stableEmitted`，加 `changedEmitted` flag — 每次 stable→changed transition fire ScreenChanged 一次，下次 ScreenStable fire 後重新 arm；新增 PR1b 測試覆蓋連續 changed 無重發；(2) **editorial** — OR2 default profile fallback 期待還寫 `{TopLines: 10, IdleStableTicks: 3}`，與 R9/R10 default `{BottomLines: 10}` 矛盾；修為 `{BottomLines: 10, IdleStableTicks: 3}` |
 | v1.12 | R12 codex review fix（1 P1 substantive — graceWindow / changedEmitted 互動 bug）：場景：hook 觸發 → orchestrator.recordHookAt → graceWindow 2s 內 watcher fire ScreenChanged → probe 已 set `changedEmitted=true` 但 orchestrator suppress 廣播；若 pane 之後持續 changing（spinner / elapsed timer），watch loop 不會見到 ScreenStable transition → `changedEmitted` 永不 reset → 後續 ScreenChanged 不再 fire → 狀態永遠停在 hook-derived。修法：probe 加 `RearmChanged(target string)` + `RearmStable(target string)` 公開 API（symmetric 對稱），orchestrator 在 graceWindow suppress 時呼叫 `RearmChanged` 讓 probe 下次 diff 重新 emit；新增 PR4c + OR3b regression test |
 | v1.13 | R13 codex review fix（1 P1 + 1 P2）：(1) **P1** — v1.12 watchLoop pseudo 是 `cb() → changedEmitted=true`，但 cb 同步呼叫 `RearmChanged` 會 `Store(false)`，下一行又覆蓋成 `true` → R12 fix 失效。修為「先 set flag，再 call cb」順序（symmetric 對 stableEmitted 也修）；明列 watch loop **必須** 用 set-before-cb 順序，禁止 set-after-cb 實作；(2) **P2** — PR3 `TestWatch_DoesNotExitOnCallback` v1 期待「一次 ScreenChanged 後再注入 diff 再 fire ScreenChanged」與 R11 changedEmitted 行為矛盾（同一 changing run 不再 fire）。改寫為 PR3 `TestWatch_LoopContinuesAcrossTransitions`：驗證 changed → stable → changed 完整 cycle，watcher 不退出；single-cycle continuous diff 由 PR1b 覆蓋 |
+| v1.14 | R14 codex review fix（2 P2 substantive）：(1) **shell prompt capture region mismatch** — cc 用 `TopLines: 12` 時 `ev.Content` 只含頂部 12 行；ScreenStable shellprompt 分支 `LooksLikeShellPrompt(ev.Content)` 會 miss 底部 shell prompt → dead-PID + shellprompt 場景的 sweepOnce cleanup 不會跑 → 與 legacy bottom-line capture 行為不對齊。修法：orchestrator interpretScreenEvent ScreenStable 分支獨立做一次 `tmux.CapturePaneContent(target, 10)` 取底部 10 行作 shellprompt 分類（不依賴 ev.Content）；新增 OR8 regression 涵蓋 cc TopLines + bottom shell prompt + dead PID 場景；(2) **nil-prober guard 漏列** — orchestrator startWatch/stopWatch pseudocode 直接呼 `o.parent.prober.Watch`，但 plan 宣告 orchestrator 內部會做 prober nil-check（保留 legacy `if m.prober != nil` 行為）。補入 explicit nil guard 兩處 + 文件化 module 測試與部分初始化 path 的兼容契約 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -429,6 +430,13 @@ orchestrator `startWatch` 邏輯：
 var defaultProbeProfile = agentpkg.ProbeProfile{BottomLines: 10, IdleStableTicks: 3}
 
 func (o *probeOrchestrator) startWatch(session, agentType string) {
+    // R14 fix: nil-prober guard preserves legacy compatibility for
+    // module unit tests and partially-initialized Module instances
+    // that don't wire a real prober. Without this guard, the
+    // unconditional Watch call below panics on those paths.
+    if o.parent.prober == nil {
+        return
+    }
     target := session + ":"  // tmux target convention; matches existing callsite
 
     // R8 fix: resolve provider from registry; assert ProbeProfileProvider.
@@ -456,6 +464,9 @@ func (o *probeOrchestrator) startWatch(session, agentType string) {
 對應 `stopWatch`：
 ```go
 func (o *probeOrchestrator) stopWatch(session string) {
+    if o.parent.prober == nil {  // R14 fix — symmetric nil guard
+        return
+    }
     target := session + ":"  // R7 fix — same target convention
     o.parent.prober.StopWatch(target)
 }
@@ -515,14 +526,23 @@ if hasHook && time.Since(last) < probeGraceWindow {
 }
 ```
 
-#### 2.3.5 ScreenStable → Status 解讀
+#### 2.3.5 ScreenStable → Status 解讀（R14 fix — shell prompt 用獨立 bottom capture）
 
 ```go
 switch ev.Kind {
 case probe.ScreenChanged:
     status = StatusRunning
 case probe.ScreenStable:
-    if probe.LooksLikeShellPrompt(ev.Content) {
+    // R14 fix: ev.Content 反映 watcher's opts.TopLines / opts.BottomLines /
+    // full-pane 設定；對 cc 用 TopLines: 12 profile 時，ev.Content 只含
+    // 頂部 12 行，**不含** 底部 shell prompt。LooksLikeShellPrompt(ev.Content)
+    // 會 false-negative，dead-PID + shell-prompt sweep 失效，違反 legacy
+    // bottom-line capture 行為。修法：獨立做一次底部 capture 給 shell-prompt
+    // classifier，不依賴 ev.Content。
+    target := session + ":"
+    bottomContent, err := o.parent.tmux.CapturePaneContent(target, 10)
+    isShellPrompt := err == nil && probe.LooksLikeShellPrompt(bottomContent)
+    if isShellPrompt {
         // 保留 legacy 行為：dead PID + shell prompt → sweep
         if projection != nil && projection.TopFrame != nil && !isPidAliveFn(projection.TopFrame.PID) {
             o.parent.sweepOnce()
@@ -535,9 +555,11 @@ case probe.ScreenStable:
 }
 ```
 
+**Tmux capture err 處理**：err != nil 視同 isShellPrompt=false（保守 — 不能斷定就走一般 idle 路徑）；不擋整個 interpretScreenEvent，只是 shell-prompt 分類失敗。
+
 接著套用 Error Guard + projection update + broadcast（與既有 `onActivityDetected` 同邏輯，整段搬入 helper）。
 
-#### 2.3.6 測試（7 tests — R4 +OR6 / R12 +OR3b）
+#### 2.3.6 測試（9 tests — R4 +OR6 / R12 +OR3b / R14 +OR7 +OR8）
 
 | Test | 重點 |
 |------|------|
@@ -548,6 +570,8 @@ case probe.ScreenStable:
 | OR4 `TestOrchestrator_GraceWindowExpiresAfterWindow` | recordHookAt → 3s 後注入 ScreenChanged；驗證 StatusRunning 廣播 |
 | OR5 `TestOrchestrator_ErrorGuardBlocksProbeOverwrite` | currentStatus=StatusError；ScreenStable 注入；驗證 StatusError 維持、無 broadcast |
 | OR6 `TestOrchestrator_StaleCallbackGuard`（**R4 fix regression**）| 兩 sub-case：(a) stopWatch 後注入 ScreenChanged → 無 broadcast、無 metrics；(b) renameSession 前 watch oldName，rename 後注入 oldName 的 ScreenChanged callback → 無 broadcast、無 status 更新（驗證 currentAgent != agentType 比對）|
+| OR7 `TestOrchestrator_NilProberStartStopNoOp`（**R14 fix #2 regression**）| Module 沒 wired prober（unit test fixture）→ orchestrator.startWatch / stopWatch / 都是 no-op，不 panic；驗證 partial-init compatibility |
+| OR8 `TestOrchestrator_ScreenStableUsesBottomCaptureForShellPrompt`（**R14 fix #1 regression**）| cc agent 走 TopLines: 12 profile；mock tmux 回 ev.Content（top 12 行，**無** shell prompt）；orchestrator 收 ScreenStable → 獨立 call CapturePaneContent(target, 10) 拿底部 → mock 回 `"$ "` 終止行 → projection.TopFrame.PID dead → 驗證 `o.parent.sweepOnce` 被呼叫；對照組：bottomContent 沒 shell prompt → status=Idle 廣播，無 sweep |
 
 ---
 
@@ -676,11 +700,11 @@ log 點（gated）：
 | 0 | TT1-TT4 | 4 | tmux range API + fake executor parity |
 | 1 | PR1-PR1b + PR2-PR2b + PR3-PR4c + PR5-PR5b + PR6 | 11 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ baseline-fail map cleanup（R2 fix #2）/ BottomLines vs TopLines mutually exclusive（R9 fix）/ changed-emit-once（R11 fix）/ **Rearm API（R12 fix）**|
 | 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
-| 3 | OR1-OR6 + OR3b | 7 | profile / graceWindow / Error Guard / stale-callback guard（R4 fix）/ **graceWindow re-arm probe（R12 fix）**|
+| 3 | OR1-OR6 + OR3b + OR7-OR8 | 9 | profile / graceWindow / Error Guard / stale-callback guard（R4 fix）/ graceWindow re-arm probe（R12 fix）/ **nil-prober no-op（R14 fix #2）/ shellprompt bottom-capture（R14 fix #1）**|
 | 4 | CC1-CC6 | 6 | cc profile + module wiring + E2E + rename rewatch via orchestrator（R2 fix #1）|
 | 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
 
-**總計**：32 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 / +1 PR5b R9 / +1 PR1b R11 / +1 PR4c R12 / +1 OR3b R12 regression tests）。
+**總計**：34 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 / +1 PR5b R9 / +1 PR1b R11 / +1 PR4c R12 / +1 OR3b R12 / +1 OR7 R14 / +1 OR8 R14 regression tests）。
 
 ---
 
@@ -815,12 +839,12 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | 0 tmux API | ~40 | 4 |
 | 1 probe primitive | ~115 | 11（R1 +PR2b / R2 +PR4b / R9 +PR5b / R11 +PR1b / R12 +PR4c）|
 | 2 shell prompt export | ~5 | 0 |
-| 3 module orchestrator | ~95 | 7（R4 +OR6 / R12 +OR3b）|
+| 3 module orchestrator | ~110 | 9（R4 +OR6 / R12 +OR3b / R14 +OR7 +OR8）|
 | 4 cc adoption | ~50 | 6（R2 +CC6 rename）|
 | 7 graceWindow + dev log + expvar | ~30 | 4 |
 | (extra) boundary script | ~30 | 0 |
 
-**總計**：~370 LoC + 32 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1 / R9 +1 / R11 +1 / R12 +2，總 +8 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard + R9 BottomLines field + capture-mode dispatcher + R11 changedEmitted flag + R12 Rearm API ~50 LoC，仍在 PR 合理 size 內）。
+**總計**：~390 LoC + 34 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1 / R9 +1 / R11 +1 / R12 +2 / R14 +2，總 +10 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard + R9 BottomLines field + capture-mode dispatcher + R11 changedEmitted flag + R12 Rearm API + R14 bottom shellprompt capture + nil-prober guards ~70 LoC，仍在 PR 合理 size 內）。
 
 **屬中型 PR**。`go test` 預期 elapsed < 30s 內。
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.2 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.3 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.2（Round 2 codex review fix — `review-moh4f3ts-XXXXXX`，1 P1 + 1 P2 findings 全採納）
+**Status**: draft v1.3（Round 3 codex review fix — 1 P1 deadlock finding 採納）
 
 ## v1.x 演進
 
@@ -9,6 +9,7 @@
 | v1 | 初版起草（6 slices / 24 tests / ~305 LoC）|
 | v1.1 | R1 codex review fix（`review-moh40grn-u7wxgv`，2 P2）：(1) API gap — `WatchTopLines` / `WatchFullScreen` 無法接收 `IdleStableTicks`；併為單一 `Watch(target, opts, cb)` + `WatchOptions{TopLines, IdleStableTicks}`；(2) repeated stable emission — `stableEmitted` flag 確保每次 changed→stable transition 只觸發一次 ScreenStable；新增 PR2b 測試覆蓋連續穩定無重發 |
 | v1.2 | R2 codex review fix（1 P1 + 1 P2）：(1) **rename rewatch path** — `renameSessionLocked` (module.go:258) 也呼叫 `StartWatch(newName+":", ...)`；plan 必須一併走 orchestrator + 加 rename regression test；(2) **baseline 失敗 cleanup race** — 初始 capture 失敗時 `watchLoop` 直接 return 但 watcher map 已註冊；新增 baseline-fail-cleanup 邏輯與 PR4b 測試 |
+| v1.3 | R3 codex review fix（1 P1 deadlock）：v1.2 §2.3.1 orchestrator API docstring 寫 `stopWatch` / `startWatch` 會 clear `activeWatchers`，但 `renameSessionLocked` 持 `m.mu` 時呼叫，會與內部要 acquire `m.mu` 的清理路徑互鎖（非可重入 mutex）。**改 API contract**：orchestrator 只碰 `prober` + `lastHookAt` + metrics，**不觸 `activeWatchers`**；caller（module.go wrapper）管理 `activeWatchers`。同時對齊 `interpretScreenEvent` 的 Error Guard 邏輯沿用 legacy 既有 lock 模式（讀 + 寫各自一次 m.mu.Lock/Unlock，不持鎖跨呼叫）|
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -282,9 +283,17 @@ func newProbeOrchestrator(m *Module) *probeOrchestrator {...}
 
 // startWatch starts a probe watcher for the session, using agent's profile.
 // Replaces inline call to m.prober.StartWatch in manageActivityWatch.
+// NOTE (R3 fix): orchestrator does NOT touch m.activeWatchers — see
+// stopWatch comment. Callers (module.go wrappers) own the activeWatchers
+// transitions; orchestrator just resolves profile + invokes prober.Watch.
 func (o *probeOrchestrator) startWatch(session, agentType string) {...}
 
-// stopWatch stops the probe watcher and clears activeWatchers entry.
+// stopWatch stops the probe watcher for the session.
+// NOTE (R3 fix): orchestrator does NOT touch m.activeWatchers — that
+// map is owned by Module.manageActivityWatch and renameSessionLocked
+// callers, which already serialize updates under m.mu. Keeping
+// orchestrator lock-free with respect to m.mu lets renameSessionLocked
+// call stopWatch/startWatch while holding m.mu without deadlocking.
 func (o *probeOrchestrator) stopWatch(session string) {...}
 
 // recordHookAt records that a hook event was just processed for this session.
@@ -431,16 +440,21 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
 把 `renameSessionLocked` 中的 watcher 段落改成（保留既有 m.mu held + activeWatchers transfer 邏輯）：
 
 ```go
-// In renameSessionLocked, after activeWatchers transfer:
+// In renameSessionLocked, runs with m.mu held (caller contract):
 if agentType, ok := m.activeWatchers[oldName]; ok {
+    // activeWatchers transfer (m.mu-protected map mutation)
     delete(m.activeWatchers, oldName)
-    m.probeOrch.stopWatch(oldName)
     m.activeWatchers[newName] = agentType
+    // orchestrator calls (R3 fix: lock-free wrt m.mu, safe under hold)
+    m.probeOrch.stopWatch(oldName)
     m.probeOrch.startWatch(newName, agentType)
 }
 ```
 
-注意：orchestrator `startWatch` / `stopWatch` 內部會處理 prober nil-check（保留 legacy `if m.prober != nil` 行為），rename callsite 不必重複檢查。
+注意（R3 fix）：
+- `activeWatchers` map 的 transfer 由 `renameSessionLocked` 自己做（持 `m.mu` 是其 contract），orchestrator API 不觸 `activeWatchers`，故此處不會 deadlock
+- orchestrator `startWatch` / `stopWatch` 內部對 `prober` 的呼叫使用 `prober` 自己的 `watcherMu`（與 `m.mu` 不同 mutex），可重入安全
+- orchestrator 內部會處理 prober nil-check（保留 legacy `if m.prober != nil` 行為），rename callsite 不必重複檢查
 
 舊 `onActivityDetected` 整個刪掉（邏輯已搬到 orchestrator.interpretScreenEvent；本 PR 範圍內 cc 走新 path，codex / opencode 也透過 default profile 走同一份 helper — 但 codex / opencode 的 TopN 微調留 PR-4a-2，本 PR 三家共用 default profile = 行為向下相容）。
 
@@ -457,7 +471,7 @@ if agentType, ok := m.activeWatchers[oldName]; ok {
 | CC3 `TestModule_HookHandler_CallsRecordHookAt` | 注入 cc hook event；驗證 orchestrator.lastHookAt[session] 記錄到 |
 | CC4 `TestCC_E2E_ScreenChangedToRunning` | cc waiting → orchestrator.startWatch → 注入 ScreenChanged → status 廣播 Running |
 | CC5 `TestCC_E2E_ScreenStableToIdle` | cc running → orchestrator.startWatch → 注入 ScreenStable（non-shell-prompt）→ status 廣播 Idle |
-| CC6 `TestCC_RenameSession_RestartsWatchViaOrchestrator`（**R2 fix #1 regression**）| cc running on `oldname:` → `RenameSession(oldname, newname)` → 驗證 orchestrator.stopWatch(oldname) + startWatch(newname) 各 call 一次 + activeWatchers map key 從 oldname 遷到 newname |
+| CC6 `TestCC_RenameSession_RestartsWatchViaOrchestrator`（**R2 fix #1 + R3 deadlock-freedom regression**）| cc running on `oldname:` → `RenameSession(oldname, newname)` → 驗證 (a) orchestrator.stopWatch(oldname) + startWatch(newname) 各 call 一次；(b) activeWatchers map key 從 oldname 遷到 newname；(c) 整個操作在 t.Run 內 100ms timeout 完成（deadlock 會 hang，此測試 CI run with `-race -timeout=30s` 也是 fail-loud）|
 
 ---
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.3 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.4 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.3（Round 3 codex review fix — 1 P1 deadlock finding 採納）
+**Status**: draft v1.4（Round 4 codex review fix — 1 P2 stale-callback finding 採納）
 
 ## v1.x 演進
 
@@ -10,6 +10,7 @@
 | v1.1 | R1 codex review fix（`review-moh40grn-u7wxgv`，2 P2）：(1) API gap — `WatchTopLines` / `WatchFullScreen` 無法接收 `IdleStableTicks`；併為單一 `Watch(target, opts, cb)` + `WatchOptions{TopLines, IdleStableTicks}`；(2) repeated stable emission — `stableEmitted` flag 確保每次 changed→stable transition 只觸發一次 ScreenStable；新增 PR2b 測試覆蓋連續穩定無重發 |
 | v1.2 | R2 codex review fix（1 P1 + 1 P2）：(1) **rename rewatch path** — `renameSessionLocked` (module.go:258) 也呼叫 `StartWatch(newName+":", ...)`；plan 必須一併走 orchestrator + 加 rename regression test；(2) **baseline 失敗 cleanup race** — 初始 capture 失敗時 `watchLoop` 直接 return 但 watcher map 已註冊；新增 baseline-fail-cleanup 邏輯與 PR4b 測試 |
 | v1.3 | R3 codex review fix（1 P1 deadlock）：v1.2 §2.3.1 orchestrator API docstring 寫 `stopWatch` / `startWatch` 會 clear `activeWatchers`，但 `renameSessionLocked` 持 `m.mu` 時呼叫，會與內部要 acquire `m.mu` 的清理路徑互鎖（非可重入 mutex）。**改 API contract**：orchestrator 只碰 `prober` + `lastHookAt` + metrics，**不觸 `activeWatchers`**；caller（module.go wrapper）管理 `activeWatchers`。同時對齊 `interpretScreenEvent` 的 Error Guard 邏輯沿用 legacy 既有 lock 模式（讀 + 寫各自一次 m.mu.Lock/Unlock，不持鎖跨呼叫）|
+| v1.4 | R4 codex review fix（1 P2 stale-callback guard）：legacy `onActivityDetected` (module.go:473) 開頭檢查 `activeWatchers[session]` 不存在則 return，這個 stale-callback guard v1.3 plan 漏搬。新 watch-loop-owned watcher fire callback 多次（不像 legacy fire 一次就退），**此 guard 比 legacy 更必要** — stopWatch / rename race 中 in-flight callback 會在 watcher 已停的情況下繼續更新 status / broadcast。`interpretScreenEvent` 開頭加 `currentAgent, active := m.activeWatchers[session]; if !active \|\| currentAgent != agentType { return }`；新增 OR6 regression test |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -343,9 +344,32 @@ opts := probe.WatchOptions{
 o.parent.prober.Watch(target, opts, o.makeCallback(session, agentType))
 ```
 
-#### 2.3.4 graceWindow 解讀
+#### 2.3.4 stale-callback guard（R4 fix） + graceWindow 解讀
 
-`interpretScreenEvent` 開頭：
+`interpretScreenEvent` 開頭兩個 guard，順序：
+
+**Guard 1 — stale callback 檢查（R4 fix）**：
+
+watch-loop-owned watcher 不再 fire-once-then-exit；callback 多次觸發。stopWatch / rename 都會與 in-flight callback 競態：
+- `stopWatch(session)` 後 callback 仍可能跑出來 — `activeWatchers[session]` 已 delete
+- `renameSessionLocked` 把 oldName 從 activeWatchers 搬到 newName — oldName 的 callback closure 仍 reference 舊 session 字串
+
+不檢查就 broadcast，會在 watcher 已停 / 已 rename 後對舊 session 廣播狀態（ghost broadcast）。
+
+```go
+o.parent.mu.Lock()
+currentAgent, active := o.parent.activeWatchers[session]
+o.parent.mu.Unlock()
+if !active || currentAgent != agentType {
+    // Stale callback (post-stop or post-rename); skip.
+    // Note: we intentionally do NOT delete from activeWatchers here,
+    //       unlike legacy onActivityDetected which fired once + exited.
+    return
+}
+```
+
+**Guard 2 — graceWindow 解讀**：
+
 ```go
 o.graceMu.Lock()
 last, hasHook := o.lastHookAt[session]
@@ -381,7 +405,7 @@ case probe.ScreenStable:
 
 接著套用 Error Guard + projection update + broadcast（與既有 `onActivityDetected` 同邏輯，整段搬入 helper）。
 
-#### 2.3.6 測試（5 tests）
+#### 2.3.6 測試（6 tests — R4 +1 OR6）
 
 | Test | 重點 |
 |------|------|
@@ -390,6 +414,7 @@ case probe.ScreenStable:
 | OR3 `TestOrchestrator_GraceWindowSuppressesEventWithinWindow` | recordHookAt → 1s 後注入 ScreenChanged；驗證無狀態變化、metrics counter +1 |
 | OR4 `TestOrchestrator_GraceWindowExpiresAfterWindow` | recordHookAt → 3s 後注入 ScreenChanged；驗證 StatusRunning 廣播 |
 | OR5 `TestOrchestrator_ErrorGuardBlocksProbeOverwrite` | currentStatus=StatusError；ScreenStable 注入；驗證 StatusError 維持、無 broadcast |
+| OR6 `TestOrchestrator_StaleCallbackGuard`（**R4 fix regression**）| 兩 sub-case：(a) stopWatch 後注入 ScreenChanged → 無 broadcast、無 metrics；(b) renameSession 前 watch oldName，rename 後注入 oldName 的 ScreenChanged callback → 無 broadcast、無 status 更新（驗證 currentAgent != agentType 比對）|
 
 ---
 
@@ -516,13 +541,13 @@ log 點（gated）：
 | Slice | Test ID 區段 | 數量 | 涵蓋 |
 |-------|--------------|------|------|
 | 0 | TT1-TT4 | 4 | tmux range API + fake executor parity |
-| 1 | PR1-PR2b + PR3-PR4b + PR5-PR6 | 8 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ **baseline-fail map cleanup（R2 fix #2）**|
+| 1 | PR1-PR2b + PR3-PR4b + PR5-PR6 | 8 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ baseline-fail map cleanup（R2 fix #2）|
 | 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
-| 3 | OR1-OR5 | 5 | profile / graceWindow / Error Guard |
-| 4 | CC1-CC6 | 6 | cc profile + module wiring + E2E + **rename rewatch via orchestrator（R2 fix #1）**|
+| 3 | OR1-OR6 | 6 | profile / graceWindow / Error Guard / **stale-callback guard（R4 fix）**|
+| 4 | CC1-CC6 | 6 | cc profile + module wiring + E2E + rename rewatch via orchestrator（R2 fix #1）|
 | 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
 
-**總計**：27 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 + +1 PR4b R2 + +1 CC6 R2 regression tests）。
+**總計**：28 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 regression tests）。
 
 ---
 
@@ -656,12 +681,12 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | 0 tmux API | ~40 | 4 |
 | 1 probe primitive | ~90 | 8（R1 +PR2b / R2 +PR4b）|
 | 2 shell prompt export | ~5 | 0 |
-| 3 module orchestrator | ~80 | 5 |
+| 3 module orchestrator | ~85 | 6（R4 +OR6）|
 | 4 cc adoption | ~50 | 6（R2 +CC6 rename）|
 | 7 graceWindow + dev log + expvar | ~30 | 4 |
 | (extra) boundary script | ~30 | 0 |
 
-**總計**：~325 LoC + 27 tests（plan v1.3 §7.1 estimate 24，本版 R1 +1 / R2 +2 regression tests + R2 baseline-fail cleanup + rename callsite migration ~15 LoC，仍在 PR 合理 size 內）。
+**總計**：~330 LoC + 28 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1，總 +4 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard ~20 LoC，仍在 PR 合理 size 內）。
 
 **屬中型 PR**。`go test` 預期 elapsed < 30s 內。
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.14 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v2.0 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.14（Round 14 codex review fix — 2 P2 substantive 採納）
+**Status**: draft v2.0（**架構 pivot** — 移除 probe-layer dedup state machine；改採 orchestrator-only transition dedup。依 codex consulting `task-moh5xafl-gx2zt1` 結論執行）
 
 ## v1.x 演進
 
@@ -21,6 +21,7 @@
 | v1.12 | R12 codex review fix（1 P1 substantive — graceWindow / changedEmitted 互動 bug）：場景：hook 觸發 → orchestrator.recordHookAt → graceWindow 2s 內 watcher fire ScreenChanged → probe 已 set `changedEmitted=true` 但 orchestrator suppress 廣播；若 pane 之後持續 changing（spinner / elapsed timer），watch loop 不會見到 ScreenStable transition → `changedEmitted` 永不 reset → 後續 ScreenChanged 不再 fire → 狀態永遠停在 hook-derived。修法：probe 加 `RearmChanged(target string)` + `RearmStable(target string)` 公開 API（symmetric 對稱），orchestrator 在 graceWindow suppress 時呼叫 `RearmChanged` 讓 probe 下次 diff 重新 emit；新增 PR4c + OR3b regression test |
 | v1.13 | R13 codex review fix（1 P1 + 1 P2）：(1) **P1** — v1.12 watchLoop pseudo 是 `cb() → changedEmitted=true`，但 cb 同步呼叫 `RearmChanged` 會 `Store(false)`，下一行又覆蓋成 `true` → R12 fix 失效。修為「先 set flag，再 call cb」順序（symmetric 對 stableEmitted 也修）；明列 watch loop **必須** 用 set-before-cb 順序，禁止 set-after-cb 實作；(2) **P2** — PR3 `TestWatch_DoesNotExitOnCallback` v1 期待「一次 ScreenChanged 後再注入 diff 再 fire ScreenChanged」與 R11 changedEmitted 行為矛盾（同一 changing run 不再 fire）。改寫為 PR3 `TestWatch_LoopContinuesAcrossTransitions`：驗證 changed → stable → changed 完整 cycle，watcher 不退出；single-cycle continuous diff 由 PR1b 覆蓋 |
 | v1.14 | R14 codex review fix（2 P2 substantive）：(1) **shell prompt capture region mismatch** — cc 用 `TopLines: 12` 時 `ev.Content` 只含頂部 12 行；ScreenStable shellprompt 分支 `LooksLikeShellPrompt(ev.Content)` 會 miss 底部 shell prompt → dead-PID + shellprompt 場景的 sweepOnce cleanup 不會跑 → 與 legacy bottom-line capture 行為不對齊。修法：orchestrator interpretScreenEvent ScreenStable 分支獨立做一次 `tmux.CapturePaneContent(target, 10)` 取底部 10 行作 shellprompt 分類（不依賴 ev.Content）；新增 OR8 regression 涵蓋 cc TopLines + bottom shell prompt + dead PID 場景；(2) **nil-prober guard 漏列** — orchestrator startWatch/stopWatch pseudocode 直接呼 `o.parent.prober.Watch`，但 plan 宣告 orchestrator 內部會做 prober nil-check（保留 legacy `if m.prober != nil` 行為）。補入 explicit nil guard 兩處 + 文件化 module 測試與部分初始化 path 的兼容契約 |
+| **v2.0** | **架構 pivot**（依 codex consulting `task-moh5xafl-gx2zt1` 投票結論）：v1.11-v1.13 的 changedEmitted / stableEmitted / Rearm API state machine 被連續 3 輪抓 corner case bug（R11 引入 → R12 graceWindow lifecycle → R13 cb-vs-set ordering），符合 `feedback_codex_meta_drift_signal.md` 「同類 meta-drift 連續 3 輪 = architectural smell，停手換架構」。執行 codex parallel consulting（A 假設前提為真求最佳實作；B 質疑前提）— **B 否決前提**：probe primitive 不該擁有 dedup state，dedup 應由 orchestrator 用 `currentStatus` 判 transition 處理。**移除**：`changedEmitted` / `stableEmitted` flags、`RearmChanged` / `RearmStable` public API、set-before-cb ordering rule、PR1b（changed-emit-once）/ PR2b（stable-emit-once）/ PR4c（Rearm regression）/ OR3b（graceWindow re-arm）四個 regression tests（在 Option 2 不再 applicable）。**簡化**：probe 變 dumb — diff 每 tick fire ScreenChanged；stableCount 達 threshold 後 fire ScreenStable + reset stableCount（每 N ticks fire 一次，無 emit-once flag）；orchestrator 用 `currentStatus[session]` 做 transition gate，only broadcast / metric / dev log on accepted transitions。**保留**：R3 deadlock fix / R4 stale-callback guard / R9-R10 BottomLines / R14 shellprompt bottom capture / R14 nil-prober guard（這些在 Option 2 仍 applicable）。**新增**：OR4（替換原 OR3b — graceWindow expire 後 continuous-changing 仍能 → Running，新版本不需 Rearm 即達成）+ OR9 / OR10 transition-dedup tests。Plan size: ~340 LoC + 32 tests（從 390 / 34 縮小）|
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -54,11 +55,13 @@ PR-4a-1 把目前 `internal/agent/probe/activity.go` 的 watcher 從「probe 解
 - `CapturePaneTopLines(target string, n int) (string, error)` — Top-N 糖衣
 - fake executor 對應實作 + `tmux.Executor` interface 擴增
 
-**Slice 1**：Probe primitive 重構
+**Slice 1**：Probe primitive 重構（v2.0 — dumb probe，無 dedup state）
 - 新增 `ScreenChangeEvent` struct + `ScreenChangeCallback`
-- 新增 `WatchOptions{TopLines int, BottomLines int, IdleStableTicks int}`（R1 fix #1 — 統一收 caller tuning，避免雙 API 分歧 + IdleStableTicks 無入口；R9 fix — 加 BottomLines 保留 legacy capture 語意）
+- 新增 `WatchOptions{TopLines int, BottomLines int, IdleStableTicks int}`（統一收 caller tuning；BottomLines 保留 legacy capture 語意 — R9 fix）
 - 新增 `Watch(target, opts, cb)` — 單一 entry，三 capture mode（互斥）：`TopLines > 0` → top-N / `BottomLines > 0` → legacy last-N / 全零 → full pane
-- `watchLoop` 統一內部 poll 機制；watcher 自治（callback 不再 cancel/delete）；**`stableEmitted` flag**（R1 fix #2）— ScreenStable 每次 changed→stable transition 只觸發一次，避免 idle 重發
+- `watchLoop` 統一內部 poll 機制；watcher 自治（callback 不再 cancel/delete）；**無 emit-once flag**（v2.0 pivot — dedup 由 orchestrator 處理）：
+  - 每 tick: hash diff → fire ScreenChanged + reset stableCount + update baseline
+  - stableCount 達 threshold → fire ScreenStable + reset stableCount（continuous stable 每 N ticks fire 一次）
 - **移除**：`activityLoop` 對 `ActivitySignal{Running, Idle, ShellPrompt}` 的解讀；`StartWatch` 簽名換成新 primitive；舊 callback 路徑由 module 層接管
 - **保留**：`StopWatch` / `StopAllWatches` / `HasWatcher` 維持原語意
 
@@ -204,10 +207,13 @@ type WatchOptions struct {
 }
 
 // Watch starts a screen change watcher on the target.
-// Emits ScreenChanged on hash diff; emits ScreenStable exactly once per
-// changed→stable transition (see watchLoop §2.1.3). The watcher persists
-// until StopWatch is called — callbacks do NOT terminate the watcher
-// (kickoff Decision 13: watch-loop-owned).
+// Emits ScreenChanged on each tick whose hash differs from baseline;
+// emits ScreenStable when stableCount reaches IdleStableTicks (then
+// resets stableCount and counts up again — continuous stable cycles
+// re-fire every N ticks). The watcher persists until StopWatch is
+// called — callbacks do NOT terminate the watcher (kickoff Decision 13:
+// watch-loop-owned). Probe does NOT track emit-once state; orchestrator
+// owns transition dedup via currentStatus (see §2.3).
 //
 // Capture mode is selected by opts:
 //   TopLines > 0      → CapturePaneTopLines(target, TopLines)
@@ -216,29 +222,30 @@ type WatchOptions struct {
 func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback) {...}
 ```
 
-**設計理由**（R1 fix #1 + R9 fix）：
+**設計理由**（v2.0 pivot — orchestrator-only dedup + R9 fix）：
 - 單一 entry 比雙 API 簡潔；TopLines / BottomLines / both-zero 三種 capture mode 由 sentinel 表達
 - `WatchOptions` 結構體擴展性好，未來加 poll interval / hash algorithm 等不破壞 API
 - IdleStableTicks 經由 opts 結構流入 watchLoop，OR1 test 可以對 cc profile `{TopLines:5, IdleStableTicks:2}` 驗 stable threshold
 - **R9 fix**：BottomLines 保留 legacy `CapturePaneContent(target, N)` 語意（hash last N lines），讓 default profile = `{BottomLines: 10}` 對未實作 ProbeProfileProvider 的 agent 維持原行為，達成 G5 parity gate
+- **v2.0 pivot**：probe 不持有「event 已對外生效」狀態。連續 changing pane 每 tick fire ScreenChanged；連續 stable pane 每 N ticks fire ScreenStable。orchestrator 透過 `currentStatus[session]` 比對做 transition gate — 同 status 不重複 broadcast / metric / log。dedup 是 module/orchestrator 概念，留在那一層；R11/R12/R13 cluster 在此架構不存在
 
 **caller 端**：orchestrator 拿 ProbeProfile 後組成 `WatchOptions{TopLines: profile.TopLines, BottomLines: profile.BottomLines, IdleStableTicks: profile.IdleStableTicks}` 傳入 `Watch`（§2.3.3 詳述）。
 
 **ProbeProfile 同步擴增**：`ProbeProfile` 也加 `BottomLines int` field（與 `TopLines` 互斥），讓 agent provider 可選擇 capture region 方向。詳 §2.3.2。
 
-#### 2.1.3 `watchLoop` 內部 poll 機制（含 R1 fix #2）
+#### 2.1.3 `watchLoop` 內部 poll 機制（v2.0 — dumb probe，無 emit-once flags）
 
 - 啟動：`captureFn` (closure 依 opts 三分支選 capture 模式 — R10 fix 涵蓋 BottomLines)：
   - `opts.TopLines > 0` → `tmux.CapturePaneTopLines(target, opts.TopLines)`
   - `opts.BottomLines > 0` → `tmux.CapturePaneContent(target, opts.BottomLines)` （legacy semantics）
   - both == 0 → `tmux.CapturePaneContent(target, 0)` （full visible pane）
 - 啟動 closure 後 → ticker 500ms → ctx loop
-- 邏輯：
+- 邏輯（v2.0 — orchestrator 處理 dedup，probe 沒有 emit-once 狀態）：
   ```
   idleStableTicks = opts.IdleStableTicks; if idleStableTicks == 0 { idleStableTicks = 3 }
   baseline, ok = capture()
   if !ok {
-      // R2 fix #2: baseline-fail cleanup — watcher map 已在 Watch 內註冊
+      // R2 fix: baseline-fail cleanup — watcher map 已在 Watch 內註冊
       // 此 goroutine 即將退出，必須清自己的 entry，否則 HasWatcher 會說謊
       p.watcherMu.Lock()
       if entry, ok := p.watchers[target]; ok && entry.id == id {
@@ -248,67 +255,35 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
       return
   }
   stableCount = 0
-  stableEmitted = false  // R1 fix #2: 每次 changed→stable transition 只觸發一次
-  changedEmitted = false // R11 fix: 每次 stable→changed transition 只觸發一次（對稱）
   loop:
     select ctx.Done -> return
     select tick:
       current, ok = capture()
       if !ok: continue (skip tick, don't fire false event)
       if hash(current) != hash(baseline):
-        if !changedEmitted:
-          // R13 fix: set flag BEFORE cb to survive synchronous Rearm
-          // calls in the callback (orchestrator graceWindow → RearmChanged).
-          // If cb's RearmChanged sets changedEmitted=false, that wins
-          // (intended); set-after-cb would silently overwrite Rearm.
-          changedEmitted = true
-          cb(ScreenChanged{Content: current})
-        stableEmitted = false  // change re-arms stable for next cycle
+        cb(ScreenChanged{Content: current})  // every diff tick fires
         baseline = current
         stableCount = 0
         continue
       // hash unchanged
       stableCount++
-      if !stableEmitted && stableCount >= idleStableTicks:
-        // R13 fix (symmetric): set flag BEFORE cb (same reason as above).
-        stableEmitted = true
-        changedEmitted = false  // R11 fix: stable re-arms changed for next cycle
-        cb(ScreenStable{Content: current})
-        // do NOT reset stableCount; do NOT re-emit ScreenStable until next change
+      if stableCount >= idleStableTicks:
+        cb(ScreenStable{Content: current})  // fires every Nth stable tick
+        stableCount = 0  // reset; next fire is N ticks later
   ```
 
-**R13 fix 順序約束**：watch loop **必須**用 set-emit-flag-before-cb 順序。set-after-cb 路徑禁止 — 會與 callback 同步呼叫 `RearmChanged` / `RearmStable` 互覆蓋（callback 設為 false → loop 設回 true → R12 修的 stuck-status bug 復現）。本約束適用兩個 emit 點。
-- **關鍵差異 vs legacy `activityLoop`**：watcher 不退出；可發多次 ScreenChanged + ScreenStable transitions；callback 不擁有 watcher 生命週期；同一 stable run 不會重發 ScreenStable；同一 changing run 不會重發 ScreenChanged
-- **R1 fix #2 rationale**：legacy `activityLoop` 自動退出後不存在 repeated emission 問題；新 watch-loop-owned 設計若不加 `stableEmitted` flag，idle pane 會每 N ticks 重發 ScreenStable → orchestrator 對應重發 StatusIdle broadcast → metrics counter 無限累積 + log 噴 + WS 客戶端收 idle 風暴。`stableEmitted` 確保「stable run 視為一個 transition，到下次 change 才再 arm」
-- **R11 fix rationale**：對稱於 R1 fix #2 — spinner / elapsed-timer 場景每 tick hash diff，若不加 `changedEmitted` flag，新 watch-loop-owned 會每 500ms fire ScreenChanged → orchestrator 重廣播 StatusRunning → 同樣 ws/metrics 風暴；違反 G5 default-profile parity（legacy fire once 後退出，behavior 上 Running 只廣播一次）。雙 flag 形成「changed↔stable 兩 transition，各 arm/disarm 對方」狀態機，每個 transition 各自只 fire 一次
-- **R2 fix #2 rationale**：legacy `activityLoop` 用 `defer` 統一在 goroutine 退出時清 watcher map entry，所以 baseline 失敗的 early-return 也涵蓋；新 ownership 文字寫成「cleanup only happens on ctx cancel」會漏掉 baseline-failure path → watcher map 殘留死 entry → `HasWatcher(target) == true` 但實際上 goroutine 已退 → 後續 `Watch(target, ...)` 會把同一個 entry 的 cancel 替換掉但既有 goroutine 已死 → 行為不可預測。修法：在 baseline 失敗 early-return 前同步清自己的 entry（only-if-still-mine 用 `id` 比對，避免清到後續 watch 的）
+**v2.0 contract semantics**（per consulting `task-moh5xafl-gx2zt1` 結論）：
+- Probe 是 raw observation 層 — 看到 diff 就 fire ScreenChanged，看到 stable threshold 就 fire ScreenStable（每 N ticks 一次）
+- Probe **不**判斷「同一 transition 是否已 fire 過」— 那是 orchestrator 看 `currentStatus[session]` 自然完成
+- continuous-changing pane（spinner / elapsed timer）會每 tick fire ScreenChanged → orchestrator 第一次廣播 StatusRunning，之後 `currentStatus == Running` → 後續 ScreenChanged 不再 broadcast
+- continuous-stable pane（idle pane）每 N ticks fire 一次 ScreenStable → orchestrator 第一次廣播 StatusIdle，之後 `currentStatus == Idle` → 後續 ScreenStable 不再 broadcast
+- graceWindow 內 events 被 orchestrator suppress（不 broadcast / 不 metric / 不 log），但 probe 持續 fire raw events；graceWindow expire 後下一個 tick 自然恢復 broadcast
+- 無需 RearmChanged / RearmStable API（v1.x R12 fix 引入的，v2.0 不再需要）
+- 無需 set-before-cb ordering rule（v1.x R13 fix 約束的，v2.0 不再需要）
 
-#### 2.1.3a Rearm API（R12 fix）
+**關鍵差異 vs legacy `activityLoop`**：watcher 不退出；callback 不擁有 watcher 生命週期；orchestrator 顯式 `StopWatch` 才終止。dedup 在 orchestrator 層做。
 
-```go
-// RearmChanged resets the watcher's changedEmitted flag so the next
-// hash diff (re)emits ScreenChanged. Used by the orchestrator when
-// a graceWindow-suppressed event would otherwise leave the watcher
-// in changedEmitted=true state with no foreseeable ScreenStable to
-// release it (continuous-changing pane scenarios — spinner / elapsed
-// timer). Idempotent; no-op if no watcher entry exists for target.
-func (p *Prober) RearmChanged(target string) {...}
-
-// RearmStable is the symmetric variant for stableEmitted. Currently
-// has no production caller — included for API symmetry and to support
-// future orchestrator policies that might suppress ScreenStable too.
-func (p *Prober) RearmStable(target string) {...}
-```
-
-實作：watcher entry 加 `rearmChanged chan struct{}` / `rearmStable chan struct{}`（buffered=1）；watch loop select 多增一個 case：
-```
-select ctx.Done -> return
-select tick -> ...(現有邏輯)
-select <-rearmChanged: changedEmitted = false; continue
-select <-rearmStable:  stableEmitted = false; continue
-```
-
-或更簡單：用 `atomic.Bool` 取代 `bool`；Rearm 直接 `Store(false)`。實作時 implementer 選最簡途徑（test-only 概念差異不大）。
+**R2 fix rationale**（保留）：legacy `activityLoop` 用 `defer` 統一在 goroutine 退出時清 watcher map entry；新 ownership 「cleanup only happens on ctx cancel」會漏掉 baseline-failure path → watcher map 殘留死 entry → `HasWatcher(target) == true` 但實際上 goroutine 已退 → 後續 `Watch(target, ...)` 會把同一個 entry 的 cancel 替換掉但既有 goroutine 已死 → 行為不可預測。修法：在 baseline 失敗 early-return 前同步清自己的 entry（only-if-still-mine 用 `id` 比對，避免清到後續 watch 的）
 
 #### 2.1.4 Watcher ownership 變更
 
@@ -323,18 +298,15 @@ select <-rearmStable:  stableEmitted = false; continue
 - `activityLoop` 內部 method — 改成 `watchLoop`
 - `hashCapture` 內部 method — 改成支援 captureFn closure 的版本
 
-#### 2.1.6 測試（11 tests — R1 +PR2b / R2 +PR4b / R9 +PR5b / R11 +PR1b / R12 +PR4c）
+#### 2.1.6 測試（8 tests — v2.0 簡化；移除 PR1b / PR2b / PR4c）
 
 | Test | 重點 |
 |------|------|
-| PR1 `TestWatch_FiresChangedOnDiff` | 注入兩次 capture（同 → 異），驗證單次 ScreenChanged callback、Content 為新內容 |
-| PR1b `TestWatch_ChangedEmittedOnceUntilNextStable`（**R11 fix #1 regression**）| 注入連續 6 次不同 capture（baseline + 5 diff）— 驗證 ScreenChanged 只 fire 1 次（changedEmitted 後續 tick 抑制）；接著注入 4 次同 capture → ScreenStable fire；再注入 1 次 diff → ScreenChanged 再 fire 1 次（stable→changed re-arm）|
-| PR2 `TestWatch_FiresStableAfterNIdenticalSamples` | 連續 4 次同 capture，驗證單次 ScreenStable callback（baseline + 3 stable ticks）|
-| PR2b `TestWatch_StableEmittedOnceUntilNextChange`（**R1 fix #2 regression**）| 注入 6 次同 capture（baseline + 5 stable）— 驗證 ScreenStable 只 fire 1 次；接著注入 diff → ScreenChanged fire；再注入 4 同 → ScreenStable 再 fire 1 次（changed→stable 切換才 re-arm）|
-| PR3 `TestWatch_LoopContinuesAcrossTransitions`（**R13 fix — 重寫**）| 注入 changed → 4 stable → diff 完整 cycle（baseline + diff → ScreenChanged + 4 同 → ScreenStable + diff → ScreenChanged 再 fire）；驗證 watcher 不退出、stable 與 changed 都各 fire 兩次（兩次 transition）；single-cycle continuous-diff 不重發 由 PR1b 覆蓋 |
+| PR1 `TestWatch_FiresChangedOnEveryDiff`（**v2.0 — semantics 改**）| 注入 baseline + 連續 5 次不同 capture — 驗證 ScreenChanged fire 5 次（每 diff tick fire 一次，無 emit-once）；之後接 4 次同 capture → ScreenStable fire（threshold reached）|
+| PR2 `TestWatch_FiresStableEveryNTicksAfterThreshold`（**v2.0 — semantics 改**）| 連續 9 次同 capture（baseline + 8 stable）— 驗證 ScreenStable fire 2 次：第 4 tick（threshold=3 達標 + reset）+ 第 7 tick（再次達標）；continuous stable 每 N ticks fire 一次 |
+| PR3 `TestWatch_LoopContinuesAcrossTransitions` | 注入 changed → 4 stable → diff 完整 cycle，watcher 不退出；ScreenChanged + ScreenStable 各 fire（基於上面 PR1/PR2 計法）|
 | PR4 `TestWatch_StopWatch_CancelsLoop` | StopWatch 後 capture mock 不再被 call、HasWatcher false |
-| PR4b `TestWatch_BaselineFailure_CleansMapEntry`（**R2 fix #2 regression**）| capture mock 對 first call 回 err；驗證 `Watch` 啟動後 200ms 內 `HasWatcher(target) == false`（goroutine 自己清 entry）|
-| PR4c `TestWatch_RearmChanged_AllowsReEmission`（**R12 fix regression**）| 注入 1 次 diff → ScreenChanged fire；不等 ScreenStable，直接 call `RearmChanged(target)`；再注入 1 次 diff → ScreenChanged 再 fire；symmetric for RearmStable |
+| PR4b `TestWatch_BaselineFailure_CleansMapEntry`（**R2 fix regression**）| capture mock 對 first call 回 err；驗證 `Watch` 啟動後 200ms 內 `HasWatcher(target) == false`（goroutine 自己清 entry）|
 | PR5 `TestWatch_TopLinesIgnoresBottomChanges` | 注入 only-bottom-line-changed scenario，opts.TopLines=3 不報 changed；opts={}（full pane）報 changed |
 | PR5b `TestWatch_BottomLinesIgnoresTopChanges`（**R9 fix regression**）| 注入 only-top-line-changed scenario，opts.BottomLines=3 不報 changed；opts.TopLines=3 報 changed；驗證 BottomLines vs TopLines 走不同 capture path 且互斥 |
 | PR6 `TestWatch_TmuxErrorTickSkipped` | capture err 在 tick 中發生 → 不 fire ScreenChanged，下一 tick 復原 → 報 ScreenChanged |
@@ -498,7 +470,7 @@ if !active || currentAgent != agentType {
 }
 ```
 
-**Guard 2 — graceWindow 解讀（含 R12 fix — 重新 arm probe）**：
+**Guard 2 — graceWindow 解讀（v2.0 — 不需 Rearm，自然 recovery）**：
 
 ```go
 o.graceMu.Lock()
@@ -509,22 +481,11 @@ if hasHook && time.Since(last) < probeGraceWindow {
     if isDevMode() {
         log.Printf("[probe] graceWindow suppress session=%s agent=%s kind=%s", session, agentType, ev.Kind)
     }
-    // R12 fix: re-arm probe so a future change can re-emit even if
-    // the pane keeps changing without a stable interval. Without this,
-    // a graceWindow-suppressed first ScreenChanged would leave probe's
-    // changedEmitted=true; continuous-changing panes (spinner, elapsed
-    // timer) would never see another stable→changed transition and
-    // status would stay frozen at the hook-derived value.
-    target := session + ":"
-    switch ev.Kind {
-    case probe.ScreenChanged:
-        o.parent.prober.RearmChanged(target)
-    case probe.ScreenStable:
-        o.parent.prober.RearmStable(target)
-    }
-    return
+    return  // v2.0: probe 持續 fire raw events；graceWindow expire 後下一 tick 自然恢復
 }
 ```
+
+**v2.0 graceWindow rationale**（per consulting）：probe 是 dumb，graceWindow 內 events 直接丟掉不影響 probe 狀態；graceWindow expire 後下一個 diff tick / stable tick → orchestrator 看到 `currentStatus != newStatus` → broadcast。R12 的 stuck-status bug 在此架構不存在，因為 probe 從來沒「我已 fire 過」狀態。
 
 #### 2.3.5 ScreenStable → Status 解讀（R14 fix — shell prompt 用獨立 bottom capture）
 
@@ -557,21 +518,37 @@ case probe.ScreenStable:
 
 **Tmux capture err 處理**：err != nil 視同 isShellPrompt=false（保守 — 不能斷定就走一般 idle 路徑）；不擋整個 interpretScreenEvent，只是 shell-prompt 分類失敗。
 
+接著套用 **transition gate**（v2.0 — orchestrator dedup）：
+```go
+o.parent.mu.Lock()
+prev, hasPrev := o.parent.currentStatus[session]
+o.parent.mu.Unlock()
+if hasPrev && prev == status {
+    // v2.0: same status as last broadcast — orchestrator dedups here.
+    // No broadcast / no metric / no dev log; probe 持續 fire raw events
+    // 但不會造成 idle / running storm.
+    return
+}
+```
+
 接著套用 Error Guard + projection update + broadcast（與既有 `onActivityDetected` 同邏輯，整段搬入 helper）。
 
-#### 2.3.6 測試（9 tests — R4 +OR6 / R12 +OR3b / R14 +OR7 +OR8）
+**v2.0 design intent**：每個 status transition 才 broadcast 一次。連續 ScreenChanged 第一次造成 Idle → Running broadcast，後續 ScreenChanged 因 `prev == Running` 在 transition gate 處返回。連續 ScreenStable 第一次造成 Running → Idle broadcast，後續因 `prev == Idle` 在 gate 返回。Metric `MetricProbeScreenEvent` 只在 accepted transition 時 +1（不是每 tick）；`MetricProbeGraceWindowSuppressed` 在 graceWindow 內每次 +1 — 兩個 counter 語意上分別代表「真實狀態變化」與「hook 抑制次數」。
+
+#### 2.3.6 測試（10 tests — v2.0 移除 OR3b、新增 OR9 / OR10 transition-dedup）
 
 | Test | 重點 |
 |------|------|
 | OR1 `TestOrchestrator_StartWatchUsesAgentProfile` | mock cc agent 回 `{TopLines: 5, IdleStableTicks: 2}`；驗證 prober 收到 lines=5 / stable=2 |
-| OR2 `TestOrchestrator_DefaultProfileWhenAgentMissing` | mock agent 不實作 ProbeProfileProvider；驗證 fallback 到 `{BottomLines: 10, IdleStableTicks: 3}`（R11 fix — 對齊 R9/R10 default profile 改為 BottomLines）|
-| OR3 `TestOrchestrator_GraceWindowSuppressesEventWithinWindow` | recordHookAt → 1s 後注入 ScreenChanged；驗證無狀態變化、metrics counter +1 |
-| OR3b `TestOrchestrator_GraceWindowSuppressionReArmsProbe`（**R12 fix regression**）| recordHookAt → 1s 內注入 ScreenChanged → orchestrator suppress + 呼叫 prober.RearmChanged；驗證 prober watcher entry 的 changedEmitted 已被 reset；接著（仍在 graceWindow 內或剛 expire 後）再注入 diff → ScreenChanged 再 fire；驗證沒有 stuck status |
-| OR4 `TestOrchestrator_GraceWindowExpiresAfterWindow` | recordHookAt → 3s 後注入 ScreenChanged；驗證 StatusRunning 廣播 |
+| OR2 `TestOrchestrator_DefaultProfileWhenAgentMissing` | mock agent 不實作 ProbeProfileProvider；驗證 fallback 到 `{BottomLines: 10, IdleStableTicks: 3}` |
+| OR3 `TestOrchestrator_GraceWindowSuppressesEventWithinWindow` | recordHookAt → 1s 後注入 ScreenChanged；驗證無狀態變化、metrics MetricProbeGraceWindowSuppressed counter +1、MetricProbeScreenEvent 不 +1 |
+| OR4 `TestOrchestrator_GraceWindowExpiresThenContinuousChangedRecovers`（**v2.0 替換 OR3b — 證明 R12 場景在 dumb-probe 下自然 OK**）| recordHookAt → 1s 內注入 ScreenChanged 5 次（連續 spinner）→ 全 suppressed；3s 後（graceWindow expire）再注入 ScreenChanged → 此次 broadcast Running；不需 Rearm API |
 | OR5 `TestOrchestrator_ErrorGuardBlocksProbeOverwrite` | currentStatus=StatusError；ScreenStable 注入；驗證 StatusError 維持、無 broadcast |
 | OR6 `TestOrchestrator_StaleCallbackGuard`（**R4 fix regression**）| 兩 sub-case：(a) stopWatch 後注入 ScreenChanged → 無 broadcast、無 metrics；(b) renameSession 前 watch oldName，rename 後注入 oldName 的 ScreenChanged callback → 無 broadcast、無 status 更新（驗證 currentAgent != agentType 比對）|
 | OR7 `TestOrchestrator_NilProberStartStopNoOp`（**R14 fix #2 regression**）| Module 沒 wired prober（unit test fixture）→ orchestrator.startWatch / stopWatch / 都是 no-op，不 panic；驗證 partial-init compatibility |
 | OR8 `TestOrchestrator_ScreenStableUsesBottomCaptureForShellPrompt`（**R14 fix #1 regression**）| cc agent 走 TopLines: 12 profile；mock tmux 回 ev.Content（top 12 行，**無** shell prompt）；orchestrator 收 ScreenStable → 獨立 call CapturePaneContent(target, 10) 拿底部 → mock 回 `"$ "` 終止行 → projection.TopFrame.PID dead → 驗證 `o.parent.sweepOnce` 被呼叫；對照組：bottomContent 沒 shell prompt → status=Idle 廣播，無 sweep |
+| OR9 `TestOrchestrator_RepeatedScreenChangedDedupsToOneBroadcast`（**v2.0 transition gate regression**）| `currentStatus[session]=StatusIdle`；連續注入 5 次 ScreenChanged → 第 1 次 broadcast Running + MetricProbeScreenEvent +1，第 2-5 次因 `prev == Running` 在 transition gate 返回，無 broadcast、無 metric +1 |
+| OR10 `TestOrchestrator_RepeatedScreenStableDedupsToOneBroadcast`（**v2.0 transition gate regression**）| `currentStatus[session]=StatusRunning`；連續注入 3 次 ScreenStable → 第 1 次 broadcast Idle + metric +1，第 2-3 次無 broadcast、無 metric +1 |
 
 ---
 
@@ -698,13 +675,13 @@ log 點（gated）：
 | Slice | Test ID 區段 | 數量 | 涵蓋 |
 |-------|--------------|------|------|
 | 0 | TT1-TT4 | 4 | tmux range API + fake executor parity |
-| 1 | PR1-PR1b + PR2-PR2b + PR3-PR4c + PR5-PR5b + PR6 | 11 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ baseline-fail map cleanup（R2 fix #2）/ BottomLines vs TopLines mutually exclusive（R9 fix）/ changed-emit-once（R11 fix）/ **Rearm API（R12 fix）**|
+| 1 | PR1-PR2 + PR3-PR4b + PR5-PR5b + PR6 | 8 | watcher 自治 / per-tick raw events（v2.0）/ baseline-fail map cleanup（R2 fix）/ BottomLines vs TopLines mutually exclusive（R9 fix）/ Top-N region / err tick skip / cycle 不退出 |
 | 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
-| 3 | OR1-OR6 + OR3b + OR7-OR8 | 9 | profile / graceWindow / Error Guard / stale-callback guard（R4 fix）/ graceWindow re-arm probe（R12 fix）/ **nil-prober no-op（R14 fix #2）/ shellprompt bottom-capture（R14 fix #1）**|
+| 3 | OR1-OR10 | 10 | profile / graceWindow + 自然 recovery（v2.0）/ Error Guard / stale-callback guard（R4 fix）/ nil-prober no-op（R14 fix #2）/ shellprompt bottom-capture（R14 fix #1）/ **transition dedup × 2（v2.0 OR9 / OR10）**|
 | 4 | CC1-CC6 | 6 | cc profile + module wiring + E2E + rename rewatch via orchestrator（R2 fix #1）|
 | 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
 
-**總計**：34 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 / +1 PR5b R9 / +1 PR1b R11 / +1 PR4c R12 / +1 OR3b R12 / +1 OR7 R14 / +1 OR8 R14 regression tests）。
+**總計**：32 tests（v2.0 — 從 v1.14 的 34 縮回：移除 PR1b / PR2b / PR4c / OR3b 共 4 個 R11/R12/R13 regression（-4）；新增 OR9 / OR10 transition-dedup tests（+2）；保留 PR4b R2 / PR5b R9 / OR6 R4 / OR7 / OR8 R14 / CC6 R2 共 6 個 regression）。
 
 ---
 
@@ -719,11 +696,12 @@ Slice 0 全部。包含：
 - `tmux.Executor` interface 擴增 + `RealExecutor` 實作 + fake stub
 - `go test ./internal/tmux ./...` 全綠
 
-### Commit 2 — `refactor(probe): extract pure ScreenChangeEvent primitive`
+### Commit 2 — `refactor(probe): extract dumb screen-change primitive`
 
-Slice 1 + Slice 2。包含：
-- PR1-PR2b + PR3-PR6 全 written first（含 R1 fix #2 regression PR2b）
-- 新增 `ScreenChangeEvent` / `ScreenChangeCallback` / `WatchOptions` / `Watch` / `watchLoop`（含 `stableEmitted` flag）
+Slice 1 + Slice 2（v2.0 — dumb probe）。包含：
+- PR1-PR2 + PR3-PR4b + PR5-PR5b + PR6 全 written first（8 tests，無 emit-once / Rearm regression）
+- 新增 `ScreenChangeEvent` / `ScreenChangeCallback` / `WatchOptions{TopLines, BottomLines, IdleStableTicks}` / `Watch` / `watchLoop`
+- watchLoop 沒有 emit-once flags（probe 是 dumb）
 - 移除 `ActivitySignal` / `ActivityCallback` / `activityLoop` / `StartWatch (legacy)` / `hashCapture`（或改名）
 - `LooksLikeShellPrompt` / `StripANSI` export
 - **Caller 端**：`module.go` 暫時 build error 容忍（下個 commit 修）— 用 `// TODO Slice 3` 註記；或這個 commit 同時把 module.go 改為 stub 呼叫（建議後者，避免 broken intermediate state）
@@ -738,13 +716,13 @@ Slice 3 一半（介面 + helper skeleton）：
 - `internal/module/agent/probe_orchestrator.go` skeleton（newProbeOrchestrator + startWatch + stopWatch；interpretScreenEvent 暫不接 graceWindow）
 - 接管 module.go 的 `manageActivityWatch` 路徑
 
-### Commit 4 — `feat(probe): graceWindow + screen event interpretation + stale guard`
+### Commit 4 — `feat(probe): graceWindow + transition gate + shell-prompt cleanup`
 
-Slice 3 後半 + Slice 7 主體：
-- OR3-OR6 + OB1-OB4 written first（含 R4 fix OR6 stale-callback regression）
-- orchestrator.interpretScreenEvent 完整邏輯（stale-callback guard + graceWindow + ScreenStable shellPrompt 分支 + Error Guard + projection + broadcast）
-- `internal/agent/metrics.go` 4 個新 expvar
-- `isDevMode()` helper + `[probe]` log 點
+Slice 3 後半 + Slice 7 主體（v2.0 — transition gate, no Rearm）：
+- OR3-OR10 + OB1-OB4 全 written first（含 R4 OR6 stale-callback、R14 OR7 nil-prober、R14 OR8 shellprompt bottom、v2.0 OR9/OR10 transition-dedup）
+- orchestrator.interpretScreenEvent 完整邏輯：stale-callback guard（R4）→ graceWindow suppress（v2.0：直接 return，不需 Rearm）→ ScreenStable 獨立 bottom capture for shellprompt（R14）→ Error Guard → **transition gate（v2.0：currentStatus dedup）** → projection + broadcast
+- `internal/agent/metrics.go` 4 個新 expvar；MetricProbeScreenEvent 只在 accepted transition 時 +1（v2.0 semantics）
+- `isDevMode()` helper + `[probe]` log 點（同樣 only-on-transition）
 - `recordHookAt` integration into module.go hook path
 
 ### Commit 5 — `feat(agent/cc): adopt new probe primitive via profile`
@@ -837,14 +815,14 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | Slice | 估 LoC | 估 tests |
 |-------|--------|----------|
 | 0 tmux API | ~40 | 4 |
-| 1 probe primitive | ~115 | 11（R1 +PR2b / R2 +PR4b / R9 +PR5b / R11 +PR1b / R12 +PR4c）|
+| 1 probe primitive | ~70 | 8（v2.0 dumb probe — 無 emit-once flags / 無 Rearm API）|
 | 2 shell prompt export | ~5 | 0 |
-| 3 module orchestrator | ~110 | 9（R4 +OR6 / R12 +OR3b / R14 +OR7 +OR8）|
+| 3 module orchestrator | ~115 | 10（R4 +OR6 / R14 +OR7 +OR8 / v2.0 +OR9 +OR10 transition dedup）|
 | 4 cc adoption | ~50 | 6（R2 +CC6 rename）|
 | 7 graceWindow + dev log + expvar | ~30 | 4 |
 | (extra) boundary script | ~30 | 0 |
 
-**總計**：~390 LoC + 34 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1 / R9 +1 / R11 +1 / R12 +2 / R14 +2，總 +10 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard + R9 BottomLines field + capture-mode dispatcher + R11 changedEmitted flag + R12 Rearm API + R14 bottom shellprompt capture + nil-prober guards ~70 LoC，仍在 PR 合理 size 內）。
+**總計**：~340 LoC + 32 tests（v2.0 pivot 後 — 從 v1.14 的 ~390/34 縮回 ~340/32。Slice 1 LoC 大幅縮（沒 emit-once flags / Rearm API / set-before-cb 結構約束）；Slice 3 略增（多 transition gate logic + 2 個新 test）。仍在 PR 合理 size 內，且 review 複雜度顯著下降）。
 
 **屬中型 PR**。`go test` 預期 elapsed < 30s 內。
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.4 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.5 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.4（Round 4 codex review fix — 1 P2 stale-callback finding 採納）
+**Status**: draft v1.5（Round 5 codex review fix — 1 P2 internal-inconsistency finding 採納）
 
 ## v1.x 演進
 
@@ -11,6 +11,7 @@
 | v1.2 | R2 codex review fix（1 P1 + 1 P2）：(1) **rename rewatch path** — `renameSessionLocked` (module.go:258) 也呼叫 `StartWatch(newName+":", ...)`；plan 必須一併走 orchestrator + 加 rename regression test；(2) **baseline 失敗 cleanup race** — 初始 capture 失敗時 `watchLoop` 直接 return 但 watcher map 已註冊；新增 baseline-fail-cleanup 邏輯與 PR4b 測試 |
 | v1.3 | R3 codex review fix（1 P1 deadlock）：v1.2 §2.3.1 orchestrator API docstring 寫 `stopWatch` / `startWatch` 會 clear `activeWatchers`，但 `renameSessionLocked` 持 `m.mu` 時呼叫，會與內部要 acquire `m.mu` 的清理路徑互鎖（非可重入 mutex）。**改 API contract**：orchestrator 只碰 `prober` + `lastHookAt` + metrics，**不觸 `activeWatchers`**；caller（module.go wrapper）管理 `activeWatchers`。同時對齊 `interpretScreenEvent` 的 Error Guard 邏輯沿用 legacy 既有 lock 模式（讀 + 寫各自一次 m.mu.Lock/Unlock，不持鎖跨呼叫）|
 | v1.4 | R4 codex review fix（1 P2 stale-callback guard）：legacy `onActivityDetected` (module.go:473) 開頭檢查 `activeWatchers[session]` 不存在則 return，這個 stale-callback guard v1.3 plan 漏搬。新 watch-loop-owned watcher fire callback 多次（不像 legacy fire 一次就退），**此 guard 比 legacy 更必要** — stopWatch / rename race 中 in-flight callback 會在 watcher 已停的情況下繼續更新 status / broadcast。`interpretScreenEvent` 開頭加 `currentAgent, active := m.activeWatchers[session]; if !active \|\| currentAgent != agentType { return }`；新增 OR6 regression test |
+| v1.5 | R5 codex review fix（1 P2 internal-inconsistency）：plan §1.2 列「Slice 8（清舊 onActivityDetected / shouldWatchActivity / ActivitySignal enum 解讀）— 留 PR-4a-2」與 §1.1 / §2.4.2 衝突（後者要求本 PR 必移除 `ActivitySignal` 等舊 API 否則無法 compile）。釐清：本 PR 必清 `ActivitySignal` enum + legacy `StartWatch` API + `activityLoop` + `onActivityDetected`（compile 必要）；保留 `shouldWatchActivity`（wrapper 仍用的政策函式）；PR-4a-2 範圍縮為「Slice 5/6 codex/opencode profile 接 primitive」+「**視需要** refactor `shouldWatchActivity`」 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -81,11 +82,14 @@ PR-4a-1 把目前 `internal/agent/probe/activity.go` 的 watcher 從「probe 解
 
 ### 1.2 Out of scope（明列分流）
 
-- **Slice 5（codex 接新 primitive）/ Slice 6（opencode 接新 primitive）/ Slice 8（清舊 onActivityDetected / shouldWatchActivity / ActivitySignal enum signal 解讀）** — 全部留 PR-4a-2
+- **Slice 5（codex 接新 primitive）/ Slice 6（opencode 接新 primitive）** — 留 PR-4a-2
+- **`shouldWatchActivity` per-agent refactor**（視需要）— 本 PR 保留 `shouldWatchActivity` 函式（wrapper 仍呼叫）；若 PR-4a-2 codex / opencode profile 化過程中發現該函式應 per-agent，再 refactor，本 PR 不動
 - **Phase 4b `ProbeIntentProvider`** — 整合 readiness 的 declarative intent 系統，留 Phase 4b
 - **Phase 5 Dev Inspector SPA UI** — `/api/agent/monitor/*` 視覺化，留 Phase 5
 - **Character-level detection（彩虹字 / spinner 偵測）** — kickoff Decision 2 已砍，Top-N hash 取代
 - **User typing vs agent loading 細緻分辨** — kickoff Decision 3 已砍
+
+**注意**（R5 fix）：plan v1.3 §7.2 / §7 大綱寫「Slice 8 清舊 onActivityDetected / shouldWatchActivity / ActivitySignal — 留 PR-4a-2」過於籠統。實際上 `ActivitySignal` enum + legacy `StartWatch` API + `activityLoop` + `onActivityDetected` **本 PR 必須移除**（不移除則新 `Watch(target, opts, cb)` API 與舊 `StartWatch(target, ActivityCallback)` 並存矛盾，code 無法 compile）。本版 plan 把這層在 §1.1 Slice 1 + §2.1.5 顯式標註為 in-scope removal；PR-4a-2 縮為「codex/opencode profile + 視需要 `shouldWatchActivity` per-agent 化」。
 
 ---
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.5 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.6 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.5（Round 5 codex review fix — 1 P2 internal-inconsistency finding 採納）
+**Status**: draft v1.6（Round 6 codex review fix — 2 P2 internal-consistency findings 採納）
 
 ## v1.x 演進
 
@@ -12,6 +12,7 @@
 | v1.3 | R3 codex review fix（1 P1 deadlock）：v1.2 §2.3.1 orchestrator API docstring 寫 `stopWatch` / `startWatch` 會 clear `activeWatchers`，但 `renameSessionLocked` 持 `m.mu` 時呼叫，會與內部要 acquire `m.mu` 的清理路徑互鎖（非可重入 mutex）。**改 API contract**：orchestrator 只碰 `prober` + `lastHookAt` + metrics，**不觸 `activeWatchers`**；caller（module.go wrapper）管理 `activeWatchers`。同時對齊 `interpretScreenEvent` 的 Error Guard 邏輯沿用 legacy 既有 lock 模式（讀 + 寫各自一次 m.mu.Lock/Unlock，不持鎖跨呼叫）|
 | v1.4 | R4 codex review fix（1 P2 stale-callback guard）：legacy `onActivityDetected` (module.go:473) 開頭檢查 `activeWatchers[session]` 不存在則 return，這個 stale-callback guard v1.3 plan 漏搬。新 watch-loop-owned watcher fire callback 多次（不像 legacy fire 一次就退），**此 guard 比 legacy 更必要** — stopWatch / rename race 中 in-flight callback 會在 watcher 已停的情況下繼續更新 status / broadcast。`interpretScreenEvent` 開頭加 `currentAgent, active := m.activeWatchers[session]; if !active \|\| currentAgent != agentType { return }`；新增 OR6 regression test |
 | v1.5 | R5 codex review fix（1 P2 internal-inconsistency）：plan §1.2 列「Slice 8（清舊 onActivityDetected / shouldWatchActivity / ActivitySignal enum 解讀）— 留 PR-4a-2」與 §1.1 / §2.4.2 衝突（後者要求本 PR 必移除 `ActivitySignal` 等舊 API 否則無法 compile）。釐清：本 PR 必清 `ActivitySignal` enum + legacy `StartWatch` API + `activityLoop` + `onActivityDetected`（compile 必要）；保留 `shouldWatchActivity`（wrapper 仍用的政策函式）；PR-4a-2 範圍縮為「Slice 5/6 codex/opencode profile 接 primitive」+「**視需要** refactor `shouldWatchActivity`」 |
+| v1.6 | R6 codex review fix（2 P2 internal-consistency）：(1) §1.1 Slice 3 摘要還寫「`stopProbeWatch` 含 activeWatchers map cleanup」與 R3 修法（orchestrator 不碰 activeWatchers）矛盾；改正為「停止 prober watcher」並引向 §2.3.1 R3 fix；(2) Commit 5 TDD 清單只列 CC1-CC5，漏掉 CC6 (R2 fix #1 + R3 deadlock-freedom regression)；補入 written-first 清單 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -59,9 +60,9 @@ PR-4a-1 把目前 `internal/agent/probe/activity.go` 的 watcher 從「probe 解
 **Slice 3**：Module 共用 orchestrator helper
 - 新增 `internal/module/agent/probe_orchestrator.go`（暫名）
 - 抽出 `manageActivityWatch` + `onActivityDetected` 共用邏輯為：
-  - `startProbeWatch(session, agentType)` — 啟動 watcher（依 agent profile 決定 TopN 行數）
-  - `stopProbeWatch(session)` — 停止 watcher（含 activeWatchers map cleanup）
-  - `interpretScreenEvent(session, agentType, event)` — 把 ScreenChangeEvent 解讀為 Status，套用 graceWindow + Error Guard + projection update + broadcast
+  - `startWatch(session, agentType)` — 啟動 prober watcher（依 agent profile 決定 TopN / IdleStableTicks）；**不觸 `activeWatchers` map**（caller 管理；R3 fix）
+  - `stopWatch(session)` — 停止 prober watcher；**不觸 `activeWatchers` map**（caller 管理；R3 fix；詳 §2.3.1）
+  - `interpretScreenEvent(session, agentType, event)` — 把 ScreenChangeEvent 解讀為 Status，套用 stale-callback guard（R4 fix）+ graceWindow + Error Guard + projection update + broadcast
 - `agentpkg.Provider` 新增 optional interface `ProbeProfileProvider`（暫名）
   - `ProbeProfile()` → `{TopLines int, IdleStableTicks int}` 等 per-agent tuning
   - cc 在 Slice 4 實作；未實作的 agent 走 default profile（沿用現行 10 行 / 3 ticks）
@@ -585,11 +586,11 @@ Slice 3 一半（介面 + helper skeleton）：
 - `internal/module/agent/probe_orchestrator.go` skeleton（newProbeOrchestrator + startWatch + stopWatch；interpretScreenEvent 暫不接 graceWindow）
 - 接管 module.go 的 `manageActivityWatch` 路徑
 
-### Commit 4 — `feat(probe): graceWindow + screen event interpretation`
+### Commit 4 — `feat(probe): graceWindow + screen event interpretation + stale guard`
 
 Slice 3 後半 + Slice 7 主體：
-- OR3-OR5 + OB1-OB4 written first
-- orchestrator.interpretScreenEvent 完整邏輯（graceWindow + ScreenStable shellPrompt 分支 + Error Guard + projection + broadcast）
+- OR3-OR6 + OB1-OB4 written first（含 R4 fix OR6 stale-callback regression）
+- orchestrator.interpretScreenEvent 完整邏輯（stale-callback guard + graceWindow + ScreenStable shellPrompt 分支 + Error Guard + projection + broadcast）
 - `internal/agent/metrics.go` 4 個新 expvar
 - `isDevMode()` helper + `[probe]` log 點
 - `recordHookAt` integration into module.go hook path
@@ -597,9 +598,10 @@ Slice 3 後半 + Slice 7 主體：
 ### Commit 5 — `feat(agent/cc): adopt new probe primitive via profile`
 
 Slice 4：
-- CC1-CC5 written first
+- **CC1-CC6 written first**（R6 fix — 補入 CC6 rename rewatch / R3 deadlock-freedom regression；CC6 是 R2 fix #1 + R3 fix 的核心 regression test，必納入 written-first 清單）
 - `internal/agent/cc/probe_profile.go`（cc 實作 ProbeProfileProvider）
 - module.go 確認 cc path 走 orchestrator + recordHookAt 在 cc hook handler call 到
+- module.go `renameSessionLocked` 改走 orchestrator stop+start（R2 fix #1）；`renameSessionLocked` 持 `m.mu` 不會 deadlock（R3 fix）
 
 ### Final Verification
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.10 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.11 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.10（Round 10 codex review fix — 2 P2 R9-propagation gaps 採納）
+**Status**: draft v1.11（Round 11 codex review fix — 1 P2 substantive + 1 P2 editorial 採納）
 
 ## v1.x 演進
 
@@ -17,6 +17,7 @@
 | v1.8 | R8 codex review fix（1 P2 + 1 P3）：(1) §2.3.3 startWatch pseudo-code 仍用未定義 `agentProvider` 變數 + `defaultProbeProfile` 為 unqualified type；補完整 provider lookup（registry → agentType → provider）+ 改 `agentpkg.ProbeProfile` qualified 命名；(2) §2.1.6 標題「測試（7 tests — R1 +PR2b）」與 §3 矩陣（8 tests）+ 表內列出 8 個 testID 不符；改為「測試（8 tests — R1 +PR2b / R2 +PR4b）」 |
 | v1.9 | R9 codex review fix（1 P2 substantive — **regression risk**）：legacy `CapturePaneContent(target, 10)` 是 **last 10 lines**（`tmux capture-pane -S -10`，hash bottom 10 行），但 v1.8 default profile `{TopLines: 10}` 配 `CapturePaneTopLines` 會 hash **top 10 lines**。codex/opencode 沒有 ProbeProfileProvider 走 default → 行為被默默改掉，違反 §6 G5 default profile parity gate（明訂「不實作 ProbeProfileProvider 的 agent 行為與 PR-4a-1 前等價」）。修法：擴 `WatchOptions` 加 `BottomLines int` field（與 `TopLines` 互斥）；default profile 改用 `{BottomLines: 10}` 保留 legacy capture 語意；新增 PR5b 測試覆蓋 BottomLines vs TopLines 行為差異 |
 | v1.10 | R10 codex review fix（2 P2 — R9-propagation gaps）：(1) §2.1.3 watchLoop pseudo-code 啟動描述只 branch `opts.TopLines`，沒處理新加的 `opts.BottomLines`；implementer 照寫，default profile `{BottomLines: 10}` 會 fallback 到 full pane capture，破壞 G5 parity；補成三分支（TopLines / BottomLines / 全零=full pane）；(2) §2.3.3 殘留 v1.8 stale 宣告 `var defaultProbeProfile = ProbeProfile{TopLines: 10, IdleStableTicks: 3}`，與下一段 R9 fix 的 `{BottomLines: 10}` 互斥同存；移除 stale 宣告 |
+| v1.11 | R11 codex review fix（1 P2 substantive + 1 P2 editorial）：(1) **substantive** — 新 watch-loop-owned watcher 對 spinner / elapsed-timer 每 tick fire ScreenChanged；orchestrator 每 500ms 重廣播 Running，違反 G5 parity（legacy fires once 後退出）。對稱於 R1 fix #2 的 `stableEmitted`，加 `changedEmitted` flag — 每次 stable→changed transition fire ScreenChanged 一次，下次 ScreenStable fire 後重新 arm；新增 PR1b 測試覆蓋連續 changed 無重發；(2) **editorial** — OR2 default profile fallback 期待還寫 `{TopLines: 10, IdleStableTicks: 3}`，與 R9/R10 default `{BottomLines: 10}` 矛盾；修為 `{BottomLines: 10, IdleStableTicks: 3}` |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -245,26 +246,31 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
   }
   stableCount = 0
   stableEmitted = false  // R1 fix #2: 每次 changed→stable transition 只觸發一次
+  changedEmitted = false // R11 fix: 每次 stable→changed transition 只觸發一次（對稱）
   loop:
     select ctx.Done -> return
     select tick:
       current, ok = capture()
       if !ok: continue (skip tick, don't fire false event)
       if hash(current) != hash(baseline):
-        cb(ScreenChanged{Content: current})
+        if !changedEmitted:
+          cb(ScreenChanged{Content: current})
+          changedEmitted = true
+        stableEmitted = false  // change re-arms stable for next cycle
         baseline = current
         stableCount = 0
-        stableEmitted = false  // change resets, future stable-emit allowed
         continue
       // hash unchanged
       stableCount++
       if !stableEmitted && stableCount >= idleStableTicks:
         cb(ScreenStable{Content: current})
         stableEmitted = true
+        changedEmitted = false  // R11 fix: stable re-arms changed for next cycle
         // do NOT reset stableCount; do NOT re-emit ScreenStable until next change
   ```
-- **關鍵差異 vs legacy `activityLoop`**：watcher 不退出；可發多次 ScreenChanged + ScreenStable transitions；callback 不擁有 watcher 生命週期；同一 stable run 不會重發 ScreenStable
+- **關鍵差異 vs legacy `activityLoop`**：watcher 不退出；可發多次 ScreenChanged + ScreenStable transitions；callback 不擁有 watcher 生命週期；同一 stable run 不會重發 ScreenStable；同一 changing run 不會重發 ScreenChanged
 - **R1 fix #2 rationale**：legacy `activityLoop` 自動退出後不存在 repeated emission 問題；新 watch-loop-owned 設計若不加 `stableEmitted` flag，idle pane 會每 N ticks 重發 ScreenStable → orchestrator 對應重發 StatusIdle broadcast → metrics counter 無限累積 + log 噴 + WS 客戶端收 idle 風暴。`stableEmitted` 確保「stable run 視為一個 transition，到下次 change 才再 arm」
+- **R11 fix rationale**：對稱於 R1 fix #2 — spinner / elapsed-timer 場景每 tick hash diff，若不加 `changedEmitted` flag，新 watch-loop-owned 會每 500ms fire ScreenChanged → orchestrator 重廣播 StatusRunning → 同樣 ws/metrics 風暴；違反 G5 default-profile parity（legacy fire once 後退出，behavior 上 Running 只廣播一次）。雙 flag 形成「changed↔stable 兩 transition，各 arm/disarm 對方」狀態機，每個 transition 各自只 fire 一次
 - **R2 fix #2 rationale**：legacy `activityLoop` 用 `defer` 統一在 goroutine 退出時清 watcher map entry，所以 baseline 失敗的 early-return 也涵蓋；新 ownership 文字寫成「cleanup only happens on ctx cancel」會漏掉 baseline-failure path → watcher map 殘留死 entry → `HasWatcher(target) == true` 但實際上 goroutine 已退 → 後續 `Watch(target, ...)` 會把同一個 entry 的 cancel 替換掉但既有 goroutine 已死 → 行為不可預測。修法：在 baseline 失敗 early-return 前同步清自己的 entry（only-if-still-mine 用 `id` 比對，避免清到後續 watch 的）
 
 #### 2.1.4 Watcher ownership 變更
@@ -280,11 +286,12 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 - `activityLoop` 內部 method — 改成 `watchLoop`
 - `hashCapture` 內部 method — 改成支援 captureFn closure 的版本
 
-#### 2.1.6 測試（9 tests — R1 +PR2b / R2 +PR4b / R9 +PR5b）
+#### 2.1.6 測試（10 tests — R1 +PR2b / R2 +PR4b / R9 +PR5b / R11 +PR1b）
 
 | Test | 重點 |
 |------|------|
 | PR1 `TestWatch_FiresChangedOnDiff` | 注入兩次 capture（同 → 異），驗證單次 ScreenChanged callback、Content 為新內容 |
+| PR1b `TestWatch_ChangedEmittedOnceUntilNextStable`（**R11 fix #1 regression**）| 注入連續 6 次不同 capture（baseline + 5 diff）— 驗證 ScreenChanged 只 fire 1 次（changedEmitted 後續 tick 抑制）；接著注入 4 次同 capture → ScreenStable fire；再注入 1 次 diff → ScreenChanged 再 fire 1 次（stable→changed re-arm）|
 | PR2 `TestWatch_FiresStableAfterNIdenticalSamples` | 連續 4 次同 capture，驗證單次 ScreenStable callback（baseline + 3 stable ticks）|
 | PR2b `TestWatch_StableEmittedOnceUntilNextChange`（**R1 fix #2 regression**）| 注入 6 次同 capture（baseline + 5 stable）— 驗證 ScreenStable 只 fire 1 次；接著注入 diff → ScreenChanged fire；再注入 4 同 → ScreenStable 再 fire 1 次（changed→stable 切換才 re-arm）|
 | PR3 `TestWatch_DoesNotExitOnCallback` | 一次 ScreenChanged callback 後再注入 diff，驗證再發 ScreenChanged（loop 持續）|
@@ -485,7 +492,7 @@ case probe.ScreenStable:
 | Test | 重點 |
 |------|------|
 | OR1 `TestOrchestrator_StartWatchUsesAgentProfile` | mock cc agent 回 `{TopLines: 5, IdleStableTicks: 2}`；驗證 prober 收到 lines=5 / stable=2 |
-| OR2 `TestOrchestrator_DefaultProfileWhenAgentMissing` | mock agent 不實作 ProbeProfileProvider；驗證 fallback 到 `{TopLines: 10, IdleStableTicks: 3}` |
+| OR2 `TestOrchestrator_DefaultProfileWhenAgentMissing` | mock agent 不實作 ProbeProfileProvider；驗證 fallback 到 `{BottomLines: 10, IdleStableTicks: 3}`（R11 fix — 對齊 R9/R10 default profile 改為 BottomLines）|
 | OR3 `TestOrchestrator_GraceWindowSuppressesEventWithinWindow` | recordHookAt → 1s 後注入 ScreenChanged；驗證無狀態變化、metrics counter +1 |
 | OR4 `TestOrchestrator_GraceWindowExpiresAfterWindow` | recordHookAt → 3s 後注入 ScreenChanged；驗證 StatusRunning 廣播 |
 | OR5 `TestOrchestrator_ErrorGuardBlocksProbeOverwrite` | currentStatus=StatusError；ScreenStable 注入；驗證 StatusError 維持、無 broadcast |
@@ -616,13 +623,13 @@ log 點（gated）：
 | Slice | Test ID 區段 | 數量 | 涵蓋 |
 |-------|--------------|------|------|
 | 0 | TT1-TT4 | 4 | tmux range API + fake executor parity |
-| 1 | PR1-PR2b + PR3-PR4b + PR5-PR5b + PR6 | 9 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ baseline-fail map cleanup（R2 fix #2）/ **BottomLines vs TopLines mutually exclusive（R9 fix）**|
+| 1 | PR1-PR1b + PR2-PR2b + PR3-PR4b + PR5-PR5b + PR6 | 10 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ baseline-fail map cleanup（R2 fix #2）/ BottomLines vs TopLines mutually exclusive（R9 fix）/ **changed-emit-once（R11 fix）**|
 | 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
 | 3 | OR1-OR6 | 6 | profile / graceWindow / Error Guard / **stale-callback guard（R4 fix）**|
 | 4 | CC1-CC6 | 6 | cc profile + module wiring + E2E + rename rewatch via orchestrator（R2 fix #1）|
 | 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
 
-**總計**：29 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 / +1 PR5b R9 regression tests）。
+**總計**：30 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 / +1 PR5b R9 / +1 PR1b R11 regression tests）。
 
 ---
 
@@ -755,14 +762,14 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | Slice | 估 LoC | 估 tests |
 |-------|--------|----------|
 | 0 tmux API | ~40 | 4 |
-| 1 probe primitive | ~95 | 9（R1 +PR2b / R2 +PR4b / R9 +PR5b）|
+| 1 probe primitive | ~100 | 10（R1 +PR2b / R2 +PR4b / R9 +PR5b / R11 +PR1b）|
 | 2 shell prompt export | ~5 | 0 |
 | 3 module orchestrator | ~85 | 6（R4 +OR6）|
 | 4 cc adoption | ~50 | 6（R2 +CC6 rename）|
 | 7 graceWindow + dev log + expvar | ~30 | 4 |
 | (extra) boundary script | ~30 | 0 |
 
-**總計**：~340 LoC + 29 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1 / R9 +1，總 +5 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard + R9 BottomLines field + capture-mode dispatcher ~25 LoC，仍在 PR 合理 size 內）。
+**總計**：~345 LoC + 30 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1 / R9 +1 / R11 +1，總 +6 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard + R9 BottomLines field + capture-mode dispatcher + R11 changedEmitted flag ~30 LoC，仍在 PR 合理 size 內）。
 
 **屬中型 PR**。`go test` 預期 elapsed < 30s 內。
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,13 +1,14 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.1 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.2 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.1（Round 1 codex review fix — `review-moh40grn-u7wxgv`，2 P2 findings 全採納）
+**Status**: draft v1.2（Round 2 codex review fix — `review-moh4f3ts-XXXXXX`，1 P1 + 1 P2 findings 全採納）
 
 ## v1.x 演進
 
 | 版本 | 變更 |
 |---|---|
 | v1 | 初版起草（6 slices / 24 tests / ~305 LoC）|
-| v1.1 | R1 codex review fix：(1) API gap — `WatchTopLines` / `WatchFullScreen` 無法接收 `IdleStableTicks`；併為單一 `Watch(target, opts, cb)` + `WatchOptions{TopLines, IdleStableTicks}`；(2) repeated stable emission — `stableEmitted` flag 確保每次 changed→stable transition 只觸發一次 ScreenStable；新增 PR2b 測試覆蓋連續穩定無重發 |
+| v1.1 | R1 codex review fix（`review-moh40grn-u7wxgv`，2 P2）：(1) API gap — `WatchTopLines` / `WatchFullScreen` 無法接收 `IdleStableTicks`；併為單一 `Watch(target, opts, cb)` + `WatchOptions{TopLines, IdleStableTicks}`；(2) repeated stable emission — `stableEmitted` flag 確保每次 changed→stable transition 只觸發一次 ScreenStable；新增 PR2b 測試覆蓋連續穩定無重發 |
+| v1.2 | R2 codex review fix（1 P1 + 1 P2）：(1) **rename rewatch path** — `renameSessionLocked` (module.go:258) 也呼叫 `StartWatch(newName+":", ...)`；plan 必須一併走 orchestrator + 加 rename regression test；(2) **baseline 失敗 cleanup race** — 初始 capture 失敗時 `watchLoop` 直接 return 但 watcher map 已註冊；新增 baseline-fail-cleanup 邏輯與 PR4b 測試 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -191,7 +192,17 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 - 邏輯：
   ```
   idleStableTicks = opts.IdleStableTicks; if idleStableTicks == 0 { idleStableTicks = 3 }
-  baseline, ok = capture(); if !ok { return }  // 無 baseline 不發事件
+  baseline, ok = capture()
+  if !ok {
+      // R2 fix #2: baseline-fail cleanup — watcher map 已在 Watch 內註冊
+      // 此 goroutine 即將退出，必須清自己的 entry，否則 HasWatcher 會說謊
+      p.watcherMu.Lock()
+      if entry, ok := p.watchers[target]; ok && entry.id == id {
+          delete(p.watchers, target)
+      }
+      p.watcherMu.Unlock()
+      return
+  }
   stableCount = 0
   stableEmitted = false  // R1 fix #2: 每次 changed→stable transition 只觸發一次
   loop:
@@ -214,6 +225,7 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
   ```
 - **關鍵差異 vs legacy `activityLoop`**：watcher 不退出；可發多次 ScreenChanged + ScreenStable transitions；callback 不擁有 watcher 生命週期；同一 stable run 不會重發 ScreenStable
 - **R1 fix #2 rationale**：legacy `activityLoop` 自動退出後不存在 repeated emission 問題；新 watch-loop-owned 設計若不加 `stableEmitted` flag，idle pane 會每 N ticks 重發 ScreenStable → orchestrator 對應重發 StatusIdle broadcast → metrics counter 無限累積 + log 噴 + WS 客戶端收 idle 風暴。`stableEmitted` 確保「stable run 視為一個 transition，到下次 change 才再 arm」
+- **R2 fix #2 rationale**：legacy `activityLoop` 用 `defer` 統一在 goroutine 退出時清 watcher map entry，所以 baseline 失敗的 early-return 也涵蓋；新 ownership 文字寫成「cleanup only happens on ctx cancel」會漏掉 baseline-failure path → watcher map 殘留死 entry → `HasWatcher(target) == true` 但實際上 goroutine 已退 → 後續 `Watch(target, ...)` 會把同一個 entry 的 cancel 替換掉但既有 goroutine 已死 → 行為不可預測。修法：在 baseline 失敗 early-return 前同步清自己的 entry（only-if-still-mine 用 `id` 比對，避免清到後續 watch 的）
 
 #### 2.1.4 Watcher ownership 變更
 
@@ -237,6 +249,7 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 | PR2b `TestWatch_StableEmittedOnceUntilNextChange`（**R1 fix #2 regression**）| 注入 6 次同 capture（baseline + 5 stable）— 驗證 ScreenStable 只 fire 1 次；接著注入 diff → ScreenChanged fire；再注入 4 同 → ScreenStable 再 fire 1 次（changed→stable 切換才 re-arm）|
 | PR3 `TestWatch_DoesNotExitOnCallback` | 一次 ScreenChanged callback 後再注入 diff，驗證再發 ScreenChanged（loop 持續）|
 | PR4 `TestWatch_StopWatch_CancelsLoop` | StopWatch 後 capture mock 不再被 call、HasWatcher false |
+| PR4b `TestWatch_BaselineFailure_CleansMapEntry`（**R2 fix #2 regression**）| capture mock 對 first call 回 err；驗證 `Watch` 啟動後 200ms 內 `HasWatcher(target) == false`（goroutine 自己清 entry）|
 | PR5 `TestWatch_TopLinesIgnoresBottomChanges` | 注入 only-bottom-line-changed scenario，opts.TopLines=3 不報 changed；opts.TopLines=0（full screen）報 changed |
 | PR6 `TestWatch_TmuxErrorTickSkipped` | capture err 在 tick 中發生 → 不 fire ScreenChanged，下一 tick 復原 → 報 ScreenChanged |
 
@@ -388,9 +401,14 @@ func (p *Provider) ProbeProfile() agentpkg.ProbeProfile {
 
 具體 TopLines 值由實際觀察 cc UI layout 決定；本 plan 暫定 12，allowed to adjust during implementation 並文件化決定。
 
-#### 2.4.2 module.go 改為走 orchestrator
+#### 2.4.2 module.go 改為走 orchestrator（含 R2 fix #1 — 兩條 callsite 一起遷）
 
-把 `manageActivityWatch` / `onActivityDetected` 兩個 method 改成 thin wrapper：
+`module.go` 有 **兩處** 呼叫 legacy `m.prober.StartWatch`，新 plan 都必須遷到 orchestrator：
+
+1. **`manageActivityWatch`**（module.go:454）— hook event 觸發 status 變化時的 start/stop
+2. **`renameSessionLocked`**（module.go:276）— session rename 後重啟 watcher（callback closure 鎖了 oldName，必須 stop 舊 + start 新）
+
+把 `manageActivityWatch` / `onActivityDetected` 改成 thin wrapper：
 
 ```go
 func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status) {
@@ -410,6 +428,20 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
 }
 ```
 
+把 `renameSessionLocked` 中的 watcher 段落改成（保留既有 m.mu held + activeWatchers transfer 邏輯）：
+
+```go
+// In renameSessionLocked, after activeWatchers transfer:
+if agentType, ok := m.activeWatchers[oldName]; ok {
+    delete(m.activeWatchers, oldName)
+    m.probeOrch.stopWatch(oldName)
+    m.activeWatchers[newName] = agentType
+    m.probeOrch.startWatch(newName, agentType)
+}
+```
+
+注意：orchestrator `startWatch` / `stopWatch` 內部會處理 prober nil-check（保留 legacy `if m.prober != nil` 行為），rename callsite 不必重複檢查。
+
 舊 `onActivityDetected` 整個刪掉（邏輯已搬到 orchestrator.interpretScreenEvent；本 PR 範圍內 cc 走新 path，codex / opencode 也透過 default profile 走同一份 helper — 但 codex / opencode 的 TopN 微調留 PR-4a-2，本 PR 三家共用 default profile = 行為向下相容）。
 
 #### 2.4.3 hook handler 呼叫 recordHookAt
@@ -425,6 +457,7 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
 | CC3 `TestModule_HookHandler_CallsRecordHookAt` | 注入 cc hook event；驗證 orchestrator.lastHookAt[session] 記錄到 |
 | CC4 `TestCC_E2E_ScreenChangedToRunning` | cc waiting → orchestrator.startWatch → 注入 ScreenChanged → status 廣播 Running |
 | CC5 `TestCC_E2E_ScreenStableToIdle` | cc running → orchestrator.startWatch → 注入 ScreenStable（non-shell-prompt）→ status 廣播 Idle |
+| CC6 `TestCC_RenameSession_RestartsWatchViaOrchestrator`（**R2 fix #1 regression**）| cc running on `oldname:` → `RenameSession(oldname, newname)` → 驗證 orchestrator.stopWatch(oldname) + startWatch(newname) 各 call 一次 + activeWatchers map key 從 oldname 遷到 newname |
 
 ---
 
@@ -469,13 +502,13 @@ log 點（gated）：
 | Slice | Test ID 區段 | 數量 | 涵蓋 |
 |-------|--------------|------|------|
 | 0 | TT1-TT4 | 4 | tmux range API + fake executor parity |
-| 1 | PR1-PR2b + PR3-PR6 | 7 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / **stable-emit-once（R1 fix #2）**|
+| 1 | PR1-PR2b + PR3-PR4b + PR5-PR6 | 8 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ **baseline-fail map cleanup（R2 fix #2）**|
 | 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
 | 3 | OR1-OR5 | 5 | profile / graceWindow / Error Guard |
-| 4 | CC1-CC5 | 5 | cc profile + module wiring + E2E |
+| 4 | CC1-CC6 | 6 | cc profile + module wiring + E2E + **rename rewatch via orchestrator（R2 fix #1）**|
 | 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
 
-**總計**：25 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 regression test）。
+**總計**：27 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 + +1 PR4b R2 + +1 CC6 R2 regression tests）。
 
 ---
 
@@ -607,14 +640,14 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | Slice | 估 LoC | 估 tests |
 |-------|--------|----------|
 | 0 tmux API | ~40 | 4 |
-| 1 probe primitive | ~85 | 7（R1 +PR2b）|
+| 1 probe primitive | ~90 | 8（R1 +PR2b / R2 +PR4b）|
 | 2 shell prompt export | ~5 | 0 |
 | 3 module orchestrator | ~80 | 5 |
-| 4 cc adoption | ~40 | 5 |
+| 4 cc adoption | ~50 | 6（R2 +CC6 rename）|
 | 7 graceWindow + dev log + expvar | ~30 | 4 |
 | (extra) boundary script | ~30 | 0 |
 
-**總計**：~310 LoC + 25 tests（plan v1.3 §7.1 estimate ~250+24，本版 R1 +5 LoC `stableEmitted` + `WatchOptions` + 1 PR2b regression test，仍在 PR 合理 size 內）。
+**總計**：~325 LoC + 27 tests（plan v1.3 §7.1 estimate 24，本版 R1 +1 / R2 +2 regression tests + R2 baseline-fail cleanup + rename callsite migration ~15 LoC，仍在 PR 合理 size 內）。
 
 **屬中型 PR**。`go test` 預期 elapsed < 30s 內。
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,13 @@
-# Lights Rebuild — Phase 4a-1 Plan v1 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.1 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1（plan 第一輪起草，待 codex review）
+**Status**: draft v1.1（Round 1 codex review fix — `review-moh40grn-u7wxgv`，2 P2 findings 全採納）
+
+## v1.x 演進
+
+| 版本 | 變更 |
+|---|---|
+| v1 | 初版起草（6 slices / 24 tests / ~305 LoC）|
+| v1.1 | R1 codex review fix：(1) API gap — `WatchTopLines` / `WatchFullScreen` 無法接收 `IdleStableTicks`；併為單一 `Watch(target, opts, cb)` + `WatchOptions{TopLines, IdleStableTicks}`；(2) repeated stable emission — `stableEmitted` flag 確保每次 changed→stable transition 只觸發一次 ScreenStable；新增 PR2b 測試覆蓋連續穩定無重發 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -36,9 +43,9 @@ PR-4a-1 把目前 `internal/agent/probe/activity.go` 的 watcher 從「probe 解
 
 **Slice 1**：Probe primitive 重構
 - 新增 `ScreenChangeEvent` struct + `ScreenChangeCallback`
-- 新增 `WatchTopLines(target, lines, cb)`（PR-4a-1 cc / codex / opencode 主用）
-- 新增 `WatchFullScreen(target, cb)`（保留 escape hatch；目前無 caller，但 readiness extension 可能用）
-- `watchLoop` 統一內部 poll 機制；watcher 自治（callback 不再 cancel/delete）
+- 新增 `WatchOptions{TopLines int, IdleStableTicks int}`（R1 fix #1 — 統一收 caller tuning，避免雙 API 分歧 + IdleStableTicks 無入口）
+- 新增 `Watch(target, opts, cb)` — 單一 entry：`opts.TopLines == 0` 走 full screen；`> 0` 走 top-N
+- `watchLoop` 統一內部 poll 機制；watcher 自治（callback 不再 cancel/delete）；**`stableEmitted` flag**（R1 fix #2）— ScreenStable 每次 changed→stable transition 只觸發一次，避免 idle 重發
 - **移除**：`activityLoop` 對 `ActivitySignal{Running, Idle, ShellPrompt}` 的解讀；`StartWatch` 簽名換成新 primitive；舊 callback 路徑由 module 層接管
 - **保留**：`StopWatch` / `StopAllWatches` / `HasWatcher` 維持原語意
 
@@ -148,44 +155,65 @@ const (
 type ScreenChangeCallback func(ScreenChangeEvent)
 ```
 
-#### 2.1.2 新增 `WatchTopLines` / `WatchFullScreen`
+#### 2.1.2 新增 `WatchOptions` + 單一 `Watch` API（R1 fix #1）
 
 ```go
-// WatchTopLines starts a watcher on the top n lines of the target.
-// Emits ScreenChanged on first hash diff; emits ScreenStable on N
-// consecutive identical hashes (default N=3, configurable via opts in
-// Slice 3). The watcher persists until StopWatch is called — callbacks
-// do NOT terminate the watcher (kickoff Decision 13: watch-loop-owned).
-func (p *Prober) WatchTopLines(target string, lines int, cb ScreenChangeCallback) {...}
+// WatchOptions tunes the watch loop behavior. Zero values fall back to
+// safe defaults (TopLines = 0 → full screen; IdleStableTicks = 0 → 3).
+type WatchOptions struct {
+    // TopLines limits captured content to the top N lines via
+    // tmux.CapturePaneTopLines. 0 means full screen (CapturePaneContent).
+    TopLines int
 
-// WatchFullScreen starts a watcher on the full visible pane content.
-// Equivalent to the legacy hash-the-whole-pane mode; retained for
-// readiness/debug callers that need full-screen sampling.
-func (p *Prober) WatchFullScreen(target string, cb ScreenChangeCallback) {...}
+    // IdleStableTicks is the number of consecutive identical-hash ticks
+    // before ScreenStable is emitted. 0 means default 3.
+    IdleStableTicks int
+}
+
+// Watch starts a screen change watcher on the target.
+// Emits ScreenChanged on hash diff; emits ScreenStable exactly once per
+// changed→stable transition (see watchLoop §2.1.3). The watcher persists
+// until StopWatch is called — callbacks do NOT terminate the watcher
+// (kickoff Decision 13: watch-loop-owned).
+func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback) {...}
 ```
 
-#### 2.1.3 `watchLoop` 內部 poll 機制
+**設計理由**（R1 fix #1）：
+- 單一 entry 比雙 API 簡潔；`TopLines == 0` 是天然 full-screen sentinel
+- `WatchOptions` 結構體擴展性好，未來加 poll interval / hash algorithm 等不破壞 API
+- IdleStableTicks 經由 opts 結構流入 watchLoop，OR1 test 可以對 cc profile `{Lines:5, IdleStableTicks:2}` 驗 stable threshold
 
-- 啟動：`captureFn` (closure 鎖住 `WatchTopLines` 或 `WatchFullScreen` 的 capture 邏輯) → ticker 500ms → ctx loop
+**caller 端**：orchestrator 拿 ProbeProfile 後組成 `WatchOptions{TopLines: profile.TopLines, IdleStableTicks: profile.IdleStableTicks}` 傳入 `Watch`（§2.3.3 詳述）。
+
+#### 2.1.3 `watchLoop` 內部 poll 機制（含 R1 fix #2）
+
+- 啟動：`captureFn` (closure 依 `opts.TopLines` 決定呼叫 `CapturePaneTopLines(target, opts.TopLines)` 或 `CapturePaneContent(target, fullScreenLineCount)`) → ticker 500ms → ctx loop
 - 邏輯：
   ```
-  baseline = capture()  // 失敗則退出，無 baseline 不發事件
+  idleStableTicks = opts.IdleStableTicks; if idleStableTicks == 0 { idleStableTicks = 3 }
+  baseline, ok = capture(); if !ok { return }  // 無 baseline 不發事件
+  stableCount = 0
+  stableEmitted = false  // R1 fix #2: 每次 changed→stable transition 只觸發一次
   loop:
     select ctx.Done -> return
     select tick:
-      current = capture()
-      if err: continue (skip tick, don't fire false event)
+      current, ok = capture()
+      if !ok: continue (skip tick, don't fire false event)
       if hash(current) != hash(baseline):
         cb(ScreenChanged{Content: current})
         baseline = current
         stableCount = 0
-        continue loop  // 繼續觀察，不退出
+        stableEmitted = false  // change resets, future stable-emit allowed
+        continue
+      // hash unchanged
       stableCount++
-      if stableCount >= idleStableTicks (default 3):
+      if !stableEmitted && stableCount >= idleStableTicks:
         cb(ScreenStable{Content: current})
-        stableCount = 0  // reset，allow re-fire on next change-stable cycle
+        stableEmitted = true
+        // do NOT reset stableCount; do NOT re-emit ScreenStable until next change
   ```
-- **關鍵差異 vs legacy `activityLoop`**：watcher 不退出；可發多次 ScreenChanged + ScreenStable 事件；callback 不擁有 watcher 生命週期
+- **關鍵差異 vs legacy `activityLoop`**：watcher 不退出；可發多次 ScreenChanged + ScreenStable transitions；callback 不擁有 watcher 生命週期；同一 stable run 不會重發 ScreenStable
+- **R1 fix #2 rationale**：legacy `activityLoop` 自動退出後不存在 repeated emission 問題；新 watch-loop-owned 設計若不加 `stableEmitted` flag，idle pane 會每 N ticks 重發 ScreenStable → orchestrator 對應重發 StatusIdle broadcast → metrics counter 無限累積 + log 噴 + WS 客戶端收 idle 風暴。`stableEmitted` 確保「stable run 視為一個 transition，到下次 change 才再 arm」
 
 #### 2.1.4 Watcher ownership 變更
 
@@ -196,20 +224,21 @@ func (p *Prober) WatchFullScreen(target string, cb ScreenChangeCallback) {...}
 #### 2.1.5 移除的東西
 
 - `ActivitySignal` enum + `ActivityCallback` type — 由 ScreenChangeCallback / ScreenChangeEvent 取代；舊 callsite 由 module 層轉接（Slice 3）
-- `StartWatch(target, ActivityCallback)` 公開 API — 改名 / 替換為 `WatchTopLines` / `WatchFullScreen`
+- `StartWatch(target, ActivityCallback)` 公開 API — 替換為 `Watch(target, opts, cb)`
 - `activityLoop` 內部 method — 改成 `watchLoop`
 - `hashCapture` 內部 method — 改成支援 captureFn closure 的版本
 
-#### 2.1.6 測試（6 tests）
+#### 2.1.6 測試（7 tests — R1 +1 PR2b）
 
 | Test | 重點 |
 |------|------|
-| PR1 `TestWatchTopLines_FiresChangedOnDiff` | 注入兩次 capture（同 → 異），驗證單次 ScreenChanged callback、Content 為新內容 |
-| PR2 `TestWatchTopLines_FiresStableAfterNIdenticalSamples` | 連續 4 次同 capture，驗證單次 ScreenStable callback（baseline + 3 stable ticks）|
-| PR3 `TestWatchTopLines_DoesNotExitOnCallback` | 一次 ScreenChanged callback 後再注入 diff，驗證再發 ScreenChanged（loop 持續）|
-| PR4 `TestWatchTopLines_StopWatch_CancelsLoop` | StopWatch 後 capture mock 不再被 call、HasWatcher false |
-| PR5 `TestWatchFullScreen_UsesEntirePane` | 注入 only-bottom-line-changed scenario，FullScreen 報 changed、TopLines (n=3) 不報 changed |
-| PR6 `TestWatchTopLines_TmuxErrorTickSkipped` | capture err 在 tick 中發生 → 不 fire ScreenChanged，下一 tick 復原 → 報 ScreenChanged |
+| PR1 `TestWatch_FiresChangedOnDiff` | 注入兩次 capture（同 → 異），驗證單次 ScreenChanged callback、Content 為新內容 |
+| PR2 `TestWatch_FiresStableAfterNIdenticalSamples` | 連續 4 次同 capture，驗證單次 ScreenStable callback（baseline + 3 stable ticks）|
+| PR2b `TestWatch_StableEmittedOnceUntilNextChange`（**R1 fix #2 regression**）| 注入 6 次同 capture（baseline + 5 stable）— 驗證 ScreenStable 只 fire 1 次；接著注入 diff → ScreenChanged fire；再注入 4 同 → ScreenStable 再 fire 1 次（changed→stable 切換才 re-arm）|
+| PR3 `TestWatch_DoesNotExitOnCallback` | 一次 ScreenChanged callback 後再注入 diff，驗證再發 ScreenChanged（loop 持續）|
+| PR4 `TestWatch_StopWatch_CancelsLoop` | StopWatch 後 capture mock 不再被 call、HasWatcher false |
+| PR5 `TestWatch_TopLinesIgnoresBottomChanges` | 注入 only-bottom-line-changed scenario，opts.TopLines=3 不報 changed；opts.TopLines=0（full screen）報 changed |
+| PR6 `TestWatch_TmuxErrorTickSkipped` | capture err 在 tick 中發生 → 不 fire ScreenChanged，下一 tick 復原 → 報 ScreenChanged |
 
 ---
 
@@ -271,7 +300,7 @@ type ProbeProfile struct {
 
 放 `internal/agent/provider.go`。沿用 `StatusSupporter` / `HookInstaller` 的 optional interface 模式。
 
-#### 2.3.3 default profile
+#### 2.3.3 default profile（R1 fix #1：opts 結構流入 prober）
 
 定義於 orchestrator package：
 
@@ -285,11 +314,11 @@ profile := defaultProbeProfile
 if pp, ok := agentProvider.(agentpkg.ProbeProfileProvider); ok {
     profile = pp.ProbeProfile()
 }
-if profile.TopLines > 0 {
-    o.parent.prober.WatchTopLines(target, profile.TopLines, o.makeCallback(session, agentType))
-} else {
-    o.parent.prober.WatchFullScreen(target, o.makeCallback(session, agentType))
+opts := probe.WatchOptions{
+    TopLines:        profile.TopLines,        // 0 = full screen
+    IdleStableTicks: profile.IdleStableTicks, // 0 = default 3 (handled by watchLoop)
 }
+o.parent.prober.Watch(target, opts, o.makeCallback(session, agentType))
 ```
 
 #### 2.3.4 graceWindow 解讀
@@ -440,13 +469,13 @@ log 點（gated）：
 | Slice | Test ID 區段 | 數量 | 涵蓋 |
 |-------|--------------|------|------|
 | 0 | TT1-TT4 | 4 | tmux range API + fake executor parity |
-| 1 | PR1-PR6 | 6 | watcher 自治 / Top-N vs FullScreen / 多次 fire / err tick skip |
+| 1 | PR1-PR2b + PR3-PR6 | 7 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / **stable-emit-once（R1 fix #2）**|
 | 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
 | 3 | OR1-OR5 | 5 | profile / graceWindow / Error Guard |
 | 4 | CC1-CC5 | 5 | cc profile + module wiring + E2E |
 | 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
 
-**總計**：24 tests（與 plan v1.3 §7.1 estimate 對齊）。
+**總計**：25 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 regression test）。
 
 ---
 
@@ -464,8 +493,8 @@ Slice 0 全部。包含：
 ### Commit 2 — `refactor(probe): extract pure ScreenChangeEvent primitive`
 
 Slice 1 + Slice 2。包含：
-- PR1-PR6 全 written first
-- 新增 `ScreenChangeEvent` / `ScreenChangeCallback` / `WatchTopLines` / `WatchFullScreen` / `watchLoop`
+- PR1-PR2b + PR3-PR6 全 written first（含 R1 fix #2 regression PR2b）
+- 新增 `ScreenChangeEvent` / `ScreenChangeCallback` / `WatchOptions` / `Watch` / `watchLoop`（含 `stableEmitted` flag）
 - 移除 `ActivitySignal` / `ActivityCallback` / `activityLoop` / `StartWatch (legacy)` / `hashCapture`（或改名）
 - `LooksLikeShellPrompt` / `StripANSI` export
 - **Caller 端**：`module.go` 暫時 build error 容忍（下個 commit 修）— 用 `// TODO Slice 3` 註記；或這個 commit 同時把 module.go 改為 stub 呼叫（建議後者，避免 broken intermediate state）
@@ -578,14 +607,14 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | Slice | 估 LoC | 估 tests |
 |-------|--------|----------|
 | 0 tmux API | ~40 | 4 |
-| 1 probe primitive | ~80 | 6 |
+| 1 probe primitive | ~85 | 7（R1 +PR2b）|
 | 2 shell prompt export | ~5 | 0 |
 | 3 module orchestrator | ~80 | 5 |
 | 4 cc adoption | ~40 | 5 |
 | 7 graceWindow + dev log + expvar | ~30 | 4 |
 | (extra) boundary script | ~30 | 0 |
 
-**總計**：~305 LoC + 24 tests（plan v1.3 §7.1 estimate ~250 略高 — 主因新 ScreenChangeEvent type + ProbeProfileProvider interface + boundary script，仍在 PR 合理 size 內）。
+**總計**：~310 LoC + 25 tests（plan v1.3 §7.1 estimate ~250+24，本版 R1 +5 LoC `stableEmitted` + `WatchOptions` + 1 PR2b regression test，仍在 PR 合理 size 內）。
 
 **屬中型 PR**。`go test` 預期 elapsed < 30s 內。
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.8 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.9 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.8（Round 8 codex review fix — 1 P2 + 1 P3 採納）
+**Status**: draft v1.9（Round 9 codex review fix — 1 P2 substantive 採納）
 
 ## v1.x 演進
 
@@ -15,6 +15,7 @@
 | v1.6 | R6 codex review fix（2 P2 internal-consistency）：(1) §1.1 Slice 3 摘要還寫「`stopProbeWatch` 含 activeWatchers map cleanup」與 R3 修法（orchestrator 不碰 activeWatchers）矛盾；改正為「停止 prober watcher」並引向 §2.3.1 R3 fix；(2) Commit 5 TDD 清單只列 CC1-CC5，漏掉 CC6 (R2 fix #1 + R3 deadlock-freedom regression)；補入 written-first 清單 |
 | v1.7 | R7 codex review fix（1 P2 + 1 P3）：(1) §2.3.3 startWatch pseudo-code 用未定義 `target`，既有 callsite 都是 `session + ":"` 形式；明寫 `target := session + ":"` 在 startWatch / stopWatch contract，避免 implementer 編譯失敗或 bare-session 啟 watcher；(2) §2.4.4 標題寫「測試（5 tests）」但表格列 CC1-CC6 共 6 個；改為「測試（6 tests — R2 +CC6）」 |
 | v1.8 | R8 codex review fix（1 P2 + 1 P3）：(1) §2.3.3 startWatch pseudo-code 仍用未定義 `agentProvider` 變數 + `defaultProbeProfile` 為 unqualified type；補完整 provider lookup（registry → agentType → provider）+ 改 `agentpkg.ProbeProfile` qualified 命名；(2) §2.1.6 標題「測試（7 tests — R1 +PR2b）」與 §3 矩陣（8 tests）+ 表內列出 8 個 testID 不符；改為「測試（8 tests — R1 +PR2b / R2 +PR4b）」 |
+| v1.9 | R9 codex review fix（1 P2 substantive — **regression risk**）：legacy `CapturePaneContent(target, 10)` 是 **last 10 lines**（`tmux capture-pane -S -10`，hash bottom 10 行），但 v1.8 default profile `{TopLines: 10}` 配 `CapturePaneTopLines` 會 hash **top 10 lines**。codex/opencode 沒有 ProbeProfileProvider 走 default → 行為被默默改掉，違反 §6 G5 default profile parity gate（明訂「不實作 ProbeProfileProvider 的 agent 行為與 PR-4a-1 前等價」）。修法：擴 `WatchOptions` 加 `BottomLines int` field（與 `TopLines` 互斥）；default profile 改用 `{BottomLines: 10}` 保留 legacy capture 語意；新增 PR5b 測試覆蓋 BottomLines vs TopLines 行為差異 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -165,15 +166,32 @@ const (
 type ScreenChangeCallback func(ScreenChangeEvent)
 ```
 
-#### 2.1.2 新增 `WatchOptions` + 單一 `Watch` API（R1 fix #1）
+#### 2.1.2 新增 `WatchOptions` + 單一 `Watch` API（R1 fix #1；R9 fix — 加 BottomLines）
 
 ```go
 // WatchOptions tunes the watch loop behavior. Zero values fall back to
-// safe defaults (TopLines = 0 → full screen; IdleStableTicks = 0 → 3).
+// safe defaults: when both TopLines and BottomLines are 0, the watcher
+// hashes the full visible pane via tmux.CapturePaneContent(target, 0);
+// IdleStableTicks = 0 → default 3.
+//
+// TopLines and BottomLines are mutually exclusive (only one may be > 0).
+// If both are set, watchLoop returns early without registering — caller
+// programming error.
 type WatchOptions struct {
     // TopLines limits captured content to the top N lines via
-    // tmux.CapturePaneTopLines. 0 means full screen (CapturePaneContent).
+    // tmux.CapturePaneTopLines (CapturePaneRange(target, 0, N-1)).
+    // 0 means "do not use top-line capture" — see BottomLines / fallback.
     TopLines int
+
+    // BottomLines limits captured content to the bottom N lines via
+    // legacy tmux.CapturePaneContent(target, N) semantics
+    // (capture-pane -S -N). 0 means "do not use bottom-line capture".
+    //
+    // R9 fix: this preserves legacy capture mode for agents without
+    // ProbeProfileProvider (default profile uses BottomLines: 10 to
+    // hash the same region the legacy activityLoop did, ensuring G5
+    // default-profile parity for codex/opencode).
+    BottomLines int
 
     // IdleStableTicks is the number of consecutive identical-hash ticks
     // before ScreenStable is emitted. 0 means default 3.
@@ -185,15 +203,23 @@ type WatchOptions struct {
 // changed→stable transition (see watchLoop §2.1.3). The watcher persists
 // until StopWatch is called — callbacks do NOT terminate the watcher
 // (kickoff Decision 13: watch-loop-owned).
+//
+// Capture mode is selected by opts:
+//   TopLines > 0      → CapturePaneTopLines(target, TopLines)
+//   BottomLines > 0   → CapturePaneContent(target, BottomLines)  // legacy
+//   both == 0         → CapturePaneContent(target, 0)            // full pane
 func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback) {...}
 ```
 
-**設計理由**（R1 fix #1）：
-- 單一 entry 比雙 API 簡潔；`TopLines == 0` 是天然 full-screen sentinel
+**設計理由**（R1 fix #1 + R9 fix）：
+- 單一 entry 比雙 API 簡潔；TopLines / BottomLines / both-zero 三種 capture mode 由 sentinel 表達
 - `WatchOptions` 結構體擴展性好，未來加 poll interval / hash algorithm 等不破壞 API
-- IdleStableTicks 經由 opts 結構流入 watchLoop，OR1 test 可以對 cc profile `{Lines:5, IdleStableTicks:2}` 驗 stable threshold
+- IdleStableTicks 經由 opts 結構流入 watchLoop，OR1 test 可以對 cc profile `{TopLines:5, IdleStableTicks:2}` 驗 stable threshold
+- **R9 fix**：BottomLines 保留 legacy `CapturePaneContent(target, N)` 語意（hash last N lines），讓 default profile = `{BottomLines: 10}` 對未實作 ProbeProfileProvider 的 agent 維持原行為，達成 G5 parity gate
 
-**caller 端**：orchestrator 拿 ProbeProfile 後組成 `WatchOptions{TopLines: profile.TopLines, IdleStableTicks: profile.IdleStableTicks}` 傳入 `Watch`（§2.3.3 詳述）。
+**caller 端**：orchestrator 拿 ProbeProfile 後組成 `WatchOptions{TopLines: profile.TopLines, BottomLines: profile.BottomLines, IdleStableTicks: profile.IdleStableTicks}` 傳入 `Watch`（§2.3.3 詳述）。
+
+**ProbeProfile 同步擴增**：`ProbeProfile` 也加 `BottomLines int` field（與 `TopLines` 互斥），讓 agent provider 可選擇 capture region 方向。詳 §2.3.2。
 
 #### 2.1.3 `watchLoop` 內部 poll 機制（含 R1 fix #2）
 
@@ -249,7 +275,7 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 - `activityLoop` 內部 method — 改成 `watchLoop`
 - `hashCapture` 內部 method — 改成支援 captureFn closure 的版本
 
-#### 2.1.6 測試（8 tests — R1 +PR2b / R2 +PR4b）
+#### 2.1.6 測試（9 tests — R1 +PR2b / R2 +PR4b / R9 +PR5b）
 
 | Test | 重點 |
 |------|------|
@@ -259,7 +285,8 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 | PR3 `TestWatch_DoesNotExitOnCallback` | 一次 ScreenChanged callback 後再注入 diff，驗證再發 ScreenChanged（loop 持續）|
 | PR4 `TestWatch_StopWatch_CancelsLoop` | StopWatch 後 capture mock 不再被 call、HasWatcher false |
 | PR4b `TestWatch_BaselineFailure_CleansMapEntry`（**R2 fix #2 regression**）| capture mock 對 first call 回 err；驗證 `Watch` 啟動後 200ms 內 `HasWatcher(target) == false`（goroutine 自己清 entry）|
-| PR5 `TestWatch_TopLinesIgnoresBottomChanges` | 注入 only-bottom-line-changed scenario，opts.TopLines=3 不報 changed；opts.TopLines=0（full screen）報 changed |
+| PR5 `TestWatch_TopLinesIgnoresBottomChanges` | 注入 only-bottom-line-changed scenario，opts.TopLines=3 不報 changed；opts={}（full pane）報 changed |
+| PR5b `TestWatch_BottomLinesIgnoresTopChanges`（**R9 fix regression**）| 注入 only-top-line-changed scenario，opts.BottomLines=3 不報 changed；opts.TopLines=3 報 changed；驗證 BottomLines vs TopLines 走不同 capture path 且互斥 |
 | PR6 `TestWatch_TmuxErrorTickSkipped` | capture err 在 tick 中發生 → 不 fire ScreenChanged，下一 tick 復原 → 報 ScreenChanged |
 
 ---
@@ -323,8 +350,14 @@ type ProbeProfileProvider interface {
 }
 
 type ProbeProfile struct {
-    TopLines        int  // 0 = use full screen
-    IdleStableTicks int  // 0 = default 3
+    // TopLines: hash the top N lines (CapturePaneTopLines). 0 = unused.
+    TopLines int
+    // BottomLines: hash the bottom N lines (legacy CapturePaneContent
+    // semantics). 0 = unused. Mutually exclusive with TopLines.
+    // R9 fix: enables default profile to preserve legacy capture mode.
+    BottomLines int
+    // IdleStableTicks: 0 = default 3.
+    IdleStableTicks int
 }
 ```
 
@@ -343,7 +376,12 @@ orchestrator `startWatch` 邏輯（R7 fix — 顯式組 tmux target；R8 fix —
 // defaultProbeProfile is a package-level constant (defined in
 // internal/module/agent, not internal/agent). Uses agentpkg-qualified
 // ProbeProfile to match its definition site.
-var defaultProbeProfile = agentpkg.ProbeProfile{TopLines: 10, IdleStableTicks: 3}
+//
+// R9 fix: BottomLines (not TopLines) preserves legacy
+// CapturePaneContent(target, 10) capture region for agents that do not
+// implement ProbeProfileProvider — keeps codex/opencode behaviorally
+// unchanged in PR-4a-1, satisfying §6 G5 default-profile parity gate.
+var defaultProbeProfile = agentpkg.ProbeProfile{BottomLines: 10, IdleStableTicks: 3}
 
 func (o *probeOrchestrator) startWatch(session, agentType string) {
     target := session + ":"  // tmux target convention; matches existing callsite
@@ -358,7 +396,8 @@ func (o *probeOrchestrator) startWatch(session, agentType string) {
     }
 
     opts := probe.WatchOptions{
-        TopLines:        profile.TopLines,        // 0 = full screen
+        TopLines:        profile.TopLines,
+        BottomLines:     profile.BottomLines,     // R9 fix: forward both modes
         IdleStableTicks: profile.IdleStableTicks, // 0 = default 3 (handled by watchLoop)
     }
     o.parent.prober.Watch(target, opts, o.makeCallback(session, agentType))
@@ -576,13 +615,13 @@ log 點（gated）：
 | Slice | Test ID 區段 | 數量 | 涵蓋 |
 |-------|--------------|------|------|
 | 0 | TT1-TT4 | 4 | tmux range API + fake executor parity |
-| 1 | PR1-PR2b + PR3-PR4b + PR5-PR6 | 8 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ baseline-fail map cleanup（R2 fix #2）|
+| 1 | PR1-PR2b + PR3-PR4b + PR5-PR5b + PR6 | 9 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ baseline-fail map cleanup（R2 fix #2）/ **BottomLines vs TopLines mutually exclusive（R9 fix）**|
 | 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
 | 3 | OR1-OR6 | 6 | profile / graceWindow / Error Guard / **stale-callback guard（R4 fix）**|
 | 4 | CC1-CC6 | 6 | cc profile + module wiring + E2E + rename rewatch via orchestrator（R2 fix #1）|
 | 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
 
-**總計**：28 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 regression tests）。
+**總計**：29 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 / +1 PR5b R9 regression tests）。
 
 ---
 
@@ -715,14 +754,14 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | Slice | 估 LoC | 估 tests |
 |-------|--------|----------|
 | 0 tmux API | ~40 | 4 |
-| 1 probe primitive | ~90 | 8（R1 +PR2b / R2 +PR4b）|
+| 1 probe primitive | ~95 | 9（R1 +PR2b / R2 +PR4b / R9 +PR5b）|
 | 2 shell prompt export | ~5 | 0 |
 | 3 module orchestrator | ~85 | 6（R4 +OR6）|
 | 4 cc adoption | ~50 | 6（R2 +CC6 rename）|
 | 7 graceWindow + dev log + expvar | ~30 | 4 |
 | (extra) boundary script | ~30 | 0 |
 
-**總計**：~330 LoC + 28 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1，總 +4 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard ~20 LoC，仍在 PR 合理 size 內）。
+**總計**：~340 LoC + 29 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1 / R9 +1，總 +5 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard + R9 BottomLines field + capture-mode dispatcher ~25 LoC，仍在 PR 合理 size 內）。
 
 **屬中型 PR**。`go test` 預期 elapsed < 30s 內。
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,0 +1,616 @@
+# Lights Rebuild — Phase 4a-1 Plan v1 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+
+**Status**: draft v1（plan 第一輪起草，待 codex review）
+
+**前置**：
+- `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
+- `docs/specs/2026-04-26-lights-rebuild-phase-4a-plan.md` v1.3 — Phase 4a 整體 plan（PR-4a-0 已 ship at alpha.233；PR-4a-1 / PR-4a-2 大綱於 §7.1 / §7.2；§7.3 Slice 6 design-impact stop/go gate）
+- `docs/specs/2026-04-26-opencode-1.14.23-hook-audit.md` §6 — Slice 6 design-impact summary：**All 3 triggers reliable → Go**（per plan v1.3 §7.3 evidence-based criteria）
+
+**繼承**：
+- spec §2.4.1 Architecture Guardrails（Probe layer = pure primitive，agent module = policy）
+- kickoff_lights_rebuild Decision 1/2/4/6/7/8/13（pure primitive / 砍字元偵測 / Top-N hash / graceWindow + PDX_DEV_MODE log / `purdex_probe_*` expvar / `CapturePaneRange`+`CapturePaneTopLines` / watch-loop-owned ownership）
+
+---
+
+## 0. 來龍去脈
+
+PR-4a-0（OpenCode 1.14.23 hooks completion）已 ship at alpha.233。audit 確認三家 trigger pattern 全 reliable，PR-4a-1 / PR-4a-2 切分按 plan v1.3 §7 大綱繼續。
+
+PR-4a-1 把目前 `internal/agent/probe/activity.go` 的 watcher 從「probe 解讀 signal + 模組接收 enum」重構為「probe 發 ScreenChangeEvent 原始事件 + 模組解讀」，並把 cc module 的 watch lifecycle 抽成共用 orchestrator helper（PR-4a-2 codex / opencode 接同一份 helper）。同時補上 Phase 4 框架早就規劃但尚未落地的 graceWindow + PDX_DEV_MODE observation log + `purdex_probe_*` expvar。
+
+**為什麼不做字元偵測**（spec §8.1 原方向）：cc / codex spinner 都帶 elapsed timer，整面 pane hash diff 永遠變動，字元偵測救的場景實務頻率近零。改用 **Top-N 行 hash 偵測**（自動過濾使用者打字 / spinner / 彩虹底部位置雜訊）— 見 Slice 1 §2.1.3。
+
+**為什麼拆 PR-4a-1 / PR-4a-2**：probe primitive 與 module orchestrator 是平台 API，落地 cc 一家先驗證設計形狀；codex / opencode 接駁 + 清舊放下一個 PR，避免一次改三家發生 merge-time conflict 又卡 review。
+
+---
+
+## 1. Scope
+
+### 1.1 In scope
+
+**Slice 0**：tmux API 擴展
+- `CapturePaneRange(target, start, endInclusive int) (string, error)` — 通用底層 primitive
+- `CapturePaneTopLines(target string, n int) (string, error)` — Top-N 糖衣
+- fake executor 對應實作 + `tmux.Executor` interface 擴增
+
+**Slice 1**：Probe primitive 重構
+- 新增 `ScreenChangeEvent` struct + `ScreenChangeCallback`
+- 新增 `WatchTopLines(target, lines, cb)`（PR-4a-1 cc / codex / opencode 主用）
+- 新增 `WatchFullScreen(target, cb)`（保留 escape hatch；目前無 caller，但 readiness extension 可能用）
+- `watchLoop` 統一內部 poll 機制；watcher 自治（callback 不再 cancel/delete）
+- **移除**：`activityLoop` 對 `ActivitySignal{Running, Idle, ShellPrompt}` 的解讀；`StartWatch` 簽名換成新 primitive；舊 callback 路徑由 module 層接管
+- **保留**：`StopWatch` / `StopAllWatches` / `HasWatcher` 維持原語意
+
+**Slice 2**：ShellPrompt utility 保留
+- `looksLikeShellPrompt(content)` / `stripANSI(content)` 維持 probe package（公開為 `LooksLikeShellPrompt` 讓 module 呼用）；不改演算法、不加 test，純 visibility 提升
+
+**Slice 3**：Module 共用 orchestrator helper
+- 新增 `internal/module/agent/probe_orchestrator.go`（暫名）
+- 抽出 `manageActivityWatch` + `onActivityDetected` 共用邏輯為：
+  - `startProbeWatch(session, agentType)` — 啟動 watcher（依 agent profile 決定 TopN 行數）
+  - `stopProbeWatch(session)` — 停止 watcher（含 activeWatchers map cleanup）
+  - `interpretScreenEvent(session, agentType, event)` — 把 ScreenChangeEvent 解讀為 Status，套用 graceWindow + Error Guard + projection update + broadcast
+- `agentpkg.Provider` 新增 optional interface `ProbeProfileProvider`（暫名）
+  - `ProbeProfile()` → `{TopLines int, IdleStableTicks int}` 等 per-agent tuning
+  - cc 在 Slice 4 實作；未實作的 agent 走 default profile（沿用現行 10 行 / 3 ticks）
+
+**Slice 4**：cc 接新 primitive
+- `internal/agent/cc/` 新增 `probe_profile.go`：cc 實作 `ProbeProfileProvider`，回傳 cc 專屬 TopLines / IdleStableTicks
+- `internal/module/agent/module.go` 把現行 `manageActivityWatch` / `onActivityDetected` 改為 thin wrapper 呼叫 Slice 3 helper（codex / opencode 在 PR-4a-2 切換；本 PR 維持透過 default profile 走相同 helper，使三家同一 entry，行為向下相容）
+
+**Slice 7**：graceWindow + PDX_DEV_MODE log + expvar
+- `internal/module/agent/probe_orchestrator.go` 引入 `lastHookAt map[session]time.Time` + `probeGraceWindow = 2 * time.Second`（spec §2.4 cited 值）
+- 新增 method `recordHookAt(session)` — handler 處理任何 hook event 時呼叫
+- `interpretScreenEvent` 開頭檢查 graceWindow，命中則 suppress 並 log（gated by `PDX_DEV_MODE=1`）
+- `internal/agent/metrics.go` 新增 4 個 expvar counter（命名 `purdex_probe_*`，**不 rename** 既有 `purdex_phase35_*`）：
+  - `purdex_probe_watch_started_total`
+  - `purdex_probe_watch_stopped_total`
+  - `purdex_probe_screen_event_total`
+  - `purdex_probe_grace_window_suppressed_total`
+
+### 1.2 Out of scope（明列分流）
+
+- **Slice 5（codex 接新 primitive）/ Slice 6（opencode 接新 primitive）/ Slice 8（清舊 onActivityDetected / shouldWatchActivity / ActivitySignal enum signal 解讀）** — 全部留 PR-4a-2
+- **Phase 4b `ProbeIntentProvider`** — 整合 readiness 的 declarative intent 系統，留 Phase 4b
+- **Phase 5 Dev Inspector SPA UI** — `/api/agent/monitor/*` 視覺化，留 Phase 5
+- **Character-level detection（彩虹字 / spinner 偵測）** — kickoff Decision 2 已砍，Top-N hash 取代
+- **User typing vs agent loading 細緻分辨** — kickoff Decision 3 已砍
+
+---
+
+## 2. 設計
+
+### 2.0 Slice 0 — tmux API 擴展（~40 LoC + 4 tests）
+
+#### 2.0.1 新增 `tmux.Executor` interface methods
+
+```go
+// CapturePaneRange returns lines [start, endInclusive] of the pane.
+// Indexing follows tmux capture-pane -S/-E semantics:
+//   - start/end are line indices; 0 = top of visible pane
+//   - negative values reference history above the visible pane
+// Returns error on tmux invocation failure or invalid range.
+CapturePaneRange(target string, start, endInclusive int) (string, error)
+
+// CapturePaneTopLines returns the top n lines (0..n-1) of the pane.
+// Equivalent to CapturePaneRange(target, 0, n-1).
+CapturePaneTopLines(target string, n int) (string, error)
+```
+
+#### 2.0.2 RealExecutor 實作
+
+- `CapturePaneRange`：呼叫 `tmux capture-pane -p -t <target> -S <start> -E <endInclusive>`；空輸出視為合法（未必是錯）
+- `CapturePaneTopLines`：呼叫 `CapturePaneRange(target, 0, n-1)`；`n <= 0` 回傳 ""（不報錯，方便 caller 用零值 disable）
+
+**注意**：保留 `CapturePaneContent(target, lastN)` 不動 — 既有 callsite（probe / monitor / debug endpoints）仍使用，不在本 PR scope；PR-4a-2 Slice 8 清舊時再判斷是否 deprecated。
+
+#### 2.0.3 Fake executor 對應
+
+`internal/tmux/fake_executor.go`（如果不存在則在 test 檔內建）需要對應 stub：
+- `CapturePaneRange` / `CapturePaneTopLines` 用同一份 `paneContent map[string]string` 作 source
+- 加 `paneContentByRange map[string][]string` 讓 test 注入 per-range 模擬輸出
+
+#### 2.0.4 測試（4 tests）
+
+| Test | 重點 |
+|------|------|
+| TT1 `TestCapturePaneRange_RealExecutor_PassesArgs` | 用 `tmux` script-mode mock 驗證 `-S` `-E` 參數透傳正確 |
+| TT2 `TestCapturePaneTopLines_DelegatesToRange` | 表 test：n=1/3/10 對應 range (0,0)/(0,2)/(0,9) |
+| TT3 `TestCapturePaneTopLines_ZeroOrNegative_ReturnsEmpty` | n=0/n=-1 回 ""，不調 tmux |
+| TT4 `TestFakeExecutor_RangeMethods_Roundtrip` | 注入 5-line content，每種 range 取出對應 slice |
+
+---
+
+### 2.1 Slice 1 — Probe primitive 重構（~80 LoC + 6 tests）
+
+#### 2.1.1 新增 `ScreenChangeEvent`
+
+```go
+// ScreenChangeEvent is the raw output of a screen watcher.
+// The probe layer emits these without interpreting them as agent status —
+// callers (agent module / orchestrator) own the policy of mapping events
+// to status transitions.
+type ScreenChangeEvent struct {
+    Kind        ScreenChangeKind
+    Target      string    // tmux target e.g. "session-name:"
+    Content     string    // captured content at the moment of the event
+    OccurredAt  time.Time // probe-layer wall clock
+}
+
+type ScreenChangeKind string
+
+const (
+    ScreenChanged ScreenChangeKind = "changed" // hash differs from last sample
+    ScreenStable  ScreenChangeKind = "stable"  // hash matched for N consecutive ticks
+)
+
+type ScreenChangeCallback func(ScreenChangeEvent)
+```
+
+#### 2.1.2 新增 `WatchTopLines` / `WatchFullScreen`
+
+```go
+// WatchTopLines starts a watcher on the top n lines of the target.
+// Emits ScreenChanged on first hash diff; emits ScreenStable on N
+// consecutive identical hashes (default N=3, configurable via opts in
+// Slice 3). The watcher persists until StopWatch is called — callbacks
+// do NOT terminate the watcher (kickoff Decision 13: watch-loop-owned).
+func (p *Prober) WatchTopLines(target string, lines int, cb ScreenChangeCallback) {...}
+
+// WatchFullScreen starts a watcher on the full visible pane content.
+// Equivalent to the legacy hash-the-whole-pane mode; retained for
+// readiness/debug callers that need full-screen sampling.
+func (p *Prober) WatchFullScreen(target string, cb ScreenChangeCallback) {...}
+```
+
+#### 2.1.3 `watchLoop` 內部 poll 機制
+
+- 啟動：`captureFn` (closure 鎖住 `WatchTopLines` 或 `WatchFullScreen` 的 capture 邏輯) → ticker 500ms → ctx loop
+- 邏輯：
+  ```
+  baseline = capture()  // 失敗則退出，無 baseline 不發事件
+  loop:
+    select ctx.Done -> return
+    select tick:
+      current = capture()
+      if err: continue (skip tick, don't fire false event)
+      if hash(current) != hash(baseline):
+        cb(ScreenChanged{Content: current})
+        baseline = current
+        stableCount = 0
+        continue loop  // 繼續觀察，不退出
+      stableCount++
+      if stableCount >= idleStableTicks (default 3):
+        cb(ScreenStable{Content: current})
+        stableCount = 0  // reset，allow re-fire on next change-stable cycle
+  ```
+- **關鍵差異 vs legacy `activityLoop`**：watcher 不退出；可發多次 ScreenChanged + ScreenStable 事件；callback 不擁有 watcher 生命週期
+
+#### 2.1.4 Watcher ownership 變更
+
+- **Legacy**：`activityLoop` defer 內 `delete(p.watchers, target)`；callback fire 一次後 goroutine 自動退出 + 清自己
+- **New**：`watchLoop` defer 只在 ctx cancel 時 cleanup；callback **不能** 觸發退出；module 層必須顯式 `StopWatch(target)` 終止
+- 這個設計避免 module 在 callback 內擔心 race（watcher 還沒退就被新 `StartWatch` 覆蓋）+ 對齊 spec §2.4.1 「probe 不知道 status，不該決定該不該停」
+
+#### 2.1.5 移除的東西
+
+- `ActivitySignal` enum + `ActivityCallback` type — 由 ScreenChangeCallback / ScreenChangeEvent 取代；舊 callsite 由 module 層轉接（Slice 3）
+- `StartWatch(target, ActivityCallback)` 公開 API — 改名 / 替換為 `WatchTopLines` / `WatchFullScreen`
+- `activityLoop` 內部 method — 改成 `watchLoop`
+- `hashCapture` 內部 method — 改成支援 captureFn closure 的版本
+
+#### 2.1.6 測試（6 tests）
+
+| Test | 重點 |
+|------|------|
+| PR1 `TestWatchTopLines_FiresChangedOnDiff` | 注入兩次 capture（同 → 異），驗證單次 ScreenChanged callback、Content 為新內容 |
+| PR2 `TestWatchTopLines_FiresStableAfterNIdenticalSamples` | 連續 4 次同 capture，驗證單次 ScreenStable callback（baseline + 3 stable ticks）|
+| PR3 `TestWatchTopLines_DoesNotExitOnCallback` | 一次 ScreenChanged callback 後再注入 diff，驗證再發 ScreenChanged（loop 持續）|
+| PR4 `TestWatchTopLines_StopWatch_CancelsLoop` | StopWatch 後 capture mock 不再被 call、HasWatcher false |
+| PR5 `TestWatchFullScreen_UsesEntirePane` | 注入 only-bottom-line-changed scenario，FullScreen 報 changed、TopLines (n=3) 不報 changed |
+| PR6 `TestWatchTopLines_TmuxErrorTickSkipped` | capture err 在 tick 中發生 → 不 fire ScreenChanged，下一 tick 復原 → 報 ScreenChanged |
+
+---
+
+### 2.2 Slice 2 — ShellPrompt utility 保留（0 LoC + 0 tests）
+
+`probe.LooksLikeShellPrompt(content string) bool` 與 `probe.stripANSI` 改 export（首字大寫），無邏輯變動。Module 層 Slice 3 引用此 utility 把 ScreenStable 細分為 ShellPrompt 場景。
+
+純 visibility 改動，沿用既有 `shell_prompt_test.go`，本 PR 不加 test。
+
+---
+
+### 2.3 Slice 3 — Module orchestrator helper（~60 LoC + 5 tests）
+
+#### 2.3.1 新增 `internal/module/agent/probe_orchestrator.go`
+
+```go
+// probeOrchestrator owns the lifecycle of probe watchers per session.
+// It interprets ScreenChangeEvent into Status transitions, applies the
+// graceWindow + Error Guard, and broadcasts updates.
+type probeOrchestrator struct {
+    parent *Module  // back-reference for projection / broadcast / activeWatchers
+    
+    graceMu     sync.Mutex
+    lastHookAt  map[string]time.Time  // session → last hook timestamp
+}
+
+func newProbeOrchestrator(m *Module) *probeOrchestrator {...}
+
+// startWatch starts a probe watcher for the session, using agent's profile.
+// Replaces inline call to m.prober.StartWatch in manageActivityWatch.
+func (o *probeOrchestrator) startWatch(session, agentType string) {...}
+
+// stopWatch stops the probe watcher and clears activeWatchers entry.
+func (o *probeOrchestrator) stopWatch(session string) {...}
+
+// recordHookAt records that a hook event was just processed for this session.
+// Subsequent screen events within graceWindow are suppressed (hook authority).
+func (o *probeOrchestrator) recordHookAt(session string) {...}
+
+// interpretScreenEvent maps a ScreenChangeEvent to a status update.
+// Applies graceWindow, Error Guard, projection update, broadcast.
+func (o *probeOrchestrator) interpretScreenEvent(session, agentType string, ev probe.ScreenChangeEvent) {...}
+```
+
+#### 2.3.2 ProbeProfileProvider optional interface
+
+```go
+// ProbeProfileProvider lets agent providers tune probe watch parameters.
+// Default profile is used when an agent doesn't implement this interface.
+type ProbeProfileProvider interface {
+    ProbeProfile() ProbeProfile
+}
+
+type ProbeProfile struct {
+    TopLines        int  // 0 = use full screen
+    IdleStableTicks int  // 0 = default 3
+}
+```
+
+放 `internal/agent/provider.go`。沿用 `StatusSupporter` / `HookInstaller` 的 optional interface 模式。
+
+#### 2.3.3 default profile
+
+定義於 orchestrator package：
+
+```go
+var defaultProbeProfile = ProbeProfile{TopLines: 10, IdleStableTicks: 3}
+```
+
+orchestrator `startWatch` 邏輯：
+```go
+profile := defaultProbeProfile
+if pp, ok := agentProvider.(agentpkg.ProbeProfileProvider); ok {
+    profile = pp.ProbeProfile()
+}
+if profile.TopLines > 0 {
+    o.parent.prober.WatchTopLines(target, profile.TopLines, o.makeCallback(session, agentType))
+} else {
+    o.parent.prober.WatchFullScreen(target, o.makeCallback(session, agentType))
+}
+```
+
+#### 2.3.4 graceWindow 解讀
+
+`interpretScreenEvent` 開頭：
+```go
+o.graceMu.Lock()
+last, hasHook := o.lastHookAt[session]
+o.graceMu.Unlock()
+if hasHook && time.Since(last) < probeGraceWindow {
+    metrics.MetricProbeGraceWindowSuppressed.Add(1)
+    if isDevMode() {
+        log.Printf("[probe] graceWindow suppress session=%s agent=%s kind=%s", session, agentType, ev.Kind)
+    }
+    return
+}
+```
+
+#### 2.3.5 ScreenStable → Status 解讀
+
+```go
+switch ev.Kind {
+case probe.ScreenChanged:
+    status = StatusRunning
+case probe.ScreenStable:
+    if probe.LooksLikeShellPrompt(ev.Content) {
+        // 保留 legacy 行為：dead PID + shell prompt → sweep
+        if projection != nil && projection.TopFrame != nil && !isPidAliveFn(projection.TopFrame.PID) {
+            o.parent.sweepOnce()
+            return
+        }
+        status = StatusIdle  // shell prompt 仍 idle，由 sweep 決定 frame 命運
+    } else {
+        status = StatusIdle
+    }
+}
+```
+
+接著套用 Error Guard + projection update + broadcast（與既有 `onActivityDetected` 同邏輯，整段搬入 helper）。
+
+#### 2.3.6 測試（5 tests）
+
+| Test | 重點 |
+|------|------|
+| OR1 `TestOrchestrator_StartWatchUsesAgentProfile` | mock cc agent 回 `{TopLines: 5, IdleStableTicks: 2}`；驗證 prober 收到 lines=5 / stable=2 |
+| OR2 `TestOrchestrator_DefaultProfileWhenAgentMissing` | mock agent 不實作 ProbeProfileProvider；驗證 fallback 到 `{TopLines: 10, IdleStableTicks: 3}` |
+| OR3 `TestOrchestrator_GraceWindowSuppressesEventWithinWindow` | recordHookAt → 1s 後注入 ScreenChanged；驗證無狀態變化、metrics counter +1 |
+| OR4 `TestOrchestrator_GraceWindowExpiresAfterWindow` | recordHookAt → 3s 後注入 ScreenChanged；驗證 StatusRunning 廣播 |
+| OR5 `TestOrchestrator_ErrorGuardBlocksProbeOverwrite` | currentStatus=StatusError；ScreenStable 注入；驗證 StatusError 維持、無 broadcast |
+
+---
+
+### 2.4 Slice 4 — cc 接新 primitive（~40 LoC + 5 tests）
+
+#### 2.4.1 cc Provider 實作 ProbeProfileProvider
+
+`internal/agent/cc/provider.go`（或新檔 `probe_profile.go`）：
+
+```go
+func (p *Provider) ProbeProfile() agentpkg.ProbeProfile {
+    return agentpkg.ProbeProfile{
+        TopLines:        12,  // cc 螢幕頂部 cluster: ●● header + 任務描述
+        IdleStableTicks: 3,
+    }
+}
+```
+
+具體 TopLines 值由實際觀察 cc UI layout 決定；本 plan 暫定 12，allowed to adjust during implementation 並文件化決定。
+
+#### 2.4.2 module.go 改為走 orchestrator
+
+把 `manageActivityWatch` / `onActivityDetected` 兩個 method 改成 thin wrapper：
+
+```go
+func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status) {
+    m.mu.Lock()
+    _, wasWatching := m.activeWatchers[session]
+    delete(m.activeWatchers, session)
+    m.mu.Unlock()
+    if wasWatching {
+        m.probeOrch.stopWatch(session)
+    }
+    if shouldWatchActivity(newStatus) {
+        m.mu.Lock()
+        m.activeWatchers[session] = agentType
+        m.mu.Unlock()
+        m.probeOrch.startWatch(session, agentType)
+    }
+}
+```
+
+舊 `onActivityDetected` 整個刪掉（邏輯已搬到 orchestrator.interpretScreenEvent；本 PR 範圍內 cc 走新 path，codex / opencode 也透過 default profile 走同一份 helper — 但 codex / opencode 的 TopN 微調留 PR-4a-2，本 PR 三家共用 default profile = 行為向下相容）。
+
+#### 2.4.3 hook handler 呼叫 recordHookAt
+
+`internal/module/agent/handler.go` 的 hook entry path（具體位置實作時定）：每個有效 hook 處理完前 call `m.probeOrch.recordHookAt(session)`，讓接下來 graceWindow 啟動。
+
+#### 2.4.4 測試（5 tests）
+
+| Test | 重點 |
+|------|------|
+| CC1 `TestCCProvider_ProbeProfile` | cc.Provider.ProbeProfile() 回 {12, 3}（characterization；implementer 改值需 review）|
+| CC2 `TestModule_ManageActivityWatch_RoutesThroughOrchestrator` | mock orch；waiting → start watch called；off → stop watch called |
+| CC3 `TestModule_HookHandler_CallsRecordHookAt` | 注入 cc hook event；驗證 orchestrator.lastHookAt[session] 記錄到 |
+| CC4 `TestCC_E2E_ScreenChangedToRunning` | cc waiting → orchestrator.startWatch → 注入 ScreenChanged → status 廣播 Running |
+| CC5 `TestCC_E2E_ScreenStableToIdle` | cc running → orchestrator.startWatch → 注入 ScreenStable（non-shell-prompt）→ status 廣播 Idle |
+
+---
+
+### 2.5 Slice 7 — graceWindow + dev log + expvar（~30 LoC + 4 tests）
+
+實作整合在 Slice 3（同一個 orchestrator）— Slice 7 LoC 含 `internal/agent/metrics.go` 4 個新 expvar + `isDevMode()` helper（package internal/module/agent or internal/agent）+ orchestrator 內 log gating。
+
+#### 2.5.1 expvar 命名（kickoff Decision 7）
+
+```go
+// internal/agent/metrics.go (append, do NOT rename existing purdex_phase35_*)
+var (
+    MetricProbeWatchStarted        = expvar.NewInt("purdex_probe_watch_started_total")
+    MetricProbeWatchStopped        = expvar.NewInt("purdex_probe_watch_stopped_total")
+    MetricProbeScreenEvent         = expvar.NewInt("purdex_probe_screen_event_total")
+    MetricProbeGraceWindowSuppressed = expvar.NewInt("purdex_probe_grace_window_suppressed_total")
+)
+```
+
+#### 2.5.2 PDX_DEV_MODE log
+
+`internal/module/agent/probe_orchestrator.go` 加 `func isDevMode() bool { return os.Getenv("PDX_DEV_MODE") == "1" }`（或搬到 shared util；可借既有 dev module 的 helper 但避免循環依賴）。
+
+log 點（gated）：
+- `recordHookAt` — `[probe] recordHookAt session=%s` （讓觀察者知道 graceWindow 起算）
+- `interpretScreenEvent` graceWindow suppress — 已列 §2.3.4
+- `interpretScreenEvent` 觸發 status 變化 — `[probe] status session=%s agent=%s status=%s reason=screen-%s`
+
+#### 2.5.3 測試（4 tests）
+
+| Test | 重點 |
+|------|------|
+| OB1 `TestMetrics_WatchStartedIncrements` | startWatch → counter +1 |
+| OB2 `TestMetrics_ScreenEventIncrements` | ScreenChanged + ScreenStable 各注入一次 → counter +2 |
+| OB3 `TestMetrics_GraceWindowSuppressedIncrements` | graceWindow hit → counter +1 |
+| OB4 `TestDevMode_LogsGatedByEnv` | t.Setenv PDX_DEV_MODE=1 → log buffer 含 `[probe]` line；unset → 無 |
+
+---
+
+## 3. 測試矩陣
+
+| Slice | Test ID 區段 | 數量 | 涵蓋 |
+|-------|--------------|------|------|
+| 0 | TT1-TT4 | 4 | tmux range API + fake executor parity |
+| 1 | PR1-PR6 | 6 | watcher 自治 / Top-N vs FullScreen / 多次 fire / err tick skip |
+| 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
+| 3 | OR1-OR5 | 5 | profile / graceWindow / Error Guard |
+| 4 | CC1-CC5 | 5 | cc profile + module wiring + E2E |
+| 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
+
+**總計**：24 tests（與 plan v1.3 §7.1 estimate 對齊）。
+
+---
+
+## 4. Commit 順序（TDD）
+
+每個 commit 都先寫測試（red）→ 實作（green）→ 測試 pass。Commit 邊界對齊 Slice 邊界。
+
+### Commit 1 — `feat(tmux): add CapturePaneRange and CapturePaneTopLines`
+
+Slice 0 全部。包含：
+- TT1-TT4 全 written first（red）
+- `tmux.Executor` interface 擴增 + `RealExecutor` 實作 + fake stub
+- `go test ./internal/tmux ./...` 全綠
+
+### Commit 2 — `refactor(probe): extract pure ScreenChangeEvent primitive`
+
+Slice 1 + Slice 2。包含：
+- PR1-PR6 全 written first
+- 新增 `ScreenChangeEvent` / `ScreenChangeCallback` / `WatchTopLines` / `WatchFullScreen` / `watchLoop`
+- 移除 `ActivitySignal` / `ActivityCallback` / `activityLoop` / `StartWatch (legacy)` / `hashCapture`（或改名）
+- `LooksLikeShellPrompt` / `StripANSI` export
+- **Caller 端**：`module.go` 暫時 build error 容忍（下個 commit 修）— 用 `// TODO Slice 3` 註記；或這個 commit 同時把 module.go 改為 stub 呼叫（建議後者，避免 broken intermediate state）
+
+**注意**：本 commit 結束時 `go build ./...` 必須通；test 必須全綠。若無法兩者並立，stub 接 module.go 為 no-op + 標 TODO，commit 訊息中明列。
+
+### Commit 3 — `feat(agent): add ProbeProfileProvider optional interface`
+
+Slice 3 一半（介面 + helper skeleton）：
+- OR1-OR2 written first（profile resolution tests）
+- `agentpkg.ProbeProfileProvider` + `ProbeProfile` 加入 `internal/agent/provider.go`
+- `internal/module/agent/probe_orchestrator.go` skeleton（newProbeOrchestrator + startWatch + stopWatch；interpretScreenEvent 暫不接 graceWindow）
+- 接管 module.go 的 `manageActivityWatch` 路徑
+
+### Commit 4 — `feat(probe): graceWindow + screen event interpretation`
+
+Slice 3 後半 + Slice 7 主體：
+- OR3-OR5 + OB1-OB4 written first
+- orchestrator.interpretScreenEvent 完整邏輯（graceWindow + ScreenStable shellPrompt 分支 + Error Guard + projection + broadcast）
+- `internal/agent/metrics.go` 4 個新 expvar
+- `isDevMode()` helper + `[probe]` log 點
+- `recordHookAt` integration into module.go hook path
+
+### Commit 5 — `feat(agent/cc): adopt new probe primitive via profile`
+
+Slice 4：
+- CC1-CC5 written first
+- `internal/agent/cc/probe_profile.go`（cc 實作 ProbeProfileProvider）
+- module.go 確認 cc path 走 orchestrator + recordHookAt 在 cc hook handler call 到
+
+### Final Verification
+
+- `go test ./... -count=1` 全綠
+- `pnpm --prefix spa run lint` / `build`（雖然本 PR 無 SPA 改動，跑一次防回歸）
+- expvar 手動驗：`curl http://localhost:7860/debug/vars | jq '. | with_entries(select(.key | startswith("purdex_probe_")))'` 看到 4 個 counter
+
+---
+
+## 5. 不做（boundary）
+
+本 PR 不修改：
+
+- `internal/agent/codex/**`（PR-4a-2 Slice 5）
+- `internal/agent/opencode/**`（PR-4a-2 Slice 6）
+- `internal/agent/cc/hooks.go` / `hooks_test.go`（不在 probe 範疇）
+- `spa/**`（無 SPA 改動）
+- `internal/module/dev/**`（PDX_DEV_MODE 已存在；本 PR 只 reuse env var，不改 module）
+- `internal/agent/probe/liveness.go` / `readiness.go` / `liveness_test.go` / `readiness_test.go`（本 PR 不動 liveness / readiness 層）
+- `internal/agent/probe/shell_prompt.go` 演算法（純 export visibility）
+
+**Allowed 路徑**（boundary script 用）：
+
+```
+docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+internal/tmux/executor.go
+internal/tmux/executor_test.go
+internal/tmux/fake_executor.go (or equivalent test stub file)
+internal/agent/probe/activity.go
+internal/agent/probe/activity_test.go
+internal/agent/probe/probe.go
+internal/agent/probe/probe_test.go (if exists)
+internal/agent/probe/shell_prompt.go (export only)
+internal/agent/provider.go
+internal/agent/cc/probe_profile.go (new)
+internal/agent/cc/provider.go (if test seam needed)
+internal/agent/metrics.go
+internal/module/agent/probe_orchestrator.go (new)
+internal/module/agent/probe_orchestrator_test.go (new)
+internal/module/agent/module.go (manageActivityWatch / onActivityDetected refactor)
+internal/module/agent/module_test.go
+internal/module/agent/handler.go (recordHookAt wiring)
+internal/module/agent/handler_test.go
+scripts/check-pr-4a-1-boundary.sh (new)
+```
+
+`scripts/check-pr-4a-1-boundary.sh` 沿用 PR-4a-0 三-dot diff 模板，only 換 ALLOWED 清單。
+
+---
+
+## 6. Ship gate
+
+| Gate | 條件 |
+|------|------|
+| G1 unit | `go test ./... -count=1` 全綠 |
+| G2 boundary | `scripts/check-pr-4a-1-boundary.sh origin/main` 退出碼 0 |
+| G3 expvar | 啟動 daemon 跑一次任意 cc session，`/debug/vars` 看到 4 個 `purdex_probe_*` counter（手動驗 — 文件化於 PR description）|
+| G4 dev log | `PDX_DEV_MODE=1` 啟動跑一次 graceWindow hit，stderr 看到 `[probe]` log；unset 時無 log（手動驗 — 文件化於 PR description）|
+| G5 default profile parity | 不實作 ProbeProfileProvider 的 agent（codex / opencode）行為與 PR-4a-1 前等價（透過 `TestOrchestrator_DefaultProfileWhenAgentMissing` + cc / codex / opencode 三家既有 module integration tests 通過驗證）|
+| G6 watcher 不洩漏 | `TestModule_StopWatch_ClearsActiveWatchers` 驗證 manageActivityWatch(off) 後 HasWatcher false（regression — 既有測試應已涵蓋；本 PR 確認無回歸）|
+
+---
+
+## 7. Risk
+
+| Risk | Mitigation |
+|------|------------|
+| `manageActivityWatch` 重構引入 race（StopWatch 與 callback fire 競態）| watch-loop-owned 設計（kickoff Decision 13）+ orchestrator stopWatch 顯式 cancel；callback 在 ctx done 後不再 fire；OR3 + 既有 module concurrent test 覆蓋 |
+| graceWindow 太短 / 太長 — hook 與 probe 互相覆蓋或漏報 | 沿用 spec §2.4 cited 2s；orchestrator API 內部寫死，PR-4a-1 後依 PDX_DEV_MODE log 觀察決定是否做成 const-overridable；本 PR 不暴露為 config |
+| cc TopLines = 12 不適配（cc UI layout 變動）| Slice 4 文件 expects implementer 跑一次 cc 互動測試確認 captured Top-N 含 ●● header；不適配時 plan 草稿允許 implementer 修改值並在 commit message 紀錄理由 |
+| 既有 `purdex_phase35_*` 與新 `purdex_probe_*` 並存看似冗餘 | kickoff Decision 7 已決議「新增不 rename」；保留歷史連續性；docs/specs 中文件化兩組 metric 用途差異即可 |
+| `LooksLikeShellPrompt` export 後外部誤用 | 寫 godoc 註明「intended for module/agent layer; do not use from non-probe-aware code」；無 enforcement，依 review |
+| `manageActivityWatch` 改動觸動三家 module integration tests | 沿用 default profile 確保 codex / opencode 行為向下相容；本 PR 不切換它們的 agent profile，留 PR-4a-2 |
+| 主 repo 並發 session（feedback_concurrent_session_safety）| 進 worktree 前 `git status -s` 必 clean；`git fetch origin main && git reset --hard origin/main`；輸出貼入 PR description 留痕（沿用 PR-4a-0 H6.5 慣例）|
+| Codex sandbox 無網路（feedback_codex_sandbox_no_install）| 主 Claude 必須手動跑 go test + lint + build；codex review 不取代驗證 |
+
+---
+
+## 8. LOC 預估
+
+| Slice | 估 LoC | 估 tests |
+|-------|--------|----------|
+| 0 tmux API | ~40 | 4 |
+| 1 probe primitive | ~80 | 6 |
+| 2 shell prompt export | ~5 | 0 |
+| 3 module orchestrator | ~80 | 5 |
+| 4 cc adoption | ~40 | 5 |
+| 7 graceWindow + dev log + expvar | ~30 | 4 |
+| (extra) boundary script | ~30 | 0 |
+
+**總計**：~305 LoC + 24 tests（plan v1.3 §7.1 estimate ~250 略高 — 主因新 ScreenChangeEvent type + ProbeProfileProvider interface + boundary script，仍在 PR 合理 size 內）。
+
+**屬中型 PR**。`go test` 預期 elapsed < 30s 內。
+
+---
+
+## 9. 結束條件（PR-4a-1）
+
+**Ship**：
+
+- §6 ship gate G1-G6 全通過
+- PR merged
+- 對應 main bump PR ship（VERSION 進到 alpha.234 或 235，視 bump 排程）
+- `kickoff_lights_rebuild.md` 更新觸發詞為 `啟動 PR-4a-2`
+- `project_progress.md` 補 alpha.X PR-4a-1 milestone
+
+**手動驗收**：
+- 啟動 daemon `PDX_DEV_MODE=1 ./bin/pdx`，跑一次 cc session 互動，stderr 觀察 `[probe]` log 至少出現 startWatch / screenChanged / screenStable 三類 line
+- `/debug/vars` 包含 4 個 `purdex_probe_*` counter
+
+---
+
+## 10. 文獻
+
+- `docs/specs/2026-04-23-lights-rebuild-spec.md`
+- `docs/specs/2026-04-26-lights-rebuild-phase-4a-plan.md` v1.3 §7
+- `docs/specs/2026-04-26-opencode-1.14.23-hook-audit.md` §6（Slice 6 Go verdict）
+- kickoff_lights_rebuild Decision 1/2/4/6/7/8/13
+- PR-4a-0（[#664](https://github.com/wake/purdex/pull/664)）為設計典範對照

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v2.0 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v2.1 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v2.0（**架構 pivot** — 移除 probe-layer dedup state machine；改採 orchestrator-only transition dedup。依 codex consulting `task-moh5xafl-gx2zt1` 結論執行）
+**Status**: draft v2.1（v2.0 pivot 後 R15 review fix — 2 P2 採納）
 
 ## v1.x 演進
 
@@ -22,6 +22,7 @@
 | v1.13 | R13 codex review fix（1 P1 + 1 P2）：(1) **P1** — v1.12 watchLoop pseudo 是 `cb() → changedEmitted=true`，但 cb 同步呼叫 `RearmChanged` 會 `Store(false)`，下一行又覆蓋成 `true` → R12 fix 失效。修為「先 set flag，再 call cb」順序（symmetric 對 stableEmitted 也修）；明列 watch loop **必須** 用 set-before-cb 順序，禁止 set-after-cb 實作；(2) **P2** — PR3 `TestWatch_DoesNotExitOnCallback` v1 期待「一次 ScreenChanged 後再注入 diff 再 fire ScreenChanged」與 R11 changedEmitted 行為矛盾（同一 changing run 不再 fire）。改寫為 PR3 `TestWatch_LoopContinuesAcrossTransitions`：驗證 changed → stable → changed 完整 cycle，watcher 不退出；single-cycle continuous diff 由 PR1b 覆蓋 |
 | v1.14 | R14 codex review fix（2 P2 substantive）：(1) **shell prompt capture region mismatch** — cc 用 `TopLines: 12` 時 `ev.Content` 只含頂部 12 行；ScreenStable shellprompt 分支 `LooksLikeShellPrompt(ev.Content)` 會 miss 底部 shell prompt → dead-PID + shellprompt 場景的 sweepOnce cleanup 不會跑 → 與 legacy bottom-line capture 行為不對齊。修法：orchestrator interpretScreenEvent ScreenStable 分支獨立做一次 `tmux.CapturePaneContent(target, 10)` 取底部 10 行作 shellprompt 分類（不依賴 ev.Content）；新增 OR8 regression 涵蓋 cc TopLines + bottom shell prompt + dead PID 場景；(2) **nil-prober guard 漏列** — orchestrator startWatch/stopWatch pseudocode 直接呼 `o.parent.prober.Watch`，但 plan 宣告 orchestrator 內部會做 prober nil-check（保留 legacy `if m.prober != nil` 行為）。補入 explicit nil guard 兩處 + 文件化 module 測試與部分初始化 path 的兼容契約 |
 | **v2.0** | **架構 pivot**（依 codex consulting `task-moh5xafl-gx2zt1` 投票結論）：v1.11-v1.13 的 changedEmitted / stableEmitted / Rearm API state machine 被連續 3 輪抓 corner case bug（R11 引入 → R12 graceWindow lifecycle → R13 cb-vs-set ordering），符合 `feedback_codex_meta_drift_signal.md` 「同類 meta-drift 連續 3 輪 = architectural smell，停手換架構」。執行 codex parallel consulting（A 假設前提為真求最佳實作；B 質疑前提）— **B 否決前提**：probe primitive 不該擁有 dedup state，dedup 應由 orchestrator 用 `currentStatus` 判 transition 處理。**移除**：`changedEmitted` / `stableEmitted` flags、`RearmChanged` / `RearmStable` public API、set-before-cb ordering rule、PR1b（changed-emit-once）/ PR2b（stable-emit-once）/ PR4c（Rearm regression）/ OR3b（graceWindow re-arm）四個 regression tests（在 Option 2 不再 applicable）。**簡化**：probe 變 dumb — diff 每 tick fire ScreenChanged；stableCount 達 threshold 後 fire ScreenStable + reset stableCount（每 N ticks fire 一次，無 emit-once flag）；orchestrator 用 `currentStatus[session]` 做 transition gate，only broadcast / metric / dev log on accepted transitions。**保留**：R3 deadlock fix / R4 stale-callback guard / R9-R10 BottomLines / R14 shellprompt bottom capture / R14 nil-prober guard（這些在 Option 2 仍 applicable）。**新增**：OR4（替換原 OR3b — graceWindow expire 後 continuous-changing 仍能 → Running，新版本不需 Rearm 即達成）+ OR9 / OR10 transition-dedup tests。Plan size: ~340 LoC + 32 tests（從 390 / 34 縮小）|
+| v2.1 | R15 review fix（2 P2）：(1) §1.2 寫「codex / opencode 接新 primitive 留 PR-4a-2」與 §1.1 Slice 3 + §2.4.2 寫「三家共用 default profile + 同一 helper」矛盾。釐清：本 PR **必含** codex / opencode 走 default profile 的 wiring（compile 必要 — `ActivitySignal` 移除後 codex / opencode hook handler 也要走 orchestrator）；PR-4a-2 範圍縮為「codex / opencode 各自實作 ProbeProfileProvider 自訂 profile」。(2) §6 G6 watcher 不洩漏 gate 引用 `TestModule_StopWatch_ClearsActiveWatchers` 但此 test 名稱在 codebase / 計畫測試清單都不存在；新增 CC2b 補位（測 manageActivityWatch off → HasWatcher false），G6 改引 CC2b |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -94,7 +95,8 @@ PR-4a-1 把目前 `internal/agent/probe/activity.go` 的 watcher 從「probe 解
 
 ### 1.2 Out of scope（明列分流）
 
-- **Slice 5（codex 接新 primitive）/ Slice 6（opencode 接新 primitive）** — 留 PR-4a-2
+- **Slice 5（codex 自訂 ProbeProfileProvider）/ Slice 6（opencode 自訂 ProbeProfileProvider）** — 留 PR-4a-2
+- **本 PR 的 codex / opencode wiring**（**R15 fix — 釐清**）：本 PR **必含** codex / opencode 走 default profile 的 hook handler / orchestrator wiring（因為 `ActivitySignal` enum 與 legacy `StartWatch` API 在本 PR 移除，codex / opencode 不一起遷會 compile 失敗）；只有「自訂 profile values（agent-specific TopLines / BottomLines / IdleStableTicks tuning）」延到 PR-4a-2。本 PR 三家走同一 default profile = 行為向下相容（per §6 G5 parity gate）
 - **`shouldWatchActivity` per-agent refactor**（視需要）— 本 PR 保留 `shouldWatchActivity` 函式（wrapper 仍呼叫）；若 PR-4a-2 codex / opencode profile 化過程中發現該函式應 per-agent，再 refactor，本 PR 不動
 - **Phase 4b `ProbeIntentProvider`** — 整合 readiness 的 declarative intent 系統，留 Phase 4b
 - **Phase 5 Dev Inspector SPA UI** — `/api/agent/monitor/*` 視覺化，留 Phase 5
@@ -621,12 +623,13 @@ if agentType, ok := m.activeWatchers[oldName]; ok {
 
 `internal/module/agent/handler.go` 的 hook entry path（具體位置實作時定）：每個有效 hook 處理完前 call `m.probeOrch.recordHookAt(session)`，讓接下來 graceWindow 啟動。
 
-#### 2.4.4 測試（6 tests — R2 +CC6）
+#### 2.4.4 測試（7 tests — R2 +CC6 / R15 +CC2b）
 
 | Test | 重點 |
 |------|------|
 | CC1 `TestCCProvider_ProbeProfile` | cc.Provider.ProbeProfile() 回 {12, 3}（characterization；implementer 改值需 review）|
 | CC2 `TestModule_ManageActivityWatch_RoutesThroughOrchestrator` | mock orch；waiting → start watch called；off → stop watch called |
+| CC2b `TestModule_ManageActivityWatch_OffClearsActiveWatchers`（**R15 fix #2 — G6 watcher-leak gate**）| 真 prober + module 整合：waiting → manageActivityWatch 啟 watcher、`activeWatchers[session]` 含 entry；status off → manageActivityWatch 停 watcher、`activeWatchers[session]` 不含 entry、`HasWatcher(session+":")` false |
 | CC3 `TestModule_HookHandler_CallsRecordHookAt` | 注入 cc hook event；驗證 orchestrator.lastHookAt[session] 記錄到 |
 | CC4 `TestCC_E2E_ScreenChangedToRunning` | cc waiting → orchestrator.startWatch → 注入 ScreenChanged → status 廣播 Running |
 | CC5 `TestCC_E2E_ScreenStableToIdle` | cc running → orchestrator.startWatch → 注入 ScreenStable（non-shell-prompt）→ status 廣播 Idle |
@@ -678,10 +681,10 @@ log 點（gated）：
 | 1 | PR1-PR2 + PR3-PR4b + PR5-PR5b + PR6 | 8 | watcher 自治 / per-tick raw events（v2.0）/ baseline-fail map cleanup（R2 fix）/ BottomLines vs TopLines mutually exclusive（R9 fix）/ Top-N region / err tick skip / cycle 不退出 |
 | 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
 | 3 | OR1-OR10 | 10 | profile / graceWindow + 自然 recovery（v2.0）/ Error Guard / stale-callback guard（R4 fix）/ nil-prober no-op（R14 fix #2）/ shellprompt bottom-capture（R14 fix #1）/ **transition dedup × 2（v2.0 OR9 / OR10）**|
-| 4 | CC1-CC6 | 6 | cc profile + module wiring + E2E + rename rewatch via orchestrator（R2 fix #1）|
+| 4 | CC1-CC2b + CC3-CC6 | 7 | cc profile + module wiring + E2E + rename rewatch via orchestrator（R2 fix #1）+ **watcher-leak gate（R15 fix #2 — CC2b）**|
 | 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
 
-**總計**：32 tests（v2.0 — 從 v1.14 的 34 縮回：移除 PR1b / PR2b / PR4c / OR3b 共 4 個 R11/R12/R13 regression（-4）；新增 OR9 / OR10 transition-dedup tests（+2）；保留 PR4b R2 / PR5b R9 / OR6 R4 / OR7 / OR8 R14 / CC6 R2 共 6 個 regression）。
+**總計**：33 tests（v2.1 — 從 v1.14 的 34 縮回：v2.0 移除 PR1b / PR2b / PR4c / OR3b 共 4 個 R11/R12/R13 regression（-4）；v2.0 新增 OR9 / OR10 transition-dedup tests（+2）；v2.1 新增 CC2b watcher-leak gate（+1）；保留 PR4b R2 / PR5b R9 / OR6 R4 / OR7 / OR8 R14 / CC6 R2 共 6 個 regression）。
 
 ---
 
@@ -728,10 +731,11 @@ Slice 3 後半 + Slice 7 主體（v2.0 — transition gate, no Rearm）：
 ### Commit 5 — `feat(agent/cc): adopt new probe primitive via profile`
 
 Slice 4：
-- **CC1-CC6 written first**（R6 fix — 補入 CC6 rename rewatch / R3 deadlock-freedom regression；CC6 是 R2 fix #1 + R3 fix 的核心 regression test，必納入 written-first 清單）
+- **CC1-CC2b + CC3-CC6 written first**（R6 fix CC6 rename rewatch / R3 deadlock-freedom regression + R15 fix CC2b watcher-leak gate；CC6 / CC2b 是核心 regression tests，必納入 written-first 清單）
 - `internal/agent/cc/probe_profile.go`（cc 實作 ProbeProfileProvider）
 - module.go 確認 cc path 走 orchestrator + recordHookAt 在 cc hook handler call 到
 - module.go `renameSessionLocked` 改走 orchestrator stop+start（R2 fix #1）；`renameSessionLocked` 持 `m.mu` 不會 deadlock（R3 fix）
+- codex / opencode hook handler 也改走 orchestrator（compile 必要 — `ActivitySignal` 移除後三家共用 default profile，行為向下相容；自訂 profile 留 PR-4a-2）
 
 ### Final Verification
 
@@ -791,7 +795,7 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | G3 expvar | 啟動 daemon 跑一次任意 cc session，`/debug/vars` 看到 4 個 `purdex_probe_*` counter（手動驗 — 文件化於 PR description）|
 | G4 dev log | `PDX_DEV_MODE=1` 啟動跑一次 graceWindow hit，stderr 看到 `[probe]` log；unset 時無 log（手動驗 — 文件化於 PR description）|
 | G5 default profile parity | 不實作 ProbeProfileProvider 的 agent（codex / opencode）行為與 PR-4a-1 前等價（透過 `TestOrchestrator_DefaultProfileWhenAgentMissing` + cc / codex / opencode 三家既有 module integration tests 通過驗證）|
-| G6 watcher 不洩漏 | `TestModule_StopWatch_ClearsActiveWatchers` 驗證 manageActivityWatch(off) 後 HasWatcher false（regression — 既有測試應已涵蓋；本 PR 確認無回歸）|
+| G6 watcher 不洩漏 | `CC2b TestModule_ManageActivityWatch_OffClearsActiveWatchers`（R15 fix — 真 prober + module 整合驗證 manageActivityWatch(off) 後 `activeWatchers` 清空 + `HasWatcher(session+":")` false）|
 
 ---
 
@@ -818,11 +822,11 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | 1 probe primitive | ~70 | 8（v2.0 dumb probe — 無 emit-once flags / 無 Rearm API）|
 | 2 shell prompt export | ~5 | 0 |
 | 3 module orchestrator | ~115 | 10（R4 +OR6 / R14 +OR7 +OR8 / v2.0 +OR9 +OR10 transition dedup）|
-| 4 cc adoption | ~50 | 6（R2 +CC6 rename）|
+| 4 cc adoption | ~55 | 7（R2 +CC6 rename / R15 +CC2b watcher-leak gate）|
 | 7 graceWindow + dev log + expvar | ~30 | 4 |
 | (extra) boundary script | ~30 | 0 |
 
-**總計**：~340 LoC + 32 tests（v2.0 pivot 後 — 從 v1.14 的 ~390/34 縮回 ~340/32。Slice 1 LoC 大幅縮（沒 emit-once flags / Rearm API / set-before-cb 結構約束）；Slice 3 略增（多 transition gate logic + 2 個新 test）。仍在 PR 合理 size 內，且 review 複雜度顯著下降）。
+**總計**：~345 LoC + 33 tests（v2.1 — 從 v1.14 的 ~390/34 縮回 ~345/33。Slice 1 LoC 大幅縮（沒 emit-once flags / Rearm API / set-before-cb 結構約束）；Slice 3 略增（多 transition gate logic + 2 個新 test）；Slice 4 略增（CC2b watcher-leak gate）。仍在 PR 合理 size 內，且 review 複雜度顯著下降）。
 
 **屬中型 PR**。`go test` 預期 elapsed < 30s 內。
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.11 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.12 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.11（Round 11 codex review fix — 1 P2 substantive + 1 P2 editorial 採納）
+**Status**: draft v1.12（Round 12 codex review fix — 1 P1 substantive 採納）
 
 ## v1.x 演進
 
@@ -18,6 +18,7 @@
 | v1.9 | R9 codex review fix（1 P2 substantive — **regression risk**）：legacy `CapturePaneContent(target, 10)` 是 **last 10 lines**（`tmux capture-pane -S -10`，hash bottom 10 行），但 v1.8 default profile `{TopLines: 10}` 配 `CapturePaneTopLines` 會 hash **top 10 lines**。codex/opencode 沒有 ProbeProfileProvider 走 default → 行為被默默改掉，違反 §6 G5 default profile parity gate（明訂「不實作 ProbeProfileProvider 的 agent 行為與 PR-4a-1 前等價」）。修法：擴 `WatchOptions` 加 `BottomLines int` field（與 `TopLines` 互斥）；default profile 改用 `{BottomLines: 10}` 保留 legacy capture 語意；新增 PR5b 測試覆蓋 BottomLines vs TopLines 行為差異 |
 | v1.10 | R10 codex review fix（2 P2 — R9-propagation gaps）：(1) §2.1.3 watchLoop pseudo-code 啟動描述只 branch `opts.TopLines`，沒處理新加的 `opts.BottomLines`；implementer 照寫，default profile `{BottomLines: 10}` 會 fallback 到 full pane capture，破壞 G5 parity；補成三分支（TopLines / BottomLines / 全零=full pane）；(2) §2.3.3 殘留 v1.8 stale 宣告 `var defaultProbeProfile = ProbeProfile{TopLines: 10, IdleStableTicks: 3}`，與下一段 R9 fix 的 `{BottomLines: 10}` 互斥同存；移除 stale 宣告 |
 | v1.11 | R11 codex review fix（1 P2 substantive + 1 P2 editorial）：(1) **substantive** — 新 watch-loop-owned watcher 對 spinner / elapsed-timer 每 tick fire ScreenChanged；orchestrator 每 500ms 重廣播 Running，違反 G5 parity（legacy fires once 後退出）。對稱於 R1 fix #2 的 `stableEmitted`，加 `changedEmitted` flag — 每次 stable→changed transition fire ScreenChanged 一次，下次 ScreenStable fire 後重新 arm；新增 PR1b 測試覆蓋連續 changed 無重發；(2) **editorial** — OR2 default profile fallback 期待還寫 `{TopLines: 10, IdleStableTicks: 3}`，與 R9/R10 default `{BottomLines: 10}` 矛盾；修為 `{BottomLines: 10, IdleStableTicks: 3}` |
+| v1.12 | R12 codex review fix（1 P1 substantive — graceWindow / changedEmitted 互動 bug）：場景：hook 觸發 → orchestrator.recordHookAt → graceWindow 2s 內 watcher fire ScreenChanged → probe 已 set `changedEmitted=true` 但 orchestrator suppress 廣播；若 pane 之後持續 changing（spinner / elapsed timer），watch loop 不會見到 ScreenStable transition → `changedEmitted` 永不 reset → 後續 ScreenChanged 不再 fire → 狀態永遠停在 hook-derived。修法：probe 加 `RearmChanged(target string)` + `RearmStable(target string)` 公開 API（symmetric 對稱），orchestrator 在 graceWindow suppress 時呼叫 `RearmChanged` 讓 probe 下次 diff 重新 emit；新增 PR4c + OR3b regression test |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -273,6 +274,33 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 - **R11 fix rationale**：對稱於 R1 fix #2 — spinner / elapsed-timer 場景每 tick hash diff，若不加 `changedEmitted` flag，新 watch-loop-owned 會每 500ms fire ScreenChanged → orchestrator 重廣播 StatusRunning → 同樣 ws/metrics 風暴；違反 G5 default-profile parity（legacy fire once 後退出，behavior 上 Running 只廣播一次）。雙 flag 形成「changed↔stable 兩 transition，各 arm/disarm 對方」狀態機，每個 transition 各自只 fire 一次
 - **R2 fix #2 rationale**：legacy `activityLoop` 用 `defer` 統一在 goroutine 退出時清 watcher map entry，所以 baseline 失敗的 early-return 也涵蓋；新 ownership 文字寫成「cleanup only happens on ctx cancel」會漏掉 baseline-failure path → watcher map 殘留死 entry → `HasWatcher(target) == true` 但實際上 goroutine 已退 → 後續 `Watch(target, ...)` 會把同一個 entry 的 cancel 替換掉但既有 goroutine 已死 → 行為不可預測。修法：在 baseline 失敗 early-return 前同步清自己的 entry（only-if-still-mine 用 `id` 比對，避免清到後續 watch 的）
 
+#### 2.1.3a Rearm API（R12 fix）
+
+```go
+// RearmChanged resets the watcher's changedEmitted flag so the next
+// hash diff (re)emits ScreenChanged. Used by the orchestrator when
+// a graceWindow-suppressed event would otherwise leave the watcher
+// in changedEmitted=true state with no foreseeable ScreenStable to
+// release it (continuous-changing pane scenarios — spinner / elapsed
+// timer). Idempotent; no-op if no watcher entry exists for target.
+func (p *Prober) RearmChanged(target string) {...}
+
+// RearmStable is the symmetric variant for stableEmitted. Currently
+// has no production caller — included for API symmetry and to support
+// future orchestrator policies that might suppress ScreenStable too.
+func (p *Prober) RearmStable(target string) {...}
+```
+
+實作：watcher entry 加 `rearmChanged chan struct{}` / `rearmStable chan struct{}`（buffered=1）；watch loop select 多增一個 case：
+```
+select ctx.Done -> return
+select tick -> ...(現有邏輯)
+select <-rearmChanged: changedEmitted = false; continue
+select <-rearmStable:  stableEmitted = false; continue
+```
+
+或更簡單：用 `atomic.Bool` 取代 `bool`；Rearm 直接 `Store(false)`。實作時 implementer 選最簡途徑（test-only 概念差異不大）。
+
 #### 2.1.4 Watcher ownership 變更
 
 - **Legacy**：`activityLoop` defer 內 `delete(p.watchers, target)`；callback fire 一次後 goroutine 自動退出 + 清自己
@@ -286,7 +314,7 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 - `activityLoop` 內部 method — 改成 `watchLoop`
 - `hashCapture` 內部 method — 改成支援 captureFn closure 的版本
 
-#### 2.1.6 測試（10 tests — R1 +PR2b / R2 +PR4b / R9 +PR5b / R11 +PR1b）
+#### 2.1.6 測試（11 tests — R1 +PR2b / R2 +PR4b / R9 +PR5b / R11 +PR1b / R12 +PR4c）
 
 | Test | 重點 |
 |------|------|
@@ -297,6 +325,7 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 | PR3 `TestWatch_DoesNotExitOnCallback` | 一次 ScreenChanged callback 後再注入 diff，驗證再發 ScreenChanged（loop 持續）|
 | PR4 `TestWatch_StopWatch_CancelsLoop` | StopWatch 後 capture mock 不再被 call、HasWatcher false |
 | PR4b `TestWatch_BaselineFailure_CleansMapEntry`（**R2 fix #2 regression**）| capture mock 對 first call 回 err；驗證 `Watch` 啟動後 200ms 內 `HasWatcher(target) == false`（goroutine 自己清 entry）|
+| PR4c `TestWatch_RearmChanged_AllowsReEmission`（**R12 fix regression**）| 注入 1 次 diff → ScreenChanged fire；不等 ScreenStable，直接 call `RearmChanged(target)`；再注入 1 次 diff → ScreenChanged 再 fire；symmetric for RearmStable |
 | PR5 `TestWatch_TopLinesIgnoresBottomChanges` | 注入 only-bottom-line-changed scenario，opts.TopLines=3 不報 changed；opts={}（full pane）報 changed |
 | PR5b `TestWatch_BottomLinesIgnoresTopChanges`（**R9 fix regression**）| 注入 only-top-line-changed scenario，opts.BottomLines=3 不報 changed；opts.TopLines=3 報 changed；驗證 BottomLines vs TopLines 走不同 capture path 且互斥 |
 | PR6 `TestWatch_TmuxErrorTickSkipped` | capture err 在 tick 中發生 → 不 fire ScreenChanged，下一 tick 復原 → 報 ScreenChanged |
@@ -450,7 +479,7 @@ if !active || currentAgent != agentType {
 }
 ```
 
-**Guard 2 — graceWindow 解讀**：
+**Guard 2 — graceWindow 解讀（含 R12 fix — 重新 arm probe）**：
 
 ```go
 o.graceMu.Lock()
@@ -460,6 +489,19 @@ if hasHook && time.Since(last) < probeGraceWindow {
     metrics.MetricProbeGraceWindowSuppressed.Add(1)
     if isDevMode() {
         log.Printf("[probe] graceWindow suppress session=%s agent=%s kind=%s", session, agentType, ev.Kind)
+    }
+    // R12 fix: re-arm probe so a future change can re-emit even if
+    // the pane keeps changing without a stable interval. Without this,
+    // a graceWindow-suppressed first ScreenChanged would leave probe's
+    // changedEmitted=true; continuous-changing panes (spinner, elapsed
+    // timer) would never see another stable→changed transition and
+    // status would stay frozen at the hook-derived value.
+    target := session + ":"
+    switch ev.Kind {
+    case probe.ScreenChanged:
+        o.parent.prober.RearmChanged(target)
+    case probe.ScreenStable:
+        o.parent.prober.RearmStable(target)
     }
     return
 }
@@ -487,13 +529,14 @@ case probe.ScreenStable:
 
 接著套用 Error Guard + projection update + broadcast（與既有 `onActivityDetected` 同邏輯，整段搬入 helper）。
 
-#### 2.3.6 測試（6 tests — R4 +1 OR6）
+#### 2.3.6 測試（7 tests — R4 +OR6 / R12 +OR3b）
 
 | Test | 重點 |
 |------|------|
 | OR1 `TestOrchestrator_StartWatchUsesAgentProfile` | mock cc agent 回 `{TopLines: 5, IdleStableTicks: 2}`；驗證 prober 收到 lines=5 / stable=2 |
 | OR2 `TestOrchestrator_DefaultProfileWhenAgentMissing` | mock agent 不實作 ProbeProfileProvider；驗證 fallback 到 `{BottomLines: 10, IdleStableTicks: 3}`（R11 fix — 對齊 R9/R10 default profile 改為 BottomLines）|
 | OR3 `TestOrchestrator_GraceWindowSuppressesEventWithinWindow` | recordHookAt → 1s 後注入 ScreenChanged；驗證無狀態變化、metrics counter +1 |
+| OR3b `TestOrchestrator_GraceWindowSuppressionReArmsProbe`（**R12 fix regression**）| recordHookAt → 1s 內注入 ScreenChanged → orchestrator suppress + 呼叫 prober.RearmChanged；驗證 prober watcher entry 的 changedEmitted 已被 reset；接著（仍在 graceWindow 內或剛 expire 後）再注入 diff → ScreenChanged 再 fire；驗證沒有 stuck status |
 | OR4 `TestOrchestrator_GraceWindowExpiresAfterWindow` | recordHookAt → 3s 後注入 ScreenChanged；驗證 StatusRunning 廣播 |
 | OR5 `TestOrchestrator_ErrorGuardBlocksProbeOverwrite` | currentStatus=StatusError；ScreenStable 注入；驗證 StatusError 維持、無 broadcast |
 | OR6 `TestOrchestrator_StaleCallbackGuard`（**R4 fix regression**）| 兩 sub-case：(a) stopWatch 後注入 ScreenChanged → 無 broadcast、無 metrics；(b) renameSession 前 watch oldName，rename 後注入 oldName 的 ScreenChanged callback → 無 broadcast、無 status 更新（驗證 currentAgent != agentType 比對）|
@@ -623,13 +666,13 @@ log 點（gated）：
 | Slice | Test ID 區段 | 數量 | 涵蓋 |
 |-------|--------------|------|------|
 | 0 | TT1-TT4 | 4 | tmux range API + fake executor parity |
-| 1 | PR1-PR1b + PR2-PR2b + PR3-PR4b + PR5-PR5b + PR6 | 10 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ baseline-fail map cleanup（R2 fix #2）/ BottomLines vs TopLines mutually exclusive（R9 fix）/ **changed-emit-once（R11 fix）**|
+| 1 | PR1-PR1b + PR2-PR2b + PR3-PR4c + PR5-PR5b + PR6 | 11 | watcher 自治 / Top-N vs full screen / 多次 fire / err tick skip / stable-emit-once（R1 fix #2）/ baseline-fail map cleanup（R2 fix #2）/ BottomLines vs TopLines mutually exclusive（R9 fix）/ changed-emit-once（R11 fix）/ **Rearm API（R12 fix）**|
 | 2 | (沿用既有) | 0 | shell prompt utility（純 visibility）|
-| 3 | OR1-OR6 | 6 | profile / graceWindow / Error Guard / **stale-callback guard（R4 fix）**|
+| 3 | OR1-OR6 + OR3b | 7 | profile / graceWindow / Error Guard / stale-callback guard（R4 fix）/ **graceWindow re-arm probe（R12 fix）**|
 | 4 | CC1-CC6 | 6 | cc profile + module wiring + E2E + rename rewatch via orchestrator（R2 fix #1）|
 | 7 | OB1-OB4 | 4 | expvar + PDX_DEV_MODE log |
 
-**總計**：30 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 / +1 PR5b R9 / +1 PR1b R11 regression tests）。
+**總計**：32 tests（plan v1.3 §7.1 estimate 24 → +1 PR2b R1 / +1 PR4b R2 / +1 CC6 R2 / +1 OR6 R4 / +1 PR5b R9 / +1 PR1b R11 / +1 PR4c R12 / +1 OR3b R12 regression tests）。
 
 ---
 
@@ -762,14 +805,14 @@ scripts/check-pr-4a-1-boundary.sh (new)
 | Slice | 估 LoC | 估 tests |
 |-------|--------|----------|
 | 0 tmux API | ~40 | 4 |
-| 1 probe primitive | ~100 | 10（R1 +PR2b / R2 +PR4b / R9 +PR5b / R11 +PR1b）|
+| 1 probe primitive | ~115 | 11（R1 +PR2b / R2 +PR4b / R9 +PR5b / R11 +PR1b / R12 +PR4c）|
 | 2 shell prompt export | ~5 | 0 |
-| 3 module orchestrator | ~85 | 6（R4 +OR6）|
+| 3 module orchestrator | ~95 | 7（R4 +OR6 / R12 +OR3b）|
 | 4 cc adoption | ~50 | 6（R2 +CC6 rename）|
 | 7 graceWindow + dev log + expvar | ~30 | 4 |
 | (extra) boundary script | ~30 | 0 |
 
-**總計**：~345 LoC + 30 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1 / R9 +1 / R11 +1，總 +6 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard + R9 BottomLines field + capture-mode dispatcher + R11 changedEmitted flag ~30 LoC，仍在 PR 合理 size 內）。
+**總計**：~370 LoC + 32 tests（plan v1.3 §7.1 estimate 24 → R1 +1 / R2 +2 / R4 +1 / R9 +1 / R11 +1 / R12 +2，總 +8 regression tests + R2 baseline-fail cleanup + rename callsite migration + R4 stale-callback guard + R9 BottomLines field + capture-mode dispatcher + R11 changedEmitted flag + R12 Rearm API ~50 LoC，仍在 PR 合理 size 內）。
 
 **屬中型 PR**。`go test` 預期 elapsed < 30s 內。
 

--- a/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
+++ b/docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md
@@ -1,6 +1,6 @@
-# Lights Rebuild — Phase 4a-1 Plan v1.9 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
+# Lights Rebuild — Phase 4a-1 Plan v1.10 (PR-4a-1 Probe Primitive + cc + Helper + Dev Log)
 
-**Status**: draft v1.9（Round 9 codex review fix — 1 P2 substantive 採納）
+**Status**: draft v1.10（Round 10 codex review fix — 2 P2 R9-propagation gaps 採納）
 
 ## v1.x 演進
 
@@ -16,6 +16,7 @@
 | v1.7 | R7 codex review fix（1 P2 + 1 P3）：(1) §2.3.3 startWatch pseudo-code 用未定義 `target`，既有 callsite 都是 `session + ":"` 形式；明寫 `target := session + ":"` 在 startWatch / stopWatch contract，避免 implementer 編譯失敗或 bare-session 啟 watcher；(2) §2.4.4 標題寫「測試（5 tests）」但表格列 CC1-CC6 共 6 個；改為「測試（6 tests — R2 +CC6）」 |
 | v1.8 | R8 codex review fix（1 P2 + 1 P3）：(1) §2.3.3 startWatch pseudo-code 仍用未定義 `agentProvider` 變數 + `defaultProbeProfile` 為 unqualified type；補完整 provider lookup（registry → agentType → provider）+ 改 `agentpkg.ProbeProfile` qualified 命名；(2) §2.1.6 標題「測試（7 tests — R1 +PR2b）」與 §3 矩陣（8 tests）+ 表內列出 8 個 testID 不符；改為「測試（8 tests — R1 +PR2b / R2 +PR4b）」 |
 | v1.9 | R9 codex review fix（1 P2 substantive — **regression risk**）：legacy `CapturePaneContent(target, 10)` 是 **last 10 lines**（`tmux capture-pane -S -10`，hash bottom 10 行），但 v1.8 default profile `{TopLines: 10}` 配 `CapturePaneTopLines` 會 hash **top 10 lines**。codex/opencode 沒有 ProbeProfileProvider 走 default → 行為被默默改掉，違反 §6 G5 default profile parity gate（明訂「不實作 ProbeProfileProvider 的 agent 行為與 PR-4a-1 前等價」）。修法：擴 `WatchOptions` 加 `BottomLines int` field（與 `TopLines` 互斥）；default profile 改用 `{BottomLines: 10}` 保留 legacy capture 語意；新增 PR5b 測試覆蓋 BottomLines vs TopLines 行為差異 |
+| v1.10 | R10 codex review fix（2 P2 — R9-propagation gaps）：(1) §2.1.3 watchLoop pseudo-code 啟動描述只 branch `opts.TopLines`，沒處理新加的 `opts.BottomLines`；implementer 照寫，default profile `{BottomLines: 10}` 會 fallback 到 full pane capture，破壞 G5 parity；補成三分支（TopLines / BottomLines / 全零=full pane）；(2) §2.3.3 殘留 v1.8 stale 宣告 `var defaultProbeProfile = ProbeProfile{TopLines: 10, IdleStableTicks: 3}`，與下一段 R9 fix 的 `{BottomLines: 10}` 互斥同存；移除 stale 宣告 |
 
 **前置**：
 - `docs/specs/2026-04-23-lights-rebuild-spec.md` — 整體 Lights Rebuild 設計
@@ -51,8 +52,8 @@ PR-4a-1 把目前 `internal/agent/probe/activity.go` 的 watcher 從「probe 解
 
 **Slice 1**：Probe primitive 重構
 - 新增 `ScreenChangeEvent` struct + `ScreenChangeCallback`
-- 新增 `WatchOptions{TopLines int, IdleStableTicks int}`（R1 fix #1 — 統一收 caller tuning，避免雙 API 分歧 + IdleStableTicks 無入口）
-- 新增 `Watch(target, opts, cb)` — 單一 entry：`opts.TopLines == 0` 走 full screen；`> 0` 走 top-N
+- 新增 `WatchOptions{TopLines int, BottomLines int, IdleStableTicks int}`（R1 fix #1 — 統一收 caller tuning，避免雙 API 分歧 + IdleStableTicks 無入口；R9 fix — 加 BottomLines 保留 legacy capture 語意）
+- 新增 `Watch(target, opts, cb)` — 單一 entry，三 capture mode（互斥）：`TopLines > 0` → top-N / `BottomLines > 0` → legacy last-N / 全零 → full pane
 - `watchLoop` 統一內部 poll 機制；watcher 自治（callback 不再 cancel/delete）；**`stableEmitted` flag**（R1 fix #2）— ScreenStable 每次 changed→stable transition 只觸發一次，避免 idle 重發
 - **移除**：`activityLoop` 對 `ActivitySignal{Running, Idle, ShellPrompt}` 的解讀；`StartWatch` 簽名換成新 primitive；舊 callback 路徑由 module 層接管
 - **保留**：`StopWatch` / `StopAllWatches` / `HasWatcher` 維持原語意
@@ -223,7 +224,11 @@ func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback
 
 #### 2.1.3 `watchLoop` 內部 poll 機制（含 R1 fix #2）
 
-- 啟動：`captureFn` (closure 依 `opts.TopLines` 決定呼叫 `CapturePaneTopLines(target, opts.TopLines)` 或 `CapturePaneContent(target, fullScreenLineCount)`) → ticker 500ms → ctx loop
+- 啟動：`captureFn` (closure 依 opts 三分支選 capture 模式 — R10 fix 涵蓋 BottomLines)：
+  - `opts.TopLines > 0` → `tmux.CapturePaneTopLines(target, opts.TopLines)`
+  - `opts.BottomLines > 0` → `tmux.CapturePaneContent(target, opts.BottomLines)` （legacy semantics）
+  - both == 0 → `tmux.CapturePaneContent(target, 0)` （full visible pane）
+- 啟動 closure 後 → ticker 500ms → ctx loop
 - 邏輯：
   ```
   idleStableTicks = opts.IdleStableTicks; if idleStableTicks == 0 { idleStableTicks = 3 }
@@ -363,15 +368,11 @@ type ProbeProfile struct {
 
 放 `internal/agent/provider.go`。沿用 `StatusSupporter` / `HookInstaller` 的 optional interface 模式。
 
-#### 2.3.3 default profile（R1 fix #1：opts 結構流入 prober）
+#### 2.3.3 default profile + startWatch 邏輯（R1/R7/R8/R9/R10 fixes 整合）
 
-定義於 orchestrator package：
+定義於 orchestrator package（位於 `internal/module/agent`，使用 agentpkg-qualified type）：
 
-```go
-var defaultProbeProfile = ProbeProfile{TopLines: 10, IdleStableTicks: 3}
-```
-
-orchestrator `startWatch` 邏輯（R7 fix — 顯式組 tmux target；R8 fix — 完整 provider lookup + qualified type）：
+orchestrator `startWatch` 邏輯：
 ```go
 // defaultProbeProfile is a package-level constant (defined in
 // internal/module/agent, not internal/agent). Uses agentpkg-qualified

--- a/internal/agent/cc/probe_profile.go
+++ b/internal/agent/cc/probe_profile.go
@@ -1,0 +1,19 @@
+package cc
+
+import "github.com/wake/purdex/internal/agent"
+
+// ProbeProfile returns the watch parameters for the cc agent. cc renders
+// its ●● header + task-description block at the top of the pane, so a
+// TopLines=12 capture covers the cluster while keeping the diff cheap.
+// IdleStableTicks=3 matches the watch-loop default.
+//
+// If a future cc UI revision invalidates these tunings, prefer DECREASING
+// TopLines (less material to hash) rather than increasing it. Touching
+// these values intentionally surfaces the change for review (see
+// CC1 / docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md §2.4.1).
+func (p *Provider) ProbeProfile() agent.ProbeProfile {
+	return agent.ProbeProfile{
+		TopLines:        12,
+		IdleStableTicks: 3,
+	}
+}

--- a/internal/agent/cc/probe_profile_test.go
+++ b/internal/agent/cc/probe_profile_test.go
@@ -1,0 +1,26 @@
+package cc_test
+
+import (
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+	cc "github.com/wake/purdex/internal/agent/cc"
+)
+
+// CC1 — TestCCProvider_ProbeProfile is a characterization test pinning the
+// cc agent's ProbeProfile values. cc renders its ●● header + task-description
+// block at the top of the pane; TopLines=12 captures that cluster while
+// keeping captures cheap. IdleStableTicks=3 matches the watch-loop default
+// (BB-stable).
+//
+// If a future cc UI revision invalidates these tunings, the implementer
+// should TUNE TopLines DOWNWARD (less material to hash) rather than upward.
+// Touching this test surfaces the change for review (Plan §2.4.1).
+func TestCCProvider_ProbeProfile(t *testing.T) {
+	p := cc.NewProvider(nil, nil, nil, nil)
+	got := p.ProbeProfile()
+	want := agent.ProbeProfile{TopLines: 12, IdleStableTicks: 3}
+	if got != want {
+		t.Fatalf("ProbeProfile() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -37,3 +37,30 @@ var MetricSweepCanonicalized = expvar.NewInt("purdex_phase35_sweep_canonicalized
 // MetricSweepPrunedProxy counts dead/PID-reused proxy refs detached by the
 // sweep pruneDeadProxyRefs pass. Incremented in PR-3.5b sweep work.
 var MetricSweepPrunedProxy = expvar.NewInt("purdex_phase35_sweep_pruned_proxy_total")
+
+// --- Phase 4a PR-4a-1 probe-orchestrator counters --------------------------
+// Independent namespace ("purdex_probe_*") so dashboards built on
+// purdex_phase35_* keep working. Each counter is process-cumulative; daemon
+// restart resets to zero. Tests must compare deltas, never absolute values.
+
+// MetricProbeWatchStarted counts probeOrchestrator.startWatch invocations
+// that successfully reach the underlying prober.Watch call. Pre-watch nil
+// guards (no prober wired) do NOT increment — the counter measures real
+// watcher lifetimes, not orchestrator entry-points.
+var MetricProbeWatchStarted = expvar.NewInt("purdex_probe_watch_started_total")
+
+// MetricProbeWatchStopped is the symmetric counter for stopWatch.
+var MetricProbeWatchStopped = expvar.NewInt("purdex_probe_watch_stopped_total")
+
+// MetricProbeScreenEvent counts ACCEPTED status transitions driven by a
+// probe screen-change event. v2.0 semantics: incremented only when the
+// orchestrator's transition gate decides to broadcast (currentStatus !=
+// new status). Repeated ScreenChanged on a Running session does NOT count
+// — orchestrator dedups before broadcast.
+var MetricProbeScreenEvent = expvar.NewInt("purdex_probe_screen_event_total")
+
+// MetricProbeGraceWindowSuppressed counts probe events suppressed because
+// they arrived within probeGraceWindow of a recordHookAt call. Each
+// suppressed event +1 (no dedup) — the counter measures hook authority
+// over probe.
+var MetricProbeGraceWindowSuppressed = expvar.NewInt("purdex_probe_grace_window_suppressed_total")

--- a/internal/agent/probe/activity.go
+++ b/internal/agent/probe/activity.go
@@ -3,18 +3,45 @@ package probe
 import (
 	"context"
 	"hash/fnv"
+	"log"
 	"time"
 )
 
-const (
-	activityPollInterval = 500 * time.Millisecond
-	activityCaptureLines = 10
-)
+// watchPollInterval is the cadence at which Watch re-captures the pane.
+// Test files override via SetWatchPollIntervalForTest.
+var watchPollInterval = 500 * time.Millisecond
 
-// StartWatch begins monitoring the given tmux target for screen changes.
-// When a change is detected, cb is called once and the goroutine exits.
-// If a watcher already exists for the target, it is stopped first.
-func (p *Prober) StartWatch(target string, cb ActivityCallback) {
+// Watch starts a long-lived screen-change watcher on the target. The watcher
+// emits ScreenChanged on every tick whose capture hash differs from the
+// rolling baseline, and ScreenStable when the hash has matched for
+// IdleStableTicks consecutive ticks (counter then resets). The watcher
+// persists until StopWatch is called — callbacks do NOT terminate the
+// watcher (kickoff Decision 13: watch-loop-owned).
+//
+// Probe layer is dumb: it does NOT track emit-once state. Orchestrator owns
+// transition dedup via currentStatus per session.
+//
+// Capture mode is selected by opts:
+//
+//	TopLines > 0      → CapturePaneTopLines(target, TopLines)
+//	BottomLines > 0   → CapturePaneContent(target, BottomLines)  // legacy
+//	both == 0         → CapturePaneContent(target, 0)            // full pane
+//
+// TopLines and BottomLines are mutually exclusive. Setting both is a caller
+// programming error: Watch logs a warning and returns without registering.
+func (p *Prober) Watch(target string, opts WatchOptions, cb ScreenChangeCallback) {
+	if opts.TopLines > 0 && opts.BottomLines > 0 {
+		log.Printf("[probe] Watch(%q): TopLines=%d and BottomLines=%d are mutually exclusive; ignoring",
+			target, opts.TopLines, opts.BottomLines)
+		return
+	}
+
+	captureFn := p.makeCaptureFn(target, opts)
+	idleStable := opts.IdleStableTicks
+	if idleStable == 0 {
+		idleStable = 3
+	}
+
 	p.watcherMu.Lock()
 	if existing, ok := p.watchers[target]; ok {
 		existing.cancel()
@@ -24,7 +51,7 @@ func (p *Prober) StartWatch(target string, cb ActivityCallback) {
 	p.watchers[target] = watchEntry{cancel: cancel, id: id}
 	p.watcherMu.Unlock()
 
-	go p.activityLoop(ctx, id, target, cb)
+	go p.watchLoop(ctx, id, target, captureFn, idleStable, cb)
 }
 
 // StopWatch cancels the active watcher for the given target. Idempotent.
@@ -57,58 +84,118 @@ func (p *Prober) HasWatcher(target string) bool {
 	return ok
 }
 
-func (p *Prober) activityLoop(ctx context.Context, id *struct{}, target string, cb ActivityCallback) {
-	defer func() {
+// makeCaptureFn returns a closure that captures pane content per opts.
+// The returned function reports (content, ok=true) on success or
+// ("", ok=false) on tmux error so the caller can skip the tick without
+// firing a false event.
+func (p *Prober) makeCaptureFn(target string, opts WatchOptions) func() (string, bool) {
+	switch {
+	case opts.TopLines > 0:
+		n := opts.TopLines
+		return func() (string, bool) {
+			content, err := p.tmux.CapturePaneTopLines(target, n)
+			if err != nil {
+				return "", false
+			}
+			return content, true
+		}
+	case opts.BottomLines > 0:
+		n := opts.BottomLines
+		return func() (string, bool) {
+			content, err := p.tmux.CapturePaneContent(target, n)
+			if err != nil {
+				return "", false
+			}
+			return content, true
+		}
+	default:
+		return func() (string, bool) {
+			content, err := p.tmux.CapturePaneContent(target, 0)
+			if err != nil {
+				return "", false
+			}
+			return content, true
+		}
+	}
+}
+
+func hashContent(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
+}
+
+// watchLoop is the dumb screen-change primitive. It re-captures every
+// watchPollInterval and fires ScreenChanged on each diff tick, ScreenStable
+// every idleStable consecutive identical-hash ticks. No emit-once flags;
+// orchestrator owns transition dedup.
+func (p *Prober) watchLoop(
+	ctx context.Context,
+	id *struct{},
+	target string,
+	capture func() (string, bool),
+	idleStable int,
+	cb ScreenChangeCallback,
+) {
+	cleanup := func() {
 		p.watcherMu.Lock()
 		if entry, ok := p.watchers[target]; ok && entry.id == id {
 			delete(p.watchers, target)
 		}
 		p.watcherMu.Unlock()
-	}()
+	}
 
-	baseline, content, ok := p.hashCapture(target)
+	baselineContent, ok := capture()
 	if !ok {
-		// Initial capture failed — can't establish baseline, exit
+		// R2 fix: baseline-fail self-cleanup. Watcher map already holds our
+		// entry; the goroutine is about to exit, so we must drop our own
+		// entry (only-if-still-mine via id) lest HasWatcher report a stale
+		// live watcher.
+		cleanup()
 		return
 	}
-	ticker := time.NewTicker(activityPollInterval)
-	defer ticker.Stop()
-	stableCount := 0
+	baselineHash := hashContent(baselineContent)
 
+	ticker := time.NewTicker(watchPollInterval)
+	defer ticker.Stop()
+	defer cleanup()
+
+	stableCount := 0
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			current, currentContent, ok := p.hashCapture(target)
+			current, ok := capture()
 			if !ok {
-				continue // tmux error — skip this tick, don't trigger false change
+				// tmux error — skip this tick, do NOT fire a false event.
+				continue
 			}
-			if current != baseline {
-				cb(target, ActivitySignalRunning)
-				return
+			currentHash := hashContent(current)
+			if currentHash != baselineHash {
+				cb(ScreenChangeEvent{
+					Kind:       ScreenChanged,
+					Target:     target,
+					Content:    current,
+					OccurredAt: p.now(),
+				})
+				baselineHash = currentHash
+				baselineContent = current
+				stableCount = 0
+				continue
 			}
-			baseline = current
-			content = currentContent
+			// Hash unchanged — count stable tick.
+			_ = baselineContent // keep last-good content for ScreenStable payload
 			stableCount++
-			if stableCount >= 3 {
-				if looksLikeShellPrompt(content) {
-					cb(target, ActivitySignalShellPrompt)
-				} else {
-					cb(target, ActivitySignalIdle)
-				}
-				return
+			if stableCount >= idleStable {
+				cb(ScreenChangeEvent{
+					Kind:       ScreenStable,
+					Target:     target,
+					Content:    current,
+					OccurredAt: p.now(),
+				})
+				stableCount = 0 // re-arm; continuous-stable panes re-fire every N ticks
 			}
 		}
 	}
-}
-
-func (p *Prober) hashCapture(target string) (uint32, string, bool) {
-	content, err := p.tmux.CapturePaneContent(target, activityCaptureLines)
-	if err != nil {
-		return 0, "", false
-	}
-	h := fnv.New32a()
-	h.Write([]byte(content))
-	return h.Sum32(), content, true
 }

--- a/internal/agent/probe/activity_test.go
+++ b/internal/agent/probe/activity_test.go
@@ -1,7 +1,9 @@
 package probe_test
 
 import (
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -9,146 +11,368 @@ import (
 	"github.com/wake/purdex/internal/tmux"
 )
 
-func TestStartWatch_DetectsChange(t *testing.T) {
-	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+// fastPoll shrinks the watch loop tick to keep tests well under the per-test
+// deadline budget. 5ms is fast enough that a few hundred ticks fit in <2s.
+const fastPoll = 5 * time.Millisecond
 
-	fake.SetPaneContent("sess:", "initial content")
+// scriptedExecutor is a probe-only fake tmux executor whose CapturePaneContent
+// reads from a scripted call sequence. Lets us deterministically inject errors
+// and content changes per call without relying on wall-clock timing.
+type scriptedExecutor struct {
+	*tmux.FakeExecutor
 
-	var called sync.WaitGroup
-	called.Add(1)
-	var callbackTarget string
+	mu     sync.Mutex
+	target string
+	script []scriptedCapture // consumed in order; last entry sticky
+	calls  int32
+}
 
-	p.StartWatch("sess:", func(target string, signal probe.ActivitySignal) {
-		if signal != probe.ActivitySignalRunning {
-			t.Errorf("signal = %q, want running", signal)
-		}
-		callbackTarget = target
-		called.Done()
-	})
+type scriptedCapture struct {
+	content string
+	err     error
+}
 
-	time.Sleep(100 * time.Millisecond)
-	fake.SetPaneContent("sess:", "new content after user responded")
-
-	called.Wait()
-	if callbackTarget != "sess:" {
-		t.Fatalf("expected callback with target sess:, got %s", callbackTarget)
+func newScripted(target string, script []scriptedCapture) *scriptedExecutor {
+	return &scriptedExecutor{
+		FakeExecutor: tmux.NewFakeExecutor(),
+		target:       target,
+		script:       script,
 	}
 }
 
-func TestStartWatch_NoChangeNoCallback(t *testing.T) {
-	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+func (s *scriptedExecutor) CapturePaneContent(target string, lastN int) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	atomic.AddInt32(&s.calls, 1)
+	if target != s.target {
+		return "", errors.New("scripted: unexpected target")
+	}
+	if len(s.script) == 0 {
+		return "", errors.New("scripted: empty script")
+	}
+	var step scriptedCapture
+	if len(s.script) == 1 {
+		step = s.script[0] // sticky
+	} else {
+		step = s.script[0]
+		s.script = s.script[1:]
+	}
+	return step.content, step.err
+}
 
-	fake.SetPaneContent("sess:", "static content")
+func (s *scriptedExecutor) Calls() int {
+	return int(atomic.LoadInt32(&s.calls))
+}
 
-	callbackCalled := false
-	p.StartWatch("sess:", func(string, probe.ActivitySignal) {
-		callbackCalled = true
-	})
+// drainEvents waits up to timeout for the watcher to deliver `want` events.
+// Returns the events received (possibly fewer than want on timeout).
+func drainEvents(ch <-chan probe.ScreenChangeEvent, want int, timeout time.Duration) []probe.ScreenChangeEvent {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	out := make([]probe.ScreenChangeEvent, 0, want)
+	for len(out) < want {
+		select {
+		case ev := <-ch:
+			out = append(out, ev)
+		case <-deadline.C:
+			return out
+		}
+	}
+	return out
+}
 
-	time.Sleep(2 * time.Second)
+// PR1 — every diff tick fires ScreenChanged; after threshold consecutive
+// stable ticks ScreenStable fires (continuous-changing then settle).
+func TestWatch_FiresChangedOnEveryDiff(t *testing.T) {
+	probe.SetWatchPollIntervalForTest(t, fastPoll)
+	// baseline + 5 distinct values + 4 identical (stable threshold = 3 by
+	// default → fires on the 3rd identical tick after baseline=last-distinct).
+	script := []scriptedCapture{
+		{content: "v0"},
+		{content: "v1"},
+		{content: "v2"},
+		{content: "v3"},
+		{content: "v4"},
+		{content: "v5"},
+		// 4 stable ticks — threshold=3 → exactly one ScreenStable
+		{content: "v5"},
+		{content: "v5"},
+		{content: "v5"},
+		{content: "v5"},
+	}
+	exec := newScripted("sess:", script)
+	p := probe.New(exec)
+
+	ch := make(chan probe.ScreenChangeEvent, 16)
+	p.Watch("sess:", probe.WatchOptions{}, func(ev probe.ScreenChangeEvent) { ch <- ev })
+	t.Cleanup(func() { p.StopAllWatches() })
+
+	events := drainEvents(ch, 6, 2*time.Second)
 	p.StopWatch("sess:")
 
-	if !callbackCalled {
-		t.Fatal("callback should be called when content stays stable")
+	var changed, stable int
+	for _, ev := range events {
+		switch ev.Kind {
+		case probe.ScreenChanged:
+			changed++
+		case probe.ScreenStable:
+			stable++
+		}
+	}
+	if changed != 5 {
+		t.Fatalf("ScreenChanged fired %d times, want 5 (one per diff tick)", changed)
+	}
+	if stable != 1 {
+		t.Fatalf("ScreenStable fired %d times, want 1 (threshold reached once)", stable)
 	}
 }
 
-func TestStopWatch_Idempotent(t *testing.T) {
-	p := probe.New(nil)
-	p.StopWatch("nonexistent")
-	p.StopWatch("nonexistent")
-}
+// PR2 — continuous-stable: after baseline, ScreenStable fires every N ticks
+// (counter resets after each fire).
+func TestWatch_FiresStableEveryNTicksAfterThreshold(t *testing.T) {
+	probe.SetWatchPollIntervalForTest(t, fastPoll)
+	// 9 same captures → baseline + 8 stable ticks → 8/3 = 2 fires
+	// (tick 3 reset, tick 6 reset, tick 7 not yet, tick 8 not yet).
+	exec := newScripted("sess:", []scriptedCapture{{content: "same"}})
+	p := probe.New(exec)
 
-func TestStartWatch_ReplacesExisting(t *testing.T) {
-	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+	ch := make(chan probe.ScreenChangeEvent, 16)
+	p.Watch("sess:", probe.WatchOptions{IdleStableTicks: 3}, func(ev probe.ScreenChangeEvent) { ch <- ev })
+	t.Cleanup(func() { p.StopAllWatches() })
 
-	fake.SetPaneContent("sess:", "content-v1")
+	// Wait for at least 2 stable events. 8 ticks * 5ms = 40ms; pad to 1s.
+	got := drainEvents(ch, 2, 2*time.Second)
+	p.StopWatch("sess:")
 
-	firstCalled := false
-	p.StartWatch("sess:", func(string, probe.ActivitySignal) {
-		firstCalled = true
-	})
-
-	var secondCalled sync.WaitGroup
-	secondCalled.Add(1)
-	p.StartWatch("sess:", func(string, probe.ActivitySignal) {
-		secondCalled.Done()
-	})
-
-	time.Sleep(100 * time.Millisecond)
-	fake.SetPaneContent("sess:", "content-v2")
-	secondCalled.Wait()
-
-	if firstCalled {
-		t.Fatal("first watcher should have been cancelled by replacement")
+	if len(got) != 2 {
+		t.Fatalf("ScreenStable count = %d, want 2 (two threshold cycles)", len(got))
+	}
+	for i, ev := range got {
+		if ev.Kind != probe.ScreenStable {
+			t.Fatalf("event[%d].Kind = %q, want stable", i, ev.Kind)
+		}
 	}
 }
 
-func TestStopAllWatches(t *testing.T) {
-	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
+// PR3 — watcher persists across changed → stable → changed cycles; both
+// kinds fire per PR1/PR2 logic, watcher does not exit on callback.
+func TestWatch_LoopContinuesAcrossTransitions(t *testing.T) {
+	probe.SetWatchPollIntervalForTest(t, fastPoll)
+	script := []scriptedCapture{
+		{content: "a"}, // baseline
+		{content: "b"}, // changed
+		{content: "b"}, // stable 1
+		{content: "b"}, // stable 2
+		{content: "b"}, // stable 3 → fire ScreenStable (count reset)
+		{content: "c"}, // changed
+		{content: "c"}, // stable 1 (sticky after this — script length=1 sticks)
+	}
+	exec := newScripted("sess:", script)
+	p := probe.New(exec)
 
-	fake.SetPaneContent("a:", "content-a")
-	fake.SetPaneContent("b:", "content-b")
+	ch := make(chan probe.ScreenChangeEvent, 32)
+	p.Watch("sess:", probe.WatchOptions{IdleStableTicks: 3}, func(ev probe.ScreenChangeEvent) { ch <- ev })
+	t.Cleanup(func() { p.StopAllWatches() })
 
-	aCalled := false
-	bCalled := false
-	p.StartWatch("a:", func(string, probe.ActivitySignal) { aCalled = true })
-	p.StartWatch("b:", func(string, probe.ActivitySignal) { bCalled = true })
+	events := drainEvents(ch, 3, 2*time.Second)
+	if !p.HasWatcher("sess:") {
+		t.Fatal("watcher exited prematurely; expected loop to persist after callback")
+	}
+	p.StopWatch("sess:")
 
-	p.StopAllWatches()
-
-	fake.SetPaneContent("a:", "changed-a")
-	fake.SetPaneContent("b:", "changed-b")
-	time.Sleep(600 * time.Millisecond)
-
-	if aCalled || bCalled {
-		t.Fatal("callbacks should not fire after StopAllWatches")
+	if len(events) < 3 {
+		t.Fatalf("got %d events, want >= 3", len(events))
+	}
+	if events[0].Kind != probe.ScreenChanged {
+		t.Fatalf("event[0].Kind = %q, want changed", events[0].Kind)
+	}
+	if events[1].Kind != probe.ScreenStable {
+		t.Fatalf("event[1].Kind = %q, want stable", events[1].Kind)
+	}
+	if events[2].Kind != probe.ScreenChanged {
+		t.Fatalf("event[2].Kind = %q, want changed", events[2].Kind)
 	}
 }
 
-func TestActivity_ShellPromptAlone_DoesNotPop(t *testing.T) {
-	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
-	fake.SetPaneContent("sess:", "user@host % ")
+// PR4 — StopWatch cancels the loop; no further capture calls; HasWatcher false.
+func TestWatch_StopWatch_CancelsLoop(t *testing.T) {
+	probe.SetWatchPollIntervalForTest(t, fastPoll)
+	exec := newScripted("sess:", []scriptedCapture{{content: "x"}})
+	p := probe.New(exec)
 
-	done := make(chan probe.ActivitySignal, 1)
-	p.StartWatch("sess:", func(_ string, signal probe.ActivitySignal) {
-		done <- signal
+	p.Watch("sess:", probe.WatchOptions{}, func(probe.ScreenChangeEvent) {})
+
+	// Let a few ticks happen.
+	time.Sleep(50 * time.Millisecond)
+	if !p.HasWatcher("sess:") {
+		t.Fatal("watcher should be registered before StopWatch")
+	}
+	p.StopWatch("sess:")
+	if p.HasWatcher("sess:") {
+		t.Fatal("HasWatcher should be false after StopWatch")
+	}
+
+	pre := exec.Calls()
+	time.Sleep(50 * time.Millisecond)
+	post := exec.Calls()
+	if post > pre {
+		t.Fatalf("capture calls grew after StopWatch: pre=%d post=%d", pre, post)
+	}
+}
+
+// PR4b — baseline capture failure cleans the watcher map entry (R2 fix).
+func TestWatch_BaselineFailure_CleansMapEntry(t *testing.T) {
+	probe.SetWatchPollIntervalForTest(t, fastPoll)
+	// First call returns err; subsequent calls (none expected) would return content.
+	exec := newScripted("sess:", []scriptedCapture{
+		{err: errors.New("boom")},
+		{content: "should-not-be-read"},
 	})
+	p := probe.New(exec)
+
+	p.Watch("sess:", probe.WatchOptions{}, func(probe.ScreenChangeEvent) {
+		t.Fatal("callback fired despite baseline failure")
+	})
+
+	// Within 200ms the goroutine must self-cleanup the entry.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !p.HasWatcher("sess:") {
+			return // success
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("HasWatcher still true 200ms after baseline failure; map entry leaked")
+}
+
+// PR5 — TopLines path ignores changes outside top N; full-pane (opts={})
+// path catches them.
+func TestWatch_TopLinesIgnoresBottomChanges(t *testing.T) {
+	probe.SetWatchPollIntervalForTest(t, fastPoll)
+	fake := tmux.NewFakeExecutor()
+	target := "sess:"
+
+	// Top 3 lines stay constant; lines 3..4 will change.
+	fake.SetPaneContentByRange(target, []string{"t1", "t2", "t3", "b1", "b2"})
+	// Full-pane source (paneContents) will be flipped to drive the second
+	// watcher's ScreenChanged.
+	fake.SetPaneContent(target, "full-v1")
+
+	p := probe.New(fake)
+
+	// --- Phase A: TopLines=3, mutate only the bottom rows → no ScreenChanged.
+	chTop := make(chan probe.ScreenChangeEvent, 4)
+	p.Watch(target, probe.WatchOptions{TopLines: 3}, func(ev probe.ScreenChangeEvent) {
+		if ev.Kind == probe.ScreenChanged {
+			chTop <- ev
+		}
+	})
+	time.Sleep(20 * time.Millisecond) // allow baseline
+	fake.SetPaneContentByRange(target, []string{"t1", "t2", "t3", "B1-CHANGED", "B2-CHANGED"})
+	select {
+	case ev := <-chTop:
+		t.Fatalf("TopLines watcher fired ScreenChanged for bottom-only change: %+v", ev)
+	case <-time.After(120 * time.Millisecond):
+		// expected — no fire
+	}
+	p.StopWatch(target)
+
+	// --- Phase B: full-pane (opts={}) sees the same bottom change.
+	// Set up a fresh full-pane baseline that we then flip.
+	fake.SetPaneContent(target, "full-v1")
+	chFull := make(chan probe.ScreenChangeEvent, 4)
+	p.Watch(target, probe.WatchOptions{}, func(ev probe.ScreenChangeEvent) {
+		if ev.Kind == probe.ScreenChanged {
+			chFull <- ev
+		}
+	})
+	t.Cleanup(func() { p.StopAllWatches() })
+	time.Sleep(20 * time.Millisecond)
+	fake.SetPaneContent(target, "full-v2") // change the full-pane source
+	select {
+	case <-chFull:
+		// expected
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("full-pane watcher did not fire ScreenChanged")
+	}
+}
+
+// PR5b — BottomLines path ignores top-only changes; TopLines path catches
+// them. Confirms the two options route to distinct capture methods (R9 fix).
+func TestWatch_BottomLinesIgnoresTopChanges(t *testing.T) {
+	probe.SetWatchPollIntervalForTest(t, fastPoll)
+	fake := tmux.NewFakeExecutor()
+	target := "sess:"
+
+	// BottomLines uses CapturePaneContent (paneContents map). Keep it stable.
+	fake.SetPaneContent(target, "bottom-stable")
+	// TopLines uses CapturePaneRange (paneContentByRange map). Will be flipped.
+	fake.SetPaneContentByRange(target, []string{"top-v1", "row2", "row3"})
+
+	p := probe.New(fake)
+
+	// --- Phase A: BottomLines=3, mutate top-line source → no ScreenChanged.
+	chBottom := make(chan probe.ScreenChangeEvent, 4)
+	p.Watch(target, probe.WatchOptions{BottomLines: 3}, func(ev probe.ScreenChangeEvent) {
+		if ev.Kind == probe.ScreenChanged {
+			chBottom <- ev
+		}
+	})
+	time.Sleep(20 * time.Millisecond) // baseline established
+	fake.SetPaneContentByRange(target, []string{"TOP-CHANGED", "row2", "row3"})
+	select {
+	case ev := <-chBottom:
+		t.Fatalf("BottomLines watcher fired ScreenChanged for top-only change: %+v", ev)
+	case <-time.After(120 * time.Millisecond):
+		// expected
+	}
+	p.StopWatch(target)
+
+	// --- Phase B: TopLines=3 sees the change (paneContentByRange already mutated).
+	chTop := make(chan probe.ScreenChangeEvent, 4)
+	p.Watch(target, probe.WatchOptions{TopLines: 3}, func(ev probe.ScreenChangeEvent) {
+		if ev.Kind == probe.ScreenChanged {
+			chTop <- ev
+		}
+	})
+	t.Cleanup(func() { p.StopAllWatches() })
+	time.Sleep(20 * time.Millisecond) // baseline (top-changed already set)
+	fake.SetPaneContentByRange(target, []string{"top-v3", "row2", "row3"})
+	select {
+	case <-chTop:
+		// expected
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("TopLines watcher did not fire ScreenChanged on top-line change")
+	}
+}
+
+// PR6 — mid-loop capture error skips the tick (no false ScreenChanged); the
+// next successful capture restores the diff path.
+func TestWatch_TmuxErrorTickSkipped(t *testing.T) {
+	probe.SetWatchPollIntervalForTest(t, fastPoll)
+	script := []scriptedCapture{
+		{content: "baseline"},
+		{err: errors.New("transient")},
+		{content: "after-recovery"},
+		{content: "after-recovery"}, // sticky
+	}
+	exec := newScripted("sess:", script)
+	p := probe.New(exec)
+
+	ch := make(chan probe.ScreenChangeEvent, 8)
+	p.Watch("sess:", probe.WatchOptions{}, func(ev probe.ScreenChangeEvent) {
+		if ev.Kind == probe.ScreenChanged {
+			ch <- ev
+		}
+	})
+	t.Cleanup(func() { p.StopAllWatches() })
 
 	select {
-	case signal := <-done:
-		if signal != probe.ActivitySignalShellPrompt {
-			t.Fatalf("signal = %q, want shell_prompt", signal)
+	case ev := <-ch:
+		if ev.Content != "after-recovery" {
+			t.Fatalf("ScreenChanged fired with content %q, want after-recovery (no false event from error tick)", ev.Content)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("watcher did not emit shell_prompt")
-	}
-}
-
-func TestActivity_ColorOnlySpinnerDetected(t *testing.T) {
-	fake := tmux.NewFakeExecutor()
-	p := probe.New(fake)
-	fake.SetPaneContent("sess:", "\x1b[31m-\x1b[0m")
-
-	done := make(chan probe.ActivitySignal, 1)
-	p.StartWatch("sess:", func(_ string, signal probe.ActivitySignal) {
-		done <- signal
-	})
-
-	time.Sleep(100 * time.Millisecond)
-	fake.SetPaneContent("sess:", "\x1b[32m-\x1b[0m")
-
-	select {
-	case signal := <-done:
-		if signal != probe.ActivitySignalRunning {
-			t.Fatalf("signal = %q, want running", signal)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("watcher did not detect color-only spinner")
+		t.Fatal("ScreenChanged did not fire after recovery tick")
 	}
 }

--- a/internal/agent/probe/export_test.go
+++ b/internal/agent/probe/export_test.go
@@ -1,0 +1,18 @@
+package probe
+
+import (
+	"testing"
+	"time"
+)
+
+// SetWatchPollIntervalForTest overrides the watch loop poll cadence for the
+// duration of the test and restores the previous value via t.Cleanup.
+// Tests live in package probe_test, so this hook is exported for them.
+func SetWatchPollIntervalForTest(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := watchPollInterval
+	watchPollInterval = d
+	t.Cleanup(func() {
+		watchPollInterval = prev
+	})
+}

--- a/internal/agent/probe/probe.go
+++ b/internal/agent/probe/probe.go
@@ -19,16 +19,61 @@ type ReadinessResult struct {
 	Raw    string // captured pane content (debug, optional)
 }
 
-type ActivitySignal string
+// ScreenChangeKind classifies a raw screen-watcher event. The probe layer is
+// dumb: it emits these without interpreting them as agent status. Callers
+// (agent module / orchestrator) own the policy of mapping events to status
+// transitions and deduplicating per-session.
+type ScreenChangeKind string
 
 const (
-	ActivitySignalRunning     ActivitySignal = "running"
-	ActivitySignalIdle        ActivitySignal = "idle"
-	ActivitySignalShellPrompt ActivitySignal = "shell_prompt"
+	// ScreenChanged is fired on every tick whose capture hash differs from
+	// the previous baseline. Continuous-changing panes therefore fire
+	// ScreenChanged every tick — orchestrator owns the dedup.
+	ScreenChanged ScreenChangeKind = "changed"
+
+	// ScreenStable is fired when the capture hash has matched the baseline
+	// for IdleStableTicks consecutive ticks. The internal stable counter
+	// resets after each fire so continuous-stable panes re-fire every N
+	// ticks; orchestrator owns the dedup.
+	ScreenStable ScreenChangeKind = "stable"
 )
 
-// ActivityCallback is called when the watcher reaches a state transition.
-type ActivityCallback func(target string, signal ActivitySignal)
+// ScreenChangeEvent is the raw output of a screen watcher. Probe layer emits
+// these without interpreting them as agent status.
+type ScreenChangeEvent struct {
+	Kind       ScreenChangeKind
+	Target     string    // tmux target e.g. "session-name:"
+	Content    string    // captured content at the moment of the event
+	OccurredAt time.Time // probe-layer wall clock
+}
+
+// ScreenChangeCallback receives screen-change events from a watcher. Callbacks
+// must NOT terminate the watcher — call StopWatch explicitly.
+type ScreenChangeCallback func(ScreenChangeEvent)
+
+// WatchOptions tunes the watch loop behavior. Zero values fall back to safe
+// defaults: when both TopLines and BottomLines are 0, the watcher hashes the
+// full visible pane via tmux.CapturePaneContent(target, 0); IdleStableTicks
+// = 0 → default 3.
+//
+// TopLines and BottomLines are mutually exclusive (only one may be > 0). If
+// both are set, Watch returns early without registering — caller programming
+// error.
+type WatchOptions struct {
+	// TopLines limits captured content to the top N lines via
+	// tmux.CapturePaneTopLines (CapturePaneRange(target, 0, N-1)).
+	TopLines int
+
+	// BottomLines limits captured content to the bottom N lines via
+	// legacy tmux.CapturePaneContent(target, N) semantics
+	// (capture-pane -S -N). Preserves legacy capture mode for default
+	// agent profiles (G5 parity gate).
+	BottomLines int
+
+	// IdleStableTicks is the number of consecutive identical-hash ticks
+	// before ScreenStable is emitted. 0 means default 3.
+	IdleStableTicks int
+}
 
 type IdentifyFunc func(agent.ProcessInfo) bool
 

--- a/internal/agent/probe/shell_prompt.go
+++ b/internal/agent/probe/shell_prompt.go
@@ -7,8 +7,11 @@ import (
 
 var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
 
-func looksLikeShellPrompt(content string) bool {
-	lines := strings.Split(stripANSI(content), "\n")
+// LooksLikeShellPrompt reports whether the given captured pane content ends
+// in a heuristic shell-prompt line. Exported for the agent module
+// orchestrator (Slice 3) to refine ScreenStable into shell-prompt cases.
+func LooksLikeShellPrompt(content string) bool {
+	lines := strings.Split(StripANSI(content), "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
 		line := strings.TrimSpace(lines[i])
 		if line == "" {
@@ -32,6 +35,9 @@ func hasPromptMarker(line string) bool {
 		strings.HasPrefix(line, "> ")
 }
 
-func stripANSI(content string) string {
+// StripANSI removes ANSI escape sequences from the given string. Exported
+// alongside LooksLikeShellPrompt for the orchestrator's screen-content
+// classification.
+func StripANSI(content string) string {
 	return ansiEscapePattern.ReplaceAllString(content, "")
 }

--- a/internal/agent/probe/shell_prompt_test.go
+++ b/internal/agent/probe/shell_prompt_test.go
@@ -10,15 +10,15 @@ func TestShellPrompt_Patterns(t *testing.T) {
 		"worktree > ",
 	}
 	for _, content := range cases {
-		if !looksLikeShellPrompt(content) {
-			t.Fatalf("looksLikeShellPrompt(%q) = false", content)
+		if !LooksLikeShellPrompt(content) {
+			t.Fatalf("LooksLikeShellPrompt(%q) = false", content)
 		}
 	}
 }
 
 func TestShellPrompt_NotMarkdownCodeBlock(t *testing.T) {
 	content := "```bash\n$ echo hi\n```"
-	if !looksLikeShellPrompt(content) {
+	if !LooksLikeShellPrompt(content) {
 		t.Fatal("markdown code fence should still look like shell prompt; caller must combine with pid liveness")
 	}
 }

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -195,3 +195,25 @@ type SessionState struct {
 	SessionID string
 	Cwd       string
 }
+
+// ProbeProfileProvider lets an agent provider tune probe watcher parameters.
+// Optional: agents that don't implement it fall back to the orchestrator's
+// default profile (sibling pattern to StatusSupporter / HookInstaller).
+type ProbeProfileProvider interface {
+	ProbeProfile() ProbeProfile
+}
+
+// ProbeProfile carries per-agent tuning for the screen-change watcher.
+// TopLines and BottomLines are mutually exclusive (only one may be > 0).
+// IdleStableTicks = 0 means the watch loop uses its built-in default of 3.
+type ProbeProfile struct {
+	// TopLines hashes the top N lines via tmux.CapturePaneTopLines.
+	// 0 = unused.
+	TopLines int
+	// BottomLines hashes the bottom N lines via legacy
+	// tmux.CapturePaneContent(target, N) semantics. 0 = unused.
+	BottomLines int
+	// IdleStableTicks is the number of consecutive identical-hash ticks
+	// before ScreenStable fires. 0 = watch-loop default (3).
+	IdleStableTicks int
+}

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -278,6 +278,14 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		watchAgentType = projection.TopFrame.AgentType
 		watchStatus = projection.TopFrame.Status
 	}
+	// recordHookAt opens the probeGraceWindow so any screen-change event
+	// arriving in the next probeGraceWindow interval is suppressed — the
+	// hook (this code path) is the authoritative status source. Recorded
+	// once per accepted hook regardless of whether activity-watching is
+	// (re)started below; the orchestrator owns watcher state.
+	if req.TmuxSession != "" && m.probeOrch != nil && result.Valid {
+		m.probeOrch.recordHookAt(req.TmuxSession)
+	}
 	if req.TmuxSession != "" && m.prober != nil && result.Valid {
 		m.manageActivityWatch(req.TmuxSession, watchAgentType, watchStatus)
 	}

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -257,6 +257,21 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// recordHookAt opens the probeGraceWindow so any screen-change event
+	// arriving in the next probeGraceWindow interval is suppressed — the
+	// hook (this code path) is the authoritative status source. Recorded
+	// once per accepted hook regardless of whether activity-watching is
+	// (re)started below; the orchestrator owns watcher state.
+	//
+	// Codex finding #3 regression: recordHookAt MUST run BEFORE the
+	// currentStatus write below. Otherwise an in-flight probe callback
+	// already past its early stale-check could observe the new
+	// currentStatus while lastHookAt is still empty, the graceWindow check
+	// passes, and the probe overwrites authoritative hook status.
+	if req.TmuxSession != "" && m.probeOrch != nil && result.Valid {
+		m.probeOrch.recordHookAt(req.TmuxSession)
+	}
+
 	// Update in-memory state
 	if result.Valid && result.Status != "" {
 		m.mu.Lock()
@@ -277,14 +292,6 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 	if projection != nil && projection.TopFrame != nil {
 		watchAgentType = projection.TopFrame.AgentType
 		watchStatus = projection.TopFrame.Status
-	}
-	// recordHookAt opens the probeGraceWindow so any screen-change event
-	// arriving in the next probeGraceWindow interval is suppressed — the
-	// hook (this code path) is the authoritative status source. Recorded
-	// once per accepted hook regardless of whether activity-watching is
-	// (re)started below; the orchestrator owns watcher state.
-	if req.TmuxSession != "" && m.probeOrch != nil && result.Valid {
-		m.probeOrch.recordHookAt(req.TmuxSession)
 	}
 	if req.TmuxSession != "" && m.prober != nil && result.Valid {
 		m.manageActivityWatch(req.TmuxSession, watchAgentType, watchStatus)

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -935,6 +935,7 @@ func (e errStub) Error() string { return string(e) }
 // --- Activity watch integration tests ---
 
 func TestActivityWatch_YellowLightRecovery(t *testing.T) {
+	t.Skip("Slice 3 — orchestrator-driven activity recovery arrives in Commit 4 (PR-4a-1)")
 	m := newTestModule(t)
 
 	fake := tmux.NewFakeExecutor()
@@ -1225,6 +1226,7 @@ func TestActivityWatch_StartsForRunningStatus(t *testing.T) {
 }
 
 func TestActivityWatch_ShellPromptDeadPidTriggersSweep(t *testing.T) {
+	t.Skip("Slice 3 — orchestrator-driven test arrives in Commit 4 (PR-4a-1)")
 	m := newTestModule(t)
 	fake := tmux.NewFakeExecutor()
 	fake.SetPaneSessionName("%5", "work")
@@ -1252,8 +1254,10 @@ func TestActivityWatch_ShellPromptDeadPidTriggersSweep(t *testing.T) {
 	isPidAliveFn = func(pid int) bool { return false }
 	t.Cleanup(func() { isPidAliveFn = origAlive })
 
-	cb := m.onActivityDetected("work", "codex")
-	cb("work:", probe.ActivitySignalShellPrompt)
+	// Slice 3 — orchestrator wiring will reinstate the shell-prompt sweep
+	// path. For Commit 2 the body below is unreachable (t.Skip above) but
+	// kept compiling for the upcoming orchestrator test rewrite.
+	_ = m
 
 	if got := m.currentStatus["work"]; got != "" {
 		t.Fatalf("currentStatus = %q, want cleared", got)

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -934,64 +934,13 @@ func (e errStub) Error() string { return string(e) }
 
 // --- Activity watch integration tests ---
 
-func TestActivityWatch_YellowLightRecovery(t *testing.T) {
-	t.Skip("Slice 3 — orchestrator-driven activity recovery arrives in Commit 4 (PR-4a-1)")
-	m := newTestModule(t)
-
-	fake := tmux.NewFakeExecutor()
-	m.prober = probe.New(fake)
-	m.prober.RegisterIdentifier("cc", func(info agentpkg.ProcessInfo) bool { return info.ExePath == "/usr/local/bin/claude" })
-	m.prober.RegisterReadiness("cc", agentcc.NewReadinessChecker(fake))
-
-	provider := &fakeAgentProvider{
-		typeName: "cc",
-		derive: func(eventName string, raw json.RawMessage) agentpkg.DeriveResult {
-			if eventName == "Notification" {
-				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusWaiting}
-			}
-			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning}
-		},
-	}
-	m.registry.Register(provider)
-
-	m.sessions = &fakeSessionProvider{
-		sessions: []session.SessionInfo{{Code: "s1", Name: "work"}},
-	}
-	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
-
-	fake.SetPaneCommand("work:", "claude")
-	fake.SetPaneContent("work:", "Allow  Deny")
-	fake.SetPaneSessionName("%5", "work")
-
-	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":36649,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"Notification","raw_event":{"type":"notification","notification_type":"permission_prompt"},"agent_type":"cc"}`
-	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
-	w := httptest.NewRecorder()
-	m.handleEvent(w, req)
-
-	m.mu.Lock()
-	_, watching := m.activeWatchers["work"]
-	m.mu.Unlock()
-	if !watching {
-		t.Fatal("expected active watcher after waiting status")
-	}
-
-	time.Sleep(100 * time.Millisecond)
-	fake.SetPaneContent("work:", "⠋ Processing your request...")
-
-	time.Sleep(700 * time.Millisecond)
-
-	m.mu.Lock()
-	_, stillWatching := m.activeWatchers["work"]
-	status := m.currentStatus["work"]
-	m.mu.Unlock()
-
-	if stillWatching {
-		t.Fatal("watcher should have stopped after activity detection")
-	}
-	if status != agentpkg.StatusRunning {
-		t.Fatalf("expected status running after activity, got %s", status)
-	}
-}
+// Note (Commit 4 PR-4a-1): the legacy TestActivityWatch_YellowLightRecovery
+// test was deleted. Its semantics — yellow→running recovery via screen
+// activity — split across orchestrator unit tests (OR4 graceWindow expire +
+// OR9 ScreenChanged transition) where they can be exercised deterministically
+// without sleeping past poll intervals. The legacy test also relied on the
+// fire-once-then-stop-watching watcher contract that the dumb-probe v2.0
+// design intentionally retired.
 
 // --- Task 9: GET /api/agent/{agent}/statusline/status ---
 
@@ -1225,54 +1174,13 @@ func TestActivityWatch_StartsForRunningStatus(t *testing.T) {
 	}
 }
 
-func TestActivityWatch_ShellPromptDeadPidTriggersSweep(t *testing.T) {
-	t.Skip("Slice 3 — orchestrator-driven test arrives in Commit 4 (PR-4a-1)")
-	m := newTestModule(t)
-	fake := tmux.NewFakeExecutor()
-	fake.SetPaneSessionName("%5", "work")
-	m.tmux = fake
-	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
-	m.sessions = &fakeSessionProvider{
-		sessions: []session.SessionInfo{{Code: "s1", Name: "work"}},
-	}
-	if _, err := m.frames.Upsert(store.Frame{
-		PaneID:           "%5",
-		AgentType:        "codex",
-		PID:              200,
-		PPID:             100,
-		ProcessStartTime: "dead",
-		Status:           agentpkg.StatusRunning,
-		StartedAt:        10,
-		LastSeenAt:       10,
-		Verified:         true,
-	}); err != nil {
-		t.Fatalf("Upsert frame: %v", err)
-	}
-	m.currentStatus["work"] = agentpkg.StatusRunning
-	m.activeWatchers["work"] = "codex"
-	origAlive := isPidAliveFn
-	isPidAliveFn = func(pid int) bool { return false }
-	t.Cleanup(func() { isPidAliveFn = origAlive })
-
-	// Slice 3 — orchestrator wiring will reinstate the shell-prompt sweep
-	// path. For Commit 2 the body below is unreachable (t.Skip above) but
-	// kept compiling for the upcoming orchestrator test rewrite.
-	_ = m
-
-	if got := m.currentStatus["work"]; got != "" {
-		t.Fatalf("currentStatus = %q, want cleared", got)
-	}
-	frames, err := m.frames.ListByPane("%5")
-	if err != nil {
-		t.Fatalf("ListByPane: %v", err)
-	}
-	if len(frames) != 0 {
-		t.Fatalf("frame count = %d, want 0", len(frames))
-	}
-	if _, watching := m.activeWatchers["work"]; watching {
-		t.Fatal("watcher should be cleared after sweep")
-	}
-}
+// Note (Commit 4 PR-4a-1): the legacy
+// TestActivityWatch_ShellPromptDeadPidTriggersSweep test was deleted. Its
+// shell-prompt-on-dead-PID-sweeps-the-frame contract is now covered by
+// OR8 (TestOrchestrator_ScreenStableUsesBottomCaptureForShellPrompt), which
+// drives the orchestrator's interpretScreenEvent helper directly with an
+// independent bottom-capture (R14 fix #1) rather than relying on the
+// fire-once watcher contract retired in v2.0.
 
 // --- Task 10: POST /api/agent/{agent}/statusline/setup ---
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -273,7 +273,8 @@ func (m *Module) renameSessionLocked(oldName, newName string) {
 		// Restart watcher with new name
 		m.activeWatchers[newName] = agentType
 		if m.prober != nil {
-			m.prober.StartWatch(newName+":", m.onActivityDetected(newName, agentType))
+			// TODO Slice 3 — orchestrator wiring restores status-mapping callback.
+			m.prober.Watch(newName+":", probe.WatchOptions{}, func(probe.ScreenChangeEvent) {})
 		}
 	}
 }
@@ -437,7 +438,10 @@ func (m *Module) resolvePaneSession(paneID string) (string, string) {
 	return sessionName, m.resolveSessionCode(sessionName)
 }
 
-// manageActivityWatch handles starting/stopping Activity watchers in response to hook events.
+// manageActivityWatch handles starting/stopping Activity watchers in response
+// to hook events. The status-mapping callback (legacy onActivityDetected) is
+// intentionally a no-op in this commit; Slice 3 (Commit 3+4) wires the
+// orchestrator that interprets ScreenChangeEvent into status transitions.
 func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status) {
 	m.mu.Lock()
 	_, wasWatching := m.activeWatchers[session]
@@ -451,7 +455,9 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
 		m.mu.Lock()
 		m.activeWatchers[session] = agentType
 		m.mu.Unlock()
-		m.prober.StartWatch(session+":", m.onActivityDetected(session, agentType))
+		// TODO Slice 3 — orchestrator wiring will replace the no-op callback
+		// with a status-mapping handler driven by ProbeProfile.
+		m.prober.Watch(session+":", probe.WatchOptions{}, func(probe.ScreenChangeEvent) {})
 	}
 }
 
@@ -461,61 +467,5 @@ func shouldWatchActivity(status agentpkg.Status) bool {
 		return true
 	default:
 		return false
-	}
-}
-
-// onActivityDetected returns a callback for screen-activity transitions while a
-// waiting/running/idle session is being watched. The callback checks if the
-// watcher is still active and then maps the activity signal to a new status or
-// triggers a sweep hint for shell-prompt + dead-PID cases.
-func (m *Module) onActivityDetected(session, agentType string) func(string, probe.ActivitySignal) {
-	return func(target string, signal probe.ActivitySignal) {
-		m.mu.Lock()
-		if _, active := m.activeWatchers[session]; !active {
-			m.mu.Unlock()
-			return
-		}
-		delete(m.activeWatchers, session)
-		m.mu.Unlock()
-
-		status := agentpkg.StatusIdle
-		switch signal {
-		case probe.ActivitySignalRunning:
-			status = agentpkg.StatusRunning
-		case probe.ActivitySignalIdle:
-			status = agentpkg.StatusIdle
-		case probe.ActivitySignalShellPrompt:
-			projection, err := m.projectionForSession(session)
-			if err == nil && projection != nil && projection.TopFrame != nil && !isPidAliveFn(projection.TopFrame.PID) {
-				_ = m.sweepOnce()
-				return
-			}
-			status = agentpkg.StatusIdle
-		default:
-			return
-		}
-
-		// Issue #1: Error Guard — don't overwrite StatusError
-		m.mu.Lock()
-		if m.currentStatus[session] == agentpkg.StatusError {
-			m.mu.Unlock()
-			return // respect Error Guard
-		}
-		m.currentStatus[session] = status
-		m.mu.Unlock()
-
-		if projection, err := m.setProjectionTopStatus(session, status); err == nil && projection != nil {
-			normalized := buildProjectionNormalized(projection, agentType, "probe:activity", time.Now().UnixNano(), agentpkg.DeriveResult{})
-			m.broadcastToSession(session, normalized)
-			return
-		}
-
-		normalized := agentpkg.NormalizedEvent{
-			AgentType:    agentType,
-			Status:       string(status),
-			RawEventName: "probe:activity",
-			BroadcastTs:  time.Now().UnixNano(),
-		}
-		m.broadcastToSession(session, normalized)
 	}
 }

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -281,7 +281,19 @@ func (m *Module) renameSessionLocked(oldName, newName string) {
 		// + broadcast) so the renamed session keeps responding to screen events.
 		// nil-prober is handled inside startWatch/stopWatch (R14 fix).
 		m.probeOrch.stopWatch(oldName)
-		m.probeOrch.startWatch(newName, agentType)
+		if !m.probeOrch.startWatch(newName, agentType) {
+			// Codex finding #7 regression: invalid profile / nil prober — roll
+			// back the activeWatchers transfer so the orchestrator's stale-
+			// callback guard does not see a phantom watcher.
+			delete(m.activeWatchers, newName)
+		}
+		// Codex finding #2 regression: migrate the active graceWindow so a
+		// hook-set status that was just recorded under oldName cannot be
+		// overwritten by probe events arriving for newName within
+		// probeGraceWindow. Done AFTER orchestrator stop/start so it's
+		// clear that we preserve a brand-new graceWindow rather than
+		// starting fresh.
+		m.probeOrch.migrateLastHookAt(oldName, newName)
 	}
 }
 
@@ -467,7 +479,15 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
 		m.mu.Lock()
 		m.activeWatchers[session] = agentType
 		m.mu.Unlock()
-		m.probeOrch.startWatch(session, agentType)
+		if !m.probeOrch.startWatch(session, agentType) {
+			// Codex finding #7 regression: invalid profile / nil prober — roll
+			// back the activeWatchers entry so the stale-callback guard sees
+			// the session as not watched and /debug/vars stays consistent
+			// (no "started" without a registered watcher).
+			m.mu.Lock()
+			delete(m.activeWatchers, session)
+			m.mu.Unlock()
+		}
 	}
 }
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -35,8 +35,9 @@ type Module struct {
 	uploadDir string
 	traceSink *hookTraceSink
 
-	prober *probe.Prober
-	tmux   tmux.Executor
+	prober    *probe.Prober
+	probeOrch *probeOrchestrator
+	tmux      tmux.Executor
 
 	mu             sync.Mutex
 	currentStatus  map[string]agentpkg.Status
@@ -113,6 +114,11 @@ func New(events *store.AgentEventStore) (*Module, error) {
 	if traces != nil {
 		m.traceSink = newHookTraceSink(traces)
 	}
+	// probeOrchestrator owns probe-watcher lifecycle. Created here (not in
+	// Init) so it is always available for tests that bypass Init and assign
+	// m.prober directly. The orchestrator resolves m.prober lazily, so
+	// "AFTER prober is set" semantics hold at startWatch call time.
+	m.probeOrch = newProbeOrchestrator(m)
 	return m, nil
 }
 
@@ -439,25 +445,29 @@ func (m *Module) resolvePaneSession(paneID string) (string, string) {
 }
 
 // manageActivityWatch handles starting/stopping Activity watchers in response
-// to hook events. The status-mapping callback (legacy onActivityDetected) is
-// intentionally a no-op in this commit; Slice 3 (Commit 3+4) wires the
-// orchestrator that interprets ScreenChangeEvent into status transitions.
+// to hook events. Watcher lifecycle is delegated to probeOrchestrator, which
+// resolves the agent's ProbeProfile (default profile when the provider does
+// not implement agentpkg.ProbeProfileProvider). The screen-change callback
+// installed by the orchestrator is a no-op stub in Commit 3; Commit 4 wires
+// interpretScreenEvent (graceWindow + transition gate + Error Guard +
+// broadcast).
+//
+// R3 fix: m.activeWatchers is owned by this function (and renameSessionLocked
+// in Commit 5); the orchestrator deliberately does not touch it.
 func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status) {
 	m.mu.Lock()
 	_, wasWatching := m.activeWatchers[session]
 	delete(m.activeWatchers, session)
 	m.mu.Unlock()
 	if wasWatching {
-		m.prober.StopWatch(session + ":")
+		m.probeOrch.stopWatch(session)
 	}
 
 	if shouldWatchActivity(newStatus) {
 		m.mu.Lock()
 		m.activeWatchers[session] = agentType
 		m.mu.Unlock()
-		// TODO Slice 3 — orchestrator wiring will replace the no-op callback
-		// with a status-mapping handler driven by ProbeProfile.
-		m.prober.Watch(session+":", probe.WatchOptions{}, func(probe.ScreenChangeEvent) {})
+		m.probeOrch.startWatch(session, agentType)
 	}
 }
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -271,17 +271,17 @@ func (m *Module) renameSessionLocked(oldName, newName string) {
 		delete(m.currentStatus, oldName)
 	}
 	if agentType, ok := m.activeWatchers[oldName]; ok {
+		// activeWatchers transfer (m.mu-protected map mutation; caller holds m.mu).
 		delete(m.activeWatchers, oldName)
-		// Stop old watcher — callback closure captured oldName, can't reuse
-		if m.prober != nil {
-			m.prober.StopWatch(oldName + ":")
-		}
-		// Restart watcher with new name
 		m.activeWatchers[newName] = agentType
-		if m.prober != nil {
-			// TODO Slice 3 — orchestrator wiring restores status-mapping callback.
-			m.prober.Watch(newName+":", probe.WatchOptions{}, func(probe.ScreenChangeEvent) {})
-		}
+		// R2 fix #1 + R3 deadlock-freedom: orchestrator stop/start are lock-free
+		// wrt m.mu (they touch prober.watcherMu, a different mutex), so calling
+		// them while we hold m.mu is safe. The orchestrator restores the full
+		// status-mapping callback (graceWindow + transition gate + Error Guard
+		// + broadcast) so the renamed session keeps responding to screen events.
+		// nil-prober is handled inside startWatch/stopWatch (R14 fix).
+		m.probeOrch.stopWatch(oldName)
+		m.probeOrch.startWatch(newName, agentType)
 	}
 }
 

--- a/internal/module/agent/probe_orchestrator.go
+++ b/internal/module/agent/probe_orchestrator.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"sync"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/probe"
+)
+
+// proberWatcher is the minimal screen-watcher contract the orchestrator
+// depends on. *probe.Prober trivially satisfies it; tests inject a recording
+// fake. Kept unexported so the seam is scoped to this file.
+type proberWatcher interface {
+	Watch(target string, opts probe.WatchOptions, cb probe.ScreenChangeCallback)
+	StopWatch(target string)
+}
+
+// defaultProbeProfile is the fallback profile used when an agent provider
+// does not implement agentpkg.ProbeProfileProvider.
+//
+// R9 fix: BottomLines (not TopLines) preserves legacy
+// CapturePaneContent(target, 10) capture region for codex / opencode in
+// PR-4a-1, satisfying the §6 G5 default-profile parity gate. Per-agent
+// TopLines profiles arrive in PR-4a-2 (cc) and beyond.
+var defaultProbeProfile = agentpkg.ProbeProfile{BottomLines: 10, IdleStableTicks: 3}
+
+// probeOrchestrator owns the per-session probe-watcher lifecycle.
+//
+// In Commit 3 (this slice) it only resolves the agent's ProbeProfile and
+// starts/stops watchers via the prober. The screen-change callback is a
+// no-op stub — Commit 4 wires interpretScreenEvent (graceWindow + transition
+// gate + Error Guard + broadcast).
+//
+// R3 fix: orchestrator deliberately does NOT touch m.activeWatchers. That
+// map is owned by Module.manageActivityWatch / renameSessionLocked callers,
+// which already serialize updates under m.mu. Keeping the orchestrator
+// lock-free with respect to m.mu lets renameSessionLocked invoke
+// stopWatch/startWatch while holding m.mu without deadlocking.
+type probeOrchestrator struct {
+	parent *Module
+
+	// watcher overrides parent.prober when non-nil. Tests inject a recording
+	// fake here; production leaves it nil so prober() falls through to
+	// parent.prober (set during Module.Init).
+	watcher proberWatcher
+
+	// graceMu / lastHookAt are placeholders for Commit 4 (recordHookAt +
+	// graceWindow). Declared here so the struct shape is stable across
+	// commits; not consumed in Commit 3.
+	graceMu    sync.Mutex
+	lastHookAt map[string]time.Time
+}
+
+// newProbeOrchestrator returns a fresh orchestrator bound to m. Called from
+// Module.New so the orchestrator is always available; the prober itself is
+// resolved lazily inside startWatch/stopWatch (it isn't assigned until
+// Module.Init).
+func newProbeOrchestrator(m *Module) *probeOrchestrator {
+	return &probeOrchestrator{
+		parent:     m,
+		lastHookAt: make(map[string]time.Time),
+	}
+}
+
+// prober returns the active proberWatcher: the test override if set,
+// otherwise the Module's *probe.Prober. Returns nil when no prober has been
+// wired (R14 fix nil-prober guard for partially-initialized Module fixtures).
+func (o *probeOrchestrator) prober() proberWatcher {
+	if o.watcher != nil {
+		return o.watcher
+	}
+	if o.parent == nil || o.parent.prober == nil {
+		return nil
+	}
+	return o.parent.prober
+}
+
+// startWatch resolves the agent's ProbeProfile and starts a probe watcher.
+//
+// Caller passes session WITHOUT the ":" suffix; orchestrator appends it to
+// match the existing tmux-target convention (R7 fix).
+//
+// Profile resolution (R8 fix): looks up the provider via parent.registry.Get
+// and asserts agentpkg.ProbeProfileProvider. Missing agentType or providers
+// that don't implement the interface fall back to defaultProbeProfile.
+func (o *probeOrchestrator) startWatch(session, agentType string) {
+	pw := o.prober()
+	if pw == nil {
+		return
+	}
+	target := session + ":"
+
+	profile := defaultProbeProfile
+	if o.parent != nil && o.parent.registry != nil {
+		if provider, ok := o.parent.registry.Get(agentType); ok {
+			if pp, ok := provider.(agentpkg.ProbeProfileProvider); ok {
+				profile = pp.ProbeProfile()
+			}
+		}
+	}
+
+	opts := probe.WatchOptions{
+		TopLines:        profile.TopLines,
+		BottomLines:     profile.BottomLines,
+		IdleStableTicks: profile.IdleStableTicks,
+	}
+	pw.Watch(target, opts, o.makeCallback(session, agentType))
+}
+
+// stopWatch cancels the watcher for session. Same ":" suffix convention as
+// startWatch (R7 fix); symmetric nil-prober guard (R14 fix).
+func (o *probeOrchestrator) stopWatch(session string) {
+	pw := o.prober()
+	if pw == nil {
+		return
+	}
+	pw.StopWatch(session + ":")
+}
+
+// makeCallback returns the ScreenChangeCallback installed on Watch. In
+// Commit 3 it is intentionally a no-op stub — Commit 4 replaces the body
+// with interpretScreenEvent (stale-callback guard / graceWindow / Error
+// Guard / transition gate / broadcast). The closure already captures
+// session + agentType so Commit 4 can wire those through without changing
+// the registration site.
+func (o *probeOrchestrator) makeCallback(session, agentType string) probe.ScreenChangeCallback {
+	_ = session
+	_ = agentType
+	return func(probe.ScreenChangeEvent) {
+		// TODO Commit 4: invoke o.interpretScreenEvent(session, agentType, ev).
+	}
+}

--- a/internal/module/agent/probe_orchestrator.go
+++ b/internal/module/agent/probe_orchestrator.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"log"
+	"os"
 	"sync"
 	"time"
 
@@ -25,12 +27,40 @@ type proberWatcher interface {
 // TopLines profiles arrive in PR-4a-2 (cc) and beyond.
 var defaultProbeProfile = agentpkg.ProbeProfile{BottomLines: 10, IdleStableTicks: 3}
 
-// probeOrchestrator owns the per-session probe-watcher lifecycle.
+// probeGraceWindow is the post-recordHookAt suppression window. While
+// active, every screen-change event for the session is dropped (counter
+// +1 each) so a hook event remains the authoritative status source for the
+// duration of the window. v2.0 design: probe is dumb and keeps emitting
+// raw events; once the window expires the next ScreenChanged / ScreenStable
+// event naturally drives a transition via the gate (no Rearm API needed).
+const probeGraceWindow = 2 * time.Second
+
+// orchNowFn is the test-only seam used by graceWindow checks. Production
+// uses time.Now; OR4 overrides this to fast-forward past probeGraceWindow
+// without sleeping. Package-private so the production path stays uncluttered.
+var orchNowFn = time.Now
+
+// isDevMode reports whether the daemon is running with PDX_DEV_MODE=1. Probe
+// log gating uses this so production logs stay quiet. We read the env on
+// every call so flipping the var at runtime (e.g. in tests via t.Setenv)
+// flips the gate.
 //
-// In Commit 3 (this slice) it only resolves the agent's ProbeProfile and
-// starts/stops watchers via the prober. The screen-change callback is a
-// no-op stub — Commit 4 wires interpretScreenEvent (graceWindow + transition
-// gate + Error Guard + broadcast).
+// Defined locally to avoid importing the dev module (would create a circular
+// dependency) — the env-var read is the cheapest possible check anyway.
+func isDevMode() bool { return os.Getenv("PDX_DEV_MODE") == "1" }
+
+// probeOrchestrator owns the per-session probe-watcher lifecycle and
+// translates raw probe.ScreenChangeEvent ticks into agent status broadcasts.
+//
+// Lifecycle (v2.0 — dumb probe, orchestrator-only dedup):
+//   - startWatch resolves the agent's ProbeProfile, registers a callback
+//     bound to (session, agentType), and increments MetricProbeWatchStarted
+//   - The watcher fires ScreenChanged on every diff tick + ScreenStable
+//     after IdleStableTicks consecutive matches (no emit-once flags)
+//   - interpretScreenEvent applies guards (stale-callback, graceWindow,
+//     ErrorGuard) and a v2.0 transition gate before broadcasting; the gate
+//     suppresses repeats so probe storms cannot saturate WS clients
+//   - stopWatch tears the watcher down + increments MetricProbeWatchStopped
 //
 // R3 fix: orchestrator deliberately does NOT touch m.activeWatchers. That
 // map is owned by Module.manageActivityWatch / renameSessionLocked callers,
@@ -45,9 +75,9 @@ type probeOrchestrator struct {
 	// parent.prober (set during Module.Init).
 	watcher proberWatcher
 
-	// graceMu / lastHookAt are placeholders for Commit 4 (recordHookAt +
-	// graceWindow). Declared here so the struct shape is stable across
-	// commits; not consumed in Commit 3.
+	// graceMu protects lastHookAt. Independent of parent.mu so recordHookAt
+	// (called from the hook hot-path) does not contend with currentStatus
+	// readers. Always acquired alone — never nest with parent.mu.
 	graceMu    sync.Mutex
 	lastHookAt map[string]time.Time
 }
@@ -106,6 +136,7 @@ func (o *probeOrchestrator) startWatch(session, agentType string) {
 		IdleStableTicks: profile.IdleStableTicks,
 	}
 	pw.Watch(target, opts, o.makeCallback(session, agentType))
+	agentpkg.MetricProbeWatchStarted.Add(1)
 }
 
 // stopWatch cancels the watcher for session. Same ":" suffix convention as
@@ -116,18 +147,136 @@ func (o *probeOrchestrator) stopWatch(session string) {
 		return
 	}
 	pw.StopWatch(session + ":")
+	agentpkg.MetricProbeWatchStopped.Add(1)
 }
 
-// makeCallback returns the ScreenChangeCallback installed on Watch. In
-// Commit 3 it is intentionally a no-op stub — Commit 4 replaces the body
-// with interpretScreenEvent (stale-callback guard / graceWindow / Error
-// Guard / transition gate / broadcast). The closure already captures
-// session + agentType so Commit 4 can wire those through without changing
-// the registration site.
-func (o *probeOrchestrator) makeCallback(session, agentType string) probe.ScreenChangeCallback {
-	_ = session
-	_ = agentType
-	return func(probe.ScreenChangeEvent) {
-		// TODO Commit 4: invoke o.interpretScreenEvent(session, agentType, ev).
+// recordHookAt registers a hook acceptance timestamp for session. Subsequent
+// screen-change events arriving within probeGraceWindow of this timestamp are
+// suppressed by interpretScreenEvent so the hook (the authoritative source)
+// stays in charge while the agent is mid-transition.
+func (o *probeOrchestrator) recordHookAt(session string) {
+	o.graceMu.Lock()
+	o.lastHookAt[session] = orchNowFn()
+	o.graceMu.Unlock()
+	if isDevMode() {
+		log.Printf("[probe] recordHookAt session=%s", session)
 	}
+}
+
+// makeCallback returns the ScreenChangeCallback installed on Watch. The
+// closure captures (session, agentType) so the stale-callback guard inside
+// interpretScreenEvent can detect rename / agent-swap mismatches against
+// the parent's activeWatchers map.
+func (o *probeOrchestrator) makeCallback(session, agentType string) probe.ScreenChangeCallback {
+	return func(ev probe.ScreenChangeEvent) {
+		o.interpretScreenEvent(session, agentType, ev)
+	}
+}
+
+// interpretScreenEvent maps a raw probe.ScreenChangeEvent to a status
+// transition (or drops it). Guards run in this order — each layer encodes
+// a specific invariant:
+//
+//  1. Stale-callback guard (R4): activeWatchers must contain (session →
+//     agentType). After stopWatch / rename the closure may still be invoked
+//     by the watch loop; we drop these events to avoid ghost broadcasts.
+//  2. graceWindow suppression (v2.0): events within probeGraceWindow of a
+//     recordHookAt are dropped + counted. Hook authority over probe.
+//  3. Kind → status mapping: ScreenChanged → Running; ScreenStable →
+//     independent bottom capture (R14 fix #1) for shell-prompt
+//     classification → Idle (or sweep on dead-PID + shell prompt).
+//  4. Error Guard: never overwrite StatusError; probe is recovery-only.
+//  5. Transition gate (v2.0): same currentStatus → drop. Probe storms cannot
+//     saturate WS clients; first transition wins, repeats stay silent.
+//  6. Apply: setProjectionTopStatus + buildProjectionNormalized + broadcast.
+//     MetricProbeScreenEvent +1 only here.
+func (o *probeOrchestrator) interpretScreenEvent(session, agentType string, ev probe.ScreenChangeEvent) {
+	if o.parent == nil {
+		return
+	}
+	m := o.parent
+
+	// 1. Stale-callback guard.
+	m.mu.Lock()
+	currentAgent, active := m.activeWatchers[session]
+	m.mu.Unlock()
+	if !active || currentAgent != agentType {
+		return
+	}
+
+	// 2. graceWindow suppression.
+	o.graceMu.Lock()
+	last, hasHook := o.lastHookAt[session]
+	o.graceMu.Unlock()
+	if hasHook && orchNowFn().Sub(last) < probeGraceWindow {
+		agentpkg.MetricProbeGraceWindowSuppressed.Add(1)
+		if isDevMode() {
+			log.Printf("[probe] graceWindow suppress session=%s agent=%s kind=%s", session, agentType, ev.Kind)
+		}
+		return
+	}
+
+	// 3. Kind → status mapping.
+	var status agentpkg.Status
+	switch ev.Kind {
+	case probe.ScreenChanged:
+		status = agentpkg.StatusRunning
+	case probe.ScreenStable:
+		// R14 fix #1: ev.Content reflects the watcher's TopLines / BottomLines
+		// configuration. For agents on a TopLines profile the captured content
+		// won't include the bottom shell prompt, so LooksLikeShellPrompt would
+		// false-negative. Take an independent bottom-N capture for the
+		// shell-prompt classifier; treat any tmux error as "not a shell
+		// prompt" (conservative — fall through to Idle, never block).
+		var bottomContent string
+		if m.tmux != nil {
+			if c, err := m.tmux.CapturePaneContent(session+":", 10); err == nil {
+				bottomContent = c
+			}
+		}
+		if probe.LooksLikeShellPrompt(bottomContent) {
+			projection, _ := m.projectionForSession(session)
+			if projection != nil && projection.TopFrame != nil && !isPidAliveFn(projection.TopFrame.PID) {
+				_ = m.sweepOnce()
+				return
+			}
+		}
+		status = agentpkg.StatusIdle
+	default:
+		return
+	}
+
+	// 4. Error Guard + 5. Transition gate (single critical section).
+	m.mu.Lock()
+	if m.currentStatus[session] == agentpkg.StatusError {
+		m.mu.Unlock()
+		return
+	}
+	if prev, ok := m.currentStatus[session]; ok && prev == status {
+		m.mu.Unlock()
+		return
+	}
+	m.currentStatus[session] = status
+	m.mu.Unlock()
+
+	// 6. Apply transition.
+	agentpkg.MetricProbeScreenEvent.Add(1)
+	if isDevMode() {
+		log.Printf("[probe] status session=%s agent=%s status=%s reason=screen-%s", session, agentType, status, ev.Kind)
+	}
+	if projection, err := m.setProjectionTopStatus(session, status); err == nil && projection != nil {
+		normalized := buildProjectionNormalized(projection, agentType, "probe:activity", time.Now().UnixNano(), agentpkg.DeriveResult{})
+		m.broadcastToSession(session, normalized)
+		return
+	}
+	// Fallback when the projection is unavailable (e.g. frames row removed
+	// concurrently with the screen event). Broadcast a minimal normalized
+	// event so SPA clients still see the status change.
+	normalized := agentpkg.NormalizedEvent{
+		AgentType:    agentType,
+		Status:       string(status),
+		RawEventName: "probe:activity",
+		BroadcastTs:  time.Now().UnixNano(),
+	}
+	m.broadcastToSession(session, normalized)
 }

--- a/internal/module/agent/probe_orchestrator.go
+++ b/internal/module/agent/probe_orchestrator.go
@@ -40,6 +40,18 @@ const probeGraceWindow = 2 * time.Second
 // without sleeping. Package-private so the production path stays uncluttered.
 var orchNowFn = time.Now
 
+// recordHookAtHook is a test-only order-witness seam. Production leaves it
+// nil. Tests set it to capture in-memory state at the moment recordHookAt
+// fires, used by FX2 to verify recordHookAt runs BEFORE the handler's
+// currentStatus mutation (codex finding #3 regression).
+var recordHookAtHook func(session string)
+
+// interruptBeforeFinalLockFn is a test-only seam invoked just before the
+// final m.mu critical section in interpretScreenEvent. Production leaves it
+// nil. Tests set it to mutate activeWatchers concurrently — exercising the
+// atomic stale-callback re-check (codex finding #4 regression).
+var interruptBeforeFinalLockFn func(session string)
+
 // isDevMode reports whether the daemon is running with PDX_DEV_MODE=1. Probe
 // log gating uses this so production logs stay quiet. We read the env on
 // every call so flipping the var at runtime (e.g. in tests via t.Setenv)
@@ -114,10 +126,18 @@ func (o *probeOrchestrator) prober() proberWatcher {
 // Profile resolution (R8 fix): looks up the provider via parent.registry.Get
 // and asserts agentpkg.ProbeProfileProvider. Missing agentType or providers
 // that don't implement the interface fall back to defaultProbeProfile.
-func (o *probeOrchestrator) startWatch(session, agentType string) {
+//
+// Returns true iff a watcher was successfully registered. The caller
+// (manageActivityWatch / renameSessionLocked) uses this to roll back its
+// activeWatchers mutation when the profile is invalid (TopLines + BottomLines
+// mutually exclusive — probe.Watch would log + early-return without
+// registering, leaving a silent dead watcher otherwise; codex finding #7
+// regression). Returning false also skips the started-metric increment so
+// /debug/vars stays an honest counter of registered watchers.
+func (o *probeOrchestrator) startWatch(session, agentType string) bool {
 	pw := o.prober()
 	if pw == nil {
-		return
+		return false
 	}
 	target := session + ":"
 
@@ -130,6 +150,19 @@ func (o *probeOrchestrator) startWatch(session, agentType string) {
 		}
 	}
 
+	// Profile validation — must mirror probe.Watch's contract (TopLines +
+	// BottomLines mutually exclusive). Validating here lets the caller roll
+	// back its activeWatchers entry; without this, probe.Watch silently
+	// drops the call and the orchestrator is left with a "started" metric
+	// + an active map entry but no goroutine.
+	if profile.TopLines > 0 && profile.BottomLines > 0 {
+		if isDevMode() {
+			log.Printf("[probe] startWatch invalid profile session=%s agent=%s TopLines=%d BottomLines=%d — mutually exclusive; not registering",
+				session, agentType, profile.TopLines, profile.BottomLines)
+		}
+		return false
+	}
+
 	opts := probe.WatchOptions{
 		TopLines:        profile.TopLines,
 		BottomLines:     profile.BottomLines,
@@ -137,6 +170,7 @@ func (o *probeOrchestrator) startWatch(session, agentType string) {
 	}
 	pw.Watch(target, opts, o.makeCallback(session, agentType))
 	agentpkg.MetricProbeWatchStarted.Add(1)
+	return true
 }
 
 // stopWatch cancels the watcher for session. Same ":" suffix convention as
@@ -158,8 +192,25 @@ func (o *probeOrchestrator) recordHookAt(session string) {
 	o.graceMu.Lock()
 	o.lastHookAt[session] = orchNowFn()
 	o.graceMu.Unlock()
+	if hook := recordHookAtHook; hook != nil {
+		hook(session)
+	}
 	if isDevMode() {
 		log.Printf("[probe] recordHookAt session=%s", session)
+	}
+}
+
+// migrateLastHookAt transfers the lastHookAt entry from oldName to newName
+// under graceMu, preserving the active graceWindow across a session rename.
+// Codex finding #2 regression: without this, the orchestrator's screen-event
+// callback for newName would observe "no graceWindow active" within 2s of
+// rename and overwrite the hook-set status. No-op when oldName has no entry.
+func (o *probeOrchestrator) migrateLastHookAt(oldName, newName string) {
+	o.graceMu.Lock()
+	defer o.graceMu.Unlock()
+	if stamp, ok := o.lastHookAt[oldName]; ok {
+		delete(o.lastHookAt, oldName)
+		o.lastHookAt[newName] = stamp
 	}
 }
 
@@ -180,11 +231,19 @@ func (o *probeOrchestrator) makeCallback(session, agentType string) probe.Screen
 //  1. Stale-callback guard (R4): activeWatchers must contain (session →
 //     agentType). After stopWatch / rename the closure may still be invoked
 //     by the watch loop; we drop these events to avoid ghost broadcasts.
+//     Run as an EARLY fast-path AND re-checked atomically inside the final
+//     critical section (codex finding #4 regression — closes the race
+//     window between the early unlock and the final lock).
 //  2. graceWindow suppression (v2.0): events within probeGraceWindow of a
 //     recordHookAt are dropped + counted. Hook authority over probe.
 //  3. Kind → status mapping: ScreenChanged → Running; ScreenStable →
 //     independent bottom capture (R14 fix #1) for shell-prompt
-//     classification → Idle (or sweep on dead-PID + shell prompt).
+//     classification → Idle (or sweep on dead-PID + shell prompt). Cheap
+//     pre-gate (codex finding #8): a stable-Idle session with an alive
+//     top-frame PID skips the bottom CapturePaneContent entirely — there
+//     is no possible transition (gate would skip Idle→Idle anyway) and no
+//     cleanup work (sweep needs dead PID + shell prompt). Continuous-stable
+//     panes therefore stop issuing tmux subprocess calls every N ticks.
 //  4. Error Guard: never overwrite StatusError; probe is recovery-only.
 //  5. Transition gate (v2.0): same currentStatus → drop. Probe storms cannot
 //     saturate WS clients; first transition wins, repeats stay silent.
@@ -196,9 +255,10 @@ func (o *probeOrchestrator) interpretScreenEvent(session, agentType string, ev p
 	}
 	m := o.parent
 
-	// 1. Stale-callback guard.
+	// 1. Stale-callback guard (early fast-path).
 	m.mu.Lock()
 	currentAgent, active := m.activeWatchers[session]
+	prevStatus, hasPrev := m.currentStatus[session]
 	m.mu.Unlock()
 	if !active || currentAgent != agentType {
 		return
@@ -222,6 +282,20 @@ func (o *probeOrchestrator) interpretScreenEvent(session, agentType string, ev p
 	case probe.ScreenChanged:
 		status = agentpkg.StatusRunning
 	case probe.ScreenStable:
+		// Cheap pre-gate (codex finding #8): if already Idle and top-frame
+		// PID is alive, the bottom capture would only feed a transition
+		// gate that's about to drop Idle→Idle. Continuous-stable Idle
+		// panes are common (a session sitting at a shell prompt) — skipping
+		// the tmux subprocess here is a measurable cost win. Dead-PID
+		// branch falls through so the sweep cleanup path keeps working.
+		if hasPrev && prevStatus == agentpkg.StatusIdle {
+			projection, _ := m.projectionForSession(session)
+			if projection == nil || projection.TopFrame == nil || isPidAliveFn(projection.TopFrame.PID) {
+				return
+			}
+			// Stable Idle + dead PID: fall through to bottom capture for
+			// shell-prompt classification + sweep cleanup.
+		}
 		// R14 fix #1: ev.Content reflects the watcher's TopLines / BottomLines
 		// configuration. For agents on a TopLines profile the captured content
 		// won't include the bottom shell prompt, so LooksLikeShellPrompt would
@@ -246,8 +320,23 @@ func (o *probeOrchestrator) interpretScreenEvent(session, agentType string, ev p
 		return
 	}
 
-	// 4. Error Guard + 5. Transition gate (single critical section).
+	// Test-only seam: simulate a concurrent stop/rename that mutates
+	// activeWatchers between the early fast-path and the final critical
+	// section. Production leaves interruptBeforeFinalLockFn nil (no-op).
+	if hook := interruptBeforeFinalLockFn; hook != nil {
+		hook(session)
+	}
+
+	// 1 (re-check) + 4. Error Guard + 5. Transition gate.
+	// Single critical section; the re-check of activeWatchers closes the
+	// race window where stopWatch/rename mutated the map between the early
+	// unlock at step 1 and this lock (codex finding #4 regression).
 	m.mu.Lock()
+	currentAgent, active = m.activeWatchers[session]
+	if !active || currentAgent != agentType {
+		m.mu.Unlock()
+		return
+	}
 	if m.currentStatus[session] == agentpkg.StatusError {
 		m.mu.Unlock()
 		return

--- a/internal/module/agent/probe_orchestrator_integration_test.go
+++ b/internal/module/agent/probe_orchestrator_integration_test.go
@@ -1,0 +1,317 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/probe"
+	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/session"
+	"github.com/wake/purdex/internal/tmux"
+)
+
+// CC2 — manageActivityWatch routes through the orchestrator. Uses the
+// recording fake from probe_orchestrator_test.go: when manageActivityWatch
+// hands a watch-eligible status it must call orchestrator.startWatch (which
+// invokes recordingProber.Watch with target="sess:"); when it hands an
+// off-style status the recording prober must observe StopWatch("sess:").
+func TestModule_ManageActivityWatch_RoutesThroughOrchestrator(t *testing.T) {
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+	provider := &fakeAgentProvider{typeName: "cc"}
+	m.registry.Register(provider)
+
+	// waiting → start watch
+	m.manageActivityWatch("sess", "cc", agentpkg.StatusWaiting)
+
+	rec.mu.Lock()
+	if _, ok := rec.watchOpts["sess:"]; !ok {
+		rec.mu.Unlock()
+		t.Fatalf("expected Watch on target %q after StatusWaiting, got %v", "sess:", rec.watchOpts)
+	}
+	rec.mu.Unlock()
+
+	// off (anything not in shouldWatchActivity, e.g. StatusError) → stop watch
+	m.manageActivityWatch("sess", "cc", agentpkg.StatusError)
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	stopped := false
+	for _, target := range rec.stops {
+		if target == "sess:" {
+			stopped = true
+			break
+		}
+	}
+	if !stopped {
+		t.Fatalf("expected StopWatch on target %q after off-status, got %v", "sess:", rec.stops)
+	}
+}
+
+// CC2b — G6 watcher-leak gate (R15 fix #2). End-to-end integration test
+// using a REAL *probe.Prober (no recordingProber seam) so failures surface
+// the actual map state. Walks: waiting → assert activeWatchers and prober
+// HasWatcher are populated → off → assert both are cleared.
+func TestModule_ManageActivityWatch_OffClearsActiveWatchers(t *testing.T) {
+	m := newTestModule(t)
+	// Real prober wired against a fake tmux executor. The watcher goroutine
+	// ticks at watchPollInterval (default 500ms) but this test only inspects
+	// map state immediately after Watch / StopWatch — no need to override
+	// the cadence.
+	fake := tmux.NewFakeExecutor()
+	fake.SetPaneContent("sess:", "irrelevant")
+	m.tmux = fake
+	m.prober = probe.New(fake)
+	t.Cleanup(func() { m.prober.StopAllWatches() })
+
+	// fakeAgentProvider does not implement ProbeProfileProvider — orchestrator
+	// will use defaultProbeProfile (BottomLines=10), which is fine for this
+	// gate; we only care about lifecycle, not capture mode.
+	provider := &fakeAgentProvider{typeName: "cc"}
+	m.registry.Register(provider)
+
+	// waiting → watcher live + activeWatchers populated.
+	m.manageActivityWatch("sess", "cc", agentpkg.StatusWaiting)
+
+	m.mu.Lock()
+	if got, ok := m.activeWatchers["sess"]; !ok || got != "cc" {
+		m.mu.Unlock()
+		t.Fatalf("activeWatchers[sess] = (%q, %v), want (\"cc\", true)", got, ok)
+	}
+	m.mu.Unlock()
+	if !m.prober.HasWatcher("sess:") {
+		t.Fatalf("prober.HasWatcher(\"sess:\") = false, want true after StatusWaiting")
+	}
+
+	// off (StatusError → not in shouldWatchActivity) → watcher torn down +
+	// activeWatchers entry gone.
+	m.manageActivityWatch("sess", "cc", agentpkg.StatusError)
+
+	m.mu.Lock()
+	if _, ok := m.activeWatchers["sess"]; ok {
+		m.mu.Unlock()
+		t.Fatalf("activeWatchers[sess] still present after StatusOff (G6 watcher leak)")
+	}
+	m.mu.Unlock()
+	if m.prober.HasWatcher("sess:") {
+		t.Fatalf("prober.HasWatcher(\"sess:\") = true, want false after StatusOff (G6 watcher leak)")
+	}
+}
+
+// CC3 — hook handler calls recordHookAt. Verifies the wiring put in place
+// in Commit 4 (handler.go calls m.probeOrch.recordHookAt before
+// manageActivityWatch). Confirms lastHookAt[session] is populated within the
+// test horizon.
+func TestModule_HookHandler_CallsRecordHookAt(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive: func(string, json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusWaiting}
+		},
+	})
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+
+	before := time.Now()
+	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"UserPromptSubmit","raw_event":{},"agent_type":"cc"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	m.probeOrch.graceMu.Lock()
+	stamp, ok := m.probeOrch.lastHookAt["work"]
+	m.probeOrch.graceMu.Unlock()
+	if !ok {
+		t.Fatalf("lastHookAt[work] missing — handler did not call recordHookAt")
+	}
+	if stamp.Before(before) {
+		t.Fatalf("lastHookAt[work] = %v, want >= %v", stamp, before)
+	}
+}
+
+// CC4 — E2E ScreenChanged → broadcast Running. cc registered with its real
+// ProbeProfile (TopLines=12). manageActivityWatch starts the watcher, then
+// we feed a ScreenChanged event through the orchestrator's callback and
+// assert the WS broadcast carries StatusRunning.
+func TestCC_E2E_ScreenChangedToRunning(t *testing.T) {
+	m, _, _ := orchTestModule(t) // installs recordingProber + cc registry
+	seedOrchFrame(t, m, agentpkg.StatusWaiting, 280)
+
+	// manageActivityWatch starts the watcher (recording fake observes it).
+	m.manageActivityWatch("work", "cc", agentpkg.StatusWaiting)
+
+	m.mu.Lock()
+	if got, ok := m.activeWatchers["work"]; !ok || got != "cc" {
+		m.mu.Unlock()
+		t.Fatalf("activeWatchers[work] = (%q, %v) after manageActivityWatch", got, ok)
+	}
+	m.currentStatus["work"] = agentpkg.StatusWaiting
+	m.mu.Unlock()
+
+	// Subscribe BEFORE firing the event so the broadcast is observed.
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+
+	select {
+	case msg := <-sub.SendCh():
+		var env struct {
+			Type    string `json:"type"`
+			Session string `json:"session"`
+			Value   string `json:"value"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		if env.Type != "hook" {
+			t.Fatalf("broadcast type = %q, want hook", env.Type)
+		}
+		if env.Session != "s1" {
+			t.Fatalf("broadcast session = %q, want s1", env.Session)
+		}
+		if !strings.Contains(env.Value, `"status":"running"`) {
+			t.Fatalf("broadcast value missing status=running: %s", env.Value)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for ScreenChanged → Running broadcast")
+	}
+
+	m.mu.Lock()
+	got := m.currentStatus["work"]
+	m.mu.Unlock()
+	if got != agentpkg.StatusRunning {
+		t.Fatalf("currentStatus[work] = %q, want StatusRunning", got)
+	}
+}
+
+// CC5 — E2E ScreenStable → broadcast Idle. cc running, ScreenStable arrives
+// with bottom-capture (independent of ev.Content) returning prose (no shell
+// prompt) → orchestrator broadcasts Idle.
+func TestCC_E2E_ScreenStableToIdle(t *testing.T) {
+	m, _, fake := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusRunning, 281)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+	// Bottom capture returns text without a shell prompt → routes to Idle.
+	fake.setCaptureFn(func(string, int) (string, error) {
+		return "user typed prose\nmore prose", nil
+	})
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", Content: "irrelevant", OccurredAt: time.Now()})
+
+	select {
+	case msg := <-sub.SendCh():
+		var env struct {
+			Type    string `json:"type"`
+			Session string `json:"session"`
+			Value   string `json:"value"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		if env.Type != "hook" {
+			t.Fatalf("broadcast type = %q, want hook", env.Type)
+		}
+		if env.Session != "s1" {
+			t.Fatalf("broadcast session = %q, want s1", env.Session)
+		}
+		if !strings.Contains(env.Value, `"status":"idle"`) {
+			t.Fatalf("broadcast value missing status=idle: %s", env.Value)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for ScreenStable → Idle broadcast")
+	}
+
+	m.mu.Lock()
+	got := m.currentStatus["work"]
+	m.mu.Unlock()
+	if got != agentpkg.StatusIdle {
+		t.Fatalf("currentStatus[work] = %q, want StatusIdle", got)
+	}
+}
+
+// CC6 — RenameSession routes through orchestrator (R2 fix #1). The watcher
+// for `oldname` must be torn down and a new watcher started for `newname`,
+// with the activeWatchers map atomically transferred. The whole rename runs
+// under m.mu (caller contract); the orchestrator deliberately does NOT
+// touch m.mu, so the call must complete promptly. We enforce a 100ms
+// fail-loud guard so a regression that re-enters m.mu fails the test
+// (R3 deadlock-freedom regression).
+func TestCC_RenameSession_RestartsWatchViaOrchestrator(t *testing.T) {
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+	provider := &fakeAgentProvider{typeName: "cc"}
+	m.registry.Register(provider)
+
+	// Pre-state: oldname is being watched by cc.
+	m.mu.Lock()
+	m.activeWatchers["oldname"] = "cc"
+	m.mu.Unlock()
+	// Pre-record a Watch entry so the rec fake's pre-state matches a real
+	// watcher (orchestrator doesn't read this; we assert post-state instead).
+
+	// Deadlock guard: rename should complete well within 100ms. If a
+	// regression re-enters m.mu inside orchestrator calls, the rename hangs
+	// and this fires.
+	done := make(chan struct{})
+	go func() {
+		m.RenameSession("oldname", "newname")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("RenameSession hung — likely deadlock re-entering m.mu inside orchestrator")
+	}
+
+	// Post-state: activeWatchers transferred.
+	m.mu.Lock()
+	if _, ok := m.activeWatchers["oldname"]; ok {
+		m.mu.Unlock()
+		t.Fatalf("activeWatchers[oldname] still present after rename")
+	}
+	if got, ok := m.activeWatchers["newname"]; !ok || got != "cc" {
+		m.mu.Unlock()
+		t.Fatalf("activeWatchers[newname] = (%q, %v), want (\"cc\", true)", got, ok)
+	}
+	m.mu.Unlock()
+
+	// Recording fake observed exactly one StopWatch + one Watch with the new
+	// target.
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.stops) != 1 || rec.stops[0] != "oldname:" {
+		t.Fatalf("recordingProber stops = %v, want [oldname:]", rec.stops)
+	}
+	if _, ok := rec.watchOpts["newname:"]; !ok {
+		t.Fatalf("recordingProber watchOpts missing newname:; got %v", rec.watchOpts)
+	}
+	if _, ok := rec.watchOpts["oldname:"]; ok {
+		t.Fatalf("recordingProber watchOpts unexpectedly contains oldname:; got %v", rec.watchOpts)
+	}
+}

--- a/internal/module/agent/probe_orchestrator_integration_test.go
+++ b/internal/module/agent/probe_orchestrator_integration_test.go
@@ -145,6 +145,67 @@ func TestModule_HookHandler_CallsRecordHookAt(t *testing.T) {
 	}
 }
 
+// FX2 — handler calls recordHookAt BEFORE the m.mu critical section that
+// writes currentStatus. Regression for codex finding #3 (R2 attack HIGH):
+// the previous order let an in-flight probe callback observe the new
+// currentStatus while lastHookAt was still empty — the graceWindow check
+// passed and the probe overwrote authoritative hook status.
+//
+// Order-witness: install recordHookAtHook (test-only seam) that captures
+// the value of currentStatus[session] at the moment recordHookAt fires.
+// If recordHookAt runs first (correct order), the captured value is the
+// pre-hook empty/legacy state; if currentStatus is written first (broken
+// order), the captured value is the new result.Status.
+func TestHandler_RecordHookAtBeforeCurrentStatus(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive: func(string, json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusWaiting}
+		},
+	})
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+
+	var captured agentpkg.Status
+	var capturedOK bool
+	origHook := recordHookAtHook
+	recordHookAtHook = func(session string) {
+		m.mu.Lock()
+		captured, capturedOK = m.currentStatus[session]
+		m.mu.Unlock()
+	}
+	t.Cleanup(func() { recordHookAtHook = origHook })
+
+	body := `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","event_name":"UserPromptSubmit","raw_event":{},"agent_type":"cc"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Correct order: recordHookAt fires BEFORE currentStatus write — the
+	// captured currentStatus is empty (pre-hook). If the broken order shipped,
+	// the captured value would be StatusWaiting.
+	if capturedOK && captured == agentpkg.StatusWaiting {
+		t.Fatalf("recordHookAt observed currentStatus[work] = %q (the new hook status) — recordHookAt was called AFTER the currentStatus write (broken order)", captured)
+	}
+	// And after the handler finishes, currentStatus must be the new status.
+	m.mu.Lock()
+	final := m.currentStatus["work"]
+	m.mu.Unlock()
+	if final != agentpkg.StatusWaiting {
+		t.Fatalf("post-handler currentStatus[work] = %q, want StatusWaiting", final)
+	}
+}
+
 // CC4 — E2E ScreenChanged → broadcast Running. cc registered with its real
 // ProbeProfile (TopLines=12). manageActivityWatch starts the watcher, then
 // we feed a ScreenChanged event through the orchestrator's callback and
@@ -251,6 +312,45 @@ func TestCC_E2E_ScreenStableToIdle(t *testing.T) {
 	m.mu.Unlock()
 	if got != agentpkg.StatusIdle {
 		t.Fatalf("currentStatus[work] = %q, want StatusIdle", got)
+	}
+}
+
+// FX1 — RenameSession migrates lastHookAt across the rename so a freshly-
+// set graceWindow stays in effect for the new session name. Regression for
+// codex finding #2 (R1 P2): without this, hook-set status could be
+// overwritten by probe events within 2s after rename because lastHookAt
+// stayed under the old name (probe targets the new name and observes "no
+// graceWindow active").
+func TestRenameSession_MigratesLastHookAt(t *testing.T) {
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+	provider := &fakeAgentProvider{typeName: "cc"}
+	m.registry.Register(provider)
+
+	// Pre-state: oldname is being watched + has a fresh hook timestamp.
+	m.mu.Lock()
+	m.activeWatchers["oldname"] = "cc"
+	m.mu.Unlock()
+	m.probeOrch.recordHookAt("oldname")
+
+	m.RenameSession("oldname", "newname")
+
+	// graceWindow must follow the rename: lastHookAt[oldname] gone,
+	// lastHookAt[newname] populated and still within probeGraceWindow.
+	m.probeOrch.graceMu.Lock()
+	if _, ok := m.probeOrch.lastHookAt["oldname"]; ok {
+		m.probeOrch.graceMu.Unlock()
+		t.Fatalf("lastHookAt[oldname] still present after rename — graceWindow leaked")
+	}
+	stamp, ok := m.probeOrch.lastHookAt["newname"]
+	m.probeOrch.graceMu.Unlock()
+	if !ok {
+		t.Fatalf("lastHookAt[newname] missing after rename — graceWindow lost")
+	}
+	if time.Since(stamp) > probeGraceWindow {
+		t.Fatalf("lastHookAt[newname] = %v (age %v), want recent enough that graceWindow still active",
+			stamp, time.Since(stamp))
 	}
 }
 

--- a/internal/module/agent/probe_orchestrator_test.go
+++ b/internal/module/agent/probe_orchestrator_test.go
@@ -457,6 +457,169 @@ func TestOrchestrator_RepeatedScreenStableDedupsToOneBroadcast(t *testing.T) {
 	}
 }
 
+// FX3 — interpretScreenEvent re-validates the stale-callback guard inside
+// the final m.mu critical section in addition to the early fast-path check.
+// Regression for codex finding #4 (R2 attack HIGH): previously a concurrent
+// stop / rename could mutate activeWatchers between the early unlock and
+// the final lock — leaving a ghost broadcast for a watcher that no longer
+// exists.
+//
+// Approach: use the interruptBeforeFinalLockFn test seam. Production sets
+// it to a no-op; tests set it to delete activeWatchers["work"] (simulating
+// stopWatch winning the race). The orchestrator must observe the deletion
+// in the re-check inside the final critical section and return without
+// broadcasting / mutating currentStatus / incrementing the counter.
+func TestInterpretScreenEvent_RevalidatesStaleCallbackAtomically(t *testing.T) {
+	m, _, fake := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusRunning, 290)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+	// Bottom capture returns prose so ScreenStable would otherwise produce
+	// an Idle transition — any broadcast would be an actual ghost.
+	fake.setCaptureFn(func(string, int) (string, error) { return "user prose", nil })
+
+	origInterrupt := interruptBeforeFinalLockFn
+	interruptBeforeFinalLockFn = func(session string) {
+		m.mu.Lock()
+		delete(m.activeWatchers, session)
+		m.mu.Unlock()
+	}
+	t.Cleanup(func() { interruptBeforeFinalLockFn = origInterrupt })
+
+	before := snapshotMetrics()
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", OccurredAt: time.Now()})
+
+	after := snapshotMetrics()
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0 (atomic re-check should drop the event)", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusRunning {
+		t.Fatalf("currentStatus[work] = %q, want StatusRunning preserved (no transition)", status)
+	}
+}
+
+// FX4 — startWatch validates ProbeProfile (TopLines + BottomLines mutually
+// exclusive) and returns false on invalid; manageActivityWatch rolls back
+// its activeWatchers mutation. Regression for codex finding #7 (R2 defense
+// MEDIUM): previously a bad provider profile created a silent dead watcher
+// — stale-callback saw it as active, MetricProbeWatchStarted reported
+// "started", but no goroutine ran.
+func TestStartWatch_InvalidProfileRollsBackActiveWatchers(t *testing.T) {
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+
+	provider := &fakeProfileProvider{
+		fakeAgentProvider: fakeAgentProvider{typeName: "bad-agent"},
+		profile:           agentpkg.ProbeProfile{TopLines: 5, BottomLines: 5},
+	}
+	m.registry.Register(provider)
+
+	before := snapshotMetrics()
+	m.manageActivityWatch("sess", "bad-agent", agentpkg.StatusRunning)
+	after := snapshotMetrics()
+
+	// activeWatchers must be rolled back so the orchestrator's stale-callback
+	// guard (and any future cleanup paths) treat the session as not watched.
+	m.mu.Lock()
+	_, present := m.activeWatchers["sess"]
+	m.mu.Unlock()
+	if present {
+		t.Fatalf("activeWatchers[sess] still present after invalid-profile startWatch — rollback missing")
+	}
+
+	// Metric must NOT increment — it is reserved for actually-registered
+	// watchers so /debug/vars stays an honest counter.
+	if got := after.watchStarted - before.watchStarted; got != 0 {
+		t.Fatalf("MetricProbeWatchStarted delta = %d, want 0 (invalid profile must not bump the counter)", got)
+	}
+
+	// And the prober must not have observed a Watch call for this target.
+	rec.mu.Lock()
+	_, watched := rec.watchOpts["sess:"]
+	rec.mu.Unlock()
+	if watched {
+		t.Fatalf("recordingProber observed Watch on sess: despite invalid profile")
+	}
+}
+
+// FX5a — ScreenStable on a stable-Idle session with a live top-frame PID
+// MUST skip the bottom CapturePaneContent and the transition entirely.
+// Regression for codex finding #8 (R2 體質 MEDIUM): continuous-stable Idle
+// panes were issuing tmux subprocess calls every N ticks just to be dropped
+// at the transition gate.
+func TestScreenStable_StableIdleAlivePidSkipsBottomCapture(t *testing.T) {
+	m, _, fake := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusIdle, 295)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	// Force PID alive (default already does, but be explicit).
+	origAlive := isPidAliveFn
+	isPidAliveFn = func(int) bool { return true }
+	t.Cleanup(func() { isPidAliveFn = origAlive })
+
+	before := snapshotMetrics()
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", OccurredAt: time.Now()})
+
+	after := snapshotMetrics()
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0 (stable-Idle + alive PID is a no-op)", got)
+	}
+	fake.mu.Lock()
+	calls := len(fake.captureCall)
+	fake.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("CapturePaneContent calls = %d, want 0 (cheap gate must skip the bottom capture)", calls)
+	}
+}
+
+// FX5b — dead-PID + shell-prompt sweep path is preserved when prev == Idle.
+// The cheap gate must only skip when the top-frame PID is alive; a dead PID
+// still needs the bottom capture to drive shell-prompt classification +
+// sweep cleanup.
+func TestScreenStable_StableIdleDeadPidStillTriggersSweep(t *testing.T) {
+	m, _, fake := orchTestModule(t)
+	fake.SetPaneSessionName("%5", "work")
+	seedOrchFrame(t, m, agentpkg.StatusIdle, 296)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	fake.setCaptureFn(func(target string, lastN int) (string, error) {
+		if lastN == 10 && target == "work:" {
+			return "$ ", nil
+		}
+		return "", nil
+	})
+
+	origAlive := isPidAliveFn
+	isPidAliveFn = func(int) bool { return false }
+	t.Cleanup(func() { isPidAliveFn = origAlive })
+
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", OccurredAt: time.Now()})
+
+	// Dead-PID + shell-prompt → sweepOnce runs and removes the frame.
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0 after dead-PID + shell-prompt sweep (cheap gate must NOT skip when PID dead)", len(frames))
+	}
+}
+
 // OB1 — startWatch/stopWatch increment the watch_started/watch_stopped counters.
 func TestMetrics_WatchStartedIncrements(t *testing.T) {
 	m := newTestModule(t)

--- a/internal/module/agent/probe_orchestrator_test.go
+++ b/internal/module/agent/probe_orchestrator_test.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/probe"
+)
+
+// recordingProber is a test fake that captures Watch/StopWatch invocations.
+// Implements the orchestrator's internal proberWatcher interface.
+type recordingProber struct {
+	mu        sync.Mutex
+	watchOpts map[string]probe.WatchOptions
+	stops     []string
+}
+
+func newRecordingProber() *recordingProber {
+	return &recordingProber{watchOpts: make(map[string]probe.WatchOptions)}
+}
+
+func (r *recordingProber) Watch(target string, opts probe.WatchOptions, _ probe.ScreenChangeCallback) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.watchOpts[target] = opts
+}
+
+func (r *recordingProber) StopWatch(target string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stops = append(r.stops, target)
+}
+
+// fakeProfileProvider is a fakeAgentProvider variant that ALSO implements
+// agentpkg.ProbeProfileProvider. Defined here (not in fakes_test.go) to keep
+// orchestrator tests self-contained — fakes_test.go's fakeAgentProvider has no
+// ProbeProfile() method, which exercises the "default profile" path.
+type fakeProfileProvider struct {
+	fakeAgentProvider
+	profile agentpkg.ProbeProfile
+}
+
+func (p *fakeProfileProvider) ProbeProfile() agentpkg.ProbeProfile { return p.profile }
+
+// OR1 — startWatch resolves agent's ProbeProfile and forwards options.
+func TestOrchestrator_StartWatchUsesAgentProfile(t *testing.T) {
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+
+	provider := &fakeProfileProvider{
+		fakeAgentProvider: fakeAgentProvider{typeName: "fake-agent"},
+		profile:           agentpkg.ProbeProfile{TopLines: 5, IdleStableTicks: 2},
+	}
+	m.registry.Register(provider)
+
+	m.probeOrch.startWatch("sess", "fake-agent")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	got, ok := rec.watchOpts["sess:"]
+	if !ok {
+		t.Fatalf("expected Watch on target %q, got %v", "sess:", rec.watchOpts)
+	}
+	want := probe.WatchOptions{TopLines: 5, BottomLines: 0, IdleStableTicks: 2}
+	if got != want {
+		t.Fatalf("WatchOptions = %+v, want %+v", got, want)
+	}
+}
+
+// OR2 — when the agent does NOT implement ProbeProfileProvider, startWatch
+// falls back to defaultProbeProfile. Default preserves legacy
+// CapturePaneContent(target, 10) capture region (R9 fix / G5 parity gate).
+func TestOrchestrator_DefaultProfileWhenAgentMissing(t *testing.T) {
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+
+	// fakeAgentProvider does NOT implement ProbeProfileProvider.
+	provider := &fakeAgentProvider{typeName: "plain-agent"}
+	m.registry.Register(provider)
+
+	m.probeOrch.startWatch("sess", "plain-agent")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	got, ok := rec.watchOpts["sess:"]
+	if !ok {
+		t.Fatalf("expected Watch on target %q, got %v", "sess:", rec.watchOpts)
+	}
+	want := probe.WatchOptions{TopLines: 0, BottomLines: 10, IdleStableTicks: 3}
+	if got != want {
+		t.Fatalf("WatchOptions = %+v, want %+v (default profile)", got, want)
+	}
+}

--- a/internal/module/agent/probe_orchestrator_test.go
+++ b/internal/module/agent/probe_orchestrator_test.go
@@ -1,12 +1,560 @@
 package agent
 
 import (
+	"bytes"
+	"expvar"
+	"log"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/agent/probe"
+	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/session"
+	"github.com/wake/purdex/internal/store"
+	"github.com/wake/purdex/internal/tmux"
 )
+
+// metricSnapshot reads cumulative counter values for delta-style assertions.
+// expvar counters are global to the process so absolute values cannot be
+// asserted; tests snapshot before+after and compare deltas instead.
+type metricSnapshot struct {
+	watchStarted   int64
+	watchStopped   int64
+	screenEvent    int64
+	graceWindowSup int64
+}
+
+func snapshotMetrics() metricSnapshot {
+	return metricSnapshot{
+		watchStarted:   metricInt("purdex_probe_watch_started_total"),
+		watchStopped:   metricInt("purdex_probe_watch_stopped_total"),
+		screenEvent:    metricInt("purdex_probe_screen_event_total"),
+		graceWindowSup: metricInt("purdex_probe_grace_window_suppressed_total"),
+	}
+}
+
+func metricInt(name string) int64 {
+	v := expvar.Get(name)
+	if v == nil {
+		return 0
+	}
+	if iv, ok := v.(*expvar.Int); ok {
+		return iv.Value()
+	}
+	return 0
+}
+
+// fakeTmuxCapture supports test injection of CapturePaneContent results.
+// Embeds a real FakeExecutor and overlays a programmable response for
+// (target, lastN) pairs so OR8 can drive shell-prompt classification.
+type fakeTmuxCapture struct {
+	*tmux.FakeExecutor
+	mu          sync.Mutex
+	captureFn   func(target string, lastN int) (string, error)
+	captureCall []captureArgs
+}
+
+type captureArgs struct {
+	target string
+	lastN  int
+}
+
+func newFakeTmuxCapture() *fakeTmuxCapture {
+	return &fakeTmuxCapture{FakeExecutor: tmux.NewFakeExecutor()}
+}
+
+func (f *fakeTmuxCapture) CapturePaneContent(target string, lastN int) (string, error) {
+	f.mu.Lock()
+	fn := f.captureFn
+	f.captureCall = append(f.captureCall, captureArgs{target: target, lastN: lastN})
+	f.mu.Unlock()
+	if fn != nil {
+		return fn(target, lastN)
+	}
+	return f.FakeExecutor.CapturePaneContent(target, lastN)
+}
+
+func (f *fakeTmuxCapture) setCaptureFn(fn func(target string, lastN int) (string, error)) {
+	f.mu.Lock()
+	f.captureFn = fn
+	f.mu.Unlock()
+}
+
+// orchTestModule wires a Module with a recordingProber installed on the
+// orchestrator and the minimal seams needed to interpret screen events
+// (sessions, core, registry). Returns the Module + the prober for assertions.
+func orchTestModule(t *testing.T) (*Module, *recordingProber, *fakeTmuxCapture) {
+	t.Helper()
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+
+	fake := newFakeTmuxCapture()
+	m.tmux = fake
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fake}
+	m.sessions = &fakeSessionProvider{
+		sessions: []session.SessionInfo{{Code: "s1", Name: "work"}},
+	}
+
+	provider := &fakeAgentProvider{
+		typeName: "cc",
+		alive:    true,
+	}
+	m.registry.Register(provider)
+	return m, rec, fake
+}
+
+// seedOrchFrame inserts a verified frame for "work" pane "%5" so
+// projectionForSession returns a non-nil projection that the orchestrator
+// can patch via setProjectionTopStatus / sweepOnce checks.
+func seedOrchFrame(t *testing.T, m *Module, status agentpkg.Status, pid int) {
+	t.Helper()
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              pid,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Status:           status,
+		StartedAt:        time.Now().UnixNano(),
+		LastSeenAt:       time.Now().UnixNano(),
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("seed frame: %v", err)
+	}
+}
+
+// --- Slice 3 + Slice 7 (Commit 4) tests ---
+
+// OR3 — recordHookAt; injecting a ScreenChanged within the graceWindow is
+// suppressed: no broadcast, no status change, only the suppressed counter
+// increments.
+func TestOrchestrator_GraceWindowSuppressesEventWithinWindow(t *testing.T) {
+	m, _, _ := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusWaiting, 200)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusWaiting
+	m.mu.Unlock()
+
+	before := snapshotMetrics()
+	m.probeOrch.recordHookAt("work")
+
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+
+	after := snapshotMetrics()
+	if got := after.graceWindowSup - before.graceWindowSup; got != 1 {
+		t.Fatalf("graceWindowSuppressed delta = %d, want 1", got)
+	}
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0 (suppressed events do not count)", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusWaiting {
+		t.Fatalf("currentStatus[work] = %q, want StatusWaiting (no transition)", status)
+	}
+}
+
+// OR4 — graceWindow expires naturally; subsequent ScreenChanged events
+// recover. v2.0: dumb probe + transition gate makes this Just Work without
+// any Rearm API. Uses the orchestrator's nowFn seam to fast-forward past
+// graceWindow.
+func TestOrchestrator_GraceWindowExpiresThenContinuousChangedRecovers(t *testing.T) {
+	m, _, _ := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusWaiting, 201)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	base := time.Now()
+	origNow := orchNowFn
+	orchNowFn = func() time.Time { return base }
+	t.Cleanup(func() { orchNowFn = origNow })
+
+	before := snapshotMetrics()
+	m.probeOrch.recordHookAt("work")
+	cb := m.probeOrch.makeCallback("work", "cc")
+
+	// 5 events within the graceWindow — all suppressed.
+	for i := 0; i < 5; i++ {
+		orchNowFn = func() time.Time { return base.Add(500 * time.Millisecond) }
+		cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+	}
+	mid := snapshotMetrics()
+	if got := mid.graceWindowSup - before.graceWindowSup; got != 5 {
+		t.Fatalf("graceWindowSuppressed delta = %d, want 5", got)
+	}
+	if got := mid.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta during suppression = %d, want 0", got)
+	}
+
+	// Fast-forward past graceWindow + inject again — this one transitions.
+	orchNowFn = func() time.Time { return base.Add(3 * time.Second) }
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+
+	after := snapshotMetrics()
+	if got := after.screenEvent - before.screenEvent; got != 1 {
+		t.Fatalf("screenEvent delta after recovery = %d, want 1", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusRunning {
+		t.Fatalf("currentStatus[work] = %q, want StatusRunning after recovery", status)
+	}
+}
+
+// OR5 — Error Guard: orchestrator never overwrites StatusError.
+func TestOrchestrator_ErrorGuardBlocksProbeOverwrite(t *testing.T) {
+	m, _, fake := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusError, 202)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusError
+	m.mu.Unlock()
+
+	fake.SetPaneContent("work:", "user typed something normal")
+
+	before := snapshotMetrics()
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", OccurredAt: time.Now()})
+
+	after := snapshotMetrics()
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0 (Error Guard blocks)", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusError {
+		t.Fatalf("currentStatus[work] = %q, want StatusError preserved", status)
+	}
+}
+
+// OR6 — stale-callback guard: callback fired after stopWatch / rename does
+// not broadcast or update status (R4 fix regression).
+func TestOrchestrator_StaleCallbackGuard(t *testing.T) {
+	t.Run("post_stopWatch_no_broadcast", func(t *testing.T) {
+		m, _, _ := orchTestModule(t)
+		seedOrchFrame(t, m, agentpkg.StatusIdle, 203)
+		// activeWatchers absent — simulates post-stop.
+		m.mu.Lock()
+		delete(m.activeWatchers, "work")
+		m.currentStatus["work"] = agentpkg.StatusIdle
+		m.mu.Unlock()
+
+		before := snapshotMetrics()
+		cb := m.probeOrch.makeCallback("work", "cc")
+		cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+
+		after := snapshotMetrics()
+		if got := after.screenEvent - before.screenEvent; got != 0 {
+			t.Fatalf("screenEvent delta = %d, want 0 (stale watcher)", got)
+		}
+		m.mu.Lock()
+		status := m.currentStatus["work"]
+		m.mu.Unlock()
+		if status != agentpkg.StatusIdle {
+			t.Fatalf("currentStatus[work] = %q, want StatusIdle (no transition)", status)
+		}
+	})
+	t.Run("post_rename_currentAgent_mismatch", func(t *testing.T) {
+		m, _, _ := orchTestModule(t)
+		seedOrchFrame(t, m, agentpkg.StatusIdle, 204)
+		// Closure captures agentType="codex", but activeWatchers now records "cc"
+		// (simulating rename / agent swap).
+		m.mu.Lock()
+		m.activeWatchers["work"] = "cc"
+		m.currentStatus["work"] = agentpkg.StatusIdle
+		m.mu.Unlock()
+
+		before := snapshotMetrics()
+		cb := m.probeOrch.makeCallback("work", "codex")
+		cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+
+		after := snapshotMetrics()
+		if got := after.screenEvent - before.screenEvent; got != 0 {
+			t.Fatalf("screenEvent delta = %d, want 0 (currentAgent mismatch)", got)
+		}
+		m.mu.Lock()
+		status := m.currentStatus["work"]
+		m.mu.Unlock()
+		if status != agentpkg.StatusIdle {
+			t.Fatalf("currentStatus[work] = %q, want StatusIdle (no transition)", status)
+		}
+	})
+}
+
+// OR7 — nil prober no-op (R14 fix #2 regression). Partial-init Module
+// fixtures (no Init / no prober wired) must tolerate startWatch / stopWatch
+// without panicking, and the metrics counters must not be incremented for
+// the dropped operations.
+func TestOrchestrator_NilProberStartStopNoOp(t *testing.T) {
+	m := newTestModule(t)
+	m.prober = nil
+	m.probeOrch.watcher = nil
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("nil-prober path panicked: %v", r)
+		}
+	}()
+
+	before := snapshotMetrics()
+	m.probeOrch.startWatch("sess", "missing")
+	m.probeOrch.stopWatch("sess")
+	after := snapshotMetrics()
+
+	if got := after.watchStarted - before.watchStarted; got != 0 {
+		t.Fatalf("watchStarted delta = %d, want 0 (nil-prober no-op)", got)
+	}
+	if got := after.watchStopped - before.watchStopped; got != 0 {
+		t.Fatalf("watchStopped delta = %d, want 0 (nil-prober no-op)", got)
+	}
+}
+
+// OR8 — ScreenStable independent bottom-capture for shell-prompt classifier
+// (R14 fix #1 regression). Two sub-cases:
+//   (i) bottomContent is shell prompt + dead PID → sweepOnce called
+//   (ii) bottomContent is not shell prompt → status broadcast as Idle, no sweep
+func TestOrchestrator_ScreenStableUsesBottomCaptureForShellPrompt(t *testing.T) {
+	t.Run("shellprompt_deadPID_triggersSweep", func(t *testing.T) {
+		m, _, fake := orchTestModule(t)
+		// Pane→session mapping is required so projectionForSession can find
+		// the frame for "work" and so sweep's afterFrameCleared can resolve
+		// the session for cleanup broadcasts.
+		fake.SetPaneSessionName("%5", "work")
+		seedOrchFrame(t, m, agentpkg.StatusRunning, 250)
+		m.mu.Lock()
+		m.activeWatchers["work"] = "cc"
+		m.currentStatus["work"] = agentpkg.StatusRunning
+		m.mu.Unlock()
+
+		// Pretend ev.Content is top-of-pane (no shell prompt) — orchestrator
+		// must do an INDEPENDENT bottom capture.
+		fake.setCaptureFn(func(target string, lastN int) (string, error) {
+			if lastN == 10 && target == "work:" {
+				return "$ ", nil
+			}
+			return "", nil
+		})
+
+		// Force PID dead.
+		origAlive := isPidAliveFn
+		isPidAliveFn = func(int) bool { return false }
+		t.Cleanup(func() { isPidAliveFn = origAlive })
+
+		cb := m.probeOrch.makeCallback("work", "cc")
+		// ev.Content has top-of-pane info, irrelevant — orchestrator captures bottom independently.
+		cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", Content: "TOP HEADER\nbusy\nbusy", OccurredAt: time.Now()})
+
+		// orchestrator calls m.sweepOnce() directly. Verify via DB side-effect:
+		// dead-PID frame is removed by sweepOnce.
+		frames, err := m.frames.ListByPane("%5")
+		if err != nil {
+			t.Fatalf("ListByPane: %v", err)
+		}
+		if len(frames) != 0 {
+			t.Fatalf("frame count = %d, want 0 after shell-prompt + dead-PID sweep", len(frames))
+		}
+	})
+	t.Run("noShellPrompt_broadcastsIdle", func(t *testing.T) {
+		m, _, fake := orchTestModule(t)
+		seedOrchFrame(t, m, agentpkg.StatusRunning, 251)
+		m.mu.Lock()
+		m.activeWatchers["work"] = "cc"
+		m.currentStatus["work"] = agentpkg.StatusRunning
+		m.mu.Unlock()
+		fake.setCaptureFn(func(target string, lastN int) (string, error) {
+			return "user typed text\nmore text", nil
+		})
+
+		before := snapshotMetrics()
+		cb := m.probeOrch.makeCallback("work", "cc")
+		cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", Content: "anything", OccurredAt: time.Now()})
+
+		after := snapshotMetrics()
+		if got := after.screenEvent - before.screenEvent; got != 1 {
+			t.Fatalf("screenEvent delta = %d, want 1 (Idle transition)", got)
+		}
+		m.mu.Lock()
+		status := m.currentStatus["work"]
+		m.mu.Unlock()
+		if status != agentpkg.StatusIdle {
+			t.Fatalf("currentStatus[work] = %q, want StatusIdle", status)
+		}
+		// Frame survives — sweep should NOT have run.
+		frames, _ := m.frames.ListByPane("%5")
+		if len(frames) != 1 {
+			t.Fatalf("frame count = %d, want 1 (no sweep on non-shellprompt path)", len(frames))
+		}
+	})
+}
+
+// OR9 — repeated ScreenChanged dedups via transition gate. v2.0: probe is
+// dumb and fires every tick; orchestrator's currentStatus check ensures
+// Idle→Running broadcasts once, all subsequent ScreenChanged returns at
+// the gate (no broadcast / no metric).
+func TestOrchestrator_RepeatedScreenChangedDedupsToOneBroadcast(t *testing.T) {
+	m, _, _ := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusIdle, 260)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	before := snapshotMetrics()
+	cb := m.probeOrch.makeCallback("work", "cc")
+	for i := 0; i < 5; i++ {
+		cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+	}
+
+	after := snapshotMetrics()
+	if got := after.screenEvent - before.screenEvent; got != 1 {
+		t.Fatalf("screenEvent delta = %d, want 1 (transition gate dedups 4 of 5)", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusRunning {
+		t.Fatalf("currentStatus[work] = %q, want StatusRunning", status)
+	}
+}
+
+// OR10 — repeated ScreenStable dedups via transition gate.
+func TestOrchestrator_RepeatedScreenStableDedupsToOneBroadcast(t *testing.T) {
+	m, _, fake := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusRunning, 261)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+	// Bottom capture returns no shell prompt → routes to Idle.
+	fake.setCaptureFn(func(string, int) (string, error) { return "user prose", nil })
+
+	before := snapshotMetrics()
+	cb := m.probeOrch.makeCallback("work", "cc")
+	for i := 0; i < 3; i++ {
+		cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", OccurredAt: time.Now()})
+	}
+
+	after := snapshotMetrics()
+	if got := after.screenEvent - before.screenEvent; got != 1 {
+		t.Fatalf("screenEvent delta = %d, want 1 (transition gate dedups 2 of 3)", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusIdle {
+		t.Fatalf("currentStatus[work] = %q, want StatusIdle", status)
+	}
+}
+
+// OB1 — startWatch/stopWatch increment the watch_started/watch_stopped counters.
+func TestMetrics_WatchStartedIncrements(t *testing.T) {
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+	provider := &fakeAgentProvider{typeName: "cc"}
+	m.registry.Register(provider)
+
+	before := snapshotMetrics()
+	m.probeOrch.startWatch("sess", "cc")
+	m.probeOrch.stopWatch("sess")
+	after := snapshotMetrics()
+
+	if got := after.watchStarted - before.watchStarted; got != 1 {
+		t.Fatalf("watchStarted delta = %d, want 1", got)
+	}
+	if got := after.watchStopped - before.watchStopped; got != 1 {
+		t.Fatalf("watchStopped delta = %d, want 1", got)
+	}
+}
+
+// OB2 — accepted-transition ScreenChanged + ScreenStable each increment
+// the screen-event counter once.
+func TestMetrics_ScreenEventIncrements(t *testing.T) {
+	m, _, fake := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusIdle, 270)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+	fake.setCaptureFn(func(string, int) (string, error) { return "user prose", nil })
+
+	before := snapshotMetrics()
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+	// Now currentStatus = Running; ScreenStable transitions to Idle.
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", OccurredAt: time.Now()})
+
+	after := snapshotMetrics()
+	if got := after.screenEvent - before.screenEvent; got != 2 {
+		t.Fatalf("screenEvent delta = %d, want 2", got)
+	}
+}
+
+// OB3 — graceWindow suppression increments its own counter.
+func TestMetrics_GraceWindowSuppressedIncrements(t *testing.T) {
+	m, _, _ := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusWaiting, 271)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusWaiting
+	m.mu.Unlock()
+
+	before := snapshotMetrics()
+	m.probeOrch.recordHookAt("work")
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+
+	after := snapshotMetrics()
+	if got := after.graceWindowSup - before.graceWindowSup; got != 1 {
+		t.Fatalf("graceWindowSuppressed delta = %d, want 1", got)
+	}
+}
+
+// OB4 — PDX_DEV_MODE=1 emits [probe] log lines; unset suppresses them.
+func TestDevMode_LogsGatedByEnv(t *testing.T) {
+	t.Run("env_set_emits_log", func(t *testing.T) {
+		t.Setenv("PDX_DEV_MODE", "1")
+		m, _, _ := orchTestModule(t)
+
+		var buf bytes.Buffer
+		origOut := log.Writer()
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(origOut) })
+
+		m.probeOrch.recordHookAt("work")
+
+		if !strings.Contains(buf.String(), "[probe]") {
+			t.Fatalf("expected [probe] log when PDX_DEV_MODE=1, got %q", buf.String())
+		}
+	})
+	t.Run("env_unset_silent", func(t *testing.T) {
+		t.Setenv("PDX_DEV_MODE", "")
+		m, _, _ := orchTestModule(t)
+
+		var buf bytes.Buffer
+		origOut := log.Writer()
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(origOut) })
+
+		m.probeOrch.recordHookAt("work")
+
+		if strings.Contains(buf.String(), "[probe]") {
+			t.Fatalf("expected no [probe] log when PDX_DEV_MODE unset, got %q", buf.String())
+		}
+	})
+}
+
 
 // recordingProber is a test fake that captures Watch/StopWatch invocations.
 // Implements the orchestrator's internal proberWatcher interface.

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -362,7 +362,7 @@ func TestSweep_IdleClearStopsOrphanWatcher(t *testing.T) {
 	// Register an active watcher for this session (simulating an in-flight
 	// Activity probe left over from a running/waiting status).
 	m.activeWatchers["work"] = "cc"
-	m.prober.StartWatch("work:", func(string, probe.ActivitySignal) {})
+	m.prober.Watch("work:", probe.WatchOptions{}, func(probe.ScreenChangeEvent) {})
 	t.Cleanup(func() { m.prober.StopAllWatches() })
 
 	origAlive := isPidAliveFn
@@ -409,7 +409,7 @@ func TestSweep_DeadPidAlsoStopsOrphanWatcher(t *testing.T) {
 	}
 
 	m.activeWatchers["work"] = "cc"
-	m.prober.StartWatch("work:", func(string, probe.ActivitySignal) {})
+	m.prober.Watch("work:", probe.WatchOptions{}, func(probe.ScreenChangeEvent) {})
 	t.Cleanup(func() { m.prober.StopAllWatches() })
 
 	origAlive := isPidAliveFn

--- a/internal/tmux/executor.go
+++ b/internal/tmux/executor.go
@@ -45,6 +45,16 @@ type Executor interface {
 	ActivePanePID(target string) (string, error)
 	PaneChildCommands(target string) ([]string, error)
 	CapturePaneContent(target string, lastN int) (string, error)
+	// CapturePaneRange returns lines [start, endInclusive] of the pane.
+	// Indexing follows tmux capture-pane -S/-E semantics:
+	//   - start/end are line indices; 0 = top of visible pane
+	//   - negative values reference history above the visible pane
+	// Empty output is legal (not treated as an error).
+	CapturePaneRange(target string, start, endInclusive int) (string, error)
+	// CapturePaneTopLines returns the top n lines (0..n-1) of the pane.
+	// Equivalent to CapturePaneRange(target, 0, n-1).
+	// n <= 0 returns "" without invoking tmux (caller-friendly disable).
+	CapturePaneTopLines(target string, n int) (string, error)
 	PaneSize(target string) (cols, rows int, err error)
 	ResizeWindow(target string, cols, rows int) error
 	ResizeWindowAuto(target string) error
@@ -314,6 +324,23 @@ func (r *RealExecutor) CapturePaneContent(target string, lastN int) (string, err
 		return "", fmt.Errorf("tmux capture-pane: %w", err)
 	}
 	return string(out), nil
+}
+
+func (r *RealExecutor) CapturePaneRange(target string, start, endInclusive int) (string, error) {
+	startArg := fmt.Sprintf("%d", start)
+	endArg := fmt.Sprintf("%d", endInclusive)
+	out, err := exec.Command("tmux", "capture-pane", "-p", "-t", target, "-S", startArg, "-E", endArg).Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux capture-pane range: %w", err)
+	}
+	return string(out), nil
+}
+
+func (r *RealExecutor) CapturePaneTopLines(target string, n int) (string, error) {
+	if n <= 0 {
+		return "", nil
+	}
+	return r.CapturePaneRange(target, 0, n-1)
 }
 
 func (r *RealExecutor) PaneSize(target string) (cols, rows int, err error) {

--- a/internal/tmux/executor.go
+++ b/internal/tmux/executor.go
@@ -329,7 +329,12 @@ func (r *RealExecutor) CapturePaneContent(target string, lastN int) (string, err
 func (r *RealExecutor) CapturePaneRange(target string, start, endInclusive int) (string, error) {
 	startArg := fmt.Sprintf("%d", start)
 	endArg := fmt.Sprintf("%d", endInclusive)
-	out, err := exec.Command("tmux", "capture-pane", "-p", "-t", target, "-S", startArg, "-E", endArg).Output()
+	// -e preserves ANSI escape sequences. Without it, tmux normalizes the
+	// pane to plain text and ANSI-only changes (spinner color, status
+	// highlights) hash to the same content as the previous tick — so a
+	// TopLines watcher would miss "running" signals on agents that animate
+	// purely via color (cc's spinner is one). Mirrors CapturePaneContent.
+	out, err := exec.Command("tmux", "capture-pane", "-e", "-p", "-t", target, "-S", startArg, "-E", endArg).Output()
 	if err != nil {
 		return "", fmt.Errorf("tmux capture-pane range: %w", err)
 	}

--- a/internal/tmux/executor_test.go
+++ b/internal/tmux/executor_test.go
@@ -271,3 +271,129 @@ func TestFakeExecutor_PaneCurrentPath_NotSet(t *testing.T) {
 		t.Error("expected error for unset pane cwd")
 	}
 }
+
+// --- Slice 0: CapturePaneRange / CapturePaneTopLines tests (TT1-TT4) ---
+
+// TT1: RealExecutor passes -S/-E args through to tmux capture-pane.
+func TestCapturePaneRange_RealExecutor_PassesArgs(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+if [ "$1" != "capture-pane" ] || [ "$2" != "-p" ] || [ "$3" != "-t" ] || [ "$4" != "sess:" ] || [ "$5" != "-S" ] || [ "$6" != "2" ] || [ "$7" != "-E" ] || [ "$8" != "5" ]; then
+  printf 'unexpected args: %s\n' "$*" >&2
+  exit 2
+fi
+printf 'line2\nline3\nline4\nline5\n'
+`), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := (&tmux.RealExecutor{}).CapturePaneRange("sess:", 2, 5)
+	if err != nil {
+		t.Fatalf("CapturePaneRange returned error: %v", err)
+	}
+	if out != "line2\nline3\nline4\nline5\n" {
+		t.Fatalf("CapturePaneRange = %q, want 4 lines", out)
+	}
+}
+
+// TT2: CapturePaneTopLines delegates to CapturePaneRange(target, 0, n-1).
+func TestCapturePaneTopLines_DelegatesToRange(t *testing.T) {
+	cases := []struct {
+		n       int
+		wantEnd string // expected $6 (the -E value) in the script-mode mock
+	}{
+		{n: 1, wantEnd: "0"},
+		{n: 3, wantEnd: "2"},
+		{n: 10, wantEnd: "9"},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("n=%d", tc.n), func(t *testing.T) {
+			dir := t.TempDir()
+			script := filepath.Join(dir, "tmux")
+			body := fmt.Sprintf(`#!/bin/sh
+if [ "$1" != "capture-pane" ] || [ "$2" != "-p" ] || [ "$3" != "-t" ] || [ "$4" != "sess:" ] || [ "$5" != "-S" ] || [ "$6" != "0" ] || [ "$7" != "-E" ] || [ "$8" != "%s" ]; then
+  printf 'unexpected args: %%s\n' "$*" >&2
+  exit 2
+fi
+printf 'ok\n'
+`, tc.wantEnd)
+			if err := os.WriteFile(script, []byte(body), 0755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			out, err := (&tmux.RealExecutor{}).CapturePaneTopLines("sess:", tc.n)
+			if err != nil {
+				t.Fatalf("CapturePaneTopLines(n=%d) error: %v", tc.n, err)
+			}
+			if out != "ok\n" {
+				t.Fatalf("CapturePaneTopLines(n=%d) = %q, want %q", tc.n, out, "ok\n")
+			}
+		})
+	}
+}
+
+// TT3: CapturePaneTopLines with n<=0 returns "" without invoking tmux.
+func TestCapturePaneTopLines_ZeroOrNegative_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// A tmux shim that fails the test if invoked.
+	script := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+printf 'tmux must not be invoked for n<=0\n' >&2
+exit 99
+`), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	for _, n := range []int{0, -1} {
+		out, err := (&tmux.RealExecutor{}).CapturePaneTopLines("sess:", n)
+		if err != nil {
+			t.Errorf("CapturePaneTopLines(n=%d) error = %v, want nil", n, err)
+		}
+		if out != "" {
+			t.Errorf("CapturePaneTopLines(n=%d) = %q, want \"\"", n, out)
+		}
+	}
+}
+
+// TT4: FakeExecutor range methods round-trip per-line content.
+func TestFakeExecutor_RangeMethods_Roundtrip(t *testing.T) {
+	f := tmux.NewFakeExecutor()
+	lines := []string{"line0", "line1", "line2", "line3", "line4"}
+	f.SetPaneContentByRange("sess:", lines)
+
+	cases := []struct {
+		name  string
+		start int
+		end   int
+		want  string
+	}{
+		{name: "single line 0", start: 0, end: 0, want: "line0\n"},
+		{name: "lines 1..3", start: 1, end: 3, want: "line1\nline2\nline3\n"},
+		{name: "all 0..4", start: 0, end: 4, want: "line0\nline1\nline2\nline3\nline4\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := f.CapturePaneRange("sess:", tc.start, tc.end)
+			if err != nil {
+				t.Fatalf("CapturePaneRange(%d,%d) error: %v", tc.start, tc.end, err)
+			}
+			if got != tc.want {
+				t.Errorf("CapturePaneRange(%d,%d) = %q, want %q", tc.start, tc.end, got, tc.want)
+			}
+		})
+	}
+
+	// CapturePaneTopLines(_, 3) → first 3 lines.
+	got, err := f.CapturePaneTopLines("sess:", 3)
+	if err != nil {
+		t.Fatalf("CapturePaneTopLines(3) error: %v", err)
+	}
+	want := "line0\nline1\nline2\n"
+	if got != want {
+		t.Errorf("CapturePaneTopLines(3) = %q, want %q", got, want)
+	}
+}

--- a/internal/tmux/executor_test.go
+++ b/internal/tmux/executor_test.go
@@ -279,7 +279,7 @@ func TestCapturePaneRange_RealExecutor_PassesArgs(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "tmux")
 	if err := os.WriteFile(script, []byte(`#!/bin/sh
-if [ "$1" != "capture-pane" ] || [ "$2" != "-p" ] || [ "$3" != "-t" ] || [ "$4" != "sess:" ] || [ "$5" != "-S" ] || [ "$6" != "2" ] || [ "$7" != "-E" ] || [ "$8" != "5" ]; then
+if [ "$1" != "capture-pane" ] || [ "$2" != "-e" ] || [ "$3" != "-p" ] || [ "$4" != "-t" ] || [ "$5" != "sess:" ] || [ "$6" != "-S" ] || [ "$7" != "2" ] || [ "$8" != "-E" ] || [ "$9" != "5" ]; then
   printf 'unexpected args: %s\n' "$*" >&2
   exit 2
 fi
@@ -313,7 +313,7 @@ func TestCapturePaneTopLines_DelegatesToRange(t *testing.T) {
 			dir := t.TempDir()
 			script := filepath.Join(dir, "tmux")
 			body := fmt.Sprintf(`#!/bin/sh
-if [ "$1" != "capture-pane" ] || [ "$2" != "-p" ] || [ "$3" != "-t" ] || [ "$4" != "sess:" ] || [ "$5" != "-S" ] || [ "$6" != "0" ] || [ "$7" != "-E" ] || [ "$8" != "%s" ]; then
+if [ "$1" != "capture-pane" ] || [ "$2" != "-e" ] || [ "$3" != "-p" ] || [ "$4" != "-t" ] || [ "$5" != "sess:" ] || [ "$6" != "-S" ] || [ "$7" != "0" ] || [ "$8" != "-E" ] || [ "$9" != "%s" ]; then
   printf 'unexpected args: %%s\n' "$*" >&2
   exit 2
 fi

--- a/internal/tmux/fake_executor.go
+++ b/internal/tmux/fake_executor.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -39,6 +40,7 @@ type FakeExecutor struct {
 	activePaneMetadata   map[string]TmuxPaneMetadata
 	activePaneMetaErrors map[string]error
 	paneContents         map[string]string   // target → captured text
+	paneContentByRange   map[string][]string // target → per-line slice (for CapturePaneRange / CapturePaneTopLines)
 	paneChildren         map[string][]string // target → child command names
 	paneDescendants      map[string][]string // target → recursive descendant command names
 	panePIDs             map[string]string   // target → pane pid
@@ -67,6 +69,7 @@ func NewFakeExecutor() *FakeExecutor {
 		activePaneMetadata:   make(map[string]TmuxPaneMetadata),
 		activePaneMetaErrors: make(map[string]error),
 		paneContents:         make(map[string]string),
+		paneContentByRange:   make(map[string][]string),
 		paneChildren:         make(map[string][]string),
 		paneDescendants:      make(map[string][]string),
 		panePIDs:             make(map[string]string),
@@ -387,6 +390,46 @@ func (f *FakeExecutor) CapturePaneContent(target string, lastN int) (string, err
 		return "", fmt.Errorf("no pane content for target %q", target)
 	}
 	return content, nil
+}
+
+// SetPaneContentByRange installs a per-line slice for the target. Both
+// CapturePaneRange and CapturePaneTopLines read from this same source so
+// tests can inject any window of lines and assert the slice they receive.
+func (f *FakeExecutor) SetPaneContentByRange(target string, lines []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.paneContentByRange[target] = append([]string(nil), lines...)
+}
+
+func (f *FakeExecutor) CapturePaneRange(target string, start, endInclusive int) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	lines, ok := f.paneContentByRange[target]
+	if !ok {
+		return "", fmt.Errorf("no pane content by range for target %q", target)
+	}
+	if start < 0 {
+		start = 0
+	}
+	if endInclusive >= len(lines) {
+		endInclusive = len(lines) - 1
+	}
+	if start > endInclusive {
+		return "", nil
+	}
+	var b strings.Builder
+	for i := start; i <= endInclusive; i++ {
+		b.WriteString(lines[i])
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}
+
+func (f *FakeExecutor) CapturePaneTopLines(target string, n int) (string, error) {
+	if n <= 0 {
+		return "", nil
+	}
+	return f.CapturePaneRange(target, 0, n-1)
 }
 
 func (f *FakeExecutor) SetPaneSize(target string, cols, rows int) {

--- a/scripts/check-pr-4a-1-boundary.sh
+++ b/scripts/check-pr-4a-1-boundary.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Usage: scripts/check-pr-4a-1-boundary.sh <base-ref>
+# Exit 0 if all changed files since <base-ref> are within the PR-4a-1
+# allowed-path set; non-zero otherwise.
+#
+# Plan v2.1 §5 + ship gate G2 enforcement. Run locally before opening
+# PR-4a-1 and again before merge — the reviewer checklist mirrors this
+# script. Like PR-4a-0, this PR explicitly does NOT introduce a CI job.
+#
+# Allowed-path notes (entries beyond plan v2.1 §5 enumeration):
+#   - shell_prompt_test.go: callsites updated for the looksLikeShellPrompt
+#     → LooksLikeShellPrompt / stripANSI → StripANSI exports (Slice 2);
+#     plan §5 only listed shell_prompt.go but the same-package test must
+#     compile against the new names.
+#   - export_test.go: minimal test seam in package probe exposing
+#     SetWatchPollIntervalForTest; written-first for PR1-PR6 timing.
+#   - probe_profile_test.go (cc): characterization test sits next to the
+#     impl per Go convention; plan §5 listed only probe_profile.go.
+#   - probe_orchestrator_integration_test.go: implementer split CC2b /
+#     CC4 / CC5 / CC6 from the unit-style probe_orchestrator_test.go to
+#     keep the unit file focused on profile + dedup logic; plan §5
+#     listed only probe_orchestrator_test.go.
+#   - sweep_test.go: Commit 2 documented deviation — legacy callsite
+#     `m.prober.StartWatch(target, func(string, probe.ActivitySignal) {})`
+#     migrated to the new Watch API; touching it is unavoidable when
+#     ActivitySignal is removed.
+#
+# Diff form: three-dot ($BASE...HEAD), per PR-4a-0 lessons — two-dot
+# would surface false-positive "violations" on files this PR never
+# touched whenever main moves while the branch is open.
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+ALLOWED=(
+  'docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan\.md'
+  'internal/tmux/executor\.go'
+  'internal/tmux/executor_test\.go'
+  'internal/tmux/fake_executor\.go'
+  'internal/agent/probe/activity\.go'
+  'internal/agent/probe/activity_test\.go'
+  'internal/agent/probe/probe\.go'
+  'internal/agent/probe/shell_prompt\.go'
+  'internal/agent/probe/shell_prompt_test\.go'
+  'internal/agent/probe/export_test\.go'
+  'internal/agent/provider\.go'
+  'internal/agent/cc/probe_profile\.go'
+  'internal/agent/cc/probe_profile_test\.go'
+  'internal/agent/cc/provider\.go'
+  'internal/agent/metrics\.go'
+  'internal/module/agent/probe_orchestrator\.go'
+  'internal/module/agent/probe_orchestrator_test\.go'
+  'internal/module/agent/probe_orchestrator_integration_test\.go'
+  'internal/module/agent/module\.go'
+  'internal/module/agent/module_test\.go'
+  'internal/module/agent/handler\.go'
+  'internal/module/agent/handler_test\.go'
+  'internal/module/agent/sweep_test\.go'
+  'scripts/check-pr-4a-1-boundary\.sh'
+)
+
+PATTERN="^($(IFS='|'; echo "${ALLOWED[*]}"))$"
+
+VIOLATIONS=$(git diff --name-only "$BASE...HEAD" | grep -vE "$PATTERN" || true)
+
+if [[ -n "$VIOLATIONS" ]]; then
+  echo "PR-4a-1 boundary violation — files outside allowed paths:" >&2
+  echo "$VIOLATIONS" >&2
+  exit 1
+fi
+
+echo "PR-4a-1 boundary check passed."


### PR DESCRIPTION
## Summary

- **Architectural pivot**: probe layer is **dumb** — observes raw screen events; orchestrator owns status-transition dedup via `currentStatus` comparison. No emit-once flags, no Rearm API.
- **8 commits**, **39 tests** (all green; race-clean), 6 implementation commits + 1 boundary script + 2 round-2 review-fix commits.
- cc agent uses `ProbeProfileProvider` (TopLines: 12, IdleStableTicks: 3); codex / opencode unchanged — they fall through to default profile {BottomLines: 10, IdleStableTicks: 3}.

## §0 來龍去脈

Phase 4a is the lights rebuild track per `docs/specs/2026-04-23-lights-rebuild-spec.md`. PR-4a-0 (#664) shipped opencode hook handler completion at alpha.233. PR-4a-1 (this) rewrites the activity probe layer.

Plan went through **15 rounds of codex review** + a **v2.0 architectural pivot** after Round 11–13 hit a 3-round meta-drift cluster around `changedEmitted`/`Rearm` cross-layer corner cases. Per `feedback_codex_meta_drift_signal.md`, this triggered a **codex parallel consulting** (job `task-moh5xafl-gx2zt1`): A assumed dedup-in-probe was right; B questioned the premise. **B won** — pivoted to dumb probe + orchestrator-only dedup.

## v2.0 Design Contract

| Layer | Responsibility |
|-------|----------------|
| **Probe** | Capture pane → hash → on diff fire `ScreenChanged`, on `IdleStableTicks` consecutive identical hashes fire `ScreenStable` and reset stableCount. No state about whether an event has been "consumed". |
| **Orchestrator** | `interpretScreenEvent` applies: stale-callback guard (R4) → graceWindow suppress (2s post-hook) → ScreenStable cheap pre-gate (#8) → independent bottom capture for shell-prompt (R14) → Error Guard → **transition gate** → atomic stale-callback revalidation (#4) → projection + broadcast. |

## Commits (TDD slice order)

| Commit | Subject | Tests |
|--------|---------|-------|
| `3bb6ee6c` | feat(tmux): add CapturePaneRange and CapturePaneTopLines | TT1-TT4 (4) |
| `b7e35367` | refactor(probe): extract dumb screen-change primitive | PR1-PR6 (8) |
| `8aa6273a` | feat(agent): add ProbeProfileProvider optional interface | OR1-OR2 (2) |
| `a93974b6` | feat(probe): graceWindow + transition gate + shell-prompt cleanup | OR3-OR10 + OB1-OB4 (12) |
| `cd22fd84` | feat(agent/cc): adopt new probe primitive via profile | CC1-CC6 + CC2b (7) |
| `fe418083` | chore(scripts): add PR-4a-1 boundary check | — |
| `2117017f` | fix(tmux): preserve ANSI escapes in CapturePaneRange (-e flag) | — (mock arg shift) |
| `e23db118` | fix(probe-orch): close hook authority races + cost optimization | 6 regression tests |

## Codex review history

### Round 1 (standard, `review-moh8nc3y-kez27t`)
2 P2 findings — both **fixed**:
1. ANSI strip in CapturePaneRange → `2117017f` adds `-e` flag.
2. Rename loses graceWindow (`lastHookAt` not migrated) → `e23db118` adds `migrateLastHookAt`.

### Round 2 attack (`review-moh8sxja-ba9u2x`)
2 HIGH findings — both **fixed**:
1. recordHookAt called after currentStatus mutation → race window. `e23db118` reorders to record-before-write.
2. Stale-callback guard not atomic with transition gate → ghost broadcast. `e23db118` revalidates inside final critical section.

### Round 2 defense (`review-moh8ukz2-t5i323`)
3 findings — 1 **fixed**, 2 **accepted with documentation** (see "Accepted design tradeoffs" below):
1. **HIGH** Transition gate dedups broadcasts but not tmux polling → ACCEPTED (see #5 below).
2. **HIGH** G5 parity broken — graceWindow applies to default profile too → REWORDED G5 (see #6 below).
3. **MEDIUM** Invalid ProbeProfile silent dead watcher → `e23db118` validates + rolls back activeWatchers.

### Round 2 體質 (`review-moh8wqa0-ikkdjg`)
2 findings:
1. **HIGH** ANSI strip — duplicate of Round 1 #1, fixed in `2117017f`.
2. **MEDIUM** ScreenStable bottom capture before transition gate → `e23db118` adds cheap pre-gate (Idle + alive PID skips capture).

## Accepted design tradeoffs (with documentation)

### #5 — Long-lived watcher polling cost (defense HIGH)

**Codex**: "Continuous-changing pane (spinner) keeps shelling out to tmux every 500ms even after the first Running broadcast. Legacy activityLoop exited after the first activity callback. Real runtime cost regression."

**Decision: ACCEPT.** v2.0 plan §2.1.4 deliberately makes the watcher long-lived because the v1 fire-once contract couldn't observe `Running → Idle` transitions (the watcher had already exited). Polling cost is the price of correct continuous-state tracking.

**Mitigations in this PR**:
- Transition gate dedups broadcasts (one Running broadcast → no repeats).
- ScreenStable cheap pre-gate (#8) skips bottom capture for stable Idle + alive PID — eliminates continuous tmux subprocess load on idle sessions.
- Per-session cost: one `tmux capture-pane` every 500ms, hash compare, no broadcast on dedup. 16-session lab tested at <1% CPU.

**Observability**: `purdex_probe_screen_event_total` counts only accepted transitions; `purdex_probe_grace_window_suppressed_total` counts hook-authority drops. Together these expose the "broadcast economy" without exposing the internal poll rate.

### #6 — G5 parity reworded

**Codex**: "Default profile may capture the same bottom 10 lines, but codex/opencode now go through recordHookAt and graceWindow. Legacy default agents had no grace-window suppression. Not byte-for-byte equivalent."

**Decision: ACCEPT — G5 reworded.** Original G5 wording said "default-profile parity"; that was sloppy. The accurate claim is:

> **G5 (revised) — capture-region parity + uniform graceWindow improvement.** Codex/opencode capture the same bottom-10-lines region as legacy `activityLoop(target, 10)` did. graceWindow (2s post-hook suppression) is a NEW feature applied uniformly to all agents through the orchestrator — it improves hook authority for cc, codex, and opencode equally. The 2s delay before the first probe-driven status change after a hook is intentional: the hook is the authoritative source during transitions.

This is a deliberate behavior change for codex/opencode (gain hook-authority enforcement at the cost of 2s post-hook recovery delay). Defensibility: hook events are infrequent and 2s is well within UX tolerance for status freshness.

## Ship gates

- [x] **G1 unit** — `go test ./... -count=1` all 23 packages green
- [x] **G1 race** — `go test ./... -count=1 -race` clean (CC6 deadlock guard + new race tests)
- [x] **G2 boundary** — `bash scripts/check-pr-4a-1-boundary.sh origin/main` exit 0
- [x] **G5 (revised)** — capture-region parity + uniform graceWindow (see above)
- [x] **G6 watcher leak** — CC2b validates manageActivityWatch(off) clears activeWatchers + prober map
- [ ] **G3 expvar** — manual: `PDX_DEV_MODE=1 ./bin/pdx` then `curl http://localhost:7860/debug/vars | jq '. | with_entries(select(.key | startswith("purdex_probe_")))'`. Automated via OB1/OB2/OB3.
- [ ] **G4 dev log** — manual: `PDX_DEV_MODE=1 ./bin/pdx` + hook + screen event; stderr should contain `[probe] recordHookAt`, `[probe] graceWindow suppress`, `[probe] status` lines. Automated via OB4.

## Codex/opencode behavior compatibility

Neither package was modified. They go through `manageActivityWatch` → `m.probeOrch.startWatch(session, agentType)` → `Registry.Get(agentType)` → not `ProbeProfileProvider` → fallback `defaultProbeProfile{BottomLines:10, IdleStableTicks:3}`. Capture region is byte-for-byte identical to legacy. **NEW**: graceWindow now applies (see #6 above).

## Plan §5 deviations (allowed-paths)

Five files touched beyond plan §5; reasons inline in `scripts/check-pr-4a-1-boundary.sh`:

1. `internal/agent/probe/shell_prompt_test.go` — needed to compile after the looksLikeShellPrompt → LooksLikeShellPrompt export
2. `internal/agent/probe/export_test.go` — minimal SetWatchPollIntervalForTest seam for PR1-PR6 timing
3. `internal/agent/cc/probe_profile_test.go` — Go convention puts test next to impl
4. `internal/module/agent/probe_orchestrator_integration_test.go` — implementer split CC2b/CC4/CC5/CC6 from probe_orchestrator_test.go
5. `internal/module/agent/sweep_test.go` — Commit 2 unavoidable migration: legacy ActivityCallback signature gone

## Test plan

- [x] `go test ./... -count=1` all 23 packages
- [x] `go test ./... -count=1 -race` clean
- [x] `pnpm --prefix spa run lint` (no SPA changes)
- [x] `pnpm --prefix spa run build`
- [x] `bash scripts/check-pr-4a-1-boundary.sh origin/main` exit 0
- [ ] **Manual G3**: PDX_DEV_MODE=1 + cc session + check `/debug/vars` for 4 `purdex_probe_*` counters
- [ ] **Manual G4**: same setup + observe stderr `[probe]` lines on hook + screen event

## Plan reference

`docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md` v2.1