### PR TITLE
fix(electron): stabilize mac signing for updates

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -30,6 +30,7 @@ const REBUILD_TRACKED_PATHS = [
   'package.json',
   'pnpm-lock.yaml',
   'electron-builder.yml',
+  'scripts/build-electron.mjs',
   'build/',
 ]
 

--- a/electron/signing.test.ts
+++ b/electron/signing.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(__dirname, '..')
+
+describe('Electron macOS signing configuration', () => {
+  it('does not explicitly disable macOS signing', () => {
+    const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'))
+    expect(pkg.build?.mac?.identity).not.toBeNull()
+  })
+
+  it('signs and verifies the final moved app bundles', () => {
+    const script = readFileSync(resolve(root, 'scripts/build-electron.mjs'), 'utf8')
+    expect(script).toContain('PDX_MAC_SIGN_IDENTITY')
+    expect(script).toContain('codesign')
+    expect(script).toContain('--verify')
+  })
+
+  it('re-signs the app bundle after dev update mutates bundled resources', () => {
+    const updater = readFileSync(resolve(root, 'electron/updater.ts'), 'utf8')
+    expect(updater).toContain('resignAppBundle')
+    expect(updater).toContain('codesign')
+    expect(updater).toContain('--identifier')
+    expect(updater).toContain('dev.wake.purdex')
+  })
+})

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -1,12 +1,15 @@
 import { app } from 'electron'
+import { execFileSync } from 'child_process'
 import { existsSync, mkdirSync, rmSync, renameSync, cpSync, createWriteStream } from 'fs'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import { pipeline } from 'stream/promises'
 import { extract } from 'tar'
 
 declare const __APP_VERSION__: string
 declare const __ELECTRON_HASH__: string
 declare const __SPA_HASH__: string
+
+const APP_ID = 'dev.wake.purdex'
 
 export interface AppInfo {
   version: string
@@ -37,6 +40,31 @@ export function getAppInfo(): AppInfo {
 
 function authHeaders(token?: string): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+function getAppBundlePath(): string | null {
+  if (process.platform !== 'darwin') return null
+  // /Foo.app/Contents/MacOS/Foo -> /Foo.app
+  return dirname(dirname(dirname(app.getPath('exe'))))
+}
+
+function resignAppBundle(): void {
+  const appBundle = getAppBundlePath()
+  if (!appBundle || process.env.PDX_SKIP_MAC_SIGN === '1') return
+
+  const identity = process.env.PDX_MAC_SIGN_IDENTITY || '-'
+  const signArgs = [
+    '--force',
+    '--deep',
+    '--options', 'runtime',
+    '--identifier', APP_ID,
+    '--sign', identity,
+  ]
+  if (identity === '-') signArgs.push('--timestamp=none')
+  signArgs.push(appBundle)
+
+  execFileSync('codesign', signArgs, { stdio: 'inherit' })
+  execFileSync('codesign', ['--verify', '--deep', '--strict', '--verbose=4', appBundle], { stdio: 'inherit' })
 }
 
 export async function checkUpdate(daemonUrl: string, token?: string): Promise<RemoteVersionInfo> {
@@ -158,6 +186,8 @@ export async function applyUpdate(
         renameSync(src, dst)
       }
     }
+    progress('signing')
+    resignAppBundle()
   } catch (err) {
     // Rollback: restore from backup — each target independently so one
     // failure does not prevent restoring the others

--- a/internal/module/dev/rebuild_detect.go
+++ b/internal/module/dev/rebuild_detect.go
@@ -9,6 +9,7 @@ var rebuildTrackedPaths = []string{
 	"package.json",
 	"pnpm-lock.yaml",
 	"electron-builder.yml",
+	"scripts/build-electron.mjs",
 	"build/",
 }
 

--- a/internal/module/dev/rebuild_detect_test.go
+++ b/internal/module/dev/rebuild_detect_test.go
@@ -2,6 +2,15 @@ package dev
 
 import "testing"
 
+func TestRebuildTrackedPathsIncludesElectronBuilderScript(t *testing.T) {
+	for _, path := range rebuildTrackedPaths {
+		if path == "scripts/build-electron.mjs" {
+			return
+		}
+	}
+	t.Fatalf("rebuildTrackedPaths missing scripts/build-electron.mjs: %#v", rebuildTrackedPaths)
+}
+
 func TestDetectRequiresFullRebuild(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     ],
     "mac": {
       "icon": "build/icon.icns",
-      "identity": null,
       "target": [
         {
           "target": "dir",

--- a/scripts/build-electron.mjs
+++ b/scripts/build-electron.mjs
@@ -1,24 +1,78 @@
 // scripts/build-electron.mjs — Build Electron for both archs with per-arch icons
-import { execSync } from 'child_process'
-import { copyFileSync, renameSync, mkdirSync, existsSync } from 'fs'
+import { execFileSync, execSync, spawnSync } from 'child_process'
+import { copyFileSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const iconDest = resolve(root, 'build/icon.icns')
 const distDir = resolve(root, 'dist')
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'))
+const appId = pkg.build?.appId ?? 'dev.wake.purdex'
+const originalIcon = readFileSync(iconDest)
 
-// Build each arch separately so icon.icns swap takes effect
-for (const [arch, iconSrc] of [['x64', 'build/icon-x64.icns'], ['arm64', 'build/icon-arm64.icns']]) {
-  copyFileSync(resolve(root, iconSrc), iconDest)
-  console.log(`\n--- Building ${arch} (icon: ${iconSrc}) ---\n`)
-  execSync(`npx electron-builder --mac --${arch} -c.directories.output=dist-${arch}`, { cwd: root, stdio: 'inherit' })
+function signAndVerifyApp(appPath) {
+  if (process.platform !== 'darwin') return
+  if (process.env.PDX_SKIP_MAC_SIGN === '1') {
+    console.log(`Skipping macOS signing for ${appPath}`)
+    return
+  }
 
-  // Move output to final dist/
-  const srcApp = resolve(root, `dist-${arch}`, arch === 'x64' ? 'mac' : 'mac-arm64', 'Purdex.app')
-  const destDir = resolve(distDir, arch === 'x64' ? 'mac' : 'mac-arm64')
-  mkdirSync(destDir, { recursive: true })
-  execSync(`rm -rf "${resolve(destDir, 'Purdex.app')}"`)
-  renameSync(srcApp, resolve(destDir, 'Purdex.app'))
-  execSync(`rm -rf "${resolve(root, `dist-${arch}`)}"`)
+  const forcedIdentity = process.env.PDX_MAC_SIGN_IDENTITY
+  if (!forcedIdentity && hasValidSignature(appPath)) {
+    console.log(`Keeping existing macOS signature for ${appPath}`)
+    return
+  }
+
+  const identity = forcedIdentity || '-'
+  const signArgs = [
+    '--force',
+    '--deep',
+    '--options', 'runtime',
+    '--identifier', appId,
+    '--sign', identity,
+  ]
+  if (identity === '-') signArgs.push('--timestamp=none')
+  signArgs.push(appPath)
+
+  console.log(`Signing ${appPath} with ${identity === '-' ? 'ad-hoc identity' : identity}`)
+  execFileSync('codesign', signArgs, { stdio: 'inherit' })
+  verifyApp(appPath)
+}
+
+function hasValidSignature(appPath) {
+  try {
+    verifyApp(appPath)
+    const result = spawnSync('codesign', ['-dv', '--verbose=4', appPath], { encoding: 'utf8' })
+    if (result.status !== 0) return false
+    const output = `${result.stdout}${result.stderr}`
+    return output.includes(`Identifier=${appId}`)
+  } catch {
+    return false
+  }
+}
+
+function verifyApp(appPath) {
+  execFileSync('codesign', ['--verify', '--deep', '--strict', '--verbose=4', appPath], { stdio: 'inherit' })
+}
+
+try {
+  // Build each arch separately so icon.icns swap takes effect
+  for (const [arch, iconSrc] of [['x64', 'build/icon-x64.icns'], ['arm64', 'build/icon-arm64.icns']]) {
+    copyFileSync(resolve(root, iconSrc), iconDest)
+    console.log(`\n--- Building ${arch} (icon: ${iconSrc}) ---\n`)
+    execSync(`npx electron-builder --mac --${arch} -c.directories.output=dist-${arch}`, { cwd: root, stdio: 'inherit' })
+
+    // Move output to final dist/
+    const srcApp = resolve(root, `dist-${arch}`, arch === 'x64' ? 'mac' : 'mac-arm64', 'Purdex.app')
+    const destDir = resolve(distDir, arch === 'x64' ? 'mac' : 'mac-arm64')
+    const destApp = resolve(destDir, 'Purdex.app')
+    mkdirSync(destDir, { recursive: true })
+    rmSync(destApp, { recursive: true, force: true })
+    renameSync(srcApp, destApp)
+    signAndVerifyApp(destApp)
+    rmSync(resolve(root, `dist-${arch}`), { recursive: true, force: true })
+  }
+} finally {
+  writeFileSync(iconDest, originalIcon)
 }

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -253,6 +253,7 @@ export function DevEnvironmentSection() {
     downloading: 'Downloading update…',
     extracting: 'Extracting…',
     applying: 'Applying update…',
+    signing: 'Signing app…',
     restarting: 'Restarting…',
   }
 


### PR DESCRIPTION
## Summary
- Re-enable macOS signing for Electron package builds and verify final app bundles.
- Re-sign the app bundle after dev update mutates packaged resources.
- Track Electron packaging script changes as full-rebuild-required inputs.

## Verification
- pnpm --prefix electron test
- go test ./internal/module/dev -count=1
- pnpm --prefix spa exec tsc -b
- pnpm exec electron-vite build
- pnpm run electron:build
- codesign -dv --verbose=4 dist/mac-arm64/Purdex.app
- codesign -dv --verbose=4 dist/mac/Purdex.app