### PR TITLE
Phase 4a PR-4a-2: codex/opencode ProbeProfileProvider

### DIFF
--- a/docs/specs/2026-04-28-lights-rebuild-fix-spec.md
+++ b/docs/specs/2026-04-28-lights-rebuild-fix-spec.md
@@ -1,0 +1,235 @@
+# Lights Rebuild — Fix-Spec (整體架構修正)
+
+- **Date**: 2026-04-28
+- **Worktree**: `lights-phase-4a-2`（branch `worktree-lights-phase-4a-2`）
+- **Status**: 整體架構修正計劃 — 不取代 `2026-04-23-lights-rebuild-spec.md`，而是修正 Phase 4a 跑偏並重新規劃 Phase 4b/5 範圍
+- **Replaces**: `2026-04-28-lights-rebuild-phase-4a-2-spec.md` + `2026-04-28-lights-rebuild-phase-4a-2-plan.md`（PR #676 跑偏產物）
+
+---
+
+## 0. 來龍去脈：為什麼需要 fix-spec
+
+Phase 0/1/2/3/3.5 全 ship 至 alpha.234。Phase 4a 系列發生**架構性跑偏**：
+
+| PR | 預期 (per spec §8.1) | 實際做了 |
+|---|---|---|
+| PR-4a-0 | OpenCode 1.14.23 hooks completion | ✅ 對 — alpha.233 ship |
+| PR-4a-1 | Activity probe 內部強化（彩虹字 / spinner） | 字元偵測砍掉改 Top-N hash + **加了 ProbeProfileProvider generic framework + cc TopLines profile + default profile fallback + always-on policy** ← **越界做了 Phase 4b 的事，且方向錯** |
+| PR-4a-2 (#676) | codex / opencode 接同 framework | 為 codex / opencode 加 generic profile（framework 本身是錯方向，再延伸只會擴大錯誤）→ codex review R3 抓到「TopLines 在 spinner-only 階段誤判 Idle」P1 → 框架定型錯誤 |
+
+**根因**：PR-4a-1 把 spec §8.1（probe 內部強化）誤擴展為 spec §8.2（per-agent ProbeIntentProvider）的初步框架，且**抽錯方向** — 抽成「per-agent generic single profile」而不是「per-agent + per-缺口 ad-hoc ProbeIntent」。
+
+**修正方向**：
+
+1. 撤回 PR-4a-1 ship 的 generic framework 部分
+2. 保留 PR-4a-1 ship 的 shared utilities（probe primitive / tmux capture / orchestrator 機制）
+3. 重做 Phase 4b（spec §8.2 既有設計）— 這次正確：per-agent + per-缺口 ProbeIntent
+4. 順手清掉一個累積已久的可讀性債：catalog naming 沒區分 PurdexName vs UpstreamKey
+
+---
+
+## 1. 架構基準圖（fix 後）
+
+```
+HOOK LAYER (per-agent installer + handler entry)
+  cc:       ~/.claude/settings.json   key=UpstreamKey "SessionStart"
+  codex:    ~/.codex/hooks.json       key=UpstreamKey "SessionStart"
+  opencode: plugin emit               key=UpstreamKey "session.created"
+                          ↓
+                   command argument = PurdexName "PdxSessionStart"
+                          ↓
+        Daemon handler entry 收到永遠是 (agent_type, PurdexName)
+                          ↓
+─────────── 對齊 audit ───────────→ 列出 hook → status → 燈號 缺口
+                          ↓
+                  決定每家 agent 哪些缺口要用 probe 補
+                          ↓
+              (only those gaps) → ad-hoc probe code in agent module
+                                  using PROBE LAYER shared utilities
+                                  via per-agent ProbeIntentProvider
+                          ↓
+                Status broadcast → SPA 燈號（不在本 fix scope）
+                          ↓
+        Observable via TraceStore + PDX_DEV_MODE log
+        Inspectable via Dev Inspector UI (Phase 5)
+```
+
+**核心原則**：
+
+- **Probe 不是 always-on**：是 hook coverage **缺口導向** 的補位工具
+- **缺口 per-agent specific**：實際運行觀察決定，不憑空假設
+- **補位方式 ad-hoc**：寫在 agent module 內，不抽 generic framework
+- **抽象在 input/output 邊界**：catalog naming 分離 PurdexName / UpstreamKey；daemon 內部一律 PurdexName
+- **觀察優先**：runtime observability (TraceStore + dev log) 比 ship-time sampling 更可靠
+
+---
+
+## 2. 工作項拆解 (W1–W7)
+
+| Work | 對應決議 | 預估規模 | 對應 spec phase |
+|---|---|---|---|
+| **W1 — Hook → status → 燈號 對齊 audit**（純 docs） | (a) | 小（純 audit doc） | Phase 4b 前置 audit (spec §8.2) |
+| **W2 — Catalog naming separation**（PurdexName + UpstreamKey） | 4 | 中（catalog + installer + tests + reinstall hooks.json） | 不在原 spec phase 內，新增 |
+| **W3 — Framework 撤回**（ProbeProfileProvider + ProbeProfile + default profile + always-on policy） | 2 | 中（撤 code + 改 manageActivityWatch policy） | Phase 4b 範圍（撤回 PR-4a-1 越界部分） |
+| **W4 — Observability 補完**（TraceStore step + PDX_DEV_MODE log 全路徑覆蓋；handler / DeriveStatus / probe / broadcast 各層） | 5 | 中 | Phase 4b 範圍 (d) |
+| **W5 — 修 W1 audit 出來的燈號 bug** | (b) | 視 audit 結果 | Phase 4b follow-up |
+| **W6 — per-agent ad-hoc probe 補缺口**（為 W1 audit 找出的缺口寫 ProbeIntent / ad-hoc detector） | (c) | 視 audit 結果 | Phase 4b 主體 (spec §8.2 ProbeIntentProvider) |
+| **W7 — Dev Inspector UI**（消費 W4 補完的 observability + Coverage endpoint） | 5 | 中（新 endpoint + SPA 4 視圖） | Phase 5 (spec §9) |
+
+**保留 unchanged**：
+
+- PR-4a-1 ship 的 shared utilities：`probe.Watch` / `WatchOptions` / `tmux.CapturePaneTopLines` / `CapturePaneRange` / `LooksLikeShellPrompt` / orchestrator `graceWindow` / `Error guard` / `stale-callback guard` / `transition gate` / `recordHookAt`
+- PR-4a-1 ship 的 `purdex_probe_*` expvar counters（4 個；跟 (d) 正交，不擴不撤）
+- PR-4a-1 ship 的 PDX_DEV_MODE log 既有 5 條（W4 是補完不是重做）
+- Phase 0–3.5 全部 ship 內容
+
+---
+
+## 3. 撤回清單（W3 範圍）
+
+**從 main 撤回**（PR-4a-1 ship 的 generic framework 部分）：
+
+| 項目 | 檔案 | 撤回後行為 |
+|---|---|---|
+| `ProbeProfileProvider` interface | `internal/agent/provider.go` | 移除；orchestrator 不再 type-assert |
+| `ProbeProfile` struct | `internal/agent/provider.go` | 移除 |
+| cc `ProbeProfile()` impl | `internal/agent/cc/probe_profile.go` (+ test) | 整檔刪 |
+| `defaultProbeProfile` | `internal/module/agent/probe_orchestrator.go` | 移除（後面也不需要 default — probe 不 always-on） |
+| `manageActivityWatch` 「status ∈ {Waiting/Running/Idle} 啟動 probe」always-on policy | `internal/module/agent/module.go:469-501` | 改為 per-agent gating，預設不啟動；W6 為各 agent 寫的 ProbeIntent 才啟動 |
+| 既有 OR1 / OR2 / FX4 等 generic profile fake test | `internal/module/agent/probe_orchestrator_test.go` | 撤；改測 ProbeIntent 行為 |
+
+**保留**：
+
+- `probe.Watch(target, opts, cb)` + `WatchOptions{TopLines, BottomLines, IdleStableTicks}` — 這是 shared utility，W6 ad-hoc detector 還會用
+- orchestrator 的 graceWindow / Error guard / stale-callback guard / transition gate — shared 機制
+- `recordHookAt` — hook → probe 銜接機制
+
+---
+
+## 4. PR 拆分提議
+
+```
+PR-1 [Step A] Close PR #676
+  - 不縮、不 squash，直接 close
+  - 跑偏的 spec/plan/sampling artifact 不 merge
+  - 留 reference link 在 fix-spec
+  - 即時可做，無相依
+
+PR-2 [W1] Hook → status → 燈號 對齊 audit doc
+  - 純 docs，無 code
+  - 產出 docs/specs/2026-04-XX-hook-status-audit.md
+  - 涵蓋三家 × 5 status × hook 觸發點 × 實際燈號 + Subagent + Proxy + Error 路徑
+  - 列出實際燈號 bug 清單作為 W5 工作池
+  - 列出實際 probe 缺口清單作為 W6 工作池
+  - 依賴 PR-1 merge
+
+PR-3 [W2] Catalog naming separation (PurdexName / UpstreamKey)
+  - HookEventSpec 加 PurdexName + UpstreamKey 欄位
+  - 三家 events.go catalog 改名（PurdexName 用 "Pdx" 前綴或自定義 namespace，視 PR-3 dev spec 決定）
+  - cc/codex installer 改：hooks file key=UpstreamKey, command arg=PurdexName
+  - opencode plugin_template 改：emit 時用 PurdexName
+  - handler entry 收到永遠是 PurdexName
+  - 既有 ~/.codex/hooks.json / ~/.claude/settings.json 需 reinstall（alpha 階段可破壞）
+  - 跟 PR-2 平行可做（不依賴 audit 結果）
+
+PR-4 [W3 + W4] Framework 撤回 + Observability 補完
+  - 撤 §3 列的 framework code
+  - manageActivityWatch policy 改 per-agent gating（三家先全 disable probe，等 W6 為各 agent 加 ProbeIntent 才啟動）
+  - 補 dev log 覆蓋整條 hook → DeriveStatus → handler → projection → broadcast 路徑
+  - 補 TraceStore step 在每層轉換點寫一筆（per spec §2.3 SOT 設計）
+  - 依賴 PR-2 audit 結果決定 dev log 哪些路徑 priority 最高
+  - 依賴 PR-3 完成（撤回時 catalog 已是 PurdexName 形態）
+
+PR-5+ [W5 + W6] 修 audit 找出的燈號 bug + 為缺口寫 per-agent ad-hoc probe
+  - per-agent / per-bug / per-缺口 拆 multiple small PR
+  - 每個 ad-hoc probe 用 ProbeIntentProvider interface（spec §8.2 形態，但 lazy 設計 — 等真寫第一個才 finalize interface shape）
+  - readiness 整合（cc CheckReadiness）也屬於這層 — spec §8.2 既定要求
+
+PR-N [W7] Dev Inspector UI (Phase 5)
+  - 新 backend endpoint /api/agent/monitor/coverage
+  - SPA 4 視圖：Chain / Detail / Projection / Coverage Matrix
+  - 主要消費 PR-4 補完的 observability + Coverage 既有結構
+  - 依賴 PR-4 ship + PR-5+ 大致 stabilize
+```
+
+---
+
+## 5. 對應原 spec phase mapping
+
+| 原 spec phase | 在 fix-spec 中對應 | 狀態 |
+|---|---|---|
+| Phase 0–3.5 | 不變，已 ship | ✅ |
+| Phase 4a (spec §8.1) | PR-4a-0 (alpha.233) ✅ ship；PR-4a-1 (alpha.234) ship 但有越界部分待 W3 撤回；PR-4a-2 (#676) close 不 ship | ⚠️ 部分撤回 |
+| Phase 4b (spec §8.2) | W1 (audit) + W3 (撤回 generic framework) + W4 (observability) + W6 (ProbeIntent + readiness 整合) | 重新規劃 |
+| Phase 5 (spec §9) | W7 | 不變，仍待 4b 完成 |
+| W2 (catalog naming) | 新增，不在原 spec | 同期可讀性整理 |
+
+---
+
+## 6. Risk & Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| PR-4a-1 ship 在 alpha.234，撤回 framework 可能影響並發開發 | W3 撤回前先 W1 audit + W2 naming，三 PR 並行；W3 撤回時 main 上 framework 才被 active 使用兩週 (alpha.234 → 撤回時 alpha.~240)，影響 surface 小 |
+| reinstall hooks.json 破壞所有現有 user 環境 | alpha 階段允許破壞性升級（per `feedback_no_alpha_migration`）；PR-3 ship 後 user 跑一次 `pdx install --reinstall` 即可 |
+| W1 audit 規模超預期（三家 × 5 status × N 路徑） | audit 不求完整，求**已知 bug + 已知缺口** 的 evidence；未發現的留 follow-up |
+| W6 ProbeIntent interface 設計過早 framework 化 | lazy 設計 — 等寫第一個 per-agent ProbeIntent 時才 finalize interface shape，避免再次 over-framework |
+| Phase 5 Inspector 等不到 4b 收斂 | W7 可選擇性提早 — backend Coverage endpoint 可以在 PR-4 一併補；SPA UI 等 PR-5+ 大致 stabilize |
+| 主 repo 並發 session（feedback_concurrent_session_safety） | 每個子 PR 進 worktree 前 `git status -s` clean check + push 前 `git pull --rebase origin main` |
+
+---
+
+## 7. 遵循的設計原則 (per lights-rebuild-spec §2.4 Architecture Guardrails)
+
+- **§2.4.1 中央 vs 分散判準**：W3 撤的 ProbeProfileProvider 是「runtime 跑過中央物件」= 嚴重膨脹徵兆 → 撤；W6 ProbeIntentProvider 是「per-agent 自宣告 + 共用 plumbing」= 不膨脹 → 寫
+- **§2.4.5 Bloat 警覺詞**：W6 ProbeIntent 設計時警覺「Central FSM / Event catalog / Transition registry」三詞；任一冒出停手反思
+- **`feedback_skeleton_convergence`**：W2/W3/W4/W6 設計時警覺五大 bloat 徵兆（把 working code 變 data / parallel registry / 統一抽象 / refactor working code / config flag）
+
+---
+
+## 8. 結束條件（fix-spec 完成）
+
+當 PR-1 至 PR-N 全部 ship 後：
+
+- Lights 子系統完全對齊 spec §8.1 (Phase 4a)/§8.2 (Phase 4b)/§9 (Phase 5) 設計
+- 三家 agent 的 hook → status → 燈號 路徑全 audit + 已知 bug 已修
+- per-agent ProbeIntent 為實際缺口提供 ad-hoc 補位
+- TraceStore + PDX_DEV_MODE log 全路徑可觀察
+- Dev Inspector UI 提供視覺化檢視
+- catalog naming 完全分離 PurdexName / UpstreamKey
+
+**memory 更新**：
+
+- `kickoff_lights_rebuild.md`：Phase 4a 標完成 with caveats（caveats 由 fix-spec 後續處理）；觸發詞改為按 W1-W7 順序執行
+- `project_progress.md`：對應 alpha 版本
+
+---
+
+## 9. 文獻
+
+- 原 spec: `docs/specs/2026-04-23-lights-rebuild-spec.md`（不取代，本 fix-spec 是其修正延伸）
+- Phase 4a plans:
+  - `docs/specs/2026-04-26-lights-rebuild-phase-4a-plan.md` (PR-4a-0 ship)
+  - `docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md` (PR-4a-1 ship, framework 部分待撤)
+- Phase 4a-2 廢棄 plans（PR #676 跑偏產物，本 fix-spec 取代）：
+  - `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md`
+  - `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md`
+  - `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-sampling.md`
+- 相關 PR: #664 (4a-0) / #670 (4a-1) / #676 (4a-2 close)
+- 相關 issue: 待 W1 audit 後開（W5/W6 工作池）
+
+---
+
+## 10. 後續產出
+
+每個 W 進入實作前，產出對應 dev spec：
+
+- `docs/specs/2026-04-XX-hook-status-audit-spec.md` (W1)
+- `docs/specs/2026-04-XX-catalog-naming-separation-spec.md` (W2)
+- `docs/specs/2026-04-XX-probe-framework-revert-spec.md` (W3)
+- `docs/specs/2026-04-XX-observability-completion-spec.md` (W4)
+- `docs/specs/2026-04-XX-light-bug-fix-spec.md` (W5，per-bug 或 batch)
+- `docs/specs/2026-04-XX-probe-intent-impl-spec.md` (W6，per-agent 或 batch)
+- `docs/specs/2026-04-XX-dev-inspector-ui-spec.md` (W7)
+
+每份 dev spec 後跟對應 plan + 實作 + 兩輪 codex review + ship + bump，沿用 CLAUDE.md 流程。

--- a/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md
+++ b/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md
@@ -33,24 +33,62 @@
 
 ## 2. Commit 順序（TDD red → green，每 commit 獨立）
 
+合併原 C3（orchestrator regression test）進 C1 / C2 — OR-codex / OR-opencode 在 codex / opencode 尚未實作 `ProbeProfile()` 時，orchestrator type-assert 失敗會走 default `{BottomLines:10}`，正好作為 C1 / C2 紅燈的另一條斷言（codex review R1 plan finding #1）。
+
 ### Commit 1 — `feat(agent/codex): implement ProbeProfileProvider with TopLines profile`
+
+**改動 4 處**：
+- 新檔 `internal/agent/codex/probe_profile.go`
+- 新檔 `internal/agent/codex/probe_profile_test.go`（CDX1）
+- 既檔 `internal/module/agent/probe_orchestrator_test.go` +OR-codex test
+- 既檔 `internal/module/agent/probe_orchestrator_test.go` 加小 helper（見 §3.1，視 OR-codex 是否需 helper 簡化而定）
 
 **TDD 流程**：
 
-1. **紅燈**：先建 `internal/agent/codex/probe_profile_test.go`：
-   ```go
-   // CDX1 — characterization test pinning codex's ProbeProfile values.
-   // codex CLI is an append-only TUI: top hash signals new turns; bottom
-   // contains spinner + elapsed timer (variable). TopLines=10 captures
-   // the recent turn cluster while keeping captures cheap. IdleStableTicks=3
-   // matches the watch-loop default (BB-stable).
-   //
-   // If a future codex UI revision invalidates these tunings, prefer
-   // RE-SAMPLING (per spec §2.2.3) and updating values + this test
-   // together. See spec docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md §2.2.
-   func TestCodexProvider_ProbeProfile(t *testing.T) { ... }
-   ```
-   `go test ./internal/agent/codex/... -run TestCodexProvider_ProbeProfile` → **fail**（method 不存在）
+1. **紅燈 — 兩個 test 一起紅**：
+   - 建 `internal/agent/codex/probe_profile_test.go`（CDX1）：
+     ```go
+     // CDX1 — characterization test pinning codex's ProbeProfile values.
+     // See spec docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md §2.2.
+     func TestCodexProvider_ProbeProfile(t *testing.T) {
+         p := codex.NewProvider()
+         got := p.ProbeProfile()
+         want := agent.ProbeProfile{TopLines: 10, IdleStableTicks: 3}
+         if got != want {
+             t.Fatalf("ProbeProfile() = %+v, want %+v", got, want)
+         }
+     }
+     ```
+     `go test ./internal/agent/codex/... -run TestCodexProvider_ProbeProfile` → **fail**（`p.ProbeProfile undefined`）
+
+   - 在 `internal/module/agent/probe_orchestrator_test.go` 加 OR-codex（沿用既有 `newTestModule` + `recordingProber` + `rec.watchOpts["sess:"]` 模式，per OR1 line 758-781）：
+     ```go
+     // OR-codex — orchestrator picks up real codex.Provider's TopLines profile
+     // (not the default BottomLines fallback). Regression for accidental
+     // ProbeProfile() removal on codex.Provider.
+     func TestOrchestrator_RealCodexProviderUsesTopLinesProfile(t *testing.T) {
+         m := newTestModule(t)
+         rec := newRecordingProber()
+         m.probeOrch.watcher = rec
+         m.registry.Register(codex.NewProvider())
+
+         m.probeOrch.startWatch("sess", "codex")
+
+         rec.mu.Lock()
+         defer rec.mu.Unlock()
+         got, ok := rec.watchOpts["sess:"]
+         if !ok {
+             t.Fatalf("expected Watch on target %q, got %v", "sess:", rec.watchOpts)
+         }
+         want := probe.WatchOptions{TopLines: 10, BottomLines: 0, IdleStableTicks: 3}
+         if got != want {
+             t.Fatalf("WatchOptions = %+v, want %+v (codex TopLines profile)", got, want)
+         }
+     }
+     ```
+     在 codex.Provider 還沒實作 `ProbeProfile()` 之前，orchestrator type-assert 失敗 → fallback 到 `defaultProbeProfile = {BottomLines: 10, IdleStableTicks: 3}` → 與 want 不符 → **fail**。
+
+   - 在 `internal/module/agent/probe_orchestrator_test.go` 同檔加 import：`"github.com/wake/purdex/internal/agent/codex"`（若尚未 import）
 
 2. **綠燈**：建 `internal/agent/codex/probe_profile.go`：
    ```go
@@ -75,13 +113,9 @@
        }
    }
    ```
-   `go test ./internal/agent/codex/... -count=1` → **pass**
+   `go test ./internal/agent/codex/... ./internal/module/agent/... -count=1` → **pass**（CDX1 + OR-codex 都綠）
 
-3. **採樣 confirm（spec G7）**：implementer 在實作後對真實 codex session 跑：
-   ```bash
-   tmux capture-pane -t <codex-session>:0 -p -S -10 -E -1   # 上方 10 行
-   ```
-   三狀態各跑一次（idle / running with output / spinner-only）— 結果寫進 PR description 的 Sampling Evidence 段（per spec §5 G7）。
+3. **採樣 confirm（spec G7）**：implementer 在實作後對真實 codex session 跑採樣（命令見 §4），三狀態結果寫進 PR description 的 Sampling Evidence — codex 段。
 
 4. **Commit msg**：
    ```
@@ -92,18 +126,29 @@
    cluster while keeping captures cheap. IdleStableTicks=3 matches the
    watch-loop default.
 
+   Tests: CDX1 (characterization) + OR-codex (orchestrator regression
+   that real codex.Provider really implements ProbeProfileProvider).
+
    See docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md §2.2.
    ```
 
 ### Commit 2 — `feat(agent/opencode): implement ProbeProfileProvider with TopLines profile`
 
-**TDD 流程**：
+**改動 3-4 處**：
+- 新檔 `internal/agent/opencode/probe_profile.go`
+- 新檔 `internal/agent/opencode/probe_profile_test.go`（OCD1）
+- 既檔 `internal/module/agent/probe_orchestrator_test.go` +OR-opencode test（同 OR-codex 結構）
 
-1. **紅燈**：建 `internal/agent/opencode/probe_profile_test.go`（OCD1，結構同 CDX1，profile 同值）→ fail
+**TDD 流程**（與 Commit 1 同型）：
 
-2. **綠燈**：建 `internal/agent/opencode/probe_profile.go`（同型，註解強調 opencode TUI 結構與 codex 同型）→ pass
+1. **紅燈 — 兩個 test 一起紅**：
+   - 建 OCD1：與 CDX1 同型，change provider 為 `opencode.NewProvider()`，want 同值（`{TopLines: 10, IdleStableTicks: 3}`）
+   - 加 OR-opencode：與 OR-codex 同型，target `"sess2:"`，agentType `"opencode"`，import `"github.com/wake/purdex/internal/agent/opencode"`
+   - 兩者都 fail（opencode.Provider 沒 `ProbeProfile()` → type-assert 失敗 → default fallback 不符 want）
 
-3. **採樣 confirm**：對真實 opencode session 跑同樣三狀態採樣，結果寫進 PR description
+2. **綠燈**：建 `internal/agent/opencode/probe_profile.go`（同 codex 結構，註解強調「opencode TUI 與 codex 同型」+ 引用 spec §2.3）→ pass
+
+3. **採樣 confirm**：對真實 opencode session 跑同樣三狀態採樣，寫進 PR description
 
 4. **Commit msg**：
    ```
@@ -113,48 +158,9 @@
    bottom prompt + spinner. TopLines=10 + IdleStableTicks=3 mirror codex
    profile values; per-agent rationale documented in spec §2.3.
 
+   Tests: OCD1 (characterization) + OR-opencode (orchestrator regression).
+
    See docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md §2.3.
-   ```
-
-### Commit 3 — `test(module/agent): cover orchestrator with real codex/opencode providers`
-
-**目的**：驗證 orchestrator 對真實 codex / opencode provider type-assert `ProbeProfileProvider` 成功（不退到 default fallback）。
-
-**TDD 流程**：
-
-1. **紅燈/綠燈一體**：在 `internal/module/agent/probe_orchestrator_test.go` 加兩 case（不需先紅後綠 — 是 integration assertion，新加直接綠才有意義；若紅就是 Commit 1/2 沒過）：
-
-   ```go
-   // OR-codex — orchestrator picks up codex.Provider.ProbeProfile() (TopLines)
-   // not the default profile (BottomLines).
-   func TestProbeOrchestrator_StartWatch_CodexProvider(t *testing.T) {
-       harness := newTestHarness(t)
-       harness.registry.Register(codex.NewProvider())
-       harness.module.manageActivityWatch("S1", "codex", agentpkg.StatusRunning)
-
-       // Assert: prober.WatchOptions has TopLines=10, BottomLines=0
-       got := harness.fakeProber.LastWatchOptions("S1:")
-       if got.TopLines != 10 || got.BottomLines != 0 {
-           t.Fatalf("expected TopLines=10 BottomLines=0, got %+v", got)
-       }
-   }
-
-   // OR-opencode — orchestrator picks up opencode.Provider.ProbeProfile()
-   func TestProbeOrchestrator_StartWatch_OpenCodeProvider(t *testing.T) { ... }
-   ```
-
-2. **跑**：`go test ./internal/module/agent/... -run "TestProbeOrchestrator_StartWatch_CodexProvider|TestProbeOrchestrator_StartWatch_OpenCodeProvider" -count=1` → pass
-
-3. **不重複既有覆蓋**：OR1（fake provider with profile）+ OR2（fake provider without profile）已驗 type-assert 機制；OR-codex / OR-opencode 是「真實 provider 對接」regression 而非 mechanism re-test。
-
-4. **Commit msg**：
-   ```
-   test(module/agent): cover orchestrator with real codex/opencode providers
-
-   OR1/OR2 cover the type-assert mechanism via fakes; OR-codex / OR-opencode
-   add regression coverage that real codex.Provider / opencode.Provider
-   actually implement ProbeProfileProvider and produce the expected
-   TopLines profile (catches future accidental method removal).
    ```
 
 ## 3. 測試矩陣
@@ -163,10 +169,20 @@
 |---|---|---|
 | CDX1 `TestCodexProvider_ProbeProfile` | `internal/agent/codex/probe_profile_test.go` | codex profile values pinning（characterization） |
 | OCD1 `TestOpenCodeProvider_ProbeProfile` | `internal/agent/opencode/probe_profile_test.go` | opencode profile values pinning（characterization） |
-| OR-codex `TestProbeOrchestrator_StartWatch_CodexProvider` | `internal/module/agent/probe_orchestrator_test.go` | orchestrator 真實 codex provider type-assert + WatchOptions forward |
-| OR-opencode `TestProbeOrchestrator_StartWatch_OpenCodeProvider` | `internal/module/agent/probe_orchestrator_test.go` | orchestrator 真實 opencode provider type-assert + WatchOptions forward |
+| OR-codex `TestOrchestrator_RealCodexProviderUsesTopLinesProfile` | `internal/module/agent/probe_orchestrator_test.go` | orchestrator 真實 codex provider type-assert + WatchOptions forward |
+| OR-opencode `TestOrchestrator_RealOpenCodeProviderUsesTopLinesProfile` | `internal/module/agent/probe_orchestrator_test.go` | orchestrator 真實 opencode provider type-assert + WatchOptions forward |
 
 **淨增**：4 tests / 0 既有 test 動到（cc CC1 / OR1 / OR2 等全部不變）。
+
+### 3.1 既有 test infrastructure 沿用
+
+OR-codex / OR-opencode 直接沿用既有 `internal/module/agent/probe_orchestrator_test.go` 既有設施（per OR1 line 758-781）：
+
+- `newTestModule(t)` — module test fixture（fakes_test.go）
+- `newRecordingProber()` — recording fake prober；直接讀 `rec.watchOpts[target]` 取 last WatchOptions（**不需新加 helper**）
+- `m.registry.Register(...)` — provider registry registration
+
+**不新增 helper**（如 `LastWatchOptions`），保持 PR diff 最小化。若 implementer 跑時發現直讀 map 太冗長導致 OR-codex / OR-opencode body 過大，可選擇加同型 helper（必須在 commit 內 docu rationale）。
 
 ## 4. Implementer 採樣 confirm 流程（落實 spec G7）
 
@@ -176,36 +192,48 @@
    - codex：開一個 codex CLI session 在某 tmux pane（target 例：`%41`）
    - opencode：開一個 opencode session 在某 tmux pane
 
-2. **三狀態採樣**（每狀態跑一次）：
+2. **三狀態採樣**（每狀態 3 次 capture，間隔 0.5s — 對齊 spec IdleStableTicks=3 約定）：
+
+   採樣命令統一使用與 production 一致的 `CapturePaneTopLines` 等價命令（per `internal/tmux/executor.go:344` → `CapturePaneRange(target, 0, n-1)` → `tmux capture-pane -e -p -t <target> -S 0 -E 9`）。**`-e` 必須加** — production 保留 ANSI escape 以區分 spinner color 動畫（per executor.go:332-336 註解）；移除 `-e` 會讓採樣跟 production 行為不同步。
+
    ```bash
+   TARGET=<codex-or-opencode-tmux-target>     # e.g. %41 or session:window.pane
+   CAPTURE() { tmux capture-pane -e -p -t "$TARGET" -S 0 -E 9; }
+   HASH() { CAPTURE | md5; }
+
    # State A: idle（agent 沒在處理，user 也沒輸入）
-   tmux capture-pane -t <target> -p -S 0 -E 9            # 頂部 10 行
-   tmux capture-pane -t <target> -p -S 0 -E 9 | md5      # hash
+   echo "=== State A capture ==="; CAPTURE
+   echo "=== State A hashes (3 ticks @ 0.5s) ==="
+   HASH; sleep 0.5; HASH; sleep 0.5; HASH
 
    # State B: running with active output（spinner 持續轉、輸出滾動）
-   # （相隔 1.5s 跑兩次，比較頂部 10 行 hash 是否變動）
-   tmux capture-pane -t <target> -p -S 0 -E 9 | md5
-   sleep 1.5
-   tmux capture-pane -t <target> -p -S 0 -E 9 | md5
+   echo "=== State B capture ==="; CAPTURE
+   echo "=== State B hashes (3 ticks @ 0.5s) ==="
+   HASH; sleep 0.5; HASH; sleep 0.5; HASH
 
-   # State C: spinner-only（agent 在等模型回應，僅 spinner 動）
-   tmux capture-pane -t <target> -p -S 0 -E 9 | md5
-   sleep 1.5
-   tmux capture-pane -t <target> -p -S 0 -E 9 | md5
+   # State C: spinner-only（agent 在等模型回應，僅 spinner 動，無新輸出 scroll 到頂部）
+   echo "=== State C capture ==="; CAPTURE
+   echo "=== State C hashes (3 ticks @ 0.5s) ==="
+   HASH; sleep 0.5; HASH; sleep 0.5; HASH
    ```
 
-3. **判讀**：
-   - State A：兩次 hash 必須**相同**（idle stable）
-   - State B：兩次 hash 必須**不同**（new content scrolls top）
-   - State C：兩次 hash 必須**相同**（spinner 在底部不影響頂部）— 此即 TopLines vs BottomLines 的關鍵差異
-   - 頂部 10 行內容檢查：**不應**含 elapsed timer / spinner 字元
+3. **判讀**（3 次 hash 為一組）：
+   - **State A — idle stable**：3 次 hash 全部**相同** → 對應 watch-loop 連續 3 ticks 一致即 fire ScreenStable，PASS
+   - **State B — top scrolls on new turn**：3 次 hash 至少**有一次變動** → 對應 watch-loop fire ScreenChanged，PASS
+   - **State C — spinner doesn't reach top**：3 次 hash 全部**相同** → 證明底部 spinner 不污染頂部 10 行；TopLines vs BottomLines 的關鍵差異，PASS
+   - 頂部 10 行**內容檢查**（State A capture）：**不應**含 elapsed timer（如 `(12s elapsed)` / `[1.5s]`）、braille spinner（`⠋⠙⠹...`）、旋轉系列（`/─\|`）字元
 
-4. **PR description 留痕**：把每次 capture 輸出的前幾行（敏感內容遮蔽）+ hash + 判讀結論貼進 PR description 的 Sampling Evidence 段（per spec §5 G7）。
+4. **PR description 留痕**（per spec §5 G7）：每家 agent 段落含：
+   - 採樣命令（含 TARGET 值；session 內容若敏感可遮蔽用戶輸入但保留 hash）
+   - State A / B / C 各自的 capture 輸出前 5 行（ANSI 可保留為 raw escape）
+   - State A / B / C 各自 3 次 hash 列表
+   - 三狀態 PASS / FAIL 判讀
+   - 「頂部 10 行不含動態字元」的 yes/no 觀察
 
 5. **若任一條件不過**：
-   - State A 失敗 → top 區域不穩定（可能 codex 在頂部畫了某個動態元件）→ 改用較大 IdleStableTicks 或改 capture mode；spec §2.2 / §2.3 同步修
-   - State B 失敗 → top 區域不會被 new turn 變動 → TopLines hash 永遠 stable → idle 判定誤報 → 應改用 BottomLines 或調整 N
-   - State C 失敗 → 頂部含動態字元 → 改 BottomLines 反而不行（同樣動態）→ 增大 N 跳過動態區，或改全 pane + 加 IdleStableTicks
+   - State A 失敗（idle 3 hash 不全同）→ top 區域不穩定（可能 codex 在頂部畫了某個動態元件）→ 改用較大 IdleStableTicks 或改 capture mode；spec §2.2 / §2.3 同步修
+   - State B 失敗（new turn 3 hash 全同）→ top 區域不會被 new turn 變動 → TopLines hash 永遠 stable → idle 判定誤報 → 應改用 BottomLines 或調整 N
+   - State C 失敗（spinner-only 3 hash 不全同）→ 頂部含動態字元 → 改 BottomLines 反而不行（同樣動態）→ 增大 N 跳過動態區，或改全 pane（`{TopLines: 0, BottomLines: 0}`）+ 加 IdleStableTicks
    - 任一情況 → spec 修值或改設計後重採樣，不硬上
 
 ## 5. Final Verification
@@ -238,7 +266,7 @@ pnpm --prefix spa exec vitest run
 | Summary | 1-2 句說明「為 codex / opencode 加自訂 ProbeProfileProvider，profile = TopLines:10 + IdleStableTicks:3」 |
 | Spec link | `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md` |
 | Plan link | `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md` |
-| Commit list | C1 codex / C2 opencode / C3 orchestrator regression — 每 commit 一行說明 |
+| Commit list | C1 codex（含 CDX1 + OR-codex）/ C2 opencode（含 OCD1 + OR-opencode）— 每 commit 一行說明 |
 | Sampling Evidence — codex | 三狀態採樣輸出（前 5 行 + hash） + 判讀結論（State A/B/C 各 PASS）|
 | Sampling Evidence — opencode | 同上 |
 | Worktree origin | `git status -s` clean check 留痕（per CLAUDE.md feedback_concurrent_session_safety） |
@@ -263,9 +291,8 @@ pnpm --prefix spa exec vitest run
 
 | Commit | 估 LoC | 估 tests | 備註 |
 |---|---|---|---|
-| 1: codex probe_profile.go + test | ~25 (impl) + ~20 (test) | 1 (CDX1) | mirrors cc/probe_profile.go shape |
-| 2: opencode probe_profile.go + test | ~25 (impl) + ~20 (test) | 1 (OCD1) | mirrors codex |
-| 3: orchestrator integration tests | ~60 (test) | 2 (OR-codex / OR-opencode) | re-uses existing newTestHarness + fakeProber |
+| 1: codex probe_profile.go + CDX1 + OR-codex | ~25 (impl) + ~20 (CDX1) + ~30 (OR-codex) | 2 (CDX1 + OR-codex) | mirrors cc/probe_profile.go shape；OR-codex 沿用 OR1 line 758-781 形狀，直讀 `rec.watchOpts["sess:"]`，不新加 helper |
+| 2: opencode probe_profile.go + OCD1 + OR-opencode | ~25 (impl) + ~20 (OCD1) + ~30 (OR-opencode) | 2 (OCD1 + OR-opencode) | mirrors codex |
 
 **總計**：~150 LoC + 4 tests。**屬小型 PR**（per spec scope 縮減）。
 
@@ -275,9 +302,20 @@ pnpm --prefix spa exec vitest run
 
 - spec §5 G1-G8 全綠
 - PR merged
-- 對應 main bump PR ship（VERSION 進到 alpha.235）
+- 對應 main bump PR ship
 
-**Memory 更新**：
+**Bump PR 步驟**（per CLAUDE.md「VERSION 為 SOT，bump 時須同步 package.json + spa/package.json」+ `feedback_bump_base_origin_not_local`）：
+
+1. 進新 worktree（branch 名 `worktree-bump-alpha-235`），先 `git fetch origin main && git reset --hard origin/main`（避免 local main 並發 session commit）
+2. 改 `VERSION`：`1.0.0-alpha.234` → `1.0.0-alpha.235`
+3. 改 `package.json` `version` field 同步
+4. 改 `spa/package.json` `version` field 同步
+5. 加 `CHANGELOG.md` alpha.235 條目（含 PR-4a-2 PR 號 + 一行說明 codex/opencode ProbeProfile）
+6. Commit message: `chore: bump version to 1.0.0-alpha.235 (#<PR>)`
+7. 開 PR、merge
+8. 退 worktree
+
+**Memory 更新**（bump merge 後）：
 
 - `kickoff_lights_rebuild.md`：標 PR-4a-2 完成 + 觸發詞清掉「PR-4a-2」分支；Phase 4a 全完工 → 下個觸發改為「啟動 Phase 4b」
 - `project_progress.md`：alpha.235

--- a/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md
+++ b/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md
@@ -1,0 +1,294 @@
+# Lights Rebuild — Phase 4a-2 Plan v1 (PR-4a-2 codex / opencode ProbeProfile)
+
+## v1.x 演進
+
+| 版本 | Commit | 日期 | 主要變更 |
+|---|---|---|---|
+| v1 | (TBD) | 2026-04-28 | 初版 |
+
+## 0. 來龍去脈
+
+依 `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md` 落實 PR-4a-2：
+
+- **Slice 5**：codex Provider 實作 `ProbeProfileProvider`（推薦 `{TopLines: 10, IdleStableTicks: 3}`）
+- **Slice 6**：opencode Provider 實作 `ProbeProfileProvider`（同推薦值）
+- **Slice 7**（新加 — orchestrator integration test）：`probe_orchestrator_test.go` 補 OR-codex / OR-opencode case，驗證 orchestrator 對 codex / opencode 取到自訂 profile（非 default fallback）
+
+承接：PR-4a-1 ship at alpha.234（PR #670），probe primitive + orchestrator + cc profile 已就位。
+
+## 1. Scope
+
+### 1.1 In scope
+
+- `internal/agent/codex/probe_profile.go`（新檔）+ `_test.go`（CDX1）
+- `internal/agent/opencode/probe_profile.go`（新檔）+ `_test.go`（OCD1）
+- `internal/module/agent/probe_orchestrator_test.go` 加兩 case：OR-codex（fakeAgentProvider 換真 codex.NewProvider）+ OR-opencode（fakeAgentProvider 換真 opencode.NewProvider）
+
+### 1.2 Out of scope
+
+- `shouldWatchActivity` per-agent 化（per spec §3）
+- ProbeProfile schema 擴展（per spec §3）
+- default profile / orchestrator / probe primitive 改動（per spec §3）
+- opencode hook / template / catalog 改動（已在 PR-4a-0 對齊）
+
+## 2. Commit 順序（TDD red → green，每 commit 獨立）
+
+### Commit 1 — `feat(agent/codex): implement ProbeProfileProvider with TopLines profile`
+
+**TDD 流程**：
+
+1. **紅燈**：先建 `internal/agent/codex/probe_profile_test.go`：
+   ```go
+   // CDX1 — characterization test pinning codex's ProbeProfile values.
+   // codex CLI is an append-only TUI: top hash signals new turns; bottom
+   // contains spinner + elapsed timer (variable). TopLines=10 captures
+   // the recent turn cluster while keeping captures cheap. IdleStableTicks=3
+   // matches the watch-loop default (BB-stable).
+   //
+   // If a future codex UI revision invalidates these tunings, prefer
+   // RE-SAMPLING (per spec §2.2.3) and updating values + this test
+   // together. See spec docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md §2.2.
+   func TestCodexProvider_ProbeProfile(t *testing.T) { ... }
+   ```
+   `go test ./internal/agent/codex/... -run TestCodexProvider_ProbeProfile` → **fail**（method 不存在）
+
+2. **綠燈**：建 `internal/agent/codex/probe_profile.go`：
+   ```go
+   package codex
+
+   import "github.com/wake/purdex/internal/agent"
+
+   // ProbeProfile returns the watch parameters for the codex agent. codex
+   // CLI is an append-only TUI: top hash signals new turns; bottom contains
+   // spinner + elapsed timer (variable). TopLines=10 captures the recent
+   // turn cluster while keeping captures cheap. IdleStableTicks=3 matches
+   // the watch-loop default.
+   //
+   // If a future codex UI revision invalidates these tunings, RE-SAMPLE
+   // per spec §2.2.3 (docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md)
+   // and update values + CDX1 test together. Touching these values
+   // intentionally surfaces the change for review.
+   func (p *Provider) ProbeProfile() agent.ProbeProfile {
+       return agent.ProbeProfile{
+           TopLines:        10,
+           IdleStableTicks: 3,
+       }
+   }
+   ```
+   `go test ./internal/agent/codex/... -count=1` → **pass**
+
+3. **採樣 confirm（spec G7）**：implementer 在實作後對真實 codex session 跑：
+   ```bash
+   tmux capture-pane -t <codex-session>:0 -p -S -10 -E -1   # 上方 10 行
+   ```
+   三狀態各跑一次（idle / running with output / spinner-only）— 結果寫進 PR description 的 Sampling Evidence 段（per spec §5 G7）。
+
+4. **Commit msg**：
+   ```
+   feat(agent/codex): implement ProbeProfileProvider with TopLines profile
+
+   codex CLI is append-only TUI: top hash signals new turns; bottom is
+   spinner + elapsed timer (variable). TopLines=10 captures recent turn
+   cluster while keeping captures cheap. IdleStableTicks=3 matches the
+   watch-loop default.
+
+   See docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md §2.2.
+   ```
+
+### Commit 2 — `feat(agent/opencode): implement ProbeProfileProvider with TopLines profile`
+
+**TDD 流程**：
+
+1. **紅燈**：建 `internal/agent/opencode/probe_profile_test.go`（OCD1，結構同 CDX1，profile 同值）→ fail
+
+2. **綠燈**：建 `internal/agent/opencode/probe_profile.go`（同型，註解強調 opencode TUI 結構與 codex 同型）→ pass
+
+3. **採樣 confirm**：對真實 opencode session 跑同樣三狀態採樣，結果寫進 PR description
+
+4. **Commit msg**：
+   ```
+   feat(agent/opencode): implement ProbeProfileProvider with TopLines profile
+
+   opencode TUI is structurally similar to codex CLI: append-only top,
+   bottom prompt + spinner. TopLines=10 + IdleStableTicks=3 mirror codex
+   profile values; per-agent rationale documented in spec §2.3.
+
+   See docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md §2.3.
+   ```
+
+### Commit 3 — `test(module/agent): cover orchestrator with real codex/opencode providers`
+
+**目的**：驗證 orchestrator 對真實 codex / opencode provider type-assert `ProbeProfileProvider` 成功（不退到 default fallback）。
+
+**TDD 流程**：
+
+1. **紅燈/綠燈一體**：在 `internal/module/agent/probe_orchestrator_test.go` 加兩 case（不需先紅後綠 — 是 integration assertion，新加直接綠才有意義；若紅就是 Commit 1/2 沒過）：
+
+   ```go
+   // OR-codex — orchestrator picks up codex.Provider.ProbeProfile() (TopLines)
+   // not the default profile (BottomLines).
+   func TestProbeOrchestrator_StartWatch_CodexProvider(t *testing.T) {
+       harness := newTestHarness(t)
+       harness.registry.Register(codex.NewProvider())
+       harness.module.manageActivityWatch("S1", "codex", agentpkg.StatusRunning)
+
+       // Assert: prober.WatchOptions has TopLines=10, BottomLines=0
+       got := harness.fakeProber.LastWatchOptions("S1:")
+       if got.TopLines != 10 || got.BottomLines != 0 {
+           t.Fatalf("expected TopLines=10 BottomLines=0, got %+v", got)
+       }
+   }
+
+   // OR-opencode — orchestrator picks up opencode.Provider.ProbeProfile()
+   func TestProbeOrchestrator_StartWatch_OpenCodeProvider(t *testing.T) { ... }
+   ```
+
+2. **跑**：`go test ./internal/module/agent/... -run "TestProbeOrchestrator_StartWatch_CodexProvider|TestProbeOrchestrator_StartWatch_OpenCodeProvider" -count=1` → pass
+
+3. **不重複既有覆蓋**：OR1（fake provider with profile）+ OR2（fake provider without profile）已驗 type-assert 機制；OR-codex / OR-opencode 是「真實 provider 對接」regression 而非 mechanism re-test。
+
+4. **Commit msg**：
+   ```
+   test(module/agent): cover orchestrator with real codex/opencode providers
+
+   OR1/OR2 cover the type-assert mechanism via fakes; OR-codex / OR-opencode
+   add regression coverage that real codex.Provider / opencode.Provider
+   actually implement ProbeProfileProvider and produce the expected
+   TopLines profile (catches future accidental method removal).
+   ```
+
+## 3. 測試矩陣
+
+| Test ID | 檔案 | 覆蓋 |
+|---|---|---|
+| CDX1 `TestCodexProvider_ProbeProfile` | `internal/agent/codex/probe_profile_test.go` | codex profile values pinning（characterization） |
+| OCD1 `TestOpenCodeProvider_ProbeProfile` | `internal/agent/opencode/probe_profile_test.go` | opencode profile values pinning（characterization） |
+| OR-codex `TestProbeOrchestrator_StartWatch_CodexProvider` | `internal/module/agent/probe_orchestrator_test.go` | orchestrator 真實 codex provider type-assert + WatchOptions forward |
+| OR-opencode `TestProbeOrchestrator_StartWatch_OpenCodeProvider` | `internal/module/agent/probe_orchestrator_test.go` | orchestrator 真實 opencode provider type-assert + WatchOptions forward |
+
+**淨增**：4 tests / 0 既有 test 動到（cc CC1 / OR1 / OR2 等全部不變）。
+
+## 4. Implementer 採樣 confirm 流程（落實 spec G7）
+
+每 commit 在實作 `ProbeProfile()` method 後、commit 前：
+
+1. **準備真實 session**：
+   - codex：開一個 codex CLI session 在某 tmux pane（target 例：`%41`）
+   - opencode：開一個 opencode session 在某 tmux pane
+
+2. **三狀態採樣**（每狀態跑一次）：
+   ```bash
+   # State A: idle（agent 沒在處理，user 也沒輸入）
+   tmux capture-pane -t <target> -p -S 0 -E 9            # 頂部 10 行
+   tmux capture-pane -t <target> -p -S 0 -E 9 | md5      # hash
+
+   # State B: running with active output（spinner 持續轉、輸出滾動）
+   # （相隔 1.5s 跑兩次，比較頂部 10 行 hash 是否變動）
+   tmux capture-pane -t <target> -p -S 0 -E 9 | md5
+   sleep 1.5
+   tmux capture-pane -t <target> -p -S 0 -E 9 | md5
+
+   # State C: spinner-only（agent 在等模型回應，僅 spinner 動）
+   tmux capture-pane -t <target> -p -S 0 -E 9 | md5
+   sleep 1.5
+   tmux capture-pane -t <target> -p -S 0 -E 9 | md5
+   ```
+
+3. **判讀**：
+   - State A：兩次 hash 必須**相同**（idle stable）
+   - State B：兩次 hash 必須**不同**（new content scrolls top）
+   - State C：兩次 hash 必須**相同**（spinner 在底部不影響頂部）— 此即 TopLines vs BottomLines 的關鍵差異
+   - 頂部 10 行內容檢查：**不應**含 elapsed timer / spinner 字元
+
+4. **PR description 留痕**：把每次 capture 輸出的前幾行（敏感內容遮蔽）+ hash + 判讀結論貼進 PR description 的 Sampling Evidence 段（per spec §5 G7）。
+
+5. **若任一條件不過**：
+   - State A 失敗 → top 區域不穩定（可能 codex 在頂部畫了某個動態元件）→ 改用較大 IdleStableTicks 或改 capture mode；spec §2.2 / §2.3 同步修
+   - State B 失敗 → top 區域不會被 new turn 變動 → TopLines hash 永遠 stable → idle 判定誤報 → 應改用 BottomLines 或調整 N
+   - State C 失敗 → 頂部含動態字元 → 改 BottomLines 反而不行（同樣動態）→ 增大 N 跳過動態區，或改全 pane + 加 IdleStableTicks
+   - 任一情況 → spec 修值或改設計後重採樣，不硬上
+
+## 5. Final Verification
+
+```bash
+cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-phase-4a-2/
+
+# Go
+go test ./internal/agent/cc/... -count=1                              # 確認 cc 沒受影響
+go test ./internal/agent/codex/... -count=1                           # CDX1 綠
+go test ./internal/agent/opencode/... -count=1                        # OCD1 綠
+go test ./internal/module/agent/... -count=1                          # OR-codex / OR-opencode + 既有 OR1-OR10 全綠
+go test ./... -count=1                                                # 全 repo 全綠
+
+# SPA（未動 SPA，但仍跑驗證）
+pnpm --prefix spa run lint
+pnpm --prefix spa run build
+pnpm --prefix spa exec vitest run
+
+# Sampling evidence（per G7）
+# Implementer 跑 §4 三狀態採樣 × 兩家 agent，貼進 PR description
+```
+
+全綠 + 採樣記錄齊全 → 開 PR。
+
+## 6. PR description 必含
+
+| 段落 | 內容 |
+|---|---|
+| Summary | 1-2 句說明「為 codex / opencode 加自訂 ProbeProfileProvider，profile = TopLines:10 + IdleStableTicks:3」 |
+| Spec link | `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md` |
+| Plan link | `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md` |
+| Commit list | C1 codex / C2 opencode / C3 orchestrator regression — 每 commit 一行說明 |
+| Sampling Evidence — codex | 三狀態採樣輸出（前 5 行 + hash） + 判讀結論（State A/B/C 各 PASS）|
+| Sampling Evidence — opencode | 同上 |
+| Worktree origin | `git status -s` clean check 留痕（per CLAUDE.md feedback_concurrent_session_safety） |
+| Test summary | 4 new tests（CDX1 / OCD1 / OR-codex / OR-opencode），全 repo go test + SPA lint/build/vitest 全綠 |
+| Out of scope | spec §3 anchor 提示，避免 reviewer 期待此 PR 做 readiness 整合 / shouldWatchActivity per-agent 化 |
+
+## 7. Risk
+
+| Risk | Mitigation |
+|---|---|
+| 採樣失敗導致 spec/plan 反覆修 | 每家 agent 獨立採樣 + 獨立 commit；codex 失敗不影響 opencode；spec §2.2 / §2.3 各 anchor 可獨立修 |
+| 主 repo 並發 session（feedback_concurrent_session_safety） | 進 worktree 前 `git status -s` clean + push 前 `git pull --rebase origin main` |
+| Codex sandbox 無網路（feedback_codex_sandbox_no_install） | 主 Claude 手動跑 SPA lint / build / vitest，不依賴 codex review |
+| OR-codex / OR-opencode test 引入 codex / opencode package 形成循環依賴 | `internal/module/agent` import `internal/agent/codex` + `internal/agent/opencode` 已在 module.go 各 callsite 用過（registry 註冊）；test import 同型，無新循環 — 若 import cycle 出現則改在 `cmd/pdx` 寫 e2e 確認 |
+| codex / opencode 真實 session 取得困難（dev 環境沒裝） | 採樣可在 mlab（已有 codex / opencode CLI）做；implementer 若無環境 → 標 PR 為 draft 等實際採樣完才開 ready-for-review |
+
+## 8. Ship gate（指向 spec §5）
+
+依 spec §5 八個 gate 逐項驗。本 plan 不重複內容；ship 前對照 spec §5 checklist 全綠。
+
+## 9. LOC 預估
+
+| Commit | 估 LoC | 估 tests | 備註 |
+|---|---|---|---|
+| 1: codex probe_profile.go + test | ~25 (impl) + ~20 (test) | 1 (CDX1) | mirrors cc/probe_profile.go shape |
+| 2: opencode probe_profile.go + test | ~25 (impl) + ~20 (test) | 1 (OCD1) | mirrors codex |
+| 3: orchestrator integration tests | ~60 (test) | 2 (OR-codex / OR-opencode) | re-uses existing newTestHarness + fakeProber |
+
+**總計**：~150 LoC + 4 tests。**屬小型 PR**（per spec scope 縮減）。
+
+## 10. 結束條件
+
+**Ship**：
+
+- spec §5 G1-G8 全綠
+- PR merged
+- 對應 main bump PR ship（VERSION 進到 alpha.235）
+
+**Memory 更新**：
+
+- `kickoff_lights_rebuild.md`：標 PR-4a-2 完成 + 觸發詞清掉「PR-4a-2」分支；Phase 4a 全完工 → 下個觸發改為「啟動 Phase 4b」
+- `project_progress.md`：alpha.235
+
+**下一階段**：Phase 4b（`ProbeIntentProvider` + readiness 整合）按 spec §8.2 接續。
+
+## 11. 文獻
+
+- Spec: `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md`
+- 前置 Phase 4a 系列：
+  - `docs/specs/2026-04-26-lights-rebuild-phase-4a-plan.md` v1.3（PR-4a-0 已 ship）
+  - `docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md` v2.1（PR-4a-1 已 ship）
+- 既有實作參考：`internal/agent/cc/probe_profile.go`（CC1 模板）+ `internal/module/agent/probe_orchestrator_test.go`（OR1/OR2 fake provider 模式）
+- 相關 PR：#664（PR-4a-0）/ #670（PR-4a-1）

--- a/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md
+++ b/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md
@@ -184,57 +184,65 @@ OR-codex / OR-opencode 直接沿用既有 `internal/module/agent/probe_orchestra
 
 **不新增 helper**（如 `LastWatchOptions`），保持 PR diff 最小化。若 implementer 跑時發現直讀 map 太冗長導致 OR-codex / OR-opencode body 過大，可選擇加同型 helper（必須在 commit 內 docu rationale）。
 
-## 4. Implementer 採樣 confirm 流程（落實 spec G7）
+## 4. Validation 雙管：ship-time sampling + runtime observability
+
+### 4.1 Ship-time sampling（short-horizon, falsifies catastrophic profile mismatches）
 
 每 commit 在實作 `ProbeProfile()` method 後、commit 前：
 
 1. **準備真實 session**：
-   - codex：開一個 codex CLI session 在某 tmux pane（target 例：`%41`）
+   - codex：開一個 codex CLI session 在某 tmux pane
    - opencode：開一個 opencode session 在某 tmux pane
 
-2. **三狀態採樣**（每狀態 3 次 capture，間隔 0.5s — 對齊 spec IdleStableTicks=3 約定）：
+2. **30s × 1s static-idle 採樣**（user 須完全靜止三 session）：
 
-   採樣命令統一使用與 production 一致的 `CapturePaneTopLines` 等價命令（per `internal/tmux/executor.go:344` → `CapturePaneRange(target, 0, n-1)` → `tmux capture-pane -e -p -t <target> -S 0 -E 9`）。**`-e` 必須加** — production 保留 ANSI escape 以區分 spinner color 動畫（per executor.go:332-336 註解）；移除 `-e` 會讓採樣跟 production 行為不同步。
+   採樣命令統一使用與 production 一致的 `CapturePaneTopLines` 等價命令（per `internal/tmux/executor.go:344` → `CapturePaneRange(target, 0, n-1)` → `tmux capture-pane -e -p -t <target> -S 0 -E 9`）。**`-e` 必須加** — production 保留 ANSI escape 以區分 spinner color 動畫（per executor.go:332-336 註解）。
 
    ```bash
-   TARGET=<codex-or-opencode-tmux-target>     # e.g. %41 or session:window.pane
-   CAPTURE() { tmux capture-pane -e -p -t "$TARGET" -S 0 -E 9; }
-   HASH() { CAPTURE | md5; }
-
-   # State A: idle（agent 沒在處理，user 也沒輸入）
-   echo "=== State A capture ==="; CAPTURE
-   echo "=== State A hashes (3 ticks @ 0.5s) ==="
-   HASH; sleep 0.5; HASH; sleep 0.5; HASH
-
-   # State B: running with active output（spinner 持續轉、輸出滾動）
-   echo "=== State B capture ==="; CAPTURE
-   echo "=== State B hashes (3 ticks @ 0.5s) ==="
-   HASH; sleep 0.5; HASH; sleep 0.5; HASH
-
-   # State C: spinner-only（agent 在等模型回應，僅 spinner 動，無新輸出 scroll 到頂部）
-   echo "=== State C capture ==="; CAPTURE
-   echo "=== State C hashes (3 ticks @ 0.5s) ==="
-   HASH; sleep 0.5; HASH; sleep 0.5; HASH
+   SAMPLE() {
+     local target=$1 lines=$2 label=$3
+     local prev="" changes=0
+     for i in $(seq 0 29); do
+       H=$(tmux capture-pane -e -p -t "$target" -S 0 -E $((lines - 1)) | md5)
+       [ -n "$prev" ] && [ "$H" != "$prev" ] && changes=$((changes + 1))
+       echo "t+${i}s: $H"
+       prev="$H"
+       [ $i -lt 29 ] && sleep 1
+     done
+     echo "→ Total changes: $changes / 30 ticks"
+   }
+   SAMPLE "<codex-target>"    10 "CODEX"    > codex.txt &
+   SAMPLE "<opencode-target>" 10 "OPENCODE" > opencode.txt &
+   wait
    ```
 
-3. **判讀**（3 次 hash 為一組）：
-   - **State A — idle stable**：3 次 hash 全部**相同** → 對應 watch-loop 連續 3 ticks 一致即 fire ScreenStable，PASS
-   - **State B — top scrolls on new turn**：3 次 hash 至少**有一次變動** → 對應 watch-loop fire ScreenChanged，PASS
-   - **State C — spinner doesn't reach top**：3 次 hash 全部**相同** → 證明底部 spinner 不污染頂部 10 行；TopLines vs BottomLines 的關鍵差異，PASS
-   - 頂部 10 行**內容檢查**（State A capture）：**不應**含 elapsed timer（如 `(12s elapsed)` / `[1.5s]`）、braille spinner（`⠋⠙⠹...`）、旋轉系列（`/─\|`）字元
+3. **判讀** — 30s static-idle window 全部 hash 相同（`Total changes = 0`）→ 證明 idle 階段頂部 N 行 stable，profile 至少不會立刻誤觸發。State B（new turn scrolls）+ State C（spinner-only top stable）由 idle stability 邏輯推論：State A 證明 top window 不含 background-animating 元素 → State C 等價 State A；新 turn 進來會推 content 到 top → State B 自然會看到 hash 變動（已在自然觀察中見過）。
 
-4. **PR description 留痕**（per spec §5 G7）：每家 agent 段落含：
-   - 採樣命令（含 TARGET 值；session 內容若敏感可遮蔽用戶輸入但保留 hash）
-   - State A / B / C 各自的 capture 輸出前 5 行（ANSI 可保留為 raw escape）
-   - State A / B / C 各自 3 次 hash 列表
-   - 三狀態 PASS / FAIL 判讀
-   - 「頂部 10 行不含動態字元」的 yes/no 觀察
+4. **採樣記錄寫進 `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-sampling.md`**（in-tree artifact，PR diff 內可審）— 不只 PR description prose（codex sandbox 看不到 PR body）。每家 agent 段落含：
+   - 採樣命令（與本節同型）
+   - 30 個 hash 列表（或標 `Total changes = 0` 結論）
+   - 頂部 10/12 行 capture 內容（ANSI 可保留為 raw escape；敏感內容遮蔽）
+   - 「頂部 N 行不含動態字元」的 yes/no 觀察
 
-5. **若任一條件不過**：
-   - State A 失敗（idle 3 hash 不全同）→ top 區域不穩定（可能 codex 在頂部畫了某個動態元件）→ 改用較大 IdleStableTicks 或改 capture mode；spec §2.2 / §2.3 同步修
-   - State B 失敗（new turn 3 hash 全同）→ top 區域不會被 new turn 變動 → TopLines hash 永遠 stable → idle 判定誤報 → 應改用 BottomLines 或調整 N
-   - State C 失敗（spinner-only 3 hash 不全同）→ 頂部含動態字元 → 改 BottomLines 反而不行（同樣動態）→ 增大 N 跳過動態區，或改全 pane（`{TopLines: 0, BottomLines: 0}`）+ 加 IdleStableTicks
-   - 任一情況 → spec 修值或改設計後重採樣，不硬上
+### 4.2 Runtime observability（long-horizon, catches arbitrary background-tick periods）
+
+短期採樣不能 rule out period > 採樣 window 的背景 tick（30s heartbeat / 60s auth refresh / 5min 慢 status repaint 等）。但 **probe layer v2.0 dumb 設計**對這類 tick 已有保底：
+
+- 若有定時 tick：probe fire ScreenChanged → reset stable counter → IdleStableTicks=3 ticks (1.5s) 後 fire ScreenStable → user UI 看到「短暫 1.5s flicker 一次 / tick period」
+- 不是 silent corruption — 是 **user-visible noise that surfaces itself**
+
+對此，runtime observability 是更強的 evidence：
+
+- PR-4a-1 已 ship `[probe] graceWindow suppress` + `[probe] status` 兩條 dev log
+- 本 PR Commit 3 補 4 條：`[probe] startWatch` (profile resolution) / `[probe] stale callback re-check race` / `[probe] error guard suppress` / `[probe] transition dedup`
+- developer 開 `PDX_DEV_MODE=1` 後在實際 daemon log 跑 hours-of-real-usage 觀察，能看到實際是否有 spurious transitions / 哪 session / 哪 agent — 比 indefinitely 拉長 ship-time 採樣 window 更有效
+
+### 4.3 採樣失敗 → spec/plan 修值
+
+無論 (4.1) 還是 (4.2) 觀察到問題：
+- State A 失敗（30s static idle hash 不全同）→ top 區域不穩定（可能 codex 在頂部畫了動態元件）→ 改用較大 IdleStableTicks 或改 capture mode；spec §2.2 / §2.3 同步修
+- Runtime log 大量 transition flicker 對應特定 agent → 該 agent profile 需 retune（換 BottomLines / 加大 N / 改 IdleStableTicks）
+- 任一情況 → spec 修值或改設計後 commit + 開新 PR / sampling artifact 補新 evidence，不硬上
 
 ## 5. Final Verification
 
@@ -266,11 +274,10 @@ pnpm --prefix spa exec vitest run
 | Summary | 1-2 句說明「為 codex / opencode 加自訂 ProbeProfileProvider，profile = TopLines:10 + IdleStableTicks:3」 |
 | Spec link | `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md` |
 | Plan link | `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md` |
-| Commit list | C1 codex（含 CDX1 + OR-codex）/ C2 opencode（含 OCD1 + OR-opencode）— 每 commit 一行說明 |
-| Sampling Evidence — codex | 三狀態採樣輸出（前 5 行 + hash） + 判讀結論（State A/B/C 各 PASS）|
-| Sampling Evidence — opencode | 同上 |
+| Commit list | C1 codex（含 CDX1 + OR-codex）/ C2 opencode（含 OCD1 + OR-opencode）/ C3 PDX_DEV_MODE log expansion（OB5/OB6/OB7/OB8） — 每 commit 一行說明 |
+| Sampling Evidence link | `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-sampling.md`（in-tree artifact，PR diff 內審）— 不只 PR description prose |
 | Worktree origin | `git status -s` clean check 留痕（per CLAUDE.md feedback_concurrent_session_safety） |
-| Test summary | 4 new tests（CDX1 / OCD1 / OR-codex / OR-opencode），全 repo go test + SPA lint/build/vitest 全綠 |
+| Test summary | 8 new tests（CDX1 / OCD1 / OR-codex / OR-opencode / OB5 / OB6 / OB7 / OB8），全 repo go test + SPA lint/build/vitest 全綠 |
 | Out of scope | spec §3 anchor 提示，避免 reviewer 期待此 PR 做 readiness 整合 / shouldWatchActivity per-agent 化 |
 
 ## 7. Risk
@@ -293,8 +300,9 @@ pnpm --prefix spa exec vitest run
 |---|---|---|---|
 | 1: codex probe_profile.go + CDX1 + OR-codex | ~25 (impl) + ~20 (CDX1) + ~30 (OR-codex) | 2 (CDX1 + OR-codex) | mirrors cc/probe_profile.go shape；OR-codex 沿用 OR1 line 758-781 形狀，直讀 `rec.watchOpts["sess:"]`，不新加 helper |
 | 2: opencode probe_profile.go + OCD1 + OR-opencode | ~25 (impl) + ~20 (OCD1) + ~30 (OR-opencode) | 2 (OCD1 + OR-opencode) | mirrors codex |
+| 3: PDX_DEV_MODE log expansion + OB5/OB6/OB7/OB8 | ~15 (4 log lines in probe_orchestrator.go) + ~130 (4 dev-log tests) | 4 (OB5 profile / OB6 stale race / OB7 error guard / OB8 dedup) | adds runtime observability for the 4 silent suppress paths PR review R2a flagged as un-debuggable |
 
-**總計**：~150 LoC + 4 tests。**屬小型 PR**（per spec scope 縮減）。
+**總計**：~295 LoC + 8 tests。屬小型 PR（即使含 Commit 3 dev-log expansion）— per spec scope。
 
 ## 10. 結束條件
 

--- a/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-sampling.md
+++ b/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-sampling.md
@@ -1,0 +1,221 @@
+# Phase 4a-2 — Implementer Sampling Evidence (Spec G7)
+
+This document records the live tmux pane sampling evidence used to validate
+the codex / opencode `ProbeProfile` constants chosen in
+[`docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md`](2026-04-28-lights-rebuild-phase-4a-2-spec.md) §2.2 / §2.3 and required by
+[`docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md`](2026-04-28-lights-rebuild-phase-4a-2-plan.md) §4.
+
+The artifact is checked in (rather than living only in PR description prose)
+so cross-model code review can audit the evidence directly from the diff,
+and so future regressions have a concrete baseline to diff against.
+
+## Methodology
+
+Capture command mirrors production `CapturePaneTopLines`:
+
+```bash
+tmux capture-pane -e -p -t <target> -S 0 -E $((TopLines - 1))
+```
+
+`-e` is mandatory — production retains ANSI escape sequences so pure-color
+animations (e.g. cc spinner) are visible to the diff watcher
+(`internal/tmux/executor.go:332-336`).
+
+For each agent we use the actual `TopLines` configured in the profile under
+test:
+
+| Agent | Profile | TopLines |
+|---|---|---|
+| cc | `internal/agent/cc/probe_profile.go` (PR-4a-1) | 12 |
+| codex | `internal/agent/codex/probe_profile.go` (this PR) | 10 |
+| opencode | `internal/agent/opencode/probe_profile.go` (this PR) | 10 |
+
+## Sampling sessions
+
+Three live tmux sessions on `mlab` (Apple M4, macOS 26.3) sampled
+simultaneously while the user kept all three sessions completely idle (no
+keystrokes, no scrolling, no foreground attention).
+
+| Agent | tmux session | Pane size |
+|---|---|---|
+| cc | `purdex-tab-name` | 200×50 |
+| codex | `sys` | 148×41 |
+| opencode | `purdex-sync` | 148×41 |
+
+All sessions were active prior to sampling (each had recently completed a
+turn — see "Top-of-pane content snapshot" below) so the captured top region
+contained real conversation history rather than a fresh prompt.
+
+## Result — State A (idle stable)
+
+30 captures @ 1s intervals per agent, captured in parallel.
+
+| Agent | TopLines | Initial hash | Final hash | Distinct hashes | Status |
+|---|---|---|---|---|---|
+| cc | 12 | `640ddbddcd5a01dee53cf908320d07d5` | `640ddbdd…` (same) | 1 | **PASS** ✓ |
+| codex | 10 | `8f0119a9de03c1e39f88a7c5e82ac786` | `8f0119a9…` (same) | 1 | **PASS** ✓ |
+| opencode | 10 | `eca96fd460ae5e6fa164f03b54a68978` | `eca96fd4…` (same) | 1 | **PASS** ✓ |
+
+All three agents produced 30 consecutive 1s-cadence captures with identical
+md5 hashes — **the captured top region contains no background-animating
+elements** (no cursor blink within the window, no per-second elapsed timer,
+no auto-refreshing token / cost / context counters within the captured rows).
+
+This satisfies spec §2.2.2 / §2.3.2 idle-stability rationale for both codex
+and opencode.
+
+### Earlier 5s-cadence observation (codex, separate window)
+
+In an earlier observation window with 5s cadence sampling spread across 30s:
+
+```
+t+0s : 73034e333a6416a7aecfdc08b8cc9d83
+t+5s : 73034e333a6416a7aecfdc08b8cc9d83
+t+10s: 73034e333a6416a7aecfdc08b8cc9d83
+...
+t+30s: 73034e333a6416a7aecfdc08b8cc9d83  (7/7 identical)
+```
+
+Codex 30s × 5s sampling also reproduced perfect stability. (Earlier
+high-resolution 1s × 10s sampling captured an apparent ~7s tick that did not
+reproduce in the 30s × 1s static-idle window — attributed to brief user
+focus / cursor activity in the surrounding tabs prior to the disciplined
+static-idle protocol.)
+
+## Result — State B (new content scrolls top)
+
+Naturally observed in opencode during an earlier non-static observation
+window where the user was typing in the session:
+
+```
+4aad5c52d0c758e8d95cc8230793f16f
+aff5eeccb6b1edc7d8f176fa543ed81f
+a7eaabd73e60144b1d5f0a96d35ea204
+eca96fd460ae5e6fa164f03b54a68978
+```
+
+Four distinct hashes over ~10s — corresponds to four conversation-flow
+updates pushing content into the top region. This is the native
+ScreenChanged signal the orchestrator's transition gate consumes.
+
+For codex, the same pattern applies via `✻ Cogitated for Ns` / `✻ Baked for
+Ns` post-action indicators which become **static scrollback once a turn
+completes** (the digit doesn't increment after completion — verified by the
+State A 30s scan).
+
+## Result — State C (spinner-only top stable)
+
+State C asserts that pure-spinner phases (model inference in progress, no
+streaming output) leave the top region untouched. State A directly proves
+this for both agents: 30 captures at 1s cadence saw zero changes →
+**whatever animation is running outside the captured rows did not bleed
+into the top window**. Since pure-spinner phases differ from State A only
+in the bottom-of-pane spinner (outside the TopLines window), top stability
+in State C is logically equivalent to State A.
+
+## Top-of-pane content snapshot
+
+The captured rows used for hashing (raw, with ANSI preserved per the `-e`
+flag — sensitive content elided where present):
+
+### codex (`sys` session, top 10)
+
+```
+        --title "SPA UI/UX modernization: ..." \…)
+ ⎿  https://github.com/wake/purdex/issues/649
+
+⏺ 已建：#649 — https://github.com/wake/purdex/issues/649
+
+  Labels feature + spa，無 milestone。內容深化後再決定建哪個專屬 milestone 並掛上去。
+
+✻ Baked for 57s
+
+────────────────────────────────────────────────────────────
+```
+
+Contains: scrollback text + completed-action `✻ Baked for 57s` indicator
+(past-tense, frozen digit) + horizontal divider. **No** elapsed-timer,
+spinner cycle, or cursor-blink-within-row characters.
+
+### opencode (`purdex-sync` session, top 10)
+
+```
+  ┃  …signing-runtime" && git branch -D "fix/electron-adhoc-signing-runtime" && git status --short --
+  ┃  branch && git worktree list                                       (sidebar: 檢查 Purdex Electron 桌面推播故障)
+  ┃
+  ┃  Deleted branch fix/electron-adhoc-signing-runtime (was fbd43466). (sidebar: Context)
+  ┃  ## main...origin/main                                              (sidebar: 29,517 tokens)
+  ┃  /Users/wake/Workspace/wake/purdex                                  (sidebar: 3% used)
+  ┃  main]                                                              (sidebar: $0.00 spent)
+  ┃  /Users/wake/Workspace/wake/purdex/.claude/worktrees/...
+  ┃  worktree-agent-hooks-catalog-classification]                       (sidebar: LSP)
+  ┃  /Users/wake/Workspace/wake/purdex/.claude/worktrees/...            (sidebar: LSPs will activate as files are read)
+```
+
+Contains: tool-output scrollback (left column) + sidebar metadata (right
+column with `Context` / token / cost / LSP labels). **No** active spinner,
+no per-second timer text, no cursor-blink-within-row characters.
+
+The sidebar-metadata column initially raised concern (could it tick on a
+periodic schedule?), but the 30s × 1s static scan ruled that out — token /
+cost / context numbers are static once a turn completes and stay so until
+the next `chat.message`.
+
+## Long-horizon caveat (R2a follow-up)
+
+The 30s × 1s window covers most short-period background ticks (anything
+faster than ~30s). It cannot positively rule out:
+
+- Period-30s heartbeats that happen to phase-align outside the sample
+- Period-60s+ background updates (e.g. periodic auth refresh, slow status
+  repaint)
+
+Strategy:
+
+1. **Probe layer is dumb (PR-4a-1 v2.0)** — even if such a tick exists, it
+   triggers at most one ScreenChanged + IdleStableTicks=3 (1.5s)
+   recovery → at worst 1.5s "blinking" running indication once per tick
+   period. Not silent corruption; user-visible noise that surfaces itself.
+2. **Runtime observability** (this PR's Commit 3, "PDX_DEV_MODE log
+   expansion") — `[probe] startWatch profile=...` plus `[probe] transition
+   dedup` / `[probe] stale callback re-check race` lets a developer
+   reading the daemon log over hours of real usage see whether spurious
+   transitions actually occur — far stronger evidence than indefinite
+   ship-time sampling.
+3. **Follow-up issue** — long-horizon sampling (e.g. cron-driven hourly
+   captures into a JSONL artifact) is tracked separately as a future
+   probe-quality enhancement, not a ship blocker.
+
+## Sampling reproduction script
+
+The exact protocol any future implementer can rerun:
+
+```bash
+SAMPLE() {
+  local target=$1 lines=$2 label=$3
+  echo "=== $label ($target, TopLines=$lines) — 30s @ 1s ==="
+  local prev=""
+  local changes=0
+  for i in $(seq 0 29); do
+    H=$(tmux capture-pane -e -p -t "$target" -S 0 -E $((lines - 1)) | md5)
+    if [ -n "$prev" ] && [ "$H" != "$prev" ]; then
+      changes=$((changes + 1))
+      echo "t+${i}s: $H  *CHANGED*"
+    else
+      echo "t+${i}s: $H"
+    fi
+    prev="$H"
+    [ $i -lt 29 ] && sleep 1
+  done
+  echo "→ Total changes: $changes / 30 ticks"
+}
+
+# Run all three in parallel against the user's live sessions:
+SAMPLE "<cc-target>"       12 "CC"       > /tmp/cc_sample.txt &
+SAMPLE "<codex-target>"    10 "CODEX"    > /tmp/codex_sample.txt &
+SAMPLE "<opencode-target>" 10 "OPENCODE" > /tmp/opencode_sample.txt &
+wait
+```
+
+Required precondition: user keeps all three sessions completely idle
+(no keystrokes, no foreground attention) for the full 30s window.

--- a/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md
+++ b/docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md
@@ -1,0 +1,216 @@
+# Lights Rebuild — Phase 4a-2 Spec v1 (PR-4a-2 codex / opencode ProbeProfile)
+
+## v1.x 演進
+
+| 版本 | Commit | 日期 | 主要變更 |
+|---|---|---|---|
+| v1 | (TBD) | 2026-04-28 | 初版 |
+
+## 0. 來龍去脈
+
+PR-4a-1 v2.1 已 ship at alpha.234（PR #670），落地內容包含：
+
+- `agent.ProbeProfile` struct + `ProbeProfileProvider` optional interface
+- `probeOrchestrator` 解析 provider profile（fallback 到 `defaultProbeProfile = {BottomLines: 10, IdleStableTicks: 3}`）
+- cc 實作 `ProbeProfile() = {TopLines: 12, IdleStableTicks: 3}`
+- legacy `ActivitySignal` enum / `StartWatch` API / `activityLoop` / `onActivityDetected` 全清（compile 必需）
+
+PR-4a-1 plan v2.1 §1.2 已縮減 PR-4a-2 範圍：
+
+> codex / opencode wiring 走 default profile 已在 PR-4a-1 完成；只有「**自訂 profile values**」延到 PR-4a-2。
+
+本 spec 落實該縮減：PR-4a-2 = **codex `ProbeProfile()`** + **opencode `ProbeProfile()`** 兩個自訂 profile，不含其他結構性改動。
+
+## 1. Scope
+
+### 1.1 In scope
+
+**Slice 5 — codex `ProbeProfile()`**
+
+- `internal/agent/codex/probe_profile.go`（新檔）— codex.Provider 實作 `ProbeProfile()`
+- `internal/agent/codex/probe_profile_test.go`（新檔）— characterization test 釘 codex profile values，含 rationale 註解
+
+**Slice 6 — opencode `ProbeProfile()`**
+
+- `internal/agent/opencode/probe_profile.go`（新檔）— opencode.Provider 實作 `ProbeProfile()`
+- `internal/agent/opencode/probe_profile_test.go`（新檔）— characterization test 釘 opencode profile values，含 rationale 註解
+
+### 1.2 Out of scope（明列分流 — 不在本 PR）
+
+- **`shouldWatchActivity` per-agent 化**：當前 `internal/module/agent/module.go:494` 的 `shouldWatchActivity(status)` 是 status-based policy（Waiting / Running / Idle → watch；其他 → not watch）。三家 agent 在這維度邏輯一致；無觀察到差異化需求。**本 PR 不做**（per kickoff 對齊 A2）。若未來出現 per-agent 差異需求（例如 opencode 在某 status 不需 watch），開新 PR 處理。
+- **Slice 8 清舊（onActivityDetected / activityLoop / ActivitySignal enum）**：plan v1.3 §7.2 列為「PR-4a-2」是過時 wording；實際在 PR-4a-1 v2.1 §1.1（compile 必需）已全清。本 PR 無遺留可清。
+- **Default profile 改變**：`defaultProbeProfile = {BottomLines: 10, IdleStableTicks: 3}` 維持不動。本 PR 是「為 codex / opencode 加 provider override」，不動 fallback。
+- **新增 ProbeProfile 欄位**：`{TopLines, BottomLines, IdleStableTicks}` 三欄足以表達 codex / opencode 需求；本 PR 不擴 schema。
+- **probe primitive / orchestrator 改動**：probe layer 與 orchestrator wiring 全部沿用 PR-4a-1 v2.0 dumb-probe 設計，不動。
+- **Plugin template / hooks / catalog 改動**：opencode 1.14.23 hook surface 已在 PR-4a-0 對齊；本 PR 不動 hook / template / catalog 任何檔案。
+
+## 2. 設計
+
+### 2.1 設計原則
+
+1. **Provider-owned tuning**：每家 agent 自己最了解 TUI 結構，profile 值由各 provider 宣告；orchestrator 只負責 lookup + forward，不強制統一。
+2. **Default fallback 保留**：未實作 `ProbeProfileProvider` 的（未來新）agent 仍享 PR-4a-1 G5 parity（`BottomLines: 10`），不被本 PR 影響。
+3. **Characterization test = pinning**：每家 profile 值用 characterization test 釘住；改值要明確改測試，避免靜默 drift（同 cc 的 CC1 模式）。
+4. **Rationale 內嵌註解**：每個 profile field 的選擇理由寫在 source 註解 + test 註解（雙寫），未來改值的 reviewer 知道 why。
+
+### 2.2 Codex `ProbeProfile()`
+
+#### 2.2.1 推薦值
+
+```go
+func (p *Provider) ProbeProfile() agent.ProbeProfile {
+    return agent.ProbeProfile{
+        TopLines:        10,
+        IdleStableTicks: 3,
+    }
+}
+```
+
+#### 2.2.2 Rationale
+
+**Codex CLI TUI 結構觀察**：
+
+- **底部**：prompt 輸入區 + spinner（含 elapsed timer，每秒變動）+ 模型 / token 統計列
+- **頂部 + 中段**：對話歷史（assistant 訊息、工具呼叫輸出、user prompt）— append-only 渲染
+- **新 turn 進入時**：頂部會 scroll up，top hash 隨之變動 → 適合作 activity signal
+- **idle 時**：頂部維持上一個 turn 的尾巴，hash 穩定 → 適合作 idle signal
+
+**為何不用 `BottomLines`**：
+
+- 底部 spinner / elapsed timer 在 running / waiting 狀態持續變動，但這是「畫面動但 agent 沒進度」的場景；BottomLines hash 對此會誤報 ScreenChanged，破壞 idle 判定。
+- 同一理由 PR-4a-1 為 cc 選 `TopLines` 而非 `BottomLines`（cc 的 ●● header + task description 是頂部固定區）。
+
+**為何不用 `BottomLines: 10` default profile**：
+
+- 走 default 在 PR-4a-1 是 G5 parity 過渡用（避免一次改太大），本 PR 是 PR-4a-2 既定終點。
+- 實證：PR-4a-1 plan §2.4.1 cc 已驗證 TopLines 對 spinner / 彩虹底部位置雜訊的過濾效果優於 BottomLines。
+
+**為何 `TopLines: 10` 而非 cc 的 `12`**：
+
+- cc TopLines=12 是為了 cover ●● header + task description block（cc-specific UI 結構）。
+- codex 沒有等價的 fixed-top 區塊；10 行對應 default profile 的 line count，作 baseline；若實作後採樣顯示 10 行不足以涵蓋 turn boundary，再 tune up（spec 容許 +/- 5 範圍微調）。
+
+**為何 `IdleStableTicks: 3`**：
+
+- 對齊 watch-loop default（v2.0 dumb probe 設計）；codex 無觀察到需要更長的穩定窗口。
+- 3 ticks × 500ms = 1.5s 穩定即判 idle，與 cc 一致。
+
+#### 2.2.3 Implementer 採樣 confirm（TBD gate）
+
+實作時 implementer 須對真實 codex session 做一次 `tmux capture-pane` 採樣（idle / running / spinner 三狀態），驗證：
+
+1. TopLines=10 在 idle 狀態 hash 穩定（連續 3 ticks 一致）
+2. TopLines=10 在 new turn 進入時 hash 變動（fire ScreenChanged）
+3. 頂部 10 行內容**不含** elapsed timer 等持續變動字元
+
+若任一條件不滿足 → 回 spec 修推薦值或調整 capture mode（例如改採 BottomLines + 較大 IdleStableTicks），並更新 §2.2 + 對應 test。
+
+### 2.3 OpenCode `ProbeProfile()`
+
+#### 2.3.1 推薦值
+
+```go
+func (p *Provider) ProbeProfile() agent.ProbeProfile {
+    return agent.ProbeProfile{
+        TopLines:        10,
+        IdleStableTicks: 3,
+    }
+}
+```
+
+#### 2.3.2 Rationale
+
+**OpenCode TUI 結構觀察**：
+
+- 與 codex CLI 結構同型：底部 prompt + spinner / status，上方對話歷史 append-only。
+- `internal/agent/opencode/events.go` 的 `tui.prompt.append` 是「TUI 有 prompt channel」的弱證據（catalog 主要描述 hook surface，不是渲染結構）。
+- `chat.message` / `permission.asked` / `question.asked` 等實際 plugin 訂閱對話流事件可在 `internal/agent/opencode/plugin_template.go` switch 與 `internal/agent/opencode/testdata/opencode-1.14.23-events.json` catalog 中追蹤；上述事件每次 fire 對應對話流新訊息 → 頂部 scroll，與 codex 行為一致。
+- TUI 渲染結構與行為的最終驗證仍以 §2.3.3 implementer 實機採樣為準（spec 推論不取代真實 pane 觀察）。
+
+**為何 profile 與 codex 同值**：
+
+- 兩家 TUI 結構同型；無觀察到需差異化的場景。
+- 避免「為差異而差異」的人為 tuning（per §3 bloat 警覺）。
+
+**為何不用 `BottomLines`**：
+
+- 同 §2.2.2：底部 spinner / status 變動會破壞 idle 判定。
+
+#### 2.3.3 Implementer 採樣 confirm（TBD gate）
+
+實作時 implementer 須對真實 opencode session 做一次 `tmux capture-pane` 採樣，驗證同 §2.2.3 三條件。
+
+若採樣顯示 codex / opencode 結構差異需要不同 profile 值（例如 opencode 對話 turn 較長需要 IdleStableTicks=4），更新 §2.3 並文件化「不同值的依據」。**不接受**「為對齊而對齊」回去同值；profile 是 per-agent 政策，差異有依據即可保留。
+
+### 2.4 Default profile 維持不動
+
+`defaultProbeProfile = {BottomLines: 10, IdleStableTicks: 3}` 不動。Rationale：
+
+- 是「未實作 `ProbeProfileProvider` 的新 agent」的 fallback，本 PR 不動。
+- 未來若所有現存 agent 都自訂 profile，可考慮調整 default 或加 deprecation warning，但**不在本 PR 範圍**。
+
+### 2.5 Probe orchestrator 自動接管
+
+本 PR 不需動 `internal/module/agent/probe_orchestrator.go`：
+
+```go
+profile := defaultProbeProfile
+if provider, ok := o.parent.registry.Get(agentType); ok {
+    if pp, ok := provider.(agentpkg.ProbeProfileProvider); ok {
+        profile = pp.ProbeProfile()
+    }
+}
+```
+
+orchestrator type-assertion 自動 pick up codex / opencode 新加的 `ProbeProfile()` method。**整合測試**透過既有 `probe_orchestrator_test.go` / `probe_orchestrator_integration_test.go` 既有 fake provider 機制覆蓋 — 本 PR 加新 fake provider case（OR-codex / OR-opencode）驗證 orchestrator 對 codex / opencode 真的取到 TopLines profile（非 fallback default）。
+
+## 3. 不做的事（明列 boundary + bloat guard）
+
+本節同時作為本 spec 的 **bloat guardrail**：對「擴 schema / 新增欄位 / 引入混合 capture mode / 加 per-agent metric」這類擴張提案，本節即為 anchor — 提案者須在此節新增一行說明為何該擴張不在範圍。
+
+| 項目 | 為何不做 |
+|---|---|
+| **`shouldWatchActivity` per-agent 化** | 三家在 status 維度邏輯一致；無 per-agent 差異需求被觀察到（per kickoff A2）。證據：`internal/module/agent/module.go:494` 的 status-only switch；三家 `internal/agent/{cc,codex,opencode}/events.go` 的 `EmitsStatus` set；`internal/agent/drift_test.go` 守住 Status 對齊 |
+| **新 ProbeProfile 欄位**（如 `BottomLines + TopLines` 同時、`SkipChars` 等） | 三欄（TopLines / BottomLines / IdleStableTicks）已足；不為假設場景擴 schema；採樣失敗只在既有三欄內調整 |
+| **混合 capture mode**（同時 hash top + bottom） | TopLines 與 BottomLines 在 `WatchOptions` 設計即為互斥（PR-4a-1 §2.1.2）；若需要 full-pane fallback 應使用 `{TopLines: 0, BottomLines: 0}`（per PR-4a-1 §2.1.2 — 兩欄同 0 才退到 full pane），而非新增混合模式或單欄走 full-pane |
+| **Default profile 改用 TopLines** | default 是「未實作 ProbeProfileProvider 的 agent fallback」；本 PR 範圍只到三家現存 agent 全自訂後再考慮 |
+| **probe primitive / orchestrator 改動** | PR-4a-1 v2.0 dumb-probe 架構未發現問題 |
+| **opencode hook / template / catalog 改動** | 已在 PR-4a-0 對齊；本 PR 不動 |
+| **加 metrics / dev log（codex / opencode 專屬）** | PR-4a-1 已加 `purdex_probe_*` expvar + `PDX_DEV_MODE=1` log，三家共用，不需 per-agent |
+| **整合 readiness（cc CheckReadiness 等）** | 是 spec §8.2 Phase 4b 範圍 |
+
+## 4. Risk
+
+| Risk | Mitigation |
+|---|---|
+| **TopLines=10 對 codex / opencode 採樣後不適用** | §2.2.3 / §2.3.3 implementer 採樣 confirm gate；若採樣不過，spec 同步修推薦值，不硬上 |
+| **codex / opencode 結構未來變動**（upstream UI 改版）| Characterization test 只防止 Purdex profile 常數 silent drift（值改了強制改測試 + reviewer 看到 rationale）；upstream UI 改版**不會** trigger test fail。upstream drift 由 §2.2.3 / §2.3.3 實機採樣與後續 e2e / observability（probe metrics 異常、user 回報誤判）發現，需顯式重採樣才能確認 |
+| **三家 profile 值難以維護一致**（drift） | 每家 profile 由各 provider 自宣告 + characterization test 釘；無「中央同步」需求（per §2.1 設計原則 #1 Provider-owned tuning；對齊 lights-rebuild-spec §2.4.1 分散判準） |
+| **新人不知道 profile 改動需 PR review** | source 註解 + test 註解雙寫 rationale + 引用本 spec 路徑（同 cc CC1 模式） |
+| **主 repo 並發 session**（feedback_concurrent_session_safety）| 進 worktree 前 `git status -s` clean check + 留痕 PR description（沿用 PR-4a-0 / PR-4a-1 流程）|
+
+## 5. Ship gate
+
+| Gate | 條件 |
+|---|---|
+| G1 codex Provider 實作 ProbeProfileProvider | `internal/agent/codex/probe_profile.go` 存在；test 覆蓋 |
+| G2 opencode Provider 實作 ProbeProfileProvider | `internal/agent/opencode/probe_profile.go` 存在；test 覆蓋 |
+| G3 orchestrator 整合測試覆蓋 | `probe_orchestrator_test.go` 加 fake codex / opencode provider case，驗證 orchestrator 取到自訂 profile（非 default fallback）|
+| G4 cc profile 不受影響 | 既有 `cc/probe_profile_test.go` 全綠 |
+| G5 default profile 不受影響 | 既有 orchestrator default-profile fallback test 全綠 |
+| G6 全 repo `go test ./...` 全綠 | TDD 紅燈→綠燈→commit；包含現有 metrics tests（`internal/agent/metrics_test.go`）與 dev log gating tests（`internal/module/agent/probe_orchestrator_test.go` 內 PDX_DEV_MODE 相關 case）— 本 PR 不加新 metrics / dev log，所以既有 test 通過即代表三家共用機制未受影響 |
+| G7 implementer 採樣 confirm — **PR description 留痕** | §2.2.3 / §2.3.3 三條件每家都驗證；**PR description 必含**：(a) 採樣命令（含 tmux session target）、(b) 三狀態（idle / running / spinner）各自 `tmux capture-pane` 輸出（前 N 行）、(c) hash 是否穩定 / 變動的判讀、(d) 頂部 N 行是否含 elapsed timer / spinner 字元的觀察。若三條件之一不過 → spec 修值或改 capture mode 後再上 |
+| G8 SPA lint / build / vitest 不受影響 | 本 PR 不動 SPA，但仍跑一次驗證 |
+
+## 6. 後續
+
+- **下個 PR**：本 PR ship 後，Phase 4a 全部完成。Phase 4b（`ProbeIntentProvider` + readiness 整合）按 spec §8.2 接續。
+- **memory 更新**：`kickoff_lights_rebuild.md` 觸發詞 / 階段更新；`project_progress.md` 更新到 alpha.235（bump PR ship 後）。
+
+## 7. 文獻
+
+- Lights rebuild spec: `docs/specs/2026-04-23-lights-rebuild-spec.md`（§8.1 Phase 4a 原方向；§8.2 Phase 4b 後續）
+- Phase 4a plan v1.3: `docs/specs/2026-04-26-lights-rebuild-phase-4a-plan.md`（§7.2 PR-4a-2 大綱起源）
+- Phase 4a-1 plan v2.1: `docs/specs/2026-04-27-lights-rebuild-phase-4a-1-plan.md`（§1.2 範圍縮減關鍵 — 本 spec 落實依據）
+- 既有實作參考: `internal/agent/cc/probe_profile.go`（cc CC1 — 同型 characterization test 模板）
+- 前置 PR: #670（PR-4a-1 ship）/ #664（PR-4a-0 ship）

--- a/internal/agent/codex/probe_profile.go
+++ b/internal/agent/codex/probe_profile.go
@@ -1,0 +1,20 @@
+package codex
+
+import "github.com/wake/purdex/internal/agent"
+
+// ProbeProfile returns the watch parameters for the codex agent. codex CLI
+// is an append-only TUI: top hash signals new turns; bottom contains
+// spinner + elapsed timer (variable). TopLines=10 captures the recent
+// turn cluster while keeping captures cheap. IdleStableTicks=3 matches
+// the watch-loop default.
+//
+// If a future codex UI revision invalidates these tunings, RE-SAMPLE per
+// spec §2.2.3 (docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md)
+// and update values + CDX1 test together. Touching these values
+// intentionally surfaces the change for review.
+func (p *Provider) ProbeProfile() agent.ProbeProfile {
+	return agent.ProbeProfile{
+		TopLines:        10,
+		IdleStableTicks: 3,
+	}
+}

--- a/internal/agent/codex/probe_profile_test.go
+++ b/internal/agent/codex/probe_profile_test.go
@@ -1,0 +1,28 @@
+package codex_test
+
+import (
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+	codex "github.com/wake/purdex/internal/agent/codex"
+)
+
+// CDX1 — TestCodexProvider_ProbeProfile is a characterization test pinning
+// the codex agent's ProbeProfile values. codex CLI is an append-only TUI:
+// top hash signals new turns; bottom contains spinner + elapsed timer
+// (variable). TopLines=10 captures the recent turn cluster while keeping
+// captures cheap. IdleStableTicks=3 matches the watch-loop default
+// (BB-stable).
+//
+// If a future codex UI revision invalidates these tunings, RE-SAMPLE per
+// spec §2.2.3 (docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md)
+// and update values + this test together. Touching these values
+// intentionally surfaces the change for review.
+func TestCodexProvider_ProbeProfile(t *testing.T) {
+	p := codex.NewProvider()
+	got := p.ProbeProfile()
+	want := agent.ProbeProfile{TopLines: 10, IdleStableTicks: 3}
+	if got != want {
+		t.Fatalf("ProbeProfile() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/agent/opencode/probe_profile.go
+++ b/internal/agent/opencode/probe_profile.go
@@ -1,0 +1,21 @@
+package opencode
+
+import "github.com/wake/purdex/internal/agent"
+
+// ProbeProfile returns the watch parameters for the opencode agent.
+// opencode TUI is structurally similar to codex CLI: append-only top with
+// new turns scrolling content; bottom prompt + spinner / status. TopLines=10
+// captures the recent turn cluster while keeping captures cheap.
+// IdleStableTicks=3 matches the watch-loop default. Profile values mirror
+// codex (no observed structural divergence justifying separate tunings).
+//
+// If a future opencode UI revision invalidates these tunings, RE-SAMPLE
+// per spec §2.3.3 (docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md)
+// and update values + OCD1 test together. Touching these values
+// intentionally surfaces the change for review.
+func (p *Provider) ProbeProfile() agent.ProbeProfile {
+	return agent.ProbeProfile{
+		TopLines:        10,
+		IdleStableTicks: 3,
+	}
+}

--- a/internal/agent/opencode/probe_profile_test.go
+++ b/internal/agent/opencode/probe_profile_test.go
@@ -1,0 +1,27 @@
+package opencode_test
+
+import (
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+	opencode "github.com/wake/purdex/internal/agent/opencode"
+)
+
+// OCD1 — TestOpenCodeProvider_ProbeProfile is a characterization test
+// pinning the opencode agent's ProbeProfile values. opencode TUI is
+// structurally similar to codex CLI (append-only top, bottom prompt +
+// spinner). TopLines=10 + IdleStableTicks=3 mirror codex profile values;
+// per-agent rationale documented in spec §2.3.
+//
+// If a future opencode UI revision invalidates these tunings, RE-SAMPLE
+// per spec §2.3.3 (docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md)
+// and update values + this test together. Touching these values
+// intentionally surfaces the change for review.
+func TestOpenCodeProvider_ProbeProfile(t *testing.T) {
+	p := opencode.NewProvider()
+	got := p.ProbeProfile()
+	want := agent.ProbeProfile{TopLines: 10, IdleStableTicks: 3}
+	if got != want {
+		t.Fatalf("ProbeProfile() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/module/agent/probe_orchestrator.go
+++ b/internal/module/agent/probe_orchestrator.go
@@ -142,12 +142,18 @@ func (o *probeOrchestrator) startWatch(session, agentType string) bool {
 	target := session + ":"
 
 	profile := defaultProbeProfile
+	profileSource := "default"
 	if o.parent != nil && o.parent.registry != nil {
 		if provider, ok := o.parent.registry.Get(agentType); ok {
 			if pp, ok := provider.(agentpkg.ProbeProfileProvider); ok {
 				profile = pp.ProbeProfile()
+				profileSource = "provider"
 			}
 		}
+	}
+	if isDevMode() {
+		log.Printf("[probe] startWatch session=%s agent=%s profile=%s TopLines=%d BottomLines=%d IdleStableTicks=%d",
+			session, agentType, profileSource, profile.TopLines, profile.BottomLines, profile.IdleStableTicks)
 	}
 
 	// Profile validation — must mirror probe.Watch's contract (TopLines +
@@ -335,14 +341,23 @@ func (o *probeOrchestrator) interpretScreenEvent(session, agentType string, ev p
 	currentAgent, active = m.activeWatchers[session]
 	if !active || currentAgent != agentType {
 		m.mu.Unlock()
+		if isDevMode() {
+			log.Printf("[probe] stale callback re-check race session=%s agent=%s kind=%s", session, agentType, ev.Kind)
+		}
 		return
 	}
 	if m.currentStatus[session] == agentpkg.StatusError {
 		m.mu.Unlock()
+		if isDevMode() {
+			log.Printf("[probe] error guard suppress session=%s agent=%s kind=%s", session, agentType, ev.Kind)
+		}
 		return
 	}
 	if prev, ok := m.currentStatus[session]; ok && prev == status {
 		m.mu.Unlock()
+		if isDevMode() {
+			log.Printf("[probe] transition dedup session=%s agent=%s status=%s kind=%s", session, agentType, status, ev.Kind)
+		}
 		return
 	}
 	m.currentStatus[session] = status

--- a/internal/module/agent/probe_orchestrator_test.go
+++ b/internal/module/agent/probe_orchestrator_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/codex"
 	"github.com/wake/purdex/internal/agent/probe"
 	"github.com/wake/purdex/internal/core"
 	"github.com/wake/purdex/internal/module/session"
@@ -805,3 +806,29 @@ func TestOrchestrator_DefaultProfileWhenAgentMissing(t *testing.T) {
 		t.Fatalf("WatchOptions = %+v, want %+v (default profile)", got, want)
 	}
 }
+
+// OR-codex — orchestrator picks up the real codex.Provider's TopLines
+// profile (TopLines=10) instead of falling back to defaultProbeProfile
+// (BottomLines=10). Regression for accidental ProbeProfile() removal on
+// codex.Provider. Spec §2.5; plan §2 Commit 1.
+func TestOrchestrator_RealCodexProviderUsesTopLinesProfile(t *testing.T) {
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+
+	m.registry.Register(codex.NewProvider())
+
+	m.probeOrch.startWatch("sess", "codex")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	got, ok := rec.watchOpts["sess:"]
+	if !ok {
+		t.Fatalf("expected Watch on target %q, got %v", "sess:", rec.watchOpts)
+	}
+	want := probe.WatchOptions{TopLines: 10, BottomLines: 0, IdleStableTicks: 3}
+	if got != want {
+		t.Fatalf("WatchOptions = %+v, want %+v (codex TopLines profile)", got, want)
+	}
+}
+

--- a/internal/module/agent/probe_orchestrator_test.go
+++ b/internal/module/agent/probe_orchestrator_test.go
@@ -720,6 +720,136 @@ func TestDevMode_LogsGatedByEnv(t *testing.T) {
 	})
 }
 
+// captureProbeLogs returns a buffer that collects log output for the duration
+// of the test. Subsequent log assertions can read buf.String().
+func captureProbeLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(origOut) })
+	return &buf
+}
+
+// OB5 — startWatch logs the resolved profile source (provider vs default).
+// Runtime debug needs to answer "is my custom ProbeProfile actually being
+// used?" — the log makes that observable in PDX_DEV_MODE without a debugger.
+func TestDevMode_LogsProfileResolution(t *testing.T) {
+	t.Run("provider_source", func(t *testing.T) {
+		t.Setenv("PDX_DEV_MODE", "1")
+		m := newTestModule(t)
+		rec := newRecordingProber()
+		m.probeOrch.watcher = rec
+
+		provider := &fakeProfileProvider{
+			fakeAgentProvider: fakeAgentProvider{typeName: "fake-agent"},
+			profile:           agentpkg.ProbeProfile{TopLines: 7, IdleStableTicks: 2},
+		}
+		m.registry.Register(provider)
+
+		buf := captureProbeLogs(t)
+		m.probeOrch.startWatch("sess", "fake-agent")
+
+		got := buf.String()
+		if !strings.Contains(got, "[probe] startWatch") || !strings.Contains(got, "profile=provider") ||
+			!strings.Contains(got, "TopLines=7") || !strings.Contains(got, "IdleStableTicks=2") {
+			t.Fatalf("expected provider profile log, got %q", got)
+		}
+	})
+	t.Run("default_source", func(t *testing.T) {
+		t.Setenv("PDX_DEV_MODE", "1")
+		m := newTestModule(t)
+		rec := newRecordingProber()
+		m.probeOrch.watcher = rec
+
+		provider := &fakeAgentProvider{typeName: "plain-agent"}
+		m.registry.Register(provider)
+
+		buf := captureProbeLogs(t)
+		m.probeOrch.startWatch("sess", "plain-agent")
+
+		got := buf.String()
+		if !strings.Contains(got, "[probe] startWatch") || !strings.Contains(got, "profile=default") ||
+			!strings.Contains(got, "BottomLines=10") {
+			t.Fatalf("expected default profile log, got %q", got)
+		}
+	})
+}
+
+// OB6 — stale callback re-check race: callback that finds activeWatchers
+// mutated under the final lock (concurrent stop/rename) emits a log line so
+// "phantom transition disappeared" debugging has a paper trail.
+func TestDevMode_LogsStaleCallbackRecheckRace(t *testing.T) {
+	t.Setenv("PDX_DEV_MODE", "1")
+	m, _, fake := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusRunning, 250)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+	fake.setCaptureFn(func(string, int) (string, error) { return "user prose", nil })
+
+	origInterrupt := interruptBeforeFinalLockFn
+	interruptBeforeFinalLockFn = func(session string) {
+		m.mu.Lock()
+		delete(m.activeWatchers, session)
+		m.mu.Unlock()
+	}
+	t.Cleanup(func() { interruptBeforeFinalLockFn = origInterrupt })
+
+	buf := captureProbeLogs(t)
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", OccurredAt: time.Now()})
+
+	if !strings.Contains(buf.String(), "stale callback re-check race") {
+		t.Fatalf("expected stale-callback re-check log, got %q", buf.String())
+	}
+}
+
+// OB7 — Error Guard: probe events arriving for a StatusError session are
+// silently dropped to keep the error sticky. The log makes "why doesn't probe
+// recover from Error" debuggable.
+func TestDevMode_LogsErrorGuardSuppress(t *testing.T) {
+	t.Setenv("PDX_DEV_MODE", "1")
+	m, _, fake := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusError, 251)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusError
+	m.mu.Unlock()
+	fake.SetPaneContent("work:", "user prose")
+
+	buf := captureProbeLogs(t)
+	cb := m.probeOrch.makeCallback("work", "cc")
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", OccurredAt: time.Now()})
+
+	if !strings.Contains(buf.String(), "error guard suppress") {
+		t.Fatalf("expected error-guard suppress log, got %q", buf.String())
+	}
+}
+
+// OB8 — Transition gate dedup: probe fires ScreenChanged but currentStatus
+// is already StatusRunning → orchestrator drops without broadcasting. The log
+// makes "probe events fire but lights don't move" debuggable.
+func TestDevMode_LogsTransitionDedup(t *testing.T) {
+	t.Setenv("PDX_DEV_MODE", "1")
+	m, _, _ := orchTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusRunning, 252)
+	m.mu.Lock()
+	m.activeWatchers["work"] = "cc"
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+
+	buf := captureProbeLogs(t)
+	cb := m.probeOrch.makeCallback("work", "cc")
+	// ScreenChanged → status=Running; currentStatus already Running → dedup.
+	cb(probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()})
+
+	got := buf.String()
+	if !strings.Contains(got, "transition dedup") || !strings.Contains(got, "status=running") {
+		t.Fatalf("expected transition-dedup log, got %q", got)
+	}
+}
 
 // recordingProber is a test fake that captures Watch/StopWatch invocations.
 // Implements the orchestrator's internal proberWatcher interface.

--- a/internal/module/agent/probe_orchestrator_test.go
+++ b/internal/module/agent/probe_orchestrator_test.go
@@ -11,6 +11,7 @@ import (
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/agent/codex"
+	"github.com/wake/purdex/internal/agent/opencode"
 	"github.com/wake/purdex/internal/agent/probe"
 	"github.com/wake/purdex/internal/core"
 	"github.com/wake/purdex/internal/module/session"
@@ -829,6 +830,31 @@ func TestOrchestrator_RealCodexProviderUsesTopLinesProfile(t *testing.T) {
 	want := probe.WatchOptions{TopLines: 10, BottomLines: 0, IdleStableTicks: 3}
 	if got != want {
 		t.Fatalf("WatchOptions = %+v, want %+v (codex TopLines profile)", got, want)
+	}
+}
+
+// OR-opencode — orchestrator picks up the real opencode.Provider's
+// TopLines profile (TopLines=10) instead of falling back to
+// defaultProbeProfile. Regression for accidental ProbeProfile() removal
+// on opencode.Provider. Spec §2.5; plan §2 Commit 2.
+func TestOrchestrator_RealOpenCodeProviderUsesTopLinesProfile(t *testing.T) {
+	m := newTestModule(t)
+	rec := newRecordingProber()
+	m.probeOrch.watcher = rec
+
+	m.registry.Register(opencode.NewProvider())
+
+	m.probeOrch.startWatch("sess2", "opencode")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	got, ok := rec.watchOpts["sess2:"]
+	if !ok {
+		t.Fatalf("expected Watch on target %q, got %v", "sess2:", rec.watchOpts)
+	}
+	want := probe.WatchOptions{TopLines: 10, BottomLines: 0, IdleStableTicks: 3}
+	if got != want {
+		t.Fatalf("WatchOptions = %+v, want %+v (opencode TopLines profile)", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 4a-2 — final piece of Phase 4a. codex / opencode each implement
`ProbeProfileProvider` returning `{TopLines: 10, IdleStableTicks: 3}`,
mirroring the cc TopLines profile pattern from PR-4a-1. After merge,
all three agents drive the orchestrator with explicit top-hash-based
watch profiles; `defaultProbeProfile` becomes the new-agent fallback only.

A third commit expands `PDX_DEV_MODE=1` log coverage for the four silent
suppress paths flagged in PR review (profile resolution / stale-callback
race / Error-guard / transition-gate dedup) so runtime observability
supersedes ship-time sampling for catching profile-vs-real-pane mismatches
across arbitrary background-tick periods.

- Spec: `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-spec.md`
- Plan: `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-plan.md`
- Sampling evidence (in-tree, codex-sandbox-visible):
  `docs/specs/2026-04-28-lights-rebuild-phase-4a-2-sampling.md`

## Commits

| Commit | Scope |
|---|---|
| `docs(specs): Phase 4a-2 spec + plan v1` | spec + plan v1 |
| `docs(specs): Phase 4a-2 plan v1.1 — codex review R1 fixes (5 P2)` | plan revision after codex spec/plan R1+R2 review (10 P2 total, all wording precision; R2 plan SHIP-READY) |
| `feat(agent/codex): implement ProbeProfileProvider with TopLines profile` | C1 — codex impl + CDX1 + OR-codex |
| `feat(agent/opencode): implement ProbeProfileProvider with TopLines profile` | C2 — opencode impl + OCD1 + OR-opencode |
| `feat(module/agent/probe): expand PDX_DEV_MODE log coverage for silent suppress paths` | C3 — 4 new dev-log lines + OB5/OB6/OB7/OB8 (added in response to PR review R2a) |
| `docs(specs): in-tree sampling artifact + plan §4 dual-track validation` | sampling artifact + plan §4 restructure (added in response to PR review R2b) |

## Codex review trail

### Spec / plan (pre-PR)

| Round | Job | Verdict | Findings |
|---|---|---|---|
| spec R1 | `task-mohevz4n-rinxje` | needs-fix | 3 P2 |
| spec R2 | `task-mohfbbyt-ddbkr7` | needs-fix | 2 P2 |
| plan R1 | `task-mohfg64s-8n3iac` | needs-fix | 5 P2 |
| plan R2 | `task-mohfxast-4uu18o` | **SHIP-READY** | — |

All findings were wording / evidence precision (no architectural drift).

### PR (post-push)

| Round | Job | Verdict | Findings |
|---|---|---|---|
| PR R1 standard | `review-mohh4sng-y933mu` | clean | — |
| PR R2a attack | `review-mohh5olm-buje44` | needs-attention | 1 high — long-horizon sampling concern |
| PR R2b defense | `review-mohh7nn0-jzexpa` | needs-attention | 1 high (in-tree evidence) + 1 medium (opencode equivalence claim) |
| PR R2c file-health | `review-mohh86ec-kp4ox9` | clean | — |
| PR R3 final re-check | (pending after this push) | — | — |

## Response to R2a / R2b findings

**R2a (high) — long-horizon sampling concern**: The recommendation to
require sampling beyond the longest known background period is treated
as an unbounded ask (60s? 5min? 1h?). Two-pronged response instead:

1. **probe-layer v2.0 dumb design** (PR-4a-1 ship) auto-recovers from any
   delayed repaint: if a 60s heartbeat exists, probe fires ScreenChanged
   → `IdleStableTicks=3` reset → 1.5s later fires ScreenStable → user UI
   sees a 1.5s flicker once per period. **User-visible noise, not silent
   corruption**.
2. **Runtime observability** (Commit 3) adds 4 PDX_DEV_MODE log lines for
   the silent suppress paths. A developer running `PDX_DEV_MODE=1` over
   hours of real usage gets stronger evidence than indefinite ship-time
   sampling — and the captured log timestamps localize problems to
   specific sessions / agents / kinds.

Plan §4 restructured to dual-track (`§4.1 ship-time` + `§4.2 runtime`).
Long-horizon scripted sampling is filed as future probe-quality
follow-up, not a ship blocker.

**R2b (high) — diff lacks in-tree sampling evidence**: Sampling Evidence
moved from PR-description prose to
`docs/specs/2026-04-28-lights-rebuild-phase-4a-2-sampling.md`. Codex
sandbox can now audit the actual hashes / capture content / methodology
from the diff alone.

**R2b (medium) — opencode equivalence rests on rationale not observation**:
The new in-tree artifact records opencode-specific 30s × 1s captures and
top-of-pane content snapshot independently from codex (not as a "mirrors
codex" prose claim). Both agents' sampling rows appear side-by-side.

## Sampling Evidence summary (full detail in artifact)

| Agent | tmux session | TopLines | Hash @ t+0 | Hash @ t+29 | Distinct hashes / 30 ticks |
|---|---|---|---|---|---|
| cc | `purdex-tab-name` | 12 | `640ddbdd…` | `640ddbdd…` (same) | **1** ✓ |
| codex | `sys` | 10 | `8f0119a9…` | `8f0119a9…` (same) | **1** ✓ |
| opencode | `purdex-sync` | 10 | `eca96fd4…` | `eca96fd4…` (same) | **1** ✓ |

All three agents produced 30 consecutive 1s-cadence captures with
identical md5 hashes during a fully-static-idle window. Top-of-pane
content snapshots inspected for elapsed-timer / spinner / cursor-blink
characters → none present in any of the three captures.

## Tests (8 new)

| Test | File | Assertion |
|---|---|---|
| CDX1 `TestCodexProvider_ProbeProfile` | `internal/agent/codex/probe_profile_test.go` | codex profile = `{TopLines:10, IdleStableTicks:3}` |
| OCD1 `TestOpenCodeProvider_ProbeProfile` | `internal/agent/opencode/probe_profile_test.go` | opencode profile = `{TopLines:10, IdleStableTicks:3}` |
| OR-codex | `internal/module/agent/probe_orchestrator_test.go` | orchestrator forwards real codex profile to `Watch(target, opts, cb)` |
| OR-opencode | `internal/module/agent/probe_orchestrator_test.go` | orchestrator forwards real opencode profile to `Watch(target, opts, cb)` |
| OB5 `TestDevMode_LogsProfileResolution` | `internal/module/agent/probe_orchestrator_test.go` | startWatch logs `profile=provider` vs `profile=default` |
| OB6 `TestDevMode_LogsStaleCallbackRecheckRace` | `internal/module/agent/probe_orchestrator_test.go` | concurrent stop/rename callback logs `stale callback re-check race` |
| OB7 `TestDevMode_LogsErrorGuardSuppress` | `internal/module/agent/probe_orchestrator_test.go` | StatusError session logs `error guard suppress` on probe event |
| OB8 `TestDevMode_LogsTransitionDedup` | `internal/module/agent/probe_orchestrator_test.go` | currentStatus already matches → logs `transition dedup` |

`go test ./... -count=1` — all green (full repo).

## Out of scope (per spec §3)

- `shouldWatchActivity` per-agent specialization (no observed status-policy divergence; module.go:494 + drift_test.go evidence)
- ProbeProfile schema extension (existing 3-field shape suffices)
- default profile change (still `{BottomLines:10}` as new-agent fallback)
- probe primitive / orchestrator structural changes (PR-4a-1 v2.0 dumb-probe holds)
- opencode hook / template / catalog changes (PR-4a-0 territory)
- readiness integration (Phase 4b)
- new metrics for the 4 silent suppress paths (dev log suffices for Commit 3 scope; counters would be a follow-up PR)
- long-horizon scripted sampling (R2a follow-up — see plan §4.2 rationale)

## Pre-existing SPA vitest failures (not blocking)

`pnpm exec vitest run` shows 4 pre-existing failures unrelated to this
PR (this PR touches no SPA code):

- `spa/src/lib/sync/contributors/hosts.test.ts` — 3 failures (token-preservation logic, last touched in PR #438 / #447 baseline)
- `spa/src/components/TabBar.test.tsx` — 1 failure (pinned-tab tooltip rendering, last touched in PR #636)

These reproduce on rebased `origin/main` with this branch's code reverted from `spa/`. Tracked separately — not a blocker for this PR.

## Worktree origin (concurrent-session safety)

Branch was rebased onto `origin/main` (alpha.235 = `fbd43466`) after the
opening commits because main advanced concurrently with PR #672 (electron
signing fix) and PR #673 (alpha.235 bump). Post-rebase `go test ./...`
re-verified green.

## Test plan

- [x] codex review round 1 (standard) — `review-mohh4sng-y933mu` — clean
- [x] codex review round 2 — 3-parallel adversarial (attack / defense / file-health) — `review-mohh5olm-buje44` / `review-mohh7nn0-jzexpa` / `review-mohh86ec-kp4ox9`
- [x] R2a / R2b findings addressed (Commit 3 dev-log expansion + sampling artifact)
- [ ] codex final re-check after R2a/R2b fixes
- [ ] After merge, ship bump PR (alpha.236) — VERSION + package.json + spa/package.json + CHANGELOG.md