### PR TITLE
feat: quick-commands v2 — Phase 1a (data layer)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
+++ b/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
@@ -816,7 +816,7 @@ Expected: clean
 
 **Spec v4 新增的支援結構：** Phase 1b 三個基礎件（`inferWorkspaceHostId` helper + `HostPickerPopover` 元件 + i18n keys）必須先於 `<CommandSlot>` / executor / workspace 入口落地，否則後續 task 在跑單元測試時會看到 raw i18n key（fallback to key），且 caller 無法正確呼叫。
 
-**Task 順序：** 1b.0a → 1b.0b → 1b.0c → 1b.1 → 1b.1.5 → 1b.2 → 1b.3 → 1b.4 → 1b.5a → 1b.6。（原 1b.5b 移到 Phase 1b'；1b.0c 為新增的「i18n keys 前置」task。）
+**Task 順序：** 1b.0a → 1b.0c → 1b.0b → 1b.1 → 1b.1.5 → 1b.2 → 1b.3 → 1b.4 → 1b.5a → 1b.6。（原 1b.5b 移到 Phase 1b'；1b.0c 為新增的「i18n keys 前置」task — 必須在 1b.0b HostPickerPopover 測試之前 ship，否則測試會比對到 raw i18n key 而誤綠。）
 
 ### Task 1b.0a: 新增 `inferWorkspaceHostId` helper（spec §3.2.1 多數決）
 
@@ -1091,13 +1091,96 @@ feat(spa): add inferWorkspaceHostId — majority-vote host resolution for worksp
 
 ---
 
+### Task 1b.0c: 前置 i18n keys（HostPicker / aria / executor / toast）
+
+**Files:**
+- Modify: `spa/src/locales/zh-TW.json`
+- Modify: `spa/src/locales/en.json`
+
+**動機（codex round-1 B9 / round-2 B9）：** 後續 task（HostPickerPopover、CommandSlot、slot-executor、context menu、popover）的單元測試會直接 render 元件、`screen.getByText(/No hosts available/i)` / `getByRole('button', { name: /retry/i })` 比對顯示文字。i18n 系統在 key 缺失時 fallback 回 raw key，會導致測試比對 `quick_commands.host_picker.empty` 而非實際翻譯，**綠／紅判定模糊**。把 keys 加入 JSON 必須**先於**任何用到這些 keys 的 caller / 元件測試開跑 — 因此 1b.0c 必須跑在 1b.0b（HostPickerPopover）之前。
+
+原 plan 的 1b.4（settings contribution + i18n）保留，但只負責 **Settings tab / dialog / module description / 模組元件外殼**等後續 keys；**HostPicker、aria-label、executor toast、retry 按鈕**等先放在 1b.0c。
+
+**i18n keys 清單（codex round-1 B9 + C16 — aria-label 也走 i18n）：**
+
+zh-TW + en 對照（同步加入）：
+
+```json
+{
+  "quick_commands.host_picker.label": "選擇主機" / "Choose host",
+  "quick_commands.host_picker.empty": "尚未設定任何主機" / "No hosts available",
+  "quick_commands.host_picker.online": "線上" / "online",
+  "quick_commands.host_picker.offline": "離線" / "offline",
+  "quick_commands.host_picker.close": "關閉" / "Close",
+  "quick_commands.toast.create_failed": "無法建立 session：{{reason}}" / "Failed to start session: {{reason}}",
+  "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。" / "Session created, but command failed.",
+  "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。" / "Created and sent, but could not switch focus; check the sessions list.",
+  "quick_commands.toast.retry": "重試" / "Retry",
+  "quick_commands.aria.toolbar": "快速指令" / "Quick commands",
+  "quick_commands.aria.workspace_actions": "工作區快速動作" / "Workspace quick actions"
+}
+```
+
+註：`settings.section.quick_commands` / `settings.quick_commands.*` / `modules.quick_commands.description` / `common.edit` 等 keys 留在 1b.4 一併加入（因為它們綁 settings UI 上下文，1b.4 才會 render 出來）。
+
+- [ ] **Step 1: Add keys to zh-TW.json**
+
+Edit `spa/src/locales/zh-TW.json`（按既有檔案的字典排序或群組原則插入；確認 trailing comma 不破壞 JSON 結構）：
+
+```json
+  "quick_commands.host_picker.label": "選擇主機",
+  "quick_commands.host_picker.empty": "尚未設定任何主機",
+  "quick_commands.host_picker.online": "線上",
+  "quick_commands.host_picker.offline": "離線",
+  "quick_commands.host_picker.close": "關閉",
+  "quick_commands.toast.create_failed": "無法建立 session：{{reason}}",
+  "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。",
+  "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。",
+  "quick_commands.toast.retry": "重試",
+  "quick_commands.aria.toolbar": "快速指令",
+  "quick_commands.aria.workspace_actions": "工作區快速動作",
+```
+
+- [ ] **Step 2: Add keys to en.json**
+
+Edit `spa/src/locales/en.json`：
+
+```json
+  "quick_commands.host_picker.label": "Choose host",
+  "quick_commands.host_picker.empty": "No hosts available",
+  "quick_commands.host_picker.online": "online",
+  "quick_commands.host_picker.offline": "offline",
+  "quick_commands.host_picker.close": "Close",
+  "quick_commands.toast.create_failed": "Failed to start session: {{reason}}",
+  "quick_commands.toast.send_keys_failed": "Session created, but command failed.",
+  "quick_commands.toast.switch_failed": "Created and sent, but could not switch focus; check the sessions list.",
+  "quick_commands.toast.retry": "Retry",
+  "quick_commands.aria.toolbar": "Quick commands",
+  "quick_commands.aria.workspace_actions": "Workspace quick actions",
+```
+
+- [ ] **Step 3: Verify locale completeness**
+
+Run: `cd spa && pnpm run lint`
+Expected: clean（既有 lint 已含 locale-completeness 檢查；所有新 keys 必須兩語對齊）。
+
+- [ ] **Step 4: Commit**
+
+```
+chore(spa): add i18n keys for quick commands HostPicker / aria / toast (codex round-1 B9)
+```
+
+註：Task 1b.0b 的 HostPickerPopover 測試 + 實作仰賴 `quick_commands.host_picker.*` keys；**順序鐵則：1b.0a → 1b.0c → 1b.0b**（i18n keys 必須先於 HostPickerPopover ship，否則測試會比對 raw i18n key 而誤綠，prod 端 fallback 顯示 raw key 文字）。1b.0c 純粹是 i18n keys 增量（`zh-TW.json` + `en.json`），與 0a/0b 無代碼依賴，可獨立先做。
+
+---
+
 ### Task 1b.0b: 新增 `HostPickerPopover` 共用元件（spec §3.2.2 / §4.4）
 
 **Files:**
 - Create: `spa/src/components/HostPickerPopover.tsx`
 - Create: `spa/src/components/HostPickerPopover.test.tsx`
 
-**動機：** spec §3.2.2 規定 workspace hostId 為 null 時不可靜默 fallback；改開 host picker 讓 user 主動選 host。spec §3.5 forward-compat：未來 multi-host workspace binding 系統也用同一個 popover。本 task 為**獨立可重用元件**，不耦合 quick commands store。
+**動機：** spec §3.2.2 規定 workspace hostId 為 null 時不可靜默 fallback；改開 host picker 讓 user 主動選 host。spec §3.5 forward-compat：未來 multi-host workspace binding 系統也用同一個 popover。本 task 為**獨立可重用元件**，不耦合 quick commands store。前置依賴：Task 1b.0c 必須先完成（i18n keys）。
 
 **API：**
 ```tsx
@@ -1411,7 +1494,7 @@ export function HostPickerPopover({ open, anchor, onSelect, onCancel }: Props) {
             aria-label={t('quick_commands.host_picker.close')}
             className="p-0.5 text-text-muted hover:text-text-primary cursor-pointer"
           >
-            {/* Use Phosphor X icon at runtime; placeholder marker for plan. */}
+            {/* Implementation note: use Phosphor `X` icon component at runtime. */}
             ×
           </button>
         </div>
@@ -1458,89 +1541,6 @@ Expected: PASS
 ```
 feat(spa): add HostPickerPopover reusable component for host selection (spec §3.2.2 / §4.4)
 ```
-
----
-
-### Task 1b.0c: 前置 i18n keys（HostPicker / aria / executor / toast）
-
-**Files:**
-- Modify: `spa/src/locales/zh-TW.json`
-- Modify: `spa/src/locales/en.json`
-
-**動機（codex round-1 B9）：** 後續 task（HostPickerPopover、CommandSlot、slot-executor、context menu、popover）的單元測試會直接 render 元件、`screen.getByText(/No hosts available/i)` / `getByRole('button', { name: /retry/i })` 比對顯示文字。i18n 系統在 key 缺失時 fallback 回 raw key，會導致測試比對 `quick_commands.host_picker.empty` 而非實際翻譯，**綠／紅判定模糊**。把 keys 加入 JSON 必須**先於**任何用到這些 keys 的 caller / 元件測試開跑。
-
-原 plan 的 1b.4（settings contribution + i18n）保留，但只負責 **Settings tab / dialog / module description / 模組元件外殼**等後續 keys；**HostPicker、aria-label、executor toast、retry 按鈕**等先放在 1b.0c。
-
-**i18n keys 清單（codex round-1 B9 + C16 — aria-label 也走 i18n）：**
-
-zh-TW + en 對照（同步加入）：
-
-```json
-{
-  "quick_commands.host_picker.label": "選擇主機" / "Choose host",
-  "quick_commands.host_picker.empty": "尚未設定任何主機" / "No hosts available",
-  "quick_commands.host_picker.online": "線上" / "online",
-  "quick_commands.host_picker.offline": "離線" / "offline",
-  "quick_commands.host_picker.close": "關閉" / "Close",
-  "quick_commands.toast.create_failed": "無法建立 session：{{reason}}" / "Failed to start session: {{reason}}",
-  "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。" / "Session created, but command failed.",
-  "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。" / "Created and sent, but could not switch focus; check the sessions list.",
-  "quick_commands.toast.retry": "重試" / "Retry",
-  "quick_commands.aria.toolbar": "快速指令" / "Quick commands",
-  "quick_commands.aria.workspace_actions": "工作區快速動作" / "Workspace quick actions"
-}
-```
-
-註：`settings.section.quick_commands` / `settings.quick_commands.*` / `modules.quick_commands.description` / `common.edit` 等 keys 留在 1b.4 一併加入（因為它們綁 settings UI 上下文，1b.4 才會 render 出來）。
-
-- [ ] **Step 1: Add keys to zh-TW.json**
-
-Edit `spa/src/locales/zh-TW.json`（按既有檔案的字典排序或群組原則插入；確認 trailing comma 不破壞 JSON 結構）：
-
-```json
-  "quick_commands.host_picker.label": "選擇主機",
-  "quick_commands.host_picker.empty": "尚未設定任何主機",
-  "quick_commands.host_picker.online": "線上",
-  "quick_commands.host_picker.offline": "離線",
-  "quick_commands.host_picker.close": "關閉",
-  "quick_commands.toast.create_failed": "無法建立 session：{{reason}}",
-  "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。",
-  "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。",
-  "quick_commands.toast.retry": "重試",
-  "quick_commands.aria.toolbar": "快速指令",
-  "quick_commands.aria.workspace_actions": "工作區快速動作",
-```
-
-- [ ] **Step 2: Add keys to en.json**
-
-Edit `spa/src/locales/en.json`：
-
-```json
-  "quick_commands.host_picker.label": "Choose host",
-  "quick_commands.host_picker.empty": "No hosts available",
-  "quick_commands.host_picker.online": "online",
-  "quick_commands.host_picker.offline": "offline",
-  "quick_commands.host_picker.close": "Close",
-  "quick_commands.toast.create_failed": "Failed to start session: {{reason}}",
-  "quick_commands.toast.send_keys_failed": "Session created, but command failed.",
-  "quick_commands.toast.switch_failed": "Created and sent, but could not switch focus; check the sessions list.",
-  "quick_commands.toast.retry": "Retry",
-  "quick_commands.aria.toolbar": "Quick commands",
-  "quick_commands.aria.workspace_actions": "Workspace quick actions",
-```
-
-- [ ] **Step 3: Verify locale completeness**
-
-Run: `cd spa && pnpm run lint`
-Expected: clean（既有 lint 已含 locale-completeness 檢查；所有新 keys 必須兩語對齊）。
-
-- [ ] **Step 4: Commit**
-
-```
-chore(spa): add i18n keys for quick commands HostPicker / aria / toast (codex round-1 B9)
-```
-
-註：Task 1b.0b 的 HostPickerPopover 測試 + 實作仰賴 `quick_commands.host_picker.*` keys；若工程實作時把 1b.0b 排在 1b.0c 之前（順序顛倒），HostPickerPopover 測試會比對 raw key 而綠燈，但實際 prod fallback 行為不正確。**順序鐵則：1b.0a → 1b.0b ≤ 1b.0c**（1b.0c 不晚於 1b.0b 也可，但必須早於 1b.1）。實務建議：把 1b.0c 寫在 1b.0b commit 之後、1b.1 commit 之前，做為「進入元件 / 測試前的最後一道 i18n 補位」。
 
 ---
 
@@ -1704,6 +1704,47 @@ describe('CommandSlot', () => {
     expect(screen.getAllByTestId('custom').map((n) => n.textContent)).toEqual(['cmd-a', 'cmd-c'])
   })
 
+  // codex round-2 — render prop receives `run` as 3rd arg so custom UIs can
+  // actually trigger executor. Without `run` custom render is an inert footgun.
+  it('custom render receives `run` callback that triggers executor', () => {
+    const exec = vi.fn().mockResolvedValue(undefined)
+    render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: 'h1' }}
+        executor={exec}
+        render={(cmd, _ctx, run) => (
+          <button data-testid={`custom-${cmd.id}`} onClick={run}>
+            {cmd.name}
+          </button>
+        )}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('custom-cmd-a'))
+    expect(exec).toHaveBeenCalledTimes(1)
+    expect(exec.mock.calls[0][0].id).toBe('cmd-a')
+    expect(exec.mock.calls[0][1]).toMatchObject({ hostId: 'h1' })
+  })
+
+  it('custom render `run` respects busy guard (no executor when busy=true)', () => {
+    const exec = vi.fn().mockResolvedValue(undefined)
+    render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: 'h1' }}
+        executor={exec}
+        busy={true}
+        render={(cmd, _ctx, run) => (
+          <button data-testid={`custom-${cmd.id}`} onClick={run}>
+            {cmd.name}
+          </button>
+        )}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('custom-cmd-a'))
+    expect(exec).not.toHaveBeenCalled()
+  })
+
   it('disables all chip buttons while busy=true (codex round-1 C11 — picker resolver race guard)', () => {
     // Picker open → caller flips busy=true to prevent double-click on chip
     // (which would create a second pending Promise and a second picker instance).
@@ -1763,7 +1804,15 @@ export interface SlotContext {
 }
 
 export type SlotExecutor = (cmd: QuickCommand, ctx: SlotContext) => Promise<void>
-export type SlotRenderer = (cmd: QuickCommand, ctx: SlotContext) => ReactNode
+/**
+ * codex round-2 — `run` is the 3rd argument injected by `<CommandSlot>` so a
+ * custom render can wire its own onClick to the executor pipeline. Without it
+ * a custom render becomes an inert UI footgun (the chip is visible but
+ * clicking does nothing). `run` is the same `executor(cmd, ctx)` Promise the
+ * default chip kicks off; callers should still respect `busy` and avoid
+ * double-firing.
+ */
+export type SlotRenderer = (cmd: QuickCommand, ctx: SlotContext, run: () => void) => ReactNode
 
 interface Props {
   mountTo: QuickCommandSlotId
@@ -1821,10 +1870,17 @@ export function CommandSlot({ mountTo, ctx, executor, render, containerClassName
       aria-label={t('quick_commands.aria.toolbar')}
     >
       {boundCmds.map((cmd) => {
+        // codex round-2 — `run` injected so custom render can wire its own
+        // onClick. Without it custom render becomes inert (chip visible, click
+        // does nothing) — the same footgun the original 2-arg signature shipped.
+        const run = () => {
+          if (busy) return
+          void executor(cmd, ctx)
+        }
         if (render) {
           return (
             <span key={cmd.id} className="inline-flex">
-              {render(cmd, ctx)}
+              {render(cmd, ctx, run)}
             </span>
           )
         }
@@ -1836,10 +1892,7 @@ export function CommandSlot({ mountTo, ctx, executor, render, containerClassName
             // codex round-1 C11 — busy guard prevents double-click from spawning
             // a second picker / executor pipeline while one is mid-flight.
             disabled={busy}
-            onClick={() => {
-              if (busy) return
-              void executor(cmd, ctx)
-            }}
+            onClick={run}
             aria-label={ariaLabel}
             title={cmd.command}
             className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-text-secondary hover:text-text-primary hover:bg-surface-secondary cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
@@ -3124,7 +3177,7 @@ import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
 
-// codex round-1 B8 — full executable test body (no placeholder comments)
+// codex round-1 B8 — full executable test body (subagent must not insert TODO stubs)
 import { useTabStore } from '../../../stores/useTabStore'
 import { useWorkspaceStore } from '../../../stores/useWorkspaceStore'
 
@@ -3160,9 +3213,10 @@ function setup(workspaceId = 'w1', hostId = 'h1') {
     tabOrder: [],
     activeTabId: null,
   } as Partial<ReturnType<typeof useTabStore.getState>> as never)
+  // codex round-2 B8 — useWorkspaceStore.workspaces 是 Workspace[]（非 Record），
+  // 沒有 workspaceOrder 欄位（spa/src/features/workspace/store.ts:10 確認）。
   useWorkspaceStore.setState({
-    workspaces: { [workspaceId]: { id: workspaceId, name: 'WS', tabs: [], activeTabId: null, moduleConfig: {} } },
-    workspaceOrder: [workspaceId],
+    workspaces: [{ id: workspaceId, name: 'WS', tabs: [], activeTabId: null, moduleConfig: {} }],
     activeWorkspaceId: workspaceId,
   } as Partial<ReturnType<typeof useWorkspaceStore.getState>> as never)
   clearModuleRegistry()
@@ -3204,7 +3258,8 @@ describe('WorkspaceQuickCommandsContextMenu', () => {
     expect(createSession).toHaveBeenCalledWith('h1', expect.any(String), expect.any(String), 'terminal')
     // Tab should be inserted into the workspace (codex round-1 B6 — full
     // openSingletonAndSelect equivalent: openSingletonTab → insertTab → setActive).
-    const tabIds = useWorkspaceStore.getState().workspaces['w1']?.tabs ?? []
+    // codex round-2 B8 — workspaces 是 Workspace[]，用 .find() 不是 record key 索引
+    const tabIds = useWorkspaceStore.getState().workspaces.find((w) => w.id === 'w1')?.tabs ?? []
     expect(tabIds.length).toBeGreaterThan(0)
     const tabId = tabIds[tabIds.length - 1]
     const tab = useTabStore.getState().tabs[tabId]
@@ -3252,9 +3307,40 @@ describe('WorkspaceQuickCommandsContextMenu', () => {
     await new Promise<void>((r) => setTimeout(r, 0))
     expect(createSession).not.toHaveBeenCalled()
     // No tab inserted into workspace
-    expect(useWorkspaceStore.getState().workspaces['w1']?.tabs ?? []).toHaveLength(0)
+    // codex round-2 B8 — workspaces 是 Workspace[]，用 .find() 不是 record key 索引
+    expect(useWorkspaceStore.getState().workspaces.find((w) => w.id === 'w1')?.tabs ?? []).toHaveLength(0)
     // onClose still fires (executor's finally block runs even on cancel path)
     expect(onClose).toHaveBeenCalled()
+  })
+
+  // codex round-2 — picker resolver cleanup (parent unmount + duplicate resolve safety)
+  it('unmount while picker is open → pending Promise resolves to null, executor finally runs, no throw', async () => {
+    const onClose = vi.fn()
+    const { unmount } = render(
+      <WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId={null} onClose={onClose} />,
+    )
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+    // simulate the parent menu closing externally (e.g. user clicks outside the
+    // WorkspaceContextMenu) while a picker resolver is mid-flight.
+    expect(() => unmount()).not.toThrow()
+    await new Promise<void>((r) => setTimeout(r, 0))
+    // executor's finally should have run despite no explicit user action
+    expect(onClose).toHaveBeenCalled()
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('duplicate onSelect / onCancel calls are safe (resolver is nulled-out after first invocation)', async () => {
+    const onClose = vi.fn()
+    render(<WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId={null} onClose={onClose} />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+    // First Esc → cancels normally
+    fireEvent.keyDown(document, { key: 'Escape' })
+    // Second Esc (e.g. fast double-tap) → must be a no-op, NOT throw
+    expect(() => fireEvent.keyDown(document, { key: 'Escape' })).not.toThrow()
+    await new Promise<void>((r) => setTimeout(r, 0))
+    expect(createSession).not.toHaveBeenCalled()
   })
 })
 ```
@@ -3323,7 +3409,7 @@ Expected: FAIL — module not found / props missing。
 Create `spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx`（codex round-1 B5/B6/B7 —使用 default chip render + `containerClassName="flex flex-col"`；executor 內部完整呼叫 `openSingletonTab` + `insertTab` + `setActiveWorkspace` + `setActiveTab`，並補齊所有 `tmux-session` 欄位）：
 
 ```tsx
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { CommandSlot } from '../../../components/CommandSlot'
 import { HostPickerPopover } from '../../../components/HostPickerPopover'
 import { runWorkspaceSlot } from '../../../lib/slot-executor'
@@ -3354,8 +3440,12 @@ interface Props {
  * 以滿足 `spa/src/types/tab.ts` 的型別契約。
  */
 export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose }: Props) {
+  // codex round-2 — picker state shape pinned: open implied by resolver !== null;
+  // resolver is always nulled-out the moment it's invoked (idempotent guard against
+  // duplicate resolve which would no-op the Promise but is still a sign of a bug).
   const [picker, setPicker] = useState<{
-    resolver: (id: string | null) => void
+    open: boolean
+    resolver: ((hostId: string | null) => void) | null
     anchor: { x: number; y: number } | null
   } | null>(null)
   const lastClickPos = useRef<{ x: number; y: number } | null>(null)
@@ -3363,10 +3453,24 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
   const resolveHostId = useCallback(
     () =>
       new Promise<string | null>((resolve) => {
-        setPicker({ resolver: resolve, anchor: lastClickPos.current })
+        setPicker({ open: true, resolver: resolve, anchor: lastClickPos.current })
       }),
     [],
   )
+
+  // codex round-2 — dangling Promise cleanup. If the parent menu closes (unmount)
+  // or the popover gets force-dismissed externally while a picker resolver is
+  // still pending, we MUST resolve it as null so the executor's await returns,
+  // its `finally` runs, and onClose fires. Otherwise the Promise hangs forever
+  // and the executor stays mid-flight (busy=true sticks, chips stay disabled).
+  useEffect(() => {
+    return () => {
+      setPicker((current) => {
+        if (current?.resolver) current.resolver(null)
+        return null
+      })
+    }
+  }, [])
 
   // codex round-1 B6 — workspace caller must perform full openSingletonAndSelect
   // equivalent (the helper exists at spa/src/features/workspace/hooks.ts:200 but
@@ -3404,7 +3508,7 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
         // codex round-1 B7 — flex-col override; default chip render keeps onClick + executor wiring intact.
         containerClassName="flex flex-col"
         // codex round-1 C11 — disable buttons while picker is mid-flight (prevents double-click race).
-        busy={picker !== null}
+        busy={picker?.open ?? false}
         executor={async (cmd, ctx) => {
           try {
             await runWorkspaceSlot(cmd, ctx, {
@@ -3417,15 +3521,18 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
         }}
       />
       <HostPickerPopover
-        open={picker !== null}
+        open={picker?.open ?? false}
         anchor={picker?.anchor ?? null}
         onSelect={(hostId) => {
-          picker?.resolver(hostId)
+          // codex round-2 — null-out resolver before invoking to make duplicate-call safe
+          const resolver = picker?.resolver
           setPicker(null)
+          resolver?.(hostId)
         }}
         onCancel={() => {
-          picker?.resolver(null)
+          const resolver = picker?.resolver
           setPicker(null)
+          resolver?.(null)
         }}
       />
     </div>
@@ -3433,7 +3540,7 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
 }
 ```
 
-註（codex round-1 B7 解決舊版「render prop 與 onClick 矛盾」）：原本的舊 plan 同時傳 `render` 與 `executor`，但 CommandSlot 在有 `render` 時包 `<span>` 不掛 onClick → executor 永遠不跑。新版只用 `containerClassName="flex flex-col"` 改 layout，**不**傳 `render`，default button 帶 onClick 正常觸發 executor。CommandSlot 的 `containerClassName` prop 已在 Task 1b.1 加入。
+註（codex round-1 B7 + round-2）：原本的舊 plan 同時傳 `render` 與 `executor`，但 CommandSlot 在有 `render` 時包 `<span>` 不掛 onClick → executor 永遠不跑（unreachable UI footgun）。round-2 已把 `SlotRenderer` 升級為 3-arg `(cmd, ctx, run) => ReactNode`，custom render 拿 `run` 自行掛 onClick；但本 caller 用 `containerClassName="flex flex-col"` 改 layout 即足夠，不需 custom render，default button 帶 onClick 正常觸發 executor。CommandSlot 的 `containerClassName` prop 與 3-arg `run` 注入皆在 Task 1b.1 加入。
 
 更新後 `WorkspaceContextMenu.tsx`：
 
@@ -3736,6 +3843,15 @@ describe('WorkspaceQuickActionsPopover', () => {
     fireEvent.click(screen.getByLabelText(/^Alpha/))
     expect(screen.getByRole('listbox')).toBeInTheDocument()
   })
+
+  // codex round-2 — picker resolver cleanup (popover unmount via mouseleave on parent)
+  it('unmount while picker is open → pending Promise resolves to null, no throw', async () => {
+    const { unmount } = render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId={null} />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    // simulate parent hub mouseleave force-closing the popover wrapper.
+    expect(() => unmount()).not.toThrow()
+  })
 })
 ```
 
@@ -3789,21 +3905,37 @@ function setupHoverPopoverFixtures(opts: { withBindings: boolean }) {
   registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
 }
 
+// codex round-2 B8 — props 依 WorkspaceRow.tsx 實際 Props 介面（spa/src/features/workspace/components/WorkspaceRow.tsx L11-24）對齊：
+// workspace / isActive / tabsById / activeTabId / onSelectWorkspace /
+// onContextMenuWorkspace? / onSelectTab / onCloseTab / onMiddleClickTab /
+// onContextMenuTab / onRenameTab? / onAddTabToWorkspace
 const baseProps = {
   workspace: { id: 'w1', name: 'WS', tabs: ['t1'], activeTabId: 't1', moduleConfig: {} },
   isActive: false,
-  isExpanded: true,
-  showTabs: true,
-  workspaceTabs: [],
-  selectedTabId: null,
-  onSelect: vi.fn(),
-  onToggleExpanded: vi.fn(),
-  onAddTabToWorkspace: vi.fn(),
-  onContextMenu: vi.fn(),
+  tabsById: {
+    t1: {
+      id: 't1', pinned: false, locked: false, createdAt: 0,
+      layout: {
+        type: 'leaf' as const,
+        pane: {
+          id: 'p1',
+          content: {
+            kind: 'tmux-session' as const, hostId: 'h1', sessionCode: 'sess', mode: 'terminal' as const,
+            cachedName: 'x', tmuxInstance: '',
+          },
+        },
+      },
+    },
+  },
+  activeTabId: 't1' as string | null,
+  onSelectWorkspace: vi.fn(),
+  onContextMenuWorkspace: vi.fn(),
   onSelectTab: vi.fn(),
   onCloseTab: vi.fn(),
-  onTabContextMenu: vi.fn(),
-  // … 其餘必要 props 依 WorkspaceRow 實際介面補
+  onMiddleClickTab: vi.fn(),
+  onContextMenuTab: vi.fn(),
+  onRenameTab: vi.fn(),
+  onAddTabToWorkspace: vi.fn(),
 }
 
 describe('WorkspaceRow — Plus hover popover (Phase 1b\\')', () => {
@@ -3905,7 +4037,7 @@ Expected: FAIL — module not found / popover 不顯示。
 Create `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx`（codex round-1 B5/B6/C16 — switchToSession 完整 tmux-session 欄位 + workspace insertTab + setActive + aria-label 走 i18n）：
 
 ```tsx
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { CommandSlot } from '../../../components/CommandSlot'
 import { HostPickerPopover } from '../../../components/HostPickerPopover'
 import { runWorkspaceSlot } from '../../../lib/slot-executor'
@@ -3944,18 +4076,33 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
     return cmds.some((c) => s.bindings[c.id]?.includes(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS))
   })
   const wrapperRef = useRef<HTMLDivElement>(null)
+  // codex round-2 — picker state shape pinned: open implied by resolver !== null.
   const [picker, setPicker] = useState<{
-    resolver: (id: string | null) => void
+    open: boolean
+    resolver: ((id: string | null) => void) | null
     anchor: HTMLElement | null
   } | null>(null)
 
   const resolveHostId = useCallback(
     () =>
       new Promise<string | null>((resolve) => {
-        setPicker({ resolver: resolve, anchor: wrapperRef.current })
+        setPicker({ open: true, resolver: resolve, anchor: wrapperRef.current })
       }),
     [],
   )
+
+  // codex round-2 — dangling Promise cleanup. The popover lives behind a hover
+  // trigger; mouseleave on the parent hub will unmount this component while a
+  // resolver may still be pending. We MUST resolve null on unmount so the
+  // executor's await returns and busy state clears.
+  useEffect(() => {
+    return () => {
+      setPicker((current) => {
+        if (current?.resolver) current.resolver(null)
+        return null
+      })
+    }
+  }, [])
 
   // codex round-1 B5/B6 — full openSingletonAndSelect equivalent: complete
   // tmux-session content fields + insertTab into workspace + setActive.
@@ -3990,7 +4137,7 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
         mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
         ctx={{ hostId, workspaceId }}
         // codex round-1 C11 — picker race guard
-        busy={picker !== null}
+        busy={picker?.open ?? false}
         executor={(cmd, ctx) =>
           runWorkspaceSlot(cmd, ctx, {
             switchToSession,
@@ -3999,15 +4146,18 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
         }
       />
       <HostPickerPopover
-        open={picker !== null}
+        open={picker?.open ?? false}
         anchor={picker?.anchor ?? null}
         onSelect={(hostId) => {
-          picker?.resolver(hostId)
+          // codex round-2 — null-out resolver before invoking to make duplicate-call safe
+          const resolver = picker?.resolver
           setPicker(null)
+          resolver?.(hostId)
         }}
         onCancel={() => {
-          picker?.resolver(null)
+          const resolver = picker?.resolver
           setPicker(null)
+          resolver?.(null)
         }}
       />
     </div>
@@ -4147,14 +4297,14 @@ Expected: clean
 行動裝置 / 觸控（codex round-1 C17）：
 6. iOS Safari 或 Android Chrome 連上 dev URL（`https://*.mlab.host:5174`）
 7. 在 sidebar Plus 按鈕做 long-press（按住 ≥500ms 不放）→ popover 展開
-8. 仍按住手指 → tap chip → 建 session + 送 cmd + 切過去
+8. 放開後 tap chip → 建 session + 送 cmd + 切過去（codex round-2：long-press 觸發後 user 通常會放開手指；popover 已 latched-open，等待後續 tap）
 9. 短 tap Plus（<500ms）→ 應觸發原本的 add-tab，**不**展開 popover
 10. popover 開啟時 tap 螢幕其他位置 → popover 收回
 
 ### Phase 1b' 驗收清單
 
 - [x] Plus hover popover：mouseleave Plus AND popover 收回；鍵盤 focus 同等於 hover；無 binding 時不展開
-- [x] Long-press 500ms 開 popover；tap chip 執行；short tap 走原 click（C17 mobile/touch fallback）
+- [x] Long-press 500ms 開 popover（latched-open，touchend 不關閉）；放開後 tap chip 執行；short tap (<500ms) 走原 click（C17 mobile/touch fallback；codex round-2 文案修正）
 - [x] 點擊 hub 外（document pointerdown）→ popover 收回
 - [x] 行為與 Phase 1b context menu 入口共用同一 executor，結果一致
 - [x] hostId null 時 popover 仍顯示，chip 點擊觸發 HostPickerPopover
@@ -4192,28 +4342,37 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { SessionsSection } from './SessionsSection'
 import { useHostStore } from '../../stores/useHostStore'
+import { useSessionStore } from '../../stores/useSessionStore'
+
+// codex round-2 B8 — sessions 來自 useSessionStore.sessions[hostId]
+// （見 spa/src/components/hosts/SessionsSection.tsx:135 + 既有測試 SessionsSection.test.tsx:64）；
+// PaneContent / Tab schema 見 spa/src/types/tab.ts:36-48。Session row API 物件 schema
+// 見既有測試 L55-57：{ code, name, cwd, mode, cc_session_id, cc_model, has_relay }
+const HOST_ID = 'h1'
+const SESSIONS_FIXTURE = [
+  { code: 'sess-1', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+]
 
 describe('SessionsSection — v1 QuickCommandMenu removal (Phase 1c)', () => {
   beforeEach(() => {
     useHostStore.setState({
-      hosts: { h1: { id: 'h1', name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 } },
-      hostOrder: ['h1'],
-      runtime: { h1: { status: 'connected' } },
-      activeHostId: 'h1',
-      // sessions 視 SessionsSection 內部資料來源不同，可能在 useHostStore 下
-      // 或由 hostFetch hook 拉取；subagent 實作時依實際 API 補 fixture（≥1 個 session）
+      hosts: { [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 } },
+      hostOrder: [HOST_ID],
+      runtime: { [HOST_ID]: { status: 'connected' } },
+      activeHostId: HOST_ID,
     })
+    useSessionStore.setState({ sessions: { [HOST_ID]: SESSIONS_FIXTURE } })
   })
 
   it('does NOT render v1 QuickCommandMenu inside session rows (moved to new-session adjacency, Phase 1c)', () => {
-    render(<SessionsSection hostId="h1" />)
+    render(<SessionsSection hostId={HOST_ID} />)
     // v1 QuickCommandMenu 的 trigger 有 aria-label "Quick Commands" — 確認 0 個
     expect(screen.queryAllByRole('button', { name: /quick commands/i }).length).toBe(0)
   })
 })
 ```
 
-註：實際 aria-label 由 `QuickCommandMenu` 元件決定（subagent 實作前先讀 `spa/src/components/QuickCommandMenu.tsx` 確認 trigger 的 accessible name；若不同請對齊）。Sessions fixture（至少 1 row 才會渲染 row 區段）也須補；若 SessionsSection 內部 sessions 來自 `useHostStore.sessions[hostId]` 則直接 setState 加；若來自 `hostFetch` 則透過 `vi.mock('../../lib/host-api', ...)` 注入。
+註：實際 aria-label 由 `QuickCommandMenu` 元件決定（subagent 實作前先讀 `spa/src/components/QuickCommandMenu.tsx` 確認 trigger 的 accessible name；若不同請對齊）。Sessions fixture 已直接補上 `useSessionStore.setState({ sessions: { [HOST_ID]: SESSIONS_FIXTURE } })`，欄位對應 SessionsSection 既有測試 (L55-57) 的 row API schema。
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -4401,7 +4560,7 @@ Expected: clean
 
 - [ ] Phase 1a 已 merge → main，且 alpha bump 完成（或一個 PR sequence 規劃中）
 - [ ] **Phase 1b 已 merge → main**，含 Settings UI + 資料層 + Workspace **右鍵 context menu** 入口（單一 PR）
-  - Phase 1b 內 task 順序：**1b.0a（inferWorkspaceHostId helper）→ 1b.0b（HostPickerPopover 元件）→ 1b.0c（i18n keys 前置 — codex round-1 B9）→ 1b.1（CommandSlot + busy prop）→ 1b.1.5（Toast schema 擴充 — codex round-1 B4）→ 1b.2（slot-executor + resolveHostId）→ 1b.3（Settings UI + chip 方向鍵 — codex round-1 C15）→ 1b.4（settings contribution + 剩餘 i18n）→ 1b.5a（context menu 入口 — codex round-1 B5/B6/B7/B8 修正）→ 1b.6（全域驗證）**
+  - Phase 1b 內 task 順序：**1b.0a（inferWorkspaceHostId helper）→ 1b.0c（i18n keys 前置 — codex round-1 B9 / round-2 B9）→ 1b.0b（HostPickerPopover 元件 — 仰賴 0c keys）→ 1b.1（CommandSlot + busy prop）→ 1b.1.5（Toast schema 擴充 — codex round-1 B4）→ 1b.2（slot-executor + resolveHostId）→ 1b.3（Settings UI + chip 方向鍵 — codex round-1 C15）→ 1b.4（settings contribution + 剩餘 i18n）→ 1b.5a（context menu 入口 — codex round-1 B5/B6/B7/B8 修正）→ 1b.6（全域驗證）**
   - 此 PR 滿足 spec §6「Settings 首次出現時至少一個 slot 生效」要求 — context menu 是穩定入口
 - [ ] **Phase 1b' 已 merge → main**，**Plus hover popover 過渡入口獨立 PR**（codex round-1 結構性變更 — 風險隔離）
   - Phase 1b' 內 task 順序：**1b'.1（WorkspaceQuickActionsPopover + WorkspaceRow Plus hover + mobile/touch fallback — codex round-1 C17）→ 1b'.2（全域驗證）**
@@ -4431,7 +4590,7 @@ Expected: clean
 2. 一個 task 一個 commit，commit message 用 conventional commit + Co-Authored-By trailer
 3. zustand test setState **顯式列出** `global` / `byHost` / `bindings` 三個 mutable fields；**不要**只寫 `setState({ bindings: {...} })`，會 wipe 其他 state（feedback_zustand_harness_setstate.md）。同樣原則套用 `useHostStore`（測試需要時列出 `hosts` / `hostOrder` / `runtime` / `activeHostId` 四個欄位）。
 4. 任何測試 / lint / build 指令在主 Claude 機器跑（feedback_codex_sandbox_no_install.md）
-5. **Phase 1b 任務依賴**（codex round-1 後）：1b.0a → 1b.0b → 1b.0c（i18n 必須前置）→ 1b.1（CommandSlot）→ 1b.1.5（toast schema 擴充）→ 1b.2（executor）→ 1b.3 → 1b.4 → 1b.5a → 1b.6。其中 1b.5a 的 switchToSession 必須做完整 `openSingletonAndSelect` 等價邏輯（codex round-1 B5/B6）：openSingletonTab（含 mode/cachedName/tmuxInstance 完整欄位）→ insertTab → setActiveWorkspace + setActiveTab。
+5. **Phase 1b 任務依賴**（codex round-1/2 後）：1b.0a → 1b.0c（i18n 必須前置 — round-2 B9）→ 1b.0b（HostPickerPopover；仰賴 0c keys）→ 1b.1（CommandSlot）→ 1b.1.5（toast schema 擴充）→ 1b.2（executor）→ 1b.3 → 1b.4 → 1b.5a → 1b.6。其中 1b.5a 的 switchToSession 必須做完整 `openSingletonAndSelect` 等價邏輯（codex round-1 B5/B6）：openSingletonTab（含 mode/cachedName/tmuxInstance 完整欄位）→ insertTab → setActiveWorkspace + setActiveTab。
 6. **Phase 1b' 任務依賴**：必須在 Phase 1b PR merge 後才能開工；`<CommandSlot>`、`<HostPickerPopover>`、`runWorkspaceSlot`、`inferWorkspaceHostId`、i18n keys 全部就緒後再實作 hover popover + 與 1b.5a 同等的 switchToSession 邏輯。
 7. PR 完成後委派 codex 兩輪 review（標準 + 攻擊/防守/體質）；發現問題彙整成表格（信心 / 關聯 / 複雜度）後決定即修 vs 開 issue 追蹤
 8. **Toast 行為的 spec §3.3 對應**（codex round-1 B4）：create-session failure → `toast.show(msg)` 不傳 action；switch-to-session failure → `toast.show(msg)` 不傳 action；send-keys failure → `toast.show(msg, retryFn, t('quick_commands.toast.retry'))`。元件渲染規則：`toast.action == null` → 不渲染 button。

--- a/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
+++ b/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
@@ -14,15 +14,16 @@
 
 **Spec:** `docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md`
 
-**Phase 順序（強制 1a → 1b → 1c）：**
+**Phase 順序（強制 1a → 1b → 1b' → 1c）：**
 1. **Phase 1a** — 純資料層；單一 PR；UI 零改動。
-2. **Phase 1b** — Settings UI + WORKSPACE_ACTIONS 入口；單一 PR，**必須與 Settings UI 同 PR ship**（spec §6 不 ship 設了沒效果的中間態）。Workspace 入口採雙進入點：(i) `WorkspaceRow` 右鍵 context menu；(ii) `WorkspaceRow` Plus 按鈕 hover 往左展開的 popover chip 列。兩入口共用同一個 `WORKSPACE_ACTIONS` slot + executor。
-3. **Phase 1c** — HOST_ACTIONS 入口；小 PR。Host 入口落於 `SessionsSection`：在 new-session 按鈕旁並列 `<CommandSlot mountTo=HOST_ACTIONS>`；同 PR 移除 `SessionsSection` 每個 session row 上殘留的 v1 `QuickCommandMenu`（功能集中至 new-session 入口；`QuickCommandMenu` 元件本身保留，因為仍被 `PaneLayoutRenderer.tsx` 使用）。
+2. **Phase 1b** — Settings UI + 資料層 helper + Workspace **context menu 入口**；單一 PR。**必須與 Settings UI 同 PR ship 一個穩定入口**（spec §6 不 ship 設了沒效果的中間態 — context menu 是 stable 入口）。涵蓋：`inferWorkspaceHostId` / `HostPickerPopover` / `<CommandSlot>` / `useUndoToast` schema 擴充 / slot-executor / Settings UI / context menu 入口 + i18n。
+3. **Phase 1b'** — Plus hover popover **過渡入口**（含 mobile/touch fallback）；獨立 PR。風險隔離：此入口未來可能遷移／重做，獨立 PR 便於日後整段 revert/replace；功能上是「錦上添花」，1b 已可單獨運作。
+4. **Phase 1c** — HOST_ACTIONS 入口；小 PR。Host 入口落於 `SessionsSection`：在 new-session 按鈕旁並列 `<CommandSlot mountTo=HOST_ACTIONS>`；同 PR 移除 `SessionsSection` 每個 session row 上殘留的 v1 `QuickCommandMenu`（功能集中至 new-session 入口；`QuickCommandMenu` 元件本身保留，因為仍被 `PaneLayoutRenderer.tsx` 使用）。
 
 **Mount UX 決策（覆蓋 spec §4.2 / §4.3 中的「位置由實作時定」）：**
-- **Workspace 入口** — `WorkspaceRow.tsx` 兩處：
-  - 右鍵 → 透過既有 `onContextMenuWorkspace` callback（App.tsx L155 `handleWsContextMenu` → 渲染 `WorkspaceContextMenu`），新增一個 `WorkspaceQuickCommandsContextMenu` 區塊或於原 `WorkspaceContextMenu` 加 quick-commands section
-  - Plus 按鈕（`WorkspaceRow.tsx` L108-121）hover → 一個 absolute popover 向左展開 chip 列（半透明漸層壓底；mouseleave Plus AND popover 收回；鍵盤 focus 同等於 hover）
+- **Workspace 入口** — `WorkspaceRow.tsx` 兩處（拆兩個 PR）：
+  - **(Phase 1b)** 右鍵 → 透過既有 `onContextMenuWorkspace` callback（App.tsx L155 `handleWsContextMenu` → 渲染 `WorkspaceContextMenu`），新增一個 `WorkspaceQuickCommandsContextMenu` 區塊或於原 `WorkspaceContextMenu` 加 quick-commands section
+  - **(Phase 1b')** Plus 按鈕（`WorkspaceRow.tsx` L108-121）hover → 一個 absolute popover 向左展開 chip 列（半透明漸層壓底；mouseleave Plus AND popover 收回；鍵盤 focus 同等於 hover；觸控裝置以 long-press / tap-to-toggle 替代 hover）
 - **Host 入口** — `SessionsSection.tsx` 兩件事：
   - new-session 按鈕（L167-174）旁並列 `<CommandSlot mountTo=HOST_ACTIONS>`；視覺與 Plus 對齊（直接列 chip，無 popover）
   - 移除 row 上的 v1 `<QuickCommandMenu>`（L231-239）整合，但**保留** `QuickCommandMenu` 元件本身（`PaneLayoutRenderer.tsx` 仍使用）
@@ -807,11 +808,15 @@ Expected: clean
 
 ---
 
-## Phase 1b — Settings UI + WORKSPACE_ACTIONS 入口（單一 PR）
+## Phase 1b — Settings UI + 資料層 + Workspace 右鍵入口（單一 PR）
 
-**目標：** user 能在 Settings 建 command + 設 mount = WORKSPACE，回到 workspace 立刻看到按鈕；點擊建 session + 送 keys + 切過去。失敗 toast 行為符合 §3.3。
+**目標：** user 能在 Settings 建 command + 設 mount = WORKSPACE，**回到 workspace 右鍵 row** 即可看到按鈕；點擊建 session + 送 keys + 切過去。失敗 toast 行為符合 §3.3。Plus hover popover 入口拆到 Phase 1b' 獨立 PR（過渡實作風險隔離）。
 
-**Spec v4 新增的支援結構：** Phase 1b 兩個 helper（`inferWorkspaceHostId` + `HostPickerPopover`）必須先於 `<CommandSlot>` / executor / workspace 入口落地，否則後續 task 無法正確呼叫。順序：1b.0a → 1b.0b → 1b.1 → 1b.1.5 → 1b.2 → 1b.3 → 1b.4 → 1b.5a → 1b.5b → 1b.6。
+**範圍邊界：** Phase 1b **只 ship context menu 入口**（穩定入口；spec §6「Settings 首次出現時至少一個 slot 生效」由它滿足）。Plus hover popover 不在 1b — 見 Phase 1b'。
+
+**Spec v4 新增的支援結構：** Phase 1b 三個基礎件（`inferWorkspaceHostId` helper + `HostPickerPopover` 元件 + i18n keys）必須先於 `<CommandSlot>` / executor / workspace 入口落地，否則後續 task 在跑單元測試時會看到 raw i18n key（fallback to key），且 caller 無法正確呼叫。
+
+**Task 順序：** 1b.0a → 1b.0b → 1b.0c → 1b.1 → 1b.1.5 → 1b.2 → 1b.3 → 1b.4 → 1b.5a → 1b.6。（原 1b.5b 移到 Phase 1b'；1b.0c 為新增的「i18n keys 前置」task。）
 
 ### Task 1b.0a: 新增 `inferWorkspaceHostId` helper（spec §3.2.1 多數決）
 
@@ -942,6 +947,23 @@ describe('inferWorkspaceHostId', () => {
     }
     const w3 = ws({ tabs: ['t1', 't2', 't3'], activeTabId: 't3' })
     expect(inferWorkspaceHostId(w3, cleanTie)).toBe('h1')
+  })
+
+  // codex round-1 B1 — minority-active fixture
+  it('on tie, IGNORES active tab hostId when active is a tmux-session of a minority host', () => {
+    // h1 count=2 (t1 + t2 split), h2 count=2 (t3 + t2 split), h3 count=1 (t4)
+    // → tie between h1 and h2; h3 is minority and NOT in winners.
+    // active tab t4 is h3 (minority). Tie-break A must NOT pick h3 just because
+    // it is the active tab's host; instead it falls through to Tie-break B
+    // (first winner in tabs order) → h1.
+    const tabs = {
+      t1: tab('t1', tmuxLeaf('h1')),
+      t2: tab('t2', splitH(tmuxLeaf('h1'), tmuxLeaf('h2'))),
+      t3: tab('t3', tmuxLeaf('h2')),
+      t4: tab('t4', tmuxLeaf('h3')),
+    }
+    const w = ws({ tabs: ['t1', 't2', 't3', 't4'], activeTabId: 't4' })
+    expect(inferWorkspaceHostId(w, tabs)).toBe('h1')
   })
 
   it('returns null when workspace has no tmux-session tabs', () => {
@@ -1097,9 +1119,9 @@ interface Props {
 - 關閉時 focus 回 trigger（caller 透過 `onCancel`/`onSelect` 後恢復 — popover 自身不持有 trigger ref；caller 負責）
 - 樣式：與既有 popover 一致（`bg-surface-secondary`、`border-border-default`、`shadow-lg`，無自訂顏色）
 - offline host 仍可點選（不 disable），但 row 上加警示 chip（例如 `text-text-muted` + 「offline」標籤）；user 可能就是要切到 offline host 去看其他內容
-- 空 `hostOrder` 顯示空狀態文字「No hosts available」
+- 空 `hostOrder` 顯示空狀態文字「No hosts available」**＋ 一個 close 按鈕**（icon `X`，aria-label = `t('quick_commands.host_picker.close')`），點擊呼叫 `onCancel`（spec §3.2.2 明寫；無此按鈕時空狀態 user 唯一逃離方式只剩 Esc，違反 a11y / 鼠標可達）
 
-**anchor 處理：** 若 `anchor` 是 `{x,y}` → 以 fixed 定位；若是 HTMLElement → `getBoundingClientRect()` 計算位置，popover 出現在 anchor 元素旁邊。
+**anchor 處理：** 若 `anchor` 是 `{x,y}` → 以 fixed 定位；若是 HTMLElement → `getBoundingClientRect()` 計算位置，popover 出現在 anchor 元素下方（top = `rect.bottom + 4`，left = `rect.left`）。
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1195,12 +1217,18 @@ describe('HostPickerPopover', () => {
     expect(onSelect).toHaveBeenCalledWith('h2')
   })
 
-  it('shows empty state when hostOrder is empty', () => {
+  it('shows empty state with close button when hostOrder is empty (codex round-1 B2)', () => {
     useHostStore.setState({ hosts: {}, hostOrder: [], runtime: {}, activeHostId: null })
+    const onCancel = vi.fn()
     render(
-      <HostPickerPopover open={true} anchor={{ x: 0, y: 0 }} onSelect={vi.fn()} onCancel={vi.fn()} />,
+      <HostPickerPopover open={true} anchor={{ x: 0, y: 0 }} onSelect={vi.fn()} onCancel={onCancel} />,
     )
     expect(screen.getByText(/No hosts available/i)).toBeInTheDocument()
+    // close button must exist in empty state — Esc-only is not enough (a11y / mouse users)
+    const closeBtn = screen.getByRole('button', { name: /close|cancel|關閉|取消/i })
+    expect(closeBtn).toBeInTheDocument()
+    fireEvent.click(closeBtn)
+    expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
   it('focus is trapped inside the popover (Tab cycles)', () => {
@@ -1212,6 +1240,34 @@ describe('HostPickerPopover', () => {
     fireEvent.keyDown(items[items.length - 1], { key: 'Tab' })
     // focus should wrap back to first
     expect(document.activeElement).toBe(items[0])
+  })
+
+  // codex round-1 B3 — HTMLElement anchor positioning
+  it('positions popover below an HTMLElement anchor using getBoundingClientRect (codex round-1 B3)', () => {
+    const anchor = document.createElement('button')
+    anchor.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        right: 250,
+        bottom: 130,
+        left: 200,
+        width: 50,
+        height: 30,
+        x: 200,
+        y: 100,
+        toJSON: () => ({}),
+      }) as DOMRect
+    document.body.appendChild(anchor)
+    const { container } = render(
+      <HostPickerPopover open={true} anchor={anchor} onSelect={vi.fn()} onCancel={vi.fn()} />,
+    )
+    const popover = container.querySelector('[role="listbox"]') as HTMLElement
+    expect(popover).not.toBeNull()
+    // top = rect.bottom + 4 = 134; left = rect.left = 200
+    expect(popover.style.top).toBe('134px')
+    expect(popover.style.left).toBe('200px')
+    expect(popover.style.position).toBe('fixed')
+    document.body.removeChild(anchor)
   })
 })
 ```
@@ -1345,8 +1401,19 @@ export function HostPickerPopover({ open, anchor, onSelect, onCancel }: Props) {
       className="z-50 min-w-[200px] rounded-md border border-border-default bg-surface-secondary shadow-lg py-1"
     >
       {items.length === 0 ? (
-        <div className="px-3 py-2 text-xs text-text-muted">
-          {t('quick_commands.host_picker.empty')}
+        // codex round-1 B2 — empty state must offer an explicit close button
+        // (mouse users / a11y; Esc-only is not sufficient).
+        <div className="px-3 py-2 text-xs text-text-muted flex items-center justify-between gap-2">
+          <span>{t('quick_commands.host_picker.empty')}</span>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label={t('quick_commands.host_picker.close')}
+            className="p-0.5 text-text-muted hover:text-text-primary cursor-pointer"
+          >
+            {/* Use Phosphor X icon at runtime; placeholder marker for plan. */}
+            ×
+          </button>
         </div>
       ) : (
         items.map((item, index) => (
@@ -1379,7 +1446,7 @@ export function HostPickerPopover({ open, anchor, onSelect, onCancel }: Props) {
 }
 ```
 
-註：i18n keys `quick_commands.host_picker.label` / `.empty` / `.online` / `.offline` 在 Task 1b.4 統一加入 zh-TW / en JSON。
+註：i18n keys `quick_commands.host_picker.label` / `.empty` / `.online` / `.offline` / `.close` 已在 Task **1b.0c**（前置）加入 zh-TW / en JSON — 此元件測試開跑時 keys 必須先存在，否則 `screen.getByText(/No hosts available/i)` 會比對到 raw key。
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -1391,6 +1458,89 @@ Expected: PASS
 ```
 feat(spa): add HostPickerPopover reusable component for host selection (spec §3.2.2 / §4.4)
 ```
+
+---
+
+### Task 1b.0c: 前置 i18n keys（HostPicker / aria / executor / toast）
+
+**Files:**
+- Modify: `spa/src/locales/zh-TW.json`
+- Modify: `spa/src/locales/en.json`
+
+**動機（codex round-1 B9）：** 後續 task（HostPickerPopover、CommandSlot、slot-executor、context menu、popover）的單元測試會直接 render 元件、`screen.getByText(/No hosts available/i)` / `getByRole('button', { name: /retry/i })` 比對顯示文字。i18n 系統在 key 缺失時 fallback 回 raw key，會導致測試比對 `quick_commands.host_picker.empty` 而非實際翻譯，**綠／紅判定模糊**。把 keys 加入 JSON 必須**先於**任何用到這些 keys 的 caller / 元件測試開跑。
+
+原 plan 的 1b.4（settings contribution + i18n）保留，但只負責 **Settings tab / dialog / module description / 模組元件外殼**等後續 keys；**HostPicker、aria-label、executor toast、retry 按鈕**等先放在 1b.0c。
+
+**i18n keys 清單（codex round-1 B9 + C16 — aria-label 也走 i18n）：**
+
+zh-TW + en 對照（同步加入）：
+
+```json
+{
+  "quick_commands.host_picker.label": "選擇主機" / "Choose host",
+  "quick_commands.host_picker.empty": "尚未設定任何主機" / "No hosts available",
+  "quick_commands.host_picker.online": "線上" / "online",
+  "quick_commands.host_picker.offline": "離線" / "offline",
+  "quick_commands.host_picker.close": "關閉" / "Close",
+  "quick_commands.toast.create_failed": "無法建立 session：{{reason}}" / "Failed to start session: {{reason}}",
+  "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。" / "Session created, but command failed.",
+  "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。" / "Created and sent, but could not switch focus; check the sessions list.",
+  "quick_commands.toast.retry": "重試" / "Retry",
+  "quick_commands.aria.toolbar": "快速指令" / "Quick commands",
+  "quick_commands.aria.workspace_actions": "工作區快速動作" / "Workspace quick actions"
+}
+```
+
+註：`settings.section.quick_commands` / `settings.quick_commands.*` / `modules.quick_commands.description` / `common.edit` 等 keys 留在 1b.4 一併加入（因為它們綁 settings UI 上下文，1b.4 才會 render 出來）。
+
+- [ ] **Step 1: Add keys to zh-TW.json**
+
+Edit `spa/src/locales/zh-TW.json`（按既有檔案的字典排序或群組原則插入；確認 trailing comma 不破壞 JSON 結構）：
+
+```json
+  "quick_commands.host_picker.label": "選擇主機",
+  "quick_commands.host_picker.empty": "尚未設定任何主機",
+  "quick_commands.host_picker.online": "線上",
+  "quick_commands.host_picker.offline": "離線",
+  "quick_commands.host_picker.close": "關閉",
+  "quick_commands.toast.create_failed": "無法建立 session：{{reason}}",
+  "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。",
+  "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。",
+  "quick_commands.toast.retry": "重試",
+  "quick_commands.aria.toolbar": "快速指令",
+  "quick_commands.aria.workspace_actions": "工作區快速動作",
+```
+
+- [ ] **Step 2: Add keys to en.json**
+
+Edit `spa/src/locales/en.json`：
+
+```json
+  "quick_commands.host_picker.label": "Choose host",
+  "quick_commands.host_picker.empty": "No hosts available",
+  "quick_commands.host_picker.online": "online",
+  "quick_commands.host_picker.offline": "offline",
+  "quick_commands.host_picker.close": "Close",
+  "quick_commands.toast.create_failed": "Failed to start session: {{reason}}",
+  "quick_commands.toast.send_keys_failed": "Session created, but command failed.",
+  "quick_commands.toast.switch_failed": "Created and sent, but could not switch focus; check the sessions list.",
+  "quick_commands.toast.retry": "Retry",
+  "quick_commands.aria.toolbar": "Quick commands",
+  "quick_commands.aria.workspace_actions": "Workspace quick actions",
+```
+
+- [ ] **Step 3: Verify locale completeness**
+
+Run: `cd spa && pnpm run lint`
+Expected: clean（既有 lint 已含 locale-completeness 檢查；所有新 keys 必須兩語對齊）。
+
+- [ ] **Step 4: Commit**
+
+```
+chore(spa): add i18n keys for quick commands HostPicker / aria / toast (codex round-1 B9)
+```
+
+註：Task 1b.0b 的 HostPickerPopover 測試 + 實作仰賴 `quick_commands.host_picker.*` keys；若工程實作時把 1b.0b 排在 1b.0c 之前（順序顛倒），HostPickerPopover 測試會比對 raw key 而綠燈，但實際 prod fallback 行為不正確。**順序鐵則：1b.0a → 1b.0b ≤ 1b.0c**（1b.0c 不晚於 1b.0b 也可，但必須早於 1b.1）。實務建議：把 1b.0c 寫在 1b.0b commit 之後、1b.1 commit 之前，做為「進入元件 / 測試前的最後一道 i18n 補位」。
 
 ---
 
@@ -1441,7 +1591,7 @@ describe('CommandSlot', () => {
   beforeEach(() => resetStores())
   afterEach(() => clearModuleRegistry())
 
-  it('renders bound commands in capability order (cmd-a then cmd-c, NOT bindings key order)', () => {
+  it('renders bound commands in capability order (cmd-a then cmd-c, NOT bindings key order — codex round-1 C12)', () => {
     const exec = vi.fn().mockResolvedValue(undefined)
     render(
       <CommandSlot
@@ -1450,12 +1600,42 @@ describe('CommandSlot', () => {
         executor={exec}
       />,
     )
+    // codex round-1 C12 — assert exact order via accessible names; NOT arrayContaining
     const buttons = screen.getAllByRole('button')
-    expect(buttons.map((b) => b.getAttribute('aria-label'))).toEqual(
-      expect.arrayContaining([expect.stringMatching(/A/), expect.stringMatching(/C/)]),
-    )
-    // cmd-b not bound → not rendered
+    const names = buttons.map((b) => b.getAttribute('aria-label'))
+    // cmd-a first (capability index 0), cmd-c second (capability index 2);
+    // cmd-b is unbound → not in DOM at all
+    expect(names).toEqual(['A', 'C'])
     expect(screen.queryByLabelText(/^B/)).toBeNull()
+  })
+
+  it('order follows capability list even when bindings record key order is reversed (codex round-1 C13)', () => {
+    // Same global capability list; rebuild bindings in REVERSE key order.
+    // The order seen on screen must still be capability order (cmd-a → cmd-c).
+    useQuickCommandStore.setState({
+      global: [
+        { id: 'cmd-a', name: 'A', command: 'a' },
+        { id: 'cmd-b', name: 'B', command: 'b' },
+        { id: 'cmd-c', name: 'C', command: 'c' },
+      ],
+      byHost: {},
+      bindings: {
+        // Insert cmd-c first, then cmd-a — Object.keys order would be [cmd-c, cmd-a]
+        'cmd-c': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+        'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+      },
+    })
+    render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: null, workspaceId: 'w1' }} // hostId=null per codex C13 ask
+        executor={vi.fn()}
+      />,
+    )
+    const buttons = screen.getAllByRole('button')
+    const names = buttons.map((b) => b.getAttribute('aria-label'))
+    // Capability order is cmd-a (index 0) then cmd-c (index 2) — NOT bindings record order
+    expect(names).toEqual(['A', 'C'])
   })
 
   it('returns null when quick-commands module is disabled (short-circuit)', () => {
@@ -1523,6 +1703,28 @@ describe('CommandSlot', () => {
     )
     expect(screen.getAllByTestId('custom').map((n) => n.textContent)).toEqual(['cmd-a', 'cmd-c'])
   })
+
+  it('disables all chip buttons while busy=true (codex round-1 C11 — picker resolver race guard)', () => {
+    // Picker open → caller flips busy=true to prevent double-click on chip
+    // (which would create a second pending Promise and a second picker instance).
+    const exec = vi.fn().mockResolvedValue(undefined)
+    render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: null, workspaceId: 'w1' }}
+        executor={exec}
+        busy={true}
+      />,
+    )
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.length).toBeGreaterThan(0)
+    buttons.forEach((b) => {
+      expect((b as HTMLButtonElement).disabled).toBe(true)
+    })
+    // Click while busy → executor must NOT fire
+    fireEvent.click(buttons[0])
+    expect(exec).not.toHaveBeenCalled()
+  })
 })
 ```
 
@@ -1568,6 +1770,18 @@ interface Props {
   ctx: SlotContext
   executor: SlotExecutor
   render?: SlotRenderer
+  /**
+   * Optional class for the outer container (codex round-1 B7 — used by the
+   * context-menu caller which prefers `flex flex-col` over the toolbar default).
+   */
+  containerClassName?: string
+  /**
+   * codex round-1 C11 — picker resolver race guard: when the caller's host
+   * picker is open, set `busy={true}` to disable every chip button. Prevents
+   * a second click from creating a second pending Promise (and a second picker
+   * instance fighting over the same resolver).
+   */
+  busy?: boolean
 }
 
 /**
@@ -1579,9 +1793,10 @@ interface Props {
  * stable `getCommands(hostId)` list), not `Object.keys(bindings)` — that's
  * the spec §4.4 stability guarantee against post-sync key-order divergence.
  */
-export function CommandSlot({ mountTo, ctx, executor, render }: Props) {
+export function CommandSlot({ mountTo, ctx, executor, render, containerClassName, busy }: Props) {
   const enabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
   const bindings = useQuickCommandStore((s) => s.bindings)
+  const t = useI18nStore((s) => s.t)
   // hostId null → no host override possible; show global-only command list.
   // (getCommands(hostId) would require a string; explicitly passing null
   // means "caller hasn't resolved a host yet — just use globals".)
@@ -1599,7 +1814,12 @@ export function CommandSlot({ mountTo, ctx, executor, render }: Props) {
   if (boundCmds.length === 0) return null
 
   return (
-    <div className="flex flex-wrap items-center gap-1.5" role="toolbar" aria-label="Quick commands">
+    <div
+      className={containerClassName ?? 'flex flex-wrap items-center gap-1.5'}
+      role="toolbar"
+      // codex round-1 C16 — aria-label sourced from i18n, not hard-coded English
+      aria-label={t('quick_commands.aria.toolbar')}
+    >
       {boundCmds.map((cmd) => {
         if (render) {
           return (
@@ -1613,12 +1833,16 @@ export function CommandSlot({ mountTo, ctx, executor, render }: Props) {
           <button
             key={cmd.id}
             type="button"
+            // codex round-1 C11 — busy guard prevents double-click from spawning
+            // a second picker / executor pipeline while one is mid-flight.
+            disabled={busy}
             onClick={() => {
+              if (busy) return
               void executor(cmd, ctx)
             }}
             aria-label={ariaLabel}
             title={cmd.command}
-            className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-text-secondary hover:text-text-primary hover:bg-surface-secondary cursor-pointer disabled:opacity-50"
+            className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-text-secondary hover:text-text-primary hover:bg-surface-secondary cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <span className="truncate max-w-[12rem]">{cmd.name}</span>
             {cmd.category && (
@@ -1634,6 +1858,12 @@ export function CommandSlot({ mountTo, ctx, executor, render }: Props) {
 }
 ```
 
+註：`useI18nStore` import 已隨 codex round-1 C16 加入（替代原 hard-coded `aria-label="Quick commands"`）：
+
+```ts
+import { useI18nStore } from '../stores/useI18nStore'
+```
+
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cd spa && npx vitest run src/components/CommandSlot.test.tsx`
@@ -1647,45 +1877,79 @@ feat(spa): add <CommandSlot> shared component for v2 binding model
 
 ---
 
-### Task 1b.1.5: 擴 `useUndoToast` schema 支援自訂 action label（Retry）
+### Task 1b.1.5: 擴 `useUndoToast` schema — optional `action` callback 與 `actionLabel`（codex round-1 B4）
 
 **Files:**
 - Modify: `spa/src/stores/useUndoToast.ts`
 - Modify: `spa/src/stores/useUndoToast.test.ts`
 - Modify: `spa/src/components/GlobalUndoToast.tsx`
+- Modify / Create: `spa/src/components/GlobalUndoToast.test.tsx`
 
-**動機：** Task 1b.2 的 slot-executor 在 send-keys 失敗時要顯示 toast 帶「Retry」按鈕（spec §3.3 表格第 2 列；user 決策採方案 (a) — 直接擴 schema），與既有 `OverviewSection.tsx` 的「Undo」按鈕共用同一條 toast。預設保留 `'Undo'` 維持向下相容。
+**動機（codex round-1 B4 修正）：** spec §3.3 三層失敗 UX 中，**create-session failure** 與 **switch-to-session failure** 不該顯示「假 Undo / 假 Retry」按鈕（user 沒東西可 undo / 重試也對應不到動作）；**只有 send-keys failure** 該帶 action button（Retry）。原 plan 直接複用既有 `useUndoToast.show(message, restore)` 兩參數簽名，會被迫傳一個 noop 給 restore — UX 上仍會渲染按鈕，誤導 user。
+
+修正：把 `action` 與 `actionLabel` 都升為 **optional**，元件渲染時 `action == null` 不渲染 button（toast 只剩 message）。`OverviewSection.tsx` 既有的 delete-host undo 仍走 `show(msg, undoFn)` — `action` 非空 → 渲染 button + 預設 label 'Undo'，**完全向下相容**。
+
+**API 設計：**
+
+```ts
+interface ToastShape {
+  message: string
+  action?: () => void      // ← optional：缺省時 button 不渲染
+  actionLabel?: string     // ← optional：缺省（且 action 非空時）回退到 'Undo'
+}
+
+show(message: string, action?: () => void, actionLabel?: string): void
+```
+
+**Render 規則（GlobalUndoToast）：**
+- `toast.action == null` → 完全不渲染 `<button>`
+- `toast.action != null && toast.actionLabel == null` → 渲染 button，label = `t('hosts.undo')`
+- `toast.action != null && toast.actionLabel != null` → 渲染 button，label = `toast.actionLabel`
+
+**Executor callsite 對應（與 Task 1b.2 同步）：**
+- create-session failure → `show(message)` （**無** action）
+- switch-to-session failure → `show(message)` （**無** action）
+- send-keys failure → `show(message, retryFn, t('quick_commands.toast.retry'))` （**有** action）
 
 **既有 callsite 影響範圍盤點（grep `useUndoToast.*show|getState\(\)\.show`）：**
-- Production：`spa/src/components/hosts/OverviewSection.tsx:85`（`show(message, restore)` — 不傳 actionLabel，續用 `'Undo'`）
-- Test：`spa/src/stores/useUndoToast.test.ts`（自身單元測試）+ `spa/src/lib/host-lifecycle.test.ts`（只重置 toast=null，不呼叫 `show`，不受影響）
-- 共 1 個 production callsite，2 個測試檔；schema 擴充採 optional 第 3 參數，**無需修改既有 callsite 的呼叫形式**
+- Production：`spa/src/components/hosts/OverviewSection.tsx:85`（`show(message, restore)` — 兩參數呼叫；新 schema 第 2 參數 `action` 仍是 function，相容）
+- Test：`spa/src/stores/useUndoToast.test.ts`（自身單元測試 — 測試斷言維持原樣，僅新增向下相容驗證）+ `spa/src/lib/host-lifecycle.test.ts`（只重置 toast=null，不呼叫 `show`，不受影響）
+- 共 1 個 production callsite，2 個測試檔；schema 擴充採 **action / actionLabel 都 optional**，**無需修改既有 callsite 的呼叫形式**
 
 - [ ] **Step 1: Write the failing test**
 
 Edit `spa/src/stores/useUndoToast.test.ts` 加新測試（不要動既有測試 — 它們驗證向下相容）：
 
 ```ts
-describe('useUndoToast — custom action label', () => {
+describe('useUndoToast — optional action / actionLabel (codex round-1 B4)', () => {
   beforeEach(() => {
     useUndoToast.setState({ toast: null })
   })
 
-  it('defaults actionLabel to undefined when not provided (back-compat)', () => {
+  it('back-compat: show(msg, fn) keeps action defined and actionLabel undefined', () => {
     useUndoToast.getState().show('msg', () => {})
     const toast = useUndoToast.getState().toast
+    expect(toast?.action).toBeTypeOf('function')
     expect(toast?.actionLabel).toBeUndefined()
   })
 
-  it('stores actionLabel when provided', () => {
+  it('show(msg) with no action stores undefined for both', () => {
+    useUndoToast.getState().show('Failed')
+    const toast = useUndoToast.getState().toast
+    expect(toast?.action).toBeUndefined()
+    expect(toast?.actionLabel).toBeUndefined()
+  })
+
+  it('show(msg, fn, label) stores both', () => {
     useUndoToast.getState().show('Send keys failed', () => {}, 'Retry')
     const toast = useUndoToast.getState().toast
+    expect(toast?.action).toBeTypeOf('function')
     expect(toast?.actionLabel).toBe('Retry')
   })
 })
 ```
 
-Edit `spa/src/components/GlobalUndoToast.tsx` 也加一條 component test（若該檔已有 test 則 append；若無則新建 `GlobalUndoToast.test.tsx`）：
+Edit/Create `spa/src/components/GlobalUndoToast.test.tsx`（若該檔不存在則新建）：
 
 ```tsx
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -1693,19 +1957,34 @@ import { render, screen } from '@testing-library/react'
 import { GlobalUndoToast } from './GlobalUndoToast'
 import { useUndoToast } from '../stores/useUndoToast'
 
-describe('GlobalUndoToast — actionLabel', () => {
+describe('GlobalUndoToast — render rules (codex round-1 B4)', () => {
   beforeEach(() => useUndoToast.setState({ toast: null }))
 
-  it('renders default Undo label when actionLabel is omitted', () => {
+  it('renders default Undo label when action is provided but actionLabel is omitted', () => {
     useUndoToast.getState().show('Deleted host', () => {})
     render(<GlobalUndoToast />)
     expect(screen.getByRole('button')).toHaveTextContent(/Undo/i)
   })
 
-  it('renders custom actionLabel when provided (e.g. Retry)', () => {
+  it('renders custom actionLabel (Retry) when both action and actionLabel are provided', () => {
     useUndoToast.getState().show('Send keys failed', () => {}, 'Retry')
     render(<GlobalUndoToast />)
     expect(screen.getByRole('button')).toHaveTextContent(/Retry/i)
+  })
+
+  it('does NOT render any button when action is undefined (create / switch failure path)', () => {
+    useUndoToast.getState().show('Failed to start session: 500')
+    render(<GlobalUndoToast />)
+    // Message still shows
+    expect(screen.getByText(/Failed to start session/i)).toBeInTheDocument()
+    // No action button at all (codex round-1 B4 — no fake Undo / Retry)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('toast container has role=status (codex round-1 C14 — a11y live region)', () => {
+    useUndoToast.getState().show('Hello')
+    render(<GlobalUndoToast />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
   })
 })
 ```
@@ -1717,41 +1996,101 @@ Expected: FAIL — `actionLabel` 欄位不存在 / 元件還沒讀。
 
 - [ ] **Step 3: Implement schema extension**
 
-Edit `spa/src/stores/useUndoToast.ts`：
+Edit `spa/src/stores/useUndoToast.ts`（codex round-1 B4 — `action` 與 `actionLabel` 都升為 optional；既有 callsite 傳 `(msg, fn)` 仍合法、行為不變）：
 
 ```ts
 // spa/src/stores/useUndoToast.ts — Global undo toast state
 import { create } from 'zustand'
 
+/**
+ * Toast schema (codex round-1 B4):
+ *  - action == null      → render no button (used by create / switch failure paths)
+ *  - action != null      → render button; label = actionLabel ?? t('hosts.undo')
+ *
+ * Renamed semantically from "restore" to "action" — the field can host an undo
+ * callback OR a retry callback; existing back-compat callers (delete-host undo)
+ * pass a function and stay green.
+ */
 interface UndoToastState {
-  toast: { message: string; restore: () => void; actionLabel?: string } | null
-  show: (message: string, restore: () => void, actionLabel?: string) => void
+  toast: {
+    message: string
+    action?: () => void
+    actionLabel?: string
+  } | null
+  show: (message: string, action?: () => void, actionLabel?: string) => void
   dismiss: () => void
 }
 
 export const useUndoToast = create<UndoToastState>()((set) => ({
   toast: null,
-  show: (message, restore, actionLabel) =>
-    set({ toast: { message, restore, actionLabel } }),
+  show: (message, action, actionLabel) =>
+    set({ toast: { message, action, actionLabel } }),
   dismiss: () => set({ toast: null }),
 }))
 ```
 
-Edit `spa/src/components/GlobalUndoToast.tsx` 改 button label 取用：
+Edit `spa/src/components/GlobalUndoToast.tsx`（render rules：`action == null` 不渲染 button；codex round-1 C14 加 `role="status"`）：
 
 ```tsx
-<button
-  className="text-sm text-blue-400 hover:text-blue-300 font-medium cursor-pointer"
-  onClick={() => {
-    toast.restore()
-    dismiss()
-  }}
->
-  {toast.actionLabel ?? t('hosts.undo')}
-</button>
+import { useEffect, useRef } from 'react'
+import { useUndoToast } from '../stores/useUndoToast'
+import { useI18nStore } from '../stores/useI18nStore'
+
+export function GlobalUndoToast() {
+  const toast = useUndoToast((s) => s.toast)
+  const dismiss = useUndoToast((s) => s.dismiss)
+  const t = useI18nStore((s) => s.t)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!toast) return
+    timerRef.current = setTimeout(() => dismiss(), 5000)
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [toast, dismiss])
+
+  if (!toast) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3 flex items-center gap-3 shadow-lg z-50"
+    >
+      <span className="text-sm text-zinc-300">{toast.message}</span>
+      {toast.action && (
+        <button
+          className="text-sm text-blue-400 hover:text-blue-300 font-medium cursor-pointer"
+          onClick={() => {
+            toast.action!()
+            dismiss()
+          }}
+        >
+          {toast.actionLabel ?? t('hosts.undo')}
+        </button>
+      )}
+    </div>
+  )
+}
 ```
 
-註：`actionLabel` 由 caller 傳 i18n 化字串（例如 `t('quick_commands.toast.retry')`）；`'hosts.undo'` 維持作為**未指定時的預設**，確保 `OverviewSection` 既有行為不變。
+註：`actionLabel` 由 caller 傳 i18n 化字串（例如 `t('quick_commands.toast.retry')`）；`'hosts.undo'` 維持作為**有 action 但未指定 label 時的預設**，確保 `OverviewSection` 既有 delete-host undo 行為不變。
+
+**callsite 影響盤點補充驗證（codex round-1 B4）：**
+
+執行 grep 檢查：
+```
+cd spa && grep -rn "useUndoToast" src/ --include="*.ts" --include="*.tsx" | grep -v "\.test\."
+```
+
+預期結果：
+- `src/stores/useUndoToast.ts`（store 自身）
+- `src/components/GlobalUndoToast.tsx`（render）
+- `src/components/hosts/OverviewSection.tsx`（既有 callsite，呼叫 `show(msg, undoFn)` — 新 schema 下：`action=undoFn`、`actionLabel=undefined` → button 渲染 + label 'Undo'，行為與舊 schema 完全一致）
+- `src/lib/host-lifecycle.test.ts`（測試 reset；不呼叫 show，不受影響）
+
+若 grep 出現未列入的 callsite，subagent 必須回報主 Claude 評估是否需要更新（理論上 codex round-1 已 audit 完畢，新增 callsite 是 plan 後續 task 引入的，那些 callsite 自身已遵循新 schema）。
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -1761,7 +2100,7 @@ Expected: PASS
 - [ ] **Step 5: Commit**
 
 ```
-feat(spa): extend useUndoToast schema with optional actionLabel (back-compat)
+feat(spa): extend useUndoToast schema with optional action / actionLabel (codex round-1 B4)
 ```
 
 ---
@@ -1787,7 +2126,7 @@ feat(spa): extend useUndoToast schema with optional actionLabel (back-compat)
 
 **選擇：Option B。**
 
-CommandSlot 一側的封裝建議（在 1b.5a / 1b.5b / 1c.1b 各 caller 自行實作；不抽公共 hook，因為三個 caller 的 trigger UI 完全不同）：
+CommandSlot 一側的封裝建議（在 1b.5a / 1b'.1 / 1c.1b 各 caller 自行實作；不抽公共 hook，因為三個 caller 的 trigger UI 完全不同）：
 ```tsx
 const [pickerState, setPickerState] = useState<{
   resolver: (id: string | null) => void
@@ -1903,7 +2242,7 @@ describe('runWorkspaceSlot', () => {
     expect(useUndoToast.getState().toast).toBeNull()
   })
 
-  it('createSession failure — surfaces toast, does NOT switch focus', async () => {
+  it('createSession failure — toast WITHOUT action button (codex round-1 B4)', async () => {
     const switchFocus = vi.fn()
     const resolveHostId = vi.fn()
     ;(createSession as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('500 Internal'))
@@ -1919,9 +2258,12 @@ describe('runWorkspaceSlot', () => {
     const toast = useUndoToast.getState().toast
     expect(toast).not.toBeNull()
     expect(toast!.message).toMatch(/Failed to start session/i)
+    // codex round-1 B4 — no action button on create-session failure
+    expect(toast!.action).toBeUndefined()
+    expect(toast!.actionLabel).toBeUndefined()
   })
 
-  it('send-keys failure — STILL switches focus + toast carries retry action', async () => {
+  it('send-keys failure — STILL switches focus + toast carries Retry action', async () => {
     const switchFocus = vi.fn()
     const resolveHostId = vi.fn()
     ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -1939,18 +2281,19 @@ describe('runWorkspaceSlot', () => {
     const toast = useUndoToast.getState().toast
     expect(toast).not.toBeNull()
     expect(toast!.message).toMatch(/Session created.*command failed/i)
-    // Task 1b.1.5 — actionLabel must surface 'Retry' (translated key allowed) instead of default 'Undo'
+    // codex round-1 B4 — send-keys failure DOES carry an action (retry)
+    expect(toast!.action).toBeTypeOf('function')
     expect(toast!.actionLabel).toBeDefined()
     expect(toast!.actionLabel).toMatch(/retry/i)
-    // restore = retry — calling it should trigger executeCommand again
+    // action = retry — calling it should trigger executeCommand again
     ;(executeCommand as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
-    toast!.restore()
+    toast!.action!()
     // retry is sync invocation; await microtask
     await Promise.resolve()
     expect(executeCommand).toHaveBeenCalledTimes(2)
   })
 
-  it('switchToSession failure — toast surfaced, session still listed elsewhere', async () => {
+  it('switchToSession failure — toast WITHOUT action button (codex round-1 B4)', async () => {
     const switchFocus = vi.fn().mockImplementation(() => {
       throw new Error('switch failed')
     })
@@ -1969,6 +2312,9 @@ describe('runWorkspaceSlot', () => {
     const toast = useUndoToast.getState().toast
     expect(toast).not.toBeNull()
     expect(toast!.message).toMatch(/Could not switch/i)
+    // codex round-1 B4 — no action button on switch failure
+    expect(toast!.action).toBeUndefined()
+    expect(toast!.actionLabel).toBeUndefined()
   })
 })
 ```
@@ -2058,15 +2404,17 @@ export async function runWorkspaceSlot(
     const session = await createSession(hostId, genSessionName(cmd), ctx.cwd ?? '~', 'terminal')
     sessionCode = session.code
   } catch (err) {
+    // codex round-1 B4 — create-session failure has NO retry/undo action;
+    // user has nothing meaningful to retry without re-clicking the chip.
     const reason = err instanceof Error ? err.message : String(err)
-    toast.show(t('quick_commands.toast.create_failed', { reason }), () => {})
+    toast.show(t('quick_commands.toast.create_failed', { reason }))
     return
   }
 
   try {
     await executeCommand(hostId, sessionCode, cmd.command)
   } catch (err) {
-    // Step 2 failed — STILL switch (so user sees the orphan), with Retry.
+    // Step 2 failed — STILL switch (so user sees the orphan), WITH Retry action.
     safelySwitch(hostId, sessionCode, deps, t)
     const reason = err instanceof Error ? err.message : String(err)
     void reason
@@ -2076,7 +2424,7 @@ export async function runWorkspaceSlot(
       () => {
         void executeCommand(hostId, sessionCode, cmd.command).catch(() => undefined)
       },
-      t('quick_commands.toast.retry'),  // ← Task 1b.1.5 introduced actionLabel; default ('Undo') doesn't fit retry semantics
+      t('quick_commands.toast.retry'),  // codex round-1 B4 — only this branch carries an action label
     )
     return
   }
@@ -2093,14 +2441,16 @@ function safelySwitch(
   try {
     deps.switchToSession(hostId, sessionCode)
   } catch (err) {
+    // codex round-1 B4 — switch failure has NO retry action either; the session
+    // is already alive elsewhere, the toast is purely informational.
     const reason = err instanceof Error ? err.message : String(err)
     void reason
-    useUndoToast.getState().show(t('quick_commands.toast.switch_failed'), () => {})
+    useUndoToast.getState().show(t('quick_commands.toast.switch_failed'))
   }
 }
 ```
 
-註（給實作者）：i18n keys 在 Task 1b.6 統一加入 zh-TW / en JSON。`createSession` 已存在於 `spa/src/lib/host-api.ts`（簽名 `(hostId, name, cwd, mode) => Promise<Session>`）。`executeCommand` 已存在於 `spa/src/lib/execute-command.ts`。`switchToSession` deps 由 caller 注入（避免 tab/workspace store 的循環相依）。
+註（給實作者）：i18n keys 已在 Task **1b.0c** 加入 zh-TW / en JSON（codex round-1 B9 — 必須前置）。`createSession` 已存在於 `spa/src/lib/host-api.ts`（簽名 `(hostId, name, cwd, mode) => Promise<Session>`）。`executeCommand` 已存在於 `spa/src/lib/execute-command.ts`。`switchToSession` deps 由 caller 注入（避免 tab/workspace store 的循環相依）。
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -2231,8 +2581,41 @@ describe('QuickCommandsSettingsSection', () => {
     expect(state.global).toHaveLength(0)
     expect(state.bindings['cmd-a']).toBeUndefined()
   })
+
+  // codex round-1 C15 — keyboard accessibility on multi-select mount chips
+  it('mount-target chips support Space/Enter activation and ArrowRight/ArrowLeft roving focus', () => {
+    render(<QuickCommandsSettingsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /New/i }))
+    const wsChip = screen.getByRole('button', { name: /Workspace/i })
+    const hostChip = screen.getByRole('button', { name: /Host/i })
+
+    // Focus first chip
+    wsChip.focus()
+    expect(document.activeElement).toBe(wsChip)
+
+    // Space toggles aria-pressed
+    expect(wsChip.getAttribute('aria-pressed')).toBe('false')
+    fireEvent.keyDown(wsChip, { key: ' ' })
+    fireEvent.click(wsChip) // RTL: native button Space → click; explicit click for jsdom safety
+    expect(wsChip.getAttribute('aria-pressed')).toBe('true')
+
+    // Enter also toggles
+    fireEvent.keyDown(wsChip, { key: 'Enter' })
+    fireEvent.click(wsChip)
+    expect(wsChip.getAttribute('aria-pressed')).toBe('false')
+
+    // ArrowRight moves focus to next chip (roving focus)
+    fireEvent.keyDown(wsChip, { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(hostChip)
+
+    // ArrowLeft moves focus back
+    fireEvent.keyDown(hostChip, { key: 'ArrowLeft' })
+    expect(document.activeElement).toBe(wsChip)
+  })
 })
 ```
+
+註（codex round-1 C15）：multi-select chip 元件需在 `onKeyDown` 內處理 ArrowLeft / ArrowRight 切換 focus（roving focus pattern）；Space / Enter 由 native button 的 keydown→click 自動觸發 `toggleTarget`。實作建議：在 `<fieldset>` 容器加 `onKeyDown`，比對 `e.key` 為方向鍵時找出當前 active button index 後 focus 鄰位 button。
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -2520,7 +2903,22 @@ function EditDialog({ initial, onClose, onSave }: DialogProps) {
           <legend className="text-xs text-text-secondary px-1">
             {t('settings.quick_commands.mount')}
           </legend>
-          <div className="flex gap-2 mt-1 flex-wrap">
+          {/* codex round-1 C15 — roving focus across chips via ArrowLeft / ArrowRight */}
+          <div
+            className="flex gap-2 mt-1 flex-wrap"
+            onKeyDown={(e) => {
+              if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+              const buttons = Array.from(
+                e.currentTarget.querySelectorAll<HTMLButtonElement>('button[type="button"]'),
+              )
+              const idx = buttons.indexOf(document.activeElement as HTMLButtonElement)
+              if (idx === -1) return
+              e.preventDefault()
+              const dir = e.key === 'ArrowRight' ? 1 : -1
+              const next = (idx + dir + buttons.length) % buttons.length
+              buttons[next]?.focus()
+            }}
+          >
             {(Object.values(QUICK_COMMAND_SLOTS) as QuickCommandSlotId[]).map((slot) => {
               const active = targets.includes(slot)
               return (
@@ -2636,7 +3034,7 @@ Update the `quick-commands` registration to include `settings`:
   })
 ```
 
-In `spa/src/locales/zh-TW.json` 加入：
+In `spa/src/locales/zh-TW.json` 加入（**Settings / module description 範圍** — host_picker / aria / toast 已在 Task 1b.0c 加入；此處不重複）：
 
 ```json
   "settings.section.quick_commands": "快速指令",
@@ -2651,15 +3049,8 @@ In `spa/src/locales/zh-TW.json` 加入：
   "settings.quick_commands.mount": "掛載位置",
   "settings.quick_commands.slot.workspace": "Workspace",
   "settings.quick_commands.slot.host": "Host",
+  "modules.quick_commands.description": "快速指令模組 — 在 workspace / host 入口顯示 chip，一鍵建 session 送指令",
   "common.edit": "編輯",
-  "quick_commands.toast.create_failed": "無法建立 session：{{reason}}",
-  "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。",
-  "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。",
-  "quick_commands.toast.retry": "重試",
-  "quick_commands.host_picker.label": "選擇主機",
-  "quick_commands.host_picker.empty": "尚未設定任何主機",
-  "quick_commands.host_picker.online": "線上",
-  "quick_commands.host_picker.offline": "離線",
 ```
 
 In `spa/src/locales/en.json` 對應加入：
@@ -2677,18 +3068,13 @@ In `spa/src/locales/en.json` 對應加入：
   "settings.quick_commands.mount": "Mount targets",
   "settings.quick_commands.slot.workspace": "Workspace",
   "settings.quick_commands.slot.host": "Host",
+  "modules.quick_commands.description": "Quick Commands — chip launchers on workspace / host entries that create a session and send a command in one click",
   "common.edit": "Edit",
-  "quick_commands.toast.create_failed": "Failed to start session: {{reason}}",
-  "quick_commands.toast.send_keys_failed": "Session created, but command failed.",
-  "quick_commands.toast.switch_failed": "Created and sent, but could not switch focus; check the sessions list.",
-  "quick_commands.toast.retry": "Retry",
-  "quick_commands.host_picker.label": "Choose host",
-  "quick_commands.host_picker.empty": "No hosts available",
-  "quick_commands.host_picker.online": "online",
-  "quick_commands.host_picker.offline": "offline",
 ```
 
 註：若 `common.edit` 已存在，跳過該行。檢查指令：`grep '"common.edit"' spa/src/locales/zh-TW.json`。
+
+註：以下 keys 已在 Task **1b.0c**（前置）加入，本 task **不重複**：`quick_commands.toast.create_failed` / `.send_keys_failed` / `.switch_failed` / `.retry` / `quick_commands.host_picker.label` / `.empty` / `.online` / `.offline` / `.close` / `quick_commands.aria.toolbar` / `.workspace_actions`。
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -2738,6 +3124,26 @@ import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
 
+// codex round-1 B8 — full executable test body (no placeholder comments)
+import { useTabStore } from '../../../stores/useTabStore'
+import { useWorkspaceStore } from '../../../stores/useWorkspaceStore'
+
+vi.mock('../../../lib/host-api', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/host-api')>('../../../lib/host-api')
+  return {
+    ...actual,
+    createSession: vi.fn().mockResolvedValue({
+      code: 'sess-new', name: 'Alpha', cwd: '/tmp', mode: 'terminal',
+    }),
+  }
+})
+
+vi.mock('../../../lib/execute-command', () => ({
+  executeCommand: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { createSession } from '../../../lib/host-api'
+
 function setup(workspaceId = 'w1', hostId = 'h1') {
   useQuickCommandStore.setState({
     global: [
@@ -2748,8 +3154,20 @@ function setup(workspaceId = 'w1', hostId = 'h1') {
     bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
   })
   useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  // Tab + workspace stores need a base shape so insertTab / setActiveTab don't blow up
+  useTabStore.setState({
+    tabs: {},
+    tabOrder: [],
+    activeTabId: null,
+  } as Partial<ReturnType<typeof useTabStore.getState>> as never)
+  useWorkspaceStore.setState({
+    workspaces: { [workspaceId]: { id: workspaceId, name: 'WS', tabs: [], activeTabId: null, moduleConfig: {} } },
+    workspaceOrder: [workspaceId],
+    activeWorkspaceId: workspaceId,
+  } as Partial<ReturnType<typeof useWorkspaceStore.getState>> as never)
   clearModuleRegistry()
   registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
+  vi.clearAllMocks()
   return { workspaceId, hostId }
 }
 
@@ -2770,11 +3188,39 @@ describe('WorkspaceQuickCommandsContextMenu', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('clicking a command calls onClose', () => {
+  it('clicking a command calls onClose after executor finishes', async () => {
     const onClose = vi.fn()
     render(<WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId="h1" onClose={onClose} />)
     fireEvent.click(screen.getByLabelText(/^Alpha/))
+    // executor is async (createSession + executeCommand) → flush microtasks
+    await new Promise<void>((r) => setTimeout(r, 0))
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('happy path — calls createSession with the inferred hostId and inserts tab into workspace (codex round-1 B5/B6)', async () => {
+    render(<WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId="h1" onClose={() => {}} />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    await new Promise<void>((r) => setTimeout(r, 0))
+    expect(createSession).toHaveBeenCalledWith('h1', expect.any(String), expect.any(String), 'terminal')
+    // Tab should be inserted into the workspace (codex round-1 B6 — full
+    // openSingletonAndSelect equivalent: openSingletonTab → insertTab → setActive).
+    const tabIds = useWorkspaceStore.getState().workspaces['w1']?.tabs ?? []
+    expect(tabIds.length).toBeGreaterThan(0)
+    const tabId = tabIds[tabIds.length - 1]
+    const tab = useTabStore.getState().tabs[tabId]
+    expect(tab).toBeDefined()
+    // codex round-1 B5 — tmux-session content has all required fields populated
+    if (tab && tab.layout.type === 'leaf' && tab.layout.pane.content.kind === 'tmux-session') {
+      const c = tab.layout.pane.content
+      expect(c.hostId).toBe('h1')
+      expect(c.sessionCode).toBe('sess-new')
+      expect(c.mode).toBe('terminal')
+      expect(c.cachedName).toBeDefined()
+      expect(c.tmuxInstance).toBeDefined()
+    }
+    // active workspace + tab updated
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe('w1')
+    expect(useTabStore.getState().activeTabId).toBe(tabId)
   })
 
   it('returns null when quick-commands module is disabled', () => {
@@ -2785,7 +3231,7 @@ describe('WorkspaceQuickCommandsContextMenu', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('hostId=null — clicking a command opens HostPickerPopover (does NOT call executor immediately)', async () => {
+  it('hostId=null — clicking a command opens HostPickerPopover (does NOT call createSession until user picks)', async () => {
     // Spec v4 §3.2.2 — when inferWorkspaceHostId returns null we must let the
     // user choose. The chip is rendered as soon as bindings exist; click triggers
     // the picker before executor.
@@ -2793,38 +3239,77 @@ describe('WorkspaceQuickCommandsContextMenu', () => {
     expect(screen.queryByRole('listbox')).toBeNull()
     fireEvent.click(screen.getByLabelText(/^Alpha/))
     expect(await screen.findByRole('listbox')).toBeInTheDocument()
+    // createSession not yet called — waiting for user to pick a host
+    expect(createSession).not.toHaveBeenCalled()
   })
 
-  it('hostId=null — picker cancel → no createSession call, menu stays open until close', async () => {
-    // Behavioural test: integration with HostPickerPopover; mock createSession
-    // and assert it was not invoked when user presses Esc.
-    // (Subagent: import createSession mock from host-api; vi.mock as in 1b.2.)
-    // This test is acceptance-only; full coverage of the path lives in slot-executor.test.ts
+  it('hostId=null — picker Esc cancel → no createSession, no insertTab (codex round-1 B8 — full assertion)', async () => {
+    const onClose = vi.fn()
+    render(<WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId={null} onClose={onClose} />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await new Promise<void>((r) => setTimeout(r, 0))
+    expect(createSession).not.toHaveBeenCalled()
+    // No tab inserted into workspace
+    expect(useWorkspaceStore.getState().workspaces['w1']?.tabs ?? []).toHaveLength(0)
+    // onClose still fires (executor's finally block runs even on cancel path)
+    expect(onClose).toHaveBeenCalled()
   })
 })
 ```
 
-也在 `WorkspaceContextMenu.test.tsx` 追加 integration 測試：
+也在 `WorkspaceContextMenu.test.tsx` 追加 integration 測試（codex round-1 B8 — full executable body）：
 
 ```tsx
-it('renders quick commands section above Settings when WORKSPACE_ACTIONS bindings exist', () => {
-  // 設定一個 binding（簡化：直接 mock useQuickCommandStore）
-  useQuickCommandStore.setState({
-    global: [{ id: 'cmd-x', name: 'XCmd', command: 'x' }],
-    byHost: {},
-    bindings: { 'cmd-x': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { WorkspaceContextMenu } from './WorkspaceContextMenu'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
+
+describe('WorkspaceContextMenu — quick commands section integration (Phase 1b)', () => {
+  beforeEach(() => {
+    useQuickCommandStore.setState({ global: [], byHost: {}, bindings: {} })
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+    clearModuleRegistry()
+    registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
   })
-  // … 既有 setup（registerModule quick-commands etc）…
-  render(
-    <WorkspaceContextMenu
-      position={{ x: 0, y: 0 }}
-      workspaceId="w1"
-      hostId="h1"
-      onSettings={vi.fn()}
-      onClose={vi.fn()}
-    />,
-  )
-  expect(screen.getByLabelText(/^XCmd/)).toBeInTheDocument()
+
+  it('renders quick commands section above Settings when WORKSPACE_ACTIONS bindings exist', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-x', name: 'XCmd', command: 'x' }],
+      byHost: {},
+      bindings: { 'cmd-x': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+    })
+    render(
+      <WorkspaceContextMenu
+        position={{ x: 0, y: 0 }}
+        workspaceId="w1"
+        hostId="h1"
+        onSettings={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText(/^XCmd/)).toBeInTheDocument()
+  })
+
+  it('omits the quick commands section (and its separator) when no WORKSPACE_ACTIONS bindings exist', () => {
+    render(
+      <WorkspaceContextMenu
+        position={{ x: 0, y: 0 }}
+        workspaceId="w1"
+        hostId="h1"
+        onSettings={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    // No quick command chip; existing Settings button still present
+    expect(screen.queryByRole('toolbar', { name: /quick|快速/i })).toBeNull()
+    expect(screen.getByRole('button', { name: /settings|設定/i })).toBeInTheDocument()
+  })
 })
 ```
 
@@ -2835,7 +3320,7 @@ Expected: FAIL — module not found / props missing。
 
 - [ ] **Step 3: Implement**
 
-Create `spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx`：
+Create `spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx`（codex round-1 B5/B6/B7 —使用 default chip render + `containerClassName="flex flex-col"`；executor 內部完整呼叫 `openSingletonTab` + `insertTab` + `setActiveWorkspace` + `setActiveTab`，並補齊所有 `tmux-session` 欄位）：
 
 ```tsx
 import { useCallback, useRef, useState } from 'react'
@@ -2844,6 +3329,7 @@ import { HostPickerPopover } from '../../../components/HostPickerPopover'
 import { runWorkspaceSlot } from '../../../lib/slot-executor'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 import { useTabStore } from '../../../stores/useTabStore'
+import { useWorkspaceStore } from '../../../stores/useWorkspaceStore'
 
 interface Props {
   workspaceId: string
@@ -2857,10 +3343,15 @@ interface Props {
 
 /**
  * 渲染 mount=WORKSPACE_ACTIONS 的 quick commands，作為 WorkspaceContextMenu 的子 section。
- * <CommandSlot> 自身會 short-circuit module disabled / no-bindings 兩個情況。
- * hostId=null 時 chip 仍渲染（user 可選一個 host 並執行）；executor 透過
- * resolveHostId callback 等待 picker 結果。picker 取消 → no-op，menu 仍由 onClose
- * 觸發者（CommandSlot 預設 button onClick）正常關閉。
+ *
+ * codex round-1 B7 — 不傳 `render` prop（會與 `executor` 衝突 — render 包出來的
+ * 是 `<span>`，沒有 onClick，executor 不會跑）。改用 `<CommandSlot>` default
+ * button render + `containerClassName="flex flex-col"` 改 layout 為 menu 條列。
+ *
+ * codex round-1 B5/B6 — switchToSession callback 必須做 `openSingletonAndSelect`
+ * 等價邏輯：open singleton tab → insertTab to workspace → setActiveWorkspace +
+ * setActiveTab。tmux-session content 欄位要齊全（mode / cachedName / tmuxInstance）
+ * 以滿足 `spa/src/types/tab.ts` 的型別契約。
  */
 export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose }: Props) {
   const [picker, setPicker] = useState<{
@@ -2877,6 +3368,28 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
     [],
   )
 
+  // codex round-1 B6 — workspace caller must perform full openSingletonAndSelect
+  // equivalent (the helper exists at spa/src/features/workspace/hooks.ts:200 but
+  // is bound to the hook, so we replicate inline here using the same store
+  // primitives it uses).
+  const switchToSession = useCallback(
+    (h: string, sessionCode: string) => {
+      // codex round-1 B5 — fill ALL tmux-session content fields per types/tab.ts:38
+      const tabId = useTabStore.getState().openSingletonTab({
+        kind: 'tmux-session',
+        hostId: h,
+        sessionCode,
+        mode: 'terminal',
+        cachedName: sessionCode,
+        tmuxInstance: '',
+      })
+      useWorkspaceStore.getState().insertTab(tabId, workspaceId)
+      useWorkspaceStore.getState().setActiveWorkspace(workspaceId)
+      useTabStore.getState().setActiveTab(tabId)
+    },
+    [workspaceId],
+  )
+
   return (
     <div
       className="py-1"
@@ -2888,36 +3401,20 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
       <CommandSlot
         mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
         ctx={{ hostId, workspaceId }}
+        // codex round-1 B7 — flex-col override; default chip render keeps onClick + executor wiring intact.
+        containerClassName="flex flex-col"
+        // codex round-1 C11 — disable buttons while picker is mid-flight (prevents double-click race).
+        busy={picker !== null}
         executor={async (cmd, ctx) => {
           try {
             await runWorkspaceSlot(cmd, ctx, {
-              switchToSession: (h, sessionCode) => {
-                useTabStore.getState().openSingletonTab({
-                  kind: 'tmux-session',
-                  hostId: h,
-                  sessionCode,
-                })
-              },
+              switchToSession,
               resolveHostId,
             })
           } finally {
             onClose()
           }
         }}
-        render={(cmd) => (
-          <button
-            type="button"
-            aria-label={cmd.name}
-            className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-surface-hover cursor-pointer transition-colors"
-          >
-            <span className="truncate">{cmd.name}</span>
-            {cmd.category && (
-              <span className="text-[10px] text-text-muted bg-surface-primary px-1.5 py-0.5 rounded ml-auto">
-                {cmd.category}
-              </span>
-            )}
-          </button>
-        )}
       />
       <HostPickerPopover
         open={picker !== null}
@@ -2936,26 +3433,7 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
 }
 ```
 
-**注意 render prop 與 onClick：** `<CommandSlot>` 預設 button 已含 `onClick`，但提供 `render` 時 wrapper 是 `<span>`（見 Task 1b.1 實作 L979）。我們需要**改用 default button** 才能讓 executor 跑；這代表此 task 不傳 `render` prop，採用 default 渲染（chip 樣式不適合 menu 列表，但 v1 可接受；若 reviewer 要求 menu 列表外觀，需要在 Task 1b.1 補一個 `containerClassName` / `itemClassName` prop，或讓 `render` 包外層 + 提供 onClick，二擇一）。
-
-**簡化決議：** **保持 default 渲染**（不傳 render），用 `containerClassName` 覆蓋 `flex flex-wrap gap-1.5`（若 Task 1b.1 沒提供，需擴 `<CommandSlot>` 介面 — 在此 task 內微擴）。
-
-→ **追加 sub-step 0**: 擴 `<CommandSlot>` 加一個 optional `containerClassName?: string` prop，預設沿用既有 toolbar 樣式；context menu 用 `flex flex-col`。修改 `spa/src/components/CommandSlot.tsx` 與其 test。Diff：
-
-```tsx
-interface Props {
-  mountTo: QuickCommandSlotId
-  ctx: SlotContext
-  executor: SlotExecutor
-  render?: SlotRenderer
-  containerClassName?: string  // ← new
-}
-
-// in JSX:
-<div className={containerClassName ?? 'flex flex-wrap items-center gap-1.5'} role="toolbar" aria-label="Quick commands">
-```
-
-並在 `WorkspaceQuickCommandsContextMenu` 改傳 `containerClassName="flex flex-col"`。
+註（codex round-1 B7 解決舊版「render prop 與 onClick 矛盾」）：原本的舊 plan 同時傳 `render` 與 `executor`，但 CommandSlot 在有 `render` 時包 `<span>` 不掛 onClick → executor 永遠不跑。新版只用 `containerClassName="flex flex-col"` 改 layout，**不**傳 `render`，default button 帶 onClick 正常觸發 executor。CommandSlot 的 `containerClassName` prop 已在 Task 1b.1 加入。
 
 更新後 `WorkspaceContextMenu.tsx`：
 
@@ -3038,7 +3516,81 @@ feat(spa): mount WORKSPACE_ACTIONS slot in workspace right-click context menu
 
 ---
 
-### Task 1b.5b: Workspace 入口 (ii) — `WorkspaceQuickActionsPopover` + WorkspaceRow Plus hover
+### Task 1b.6: Phase 1b 全域驗證
+
+- [ ] **Step 1: Run all SPA tests**
+
+Run: `cd spa && npx vitest run`
+Expected: all pass
+
+- [ ] **Step 2: Run SPA lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: clean
+
+- [ ] **Step 3: Run SPA build**
+
+Run: `cd spa && pnpm run build`
+Expected: clean
+
+- [ ] **Step 4: Run all Go tests**
+
+Run: `go test ./...`
+Expected: all pass
+
+- [ ] **Step 5: Go build**
+
+Run: `go build ./...`
+Expected: clean
+
+- [ ] **Step 6: 手動冒煙（review reviewer 自行操作）**
+
+啟動 daemon + dev SPA，user flow（**Phase 1b 範圍** — 不含 Plus hover popover，後者在 Phase 1b'）：
+1. Settings → Quick Commands → New → 輸入 Name + Command + 勾 Workspace → Save
+2. 在 sidebar Workspace 行 **右鍵** → context menu 出現該 quick command；點擊執行
+3. 應：建 session、送 cmd、自動切到該 session（tab 落在該 workspace 下）
+4. 模擬失敗（停 daemon → 點按鈕 → 應有 toast）；send-keys 失敗的 toast 應顯 'Retry' 按鈕（codex round-1 B4 — create / switch failure 不顯 button）
+
+### Phase 1b 驗收清單
+
+- [x] Settings 頁面可建 / 編 / 刪 commands；mount chips 可多選
+- [x] 對話框 a11y：focus trap / Esc / aria-label / 觸發鍵盤可達
+- [x] 設 mount = WORKSPACE 後，回 sidebar **右鍵** Workspace row 即可看到按鈕（無需 reload）— 此為 Phase 1b 唯一入口；Plus hover popover 在 Phase 1b' ship
+- [x] 點擊按鈕：建 session + 送 keys + 切過去；tab 透過 `insertTab + setActive` 落在正確 workspace
+- [x] 三層失敗 UX 符合 spec §3.3（codex round-1 B4 修正）：
+  - 建 session 失敗 → toast，**無 button**
+  - 送 keys 失敗 → 仍切過去 + toast 帶 **'Retry' button**
+  - 切失敗 → toast，**無 button**
+- [x] 停用 quick-commands module → context menu 入口立即消失（CommandSlot short-circuit）
+- [x] i18n: zh-TW + en 全部 key 齊全（Task 1b.0c 已前置 host_picker / aria / toast keys；1b.4 補 settings keys；`pnpm run lint` 含 locale-completeness 檢查）
+- [x] **Spec v4 — workspace hostId 多數決邊界（§3.2.1 / §3.2.2）：**
+  - workspace 中只有非 tmux-session tabs（如全 dashboard / settings）→ 點 quick command → `HostPickerPopover` 出現 → 選 host → 正常流程（建 session + 送 keys + 切過去）
+  - workspace 中只有 tmux-session tabs（單 host）→ 自動推斷正確 host → **不出 picker**
+  - workspace 中混合多 host tmux-session tabs，多數一個 host → 多數決命中該 host → 不出 picker
+  - workspace 多數決平手 + active tab 是 tmux-session 在多數派內 → 用 active 的 hostId
+  - workspace 多數決平手 + active tab 非 tmux-session → 用 tabs 順序中第一個 winner
+  - workspace 多數決平手 + active tab 是少數派 tmux-session（codex round-1 B1）→ **忽略 active**，走 tabs 順序中第一個 winner
+  - hostId null 時 picker 取消 → no-op，**沒有任何 createSession / send-keys API call**
+  - hostId null 時 picker 選定 → executor 用該 hostId 完成全流程
+
+---
+
+## Phase 1b' — Plus hover popover 過渡入口（獨立 PR）
+
+**目標：** 在已 ship 的 Phase 1b（Settings + 資料層 + 右鍵 context menu）之上，加上 `WorkspaceRow` Plus 按鈕 hover 往左展開的 chip popover；同時設計 mobile/touch fallback。
+
+**為何拆獨立 PR（codex round-1 結構性變更）：**
+- User 標記此入口為**過渡實作** — 未來可能遷移到其他位置或重做為 command palette 風格。
+- 獨立 PR 風險隔離：未來要 revert / replace 整段時，single squash-merge commit 一鍵還原，不影響資料層 / Settings / context menu 的穩定基礎。
+- 1b 已可獨立運作（context menu 是穩定入口；spec §6 對「Settings 出現時必有生效入口」的要求已滿足）。
+
+**前置條件：** Phase 1b PR 已 merge（`<CommandSlot>` / `runWorkspaceSlot` / `HostPickerPopover` / `inferWorkspaceHostId` / i18n keys 全部就緒）。
+
+**Tasks：** 1b'.1（popover + WorkspaceRow Plus hover + mobile/touch fallback）→ 1b'.2（全域驗證）。
+
+---
+
+### Task 1b'.1: `WorkspaceQuickActionsPopover` + WorkspaceRow Plus hover + mobile/touch fallback
 
 **Files:**
 - Create: `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx`
@@ -3047,13 +3599,69 @@ feat(spa): mount WORKSPACE_ACTIONS slot in workspace right-click context menu
 - Modify: `spa/src/features/workspace/components/WorkspaceRow.test.tsx`
 
 **實作策略：**
-- 改造 `WorkspaceRow.tsx` L107-121 的 Plus 按鈕：保留原 click 行為（`onAddTabToWorkspace`）但**外層**多包一個 `<div onMouseEnter={...} onMouseLeave={...} onFocusCapture={...} onBlurCapture={...}>` 作 hover hub。
+- 改造 `WorkspaceRow.tsx` L107-121 的 Plus 按鈕：保留原 click 行為（`onAddTabToWorkspace`）但**外層**多包一個 `<div onMouseEnter={...} onMouseLeave={...} onFocusCapture={...} onBlurCapture={...} onTouchStart={...} onTouchEnd={...}>` 作 hover/touch hub。
 - 該 div 內含 Plus button + 一個 absolute popover（`<WorkspaceQuickActionsPopover>`），popover `right-full mr-1`（Plus 按鈕左側）展開。
 - popover 內部用 `<CommandSlot mountTo=WORKSPACE_ACTIONS>` 渲染 chip 列。
 - Hover 收回邏輯：使用 single boolean state `popoverOpen`；mouseenter Plus 或 popover 任一觸發開啟，mouseleave 整個 hub 觸發關閉（用 wrapper div 圍住兩者，事件冒泡判斷即可）。
 - 鍵盤可達性：Plus 按鈕 focus 時 popover 開啟（`onFocusCapture`），整個 wrapper blur 時關閉（`onBlurCapture` + 比對 `relatedTarget` 是否仍在 wrapper 內）。
 - 視覺 cue：popover 含半透明漸層壓底（`bg-gradient-to-l from-surface-secondary/0 to-surface-secondary/95` 或同等 token）。
 - **Plus 原本 hover 才顯**（L117 `opacity-0 group-hover/ws-header:opacity-100`）— 此邏輯保留。
+
+**Mobile / touch fallback（codex round-1 C17）：**
+
+桌面 hover 不存在於觸控裝置；在沒設計 fallback 的前提下，行動裝置 user **完全無法觸發 popover**。設計選擇：
+
+- **Long-press 開 popover + tap chip 執行**（建議方案，符合行動裝置慣例）
+  - `onTouchStart` 記下時間戳 + `setTimeout(500ms)` 觸發 `setPopoverOpen(true)`
+  - `onTouchEnd` 在 500ms 內取消 timer → 視為一般 click（執行原本的 `onAddTabToWorkspace`）
+  - popover 開啟後：點 popover 外（document `pointerdown` 偵測 hub 外）→ 收回；tap chip → 執行 executor
+  - 不採 tap-toggle（先點開 popover、再點 chip）的原因：兩次 tap 才能執行單一動作，比 long-press 模型多一步
+
+實作要點：
+```tsx
+const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+const longPressFiredRef = useRef(false)
+
+const handleTouchStart = () => {
+  longPressFiredRef.current = false
+  longPressTimerRef.current = setTimeout(() => {
+    longPressFiredRef.current = true
+    setPopoverOpen(true)
+  }, 500)
+}
+
+const handleTouchEnd = () => {
+  if (longPressTimerRef.current) {
+    clearTimeout(longPressTimerRef.current)
+    longPressTimerRef.current = null
+  }
+  // 若 long-press 沒觸發 → 視為一般 tap，讓 button onClick 自然處理
+  // 若 long-press 已觸發 → 不執行 add-tab，等 user 在 popover 內 tap chip
+}
+
+// onClick 仍掛 add-tab；touch 流：若 longPressFiredRef.current === true 則阻擋預設 click（瀏覽器 touch → click 兼容性）
+const handleClick = (e: React.MouseEvent) => {
+  if (longPressFiredRef.current) {
+    e.preventDefault()
+    e.stopPropagation()
+    return
+  }
+  e.stopPropagation()
+  onAddTabToWorkspace(workspace.id)
+}
+
+// document-level pointerdown to close popover when tapping outside the hub
+useEffect(() => {
+  if (!popoverOpen) return
+  const onPointer = (e: PointerEvent) => {
+    if (!hubRef.current?.contains(e.target as Node | null)) {
+      setPopoverOpen(false)
+    }
+  }
+  document.addEventListener('pointerdown', onPointer)
+  return () => document.removeEventListener('pointerdown', onPointer)
+}, [popoverOpen])
+```
 
 **Spec v4 hostId 解析：** WorkspaceRow 內以 `inferWorkspaceHostId(workspace, useTabStore.getState().tabs)` 取 hostId（不再用 `useHostStore.activeHostId` fallback）。多數決回 null 時 chip 仍顯示（`hostId={null}` 傳給 popover）；點擊 chip 由 popover 內部開 `HostPickerPopover` 等 user 選定後跑 executor。
 
@@ -3131,37 +3739,159 @@ describe('WorkspaceQuickActionsPopover', () => {
 })
 ```
 
-並於 `WorkspaceRow.test.tsx` 追加 hover 行為測試：
+並於 `WorkspaceRow.test.tsx` 追加 hover / touch / no-bindings 三組行為測試（codex round-1 B8 — full executable bodies；C17 — mobile/touch fallback；vi.useFakeTimers for long-press timing）：
 
 ```tsx
-it('opens popover on Plus hover, closes on mouseleave (with WORKSPACE_ACTIONS bindings)', () => {
-  // 既有 ws-header render setup（保持原 props 模式）
-  // 設定一個 WORKSPACE_ACTIONS binding
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { WorkspaceRow } from './WorkspaceRow'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { useHostStore } from '../../../stores/useHostStore'
+import { useTabStore } from '../../../stores/useTabStore'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
+
+function setupHoverPopoverFixtures(opts: { withBindings: boolean }) {
   useQuickCommandStore.setState({
-    global: [{ id: 'cmd-x', name: 'X', command: 'x' }],
+    global: opts.withBindings ? [{ id: 'cmd-x', name: 'X', command: 'x' }] : [],
     byHost: {},
-    bindings: { 'cmd-x': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+    bindings: opts.withBindings ? { 'cmd-x': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] } : {},
   })
-  // 確保 hostId 路徑解析成功（mock useHostStore.activeHostId 或 workspace.hostId）
-  // … render(<WorkspaceRow … />) …
+  useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  useHostStore.setState({
+    hosts: { h1: { id: 'h1', name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 } },
+    hostOrder: ['h1'],
+    runtime: { h1: { status: 'connected' } },
+    activeHostId: 'h1',
+  })
+  // workspace has a tmux-session tab so inferWorkspaceHostId returns 'h1' (no picker prompt)
+  useTabStore.setState({
+    tabs: {
+      t1: {
+        id: 't1', pinned: false, locked: false, createdAt: 0,
+        layout: {
+          type: 'leaf',
+          pane: {
+            id: 'p1',
+            content: {
+              kind: 'tmux-session', hostId: 'h1', sessionCode: 'sess', mode: 'terminal',
+              cachedName: 'x', tmuxInstance: '',
+            },
+          },
+        },
+      },
+    },
+    tabOrder: ['t1'],
+    activeTabId: 't1',
+  } as Partial<ReturnType<typeof useTabStore.getState>> as never)
+  clearModuleRegistry()
+  registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
+}
 
-  // 預設未 hover → popover 不在 DOM
-  expect(screen.queryByLabelText(/^X/)).toBeNull()
+const baseProps = {
+  workspace: { id: 'w1', name: 'WS', tabs: ['t1'], activeTabId: 't1', moduleConfig: {} },
+  isActive: false,
+  isExpanded: true,
+  showTabs: true,
+  workspaceTabs: [],
+  selectedTabId: null,
+  onSelect: vi.fn(),
+  onToggleExpanded: vi.fn(),
+  onAddTabToWorkspace: vi.fn(),
+  onContextMenu: vi.fn(),
+  onSelectTab: vi.fn(),
+  onCloseTab: vi.fn(),
+  onTabContextMenu: vi.fn(),
+  // … 其餘必要 props 依 WorkspaceRow 實際介面補
+}
 
-  // hover Plus → popover 顯示
-  fireEvent.mouseEnter(screen.getByLabelText(/Add tab to/i).parentElement!)
-  expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+describe('WorkspaceRow — Plus hover popover (Phase 1b\\')', () => {
+  beforeEach(() => setupHoverPopoverFixtures({ withBindings: true }))
 
-  // mouseleave wrapper → popover 收回
-  fireEvent.mouseLeave(screen.getByLabelText(/Add tab to/i).parentElement!)
-  expect(screen.queryByLabelText(/^X/)).toBeNull()
+  it('opens popover on Plus hover, closes on mouseleave', () => {
+    render(<WorkspaceRow {...(baseProps as never)} />)
+    const plusBtn = screen.getByLabelText(/Add tab to/i)
+    const hub = plusBtn.parentElement!
+
+    // 預設未 hover → chip 不在 DOM
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+
+    // hover Plus → popover 顯示
+    fireEvent.mouseEnter(hub)
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+
+    // mouseleave wrapper → popover 收回
+    fireEvent.mouseLeave(hub)
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+  })
+
+  it('does NOT open popover when no WORKSPACE_ACTIONS bindings exist', () => {
+    setupHoverPopoverFixtures({ withBindings: false })
+    render(<WorkspaceRow {...(baseProps as never)} />)
+    const plusBtn = screen.getByLabelText(/Add tab to/i)
+    fireEvent.mouseEnter(plusBtn.parentElement!)
+    expect(screen.queryByRole('toolbar', { name: /Quick commands|快速指令/i })).toBeNull()
+  })
 })
 
-it('does NOT open popover when no WORKSPACE_ACTIONS bindings exist', () => {
-  useQuickCommandStore.setState({ bindings: {} })
-  // … render WorkspaceRow …
-  fireEvent.mouseEnter(screen.getByLabelText(/Add tab to/i).parentElement!)
-  expect(screen.queryByRole('toolbar', { name: /Quick commands/i })).toBeNull()
+describe('WorkspaceRow — touch fallback (codex round-1 C17)', () => {
+  beforeEach(() => {
+    setupHoverPopoverFixtures({ withBindings: true })
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('long-press (>=500ms) on Plus opens the popover; tap chip executes', () => {
+    render(<WorkspaceRow {...(baseProps as never)} />)
+    const plusBtn = screen.getByLabelText(/Add tab to/i)
+    const hub = plusBtn.parentElement!
+
+    // touch start → wait 500ms → long-press fires
+    fireEvent.touchStart(hub)
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+    fireEvent.touchEnd(hub)
+    // popover stays open (long-press fired)
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+  })
+
+  it('short tap (<500ms) on Plus triggers add-tab, NOT popover', () => {
+    const onAddTabToWorkspace = vi.fn()
+    render(<WorkspaceRow {...(baseProps as never)} onAddTabToWorkspace={onAddTabToWorkspace} />)
+    const plusBtn = screen.getByLabelText(/Add tab to/i)
+
+    fireEvent.touchStart(plusBtn.parentElement!)
+    act(() => {
+      vi.advanceTimersByTime(200) // less than 500ms
+    })
+    fireEvent.touchEnd(plusBtn.parentElement!)
+    fireEvent.click(plusBtn)
+
+    expect(onAddTabToWorkspace).toHaveBeenCalledWith('w1')
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+  })
+
+  it('tapping outside the hub closes an open touch-popover', () => {
+    render(<WorkspaceRow {...(baseProps as never)} />)
+    const plusBtn = screen.getByLabelText(/Add tab to/i)
+    const hub = plusBtn.parentElement!
+
+    fireEvent.touchStart(hub)
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+    fireEvent.touchEnd(hub)
+
+    // tap outside the hub
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+  })
 })
 ```
 
@@ -3172,7 +3902,7 @@ Expected: FAIL — module not found / popover 不顯示。
 
 - [ ] **Step 3: Implement popover + WorkspaceRow integration**
 
-Create `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx`：
+Create `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx`（codex round-1 B5/B6/C16 — switchToSession 完整 tmux-session 欄位 + workspace insertTab + setActive + aria-label 走 i18n）：
 
 ```tsx
 import { useCallback, useRef, useState } from 'react'
@@ -3181,8 +3911,10 @@ import { HostPickerPopover } from '../../../components/HostPickerPopover'
 import { runWorkspaceSlot } from '../../../lib/slot-executor'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 import { useTabStore } from '../../../stores/useTabStore'
+import { useWorkspaceStore } from '../../../stores/useWorkspaceStore'
 import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
 import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { useI18nStore } from '../../../stores/useI18nStore'
 
 interface Props {
   workspaceId: string
@@ -3205,6 +3937,7 @@ interface Props {
  * suppress the wrapper.
  */
 export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
+  const t = useI18nStore((s) => s.t)
   const moduleEnabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
   const hasBindings = useQuickCommandStore((s) => {
     const cmds = hostId == null ? s.global : s.getCommands(hostId)
@@ -3224,27 +3957,43 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
     [],
   )
 
+  // codex round-1 B5/B6 — full openSingletonAndSelect equivalent: complete
+  // tmux-session content fields + insertTab into workspace + setActive.
+  const switchToSession = useCallback(
+    (h: string, sessionCode: string) => {
+      const tabId = useTabStore.getState().openSingletonTab({
+        kind: 'tmux-session',
+        hostId: h,
+        sessionCode,
+        mode: 'terminal',
+        cachedName: sessionCode,
+        tmuxInstance: '',
+      })
+      useWorkspaceStore.getState().insertTab(tabId, workspaceId)
+      useWorkspaceStore.getState().setActiveWorkspace(workspaceId)
+      useTabStore.getState().setActiveTab(tabId)
+    },
+    [workspaceId],
+  )
+
   if (!moduleEnabled || !hasBindings) return null
 
   return (
     <div
       ref={wrapperRef}
       role="group"
-      aria-label="Workspace quick actions"
+      // codex round-1 C16 — i18n key, not hard-coded English
+      aria-label={t('quick_commands.aria.workspace_actions')}
       className="absolute right-full top-1/2 -translate-y-1/2 mr-1 flex items-center gap-1 px-2 py-1 rounded-md bg-gradient-to-l from-surface-secondary/0 to-surface-secondary/95 backdrop-blur-sm shadow-md z-30"
     >
       <CommandSlot
         mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
         ctx={{ hostId, workspaceId }}
+        // codex round-1 C11 — picker race guard
+        busy={picker !== null}
         executor={(cmd, ctx) =>
           runWorkspaceSlot(cmd, ctx, {
-            switchToSession: (h, sessionCode) => {
-              useTabStore.getState().openSingletonTab({
-                kind: 'tmux-session',
-                hostId: h,
-                sessionCode,
-              })
-            },
+            switchToSession,
             resolveHostId,
           })
         }
@@ -3266,10 +4015,10 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
 }
 ```
 
-修改 `spa/src/features/workspace/components/WorkspaceRow.tsx` Plus 按鈕區段（L107-121）：
+修改 `spa/src/features/workspace/components/WorkspaceRow.tsx` Plus 按鈕區段（L107-121）— 含 codex round-1 C17 的 touch fallback：
 
 ```tsx
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 // … 既有 imports
 import { useTabStore } from '../../../stores/useTabStore'
 import { inferWorkspaceHostId } from '../../../lib/infer-workspace-host-id'
@@ -3280,6 +4029,35 @@ const [popoverOpen, setPopoverOpen] = useState(false)
 const hubRef = useRef<HTMLDivElement>(null)
 const tabsMap = useTabStore((s) => s.tabs)  // 訂閱 tabs 變動，hostId 隨 layout 變化即時更新
 const hostId = inferWorkspaceHostId(workspace, tabsMap)  // string | null
+
+// codex round-1 C17 — touch fallback (long-press 500ms opens popover; tap < 500ms triggers add-tab)
+const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+const longPressFiredRef = useRef(false)
+
+const handleTouchStart = () => {
+  longPressFiredRef.current = false
+  longPressTimerRef.current = setTimeout(() => {
+    longPressFiredRef.current = true
+    setPopoverOpen(true)
+  }, 500)
+}
+const handleTouchEnd = () => {
+  if (longPressTimerRef.current) {
+    clearTimeout(longPressTimerRef.current)
+    longPressTimerRef.current = null
+  }
+  // long-press fired → user is now interacting with popover; do NOT trigger add-tab onClick.
+}
+useEffect(() => {
+  if (!popoverOpen) return
+  const onPointer = (e: PointerEvent) => {
+    if (!hubRef.current?.contains(e.target as Node | null)) {
+      setPopoverOpen(false)
+    }
+  }
+  document.addEventListener('pointerdown', onPointer)
+  return () => document.removeEventListener('pointerdown', onPointer)
+}, [popoverOpen])
 
 // 改 Plus 區段（保留原條件 showTabs）：
 {showTabs && (
@@ -3295,12 +4073,21 @@ const hostId = inferWorkspaceHostId(workspace, tabsMap)  // string | null
         setPopoverOpen(false)
       }
     }}
+    onTouchStart={handleTouchStart}
+    onTouchEnd={handleTouchEnd}
+    onTouchCancel={handleTouchEnd}
   >
     <button
       type="button"
       aria-label={t('nav.add_tab_to_workspace', { name: workspace.name })}
       title={t('nav.add_tab_to_workspace', { name: workspace.name })}
       onClick={(e) => {
+        // codex round-1 C17 — if long-press fired, suppress click (touch → click compat)
+        if (longPressFiredRef.current) {
+          e.preventDefault()
+          e.stopPropagation()
+          return
+        }
         e.stopPropagation()
         onAddTabToWorkspace(workspace.id)
       }}
@@ -3316,7 +4103,7 @@ const hostId = inferWorkspaceHostId(workspace, tabsMap)  // string | null
 )}
 ```
 
-註：popover 觸發 hover 時 Plus 仍是 hover 中（同一個 group），不會閃。`WorkspaceQuickActionsPopover` 內部已 short-circuit 模組停用 / 無 binding；hostId 為 null 時 chip 仍顯示（spec v4 §3.2.2 — picker 會在點擊時開）。
+註：popover 觸發 hover 時 Plus 仍是 hover 中（同一個 group），不會閃。`WorkspaceQuickActionsPopover` 內部已 short-circuit 模組停用 / 無 binding；hostId 為 null 時 chip 仍顯示（spec v4 §3.2.2 — picker 會在點擊時開）。Touch 流程：long-press 500ms 開 popover；短 tap 走原本 click。document `pointerdown` 偵測 hub 外點擊以收回。
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -3326,12 +4113,12 @@ Expected: PASS
 - [ ] **Step 5: Commit**
 
 ```
-feat(spa): add hover popover for WORKSPACE_ACTIONS chips beside WorkspaceRow Plus button
+feat(spa): add hover/long-press popover for WORKSPACE_ACTIONS chips beside WorkspaceRow Plus button
 ```
 
 ---
 
-### Task 1b.6: Phase 1b 全域驗證
+### Task 1b'.2: Phase 1b' 全域驗證
 
 - [ ] **Step 1: Run all SPA tests**
 
@@ -3348,44 +4135,29 @@ Expected: clean
 Run: `cd spa && pnpm run build`
 Expected: clean
 
-- [ ] **Step 4: Run all Go tests**
+- [ ] **Step 4: 手動冒煙（review reviewer 自行操作）**
 
-Run: `go test ./...`
-Expected: all pass
+桌面：
+1. Settings → Quick Commands → 確認已有一個 mount=Workspace 的 command
+2. sidebar Workspace 行 hover Plus 按鈕 → 左側 popover 展開 chip
+3. 點擊 chip → 建 session + 送 cmd + 切過去
+4. mouseleave hub → popover 收回
+5. 鍵盤 Tab focus 到 Plus → popover 開；blur 整個 hub → popover 收
 
-- [ ] **Step 5: Go build**
+行動裝置 / 觸控（codex round-1 C17）：
+6. iOS Safari 或 Android Chrome 連上 dev URL（`https://*.mlab.host:5174`）
+7. 在 sidebar Plus 按鈕做 long-press（按住 ≥500ms 不放）→ popover 展開
+8. 仍按住手指 → tap chip → 建 session + 送 cmd + 切過去
+9. 短 tap Plus（<500ms）→ 應觸發原本的 add-tab，**不**展開 popover
+10. popover 開啟時 tap 螢幕其他位置 → popover 收回
 
-Run: `go build ./...`
-Expected: clean
+### Phase 1b' 驗收清單
 
-- [ ] **Step 6: 手動冒煙（review reviewer 自行操作）**
-
-啟動 daemon + dev SPA，user flow：
-1. Settings → Quick Commands → New → 輸入 Name + Command + 勾 Workspace → Save
-2. 在 sidebar Workspace 行 **右鍵** → context menu 出現該 quick command；點擊執行
-3. 在 sidebar Workspace 行 **hover Plus 按鈕** → 左側 popover 展開 chip；點擊執行
-4. 兩條路徑都應：建 session、送 cmd、自動切到該 session
-5. 模擬失敗（停 daemon → 點按鈕 → 應有 toast）；send-keys 失敗的 toast 應顯 'Retry' 按鈕（Task 1b.1.5 + 1b.2 共同支撐）
-
-### Phase 1b 驗收清單
-
-- [x] Settings 頁面可建 / 編 / 刪 commands；mount chips 可多選
-- [x] 對話框 a11y：focus trap / Esc / aria-label / 觸發鍵盤可達
-- [x] 設 mount = WORKSPACE 後，回 sidebar 即可在「Workspace 右鍵 menu」與「Plus hover popover」兩個入口看到按鈕（無需 reload）
-- [x] 兩個入口共用同一個 executor，行為一致
 - [x] Plus hover popover：mouseleave Plus AND popover 收回；鍵盤 focus 同等於 hover；無 binding 時不展開
-- [x] 點擊按鈕：建 session + 送 keys + 切過去
-- [x] 三層失敗 UX 符合 spec §3.3：建失敗 / 送 keys 失敗仍切過去 + **toast 顯 'Retry' 按鈕** / 切失敗 toast
-- [x] 停用 quick-commands module → 兩個入口皆立即消失（CommandSlot short-circuit）
-- [x] i18n: zh-TW + en 全部 key 齊全（含新增 `quick_commands.toast.retry` + 4 個 `quick_commands.host_picker.*`；`pnpm run lint` 含 locale-completeness 檢查）
-- [x] **Spec v4 — workspace hostId 多數決邊界（§3.2.1 / §3.2.2）：**
-  - workspace 中只有非 tmux-session tabs（如全 dashboard / settings）→ 點 quick command → `HostPickerPopover` 出現 → 選 host → 正常流程（建 session + 送 keys + 切過去）
-  - workspace 中只有 tmux-session tabs（單 host）→ 自動推斷正確 host → **不出 picker**
-  - workspace 中混合多 host tmux-session tabs，多數一個 host → 多數決命中該 host → 不出 picker
-  - workspace 多數決平手 + active tab 是 tmux-session 在多數派內 → 用 active 的 hostId
-  - workspace 多數決平手 + active tab 非 tmux-session → 用 tabs 順序中第一個 winner
-  - hostId null 時 picker 取消 → no-op，**沒有任何 createSession / send-keys API call**
-  - hostId null 時 picker 選定 → executor 用該 hostId 完成全流程
+- [x] Long-press 500ms 開 popover；tap chip 執行；short tap 走原 click（C17 mobile/touch fallback）
+- [x] 點擊 hub 外（document pointerdown）→ popover 收回
+- [x] 行為與 Phase 1b context menu 入口共用同一 executor，結果一致
+- [x] hostId null 時 popover 仍顯示，chip 點擊觸發 HostPickerPopover
 
 ---
 
@@ -3413,17 +4185,35 @@ Expected: clean
 
 Edit `spa/src/components/hosts/SessionsSection.test.tsx`：
 - 若有測試斷言「session row 顯示 quick command 按鈕」，改為斷言「session row 不再有該按鈕」（或 `getAllByLabelText(/Quick Command/i)` 為空）
-- 若沒對應測試，新增一條保護性測試：
+- 若沒對應測試，新增一條保護性測試（codex round-1 B8 — full executable body）：
 
 ```tsx
-it('does NOT render v1 QuickCommandMenu inside session rows (moved to new-session adjacency, Phase 1c)', () => {
-  // 既有 setup：mock host / sessions store，render <SessionsSection hostId="h1" />
-  // 假設 v1 QuickCommandMenu 的 trigger 有 aria-label 含 "Quick Commands"
-  expect(screen.queryAllByRole('button', { name: /quick commands/i }).length).toBe(0)
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SessionsSection } from './SessionsSection'
+import { useHostStore } from '../../stores/useHostStore'
+
+describe('SessionsSection — v1 QuickCommandMenu removal (Phase 1c)', () => {
+  beforeEach(() => {
+    useHostStore.setState({
+      hosts: { h1: { id: 'h1', name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 } },
+      hostOrder: ['h1'],
+      runtime: { h1: { status: 'connected' } },
+      activeHostId: 'h1',
+      // sessions 視 SessionsSection 內部資料來源不同，可能在 useHostStore 下
+      // 或由 hostFetch hook 拉取；subagent 實作時依實際 API 補 fixture（≥1 個 session）
+    })
+  })
+
+  it('does NOT render v1 QuickCommandMenu inside session rows (moved to new-session adjacency, Phase 1c)', () => {
+    render(<SessionsSection hostId="h1" />)
+    // v1 QuickCommandMenu 的 trigger 有 aria-label "Quick Commands" — 確認 0 個
+    expect(screen.queryAllByRole('button', { name: /quick commands/i }).length).toBe(0)
+  })
 })
 ```
 
-註：實際 aria-label 由 `QuickCommandMenu` 元件決定（subagent 實作前先讀 `spa/src/components/QuickCommandMenu.tsx` 確認 trigger 的 accessible name；若不同請對齊）。
+註：實際 aria-label 由 `QuickCommandMenu` 元件決定（subagent 實作前先讀 `spa/src/components/QuickCommandMenu.tsx` 確認 trigger 的 accessible name；若不同請對齊）。Sessions fixture（至少 1 row 才會渲染 row 區段）也須補；若 SessionsSection 內部 sessions 來自 `useHostStore.sessions[hostId]` 則直接 setState 加；若來自 `hostFetch` 則透過 `vi.mock('../../lib/host-api', ...)` 注入。
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -3510,7 +4300,7 @@ import { QUICK_COMMAND_SLOTS } from '../../lib/quick-command-slots'
 import { useTabStore } from '../../stores/useTabStore'
 ```
 
-修改 L165-175 區段：
+修改 L165-175 區段（codex round-1 B5 — switchToSession 補完整 tmux-session content 欄位；HOST_ACTIONS 不需 workspace insertTab）：
 
 ```tsx
 <div className="flex items-center justify-between mb-4">
@@ -3522,11 +4312,18 @@ import { useTabStore } from '../../stores/useTabStore'
       executor={(cmd, ctx) =>
         runWorkspaceSlot(cmd, ctx, {
           switchToSession: (h, sessionCode) => {
+            // codex round-1 B5 — fill ALL tmux-session content fields per types/tab.ts:38
             useTabStore.getState().openSingletonTab({
               kind: 'tmux-session',
               hostId: h,
               sessionCode,
+              mode: 'terminal',
+              cachedName: sessionCode,
+              tmuxInstance: '',
             })
+            // codex round-1 B6 — HOST_ACTIONS does NOT insert into a workspace
+            // (host detail page is a standalone tab, not a workspace context).
+            // We just open the session tab and let user navigate via tab strip.
           },
           // HOST_ACTIONS 入口必有 hostId；resolveHostId 不會被呼叫。仍提供
           // safety-net noop 以滿足型別契約（spec v4）。
@@ -3600,11 +4397,18 @@ Expected: clean
 
 ## Phase 完成順序檢查清單（送 reviewer 前確認）
 
+**新 Phase 順序（codex round-1 結構性變更）：1a → 1b → 1b' → 1c。**
+
 - [ ] Phase 1a 已 merge → main，且 alpha bump 完成（或一個 PR sequence 規劃中）
-- [ ] Phase 1b 已 merge → main，**Settings UI 與 WORKSPACE_ACTIONS 兩個入口（context menu + hover popover）同 PR**（不可拆）
-- [ ] Phase 1b 內 task 順序：**1b.0a（inferWorkspaceHostId helper）→ 1b.0b（HostPickerPopover 元件）→ 1b.1（CommandSlot）→ 1b.1.5（Toast schema 擴充）→ 1b.2（slot-executor + resolveHostId）→ 1b.3（Settings UI）→ 1b.4（settings contribution + i18n）→ 1b.5a（context menu 入口）→ 1b.5b（hover popover 入口）→ 1b.6（全域驗證）**
-- [ ] Phase 1c 已 merge → main，**1c.1a（移除 SessionsSection row 的 v1 整合）→ 1c.1b（new-session 旁掛 HOST_ACTIONS）兩個 commits 同 PR、依序 ship**（先 commit 純減量，再 commit 純新增；diff 易 review）
+- [ ] **Phase 1b 已 merge → main**，含 Settings UI + 資料層 + Workspace **右鍵 context menu** 入口（單一 PR）
+  - Phase 1b 內 task 順序：**1b.0a（inferWorkspaceHostId helper）→ 1b.0b（HostPickerPopover 元件）→ 1b.0c（i18n keys 前置 — codex round-1 B9）→ 1b.1（CommandSlot + busy prop）→ 1b.1.5（Toast schema 擴充 — codex round-1 B4）→ 1b.2（slot-executor + resolveHostId）→ 1b.3（Settings UI + chip 方向鍵 — codex round-1 C15）→ 1b.4（settings contribution + 剩餘 i18n）→ 1b.5a（context menu 入口 — codex round-1 B5/B6/B7/B8 修正）→ 1b.6（全域驗證）**
+  - 此 PR 滿足 spec §6「Settings 首次出現時至少一個 slot 生效」要求 — context menu 是穩定入口
+- [ ] **Phase 1b' 已 merge → main**，**Plus hover popover 過渡入口獨立 PR**（codex round-1 結構性變更 — 風險隔離）
+  - Phase 1b' 內 task 順序：**1b'.1（WorkspaceQuickActionsPopover + WorkspaceRow Plus hover + mobile/touch fallback — codex round-1 C17）→ 1b'.2（全域驗證）**
+  - User 標記此入口為過渡實作；獨立 PR 便於日後 revert / replace
+- [ ] Phase 1c 已 merge → main，**1c.1a（移除 SessionsSection row 的 v1 整合 — codex round-1 B8）→ 1c.1b（new-session 旁掛 HOST_ACTIONS — codex round-1 B5）兩個 commits 同 PR、依序 ship**（先 commit 純減量，再 commit 純新增；diff 易 review）
 - [ ] Phase 1a 不可單獨 ship 在沒有 Phase 1b 計畫的情況（純資料層 user 看不到任何成果，會困惑）— 但 1a + 1b 兩個 PR 接力 ship 是允許的（spec §6 只要求 Settings UI 出現時必有 slot 生效）
+- [ ] Phase 1b' 與 1c 之間順序可彈性（user 可決定先 ship 哪個）；建議 1b' → 1c 因為 1b' 是 Phase 1b 的延伸，1c 是新 mount 點
 
 ## 範圍邊界（Phase 1 不做）
 
@@ -3627,5 +4431,7 @@ Expected: clean
 2. 一個 task 一個 commit，commit message 用 conventional commit + Co-Authored-By trailer
 3. zustand test setState **顯式列出** `global` / `byHost` / `bindings` 三個 mutable fields；**不要**只寫 `setState({ bindings: {...} })`，會 wipe 其他 state（feedback_zustand_harness_setstate.md）。同樣原則套用 `useHostStore`（測試需要時列出 `hosts` / `hostOrder` / `runtime` / `activeHostId` 四個欄位）。
 4. 任何測試 / lint / build 指令在主 Claude 機器跑（feedback_codex_sandbox_no_install.md）
-5. **Phase 1b 任務依賴**：1b.0a 與 1b.0b 必須先於其他 1b.* 任務完成；1b.1（CommandSlot）依賴 1b.0a 的型別 + 1b.0b 不直接依賴但 picker 是後續 caller 必用；1b.2（executor）依賴 1b.0b 的 `resolveHostId` callback 契約；1b.5a / 1b.5b / 1c.1b 各自整合 picker UI
-5. PR 完成後委派 codex 兩輪 review（標準 + 攻擊/防守/體質）；發現問題彙整成表格（信心 / 關聯 / 複雜度）後決定即修 vs 開 issue 追蹤
+5. **Phase 1b 任務依賴**（codex round-1 後）：1b.0a → 1b.0b → 1b.0c（i18n 必須前置）→ 1b.1（CommandSlot）→ 1b.1.5（toast schema 擴充）→ 1b.2（executor）→ 1b.3 → 1b.4 → 1b.5a → 1b.6。其中 1b.5a 的 switchToSession 必須做完整 `openSingletonAndSelect` 等價邏輯（codex round-1 B5/B6）：openSingletonTab（含 mode/cachedName/tmuxInstance 完整欄位）→ insertTab → setActiveWorkspace + setActiveTab。
+6. **Phase 1b' 任務依賴**：必須在 Phase 1b PR merge 後才能開工；`<CommandSlot>`、`<HostPickerPopover>`、`runWorkspaceSlot`、`inferWorkspaceHostId`、i18n keys 全部就緒後再實作 hover popover + 與 1b.5a 同等的 switchToSession 邏輯。
+7. PR 完成後委派 codex 兩輪 review（標準 + 攻擊/防守/體質）；發現問題彙整成表格（信心 / 關聯 / 複雜度）後決定即修 vs 開 issue 追蹤
+8. **Toast 行為的 spec §3.3 對應**（codex round-1 B4）：create-session failure → `toast.show(msg)` 不傳 action；switch-to-session failure → `toast.show(msg)` 不傳 action；send-keys failure → `toast.show(msg, retryFn, t('quick_commands.toast.retry'))`。元件渲染規則：`toast.action == null` → 不渲染 button。

--- a/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
+++ b/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
@@ -1,0 +1,2175 @@
+# Quick Commands v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-architect Quick Commands as a three-layer **Capability / Binding / Slot** system so user 可以在 Settings 統一新增 / 編輯 commands、自選 mount 位置（Workspace / Host），並由 slot 端集中處理 executor + 失敗 UX。
+
+**Architecture:**
+- **Capability** — `QuickCommand` 純資料（id / name / command / icon / category）
+- **Binding** — user 意圖 `Record<commandId, slotId[]>`，sync 跨裝置
+- **Slot** — 模組決定如何渲染 / 執行；`<CommandSlot>` 共用元件 + slot-side executor
+- **Module** — `quick-commands` 註冊為獨立 disableable module，遵循既有啟用 / 停用規範
+
+**Tech Stack:** React / Zustand 5 / Tailwind 4 / Vitest / Phosphor Icons / 既有 sync-contributor / `useModuleEnabledStore` AR-1 sanitizer 模式
+
+**Spec:** `docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md`
+
+**Phase 順序（強制 1a → 1b → 1c）：**
+1. **Phase 1a** — 純資料層；單一 PR；UI 零改動。
+2. **Phase 1b** — Settings UI + WORKSPACE_ACTIONS 入口；單一 PR，**必須與 Settings UI 同 PR ship**（spec §6 不 ship 設了沒效果的中間態）。
+3. **Phase 1c** — HOST_ACTIONS 入口；小 PR。
+
+**測試指令備忘（主 Claude 機器跑，subagent 寫 plan 不執行）：**
+- SPA test: `cd spa && npx vitest run`
+- SPA lint: `cd spa && pnpm run lint`
+- SPA build: `cd spa && pnpm run build`
+- Go test: `go test ./...`
+- Go build: `go build ./...`
+
+**避雷備忘：**
+- Zustand test harness 用 `setState({...}, false)`（merge mode）並**顯式列出所有 mutable fields**，避免 wipe action methods（見 `feedback_zustand_harness_setstate.md`）。
+- Alpha 階段 **不寫 persist migration**（見 `feedback_no_alpha_migration.md`）。
+- Codex sandbox 無網路；plan 中所有 `pnpm install` / `vitest` / `lint` / `build` 指令必須在主 Claude 機器跑（見 `feedback_codex_sandbox_no_install.md`）。
+- 子 agent 每個 Bash 強制 `cd <worktree-path> && ` 前綴，否則 commit 會落到錯誤分支。
+
+---
+
+## Phase 1a — 純資料層（單一 PR）
+
+**目標：** 完成 store schema 升級 + sanitizer + sync `bindings` 欄位 + module 註冊（無 settings contribution），UI 零改動。Modules Switchboard 可看到 quick-commands 模組可開關。
+
+### Task 1a.1: 新增 `quick-command-slots.ts` 常數與型別
+
+**Files:**
+- Create: `spa/src/lib/quick-command-slots.ts`
+- Create: `spa/src/lib/quick-command-slots.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spa/src/lib/quick-command-slots.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { QUICK_COMMAND_SLOTS, type QuickCommandSlotId } from './quick-command-slots'
+
+describe('quick-command-slots', () => {
+  it('exposes WORKSPACE_ACTIONS and HOST_ACTIONS literals', () => {
+    expect(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS).toBe('workspace.actions')
+    expect(QUICK_COMMAND_SLOTS.HOST_ACTIONS).toBe('host.actions')
+  })
+
+  it('values are unique', () => {
+    const values = Object.values(QUICK_COMMAND_SLOTS)
+    expect(new Set(values).size).toBe(values.length)
+  })
+
+  it('QuickCommandSlotId narrows to the value union', () => {
+    const x: QuickCommandSlotId = QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS
+    expect(typeof x).toBe('string')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/lib/quick-command-slots.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement constants**
+
+Create `spa/src/lib/quick-command-slots.ts`:
+
+```ts
+/**
+ * Slot identifiers for the Quick Commands v2 capability/binding/slot model
+ * (spec §2.2). Settings UI, <CommandSlot>, and binding sanitizer must read
+ * from this constant — string literals are forbidden so a typo can't drift
+ * away from the registered slots.
+ *
+ * If/when external modules need to register new slots, upgrade to a
+ * `registerQuickCommandSlot()` registry (Phase 2+; YAGNI for now).
+ */
+export const QUICK_COMMAND_SLOTS = {
+  WORKSPACE_ACTIONS: 'workspace.actions',
+  HOST_ACTIONS: 'host.actions',
+} as const
+
+export type QuickCommandSlotId =
+  (typeof QUICK_COMMAND_SLOTS)[keyof typeof QUICK_COMMAND_SLOTS]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/lib/quick-command-slots.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): add QUICK_COMMAND_SLOTS typed constants for v2 binding model
+```
+
+---
+
+### Task 1a.2: Store schema 升級 — 加 `bindings` 欄位 + sanitizer + binding API
+
+**Files:**
+- Modify: `spa/src/stores/useQuickCommandStore.ts`
+- Modify: `spa/src/stores/useQuickCommandStore.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spa/src/stores/useQuickCommandStore.test.ts` (保留既有 5 個 test，覆蓋寫整個 file 內容)：
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useQuickCommandStore } from './useQuickCommandStore'
+import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
+
+// 顯式列出所有 mutable fields — zustand setState merge 模式下，
+// action methods 由 closure 持有，不會被覆蓋（見 feedback_zustand_harness_setstate.md）。
+function resetStore(initial?: {
+  global?: ReturnType<typeof useQuickCommandStore.getState>['global']
+  byHost?: ReturnType<typeof useQuickCommandStore.getState>['byHost']
+  bindings?: ReturnType<typeof useQuickCommandStore.getState>['bindings']
+}) {
+  useQuickCommandStore.setState({
+    global: initial?.global ?? [],
+    byHost: initial?.byHost ?? {},
+    bindings: initial?.bindings ?? {},
+  })
+}
+
+describe('useQuickCommandStore — capability CRUD (Phase 1a)', () => {
+  beforeEach(() => {
+    resetStore({
+      global: [
+        { id: 'cmd-a', name: 'A', command: 'a', category: 'agent' },
+        { id: 'cmd-b', name: 'B', command: 'b' },
+      ],
+    })
+  })
+
+  it('getCommands returns global commands when no host overrides', () => {
+    const cmds = useQuickCommandStore.getState().getCommands('host-1')
+    expect(cmds.map((c) => c.id)).toEqual(['cmd-a', 'cmd-b'])
+  })
+
+  it('per-host overrides global by id', () => {
+    useQuickCommandStore.getState().addCommand(
+      { id: 'cmd-a', name: 'A-host', command: 'aa' },
+      'host-1',
+    )
+    const cmds = useQuickCommandStore.getState().getCommands('host-1')
+    const a = cmds.find((c) => c.id === 'cmd-a')!
+    expect(a.command).toBe('aa')
+    expect(a.name).toBe('A-host')
+  })
+
+  it('addCommand to global', () => {
+    useQuickCommandStore.getState().addCommand({ id: 'cmd-c', name: 'C', command: 'c' })
+    expect(useQuickCommandStore.getState().global).toHaveLength(3)
+  })
+
+  it('removeCommand from global', () => {
+    useQuickCommandStore.getState().removeCommand('cmd-a')
+    expect(useQuickCommandStore.getState().global.find((c) => c.id === 'cmd-a')).toBeUndefined()
+  })
+
+  it('updateCommand in global', () => {
+    useQuickCommandStore.getState().updateCommand('cmd-a', { name: 'A-updated' })
+    expect(useQuickCommandStore.getState().global.find((c) => c.id === 'cmd-a')!.name).toBe('A-updated')
+  })
+})
+
+describe('useQuickCommandStore — bindings (Phase 1a)', () => {
+  beforeEach(() => {
+    resetStore({
+      global: [
+        { id: 'cmd-a', name: 'A', command: 'a' },
+        { id: 'cmd-b', name: 'B', command: 'b' },
+      ],
+    })
+  })
+
+  it('bindings default to empty object', () => {
+    expect(useQuickCommandStore.getState().bindings).toEqual({})
+  })
+
+  it('setBinding records command -> slot mapping', () => {
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toEqual(['workspace.actions'])
+  })
+
+  it('setBinding with empty array removes the binding entry', () => {
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().setBinding('cmd-a', [])
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toBeUndefined()
+  })
+
+  it('setBinding can mount a command into multiple slots', () => {
+    useQuickCommandStore.getState().setBinding('cmd-a', [
+      QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS,
+      QUICK_COMMAND_SLOTS.HOST_ACTIONS,
+    ])
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toEqual([
+      'workspace.actions',
+      'host.actions',
+    ])
+  })
+
+  it('getBoundCommands returns commands mounted to the slot, in capability order', () => {
+    useQuickCommandStore.getState().setBinding('cmd-b', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    const bound = useQuickCommandStore
+      .getState()
+      .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'host-1')
+    // 順序穩定 — 跟著 getCommands(hostId) 的順序，不是 bindings Record 的 key 順序
+    expect(bound.map((c) => c.id)).toEqual(['cmd-a', 'cmd-b'])
+  })
+
+  it('getBoundCommands skips bindings whose command no longer exists (dangling filter)', () => {
+    useQuickCommandStore.getState().setBinding('cmd-zombie', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    const bound = useQuickCommandStore
+      .getState()
+      .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'host-1')
+    expect(bound.map((c) => c.id)).toEqual(['cmd-a'])
+  })
+
+  it('removeCommand on a global command also clears its binding', () => {
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().removeCommand('cmd-a')
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toBeUndefined()
+  })
+
+  it('removeCommand on a per-host command does NOT clear its binding (binding is global concept)', () => {
+    useQuickCommandStore.getState().addCommand({ id: 'cmd-a', name: 'A-host', command: 'aa' }, 'host-1')
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().removeCommand('cmd-a', 'host-1')
+    // global cmd-a 仍存在；per-host override 被刪；binding 不動
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toEqual(['workspace.actions'])
+  })
+})
+
+describe('useQuickCommandStore — sanitizeBindings via merge', () => {
+  it('drops non-object payloads', () => {
+    // 直接呼叫 merge 行為：模擬 hydrated raw string
+    // (sanitizer 是 module-private，所以透過 setState + merge hook 間接驗；
+    //  這裡的合理代表是斷言 store 在惡意 payload 注入後仍維持 bindings = {})
+    useQuickCommandStore.setState({ bindings: {} })
+    expect(useQuickCommandStore.getState().bindings).toEqual({})
+  })
+})
+```
+
+註：上面 sanitize merge 的端對端測試會在 Task 1a.4 sync deserialize 路徑補上（cross-field dangling case），這裡 store-level 的 sanitizer 主要靠 `merge` hook 在 hydrate 期跑，本 task 只驗 happy-path 行為。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/stores/useQuickCommandStore.test.ts`
+Expected: FAIL — `bindings` 不存在、`setBinding` / `getBoundCommands` 不存在。
+
+- [ ] **Step 3: Implement schema upgrade**
+
+Rewrite `spa/src/stores/useQuickCommandStore.ts`:
+
+```ts
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
+import type { QuickCommandSlotId } from '../lib/quick-command-slots'
+
+export interface QuickCommand {
+  id: string
+  name: string
+  command: string
+  icon?: string
+  category?: string
+  hostOnly?: boolean
+}
+
+export type Bindings = Record<string /* commandId */, QuickCommandSlotId[]>
+
+interface QuickCommandState {
+  global: QuickCommand[]
+  byHost: Record<string, QuickCommand[]>
+  bindings: Bindings
+
+  addCommand: (cmd: QuickCommand, hostId?: string) => void
+  updateCommand: (id: string, patch: Partial<QuickCommand>, hostId?: string) => void
+  removeCommand: (id: string, hostId?: string) => void
+  getCommands: (hostId: string) => QuickCommand[]
+
+  setBinding: (commandId: string, targets: QuickCommandSlotId[]) => void
+  getBoundCommands: (mountTarget: QuickCommandSlotId, hostId: string) => QuickCommand[]
+}
+
+// v2: do NOT pre-seed defaults. Existing users who hydrated v1 defaults
+// (`start-cc` / `start-codex`) keep them but bindings = {} so nothing renders
+// until the user mounts them via Settings.
+const DEFAULT_COMMANDS: QuickCommand[] = []
+
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * AR-1 (mirrors `useModuleEnabledStore` codex review #617):
+ * Sanitize bindings on rehydrate / sync deserialize. A corrupted payload —
+ * hand-edited localStorage, failed migration, hostile sync source — must
+ * NEVER let arbitrary string keys silently mount commands into slots.
+ *
+ * Rules:
+ *  - Top-level value must be a plain object (rejects arrays, null, primitives).
+ *  - Reject `__proto__` / `constructor` / `prototype` keys (prototype pollution).
+ *  - Drop entries whose value is not an array.
+ *  - Within each array, keep only non-empty strings (dedupe NOT done here —
+ *    UI guarantees uniqueness; tolerating duplicates is forward-compatible).
+ *  - Drop entries whose cleaned array is empty (matches setBinding(id, [])).
+ */
+export function sanitizeBindings(raw: unknown): Bindings {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out: Bindings = {}
+  for (const [cmdId, targets] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof cmdId !== 'string' || cmdId.length === 0) continue
+    if (UNSAFE_KEYS.has(cmdId)) continue
+    if (!Array.isArray(targets)) continue
+    const cleaned: QuickCommandSlotId[] = []
+    for (const t of targets) {
+      if (typeof t === 'string' && t.length > 0) cleaned.push(t as QuickCommandSlotId)
+    }
+    if (cleaned.length > 0) out[cmdId] = cleaned
+  }
+  return out
+}
+
+export const useQuickCommandStore = create<QuickCommandState>()(
+  persist(
+    (set, get) => ({
+      global: DEFAULT_COMMANDS,
+      byHost: {},
+      bindings: {},
+
+      addCommand: (cmd, hostId) =>
+        set((state) => {
+          if (hostId) {
+            const hostCmds = [...(state.byHost[hostId] ?? []).filter((c) => c.id !== cmd.id), cmd]
+            return { byHost: { ...state.byHost, [hostId]: hostCmds } }
+          }
+          // global add: replace if id exists, else append
+          const existingIdx = state.global.findIndex((c) => c.id === cmd.id)
+          if (existingIdx >= 0) {
+            const next = [...state.global]
+            next[existingIdx] = cmd
+            return { global: next }
+          }
+          return { global: [...state.global, cmd] }
+        }),
+
+      updateCommand: (id, patch, hostId) =>
+        set((state) => {
+          const update = (cmds: QuickCommand[]) =>
+            cmds.map((c) => (c.id === id ? { ...c, ...patch } : c))
+          if (hostId) {
+            const hostCmds = update(state.byHost[hostId] ?? [])
+            return { byHost: { ...state.byHost, [hostId]: hostCmds } }
+          }
+          return { global: update(state.global) }
+        }),
+
+      removeCommand: (id, hostId) =>
+        set((state) => {
+          if (hostId) {
+            const hostCmds = (state.byHost[hostId] ?? []).filter((c) => c.id !== id)
+            // per-host removal does NOT touch bindings (binding is a global concept)
+            return { byHost: { ...state.byHost, [hostId]: hostCmds } }
+          }
+          // global removal — also drop the binding entry to avoid dangling refs.
+          // getBoundCommands also filters at read-time as a defense-in-depth net.
+          const nextBindings = { ...state.bindings }
+          delete nextBindings[id]
+          return {
+            global: state.global.filter((c) => c.id !== id),
+            bindings: nextBindings,
+          }
+        }),
+
+      getCommands: (hostId) => {
+        const { global, byHost } = get()
+        const hostCmds = byHost[hostId] ?? []
+        if (hostCmds.length === 0) return global
+
+        const merged = [
+          ...global.map((g) => {
+            const override = hostCmds.find((h) => h.id === g.id)
+            return override ?? g
+          }),
+          ...hostCmds.filter((h) => !global.some((g) => g.id === h.id)),
+        ]
+        return merged
+      },
+
+      setBinding: (commandId, targets) =>
+        set((state) => {
+          const nextBindings = { ...state.bindings }
+          if (targets.length === 0) {
+            delete nextBindings[commandId]
+          } else {
+            nextBindings[commandId] = [...targets]
+          }
+          return { bindings: nextBindings }
+        }),
+
+      getBoundCommands: (mountTarget, hostId) => {
+        // Iterate the capability list (stable, sync-safe order) — NOT
+        // Object.keys(bindings) which has unpredictable post-sync order
+        // (spec §4.4). Dangling binding entries (commandId without a matching
+        // capability) are skipped here as well as cleared at removeCommand.
+        const cmds = get().getCommands(hostId)
+        const { bindings } = get()
+        return cmds.filter((c) => bindings[c.id]?.includes(mountTarget))
+      },
+    }),
+    {
+      name: STORAGE_KEYS.QUICK_COMMANDS,
+      storage: purdexStorage,
+      version: 1,
+      partialize: (state) => ({
+        global: state.global,
+        byHost: state.byHost,
+        bindings: state.bindings,
+      }),
+      merge: (persisted, current) => {
+        // AR-1: sanitize hydrated bindings BEFORE first read. global / byHost
+        // come from a known-shape v1 payload — keep as-is. Only bindings is
+        // newly added in v2 and must be clamped against hostile payloads.
+        const p = persisted as { global?: unknown; byHost?: unknown; bindings?: unknown } | null | undefined
+        return {
+          ...current,
+          global: Array.isArray(p?.global) ? (p?.global as QuickCommand[]) : current.global,
+          byHost: typeof p?.byHost === 'object' && p?.byHost !== null && !Array.isArray(p?.byHost)
+            ? (p?.byHost as Record<string, QuickCommand[]>)
+            : current.byHost,
+          bindings: sanitizeBindings(p?.bindings),
+        }
+      },
+    },
+  ),
+)
+
+syncManager.register(STORAGE_KEYS.QUICK_COMMANDS, useQuickCommandStore)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/stores/useQuickCommandStore.test.ts`
+Expected: PASS（包含既有 5 個 + 新增 9 個 binding/dangling/sanitize tests）
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): add bindings field + sanitizer to useQuickCommandStore for v2 slot model
+```
+
+---
+
+### Task 1a.3: Sync contributor 加入 `bindings` field + cross-field dangling test
+
+**Files:**
+- Modify: `spa/src/lib/sync/contributors/quick-commands.ts`
+- Modify: `spa/src/lib/sync/contributors/quick-commands.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spa/src/lib/sync/contributors/quick-commands.test.ts`（保留既有 tests）：
+
+```ts
+// (在現有 import 後加入)
+import { sanitizeBindings } from '../../../stores/useQuickCommandStore'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+
+describe('createQuickCommandsContributor — bindings field (v2)', () => {
+  let contributor: ReturnType<typeof createQuickCommandsContributor>
+
+  beforeEach(() => {
+    useQuickCommandStore.setState({
+      global: [],
+      byHost: {},
+      bindings: {},
+    })
+    contributor = createQuickCommandsContributor()
+  })
+
+  it('serialize includes bindings field', () => {
+    useQuickCommandStore.getState().addCommand({ id: 'cmd-a', name: 'A', command: 'a' })
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.data.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
+  })
+
+  it('serialize keys exclude action functions but include bindings', () => {
+    const payload = contributor.serialize() as FullPayload
+    const keys = Object.keys(payload.data)
+    expect(keys).toContain('global')
+    expect(keys).toContain('byHost')
+    expect(keys).toContain('bindings')
+    expect(keys).not.toContain('setBinding')
+    expect(keys).not.toContain('getBoundCommands')
+  })
+
+  it('deserialize full-replace with bindings overwrites local bindings', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'local', name: 'L', command: 'l' }],
+      byHost: {},
+      bindings: { 'local': ['workspace.actions'] },
+    })
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'remote', name: 'R', command: 'r' }],
+        byHost: {},
+        bindings: { 'remote': ['host.actions'] },
+      },
+    }
+    contributor.deserialize(incoming, { type: 'full-replace' })
+    const state = useQuickCommandStore.getState()
+    expect(state.bindings).toEqual({ 'remote': ['host.actions'] })
+  })
+
+  it('deserialize sanitizes incoming bindings (drops malformed entries)', () => {
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+        byHost: {},
+        bindings: {
+          'cmd-a': ['workspace.actions'],
+          // hostile payload variants — must all be dropped:
+          '__proto__': ['host.actions'],
+          'cmd-bad-targets': 'not-an-array' as unknown as string[],
+          '': ['host.actions'],
+        },
+      },
+    }
+    contributor.deserialize(incoming, { type: 'full-replace' })
+    const state = useQuickCommandStore.getState()
+    expect(state.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
+  })
+
+  it('field-merge: cross-field dangling — global=local + bindings=remote → getBoundCommands returns empty', () => {
+    // local has cmd-A only; remote bindings reference cmd-B (not in local global)
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+      byHost: {},
+      bindings: {},
+    })
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'cmd-b', name: 'B', command: 'b' }],
+        byHost: {},
+        bindings: { 'cmd-b': ['workspace.actions'] },
+      },
+    }
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { global: 'local', bindings: 'remote' },
+    })
+    const state = useQuickCommandStore.getState()
+    // global stayed local — only cmd-a
+    expect(state.global.map((c) => c.id)).toEqual(['cmd-a'])
+    // bindings took remote — references cmd-b
+    expect(state.bindings['cmd-b']).toEqual(['workspace.actions'])
+    // BUT getBoundCommands filters dangling at read-time → empty
+    const bound = state.getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'host-1')
+    expect(bound).toEqual([])
+  })
+
+  it('sanitizeBindings is idempotent on already-clean payload', () => {
+    const clean = { 'cmd-a': ['workspace.actions'] }
+    expect(sanitizeBindings(clean)).toEqual(clean)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/lib/sync/contributors/quick-commands.test.ts`
+Expected: FAIL — `bindings` 不在 `DATA_FIELDS`，sanitize 路徑未呼叫。
+
+- [ ] **Step 3: Modify the contributor**
+
+Update `spa/src/lib/sync/contributors/quick-commands.ts`:
+
+```ts
+import { useQuickCommandStore, sanitizeBindings } from '../../../stores/useQuickCommandStore'
+import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
+
+const DATA_FIELDS = ['global', 'byHost', 'bindings'] as const
+
+type QuickCommandsData = {
+  [K in (typeof DATA_FIELDS)[number]]: ReturnType<typeof useQuickCommandStore.getState>[K]
+}
+
+export function createQuickCommandsContributor(): SyncContributor {
+  return {
+    id: 'quick-commands',
+    strategy: 'full',
+
+    getVersion(): number {
+      return 1
+    },
+
+    serialize(): FullPayload {
+      const state = useQuickCommandStore.getState()
+      const data: Record<string, unknown> = {}
+      for (const field of DATA_FIELDS) {
+        data[field] = state[field]
+      }
+      return { version: 1, data }
+    },
+
+    deserialize(payload: unknown, merge: MergeStrategy): void {
+      const fp = payload as FullPayload
+      const incoming = fp.data as Partial<QuickCommandsData>
+
+      // Sanitize untrusted incoming bindings BEFORE applying. Mirrors the
+      // store's `merge` hook — sync payloads are equally untrusted.
+      const sanitizedIncoming: Partial<QuickCommandsData> = {
+        ...incoming,
+        ...(incoming.bindings !== undefined
+          ? { bindings: sanitizeBindings(incoming.bindings) }
+          : {}),
+      }
+
+      if (merge.type === 'full-replace') {
+        useQuickCommandStore.setState(sanitizedIncoming as QuickCommandsData)
+        return
+      }
+
+      const patch: Partial<QuickCommandsData> = {}
+      for (const field of DATA_FIELDS) {
+        if (merge.resolved[field] === 'remote' && field in sanitizedIncoming) {
+          ;(patch as Record<string, unknown>)[field] = sanitizedIncoming[field]
+        }
+      }
+
+      if (Object.keys(patch).length > 0) {
+        useQuickCommandStore.setState(patch as QuickCommandsData)
+      }
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/lib/sync/contributors/quick-commands.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): sync quick-commands bindings + sanitize incoming payload
+```
+
+---
+
+### Task 1a.4: 註冊 `quick-commands` module（disableable，無 settings contribution）
+
+**Files:**
+- Modify: `spa/src/lib/register-modules.tsx`
+- Modify: `spa/src/locales/zh-TW.json`
+- Modify: `spa/src/locales/en.json`
+- Create: `spa/src/lib/register-modules.quick-commands.test.tsx`（或合併進既有 register-modules test）
+
+註：本 task 只註冊 module + descriptionKey，**不掛 settings contribution**（spec §6 Phase 1a 明確：「暫無 settings contribution，等 1b」）。
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spa/src/lib/register-modules.quick-commands.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from 'vitest'
+import { clearModuleRegistry, getModule } from './module-registry'
+import { registerBuiltinModules } from './register-modules'
+
+describe('register-modules — quick-commands module (Phase 1a)', () => {
+  beforeEach(() => {
+    clearModuleRegistry()
+  })
+
+  it('registers quick-commands as a disableable module', () => {
+    registerBuiltinModules()
+    const m = getModule('quick-commands')
+    expect(m).toBeDefined()
+    expect(m!.disableable).toBe(true)
+    expect(m!.descriptionKey).toBe('modules.quick_commands.description')
+  })
+
+  it('Phase 1a: quick-commands has NO settings contribution yet (deferred to Phase 1b)', () => {
+    registerBuiltinModules()
+    const m = getModule('quick-commands')
+    expect(m!.settings ?? []).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/lib/register-modules.quick-commands.test.tsx`
+Expected: FAIL — module 未註冊。
+
+- [ ] **Step 3: Add registration**
+
+In `spa/src/lib/register-modules.tsx`, 在 `editor` module 註冊區塊**之後**、`getFsBackend({ type: 'inapp' })` 區塊**之前**插入：
+
+```tsx
+  // Quick Commands v2 — Phase 1a registers the module shell only (disableable
+  // gate + Modules Switchboard listing). Settings contribution + UI surfaces
+  // ship together in Phase 1b (spec §6 — never ship a "configured but no
+  // effect" intermediate state).
+  registerModule({
+    id: 'quick-commands',
+    name: 'Quick Commands',
+    disableable: true,
+    descriptionKey: 'modules.quick_commands.description',
+  })
+```
+
+In `spa/src/locales/zh-TW.json`, 在 `modules.memory_monitor.description` 之後插入：
+
+```json
+  "modules.quick_commands.description": "讓你在 Workspace 與 Host 入口快速執行常用指令",
+```
+
+In `spa/src/locales/en.json`, 對應位置插入：
+
+```json
+  "modules.quick_commands.description": "Quickly run frequently-used commands from Workspace and Host entry points",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/lib/register-modules.quick-commands.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): register quick-commands as disableable module (Phase 1a)
+```
+
+---
+
+### Task 1a.5: Phase 1a 全域驗證
+
+- [ ] **Step 1: Run all SPA tests**
+
+Run: `cd spa && npx vitest run`
+Expected: all pass（既有 + 新增 quick-command-slots / store / sync / register-modules tests）
+
+- [ ] **Step 2: Run SPA lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: clean
+
+- [ ] **Step 3: Run SPA build**
+
+Run: `cd spa && pnpm run build`
+Expected: clean
+
+- [ ] **Step 4: Run all Go tests**
+
+Run: `go test ./...`
+Expected: all pass
+
+- [ ] **Step 5: Go build**
+
+Run: `go build ./...`
+Expected: clean
+
+### Phase 1a 驗收清單
+
+- [x] 資料層完整：bindings + sanitizer + setBinding / getBoundCommands API + dangling 清理
+- [x] Sync OK：`bindings` field-merge cross-field dangling case 過綠
+- [x] Modules Switchboard 看得到 `quick-commands` 可開關
+- [x] UI 零改動，純基礎建設
+- [x] `DEFAULT_COMMANDS = []`，舊 user 既有 commands 不主動清
+
+---
+
+## Phase 1b — Settings UI + WORKSPACE_ACTIONS 入口（單一 PR）
+
+**目標：** user 能在 Settings 建 command + 設 mount = WORKSPACE，回到 workspace 立刻看到按鈕；點擊建 session + 送 keys + 切過去。失敗 toast 行為符合 §3.3。
+
+### Task 1b.1: `<CommandSlot>` 共用元件
+
+**Files:**
+- Create: `spa/src/components/CommandSlot.tsx`
+- Create: `spa/src/components/CommandSlot.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spa/src/components/CommandSlot.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CommandSlot } from './CommandSlot'
+import { useQuickCommandStore } from '../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../stores/useModuleEnabledStore'
+import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
+import { clearModuleRegistry, registerModule } from '../lib/module-registry'
+
+function resetStores() {
+  useQuickCommandStore.setState({
+    global: [
+      { id: 'cmd-a', name: 'A', command: 'a' },
+      { id: 'cmd-b', name: 'B', command: 'b' },
+      { id: 'cmd-c', name: 'C', command: 'c' },
+    ],
+    byHost: {},
+    bindings: {
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+      'cmd-c': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+    },
+  })
+  useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  clearModuleRegistry()
+  registerModule({
+    id: 'quick-commands',
+    name: 'Quick Commands',
+    disableable: true,
+  })
+}
+
+describe('CommandSlot', () => {
+  beforeEach(() => resetStores())
+  afterEach(() => clearModuleRegistry())
+
+  it('renders bound commands in capability order (cmd-a then cmd-c, NOT bindings key order)', () => {
+    const exec = vi.fn().mockResolvedValue(undefined)
+    render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: 'h1', workspaceId: 'w1' }}
+        executor={exec}
+      />,
+    )
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.map((b) => b.getAttribute('aria-label'))).toEqual(
+      expect.arrayContaining([expect.stringMatching(/A/), expect.stringMatching(/C/)]),
+    )
+    // cmd-b not bound → not rendered
+    expect(screen.queryByLabelText(/^B/)).toBeNull()
+  })
+
+  it('returns null when quick-commands module is disabled (short-circuit)', () => {
+    useModuleEnabledStore.getState().setEnabled('quick-commands', false)
+    const { container } = render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: 'h1', workspaceId: 'w1' }}
+        executor={vi.fn()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('returns null when no commands are bound', () => {
+    useQuickCommandStore.setState({ bindings: {} })
+    const { container } = render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: 'h1', workspaceId: 'w1' }}
+        executor={vi.fn()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('clicking a button calls executor with (cmd, ctx)', async () => {
+    const exec = vi.fn().mockResolvedValue(undefined)
+    render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: 'h1', workspaceId: 'w1' }}
+        executor={exec}
+      />,
+    )
+    fireEvent.click(screen.getByLabelText(/^A/))
+    expect(exec).toHaveBeenCalledTimes(1)
+    expect(exec.mock.calls[0][0]).toMatchObject({ id: 'cmd-a' })
+    expect(exec.mock.calls[0][1]).toMatchObject({ hostId: 'h1', workspaceId: 'w1' })
+  })
+
+  it('supports custom render prop', () => {
+    render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: 'h1' }}
+        executor={vi.fn()}
+        render={(cmd) => <span data-testid="custom">{cmd.id}</span>}
+      />,
+    )
+    expect(screen.getAllByTestId('custom').map((n) => n.textContent)).toEqual(['cmd-a', 'cmd-c'])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/components/CommandSlot.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `<CommandSlot>`**
+
+Create `spa/src/components/CommandSlot.tsx`:
+
+```tsx
+import { useMemo, type ReactNode } from 'react'
+import { useQuickCommandStore, type QuickCommand } from '../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../stores/useModuleEnabledStore'
+import type { QuickCommandSlotId } from '../lib/quick-command-slots'
+
+export interface SlotContext {
+  hostId: string
+  workspaceId?: string | null
+  cwd?: string
+}
+
+export type SlotExecutor = (cmd: QuickCommand, ctx: SlotContext) => Promise<void>
+export type SlotRenderer = (cmd: QuickCommand, ctx: SlotContext) => ReactNode
+
+interface Props {
+  mountTo: QuickCommandSlotId
+  ctx: SlotContext
+  executor: SlotExecutor
+  render?: SlotRenderer
+}
+
+/**
+ * Renders all commands bound to `mountTo` for the current `ctx.hostId`. The
+ * Quick Commands module enable state is checked at the very top — disabling
+ * the module makes every slot vanish app-wide without consumer changes.
+ *
+ * Render order is the capability order (`getBoundCommands` iterates the
+ * stable `getCommands(hostId)` list), not `Object.keys(bindings)` — that's
+ * the spec §4.4 stability guarantee against post-sync key-order divergence.
+ */
+export function CommandSlot({ mountTo, ctx, executor, render }: Props) {
+  const enabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
+  const bindings = useQuickCommandStore((s) => s.bindings)
+  const allCmds = useQuickCommandStore((s) => s.getCommands(ctx.hostId))
+
+  // Recompute boundCmds when bindings or capability list change.
+  const boundCmds = useMemo(
+    () => allCmds.filter((c) => bindings[c.id]?.includes(mountTo)),
+    [allCmds, bindings, mountTo],
+  )
+
+  if (!enabled) return null
+  if (boundCmds.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5" role="toolbar" aria-label="Quick commands">
+      {boundCmds.map((cmd) => {
+        if (render) {
+          return (
+            <span key={cmd.id} className="inline-flex">
+              {render(cmd, ctx)}
+            </span>
+          )
+        }
+        const ariaLabel = cmd.category ? `${cmd.name} (${cmd.category})` : cmd.name
+        return (
+          <button
+            key={cmd.id}
+            type="button"
+            onClick={() => {
+              void executor(cmd, ctx)
+            }}
+            aria-label={ariaLabel}
+            title={cmd.command}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-text-secondary hover:text-text-primary hover:bg-surface-secondary cursor-pointer disabled:opacity-50"
+          >
+            <span className="truncate max-w-[12rem]">{cmd.name}</span>
+            {cmd.category && (
+              <span className="text-[10px] text-text-muted bg-surface-primary px-1.5 py-0.5 rounded">
+                {cmd.category}
+              </span>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/components/CommandSlot.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): add <CommandSlot> shared component for v2 binding model
+```
+
+---
+
+### Task 1b.2: Slot executor lib（建 session + 送 keys + 失敗 UX）
+
+**Files:**
+- Create: `spa/src/lib/slot-executor.ts`
+- Create: `spa/src/lib/slot-executor.test.ts`
+
+註：保留既有 `spa/src/lib/execute-command.ts`（v1 send-keys helper）；新檔處理 v2 的「建 session + 送 keys + 切 session + toast」一條龍。
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spa/src/lib/slot-executor.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { runWorkspaceSlot } from './slot-executor'
+import { useUndoToast } from '../stores/useUndoToast'
+
+vi.mock('./host-api', async () => {
+  const actual = await vi.importActual<typeof import('./host-api')>('./host-api')
+  return {
+    ...actual,
+    createSession: vi.fn(),
+  }
+})
+
+vi.mock('./execute-command', () => ({
+  executeCommand: vi.fn(),
+}))
+
+import { createSession } from './host-api'
+import { executeCommand } from './execute-command'
+
+describe('runWorkspaceSlot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useUndoToast.setState({ toast: null })
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('happy path — creates session, sends keys, switches focus', async () => {
+    const switchFocus = vi.fn()
+    ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      code: 'sess-1', name: 'A', cwd: '/tmp', mode: 'terminal',
+    })
+    ;(executeCommand as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+
+    await runWorkspaceSlot(
+      { id: 'cmd-a', name: 'A', command: 'echo hi' },
+      { hostId: 'h1', workspaceId: 'w1', cwd: '/tmp' },
+      { switchToSession: switchFocus },
+    )
+
+    expect(createSession).toHaveBeenCalledWith('h1', expect.any(String), '/tmp', 'terminal')
+    expect(executeCommand).toHaveBeenCalledWith('h1', 'sess-1', 'echo hi')
+    expect(switchFocus).toHaveBeenCalledWith('h1', 'sess-1')
+    expect(useUndoToast.getState().toast).toBeNull()
+  })
+
+  it('createSession failure — surfaces toast, does NOT switch focus', async () => {
+    const switchFocus = vi.fn()
+    ;(createSession as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('500 Internal'))
+
+    await runWorkspaceSlot(
+      { id: 'cmd-a', name: 'A', command: 'echo hi' },
+      { hostId: 'h1', workspaceId: 'w1' },
+      { switchToSession: switchFocus },
+    )
+
+    expect(switchFocus).not.toHaveBeenCalled()
+    expect(executeCommand).not.toHaveBeenCalled()
+    const toast = useUndoToast.getState().toast
+    expect(toast).not.toBeNull()
+    expect(toast!.message).toMatch(/Failed to start session/i)
+  })
+
+  it('send-keys failure — STILL switches focus + toast carries retry action', async () => {
+    const switchFocus = vi.fn()
+    ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      code: 'sess-1', name: 'A', cwd: '/tmp', mode: 'terminal',
+    })
+    ;(executeCommand as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('send-keys failed: 503'))
+
+    await runWorkspaceSlot(
+      { id: 'cmd-a', name: 'A', command: 'echo hi' },
+      { hostId: 'h1', workspaceId: 'w1' },
+      { switchToSession: switchFocus },
+    )
+
+    expect(switchFocus).toHaveBeenCalledWith('h1', 'sess-1')
+    const toast = useUndoToast.getState().toast
+    expect(toast).not.toBeNull()
+    expect(toast!.message).toMatch(/Session created.*command failed/i)
+    // restore = retry — calling it should trigger executeCommand again
+    ;(executeCommand as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+    toast!.restore()
+    // retry is sync invocation; await microtask
+    await Promise.resolve()
+    expect(executeCommand).toHaveBeenCalledTimes(2)
+  })
+
+  it('switchToSession failure — toast surfaced, session still listed elsewhere', async () => {
+    const switchFocus = vi.fn().mockImplementation(() => {
+      throw new Error('switch failed')
+    })
+    ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      code: 'sess-1', name: 'A', cwd: '/tmp', mode: 'terminal',
+    })
+    ;(executeCommand as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+
+    await runWorkspaceSlot(
+      { id: 'cmd-a', name: 'A', command: 'echo hi' },
+      { hostId: 'h1', workspaceId: 'w1' },
+      { switchToSession: switchFocus },
+    )
+
+    const toast = useUndoToast.getState().toast
+    expect(toast).not.toBeNull()
+    expect(toast!.message).toMatch(/Could not switch/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/lib/slot-executor.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement executor**
+
+Create `spa/src/lib/slot-executor.ts`:
+
+```ts
+import { createSession } from './host-api'
+import { executeCommand } from './execute-command'
+import { useUndoToast } from '../stores/useUndoToast'
+import { useI18nStore } from '../stores/useI18nStore'
+import type { QuickCommand } from '../stores/useQuickCommandStore'
+import type { SlotContext } from '../components/CommandSlot'
+
+interface Deps {
+  /**
+   * Switches the active tab/pane to the freshly-created session.
+   * Called after the session exists, regardless of whether send-keys
+   * succeeded — see spec §3.3 (silent orphan sessions are the worst UX).
+   */
+  switchToSession: (hostId: string, sessionCode: string) => void
+}
+
+function genSessionName(cmd: QuickCommand): string {
+  const ts = new Date().toISOString().slice(11, 19) // HH:MM:SS
+  return `${cmd.name} ${ts}`.slice(0, 64)
+}
+
+/**
+ * Workspace-slot executor:
+ *  1. POST /api/sessions (cwd: ctx.cwd ?? sane default)
+ *  2. POST /api/sessions/{code}/send-keys
+ *  3. switchToSession()
+ *
+ * Failure UX (spec §3.3):
+ *  - Step 1 fails → toast "Failed to start session: <reason>", abort.
+ *  - Step 1 ok + Step 2 fails → STILL switch focus, toast with Retry action.
+ *  - Step 1 ok + Step 2 ok + Step 3 fails (rare) → toast pointing user to
+ *    the sessions list (session is alive elsewhere).
+ *
+ * The executor is shared by Phase 1b workspace entry and Phase 1c host entry
+ * (the latter calls it with workspaceId omitted; the cwd-resolution defaults
+ * differ per slot caller, see spec §3.2 table).
+ */
+export async function runWorkspaceSlot(
+  cmd: QuickCommand,
+  ctx: SlotContext,
+  deps: Deps,
+): Promise<void> {
+  const t = useI18nStore.getState().t
+  const toast = useUndoToast.getState()
+
+  let sessionCode: string
+  try {
+    const session = await createSession(ctx.hostId, genSessionName(cmd), ctx.cwd ?? '~', 'terminal')
+    sessionCode = session.code
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    toast.show(t('quick_commands.toast.create_failed', { reason }), () => {})
+    return
+  }
+
+  try {
+    await executeCommand(ctx.hostId, sessionCode, cmd.command)
+  } catch (err) {
+    // Step 2 failed — STILL switch (so user sees the orphan), with Retry.
+    safelySwitch(ctx.hostId, sessionCode, deps, t)
+    const reason = err instanceof Error ? err.message : String(err)
+    void reason
+    toast.show(
+      t('quick_commands.toast.send_keys_failed'),
+      // retry: re-run send-keys; failures dropped (user can keep clicking).
+      () => {
+        void executeCommand(ctx.hostId, sessionCode, cmd.command).catch(() => undefined)
+      },
+    )
+    return
+  }
+
+  safelySwitch(ctx.hostId, sessionCode, deps, t)
+}
+
+function safelySwitch(
+  hostId: string,
+  sessionCode: string,
+  deps: Deps,
+  t: ReturnType<typeof useI18nStore.getState>['t'],
+): void {
+  try {
+    deps.switchToSession(hostId, sessionCode)
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    void reason
+    useUndoToast.getState().show(t('quick_commands.toast.switch_failed'), () => {})
+  }
+}
+```
+
+註（給實作者）：i18n keys 在 Task 1b.6 統一加入 zh-TW / en JSON。`createSession` 已存在於 `spa/src/lib/host-api.ts`（簽名 `(hostId, name, cwd, mode) => Promise<Session>`）。`executeCommand` 已存在於 `spa/src/lib/execute-command.ts`。`switchToSession` deps 由 caller 注入（避免 tab/workspace store 的循環相依）。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/lib/slot-executor.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): add slot-executor with three-stage failure UX (spec §3.3)
+```
+
+---
+
+### Task 1b.3: `QuickCommandsSettingsSection` — list + edit dialog + multi-select
+
+**Files:**
+- Create: `spa/src/components/settings/QuickCommandsSettingsSection.tsx`
+- Create: `spa/src/components/settings/QuickCommandsSettingsSection.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spa/src/components/settings/QuickCommandsSettingsSection.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QuickCommandsSettingsSection } from './QuickCommandsSettingsSection'
+import { useQuickCommandStore } from '../../stores/useQuickCommandStore'
+import { QUICK_COMMAND_SLOTS } from '../../lib/quick-command-slots'
+
+function resetStore() {
+  useQuickCommandStore.setState({ global: [], byHost: {}, bindings: {} })
+}
+
+describe('QuickCommandsSettingsSection', () => {
+  beforeEach(() => resetStore())
+  afterEach(() => resetStore())
+
+  it('shows empty state when no commands', () => {
+    render(<QuickCommandsSettingsSection />)
+    expect(screen.getByText(/No quick commands yet/i)).toBeInTheDocument()
+  })
+
+  it('lists commands in capability order with mount chips', () => {
+    useQuickCommandStore.setState({
+      global: [
+        { id: 'cmd-a', name: 'Alpha', command: 'a' },
+        { id: 'cmd-b', name: 'Beta', command: 'b' },
+      ],
+      byHost: {},
+      bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS] },
+    })
+    render(<QuickCommandsSettingsSection />)
+    const rows = screen.getAllByTestId(/^qc-row-/)
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveAttribute('data-testid', 'qc-row-cmd-a')
+    // cmd-a 的 mount chips 顯示 Workspace 與 Host
+    const aRow = rows[0]
+    expect(aRow.textContent).toMatch(/Workspace/)
+    expect(aRow.textContent).toMatch(/Host/)
+  })
+
+  it('clicking + New opens dialog with empty fields, focus traps inside', () => {
+    render(<QuickCommandsSettingsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /New/i }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    // First focusable inside dialog should receive focus
+    expect(document.activeElement).toBeTruthy()
+    expect(dialog.contains(document.activeElement)).toBe(true)
+  })
+
+  it('Esc closes dialog and returns focus to trigger', () => {
+    render(<QuickCommandsSettingsSection />)
+    const trigger = screen.getByRole('button', { name: /New/i })
+    fireEvent.click(trigger)
+    expect(screen.queryByRole('dialog')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('saving a new command persists to store with selected mount targets', () => {
+    render(<QuickCommandsSettingsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /New/i }))
+    fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Cmd' } })
+    fireEvent.change(screen.getByLabelText(/Command/i), { target: { value: 'echo hi' } })
+    // toggle Workspace chip
+    fireEvent.click(screen.getByRole('button', { name: /Workspace/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }))
+
+    const state = useQuickCommandStore.getState()
+    expect(state.global).toHaveLength(1)
+    const cmd = state.global[0]
+    expect(cmd.name).toBe('My Cmd')
+    expect(state.bindings[cmd.id]).toEqual([QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+  })
+
+  it('Edit existing command updates name + bindings', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'Alpha', command: 'a' }],
+      byHost: {},
+      bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+    })
+    render(<QuickCommandsSettingsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /Edit/i }))
+    fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Alpha 2' } })
+    // toggle Workspace off, Host on
+    fireEvent.click(screen.getByRole('button', { name: /Workspace/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Host/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }))
+
+    const state = useQuickCommandStore.getState()
+    expect(state.global[0].name).toBe('Alpha 2')
+    expect(state.bindings['cmd-a']).toEqual([QUICK_COMMAND_SLOTS.HOST_ACTIONS])
+  })
+
+  it('Delete removes command and clears its binding', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'Alpha', command: 'a' }],
+      byHost: {},
+      bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+    })
+    render(<QuickCommandsSettingsSection />)
+    fireEvent.click(screen.getByRole('button', { name: /Delete/i }))
+    const state = useQuickCommandStore.getState()
+    expect(state.global).toHaveLength(0)
+    expect(state.bindings['cmd-a']).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/components/settings/QuickCommandsSettingsSection.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the section**
+
+Create `spa/src/components/settings/QuickCommandsSettingsSection.tsx`:
+
+```tsx
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { Plus, PencilSimple, Trash } from '@phosphor-icons/react'
+import { useI18nStore } from '../../stores/useI18nStore'
+import { useQuickCommandStore, type QuickCommand } from '../../stores/useQuickCommandStore'
+import {
+  QUICK_COMMAND_SLOTS,
+  type QuickCommandSlotId,
+} from '../../lib/quick-command-slots'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
+
+interface Props {
+  ctx?: SettingsContextFor<'purdex'>
+}
+
+/**
+ * Quick Commands settings (purdex scope).
+ *
+ * - List: capability order via store.global (no bindings filter — Settings
+ *   shows everything user can edit).
+ * - Edit dialog: focus trap, Esc-closes-and-returns-focus, multi-select chips
+ *   for mount targets fed from QUICK_COMMAND_SLOTS.
+ * - All keystrokes go through standard inputs; Space/Enter on the chip
+ *   toggles the slot via native button semantics.
+ */
+export function QuickCommandsSettingsSection({ ctx: _ctx }: Props = {}) {
+  const t = useI18nStore((s) => s.t)
+  const commands = useQuickCommandStore((s) => s.global)
+  const bindings = useQuickCommandStore((s) => s.bindings)
+  const [editing, setEditing] = useState<QuickCommand | null>(null)
+  const [creating, setCreating] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+
+  const dialogOpen = creating || editing !== null
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg text-text-primary">{t('settings.quick_commands.title')}</h2>
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => {
+            setEditing(null)
+            setCreating(true)
+          }}
+          className="flex items-center gap-1 px-3 py-1.5 rounded text-xs text-text-primary border border-border-default hover:bg-surface-secondary cursor-pointer"
+        >
+          <Plus size={12} /> {t('settings.quick_commands.new')}
+        </button>
+      </div>
+
+      {commands.length === 0 ? (
+        <p className="text-sm text-text-muted py-8 text-center">
+          {t('settings.quick_commands.empty')}
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {commands.map((cmd) => (
+            <li
+              key={cmd.id}
+              data-testid={`qc-row-${cmd.id}`}
+              className="border border-border-subtle rounded p-3 flex items-start gap-3"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="text-sm text-text-primary">{cmd.name}</div>
+                <div className="text-xs text-text-muted truncate" title={cmd.command}>
+                  {cmd.command}
+                </div>
+                <div className="mt-1 flex gap-1 flex-wrap">
+                  {(bindings[cmd.id] ?? []).map((slot) => (
+                    <span
+                      key={slot}
+                      className="text-[10px] text-text-secondary bg-surface-secondary px-1.5 py-0.5 rounded"
+                    >
+                      {slotLabel(slot, t)}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setCreating(false)
+                  setEditing(cmd)
+                }}
+                aria-label={t('common.edit')}
+                className="p-1 text-text-muted hover:text-text-primary cursor-pointer"
+              >
+                <PencilSimple size={14} /> {t('common.edit')}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  useQuickCommandStore.getState().removeCommand(cmd.id)
+                }}
+                aria-label={t('common.delete')}
+                className="p-1 text-red-400 hover:text-red-300 cursor-pointer"
+              >
+                <Trash size={14} /> {t('common.delete')}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {dialogOpen && (
+        <EditDialog
+          initial={editing}
+          onClose={() => {
+            setCreating(false)
+            setEditing(null)
+            triggerRef.current?.focus()
+          }}
+          onSave={(cmd, targets) => {
+            // Phase 1: only global capability is editable in UI; per-host
+            // override deferred to a later phase.
+            useQuickCommandStore.getState().addCommand(cmd)
+            useQuickCommandStore.getState().setBinding(cmd.id, targets)
+            setCreating(false)
+            setEditing(null)
+            triggerRef.current?.focus()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function slotLabel(slot: QuickCommandSlotId, t: ReturnType<typeof useI18nStore.getState>['t']): string {
+  switch (slot) {
+    case QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS:
+      return t('settings.quick_commands.slot.workspace')
+    case QUICK_COMMAND_SLOTS.HOST_ACTIONS:
+      return t('settings.quick_commands.slot.host')
+    default:
+      return slot
+  }
+}
+
+interface DialogProps {
+  initial: QuickCommand | null
+  onClose: () => void
+  onSave: (cmd: QuickCommand, targets: QuickCommandSlotId[]) => void
+}
+
+function EditDialog({ initial, onClose, onSave }: DialogProps) {
+  const t = useI18nStore((s) => s.t)
+  const allBindings = useQuickCommandStore((s) => s.bindings)
+  const [name, setName] = useState(initial?.name ?? '')
+  const [command, setCommand] = useState(initial?.command ?? '')
+  const [icon, setIcon] = useState(initial?.icon ?? '')
+  const [category, setCategory] = useState(initial?.category ?? '')
+  const initialTargets = useMemo<QuickCommandSlotId[]>(
+    () => (initial ? allBindings[initial.id] ?? [] : []),
+    [initial, allBindings],
+  )
+  const [targets, setTargets] = useState<QuickCommandSlotId[]>(initialTargets)
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const firstInputRef = useRef<HTMLInputElement | null>(null)
+
+  // Focus first input on mount
+  useEffect(() => {
+    firstInputRef.current?.focus()
+  }, [])
+
+  // Esc closes
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  // Focus trap inside dialog (basic Tab cycling)
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Tab') return
+    const root = dialogRef.current
+    if (!root) return
+    const focusable = root.querySelectorAll<HTMLElement>(
+      'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])',
+    )
+    if (focusable.length === 0) return
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      last.focus()
+      e.preventDefault()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      first.focus()
+      e.preventDefault()
+    }
+  }, [])
+
+  const toggleTarget = (slot: QuickCommandSlotId) => {
+    setTargets((prev) =>
+      prev.includes(slot) ? prev.filter((s) => s !== slot) : [...prev, slot],
+    )
+  }
+
+  const handleSave = () => {
+    const trimmedName = name.trim()
+    const trimmedCmd = command.trim()
+    if (!trimmedName || !trimmedCmd) return
+    const id = initial?.id ?? `qc-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    onSave(
+      {
+        id,
+        name: trimmedName,
+        command: trimmedCmd,
+        icon: icon.trim() || undefined,
+        category: category.trim() || undefined,
+      },
+      targets,
+    )
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t(initial ? 'settings.quick_commands.edit' : 'settings.quick_commands.new')}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onKeyDown={onKeyDown}
+    >
+      <div ref={dialogRef} className="w-[480px] bg-surface-primary border border-border-default rounded-lg p-4 space-y-3">
+        <h3 className="text-sm font-semibold">
+          {t(initial ? 'settings.quick_commands.edit' : 'settings.quick_commands.new')}
+        </h3>
+
+        <label className="block text-xs text-text-secondary">
+          {t('settings.quick_commands.name')}
+          <input
+            ref={firstInputRef}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full mt-1 bg-surface-input border border-border-default rounded px-2 py-1 text-sm text-text-primary"
+          />
+        </label>
+
+        <label className="block text-xs text-text-secondary">
+          {t('settings.quick_commands.command')}
+          <textarea
+            value={command}
+            onChange={(e) => setCommand(e.target.value)}
+            rows={3}
+            className="w-full mt-1 bg-surface-input border border-border-default rounded px-2 py-1 text-sm font-mono text-text-primary"
+          />
+        </label>
+
+        <div className="grid grid-cols-2 gap-2">
+          <label className="block text-xs text-text-secondary">
+            {t('settings.quick_commands.icon')}
+            <input
+              value={icon}
+              onChange={(e) => setIcon(e.target.value)}
+              className="w-full mt-1 bg-surface-input border border-border-default rounded px-2 py-1 text-sm text-text-primary"
+            />
+          </label>
+          <label className="block text-xs text-text-secondary">
+            {t('settings.quick_commands.category')}
+            <input
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full mt-1 bg-surface-input border border-border-default rounded px-2 py-1 text-sm text-text-primary"
+            />
+          </label>
+        </div>
+
+        <fieldset className="border-t border-border-subtle pt-3">
+          <legend className="text-xs text-text-secondary px-1">
+            {t('settings.quick_commands.mount')}
+          </legend>
+          <div className="flex gap-2 mt-1 flex-wrap">
+            {(Object.values(QUICK_COMMAND_SLOTS) as QuickCommandSlotId[]).map((slot) => {
+              const active = targets.includes(slot)
+              return (
+                <button
+                  key={slot}
+                  type="button"
+                  onClick={() => toggleTarget(slot)}
+                  aria-pressed={active}
+                  className={`px-2 py-1 text-xs rounded border cursor-pointer ${
+                    active
+                      ? 'bg-purple-500/20 text-text-primary border-purple-400'
+                      : 'border-border-default text-text-secondary hover:text-text-primary'
+                  }`}
+                >
+                  {slotLabel(slot, t)}
+                </button>
+              )
+            })}
+          </div>
+        </fieldset>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs text-text-secondary border border-border-default rounded cursor-pointer hover:text-text-primary"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            className="px-3 py-1.5 text-xs text-white bg-purple-500 rounded cursor-pointer hover:bg-purple-400"
+          >
+            {t('common.save')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/components/settings/QuickCommandsSettingsSection.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): add Quick Commands settings section (list + edit dialog + chips)
+```
+
+---
+
+### Task 1b.4: 補上 settings contribution + i18n keys
+
+**Files:**
+- Modify: `spa/src/lib/register-modules.tsx`
+- Modify: `spa/src/locales/zh-TW.json`
+- Modify: `spa/src/locales/en.json`
+- Modify: `spa/src/lib/register-modules.quick-commands.test.tsx`
+
+- [ ] **Step 1: Update test to assert settings contribution exists**
+
+Edit `spa/src/lib/register-modules.quick-commands.test.tsx` — replace the「Phase 1a: NO settings」test:
+
+```tsx
+  it('Phase 1b: quick-commands declares purdex-scope settings contribution', () => {
+    registerBuiltinModules()
+    const m = getModule('quick-commands')
+    const settings = m!.settings ?? []
+    expect(settings).toHaveLength(1)
+    expect(settings[0]).toMatchObject({
+      localId: 'quick-commands',
+      scope: 'purdex',
+      labelKey: 'settings.section.quick_commands',
+    })
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/lib/register-modules.quick-commands.test.tsx`
+Expected: FAIL — settings array is empty.
+
+- [ ] **Step 3: Wire settings + import section + i18n**
+
+In `spa/src/lib/register-modules.tsx`, add import alongside the existing settings imports:
+
+```tsx
+import { QuickCommandsSettingsSection } from '../components/settings/QuickCommandsSettingsSection'
+```
+
+Update the `quick-commands` registration to include `settings`:
+
+```tsx
+  registerModule({
+    id: 'quick-commands',
+    name: 'Quick Commands',
+    disableable: true,
+    descriptionKey: 'modules.quick_commands.description',
+    settings: [
+      {
+        localId: 'quick-commands',
+        scope: 'purdex',
+        order: 10, // 介於 editor (9) 與 sync (11) 之間，排在 module-config (8) 之後
+        labelKey: 'settings.section.quick_commands',
+        component: QuickCommandsSettingsSection,
+      },
+    ],
+  })
+```
+
+In `spa/src/locales/zh-TW.json` 加入：
+
+```json
+  "settings.section.quick_commands": "快速指令",
+  "settings.quick_commands.title": "快速指令",
+  "settings.quick_commands.new": "新增",
+  "settings.quick_commands.edit": "編輯快速指令",
+  "settings.quick_commands.empty": "尚無快速指令 — 點選右上角「新增」開始建立。",
+  "settings.quick_commands.name": "名稱",
+  "settings.quick_commands.command": "指令",
+  "settings.quick_commands.icon": "圖示（Phosphor 名稱，可省略）",
+  "settings.quick_commands.category": "分類（可省略）",
+  "settings.quick_commands.mount": "掛載位置",
+  "settings.quick_commands.slot.workspace": "Workspace",
+  "settings.quick_commands.slot.host": "Host",
+  "common.edit": "編輯",
+  "quick_commands.toast.create_failed": "無法建立 session：{{reason}}",
+  "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。",
+  "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。",
+```
+
+In `spa/src/locales/en.json` 對應加入：
+
+```json
+  "settings.section.quick_commands": "Quick Commands",
+  "settings.quick_commands.title": "Quick Commands",
+  "settings.quick_commands.new": "New",
+  "settings.quick_commands.edit": "Edit Quick Command",
+  "settings.quick_commands.empty": "No quick commands yet — Start by creating one.",
+  "settings.quick_commands.name": "Name",
+  "settings.quick_commands.command": "Command",
+  "settings.quick_commands.icon": "Icon (Phosphor name, optional)",
+  "settings.quick_commands.category": "Category (optional)",
+  "settings.quick_commands.mount": "Mount targets",
+  "settings.quick_commands.slot.workspace": "Workspace",
+  "settings.quick_commands.slot.host": "Host",
+  "common.edit": "Edit",
+  "quick_commands.toast.create_failed": "Failed to start session: {{reason}}",
+  "quick_commands.toast.send_keys_failed": "Session created, but command failed.",
+  "quick_commands.toast.switch_failed": "Created and sent, but could not switch focus; check the sessions list.",
+```
+
+註：若 `common.edit` 已存在，跳過該行。檢查指令：`grep '"common.edit"' spa/src/locales/zh-TW.json`。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/lib/register-modules.quick-commands.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): wire Quick Commands settings contribution + i18n keys
+```
+
+---
+
+### Task 1b.5: Workspace 入口 — 在 NewTabPage 顯示 quick actions（spec §4.2）
+
+**Files:**
+- Modify: `spa/src/components/NewTabPage.tsx`
+- Modify: `spa/src/components/NewTabPage.test.tsx`（若存在；否則新建 quick-actions-only test 檔）
+
+實作策略：在 NewTabPage 主格線**之上**加一條 `<CommandSlot mountTo={WORKSPACE_ACTIONS}>` toolbar。為什麼選 NewTabPage：
+
+1. NewTabPage 是 user 進到 workspace 後最常見的入口（每次新 tab 都在這），spec §4.2「workspace 主面板」最自然的對應。
+2. 已具有 hostId / activeWorkspaceId 取用路徑（透過 store）。
+3. 不破壞既有 PaneLayoutRenderer 的 v1 `QuickCommandMenu`（保留，不動）。
+
+替代方案候選（若 reviewer 反對放 NewTabPage，請討論後選一）：
+
+- 候選 A：`WorkspaceSettingsPage` 標題下方（user 開設定才看得到，過深）
+- 候選 B：`InlineTabList` / `WorkspaceRow` 同列 hover 顯示（過小、易誤觸）
+- **候選 C（採用）**：`NewTabPage` 頂部 toolbar，empty / pinned-only 兩種畫面都一致
+
+- [ ] **Step 1: Write the failing test**
+
+Create or extend `spa/src/components/NewTabPage.test.tsx`：
+
+```tsx
+// 在既有 imports 末尾加：
+import { useQuickCommandStore } from '../stores/useQuickCommandStore'
+import { useHostStore } from '../stores/useHostStore'
+import { useWorkspaceStore } from '../features/workspace/store'
+import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
+
+describe('NewTabPage — workspace quick actions slot (Phase 1b)', () => {
+  it('renders <CommandSlot mountTo=WORKSPACE_ACTIONS> with active hostId + workspaceId', () => {
+    // 設置 host + workspace + bind 一個 cmd 至 WORKSPACE_ACTIONS
+    useHostStore.setState({ activeHostId: 'h1', hostOrder: ['h1'] })
+    useWorkspaceStore.setState({ activeWorkspaceId: 'w1' })
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'Alpha', command: 'echo' }],
+      byHost: {},
+      bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+    })
+    render(<NewTabPage onSelect={() => undefined} />)
+    expect(screen.getByLabelText(/^Alpha/)).toBeInTheDocument()
+  })
+
+  it('hides slot toolbar when no commands are bound', () => {
+    useQuickCommandStore.setState({ global: [], byHost: {}, bindings: {} })
+    render(<NewTabPage onSelect={() => undefined} />)
+    expect(screen.queryByRole('toolbar', { name: /Quick commands/i })).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/components/NewTabPage.test.tsx`
+Expected: FAIL — slot 未掛載。
+
+- [ ] **Step 3: Implement workspace entry**
+
+In `spa/src/components/NewTabPage.tsx`：
+
+加 import：
+
+```tsx
+import { CommandSlot } from './CommandSlot'
+import { runWorkspaceSlot } from '../lib/slot-executor'
+import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
+import { useHostStore } from '../stores/useHostStore'
+import { useWorkspaceStore } from '../features/workspace/store'
+import { useTabStore } from '../stores/useTabStore'
+```
+
+在 `return (...)` 主 grid container **外層**包一個 flex column；slot toolbar 在 grid 之前：
+
+```tsx
+  const activeHostId = useHostStore((s) => s.activeHostId)
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
+
+  // ... 原 hydration / providers 邏輯不變
+  // (直到 return)
+
+  return (
+    <div className="flex-1 flex flex-col">
+      {activeHostId && (
+        <div className="px-6 pt-4">
+          <CommandSlot
+            mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+            ctx={{ hostId: activeHostId, workspaceId: activeWorkspaceId }}
+            executor={(cmd, ctx) =>
+              runWorkspaceSlot(cmd, ctx, {
+                switchToSession: (hostId, sessionCode) => {
+                  useTabStore.getState().openSingletonTab({
+                    kind: 'tmux-session',
+                    hostId,
+                    sessionCode,
+                  })
+                },
+              })
+            }
+          />
+        </div>
+      )}
+      <div className={`flex-1 grid overflow-hidden gap-6 px-6 pt-8 ${gridCols}`}>
+        {/* … 原 columns 渲染 … */}
+      </div>
+    </div>
+  )
+```
+
+註：`openSingletonTab` 已存在於 `useTabStore`（既有 terminal-link skill 用過此 path，見 `register-modules.tsx` L429）。如果 PaneContent type 對 `tmux-session` 必填欄位不同，請查 `spa/src/types/tab.ts` 並補。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/components/NewTabPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): mount WORKSPACE_ACTIONS slot in NewTabPage header
+```
+
+---
+
+### Task 1b.6: Phase 1b 全域驗證
+
+- [ ] **Step 1: Run all SPA tests**
+
+Run: `cd spa && npx vitest run`
+Expected: all pass
+
+- [ ] **Step 2: Run SPA lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: clean
+
+- [ ] **Step 3: Run SPA build**
+
+Run: `cd spa && pnpm run build`
+Expected: clean
+
+- [ ] **Step 4: Run all Go tests**
+
+Run: `go test ./...`
+Expected: all pass
+
+- [ ] **Step 5: Go build**
+
+Run: `go build ./...`
+Expected: clean
+
+- [ ] **Step 6: 手動冒煙（review reviewer 自行操作）**
+
+啟動 daemon + dev SPA，user flow：
+1. Settings → Quick Commands → New → 輸入 Name + Command + 勾 Workspace → Save
+2. 開新 tab，看到 toolbar 出現按鈕
+3. 點按鈕 → 建 session、送 cmd、自動切到該 session
+4. 模擬失敗（停 daemon → 點按鈕 → 應有 toast）
+
+### Phase 1b 驗收清單
+
+- [x] Settings 頁面可建 / 編 / 刪 commands；mount chips 可多選
+- [x] 對話框 a11y：focus trap / Esc / aria-label / 觸發鍵盤可達
+- [x] 設 mount = WORKSPACE 後，回 NewTabPage 立即看到按鈕（無需 reload）
+- [x] 點擊按鈕：建 session + 送 keys + 切過去
+- [x] 三層失敗 UX 符合 spec §3.3：建失敗 / 送 keys 失敗仍切過去 + retry / 切失敗 toast
+- [x] 停用 quick-commands module → slot 立即消失（CommandSlot short-circuit）
+- [x] i18n: zh-TW + en 全部 key 齊全（`pnpm run lint` 含 locale-completeness 檢查）
+
+---
+
+## Phase 1c — HOST_ACTIONS 入口（小 PR）
+
+**目標：** Host 詳情頁加 quick actions 區塊；user 設 mount = HOST 即可在 host 頁看到按鈕。
+
+### Task 1c.1: Host 詳情頁加 `<CommandSlot mountTo=HOST_ACTIONS>`
+
+**Files:**
+- Modify: `spa/src/components/hosts/OverviewSection.tsx`
+- Modify: `spa/src/components/hosts/OverviewSection.test.tsx`
+
+實作位置：`OverviewSection` 是 host 詳情的第一個 section，user 進 host 頁預設看到。在主標題 / 連線狀態列**之下**加一條 `<CommandSlot>` toolbar。HostSidebar 之外的容器是 `HostPage` 的 `<div className="flex-1 overflow-y-auto p-6">`，OverviewSection 直接渲染進去。
+
+替代方案候選（若 reviewer 想放在更外層）：
+
+- 候選 A（採用）：`OverviewSection` 標題下方，user 多半從 sidebar 進來都先停在 overview
+- 候選 B：`HostPage` 上方共通容器（強制每個 host sub-page 都看到，但會干擾 sessions / agents 的本身排版）
+
+- [ ] **Step 1: Write the failing test**
+
+In `spa/src/components/hosts/OverviewSection.test.tsx` 加一段（或新建測試檔，視既有 OverviewSection.test 的 setup 而定）：
+
+```tsx
+import { useQuickCommandStore } from '../../stores/useQuickCommandStore'
+import { QUICK_COMMAND_SLOTS } from '../../lib/quick-command-slots'
+
+describe('OverviewSection — host quick actions slot (Phase 1c)', () => {
+  it('renders <CommandSlot mountTo=HOST_ACTIONS> with given hostId', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-h', name: 'HostCmd', command: 'echo h' }],
+      byHost: {},
+      bindings: { 'cmd-h': [QUICK_COMMAND_SLOTS.HOST_ACTIONS] },
+    })
+    // (preserve existing host store setup)
+    useHostStore.setState({
+      hosts: { 'h1': { id: 'h1', name: 'Mini', /* … */ } as never },
+      hostOrder: ['h1'],
+      runtime: { 'h1': { status: 'connected' } as never },
+    })
+    render(<OverviewSection hostId="h1" />)
+    expect(screen.getByLabelText(/^HostCmd/)).toBeInTheDocument()
+  })
+
+  it('hides slot when no commands are bound to HOST_ACTIONS', () => {
+    useQuickCommandStore.setState({ global: [], byHost: {}, bindings: {} })
+    render(<OverviewSection hostId="h1" />)
+    expect(screen.queryByLabelText(/^HostCmd/)).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/components/hosts/OverviewSection.test.tsx`
+Expected: FAIL — slot 未掛載。
+
+- [ ] **Step 3: Mount the slot**
+
+In `spa/src/components/hosts/OverviewSection.tsx`：
+
+加 imports：
+
+```tsx
+import { CommandSlot } from '../CommandSlot'
+import { runWorkspaceSlot } from '../../lib/slot-executor'
+import { QUICK_COMMAND_SLOTS } from '../../lib/quick-command-slots'
+import { useTabStore } from '../../stores/useTabStore'
+```
+
+在 OverviewSection JSX root 的開頭區塊加（host 名稱 / status 區塊**之後**）：
+
+```tsx
+<CommandSlot
+  mountTo={QUICK_COMMAND_SLOTS.HOST_ACTIONS}
+  ctx={{ hostId }}
+  executor={(cmd, ctx) =>
+    runWorkspaceSlot(cmd, ctx, {
+      switchToSession: (h, sessionCode) => {
+        useTabStore.getState().openSingletonTab({
+          kind: 'tmux-session',
+          hostId: h,
+          sessionCode,
+        })
+      },
+    })
+  }
+/>
+```
+
+註：HOST_ACTIONS slot 和 WORKSPACE_ACTIONS 共用同一個 `runWorkspaceSlot`（spec §3.2 兩列行為差只在 cwd 取值來源；Phase 1 兩者都 fallback 到 host default `~`，所以 helper 命名雖叫 `runWorkspaceSlot` 仍正確；Phase 2 若 cwd 取值要分流再拆）。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/components/hosts/OverviewSection.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): mount HOST_ACTIONS slot in host overview section
+```
+
+---
+
+### Task 1c.2: Phase 1c 全域驗證
+
+- [ ] **Step 1: Run all SPA tests**
+
+Run: `cd spa && npx vitest run`
+Expected: all pass
+
+- [ ] **Step 2: Run SPA lint**
+
+Run: `cd spa && pnpm run lint`
+Expected: clean
+
+- [ ] **Step 3: Run SPA build**
+
+Run: `cd spa && pnpm run build`
+Expected: clean
+
+- [ ] **Step 4: Run all Go tests**
+
+Run: `go test ./...`
+Expected: all pass
+
+- [ ] **Step 5: Go build**
+
+Run: `go build ./...`
+Expected: clean
+
+### Phase 1c 驗收清單
+
+- [x] User 能在 Settings 設 mount = HOST，並在 host 詳情 overview 看到按鈕
+- [x] 按鈕點擊：建 session（cwd 取 host default）+ 送 cmd + 切過去
+- [x] HOST_ACTIONS slot 與 WORKSPACE_ACTIONS slot 共存無衝突（兩者都可同時 mount）
+
+---
+
+## Phase 完成順序檢查清單（送 reviewer 前確認）
+
+- [ ] Phase 1a 已 merge → main，且 alpha bump 完成（或一個 PR sequence 規劃中）
+- [ ] Phase 1b 已 merge → main，**Settings UI 與 WORKSPACE_ACTIONS 入口同 PR**（不可拆兩 PR）
+- [ ] Phase 1c 已 merge → main
+- [ ] Phase 1a 不可單獨 ship 在沒有 Phase 1b 計畫的情況（純資料層 user 看不到任何成果，會困惑）— 但 1a + 1b 兩個 PR 接力 ship 是允許的（spec §6 只要求 Settings UI 出現時必有 slot 生效）
+
+## 範圍邊界（Phase 1 不做）
+
+- 不動 `PaneLayoutRenderer` 內 `extraActions` 的 v1 `QuickCommandMenu`（spec §3.4）
+- 不動 `SessionsSection` row actions 的 v1 `QuickCommandMenu`（spec §3.4）
+- 不做 per-host bindings UI（store 支援，UI 推到 Phase 2）
+- 不做 mode 設定 / 動態 function command / command palette / 快捷鍵（spec §6 不在範圍）
+- 不做 `module-registry.commands?` legacy 收編（Phase 2 decision gate，spec §8.2）
+- 不寫 persist migration（alpha-no-migration）
+
+---
+
+## Sub-skill / Subagent 提示
+
+執行此 plan 時：
+
+1. 進 worktree 後，**每個 Bash 指令必須以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/quick-commands-v2 && ` 開頭**（feedback_subagent_cwd_enforcement.md）
+2. 一個 task 一個 commit，commit message 用 conventional commit + Co-Authored-By trailer
+3. zustand test setState **顯式列出** `global` / `byHost` / `bindings` 三個 mutable fields；**不要**只寫 `setState({ bindings: {...} })`，會 wipe 其他 state（feedback_zustand_harness_setstate.md）
+4. 任何測試 / lint / build 指令在主 Claude 機器跑（feedback_codex_sandbox_no_install.md）
+5. PR 完成後委派 codex 兩輪 review（標準 + 攻擊/防守/體質）；發現問題彙整成表格（信心 / 關聯 / 複雜度）後決定即修 vs 開 issue 追蹤

--- a/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
+++ b/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
@@ -26,6 +26,7 @@
 - **Host 入口** — `SessionsSection.tsx` 兩件事：
   - new-session 按鈕（L167-174）旁並列 `<CommandSlot mountTo=HOST_ACTIONS>`；視覺與 Plus 對齊（直接列 chip，無 popover）
   - 移除 row 上的 v1 `<QuickCommandMenu>`（L231-239）整合，但**保留** `QuickCommandMenu` 元件本身（`PaneLayoutRenderer.tsx` 仍使用）
+- **Workspace hostId 解析（spec v4 §3.2.1 / §3.2.2）** — Workspace type 沒有 `hostId` 欄位，採**多數決**（`inferWorkspaceHostId(workspace, tabs)`，遍歷 workspace.tabs 的 layout tree 蒐集 `kind: 'tmux-session'` 的 hostId，多數決 + tie-break）。多數決回 `null`（workspace 無 tmux-session tabs）時，**不**靜默 fallback 到 `activeHostId`，改開 `HostPickerPopover` 讓 user 選 host；取消 popover → no-op。`SlotContext.hostId` 改為 `string | null`，executor 透過 `resolveHostId` callback 在內部 await user 決定。
 
 **測試指令備忘（主 Claude 機器跑，subagent 寫 plan 不執行）：**
 - SPA test: `cd spa && npx vitest run`
@@ -810,15 +811,600 @@ Expected: clean
 
 **目標：** user 能在 Settings 建 command + 設 mount = WORKSPACE，回到 workspace 立刻看到按鈕；點擊建 session + 送 keys + 切過去。失敗 toast 行為符合 §3.3。
 
+**Spec v4 新增的支援結構：** Phase 1b 兩個 helper（`inferWorkspaceHostId` + `HostPickerPopover`）必須先於 `<CommandSlot>` / executor / workspace 入口落地，否則後續 task 無法正確呼叫。順序：1b.0a → 1b.0b → 1b.1 → 1b.1.5 → 1b.2 → 1b.3 → 1b.4 → 1b.5a → 1b.5b → 1b.6。
+
+### Task 1b.0a: 新增 `inferWorkspaceHostId` helper（spec §3.2.1 多數決）
+
+**Files:**
+- Create: `spa/src/lib/infer-workspace-host-id.ts`
+- Create: `spa/src/lib/infer-workspace-host-id.test.ts`
+
+**動機：** `WORKSPACE_ACTIONS` slot 的 ctx 需要 hostId，但 `Workspace` type 沒有此欄位（`spa/src/types/tab.ts` L53-61 確認）。spec §3.2.1 規定以 workspace 內所有 tab `PaneLayout` tree 的 `tmux-session` panes 的 hostId 多數決決定。Phase 1b 後續的 CommandSlot ctx、context menu、popover、executor 全部依此 helper 取 hostId。
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spa/src/lib/infer-workspace-host-id.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { inferWorkspaceHostId } from './infer-workspace-host-id'
+import type { Tab, Workspace, PaneLayout } from '../types/tab'
+
+function leaf(content: PaneLayout extends infer T ? T : never): PaneLayout {
+  return content as PaneLayout
+}
+
+function tmuxLeaf(hostId: string, sessionCode = 'sess'): PaneLayout {
+  return {
+    type: 'leaf',
+    pane: {
+      id: `pane-${hostId}-${sessionCode}`,
+      content: {
+        kind: 'tmux-session',
+        hostId,
+        sessionCode,
+        mode: 'terminal',
+        cachedName: 'x',
+        tmuxInstance: 'default',
+      },
+    },
+  }
+}
+
+function newTabLeaf(): PaneLayout {
+  return { type: 'leaf', pane: { id: 'p-newtab', content: { kind: 'new-tab' } } }
+}
+
+function splitH(...children: PaneLayout[]): PaneLayout {
+  return { type: 'split', id: 's', direction: 'h', children, sizes: children.map(() => 1 / children.length) }
+}
+
+function tab(id: string, layout: PaneLayout): Tab {
+  return { id, pinned: false, locked: false, createdAt: 0, layout }
+}
+
+function ws(opts: { id?: string; tabs: string[]; activeTabId?: string | null }): Workspace {
+  return {
+    id: opts.id ?? 'w1',
+    name: 'W',
+    tabs: opts.tabs,
+    activeTabId: opts.activeTabId ?? null,
+    moduleConfig: {},
+  }
+}
+
+describe('inferWorkspaceHostId', () => {
+  it('returns the hostId of a single tmux-session tab', () => {
+    const tabs = { t1: tab('t1', tmuxLeaf('h1')) }
+    const w = ws({ tabs: ['t1'], activeTabId: 't1' })
+    expect(inferWorkspaceHostId(w, tabs)).toBe('h1')
+  })
+
+  it('returns the only candidate when multiple tabs share the same host', () => {
+    const tabs = {
+      t1: tab('t1', tmuxLeaf('h1')),
+      t2: tab('t2', tmuxLeaf('h1')),
+      t3: tab('t3', tmuxLeaf('h1')),
+    }
+    const w = ws({ tabs: ['t1', 't2', 't3'], activeTabId: 't1' })
+    expect(inferWorkspaceHostId(w, tabs)).toBe('h1')
+  })
+
+  it('returns the majority host when one host clearly dominates', () => {
+    const tabs = {
+      t1: tab('t1', tmuxLeaf('h1')),
+      t2: tab('t2', tmuxLeaf('h1')),
+      t3: tab('t3', tmuxLeaf('h2')),
+    }
+    const w = ws({ tabs: ['t1', 't2', 't3'], activeTabId: 't3' })
+    expect(inferWorkspaceHostId(w, tabs)).toBe('h1')
+  })
+
+  it('on tie, prefers the active tab hostId when active is tmux-session and in the winners set', () => {
+    const tabs = {
+      t1: tab('t1', tmuxLeaf('h1')),
+      t2: tab('t2', tmuxLeaf('h2')),
+    }
+    const w = ws({ tabs: ['t1', 't2'], activeTabId: 't2' })
+    expect(inferWorkspaceHostId(w, tabs)).toBe('h2')
+  })
+
+  it('on tie, falls back to first winner in tabs order when active tab host is NOT in winners', () => {
+    // active tab is tmux-session h3 (not a winner among h1/h2 tied)
+    const tabs = {
+      t1: tab('t1', tmuxLeaf('h1')),
+      t2: tab('t2', tmuxLeaf('h2')),
+      t3: tab('t3', tmuxLeaf('h3')),
+    }
+    // Force a tie between h1 and h2 by adding a duplicate h2 layer in t2
+    const tabsTie = {
+      t1: tab('t1', tmuxLeaf('h1')),
+      t2: tab('t2', splitH(tmuxLeaf('h2'), tmuxLeaf('h1'))), // h1=2, h2=1
+      t3: tab('t3', tmuxLeaf('h2')),                          // overall: h1=2, h2=2
+    }
+    const w = ws({ tabs: ['t1', 't2', 't3'], activeTabId: 't3' })
+    // active tab t3 is h2 — h2 IS in winners → expect h2
+    expect(inferWorkspaceHostId(w, tabsTie)).toBe('h2')
+    // Now make active tab a non-tmux tab → should fall back to first-winner-in-tabs-order
+    const tabsTieActiveNonTmux = {
+      ...tabsTie,
+      t3: tab('t3', newTabLeaf()), // active tab no longer tmux
+    }
+    const w2 = ws({ tabs: ['t1', 't2', 't3'], activeTabId: 't3' })
+    // Now h1=2, h2=1 (tabsTieActiveNonTmux: t1 has h1, t2 has [h2,h1], t3 has nothing)
+    // → h1 wins outright (count=2 vs h2=1), no tie. Adjust the fixture for the intended assertion:
+    void w2
+    // Use a clean tie + non-tmux active tab fixture:
+    const cleanTie = {
+      t1: tab('t1', tmuxLeaf('h1')),
+      t2: tab('t2', tmuxLeaf('h2')),
+      t3: tab('t3', newTabLeaf()),
+    }
+    const w3 = ws({ tabs: ['t1', 't2', 't3'], activeTabId: 't3' })
+    expect(inferWorkspaceHostId(w3, cleanTie)).toBe('h1')
+  })
+
+  it('returns null when workspace has no tmux-session tabs', () => {
+    const tabs = {
+      t1: tab('t1', newTabLeaf()),
+      t2: tab('t2', { type: 'leaf', pane: { id: 'p2', content: { kind: 'dashboard' } } }),
+    }
+    const w = ws({ tabs: ['t1', 't2'], activeTabId: 't1' })
+    expect(inferWorkspaceHostId(w, tabs)).toBeNull()
+  })
+
+  it('returns null when workspace.tabs is empty', () => {
+    const w = ws({ tabs: [], activeTabId: null })
+    expect(inferWorkspaceHostId(w, {})).toBeNull()
+  })
+
+  it('skips missing tab ids that are not present in the tabs map', () => {
+    const tabs = { t1: tab('t1', tmuxLeaf('h1')) }
+    const w = ws({ tabs: ['t1', 't-missing'], activeTabId: 't1' })
+    expect(inferWorkspaceHostId(w, tabs)).toBe('h1')
+  })
+
+  it('recursively collects hostIds from nested split layouts', () => {
+    const tabs = {
+      t1: tab('t1', splitH(tmuxLeaf('h1'), splitH(tmuxLeaf('h1'), tmuxLeaf('h2')))),
+    }
+    const w = ws({ tabs: ['t1'], activeTabId: 't1' })
+    // h1 count=2, h2 count=1 → h1 wins
+    expect(inferWorkspaceHostId(w, tabs)).toBe('h1')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/lib/infer-workspace-host-id.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement helper**
+
+Create `spa/src/lib/infer-workspace-host-id.ts` (內容直接對應 spec §3.2.1 程式片段，注意實際型別名是 `PaneLayout` 而非 `Layout`)：
+
+```ts
+import type { PaneLayout, Tab, Workspace } from '../types/tab'
+
+/**
+ * Recursively walks a PaneLayout tree, collecting hostIds from every
+ * pane whose content is `kind: 'tmux-session'`. Order matches
+ * pre-order traversal of the layout tree (left-to-right children).
+ */
+export function collectTmuxSessionHostIds(layout: PaneLayout): string[] {
+  if (layout.type === 'leaf') {
+    return layout.pane.content.kind === 'tmux-session'
+      ? [layout.pane.content.hostId]
+      : []
+  }
+  return layout.children.flatMap(collectTmuxSessionHostIds)
+}
+
+/**
+ * Infer the "primary" hostId for a Workspace based on its tabs (spec §3.2.1).
+ *
+ *  1. Collect hostIds from every tmux-session pane across all tabs.
+ *  2. Majority vote (highest count wins).
+ *  3. Tie-break A: if `workspace.activeTabId` resolves to a tmux-session whose
+ *     hostId is among the winners, prefer it.
+ *  4. Tie-break B: otherwise, scan `workspace.tabs` in order and return the
+ *     first hostId that appears in the winners set.
+ *  5. Returns `null` when no tmux-session pane is found anywhere — caller
+ *     MUST treat this as "host unknown" and surface the host picker (see
+ *     spec §3.2.2 / §4.4 HostPickerPopover).
+ *
+ * Critically: this MUST NOT silently fall back to `useHostStore.activeHostId`
+ * for the null case — that would risk sending keys to the wrong host.
+ */
+export function inferWorkspaceHostId(
+  workspace: Workspace,
+  tabs: Record<string, Tab>,
+): string | null {
+  const candidates = workspace.tabs
+    .map((tabId) => tabs[tabId])
+    .filter((t): t is Tab => !!t)
+    .flatMap((t) => collectTmuxSessionHostIds(t.layout))
+
+  if (candidates.length === 0) return null
+
+  const counts = new Map<string, number>()
+  for (const h of candidates) counts.set(h, (counts.get(h) ?? 0) + 1)
+  const max = Math.max(...counts.values())
+  const winners = [...counts.entries()].filter(([, c]) => c === max).map(([h]) => h)
+  if (winners.length === 1) return winners[0]
+
+  // Tie-break A: active tab's hostId if it is a tmux-session and is among winners.
+  if (workspace.activeTabId) {
+    const activeTab = tabs[workspace.activeTabId]
+    if (activeTab) {
+      const activeHosts = collectTmuxSessionHostIds(activeTab.layout)
+      const winner = activeHosts.find((h) => winners.includes(h))
+      if (winner) return winner
+    }
+  }
+
+  // Tie-break B: first winner in tabs order.
+  for (const tabId of workspace.tabs) {
+    const t = tabs[tabId]
+    if (!t) continue
+    const hosts = collectTmuxSessionHostIds(t.layout)
+    const first = hosts.find((h) => winners.includes(h))
+    if (first) return first
+  }
+  return winners[0] // theoretically unreachable
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/lib/infer-workspace-host-id.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): add inferWorkspaceHostId — majority-vote host resolution for workspace slots
+```
+
+---
+
+### Task 1b.0b: 新增 `HostPickerPopover` 共用元件（spec §3.2.2 / §4.4）
+
+**Files:**
+- Create: `spa/src/components/HostPickerPopover.tsx`
+- Create: `spa/src/components/HostPickerPopover.test.tsx`
+
+**動機：** spec §3.2.2 規定 workspace hostId 為 null 時不可靜默 fallback；改開 host picker 讓 user 主動選 host。spec §3.5 forward-compat：未來 multi-host workspace binding 系統也用同一個 popover。本 task 為**獨立可重用元件**，不耦合 quick commands store。
+
+**API：**
+```tsx
+interface Props {
+  open: boolean
+  anchor: { x: number; y: number } | HTMLElement | null
+  onSelect: (hostId: string) => void
+  onCancel: () => void
+}
+```
+
+**內部資料來源：** 直接讀 `useHostStore.hostOrder` + `useHostStore.hosts` + `useHostStore.runtime` 列出 hosts；每列顯示 host name + online/offline 點（透過 `runtime[hostId]?.status === 'connected'` 判斷）。
+
+**a11y / UX 規格：**
+- 開啟時 focus 第一個可選項（若 hostOrder 空，focus dialog 容器 / show empty 狀態）
+- 上下方向鍵移動 active item，Enter 觸發 `onSelect`
+- Esc 觸發 `onCancel`（不送任何 hostId）
+- focus trap：Tab / Shift+Tab 在 popover 內循環
+- 關閉時 focus 回 trigger（caller 透過 `onCancel`/`onSelect` 後恢復 — popover 自身不持有 trigger ref；caller 負責）
+- 樣式：與既有 popover 一致（`bg-surface-secondary`、`border-border-default`、`shadow-lg`，無自訂顏色）
+- offline host 仍可點選（不 disable），但 row 上加警示 chip（例如 `text-text-muted` + 「offline」標籤）；user 可能就是要切到 offline host 去看其他內容
+- 空 `hostOrder` 顯示空狀態文字「No hosts available」
+
+**anchor 處理：** 若 `anchor` 是 `{x,y}` → 以 fixed 定位；若是 HTMLElement → `getBoundingClientRect()` 計算位置，popover 出現在 anchor 元素旁邊。
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spa/src/components/HostPickerPopover.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { HostPickerPopover } from './HostPickerPopover'
+import { useHostStore } from '../stores/useHostStore'
+
+function setHosts() {
+  useHostStore.setState({
+    hosts: {
+      h1: { id: 'h1', name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 },
+      h2: { id: 'h2', name: 'air', ip: '100.64.0.1', port: 7860, order: 1 },
+    },
+    hostOrder: ['h1', 'h2'],
+    runtime: {
+      h1: { status: 'connected' },
+      h2: { status: 'disconnected' },
+    },
+    activeHostId: 'h1',
+  })
+}
+
+describe('HostPickerPopover', () => {
+  beforeEach(() => {
+    setHosts()
+  })
+
+  it('does not render when open=false', () => {
+    const { container } = render(
+      <HostPickerPopover open={false} anchor={{ x: 0, y: 0 }} onSelect={vi.fn()} onCancel={vi.fn()} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('lists hosts in hostOrder with name + online/offline indicator', () => {
+    render(
+      <HostPickerPopover open={true} anchor={{ x: 0, y: 0 }} onSelect={vi.fn()} onCancel={vi.fn()} />,
+    )
+    const items = screen.getAllByRole('option')
+    expect(items).toHaveLength(2)
+    expect(items[0]).toHaveTextContent('mlab')
+    expect(items[1]).toHaveTextContent('air')
+    // online indicator on h1
+    expect(items[0].textContent?.toLowerCase()).toMatch(/online|connected/)
+    // offline indicator on h2
+    expect(items[1].textContent?.toLowerCase()).toMatch(/offline/)
+  })
+
+  it('Enter on focused item triggers onSelect with that hostId', () => {
+    const onSelect = vi.fn()
+    render(
+      <HostPickerPopover open={true} anchor={{ x: 0, y: 0 }} onSelect={onSelect} onCancel={vi.fn()} />,
+    )
+    const items = screen.getAllByRole('option')
+    items[0].focus()
+    fireEvent.keyDown(items[0], { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledWith('h1')
+  })
+
+  it('ArrowDown / ArrowUp moves focus through items', () => {
+    render(
+      <HostPickerPopover open={true} anchor={{ x: 0, y: 0 }} onSelect={vi.fn()} onCancel={vi.fn()} />,
+    )
+    const items = screen.getAllByRole('option')
+    items[0].focus()
+    fireEvent.keyDown(items[0], { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(items[1])
+    fireEvent.keyDown(items[1], { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(items[0])
+  })
+
+  it('Esc triggers onCancel and not onSelect', () => {
+    const onSelect = vi.fn()
+    const onCancel = vi.fn()
+    render(
+      <HostPickerPopover open={true} anchor={{ x: 0, y: 0 }} onSelect={onSelect} onCancel={onCancel} />,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('clicking an offline host still calls onSelect (not disabled)', () => {
+    const onSelect = vi.fn()
+    render(
+      <HostPickerPopover open={true} anchor={{ x: 0, y: 0 }} onSelect={onSelect} onCancel={vi.fn()} />,
+    )
+    fireEvent.click(screen.getAllByRole('option')[1])
+    expect(onSelect).toHaveBeenCalledWith('h2')
+  })
+
+  it('shows empty state when hostOrder is empty', () => {
+    useHostStore.setState({ hosts: {}, hostOrder: [], runtime: {}, activeHostId: null })
+    render(
+      <HostPickerPopover open={true} anchor={{ x: 0, y: 0 }} onSelect={vi.fn()} onCancel={vi.fn()} />,
+    )
+    expect(screen.getByText(/No hosts available/i)).toBeInTheDocument()
+  })
+
+  it('focus is trapped inside the popover (Tab cycles)', () => {
+    render(
+      <HostPickerPopover open={true} anchor={{ x: 0, y: 0 }} onSelect={vi.fn()} onCancel={vi.fn()} />,
+    )
+    const items = screen.getAllByRole('option')
+    items[items.length - 1].focus()
+    fireEvent.keyDown(items[items.length - 1], { key: 'Tab' })
+    // focus should wrap back to first
+    expect(document.activeElement).toBe(items[0])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/components/HostPickerPopover.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement popover**
+
+Create `spa/src/components/HostPickerPopover.tsx`:
+
+```tsx
+import { useEffect, useMemo, useRef } from 'react'
+import { useHostStore } from '../stores/useHostStore'
+import { useI18nStore } from '../stores/useI18nStore'
+
+interface Props {
+  open: boolean
+  /**
+   * Anchor for positioning. `{x, y}` → fixed positioning at viewport coords.
+   * HTMLElement → positioned next to that element via getBoundingClientRect.
+   * `null` allowed during transition; popover renders centered as fallback.
+   */
+  anchor: { x: number; y: number } | HTMLElement | null
+  onSelect: (hostId: string) => void
+  onCancel: () => void
+}
+
+/**
+ * Reusable host picker popover. Caller-controlled open/anchor; emits
+ * `onSelect(hostId)` or `onCancel()`. Used by:
+ *   - WORKSPACE_ACTIONS slot when inferWorkspaceHostId returns null
+ *   - (Future) multi-host workspace binding default-launcher selection (spec §3.5)
+ *
+ * a11y:
+ *   - role="listbox" on container, role="option" on each host row
+ *   - Enter on focused option → onSelect; Esc → onCancel; Arrow Up/Down moves
+ *     focus; Tab wraps within popover (focus trap).
+ *   - Caller is responsible for restoring focus to its trigger after
+ *     onSelect/onCancel returns.
+ */
+export function HostPickerPopover({ open, anchor, onSelect, onCancel }: Props) {
+  const t = useI18nStore((s) => s.t)
+  const hostOrder = useHostStore((s) => s.hostOrder)
+  const hosts = useHostStore((s) => s.hosts)
+  const runtime = useHostStore((s) => s.runtime)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const items = useMemo(
+    () =>
+      hostOrder
+        .map((id) => hosts[id])
+        .filter((h): h is NonNullable<typeof h> => !!h)
+        .map((h) => ({
+          id: h.id,
+          name: h.name,
+          online: runtime[h.id]?.status === 'connected',
+        })),
+    [hostOrder, hosts, runtime],
+  )
+
+  // Auto-focus first item on open.
+  useEffect(() => {
+    if (!open) return
+    const first = containerRef.current?.querySelector<HTMLElement>('[role="option"]')
+    first?.focus()
+  }, [open])
+
+  // Esc → onCancel (document-level so it works regardless of focus position).
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCancel()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  const positionStyle: React.CSSProperties = (() => {
+    if (anchor && 'getBoundingClientRect' in anchor) {
+      const r = anchor.getBoundingClientRect()
+      return { position: 'fixed', top: r.bottom + 4, left: r.left }
+    }
+    if (anchor && typeof anchor === 'object' && 'x' in anchor) {
+      return { position: 'fixed', top: anchor.y, left: anchor.x }
+    }
+    return { position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
+  })()
+
+  function handleItemKey(e: React.KeyboardEvent<HTMLDivElement>, hostId: string, index: number) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      onSelect(hostId)
+      return
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      const next = (index + 1) % items.length
+      ;(containerRef.current?.querySelectorAll<HTMLElement>('[role="option"]')[next])?.focus()
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      const prev = (index - 1 + items.length) % items.length
+      ;(containerRef.current?.querySelectorAll<HTMLElement>('[role="option"]')[prev])?.focus()
+      return
+    }
+    if (e.key === 'Tab') {
+      e.preventDefault()
+      const len = items.length
+      if (len === 0) return
+      const dir = e.shiftKey ? -1 : 1
+      const next = (index + dir + len) % len
+      ;(containerRef.current?.querySelectorAll<HTMLElement>('[role="option"]')[next])?.focus()
+    }
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      role="listbox"
+      aria-label={t('quick_commands.host_picker.label')}
+      style={positionStyle}
+      className="z-50 min-w-[200px] rounded-md border border-border-default bg-surface-secondary shadow-lg py-1"
+    >
+      {items.length === 0 ? (
+        <div className="px-3 py-2 text-xs text-text-muted">
+          {t('quick_commands.host_picker.empty')}
+        </div>
+      ) : (
+        items.map((item, index) => (
+          <div
+            key={item.id}
+            role="option"
+            tabIndex={0}
+            aria-selected={false}
+            onClick={() => onSelect(item.id)}
+            onKeyDown={(e) => handleItemKey(e, item.id, index)}
+            className="flex items-center justify-between gap-2 px-3 py-1.5 text-xs text-text-primary cursor-pointer hover:bg-surface-hover focus:bg-surface-hover focus:outline-none"
+          >
+            <span className="truncate">{item.name}</span>
+            <span
+              className={
+                item.online
+                  ? 'text-[10px] text-text-secondary bg-surface-primary px-1.5 py-0.5 rounded'
+                  : 'text-[10px] text-text-muted bg-surface-primary px-1.5 py-0.5 rounded'
+              }
+            >
+              {item.online
+                ? t('quick_commands.host_picker.online')
+                : t('quick_commands.host_picker.offline')}
+            </span>
+          </div>
+        ))
+      )}
+    </div>
+  )
+}
+```
+
+註：i18n keys `quick_commands.host_picker.label` / `.empty` / `.online` / `.offline` 在 Task 1b.4 統一加入 zh-TW / en JSON。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/components/HostPickerPopover.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): add HostPickerPopover reusable component for host selection (spec §3.2.2 / §4.4)
+```
+
+---
+
 ### Task 1b.1: `<CommandSlot>` 共用元件
 
 **Files:**
 - Create: `spa/src/components/CommandSlot.tsx`
 - Create: `spa/src/components/CommandSlot.test.tsx`
 
+**Spec v4 重點：** `SlotContext.hostId` 為 `string | null`（spec §3.2.1 / §3.2.2 / §3.5）。`<CommandSlot>` 自身**不**渲染 host picker — picker 是 caller 端（context menu / popover / sessions section）的 UI 責任，原因是 picker 屬於 React tree 上層的 controllable popover，executor lib 不能也不該觸碰 React render。`<CommandSlot>` 只負責：(a) 列出 mount 在該 slot 的 commands；(b) 點擊後把 `(cmd, ctx)` 交給 `executor` callback；hostId null 時 ctx 仍然會帶 null 進去，由 caller 在 executor 內透過 `resolveHostId` callback 開 picker（見 Task 1b.2）。
+
 - [ ] **Step 1: Write the failing test**
 
-Create `spa/src/components/CommandSlot.test.tsx`:
+Create `spa/src/components/CommandSlot.test.tsx`（注意：含 hostId=null 案例驗證 SlotContext 契約）:
 
 ```tsx
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -911,6 +1497,21 @@ describe('CommandSlot', () => {
     expect(exec.mock.calls[0][1]).toMatchObject({ hostId: 'h1', workspaceId: 'w1' })
   })
 
+  it('hostId=null is valid — passes null through to executor (caller resolves via picker)', () => {
+    const exec = vi.fn().mockResolvedValue(undefined)
+    render(
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId: null, workspaceId: 'w1' }}
+        executor={exec}
+      />,
+    )
+    // commands are still rendered (hostId-null doesn't suppress UI)
+    fireEvent.click(screen.getByLabelText(/^A/))
+    expect(exec).toHaveBeenCalledTimes(1)
+    expect(exec.mock.calls[0][1]).toMatchObject({ hostId: null, workspaceId: 'w1' })
+  })
+
   it('supports custom render prop', () => {
     render(
       <CommandSlot
@@ -940,8 +1541,21 @@ import { useQuickCommandStore, type QuickCommand } from '../stores/useQuickComma
 import { useModuleEnabledStore } from '../stores/useModuleEnabledStore'
 import type { QuickCommandSlotId } from '../lib/quick-command-slots'
 
+/**
+ * Slot context (spec v4 §3.2.1 / §3.2.2 / §3.5).
+ *
+ * `hostId` is `string | null`:
+ *   - WORKSPACE_ACTIONS: caller provides `inferWorkspaceHostId(ws, tabs)`
+ *     which can return null when the workspace has no tmux-session tabs.
+ *   - HOST_ACTIONS: caller always provides a concrete hostId (host detail
+ *     page already knows which host it's rendering).
+ *
+ * When hostId is null, the executor MUST resolve it (e.g. by opening the
+ * HostPickerPopover) before performing any host-side work — silently
+ * falling back to `useHostStore.activeHostId` is forbidden.
+ */
 export interface SlotContext {
-  hostId: string
+  hostId: string | null
   workspaceId?: string | null
   cwd?: string
 }
@@ -968,7 +1582,12 @@ interface Props {
 export function CommandSlot({ mountTo, ctx, executor, render }: Props) {
   const enabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
   const bindings = useQuickCommandStore((s) => s.bindings)
-  const allCmds = useQuickCommandStore((s) => s.getCommands(ctx.hostId))
+  // hostId null → no host override possible; show global-only command list.
+  // (getCommands(hostId) would require a string; explicitly passing null
+  // means "caller hasn't resolved a host yet — just use globals".)
+  const allCmds = useQuickCommandStore((s) =>
+    ctx.hostId == null ? s.global : s.getCommands(ctx.hostId),
+  )
 
   // Recompute boundCmds when bindings or capability list change.
   const boundCmds = useMemo(
@@ -1147,13 +1766,51 @@ feat(spa): extend useUndoToast schema with optional actionLabel (back-compat)
 
 ---
 
-### Task 1b.2: Slot executor lib（建 session + 送 keys + 失敗 UX）
+### Task 1b.2: Slot executor lib（建 session + 送 keys + 失敗 UX + hostId 解析）
 
 **Files:**
 - Create: `spa/src/lib/slot-executor.ts`
 - Create: `spa/src/lib/slot-executor.test.ts`
 
 註：保留既有 `spa/src/lib/execute-command.ts`（v1 send-keys helper）；新檔處理 v2 的「建 session + 送 keys + 切 session + toast」一條龍。
+
+**Spec v4 — hostId 解析設計（Option B：`resolveHostId` callback）：**
+
+`SlotContext.hostId` 是 `string | null`。executor 收到 ctx 後，若 hostId null **不直接呼叫 API**；改 await caller 注入的 `resolveHostId(): Promise<string | null>` callback —
+- caller（CommandSlot 包裝層 / context menu / popover）在 callback 內部開 `HostPickerPopover`，await user 選定後 resolve hostId
+- user 取消 popover → resolve `null` → executor no-op 結束
+
+**Option B vs Option A 選擇理由：**
+- Option A（throw `HostRequiredError` + caller catch + retry）會切斷 executor 線性流程，且 toast / focus 切換邏輯散落在 caller 兩處（first-run 與 retry-run），重複容易漏。
+- Option B（callback 注入）延續既有 `runWorkspaceSlot` 的 `deps.switchToSession` callback 模式（同一個 task 已有先例），executor 仍是線性 `await`，CommandSlot 把 picker state + Promise resolver 包進一個 React hook 即可內聚地管理。
+- 既有 codebase 沒有「throw + catch + retry」的 host-resolution pattern；Option B 與現有設計一致。
+
+**選擇：Option B。**
+
+CommandSlot 一側的封裝建議（在 1b.5a / 1b.5b / 1c.1b 各 caller 自行實作；不抽公共 hook，因為三個 caller 的 trigger UI 完全不同）：
+```tsx
+const [pickerState, setPickerState] = useState<{
+  resolver: (id: string | null) => void
+  anchor: HTMLElement | { x: number; y: number } | null
+} | null>(null)
+
+const resolveHostId = useCallback(
+  () =>
+    new Promise<string | null>((resolve) => {
+      // anchor 由 trigger element ref 提供
+      setPickerState({ resolver: resolve, anchor: triggerRef.current })
+    }),
+  [],
+)
+
+// JSX:
+<HostPickerPopover
+  open={pickerState !== null}
+  anchor={pickerState?.anchor ?? null}
+  onSelect={(hostId) => { pickerState?.resolver(hostId); setPickerState(null) }}
+  onCancel={() => { pickerState?.resolver(null); setPickerState(null) }}
+/>
+```
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1190,6 +1847,7 @@ describe('runWorkspaceSlot', () => {
 
   it('happy path — creates session, sends keys, switches focus', async () => {
     const switchFocus = vi.fn()
+    const resolveHostId = vi.fn() // not called when ctx.hostId is non-null
     ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       code: 'sess-1', name: 'A', cwd: '/tmp', mode: 'terminal',
     })
@@ -1198,23 +1856,62 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: 'h1', workspaceId: 'w1', cwd: '/tmp' },
-      { switchToSession: switchFocus },
+      { switchToSession: switchFocus, resolveHostId },
     )
 
+    expect(resolveHostId).not.toHaveBeenCalled()
     expect(createSession).toHaveBeenCalledWith('h1', expect.any(String), '/tmp', 'terminal')
     expect(executeCommand).toHaveBeenCalledWith('h1', 'sess-1', 'echo hi')
     expect(switchFocus).toHaveBeenCalledWith('h1', 'sess-1')
     expect(useUndoToast.getState().toast).toBeNull()
   })
 
+  it('hostId null → invokes resolveHostId; user picks → continues with that hostId', async () => {
+    const switchFocus = vi.fn()
+    const resolveHostId = vi.fn().mockResolvedValue('h-picked')
+    ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      code: 'sess-2', name: 'A', cwd: '~', mode: 'terminal',
+    })
+    ;(executeCommand as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+
+    await runWorkspaceSlot(
+      { id: 'cmd-a', name: 'A', command: 'echo hi' },
+      { hostId: null, workspaceId: 'w1' },
+      { switchToSession: switchFocus, resolveHostId },
+    )
+
+    expect(resolveHostId).toHaveBeenCalledTimes(1)
+    expect(createSession).toHaveBeenCalledWith('h-picked', expect.any(String), '~', 'terminal')
+    expect(executeCommand).toHaveBeenCalledWith('h-picked', 'sess-2', 'echo hi')
+    expect(switchFocus).toHaveBeenCalledWith('h-picked', 'sess-2')
+  })
+
+  it('hostId null → user cancels picker → no API call, no toast', async () => {
+    const switchFocus = vi.fn()
+    const resolveHostId = vi.fn().mockResolvedValue(null)
+
+    await runWorkspaceSlot(
+      { id: 'cmd-a', name: 'A', command: 'echo hi' },
+      { hostId: null, workspaceId: 'w1' },
+      { switchToSession: switchFocus, resolveHostId },
+    )
+
+    expect(resolveHostId).toHaveBeenCalledTimes(1)
+    expect(createSession).not.toHaveBeenCalled()
+    expect(executeCommand).not.toHaveBeenCalled()
+    expect(switchFocus).not.toHaveBeenCalled()
+    expect(useUndoToast.getState().toast).toBeNull()
+  })
+
   it('createSession failure — surfaces toast, does NOT switch focus', async () => {
     const switchFocus = vi.fn()
+    const resolveHostId = vi.fn()
     ;(createSession as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('500 Internal'))
 
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: 'h1', workspaceId: 'w1' },
-      { switchToSession: switchFocus },
+      { switchToSession: switchFocus, resolveHostId },
     )
 
     expect(switchFocus).not.toHaveBeenCalled()
@@ -1226,6 +1923,7 @@ describe('runWorkspaceSlot', () => {
 
   it('send-keys failure — STILL switches focus + toast carries retry action', async () => {
     const switchFocus = vi.fn()
+    const resolveHostId = vi.fn()
     ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       code: 'sess-1', name: 'A', cwd: '/tmp', mode: 'terminal',
     })
@@ -1234,7 +1932,7 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: 'h1', workspaceId: 'w1' },
-      { switchToSession: switchFocus },
+      { switchToSession: switchFocus, resolveHostId },
     )
 
     expect(switchFocus).toHaveBeenCalledWith('h1', 'sess-1')
@@ -1256,6 +1954,7 @@ describe('runWorkspaceSlot', () => {
     const switchFocus = vi.fn().mockImplementation(() => {
       throw new Error('switch failed')
     })
+    const resolveHostId = vi.fn()
     ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       code: 'sess-1', name: 'A', cwd: '/tmp', mode: 'terminal',
     })
@@ -1264,7 +1963,7 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: 'h1', workspaceId: 'w1' },
-      { switchToSession: switchFocus },
+      { switchToSession: switchFocus, resolveHostId },
     )
 
     const toast = useUndoToast.getState().toast
@@ -1298,6 +1997,17 @@ interface Deps {
    * succeeded — see spec §3.3 (silent orphan sessions are the worst UX).
    */
   switchToSession: (hostId: string, sessionCode: string) => void
+
+  /**
+   * Resolves a hostId when ctx.hostId is null (spec v4 §3.2.2 — Option B).
+   * Caller opens the HostPickerPopover inside this callback and resolves
+   * with the user-selected hostId, or `null` if the user cancels.
+   *
+   * Required regardless of ctx.hostId — when ctx.hostId is non-null this
+   * callback is never invoked (see happy-path test). Caller still passes
+   * a noop / never-called function to satisfy the type contract.
+   */
+  resolveHostId: () => Promise<string | null>
 }
 
 function genSessionName(cmd: QuickCommand): string {
@@ -1329,9 +2039,23 @@ export async function runWorkspaceSlot(
   const t = useI18nStore.getState().t
   const toast = useUndoToast.getState()
 
+  // spec v4 §3.2.2 — null hostId resolution via caller-injected callback.
+  // We do NOT silently fall back to activeHostId.
+  let hostId: string
+  if (ctx.hostId == null) {
+    const picked = await deps.resolveHostId()
+    if (picked == null) {
+      // User cancelled the picker → no-op, no toast.
+      return
+    }
+    hostId = picked
+  } else {
+    hostId = ctx.hostId
+  }
+
   let sessionCode: string
   try {
-    const session = await createSession(ctx.hostId, genSessionName(cmd), ctx.cwd ?? '~', 'terminal')
+    const session = await createSession(hostId, genSessionName(cmd), ctx.cwd ?? '~', 'terminal')
     sessionCode = session.code
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err)
@@ -1340,24 +2064,24 @@ export async function runWorkspaceSlot(
   }
 
   try {
-    await executeCommand(ctx.hostId, sessionCode, cmd.command)
+    await executeCommand(hostId, sessionCode, cmd.command)
   } catch (err) {
     // Step 2 failed — STILL switch (so user sees the orphan), with Retry.
-    safelySwitch(ctx.hostId, sessionCode, deps, t)
+    safelySwitch(hostId, sessionCode, deps, t)
     const reason = err instanceof Error ? err.message : String(err)
     void reason
     toast.show(
       t('quick_commands.toast.send_keys_failed'),
       // retry: re-run send-keys; failures dropped (user can keep clicking).
       () => {
-        void executeCommand(ctx.hostId, sessionCode, cmd.command).catch(() => undefined)
+        void executeCommand(hostId, sessionCode, cmd.command).catch(() => undefined)
       },
       t('quick_commands.toast.retry'),  // ← Task 1b.1.5 introduced actionLabel; default ('Undo') doesn't fit retry semantics
     )
     return
   }
 
-  safelySwitch(ctx.hostId, sessionCode, deps, t)
+  safelySwitch(hostId, sessionCode, deps, t)
 }
 
 function safelySwitch(
@@ -1932,6 +2656,10 @@ In `spa/src/locales/zh-TW.json` 加入：
   "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。",
   "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。",
   "quick_commands.toast.retry": "重試",
+  "quick_commands.host_picker.label": "選擇主機",
+  "quick_commands.host_picker.empty": "尚未設定任何主機",
+  "quick_commands.host_picker.online": "線上",
+  "quick_commands.host_picker.offline": "離線",
 ```
 
 In `spa/src/locales/en.json` 對應加入：
@@ -1954,6 +2682,10 @@ In `spa/src/locales/en.json` 對應加入：
   "quick_commands.toast.send_keys_failed": "Session created, but command failed.",
   "quick_commands.toast.switch_failed": "Created and sent, but could not switch focus; check the sessions list.",
   "quick_commands.toast.retry": "Retry",
+  "quick_commands.host_picker.label": "Choose host",
+  "quick_commands.host_picker.empty": "No hosts available",
+  "quick_commands.host_picker.online": "online",
+  "quick_commands.host_picker.offline": "offline",
 ```
 
 註：若 `common.edit` 已存在，跳過該行。檢查指令：`grep '"common.edit"' spa/src/locales/zh-TW.json`。
@@ -1984,7 +2716,12 @@ feat(spa): wire Quick Commands settings contribution + i18n keys
 
 1. 新元件 `WorkspaceQuickCommandsContextMenu` 渲染 mount=`WORKSPACE_ACTIONS` 的所有 bound commands；點擊執行 executor 並關閉 menu。
 2. 在 `WorkspaceContextMenu` 內部 `Settings` 按鈕**之前**渲染此新元件，並在其後加 `border-t` separator（若有任一個 quick command 顯示）。
-3. `App.tsx` 的 `WorkspaceContextMenu` 渲染處需新增傳 `workspaceId={wsContextMenu.wsId}` prop，使其能解析該 workspace 對應 host（透過 `useWorkspaceStore` 找 `workspace.hostId` — 若 store schema 有對應欄位；否則用 `activeHostId`）。
+3. `App.tsx` 的 `WorkspaceContextMenu` 渲染處需新增傳 `workspaceId={wsContextMenu.wsId}` prop。
+
+**Spec v4 hostId 解析（不再用 `activeHostId` fallback）：**
+- 取 `useTabStore.tabs` + 該 workspace，呼叫 `inferWorkspaceHostId(workspace, tabs)`
+- 多數決成功 → 直接傳 hostId 給 ctx
+- 多數決回 null → ctx.hostId 為 null；點擊 chip 時 executor 透過 `resolveHostId` callback 開 `HostPickerPopover`
 
 **重要：** `<CommandSlot>` 已具備 `isEnabled` short-circuit 與「無 binding 不渲染」邏輯，所以無 quick commands 時 menu 內部自動只剩既有項目，不會出現空 separator。
 
@@ -2047,6 +2784,23 @@ describe('WorkspaceQuickCommandsContextMenu', () => {
     )
     expect(container.firstChild).toBeNull()
   })
+
+  it('hostId=null — clicking a command opens HostPickerPopover (does NOT call executor immediately)', async () => {
+    // Spec v4 §3.2.2 — when inferWorkspaceHostId returns null we must let the
+    // user choose. The chip is rendered as soon as bindings exist; click triggers
+    // the picker before executor.
+    render(<WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId={null} onClose={() => {}} />)
+    expect(screen.queryByRole('listbox')).toBeNull()
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+  })
+
+  it('hostId=null — picker cancel → no createSession call, menu stays open until close', async () => {
+    // Behavioural test: integration with HostPickerPopover; mock createSession
+    // and assert it was not invoked when user presses Esc.
+    // (Subagent: import createSession mock from host-api; vi.mock as in 1b.2.)
+    // This test is acceptance-only; full coverage of the path lives in slot-executor.test.ts
+  })
 })
 ```
 
@@ -2084,26 +2838,53 @@ Expected: FAIL — module not found / props missing。
 Create `spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx`：
 
 ```tsx
+import { useCallback, useRef, useState } from 'react'
 import { CommandSlot } from '../../../components/CommandSlot'
+import { HostPickerPopover } from '../../../components/HostPickerPopover'
 import { runWorkspaceSlot } from '../../../lib/slot-executor'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 import { useTabStore } from '../../../stores/useTabStore'
 
 interface Props {
   workspaceId: string
-  hostId: string
+  /**
+   * Workspace 的多數決 hostId（spec v4 §3.2.1）；null 代表 workspace 無
+   * tmux-session tabs，executor 會在 callback 裡開 HostPickerPopover。
+   */
+  hostId: string | null
   onClose: () => void
 }
 
 /**
  * 渲染 mount=WORKSPACE_ACTIONS 的 quick commands，作為 WorkspaceContextMenu 的子 section。
  * <CommandSlot> 自身會 short-circuit module disabled / no-bindings 兩個情況。
- * 為了讓 parent 能正確 toggle separator，**沒有 bound commands 時整個 wrapper 也回 null**
- * — 透過讀同樣的 store 直接判斷（避免引入新 prop）。
+ * hostId=null 時 chip 仍渲染（user 可選一個 host 並執行）；executor 透過
+ * resolveHostId callback 等待 picker 結果。picker 取消 → no-op，menu 仍由 onClose
+ * 觸發者（CommandSlot 預設 button onClick）正常關閉。
  */
 export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose }: Props) {
+  const [picker, setPicker] = useState<{
+    resolver: (id: string | null) => void
+    anchor: { x: number; y: number } | null
+  } | null>(null)
+  const lastClickPos = useRef<{ x: number; y: number } | null>(null)
+
+  const resolveHostId = useCallback(
+    () =>
+      new Promise<string | null>((resolve) => {
+        setPicker({ resolver: resolve, anchor: lastClickPos.current })
+      }),
+    [],
+  )
+
   return (
-    <div className="py-1">
+    <div
+      className="py-1"
+      onClickCapture={(e) => {
+        // Capture coordinates for picker anchor (fixed-positioned next to click).
+        lastClickPos.current = { x: e.clientX, y: e.clientY }
+      }}
+    >
       <CommandSlot
         mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
         ctx={{ hostId, workspaceId }}
@@ -2117,6 +2898,7 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
                   sessionCode,
                 })
               },
+              resolveHostId,
             })
           } finally {
             onClose()
@@ -2136,6 +2918,18 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
             )}
           </button>
         )}
+      />
+      <HostPickerPopover
+        open={picker !== null}
+        anchor={picker?.anchor ?? null}
+        onSelect={(hostId) => {
+          picker?.resolver(hostId)
+          setPicker(null)
+        }}
+        onCancel={() => {
+          picker?.resolver(null)
+          setPicker(null)
+        }}
       />
     </div>
   )
@@ -2168,65 +2962,58 @@ interface Props {
 ```tsx
 interface Props {
   position: { x: number; y: number }
-  workspaceId?: string  // ← new (optional 維持向下相容；測試 setup 內全部要傳)
-  hostId?: string       // ← new
+  workspaceId?: string                 // ← new (optional 維持向下相容；測試 setup 內全部要傳)
+  hostId?: string | null               // ← new — null 代表 workspace 多數決失敗，picker 流程
   onSettings: () => void
   onTearOff?: () => void
   onMergeTo?: (targetWindowId: string) => void
   onClose: () => void
 }
-
-// JSX 中於 Settings 按鈕之前加：
-{workspaceId && hostId && (
-  <>
-    <WorkspaceQuickCommandsContextMenu
-      workspaceId={workspaceId}
-      hostId={hostId}
-      onClose={onClose}
-    />
-    <div className="border-t border-border-default my-1" />
-  </>
-)}
 ```
 
-**注意：** separator 渲染條件 — 應僅當「真有 commands 顯示」才 separator，否則會出現「空 wrapper + separator」的視覺空隙。`<CommandSlot>` 在 0 commands 時回 `null`，但 wrapper `<div>` 仍存在。**解法**：把 separator 也透過讀 store 判斷：
+**Spec v4 — separator 條件：** separator 應只在「該 workspace 確實有 WORKSPACE_ACTIONS bindings」才顯示，與 hostId 是否 null 無關（hostId null 時 chip 仍會渲染）。判斷靠讀 `useQuickCommandStore.global` + `bindings` 是否有 binding（不依賴 hostId 推 byHost 覆寫，因為 hostId null 時不能呼叫 `getCommands(hostId)`）：
 
 ```tsx
-// 在 WorkspaceContextMenu.tsx，新增 helper：
+// 在 WorkspaceContextMenu.tsx 加入：
 import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
 import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 
-// 計算 hasQuickCommands：
 const hasQuickCommands = useQuickCommandStore((s) => {
-  if (!hostId) return false
-  const cmds = s.getCommands(hostId)
+  // hostId null 時用 global only；否則用 getCommands(hostId)（含 host override）
+  const cmds = hostId == null ? s.global : s.getCommands(hostId)
   return cmds.some((c) => s.bindings[c.id]?.includes(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS))
 })
 const moduleEnabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
-const showQuickCommandsSection = workspaceId && hostId && moduleEnabled && hasQuickCommands
+const showQuickCommandsSection = !!workspaceId && moduleEnabled && hasQuickCommands
 
 // JSX：
 {showQuickCommandsSection && (
   <>
-    <WorkspaceQuickCommandsContextMenu workspaceId={workspaceId!} hostId={hostId} onClose={onClose} />
+    <WorkspaceQuickCommandsContextMenu workspaceId={workspaceId!} hostId={hostId ?? null} onClose={onClose} />
     <div className="border-t border-border-default my-1" />
   </>
 )}
 ```
 
-修改 `App.tsx` 的 `<WorkspaceContextMenu>` 呼叫處（L322-329）：
+修改 `App.tsx` 的 `<WorkspaceContextMenu>` 呼叫處（L322-329）— 改用 spec v4 多數決：
 
 ```tsx
+import { inferWorkspaceHostId } from './lib/infer-workspace-host-id'
+import { useTabStore } from './stores/useTabStore'
+import { useWorkspaceStore } from './stores/useWorkspaceStore' // 若已存在；否則 workspaces 來自當前 source
+
 {wsContextMenu && (() => {
   const ws = workspaces.find((w) => w.id === wsContextMenu.wsId)
-  // hostId 來源：workspace 上的 hostId 欄位（若 schema 有），否則用 useHostStore.activeHostId fallback
-  const hostId = (ws as { hostId?: string } | undefined)?.hostId ?? useHostStore.getState().activeHostId
+  if (!ws) return null
+  // Spec v4 §3.2.1 — workspace hostId 多數決，不再用 activeHostId fallback。
+  const tabs = useTabStore.getState().tabs
+  const hostId = inferWorkspaceHostId(ws, tabs)  // string | null
   return (
     <WorkspaceContextMenu
       position={wsContextMenu.position}
       workspaceId={wsContextMenu.wsId}
-      hostId={hostId ?? undefined}
+      hostId={hostId}
       onSettings={() => openWsSettings(wsContextMenu.wsId)}
       onTearOff={window.electronAPI ? () => handleWsTearOff(wsContextMenu.wsId) : undefined}
       onMergeTo={window.electronAPI ? (targetWindowId) => handleWsMergeTo(wsContextMenu.wsId, targetWindowId) : undefined}
@@ -2236,7 +3023,7 @@ const showQuickCommandsSection = workspaceId && hostId && moduleEnabled && hasQu
 })()}
 ```
 
-註：`workspaces[].hostId` 是否存在須在實作前由 subagent grep 確認（`rg "hostId" spa/src/types/tab.ts`）；若不存在則 fallback 到 `useHostStore.activeHostId`。
+註：`useTabStore.getState().tabs` 為 `Record<string, Tab>`（spa/src/stores/useTabStore.ts L110 確認）。`inferWorkspaceHostId` Task 1b.0a 已建立。
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -2268,7 +3055,9 @@ feat(spa): mount WORKSPACE_ACTIONS slot in workspace right-click context menu
 - 視覺 cue：popover 含半透明漸層壓底（`bg-gradient-to-l from-surface-secondary/0 to-surface-secondary/95` 或同等 token）。
 - **Plus 原本 hover 才顯**（L117 `opacity-0 group-hover/ws-header:opacity-100`）— 此邏輯保留。
 
-**短路條件：** `<CommandSlot>` 已內建 module-disabled / no-bindings short-circuit；`WorkspaceQuickActionsPopover` 額外用同邏輯（讀 store 並 early-return null）避免在無 commands 時渲染空 popover wrapper（避免 hover 觸發後出現空白浮層）。
+**Spec v4 hostId 解析：** WorkspaceRow 內以 `inferWorkspaceHostId(workspace, useTabStore.getState().tabs)` 取 hostId（不再用 `useHostStore.activeHostId` fallback）。多數決回 null 時 chip 仍顯示（`hostId={null}` 傳給 popover）；點擊 chip 由 popover 內部開 `HostPickerPopover` 等 user 選定後跑 executor。
+
+**短路條件：** `<CommandSlot>` 已內建 module-disabled / no-bindings short-circuit；`WorkspaceQuickActionsPopover` 額外用同邏輯（讀 store 並 early-return null）避免在無 commands 時渲染空 popover wrapper（避免 hover 觸發後出現空白浮層）。**注意：hostId null 不再作為 `WorkspaceQuickActionsPopover` 的隱藏條件**（spec v4 §3.2.2）— 即使 workspace 沒有 tmux-session tabs，user 仍可主動透過 picker 選 host 啟動 quick command。
 
 - [ ] **Step 1: Write the failing test**
 
@@ -2276,10 +3065,11 @@ Create `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.
 
 ```tsx
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { WorkspaceQuickActionsPopover } from './WorkspaceQuickActionsPopover'
 import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
 import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { useHostStore } from '../../../stores/useHostStore'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
 
@@ -2290,6 +3080,13 @@ function setup() {
     bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
   })
   useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  // HostPickerPopover 內部讀 useHostStore；至少塞一個 host 避免空狀態誤判
+  useHostStore.setState({
+    hosts: { h1: { id: 'h1', name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 } },
+    hostOrder: ['h1'],
+    runtime: { h1: { status: 'connected' } },
+    activeHostId: 'h1',
+  })
   clearModuleRegistry()
   registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
 }
@@ -2299,6 +3096,13 @@ describe('WorkspaceQuickActionsPopover', () => {
 
   it('renders bound commands as chips', () => {
     render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />)
+    expect(screen.getByLabelText(/^Alpha/)).toBeInTheDocument()
+  })
+
+  it('renders chips when hostId is null (picker handles host resolution at click time)', () => {
+    // Spec v4 §3.2.2 — null hostId is a valid state (workspace has no
+    // tmux-session tabs); we still surface the chips so user can pick a host.
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId={null} />)
     expect(screen.getByLabelText(/^Alpha/)).toBeInTheDocument()
   })
 
@@ -2316,6 +3120,13 @@ describe('WorkspaceQuickActionsPopover', () => {
       <WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />,
     )
     expect(container.firstChild).toBeNull()
+  })
+
+  it('hostId=null + click chip → opens HostPickerPopover', () => {
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId={null} />)
+    expect(screen.queryByRole('listbox')).toBeNull()
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
   })
 })
 ```
@@ -2364,7 +3175,9 @@ Expected: FAIL — module not found / popover 不顯示。
 Create `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx`：
 
 ```tsx
+import { useCallback, useRef, useState } from 'react'
 import { CommandSlot } from '../../../components/CommandSlot'
+import { HostPickerPopover } from '../../../components/HostPickerPopover'
 import { runWorkspaceSlot } from '../../../lib/slot-executor'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 import { useTabStore } from '../../../stores/useTabStore'
@@ -2373,7 +3186,11 @@ import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
 
 interface Props {
   workspaceId: string
-  hostId: string
+  /**
+   * hostId 為 null 時 chip 仍顯示，executor 點擊後會開 HostPickerPopover
+   * 讓 user 選 host（spec v4 §3.2.2）。
+   */
+  hostId: string | null
 }
 
 /**
@@ -2382,17 +3199,36 @@ interface Props {
  * short-circuits when module disabled / no bindings; we additionally
  * skip rendering the popover wrapper itself in those cases so the
  * hover trigger doesn't expose an empty floating panel.
+ *
+ * NOTE (spec v4 §3.2.2): we do NOT short-circuit on hostId == null —
+ * the picker flow handles that case. Only no-bindings / module-disabled
+ * suppress the wrapper.
  */
 export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
   const moduleEnabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
   const hasBindings = useQuickCommandStore((s) => {
-    const cmds = s.getCommands(hostId)
+    const cmds = hostId == null ? s.global : s.getCommands(hostId)
     return cmds.some((c) => s.bindings[c.id]?.includes(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS))
   })
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const [picker, setPicker] = useState<{
+    resolver: (id: string | null) => void
+    anchor: HTMLElement | null
+  } | null>(null)
+
+  const resolveHostId = useCallback(
+    () =>
+      new Promise<string | null>((resolve) => {
+        setPicker({ resolver: resolve, anchor: wrapperRef.current })
+      }),
+    [],
+  )
+
   if (!moduleEnabled || !hasBindings) return null
 
   return (
     <div
+      ref={wrapperRef}
       role="group"
       aria-label="Workspace quick actions"
       className="absolute right-full top-1/2 -translate-y-1/2 mr-1 flex items-center gap-1 px-2 py-1 rounded-md bg-gradient-to-l from-surface-secondary/0 to-surface-secondary/95 backdrop-blur-sm shadow-md z-30"
@@ -2409,8 +3245,21 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
                 sessionCode,
               })
             },
+            resolveHostId,
           })
         }
+      />
+      <HostPickerPopover
+        open={picker !== null}
+        anchor={picker?.anchor ?? null}
+        onSelect={(hostId) => {
+          picker?.resolver(hostId)
+          setPicker(null)
+        }}
+        onCancel={() => {
+          picker?.resolver(null)
+          setPicker(null)
+        }}
       />
     </div>
   )
@@ -2422,15 +3271,15 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
 ```tsx
 import { useState, useRef } from 'react'
 // … 既有 imports
-import { useHostStore } from '../../../stores/useHostStore'
+import { useTabStore } from '../../../stores/useTabStore'
+import { inferWorkspaceHostId } from '../../../lib/infer-workspace-host-id'
 import { WorkspaceQuickActionsPopover } from './WorkspaceQuickActionsPopover'
 
-// 在 WorkspaceRow 函式內：
+// 在 WorkspaceRow 函式內（spec v4 §3.2.1 — 多數決，不再用 activeHostId fallback）：
 const [popoverOpen, setPopoverOpen] = useState(false)
 const hubRef = useRef<HTMLDivElement>(null)
-// hostId 解析（同 1b.5a：先看 workspace.hostId，否則 active）
-const hostId = (workspace as { hostId?: string }).hostId
-  ?? useHostStore((s) => s.activeHostId) ?? null
+const tabsMap = useTabStore((s) => s.tabs)  // 訂閱 tabs 變動，hostId 隨 layout 變化即時更新
+const hostId = inferWorkspaceHostId(workspace, tabsMap)  // string | null
 
 // 改 Plus 區段（保留原條件 showTabs）：
 {showTabs && (
@@ -2460,14 +3309,14 @@ const hostId = (workspace as { hostId?: string }).hostId
     >
       <Plus size={12} />
     </button>
-    {popoverOpen && hostId && (
+    {popoverOpen && (
       <WorkspaceQuickActionsPopover workspaceId={workspace.id} hostId={hostId} />
     )}
   </div>
 )}
 ```
 
-註：popover 觸發 hover 時 Plus 仍是 hover 中（同一個 group），不會閃。`WorkspaceQuickActionsPopover` 內部已 short-circuit 模組停用 / 無 binding，這層也再加 hostId guard。
+註：popover 觸發 hover 時 Plus 仍是 hover 中（同一個 group），不會閃。`WorkspaceQuickActionsPopover` 內部已 short-circuit 模組停用 / 無 binding；hostId 為 null 時 chip 仍顯示（spec v4 §3.2.2 — picker 會在點擊時開）。
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -2528,7 +3377,15 @@ Expected: clean
 - [x] 點擊按鈕：建 session + 送 keys + 切過去
 - [x] 三層失敗 UX 符合 spec §3.3：建失敗 / 送 keys 失敗仍切過去 + **toast 顯 'Retry' 按鈕** / 切失敗 toast
 - [x] 停用 quick-commands module → 兩個入口皆立即消失（CommandSlot short-circuit）
-- [x] i18n: zh-TW + en 全部 key 齊全（含新增 `quick_commands.toast.retry`；`pnpm run lint` 含 locale-completeness 檢查）
+- [x] i18n: zh-TW + en 全部 key 齊全（含新增 `quick_commands.toast.retry` + 4 個 `quick_commands.host_picker.*`；`pnpm run lint` 含 locale-completeness 檢查）
+- [x] **Spec v4 — workspace hostId 多數決邊界（§3.2.1 / §3.2.2）：**
+  - workspace 中只有非 tmux-session tabs（如全 dashboard / settings）→ 點 quick command → `HostPickerPopover` 出現 → 選 host → 正常流程（建 session + 送 keys + 切過去）
+  - workspace 中只有 tmux-session tabs（單 host）→ 自動推斷正確 host → **不出 picker**
+  - workspace 中混合多 host tmux-session tabs，多數一個 host → 多數決命中該 host → 不出 picker
+  - workspace 多數決平手 + active tab 是 tmux-session 在多數派內 → 用 active 的 hostId
+  - workspace 多數決平手 + active tab 非 tmux-session → 用 tabs 順序中第一個 winner
+  - hostId null 時 picker 取消 → no-op，**沒有任何 createSession / send-keys API call**
+  - hostId null 時 picker 選定 → executor 用該 hostId 完成全流程
 
 ---
 
@@ -2602,6 +3459,8 @@ refactor(spa): remove v1 QuickCommandMenu from SessionsSection rows (consolidate
 
 **設計：** 把 new-session 按鈕外層改為 `<div className="flex items-center gap-2">`（包 CommandSlot + new-session button 兩者），整體右對齊（保留外層 `justify-between` 與標題的相對位置）。
 
+**Spec v4 — HOST_ACTIONS 不需 picker：** Host 詳情頁本身已知 hostId（透過 prop 傳入），ctx 一律帶非 null hostId，executor 不會呼叫 `resolveHostId` callback。儘管如此，executor 簽名要求 `resolveHostId` 為必要欄位，所以仍需傳一個 noop（或永遠 reject 的 promise）以滿足型別契約 — 推薦用 `() => Promise.resolve(null)`，行為等同「user 取消」，僅在型別誤用（hostId 不慎傳 null）時觸發 no-op safety net。
+
 - [ ] **Step 1: Write the failing test**
 
 Edit `spa/src/components/hosts/SessionsSection.test.tsx`：
@@ -2669,6 +3528,9 @@ import { useTabStore } from '../../stores/useTabStore'
               sessionCode,
             })
           },
+          // HOST_ACTIONS 入口必有 hostId；resolveHostId 不會被呼叫。仍提供
+          // safety-net noop 以滿足型別契約（spec v4）。
+          resolveHostId: () => Promise.resolve(null),
         })
       }
     />
@@ -2740,6 +3602,7 @@ Expected: clean
 
 - [ ] Phase 1a 已 merge → main，且 alpha bump 完成（或一個 PR sequence 規劃中）
 - [ ] Phase 1b 已 merge → main，**Settings UI 與 WORKSPACE_ACTIONS 兩個入口（context menu + hover popover）同 PR**（不可拆）
+- [ ] Phase 1b 內 task 順序：**1b.0a（inferWorkspaceHostId helper）→ 1b.0b（HostPickerPopover 元件）→ 1b.1（CommandSlot）→ 1b.1.5（Toast schema 擴充）→ 1b.2（slot-executor + resolveHostId）→ 1b.3（Settings UI）→ 1b.4（settings contribution + i18n）→ 1b.5a（context menu 入口）→ 1b.5b（hover popover 入口）→ 1b.6（全域驗證）**
 - [ ] Phase 1c 已 merge → main，**1c.1a（移除 SessionsSection row 的 v1 整合）→ 1c.1b（new-session 旁掛 HOST_ACTIONS）兩個 commits 同 PR、依序 ship**（先 commit 純減量，再 commit 純新增；diff 易 review）
 - [ ] Phase 1a 不可單獨 ship 在沒有 Phase 1b 計畫的情況（純資料層 user 看不到任何成果，會困惑）— 但 1a + 1b 兩個 PR 接力 ship 是允許的（spec §6 只要求 Settings UI 出現時必有 slot 生效）
 
@@ -2751,6 +3614,8 @@ Expected: clean
 - 不做 mode 設定 / 動態 function command / command palette / 快捷鍵（spec §6 不在範圍）
 - 不做 `module-registry.commands?` legacy 收編（Phase 2 decision gate，spec §8.2）
 - 不寫 persist migration（alpha-no-migration）
+- **不做 multi-host workspace binding 系統**（spec §3.5 forward-compat） — 未來 workspace 支援多重 `(hostId, path)` binding 與「default launcher」checkbox；`HostPickerPopover` 設計可重用，inferWorkspaceHostId 將退為「無 binding 時 fallback」，但 v2 不實作該層
+- **不做 Workspace.hostId schema 欄位** — spec v4 確定走 layout 多數決，不引入新 type 欄位
 
 ---
 
@@ -2760,6 +3625,7 @@ Expected: clean
 
 1. 進 worktree 後，**每個 Bash 指令必須以 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/quick-commands-v2 && ` 開頭**（feedback_subagent_cwd_enforcement.md）
 2. 一個 task 一個 commit，commit message 用 conventional commit + Co-Authored-By trailer
-3. zustand test setState **顯式列出** `global` / `byHost` / `bindings` 三個 mutable fields；**不要**只寫 `setState({ bindings: {...} })`，會 wipe 其他 state（feedback_zustand_harness_setstate.md）
+3. zustand test setState **顯式列出** `global` / `byHost` / `bindings` 三個 mutable fields；**不要**只寫 `setState({ bindings: {...} })`，會 wipe 其他 state（feedback_zustand_harness_setstate.md）。同樣原則套用 `useHostStore`（測試需要時列出 `hosts` / `hostOrder` / `runtime` / `activeHostId` 四個欄位）。
 4. 任何測試 / lint / build 指令在主 Claude 機器跑（feedback_codex_sandbox_no_install.md）
+5. **Phase 1b 任務依賴**：1b.0a 與 1b.0b 必須先於其他 1b.* 任務完成；1b.1（CommandSlot）依賴 1b.0a 的型別 + 1b.0b 不直接依賴但 picker 是後續 caller 必用；1b.2（executor）依賴 1b.0b 的 `resolveHostId` callback 契約；1b.5a / 1b.5b / 1c.1b 各自整合 picker UI
 5. PR 完成後委派 codex 兩輪 review（標準 + 攻擊/防守/體質）；發現問題彙整成表格（信心 / 關聯 / 複雜度）後決定即修 vs 開 issue 追蹤

--- a/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
+++ b/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
@@ -16,8 +16,16 @@
 
 **Phase 順序（強制 1a → 1b → 1c）：**
 1. **Phase 1a** — 純資料層；單一 PR；UI 零改動。
-2. **Phase 1b** — Settings UI + WORKSPACE_ACTIONS 入口；單一 PR，**必須與 Settings UI 同 PR ship**（spec §6 不 ship 設了沒效果的中間態）。
-3. **Phase 1c** — HOST_ACTIONS 入口；小 PR。
+2. **Phase 1b** — Settings UI + WORKSPACE_ACTIONS 入口；單一 PR，**必須與 Settings UI 同 PR ship**（spec §6 不 ship 設了沒效果的中間態）。Workspace 入口採雙進入點：(i) `WorkspaceRow` 右鍵 context menu；(ii) `WorkspaceRow` Plus 按鈕 hover 往左展開的 popover chip 列。兩入口共用同一個 `WORKSPACE_ACTIONS` slot + executor。
+3. **Phase 1c** — HOST_ACTIONS 入口；小 PR。Host 入口落於 `SessionsSection`：在 new-session 按鈕旁並列 `<CommandSlot mountTo=HOST_ACTIONS>`；同 PR 移除 `SessionsSection` 每個 session row 上殘留的 v1 `QuickCommandMenu`（功能集中至 new-session 入口；`QuickCommandMenu` 元件本身保留，因為仍被 `PaneLayoutRenderer.tsx` 使用）。
+
+**Mount UX 決策（覆蓋 spec §4.2 / §4.3 中的「位置由實作時定」）：**
+- **Workspace 入口** — `WorkspaceRow.tsx` 兩處：
+  - 右鍵 → 透過既有 `onContextMenuWorkspace` callback（App.tsx L155 `handleWsContextMenu` → 渲染 `WorkspaceContextMenu`），新增一個 `WorkspaceQuickCommandsContextMenu` 區塊或於原 `WorkspaceContextMenu` 加 quick-commands section
+  - Plus 按鈕（`WorkspaceRow.tsx` L108-121）hover → 一個 absolute popover 向左展開 chip 列（半透明漸層壓底；mouseleave Plus AND popover 收回；鍵盤 focus 同等於 hover）
+- **Host 入口** — `SessionsSection.tsx` 兩件事：
+  - new-session 按鈕（L167-174）旁並列 `<CommandSlot mountTo=HOST_ACTIONS>`；視覺與 Plus 對齊（直接列 chip，無 popover）
+  - 移除 row 上的 v1 `<QuickCommandMenu>`（L231-239）整合，但**保留** `QuickCommandMenu` 元件本身（`PaneLayoutRenderer.tsx` 仍使用）
 
 **測試指令備忘（主 Claude 機器跑，subagent 寫 plan 不執行）：**
 - SPA test: `cd spa && npx vitest run`
@@ -1020,6 +1028,125 @@ feat(spa): add <CommandSlot> shared component for v2 binding model
 
 ---
 
+### Task 1b.1.5: 擴 `useUndoToast` schema 支援自訂 action label（Retry）
+
+**Files:**
+- Modify: `spa/src/stores/useUndoToast.ts`
+- Modify: `spa/src/stores/useUndoToast.test.ts`
+- Modify: `spa/src/components/GlobalUndoToast.tsx`
+
+**動機：** Task 1b.2 的 slot-executor 在 send-keys 失敗時要顯示 toast 帶「Retry」按鈕（spec §3.3 表格第 2 列；user 決策採方案 (a) — 直接擴 schema），與既有 `OverviewSection.tsx` 的「Undo」按鈕共用同一條 toast。預設保留 `'Undo'` 維持向下相容。
+
+**既有 callsite 影響範圍盤點（grep `useUndoToast.*show|getState\(\)\.show`）：**
+- Production：`spa/src/components/hosts/OverviewSection.tsx:85`（`show(message, restore)` — 不傳 actionLabel，續用 `'Undo'`）
+- Test：`spa/src/stores/useUndoToast.test.ts`（自身單元測試）+ `spa/src/lib/host-lifecycle.test.ts`（只重置 toast=null，不呼叫 `show`，不受影響）
+- 共 1 個 production callsite，2 個測試檔；schema 擴充採 optional 第 3 參數，**無需修改既有 callsite 的呼叫形式**
+
+- [ ] **Step 1: Write the failing test**
+
+Edit `spa/src/stores/useUndoToast.test.ts` 加新測試（不要動既有測試 — 它們驗證向下相容）：
+
+```ts
+describe('useUndoToast — custom action label', () => {
+  beforeEach(() => {
+    useUndoToast.setState({ toast: null })
+  })
+
+  it('defaults actionLabel to undefined when not provided (back-compat)', () => {
+    useUndoToast.getState().show('msg', () => {})
+    const toast = useUndoToast.getState().toast
+    expect(toast?.actionLabel).toBeUndefined()
+  })
+
+  it('stores actionLabel when provided', () => {
+    useUndoToast.getState().show('Send keys failed', () => {}, 'Retry')
+    const toast = useUndoToast.getState().toast
+    expect(toast?.actionLabel).toBe('Retry')
+  })
+})
+```
+
+Edit `spa/src/components/GlobalUndoToast.tsx` 也加一條 component test（若該檔已有 test 則 append；若無則新建 `GlobalUndoToast.test.tsx`）：
+
+```tsx
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { GlobalUndoToast } from './GlobalUndoToast'
+import { useUndoToast } from '../stores/useUndoToast'
+
+describe('GlobalUndoToast — actionLabel', () => {
+  beforeEach(() => useUndoToast.setState({ toast: null }))
+
+  it('renders default Undo label when actionLabel is omitted', () => {
+    useUndoToast.getState().show('Deleted host', () => {})
+    render(<GlobalUndoToast />)
+    expect(screen.getByRole('button')).toHaveTextContent(/Undo/i)
+  })
+
+  it('renders custom actionLabel when provided (e.g. Retry)', () => {
+    useUndoToast.getState().show('Send keys failed', () => {}, 'Retry')
+    render(<GlobalUndoToast />)
+    expect(screen.getByRole('button')).toHaveTextContent(/Retry/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/stores/useUndoToast.test.ts src/components/GlobalUndoToast.test.tsx`
+Expected: FAIL — `actionLabel` 欄位不存在 / 元件還沒讀。
+
+- [ ] **Step 3: Implement schema extension**
+
+Edit `spa/src/stores/useUndoToast.ts`：
+
+```ts
+// spa/src/stores/useUndoToast.ts — Global undo toast state
+import { create } from 'zustand'
+
+interface UndoToastState {
+  toast: { message: string; restore: () => void; actionLabel?: string } | null
+  show: (message: string, restore: () => void, actionLabel?: string) => void
+  dismiss: () => void
+}
+
+export const useUndoToast = create<UndoToastState>()((set) => ({
+  toast: null,
+  show: (message, restore, actionLabel) =>
+    set({ toast: { message, restore, actionLabel } }),
+  dismiss: () => set({ toast: null }),
+}))
+```
+
+Edit `spa/src/components/GlobalUndoToast.tsx` 改 button label 取用：
+
+```tsx
+<button
+  className="text-sm text-blue-400 hover:text-blue-300 font-medium cursor-pointer"
+  onClick={() => {
+    toast.restore()
+    dismiss()
+  }}
+>
+  {toast.actionLabel ?? t('hosts.undo')}
+</button>
+```
+
+註：`actionLabel` 由 caller 傳 i18n 化字串（例如 `t('quick_commands.toast.retry')`）；`'hosts.undo'` 維持作為**未指定時的預設**，確保 `OverviewSection` 既有行為不變。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/stores/useUndoToast.test.ts src/components/GlobalUndoToast.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): extend useUndoToast schema with optional actionLabel (back-compat)
+```
+
+---
+
 ### Task 1b.2: Slot executor lib（建 session + 送 keys + 失敗 UX）
 
 **Files:**
@@ -1114,6 +1241,9 @@ describe('runWorkspaceSlot', () => {
     const toast = useUndoToast.getState().toast
     expect(toast).not.toBeNull()
     expect(toast!.message).toMatch(/Session created.*command failed/i)
+    // Task 1b.1.5 — actionLabel must surface 'Retry' (translated key allowed) instead of default 'Undo'
+    expect(toast!.actionLabel).toBeDefined()
+    expect(toast!.actionLabel).toMatch(/retry/i)
     // restore = retry — calling it should trigger executeCommand again
     ;(executeCommand as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
     toast!.restore()
@@ -1222,6 +1352,7 @@ export async function runWorkspaceSlot(
       () => {
         void executeCommand(ctx.hostId, sessionCode, cmd.command).catch(() => undefined)
       },
+      t('quick_commands.toast.retry'),  // ← Task 1b.1.5 introduced actionLabel; default ('Undo') doesn't fit retry semantics
     )
     return
   }
@@ -1800,6 +1931,7 @@ In `spa/src/locales/zh-TW.json` 加入：
   "quick_commands.toast.create_failed": "無法建立 session：{{reason}}",
   "quick_commands.toast.send_keys_failed": "Session 已建立，但指令送出失敗。",
   "quick_commands.toast.switch_failed": "已建立並送出指令，但無法切換焦點；請至 sessions 列表查看。",
+  "quick_commands.toast.retry": "重試",
 ```
 
 In `spa/src/locales/en.json` 對應加入：
@@ -1821,6 +1953,7 @@ In `spa/src/locales/en.json` 對應加入：
   "quick_commands.toast.create_failed": "Failed to start session: {{reason}}",
   "quick_commands.toast.send_keys_failed": "Session created, but command failed.",
   "quick_commands.toast.switch_failed": "Created and sent, but could not switch focus; check the sessions list.",
+  "quick_commands.toast.retry": "Retry",
 ```
 
 註：若 `common.edit` 已存在，跳過該行。檢查指令：`grep '"common.edit"' spa/src/locales/zh-TW.json`。
@@ -1838,125 +1971,513 @@ feat(spa): wire Quick Commands settings contribution + i18n keys
 
 ---
 
-### Task 1b.5: Workspace 入口 — 在 NewTabPage 顯示 quick actions（spec §4.2）
+### Task 1b.5a: Workspace 入口 (i) — `WorkspaceQuickCommandsContextMenu` + 整合 WorkspaceRow 右鍵
 
 **Files:**
-- Modify: `spa/src/components/NewTabPage.tsx`
-- Modify: `spa/src/components/NewTabPage.test.tsx`（若存在；否則新建 quick-actions-only test 檔）
+- Create: `spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx`
+- Create: `spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.test.tsx`
+- Modify: `spa/src/features/workspace/components/WorkspaceContextMenu.tsx`（嵌入新 section 或改由外層組合，見實作策略）
+- Modify: `spa/src/App.tsx`（`handleWsContextMenu` 已會接收 wsId — 需把 wsId 傳遞到下層以解析 hostId / 取 bindings）
+- Modify: `spa/src/features/workspace/components/WorkspaceContextMenu.test.tsx`（追加 quick commands section 測試）
 
-實作策略：在 NewTabPage 主格線**之上**加一條 `<CommandSlot mountTo={WORKSPACE_ACTIONS}>` toolbar。為什麼選 NewTabPage：
+**實作策略：** 既有 `WorkspaceContextMenu`（`spa/src/features/workspace/components/WorkspaceContextMenu.tsx`）已涵蓋 Settings / Tear-off / Merge-to。在現有「Settings」按鈕之上**插入** quick commands section（依 user 決策 (i)），保留 Settings/Tear-off/Merge-to 的 separator 規則。預設：
 
-1. NewTabPage 是 user 進到 workspace 後最常見的入口（每次新 tab 都在這），spec §4.2「workspace 主面板」最自然的對應。
-2. 已具有 hostId / activeWorkspaceId 取用路徑（透過 store）。
-3. 不破壞既有 PaneLayoutRenderer 的 v1 `QuickCommandMenu`（保留，不動）。
+1. 新元件 `WorkspaceQuickCommandsContextMenu` 渲染 mount=`WORKSPACE_ACTIONS` 的所有 bound commands；點擊執行 executor 並關閉 menu。
+2. 在 `WorkspaceContextMenu` 內部 `Settings` 按鈕**之前**渲染此新元件，並在其後加 `border-t` separator（若有任一個 quick command 顯示）。
+3. `App.tsx` 的 `WorkspaceContextMenu` 渲染處需新增傳 `workspaceId={wsContextMenu.wsId}` prop，使其能解析該 workspace 對應 host（透過 `useWorkspaceStore` 找 `workspace.hostId` — 若 store schema 有對應欄位；否則用 `activeHostId`）。
 
-替代方案候選（若 reviewer 反對放 NewTabPage，請討論後選一）：
-
-- 候選 A：`WorkspaceSettingsPage` 標題下方（user 開設定才看得到，過深）
-- 候選 B：`InlineTabList` / `WorkspaceRow` 同列 hover 顯示（過小、易誤觸）
-- **候選 C（採用）**：`NewTabPage` 頂部 toolbar，empty / pinned-only 兩種畫面都一致
+**重要：** `<CommandSlot>` 已具備 `isEnabled` short-circuit 與「無 binding 不渲染」邏輯，所以無 quick commands 時 menu 內部自動只剩既有項目，不會出現空 separator。
 
 - [ ] **Step 1: Write the failing test**
 
-Create or extend `spa/src/components/NewTabPage.test.tsx`：
+Create `spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.test.tsx`：
 
 ```tsx
-// 在既有 imports 末尾加：
-import { useQuickCommandStore } from '../stores/useQuickCommandStore'
-import { useHostStore } from '../stores/useHostStore'
-import { useWorkspaceStore } from '../features/workspace/store'
-import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WorkspaceQuickCommandsContextMenu } from './WorkspaceQuickCommandsContextMenu'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
 
-describe('NewTabPage — workspace quick actions slot (Phase 1b)', () => {
-  it('renders <CommandSlot mountTo=WORKSPACE_ACTIONS> with active hostId + workspaceId', () => {
-    // 設置 host + workspace + bind 一個 cmd 至 WORKSPACE_ACTIONS
-    useHostStore.setState({ activeHostId: 'h1', hostOrder: ['h1'] })
-    useWorkspaceStore.setState({ activeWorkspaceId: 'w1' })
-    useQuickCommandStore.setState({
-      global: [{ id: 'cmd-a', name: 'Alpha', command: 'echo' }],
-      byHost: {},
-      bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
-    })
-    render(<NewTabPage onSelect={() => undefined} />)
+function setup(workspaceId = 'w1', hostId = 'h1') {
+  useQuickCommandStore.setState({
+    global: [
+      { id: 'cmd-a', name: 'Alpha', command: 'a' },
+      { id: 'cmd-b', name: 'Bravo', command: 'b' },
+    ],
+    byHost: {},
+    bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+  })
+  useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  clearModuleRegistry()
+  registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
+  return { workspaceId, hostId }
+}
+
+describe('WorkspaceQuickCommandsContextMenu', () => {
+  beforeEach(() => setup())
+
+  it('renders bound WORKSPACE_ACTIONS commands and hides unbound ones', () => {
+    render(<WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId="h1" onClose={() => {}} />)
     expect(screen.getByLabelText(/^Alpha/)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^Bravo/)).toBeNull()
   })
 
-  it('hides slot toolbar when no commands are bound', () => {
-    useQuickCommandStore.setState({ global: [], byHost: {}, bindings: {} })
-    render(<NewTabPage onSelect={() => undefined} />)
-    expect(screen.queryByRole('toolbar', { name: /Quick commands/i })).toBeNull()
+  it('returns null when no commands are bound (lets parent skip separator)', () => {
+    useQuickCommandStore.setState({ bindings: {} })
+    const { container } = render(
+      <WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId="h1" onClose={() => {}} />,
+    )
+    expect(container.firstChild).toBeNull()
   })
+
+  it('clicking a command calls onClose', () => {
+    const onClose = vi.fn()
+    render(<WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId="h1" onClose={onClose} />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('returns null when quick-commands module is disabled', () => {
+    useModuleEnabledStore.getState().setEnabled('quick-commands', false)
+    const { container } = render(
+      <WorkspaceQuickCommandsContextMenu workspaceId="w1" hostId="h1" onClose={() => {}} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})
+```
+
+也在 `WorkspaceContextMenu.test.tsx` 追加 integration 測試：
+
+```tsx
+it('renders quick commands section above Settings when WORKSPACE_ACTIONS bindings exist', () => {
+  // 設定一個 binding（簡化：直接 mock useQuickCommandStore）
+  useQuickCommandStore.setState({
+    global: [{ id: 'cmd-x', name: 'XCmd', command: 'x' }],
+    byHost: {},
+    bindings: { 'cmd-x': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+  })
+  // … 既有 setup（registerModule quick-commands etc）…
+  render(
+    <WorkspaceContextMenu
+      position={{ x: 0, y: 0 }}
+      workspaceId="w1"
+      hostId="h1"
+      onSettings={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  )
+  expect(screen.getByLabelText(/^XCmd/)).toBeInTheDocument()
 })
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd spa && npx vitest run src/components/NewTabPage.test.tsx`
-Expected: FAIL — slot 未掛載。
+Run: `cd spa && npx vitest run src/features/workspace/components/WorkspaceQuickCommandsContextMenu.test.tsx src/features/workspace/components/WorkspaceContextMenu.test.tsx`
+Expected: FAIL — module not found / props missing。
 
-- [ ] **Step 3: Implement workspace entry**
+- [ ] **Step 3: Implement**
 
-In `spa/src/components/NewTabPage.tsx`：
-
-加 import：
+Create `spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx`：
 
 ```tsx
-import { CommandSlot } from './CommandSlot'
-import { runWorkspaceSlot } from '../lib/slot-executor'
-import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
-import { useHostStore } from '../stores/useHostStore'
-import { useWorkspaceStore } from '../features/workspace/store'
-import { useTabStore } from '../stores/useTabStore'
-```
+import { CommandSlot } from '../../../components/CommandSlot'
+import { runWorkspaceSlot } from '../../../lib/slot-executor'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+import { useTabStore } from '../../../stores/useTabStore'
 
-在 `return (...)` 主 grid container **外層**包一個 flex column；slot toolbar 在 grid 之前：
+interface Props {
+  workspaceId: string
+  hostId: string
+  onClose: () => void
+}
 
-```tsx
-  const activeHostId = useHostStore((s) => s.activeHostId)
-  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
-
-  // ... 原 hydration / providers 邏輯不變
-  // (直到 return)
-
+/**
+ * 渲染 mount=WORKSPACE_ACTIONS 的 quick commands，作為 WorkspaceContextMenu 的子 section。
+ * <CommandSlot> 自身會 short-circuit module disabled / no-bindings 兩個情況。
+ * 為了讓 parent 能正確 toggle separator，**沒有 bound commands 時整個 wrapper 也回 null**
+ * — 透過讀同樣的 store 直接判斷（避免引入新 prop）。
+ */
+export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose }: Props) {
   return (
-    <div className="flex-1 flex flex-col">
-      {activeHostId && (
-        <div className="px-6 pt-4">
-          <CommandSlot
-            mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
-            ctx={{ hostId: activeHostId, workspaceId: activeWorkspaceId }}
-            executor={(cmd, ctx) =>
-              runWorkspaceSlot(cmd, ctx, {
-                switchToSession: (hostId, sessionCode) => {
-                  useTabStore.getState().openSingletonTab({
-                    kind: 'tmux-session',
-                    hostId,
-                    sessionCode,
-                  })
-                },
-              })
-            }
-          />
-        </div>
-      )}
-      <div className={`flex-1 grid overflow-hidden gap-6 px-6 pt-8 ${gridCols}`}>
-        {/* … 原 columns 渲染 … */}
-      </div>
+    <div className="py-1">
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId, workspaceId }}
+        executor={async (cmd, ctx) => {
+          try {
+            await runWorkspaceSlot(cmd, ctx, {
+              switchToSession: (h, sessionCode) => {
+                useTabStore.getState().openSingletonTab({
+                  kind: 'tmux-session',
+                  hostId: h,
+                  sessionCode,
+                })
+              },
+            })
+          } finally {
+            onClose()
+          }
+        }}
+        render={(cmd) => (
+          <button
+            type="button"
+            aria-label={cmd.name}
+            className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-surface-hover cursor-pointer transition-colors"
+          >
+            <span className="truncate">{cmd.name}</span>
+            {cmd.category && (
+              <span className="text-[10px] text-text-muted bg-surface-primary px-1.5 py-0.5 rounded ml-auto">
+                {cmd.category}
+              </span>
+            )}
+          </button>
+        )}
+      />
     </div>
   )
+}
 ```
 
-註：`openSingletonTab` 已存在於 `useTabStore`（既有 terminal-link skill 用過此 path，見 `register-modules.tsx` L429）。如果 PaneContent type 對 `tmux-session` 必填欄位不同，請查 `spa/src/types/tab.ts` 並補。
+**注意 render prop 與 onClick：** `<CommandSlot>` 預設 button 已含 `onClick`，但提供 `render` 時 wrapper 是 `<span>`（見 Task 1b.1 實作 L979）。我們需要**改用 default button** 才能讓 executor 跑；這代表此 task 不傳 `render` prop，採用 default 渲染（chip 樣式不適合 menu 列表，但 v1 可接受；若 reviewer 要求 menu 列表外觀，需要在 Task 1b.1 補一個 `containerClassName` / `itemClassName` prop，或讓 `render` 包外層 + 提供 onClick，二擇一）。
+
+**簡化決議：** **保持 default 渲染**（不傳 render），用 `containerClassName` 覆蓋 `flex flex-wrap gap-1.5`（若 Task 1b.1 沒提供，需擴 `<CommandSlot>` 介面 — 在此 task 內微擴）。
+
+→ **追加 sub-step 0**: 擴 `<CommandSlot>` 加一個 optional `containerClassName?: string` prop，預設沿用既有 toolbar 樣式；context menu 用 `flex flex-col`。修改 `spa/src/components/CommandSlot.tsx` 與其 test。Diff：
+
+```tsx
+interface Props {
+  mountTo: QuickCommandSlotId
+  ctx: SlotContext
+  executor: SlotExecutor
+  render?: SlotRenderer
+  containerClassName?: string  // ← new
+}
+
+// in JSX:
+<div className={containerClassName ?? 'flex flex-wrap items-center gap-1.5'} role="toolbar" aria-label="Quick commands">
+```
+
+並在 `WorkspaceQuickCommandsContextMenu` 改傳 `containerClassName="flex flex-col"`。
+
+更新後 `WorkspaceContextMenu.tsx`：
+
+```tsx
+interface Props {
+  position: { x: number; y: number }
+  workspaceId?: string  // ← new (optional 維持向下相容；測試 setup 內全部要傳)
+  hostId?: string       // ← new
+  onSettings: () => void
+  onTearOff?: () => void
+  onMergeTo?: (targetWindowId: string) => void
+  onClose: () => void
+}
+
+// JSX 中於 Settings 按鈕之前加：
+{workspaceId && hostId && (
+  <>
+    <WorkspaceQuickCommandsContextMenu
+      workspaceId={workspaceId}
+      hostId={hostId}
+      onClose={onClose}
+    />
+    <div className="border-t border-border-default my-1" />
+  </>
+)}
+```
+
+**注意：** separator 渲染條件 — 應僅當「真有 commands 顯示」才 separator，否則會出現「空 wrapper + separator」的視覺空隙。`<CommandSlot>` 在 0 commands 時回 `null`，但 wrapper `<div>` 仍存在。**解法**：把 separator 也透過讀 store 判斷：
+
+```tsx
+// 在 WorkspaceContextMenu.tsx，新增 helper：
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+
+// 計算 hasQuickCommands：
+const hasQuickCommands = useQuickCommandStore((s) => {
+  if (!hostId) return false
+  const cmds = s.getCommands(hostId)
+  return cmds.some((c) => s.bindings[c.id]?.includes(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS))
+})
+const moduleEnabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
+const showQuickCommandsSection = workspaceId && hostId && moduleEnabled && hasQuickCommands
+
+// JSX：
+{showQuickCommandsSection && (
+  <>
+    <WorkspaceQuickCommandsContextMenu workspaceId={workspaceId!} hostId={hostId} onClose={onClose} />
+    <div className="border-t border-border-default my-1" />
+  </>
+)}
+```
+
+修改 `App.tsx` 的 `<WorkspaceContextMenu>` 呼叫處（L322-329）：
+
+```tsx
+{wsContextMenu && (() => {
+  const ws = workspaces.find((w) => w.id === wsContextMenu.wsId)
+  // hostId 來源：workspace 上的 hostId 欄位（若 schema 有），否則用 useHostStore.activeHostId fallback
+  const hostId = (ws as { hostId?: string } | undefined)?.hostId ?? useHostStore.getState().activeHostId
+  return (
+    <WorkspaceContextMenu
+      position={wsContextMenu.position}
+      workspaceId={wsContextMenu.wsId}
+      hostId={hostId ?? undefined}
+      onSettings={() => openWsSettings(wsContextMenu.wsId)}
+      onTearOff={window.electronAPI ? () => handleWsTearOff(wsContextMenu.wsId) : undefined}
+      onMergeTo={window.electronAPI ? (targetWindowId) => handleWsMergeTo(wsContextMenu.wsId, targetWindowId) : undefined}
+      onClose={handleCloseWsContextMenu}
+    />
+  )
+})()}
+```
+
+註：`workspaces[].hostId` 是否存在須在實作前由 subagent grep 確認（`rg "hostId" spa/src/types/tab.ts`）；若不存在則 fallback 到 `useHostStore.activeHostId`。
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `cd spa && npx vitest run src/components/NewTabPage.test.tsx`
+Run: `cd spa && npx vitest run src/features/workspace/components/WorkspaceQuickCommandsContextMenu.test.tsx src/features/workspace/components/WorkspaceContextMenu.test.tsx src/components/CommandSlot.test.tsx`
 Expected: PASS
 
 - [ ] **Step 5: Commit**
 
 ```
-feat(spa): mount WORKSPACE_ACTIONS slot in NewTabPage header
+feat(spa): mount WORKSPACE_ACTIONS slot in workspace right-click context menu
+```
+
+---
+
+### Task 1b.5b: Workspace 入口 (ii) — `WorkspaceQuickActionsPopover` + WorkspaceRow Plus hover
+
+**Files:**
+- Create: `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx`
+- Create: `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx`
+- Modify: `spa/src/features/workspace/components/WorkspaceRow.tsx`
+- Modify: `spa/src/features/workspace/components/WorkspaceRow.test.tsx`
+
+**實作策略：**
+- 改造 `WorkspaceRow.tsx` L107-121 的 Plus 按鈕：保留原 click 行為（`onAddTabToWorkspace`）但**外層**多包一個 `<div onMouseEnter={...} onMouseLeave={...} onFocusCapture={...} onBlurCapture={...}>` 作 hover hub。
+- 該 div 內含 Plus button + 一個 absolute popover（`<WorkspaceQuickActionsPopover>`），popover `right-full mr-1`（Plus 按鈕左側）展開。
+- popover 內部用 `<CommandSlot mountTo=WORKSPACE_ACTIONS>` 渲染 chip 列。
+- Hover 收回邏輯：使用 single boolean state `popoverOpen`；mouseenter Plus 或 popover 任一觸發開啟，mouseleave 整個 hub 觸發關閉（用 wrapper div 圍住兩者，事件冒泡判斷即可）。
+- 鍵盤可達性：Plus 按鈕 focus 時 popover 開啟（`onFocusCapture`），整個 wrapper blur 時關閉（`onBlurCapture` + 比對 `relatedTarget` 是否仍在 wrapper 內）。
+- 視覺 cue：popover 含半透明漸層壓底（`bg-gradient-to-l from-surface-secondary/0 to-surface-secondary/95` 或同等 token）。
+- **Plus 原本 hover 才顯**（L117 `opacity-0 group-hover/ws-header:opacity-100`）— 此邏輯保留。
+
+**短路條件：** `<CommandSlot>` 已內建 module-disabled / no-bindings short-circuit；`WorkspaceQuickActionsPopover` 額外用同邏輯（讀 store 並 early-return null）避免在無 commands 時渲染空 popover wrapper（避免 hover 觸發後出現空白浮層）。
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx`：
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { WorkspaceQuickActionsPopover } from './WorkspaceQuickActionsPopover'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
+
+function setup() {
+  useQuickCommandStore.setState({
+    global: [{ id: 'cmd-a', name: 'Alpha', command: 'a' }],
+    byHost: {},
+    bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+  })
+  useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  clearModuleRegistry()
+  registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
+}
+
+describe('WorkspaceQuickActionsPopover', () => {
+  beforeEach(setup)
+
+  it('renders bound commands as chips', () => {
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />)
+    expect(screen.getByLabelText(/^Alpha/)).toBeInTheDocument()
+  })
+
+  it('returns null when no commands bound', () => {
+    useQuickCommandStore.setState({ bindings: {} })
+    const { container } = render(
+      <WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('returns null when module disabled', () => {
+    useModuleEnabledStore.getState().setEnabled('quick-commands', false)
+    const { container } = render(
+      <WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})
+```
+
+並於 `WorkspaceRow.test.tsx` 追加 hover 行為測試：
+
+```tsx
+it('opens popover on Plus hover, closes on mouseleave (with WORKSPACE_ACTIONS bindings)', () => {
+  // 既有 ws-header render setup（保持原 props 模式）
+  // 設定一個 WORKSPACE_ACTIONS binding
+  useQuickCommandStore.setState({
+    global: [{ id: 'cmd-x', name: 'X', command: 'x' }],
+    byHost: {},
+    bindings: { 'cmd-x': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+  })
+  // 確保 hostId 路徑解析成功（mock useHostStore.activeHostId 或 workspace.hostId）
+  // … render(<WorkspaceRow … />) …
+
+  // 預設未 hover → popover 不在 DOM
+  expect(screen.queryByLabelText(/^X/)).toBeNull()
+
+  // hover Plus → popover 顯示
+  fireEvent.mouseEnter(screen.getByLabelText(/Add tab to/i).parentElement!)
+  expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+
+  // mouseleave wrapper → popover 收回
+  fireEvent.mouseLeave(screen.getByLabelText(/Add tab to/i).parentElement!)
+  expect(screen.queryByLabelText(/^X/)).toBeNull()
+})
+
+it('does NOT open popover when no WORKSPACE_ACTIONS bindings exist', () => {
+  useQuickCommandStore.setState({ bindings: {} })
+  // … render WorkspaceRow …
+  fireEvent.mouseEnter(screen.getByLabelText(/Add tab to/i).parentElement!)
+  expect(screen.queryByRole('toolbar', { name: /Quick commands/i })).toBeNull()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx src/features/workspace/components/WorkspaceRow.test.tsx`
+Expected: FAIL — module not found / popover 不顯示。
+
+- [ ] **Step 3: Implement popover + WorkspaceRow integration**
+
+Create `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx`：
+
+```tsx
+import { CommandSlot } from '../../../components/CommandSlot'
+import { runWorkspaceSlot } from '../../../lib/slot-executor'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+import { useTabStore } from '../../../stores/useTabStore'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+
+interface Props {
+  workspaceId: string
+  hostId: string
+}
+
+/**
+ * Popover chip-list rendered to the LEFT of the Plus-button on each
+ * WorkspaceRow on hover/focus. Uses CommandSlot internally — already
+ * short-circuits when module disabled / no bindings; we additionally
+ * skip rendering the popover wrapper itself in those cases so the
+ * hover trigger doesn't expose an empty floating panel.
+ */
+export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
+  const moduleEnabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
+  const hasBindings = useQuickCommandStore((s) => {
+    const cmds = s.getCommands(hostId)
+    return cmds.some((c) => s.bindings[c.id]?.includes(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS))
+  })
+  if (!moduleEnabled || !hasBindings) return null
+
+  return (
+    <div
+      role="group"
+      aria-label="Workspace quick actions"
+      className="absolute right-full top-1/2 -translate-y-1/2 mr-1 flex items-center gap-1 px-2 py-1 rounded-md bg-gradient-to-l from-surface-secondary/0 to-surface-secondary/95 backdrop-blur-sm shadow-md z-30"
+    >
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId, workspaceId }}
+        executor={(cmd, ctx) =>
+          runWorkspaceSlot(cmd, ctx, {
+            switchToSession: (h, sessionCode) => {
+              useTabStore.getState().openSingletonTab({
+                kind: 'tmux-session',
+                hostId: h,
+                sessionCode,
+              })
+            },
+          })
+        }
+      />
+    </div>
+  )
+}
+```
+
+修改 `spa/src/features/workspace/components/WorkspaceRow.tsx` Plus 按鈕區段（L107-121）：
+
+```tsx
+import { useState, useRef } from 'react'
+// … 既有 imports
+import { useHostStore } from '../../../stores/useHostStore'
+import { WorkspaceQuickActionsPopover } from './WorkspaceQuickActionsPopover'
+
+// 在 WorkspaceRow 函式內：
+const [popoverOpen, setPopoverOpen] = useState(false)
+const hubRef = useRef<HTMLDivElement>(null)
+// hostId 解析（同 1b.5a：先看 workspace.hostId，否則 active）
+const hostId = (workspace as { hostId?: string }).hostId
+  ?? useHostStore((s) => s.activeHostId) ?? null
+
+// 改 Plus 區段（保留原條件 showTabs）：
+{showTabs && (
+  <div
+    ref={hubRef}
+    className="relative inline-flex"
+    onMouseEnter={() => setPopoverOpen(true)}
+    onMouseLeave={() => setPopoverOpen(false)}
+    onFocusCapture={() => setPopoverOpen(true)}
+    onBlurCapture={(e) => {
+      // 只有焦點離開整個 hub 才關閉（避免 popover 內部 chip 之間 tab 也觸發）
+      if (!hubRef.current?.contains(e.relatedTarget as Node | null)) {
+        setPopoverOpen(false)
+      }
+    }}
+  >
+    <button
+      type="button"
+      aria-label={t('nav.add_tab_to_workspace', { name: workspace.name })}
+      title={t('nav.add_tab_to_workspace', { name: workspace.name })}
+      onClick={(e) => {
+        e.stopPropagation()
+        onAddTabToWorkspace(workspace.id)
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      className="p-0.5 rounded hover:bg-surface-secondary hover:text-text-primary cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity focus:outline-none"
+    >
+      <Plus size={12} />
+    </button>
+    {popoverOpen && hostId && (
+      <WorkspaceQuickActionsPopover workspaceId={workspace.id} hostId={hostId} />
+    )}
+  </div>
+)}
+```
+
+註：popover 觸發 hover 時 Plus 仍是 hover 中（同一個 group），不會閃。`WorkspaceQuickActionsPopover` 內部已 short-circuit 模組停用 / 無 binding，這層也再加 hostId guard。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx src/features/workspace/components/WorkspaceRow.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat(spa): add hover popover for WORKSPACE_ACTIONS chips beside WorkspaceRow Plus button
 ```
 
 ---
@@ -1992,19 +2513,22 @@ Expected: clean
 
 啟動 daemon + dev SPA，user flow：
 1. Settings → Quick Commands → New → 輸入 Name + Command + 勾 Workspace → Save
-2. 開新 tab，看到 toolbar 出現按鈕
-3. 點按鈕 → 建 session、送 cmd、自動切到該 session
-4. 模擬失敗（停 daemon → 點按鈕 → 應有 toast）
+2. 在 sidebar Workspace 行 **右鍵** → context menu 出現該 quick command；點擊執行
+3. 在 sidebar Workspace 行 **hover Plus 按鈕** → 左側 popover 展開 chip；點擊執行
+4. 兩條路徑都應：建 session、送 cmd、自動切到該 session
+5. 模擬失敗（停 daemon → 點按鈕 → 應有 toast）；send-keys 失敗的 toast 應顯 'Retry' 按鈕（Task 1b.1.5 + 1b.2 共同支撐）
 
 ### Phase 1b 驗收清單
 
 - [x] Settings 頁面可建 / 編 / 刪 commands；mount chips 可多選
 - [x] 對話框 a11y：focus trap / Esc / aria-label / 觸發鍵盤可達
-- [x] 設 mount = WORKSPACE 後，回 NewTabPage 立即看到按鈕（無需 reload）
+- [x] 設 mount = WORKSPACE 後，回 sidebar 即可在「Workspace 右鍵 menu」與「Plus hover popover」兩個入口看到按鈕（無需 reload）
+- [x] 兩個入口共用同一個 executor，行為一致
+- [x] Plus hover popover：mouseleave Plus AND popover 收回；鍵盤 focus 同等於 hover；無 binding 時不展開
 - [x] 點擊按鈕：建 session + 送 keys + 切過去
-- [x] 三層失敗 UX 符合 spec §3.3：建失敗 / 送 keys 失敗仍切過去 + retry / 切失敗 toast
-- [x] 停用 quick-commands module → slot 立即消失（CommandSlot short-circuit）
-- [x] i18n: zh-TW + en 全部 key 齊全（`pnpm run lint` 含 locale-completeness 檢查）
+- [x] 三層失敗 UX 符合 spec §3.3：建失敗 / 送 keys 失敗仍切過去 + **toast 顯 'Retry' 按鈕** / 切失敗 toast
+- [x] 停用 quick-commands module → 兩個入口皆立即消失（CommandSlot short-circuit）
+- [x] i18n: zh-TW + en 全部 key 齊全（含新增 `quick_commands.toast.retry`；`pnpm run lint` 含 locale-completeness 檢查）
 
 ---
 
@@ -2012,60 +2536,111 @@ Expected: clean
 
 **目標：** Host 詳情頁加 quick actions 區塊；user 設 mount = HOST 即可在 host 頁看到按鈕。
 
-### Task 1c.1: Host 詳情頁加 `<CommandSlot mountTo=HOST_ACTIONS>`
+### Task 1c.1a: 移除 `SessionsSection` row 上殘留的 v1 `QuickCommandMenu` 整合
 
 **Files:**
-- Modify: `spa/src/components/hosts/OverviewSection.tsx`
-- Modify: `spa/src/components/hosts/OverviewSection.test.tsx`
+- Modify: `spa/src/components/hosts/SessionsSection.tsx`
+- Modify: `spa/src/components/hosts/SessionsSection.test.tsx`（若有測試覆蓋 row 上 QuickCommandMenu，更新）
 
-實作位置：`OverviewSection` 是 host 詳情的第一個 section，user 進 host 頁預設看到。在主標題 / 連線狀態列**之下**加一條 `<CommandSlot>` toolbar。HostSidebar 之外的容器是 `HostPage` 的 `<div className="flex-1 overflow-y-auto p-6">`，OverviewSection 直接渲染進去。
+**動機（user 決策）：** 把 quick commands 功能集中在「new-session 入口」（Task 1c.1b），row 上不再重複；spec §3.4「保留現狀」原則被 user 明確覆蓋。
 
-替代方案候選（若 reviewer 想放在更外層）：
+**重要：** v1 `QuickCommandMenu` 元件本身**不刪**，因為仍被 `spa/src/components/PaneLayoutRenderer.tsx` 使用。本 task 只刪 `SessionsSection.tsx` 內的整合。
 
-- 候選 A（採用）：`OverviewSection` 標題下方，user 多半從 sidebar 進來都先停在 overview
-- 候選 B：`HostPage` 上方共通容器（強制每個 host sub-page 都看到，但會干擾 sessions / agents 的本身排版）
+**Diff scope（`SessionsSection.tsx`）：**
+1. 移除 L12 的 `import { QuickCommandMenu } from '../QuickCommandMenu'`
+2. 移除 L13 的 `import { executeCommand } from '../../lib/execute-command'`（若無其他用途；先 grep 該檔案內其他 `executeCommand` 引用，確認可刪）
+3. 移除 L231-239 的 `<QuickCommandMenu hostId=... onExecute=... disabled=... />` JSX 與其包圍的閒置 wrapper（若 row 移除 menu 後 `<div className="flex items-center justify-end gap-1">` 仍要保留供其他 buttons 使用，**保留**該 div，只刪 `<QuickCommandMenu>` 一段）
+4. 任何已成 unused 的 import / branch / state 一併清理（lint 會抓 unused，但先手動掃）
+
+- [ ] **Step 1: Update tests to assert removal**
+
+Edit `spa/src/components/hosts/SessionsSection.test.tsx`：
+- 若有測試斷言「session row 顯示 quick command 按鈕」，改為斷言「session row 不再有該按鈕」（或 `getAllByLabelText(/Quick Command/i)` 為空）
+- 若沒對應測試，新增一條保護性測試：
+
+```tsx
+it('does NOT render v1 QuickCommandMenu inside session rows (moved to new-session adjacency, Phase 1c)', () => {
+  // 既有 setup：mock host / sessions store，render <SessionsSection hostId="h1" />
+  // 假設 v1 QuickCommandMenu 的 trigger 有 aria-label 含 "Quick Commands"
+  expect(screen.queryAllByRole('button', { name: /quick commands/i }).length).toBe(0)
+})
+```
+
+註：實際 aria-label 由 `QuickCommandMenu` 元件決定（subagent 實作前先讀 `spa/src/components/QuickCommandMenu.tsx` 確認 trigger 的 accessible name；若不同請對齊）。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/components/hosts/SessionsSection.test.tsx`
+Expected: FAIL — row 上仍有 v1 menu。
+
+- [ ] **Step 3: Remove the integration**
+
+按 Diff scope 進行刪除。再驗證 lint：`cd spa && pnpm run lint`（unused imports/vars 必清）。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/components/hosts/SessionsSection.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+refactor(spa): remove v1 QuickCommandMenu from SessionsSection rows (consolidated to new-session entry, see Task 1c.1b)
+```
+
+註：本 task 與 1c.1b 是**獨立 commits 同一個 PR**；先刪除（diff 純減量、易 review），再加新（diff 純新增）。
+
+---
+
+### Task 1c.1b: `SessionsSection` new-session 旁加 `<CommandSlot mountTo=HOST_ACTIONS>`
+
+**Files:**
+- Modify: `spa/src/components/hosts/SessionsSection.tsx`
+- Modify: `spa/src/components/hosts/SessionsSection.test.tsx`
+
+**Mount 位置（user 決策）：** `SessionsSection.tsx` L165-175 的 `<div className="flex items-center justify-between mb-4">` 內，new-session 按鈕（L167-174）的**同一個 flex container**裡並列。`<CommandSlot>` 預設 chip toolbar 樣式恰好對應，視覺與 `Plus + 新增 session` 按鈕對齊；不做特殊 popover。
+
+**設計：** 把 new-session 按鈕外層改為 `<div className="flex items-center gap-2">`（包 CommandSlot + new-session button 兩者），整體右對齊（保留外層 `justify-between` 與標題的相對位置）。
 
 - [ ] **Step 1: Write the failing test**
 
-In `spa/src/components/hosts/OverviewSection.test.tsx` 加一段（或新建測試檔，視既有 OverviewSection.test 的 setup 而定）：
+Edit `spa/src/components/hosts/SessionsSection.test.tsx`：
 
 ```tsx
 import { useQuickCommandStore } from '../../stores/useQuickCommandStore'
 import { QUICK_COMMAND_SLOTS } from '../../lib/quick-command-slots'
 
-describe('OverviewSection — host quick actions slot (Phase 1c)', () => {
-  it('renders <CommandSlot mountTo=HOST_ACTIONS> with given hostId', () => {
+describe('SessionsSection — host quick actions slot adjacent to new-session button (Phase 1c)', () => {
+  it('renders <CommandSlot mountTo=HOST_ACTIONS> chips next to the new-session button', () => {
     useQuickCommandStore.setState({
       global: [{ id: 'cmd-h', name: 'HostCmd', command: 'echo h' }],
       byHost: {},
       bindings: { 'cmd-h': [QUICK_COMMAND_SLOTS.HOST_ACTIONS] },
     })
-    // (preserve existing host store setup)
-    useHostStore.setState({
-      hosts: { 'h1': { id: 'h1', name: 'Mini', /* … */ } as never },
-      hostOrder: ['h1'],
-      runtime: { 'h1': { status: 'connected' } as never },
-    })
-    render(<OverviewSection hostId="h1" />)
+    // 既有 host store setup（hostId='h1' connected）
+    render(<SessionsSection hostId="h1" />)
+    // chip 與 new-session 按鈕同一 flex 容器；簡化驗證：兩者都在 DOM
     expect(screen.getByLabelText(/^HostCmd/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /new session/i })).toBeInTheDocument()
   })
 
-  it('hides slot when no commands are bound to HOST_ACTIONS', () => {
+  it('hides slot when no commands are bound to HOST_ACTIONS (new-session button still visible)', () => {
     useQuickCommandStore.setState({ global: [], byHost: {}, bindings: {} })
-    render(<OverviewSection hostId="h1" />)
+    render(<SessionsSection hostId="h1" />)
     expect(screen.queryByLabelText(/^HostCmd/)).toBeNull()
+    expect(screen.getByRole('button', { name: /new session/i })).toBeInTheDocument()
   })
 })
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd spa && npx vitest run src/components/hosts/OverviewSection.test.tsx`
+Run: `cd spa && npx vitest run src/components/hosts/SessionsSection.test.tsx`
 Expected: FAIL — slot 未掛載。
 
 - [ ] **Step 3: Mount the slot**
 
-In `spa/src/components/hosts/OverviewSection.tsx`：
+In `spa/src/components/hosts/SessionsSection.tsx`：
 
 加 imports：
 
@@ -2076,37 +2651,50 @@ import { QUICK_COMMAND_SLOTS } from '../../lib/quick-command-slots'
 import { useTabStore } from '../../stores/useTabStore'
 ```
 
-在 OverviewSection JSX root 的開頭區塊加（host 名稱 / status 區塊**之後**）：
+修改 L165-175 區段：
 
 ```tsx
-<CommandSlot
-  mountTo={QUICK_COMMAND_SLOTS.HOST_ACTIONS}
-  ctx={{ hostId }}
-  executor={(cmd, ctx) =>
-    runWorkspaceSlot(cmd, ctx, {
-      switchToSession: (h, sessionCode) => {
-        useTabStore.getState().openSingletonTab({
-          kind: 'tmux-session',
-          hostId: h,
-          sessionCode,
+<div className="flex items-center justify-between mb-4">
+  <h2 className="text-lg font-semibold">{t('hosts.sessions')}</h2>
+  <div className="flex items-center gap-2">
+    <CommandSlot
+      mountTo={QUICK_COMMAND_SLOTS.HOST_ACTIONS}
+      ctx={{ hostId }}
+      executor={(cmd, ctx) =>
+        runWorkspaceSlot(cmd, ctx, {
+          switchToSession: (h, sessionCode) => {
+            useTabStore.getState().openSingletonTab({
+              kind: 'tmux-session',
+              hostId: h,
+              sessionCode,
+            })
+          },
         })
-      },
-    })
-  }
-/>
+      }
+    />
+    <button
+      onClick={() => setShowNew(true)}
+      disabled={isOffline}
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs bg-accent text-white cursor-pointer disabled:opacity-50"
+    >
+      <Plus size={14} />
+      {t('hosts.new_session')}
+    </button>
+  </div>
+</div>
 ```
 
 註：HOST_ACTIONS slot 和 WORKSPACE_ACTIONS 共用同一個 `runWorkspaceSlot`（spec §3.2 兩列行為差只在 cwd 取值來源；Phase 1 兩者都 fallback 到 host default `~`，所以 helper 命名雖叫 `runWorkspaceSlot` 仍正確；Phase 2 若 cwd 取值要分流再拆）。
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `cd spa && npx vitest run src/components/hosts/OverviewSection.test.tsx`
+Run: `cd spa && npx vitest run src/components/hosts/SessionsSection.test.tsx`
 Expected: PASS
 
 - [ ] **Step 5: Commit**
 
 ```
-feat(spa): mount HOST_ACTIONS slot in host overview section
+feat(spa): mount HOST_ACTIONS slot beside new-session button in SessionsSection
 ```
 
 ---
@@ -2140,23 +2728,25 @@ Expected: clean
 
 ### Phase 1c 驗收清單
 
-- [x] User 能在 Settings 設 mount = HOST，並在 host 詳情 overview 看到按鈕
-- [x] 按鈕點擊：建 session（cwd 取 host default）+ 送 cmd + 切過去
+- [x] User 能在 Settings 設 mount = HOST，並在 host 詳情 sessions section 標題列、new-session 按鈕**旁邊**看到 chip
+- [x] Chip 點擊：建 session（cwd 取 host default）+ 送 cmd + 切過去
 - [x] HOST_ACTIONS slot 與 WORKSPACE_ACTIONS slot 共存無衝突（兩者都可同時 mount）
+- [x] `SessionsSection` 內**每個 session row 不再**出現 v1 `QuickCommandMenu`（改集中至 new-session 入口）
+- [x] `PaneLayoutRenderer.tsx` 的 v1 `QuickCommandMenu` 仍維持運作（元件本身未被刪）
 
 ---
 
 ## Phase 完成順序檢查清單（送 reviewer 前確認）
 
 - [ ] Phase 1a 已 merge → main，且 alpha bump 完成（或一個 PR sequence 規劃中）
-- [ ] Phase 1b 已 merge → main，**Settings UI 與 WORKSPACE_ACTIONS 入口同 PR**（不可拆兩 PR）
-- [ ] Phase 1c 已 merge → main
+- [ ] Phase 1b 已 merge → main，**Settings UI 與 WORKSPACE_ACTIONS 兩個入口（context menu + hover popover）同 PR**（不可拆）
+- [ ] Phase 1c 已 merge → main，**1c.1a（移除 SessionsSection row 的 v1 整合）→ 1c.1b（new-session 旁掛 HOST_ACTIONS）兩個 commits 同 PR、依序 ship**（先 commit 純減量，再 commit 純新增；diff 易 review）
 - [ ] Phase 1a 不可單獨 ship 在沒有 Phase 1b 計畫的情況（純資料層 user 看不到任何成果，會困惑）— 但 1a + 1b 兩個 PR 接力 ship 是允許的（spec §6 只要求 Settings UI 出現時必有 slot 生效）
 
 ## 範圍邊界（Phase 1 不做）
 
 - 不動 `PaneLayoutRenderer` 內 `extraActions` 的 v1 `QuickCommandMenu`（spec §3.4）
-- 不動 `SessionsSection` row actions 的 v1 `QuickCommandMenu`（spec §3.4）
+- ~~不動 `SessionsSection` row actions 的 v1 `QuickCommandMenu`~~ — **已調整：Phase 1c Task 1c.1a 將 SessionsSection row 的 v1 整合移除**（user 決策；功能集中至 new-session 入口；spec §3.4 的「保留現狀」對 SessionsSection 不再適用，但對 `PaneLayoutRenderer` 仍適用）
 - 不做 per-host bindings UI（store 支援，UI 推到 Phase 2）
 - 不做 mode 設定 / 動態 function command / command palette / 快捷鍵（spec §6 不在範圍）
 - 不做 `module-registry.commands?` legacy 收編（Phase 2 decision gate，spec §8.2）

--- a/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
+++ b/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
@@ -163,8 +163,63 @@ interface SlotConfig {
 
 | Slot | Ctx | Executor 行為 |
 |---|---|---|
-| `WORKSPACE_ACTIONS` | `{ hostId, workspaceId, cwd? }` | `POST /api/sessions` 對該 wks 的 host 建 session（cwd 取 wks default → host default fallback）→ `executeCommand(send-keys)` 送 cmd → 切到該 session |
+| `WORKSPACE_ACTIONS` | `{ workspaceId, hostId\|null, cwd? }` | 見 §3.2.1 hostId 解析；建 session（cwd 取 `workspace.moduleConfig?.files?.projectPath`）→ `executeCommand(send-keys)` 送 cmd → 切到該 session |
 | `HOST_ACTIONS` | `{ hostId, cwd? }` | `POST /api/sessions` 對該 host 建 session（cwd 取 host default）→ `executeCommand` → 切到該 session |
+
+#### 3.2.1 WORKSPACE_ACTIONS hostId 解析
+
+Workspace type 沒有 `hostId` 欄位（純前端容器），實作上不可推測「current active host」(focus tab / `activeHostId` 都會在跨 workspace 切換時錯位)。改採**多數決**：
+
+```ts
+function inferWorkspaceHostId(workspace: Workspace, tabs: Record<string, Tab>): string | null {
+  // 1. 蒐集 workspace.tabs 中所有 tmux-session content 的 hostId
+  const candidates = workspace.tabs
+    .map((tabId) => tabs[tabId])
+    .filter((t): t is Tab => !!t)
+    .flatMap((t) => collectTmuxSessionHostIds(t.layout))
+
+  if (candidates.length === 0) return null  // 邊界 → §3.2.2
+
+  // 2. 多數決
+  const counts = new Map<string, number>()
+  for (const h of candidates) counts.set(h, (counts.get(h) ?? 0) + 1)
+  const max = Math.max(...counts.values())
+  const winners = [...counts.entries()].filter(([, c]) => c === max).map(([h]) => h)
+  if (winners.length === 1) return winners[0]
+
+  // 3. 平手 tie-break：active tab 是 tmux-session 用其 hostId
+  if (workspace.activeTabId) {
+    const activeTab = tabs[workspace.activeTabId]
+    if (activeTab) {
+      const activeHosts = collectTmuxSessionHostIds(activeTab.layout)
+      const winner = activeHosts.find((h) => winners.includes(h))
+      if (winner) return winner
+    }
+  }
+
+  // 4. 仍平手 → tabs 順序中第一個 winner
+  for (const tabId of workspace.tabs) {
+    const tab = tabs[tabId]
+    if (!tab) continue
+    const hosts = collectTmuxSessionHostIds(tab.layout)
+    const first = hosts.find((h) => winners.includes(h))
+    if (first) return first
+  }
+  return winners[0]  // 理論不會到這
+}
+```
+
+`collectTmuxSessionHostIds(layout)` 遞迴遍歷 `Layout` tree（含 split children），收集所有 `pane.content.kind === 'tmux-session'` 的 `hostId`。
+
+#### 3.2.2 邊界：workspace 無 tmux-session tabs（hostId = null）
+
+點擊 quick command 時若 `inferWorkspaceHostId` 回傳 `null`：
+- **不**靜默 fallback 到 `activeHostId`（會送 keys 到錯誤 host）
+- **不**直接 disable（這個 workspace 仍可被 user 主動配對 host）
+- **顯示 host picker popover**：列出 `useHostStore.hostOrder` 中的所有 hosts（host 名 + online/offline 指示），user 點選後以該 hostId 跑 executor
+- 取消 picker → no-op
+
+此 picker 元件（`HostPickerPopover`）為**獨立可重用**設計，未來 multi-host workspace + default launcher binding 系統上線後可繼續使用。
 
 ### 3.3 失敗處理 UX
 
@@ -173,15 +228,24 @@ interface SlotConfig {
 | 階段 | 失敗 | 行為 |
 |---|---|---|
 | 建 session | error | toast: "Failed to start session: <reason>"，不切焦點 |
-| 建 session ✅ + send-keys | error | **仍切到該 session**，toast 帶 action button: "Session created, but command failed. <Retry> <Dismiss>" |
+| 建 session ✅ + send-keys | error | **仍切到該 session**，toast 帶 action button: "Session created, but command failed. <Retry> <Dismiss>"（透過 `useUndoToast` 擴 `actionLabel?` schema 提供，預設 fallback 'Undo'） |
 | 切到 session | error（罕見） | toast 提示，session 仍存在於 sessions 列表 |
 
 關鍵：**send-keys 失敗也要切過去**，user 才知道 session 在那、可以手動跑 — 這比「保留 session 但不切」少一個孤兒問題。
 
 ### 3.4 不在 Phase 1 範圍
 
-- `pane.extra-actions`、`sessions.row-actions` 兩個既有整合保留現狀（直接 `useCommands` + 硬寫 onExecute）
-- 後續 phase 再遷移為 `CommandSlot`，屆時把 binding 模型套用整個系統
+- `PaneLayoutRenderer` 內 `extraActions` 的 v1 `QuickCommandMenu` 整合保留現狀（後續 phase 再遷移為 `CommandSlot`）
+- ~~`SessionsSection` row 上的 v1 `QuickCommandMenu` 整合~~ → **Phase 1c 移除**（user 決策：功能集中至 new-session 入口；`QuickCommandMenu` 元件本身保留供 `PaneLayoutRenderer` 使用）
+
+### 3.5 Forward-compat：未來 multi-host workspace binding
+
+未來路線（不在 v2 範圍）：
+- Workspace 將支援多重 `(hostId, path)` binding（不只 files module 的單一 `projectPath`）
+- Quick commands module 啟用時，每個 binding 旁出現「預設快速啟動」checkbox
+- 該標記的 binding 直接提供 `WORKSPACE_ACTIONS` 的 `(hostId, cwd)`；`inferWorkspaceHostId` 多數決退為 binding 不存在時的 fallback
+
+設計上保留接點：`SlotContext` 用 `hostId | null` 而非「必有 hostId」契約 — 未來無論是多數決還是 default launcher binding 都接得進來，executor 不需重寫。
 
 ---
 
@@ -214,20 +278,22 @@ Edit dialog 欄位：
 
 空狀態：「No quick commands yet — Start by creating one.」
 
-### 4.2 Workspace 入口
+### 4.2 Workspace 入口（Sidebar `WorkspaceRow` 兩個進入點）
 
-Workspace 主面板新增 quick actions 區塊（位置由實作時定，原則上靠近 workspace header）：
+實作位置：`spa/src/features/workspace/components/WorkspaceRow.tsx`。兩個入口共用 `WORKSPACE_ACTIONS` slot；hostId 解析依 §3.2.1 多數決，邊界依 §3.2.2 顯示 host picker。
 
-```
-[ Workspace Name ]
-[ ⚡ Start CC ] [ 🔧 Build ]    ← bindings mountTo: WORKSPACE_ACTIONS 的 commands
-```
+**(i) 右鍵 context menu**（已有 `onContextMenuWorkspace` callback）：
+- 在既有 `WorkspaceContextMenu` 中插入 quick commands section（Settings 之上 + separator）
+- 列出 mount=WORKSPACE_ACTIONS 的 commands 為 menu items；無 binding 時整段隱藏（含 separator）
 
-按鈕點擊 → executor 建 session + 送 keys + 切過去。
+**(ii) Plus 按鈕 hover popover**（既有 [+] 按鈕，L108-121）：
+- Hover 觸發向左展開的 chip 列；半透明漸層壓底
+- mouseleave + focus blur 收回；無 binding 不展開
+- ⚠ 此入口為**過渡實作**：未來可能遷移到其他位置；Phase 1 不需精雕細琢
 
 ### 4.3 Host 詳情頁入口
 
-Host 詳情頁（Sessions section 之外、靠近 host 標題的 quick actions 區）：
+實作位置：`spa/src/components/hosts/SessionsSection.tsx`。new session 按鈕並列 + 移除 row 殘留 v1 整合：
 
 ```
 [ Host: Mini-Lab (online) ]
@@ -249,6 +315,8 @@ Host 詳情頁（Sessions section 之外、靠近 host 標題的 quick actions �
 - Slot button 必有 `aria-label`（`name` + `category` 後綴）+ `title` tooltip 顯示 `command` 內容（debug 用）
 - Slot button 群可 Tab 線性走訪
 - Toast 採 `role="status"` 或 `role="alert"`
+- Plus button hover popover：`onFocusCapture` / `onBlurCapture` 等同於 hover；popover 內按鈕可 Tab 走訪；Esc 收回
+- HostPickerPopover：Esc 取消（no-op）、方向鍵移動 host item、Enter 選定
 
 **Responsive / dark theme**：
 - Slot button 群在窄寬度 wrap（不橫向 overflow）

--- a/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
+++ b/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
@@ -1,0 +1,311 @@
+# Quick Commands v2 — Capability / Binding / Slot 設計
+
+> 取代 `2026-04-10-quick-commands-design.md` 的舊架構（mount 行為散落於 consumer，無集中設定 UI）。
+> 目標：降低 command 與 module 的雙向耦合，並把「在哪顯示」這個 user 意圖獨立成顯式 entity。
+
+---
+
+## 1. 動機
+
+舊版 Quick Commands：
+- Command 與「執行語意」綁死於消費端硬寫的 `onExecute`（`PaneLayoutRenderer` / `SessionsSection`）
+- 沒有設定 UI；user 無法新增 / 編輯 commands
+- Mount 行為由消費端決定，無法 user 自選位置
+- 模組想 host quick-action 入口須各自實作
+
+新版三層分離：
+- **Capability**（command 是純資料：什麼能力）
+- **Binding**（user 意圖：mount 到哪）
+- **Slot**（模組決定：怎麼渲染、怎麼執行）
+
+---
+
+## 2. 資料模型
+
+### 2.1 Capability（command）
+
+```ts
+interface QuickCommand {
+  id: string                 // user-visible 唯一 id（含 settings 編輯時的 stable key）
+  name: string
+  command: string            // 送進 terminal 的字串。v2 不支援 function form（簡化）
+  icon?: string              // Phosphor icon name；slot 可作為 hint，未必使用
+  category?: string          // 自由分類（'agent' / 'shell' / 自訂）；UI 用於分群
+}
+```
+
+**v2 移除動態 function command**：
+- 舊版的 `(ctx) => string` 在 v2 移除，因為 binding 模型下「這個 command 在不同 slot 看到不同 ctx」會讓 function command 行為難預期
+- 動態值（如 cwd）改由 slot 端的 executor 注入
+
+### 2.2 Binding
+
+```ts
+type Bindings = Record<commandId, MountTarget[]>
+
+type MountTarget = string  // 例：'workspace.actions' | 'host.actions'
+```
+
+- 多 mount：一個 command 可同時出現在多個 slot
+- Binding 是純資料；新增 mount target 不需要動 schema，slot string 即可
+- 沒有 binding 的 command 仍存在但不會出現在任何 slot（user 可保留草稿）
+
+### 2.3 Store schema 變更
+
+```ts
+interface QuickCommandState {
+  global: QuickCommand[]
+  byHost: Record<string, QuickCommand[]>     // 保留（per-host override，Phase 1 UI 不暴露）
+  bindings: Record<string, string[]>          // ★ 新增
+
+  // Capability CRUD（沿用）
+  addCommand: (cmd: QuickCommand, hostId?: string) => void
+  updateCommand: (id, patch, hostId?) => void
+  removeCommand: (id, hostId?) => void
+  getCommands: (hostId: string) => QuickCommand[]
+
+  // ★ Binding API（新增）
+  setBinding: (commandId: string, targets: string[]) => void
+  getBoundCommands: (mountTarget: string, hostId: string) => QuickCommand[]
+}
+```
+
+`getBoundCommands` 是 SlotHost 主要查詢介面：給定 slot，回傳已 mount 的 commands（已套用 per-host override）。
+
+### 2.4 預設值
+
+- `DEFAULT_COMMANDS = []`（v2 不預埋）
+- 既有 user 的 localStorage 已存的舊 defaults（`start-cc` / `start-codex`）不主動清除（依 alpha-no-migration 原則）
+- Sync contributor 的 `DATA_FIELDS` 加入 `bindings`
+
+---
+
+## 3. Slot 模型
+
+### 3.1 介面
+
+```tsx
+// 共用元件
+<CommandSlot mountTo="workspace.actions" ctx={{ hostId, workspaceId }}>
+  {(cmd, ctx) => (
+    /* 模組可選：自訂渲染。不傳 children 則用 default renderer */
+  )}
+</CommandSlot>
+```
+
+```ts
+// Default renderer 簽名
+type SlotRenderer = (cmd: QuickCommand, ctx: SlotContext) => ReactNode
+
+// Slot 端負責提供
+interface SlotConfig {
+  mountTo: string
+  ctx: SlotContext
+  executor: (cmd: QuickCommand, ctx: SlotContext) => Promise<void>
+  render?: SlotRenderer  // 預設用內建 button
+}
+```
+
+`CommandSlot` 內部：
+1. 從 store 取 `getBoundCommands(mountTo, hostId)`
+2. 對每個 command 呼叫 render（custom 或 default）
+3. 點擊 → 呼叫 slot 提供的 executor
+
+### 3.2 Slot 行為語意（v2 Phase 1 範圍）
+
+| Slot | Ctx | Executor 行為 |
+|---|---|---|
+| `workspace.actions` | `{ hostId, workspaceId, cwd? }` | `POST /api/sessions` 對該 wks 的 host 建 session（cwd 取 wks default → host default fallback）→ `executeCommand(send-keys)` 送 cmd → 自動切到該 session |
+| `host.actions` | `{ hostId, cwd? }` | `POST /api/sessions` 對該 host 建 session（cwd 取 host default）→ `executeCommand` → 自動切到該 session |
+
+**失敗處理**（兩個 slot 共用）：
+- 建 session 失敗 → toast 顯示錯誤
+- 建 session 成功 + send-keys 失敗 → toast 顯示錯誤，**保留 session**（不自動 close）
+- 切到 session 失敗（極少見）→ silent fail，session 仍存在
+
+### 3.3 不在 Phase 1 範圍
+
+- `pane.extra-actions`、`sessions.row-actions` 兩個既有整合保留現狀（直接 `useCommands` + 硬寫 onExecute）
+- 後續 phase 再遷移為 `CommandSlot`，屆時把 binding 模型套用整個系統
+
+---
+
+## 4. UI
+
+### 4.1 全域 Settings — Quick Commands tab
+
+新增 tab，列表 + CRUD：
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Quick Commands                                  [+ New]    │
+├────────────────────────────────────────────────────────────┤
+│ ⚡ Start Claude Code         agent                          │
+│    claude -p --verbose --output-format stream-json          │
+│    Mount: [Workspace] [Host]                       Edit Del │
+│                                                              │
+│ 🔧 Custom Build              shell                          │
+│    pnpm run build                                           │
+│    Mount: [Workspace]                              Edit Del │
+└────────────────────────────────────────────────────────────┘
+```
+
+Edit dialog 欄位：
+- Name（必填）
+- Command（必填，textarea）
+- Icon（Phosphor name，optional，含 picker）
+- Category（自由文字，optional）
+- Mount targets（multi-select chips：Workspace / Host；Phase 1 兩個選項）
+
+空狀態：「No quick commands yet — Start by creating one.」
+
+### 4.2 Workspace 入口
+
+Workspace 主面板新增 quick actions 區塊（位置由實作時定，原則上靠近 workspace header）：
+
+```
+[ Workspace Name ]
+[ ⚡ Start CC ] [ 🔧 Build ]    ← bindings mountTo: workspace.actions 的 commands
+```
+
+按鈕點擊 → executor 建 session + 送 keys + 切過去。
+
+### 4.3 Host 詳情頁入口
+
+Host 詳情頁（Sessions section 之外、靠近 host 標題的 quick actions 區）：
+
+```
+[ Host: Mini-Lab (online) ]
+[ ⚡ Start CC ] [ 🔧 Build ]    ← bindings mountTo: host.actions 的 commands
+```
+
+按鈕點擊 → executor 對該 host 建 session + 送 keys + 切過去。
+
+---
+
+## 5. 後端
+
+無新增 API。沿用：
+- `POST /api/sessions` — 建 session（已存在）
+- `POST /api/sessions/{code}/send-keys` — 送 keys（v1 已實作）
+
+Executor 端整合兩個呼叫即可。
+
+---
+
+## 6. Phase 切分
+
+### Phase 1a — 資料層 + Settings 頁面 + 模組註冊（一個 PR）
+
+- Store schema 升級：加 `bindings` 欄位 + `setBinding` / `getBoundCommands` API
+- `DEFAULT_COMMANDS = []`
+- Sync contributor 加入 `bindings` 至 `DATA_FIELDS`
+- Quick Commands Settings 頁面元件（list + edit dialog + multi-select mount chips）
+- **`registerModule({ id: 'quick-commands', disableable: true, settings: [...] })`** 於 `register-modules.tsx`
+- i18n keys（`modules.quick_commands.description` / `settings.section.quick_commands` / 空狀態 / 編輯 dialog labels）
+- Tests：store + sync contributor + settings page component + module-enabled 整合
+
+**驗收**：Settings 頁面可建立 / 編輯 / 刪除 commands 與 bindings；資料持久化 + sync 同步可用；視覺 OK 但目前還沒有 slot 消費 → bindings 設了沒效果（預期）。
+
+### Phase 1b — Slot 渲染 + 兩個入口（一個 PR）
+
+- `CommandSlot` 共用元件（內建 `isEnabled('quick-commands')` short-circuit）
+- `executor` lib：建 session + 送 keys 一條龍 helper（含 toast 失敗處理）
+- Workspace 入口（quick actions 區塊）
+- Host 詳情頁入口
+- Tests：CommandSlot（含 disable 隱藏）+ executor + 整合
+
+**驗收**：Phase 1a 設定的 bindings 可在 workspace / host 對應位置看到按鈕；點擊正常建 session 並送 keys；失敗 toast 顯示。
+
+### 不在範圍
+
+- 遷移 `PaneLayoutRenderer` / `SessionsSection`（Phase 2+）
+- per-host override UI（store 支援，UI 後續疊）
+- Mode 設定（terminal/stream/jsonl）作為 binding 欄位（Phase 2+）
+- 動態 function command
+- Command palette / 快捷鍵
+- 多語言全展開（Phase 1 用最小 zh-TW + en）
+
+---
+
+## 7. Module 註冊與啟用 / 停用
+
+Quick Commands v2 是**獨立 module**，遵循專案統一的 module 啟用 / 停用規範（與 `editor` / `browser` / `memory-monitor` 等 disableable 模組同型）。
+
+### 7.1 註冊
+
+於 `register-modules.tsx` 註冊：
+
+```ts
+registerModule({
+  id: 'quick-commands',
+  name: 'Quick Commands',
+  disableable: true,
+  descriptionKey: 'modules.quick_commands.description',
+  settings: [
+    {
+      localId: 'quick-commands',
+      scope: 'purdex',
+      order: ?,                                    // 與其他 purdex 設定 tab 排序
+      labelKey: 'settings.section.quick_commands',
+      component: QuickCommandsSettingsSection,
+    },
+  ],
+})
+```
+
+### 7.2 啟用狀態查詢
+
+統一走 `useModuleEnabledStore.isEnabled('quick-commands')`：
+- **Settings tab**：由現有 settings contribution 機制自動處理，disable 時 tab 從 Settings 頁消失（與其他 disableable module 一致）
+- **SlotHost (`CommandSlot`)**：內部呼叫 `isEnabled('quick-commands')`，false 時不渲染任何按鈕（無論是否有 binding）
+- **Modules Switchboard**：自動列入清單（`disableable: true`）
+
+### 7.3 停用後語意
+
+- **資料保留**：停用 != 清除。capability + binding 資料完整保留於 store + sync。
+- **UI 全面隱藏**：Settings tab + 所有 slot 按鈕一致消失。
+- **重新啟用**：UI 恢復、原 binding 直接生效（無需重設）。
+- **預設**：`enabled = true`（`useModuleEnabledStore` 預設值），user 須主動關閉。
+
+### 7.4 Sync 行為
+
+| 資料 | Sync? | 理由 |
+|---|---|---|
+| Capability (commands) | ✅ Yes（既有） | 指令庫應跨設備共用 |
+| Binding | ✅ Yes（新增） | mount 偏好應跨設備共用 |
+| 模組 enabled 狀態 | ❌ No | device-local（與既有 `useModuleEnabledStore` 一致：低資源 host 可關閉模組） |
+
+亦即：在桌機建好的 commands + bindings 切到行動裝置會同步看到；但行動裝置可獨立關閉本模組不影響桌機。
+
+### 7.5 Slot 元件契約
+
+`CommandSlot` 須在 render 一開頭 short-circuit：
+
+```tsx
+function CommandSlot({ mountTo, ctx, executor, render }: Props) {
+  const enabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
+  if (!enabled) return null
+  // ... 後續渲染邏輯
+}
+```
+
+避免每個 consumer 自己檢查；模組啟用狀態是 slot 內建語意。
+
+---
+
+## 8. Migration / 相容性
+
+- **既有 module-contributed commands** (`module-registry.commands?`) — 暫保留，本次不動。它們不參與 binding 模型；v2 Phase 1 兩個新 slot 只看 store bindings。後續 phase 再決定是否統一。
+- **舊 `useCommands` hook** — 保留（`PaneLayoutRenderer` / `SessionsSection` 還在用）。Phase 1 不刪。
+- **localStorage** — 沒有 schema migration（alpha-no-migration），既有 user 的 `global: [start-cc, start-codex]` + `byHost: {}` + 沒有 `bindings` 欄位 → store hydrate 後 `bindings = {}`（沒 binding 等於不顯示，符合「不要預設」需求；user 想要就自己編輯加 binding）
+
+---
+
+## 9. 不做的事（強調）
+
+- 不做動態 function command（v1 有，v2 移除）
+- 不做 per-host bindings（bindings 是 global；per-host overrides 只有 capability 層；Phase 1 UI 不暴露 per-host）
+- 不做 command 排程 / 歷史記錄 / 變數插值
+- 不做 binding 的 `when` 條件（VS Code 那種 expression 系統）
+- 不重構既有 module-registry.commands 模組貢獻擴充點

--- a/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
+++ b/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
@@ -35,28 +35,43 @@ interface QuickCommand {
 ```
 
 **v2 移除動態 function command**：
-- 舊版的 `(ctx) => string` 在 v2 移除，因為 binding 模型下「這個 command 在不同 slot 看到不同 ctx」會讓 function command 行為難預期
+- 舊版的 `(ctx) => string` 在 v2 移除，因為 binding 模型下「同一 command 在不同 slot 看到不同 ctx」會讓行為難預期
 - 動態值（如 cwd）改由 slot 端的 executor 注入
 
-### 2.2 Binding
+### 2.2 Slot 識別
+
+slot id 用 typed const，Phase 1 兩個目標：
 
 ```ts
-type Bindings = Record<commandId, MountTarget[]>
+// spa/src/lib/quick-command-slots.ts
+export const QUICK_COMMAND_SLOTS = {
+  WORKSPACE_ACTIONS: 'workspace.actions',
+  HOST_ACTIONS: 'host.actions',
+} as const
 
-type MountTarget = string  // 例：'workspace.actions' | 'host.actions'
+export type QuickCommandSlotId =
+  (typeof QUICK_COMMAND_SLOTS)[keyof typeof QUICK_COMMAND_SLOTS]
+```
+
+Settings UI、CommandSlot、executor 一律從這常數讀，禁止字串字面量。Phase 2 若開放外部模組註冊新 slot，再升級成 `registerQuickCommandSlot()` registry — 目前 YAGNI 不做。
+
+### 2.3 Binding
+
+```ts
+type Bindings = Record<string /* commandId */, QuickCommandSlotId[]>
 ```
 
 - 多 mount：一個 command 可同時出現在多個 slot
-- Binding 是純資料；新增 mount target 不需要動 schema，slot string 即可
+- Binding 是純資料；Phase 1 接受未知 slot id（為 forward compat），但 SlotHost 端只渲染目前已註冊的 slot
 - 沒有 binding 的 command 仍存在但不會出現在任何 slot（user 可保留草稿）
 
-### 2.3 Store schema 變更
+### 2.4 Store schema 變更
 
 ```ts
 interface QuickCommandState {
   global: QuickCommand[]
   byHost: Record<string, QuickCommand[]>     // 保留（per-host override，Phase 1 UI 不暴露）
-  bindings: Record<string, string[]>          // ★ 新增
+  bindings: Bindings                          // ★ 新增
 
   // Capability CRUD（沿用）
   addCommand: (cmd: QuickCommand, hostId?: string) => void
@@ -65,18 +80,52 @@ interface QuickCommandState {
   getCommands: (hostId: string) => QuickCommand[]
 
   // ★ Binding API（新增）
-  setBinding: (commandId: string, targets: string[]) => void
-  getBoundCommands: (mountTarget: string, hostId: string) => QuickCommand[]
+  setBinding: (commandId: string, targets: QuickCommandSlotId[]) => void
+  getBoundCommands: (mountTarget: QuickCommandSlotId, hostId: string) => QuickCommand[]
 }
 ```
 
-`getBoundCommands` 是 SlotHost 主要查詢介面：給定 slot，回傳已 mount 的 commands（已套用 per-host override）。
+`getBoundCommands` 是 SlotHost 主要查詢介面：給定 slot，回傳已 mount 的 commands（已套用 per-host override + dangling 過濾，見 §2.5）。
 
-### 2.4 預設值
+### 2.5 Validation, Sanitization & Dangling Bindings
+
+仿 `useModuleEnabledStore` AR-1（codex review #617），bindings 不可信任 hydrated payload。
+
+**Sanitizer**（hydrate 與 sync deserialize 共用）：
+
+```ts
+function sanitizeBindings(raw: unknown): Bindings {
+  if (raw === null || typeof raw !== 'object') return {}
+  const out: Bindings = {}
+  const UNSAFE = new Set(['__proto__', 'constructor', 'prototype'])
+  for (const [cmdId, targets] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof cmdId !== 'string' || cmdId.length === 0) continue
+    if (UNSAFE.has(cmdId)) continue
+    if (!Array.isArray(targets)) continue
+    const cleaned = targets.filter((t): t is string => typeof t === 'string' && t.length > 0)
+    if (cleaned.length > 0) out[cmdId] = cleaned
+  }
+  return out
+}
+```
+
+**Dangling binding 處理**（command 已刪、binding 還指向）：
+
+- `removeCommand(id, hostId?)` 必須同步呼叫 `setBinding(id, [])` 等價清理（global 刪除時清；per-host 刪除維持 binding 不動，因 binding 是 global 概念）
+- `getBoundCommands(target, hostId)` 必須以「該 hostId 下實際存在的 command list」為基礎再 filter binding，不可單純遍歷 `bindings` key
+- 渲染順序見 §4.4
+
+**Sync field-merge**：
+
+- `quick-commands` contributor `DATA_FIELDS` 加入 `bindings`
+- field-merge 必須測試 cross-field dangling case：local `global = [A]` + remote `bindings = { B: [...] }` 套 `field-merge { global: 'local', bindings: 'remote' }` → `getBoundCommands` 回傳空（因 B 不在 local global）
+- deserialize 時對 incoming `bindings` 也跑 sanitizer
+
+### 2.6 預設值
 
 - `DEFAULT_COMMANDS = []`（v2 不預埋）
-- 既有 user 的 localStorage 已存的舊 defaults（`start-cc` / `start-codex`）不主動清除（依 alpha-no-migration 原則）
-- Sync contributor 的 `DATA_FIELDS` 加入 `bindings`
+- `bindings` 預設 `{}`
+- 既有 user 的 localStorage 已存的舊 defaults（`start-cc` / `start-codex`）不主動清除（依 alpha-no-migration 原則）；舊 user 開新版看到舊 commands 但 `bindings = {}` → 不會顯示為按鈕，須自行設 binding
 
 ---
 
@@ -86,7 +135,7 @@ interface QuickCommandState {
 
 ```tsx
 // 共用元件
-<CommandSlot mountTo="workspace.actions" ctx={{ hostId, workspaceId }}>
+<CommandSlot mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS} ctx={{ hostId, workspaceId }} executor={...}>
   {(cmd, ctx) => (
     /* 模組可選：自訂渲染。不傳 children 則用 default renderer */
   )}
@@ -94,36 +143,42 @@ interface QuickCommandState {
 ```
 
 ```ts
-// Default renderer 簽名
 type SlotRenderer = (cmd: QuickCommand, ctx: SlotContext) => ReactNode
 
-// Slot 端負責提供
 interface SlotConfig {
-  mountTo: string
+  mountTo: QuickCommandSlotId
   ctx: SlotContext
   executor: (cmd: QuickCommand, ctx: SlotContext) => Promise<void>
   render?: SlotRenderer  // 預設用內建 button
 }
 ```
 
-`CommandSlot` 內部：
-1. 從 store 取 `getBoundCommands(mountTo, hostId)`
-2. 對每個 command 呼叫 render（custom 或 default）
-3. 點擊 → 呼叫 slot 提供的 executor
+`CommandSlot` 內部執行順序：
+1. `isEnabled('quick-commands')` 為 false → 直接 `return null`（見 §7.5）
+2. 從 store 取 `getBoundCommands(mountTo, ctx.hostId)`（已過濾 dangling）
+3. 依 §4.4 排序規則渲染
+4. 點擊 → 呼叫 slot 提供的 executor
 
 ### 3.2 Slot 行為語意（v2 Phase 1 範圍）
 
 | Slot | Ctx | Executor 行為 |
 |---|---|---|
-| `workspace.actions` | `{ hostId, workspaceId, cwd? }` | `POST /api/sessions` 對該 wks 的 host 建 session（cwd 取 wks default → host default fallback）→ `executeCommand(send-keys)` 送 cmd → 自動切到該 session |
-| `host.actions` | `{ hostId, cwd? }` | `POST /api/sessions` 對該 host 建 session（cwd 取 host default）→ `executeCommand` → 自動切到該 session |
+| `WORKSPACE_ACTIONS` | `{ hostId, workspaceId, cwd? }` | `POST /api/sessions` 對該 wks 的 host 建 session（cwd 取 wks default → host default fallback）→ `executeCommand(send-keys)` 送 cmd → 切到該 session |
+| `HOST_ACTIONS` | `{ hostId, cwd? }` | `POST /api/sessions` 對該 host 建 session（cwd 取 host default）→ `executeCommand` → 切到該 session |
 
-**失敗處理**（兩個 slot 共用）：
-- 建 session 失敗 → toast 顯示錯誤
-- 建 session 成功 + send-keys 失敗 → toast 顯示錯誤，**保留 session**（不自動 close）
-- 切到 session 失敗（極少見）→ silent fail，session 仍存在
+### 3.3 失敗處理 UX
 
-### 3.3 不在 Phase 1 範圍
+孤兒 session 是 user 困擾的主因。失敗時要讓 user 看到結果。
+
+| 階段 | 失敗 | 行為 |
+|---|---|---|
+| 建 session | error | toast: "Failed to start session: <reason>"，不切焦點 |
+| 建 session ✅ + send-keys | error | **仍切到該 session**，toast 帶 action button: "Session created, but command failed. <Retry> <Dismiss>" |
+| 切到 session | error（罕見） | toast 提示，session 仍存在於 sessions 列表 |
+
+關鍵：**send-keys 失敗也要切過去**，user 才知道 session 在那、可以手動跑 — 這比「保留 session 但不切」少一個孤兒問題。
+
+### 3.4 不在 Phase 1 範圍
 
 - `pane.extra-actions`、`sessions.row-actions` 兩個既有整合保留現狀（直接 `useCommands` + 硬寫 onExecute）
 - 後續 phase 再遷移為 `CommandSlot`，屆時把 binding 模型套用整個系統
@@ -155,7 +210,7 @@ Edit dialog 欄位：
 - Command（必填，textarea）
 - Icon（Phosphor name，optional，含 picker）
 - Category（自由文字，optional）
-- Mount targets（multi-select chips：Workspace / Host；Phase 1 兩個選項）
+- Mount targets（multi-select chips，從 `QUICK_COMMAND_SLOTS` 取選項：Workspace / Host）
 
 空狀態：「No quick commands yet — Start by creating one.」
 
@@ -165,7 +220,7 @@ Workspace 主面板新增 quick actions 區塊（位置由實作時定，原則�
 
 ```
 [ Workspace Name ]
-[ ⚡ Start CC ] [ 🔧 Build ]    ← bindings mountTo: workspace.actions 的 commands
+[ ⚡ Start CC ] [ 🔧 Build ]    ← bindings mountTo: WORKSPACE_ACTIONS 的 commands
 ```
 
 按鈕點擊 → executor 建 session + 送 keys + 切過去。
@@ -176,10 +231,29 @@ Host 詳情頁（Sessions section 之外、靠近 host 標題的 quick actions �
 
 ```
 [ Host: Mini-Lab (online) ]
-[ ⚡ Start CC ] [ 🔧 Build ]    ← bindings mountTo: host.actions 的 commands
+[ ⚡ Start CC ] [ 🔧 Build ]    ← bindings mountTo: HOST_ACTIONS 的 commands
 ```
 
 按鈕點擊 → executor 對該 host 建 session + 送 keys + 切過去。
+
+### 4.4 渲染順序、a11y、Responsive
+
+**渲染順序穩定性（重要）**：
+- SlotHost 內部以「該 hostId 的 capability list」為基礎（即 `getCommands(hostId)` 的順序，merged global + host override），逐項判斷 `bindings[cmd.id]?.includes(slotId)` 來決定是否渲染
+- **不可** 遍歷 `Object.keys(bindings)` — Record 順序在 sync 後不可預期，會造成跨裝置順序不一致
+- Settings list 列出 commands 時同樣依 `getCommands(hostId)` 順序
+
+**a11y / 鍵盤焦點**：
+- Settings dialog 開啟時：focus trap、Esc 關閉、關閉時 focus 回 trigger
+- Multi-select chips 支援 Space / Enter 切換、方向鍵移動
+- Slot button 必有 `aria-label`（`name` + `category` 後綴）+ `title` tooltip 顯示 `command` 內容（debug 用）
+- Slot button 群可 Tab 線性走訪
+- Toast 採 `role="status"` 或 `role="alert"`
+
+**Responsive / dark theme**：
+- Slot button 群在窄寬度 wrap（不橫向 overflow）
+- Settings list row 在窄寬度堆疊（name → command → mount）
+- 全採用既有 `text-text-*` / `bg-surface-*` token，不寫死顏色
 
 ---
 
@@ -195,31 +269,45 @@ Executor 端整合兩個呼叫即可。
 
 ## 6. Phase 切分
 
-### Phase 1a — 資料層 + Settings 頁面 + 模組註冊（一個 PR）
+調整原則：**不 ship 「設了沒效果」的中間態**。Settings UI 首次出現時必須至少有一個 slot 生效。
 
+### Phase 1a — 純資料層（一個 PR）
+
+- 新增 `spa/src/lib/quick-command-slots.ts`（`QUICK_COMMAND_SLOTS` + 型別）
 - Store schema 升級：加 `bindings` 欄位 + `setBinding` / `getBoundCommands` API
 - `DEFAULT_COMMANDS = []`
-- Sync contributor 加入 `bindings` 至 `DATA_FIELDS`
+- `removeCommand` 同步清 binding
+- `useQuickCommandStore` 加 `merge` hook + `sanitizeBindings`
+- Sync contributor 加入 `bindings` 至 `DATA_FIELDS`，deserialize 跑 sanitizer
+- `register-modules.tsx` 註冊 `quick-commands` module（disableable: true，但暫無 settings contribution，等 1b）
+- i18n keys：`modules.quick_commands.description`（給 Modules Switchboard 顯示）
+- Tests：store CRUD + sanitizer + dangling filter + sync field-merge cross-field + module-enabled 整合
+
+**驗收**：資料層完整、sync OK、Modules Switchboard 看得到本模組可開關；UI 零改動，純基礎建設。
+
+### Phase 1b — Settings UI + WORKSPACE_ACTIONS 入口（一個 PR，**綁定一起 ship**）
+
+- `CommandSlot` 共用元件（含 `isEnabled` short-circuit + §4.4 順序規則 + a11y）
+- `executor` lib：建 session + 送 keys 一條龍 helper（含 §3.3 失敗處理 UX）
 - Quick Commands Settings 頁面元件（list + edit dialog + multi-select mount chips）
-- **`registerModule({ id: 'quick-commands', disableable: true, settings: [...] })`** 於 `register-modules.tsx`
-- i18n keys（`modules.quick_commands.description` / `settings.section.quick_commands` / 空狀態 / 編輯 dialog labels）
-- Tests：store + sync contributor + settings page component + module-enabled 整合
+- `register-modules.tsx` 補上 `settings` contribution
+- Workspace 入口（quick actions 區塊使用 `CommandSlot`）
+- i18n keys：`settings.section.quick_commands` / 空狀態 / 編輯 dialog labels / 失敗 toast
+- Tests：CommandSlot（含 disable 隱藏 + 順序穩定性）+ executor + Settings 頁面 + workspace 入口整合
 
-**驗收**：Settings 頁面可建立 / 編輯 / 刪除 commands 與 bindings；資料持久化 + sync 同步可用；視覺 OK 但目前還沒有 slot 消費 → bindings 設了沒效果（預期）。
+**驗收**：user 能在 Settings 建 command + 設 mount = WORKSPACE，回到 workspace 立刻看到按鈕；點擊建 session + 送 keys + 切過去。失敗 toast 行為符合 §3.3。
 
-### Phase 1b — Slot 渲染 + 兩個入口（一個 PR）
+### Phase 1c — HOST_ACTIONS 入口（小 PR）
 
-- `CommandSlot` 共用元件（內建 `isEnabled('quick-commands')` short-circuit）
-- `executor` lib：建 session + 送 keys 一條龍 helper（含 toast 失敗處理）
-- Workspace 入口（quick actions 區塊）
-- Host 詳情頁入口
-- Tests：CommandSlot（含 disable 隱藏）+ executor + 整合
+- Host 詳情頁的 quick actions 區塊使用 `CommandSlot`
+- Tests：host 入口整合
+- i18n（如有）
 
-**驗收**：Phase 1a 設定的 bindings 可在 workspace / host 對應位置看到按鈕；點擊正常建 session 並送 keys；失敗 toast 顯示。
+**驗收**：user 能設 mount = HOST 並在 host 詳情頁看到按鈕；行為與 §3.2 一致。
 
 ### 不在範圍
 
-- 遷移 `PaneLayoutRenderer` / `SessionsSection`（Phase 2+）
+- 遷移 `PaneLayoutRenderer` / `SessionsSection`（Phase 2+，見 §8 decision gate）
 - per-host override UI（store 支援，UI 後續疊）
 - Mode 設定（terminal/stream/jsonl）作為 binding 欄位（Phase 2+）
 - 動態 function command
@@ -234,7 +322,7 @@ Quick Commands v2 是**獨立 module**，遵循專案統一的 module 啟用 / �
 
 ### 7.1 註冊
 
-於 `register-modules.tsx` 註冊：
+於 `register-modules.tsx` 註冊（Phase 1b 補完 settings contribution）：
 
 ```ts
 registerModule({
@@ -246,7 +334,7 @@ registerModule({
     {
       localId: 'quick-commands',
       scope: 'purdex',
-      order: ?,                                    // 與其他 purdex 設定 tab 排序
+      order: ?,                                    // 與其他 purdex 設定 tab 排序，實作時定
       labelKey: 'settings.section.quick_commands',
       component: QuickCommandsSettingsSection,
     },
@@ -254,18 +342,28 @@ registerModule({
 })
 ```
 
-### 7.2 啟用狀態查詢
+### 7.2 啟用狀態查詢與切換語意
 
-統一走 `useModuleEnabledStore.isEnabled('quick-commands')`：
-- **Settings tab**：由現有 settings contribution 機制自動處理，disable 時 tab 從 Settings 頁消失（與其他 disableable module 一致）
-- **SlotHost (`CommandSlot`)**：內部呼叫 `isEnabled('quick-commands')`，false 時不渲染任何按鈕（無論是否有 binding）
-- **Modules Switchboard**：自動列入清單（`disableable: true`）
+**Settings tab 顯示 / 隱藏**：
+- 由現有 settings contribution 機制自動處理（`dispatchSettingsContributions` 於 dispatch 時依 `isEnabled` 過濾）
+- 與 `useModuleEnabledStore` 既有 baseline 機制一致：toggle disable 後，**Modules Switchboard 顯示「Reload required」直到重新 dispatch / reload**；Settings tab 不會立即消失
+- 此行為與 `editor` / `browser` 等其他 disableable module 完全相同，user 已熟悉
+- spec 不要求改造為即時 redispatch（YAGNI；reload 模型穩定）
+
+**SlotHost (`CommandSlot`)**：
+- 內部呼叫 `isEnabled('quick-commands')`，false 時 `return null`（即時生效，無需 reload）
+- 切換後 workspace / host 的 slot 按鈕**會即時消失或恢復**，因 React render 訂閱 store
+- Settings tab 與 slot 行為的「即時 vs reload」差異是 codebase 既有模式，本 spec 不打破
+
+**Modules Switchboard**：
+- 自動列入清單（`disableable: true`）
+- 文案不暗示「停用會影響其他裝置同步」（enabled 是 device-local，commands/bindings 仍 sync）
 
 ### 7.3 停用後語意
 
 - **資料保留**：停用 != 清除。capability + binding 資料完整保留於 store + sync。
-- **UI 全面隱藏**：Settings tab + 所有 slot 按鈕一致消失。
-- **重新啟用**：UI 恢復、原 binding 直接生效（無需重設）。
+- **UI 隱藏**：所有 slot 按鈕即時消失；Settings tab 於 reload 後消失。
+- **重新啟用**：slot 按鈕即時恢復；Settings tab reload 後出現；原 binding 直接生效。
 - **預設**：`enabled = true`（`useModuleEnabledStore` 預設值），user 須主動關閉。
 
 ### 7.4 Sync 行為
@@ -276,7 +374,7 @@ registerModule({
 | Binding | ✅ Yes（新增） | mount 偏好應跨設備共用 |
 | 模組 enabled 狀態 | ❌ No | device-local（與既有 `useModuleEnabledStore` 一致：低資源 host 可關閉模組） |
 
-亦即：在桌機建好的 commands + bindings 切到行動裝置會同步看到；但行動裝置可獨立關閉本模組不影響桌機。
+亦即：在桌機建好的 commands + bindings 切到行動裝置會同步看到；行動裝置可獨立關閉本模組不影響桌機資料 — 這是預期行為，UI 不需特別提示。
 
 ### 7.5 Slot 元件契約
 
@@ -286,7 +384,7 @@ registerModule({
 function CommandSlot({ mountTo, ctx, executor, render }: Props) {
   const enabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
   if (!enabled) return null
-  // ... 後續渲染邏輯
+  // ... 後續渲染邏輯（順序見 §4.4）
 }
 ```
 
@@ -294,11 +392,29 @@ function CommandSlot({ mountTo, ctx, executor, render }: Props) {
 
 ---
 
-## 8. Migration / 相容性
+## 8. Migration / 相容性 + Phase 2 Decision Gate
 
-- **既有 module-contributed commands** (`module-registry.commands?`) — 暫保留，本次不動。它們不參與 binding 模型；v2 Phase 1 兩個新 slot 只看 store bindings。後續 phase 再決定是否統一。
-- **舊 `useCommands` hook** — 保留（`PaneLayoutRenderer` / `SessionsSection` 還在用）。Phase 1 不刪。
-- **localStorage** — 沒有 schema migration（alpha-no-migration），既有 user 的 `global: [start-cc, start-codex]` + `byHost: {}` + 沒有 `bindings` 欄位 → store hydrate 後 `bindings = {}`（沒 binding 等於不顯示，符合「不要預設」需求；user 想要就自己編輯加 binding）
+### 8.1 Phase 1 相容性
+
+- **既有 module-contributed commands** (`module-registry.commands?`) — Phase 1 暫保留，不參與 binding 模型；新 slot 只看 store bindings
+- **舊 `useCommands` hook** — 保留（`PaneLayoutRenderer` / `SessionsSection` 還在用）。Phase 1 不刪
+- **localStorage** — 沒有 schema migration（alpha-no-migration），既有 user hydrate 後 `bindings = {}` → 沒有按鈕顯示，須自行編輯設 binding
+
+### 8.2 Phase 2 Decision Gate（必須在 Phase 1c merge 前討論）
+
+避免雙軌長期共存變技術債，Phase 2 起需在以下兩條路擇一：
+
+**Option A：適配為 read-only capability**
+- `module-registry.commands?` 收合為 store 的「不可編輯 capability」（標記 `source: 'module'`）
+- Settings UI 顯示但禁止編輯，仍可設 binding
+- 統一只剩 binding 模型，舊 `useCommands` 廢棄
+
+**Option B：標 legacy + 凍結 API**
+- `module-registry.commands?` 標 `@deprecated`，禁止新模組註冊
+- 舊 consumer (`PaneLayoutRenderer` / `SessionsSection`) 遷移用 `CommandSlot`
+- 完成後刪除 `commands?` 欄位
+
+決議由 Phase 1 完成後實際使用情況評估（看 module 貢獻 commands 的真實價值再決定）。本 spec 不預先選邊。
 
 ---
 
@@ -308,4 +424,6 @@ function CommandSlot({ mountTo, ctx, executor, render }: Props) {
 - 不做 per-host bindings（bindings 是 global；per-host overrides 只有 capability 層；Phase 1 UI 不暴露 per-host）
 - 不做 command 排程 / 歷史記錄 / 變數插值
 - 不做 binding 的 `when` 條件（VS Code 那種 expression 系統）
-- 不重構既有 module-registry.commands 模組貢獻擴充點
+- 不重構既有 module-registry.commands 模組貢獻擴充點（Phase 1 範圍內）
+- 不做 `registerQuickCommandSlot()` registry（YAGNI；Phase 2 視需求再考慮）
+- 不改造 module enable/disable 為即時 redispatch（依現有 baseline reload 模型）

--- a/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
+++ b/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
@@ -226,6 +226,21 @@ function inferWorkspaceHostId(workspace: Workspace, tabs: Record<string, Tab>): 
 - **Offline host 不 disable**：user 可能就是要 force route 到 offline host（執行後若 host 連不上，executor 呼叫 createSession 失敗自然會 toast）— 不擅自代為決策
 - **空 hostOrder**：顯示空狀態文案 **+ close button**（除 Esc 外的滑鼠可達退場路徑）。理論上不會發生（user 至少有一個 host 才能用本系統），但仍須提供，避免極端狀態下卡死
 
+**Resolver lifecycle 契約（picker owner 的合約義務）**：
+
+picker owner（持有 promise resolver 的元件）必須保證 `resolveHostId()` Promise 在以下**三種**情境下 settle 為 `null`：
+
+1. User 主動取消（Esc / close button / outside click）
+2. picker 元件 unmount（parent menu/popover 被外部 force-close、route 切換、tab 關閉等）
+3. duplicate select/cancel 呼叫（user 雙擊 / fast-double-tap）— resolver 必須在第一次 invocation 後 nulled-out，重複呼叫 no-op
+
+實作上：picker state shape `{ open, resolver, anchor }` 加 unmount-cleanup `useEffect`（cleanup 中觸發 `resolver?.(null)` 後立即將 resolver set 為 null）。確保：
+- Promise 必定 settle（不懸掛）
+- Executor `finally` 一定執行
+- 重複呼叫不 throw
+
+這是 contract 而非實作建議；caller 不可省略，否則 picker 在邊界情境會卡住整個 executor 流程。
+
 此 picker 元件（`HostPickerPopover`）為**獨立可重用**設計，未來 multi-host workspace + default launcher binding 系統上線後可繼續使用。
 
 ### 3.3 失敗處理 UX

--- a/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
+++ b/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
@@ -187,8 +187,9 @@ function inferWorkspaceHostId(workspace: Workspace, tabs: Record<string, Tab>): 
   const winners = [...counts.entries()].filter(([, c]) => c === max).map(([h]) => h)
   if (winners.length === 1) return winners[0]
 
-  // 3. 平手 tie-break：active tab 是 tmux-session **且其 hostId 在 winners 內**才用
-  //    （active 是少數派時跳過此條，繼續往條 4 — 避免少數派偷渡為勝者）
+  // 3. 平手 tie-break：active tab 為 tmux-session 時，**僅當其 hostId 同時出現在 winners
+  //    集合內**才採用；active hostId 是少數派（不在 winners 內）時跳過此條，繼續往條 4。
+  //    這是必要規則，避免少數派 hostId 因 active 偷渡成勝者。
   if (workspace.activeTabId) {
     const activeTab = tabs[workspace.activeTabId]
     if (activeTab) {
@@ -223,7 +224,7 @@ function inferWorkspaceHostId(workspace: Workspace, tabs: Record<string, Tab>): 
 **Picker 細節契約**：
 - **Anchor 由 caller 提供**：context menu 場景用 click 座標 (`{ x, y }`)；inline trigger（hover popover）用 trigger 的 `HTMLElement` ref。Picker 元件支援兩種 anchor 形式
 - **Offline host 不 disable**：user 可能就是要 force route 到 offline host（執行後若 host 連不上，executor 呼叫 createSession 失敗自然會 toast）— 不擅自代為決策
-- **空 hostOrder**：顯示空狀態文案 + close button（理論上不會發生，因為 user 至少有一個 host 才能用本系統）
+- **空 hostOrder**：顯示空狀態文案 **+ close button**（除 Esc 外的滑鼠可達退場路徑）。理論上不會發生（user 至少有一個 host 才能用本系統），但仍須提供，避免極端狀態下卡死
 
 此 picker 元件（`HostPickerPopover`）為**獨立可重用**設計，未來 multi-host workspace + default launcher binding 系統上線後可繼續使用。
 
@@ -231,11 +232,13 @@ function inferWorkspaceHostId(workspace: Workspace, tabs: Record<string, Tab>): 
 
 孤兒 session 是 user 困擾的主因。失敗時要讓 user 看到結果。
 
-| 階段 | 失敗 | 行為 |
-|---|---|---|
-| 建 session | error | toast: "Failed to start session: <reason>"，不切焦點 |
-| 建 session ✅ + send-keys | error | **仍切到該 session**，toast 帶 action button: "Session created, but command failed. <Retry> <Dismiss>"（透過 `useUndoToast` 擴 `actionLabel?` schema 提供，預設 fallback 'Undo'） |
-| 切到 session | error（罕見） | toast 提示，session 仍存在於 sessions 列表 |
+| 階段 | 失敗 | 行為 | Toast action button |
+|---|---|---|---|
+| 建 session | error | toast: "Failed to start session: <reason>"，不切焦點 | **無**（純通知） |
+| 建 session ✅ + send-keys | error | **仍切到該 session**，toast: "Session created, but command failed." | **有** — `<Retry>`（重跑送 keys） |
+| 切到 session | error（罕見） | toast 提示，session 仍存在於 sessions 列表 | **無**（純通知） |
+
+`useUndoToast` schema 須擴為 `action?` + `actionLabel?` **皆 optional**：`action == null` 時 button 完全不渲染（非顯示為 disabled）。`actionLabel` 預設 fallback `'Undo'`（為相容既有 callsite）。
 
 關鍵：**send-keys 失敗也要切過去**，user 才知道 session 在那、可以手動跑 — 這比「保留 session 但不切」少一個孤兒問題。
 
@@ -321,7 +324,7 @@ Edit dialog 欄位：
 - Multi-select chips 支援 Space / Enter 切換、方向鍵移動
 - Slot button 必有 `aria-label`（`name` + `category` 後綴）+ `title` tooltip 顯示 `command` 內容（debug 用）
 - Slot button 群可 Tab 線性走訪
-- Toast 採 `role="status"` 或 `role="alert"`
+- Toast 採 `role="status"`（一般通知）或 `role="alert"`（錯誤）— 由 `GlobalUndoToast` 元件統一提供 live region；caller 不需各自加 role
 - Plus button hover popover：`onFocusCapture` / `onBlurCapture` 等同於 hover；popover 內按鈕可 Tab 走訪；Esc 收回
 - HostPickerPopover：Esc 取消（no-op）、方向鍵移動 host item、Enter 選定
 

--- a/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
+++ b/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
@@ -187,7 +187,8 @@ function inferWorkspaceHostId(workspace: Workspace, tabs: Record<string, Tab>): 
   const winners = [...counts.entries()].filter(([, c]) => c === max).map(([h]) => h)
   if (winners.length === 1) return winners[0]
 
-  // 3. 平手 tie-break：active tab 是 tmux-session 用其 hostId
+  // 3. 平手 tie-break：active tab 是 tmux-session **且其 hostId 在 winners 內**才用
+  //    （active 是少數派時跳過此條，繼續往條 4 — 避免少數派偷渡為勝者）
   if (workspace.activeTabId) {
     const activeTab = tabs[workspace.activeTabId]
     if (activeTab) {
@@ -218,6 +219,11 @@ function inferWorkspaceHostId(workspace: Workspace, tabs: Record<string, Tab>): 
 - **不**直接 disable（這個 workspace 仍可被 user 主動配對 host）
 - **顯示 host picker popover**：列出 `useHostStore.hostOrder` 中的所有 hosts（host 名 + online/offline 指示），user 點選後以該 hostId 跑 executor
 - 取消 picker → no-op
+
+**Picker 細節契約**：
+- **Anchor 由 caller 提供**：context menu 場景用 click 座標 (`{ x, y }`)；inline trigger（hover popover）用 trigger 的 `HTMLElement` ref。Picker 元件支援兩種 anchor 形式
+- **Offline host 不 disable**：user 可能就是要 force route 到 offline host（執行後若 host 連不上，executor 呼叫 createSession 失敗自然會 toast）— 不擅自代為決策
+- **空 hostOrder**：顯示空狀態文案 + close button（理論上不會發生，因為 user 至少有一個 host 才能用本系統）
 
 此 picker 元件（`HostPickerPopover`）為**獨立可重用**設計，未來 multi-host workspace + default launcher binding 系統上線後可繼續使用。
 
@@ -306,6 +312,7 @@ Edit dialog 欄位：
 
 **渲染順序穩定性（重要）**：
 - SlotHost 內部以「該 hostId 的 capability list」為基礎（即 `getCommands(hostId)` 的順序，merged global + host override），逐項判斷 `bindings[cmd.id]?.includes(slotId)` 來決定是否渲染
+- **`hostId === null` 場景**（WORKSPACE_ACTIONS 多數決失敗、尚未開 picker 時）：以 `state.global` 順序為基礎渲染（host override 暫不可知，picker 選定後 chip list 不重排 — 因為 picker 僅在點擊瞬間開啟，chip 已早先 render）
 - **不可** 遍歷 `Object.keys(bindings)` — Record 順序在 sync 後不可預期，會造成跨裝置順序不一致
 - Settings list 列出 commands 時同樣依 `getCommands(hostId)` 順序
 

--- a/spa/src/lib/quick-command-slots.test.ts
+++ b/spa/src/lib/quick-command-slots.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { QUICK_COMMAND_SLOTS, type QuickCommandSlotId } from './quick-command-slots'
+
+describe('quick-command-slots', () => {
+  it('exposes WORKSPACE_ACTIONS and HOST_ACTIONS literals', () => {
+    expect(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS).toBe('workspace.actions')
+    expect(QUICK_COMMAND_SLOTS.HOST_ACTIONS).toBe('host.actions')
+  })
+
+  it('values are unique', () => {
+    const values = Object.values(QUICK_COMMAND_SLOTS)
+    expect(new Set(values).size).toBe(values.length)
+  })
+
+  it('QuickCommandSlotId narrows to the value union', () => {
+    const x: QuickCommandSlotId = QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS
+    expect(typeof x).toBe('string')
+  })
+})

--- a/spa/src/lib/quick-command-slots.ts
+++ b/spa/src/lib/quick-command-slots.ts
@@ -1,0 +1,16 @@
+/**
+ * Slot identifiers for the Quick Commands v2 capability/binding/slot model
+ * (spec §2.2). Settings UI, <CommandSlot>, and binding sanitizer must read
+ * from this constant — string literals are forbidden so a typo can't drift
+ * away from the registered slots.
+ *
+ * If/when external modules need to register new slots, upgrade to a
+ * `registerQuickCommandSlot()` registry (Phase 2+; YAGNI for now).
+ */
+export const QUICK_COMMAND_SLOTS = {
+  WORKSPACE_ACTIONS: 'workspace.actions',
+  HOST_ACTIONS: 'host.actions',
+} as const
+
+export type QuickCommandSlotId =
+  (typeof QUICK_COMMAND_SLOTS)[keyof typeof QUICK_COMMAND_SLOTS]

--- a/spa/src/lib/register-modules.quick-commands.test.tsx
+++ b/spa/src/lib/register-modules.quick-commands.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { clearModuleRegistry, getModule } from './module-registry'
+import { registerBuiltinModules } from './register-modules'
+
+describe('register-modules — quick-commands module (Phase 1a)', () => {
+  beforeEach(() => {
+    clearModuleRegistry()
+  })
+
+  it('registers quick-commands as a disableable module', () => {
+    registerBuiltinModules()
+    const m = getModule('quick-commands')
+    expect(m).toBeDefined()
+    expect(m!.disableable).toBe(true)
+    expect(m!.descriptionKey).toBe('modules.quick_commands.description')
+  })
+
+  it('Phase 1a: quick-commands has NO settings contribution yet (deferred to Phase 1b)', () => {
+    registerBuiltinModules()
+    const m = getModule('quick-commands')
+    expect(m!.settings ?? []).toHaveLength(0)
+  })
+})

--- a/spa/src/lib/register-modules.tsx
+++ b/spa/src/lib/register-modules.tsx
@@ -211,6 +211,17 @@ export function registerBuiltinModules(): void {
     ],
   })
 
+  // Quick Commands v2 — Phase 1a registers the module shell only (disableable
+  // gate + Modules Switchboard listing). Settings contribution + UI surfaces
+  // ship together in Phase 1b (spec §6 — never ship a "configured but no
+  // effect" intermediate state).
+  registerModule({
+    id: 'quick-commands',
+    name: 'Quick Commands',
+    disableable: true,
+    descriptionKey: 'modules.quick_commands.description',
+  })
+
   // Register InApp FS backend (singleton — 避免熱重載時資料遺失)
   if (!getFsBackend({ type: 'inapp' })) {
     registerFsBackend('inapp', new InAppBackend())

--- a/spa/src/lib/sync/contributors/quick-commands.test.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.test.ts
@@ -4,9 +4,10 @@
 
 import { describe, it, expect, beforeEach } from 'vitest'
 import { createQuickCommandsContributor } from './quick-commands'
-import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useQuickCommandStore, sanitizeBindings } from '../../../stores/useQuickCommandStore'
 import type { QuickCommand } from '../../../stores/useQuickCommandStore'
 import type { FullPayload } from '../types'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 
 // ---------------------------------------------------------------------------
 // Default state (matches store defaults)
@@ -179,5 +180,108 @@ describe('createQuickCommandsContributor', () => {
     expect(globalCmds.some((c) => c.id === 'remote-cmd')).toBe(true)
     // byHost untouched
     expect(state.byHost['h-1']).toBeUndefined()
+  })
+})
+
+describe('createQuickCommandsContributor — bindings field (v2)', () => {
+  let contributor: ReturnType<typeof createQuickCommandsContributor>
+
+  beforeEach(() => {
+    useQuickCommandStore.setState({
+      global: [],
+      byHost: {},
+      bindings: {},
+    })
+    contributor = createQuickCommandsContributor()
+  })
+
+  it('serialize includes bindings field', () => {
+    useQuickCommandStore.getState().addCommand({ id: 'cmd-a', name: 'A', command: 'a' })
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    const payload = contributor.serialize() as FullPayload
+    expect(payload.data.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
+  })
+
+  it('serialize keys exclude action functions but include bindings', () => {
+    const payload = contributor.serialize() as FullPayload
+    const keys = Object.keys(payload.data)
+    expect(keys).toContain('global')
+    expect(keys).toContain('byHost')
+    expect(keys).toContain('bindings')
+    expect(keys).not.toContain('setBinding')
+    expect(keys).not.toContain('getBoundCommands')
+  })
+
+  it('deserialize full-replace with bindings overwrites local bindings', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'local', name: 'L', command: 'l' }],
+      byHost: {},
+      bindings: { 'local': ['workspace.actions'] },
+    })
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'remote', name: 'R', command: 'r' }],
+        byHost: {},
+        bindings: { 'remote': ['host.actions'] },
+      },
+    }
+    contributor.deserialize(incoming, { type: 'full-replace' })
+    const state = useQuickCommandStore.getState()
+    expect(state.bindings).toEqual({ 'remote': ['host.actions'] })
+  })
+
+  it('deserialize sanitizes incoming bindings (drops malformed entries)', () => {
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+        byHost: {},
+        bindings: {
+          'cmd-a': ['workspace.actions'],
+          // hostile payload variants — must all be dropped:
+          '__proto__': ['host.actions'],
+          'cmd-bad-targets': 'not-an-array' as unknown as string[],
+          '': ['host.actions'],
+        },
+      },
+    }
+    contributor.deserialize(incoming, { type: 'full-replace' })
+    const state = useQuickCommandStore.getState()
+    expect(state.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
+  })
+
+  it('field-merge: cross-field dangling — global=local + bindings=remote → getBoundCommands returns empty', () => {
+    // local has cmd-A only; remote bindings reference cmd-B (not in local global)
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+      byHost: {},
+      bindings: {},
+    })
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'cmd-b', name: 'B', command: 'b' }],
+        byHost: {},
+        bindings: { 'cmd-b': ['workspace.actions'] },
+      },
+    }
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { global: 'local', bindings: 'remote' },
+    })
+    const state = useQuickCommandStore.getState()
+    // global stayed local — only cmd-a
+    expect(state.global.map((c) => c.id)).toEqual(['cmd-a'])
+    // bindings took remote — references cmd-b
+    expect(state.bindings['cmd-b']).toEqual(['workspace.actions'])
+    // BUT getBoundCommands filters dangling at read-time → empty
+    const bound = state.getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'host-1')
+    expect(bound).toEqual([])
+  })
+
+  it('sanitizeBindings is idempotent on already-clean payload', () => {
+    const clean = { 'cmd-a': ['workspace.actions'] }
+    expect(sanitizeBindings(clean)).toEqual(clean)
   })
 })

--- a/spa/src/lib/sync/contributors/quick-commands.test.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.test.ts
@@ -284,4 +284,71 @@ describe('createQuickCommandsContributor — bindings field (v2)', () => {
     const clean = { 'cmd-a': ['workspace.actions'] }
     expect(sanitizeBindings(clean)).toEqual(clean)
   })
+
+  // codex round-1 P2: missing/undefined bindings normalization
+  it('full-replace defaults missing bindings to {} (older payload bundle)', () => {
+    // simulate older sync bundle without bindings field
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+      byHost: {},
+      bindings: { 'cmd-a': ['workspace.actions'] }, // local has stale bindings
+    })
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'cmd-b', name: 'B', command: 'b' }],
+        byHost: {},
+        // bindings absent — older format
+      } as unknown as Record<string, unknown>,
+    }
+    contributor.deserialize(incoming, { type: 'full-replace' })
+    const state = useQuickCommandStore.getState()
+    // bindings reset to {} — must be a record, NEVER undefined
+    expect(state.bindings).toEqual({})
+    expect(typeof state.bindings).toBe('object')
+  })
+
+  it('full-replace defaults null bindings to {} (corrupted payload)', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+      byHost: {},
+      bindings: { 'cmd-a': ['workspace.actions'] },
+    })
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [],
+        byHost: {},
+        bindings: null,
+      } as unknown as Record<string, unknown>,
+    }
+    contributor.deserialize(incoming, { type: 'full-replace' })
+    expect(useQuickCommandStore.getState().bindings).toEqual({})
+  })
+
+  it('field-merge with missing bindings field leaves local bindings untouched', () => {
+    // Even when resolved says bindings='remote', if incoming omits the field,
+    // patch must NOT clear local (preserves field-merge "absent = no change" semantic).
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+      byHost: {},
+      bindings: { 'cmd-a': ['workspace.actions'] },
+    })
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+        byHost: {},
+        // bindings absent
+      } as unknown as Record<string, unknown>,
+    }
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { bindings: 'remote' },
+    })
+    // Local bindings preserved (field absent → no patch applied)
+    expect(useQuickCommandStore.getState().bindings).toEqual({
+      'cmd-a': ['workspace.actions'],
+    })
+  })
 })

--- a/spa/src/lib/sync/contributors/quick-commands.test.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.test.ts
@@ -326,6 +326,59 @@ describe('createQuickCommandsContributor — bindings field (v2)', () => {
     expect(useQuickCommandStore.getState().bindings).toEqual({})
   })
 
+  // codex round-2 A2: hostile sync payload action-method overwrite attack
+  it('full-replace ignores non-DATA_FIELDS keys (e.g. setBinding overwrite attempt)', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+      byHost: {},
+      bindings: {},
+    })
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [],
+        byHost: {},
+        bindings: {},
+        // hostile keys attempting to overwrite zustand action methods
+        setBinding: null,
+        getBoundCommands: 'evil',
+        addCommand: () => {
+          throw new Error('hijacked')
+        },
+      } as unknown as Record<string, unknown>,
+    }
+    contributor.deserialize(incoming, { type: 'full-replace' })
+    const state = useQuickCommandStore.getState()
+    // Action methods MUST remain functions
+    expect(typeof state.setBinding).toBe('function')
+    expect(typeof state.getBoundCommands).toBe('function')
+    expect(typeof state.addCommand).toBe('function')
+    // And actually be callable (no hijack)
+    expect(() => state.addCommand({ id: 'safe', name: 'S', command: 's' })).not.toThrow()
+  })
+
+  it('field-merge ignores non-DATA_FIELDS keys', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+      byHost: {},
+      bindings: {},
+    })
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        global: [{ id: 'cmd-b', name: 'B', command: 'b' }],
+        setBinding: null, // hostile
+      } as unknown as Record<string, unknown>,
+    }
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { global: 'remote' },
+    })
+    const state = useQuickCommandStore.getState()
+    expect(typeof state.setBinding).toBe('function')
+    expect(state.global).toEqual([{ id: 'cmd-b', name: 'B', command: 'b' }])
+  })
+
   it('field-merge with missing bindings field leaves local bindings untouched', () => {
     // Even when resolved says bindings='remote', if incoming omits the field,
     // patch must NOT clear local (preserves field-merge "absent = no change" semantic).

--- a/spa/src/lib/sync/contributors/quick-commands.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.ts
@@ -2,14 +2,14 @@
 // Sync Architecture — QuickCommandsContributor
 // =============================================================================
 
-import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useQuickCommandStore, sanitizeBindings } from '../../../stores/useQuickCommandStore'
 import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
 
 // ---------------------------------------------------------------------------
 // Data field list (non-function fields from QuickCommandState)
 // ---------------------------------------------------------------------------
 
-const DATA_FIELDS = ['global', 'byHost'] as const
+const DATA_FIELDS = ['global', 'byHost', 'bindings'] as const
 
 type QuickCommandsData = {
   [K in (typeof DATA_FIELDS)[number]]: ReturnType<typeof useQuickCommandStore.getState>[K]
@@ -41,16 +41,24 @@ export function createQuickCommandsContributor(): SyncContributor {
       const fp = payload as FullPayload
       const incoming = fp.data as Partial<QuickCommandsData>
 
+      // Sanitize untrusted incoming bindings BEFORE applying. Mirrors the
+      // store's `merge` hook — sync payloads are equally untrusted.
+      const sanitizedIncoming: Partial<QuickCommandsData> = {
+        ...incoming,
+        ...(incoming.bindings !== undefined
+          ? { bindings: sanitizeBindings(incoming.bindings) }
+          : {}),
+      }
+
       if (merge.type === 'full-replace') {
-        useQuickCommandStore.setState(incoming as QuickCommandsData)
+        useQuickCommandStore.setState(sanitizedIncoming as QuickCommandsData)
         return
       }
 
-      // field-merge: only apply fields where resolved[field] === 'remote'
       const patch: Partial<QuickCommandsData> = {}
       for (const field of DATA_FIELDS) {
-        if (merge.resolved[field] === 'remote' && field in incoming) {
-          ;(patch as Record<string, unknown>)[field] = incoming[field]
+        if (merge.resolved[field] === 'remote' && field in sanitizedIncoming) {
+          ;(patch as Record<string, unknown>)[field] = sanitizedIncoming[field]
         }
       }
 

--- a/spa/src/lib/sync/contributors/quick-commands.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.ts
@@ -39,36 +39,55 @@ export function createQuickCommandsContributor(): SyncContributor {
 
     deserialize(payload: unknown, merge: MergeStrategy): void {
       const fp = payload as FullPayload
-      const incoming = fp.data as Partial<QuickCommandsData>
+      const incoming = (fp.data ?? {}) as Record<string, unknown>
 
-      // Sanitize untrusted incoming bindings BEFORE applying. Mirrors the
-      // store's `merge` hook — sync payloads are equally untrusted.
-      // Only attach sanitized bindings when incoming has the field (preserves
-      // field-merge semantics: absent field → no patch → local untouched).
-      const sanitizedIncoming: Partial<QuickCommandsData> = {
-        ...incoming,
-        ...(incoming.bindings !== undefined
-          ? { bindings: sanitizeBindings(incoming.bindings) }
-          : {}),
-      }
+      // codex round-2 attack vector: a hostile sync payload could include
+      // keys like `setBinding`, `getBoundCommands`, `addCommand` etc. and
+      // zustand merge mode would overwrite those action methods with
+      // attacker-controlled values, defeating the action-method protection.
+      //
+      // Defense: build patch ONLY from whitelisted DATA_FIELDS. Never spread
+      // arbitrary `incoming` into setState.
 
       if (merge.type === 'full-replace') {
-        // Full-replace: bindings MUST be a record after this call. If incoming
-        // omitted bindings (older bundle), default to {} so getBoundCommands
-        // and friends never see undefined leaked into the store.
-        useQuickCommandStore.setState({
-          ...sanitizedIncoming,
-          bindings: sanitizedIncoming.bindings ?? {},
-        } as QuickCommandsData)
+        // Full-replace: explicitly assign each whitelisted field with safe
+        // defaults. bindings MUST be a record after this call (sanitizer
+        // returns {} for absent / null / garbage), so getBoundCommands and
+        // friends never see `undefined` leaked into the store.
+        const patch: Partial<QuickCommandsData> = {
+          global: Array.isArray(incoming.global) ? (incoming.global as QuickCommandsData['global']) : [],
+          byHost:
+            typeof incoming.byHost === 'object' &&
+            incoming.byHost !== null &&
+            !Array.isArray(incoming.byHost)
+              ? (incoming.byHost as QuickCommandsData['byHost'])
+              : {},
+          bindings: sanitizeBindings(incoming.bindings),
+        }
+        useQuickCommandStore.setState(patch as QuickCommandsData)
         return
       }
 
       // field-merge: only apply remote-resolved fields actually present in
-      // incoming. Absent bindings → leave local untouched (don't force {}).
+      // incoming. Absent fields → leave local untouched.
       const patch: Partial<QuickCommandsData> = {}
       for (const field of DATA_FIELDS) {
-        if (merge.resolved[field] === 'remote' && field in sanitizedIncoming) {
-          ;(patch as Record<string, unknown>)[field] = sanitizedIncoming[field]
+        if (merge.resolved[field] !== 'remote') continue
+        if (!(field in incoming)) continue
+        if (field === 'bindings') {
+          patch.bindings = sanitizeBindings(incoming.bindings)
+        } else if (field === 'global') {
+          if (Array.isArray(incoming.global)) {
+            patch.global = incoming.global as QuickCommandsData['global']
+          }
+        } else if (field === 'byHost') {
+          if (
+            typeof incoming.byHost === 'object' &&
+            incoming.byHost !== null &&
+            !Array.isArray(incoming.byHost)
+          ) {
+            patch.byHost = incoming.byHost as QuickCommandsData['byHost']
+          }
         }
       }
 

--- a/spa/src/lib/sync/contributors/quick-commands.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.ts
@@ -43,6 +43,8 @@ export function createQuickCommandsContributor(): SyncContributor {
 
       // Sanitize untrusted incoming bindings BEFORE applying. Mirrors the
       // store's `merge` hook — sync payloads are equally untrusted.
+      // Only attach sanitized bindings when incoming has the field (preserves
+      // field-merge semantics: absent field → no patch → local untouched).
       const sanitizedIncoming: Partial<QuickCommandsData> = {
         ...incoming,
         ...(incoming.bindings !== undefined
@@ -51,10 +53,18 @@ export function createQuickCommandsContributor(): SyncContributor {
       }
 
       if (merge.type === 'full-replace') {
-        useQuickCommandStore.setState(sanitizedIncoming as QuickCommandsData)
+        // Full-replace: bindings MUST be a record after this call. If incoming
+        // omitted bindings (older bundle), default to {} so getBoundCommands
+        // and friends never see undefined leaked into the store.
+        useQuickCommandStore.setState({
+          ...sanitizedIncoming,
+          bindings: sanitizedIncoming.bindings ?? {},
+        } as QuickCommandsData)
         return
       }
 
+      // field-merge: only apply remote-resolved fields actually present in
+      // incoming. Absent bindings → leave local untouched (don't force {}).
       const patch: Partial<QuickCommandsData> = {}
       for (const field of DATA_FIELDS) {
         if (merge.resolved[field] === 'remote' && field in sanitizedIncoming) {

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -21,6 +21,7 @@
   "modules.editor.description": "Text and rich content editor with syntax highlighting",
   "modules.browser.description": "Embedded web browser pane (requires desktop app)",
   "modules.memory_monitor.description": "System memory and renderer diagnostics",
+  "modules.quick_commands.description": "Quickly run frequently-used commands from Workspace and Host entry points",
   "settings.sync.description": "Synchronise settings and workspaces across devices.",
   "settings.sync.provider.label": "Provider",
   "settings.sync.provider.description": "Select where sync data is stored and exchanged.",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -21,6 +21,7 @@
   "modules.editor.description": "具語法高亮的文字與多樣內容編輯器",
   "modules.browser.description": "內嵌網頁瀏覽器面板（需桌面版）",
   "modules.memory_monitor.description": "系統記憶體與 renderer 診斷",
+  "modules.quick_commands.description": "讓你在 Workspace 與 Host 入口快速執行常用指令",
   "settings.sync.description": "在多裝置之間同步設定與工作區。",
   "settings.sync.provider.label": "提供者",
   "settings.sync.provider.description": "選擇同步資料的儲存與交換位置。",

--- a/spa/src/stores/useQuickCommandStore.test.ts
+++ b/spa/src/stores/useQuickCommandStore.test.ts
@@ -1,48 +1,139 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useQuickCommandStore } from './useQuickCommandStore'
+import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
 
-describe('useQuickCommandStore', () => {
+// 顯式列出所有 mutable fields — zustand setState merge 模式下，
+// action methods 由 closure 持有，不會被覆蓋（見 feedback_zustand_harness_setstate.md）。
+function resetStore(initial?: {
+  global?: ReturnType<typeof useQuickCommandStore.getState>['global']
+  byHost?: ReturnType<typeof useQuickCommandStore.getState>['byHost']
+  bindings?: ReturnType<typeof useQuickCommandStore.getState>['bindings']
+}) {
+  useQuickCommandStore.setState({
+    global: initial?.global ?? [],
+    byHost: initial?.byHost ?? {},
+    bindings: initial?.bindings ?? {},
+  })
+}
+
+describe('useQuickCommandStore — capability CRUD (Phase 1a)', () => {
   beforeEach(() => {
-    useQuickCommandStore.setState({
+    resetStore({
       global: [
-        { id: 'start-cc', name: 'Start Claude Code', command: 'claude -p --verbose --output-format stream-json', category: 'agent' },
-        { id: 'start-codex', name: 'Start Codex', command: 'codex', category: 'agent' },
+        { id: 'cmd-a', name: 'A', command: 'a', category: 'agent' },
+        { id: 'cmd-b', name: 'B', command: 'b' },
       ],
-      byHost: {},
     })
   })
 
   it('getCommands returns global commands when no host overrides', () => {
     const cmds = useQuickCommandStore.getState().getCommands('host-1')
-    expect(cmds).toHaveLength(2)
-    expect(cmds[0].id).toBe('start-cc')
+    expect(cmds.map((c) => c.id)).toEqual(['cmd-a', 'cmd-b'])
   })
 
   it('per-host overrides global by id', () => {
     useQuickCommandStore.getState().addCommand(
-      { id: 'start-cc', name: 'CC Custom', command: 'claude --custom', category: 'agent' },
+      { id: 'cmd-a', name: 'A-host', command: 'aa' },
       'host-1',
     )
     const cmds = useQuickCommandStore.getState().getCommands('host-1')
-    const cc = cmds.find((c) => c.id === 'start-cc')!
-    expect(cc.command).toBe('claude --custom')
-    expect(cc.name).toBe('CC Custom')
+    const a = cmds.find((c) => c.id === 'cmd-a')!
+    expect(a.command).toBe('aa')
+    expect(a.name).toBe('A-host')
   })
 
   it('addCommand to global', () => {
-    useQuickCommandStore.getState().addCommand({ id: 'custom', name: 'Custom', command: 'ls -la' })
+    useQuickCommandStore.getState().addCommand({ id: 'cmd-c', name: 'C', command: 'c' })
     expect(useQuickCommandStore.getState().global).toHaveLength(3)
   })
 
   it('removeCommand from global', () => {
-    useQuickCommandStore.getState().removeCommand('start-codex')
-    expect(useQuickCommandStore.getState().global).toHaveLength(1)
+    useQuickCommandStore.getState().removeCommand('cmd-a')
+    expect(useQuickCommandStore.getState().global.find((c) => c.id === 'cmd-a')).toBeUndefined()
   })
 
   it('updateCommand in global', () => {
-    useQuickCommandStore.getState().updateCommand('start-cc', { name: 'CC Updated' })
-    const cmd = useQuickCommandStore.getState().global.find((c) => c.id === 'start-cc')!
-    expect(cmd.name).toBe('CC Updated')
-    expect(cmd.command).toBe('claude -p --verbose --output-format stream-json')
+    useQuickCommandStore.getState().updateCommand('cmd-a', { name: 'A-updated' })
+    expect(useQuickCommandStore.getState().global.find((c) => c.id === 'cmd-a')!.name).toBe('A-updated')
+  })
+})
+
+describe('useQuickCommandStore — bindings (Phase 1a)', () => {
+  beforeEach(() => {
+    resetStore({
+      global: [
+        { id: 'cmd-a', name: 'A', command: 'a' },
+        { id: 'cmd-b', name: 'B', command: 'b' },
+      ],
+    })
+  })
+
+  it('bindings default to empty object', () => {
+    expect(useQuickCommandStore.getState().bindings).toEqual({})
+  })
+
+  it('setBinding records command -> slot mapping', () => {
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toEqual(['workspace.actions'])
+  })
+
+  it('setBinding with empty array removes the binding entry', () => {
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().setBinding('cmd-a', [])
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toBeUndefined()
+  })
+
+  it('setBinding can mount a command into multiple slots', () => {
+    useQuickCommandStore.getState().setBinding('cmd-a', [
+      QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS,
+      QUICK_COMMAND_SLOTS.HOST_ACTIONS,
+    ])
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toEqual([
+      'workspace.actions',
+      'host.actions',
+    ])
+  })
+
+  it('getBoundCommands returns commands mounted to the slot, in capability order', () => {
+    useQuickCommandStore.getState().setBinding('cmd-b', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    const bound = useQuickCommandStore
+      .getState()
+      .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'host-1')
+    // 順序穩定 — 跟著 getCommands(hostId) 的順序，不是 bindings Record 的 key 順序
+    expect(bound.map((c) => c.id)).toEqual(['cmd-a', 'cmd-b'])
+  })
+
+  it('getBoundCommands skips bindings whose command no longer exists (dangling filter)', () => {
+    useQuickCommandStore.getState().setBinding('cmd-zombie', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    const bound = useQuickCommandStore
+      .getState()
+      .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'host-1')
+    expect(bound.map((c) => c.id)).toEqual(['cmd-a'])
+  })
+
+  it('removeCommand on a global command also clears its binding', () => {
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().removeCommand('cmd-a')
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toBeUndefined()
+  })
+
+  it('removeCommand on a per-host command does NOT clear its binding (binding is global concept)', () => {
+    useQuickCommandStore.getState().addCommand({ id: 'cmd-a', name: 'A-host', command: 'aa' }, 'host-1')
+    useQuickCommandStore.getState().setBinding('cmd-a', [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS])
+    useQuickCommandStore.getState().removeCommand('cmd-a', 'host-1')
+    // global cmd-a 仍存在；per-host override 被刪；binding 不動
+    expect(useQuickCommandStore.getState().bindings['cmd-a']).toEqual(['workspace.actions'])
+  })
+})
+
+describe('useQuickCommandStore — sanitizeBindings via merge', () => {
+  it('drops non-object payloads', () => {
+    // 直接呼叫 merge 行為：模擬 hydrated raw string
+    // (sanitizer 是 module-private，所以透過 setState + merge hook 間接驗；
+    //  這裡的合理代表是斷言 store 在惡意 payload 注入後仍維持 bindings = {})
+    useQuickCommandStore.setState({ bindings: {} })
+    expect(useQuickCommandStore.getState().bindings).toEqual({})
   })
 })

--- a/spa/src/stores/useQuickCommandStore.test.ts
+++ b/spa/src/stores/useQuickCommandStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { useQuickCommandStore } from './useQuickCommandStore'
+import { useQuickCommandStore, sanitizeBindings } from './useQuickCommandStore'
 import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
 
 // 顯式列出所有 mutable fields — zustand setState merge 模式下，
@@ -135,5 +135,48 @@ describe('useQuickCommandStore — sanitizeBindings via merge', () => {
     //  這裡的合理代表是斷言 store 在惡意 payload 注入後仍維持 bindings = {})
     useQuickCommandStore.setState({ bindings: {} })
     expect(useQuickCommandStore.getState().bindings).toEqual({})
+  })
+})
+
+describe('sanitizeBindings — slot id whitelist (codex round-1 P2)', () => {
+  it('accepts known QUICK_COMMAND_SLOTS values', () => {
+    const out = sanitizeBindings({
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS],
+    })
+    expect(out).toEqual({
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS],
+    })
+  })
+
+  it('rejects unknown slot ids (typos / future slots)', () => {
+    const out = sanitizeBindings({
+      'cmd-a': ['workspace.action', 'workspaces.actions', 'host.action'],
+    })
+    // All three are typos / unknown → entry dropped (cleaned array empty)
+    expect(out).toEqual({})
+  })
+
+  it('keeps only whitelisted slot ids in mixed array', () => {
+    const out = sanitizeBindings({
+      'cmd-a': [
+        QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS,
+        'workspace.action',
+        QUICK_COMMAND_SLOTS.HOST_ACTIONS,
+        'random.target',
+      ],
+    })
+    expect(out).toEqual({
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS],
+    })
+  })
+
+  it('drops entries whose targets are all invalid', () => {
+    const out = sanitizeBindings({
+      'cmd-a': ['unknown'],
+      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+    })
+    expect(out).toEqual({
+      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+    })
   })
 })

--- a/spa/src/stores/useQuickCommandStore.test.ts
+++ b/spa/src/stores/useQuickCommandStore.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { useQuickCommandStore, sanitizeBindings } from './useQuickCommandStore'
+import {
+  useQuickCommandStore,
+  sanitizeBindings,
+  mergePersistedQuickCommandState,
+} from './useQuickCommandStore'
 import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
 
 // 顯式列出所有 mutable fields — zustand setState merge 模式下，
@@ -138,7 +142,10 @@ describe('useQuickCommandStore — sanitizeBindings via merge', () => {
   })
 })
 
-describe('sanitizeBindings — slot id whitelist (codex round-1 P2)', () => {
+describe('sanitizeBindings — forward-compat with unknown slot ids (spec §2.3)', () => {
+  // Spec §2.3 explicitly allows unknown slot ids in Phase 1 so cross-version
+  // sync (older client pulls newer client's future slot binding) doesn't
+  // lose data. SlotHost ignores unknown ids at render time.
   it('accepts known QUICK_COMMAND_SLOTS values', () => {
     const out = sanitizeBindings({
       'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS],
@@ -148,35 +155,212 @@ describe('sanitizeBindings — slot id whitelist (codex round-1 P2)', () => {
     })
   })
 
-  it('rejects unknown slot ids (typos / future slots)', () => {
+  it('preserves unknown / future slot ids verbatim (forward-compat)', () => {
     const out = sanitizeBindings({
-      'cmd-a': ['workspace.action', 'workspaces.actions', 'host.action'],
+      'cmd-a': ['future.actions', 'workspace.action'],
     })
-    // All three are typos / unknown → entry dropped (cleaned array empty)
-    expect(out).toEqual({})
+    // Both kept — spec requires forward-compat. SlotHost doesn't render them
+    // because no slot is registered, but data persists for newer clients.
+    expect(out).toEqual({
+      'cmd-a': ['future.actions', 'workspace.action'],
+    })
   })
 
-  it('keeps only whitelisted slot ids in mixed array', () => {
+  it('drops only empty / non-string targets', () => {
     const out = sanitizeBindings({
-      'cmd-a': [
-        QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS,
-        'workspace.action',
-        QUICK_COMMAND_SLOTS.HOST_ACTIONS,
-        'random.target',
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, '', 123, null, 'host.actions'],
+    })
+    expect(out).toEqual({
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'host.actions'],
+    })
+  })
+
+  it('drops entries whose value is not an array', () => {
+    const out = sanitizeBindings({
+      'cmd-a': 'workspace.actions', // not an array
+      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+    })
+    expect(out).toEqual({
+      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+    })
+  })
+
+  it('rejects prototype-pollution command id keys', () => {
+    const out = sanitizeBindings({
+      __proto__: ['workspace.actions'],
+      constructor: ['workspace.actions'],
+      prototype: ['workspace.actions'],
+      'cmd-a': ['workspace.actions'],
+    })
+    expect(out).toEqual({ 'cmd-a': ['workspace.actions'] })
+  })
+})
+
+describe('getBoundCommands — prototype-key safety (codex round-2 A1)', () => {
+  // Without own-property check, a command id that happens to match an
+  // Object.prototype method (toString / valueOf / hasOwnProperty / etc.)
+  // would resolve `bindings[c.id]` to an inherited function, and `.includes()`
+  // on a function would throw → DoS for every caller of getBoundCommands.
+  it('does NOT throw when capability id collides with Object.prototype method (toString)', () => {
+    useQuickCommandStore.setState({
+      global: [{ id: 'toString', name: 'Evil', command: 'rm -rf /' }],
+      byHost: {},
+      bindings: {}, // no binding for 'toString' — but Object.prototype.toString exists
+    })
+    expect(() =>
+      useQuickCommandStore
+        .getState()
+        .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'h1'),
+    ).not.toThrow()
+    // Should treat it as "no binding" — not render the evil command
+    const result = useQuickCommandStore
+      .getState()
+      .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'h1')
+    expect(result).toEqual([])
+  })
+
+  it('safe when bindings has prototype-method ids (valueOf / hasOwnProperty)', () => {
+    useQuickCommandStore.setState({
+      global: [
+        { id: 'valueOf', name: 'V', command: 'v' },
+        { id: 'hasOwnProperty', name: 'H', command: 'h' },
       ],
+      byHost: {},
+      bindings: {},
     })
-    expect(out).toEqual({
-      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS],
+    expect(() =>
+      useQuickCommandStore
+        .getState()
+        .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'h1'),
+    ).not.toThrow()
+  })
+})
+
+describe('getBoundCommands — null hostId (spec §4.4 / codex round-2 D2)', () => {
+  beforeEach(() => {
+    resetStore({
+      global: [
+        { id: 'cmd-a', name: 'A', command: 'a' },
+        { id: 'cmd-b', name: 'B', command: 'b' },
+        { id: 'cmd-c', name: 'C', command: 'c' },
+      ],
+      byHost: {
+        'h1': [{ id: 'cmd-a', name: 'A-host', command: 'a-host' }], // override
+      },
+      bindings: {
+        'cmd-c': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+        'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+      },
     })
   })
 
-  it('drops entries whose targets are all invalid', () => {
-    const out = sanitizeBindings({
-      'cmd-a': ['unknown'],
-      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+  it('hostId=null uses state.global (NOT host override) for capability order', () => {
+    const out = useQuickCommandStore
+      .getState()
+      .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, null)
+    // Order follows global (cmd-a appears before cmd-c)
+    expect(out.map((c) => c.id)).toEqual(['cmd-a', 'cmd-c'])
+    // 'cmd-a' is the global version, NOT the host override
+    expect(out[0].command).toBe('a')
+    expect(out[0].name).toBe('A')
+  })
+
+  it('hostId="h1" uses getCommands(h1) which applies override', () => {
+    const out = useQuickCommandStore
+      .getState()
+      .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'h1')
+    expect(out.map((c) => c.id)).toEqual(['cmd-a', 'cmd-c'])
+    expect(out[0].command).toBe('a-host') // override applied
+  })
+
+  it('hostId=null is stable regardless of bindings record key order', () => {
+    // Reset bindings with reversed key order — global capability order should still win
+    resetStore({
+      global: [
+        { id: 'cmd-a', name: 'A', command: 'a' },
+        { id: 'cmd-b', name: 'B', command: 'b' },
+        { id: 'cmd-c', name: 'C', command: 'c' },
+      ],
+      byHost: {},
+      bindings: {
+        // intentionally reversed
+        'cmd-c': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+        'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+        'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+      },
     })
-    expect(out).toEqual({
-      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
-    })
+    const out = useQuickCommandStore
+      .getState()
+      .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, null)
+    expect(out.map((c) => c.id)).toEqual(['cmd-a', 'cmd-b', 'cmd-c'])
+  })
+})
+
+describe('mergePersistedQuickCommandState — real hydrate trust boundary (codex round-2 Q1)', () => {
+  // Drives the actual `merge` hook used by zustand persist on rehydrate,
+  // not a setState fake. Catches any future regression where someone
+  // inadvertently bypasses sanitizer at the hydrate trust boundary.
+  // mergePersistedQuickCommandState only reads the three data fields and
+  // spreads `current` for the rest. Tests don't exercise action methods,
+  // so a minimal data-only stub is sufficient (cast via unknown).
+  const baselineCurrent = {
+    global: [],
+    byHost: {},
+    bindings: {},
+  } as unknown as Parameters<typeof mergePersistedQuickCommandState>[1]
+
+  it('null persisted payload → returns current with empty bindings', () => {
+    const out = mergePersistedQuickCommandState(null, baselineCurrent)
+    expect(out.bindings).toEqual({})
+  })
+
+  it('hostile bindings payload (prototype keys) → sanitized to safe record', () => {
+    const out = mergePersistedQuickCommandState(
+      {
+        global: [],
+        byHost: {},
+        bindings: {
+          __proto__: ['workspace.actions'],
+          constructor: ['workspace.actions'],
+          'cmd-a': ['workspace.actions'],
+        },
+      },
+      baselineCurrent,
+    )
+    expect(out.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
+  })
+
+  it('non-array bindings → fallback to {}', () => {
+    const out = mergePersistedQuickCommandState(
+      { global: [], byHost: {}, bindings: 'not-an-object' },
+      baselineCurrent,
+    )
+    expect(out.bindings).toEqual({})
+  })
+
+  it('non-array global → keeps current.global (preserves alpha state)', () => {
+    const current = {
+      ...baselineCurrent,
+      global: [{ id: 'existing', name: 'E', command: 'e' }],
+    }
+    const out = mergePersistedQuickCommandState(
+      { global: 'corrupt', byHost: {}, bindings: {} },
+      current,
+    )
+    expect(out.global).toEqual([{ id: 'existing', name: 'E', command: 'e' }])
+  })
+
+  it('valid payload passes through (sanity)', () => {
+    const out = mergePersistedQuickCommandState(
+      {
+        global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+        byHost: { h1: [] },
+        bindings: { 'cmd-a': ['workspace.actions'] },
+      },
+      baselineCurrent,
+    )
+    expect(out.global).toEqual([{ id: 'cmd-a', name: 'A', command: 'a' }])
+    expect(out.byHost).toEqual({ h1: [] })
+    expect(out.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
   })
 })

--- a/spa/src/stores/useQuickCommandStore.ts
+++ b/spa/src/stores/useQuickCommandStore.ts
@@ -1,9 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
-import { QUICK_COMMAND_SLOTS, type QuickCommandSlotId } from '../lib/quick-command-slots'
-
-const VALID_SLOT_IDS = new Set<string>(Object.values(QUICK_COMMAND_SLOTS))
+import type { QuickCommandSlotId } from '../lib/quick-command-slots'
 
 export interface QuickCommand {
   id: string
@@ -27,7 +25,10 @@ interface QuickCommandState {
   getCommands: (hostId: string) => QuickCommand[]
 
   setBinding: (commandId: string, targets: QuickCommandSlotId[]) => void
-  getBoundCommands: (mountTarget: QuickCommandSlotId, hostId: string) => QuickCommand[]
+  // hostId === null: workspace caller before HostPicker resolves a host;
+  // renderer uses state.global as capability order (spec §4.4).
+  // hostId !== null: per-host capability list from getCommands.
+  getBoundCommands: (mountTarget: QuickCommandSlotId, hostId: string | null) => QuickCommand[]
 }
 
 // v2: do NOT pre-seed defaults. Existing users who hydrated v1 defaults
@@ -43,13 +44,16 @@ const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
  * hand-edited localStorage, failed migration, hostile sync source — must
  * NEVER let arbitrary string keys silently mount commands into slots.
  *
- * Rules:
+ * Rules (spec §2.3 — forward-compat with future slot ids):
  *  - Top-level value must be a plain object (rejects arrays, null, primitives).
- *  - Reject `__proto__` / `constructor` / `prototype` keys (prototype pollution).
+ *  - Reject `__proto__` / `constructor` / `prototype` command id keys
+ *    (prototype pollution).
  *  - Drop entries whose value is not an array.
- *  - Within each array, keep only strings present in `QUICK_COMMAND_SLOTS`
- *    (whitelist; rejects typos like `'workspace.action'` and forward-incompat
- *    slot ids — if a future version adds slots, sanitizer ships in that PR).
+ *  - Within each array, keep only non-empty strings. NO slot id whitelist —
+ *    spec §2.3 explicitly requires accepting unknown slot ids in Phase 1
+ *    so cross-version sync (older client pulls newer client's future slot
+ *    binding) doesn't lose data; SlotHost simply ignores unknown slot ids
+ *    at render time.
  *  - Drop entries whose cleaned array is empty (matches setBinding(id, [])).
  */
 export function sanitizeBindings(raw: unknown): Bindings {
@@ -61,11 +65,52 @@ export function sanitizeBindings(raw: unknown): Bindings {
     if (!Array.isArray(targets)) continue
     const cleaned: QuickCommandSlotId[] = []
     for (const t of targets) {
-      if (typeof t === 'string' && VALID_SLOT_IDS.has(t)) cleaned.push(t as QuickCommandSlotId)
+      if (typeof t === 'string' && t.length > 0) cleaned.push(t as QuickCommandSlotId)
     }
     if (cleaned.length > 0) out[cmdId] = cleaned
   }
   return out
+}
+
+/**
+ * Read bindings[cmdId] safely. Prevents inherited-prop attacks where cmdId
+ * happens to match Object.prototype methods (toString / valueOf / hasOwnProperty
+ * / isPrototypeOf / etc.) — naive `bindings[cmdId]` would resolve to a
+ * non-array function and `.includes(slot)` would throw, crashing
+ * getBoundCommands for every caller (DoS).
+ *
+ * Returns undefined unless `bindings` has its OWN property `cmdId` AND that
+ * value is an array.
+ */
+function getBindingTargets(bindings: Bindings, cmdId: string): QuickCommandSlotId[] | undefined {
+  if (!Object.prototype.hasOwnProperty.call(bindings, cmdId)) return undefined
+  const targets = bindings[cmdId]
+  return Array.isArray(targets) ? targets : undefined
+}
+
+/**
+ * Pure merge function — used by zustand persist `merge` hook AND directly by
+ * tests to drive the real hydrate trust boundary with malformed payloads.
+ * Exporting this avoids the previous test pattern of using setState as a
+ * mock for hydrate, which never actually went through sanitizer.
+ */
+export function mergePersistedQuickCommandState(
+  persisted: unknown,
+  current: QuickCommandState,
+): QuickCommandState {
+  const p = persisted as
+    | { global?: unknown; byHost?: unknown; bindings?: unknown }
+    | null
+    | undefined
+  return {
+    ...current,
+    global: Array.isArray(p?.global) ? (p?.global as QuickCommand[]) : current.global,
+    byHost:
+      typeof p?.byHost === 'object' && p?.byHost !== null && !Array.isArray(p?.byHost)
+        ? (p?.byHost as Record<string, QuickCommand[]>)
+        : current.byHost,
+    bindings: sanitizeBindings(p?.bindings),
+  }
 }
 
 export const useQuickCommandStore = create<QuickCommandState>()(
@@ -146,13 +191,20 @@ export const useQuickCommandStore = create<QuickCommandState>()(
         }),
 
       getBoundCommands: (mountTarget, hostId) => {
+        // hostId === null: spec §4.4 — workspace caller before HostPicker
+        // resolved a host; render uses state.global as capability order so
+        // chip list isn't re-sorted when picker eventually picks a host.
+        // Non-null: per-host capability order from getCommands.
         // Iterate the capability list (stable, sync-safe order) — NOT
-        // Object.keys(bindings) which has unpredictable post-sync order
-        // (spec §4.4). Dangling binding entries (commandId without a matching
-        // capability) are skipped here as well as cleared at removeCommand.
-        const cmds = get().getCommands(hostId)
+        // Object.keys(bindings) which has unpredictable post-sync order.
+        // Dangling binding entries (commandId without a matching capability)
+        // are skipped here as well as cleared at removeCommand.
+        const cmds = hostId === null ? get().global : get().getCommands(hostId)
         const { bindings } = get()
-        return cmds.filter((c) => bindings[c.id]?.includes(mountTarget))
+        return cmds.filter((c) => {
+          const targets = getBindingTargets(bindings, c.id)
+          return targets !== undefined && targets.includes(mountTarget)
+        })
       },
     }),
     {
@@ -164,20 +216,8 @@ export const useQuickCommandStore = create<QuickCommandState>()(
         byHost: state.byHost,
         bindings: state.bindings,
       }),
-      merge: (persisted, current) => {
-        // AR-1: sanitize hydrated bindings BEFORE first read. global / byHost
-        // come from a known-shape v1 payload — keep as-is. Only bindings is
-        // newly added in v2 and must be clamped against hostile payloads.
-        const p = persisted as { global?: unknown; byHost?: unknown; bindings?: unknown } | null | undefined
-        return {
-          ...current,
-          global: Array.isArray(p?.global) ? (p?.global as QuickCommand[]) : current.global,
-          byHost: typeof p?.byHost === 'object' && p?.byHost !== null && !Array.isArray(p?.byHost)
-            ? (p?.byHost as Record<string, QuickCommand[]>)
-            : current.byHost,
-          bindings: sanitizeBindings(p?.bindings),
-        }
-      },
+      merge: (persisted, current) =>
+        mergePersistedQuickCommandState(persisted, current as QuickCommandState),
     },
   ),
 )

--- a/spa/src/stores/useQuickCommandStore.ts
+++ b/spa/src/stores/useQuickCommandStore.ts
@@ -1,7 +1,9 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
-import type { QuickCommandSlotId } from '../lib/quick-command-slots'
+import { QUICK_COMMAND_SLOTS, type QuickCommandSlotId } from '../lib/quick-command-slots'
+
+const VALID_SLOT_IDS = new Set<string>(Object.values(QUICK_COMMAND_SLOTS))
 
 export interface QuickCommand {
   id: string
@@ -45,8 +47,9 @@ const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
  *  - Top-level value must be a plain object (rejects arrays, null, primitives).
  *  - Reject `__proto__` / `constructor` / `prototype` keys (prototype pollution).
  *  - Drop entries whose value is not an array.
- *  - Within each array, keep only non-empty strings (dedupe NOT done here —
- *    UI guarantees uniqueness; tolerating duplicates is forward-compatible).
+ *  - Within each array, keep only strings present in `QUICK_COMMAND_SLOTS`
+ *    (whitelist; rejects typos like `'workspace.action'` and forward-incompat
+ *    slot ids — if a future version adds slots, sanitizer ships in that PR).
  *  - Drop entries whose cleaned array is empty (matches setBinding(id, [])).
  */
 export function sanitizeBindings(raw: unknown): Bindings {
@@ -58,7 +61,7 @@ export function sanitizeBindings(raw: unknown): Bindings {
     if (!Array.isArray(targets)) continue
     const cleaned: QuickCommandSlotId[] = []
     for (const t of targets) {
-      if (typeof t === 'string' && t.length > 0) cleaned.push(t as QuickCommandSlotId)
+      if (typeof t === 'string' && VALID_SLOT_IDS.has(t)) cleaned.push(t as QuickCommandSlotId)
     }
     if (cleaned.length > 0) out[cmdId] = cleaned
   }

--- a/spa/src/stores/useQuickCommandStore.ts
+++ b/spa/src/stores/useQuickCommandStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
+import type { QuickCommandSlotId } from '../lib/quick-command-slots'
 
 export interface QuickCommand {
   id: string
@@ -11,32 +12,78 @@ export interface QuickCommand {
   hostOnly?: boolean
 }
 
+export type Bindings = Record<string /* commandId */, QuickCommandSlotId[]>
+
 interface QuickCommandState {
   global: QuickCommand[]
   byHost: Record<string, QuickCommand[]>
+  bindings: Bindings
 
   addCommand: (cmd: QuickCommand, hostId?: string) => void
   updateCommand: (id: string, patch: Partial<QuickCommand>, hostId?: string) => void
   removeCommand: (id: string, hostId?: string) => void
   getCommands: (hostId: string) => QuickCommand[]
+
+  setBinding: (commandId: string, targets: QuickCommandSlotId[]) => void
+  getBoundCommands: (mountTarget: QuickCommandSlotId, hostId: string) => QuickCommand[]
 }
 
-const DEFAULT_COMMANDS: QuickCommand[] = [
-  { id: 'start-cc', name: 'Start Claude Code', command: 'claude -p --verbose --output-format stream-json', category: 'agent' },
-  { id: 'start-codex', name: 'Start Codex', command: 'codex', category: 'agent' },
-]
+// v2: do NOT pre-seed defaults. Existing users who hydrated v1 defaults
+// (`start-cc` / `start-codex`) keep them but bindings = {} so nothing renders
+// until the user mounts them via Settings.
+const DEFAULT_COMMANDS: QuickCommand[] = []
+
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * AR-1 (mirrors `useModuleEnabledStore` codex review #617):
+ * Sanitize bindings on rehydrate / sync deserialize. A corrupted payload —
+ * hand-edited localStorage, failed migration, hostile sync source — must
+ * NEVER let arbitrary string keys silently mount commands into slots.
+ *
+ * Rules:
+ *  - Top-level value must be a plain object (rejects arrays, null, primitives).
+ *  - Reject `__proto__` / `constructor` / `prototype` keys (prototype pollution).
+ *  - Drop entries whose value is not an array.
+ *  - Within each array, keep only non-empty strings (dedupe NOT done here —
+ *    UI guarantees uniqueness; tolerating duplicates is forward-compatible).
+ *  - Drop entries whose cleaned array is empty (matches setBinding(id, [])).
+ */
+export function sanitizeBindings(raw: unknown): Bindings {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out: Bindings = {}
+  for (const [cmdId, targets] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof cmdId !== 'string' || cmdId.length === 0) continue
+    if (UNSAFE_KEYS.has(cmdId)) continue
+    if (!Array.isArray(targets)) continue
+    const cleaned: QuickCommandSlotId[] = []
+    for (const t of targets) {
+      if (typeof t === 'string' && t.length > 0) cleaned.push(t as QuickCommandSlotId)
+    }
+    if (cleaned.length > 0) out[cmdId] = cleaned
+  }
+  return out
+}
 
 export const useQuickCommandStore = create<QuickCommandState>()(
   persist(
     (set, get) => ({
       global: DEFAULT_COMMANDS,
       byHost: {},
+      bindings: {},
 
       addCommand: (cmd, hostId) =>
         set((state) => {
           if (hostId) {
-            const hostCmds = [...(state.byHost[hostId] ?? []), cmd]
+            const hostCmds = [...(state.byHost[hostId] ?? []).filter((c) => c.id !== cmd.id), cmd]
             return { byHost: { ...state.byHost, [hostId]: hostCmds } }
+          }
+          // global add: replace if id exists, else append
+          const existingIdx = state.global.findIndex((c) => c.id === cmd.id)
+          if (existingIdx >= 0) {
+            const next = [...state.global]
+            next[existingIdx] = cmd
+            return { global: next }
           }
           return { global: [...state.global, cmd] }
         }),
@@ -56,9 +103,17 @@ export const useQuickCommandStore = create<QuickCommandState>()(
         set((state) => {
           if (hostId) {
             const hostCmds = (state.byHost[hostId] ?? []).filter((c) => c.id !== id)
+            // per-host removal does NOT touch bindings (binding is a global concept)
             return { byHost: { ...state.byHost, [hostId]: hostCmds } }
           }
-          return { global: state.global.filter((c) => c.id !== id) }
+          // global removal — also drop the binding entry to avoid dangling refs.
+          // getBoundCommands also filters at read-time as a defense-in-depth net.
+          const nextBindings = { ...state.bindings }
+          delete nextBindings[id]
+          return {
+            global: state.global.filter((c) => c.id !== id),
+            bindings: nextBindings,
+          }
         }),
 
       getCommands: (hostId) => {
@@ -75,6 +130,27 @@ export const useQuickCommandStore = create<QuickCommandState>()(
         ]
         return merged
       },
+
+      setBinding: (commandId, targets) =>
+        set((state) => {
+          const nextBindings = { ...state.bindings }
+          if (targets.length === 0) {
+            delete nextBindings[commandId]
+          } else {
+            nextBindings[commandId] = [...targets]
+          }
+          return { bindings: nextBindings }
+        }),
+
+      getBoundCommands: (mountTarget, hostId) => {
+        // Iterate the capability list (stable, sync-safe order) — NOT
+        // Object.keys(bindings) which has unpredictable post-sync order
+        // (spec §4.4). Dangling binding entries (commandId without a matching
+        // capability) are skipped here as well as cleared at removeCommand.
+        const cmds = get().getCommands(hostId)
+        const { bindings } = get()
+        return cmds.filter((c) => bindings[c.id]?.includes(mountTarget))
+      },
     }),
     {
       name: STORAGE_KEYS.QUICK_COMMANDS,
@@ -83,7 +159,22 @@ export const useQuickCommandStore = create<QuickCommandState>()(
       partialize: (state) => ({
         global: state.global,
         byHost: state.byHost,
+        bindings: state.bindings,
       }),
+      merge: (persisted, current) => {
+        // AR-1: sanitize hydrated bindings BEFORE first read. global / byHost
+        // come from a known-shape v1 payload — keep as-is. Only bindings is
+        // newly added in v2 and must be clamped against hostile payloads.
+        const p = persisted as { global?: unknown; byHost?: unknown; bindings?: unknown } | null | undefined
+        return {
+          ...current,
+          global: Array.isArray(p?.global) ? (p?.global as QuickCommand[]) : current.global,
+          byHost: typeof p?.byHost === 'object' && p?.byHost !== null && !Array.isArray(p?.byHost)
+            ? (p?.byHost as Record<string, QuickCommand[]>)
+            : current.byHost,
+          bindings: sanitizeBindings(p?.bindings),
+        }
+      },
     },
   ),
 )


### PR DESCRIPTION
## Summary

Quick Commands v2 重構的 **Phase 1a — 純資料層**。為三層分離 (capability / binding / slot) 鋪好 store schema、sanitizer、sync contributor、module 註冊。本 PR 不含 UI，無使用者可見變化。

## Phase 1a 範圍（4 個 commits）

- `09e3c9d5` 1a.1 — `QUICK_COMMAND_SLOTS` typed constants（slot id 字面量集中管理，避免硬寫字串）
- `9d0714a5` 1a.2 — `useQuickCommandStore` 加 `bindings` 欄位 + `setBinding` / `getBoundCommands` API + `sanitizeBindings` (仿 `useModuleEnabledStore` AR-1) + persist `merge` hook + `DEFAULT_COMMANDS = []` + `removeCommand` 同步清 binding
- `78bc2e62` 1a.3 — sync contributor `bindings` 加入 `DATA_FIELDS` + deserialize 跑 sanitizer + cross-field dangling test
- `615293b3` 1a.4 — `register-modules.tsx` 註冊 `quick-commands` 為 `disableable: true` module（settings contribution 等 Phase 1b）+ `modules.quick_commands.description` i18n key (zh-TW + en)

## 設計文件

- Spec: `docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-quick-commands-v2.md`
- 經 codex 兩輪 spec review + 兩輪 plan review，所有 finding 全採納

## 不在本 PR 範圍

- Phase 1b — Settings UI + CommandSlot + executor + HostPicker + WorkspaceRow context menu 入口
- Phase 1b' — Plus hover popover (含 mobile long-press)
- Phase 1c — SessionsSection new-session 旁 chip + 移除 row 殘留 v1 整合

## 驗證

- 4 個新測試檔 / 34 個新測試全綠
- SPA lint clean / build clean
- Go test 23 packages 全 ok / Go build clean
- ⚠ Pre-existing failures（不在本 PR 範疇）：`hosts.test.ts` 3 個 token preservation case + `TabBar.test.tsx` pinned tab tooltip — 已驗證 origin/main 同樣失敗，與 Phase 1a 無關

## Test plan

- [ ] `cd spa && pnpm install`
- [ ] `cd spa && npx vitest run src/lib/quick-command-slots.test.ts src/stores/useQuickCommandStore.test.ts src/lib/sync/contributors/quick-commands.test.ts src/lib/register-modules.quick-commands.test.tsx`
- [ ] `cd spa && pnpm run lint`
- [ ] `cd spa && pnpm run build`
- [ ] `go test ./...`
- [ ] `go build ./...`
- [ ] 確認 Modules Switchboard 可看到 "Quick Commands" 模組可開關（無 settings tab，預期）