### PR TITLE
refactor(spa): extract quick-command-bindings module + split store tests (#679)

### DIFF
--- a/spa/src/lib/quick-command-bindings.test.ts
+++ b/spa/src/lib/quick-command-bindings.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import {
+  type Bindings,
+  type QuickCommandData,
+  sanitizeBindings,
+  getBindingTargets,
+  mergePersistedQuickCommandState,
+} from './quick-command-bindings'
+import { QUICK_COMMAND_SLOTS } from './quick-command-slots'
+
+describe('sanitizeBindings — forward-compat with unknown slot ids (spec §2.3)', () => {
+  // Spec §2.3 explicitly allows unknown slot ids in Phase 1 so cross-version
+  // sync (older client pulls newer client's future slot binding) doesn't
+  // lose data. SlotHost ignores unknown ids at render time.
+  it('accepts known QUICK_COMMAND_SLOTS values', () => {
+    const out = sanitizeBindings({
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS],
+    })
+    expect(out).toEqual({
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS],
+    })
+  })
+
+  it('preserves unknown / future slot ids verbatim (forward-compat)', () => {
+    const out = sanitizeBindings({
+      'cmd-a': ['future.actions', 'workspace.action'],
+    })
+    // Both kept — spec requires forward-compat. SlotHost doesn't render them
+    // because no slot is registered, but data persists for newer clients.
+    expect(out).toEqual({
+      'cmd-a': ['future.actions', 'workspace.action'],
+    })
+  })
+
+  it('drops only empty / non-string targets', () => {
+    const out = sanitizeBindings({
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, '', 123, null, 'host.actions'],
+    })
+    expect(out).toEqual({
+      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'host.actions'],
+    })
+  })
+
+  it('drops entries whose value is not an array', () => {
+    const out = sanitizeBindings({
+      'cmd-a': 'workspace.actions', // not an array
+      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+    })
+    expect(out).toEqual({
+      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
+    })
+  })
+
+  it('rejects prototype-pollution command id keys', () => {
+    const out = sanitizeBindings({
+      __proto__: ['workspace.actions'],
+      constructor: ['workspace.actions'],
+      prototype: ['workspace.actions'],
+      'cmd-a': ['workspace.actions'],
+    })
+    expect(out).toEqual({ 'cmd-a': ['workspace.actions'] })
+  })
+
+  it('rejects non-object payloads (null / array / primitive)', () => {
+    expect(sanitizeBindings(null)).toEqual({})
+    expect(sanitizeBindings(undefined)).toEqual({})
+    expect(sanitizeBindings('a string')).toEqual({})
+    expect(sanitizeBindings(42)).toEqual({})
+    expect(sanitizeBindings([['cmd-a', ['workspace.actions']]])).toEqual({})
+  })
+})
+
+describe('getBindingTargets — own-property guard (codex round-2 A1)', () => {
+  // Mirrors the prototype-method protection used inside store.getBoundCommands.
+  // Naive `bindings[cmdId]` would resolve inherited Object.prototype methods
+  // (toString / valueOf / hasOwnProperty) for capability ids that happen to
+  // collide; subsequent .includes() on a function would throw.
+  it('returns the array when bindings owns the property', () => {
+    const bindings: Bindings = { 'cmd-a': ['workspace.actions'] }
+    expect(getBindingTargets(bindings, 'cmd-a')).toEqual(['workspace.actions'])
+  })
+
+  it('returns undefined for inherited Object.prototype keys (toString / valueOf)', () => {
+    const bindings: Bindings = {}
+    expect(getBindingTargets(bindings, 'toString')).toBeUndefined()
+    expect(getBindingTargets(bindings, 'valueOf')).toBeUndefined()
+    expect(getBindingTargets(bindings, 'hasOwnProperty')).toBeUndefined()
+  })
+
+  it('returns undefined when own value is not an array (defensive)', () => {
+    // Forced through the type system to simulate a corrupted runtime payload
+    // that bypassed sanitizer (e.g. someone wrote setState directly).
+    const bindings = { 'cmd-a': 'workspace.actions' as unknown as string[] } as Bindings
+    expect(getBindingTargets(bindings, 'cmd-a')).toBeUndefined()
+  })
+})
+
+describe('mergePersistedQuickCommandState — real hydrate trust boundary (codex round-2 Q1)', () => {
+  // Drives the actual `merge` hook used by zustand persist on rehydrate,
+  // not a setState fake. Catches any future regression where someone
+  // inadvertently bypasses sanitizer at the hydrate trust boundary.
+  const baselineCurrent: QuickCommandData = {
+    global: [],
+    byHost: {},
+    bindings: {},
+  }
+
+  it('null persisted payload → returns current with empty bindings', () => {
+    const out = mergePersistedQuickCommandState(null, baselineCurrent)
+    expect(out.bindings).toEqual({})
+  })
+
+  it('hostile bindings payload (prototype keys) → sanitized to safe record', () => {
+    const out = mergePersistedQuickCommandState(
+      {
+        global: [],
+        byHost: {},
+        bindings: {
+          __proto__: ['workspace.actions'],
+          constructor: ['workspace.actions'],
+          'cmd-a': ['workspace.actions'],
+        },
+      },
+      baselineCurrent,
+    )
+    expect(out.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
+  })
+
+  it('non-object bindings → fallback to {}', () => {
+    const out = mergePersistedQuickCommandState(
+      { global: [], byHost: {}, bindings: 'not-an-object' },
+      baselineCurrent,
+    )
+    expect(out.bindings).toEqual({})
+  })
+
+  it('non-array global → keeps current.global (preserves alpha state)', () => {
+    const current: QuickCommandData = {
+      ...baselineCurrent,
+      global: [{ id: 'existing', name: 'E', command: 'e' }],
+    }
+    const out = mergePersistedQuickCommandState(
+      { global: 'corrupt', byHost: {}, bindings: {} },
+      current,
+    )
+    expect(out.global).toEqual([{ id: 'existing', name: 'E', command: 'e' }])
+  })
+
+  it('valid payload passes through (sanity)', () => {
+    const out = mergePersistedQuickCommandState(
+      {
+        global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
+        byHost: { h1: [] },
+        bindings: { 'cmd-a': ['workspace.actions'] },
+      },
+      baselineCurrent,
+    )
+    expect(out.global).toEqual([{ id: 'cmd-a', name: 'A', command: 'a' }])
+    expect(out.byHost).toEqual({ h1: [] })
+    expect(out.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
+  })
+
+  it('preserves caller-supplied extra fields on the current shape (generic over T)', () => {
+    // Ensures the store can pass its full state (data + actions) and recover
+    // the same shape — actions must survive the merge.
+    type StoreLike = QuickCommandData & { actionMarker: () => string }
+    const current: StoreLike = {
+      ...baselineCurrent,
+      actionMarker: () => 'still-here',
+    }
+    const out = mergePersistedQuickCommandState({ global: [], byHost: {}, bindings: {} }, current)
+    expect(out.actionMarker()).toBe('still-here')
+  })
+})

--- a/spa/src/lib/quick-command-bindings.ts
+++ b/spa/src/lib/quick-command-bindings.ts
@@ -1,0 +1,110 @@
+// =============================================================================
+// Quick Commands — pure data module (Phase 1a Q2 extraction, issue #679)
+// =============================================================================
+// Schema, sanitizer, own-property guard, and persist merge function. Imported
+// by both `useQuickCommandStore` and the sync contributor so neither has to
+// drag the whole zustand store to reach the data primitives.
+// =============================================================================
+
+import type { QuickCommandSlotId } from './quick-command-slots'
+
+export interface QuickCommand {
+  id: string
+  name: string
+  command: string
+  icon?: string
+  category?: string
+  hostOnly?: boolean
+}
+
+export type Bindings = Record<string /* commandId */, QuickCommandSlotId[]>
+
+/**
+ * Pure data shape persisted to storage and exchanged via sync. The store
+ * extends this with action methods; the sync contributor reuses it directly.
+ */
+export interface QuickCommandData {
+  global: QuickCommand[]
+  byHost: Record<string, QuickCommand[]>
+  bindings: Bindings
+}
+
+export const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * AR-1 (mirrors `useModuleEnabledStore` codex review #617):
+ * Sanitize bindings on rehydrate / sync deserialize. A corrupted payload —
+ * hand-edited localStorage, failed migration, hostile sync source — must
+ * NEVER let arbitrary string keys silently mount commands into slots.
+ *
+ * Rules (spec §2.3 — forward-compat with future slot ids):
+ *  - Top-level value must be a plain object (rejects arrays, null, primitives).
+ *  - Reject `__proto__` / `constructor` / `prototype` command id keys
+ *    (prototype pollution).
+ *  - Drop entries whose value is not an array.
+ *  - Within each array, keep only non-empty strings. NO slot id whitelist —
+ *    spec §2.3 explicitly requires accepting unknown slot ids in Phase 1
+ *    so cross-version sync (older client pulls newer client's future slot
+ *    binding) doesn't lose data; SlotHost simply ignores unknown slot ids
+ *    at render time.
+ *  - Drop entries whose cleaned array is empty (matches setBinding(id, [])).
+ */
+export function sanitizeBindings(raw: unknown): Bindings {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out: Bindings = {}
+  for (const [cmdId, targets] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof cmdId !== 'string' || cmdId.length === 0) continue
+    if (UNSAFE_KEYS.has(cmdId)) continue
+    if (!Array.isArray(targets)) continue
+    const cleaned: QuickCommandSlotId[] = []
+    for (const t of targets) {
+      if (typeof t === 'string' && t.length > 0) cleaned.push(t as QuickCommandSlotId)
+    }
+    if (cleaned.length > 0) out[cmdId] = cleaned
+  }
+  return out
+}
+
+/**
+ * Read bindings[cmdId] safely. Prevents inherited-prop attacks where cmdId
+ * happens to match Object.prototype methods (toString / valueOf / hasOwnProperty
+ * / isPrototypeOf / etc.) — naive `bindings[cmdId]` would resolve to a
+ * non-array function and `.includes(slot)` would throw, crashing
+ * getBoundCommands for every caller (DoS).
+ *
+ * Returns undefined unless `bindings` has its OWN property `cmdId` AND that
+ * value is an array.
+ */
+export function getBindingTargets(
+  bindings: Bindings,
+  cmdId: string,
+): QuickCommandSlotId[] | undefined {
+  if (!Object.prototype.hasOwnProperty.call(bindings, cmdId)) return undefined
+  const targets = bindings[cmdId]
+  return Array.isArray(targets) ? targets : undefined
+}
+
+/**
+ * Pure merge function — used by zustand persist `merge` hook AND directly by
+ * tests to drive the real hydrate trust boundary with malformed payloads.
+ * Generic over `T extends QuickCommandData` so the store can pass its full
+ * `QuickCommandState` (data + actions) and recover the same shape after merge.
+ */
+export function mergePersistedQuickCommandState<T extends QuickCommandData>(
+  persisted: unknown,
+  current: T,
+): T {
+  const p = persisted as
+    | { global?: unknown; byHost?: unknown; bindings?: unknown }
+    | null
+    | undefined
+  return {
+    ...current,
+    global: Array.isArray(p?.global) ? (p?.global as QuickCommand[]) : current.global,
+    byHost:
+      typeof p?.byHost === 'object' && p?.byHost !== null && !Array.isArray(p?.byHost)
+        ? (p?.byHost as Record<string, QuickCommand[]>)
+        : current.byHost,
+    bindings: sanitizeBindings(p?.bindings),
+  }
+}

--- a/spa/src/lib/sync/contributors/quick-commands.test.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.test.ts
@@ -4,8 +4,8 @@
 
 import { describe, it, expect, beforeEach } from 'vitest'
 import { createQuickCommandsContributor } from './quick-commands'
-import { useQuickCommandStore, sanitizeBindings } from '../../../stores/useQuickCommandStore'
-import type { QuickCommand } from '../../../stores/useQuickCommandStore'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { sanitizeBindings, type QuickCommand } from '../../quick-command-bindings'
 import type { FullPayload } from '../types'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 

--- a/spa/src/lib/sync/contributors/quick-commands.ts
+++ b/spa/src/lib/sync/contributors/quick-commands.ts
@@ -2,7 +2,8 @@
 // Sync Architecture — QuickCommandsContributor
 // =============================================================================
 
-import { useQuickCommandStore, sanitizeBindings } from '../../../stores/useQuickCommandStore'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { sanitizeBindings } from '../../quick-command-bindings'
 import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
 
 // ---------------------------------------------------------------------------

--- a/spa/src/stores/useQuickCommandStore.bindings.test.ts
+++ b/spa/src/stores/useQuickCommandStore.bindings.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import {
-  useQuickCommandStore,
-  sanitizeBindings,
-  mergePersistedQuickCommandState,
-} from './useQuickCommandStore'
+import { useQuickCommandStore } from './useQuickCommandStore'
 import { QUICK_COMMAND_SLOTS } from '../lib/quick-command-slots'
 
 // 顯式列出所有 mutable fields — zustand setState merge 模式下，
@@ -20,49 +16,7 @@ function resetStore(initial?: {
   })
 }
 
-describe('useQuickCommandStore — capability CRUD (Phase 1a)', () => {
-  beforeEach(() => {
-    resetStore({
-      global: [
-        { id: 'cmd-a', name: 'A', command: 'a', category: 'agent' },
-        { id: 'cmd-b', name: 'B', command: 'b' },
-      ],
-    })
-  })
-
-  it('getCommands returns global commands when no host overrides', () => {
-    const cmds = useQuickCommandStore.getState().getCommands('host-1')
-    expect(cmds.map((c) => c.id)).toEqual(['cmd-a', 'cmd-b'])
-  })
-
-  it('per-host overrides global by id', () => {
-    useQuickCommandStore.getState().addCommand(
-      { id: 'cmd-a', name: 'A-host', command: 'aa' },
-      'host-1',
-    )
-    const cmds = useQuickCommandStore.getState().getCommands('host-1')
-    const a = cmds.find((c) => c.id === 'cmd-a')!
-    expect(a.command).toBe('aa')
-    expect(a.name).toBe('A-host')
-  })
-
-  it('addCommand to global', () => {
-    useQuickCommandStore.getState().addCommand({ id: 'cmd-c', name: 'C', command: 'c' })
-    expect(useQuickCommandStore.getState().global).toHaveLength(3)
-  })
-
-  it('removeCommand from global', () => {
-    useQuickCommandStore.getState().removeCommand('cmd-a')
-    expect(useQuickCommandStore.getState().global.find((c) => c.id === 'cmd-a')).toBeUndefined()
-  })
-
-  it('updateCommand in global', () => {
-    useQuickCommandStore.getState().updateCommand('cmd-a', { name: 'A-updated' })
-    expect(useQuickCommandStore.getState().global.find((c) => c.id === 'cmd-a')!.name).toBe('A-updated')
-  })
-})
-
-describe('useQuickCommandStore — bindings (Phase 1a)', () => {
+describe('useQuickCommandStore — bindings API (Phase 1a)', () => {
   beforeEach(() => {
     resetStore({
       global: [
@@ -129,70 +83,6 @@ describe('useQuickCommandStore — bindings (Phase 1a)', () => {
     useQuickCommandStore.getState().removeCommand('cmd-a', 'host-1')
     // global cmd-a 仍存在；per-host override 被刪；binding 不動
     expect(useQuickCommandStore.getState().bindings['cmd-a']).toEqual(['workspace.actions'])
-  })
-})
-
-describe('useQuickCommandStore — sanitizeBindings via merge', () => {
-  it('drops non-object payloads', () => {
-    // 直接呼叫 merge 行為：模擬 hydrated raw string
-    // (sanitizer 是 module-private，所以透過 setState + merge hook 間接驗；
-    //  這裡的合理代表是斷言 store 在惡意 payload 注入後仍維持 bindings = {})
-    useQuickCommandStore.setState({ bindings: {} })
-    expect(useQuickCommandStore.getState().bindings).toEqual({})
-  })
-})
-
-describe('sanitizeBindings — forward-compat with unknown slot ids (spec §2.3)', () => {
-  // Spec §2.3 explicitly allows unknown slot ids in Phase 1 so cross-version
-  // sync (older client pulls newer client's future slot binding) doesn't
-  // lose data. SlotHost ignores unknown ids at render time.
-  it('accepts known QUICK_COMMAND_SLOTS values', () => {
-    const out = sanitizeBindings({
-      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS],
-    })
-    expect(out).toEqual({
-      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, QUICK_COMMAND_SLOTS.HOST_ACTIONS],
-    })
-  })
-
-  it('preserves unknown / future slot ids verbatim (forward-compat)', () => {
-    const out = sanitizeBindings({
-      'cmd-a': ['future.actions', 'workspace.action'],
-    })
-    // Both kept — spec requires forward-compat. SlotHost doesn't render them
-    // because no slot is registered, but data persists for newer clients.
-    expect(out).toEqual({
-      'cmd-a': ['future.actions', 'workspace.action'],
-    })
-  })
-
-  it('drops only empty / non-string targets', () => {
-    const out = sanitizeBindings({
-      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, '', 123, null, 'host.actions'],
-    })
-    expect(out).toEqual({
-      'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, 'host.actions'],
-    })
-  })
-
-  it('drops entries whose value is not an array', () => {
-    const out = sanitizeBindings({
-      'cmd-a': 'workspace.actions', // not an array
-      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
-    })
-    expect(out).toEqual({
-      'cmd-b': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS],
-    })
-  })
-
-  it('rejects prototype-pollution command id keys', () => {
-    const out = sanitizeBindings({
-      __proto__: ['workspace.actions'],
-      constructor: ['workspace.actions'],
-      prototype: ['workspace.actions'],
-      'cmd-a': ['workspace.actions'],
-    })
-    expect(out).toEqual({ 'cmd-a': ['workspace.actions'] })
   })
 })
 
@@ -293,74 +183,5 @@ describe('getBoundCommands — null hostId (spec §4.4 / codex round-2 D2)', () 
       .getState()
       .getBoundCommands(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS, null)
     expect(out.map((c) => c.id)).toEqual(['cmd-a', 'cmd-b', 'cmd-c'])
-  })
-})
-
-describe('mergePersistedQuickCommandState — real hydrate trust boundary (codex round-2 Q1)', () => {
-  // Drives the actual `merge` hook used by zustand persist on rehydrate,
-  // not a setState fake. Catches any future regression where someone
-  // inadvertently bypasses sanitizer at the hydrate trust boundary.
-  // mergePersistedQuickCommandState only reads the three data fields and
-  // spreads `current` for the rest. Tests don't exercise action methods,
-  // so a minimal data-only stub is sufficient (cast via unknown).
-  const baselineCurrent = {
-    global: [],
-    byHost: {},
-    bindings: {},
-  } as unknown as Parameters<typeof mergePersistedQuickCommandState>[1]
-
-  it('null persisted payload → returns current with empty bindings', () => {
-    const out = mergePersistedQuickCommandState(null, baselineCurrent)
-    expect(out.bindings).toEqual({})
-  })
-
-  it('hostile bindings payload (prototype keys) → sanitized to safe record', () => {
-    const out = mergePersistedQuickCommandState(
-      {
-        global: [],
-        byHost: {},
-        bindings: {
-          __proto__: ['workspace.actions'],
-          constructor: ['workspace.actions'],
-          'cmd-a': ['workspace.actions'],
-        },
-      },
-      baselineCurrent,
-    )
-    expect(out.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
-  })
-
-  it('non-array bindings → fallback to {}', () => {
-    const out = mergePersistedQuickCommandState(
-      { global: [], byHost: {}, bindings: 'not-an-object' },
-      baselineCurrent,
-    )
-    expect(out.bindings).toEqual({})
-  })
-
-  it('non-array global → keeps current.global (preserves alpha state)', () => {
-    const current = {
-      ...baselineCurrent,
-      global: [{ id: 'existing', name: 'E', command: 'e' }],
-    }
-    const out = mergePersistedQuickCommandState(
-      { global: 'corrupt', byHost: {}, bindings: {} },
-      current,
-    )
-    expect(out.global).toEqual([{ id: 'existing', name: 'E', command: 'e' }])
-  })
-
-  it('valid payload passes through (sanity)', () => {
-    const out = mergePersistedQuickCommandState(
-      {
-        global: [{ id: 'cmd-a', name: 'A', command: 'a' }],
-        byHost: { h1: [] },
-        bindings: { 'cmd-a': ['workspace.actions'] },
-      },
-      baselineCurrent,
-    )
-    expect(out.global).toEqual([{ id: 'cmd-a', name: 'A', command: 'a' }])
-    expect(out.byHost).toEqual({ h1: [] })
-    expect(out.bindings).toEqual({ 'cmd-a': ['workspace.actions'] })
   })
 })

--- a/spa/src/stores/useQuickCommandStore.crud.test.ts
+++ b/spa/src/stores/useQuickCommandStore.crud.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useQuickCommandStore } from './useQuickCommandStore'
+
+// 顯式列出所有 mutable fields — zustand setState merge 模式下，
+// action methods 由 closure 持有，不會被覆蓋（見 feedback_zustand_harness_setstate.md）。
+function resetStore(initial?: {
+  global?: ReturnType<typeof useQuickCommandStore.getState>['global']
+  byHost?: ReturnType<typeof useQuickCommandStore.getState>['byHost']
+  bindings?: ReturnType<typeof useQuickCommandStore.getState>['bindings']
+}) {
+  useQuickCommandStore.setState({
+    global: initial?.global ?? [],
+    byHost: initial?.byHost ?? {},
+    bindings: initial?.bindings ?? {},
+  })
+}
+
+describe('useQuickCommandStore — capability CRUD (Phase 1a)', () => {
+  beforeEach(() => {
+    resetStore({
+      global: [
+        { id: 'cmd-a', name: 'A', command: 'a', category: 'agent' },
+        { id: 'cmd-b', name: 'B', command: 'b' },
+      ],
+    })
+  })
+
+  it('getCommands returns global commands when no host overrides', () => {
+    const cmds = useQuickCommandStore.getState().getCommands('host-1')
+    expect(cmds.map((c) => c.id)).toEqual(['cmd-a', 'cmd-b'])
+  })
+
+  it('per-host overrides global by id', () => {
+    useQuickCommandStore.getState().addCommand(
+      { id: 'cmd-a', name: 'A-host', command: 'aa' },
+      'host-1',
+    )
+    const cmds = useQuickCommandStore.getState().getCommands('host-1')
+    const a = cmds.find((c) => c.id === 'cmd-a')!
+    expect(a.command).toBe('aa')
+    expect(a.name).toBe('A-host')
+  })
+
+  it('addCommand to global', () => {
+    useQuickCommandStore.getState().addCommand({ id: 'cmd-c', name: 'C', command: 'c' })
+    expect(useQuickCommandStore.getState().global).toHaveLength(3)
+  })
+
+  it('removeCommand from global', () => {
+    useQuickCommandStore.getState().removeCommand('cmd-a')
+    expect(useQuickCommandStore.getState().global.find((c) => c.id === 'cmd-a')).toBeUndefined()
+  })
+
+  it('updateCommand in global', () => {
+    useQuickCommandStore.getState().updateCommand('cmd-a', { name: 'A-updated' })
+    expect(useQuickCommandStore.getState().global.find((c) => c.id === 'cmd-a')!.name).toBe('A-updated')
+  })
+})

--- a/spa/src/stores/useQuickCommandStore.ts
+++ b/spa/src/stores/useQuickCommandStore.ts
@@ -2,23 +2,14 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { purdexStorage, STORAGE_KEYS, syncManager } from '../lib/storage'
 import type { QuickCommandSlotId } from '../lib/quick-command-slots'
+import {
+  type QuickCommand,
+  type QuickCommandData,
+  getBindingTargets,
+  mergePersistedQuickCommandState,
+} from '../lib/quick-command-bindings'
 
-export interface QuickCommand {
-  id: string
-  name: string
-  command: string
-  icon?: string
-  category?: string
-  hostOnly?: boolean
-}
-
-export type Bindings = Record<string /* commandId */, QuickCommandSlotId[]>
-
-interface QuickCommandState {
-  global: QuickCommand[]
-  byHost: Record<string, QuickCommand[]>
-  bindings: Bindings
-
+interface QuickCommandState extends QuickCommandData {
   addCommand: (cmd: QuickCommand, hostId?: string) => void
   updateCommand: (id: string, patch: Partial<QuickCommand>, hostId?: string) => void
   removeCommand: (id: string, hostId?: string) => void
@@ -35,83 +26,6 @@ interface QuickCommandState {
 // (`start-cc` / `start-codex`) keep them but bindings = {} so nothing renders
 // until the user mounts them via Settings.
 const DEFAULT_COMMANDS: QuickCommand[] = []
-
-const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
-
-/**
- * AR-1 (mirrors `useModuleEnabledStore` codex review #617):
- * Sanitize bindings on rehydrate / sync deserialize. A corrupted payload —
- * hand-edited localStorage, failed migration, hostile sync source — must
- * NEVER let arbitrary string keys silently mount commands into slots.
- *
- * Rules (spec §2.3 — forward-compat with future slot ids):
- *  - Top-level value must be a plain object (rejects arrays, null, primitives).
- *  - Reject `__proto__` / `constructor` / `prototype` command id keys
- *    (prototype pollution).
- *  - Drop entries whose value is not an array.
- *  - Within each array, keep only non-empty strings. NO slot id whitelist —
- *    spec §2.3 explicitly requires accepting unknown slot ids in Phase 1
- *    so cross-version sync (older client pulls newer client's future slot
- *    binding) doesn't lose data; SlotHost simply ignores unknown slot ids
- *    at render time.
- *  - Drop entries whose cleaned array is empty (matches setBinding(id, [])).
- */
-export function sanitizeBindings(raw: unknown): Bindings {
-  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return {}
-  const out: Bindings = {}
-  for (const [cmdId, targets] of Object.entries(raw as Record<string, unknown>)) {
-    if (typeof cmdId !== 'string' || cmdId.length === 0) continue
-    if (UNSAFE_KEYS.has(cmdId)) continue
-    if (!Array.isArray(targets)) continue
-    const cleaned: QuickCommandSlotId[] = []
-    for (const t of targets) {
-      if (typeof t === 'string' && t.length > 0) cleaned.push(t as QuickCommandSlotId)
-    }
-    if (cleaned.length > 0) out[cmdId] = cleaned
-  }
-  return out
-}
-
-/**
- * Read bindings[cmdId] safely. Prevents inherited-prop attacks where cmdId
- * happens to match Object.prototype methods (toString / valueOf / hasOwnProperty
- * / isPrototypeOf / etc.) — naive `bindings[cmdId]` would resolve to a
- * non-array function and `.includes(slot)` would throw, crashing
- * getBoundCommands for every caller (DoS).
- *
- * Returns undefined unless `bindings` has its OWN property `cmdId` AND that
- * value is an array.
- */
-function getBindingTargets(bindings: Bindings, cmdId: string): QuickCommandSlotId[] | undefined {
-  if (!Object.prototype.hasOwnProperty.call(bindings, cmdId)) return undefined
-  const targets = bindings[cmdId]
-  return Array.isArray(targets) ? targets : undefined
-}
-
-/**
- * Pure merge function — used by zustand persist `merge` hook AND directly by
- * tests to drive the real hydrate trust boundary with malformed payloads.
- * Exporting this avoids the previous test pattern of using setState as a
- * mock for hydrate, which never actually went through sanitizer.
- */
-export function mergePersistedQuickCommandState(
-  persisted: unknown,
-  current: QuickCommandState,
-): QuickCommandState {
-  const p = persisted as
-    | { global?: unknown; byHost?: unknown; bindings?: unknown }
-    | null
-    | undefined
-  return {
-    ...current,
-    global: Array.isArray(p?.global) ? (p?.global as QuickCommand[]) : current.global,
-    byHost:
-      typeof p?.byHost === 'object' && p?.byHost !== null && !Array.isArray(p?.byHost)
-        ? (p?.byHost as Record<string, QuickCommand[]>)
-        : current.byHost,
-    bindings: sanitizeBindings(p?.bindings),
-  }
-}
 
 export const useQuickCommandStore = create<QuickCommandState>()(
   persist(


### PR DESCRIPTION
Closes #679 — codex round-2 followups deferred from PR #677.

## Summary

- **Q2** Extract pure-data primitives (`QuickCommand` / `Bindings` / `QuickCommandData` / `UNSAFE_KEYS` / `sanitizeBindings` / `getBindingTargets` / `mergePersistedQuickCommandState`) into new `spa/src/lib/quick-command-bindings.ts`. Store reduces to state + actions + persist + sync glue. Sync contributor imports the sanitizer + `QuickCommand` directly from the pure module instead of pulling them through the store.
- **Q3** Split `useQuickCommandStore.test.ts` (366 lines) into three:
  - `lib/quick-command-bindings.test.ts` — sanitizer / `getBindingTargets` own-property guard / `mergePersistedQuickCommandState` hydrate boundary
  - `stores/useQuickCommandStore.crud.test.ts` — capability CRUD
  - `stores/useQuickCommandStore.bindings.test.ts` — store-level binding integration (setBinding / getBoundCommands / prototype safety / null-hostId §4.4)

`mergePersistedQuickCommandState` is now generic over `T extends QuickCommandData` so the store can pass its full state (data + actions) and recover the same shape — action methods survive the merge. New test guards this contract.

## Test plan

- [x] `npx vitest run` — 2822 pass / 4 pre-existing fail (`hosts.test.ts` token preservation × 3 + `TabBar.test.tsx` pinned tooltip × 1, unrelated)
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` — clean
- [ ] Two rounds of codex review (per CLAUDE.md PR workflow)