### PR TITLE
feat(spa): enforce assertContextLive on runWorkspaceSlot Deps (#690)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
+++ b/docs/superpowers/plans/2026-04-27-quick-commands-v2.md
@@ -3684,6 +3684,13 @@ Expected: clean
 
 ## Phase 1b' — Plus hover popover 過渡入口（獨立 PR）
 
+> **⚠️ #690 superseded note（2026-04-28）**：本 phase 範例（Task 1b'.1）內的 `runWorkspaceSlot(...)` deps 物件**漏 `assertContextLive`**。依 [issue #690](https://github.com/wake/purdex/issues/690) / spec §3.3.1，`Deps.assertContextLive` 為 type-level required。1b' 實作時必須補：
+> ```tsx
+> assertContextLive: () =>
+>   useWorkspaceStore.getState().workspaces.some((w) => w.id === workspaceId),
+> ```
+> 範例本身保留為 historical reference（codex review 採納紀錄），實作前以 #690 enforcement 規範為準。
+
 **目標：** 在已 ship 的 Phase 1b（Settings + 資料層 + 右鍵 context menu）之上，加上 `WorkspaceRow` Plus 按鈕 hover 往左展開的 chip popover；同時設計 mobile/touch fallback。
 
 **為何拆獨立 PR（codex round-1 結構性變更）：**
@@ -4312,6 +4319,8 @@ Expected: clean
 ---
 
 ## Phase 1c — HOST_ACTIONS 入口（小 PR）
+
+> **⚠️ #690 superseded note（2026-04-28）**：本 phase 範例（Task 1c.1b）寫「HOST_ACTIONS 與 WORKSPACE_ACTIONS 共用 `runWorkspaceSlot`」— 此設計與 [issue #690](https://github.com/wake/purdex/issues/690) / spec §3.3.1 衝突。enforcement 落地後 `runWorkspaceSlot.Deps.assertContextLive` 為 required，但 host caller 無 workspace 可驗。1c 實作時須**新建 `runHostSlot`**（或以 generic 分流 `WorkspaceDeps` / `HostDeps`），不得 reuse `runWorkspaceSlot`；分流形狀以 1c 寫到時的 cwd 解析需求為準（spec §3.2 表格）。範例本身保留為 historical reference。
 
 **目標：** Host 詳情頁加 quick actions 區塊；user 設 mount = HOST 即可在 host 頁看到按鈕。
 

--- a/docs/superpowers/plans/2026-04-28-quick-commands-v2-690-assert-context-live.md
+++ b/docs/superpowers/plans/2026-04-28-quick-commands-v2-690-assert-context-live.md
@@ -1,0 +1,151 @@
+# Plan: Quick Commands v2 — `assertContextLive` enforcement (#690)
+
+**Source**: spec `2026-04-27-quick-commands-v2-design.md` §3.3.1（spec patch 同 PR）
+**Issue**: [#690](https://github.com/wake/purdex/issues/690)
+**Phase**: Pre-Phase 1b'（小型 enforcement，不屬 1b' 本體）
+**Branch**: `feat/quick-commands-v2-assert-context-live-required`（off `origin/main` @ `3c999acf` alpha.240）
+**Estimate**: 1 commit / ~30 行 diff
+
+## Context recap
+
+PR #686 codex round-5（final approve）建議 followup：把 `runWorkspaceSlot` 的 `Deps.assertContextLive` 從 optional 改 required，避免未來 workspace-context caller 漏 wire（Phase 1b' Plus hover popover 是首個 high-risk 場景）。
+
+選 **Option 1（type-level）**，理由：
+- Compile-time 擋住，比 grep test（Option 2）穩
+- Phase 1c HOST_ACTIONS 自然分流為 `runHostSlot` — 強制好設計
+- 改動表面 < 30 行，無 behavior change（caller 已 wire）
+
+不選 Option 2 / 3：
+- Option 2 grep test 會被 `// eslint-disable` 或檔名移動繞過
+- Option 3 lint plugin 是 overkill，純為 1 個 callsite 寫 plugin
+
+## 變更範圍
+
+### 1. `spa/src/lib/slot-executor.ts`
+
+```diff
+ interface Deps {
+   switchToSession: (hostId: string, sessionCode: string) => void
+   resolveHostId: () => Promise<string | null>
+-  /**
+-   * Optional — HOST_ACTIONS callers (Phase 1c) don't have a workspace context
+-   * to verify and pass `undefined` to opt out of this check.
+-   */
+-  assertContextLive?: () => boolean
++  /**
++   * Required — workspace liveness probe. Returns false if the surrounding
++   * UI context (e.g. workspace) was destroyed while async work was in flight.
++   * The executor calls this after `createSession` resolves and BEFORE
++   * `executeCommand` runs so destructive commands aren't sent to a session
++   * the user can no longer reach.
++   *
++   * Phase 1c HOST_ACTIONS: host context has no workspace to verify and will
++   * use a separate `runHostSlot` entry point (spec §3.3.1).
++   */
++  assertContextLive: () => boolean
+ }
+```
+
+```diff
+-  if (deps.assertContextLive && !deps.assertContextLive()) {
++  if (!deps.assertContextLive()) {
+     toast.show(t('quick_commands.toast.switch_failed'))
+     return
+   }
+```
+
+註解的 "shared with Phase 1c host entry" 改寫為「workspace-only entry; Phase 1c will introduce a sibling `runHostSlot`」。
+
+### 2. `spa/src/lib/slot-executor.test.ts`
+
+7 個既有 test 補 `assertContextLive: () => true`（負控；保留 happy-path 行為）：
+- `happy path` (line 40)
+- `hostId null → invokes resolveHostId` (line 64)
+- `hostId null → user cancels picker` (line 80)
+- `createSession failure` (line 98)
+- `send-keys failure` (line 127)
+- `switchToSession failure` (line 162)
+- `combined send-keys + switch failure` (line 249)
+
+加一個 type-level test。寫法（codex round-1 M1 — `@ts-expect-error` 必須直接放在會報錯的那一行；放在物件內結尾會壓不到「缺 key」的 diagnosis）：
+
+```typescript
+it('requires assertContextLive at type level (#690 / spec §3.3.1)', () => {
+  // Future workspace-context callers (e.g. Phase 1b' popover) cannot silently
+  // regress to round-4-vulnerable shape without this @ts-expect-error firing.
+  // The directive sits on the `const` line — that's where TS reports the
+  // "missing required property 'assertContextLive'" error; if we ever add
+  // assertContextLive to the literal below, this test breaks loudly to flag
+  // the regression.
+  // @ts-expect-error - assertContextLive is required (#690)
+  const deps: Parameters<typeof runWorkspaceSlot>[2] = {
+    switchToSession: () => {},
+    resolveHostId: async () => null,
+  }
+  expect(deps).toBeDefined()
+})
+```
+
+包進 `it()` block 是為了：
+1. 避免 `noUnusedLocals` 編譯錯誤（型別檢查已執行，runtime 用 `expect(deps).toBeDefined()` 帶過）
+2. 讓 vitest 計入 test count（regression 時 vitest output 會顯示 fail）
+3. 統一在 `describe('runWorkspaceSlot')` 區塊內
+
+### 3. `WorkspaceQuickCommandsContextMenu.tsx`
+
+無變更 — caller 已 wire `assertContextLive`（PR #686 round-4 fix `0b23593e` 引入）。
+
+### 4. spec `2026-04-27-quick-commands-v2-design.md`
+
+§3.3.1 已加（同 PR）— 內含 Why / Enforcement / Phase 1c 影響 / 驗收。
+
+## 驗證指令
+
+於 worktree root：
+
+```bash
+cd spa
+pnpm install --frozen-lockfile  # 若需要
+pnpm run build                       # 等同 tsc -b + vite build；包含完整 src 型別檢查（codex round-1 L1）
+pnpm vitest run lib/slot-executor   # 7+1 test 全綠
+pnpm run lint                        # 無新 warning
+```
+
+`pnpm exec tsc --noEmit` 不寫進步驟 — `spa/tsconfig.json` 是 project-reference root（`files: []`），單獨跑 `--noEmit` 不會檢查 `src/`，反而給錯誤的安全感。`pnpm run build` 內部的 `tsc -b` 會實際編譯 referenced projects（`tsconfig.app.json` + `tsconfig.node.json`），可一次涵蓋 type check + build 驗證。
+
+無 daemon 改動，免跑 `go test`。
+
+## 風險評估
+
+| 風險 | 等級 | mitigation |
+|---|---|---|
+| caller 編譯失敗 | 低 | 已盤點：production 1 個 caller 已 wire；test 7 個會補 |
+| 既有 test 行為改變 | 極低 | `() => true` 是負控，等價於原 `undefined` 略過 guard 路徑；toast assertion 不變 |
+| Phase 1c 設計被綁死 | 低 | spec §3.3.1 明示「分流形狀以 1c 寫到時為準」，本次不預先決定 generic 還是兩個 function |
+| ts-expect-error 反向 fail（key 已加導致 expect-error 不再觸發） | 中 | 用 `Parameters<typeof runWorkspaceSlot>[2]` 動態取型，避免 hardcode interface |
+| Type escape hatch 繞過 enforcement（codex round-1 L2） | 中 | type-level required 擋正常 caller 但擋不住 `as any` / `as unknown as Deps` / `Object.assign(base, payload as any)` 等。code review checklist 必含「新增 `runWorkspaceSlot` caller 是否用 type cast 繞過 deps 完整性」；spec §3.3.1 之外另在 PR description 提示 reviewer |
+
+## 回滾
+
+單一 commit revert 即可；caller 端不需改。
+
+## Phase 順序檢查
+
+依 `2026-04-27-quick-commands-v2.md` plan §順序檢查清單：
+
+- [x] 1a — alpha.236
+- [x] (prep) #679 — alpha.238
+- [x] 1b — alpha.240
+- [ ] **#690 enforcement（本 PR）** ← 在此插入
+- [ ] 1b' — Plus hover popover
+- [ ] 1c — HOST_ACTIONS chip
+
+#690 不是新 phase，是 1b ship 後 1b' 之前的 type-safety 強化。1b' 的 popover caller 將直接 benefit 於本次 enforcement（漏 wire 即編譯 fail）。
+
+## Codex review 關注點建議
+
+- **Round 1（standard）**：spec §3.3.1 / plan / diff 連貫性；type-level test 寫法是否 robust
+- **Round 2（3 parallel）**：
+  - **Attacker**：能否繞過 enforcement？例如 `as any` cast、`satisfies` 後 spread、interface widening
+  - **Defender**：是否阻擋了合法用例？optional 是否真的不必要（HOST_ACTIONS 之外還有別的 path 嗎）
+  - **File-quality**：slot-executor.ts SRP 是否被影響；test 檔加 `_typeCheck_*` 的 noise 是否可接受

--- a/docs/superpowers/plans/2026-04-28-quick-commands-v2-690-assert-context-live.md
+++ b/docs/superpowers/plans/2026-04-28-quick-commands-v2-690-assert-context-live.md
@@ -4,7 +4,9 @@
 **Issue**: [#690](https://github.com/wake/purdex/issues/690)
 **Phase**: Pre-Phase 1b'（小型 enforcement，不屬 1b' 本體）
 **Branch**: `feat/quick-commands-v2-assert-context-live-required`（off `origin/main` @ `3c999acf` alpha.240）
-**Estimate**: 1 commit / ~30 行 diff
+**Estimate**: 3 commits / ~120 行 diff（round-2 強化後）
+
+> **更新（2026-04-28，PR #694 round-2）**：原計畫 1 commit / ~30 行因 codex round-2 三 reviewer（attacker / defender / file-quality）找出 5 個 medium finding，擴張為 3 commit / ~120 行。最終形狀詳見下方「實際變更（PR 最終）」。
 
 ## Context recap
 
@@ -149,3 +151,42 @@ pnpm run lint                        # 無新 warning
   - **Attacker**：能否繞過 enforcement？例如 `as any` cast、`satisfies` 後 spread、interface widening
   - **Defender**：是否阻擋了合法用例？optional 是否真的不必要（HOST_ACTIONS 之外還有別的 path 嗎）
   - **File-quality**：slot-executor.ts SRP 是否被影響；test 檔加 `_typeCheck_*` 的 noise 是否可接受
+
+## 實際變更（PR 最終，#694 round-2 採納後）
+
+Round 2 三 reviewer needs-attention，5 個 medium finding 整理：
+
+| ID | Source | Finding | 採納 |
+|---|---|---|---|
+| **D1** | defender | `runWorkspaceSlot` ctx 仍吃 host-shaped（`workspaceId` optional），dummy probe 可繞過 spec §3.3.1 | 修：加 `WorkspaceSlotContext extends SlotContext { workspaceId: string }`；caller 端 spread `{ ...ctx, workspaceId }` 從 closure narrow |
+| **A1** | attacker | `@ts-expect-error` 不精準 — Deps 加新 required field 會吃掉 directive | 修：用 conditional type assertion（`IsAny` + `Pick`-required check + null-rejection check） |
+| **F1** | file-quality | type-level test 在 vitest 檔內，vitest 不跑 typecheck → false green 風險 | 修：test 名稱 + 註解明示「靠 tsc -b 保證，不靠 vitest」 |
+| **A2** | attacker | broken/cast-bypassed probe 拋例外會穿透 try/catch | 修：runtime fail-closed（typeof check + try/catch + strict bool check）；加 2 個對應 test |
+| **A3** | attacker | type escape hatch 只靠 reviewer checklist 沒有 ESLint enforcement | 延後：開 issue 追蹤（custom ESLint rule 是 nice-to-have 但 scope 比 #690 大） |
+
+### 變更（最終形狀）
+
+**`spa/src/lib/slot-executor.ts`**：
+- 新增 `export interface WorkspaceSlotContext extends SlotContext { workspaceId: string }`
+- `runWorkspaceSlot` ctx 型別 `SlotContext` → `WorkspaceSlotContext`
+- runtime guard 改 fail-closed（typeof + try/catch + strict bool）
+
+**`spa/src/lib/slot-executor.test.ts`**：
+- 7 個既有 test 補 `assertContextLive: () => true` 負控
+- 加 2 個 fail-closed test（probe throws / probe non-function cast）
+- 加 1 個 type-level invariant test（conditional types，靠 tsc -b 驗證；vitest 不檢查）
+
+**`spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx`**：
+- caller 端 `runWorkspaceSlot(cmd, { ...ctx, workspaceId }, deps)` — 用 closure 的 `workspaceId`（typed `string`）滿足 `WorkspaceSlotContext` narrow
+
+### 驗證（最終）
+
+- `pnpm run build` clean（tsc -b 全 src 型別檢查 + vite build）
+- `pnpm vitest run src/lib/slot-executor` — 12 test pass（原 7 + 1 round-4 + 1 round-4 negative + 2 round-2 fail-closed + 1 round-2 type invariant）
+- `pnpm vitest run src/features/workspace` — 359 test pass（caller narrow 不影響其他 component test）
+- `pnpm vitest run` 全套 — 2961+/2965+（4 pre-existing fail #674）
+- `pnpm run lint` clean
+
+### A3 followup issue
+
+ESLint custom rule 限制 `runWorkspaceSlot` 第二/第三參數必須是 inline object literal、禁 cast/spread/Object.assign — 開 issue 追蹤，scope 比 #690 大，不在本 PR 範圍。

--- a/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
+++ b/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
@@ -257,6 +257,24 @@ picker owner（持有 promise resolver 的元件）必須保證 `resolveHostId()
 
 關鍵：**send-keys 失敗也要切過去**，user 才知道 session 在那、可以手動跑 — 這比「保留 session 但不切」少一個孤兒問題。
 
+#### 3.3.1 Workspace executor `assertContextLive` enforcement（post-1b，補強 #690）
+
+`runWorkspaceSlot` 的 `Deps.assertContextLive` 為 **type-level required**（非 optional）。
+
+**Why**：codex round-4（PR #686）引入 `assertContextLive` 作為 destructive-command guard — 在 `createSession` resolve 後、`executeCommand` 發送前，確認 workspace 仍存在；否則 user 已手動刪 workspace 但 `rm -rf` 仍會 ship 到 host tmux。Phase 1b 將其設為 optional 是預留 Phase 1c HOST_ACTIONS（host caller 無 workspace 可驗）。但 optional 形狀代表 **未來新增的 workspace-context caller 漏 wire 時，會靜默回退到 round-4 之前的不安全狀態**（type checker 不抓、test 不抓、UX 看似正常）。Phase 1b' 即將新增 Plus hover popover 這個 caller，是最容易出包的 forward-compat 缺口。
+
+**Enforcement**：
+- `Deps.assertContextLive: () => boolean`（移除 optional `?`）
+- runtime guard `if (deps.assertContextLive && !deps.assertContextLive())` 簡化為 `if (!deps.assertContextLive())`
+- 加一個 type-level test（`@ts-expect-error - assertContextLive is required`）卡住未來「再次 optional 化」的退路
+
+**Phase 1c HOST_ACTIONS 影響**：HOST_ACTIONS 不能再 reuse `runWorkspaceSlot`（強制需 `assertContextLive` 但 host caller 沒有 workspace 可驗）。由 1c 寫到時新建 `runHostSlot`（或以 generic 分流 `WorkspaceDeps` / `HostDeps`），本次 #690 不預先設計 — 避免 over-engineer，且 Phase 1c 的 cwd 解析邏輯仍在 spec §3.2 表格規畫中，分流形狀以彼時為準。
+
+**驗收**：
+- 未傳 `assertContextLive` 的 caller 編譯期 fail
+- 既有 7 個 test 補 `assertContextLive: () => true` 作 negative control（保留行為，不影響 toast assertion）
+- vitest / lint / build / tsc --noEmit 全綠
+
 ### 3.4 不在 Phase 1 範圍
 
 - `PaneLayoutRenderer` 內 `extraActions` 的 v1 `QuickCommandMenu` 整合保留現狀（後續 phase 再遷移為 `CommandSlot`）

--- a/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
+++ b/docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md
@@ -263,17 +263,32 @@ picker owner（持有 promise resolver 的元件）必須保證 `resolveHostId()
 
 **Why**：codex round-4（PR #686）引入 `assertContextLive` 作為 destructive-command guard — 在 `createSession` resolve 後、`executeCommand` 發送前，確認 workspace 仍存在；否則 user 已手動刪 workspace 但 `rm -rf` 仍會 ship 到 host tmux。Phase 1b 將其設為 optional 是預留 Phase 1c HOST_ACTIONS（host caller 無 workspace 可驗）。但 optional 形狀代表 **未來新增的 workspace-context caller 漏 wire 時，會靜默回退到 round-4 之前的不安全狀態**（type checker 不抓、test 不抓、UX 看似正常）。Phase 1b' 即將新增 Plus hover popover 這個 caller，是最容易出包的 forward-compat 缺口。
 
-**Enforcement**：
+**Enforcement（PR #694 codex round-2 強化後的最終形狀）**：
 - `Deps.assertContextLive: () => boolean`（移除 optional `?`）
-- runtime guard `if (deps.assertContextLive && !deps.assertContextLive())` 簡化為 `if (!deps.assertContextLive())`
-- 加一個 type-level test（`@ts-expect-error - assertContextLive is required`）卡住未來「再次 optional 化」的退路
+- **`ctx: WorkspaceSlotContext`** — `WorkspaceSlotContext extends SlotContext { workspaceId: string }`。Phase 1c HOST_ACTIONS 即使硬塞 dummy `assertContextLive` 也通不過編譯（缺 workspaceId）→ 強制 1c 必須走 `runHostSlot` / `HostSlotContext`，不能用 trick reuse 此入口（round-2 D1）。
+- runtime guard 改為 **fail-closed defense in depth**（round-2 A2）：
+  ```ts
+  let live = false
+  try {
+    if (typeof deps.assertContextLive === 'function') {
+      live = deps.assertContextLive() === true
+    }
+  } catch { live = false }
+  if (!live) { toast.show(switch_failed); return }
+  ```
+  Type-level required 是首層；runtime typeof + try/catch + strict bool check 是第二層。即便 `as any` cast 繞過或 probe 拋例外，`executeCommand` 也不會被觸發，destructive command 不會 ship。
+- **Type-level test 靠 `tsc -b` 保證**（round-2 A1 / F1）：用 conditional types 對 `Parameters<typeof runWorkspaceSlot>` 斷言 `Deps !== any`、`assertContextLive` required、`workspaceId` required、`workspaceId` 不可 null。`@ts-expect-error` 不夠精準（未來 Deps 加新 required field 會吃掉 directive），改用顯式 conditional type assertion。**Test 跑在 vitest 檔內，但實際保證來自 `tsc -b`，不是 `vitest run`** — 必須在 PR description / test 註解清楚此事，避免 reviewer 誤以為 `pnpm vitest run` 就驗過 type contract。
 
-**Phase 1c HOST_ACTIONS 影響**：HOST_ACTIONS 不能再 reuse `runWorkspaceSlot`（強制需 `assertContextLive` 但 host caller 沒有 workspace 可驗）。由 1c 寫到時新建 `runHostSlot`（或以 generic 分流 `WorkspaceDeps` / `HostDeps`），本次 #690 不預先設計 — 避免 over-engineer，且 Phase 1c 的 cwd 解析邏輯仍在 spec §3.2 表格規畫中，分流形狀以彼時為準。
+**Phase 1c HOST_ACTIONS 影響**：強制需 `runHostSlot` / `HostSlotContext`（不再選擇性建議，是 type-level hard 約束）。`HostSlotContext` 形狀以 1c 寫到時的 cwd 解析需求為準（spec §3.2 表格）；不在 #690 預先設計。
 
 **驗收**：
-- 未傳 `assertContextLive` 的 caller 編譯期 fail
-- 既有 7 個 test 補 `assertContextLive: () => true` 作 negative control（保留行為，不影響 toast assertion）
-- vitest / lint / build / tsc --noEmit 全綠
+- 未傳 `assertContextLive` 或 `workspaceId` 的 caller 編譯期 fail
+- 既有 7 個 test 補 `assertContextLive: () => true` 作 negative control（不影響 toast assertion）
+- 加 2 個 fail-closed test（probe throws / probe non-function cast bypass）
+- 加 1 個 type-level invariant test（IsAny + required-prop + null-rejection conditional types）
+- `pnpm run build`（內含 `tsc -b`）/ vitest / lint 全綠
+
+**已知殘留風險**：`as any` / `as unknown as Deps` / `Object.assign(... payload as any)` 仍可從 type 層繞過。Type-level required 擋誠實 caller，runtime fail-closed 擋 broken probe；但 ESLint 層面尚無 enforcement（custom rule 限制 `runWorkspaceSlot` 第三/第二參數形狀）— 為 followup（issue 追蹤）。
 
 ### 3.4 不在 Phase 1 範圍
 

--- a/spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx
+++ b/spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx
@@ -187,10 +187,15 @@ export function WorkspaceQuickCommandsContextMenu({ workspaceId, hostId, onClose
           // window before React re-renders the disabled state. `executing` is
           // mirrored to React state below for the disabled UI.
           if (executingRef.current) return
+          // #690 round-2 D1 — runWorkspaceSlot now requires `ctx.workspaceId`
+          // as a non-null string. WORKSPACE_ACTIONS slots only mount inside
+          // workspace context, so this is a contract guarantee, not a
+          // user-facing error path. Use the closure `workspaceId` (typed as
+          // string from props) to satisfy the narrowed type.
           executingRef.current = true
           setExecuting(true)
           try {
-            await runWorkspaceSlot(cmd, ctx, {
+            await runWorkspaceSlot(cmd, { ...ctx, workspaceId }, {
               switchToSession,
               resolveHostId,
               // codex round-4 — workspace liveness probe; called by executor

--- a/spa/src/lib/slot-executor.test.ts
+++ b/spa/src/lib/slot-executor.test.ts
@@ -262,18 +262,111 @@ describe('runWorkspaceSlot', () => {
     expect(toast!.actionLabel).toBeUndefined()
   })
 
-  // #690 / spec §3.3.1 — type-level enforcement: Deps.assertContextLive is required.
-  // Future workspace-context callers (e.g. Phase 1b' Plus hover popover) cannot
-  // silently regress the round-4 destructive-command guard by omitting the probe.
-  // If we ever add `assertContextLive` to the literal below (or revert the type
-  // to optional), this @ts-expect-error directive becomes "unused" and TS will
-  // fail the build — surfacing the regression loudly.
-  it('requires assertContextLive at type level (#690 / spec §3.3.1)', () => {
-    // @ts-expect-error - assertContextLive is required (#690)
-    const deps: Parameters<typeof runWorkspaceSlot>[2] = {
-      switchToSession: () => {},
-      resolveHostId: async () => null,
-    }
-    expect(deps).toBeDefined()
+  // #690 round-2 A2 — defense in depth: probe that throws should fail-closed
+  // (no executeCommand, no switch, switch_failed toast, no retry). Type-level
+  // required guarantees probe shape under normal use, but cast-bypassed or
+  // genuinely buggy probes must not let destructive commands ship.
+  it('assertContextLive throwing fails closed — no executeCommand, switch_failed toast', async () => {
+    const switchFocus = vi.fn()
+    const resolveHostId = vi.fn()
+    const assertContextLive = vi.fn().mockImplementation(() => {
+      throw new Error('probe blew up')
+    })
+    ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      code: 'sess-orphan',
+      name: 'A',
+      cwd: '/tmp',
+      mode: 'terminal',
+    })
+
+    await runWorkspaceSlot(
+      { id: 'cmd-a', name: 'A', command: 'rm -rf /' },
+      { hostId: 'h1', workspaceId: 'w1' },
+      { switchToSession: switchFocus, resolveHostId, assertContextLive },
+    )
+
+    expect(createSession).toHaveBeenCalledTimes(1)
+    expect(executeCommand).not.toHaveBeenCalled()
+    expect(switchFocus).not.toHaveBeenCalled()
+    const toast = useUndoToast.getState().toast
+    expect(toast).not.toBeNull()
+    expect(toast!.message).toMatch(/could not switch/i)
+    expect(toast!.action).toBeUndefined()
+  })
+
+  // #690 round-2 A2 — cast-bypassed probe (non-function value) must also fail
+  // closed. Type-level required catches honest callers but `as any` / spread
+  // tricks can still slip through; the runtime `typeof === 'function'` check
+  // is the second line of defense.
+  it('assertContextLive that is not a function fails closed (cast-bypass simulation)', async () => {
+    const switchFocus = vi.fn()
+    const resolveHostId = vi.fn()
+    ;(createSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      code: 'sess-orphan',
+      name: 'A',
+      cwd: '/tmp',
+      mode: 'terminal',
+    })
+
+    await runWorkspaceSlot(
+      { id: 'cmd-a', name: 'A', command: 'rm -rf /' },
+      { hostId: 'h1', workspaceId: 'w1' },
+      // Simulate a cast-bypass (`Object.assign(base, { assertContextLive: undefined } as any)`)
+      // by passing a non-function value through the type system.
+      {
+        switchToSession: switchFocus,
+        resolveHostId,
+        assertContextLive: undefined as unknown as () => boolean,
+      },
+    )
+
+    expect(executeCommand).not.toHaveBeenCalled()
+    expect(switchFocus).not.toHaveBeenCalled()
+    const toast = useUndoToast.getState().toast
+    expect(toast).not.toBeNull()
+    expect(toast!.message).toMatch(/could not switch/i)
+    expect(toast!.action).toBeUndefined()
+  })
+
+  // #690 round-2 A1 / F1 — type-level invariants for spec §3.3.1.
+  //
+  // IMPORTANT: This test's pass/fail is determined by the TypeScript compiler
+  // (`tsc -b`, run via `pnpm run build`), NOT by the Vitest runtime. Vitest
+  // does not type-check by default; `pnpm vitest run lib/slot-executor` will
+  // report this as passing even if the type contract has regressed. The
+  // protection only fires during `tsc -b` — see `pnpm run build`.
+  //
+  // This guards against three regressions that an `@ts-expect-error` directive
+  // would miss (round-1 directive could be silently consumed by an unrelated
+  // missing field if `Deps` ever grows):
+  //  1. The third parameter of `runWorkspaceSlot` collapses to `any`.
+  //  2. `Deps.assertContextLive` reverts to optional.
+  //  3. `WorkspaceSlotContext.workspaceId` reverts to optional / nullable
+  //     (round-2 D1 — Phase 1c HOST_ACTIONS must NOT be allowed to share this
+  //     entry by passing `{ hostId }` alone with a dummy `() => true` probe).
+  //
+  // If any invariant breaks, the `: true` assignments below become TS errors.
+  it('type-level invariants verified by tsc -b — Deps required, ctx requires workspaceId (#690 / spec §3.3.1)', () => {
+    type Deps = Parameters<typeof runWorkspaceSlot>[2]
+    type Ctx = Parameters<typeof runWorkspaceSlot>[1]
+
+    // IsAny<T> trick: `0 extends 1 & T` is true only when T is `any`.
+    type IsAny<T> = 0 extends 1 & T ? true : false
+    type DepsIsNotAny = IsAny<Deps> extends true ? false : true
+
+    // {} extends Pick<T, K> is true only when K is optional in T; we require
+    // it to be false → key is required.
+    type AssertContextLiveRequired = object extends Pick<Deps, 'assertContextLive'> ? false : true
+    type WorkspaceIdRequired = object extends Pick<Ctx, 'workspaceId'> ? false : true
+
+    // null assignability check — ctx.workspaceId must reject null/undefined.
+    type WorkspaceIdRejectsNull = null extends Ctx['workspaceId'] ? false : true
+
+    const _depsNotAny: DepsIsNotAny = true
+    const _assertRequired: AssertContextLiveRequired = true
+    const _workspaceIdRequired: WorkspaceIdRequired = true
+    const _workspaceIdRejectsNull: WorkspaceIdRejectsNull = true
+
+    expect(_depsNotAny && _assertRequired && _workspaceIdRequired && _workspaceIdRejectsNull).toBe(true)
   })
 })

--- a/spa/src/lib/slot-executor.test.ts
+++ b/spa/src/lib/slot-executor.test.ts
@@ -40,7 +40,7 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: 'h1', workspaceId: 'w1', cwd: '/tmp' },
-      { switchToSession: switchFocus, resolveHostId },
+      { switchToSession: switchFocus, resolveHostId, assertContextLive: () => true },
     )
 
     expect(resolveHostId).not.toHaveBeenCalled()
@@ -64,7 +64,7 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: null, workspaceId: 'w1' },
-      { switchToSession: switchFocus, resolveHostId },
+      { switchToSession: switchFocus, resolveHostId, assertContextLive: () => true },
     )
 
     expect(resolveHostId).toHaveBeenCalledTimes(1)
@@ -80,7 +80,7 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: null, workspaceId: 'w1' },
-      { switchToSession: switchFocus, resolveHostId },
+      { switchToSession: switchFocus, resolveHostId, assertContextLive: () => true },
     )
 
     expect(resolveHostId).toHaveBeenCalledTimes(1)
@@ -98,7 +98,7 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: 'h1', workspaceId: 'w1' },
-      { switchToSession: switchFocus, resolveHostId },
+      { switchToSession: switchFocus, resolveHostId, assertContextLive: () => true },
     )
 
     expect(switchFocus).not.toHaveBeenCalled()
@@ -127,7 +127,7 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: 'h1', workspaceId: 'w1' },
-      { switchToSession: switchFocus, resolveHostId },
+      { switchToSession: switchFocus, resolveHostId, assertContextLive: () => true },
     )
 
     expect(switchFocus).toHaveBeenCalledWith('h1', 'sess-1')
@@ -162,7 +162,7 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: 'h1', workspaceId: 'w1' },
-      { switchToSession: switchFocus, resolveHostId },
+      { switchToSession: switchFocus, resolveHostId, assertContextLive: () => true },
     )
 
     const toast = useUndoToast.getState().toast
@@ -249,7 +249,7 @@ describe('runWorkspaceSlot', () => {
     await runWorkspaceSlot(
       { id: 'cmd-a', name: 'A', command: 'echo hi' },
       { hostId: 'h1', workspaceId: 'w1' },
-      { switchToSession: switchFocus, resolveHostId },
+      { switchToSession: switchFocus, resolveHostId, assertContextLive: () => true },
     )
 
     const toast = useUndoToast.getState().toast
@@ -260,5 +260,20 @@ describe('runWorkspaceSlot', () => {
     // No retry — retry would re-send to a session the user cannot see
     expect(toast!.action).toBeUndefined()
     expect(toast!.actionLabel).toBeUndefined()
+  })
+
+  // #690 / spec §3.3.1 — type-level enforcement: Deps.assertContextLive is required.
+  // Future workspace-context callers (e.g. Phase 1b' Plus hover popover) cannot
+  // silently regress the round-4 destructive-command guard by omitting the probe.
+  // If we ever add `assertContextLive` to the literal below (or revert the type
+  // to optional), this @ts-expect-error directive becomes "unused" and TS will
+  // fail the build — surfacing the regression loudly.
+  it('requires assertContextLive at type level (#690 / spec §3.3.1)', () => {
+    // @ts-expect-error - assertContextLive is required (#690)
+    const deps: Parameters<typeof runWorkspaceSlot>[2] = {
+      switchToSession: () => {},
+      resolveHostId: async () => null,
+    }
+    expect(deps).toBeDefined()
   })
 })

--- a/spa/src/lib/slot-executor.ts
+++ b/spa/src/lib/slot-executor.ts
@@ -5,6 +5,20 @@ import { useI18nStore } from '../stores/useI18nStore'
 import type { QuickCommand } from './quick-command-bindings'
 import type { SlotContext } from '../components/CommandSlot'
 
+/**
+ * Workspace-narrowed slot context (#690 round-2 D1 / spec §3.3.1):
+ * `workspaceId` is required (non-null string) — the round-4 destructive-command
+ * guard relies on a real workspace to validate via `assertContextLive`. Host
+ * contexts have no workspace to probe and must NOT reuse `runWorkspaceSlot`;
+ * Phase 1c will introduce a sibling `runHostSlot` with `HostSlotContext` instead.
+ *
+ * `SlotContext.workspaceId` itself stays optional (HOST_ACTIONS shares the same
+ * shape via CommandSlot props). The narrow happens at this entry point only.
+ */
+export interface WorkspaceSlotContext extends SlotContext {
+  workspaceId: string
+}
+
 interface Deps {
   /**
    * Switches the active tab/pane to the freshly-created session.
@@ -65,7 +79,7 @@ function genSessionName(cmd: QuickCommand): string {
  */
 export async function runWorkspaceSlot(
   cmd: QuickCommand,
-  ctx: SlotContext,
+  ctx: WorkspaceSlotContext,
   deps: Deps,
 ): Promise<void> {
   const t = useI18nStore.getState().t
@@ -104,7 +118,21 @@ export async function runWorkspaceSlot(
   // is already created server-side; surface it as a switch failure (no retry)
   // so the user knows the operation didn't reach completion. Cleanup of the
   // server-side session is tracked separately (#689).
-  if (!deps.assertContextLive()) {
+  //
+  // #690 round-2 A2 — defense in depth. Type-level enforcement guarantees
+  // `assertContextLive` is a function, but a cast-bypass (`as any` / `as
+  // unknown as Deps` / Object.assign with payload-as-any) could still ship
+  // a non-function or one that throws. Fail closed in either case so we
+  // never reach `executeCommand` when the probe is unreliable.
+  let live = false
+  try {
+    if (typeof deps.assertContextLive === 'function') {
+      live = deps.assertContextLive() === true
+    }
+  } catch {
+    live = false
+  }
+  if (!live) {
     toast.show(t('quick_commands.toast.switch_failed'))
     return
   }

--- a/spa/src/lib/slot-executor.ts
+++ b/spa/src/lib/slot-executor.ts
@@ -25,16 +25,19 @@ interface Deps {
   resolveHostId: () => Promise<string | null>
 
   /**
-   * codex round-4 — workspace liveness probe. Returns false if the surrounding
-   * UI context (e.g. workspace) was destroyed while async work was in flight.
-   * The executor calls this after `createSession` resolves and BEFORE
-   * `executeCommand` runs so destructive commands aren't sent to a session
-   * the user can no longer reach.
+   * Required (#690 / spec §3.3.1) — workspace liveness probe. Returns false if
+   * the surrounding UI context (e.g. workspace) was destroyed while async work
+   * was in flight. The executor calls this after `createSession` resolves and
+   * BEFORE `executeCommand` runs so destructive commands aren't sent to a
+   * session the user can no longer reach (codex round-4 of PR #686).
    *
-   * Optional — HOST_ACTIONS callers (Phase 1c) don't have a workspace context
-   * to verify and pass `undefined` to opt out of this check.
+   * Phase 1c HOST_ACTIONS will introduce a separate `runHostSlot` entry point
+   * — host context has no workspace to verify and must NOT reuse this function
+   * (was originally optional to share, but that path silently regresses the
+   * round-4 guard for any future workspace-context caller that forgets to
+   * wire it; e.g. Phase 1b' Plus hover popover).
    */
-  assertContextLive?: () => boolean
+  assertContextLive: () => boolean
 }
 
 function genSessionName(cmd: QuickCommand): string {
@@ -54,9 +57,11 @@ function genSessionName(cmd: QuickCommand): string {
  *  - Step 1 ok + Step 2 ok + Step 3 fails (rare) → toast pointing user to
  *    the sessions list (session is alive elsewhere).
  *
- * The executor is shared by Phase 1b workspace entry and Phase 1c host entry
- * (the latter calls it with workspaceId omitted; the cwd-resolution defaults
- * differ per slot caller, see spec §3.2 table).
+ * Workspace-only entry (#690 / spec §3.3.1). Phase 1c HOST_ACTIONS will
+ * introduce a sibling `runHostSlot` rather than reusing this — host callers
+ * have no workspace context to validate via `assertContextLive`, and sharing
+ * the executor with an optional probe was the round-4 regression risk #690
+ * is closing.
  */
 export async function runWorkspaceSlot(
   cmd: QuickCommand,
@@ -92,14 +97,14 @@ export async function runWorkspaceSlot(
     return
   }
 
-  // codex round-4 — workspace liveness gate. If the surrounding context (e.g.
-  // workspace) was destroyed while createSession was in flight, do NOT send
-  // the user command — destructive quick commands (rm / drop / etc.) must not
-  // execute remotely once their context is gone. The session is already
-  // created server-side; surface it as a switch failure (no retry) so the
-  // user knows the operation didn't reach completion. Cleanup of the
-  // server-side session is a separate concern (see PR follow-up).
-  if (deps.assertContextLive && !deps.assertContextLive()) {
+  // codex round-4 (PR #686) — workspace liveness gate. If the surrounding
+  // context (e.g. workspace) was destroyed while createSession was in flight,
+  // do NOT send the user command — destructive quick commands (rm / drop /
+  // etc.) must not execute remotely once their context is gone. The session
+  // is already created server-side; surface it as a switch failure (no retry)
+  // so the user knows the operation didn't reach completion. Cleanup of the
+  // server-side session is tracked separately (#689).
+  if (!deps.assertContextLive()) {
     toast.show(t('quick_commands.toast.switch_failed'))
     return
   }


### PR DESCRIPTION
## Summary

- Promote `runWorkspaceSlot` to **type-level required** ctx + Deps + runtime fail-closed defense in depth, closing the regression risk codex round-5 of PR #686 flagged via [issue #690](https://github.com/wake/purdex/issues/690).
- Phase 1b' (Plus hover popover) is the imminent at-risk caller; without enforcement it could silently omit the round-4 destructive-command guard.
- Spec §3.3.1 + master plan Phase 1b'/1c **superseded notes** added so future implementers see #690 instructions before copying historical examples.

## Why now

Phase 1b shipped at alpha.240 (PR #686 `cb1423f4`). Round-5 final approve recommended this as the followup gate before Phase 1b'. Pre-1b' is the right time:

- Type-level enforcement only catches future regressions if it lands BEFORE the next caller is added.
- Phase 1b' adds a workspace-context caller — exactly the failure mode #690 prevents.
- Phase 1c HOST_ACTIONS will now need a sibling `runHostSlot` (no workspace to verify); enforcement here forces 1c to do the right thing instead of reusing the executor.

## Final shape (post round-2/3 hardening)

### Runtime (`spa/src/lib/slot-executor.ts`)
- `Deps.assertContextLive: () => boolean` (required, was optional).
- New exported `WorkspaceSlotContext = SlotContext & { workspaceId: string }`. `runWorkspaceSlot(ctx: WorkspaceSlotContext)` — Phase 1c HOST_ACTIONS can no longer slip through with `{ hostId }` + dummy probe.
- Runtime guard now **fail-closed defense in depth**: `typeof === 'function'` + try/catch + strict bool check. Cast-bypassed or throwing probes never reach `executeCommand`.

### Tests (`spa/src/lib/slot-executor.test.ts`)
- 7 existing tests gain `assertContextLive: () => true` as negative control.
- 2 new fail-closed tests: probe throws / probe non-function (cast-bypass simulation).
- 1 new type-level invariant test using conditional types: asserts `Deps !== any`, `assertContextLive` required, `workspaceId` required, `workspaceId` rejects null. **Verified by `tsc -b` (run via `pnpm run build`), NOT by vitest** — explicit JSDoc + test name flag this so reviewers don't read "vitest passed" as proof of the type contract.

### Caller (`spa/src/features/workspace/components/WorkspaceQuickCommandsContextMenu.tsx`)
- Spreads `{ ...ctx, workspaceId }` from closure (typed `string` from props) to satisfy `WorkspaceSlotContext`. No runtime change.

### Docs
- `docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md` §3.3.1 (new) — Why / Enforcement (type+runtime two layers) / Phase 1c impact / known residual risk.
- `docs/superpowers/plans/2026-04-28-quick-commands-v2-690-assert-context-live.md` (new) — implementation plan + final-shape table.
- `docs/superpowers/plans/2026-04-27-quick-commands-v2.md` Phase 1b' / 1c — superseded notes.

## Spec/plan + multi-round codex review

| Round | Findings | Outcome |
|---|---|---|
| Spec+plan review (pre-impl) | 5 (2 M / 3 L) | All adopted; docs rewritten |
| Round 1 (standard) | 0 | Approve |
| Round 2 (3-parallel: attacker / defender / file-quality) | 5 medium (D1 / A1 / A2 / F1 / A3) | 4 fixed inline (D1/A1/A2/F1); A3 → issue #695 |
| Round 3 (verification) | 1 high (branch base lagged main → silent version rollback) | Rebased onto alpha.241 |

### Round-2 finding details

| ID | Source | Finding | Fix |
|---|---|---|---|
| **D1** | defender | ctx still accepted host-shaped contexts (`workspaceId` optional) | Added `WorkspaceSlotContext`; caller spreads `workspaceId` from closure |
| **A1** | attacker | `@ts-expect-error` not robust to Deps growth | Replaced with conditional-type assertions (IsAny + Pick-required + null-rejection) |
| **F1** | file-quality | Type-level test in vitest suite → false-green risk | Renamed test + JSDoc explicitly: enforcement runs only via `tsc -b` |
| **A2** | attacker | Probe throw / cast-bypass would unhandled-reject after createSession | Runtime fail-closed: `typeof === 'function'` + try/catch + strict bool |
| **A3** | attacker | Type escape hatches not lint-enforced | Deferred → issue #695 (custom ESLint rule, scope > #690) |

## Reviewer attention

- Type-level invariants are verified by `pnpm run build` (`tsc -b`), not `pnpm vitest run`. Vitest does not type-check by default.
- `WorkspaceSlotContext` is the intended public type for workspace executors. Phase 1c will introduce a sibling `HostSlotContext`; do **not** reuse `WorkspaceSlotContext` for host callers.
- Type cast escape hatches (`as any`, `as unknown as ...`, `Object.assign(... payload as any)`) bypass type-level enforcement — runtime fail-closed catches these but ESLint doesn't (yet, see #695).

## Test plan

- [x] `pnpm run build` — clean (tsc -b + vite build)
- [x] `pnpm vitest run src/lib/slot-executor` — 12/12 pass (was 9 in main; +3: 2 fail-closed + 1 type-level invariant)
- [x] `pnpm vitest run src/features/workspace` — 359/359 pass (caller narrow OK)
- [x] `pnpm vitest run` — 2961/2965 (4 pre-existing fails tracked in #674)
- [x] `pnpm run lint` — clean
- [x] Branch rebased on `origin/main` @ `354bd813` (alpha.241)

## Refs

- Closes #690
- Followup: #695 (ESLint enforcement)
- Related: #689 (server-side orphan session cleanup, Phase 2)
- Spec: `docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md` §3.3.1
- Plan: `docs/superpowers/plans/2026-04-28-quick-commands-v2-690-assert-context-live.md`