### PR TITLE
feat(spa): Quick Commands v2 Phase 1b' — Plus hover popover (WORKSPACE_ACTIONS)

### DIFF
--- a/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx
@@ -1,11 +1,28 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
 import { WorkspaceQuickActionsPopover } from './WorkspaceQuickActionsPopover'
 import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
 import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
 import { useHostStore } from '../../../stores/useHostStore'
+import { useWorkspaceStore } from '../../../stores/useWorkspaceStore'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
+import { createSession } from '../../../lib/host-api'
+
+// codex round-1 P2 fix tests need to spy on createSession (the cwd sink in
+// runWorkspaceSlot) without performing real network calls. importActual
+// preserves every other host-api export so unrelated callers still resolve.
+vi.mock('../../../lib/host-api', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/host-api')>(
+    '../../../lib/host-api',
+  )
+  return {
+    ...actual,
+    // Never resolves — keeps runWorkspaceSlot pending so we can assert call args
+    // before the executor moves past createSession.
+    createSession: vi.fn(() => new Promise(() => {})),
+  }
+})
 
 function setup() {
   useQuickCommandStore.setState({
@@ -27,6 +44,7 @@ function setup() {
 
 beforeEach(() => {
   cleanup()
+  vi.mocked(createSession).mockClear()
   setup()
 })
 
@@ -73,5 +91,84 @@ describe('WorkspaceQuickActionsPopover', () => {
     expect(screen.getByRole('listbox')).toBeInTheDocument()
     // simulate parent hub mouseleave force-closing the popover wrapper.
     expect(() => unmount()).not.toThrow()
+  })
+
+  // codex round-1 P2 (F1) — cwd parity with context-menu path. Without this fix
+  // the hover popover would call createSession with cwd='~' even when the
+  // workspace has files.projectPath configured, while the right-click context
+  // menu correctly inherits projectPath. Same command, divergent behavior.
+  it('hostId known + workspace has projectPath → createSession invoked with cwd=projectPath', async () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: 'w1',
+          name: 'WS',
+          tabs: [],
+          activeTabId: null,
+          moduleConfig: { files: { projectPath: '/srv/work' } },
+        },
+      ],
+      activeWorkspaceId: 'w1',
+    } as Partial<ReturnType<typeof useWorkspaceStore.getState>> as never)
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />)
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(/^Alpha/))
+    })
+    expect(createSession).toHaveBeenCalledTimes(1)
+    // createSession(hostId, name, cwd, mode)
+    expect(vi.mocked(createSession).mock.calls[0]?.[2]).toBe('/srv/work')
+  })
+
+  // codex round-1 P2 (F2) — double-click race. With hostId already known the
+  // picker never opens, so without an explicit executing guard busy stayed
+  // false for the entire async createSession round-trip and a fast double-click
+  // would queue two pipelines. Synchronous ref guard catches the same-tick
+  // double-fire before React re-renders the disabled state.
+  it('rapid double-click on chip → executor fires only once (executing race guard)', async () => {
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />)
+    const chip = screen.getByLabelText(/^Alpha/)
+    await act(async () => {
+      fireEvent.click(chip)
+      fireEvent.click(chip)
+    })
+    expect(createSession).toHaveBeenCalledTimes(1)
+  })
+
+  // codex round-1 P2 (F3) — picker hover-dismissal. The parent hub uses
+  // onPickerOpenChange to decide whether to honor mouseleave / pointerdown
+  // close events. Mount notifies false; opening the picker notifies true;
+  // selecting/cancelling notifies false; unmount notifies false again.
+  it('onPickerOpenChange fires true when picker opens, false when picker closes', () => {
+    const onPickerOpenChange = vi.fn()
+    render(
+      <WorkspaceQuickActionsPopover
+        workspaceId="w1"
+        hostId={null}
+        onPickerOpenChange={onPickerOpenChange}
+      />,
+    )
+    // initial mount fires false; record the count then verify subsequent transitions.
+    onPickerOpenChange.mockClear()
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(onPickerOpenChange).toHaveBeenCalledWith(true)
+
+    // select host → picker closes
+    onPickerOpenChange.mockClear()
+    fireEvent.click(screen.getByText(/mlab/))
+    expect(onPickerOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('onPickerOpenChange fires false on unmount even if picker was never opened', () => {
+    const onPickerOpenChange = vi.fn()
+    const { unmount } = render(
+      <WorkspaceQuickActionsPopover
+        workspaceId="w1"
+        hostId="h1"
+        onPickerOpenChange={onPickerOpenChange}
+      />,
+    )
+    onPickerOpenChange.mockClear()
+    unmount()
+    expect(onPickerOpenChange).toHaveBeenCalledWith(false)
   })
 })

--- a/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx
@@ -5,24 +5,38 @@ import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
 import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
 import { useHostStore } from '../../../stores/useHostStore'
 import { useWorkspaceStore } from '../../../stores/useWorkspaceStore'
+import { useTabStore } from '../../../stores/useTabStore'
 import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
 import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
-import { createSession } from '../../../lib/host-api'
 
-// codex round-1 P2 fix tests need to spy on createSession (the cwd sink in
-// runWorkspaceSlot) without performing real network calls. importActual
-// preserves every other host-api export so unrelated callers still resolve.
+// codex round-1 P2 + round-2 fix tests need to drive runWorkspaceSlot to
+// completion or pause it at the picker stage. importActual preserves every
+// other host-api / execute-command export so unrelated callers still resolve.
+// Default: createSession resolves quickly so transaction-safety tests can
+// reach switchToSession; tests that need to inspect cwd/double-click before
+// completion still get accurate call args because runWorkspaceSlot synchronously
+// calls createSession from the executor.
 vi.mock('../../../lib/host-api', async () => {
   const actual = await vi.importActual<typeof import('../../../lib/host-api')>(
     '../../../lib/host-api',
   )
   return {
     ...actual,
-    // Never resolves — keeps runWorkspaceSlot pending so we can assert call args
-    // before the executor moves past createSession.
-    createSession: vi.fn(() => new Promise(() => {})),
+    createSession: vi.fn().mockResolvedValue({
+      code: 'sess-new',
+      name: 'sess-new',
+      cwd: '/tmp',
+      mode: 'terminal',
+    }),
   }
 })
+
+vi.mock('../../../lib/execute-command', () => ({
+  executeCommand: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { createSession } from '../../../lib/host-api'
+import { executeCommand } from '../../../lib/execute-command'
 
 function setup() {
   useQuickCommandStore.setState({
@@ -38,13 +52,32 @@ function setup() {
     runtime: { h1: { status: 'connected' } },
     activeHostId: 'h1',
   } as Partial<ReturnType<typeof useHostStore.getState>> as never)
+  // Tab + workspace stores need a baseline shape so insertTab / setActiveTab
+  // don't blow up when the executor reaches switchToSession.
+  useTabStore.setState({
+    tabs: {},
+    tabOrder: [],
+    activeTabId: null,
+  } as Partial<ReturnType<typeof useTabStore.getState>> as never)
+  useWorkspaceStore.setState({
+    workspaces: [{ id: 'w1', name: 'WS', tabs: [], activeTabId: null, moduleConfig: {} }],
+    activeWorkspaceId: 'w1',
+  } as Partial<ReturnType<typeof useWorkspaceStore.getState>> as never)
   clearModuleRegistry()
   registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
+  vi.clearAllMocks()
+  // Restore the default createSession resolved value after clearAllMocks wipes it.
+  vi.mocked(createSession).mockResolvedValue({
+    code: 'sess-new',
+    name: 'sess-new',
+    cwd: '/tmp',
+    mode: 'terminal',
+  } as Awaited<ReturnType<typeof createSession>>)
+  vi.mocked(executeCommand).mockResolvedValue(undefined)
 }
 
 beforeEach(() => {
   cleanup()
-  vi.mocked(createSession).mockClear()
   setup()
 })
 
@@ -170,5 +203,105 @@ describe('WorkspaceQuickActionsPopover', () => {
     onPickerOpenChange.mockClear()
     unmount()
     expect(onPickerOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  // codex round-2 fix tests (R2)
+  // ────────────────────────────────────────────────────────────────────
+
+  // codex round-2 D1 — picker positioning when wrapper has CSS transform
+  // (-translate-y-1/2). HostPickerPopover uses position:fixed; portal'ing it
+  // out of the transformed subtree restores viewport-anchored layout.
+  it('R2 D1: HostPickerPopover renders via portal into document.body, NOT inside the wrapper', () => {
+    const { container } = render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId={null} />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    const listbox = screen.getByRole('listbox')
+    expect(listbox).toBeInTheDocument()
+    // The container is the (transformed) wrapper subtree; listbox must NOT be inside it.
+    expect(container.contains(listbox)).toBe(false)
+    expect(document.body.contains(listbox)).toBe(true)
+  })
+
+  // codex round-2 D2 — pendingResolverRef cleanup. Unmount while picker is up
+  // must actually settle the executor's await Promise (resolveHostId) so the
+  // executor returns through its `finally` block. Without the ref, settling
+  // relied on a setState updater that could miss a torn-down component, leaving
+  // executingRef stuck and chips disabled forever.
+  it('R2 D2: unmount while picker open → executor resolveHostId resolves null → createSession NOT called', async () => {
+    const { unmount } = render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId={null} />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    unmount()
+    await new Promise<void>((r) => setTimeout(r, 0))
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  // codex round-2 F1 — early-return-null cleanup. When module is disabled (or
+  // bindings disappear) mid-pick, the popover hides via early-return; the
+  // unmount cleanup never fires because the component itself is still mounted.
+  // Without the F1 effect, resolveHostId hangs forever and the chips stay busy.
+  it('R2 F1: module disabled while picker open → picker closes, executor short-circuits without createSession', async () => {
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId={null} />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    act(() => {
+      useModuleEnabledStore.getState().setEnabled('quick-commands', false)
+    })
+    await new Promise<void>((r) => setTimeout(r, 0))
+
+    // Picker DOM gone; executor returned early with hostId=null cancellation.
+    expect(screen.queryByRole('listbox')).toBeNull()
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  // codex round-2 A1 — switchToSession transaction safety. If the workspace
+  // is deleted in the executeCommand await window (after assertContextLive
+  // already passed), switchToSession's pre-check fast-fails BEFORE
+  // openSingletonTab, so no orphan tab + no active-tab/workspace mutations
+  // leak through.
+  it('R2 A1: workspace deleted during executeCommand await → switchToSession pre-check rejects, no orphan tab', async () => {
+    let resumeExecuteCommand: (() => void) | null = null
+    vi.mocked(executeCommand).mockImplementationOnce(
+      () => new Promise<void>((resolve) => {
+        resumeExecuteCommand = resolve
+      }),
+    )
+
+    const prevTabsCount = Object.keys(useTabStore.getState().tabs).length
+    const prevActiveTabId = useTabStore.getState().activeTabId
+
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+
+    // Flush createSession + assertContextLive; we are now paused inside the
+    // executeCommand await.
+    await act(async () => {
+      await new Promise<void>((r) => setTimeout(r, 0))
+    })
+    expect(executeCommand).toHaveBeenCalledTimes(1)
+    expect(resumeExecuteCommand).not.toBeNull()
+
+    // Delete the workspace mid-flight.
+    act(() => {
+      useWorkspaceStore.setState({
+        workspaces: [],
+        activeWorkspaceId: null,
+      } as Partial<ReturnType<typeof useWorkspaceStore.getState>> as never)
+    })
+
+    // Resume executeCommand → trySwitch → switchToSession's pre-check throws.
+    // trySwitch swallows the throw and returns false; slot-executor surfaces
+    // switch_failed toast and returns. Tab store stays clean.
+    await act(async () => {
+      resumeExecuteCommand?.()
+      await new Promise<void>((r) => setTimeout(r, 0))
+    })
+
+    expect(Object.keys(useTabStore.getState().tabs)).toHaveLength(prevTabsCount)
+    expect(useTabStore.getState().activeTabId).toBe(prevActiveTabId)
+    // Workspace stays deleted; we did NOT force activeWorkspaceId back to 'w1'.
+    expect(useWorkspaceStore.getState().workspaces.find((w) => w.id === 'w1')).toBeUndefined()
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(null)
   })
 })

--- a/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx
@@ -255,6 +255,54 @@ describe('WorkspaceQuickActionsPopover', () => {
     expect(createSession).not.toHaveBeenCalled()
   })
 
+  // codex round-3 R3 F1 — sync open notification. The hub's pickerOpenRef must
+  // be flipped BEFORE child popover effects fire (HostPickerPopover auto-focuses
+  // its first option, which steals focus from the chip and triggers the hub's
+  // onBlurCapture). If the notification ran in a useEffect (post-commit, AFTER
+  // child effects), pickerOpenRef would still be false during blur and the hub
+  // would unconditionally collapse popover, unmounting the picker before the
+  // user could click. Verify the very first post-click notify is `(true)` —
+  // i.e. fired synchronously inside resolveHostId, not asynchronously in a
+  // useEffect tick (which would have produced an unrelated initial-mount false
+  // first or fired after blur/render order).
+  it('R3 F1: onPickerOpenChange(true) fires synchronously inside resolveHostId, not via post-commit useEffect', () => {
+    const onPickerOpenChange = vi.fn()
+    render(
+      <WorkspaceQuickActionsPopover
+        workspaceId="w1"
+        hostId={null}
+        onPickerOpenChange={onPickerOpenChange}
+      />,
+    )
+    onPickerOpenChange.mockClear()
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    // The very first call after click MUST be (true). The legacy useEffect-based
+    // notify could produce other patterns; sync notify produces exactly (true)
+    // first, with no spurious initial false in between.
+    expect(onPickerOpenChange.mock.calls[0]?.[0]).toBe(true)
+  })
+
+  // codex round-3 R3 F1 — same race, settle path. Selecting a host must sync
+  // notify (false) so the hub's pickerOpenRef updates before HostPickerPopover
+  // unmounts (which would otherwise fire focus-restore blur events with
+  // pickerOpenRef still true → wrong, hub thinks picker is up).
+  it('R3 F1: onPickerOpenChange(false) fires synchronously inside settlePicker (select)', () => {
+    const onPickerOpenChange = vi.fn()
+    render(
+      <WorkspaceQuickActionsPopover
+        workspaceId="w1"
+        hostId={null}
+        onPickerOpenChange={onPickerOpenChange}
+      />,
+    )
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    onPickerOpenChange.mockClear()
+    fireEvent.click(screen.getByText(/mlab/))
+    // Sync settle: the very first call after select MUST be (false), no
+    // intervening true.
+    expect(onPickerOpenChange.mock.calls[0]?.[0]).toBe(false)
+  })
+
   // codex round-2 A1 — switchToSession transaction safety. If the workspace
   // is deleted in the executeCommand await window (after assertContextLive
   // already passed), switchToSession's pre-check fast-fails BEFORE

--- a/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { WorkspaceQuickActionsPopover } from './WorkspaceQuickActionsPopover'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { useHostStore } from '../../../stores/useHostStore'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
+
+function setup() {
+  useQuickCommandStore.setState({
+    global: [{ id: 'cmd-a', name: 'Alpha', command: 'a' }],
+    byHost: {},
+    bindings: { 'cmd-a': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] },
+  })
+  useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  // HostPickerPopover 內部讀 useHostStore；至少塞一個 host 避免空狀態誤判
+  useHostStore.setState({
+    hosts: { h1: { id: 'h1', name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 } },
+    hostOrder: ['h1'],
+    runtime: { h1: { status: 'connected' } },
+    activeHostId: 'h1',
+  } as Partial<ReturnType<typeof useHostStore.getState>> as never)
+  clearModuleRegistry()
+  registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
+}
+
+beforeEach(() => {
+  cleanup()
+  setup()
+})
+
+describe('WorkspaceQuickActionsPopover', () => {
+  it('renders bound commands as chips', () => {
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />)
+    expect(screen.getByLabelText(/^Alpha/)).toBeInTheDocument()
+  })
+
+  it('renders chips when hostId is null (picker handles host resolution at click time)', () => {
+    // Spec v4 §3.2.2 — null hostId is a valid state (workspace has no
+    // tmux-session tabs); we still surface the chips so user can pick a host.
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId={null} />)
+    expect(screen.getByLabelText(/^Alpha/)).toBeInTheDocument()
+  })
+
+  it('returns null when no commands bound', () => {
+    useQuickCommandStore.setState({ bindings: {} })
+    const { container } = render(
+      <WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('returns null when module disabled', () => {
+    useModuleEnabledStore.getState().setEnabled('quick-commands', false)
+    const { container } = render(
+      <WorkspaceQuickActionsPopover workspaceId="w1" hostId="h1" />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('hostId=null + click chip → opens HostPickerPopover', () => {
+    render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId={null} />)
+    expect(screen.queryByRole('listbox')).toBeNull()
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+  })
+
+  // codex round-2 — picker resolver cleanup (popover unmount via mouseleave on parent)
+  it('unmount while picker is open → pending Promise resolves to null, no throw', () => {
+    const { unmount } = render(<WorkspaceQuickActionsPopover workspaceId="w1" hostId={null} />)
+    fireEvent.click(screen.getByLabelText(/^Alpha/))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    // simulate parent hub mouseleave force-closing the popover wrapper.
+    expect(() => unmount()).not.toThrow()
+  })
+})

--- a/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx
+++ b/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { CommandSlot } from '../../../components/CommandSlot'
 import { HostPickerPopover } from '../../../components/HostPickerPopover'
 import { runWorkspaceSlot } from '../../../lib/slot-executor'
@@ -68,6 +69,11 @@ export function WorkspaceQuickActionsPopover({
     resolver: ((id: string | null) => void) | null
     anchor: HTMLElement | null
   } | null>(null)
+  // codex round-2 D2 — resolver mirrored in a ref so unmount cleanup and
+  // early-return-null cleanup (F1) can settle the Promise without going
+  // through React state. setState updaters do not run reliably on unmounted
+  // / about-to-return-null components, but a ref is always readable.
+  const pendingResolverRef = useRef<((id: string | null) => void) | null>(null)
 
   // codex round-1 P2 (F2 — double-click race) — when hostId is already known the
   // picker never opens, so `picker?.open` stays false for the entire async
@@ -79,9 +85,17 @@ export function WorkspaceQuickActionsPopover({
   const executingRef = useRef(false)
   const [executing, setExecuting] = useState(false)
 
+  const settlePicker = useCallback((id: string | null) => {
+    const resolver = pendingResolverRef.current
+    pendingResolverRef.current = null
+    setPicker(null)
+    if (resolver) resolver(id)
+  }, [])
+
   const resolveHostId = useCallback(
     () =>
       new Promise<string | null>((resolve) => {
+        pendingResolverRef.current = resolve
         setPicker({ open: true, resolver: resolve, anchor: wrapperRef.current })
       }),
     [],
@@ -89,14 +103,13 @@ export function WorkspaceQuickActionsPopover({
 
   // codex round-2 — dangling Promise cleanup. The popover lives behind a hover
   // trigger; mouseleave on the parent hub will unmount this component while a
-  // resolver may still be pending. We MUST resolve null on unmount so the
-  // executor's await returns and busy state clears.
+  // resolver may still be pending. Settling via ref (D2) so cleanup remains
+  // reliable even if React has already torn down the component.
   useEffect(() => {
     return () => {
-      setPicker((current) => {
-        if (current?.resolver) current.resolver(null)
-        return null
-      })
+      const resolver = pendingResolverRef.current
+      pendingResolverRef.current = null
+      if (resolver) resolver(null)
     }
   }, [])
 
@@ -112,10 +125,41 @@ export function WorkspaceQuickActionsPopover({
     return () => onPickerOpenChange?.(false)
   }, [onPickerOpenChange])
 
-  // codex round-1 B5/B6 — full openSingletonAndSelect equivalent: complete
-  // tmux-session content fields + insertTab into workspace + setActive.
+  // codex round-2 F1 — early-return-null does NOT unmount the component, so the
+  // unmount-cleanup `useEffect` above never fires when bindings disappear or
+  // the module is disabled mid-pick. That leaves the picker resolver hanging
+  // forever (executor's await never resolves; busy state sticks; pointer/blur
+  // close paths stay suppressed). Detect the transition and settle ourselves.
+  const visible = moduleEnabled && hasBindings
+  useEffect(() => {
+    if (!visible) {
+      settlePicker(null)
+      // keep executing flag in sync; if executor was past resolveHostId we
+      // can't unwind it, but the resolver-null path will short-circuit it.
+      if (executingRef.current && !pickerOpen) {
+        // Executor was past the picker stage — let it finish naturally.
+      }
+    }
+  }, [visible, pickerOpen, settlePicker])
+
+  // codex round-2 A1 — workspace-deletion transaction safety (parity with
+  // WorkspaceQuickCommandsContextMenu). createSession + send-keys are async;
+  // the workspace can be deleted in that window. Without pre-check / read-back
+  // / rollback, openSingletonTab would still create a tab while insertTab
+  // silently no-ops (workspace gone), then setActive* would mutate state for
+  // a nonexistent workspace and leave an orphan tab unattached anywhere.
   const switchToSession = useCallback(
     (h: string, sessionCode: string) => {
+      // (1) pre-check — fail fast if the workspace is already gone.
+      if (
+        !useWorkspaceStore.getState().workspaces.some((w) => w.id === workspaceId)
+      ) {
+        throw new Error(
+          `WorkspaceQuickActionsPopover: workspace ${workspaceId} no longer exists; aborting before tab creation`,
+        )
+      }
+      // Snapshot for rollback when the residual race fires.
+      const prevActiveTabId = useTabStore.getState().activeTabId
       const tabId = useTabStore.getState().openSingletonTab({
         kind: 'tmux-session',
         hostId: h,
@@ -125,13 +169,30 @@ export function WorkspaceQuickActionsPopover({
         tmuxInstance: '',
       })
       useWorkspaceStore.getState().insertTab(tabId, workspaceId)
+      // (2) read-back — workspace may have been deleted between the pre-check
+      // and insertTab.
+      const inserted =
+        useWorkspaceStore
+          .getState()
+          .workspaces.find((w) => w.id === workspaceId)
+          ?.tabs.includes(tabId) ?? false
+      if (!inserted) {
+        // (3) rollback — close the freshly-created tab and restore the prior
+        // activeTabId so the failed switch leaves no orphan + no dangling
+        // active-tab mutation. Throw so trySwitch surfaces switch_failed.
+        useTabStore.getState().closeTab(tabId)
+        useTabStore.getState().setActiveTab(prevActiveTabId)
+        throw new Error(
+          `WorkspaceQuickActionsPopover: workspace ${workspaceId} deleted mid-flight; rolled back tab ${tabId}`,
+        )
+      }
       useWorkspaceStore.getState().setActiveWorkspace(workspaceId)
       useTabStore.getState().setActiveTab(tabId)
     },
     [workspaceId],
   )
 
-  if (!moduleEnabled || !hasBindings) return null
+  if (!visible) return null
 
   return (
     <div
@@ -177,21 +238,24 @@ export function WorkspaceQuickActionsPopover({
           }
         }}
       />
-      <HostPickerPopover
-        open={picker?.open ?? false}
-        anchor={picker?.anchor ?? null}
-        onSelect={(hid) => {
-          // codex round-2 — null-out resolver before invoking to make duplicate-call safe
-          const resolver = picker?.resolver
-          setPicker(null)
-          resolver?.(hid)
-        }}
-        onCancel={() => {
-          const resolver = picker?.resolver
-          setPicker(null)
-          resolver?.(null)
-        }}
-      />
+      {/*
+        codex round-2 D1 — HostPickerPopover uses position:fixed sourced from
+        anchor.getBoundingClientRect(). Inside our transformed wrapper
+        (-translate-y-1/2) a fixed descendant is positioned relative to that
+        ancestor instead of the viewport, throwing the picker off by tens of
+        pixels in real browsers (jsdom tests don't reproduce). Portal to body
+        so the picker escapes the transformed subtree while still receiving
+        the same DOM anchor for coordinate computation.
+      */}
+      {createPortal(
+        <HostPickerPopover
+          open={pickerOpen}
+          anchor={picker?.anchor ?? null}
+          onSelect={(hid) => settlePicker(hid)}
+          onCancel={() => settlePicker(null)}
+        />,
+        document.body,
+      )}
     </div>
   )
 }

--- a/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx
+++ b/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { CommandSlot } from '../../../components/CommandSlot'
+import { HostPickerPopover } from '../../../components/HostPickerPopover'
+import { runWorkspaceSlot } from '../../../lib/slot-executor'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+import { useTabStore } from '../../../stores/useTabStore'
+import { useWorkspaceStore } from '../../../stores/useWorkspaceStore'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { useI18nStore } from '../../../stores/useI18nStore'
+import { getBindingTargets } from '../../../lib/quick-command-bindings'
+
+interface Props {
+  workspaceId: string
+  /**
+   * hostId 為 null 時 chip 仍顯示，executor 點擊後會開 HostPickerPopover
+   * 讓 user 選 host（spec v4 §3.2.2）。
+   */
+  hostId: string | null
+}
+
+/**
+ * Popover chip-list rendered to the LEFT of the Plus-button on each
+ * WorkspaceRow on hover/focus. Uses CommandSlot internally — already
+ * short-circuits when module disabled / no bindings; we additionally
+ * skip rendering the popover wrapper itself in those cases so the
+ * hover trigger doesn't expose an empty floating panel.
+ *
+ * NOTE (spec v4 §3.2.2): we do NOT short-circuit on hostId == null —
+ * the picker flow handles that case. Only no-bindings / module-disabled
+ * suppress the wrapper.
+ */
+export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
+  const t = useI18nStore((s) => s.t)
+  const moduleEnabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
+  const hasBindings = useQuickCommandStore((s) => {
+    const cmds = hostId == null ? s.global : s.getCommands(hostId)
+    return cmds.some((c) => {
+      const targets = getBindingTargets(s.bindings, c.id)
+      return targets !== undefined && targets.includes(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS)
+    })
+  })
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  // codex round-2 — picker state shape pinned: open implied by resolver !== null.
+  const [picker, setPicker] = useState<{
+    open: boolean
+    resolver: ((id: string | null) => void) | null
+    anchor: HTMLElement | null
+  } | null>(null)
+
+  const resolveHostId = useCallback(
+    () =>
+      new Promise<string | null>((resolve) => {
+        setPicker({ open: true, resolver: resolve, anchor: wrapperRef.current })
+      }),
+    [],
+  )
+
+  // codex round-2 — dangling Promise cleanup. The popover lives behind a hover
+  // trigger; mouseleave on the parent hub will unmount this component while a
+  // resolver may still be pending. We MUST resolve null on unmount so the
+  // executor's await returns and busy state clears.
+  useEffect(() => {
+    return () => {
+      setPicker((current) => {
+        if (current?.resolver) current.resolver(null)
+        return null
+      })
+    }
+  }, [])
+
+  // codex round-1 B5/B6 — full openSingletonAndSelect equivalent: complete
+  // tmux-session content fields + insertTab into workspace + setActive.
+  const switchToSession = useCallback(
+    (h: string, sessionCode: string) => {
+      const tabId = useTabStore.getState().openSingletonTab({
+        kind: 'tmux-session',
+        hostId: h,
+        sessionCode,
+        mode: 'terminal',
+        cachedName: sessionCode,
+        tmuxInstance: '',
+      })
+      useWorkspaceStore.getState().insertTab(tabId, workspaceId)
+      useWorkspaceStore.getState().setActiveWorkspace(workspaceId)
+      useTabStore.getState().setActiveTab(tabId)
+    },
+    [workspaceId],
+  )
+
+  if (!moduleEnabled || !hasBindings) return null
+
+  return (
+    <div
+      ref={wrapperRef}
+      role="group"
+      // codex round-1 C16 — i18n key, not hard-coded English
+      aria-label={t('quick_commands.aria.workspace_actions')}
+      className="absolute right-full top-1/2 -translate-y-1/2 mr-1 flex items-center gap-1 px-2 py-1 rounded-md bg-gradient-to-l from-surface-secondary/0 to-surface-secondary/95 backdrop-blur-sm shadow-md z-30"
+    >
+      <CommandSlot
+        mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
+        ctx={{ hostId, workspaceId }}
+        // codex round-1 C11 — picker race guard
+        busy={picker?.open ?? false}
+        executor={(cmd, ctx) =>
+          runWorkspaceSlot(
+            cmd,
+            { ...ctx, workspaceId },
+            {
+              switchToSession,
+              resolveHostId,
+              // #690 enforcement (alpha.242) — workspace liveness probe is
+              // type-level required on Deps. Workspace gets unmounted async
+              // (mouseleave / route change) while createSession is in flight;
+              // returning false here aborts before send-keys.
+              assertContextLive: () =>
+                useWorkspaceStore.getState().workspaces.some((w) => w.id === workspaceId),
+            },
+          )
+        }
+      />
+      <HostPickerPopover
+        open={picker?.open ?? false}
+        anchor={picker?.anchor ?? null}
+        onSelect={(hid) => {
+          // codex round-2 — null-out resolver before invoking to make duplicate-call safe
+          const resolver = picker?.resolver
+          setPicker(null)
+          resolver?.(hid)
+        }}
+        onCancel={() => {
+          const resolver = picker?.resolver
+          setPicker(null)
+          resolver?.(null)
+        }}
+      />
+    </div>
+  )
+}

--- a/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx
+++ b/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx
@@ -89,16 +89,26 @@ export function WorkspaceQuickActionsPopover({
     const resolver = pendingResolverRef.current
     pendingResolverRef.current = null
     setPicker(null)
+    // codex round-3 — sync notify so the parent hub's pickerOpenRef updates
+    // before any blur/pointer event fires from the unmounting picker.
+    onPickerOpenChange?.(false)
     if (resolver) resolver(id)
-  }, [])
+  }, [onPickerOpenChange])
 
   const resolveHostId = useCallback(
     () =>
       new Promise<string | null>((resolve) => {
         pendingResolverRef.current = resolve
+        // codex round-3 — sync notify BEFORE setPicker triggers HostPickerPopover
+        // render + auto-focus(first option). Without sync notify, pickerOpenRef
+        // would still be false when the child popover's focus() steals focus from
+        // the chip, causing the hub's onBlurCapture to collapse popover (and
+        // unmount the picker) before the user can click anything. The previous
+        // useEffect-based notify ran AFTER child effects — too late.
+        onPickerOpenChange?.(true)
         setPicker({ open: true, resolver: resolve, anchor: wrapperRef.current })
       }),
-    [],
+    [onPickerOpenChange],
   )
 
   // codex round-2 — dangling Promise cleanup. The popover lives behind a hover
@@ -113,14 +123,15 @@ export function WorkspaceQuickActionsPopover({
     }
   }, [])
 
-  // codex round-1 P2 (F3 — picker hover-dismissal) — propagate picker open state
-  // to the parent hub so it can suppress its mouseleave/pointerdown close logic
-  // while the picker is up. Cleanup notifies false on unmount so the hub never
-  // gets stuck thinking a picker is still open after the popover is gone.
+  // codex round-1 P2 (F3 — picker hover-dismissal) / round-3 — picker open
+  // notification is now sync'd from resolveHostId/settlePicker (see above) so
+  // the hub's pickerOpenRef is updated BEFORE child focus/blur events fire.
+  // The useEffect-based notify shipped initially is gone for that reason.
+  // We still need an unmount-cleanup notify to clear the hub's ref if the
+  // popover is torn down externally (mouseleave) without going through
+  // settlePicker first — e.g. picker never opened, or picker was open and
+  // unmount cleanup runs before settlePicker can.
   const pickerOpen = picker?.open ?? false
-  useEffect(() => {
-    onPickerOpenChange?.(pickerOpen)
-  }, [pickerOpen, onPickerOpenChange])
   useEffect(() => {
     return () => onPickerOpenChange?.(false)
   }, [onPickerOpenChange])

--- a/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx
+++ b/spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx
@@ -17,6 +17,14 @@ interface Props {
    * 讓 user 選 host（spec v4 §3.2.2）。
    */
   hostId: string | null
+  /**
+   * codex round-1 P2 (F3 — picker hover-dismissal) — invoked whenever the
+   * internal HostPickerPopover open state flips. The parent hub uses this to
+   * suppress its own mouseleave / pointerdown close logic while the picker is
+   * up, so moving the pointer toward a host option does not unmount the
+   * popover (and the picker with it) before the user can click.
+   */
+  onPickerOpenChange?: (open: boolean) => void
 }
 
 /**
@@ -30,7 +38,11 @@ interface Props {
  * the picker flow handles that case. Only no-bindings / module-disabled
  * suppress the wrapper.
  */
-export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
+export function WorkspaceQuickActionsPopover({
+  workspaceId,
+  hostId,
+  onPickerOpenChange,
+}: Props) {
   const t = useI18nStore((s) => s.t)
   const moduleEnabled = useModuleEnabledStore((s) => s.isEnabled('quick-commands'))
   const hasBindings = useQuickCommandStore((s) => {
@@ -40,6 +52,15 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
       return targets !== undefined && targets.includes(QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS)
     })
   })
+  // codex round-1 P2 (F1 — cwd parity with context-menu) — spec §3.2 says
+  // WORKSPACE_ACTIONS sessions inherit `workspace.moduleConfig.files.projectPath`
+  // as cwd. Without this, hover-popover commands fall back to `~` while the
+  // identical command from the right-click context menu would run in projectPath.
+  const cwd = useWorkspaceStore((s) => {
+    const ws = s.workspaces.find((w) => w.id === workspaceId)
+    const path = ws?.moduleConfig?.['files']?.['projectPath']
+    return typeof path === 'string' && path.length > 0 ? path : undefined
+  })
   const wrapperRef = useRef<HTMLDivElement>(null)
   // codex round-2 — picker state shape pinned: open implied by resolver !== null.
   const [picker, setPicker] = useState<{
@@ -47,6 +68,16 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
     resolver: ((id: string | null) => void) | null
     anchor: HTMLElement | null
   } | null>(null)
+
+  // codex round-1 P2 (F2 — double-click race) — when hostId is already known the
+  // picker never opens, so `picker?.open` stays false for the entire async
+  // createSession + send-keys round-trip. Without an explicit pending flag a
+  // fast double-click would queue two executor pipelines and create two sessions
+  // for the same command. The ref is the synchronous guard (covers same-tick
+  // double-fire before React re-renders); `executing` mirrors it to React state
+  // so the disabled UI in CommandSlot updates.
+  const executingRef = useRef(false)
+  const [executing, setExecuting] = useState(false)
 
   const resolveHostId = useCallback(
     () =>
@@ -68,6 +99,18 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
       })
     }
   }, [])
+
+  // codex round-1 P2 (F3 — picker hover-dismissal) — propagate picker open state
+  // to the parent hub so it can suppress its mouseleave/pointerdown close logic
+  // while the picker is up. Cleanup notifies false on unmount so the hub never
+  // gets stuck thinking a picker is still open after the popover is gone.
+  const pickerOpen = picker?.open ?? false
+  useEffect(() => {
+    onPickerOpenChange?.(pickerOpen)
+  }, [pickerOpen, onPickerOpenChange])
+  useEffect(() => {
+    return () => onPickerOpenChange?.(false)
+  }, [onPickerOpenChange])
 
   // codex round-1 B5/B6 — full openSingletonAndSelect equivalent: complete
   // tmux-session content fields + insertTab into workspace + setActive.
@@ -100,25 +143,39 @@ export function WorkspaceQuickActionsPopover({ workspaceId, hostId }: Props) {
     >
       <CommandSlot
         mountTo={QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS}
-        ctx={{ hostId, workspaceId }}
-        // codex round-1 C11 — picker race guard
-        busy={picker?.open ?? false}
-        executor={(cmd, ctx) =>
-          runWorkspaceSlot(
-            cmd,
-            { ...ctx, workspaceId },
-            {
-              switchToSession,
-              resolveHostId,
-              // #690 enforcement (alpha.242) — workspace liveness probe is
-              // type-level required on Deps. Workspace gets unmounted async
-              // (mouseleave / route change) while createSession is in flight;
-              // returning false here aborts before send-keys.
-              assertContextLive: () =>
-                useWorkspaceStore.getState().workspaces.some((w) => w.id === workspaceId),
-            },
-          )
-        }
+        // codex round-1 P2 (F1) — pass cwd so hover-popover commands inherit
+        // workspace projectPath, matching context-menu behavior.
+        ctx={{ hostId, workspaceId, cwd }}
+        // codex round-1 C11 + P2 (F2) — busy=true during picker mid-flight OR
+        // executor mid-flight; without `executing` the hostId-known path would
+        // never disable chips, allowing double-click duplicate session creation.
+        busy={pickerOpen || executing}
+        executor={async (cmd, ctx) => {
+          // codex round-1 P2 (F2) — synchronous ref guard catches the
+          // double-click window before React re-renders the disabled state.
+          if (executingRef.current) return
+          executingRef.current = true
+          setExecuting(true)
+          try {
+            await runWorkspaceSlot(
+              cmd,
+              { ...ctx, workspaceId },
+              {
+                switchToSession,
+                resolveHostId,
+                // #690 enforcement (alpha.242) — workspace liveness probe is
+                // type-level required on Deps. Workspace gets unmounted async
+                // (mouseleave / route change) while createSession is in flight;
+                // returning false here aborts before send-keys.
+                assertContextLive: () =>
+                  useWorkspaceStore.getState().workspaces.some((w) => w.id === workspaceId),
+              },
+            )
+          } finally {
+            executingRef.current = false
+            setExecuting(false)
+          }
+        }}
       />
       <HostPickerPopover
         open={picker?.open ?? false}

--- a/spa/src/features/workspace/components/WorkspaceRow.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.test.tsx
@@ -1,9 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
 import { DndContext } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'
 import { WorkspaceRow } from './WorkspaceRow'
 import { useLayoutStore } from '../../../stores/useLayoutStore'
+import { useQuickCommandStore } from '../../../stores/useQuickCommandStore'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+import { useHostStore } from '../../../stores/useHostStore'
+import { useTabStore } from '../../../stores/useTabStore'
+import { QUICK_COMMAND_SLOTS } from '../../../lib/quick-command-slots'
+import { clearModuleRegistry, registerModule } from '../../../lib/module-registry'
 import type { Workspace, Tab } from '../../../types/tab'
 
 const mkWs = (id: string, name: string, tabs: string[] = []): Workspace => ({
@@ -226,5 +232,174 @@ describe('WorkspaceRow — header "+ New tab"', () => {
     useLayoutStore.setState({ tabPosition: 'top' })
     render(<WorkspaceRow {...baseProps} onAddTabToWorkspace={() => {}} />)
     expect(screen.queryByLabelText(/new tab in alpha/i)).not.toBeInTheDocument()
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Phase 1b' — Plus hover popover + touch fallback (codex round-1 B8 / C17)
+// ──────────────────────────────────────────────────────────────────────
+
+function setupHoverPopoverFixtures(opts: { withBindings: boolean }) {
+  useQuickCommandStore.setState({
+    global: opts.withBindings ? [{ id: 'cmd-x', name: 'X', command: 'x' }] : [],
+    byHost: {},
+    bindings: opts.withBindings ? { 'cmd-x': [QUICK_COMMAND_SLOTS.WORKSPACE_ACTIONS] } : {},
+  })
+  useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  useHostStore.setState({
+    hosts: { h1: { id: 'h1', name: 'mlab', ip: '100.64.0.2', port: 7860, order: 0 } },
+    hostOrder: ['h1'],
+    runtime: { h1: { status: 'connected' } },
+    activeHostId: 'h1',
+  } as Partial<ReturnType<typeof useHostStore.getState>> as never)
+  // workspace has a tmux-session tab so inferWorkspaceHostId returns 'h1' (no picker prompt)
+  useTabStore.setState({
+    tabs: {
+      t1: {
+        id: 't1', pinned: false, locked: false, createdAt: 0,
+        layout: {
+          type: 'leaf',
+          pane: {
+            id: 'p1',
+            content: {
+              kind: 'tmux-session', hostId: 'h1', sessionCode: 'sess', mode: 'terminal',
+              cachedName: 'x', tmuxInstance: '',
+            },
+          },
+        },
+      },
+    },
+    tabOrder: ['t1'],
+    activeTabId: 't1',
+  } as Partial<ReturnType<typeof useTabStore.getState>> as never)
+  useLayoutStore.setState({
+    ...useLayoutStore.getInitialState(),
+    tabPosition: 'left',
+    activityBarWidth: 'wide',
+  })
+  clearModuleRegistry()
+  registerModule({ id: 'quick-commands', name: 'Quick Commands', disableable: true })
+}
+
+// Props 依 WorkspaceRow.tsx Props 介面 (L11-24) 對齊
+const hoverBaseProps: React.ComponentProps<typeof WorkspaceRow> = {
+  workspace: { id: 'w1', name: 'WS', tabs: ['t1'], activeTabId: 't1' },
+  isActive: false,
+  tabsById: {
+    t1: {
+      id: 't1', pinned: false, locked: false, createdAt: 0,
+      layout: {
+        type: 'leaf' as const,
+        pane: {
+          id: 'p1',
+          content: {
+            kind: 'tmux-session' as const, hostId: 'h1', sessionCode: 'sess', mode: 'terminal' as const,
+            cachedName: 'x', tmuxInstance: '',
+          },
+        },
+      },
+    } as Tab,
+  },
+  activeTabId: 't1',
+  onSelectWorkspace: vi.fn(),
+  onContextMenuWorkspace: vi.fn(),
+  onSelectTab: vi.fn(),
+  onCloseTab: vi.fn(),
+  onMiddleClickTab: vi.fn(),
+  onContextMenuTab: vi.fn(),
+  onRenameTab: vi.fn(),
+  onAddTabToWorkspace: vi.fn(),
+}
+
+describe("WorkspaceRow — Plus hover popover (Phase 1b')", () => {
+  beforeEach(() => {
+    cleanup()
+    setupHoverPopoverFixtures({ withBindings: true })
+  })
+
+  it('opens popover on Plus hover, closes on mouseleave', () => {
+    render(<WorkspaceRow {...hoverBaseProps} />)
+    const plusBtn = screen.getByLabelText(/new tab in/i)
+    const hub = plusBtn.parentElement!
+
+    // 預設未 hover → chip 不在 DOM
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+
+    // hover Plus → popover 顯示
+    fireEvent.mouseEnter(hub)
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+
+    // mouseleave wrapper → popover 收回
+    fireEvent.mouseLeave(hub)
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+  })
+
+  it('does NOT open popover when no WORKSPACE_ACTIONS bindings exist', () => {
+    setupHoverPopoverFixtures({ withBindings: false })
+    render(<WorkspaceRow {...hoverBaseProps} />)
+    const plusBtn = screen.getByLabelText(/new tab in/i)
+    fireEvent.mouseEnter(plusBtn.parentElement!)
+    // popover wrapper not rendered → no toolbar / no chip
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+  })
+})
+
+describe('WorkspaceRow — touch fallback (codex round-1 C17)', () => {
+  beforeEach(() => {
+    cleanup()
+    setupHoverPopoverFixtures({ withBindings: true })
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('long-press (>=500ms) on Plus opens the popover; tap chip executes', () => {
+    render(<WorkspaceRow {...hoverBaseProps} />)
+    const plusBtn = screen.getByLabelText(/new tab in/i)
+    const hub = plusBtn.parentElement!
+
+    // touch start → wait 500ms → long-press fires
+    fireEvent.touchStart(hub)
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+    fireEvent.touchEnd(hub)
+    // popover stays open (long-press fired)
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+  })
+
+  it('short tap (<500ms) on Plus triggers add-tab, NOT popover', () => {
+    const onAddTabToWorkspace = vi.fn()
+    render(<WorkspaceRow {...hoverBaseProps} onAddTabToWorkspace={onAddTabToWorkspace} />)
+    const plusBtn = screen.getByLabelText(/new tab in/i)
+
+    fireEvent.touchStart(plusBtn.parentElement!)
+    act(() => {
+      vi.advanceTimersByTime(200) // less than 500ms
+    })
+    fireEvent.touchEnd(plusBtn.parentElement!)
+    fireEvent.click(plusBtn)
+
+    expect(onAddTabToWorkspace).toHaveBeenCalledWith('w1')
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+  })
+
+  it('tapping outside the hub closes an open touch-popover', () => {
+    render(<WorkspaceRow {...hoverBaseProps} />)
+    const plusBtn = screen.getByLabelText(/new tab in/i)
+    const hub = plusBtn.parentElement!
+
+    fireEvent.touchStart(hub)
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+    fireEvent.touchEnd(hub)
+
+    // tap outside the hub
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
   })
 })

--- a/spa/src/features/workspace/components/WorkspaceRow.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.test.tsx
@@ -342,6 +342,46 @@ describe("WorkspaceRow — Plus hover popover (Phase 1b')", () => {
     // popover wrapper not rendered → no toolbar / no chip
     expect(screen.queryByLabelText(/^X/)).toBeNull()
   })
+
+  // codex round-1 P2 (F3 — picker hover-dismissal). Without this guard the
+  // hub's mouseleave handler unconditionally collapsed the popover, taking the
+  // HostPickerPopover (rendered inside) down with it the moment the user
+  // moved the pointer toward a host option.
+  it('keeps popover up while picker is open; collapses after picker resolves outside hub', () => {
+    // Override fixture so workspace has no tmux-session tabs → hostId resolves
+    // to null → clicking a chip opens HostPickerPopover.
+    useTabStore.setState({
+      tabs: {},
+      tabOrder: [],
+      activeTabId: null,
+    } as Partial<ReturnType<typeof useTabStore.getState>> as never)
+    const props: React.ComponentProps<typeof WorkspaceRow> = {
+      ...hoverBaseProps,
+      workspace: { ...hoverBaseProps.workspace, tabs: [] },
+      tabsById: {},
+    }
+    render(<WorkspaceRow {...props} />)
+    const plusBtn = screen.getByLabelText(/new tab in/i)
+    const hub = plusBtn.parentElement!
+
+    fireEvent.mouseEnter(hub)
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText(/^X/))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    // mouseleave the hub while picker is up — popover MUST stay so the user
+    // can drift onto a host option without losing it.
+    fireEvent.mouseLeave(hub)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+
+    // select a host → picker resolves → onPickerOpenChange(false) →
+    // pointerInHubRef is false (we left earlier) → popover collapses.
+    fireEvent.click(screen.getByText(/mlab/))
+    expect(screen.queryByRole('listbox')).toBeNull()
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+  })
 })
 
 describe('WorkspaceRow — touch fallback (codex round-1 C17)', () => {

--- a/spa/src/features/workspace/components/WorkspaceRow.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.test.tsx
@@ -426,6 +426,41 @@ describe('WorkspaceRow — touch fallback (codex round-1 C17)', () => {
     expect(screen.queryByLabelText(/^X/)).toBeNull()
   })
 
+  // codex round-2 A2/F2 — long-press click suppression must be one-shot.
+  // Without resetting longPressFiredRef the synthetic click after touchend
+  // would leave the ref true, blocking every subsequent mouse / keyboard
+  // activation of Plus until another touchstart on the hub.
+  it('long-press → tap outside (close) → click Plus → onAddTabToWorkspace fires (suppressor cleared)', () => {
+    const onAddTabToWorkspace = vi.fn()
+    render(
+      <WorkspaceRow {...hoverBaseProps} onAddTabToWorkspace={onAddTabToWorkspace} />,
+    )
+    const plusBtn = screen.getByLabelText(/new tab in/i)
+    const hub = plusBtn.parentElement!
+
+    // 1. long-press → popover open
+    fireEvent.touchStart(hub)
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(screen.getByLabelText(/^X/)).toBeInTheDocument()
+    fireEvent.touchEnd(hub)
+
+    // 2. simulate the synthetic compatibility click that browsers fire after
+    // touchstart/touchend: hits Plus, but onClick should suppress add-tab AND
+    // clear the suppressor.
+    fireEvent.click(plusBtn)
+    expect(onAddTabToWorkspace).not.toHaveBeenCalled()
+
+    // 3. tap outside to dismiss popover (also clears via the popoverOpen useEffect).
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByLabelText(/^X/)).toBeNull()
+
+    // 4. click Plus again with a real mouse → MUST trigger add-tab now.
+    fireEvent.click(plusBtn)
+    expect(onAddTabToWorkspace).toHaveBeenCalledWith('w1')
+  })
+
   it('tapping outside the hub closes an open touch-popover', () => {
     render(<WorkspaceRow {...hoverBaseProps} />)
     const plusBtn = screen.getByLabelText(/new tab in/i)

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -106,6 +106,18 @@ export function WorkspaceRow(props: Props) {
     }
   }, [])
 
+  // codex round-2 A2/F2 — clear the long-press click suppressor whenever the
+  // popover collapses. Without this the ref stays true after long-press → tap
+  // outside → next mouse/keyboard activation of Plus is silently dropped.
+  // (We also clear it inline in onClick when we actually consume the
+  // compatibility click; this useEffect catches the case where the browser
+  // skips the synthetic click entirely.)
+  useEffect(() => {
+    if (!popoverOpen) {
+      longPressFiredRef.current = false
+    }
+  }, [popoverOpen])
+
   // Document-level pointerdown closes touch-popover when user taps outside hub.
   // codex round-1 P2 (F3) — but NOT while the host picker is open; the picker
   // is positioned outside the hub DOM and a pointerdown on a host option would
@@ -217,6 +229,9 @@ export function WorkspaceRow(props: Props) {
               onClick={(e) => {
                 // codex round-1 C17 — touch → click compat: if long-press fired, suppress click.
                 if (longPressFiredRef.current) {
+                  // codex round-2 A2 — one-shot suppressor: clear immediately
+                  // so the next mouse/keyboard activation isn't also dropped.
+                  longPressFiredRef.current = false
                   e.preventDefault()
                   e.stopPropagation()
                   return

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { CaretRight, CaretDown, Plus } from '@phosphor-icons/react'
 import { useDroppable } from '@dnd-kit/core'
 import { useSortable } from '@dnd-kit/sortable'
@@ -59,6 +59,25 @@ export function WorkspaceRow(props: Props) {
 
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const longPressFiredRef = useRef(false)
+  // codex round-1 P2 (F3 — picker hover-dismissal). When the popover's internal
+  // HostPickerPopover is up we must NOT collapse the hub on mouseleave /
+  // pointerdown — otherwise moving the pointer toward a host option unmounts
+  // the popover (and the picker with it) before the user can click. Tracked
+  // via refs because mouseleave/pointerdown handlers fire from event listeners
+  // whose closures snapshot stale state.
+  const pickerOpenRef = useRef(false)
+  const pointerInHubRef = useRef(false)
+  const handlePickerOpenChange = useCallback((open: boolean) => {
+    const wasOpen = pickerOpenRef.current
+    pickerOpenRef.current = open
+    // Only collapse on the open → closed transition. Initial mount notifies
+    // false (and so does the unmount cleanup); collapsing on that would shut
+    // the popover the moment it opens, especially on touch where mouseEnter
+    // never fires and pointerInHubRef stays false.
+    if (wasOpen && !open && !pointerInHubRef.current) {
+      setPopoverOpen(false)
+    }
+  }, [])
 
   const handleTouchStart = () => {
     longPressFiredRef.current = false
@@ -88,9 +107,13 @@ export function WorkspaceRow(props: Props) {
   }, [])
 
   // Document-level pointerdown closes touch-popover when user taps outside hub.
+  // codex round-1 P2 (F3) — but NOT while the host picker is open; the picker
+  // is positioned outside the hub DOM and a pointerdown on a host option would
+  // otherwise close the popover before the picker's own onSelect handler fires.
   useEffect(() => {
     if (!popoverOpen) return
     const onPointer = (e: PointerEvent) => {
+      if (pickerOpenRef.current) return
       if (!hubRef.current?.contains(e.target as Node | null)) {
         setPopoverOpen(false)
       }
@@ -163,12 +186,23 @@ export function WorkspaceRow(props: Props) {
           <div
             ref={hubRef}
             className="relative inline-flex"
-            onMouseEnter={() => setPopoverOpen(true)}
-            onMouseLeave={() => setPopoverOpen(false)}
+            onMouseEnter={() => {
+              pointerInHubRef.current = true
+              setPopoverOpen(true)
+            }}
+            onMouseLeave={() => {
+              pointerInHubRef.current = false
+              // codex round-1 P2 (F3) — keep popover up while picker is open so
+              // the user can drift the pointer onto a host option without it
+              // disappearing.
+              if (pickerOpenRef.current) return
+              setPopoverOpen(false)
+            }}
             onFocusCapture={() => setPopoverOpen(true)}
             onBlurCapture={(e) => {
               // Only close if focus actually left the hub (chip→chip Tab keeps focus inside).
               if (!hubRef.current?.contains(e.relatedTarget as Node | null)) {
+                if (pickerOpenRef.current) return
                 setPopoverOpen(false)
               }
             }}
@@ -196,7 +230,11 @@ export function WorkspaceRow(props: Props) {
               <Plus size={12} />
             </button>
             {popoverOpen && (
-              <WorkspaceQuickActionsPopover workspaceId={workspace.id} hostId={hostId} />
+              <WorkspaceQuickActionsPopover
+                workspaceId={workspace.id}
+                hostId={hostId}
+                onPickerOpenChange={handlePickerOpenChange}
+              />
             )}
           </div>
         )}

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react'
 import { CaretRight, CaretDown, Plus } from '@phosphor-icons/react'
 import { useDroppable } from '@dnd-kit/core'
 import { useSortable } from '@dnd-kit/sortable'
@@ -5,8 +6,11 @@ import { CSS } from '@dnd-kit/utilities'
 import type { Workspace, Tab } from '../../../types/tab'
 import { useLayoutStore } from '../../../stores/useLayoutStore'
 import { useI18nStore } from '../../../stores/useI18nStore'
+import { useTabStore } from '../../../stores/useTabStore'
+import { inferWorkspaceHostId } from '../../../lib/infer-workspace-host-id'
 import { WorkspaceIcon } from './WorkspaceIcon'
 import { InlineTabList } from './InlineTabList'
+import { WorkspaceQuickActionsPopover } from './WorkspaceQuickActionsPopover'
 
 interface Props {
   workspace: Workspace
@@ -43,6 +47,57 @@ export function WorkspaceRow(props: Props) {
   const toggleExpanded = useLayoutStore((s) => s.toggleWorkspaceExpanded)
   const tabPosition = useLayoutStore((s) => s.tabPosition)
   const showTabs = tabPosition !== 'top'
+
+  // Phase 1b' — Plus hover popover state + touch fallback (codex round-1 C17).
+  // hostId resolves via inferWorkspaceHostId (spec v4 §3.2.1 majority vote, no
+  // activeHostId fallback). Subscribing to tabsMap so hostId reacts to layout
+  // changes (e.g. user opens / closes a tmux pane).
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  const hubRef = useRef<HTMLDivElement>(null)
+  const tabsMap = useTabStore((s) => s.tabs)
+  const hostId = inferWorkspaceHostId(workspace, tabsMap)
+
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const longPressFiredRef = useRef(false)
+
+  const handleTouchStart = () => {
+    longPressFiredRef.current = false
+    longPressTimerRef.current = setTimeout(() => {
+      longPressFiredRef.current = true
+      setPopoverOpen(true)
+    }, 500)
+  }
+  const handleTouchEnd = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current)
+      longPressTimerRef.current = null
+    }
+    // long-press fired → user is now interacting with popover; do NOT trigger add-tab onClick.
+  }
+
+  // Cleanup any pending timer on unmount so we don't fire setPopoverOpen on a
+  // disposed component (silent in React 18 but a real bug if the component
+  // re-mounts at the same workspace.id).
+  useEffect(() => {
+    return () => {
+      if (longPressTimerRef.current) {
+        clearTimeout(longPressTimerRef.current)
+        longPressTimerRef.current = null
+      }
+    }
+  }, [])
+
+  // Document-level pointerdown closes touch-popover when user taps outside hub.
+  useEffect(() => {
+    if (!popoverOpen) return
+    const onPointer = (e: PointerEvent) => {
+      if (!hubRef.current?.contains(e.target as Node | null)) {
+        setPopoverOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', onPointer)
+    return () => document.removeEventListener('pointerdown', onPointer)
+  }, [popoverOpen])
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: workspace.id,
@@ -105,19 +160,45 @@ export function WorkspaceRow(props: Props) {
           </span>
         </button>
         {showTabs && (
-          <button
-            type="button"
-            aria-label={t('nav.add_tab_to_workspace', { name: workspace.name })}
-            title={t('nav.add_tab_to_workspace', { name: workspace.name })}
-            onClick={(e) => {
-              e.stopPropagation()
-              onAddTabToWorkspace(workspace.id)
+          <div
+            ref={hubRef}
+            className="relative inline-flex"
+            onMouseEnter={() => setPopoverOpen(true)}
+            onMouseLeave={() => setPopoverOpen(false)}
+            onFocusCapture={() => setPopoverOpen(true)}
+            onBlurCapture={(e) => {
+              // Only close if focus actually left the hub (chip→chip Tab keeps focus inside).
+              if (!hubRef.current?.contains(e.relatedTarget as Node | null)) {
+                setPopoverOpen(false)
+              }
             }}
-            onPointerDown={(e) => e.stopPropagation()}
-            className="p-0.5 rounded hover:bg-surface-secondary hover:text-text-primary cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity focus:outline-none"
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+            onTouchCancel={handleTouchEnd}
           >
-            <Plus size={12} />
-          </button>
+            <button
+              type="button"
+              aria-label={t('nav.add_tab_to_workspace', { name: workspace.name })}
+              title={t('nav.add_tab_to_workspace', { name: workspace.name })}
+              onClick={(e) => {
+                // codex round-1 C17 — touch → click compat: if long-press fired, suppress click.
+                if (longPressFiredRef.current) {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  return
+                }
+                e.stopPropagation()
+                onAddTabToWorkspace(workspace.id)
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="p-0.5 rounded hover:bg-surface-secondary hover:text-text-primary cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity focus:outline-none"
+            >
+              <Plus size={12} />
+            </button>
+            {popoverOpen && (
+              <WorkspaceQuickActionsPopover workspaceId={workspace.id} hostId={hostId} />
+            )}
+          </div>
         )}
         {showTabs && (
           <button


### PR DESCRIPTION
## Summary

Phase 1b' of [Quick Commands v2](docs/superpowers/specs/2026-04-27-quick-commands-v2-design.md) — adds the **Plus-button hover popover** entry-point for `WORKSPACE_ACTIONS` chips on each `WorkspaceRow` in the sidebar, with a **mobile/touch long-press fallback**.

- Desktop: hover (or keyboard focus) on the Plus button → chip popover unfolds to the LEFT of the button. Mouseleave / blur the wrapper hub → popover collapses.
- Mobile/touch: long-press (≥500ms) on Plus → popover latches open; release-then-tap a chip executes. Short tap (<500ms) → original add-tab behavior unchanged. Tapping outside the hub closes the popover.
- Wires `runWorkspaceSlot` with the **#690 enforcement pattern** (alpha.242): `assertContextLive` is type-level required; passes a workspace-liveness probe so executor fails-closed if the workspace is destroyed mid-flight (e.g. mouseleave unmounts popover during createSession).
- Picker resolver cleanup on unmount resolves any pending Promise to `null` — executor's await returns and busy state clears (codex round-2 dangling-Promise guard).

Marked as **transitional** entry-point — packaged as a stand-alone PR so it can be reverted/replaced later without touching the stable Phase 1b foundation (data layer / Settings UI / context menu).

## Spec & Plan

- Spec §3.2.2 (HostPickerPopover lifecycle), §3.2.1 (`inferWorkspaceHostId` majority-vote), §3.3.1 (#690 type-level required `assertContextLive`)
- Plan §Phase 1b' (lines 3685–4313)

## Files

| File | Change |
|---|---|
| `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.tsx` | new (140 lines) — popover wrapper, hostId-null picker flow, picker unmount cleanup, `assertContextLive` wired |
| `spa/src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx` | new (77 lines, 6 tests) — chips render / null hostId / no bindings / module disabled / picker open on click / unmount cleanup |
| `spa/src/features/workspace/components/WorkspaceRow.tsx` | +103 lines — Plus button wrapped in hover/focus/touch hub; long-press timer + onClick suppress; document pointerdown close |
| `spa/src/features/workspace/components/WorkspaceRow.test.tsx` | +179 lines (5 new tests) — hover open/close × 2 + touch long-press / short-tap / outside-tap × 3 |

## Test plan

- [x] `cd spa && npx vitest run src/features/workspace/components/WorkspaceQuickActionsPopover.test.tsx src/features/workspace/components/WorkspaceRow.test.tsx` → 30/30 pass
- [x] `cd spa && npx vitest run` → 2978/2982 pass (4 pre-existing failures from #674 — `hosts.test.ts` × 3 + `TabBar.test.tsx` × 1; not introduced here)
- [x] `cd spa && pnpm run lint` → clean
- [x] `cd spa && pnpm run build` → clean
- [ ] Manual smoke (reviewer / merger to verify):
  - Desktop: Settings → Quick Commands → bind a command to Workspace mount → sidebar workspace row → hover Plus → popover unfolds left → click chip → session created + cmd sent
  - Mobile: long-press Plus on iOS Safari / Android Chrome (`https://*.mlab.host:5174`) → popover latches open after release → tap chip executes
  - Edge: mouseleave hub mid-execute (workspace destroyed) → executor fails-closed via `assertContextLive`, no orphan tab

## Deviations from plan

- Tests use `getByLabelText(/new tab in/i)` to match the actual i18n key `nav.add_tab_to_workspace = "New tab in {name}"` (plan example used `/Add tab to/i`)
- `WorkspaceRow.test.tsx` fixtures set `tabPosition: 'left'` + `activityBarWidth: 'wide'` to satisfy `showTabs` precondition for hub rendering
- Replaced `<WorkspaceRow {...(baseProps as never)} />` cast pattern with explicit `React.ComponentProps<typeof WorkspaceRow>` annotation (`tsc -b` strictness)
- `WorkspaceQuickActionsPopover.hasBindings` selector uses `getBindingTargets` (own-property guard against prototype pollution) for consistency with `CommandSlot`