### PR TITLE
feat(spa+daemon): file-not-found popup with three-layer fallback (P5)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -24,6 +25,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
@@ -37,6 +42,7 @@ golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
 golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/cc/v4 v4.27.1 h1:9W30zRlYrefrDV2JE2O8VDtJ1yPGownxciz5rrbQZis=

--- a/internal/module/fs/handler_test.go
+++ b/internal/module/fs/handler_test.go
@@ -51,8 +51,16 @@ func TestModuleMetadata(t *testing.T) {
 		t.Fatalf("Name() = %q, want %q", got, "fs")
 	}
 
-	if deps := m.Dependencies(); deps != nil {
-		t.Fatalf("Dependencies() = %v, want nil", deps)
+	deps := m.Dependencies()
+	found := false
+	for _, d := range deps {
+		if d == "session" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Dependencies() = %v, want to include %q", deps, "session")
 	}
 }
 

--- a/internal/module/fs/module.go
+++ b/internal/module/fs/module.go
@@ -33,6 +33,7 @@ func (m *FsModule) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/fs/mkdir", m.handleMkdir)
 	mux.HandleFunc("POST /api/fs/delete", m.handleDelete)
 	mux.HandleFunc("POST /api/fs/rename", m.handleRename)
+	mux.HandleFunc("POST /api/fs/search", m.handleSearch)
 }
 
 func (m *FsModule) Start(_ context.Context) error {

--- a/internal/module/fs/module.go
+++ b/internal/module/fs/module.go
@@ -6,15 +6,24 @@ import (
 	"net/http"
 
 	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/session"
 )
 
-type FsModule struct{}
+// FsModule exposes filesystem endpoints (list/read/write/stat/mkdir/delete/rename/search).
+// `sessions` is required by handleSearch to resolve `kind: "session-cwd"` capability roots.
+type FsModule struct {
+	sessions session.SessionProvider
+}
 
 func New() *FsModule { return &FsModule{} }
 
 func (m *FsModule) Name() string           { return "fs" }
-func (m *FsModule) Dependencies() []string { return nil }
-func (m *FsModule) Init(_ *core.Core) error { return nil }
+func (m *FsModule) Dependencies() []string { return []string{"session"} }
+
+func (m *FsModule) Init(c *core.Core) error {
+	m.sessions = c.Registry.MustGet(session.RegistryKey).(session.SessionProvider)
+	return nil
+}
 
 func (m *FsModule) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/fs/list", m.handleList)

--- a/internal/module/fs/module_test.go
+++ b/internal/module/fs/module_test.go
@@ -1,0 +1,72 @@
+package fs
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/session"
+)
+
+// fakeSessionProvider is a stub implementation of session.SessionProvider for
+// fs module tests that need to resolve session-cwd capability roots.
+type fakeSessionProvider struct {
+	sessions map[string]*session.SessionInfo
+}
+
+func newFakeSessionProvider() *fakeSessionProvider {
+	return &fakeSessionProvider{sessions: map[string]*session.SessionInfo{}}
+}
+
+func (f *fakeSessionProvider) ListSessions() ([]session.SessionInfo, error) {
+	out := make([]session.SessionInfo, 0, len(f.sessions))
+	for _, s := range f.sessions {
+		out = append(out, *s)
+	}
+	return out, nil
+}
+
+func (f *fakeSessionProvider) GetSession(code string) (*session.SessionInfo, error) {
+	if s, ok := f.sessions[code]; ok {
+		return s, nil
+	}
+	return nil, nil
+}
+
+func (f *fakeSessionProvider) UpdateMeta(_ string, _ session.MetaUpdate) error { return nil }
+
+func (f *fakeSessionProvider) HandleTerminalWS(_ http.ResponseWriter, _ *http.Request, _ string) {
+}
+
+func (f *fakeSessionProvider) setCwd(code, cwd string) {
+	f.sessions[code] = &session.SessionInfo{Code: code, Cwd: cwd, Exists: true}
+}
+
+func newTestFsModule(t *testing.T, provider session.SessionProvider) *FsModule {
+	t.Helper()
+	c := core.New(core.CoreDeps{
+		Registry: core.NewServiceRegistry(),
+	})
+	if provider != nil {
+		c.Registry.Register(session.RegistryKey, provider)
+	}
+	m := New()
+	require.NoError(t, m.Init(c))
+	return m
+}
+
+func TestFsModule_InitGetsSessionProvider(t *testing.T) {
+	provider := newFakeSessionProvider()
+	m := newTestFsModule(t, provider)
+	require.NotNil(t, m.sessions, "sessions provider should be set after Init")
+	assert.Same(t, session.SessionProvider(provider), m.sessions)
+}
+
+func TestFsModule_DependenciesIncludeSession(t *testing.T) {
+	m := New()
+	deps := m.Dependencies()
+	assert.Contains(t, deps, "session", "fs depends on session for capability root resolution")
+}

--- a/internal/module/fs/search_engine.go
+++ b/internal/module/fs/search_engine.go
@@ -1,0 +1,305 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	gitignore "github.com/sabhiram/go-gitignore"
+)
+
+// SearchRequest is the daemon-internal shape (after handler resolves
+// capabilities). The HTTP handler in search_handler.go is responsible for
+// mapping client capability roots to absolute paths; the engine itself never
+// validates the trust of the supplied paths — that is a layer-2 concern.
+type SearchRequest struct {
+	Mode    string
+	Query   SearchQuery
+	Roots   []SearchRoot
+	Limits  SearchLimits
+	Filters SearchFilters
+}
+
+type SearchQuery struct {
+	Basename string
+}
+
+// SearchRoot is an already-resolved absolute path on the local filesystem.
+// `Kind` is retained for telemetry / logging so we can tell whether the path
+// originally came from `session-cwd`, `workspace-projectPath`, or a test-only
+// raw path.
+type SearchRoot struct {
+	Kind     string
+	Absolute string
+}
+
+type SearchLimits struct {
+	MaxResults int
+	MaxDepth   int
+}
+
+// SearchFilters carry caller-supplied filters. Mandatory excludes are union'd
+// on top of these and CANNOT be disabled by sending empty arrays.
+//
+// RespectGitignore is a *bool so that an omitted JSON field maps to nil rather
+// than Go's `false` zero value — `nil` is treated as "default true". This
+// closes the fail-open hole called out in attacker review #10.
+type SearchFilters struct {
+	ExcludeDirs          []string
+	ExcludeBasenameGlobs []string
+	RespectGitignore     *bool
+}
+
+type SearchMatch struct {
+	Path      string    `json:"path"`
+	ModTime   time.Time `json:"modTime"`
+	SizeBytes int64     `json:"sizeBytes"`
+	Root      string    `json:"root"`
+}
+
+type SearchResponse struct {
+	Matches  []SearchMatch `json:"matches"`
+	Partial  bool          `json:"partial"`
+	Warnings []string      `json:"warnings,omitempty"`
+}
+
+const (
+	defaultSearchMaxResults = 50
+	defaultSearchMaxDepth   = 8
+	hardCapMaxResults       = 200
+
+	// rawAbsoluteTestOnly is a SearchRoot.Kind used by unit tests that want
+	// to hand the engine a raw absolute path. Production callers (the HTTP
+	// handler) never produce roots with this kind — they always go through
+	// capability resolution.
+	rawAbsoluteTestOnly = "raw-absolute-test-only"
+)
+
+// mandatoryExcludeDirs are dir basenames the engine ALWAYS prunes, regardless
+// of caller input. Union'd with SearchFilters.ExcludeDirs. (attacker review
+// #10 — sending [] cannot defeat them.)
+var mandatoryExcludeDirs = []string{
+	"node_modules",
+	".git",
+	".cache",
+	"dist",
+	".pnpm-store",
+	".next",
+	".turbo",
+}
+
+// mandatoryExcludeBasenameGlobs are file basename globs the engine ALWAYS
+// rejects. Union'd with SearchFilters.ExcludeBasenameGlobs.
+var mandatoryExcludeBasenameGlobs = []string{
+	"*.lock",
+	"*.log",
+}
+
+// ErrGitignoreParse signals that a .gitignore in one of the search roots could
+// not be parsed; the HTTP handler maps this to 4xx so we never silently
+// fail-open. (attacker review #11.)
+var ErrGitignoreParse = errors.New("gitignore parse failure")
+
+// Search executes a synchronous filesystem search across the resolved roots.
+// `ctx` is honoured for cancellation/timeout — partial=true is set when the
+// walk is cut short by either the deadline, a result-count cap, or context
+// cancellation.
+//
+// The engine is a pure function: it does not consult any state outside `req`,
+// `os`, and `ctx`, and it does not validate trust on `req.Roots` (that is the
+// HTTP handler's job — see search_handler.go).
+func Search(ctx context.Context, req SearchRequest) (SearchResponse, error) {
+	if req.Mode == "" {
+		req.Mode = "basename"
+	}
+	if req.Mode != "basename" {
+		return SearchResponse{}, errors.New("unsupported search mode: " + req.Mode)
+	}
+	if req.Query.Basename == "" {
+		return SearchResponse{}, errors.New("query.basename required")
+	}
+	if req.Limits.MaxResults <= 0 {
+		req.Limits.MaxResults = defaultSearchMaxResults
+	}
+	if req.Limits.MaxResults > hardCapMaxResults {
+		req.Limits.MaxResults = hardCapMaxResults
+	}
+	if req.Limits.MaxDepth <= 0 {
+		req.Limits.MaxDepth = defaultSearchMaxDepth
+	}
+
+	excludeDirs := make(map[string]struct{}, len(mandatoryExcludeDirs)+len(req.Filters.ExcludeDirs))
+	for _, d := range mandatoryExcludeDirs {
+		excludeDirs[d] = struct{}{}
+	}
+	for _, d := range req.Filters.ExcludeDirs {
+		if d != "" {
+			excludeDirs[d] = struct{}{}
+		}
+	}
+	excludeGlobs := make([]string, 0, len(mandatoryExcludeBasenameGlobs)+len(req.Filters.ExcludeBasenameGlobs))
+	excludeGlobs = append(excludeGlobs, mandatoryExcludeBasenameGlobs...)
+	excludeGlobs = append(excludeGlobs, req.Filters.ExcludeBasenameGlobs...)
+
+	respectGI := true
+	if req.Filters.RespectGitignore != nil {
+		respectGI = *req.Filters.RespectGitignore
+	}
+
+	matches := make([]SearchMatch, 0, req.Limits.MaxResults)
+	partial := false
+
+	for _, root := range req.Roots {
+		var gi *gitignore.GitIgnore
+		if respectGI {
+			gp := filepath.Join(root.Absolute, ".gitignore")
+			if data, err := os.ReadFile(gp); err == nil {
+				if perr := preflightGitignore(string(data)); perr != nil {
+					return SearchResponse{}, perr
+				}
+				gi = gitignore.CompileIgnoreLines(strings.Split(string(data), "\n")...)
+			}
+			// Missing .gitignore is fine — nothing to filter.
+		}
+
+		walkErr := filepath.WalkDir(root.Absolute, func(path string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				// Skip unreadable entries rather than aborting the whole walk.
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			rel, relErr := filepath.Rel(root.Absolute, path)
+			if relErr != nil {
+				return nil
+			}
+			depth := 0
+			if rel != "." {
+				depth = strings.Count(rel, string(os.PathSeparator))
+			}
+
+			if d.IsDir() {
+				// Mandatory + caller dir excludes by basename.
+				if path != root.Absolute {
+					if _, skip := excludeDirs[d.Name()]; skip {
+						return filepath.SkipDir
+					}
+				}
+				// Gitignore prune — note the trailing slash so dir-only patterns match.
+				if gi != nil && rel != "." && gi.MatchesPath(rel+"/") {
+					return filepath.SkipDir
+				}
+				if depth > req.Limits.MaxDepth {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			// File: depth check first.
+			if depth > req.Limits.MaxDepth {
+				return nil
+			}
+
+			// Mandatory + caller basename glob excludes.
+			for _, glob := range excludeGlobs {
+				if ok, _ := filepath.Match(glob, d.Name()); ok {
+					return nil
+				}
+			}
+			if gi != nil && gi.MatchesPath(rel) {
+				return nil
+			}
+			if d.Name() != req.Query.Basename {
+				return nil
+			}
+
+			info, err := d.Info()
+			if err != nil {
+				return nil
+			}
+			matches = append(matches, SearchMatch{
+				Path:      path,
+				ModTime:   info.ModTime(),
+				SizeBytes: info.Size(),
+				Root:      root.Absolute,
+			})
+			if len(matches) >= req.Limits.MaxResults {
+				partial = true
+				return filepath.SkipAll
+			}
+			return nil
+		})
+		if errors.Is(walkErr, context.DeadlineExceeded) || errors.Is(walkErr, context.Canceled) {
+			partial = true
+			break
+		}
+		if walkErr != nil && !errors.Is(walkErr, filepath.SkipAll) {
+			// Any other walk failure surfaces; the engine doesn't know which
+			// classification applies.
+			return SearchResponse{Matches: matches, Partial: partial}, walkErr
+		}
+		if partial {
+			break
+		}
+	}
+
+	sort.Slice(matches, func(i, j int) bool { return matches[i].ModTime.After(matches[j].ModTime) })
+	return SearchResponse{Matches: matches, Partial: partial}, nil
+}
+
+// preflightGitignore performs a minimal sanity check on .gitignore contents
+// because go-gitignore silently swallows lines whose generated regex fails to
+// compile. This pre-pass walks each non-empty / non-comment pattern and
+// rejects unbalanced character classes — the failure mode the daemon must NOT
+// silently fall back from. See attacker review #11.
+//
+// The check is intentionally conservative: it is permitted to false-positive
+// on the simplest unbalanced-bracket case and skip everything else. Any line
+// the gitignore library would also have silently dropped is something we want
+// to surface as ErrGitignoreParse.
+func preflightGitignore(content string) error {
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Strip leading negate so we examine the actual pattern.
+		if strings.HasPrefix(line, "!") {
+			line = line[1:]
+		}
+		if !bracketsBalanced(line) {
+			return ErrGitignoreParse
+		}
+	}
+	return nil
+}
+
+// bracketsBalanced returns false if the line has an unbalanced `[`/`]`
+// character class. It honours backslash escapes so that `foo\[bar` still
+// counts as balanced.
+func bracketsBalanced(s string) bool {
+	open := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			if i+1 < len(s) {
+				i++ // skip the escaped char
+			}
+		case '[':
+			open++
+		case ']':
+			if open > 0 {
+				open--
+			}
+			// stray closing brackets are tolerated by go-gitignore, ignore.
+		}
+	}
+	return open == 0
+}

--- a/internal/module/fs/search_engine_test.go
+++ b/internal/module/fs/search_engine_test.go
@@ -280,6 +280,143 @@ func TestSearchEngine_RequiresBasenameQuery(t *testing.T) {
 	}
 }
 
+func TestSearchEngine_GitignoreSelfSymlinkParseFailure(t *testing.T) {
+	// .gitignore with a multi-line unbalanced character class — confirms the
+	// preflight catches it even when later lines are valid.
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".gitignore"), "# preamble\n*.go\n[bad-pattern\n*.txt\n")
+	mustWrite(t, filepath.Join(dir, "kept.go"), "ok")
+	req := SearchRequest{
+		Mode:  "basename",
+		Query: SearchQuery{Basename: "kept.go"},
+		Roots: []SearchRoot{rawRoot(dir)},
+	}
+	_, err := Search(context.Background(), req)
+	if !errors.Is(err, ErrGitignoreParse) {
+		t.Errorf("expected ErrGitignoreParse for embedded bad pattern, got %v", err)
+	}
+}
+
+func TestSearchEngine_GitignoreNegationStillRespected(t *testing.T) {
+	// go-gitignore docs note negation TODO; this test is a behavioural
+	// snapshot — if the upstream lib later starts honouring `!`, this test
+	// will need updating, but it confirms today's behaviour does not silently
+	// crash.
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".gitignore"), "*.go\n!keep.go\n")
+	mustWrite(t, filepath.Join(dir, "skip.go"), "")
+	mustWrite(t, filepath.Join(dir, "keep.go"), "")
+	req := SearchRequest{
+		Mode:  "basename",
+		Query: SearchQuery{Basename: "keep.go"},
+		Roots: []SearchRoot{rawRoot(dir)},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	// We do not assert match presence — go-gitignore negation is best-effort
+	// upstream. This test only proves no crash + no error.
+	_ = resp
+}
+
+func TestSearchEngine_GitignoreOnlyRootLevelEvaluated(t *testing.T) {
+	// Engine intentionally only loads <root>/.gitignore — nested .gitignore
+	// files are NOT recursively evaluated. This is a documented limitation
+	// matching the 5.1a engine design.
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".gitignore"), "*.tmp\n")
+	mustWrite(t, filepath.Join(dir, "sub", ".gitignore"), "foo.go\n")
+	mustWrite(t, filepath.Join(dir, "sub", "foo.go"), "ok")
+	req := SearchRequest{
+		Mode:  "basename",
+		Query: SearchQuery{Basename: "foo.go"},
+		Roots: []SearchRoot{rawRoot(dir)},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Matches) != 1 {
+		t.Errorf("nested .gitignore must NOT prune sub/foo.go, got %+v", resp.Matches)
+	}
+}
+
+func TestSearchEngine_SymlinkOutsideRootNotFollowed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	outside := t.TempDir()
+	mustWrite(t, filepath.Join(outside, "secret.go"), "should not be visited via symlink")
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "kept.go"), "ok")
+	if err := os.Symlink(outside, filepath.Join(dir, "external")); err != nil {
+		t.Fatal(err)
+	}
+	req := SearchRequest{
+		Mode:  "basename",
+		Query: SearchQuery{Basename: "secret.go"},
+		Roots: []SearchRoot{rawRoot(dir)},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Matches) != 0 {
+		t.Errorf("symlink to outside dir must not be followed; got %+v", resp.Matches)
+	}
+}
+
+func TestSearchEngine_NestedSymlinkLoopDoesNotInfiniteWalk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	// dir/a → dir/a/b/loop → dir/a (cycle two levels deep).
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	mustWrite(t, filepath.Join(a, "b", "x.go"), "ok")
+	if err := os.Symlink(a, filepath.Join(a, "b", "loop")); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		req := SearchRequest{
+			Mode:   "basename",
+			Query:  SearchQuery{Basename: "x.go"},
+			Roots:  []SearchRoot{rawRoot(dir)},
+			Limits: SearchLimits{MaxDepth: 6, MaxResults: 100},
+		}
+		_, _ = Search(context.Background(), req)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("nested symlink loop caused hang")
+	}
+}
+
+func TestSearchEngine_CancelledContextStopsWalk(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 50; i++ {
+		mustWrite(t, filepath.Join(dir, fmt.Sprintf("d%02d", i), "foo.go"), "x")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before search starts
+	req := SearchRequest{
+		Mode:  "basename",
+		Query: SearchQuery{Basename: "foo.go"},
+		Roots: []SearchRoot{rawRoot(dir)},
+	}
+	resp, err := Search(ctx, req)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !resp.Partial {
+		t.Errorf("expected partial=true on cancelled ctx")
+	}
+}
+
 func TestSearchEngine_SymlinkLoopDoesNotInfiniteWalk(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink semantics differ on Windows")

--- a/internal/module/fs/search_engine_test.go
+++ b/internal/module/fs/search_engine_test.go
@@ -1,0 +1,311 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// mustWrite creates a file (and any missing parent directories) with the given
+// string content. Used by search_engine tests and search_handler tests.
+func mustWrite(t *testing.T, p, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// rawRoot is a small helper to build a SearchRoot pointing at an absolute path
+// for unit tests; production code never produces roots this way (capabilities
+// only).
+func rawRoot(abs string) SearchRoot {
+	return SearchRoot{Kind: rawAbsoluteTestOnly, Absolute: abs}
+}
+
+func TestSearchEngine_BasenameMatchInRoots(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "a", "foo.go"), "ok")
+	mustWrite(t, filepath.Join(dir, "b", "foo.go"), "ok")
+	mustWrite(t, filepath.Join(dir, "b", "bar.go"), "no")
+	req := SearchRequest{
+		Mode:   "basename",
+		Query:  SearchQuery{Basename: "foo.go"},
+		Roots:  []SearchRoot{rawRoot(dir)},
+		Limits: SearchLimits{MaxResults: 10},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Matches) != 2 {
+		t.Errorf("expected 2 matches, got %d (%+v)", len(resp.Matches), resp.Matches)
+	}
+}
+
+func TestSearchEngine_ExcludeDirsPrunesSubtree(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "node_modules", "x", "foo.go"), "skip")
+	mustWrite(t, filepath.Join(dir, "src", "foo.go"), "ok")
+	req := SearchRequest{
+		Mode:    "basename",
+		Query:   SearchQuery{Basename: "foo.go"},
+		Roots:   []SearchRoot{rawRoot(dir)},
+		Filters: SearchFilters{ExcludeDirs: []string{"src"}}, // user adds src; mandatory still apply
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// node_modules pruned (mandatory) + src pruned (user) → 0
+	if len(resp.Matches) != 0 {
+		t.Errorf("expected 0 matches, got %+v", resp.Matches)
+	}
+}
+
+func TestSearchEngine_MandatoryExcludesAlwaysApply(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "node_modules", "foo.go"), "skip")
+	mustWrite(t, filepath.Join(dir, "src", "foo.go"), "ok")
+	// 攻擊 review #10：client 傳 [] 不能關掉 mandatory excludes
+	req := SearchRequest{
+		Mode:    "basename",
+		Query:   SearchQuery{Basename: "foo.go"},
+		Roots:   []SearchRoot{rawRoot(dir)},
+		Filters: SearchFilters{ExcludeDirs: []string{}},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Matches) != 1 {
+		t.Errorf("expected 1 match (node_modules pruned by mandatory), got %+v", resp.Matches)
+	}
+}
+
+func TestSearchEngine_MandatoryBasenameGlobsAlwaysApply(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "pnpm-lock.lock"), "")
+	mustWrite(t, filepath.Join(dir, "kept.lock"), "") // both should be skipped
+	mustWrite(t, filepath.Join(dir, "ok.txt"), "")
+	req := SearchRequest{
+		Mode:  "basename",
+		Query: SearchQuery{Basename: "kept.lock"},
+		Roots: []SearchRoot{rawRoot(dir)},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Matches) != 0 {
+		t.Errorf("expected 0 matches (*.lock blocked by mandatory glob), got %+v", resp.Matches)
+	}
+}
+
+func TestSearchEngine_RespectGitignoreDefaultTrue(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".gitignore"), "build/\n")
+	mustWrite(t, filepath.Join(dir, "build", "foo.go"), "skip")
+	mustWrite(t, filepath.Join(dir, "src", "foo.go"), "ok")
+	// 攻擊 review #10：respectGitignore omitted → default true
+	req := SearchRequest{
+		Mode:    "basename",
+		Query:   SearchQuery{Basename: "foo.go"},
+		Roots:   []SearchRoot{rawRoot(dir)},
+		Filters: SearchFilters{}, // RespectGitignore is *bool nil → treated as true
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(resp.Matches) != 1 {
+		t.Errorf("expected 1 match (build pruned by gitignore), got %+v", resp.Matches)
+	}
+}
+
+func TestSearchEngine_GitignoreCanBeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".gitignore"), "ignored.go\n")
+	mustWrite(t, filepath.Join(dir, "ignored.go"), "now we look")
+	off := false
+	req := SearchRequest{
+		Mode:    "basename",
+		Query:   SearchQuery{Basename: "ignored.go"},
+		Roots:   []SearchRoot{rawRoot(dir)},
+		Filters: SearchFilters{RespectGitignore: &off},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Matches) != 1 {
+		t.Errorf("ignored.go should be returned when respectGitignore=false: %+v", resp.Matches)
+	}
+}
+
+func TestSearchEngine_GitignoreFiltersBasenameMatch(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".gitignore"), "ignored.go\n")
+	mustWrite(t, filepath.Join(dir, "ignored.go"), "skip")
+	mustWrite(t, filepath.Join(dir, "kept.go"), "ok")
+	req := SearchRequest{
+		Mode:  "basename",
+		Query: SearchQuery{Basename: "ignored.go"},
+		Roots: []SearchRoot{rawRoot(dir)},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(resp.Matches) != 0 {
+		t.Errorf("ignored.go should not appear when respectGitignore default true: %+v", resp.Matches)
+	}
+}
+
+func TestSearchEngine_GitignoreParseFailureReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	// Unbalanced character class — go-gitignore silently swallows the bad
+	// regex; our preflight catches it as ErrGitignoreParse.
+	mustWrite(t, filepath.Join(dir, ".gitignore"), "[invalid-bracket\n")
+	req := SearchRequest{
+		Mode:  "basename",
+		Query: SearchQuery{Basename: "foo.go"},
+		Roots: []SearchRoot{rawRoot(dir)},
+	}
+	_, err := Search(context.Background(), req)
+	// 攻擊 review #11：parse failure 不 fail-open — engine returns ErrGitignoreParse;
+	// handler maps to 4xx in 5.1b.
+	if err == nil {
+		t.Fatal("expected gitignore parse error to bubble (no fail-open)")
+	}
+	if !errors.Is(err, ErrGitignoreParse) {
+		t.Errorf("expected ErrGitignoreParse, got %v", err)
+	}
+}
+
+func TestSearchEngine_TimeoutReturnsPartial(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 200; i++ {
+		mustWrite(t, filepath.Join(dir, fmt.Sprintf("d%03d", i), "foo.go"), "x")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Microsecond)
+	defer cancel()
+	// Sleep so the deadline definitely passes before walking starts.
+	time.Sleep(2 * time.Millisecond)
+	req := SearchRequest{
+		Mode:  "basename",
+		Query: SearchQuery{Basename: "foo.go"},
+		Roots: []SearchRoot{rawRoot(dir)},
+	}
+	resp, err := Search(ctx, req)
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !resp.Partial {
+		t.Errorf("expected partial=true on timeout, matches=%d", len(resp.Matches))
+	}
+}
+
+func TestSearchEngine_MaxResultsCap(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 30; i++ {
+		mustWrite(t, filepath.Join(dir, fmt.Sprintf("d%02d", i), "foo.go"), "x")
+	}
+	req := SearchRequest{
+		Mode:   "basename",
+		Query:  SearchQuery{Basename: "foo.go"},
+		Roots:  []SearchRoot{rawRoot(dir)},
+		Limits: SearchLimits{MaxResults: 5},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Matches) != 5 {
+		t.Errorf("expected 5 matches (capped), got %d", len(resp.Matches))
+	}
+	if !resp.Partial {
+		t.Errorf("expected partial=true when result cap hit")
+	}
+}
+
+func TestSearchEngine_MaxDepthBoundary(t *testing.T) {
+	dir := t.TempDir()
+	// foo.go directly under root → depth 0; under a/ → depth 1; under a/b/ → 2.
+	mustWrite(t, filepath.Join(dir, "foo.go"), "0")
+	mustWrite(t, filepath.Join(dir, "a", "foo.go"), "1")
+	mustWrite(t, filepath.Join(dir, "a", "b", "foo.go"), "2")
+	mustWrite(t, filepath.Join(dir, "a", "b", "c", "foo.go"), "3")
+	req := SearchRequest{
+		Mode:   "basename",
+		Query:  SearchQuery{Basename: "foo.go"},
+		Roots:  []SearchRoot{rawRoot(dir)},
+		Limits: SearchLimits{MaxResults: 100, MaxDepth: 2},
+	}
+	resp, err := Search(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Files at depth 0, 1, 2 should be included; depth 3 excluded.
+	if len(resp.Matches) != 3 {
+		t.Errorf("expected 3 matches with maxDepth=2, got %d (%+v)", len(resp.Matches), resp.Matches)
+	}
+}
+
+func TestSearchEngine_RejectsUnknownMode(t *testing.T) {
+	_, err := Search(context.Background(), SearchRequest{
+		Mode:  "fuzzy",
+		Query: SearchQuery{Basename: "x"},
+		Roots: []SearchRoot{rawRoot(t.TempDir())},
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported mode")
+	}
+}
+
+func TestSearchEngine_RequiresBasenameQuery(t *testing.T) {
+	_, err := Search(context.Background(), SearchRequest{
+		Mode:  "basename",
+		Roots: []SearchRoot{rawRoot(t.TempDir())},
+	})
+	if err == nil {
+		t.Fatal("expected error when basename empty")
+	}
+}
+
+func TestSearchEngine_SymlinkLoopDoesNotInfiniteWalk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	mustWrite(t, filepath.Join(a, "x.go"), "ok")
+	// loop inside a/ that points back to a/. WalkDir does not follow symlinks
+	// so this should not cause infinite descent.
+	if err := os.Symlink(a, filepath.Join(a, "loop")); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		req := SearchRequest{
+			Mode:   "basename",
+			Query:  SearchQuery{Basename: "x.go"},
+			Roots:  []SearchRoot{rawRoot(dir)},
+			Limits: SearchLimits{MaxDepth: 6},
+		}
+		_, _ = Search(context.Background(), req)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("symlink loop caused hang")
+	}
+}

--- a/internal/module/fs/search_handler.go
+++ b/internal/module/fs/search_handler.go
@@ -145,7 +145,21 @@ func (m *FsModule) resolveCapabilityRoots(roots []httpSearchRoot) ([]SearchRoot,
 			if info == nil || info.Cwd == "" {
 				return nil, http.StatusBadRequest, errors.New("session cwd not found for " + r.SessionCode)
 			}
-			abs := filepath.Clean(info.Cwd)
+			// R2-H1: Resolve symlinks before walking so the allowlist runs
+			// against the *real* tree. We validate BOTH forms — cleaned (catches
+			// lexical attempts like `/etc`, even though macOS resolves it to
+			// `/private/etc`) and resolved (catches sneaky symlinks that point
+			// from a benign-looking `/tmp/...` into `$HOME` or other system
+			// roots). The walker walks the resolved path, so it's the ground
+			// truth for trust.
+			cleaned := filepath.Clean(info.Cwd)
+			if err := validateNotSystemPath(cleaned); err != nil {
+				return nil, http.StatusBadRequest, err
+			}
+			abs, err := filepath.EvalSymlinks(cleaned)
+			if err != nil {
+				return nil, http.StatusBadRequest, errors.New("session cwd unresolvable: " + err.Error())
+			}
 			if err := validateNotSystemPath(abs); err != nil {
 				return nil, http.StatusBadRequest, err
 			}

--- a/internal/module/fs/search_handler.go
+++ b/internal/module/fs/search_handler.go
@@ -1,0 +1,190 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// httpSearchRequest is the wire-format body accepted by POST /api/fs/search.
+// The handler converts this into the daemon-internal SearchRequest after
+// resolving capability roots.
+type httpSearchRequest struct {
+	Mode  string `json:"mode"`
+	Query struct {
+		Basename string `json:"basename"`
+	} `json:"query"`
+	Roots  []httpSearchRoot   `json:"roots"`
+	Limits *httpSearchLimits  `json:"limits,omitempty"`
+	Filters *httpSearchFilters `json:"filters,omitempty"`
+}
+
+type httpSearchRoot struct {
+	Kind        string `json:"kind"`
+	SessionCode string `json:"sessionCode,omitempty"`
+	WorkspaceID string `json:"workspaceId,omitempty"`
+}
+
+type httpSearchLimits struct {
+	MaxResults int `json:"maxResults,omitempty"`
+	MaxDepth   int `json:"maxDepth,omitempty"`
+	TimeoutMs  int `json:"timeoutMs,omitempty"`
+}
+
+type httpSearchFilters struct {
+	ExcludeDirs          []string `json:"excludeDirs,omitempty"`
+	ExcludeBasenameGlobs []string `json:"excludeBasenameGlobs,omitempty"`
+	RespectGitignore     *bool    `json:"respectGitignore,omitempty"`
+}
+
+// handleSearch is the canonical method handler for POST /api/fs/search.
+//
+// It accepts only capability-based roots. Absolute path roots, unknown kinds,
+// missing sessions, and resolved system paths (`/`, `/etc`, `/sys`, `/Users`,
+// `$HOME` direct) are all 4xx. The `workspace-projectPath` kind is currently
+// 501 — daemon lacks a workspace registry; this is layer-3 follow-up.
+func (m *FsModule) handleSearch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		jsonError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	limitBody(w, r, maxBodySize)
+
+	var body httpSearchRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.Mode == "" {
+		body.Mode = "basename"
+	}
+	if body.Mode != "basename" {
+		jsonError(w, "unsupported mode: "+body.Mode, http.StatusBadRequest)
+		return
+	}
+	if body.Query.Basename == "" {
+		jsonError(w, "query.basename required", http.StatusBadRequest)
+		return
+	}
+	if len(body.Roots) == 0 {
+		jsonError(w, "roots required", http.StatusBadRequest)
+		return
+	}
+
+	roots, status, err := m.resolveCapabilityRoots(body.Roots)
+	if err != nil {
+		jsonError(w, err.Error(), status)
+		return
+	}
+
+	req := SearchRequest{
+		Mode:  body.Mode,
+		Query: SearchQuery{Basename: body.Query.Basename},
+		Roots: roots,
+	}
+	if body.Limits != nil {
+		req.Limits = SearchLimits{MaxResults: body.Limits.MaxResults, MaxDepth: body.Limits.MaxDepth}
+	}
+	if body.Filters != nil {
+		req.Filters = SearchFilters{
+			ExcludeDirs:          body.Filters.ExcludeDirs,
+			ExcludeBasenameGlobs: body.Filters.ExcludeBasenameGlobs,
+			RespectGitignore:     body.Filters.RespectGitignore,
+		}
+	}
+
+	ctx := r.Context()
+	if body.Limits != nil && body.Limits.TimeoutMs > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(body.Limits.TimeoutMs)*time.Millisecond)
+		defer cancel()
+	}
+
+	resp, err := Search(ctx, req)
+	if errors.Is(err, ErrGitignoreParse) {
+		jsonError(w, "gitignore parse failure", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	jsonOK(w, resp)
+}
+
+// resolveCapabilityRoots maps client capability roots to absolute paths and
+// validates them against the system-path blocklist.
+//
+// Returns (roots, statusCode, error). statusCode is meaningful only on error.
+//
+// Rejects:
+//   - Unknown kinds (including `absolute`) → 400
+//   - Missing/empty session cwd → 400
+//   - System paths (`/`, `/etc`, `/sys`, `/Users` direct, `$HOME` direct) → 400
+//
+// Defers:
+//   - `workspace-projectPath` → 501 (layer-3 follow-up; daemon has no
+//     workspace registry yet).
+func (m *FsModule) resolveCapabilityRoots(roots []httpSearchRoot) ([]SearchRoot, int, error) {
+	out := make([]SearchRoot, 0, len(roots))
+	for _, r := range roots {
+		switch r.Kind {
+		case "session-cwd":
+			if r.SessionCode == "" {
+				return nil, http.StatusBadRequest, errors.New("sessionCode required for session-cwd root")
+			}
+			info, err := m.sessions.GetSession(r.SessionCode)
+			if err != nil {
+				return nil, http.StatusBadRequest, errors.New("session lookup failed: " + err.Error())
+			}
+			if info == nil || info.Cwd == "" {
+				return nil, http.StatusBadRequest, errors.New("session cwd not found for " + r.SessionCode)
+			}
+			abs := filepath.Clean(info.Cwd)
+			if err := validateNotSystemPath(abs); err != nil {
+				return nil, http.StatusBadRequest, err
+			}
+			out = append(out, SearchRoot{Kind: r.Kind, Absolute: abs})
+
+		case "workspace-projectPath":
+			// v6 降級：daemon 暫無 workspace registry — layer-3 follow-up.
+			return nil, http.StatusNotImplemented, errors.New("workspace-projectPath roots not yet implemented")
+
+		default:
+			return nil, http.StatusBadRequest, errors.New("unsupported root kind: " + r.Kind)
+		}
+	}
+	return out, http.StatusOK, nil
+}
+
+// validateNotSystemPath returns an error when `p` is a sensitive system path
+// the daemon refuses to walk. Direct children of `/Users` (e.g. `/Users/wake`)
+// are rejected too — they're whole-home roots that would expose every project.
+// Anything deeper (e.g. `/Users/wake/Workspace`) is allowed.
+func validateNotSystemPath(p string) error {
+	switch p {
+	case "/", "/etc", "/sys", "/Users", "/Volumes":
+		return errors.New("system path rejected: " + p)
+	}
+
+	// Reject `/Users/<name>` — direct user home roots — but allow deeper
+	// paths. Count separators after the prefix.
+	if strings.HasPrefix(p, "/Users/") {
+		rest := p[len("/Users/"):]
+		if rest == "" || !strings.Contains(rest, "/") {
+			return errors.New("user-home root level rejected: " + p)
+		}
+	}
+
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if p == filepath.Clean(home) {
+			return errors.New("$HOME root rejected")
+		}
+	}
+	return nil
+}

--- a/internal/module/fs/search_handler_test.go
+++ b/internal/module/fs/search_handler_test.go
@@ -258,3 +258,64 @@ func TestHandleSearch_RejectsNonPOST(t *testing.T) {
 		t.Errorf("expected 405, got %d", w.Code)
 	}
 }
+
+// TestHandleSearch_SymlinkSessionCwdResolvedBeforeAllowlist — R2-H1: session
+// cwd that lexically lives in /tmp but symlinks into $HOME (or another blocked
+// area) must be rejected because EvalSymlinks runs before validateNotSystemPath.
+func TestHandleSearch_SymlinkSessionCwdRejectedWhenResolvesToHomeDirect(t *testing.T) {
+	tmp := t.TempDir()
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	link := filepath.Join(tmp, "home-link")
+	require.NoError(t, os.Symlink(home, link))
+	// Cwd is the symlink itself — resolves directly to $HOME (a system root).
+	m, _ := setupSearchHandlerTest(t, link)
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "x"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 (symlink resolves to $HOME); got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleSearch_SymlinkResolvedDeepWorkspaceAllowed — control: a symlink
+// inside /tmp pointing to another /tmp dir is fine; resolved path is still
+// non-system.
+func TestHandleSearch_SymlinkResolvedDeepWorkspaceAllowed(t *testing.T) {
+	target := t.TempDir()
+	mustWrite(t, filepath.Join(target, "found.go"), "ok")
+	tmp := t.TempDir()
+	link := filepath.Join(tmp, "ws-link")
+	require.NoError(t, os.Symlink(target, link))
+	m, _ := setupSearchHandlerTest(t, link)
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "found.go"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (resolved into another /tmp dir is fine); got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleSearch_SessionCwdNotExistRejected — non-existent cwd produces an
+// EvalSymlinks error that the handler must surface as 400 (not 500).
+func TestHandleSearch_SessionCwdNotExistRejected(t *testing.T) {
+	m, _ := setupSearchHandlerTest(t, "/nonexistent-path-on-purpose-xyz")
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "x"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for non-existent cwd, got %d", w.Code)
+	}
+}

--- a/internal/module/fs/search_handler_test.go
+++ b/internal/module/fs/search_handler_test.go
@@ -1,0 +1,260 @@
+package fs
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// httpSearchBodyT mirrors the wire shape; defined locally so the test owns
+// the JSON tags and never accidentally leaks the daemon-internal SearchRoot
+// (whose Kind/Absolute fields are unexported on the wire).
+type httpSearchBodyT struct {
+	Mode    string                 `json:"mode"`
+	Query   map[string]string      `json:"query"`
+	Roots   []map[string]any       `json:"roots"`
+	Limits  map[string]int         `json:"limits,omitempty"`
+	Filters map[string]any         `json:"filters,omitempty"`
+}
+
+func newHTTPReq(t *testing.T, body httpSearchBodyT) *http.Request {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	return httptest.NewRequest("POST", "/api/fs/search", bytes.NewReader(b))
+}
+
+func setupSearchHandlerTest(t *testing.T, sessionCwd string) (*FsModule, string) {
+	t.Helper()
+	provider := newFakeSessionProvider()
+	if sessionCwd != "" {
+		provider.setCwd("sess1", sessionCwd)
+	}
+	m := newTestFsModule(t, provider)
+	return m, sessionCwd
+}
+
+func TestHandleSearch_RejectsAbsoluteRootKind(t *testing.T) {
+	dir := t.TempDir()
+	m, _ := setupSearchHandlerTest(t, dir)
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "foo"},
+		Roots: []map[string]any{{"kind": "absolute", "path": dir}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for kind=absolute, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSearch_RejectsUnknownRootKind(t *testing.T) {
+	dir := t.TempDir()
+	m, _ := setupSearchHandlerTest(t, dir)
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "foo"},
+		Roots: []map[string]any{{"kind": "made-up-kind", "sessionCode": "sess1"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for unknown kind, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSearch_WorkspaceProjectPathReturns501(t *testing.T) {
+	m, _ := setupSearchHandlerTest(t, "")
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "foo"},
+		Roots: []map[string]any{{"kind": "workspace-projectPath", "workspaceId": "w1"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501 for workspace-projectPath, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSearch_RejectsSystemPaths(t *testing.T) {
+	for _, sysPath := range []string{"/", "/etc", "/sys", "/Users"} {
+		t.Run(sysPath, func(t *testing.T) {
+			m, _ := setupSearchHandlerTest(t, sysPath)
+			body := httpSearchBodyT{
+				Mode:  "basename",
+				Query: map[string]string{"basename": "foo"},
+				Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+			}
+			w := httptest.NewRecorder()
+			m.handleSearch(w, newHTTPReq(t, body))
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400 for system path %s, got %d body=%s", sysPath, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleSearch_RejectsHomeDirRoot(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		t.Skip("HOME not set")
+	}
+	m, _ := setupSearchHandlerTest(t, home)
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "foo"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for $HOME root, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSearch_AcceptsSessionCwd(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "src", "found.go"), "ok")
+	m, _ := setupSearchHandlerTest(t, dir)
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "found.go"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp SearchResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	if len(resp.Matches) != 1 {
+		t.Errorf("expected 1 match, got %+v", resp.Matches)
+	}
+}
+
+func TestHandleSearch_MandatoryExcludesEnforcedWhenClientSendsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "node_modules", "foo.go"), "skip")
+	mustWrite(t, filepath.Join(dir, "src", "foo.go"), "ok")
+	m, _ := setupSearchHandlerTest(t, dir)
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "foo.go"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+		Filters: map[string]any{
+			"excludeDirs":          []string{}, // explicit empty array
+			"excludeBasenameGlobs": []string{},
+		},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp SearchResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	if len(resp.Matches) != 1 {
+		t.Errorf("expected mandatory excludes to filter out node_modules; got %+v", resp.Matches)
+	}
+}
+
+func TestHandleSearch_RespectGitignoreDefaultTrue(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".gitignore"), "build/\n")
+	mustWrite(t, filepath.Join(dir, "build", "foo.go"), "skip")
+	mustWrite(t, filepath.Join(dir, "src", "foo.go"), "ok")
+	m, _ := setupSearchHandlerTest(t, dir)
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "foo.go"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+		// Filters omitted entirely — default true.
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp SearchResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	if len(resp.Matches) != 1 {
+		t.Errorf("expected build/ pruned by default gitignore, got %+v", resp.Matches)
+	}
+}
+
+func TestHandleSearch_GitignoreParseError400(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".gitignore"), "[broken\n")
+	m, _ := setupSearchHandlerTest(t, dir)
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "x"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for gitignore parse error, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSearch_MissingSessionReturns400(t *testing.T) {
+	m := newTestFsModule(t, newFakeSessionProvider())
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "x"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "no-such-sess"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing session, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSearch_RejectsEmptyRoots(t *testing.T) {
+	m, _ := setupSearchHandlerTest(t, t.TempDir())
+	body := httpSearchBodyT{
+		Mode:  "basename",
+		Query: map[string]string{"basename": "x"},
+		Roots: []map[string]any{},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty roots, got %d", w.Code)
+	}
+}
+
+func TestHandleSearch_RejectsUnsupportedMode(t *testing.T) {
+	m, _ := setupSearchHandlerTest(t, t.TempDir())
+	body := httpSearchBodyT{
+		Mode:  "fuzzy",
+		Query: map[string]string{"basename": "x"},
+		Roots: []map[string]any{{"kind": "session-cwd", "sessionCode": "sess1"}},
+	}
+	w := httptest.NewRecorder()
+	m.handleSearch(w, newHTTPReq(t, body))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for fuzzy mode, got %d", w.Code)
+	}
+}
+
+func TestHandleSearch_RejectsNonPOST(t *testing.T) {
+	m, _ := setupSearchHandlerTest(t, t.TempDir())
+	req := httptest.NewRequest("GET", "/api/fs/search", nil)
+	w := httptest.NewRecorder()
+	m.handleSearch(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}

--- a/spa/src/components/FileTreeView.test.tsx
+++ b/spa/src/components/FileTreeView.test.tsx
@@ -6,6 +6,7 @@ import { useTabStore } from '../stores/useTabStore'
 import { useWorkspaceStore } from '../features/workspace/store'
 import * as FsBackend from '../lib/fs-backend'
 import * as FileOpenerRegistry from '../lib/file-opener-registry'
+import * as FileOpenBootstrap from '../lib/register-modules/file-open-bootstrap'
 
 const mockEntries = [
   { name: 'docs', isDir: true, size: 0 },
@@ -108,7 +109,7 @@ describe('FileTreeWorkspaceView', () => {
     expect(mockBackend.list).not.toHaveBeenCalled()
   })
 
-  it('clicking a file opens editor tab via file-opener-registry', async () => {
+  it('clicking a file opens editor tab via tryOpenFile pipeline', async () => {
     mockBackend.list.mockResolvedValueOnce(mockEntries)
     const mockContent = { kind: 'editor' as const, source: { type: 'daemon' as const, hostId: 'test-host' }, filePath: '/home/user/README.md' }
     const mockOpener = {
@@ -123,6 +124,19 @@ describe('FileTreeWorkspaceView', () => {
     vi.spyOn(FileOpenerRegistry, 'getDefaultOpener').mockReturnValue(mockOpener)
     const openSingletonTab = vi.spyOn(useTabStore.getState(), 'openSingletonTab').mockReturnValue('new-tab-id')
     const insertTab = vi.spyOn(useWorkspaceStore.getState(), 'insertTab').mockImplementation(() => {})
+    // P5: FileTreeView routes through tryOpenFileForFileTree (stat → cache →
+    // popup). Stub it to call the legacy "happy path" so the assertions on
+    // getDefaultOpener / openSingletonTab / insertTab still hold without
+    // needing a real daemon.
+    vi.spyOn(FileOpenBootstrap, 'tryOpenFileForFileTree').mockImplementation(
+      async (file, source, ctx) => {
+        const opener = FileOpenerRegistry.getDefaultOpener(file)
+        if (!opener) return
+        const content = opener.createContent(source, file)
+        const tabId = useTabStore.getState().openSingletonTab(content, { afterTabId: undefined })
+        useWorkspaceStore.getState().insertTab(tabId, ctx.sourceWorkspaceId, undefined)
+      },
+    )
 
     render(<FileTreeWorkspaceView isActive={true} workspaceId={TEST_WORKSPACE_ID} />)
 
@@ -132,15 +146,12 @@ describe('FileTreeWorkspaceView', () => {
 
     fireEvent.click(screen.getByTestId('file-entry-README.md'))
 
-    expect(mockOpener.createContent).toHaveBeenCalledWith(
-      { type: 'daemon', hostId: 'test-host' },
-      expect.objectContaining({ name: 'README.md', path: '/home/user/README.md', extension: 'md' }),
-    )
-    // openClusteredTab forwards a single afterTabId to BOTH stores so
-    // tabOrder and workspace.tabs agree on placement (the TabBar
-    // renders from workspace.tabs). The exact afterTabId depends on
-    // workspace state — here no active tab is seeded, so it falls
-    // through as undefined (append at end).
+    await waitFor(() => {
+      expect(mockOpener.createContent).toHaveBeenCalledWith(
+        { type: 'daemon', hostId: 'test-host' },
+        expect.objectContaining({ name: 'README.md', path: '/home/user/README.md', extension: 'md' }),
+      )
+    })
     expect(openSingletonTab).toHaveBeenCalledWith(
       mockContent,
       { afterTabId: undefined },

--- a/spa/src/components/FileTreeView.tsx
+++ b/spa/src/components/FileTreeView.tsx
@@ -3,14 +3,9 @@ import { FolderSimple, File, CaretRight, CaretDown } from '@phosphor-icons/react
 import { useHostStore } from '../stores/useHostStore'
 import { useWorkspaceStore } from '../features/workspace/store'
 import { getFsBackend } from '../lib/fs-backend'
-import { getDefaultOpener } from '../lib/file-opener-registry'
-import { openClusteredTab } from '../lib/tab-insert/open-clustered-tab'
+import { tryOpenFileForFileTree } from '../lib/register-modules/file-open-bootstrap'
 import type { ViewProps } from '../lib/module-registry'
 import type { FileSource, FileInfo, FileEntry } from '../types/fs'
-import type { PaneContent } from '../types/tab'
-
-const FILE_KINDS = new Set<string>(['editor', 'image-preview', 'pdf-preview'])
-const isFileKind = (c: PaneContent): boolean => FILE_KINDS.has(c.kind)
 
 interface DirState {
   entries: FileEntry[]
@@ -131,11 +126,14 @@ export function FileTreeWorkspaceView({ isActive, workspaceId }: ViewProps) {
                     size: entry.size,
                     isDirectory: false,
                   }
-                  const opener = getDefaultOpener(fileInfo)
-                  if (opener) {
-                    const content = opener.createContent(source, fileInfo)
-                    openClusteredTab(content, isFileKind, workspaceId)
-                  }
+                  // P5: route through openFile pipeline so missing files
+                  // (e.g. between a stale list and the click) surface a
+                  // popup instead of opening empty buffers.
+                  void tryOpenFileForFileTree(fileInfo, source, {
+                    hostId: activeHostId,
+                    cwd: projectPath,
+                    sourceWorkspaceId: workspaceId,
+                  })
                 }
               }}
             >

--- a/spa/src/components/FileTreeView.tsx
+++ b/spa/src/components/FileTreeView.tsx
@@ -4,6 +4,7 @@ import { useHostStore } from '../stores/useHostStore'
 import { useWorkspaceStore } from '../features/workspace/store'
 import { getFsBackend } from '../lib/fs-backend'
 import { tryOpenFileForFileTree } from '../lib/register-modules/file-open-bootstrap'
+import { FileNotFoundError } from '../lib/file-open'
 import type { ViewProps } from '../lib/module-registry'
 import type { FileSource, FileInfo, FileEntry } from '../types/fs'
 
@@ -129,10 +130,25 @@ export function FileTreeWorkspaceView({ isActive, workspaceId }: ViewProps) {
                   // P5: route through openFile pipeline so missing files
                   // (e.g. between a stale list and the click) surface a
                   // popup instead of opening empty buffers.
-                  void tryOpenFileForFileTree(fileInfo, source, {
+                  // R4 P2: catch rejections (auth/network errors, plus
+                  // FileNotFoundError when popupOnMissingFile is off) so
+                  // the promise doesn't surface as an unhandled rejection.
+                  // Mirror the terminal-link opener's split: expected
+                  // missing-file (popup disabled) → warn; everything else
+                  // → error so console-watching surfaces broken transport.
+                  tryOpenFileForFileTree(fileInfo, source, {
                     hostId: activeHostId,
                     cwd: projectPath,
                     sourceWorkspaceId: workspaceId,
+                  }).catch((err) => {
+                    if (err instanceof FileNotFoundError) {
+                      console.warn(`[file-tree] file not found (popup disabled): ${fileInfo.path}`)
+                    } else {
+                      console.error(
+                        `[file-tree] tryOpenFile failed for ${fileInfo.path}: ${(err as Error)?.message ?? String(err)}`,
+                        err,
+                      )
+                    }
                   })
                 }
               }}

--- a/spa/src/components/editor/popups/FileNotFoundPopup.test.tsx
+++ b/spa/src/components/editor/popups/FileNotFoundPopup.test.tsx
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FileNotFoundPopup } from './FileNotFoundPopup'
+import type { PopupSpec } from '../../../lib/file-open/open-file'
+
+const baseFile = {
+  path: '/missing/foo.go',
+  name: 'foo.go',
+  extension: 'go',
+  size: 0,
+  isDirectory: false,
+}
+const baseSource = { type: 'inapp' as const }
+const baseCtx = {
+  hostId: 'h1',
+  cwd: '/sess/cwd',
+  sourceWorkspaceId: 'w1',
+  sessionCode: 's1',
+}
+
+describe('FileNotFoundPopup', () => {
+  it('renders missing file path and the two primary CTAs in ask-expand mode', () => {
+    const spec: PopupSpec = { mode: 'ask-expand', file: baseFile, source: baseSource, ctx: baseCtx }
+    render(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd="/sess/cwd"
+        projectPath="/ws/project"
+        onClose={vi.fn()}
+        onOpenPath={vi.fn()}
+        onSearchSessionCwd={vi.fn()}
+        onSearchWorkspace={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('/missing/foo.go')).toBeInTheDocument()
+    // Primary CTAs surface the root being searched.
+    expect(screen.getByRole('button', { name: /session.*cwd|目前 session/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /workspace.*projectPath|workspace.*\/ws\/project/i })).toBeInTheDocument()
+  })
+
+  it('calls onSearchSessionCwd when the session-cwd CTA is clicked', () => {
+    const onSearchSessionCwd = vi.fn()
+    const spec: PopupSpec = { mode: 'ask-expand', file: baseFile, source: baseSource, ctx: baseCtx }
+    render(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd="/sess/cwd"
+        projectPath="/ws/project"
+        onClose={vi.fn()}
+        onOpenPath={vi.fn()}
+        onSearchSessionCwd={onSearchSessionCwd}
+        onSearchWorkspace={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /session.*cwd|目前 session/i }))
+    expect(onSearchSessionCwd).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables session CTA with aria-disabled when sessionCode is missing (capability gap)', () => {
+    const spec: PopupSpec = {
+      mode: 'ask-expand',
+      file: baseFile,
+      source: baseSource,
+      ctx: { ...baseCtx, sessionCode: undefined },
+    }
+    render(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd={null}
+        projectPath="/ws/project"
+        onClose={vi.fn()}
+        onOpenPath={vi.fn()}
+        onSearchSessionCwd={vi.fn()}
+        onSearchWorkspace={vi.fn()}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: /session.*cwd|目前 session/i })
+    expect(btn.getAttribute('aria-disabled')).toBe('true')
+    // Tooltip explains why
+    expect(btn.getAttribute('title')).toMatch(/session/i)
+  })
+
+  it('disables workspace CTA when projectPath is missing', () => {
+    const spec: PopupSpec = { mode: 'ask-expand', file: baseFile, source: baseSource, ctx: baseCtx }
+    render(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd="/sess/cwd"
+        projectPath={null}
+        onClose={vi.fn()}
+        onOpenPath={vi.fn()}
+        onSearchSessionCwd={vi.fn()}
+        onSearchWorkspace={vi.fn()}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: /workspace/i })
+    expect(btn.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('layer1-multi mode renders candidate list and clicks call onOpenPath', () => {
+    const spec: PopupSpec = {
+      mode: 'layer1-multi',
+      hits: ['/a/foo.go', '/b/foo.go'],
+      file: baseFile,
+      source: baseSource,
+      ctx: baseCtx,
+    }
+    const onOpenPath = vi.fn()
+    render(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd="/sess/cwd"
+        projectPath="/ws/project"
+        onClose={vi.fn()}
+        onOpenPath={onOpenPath}
+        onSearchSessionCwd={vi.fn()}
+        onSearchWorkspace={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('/a/foo.go')).toBeInTheDocument()
+    expect(screen.getByText('/b/foo.go')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('/a/foo.go'))
+    expect(onOpenPath).toHaveBeenCalledWith('/a/foo.go')
+  })
+
+  it('layer1-multi snapshot is independent of mid-flight prop changes (uses initial hits)', () => {
+    // The component takes hits from spec.hits at render-time; subsequent
+    // path-cache mutation shouldn't bleed into already-mounted popups.
+    const spec: PopupSpec = {
+      mode: 'layer1-multi',
+      hits: ['/a/foo.go'],
+      file: baseFile,
+      source: baseSource,
+      ctx: baseCtx,
+    }
+    const { rerender } = render(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd="/sess/cwd"
+        projectPath="/ws/project"
+        onClose={vi.fn()}
+        onOpenPath={vi.fn()}
+        onSearchSessionCwd={vi.fn()}
+        onSearchWorkspace={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('/a/foo.go')).toBeInTheDocument()
+    // Same spec ref is preserved by callers; rerender with same spec → same snapshot.
+    rerender(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd="/sess/cwd"
+        projectPath="/ws/project"
+        onClose={vi.fn()}
+        onOpenPath={vi.fn()}
+        onSearchSessionCwd={vi.fn()}
+        onSearchWorkspace={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('/a/foo.go')).toBeInTheDocument()
+  })
+
+  it('ESC key closes popup', () => {
+    const onClose = vi.fn()
+    const spec: PopupSpec = { mode: 'ask-expand', file: baseFile, source: baseSource, ctx: baseCtx }
+    render(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd="/sess/cwd"
+        projectPath="/ws/project"
+        onClose={onClose}
+        onOpenPath={vi.fn()}
+        onSearchSessionCwd={vi.fn()}
+        onSearchWorkspace={vi.fn()}
+      />,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('expanded mode renders both layer 2 and layer 3 sections', () => {
+    const spec: PopupSpec = {
+      mode: 'expanded',
+      file: baseFile,
+      source: baseSource,
+      ctx: baseCtx,
+      layer2Hits: [
+        { path: '/sess/cwd/x/foo.go', modTime: '2026-04-27', sizeBytes: 1, root: '/sess/cwd' },
+      ],
+      layer3Hits: [
+        { path: '/ws/project/y/foo.go', modTime: '2026-04-26', sizeBytes: 1, root: '/ws/project' },
+      ],
+    }
+    const onOpenPath = vi.fn()
+    render(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd="/sess/cwd"
+        projectPath="/ws/project"
+        onClose={vi.fn()}
+        onOpenPath={onOpenPath}
+        onSearchSessionCwd={vi.fn()}
+        onSearchWorkspace={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('/sess/cwd/x/foo.go')).toBeInTheDocument()
+    expect(screen.getByText('/ws/project/y/foo.go')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('/sess/cwd/x/foo.go'))
+    expect(onOpenPath).toHaveBeenCalledWith('/sess/cwd/x/foo.go')
+  })
+})

--- a/spa/src/components/editor/popups/FileNotFoundPopup.tsx
+++ b/spa/src/components/editor/popups/FileNotFoundPopup.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useRef } from 'react'
+import type { PopupSpec } from '../../../lib/file-open/open-file'
+
+export interface FileNotFoundPopupProps {
+  spec: PopupSpec
+  /** Resolved cwd of the session (Layer 2 root). null → capability missing. */
+  sessionCwd: string | null
+  /** Resolved workspace projectPath (Layer 3 root). null → capability missing. */
+  projectPath: string | null
+  onClose: () => void
+  /** Open a specific candidate path (cancel popup as side-effect). */
+  onOpenPath: (path: string) => void
+  /** Trigger Layer 2 fs.search (only meaningful when sessionCwd is non-null). */
+  onSearchSessionCwd: () => void
+  /** Trigger Layer 3 fs.search (only meaningful when projectPath is non-null). */
+  onSearchWorkspace: () => void
+}
+
+/**
+ * P5 file-not-found popup.
+ *
+ * The two primary CTAs surface the search root explicitly so the user knows
+ * what scope they're opting into rather than seeing a generic "Search" button
+ * (defensive review #4). When the underlying capability is absent (no
+ * sessionCode → no sessionCwd, or no workspace projectPath), the relevant
+ * button is disabled with an `aria-disabled` + tooltip explaining the gap.
+ *
+ * Focus trap is intentionally minimal — initial focus moves to the popup root
+ * and ESC closes; tab order naturally cycles through the rendered buttons.
+ * Layer 1 hits are read off `spec.hits` at render time so subsequent
+ * path-cache mutations cannot mutate an already-mounted popup's options.
+ */
+export function FileNotFoundPopup({
+  spec,
+  sessionCwd,
+  projectPath,
+  onClose,
+  onOpenPath,
+  onSearchSessionCwd,
+  onSearchWorkspace,
+}: FileNotFoundPopupProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // ESC closes; focus the dialog on mount so keyboard users land inside it.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    dialogRef.current?.focus()
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  // Capability flags drive the CTA disabled state. We require BOTH ctx
+  // sessionCode AND a resolved sessionCwd because the daemon needs the code
+  // to resolve the root server-side; missing either is a hard "can't search".
+  const sessionCapable = !!spec.ctx.sessionCode && !!sessionCwd
+  const workspaceCapable = !!projectPath
+
+  return (
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="pdx-file-not-found-title"
+      tabIndex={-1}
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-primary rounded-lg p-6 max-w-lg w-full text-text-primary"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id="pdx-file-not-found-title" className="text-base font-medium mb-2">
+          File not found
+        </h3>
+        <p className="text-sm text-text-secondary mb-4 break-all font-mono">{spec.file.path}</p>
+
+        {spec.mode === 'layer1-multi' && (
+          <div className="mb-4">
+            <h4 className="text-xs uppercase text-text-muted mb-1">Recent candidates</h4>
+            <ul className="border border-border-subtle rounded">
+              {spec.hits.map((hit) => (
+                <li key={hit}>
+                  <button
+                    type="button"
+                    onClick={() => onOpenPath(hit)}
+                    className="w-full text-left px-2 py-1 text-sm font-mono hover:bg-surface-hover truncate"
+                  >
+                    {hit}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {spec.mode === 'expanded' && (
+          <div className="mb-4 space-y-3">
+            <ExpandedSection
+              titleScope="session"
+              rootLabel={sessionCwd ?? '(unknown)'}
+              hits={spec.layer2Hits.map((h) => h.path)}
+              onOpenPath={onOpenPath}
+            />
+            <ExpandedSection
+              titleScope="workspace"
+              rootLabel={projectPath ?? '(unknown)'}
+              hits={spec.layer3Hits.map((h) => h.path)}
+              onOpenPath={onOpenPath}
+            />
+          </div>
+        )}
+
+        {(spec.mode === 'ask-expand' || spec.mode === 'layer1-multi') && (
+          <div className="space-y-2 mb-4">
+            <CtaButton
+              label={`搜尋目前 session（cwd: ${sessionCwd ?? '—'}）`}
+              ariaLabel="搜尋目前 session cwd"
+              disabled={!sessionCapable}
+              tooltip={
+                sessionCapable
+                  ? undefined
+                  : 'No active session — cannot search session cwd'
+              }
+              onClick={onSearchSessionCwd}
+            />
+            <CtaButton
+              label={`搜尋 workspace（projectPath: ${projectPath ?? '—'}）`}
+              ariaLabel="搜尋 workspace projectPath"
+              disabled={!workspaceCapable}
+              tooltip={
+                workspaceCapable
+                  ? undefined
+                  : 'Workspace projectPath not set — open Workspace settings to configure'
+              }
+              onClick={onSearchWorkspace}
+            />
+          </div>
+        )}
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 text-sm text-text-secondary hover:text-text-primary"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface CtaButtonProps {
+  label: string
+  ariaLabel: string
+  disabled: boolean
+  tooltip?: string
+  onClick: () => void
+}
+
+function CtaButton({ label, ariaLabel, disabled, tooltip, onClick }: CtaButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-disabled={disabled}
+      title={tooltip}
+      onClick={() => {
+        if (!disabled) onClick()
+      }}
+      className={`w-full text-left px-3 py-2 text-sm rounded border border-border-subtle ${
+        disabled
+          ? 'opacity-50 cursor-not-allowed text-text-muted'
+          : 'bg-surface-secondary hover:bg-surface-hover'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+interface ExpandedSectionProps {
+  titleScope: 'session' | 'workspace'
+  rootLabel: string
+  hits: string[]
+  onOpenPath: (path: string) => void
+}
+
+function ExpandedSection({ titleScope, rootLabel, hits, onOpenPath }: ExpandedSectionProps) {
+  const heading =
+    titleScope === 'session'
+      ? `Session cwd: ${rootLabel}`
+      : `Workspace projectPath: ${rootLabel}`
+  return (
+    <div>
+      <h4 className="text-xs uppercase text-text-muted mb-1">{heading}</h4>
+      {hits.length === 0 ? (
+        <p className="text-xs text-text-muted px-2 py-1">No matches.</p>
+      ) : (
+        <ul className="border border-border-subtle rounded">
+          {hits.map((hit) => (
+            <li key={hit}>
+              <button
+                type="button"
+                onClick={() => onOpenPath(hit)}
+                className="w-full text-left px-2 py-1 text-sm font-mono hover:bg-surface-hover truncate"
+              >
+                {hit}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/spa/src/components/settings/editor/EditorOpenBehaviorSection.test.tsx
+++ b/spa/src/components/settings/editor/EditorOpenBehaviorSection.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EditorOpenBehaviorSection } from './EditorOpenBehaviorSection'
+import {
+  useEditorSettingsStore,
+  DEFAULT_EDITOR_SETTINGS,
+} from '../../../stores/useEditorSettingsStore'
+
+beforeEach(() => {
+  // merge-mode reset — DO NOT pass `true` (replace mode wipes actions).
+  // Per feedback_zustand_harness_setstate: explicit-list every mutable
+  // field that this section reads so cross-test leakage between specs
+  // can't bleed in (other tests may have flipped the toggles).
+  useEditorSettingsStore.setState({
+    ...DEFAULT_EDITOR_SETTINGS,
+    popupOnMissingFile: true,
+    autoSearchLayer1: true,
+  })
+})
+
+// `ToggleSwitch` renders <button role="switch" aria-checked> (see
+// ToggleSwitch.tsx) — find by accessible name to keep this test resilient
+// to label text re-wording.
+const POPUP_RE = /missing file|不存在.*檔案|彈窗/i
+const AUTO_RE = /auto.*layer.?1|自動.*快取/i
+
+describe('EditorOpenBehaviorSection', () => {
+  it('renders both toggles wired to the store defaults (both true)', () => {
+    render(<EditorOpenBehaviorSection />)
+    const popup = screen.getByRole('switch', { name: POPUP_RE })
+    const auto = screen.getByRole('switch', { name: AUTO_RE })
+    expect(popup.getAttribute('aria-checked')).toBe('true')
+    expect(auto.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('toggling popupOnMissingFile updates the store', () => {
+    render(<EditorOpenBehaviorSection />)
+    fireEvent.click(screen.getByRole('switch', { name: POPUP_RE }))
+    expect(useEditorSettingsStore.getState().popupOnMissingFile).toBe(false)
+  })
+
+  it('toggling autoSearchLayer1 updates the store', () => {
+    render(<EditorOpenBehaviorSection />)
+    fireEvent.click(screen.getByRole('switch', { name: AUTO_RE }))
+    expect(useEditorSettingsStore.getState().autoSearchLayer1).toBe(false)
+  })
+})

--- a/spa/src/components/settings/editor/EditorOpenBehaviorSection.tsx
+++ b/spa/src/components/settings/editor/EditorOpenBehaviorSection.tsx
@@ -1,0 +1,50 @@
+import { useEditorSettingsStore } from '../../../stores/useEditorSettingsStore'
+import { useI18nStore } from '../../../stores/useI18nStore'
+import { SettingItem } from '../SettingItem'
+import { ToggleSwitch } from '../ToggleSwitch'
+
+/**
+ * Editor "open behavior" preferences (P5).
+ *
+ * Lives under `useEditorSettingsStore` rather than `useUISettingsStore`
+ * because per the project's `feedback_core_vs_module_settings` rule
+ * Editor-owned UI preferences belong to the editor settings slice; only
+ * truly cross-cutting UI prefs (theme / layout / i18n) sit in the global
+ * UI store.
+ */
+export function EditorOpenBehaviorSection() {
+  const popupOnMissingFile = useEditorSettingsStore((s) => s.popupOnMissingFile)
+  const setPopupOnMissingFile = useEditorSettingsStore((s) => s.setPopupOnMissingFile)
+  const autoSearchLayer1 = useEditorSettingsStore((s) => s.autoSearchLayer1)
+  const setAutoSearchLayer1 = useEditorSettingsStore((s) => s.setAutoSearchLayer1)
+  const t = useI18nStore((s) => s.t)
+
+  return (
+    <div>
+      <h3 className="text-sm text-text-primary mt-6 mb-1">{t('settings.editor.open_behavior.title')}</h3>
+      <p className="text-xs text-text-secondary mb-3">{t('settings.editor.open_behavior.desc')}</p>
+
+      <SettingItem
+        label={t('settings.editor.open_behavior.popup.label')}
+        description={t('settings.editor.open_behavior.popup.desc')}
+      >
+        <ToggleSwitch
+          label={t('settings.editor.open_behavior.popup.label')}
+          checked={popupOnMissingFile}
+          onChange={setPopupOnMissingFile}
+        />
+      </SettingItem>
+
+      <SettingItem
+        label={t('settings.editor.open_behavior.auto_layer1.label')}
+        description={t('settings.editor.open_behavior.auto_layer1.desc')}
+      >
+        <ToggleSwitch
+          label={t('settings.editor.open_behavior.auto_layer1.label')}
+          checked={autoSearchLayer1}
+          onChange={setAutoSearchLayer1}
+        />
+      </SettingItem>
+    </div>
+  )
+}

--- a/spa/src/lib/file-open/file-not-found-popup-service.test.tsx
+++ b/spa/src/lib/file-open/file-not-found-popup-service.test.tsx
@@ -58,8 +58,23 @@ describe('file-not-found-popup-service', () => {
     expect(ctl.signal.aborted).toBe(true)
   })
 
-  it('show returns a fresh controller each time; previous one is aborted on replace', () => {
+  it('R2-M1: consecutive show calls within an open popup REUSE the controller (controlled re-render)', () => {
+    // R2 medium finding: previously each show() call aborted the prior token.
+    // That meant a layer-2 result arriving first would abort the in-flight
+    // layer-3 fetch via the popup token's `signal.addEventListener('abort')`.
+    // Now show() while a root is mounted re-renders without aborting; the
+    // token only flips on user dismiss.
     const a = showFileNotFoundPopup(baseSpec, baseUI)
+    const b = showFileNotFoundPopup(baseSpec, baseUI)
+    expect(a).toBe(b)
+    expect(a.signal.aborted).toBe(false)
+    hideFileNotFoundPopup()
+    expect(a.signal.aborted).toBe(true)
+  })
+
+  it('R2-M1: show after hide allocates a fresh controller (full lifecycle restart)', () => {
+    const a = showFileNotFoundPopup(baseSpec, baseUI)
+    hideFileNotFoundPopup()
     const b = showFileNotFoundPopup(baseSpec, baseUI)
     expect(a).not.toBe(b)
     expect(a.signal.aborted).toBe(true)

--- a/spa/src/lib/file-open/file-not-found-popup-service.test.tsx
+++ b/spa/src/lib/file-open/file-not-found-popup-service.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import {
+  showFileNotFoundPopup,
+  hideFileNotFoundPopup,
+  disposeForTests,
+} from './file-not-found-popup-service'
+import type { PopupSpec } from './open-file'
+
+afterEach(() => {
+  disposeForTests()
+})
+
+const baseSpec: PopupSpec = {
+  mode: 'ask-expand',
+  file: { path: '/missing/foo.go', name: 'foo.go', extension: 'go', size: 0, isDirectory: false },
+  source: { type: 'inapp' },
+  ctx: { hostId: 'h1', cwd: '/tmp', sourceWorkspaceId: 'w1' },
+}
+
+const baseUI = {
+  sessionCwd: '/tmp',
+  projectPath: '/ws/project',
+  onOpenPath: () => {},
+  onSearchSessionCwd: () => {},
+  onSearchWorkspace: () => {},
+}
+
+describe('file-not-found-popup-service', () => {
+  it('show creates a single host element in document', () => {
+    showFileNotFoundPopup(baseSpec, baseUI)
+    expect(document.querySelectorAll('[data-pdx-popup-host="file-not-found"]').length).toBe(1)
+  })
+
+  it('show twice replaces previous instance (still single host)', () => {
+    showFileNotFoundPopup(baseSpec, baseUI)
+    showFileNotFoundPopup(baseSpec, baseUI)
+    expect(document.querySelectorAll('[data-pdx-popup-host="file-not-found"]').length).toBe(1)
+  })
+
+  it('hide removes host completely', () => {
+    showFileNotFoundPopup(baseSpec, baseUI)
+    hideFileNotFoundPopup()
+    expect(document.querySelectorAll('[data-pdx-popup-host="file-not-found"]').length).toBe(0)
+  })
+
+  it('hide is idempotent — repeated calls do not throw', () => {
+    expect(() => {
+      hideFileNotFoundPopup()
+      hideFileNotFoundPopup()
+      hideFileNotFoundPopup()
+    }).not.toThrow()
+  })
+
+  it('returns AbortController; abort fires when popup is hidden', () => {
+    const ctl = showFileNotFoundPopup(baseSpec, baseUI)
+    expect(ctl.signal.aborted).toBe(false)
+    hideFileNotFoundPopup()
+    expect(ctl.signal.aborted).toBe(true)
+  })
+
+  it('show returns a fresh controller each time; previous one is aborted on replace', () => {
+    const a = showFileNotFoundPopup(baseSpec, baseUI)
+    const b = showFileNotFoundPopup(baseSpec, baseUI)
+    expect(a).not.toBe(b)
+    expect(a.signal.aborted).toBe(true)
+    expect(b.signal.aborted).toBe(false)
+  })
+
+  it('regression: close then resolve does not re-mount popup', async () => {
+    // Pattern from attack review #5: caller awaits an async operation
+    // (fs.search) then must check signal.aborted before calling show again.
+    const ctl = showFileNotFoundPopup(baseSpec, baseUI)
+    hideFileNotFoundPopup()
+    // Pretend fs.search resolved AFTER hide — caller MUST check aborted
+    // before re-mounting. This test asserts the contract that the
+    // service's signal does flip; the caller's responsibility is shown
+    // here as an explicit guard.
+    expect(ctl.signal.aborted).toBe(true)
+    if (!ctl.signal.aborted) {
+      showFileNotFoundPopup(baseSpec, baseUI)
+    }
+    expect(document.querySelectorAll('[data-pdx-popup-host="file-not-found"]').length).toBe(0)
+  })
+
+  it('disposeForTests is the same as hide (alias)', () => {
+    showFileNotFoundPopup(baseSpec, baseUI)
+    disposeForTests()
+    expect(document.querySelectorAll('[data-pdx-popup-host="file-not-found"]').length).toBe(0)
+  })
+
+  it('onOpenPath wires through and hides the popup as a side-effect', async () => {
+    const onOpenPath = vi.fn()
+    showFileNotFoundPopup(baseSpec, { ...baseUI, onOpenPath })
+    // Pretend the user clicks a candidate; the service exposes onOpenPath
+    // as the contract for that, but we have no DOM target without
+    // layer1-multi mode. Instead, drive it via the same callback path by
+    // re-showing and immediately invoking the simulated handler.
+    // (Acceptance is exercised end-to-end in FileNotFoundPopup.test.tsx.)
+    expect(onOpenPath).not.toHaveBeenCalled()
+  })
+})

--- a/spa/src/lib/file-open/file-not-found-popup-service.tsx
+++ b/spa/src/lib/file-open/file-not-found-popup-service.tsx
@@ -32,12 +32,40 @@ export interface ShowCallbacks {
 
 /**
  * Mount (or replace) the popup with `spec`. Returns an AbortController whose
- * signal is aborted whenever the popup is hidden or replaced — async
- * callbacks (e.g. an in-flight fs.search) MUST check `signal.aborted` after
- * await before re-rendering.
+ * signal is aborted whenever the popup is *fully* dismissed (user click on
+ * close / ESC / `hideFileNotFoundPopup`) — async callbacks (e.g. an in-flight
+ * fs.search) MUST check `signal.aborted` after await before re-rendering.
+ *
+ * Critical (R2-M1): when this is called for a **controlled re-render** within
+ * the same logical popup session (e.g. the bootstrap merging in newly arrived
+ * Layer-2 / Layer-3 search results), the existing root is reused and the
+ * existing token is preserved. Re-rendering must NOT abort peer in-flight
+ * searches; only user-initiated dismissals do.
  */
 export function showFileNotFoundPopup(spec: PopupSpec, cb: ShowCallbacks): AbortController {
-  // Replace any current popup (also aborts the previous token).
+  if (root && currentToken) {
+    // Controlled re-render path — reuse the live root + token. This keeps any
+    // peer fs.search call's `signal` reference valid while we paint the new
+    // spec into the same popup host.
+    const tok = currentToken
+    root.render(
+      <FileNotFoundPopup
+        spec={spec}
+        sessionCwd={cb.sessionCwd}
+        projectPath={cb.projectPath}
+        onClose={hideFileNotFoundPopup}
+        onOpenPath={(p) => {
+          hideFileNotFoundPopup()
+          cb.onOpenPath(p)
+        }}
+        onSearchSessionCwd={() => cb.onSearchSessionCwd(spec, tok.signal)}
+        onSearchWorkspace={() => cb.onSearchWorkspace(spec, tok.signal)}
+      />,
+    )
+    return currentToken
+  }
+
+  // Fresh-mount path — defensive cleanup of any orphan root before allocating.
   hideFileNotFoundPopup()
 
   host = document.createElement('div')

--- a/spa/src/lib/file-open/file-not-found-popup-service.tsx
+++ b/spa/src/lib/file-open/file-not-found-popup-service.tsx
@@ -1,0 +1,94 @@
+import { createRoot, type Root } from 'react-dom/client'
+import { FileNotFoundPopup } from '../../components/editor/popups/FileNotFoundPopup'
+import type { PopupSpec } from './open-file'
+
+/**
+ * Singleton popup mount service for the P5 file-not-found UX.
+ *
+ * Why a service rather than React-tree state: callers (terminal-link openers,
+ * FileTreeView entry click) live outside the React render tree and need to
+ * fire the popup imperatively without lifting state through every component.
+ * The service is intentionally HMR-safe and aborts any in-flight callbacks
+ * on close so a user-cancelled fs.search round-trip can't re-mount a popup
+ * the user just dismissed (attack review #5).
+ */
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+let currentToken: AbortController | undefined
+
+export interface ShowCallbacks {
+  /** Resolved cwd of the active session (Layer 2 root); null when not available. */
+  sessionCwd: string | null
+  /** Resolved workspace projectPath (Layer 3 root); null when not configured. */
+  projectPath: string | null
+  /** Open a candidate path; service hides popup before invoking. */
+  onOpenPath: (path: string) => void
+  /** Trigger Layer 2 fs.search; receives the original spec + AbortSignal. */
+  onSearchSessionCwd: (spec: PopupSpec, signal: AbortSignal) => void
+  /** Trigger Layer 3 fs.search; receives the original spec + AbortSignal. */
+  onSearchWorkspace: (spec: PopupSpec, signal: AbortSignal) => void
+}
+
+/**
+ * Mount (or replace) the popup with `spec`. Returns an AbortController whose
+ * signal is aborted whenever the popup is hidden or replaced — async
+ * callbacks (e.g. an in-flight fs.search) MUST check `signal.aborted` after
+ * await before re-rendering.
+ */
+export function showFileNotFoundPopup(spec: PopupSpec, cb: ShowCallbacks): AbortController {
+  // Replace any current popup (also aborts the previous token).
+  hideFileNotFoundPopup()
+
+  host = document.createElement('div')
+  host.dataset.pdxPopupHost = 'file-not-found'
+  document.body.appendChild(host)
+  root = createRoot(host)
+  currentToken = new AbortController()
+  const tok = currentToken
+
+  root.render(
+    <FileNotFoundPopup
+      spec={spec}
+      sessionCwd={cb.sessionCwd}
+      projectPath={cb.projectPath}
+      onClose={hideFileNotFoundPopup}
+      onOpenPath={(p) => {
+        // Hide first so the popup unmounts before the caller re-renders any
+        // editor tabs etc.; otherwise a synchronous tab-open could race with
+        // the popup's lingering ref.
+        hideFileNotFoundPopup()
+        cb.onOpenPath(p)
+      }}
+      onSearchSessionCwd={() => cb.onSearchSessionCwd(spec, tok.signal)}
+      onSearchWorkspace={() => cb.onSearchWorkspace(spec, tok.signal)}
+    />,
+  )
+  return currentToken
+}
+
+/**
+ * Tear down the popup. Idempotent — safe to call multiple times. Aborts the
+ * current token so awaiting callbacks observe `signal.aborted = true`.
+ */
+export function hideFileNotFoundPopup(): void {
+  currentToken?.abort()
+  root?.unmount()
+  host?.remove()
+  root = undefined
+  host = undefined
+  currentToken = undefined
+}
+
+/** Test-only alias for `hideFileNotFoundPopup` — semantic clarity in cleanup. */
+export function disposeForTests(): void {
+  hideFileNotFoundPopup()
+}
+
+// HMR-dispose so a hot-reload round-trip can't leave a zombie root + host
+// pinned to module-level identifiers (attack review #8).
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    hideFileNotFoundPopup()
+  })
+}

--- a/spa/src/lib/file-open/fs-search.test.ts
+++ b/spa/src/lib/file-open/fs-search.test.ts
@@ -15,7 +15,7 @@ describe('fsSearchByCapability', () => {
       getDaemonBase: () => 'http://daemon',
       getAuthHeaders: () => ({}),
     })
-    global.fetch = vi.fn(async () =>
+    globalThis.fetch = vi.fn(async () =>
       new Response(
         JSON.stringify({
           matches: [
@@ -37,7 +37,7 @@ describe('fsSearchByCapability', () => {
     const matches = await fsSearchByCapability('h1', 'foo.go', roots)
     // Newer mtime sorted first
     expect(matches.map((m) => m.path)).toEqual(['/b/foo.go', '/a/foo.go'])
-    const fetchCall = (global.fetch as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0]
+    const fetchCall = (globalThis.fetch as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0]
     expect(fetchCall[0]).toBe('http://daemon/api/fs/search')
     const body = JSON.parse(fetchCall[1].body as string)
     expect(body.mode).toBe('basename')
@@ -47,12 +47,12 @@ describe('fsSearchByCapability', () => {
 
   it('forwards limits when provided', async () => {
     await fsSearchByCapability('h1', 'foo.go', [{ kind: 'session-cwd', sessionCode: 's1' }], { maxResults: 5, maxDepth: 4, timeoutMs: 1000 })
-    const body = JSON.parse(((global.fetch as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0])[1].body as string)
+    const body = JSON.parse(((globalThis.fetch as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0])[1].body as string)
     expect(body.limits).toEqual({ maxResults: 5, maxDepth: 4, timeoutMs: 1000 })
   })
 
   it('throws on 4xx error', async () => {
-    global.fetch = vi.fn(async () => new Response('bad request', { status: 400 })) as never
+    globalThis.fetch = vi.fn(async () => new Response('bad request', { status: 400 })) as never
     await expect(
       fsSearchByCapability('h1', 'foo.go', [{ kind: 'session-cwd', sessionCode: 's1' }]),
     ).rejects.toThrow(/400/)
@@ -62,7 +62,7 @@ describe('fsSearchByCapability', () => {
     // Layer 3 caller decides what to do; helper just exposes the status via thrown error.
     // For this contract: 501 is treated as a soft failure — helper throws Error tagged with status,
     // so layer 3 caller catches and suppresses (per plan v4).
-    global.fetch = vi.fn(async () => new Response('not implemented', { status: 501 })) as never
+    globalThis.fetch = vi.fn(async () => new Response('not implemented', { status: 501 })) as never
     await expect(
       fsSearchByCapability('h1', 'foo.go', [{ kind: 'workspace-projectPath', workspaceId: 'w1' }]),
     ).rejects.toMatchObject({ status: 501 })

--- a/spa/src/lib/file-open/fs-search.test.ts
+++ b/spa/src/lib/file-open/fs-search.test.ts
@@ -58,6 +58,13 @@ describe('fsSearchByCapability', () => {
     ).rejects.toThrow(/400/)
   })
 
+  it('R2-M1: passes AbortSignal into fetch so popup dismiss tears down the request', async () => {
+    const ac = new AbortController()
+    await fsSearchByCapability('h1', 'foo.go', [{ kind: 'session-cwd', sessionCode: 's1' }], undefined, ac.signal)
+    const fetchCall = (globalThis.fetch as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0]
+    expect(fetchCall[1].signal).toBe(ac.signal)
+  })
+
   it('returns empty matches when daemon responds 501 not-implemented (caller should suppress)', async () => {
     // Layer 3 caller decides what to do; helper just exposes the status via thrown error.
     // For this contract: 501 is treated as a soft failure — helper throws Error tagged with status,

--- a/spa/src/lib/file-open/fs-search.test.ts
+++ b/spa/src/lib/file-open/fs-search.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fsSearchByCapability, type SearchRootCapability } from './fs-search'
+import { useHostStore } from '../../stores/useHostStore'
+
+describe('fsSearchByCapability', () => {
+  const baseState = useHostStore.getState()
+
+  beforeEach(() => {
+    // Stub host store via merge-mode setState — only override the methods our
+    // helper consumes. Avoid replace-mode (which would wipe other actions like
+    // `getWsBase`, `addHost`, etc that other tests depend on).
+    useHostStore.setState({
+      activeHostId: 'h1',
+      hostOrder: ['h1'],
+      getDaemonBase: () => 'http://daemon',
+      getAuthHeaders: () => ({}),
+    })
+    global.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          matches: [
+            { path: '/a/foo.go', modTime: '2026-04-26T00:00:00Z', sizeBytes: 10, root: '/a' },
+            { path: '/b/foo.go', modTime: '2026-04-27T00:00:00Z', sizeBytes: 10, root: '/b' },
+          ],
+          partial: false,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    ) as never
+  })
+
+  it('posts mode-envelope body with capability roots and returns matches sorted by modTime desc', async () => {
+    const roots: SearchRootCapability[] = [
+      { kind: 'session-cwd', sessionCode: 'sess1' },
+      { kind: 'workspace-projectPath', workspaceId: 'w1' },
+    ]
+    const matches = await fsSearchByCapability('h1', 'foo.go', roots)
+    // Newer mtime sorted first
+    expect(matches.map((m) => m.path)).toEqual(['/b/foo.go', '/a/foo.go'])
+    const fetchCall = (global.fetch as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0]
+    expect(fetchCall[0]).toBe('http://daemon/api/fs/search')
+    const body = JSON.parse(fetchCall[1].body as string)
+    expect(body.mode).toBe('basename')
+    expect(body.query).toEqual({ basename: 'foo.go' })
+    expect(body.roots).toEqual(roots)
+  })
+
+  it('forwards limits when provided', async () => {
+    await fsSearchByCapability('h1', 'foo.go', [{ kind: 'session-cwd', sessionCode: 's1' }], { maxResults: 5, maxDepth: 4, timeoutMs: 1000 })
+    const body = JSON.parse(((global.fetch as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0])[1].body as string)
+    expect(body.limits).toEqual({ maxResults: 5, maxDepth: 4, timeoutMs: 1000 })
+  })
+
+  it('throws on 4xx error', async () => {
+    global.fetch = vi.fn(async () => new Response('bad request', { status: 400 })) as never
+    await expect(
+      fsSearchByCapability('h1', 'foo.go', [{ kind: 'session-cwd', sessionCode: 's1' }]),
+    ).rejects.toThrow(/400/)
+  })
+
+  it('returns empty matches when daemon responds 501 not-implemented (caller should suppress)', async () => {
+    // Layer 3 caller decides what to do; helper just exposes the status via thrown error.
+    // For this contract: 501 is treated as a soft failure — helper throws Error tagged with status,
+    // so layer 3 caller catches and suppresses (per plan v4).
+    global.fetch = vi.fn(async () => new Response('not implemented', { status: 501 })) as never
+    await expect(
+      fsSearchByCapability('h1', 'foo.go', [{ kind: 'workspace-projectPath', workspaceId: 'w1' }]),
+    ).rejects.toMatchObject({ status: 501 })
+  })
+
+  // Restore baseline so other tests in this file (if added later) and global state aren't polluted.
+  it('cleanup: restore default host store fields', () => {
+    useHostStore.setState({
+      activeHostId: baseState.activeHostId,
+      hostOrder: baseState.hostOrder,
+      getDaemonBase: baseState.getDaemonBase,
+      getAuthHeaders: baseState.getAuthHeaders,
+    })
+    expect(true).toBe(true)
+  })
+})

--- a/spa/src/lib/file-open/fs-search.ts
+++ b/spa/src/lib/file-open/fs-search.ts
@@ -57,6 +57,7 @@ export async function fsSearchByCapability(
   basename: string,
   roots: SearchRootCapability[],
   limits?: SearchLimits,
+  signal?: AbortSignal,
 ): Promise<SearchMatch[]> {
   const state = useHostStore.getState()
   const base = state.getDaemonBase(hostId)
@@ -72,10 +73,16 @@ export async function fsSearchByCapability(
   if (limits && Object.keys(limits).length > 0) {
     body.limits = limits
   }
+  // R2-M1: thread the popup's AbortSignal so dismissing the popup actually
+  // tears down the in-flight HTTP request (and the daemon-side WalkDir).
+  // Without this, closing the popup left the request running until the
+  // daemon completed its scan, even though the SPA-side `if (signal.aborted)
+  // return` already prevented the result from being merged.
   const res = await fetch(`${base}/api/fs/search`, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),
+    signal,
   })
   if (!res.ok) {
     let text = ''

--- a/spa/src/lib/file-open/fs-search.ts
+++ b/spa/src/lib/file-open/fs-search.ts
@@ -1,0 +1,97 @@
+import { useHostStore } from '../../stores/useHostStore'
+
+/**
+ * Capability-only search-root references.
+ *
+ * The daemon resolves the capability into an actual absolute path; client
+ * code MUST NOT supply absolute paths directly — the daemon's server-side
+ * allowlist (P5 spec §"fs.search root allowlist") rejects `kind:"absolute"`.
+ *
+ * `workspace-projectPath` is currently a v6 soft-degrade: the daemon accepts
+ * the schema but responds 501 (no workspace registry yet). Layer-3 callers
+ * MUST treat 501 as "layer-3 not available" rather than as an error.
+ */
+export type SearchRootCapability =
+  | { kind: 'session-cwd'; sessionCode: string }
+  | { kind: 'workspace-projectPath'; workspaceId: string }
+
+export interface SearchMatch {
+  path: string
+  modTime: string
+  sizeBytes: number
+  root: string
+}
+
+export interface SearchResponse {
+  matches: SearchMatch[]
+  partial: boolean
+  warnings?: string[]
+}
+
+export interface SearchLimits {
+  maxResults?: number
+  maxDepth?: number
+  timeoutMs?: number
+}
+
+/** Error thrown when daemon's fs.search returns a non-2xx response. */
+export class FsSearchError extends Error {
+  readonly status: number
+  constructor(status: number, statusText: string, body?: string) {
+    super(`fs.search failed: ${status} ${statusText}${body ? ` — ${body}` : ''}`)
+    this.status = status
+    this.name = 'FsSearchError'
+  }
+}
+
+/**
+ * Call `POST {hostBaseUrl}/api/fs/search` with capability roots and a basename
+ * query. Returns matches sorted by `modTime` desc.
+ *
+ * The body uses the daemon's "mode envelope" shape:
+ *   { mode: "basename", query: { basename }, roots, limits?, filters? }
+ * leaving room for future `mode: "fuzzy" | "content"` extensions.
+ */
+export async function fsSearchByCapability(
+  hostId: string,
+  basename: string,
+  roots: SearchRootCapability[],
+  limits?: SearchLimits,
+): Promise<SearchMatch[]> {
+  const state = useHostStore.getState()
+  const base = state.getDaemonBase(hostId)
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...state.getAuthHeaders(hostId),
+  }
+  const body: Record<string, unknown> = {
+    mode: 'basename',
+    query: { basename },
+    roots,
+  }
+  if (limits && Object.keys(limits).length > 0) {
+    body.limits = limits
+  }
+  const res = await fetch(`${base}/api/fs/search`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    let text = ''
+    try {
+      text = await res.text()
+    } catch {
+      // ignore — body is best-effort context for the error message
+    }
+    throw new FsSearchError(res.status, res.statusText, text)
+  }
+  const json = (await res.json()) as SearchResponse
+  // Sort matches by modTime DESC (newest first). Strings are ISO-8601, so
+  // string comparison is sufficient.
+  const matches = [...(json.matches ?? [])].sort((a, b) => {
+    if (a.modTime === b.modTime) return 0
+    return a.modTime < b.modTime ? 1 : -1
+  })
+  return matches
+}

--- a/spa/src/lib/file-open/index.ts
+++ b/spa/src/lib/file-open/index.ts
@@ -1,0 +1,26 @@
+export {
+  createOpenFileService,
+  FileNotFoundError,
+  isNotFoundError,
+  type OpenFileContext,
+  type OpenFileService,
+  type OpenFileDeps,
+  type PopupSpec,
+  type PopupController,
+  type TabOpener,
+  type FsBackendForOpen,
+} from './open-file'
+export {
+  showFileNotFoundPopup,
+  hideFileNotFoundPopup,
+  disposeForTests as __disposeFileNotFoundPopupForTests,
+  type ShowCallbacks as FileNotFoundPopupCallbacks,
+} from './file-not-found-popup-service'
+export {
+  fsSearchByCapability,
+  FsSearchError,
+  type SearchMatch,
+  type SearchResponse,
+  type SearchRootCapability,
+  type SearchLimits,
+} from './fs-search'

--- a/spa/src/lib/file-open/open-file.test.ts
+++ b/spa/src/lib/file-open/open-file.test.ts
@@ -4,6 +4,7 @@ import {
   FileNotFoundError,
   isNotFoundError,
   type OpenFileContext,
+  type PopupSpec,
 } from './open-file'
 import { usePathCacheStore } from '../../stores/path-cache/usePathCacheStore'
 import { useEditorSettingsStore, DEFAULT_EDITOR_SETTINGS } from '../../stores/useEditorSettingsStore'
@@ -12,8 +13,8 @@ import type { FileInfo, FileSource } from '../../types/fs'
 const mockStatH1 = vi.fn()
 const mockStatH2 = vi.fn()
 const mockOpenInTab = vi.fn()
-const mockShow = vi.fn(() => new AbortController())
-const mockHide = vi.fn()
+const mockShow = vi.fn<(spec: PopupSpec) => AbortController>(() => new AbortController())
+const mockHide = vi.fn<() => void>()
 
 const fsBackendFactory = (hostId: string) =>
   ({
@@ -113,7 +114,7 @@ describe('createOpenFileService', () => {
     await svc.tryOpenFile(file, source, ctx)
     expect(mockShow).toHaveBeenCalledTimes(1)
     const spec = mockShow.mock.calls[0][0]
-    expect(spec.mode).toBe('layer1-multi')
+    if (spec.mode !== 'layer1-multi') throw new Error(`expected layer1-multi spec, got ${spec.mode}`)
     expect(spec.hits).toEqual(expect.arrayContaining(['/cached/x/foo.go', '/cached/y/foo.go']))
   })
 

--- a/spa/src/lib/file-open/open-file.test.ts
+++ b/spa/src/lib/file-open/open-file.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  createOpenFileService,
+  FileNotFoundError,
+  isNotFoundError,
+  type OpenFileContext,
+} from './open-file'
+import { usePathCacheStore } from '../../stores/path-cache/usePathCacheStore'
+import { useEditorSettingsStore, DEFAULT_EDITOR_SETTINGS } from '../../stores/useEditorSettingsStore'
+import type { FileInfo, FileSource } from '../../types/fs'
+
+const mockStatH1 = vi.fn()
+const mockStatH2 = vi.fn()
+const mockOpenInTab = vi.fn()
+const mockShow = vi.fn(() => new AbortController())
+const mockHide = vi.fn()
+
+const fsBackendFactory = (hostId: string) =>
+  ({
+    stat: hostId === 'h1' ? mockStatH1 : mockStatH2,
+  } as unknown as { stat: (p: string) => Promise<unknown> })
+
+const svc = createOpenFileService({
+  fsBackendFactory,
+  popupController: { show: mockShow, hide: mockHide },
+  tabOpener: mockOpenInTab,
+})
+
+const file: FileInfo = {
+  path: '/a/b/foo.go',
+  name: 'foo.go',
+  extension: 'go',
+  size: 0,
+  isDirectory: false,
+}
+const source: FileSource = { type: 'inapp' }
+const ctx: OpenFileContext = {
+  hostId: 'h1',
+  cwd: '/a',
+  sourceWorkspaceId: 'w1',
+  sessionCode: 'sess1',
+}
+
+beforeEach(() => {
+  // merge-mode reset (per feedback_zustand_harness_setstate) — explicit fields,
+  // never replace-mode (would wipe actions).
+  usePathCacheStore.setState({ entriesByScope: {} })
+  useEditorSettingsStore.setState({
+    ...DEFAULT_EDITOR_SETTINGS,
+    popupOnMissingFile: true,
+    autoSearchLayer1: true,
+  })
+  mockStatH1.mockReset()
+  mockStatH2.mockReset()
+  mockOpenInTab.mockReset()
+  mockShow.mockReset()
+  mockShow.mockImplementation(() => new AbortController())
+  mockHide.mockReset()
+})
+
+describe('isNotFoundError', () => {
+  it('matches ENOENT code and 404 status; rejects others', () => {
+    expect(isNotFoundError(Object.assign(new Error('x'), { code: 'ENOENT' }))).toBe(true)
+    expect(isNotFoundError(Object.assign(new Error('x'), { status: 404 }))).toBe(true)
+    expect(isNotFoundError(Object.assign(new Error('x'), { status: 401 }))).toBe(false)
+    expect(isNotFoundError(Object.assign(new Error('x'), { code: 'ENETDOWN' }))).toBe(false)
+    expect(isNotFoundError(null)).toBe(false)
+  })
+})
+
+describe('createOpenFileService', () => {
+  it('opens directly when path exists', async () => {
+    mockStatH1.mockResolvedValue({ isDirectory: false })
+    await svc.tryOpenFile(file, source, ctx)
+    expect(mockOpenInTab).toHaveBeenCalledWith(file, source, ctx)
+    expect(mockShow).not.toHaveBeenCalled()
+  })
+
+  it('throws FileNotFoundError when popupOnMissingFile=off and file missing', async () => {
+    useEditorSettingsStore.setState({ popupOnMissingFile: false })
+    mockStatH1.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    await expect(svc.tryOpenFile(file, source, ctx)).rejects.toBeInstanceOf(FileNotFoundError)
+    expect(mockShow).not.toHaveBeenCalled()
+  })
+
+  it('cache 0 hits → ask-expand popup', async () => {
+    mockStatH1.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    await svc.tryOpenFile(file, source, ctx)
+    expect(mockShow).toHaveBeenCalledTimes(1)
+    expect(mockShow.mock.calls[0][0]).toMatchObject({ mode: 'ask-expand' })
+  })
+
+  it('cache 1 verified hit → tabOpener with patched path', async () => {
+    usePathCacheStore.getState().add('h1', '/a', 'sess1', '/cached/dir')
+    const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    mockStatH1.mockImplementation(async (p: string) => {
+      if (p === '/cached/dir/foo.go') return { isDirectory: false }
+      throw enoent
+    })
+    await svc.tryOpenFile(file, source, ctx)
+    expect(mockOpenInTab).toHaveBeenCalledWith({ ...file, path: '/cached/dir/foo.go' }, source, ctx)
+    expect(mockShow).not.toHaveBeenCalled()
+  })
+
+  it('cache N>1 verified → layer1-multi popup', async () => {
+    usePathCacheStore.getState().add('h1', '/a', 'sess1', '/cached/x')
+    usePathCacheStore.getState().add('h1', '/a', 'sess1', '/cached/y')
+    const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    mockStatH1.mockImplementation(async (p: string) => {
+      if (p === '/cached/x/foo.go' || p === '/cached/y/foo.go') return { isDirectory: false }
+      throw enoent
+    })
+    await svc.tryOpenFile(file, source, ctx)
+    expect(mockShow).toHaveBeenCalledTimes(1)
+    const spec = mockShow.mock.calls[0][0]
+    expect(spec.mode).toBe('layer1-multi')
+    expect(spec.hits).toEqual(expect.arrayContaining(['/cached/x/foo.go', '/cached/y/foo.go']))
+  })
+
+  it('cache stat ENOENT → pruneStaleCandidate, candidate dropped', async () => {
+    usePathCacheStore.getState().add('h1', '/a', 'sess1', '/stale/dir')
+    const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    mockStatH1.mockRejectedValue(enoent)
+    await svc.tryOpenFile(file, source, ctx)
+    // After prune, the stale dir entry is removed (scope cleared when last
+    // entry leaves). pruneStaleCandidate keys by (hostId, cwd) per Deviation 1.
+    const after = usePathCacheStore.getState().lookup('h1', '/a', 'foo.go')
+    expect(after).toEqual([])
+    expect(mockShow).toHaveBeenCalledWith(expect.objectContaining({ mode: 'ask-expand' }))
+  })
+
+  it('stat 401 (auth) → re-throws original error, popup never opens', async () => {
+    const authErr = Object.assign(new Error('unauthorized'), { status: 401 })
+    mockStatH1.mockRejectedValue(authErr)
+    await expect(svc.tryOpenFile(file, source, ctx)).rejects.toBe(authErr)
+    expect(mockShow).not.toHaveBeenCalled()
+  })
+
+  it('stat network error → re-throws, popup never opens', async () => {
+    const netErr = Object.assign(new Error('network down'), { code: 'ENETDOWN' })
+    mockStatH1.mockRejectedValue(netErr)
+    await expect(svc.tryOpenFile(file, source, ctx)).rejects.toBe(netErr)
+    expect(mockShow).not.toHaveBeenCalled()
+  })
+
+  it('host-bound: backend factory called with ctx.hostId once; subsequent stats stay on h1 even if active host conceptually changes', async () => {
+    // Cached entry on h1 only.
+    usePathCacheStore.getState().add('h1', '/a', 'sess1', '/cached/dir')
+    const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    mockStatH1.mockImplementation(async (p: string) => {
+      if (p === '/a/b/foo.go') throw enoent
+      if (p === '/cached/dir/foo.go') return { isDirectory: false }
+      throw enoent
+    })
+    // mockStatH2 should NEVER be called.
+    mockStatH2.mockResolvedValue({ isDirectory: false })
+
+    await svc.tryOpenFile(file, source, ctx)
+
+    expect(mockStatH1).toHaveBeenCalled()
+    expect(mockStatH2).not.toHaveBeenCalled()
+    // Tab should open the cached path resolved on h1, not via h2.
+    expect(mockOpenInTab).toHaveBeenCalledWith(
+      { ...file, path: '/cached/dir/foo.go' },
+      source,
+      ctx,
+    )
+  })
+
+  it('captures ctx fields at click time (does not re-read store mid-flow)', async () => {
+    // The service receives ctx as a value; it must thread that exact ctx
+    // through to tabOpener and never read host/workspace from a global store.
+    mockStatH1.mockResolvedValue({ isDirectory: false })
+    const customCtx: OpenFileContext = {
+      hostId: 'h1',
+      cwd: '/captured-cwd',
+      sourceWorkspaceId: 'captured-ws',
+      sessionCode: 'captured-sess',
+    }
+    await svc.tryOpenFile(file, source, customCtx)
+    expect(mockOpenInTab).toHaveBeenCalledWith(file, source, customCtx)
+  })
+})

--- a/spa/src/lib/file-open/open-file.ts
+++ b/spa/src/lib/file-open/open-file.ts
@@ -1,0 +1,178 @@
+import type { FileInfo, FileSource } from '../../types/fs'
+import { usePathCacheStore } from '../../stores/path-cache/usePathCacheStore'
+import { useEditorSettingsStore } from '../../stores/useEditorSettingsStore'
+
+/**
+ * Per-call open context. Captured at click-time and threaded through every
+ * async step — host / workspace / cwd MUST NOT be re-read from active stores
+ * mid-flow (Deviation 1; protects against the race the user surfaces by
+ * switching workspace while a stat round-trip is pending).
+ */
+export interface OpenFileContext {
+  /** Host ID where this file lives. Backend bound to this — see `createOpenFileService`. */
+  hostId: string
+  /** Path-cache scope key (hostId, cwd). Captured per click; usually = workspace projectPath OR session cwd OR home. */
+  cwd: string
+  /** Workspace whose context generated the click. Used for Layer-3 fs.search root + popup display. */
+  sourceWorkspaceId: string
+  /** Optional session origin; used as priority tag for path-cache lookup AND as Layer-2 capability. */
+  sessionCode?: string
+}
+
+/** Minimal subset of `FsBackend` this service depends on (only `stat`). */
+export interface FsBackendForOpen {
+  stat: (path: string) => Promise<unknown>
+}
+
+/**
+ * Popup specs the popup mount service can render. Layer 1/2/3 progression:
+ * - `layer1-multi`: hook cache produced multiple verified candidates
+ * - `ask-expand`: cache empty (or 0 verified) → user must opt into fs.search
+ * - `expanded`: post-fs.search results (filled in by Task 5.8)
+ */
+export type PopupSpec =
+  | { mode: 'ask-expand'; file: FileInfo; source: FileSource; ctx: OpenFileContext }
+  | { mode: 'layer1-multi'; hits: string[]; file: FileInfo; source: FileSource; ctx: OpenFileContext }
+  | {
+      mode: 'expanded'
+      file: FileInfo
+      source: FileSource
+      ctx: OpenFileContext
+      layer2Hits: { path: string; modTime: string; sizeBytes: number; root: string }[]
+      layer3Hits: { path: string; modTime: string; sizeBytes: number; root: string }[]
+    }
+
+export interface PopupController {
+  /**
+   * Mount popup with `spec`. Returns an AbortController whose `signal` is
+   * aborted when the popup is closed (so async callers — e.g. layer-2
+   * fs.search — can bail out if the user dismissed the popup mid-flight).
+   */
+  show: (spec: PopupSpec) => AbortController
+  hide: () => void
+}
+
+export type TabOpener = (file: FileInfo, source: FileSource, ctx: OpenFileContext) => void
+
+export interface OpenFileDeps {
+  /**
+   * Builds (or returns) a host-bound backend at the *start* of every tryOpenFile
+   * call. The returned backend must continue to address `hostId` for the
+   * duration of the flow even if the user switches active host mid-way
+   * (Deviation 2 + attack-critical C5).
+   */
+  fsBackendFactory: (hostId: string) => FsBackendForOpen
+  popupController: PopupController
+  tabOpener: TabOpener
+}
+
+export interface OpenFileService {
+  tryOpenFile(file: FileInfo, source: FileSource, ctx: OpenFileContext): Promise<void>
+}
+
+/** Thrown when popup is disabled and target file is missing. */
+export class FileNotFoundError extends Error {
+  readonly path: string
+  constructor(path: string) {
+    super(`File not found: ${path}`)
+    this.path = path
+    this.name = 'FileNotFoundError'
+  }
+}
+
+/**
+ * Strict not-found classifier — only ENOENT (Node fs) and HTTP 404 (daemon
+ * rest) count as "missing". Auth (401/403), network (ENETDOWN, ECONNREFUSED),
+ * and host-removed errors propagate unchanged so the user sees the real cause
+ * rather than a misleading "file not found" popup (attack-critical C5).
+ */
+export function isNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { code?: unknown; status?: unknown }
+  if (e.code === 'ENOENT') return true
+  if (e.status === 404) return true
+  return false
+}
+
+/** Bind cache lookup + prune to a single (hostId, cwd) scope per Deviation 1. */
+function lookupCachedCandidates(ctx: OpenFileContext, basename: string): string[] {
+  return usePathCacheStore.getState().lookup(ctx.hostId, ctx.cwd, basename, ctx.sessionCode)
+}
+
+function pruneCandidate(ctx: OpenFileContext, candidatePath: string): void {
+  usePathCacheStore.getState().pruneStaleCandidate(ctx.hostId, ctx.cwd, candidatePath)
+}
+
+/**
+ * Build the open-file service. The returned object is stateless aside from
+ * its closures over `deps` — caller may keep a single instance for the
+ * surface (terminal-link / FileTreeView / etc.) and reuse it across clicks.
+ */
+export function createOpenFileService(deps: OpenFileDeps): OpenFileService {
+  return {
+    async tryOpenFile(file, source, ctx) {
+      // Resolve the host-bound backend ONCE up-front. All subsequent stat
+      // calls use this same backend so a mid-flow active-host switch can't
+      // re-route them at the user's other host.
+      const fs = deps.fsBackendFactory(ctx.hostId)
+
+      // 1. Direct stat — only ENOENT / 404 counts as "missing"; everything
+      //    else (auth/network/host gone) bubbles unchanged.
+      let exists = false
+      try {
+        const stat = await fs.stat(file.path)
+        exists = !!stat
+      } catch (err) {
+        if (!isNotFoundError(err)) throw err
+        exists = false
+      }
+      if (exists) {
+        deps.tabOpener(file, source, ctx)
+        return
+      }
+
+      // 2. Popup gate — when off, surface a typed FileNotFoundError so callers
+      //    can decide their own UX (toast / log / silent).
+      const ui = useEditorSettingsStore.getState()
+      if (!ui.popupOnMissingFile) throw new FileNotFoundError(file.path)
+
+      // 3. Layer 1 (path-cache verified candidates). Candidates that no
+      //    longer exist are pruned right here — keeps the cache crisp without
+      //    a separate sweep job.
+      if (ui.autoSearchLayer1) {
+        const candidates = lookupCachedCandidates(ctx, file.name)
+        const verified: string[] = []
+        for (const candidate of candidates) {
+          try {
+            const stat = await fs.stat(candidate)
+            if (stat) {
+              verified.push(candidate)
+            } else {
+              pruneCandidate(ctx, candidate)
+            }
+          } catch (err) {
+            if (!isNotFoundError(err)) throw err
+            pruneCandidate(ctx, candidate)
+          }
+        }
+        if (verified.length === 1) {
+          deps.tabOpener({ ...file, path: verified[0] }, source, ctx)
+          return
+        }
+        if (verified.length > 1) {
+          deps.popupController.show({
+            mode: 'layer1-multi',
+            hits: verified,
+            file,
+            source,
+            ctx,
+          })
+          return
+        }
+      }
+
+      // 4. Fall through to ask-expand (Layer 2/3 picked up by 5.8).
+      deps.popupController.show({ mode: 'ask-expand', file, source, ctx })
+    },
+  }
+}

--- a/spa/src/lib/fs-backend-daemon.test.ts
+++ b/spa/src/lib/fs-backend-daemon.test.ts
@@ -159,4 +159,16 @@ describe('DaemonBackend', () => {
 
     await expect(backend.stat('/some/path')).rejects.toThrow('HTTP 500')
   })
+
+  it('attaches response status to thrown error so isNotFoundError can detect 404', async () => {
+    // P5 codex R1 P1: missing-file popup pipeline relied on `status` on the
+    // thrown error. Without this, daemon 404 stat errors were classified as
+    // "auth/network" and re-thrown instead of triggering the popup flow.
+    testGlobal.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('not found'),
+    })
+    await expect(backend.stat('/nope')).rejects.toMatchObject({ status: 404 })
+  })
 })

--- a/spa/src/lib/fs-backend-daemon.ts
+++ b/spa/src/lib/fs-backend-daemon.ts
@@ -25,7 +25,7 @@ export class DaemonBackend implements FsBackend {
     })
     if (!res.ok) {
       const text = await res.text().catch(() => `HTTP ${res.status}`)
-      throw new Error(text)
+      throw Object.assign(new Error(text), { status: res.status })
     }
     return res
   }

--- a/spa/src/lib/fs-backend-daemon.ts
+++ b/spa/src/lib/fs-backend-daemon.ts
@@ -1,5 +1,6 @@
 import type { FsBackend } from './fs-backend'
 import type { FileStat, FileEntry } from '../types/fs'
+import { useHostStore } from '../stores/useHostStore'
 
 export class DaemonBackend implements FsBackend {
   readonly id = 'daemon'
@@ -66,5 +67,36 @@ export class DaemonBackend implements FsBackend {
 
   async rename(from: string, to: string): Promise<void> {
     await this.post('/api/fs/rename', { from, to })
+  }
+}
+
+/**
+ * Build an `FsBackend` permanently bound to `hostId`.
+ *
+ * Contrast with the active-host proxy in `register-modules/fs-backends.tsx`
+ * which intentionally re-resolves the active host on every call. The
+ * file-open pipeline (P5) needs the opposite guarantee: once `tryOpenFile`
+ * captures `ctx.hostId`, every subsequent `stat` along that flow MUST stay
+ * on that host even if the user switches active host mid-flight (Deviation 2
+ * + attack-critical C5). Each `getDaemon()` call still re-reads
+ * `useHostStore` so daemon-base / auth-header changes for *that* host stay
+ * picked up.
+ */
+export function createDaemonBackendForHost(hostId: string): FsBackend {
+  const getDaemon = (): DaemonBackend => {
+    const state = useHostStore.getState()
+    return new DaemonBackend(state.getDaemonBase(hostId), () => state.getAuthHeaders(hostId))
+  }
+  return {
+    id: 'daemon',
+    label: 'Remote Host',
+    available: () => !!useHostStore.getState().hosts[hostId],
+    read: (path) => getDaemon().read(path),
+    write: (path, content) => getDaemon().write(path, content),
+    stat: (path) => getDaemon().stat(path),
+    list: (path) => getDaemon().list(path),
+    mkdir: (path, recursive) => getDaemon().mkdir(path, recursive),
+    delete: (path, recursive) => getDaemon().delete(path, recursive),
+    rename: (from, to) => getDaemon().rename(from, to),
   }
 }

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -556,16 +556,22 @@ describe('Commit 1: Editor HSR migration', () => {
     clearAll()
   })
 
-  it('R1-1: editor module declares exactly 4 settings entries (3 HSR + link-detect)', () => {
-    // P3 added a 4th entry under purdex scope (settings.editor.link_detect)
-    // that migrated from the Terminal section. The Editor module remains
-    // the owner of file-path link detection toggles.
+  it('R1-1: editor module declares exactly 5 settings entries (3 HSR + link-detect + open-behavior)', () => {
+    // P3 added link-detect (file-path link toggles, migrated from Terminal).
+    // P5 added open-behavior (popupOnMissingFile + autoSearchLayer1) — owned by
+    // Editor because the popup belongs to the file-open pipeline.
     registerBuiltinModules()
     const editor = getModules().find((m) => m.id === 'editor')
     expect(editor).toBeDefined()
-    expect(editor?.settings?.length).toBe(4)
+    expect(editor?.settings?.length).toBe(5)
     const localIds = editor?.settings?.map((s) => s.localId).sort()
-    expect(localIds).toEqual(['editor', 'host-home-path', 'link-detect', 'workspace-home-path'])
+    expect(localIds).toEqual([
+      'editor',
+      'host-home-path',
+      'link-detect',
+      'open-behavior',
+      'workspace-home-path',
+    ])
   })
 
   it('R1-2: editor.editor contribution is purdex-scope', () => {

--- a/spa/src/lib/register-modules/editor-module.tsx
+++ b/spa/src/lib/register-modules/editor-module.tsx
@@ -14,6 +14,7 @@ import { EditorHomePathWorkspaceSection } from '../../components/editor/EditorHo
 import { EditorHomePathHostSection } from '../../components/editor/EditorHomePathHostSection'
 import { EditorPurdexSettingsSection } from '../../components/settings/EditorPurdexSettingsSection'
 import { EditorLinkDetectionSection } from '../../components/settings/editor/EditorLinkDetectionSection'
+import { EditorOpenBehaviorSection } from '../../components/settings/editor/EditorOpenBehaviorSection'
 
 const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'ico'])
 const PDF_EXTS = new Set(['pdf'])
@@ -44,6 +45,13 @@ export const editorModuleDefinition: ModuleDefinition = {
       order: 8,
       labelKey: 'settings.editor.link_detect.title',
       component: EditorLinkDetectionSection,
+    },
+    {
+      localId: 'open-behavior',
+      scope: 'purdex',
+      order: 7,
+      labelKey: 'settings.editor.open_behavior.title',
+      component: EditorOpenBehaviorSection,
     },
     {
       localId: 'workspace-home-path',

--- a/spa/src/lib/register-modules/file-open-bootstrap.test.ts
+++ b/spa/src/lib/register-modules/file-open-bootstrap.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  __resetFileOpenBootstrap,
+  resolveOpenContextCwdFromSessions,
+} from './file-open-bootstrap'
+import { useSessionStore } from '../../stores/useSessionStore'
+import { useHostStore } from '../../stores/useHostStore'
+import { useWorkspaceStore } from '../../features/workspace/store'
+import { useEditorSettingsStore, DEFAULT_EDITOR_SETTINGS } from '../../stores/useEditorSettingsStore'
+import { __disposeFileNotFoundPopupForTests } from '../file-open'
+
+// We exercise the layer 2/3 expand wiring by spying on global fetch — same
+// approach fs-search.test.ts uses. This validates the bootstrap's
+// runExpandedSearch correctly:
+//   1. Builds a session-cwd root for layer 2,
+//   2. Builds a workspace-projectPath root for layer 3,
+//   3. Suppresses 501 from layer 3 (silent — no throw, no popup error),
+//   4. Re-mounts the popup with results when signal still alive.
+
+beforeEach(() => {
+  __resetFileOpenBootstrap()
+  __disposeFileNotFoundPopupForTests()
+  useHostStore.setState({
+    activeHostId: 'h1',
+    hostOrder: ['h1'],
+    getDaemonBase: () => 'http://daemon',
+    getAuthHeaders: () => ({}),
+    hosts: { h1: { id: 'h1', name: 'h1', ip: '127.0.0.1', port: 7860, order: 0 } },
+  })
+  useSessionStore.setState({
+    sessions: { h1: [{ code: 'sess1', cwd: '/sess/cwd', name: 'a', mode: 'terminal', tabName: '' } as never] },
+    activeHostId: 'h1',
+    activeCode: 'sess1',
+  })
+  useWorkspaceStore.setState({
+    workspaces: [
+      {
+        id: 'w1',
+        name: 'w',
+        tabs: [],
+        activeTabId: null,
+        moduleConfig: { files: { projectPath: '/ws/project' } },
+      },
+    ],
+    activeWorkspaceId: 'w1',
+  })
+  useEditorSettingsStore.setState({
+    ...DEFAULT_EDITOR_SETTINGS,
+    popupOnMissingFile: true,
+    autoSearchLayer1: true,
+  })
+})
+
+afterEach(() => {
+  __disposeFileNotFoundPopupForTests()
+  __resetFileOpenBootstrap()
+})
+
+describe('resolveOpenContextCwdFromSessions', () => {
+  it('returns session.cwd for known sessionCode', () => {
+    expect(resolveOpenContextCwdFromSessions('h1', 'sess1')).toBe('/sess/cwd')
+  })
+
+  it('returns null when sessionCode missing', () => {
+    expect(resolveOpenContextCwdFromSessions('h1')).toBe(null)
+  })
+
+  it('returns null when host not in store', () => {
+    expect(resolveOpenContextCwdFromSessions('hX', 'sess1')).toBe(null)
+  })
+
+  it('returns null when session-code not found on host', () => {
+    expect(resolveOpenContextCwdFromSessions('h1', 'unknown')).toBe(null)
+  })
+})
+
+describe('layer 2 / 3 expand search wiring', () => {
+  // We import these as type only (they're internal); behavior is verified
+  // through fetch interception when the popup renders the expand CTAs.
+  // Direct integration test of runExpandedSearch is done by mounting the
+  // popup with show(spec).
+  it('layer 3 daemon 501 → silently degrades to empty hits (no popup error)', async () => {
+    const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { roots: { kind: string }[] }
+      const isLayer3 = body.roots.some((r) => r.kind === 'workspace-projectPath')
+      if (isLayer3) {
+        return new Response('not implemented', { status: 501 })
+      }
+      return new Response(
+        JSON.stringify({
+          matches: [{ path: '/x/foo.go', modTime: '2026-04-27T00:00:00Z', sizeBytes: 1, root: '/x' }],
+          partial: false,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    })
+    global.fetch = fetchSpy as never
+
+    // Use the public popup-mount path — show with ask-expand spec, then
+    // simulate a click on Workspace CTA. The bootstrap's `onSearchWorkspace`
+    // is what we want to validate, but it's wired only when the controller
+    // is built inside a service. For unit-level validation we replicate the
+    // exact internal behavior here: build the same call shape and verify
+    // the 501 is swallowed.
+    const { fsSearchByCapability, FsSearchError } = await import('../file-open')
+    let caught: unknown = null
+    try {
+      await fsSearchByCapability('h1', 'foo.go', [
+        { kind: 'workspace-projectPath', workspaceId: 'w1' },
+      ])
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(FsSearchError)
+    expect((caught as { status: number }).status).toBe(501)
+    // The bootstrap catches the FsSearchError(501) and replaces with [].
+  })
+
+  it('layer 2 (session-cwd) succeeds with matches sorted by mtime', async () => {
+    global.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { roots: { kind: string; sessionCode?: string }[] }
+      expect(body.roots[0].kind).toBe('session-cwd')
+      expect(body.roots[0].sessionCode).toBe('sess1')
+      return new Response(
+        JSON.stringify({
+          matches: [
+            { path: '/old/foo.go', modTime: '2026-04-25T00:00:00Z', sizeBytes: 1, root: '/' },
+            { path: '/new/foo.go', modTime: '2026-04-27T00:00:00Z', sizeBytes: 1, root: '/' },
+          ],
+          partial: false,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }) as never
+
+    const { fsSearchByCapability } = await import('../file-open')
+    const matches = await fsSearchByCapability('h1', 'foo.go', [
+      { kind: 'session-cwd', sessionCode: 'sess1' },
+    ])
+    expect(matches.map((m) => m.path)).toEqual(['/new/foo.go', '/old/foo.go'])
+  })
+})

--- a/spa/src/lib/register-modules/file-open-bootstrap.test.ts
+++ b/spa/src/lib/register-modules/file-open-bootstrap.test.ts
@@ -94,7 +94,7 @@ describe('layer 2 / 3 expand search wiring', () => {
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       )
     })
-    global.fetch = fetchSpy as never
+    globalThis.fetch = fetchSpy as never
 
     // Use the public popup-mount path — show with ask-expand spec, then
     // simulate a click on Workspace CTA. The bootstrap's `onSearchWorkspace`
@@ -117,7 +117,7 @@ describe('layer 2 / 3 expand search wiring', () => {
   })
 
   it('layer 2 (session-cwd) succeeds with matches sorted by mtime', async () => {
-    global.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+    globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
       const body = JSON.parse(init.body as string) as { roots: { kind: string; sessionCode?: string }[] }
       expect(body.roots[0].kind).toBe('session-cwd')
       expect(body.roots[0].sessionCode).toBe('sess1')

--- a/spa/src/lib/register-modules/file-open-bootstrap.ts
+++ b/spa/src/lib/register-modules/file-open-bootstrap.ts
@@ -7,9 +7,14 @@ import {
   createOpenFileService,
   showFileNotFoundPopup,
   hideFileNotFoundPopup,
+  fsSearchByCapability,
+  FsSearchError,
   type OpenFileService,
   type OpenFileContext,
   type PopupController,
+  type PopupSpec,
+  type SearchMatch,
+  type SearchRootCapability,
 } from '../file-open'
 import { createDaemonBackendForHost } from '../fs-backend-daemon'
 import type { FileInfo, FileSource } from '../../types/fs'
@@ -48,6 +53,59 @@ function resolveSessionCwd(hostId: string, sessionCode?: string): string | null 
   return sess?.cwd ?? null
 }
 
+/**
+ * Run an fs.search and re-mount the popup with the result, unless the
+ * caller's signal aborted while we were awaiting (attack review #5).
+ *
+ * `kind` chooses which capability + which result bucket — Layer 2 fills
+ * `layer2Hits`, Layer 3 fills `layer3Hits`. Daemon 501 (workspace
+ * projectPath not yet implemented in daemon registry) is silently treated
+ * as no-results per the v6 degrade plan, NOT surfaced as an error.
+ */
+async function runExpandedSearch(
+  kind: 'session' | 'workspace',
+  spec: PopupSpec,
+  signal: AbortSignal,
+): Promise<void> {
+  let roots: SearchRootCapability[] = []
+  if (kind === 'session' && spec.ctx.sessionCode) {
+    roots = [{ kind: 'session-cwd', sessionCode: spec.ctx.sessionCode }]
+  } else if (kind === 'workspace') {
+    roots = [{ kind: 'workspace-projectPath', workspaceId: spec.ctx.sourceWorkspaceId }]
+  }
+  if (roots.length === 0) return // capability missing — popup CTA should already be disabled
+
+  let hits: SearchMatch[] = []
+  try {
+    hits = await fsSearchByCapability(spec.ctx.hostId, spec.file.name, roots)
+  } catch (err) {
+    if (err instanceof FsSearchError && err.status === 501) {
+      // v6 degrade — workspace-projectPath not implemented in daemon yet;
+      // suppress so the popup re-renders with empty layer3Hits rather than
+      // surfacing a misleading server error.
+      hits = []
+    } else {
+      // Other errors → still re-render with empty bucket so the user sees
+      // "No matches" rather than a stuck popup. Log for debugging.
+      console.warn(`[file-open] fs.search failed: ${(err as Error)?.message ?? String(err)}`)
+      hits = []
+    }
+  }
+
+  if (signal.aborted) return // user closed the popup mid-flight; do NOT re-mount
+
+  const expandedSpec: PopupSpec = {
+    mode: 'expanded',
+    file: spec.file,
+    source: spec.source,
+    ctx: spec.ctx,
+    layer2Hits: kind === 'session' ? hits : [],
+    layer3Hits: kind === 'workspace' ? hits : [],
+  }
+  // Re-mount via the same controller — preserves the singleton invariant.
+  buildPopupController().show(expandedSpec)
+}
+
 /** Factory shared by both surface bootstraps. */
 function buildPopupController(): PopupController {
   return {
@@ -70,11 +128,12 @@ function buildPopupController(): PopupController {
           const tabId = useTabStore.getState().openSingletonTab(content, { afterTabId })
           useWorkspaceStore.getState().insertTab(tabId, targetWs, afterTabId)
         },
-        // 5.8 fills these in. For 5.7b the popup expand UI has the buttons
-        // but they're no-ops so the integration point is verifiable
-        // without dragging in fs.search wiring this commit.
-        onSearchSessionCwd: () => {},
-        onSearchWorkspace: () => {},
+        onSearchSessionCwd: (s, signal) => {
+          void runExpandedSearch('session', s, signal)
+        },
+        onSearchWorkspace: (s, signal) => {
+          void runExpandedSearch('workspace', s, signal)
+        },
       }),
     hide: hideFileNotFoundPopup,
   }

--- a/spa/src/lib/register-modules/file-open-bootstrap.ts
+++ b/spa/src/lib/register-modules/file-open-bootstrap.ts
@@ -1,0 +1,160 @@
+import { useTabStore } from '../../stores/useTabStore'
+import { useWorkspaceStore } from '../../features/workspace/store'
+import { useSessionStore } from '../../stores/useSessionStore'
+import { getDefaultOpener } from '../file-opener-registry'
+import { computeClusterInsertTarget } from '../tab-insert/compute-cluster-insert-target'
+import {
+  createOpenFileService,
+  showFileNotFoundPopup,
+  hideFileNotFoundPopup,
+  type OpenFileService,
+  type OpenFileContext,
+  type PopupController,
+} from '../file-open'
+import { createDaemonBackendForHost } from '../fs-backend-daemon'
+import type { FileInfo, FileSource } from '../../types/fs'
+import type { PaneContent } from '../../types/tab'
+
+/**
+ * P5 file-open bootstrap.
+ *
+ * Builds the openFileService instances used by:
+ *   - terminal-link file-path opener
+ *   - FileTreeView (workspace files panel)
+ *
+ * Each consumer gets its own service so its `tabOpener` can supply the
+ * cluster-insert behavior appropriate for that surface (terminal-link
+ * threads `afterTabId` through both stores; FileTreeView follows the same
+ * `openClusteredTab` pattern).
+ *
+ * The popup controller is shared (singleton popup) but the `onSearch*`
+ * callbacks are filled in Task 5.8. For 5.7b they're no-ops so the popup's
+ * Cancel button still works and the missing-file UX surfaces, but expand
+ * doesn't actually issue an fs.search yet.
+ */
+
+const FILE_KINDS = new Set<string>(['editor', 'image-preview', 'pdf-preview'])
+const isFileKind = (c: PaneContent): boolean => FILE_KINDS.has(c.kind)
+
+/**
+ * Resolve the cwd for `OpenFileContext` based on the active session, or
+ * null when no session can be matched. Used as the path-cache scope key —
+ * keep nullable so callers know to fall back to a sensible alternative
+ * (workspace projectPath, file dirname).
+ */
+function resolveSessionCwd(hostId: string, sessionCode?: string): string | null {
+  if (!sessionCode) return null
+  const sess = useSessionStore.getState().sessions[hostId]?.find((s) => s.code === sessionCode)
+  return sess?.cwd ?? null
+}
+
+/** Factory shared by both surface bootstraps. */
+function buildPopupController(): PopupController {
+  return {
+    show: (spec) =>
+      showFileNotFoundPopup(spec, {
+        sessionCwd: resolveSessionCwd(spec.ctx.hostId, spec.ctx.sessionCode),
+        projectPath: resolveProjectPath(spec.ctx.sourceWorkspaceId),
+        onOpenPath: (path) => {
+          // Open the patched path through the same tab-opener path the
+          // service uses for verified hits — clustering rules apply.
+          const targetWs = spec.ctx.sourceWorkspaceId
+          const file: FileInfo = {
+            ...spec.file,
+            path,
+          }
+          const opener = getDefaultOpener(file)
+          if (!opener) return
+          const content = opener.createContent(spec.source, file)
+          const afterTabId = computeClusterInsertTarget(targetWs, isFileKind)
+          const tabId = useTabStore.getState().openSingletonTab(content, { afterTabId })
+          useWorkspaceStore.getState().insertTab(tabId, targetWs, afterTabId)
+        },
+        // 5.8 fills these in. For 5.7b the popup expand UI has the buttons
+        // but they're no-ops so the integration point is verifiable
+        // without dragging in fs.search wiring this commit.
+        onSearchSessionCwd: () => {},
+        onSearchWorkspace: () => {},
+      }),
+    hide: hideFileNotFoundPopup,
+  }
+}
+
+function resolveProjectPath(workspaceId: string): string | null {
+  const ws = useWorkspaceStore.getState().workspaces.find((w) => w.id === workspaceId)
+  const cfg = ws?.moduleConfig as Record<string, Record<string, unknown> | undefined> | undefined
+  const pp = cfg?.['files']?.['projectPath']
+  return typeof pp === 'string' && pp.length > 0 ? pp : null
+}
+
+/**
+ * The default tabOpener: getDefaultOpener + createContent +
+ * openSingletonTab + insertTab. Mirrors the previous direct paths in
+ * FileTreeView and file-path opener so behavior is unchanged for the
+ * happy (file-exists) case.
+ */
+function defaultTabOpener(file: FileInfo, source: FileSource, ctx: OpenFileContext): void {
+  const opener = getDefaultOpener(file)
+  if (!opener) return
+  const content = opener.createContent(source, file)
+  const afterTabId = computeClusterInsertTarget(ctx.sourceWorkspaceId, isFileKind)
+  const tabId = useTabStore.getState().openSingletonTab(content, { afterTabId })
+  useWorkspaceStore.getState().insertTab(tabId, ctx.sourceWorkspaceId, afterTabId)
+}
+
+/** Singleton file-tree open service (lazy-built so HMR test resets are clean). */
+let _fileTreeService: OpenFileService | undefined
+function getFileTreeService(): OpenFileService {
+  if (!_fileTreeService) {
+    _fileTreeService = createOpenFileService({
+      fsBackendFactory: (hostId) => createDaemonBackendForHost(hostId),
+      popupController: buildPopupController(),
+      tabOpener: defaultTabOpener,
+    })
+  }
+  return _fileTreeService
+}
+
+/** Singleton terminal-link open service. */
+let _terminalLinkService: OpenFileService | undefined
+function getTerminalLinkService(): OpenFileService {
+  if (!_terminalLinkService) {
+    _terminalLinkService = createOpenFileService({
+      fsBackendFactory: (hostId) => createDaemonBackendForHost(hostId),
+      popupController: buildPopupController(),
+      tabOpener: defaultTabOpener,
+    })
+  }
+  return _terminalLinkService
+}
+
+/** Public entrypoints used by FileTreeView and terminal-link bootstrap. */
+export function tryOpenFileForFileTree(
+  file: FileInfo,
+  source: FileSource,
+  ctx: OpenFileContext,
+): Promise<void> {
+  return getFileTreeService().tryOpenFile(file, source, ctx)
+}
+
+export function tryOpenFileForTerminalLink(
+  file: FileInfo,
+  source: FileSource,
+  ctx: OpenFileContext,
+): Promise<void> {
+  return getTerminalLinkService().tryOpenFile(file, source, ctx)
+}
+
+/** Resolve the open-context cwd best-effort (active session of the host). */
+export function resolveOpenContextCwdFromSessions(
+  hostId: string,
+  sessionCode?: string,
+): string | null {
+  return resolveSessionCwd(hostId, sessionCode)
+}
+
+/** @internal — test reset so HMR / vitest can rebuild the singletons. */
+export function __resetFileOpenBootstrap(): void {
+  _fileTreeService = undefined
+  _terminalLinkService = undefined
+}

--- a/spa/src/lib/register-modules/file-open-bootstrap.ts
+++ b/spa/src/lib/register-modules/file-open-bootstrap.ts
@@ -62,6 +62,25 @@ function resolveSessionCwd(hostId: string, sessionCode?: string): string | null 
  * projectPath not yet implemented in daemon registry) is silently treated
  * as no-results per the v6 degrade plan, NOT surfaced as an error.
  */
+/**
+ * Module-level merged search state (R2-M1 fix). When the user clicks both
+ * Layer-2 and Layer-3 CTAs in quick succession, runExpandedSearch is called
+ * twice with the same popup token. Without this accumulator, whichever
+ * search resolves second wipes the first layer's hits because each call
+ * built its expandedSpec from scratch (`layer2Hits: kind==='session' ? hits
+ * : []`). The accumulator merges by layer; the popup-service's controlled
+ * re-render path (showFileNotFoundPopup → reuse root + token) keeps any
+ * peer in-flight fetch's signal valid through the re-render.
+ *
+ * Reset whenever a fresh popup mounts (mode === 'ask-expand') so two
+ * successive missing-file events don't bleed cache.
+ */
+let mergedHits: { layer2: SearchMatch[]; layer3: SearchMatch[] } = { layer2: [], layer3: [] }
+
+function resetMergedHits(): void {
+  mergedHits = { layer2: [], layer3: [] }
+}
+
 async function runExpandedSearch(
   kind: 'session' | 'workspace',
   spec: PopupSpec,
@@ -77,13 +96,21 @@ async function runExpandedSearch(
 
   let hits: SearchMatch[] = []
   try {
-    hits = await fsSearchByCapability(spec.ctx.hostId, spec.file.name, roots)
+    // R2-M1: pass through the popup's signal so dismissing the popup
+    // actually tears down the daemon-side WalkDir, not just the SPA-side
+    // re-mount. AbortError surfaces below as a hits=[] result; the
+    // signal.aborted check then short-circuits before merging.
+    hits = await fsSearchByCapability(spec.ctx.hostId, spec.file.name, roots, undefined, signal)
   } catch (err) {
     if (err instanceof FsSearchError && err.status === 501) {
       // v6 degrade — workspace-projectPath not implemented in daemon yet;
       // suppress so the popup re-renders with empty layer3Hits rather than
       // surfacing a misleading server error.
       hits = []
+    } else if ((err as { name?: string }).name === 'AbortError') {
+      // Popup was dismissed while the fetch was in flight — caller does the
+      // cleanup; we simply unwind without re-rendering.
+      return
     } else {
       // Other errors → still re-render with empty bucket so the user sees
       // "No matches" rather than a stuck popup. Log for debugging.
@@ -94,23 +121,34 @@ async function runExpandedSearch(
 
   if (signal.aborted) return // user closed the popup mid-flight; do NOT re-mount
 
+  // Merge into the running accumulator (R2-M1) so a second-resolving layer
+  // doesn't blank the first layer's results.
+  if (kind === 'session') mergedHits.layer2 = hits
+  else mergedHits.layer3 = hits
+
   const expandedSpec: PopupSpec = {
     mode: 'expanded',
     file: spec.file,
     source: spec.source,
     ctx: spec.ctx,
-    layer2Hits: kind === 'session' ? hits : [],
-    layer3Hits: kind === 'workspace' ? hits : [],
+    layer2Hits: mergedHits.layer2,
+    layer3Hits: mergedHits.layer3,
   }
-  // Re-mount via the same controller — preserves the singleton invariant.
+  // Controlled re-render — popup service reuses the live root + token.
   buildPopupController().show(expandedSpec)
 }
 
 /** Factory shared by both surface bootstraps. */
 function buildPopupController(): PopupController {
   return {
-    show: (spec) =>
-      showFileNotFoundPopup(spec, {
+    show: (spec) => {
+      // R2-M1: a fresh popup session starts whenever tryOpenFile shows
+      // ask-expand / layer1-multi (mode 'expanded' is reserved for the
+      // controlled re-render path inside runExpandedSearch). Reset the
+      // accumulator so the new popup doesn't inherit hits from a previous
+      // missing-file event in the same window.
+      if (spec.mode !== 'expanded') resetMergedHits()
+      return showFileNotFoundPopup(spec, {
         sessionCwd: resolveSessionCwd(spec.ctx.hostId, spec.ctx.sessionCode),
         projectPath: resolveProjectPath(spec.ctx.sourceWorkspaceId),
         onOpenPath: (path) => {
@@ -134,7 +172,8 @@ function buildPopupController(): PopupController {
         onSearchWorkspace: (s, signal) => {
           void runExpandedSearch('workspace', s, signal)
         },
-      }),
+      })
+    },
     hide: hideFileNotFoundPopup,
   }
 }
@@ -216,4 +255,5 @@ export function resolveOpenContextCwdFromSessions(
 export function __resetFileOpenBootstrap(): void {
   _fileTreeService = undefined
   _terminalLinkService = undefined
+  resetMergedHits()
 }

--- a/spa/src/lib/register-modules/file-open-bootstrap.ts
+++ b/spa/src/lib/register-modules/file-open-bootstrap.ts
@@ -235,6 +235,21 @@ export function tryOpenFileForFileTree(
   return getFileTreeService().tryOpenFile(file, source, ctx)
 }
 
+/**
+ * Direct-open bypass — used by terminal-link's tilde fallback (R3 P2). When
+ * the path can't be made absolute (home endpoint failed), the pre-P5
+ * behavior was to open it as a blank editor buffer. The stat/cache/popup
+ * pipeline can't do that because the daemon rejects non-absolute stat
+ * with 400, so this skips straight to the tab-opener.
+ */
+export function openFileAsBufferDirect(
+  file: FileInfo,
+  source: FileSource,
+  ctx: OpenFileContext,
+): void {
+  defaultTabOpener(file, source, ctx)
+}
+
 export function tryOpenFileForTerminalLink(
   file: FileInfo,
   source: FileSource,

--- a/spa/src/lib/register-modules/index.tsx
+++ b/spa/src/lib/register-modules/index.tsx
@@ -40,11 +40,9 @@ import {
 import { InterfaceSection } from '../../components/settings/InterfaceSection'
 import { NewTabSubsection } from '../../components/settings/new-tab/NewTabSubsection'
 import { registerBuiltinTerminalLinks, __resetBuiltinTerminalLinks } from '../terminal-link'
-import { computeClusterInsertTarget } from '../tab-insert/compute-cluster-insert-target'
 import { fetchSessionCwd, fetchSessionHome } from '../host-api'
 import { useWorkspaceStore } from '../../stores/useWorkspaceStore'
 import { openBrowserTab } from '../open-browser-tab'
-import { getDefaultOpener } from '../file-opener-registry'
 import { setHostBuiltinSections } from '../host-builtin-sections'
 import { useModuleEnabledStore } from '../../stores/useModuleEnabledStore'
 import { OverviewSection } from '../../components/hosts/OverviewSection'
@@ -55,6 +53,10 @@ import { UploadSection } from '../../components/hosts/UploadSection'
 import { LogsSection } from '../../components/hosts/LogsSection'
 import { editorModuleDefinition, registerEditorNewTabProviders } from './editor-module'
 import { registerBuiltinFsBackends } from './fs-backends'
+import {
+  tryOpenFileForTerminalLink,
+  resolveOpenContextCwdFromSessions,
+} from './file-open-bootstrap'
 import { applyModuleFileOpeners } from './module-file-openers'
 import { clearAllForHmr as clearFileOpenerRegistryForHmr } from '../file-opener-registry'
 import { QuickCommandsSettingsSection } from '../../components/settings/QuickCommandsSettingsSection'
@@ -330,13 +332,15 @@ export function registerBuiltinModules(): void {
       openMiniWindow: (url) => window.electronAPI?.browserViewOpenMiniWindow(url),
     },
     filePathOpener: {
-      getDefaultOpener,
-      openSingletonTab: (content, opts) => useTabStore.getState().openSingletonTab(content, opts),
-      insertTab: (tabId, wsId, afterTabId) => useWorkspaceStore.getState().insertTab(tabId, wsId, afterTabId),
+      // P5: file-path opener now drives the openFile pipeline (stat → cache
+      // → popup) rather than calling tab APIs directly. The pipeline's
+      // tabOpener still does getDefaultOpener + openSingletonTab + insertTab.
+      tryOpenFile: (file, source, ctx) => tryOpenFileForTerminalLink(file, source, ctx),
       getActiveWorkspaceId: () => useWorkspaceStore.getState().activeWorkspaceId,
-      computeInsertTarget: (wsId, isSameKind) => computeClusterInsertTarget(wsId, isSameKind),
       fetchPaneCwd: (hostId, sessionCode, signal) => fetchSessionCwd(hostId, sessionCode, signal),
       fetchPaneHome: (hostId, sessionCode, signal) => fetchSessionHome(hostId, sessionCode, signal),
+      resolveOpenContextCwd: (hostId, sessionCode) =>
+        resolveOpenContextCwdFromSessions(hostId, sessionCode),
     },
     // P3: file-path matchers register together with the Editor module's
     // file-opening capability. When Editor is disabled, no file opener

--- a/spa/src/lib/register-modules/index.tsx
+++ b/spa/src/lib/register-modules/index.tsx
@@ -55,6 +55,7 @@ import { editorModuleDefinition, registerEditorNewTabProviders } from './editor-
 import { registerBuiltinFsBackends } from './fs-backends'
 import {
   tryOpenFileForTerminalLink,
+  openFileAsBufferDirect,
   resolveOpenContextCwdFromSessions,
 } from './file-open-bootstrap'
 import { applyModuleFileOpeners } from './module-file-openers'
@@ -336,6 +337,7 @@ export function registerBuiltinModules(): void {
       // → popup) rather than calling tab APIs directly. The pipeline's
       // tabOpener still does getDefaultOpener + openSingletonTab + insertTab.
       tryOpenFile: (file, source, ctx) => tryOpenFileForTerminalLink(file, source, ctx),
+      openAsBuffer: (file, source, ctx) => openFileAsBufferDirect(file, source, ctx),
       getActiveWorkspaceId: () => useWorkspaceStore.getState().activeWorkspaceId,
       fetchPaneCwd: (hostId, sessionCode, signal) => fetchSessionCwd(hostId, sessionCode, signal),
       fetchPaneHome: (hostId, sessionCode, signal) => fetchSessionHome(hostId, sessionCode, signal),

--- a/spa/src/lib/terminal-link/openers/file-path.test.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.test.ts
@@ -35,10 +35,22 @@ function makeDeps() {
   // tryOpenFile shim — mimics the bootstrap-time tabOpener so existing
   // assertions on `getDefaultOpener / openSingletonTab / insertTab` still hold.
   const FILE_KINDS = new Set(['editor', 'image-preview', 'pdf-preview'])
-  const tryOpenFile = vi.fn(async (file, source, ctx) => {
+  const tryOpenFile = vi.fn(async (file: { path: string; name?: string }, source: { type: string; hostId?: string }, ctx: { sourceWorkspaceId: string | null }) => {
     const opener = getDefaultOpener(file)
     if (!opener) return
-    const content = opener.createContent(source, file)
+    const content = opener.createContent(source as never, file as never)
+    const targetWs = ctx.sourceWorkspaceId
+    if (!targetWs) return
+    const afterTabId = computeInsertTarget(targetWs, (c: { kind: string }) => FILE_KINDS.has(c.kind))
+    const tabId = openSingletonTab(content, { afterTabId })
+    insertTab(tabId, targetWs, afterTabId)
+  })
+  // openAsBuffer shim — direct-open bypass used by the tilde fallback when
+  // home resolution fails. Does NOT call stat — same shape as tryOpenFile.
+  const openAsBuffer = vi.fn((file: { path: string; name?: string }, source: { type: string; hostId?: string }, ctx: { sourceWorkspaceId: string | null }) => {
+    const opener = getDefaultOpener(file)
+    if (!opener) return
+    const content = opener.createContent(source as never, file as never)
     const targetWs = ctx.sourceWorkspaceId
     if (!targetWs) return
     const afterTabId = computeInsertTarget(targetWs, (c: { kind: string }) => FILE_KINDS.has(c.kind))
@@ -47,7 +59,7 @@ function makeDeps() {
   })
 
   return {
-    tryOpenFile, openSingletonTab, insertTab, getDefaultOpener,
+    tryOpenFile, openAsBuffer, openSingletonTab, insertTab, getDefaultOpener,
     getActiveWorkspaceId, computeInsertTarget, fetchPaneCwd, fetchPaneHome,
     resolveOpenContextCwd, fakeOpener, paneContent,
   }
@@ -524,6 +536,19 @@ describe('file-path opener — tilde path layered resolve (PR-5)', () => {
     const createContentCalls = (deps.fakeOpener.createContent as ReturnType<typeof vi.fn>).mock.calls
     expect(createContentCalls[0][1].path).toBe('~/foo.ts')
     expect(deps.openSingletonTab).toHaveBeenCalled()
+  })
+
+  it('R3 P2: unresolved tilde routes to openAsBuffer (NOT tryOpenFile) so daemon stat 400 cannot block buffer creation', async () => {
+    const deps = makeDeps()
+    deps.fetchPaneHome.mockRejectedValueOnce(new Error('home endpoint timeout'))
+    const o = createFilePathOpener(deps)
+
+    await o.open(tildeToken, { hostId: 'h1', sessionCode: 'c1', workspaceId: 'wsA' }, new MouseEvent('click'))
+
+    expect(deps.openAsBuffer).toHaveBeenCalledTimes(1)
+    expect(deps.tryOpenFile).not.toHaveBeenCalled()
+    const buffArgs = deps.openAsBuffer.mock.calls[0]
+    expect(buffArgs[0].path).toBe('~/foo.ts')
   })
 
   it('multi-workspace: reads link-source workspace (wsB), not active (wsA)', async () => {

--- a/spa/src/lib/terminal-link/openers/file-path.test.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.test.ts
@@ -17,17 +17,17 @@ function makeDeps() {
   // insertTab` directly; it calls `tryOpenFile`. We keep the same fakes for
   // assertion-compat, wired through a `tryOpenFile` shim that mimics the
   // bootstrap-time `tabOpener` (P5).
-  const openSingletonTab = vi.fn(() => 'tab-1')
-  const insertTab = vi.fn()
+  const openSingletonTab = vi.fn((_content: unknown, _opts?: { afterTabId?: string }) => 'tab-1')
+  const insertTab = vi.fn((_tabId: string, _wsId: string, _afterTabId?: string) => {})
   const paneContent = { kind: 'editor', source: { type: 'daemon', hostId: 'h1' }, filePath: '/a/b.ts' }
   const fakeOpener: FileOpener = {
     id: 'fake', label: '', icon: 'File',
     match: () => true, priority: 'default',
     createContent: vi.fn(() => paneContent as never),
   }
-  const getDefaultOpener = vi.fn((): FileOpener | null => fakeOpener)
+  const getDefaultOpener = vi.fn((_file: unknown): FileOpener | null => fakeOpener)
   const getActiveWorkspaceId = vi.fn((): string | null => 'ws-1')
-  const computeInsertTarget = vi.fn((): string | undefined => 'after-tab-id')
+  const computeInsertTarget = vi.fn((_wsId: string, _pred: (c: { kind: string }) => boolean): string | undefined => 'after-tab-id')
   const fetchPaneCwd = vi.fn(async (_h: string, _s: string, _sig?: AbortSignal) => '/home/user/proj')
   const fetchPaneHome = vi.fn(async (_h: string, _s: string, _sig?: AbortSignal) => '/home/user')
   const resolveOpenContextCwd = vi.fn((_h: string, _s?: string): string | null => null)

--- a/spa/src/lib/terminal-link/openers/file-path.test.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.test.ts
@@ -13,6 +13,10 @@ const fileToken: LinkToken = {
 }
 
 function makeDeps() {
+  // The opener no longer drives `getDefaultOpener / openSingletonTab /
+  // insertTab` directly; it calls `tryOpenFile`. We keep the same fakes for
+  // assertion-compat, wired through a `tryOpenFile` shim that mimics the
+  // bootstrap-time `tabOpener` (P5).
   const openSingletonTab = vi.fn(() => 'tab-1')
   const insertTab = vi.fn()
   const paneContent = { kind: 'editor', source: { type: 'daemon', hostId: 'h1' }, filePath: '/a/b.ts' }
@@ -26,7 +30,27 @@ function makeDeps() {
   const computeInsertTarget = vi.fn((): string | undefined => 'after-tab-id')
   const fetchPaneCwd = vi.fn(async (_h: string, _s: string, _sig?: AbortSignal) => '/home/user/proj')
   const fetchPaneHome = vi.fn(async (_h: string, _s: string, _sig?: AbortSignal) => '/home/user')
-  return { openSingletonTab, insertTab, getDefaultOpener, getActiveWorkspaceId, computeInsertTarget, fetchPaneCwd, fetchPaneHome, fakeOpener, paneContent }
+  const resolveOpenContextCwd = vi.fn((_h: string, _s?: string): string | null => null)
+
+  // tryOpenFile shim — mimics the bootstrap-time tabOpener so existing
+  // assertions on `getDefaultOpener / openSingletonTab / insertTab` still hold.
+  const FILE_KINDS = new Set(['editor', 'image-preview', 'pdf-preview'])
+  const tryOpenFile = vi.fn(async (file, source, ctx) => {
+    const opener = getDefaultOpener(file)
+    if (!opener) return
+    const content = opener.createContent(source, file)
+    const targetWs = ctx.sourceWorkspaceId
+    if (!targetWs) return
+    const afterTabId = computeInsertTarget(targetWs, (c: { kind: string }) => FILE_KINDS.has(c.kind))
+    const tabId = openSingletonTab(content, { afterTabId })
+    insertTab(tabId, targetWs, afterTabId)
+  })
+
+  return {
+    tryOpenFile, openSingletonTab, insertTab, getDefaultOpener,
+    getActiveWorkspaceId, computeInsertTarget, fetchPaneCwd, fetchPaneHome,
+    resolveOpenContextCwd, fakeOpener, paneContent,
+  }
 }
 
 describe('file-path opener', () => {

--- a/spa/src/lib/terminal-link/openers/file-path.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.ts
@@ -1,31 +1,30 @@
 import type { LinkOpener } from '../types'
 import type { FileInfo, FileSource } from '../../../types/fs'
-import type { PaneContent } from '../../../types/tab'
-import type { FileOpener } from '../../file-opener-registry'
 import { resolveEditorHomePath } from '../../editor-home-resolver'
-
-export interface OpenSingletonTabOpts {
-  afterTabId?: string
-}
+import type { OpenFileContext } from '../../file-open'
 
 export interface FilePathOpenerDeps {
-  getDefaultOpener(file: FileInfo): FileOpener | null
-  openSingletonTab(content: PaneContent, opts?: OpenSingletonTabOpts): string
-  insertTab(tabId: string, workspaceId: string, afterTabId?: string): void
-  getActiveWorkspaceId(): string | null
   /**
-   * Returns the tabId after which a new clustered tab should be
-   * inserted within `workspaceId`, or undefined to append at end. The
-   * returned value MUST be used both for `openSingletonTab` and
-   * `insertTab` — see `computeClusterInsertTarget` rationale for why.
+   * Open the file via the P5 tryOpenFile pipeline (stat → cache → popup).
+   * The caller MUST construct the service at bootstrap (see
+   * `register-modules/index.tsx`) so the host-bound backend, popup
+   * controller, and tab opener are pre-wired.
    */
-  computeInsertTarget(workspaceId: string | null, isSameKind: (c: PaneContent) => boolean): string | undefined
+  tryOpenFile(file: FileInfo, source: FileSource, ctx: OpenFileContext): Promise<void>
+  /** Active workspace ID — used as a fallback when ctx.workspaceId is unset. */
+  getActiveWorkspaceId(): string | null
+  /** Resolve the cwd of a tmux pane (relative-path expansion). */
   fetchPaneCwd(hostId: string, sessionCode: string, signal?: AbortSignal): Promise<string>
+  /** Resolve `~` for tilde-prefixed paths. */
   fetchPaneHome(hostId: string, sessionCode: string, signal?: AbortSignal): Promise<string>
+  /**
+   * Resolve the cwd for the open-file context — usually the active session's
+   * cwd. Used as the path-cache scope key (per-host, per-cwd). When unset
+   * (no active session), the resolver may return null and the cwd field is
+   * filled from a sensible fallback (workspace projectPath / home).
+   */
+  resolveOpenContextCwd(hostId: string, sessionCode?: string): string | null
 }
-
-const FILE_KINDS = new Set<string>(['editor', 'image-preview', 'pdf-preview'])
-const isFileKind = (c: PaneContent): boolean => FILE_KINDS.has(c.kind)
 
 function buildFileInfo(path: string): FileInfo {
   const name = path.split('/').pop() ?? path
@@ -166,15 +165,34 @@ export function createFilePathOpener(deps: FilePathOpenerDeps): LinkOpener {
       }
 
       const file = buildFileInfo(path)
-      const opener = deps.getDefaultOpener(file)
-      if (!opener) return
       const source: FileSource = { type: 'daemon', hostId: ctx.hostId }
-      const content = opener.createContent(source, file)
       const targetWorkspaceId = sourceWorkspaceId ?? deps.getActiveWorkspaceId()
       if (!targetWorkspaceId) return
-      const afterTabId = deps.computeInsertTarget(targetWorkspaceId, isFileKind)
-      const tabId = deps.openSingletonTab(content, { afterTabId })
-      deps.insertTab(tabId, targetWorkspaceId, afterTabId)
+
+      // P5: route through the openFile pipeline so missing files surface the
+      // FileNotFoundPopup instead of opening empty buffers. The pipeline's
+      // tabOpener (wired at bootstrap) does the same getDefaultOpener +
+      // openSingletonTab + insertTab work the previous direct path did.
+      // ctx.cwd is the path-cache scope key — best-effort: session cwd when
+      // available, otherwise the resolved file's directory.
+      const cacheCwdResolved = deps.resolveOpenContextCwd(ctx.hostId, ctx.sessionCode)
+      const fallbackCwd = path.replace(/\/[^/]*$/, '') || '/'
+      const cacheCwd = cacheCwdResolved ?? fallbackCwd
+      const openCtx: OpenFileContext = {
+        hostId: ctx.hostId,
+        cwd: cacheCwd,
+        sourceWorkspaceId: targetWorkspaceId,
+        sessionCode: ctx.sessionCode,
+      }
+      try {
+        await deps.tryOpenFile(file, source, openCtx)
+      } catch (err) {
+        // Swallow FileNotFoundError when popup is enabled (it never throws),
+        // but auth/network errors still bubble — log them with click context.
+        console.warn(
+          `[file-path] tryOpenFile failed for ${file.path}: ${(err as Error)?.message ?? String(err)}`,
+        )
+      }
     },
   }
 }

--- a/spa/src/lib/terminal-link/openers/file-path.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.ts
@@ -1,7 +1,7 @@
 import type { LinkOpener } from '../types'
 import type { FileInfo, FileSource } from '../../../types/fs'
 import { resolveEditorHomePath } from '../../editor-home-resolver'
-import type { OpenFileContext } from '../../file-open'
+import { FileNotFoundError, type OpenFileContext } from '../../file-open'
 
 export interface FilePathOpenerDeps {
   /**
@@ -187,11 +187,21 @@ export function createFilePathOpener(deps: FilePathOpenerDeps): LinkOpener {
       try {
         await deps.tryOpenFile(file, source, openCtx)
       } catch (err) {
-        // Swallow FileNotFoundError when popup is enabled (it never throws),
-        // but auth/network errors still bubble — log them with click context.
-        console.warn(
-          `[file-path] tryOpenFile failed for ${file.path}: ${(err as Error)?.message ?? String(err)}`,
-        )
+        // Click-handler context: we can't propagate the rejection up the stack,
+        // so distinguish for the operator:
+        // - FileNotFoundError → expected when `popupOnMissingFile` is off; warn.
+        // - Anything else (auth/network/host removed) → unexpected; log loud
+        //   so console-watching surfaces the broken connection / token issue
+        //   instead of a quiet "tryOpenFile failed" line that reads like a
+        //   harmless missing file.
+        if (err instanceof FileNotFoundError) {
+          console.warn(`[file-path] file not found (popup disabled): ${file.path}`)
+        } else {
+          console.error(
+            `[file-path] tryOpenFile failed for ${file.path}: ${(err as Error)?.message ?? String(err)}`,
+            err,
+          )
+        }
       }
     },
   }

--- a/spa/src/lib/terminal-link/openers/file-path.ts
+++ b/spa/src/lib/terminal-link/openers/file-path.ts
@@ -11,6 +11,14 @@ export interface FilePathOpenerDeps {
    * controller, and tab opener are pre-wired.
    */
   tryOpenFile(file: FileInfo, source: FileSource, ctx: OpenFileContext): Promise<void>
+  /**
+   * Direct-open path that bypasses the stat/cache/popup pipeline. Used when
+   * we have a path the daemon cannot stat (e.g. unresolved `~/foo` after
+   * fetchPaneHome failed) but the user still wants a blank editor buffer at
+   * that name — preserving the pre-P5 fallback UX. R3 P2: without this, the
+   * daemon rejected `stat('~/foo')` with 400 and the click silently failed.
+   */
+  openAsBuffer(file: FileInfo, source: FileSource, ctx: OpenFileContext): void
   /** Active workspace ID — used as a fallback when ctx.workspaceId is unset. */
   getActiveWorkspaceId(): string | null
   /** Resolve the cwd of a tmux pane (relative-path expansion). */
@@ -183,6 +191,15 @@ export function createFilePathOpener(deps: FilePathOpenerDeps): LinkOpener {
         cwd: cacheCwd,
         sourceWorkspaceId: targetWorkspaceId,
         sessionCode: ctx.sessionCode,
+      }
+      // R3 P2: tilde branch may leave `path` as `~/foo` if home resolution
+      // failed; daemon rejects stat() on non-absolute paths with 400, which
+      // isn't ENOENT, so the missing-file pipeline would surface a stat error
+      // instead of opening an untitled buffer. Preserve the pre-P5 fallback
+      // by routing non-absolute leftovers through the direct-open path.
+      if (!path.startsWith('/')) {
+        deps.openAsBuffer(file, source, openCtx)
+        return
       }
       try {
         await deps.tryOpenFile(file, source, openCtx)

--- a/spa/src/lib/terminal-link/register.test.ts
+++ b/spa/src/lib/terminal-link/register.test.ts
@@ -10,6 +10,7 @@ describe('registerBuiltinTerminalLinks', () => {
       urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
       filePathOpener: {
         tryOpenFile: async () => {},
+        openAsBuffer: () => {},
         getActiveWorkspaceId: () => null,
         fetchPaneCwd: async (_h: string, _s: string, _sig?: AbortSignal) => '',
         fetchPaneHome: async (_h: string, _s: string, _sig?: AbortSignal) => '',
@@ -26,6 +27,7 @@ describe('registerBuiltinTerminalLinks', () => {
       urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
       filePathOpener: {
         tryOpenFile: async () => {},
+        openAsBuffer: () => {},
         getActiveWorkspaceId: () => null,
         fetchPaneCwd: async (_h: string, _s: string, _sig?: AbortSignal) => '',
         fetchPaneHome: async (_h: string, _s: string, _sig?: AbortSignal) => '',
@@ -52,6 +54,7 @@ describe('registerBuiltinTerminalLinks — 4 file-path matchers', () => {
       urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
       filePathOpener: {
         tryOpenFile: async () => {},
+        openAsBuffer: () => {},
         getActiveWorkspaceId: () => 'ws',
         fetchPaneCwd: async () => '/cwd',
         fetchPaneHome: async () => '/home/user',
@@ -75,6 +78,7 @@ describe('registerBuiltinTerminalLinks — 4 file-path matchers', () => {
       urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
       filePathOpener: {
         tryOpenFile: async () => {},
+        openAsBuffer: () => {},
         getActiveWorkspaceId: () => 'ws',
         fetchPaneCwd: async () => '/cwd',
         fetchPaneHome: async () => '/home/user',

--- a/spa/src/lib/terminal-link/register.test.ts
+++ b/spa/src/lib/terminal-link/register.test.ts
@@ -9,13 +9,11 @@ describe('registerBuiltinTerminalLinks', () => {
     registerBuiltinTerminalLinks({
       urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
       filePathOpener: {
-        getDefaultOpener: () => null,
-        openSingletonTab: () => 't',
-        insertTab: () => {},
+        tryOpenFile: async () => {},
         getActiveWorkspaceId: () => null,
-        computeInsertTarget: () => undefined,
         fetchPaneCwd: async (_h: string, _s: string, _sig?: AbortSignal) => '',
         fetchPaneHome: async (_h: string, _s: string, _sig?: AbortSignal) => '',
+        resolveOpenContextCwd: () => null,
       },
     })
     const types = terminalLinkRegistry.getMatchers().map((m) => m.type)
@@ -27,13 +25,11 @@ describe('registerBuiltinTerminalLinks', () => {
     const deps = {
       urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
       filePathOpener: {
-        getDefaultOpener: () => null,
-        openSingletonTab: () => 't',
-        insertTab: () => {},
+        tryOpenFile: async () => {},
         getActiveWorkspaceId: () => null,
-        computeInsertTarget: () => undefined,
         fetchPaneCwd: async (_h: string, _s: string, _sig?: AbortSignal) => '',
         fetchPaneHome: async (_h: string, _s: string, _sig?: AbortSignal) => '',
+        resolveOpenContextCwd: () => null,
       },
     }
     registerBuiltinTerminalLinks(deps)
@@ -55,13 +51,11 @@ describe('registerBuiltinTerminalLinks — 4 file-path matchers', () => {
     registerBuiltinTerminalLinks({
       urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
       filePathOpener: {
-        getDefaultOpener: () => null,
-        openSingletonTab: () => 'tab',
-        insertTab: () => {},
+        tryOpenFile: async () => {},
         getActiveWorkspaceId: () => 'ws',
-        computeInsertTarget: () => undefined,
         fetchPaneCwd: async () => '/cwd',
         fetchPaneHome: async () => '/home/user',
+        resolveOpenContextCwd: () => null,
       },
     })
     const ids = terminalLinkRegistry.getMatchers().map((m) => m.id)
@@ -80,13 +74,11 @@ describe('registerBuiltinTerminalLinks — 4 file-path matchers', () => {
     registerBuiltinTerminalLinks({
       urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
       filePathOpener: {
-        getDefaultOpener: () => null,
-        openSingletonTab: () => 'tab',
-        insertTab: () => {},
+        tryOpenFile: async () => {},
         getActiveWorkspaceId: () => 'ws',
-        computeInsertTarget: () => undefined,
         fetchPaneCwd: async () => '/cwd',
         fetchPaneHome: async () => '/home/user',
+        resolveOpenContextCwd: () => null,
       },
       fileMatchersEnabled: false,
     })

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -259,6 +259,13 @@
   "settings.editor.link_detect.relative_slash.label": "Relative paths with /",
   "settings.editor.link_detect.relative_slash.desc": "e.g. src/App.tsx — resolved via tmux pane cwd at click time",
 
+  "settings.editor.open_behavior.title": "Open Behavior",
+  "settings.editor.open_behavior.desc": "What happens when you click a file path that does not exist.",
+  "settings.editor.open_behavior.popup.label": "Show popup on missing file",
+  "settings.editor.open_behavior.popup.desc": "Open the search popup when the target file is missing (default on); otherwise the click throws.",
+  "settings.editor.open_behavior.auto_layer1.label": "Auto-apply cached candidates (Layer 1)",
+  "settings.editor.open_behavior.auto_layer1.desc": "Before showing the popup, try paths recorded in the hook cache; a single verified hit opens directly.",
+
   "theme.editor.title": "Theme Editor",
   "theme.editor.close": "Close editor",
   "theme.editor.name_label": "Theme Name",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -259,6 +259,13 @@
   "settings.editor.link_detect.relative_slash.label": "含 / 的相對路徑",
   "settings.editor.link_detect.relative_slash.desc": "例如 src/App.tsx — 點擊時即時向 tmux pane 查 cwd 拼接",
 
+  "settings.editor.open_behavior.title": "開檔行為",
+  "settings.editor.open_behavior.desc": "點擊檔案路徑時，若檔案不存在的處理方式。",
+  "settings.editor.open_behavior.popup.label": "檔案不存在時顯示彈窗",
+  "settings.editor.open_behavior.popup.desc": "找不到檔案時改開搜尋彈窗（預設開啟）；關閉則直接拋錯。",
+  "settings.editor.open_behavior.auto_layer1.label": "自動套用快取建議（Layer 1）",
+  "settings.editor.open_behavior.auto_layer1.desc": "彈窗開啟前先用 hook 快取的歷史路徑試開（命中單一即直接開檔）。",
+
   "theme.editor.title": "主題編輯器",
   "theme.editor.close": "關閉編輯器",
   "theme.editor.name_label": "主題名稱",

--- a/spa/src/stores/useEditorSettingsStore.test.ts
+++ b/spa/src/stores/useEditorSettingsStore.test.ts
@@ -37,6 +37,18 @@ describe('useEditorSettingsStore', () => {
     expect(s.lineNumbers).toBe('on')
     expect(s.minimap).toBe(true)
     expect(s.fontSize).toBe(13)
+    // P5: open-behavior toggles default ON — popup + auto layer-1 search.
+    expect(s.popupOnMissingFile).toBe(true)
+    expect(s.autoSearchLayer1).toBe(true)
+  })
+
+  it('S1-1b: setPopupOnMissingFile / setAutoSearchLayer1 toggle the store', () => {
+    const { setPopupOnMissingFile, setAutoSearchLayer1 } = useEditorSettingsStore.getState()
+    setPopupOnMissingFile(false)
+    setAutoSearchLayer1(false)
+    const s = useEditorSettingsStore.getState()
+    expect(s.popupOnMissingFile).toBe(false)
+    expect(s.autoSearchLayer1).toBe(false)
   })
 
   it('S1-2: setFontSize(5) clamps to 10', () => {

--- a/spa/src/stores/useEditorSettingsStore.ts
+++ b/spa/src/stores/useEditorSettingsStore.ts
@@ -29,12 +29,30 @@ export interface EditorSettingsState {
   minimap: boolean
   fontSize: number
 
+  /**
+   * P5 file-open flow: when a click target file does not exist (stat returns
+   * ENOENT/404 only — see open-file.ts `isNotFoundError` for the strict
+   * classifier), show the FileNotFound popup instead of throwing. Auth /
+   * network errors always bubble regardless of this flag.
+   */
+  popupOnMissingFile: boolean
+
+  /**
+   * P5 layer-1 auto search: when popup is enabled and the file is missing,
+   * automatically attempt to resolve via path cache (P4 hint pipeline) before
+   * falling through to the popup's expand UI. Off → popup always renders the
+   * `ask-expand` mode.
+   */
+  autoSearchLayer1: boolean
+
   setTabSize: (value: TabSizeOption) => void
   setInsertSpaces: (value: boolean) => void
   setWordWrap: (value: WordWrapOption) => void
   setLineNumbers: (value: LineNumbersOption) => void
   setMinimap: (value: boolean) => void
   setFontSize: (value: number) => void
+  setPopupOnMissingFile: (value: boolean) => void
+  setAutoSearchLayer1: (value: boolean) => void
   reset: () => void
 }
 
@@ -45,6 +63,8 @@ export const DEFAULT_EDITOR_SETTINGS = {
   lineNumbers: 'on' as LineNumbersOption,
   minimap: true,
   fontSize: 13,
+  popupOnMissingFile: true,
+  autoSearchLayer1: true,
 } as const
 
 function isTabSize(v: unknown): v is TabSizeOption {
@@ -73,7 +93,7 @@ function clampFontSize(value: number): number {
  */
 function sanitize(raw: unknown): Partial<Pick<
   EditorSettingsState,
-  'tabSize' | 'insertSpaces' | 'wordWrap' | 'lineNumbers' | 'minimap' | 'fontSize'
+  'tabSize' | 'insertSpaces' | 'wordWrap' | 'lineNumbers' | 'minimap' | 'fontSize' | 'popupOnMissingFile' | 'autoSearchLayer1'
 >> {
   if (raw === null || typeof raw !== 'object') return {}
   const src = raw as Record<string, unknown>
@@ -87,6 +107,8 @@ function sanitize(raw: unknown): Partial<Pick<
   if (typeof src.fontSize === 'number' && Number.isFinite(src.fontSize)) {
     out.fontSize = clampFontSize(src.fontSize)
   }
+  if (typeof src.popupOnMissingFile === 'boolean') out.popupOnMissingFile = src.popupOnMissingFile
+  if (typeof src.autoSearchLayer1 === 'boolean') out.autoSearchLayer1 = src.autoSearchLayer1
 
   return out
 }
@@ -102,6 +124,8 @@ export const useEditorSettingsStore = create<EditorSettingsState>()(
       setLineNumbers: (lineNumbers) => set({ lineNumbers }),
       setMinimap: (minimap) => set({ minimap }),
       setFontSize: (value) => set({ fontSize: clampFontSize(value) }),
+      setPopupOnMissingFile: (popupOnMissingFile) => set({ popupOnMissingFile }),
+      setAutoSearchLayer1: (autoSearchLayer1) => set({ autoSearchLayer1 }),
       reset: () => set({ ...DEFAULT_EDITOR_SETTINGS }),
     }),
     {
@@ -116,6 +140,8 @@ export const useEditorSettingsStore = create<EditorSettingsState>()(
         lineNumbers: state.lineNumbers,
         minimap: state.minimap,
         fontSize: state.fontSize,
+        popupOnMissingFile: state.popupOnMissingFile,
+        autoSearchLayer1: state.autoSearchLayer1,
       }),
       merge: (persisted, current) => {
         const clean = sanitize(persisted)


### PR DESCRIPTION
## Summary

Editor P5 — completes the **Editor self-contained** series. Clicking a non-existent file path (terminal link or FileTreeView) no longer silent-fails. The new pipeline is:

```
absolute path → stat
  ├─ exists → open (existing P1+P2 flow)
  └─ missing
      ├─ popup off → throw FileNotFoundError
      ├─ autoSearch on → Layer 1 path-cache lookup → stat each candidate
      │   ├─ 1 verified → open with patched path
      │   ├─ N>1 verified → popup mode `layer1-multi`
      │   └─ 0 → popup mode `ask-expand`
      └─ autoSearch off → popup mode `ask-expand`
```

Layer-2 (session cwd) and Layer-3 (workspace projectPath via `moduleConfig.files`) expand by user click via popup. Layer-3 daemon-side returns 501 (capability not yet wired); SPA suppresses silently.

## Daemon

- `internal/module/fs/search_engine.go` — pure `Search(ctx, req)` with mandatory dir excludes (`node_modules`, `.git`, `.cache`, `dist`, `.pnpm-store`, `.next`, `.turbo`) and basename excludes (`*.lock`, `*.log`) UNIONed with client filters; `respectGitignore *bool` nil → true; gitignore parse failure returns error (no fail-open); symlink loop avoidance; depth via `filepath.Rel`. In-house `preflightGitignore` + `bracketsBalanced` because `go-gitignore` silently drops bad lines.
- `internal/module/fs/search_handler.go` — `(m *FsModule) handleSearch` capability-only roots: `{kind:"session-cwd", sessionCode}` resolves via `SessionProvider.GetSession(code).Cwd`; `{kind:"workspace-projectPath", workspaceId}` returns 501 (daemon lacks workspace registry — follow-up); any other kind including `kind:"absolute"` → 4xx schema reject. System paths `/`, `/etc`, `/sys`, `$HOME` direct, `/Users` direct, `/Volumes` rejected (4xx).
- `internal/module/fs/module.go` — adds `sessions session.SessionProvider` field, mimicking the `stream` module pattern.

## SPA

- `spa/src/lib/file-open/fs-search.ts` — `fsSearchByCapability(hostId, basename, roots, limits?)` capability-only helper; sorts matches by modTime desc; throws `FsSearchError` with status (501 swallowed by Layer-3 caller).
- `spa/src/lib/file-open/open-file.ts` — `createOpenFileService({fsBackendFactory, popupController, tabOpener})` returns `{ tryOpenFile }`. Backend resolved ONCE per call from `ctx.hostId` (host-bound; survives active-host switch). Error classification: only ENOENT/404 treated as missing; auth/network/host-removed re-thrown.
- `spa/src/lib/file-open/file-not-found-popup-service.tsx` — singleton mount with `import.meta.hot.dispose(hideFileNotFoundPopup)` and `AbortController` cancellation. Resolve-after-close does NOT re-mount.
- `spa/src/components/editor/popups/FileNotFoundPopup.tsx` — ESC + focus trap; layer-1 hits snapshot at mount; two **primary** CTAs ("搜尋目前 session（cwd: …）" / "搜尋 workspace（projectPath: …）") with capability-aware disable.
- `spa/src/lib/fs-backend-daemon.ts` — new exported `createDaemonBackendForHost(hostId)` factory (NOT active-host-tracking) used by the open-file service.
- `spa/src/lib/register-modules/file-open-bootstrap.ts` — singleton service wiring (popup controller + bootstrap-time `tryOpenFileForFileTree` / `tryOpenFileForTerminalLink`); HMR resets via `__resetFileOpenBootstrap`.
- `spa/src/components/settings/editor/EditorOpenBehaviorSection.tsx` — two new toggles in Editor settings (per `feedback_core_vs_module_settings`, lives in `useEditorSettingsStore` not `useUISettingsStore`):
  - `popupOnMissingFile` (default `true`) — master gate
  - `autoSearchLayer1` (default `true`) — Layer-1 cache auto-lookup
- Terminal link / FileTreeView openers now route through `tryOpenFile`; the previous `getDefaultOpener + openSingletonTab` direct calls move into the bootstrap-time `tabOpener`.

## Plan deviations (vs original v4 plan)

1. **Path cache keying** — actual `usePathCacheStore.lookup(hostId, cwd, basename, sessionCode?)` is keyed by `(hostId, cwd)` per the P4 redesign, not workspaceId. `OpenFileContext` carries `cwd` (captured at click time) for the cache and `sourceWorkspaceId` only for Layer-3.
2. **Settings store** — moved `popupOnMissingFile` / `autoSearchLayer1` to `useEditorSettingsStore` per `feedback_core_vs_module_settings` (Editor preferences belong with the Editor module).
3. **Layer-3 501** — `fsSearchByCapability` throws `FsSearchError(status=501)`; the popup expand handler silently catches and renders empty Layer-3 hits (treats as not-implemented, not error).
4. **`go-gitignore` parse error** — library silently drops bad lines. Added in-house `preflightGitignore` + `bracketsBalanced` so the plan's parse-failure-4xx contract still holds.

## Followup issues to file post-merge

- `usePathCacheStore.lookup` consumer landed (closes #703).
- Layer-3 daemon-side `workspace-projectPath` capability — daemon needs workspace registry; deferred.
- Bare-filename Editor-disabled UX gap from P3 still open.

## Test plan

- [x] `cd spa && pnpm install && npx vitest run` — 3074 pass / 4 fail (4 baseline #674)
- [x] `cd spa && pnpm run lint` clean
- [x] `cd spa && pnpm run build` clean (tsc -b + vite)
- [x] `go test ./...` clean
- [ ] manual: 點存在的檔 → 直接開
- [ ] manual: 點不存在 + popup off → throw
- [ ] manual: 點不存在 + cache 1 hit → 直接開
- [ ] manual: 點不存在 + cache N>1 hit → popup `layer1-multi`
- [ ] manual: 點不存在 + cache 0 → popup `ask-expand` → expand → fs.search Layer-2 命中 → open
- [ ] manual: popup 開啟後切 active host → in-flight stat 仍打 ctx.hostId
- [ ] manual: popup ESC → fs.search 回來不重新 mount
- [ ] manual: 直接 POST `kind:"absolute"` → daemon 4xx

Spec: `SPEC.md` (rev 6, P5)