### PR TITLE
fix(electron): unsigned-aware preflight in dev update resign (#709 Stage 0)

### DIFF
--- a/docs/specs/2026-04-28-electron-signing-stage0-plan.md
+++ b/docs/specs/2026-04-28-electron-signing-stage0-plan.md
@@ -196,15 +196,25 @@ Before committing T2:
 
 ```bash
 pnpm --prefix electron test 2>&1 | tee /tmp/stage0-red.log
-# Expected:
+# Actual outcome (full electron test suite):
 #   - 22 existing tests pass (2 static + 20 keybindings)
-#   - smoke test passes (sees stub strings)
-#   - 11 new runtime tests fail with "Expected 'unsigned'/... but received 'unknown'" or thrown errors
-# Total: ~14 pass + 11 fail
+#   - 1 smoke test passes (sees stub strings)
+#   - 7 of 11 new runtime tests pass coincidentally:
+#     * 3 detectSignedState 'unknown' cases match the stub's hardcoded 'unknown'
+#     * 4 resignAppBundle paths already exercise existing sign-everything behaviour
+#       (PDX_SKIP_MAC_SIGN, non-darwin, ad-hoc identity, forced identity)
+#   - 4 of 11 fail with assertion mismatches — the new contract paths:
+#     ✗ detectSignedState returns "signed" when codesign exits 0
+#     ✗ detectSignedState returns "unsigned" on canonical stderr
+#     ✗ resignAppBundle skips codesign when bundle is unsigned
+#     ✗ resignAppBundle throws when detection returns "unknown"
+# Total: 29 pass + 4 fail (out of 33)
 ```
 
+The expected RED count is 4, not 11, because seven runtime tests pass coincidentally — both because the stub returns 'unknown' (matching three cases by design) and because the existing pre-refactor `resignAppBundle` happens to satisfy four assertions (skip env / non-darwin / ad-hoc default / forced identity). The 4 failing tests are exactly the ones that exercise the new contract paths; T3 turns those into pass.
+
 Confirm:
-- All 11 RED failures reference assertion mismatches or thrown messages, NOT `Cannot read properties of undefined`.
+- All 4 RED failures reference assertion mismatches or thrown messages, NOT `Cannot read properties of undefined`.
 - No other test regressed.
 
 **Commit**: `test(electron/updater): add three-state preflight tests + stub (RED)`

--- a/docs/specs/2026-04-28-electron-signing-stage0-plan.md
+++ b/docs/specs/2026-04-28-electron-signing-stage0-plan.md
@@ -1,7 +1,7 @@
 # Electron Signing — Stage 0 Hotfix TDD Plan
 
 - **Date**: 2026-04-28
-- **Status**: Draft plan (pending codex plan review)
+- **Status**: Draft plan v1.1 — incorporates codex plan review (job `task-moiq52ft-3yvukg`, 8 findings: 4 P1 + 4 P2, all addressed).
 - **Worktree**: `.claude/worktrees/electron-signing-stage0-hotfix` (branch `worktree-electron-signing-stage0-hotfix`)
 - **Baseline**: `origin/main @ 166bac19` (`1.0.0-alpha.247`)
 - **Spec**: `docs/specs/2026-04-28-electron-signing-stage0-spec.md` (v1.1)
@@ -20,158 +20,306 @@
 
 ### 0.2 Files this PR must NOT touch
 
-- `scripts/build-electron.mjs` — explicitly out of scope per spec §5. Build-time signing is unchanged.
-- `electron/main.ts`, `electron/preload.ts`, `electron/window-manager.ts` etc. — unrelated.
-- `internal/module/dev/*` — daemon side dev update endpoints unchanged.
+- `scripts/build-electron.mjs` — explicitly out of scope per spec §5.
+- `electron/main.ts`, `electron/preload.ts`, `electron/window-manager.ts` etc. — `resignAppBundle` is only referenced in `electron/updater.ts:190`; nothing else needs to change.
+- `internal/module/dev/*` — daemon-side dev update endpoints unchanged.
 - `spa/**` — no SPA changes; the renderer-side progress UI already labels `signing` (`spa/src/components/settings/DevEnvironmentSection.tsx:256`).
 - `package.json` — Stage 1 territory.
 
 ### 0.3 Concurrent-session safety
 
-Memory `feedback_concurrent_session_safety.md` warns that the main repo may have parallel sessions. Worktree is isolated; the only files that could collide are the spec/plan we own. No risk.
+Worktree is isolated. Per `feedback_concurrent_session_safety.md`, the only collision risk is the spec/plan/test files we own. No risk.
+
+### 0.4 Verification toolchain — what is and isn't available
+
+After `pnpm install --frozen-lockfile` from the worktree root:
+
+| Tool | Path | Verdict |
+| ---- | ---- | ------- |
+| `vitest` | `pnpm --prefix electron test` | ✅ available, 22 existing tests pass |
+| `electron-vite` | `pnpm exec electron-vite ...` | ✅ available (root devDependency) |
+| `tsc` (electron pkg) | `pnpm --prefix electron exec tsc` | ❌ NOT available (electron pkg has only vitest as devDep) |
+| `tsc` (spa pkg) | `pnpm --prefix spa exec tsc -p ../electron/tsconfig.json --noEmit` | ✅ available — typescript 5.9.3 in spa devDeps; works cross-prefix because `tsc` is a CLI not a workspace tool |
+| `electron-vite build` | `pnpm exec electron-vite build` | ✅ available; produces `out/` (we will clean up before commit) |
+
+Implication: standalone `pnpm --prefix electron exec tsc` is removed from gates throughout. Type checking happens via:
+- vitest's ts-loader during `pnpm --prefix electron test` (catches type errors in `electron/**/*.ts` reachable from tests)
+- `pnpm exec electron-vite build` for the full bundler-side type check
+- optionally `pnpm --prefix spa exec tsc -p ../electron/tsconfig.json --noEmit` for explicit no-emit pass
 
 ---
 
-## 1. Pre-flight checks (T0 — already complete)
+## 1. Pre-flight checks (T0)
 
 - [x] Worktree created at `.claude/worktrees/electron-signing-stage0-hotfix`.
 - [x] Issue #709 filed.
 - [x] Spec v1.1 committed (`7eef4929`).
-- [x] Plan committed (this file).
+- [x] Plan v1.1 committed (this file).
+- [x] **`pnpm install --frozen-lockfile` run from worktree root** — required before any test/build command works in the worktree.
 
-No code changes in T0 — the prior commits are spec-only.
+If a fresh subagent picks up this plan, **first action** is to verify `node_modules` exists; if not, run `pnpm install --frozen-lockfile` before T1.
 
 ---
 
 ## 2. Task sequence (TDD)
 
-Each task ends with a single commit. Verification commands listed
-under each task must pass before committing.
+Each task ends with a single commit. RED commits in TDD are explicitly allowed for T2 (commit policy §2.0).
+
+### 2.0 Commit policy clarification
+
+The CLAUDE.md "每個 task 獨立 commit" rule does not require every commit to be green. TDD's RED→GREEN cycle requires the failing-test commit to land first as evidence the test actually fails for the right reason. T2 produces a **behaviour-RED** commit (assertions fail, not import errors); T3 turns it green.
+
+The PR description must explicitly note this policy so reviewers don't flag the temporary failing tests.
 
 ### T1 — Switch updater to `node:` prefix imports
 
-**Why first.** The runtime tests in T2 rely on `vi.mock('node:child_process')`. Switching the production import first lets us write tests against the canonical specifier. T1 is a no-op refactor — green should stay green.
+**Why first.** Tests in T2 mock `node:child_process`. Production import must be on the canonical specifier first.
 
-**Change**:
-
-`electron/updater.ts:2`
+**Change**: `electron/updater.ts:2`
 
 ```diff
 - import { execFileSync } from 'child_process'
 + import { execFileSync, spawnSync } from 'node:child_process'
 ```
 
-`spawnSync` is added in the same import to avoid a churn commit later. T1 does not yet use `spawnSync`; that lands in T3.
+`spawnSync` is added now to avoid a churn diff in T3. `electron/tsconfig.json` does not enable `noUnusedLocals` and there is no lint script for the electron package, so the unused import in T1 is not a gate violation.
 
 **Verification**:
 
 ```bash
-pnpm --prefix electron exec tsc -p tsconfig.json --noEmit
 pnpm --prefix electron test
 ```
 
-Both must pass (existing tests are static grep — they still pass because `'codesign'`, `'--identifier'`, `'dev.wake.purdex'`, `'resignAppBundle'` strings remain).
+Existing 22 tests must remain green. (Type check is implicit via vitest's loader; standalone `tsc` not used per §0.4.)
 
 **Commit**: `refactor(electron/updater): unify imports to node: prefix`
 
 ---
 
-### T2 — Add 11 runtime tests (RED)
+### T2 — Add 11 runtime tests + smoke update + minimal stub (behaviour RED)
 
-**Why before implementation.** Per spec §4.2 / §4.3 + project TDD policy.
+**Why a stub.** Per codex F3, RED must come from assertion mismatch, not from `__testing` being undefined and crashing test setup. T2 commits a stub that makes all 11 tests **runnable but failing on assertions**.
 
-**Change**: rewrite `electron/signing.test.ts` to:
+**Changes**:
 
-1. Keep the two existing static tests for `package.json mac.identity` and `build-electron.mjs` codesign references (`signing.test.ts:8-18`).
-2. Replace the third static grep test with the spec §4.1 smoke version that asserts presence of `detectSignedState`, `resignAppBundle`, and `'node:child_process'` strings.
-3. Add a new `describe('updater signing preflight (runtime)', ...)` block with:
-   - `vi.mock('electron', () => ({ app: { getPath: vi.fn(() => '/Applications/Purdex.app/Contents/MacOS/Purdex') } }))`
-   - `vi.mock('node:child_process', () => ({ spawnSync: vi.fn(), execFileSync: vi.fn() }))`
-   - `beforeEach`: `vi.resetModules()`, reset env vars, reset mocks
-   - `afterEach`: restore env vars
-   - 5 `detectSignedState` cases per spec §4.2 table
-   - 6 `resignAppBundle` cases per spec §4.3 table
+#### 2.T2.A `electron/updater.ts` — minimal stub
 
-Test access pattern (per case):
+Add at end of file (will be replaced by real implementation in T3):
 
 ```ts
-const cp = await import('node:child_process')
-;(cp.spawnSync as Mock).mockReturnValue({ status: 1, stderr: '...' })
-const { __testing } = await import('./updater')
-expect(__testing.detectSignedState('/x/Purdex.app')).toBe('unsigned')
-```
+type SignedState = 'signed' | 'unsigned' | 'unknown'
 
-For non-darwin path (one of the §4.3 cases): mock `process.platform`. Use `vi.stubGlobal('process', { ...process, platform: 'linux' })` or `Object.defineProperty(process, 'platform', { value: 'linux' })` with restore in `afterEach`. Pick the latter — simpler and doesn't require touching every property.
+function detectSignedState(_appBundle: string): SignedState {
+  return 'unknown'   // T3 replaces with real codesign -dv invocation
+}
 
-**Expected outcome**: tests fail because `__testing` does not exist on `./updater` yet (`undefined.detectSignedState` throws). This is the canonical RED state.
-
-**Verification**:
-
-```bash
-pnpm --prefix electron test 2>&1 | tee /tmp/red.log
-# Expected: new tests fail with "Cannot read properties of undefined (reading 'detectSignedState')"
-# Existing static tests (smoke + package.json + build-electron) still pass
-```
-
-Confirm RED tests are exactly the 11 new ones, no other regressions.
-
-**Commit**: `test(electron/updater): add detectSignedState + resignAppBundle preflight tests (RED)`
-
----
-
-### T3 — Implement three-state detection + refactor resign (GREEN)
-
-**Change**: `electron/updater.ts`
-
-1. Add `SignedState` type and `detectSignedState` helper per spec §3.2.
-2. Refactor `resignAppBundle` to:
-   - Early-return on `!appBundle` or `PDX_SKIP_MAC_SIGN === '1'` (existing).
-   - Call `detectSignedState(appBundle)`.
-   - If `'unsigned'`, return.
-   - If `'unknown'`, throw `Error('codesign preflight detection failed; aborting re-sign')`.
-   - If `'signed'`, run existing `execFileSync` codesign + verify chain.
-3. Add the `__testing` namespace export at file end:
-
-```ts
 export const __testing = { detectSignedState, resignAppBundle }
 ```
 
-Function ordering: `getAppBundlePath` → `detectSignedState` → `resignAppBundle` → existing functions, keeping diffs local.
+Also add `_appBundle` to keep the parameter named for the test contract; existing `resignAppBundle` body is unchanged — the test cases for signed/unsigned will fail because the stub returns `'unknown'`, which causes `resignAppBundle` to throw rather than skip-or-resign appropriately. This is the desired behaviour-RED.
 
-**Verification**:
+#### 2.T2.B `electron/signing.test.ts` — restructure
 
-```bash
-pnpm --prefix electron exec tsc -p tsconfig.json --noEmit
-pnpm --prefix electron test
+Keep static tests for `package.json mac.identity` and `build-electron.mjs` codesign references (`signing.test.ts:8-18`). Replace the third static grep with the spec §4.1 smoke version:
+
+```ts
+it('updater exposes signing preflight + re-sign helpers', () => {
+  const updater = readFileSync(resolve(root, 'electron/updater.ts'), 'utf8')
+  expect(updater).toContain('detectSignedState')
+  expect(updater).toContain('resignAppBundle')
+  expect(updater).toContain("'node:child_process'")
+})
 ```
 
-All 11 new tests must turn GREEN. Existing tests must remain GREEN.
+(Smoke test PASSES in T2 because the stub already contains `detectSignedState` and the import is `'node:child_process'`. So the **expected RED count after T2 is 11**, all behavioural — codex F2 resolved.)
+
+Add a new `describe('updater signing preflight (runtime)', ...)` block:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+// import readFileSync, resolve as before for static tests
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((name: string) => {
+      if (name === 'exe') return '/Applications/Purdex.app/Contents/MacOS/Purdex'
+      if (name === 'temp') return '/tmp'
+      return '/'
+    }),
+  },
+}))
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+  execFileSync: vi.fn(),
+}))
+
+describe('updater signing preflight (runtime)', () => {
+  let originalPlatform: PropertyDescriptor
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { ...originalPlatform, value: 'darwin' })
+    originalEnv = { ...process.env }
+    delete process.env.PDX_SKIP_MAC_SIGN
+    delete process.env.PDX_MAC_SIGN_IDENTITY
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform)
+    process.env = originalEnv
+  })
+
+  // 5 detectSignedState cases + 6 resignAppBundle cases per spec §4.2 / §4.3
+})
+```
+
+Test cases use this access pattern:
+
+```ts
+it('detectSignedState returns "signed" when codesign exits 0', async () => {
+  const cp = await import('node:child_process')
+  ;(cp.spawnSync as Mock).mockReturnValue({ status: 0, stderr: 'Identifier=dev.wake.purdex\n' })
+  const { __testing } = await import('./updater')
+  expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('signed')
+})
+```
+
+**Critical**: codex F4 — `Object.defineProperty(process, 'platform')` MUST preserve descriptor flags. Pattern above (spread `originalPlatform` into the override, restore full descriptor in `afterEach`) is the correct shape. Do NOT use `vi.stubGlobal('process', ...)` — that replaces the entire process object and breaks unrelated test infrastructure.
+
+#### 2.T2.C Capture the RED log
+
+Before committing T2:
+
+```bash
+pnpm --prefix electron test 2>&1 | tee /tmp/stage0-red.log
+# Expected:
+#   - 22 existing tests pass (2 static + 20 keybindings)
+#   - smoke test passes (sees stub strings)
+#   - 11 new runtime tests fail with "Expected 'unsigned'/... but received 'unknown'" or thrown errors
+# Total: ~14 pass + 11 fail
+```
+
+Confirm:
+- All 11 RED failures reference assertion mismatches or thrown messages, NOT `Cannot read properties of undefined`.
+- No other test regressed.
+
+**Commit**: `test(electron/updater): add three-state preflight tests + stub (RED)`
+
+The commit message body should explicitly state "T2 of TDD plan; assertion-level RED, T3 turns green."
+
+---
+
+### T3 — Implement detectSignedState + refactor resign (GREEN)
+
+**Changes**: `electron/updater.ts`
+
+1. Replace the T2 stub `detectSignedState` with the real spec §3.2 implementation:
+
+```ts
+function detectSignedState(appBundle: string): SignedState {
+  const result = spawnSync('codesign', ['-dv', appBundle], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  })
+  if (result.status === 0) return 'signed'
+  if (result.status !== null && result.stderr?.includes('code object is not signed at all')) {
+    return 'unsigned'
+  }
+  return 'unknown'
+}
+```
+
+2. Refactor `resignAppBundle` (`electron/updater.ts:51-68`) per spec §3.2:
+
+```ts
+function resignAppBundle(): void {
+  const appBundle = getAppBundlePath()
+  if (!appBundle || process.env.PDX_SKIP_MAC_SIGN === '1') return
+
+  const state = detectSignedState(appBundle)
+  if (state === 'unsigned') return
+  if (state === 'unknown') {
+    throw new Error('codesign preflight detection failed; aborting re-sign')
+  }
+  // state === 'signed': existing codesign + verify chain (unchanged)
+  const identity = process.env.PDX_MAC_SIGN_IDENTITY || '-'
+  const signArgs = [
+    '--force',
+    '--deep',
+    '--options', 'runtime',
+    '--identifier', APP_ID,
+    '--sign', identity,
+  ]
+  if (identity === '-') signArgs.push('--timestamp=none')
+  signArgs.push(appBundle)
+
+  execFileSync('codesign', signArgs, { stdio: 'inherit' })
+  execFileSync('codesign', ['--verify', '--deep', '--strict', '--verbose=4', appBundle], { stdio: 'inherit' })
+}
+```
+
+3. `__testing` namespace export at the file end remains as added in T2.
+
+**Verification (RED→GREEN proof)**:
+
+```bash
+# Targeted: confirm signing.test.ts is fully green
+pnpm --prefix electron exec vitest run signing.test.ts 2>&1 | tee /tmp/stage0-green.log
+
+# Expected:
+#   - 3 static tests pass (2 existing + 1 smoke)
+#   - 11 runtime tests pass
+#   - Total: 14 pass, 0 fail
+
+# RED→GREEN diff
+diff <(grep -E "(✓|×|FAIL)" /tmp/stage0-red.log | sort) \
+     <(grep -E "(✓|×|FAIL)" /tmp/stage0-green.log | sort) || true
+# Confirm: T2 RED tests are exactly the ones that flipped to ✓ in T3.
+
+# Full electron test suite
+pnpm --prefix electron test
+
+# Full build (catches type errors at bundler level; cleans out/ after)
+pnpm exec electron-vite build
+rm -rf out  # leave worktree clean — out/ is gitignored anyway
+```
+
+All three commands must report success. If `electron-vite build` fails on type errors, fix in T3 before commit.
 
 **Commit**: `feat(electron/updater): three-state preflight skips unsigned re-sign`
+
+The commit message body lists which RED test names flipped to GREEN.
 
 ---
 
 ### T4 — Final verification
 
-No code change. Confirm acceptance criteria:
+No code change. Confirm acceptance criteria from spec §6:
 
 ```bash
-# Test suite
+# 1. Tests
 pnpm --prefix electron test
 
-# Type check
-pnpm --prefix electron exec tsc -p tsconfig.json --noEmit
+# 2. Build
+pnpm exec electron-vite build && rm -rf out
 
-# Build
-pnpm exec electron-vite build
-
-# Smoke read of updater.ts to confirm the contract is wired
+# 3. Smoke read of updater.ts contract
 grep -n "detectSignedState\|resignAppBundle\|node:child_process" electron/updater.ts
+# Expect: detectSignedState definition, resignAppBundle dispatching three states,
+#         and exactly one 'node:child_process' import.
+
+# 4. Static + runtime test count
+pnpm --prefix electron exec vitest run signing.test.ts --reporter verbose
+# Expect: 14 pass (3 static + 11 runtime)
 ```
 
 If all green, T4 produces no commit; the branch is ready for PR.
 
-If anything red, **do not paper over** — go back to T2/T3 and adjust. Memory `feedback_codex_review_termination.md` says known/tracked issues can ship, but `pnpm test` red is not a known issue, it's a regression.
+If anything red, **do not paper over** — go back to T2/T3 and adjust.
 
 ---
 
@@ -194,7 +342,7 @@ If during T2/T3 a bug surfaces that requires touching one of these, **stop and s
 
 Per spec §8.2, before tagging alpha.248:
 
-1. Mini: `PDX_SKIP_MAC_SIGN=1 pnpm run electron:build`
+1. Mini: from main repo (post-merge), `PDX_SKIP_MAC_SIGN=1 pnpm run electron:build`
 2. Copy `dist/mac-arm64/Purdex.app` to Air's `/Applications/`
 3. `codesign -dv /Applications/Purdex.app 2>&1` → confirm `code object is not signed at all`
 4. Launch this Purdex
@@ -203,26 +351,59 @@ Per spec §8.2, before tagging alpha.248:
 7. New version visible after relaunch
 8. Post-state: `codesign -dv /Applications/Purdex.app 2>&1` still reports unsigned
 
-If any step fails — do not bump. File issue. The spec covers `unknown` state via throw + rollback, so a thrown detection should leave the system in a recoverable state, but a SIGKILL would mean the contract didn't hold and Stage 1 needs to come earlier.
+**If any step 5-8 fails: do NOT bump alpha.248.** Open an issue, refer back to this plan and the spec. Mock-level test green ≠ runtime contract held.
+
+The bump PR description MUST include a copy-paste of the manual verification result (steps 3, 6, 7, 8 outputs). If not present, bump is incomplete.
 
 ---
 
 ## 5. PR + bump protocol
 
+### 5.1 Stage 0 PR
+
 Per CLAUDE.md:
 
-- PR (Stage 0 fix) → 2-round codex review → resolve findings → merge to `main`.
-- Bump PR (alpha.248) — separate worktree, base `origin/main`, update `VERSION` + `package.json` + `spa/package.json` + `CHANGELOG.md`.
-- Manual verification protocol §4 lives **before** bump; if bump bypasses it, document why in the bump PR description.
+1. Push branch, open PR against `main` with title `fix(electron): unsigned-aware preflight in dev update resign (#709 Stage 0)`.
+2. PR description references #709, links spec v1.1 + plan v1.1, notes T2 RED commit policy from §2.0.
+3. Round-1 codex standard review.
+4. Round-2 codex 3-parallel: attack / defense / file-health.
+5. Resolve findings into table; merge when no P0/P1 outstanding.
+6. After merge, run §4 manual verification before bump.
+
+### 5.2 Bump PR (per `feedback_bump_base_origin_not_local`)
+
+Stage 0 PR squash-merges to `origin/main`. Bump PR is created from a fresh worktree against the latest `origin/main`:
+
+```bash
+# In main repo (NOT this Stage 0 worktree)
+EnterWorktree --name bump-alpha-248
+git fetch origin main
+git reset --hard origin/main
+git log -1                  # must show the just-merged Stage 0 SHA
+
+# Bump
+# - VERSION → 1.0.0-alpha.248
+# - package.json version → 1.0.0-alpha.248
+# - spa/package.json version → 1.0.0-alpha.248
+# - CHANGELOG.md → new section + manual verification result paste
+
+git add -A
+git commit -m "chore: bump version to 1.0.0-alpha.248"
+git push -u origin worktree-bump-alpha-248
+gh pr create --base main --title "chore: bump version to 1.0.0-alpha.248" ...
+```
+
+Per `feedback_bump_base_origin_not_local`: the `git reset --hard origin/main` is mandatory — without it, the worktree may carry a local-main state that includes parallel-session commits not yet on origin.
 
 ---
 
-## 6. Risk register (delta from spec)
+## 6. Risk register
 
-Plan-specific risks (spec §7 covers product-level risks):
-
-| # | Risk | Mitigation |
-| - | ---- | ---------- |
-| P1 | RED→GREEN flip lies — tests pass for the wrong reason (e.g. mock leaks across tests) | `vi.resetModules()` + explicit `vi.clearAllMocks()` in `beforeEach`; each test re-imports updater fresh. |
-| P2 | `Object.defineProperty(process, 'platform', ...)` mutates real process | Restore in `afterEach`; alternative is `vi.stubGlobal` or hoisted setup-file mock. Acceptable risk for a single test. |
-| P3 | Test for "throw on unknown" doesn't actually go through `applyUpdate` rollback (only tests `resignAppBundle` in isolation) | Acceptable — `applyUpdate`'s try/catch is existing tested-by-staging surface; Stage 0 doesn't change it. Spec §4.4 marks this as deferred to Stage 1+ verification. |
+| # | Risk | Likelihood | Impact | Mitigation |
+| - | ---- | ---------- | ------ | ---------- |
+| P1 | RED→GREEN flip lies — tests pass for the wrong reason (e.g. mock leaks across tests) | Low | Medium | `vi.resetModules()` + `vi.clearAllMocks()` in `beforeEach`; each test re-imports updater fresh; T3 verification explicitly diffs RED vs GREEN logs (§T3). |
+| P2 | `process.platform` mock leaks past test boundary | Low | High | Use `getOwnPropertyDescriptor` to capture full descriptor, restore in `afterEach`. Documented in §T2.B. Codex F4 source. |
+| P3 | Test for "throw on unknown" doesn't go through `applyUpdate` rollback (only tests `resignAppBundle` in isolation) | High | Low | Acceptable — `applyUpdate`'s try/catch is existing pre-tested surface; Stage 0 doesn't change it. Spec §4.4 marks this as deferred to Stage 1+. |
+| **P4** | **Mock tests pass but manual §4 protocol fails on real unsigned bundle** | **Low** | **High** | **Manual §4 is mandatory before bump. Bump PR description must paste verification output. If §4 fails, bump is blocked and Stage 1 must be accelerated. Codex F7 source.** |
+| P5 | Subagent runs commands without first running `pnpm install --frozen-lockfile` and gets "command not found" | Medium | Low | §0.4 lists the install precondition; T0 list includes the install as a checkpoint; subagent prompt will reference §0.4. Codex F1 source. |
+| P6 | T2 RED commit accidentally lands on main without T3 (interrupted PR) | Low | Medium | PR is unitary (T1+T2+T3+T4 in one PR, squash-merge). Even if pushed mid-way, the PR is not mergeable until T3 turns tests green. CI gate would block. |

--- a/docs/specs/2026-04-28-electron-signing-stage0-plan.md
+++ b/docs/specs/2026-04-28-electron-signing-stage0-plan.md
@@ -1,0 +1,228 @@
+# Electron Signing — Stage 0 Hotfix TDD Plan
+
+- **Date**: 2026-04-28
+- **Status**: Draft plan (pending codex plan review)
+- **Worktree**: `.claude/worktrees/electron-signing-stage0-hotfix` (branch `worktree-electron-signing-stage0-hotfix`)
+- **Baseline**: `origin/main @ 166bac19` (`1.0.0-alpha.247`)
+- **Spec**: `docs/specs/2026-04-28-electron-signing-stage0-spec.md` (v1.1)
+- **Tracking**: #709 (epic) — Stage 0 deliverable
+- **Target ship**: alpha.248 (separate bump PR)
+
+---
+
+## 0. Scope confirmation
+
+### 0.1 Files this PR may modify
+
+- `electron/updater.ts` — add `detectSignedState`, refactor `resignAppBundle` for three-state dispatch, add `__testing` namespace export, switch import to `node:child_process`.
+- `electron/signing.test.ts` — replace third grep test with smoke; add 5 + 6 = 11 runtime tests under `vi.mock('node:child_process')` + `vi.mock('electron', ...)`.
+- `docs/specs/2026-04-28-electron-signing-stage0-plan.md` — this plan (committed in T0).
+
+### 0.2 Files this PR must NOT touch
+
+- `scripts/build-electron.mjs` — explicitly out of scope per spec §5. Build-time signing is unchanged.
+- `electron/main.ts`, `electron/preload.ts`, `electron/window-manager.ts` etc. — unrelated.
+- `internal/module/dev/*` — daemon side dev update endpoints unchanged.
+- `spa/**` — no SPA changes; the renderer-side progress UI already labels `signing` (`spa/src/components/settings/DevEnvironmentSection.tsx:256`).
+- `package.json` — Stage 1 territory.
+
+### 0.3 Concurrent-session safety
+
+Memory `feedback_concurrent_session_safety.md` warns that the main repo may have parallel sessions. Worktree is isolated; the only files that could collide are the spec/plan we own. No risk.
+
+---
+
+## 1. Pre-flight checks (T0 — already complete)
+
+- [x] Worktree created at `.claude/worktrees/electron-signing-stage0-hotfix`.
+- [x] Issue #709 filed.
+- [x] Spec v1.1 committed (`7eef4929`).
+- [x] Plan committed (this file).
+
+No code changes in T0 — the prior commits are spec-only.
+
+---
+
+## 2. Task sequence (TDD)
+
+Each task ends with a single commit. Verification commands listed
+under each task must pass before committing.
+
+### T1 — Switch updater to `node:` prefix imports
+
+**Why first.** The runtime tests in T2 rely on `vi.mock('node:child_process')`. Switching the production import first lets us write tests against the canonical specifier. T1 is a no-op refactor — green should stay green.
+
+**Change**:
+
+`electron/updater.ts:2`
+
+```diff
+- import { execFileSync } from 'child_process'
++ import { execFileSync, spawnSync } from 'node:child_process'
+```
+
+`spawnSync` is added in the same import to avoid a churn commit later. T1 does not yet use `spawnSync`; that lands in T3.
+
+**Verification**:
+
+```bash
+pnpm --prefix electron exec tsc -p tsconfig.json --noEmit
+pnpm --prefix electron test
+```
+
+Both must pass (existing tests are static grep — they still pass because `'codesign'`, `'--identifier'`, `'dev.wake.purdex'`, `'resignAppBundle'` strings remain).
+
+**Commit**: `refactor(electron/updater): unify imports to node: prefix`
+
+---
+
+### T2 — Add 11 runtime tests (RED)
+
+**Why before implementation.** Per spec §4.2 / §4.3 + project TDD policy.
+
+**Change**: rewrite `electron/signing.test.ts` to:
+
+1. Keep the two existing static tests for `package.json mac.identity` and `build-electron.mjs` codesign references (`signing.test.ts:8-18`).
+2. Replace the third static grep test with the spec §4.1 smoke version that asserts presence of `detectSignedState`, `resignAppBundle`, and `'node:child_process'` strings.
+3. Add a new `describe('updater signing preflight (runtime)', ...)` block with:
+   - `vi.mock('electron', () => ({ app: { getPath: vi.fn(() => '/Applications/Purdex.app/Contents/MacOS/Purdex') } }))`
+   - `vi.mock('node:child_process', () => ({ spawnSync: vi.fn(), execFileSync: vi.fn() }))`
+   - `beforeEach`: `vi.resetModules()`, reset env vars, reset mocks
+   - `afterEach`: restore env vars
+   - 5 `detectSignedState` cases per spec §4.2 table
+   - 6 `resignAppBundle` cases per spec §4.3 table
+
+Test access pattern (per case):
+
+```ts
+const cp = await import('node:child_process')
+;(cp.spawnSync as Mock).mockReturnValue({ status: 1, stderr: '...' })
+const { __testing } = await import('./updater')
+expect(__testing.detectSignedState('/x/Purdex.app')).toBe('unsigned')
+```
+
+For non-darwin path (one of the §4.3 cases): mock `process.platform`. Use `vi.stubGlobal('process', { ...process, platform: 'linux' })` or `Object.defineProperty(process, 'platform', { value: 'linux' })` with restore in `afterEach`. Pick the latter — simpler and doesn't require touching every property.
+
+**Expected outcome**: tests fail because `__testing` does not exist on `./updater` yet (`undefined.detectSignedState` throws). This is the canonical RED state.
+
+**Verification**:
+
+```bash
+pnpm --prefix electron test 2>&1 | tee /tmp/red.log
+# Expected: new tests fail with "Cannot read properties of undefined (reading 'detectSignedState')"
+# Existing static tests (smoke + package.json + build-electron) still pass
+```
+
+Confirm RED tests are exactly the 11 new ones, no other regressions.
+
+**Commit**: `test(electron/updater): add detectSignedState + resignAppBundle preflight tests (RED)`
+
+---
+
+### T3 — Implement three-state detection + refactor resign (GREEN)
+
+**Change**: `electron/updater.ts`
+
+1. Add `SignedState` type and `detectSignedState` helper per spec §3.2.
+2. Refactor `resignAppBundle` to:
+   - Early-return on `!appBundle` or `PDX_SKIP_MAC_SIGN === '1'` (existing).
+   - Call `detectSignedState(appBundle)`.
+   - If `'unsigned'`, return.
+   - If `'unknown'`, throw `Error('codesign preflight detection failed; aborting re-sign')`.
+   - If `'signed'`, run existing `execFileSync` codesign + verify chain.
+3. Add the `__testing` namespace export at file end:
+
+```ts
+export const __testing = { detectSignedState, resignAppBundle }
+```
+
+Function ordering: `getAppBundlePath` → `detectSignedState` → `resignAppBundle` → existing functions, keeping diffs local.
+
+**Verification**:
+
+```bash
+pnpm --prefix electron exec tsc -p tsconfig.json --noEmit
+pnpm --prefix electron test
+```
+
+All 11 new tests must turn GREEN. Existing tests must remain GREEN.
+
+**Commit**: `feat(electron/updater): three-state preflight skips unsigned re-sign`
+
+---
+
+### T4 — Final verification
+
+No code change. Confirm acceptance criteria:
+
+```bash
+# Test suite
+pnpm --prefix electron test
+
+# Type check
+pnpm --prefix electron exec tsc -p tsconfig.json --noEmit
+
+# Build
+pnpm exec electron-vite build
+
+# Smoke read of updater.ts to confirm the contract is wired
+grep -n "detectSignedState\|resignAppBundle\|node:child_process" electron/updater.ts
+```
+
+If all green, T4 produces no commit; the branch is ready for PR.
+
+If anything red, **do not paper over** — go back to T2/T3 and adjust. Memory `feedback_codex_review_termination.md` says known/tracked issues can ship, but `pnpm test` red is not a known issue, it's a regression.
+
+---
+
+## 3. Out-of-scope guards
+
+This plan deliberately defers to Stage 1+:
+
+- ❌ `scripts/build-electron.mjs` — leave alone. Spec §5.
+- ❌ `package.json mac.entitlements` — Stage 1 (1a).
+- ❌ Removing the runtime resign — Stage 1 (1b architectural fix).
+- ❌ daemon-side bundle packaging — Stage 1.
+- ❌ Self-signed cert workflow — Stage 2.
+- ❌ Notarization — Stage 3.
+
+If during T2/T3 a bug surfaces that requires touching one of these, **stop and surface** (per `feedback_phase_skip_threshold.md`). Do not silently expand scope.
+
+---
+
+## 4. Manual verification protocol (post-merge, pre-bump)
+
+Per spec §8.2, before tagging alpha.248:
+
+1. Mini: `PDX_SKIP_MAC_SIGN=1 pnpm run electron:build`
+2. Copy `dist/mac-arm64/Purdex.app` to Air's `/Applications/`
+3. `codesign -dv /Applications/Purdex.app 2>&1` → confirm `code object is not signed at all`
+4. Launch this Purdex
+5. Trigger dev update from Settings → Development
+6. SPA progress reaches `signing` then app exits and relaunches
+7. New version visible after relaunch
+8. Post-state: `codesign -dv /Applications/Purdex.app 2>&1` still reports unsigned
+
+If any step fails — do not bump. File issue. The spec covers `unknown` state via throw + rollback, so a thrown detection should leave the system in a recoverable state, but a SIGKILL would mean the contract didn't hold and Stage 1 needs to come earlier.
+
+---
+
+## 5. PR + bump protocol
+
+Per CLAUDE.md:
+
+- PR (Stage 0 fix) → 2-round codex review → resolve findings → merge to `main`.
+- Bump PR (alpha.248) — separate worktree, base `origin/main`, update `VERSION` + `package.json` + `spa/package.json` + `CHANGELOG.md`.
+- Manual verification protocol §4 lives **before** bump; if bump bypasses it, document why in the bump PR description.
+
+---
+
+## 6. Risk register (delta from spec)
+
+Plan-specific risks (spec §7 covers product-level risks):
+
+| # | Risk | Mitigation |
+| - | ---- | ---------- |
+| P1 | RED→GREEN flip lies — tests pass for the wrong reason (e.g. mock leaks across tests) | `vi.resetModules()` + explicit `vi.clearAllMocks()` in `beforeEach`; each test re-imports updater fresh. |
+| P2 | `Object.defineProperty(process, 'platform', ...)` mutates real process | Restore in `afterEach`; alternative is `vi.stubGlobal` or hoisted setup-file mock. Acceptable risk for a single test. |
+| P3 | Test for "throw on unknown" doesn't actually go through `applyUpdate` rollback (only tests `resignAppBundle` in isolation) | Acceptable — `applyUpdate`'s try/catch is existing tested-by-staging surface; Stage 0 doesn't change it. Spec §4.4 marks this as deferred to Stage 1+ verification. |

--- a/docs/specs/2026-04-28-electron-signing-stage0-spec.md
+++ b/docs/specs/2026-04-28-electron-signing-stage0-spec.md
@@ -2,10 +2,10 @@
 
 - **Version**: 1.0.0-alpha.248 (target bump after merge)
 - **Date**: 2026-04-28
-- **Spec revision**: v1.0 (initial)
+- **Spec revision**: v1.1 (2026-04-28) — incorporates codex spec review (job `task-moipomzf-ivpqjj`, 9 findings: 4 P1 + 4 P2 + 1 P3, all addressed).
 - **Base**: `166bac19` (main @ alpha.247)
 - **Author**: claude-code + wake
-- **Status**: Draft (pending codex spec review)
+- **Status**: Draft (pending plan)
 - **Tracking**: #709 (epic) — Stage 0 deliverable
 
 ## 1. Context
@@ -31,10 +31,12 @@ object is not signed at all`), this is harmful:
 2. macOS AMFI detects the running executable was modified and SIGKILLs
    the process before `app.exit(0)` can run.
 3. `app.relaunch()` is never reached — no new instance launches.
-4. The renaming of `out/{main,preload,renderer}` already completed
-   before signing started, so files are in the new state — but the
-   `catch` block partially rolled back before SIGKILL took effect, so
-   manual restart shows the **old** version.
+
+**Observed result** (alpha.247, 2026-04-28): manual restart shows the
+old version, consistent with the rollback `catch` block having
+completed or partially completed before SIGKILL took effect. Exact
+timing of the rollback relative to SIGKILL is not relied on by this
+hotfix; the goal is to prevent the SIGKILL in the first place.
 
 User-visible symptom (alpha.247, 2026-04-28):
 
@@ -63,44 +65,113 @@ running bundle on macOS:
 The fix is **not** to make codesign safer (we cannot sign a running
 binary safely on macOS — that is a Stage 1 architectural concern,
 addressed by the bundle-swap refactor). The Stage 0 fix is to
-**skip codesign when there is no signature to preserve**.
+**skip codesign when there is no signature to preserve**, while
+distinguishing genuinely-unsigned bundles from situations where the
+detection itself failed (those should propagate as errors, not be
+silently treated as unsigned).
 
 ## 3. Proposed change
 
-### 3.1 Behaviour
+### 3.1 Three-state detection contract
 
-`resignAppBundle()` gains a pre-flight detection step. If the bundle
-is currently unsigned, return early without invoking codesign:
+`resignAppBundle()` gains a pre-flight detection step that classifies
+the bundle into one of three states:
 
-```
+| State      | Decision                | Trigger                                                           |
+| ---------- | ----------------------- | ----------------------------------------------------------------- |
+| `signed`   | Proceed with re-sign    | `codesign -dv` exits with status `0`                              |
+| `unsigned` | **Skip** re-sign (new)  | `codesign -dv` exits non-zero **AND** stderr contains `code object is not signed at all` |
+| `unknown`  | **Throw** (existing rollback runs) | All other outcomes: `status === null` (signal kill), `error` populated (spawn failed), non-zero status with different stderr (e.g. `bundle format unrecognised`, `not a valid Mach-O`, etc.) |
+
+Rationale:
+
+- **Why `unknown` throws.** Silently treating "we don't know" as
+  "skip" turns every detection edge case (PATH issues, broken
+  codesign install, unexpected codesign errors, codesign killed by
+  signal) into a stale-signature production. The `applyUpdate`
+  `try/catch` already handles a thrown signing error by rolling back
+  the file replacement. Routing `unknown` through the same path
+  preserves rollback semantics for legitimately broken environments
+  while specifically targeting the user's confirmed `code object is
+  not signed at all` case.
+- **Why match on stderr, not just exit code.** `codesign -dv`'s
+  non-zero exits cover many distinct failure modes; only the one with
+  the canonical "not signed at all" message is the case Stage 0
+  intends to bypass.
+
+### 3.2 Implementation shape
+
+The detection logic is extracted as a named, testable helper. To
+keep test wiring simple, the helper and `resignAppBundle` are exposed
+via a `__testing` namespace export (no public API change):
+
+```ts
+type SignedState = 'signed' | 'unsigned' | 'unknown'
+
+function detectSignedState(appBundle: string): SignedState {
+  const result = spawnSync('codesign', ['-dv', appBundle], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  })
+  if (result.status === 0) return 'signed'
+  if (result.status !== null && result.stderr?.includes('code object is not signed at all')) {
+    return 'unsigned'
+  }
+  return 'unknown'
+}
+
 function resignAppBundle(): void {
   const appBundle = getAppBundlePath()
   if (!appBundle || process.env.PDX_SKIP_MAC_SIGN === '1') return
-  if (!isAppBundleSigned(appBundle)) return  // ← new
-  // ... existing codesign + verify
+
+  const state = detectSignedState(appBundle)
+  if (state === 'unsigned') return                        // skip
+  if (state === 'unknown') {
+    throw new Error('codesign preflight detection failed; aborting re-sign')
+  }
+  // state === 'signed': existing codesign + verify (unchanged)
+  ...
 }
+
+export const __testing = { detectSignedState, resignAppBundle }
 ```
 
-Detection uses `codesign -dv <bundle>` via `spawnSync`:
+**Module imports unified to `node:` prefix.** As part of this change,
+`electron/updater.ts` switches `import ... from 'child_process'` to
+`import ... from 'node:child_process'` (line 2). This makes
+`vi.mock('node:child_process')` reliably intercept both
+`execFileSync` and `spawnSync` in tests. No runtime behaviour change.
 
-- exit code 0 → bundle is signed → proceed with re-sign (existing
-  behaviour preserved for signed builds, including future Stage 2/3
-  Developer ID setups)
-- exit code non-zero (typically 1 with stderr `code object is not
-  signed at all`) → skip; bundle stays unsigned post-update
+### 3.3 Behaviour matrix
 
-The detection function is extracted as a named, testable helper:
+Reachable states after Stage 0:
 
-```
-function isAppBundleSigned(appBundle: string): boolean {
-  const result = spawnSync('codesign', ['-dv', appBundle], {
-    stdio: ['ignore', 'ignore', 'ignore'],
-  })
-  return result.status === 0
-}
-```
+| Pre-update bundle | `PDX_SKIP_MAC_SIGN` | `PDX_MAC_SIGN_IDENTITY` | Behaviour                                  | Change |
+| ----------------- | ------------------- | ----------------------- | ------------------------------------------ | ------ |
+| Non-darwin        | (any)               | (any)                   | `getAppBundlePath()` returns null → skip   | unchanged |
+| Any               | `=1`                | (any)                   | Skip codesign                              | unchanged |
+| Signed            | unset               | unset                   | Re-sign with ad-hoc `-`, then verify       | unchanged |
+| Signed            | unset               | set                     | Re-sign with given identity, then verify   | unchanged |
+| Unsigned (`code object is not signed at all`) | unset | unset            | **Skip codesign (new)**                    | **new** |
+| Unsigned          | unset               | set                     | **Skip codesign (new)** — preflight wins   | **new** (see §3.4) |
+| Detection error / unknown | unset       | (any)                   | Throw → existing rollback runs             | (was: blanket sign attempt) |
 
-### 3.2 Why detection, not blanket removal
+### 3.4 Precedence: preflight over forced identity
+
+`PDX_MAC_SIGN_IDENTITY` does **not** override the unsigned preflight.
+Even if a user sets `PDX_MAC_SIGN_IDENTITY="Developer ID Application: ..."`,
+an unsigned running bundle still skips re-sign. Rationale:
+
+- This is a hotfix; the architectural fix (Stage 1 bundle-swap)
+  decouples signing from runtime entirely. Forced-identity users on
+  unsigned running bundles are accepting Stage 0's "leave as
+  unsigned" outcome as the lesser evil vs. the SIGKILL.
+- Once Stage 1 ships, dev update never signs at runtime, so this
+  precedence rule becomes moot.
+- `PDX_SKIP_MAC_SIGN=1` remains the highest-priority bypass (skip
+  unconditionally, do not even run preflight).
+
+### 3.5 Why detection, not blanket removal
 
 Three reasons to keep `resignAppBundle()` rather than delete it:
 
@@ -109,57 +180,67 @@ Three reasons to keep `resignAppBundle()` rather than delete it:
    depth before the runtime resign is fully retired).
 2. **Existing test contract** (`signing.test.ts:20-26`) asserts
    `resignAppBundle` exists in `updater.ts`. Removing it requires
-   rewriting that test; out of scope for a hotfix.
+   rewriting that test; this hotfix updates the assertion shape, not
+   the existence claim.
 3. **Local Developer ID dev environments** (Stage 3 and beyond) may
    maintain signed bundles and still benefit from the re-sign step
    while the bundle-swap refactor is pending.
 
-### 3.3 Behaviour matrix after change
-
-| Bundle state pre-update | `PDX_SKIP_MAC_SIGN=1` | Behaviour                  |
-| ----------------------- | --------------------- | -------------------------- |
-| Unsigned                | (any)                 | Skip codesign (new)        |
-| Signed                  | Set                   | Skip codesign (unchanged)  |
-| Signed                  | Unset                 | Re-sign + verify (unchanged) |
-| Non-darwin              | (any)                 | Return early (unchanged)   |
-
 ## 4. Test contract changes
 
-`electron/signing.test.ts` currently has three tests. Stage 0 keeps
-all three with the third updated to reflect the new contract:
+`electron/signing.test.ts` keeps three tests in restructured form,
+plus new runtime tests for `detectSignedState` and `resignAppBundle`.
 
-**Existing test (renamed/updated):**
+### 4.1 Static smoke (existing test, simplified)
+
+The third static grep test is downgraded to a smoke guard — runtime
+tests now own the behaviour contract:
 
 ```ts
-it('re-signs the app bundle only when previously signed', () => {
+it('updater exposes signing preflight + re-sign helpers', () => {
   const updater = readFileSync(resolve(root, 'electron/updater.ts'), 'utf8')
+  expect(updater).toContain('detectSignedState')
   expect(updater).toContain('resignAppBundle')
-  expect(updater).toContain('isAppBundleSigned')   // ← new requirement
-  expect(updater).toContain('codesign')
-  expect(updater).toContain('--identifier')
-  expect(updater).toContain('dev.wake.purdex')
+  expect(updater).toContain("'node:child_process'")
 })
 ```
 
-**New runtime test** for the detection function (mocking `spawnSync`):
+Existing static tests for `package.json` and `build-electron.mjs`
+(`signing.test.ts:8-18`) remain unchanged — they belong to a
+different surface (build pipeline) and Stage 0 does not touch
+`scripts/build-electron.mjs`.
 
-```ts
-it('isAppBundleSigned returns false when codesign reports unsigned', () => {
-  // spawnSync returns { status: 1 } when codesign -dv exits non-zero
-  // resignAppBundle short-circuits — no codesign --sign invocation
-})
+### 4.2 Runtime tests for `detectSignedState`
 
-it('isAppBundleSigned returns true when codesign reports signed', () => {
-  // spawnSync returns { status: 0 }
-  // resignAppBundle proceeds to invoke codesign --sign
-})
-```
+Mocking strategy: `vi.mock('node:child_process')` plus `vi.mock('electron', ...)` to satisfy the top-level `import { app } from 'electron'`. The updater is `dynamic-import`ed inside each test after mocks are set, accessed via `__testing`.
 
-The runtime tests require extracting `isAppBundleSigned` and
-`resignAppBundle` such that `spawnSync` and `execFileSync` can be
-substituted (either via `vi.mock('child_process')` or DI).
-**Preferred approach: `vi.mock('node:child_process')`**, matching the
-style already used elsewhere in this codebase.
+Test cases (one per row):
+
+| Mock outcome                                                            | Expected `detectSignedState` |
+| ----------------------------------------------------------------------- | ---------------------------- |
+| `{ status: 0, stderr: 'Identifier=dev.wake.purdex\n...' }`              | `'signed'`                   |
+| `{ status: 1, stderr: '/Applications/Purdex.app: code object is not signed at all\n' }` | `'unsigned'`                 |
+| `{ status: 1, stderr: 'bundle format unrecognized, invalid, or unsuitable\n' }` | `'unknown'`                  |
+| `{ status: null, signal: 'SIGTERM' }`                                   | `'unknown'`                  |
+| `{ error: new Error('ENOENT: codesign not found') }`                    | `'unknown'`                  |
+
+### 4.3 Runtime tests for `resignAppBundle` integration
+
+| Setup                                                              | Expected behaviour |
+| ------------------------------------------------------------------ | ------------------ |
+| `process.env.PDX_SKIP_MAC_SIGN = '1'`                              | No `spawnSync` or `execFileSync` call. |
+| `getAppBundlePath()` returns null (non-darwin path)                | No `spawnSync` or `execFileSync` call. |
+| Detection returns `'unsigned'`                                     | No `execFileSync` (codesign --sign) call. Function returns normally. |
+| Detection returns `'unknown'`                                      | Throws. No `execFileSync` (codesign --sign) call. |
+| Detection returns `'signed'`, `PDX_MAC_SIGN_IDENTITY` unset        | `execFileSync` invoked with `--sign -` and `--timestamp=none`, then `--verify`. |
+| Detection returns `'signed'`, `PDX_MAC_SIGN_IDENTITY = 'X'`        | `execFileSync` invoked with `--sign X`, no `--timestamp=none`, then `--verify`. |
+
+### 4.4 Coverage of acceptance §6
+
+Each acceptance criterion in §6 maps to at least one runtime test in
+§4.2 / §4.3. The signed-path acceptance is verified at mock level
+only; runtime manual verification on a signed bundle is deferred to
+Stage 2/3 (no signed Stage 0 setup exists).
 
 ## 5. Non-goals
 
@@ -169,53 +250,99 @@ style already used elsewhere in this codebase.
 - **Adding entitlements / Hardened Runtime configuration** — Stage 1.
 - **Self-signed cert workflow** — Stage 2.
 - **Apple Developer ID / notarization** — Stage 3.
-- **Behaviour for signed bundles** — unchanged. If a user has a
-  Developer-ID-signed Purdex.app today, Stage 0 does not affect
-  their dev update flow (broken or otherwise).
+- **Behaviour for signed bundles** — unchanged at runtime (Stage 0
+  verifies signed-path mock contract only).
 - **Reworking rollback semantics** in `applyUpdate` — Stage 1 takes
   this on holistically when the swap model changes.
+- **Modifying `scripts/build-electron.mjs`** — out of scope. Stage 0
+  touches `electron/updater.ts` and `electron/signing.test.ts` only.
 
 ## 6. Acceptance criteria
 
-- `resignAppBundle()` short-circuits before invoking codesign when
-  `codesign -dv <bundle>` exits non-zero on the running bundle.
-- For an unsigned `Purdex.app`, dev update flow reaches `app.relaunch()`
-  and the new instance launches with the new `out/{main,preload,renderer}`.
-- For a signed `Purdex.app` (hypothetical Stage 2/3 setup), no
-  observable behaviour change.
-- `PDX_SKIP_MAC_SIGN=1` continues to bypass everything.
-- `electron/signing.test.ts` passes with the updated contract.
-- New runtime tests for `isAppBundleSigned` pass.
+Verifiable in CI:
+
+- New `detectSignedState` helper exists and is exported via
+  `__testing` namespace.
+- `electron/updater.ts` imports from `node:child_process` (not
+  `child_process`).
+- `electron/signing.test.ts` runtime tests for the 5 detection cases
+  in §4.2 pass.
+- `electron/signing.test.ts` runtime tests for the 6 `resignAppBundle`
+  paths in §4.3 pass.
+- Existing static tests for `package.json mac.identity` and
+  `build-electron.mjs` continue to pass.
 - `pnpm --prefix electron test` green.
-- No changes to daemon-side build/check/download endpoints.
-- No changes to `scripts/build-electron.mjs` (Stage 0 scope is
-  `electron/updater.ts` + `electron/signing.test.ts` only).
+- `pnpm exec electron-vite build` green (no type/build regressions).
+
+Verifiable manually:
+
+- For an unsigned `Purdex.app` (reproducible setup in §8.2), dev
+  update flow reaches `app.relaunch()` and the new instance launches
+  with the new `out/{main,preload,renderer}`.
+- After update, `codesign -dv /Applications/Purdex.app` still reports
+  unsigned (we did not accidentally sign it).
+
+Not verified by Stage 0 (deferred):
+
+- Observable runtime behaviour on a signed bundle. Stage 0 verifies
+  signed-path contract at mock level; full runtime path lives with
+  Stage 2/3.
 
 ## 7. Risk assessment
 
-| Risk | Likelihood | Impact | Mitigation |
-| ---- | ---------- | ------ | ---------- |
-| Detection misclassifies a signed bundle as unsigned (false negative on `-dv`) | Low | Medium — re-sign would be skipped, signature stale after update | `codesign -dv` is the canonical detection tool used in `build-electron.mjs:hasValidSignature`; same primitive. |
-| `spawnSync` itself throws on non-darwin | Low | Low | `getAppBundlePath()` already returns `null` on non-darwin; detection never runs. |
-| Future signed setups regress because we skipped a re-sign | Low | Low | Stage 1 retires this path entirely; window is short. |
-| Hotfix lands but Stage 1 takes long → users live on a "duct-taped" flow | Medium | Low | Stage 1 explicitly tracked in #709; Stage 0 is documented as transitional. |
+| # | Risk | Likelihood | Impact | Mitigation |
+| - | ---- | ---------- | ------ | ---------- |
+| R1 | False negative: detection classifies a real signed bundle as `unsigned` (stderr unexpectedly contains the canonical phrase) | Very low | Medium — re-sign skipped, signature stale after update | The phrase `code object is not signed at all` is documented codesign output; Apple has not changed it across recent macOS releases. Treated as design assumption, revisit if codesign output format changes. |
+| R2 | False positive: detection classifies a corrupt/expired/revoked bundle as `signed` (status 0 but signature actually broken) | Low | Low | Stage 0 intentionally uses a weaker signature-presence check than `build-electron.mjs:hasValidSignature()` (which also runs `codesign --verify --deep --strict` and matches `Identifier=`). Updater only needs to decide whether a prior signature exists, not whether it is trusted/notarized/valid. The downstream `codesign --verify` step will catch broken signatures and throw, hitting rollback. |
+| R3 | `unknown` state throws too eagerly in CI / sandbox environments where codesign behaves unexpectedly | Low | Low | Test suite covers `unknown` as a thrown error; rollback path is the existing one. Real-world `unknown` is rare on real macOS hardware. |
+| R4 | Forced-identity users on unsigned bundles get silently skipped | Low | Low | §3.4 documents this as design intent. Stage 1 bundle-swap removes the rule. |
+| R5 | macOS version drift: future codesign returns different exit codes or stderr phrasing | Low | Low | Detection is centralised in one helper with full test coverage; updating is a one-line change. |
+| R6 | Hotfix lands but Stage 1 takes long → users live on a "duct-taped" flow | Medium | Low | Stage 1 explicitly tracked in #709 with no deferred dependency. Stage 0 is documented as transitional. |
 
 ## 8. Verification plan
 
-1. Unit: `pnpm --prefix electron test` — all tests including new
-   runtime tests pass.
-2. Manual on Air (M1, unsigned bundle, the affected user setup):
-   - Trigger dev update from a fresh alpha.247 → alpha.248 build.
-   - Confirm SPA progress reaches `restarting`.
-   - Confirm app relaunches automatically with new version.
-   - Confirm `codesign -dv /Applications/Purdex.app` still reports
-     unsigned (we did not accidentally sign it).
-3. Optional manual on a signed bundle: skip — no signed setup exists
-   in this project at Stage 0; signed-path coverage is a Stage 2
-   concern.
+### 8.1 Automated
+
+`pnpm --prefix electron test` — runs the updated `signing.test.ts`
+including all 11 runtime cases (5 detection + 6 resign integration).
+
+### 8.2 Manual on Air (M1, the affected user setup)
+
+Prerequisites — produce a stably-unsigned bundle:
+
+1. On Mini, run `PDX_SKIP_MAC_SIGN=1 pnpm run electron:build`.
+   This forces `scripts/build-electron.mjs:signAndVerifyApp` to early-
+   return without signing.
+2. Copy `dist/mac-arm64/Purdex.app` to Air's `/Applications/`.
+3. Confirm pre-state on Air:
+   ```
+   codesign -dv /Applications/Purdex.app 2>&1
+   # Expected: "/Applications/Purdex.app: code object is not signed at all"
+   ```
+
+Test:
+
+4. Launch alpha.247 (or whatever version contains the bug + the
+   Stage 0 fix candidate).
+5. Trigger dev update from Settings → Development.
+6. Confirm SPA progress sequence: `downloading → extracting →
+   applying → signing` (note: `signing` IS the last visible step;
+   `restarting` is never sent because `app.exit(0)` kills the process
+   before IPC delivers — see `electron/updater.ts:213-216`).
+7. Confirm Electron relaunches automatically with the new version.
+8. Confirm post-state: `codesign -dv /Applications/Purdex.app 2>&1`
+   still reports `code object is not signed at all` — we did not
+   accidentally sign it.
+
+### 8.3 Signed-bundle runtime path
+
+Deferred. No signed Stage 0 setup exists in this project. Mock-level
+contract is verified by §4.3 runtime tests; full runtime verification
+is part of Stage 2 (self-signed cert) or Stage 3 (Developer ID).
 
 ## 9. Out-of-scope follow-ups (filed under #709)
 
-- Stage 1: dev update bundle-swap refactor + entitlements.
-- Stage 2: self-signed cert flow.
-- Stage 3: Developer ID + notarization.
+- Stage 1: dev update bundle-swap refactor + entitlements + Hardened
+  Runtime config.
+- Stage 2: self-signed cert flow + cross-machine trust docs.
+- Stage 3: Developer ID + notarization in CI release pipeline.

--- a/docs/specs/2026-04-28-electron-signing-stage0-spec.md
+++ b/docs/specs/2026-04-28-electron-signing-stage0-spec.md
@@ -1,0 +1,221 @@
+# Electron Signing — Stage 0 Hotfix Spec
+
+- **Version**: 1.0.0-alpha.248 (target bump after merge)
+- **Date**: 2026-04-28
+- **Spec revision**: v1.0 (initial)
+- **Base**: `166bac19` (main @ alpha.247)
+- **Author**: claude-code + wake
+- **Status**: Draft (pending codex spec review)
+- **Tracking**: #709 (epic) — Stage 0 deliverable
+
+## 1. Context
+
+PR #672 (commit `7cad0823`, alpha.234) added `resignAppBundle()` to
+`electron/updater.ts:applyUpdate` to keep the app bundle signature
+valid after dev update mutates `out/main`, `out/preload`, `out/renderer`.
+The function unconditionally runs:
+
+```
+codesign --force --deep --options runtime \
+  --identifier dev.wake.purdex --sign - <bundle>
+```
+
+on the **currently running** `Purdex.app`.
+
+For setups where the bundle has never been signed (the user's actual
+deployment — `codesign -dv /Applications/Purdex.app` reports `code
+object is not signed at all`), this is harmful:
+
+1. codesign rewrites `Contents/MacOS/Purdex`, the running Mach-O whose
+   pages are mapped into the live process.
+2. macOS AMFI detects the running executable was modified and SIGKILLs
+   the process before `app.exit(0)` can run.
+3. `app.relaunch()` is never reached — no new instance launches.
+4. The renaming of `out/{main,preload,renderer}` already completed
+   before signing started, so files are in the new state — but the
+   `catch` block partially rolled back before SIGKILL took effect, so
+   manual restart shows the **old** version.
+
+User-visible symptom (alpha.247, 2026-04-28):
+
+- SPA progress reaches `applying`, then disappears
+- DiagnosticsReporter (macOS crash collector) spawns
+- App does not relaunch
+- Manual restart shows the old version
+
+The dev update flow had been working in the unsigned state for the
+entire project history (since the original `feat: dev auto-update
+system` at `a082e100`). PR #672's intent — "keep bundle signature
+valid after mutation" — only applies when the bundle **is** signed;
+on unsigned bundles the re-sign step is gratuitous and now load-
+bearingly broken.
+
+## 2. Problem statement
+
+`resignAppBundle()` runs unconditionally regardless of whether the
+target bundle was signed before the update. Re-signing an unsigned
+running bundle on macOS:
+
+- requires writing to a Mach-O whose pages are live-mapped
+- triggers AMFI's "code modified at runtime" enforcement → SIGKILL
+- aborts the entire `applyUpdate` flow before `app.relaunch()`
+
+The fix is **not** to make codesign safer (we cannot sign a running
+binary safely on macOS — that is a Stage 1 architectural concern,
+addressed by the bundle-swap refactor). The Stage 0 fix is to
+**skip codesign when there is no signature to preserve**.
+
+## 3. Proposed change
+
+### 3.1 Behaviour
+
+`resignAppBundle()` gains a pre-flight detection step. If the bundle
+is currently unsigned, return early without invoking codesign:
+
+```
+function resignAppBundle(): void {
+  const appBundle = getAppBundlePath()
+  if (!appBundle || process.env.PDX_SKIP_MAC_SIGN === '1') return
+  if (!isAppBundleSigned(appBundle)) return  // ← new
+  // ... existing codesign + verify
+}
+```
+
+Detection uses `codesign -dv <bundle>` via `spawnSync`:
+
+- exit code 0 → bundle is signed → proceed with re-sign (existing
+  behaviour preserved for signed builds, including future Stage 2/3
+  Developer ID setups)
+- exit code non-zero (typically 1 with stderr `code object is not
+  signed at all`) → skip; bundle stays unsigned post-update
+
+The detection function is extracted as a named, testable helper:
+
+```
+function isAppBundleSigned(appBundle: string): boolean {
+  const result = spawnSync('codesign', ['-dv', appBundle], {
+    stdio: ['ignore', 'ignore', 'ignore'],
+  })
+  return result.status === 0
+}
+```
+
+### 3.2 Why detection, not blanket removal
+
+Three reasons to keep `resignAppBundle()` rather than delete it:
+
+1. **Forward compatibility with Stage 1.** Stage 1 may still want to
+   re-sign as a safety net during the bundle-swap rollout (defence in
+   depth before the runtime resign is fully retired).
+2. **Existing test contract** (`signing.test.ts:20-26`) asserts
+   `resignAppBundle` exists in `updater.ts`. Removing it requires
+   rewriting that test; out of scope for a hotfix.
+3. **Local Developer ID dev environments** (Stage 3 and beyond) may
+   maintain signed bundles and still benefit from the re-sign step
+   while the bundle-swap refactor is pending.
+
+### 3.3 Behaviour matrix after change
+
+| Bundle state pre-update | `PDX_SKIP_MAC_SIGN=1` | Behaviour                  |
+| ----------------------- | --------------------- | -------------------------- |
+| Unsigned                | (any)                 | Skip codesign (new)        |
+| Signed                  | Set                   | Skip codesign (unchanged)  |
+| Signed                  | Unset                 | Re-sign + verify (unchanged) |
+| Non-darwin              | (any)                 | Return early (unchanged)   |
+
+## 4. Test contract changes
+
+`electron/signing.test.ts` currently has three tests. Stage 0 keeps
+all three with the third updated to reflect the new contract:
+
+**Existing test (renamed/updated):**
+
+```ts
+it('re-signs the app bundle only when previously signed', () => {
+  const updater = readFileSync(resolve(root, 'electron/updater.ts'), 'utf8')
+  expect(updater).toContain('resignAppBundle')
+  expect(updater).toContain('isAppBundleSigned')   // ← new requirement
+  expect(updater).toContain('codesign')
+  expect(updater).toContain('--identifier')
+  expect(updater).toContain('dev.wake.purdex')
+})
+```
+
+**New runtime test** for the detection function (mocking `spawnSync`):
+
+```ts
+it('isAppBundleSigned returns false when codesign reports unsigned', () => {
+  // spawnSync returns { status: 1 } when codesign -dv exits non-zero
+  // resignAppBundle short-circuits — no codesign --sign invocation
+})
+
+it('isAppBundleSigned returns true when codesign reports signed', () => {
+  // spawnSync returns { status: 0 }
+  // resignAppBundle proceeds to invoke codesign --sign
+})
+```
+
+The runtime tests require extracting `isAppBundleSigned` and
+`resignAppBundle` such that `spawnSync` and `execFileSync` can be
+substituted (either via `vi.mock('child_process')` or DI).
+**Preferred approach: `vi.mock('node:child_process')`**, matching the
+style already used elsewhere in this codebase.
+
+## 5. Non-goals
+
+- **Removing the runtime resign** — that is the Stage 1 architectural
+  fix (bundle-swap refactor). Stage 0 only stops the bleeding for
+  unsigned bundles.
+- **Adding entitlements / Hardened Runtime configuration** — Stage 1.
+- **Self-signed cert workflow** — Stage 2.
+- **Apple Developer ID / notarization** — Stage 3.
+- **Behaviour for signed bundles** — unchanged. If a user has a
+  Developer-ID-signed Purdex.app today, Stage 0 does not affect
+  their dev update flow (broken or otherwise).
+- **Reworking rollback semantics** in `applyUpdate` — Stage 1 takes
+  this on holistically when the swap model changes.
+
+## 6. Acceptance criteria
+
+- `resignAppBundle()` short-circuits before invoking codesign when
+  `codesign -dv <bundle>` exits non-zero on the running bundle.
+- For an unsigned `Purdex.app`, dev update flow reaches `app.relaunch()`
+  and the new instance launches with the new `out/{main,preload,renderer}`.
+- For a signed `Purdex.app` (hypothetical Stage 2/3 setup), no
+  observable behaviour change.
+- `PDX_SKIP_MAC_SIGN=1` continues to bypass everything.
+- `electron/signing.test.ts` passes with the updated contract.
+- New runtime tests for `isAppBundleSigned` pass.
+- `pnpm --prefix electron test` green.
+- No changes to daemon-side build/check/download endpoints.
+- No changes to `scripts/build-electron.mjs` (Stage 0 scope is
+  `electron/updater.ts` + `electron/signing.test.ts` only).
+
+## 7. Risk assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+| ---- | ---------- | ------ | ---------- |
+| Detection misclassifies a signed bundle as unsigned (false negative on `-dv`) | Low | Medium — re-sign would be skipped, signature stale after update | `codesign -dv` is the canonical detection tool used in `build-electron.mjs:hasValidSignature`; same primitive. |
+| `spawnSync` itself throws on non-darwin | Low | Low | `getAppBundlePath()` already returns `null` on non-darwin; detection never runs. |
+| Future signed setups regress because we skipped a re-sign | Low | Low | Stage 1 retires this path entirely; window is short. |
+| Hotfix lands but Stage 1 takes long → users live on a "duct-taped" flow | Medium | Low | Stage 1 explicitly tracked in #709; Stage 0 is documented as transitional. |
+
+## 8. Verification plan
+
+1. Unit: `pnpm --prefix electron test` — all tests including new
+   runtime tests pass.
+2. Manual on Air (M1, unsigned bundle, the affected user setup):
+   - Trigger dev update from a fresh alpha.247 → alpha.248 build.
+   - Confirm SPA progress reaches `restarting`.
+   - Confirm app relaunches automatically with new version.
+   - Confirm `codesign -dv /Applications/Purdex.app` still reports
+     unsigned (we did not accidentally sign it).
+3. Optional manual on a signed bundle: skip — no signed setup exists
+   in this project at Stage 0; signed-path coverage is a Stage 2
+   concern.
+
+## 9. Out-of-scope follow-ups (filed under #709)
+
+- Stage 1: dev update bundle-swap refactor + entitlements.
+- Stage 2: self-signed cert flow.
+- Stage 3: Developer ID + notarization.

--- a/electron/signing.test.ts
+++ b/electron/signing.test.ts
@@ -1,10 +1,25 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 const root = resolve(__dirname, '..')
 
-describe('Electron macOS signing configuration', () => {
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((name: string) => {
+      if (name === 'exe') return '/Applications/Purdex.app/Contents/MacOS/Purdex'
+      if (name === 'temp') return '/tmp'
+      return '/'
+    }),
+  },
+}))
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+  execFileSync: vi.fn(),
+}))
+
+describe('Electron macOS signing configuration (static)', () => {
   it('does not explicitly disable macOS signing', () => {
     const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'))
     expect(pkg.build?.mac?.identity).not.toBeNull()
@@ -17,11 +32,157 @@ describe('Electron macOS signing configuration', () => {
     expect(script).toContain('--verify')
   })
 
-  it('re-signs the app bundle after dev update mutates bundled resources', () => {
+  it('updater exposes signing preflight + re-sign helpers', () => {
     const updater = readFileSync(resolve(root, 'electron/updater.ts'), 'utf8')
+    expect(updater).toContain('detectSignedState')
     expect(updater).toContain('resignAppBundle')
-    expect(updater).toContain('codesign')
-    expect(updater).toContain('--identifier')
-    expect(updater).toContain('dev.wake.purdex')
+    expect(updater).toContain("'node:child_process'")
+  })
+})
+
+describe('updater signing preflight (runtime)', () => {
+  let originalPlatform: PropertyDescriptor
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { ...originalPlatform, value: 'darwin' })
+    originalEnv = { ...process.env }
+    delete process.env.PDX_SKIP_MAC_SIGN
+    delete process.env.PDX_MAC_SIGN_IDENTITY
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform)
+    process.env = originalEnv
+  })
+
+  // ── detectSignedState (5 cases per spec §4.2) ───────────────────────
+
+  it('detectSignedState returns "signed" when codesign exits 0', async () => {
+    const cp = await import('node:child_process')
+    ;(cp.spawnSync as Mock).mockReturnValue({
+      status: 0,
+      stderr: 'Identifier=dev.wake.purdex\n',
+    })
+    const { __testing } = await import('./updater')
+    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('signed')
+  })
+
+  it('detectSignedState returns "unsigned" on canonical "not signed at all" stderr', async () => {
+    const cp = await import('node:child_process')
+    ;(cp.spawnSync as Mock).mockReturnValue({
+      status: 1,
+      stderr: '/Applications/Purdex.app: code object is not signed at all\n',
+    })
+    const { __testing } = await import('./updater')
+    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('unsigned')
+  })
+
+  it('detectSignedState returns "unknown" on non-zero exit with unrelated stderr', async () => {
+    const cp = await import('node:child_process')
+    ;(cp.spawnSync as Mock).mockReturnValue({
+      status: 1,
+      stderr: 'bundle format unrecognized, invalid, or unsuitable\n',
+    })
+    const { __testing } = await import('./updater')
+    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
+  })
+
+  it('detectSignedState returns "unknown" when codesign killed by signal (status null)', async () => {
+    const cp = await import('node:child_process')
+    ;(cp.spawnSync as Mock).mockReturnValue({
+      status: null,
+      signal: 'SIGTERM',
+      stderr: '',
+    })
+    const { __testing } = await import('./updater')
+    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
+  })
+
+  it('detectSignedState returns "unknown" when spawnSync reports an error', async () => {
+    const cp = await import('node:child_process')
+    ;(cp.spawnSync as Mock).mockReturnValue({
+      status: null,
+      error: new Error('ENOENT: codesign not found'),
+      stderr: '',
+    })
+    const { __testing } = await import('./updater')
+    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
+  })
+
+  // ── resignAppBundle (6 cases per spec §4.3) ─────────────────────────
+
+  it('resignAppBundle skips everything when PDX_SKIP_MAC_SIGN=1', async () => {
+    process.env.PDX_SKIP_MAC_SIGN = '1'
+    const cp = await import('node:child_process')
+    const { __testing } = await import('./updater')
+    __testing.resignAppBundle()
+    expect(cp.spawnSync).not.toHaveBeenCalled()
+    expect(cp.execFileSync).not.toHaveBeenCalled()
+  })
+
+  it('resignAppBundle skips on non-darwin (getAppBundlePath returns null)', async () => {
+    Object.defineProperty(process, 'platform', { ...originalPlatform, value: 'linux' })
+    const cp = await import('node:child_process')
+    const { __testing } = await import('./updater')
+    __testing.resignAppBundle()
+    expect(cp.spawnSync).not.toHaveBeenCalled()
+    expect(cp.execFileSync).not.toHaveBeenCalled()
+  })
+
+  it('resignAppBundle skips codesign when bundle is unsigned', async () => {
+    const cp = await import('node:child_process')
+    ;(cp.spawnSync as Mock).mockReturnValue({
+      status: 1,
+      stderr: '/Applications/Purdex.app: code object is not signed at all\n',
+    })
+    const { __testing } = await import('./updater')
+    __testing.resignAppBundle()
+    expect(cp.spawnSync).toHaveBeenCalledTimes(1)
+    expect(cp.execFileSync).not.toHaveBeenCalled()
+  })
+
+  it('resignAppBundle throws when detection returns "unknown"', async () => {
+    const cp = await import('node:child_process')
+    ;(cp.spawnSync as Mock).mockReturnValue({
+      status: null,
+      signal: 'SIGTERM',
+      stderr: '',
+    })
+    const { __testing } = await import('./updater')
+    expect(() => __testing.resignAppBundle()).toThrow(/codesign preflight/i)
+    expect(cp.execFileSync).not.toHaveBeenCalled()
+  })
+
+  it('resignAppBundle uses ad-hoc identity when PDX_MAC_SIGN_IDENTITY unset', async () => {
+    const cp = await import('node:child_process')
+    ;(cp.spawnSync as Mock).mockReturnValue({ status: 0, stderr: 'Identifier=dev.wake.purdex\n' })
+    const { __testing } = await import('./updater')
+    __testing.resignAppBundle()
+    expect(cp.execFileSync).toHaveBeenCalledTimes(2)
+    const signCall = (cp.execFileSync as Mock).mock.calls[0]
+    expect(signCall[0]).toBe('codesign')
+    expect(signCall[1]).toContain('--sign')
+    expect(signCall[1][signCall[1].indexOf('--sign') + 1]).toBe('-')
+    expect(signCall[1]).toContain('--timestamp=none')
+    expect(signCall[1]).toContain('--identifier')
+    expect(signCall[1][signCall[1].indexOf('--identifier') + 1]).toBe('dev.wake.purdex')
+    const verifyCall = (cp.execFileSync as Mock).mock.calls[1]
+    expect(verifyCall[1]).toContain('--verify')
+  })
+
+  it('resignAppBundle uses forced identity when PDX_MAC_SIGN_IDENTITY set', async () => {
+    process.env.PDX_MAC_SIGN_IDENTITY = 'Developer ID Application: Test (XYZ123)'
+    const cp = await import('node:child_process')
+    ;(cp.spawnSync as Mock).mockReturnValue({ status: 0, stderr: 'Identifier=dev.wake.purdex\n' })
+    const { __testing } = await import('./updater')
+    __testing.resignAppBundle()
+    expect(cp.execFileSync).toHaveBeenCalledTimes(2)
+    const signCall = (cp.execFileSync as Mock).mock.calls[0]
+    expect(signCall[1][signCall[1].indexOf('--sign') + 1]).toBe('Developer ID Application: Test (XYZ123)')
+    expect(signCall[1]).not.toContain('--timestamp=none')
   })
 })

--- a/electron/signing.test.ts
+++ b/electron/signing.test.ts
@@ -40,6 +40,35 @@ describe('Electron macOS signing configuration (static)', () => {
   })
 })
 
+// ── Test helpers ─────────────────────────────────────────────────────
+
+type SpawnSyncResult = {
+  status?: number | null
+  signal?: string | null
+  stdout?: string
+  stderr?: string
+  error?: Error
+}
+
+async function loadTesting() {
+  return (await import('./updater')).__testing
+}
+
+async function mockCodesign(result: SpawnSyncResult): Promise<void> {
+  const cp = await import('node:child_process')
+  ;(cp.spawnSync as Mock).mockReturnValue({
+    status: result.status ?? null,
+    signal: result.signal ?? null,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    ...(result.error ? { error: result.error } : {}),
+  })
+}
+
+async function getCp() {
+  return await import('node:child_process')
+}
+
 describe('updater signing preflight (runtime)', () => {
   let originalPlatform: PropertyDescriptor
   let originalEnv: NodeJS.ProcessEnv
@@ -59,116 +88,151 @@ describe('updater signing preflight (runtime)', () => {
     process.env = originalEnv
   })
 
-  // ── detectSignedState (5 cases per spec §4.2) ───────────────────────
+  // ── detectSignedState core cases (spec §4.2) ────────────────────────
 
-  it('detectSignedState returns "signed" when codesign exits 0', async () => {
-    const cp = await import('node:child_process')
-    ;(cp.spawnSync as Mock).mockReturnValue({
-      status: 0,
-      stderr: 'Identifier=dev.wake.purdex\n',
-    })
-    const { __testing } = await import('./updater')
-    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('signed')
+  it('returns "signed" when codesign exits 0', async () => {
+    await mockCodesign({ status: 0, stderr: 'Identifier=dev.wake.purdex\n' })
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('signed')
   })
 
-  it('detectSignedState returns "unsigned" on canonical "not signed at all" stderr', async () => {
-    const cp = await import('node:child_process')
-    ;(cp.spawnSync as Mock).mockReturnValue({
+  it('returns "unsigned" on canonical "not signed at all" stderr', async () => {
+    await mockCodesign({
       status: 1,
       stderr: '/Applications/Purdex.app: code object is not signed at all\n',
     })
-    const { __testing } = await import('./updater')
-    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('unsigned')
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('unsigned')
   })
 
-  it('detectSignedState returns "unknown" on non-zero exit with unrelated stderr', async () => {
-    const cp = await import('node:child_process')
-    ;(cp.spawnSync as Mock).mockReturnValue({
+  it('returns "unknown" on non-zero exit with unrelated stderr', async () => {
+    await mockCodesign({ status: 1, stderr: 'bundle format unrecognized, invalid, or unsuitable\n' })
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
+  })
+
+  it('returns "unknown" when codesign killed by signal (status null)', async () => {
+    await mockCodesign({ status: null, signal: 'SIGTERM' })
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
+  })
+
+  it('returns "unknown" when spawnSync reports an error', async () => {
+    await mockCodesign({ status: null, error: new Error('ENOENT: codesign not found') })
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
+  })
+
+  // ── detectSignedState resilience cases (Round-2 F1) ────────────────
+
+  it('returns "unsigned" when canonical phrase has different case', async () => {
+    await mockCodesign({
       status: 1,
-      stderr: 'bundle format unrecognized, invalid, or unsuitable\n',
+      stderr: '/Applications/Purdex.app: CODE OBJECT IS NOT SIGNED AT ALL\n',
     })
-    const { __testing } = await import('./updater')
-    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('unsigned')
   })
 
-  it('detectSignedState returns "unknown" when codesign killed by signal (status null)', async () => {
-    const cp = await import('node:child_process')
-    ;(cp.spawnSync as Mock).mockReturnValue({
+  it('returns "unsigned" when canonical phrase is wrapped in ANSI escape codes', async () => {
+    await mockCodesign({
+      status: 1,
+      stderr: '\x1b[31m/Applications/Purdex.app: code object is not signed at all\x1b[0m\n',
+    })
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('unsigned')
+  })
+
+  it('returns "unsigned" when canonical phrase appears on stdout instead of stderr', async () => {
+    await mockCodesign({
+      status: 1,
+      stdout: '/Applications/Purdex.app: code object is not signed at all\n',
+      stderr: '',
+    })
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('unsigned')
+  })
+
+  it('returns "unsigned" when canonical phrase has irregular whitespace', async () => {
+    await mockCodesign({
+      status: 1,
+      stderr: 'code object\tis  not\nsigned at all\n',
+    })
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('unsigned')
+  })
+
+  it('returns "unknown" when codesign times out (Round-2 F2)', async () => {
+    await mockCodesign({
       status: null,
       signal: 'SIGTERM',
-      stderr: '',
+      error: Object.assign(new Error('ETIMEDOUT'), { code: 'ETIMEDOUT' }),
     })
-    const { __testing } = await import('./updater')
-    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
+    const t = await loadTesting()
+    expect(t.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
   })
 
-  it('detectSignedState returns "unknown" when spawnSync reports an error', async () => {
-    const cp = await import('node:child_process')
-    ;(cp.spawnSync as Mock).mockReturnValue({
-      status: null,
-      error: new Error('ENOENT: codesign not found'),
-      stderr: '',
-    })
-    const { __testing } = await import('./updater')
-    expect(__testing.detectSignedState('/Applications/Purdex.app')).toBe('unknown')
+  it('passes a timeout to spawnSync to prevent hangs', async () => {
+    await mockCodesign({ status: 0 })
+    const t = await loadTesting()
+    t.detectSignedState('/Applications/Purdex.app')
+    const cp = await getCp()
+    const opts = (cp.spawnSync as Mock).mock.calls[0][2]
+    expect(opts.timeout).toBeGreaterThanOrEqual(1_000)
+    expect(opts.timeout).toBeLessThanOrEqual(60_000)
   })
 
-  // ── resignAppBundle (6 cases per spec §4.3) ─────────────────────────
+  // ── resignAppBundle dispatch (spec §4.3) ────────────────────────────
 
   it('resignAppBundle skips everything when PDX_SKIP_MAC_SIGN=1', async () => {
     process.env.PDX_SKIP_MAC_SIGN = '1'
-    const cp = await import('node:child_process')
-    const { __testing } = await import('./updater')
-    __testing.resignAppBundle()
+    const cp = await getCp()
+    const t = await loadTesting()
+    t.resignAppBundle()
     expect(cp.spawnSync).not.toHaveBeenCalled()
     expect(cp.execFileSync).not.toHaveBeenCalled()
   })
 
   it('resignAppBundle skips on non-darwin (getAppBundlePath returns null)', async () => {
     Object.defineProperty(process, 'platform', { ...originalPlatform, value: 'linux' })
-    const cp = await import('node:child_process')
-    const { __testing } = await import('./updater')
-    __testing.resignAppBundle()
+    const cp = await getCp()
+    const t = await loadTesting()
+    t.resignAppBundle()
     expect(cp.spawnSync).not.toHaveBeenCalled()
     expect(cp.execFileSync).not.toHaveBeenCalled()
   })
 
   it('resignAppBundle skips codesign when bundle is unsigned', async () => {
-    const cp = await import('node:child_process')
-    ;(cp.spawnSync as Mock).mockReturnValue({
+    await mockCodesign({
       status: 1,
       stderr: '/Applications/Purdex.app: code object is not signed at all\n',
     })
-    const { __testing } = await import('./updater')
-    __testing.resignAppBundle()
+    const cp = await getCp()
+    const t = await loadTesting()
+    t.resignAppBundle()
     expect(cp.spawnSync).toHaveBeenCalledTimes(1)
     expect(cp.execFileSync).not.toHaveBeenCalled()
   })
 
-  it('resignAppBundle throws when detection returns "unknown"', async () => {
-    const cp = await import('node:child_process')
-    ;(cp.spawnSync as Mock).mockReturnValue({
-      status: null,
-      signal: 'SIGTERM',
-      stderr: '',
-    })
-    const { __testing } = await import('./updater')
-    expect(() => __testing.resignAppBundle()).toThrow(/codesign preflight/i)
+  it('resignAppBundle throws actionable error on unknown', async () => {
+    await mockCodesign({ status: null, signal: 'SIGTERM' })
+    const cp = await getCp()
+    const t = await loadTesting()
+    expect(() => t.resignAppBundle()).toThrow(/preflight detection failed/i)
+    expect(() => t.resignAppBundle()).toThrow(/PDX_SKIP_MAC_SIGN/) // remediation hint
     expect(cp.execFileSync).not.toHaveBeenCalled()
   })
 
   it('resignAppBundle uses ad-hoc identity when PDX_MAC_SIGN_IDENTITY unset', async () => {
-    const cp = await import('node:child_process')
-    ;(cp.spawnSync as Mock).mockReturnValue({ status: 0, stderr: 'Identifier=dev.wake.purdex\n' })
-    const { __testing } = await import('./updater')
-    __testing.resignAppBundle()
+    await mockCodesign({ status: 0, stderr: 'Identifier=dev.wake.purdex\n' })
+    const cp = await getCp()
+    const t = await loadTesting()
+    t.resignAppBundle()
     expect(cp.execFileSync).toHaveBeenCalledTimes(2)
     const signCall = (cp.execFileSync as Mock).mock.calls[0]
     expect(signCall[0]).toBe('codesign')
-    expect(signCall[1]).toContain('--sign')
     expect(signCall[1][signCall[1].indexOf('--sign') + 1]).toBe('-')
     expect(signCall[1]).toContain('--timestamp=none')
-    expect(signCall[1]).toContain('--identifier')
     expect(signCall[1][signCall[1].indexOf('--identifier') + 1]).toBe('dev.wake.purdex')
     const verifyCall = (cp.execFileSync as Mock).mock.calls[1]
     expect(verifyCall[1]).toContain('--verify')
@@ -176,10 +240,10 @@ describe('updater signing preflight (runtime)', () => {
 
   it('resignAppBundle uses forced identity when PDX_MAC_SIGN_IDENTITY set', async () => {
     process.env.PDX_MAC_SIGN_IDENTITY = 'Developer ID Application: Test (XYZ123)'
-    const cp = await import('node:child_process')
-    ;(cp.spawnSync as Mock).mockReturnValue({ status: 0, stderr: 'Identifier=dev.wake.purdex\n' })
-    const { __testing } = await import('./updater')
-    __testing.resignAppBundle()
+    await mockCodesign({ status: 0, stderr: 'Identifier=dev.wake.purdex\n' })
+    const cp = await getCp()
+    const t = await loadTesting()
+    t.resignAppBundle()
     expect(cp.execFileSync).toHaveBeenCalledTimes(2)
     const signCall = (cp.execFileSync as Mock).mock.calls[0]
     expect(signCall[1][signCall[1].indexOf('--sign') + 1]).toBe('Developer ID Application: Test (XYZ123)')

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -48,10 +48,30 @@ function getAppBundlePath(): string | null {
   return dirname(dirname(dirname(app.getPath('exe'))))
 }
 
+type SignedState = 'signed' | 'unsigned' | 'unknown'
+
+function detectSignedState(appBundle: string): SignedState {
+  const result = spawnSync('codesign', ['-dv', appBundle], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  })
+  if (result.status === 0) return 'signed'
+  if (result.status !== null && result.stderr?.includes('code object is not signed at all')) {
+    return 'unsigned'
+  }
+  return 'unknown'
+}
+
 function resignAppBundle(): void {
   const appBundle = getAppBundlePath()
   if (!appBundle || process.env.PDX_SKIP_MAC_SIGN === '1') return
 
+  const state = detectSignedState(appBundle)
+  if (state === 'unsigned') return
+  if (state === 'unknown') {
+    throw new Error('codesign preflight detection failed; aborting re-sign')
+  }
+  // state === 'signed'
   const identity = process.env.PDX_MAC_SIGN_IDENTITY || '-'
   const signArgs = [
     '--force',
@@ -216,16 +236,6 @@ export async function applyUpdate(
   app.exit(0)
 
   return { success: true, message: 'Update applied, restarting...' }
-}
-
-// T2 stub — T3 replaces detectSignedState body with real codesign -dv
-// invocation. The stub returns 'unknown' so that all 11 runtime tests
-// in signing.test.ts run and fail on assertions (behaviour RED), not
-// on missing __testing export.
-type SignedState = 'signed' | 'unsigned' | 'unknown'
-
-function detectSignedState(_appBundle: string): SignedState {
-  return 'unknown'
 }
 
 export const __testing = { detectSignedState, resignAppBundle }

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -50,15 +50,31 @@ function getAppBundlePath(): string | null {
 
 type SignedState = 'signed' | 'unsigned' | 'unknown'
 
+const PREFLIGHT_TIMEOUT_MS = 10_000
+
+// Loose match — tolerates ANSI escapes, leading paths/colons, case
+// differences, and varying whitespace. The phrase itself is documented
+// codesign output going back many macOS releases, but Apple makes no
+// stability guarantee, so we normalise both stdout and stderr before
+// matching.
+const NOT_SIGNED_PATTERN = /code object\s+is\s+not\s+signed\s+at\s+all/i
+
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '')
+}
+
 function detectSignedState(appBundle: string): SignedState {
   const result = spawnSync('codesign', ['-dv', appBundle], {
     stdio: ['ignore', 'pipe', 'pipe'],
     encoding: 'utf8',
+    timeout: PREFLIGHT_TIMEOUT_MS,
   })
   if (result.status === 0) return 'signed'
-  if (result.status !== null && result.stderr?.includes('code object is not signed at all')) {
-    return 'unsigned'
-  }
+  // status === null covers SIGTERM kills, ETIMEDOUT, ENOENT, etc.
+  if (result.status === null || result.error) return 'unknown'
+  const merged = stripAnsi(`${result.stdout ?? ''}\n${result.stderr ?? ''}`)
+  if (NOT_SIGNED_PATTERN.test(merged)) return 'unsigned'
   return 'unknown'
 }
 
@@ -69,7 +85,10 @@ function resignAppBundle(): void {
   const state = detectSignedState(appBundle)
   if (state === 'unsigned') return
   if (state === 'unknown') {
-    throw new Error('codesign preflight detection failed; aborting re-sign')
+    throw new Error(
+      `codesign preflight detection failed for ${appBundle}; ` +
+      `set PDX_SKIP_MAC_SIGN=1 to bypass, or rebuild the app bundle.`
+    )
   }
   // state === 'signed'
   const identity = process.env.PDX_MAC_SIGN_IDENTITY || '-'

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -217,3 +217,15 @@ export async function applyUpdate(
 
   return { success: true, message: 'Update applied, restarting...' }
 }
+
+// T2 stub — T3 replaces detectSignedState body with real codesign -dv
+// invocation. The stub returns 'unknown' so that all 11 runtime tests
+// in signing.test.ts run and fail on assertions (behaviour RED), not
+// on missing __testing export.
+type SignedState = 'signed' | 'unsigned' | 'unknown'
+
+function detectSignedState(_appBundle: string): SignedState {
+  return 'unknown'
+}
+
+export const __testing = { detectSignedState, resignAppBundle }

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron'
-import { execFileSync } from 'child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, rmSync, renameSync, cpSync, createWriteStream } from 'fs'
 import { dirname, join } from 'path'
 import { pipeline } from 'stream/promises'


### PR DESCRIPTION
## Summary

Stage 0 of #709 (macOS code signing roadmap). Fixes the dev update regression introduced by PR #672 (commit `7cad0823`, alpha.234) where `applyUpdate` unconditionally re-signs the running bundle and triggers macOS AMFI to SIGKILL the process before `app.relaunch()` can run.

User-visible bug (alpha.247, 2026-04-28): SPA progress reaches `applying` then disappears, app doesn't relaunch, manual restart shows old version. Reproduces on **unsigned** `Purdex.app` (the user's actual deployment — `codesign -dv` reports `code object is not signed at all`).

## Root cause

`resignAppBundle()` ran `codesign --force --deep --options runtime --sign -` on the currently running bundle. On unsigned bundles this is the FIRST time `Contents/MacOS/Purdex` gets a signature written; AMFI detects the running Mach-O was modified and SIGKILLs the process.

## Fix

Pre-flight detection via `codesign -dv`. Three-state classification:

| codesign -dv result | State | Action |
| --- | --- | --- |
| status 0 | `signed` | Re-sign + verify (unchanged) |
| non-zero AND stderr contains `code object is not signed at all` | `unsigned` | **Skip codesign (new)** |
| any other (status null / spawnSync error / unrelated stderr) | `unknown` | Throw → existing rollback runs |

Why three states (not just signed/unsigned): silently treating "we don't know" as "skip" turns every detection edge case into a stale-signature production. The `unknown` path routes through the existing `applyUpdate` try/catch rollback.

## Out of scope (Stage 1+)

- Removing the runtime resign entirely (Stage 1 architectural fix — bundle-swap refactor)
- Entitlements + Hardened Runtime config (Stage 1)
- Self-signed cert workflow (Stage 2)
- Apple Developer ID + notarization (Stage 3)

All tracked in #709.

## Commit history

This PR contains a TDD RED→GREEN cycle (squash-merge will collapse them):

- `834314cb` refactor — switch updater to `node:` prefix imports (T1)
- `1f723be2` test — add 11 runtime tests + stub (T2 RED, 4 behaviour failures)
- `e98239b2` feat — three-state preflight implementation (T3 GREEN, all 4 flip)
- Plus 4 docs commits for spec v1.1 + plan v1.1 (both passed codex review)

## Test plan

- [x] `pnpm --prefix electron test` → 33/33 pass (3 static + 11 runtime + 19 keybindings)
- [x] `pnpm exec electron-vite build` → success, no type errors
- [x] RED→GREEN diff confirmed: 4 failing tests in T2 all flip in T3
- [ ] **Manual verification before alpha.248 bump** (per spec §8.2):
  - [ ] Mini: `PDX_SKIP_MAC_SIGN=1 pnpm run electron:build`
  - [ ] Copy `dist/mac-arm64/Purdex.app` to Air's `/Applications/`
  - [ ] Pre-state: `codesign -dv` reports unsigned
  - [ ] Trigger dev update from Settings → Development
  - [ ] SPA progress reaches `signing`, app exits and relaunches
  - [ ] Post-state: still unsigned (we did not accidentally sign it)

## Spec / Plan

- Spec: `docs/specs/2026-04-28-electron-signing-stage0-spec.md` (v1.1, 9 codex findings addressed)
- Plan: `docs/specs/2026-04-28-electron-signing-stage0-plan.md` (v1.1, 8 codex findings addressed)