### PR TITLE
fix(opencode): plugin emit() stdin TypeError hotfix (#715)

### DIFF
--- a/docs/specs/2026-04-29-opencode-bun-spawn-stdin-fix-plan.md
+++ b/docs/specs/2026-04-29-opencode-bun-spawn-stdin-fix-plan.md
@@ -1,0 +1,433 @@
+# opencode Plugin `Bun.spawn` stdin Hotfix — Implementation Plan
+
+- **Spec**: `docs/specs/2026-04-29-opencode-bun-spawn-stdin-fix-spec.md`
+- **Date**: 2026-04-29
+- **Base**: `96bae3ce` (main @ alpha.248)
+- **Worktree**: `.claude/worktrees/opencode-spawn-fix`
+- **Branch**: `worktree-opencode-spawn-fix`
+- **Tracking**: #715
+- **Plan revision**: v1.1 (2026-04-29) — incorporates codex plan review job `task-moiufay4-0c5pdm` (3 P2 + 3 P3, 0 P0/P1, all addressed).
+
+## 1. Scope summary
+
+A 1-line fix to the JS template rendered by
+`internal/agent/opencode/plugin_template.go:34` (the `stdin` field of
+the `Bun.spawn` call inside the rendered `emit()` helper), plus a new
+real-Bun integration test that catches the regression.
+
+Total expected diff:
+
+| File | Action | Lines |
+|------|--------|-------|
+| `internal/agent/opencode/plugin_template.go` | Edit `stdin: JSON.stringify(payload)` line + add 2 follow-up lines (`proc.stdin.write(...)` / `proc.stdin.end()`) | ~ +2 / -1 |
+| `internal/agent/opencode/plugin_template_bun_integration_test.go` | New file: real-Bun integration test that proves `emit()` works at runtime | ~ +130 |
+| `internal/agent/opencode/hooks_test.go` (existing) | Append one new test `TestCheckHooks_PreFixManagedBodyReportsDrift` that hand-writes a pre-fix body and asserts drift then reinstall convergence | ~ +60 |
+| `docs/specs/2026-04-29-opencode-bun-spawn-stdin-fix-spec.md` | New (already in tree) | +330 |
+| `docs/specs/2026-04-29-opencode-bun-spawn-stdin-fix-plan.md` | This file | +(this) |
+
+No other files touched.
+
+## 2. Phase split — single phase, 5 ordered tasks
+
+### Task T1 — Add failing real-Bun integration test (TDD red)
+
+**Files:** `internal/agent/opencode/plugin_template_bun_integration_test.go` (new)
+
+**What:**
+
+Create the integration test per spec §4.2 with the codex-plan-review
+adjustments below:
+
+1. File header:
+   ```go
+   package opencode
+
+   import (
+       "context"
+       "encoding/json"
+       "os"
+       "os/exec"
+       "path/filepath"
+       "runtime"
+       "strings"
+       "testing"
+       "time"
+   )
+   ```
+   (No build tag — the test gates internally per spec §4.2.1 so a
+   single `go test ./...` invocation runs whatever the environment
+   supports.)
+
+2. One test function `TestRenderManagedPlugin_BunRuntimeEmitsStdin` that:
+   - Applies **four** layered skip gates (per spec §4.2.1 + plan-review P3-4):
+     1. `runtime.GOOS == "windows"` → skip.
+     2. `os.Stat("/bin/sh")` errors → skip (covers exotic POSIX
+        environments without a baseline shell).
+     3. `exec.LookPath("bun")` errors → skip.
+     4. `bun --version` exits non-zero or empty → skip.
+   - Builds a temp dir via `t.TempDir()`.
+   - Writes a stub `pdx` shell script:
+     ```sh
+     #!/bin/sh
+     cat > "$PDX_TEST_STDIN_CAPTURE"
+     ```
+     Stub captures stdin via the env var — independent of the
+     rendered command line (`pdx hook --agent opencode <event>`).
+   - `os.Chmod(stubPath, 0o755)`.
+   - `body := renderManagedPlugin(stubPath)` and append a tail that
+     triggers one event, wrapped as an IIFE so we don't depend on
+     top-level await module semantics, and write to a `.mjs` file so
+     Bun parses ESM unambiguously:
+     ```js
+     ;(async () => {
+       const hooks = await PurdexOpenCodeHooks()
+       await hooks.event({
+         event: {
+           type: 'session.created',
+           properties: { sessionID: 'test-session' },
+         },
+       })
+     })()
+     ```
+   - Write `body + tail` to `t.TempDir()/plugin.mjs`.
+   - **Single-execution pattern** (plan-review P2-2): use
+     `output, err := cmd.CombinedOutput()` exactly once. Do not call
+     `cmd.Run()` then `cmd.CombinedOutput()` separately — that would
+     spawn Bun twice and lose the first execution's evidence.
+   - 5s `context.WithTimeout` and `cmd.Env = append(os.Environ(),
+     "PDX_TEST_STDIN_CAPTURE="+capturePath)`.
+   - **Failure-mode classification** (plan-review P2-1): when
+     `err != nil`, examine `string(output)`:
+     - If it contains `ERR_INVALID_ARG_TYPE` or `stdio must be an
+       array` → before-fix expected failure. Record via
+       `t.Logf("pre-fix TypeError observed (TDD red)")`. (When
+       running pre-fix this is the red signal; when running
+       post-fix this branch should be unreachable.)
+     - Else → unexpected failure (envelope mismatch, deadlock, syntax
+       error, …). `t.Fatalf("unexpected bun failure: err=%v output=%s",
+       err, output)` so the test surfaces the wrong-reason red.
+     - On `err == nil`, proceed to the capture-file assertion below.
+   - Read `capturePath`, `json.Unmarshal` into a generic map, assert
+     `m["session_id"] == "test-session"`. Mismatch → `t.Fatalf`.
+
+3. Confirm the test fails before the fix in the **expected** way:
+   - `go test ./internal/agent/opencode/ -run BunRuntimeEmitsStdin -v`
+   - Expect: stderr contains `ERR_INVALID_ARG_TYPE`. We deliberately
+     keep this as a `t.Fatalf` (the test is red because we have not
+     applied T2 yet) so re-running after T2 turns it green. **This
+     is the TDD red.**
+
+**Verify:** failing test exists with the documented stderr-contains
+classification, so we know "red because of the bug, not because of a
+harness mistake."
+
+**Commit:** `test(opencode): add real-Bun integration test for plugin emit() stdin (#715)`
+
+---
+
+### Task T2 — Apply 1-line stdin fix (TDD green)
+
+**Files:** `internal/agent/opencode/plugin_template.go`
+
+**What:** edit the `emit()` body inside `renderManagedPlugin`:
+
+Before (line 32-39):
+```js
+async function emit(eventName, payload = {}) {
+  const proc = Bun.spawn({
+    cmd: [pdxPath, 'hook', '--agent', 'opencode', eventName],
+    stdin: JSON.stringify(payload),
+    stdout: 'ignore',
+    stderr: 'ignore',
+  })
+  await proc.exited
+}
+```
+
+After:
+```js
+async function emit(eventName, payload = {}) {
+  const proc = Bun.spawn({
+    cmd: [pdxPath, 'hook', '--agent', 'opencode', eventName],
+    stdin: 'pipe',
+    stdout: 'ignore',
+    stderr: 'ignore',
+  })
+  proc.stdin.write(JSON.stringify(payload))
+  proc.stdin.end()
+  await proc.exited
+}
+```
+
+**Do not touch** anything else in the file (regex helpers, constants,
+non-emit handlers).
+
+**Verify:**
+
+- `go test ./internal/agent/opencode/ -run BunRuntimeEmitsStdin -v` is now green.
+- `go test ./internal/agent/opencode/...` is green (all 8 existing tests + 1 new = 9 pass).
+
+**Commit:** `fix(opencode): use stdin pipe for Bun.spawn in plugin emit() (#715)`
+
+---
+
+### Task T3 — Confirm test parity helpers still pass
+
+**Files:** none (verification only)
+
+**What:** Re-read the existing parity tests to confirm none of their
+assertions overlap with the changed lines:
+
+- `extractEmittedEvents` looks for `emit('Name'` — emit() name strings
+  unchanged; pass.
+- `extractPdxPath` looks for `const pdxPath = "..."` — line untouched;
+  pass.
+- `TestRenderManagedPlugin_UsesInputModelAndSessionScopedSubagentKeys`
+  asserts `const model = input.model`, `const subagentKey = …`, `if
+  (activeSubagents.has(subagentKey)) return` — all in
+  `chat.message`/`tool.execute.before` handlers; pass.
+- `TestValidateSpecsCoverEmitted_*` — about event names, not stdin;
+  pass.
+- `TestRenderManagedPlugin_ProducesValidBody` — managed marker;
+  pass.
+
+**Verify:** `go test ./internal/agent/opencode/...` green from T2 already
+covers this; this task is the explicit gate-confirm step.
+
+**No commit** (verification only).
+
+---
+
+### Task T3.5 — Add `CheckHooks` drift unit test (AC3 in-repo)
+
+**Files:** `internal/agent/opencode/hooks_test.go` (append one test)
+
+**What:** lift AC3 (drift detection on pre-fix managed plugins) from
+manual mlab steps to a CI-enforceable assertion (plan-review P3-5).
+Append after the existing `TestOpenCodeHooks_InstallCheckRemove`:
+
+```go
+// TestCheckHooks_PreFixManagedBodyReportsDrift documents AC3 from
+// 2026-04-29 spec §7: a managed plugin file shipped before the
+// stdin-pipe fix (byte-different from the fixed render) must surface
+// as drift via CheckHooks, and a subsequent InstallHooks must
+// converge it back. We synthesize the pre-fix body by string-replace
+// rather than vendor a snapshot — the contract under test is "if the
+// on-disk body differs from renderManagedPlugin's current output by
+// even one byte, CheckHooks reports drift."
+func TestCheckHooks_PreFixManagedBodyReportsDrift(t *testing.T) {
+    home := t.TempDir()
+    t.Setenv("HOME", home)
+    pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
+
+    p := opencode.NewProvider()
+
+    // Hand-author a plugin file that mirrors a pre-fix body shape:
+    // start from the fixed render and replace stdin: 'pipe' with
+    // stdin: JSON.stringify(payload). The marker stays intact so
+    // CheckHooks treats it as a managed plugin (drifted), not as
+    // unmanaged.
+    fixed := opencode.RenderManagedPluginForTesting("/usr/local/bin/pdx")
+    preFix := strings.Replace(
+        fixed,
+        "stdin: 'pipe',\n    stdout: 'ignore',",
+        "stdin: JSON.stringify(payload),\n    stdout: 'ignore',",
+        1,
+    )
+    if preFix == fixed {
+        t.Fatal("synthetic pre-fix body identical to fixed; replace pattern stale")
+    }
+
+    pluginDir := filepath.Join(home, ".config", "opencode", "plugins")
+    if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+        t.Fatalf("mkdir: %v", err)
+    }
+    pluginPath := filepath.Join(pluginDir, "pdx-agent-hooks.js")
+    if err := os.WriteFile(pluginPath, []byte(preFix), 0o644); err != nil {
+        t.Fatalf("write pre-fix body: %v", err)
+    }
+
+    status, err := p.CheckHooks()
+    if err != nil {
+        t.Fatalf("CheckHooks: %v", err)
+    }
+    foundDrift := false
+    for name, ev := range status.Events {
+        if !ev.Installed {
+            foundDrift = true
+            t.Logf("drift on event %q (Installed=false)", name)
+        }
+    }
+    if !foundDrift {
+        t.Fatal("expected at least one event to report drift on pre-fix body")
+    }
+
+    if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+        t.Fatalf("InstallHooks: %v", err)
+    }
+    after, err := p.CheckHooks()
+    if err != nil {
+        t.Fatalf("CheckHooks post-reinstall: %v", err)
+    }
+    for name, ev := range after.Events {
+        if !ev.Installed {
+            t.Errorf("post-reinstall event %q still drifting", name)
+        }
+    }
+
+    _ = agent.HookEventSpec{} // import-keeper; remove if unused
+}
+```
+
+This test relies on a tiny test-only export — see implementation note
+below. If a `RenderManagedPluginForTesting` export does not yet exist
+add a one-liner:
+
+```go
+// In internal/agent/opencode/plugin_template.go (or a sibling test-export file):
+func RenderManagedPluginForTesting(p string) string { return renderManagedPlugin(p) }
+```
+
+(Use the existing `*_export_test.go` style — there is already a
+`hooks_export_test.go` that exports test hooks via `var
+SetResolveCanonicalPdxPathForTesting = …`. Mirror that convention.)
+
+**Verify:**
+
+- `go test ./internal/agent/opencode/ -run PreFixManagedBodyReportsDrift -v` green.
+- Existing `TestOpenCodeHooks_InstallCheckRemove` still green.
+
+**Commit:** `test(opencode): add CheckHooks drift coverage for pre-fix managed body (#715)`
+
+---
+
+### Task T4 — Local `pdx setup --agent opencode` smoke
+
+**Files:** none (manual)
+
+**What:**
+
+```bash
+go build -o /tmp/pdx-fix ./cmd/pdx
+HOME=$(mktemp -d) /tmp/pdx-fix setup --agent opencode
+cat $HOME/.config/opencode/plugins/pdx-agent-hooks.js | sed -n '30,42p'
+```
+
+Expect to see the new `stdin: 'pipe'` + `proc.stdin.write(...)` /
+`proc.stdin.end()` lines. The `JSON.stringify` should appear inside
+`write(JSON.stringify(payload))`, not in the `stdin` field.
+
+**Verify:** rendered file contains the fixed template; managed marker
+intact.
+
+**No commit** (verification only — purely local tempdir, throwaway).
+
+---
+
+### Task T5 — Update kickoff memory pointer
+
+**Files:** `~/.claude/projects/-Users-wake-Workspace-wake-purdex/memory/MEMORY.md`
+(via local memory write — done in the conversation, not committed to repo)
+
+**What:** Once the PR is open, update the kickoff entry's status line.
+Once merged, archive per kickoff norms.
+
+**No commit.**
+
+## 3. Verification matrix (spec §7 mapping)
+
+| Spec §7 acceptance | How verified | Where |
+|---|---|---|
+| AC1 — `go test` green w/ Bun | T1+T2 | local + CI runner with bun |
+| AC2 — `go test` green w/o Bun (skip path) | manual `PATH= go test …` | local |
+| AC3 — pre-fix plugin reports drift, reinstall converges | T3.5 unit test (in-repo CI) + corroborating mlab observation in §4 | repo + mlab |
+| AC4 — opencode events reach daemon DB | mlab live verify §4 | mlab |
+
+## 4. mlab live verify (PR test plan, post-T2 commits pushed)
+
+**Owner:** wake (manual). Recorded in PR body as a checklist for
+reviewer benefit; this plan does not block on it during code review.
+
+```bash
+# On mlab:
+cd ~/Workspace/wake/purdex
+git fetch origin pull/<PR#>/head:opencode-spawn-fix-pr
+git checkout opencode-spawn-fix-pr
+go build -o /tmp/pdx-fix ./cmd/pdx
+
+# Verify the rendered plugin updates correctly (covers AC3):
+ls -l ~/.config/opencode/plugins/pdx-agent-hooks.js  # pre-fix file age
+/tmp/pdx-fix setup --agent opencode
+ls -l ~/.config/opencode/plugins/pdx-agent-hooks.js  # rewritten timestamp
+sed -n '30,42p' ~/.config/opencode/plugins/pdx-agent-hooks.js  # fixed body
+
+# Restart daemon if running on the broken binary (already W2's daemon
+# from PR #710 verification — kill + re-launch with the fix binary).
+# Then start opencode in tmux purdex-sync, exchange one prompt.
+
+# AC4 evidence:
+sqlite3 ~/.config/pdx/agent_events.db \
+  "SELECT root_event_name, latest_decision,
+          datetime(started_at/1000000000, 'unixepoch', 'localtime')
+   FROM agent_trace_chains
+   WHERE root_agent_type='opencode'
+   ORDER BY started_at DESC LIMIT 5"
+# Expect: at least one new SessionStart row with this run's timestamp.
+```
+
+If AC3/AC4 fail on mlab, do not merge — file the actual evidence in
+PR comments and treat as a Plan failure (return to T1/T2 with
+adjusted assertions).
+
+## 5. Risk register (delta from spec §6)
+
+Plan-specific risks the spec doesn't already cover:
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| The rendered tail script that drives `event()` doesn't actually fire `emit('SessionStart', …)` because the JS hook expects different envelope shape than the inline harness provides | Medium | Read the existing handler at `plugin_template.go:48-86` for the exact `case 'session.created'` shape (`event.properties.sessionID`) — the harness already mirrors that. If T1 fails for envelope reasons (cmd.Run non-zero with shape error rather than TypeError) we adjust the harness in T1 itself before declaring the test "red" for the right reason. |
+| The stub `pdx` script's `cat > $PDX_TEST_STDIN_CAPTURE` blocks waiting on stdin EOF; the plugin's `proc.stdin.end()` after `write` should close cleanly, but if `end()` doesn't flush we deadlock | Low | The 5s context timeout covers it. If the deadlock is a real Bun behavior, T1 turns red for a different reason than the TypeError and forces design-time correction (then T2's fix is what makes the deadlock impossible — `end()` is the contract). The deadlock-vs-TypeError distinction is informative. |
+| `t.TempDir()` plugin.js is parsed by Bun as a module path that conflicts with package-detection (Bun walks up looking for `package.json`) | Low | We pass an absolute path with no surrounding `package.json`; tested manually before in similar setups. If observed, fall back to a `.mjs` extension. |
+
+## 6. Out-of-scope guardrails (re-stated from spec §2.3)
+
+The implementer must not:
+
+- Edit `plugin_template.go` lines outside the `emit()` body inside
+  `renderManagedPlugin` (the only allowed adjacent change is adding
+  `RenderManagedPluginForTesting` to `hooks_export_test.go` for T3.5).
+- Modify `hooks.go`, `events.go`, `provider.go`, `status.go` runtime
+  files, or any test file other than the new
+  `plugin_template_bun_integration_test.go` and the appended block in
+  `hooks_test.go` for T3.5.
+- Touch other agents (`internal/agent/cc/*`, `internal/agent/codex/*`).
+- "While we're here" tweak the parity regex helpers or refactor the
+  stub-binary harness into a shared `testdata/` helper.
+- Update `CHANGELOG.md` inline (the bump PR owns that).
+- Bump `VERSION` (a separate bump PR follows merge per repo workflow).
+
+If the implementer hits a real bug in those areas during T1-T2, file
+a follow-up issue and stop.
+
+## 7. Definition of done
+
+### 7.1 Code & test verification (PR-blocking)
+
+These are the criteria that determine whether the hotfix is correct:
+
+- All commits in §2 pushed to `origin/worktree-opencode-spawn-fix`.
+- T1, T2, T3, T3.5 verifications pass locally.
+- `go test ./internal/agent/opencode/...` green with Bun installed and
+  green with Bun absent (skip path).
+
+### 7.2 Process gates (workflow, tracked separately)
+
+These are repo-workflow steps; they happen for this PR like any other,
+but are not technical correctness criteria:
+
+- PR opened against `main` referencing #715 with the §4 manual checklist.
+- Two-round codex review (standard + adversarial); 0 unaddressed P0/P1.
+- mlab live verify (AC4) recorded as PASS in PR body.
+- Squash-merged to `main`.
+- Independent bump PR opens (alpha.249) with `VERSION` + `CHANGELOG.md` updates.
+- W2 PR #710 rebased / merged main and §7 live re-run.

--- a/docs/specs/2026-04-29-opencode-bun-spawn-stdin-fix-spec.md
+++ b/docs/specs/2026-04-29-opencode-bun-spawn-stdin-fix-spec.md
@@ -1,0 +1,306 @@
+# opencode Plugin `Bun.spawn` stdin Hotfix Spec
+
+- **Version**: 1.0.0-alpha.248 (target bump after merge)
+- **Date**: 2026-04-29
+- **Base**: `96bae3ce` (main @ alpha.248)
+- **Author**: claude-code + wake
+- **Status**: Draft (revised after codex spec review job `task-moiu936r-x7a8nh`; 5 P2 + 2 P3 findings, 0 P0/P1, all addressed)
+- **Tracking**: #715 (bug, daemon)
+- **Worktree**: `.claude/worktrees/opencode-spawn-fix`
+- **Branch**: `worktree-opencode-spawn-fix`
+
+## 1. Context
+
+The opencode hook plugin (`internal/agent/opencode/plugin_template.go`)
+renders a JS template that defines a single `emit(eventName, payload)`
+helper. Every Bus / strong-hook callback funnels through it to spawn
+`pdx hook --agent opencode <eventName>` and pipe the JSON payload via
+stdin.
+
+The current rendering (line 34) passes a **bare JSON string** as the
+`stdin` field of `Bun.spawn`:
+
+```js
+const proc = Bun.spawn({
+  cmd: [pdxPath, 'hook', '--agent', 'opencode', eventName],
+  stdin: JSON.stringify(payload),
+  stdout: 'ignore',
+  stderr: 'ignore',
+})
+await proc.exited
+```
+
+`Bun.spawn` rejects raw strings — per the Bun runtime docs
+(https://bun.sh/docs/runtime/child-process) the `stdin` field accepts:
+
+```
+'pipe' | 'inherit' | 'ignore'
+| BunFile | ArrayBufferView | Blob
+| ReadableStream | Response | Request
+| number  // file descriptor
+```
+
+A bare `string` is not in that union, so the first call throws
+synchronously inside the plugin:
+
+```
+TypeError: stdio must be an array of
+code: ERR_INVALID_ARG_TYPE
+```
+
+### 1.1 Discovery & impact
+
+- Pre-existing since commit `ffdd4e14` (2026-04-21, initial opencode
+  integration). 7 days in production.
+- Found during W2 PR #710 §7 live verification on mlab — opencode
+  session inside tmux `purdex-sync` raised the TypeError on every event.
+- `agent_events.db` confirms zero `agent_type='opencode'` rows have
+  ever reached the daemon since `ffdd4e14`. No opencode trace chain
+  has ever closed.
+- Existing tests in `plugin_template_test.go` only diff the rendered
+  template **as text** (`extractEmittedEvents`, `validateSpecsCoverEmitted`,
+  parity checks). They never invoke `bun` — so CI silently passed for
+  a week.
+
+### 1.2 Why hotfix-PR (not folded into W2)
+
+W2 PR #710 (`lights-w2-naming`) ships catalog-naming separation and
+does not touch `plugin_template.go`. Folding the fix in:
+
+1. Expands W2 scope mid-review and risks codex flagging scope drift.
+2. Couples merge timing — W2 cannot ship while §7 live cannot
+   complete; conversely the spawn fix should be reviewable on its own
+   for a 7-day-old runtime bug.
+
+The hotfix is small (1-line template change + 1 integration test) and
+ships from `main` (`96bae3ce`, alpha.248). After merge, W2 rebases and
+re-runs §7 live.
+
+## 2. Requirements
+
+### 2.1 Functional
+
+| ID  | Requirement |
+|-----|-------------|
+| F1  | The rendered managed plugin must call `Bun.spawn` with a stdin shape Bun 1.3.x accepts, such that `emit('SessionStart', {…})` against a real `bun` runtime exits with status 0 and the stub `pdx` binary observes the JSON payload on stdin. |
+| F2  | The fix must preserve the existing `emit()` JS surface — the function's name, signature `(eventName, payload = {})`, and `await proc.exited` semantics must remain so the rest of the rendered handlers (`session.created`, `tool.execute.before`, …) call sites do not change. |
+| F3  | The managed marker (`pdx-managed:opencode-hooks:v1`) must remain unchanged so existing installed plugins still match `CheckHooks` detection logic. |
+| F4  | The byte-exact template-equality assumption used by `CheckHooks` (in `hooks.go`) must continue to hold: the rendered body for a given `pdxPath` is deterministic and stable. |
+
+### 2.2 Non-functional
+
+| ID  | Requirement |
+|-----|-------------|
+| N1  | Existing `plugin_template_test.go` cases must keep passing without modification of their assertions (no test deletion to make this green). |
+| N2  | The new integration test must skip cleanly when `bun` is not on `PATH` (`exec.LookPath` gate) so CI environments without Bun do not fail. |
+| N3  | The integration test must run in <5s on a developer machine (Bun cold start ~200ms; we exec it once). |
+| N4  | The fix must not introduce any new runtime dependency in `pdx` itself — Bun is already required at runtime by opencode, the fix only changes how we hand stdin to it. |
+
+### 2.3 Out of scope (explicit)
+
+- Refactoring `plugin_template.go`'s template structure, regex helpers,
+  or `validateSpecsCoverEmitted`.
+- Changes to `hooks.go` (`InstallHooks` / `CheckHooks`).
+- Catalog naming or event-spec edits (these are W2 / Phase 3 concerns).
+- Other agent plugins (cc, codex) — no shared code path.
+- Pdx-prefix migration of opencode plugin file (Phase 3 work).
+
+## 3. Fix decision
+
+Two candidates from issue #715:
+
+| Option | Code | Pros | Cons |
+|--------|------|------|------|
+| A — `'pipe'` + write/end | `stdin: 'pipe'`, then `proc.stdin.write(payload); proc.stdin.end(); await proc.exited;` | Most explicit lifecycle; matches Bun docs; works on every Bun release that has stdin streams (since 0.5.x); easy to reason about for buffer / large payload edge cases. | One extra logical step; two more lines in the rendered body. |
+| B — `TextEncoder` to TypedArray | `stdin: new TextEncoder().encode(JSON.stringify(payload))` | Single field, smaller diff. | Relies on `Bun.spawn` accepting `Uint8Array` — supported in current Bun but a less-traveled path; behavior with very large payloads less documented. |
+
+**Decision: Option A.**
+
+Rationale:
+- The payloads we send are small JSON objects (typically <1 KB session
+  metadata), so neither option has a real performance edge.
+- Option A's `write/end` lifecycle is explicit; future contributors
+  reading the rendered template will recognize the pattern from any
+  Node/Bun child-process tutorial. Option B's TypedArray form is less
+  common as a stdin payload and would benefit from a comment to
+  explain — extra cognitive cost relative to the fix's tiny scope.
+- Option A matches what the issue's "suggested fix" leads with — the
+  spec-review feedback can override, but absent that we follow the
+  documented preference.
+- On the `await` question: per Bun docs `proc.stdin.write(...)` on a
+  `pipe` is a synchronous write to a `FileSink` (returns the number of
+  bytes written), so we deliberately do not `await` it. `end()` is
+  also synchronous. The only async point is `await proc.exited`. If a
+  future Bun version makes `write` return a Promise, the rendered
+  body still emits at-least-once because every event flows through
+  `await proc.exited` regardless. We keep the no-await form so the
+  diff is minimal and readers do not need to chase a Promise that
+  current Bun does not produce.
+
+The rendered body becomes:
+
+```js
+async function emit(eventName, payload = {}) {
+  const proc = Bun.spawn({
+    cmd: [pdxPath, 'hook', '--agent', 'opencode', eventName],
+    stdin: 'pipe',
+    stdout: 'ignore',
+    stderr: 'ignore',
+  })
+  proc.stdin.write(JSON.stringify(payload))
+  proc.stdin.end()
+  await proc.exited
+}
+```
+
+## 4. Test strategy
+
+### 4.1 Existing tests (no changes)
+
+All eight existing tests in `plugin_template_test.go` remain untouched:
+
+- `TestValidateSpecsCoverEmitted_Equal` / `_EmitNotInSpec` /
+  `_SpecNotInEmit` / `_IgnoresNonInstallableSpecs` — exercise regex
+  parity helpers. They scan emit() *names*, not stdin shape; the fix
+  doesn't change names.
+- `TestOpenCodeCheckHooks_ExcludesNonInstallableSpecs` — installs
+  managed plugin and re-checks. Driven by managed marker presence.
+- `TestRenderManagedPlugin_ProducesValidBody` — checks managed marker.
+- `TestTemplateSpecsParity` — same parity check.
+- `TestExtractEmittedEvents` / `TestExtractPdxPath_RoundtripEscapedLiterals` /
+  `TestRenderManagedPlugin_UsesInputModelAndSessionScopedSubagentKeys` —
+  string-shape assertions on the rendered body.
+
+`TestRenderManagedPlugin_UsesInputModelAndSessionScopedSubagentKeys`
+asserts certain literal substrings (e.g. `const subagentKey = …`); none
+of those overlap with the `stdin:` line that we change, so this test
+keeps its meaning.
+
+### 4.2 New integration test — `TestRenderManagedPlugin_BunRuntimeEmitsStdin`
+
+A real-runtime test that proves the rendered body's `emit()` works in
+Bun. Lives in a separate file (`plugin_template_bun_integration_test.go`)
+to keep the fast unit suite untouched and so a future build tag could
+isolate it if needed.
+
+#### 4.2.1 Skip gate
+
+Three layered gates — each gate skips (not fails) when the
+precondition is not met, so CI environments without Bun and Windows
+runners both pass cleanly:
+
+```go
+if runtime.GOOS == "windows" {
+    t.Skip("opencode plugin runtime is POSIX-only; skipping real-runtime integration test")
+}
+bunPath, err := exec.LookPath("bun")
+if err != nil {
+    t.Skip("bun not on PATH; skipping real-runtime integration test")
+}
+// Probe bun executability so a stale/broken binary doesn't poison the suite.
+out, err := exec.Command(bunPath, "--version").Output()
+if err != nil || strings.TrimSpace(string(out)) == "" {
+    t.Skipf("bun --version failed (%v); skipping real-runtime integration test", err)
+}
+```
+
+The `LookPath` pattern matches existing usage in
+`internal/module/agent/handler.go:973`, `internal/agent/process_info.go:66`.
+The version probe protects against a `bun` shim that is on PATH but
+not a working executable (e.g. a stale wrapper script in CI).
+
+#### 4.2.2 Stub `pdx` binary
+
+Write a tiny shell script into `t.TempDir()` that captures stdin to a
+known path and exits 0:
+
+```sh
+#!/bin/sh
+cat > "$STDIN_CAPTURE_PATH"
+```
+
+Marked executable with `os.Chmod(0o755)`. The `runtime.GOOS == "windows"`
+gate above keeps this off Windows runners — opencode itself targets
+POSIX and the kickoff context is Mini-Lab macOS.
+
+#### 4.2.3 Render + execute
+
+1. `body := renderManagedPlugin(stubPath)` against the stub.
+2. Write `body` plus a small tail (`await (await PurdexOpenCodeHooks()).event({event:{type:'session.created', properties:{sessionID:'test-session'}}})`) into a `.js` file inside `t.TempDir()`.
+3. `exec.CommandContext(ctx, bunPath, scriptPath)` with a 5s timeout.
+   We invoke `bun <script>` directly rather than `bun run <script>` —
+   the latter goes through Bun's package-script resolver and adds
+   non-trivial CLI overhead; direct execution is faster and exercises
+   the same `Bun.spawn` runtime path that opencode uses in production.
+4. Assert `cmd.Run()` returns nil (exit 0).
+5. Read `STDIN_CAPTURE_PATH` and assert it equals
+   `{"session_id":"test-session"}` (or contains `session_id` —
+   payload key order is JSON-stable, but keep the assertion tolerant
+   by using `json.Unmarshal` round-trip).
+
+#### 4.2.4 Negative-test path (mark optional)
+
+Adding a "before-fix" failing test would require either pinning the
+old broken template or skipping conditionally — both add maintenance
+cost for limited value. The asserted positive path on real Bun is the
+authoritative regression catch: if anyone reverts to a stdin shape
+Bun rejects, this test fails immediately.
+
+### 4.3 Manual mlab live verify (PR test plan)
+
+Per kickoff §"在 mlab 端 live verify":
+
+```bash
+go build -o /tmp/pdx ./cmd/pdx
+/tmp/pdx setup --agent opencode
+cat ~/.config/opencode/plugins/pdx-agent-hooks.js | head -20
+# Expect: stdin: 'pipe' / proc.stdin.write / .end() — no JSON.stringify in stdin field
+
+# Restart daemon if needed; start opencode in tmux purdex-sync
+# Observe agent_events.db has new opencode rows after a session start
+sqlite3 ~/.config/pdx/agent_events.db "SELECT root_event_name, latest_decision, datetime(started_at/1000000000, 'unixepoch', 'localtime') FROM agent_trace_chains WHERE root_agent_type='opencode' ORDER BY started_at DESC LIMIT 5"
+```
+
+## 5. Phase split
+
+**Single phase** — the change is too small to warrant subdivision.
+
+| Step | What | Verify |
+|------|------|--------|
+| 1 | Add failing integration test (TDD red) | `go test ./internal/agent/opencode/ -run BunRuntimeEmitsStdin` fails (Bun TypeError) |
+| 2 | Apply 1-line stdin fix in `plugin_template.go` | Same test passes; entire `go test ./internal/agent/opencode/` suite green |
+| 3 | Run mlab live verify (manual, in PR test plan) | New rows appear in `agent_trace_chains` for `agent_type='opencode'` |
+
+## 6. Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `bun` version on developer machine differs from version bundled with opencode → behavior diverges | Low | Bun's `Bun.spawn({stdin:'pipe'})` API has been stable since 0.5.x. Any version that opencode ships with supports it. |
+| The integration test masks payload-encoding issues (e.g. UTF-8 surrogate edge cases) by only testing ASCII | Low | Out of scope — the fix is structural (stdin field shape). Future test additions can deepen coverage; a dedicated UTF-8 case is not load-bearing for catching the runtime regression. |
+| `proc.stdin.write(...)` returns a Promise in some Bun versions and we ignore it | Very Low | Per Bun docs, `write` on a `FileSink` returns synchronously (number of bytes). `end()` is also sync. `await proc.exited` is the only async point. Even if a future Bun made `write` async, the fix would still emit at-least-once because we await `proc.exited`. |
+| Rendered byte change breaks `CheckHooks` for users with managed plugins from before the fix | Expected & desired | A managed plugin from the broken era is byte-different from the fixed render. `hooks.go` `CheckHooks` uses `bytes.Equal` of the on-disk plugin against `renderManagedPlugin(canonicalPath)`, so a pre-fix managed plugin reports `Installed=false` (drift). The remediation is the same as any other drift: re-running `pdx setup --agent opencode` (or the SPA's "reinstall hooks" affordance) writes the fixed body. This is documented behavior, not a regression. The mlab live-verify step explicitly observes a fresh `setup --agent opencode` run before opening a session — so it covers this path implicitly. |
+
+## 7. Acceptance criteria
+
+The hotfix is verified when **all** of the following hold:
+
+1. ☐ `go test ./internal/agent/opencode/...` is green on a machine with `bun` installed — the new integration test runs, exits 0, and the captured stdin file round-trips to the expected payload.
+2. ☐ `go test ./internal/agent/opencode/...` is green on a machine without `bun` (and on Windows) — the integration test reports `--- SKIP` with a recognizable reason; all other opencode tests pass unchanged.
+3. ☐ A pre-fix managed plugin (rendered from the broken template body) when present in `~/.config/opencode/plugins/pdx-agent-hooks.js` causes `CheckHooks().Events` to report drift (`Installed=false` for at least one event), and a subsequent `pdx setup --agent opencode` rewrites it to the fixed body — exercised in mlab live-verify.
+4. ☐ Manual mlab live verify produces at least one new row with `root_agent_type='opencode'` in `agent_trace_chains` after the daemon picks up the fixed binary and a real opencode session emits a `SessionStart`.
+
+### 7.1 Process gates (tracked separately, not part of verification)
+
+These belong to the workflow, not the hotfix's correctness:
+
+- Codex spec review (this doc): 0 unaddressed P0/P1 findings — done in this revision.
+- Codex two-round PR review: 0 unaddressed P0/P1 findings.
+- PR squash-merged to `main`; `lights-w2-naming` rebases / merges main and re-runs §7 live.
+- `go vet ./...` and any repo-wide CI clean **on this PR's diff**. Pre-existing vet noise outside the changed package is not a blocker for this hotfix and should be tracked separately.
+
+## 8. References
+
+- Issue: https://github.com/wake/purdex/issues/715
+- W2 PR (downstream beneficiary): https://github.com/wake/purdex/pull/710
+- Bug introduced: commit `ffdd4e14` (2026-04-21, initial opencode integration)
+- Bun docs (Bun.spawn stdin): https://bun.sh/docs/api/spawn

--- a/internal/agent/opencode/hooks_export_test.go
+++ b/internal/agent/opencode/hooks_export_test.go
@@ -14,3 +14,12 @@ func SetResolveCanonicalPdxPathForTesting(t *testing.T, fn func() (string, bool)
 	resolveCanonicalPdxPath = fn
 	t.Cleanup(func() { resolveCanonicalPdxPath = prev })
 }
+
+// RenderManagedPluginForTesting exposes renderManagedPlugin to the
+// external _test package so the drift-detection contract test (#715,
+// 2026-04-29 plan §T3.5) can synthesize a pre-fix managed body by
+// string-substitution against the current fixed render. Test-only —
+// production callers go through InstallHooks.
+func RenderManagedPluginForTesting(pdxPath string) string {
+	return renderManagedPlugin(pdxPath)
+}

--- a/internal/agent/opencode/hooks_test.go
+++ b/internal/agent/opencode/hooks_test.go
@@ -749,3 +749,68 @@ func TestOpenCodeHooks_UnmanagedFileRejected(t *testing.T) {
 		t.Fatalf("expected unmanaged issue text, got %+v", status.Issues)
 	}
 }
+
+// TestCheckHooks_PreFixManagedBodyReportsDrift documents AC3 from
+// 2026-04-29 spec §7: a managed plugin file shipped before the
+// stdin-pipe fix (byte-different from the fixed render) must surface
+// as drift via CheckHooks, and a subsequent InstallHooks must
+// converge it back. We synthesize the pre-fix body by string-replace
+// rather than vendor a snapshot — the contract under test is "if the
+// on-disk body differs from renderManagedPlugin's current output by
+// even one byte, CheckHooks reports drift."
+func TestCheckHooks_PreFixManagedBodyReportsDrift(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pinCanonicalPdxPath(t, "/usr/local/bin/pdx")
+
+	p := opencode.NewProvider()
+
+	fixed := opencode.RenderManagedPluginForTesting("/usr/local/bin/pdx")
+	preFix := strings.Replace(
+		fixed,
+		"      stdin: 'pipe',\n      stdout: 'ignore',",
+		"      stdin: JSON.stringify(payload),\n      stdout: 'ignore',",
+		1,
+	)
+	if preFix == fixed {
+		t.Fatal("synthetic pre-fix body identical to fixed render; replace pattern stale — re-derive from current emit() shape")
+	}
+
+	pluginDir := filepath.Join(home, ".config", "opencode", "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	pluginPath := filepath.Join(pluginDir, "pdx-agent-hooks.js")
+	if err := os.WriteFile(pluginPath, []byte(preFix), 0o644); err != nil {
+		t.Fatalf("write pre-fix body: %v", err)
+	}
+
+	status, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks (pre-fix on disk): %v", err)
+	}
+	foundDrift := false
+	for name, ev := range status.Events {
+		if !ev.Installed {
+			foundDrift = true
+			t.Logf("drift on event %q (Installed=false)", name)
+		}
+	}
+	if !foundDrift {
+		t.Fatal("expected at least one event to report drift on pre-fix body; got all Installed=true")
+	}
+
+	if err := p.InstallHooks("/usr/local/bin/pdx"); err != nil {
+		t.Fatalf("InstallHooks (reinstall): %v", err)
+	}
+	after, err := p.CheckHooks()
+	if err != nil {
+		t.Fatalf("CheckHooks (post-reinstall): %v", err)
+	}
+	for name, ev := range after.Events {
+		if !ev.Installed {
+			t.Errorf("post-reinstall event %q still drifting", name)
+		}
+	}
+	_ = agent.HookEventSpec{}
+}

--- a/internal/agent/opencode/hooks_test.go
+++ b/internal/agent/opencode/hooks_test.go
@@ -766,12 +766,27 @@ func TestCheckHooks_PreFixManagedBodyReportsDrift(t *testing.T) {
 	p := opencode.NewProvider()
 
 	fixed := opencode.RenderManagedPluginForTesting("/usr/local/bin/pdx")
-	preFix := strings.Replace(
-		fixed,
-		"      stdin: 'pipe',\n      stdout: 'ignore',",
-		"      stdin: JSON.stringify(payload),\n      stdout: 'ignore',",
-		1,
-	)
+	// Synthesize the actual pre-fix body: stdin: JSON.stringify(...) and
+	// no separate proc.stdin.write/.end lines (those lines did not exist
+	// before the fix). Without removing them this test would only prove
+	// "any byte difference triggers drift" rather than "the broken
+	// managed plugin from #715 is detected and repaired."
+	const fixedBlock = "    const encoded = JSON.stringify(payload)\n" +
+		"    const proc = Bun.spawn({\n" +
+		"      cmd: [pdxPath, 'hook', '--agent', 'opencode', eventName],\n" +
+		"      stdin: 'pipe',\n" +
+		"      stdout: 'ignore',\n" +
+		"      stderr: 'ignore',\n" +
+		"    })\n" +
+		"    proc.stdin.write(encoded)\n" +
+		"    proc.stdin.end()\n"
+	const preFixBlock = "    const proc = Bun.spawn({\n" +
+		"      cmd: [pdxPath, 'hook', '--agent', 'opencode', eventName],\n" +
+		"      stdin: JSON.stringify(payload),\n" +
+		"      stdout: 'ignore',\n" +
+		"      stderr: 'ignore',\n" +
+		"    })\n"
+	preFix := strings.Replace(fixed, fixedBlock, preFixBlock, 1)
 	if preFix == fixed {
 		t.Fatal("synthetic pre-fix body identical to fixed render; replace pattern stale — re-derive from current emit() shape")
 	}

--- a/internal/agent/opencode/plugin_template.go
+++ b/internal/agent/opencode/plugin_template.go
@@ -31,10 +31,12 @@ export const PurdexOpenCodeHooks = async () => {
   async function emit(eventName, payload = {}) {
     const proc = Bun.spawn({
       cmd: [pdxPath, 'hook', '--agent', 'opencode', eventName],
-      stdin: JSON.stringify(payload),
+      stdin: 'pipe',
       stdout: 'ignore',
       stderr: 'ignore',
     })
+    proc.stdin.write(JSON.stringify(payload))
+    proc.stdin.end()
     await proc.exited
   }
 

--- a/internal/agent/opencode/plugin_template.go
+++ b/internal/agent/opencode/plugin_template.go
@@ -29,13 +29,14 @@ export const PurdexOpenCodeHooks = async () => {
   const pdxPath = %q
 
   async function emit(eventName, payload = {}) {
+    const encoded = JSON.stringify(payload)
     const proc = Bun.spawn({
       cmd: [pdxPath, 'hook', '--agent', 'opencode', eventName],
       stdin: 'pipe',
       stdout: 'ignore',
       stderr: 'ignore',
     })
-    proc.stdin.write(JSON.stringify(payload))
+    proc.stdin.write(encoded)
     proc.stdin.end()
     await proc.exited
   }

--- a/internal/agent/opencode/plugin_template_bun_integration_test.go
+++ b/internal/agent/opencode/plugin_template_bun_integration_test.go
@@ -1,0 +1,102 @@
+package opencode
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRenderManagedPlugin_BunRuntimeEmitsStdin proves the rendered emit()
+// helper actually drives Bun.spawn correctly at runtime. Plan
+// 2026-04-29 §T1: existing string-shape tests cannot catch the
+// TypeError: ERR_INVALID_ARG_TYPE that ships with stdin: <raw string>,
+// because they never invoke a real Bun. We render the plugin against
+// a stub pdx shell binary, append an async IIFE that fires one
+// session.created event, run the result with `bun <script.mjs>`, and
+// assert the stub captured the JSON payload on stdin.
+//
+// The test skips on Windows, on hosts without /bin/sh, on hosts
+// without bun on PATH, and on hosts where `bun --version` fails. Each
+// gate is a skip rather than a fail so a single `go test ./...`
+// invocation works across CI environments.
+func TestRenderManagedPlugin_BunRuntimeEmitsStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("opencode plugin runtime is POSIX-only; skipping real-Bun integration test")
+	}
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skipf("/bin/sh unavailable (%v); skipping real-Bun integration test", err)
+	}
+	bunPath, err := exec.LookPath("bun")
+	if err != nil {
+		t.Skip("bun not on PATH; skipping real-Bun integration test")
+	}
+	if out, err := exec.Command(bunPath, "--version").Output(); err != nil || strings.TrimSpace(string(out)) == "" {
+		t.Skipf("bun --version failed (%v); skipping real-Bun integration test", err)
+	}
+
+	tmp := t.TempDir()
+	stubPath := filepath.Join(tmp, "pdx-stub")
+	capturePath := filepath.Join(tmp, "stdin-capture")
+	stubBody := "#!/bin/sh\ncat > \"$PDX_TEST_STDIN_CAPTURE\"\n"
+	if err := os.WriteFile(stubPath, []byte(stubBody), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	// Belt-and-braces chmod in case umask stripped exec bit.
+	if err := os.Chmod(stubPath, 0o755); err != nil {
+		t.Fatalf("chmod stub: %v", err)
+	}
+
+	body := renderManagedPlugin(stubPath)
+	tail := `
+;(async () => {
+  const hooks = await PurdexOpenCodeHooks()
+  await hooks.event({
+    event: {
+      type: 'session.created',
+      properties: { sessionID: 'test-session' },
+    },
+  })
+})()
+`
+	scriptPath := filepath.Join(tmp, "plugin.mjs")
+	if err := os.WriteFile(scriptPath, []byte(body+tail), 0o644); err != nil {
+		t.Fatalf("write plugin.mjs: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bunPath, scriptPath)
+	cmd.Env = append(os.Environ(), "PDX_TEST_STDIN_CAPTURE="+capturePath)
+	output, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		// Classify the failure: a TypeError mentioning ERR_INVALID_ARG_TYPE
+		// (or the literal "stdio must be an array") is the pre-fix red
+		// signal. Any other failure (envelope mismatch, deadlock, syntax
+		// error) means the harness itself is wrong; surface it explicitly
+		// so a future contributor can repair it without conflating with
+		// the actual regression.
+		out := string(output)
+		if strings.Contains(out, "ERR_INVALID_ARG_TYPE") || strings.Contains(out, "stdio must be an array") {
+			t.Fatalf("pre-fix Bun TypeError observed; apply T2 stdin-pipe fix to turn this green: %s", out)
+		}
+		t.Fatalf("unexpected bun failure: err=%v output=%s", runErr, out)
+	}
+
+	captured, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("read capture: %v (bun output: %s)", err, output)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(captured, &payload); err != nil {
+		t.Fatalf("unmarshal captured stdin: %v (raw=%q)", err, string(captured))
+	}
+	if got := payload["session_id"]; got != "test-session" {
+		t.Fatalf("captured stdin session_id = %v, want %q (raw=%q)", got, "test-session", string(captured))
+	}
+}


### PR DESCRIPTION
## Summary

- Fix pre-existing bug since `ffdd4e14` (2026-04-21): the rendered opencode plugin's `emit()` helper passed a raw JSON string as `Bun.spawn` `stdin`, which Bun rejects (`TypeError: ERR_INVALID_ARG_TYPE`). Every opencode hook event has thrown for 7 days; daemon DB has zero `agent_type='opencode'` rows.
- Switch to `stdin: 'pipe'` + explicit `proc.stdin.write(...)` / `.end()` (Option A in spec §3) for documented, version-stable lifecycle.
- Add real-Bun integration test that catches the regression — existing tests only diff rendered template *text* and never exercised a real Bun runtime, which is why CI passed silently for a week.
- Add CheckHooks drift unit test that verifies a pre-fix on-disk plugin reports `Installed=false` and that reinstall converges (lifts spec AC3 from manual mlab to in-repo CI).

Closes #715.

## Spec & plan

- Spec: `docs/specs/2026-04-29-opencode-bun-spawn-stdin-fix-spec.md` — codex review job `task-moiu936r-x7a8nh` (5 P2 + 2 P3, 0 P0/P1, all addressed).
- Plan: `docs/specs/2026-04-29-opencode-bun-spawn-stdin-fix-plan.md` — codex review job `task-moiufay4-0c5pdm` (3 P2 + 3 P3, 0 P0/P1, all addressed).

## Commits

| Commit | Purpose |
|---|---|
| `cb89a41e` | docs: spec + plan |
| `7e133fe7` | test(opencode): real-Bun integration test (TDD red) |
| `093f3e71` | fix(opencode): stdin pipe (TDD green) |
| `de8e09fc` | test(opencode): CheckHooks drift coverage (AC3 in-repo) |

## Test plan

### Automated (this PR)

- [x] `go test ./internal/agent/opencode/...` green with `bun` installed (Bun 1.3.11 on dev box) — new integration test passes end-to-end against stub `pdx`.
- [x] `go test ./internal/agent/opencode/...` green with `bun` absent — integration test reports `--- SKIP` cleanly.
- [x] `go vet ./internal/agent/opencode/...` clean.
- [x] `go build ./...` clean.
- [x] Pre-fix synthetic body causes `CheckHooks` to report drift on all 8 events; reinstall converges (TestCheckHooks_PreFixManagedBodyReportsDrift).

### Manual (mlab live verify — for reviewer / wake)

```bash
# On mlab:
cd ~/Workspace/wake/purdex
git fetch origin pull/<this-PR>/head:opencode-spawn-fix-pr
git checkout opencode-spawn-fix-pr
go build -o /tmp/pdx-fix ./cmd/pdx

# AC3 in mlab terms:
ls -l ~/.config/opencode/plugins/pdx-agent-hooks.js   # pre-fix file mtime
/tmp/pdx-fix setup --agent opencode
ls -l ~/.config/opencode/plugins/pdx-agent-hooks.js   # rewritten timestamp
sed -n '1,20p' ~/.config/opencode/plugins/pdx-agent-hooks.js
# Expect: stdin: 'pipe' / proc.stdin.write(JSON.stringify(payload)) / proc.stdin.end()
# JSON.stringify must NOT appear in the stdin: field directly.

# Restart daemon to pick up fix binary if needed.
# Start opencode in tmux purdex-sync, exchange one prompt.

# AC4 evidence:
sqlite3 ~/.config/pdx/agent_events.db \
  "SELECT root_event_name, latest_decision,
          datetime(started_at/1000000000, 'unixepoch', 'localtime')
   FROM agent_trace_chains
   WHERE root_agent_type='opencode'
   ORDER BY started_at DESC LIMIT 5"
# Expect: at least one new SessionStart row with this run's timestamp.
```

## Out of scope

- Catalog naming or event-spec edits (that's W2 PR #710).
- Pdx-prefix migration of the opencode plugin filename (Phase 3).
- Refactoring `plugin_template.go` regex helpers or the parity validators.
- Other agents (`cc`, `codex`).
- Version bump (separate bump PR follows merge per repo workflow).

## Downstream

W2 PR #710 (`lights-w2-naming`) is blocked from completing its §7 live verification while this bug is in `main`. After this PR merges, W2 rebases / merges main and re-runs §7 live.