### PR TITLE
fix(agent): default sweep:pid_dead broadcast to clear when session empties

### DIFF
--- a/docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-plan.md
+++ b/docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-plan.md
@@ -6,6 +6,7 @@
 - **Worktree**: `.claude/worktrees/sweep-pid-dead-broadcast`
 - **Branch**: `worktree-sweep-pid-dead-broadcast`
 - **Tracking**: #717
+- **Plan revision**: v1.1 (2026-04-29) — incorporates codex plan review job `task-moizmm1e-zakq8b` (1 P2 + 1 P3, 0 P0/P1, both addressed).
 
 ## 1. Scope summary
 
@@ -175,9 +176,11 @@ test would *also* pass against Option A — included to prove Option B
 does not regress relative to A):
 
 1. Same setup but two frames in pane "%5":
-   - cc parent (PID 200, alive, `StatusIdle`)
-   - codex child (PID 300, **dead**, `StatusRunning`)
-2. Stub `isPidAliveFn` so `pid != 300` is alive.
+   - cc parent — `PID: 200`, alive, `StatusIdle`, **`StartedAt: 10`**, `LastSeenAt: 10`, `ProcessStartTime: "A"`, `Verified: true`
+   - codex child — `PID: 300`, **dead**, `StatusRunning`, **`StartedAt: 20`**, `LastSeenAt: 20`, `PPID: 200`, `ProcessStartTime: "B"`, `Verified: true`
+2. Stub `isPidAliveFn` so `pid != 300` is alive;
+   `processStartTimeFn` returns `"A"` for 200, `"B"` for 300;
+   `nowFn` pinned to a fixed instant.
 3. Call `m.sweepOnce()`.
 4. Capture `sweep:pid_dead` broadcast.
 5. Decode and assert:
@@ -185,12 +188,14 @@ does not regress relative to A):
    - `normalized.RawEventName == "sweep:pid_dead"`
    - `normalized.AgentType == "cc"` (TopFrame override)
 
-**Note on TopFrame selection**: confirm via reading
-`buildPaneProjection` / `projectionSortGreater` that with two frames
-in the same pane the cc parent at `StatusIdle` is the surviving
-TopFrame. If sort surfaces the codex child instead, adjust the test
-to seed an unambiguous TopFrame ordering rather than tweaking the
-expected value.
+**Stability note (codex P2 0.94)**: `buildPaneProjection` /
+`projectionSortGreater` first compare `StartedAt`, then fall back to
+`FrameID` (assigned a random UUID by `frames.Upsert`). If both
+frames default `StartedAt` to `0`, tie-break flips to a non-
+deterministic FrameID order and the test goes flaky. Explicit
+non-equal `StartedAt` (10 vs 20) eliminates the tie. After sweep
+deletes the codex child, the cc parent is the unambiguous surviving
+TopFrame regardless of FrameID UUID.
 
 **Verify red:**
 
@@ -265,6 +270,18 @@ cd spa && pnpm install --frozen-lockfile && npx vitest run --reporter=dot
 cd spa && pnpm run lint
 ```
 
+If `pnpm install --frozen-lockfile` is unavailable (offline / cache
+miss), fall back to running tests against whatever node_modules is
+already present:
+
+```bash
+cd spa && pnpm exec vitest run --reporter=dot
+cd spa && pnpm exec eslint .
+```
+
+If both paths fail, document the gap in the PR body so the user can
+run vitest on mlab during manual verification.
+
 If any test or lint fails outside the patched area, investigate
 before declaring T4 done. Do **not** widen scope to fix unrelated
 breakage — open a separate issue.
@@ -310,12 +327,27 @@ Per `feedback_bump_base_origin_not_local`: enter the bump worktree
 and immediately `git reset --hard origin/main` to avoid pulling in
 parallel session commits from local `main`.
 
+**Pre-bump remote check (codex P3 0.62)**: local files only prove no
+in-flight bump in *this* checkout. Before reserving alpha.250,
+verify no other branch already claims it:
+
+```bash
+gh pr list --search "alpha.250 in:title is:open" --json number,title
+gh api repos/wake/purdex/branches --paginate --jq '.[].name' | grep -i bump
+```
+
+If any open PR or branch already targets alpha.250, jump to the
+next free version and update plan + commit message accordingly.
+
 ## 5. Out of scope (do not regress into)
 
 - ❌ Modifying `sweep.go` (any line). The fix is intentionally at
   `frame_ops.go` per spec §3.
 - ❌ Modifying `handler.go`, `module.go`, `probe_orchestrator.go`.
 - ❌ Modifying SPA files.
+- ❌ Modifying the WS payload schema (`core.HostEvent` /
+  `agentpkg.NormalizedEvent` field set). The fix populates an
+  existing field; it does not add or rename fields.
 - ❌ Adding liveness probe / heartbeat / process-tree watcher
   features.
 - ❌ Refactoring `buildProjectionNormalized` (collapsing branches,

--- a/docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-plan.md
+++ b/docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-plan.md
@@ -1,0 +1,346 @@
+# sweep:pid_dead Broadcast Clear-Status Hotfix — Implementation Plan
+
+- **Spec**: `docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-spec.md`
+- **Date**: 2026-04-29
+- **Base**: `7463883f` (main @ alpha.249)
+- **Worktree**: `.claude/worktrees/sweep-pid-dead-broadcast`
+- **Branch**: `worktree-sweep-pid-dead-broadcast`
+- **Tracking**: #717
+
+## 1. Scope summary
+
+Production change is a 3-line guard inside an existing 22-line
+function. Tests are split between unit-level (invariant on
+`buildProjectionNormalized`) and integration-level (sweep pipeline
+broadcast).
+
+| File | Action | Lines |
+|------|--------|-------|
+| `internal/module/agent/frame_ops.go` | Edit `projection == nil` branch in `buildProjectionNormalized` (line 659) — add `if normalized.Status == "" { normalized.Status = string(agentpkg.StatusClear) }` guard | +3 / -0 |
+| `internal/module/agent/frame_ops_test.go` | Append `TestBuildProjectionNormalized_NilProjectionGuard` covering the four invariant states (spec §5.2) | ~ +90 |
+| `internal/module/agent/sweep_test.go` | Append `TestSweep_PidDead_BroadcastsClearWhenSessionEmpties` and `TestSweep_PidDead_PreservesSiblingStatus` (spec §5.3) | ~ +160 |
+| `docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-spec.md` | Already in tree (commits `882ade35` + `9bf62824`) | — |
+| `docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-plan.md` | This file | +(this) |
+
+No other production files touched. No SPA changes.
+
+## 2. Phase split — single phase, 4 ordered TDD tasks
+
+### Task T1 — Add failing unit tests on `buildProjectionNormalized` (TDD red)
+
+**Files:** `internal/module/agent/frame_ops_test.go`
+
+**What:**
+
+Append a single table-driven test
+`TestBuildProjectionNormalized_NilProjectionGuard` covering the four
+states from spec §5.2:
+
+| sub-test | projection | TopFrame | result.Status | Expected `Status` | Notes |
+|----------|-----------|----------|---------------|-------------------|-------|
+| `nil_projection_empty_status` | nil | — | `""` | `"clear"` | New guard fires; the bug fix |
+| `nil_projection_non_empty_status` | nil | — | `"running"` | `"running"` | Guard skipped; protects handler.go:211 |
+| `non_nil_projection_no_top_frame` | non-nil | nil | `""` | `"clear"` | Branch [B] unchanged |
+| `non_nil_projection_with_top_frame` | non-nil | non-nil (`StatusRunning`, `AgentType: "cc"`) | `""` | `"running"` | Branch [C] unchanged; also asserts `AgentType` is overridden from TopFrame |
+
+Implementation:
+
+```go
+func TestBuildProjectionNormalized_NilProjectionGuard(t *testing.T) {
+    cases := []struct {
+        name        string
+        projection  *SessionProjection
+        result      agentpkg.DeriveResult
+        wantStatus  string
+        wantAgent   string
+    }{
+        {
+            name:       "nil_projection_empty_status",
+            projection: nil,
+            result:     agentpkg.DeriveResult{},
+            wantStatus: string(agentpkg.StatusClear),
+            wantAgent:  "fallback",
+        },
+        {
+            name:       "nil_projection_non_empty_status",
+            projection: nil,
+            result:     agentpkg.DeriveResult{Status: agentpkg.StatusRunning},
+            wantStatus: string(agentpkg.StatusRunning),
+            wantAgent:  "fallback",
+        },
+        {
+            name:       "non_nil_projection_no_top_frame",
+            projection: &SessionProjection{},
+            result:     agentpkg.DeriveResult{},
+            wantStatus: string(agentpkg.StatusClear),
+            wantAgent:  "fallback",
+        },
+        {
+            name: "non_nil_projection_with_top_frame",
+            projection: &SessionProjection{
+                TopFrame: &store.Frame{AgentType: "cc", Status: agentpkg.StatusRunning},
+            },
+            result:     agentpkg.DeriveResult{},
+            wantStatus: string(agentpkg.StatusRunning),
+            wantAgent:  "cc",
+        },
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            got := buildProjectionNormalized(tc.projection, "fallback", "test_event", 0, tc.result)
+            if got.Status != tc.wantStatus {
+                t.Fatalf("Status = %q, want %q", got.Status, tc.wantStatus)
+            }
+            if got.AgentType != tc.wantAgent {
+                t.Fatalf("AgentType = %q, want %q", got.AgentType, tc.wantAgent)
+            }
+        })
+    }
+}
+```
+
+**Assertions to add to `frame_ops_test.go` imports** (if not already
+present): `agentpkg "github.com/wake/purdex/internal/agent"` and
+`"github.com/wake/purdex/internal/store"`.
+
+**Verify red:**
+
+```bash
+go test ./internal/module/agent/ -run TestBuildProjectionNormalized_NilProjectionGuard -v
+```
+
+Expected: `nil_projection_empty_status` fails with
+`Status = "", want "clear"`. Other three sub-tests pass against the
+unchanged function.
+
+**Commit:** `test(agent): add failing nil-projection guard invariant test for #717`
+
+---
+
+### Task T2 — Add failing integration tests on sweep pipeline (TDD red)
+
+**Files:** `internal/module/agent/sweep_test.go`
+
+**What:**
+
+Append two tests that drive the full sweep → DB delete → broadcast
+pipeline end-to-end, using the existing
+`m.core.Events.AddTestSubscriber()` capture pattern (see
+`TestSweep_PruneDeadProxyRefs_BroadcastsProjectionAfterDetach` at
+`sweep_test.go:811` for reference).
+
+Both tests use the same wire-format decoder helper to assert exact
+field values, not substring matches:
+
+```go
+func decodeSweepBroadcast(t *testing.T, raw []byte) agentpkg.NormalizedEvent {
+    t.Helper()
+    var hostEvent core.HostEvent
+    if err := json.Unmarshal(raw, &hostEvent); err != nil {
+        t.Fatalf("unmarshal HostEvent: %v (raw=%s)", err, raw)
+    }
+    var normalized agentpkg.NormalizedEvent
+    if err := json.Unmarshal([]byte(hostEvent.Value), &normalized); err != nil {
+        t.Fatalf("unmarshal NormalizedEvent: %v (value=%s)", err, hostEvent.Value)
+    }
+    return normalized
+}
+```
+
+(Place the helper near the top of `sweep_test.go`, just below the
+`newSweepTestModule` helper.)
+
+#### Test A — `TestSweep_PidDead_BroadcastsClearWhenSessionEmpties`
+
+Reproduces the #717 symptom:
+
+1. Wire `m.core` with a real `EventsBroadcaster` and add a test
+   subscriber.
+2. Upsert one frame (PID 99999, AgentType "opencode") in pane "%5"
+   of session "work".
+3. Stub `isPidAliveFn = func(int) bool { return false }`.
+4. Call `m.sweepOnce()`.
+5. Drain the subscriber's `SendCh()` looking for a broadcast.
+6. Decode it with `decodeSweepBroadcast`.
+7. Assert:
+   - `normalized.Status == "clear"`
+   - `normalized.RawEventName == "sweep:pid_dead"`
+   - `normalized.AgentType == "opencode"` (fallback preserved when
+     projection is nil)
+
+#### Test B — `TestSweep_PidDead_PreservesSiblingStatus`
+
+Confirms the guard does not over-clear when siblings exist (this
+test would *also* pass against Option A — included to prove Option B
+does not regress relative to A):
+
+1. Same setup but two frames in pane "%5":
+   - cc parent (PID 200, alive, `StatusIdle`)
+   - codex child (PID 300, **dead**, `StatusRunning`)
+2. Stub `isPidAliveFn` so `pid != 300` is alive.
+3. Call `m.sweepOnce()`.
+4. Capture `sweep:pid_dead` broadcast.
+5. Decode and assert:
+   - `normalized.Status == "idle"` (TopFrame.Status, branch [C])
+   - `normalized.RawEventName == "sweep:pid_dead"`
+   - `normalized.AgentType == "cc"` (TopFrame override)
+
+**Note on TopFrame selection**: confirm via reading
+`buildPaneProjection` / `projectionSortGreater` that with two frames
+in the same pane the cc parent at `StatusIdle` is the surviving
+TopFrame. If sort surfaces the codex child instead, adjust the test
+to seed an unambiguous TopFrame ordering rather than tweaking the
+expected value.
+
+**Verify red:**
+
+```bash
+go test ./internal/module/agent/ -run "TestSweep_PidDead_(BroadcastsClearWhenSessionEmpties|PreservesSiblingStatus)" -v
+```
+
+Expected: Test A fails on `Status == ""` (the bug). Test B may pass
+already against the unfixed code — that is fine; B is a regression
+guard, not a bug witness.
+
+**Commit:** `test(agent): add failing sweep:pid_dead broadcast assertions for #717`
+
+---
+
+### Task T3 — Apply the 3-line guard (TDD green)
+
+**Files:** `internal/module/agent/frame_ops.go`
+
+**What:**
+
+Edit lines 659-661 of `buildProjectionNormalized`:
+
+```diff
+ if projection == nil {
++    if normalized.Status == "" {
++        normalized.Status = string(agentpkg.StatusClear)
++    }
+     return normalized
+ }
+```
+
+No comments. No helper function. No restructure. The guard reads as
+plain English ("if no status was supplied, default to clear") at the
+exact branch where the invariant matters.
+
+**Verify green:**
+
+```bash
+go test ./internal/module/agent/ -run "TestBuildProjectionNormalized_NilProjectionGuard|TestSweep_PidDead_" -v
+```
+
+Expected: all six sub-tests pass.
+
+Also run the full agent test suite to confirm no regression:
+
+```bash
+go test ./internal/module/agent/...
+```
+
+**Commit:** `fix(agent): default sweep:pid_dead broadcast to clear when session empties`
+
+---
+
+### Task T4 — Full repo verification
+
+**What:**
+
+Run the complete daemon test suite + lint + build:
+
+```bash
+go test ./...
+go vet ./...
+go build ./...
+```
+
+SPA is untouched, but run vitest for sanity (per CLAUDE.md
+"Codex sandbox 無網路" — Claude must run pnpm tests manually):
+
+```bash
+cd spa && pnpm install --frozen-lockfile && npx vitest run --reporter=dot
+cd spa && pnpm run lint
+```
+
+If any test or lint fails outside the patched area, investigate
+before declaring T4 done. Do **not** widen scope to fix unrelated
+breakage — open a separate issue.
+
+**No commit** for T4 (verification only).
+
+---
+
+## 3. PR plan
+
+After T1-T4 succeed:
+
+1. Push `worktree-sweep-pid-dead-broadcast` to origin.
+2. `gh pr create` with body:
+   - **Summary**: 3 bullets — root cause, fix, behavior change at
+     handler.go:266/328 (desired).
+   - **Test plan**: lift §8 from spec.
+   - **Closes**: #717.
+3. Round 1 review: `/codex:review --base main` (standard).
+4. Round 2 review: 3-parallel `/codex:adversarial-review` runs:
+   - Attack: bugs / races / boundary conditions in the guard +
+     callsite audit reasoning.
+   - Defense: validate Option B vs A again under adversarial
+     re-reading of the spec; check architectural fit.
+   - File quality: `frame_ops.go` SRP / size / responsibility
+     creep.
+5. Aggregate findings (severity / confidence / complexity table per
+   `feedback_dev_process`). Fix high-confidence + low-complexity +
+   high-relevance items inline; defer the rest as `gh issue`.
+6. Merge (squash). Squash commit message follows existing convention
+   (`fix(agent): ...`).
+
+## 4. Bump PR (after merge)
+
+Independent PR from a fresh worktree off `origin/main`:
+
+- `VERSION` → `1.0.0-alpha.250`
+- `package.json` + `spa/package.json` → `1.0.0-alpha.250`
+- `CHANGELOG.md` → entry under `## [1.0.0-alpha.250]` referencing
+  #717
+
+Per `feedback_bump_base_origin_not_local`: enter the bump worktree
+and immediately `git reset --hard origin/main` to avoid pulling in
+parallel session commits from local `main`.
+
+## 5. Out of scope (do not regress into)
+
+- ❌ Modifying `sweep.go` (any line). The fix is intentionally at
+  `frame_ops.go` per spec §3.
+- ❌ Modifying `handler.go`, `module.go`, `probe_orchestrator.go`.
+- ❌ Modifying SPA files.
+- ❌ Adding liveness probe / heartbeat / process-tree watcher
+  features.
+- ❌ Refactoring `buildProjectionNormalized` (collapsing branches,
+  extracting helpers, adding comments).
+- ❌ Touching unrelated agent tests "while we're in there".
+
+## 6. Rollback
+
+The fix is purely additive (3 conditional lines inside an existing
+branch). To roll back, delete those 3 lines. No database
+migration, no SPA contract change, no external state change.
+
+## 7. Verification checklist (before opening PR)
+
+- [ ] T1: 4 invariant sub-tests added, all 4 pass after T3
+- [ ] T2: 2 sweep integration tests added, Test A demonstrably red
+      before T3 and green after
+- [ ] T3: 3-line guard applied at frame_ops.go:659; no other
+      production changes
+- [ ] T4: `go test ./...` green, `go vet ./...` green,
+      `go build ./...` green
+- [ ] T4: `cd spa && npx vitest run` green, `pnpm run lint` green
+- [ ] No new comments added inside `buildProjectionNormalized`
+- [ ] No new helpers / abstractions introduced
+- [ ] Diff stat matches §1 budget (≤ +260 / -0 across 3 files
+      excluding spec/plan)
+- [ ] Manual mlab repro from spec §8 still drafted in PR body
+      (executed by user)

--- a/docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-spec.md
+++ b/docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-spec.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-04-29
 - **Base**: `7463883f` (main @ alpha.249)
 - **Author**: claude-code + wake
-- **Status**: Draft
+- **Status**: Draft (revised after codex spec review job `task-moizea6l-z32mvg`; 3 P2 + 2 P3 findings, 0 P0/P1, all addressed)
 - **Tracking**: #717 (bug, daemon, spa)
 - **Worktree**: `.claude/worktrees/sweep-pid-dead-broadcast`
 - **Branch**: `worktree-sweep-pid-dead-broadcast`
@@ -124,25 +124,36 @@ if projection == nil {
 
 ## 4. Callsite Audit — Why the Guard is Safe
 
-`buildProjectionNormalized` has 7 callsites
-(`grep -n buildProjectionNormalized internal/module/agent/*.go`):
+`buildProjectionNormalized` has 8 callsites
+(`grep -n buildProjectionNormalized internal/module/agent/*.go`).
+`projection` source is "non-nil" iff the call structurally cannot
+receive `nil`; "nil-possible" means `projectionForSession` /
+`selectSessionProjection` may return `nil` when the session has no
+matching live frames.
 
-| Callsite | Projection | `result.Status` | Branch |
-|----------|-----------|-----------------|--------|
-| `module.go:388` (replay) | non-nil | `""` (DeriveResult{}) | [B] or [C] |
-| `handler.go:211` (error_guard_blocked) | **nil** | **non-empty** (gated by line 196: `result.Valid && result.Status != "" && result.Status != StatusError`) | [A] |
-| `handler.go:266` (event handler) | non-nil | derived | [B] or [C] |
-| `handler.go:328` (event handler) | non-nil | derived | [B] or [C] |
-| `probe_orchestrator.go:357` (probe:activity) | non-nil | `""` | [B] or [C] |
-| `sweep.go:327` (sweep:proxy_canonicalized) | non-nil | `""` | [C] |
-| `sweep.go:499` (sweep:proxy_pruned) | non-nil | `""` | [C] |
-| `sweep.go:551` (sweep:pid_dead) | **nil-or-non-nil** | `""` | **[A] or [B] or [C]** |
+| Callsite | Projection | `result.Status` | Guard fires? | Behavior |
+|----------|-----------|-----------------|--------------|----------|
+| `module.go:388` (replay) | **non-nil, TopFrame non-nil** by construction (`BuildSessionProjections` filters `TopFrame != nil` at `projection.go:31`) | `""` | No | Branch [C], `TopFrame.Status` |
+| `handler.go:211` (error_guard_blocked) | **nil** | **non-empty** (gated by line 196: `result.Valid && result.Status != "" && result.Status != StatusError`) | No | Branch [A], caller's status preserved (unchanged) |
+| `handler.go:266` (SubagentStart/Stop emit) | **nil-possible** | usually `""` (subagent events do not derive a status) | **Possibly** if `projection==nil` AND `result.Status==""` | Branch [A] guarded → `clear`. Race scenario: SubagentStart arrives after the session's last frame was reaped. Original behavior dropped the broadcast at SPA `if (status)`; new behavior actively clears the indicator — **desired**, the session truly has no frame to display. |
+| `handler.go:328` (general hook emit) | **nil-possible** | usually non-empty when `result.Valid` (derived from event), but `""` is reachable | **Possibly** if `projection==nil` AND `result.Status==""` | Same race semantics as 266; guard's clearing behavior is the desired outcome. |
+| `probe_orchestrator.go:357` (probe:activity) | non-nil by control flow: `setProjectionTopStatus` returns `(projection, nil)` only when `projection != nil && TopFrame != nil`; failure paths fall back to a directly-built `NormalizedEvent`, not this callsite (`probe_orchestrator.go:692-706`) | `""` (DeriveResult{}) | No | Branch [C], `TopFrame.Status` |
+| `sweep.go:327` (sweep:proxy_canonicalized) | non-nil with TopFrame (operates on live pane with surviving canonical) | `""` | No | Branch [C] |
+| `sweep.go:499` (sweep:proxy_pruned) | non-nil with TopFrame (proxy pruned but parent live) | `""` | No | Branch [C] |
+| `sweep.go:551` (sweep:pid_dead) | **nil-possible** (last frame may have been the one cleared) | `""` (DeriveResult{}) | **Yes** when `projection==nil` | Branch [A] guarded → `clear` (the bug fix) |
 
-The new guard only triggers when **projection is nil AND result.Status
-is empty**. The audit confirms that combination is unique to
-`sweep.go:551` (the bug case). `handler.go:211` is the only other
-nil-projection callsite, and line 196 guarantees a non-empty
-`result.Status` reaches it — guard is bypassed, behavior unchanged.
+**Net behavior change**: at `handler.go:266` and `handler.go:328`,
+when projection drops to nil mid-flight (race after the last frame is
+reaped) and the incoming hook does not derive a status, the broadcast
+now carries `status=clear` instead of empty. SPA goes from "ignore"
+to "actively clear indicator". This is the same correctness gap as
+the `sweep:pid_dead` bug — the SPA had no frame to display, but its
+indicator stayed at the last value because the broadcast carried no
+intent.
+
+Branch [A] callers that pass non-empty `result.Status` (handler.go:211)
+are unaffected: guard checks `if normalized.Status == ""` before
+overwriting.
 
 ## 5. Test Strategy
 
@@ -164,28 +175,38 @@ state combinations:
 | 3 | non-nil | nil | any | `"clear"` (branch [B], unchanged) |
 | 4 | non-nil | non-nil | any | `TopFrame.Status` (branch [C], unchanged) |
 
-Test #2 specifically guards against regression at `handler.go:211`.
+Test #2 specifically guards against regression at `handler.go:211`
+(and any future caller that legitimately passes nil projection with a
+non-empty status).
 
-### 5.3 sweep_test.go — broadcast capture
+### 5.3 sweep_test.go — broadcast capture (strict assertion)
 
 End-to-end test that exercises sweep → DB delete → broadcast pipeline:
 
-- **Test A**: Single frame, PID dies, sweep clears. Capture
-  `sweep:pid_dead` broadcast payload and assert
-  `event.status === "clear"`.
+- **Test A**: Single frame, PID dies, sweep clears. Capture the
+  `sweep:pid_dead` `core.HostEvent`, JSON-decode `Value` into
+  `agentpkg.NormalizedEvent`, assert
+  `normalized.Status == "clear"` AND
+  `normalized.RawEventName == "sweep:pid_dead"` AND
+  `normalized.AgentType == frame.AgentType` (fallback preserved).
 - **Test B**: Two frames in same session (different panes), one PID
-  dies, sweep clears it. Capture broadcast and assert
-  `event.status` reflects the surviving `TopFrame.Status` (i.e. the
-  guard does not over-clear when siblings exist).
+  dies, sweep clears it. JSON-decode the broadcast and assert
+  `normalized.Status == surviving TopFrame.Status` (i.e. the guard
+  does not over-clear when siblings exist).
+
+Substring assertions (`strings.Contains(payload, "sweep:pid_dead")`)
+are insufficient — they would pass for any broadcast that mentions
+the reason but carries the wrong status. The decoder-level assertion
+is required to defend the actual invariant.
 
 ### 5.4 Capture mechanism
 
 Inspect existing `newSweepTestModule` helper. If `m.core.Events` is
 already wired with a capture-friendly broadcaster, reuse it.
 Otherwise, install a minimal in-memory capture seam (e.g. a fake
-broadcaster that records `(code, kind, payload)` tuples). Do **not**
-introduce a new abstraction or production seam — capture is
-test-only.
+broadcaster that records `core.HostEvent` values and exposes them to
+the test). Do **not** introduce a new abstraction or production seam
+— capture is test-only.
 
 ### 5.5 SPA-side regression coverage
 
@@ -269,7 +290,10 @@ a single-line removal with no migration concerns.
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| Guard fires for an unintended callsite | Very low | Wrong status broadcast | Callsite audit (§4) + invariant test #2 |
+| Guard fires for an unintended callsite | Very low | Wrong status broadcast | Callsite audit (§4) + invariant test #2 (`projection==nil` + non-empty status passes through) |
+| `handler.go:266`/`328` race: SubagentStart/Stop or hook with `result.Status==""` lands when projection just dropped to nil | Low | Net change: SPA goes from "ignore" to "actively clear" the indicator | Behavior change is desired (the session truly has no displayable frame); §4 documents this; integration test in §5.3 Test A covers the same wire shape |
+| `module.go:388` (replay) starts hitting `projection==nil` | Cannot occur | n/a | Structurally impossible: `BuildSessionProjections` filters `TopFrame != nil` at `projection.go:31`; replay only iterates that filtered set |
+| `probe_orchestrator.go:357` starts hitting `projection==nil` | Cannot occur | n/a | Control flow at `setProjectionTopStatus` returns `(projection, nil)` only when `projection != nil && TopFrame != nil`; failure paths route to a different `NormalizedEvent` build, not this callsite |
 | Test capture seam leaks into production | Low | Code smell | Keep capture test-only (§5.4) |
 | SPA contract changes underneath | Very low | Fix becomes ineffective | SPA test suite covers `status === 'clear'`; no SPA changes in this PR |
 

--- a/docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-spec.md
+++ b/docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-spec.md
@@ -1,0 +1,284 @@
+# sweep:pid_dead Broadcast Clear-Status Hotfix Spec
+
+- **Version**: 1.0.0-alpha.249 (target bump after merge)
+- **Date**: 2026-04-29
+- **Base**: `7463883f` (main @ alpha.249)
+- **Author**: claude-code + wake
+- **Status**: Draft
+- **Tracking**: #717 (bug, daemon, spa)
+- **Worktree**: `.claude/worktrees/sweep-pid-dead-broadcast`
+- **Branch**: `worktree-sweep-pid-dead-broadcast`
+
+## 1. Context
+
+When an agent process inside a tmux pane dies (e.g. `Ctrl+C` on opencode),
+the daemon's sweep loop detects the dead PID and clears the corresponding
+frame from the DB. After the frame is cleared, sweep emits a
+`sweep:pid_dead` broadcast so the SPA can update the agent indicator.
+
+Live mlab repro (issue #717) confirms detection and DB cleanup are
+correct, but the broadcast carries `status=""` instead of
+`status="clear"`. The SPA's `useAgentStore.handleNormalizedEvent`
+strictly tests `event.status === 'clear'` and a falsy `if (status)`
+guard at the status block, so an empty status is silently dropped: the
+indicator (icon + agent_type) stays at its last value, looking as if
+the agent is still alive.
+
+Symptom: SPA agent activity indicator does not clear after opencode
+exits via SIGINT, even though the daemon has fully reaped the frame.
+
+## 2. Root Cause — Asymmetric Nil Branches
+
+`internal/module/agent/frame_ops.go:649-670` defines
+`buildProjectionNormalized`, which converts internal projection state
+into a wire-format `NormalizedEvent` for the SPA. The function has
+three control branches:
+
+```go
+normalized := agentpkg.NormalizedEvent{
+    AgentType: fallbackAgentType,
+    Status:    string(result.Status),   // (*) caller-supplied status
+    ...
+}
+if projection == nil {
+    return normalized                   // [A] caller's status leaks through
+}
+normalized.Subagents = append(...)
+if projection.TopFrame == nil {
+    normalized.Status = string(agentpkg.StatusClear)  // [B] forces clear
+    return normalized
+}
+normalized.AgentType = projection.TopFrame.AgentType
+normalized.Status = string(projection.TopFrame.Status)  // [C] uses TopFrame
+return normalized
+```
+
+Branches [A] and [B] semantically mean the same thing: **no top frame
+exists for the SPA to display**. They should produce the same
+`Status` (`clear`). But only [B] enforces this — [A] passes through
+whatever the caller put into `result.Status`.
+
+`sweep.go:551` (the `afterFrameCleared` callsite) calls the function
+with an empty `agentpkg.DeriveResult{}` because sweep is not deriving
+a status from a hook event — it is just reporting "frame cleared,
+recompute projection". When the dead frame was the only frame in the
+session, projection is nil → branch [A] runs → empty status leaks.
+
+## 3. Decision — Option B (frame_ops symmetric guard)
+
+Two viable fixes were considered.
+
+### Option A — Surgical at sweep callsite
+
+Pre-cook `DeriveResult{Status: agentpkg.StatusClear}` at `sweep.go:551`
+so branch [A] receives `clear` instead of `""`.
+
+**Rejected** for these reasons:
+
+1. **Scatters the invariant.** "No top frame ⇒ broadcast clear" is a
+   property of the wire format, not of any specific caller. Encoding
+   it at the callsite means each future nil-projection caller must
+   re-discover and re-encode the rule.
+2. **Misleads the reader.** `Status: StatusClear` at the sweep
+   callsite reads as "I'm broadcasting clear", but if a sibling frame
+   survived the sweep, branch [C] still wins and the actual broadcast
+   carries `TopFrame.Status`. The callsite hint is divorced from the
+   real output.
+3. **Leaves the latent asymmetry in `frame_ops.go`.** A future caller
+   that passes nil projection without setting status would re-trigger
+   the same bug.
+4. **Internally contradictory.** Sweep calls
+   `buildProjectionNormalized` precisely so the function will figure
+   out the right status across the three projection states. Forcing
+   the callsite to also pre-supply a status undermines that
+   abstraction.
+
+### Option B — Symmetric guard in `buildProjectionNormalized` (chosen)
+
+Add a defensive guard inside the `projection == nil` branch so the
+function itself enforces "no top frame ⇒ status defaults to clear":
+
+```go
+if projection == nil {
+    if normalized.Status == "" {
+        normalized.Status = string(agentpkg.StatusClear)
+    }
+    return normalized
+}
+```
+
+**Properties**:
+
+- **Single source of truth.** The invariant lives in the function that
+  owns the wire format. Callers no longer need to know about the
+  nil-projection edge case.
+- **Backwards-compatible.** When a caller passes nil projection with
+  a non-empty `result.Status` (e.g. `handler.go:211` error_guard
+  path), the guard is skipped and the caller's status is preserved.
+- **Surgical.** One conditional inside an existing 22-line function.
+  No new helpers, types, abstractions, files, comments, or
+  reorganization.
+- **Symmetric to branch [B].** Both branches now share the
+  "no top frame ⇒ clear" semantics; only the means differ
+  (unconditional in [B], guarded in [A]).
+
+## 4. Callsite Audit — Why the Guard is Safe
+
+`buildProjectionNormalized` has 7 callsites
+(`grep -n buildProjectionNormalized internal/module/agent/*.go`):
+
+| Callsite | Projection | `result.Status` | Branch |
+|----------|-----------|-----------------|--------|
+| `module.go:388` (replay) | non-nil | `""` (DeriveResult{}) | [B] or [C] |
+| `handler.go:211` (error_guard_blocked) | **nil** | **non-empty** (gated by line 196: `result.Valid && result.Status != "" && result.Status != StatusError`) | [A] |
+| `handler.go:266` (event handler) | non-nil | derived | [B] or [C] |
+| `handler.go:328` (event handler) | non-nil | derived | [B] or [C] |
+| `probe_orchestrator.go:357` (probe:activity) | non-nil | `""` | [B] or [C] |
+| `sweep.go:327` (sweep:proxy_canonicalized) | non-nil | `""` | [C] |
+| `sweep.go:499` (sweep:proxy_pruned) | non-nil | `""` | [C] |
+| `sweep.go:551` (sweep:pid_dead) | **nil-or-non-nil** | `""` | **[A] or [B] or [C]** |
+
+The new guard only triggers when **projection is nil AND result.Status
+is empty**. The audit confirms that combination is unique to
+`sweep.go:551` (the bug case). `handler.go:211` is the only other
+nil-projection callsite, and line 196 guarantees a non-empty
+`result.Status` reaches it — guard is bypassed, behavior unchanged.
+
+## 5. Test Strategy
+
+### 5.1 Test placement
+
+Tests live in `internal/module/agent/frame_ops_test.go`
+(invariant-level) and `internal/module/agent/sweep_test.go`
+(integration-level).
+
+### 5.2 frame_ops_test.go — invariant coverage
+
+Direct unit tests on `buildProjectionNormalized` covering all four
+state combinations:
+
+| # | projection | TopFrame | result.Status | Expected `Status` |
+|---|-----------|----------|---------------|-------------------|
+| 1 | nil | — | `""` | `"clear"` (new guard fires) |
+| 2 | nil | — | `"running"` | `"running"` (guard skipped, caller wins) |
+| 3 | non-nil | nil | any | `"clear"` (branch [B], unchanged) |
+| 4 | non-nil | non-nil | any | `TopFrame.Status` (branch [C], unchanged) |
+
+Test #2 specifically guards against regression at `handler.go:211`.
+
+### 5.3 sweep_test.go — broadcast capture
+
+End-to-end test that exercises sweep → DB delete → broadcast pipeline:
+
+- **Test A**: Single frame, PID dies, sweep clears. Capture
+  `sweep:pid_dead` broadcast payload and assert
+  `event.status === "clear"`.
+- **Test B**: Two frames in same session (different panes), one PID
+  dies, sweep clears it. Capture broadcast and assert
+  `event.status` reflects the surviving `TopFrame.Status` (i.e. the
+  guard does not over-clear when siblings exist).
+
+### 5.4 Capture mechanism
+
+Inspect existing `newSweepTestModule` helper. If `m.core.Events` is
+already wired with a capture-friendly broadcaster, reuse it.
+Otherwise, install a minimal in-memory capture seam (e.g. a fake
+broadcaster that records `(code, kind, payload)` tuples). Do **not**
+introduce a new abstraction or production seam — capture is
+test-only.
+
+### 5.5 SPA-side regression coverage
+
+`spa/src/stores/useAgentStore.test.ts` is not modified. The SPA's
+`status === 'clear'` branch is already covered by existing tests; the
+fix is in the daemon's wire output, not in SPA logic.
+
+## 6. Scope Discipline (What NOT To Touch)
+
+- ❌ Do not collapse branches [A] and [B] into a single
+  `projection == nil || projection.TopFrame == nil` block. That is a
+  separate refactor.
+- ❌ Do not introduce a helper (e.g. `clearStatusIfNoTopFrame`) for
+  the new guard — keep it inline.
+- ❌ Do not add comments inside `buildProjectionNormalized`. Per
+  CLAUDE.md "default no comments". The function name + symmetric
+  branches are self-documenting.
+- ❌ Do not modify `sweep.go:551`, `sweep.go:327`, or `sweep.go:499`.
+- ❌ Do not modify `handler.go:211` (callsite audit confirms it is
+  unaffected; touching it expands review surface for no reason).
+- ❌ Do not modify any SPA file. The fix is server-side; SPA contract
+  (`status === 'clear'`) is unchanged.
+- ❌ Do not add liveness probe / heartbeat / process-tree watcher
+  features (originally proposed in #717 body but ruled out — sweep
+  already does PID polling every 2s; adding more polling is
+  unnecessary).
+
+## 7. Phase Plan
+
+Single phase. The change is one production-code edit (3 lines) plus
+test additions.
+
+| Step | Action |
+|------|--------|
+| 1 | Spec review by codex (this file) |
+| 2 | Write plan (single-phase TDD task breakdown) |
+| 3 | Plan review by codex |
+| 4 | TDD: write failing tests in `frame_ops_test.go` and `sweep_test.go` first |
+| 5 | Apply 3-line guard at `frame_ops.go:659` |
+| 6 | Verify all tests green: `go test ./internal/module/agent/...` |
+| 7 | Open PR; cross-model codex review (2 rounds: standard + adversarial 3-parallel) |
+| 8 | Address findings, merge |
+| 9 | Independent bump PR (alpha.250) |
+
+## 8. Manual Verification Plan (PR Test Plan)
+
+Live test on mlab to reproduce the original symptom and confirm the
+fix:
+
+```bash
+# Build daemon with fix
+go build -o /tmp/pdx-fix ./cmd/pdx
+
+# Restart daemon
+pkill -f "pdx serve" || true
+PDX_DEV_MODE=1 nohup /tmp/pdx-fix serve > /tmp/pdx.log 2>&1 &
+
+# Trigger repro: open opencode in tmux, exchange a prompt, Ctrl+C
+tmux new -s opencode-fix-test
+opencode
+# > /chat hello
+# Wait for response, then Ctrl+C twice to exit opencode
+
+# Verify SPA agent indicator clears immediately for that session
+# (check Purdex SPA — the agent dot should disappear within ~2s sweep cadence)
+
+# Forensic confirmation
+sqlite3 ~/.config/pdx/agent_events.db \
+  "SELECT root_event_name, latest_decision FROM agent_trace_chains \
+   WHERE root_agent_type='opencode' ORDER BY started_at DESC LIMIT 5"
+# Expected: latest sweep:pid_dead broadcast carries status=clear (visible in
+# WS frame, captured separately if needed)
+```
+
+## 9. Rollback
+
+The guard is purely additive within an existing branch. Reverting is
+a single-line removal with no migration concerns.
+
+## 10. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Guard fires for an unintended callsite | Very low | Wrong status broadcast | Callsite audit (§4) + invariant test #2 |
+| Test capture seam leaks into production | Low | Code smell | Keep capture test-only (§5.4) |
+| SPA contract changes underneath | Very low | Fix becomes ineffective | SPA test suite covers `status === 'clear'`; no SPA changes in this PR |
+
+## 11. Out of Scope (Tracked Elsewhere)
+
+- Liveness heartbeat / process-tree watch / upstream opencode
+  shutdown hook — issue #717 originally listed these, but sweep's
+  existing 2s PID poll is sufficient once the broadcast is correct.
+- Refactor of `buildProjectionNormalized` to collapse branches [A]
+  and [B] — possible future cleanup, not required for this fix.
+- Other `sweep:*` reasons (`proxy_canonicalized`, `proxy_pruned`) —
+  audited safe (§4); no changes.

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -657,6 +657,9 @@ func buildProjectionNormalized(projection *SessionProjection, fallbackAgentType,
 		Detail:       result.Detail,
 	}
 	if projection == nil {
+		if normalized.Status == "" {
+			normalized.Status = string(agentpkg.StatusClear)
+		}
 		return normalized
 	}
 	normalized.Subagents = append([]agentpkg.SubagentRef(nil), projection.Subagents...)

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -4109,3 +4109,61 @@ func TestCandidateHasOwnedState_EmptySubagentsReturnsFalse(t *testing.T) {
 		t.Fatal("candidateHasOwnedState = true, want false (empty subagents — no state to preserve)")
 	}
 }
+
+// #717 — buildProjectionNormalized must produce status=clear whenever
+// the projection has no top frame to display. Both nil branches
+// (projection==nil and projection!=nil with TopFrame==nil) share the
+// same wire-format invariant; the function previously enforced it
+// only on the second branch, leaking caller-supplied empty status
+// through the first.
+func TestBuildProjectionNormalized_NilProjectionGuard(t *testing.T) {
+	cases := []struct {
+		name       string
+		projection *SessionProjection
+		result     agentpkg.DeriveResult
+		wantStatus string
+		wantAgent  string
+	}{
+		{
+			name:       "nil_projection_empty_status",
+			projection: nil,
+			result:     agentpkg.DeriveResult{},
+			wantStatus: string(agentpkg.StatusClear),
+			wantAgent:  "fallback",
+		},
+		{
+			name:       "nil_projection_non_empty_status",
+			projection: nil,
+			result:     agentpkg.DeriveResult{Status: agentpkg.StatusRunning},
+			wantStatus: string(agentpkg.StatusRunning),
+			wantAgent:  "fallback",
+		},
+		{
+			name:       "non_nil_projection_no_top_frame",
+			projection: &SessionProjection{},
+			result:     agentpkg.DeriveResult{},
+			wantStatus: string(agentpkg.StatusClear),
+			wantAgent:  "fallback",
+		},
+		{
+			name: "non_nil_projection_with_top_frame",
+			projection: &SessionProjection{
+				TopFrame: &store.Frame{AgentType: "cc", Status: agentpkg.StatusRunning},
+			},
+			result:     agentpkg.DeriveResult{},
+			wantStatus: string(agentpkg.StatusRunning),
+			wantAgent:  "cc",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildProjectionNormalized(tc.projection, "fallback", "test_event", 0, tc.result)
+			if got.Status != tc.wantStatus {
+				t.Fatalf("Status = %q, want %q", got.Status, tc.wantStatus)
+			}
+			if got.AgentType != tc.wantAgent {
+				t.Fatalf("AgentType = %q, want %q", got.AgentType, tc.wantAgent)
+			}
+		})
+	}
+}

--- a/internal/module/agent/sweep_test.go
+++ b/internal/module/agent/sweep_test.go
@@ -24,6 +24,24 @@ func newSweepTestModule(t *testing.T) *Module {
 	return m
 }
 
+// decodeSweepBroadcast unwraps a raw subscriber message into the
+// inner agentpkg.NormalizedEvent. The broadcaster sends each event
+// as core.HostEvent JSON; HostEvent.Value is itself a JSON-encoded
+// NormalizedEvent string. Strict equality assertions on Status /
+// RawEventName / AgentType need both layers parsed.
+func decodeSweepBroadcast(t *testing.T, raw []byte) agentpkg.NormalizedEvent {
+	t.Helper()
+	var hostEvent core.HostEvent
+	if err := json.Unmarshal(raw, &hostEvent); err != nil {
+		t.Fatalf("unmarshal HostEvent: %v (raw=%s)", err, raw)
+	}
+	var normalized agentpkg.NormalizedEvent
+	if err := json.Unmarshal([]byte(hostEvent.Value), &normalized); err != nil {
+		t.Fatalf("unmarshal NormalizedEvent: %v (value=%s)", err, hostEvent.Value)
+	}
+	return normalized
+}
+
 func TestSweep_ClearsDeadFramesByPid(t *testing.T) {
 	m := newSweepTestModule(t)
 	if err := m.events.Set("work", "Stop", json.RawMessage(`{}`), "cc", 1); err != nil {
@@ -2641,5 +2659,143 @@ func TestSweep_CanonicalizeSkipsCandidateWithLiveProxy(t *testing.T) {
 	}
 	if delta := agentpkg.MetricPartialCanonicalizationCreated.Value() - startPartial; delta != 1 {
 		t.Fatalf("MetricPartialCanonicalizationCreated delta = %d, want 1 (deliberate partial: attach without delete)", delta)
+	}
+}
+
+// #717 — sweep:pid_dead broadcast must carry status=clear when the
+// dead frame was the only frame in its tmux session. SPA's
+// useAgentStore strict-equality tests (`event.status === 'clear'`)
+// drop empty status as a no-op, leaving the agent indicator stuck
+// at its last value (the user-visible #717 symptom).
+func TestSweep_PidDead_BroadcastsClearWhenSessionEmpties(t *testing.T) {
+	m := newSweepTestModule(t)
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: m.tmux}
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "opencode",
+		PID:              99999,
+		PPID:             1,
+		ProcessStartTime: "dead",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(int) bool { return false }
+	processStartTimeFn = func(int) (string, error) { return "dead", nil }
+	nowFn = func() time.Time { return time.Unix(0, 20) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	select {
+	case msg := <-sub.SendCh():
+		got := decodeSweepBroadcast(t, msg)
+		if got.RawEventName != "sweep:pid_dead" {
+			t.Fatalf("RawEventName = %q, want %q", got.RawEventName, "sweep:pid_dead")
+		}
+		if got.Status != string(agentpkg.StatusClear) {
+			t.Fatalf("Status = %q, want %q (#717: empty status leaks through projection==nil branch)", got.Status, agentpkg.StatusClear)
+		}
+		if got.AgentType != "opencode" {
+			t.Fatalf("AgentType = %q, want %q (fallback should preserve dead frame's type)", got.AgentType, "opencode")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for sweep:pid_dead broadcast")
+	}
+}
+
+// #717 — when a sibling frame survives the sweep in the same tmux
+// session, the broadcast must surface the surviving TopFrame's status
+// (branch [C] of buildProjectionNormalized), NOT clear. This guards
+// against an over-eager fix that would always force clear regardless
+// of remaining projection state.
+func TestSweep_PidDead_PreservesSiblingStatus(t *testing.T) {
+	m := newSweepTestModule(t)
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: m.tmux}
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	// cc parent (alive, idle, StartedAt=10) and codex child (dead,
+	// running, StartedAt=20). Explicit non-equal StartedAt eliminates
+	// the projectionSortGreater FrameID-uuid tiebreak (codex plan
+	// review P2 0.94: would otherwise be flaky on tie).
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "A",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert cc parent: %v", err)
+	}
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "codex",
+		PID:              300,
+		PPID:             200,
+		ProcessStartTime: "B",
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        20,
+		LastSeenAt:       20,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert codex child: %v", err)
+	}
+
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origNow := nowFn
+	isPidAliveFn = func(pid int) bool { return pid != 300 }
+	processStartTimeFn = func(pid int) (string, error) {
+		if pid == 200 {
+			return "A", nil
+		}
+		return "B", nil
+	}
+	nowFn = func() time.Time { return time.Unix(0, 30) }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		nowFn = origNow
+	})
+
+	if err := m.sweepOnce(); err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+
+	select {
+	case msg := <-sub.SendCh():
+		got := decodeSweepBroadcast(t, msg)
+		if got.RawEventName != "sweep:pid_dead" {
+			t.Fatalf("RawEventName = %q, want %q", got.RawEventName, "sweep:pid_dead")
+		}
+		if got.Status != string(agentpkg.StatusIdle) {
+			t.Fatalf("Status = %q, want %q (TopFrame=cc StatusIdle should dominate via branch [C])", got.Status, agentpkg.StatusIdle)
+		}
+		if got.AgentType != "cc" {
+			t.Fatalf("AgentType = %q, want %q (TopFrame override expected)", got.AgentType, "cc")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for sweep:pid_dead broadcast")
 	}
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `buildProjectionNormalized` (`internal/module/agent/frame_ops.go:649-672`) had asymmetric nil branches — `projection==nil` trusted caller-supplied `result.Status` while the parallel `projection!=nil && TopFrame==nil` branch unconditionally set `StatusClear`. When sweep cleared a frame whose tmux session had no remaining frames, the broadcast leaked `status=""`. SPA's `useAgentStore.handleNormalizedEvent` strict-equality tests `event.status === 'clear'` and the `if (status)` guard at the status block, so empty status fell through and the agent indicator stayed at its last value.
- **Fix**: 3-line symmetric guard inside `buildProjectionNormalized`'s `projection==nil` branch — `if normalized.Status == "" { normalized.Status = StatusClear }`. The wire-format invariant "no top frame to display ⇒ broadcast clear" is now centralized in the function rather than scattered across callers.
- **Behavior change** (intentional, documented): at `handler.go:266` and `handler.go:328`, when projection drops to nil mid-flight (race after the last frame is reaped) and the incoming hook does not derive a status, the broadcast now carries `status=clear` instead of empty. SPA goes from "ignore" to "actively clear indicator" — same correctness gap as the `sweep:pid_dead` case. Other callers are unaffected: `handler.go:211` (error_guard_blocked) is gated upstream by `result.Status != ""`; `module.go:388` (replay) cannot hit `projection==nil` because `BuildSessionProjections` filters TopFrame; `probe_orchestrator.go:357` is isolated by `setProjectionTopStatus` control flow.

## Architecture decision: Option B over Option A

Spec §3 documents the choice. Both fixes are 1 line, but A scatters the invariant across callers, makes the sweep callsite misleading (says "clear" but may produce non-clear output), and leaves the latent asymmetry in `frame_ops.go`. B encodes the invariant where it belongs and self-documents through symmetric branches. Codex spec review (`task-moizea6l-z32mvg`) explicitly agreed: "Option B 邏輯上更乾淨，我不會換成 A".

## Closes

closes #717

## Spec / Plan

- Spec: `docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-spec.md`
- Plan: `docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-plan.md`

Both reviewed by codex (spec: `task-moizea6l-z32mvg`, plan: `task-moizmm1e-zakq8b`). 0 P0/P1 across both rounds; all P2/P3 findings folded into spec/plan revisions before implementation.

## Files

| File | Lines | Purpose |
|------|------:|---------|
| `internal/module/agent/frame_ops.go` | +3 | The fix |
| `internal/module/agent/frame_ops_test.go` | +58 | 4 sub-test invariant table for `buildProjectionNormalized` |
| `internal/module/agent/sweep_test.go` | +156 | Two sweep pipeline integration tests + `decodeSweepBroadcast` helper |
| `docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-spec.md` | +308 | Spec |
| `docs/specs/2026-04-29-sweep-pid-dead-broadcast-clear-plan.md` | +378 | Plan |

No SPA, electron, or other files touched.

## Test plan

### Automated

- [x] `go test ./internal/module/agent/...` — 6 new sub-tests (4 invariant + 2 integration) green
- [x] `go test ./...` — full daemon test suite green (no regression in adjacent packages)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `cd spa && pnpm run lint` — clean
- [x] `cd spa && npx vitest run` — 3099 / 3103 pass; **4 pre-existing failures** in `src/components/TabBar.test.tsx` (1) + `src/lib/sync/contributors/hosts.test.ts` (3). Verified failing on `origin/main` (alpha.250) without this PR's changes — unrelated to the fix.

### Manual mlab verification (per spec §8 — to run by user)

```bash
# Build daemon with fix
cd <worktree>
go build -o /tmp/pdx-fix ./cmd/pdx

# Restart daemon
pkill -f "pdx serve" || true
PDX_DEV_MODE=1 nohup /tmp/pdx-fix serve > /tmp/pdx.log 2>&1 &

# Reproduce
tmux new -s opencode-fix-test
opencode
# > /chat hello
# Wait for response, Ctrl+C twice to exit

# Verify SPA agent indicator clears within ~2s sweep cadence
# (this was the bug — indicator stuck at last value)
```

## Notes for reviewer

- **Diff intentionally surgical**: 3 production lines, no comments, no helpers, no refactor. Spec §6 / plan §5 list explicit out-of-scope items to defend against scope creep.
- **handler.go:266/328 behavior change**: spec §4 callsite audit + §10 risks document this; new behavior matches the same correctness intent as the `sweep:pid_dead` fix.
- **Bump version**: `alpha.250` is taken (PR #721, Stage 1b signing). Bump PR will target **alpha.251**, opened separately after this merges per project workflow.