### PR TITLE
fix(spa): wide-mode workspace drag — reorderable, smooth, axis-locked

### DIFF
--- a/spa/src/features/workspace/components/ActivityBarWide.tsx
+++ b/spa/src/features/workspace/components/ActivityBarWide.tsx
@@ -11,6 +11,7 @@ import {
   type CollisionDetection,
   type DragEndEvent,
   type DragOverEvent,
+  type Modifier,
 } from '@dnd-kit/core'
 import {
   SortableContext,
@@ -33,12 +34,38 @@ import { computeDragEndAction, dispatchDragEndAction, type DragData } from '../l
 import { useSpringLoad } from '../lib/useSpringLoad'
 import { useCrossWorkspaceDragOver } from '../lib/useCrossWorkspaceDragOver'
 
+// Each WorkspaceRow registers two overlapping droppables: the useSortable
+// wrapper (id = workspace.id) for workspace reordering, and a useDroppable
+// header (id = `ws-header-${id}`) for tab cross-ws drops. When dragging a
+// workspace, both contain the pointer; pointerWithin returns both and `over`
+// flickers between them — verticalListSortingStrategy displaces siblings only
+// when over.id is in its items list, so siblings bounce in/out as the over
+// alternates. Filter the droppable set by the active drag's type so each
+// drag mode only sees its meaningful targets.
 const customCollisionDetection: CollisionDetection = (args) => {
-  const pw = pointerWithin(args)
+  const activeData = args.active.data.current as DragData | undefined
+  const containers =
+    activeData?.type === 'workspace'
+      ? args.droppableContainers.filter((c) => {
+          const d = c.data.current as DragData | undefined
+          return d?.type === 'workspace'
+        })
+      : activeData?.type === 'tab'
+        ? args.droppableContainers.filter((c) => {
+            const d = c.data.current as DragData | undefined
+            // Workspace sortables produce no meaningful action for tab drops
+            // (computeDragEndAction returns NOOP); excluding them prevents
+            // the same over-flicker between the workspace sortable and its
+            // own header droppable when a tab hovers over a row.
+            return d?.type !== 'workspace'
+          })
+        : args.droppableContainers
+  const filtered = { ...args, droppableContainers: containers }
+  const pw = pointerWithin(filtered)
   if (pw.length > 0) return pw
-  const ri = rectIntersection(args)
+  const ri = rectIntersection(filtered)
   if (ri.length > 0) return ri
-  return closestCenter(args)
+  return closestCenter(filtered)
 }
 
 const NOOP = () => {}
@@ -86,6 +113,30 @@ export function ActivityBarWide(props: ActivityBarProps) {
   )
   const wsIds = useMemo(() => workspaces.map((ws) => ws.id), [workspaces])
   const isHomeActive = !activeWorkspaceId
+
+  // Lock workspace drag to the Y axis and clamp inside the scroll zone so the
+  // dragged row cannot escape the list. Tab drag must remain unrestricted to
+  // preserve cross-workspace movement, so the modifier short-circuits unless
+  // the active drag is a workspace. Mirrors ActivityBarNarrow's restriction.
+  const wsScrollRef = useRef<HTMLDivElement>(null)
+  const restrictWorkspaceDrag = useCallback<Modifier>(
+    ({ transform, activeNodeRect, active }) => {
+      const activeData = active?.data?.current as DragData | undefined
+      if (activeData?.type !== 'workspace') return transform
+      if (!activeNodeRect || !wsScrollRef.current) {
+        return { ...transform, x: 0 }
+      }
+      const zoneRect = wsScrollRef.current.getBoundingClientRect()
+      const minY = zoneRect.top - activeNodeRect.top
+      const maxY = zoneRect.bottom - activeNodeRect.bottom
+      return {
+        ...transform,
+        x: 0,
+        y: Math.min(Math.max(transform.y, minY), maxY),
+      }
+    },
+    [],
+  )
 
   const selectTab = onSelectTab ?? NOOP
   const closeTab = onCloseTab ?? NOOP
@@ -265,6 +316,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
         <DndContext
           sensors={sensors}
           collisionDetection={customCollisionDetection}
+          modifiers={[restrictWorkspaceDrag]}
           onDragStart={handleDragStart}
           onDragOver={handleDragOver}
           onDragEnd={handleDragEnd}
@@ -287,6 +339,7 @@ export function ActivityBarWide(props: ActivityBarProps) {
           )}
 
           <div
+            ref={wsScrollRef}
             data-testid="activity-bar-workspace-scroll"
             className="activity-bar-workspace-scroll min-h-0 flex-1 overflow-y-auto overscroll-contain py-0.5"
           >

--- a/spa/src/features/workspace/components/WorkspaceRow.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.test.tsx
@@ -142,23 +142,40 @@ describe('WorkspaceRow', () => {
     })
   })
 
-  describe('drag-steals-click guard', () => {
-    it('name button stops pointer-down propagation so dnd-kit drag does not start on click', () => {
+  // Header drag activation must reach the dnd-kit listeners attached to the
+  // header wrapper, otherwise wide-mode workspaces become un-reorderable
+  // (the name button covers `flex-1` of the row, dwarfing chevron / Plus).
+  // PointerSensor's `activationConstraint: { distance: 5 }` already separates
+  // click-without-movement from drag-with-movement, so inner buttons must NOT
+  // call stopPropagation on pointerdown — doing so was the regression in
+  // 259c2a4f / Phase 3a.
+  describe('header pointer-down propagation (drag reachability)', () => {
+    it('name button does not block pointer-down', () => {
       renderRow(mkWs('ws-1', 'Alpha'))
       const nameBtn = screen.getByText('Alpha').closest('button')!
       const evt = new Event('pointerdown', { bubbles: true, cancelable: true })
       const stopPropagationSpy = vi.spyOn(evt, 'stopPropagation')
       nameBtn.dispatchEvent(evt)
-      expect(stopPropagationSpy).toHaveBeenCalled()
+      expect(stopPropagationSpy).not.toHaveBeenCalled()
     })
 
-    it('chevron does not block pointer-down (keeps row drag reachable)', () => {
+    it('chevron does not block pointer-down', () => {
       useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide' })
       renderRow(mkWs('ws-1', 'Alpha'))
       const chevron = screen.getByRole('button', { name: /expand|collapse/i })
       const evt = new Event('pointerdown', { bubbles: true, cancelable: true })
       const stopPropagationSpy = vi.spyOn(evt, 'stopPropagation')
       chevron.dispatchEvent(evt)
+      expect(stopPropagationSpy).not.toHaveBeenCalled()
+    })
+
+    it('Plus button does not block pointer-down', () => {
+      useLayoutStore.setState({ tabPosition: 'left', activityBarWidth: 'wide' })
+      renderRow(mkWs('ws-1', 'Alpha'))
+      const plusBtn = screen.getByLabelText(/new tab in alpha/i)
+      const evt = new Event('pointerdown', { bubbles: true, cancelable: true })
+      const stopPropagationSpy = vi.spyOn(evt, 'stopPropagation')
+      plusBtn.dispatchEvent(evt)
       expect(stopPropagationSpy).not.toHaveBeenCalled()
     })
   })

--- a/spa/src/features/workspace/components/WorkspaceRow.tsx
+++ b/spa/src/features/workspace/components/WorkspaceRow.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { CaretRight, CaretDown, Plus } from '@phosphor-icons/react'
 import { useDroppable } from '@dnd-kit/core'
 import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
 import type { Workspace, Tab } from '../../../types/tab'
 import { useLayoutStore } from '../../../stores/useLayoutStore'
 import { useI18nStore } from '../../../stores/useI18nStore'
@@ -144,8 +143,14 @@ export function WorkspaceRow(props: Props) {
     data: { type: 'workspace-header', wsId: workspace.id },
   })
 
+  // Use a Y-only integer translate to avoid sub-pixel transform interpolation
+  // blurring the row's text during drag (CSS.Transform.toString emits a 3-axis
+  // translate + scaleX/Y which can land on non-integer pixels). Mirrors the
+  // narrow-mode InlineTab / SortableWorkspaceButton pattern.
   const style: React.CSSProperties = {
-    transform: CSS.Transform.toString(transform),
+    transform: transform
+      ? `translate3d(0, ${Math.round(transform.y)}px, 0)`
+      : undefined,
     transition,
     opacity: isDragging ? 0.5 : 1,
   }
@@ -177,7 +182,6 @@ export function WorkspaceRow(props: Props) {
               onSelectWorkspace(workspace.id)
             }
           }}
-          onPointerDown={(e) => e.stopPropagation()}
           onContextMenu={(e) => {
             e.preventDefault()
             onContextMenuWorkspace?.(e, workspace.id)
@@ -190,9 +194,7 @@ export function WorkspaceRow(props: Props) {
             size={16}
             weight={workspace.iconWeight}
           />
-          <span className="truncate" title={workspace.name}>
-            {workspace.name}
-          </span>
+          <span className="truncate">{workspace.name}</span>
         </button>
         {showTabs && (
           <div
@@ -239,7 +241,6 @@ export function WorkspaceRow(props: Props) {
                 e.stopPropagation()
                 onAddTabToWorkspace(workspace.id)
               }}
-              onPointerDown={(e) => e.stopPropagation()}
               className="p-0.5 rounded hover:bg-surface-secondary hover:text-text-primary cursor-pointer opacity-0 group-hover/ws-header:opacity-100 focus:opacity-100 transition-opacity focus:outline-none"
             >
               <Plus size={12} />


### PR DESCRIPTION
## Summary

Wide ActivityBar 拖曳 workspace 排序整體修復 — 一次處理 4 個相關問題：

1. **拖不動**：`WorkspaceRow` 的 name button (`flex-1`) 與 Plus button 在 `onPointerDown` 呼叫 `stopPropagation()`，dnd-kit `PointerSensor` 收不到事件 → drag 永不啟動。259c2a4f / Phase 3a 加的「drag hijack」guard 是誤判（`activationConstraint: { distance: 5 }` 已經分離 click/drag）。
2. **拖曳彈跳閃動**：每個 row 同時註冊 `useSortable` wrapper（id = `workspace.id`）與 header `useDroppable`（id = `ws-header-${id}`），`pointerWithin` 回傳兩個，`over` 在兩 id 間切換，`verticalListSortingStrategy` 因 over.id 不在 items 而反覆進出位移。`customCollisionDetection` 依 active 拖曳型別過濾 droppable container 解決。
3. **可拖出邊界 / 可橫向位移**：補 `restrictWorkspaceDrag` modifier（仿 narrow 模式）— Y-only + scroll zone bbox clamp；modifier 在 active 是 tab 時短路，避免影響 cross-ws tab 移動。
4. **拖曳時文字變形**：`CSS.Transform.toString(transform)` 會輸出 scaleX/Y + 可能非整數 y，sub-pixel 渲染讓文字模糊變形。改成 `translate3d(0, Math.round(y), 0)` 同 narrow `InlineTab` / `SortableWorkspaceButton` 模式。順手拿掉 name span 的 `title` attr — 拖曳時會觸發 native tooltip。

`WorkspaceRow.test.tsx` 的 `drag-steals-click guard` describe（其前提就是這個 bug）反向改寫成 `header pointer-down propagation (drag reachability)`，新增 Plus button case。

## Test plan

- [x] `npx vitest run src/features/workspace` — 32 files / 383 tests pass
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` — OK
- [x] 全 SPA `npx vitest run` — 4 個既存失敗（TabBar pinned + hosts contributor 3 個）皆與本 PR 無關，已比對 origin/main 一致
- [x] 實機驗證（Mini SPA / 100.64.0.2:5174）：
  - Wide workspace 名稱可拖曳排序
  - 拖曳鎖 Y 軸、不超出第一/最後一筆
  - 兄弟 row 平順讓位、不再彈跳
  - 文字不再變形
  - 拖曳時不再出現 native tooltip
  - 回歸：Wide tab 拖曳（含 cross-ws drop 進其他 ws header）OK / Narrow workspace 拖曳 OK / 點 workspace 名稱（不移動）正常切換或 toggle expand