### PR TITLE
refactor(agent): W2 cleanup-followup — simplify cc/codex cleanup sets

### DIFF
--- a/internal/agent/cc/hooks.go
+++ b/internal/agent/cc/hooks.go
@@ -400,30 +400,12 @@ func ccKnownEventNames() map[string]bool {
 	return known
 }
 
-// ccLegacyEventNames pins the pre-W2 command-tail tokens cc installers
-// emitted (e.g. `pdx hook --agent cc SessionStart`). Sourced as a static
-// fixture rather than a runtime spec.Name traversal so that P3-T4 can
-// remove HookEventSpec.Name without breaking the cleanup helper. The set
-// is kept until PR-W2-cleanup-followup (plan G1 / §5.3 CLEANUP-T1) so
-// reinstalls following alpha.254 still recognise pre-W2 tokens.
-var ccLegacyEventNames = []string{
-	"SessionStart",
-	"UserPromptSubmit",
-	"SubagentStart",
-	"SubagentStop",
-	"Stop",
-	"StopFailure",
-	"Notification",
-	"PermissionRequest",
-	"SessionEnd",
-}
-
-// ccOwnedCleanupEventNames is the three-set union per spec §6.1 invariant 6:
-// installable specs' UpstreamKeys ∪ PurdexName ∪ legacy Name. cc has
-// one-to-one upstream/Pdx mapping so the union collapses to legacy Name ∪
-// PurdexName at runtime. P3-T4a sources the legacy Name set from
-// ccLegacyEventNames (static fixture) so removing the deprecated
-// HookEventSpec.Name field in P3-T4 doesn't break the cleanup helper.
+// ccOwnedCleanupEventNames is the two-set union per spec §6.1 invariant 6
+// post-cleanup: installable specs' UpstreamKeys ∪ PurdexName. cc has
+// one-to-one upstream/Pdx mapping so pre-W2 command-tail tokens (e.g.
+// `Stop`) are still recognised via the UpstreamKey leg; the redundant
+// legacy Name set retired in PR-W2-cleanup-followup (plan §5.3 CLEANUP-T1)
+// once W2 alpha.255 shipped and user reinstall completed.
 func ccOwnedCleanupEventNames() map[string]bool {
 	owned := make(map[string]bool)
 	for _, spec := range ccEventSpecs {
@@ -434,9 +416,6 @@ func ccOwnedCleanupEventNames() map[string]bool {
 			owned[key] = true
 		}
 		owned[spec.PurdexName] = true
-	}
-	for _, legacy := range ccLegacyEventNames {
-		owned[legacy] = true
 	}
 	return owned
 }

--- a/internal/agent/cc/hooks_test.go
+++ b/internal/agent/cc/hooks_test.go
@@ -960,51 +960,14 @@ func TestCcKnownEventNames_DerivedFromUpstreamKeys(t *testing.T) {
 	}
 }
 
-// ---- P1-T10: ccOwnedCleanupEventNames is the three-set union ----
+// ---- CLEANUP-T1: ccOwnedCleanupEventNames is the two-set union ----
 
-// TestCcOwnedCleanupEventNames_FixtureDerivedLegacySet pins the static
-// fixture introduced in P3-T4a to the runtime cc installable upstream-key
-// set. After P3-T4 removed spec.Name, the legacy upstream-key strings live
-// only in ccLegacyEventNames; the catalog still exposes them via
-// UpstreamKeys[0] (cc has 1:1 PurdexName ↔ UpstreamKey mapping). This test
-// guards against drift — adding/removing an installable in the catalog must
-// be reflected in ccLegacyEventNames manually (PR-W2-cleanup-followup will
-// retire the legacy set entirely).
-func TestCcOwnedCleanupEventNames_FixtureDerivedLegacySet(t *testing.T) {
-	fixture := make(map[string]bool, len(ccLegacyEventNames))
-	for _, n := range ccLegacyEventNames {
-		fixture[n] = true
-	}
-	runtime := make(map[string]bool)
-	for _, spec := range ccEventSpecs {
-		if !agent.IsInstallableHookSpec(spec) {
-			continue
-		}
-		// cc installable specs have a single-element UpstreamKeys slice; that
-		// element is the legacy upstream event name (e.g. "Stop") that
-		// ccLegacyEventNames also lists.
-		runtime[spec.UpstreamKeys[0]] = true
-	}
-	if len(fixture) != len(runtime) {
-		t.Errorf("ccLegacyEventNames size = %d, runtime installable upstream-key set size = %d", len(fixture), len(runtime))
-	}
-	for n := range runtime {
-		if !fixture[n] {
-			t.Errorf("ccLegacyEventNames missing runtime installable UpstreamKey %q", n)
-		}
-	}
-	for n := range fixture {
-		if !runtime[n] {
-			t.Errorf("ccLegacyEventNames has %q but no runtime installable UpstreamKey matches (drift — update fixture or catalog)", n)
-		}
-	}
-}
-
-// TestCcOwnedCleanupEventNames_ThreeSetUnion asserts cleanup set == union of
-// installable specs' UpstreamKeys ∪ PurdexName ∪ legacy Name. Per spec §6.1
-// invariant 6. cc has one-to-one mapping so UpstreamKeys[0] == Name and the
-// union collapses to legacy Name ∪ PurdexName.
-func TestCcOwnedCleanupEventNames_ThreeSetUnion(t *testing.T) {
+// TestCcOwnedCleanupEventNames_TwoSetUnion asserts cleanup set == union of
+// installable specs' UpstreamKeys ∪ PurdexName. Per spec §6.1 invariant 6
+// post-cleanup: legacy Name set retired (W2 alpha.255 + reinstall assumed).
+// cc has one-to-one upstream/Pdx mapping so the two-set union has 2× the
+// installable count keys (legacy upstream key + Pdx-prefixed).
+func TestCcOwnedCleanupEventNames_TwoSetUnion(t *testing.T) {
 	got := ccOwnedCleanupEventNames()
 	want := map[string]bool{}
 	for _, spec := range ccEventSpecs {
@@ -1014,7 +977,6 @@ func TestCcOwnedCleanupEventNames_ThreeSetUnion(t *testing.T) {
 		for _, key := range spec.UpstreamKeys {
 			want[key] = true
 		}
-		want[spec.PurdexName] = true
 		want[spec.PurdexName] = true
 	}
 	if len(got) != len(want) {

--- a/internal/agent/codex/hooks.go
+++ b/internal/agent/codex/hooks.go
@@ -708,31 +708,12 @@ func codexKnownEventNames() map[string]bool {
 	return known
 }
 
-// codexLegacyEventNames pins the pre-W2 command-tail tokens codex
-// installers emitted (e.g. `pdx hook --agent codex SessionStart`). Sourced
-// as a static fixture rather than a runtime spec.Name traversal so that
-// P3-T4 can remove HookEventSpec.Name without breaking the cleanup helper.
-// The set is kept until PR-W2-cleanup-followup (plan G1 / §5.3
-// CLEANUP-T1) so reinstalls following alpha.254 still recognise pre-W2
-// tokens.
-var codexLegacyEventNames = []string{
-	"SessionStart",
-	"UserPromptSubmit",
-	"SubagentStart",
-	"SubagentStop",
-	"Stop",
-	"StopFailure",
-	"Notification",
-	"PermissionRequest",
-	"SessionEnd",
-}
-
-// codexOwnedCleanupEventNames is the three-set union per spec §6.1
-// invariant 6: installable specs' UpstreamKeys ∪ PurdexName ∪ legacy Name.
-// codex has one-to-one upstream/Pdx mapping so the union collapses to legacy
-// Name ∪ PurdexName at runtime. P3-T4a sources the legacy Name set from
-// codexLegacyEventNames (static fixture) so removing the deprecated
-// HookEventSpec.Name field in P3-T4 doesn't break the cleanup helper.
+// codexOwnedCleanupEventNames is the two-set union per spec §6.1 invariant
+// 6 post-cleanup: installable specs' UpstreamKeys ∪ PurdexName. codex has
+// one-to-one upstream/Pdx mapping so pre-W2 command-tail tokens (e.g.
+// `Stop`) are still recognised via the UpstreamKey leg; the redundant
+// legacy Name set retired in PR-W2-cleanup-followup (plan §5.3 CLEANUP-T1)
+// once W2 alpha.255 shipped and user reinstall completed.
 func codexOwnedCleanupEventNames() map[string]bool {
 	owned := make(map[string]bool)
 	for _, spec := range codexEventSpecs {
@@ -743,9 +724,6 @@ func codexOwnedCleanupEventNames() map[string]bool {
 			owned[key] = true
 		}
 		owned[spec.PurdexName] = true
-	}
-	for _, legacy := range codexLegacyEventNames {
-		owned[legacy] = true
 	}
 	return owned
 }

--- a/internal/agent/codex/hooks_test.go
+++ b/internal/agent/codex/hooks_test.go
@@ -1796,49 +1796,13 @@ func TestCodexKnownEventNames_DerivedFromUpstreamKeys(t *testing.T) {
 	}
 }
 
-// TestCodexOwnedCleanupEventNames_FixtureDerivedLegacySet pins the static
-// fixture introduced in P3-T4a to the runtime codex installable upstream-key
-// set. After P3-T4 removed spec.Name the legacy upstream-key strings live
-// only in codexLegacyEventNames; the catalog still exposes them via
-// UpstreamKeys[0] (codex has 1:1 PurdexName ↔ UpstreamKey mapping). Drift
-// detected here means the fixture is out of sync with the catalog (until
-// PR-W2-cleanup-followup removes the legacy set entirely).
-func TestCodexOwnedCleanupEventNames_FixtureDerivedLegacySet(t *testing.T) {
-	fixture := make(map[string]bool, len(codexLegacyEventNames))
-	for _, n := range codexLegacyEventNames {
-		fixture[n] = true
-	}
-	runtime := make(map[string]bool)
-	for _, spec := range codexEventSpecs {
-		if !agent.IsInstallableHookSpec(spec) {
-			continue
-		}
-		// codex installable specs have a single-element UpstreamKeys slice
-		// equal to the legacy upstream event name (e.g. "Stop") that
-		// codexLegacyEventNames also lists.
-		runtime[spec.UpstreamKeys[0]] = true
-	}
-	if len(fixture) != len(runtime) {
-		t.Errorf("codexLegacyEventNames size = %d, runtime installable upstream-key set size = %d", len(fixture), len(runtime))
-	}
-	for n := range runtime {
-		if !fixture[n] {
-			t.Errorf("codexLegacyEventNames missing runtime installable Name %q", n)
-		}
-	}
-	for n := range fixture {
-		if !runtime[n] {
-			t.Errorf("codexLegacyEventNames has %q but no runtime installable Name matches (drift — update fixture or catalog)", n)
-		}
-	}
-}
-
-// TestCodexOwnedCleanupEventNames_ThreeSetUnion asserts the cleanup set is
-// the three-set union per spec §6.1 invariant 6: installable specs'
-// UpstreamKeys ∪ PurdexName ∪ legacy Name. codex has one-to-one mapping so
-// the union collapses to legacy Name ∪ PurdexName at runtime; the legacy
-// Name set is preserved per plan G1 until PR-W2-cleanup-followup.
-func TestCodexOwnedCleanupEventNames_ThreeSetUnion(t *testing.T) {
+// TestCodexOwnedCleanupEventNames_TwoSetUnion asserts the cleanup set is
+// the two-set union per spec §6.1 invariant 6 post-cleanup: installable
+// specs' UpstreamKeys ∪ PurdexName. codex has one-to-one upstream/Pdx
+// mapping so the union has 2× the installable count keys. Legacy Name set
+// retired in CLEANUP-T1 (W2 alpha.255 + reinstall assumed; cc/codex
+// 1:1 mapping makes the legacy Name set redundant with UpstreamKeys).
+func TestCodexOwnedCleanupEventNames_TwoSetUnion(t *testing.T) {
 	got := codexOwnedCleanupEventNames()
 	want := map[string]bool{}
 	for _, spec := range codexEventSpecs {
@@ -1848,7 +1812,6 @@ func TestCodexOwnedCleanupEventNames_ThreeSetUnion(t *testing.T) {
 		for _, key := range spec.UpstreamKeys {
 			want[key] = true
 		}
-		want[spec.PurdexName] = true
 		want[spec.PurdexName] = true
 	}
 	if len(got) != len(want) {


### PR DESCRIPTION
## Summary

Per W2 plan §5.3 CLEANUP-T1: drop `ccLegacyEventNames` / `codexLegacyEventNames` static fixtures introduced in P3-T4a (kept as a P3-T4 safety net while `spec.Name` was being removed). cc and codex catalogs have a 1:1 upstream/Pdx mapping where each installable spec's `UpstreamKeys[0]` equals the pre-W2 command-tail token, so the three-set union (`UpstreamKeys ∪ PurdexName ∪ legacy Name`) collapses to a two-set union once legacy Name is dropped — pre-W2 tokens are still cleaned via the UpstreamKey leg.

**Behavioural delta: zero.** The fixture's only purpose was a transition-window safety net.

## Spec note (deviation from plan §5.3)

Plan §5.3 anticipated a `TestCcOwnedCleanupEventNames_OldFixtureNotCleaned` test asserting that "舊命令會殘留（已不在 cleanup set）" after CLEANUP-T1. That assertion isn't implementable for cc/codex's actual catalog: every legacy Name string is identical to its `UpstreamKeys[0]`, so the cleanup set still contains it via the UpstreamKey leg. The plan's wording was speculative about a scenario that doesn't exist in the live catalog. Test intent is preserved by keeping `TestCcOwnedCleanupEventNames_CleansLegacyAndNew` (which round-trips a mixed legacy+Pdx fixture and asserts only the canonical Pdx entry remains).

## Changes

| File | Change |
|------|--------|
| `internal/agent/cc/hooks.go` | Drop `ccLegacyEventNames` const; cleanup helper → two-set union |
| `internal/agent/cc/hooks_test.go` | Drop `TestCcOwnedCleanupEventNames_FixtureDerivedLegacySet`; rename `ThreeSetUnion` → `TwoSetUnion` (the prior test only asserted two-set behaviour anyway — its `want` never added the legacy Name set) |
| `internal/agent/codex/hooks.go` | Same as cc |
| `internal/agent/codex/hooks_test.go` | Same as cc |

Net diff: −145 / +27 lines.

## Verify

- `go test ./internal/agent/... ./internal/module/agent/...` — all green
- No remaining references to `*LegacyEventNames` outside of git history
- `go vet` clean

## Risk

Negligible — cc/codex 1:1 mapping makes legacy Name set redundant with UpstreamKeys; both unit tests and the hook round-trip test prove zero behavioural change. Plan G1 deferred this CLEANUP until W2 alpha.255 shipped + user reinstall (both done at alpha.255 ship 2026-04-29).

## Test plan

- [x] `go test ./internal/agent/...` — green
- [x] `go test ./internal/module/agent/...` — green (handler + frame_ops still happy)
- [x] `go vet ./internal/agent/...` — clean
- [x] grep confirms no leftover refs to `ccLegacyEventNames` / `codexLegacyEventNames`
- [ ] Codex round 1 review (standard) — small PR, one round per plan §5.3 CLEANUP-T2

## Codex round 1 review (standard)

> 未發現會破壞現有行為的問題。移除 legacy event name fixture 後，目前 cc/codex 的 installable UpstreamKeys 仍涵蓋原本 legacy command-tail tokens，相關 cleanup 與 managed detection 路徑仍可識別既有條目。

**0 finding**. Plan §5.3 specifies 1 standard round for this small DRY refactor (no architecture risk). Approved.
