### PR TITLE
feat(monitor): add daemon foundation

### DIFF
--- a/cmd/pdx/main.go
+++ b/cmd/pdx/main.go
@@ -21,9 +21,10 @@ import (
 	"github.com/wake/purdex/internal/module/dev"
 	fsmod "github.com/wake/purdex/internal/module/fs"
 	"github.com/wake/purdex/internal/module/logs"
-	syncmod "github.com/wake/purdex/internal/module/sync"
+	"github.com/wake/purdex/internal/module/monitor"
 	"github.com/wake/purdex/internal/module/session"
 	"github.com/wake/purdex/internal/module/stream"
+	syncmod "github.com/wake/purdex/internal/module/sync"
 	"github.com/wake/purdex/internal/relay"
 	"github.com/wake/purdex/internal/store"
 	"github.com/wake/purdex/internal/tmux"
@@ -150,16 +151,9 @@ func runServe(args []string) {
 	initPairing(c, &cfg, resolvedCfgPath, *quick)
 
 	// 5. Add modules (order doesn't matter — topoSort handles dependencies)
-	c.AddModule(session.NewSessionModule(meta))
-	c.AddModule(stream.New())
-	agentMod, err := agent.New(agentEvents)
-	if err != nil {
-		log.Fatalf("agent module: %v", err)
+	if err := registerServeModules(c, meta, agentEvents); err != nil {
+		log.Fatalf("serve modules: %v", err)
 	}
-	c.AddModule(agentMod)
-	c.AddModule(fsmod.New())
-	c.AddModule(logs.New())
-	c.AddModule(syncmod.New())
 	if c.Cfg.Dev.Update {
 		repoRoot := c.Cfg.Dev.RepoRoot
 		if repoRoot == "" {
@@ -237,6 +231,21 @@ func runServe(args []string) {
 	if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
 		log.Printf("server error: %v", err)
 	}
+}
+
+func registerServeModules(c *core.Core, meta *store.MetaStore, agentEvents *store.AgentEventStore) error {
+	c.AddModule(session.NewSessionModule(meta))
+	c.AddModule(stream.New())
+	agentMod, err := agent.New(agentEvents)
+	if err != nil {
+		return err
+	}
+	c.AddModule(agentMod)
+	c.AddModule(fsmod.New())
+	c.AddModule(logs.New())
+	c.AddModule(syncmod.New())
+	c.AddModule(monitor.New())
+	return nil
 }
 
 func runRelay(args []string) {

--- a/cmd/pdx/monitor_module_test.go
+++ b/cmd/pdx/monitor_module_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wake/purdex/internal/config"
+	"github.com/wake/purdex/internal/core"
+)
+
+func TestRegisterServeModules_IncludesMonitorRoutes(t *testing.T) {
+	c := core.New(core.CoreDeps{Config: &config.Config{DataDir: t.TempDir()}})
+
+	require.NoError(t, registerServeModules(c, nil, nil))
+	require.NoError(t, c.InitModules())
+
+	mux := http.NewServeMux()
+	c.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/monitor/snapshot", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,11 @@ type TerminalConfig struct {
 	SizingMode string `toml:"sizing_mode" json:"sizing_mode"`
 }
 
+type MonitorConfig struct {
+	RefreshIntervalMS int `toml:"refresh_interval_ms" json:"refresh_interval_ms"`
+	TopProcessLimit   int `toml:"top_process_limit"   json:"top_process_limit"`
+}
+
 // GetSizingMode returns the sizing mode, defaulting to "auto".
 func (tc TerminalConfig) GetSizingMode() string {
 	if tc.SizingMode == "" {
@@ -56,6 +61,7 @@ type Config struct {
 	Terminal     TerminalConfig `toml:"terminal"       json:"terminal"`
 	Stream       StreamConfig   `toml:"stream"         json:"stream"`
 	Detect       DetectConfig   `toml:"detect"         json:"detect"`
+	Monitor      MonitorConfig  `toml:"monitor"        json:"monitor"`
 	Features     FeaturesConfig `toml:"features"       json:"features"`
 	Dev          DevConfig      `toml:"dev"            json:"dev"`
 }
@@ -63,8 +69,8 @@ type Config struct {
 func defaults() Config {
 	home, _ := os.UserHomeDir()
 	return Config{
-		Bind:    "127.0.0.1",
-		Port:    7860,
+		Bind:      "127.0.0.1",
+		Port:      7860,
 		DataDir:   filepath.Join(home, ".config", "pdx"),
 		UploadDir: filepath.Join(home, "tmp", "purdex-upload"),
 		Stream: StreamConfig{
@@ -76,6 +82,10 @@ func defaults() Config {
 		Detect: DetectConfig{
 			CCCommands:   []string{"claude"},
 			PollInterval: 2,
+		},
+		Monitor: MonitorConfig{
+			RefreshIntervalMS: 5000,
+			TopProcessLimit:   10,
 		},
 	}
 }

--- a/internal/module/monitor/config.go
+++ b/internal/module/monitor/config.go
@@ -1,0 +1,88 @@
+package monitor
+
+import "github.com/wake/purdex/internal/config"
+
+const (
+	DefaultRefreshIntervalMS = 5000
+	MinRefreshIntervalMS     = 1000
+	MaxRefreshIntervalMS     = 60000
+
+	DefaultTopProcessLimit = 10
+	MinTopProcessLimit     = 1
+	MaxTopProcessLimit     = 50
+)
+
+type MonitorConfig = config.MonitorConfig
+
+type Bound struct {
+	Min int `json:"min"`
+	Max int `json:"max"`
+}
+
+type ConfigBounds struct {
+	RefreshIntervalMS Bound `json:"refresh_interval_ms"`
+	TopProcessLimit   Bound `json:"top_process_limit"`
+}
+
+type EffectiveConfig struct {
+	RefreshIntervalMS int          `json:"refresh_interval_ms"`
+	TopProcessLimit   int          `json:"top_process_limit"`
+	Bounds            ConfigBounds `json:"bounds"`
+}
+
+func DefaultMonitorConfig() MonitorConfig {
+	return MonitorConfig{
+		RefreshIntervalMS: DefaultRefreshIntervalMS,
+		TopProcessLimit:   DefaultTopProcessLimit,
+	}
+}
+
+func EffectiveMonitorConfig(cfg MonitorConfig) EffectiveConfig {
+	refreshInterval := cfg.RefreshIntervalMS
+	if refreshInterval == 0 {
+		refreshInterval = DefaultRefreshIntervalMS
+	}
+
+	topProcessLimit := cfg.TopProcessLimit
+	if topProcessLimit == 0 {
+		topProcessLimit = DefaultTopProcessLimit
+	}
+
+	return EffectiveConfig{
+		RefreshIntervalMS: clamp(refreshInterval, MinRefreshIntervalMS, MaxRefreshIntervalMS),
+		TopProcessLimit:   clamp(topProcessLimit, MinTopProcessLimit, MaxTopProcessLimit),
+		Bounds:            monitorConfigBounds(),
+	}
+}
+
+func ClampSubmittedMonitorConfig(cfg MonitorConfig) EffectiveConfig {
+	return EffectiveConfig{
+		RefreshIntervalMS: clamp(cfg.RefreshIntervalMS, MinRefreshIntervalMS, MaxRefreshIntervalMS),
+		TopProcessLimit:   clamp(cfg.TopProcessLimit, MinTopProcessLimit, MaxTopProcessLimit),
+		Bounds:            monitorConfigBounds(),
+	}
+}
+
+func monitorConfigBounds() ConfigBounds {
+	return ConfigBounds{
+		RefreshIntervalMS: Bound{Min: MinRefreshIntervalMS, Max: MaxRefreshIntervalMS},
+		TopProcessLimit:   Bound{Min: MinTopProcessLimit, Max: MaxTopProcessLimit},
+	}
+}
+
+func (cfg EffectiveConfig) persistedConfig() MonitorConfig {
+	return MonitorConfig{
+		RefreshIntervalMS: cfg.RefreshIntervalMS,
+		TopProcessLimit:   cfg.TopProcessLimit,
+	}
+}
+
+func clamp(value, min, max int) int {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}

--- a/internal/module/monitor/config_test.go
+++ b/internal/module/monitor/config_test.go
@@ -1,0 +1,42 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultMonitorConfig_ReturnsBoundsAndNoDaemonEnabledFlag(t *testing.T) {
+	got := EffectiveMonitorConfig(DefaultMonitorConfig())
+
+	assert.Equal(t, 5000, got.RefreshIntervalMS)
+	assert.Equal(t, 1000, got.Bounds.RefreshIntervalMS.Min)
+	assert.Equal(t, 60000, got.Bounds.RefreshIntervalMS.Max)
+	assert.Equal(t, 10, got.TopProcessLimit)
+	assert.Equal(t, 1, got.Bounds.TopProcessLimit.Min)
+	assert.Equal(t, 50, got.Bounds.TopProcessLimit.Max)
+
+	assert.NotContains(t, toJSONMap(t, got), "enabled", "daemon config must not own monitor enablement")
+}
+
+func TestMonitorConfig_ClampsUnsafeRefreshInterval(t *testing.T) {
+	tooLow := EffectiveMonitorConfig(MonitorConfig{RefreshIntervalMS: 10, TopProcessLimit: 10})
+	assert.Equal(t, 1000, tooLow.RefreshIntervalMS)
+
+	zero := ClampSubmittedMonitorConfig(MonitorConfig{RefreshIntervalMS: 0, TopProcessLimit: 10})
+	assert.Equal(t, 1000, zero.RefreshIntervalMS)
+
+	tooHigh := EffectiveMonitorConfig(MonitorConfig{RefreshIntervalMS: 120000, TopProcessLimit: 10})
+	assert.Equal(t, 60000, tooHigh.RefreshIntervalMS)
+}
+
+func TestMonitorConfig_ClampsUnsafeTopProcessLimit(t *testing.T) {
+	tooLow := EffectiveMonitorConfig(MonitorConfig{RefreshIntervalMS: 5000, TopProcessLimit: -1})
+	assert.Equal(t, 1, tooLow.TopProcessLimit)
+
+	zero := ClampSubmittedMonitorConfig(MonitorConfig{RefreshIntervalMS: 5000, TopProcessLimit: 0})
+	assert.Equal(t, 1, zero.TopProcessLimit)
+
+	tooHigh := EffectiveMonitorConfig(MonitorConfig{RefreshIntervalMS: 5000, TopProcessLimit: 100})
+	assert.Equal(t, 50, tooHigh.TopProcessLimit)
+}

--- a/internal/module/monitor/handler_test.go
+++ b/internal/module/monitor/handler_test.go
@@ -1,0 +1,117 @@
+package monitor
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wake/purdex/internal/config"
+	"github.com/wake/purdex/internal/core"
+)
+
+func TestGetMonitorConfig_ReturnsEffectiveConfigAndBounds(t *testing.T) {
+	m := New()
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{}})))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/monitor/config", nil)
+	m.handleConfig(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var got EffectiveConfig
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, 5000, got.RefreshIntervalMS)
+	assert.Equal(t, 1000, got.Bounds.RefreshIntervalMS.Min)
+	assert.Equal(t, 60000, got.Bounds.RefreshIntervalMS.Max)
+	assert.Equal(t, 10, got.TopProcessLimit)
+	assert.NotContains(t, toJSONMap(t, got), "enabled")
+}
+
+func TestPutMonitorConfig_PersistsSupportedValuesAndReturnsEffectiveConfig(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	cfg := &config.Config{}
+	m := New()
+	c := core.New(core.CoreDeps{Config: cfg})
+	c.CfgPath = cfgPath
+	require.NoError(t, m.Init(c))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/monitor/config", bytes.NewBufferString(`{"refresh_interval_ms":2000,"top_process_limit":25}`))
+	m.handleConfig(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got EffectiveConfig
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, 2000, got.RefreshIntervalMS)
+	assert.Equal(t, 25, got.TopProcessLimit)
+
+	reloaded, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, 2000, reloaded.Monitor.RefreshIntervalMS)
+	assert.Equal(t, 25, reloaded.Monitor.TopProcessLimit)
+}
+
+func TestPutMonitorConfig_ClampsUnsafeValuesBeforePersisting(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	cfg := &config.Config{}
+	m := New()
+	c := core.New(core.CoreDeps{Config: cfg})
+	c.CfgPath = cfgPath
+	require.NoError(t, m.Init(c))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/monitor/config", bytes.NewBufferString(`{"refresh_interval_ms":1,"top_process_limit":999}`))
+	m.handleConfig(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got EffectiveConfig
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, 1000, got.RefreshIntervalMS)
+	assert.Equal(t, 50, got.TopProcessLimit)
+
+	reloaded, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, 1000, reloaded.Monitor.RefreshIntervalMS)
+	assert.Equal(t, 50, reloaded.Monitor.TopProcessLimit)
+}
+
+func TestPutMonitorConfig_ClampsExplicitZeroValuesBeforePersisting(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	cfg := &config.Config{}
+	m := New()
+	c := core.New(core.CoreDeps{Config: cfg})
+	c.CfgPath = cfgPath
+	require.NoError(t, m.Init(c))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/monitor/config", bytes.NewBufferString(`{"refresh_interval_ms":0,"top_process_limit":0}`))
+	m.handleConfig(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got EffectiveConfig
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, 1000, got.RefreshIntervalMS)
+	assert.Equal(t, 1, got.TopProcessLimit)
+
+	reloaded, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, 1000, reloaded.Monitor.RefreshIntervalMS)
+	assert.Equal(t, 1, reloaded.Monitor.TopProcessLimit)
+}
+
+func toJSONMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(data, &got))
+	return got
+}

--- a/internal/module/monitor/host.go
+++ b/internal/module/monitor/host.go
@@ -1,0 +1,148 @@
+package monitor
+
+import "context"
+
+const (
+	hostCPUUnavailableReason    = "host_cpu_unavailable"
+	hostMemoryUnavailableReason = "host_memory_unavailable"
+	hostDiskUnavailableReason   = "host_disk_unavailable"
+	hostCPUPendingReason        = "pending"
+)
+
+type HostCollector interface {
+	CollectCPU(context.Context) (HostCPUSample, error)
+	CollectMemory(context.Context) (HostMemorySample, error)
+	CollectDisk(context.Context) (HostDiskSample, error)
+}
+
+type HostCPUSample struct {
+	Idle  uint64
+	Total uint64
+}
+
+type HostMemorySample struct {
+	TotalBytes uint64
+	UsedBytes  uint64
+}
+
+type HostDiskSample struct {
+	TotalBytes uint64
+	UsedBytes  uint64
+}
+
+type HostMetrics struct {
+	CPU    *HostCPUMetrics    `json:"cpu"`
+	Memory *HostMemoryMetrics `json:"memory"`
+	Disk   *HostDiskMetrics   `json:"disk"`
+}
+
+type HostCPUMetrics struct {
+	Percent           *float64 `json:"percent"`
+	UnavailableReason string   `json:"unavailable_reason,omitempty"`
+}
+
+type HostMemoryMetrics struct {
+	TotalBytes        *uint64  `json:"total_bytes"`
+	UsedBytes         *uint64  `json:"used_bytes"`
+	UsedPercent       *float64 `json:"used_percent"`
+	UnavailableReason string   `json:"unavailable_reason,omitempty"`
+}
+
+type HostDiskMetrics struct {
+	TotalBytes        *uint64  `json:"total_bytes"`
+	UsedBytes         *uint64  `json:"used_bytes"`
+	UsedPercent       *float64 `json:"used_percent"`
+	UnavailableReason string   `json:"unavailable_reason,omitempty"`
+}
+
+type HostMetricsState struct {
+	collector HostCollector
+	previous  *HostCPUSample
+}
+
+func NewHostMetricsState(collector HostCollector) *HostMetricsState {
+	return &HostMetricsState{collector: collector}
+}
+
+func collectHostMetrics(ctx context.Context, state *HostMetricsState) HostMetrics {
+	if state == nil || state.collector == nil {
+		return HostMetrics{
+			CPU:    &HostCPUMetrics{UnavailableReason: hostCPUUnavailableReason},
+			Memory: &HostMemoryMetrics{UnavailableReason: hostMemoryUnavailableReason},
+			Disk:   &HostDiskMetrics{UnavailableReason: hostDiskUnavailableReason},
+		}
+	}
+
+	return HostMetrics{
+		CPU:    collectHostCPU(ctx, state),
+		Memory: collectHostMemory(ctx, state.collector),
+		Disk:   collectHostDisk(ctx, state.collector),
+	}
+}
+
+func collectHostCPU(ctx context.Context, state *HostMetricsState) *HostCPUMetrics {
+	sample, err := state.collector.CollectCPU(ctx)
+	if err != nil {
+		return &HostCPUMetrics{UnavailableReason: hostCPUUnavailableReason}
+	}
+
+	if state.previous == nil {
+		state.previous = &sample
+		return &HostCPUMetrics{UnavailableReason: hostCPUPendingReason}
+	}
+
+	percent := hostCPUPercent(*state.previous, sample)
+	state.previous = &sample
+	if percent == nil {
+		return &HostCPUMetrics{UnavailableReason: hostCPUPendingReason}
+	}
+	return &HostCPUMetrics{Percent: percent}
+}
+
+func collectHostMemory(ctx context.Context, collector HostCollector) *HostMemoryMetrics {
+	sample, err := collector.CollectMemory(ctx)
+	if err != nil {
+		return &HostMemoryMetrics{UnavailableReason: hostMemoryUnavailableReason}
+	}
+	usedPercent := usedPercent(sample.UsedBytes, sample.TotalBytes)
+	return &HostMemoryMetrics{
+		TotalBytes:  &sample.TotalBytes,
+		UsedBytes:   &sample.UsedBytes,
+		UsedPercent: &usedPercent,
+	}
+}
+
+func collectHostDisk(ctx context.Context, collector HostCollector) *HostDiskMetrics {
+	sample, err := collector.CollectDisk(ctx)
+	if err != nil {
+		return &HostDiskMetrics{UnavailableReason: hostDiskUnavailableReason}
+	}
+	usedPercent := usedPercent(sample.UsedBytes, sample.TotalBytes)
+	return &HostDiskMetrics{
+		TotalBytes:  &sample.TotalBytes,
+		UsedBytes:   &sample.UsedBytes,
+		UsedPercent: &usedPercent,
+	}
+}
+
+func hostCPUPercent(previous, current HostCPUSample) *float64 {
+	if current.Total <= previous.Total || current.Idle < previous.Idle {
+		return nil
+	}
+
+	deltaTotal := current.Total - previous.Total
+	deltaIdle := current.Idle - previous.Idle
+	if deltaTotal == 0 || deltaIdle > deltaTotal {
+		return nil
+	}
+
+	percent := float64(deltaTotal-deltaIdle) / float64(deltaTotal) * 100
+	return &percent
+}
+
+func usedPercent(used, total uint64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(used) / float64(total) * 100
+}

--- a/internal/module/monitor/host_system.go
+++ b/internal/module/monitor/host_system.go
@@ -1,0 +1,201 @@
+package monitor
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+type systemHostCollector struct{}
+
+func NewSystemHostCollector() HostCollector {
+	return systemHostCollector{}
+}
+
+func (systemHostCollector) CollectCPU(ctx context.Context) (HostCPUSample, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return collectDarwinCPU(ctx)
+	case "linux":
+		return collectLinuxCPU()
+	default:
+		return HostCPUSample{}, fmt.Errorf("unsupported host cpu platform: %s", runtime.GOOS)
+	}
+}
+
+func (systemHostCollector) CollectMemory(ctx context.Context) (HostMemorySample, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return collectDarwinMemory(ctx)
+	case "linux":
+		return collectLinuxMemory()
+	default:
+		return HostMemorySample{}, fmt.Errorf("unsupported host memory platform: %s", runtime.GOOS)
+	}
+}
+
+func (systemHostCollector) CollectDisk(context.Context) (HostDiskSample, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs("/", &stat); err != nil {
+		return HostDiskSample{}, err
+	}
+	total := stat.Blocks * uint64(stat.Bsize)
+	free := stat.Bavail * uint64(stat.Bsize)
+	used := total - free
+	return HostDiskSample{TotalBytes: total, UsedBytes: used}, nil
+}
+
+func collectDarwinCPU(ctx context.Context) (HostCPUSample, error) {
+	out, err := exec.CommandContext(ctx, "sysctl", "-n", "kern.cp_time").Output()
+	if err != nil {
+		return HostCPUSample{}, fmt.Errorf("sysctl kern.cp_time: %w", err)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) < 4 {
+		return HostCPUSample{}, fmt.Errorf("sysctl kern.cp_time: expected at least 4 fields")
+	}
+	values := make([]uint64, 0, len(fields))
+	for _, field := range fields {
+		value, err := strconv.ParseUint(field, 10, 64)
+		if err != nil {
+			return HostCPUSample{}, fmt.Errorf("parse kern.cp_time: %w", err)
+		}
+		values = append(values, value)
+	}
+	var total uint64
+	for _, value := range values {
+		total += value
+	}
+	return HostCPUSample{Idle: values[3], Total: total}, nil
+}
+
+func collectDarwinMemory(ctx context.Context) (HostMemorySample, error) {
+	total, err := unix.SysctlUint64("hw.memsize")
+	if err != nil {
+		return HostMemorySample{}, fmt.Errorf("sysctl hw.memsize: %w", err)
+	}
+	out, err := exec.CommandContext(ctx, "vm_stat").Output()
+	if err != nil {
+		return HostMemorySample{}, fmt.Errorf("vm_stat: %w", err)
+	}
+	pageSize, freePages, inactivePages, err := parseDarwinVMStat(string(out))
+	if err != nil {
+		return HostMemorySample{}, err
+	}
+	available := (freePages + inactivePages) * pageSize
+	used := uint64(0)
+	if total > available {
+		used = total - available
+	}
+	return HostMemorySample{TotalBytes: total, UsedBytes: used}, nil
+}
+
+func parseDarwinVMStat(raw string) (pageSize, freePages, inactivePages uint64, err error) {
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "page size of") {
+			fields := strings.Fields(line)
+			for i, field := range fields {
+				if field == "of" && i+1 < len(fields) {
+					pageSize, _ = strconv.ParseUint(fields[i+1], 10, 64)
+				}
+			}
+			continue
+		}
+		value, ok := parseDarwinVMStatLine(line)
+		if !ok {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "Pages free:"):
+			freePages = value
+		case strings.HasPrefix(line, "Pages inactive:"):
+			inactivePages = value
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, 0, 0, err
+	}
+	if pageSize == 0 {
+		return 0, 0, 0, fmt.Errorf("vm_stat: missing page size")
+	}
+	return pageSize, freePages, inactivePages, nil
+}
+
+func parseDarwinVMStatLine(line string) (uint64, bool) {
+	parts := strings.Split(line, ":")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	raw := strings.TrimSpace(strings.TrimSuffix(parts[1], "."))
+	value, err := strconv.ParseUint(raw, 10, 64)
+	return value, err == nil
+}
+
+func collectLinuxCPU() (HostCPUSample, error) {
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return HostCPUSample{}, err
+	}
+	line := strings.SplitN(string(data), "\n", 2)[0]
+	fields := strings.Fields(line)
+	if len(fields) < 5 || fields[0] != "cpu" {
+		return HostCPUSample{}, fmt.Errorf("/proc/stat: malformed cpu line")
+	}
+	var total uint64
+	values := make([]uint64, 0, len(fields)-1)
+	for _, field := range fields[1:] {
+		value, err := strconv.ParseUint(field, 10, 64)
+		if err != nil {
+			return HostCPUSample{}, fmt.Errorf("parse /proc/stat: %w", err)
+		}
+		values = append(values, value)
+		total += value
+	}
+	idle := values[3]
+	if len(values) > 4 {
+		idle += values[4]
+	}
+	return HostCPUSample{Idle: idle, Total: total}, nil
+}
+
+func collectLinuxMemory() (HostMemorySample, error) {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return HostMemorySample{}, err
+	}
+	values := map[string]uint64{}
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		value, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		values[strings.TrimSuffix(fields[0], ":")] = value * 1024
+	}
+	if err := scanner.Err(); err != nil {
+		return HostMemorySample{}, err
+	}
+	total := values["MemTotal"]
+	available := values["MemAvailable"]
+	if total == 0 {
+		return HostMemorySample{}, fmt.Errorf("/proc/meminfo: missing MemTotal")
+	}
+	used := uint64(0)
+	if total > available {
+		used = total - available
+	}
+	return HostMemorySample{TotalBytes: total, UsedBytes: used}, nil
+}

--- a/internal/module/monitor/host_test.go
+++ b/internal/module/monitor/host_test.go
@@ -1,0 +1,184 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHost_FirstCPUSampleIsPendingWhileMemoryAndDiskArePresent(t *testing.T) {
+	collector := newFakeHostCollector()
+	collector.cpuSamples = []HostCPUSample{{Idle: 80, Total: 100}}
+	collector.memory = HostMemorySample{TotalBytes: 1000, UsedBytes: 250}
+	collector.disk = HostDiskSample{TotalBytes: 2000, UsedBytes: 500}
+	state := NewHostMetricsState(collector)
+
+	host := collectHostMetrics(context.Background(), state)
+
+	require.NotNil(t, host.CPU)
+	assert.Nil(t, host.CPU.Percent)
+	assert.Equal(t, "pending", host.CPU.UnavailableReason)
+	require.NotNil(t, host.Memory)
+	assert.Equal(t, uint64(1000), *host.Memory.TotalBytes)
+	assert.Equal(t, uint64(250), *host.Memory.UsedBytes)
+	assert.Equal(t, 25.0, *host.Memory.UsedPercent)
+	require.NotNil(t, host.Disk)
+	assert.Equal(t, uint64(2000), *host.Disk.TotalBytes)
+	assert.Equal(t, uint64(500), *host.Disk.UsedBytes)
+	assert.Equal(t, 25.0, *host.Disk.UsedPercent)
+}
+
+func TestHost_SecondCPUSampleComputesPercentFromDeltas(t *testing.T) {
+	collector := newFakeHostCollector()
+	collector.cpuSamples = []HostCPUSample{
+		{Idle: 80, Total: 100},
+		{Idle: 90, Total: 150},
+	}
+	state := NewHostMetricsState(collector)
+
+	first := collectHostMetrics(context.Background(), state)
+	second := collectHostMetrics(context.Background(), state)
+
+	require.Nil(t, first.CPU.Percent)
+	require.NotNil(t, second.CPU.Percent)
+	assert.Equal(t, 80.0, *second.CPU.Percent)
+	assert.Empty(t, second.CPU.UnavailableReason)
+}
+
+func TestHost_MemoryCollectorReturnsBytesAndPercent(t *testing.T) {
+	collector := newFakeHostCollector()
+	collector.memory = HostMemorySample{TotalBytes: 4096, UsedBytes: 1024}
+	state := NewHostMetricsState(collector)
+
+	host := collectHostMetrics(context.Background(), state)
+
+	require.NotNil(t, host.Memory)
+	assert.Equal(t, uint64(4096), *host.Memory.TotalBytes)
+	assert.Equal(t, uint64(1024), *host.Memory.UsedBytes)
+	assert.Equal(t, 25.0, *host.Memory.UsedPercent)
+}
+
+func TestHost_DiskCollectorReturnsSingleWholeHostSummary(t *testing.T) {
+	collector := newFakeHostCollector()
+	collector.disk = HostDiskSample{TotalBytes: 9000, UsedBytes: 3000}
+	state := NewHostMetricsState(collector)
+
+	host := collectHostMetrics(context.Background(), state)
+
+	require.NotNil(t, host.Disk)
+	assert.Equal(t, uint64(9000), *host.Disk.TotalBytes)
+	assert.Equal(t, uint64(3000), *host.Disk.UsedBytes)
+	assert.Equal(t, 33.33333333333333, *host.Disk.UsedPercent)
+}
+
+func TestHost_PartialCollectorFailureReturnsStableUnavailableReasons(t *testing.T) {
+	collector := newFakeHostCollector()
+	collector.cpuErr = errors.New("boom")
+	collector.memoryErr = errors.New("boom")
+	collector.diskErr = errors.New("boom")
+	state := NewHostMetricsState(collector)
+
+	host := collectHostMetrics(context.Background(), state)
+
+	require.NotNil(t, host.CPU)
+	assert.Nil(t, host.CPU.Percent)
+	assert.Equal(t, "host_cpu_unavailable", host.CPU.UnavailableReason)
+	require.NotNil(t, host.Memory)
+	assert.Equal(t, "host_memory_unavailable", host.Memory.UnavailableReason)
+	assert.Nil(t, host.Memory.TotalBytes)
+	assert.Nil(t, host.Memory.UsedBytes)
+	assert.Nil(t, host.Memory.UsedPercent)
+	require.NotNil(t, host.Disk)
+	assert.Equal(t, "host_disk_unavailable", host.Disk.UnavailableReason)
+	assert.Nil(t, host.Disk.TotalBytes)
+	assert.Nil(t, host.Disk.UsedBytes)
+	assert.Nil(t, host.Disk.UsedPercent)
+}
+
+func TestHost_PartialCollectorFailureSerializesUnavailableValuesAsNull(t *testing.T) {
+	collector := newFakeHostCollector()
+	collector.memoryErr = errors.New("boom")
+	collector.diskErr = errors.New("boom")
+	state := NewHostMetricsState(collector)
+
+	host := collectHostMetrics(context.Background(), state)
+	data, err := json.Marshal(host)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), `"memory":{"total_bytes":null,"used_bytes":null,"used_percent":null,"unavailable_reason":"host_memory_unavailable"}`)
+	assert.Contains(t, string(data), `"disk":{"total_bytes":null,"used_bytes":null,"used_percent":null,"unavailable_reason":"host_disk_unavailable"}`)
+}
+
+func TestHost_PartialCollectorFailureKeepsAvailableMetrics(t *testing.T) {
+	collector := newFakeHostCollector()
+	collector.cpuErr = errors.New("boom")
+	collector.memory = HostMemorySample{TotalBytes: 1000, UsedBytes: 400}
+	collector.diskErr = errors.New("boom")
+	state := NewHostMetricsState(collector)
+
+	host := collectHostMetrics(context.Background(), state)
+
+	require.NotNil(t, host.CPU)
+	assert.Equal(t, "host_cpu_unavailable", host.CPU.UnavailableReason)
+	require.NotNil(t, host.Memory)
+	assert.Equal(t, uint64(1000), *host.Memory.TotalBytes)
+	assert.Equal(t, uint64(400), *host.Memory.UsedBytes)
+	assert.Equal(t, 40.0, *host.Memory.UsedPercent)
+	assert.Empty(t, host.Memory.UnavailableReason)
+	require.NotNil(t, host.Disk)
+	assert.Equal(t, "host_disk_unavailable", host.Disk.UnavailableReason)
+}
+
+type fakeHostCollector struct {
+	cpuSamples []HostCPUSample
+	cpuCalls   int
+	cpuErr     error
+
+	memory      HostMemorySample
+	memoryCalls int
+	memoryErr   error
+
+	disk      HostDiskSample
+	diskCalls int
+	diskErr   error
+}
+
+func newFakeHostCollector() *fakeHostCollector {
+	return &fakeHostCollector{
+		memory: HostMemorySample{TotalBytes: 1, UsedBytes: 0},
+		disk:   HostDiskSample{TotalBytes: 1, UsedBytes: 0},
+	}
+}
+
+func (c *fakeHostCollector) CollectCPU(context.Context) (HostCPUSample, error) {
+	c.cpuCalls++
+	if c.cpuErr != nil {
+		return HostCPUSample{}, c.cpuErr
+	}
+	idx := c.cpuCalls - 1
+	if idx >= len(c.cpuSamples) {
+		return HostCPUSample{}, nil
+	}
+	sample := c.cpuSamples[idx]
+	return sample, nil
+}
+
+func (c *fakeHostCollector) CollectMemory(context.Context) (HostMemorySample, error) {
+	c.memoryCalls++
+	if c.memoryErr != nil {
+		return HostMemorySample{}, c.memoryErr
+	}
+	return c.memory, nil
+}
+
+func (c *fakeHostCollector) CollectDisk(context.Context) (HostDiskSample, error) {
+	c.diskCalls++
+	if c.diskErr != nil {
+		return HostDiskSample{}, c.diskErr
+	}
+	return c.disk, nil
+}

--- a/internal/module/monitor/module.go
+++ b/internal/module/monitor/module.go
@@ -1,0 +1,230 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/wake/purdex/internal/config"
+	"github.com/wake/purdex/internal/core"
+)
+
+type TmuxPane struct {
+	TmuxSessionID   string `json:"tmux_session_id"`
+	TmuxSessionName string `json:"tmux_session_name"`
+	PaneID          string `json:"pane_id"`
+	PanePID         int    `json:"pane_pid"`
+}
+
+type TmuxPaneLister interface {
+	ListPanes(context.Context) ([]TmuxPane, error)
+}
+
+type ProcessTableCollector interface {
+	ListProcesses(context.Context) ([]Process, error)
+}
+
+type Collectors struct {
+	HostCollector         HostCollector
+	TmuxPaneLister        TmuxPaneLister
+	ProcessTableCollector ProcessTableCollector
+}
+
+type Option func(*Module)
+
+type Module struct {
+	collectors Collectors
+	core       *core.Core
+	now        func() time.Time
+	hostState  *HostMetricsState
+
+	snapshotMu     sync.Mutex
+	cachedSnapshot *snapshot
+}
+
+func New(opts ...Option) *Module {
+	collectors := Collectors{
+		HostCollector:         NewSystemHostCollector(),
+		TmuxPaneLister:        NewTmuxPaneLister(nil),
+		ProcessTableCollector: NewProcessTableCollector(nil),
+	}
+	m := &Module{
+		collectors: collectors,
+		now:        time.Now,
+		hostState:  NewHostMetricsState(collectors.HostCollector),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+func WithCollectors(collectors Collectors) Option {
+	return func(m *Module) {
+		m.collectors = collectors
+		m.hostState = NewHostMetricsState(collectors.HostCollector)
+	}
+}
+
+func withClock(now func() time.Time) Option {
+	return func(m *Module) {
+		m.now = now
+	}
+}
+
+func (m *Module) Name() string { return "monitor" }
+
+func (m *Module) Dependencies() []string { return nil }
+
+func (m *Module) Init(c *core.Core) error {
+	m.core = c
+	return nil
+}
+
+func (m *Module) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/monitor/snapshot", m.handleSnapshot)
+	mux.HandleFunc("GET /api/monitor/config", m.handleConfig)
+	mux.HandleFunc("PUT /api/monitor/config", m.handleConfig)
+}
+
+func (m *Module) Start(_ context.Context) error {
+	log.Println("[monitor] endpoints enabled")
+	return nil
+}
+
+func (m *Module) Stop(_ context.Context) error { return nil }
+
+func (m *Module) handleSnapshot(w http.ResponseWriter, r *http.Request) {
+	snapshot, err := m.getSnapshot(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, snapshot)
+}
+
+type snapshot struct {
+	SampledAt int64           `json:"sampled_at"`
+	Host      HostMetrics     `json:"host"`
+	Sessions  []any           `json:"sessions"`
+	Config    EffectiveConfig `json:"config"`
+	sampledAt time.Time
+}
+
+func (m *Module) getSnapshot(ctx context.Context) (*snapshot, error) {
+	now := m.now()
+	cfg := m.effectiveConfig()
+	refreshInterval := time.Duration(cfg.RefreshIntervalMS) * time.Millisecond
+
+	m.snapshotMu.Lock()
+	defer m.snapshotMu.Unlock()
+
+	if m.cachedSnapshot != nil && now.Sub(m.cachedSnapshot.sampledAt) < refreshInterval {
+		return m.cachedSnapshot, nil
+	}
+
+	sampledAt := m.now()
+	snapshot := &snapshot{
+		SampledAt: sampledAt.UnixMilli(),
+		Host:      collectHostMetrics(ctx, m.ensureHostMetricsState()),
+		Sessions:  []any{},
+		Config:    cfg,
+		sampledAt: sampledAt,
+	}
+	m.cachedSnapshot = snapshot
+	return snapshot, nil
+}
+
+func (m *Module) ensureHostMetricsState() *HostMetricsState {
+	if m.hostState == nil {
+		m.hostState = NewHostMetricsState(m.collectors.HostCollector)
+	}
+	return m.hostState
+}
+
+func (m *Module) effectiveConfig() EffectiveConfig {
+	if m.core == nil || m.core.Cfg == nil {
+		return EffectiveMonitorConfig(DefaultMonitorConfig())
+	}
+
+	m.core.CfgMu.RLock()
+	cfg := m.core.Cfg.Monitor
+	m.core.CfgMu.RUnlock()
+	return EffectiveMonitorConfig(cfg)
+}
+
+func (m *Module) handleConfig(w http.ResponseWriter, r *http.Request) {
+	if m.core == nil || m.core.Cfg == nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "monitor config unavailable"})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		m.core.CfgMu.RLock()
+		cfg := m.core.Cfg.Monitor
+		m.core.CfgMu.RUnlock()
+		writeJSON(w, http.StatusOK, EffectiveMonitorConfig(cfg))
+	case http.MethodPut:
+		m.handlePutConfig(w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+type configUpdateRequest struct {
+	RefreshIntervalMS *int `json:"refresh_interval_ms,omitempty"`
+	TopProcessLimit   *int `json:"top_process_limit,omitempty"`
+}
+
+func (m *Module) handlePutConfig(w http.ResponseWriter, r *http.Request) {
+	var req configUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	m.core.CfgMu.Lock()
+	snapshot := *m.core.Cfg
+
+	current := EffectiveMonitorConfig(m.core.Cfg.Monitor).persistedConfig()
+	if req.RefreshIntervalMS != nil {
+		current.RefreshIntervalMS = *req.RefreshIntervalMS
+	}
+	if req.TopProcessLimit != nil {
+		current.TopProcessLimit = *req.TopProcessLimit
+	}
+
+	effective := ClampSubmittedMonitorConfig(current)
+	m.core.Cfg.Monitor = effective.persistedConfig()
+
+	if m.core.CfgPath != "" {
+		if err := config.WriteFile(m.core.CfgPath, *m.core.Cfg); err != nil {
+			*m.core.Cfg = snapshot
+			m.core.CfgMu.Unlock()
+			http.Error(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	m.core.CfgMu.Unlock()
+
+	m.invalidateSnapshot()
+	m.core.NotifyConfigChange()
+	writeJSON(w, http.StatusOK, effective)
+}
+
+func (m *Module) invalidateSnapshot() {
+	m.snapshotMu.Lock()
+	m.cachedSnapshot = nil
+	m.snapshotMu.Unlock()
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/internal/module/monitor/module_test.go
+++ b/internal/module/monitor/module_test.go
@@ -1,0 +1,82 @@
+package monitor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wake/purdex/internal/core"
+)
+
+type countingTmuxPaneLister struct {
+	calls int
+}
+
+func (l *countingTmuxPaneLister) ListPanes(context.Context) ([]TmuxPane, error) {
+	l.calls++
+	return nil, nil
+}
+
+type countingProcessCollector struct {
+	calls int
+}
+
+func (c *countingProcessCollector) ListProcesses(context.Context) ([]Process, error) {
+	c.calls++
+	return nil, nil
+}
+
+func TestModule_ImplementsCoreModule(t *testing.T) {
+	var _ core.Module = (*Module)(nil)
+
+	m := New()
+
+	assert.Equal(t, "monitor", m.Name())
+	assert.NotContains(t, m.Dependencies(), "agent")
+}
+
+func TestModule_RegisterRoutes(t *testing.T) {
+	m := New()
+	mux := http.NewServeMux()
+	m.RegisterRoutes(mux)
+
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: "/api/monitor/snapshot"},
+		{method: http.MethodGet, path: "/api/monitor/config"},
+		{method: http.MethodPut, path: "/api/monitor/config"},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			mux.ServeHTTP(rec, req)
+
+			assert.NotEqual(t, http.StatusNotFound, rec.Code)
+			assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+		})
+	}
+}
+
+func TestModule_DoesNotSampleOnStart(t *testing.T) {
+	tmuxLister := &countingTmuxPaneLister{}
+	processCollector := &countingProcessCollector{}
+	m := New(WithCollectors(Collectors{
+		TmuxPaneLister:        tmuxLister,
+		ProcessTableCollector: processCollector,
+	}))
+
+	require.NoError(t, m.Init(core.New(core.CoreDeps{})))
+	require.NoError(t, m.Start(context.Background()))
+
+	assert.Zero(t, tmuxLister.calls, "monitor should not list tmux panes during startup")
+	assert.Zero(t, processCollector.calls, "monitor should not collect processes during startup")
+
+	require.NoError(t, m.Stop(context.Background()))
+}

--- a/internal/module/monitor/process.go
+++ b/internal/module/monitor/process.go
@@ -1,0 +1,174 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Process struct {
+	PID         int     `json:"pid"`
+	PPID        int     `json:"ppid"`
+	Command     string  `json:"command"`
+	CPUPercent  float64 `json:"cpu_percent"`
+	MemoryBytes uint64  `json:"memory_bytes"`
+}
+
+type PaneProcessAggregate struct {
+	CPUPercent   float64 `json:"cpu_percent"`
+	MemoryBytes  uint64  `json:"memory_bytes"`
+	ProcessCount int     `json:"process_count"`
+}
+
+type ProcessCommandRunner interface {
+	Output(ctx context.Context, args ...string) (string, error)
+}
+
+type processTableCollector struct {
+	runner ProcessCommandRunner
+}
+
+func NewProcessTableCollector(runner ProcessCommandRunner) ProcessTableCollector {
+	if runner == nil {
+		runner = processCLICommandRunner{}
+	}
+	return &processTableCollector{runner: runner}
+}
+
+func (c *processTableCollector) ListProcesses(ctx context.Context) ([]Process, error) {
+	out, err := c.runner.Output(ctx, "-axo", "pid=,ppid=,pcpu=,rss=,command=")
+	if err != nil {
+		return nil, fmt.Errorf("ps process table: %w", err)
+	}
+	return parseProcessTableOutput(out)
+}
+
+func parseProcessTableOutput(out string) ([]Process, error) {
+	var processes []Process
+	for i, line := range strings.Split(out, "\n") {
+		lineNo := i + 1
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields, command := splitProcessTableLine(line)
+		if len(fields) < 4 {
+			return nil, fmt.Errorf("malformed process table line %d: expected at least 4 fields, got %d", lineNo, len(fields))
+		}
+		if strings.EqualFold(fields[0], "PID") {
+			continue
+		}
+
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || pid <= 0 {
+			return nil, fmt.Errorf("invalid process pid on line %d: %q", lineNo, fields[0])
+		}
+		ppid, err := strconv.Atoi(fields[1])
+		if err != nil || ppid < 0 {
+			return nil, fmt.Errorf("invalid process ppid on line %d: %q", lineNo, fields[1])
+		}
+		cpuPercent, err := strconv.ParseFloat(fields[2], 64)
+		if err != nil || math.IsNaN(cpuPercent) || math.IsInf(cpuPercent, 0) || cpuPercent < 0 {
+			return nil, fmt.Errorf("invalid process cpu percent on line %d: %q", lineNo, fields[2])
+		}
+		rssKB, err := strconv.ParseUint(fields[3], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid process rss on line %d: %q", lineNo, fields[3])
+		}
+		if rssKB > math.MaxUint64/1024 {
+			return nil, fmt.Errorf("invalid process rss on line %d: %q", lineNo, fields[3])
+		}
+
+		processes = append(processes, Process{
+			PID:         pid,
+			PPID:        ppid,
+			CPUPercent:  cpuPercent,
+			MemoryBytes: rssKB * 1024,
+			Command:     command,
+		})
+	}
+	return processes, nil
+}
+
+func splitProcessTableLine(line string) ([]string, string) {
+	fields := make([]string, 0, 4)
+	pos := 0
+	for len(fields) < 4 {
+		for pos < len(line) && (line[pos] == ' ' || line[pos] == '\t') {
+			pos++
+		}
+		if pos >= len(line) {
+			break
+		}
+		start := pos
+		for pos < len(line) && line[pos] != ' ' && line[pos] != '\t' {
+			pos++
+		}
+		fields = append(fields, line[start:pos])
+	}
+	if len(fields) < 4 {
+		return fields, ""
+	}
+	for pos < len(line) && (line[pos] == ' ' || line[pos] == '\t') {
+		pos++
+	}
+	if pos >= len(line) {
+		return fields, ""
+	}
+	return fields, line[pos:]
+}
+
+func AggregatePaneDescendants(panePID int, processes []Process) PaneProcessAggregate {
+	if panePID <= 0 {
+		return PaneProcessAggregate{}
+	}
+
+	processByPID := make(map[int]Process, len(processes))
+	childrenByPPID := make(map[int][]int, len(processes))
+	for _, process := range processes {
+		if process.PID <= 0 {
+			continue
+		}
+		if _, exists := processByPID[process.PID]; !exists {
+			processByPID[process.PID] = process
+		}
+		if process.PPID > 0 {
+			childrenByPPID[process.PPID] = append(childrenByPPID[process.PPID], process.PID)
+		}
+	}
+
+	var aggregate PaneProcessAggregate
+	queue := []int{panePID}
+	visited := make(map[int]bool, len(processes))
+	for len(queue) > 0 {
+		pid := queue[0]
+		queue = queue[1:]
+		if visited[pid] {
+			continue
+		}
+		visited[pid] = true
+
+		process, ok := processByPID[pid]
+		if !ok {
+			continue
+		}
+		aggregate.CPUPercent += process.CPUPercent
+		aggregate.MemoryBytes += process.MemoryBytes
+		aggregate.ProcessCount++
+		queue = append(queue, childrenByPPID[pid]...)
+	}
+
+	return aggregate
+}
+
+type processCLICommandRunner struct{}
+
+func (processCLICommandRunner) Output(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "ps", args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/internal/module/monitor/process_test.go
+++ b/internal/module/monitor/process_test.go
@@ -1,0 +1,217 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTmuxPaneListerListsActiveAndInactivePanes(t *testing.T) {
+	runner := &fakeTmuxCommandRunner{output: "$1\twork\t%1\t101\n$1\twork\t%2\t202\n$2\tlogs\t%3\t303\n"}
+	lister := NewTmuxPaneLister(runner)
+
+	panes, err := lister.ListPanes(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"list-panes", "-a", "-F", tmuxPaneListFormat}}, runner.calls)
+	assert.Equal(t, []TmuxPane{
+		{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101},
+		{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%2", PanePID: 202},
+		{TmuxSessionID: "$2", TmuxSessionName: "logs", PaneID: "%3", PanePID: 303},
+	}, panes)
+}
+
+func TestTmuxPaneListerReturnsEmptyForEmptyOutput(t *testing.T) {
+	lister := NewTmuxPaneLister(&fakeTmuxCommandRunner{output: "\n\n"})
+
+	panes, err := lister.ListPanes(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, panes)
+}
+
+func TestTmuxPaneListerSkipsBlankLines(t *testing.T) {
+	lister := NewTmuxPaneLister(&fakeTmuxCommandRunner{output: "\n$1\twork\t%1\t101\n\n"})
+
+	panes, err := lister.ListPanes(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, []TmuxPane{{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101}}, panes)
+}
+
+func TestTmuxPaneListerReturnsErrorForMalformedLine(t *testing.T) {
+	lister := NewTmuxPaneLister(&fakeTmuxCommandRunner{output: "$1\twork\t%1\n"})
+
+	panes, err := lister.ListPanes(context.Background())
+
+	assert.Nil(t, panes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed tmux pane line 1")
+}
+
+func TestTmuxPaneListerReturnsErrorForInvalidPanePID(t *testing.T) {
+	for _, rawPID := range []string{"nope", "0", "-1"} {
+		t.Run(rawPID, func(t *testing.T) {
+			lister := NewTmuxPaneLister(&fakeTmuxCommandRunner{output: "$1\twork\t%1\t" + rawPID + "\n"})
+
+			panes, err := lister.ListPanes(context.Background())
+
+			assert.Nil(t, panes)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid tmux pane pid on line 1")
+		})
+	}
+}
+
+func TestTmuxPaneListerReturnsEmptyForNoServerOrSessions(t *testing.T) {
+	for _, output := range []string{"no server running on /tmp/tmux", "no sessions"} {
+		t.Run(output, func(t *testing.T) {
+			lister := NewTmuxPaneLister(&fakeTmuxCommandRunner{output: output, err: errors.New("tmux failed")})
+
+			panes, err := lister.ListPanes(context.Background())
+
+			require.NoError(t, err)
+			assert.Empty(t, panes)
+		})
+	}
+}
+
+func TestTmuxPaneListerWrapsRunnerError(t *testing.T) {
+	lister := NewTmuxPaneLister(&fakeTmuxCommandRunner{err: errors.New("boom")})
+
+	panes, err := lister.ListPanes(context.Background())
+
+	assert.Nil(t, panes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tmux list-panes")
+}
+
+func TestProcessModelHasExplicitUnits(t *testing.T) {
+	processType := reflect.TypeOf(Process{})
+
+	assertProcessField(t, processType, "PID", reflect.Int, `json:"pid"`)
+	assertProcessField(t, processType, "PPID", reflect.Int, `json:"ppid"`)
+	assertProcessField(t, processType, "Command", reflect.String, `json:"command"`)
+	assertProcessField(t, processType, "CPUPercent", reflect.Float64, `json:"cpu_percent"`)
+	assertProcessField(t, processType, "MemoryBytes", reflect.Uint64, `json:"memory_bytes"`)
+}
+
+func TestProcessCollectorListsProcessTableWithExplicitUnits(t *testing.T) {
+	collector := NewProcessTableCollector(&fakeProcessCommandRunner{output: "  PID  PPID  %CPU RSS COMMAND\n 101 1 0.0 1024 tmux\n 201 101 12.5 2048 node   server.js\n 202 101 1.5 512\n"})
+
+	processes, err := collector.ListProcesses(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"-axo", "pid=,ppid=,pcpu=,rss=,command="}}, collector.(*processTableCollector).runner.(*fakeProcessCommandRunner).calls)
+	assert.Equal(t, []Process{
+		{PID: 101, PPID: 1, Command: "tmux", CPUPercent: 0, MemoryBytes: 1024 * 1024},
+		{PID: 201, PPID: 101, Command: "node   server.js", CPUPercent: 12.5, MemoryBytes: 2048 * 1024},
+		{PID: 202, PPID: 101, Command: "", CPUPercent: 1.5, MemoryBytes: 512 * 1024},
+	}, processes)
+}
+
+func TestProcessCollectorRejectsInvalidNumericValues(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		line    string
+		message string
+	}{
+		{name: "zero pid", line: "0 1 1.0 100 bad", message: "invalid process pid"},
+		{name: "negative pid", line: "-1 1 1.0 100 bad", message: "invalid process pid"},
+		{name: "negative ppid", line: "10 -1 1.0 100 bad", message: "invalid process ppid"},
+		{name: "negative cpu", line: "10 1 -1.0 100 bad", message: "invalid process cpu percent"},
+		{name: "nan cpu", line: "10 1 NaN 100 bad", message: "invalid process cpu percent"},
+		{name: "inf cpu", line: "10 1 +Inf 100 bad", message: "invalid process cpu percent"},
+		{name: "rss overflow", line: "10 1 1.0 18014398509481984 bad", message: "invalid process rss"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			collector := NewProcessTableCollector(&fakeProcessCommandRunner{output: tc.line + "\n"})
+
+			processes, err := collector.ListProcesses(context.Background())
+
+			assert.Nil(t, processes)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.message)
+		})
+	}
+}
+
+func TestAggregatePaneDescendantsAggregatesDirectChildren(t *testing.T) {
+	got := AggregatePaneDescendants(101, []Process{
+		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+		{PID: 201, PPID: 101, Command: "node", CPUPercent: 12.5, MemoryBytes: 2000},
+		{PID: 202, PPID: 101, Command: "go", CPUPercent: 3.5, MemoryBytes: 3000},
+	})
+
+	assert.Equal(t, PaneProcessAggregate{CPUPercent: 17, MemoryBytes: 5100, ProcessCount: 3}, got)
+}
+
+func TestAggregatePaneDescendantsExcludesUnrelatedProcesses(t *testing.T) {
+	got := AggregatePaneDescendants(101, []Process{
+		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+		{PID: 201, PPID: 101, Command: "node", CPUPercent: 2, MemoryBytes: 200},
+		{PID: 999, PPID: 1, Command: "other", CPUPercent: 50, MemoryBytes: 5000},
+		{PID: 1000, PPID: 999, Command: "other-child", CPUPercent: 20, MemoryBytes: 1000},
+	})
+
+	assert.Equal(t, PaneProcessAggregate{CPUPercent: 3, MemoryBytes: 300, ProcessCount: 2}, got)
+}
+
+func TestAggregatePaneDescendantsIncludesNestedDescendants(t *testing.T) {
+	got := AggregatePaneDescendants(101, []Process{
+		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+		{PID: 201, PPID: 101, Command: "npm", CPUPercent: 2, MemoryBytes: 200},
+		{PID: 301, PPID: 201, Command: "vite", CPUPercent: 3, MemoryBytes: 300},
+		{PID: 401, PPID: 301, Command: "esbuild", CPUPercent: 4, MemoryBytes: 400},
+	})
+
+	assert.Equal(t, PaneProcessAggregate{CPUPercent: 10, MemoryBytes: 1000, ProcessCount: 4}, got)
+}
+
+func TestAggregatePaneDescendantsHandlesCyclesAndMalformedParents(t *testing.T) {
+	got := AggregatePaneDescendants(101, []Process{
+		{PID: 101, PPID: 303, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+		{PID: 201, PPID: 101, Command: "worker", CPUPercent: 2, MemoryBytes: 200},
+		{PID: 202, PPID: 202, Command: "self-cycle", CPUPercent: 50, MemoryBytes: 5000},
+		{PID: 303, PPID: 201, Command: "cycle", CPUPercent: 3, MemoryBytes: 300},
+		{PID: 404, PPID: -1, Command: "malformed", CPUPercent: 80, MemoryBytes: 8000},
+		{PID: 0, PPID: 101, Command: "bad-pid", CPUPercent: 90, MemoryBytes: 9000},
+	})
+
+	assert.Equal(t, PaneProcessAggregate{CPUPercent: 6, MemoryBytes: 600, ProcessCount: 3}, got)
+}
+
+func assertProcessField(t *testing.T, processType reflect.Type, name string, kind reflect.Kind, tag string) {
+	t.Helper()
+
+	field, ok := processType.FieldByName(name)
+	require.True(t, ok, "Process.%s must exist", name)
+	assert.Equal(t, kind, field.Type.Kind())
+	assert.Equal(t, reflect.StructTag(tag), field.Tag)
+}
+
+type fakeTmuxCommandRunner struct {
+	output string
+	err    error
+	calls  [][]string
+}
+
+type fakeProcessCommandRunner struct {
+	output string
+	err    error
+	calls  [][]string
+}
+
+func (r *fakeProcessCommandRunner) Output(_ context.Context, args ...string) (string, error) {
+	r.calls = append(r.calls, args)
+	return r.output, r.err
+}
+
+func (r *fakeTmuxCommandRunner) Output(_ context.Context, args ...string) (string, error) {
+	r.calls = append(r.calls, args)
+	return r.output, r.err
+}

--- a/internal/module/monitor/snapshot_test.go
+++ b/internal/module/monitor/snapshot_test.go
@@ -1,0 +1,166 @@
+package monitor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wake/purdex/internal/config"
+	"github.com/wake/purdex/internal/core"
+)
+
+func TestSnapshot_ReusesCachedSnapshotWithinRefreshInterval(t *testing.T) {
+	hostCollector := newFakeHostCollector()
+	clock := newFakeClock(time.Unix(100, 0))
+	m := New(WithCollectors(Collectors{
+		HostCollector: hostCollector,
+	}), withClock(clock.Now))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{
+		Monitor: MonitorConfig{RefreshIntervalMS: 5000, TopProcessLimit: 10},
+	}})))
+
+	first := requestSnapshot(t, m)
+	second := requestSnapshot(t, m)
+
+	assert.Equal(t, first.SampledAt, second.SampledAt, "fresh repeated requests should return the cached snapshot")
+	assert.Equal(t, 1, hostCollector.cpuCalls, "host cpu should be sampled once for repeated fresh requests")
+	assert.Equal(t, 1, hostCollector.memoryCalls, "host memory should be sampled once for repeated fresh requests")
+	assert.Equal(t, 1, hostCollector.diskCalls, "host disk should be sampled once for repeated fresh requests")
+}
+
+func TestSnapshot_RecollectsWhenCacheExpires(t *testing.T) {
+	hostCollector := newFakeHostCollector()
+	clock := newFakeClock(time.Unix(100, 0))
+	m := New(WithCollectors(Collectors{
+		HostCollector: hostCollector,
+	}), withClock(clock.Now))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{
+		Monitor: MonitorConfig{RefreshIntervalMS: 5000, TopProcessLimit: 10},
+	}})))
+
+	first := requestSnapshot(t, m)
+	clock.Advance(5 * time.Second)
+	second := requestSnapshot(t, m)
+
+	assert.NotEqual(t, first.SampledAt, second.SampledAt, "stale requests should collect a new snapshot")
+	assert.Equal(t, 2, hostCollector.cpuCalls)
+	assert.Equal(t, 2, hostCollector.memoryCalls)
+	assert.Equal(t, 2, hostCollector.diskCalls)
+}
+
+func TestSnapshot_UsesUpdatedRefreshIntervalForCacheFreshness(t *testing.T) {
+	hostCollector := newFakeHostCollector()
+	clock := newFakeClock(time.Unix(100, 0))
+	cfg := &config.Config{Monitor: MonitorConfig{RefreshIntervalMS: 5000, TopProcessLimit: 10}}
+	m := New(WithCollectors(Collectors{
+		HostCollector: hostCollector,
+	}), withClock(clock.Now))
+	c := core.New(core.CoreDeps{Config: cfg})
+	require.NoError(t, m.Init(c))
+
+	first := requestSnapshot(t, m)
+	c.CfgMu.Lock()
+	c.Cfg.Monitor.RefreshIntervalMS = 1000
+	c.CfgMu.Unlock()
+	clock.Advance(1500 * time.Millisecond)
+	second := requestSnapshot(t, m)
+
+	assert.NotEqual(t, first.SampledAt, second.SampledAt, "cache freshness should use the latest effective refresh interval")
+	assert.Equal(t, 2, hostCollector.cpuCalls)
+	assert.Equal(t, 2, hostCollector.memoryCalls)
+	assert.Equal(t, 2, hostCollector.diskCalls)
+}
+
+func TestPutMonitorConfigInvalidatesCachedSnapshot(t *testing.T) {
+	hostCollector := newFakeHostCollector()
+	clock := newFakeClock(time.Unix(100, 0))
+	m := New(WithCollectors(Collectors{HostCollector: hostCollector}), withClock(clock.Now))
+	c := core.New(core.CoreDeps{Config: &config.Config{
+		Monitor: MonitorConfig{RefreshIntervalMS: 5000, TopProcessLimit: 10},
+	}})
+	require.NoError(t, m.Init(c))
+
+	first := requestSnapshot(t, m)
+	require.Equal(t, 1, hostCollector.cpuCalls)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/monitor/config", bytes.NewBufferString(`{"refresh_interval_ms":60000,"top_process_limit":7}`))
+	m.handleConfig(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	second := requestSnapshot(t, m)
+	assert.NotEqual(t, first.Config.TopProcessLimit, second.Config.TopProcessLimit)
+	assert.Equal(t, 7, second.Config.TopProcessLimit)
+	assert.Equal(t, 2, hostCollector.cpuCalls, "config updates should invalidate cached snapshots")
+}
+
+func TestSnapshot_IncludesHostMetrics(t *testing.T) {
+	collector := newFakeHostCollector()
+	collector.cpuSamples = []HostCPUSample{{Idle: 80, Total: 100}}
+	collector.memory = HostMemorySample{TotalBytes: 1000, UsedBytes: 250}
+	collector.disk = HostDiskSample{TotalBytes: 2000, UsedBytes: 500}
+	m := New(WithCollectors(Collectors{HostCollector: collector}))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{}})))
+
+	snapshot := requestSnapshot(t, m)
+
+	var host HostMetrics
+	require.NoError(t, json.Unmarshal(snapshot.Host, &host))
+	require.NotNil(t, host.CPU)
+	assert.Nil(t, host.CPU.Percent)
+	assert.Equal(t, "pending", host.CPU.UnavailableReason)
+	require.NotNil(t, host.Memory)
+	assert.Equal(t, uint64(1000), *host.Memory.TotalBytes)
+	require.NotNil(t, host.Disk)
+	assert.Equal(t, uint64(2000), *host.Disk.TotalBytes)
+}
+
+type snapshotResponse struct {
+	SampledAt int64           `json:"sampled_at"`
+	Host      json.RawMessage `json:"host"`
+	Sessions  json.RawMessage `json:"sessions"`
+	Config    EffectiveConfig `json:"config"`
+}
+
+func requestSnapshot(t *testing.T, m *Module) snapshotResponse {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/monitor/snapshot", nil).WithContext(context.Background())
+	m.handleSnapshot(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var got snapshotResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	require.NotZero(t, got.SampledAt)
+	require.NotNil(t, got.Host)
+	require.NotNil(t, got.Sessions)
+	assert.Positive(t, got.Config.RefreshIntervalMS)
+	assert.Positive(t, got.Config.TopProcessLimit)
+	return got
+}
+
+type fakeClock struct {
+	now time.Time
+}
+
+func newFakeClock(now time.Time) *fakeClock {
+	return &fakeClock{now: now}
+}
+
+func (c *fakeClock) Now() time.Time {
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.now = c.now.Add(d)
+}

--- a/internal/module/monitor/tmux_panes.go
+++ b/internal/module/monitor/tmux_panes.go
@@ -1,0 +1,82 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const tmuxPaneListFormat = "#{session_id}\t#{session_name}\t#{pane_id}\t#{pane_pid}"
+
+type TmuxCommandRunner interface {
+	Output(ctx context.Context, args ...string) (string, error)
+}
+
+type tmuxPaneLister struct {
+	runner TmuxCommandRunner
+}
+
+func NewTmuxPaneLister(runner TmuxCommandRunner) TmuxPaneLister {
+	if runner == nil {
+		runner = tmuxCLICommandRunner{}
+	}
+	return &tmuxPaneLister{runner: runner}
+}
+
+func (l *tmuxPaneLister) ListPanes(ctx context.Context) ([]TmuxPane, error) {
+	out, err := l.runner.Output(ctx, "list-panes", "-a", "-F", tmuxPaneListFormat)
+	if err != nil {
+		if isNoTmuxPanesOutput(out) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("tmux list-panes: %w", err)
+	}
+
+	panes, err := parseTmuxPaneListOutput(out)
+	if err != nil {
+		return nil, err
+	}
+	return panes, nil
+}
+
+func parseTmuxPaneListOutput(out string) ([]TmuxPane, error) {
+	var panes []TmuxPane
+	for i, line := range strings.Split(out, "\n") {
+		lineNo := i + 1
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		parts := strings.Split(line, "\t")
+		if len(parts) != 4 {
+			return nil, fmt.Errorf("malformed tmux pane line %d: expected 4 fields, got %d", lineNo, len(parts))
+		}
+
+		panePID, err := strconv.Atoi(parts[3])
+		if err != nil || panePID <= 0 {
+			return nil, fmt.Errorf("invalid tmux pane pid on line %d: %q", lineNo, parts[3])
+		}
+
+		panes = append(panes, TmuxPane{
+			TmuxSessionID:   parts[0],
+			TmuxSessionName: parts[1],
+			PaneID:          parts[2],
+			PanePID:         panePID,
+		})
+	}
+	return panes, nil
+}
+
+func isNoTmuxPanesOutput(out string) bool {
+	return strings.Contains(out, "no server running") || strings.Contains(out, "no sessions")
+}
+
+type tmuxCLICommandRunner struct{}
+
+func (tmuxCLICommandRunner) Output(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "tmux", args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}


### PR DESCRIPTION
## Summary
- Add an independent daemon monitor module with `/api/monitor/config` and cached `/api/monitor/snapshot` skeleton.
- Add monitor config persistence, bounds, clamping, and cache invalidation on config updates.
- Add host metrics, tmux all-pane listing, and process-table aggregation primitives for later tab/session metrics.

## Verification
- `make test`
- `go test ./cmd/pdx ./internal/config ./internal/module/monitor -count=1`
- Two rounds of subagent review for this PR slice, no remaining findings.

## Scope
This PR intentionally does not add SPA UI or expose session metrics. It is the non-breaking daemon foundation slice for `revamp-performance-monitor`.