### PR TITLE
feat(monitor): aggregate session process totals

### DIFF
--- a/cmd/pdx/monitor_module_test.go
+++ b/cmd/pdx/monitor_module_test.go
@@ -21,7 +21,7 @@ func TestRegisterServeModules_IncludesMonitorRoutes(t *testing.T) {
 	mux := http.NewServeMux()
 	c.RegisterRoutes(mux)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/monitor/snapshot", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/monitor/config", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 

--- a/internal/module/monitor/module.go
+++ b/internal/module/monitor/module.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/wake/purdex/internal/config"
 	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/session"
 )
 
 type TmuxPane struct {
@@ -27,6 +28,10 @@ type ProcessTableCollector interface {
 	ListProcesses(context.Context) ([]Process, error)
 }
 
+type sessionProvider interface {
+	ListSessions() ([]session.SessionInfo, error)
+}
+
 type Collectors struct {
 	HostCollector         HostCollector
 	TmuxPaneLister        TmuxPaneLister
@@ -36,10 +41,11 @@ type Collectors struct {
 type Option func(*Module)
 
 type Module struct {
-	collectors Collectors
-	core       *core.Core
-	now        func() time.Time
-	hostState  *HostMetricsState
+	collectors      Collectors
+	core            *core.Core
+	now             func() time.Time
+	hostState       *HostMetricsState
+	sessionProvider sessionProvider
 
 	snapshotMu     sync.Mutex
 	cachedSnapshot *snapshot
@@ -75,12 +81,25 @@ func withClock(now func() time.Time) Option {
 	}
 }
 
+func withSessionProvider(provider sessionProvider) Option {
+	return func(m *Module) {
+		m.sessionProvider = provider
+	}
+}
+
 func (m *Module) Name() string { return "monitor" }
 
-func (m *Module) Dependencies() []string { return nil }
+func (m *Module) Dependencies() []string { return []string{"session"} }
 
 func (m *Module) Init(c *core.Core) error {
 	m.core = c
+	if m.sessionProvider == nil && c != nil && c.Registry != nil {
+		if svc, ok := c.Registry.Get(session.RegistryKey); ok {
+			if provider, ok := svc.(sessionProvider); ok {
+				m.sessionProvider = provider
+			}
+		}
+	}
 	return nil
 }
 
@@ -108,11 +127,22 @@ func (m *Module) handleSnapshot(w http.ResponseWriter, r *http.Request) {
 }
 
 type snapshot struct {
-	SampledAt int64           `json:"sampled_at"`
-	Host      HostMetrics     `json:"host"`
-	Sessions  []any           `json:"sessions"`
-	Config    EffectiveConfig `json:"config"`
+	SampledAt int64            `json:"sampled_at"`
+	Host      HostMetrics      `json:"host"`
+	Sessions  []SessionMetrics `json:"sessions"`
+	Config    EffectiveConfig  `json:"config"`
 	sampledAt time.Time
+}
+
+type TmuxSessionRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type SessionMetrics struct {
+	SessionCode string               `json:"session_code"`
+	TmuxSession TmuxSessionRef       `json:"tmux_session"`
+	Daemon      PaneProcessAggregate `json:"daemon"`
 }
 
 func (m *Module) getSnapshot(ctx context.Context) (*snapshot, error) {
@@ -127,11 +157,16 @@ func (m *Module) getSnapshot(ctx context.Context) (*snapshot, error) {
 		return m.cachedSnapshot, nil
 	}
 
+	sessions, err := m.collectSessionMetrics(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	sampledAt := m.now()
 	snapshot := &snapshot{
 		SampledAt: sampledAt.UnixMilli(),
 		Host:      collectHostMetrics(ctx, m.ensureHostMetricsState()),
-		Sessions:  []any{},
+		Sessions:  sessions,
 		Config:    cfg,
 		sampledAt: sampledAt,
 	}
@@ -144,6 +179,41 @@ func (m *Module) ensureHostMetricsState() *HostMetricsState {
 		m.hostState = NewHostMetricsState(m.collectors.HostCollector)
 	}
 	return m.hostState
+}
+
+func (m *Module) collectSessionMetrics(ctx context.Context) ([]SessionMetrics, error) {
+	if m.sessionProvider == nil {
+		return []SessionMetrics{}, nil
+	}
+	sessions, err := m.sessionProvider.ListSessions()
+	if err != nil {
+		return nil, err
+	}
+	if len(sessions) == 0 {
+		return []SessionMetrics{}, nil
+	}
+
+	panes, err := m.collectors.TmuxPaneLister.ListPanes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	processes, err := m.collectors.ProcessTableCollector.ListProcesses(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics := make([]SessionMetrics, 0, len(sessions))
+	for _, sess := range sessions {
+		metrics = append(metrics, SessionMetrics{
+			SessionCode: sess.Code,
+			TmuxSession: TmuxSessionRef{
+				ID:   sess.TmuxID,
+				Name: sess.Name,
+			},
+			Daemon: AggregateSessionProcesses(sess.TmuxID, panes, processes),
+		})
+	}
+	return metrics, nil
 }
 
 func (m *Module) effectiveConfig() EffectiveConfig {

--- a/internal/module/monitor/process.go
+++ b/internal/module/monitor/process.go
@@ -165,6 +165,55 @@ func AggregatePaneDescendants(panePID int, processes []Process) PaneProcessAggre
 	return aggregate
 }
 
+func AggregateSessionProcesses(tmuxSessionID string, panes []TmuxPane, processes []Process) PaneProcessAggregate {
+	if tmuxSessionID == "" {
+		return PaneProcessAggregate{}
+	}
+
+	processByPID := make(map[int]Process, len(processes))
+	childrenByPPID := make(map[int][]int, len(processes))
+	for _, process := range processes {
+		if process.PID <= 0 {
+			continue
+		}
+		if _, exists := processByPID[process.PID]; !exists {
+			processByPID[process.PID] = process
+		}
+		if process.PPID > 0 {
+			childrenByPPID[process.PPID] = append(childrenByPPID[process.PPID], process.PID)
+		}
+	}
+
+	var queue []int
+	for _, pane := range panes {
+		if pane.TmuxSessionID == tmuxSessionID && pane.PanePID > 0 {
+			queue = append(queue, pane.PanePID)
+		}
+	}
+
+	var aggregate PaneProcessAggregate
+	visited := make(map[int]bool, len(processes))
+	for len(queue) > 0 {
+		pid := queue[0]
+		queue = queue[1:]
+		if visited[pid] {
+			continue
+		}
+		visited[pid] = true
+
+		process, ok := processByPID[pid]
+		if !ok {
+			continue
+		}
+		aggregate.CPUPercent += process.CPUPercent
+		aggregate.MemoryBytes += process.MemoryBytes
+		aggregate.ProcessCount++
+		queue = append(queue, childrenByPPID[pid]...)
+	}
+
+	return aggregate
+}
+
 type processCLICommandRunner struct{}
 
 func (processCLICommandRunner) Output(ctx context.Context, args ...string) (string, error) {

--- a/internal/module/monitor/process_test.go
+++ b/internal/module/monitor/process_test.go
@@ -185,6 +185,21 @@ func TestAggregatePaneDescendantsHandlesCyclesAndMalformedParents(t *testing.T) 
 	assert.Equal(t, PaneProcessAggregate{CPUPercent: 6, MemoryBytes: 600, ProcessCount: 3}, got)
 }
 
+func TestAggregateSessionProcessesAggregatesAllPanesAndDeduplicatesByPID(t *testing.T) {
+	got := AggregateSessionProcesses("$1", []TmuxPane{
+		{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101},
+		{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%2", PanePID: 201},
+		{TmuxSessionID: "$2", TmuxSessionName: "other", PaneID: "%3", PanePID: 901},
+	}, []Process{
+		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+		{PID: 201, PPID: 101, Command: "worker", CPUPercent: 2, MemoryBytes: 200},
+		{PID: 301, PPID: 201, Command: "nested", CPUPercent: 3, MemoryBytes: 300},
+		{PID: 901, PPID: 1, Command: "unrelated", CPUPercent: 90, MemoryBytes: 9000},
+	})
+
+	assert.Equal(t, PaneProcessAggregate{CPUPercent: 6, MemoryBytes: 600, ProcessCount: 3}, got)
+}
+
 func assertProcessField(t *testing.T, processType reflect.Type, name string, kind reflect.Kind, tag string) {
 	t.Helper()
 

--- a/internal/module/monitor/snapshot_test.go
+++ b/internal/module/monitor/snapshot_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/wake/purdex/internal/config"
 	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/session"
 )
 
 func TestSnapshot_ReusesCachedSnapshotWithinRefreshInterval(t *testing.T) {
@@ -122,6 +123,87 @@ func TestSnapshot_IncludesHostMetrics(t *testing.T) {
 	assert.Equal(t, uint64(2000), *host.Disk.TotalBytes)
 }
 
+func TestSnapshot_IncludesPurdexSessionProcessTotals(t *testing.T) {
+	collector := newFakeHostCollector()
+	tmuxLister := &fakeSnapshotTmuxPaneLister{panes: []TmuxPane{
+		{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101},
+		{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%2", PanePID: 201},
+		{TmuxSessionID: "$2", TmuxSessionName: "other", PaneID: "%3", PanePID: 901},
+	}}
+	processCollector := &fakeSnapshotProcessCollector{processes: []Process{
+		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+		{PID: 201, PPID: 101, Command: "worker", CPUPercent: 2, MemoryBytes: 200},
+		{PID: 301, PPID: 201, Command: "nested", CPUPercent: 3, MemoryBytes: 300},
+		{PID: 901, PPID: 1, Command: "unrelated", CPUPercent: 90, MemoryBytes: 9000},
+	}}
+	m := New(WithCollectors(Collectors{
+		HostCollector:         collector,
+		TmuxPaneLister:        tmuxLister,
+		ProcessTableCollector: processCollector,
+	}), withSessionProvider(&fakeSessionProvider{sessions: []session.SessionInfo{
+		{Code: "abc123", TmuxID: "$1", Name: "work"},
+	}}))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{}})))
+
+	snapshot := requestSnapshot(t, m)
+
+	var sessions []SessionMetrics
+	require.NoError(t, json.Unmarshal(snapshot.Sessions, &sessions))
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "abc123", sessions[0].SessionCode)
+	assert.Equal(t, "$1", sessions[0].TmuxSession.ID)
+	assert.Equal(t, "work", sessions[0].TmuxSession.Name)
+	assert.Equal(t, 6.0, sessions[0].Daemon.CPUPercent)
+	assert.Equal(t, uint64(600), sessions[0].Daemon.MemoryBytes)
+	assert.Equal(t, 3, sessions[0].Daemon.ProcessCount)
+	assert.Equal(t, 1, tmuxLister.calls)
+	assert.Equal(t, 1, processCollector.calls)
+}
+
+func TestSnapshot_UsesSessionProviderFromRegistry(t *testing.T) {
+	collector := newFakeHostCollector()
+	tmuxLister := &fakeSnapshotTmuxPaneLister{panes: []TmuxPane{
+		{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101},
+	}}
+	processCollector := &fakeSnapshotProcessCollector{processes: []Process{
+		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+	}}
+	provider := &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "abc123", TmuxID: "$1", Name: "work"}}}
+	c := core.New(core.CoreDeps{Config: &config.Config{}})
+	c.Registry.Register(session.RegistryKey, sessionProvider(provider))
+	m := New(WithCollectors(Collectors{
+		HostCollector:         collector,
+		TmuxPaneLister:        tmuxLister,
+		ProcessTableCollector: processCollector,
+	}))
+	require.NoError(t, m.Init(c))
+
+	snapshot := requestSnapshot(t, m)
+
+	var sessions []SessionMetrics
+	require.NoError(t, json.Unmarshal(snapshot.Sessions, &sessions))
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "abc123", sessions[0].SessionCode)
+	assert.Equal(t, 1, provider.calls)
+}
+
+func TestSnapshot_SkipsTmuxAndProcessCollectorsWhenNoLiveSessions(t *testing.T) {
+	tmuxLister := &fakeSnapshotTmuxPaneLister{}
+	processCollector := &fakeSnapshotProcessCollector{}
+	m := New(WithCollectors(Collectors{
+		HostCollector:         newFakeHostCollector(),
+		TmuxPaneLister:        tmuxLister,
+		ProcessTableCollector: processCollector,
+	}), withSessionProvider(&fakeSessionProvider{}))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{}})))
+
+	snapshot := requestSnapshot(t, m)
+
+	assert.JSONEq(t, `[]`, string(snapshot.Sessions))
+	assert.Zero(t, tmuxLister.calls)
+	assert.Zero(t, processCollector.calls)
+}
+
 type snapshotResponse struct {
 	SampledAt int64           `json:"sampled_at"`
 	Host      json.RawMessage `json:"host"`
@@ -163,4 +245,35 @@ func (c *fakeClock) Now() time.Time {
 
 func (c *fakeClock) Advance(d time.Duration) {
 	c.now = c.now.Add(d)
+}
+
+type fakeSessionProvider struct {
+	sessions []session.SessionInfo
+	err      error
+	calls    int
+}
+
+func (p *fakeSessionProvider) ListSessions() ([]session.SessionInfo, error) {
+	p.calls++
+	return p.sessions, p.err
+}
+
+type fakeSnapshotTmuxPaneLister struct {
+	panes []TmuxPane
+	calls int
+}
+
+func (l *fakeSnapshotTmuxPaneLister) ListPanes(context.Context) ([]TmuxPane, error) {
+	l.calls++
+	return l.panes, nil
+}
+
+type fakeSnapshotProcessCollector struct {
+	processes []Process
+	calls     int
+}
+
+func (c *fakeSnapshotProcessCollector) ListProcesses(context.Context) ([]Process, error) {
+	c.calls++
+	return c.processes, nil
 }


### PR DESCRIPTION
## Summary
- Map live Purdex sessions from the session registry into monitor snapshots by `session_code` and tmux session id.
- Aggregate all tmux panes for each Purdex session, including pane root processes and descendants, with PID de-duplication across panes.
- Avoid tmux/process scans when there are no live sessions.

## Verification
- `go test ./cmd/pdx ./internal/config ./internal/module/session ./internal/module/monitor -count=1`
- `make test`
- Two rounds of subagent review for this PR slice, no remaining findings.

## Scope
This PR intentionally does not add SPA UI, unavailable-state handling, top-process selection, or single-flight sampling. It is the next non-breaking daemon slice after alpha.257.