### PR TITLE
feat(monitor): add bounded top processes

### DIFF
--- a/internal/module/monitor/module.go
+++ b/internal/module/monitor/module.go
@@ -154,10 +154,11 @@ type SessionMetrics struct {
 }
 
 type SessionDaemonMetrics struct {
-	CPUPercent        *float64 `json:"cpu_percent"`
-	MemoryBytes       *uint64  `json:"memory_bytes"`
-	ProcessCount      *int     `json:"process_count"`
-	UnavailableReason string   `json:"unavailable_reason,omitempty"`
+	CPUPercent        *float64  `json:"cpu_percent"`
+	MemoryBytes       *uint64   `json:"memory_bytes"`
+	ProcessCount      *int      `json:"process_count"`
+	TopProcesses      []Process `json:"top_processes"`
+	UnavailableReason string    `json:"unavailable_reason,omitempty"`
 }
 
 func (m *Module) getSnapshot(ctx context.Context) (*snapshot, error) {
@@ -172,7 +173,7 @@ func (m *Module) getSnapshot(ctx context.Context) (*snapshot, error) {
 		return m.cachedSnapshot, nil
 	}
 
-	sessions, err := m.collectSessionMetrics(ctx)
+	sessions, err := m.collectSessionMetrics(ctx, cfg.TopProcessLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +197,7 @@ func (m *Module) ensureHostMetricsState() *HostMetricsState {
 	return m.hostState
 }
 
-func (m *Module) collectSessionMetrics(ctx context.Context) ([]SessionMetrics, error) {
+func (m *Module) collectSessionMetrics(ctx context.Context, topProcessLimit int) ([]SessionMetrics, error) {
 	if m.sessionProvider == nil {
 		return []SessionMetrics{}, nil
 	}
@@ -250,7 +251,7 @@ func (m *Module) collectSessionMetrics(ctx context.Context) ([]SessionMetrics, e
 			metrics = append(metrics, unavailableSessionMetric(sess, sessionPanesUnavailableReason))
 			continue
 		}
-		aggregate := AggregateSessionProcesses(sess.TmuxID, panes, processes)
+		aggregate := AggregateSessionProcesses(sess.TmuxID, panes, processes, topProcessLimit)
 		if aggregate.ProcessCount == 0 {
 			metrics = append(metrics, unavailableSessionMetric(sess, processDataUnavailableReason))
 			continue
@@ -308,7 +309,7 @@ func unavailableSessionMetric(sess session.SessionInfo, reason string) SessionMe
 			ID:   sess.TmuxID,
 			Name: sess.Name,
 		},
-		Daemon: SessionDaemonMetrics{UnavailableReason: reason},
+		Daemon: SessionDaemonMetrics{TopProcesses: []Process{}, UnavailableReason: reason},
 	}
 }
 
@@ -317,6 +318,7 @@ func availableSessionDaemonMetrics(aggregate PaneProcessAggregate) SessionDaemon
 		CPUPercent:   &aggregate.CPUPercent,
 		MemoryBytes:  &aggregate.MemoryBytes,
 		ProcessCount: &aggregate.ProcessCount,
+		TopProcesses: aggregate.TopProcesses,
 	}
 }
 

--- a/internal/module/monitor/process.go
+++ b/internal/module/monitor/process.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -18,9 +19,10 @@ type Process struct {
 }
 
 type PaneProcessAggregate struct {
-	CPUPercent   float64 `json:"cpu_percent"`
-	MemoryBytes  uint64  `json:"memory_bytes"`
-	ProcessCount int     `json:"process_count"`
+	CPUPercent   float64   `json:"cpu_percent"`
+	MemoryBytes  uint64    `json:"memory_bytes"`
+	ProcessCount int       `json:"process_count"`
+	TopProcesses []Process `json:"top_processes"`
 }
 
 type ProcessCommandRunner interface {
@@ -165,7 +167,7 @@ func AggregatePaneDescendants(panePID int, processes []Process) PaneProcessAggre
 	return aggregate
 }
 
-func AggregateSessionProcesses(tmuxSessionID string, panes []TmuxPane, processes []Process) PaneProcessAggregate {
+func AggregateSessionProcesses(tmuxSessionID string, panes []TmuxPane, processes []Process, topLimit int) PaneProcessAggregate {
 	if tmuxSessionID == "" {
 		return PaneProcessAggregate{}
 	}
@@ -192,6 +194,7 @@ func AggregateSessionProcesses(tmuxSessionID string, panes []TmuxPane, processes
 	}
 
 	var aggregate PaneProcessAggregate
+	var included []Process
 	visited := make(map[int]bool, len(processes))
 	for len(queue) > 0 {
 		pid := queue[0]
@@ -208,10 +211,32 @@ func AggregateSessionProcesses(tmuxSessionID string, panes []TmuxPane, processes
 		aggregate.CPUPercent += process.CPUPercent
 		aggregate.MemoryBytes += process.MemoryBytes
 		aggregate.ProcessCount++
+		included = append(included, process)
 		queue = append(queue, childrenByPPID[pid]...)
 	}
+	aggregate.TopProcesses = selectTopProcesses(included, topLimit)
 
 	return aggregate
+}
+
+func selectTopProcesses(processes []Process, limit int) []Process {
+	if limit <= 0 || len(processes) == 0 {
+		return nil
+	}
+	sorted := append([]Process(nil), processes...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].CPUPercent != sorted[j].CPUPercent {
+			return sorted[i].CPUPercent > sorted[j].CPUPercent
+		}
+		if sorted[i].MemoryBytes != sorted[j].MemoryBytes {
+			return sorted[i].MemoryBytes > sorted[j].MemoryBytes
+		}
+		return sorted[i].PID < sorted[j].PID
+	})
+	if len(sorted) > limit {
+		sorted = sorted[:limit]
+	}
+	return sorted
 }
 
 type processCLICommandRunner struct{}

--- a/internal/module/monitor/process_test.go
+++ b/internal/module/monitor/process_test.go
@@ -182,7 +182,9 @@ func TestAggregatePaneDescendantsHandlesCyclesAndMalformedParents(t *testing.T) 
 		{PID: 0, PPID: 101, Command: "bad-pid", CPUPercent: 90, MemoryBytes: 9000},
 	})
 
-	assert.Equal(t, PaneProcessAggregate{CPUPercent: 6, MemoryBytes: 600, ProcessCount: 3}, got)
+	assert.Equal(t, 6.0, got.CPUPercent)
+	assert.Equal(t, uint64(600), got.MemoryBytes)
+	assert.Equal(t, 3, got.ProcessCount)
 }
 
 func TestAggregateSessionProcessesAggregatesAllPanesAndDeduplicatesByPID(t *testing.T) {
@@ -195,9 +197,47 @@ func TestAggregateSessionProcessesAggregatesAllPanesAndDeduplicatesByPID(t *test
 		{PID: 201, PPID: 101, Command: "worker", CPUPercent: 2, MemoryBytes: 200},
 		{PID: 301, PPID: 201, Command: "nested", CPUPercent: 3, MemoryBytes: 300},
 		{PID: 901, PPID: 1, Command: "unrelated", CPUPercent: 90, MemoryBytes: 9000},
-	})
+	}, 10)
 
-	assert.Equal(t, PaneProcessAggregate{CPUPercent: 6, MemoryBytes: 600, ProcessCount: 3}, got)
+	assert.Equal(t, 6.0, got.CPUPercent)
+	assert.Equal(t, uint64(600), got.MemoryBytes)
+	assert.Equal(t, 3, got.ProcessCount)
+}
+
+func TestAggregateSessionProcessesReturnsBoundedTopProcesses(t *testing.T) {
+	got := AggregateSessionProcesses("$1", []TmuxPane{
+		{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101},
+	}, []Process{
+		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+		{PID: 201, PPID: 101, Command: "high-memory", CPUPercent: 5, MemoryBytes: 900},
+		{PID: 202, PPID: 101, Command: "low-pid", CPUPercent: 5, MemoryBytes: 900},
+		{PID: 203, PPID: 101, Command: "high-cpu", CPUPercent: 9, MemoryBytes: 10},
+		{PID: 204, PPID: 101, Command: "hidden", CPUPercent: 4, MemoryBytes: 1000},
+	}, 3)
+
+	assert.Equal(t, 24.0, got.CPUPercent)
+	assert.Equal(t, uint64(2910), got.MemoryBytes)
+	assert.Equal(t, 5, got.ProcessCount)
+	assert.Equal(t, []Process{
+		{PID: 203, PPID: 101, Command: "high-cpu", CPUPercent: 9, MemoryBytes: 10},
+		{PID: 201, PPID: 101, Command: "high-memory", CPUPercent: 5, MemoryBytes: 900},
+		{PID: 202, PPID: 101, Command: "low-pid", CPUPercent: 5, MemoryBytes: 900},
+	}, got.TopProcesses)
+}
+
+func TestAggregateSessionProcessesSortsTopProcessesByMemoryBeforePID(t *testing.T) {
+	got := AggregateSessionProcesses("$1", []TmuxPane{
+		{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101},
+	}, []Process{
+		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+		{PID: 201, PPID: 101, Command: "higher-memory", CPUPercent: 5, MemoryBytes: 900},
+		{PID: 200, PPID: 101, Command: "lower-pid", CPUPercent: 5, MemoryBytes: 100},
+	}, 2)
+
+	assert.Equal(t, []Process{
+		{PID: 201, PPID: 101, Command: "higher-memory", CPUPercent: 5, MemoryBytes: 900},
+		{PID: 200, PPID: 101, Command: "lower-pid", CPUPercent: 5, MemoryBytes: 100},
+	}, got.TopProcesses)
 }
 
 func assertProcessField(t *testing.T, processType reflect.Type, name string, kind reflect.Kind, tag string) {

--- a/internal/module/monitor/snapshot_test.go
+++ b/internal/module/monitor/snapshot_test.go
@@ -157,9 +157,43 @@ func TestSnapshot_IncludesPurdexSessionProcessTotals(t *testing.T) {
 	assert.Equal(t, 6.0, *sessions[0].Daemon.CPUPercent)
 	assert.Equal(t, uint64(600), *sessions[0].Daemon.MemoryBytes)
 	assert.Equal(t, 3, *sessions[0].Daemon.ProcessCount)
+	assert.Equal(t, []Process{
+		{PID: 301, PPID: 201, Command: "nested", CPUPercent: 3, MemoryBytes: 300},
+		{PID: 201, PPID: 101, Command: "worker", CPUPercent: 2, MemoryBytes: 200},
+		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+	}, sessions[0].Daemon.TopProcesses)
 	assert.Empty(t, sessions[0].Daemon.UnavailableReason)
 	assert.Equal(t, 1, tmuxLister.calls)
 	assert.Equal(t, 1, processCollector.calls)
+}
+
+func TestSnapshot_UsesConfiguredTopProcessLimitWhileKeepingTotalsInclusive(t *testing.T) {
+	m := New(WithCollectors(Collectors{
+		HostCollector: newFakeHostCollector(),
+		TmuxPaneLister: &fakeSnapshotTmuxPaneLister{panes: []TmuxPane{
+			{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101},
+		}},
+		ProcessTableCollector: &fakeSnapshotProcessCollector{processes: []Process{
+			{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
+			{PID: 201, PPID: 101, Command: "node", CPUPercent: 8, MemoryBytes: 800},
+			{PID: 202, PPID: 101, Command: "go", CPUPercent: 4, MemoryBytes: 400},
+		}},
+	}), withSessionProvider(&fakeSessionProvider{sessions: []session.SessionInfo{
+		{Code: "abc123", TmuxID: "$1", Name: "work"},
+	}}))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{
+		Monitor: MonitorConfig{RefreshIntervalMS: 5000, TopProcessLimit: 1},
+	}})))
+
+	snapshot := requestSnapshot(t, m)
+
+	var sessions []SessionMetrics
+	require.NoError(t, json.Unmarshal(snapshot.Sessions, &sessions))
+	require.Len(t, sessions, 1)
+	assert.Equal(t, 13.0, *sessions[0].Daemon.CPUPercent)
+	assert.Equal(t, uint64(1300), *sessions[0].Daemon.MemoryBytes)
+	assert.Equal(t, 3, *sessions[0].Daemon.ProcessCount)
+	assert.Equal(t, []Process{{PID: 201, PPID: 101, Command: "node", CPUPercent: 8, MemoryBytes: 800}}, sessions[0].Daemon.TopProcesses)
 }
 
 func TestSnapshot_MarksSessionUnavailableWhenTmuxPaneListingFails(t *testing.T) {
@@ -416,6 +450,7 @@ func assertSessionDaemonUnavailable(t *testing.T, daemon SessionDaemonMetrics, r
 	assert.Nil(t, daemon.CPUPercent)
 	assert.Nil(t, daemon.MemoryBytes)
 	assert.Nil(t, daemon.ProcessCount)
+	assert.Empty(t, daemon.TopProcesses)
 	assert.Equal(t, reason, daemon.UnavailableReason)
 }
 
@@ -439,4 +474,7 @@ func assertRawSessionDaemonNullFields(t *testing.T, raw json.RawMessage, index i
 		assert.True(t, exists, "%s should be present", field)
 		assert.Nil(t, value, "%s should be null", field)
 	}
+	topProcesses, exists := daemon["top_processes"]
+	assert.True(t, exists, "top_processes should be present")
+	assert.Empty(t, topProcesses, "top_processes should be an empty array")
 }


### PR DESCRIPTION
## Summary
- Add bounded `daemon.top_processes[]` to monitor session metrics.
- Sort top processes deterministically by CPU desc, memory desc, then PID asc.
- Keep session totals inclusive of all descendants even when the top-process list is truncated by config.

## Verification
- `go test ./cmd/pdx ./internal/config ./internal/module/session ./internal/module/monitor -count=1`
- `make test`
- Two rounds of subagent review, no remaining findings.

## Scope
This PR intentionally does not add SPA UI, single-flight sampling, daemon CPU delta, or a broader API redesign. It is the bounded top-process daemon slice after alpha.260.