### PR TITLE
feat(monitor): single-flight snapshot sampling

### DIFF
--- a/internal/module/monitor/module.go
+++ b/internal/module/monitor/module.go
@@ -57,6 +57,15 @@ type Module struct {
 
 	snapshotMu     sync.Mutex
 	cachedSnapshot *snapshot
+	inFlight       *snapshotFlight
+	snapshotGen    uint64
+}
+
+type snapshotFlight struct {
+	generation uint64
+	done       chan struct{}
+	snapshot   *snapshot
+	err        error
 }
 
 func New(opts ...Option) *Module {
@@ -162,32 +171,71 @@ type SessionDaemonMetrics struct {
 }
 
 func (m *Module) getSnapshot(ctx context.Context) (*snapshot, error) {
-	now := m.now()
-	cfg := m.effectiveConfig()
-	refreshInterval := time.Duration(cfg.RefreshIntervalMS) * time.Millisecond
+	for {
+		now := m.now()
+		m.snapshotMu.Lock()
+		cfg := m.effectiveConfig()
+		refreshInterval := time.Duration(cfg.RefreshIntervalMS) * time.Millisecond
+		if m.cachedSnapshot != nil && now.Sub(m.cachedSnapshot.sampledAt) < refreshInterval {
+			snapshot := m.cachedSnapshot
+			m.snapshotMu.Unlock()
+			return snapshot, nil
+		}
+		if m.inFlight != nil {
+			flight := m.inFlight
+			m.snapshotMu.Unlock()
+			select {
+			case <-flight.done:
+				m.snapshotMu.Lock()
+				stale := flight.generation != m.snapshotGen
+				m.snapshotMu.Unlock()
+				if stale {
+					continue
+				}
+				if flight.err != nil {
+					return nil, flight.err
+				}
+				return flight.snapshot, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
 
-	m.snapshotMu.Lock()
-	defer m.snapshotMu.Unlock()
+		flight := &snapshotFlight{generation: m.snapshotGen, done: make(chan struct{})}
+		m.inFlight = flight
+		m.snapshotMu.Unlock()
 
-	if m.cachedSnapshot != nil && now.Sub(m.cachedSnapshot.sampledAt) < refreshInterval {
-		return m.cachedSnapshot, nil
+		snapshot, err := m.collectSnapshot(context.WithoutCancel(ctx), cfg)
+
+		m.snapshotMu.Lock()
+		if m.inFlight == flight {
+			m.inFlight = nil
+		}
+		if err == nil && flight.generation == m.snapshotGen {
+			m.cachedSnapshot = snapshot
+		}
+		flight.snapshot = snapshot
+		flight.err = err
+		close(flight.done)
+		m.snapshotMu.Unlock()
+		return snapshot, err
 	}
+}
 
+func (m *Module) collectSnapshot(ctx context.Context, cfg EffectiveConfig) (*snapshot, error) {
 	sessions, err := m.collectSessionMetrics(ctx, cfg.TopProcessLimit)
 	if err != nil {
 		return nil, err
 	}
 
 	sampledAt := m.now()
-	snapshot := &snapshot{
+	return &snapshot{
 		SampledAt: sampledAt.UnixMilli(),
 		Host:      collectHostMetrics(ctx, m.ensureHostMetricsState()),
 		Sessions:  sessions,
 		Config:    cfg,
 		sampledAt: sampledAt,
-	}
-	m.cachedSnapshot = snapshot
-	return snapshot, nil
+	}, nil
 }
 
 func (m *Module) ensureHostMetricsState() *HostMetricsState {
@@ -396,6 +444,7 @@ func (m *Module) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 func (m *Module) invalidateSnapshot() {
 	m.snapshotMu.Lock()
 	m.cachedSnapshot = nil
+	m.snapshotGen++
 	m.snapshotMu.Unlock()
 }
 

--- a/internal/module/monitor/snapshot_test.go
+++ b/internal/module/monitor/snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -55,6 +56,159 @@ func TestSnapshot_RecollectsWhenCacheExpires(t *testing.T) {
 	assert.Equal(t, 2, hostCollector.cpuCalls)
 	assert.Equal(t, 2, hostCollector.memoryCalls)
 	assert.Equal(t, 2, hostCollector.diskCalls)
+}
+
+func TestSnapshot_StaleConcurrentRequestsShareInFlightSample(t *testing.T) {
+	collector := newBlockingHostCollector()
+	clock := newFakeClock(time.Unix(100, 0))
+	m := New(WithCollectors(Collectors{HostCollector: collector}), withClock(clock.Now))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{
+		Monitor: MonitorConfig{RefreshIntervalMS: 1000, TopProcessLimit: 10},
+	}})))
+
+	firstDone := make(chan snapshotResult, 1)
+	go func() {
+		firstDone <- requestSnapshotResult(m)
+	}()
+	collector.WaitForCPUCall(t, 1)
+	collector.ReleaseOne()
+	firstResult := <-firstDone
+	require.NoError(t, firstResult.err)
+	require.Equal(t, http.StatusOK, firstResult.statusCode)
+	first := firstResult.response
+	require.Equal(t, 1, collector.cpuCalls)
+
+	clock.Advance(time.Second)
+	const concurrentRequests = 5
+	responses := make(chan snapshotResult, concurrentRequests)
+	var wg sync.WaitGroup
+	for range concurrentRequests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			responses <- requestSnapshotResult(m)
+		}()
+	}
+	collector.WaitForCPUCall(t, 2)
+	collector.ReleaseOne()
+	wg.Wait()
+	close(responses)
+
+	var sampledAt int64
+	for result := range responses {
+		require.NoError(t, result.err)
+		require.Equal(t, http.StatusOK, result.statusCode)
+		response := result.response
+		assert.NotEqual(t, first.SampledAt, response.SampledAt)
+		if sampledAt == 0 {
+			sampledAt = response.SampledAt
+		}
+		assert.Equal(t, sampledAt, response.SampledAt)
+	}
+	assert.Equal(t, 2, collector.cpuCalls)
+	assert.Equal(t, 2, collector.memoryCalls)
+	assert.Equal(t, 2, collector.diskCalls)
+}
+
+func TestPutMonitorConfigDoesNotWaitForInFlightSnapshotCollection(t *testing.T) {
+	collector := newBlockingHostCollector()
+	m := New(WithCollectors(Collectors{HostCollector: collector}))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{
+		Monitor: MonitorConfig{RefreshIntervalMS: 1000, TopProcessLimit: 10},
+	}})))
+
+	snapshotDone := make(chan struct{})
+	go func() {
+		_ = requestSnapshotResult(m)
+		close(snapshotDone)
+	}()
+	collector.WaitForCPUCall(t, 1)
+
+	putDone := make(chan int, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPut, "/api/monitor/config", bytes.NewBufferString(`{"refresh_interval_ms":2000,"top_process_limit":7}`))
+		m.handleConfig(rec, req)
+		putDone <- rec.Code
+	}()
+
+	select {
+	case code := <-putDone:
+		assert.Equal(t, http.StatusOK, code)
+	case <-time.After(100 * time.Millisecond):
+		collector.ReleaseOne()
+		<-snapshotDone
+		t.Fatal("PUT /api/monitor/config should not wait for in-flight snapshot collection")
+	}
+
+	collector.ReleaseOne()
+	<-snapshotDone
+}
+
+func TestSnapshot_LeaderCancellationDoesNotCancelSharedInFlightSample(t *testing.T) {
+	collector := newBlockingHostCollector()
+	m := New(WithCollectors(Collectors{HostCollector: collector}))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{
+		Monitor: MonitorConfig{RefreshIntervalMS: 1000, TopProcessLimit: 10},
+	}})))
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := m.getSnapshot(leaderCtx)
+		leaderDone <- err
+	}()
+	collector.WaitForCPUCall(t, 1)
+	cancelLeader()
+
+	waiterDone := make(chan snapshotResult, 1)
+	go func() {
+		waiterDone <- requestSnapshotResult(m)
+	}()
+
+	collector.ReleaseOne()
+	require.NoError(t, <-leaderDone)
+	waiter := <-waiterDone
+	require.NoError(t, waiter.err)
+	require.Equal(t, http.StatusOK, waiter.statusCode)
+	assert.NotZero(t, waiter.response.SampledAt)
+	assert.Equal(t, 1, collector.cpuCalls)
+}
+
+func TestSnapshot_WaiterIgnoresStaleGenerationInFlightError(t *testing.T) {
+	provider := newBlockingFirstSessionProvider([]session.SessionInfo{{Code: "abc123", TmuxID: "$1", Name: "work"}})
+	m := New(WithCollectors(Collectors{
+		HostCollector:         newFakeHostCollector(),
+		TmuxPaneLister:        &fakeSnapshotTmuxPaneLister{panes: []TmuxPane{{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101}}},
+		ProcessTableCollector: &fakeSnapshotProcessCollector{processes: []Process{{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100}}},
+	}), withSessionProvider(provider))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{
+		Monitor: MonitorConfig{RefreshIntervalMS: 1000, TopProcessLimit: 10},
+	}})))
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := m.getSnapshot(context.Background())
+		leaderDone <- err
+	}()
+	provider.WaitForFirstCall(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/monitor/config", bytes.NewBufferString(`{"refresh_interval_ms":2000,"top_process_limit":7}`))
+	m.handleConfig(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	waiterDone := make(chan snapshotResult, 1)
+	go func() {
+		waiterDone <- requestSnapshotResult(m)
+	}()
+
+	provider.ReleaseFirst(errors.New("stale boom"))
+	require.Error(t, <-leaderDone)
+	waiter := <-waiterDone
+	require.NoError(t, waiter.err)
+	require.Equal(t, http.StatusOK, waiter.statusCode)
+	assert.Equal(t, 2, provider.Calls())
 }
 
 func TestSnapshot_UsesUpdatedRefreshIntervalForCacheFreshness(t *testing.T) {
@@ -370,6 +524,28 @@ type snapshotResponse struct {
 	Config    EffectiveConfig `json:"config"`
 }
 
+type snapshotResult struct {
+	response    snapshotResponse
+	statusCode  int
+	contentType string
+	err         error
+}
+
+func requestSnapshotResult(m *Module) snapshotResult {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/monitor/snapshot", nil).WithContext(context.Background())
+	m.handleSnapshot(rec, req)
+
+	var got snapshotResponse
+	err := json.NewDecoder(rec.Body).Decode(&got)
+	return snapshotResult{
+		response:    got,
+		statusCode:  rec.Code,
+		contentType: rec.Header().Get("Content-Type"),
+		err:         err,
+	}
+}
+
 func requestSnapshot(t *testing.T, m *Module) snapshotResponse {
 	t.Helper()
 
@@ -410,11 +586,69 @@ type fakeSessionProvider struct {
 	sessions []session.SessionInfo
 	err      error
 	calls    int
+	mu       sync.Mutex
 }
 
 func (p *fakeSessionProvider) ListSessions() ([]session.SessionInfo, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.calls++
 	return p.sessions, p.err
+}
+
+func (p *fakeSessionProvider) setError(err error) {
+	p.mu.Lock()
+	p.err = err
+	p.mu.Unlock()
+}
+
+type blockingFirstSessionProvider struct {
+	sessions     []session.SessionInfo
+	mu           sync.Mutex
+	calls        int
+	firstStarted chan struct{}
+	releaseFirst chan error
+}
+
+func newBlockingFirstSessionProvider(sessions []session.SessionInfo) *blockingFirstSessionProvider {
+	return &blockingFirstSessionProvider{
+		sessions:     sessions,
+		firstStarted: make(chan struct{}),
+		releaseFirst: make(chan error, 1),
+	}
+}
+
+func (p *blockingFirstSessionProvider) ListSessions() ([]session.SessionInfo, error) {
+	p.mu.Lock()
+	p.calls++
+	call := p.calls
+	p.mu.Unlock()
+	if call == 1 {
+		close(p.firstStarted)
+		if err := <-p.releaseFirst; err != nil {
+			return nil, err
+		}
+	}
+	return p.sessions, nil
+}
+
+func (p *blockingFirstSessionProvider) WaitForFirstCall(t *testing.T) {
+	t.Helper()
+	select {
+	case <-p.firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first ListSessions call did not start")
+	}
+}
+
+func (p *blockingFirstSessionProvider) ReleaseFirst(err error) {
+	p.releaseFirst <- err
+}
+
+func (p *blockingFirstSessionProvider) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
 }
 
 type fakeSnapshotTmuxPaneLister struct {
@@ -477,4 +711,66 @@ func assertRawSessionDaemonNullFields(t *testing.T, raw json.RawMessage, index i
 	topProcesses, exists := daemon["top_processes"]
 	assert.True(t, exists, "top_processes should be present")
 	assert.Empty(t, topProcesses, "top_processes should be an empty array")
+}
+
+type blockingHostCollector struct {
+	mu          sync.Mutex
+	cpuCalls    int
+	memoryCalls int
+	diskCalls   int
+	cpuCalled   chan int
+	releaseCPU  chan struct{}
+}
+
+func newBlockingHostCollector() *blockingHostCollector {
+	return &blockingHostCollector{
+		cpuCalled:  make(chan int, 10),
+		releaseCPU: make(chan struct{}, 10),
+	}
+}
+
+func (c *blockingHostCollector) CollectCPU(context.Context) (HostCPUSample, error) {
+	c.mu.Lock()
+	c.cpuCalls++
+	call := c.cpuCalls
+	c.mu.Unlock()
+	c.cpuCalled <- call
+	<-c.releaseCPU
+	return HostCPUSample{Idle: uint64(100 - call), Total: uint64(100 + call)}, nil
+}
+
+func (c *blockingHostCollector) CollectMemory(context.Context) (HostMemorySample, error) {
+	c.mu.Lock()
+	c.memoryCalls++
+	c.mu.Unlock()
+	return HostMemorySample{TotalBytes: 1, UsedBytes: 0}, nil
+}
+
+func (c *blockingHostCollector) CollectDisk(context.Context) (HostDiskSample, error) {
+	c.mu.Lock()
+	c.diskCalls++
+	c.mu.Unlock()
+	return HostDiskSample{TotalBytes: 1, UsedBytes: 0}, nil
+}
+
+func (c *blockingHostCollector) WaitForCPUCall(t *testing.T, calls int) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case call := <-c.cpuCalled:
+			if call >= calls {
+				return
+			}
+		case <-deadline:
+			c.mu.Lock()
+			actual := c.cpuCalls
+			c.mu.Unlock()
+			require.GreaterOrEqual(t, actual, calls)
+		}
+	}
+}
+
+func (c *blockingHostCollector) ReleaseOne() {
+	c.releaseCPU <- struct{}{}
 }


### PR DESCRIPTION
## Summary
- Add single-flight coordination for stale monitor snapshot collection so concurrent requests share one in-flight sample.
- Move expensive snapshot collection outside the snapshot state lock so config updates are not blocked by collectors.
- Guard cache writes with a snapshot generation so invalidated in-flight results do not repopulate stale cache.

## Verification
- `go test ./cmd/pdx ./internal/config ./internal/module/session ./internal/module/monitor -count=1`
- `make test`
- Subagent review to convergence, no remaining findings.

## Scope
This PR intentionally does not add SPA UI, daemon CPU delta, or a broader API redesign. It is the daemon single-flight sampling slice after alpha.261.