### PR TITLE
feat(monitor): stabilize API contract fields

### DIFF
--- a/internal/module/monitor/api_contract_test.go
+++ b/internal/module/monitor/api_contract_test.go
@@ -1,0 +1,145 @@
+package monitor
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wake/purdex/internal/config"
+	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/session"
+)
+
+func TestSnapshotHandlerContract_ReturnsStableJSONFieldsAndUnits(t *testing.T) {
+	clock := newFakeClock(time.Unix(100, 123000000))
+	hostCollector := newFakeHostCollector()
+	hostCollector.cpuSamples = []HostCPUSample{{Idle: 80, Total: 100}, {Idle: 90, Total: 150}}
+	hostCollector.memory = HostMemorySample{TotalBytes: 1024, UsedBytes: 256}
+	hostCollector.disk = HostDiskSample{TotalBytes: 4096, UsedBytes: 1024}
+	m := New(WithCollectors(Collectors{
+		HostCollector: hostCollector,
+		TmuxPaneLister: &fakeSnapshotTmuxPaneLister{panes: []TmuxPane{
+			{TmuxSessionID: "$1", TmuxSessionName: "work", PaneID: "%1", PanePID: 101},
+		}},
+		ProcessTableCollector: &fakeSnapshotProcessCollector{processes: []Process{
+			{PID: 101, PPID: 1, Command: "shell", CPUPercent: 2.5, MemoryBytes: 2048},
+		}},
+	}), withClock(clock.Now), withSessionProvider(&fakeSessionProvider{sessions: []session.SessionInfo{
+		{Code: "abc123", TmuxID: "$1", Name: "work"},
+	}}))
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: &config.Config{
+		Monitor: MonitorConfig{RefreshIntervalMS: 2000, TopProcessLimit: 5},
+	}})))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/monitor/snapshot", nil)
+	m.handleSnapshot(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var first map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&first))
+	assert.Equal(t, float64(clock.Now().UnixMilli()), first["sampled_at"])
+	firstHost := requireMap(t, first["host"])
+	firstCPU := requireMap(t, firstHost["cpu"])
+	assert.Nil(t, firstCPU["percent"])
+	assert.Equal(t, "pending", firstCPU["unavailable_reason"])
+
+	clock.Advance(2 * time.Second)
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/monitor/snapshot", nil)
+	m.handleSnapshot(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, float64(clock.Now().UnixMilli()), got["sampled_at"])
+
+	host := requireMap(t, got["host"])
+	cpu := requireMap(t, host["cpu"])
+	assert.Equal(t, float64(80), cpu["percent"])
+	assertPresentNil(t, cpu, "unavailable_reason")
+	memory := requireMap(t, host["memory"])
+	assert.Equal(t, float64(1024), memory["total_bytes"])
+	assert.Equal(t, float64(256), memory["used_bytes"])
+	assert.Equal(t, float64(25), memory["used_percent"])
+	assertPresentNil(t, memory, "unavailable_reason")
+	disk := requireMap(t, host["disk"])
+	assert.Equal(t, float64(4096), disk["total_bytes"])
+	assert.Equal(t, float64(1024), disk["used_bytes"])
+	assert.Equal(t, float64(25), disk["used_percent"])
+	assertPresentNil(t, disk, "unavailable_reason")
+
+	sessions, ok := got["sessions"].([]any)
+	require.True(t, ok)
+	require.Len(t, sessions, 1)
+	sessionMetric := requireMap(t, sessions[0])
+	assert.Equal(t, "abc123", sessionMetric["session_code"])
+	tmuxSession := requireMap(t, sessionMetric["tmux_session"])
+	assert.Equal(t, "$1", tmuxSession["id"])
+	assert.Equal(t, "work", tmuxSession["name"])
+	daemon := requireMap(t, sessionMetric["daemon"])
+	assert.Equal(t, float64(2.5), daemon["cpu_percent"])
+	assert.Equal(t, float64(2048), daemon["memory_bytes"])
+	assert.Equal(t, float64(1), daemon["process_count"])
+	assertPresentNil(t, daemon, "unavailable_reason")
+	topProcesses, ok := daemon["top_processes"].([]any)
+	require.True(t, ok)
+	require.Len(t, topProcesses, 1)
+	topProcess := requireMap(t, topProcesses[0])
+	assert.Equal(t, float64(101), topProcess["pid"])
+	assert.Equal(t, float64(1), topProcess["ppid"])
+	assert.Equal(t, "shell", topProcess["command"])
+	assert.Equal(t, float64(2.5), topProcess["cpu_percent"])
+	assert.Equal(t, float64(2048), topProcess["memory_bytes"])
+
+	config := requireMap(t, got["config"])
+	assert.Equal(t, float64(2000), config["refresh_interval_ms"])
+	assert.Equal(t, float64(5), config["top_process_limit"])
+	bounds := requireMap(t, config["bounds"])
+	refreshBounds := requireMap(t, bounds["refresh_interval_ms"])
+	assert.Equal(t, float64(1000), refreshBounds["min"])
+	assert.Equal(t, float64(60000), refreshBounds["max"])
+	topProcessBounds := requireMap(t, bounds["top_process_limit"])
+	assert.Equal(t, float64(1), topProcessBounds["min"])
+	assert.Equal(t, float64(50), topProcessBounds["max"])
+}
+
+func TestConfigHandlerContract_PartialPutClampsAndPreservesExistingValues(t *testing.T) {
+	cfg := &config.Config{Monitor: MonitorConfig{RefreshIntervalMS: 3000, TopProcessLimit: 7}}
+	m := New()
+	require.NoError(t, m.Init(core.New(core.CoreDeps{Config: cfg})))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/monitor/config", bytes.NewBufferString(`{"top_process_limit":999}`))
+	m.handleConfig(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got EffectiveConfig
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, 3000, got.RefreshIntervalMS)
+	assert.Equal(t, 50, got.TopProcessLimit)
+	assert.Equal(t, 3000, cfg.Monitor.RefreshIntervalMS)
+	assert.Equal(t, 50, cfg.Monitor.TopProcessLimit)
+}
+
+func requireMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	got, ok := value.(map[string]any)
+	require.True(t, ok)
+	return got
+}
+
+func assertPresentNil(t *testing.T, values map[string]any, key string) {
+	t.Helper()
+	value, ok := values[key]
+	require.True(t, ok, "%s should be present", key)
+	assert.Nil(t, value)
+}

--- a/internal/module/monitor/host.go
+++ b/internal/module/monitor/host.go
@@ -38,21 +38,21 @@ type HostMetrics struct {
 
 type HostCPUMetrics struct {
 	Percent           *float64 `json:"percent"`
-	UnavailableReason string   `json:"unavailable_reason,omitempty"`
+	UnavailableReason *string  `json:"unavailable_reason"`
 }
 
 type HostMemoryMetrics struct {
 	TotalBytes        *uint64  `json:"total_bytes"`
 	UsedBytes         *uint64  `json:"used_bytes"`
 	UsedPercent       *float64 `json:"used_percent"`
-	UnavailableReason string   `json:"unavailable_reason,omitempty"`
+	UnavailableReason *string  `json:"unavailable_reason"`
 }
 
 type HostDiskMetrics struct {
 	TotalBytes        *uint64  `json:"total_bytes"`
 	UsedBytes         *uint64  `json:"used_bytes"`
 	UsedPercent       *float64 `json:"used_percent"`
-	UnavailableReason string   `json:"unavailable_reason,omitempty"`
+	UnavailableReason *string  `json:"unavailable_reason"`
 }
 
 type HostMetricsState struct {
@@ -67,9 +67,9 @@ func NewHostMetricsState(collector HostCollector) *HostMetricsState {
 func collectHostMetrics(ctx context.Context, state *HostMetricsState) HostMetrics {
 	if state == nil || state.collector == nil {
 		return HostMetrics{
-			CPU:    &HostCPUMetrics{UnavailableReason: hostCPUUnavailableReason},
-			Memory: &HostMemoryMetrics{UnavailableReason: hostMemoryUnavailableReason},
-			Disk:   &HostDiskMetrics{UnavailableReason: hostDiskUnavailableReason},
+			CPU:    &HostCPUMetrics{UnavailableReason: reasonPtr(hostCPUUnavailableReason)},
+			Memory: &HostMemoryMetrics{UnavailableReason: reasonPtr(hostMemoryUnavailableReason)},
+			Disk:   &HostDiskMetrics{UnavailableReason: reasonPtr(hostDiskUnavailableReason)},
 		}
 	}
 
@@ -83,18 +83,18 @@ func collectHostMetrics(ctx context.Context, state *HostMetricsState) HostMetric
 func collectHostCPU(ctx context.Context, state *HostMetricsState) *HostCPUMetrics {
 	sample, err := state.collector.CollectCPU(ctx)
 	if err != nil {
-		return &HostCPUMetrics{UnavailableReason: hostCPUUnavailableReason}
+		return &HostCPUMetrics{UnavailableReason: reasonPtr(hostCPUUnavailableReason)}
 	}
 
 	if state.previous == nil {
 		state.previous = &sample
-		return &HostCPUMetrics{UnavailableReason: hostCPUPendingReason}
+		return &HostCPUMetrics{UnavailableReason: reasonPtr(hostCPUPendingReason)}
 	}
 
 	percent := hostCPUPercent(*state.previous, sample)
 	state.previous = &sample
 	if percent == nil {
-		return &HostCPUMetrics{UnavailableReason: hostCPUPendingReason}
+		return &HostCPUMetrics{UnavailableReason: reasonPtr(hostCPUPendingReason)}
 	}
 	return &HostCPUMetrics{Percent: percent}
 }
@@ -102,7 +102,7 @@ func collectHostCPU(ctx context.Context, state *HostMetricsState) *HostCPUMetric
 func collectHostMemory(ctx context.Context, collector HostCollector) *HostMemoryMetrics {
 	sample, err := collector.CollectMemory(ctx)
 	if err != nil {
-		return &HostMemoryMetrics{UnavailableReason: hostMemoryUnavailableReason}
+		return &HostMemoryMetrics{UnavailableReason: reasonPtr(hostMemoryUnavailableReason)}
 	}
 	usedPercent := usedPercent(sample.UsedBytes, sample.TotalBytes)
 	return &HostMemoryMetrics{
@@ -115,7 +115,7 @@ func collectHostMemory(ctx context.Context, collector HostCollector) *HostMemory
 func collectHostDisk(ctx context.Context, collector HostCollector) *HostDiskMetrics {
 	sample, err := collector.CollectDisk(ctx)
 	if err != nil {
-		return &HostDiskMetrics{UnavailableReason: hostDiskUnavailableReason}
+		return &HostDiskMetrics{UnavailableReason: reasonPtr(hostDiskUnavailableReason)}
 	}
 	usedPercent := usedPercent(sample.UsedBytes, sample.TotalBytes)
 	return &HostDiskMetrics{

--- a/internal/module/monitor/host_test.go
+++ b/internal/module/monitor/host_test.go
@@ -21,7 +21,8 @@ func TestHost_FirstCPUSampleIsPendingWhileMemoryAndDiskArePresent(t *testing.T) 
 
 	require.NotNil(t, host.CPU)
 	assert.Nil(t, host.CPU.Percent)
-	assert.Equal(t, "pending", host.CPU.UnavailableReason)
+	require.NotNil(t, host.CPU.UnavailableReason)
+	assert.Equal(t, "pending", *host.CPU.UnavailableReason)
 	require.NotNil(t, host.Memory)
 	assert.Equal(t, uint64(1000), *host.Memory.TotalBytes)
 	assert.Equal(t, uint64(250), *host.Memory.UsedBytes)
@@ -46,7 +47,7 @@ func TestHost_SecondCPUSampleComputesPercentFromDeltas(t *testing.T) {
 	require.Nil(t, first.CPU.Percent)
 	require.NotNil(t, second.CPU.Percent)
 	assert.Equal(t, 80.0, *second.CPU.Percent)
-	assert.Empty(t, second.CPU.UnavailableReason)
+	assert.Nil(t, second.CPU.UnavailableReason)
 }
 
 func TestHost_MemoryCollectorReturnsBytesAndPercent(t *testing.T) {
@@ -86,14 +87,17 @@ func TestHost_PartialCollectorFailureReturnsStableUnavailableReasons(t *testing.
 
 	require.NotNil(t, host.CPU)
 	assert.Nil(t, host.CPU.Percent)
-	assert.Equal(t, "host_cpu_unavailable", host.CPU.UnavailableReason)
+	require.NotNil(t, host.CPU.UnavailableReason)
+	assert.Equal(t, "host_cpu_unavailable", *host.CPU.UnavailableReason)
 	require.NotNil(t, host.Memory)
-	assert.Equal(t, "host_memory_unavailable", host.Memory.UnavailableReason)
+	require.NotNil(t, host.Memory.UnavailableReason)
+	assert.Equal(t, "host_memory_unavailable", *host.Memory.UnavailableReason)
 	assert.Nil(t, host.Memory.TotalBytes)
 	assert.Nil(t, host.Memory.UsedBytes)
 	assert.Nil(t, host.Memory.UsedPercent)
 	require.NotNil(t, host.Disk)
-	assert.Equal(t, "host_disk_unavailable", host.Disk.UnavailableReason)
+	require.NotNil(t, host.Disk.UnavailableReason)
+	assert.Equal(t, "host_disk_unavailable", *host.Disk.UnavailableReason)
 	assert.Nil(t, host.Disk.TotalBytes)
 	assert.Nil(t, host.Disk.UsedBytes)
 	assert.Nil(t, host.Disk.UsedPercent)
@@ -123,14 +127,16 @@ func TestHost_PartialCollectorFailureKeepsAvailableMetrics(t *testing.T) {
 	host := collectHostMetrics(context.Background(), state)
 
 	require.NotNil(t, host.CPU)
-	assert.Equal(t, "host_cpu_unavailable", host.CPU.UnavailableReason)
+	require.NotNil(t, host.CPU.UnavailableReason)
+	assert.Equal(t, "host_cpu_unavailable", *host.CPU.UnavailableReason)
 	require.NotNil(t, host.Memory)
 	assert.Equal(t, uint64(1000), *host.Memory.TotalBytes)
 	assert.Equal(t, uint64(400), *host.Memory.UsedBytes)
 	assert.Equal(t, 40.0, *host.Memory.UsedPercent)
-	assert.Empty(t, host.Memory.UnavailableReason)
+	assert.Nil(t, host.Memory.UnavailableReason)
 	require.NotNil(t, host.Disk)
-	assert.Equal(t, "host_disk_unavailable", host.Disk.UnavailableReason)
+	require.NotNil(t, host.Disk.UnavailableReason)
+	assert.Equal(t, "host_disk_unavailable", *host.Disk.UnavailableReason)
 }
 
 type fakeHostCollector struct {

--- a/internal/module/monitor/module.go
+++ b/internal/module/monitor/module.go
@@ -167,7 +167,7 @@ type SessionDaemonMetrics struct {
 	MemoryBytes       *uint64   `json:"memory_bytes"`
 	ProcessCount      *int      `json:"process_count"`
 	TopProcesses      []Process `json:"top_processes"`
-	UnavailableReason string    `json:"unavailable_reason,omitempty"`
+	UnavailableReason *string   `json:"unavailable_reason"`
 }
 
 func (m *Module) getSnapshot(ctx context.Context) (*snapshot, error) {
@@ -357,8 +357,12 @@ func unavailableSessionMetric(sess session.SessionInfo, reason string) SessionMe
 			ID:   sess.TmuxID,
 			Name: sess.Name,
 		},
-		Daemon: SessionDaemonMetrics{TopProcesses: []Process{}, UnavailableReason: reason},
+		Daemon: SessionDaemonMetrics{TopProcesses: []Process{}, UnavailableReason: reasonPtr(reason)},
 	}
+}
+
+func reasonPtr(reason string) *string {
+	return &reason
 }
 
 func availableSessionDaemonMetrics(aggregate PaneProcessAggregate) SessionDaemonMetrics {

--- a/internal/module/monitor/snapshot_test.go
+++ b/internal/module/monitor/snapshot_test.go
@@ -271,7 +271,8 @@ func TestSnapshot_IncludesHostMetrics(t *testing.T) {
 	require.NoError(t, json.Unmarshal(snapshot.Host, &host))
 	require.NotNil(t, host.CPU)
 	assert.Nil(t, host.CPU.Percent)
-	assert.Equal(t, "pending", host.CPU.UnavailableReason)
+	require.NotNil(t, host.CPU.UnavailableReason)
+	assert.Equal(t, "pending", *host.CPU.UnavailableReason)
 	require.NotNil(t, host.Memory)
 	assert.Equal(t, uint64(1000), *host.Memory.TotalBytes)
 	require.NotNil(t, host.Disk)
@@ -316,7 +317,7 @@ func TestSnapshot_IncludesPurdexSessionProcessTotals(t *testing.T) {
 		{PID: 201, PPID: 101, Command: "worker", CPUPercent: 2, MemoryBytes: 200},
 		{PID: 101, PPID: 1, Command: "shell", CPUPercent: 1, MemoryBytes: 100},
 	}, sessions[0].Daemon.TopProcesses)
-	assert.Empty(t, sessions[0].Daemon.UnavailableReason)
+	assert.Nil(t, sessions[0].Daemon.UnavailableReason)
 	assert.Equal(t, 1, tmuxLister.calls)
 	assert.Equal(t, 1, processCollector.calls)
 }
@@ -685,13 +686,16 @@ func assertSessionDaemonUnavailable(t *testing.T, daemon SessionDaemonMetrics, r
 	assert.Nil(t, daemon.MemoryBytes)
 	assert.Nil(t, daemon.ProcessCount)
 	assert.Empty(t, daemon.TopProcesses)
-	assert.Equal(t, reason, daemon.UnavailableReason)
+	require.NotNil(t, daemon.UnavailableReason)
+	assert.Equal(t, reason, *daemon.UnavailableReason)
 }
 
 func sessionUnavailableReasonsByCode(sessions []SessionMetrics) map[string]string {
 	reasons := make(map[string]string, len(sessions))
 	for _, sess := range sessions {
-		reasons[sess.SessionCode] = sess.Daemon.UnavailableReason
+		if sess.Daemon.UnavailableReason != nil {
+			reasons[sess.SessionCode] = *sess.Daemon.UnavailableReason
+		}
 	}
 	return reasons
 }


### PR DESCRIPTION
## Summary
- Add handler-level monitor API contract coverage for snapshot JSON shape, units, timestamps, config bounds, and partial config updates.
- Serialize host and session daemon `unavailable_reason` as stable nullable fields so available metrics return `null` instead of omitting the key.

## Verification
- `go test ./internal/module/monitor -count=1`
- `go test ./cmd/pdx ./internal/config ./internal/module/session ./internal/module/monitor -count=1`
- `go test -race ./internal/agent/probe -count=1`
- `make test` (first run hit transient `internal/agent/probe` timing failure; package rerun and full rerun passed)

## Reviews
- Subagent review round 1: findings addressed
- Subagent review round 2: findings addressed
- Subagent final review: no findings