### PR TITLE
feat(spa): add monitor host API helpers

### DIFF
--- a/spa/src/lib/host-api.test.ts
+++ b/spa/src/lib/host-api.test.ts
@@ -5,7 +5,8 @@ import {
   listSessions, createSession, deleteSession, switchMode,
   handoff, fetchHistory, fetchSessionCwd, fetchSessionHome, getConfig, updateConfig, agentUpload,
   fetchAgentMonitorChains, fetchAgentMonitorChain, fetchAgentMonitorProjection,
-  type Session,
+  fetchMonitorSnapshot, fetchMonitorConfig, updateMonitorConfig,
+  type MonitorSnapshot, type Session,
 } from './host-api'
 
 const HOST_ID = 'test-host'
@@ -306,6 +307,94 @@ describe('agent monitor api', () => {
 
     await expect(fetchAgentMonitorProjection(HOST_ID, new URLSearchParams({ pane: '%7' })))
       .rejects.toThrow('fetchAgentMonitorProjection failed: 500')
+  })
+})
+
+describe('monitor api', () => {
+  const monitorSnapshot: MonitorSnapshot = {
+    sampled_at: 180000,
+    host: {
+      cpu: { percent: null, unavailable_reason: 'pending' },
+      memory: { total_bytes: 1024, used_bytes: 256, used_percent: 25, unavailable_reason: null },
+      disk: { total_bytes: 4096, used_bytes: 1024, used_percent: 25, unavailable_reason: null },
+    },
+    sessions: [
+      {
+        session_code: 'abc123',
+        tmux_session: { id: '$1', name: 'work' },
+        daemon: {
+          cpu_percent: null,
+          memory_bytes: 2048,
+          process_count: 2,
+          unavailable_reason: null,
+          top_processes: [
+            { pid: 101, ppid: 1, command: 'shell', cpu_percent: 1.5, memory_bytes: 1024 },
+          ],
+        },
+      },
+    ],
+    config: {
+      refresh_interval_ms: 5000,
+      top_process_limit: 10,
+      bounds: {
+        refresh_interval_ms: { min: 1000, max: 60000 },
+        top_process_limit: { min: 1, max: 50 },
+      },
+    },
+  }
+
+  it('fetches monitor snapshot with auth', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(monitorSnapshot), { status: 200 }),
+    )
+
+    const result = await fetchMonitorSnapshot(HOST_ID)
+
+    expect(result).toEqual(monitorSnapshot)
+    expectAuthFetch(`${BASE}/api/monitor/snapshot`)
+  })
+
+  it('throws when monitor snapshot request fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('error', { status: 503 }),
+    )
+
+    await expect(fetchMonitorSnapshot(HOST_ID)).rejects.toThrow('fetchMonitorSnapshot failed: 503')
+  })
+
+  it('fetches monitor config with auth', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(monitorSnapshot.config), { status: 200 }),
+    )
+
+    const result = await fetchMonitorConfig(HOST_ID)
+
+    expect(result).toEqual(monitorSnapshot.config)
+    expectAuthFetch(`${BASE}/api/monitor/config`)
+  })
+
+  it('updates monitor config with JSON body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ...monitorSnapshot.config, top_process_limit: 25 }), { status: 200 }),
+    )
+
+    const result = await updateMonitorConfig(HOST_ID, { top_process_limit: 25 })
+
+    expect(result.top_process_limit).toBe(25)
+    expectAuthFetch(`${BASE}/api/monitor/config`, { method: 'PUT' })
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect((call[1].headers as Headers).get('Content-Type')).toBe('application/json')
+    expect(JSON.parse(call[1].body)).toEqual({ top_process_limit: 25 })
+  })
+
+  it('throws when monitor config requests fail', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('error', { status: 500 }),
+    )
+
+    await expect(fetchMonitorConfig(HOST_ID)).rejects.toThrow('fetchMonitorConfig failed: 500')
+    await expect(updateMonitorConfig(HOST_ID, { refresh_interval_ms: 2000 }))
+      .rejects.toThrow('updateMonitorConfig failed: 500')
   })
 })
 

--- a/spa/src/lib/host-api.ts
+++ b/spa/src/lib/host-api.ts
@@ -215,6 +215,110 @@ export async function agentUpload(
   return res.json()
 }
 
+/* ─── Monitor API ─── */
+
+export interface MonitorMetricBounds {
+  min: number
+  max: number
+}
+
+export interface MonitorConfigBounds {
+  refresh_interval_ms: MonitorMetricBounds
+  top_process_limit: MonitorMetricBounds
+}
+
+export interface MonitorConfig {
+  refresh_interval_ms: number
+  top_process_limit: number
+  bounds: MonitorConfigBounds
+}
+
+export type MonitorConfigUpdate = Partial<Pick<MonitorConfig, 'refresh_interval_ms' | 'top_process_limit'>>
+
+export interface MonitorHostCPU {
+  percent: number | null
+  unavailable_reason: string | null
+}
+
+export interface MonitorHostMemory {
+  total_bytes: number | null
+  used_bytes: number | null
+  used_percent: number | null
+  unavailable_reason: string | null
+}
+
+export interface MonitorHostDisk {
+  total_bytes: number | null
+  used_bytes: number | null
+  used_percent: number | null
+  unavailable_reason: string | null
+}
+
+export interface MonitorHostMetrics {
+  cpu: MonitorHostCPU
+  memory: MonitorHostMemory
+  disk: MonitorHostDisk
+}
+
+export interface MonitorTopProcess {
+  pid: number
+  ppid: number
+  command: string
+  cpu_percent: number
+  memory_bytes: number
+}
+
+export interface MonitorTmuxSession {
+  id: string
+  name: string
+}
+
+export interface MonitorSessionDaemonMetrics {
+  cpu_percent: number | null
+  memory_bytes: number | null
+  process_count: number | null
+  top_processes: MonitorTopProcess[]
+  unavailable_reason: string | null
+}
+
+export interface MonitorSessionMetrics {
+  session_code: string
+  tmux_session: MonitorTmuxSession
+  daemon: MonitorSessionDaemonMetrics
+}
+
+export interface MonitorSnapshot {
+  sampled_at: number
+  host: MonitorHostMetrics
+  sessions: MonitorSessionMetrics[]
+  config: MonitorConfig
+}
+
+export async function fetchMonitorSnapshot(hostId: string): Promise<MonitorSnapshot> {
+  const res = await hostFetch(hostId, '/api/monitor/snapshot')
+  if (!res.ok) throw new Error(`fetchMonitorSnapshot failed: ${res.status}`)
+  return res.json()
+}
+
+export async function fetchMonitorConfig(hostId: string): Promise<MonitorConfig> {
+  const res = await hostFetch(hostId, '/api/monitor/config')
+  if (!res.ok) throw new Error(`fetchMonitorConfig failed: ${res.status}`)
+  return res.json()
+}
+
+export async function updateMonitorConfig(
+  hostId: string,
+  updates: MonitorConfigUpdate,
+): Promise<MonitorConfig> {
+  const res = await hostFetch(hostId, '/api/monitor/config', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  })
+  if (!res.ok) throw new Error(`updateMonitorConfig failed: ${res.status}`)
+  return res.json()
+}
+
 /* ─── Agent Monitor API ─── */
 
 export interface AgentMonitorChainSummary {


### PR DESCRIPTION
## Summary
- Add SPA monitor snapshot/config TypeScript types matching the daemon API contract.
- Add `fetchMonitorSnapshot`, `fetchMonitorConfig`, and `updateMonitorConfig` helpers through `hostFetch`.
- Cover monitor helper auth, non-OK errors, PUT JSON body, and nullable response typing in `host-api` tests.

## Verification
- `pnpm --prefix spa exec vitest run src/lib/host-api.test.ts`
- `pnpm --prefix spa run lint`
- `pnpm --prefix spa exec tsc -b`

## Reviews
- Subagent review round 1: no findings