### PR TITLE
feat(spa): fetch monitor rows per host

### DIFF
--- a/spa/src/components/MemoryMonitorPage.test.tsx
+++ b/spa/src/components/MemoryMonitorPage.test.tsx
@@ -296,7 +296,363 @@ describe('MemoryMonitorPage', () => {
     expect(within(sessionRow).getAllByText('Not wired')).toHaveLength(1)
   })
 
-  it('does not apply active-host daemon metrics to session panes from another host', async () => {
+  it('renders daemon metrics for session panes from their own host snapshots', async () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 },
+        'host-b': { id: 'host-b', name: 'Host B', ip: '100.64.0.2', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, 'host-b'],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+    useTabStore.setState({
+      tabs: {
+        'tab-a': tabWithLeaf('tab-a', 'pane-a', {
+          kind: 'tmux-session',
+          hostId: HOST_ID,
+          sessionCode: 'same-code',
+          mode: 'terminal',
+          cachedName: 'A',
+          tmuxInstance: 'main',
+        }),
+        'tab-b': tabWithLeaf('tab-b', 'pane-b', {
+          kind: 'tmux-session',
+          hostId: 'host-b',
+          sessionCode: 'same-code',
+          mode: 'terminal',
+          cachedName: 'B',
+          tmuxInstance: 'main',
+        }),
+      },
+      tabOrder: ['tab-a', 'tab-b'],
+      activeTabId: 'tab-a',
+      visitHistory: [],
+    })
+    vi.mocked(fetchMonitorSnapshot).mockImplementation(async (hostId) => ({
+      ...monitorSnapshot,
+      sessions: [{
+        session_code: 'same-code',
+        tmux_session: { id: hostId === HOST_ID ? '$1' : '$2', name: `pdx-${hostId}` },
+        daemon: {
+          cpu_percent: hostId === HOST_ID ? 12.3 : 45.6,
+          memory_bytes: hostId === HOST_ID ? 2048 : 4096,
+          process_count: hostId === HOST_ID ? 3 : 7,
+          top_processes: [],
+          unavailable_reason: null,
+        },
+      }],
+    }))
+
+    render(<MemoryMonitorPage />)
+
+    await waitFor(() => expect(fetchMonitorSnapshot).toHaveBeenCalledWith(HOST_ID))
+    await waitFor(() => expect(fetchMonitorSnapshot).toHaveBeenCalledWith('host-b'))
+
+    const hostARow = await screen.findByTestId('monitor-row-tab-a-pane-a')
+    expect(within(hostARow).getByText('CPU 12.3%')).toBeInTheDocument()
+    expect(within(hostARow).getByText('Memory 2 KB')).toBeInTheDocument()
+    expect(within(hostARow).getByText('3 processes')).toBeInTheDocument()
+
+    const hostBRow = await screen.findByTestId('monitor-row-tab-b-pane-b')
+    expect(within(hostBRow).getByText('CPU 45.6%')).toBeInTheDocument()
+    expect(within(hostBRow).getByText('Memory 4 KB')).toBeInTheDocument()
+    expect(within(hostBRow).getByText('7 processes')).toBeInTheDocument()
+  })
+
+  it('keeps active-host rows fresh when a secondary host snapshot fails', async () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 },
+        'host-b': { id: 'host-b', name: 'Host B', ip: '100.64.0.2', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, 'host-b'],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+    useTabStore.setState({
+      tabs: {
+        'tab-a': tabWithLeaf('tab-a', 'pane-a', {
+          kind: 'tmux-session',
+          hostId: HOST_ID,
+          sessionCode: 'active-code',
+          mode: 'terminal',
+          cachedName: 'A',
+          tmuxInstance: 'main',
+        }),
+        'tab-b': tabWithLeaf('tab-b', 'pane-b', {
+          kind: 'tmux-session',
+          hostId: 'host-b',
+          sessionCode: 'remote-code',
+          mode: 'terminal',
+          cachedName: 'B',
+          tmuxInstance: 'main',
+        }),
+      },
+      tabOrder: ['tab-a', 'tab-b'],
+      activeTabId: 'tab-a',
+      visitHistory: [],
+    })
+    vi.mocked(fetchMonitorSnapshot).mockImplementation(async (hostId) => {
+      if (hostId === 'host-b') throw new Error('remote snapshot failed')
+      return {
+        ...monitorSnapshot,
+        sessions: [{
+          session_code: 'active-code',
+          tmux_session: { id: '$1', name: 'pdx-active' },
+          daemon: {
+            cpu_percent: 12.3,
+            memory_bytes: 2048,
+            process_count: 3,
+            top_processes: [],
+            unavailable_reason: null,
+          },
+        }],
+      }
+    })
+
+    render(<MemoryMonitorPage />)
+
+    expect(await screen.findByText('Unable to load monitor data: host-b: remote snapshot failed')).toBeInTheDocument()
+    const hostARow = await screen.findByTestId('monitor-row-tab-a-pane-a')
+    expect(within(hostARow).getByText('CPU 12.3%')).toBeInTheDocument()
+    const hostBRow = await screen.findByTestId('monitor-row-tab-b-pane-b')
+    expect(within(hostBRow).getAllByText('Not wired')).toHaveLength(2)
+  })
+
+  it('renders active-host rows without waiting for a slow secondary host snapshot', async () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 },
+        'host-b': { id: 'host-b', name: 'Host B', ip: '100.64.0.2', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, 'host-b'],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+    useTabStore.setState({
+      tabs: {
+        'tab-a': tabWithLeaf('tab-a', 'pane-a', {
+          kind: 'tmux-session',
+          hostId: HOST_ID,
+          sessionCode: 'active-code',
+          mode: 'terminal',
+          cachedName: 'A',
+          tmuxInstance: 'main',
+        }),
+        'tab-b': tabWithLeaf('tab-b', 'pane-b', {
+          kind: 'tmux-session',
+          hostId: 'host-b',
+          sessionCode: 'remote-code',
+          mode: 'terminal',
+          cachedName: 'B',
+          tmuxInstance: 'main',
+        }),
+      },
+      tabOrder: ['tab-a', 'tab-b'],
+      activeTabId: 'tab-a',
+      visitHistory: [],
+    })
+    vi.mocked(fetchMonitorSnapshot).mockImplementation((hostId) => {
+      if (hostId === 'host-b') return new Promise<MonitorSnapshot>(() => {})
+      return Promise.resolve({
+        ...monitorSnapshot,
+        sessions: [{
+          session_code: 'active-code',
+          tmux_session: { id: '$1', name: 'pdx-active' },
+          daemon: {
+            cpu_percent: 12.3,
+            memory_bytes: 2048,
+            process_count: 3,
+            top_processes: [],
+            unavailable_reason: null,
+          },
+        }],
+      })
+    })
+
+    render(<MemoryMonitorPage />)
+
+    await waitFor(() => expect(fetchMonitorSnapshot).toHaveBeenCalledWith('host-b'))
+    const hostARow = await screen.findByTestId('monitor-row-tab-a-pane-a')
+    expect(within(hostARow).getByText('CPU 12.3%')).toBeInTheDocument()
+    const hostBRow = await screen.findByTestId('monitor-row-tab-b-pane-b')
+    expect(within(hostBRow).getAllByText('Not wired')).toHaveLength(2)
+  })
+
+  it('renders a fast secondary host row without waiting for another slow secondary host', async () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 },
+        'host-b': { id: 'host-b', name: 'Host B', ip: '100.64.0.2', port: 7860, order: 1 },
+        'host-c': { id: 'host-c', name: 'Host C', ip: '100.64.0.3', port: 7860, order: 2 },
+      },
+      hostOrder: [HOST_ID, 'host-b', 'host-c'],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+    useTabStore.setState({
+      tabs: {
+        'tab-a': tabWithLeaf('tab-a', 'pane-a', {
+          kind: 'tmux-session',
+          hostId: HOST_ID,
+          sessionCode: 'active-code',
+          mode: 'terminal',
+          cachedName: 'A',
+          tmuxInstance: 'main',
+        }),
+        'tab-b': tabWithLeaf('tab-b', 'pane-b', {
+          kind: 'tmux-session',
+          hostId: 'host-b',
+          sessionCode: 'fast-code',
+          mode: 'terminal',
+          cachedName: 'B',
+          tmuxInstance: 'main',
+        }),
+        'tab-c': tabWithLeaf('tab-c', 'pane-c', {
+          kind: 'tmux-session',
+          hostId: 'host-c',
+          sessionCode: 'slow-code',
+          mode: 'terminal',
+          cachedName: 'C',
+          tmuxInstance: 'main',
+        }),
+      },
+      tabOrder: ['tab-a', 'tab-b', 'tab-c'],
+      activeTabId: 'tab-a',
+      visitHistory: [],
+    })
+    vi.mocked(fetchMonitorSnapshot).mockImplementation((hostId) => {
+      if (hostId === 'host-c') return new Promise<MonitorSnapshot>(() => {})
+      return Promise.resolve({
+        ...monitorSnapshot,
+        sessions: hostId === 'host-b' ? [{
+          session_code: 'fast-code',
+          tmux_session: { id: '$2', name: 'pdx-fast' },
+          daemon: {
+            cpu_percent: 45.6,
+            memory_bytes: 4096,
+            process_count: 7,
+            top_processes: [],
+            unavailable_reason: null,
+          },
+        }] : [{
+          session_code: 'active-code',
+          tmux_session: { id: '$1', name: 'pdx-active' },
+          daemon: {
+            cpu_percent: 12.3,
+            memory_bytes: 2048,
+            process_count: 3,
+            top_processes: [],
+            unavailable_reason: null,
+          },
+        }],
+      })
+    })
+
+    render(<MemoryMonitorPage />)
+
+    await waitFor(() => expect(fetchMonitorSnapshot).toHaveBeenCalledWith('host-c'))
+    const hostBRow = await screen.findByTestId('monitor-row-tab-b-pane-b')
+    expect(within(hostBRow).getByText('CPU 45.6%')).toBeInTheDocument()
+    expect(within(hostBRow).getByText('Memory 4 KB')).toBeInTheDocument()
+    expect(within(hostBRow).getByText('7 processes')).toBeInTheDocument()
+    const hostCRow = await screen.findByTestId('monitor-row-tab-c-pane-c')
+    expect(within(hostCRow).getAllByText('Not wired')).toHaveLength(2)
+  })
+
+  it('preserves secondary host metrics across active-host refreshes while the next secondary request is pending', async () => {
+    const fastConfig = { ...monitorConfig, refresh_interval_ms: 10 }
+    vi.mocked(fetchMonitorConfig).mockResolvedValue(fastConfig)
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 },
+        'host-b': { id: 'host-b', name: 'Host B', ip: '100.64.0.2', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, 'host-b'],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+    useTabStore.setState({
+      tabs: {
+        'tab-a': tabWithLeaf('tab-a', 'pane-a', {
+          kind: 'tmux-session',
+          hostId: HOST_ID,
+          sessionCode: 'active-code',
+          mode: 'terminal',
+          cachedName: 'A',
+          tmuxInstance: 'main',
+        }),
+        'tab-b': tabWithLeaf('tab-b', 'pane-b', {
+          kind: 'tmux-session',
+          hostId: 'host-b',
+          sessionCode: 'remote-code',
+          mode: 'terminal',
+          cachedName: 'B',
+          tmuxInstance: 'main',
+        }),
+      },
+      tabOrder: ['tab-a', 'tab-b'],
+      activeTabId: 'tab-a',
+      visitHistory: [],
+    })
+    let hostBCalls = 0
+    vi.mocked(fetchMonitorSnapshot).mockImplementation((hostId) => {
+      if (hostId === 'host-b') {
+        hostBCalls += 1
+        if (hostBCalls > 1) return new Promise<MonitorSnapshot>(() => {})
+        return Promise.resolve({
+          ...monitorSnapshot,
+          sessions: [{
+            session_code: 'remote-code',
+            tmux_session: { id: '$2', name: 'pdx-remote' },
+            daemon: {
+              cpu_percent: 45.6,
+              memory_bytes: 4096,
+              process_count: 7,
+              top_processes: [],
+              unavailable_reason: null,
+            },
+          }],
+        })
+      }
+      return Promise.resolve({
+        ...monitorSnapshot,
+        sessions: [{
+          session_code: 'active-code',
+          tmux_session: { id: '$1', name: 'pdx-active' },
+          daemon: {
+            cpu_percent: 12.3,
+            memory_bytes: 2048,
+            process_count: 3,
+            top_processes: [],
+            unavailable_reason: null,
+          },
+        }],
+      })
+    })
+
+    render(<MemoryMonitorPage />)
+
+    const hostBRow = await screen.findByTestId('monitor-row-tab-b-pane-b')
+    expect(within(hostBRow).getByText('CPU 45.6%')).toBeInTheDocument()
+    await waitFor(() => {
+      const activeHostCalls = vi.mocked(fetchMonitorSnapshot).mock.calls.filter(([hostId]) => hostId === HOST_ID)
+      expect(activeHostCalls.length).toBeGreaterThanOrEqual(2)
+    })
+    expect(within(hostBRow).getByText('CPU 45.6%')).toBeInTheDocument()
+  })
+
+  it('does not apply active-host daemon metrics to session panes from another host snapshot', async () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 },
+        'host-b': { id: 'host-b', name: 'Host B', ip: '100.64.0.2', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, 'host-b'],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
     useTabStore.setState({
       tabs: {
         'tab-session': tabWithLeaf('tab-session', 'pane-session', {
@@ -312,9 +668,9 @@ describe('MemoryMonitorPage', () => {
       activeTabId: 'tab-session',
       visitHistory: [],
     })
-    vi.mocked(fetchMonitorSnapshot).mockResolvedValue({
+    vi.mocked(fetchMonitorSnapshot).mockImplementation(async (hostId) => ({
       ...monitorSnapshot,
-      sessions: [{
+      sessions: hostId === HOST_ID ? [{
         session_code: 'abc123',
         tmux_session: { id: '$1', name: 'pdx-abc123' },
         daemon: {
@@ -324,13 +680,227 @@ describe('MemoryMonitorPage', () => {
           top_processes: [],
           unavailable_reason: null,
         },
-      }],
+      }] : [],
+    }))
+
+    render(<MemoryMonitorPage />)
+
+    await waitFor(() => expect(fetchMonitorSnapshot).toHaveBeenCalledWith('host-b'))
+    const sessionRow = await screen.findByTestId('monitor-row-tab-session-pane-session')
+    expect(within(sessionRow).queryByText('CPU 12.3%')).not.toBeInTheDocument()
+    expect(within(sessionRow).getAllByText('Not wired')).toHaveLength(2)
+  })
+
+  it('does not fetch a fallback snapshot for panes with missing host records', async () => {
+    useTabStore.setState({
+      tabs: {
+        'tab-session': tabWithLeaf('tab-session', 'pane-session', {
+          kind: 'tmux-session',
+          hostId: 'missing-host',
+          sessionCode: 'abc123',
+          mode: 'terminal',
+          cachedName: 'Missing Host',
+          tmuxInstance: 'main',
+        }),
+      },
+      tabOrder: ['tab-session'],
+      activeTabId: 'tab-session',
+      visitHistory: [],
+    })
+
+    render(<MemoryMonitorPage />)
+
+    await waitFor(() => expect(fetchMonitorSnapshot).toHaveBeenCalledWith(HOST_ID))
+    expect(fetchMonitorSnapshot).not.toHaveBeenCalledWith('missing-host')
+    const sessionRow = await screen.findByTestId('monitor-row-tab-session-pane-session')
+    expect(within(sessionRow).getAllByText('Not wired')).toHaveLength(2)
+  })
+
+  it('stops rendering cached daemon metrics after a pane host record is removed', async () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 },
+        'host-b': { id: 'host-b', name: 'Host B', ip: '100.64.0.2', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, 'host-b'],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+    useTabStore.setState({
+      tabs: {
+        'tab-session': tabWithLeaf('tab-session', 'pane-session', {
+          kind: 'tmux-session',
+          hostId: 'host-b',
+          sessionCode: 'remote-code',
+          mode: 'terminal',
+          cachedName: 'Remote Work',
+          tmuxInstance: 'main',
+        }),
+      },
+      tabOrder: ['tab-session'],
+      activeTabId: 'tab-session',
+      visitHistory: [],
+    })
+    vi.mocked(fetchMonitorSnapshot).mockImplementation(async (hostId) => ({
+      ...monitorSnapshot,
+      sessions: hostId === 'host-b' ? [{
+        session_code: 'remote-code',
+        tmux_session: { id: '$2', name: 'pdx-remote' },
+        daemon: {
+          cpu_percent: 45.6,
+          memory_bytes: 4096,
+          process_count: 7,
+          top_processes: [],
+          unavailable_reason: null,
+        },
+      }] : [],
+    }))
+
+    render(<MemoryMonitorPage />)
+
+    const sessionRow = await screen.findByTestId('monitor-row-tab-session-pane-session')
+    expect(within(sessionRow).getByText('CPU 45.6%')).toBeInTheDocument()
+
+    useHostStore.setState({
+      hosts: { [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 } },
+      hostOrder: [HOST_ID],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+
+    await waitFor(() => expect(within(sessionRow).queryByText('CPU 45.6%')).not.toBeInTheDocument())
+    expect(within(sessionRow).queryByText('Memory 4 KB')).not.toBeInTheDocument()
+    expect(within(sessionRow).queryByText('7 processes')).not.toBeInTheDocument()
+    expect(within(sessionRow).getAllByText('Not wired').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('stops rendering cached daemon metrics after a pane host endpoint changes', async () => {
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 },
+        'host-b': { id: 'host-b', name: 'Host B', ip: '100.64.0.2', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, 'host-b'],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+    useTabStore.setState({
+      tabs: {
+        'tab-session': tabWithLeaf('tab-session', 'pane-session', {
+          kind: 'tmux-session',
+          hostId: 'host-b',
+          sessionCode: 'remote-code',
+          mode: 'terminal',
+          cachedName: 'Remote Work',
+          tmuxInstance: 'main',
+        }),
+      },
+      tabOrder: ['tab-session'],
+      activeTabId: 'tab-session',
+      visitHistory: [],
+    })
+    let hostBCalls = 0
+    vi.mocked(fetchMonitorSnapshot).mockImplementation((hostId) => {
+      if (hostId === 'host-b') {
+        hostBCalls += 1
+        if (hostBCalls > 1) return new Promise<MonitorSnapshot>(() => {})
+        return Promise.resolve({
+          ...monitorSnapshot,
+          sessions: [{
+            session_code: 'remote-code',
+            tmux_session: { id: '$2', name: 'pdx-remote' },
+            daemon: {
+              cpu_percent: 45.6,
+              memory_bytes: 4096,
+              process_count: 7,
+              top_processes: [],
+              unavailable_reason: null,
+            },
+          }],
+        })
+      }
+      return Promise.resolve({ ...monitorSnapshot, sessions: [] })
     })
 
     render(<MemoryMonitorPage />)
 
     const sessionRow = await screen.findByTestId('monitor-row-tab-session-pane-session')
-    expect(within(sessionRow).queryByText('CPU 12.3%')).not.toBeInTheDocument()
+    expect(within(sessionRow).getByText('CPU 45.6%')).toBeInTheDocument()
+
+    useHostStore.setState({
+      hosts: {
+        [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.1', port: 7860, order: 0 },
+        'host-b': { id: 'host-b', name: 'Host B', ip: '100.64.0.22', port: 7860, order: 1 },
+      },
+      hostOrder: [HOST_ID, 'host-b'],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+
+    await waitFor(() => expect(within(sessionRow).queryByText('CPU 45.6%')).not.toBeInTheDocument())
+    expect(within(sessionRow).queryByText('Memory 4 KB')).not.toBeInTheDocument()
+    expect(within(sessionRow).queryByText('7 processes')).not.toBeInTheDocument()
+    expect(within(sessionRow).getAllByText('Not wired').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('stops rendering cached active-host metrics after the active host endpoint changes', async () => {
+    useTabStore.setState({
+      tabs: {
+        'tab-session': tabWithLeaf('tab-session', 'pane-session', {
+          kind: 'tmux-session',
+          hostId: HOST_ID,
+          sessionCode: 'active-code',
+          mode: 'terminal',
+          cachedName: 'Active Work',
+          tmuxInstance: 'main',
+        }),
+      },
+      tabOrder: ['tab-session'],
+      activeTabId: 'tab-session',
+      visitHistory: [],
+    })
+    let activeCalls = 0
+    vi.mocked(fetchMonitorSnapshot).mockImplementation((hostId) => {
+      if (hostId === HOST_ID) {
+        activeCalls += 1
+        if (activeCalls > 1) return new Promise<MonitorSnapshot>(() => {})
+        return Promise.resolve({
+          ...monitorSnapshot,
+          host: {
+            ...monitorSnapshot.host,
+            cpu: { percent: 12.3, unavailable_reason: null },
+          },
+          sessions: [{
+            session_code: 'active-code',
+            tmux_session: { id: '$1', name: 'pdx-active' },
+            daemon: {
+              cpu_percent: 45.6,
+              memory_bytes: 4096,
+              process_count: 7,
+              top_processes: [],
+              unavailable_reason: null,
+            },
+          }],
+        })
+      }
+      return Promise.resolve({ ...monitorSnapshot, sessions: [] })
+    })
+
+    render(<MemoryMonitorPage />)
+
+    const sessionRow = await screen.findByTestId('monitor-row-tab-session-pane-session')
+    expect(within(sessionRow).getByText('CPU 45.6%')).toBeInTheDocument()
+    expect(screen.getByText('12.3%')).toBeInTheDocument()
+
+    useHostStore.setState({
+      hosts: { [HOST_ID]: { id: HOST_ID, name: 'Host A', ip: '100.64.0.22', port: 7860, order: 0 } },
+      hostOrder: [HOST_ID],
+      activeHostId: HOST_ID,
+      runtime: {},
+    })
+
+    await waitFor(() => expect(within(sessionRow).queryByText('CPU 45.6%')).not.toBeInTheDocument())
+    expect(screen.queryByText('12.3%')).not.toBeInTheDocument()
     expect(within(sessionRow).getAllByText('Not wired')).toHaveLength(2)
   })
 

--- a/spa/src/components/MemoryMonitorPage.tsx
+++ b/spa/src/components/MemoryMonitorPage.tsx
@@ -9,7 +9,7 @@ import {
   type MonitorSessionDaemonMetrics,
   type MonitorSnapshot,
 } from '../lib/host-api'
-import { useHostStore } from '../stores/useHostStore'
+import { useHostStore, type HostConfig } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { useTabStore } from '../stores/useTabStore'
 import { useWorkspaceStore } from '../features/workspace/store'
@@ -17,10 +17,14 @@ import type { PaneContent, Tab } from '../types/tab'
 
 type LoadState = 'loading' | 'ready' | 'error'
 
+const MIN_SECONDARY_SNAPSHOT_TIMEOUT_MS = 1000
+
 interface MonitorData {
   hostId: string
+  activeHostKey: string
+  snapshotHostKey: string
   config: MonitorConfig
-  snapshot: MonitorSnapshot
+  snapshotsByHostId: Record<string, MonitorSnapshot>
 }
 
 interface MonitorError {
@@ -35,10 +39,17 @@ interface PaneRow {
   content: PaneContent
 }
 
+interface SnapshotHostTarget {
+  hostId: string
+  key: string
+}
+
 export function MemoryMonitorPage() {
   const t = useI18nStore((s) => s.t)
   const activeHostId = useHostStore((s) => s.activeHostId)
-  const host = useHostStore((s) => (activeHostId ? s.hosts[activeHostId] : undefined))
+  const hosts = useHostStore((s) => s.hosts)
+  const host = activeHostId ? hosts[activeHostId] : undefined
+  const activeHostKey = host ? snapshotHostTargetKey(host) : ''
   const tabs = useTabStore((s) => s.tabs)
   const tabOrder = useTabStore((s) => s.tabOrder)
   const workspaces = useWorkspaceStore((s) => s.workspaces)
@@ -46,16 +57,25 @@ export function MemoryMonitorPage() {
   const [data, setData] = useState<MonitorData | null>(null)
   const [error, setError] = useState<MonitorError | null>(null)
   const retryIntervalMS = useRef(5000)
+  const activeWorkspace = activeWorkspaceId ? workspaces.find((workspace) => workspace.id === activeWorkspaceId) : undefined
+  const paneRows = collectPaneRows(tabs, activeWorkspace?.tabs ?? tabOrder)
+  const snapshotHostTargets = collectSnapshotHostTargets(activeHostId, paneRows, hosts)
+  const snapshotHostIdKey = snapshotHostTargets.map((target) => target.hostId).join('\0')
+  const snapshotHostKey = snapshotHostTargets.map((target) => target.key).join('\0')
 
   useEffect(() => {
     if (!activeHostId || !host) return
 
     let cancelled = false
     let timer: ReturnType<typeof setTimeout> | undefined
+    const secondaryInFlight = new Set<string>()
     retryIntervalMS.current = 5000
 
     const load = async () => {
       const requestHostId = activeHostId
+      const requestActiveHostKey = activeHostKey
+      const requestSnapshotHostKey = snapshotHostKey
+      const requestHostIds = snapshotHostIdKey ? snapshotHostIdKey.split('\0') : []
       queueMicrotask(() => {
         if (cancelled) return
         setError((current) => (current?.hostId === requestHostId ? null : current))
@@ -65,10 +85,47 @@ export function MemoryMonitorPage() {
         const nextConfig = await fetchMonitorConfig(requestHostId)
         if (cancelled) return
         retryIntervalMS.current = nextConfig.refresh_interval_ms
-        const nextSnapshot = await fetchMonitorSnapshot(requestHostId)
+        const activeSnapshot = await fetchMonitorSnapshot(requestHostId)
         if (cancelled) return
-        setData({ hostId: requestHostId, config: nextConfig, snapshot: nextSnapshot })
+        setData((current) => ({
+          hostId: requestHostId,
+          activeHostKey: requestActiveHostKey,
+          snapshotHostKey: requestSnapshotHostKey,
+          config: nextConfig,
+          snapshotsByHostId: {
+            ...preserveSecondarySnapshots(
+              current?.snapshotHostKey === requestSnapshotHostKey ? current : null,
+              requestHostId,
+              requestHostIds,
+            ),
+            [requestHostId]: activeSnapshot,
+          },
+        }))
         timer = setTimeout(load, nextConfig.refresh_interval_ms)
+
+        const secondaryHostIds = requestHostIds.filter((hostId) => hostId !== requestHostId)
+        const secondaryTimeoutMS = Math.max(nextConfig.refresh_interval_ms, MIN_SECONDARY_SNAPSHOT_TIMEOUT_MS)
+        for (const hostId of secondaryHostIds) {
+          if (secondaryInFlight.has(hostId)) continue
+          secondaryInFlight.add(hostId)
+          void fetchSnapshotResult(hostId, secondaryTimeoutMS).then((result) => {
+            if (cancelled) return
+            secondaryInFlight.delete(hostId)
+
+            const snapshot = result.snapshot
+            if (snapshot) {
+              setData((current) => {
+                if (current?.hostId !== requestHostId) return current
+                return {
+                  ...current,
+                  snapshotsByHostId: { ...current.snapshotsByHostId, [result.hostId]: snapshot },
+                }
+              })
+            }
+
+            if (result.error) setError({ hostId: requestHostId, message: formatSnapshotError(result.hostId, result.error) })
+          })
+        }
       } catch (err: unknown) {
         if (cancelled) return
         setError({ hostId: requestHostId, message: err instanceof Error ? err.message : String(err) })
@@ -80,9 +137,10 @@ export function MemoryMonitorPage() {
 
     return () => {
       cancelled = true
+      secondaryInFlight.clear()
       if (timer) clearTimeout(timer)
     }
-  }, [activeHostId, host])
+  }, [activeHostId, activeHostKey, host, snapshotHostIdKey, snapshotHostKey])
 
   if (!activeHostId || !host) {
     return (
@@ -94,11 +152,15 @@ export function MemoryMonitorPage() {
 
   const currentData = data?.hostId === activeHostId ? data : null
   const currentError = error?.hostId === activeHostId ? error : null
-  const loadState: LoadState = currentData ? 'ready' : currentError ? 'error' : 'loading'
-  const snapshot = currentData?.snapshot ?? null
+  const activeHostKeyMatches = currentData?.activeHostKey === activeHostKey
+  const loadState: LoadState = currentData && activeHostKeyMatches ? 'ready' : currentError ? 'error' : 'loading'
+  const snapshotsByHostId = currentData?.snapshotsByHostId ?? {}
+  const rowSnapshotsByHostId = currentData?.snapshotHostKey === snapshotHostKey
+    ? snapshotsByHostId
+    : activeHostKeyMatches ? preserveActiveSnapshot(activeHostId, snapshotsByHostId) : {}
+  const snapshot = activeHostKeyMatches && activeHostId ? snapshotsByHostId[activeHostId] ?? null : null
   const config = currentData?.config ?? null
-  const activeWorkspace = activeWorkspaceId ? workspaces.find((workspace) => workspace.id === activeWorkspaceId) : undefined
-  const paneRows = collectPaneRows(tabs, activeWorkspace?.tabs ?? tabOrder)
+  const validSnapshotHostIds = snapshotHostIdKey ? snapshotHostIdKey.split('\0') : []
 
   return (
     <div className="flex-1 overflow-y-auto bg-bg-base">
@@ -192,7 +254,7 @@ export function MemoryMonitorPage() {
                     <td className="px-3 py-2 text-text-muted">{row.kind}</td>
                     <td className="px-3 py-2 text-text-muted">{t('performance_monitor.not_wired')}</td>
                     <td className="px-3 py-2 text-text-muted">
-                      <DaemonMetricCell row={row} snapshot={snapshot} activeHostId={activeHostId} />
+                      <DaemonMetricCell row={row} snapshotsByHostId={rowSnapshotsByHostId} validHostIds={validSnapshotHostIds} />
                     </td>
                   </tr>
                 ))}
@@ -217,9 +279,75 @@ function collectPaneRows(tabs: Record<string, Tab>, tabOrder: string[]): PaneRow
   return rows
 }
 
-function DaemonMetricCell({ row, snapshot, activeHostId }: { row: PaneRow; snapshot: MonitorSnapshot | null; activeHostId: string }) {
+function preserveSecondarySnapshots(current: MonitorData | null, activeHostId: string, requestHostIds: string[]) {
+  if (!current) return {}
+  return Object.fromEntries(
+    requestHostIds.flatMap((hostId) => {
+      const snapshot = hostId === activeHostId ? null : current.snapshotsByHostId[hostId]
+      return snapshot ? [[hostId, snapshot] as const] : []
+    }),
+  )
+}
+
+function preserveActiveSnapshot(activeHostId: string | null, snapshotsByHostId: Record<string, MonitorSnapshot>) {
+  if (!activeHostId || !snapshotsByHostId[activeHostId]) return {}
+  return { [activeHostId]: snapshotsByHostId[activeHostId] }
+}
+
+function collectSnapshotHostTargets(activeHostId: string | null, rows: PaneRow[], hosts: Record<string, HostConfig>): SnapshotHostTarget[] {
+  const rowHostIds = new Set<string>()
+
+  for (const row of rows) {
+    if (row.content.kind === 'tmux-session' && hosts[row.content.hostId] && row.content.hostId !== activeHostId) {
+      rowHostIds.add(row.content.hostId)
+    }
+  }
+
+  const hostIds = activeHostId && hosts[activeHostId]
+    ? [activeHostId, ...[...rowHostIds].sort()]
+    : [...rowHostIds].sort()
+  return hostIds.map((hostId) => ({ hostId, key: snapshotHostTargetKey(hosts[hostId]) }))
+}
+
+function snapshotHostTargetKey(host: HostConfig) {
+  return JSON.stringify([host.id, host.ip, host.port, host.token ?? ''])
+}
+
+async function fetchSnapshotResult(hostId: string, timeoutMS?: number): Promise<{ hostId: string; snapshot?: MonitorSnapshot; error?: unknown }> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    const snapshot = timeoutMS === undefined
+      ? await fetchMonitorSnapshot(hostId)
+      : await Promise.race([
+        fetchMonitorSnapshot(hostId),
+        new Promise<MonitorSnapshot>((_, reject) => {
+          timeout = setTimeout(() => reject(new Error('snapshot timed out')), timeoutMS)
+        }),
+      ])
+    return { hostId, snapshot }
+  } catch (error) {
+    return { hostId, error }
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
+function formatSnapshotError(hostId: string, error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  return `${hostId}: ${message}`
+}
+
+function DaemonMetricCell({
+  row,
+  snapshotsByHostId,
+  validHostIds,
+}: {
+  row: PaneRow
+  snapshotsByHostId: Record<string, MonitorSnapshot>
+  validHostIds: string[]
+}) {
   const t = useI18nStore((s) => s.t)
-  const metrics = findDaemonMetrics(row, snapshot, activeHostId)
+  const metrics = findDaemonMetrics(row, snapshotsByHostId, validHostIds)
   if (!metrics) return t('performance_monitor.not_wired')
   if (metrics.unavailable_reason) return formatUnavailableReason(metrics.unavailable_reason, t)
 
@@ -232,9 +360,11 @@ function DaemonMetricCell({ row, snapshot, activeHostId }: { row: PaneRow; snaps
   )
 }
 
-function findDaemonMetrics(row: PaneRow, snapshot: MonitorSnapshot | null, activeHostId: string): MonitorSessionDaemonMetrics | null {
+function findDaemonMetrics(row: PaneRow, snapshotsByHostId: Record<string, MonitorSnapshot>, validHostIds: string[]): MonitorSessionDaemonMetrics | null {
   const content = row.content
-  if (!snapshot || content.kind !== 'tmux-session' || content.hostId !== activeHostId) return null
+  if (content.kind !== 'tmux-session' || !validHostIds.includes(content.hostId)) return null
+  const snapshot = snapshotsByHostId[content.hostId]
+  if (!snapshot) return null
   return snapshot.sessions.find((session) => session.session_code === content.sessionCode)?.daemon ?? null
 }
 


### PR DESCRIPTION
## Summary
- Fetch monitor snapshots for each distinct host-bound tmux-session pane, not only the active host.
- Scope daemon row metrics by pane host snapshot so equal session codes across hosts do not collide.
- Keep active-host rendering independent from slow/failing secondary hosts, with bounded secondary timeouts and endpoint-keyed stale-data guards.

## Verification
- `pnpm --prefix spa exec vitest run src/components/MemoryMonitorPage.test.tsx src/lib/host-api.test.ts src/locales/locale-completeness.test.ts src/lib/pane-tree.test.ts`
- `pnpm --prefix spa run lint`
- `pnpm --prefix spa exec tsc -b`
- `git diff --check`