### PR TITLE
feat(agent): W6-3+W6-4 codex error/clear ad-hoc ProbeIntent (first per-agent probe)

### DIFF
--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-plan.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-plan.md
@@ -1,6 +1,6 @@
 # W6-3 codex error ad-hoc ProbeIntent — Implementation Plan
 
-> **Status**：draft（待 codex plan review）
+> **Status**：v2（codex plan review 4 finding 全採納）
 > **依賴 spec**：`docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md` v6 final（5 輪 review 12 finding 採納）
 > **Worktree**：`.claude/worktrees/lights-w6-3-codex-error` / branch `worktree-lights-w6-3-codex-error`
 > **Base**：`origin/main` @ alpha.261
@@ -65,35 +65,92 @@ per spec §2.1 必守清單，實作時必持守：
 
 **目標**：從 `probe_orchestrator.go interpretScreenEvent` 抽出 free function `applyProbeGuards`；行為零變動；ScreenChange 路徑改用新 helper；新加 strategy injection point（Mapping callback + StaleCheck closure）。
 
+**1:1 mapping table**（per plan-review P2-2 — 強制 mechanical extraction，可重複驗證）：
+
+| 既有 `interpretScreenEvent` step | 抽出後位置 | 變動類型 |
+|---|---|---|
+| step 1 (line 240-247): stale-callback guard fast-path（read activeWatchers + agentType match） | `applyProbeGuards` step 1：caller-supplied `StaleCheck closure` 在 m.mu 內 invoke；ScreenChange 路徑 closure 內容 = 既有 read 邏輯 | mechanical（read 路徑包進 closure）|
+| step 2 (line 249-259): graceWindow check（取 graceMu lock + lastHookAt）| `applyProbeGuards` step 2：identical 區塊 | identical |
+| step 3 (line 261-303): Kind → status mapping（含 ScreenStable 的 dead-PID sweep 分支） | **保留在 `interpretScreenEvent` 上層** — 完成 mapping 後將 `newStatus` 傳入 `applyProbeGuards` 作為已 mapped 結果（透過 `Mapping closure`） | reorganization：mapping 移到 caller layer |
+| step 4 (line 312-325): final critical section + stale guard re-check + ErrorGuard + transition gate | `applyProbeGuards` step 4：identical（用同一 StaleCheck closure 在 m.mu 內 re-check）| identical |
+| step 5 (line 326-353): mutate currentStatus + setProjectionTopStatus + broadcastToSession | `applyProbeGuards` step 5：identical | identical |
+
 **改動**：
 
 | 檔案 | 改動 |
 |---|---|
-| `internal/module/agent/probe_orchestrator.go` | `interpretScreenEvent` step 1+2+4+5+6 (stale guard / graceWindow / ErrorGuard / transition gate / broadcast) 抽到 free function `applyProbeGuards`；step 3 (Kind→status mapping) 改用 caller-supplied Mapping callback；ScreenChange 路徑用 ScreenChange-specific Mapping function 不變語意 |
-| `internal/module/agent/probe_orchestrator_test.go` | 既有 test 全綠（regression assertion） |
+| `internal/module/agent/probe_orchestrator.go` | `interpretScreenEvent` step 1+2+4+5 抽到 `applyProbeGuards`；step 3 mapping 留 caller；ScreenChange 路徑 caller adaptor 把 ScreenChange-specific Kind→status 包成 Mapping closure；StaleCheck closure 包 activeWatchers read |
+| `internal/module/agent/probe_orchestrator_test.go` | 既有 test 全綠（zero regression assertion） |
 | `internal/module/agent/probe_intent_dispatcher.go`（新檔，骨架） | 預留 `probeGuardArgs` struct + `applyProbeGuards` signature；本 task 只填 ScreenChange caller |
 
-**Test**：
-- 既有 `TestInterpretScreenEvent_*` 全部通過（zero regression）
-- 新增 `TestApplyProbeGuards_StaleCheckGuard_ScreenChangeRoute` — fake Module + activeWatchers 缺 entry → applied=false
-- 新增 `TestApplyProbeGuards_GraceWindow` — recordHookAt 後 2s 內 → applied=false
-- 新增 `TestApplyProbeGuards_ErrorGuard` — currentStatus=error → applied=false
-- 新增 `TestApplyProbeGuards_TransitionGate` — currentStatus=newStatus → applied=false
-- 新增 `TestApplyProbeGuards_HappyPath` — 所有 guard pass → mutate + broadcast + applied=true
-- 新增 `TestApplyProbeGuards_FinalCriticalSectionReCheck` — fake interruptBeforeFinalLockFn 模擬 step 1 unlock 後 stop → step 4 lock 內 staleCheck 為 false → 取消 mutate
+**Test**（含 table-driven regression — per plan-review P2-2）：
+
+新加 `applyProbeGuards` 直接測試：
+- `TestApplyProbeGuards_StaleCheckGuard_FastPath` — StaleCheck closure 回 false → applied=false（不進 graceWindow / mapping）
+- `TestApplyProbeGuards_GraceWindow` — recordHookAt 後 2s 內 → applied=false
+- `TestApplyProbeGuards_Mapping_NewStatusEmpty_Drops` — Mapping returns "" → applied=false
+- `TestApplyProbeGuards_ErrorGuard` — currentStatus=error → applied=false
+- `TestApplyProbeGuards_TransitionGate` — currentStatus=newStatus → applied=false
+- `TestApplyProbeGuards_HappyPath_MutatesAndBroadcasts` — 所有 guard pass → mutate + broadcast + applied=true
+- `TestApplyProbeGuards_FinalCriticalSectionReCheck` — fake interruptBeforeFinalLockFn 模擬 step 1 unlock 後 stop → step 4 lock 內 StaleCheck 為 false → 取消 mutate
+
+ScreenChange path table-driven regression（per plan-review P2-2 — 機械驗證 5 類觀察 output 與 pre-extraction 一致）：
+
+```go
+// TestScreenChangePath_RegressionMatrix iterates a 5-case table and asserts
+// each case's externally observable output (broadcast / metric counter /
+// dev log line) matches the pre-extraction baseline fixture verbatim.
+//
+// Cases (5; 對應 step 1-5 各一個觀察點)：
+//   1. stale_active_watchers_drop  — activeWatchers 缺 entry → 無 broadcast、無 metric、無 dev log
+//   2. grace_window_drop           — recordHookAt 後 1s → 無 broadcast、graceWindow counter +1
+//   3. error_guard_drop            — currentStatus=error → 無 broadcast、無 transition counter
+//   4. transition_gate_drop        — currentStatus 已是 target → 無 broadcast、無 mutation
+//   5. happy_path_apply            — 全 pass → broadcast 一次 + transition counter +1 + dev log
+//
+// 每 case 跑 pre-extraction (git stash 模擬) + post-extraction，assert output 字串相等。
+```
 
 **Acceptance**：
 - `go test ./internal/module/agent/...` 全綠
-- `git diff` 確認 ScreenChange 路徑語意變動為 0（除新加 caller indirection 外）
+- 既有 `TestInterpretScreenEvent_*` zero regression
+- `TestScreenChangePath_RegressionMatrix` 5 case 全 pass — output 字串級對齊 pre-extraction baseline
+- 1:1 mapping table 在 PR description 中明示，codex review 對 mapping table 二次 verify
 - ProbeIntent 路徑骨架（Mapping / StaleCheck）暫無 caller，但簽名 finalize
 
-**估計**：~120 行 production（含 free function + ScreenChange caller adaptor）/ ~250 行 test。
+**估計**：~120 行 production（含 free function + ScreenChange caller adaptor）/ ~350 行 test（含 regression matrix fixture）。
 
 **依賴**：P1-T1（用到 ProbeIntent types — 但 P1-T2 ScreenChange 路徑暫不用）。實際 P1-T1 + P1-T2 可平行做。
 
 ---
 
-### P1-T3 — Dispatcher core: `applyStatus` / `reconcileSessionActive` / `applyIntentLifecycle` / `consumeSignals`
+### P1-T3 — `Module.lookupTopFrameForSessionLocked` helper
+
+**目標**：在 m.mu 內讀 frame projection top frame `(paneID, pid)`，給 dispatcher 用。**提前到 P1-T3**（per plan-review P1-1 修法 — dispatcher core 編譯前置依賴）。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/module.go` | 新加 `lookupTopFrameForSessionLocked(session) (paneID string, pid int, ok bool)` — caller 已持 m.mu；走既有 `projectionForSessionLocked`（如有）/ 或 `m.frames` 直接 lookup top frame |
+| `internal/module/agent/module_test.go` | 加 unit test |
+
+**Test**：
+- `TestLookupTopFrameForSessionLocked_HappyPath`
+- `TestLookupTopFrameForSessionLocked_NoSession_NotOk`
+- `TestLookupTopFrameForSessionLocked_NoTopFrame_NotOk`
+
+**Acceptance**：`go test ./internal/module/agent/...` 全綠。
+
+**估計**：~30 行 production / ~80 行 test。
+
+**依賴**：none。
+
+> 註：若既有 `projectionForSession` 已是 m.mu 內 lock-free read，可直接 reuse — 本 task 退化為 wrapper 對齊 dispatcher 預期 contract（`paneID, senderPID, ok`）。實作時驗證。
+
+---
+
+### P1-T4 — Dispatcher core: `applyStatus` / `reconcileSessionActive` / `applyIntentLifecycle` / `consumeSignals`
 
 **目標**：實作 dispatcher 核心邏輯；用 stub detector（永不 emit）跑 lifecycle 5 case + 4 reconcile case + probe-applied teardown 全部 test。
 
@@ -144,33 +201,7 @@ Concurrent rename（補 §6.4 race）：
 
 **估計**：~250 行 production / ~500 行 test。
 
-**依賴**：P1-T1 + P1-T2。
-
----
-
-### P1-T4 — `Module.lookupTopFrameForSessionLocked` helper
-
-**目標**：在 m.mu 內讀 frame projection top frame `(paneID, pid)`，給 dispatcher 用。
-
-**改動**：
-
-| 檔案 | 改動 |
-|---|---|
-| `internal/module/agent/module.go` | 新加 `lookupTopFrameForSessionLocked(session) (paneID string, pid int, ok bool)` — caller 已持 m.mu；走既有 `projectionForSessionLocked`（如有）/ 或 `m.frames` 直接 lookup top frame |
-| `internal/module/agent/module_test.go` | 加 unit test |
-
-**Test**：
-- `TestLookupTopFrameForSessionLocked_HappyPath`
-- `TestLookupTopFrameForSessionLocked_NoSession_NotOk`
-- `TestLookupTopFrameForSessionLocked_NoTopFrame_NotOk`
-
-**Acceptance**：`go test ./internal/module/agent/...` 全綠。
-
-**估計**：~30 行 production / ~80 行 test。
-
-**依賴**：none（與 P1-T3 平行）。實際 P1-T3 會用到此 helper，但兩 task 可同 commit 不衝突。
-
-> 註：若既有 `projectionForSession` 已是 m.mu 內 lock-free read，可直接 reuse — 本 task 退化為 wrapper 對齊 dispatcher 預期 contract（`paneID, senderPID, ok`）。實作時驗證。
+**依賴**：P1-T1 + P1-T2 + **P1-T3**（lookupTopFrameForSessionLocked 是 dispatcher 必要前置 — per plan-review P1-1 修法）。
 
 ---
 
@@ -195,7 +226,7 @@ Concurrent rename（補 §6.4 race）：
 
 **估計**：~30 行 production / ~120 行 test。
 
-**依賴**：P1-T3 + P1-T4。
+**依賴**：P1-T4（dispatcher core）。
 
 ---
 
@@ -220,7 +251,7 @@ Concurrent rename（補 §6.4 race）：
 
 **估計**：~40 行 production / ~150 行 test。
 
-**依賴**：P1-T3 + P1-T4 + P1-T5。
+**依賴**：P1-T4 + P1-T5。
 
 ---
 
@@ -341,7 +372,7 @@ Concurrent rename（補 §6.4 race）：
 
 **估計**：~10 行 production / ~120 行 test。
 
-**依賴**：P1-T3 + P2-T2 + P2-T3。
+**依賴**：P1-T4（dispatcher core）+ P2-T2 + P2-T3。
 
 ---
 
@@ -368,26 +399,46 @@ Concurrent rename（補 §6.4 race）：
 
 ---
 
-### P2-T6 — Trace dev log: `[probe-intent]` step kind
+### P2-T6 — Observability: dev log + TraceStore step + expvar metrics（per plan-review P2-1）
 
-**目標**：W4 trace pipeline 加第 6 條 chain log `[probe-intent]`；同時更新 `trace.go` package comment 列出 6 條 step 順序。
+**目標**：spec §8.4 三件事都做：(a) dev log 4 類 line / (b) TraceStore `[probe-intent]` step kind（chain log 第 6 條）/ (c) expvar metrics counter。
 
-**改動**：
+**(a) dev log**：
 
 | 檔案 | 改動 |
 |---|---|
 | `internal/module/agent/trace.go` | package comment 補 `[probe-intent]` step（包含 start / signal / stop / drop 4 個 sub-step）|
-| `internal/module/agent/probe_intent_dispatcher.go` | dev log（在 `isDevMode()` 條件下）— `[probe-intent] start session=X agent=codex kind=process_dead pane=%5 pid=12345 generation=N` / `[probe-intent] signal session=X kind=process_dead PaneAlive=true newStatus=error applied=true` / `[probe-intent] stop session=X kind=process_dead reason=Y` / `[probe-intent] drop session=X kind=process_dead reason=stale-callback\|grace\|error-guard` |
-| `internal/module/agent/probe_intent_dispatcher_test.go` | 補 dev log 測試（用 capturing logger）|
+| `internal/module/agent/probe_intent_dispatcher.go` | 4 類 dev log（在 `isDevMode()` 條件下）：<br>• `[probe-intent] start session=X agent=codex kind=process_dead pane=%5 pid=12345 generation=N`<br>• `[probe-intent] signal session=X kind=process_dead PaneAlive=true newStatus=error applied=true`<br>• `[probe-intent] stop session=X kind=process_dead reason=lifecycle-applyStatus\|reconcile\|stop-all`<br>• `[probe-intent] drop session=X kind=process_dead reason=stale-callback\|grace\|error-guard\|transition-gate` |
+
+**(b) TraceStore step**：spec §8.4 #2 — chain log 第 6 條 `[probe-intent]` 與 `[hook] / [derive] / [handler] / [broadcast] / [verify_passed]` 對齊：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/trace.go` | 加 `TraceStepProbeIntent` 常數 + step 寫入 helper（reuse 既有 `traceSink.Append` 路徑） |
+| `internal/module/agent/probe_intent_dispatcher.go` | `applyIntentLifecycle` start/stop 路徑 + `consumeSignals` applied 路徑 寫入 trace step（含 chain id — sourced 自 hook 觸發或 replay context）|
+
+**(c) expvar metrics**：spec §8.4 #3 — 沿既有 `internal/agent/MetricProbeXxx` pattern：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/agent/metrics.go`（既有） | 加 `MetricProbeIntentStarted` / `MetricProbeIntentStopped` / `MetricProbeIntentSignalEmitted` / `MetricProbeIntentApplied` / `MetricProbeIntentDroppedStale` / `MetricProbeIntentDroppedGrace` / `MetricProbeIntentDroppedErrorGuard` / `MetricProbeIntentDroppedTransitionGate`（8 個 counter）|
+| `internal/module/agent/probe_intent_dispatcher.go` | 對應路徑 `Metric*.Add(1)` |
 
 **Test**：
 - `TestProbeIntent_DevLog_StartLine`
 - `TestProbeIntent_DevLog_SignalLine`
 - `TestProbeIntent_DevLog_DropReason_StaleCallback`
+- `TestProbeIntent_TraceStore_StartStep`（fake traceSink + assert Append 被呼叫含 `TraceStepProbeIntent` + chain id）
+- `TestProbeIntent_TraceStore_SignalStep`
+- `TestProbeIntent_Expvar_StartedCounterIncrement`（counter delta test：fire start → counter +1）
+- `TestProbeIntent_Expvar_DroppedCounterByReason`（4 種 drop reason 各對應 counter +1）
 
-**Acceptance**：`PDX_DEV_MODE=1` 下 4 類 log 在對應路徑被印出。
+**Acceptance**：
+- `PDX_DEV_MODE=1` 下 4 類 log 在對應路徑被印出
+- TraceStore 中可 query 出 `TraceStepProbeIntent` step entries（與 hook chain 對齊）
+- `/debug/vars` JSON 內 8 個 `probe_intent_*` counter 反映 dispatcher 動作
 
-**估計**：~30 行 production / ~100 行 test。
+**估計**：~80 行 production / ~250 行 test。
 
 **依賴**：P2-T4。
 
@@ -409,6 +460,8 @@ Concurrent rename（補 §6.4 race）：
 - `TestIntegration_CodexNormalExit_NoErrorBroadcast`（status=idle 期間 process dead → ProbeIntent 不 armed → 不 broadcast）
 - `TestIntegration_CodexRestart_ActiveTargetMismatch_ReArms`（同 pane 內換 pid → case 5 觸發）
 - `TestIntegration_AgentSwitchCodexToCC_OldDetectorTornDown`（reconcile cleanup 驗證）
+- `TestIntegration_ReplayWithRealDetector_PaneGone_BroadcastsClear`（per plan-review P1-2：replayStatus 用 real ProcessDead detector，fixture：projection top frame.pid 已死 + HasPane=false → restart 後立即 emit clear → 對應 §8.1 #5 的 clear 路徑）
+- `TestIntegration_ReplayWithRealDetector_PaneAlive_BroadcastsError`（同上但 HasPane=true → emit error；對應 §8.1 #5 error 路徑）
 
 **Acceptance**：`go test ./internal/module/agent/...` 全綠 + integration test list 全 pass。
 
@@ -446,17 +499,18 @@ Concurrent rename（補 §6.4 race）：
 | §1 codex SIGKILL | codex running 中 → `kill -9 <codex_pid>` | ≤2s lights 變 error | `[probe-intent] signal ... PaneAlive=true newStatus=error applied=true` log + SPA tab icon 紅 |
 | §2 codex pane close | codex running 中 → `tmux kill-pane -t %X` | ≤2s lights 變 clear | `[probe-intent] signal ... PaneAlive=false newStatus=clear applied=true` log + SPA tab icon 灰 |
 | §3 codex /exit | codex running → `/exit` | lights → idle 後 ProbeIntent 停；後續 pane close 不誤觸 | `[probe-intent] stop session=X kind=process_dead reason=lifecycle-applyStatus` log；後續 pane close **無** signal log |
-| §4 daemon restart 後 codex 已死 | codex running 中 stop daemon → kill codex → restart daemon | restart 後 ≤2s lights 變 error | `[probe-intent] start ...` (replay arm) → 立刻 `[probe-intent] signal ... PaneAlive=true ... applied=true` log |
+| §4 daemon restart 後 codex 已死（pane 仍存在）→ error | codex running 中 stop daemon → kill -9 codex → restart daemon | restart 後 ≤2s lights 變 error | `[probe-intent] start ...` (replay arm) → 立刻 `[probe-intent] signal ... PaneAlive=true ... applied=true` log |
+| §5 daemon restart 後 codex 已死（pane 也消失）→ clear（per plan-review P1-2 補測） | codex running 中 stop daemon → `tmux kill-pane` 將 codex pane 連同 process 移除 → restart daemon | restart 後 ≤2s lights 變 clear | `[probe-intent] start ...` (replay arm) → 立刻 `[probe-intent] signal ... PaneAlive=false newStatus=clear ... applied=true` log |
 
 **附加場景（可選）**：
 
 | § | 場景 | 期望 |
 |---|---|---|
-| §5 codex restart 換 pid | codex running → /exit → 重新啟新 codex（同 pane）→ 新 status=running 後 kill 新 pid | lights 變 error，舊 detector 不誤觸 |
-| §6 multi-pane | 同 window 兩個 pane 都跑 codex → kill 其中一個 | 該 pane lights 變 error，另一個 pane 不受影響 |
-| §7 cross-provider | codex running → user 切到該 session 跑 cc → cc 啟動後 kill 原 codex pid | 不誤觸 error（codex active entry 已被 reconcile 清掉）|
+| §6 codex restart 換 pid | codex running → /exit → 重新啟新 codex（同 pane）→ 新 status=running 後 kill 新 pid | lights 變 error，舊 detector 不誤觸 |
+| §7 multi-pane | 同 window 兩個 pane 都跑 codex → kill 其中一個 | 該 pane lights 變 error，另一個 pane 不受影響 |
+| §8 cross-provider | codex running → user 切到該 session 跑 cc → cc 啟動後 kill 原 codex pid | 不誤觸 error（codex active entry 已被 reconcile 清掉）|
 
-**Acceptance**：4 個必驗場景全 PASS，留下 log evidence；不必驗證附加場景（test 已覆蓋）。
+**Acceptance**：5 個必驗場景全 PASS（含 §5 clear 路徑 — per plan-review P1-2），留下 log evidence；不必驗證附加場景（test 已覆蓋）。
 
 **估計**：1-2 小時 manual。
 
@@ -534,29 +588,29 @@ Acceptance: <copy from plan>
 
 ### Unit test（隔離測試）
 - ProbeIntent types（P1-T1）：3-5 tests
-- applyProbeGuards 5 個 guard layer（P1-T2）：6-7 tests
-- Dispatcher lifecycle 5 case（P1-T3）：5 tests
-- Reconcile 4 case（P1-T3）：4 tests
-- Probe-applied teardown（P1-T3）：2 tests
-- Stale-callback / generation（P1-T3）：3 tests
-- Replay race（P1-T3, P1-T6）：2-3 tests
-- lookupTopFrame helper（P1-T4）：3 tests
+- applyProbeGuards 7 個 guard test + ScreenChange regression matrix 5 case（P1-T2）：12 tests
+- lookupTopFrame helper（P1-T3）：3 tests
+- Dispatcher lifecycle 5 case（P1-T4）：5 tests
+- Reconcile 4 case（P1-T4）：4 tests
+- Probe-applied teardown（P1-T4）：2 tests
+- Stale-callback / generation（P1-T4）：3 tests
+- Replay race（P1-T4, P1-T6）：2-3 tests
 - manageActivityWatch / rename / Stop（P1-T5）：4 tests
 - replayStatus（P1-T6）：3 tests
 - HasPane（P2-T1）：4 tests
 - ProcessDead detector（P2-T2）：8 tests
 - Provider ProbeIntents + OnSignal（P2-T3）：5 tests
 - Drift（P2-T5）：3 tests
-- Dev log（P2-T6）：3 tests
+- Observability — dev log + TraceStore + expvar（P2-T6）：7 tests
 
 ### Integration test（跨層）
 - codex detector + dispatcher（P2-T4）：1 test
-- 完整 broadcast path 兩條 mapping（P2-T7）：5 tests
+- 完整 broadcast path 兩條 mapping + replay-real-detector 兩路徑（P2-T7）：7 tests
 
-**Test 總計**：~60+ tests。
+**Test 總計**：~80+ tests。
 
 ### Live verify
-- mlab §1-§4：4 必驗場景
+- mlab §1-§5：5 必驗場景（含 daemon restart + pane gone clear path — per plan-review P1-2）
 
 ---
 
@@ -612,7 +666,7 @@ Phase 2 PR squash merge 後獨立 bump PR：
 |---|---|---|
 | Phase 1 P1-T1~T6 | 6 task 全 commit + test 全綠 + race 全綠 + ScreenChange regression 0 | ⏳ |
 | Phase 2 P2-T1~T7 | 7 task 全 commit + test 全綠 + drift test pass + dev log 完整 | ⏳ |
-| Phase 2 P2-T8 | mlab live §1-§4 全 PASS | ⏳ |
+| Phase 2 P2-T8 | mlab live §1-§5 全 PASS（含 daemon-restart pane-gone clear 路徑）| ⏳ |
 | PR + codex review 兩輪 | 0 critical/P1 + known issue 追蹤化 | ⏳ |
 | Squash merge → main | branch 刪除 + worktree 清理 | ⏳ |
 | Bump PR alpha.262 | merge | ⏳ |

--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-plan.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-plan.md
@@ -1,0 +1,618 @@
+# W6-3 codex error ad-hoc ProbeIntent — Implementation Plan
+
+> **Status**：draft（待 codex plan review）
+> **依賴 spec**：`docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md` v6 final（5 輪 review 12 finding 採納）
+> **Worktree**：`.claude/worktrees/lights-w6-3-codex-error` / branch `worktree-lights-w6-3-codex-error`
+> **Base**：`origin/main` @ alpha.261
+> **拆分**：Phase 1（interface + dispatcher plumbing；TDD subagent）→ Phase 2（codex detector + verify；TDD subagent）→ PR
+
+---
+
+## 0. Plan 總覽
+
+### 0.1 範圍重申（per spec §1.1）
+
+W6-3 + W6-4 合併 first PR，14 task 分兩 phase：
+
+- **Phase 1**：6 task — `ProbeIntentProvider` interface + `applyProbeGuards` mechanical extraction + dispatcher plumbing（`applyStatus` / `reconcileSessionActive` / `applyIntentLifecycle` / `consumeSignals`）+ replay recovery；codex provider 暫用 stub detector 跑 lifecycle test
+- **Phase 2**：8 task — `tmux.HasPane` + codex `StartProcessDeadDetector` + provider wiring + drift test + dev log + integration test + mlab live verify
+
+### 0.2 估計
+
+- 總 production code：~600-700 行（spec §3 / §5 程式碼草稿是約等量）
+- 總 test code：~800-1000 行（5 lifecycle case + 4 reconcile + probe-applied teardown + replay race + multi-pane + integration）
+- 預估 PR diff：~1500-1700 行
+- 預估時間：8-12 小時 subagent 工作（包含 mlab live verify）
+
+### 0.3 鎖序與不變式
+
+per spec §2.1 必守清單，實作時必持守：
+- 鎖序：m.mu only（無 cross-lock）
+- ProbeIntent state（`activeProbeIntents`）由 m.mu 保護
+- detector goroutine 不持 m.mu
+- channel buffer = 1
+- generation token uint64 純遞增
+
+---
+
+## 1. Phase 1：Interface + dispatcher plumbing + replay
+
+### P1-T1 — `ProbeIntent` types in `internal/agent/provider.go`
+
+**目標**：落 `ProbeIntentProvider` interface + `ProbeIntent` / `ProbeIntentKind` / `Signal` types。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/agent/provider.go` | 附加 ProbeIntentProvider interface + ProbeIntent struct (Kind / OnEntryStatus / OnSignal) + ProbeIntentKind string type + ProbeIntentKindProcessDead const + Signal struct (Kind / PaneAlive / PaneID / SenderPID) |
+| `internal/agent/provider_test.go` | 新增 unit test：interface 簽名 + Signal struct 完整性 + Kind const |
+
+**Test**：
+- `TestProbeIntent_StructFields` — Signal 4 fields 都存在 + 型別正確
+- `TestProbeIntentKind_ProcessDead` — const 值是 "process_dead"
+- `TestProbeIntentProvider_OptionalNil` — fakeProvider 不實作 → 仍滿足 AgentProvider
+
+**Acceptance**：`go test ./internal/agent/...` 全綠；`go build ./...` 全綠。
+
+**估計**：~50 行 production / ~100 行 test。
+
+**依賴**：none（最先做）。
+
+---
+
+### P1-T2 — `applyProbeGuards` mechanical extraction
+
+**目標**：從 `probe_orchestrator.go interpretScreenEvent` 抽出 free function `applyProbeGuards`；行為零變動；ScreenChange 路徑改用新 helper；新加 strategy injection point（Mapping callback + StaleCheck closure）。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/probe_orchestrator.go` | `interpretScreenEvent` step 1+2+4+5+6 (stale guard / graceWindow / ErrorGuard / transition gate / broadcast) 抽到 free function `applyProbeGuards`；step 3 (Kind→status mapping) 改用 caller-supplied Mapping callback；ScreenChange 路徑用 ScreenChange-specific Mapping function 不變語意 |
+| `internal/module/agent/probe_orchestrator_test.go` | 既有 test 全綠（regression assertion） |
+| `internal/module/agent/probe_intent_dispatcher.go`（新檔，骨架） | 預留 `probeGuardArgs` struct + `applyProbeGuards` signature；本 task 只填 ScreenChange caller |
+
+**Test**：
+- 既有 `TestInterpretScreenEvent_*` 全部通過（zero regression）
+- 新增 `TestApplyProbeGuards_StaleCheckGuard_ScreenChangeRoute` — fake Module + activeWatchers 缺 entry → applied=false
+- 新增 `TestApplyProbeGuards_GraceWindow` — recordHookAt 後 2s 內 → applied=false
+- 新增 `TestApplyProbeGuards_ErrorGuard` — currentStatus=error → applied=false
+- 新增 `TestApplyProbeGuards_TransitionGate` — currentStatus=newStatus → applied=false
+- 新增 `TestApplyProbeGuards_HappyPath` — 所有 guard pass → mutate + broadcast + applied=true
+- 新增 `TestApplyProbeGuards_FinalCriticalSectionReCheck` — fake interruptBeforeFinalLockFn 模擬 step 1 unlock 後 stop → step 4 lock 內 staleCheck 為 false → 取消 mutate
+
+**Acceptance**：
+- `go test ./internal/module/agent/...` 全綠
+- `git diff` 確認 ScreenChange 路徑語意變動為 0（除新加 caller indirection 外）
+- ProbeIntent 路徑骨架（Mapping / StaleCheck）暫無 caller，但簽名 finalize
+
+**估計**：~120 行 production（含 free function + ScreenChange caller adaptor）/ ~250 行 test。
+
+**依賴**：P1-T1（用到 ProbeIntent types — 但 P1-T2 ScreenChange 路徑暫不用）。實際 P1-T1 + P1-T2 可平行做。
+
+---
+
+### P1-T3 — Dispatcher core: `applyStatus` / `reconcileSessionActive` / `applyIntentLifecycle` / `consumeSignals`
+
+**目標**：實作 dispatcher 核心邏輯；用 stub detector（永不 emit）跑 lifecycle 5 case + 4 reconcile case + probe-applied teardown 全部 test。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/probe_intent_dispatcher.go` | 完整實作：probeIntentDispatcher struct / activeIntent / lifecyclePlan / applyStatus / reconcileSessionActive / applyIntentLifecycle / consumeSignals / makeProbeIntentStaleCheck / nextProbeIntentGeneration / stopAll |
+| `internal/module/agent/module.go` | `Module` struct 加 `activeProbeIntents map[string]map[agent.ProbeIntentKind]activeIntent` + `probeIntentGen uint64` + `probeIntentDisp *probeIntentDispatcher`；`New()` 初始化；`Stop()` 呼叫 `probeIntentDisp.stopAll()` |
+| `internal/module/agent/probe_intent_dispatcher_test.go` | 新檔：lifecycle 5 case test + reconcile 4 case + probe-applied teardown |
+| `internal/module/agent/fakes_test.go` | 加 fakeProbeIntentProvider（測 stub detector）|
+
+**Test list**（核心 lifecycle / reconcile / teardown）：
+
+Lifecycle 5 case：
+- `TestApplyIntentLifecycle_Case1_NotActive_NotShouldActive_Noop`
+- `TestApplyIntentLifecycle_Case2_NotActive_ShouldActive_Start`
+- `TestApplyIntentLifecycle_Case3_Active_NotShouldActive_Stop`
+- `TestApplyIntentLifecycle_Case4_Active_ShouldActive_TargetMatch_Noop`
+- `TestApplyIntentLifecycle_Case5_Active_ShouldActive_TargetMismatch_CancelAndRearm`
+
+Reconcile 4 case：
+- `TestReconcileSessionActive_UnknownAgent_DropAll`
+- `TestReconcileSessionActive_ProviderHasNoIntents_DropAll`
+- `TestReconcileSessionActive_AgentTypeChanged_DropOld`（codex active → newAgentType=cc）
+- `TestReconcileSessionActive_KindNotInDeclared_DropOldKind`
+
+Probe-applied teardown：
+- `TestConsumeSignals_AppliedTrue_ReRunsApplyStatus`（stub detector emit 後 status=error → activeProbeIntents 該 entry 應被清）
+- `TestConsumeSignals_AppliedFalse_NoTeardown`（applied=false → active entry 仍在）
+
+Stale-callback / generation：
+- `TestMakeStaleCheck_GenerationMismatch_ReturnsFalse`
+- `TestMakeStaleCheck_AgentTypeMismatch_ReturnsFalse`
+- `TestMakeStaleCheck_AllMatch_ReturnsTrue`
+
+Replay race（補 by2z79ouc ATK-2 防回歸）：
+- `TestApplyIntentLifecycle_StatusChangedBetweenSnapshotAndArm_NoArming`（fake hook 在 m.mu 解鎖前改 currentStatus=idle）
+
+Concurrent rename（補 §6.4 race）：
+- `TestApplyStatus_DuringRename_NewSessionGetsActiveEntry`
+
+**Acceptance**：
+- `go test ./internal/module/agent/...` 全綠
+- 13+ test 全部 pass
+- 無 race（用 `go test -race` 跑）
+- ScreenChange path 不受影響（既有 test 全綠）
+
+**估計**：~250 行 production / ~500 行 test。
+
+**依賴**：P1-T1 + P1-T2。
+
+---
+
+### P1-T4 — `Module.lookupTopFrameForSessionLocked` helper
+
+**目標**：在 m.mu 內讀 frame projection top frame `(paneID, pid)`，給 dispatcher 用。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/module.go` | 新加 `lookupTopFrameForSessionLocked(session) (paneID string, pid int, ok bool)` — caller 已持 m.mu；走既有 `projectionForSessionLocked`（如有）/ 或 `m.frames` 直接 lookup top frame |
+| `internal/module/agent/module_test.go` | 加 unit test |
+
+**Test**：
+- `TestLookupTopFrameForSessionLocked_HappyPath`
+- `TestLookupTopFrameForSessionLocked_NoSession_NotOk`
+- `TestLookupTopFrameForSessionLocked_NoTopFrame_NotOk`
+
+**Acceptance**：`go test ./internal/module/agent/...` 全綠。
+
+**估計**：~30 行 production / ~80 行 test。
+
+**依賴**：none（與 P1-T3 平行）。實際 P1-T3 會用到此 helper，但兩 task 可同 commit 不衝突。
+
+> 註：若既有 `projectionForSession` 已是 m.mu 內 lock-free read，可直接 reuse — 本 task 退化為 wrapper 對齊 dispatcher 預期 contract（`paneID, senderPID, ok`）。實作時驗證。
+
+---
+
+### P1-T5 — `manageActivityWatch` 接 dispatcher + rename / Stop 路徑
+
+**目標**：`manageActivityWatch` 退化的 stop-only 版本加 `probeIntentDisp.applyStatus` 呼叫；`renameSessionLocked` / `Module.Stop` 路徑也接。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/module.go` | `manageActivityWatch` body 加 step 2（dispatch ProbeIntent applyStatus）；`renameSessionLocked` 補 `applyStatus(newName, agentType, currentStatus)` — oldName 在 m.mu 內已被先轉移到 newName，applyStatus 看到的 currentStatus 是 newName 的 |
+| `internal/module/agent/module_test.go` | 加 rename / Stop 路徑 integration |
+
+**Test**：
+- `TestManageActivityWatch_StatusToRunning_ProbeIntentArmed`
+- `TestManageActivityWatch_StatusToIdle_ProbeIntentTornDown`
+- `TestRenameSession_OldNameProbeIntentMigratesToNew`
+- `TestModuleStop_ProbeIntentDispatcherStoppedAll`
+
+**Acceptance**：`go test ./internal/module/agent/...` 全綠。
+
+**估計**：~30 行 production / ~120 行 test。
+
+**依賴**：P1-T3 + P1-T4。
+
+---
+
+### P1-T6 — `Module.Start` replay recovery + `replayStatus`
+
+**目標**：`Module.Start` 在 `replayFromDB + startSweep` 後呼叫 `probeIntentDisp.replayStatus()`；對所有 session 重新評估 ProbeIntent gating + 啟動 detector。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/module.go` | `Start()` 加 `m.probeIntentDisp.replayStatus()` 呼叫（`startSweep` 之後）|
+| `internal/module/agent/probe_intent_dispatcher.go` | 加 `replayStatus()` method — 走 `m.snapshotStatuses()` 拿 session 列表 + agentType + status → 對每個 session 走 `applyStatus` |
+| `internal/module/agent/probe_intent_dispatcher_test.go` | 加 replay integration test |
+
+**Test**：
+- `TestReplayStatus_RunningSession_DetectorArmed`（fixture：projection top frame + status=running → Start 後 dispatcher.activeProbeIntents 含對應 entry）
+- `TestReplayStatus_IdleSession_DetectorNotArmed`
+- `TestReplayStatus_StaleFrame_DetectorEmitsImmediately`（fixture：projection top frame.pid 已死 + status=running → Start 後 detector 第一次 poll 立即 emit + broadcast error）— 此 test 用 stub detector 模擬 emit；real 場景在 Phase 2 P2-T8
+
+**Acceptance**：`go test ./internal/module/agent/...` 全綠。
+
+**估計**：~40 行 production / ~150 行 test。
+
+**依賴**：P1-T3 + P1-T4 + P1-T5。
+
+---
+
+### Phase 1 完成檢核
+
+- [ ] `go test ./internal/agent/... ./internal/module/agent/...` 全綠
+- [ ] `go test -race ./internal/module/agent/...` 全綠（race 檢查）
+- [ ] `go build ./...` 全綠
+- [ ] ScreenChange path zero regression（既有 probe_orchestrator_test.go / probe_orchestrator_integration_test.go 全綠）
+- [ ] dispatcher / lifecycle test list 全部 pass（30+ tests）
+- [ ] `pnpm lint` / `pnpm build` clean（SPA 不受影響）
+
+完成後可進 Phase 2。
+
+---
+
+## 2. Phase 2：codex detector + drift test + mlab live verify
+
+### P2-T1 — `tmux.Executor.HasPane(paneID) bool`
+
+**目標**：tmux helper 新方法 — `tmux list-panes -a -F '#{pane_id}'` + scan paneID。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/tmux/executor.go` | 新加 `HasPane(paneID string) bool` 方法（包 list-panes -a；scan output；包含 paneID 即 true） |
+| `internal/tmux/executor_test.go` | 加 unit test（mock command output） |
+
+**Test**：
+- `TestHasPane_PaneExists_ReturnsTrue`
+- `TestHasPane_PaneNotInList_ReturnsFalse`
+- `TestHasPane_TmuxCommandError_ReturnsFalse`（conservative — 任何 error 都當 not found）
+- `TestHasPane_EmptyPaneID_ReturnsFalse`
+
+**Acceptance**：`go test ./internal/tmux/...` 全綠。
+
+**估計**：~25 行 production / ~80 行 test。
+
+**依賴**：none。**必須在 P2-T2 detector 之前**（per by2z79ouc Defense — detector 編譯需要 HasPane 存在）。
+
+---
+
+### P2-T2 — codex `StartProcessDeadDetector` + `isPidAliveFn` injection
+
+**目標**：實作 codex-side detector。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/agent/codex/probe_intent_process_dead.go`（新檔） | per spec §4.2 完整偽碼：`isPidAliveFn = probe.IsPidAlive` package var + `processDeadPollInterval = 1 * time.Second` package var + `StartProcessDeadDetector(ctx, paneLister, paneID, senderPID, out)` + `tmuxPaneLister` interface |
+| `internal/agent/codex/probe_intent_process_dead_test.go`（新檔） | 4 種 (pidAlive×paneAlive) 組合 + multi-pane fixture |
+
+**Test list**：
+- `TestStartProcessDeadDetector_BothAlive_KeepsPolling`（2 ticks 後 ctx cancel；channel 無 emission）
+- `TestStartProcessDeadDetector_PidDead_PaneAlive_EmitsErrorPath`（PaneAlive=true → error）
+- `TestStartProcessDeadDetector_PidDead_PaneGone_EmitsClearPath`（PaneAlive=false → clear）
+- `TestStartProcessDeadDetector_PidAlive_PaneGone_TreatedAsPaneGone`（process re-parented edge case → PaneAlive=false 路徑）
+- `TestStartProcessDeadDetector_CtxCancel_ExitsImmediately`
+- `TestStartProcessDeadDetector_EmitsOnceThenReturns`（dead-confirmed 後不再 poll）
+- `TestStartProcessDeadDetector_PidAliveFn_OverrideAndCleanup`（test override + cleanup pattern）
+- `TestStartProcessDeadDetector_MultiPane_UsesCorrectPaneID`（fixture：tmux list-panes 回 [%5, %7]，detector 看 %5 是否還在；不被 %7 影響）
+
+**Acceptance**：
+- `go test ./internal/agent/codex/...` 全綠
+- `go test -race` 全綠
+- 4 個 (pidAlive×paneAlive) 組合都驗證
+- `isPidAliveFn` override + cleanup pattern 正確
+
+**估計**：~70 行 production / ~220 行 test。
+
+**依賴**：P1-T1 + P2-T1。
+
+---
+
+### P2-T3 — codex `Provider.ProbeIntents()` + `onProcessDead` mapper
+
+**目標**：codex provider 實作 ProbeIntentProvider；OnSignal 區分 PaneAlive=true→error / =false→clear。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/agent/codex/provider.go` | 加 `ProbeIntents() []agent.ProbeIntent` method + `onProcessDead(sig agent.Signal) agent.Status` |
+| `internal/agent/codex/provider_test.go` | 加 unit test |
+
+**Test**：
+- `TestProvider_ProbeIntents_DeclaresProcessDead`
+- `TestProvider_ProbeIntents_OnEntryStatusContainsRunningWaiting`
+- `TestOnProcessDead_PaneAliveTrue_MapsToError`
+- `TestOnProcessDead_PaneAliveFalse_MapsToClear`
+- `TestOnProcessDead_WrongKind_ReturnsEmpty`（防 dispatcher misuse）
+
+**Acceptance**：`go test ./internal/agent/codex/...` 全綠。
+
+**估計**：~25 行 production / ~80 行 test。
+
+**依賴**：P1-T1 + P2-T2。
+
+---
+
+### P2-T4 — Dispatcher 路由 `ProcessDead` Kind 到 codex detector（生產 wiring）
+
+**目標**：`probe_intent_dispatcher.go` 的 `applyIntentLifecycle` switch on Kind 加 ProcessDead case，呼叫 `codex.StartProcessDeadDetector`。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/probe_intent_dispatcher.go` | 在 `applyIntentLifecycle` 內 lifecycle plan execution 段，switch on intent.Kind：`case agent.ProbeIntentKindProcessDead: codex.StartProcessDeadDetector(...)` |
+| `internal/module/agent/probe_intent_dispatcher_test.go` | 加 integration test |
+
+**Test**：
+- `TestApplyStatus_RealCodexDetector_ArmsAndStops`（用 fake `tmux.Executor` + override `isPidAliveFn` → emit signal → 驗 lifecycle teardown）
+
+**Acceptance**：`go test ./internal/module/agent/...` 全綠 + 整合 codex detector 跑通。
+
+**估計**：~10 行 production / ~120 行 test。
+
+**依賴**：P1-T3 + P2-T2 + P2-T3。
+
+---
+
+### P2-T5 — Drift test
+
+**目標**：iterate registry 找所有 `ProbeIntentProvider`；對每個逐一驗證 dispatcher 路由完整性。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/probe_intent_dispatcher_drift_test.go`（新檔） | 走 registry → for each provider 實作 ProbeIntentProvider → for each declared Kind → assert dispatcher case 存在 + OnSignal 不為 nil + OnEntryStatus 非空 + Signal 4 fields 都被 detector 寫入 |
+
+**Test**：
+- `TestProbeIntentDriftCoverage`：registry sweep + assertions
+- `TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase`
+- `TestProbeIntentDrift_OnSignalNonNil_OnEntryStatusNonEmpty`
+
+**Acceptance**：drift test 失敗時 error message 清楚指出哪個 provider / kind 缺實作。
+
+**估計**：~80 行 test。
+
+**依賴**：P2-T4。
+
+---
+
+### P2-T6 — Trace dev log: `[probe-intent]` step kind
+
+**目標**：W4 trace pipeline 加第 6 條 chain log `[probe-intent]`；同時更新 `trace.go` package comment 列出 6 條 step 順序。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/trace.go` | package comment 補 `[probe-intent]` step（包含 start / signal / stop / drop 4 個 sub-step）|
+| `internal/module/agent/probe_intent_dispatcher.go` | dev log（在 `isDevMode()` 條件下）— `[probe-intent] start session=X agent=codex kind=process_dead pane=%5 pid=12345 generation=N` / `[probe-intent] signal session=X kind=process_dead PaneAlive=true newStatus=error applied=true` / `[probe-intent] stop session=X kind=process_dead reason=Y` / `[probe-intent] drop session=X kind=process_dead reason=stale-callback\|grace\|error-guard` |
+| `internal/module/agent/probe_intent_dispatcher_test.go` | 補 dev log 測試（用 capturing logger）|
+
+**Test**：
+- `TestProbeIntent_DevLog_StartLine`
+- `TestProbeIntent_DevLog_SignalLine`
+- `TestProbeIntent_DevLog_DropReason_StaleCallback`
+
+**Acceptance**：`PDX_DEV_MODE=1` 下 4 類 log 在對應路徑被印出。
+
+**估計**：~30 行 production / ~100 行 test。
+
+**依賴**：P2-T4。
+
+---
+
+### P2-T7 — Integration test: codex 進程 alive→dead 兩條 mapping path
+
+**目標**：mock codex 進程 alive→dead；驗 status running → error / running → clear 兩條完整 broadcast。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/probe_intent_dispatcher_integration_test.go`（新檔） | 整合 codex detector + dispatcher + applyProbeGuards + broadcast；mock tmux + override isPidAliveFn 控制 process state |
+
+**Test**：
+- `TestIntegration_CodexProcessDead_PaneAlive_BroadcastsError`
+- `TestIntegration_CodexProcessDead_PaneGone_BroadcastsClear`
+- `TestIntegration_CodexNormalExit_NoErrorBroadcast`（status=idle 期間 process dead → ProbeIntent 不 armed → 不 broadcast）
+- `TestIntegration_CodexRestart_ActiveTargetMismatch_ReArms`（同 pane 內換 pid → case 5 觸發）
+- `TestIntegration_AgentSwitchCodexToCC_OldDetectorTornDown`（reconcile cleanup 驗證）
+
+**Acceptance**：`go test ./internal/module/agent/...` 全綠 + integration test list 全 pass。
+
+**估計**：~300 行 test。
+
+**依賴**：P2-T4 + P2-T6。
+
+---
+
+### P2-T8 — mlab live verify
+
+**目標**：手動驗證 4 個關鍵場景；產出證據（log + screenshot）。
+
+**步驟**：
+
+1. **Build worktree binary**：
+   ```
+   cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-w6-3-codex-error
+   go build -o /tmp/pdx-w6-3 ./cmd/pdx
+   ```
+2. **Stop existing daemon**：`pkill -f "/tmp/pdx serve"`
+3. **Start W6-3 daemon**：
+   ```
+   PDX_DEV_MODE=1 /tmp/pdx-w6-3 serve > /tmp/pdx-w6-3.log 2>&1 &
+   ```
+4. **Reinstall codex hooks**（若 sender_pid 路徑有變動）：
+   ```
+   /tmp/pdx-w6-3 install --reinstall --agent codex
+   ```
+
+**4 個場景**：
+
+| § | 場景 | 期望 | 驗證 |
+|---|---|---|---|
+| §1 codex SIGKILL | codex running 中 → `kill -9 <codex_pid>` | ≤2s lights 變 error | `[probe-intent] signal ... PaneAlive=true newStatus=error applied=true` log + SPA tab icon 紅 |
+| §2 codex pane close | codex running 中 → `tmux kill-pane -t %X` | ≤2s lights 變 clear | `[probe-intent] signal ... PaneAlive=false newStatus=clear applied=true` log + SPA tab icon 灰 |
+| §3 codex /exit | codex running → `/exit` | lights → idle 後 ProbeIntent 停；後續 pane close 不誤觸 | `[probe-intent] stop session=X kind=process_dead reason=lifecycle-applyStatus` log；後續 pane close **無** signal log |
+| §4 daemon restart 後 codex 已死 | codex running 中 stop daemon → kill codex → restart daemon | restart 後 ≤2s lights 變 error | `[probe-intent] start ...` (replay arm) → 立刻 `[probe-intent] signal ... PaneAlive=true ... applied=true` log |
+
+**附加場景（可選）**：
+
+| § | 場景 | 期望 |
+|---|---|---|
+| §5 codex restart 換 pid | codex running → /exit → 重新啟新 codex（同 pane）→ 新 status=running 後 kill 新 pid | lights 變 error，舊 detector 不誤觸 |
+| §6 multi-pane | 同 window 兩個 pane 都跑 codex → kill 其中一個 | 該 pane lights 變 error，另一個 pane 不受影響 |
+| §7 cross-provider | codex running → user 切到該 session 跑 cc → cc 啟動後 kill 原 codex pid | 不誤觸 error（codex active entry 已被 reconcile 清掉）|
+
+**Acceptance**：4 個必驗場景全 PASS，留下 log evidence；不必驗證附加場景（test 已覆蓋）。
+
+**估計**：1-2 小時 manual。
+
+**依賴**：P2-T1-T7 全部 commit。
+
+---
+
+### Phase 2 完成檢核
+
+- [ ] `go test ./...` 全綠
+- [ ] `go test -race ./...` 全綠
+- [ ] `pnpm lint && pnpm build` clean
+- [ ] drift test 通過 + 失敗訊息有意義
+- [ ] dev log 4 類 line 都產出
+- [ ] mlab live §1-§4 全 PASS
+
+---
+
+## 3. Subagent 派發策略（per `feedback_subagent_tdd_priority`）
+
+每個 task 派 subagent 跑 TDD：
+1. 讀 spec 對應段落 + plan task description
+2. 寫 failing test 先
+3. 寫最小 production code 讓 test pass
+4. refactor / cleanup
+5. 跑 `go test -race`（dispatcher 相關）+ `go build`
+6. commit（per CLAUDE.md「每個 task 獨立 commit」）
+
+Subagent prompt 模板：
+
+```
+你是 W6-3 PR Phase X 的 P{X-Y} task 實作 subagent。
+
+Worktree: /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-w6-3-codex-error
+Spec: docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md（v6 final）
+Plan: docs/specs/2026-04-29-w6-3-codex-error-probe-intent-plan.md
+
+Task: P{X-Y}
+目標: <copy from plan>
+改動檔案: <copy from plan>
+Test: <copy from plan>
+Acceptance: <copy from plan>
+
+務必：
+1. 每個 Bash 命令前綴 `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-w6-3-codex-error && `（per feedback_subagent_cwd_enforcement）
+2. Edit/Write 用絕對路徑（per feedback_worktree_absolute_path）
+3. TDD：failing test 先、minimal impl 後
+4. 完成後 commit message: "<type>(<scope>): <task name>"
+5. 不主動 push（push 由主 session 控制）
+6. 報告：所有改動的檔案 + 跑過的 test + 任何 spec 解讀疑問
+```
+
+主 session 職責：
+- 監控 subagent 進度
+- 驗證每 task commit 內容（`git diff` 檢查）
+- 跨 task integration regression 檢查
+- mlab live verify P2-T8（不派 subagent，手動操作）
+
+---
+
+## 4. PR 拆 / merge 流程（per CLAUDE.md）
+
+1. Phase 1 + Phase 2 全 commit 完，跑 `go test ./...` + `pnpm lint && pnpm build` 全綠
+2. PR body 起草（含 spec / plan 連結 + test plan + 14 task summary）
+3. 委派 codex round 1 標準 review（`/codex:review --base origin/main --background`）
+4. 收斂 round 1 finding；要修就修，要 defer 就建 issue
+5. 委派 codex round 2 三平行 adversarial（攻擊 / 防守 / 體質）— focus 文已在 spec 階段累積；prompt 強調 P1-T2 mechanical extraction 行為一致性 + lifecycle race 全 case
+6. 收斂 round 2 finding 直到 0 P1
+7. squash merge → main
+8. 起 bump PR alpha.262（VERSION + package.json + spa/package.json + CHANGELOG.md）
+
+---
+
+## 5. Test plan summary
+
+### Unit test（隔離測試）
+- ProbeIntent types（P1-T1）：3-5 tests
+- applyProbeGuards 5 個 guard layer（P1-T2）：6-7 tests
+- Dispatcher lifecycle 5 case（P1-T3）：5 tests
+- Reconcile 4 case（P1-T3）：4 tests
+- Probe-applied teardown（P1-T3）：2 tests
+- Stale-callback / generation（P1-T3）：3 tests
+- Replay race（P1-T3, P1-T6）：2-3 tests
+- lookupTopFrame helper（P1-T4）：3 tests
+- manageActivityWatch / rename / Stop（P1-T5）：4 tests
+- replayStatus（P1-T6）：3 tests
+- HasPane（P2-T1）：4 tests
+- ProcessDead detector（P2-T2）：8 tests
+- Provider ProbeIntents + OnSignal（P2-T3）：5 tests
+- Drift（P2-T5）：3 tests
+- Dev log（P2-T6）：3 tests
+
+### Integration test（跨層）
+- codex detector + dispatcher（P2-T4）：1 test
+- 完整 broadcast path 兩條 mapping（P2-T7）：5 tests
+
+**Test 總計**：~60+ tests。
+
+### Live verify
+- mlab §1-§4：4 必驗場景
+
+---
+
+## 6. Known issues / risks
+
+### 已知接受限制（non-blocking for ship）
+
+1. **Idle session pane gone（spec §6.4 / §8.1 #4）**：codex 走完 PdxStop 進 idle 後 pane close，ProbeIntent 不 armed → 不會自動轉 clear（由 sweep / SessionEnd hook 處理）— 不在 W6-3+W6-4 scope
+2. **codex /exit 不發 SessionEnd hook**：documented in audit / `docs/research/2026-03-19:159`；W6-4 處理 pane close 場景，但 codex `/exit` 後 user 不 close pane 仍是 idle 永久（非本 PR scope）
+
+### 風險與對策
+
+| 風險 | 機率 | 影響 | 對策 |
+|---|---|---|---|
+| `applyProbeGuards` mechanical extraction 不夠 mechanical（行為微變） | medium | high (regression) | P1-T2 嚴格跑既有 ScreenChange test 全綠；codex review 對 mechanical extraction 二次 verify |
+| ProbeIntent lifecycle 還有 corner case 未列（spec convergence 5 → 1 trend） | medium | medium | plan / 實作 / PR codex review 三層把關；known issue 化追蹤 |
+| frame projection top frame 不存在（罕見：projection rebuild 失敗）| low | low | dispatcher skip arm，下個 hook 重 hydrate 後 applyStatus 再試 — 已 spec |
+| daemon restart 後 stale frame 立即 emit error（spec §6.4 — accept） | low | low (符合 #698 修復目標) | accept；mlab live §4 驗證 |
+| 1Hz polling 對 idle daemon 額外 cost | very low | very low | accept（成本可忽略；spec §4.2 已論證） |
+
+### Rollback 計畫
+
+若 ship 後發現 regression：
+1. revert merge commit
+2. 起 hotfix bump
+3. issue 追蹤 root cause
+4. 重新 plan 修法 → 重新 PR
+
+---
+
+## 7. Bump PR
+
+Phase 2 PR squash merge 後獨立 bump PR：
+- VERSION: alpha.261 → alpha.262
+- spa/package.json + package.json 同步
+- CHANGELOG.md 加：
+  ```
+  ### lights rebuild
+  - **W6-3 + W6-4**: codex error / clear ad-hoc ProbeIntent
+    - codex 進程被 SIGKILL（pane 仍存在）→ lights 自動變紅（W5-4 修復）
+    - codex pane 被關閉（process 同時退出）→ lights 自動變灰（W5-5 修復）
+    - daemon restart 後仍能正確發現 codex 已死亡（issue #698 修復）
+    - 引入 `ProbeIntentProvider` interface + 內部 dispatcher（lifecycle / guard / generation token）
+  ```
+- closes #698（W6 platform prerequisite）；標 W5-4 / W5-5 fixed
+- bump PR 用獨立 worktree：`bump-alpha-262`
+
+---
+
+## 8. 完成檢核總表
+
+| Phase | 檢核 | 狀態 |
+|---|---|---|
+| Phase 1 P1-T1~T6 | 6 task 全 commit + test 全綠 + race 全綠 + ScreenChange regression 0 | ⏳ |
+| Phase 2 P2-T1~T7 | 7 task 全 commit + test 全綠 + drift test pass + dev log 完整 | ⏳ |
+| Phase 2 P2-T8 | mlab live §1-§4 全 PASS | ⏳ |
+| PR + codex review 兩輪 | 0 critical/P1 + known issue 追蹤化 | ⏳ |
+| Squash merge → main | branch 刪除 + worktree 清理 | ⏳ |
+| Bump PR alpha.262 | merge | ⏳ |

--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-plan.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-plan.md
@@ -525,7 +525,7 @@ Concurrent rename（補 §6.4 race）：
 - [ ] `pnpm lint && pnpm build` clean
 - [ ] drift test 通過 + 失敗訊息有意義
 - [ ] dev log 4 類 line 都產出
-- [ ] mlab live §1-§4 全 PASS
+- [ ] mlab live §1-§5 全 PASS（含 daemon-restart pane-gone clear 路徑）
 
 ---
 

--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
@@ -1,6 +1,6 @@
 # W6-3 codex error ad-hoc ProbeIntent spec
 
-> **Status**：draft v4（codex review round 3 1 P1 finding — active target mismatch lifecycle gap — 採納修訂）
+> **Status**：draft v5（codex review round 4 1 P1 — cross-provider lifecycle gap — 採納修訂）
 > **Worktree**：`.claude/worktrees/lights-w6-3-codex-error` / branch `worktree-lights-w6-3-codex-error`
 > **Base**：`origin/main` @ alpha.261（W3+W4 reverted ProbeProfile framework + monitor top processes）
 > **依賴**：W1 audit `docs/specs/2026-04-28-hook-status-audit-spec.md` §6/§7 / lights-rebuild-spec `docs/specs/2026-04-23-lights-rebuild-spec.md` §8.2 / fix-spec `docs/specs/2026-04-28-lights-rebuild-fix-spec.md` §3
@@ -94,6 +94,7 @@ W3 撤回後（alpha.260）的現況：
 | **OnSignal mapping callback in applyProbeGuards（guard 後才 invoke）** | by2z79ouc DEF-1 | 本 spec §3.2 / §5.2 / §5.4 |
 | **detector `isPidAliveFn` package var injection** | by2z79ouc FH-1 | 本 spec §4.2 |
 | **單一 lifecycle helper + active target mismatch 第五 case** | round 3 P1 | 本 spec §5.4 |
+| **applyStatus 入口 reconcileSessionActive（cross-provider cleanup）** | round 4 P1 | 本 spec §5.4 |
 
 ---
 
@@ -147,6 +148,7 @@ W3 撤回後（alpha.260）的現況：
 11. ✅ ProbeIntent compare-and-arm（per by2z79ouc ATK-2）：lifecycle 在 m.mu 內 re-read `currentStatus` + 比對 `OnEntryStatus`，只在 live status 仍 match 才 record active；防 replay 期間 hook race 後 arm stale watcher
 12. ✅ Detector pidAlive 注入（per by2z79ouc FH-1）：codex 包用 `isPidAliveFn` package var（沿 module 包既有 `orchNowFn` / `isPidAliveFn` pattern）；test 覆寫後 cleanup
 13. ✅ ProbeIntent active target re-arm（per round 3 P1）：lifecycle helper 在 `wasActive && shouldActive` 時 m.mu 內比對 `(agentType, paneID, senderPID)` 是否與 active entry 一致；不一致 → cancel 舊 detector + 計算 new generation + 寫入新 entry；防同 status 內 codex 換 pid/pane（restart / multi-pane 切換）後舊 detector 蓋掉新狀態
+14. ✅ Cross-provider reconcile（per round 4 P1）：`applyStatus` 入口先 `reconcileSessionActive`，cancel/delete 任何 `(agentType, kind)` 不再屬於新 provider 宣告集合的 active entry；防 session 切到無 ProbeIntent 的 provider（cc / opencode）後舊 codex detector 仍 emit 蓋掉新狀態
 
 ### 2.2 禁忌
 
@@ -619,10 +621,63 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
 ```go
 func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus agent.Status) {
     provider, ok := d.parent.registry.GetByType(agentType)
-    if !ok { return }
-    intents := probeIntentsOf(provider)  // type assert ProbeIntentProvider；ok=false 直接 return
+    if !ok {
+        // 未知 agent → reconcile 清掉所有 active（含舊 codex entry 等）
+        d.reconcileSessionActive(session, agentType, nil)
+        return
+    }
+    intents := probeIntentsOf(provider)  // type assert ProbeIntentProvider；non-implementer 回 nil
+
+    // round 4 P1：reconcile session 既有 active entries
+    // 凡 (cur.agentType != newAgentType) 或 cur.kind 不在新 provider 宣告集合 → cancel + delete
+    declaredKinds := make(map[agent.ProbeIntentKind]struct{}, len(intents))
+    for _, intent := range intents {
+        declaredKinds[intent.Kind] = struct{}{}
+    }
+    d.reconcileSessionActive(session, agentType, declaredKinds)
+
     for _, intent := range intents {
         d.applyIntentLifecycle(session, agentType, newStatus, intent)
+    }
+}
+
+// reconcileSessionActive cancel/delete active entries that don't apply to the
+// (newAgentType, declaredKinds) pair. Called from applyStatus before the
+// lifecycle loop. declaredKinds=nil → drop everything (unknown agent / no
+// ProbeIntents declared).
+//
+// Per round 4 P1: without this, switching session top agent from codex (with
+// ProcessDead intent) to cc/opencode (no ProbeIntents) would leave codex
+// active entry stranded. The stranded detector continues polling and its
+// emission still passes makeProbeIntentStaleCheck (active entry's agentType
+// + generation match) → broadcasts wrong status for the new agent.
+func (d *probeIntentDispatcher) reconcileSessionActive(
+    session string,
+    newAgentType string,
+    declaredKinds map[agent.ProbeIntentKind]struct{}, // nil = drop all
+) {
+    var toCancel []context.CancelFunc
+
+    d.parent.mu.Lock()
+    perSession := d.parent.activeProbeIntents[session]
+    if perSession != nil {
+        for kind, cur := range perSession {
+            stale := declaredKinds == nil ||
+                cur.agentType != newAgentType ||
+                func() bool { _, ok := declaredKinds[kind]; return !ok }()
+            if stale {
+                toCancel = append(toCancel, cur.cancel)
+                delete(perSession, kind)
+            }
+        }
+        if len(perSession) == 0 {
+            delete(d.parent.activeProbeIntents, session)
+        }
+    }
+    d.parent.mu.Unlock()
+
+    for _, cancel := range toCancel {
+        cancel()
     }
 }
 
@@ -846,6 +901,7 @@ func (d *probeIntentDispatcher) replayStatus() {
 - replay 順序：先 `replayFromDB` 把 currentStatus + projection 全 hydrate 完，再 `replayStatus()` — 避免 detector 啟動時 `lookupTopFrameForSession` miss
 - **Replay vs hook race（by2z79ouc ATK-2 + round 3 P1 修法）**：`replayStatus` 內部呼叫 `applyStatus(session, agentType, snapshotStatus)` 走標準路徑；`applyIntentLifecycle` 在 m.mu 內 re-read `currentStatus` + `lookupTopFrameForSessionLocked` + 比對 active target — 若 snapshot 取到 `running` 但 hook 已先把 status 改成 `idle`（or 改了 top frame target），lifecycle 在 m.mu 內看到 live state 為基準直接 skip / restart。**Race 完全封閉**
 - **Active target mismatch（round 3 P1）**：同 status 內 codex 換 pid/pane（restart / multi-pane 切換）— `applyIntentLifecycle` 第五 case：cancel 舊 detector + 寫新 entry（含新 generation） + 啟新 detector；舊 detector 在新 entry 寫入後仍可能 emit 舊 generation 的 stale signal，被 `makeProbeIntentStaleCheck` drop（generation mismatch）
+- **Cross-provider lifecycle gap（round 4 P1）**：session 切到無 ProbeIntent 的 provider（cc / opencode）時，`applyStatus` 入口 `reconcileSessionActive` 清掉舊 codex active entry → 舊 detector emission 因 active entry 已不存在被 `makeProbeIntentStaleCheck` drop
 - **Stale frame race**：若 daemon 在 codex 已死的情況下重啟，replay 取到的 top frame.pid 已是 dead → detector 第一次 poll 立即 emit signal → 套 guards → 因 currentStatus 經 replay 仍是 running，transition gate 通過 → broadcast `error`。**這是預期行為**：user-facing 結果是「daemon restart 後正確發現 codex 不見了，立刻變色」，符合 #698 修復目標
 - **Idle session pane gone（accept 限制）**：若 codex 走完 PdxStop hook（status=idle）後 daemon restart，replay snapshot status=idle → ProbeIntent 不在 OnEntryStatus 不啟 detector → pane 後續被 close 不會自動轉 clear。此屬 §8.1 #4 的 accept 限制（idle 期間 pane 退場由 sweep / SessionEnd hook 處理，不在 W6-3+W6-4 scope）
 - ErrorGuard 與 grace window：replay 路徑**沒有**剛收的 hook，故 graceWindow 不啟動；ErrorGuard 視 currentStatus 而定（若已是 error，guard 阻擋無妨）
@@ -865,7 +921,7 @@ func (d *probeIntentDispatcher) replayStatus() {
 |---|---|
 | P1-T1 | `ProbeIntent` / `ProbeIntentKind` / `Signal` / `ProbeIntentProvider` 落 `internal/agent/provider.go` + 單元測試（schema 對齊 §3.2；Signal 4 fields） |
 | P1-T2 | `applyProbeGuards` free function 抽出（mechanical extraction `probe_orchestrator.go interpretScreenEvent` step 1+2+4+5+6） + 新 `staleCheck strategy` 注入點；regression test 確保 ScreenChange 行為零變動（既有 probe_orchestrator_test.go / probe_orchestrator_integration_test.go 全綠） |
-| P1-T3 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `applyIntentLifecycle` / `consumeSignals` + activeProbeIntents 結構（在 m.mu 內保護） + generation token；用 stub detector 測 lifecycle 5 case（含 active target mismatch 觸發 cancel-and-rearm） + stale-callback re-check + generation 不匹配 drop |
+| P1-T3 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `reconcileSessionActive` / `applyIntentLifecycle` / `consumeSignals` + activeProbeIntents 結構（在 m.mu 內保護） + generation token；用 stub detector 測 lifecycle 5 case（含 active target mismatch 觸發 cancel-and-rearm） + cross-provider reconcile（codex → cc 切換清掉舊 entry） + stale-callback re-check + generation 不匹配 drop |
 | P1-T4 | `Module.lookupTopFrameForSession` helper（讀 projection top frame `(paneID, pid)`）+ test |
 | P1-T5 | `manageActivityWatch` 接 `probeIntentDisp.applyStatus`；rename / Stop 路徑也接；test 覆蓋 rename 期間 (oldName stop, newName 重評估) |
 | P1-T6 | `Module.Start` 加 `probeIntentDisp.replayStatus`；daemon-restart recovery integration test（fixture：projection top frame 含 dead pid + status=running → Start 後 detector 啟動立即 emit → broadcast error） |
@@ -922,6 +978,7 @@ func (d *probeIntentDispatcher) replayStatus() {
 7. ✅ multi-pane window：detector 對 hook 來源 pane 作判斷，不被同 window 其他 pane（含其他 codex 實例）影響
 8. ✅ active target mismatch（round 3 P1 防護）：codex pane 內 `/exit` + 立即重啟新實例（同 session、status 短暫從 idle 經 SessionStart→UserPromptSubmit 變回 running），detector 必須 cancel 舊 (paneID, oldPID) entry 並 arm 新 (paneID, newPID) entry — 舊 detector 對 oldPID 死亡的 emission 不應蓋掉新 codex 的 running status
 9. ✅ status-stable 換 frame：罕見場景下若 hook 在不變 status 的情況下推送新 top frame（例 frame_ops 重 detect），lifecycle 仍正確 re-arm（不沿用舊 detector）
+10. ✅ provider 切換（round 4 P1 防護）：session 從 codex 切到 cc / opencode（後者無 ProbeIntents）— 舊 codex active entry 必須被 `reconcileSessionActive` 清掉；舊 detector 後續 emission 因 active entry 不存在被 stale guard drop
 
 ### 8.2 不回歸
 
@@ -989,9 +1046,13 @@ func (d *probeIntentDispatcher) replayStatus() {
 
 **決議**：`applyIntentLifecycle` 在單一 m.mu critical section 內處理 5 case（含 active 但 target changed 的 cancel-and-rearm）；不暴露 `startDetector` / `stopDetector` 為公開 method（避免 caller 跳過 lifecycle 比對）。修法詳 §5.4。
 
+### 9.11 ✅ 採 `reconcileSessionActive` 入口清理 — 解 round 4 P1
+
+**決議**：`applyStatus` 入口先 reconcile session 既有 active entries，cancel/delete 任何 `(agentType, kind)` 不再屬於新 provider 宣告集合的 entry；防 cross-provider 切換的 stranded detector。修法詳 §5.4 reconcileSessionActive helper。
+
 ---
 
-**所有 spec drift signal 已收斂；本 spec v4 進 plan 前需通過 codex 第四輪確認。**
+**所有 spec drift signal 已收斂；本 spec v5 進 plan 前需通過 codex 第五輪確認。**
 
 ---
 

--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
@@ -1,6 +1,6 @@
 # W6-3 codex error ad-hoc ProbeIntent spec
 
-> **Status**：draft v2（codex review b36pap7jc 5 finding 全採納修訂；待 codex 二輪確認）
+> **Status**：draft v3（codex review by2z79ouc 4 finding 採納精度修訂；progressive precision，非 architectural drift）
 > **Worktree**：`.claude/worktrees/lights-w6-3-codex-error` / branch `worktree-lights-w6-3-codex-error`
 > **Base**：`origin/main` @ alpha.261（W3+W4 reverted ProbeProfile framework + monitor top processes）
 > **依賴**：W1 audit `docs/specs/2026-04-28-hook-status-audit-spec.md` §6/§7 / lights-rebuild-spec `docs/specs/2026-04-23-lights-rebuild-spec.md` §8.2 / fix-spec `docs/specs/2026-04-28-lights-rebuild-fix-spec.md` §3
@@ -89,6 +89,10 @@ W3 撤回後（alpha.260）的現況：
 | **detector 用 pane id target，非 session target** | b36pap7jc ATK-2 / PR #638 教訓 | 本 spec §4.2 |
 | **W6-3 + W6-4 合併 first PR**（避免 ship 已知 false alarm） | b36pap7jc ATK-3 | 本 spec §0.2.1 / §1.1 |
 | **reuse `agent_frames.pid + pane_id`，不新增 schema 欄位** | b36pap7jc FH-1 + self-check | 本 spec §4.3 / §6.2 |
+| **單一 m.mu 統管 active-set（含 activeProbeIntents）** | by2z79ouc ATK-1 | 本 spec §5.1 / §5.2 |
+| **startDetector compare-and-arm（m.mu 內 re-read currentStatus）** | by2z79ouc ATK-2 | 本 spec §5.4 / §6.4 |
+| **OnSignal mapping callback in applyProbeGuards（guard 後才 invoke）** | by2z79ouc DEF-1 | 本 spec §3.2 / §5.2 / §5.4 |
+| **detector `isPidAliveFn` package var injection** | by2z79ouc FH-1 | 本 spec §4.2 |
 
 ---
 
@@ -135,9 +139,12 @@ W3 撤回後（alpha.260）的現況：
 4. ✅ Interface lazy 設計 — W6-3 first PR finalize 唯一 `ProcessDead` Kind；後續 PR 加新 Kind 時 extend struct（Signal 既有 fields 必保持向後相容）
 5. ✅ probe channel 與 hook channel 獨立 — probe 推論、hook 權威；`recordHookAt` graceWindow 機制保留
 6. ✅ ErrorGuard 維持：`currentStatus == StatusError` 時 probe 不再覆寫
-7. ✅ Stale-callback guard（per-route）：ProbeIntent 路徑必須 re-check `activeProbeIntents[session][kind] && agentType == 期望` 兩條件；ScreenChange 路徑維持 re-check `activeWatchers[session] == agentType`；**兩條 active-set 互不共用** — `applyProbeGuards` 透過 strategy 注入正確的 active-set checker
-8. ✅ Detector goroutine 不持有 `m.mu`（鎖路徑 `dispatcher mu → m.mu` 嚴禁逆向）；Signal channel buffer = 1（detector emit 一次後退出）
+7. ✅ Stale-callback guard（per-route）：ProbeIntent 路徑必須 re-check `activeProbeIntents[session][kind] && agentType == 期望 && generation == 期望` 三條件；ScreenChange 路徑維持 re-check `activeWatchers[session] == agentType`；**兩條 active-set 共享 m.mu**（per by2z79ouc ATK-1）— `applyProbeGuards` 透過 strategy 注入正確的 active-set checker，但 checker 與 module mutation 在同一 mutex 內，no cross-lock
+8. ✅ Detector goroutine 不持有 `m.mu`；channel emit 後 dispatcher 內 consume → 走 `applyProbeGuards`；Signal channel buffer = 1（detector emit 一次後退出）；**鎖序：m.mu only**（per by2z79ouc ATK-1：activeProbeIntents 移進 m.mu 保護，dispatcher 不另持 mutex）
 9. ✅ ProbeIntent state 必須含 pane id；detector 觀察 pane existence 用 pane id 為 tmux target（不是 session target）— 防 multi-pane window 取錯 pane PID（per PR #638 教訓 / b36pap7jc ATK-2）
+10. ✅ ProbeIntent contract（per by2z79ouc DEF-1）：dispatcher 在 **guard 通過後**才 invoke OnSignal（mapping callback）；OnSignal 不會看到被 stale guard / graceWindow / ErrorGuard drop 的 signal — provider 即使有 side effect 也安全
+11. ✅ ProbeIntent compare-and-arm（per by2z79ouc ATK-2）：`startDetector` 在 m.mu 內 re-read `currentStatus` + 比對 `OnEntryStatus`，只在 live status 仍 match 才 record active；防 replay 期間 hook race 後 arm stale watcher
+12. ✅ Detector pidAlive 注入（per by2z79ouc FH-1）：codex 包用 `isPidAliveFn` package var（沿 module 包既有 `orchNowFn` / `isPidAliveFn` pattern）；test 覆寫後 cleanup
 
 ### 2.2 禁忌
 
@@ -226,10 +233,13 @@ type ProbeIntent struct {
     // by OnSignal means "drop this signal" (detector observed transient state
     // that doesn't warrant a transition).
     //
-    // dispatcher applies guards BEFORE invoking OnSignal: stale-callback guard
-    // (re-check activeProbeIntents[session][kind] + agentType), graceWindow,
-    // ErrorGuard, transition gate. OnSignal sees only signals that survive
-    // those guards.
+    // Contract (per by2z79ouc DEF-1): dispatcher invokes OnSignal as a
+    // mapping callback INSIDE applyProbeGuards, AFTER the stale-callback
+    // guard + graceWindow guard pass. OnSignal therefore never sees signals
+    // that should have been dropped by hook authority. ErrorGuard +
+    // transition gate run AFTER OnSignal returns (they need newStatus to
+    // compare against currentStatus). Provider may safely log / count in
+    // OnSignal because pre-guard-survived signals are guaranteed.
     OnSignal func(Signal) Status
 }
 
@@ -366,10 +376,20 @@ import (
     "github.com/wake/purdex/internal/agent/probe"
 )
 
-// processDeadPollInterval is the polling cadence for IsPidAlive + HasPane.
+// processDeadPollInterval is the polling cadence for pidAlive + HasPane.
 // Exported as a package var so tests can override — production code never
 // mutates it.
 var processDeadPollInterval = 1 * time.Second
+
+// isPidAliveFn is the injectable pid-liveness probe. Production points at
+// probe.IsPidAlive (which is a syscall.Kill(pid, 0) wrapper). Tests override
+// to control the alive/dead state per call (per by2z79ouc FH-1 — the
+// 4 pidAlive×paneAlive combinations require deterministic injection rather
+// than spawning real processes).
+//
+// Same pattern as internal/module/agent/probe_orchestrator.go's
+// `isPidAliveFn` / `orchNowFn` / `recordHookAtHook` etc.
+var isPidAliveFn = probe.IsPidAlive
 
 // StartProcessDeadDetector is the codex-side detector for
 // ProbeIntentKindProcessDead. It polls senderPID + paneID; on first dead-
@@ -380,8 +400,9 @@ var processDeadPollInterval = 1 * time.Second
 // paneLister is the minimal contract the detector needs (HasPane(paneID)).
 // Tests inject a recording fake. Production wires *tmux.Executor.
 //
-// Caller is expected to dispatch the emitted Signal to OnSignal and apply the
-// usual probe guards (graceWindow / ErrorGuard / transition gate).
+// Caller is expected to consume the emitted Signal via dispatcher's
+// applyProbeGuards (graceWindow / stale-callback / ErrorGuard / transition
+// gate / OnSignal mapping all live there).
 func StartProcessDeadDetector(
     ctx context.Context,
     paneLister tmuxPaneLister,
@@ -397,7 +418,7 @@ func StartProcessDeadDetector(
         case <-ctx.Done():
             return
         case <-ticker.C:
-            pidAlive := probe.IsPidAlive(senderPID)
+            pidAlive := isPidAliveFn(senderPID)
             paneAlive := paneLister.HasPane(paneID)
             if pidAlive && paneAlive {
                 continue  // both alive, keep polling
@@ -474,10 +495,14 @@ type tmuxPaneLister interface {
 
 職責：
 
-- 持有 per-session × per-Kind detector goroutine 集合：`activeProbeIntents map[session]map[Kind]activeIntent`，其中 `activeIntent` 含 `cancelFn` + `agentType` + `paneID` + `senderPID` + `generation` token（防 stale callback / re-arm race）
-- 在 status 變更時讀取 provider.ProbeIntents()，啟停對應 detector
-- detector 透過 channel emit Signal → dispatcher 套 ProbeIntent-aware guards → 走 OnSignal → broadcast
-- 不直接 mutate `m.activeWatchers`（保留給 ScreenChangeWatcher）
+- 提供 ProbeIntent gating logic（status 變更時讀 provider.ProbeIntents() 啟停對應 detector）
+- detector 透過 channel emit Signal → dispatcher 套 `applyProbeGuards`（含 OnSignal mapping）
+
+**Lock ownership**（per by2z79ouc ATK-1 — v2 設計修正）：
+
+- `activeProbeIntents map[session]map[Kind]activeIntent` **由 m.mu 保護**（與 `activeWatchers` 同一 mutex），**不**另起 dispatcher.mu
+- 統一鎖序：`m.mu only`，無 cross-lock；`applyProbeGuards` 在 m.mu 內 re-check active-set 是 lock-free read（lock 已持）
+- `activeIntent` 結構：`cancel func()` / `agentType string` / `paneID string` / `senderPID int` / `generation uint64`
 
 **為何不 reuse `probeOrchestrator`**（per b36pap7jc DEF — 重新挑戰過）：
 
@@ -485,41 +510,57 @@ type tmuxPaneLister interface {
 - ProcessDead detector 與 ScreenChange 是兩種獨立 mechanism（前者 `(senderPID, paneID) → bool×bool`；後者 `tmux pane content hash → ScreenChanged|ScreenStable`）— 強行整進 `probeOrchestrator` 會引入「unify abstraction」bloat（§2.3）
 - 共用部分（graceWindow / ErrorGuard / transition gate / **strategy-injectable** stale-callback guard）抽為 free function `applyProbeGuards(m, args)`，在兩個 dispatcher 間共用 — 行為零變動，是 mechanical extraction（不違 §2.3 refactor without functional reason）
 
-### 5.2 `applyProbeGuards` strategy 注入（核心修正：per b36pap7jc ATK-1）
+### 5.2 `applyProbeGuards` 重設計（per by2z79ouc ATK-1 / DEF-1）
 
-抽 free function，但**stale-callback guard 用 strategy 注入** — ProbeIntent 路徑與 ScreenChange 路徑各自走自己的 active-set checker，不共用 `m.activeWatchers`：
+抽 free function — **單一 m.mu 保護**所有 active-set；OnSignal 在 guard 通過後才被 invoke：
 
 ```go
-// applyProbeGuards 套用 5 層 guard 並 broadcast。回傳 (newStatus, applied)；
-// applied=false 代表此 signal 被 guard drop / 視為 no-op。
+// applyProbeGuards 套用 4 層 guard（含 mapping）並 broadcast。
+// 回傳 applied=false 代表此 signal 被 guard drop / 視為 no-op。
 //
-// 5 層 guard（按順序）：
-//   1. Stale-callback guard（透過 staleCheck 注入）：
-//        ProbeIntent 路徑：active.checker = activeProbeIntentChecker(session, kind, agentType, generation)
-//        ScreenChange 路徑：active.checker = activeWatcherChecker(session, agentType)
-//   2. graceWindow（hook authority；既有 probeGraceWindow=2s）
-//   3. Mapping → newStatus（caller-provided：ScreenChange 路徑用 kind→status；ProbeIntent 路徑用 OnSignal）
-//   4. ErrorGuard：currentStatus == StatusError 時 drop
-//   5. Transition gate：currentStatus == newStatus 時 drop（避免 broadcast spam）
+// 流程（m.mu 在 step 1+5 內各持一次）：
+//   1. m.mu Lock — Stale-callback guard：透過 StaleCheck closure（caller 提供）
+//      檢查 active-set 是否仍含目標 entry 且 agentType + generation 都匹配
+//      ProbeIntent 路徑：staleCheck 讀 m.activeProbeIntents[session][kind] +
+//                        agentType + generation
+//      ScreenChange 路徑：staleCheck 讀 m.activeWatchers[session] + agentType
+//      不匹配 → m.mu Unlock + return false
+//      匹配 → m.mu Unlock（不持 lock 進下一步，因為 graceWindow / mapping 不需要）
 //
-// 通過 5 層後在最後 critical section 執行：
-//   - 再次原子 re-check staleCheck（codex finding #4 regression — close race window）
-//   - mutate m.currentStatus[session]
-//   - setProjectionTopStatus + buildProjectionNormalized + broadcastToSession
+//   2. graceWindow check（probeGraceMu 獨立 mutex — 既有 lock）
+//      hook recent (≤ probeGraceWindow) → return false
 //
-// 簽名：
+//   3. Mapping callback (per by2z79ouc DEF-1)：
+//      caller 已 captured Signal + Mapping function 進 args
+//      newStatus := args.Mapping(args.Signal)
+//      newStatus == "" → return false
+//      （ProbeIntent 路徑：args.Mapping = intent.OnSignal；
+//        ScreenChange 路徑：args.Mapping = kind→status fixed function）
+//
+//   4. m.mu Lock — final critical section + 再次原子 staleCheck
+//      （close race window between step 1 unlock and this lock — codex
+//       finding #4 regression）
+//      staleCheck false → m.mu Unlock + return false
+//      ErrorGuard：m.currentStatus[session] == StatusError → m.mu Unlock + return false
+//      Transition gate：m.currentStatus[session] == newStatus → m.mu Unlock + return false
+//      mutate m.currentStatus[session] = newStatus
+//      m.mu Unlock
+//
+//   5. broadcast（lock-free）：setProjectionTopStatus + buildProjectionNormalized + broadcastToSession
+//
 type probeGuardArgs struct {
     Session    string
     AgentType  string
-    Reason     string                 // 進 trace dev log（"probe-intent:process_dead" / "probe:activity"）
-    NewStatus  Status                 // 已 mapping 完的 status（caller 已套 OnSignal / kind→status）
-    StaleCheck func(*Module) bool     // 同一 critical section 內 re-check active-set；true=still active, false=drop
+    Reason     string                          // dev log："probe-intent:process_dead" / "probe:activity"
+    Signal     Signal                          // raw signal，未 mapping
+    Mapping    func(Signal) Status             // OnSignal (ProbeIntent) / kind→status (ScreenChange)
+    StaleCheck func(*Module) bool              // m.mu 內 lock-free read（caller 已持 m.mu 進入）
 }
 
 func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) { ... }
 ```
 
-ProbeIntent 路徑的 staleCheck 範例：
+ProbeIntent 路徑的 staleCheck 範例（**caller 在 m.mu 內呼叫 — lock-free read**）：
 
 ```go
 staleCheck := func(m *Module) bool {
@@ -533,7 +574,9 @@ staleCheck := func(m *Module) bool {
 }
 ```
 
-`generation` token：每次 `startDetector` 對 (session, kind) 啟動時遞增；detector emit signal 時帶當下 generation；guard re-check 確保 detector 沒被中途 stop+restart 過（防 ghost broadcast，per audit §7.1 必守 #7）。
+`generation` token：每次 `startDetector` 對 (session, kind) 啟動時遞增；detector emit signal 時帶當下 generation；guard re-check 確保 detector 沒被中途 stop+restart 過（防 ghost broadcast，per audit §7.1 必守 #7 / by2z79ouc DEF）。
+
+**Generation token 必要性**（回應 by2z79ouc Defense round 2 questioning）：理論上 ctx cancel 後 detector goroutine 已退出，新 detector 是新 goroutine，channel 也不同 — 但 emission 在 channel buffer 內可能還沒被 consume；start→stop→start' 期間 stop 走的 cancel 不保證**已 consume 的 signal** 不會繼續走完 `applyProbeGuards`（goroutine schedule 問題）。Generation 是兩次 active set 檢查的雙保險，相對 over-engineering 風險低（uint64 增量；無 owner reuse）。
 
 ### 5.3 `manageActivityWatch` 改造
 
@@ -577,25 +620,40 @@ func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus
 }
 ```
 
-### 5.4 startDetector / Signal 處理
+### 5.4 startDetector / Signal 處理（per by2z79ouc ATK-2 compare-and-arm + DEF-1 mapping callback）
 
 ```go
 func (d *probeIntentDispatcher) startDetector(session, agentType string, intent agent.ProbeIntent) {
     paneID, senderPID, ok := d.parent.lookupTopFrameForSession(session)
     if !ok || paneID == "" || senderPID == 0 {
-        return  // top frame 缺失（罕見），下個 hook 重 hydrate 後 applyStatus 再試
+        return  // top frame 缺失，下個 hook 重 hydrate 後 applyStatus 再試
     }
-    generation := d.nextGeneration()
+
+    // Compare-and-arm（per by2z79ouc ATK-2）：在 m.mu 內 re-read currentStatus，
+    // 確認 live status 仍 match OnEntryStatus 才 record active。防 replay race —
+    // snapshot 與 startDetector 之間 hook 可能改 status。
+    d.parent.mu.Lock()
+    curStatus, hasStatus := d.parent.currentStatus[session]
+    if !hasStatus || !slices.Contains(intent.OnEntryStatus, curStatus) {
+        d.parent.mu.Unlock()
+        return  // status 已變，stale arming attempt → skip
+    }
+    // 還在 m.mu 內 record active — 與 hook applyStatus 路徑同 mutex 保證原子
+    generation := d.parent.nextProbeIntentGeneration()
     ctx, cancel := context.WithCancel(d.parentCtx)
-    out := make(chan agent.Signal, 1)
-    d.recordActive(session, intent.Kind, activeIntent{
+    if d.parent.activeProbeIntents[session] == nil {
+        d.parent.activeProbeIntents[session] = make(map[agent.ProbeIntentKind]activeIntent)
+    }
+    d.parent.activeProbeIntents[session][intent.Kind] = activeIntent{
         agentType:  agentType,
         paneID:     paneID,
         senderPID:  senderPID,
         cancel:     cancel,
         generation: generation,
-    })
+    }
+    d.parent.mu.Unlock()
 
+    out := make(chan agent.Signal, 1)
     go func() {
         switch intent.Kind {
         case agent.ProbeIntentKindProcessDead:
@@ -615,20 +673,29 @@ func (d *probeIntentDispatcher) consumeSignals(
     in <-chan agent.Signal,
 ) {
     for sig := range in {
-        newStatus := intent.OnSignal(sig)
-        if newStatus == "" { continue }
+        // OnSignal 由 applyProbeGuards 在 guard 通過後 invoke（per by2z79ouc DEF-1）
         applyProbeGuards(d.parent, probeGuardArgs{
             Session:    session,
             AgentType:  agentType,
             Reason:     "probe-intent:" + string(intent.Kind),
-            NewStatus:  newStatus,
-            StaleCheck: d.makeStaleCheck(session, intent.Kind, agentType, generation),
+            Signal:     sig,
+            Mapping:    intent.OnSignal,
+            StaleCheck: makeProbeIntentStaleCheck(session, intent.Kind, agentType, generation),
         })
+    }
+}
+
+func makeProbeIntentStaleCheck(session string, kind agent.ProbeIntentKind, agentType string, generation uint64) func(*Module) bool {
+    return func(m *Module) bool {
+        intents, ok := m.activeProbeIntents[session]
+        if !ok { return false }
+        cur, ok := intents[kind]
+        return ok && cur.agentType == agentType && cur.generation == generation
     }
 }
 ```
 
-`recordActive` 在 dispatcher 內部 mutex 保護下 mutate `activeProbeIntents`；不持有 `m.mu`（鎖序：dispatcher.mu → m.mu，per §2.1 必守 #8）。
+`stopDetector`：在 m.mu 內 lookup activeProbeIntents → 取 cancel → call cancel → 從 map 刪除。Cancel 後 detector 收到 ctx.Done()，退出時 close(out)；consumeSignals goroutine 走完 range 後退出。Generation 不重置 — uint64 純遞增，無 reuse 風險。
 
 ### 5.5 Polling 頻率 / grace window
 
@@ -707,11 +774,13 @@ func (d *probeIntentDispatcher) replayStatus() {
 }
 ```
 
-### 6.4 Race / 一致性（per b36pap7jc Defense — replay 期間 hook race）
+### 6.4 Race / 一致性（per b36pap7jc + by2z79ouc ATK-2）
 
 - `applyStatus` 已是 dispatcher 公開介面（hook 路徑也走它）— 重用即可
 - replay 順序：先 `replayFromDB` 把 currentStatus + projection 全 hydrate 完，再 `replayStatus()` — 避免 detector 啟動時 `lookupTopFrameForSession` miss
+- **Replay vs hook race（by2z79ouc ATK-2 修法）**：`replayStatus` 內部呼叫 `applyStatus(session, agentType, snapshotStatus)` 走標準路徑；`startDetector` 內部 compare-and-arm（§5.4）— 若 snapshot 取到 `running` 但 hook 已先把 status 改成 `idle`，`startDetector` 在 m.mu 內 re-read `currentStatus` 看到 `idle` 不在 OnEntryStatus 即 skip arming。**Race 完全封閉**
 - **Stale frame race**：若 daemon 在 codex 已死的情況下重啟，replay 取到的 top frame.pid 已是 dead → detector 第一次 poll 立即 emit signal → 套 guards → 因 currentStatus 經 replay 仍是 running，transition gate 通過 → broadcast `error`。**這是預期行為**：user-facing 結果是「daemon restart 後正確發現 codex 不見了，立刻變色」，符合 #698 修復目標
+- **Idle session pane gone（accept 限制）**：若 codex 走完 PdxStop hook（status=idle）後 daemon restart，replay snapshot status=idle → ProbeIntent 不在 OnEntryStatus 不啟 detector → pane 後續被 close 不會自動轉 clear。此屬 §8.1 #4 的 accept 限制（idle 期間 pane 退場由 sweep / SessionEnd hook 處理，不在 W6-3+W6-4 scope）
 - ErrorGuard 與 grace window：replay 路徑**沒有**剛收的 hook，故 graceWindow 不啟動；ErrorGuard 視 currentStatus 而定（若已是 error，guard 阻擋無妨）
 - 若 replay 後某 session 的 top frame 缺失（projection rebuild 失敗 / 老資料），`startDetector` skip — 等下個 hook 補
 
@@ -748,8 +817,8 @@ func (d *probeIntentDispatcher) replayStatus() {
 
 | ID | 內容 |
 |---|---|
-| P2-T1 | `internal/agent/codex/probe_intent_process_dead.go` 新檔 + 單元測試（fake `tmuxPaneLister` + IsPidAlive 控制 4 種 pidAlive×paneAlive 組合 + emit Signal 1 次後退出 + ctx cancel 提早退出 + multi-pane fixture 驗 paneID 路徑取對 pane） |
-| P2-T2 | `tmux.Executor.HasPane(paneID string) bool` 方法新增 + 單元測試（wraps `tmux list-panes -a -F '#{pane_id}'`） |
+| P2-T1 | `tmux.Executor.HasPane(paneID string) bool` 方法新增 + 單元測試（wraps `tmux list-panes -a -F '#{pane_id}'`）— 排序前置 detector，因 detector 編譯需要此方法（per by2z79ouc Defense） |
+| P2-T2 | `internal/agent/codex/probe_intent_process_dead.go` 新檔 + 單元測試（fake `tmuxPaneLister` + 覆寫 `isPidAliveFn` package var 控制 4 種 pidAlive×paneAlive 組合 + emit Signal 1 次後退出 + ctx cancel 提早退出 + multi-pane fixture 驗 paneID 路徑取對 pane）；test cleanup 還原 `isPidAliveFn` |
 | P2-T3 | codex `Provider.ProbeIntents()` 宣告 + provider_test.go regression（OnSignal 區分 PaneAlive=true→error / =false→clear） |
 | P2-T4 | dispatcher 路由 `ProbeIntentKindProcessDead` 到 `codex.StartProcessDeadDetector`（生產 wiring，傳 `(tmux, paneID, senderPID)` 三參數） |
 | P2-T5 | drift test：iterate `registry` 找出所有 `ProbeIntentProvider`；逐一驗證 `ProbeIntents()` 宣告的 Kind 都有 dispatcher case + OnSignal 不為 nil + OnEntryStatus 非空 + Signal context fields semantics 不被改變（PaneAlive / PaneID / SenderPID 必填） |
@@ -831,9 +900,25 @@ func (d *probeIntentDispatcher) replayStatus() {
 
 **決議**：per b36pap7jc FH-1 + 後續 self-check（既有 frame.pid / pane_id 已涵蓋語意，新增 last_sender_pid 欄位是「把 working code 變 data」徵兆）。修法詳 §4.3 / §6.2。
 
+### 9.6 ✅ 採單一 m.mu 統管 active-set — 解 by2z79ouc ATK-1
+
+**決議**：`activeProbeIntents` 移到 `m.mu` 保護（與 `activeWatchers` 同 mutex），不另起 dispatcher.mu。鎖序簡化為 m.mu only，`applyProbeGuards` 內 staleCheck closure 為 lock-free read（caller 已持 m.mu）。修法詳 §5.1 / §5.2。
+
+### 9.7 ✅ 採 compare-and-arm — 解 by2z79ouc ATK-2
+
+**決議**：`startDetector` 在 m.mu 內 re-read `currentStatus` + 比對 `OnEntryStatus`，只在 live status 仍 match 才 record active；防 replay snapshot 與 hook 之間 race。修法詳 §5.4 / §6.4。
+
+### 9.8 ✅ 採 mapping callback in applyProbeGuards — 解 by2z79ouc DEF-1
+
+**決議**：`applyProbeGuards` 接受 `Mapping func(Signal) Status` callback，在 stale guard + graceWindow guard 通過後才 invoke；ProbeIntent 路徑 args.Mapping = intent.OnSignal；ScreenChange 路徑 args.Mapping = kind→status。Provider OnSignal 不會被 drop signal 打到。修法詳 §3.2 / §5.2 / §5.4。
+
+### 9.9 ✅ 採 `isPidAliveFn` package var injection — 解 by2z79ouc FH-1
+
+**決議**：codex 包加 `isPidAliveFn = probe.IsPidAlive` package var；test 覆寫 + cleanup（同既有 `orchNowFn` / `recordHookAtHook` / `interruptBeforeFinalLockFn` pattern）。修法詳 §4.2。
+
 ---
 
-**所有 spec drift signal 已收斂；本 spec 進 plan 前需通過 codex 二輪確認。**
+**所有 spec drift signal 已收斂；本 spec v3 進 plan 前需通過 codex 第三輪確認。**
 
 ---
 

--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
@@ -1,10 +1,10 @@
 # W6-3 codex error ad-hoc ProbeIntent spec
 
-> **Status**：draft（待 codex review）
+> **Status**：draft v2（codex review b36pap7jc 5 finding 全採納修訂；待 codex 二輪確認）
 > **Worktree**：`.claude/worktrees/lights-w6-3-codex-error` / branch `worktree-lights-w6-3-codex-error`
-> **Base**：`origin/main` @ alpha.260（W3+W4 reverted ProbeProfile framework + dev log baseline）
+> **Base**：`origin/main` @ alpha.261（W3+W4 reverted ProbeProfile framework + monitor top processes）
 > **依賴**：W1 audit `docs/specs/2026-04-28-hook-status-audit-spec.md` §6/§7 / lights-rebuild-spec `docs/specs/2026-04-23-lights-rebuild-spec.md` §8.2 / fix-spec `docs/specs/2026-04-28-lights-rebuild-fix-spec.md` §3
-> **後續**：W6-4 codex clear（沿用本 spec finalize 的 interface）/ W6-1/2/6 cc + codex TUI 觀察（新增 ScreenChange detector kind 時 generalize）
+> **後續**：W6-1/2/6 cc + codex TUI 觀察（新增 ScreenChange detector kind 時 generalize）— **W6-4 已併入本 PR**（詳 §0.2）
 
 ---
 
@@ -33,7 +33,7 @@ W3 撤回後（alpha.260）的現況：
 | `probe.ScreenChangeWatcher` (`probe.Watch / WatchOptions / ScreenChangeEvent`) | 已 ship；**只**支援 tmux pane content 變化觀察 — **不**支援 process-exit 觀察 |
 | Trace dev log（W4） | `[hook] / [derive] / [handler] / [broadcast]` 5 條 chain log；W6-3 將新增 `[probe-intent]` step kind |
 
-### 0.2 重要 spec drift 修正（與 W1 audit §7 假設不符）
+### 0.2 重要 spec drift 修正（與 W1 audit §7 假設不符；codex review b36pap7jc 已確認）
 
 **audit §7 W6-3 寫**：
 
@@ -55,13 +55,24 @@ W3 撤回後（alpha.260）的現況：
 | `process_dead + tmux_pane_alive` | codex 在 pane 內崩潰 / 被 kill / 異常退出，pane 回到 shell prompt | `error` |
 | `process_dead + tmux_pane_gone` | user 主動關閉 pane / window，連帶 codex 退出 | `clear` |
 
-> **W6-3 vs W6-4 拆分權衡**（spec drift signal #1，待 codex review 決議）
->
-> 由於兩者共用 detector，「合併 first PR」也是合理選項。本 spec 預設**遵守 audit 拆分**：W6-3 first PR 只實作 `process_dead → error`（不觀察 pane existence）；W6-4 follow-up 加入 pane 觀察區分。
->
-> Trade-off：W6-3 first PR scope 簡單但會誤標（user 主動退 codex 也標 error）。詳 §9.1。
+### 0.2.1 W6-3 + W6-4 合併 first PR（per b36pap7jc ATK-3 / DEF-1）
 
-### 0.3 與 fix-spec / W1 audit 對齊
+**原 spec drift 決議**：採 §9.2 選項 B — W6-3（error）與 W6-4（clear）合併 first PR。
+
+**理由**：
+
+1. **detector 共用** — process_dead detector 已能同時觀察 pane existence；拆兩 PR 等於造兩個幾乎相同 detector
+2. **interface 穩定性** — W6-3 first PR 既要 finalize ProbeIntent interface，必須包含 W6-4 共用 minimum context（PaneAlive / PaneID / SenderPID），否則第二 PR 立刻改 signature 是 framework drift（fix-spec §3 要避免的徵兆）
+3. **避免 user-visible false alarm** — 拆分意味 W6-3 ship 後 user 主動 close pane（codex running/waiting）會被誤標 error，且因 ErrorGuard 一直 pin 到下次 hook；這不是「小折扣」，是 user-visible 缺陷
+
+**W6-3 + W6-4 合併後 first PR 實際範圍**：
+
+- ProbeIntent interface finalize（含 PaneAlive / PaneID / SenderPID 在 Signal 內，給未來 Kind 同樣的最小 context）
+- codex provider 宣告唯一 ProbeIntent，OnSignal 區分：pane alive → `error` / pane gone → `clear`
+- detector 觀察 pane id 是否還在 tmux pane list（不是 session target — 細節 §4.2）
+- module dispatcher + persist + #698 daemon-restart recovery 一次到位
+
+### 0.3 與 fix-spec / W1 audit / b36pap7jc 對齊
 
 | 設計要點 | 來源 | 落地處 |
 |---|---|---|
@@ -71,41 +82,45 @@ W3 撤回後（alpha.260）的現況：
 | 不做 always-on probe / generic ProbeProfileProvider | audit §7.1 / fix-spec §3 | 本 spec §5（per-agent gating + 條件式 watch） |
 | Detector 歸 `internal/agent/codex/probe_intent_*.go` | audit §7.1 | 本 spec §4 |
 | daemon module 只負責 plumbing | audit §7.1 | 本 spec §5 |
-| ProbeIntent interface lazy 設計（W6-3 finalize） | audit §7.1 | 本 spec §3.4 |
-| 五大 bloat 徵兆 self-check | audit §7.1.3 / `feedback_skeleton_convergence` | 本 spec §2.2 |
+| ProbeIntent interface lazy 設計（W6-3 finalize 含 W6-4 共用 minimum context） | audit §7.1 / b36pap7jc DEF-1 | 本 spec §3.2 |
+| 五大 bloat 徵兆 self-check | audit §7.1.3 / `feedback_skeleton_convergence` | 本 spec §2.3 |
 | daemon-restart watcher recovery (issue #698) | audit §7.1.2 | 本 spec §6 |
+| **stale-callback guard 用 active-set strategy 注入** | b36pap7jc ATK-1 | 本 spec §5.2 |
+| **detector 用 pane id target，非 session target** | b36pap7jc ATK-2 / PR #638 教訓 | 本 spec §4.2 |
+| **W6-3 + W6-4 合併 first PR**（避免 ship 已知 false alarm） | b36pap7jc ATK-3 | 本 spec §0.2.1 / §1.1 |
+| **reuse `agent_frames.pid + pane_id`，不新增 schema 欄位** | b36pap7jc FH-1 + self-check | 本 spec §4.3 / §6.2 |
 
 ---
 
 ## 1. 範圍與目標
 
-### 1.1 在範圍
+### 1.1 在範圍（W6-3 + W6-4 合併）
 
 1. `ProbeIntentProvider` 新 optional interface 落 `internal/agent/provider.go`
-2. `ProbeIntent` / `ProbeIntentKind` / `Signal` 結構 finalize（lazy；first PR 唯一 Kind = `ProcessDead`）
-3. codex provider 宣告 `ProcessDead` ProbeIntent → `error`
-4. codex `probe_intent_process_dead.go` detector：polling + `IsPidAlive(senderPID)` 雙檢查
-5. 新檔 `internal/module/agent/probe_intent_dispatcher.go`：per-agent ProbeIntent gating + watcher lifecycle plumbing
-6. `manageActivityWatch` 改造：接 ProbeIntent 啟停（per-agent，**不**做跨 agent 規則）
-7. SenderPID 持久化 + daemon-restart 後 ProbeIntent watcher recovery（issue #698）
-8. drift test：每 ProbeIntent 宣告 vs runtime 實際 dispatch 路徑對齊
-9. dev log 補：`[probe-intent]` step kind（W4 trace pipeline 第 6 條 chain log）
-10. mlab live verify：codex 進程被 kill → lights 變 error
+2. `ProbeIntent` / `ProbeIntentKind` / `Signal` 結構 finalize；Signal 含 W6 共用最小 context（`Kind` / `PaneAlive bool` / `PaneID string` / `SenderPID int`）— 讓未來 Kind 沿用同一 context shape
+3. codex provider 宣告唯一 `ProcessDead` ProbeIntent；OnSignal 依 `PaneAlive` 區分 `error` / `clear`
+4. codex `probe_intent_process_dead.go` detector：polling + `IsPidAlive(senderPID)` + 「pane id 還在 tmux pane list」雙檢查
+5. 新檔 `internal/module/agent/probe_intent_dispatcher.go`：per-agent ProbeIntent gating + per-(session, kind) watcher lifecycle + active-set 自管（不共用 `activeWatchers`）
+6. `applyProbeGuards` 抽 free function — guard / re-check active-set 透過注入 strategy（ProbeIntent 路徑用 `activeProbeIntents`，ScreenChange 路徑沿用 `activeWatchers`）
+7. `manageActivityWatch` 改造：接 ProbeIntent 啟停（per-agent，**不**做跨 agent 規則）
+8. Replay recovery：reuse 既有 `agent_frames.pid + pane_id`（無需新欄位）；`Module.Start` 後重建 ProbeIntent watcher
+9. drift test：每 ProbeIntent 宣告 vs runtime 實際 dispatch 路徑對齊
+10. dev log 補：`[probe-intent]` step kind（W4 trace pipeline 第 6 條 chain log）
+11. mlab live verify：codex 進程被 kill（pane alive） → lights 變 `error`；codex pane 被 close → lights 變 `clear`
 
 ### 1.2 不在範圍
 
-- W6-4 codex clear（pane 觀察區分 error/clear；本 spec 預設拆 follow-up PR — 詳 §9.1）
 - W6-1/2/6 cc + codex TUI 觀察（不同 detector kind，需新增 `ScreenChange` Kind 時再 generalize）
 - W6-5 opencode busy/retry（首選 plugin 補 mapping，issue #661）
 - Always-on probe 復辟（W3 已撤；本 spec 嚴禁）
-- ScreenChange watcher 改造（W6-3 純 process_dead detector，與 ScreenChange watcher 平行 lifecycle）
+- ScreenChange watcher 機制改造（W6-3 純 process_dead detector，與 ScreenChange watcher 平行 lifecycle；只共用 guard helpers）
 - TraceStore schema 改動（dev log 走現有 trace pipeline 加 step kind 即可）
 - Inspector UI（W7 範圍）
 
 ### 1.3 為何要做
 
-- W5-4 燈號 bug：codex error 物理不可達是 user-visible 缺口（codex 異常退出時 lights 不變紅）
-- 為 W6 系列鋪 interface — W6-3 first PR finalize 讓 W6-4 / W6-1/2/6 直接沿用
+- W5-4 + W5-5 燈號 bug：codex `error` / `clear` 物理不可達是 user-visible 缺口
+- 為 W6 系列鋪 interface — W6-3 first PR finalize 讓 W6-1/2/6 直接沿用
 - 為 #698 daemon-restart 場景補 platform plumbing — 否則 W6 ProbeIntent 在 daemon 重啟後直到下個 hook 才重新掛，多數 W5/W6 ship 後 daemon-restart 體驗破功
 
 ---
@@ -116,11 +131,13 @@ W3 撤回後（alpha.260）的現況：
 
 1. ✅ ProbeIntent 由 codex provider 透過 `ProbeIntentProvider` 宣告；detector 實作歸 `internal/agent/codex/`
 2. ✅ daemon module 只負責 plumbing（dispatcher / watcher lifecycle / hook → status → broadcast）
-3. ✅ ProbeIntent gating 為條件式（status ∈ {running, waiting} 且 senderPID 已知時 watch；否則 unwatch）
-4. ✅ Interface lazy 設計 — W6-3 finalize 唯一 `ProcessDead` Kind；後續 PR 加新 Kind 時 extend struct
+3. ✅ ProbeIntent gating 為條件式（status ∈ {running, waiting} 且 senderPID + paneID 已知時 watch；否則 unwatch）
+4. ✅ Interface lazy 設計 — W6-3 first PR finalize 唯一 `ProcessDead` Kind；後續 PR 加新 Kind 時 extend struct（Signal 既有 fields 必保持向後相容）
 5. ✅ probe channel 與 hook channel 獨立 — probe 推論、hook 權威；`recordHookAt` graceWindow 機制保留
 6. ✅ ErrorGuard 維持：`currentStatus == StatusError` 時 probe 不再覆寫
-7. ✅ Stale-callback guard：watcher callback 收到事件時必須 re-check `activeWatchers[session] == agentType`，防 rename / agent-swap 後的 ghost broadcast
+7. ✅ Stale-callback guard（per-route）：ProbeIntent 路徑必須 re-check `activeProbeIntents[session][kind] && agentType == 期望` 兩條件；ScreenChange 路徑維持 re-check `activeWatchers[session] == agentType`；**兩條 active-set 互不共用** — `applyProbeGuards` 透過 strategy 注入正確的 active-set checker
+8. ✅ Detector goroutine 不持有 `m.mu`（鎖路徑 `dispatcher mu → m.mu` 嚴禁逆向）；Signal channel buffer = 1（detector emit 一次後退出）
+9. ✅ ProbeIntent state 必須含 pane id；detector 觀察 pane existence 用 pane id 為 tmux target（不是 session target）— 防 multi-pane window 取錯 pane PID（per PR #638 教訓 / b36pap7jc ATK-2）
 
 ### 2.2 禁忌
 
@@ -135,12 +152,12 @@ W3 撤回後（alpha.260）的現況：
 
 每個 PR commit 前 self-check：
 
-| 徵兆 | W6-3 self-check |
+| 徵兆 | W6-3+W6-4 self-check |
 |---|---|
-| 把 working code 變 data | 不動 codex `events.go` / `status.go` / `hooks.go`；ProbeIntent 是新增 capability，不重寫既有 hook 路徑 |
-| parallel registry | 不加新 registry；ProbeIntent 由 provider 宣告 → dispatcher 在 status 變更時讀取 |
-| 統一抽象（generic framework） | `ProbeIntentKind` 只有 `ProcessDead` 一個 const；不預定義 `ScreenChange` / `LogTail` 等 |
-| refactor working code | 不重寫 ScreenChangeWatcher / probeOrchestrator；新增獨立 `probe_intent_dispatcher.go` plumbing |
+| 把 working code 變 data | 不動 codex `events.go` / `status.go` / `hooks.go`；ProbeIntent 是新增 capability，不重寫既有 hook 路徑；不新增 schema 欄位（reuse `agent_frames.pid + pane_id`） |
+| parallel registry | 不加新 registry；ProbeIntent 由 provider 宣告 → dispatcher 在 status 變更時讀取；`activeProbeIntents` 是 lifecycle 狀態（不是 declaration registry） |
+| 統一抽象（generic framework） | `ProbeIntentKind` 只有 `ProcessDead` 一個 const；不預定義 `ScreenChange` / `LogTail` 等；Signal 預留 `PaneAlive` / `PaneID` / `SenderPID` 是 W6-3+W6-4 的當下需求，**非**為未來 Kind 預留 |
+| refactor working code | 不重寫 ScreenChangeWatcher / probeOrchestrator；`applyProbeGuards` 抽 free function 是 ScreenChange 路徑既有邏輯的 mechanical extraction（行為零變動），不是 refactor without functional reason — 用 `applyProbeGuards` 後 ProbeIntent 路徑能 reuse 同一 guard 是 functional 必要 |
 | config flag | 不加 `PDX_PROBE_INTENT_ENABLED` 之類的 flag；alpha 階段直接 ship |
 
 任一冒出 → 停手 surface（per fix-spec §7）。
@@ -174,41 +191,45 @@ type ProbeIntentProvider interface {
 }
 ```
 
-### 3.2 `ProbeIntent` struct（lazy；W6-3 finalize）
+### 3.2 `ProbeIntent` struct（W6-3+W6-4 finalize；含未來 Kind 共用 minimum context）
 
 ```go
 // ProbeIntent is one probe-driven transition declared by an agent provider.
 //
 // Lifecycle (driven by daemon dispatcher):
-//   1. Status changes to a value listed in OnEntryStatus → dispatcher calls
-//      Detector.Start(ctx) on the per-agent detector instance
-//   2. Detector observes runtime state and emits Signal events on a channel
-//   3. Dispatcher converts Signal → Status via OnSignal and broadcasts
+//   1. Status changes to a value listed in OnEntryStatus → dispatcher resolves
+//      pane id + senderPID from the active frame, then dispatches to the
+//      per-Kind detector goroutine
+//   2. Detector observes runtime state (per Kind) and emits Signal events
+//   3. Dispatcher applies guards (see §5.3) then OnSignal(sig) → Status
 //   4. Status changes to a value NOT in OnEntryStatus → dispatcher stops
-//      detector (cancel ctx) and frees per-session state
+//      detector (cancel ctx) and frees per-(session, kind) state
 //
-// W6-3 first PR has one Kind: ProbeIntentKindProcessDead.
+// W6-3 first PR finalize: one Kind = ProbeIntentKindProcessDead. Future Kind
+// additions (W6-1/2/6 ScreenChange) MUST keep the existing Signal fields
+// backward compatible (add fields, don't repurpose).
 type ProbeIntent struct {
     // Kind classifies the detector. W6-3 finalize: only ProbeIntentKindProcessDead.
     // Subsequent W6 PRs MAY introduce additional Kind constants; existing Kind
-    // semantics MUST remain stable.
+    // semantics and Signal field semantics MUST remain stable.
     Kind ProbeIntentKind
 
     // OnEntryStatus is the set of currentStatus values that gate this intent
     // active. Detector starts on entry to any of these and stops on exit to any
     // status outside the set.
     //
-    // Example (W6-3): {StatusRunning, StatusWaiting} — codex error inference
-    // only makes sense while codex is supposed to be doing work.
+    // Example (W6-3+W6-4): {StatusRunning, StatusWaiting} — codex process_dead
+    // inference only makes sense while codex is supposed to be doing work.
     OnEntryStatus []Status
 
     // OnSignal maps a detector signal to the new Status. Empty Status returned
     // by OnSignal means "drop this signal" (detector observed transient state
     // that doesn't warrant a transition).
     //
-    // dispatcher applies the same guards as ScreenChangeWatcher
-    // (interpretScreenEvent in probe_orchestrator.go): graceWindow / ErrorGuard
-    // / transition gate.
+    // dispatcher applies guards BEFORE invoking OnSignal: stale-callback guard
+    // (re-check activeProbeIntents[session][kind] + agentType), graceWindow,
+    // ErrorGuard, transition gate. OnSignal sees only signals that survive
+    // those guards.
     OnSignal func(Signal) Status
 }
 
@@ -218,44 +239,61 @@ type ProbeIntent struct {
 type ProbeIntentKind string
 
 const (
-    // ProbeIntentKindProcessDead — detector polls senderPID via probe.IsPidAlive
-    // and fires when the agent process is no longer in the tmux pane PID tree.
+    // ProbeIntentKindProcessDead — detector polls senderPID + observes pane
+    // existence; emits one Signal with PaneAlive set when the agent process
+    // is no longer in the pane PID tree (W6-3+W6-4 combined: PaneAlive=true
+    // → caller maps to error; false → caller maps to clear).
     ProbeIntentKindProcessDead ProbeIntentKind = "process_dead"
 )
 
-// Signal is the runtime observation emitted by a detector. The struct is
-// intentionally minimal in W6-3 — future Kind additions extend by adding
-// optional fields (existing fields MUST remain backward compatible).
+// Signal is the runtime observation emitted by a detector. W6-3 finalize
+// includes the minimum context W6-3+W6-4 both need; future Kind additions
+// MAY add fields but MUST keep existing field semantics stable.
+//
+// Field rationale (per b36pap7jc DEF-1 — preventing immediate signature churn
+// on the next W6 PR):
+//   - Kind: required for OnSignal type discrimination
+//   - PaneAlive: W6-3+W6-4 binary distinction; future ScreenChange Kinds may
+//     leave it unconditionally true (they observe pane content, not pane life)
+//   - PaneID: explicit pane id — detector resolves & captures this when the
+//     intent arms; OnSignal receives the same value (used by trace
+//     observability and for downstream future-Kind detectors that act on
+//     pane-scoped state)
+//   - SenderPID: the codex sender pid resolved from frame state; carried on
+//     Signal so OnSignal handlers can log without re-querying
 type Signal struct {
-    Kind ProbeIntentKind
-
-    // Reserved: future Kind variants populate richer payload here. W6-3
-    // ProcessDead carries no extra payload — the signal itself is the
-    // observation.
+    Kind       ProbeIntentKind
+    PaneAlive  bool
+    PaneID     string
+    SenderPID  int
 }
 ```
 
-**Lazy 設計理由**（per audit §7.1 / `feedback_skeleton_convergence`）：
+**Lazy 設計理由**（per audit §7.1 / `feedback_skeleton_convergence` / b36pap7jc DEF-1）：
 
-- `ProbeIntent` 只設計 W6-3 + W6-4 都會用的 `OnEntryStatus` / `OnSignal` 兩欄位
-- `Signal` 預留結構但只有 `Kind` 欄位 — 不預先填 `Payload struct { ... }`
+- `ProbeIntent` 只兩個 owner-supplied 欄位（`OnEntryStatus` / `OnSignal`）+ 一個 `Kind` discriminator
+- `Signal` 4 欄位都是 W6-3+W6-4 當下需求（不是預留為未來 Kind）；future Kind 加新 fields 但既有 fields 不改語意
 - `ProbeIntentKind` 只有一個 const — 後續 PR extend 時加 const 即可
 - 不抽 `Detector` interface — 每 Kind 一個 detector goroutine，dispatcher 用 switch on Kind 啟停（switch 範圍小，比 interface 抽象更直白）
 
-### 3.3 First PR 範圍：唯一 Kind = `ProcessDead`
+### 3.3 First PR 範圍：W6-3 + W6-4 共用 `ProcessDead`
 
-W6-3 only：
+合併後的 codex 宣告：
 
 - `ProbeIntentKindProcessDead`
 - detector：codex 實作 `probe_intent_process_dead.go`
-- 觀察：tmux pane PID tree 是否仍含 codex 進程（透過 `probe.Prober.IsAliveFor("codex", target)`，已有方法）
+- 觀察雙條件：
+  - `probe.IsPidAlive(senderPID)` — 進程級
+  - pane id 是否仍在 tmux pane list（detector 內部用 `tmux list-panes -F '#{pane_id}'` 檢查 paneID 是否還在當前 session 列表中）
 - gating：`OnEntryStatus = {StatusRunning, StatusWaiting}`
-- mapping：`OnSignal = func(Signal) { return StatusError }`
-
-W6-4 follow-up（不在 W6-3 PR 範圍）：
-
-- 同 `ProcessDead` Kind，OnSignal 改為依 pane existence 區分 error/clear
-- 需要時 `Signal.Payload` 增 `PaneAlive bool`（**或** dispatcher 直接傳 pane 觀察結果為第二參數；W6-4 設計時決定）
+- mapping：
+  ```go
+  OnSignal = func(sig Signal) Status {
+      if sig.Kind != ProbeIntentKindProcessDead { return "" }
+      if sig.PaneAlive { return StatusError }   // W6-3
+      return StatusClear                         // W6-4
+  }
+  ```
 
 ---
 
@@ -274,14 +312,17 @@ func (p *Provider) ProbeIntents() []agent.ProbeIntent {
     }
 }
 
-// onProcessDead maps a ProcessDead signal to the recovery status. W6-3 first
-// PR returns Error unconditionally; W6-4 will refine to (Error | Clear) based
-// on tmux pane existence observation.
+// onProcessDead maps a ProcessDead signal to the recovery status, splitting
+// W6-3 (PaneAlive=true → Error) and W6-4 (PaneAlive=false → Clear) on the
+// pane existence observation that detector captured.
 func onProcessDead(sig agent.Signal) agent.Status {
     if sig.Kind != agent.ProbeIntentKindProcessDead {
         return ""  // dispatcher should not invoke OnSignal for mismatched Kind
     }
-    return agent.StatusError
+    if sig.PaneAlive {
+        return agent.StatusError
+    }
+    return agent.StatusClear
 }
 ```
 
@@ -289,16 +330,26 @@ func onProcessDead(sig agent.Signal) agent.Status {
 
 **Polling-based detection**（不用 platform-specific kqueue / pidfd）：
 
-- daemon 持有 codex senderPID（per-session）
-- detector goroutine 每 `processDeadPollInterval` 醒來檢查：
-  1. `probe.IsPidAlive(senderPID)` — false 即視為 dead（基本快檢）
-  2. （補強）`prober.IsAliveFor("codex", target)` — 整個 tmux pane PID tree 都不含 codex 進程才確認 dead（防 senderPID 是 short-lived 子進程的誤判）
-- dead 確認後 emit signal 一次，detector 結束（dispatcher 已停 watcher，不再 poll）
+detector goroutine 接收 dispatcher 提供的 `(senderPID, paneID)` snapshot，每 `processDeadPollInterval` 醒來檢查兩個獨立 invariant：
 
-**Polling 頻率**：建議 `1 * time.Second`。理由：
+1. **進程級 alive**：`probe.IsPidAlive(senderPID)` — 直接 `syscall.Kill(pid, 0)`，cross-platform、cheap
+2. **pane 級 alive**：透過 `tmuxPaneLister.HasPane(paneID)` 檢查 paneID 是否仍出現在當前 tmux pane list（**不**用 session target 走 `IsAliveFor`，避免 multi-pane window 誤判 — per b36pap7jc ATK-2）
 
-- codex crash 復原需求對 latency 不敏感（user 看到 codex 不在了，等 1s 變紅可接受）
-- 1Hz × pane PID tree 查詢成本（`ps -Ao pid=,ppid=` + descendant cache 250ms TTL）：每秒 1 個 ps 子進程，可忽略
+**Signal emission 邏輯**：
+
+| `IsPidAlive(senderPID)` | `HasPane(paneID)` | 動作 |
+|---|---|---|
+| true | true | 全活，繼續 poll |
+| true | false | 進程在但 pane 不見（罕見：tmux pane killed but process re-parented to init）→ 視為 `pane_alive=false` 路徑 emit |
+| false | true | 進程死、pane 還在 → emit `Signal{PaneAlive: true}`（W6-3 error） |
+| false | false | 進程死、pane 也不見 → emit `Signal{PaneAlive: false}`（W6-4 clear） |
+
+進程死即 emit 一次後 detector 結束（dispatcher 已停 watcher，不再 poll）。
+
+**Polling 頻率**：`1 * time.Second`。理由：
+
+- codex crash 復原需求對 latency 不敏感（user 看到 codex 不在了，等 1s 變色可接受）
+- 1Hz × `tmux list-panes` + `syscall.Kill(pid, 0)` 成本可忽略
 - 比 ScreenChangeWatcher 預設 200ms tick 慢 5×，符合「probe 是 recovery」精神（不搶 hook）
 
 **Detector signature**（與 dispatcher 約定）：
@@ -315,26 +366,26 @@ import (
     "github.com/wake/purdex/internal/agent/probe"
 )
 
-// processDeadPollInterval is the polling cadence for IsPidAlive + IsAliveFor.
-// Exported as a package var so tests can override (see *_test.go) — production
-// code never mutates it.
+// processDeadPollInterval is the polling cadence for IsPidAlive + HasPane.
+// Exported as a package var so tests can override — production code never
+// mutates it.
 var processDeadPollInterval = 1 * time.Second
 
-// ProcessDeadDetector is the codex-side detector for ProbeIntentKindProcessDead.
-// It polls the agent module's prober + senderPID; on first dead-confirmed tick
-// it emits one Signal and returns. Cancel ctx to stop early (e.g. on session
-// rename / status exit OnEntryStatus).
+// StartProcessDeadDetector is the codex-side detector for
+// ProbeIntentKindProcessDead. It polls senderPID + paneID; on first dead-
+// confirmed tick it emits one Signal carrying PaneAlive observation and
+// returns. Cancel ctx to stop early (e.g. on session rename / status exit
+// OnEntryStatus).
 //
-// prober is *probe.Prober (production) or a test fake satisfying probeIntentProber.
-// target is the tmux target with ":" suffix (e.g. "mySession:") matching the
-// ScreenChangeWatcher convention.
+// paneLister is the minimal contract the detector needs (HasPane(paneID)).
+// Tests inject a recording fake. Production wires *tmux.Executor.
 //
 // Caller is expected to dispatch the emitted Signal to OnSignal and apply the
 // usual probe guards (graceWindow / ErrorGuard / transition gate).
 func StartProcessDeadDetector(
     ctx context.Context,
-    prober probeIntentProber,
-    target string,
+    paneLister tmuxPaneLister,
+    paneID string,
     senderPID int,
     out chan<- agent.Signal,
 ) {
@@ -346,17 +397,22 @@ func StartProcessDeadDetector(
         case <-ctx.Done():
             return
         case <-ticker.C:
-            if probe.IsPidAlive(senderPID) {
-                continue
+            pidAlive := probe.IsPidAlive(senderPID)
+            paneAlive := paneLister.HasPane(paneID)
+            if pidAlive && paneAlive {
+                continue  // both alive, keep polling
             }
-            // senderPID is gone; double-check the tmux pane tree to avoid
-            // false-positive on senderPID being a short-lived child (e.g.
-            // codex helper script) that exited but parent codex is alive.
-            if prober.IsAliveFor("codex", target) {
-                continue
+            if pidAlive && !paneAlive {
+                // process re-parented but pane gone; treat as pane-gone path
+                pidAlive = false
             }
             select {
-            case out <- agent.Signal{Kind: agent.ProbeIntentKindProcessDead}:
+            case out <- agent.Signal{
+                Kind:      agent.ProbeIntentKindProcessDead,
+                PaneAlive: paneAlive,
+                PaneID:    paneID,
+                SenderPID: senderPID,
+            }:
             case <-ctx.Done():
             }
             return
@@ -364,36 +420,51 @@ func StartProcessDeadDetector(
     }
 }
 
-// probeIntentProber is the minimal contract this detector requires from
-// internal/agent/probe.Prober. Tests inject a recording fake; production wires
-// the real *probe.Prober.
-type probeIntentProber interface {
-    IsAliveFor(agentType, target string) bool
+// tmuxPaneLister is the minimal contract this detector requires for pane
+// existence checks. Implementation: tmux.Executor.HasPane(paneID) — wraps
+// `tmux list-panes -a -F '#{pane_id}'` and scans for the target id.
+//
+// Per b36pap7jc ATK-2: do NOT delegate to probe.Prober.IsAliveFor with a
+// session target — PanePID(session) on multi-pane window resolves to first
+// pane, which is the wrong pane for non-first siblings.
+type tmuxPaneLister interface {
+    HasPane(paneID string) bool
 }
 ```
 
-### 4.3 SenderPID 來源
+### 4.3 SenderPID + PaneID 來源（**不**新增 schema 欄位）
 
-**hook payload SenderPID** 已在 `EventRequest`（`internal/module/agent/handler.go:91`）+ 強制 validation（line 145：`req.SenderPID == 0` → invalid 400）。daemon 處理每筆 hook event 時：
+**Hook 路徑 hydration**（per b36pap7jc FH-1 修正）：
 
-1. 在 handler.go 主路徑 store senderPID 進 module 新欄位 `senderPIDs map[string]int` (session → pid)
-2. **同時**寫入 frame projection（DB 持久化，給 #698 daemon-restart recovery 用）
-3. 後續 codex hook 抵達時 update senderPID（user 重新啟 codex 會給新 PID）
+`EventRequest`（`internal/module/agent/handler.go:91, 145`）已強制要求 `SenderPID != 0`。daemon 處理每筆 hook 時 frame_ops 已將 `(pane_id, agent_type, pid, ppid, process_start_time, status, ...)` 寫入 `agent_frames` 表，**`agent_frames.pid` 即是 codex sender 的進程 PID**（daemon 觀察 tmux pane PID tree + identifier 找到的 codex process — 在 codex 場景下與 hook payload `sender_pid` 一致；frame.pid 是 daemon 已驗證版本的 senderPID）。
 
-**選項 A（推薦）**：在 `frames` table 加欄位 `last_sender_pid INTEGER`
-**選項 B**：另起 in-memory map + 不持久化（daemon-restart 後 senderPID 缺失，等下個 hook 重 hydrate；不滿足 #698）
+**Replay 路徑 hydration**：
 
-預設選 **A** — 詳 §6 daemon-restart recovery。
+`agent_frames.pane_id` + `agent_frames.pid` 已是 frame schema 既有欄位，**不需新增 column**：
+
+- ProbeIntent dispatcher 啟動 detector 時，從 frame projection 取 top frame：`(paneID, pid) = projection.TopFrame.PaneID, projection.TopFrame.PID`
+- daemon-restart 後 `replayFromDB` 已將 `agent_frames` 重建到 `m.framesByPane`；`Module.Start` 後續呼叫 `dispatcher.replayStatus()` 對每個 session 取 top frame → 啟 detector
+
+**為何 reuse 而非新增 `last_sender_pid`**（per `feedback_skeleton_convergence` self-check）：
+
+| 比較 | reuse `agent_frames.pid + pane_id` | 新增 `last_sender_pid` 欄位 |
+|---|---|---|
+| schema 改動 | 0（既有） | +1 column |
+| frame.pid vs sender_pid 語意一致性 | frame.pid 是 daemon identify 驗證後的 codex pid（更穩） | sender_pid 是 hook 自報（未驗證） |
+| 「把 working code 變 data」徵兆 | 不觸發 | 觸發（既有概念已涵蓋） |
+| multi-frame session（罕見） | 取 top frame，與 lights status 同來源 | 需要決定哪個 sender_pid 是有效的 |
+
+採 reuse 方案，spec drift signal #5 已決議。
 
 ### 4.4 Detector lifecycle（與 dispatcher 互動）
 
 | 觸發 | 動作 |
 |---|---|
-| status enter `running` 或 `waiting`，且 senderPID 已知 | dispatcher 啟 detector goroutine（context cancel 在手） |
+| status enter `running` 或 `waiting`，frame projection top frame `(paneID, pid)` 已知 | dispatcher 啟 detector goroutine 帶 `(paneID, pid)` snapshot |
 | status exit OnEntryStatus（變 idle / error / clear） | dispatcher cancel ctx，detector 收到 `<-ctx.Done()` 退出 |
-| session rename | renameSessionLocked 呼叫 dispatcher.stopFor(oldName) + startFor(newName)（若新 status 仍在 OnEntryStatus） |
-| daemon stop | Module.Stop 呼叫 dispatcher.stopAll |
-| senderPID 缺失（罕見：hook 缺欄位被 handler reject 在前；replay 後 DB 無 last_sender_pid） | dispatcher skip 啟 detector；下個 hook 帶來 PID 後重新觸發 |
+| session rename | `renameSessionLocked` 呼叫 dispatcher.applyStatus(newName, agentType, currentStatus) — detector 在 oldName 已被先 stop（`activeProbeIntents[oldName]` 清掉），newName 重新評估 + 啟動（pane id 不變，frame state migrate） |
+| daemon stop | `Module.Stop` 呼叫 dispatcher.stopAll |
+| top frame `(paneID, pid)` 缺失（罕見：projection rebuild 失敗） | dispatcher skip 啟 detector；下個 hook 重建 projection 後 applyStatus 再次嘗試 |
 
 ---
 
@@ -403,18 +474,68 @@ type probeIntentProber interface {
 
 職責：
 
-- 持有 per-session detector goroutine 集合（`map[session]map[ProbeIntentKind]context.CancelFunc`）
+- 持有 per-session × per-Kind detector goroutine 集合：`activeProbeIntents map[session]map[Kind]activeIntent`，其中 `activeIntent` 含 `cancelFn` + `agentType` + `paneID` + `senderPID` + `generation` token（防 stale callback / re-arm race）
 - 在 status 變更時讀取 provider.ProbeIntents()，啟停對應 detector
-- detector 透過 channel emit Signal → dispatcher 走 OnSignal → 套 guards（graceWindow / ErrorGuard / transition gate） → broadcast
-- 不直接 mutate `m.activeWatchers`（保留給 ScreenChangeWatcher）；新增 `m.activeProbeIntents map[session]map[Kind]ctxCancel`
+- detector 透過 channel emit Signal → dispatcher 套 ProbeIntent-aware guards → 走 OnSignal → broadcast
+- 不直接 mutate `m.activeWatchers`（保留給 ScreenChangeWatcher）
 
-**為何不 reuse `probeOrchestrator`**：
+**為何不 reuse `probeOrchestrator`**（per b36pap7jc DEF — 重新挑戰過）：
 
-- `probeOrchestrator` 與 `ScreenChangeWatcher` 緊耦合（`startWatch(session, agentType, opts probe.WatchOptions)` 簽名、`makeCallback` 走 `probe.ScreenChangeCallback` 等）
-- ProcessDead detector 與 ScreenChange 是兩種獨立 mechanism — 強行整進 `probeOrchestrator` 會引入「unify abstraction」bloat（§2.3）
-- 共用部分（graceWindow / ErrorGuard / transition gate）抽為 free function `applyProbeGuards(m, session, agentType, status) (Status, bool)`，在兩個 dispatcher 間共用
+- `probeOrchestrator` 簽名與 `probe.ScreenChangeWatcher` 緊耦合（`startWatch(session, agentType, opts probe.WatchOptions)` / `makeCallback` 走 `probe.ScreenChangeCallback` / `interpretScreenEvent` 直接套 `m.activeWatchers`）
+- ProcessDead detector 與 ScreenChange 是兩種獨立 mechanism（前者 `(senderPID, paneID) → bool×bool`；後者 `tmux pane content hash → ScreenChanged|ScreenStable`）— 強行整進 `probeOrchestrator` 會引入「unify abstraction」bloat（§2.3）
+- 共用部分（graceWindow / ErrorGuard / transition gate / **strategy-injectable** stale-callback guard）抽為 free function `applyProbeGuards(m, args)`，在兩個 dispatcher 間共用 — 行為零變動，是 mechanical extraction（不違 §2.3 refactor without functional reason）
 
-### 5.2 `manageActivityWatch` 改造
+### 5.2 `applyProbeGuards` strategy 注入（核心修正：per b36pap7jc ATK-1）
+
+抽 free function，但**stale-callback guard 用 strategy 注入** — ProbeIntent 路徑與 ScreenChange 路徑各自走自己的 active-set checker，不共用 `m.activeWatchers`：
+
+```go
+// applyProbeGuards 套用 5 層 guard 並 broadcast。回傳 (newStatus, applied)；
+// applied=false 代表此 signal 被 guard drop / 視為 no-op。
+//
+// 5 層 guard（按順序）：
+//   1. Stale-callback guard（透過 staleCheck 注入）：
+//        ProbeIntent 路徑：active.checker = activeProbeIntentChecker(session, kind, agentType, generation)
+//        ScreenChange 路徑：active.checker = activeWatcherChecker(session, agentType)
+//   2. graceWindow（hook authority；既有 probeGraceWindow=2s）
+//   3. Mapping → newStatus（caller-provided：ScreenChange 路徑用 kind→status；ProbeIntent 路徑用 OnSignal）
+//   4. ErrorGuard：currentStatus == StatusError 時 drop
+//   5. Transition gate：currentStatus == newStatus 時 drop（避免 broadcast spam）
+//
+// 通過 5 層後在最後 critical section 執行：
+//   - 再次原子 re-check staleCheck（codex finding #4 regression — close race window）
+//   - mutate m.currentStatus[session]
+//   - setProjectionTopStatus + buildProjectionNormalized + broadcastToSession
+//
+// 簽名：
+type probeGuardArgs struct {
+    Session    string
+    AgentType  string
+    Reason     string                 // 進 trace dev log（"probe-intent:process_dead" / "probe:activity"）
+    NewStatus  Status                 // 已 mapping 完的 status（caller 已套 OnSignal / kind→status）
+    StaleCheck func(*Module) bool     // 同一 critical section 內 re-check active-set；true=still active, false=drop
+}
+
+func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) { ... }
+```
+
+ProbeIntent 路徑的 staleCheck 範例：
+
+```go
+staleCheck := func(m *Module) bool {
+    intents, ok := m.activeProbeIntents[args.Session]
+    if !ok { return false }
+    cur, ok := intents[currentIntentKind]
+    if !ok || cur.agentType != args.AgentType || cur.generation != currentGeneration {
+        return false
+    }
+    return true
+}
+```
+
+`generation` token：每次 `startDetector` 對 (session, kind) 啟動時遞增；detector emit signal 時帶當下 generation；guard re-check 確保 detector 沒被中途 stop+restart 過（防 ghost broadcast，per audit §7.1 必守 #7）。
+
+### 5.3 `manageActivityWatch` 改造
 
 退化為 stop-only no-op 的版本（W3 撤後）改為：
 
@@ -442,7 +563,7 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
 func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus agent.Status) {
     provider, ok := d.parent.registry.GetByType(agentType)
     if !ok { return }
-    intents := probeIntentsOf(provider)  // 走 type assert ProbeIntentProvider
+    intents := probeIntentsOf(provider)  // type assert ProbeIntentProvider；ok=false 直接 return
     for _, intent := range intents {
         wasActive := d.isActive(session, intent.Kind)
         shouldActive := slices.Contains(intent.OnEntryStatus, newStatus)
@@ -456,47 +577,64 @@ func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus
 }
 ```
 
-### 5.3 watcher lifecycle / Signal 處理
+### 5.4 startDetector / Signal 處理
 
 ```go
 func (d *probeIntentDispatcher) startDetector(session, agentType string, intent agent.ProbeIntent) {
-    senderPID, ok := d.parent.lookupSenderPID(session)
-    if !ok || senderPID == 0 {
-        return  // 等下個 hook 帶 PID，applyStatus 會再次嘗試
+    paneID, senderPID, ok := d.parent.lookupTopFrameForSession(session)
+    if !ok || paneID == "" || senderPID == 0 {
+        return  // top frame 缺失（罕見），下個 hook 重 hydrate 後 applyStatus 再試
     }
+    generation := d.nextGeneration()
     ctx, cancel := context.WithCancel(d.parentCtx)
     out := make(chan agent.Signal, 1)
-    d.recordActive(session, intent.Kind, cancel)
+    d.recordActive(session, intent.Kind, activeIntent{
+        agentType:  agentType,
+        paneID:     paneID,
+        senderPID:  senderPID,
+        cancel:     cancel,
+        generation: generation,
+    })
 
     go func() {
         switch intent.Kind {
         case agent.ProbeIntentKindProcessDead:
-            codex.StartProcessDeadDetector(ctx, d.parent.prober, session+":", senderPID, out)
+            codex.StartProcessDeadDetector(ctx, d.parent.tmux, paneID, senderPID, out)
         // future Kind: 加 case
         }
         close(out)
     }()
-    go d.consumeSignals(ctx, session, agentType, intent, out)
+    go d.consumeSignals(ctx, session, agentType, intent, generation, out)
 }
 
-func (d *probeIntentDispatcher) consumeSignals(ctx context.Context, session, agentType string, intent agent.ProbeIntent, in <-chan agent.Signal) {
+func (d *probeIntentDispatcher) consumeSignals(
+    ctx context.Context,
+    session, agentType string,
+    intent agent.ProbeIntent,
+    generation uint64,
+    in <-chan agent.Signal,
+) {
     for sig := range in {
         newStatus := intent.OnSignal(sig)
         if newStatus == "" { continue }
-        // applyProbeGuards: graceWindow / ErrorGuard / transition gate / stale-callback re-check
-        // 與 probeOrchestrator.interpretScreenEvent 同邏輯；抽 free function 共用
-        if d.parent.applyProbeGuards(session, agentType, newStatus, "probe-intent:"+string(intent.Kind)) {
-            // applyProbeGuards 內部已 setProjectionTopStatus + broadcast
-        }
+        applyProbeGuards(d.parent, probeGuardArgs{
+            Session:    session,
+            AgentType:  agentType,
+            Reason:     "probe-intent:" + string(intent.Kind),
+            NewStatus:  newStatus,
+            StaleCheck: d.makeStaleCheck(session, intent.Kind, agentType, generation),
+        })
     }
 }
 ```
 
-### 5.4 Polling 頻率 / grace window
+`recordActive` 在 dispatcher 內部 mutex 保護下 mutate `activeProbeIntents`；不持有 `m.mu`（鎖序：dispatcher.mu → m.mu，per §2.1 必守 #8）。
 
-- ProcessDead polling：1Hz（4.2 已述）
+### 5.5 Polling 頻率 / grace window
+
+- ProcessDead polling：1Hz（§4.2 已述）
 - graceWindow：沿用既有 `probeGraceWindow = 2s`（hook 後 2s 內 probe signal 全 drop）
-- `applyProbeGuards` free function 抽 `probe_orchestrator.go interpretScreenEvent` 的 step 1+2+4+5+6（stale guard / graceWindow / ErrorGuard / transition gate / broadcast），讓 ProcessDead 與 ScreenChange 兩條 dispatcher 共用
+- `applyProbeGuards` free function 抽 `probe_orchestrator.go interpretScreenEvent` 的 step 1+2+4+5+6（stale guard / graceWindow / ErrorGuard / transition gate / broadcast），讓 ProcessDead 與 ScreenChange 兩條 dispatcher 共用 — guard 都用 strategy 注入 active-set checker（§5.2）
 
 ---
 
@@ -508,17 +646,44 @@ func (d *probeIntentDispatcher) consumeSignals(ctx context.Context, session, age
 
 對 W6-3 的影響：user 在 daemon 重啟前 codex 是 running 狀態，daemon 重啟後若 codex crash，**沒有 ProbeIntent watcher**會發現，user 看不到 lights 變紅。
 
-### 6.2 SenderPID 持久化
+### 6.2 hydrate 來源：reuse `agent_frames.pid + pane_id`（**不**新增欄位）
 
-`frames` table 加欄位 `last_sender_pid INTEGER`：
+per §4.3 / b36pap7jc FH-1 修正 — 不採 spec v1 的「frames 加 last_sender_pid」設計。
 
-- 每次 hook handler 處理 EventRequest 時 update：
-  ```sql
-  UPDATE frames SET last_sender_pid = ?, ... WHERE tmux_session = ?
-  ```
-- replayFromDB 時 read 出來填回 `m.senderPIDs[session]`
+`agent_frames` 表既有結構（`internal/store/frames.go:34-48`）：
 
-DB schema：alpha 階段直接 alter（per `feedback_no_alpha_migration` — 不用 migration script，直接改 `internal/store/frame.go` schema）。
+```sql
+CREATE TABLE IF NOT EXISTS agent_frames (
+    frame_id            TEXT PRIMARY KEY,
+    pane_id             TEXT NOT NULL,
+    agent_type          TEXT NOT NULL,
+    pid                 INTEGER NOT NULL,
+    ppid                INTEGER NOT NULL,
+    process_start_time  TEXT NOT NULL,
+    parent_frame_id     TEXT,
+    subagents_json      TEXT NOT NULL DEFAULT '[]',
+    status              TEXT NOT NULL,
+    started_at          INTEGER NOT NULL,
+    last_seen_at        INTEGER NOT NULL,
+    verified            INTEGER NOT NULL DEFAULT 1,
+    ...
+)
+```
+
+ProbeIntent dispatcher 啟動 detector 時走：
+
+```go
+// lookupTopFrameForSession 從現有 projection 取 top frame 的 pane_id + pid
+func (m *Module) lookupTopFrameForSession(session string) (paneID string, pid int, ok bool) {
+    projection, err := m.projectionForSession(session)
+    if err != nil || projection == nil || projection.TopFrame == nil {
+        return "", 0, false
+    }
+    return projection.TopFrame.PaneID, projection.TopFrame.PID, true
+}
+```
+
+frame projection 已是 hook 路徑 + replayFromDB 共用的 single source（`internal/module/agent/projection.go`） — replay 後 projection 已 hydrate 完成。
 
 ### 6.3 Replay 後重新啟動 dispatcher
 
@@ -527,7 +692,7 @@ DB schema：alpha 階段直接 alter（per `feedback_no_alpha_migration` — 不
 ```go
 func (m *Module) Start(_ context.Context) error {
     if err := m.sweepOnce(); err != nil { ... }
-    m.replayFromDB()         // 重建 currentStatus + senderPIDs + frame projection
+    m.replayFromDB()         // 重建 currentStatus + agent_frames + frame projection
     m.startSweep()
     // 新：根據 replay 後的 currentStatus 重新評估 ProbeIntent gating + 啟動 detector
     m.probeIntentDisp.replayStatus()
@@ -542,38 +707,40 @@ func (d *probeIntentDispatcher) replayStatus() {
 }
 ```
 
-### 6.4 Race / 一致性
+### 6.4 Race / 一致性（per b36pap7jc Defense — replay 期間 hook race）
 
-- `applyStatus` 已是 dispatcher 公開介面（hook 路徑也走它）— 重用即可，不需另起新方法
-- replay 順序：先 `replayFromDB` 把 senderPIDs / currentStatus 都 hydrate 完，再 `replayStatus()`，避免 detector 啟動時 lookupSenderPID miss
-- 若 replay 後某 session 的 senderPID 真的缺失（DB 欄位 NULL，老資料），`startDetector` skip — 等下個 hook 補
+- `applyStatus` 已是 dispatcher 公開介面（hook 路徑也走它）— 重用即可
+- replay 順序：先 `replayFromDB` 把 currentStatus + projection 全 hydrate 完，再 `replayStatus()` — 避免 detector 啟動時 `lookupTopFrameForSession` miss
+- **Stale frame race**：若 daemon 在 codex 已死的情況下重啟，replay 取到的 top frame.pid 已是 dead → detector 第一次 poll 立即 emit signal → 套 guards → 因 currentStatus 經 replay 仍是 running，transition gate 通過 → broadcast `error`。**這是預期行為**：user-facing 結果是「daemon restart 後正確發現 codex 不見了，立刻變色」，符合 #698 修復目標
+- ErrorGuard 與 grace window：replay 路徑**沒有**剛收的 hook，故 graceWindow 不啟動；ErrorGuard 視 currentStatus 而定（若已是 error，guard 阻擋無妨）
+- 若 replay 後某 session 的 top frame 缺失（projection rebuild 失敗 / 老資料），`startDetector` skip — 等下個 hook 補
 
 ---
 
 ## 7. Phase 拆分
 
-### Phase 1 — Interface finalize + module dispatcher + #698 recovery
+### Phase 1 — Interface finalize + module dispatcher + replay recovery
 
-**目標**：建立 `ProbeIntentProvider` interface + module dispatcher plumbing + DB schema 升級 + replay recovery；codex provider **暫**用 stub detector（永不 emit signal，純測 dispatcher lifecycle）。
+**目標**：建立 `ProbeIntentProvider` interface + module dispatcher plumbing + replay recovery；codex provider **暫**用 stub detector（永不 emit signal，純測 dispatcher lifecycle）。**不**動 schema（reuse `agent_frames.pid + pane_id`）。
 
 **Tasks**（每 task 獨立 commit；TDD）：
 
 | ID | 內容 |
 |---|---|
-| P1-T1 | `ProbeIntent` / `ProbeIntentKind` / `Signal` / `ProbeIntentProvider` 落 `internal/agent/provider.go` + 單元測試 |
-| P1-T2 | `frames` 表加 `last_sender_pid INTEGER`；schema migration（alpha：直接改）+ store layer test |
-| P1-T3 | handler.go 路徑 store senderPID 進 `m.senderPIDs` + DB；replayFromDB 補 hydrate；test |
-| P1-T4 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `startDetector` / `stopDetector` / `replayStatus` / `consumeSignals`；用 stub detector 測 lifecycle |
-| P1-T5 | `applyProbeGuards` free function 抽出（`probe_orchestrator.go` 的 stale guard / graceWindow / ErrorGuard / transition gate / broadcast），ScreenChange + ProbeIntent 兩 dispatcher 共用；regression test 確保 ScreenChange 行為不變 |
-| P1-T6 | `manageActivityWatch` 接 `probeIntentDisp.applyStatus`；rename / Stop 路徑也接 |
-| P1-T7 | `Module.Start` 加 `probeIntentDisp.replayStatus`；daemon-restart recovery integration test |
+| P1-T1 | `ProbeIntent` / `ProbeIntentKind` / `Signal` / `ProbeIntentProvider` 落 `internal/agent/provider.go` + 單元測試（schema 對齊 §3.2；Signal 4 fields） |
+| P1-T2 | `applyProbeGuards` free function 抽出（mechanical extraction `probe_orchestrator.go interpretScreenEvent` step 1+2+4+5+6） + 新 `staleCheck strategy` 注入點；regression test 確保 ScreenChange 行為零變動（既有 probe_orchestrator_test.go / probe_orchestrator_integration_test.go 全綠） |
+| P1-T3 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `startDetector` / `stopDetector` / `replayStatus` / `consumeSignals` + activeProbeIntents 結構 + generation token；用 stub detector 測 lifecycle（包括 stale-callback re-check / generation 不匹配 drop） |
+| P1-T4 | `Module.lookupTopFrameForSession` helper（讀 projection top frame `(paneID, pid)`）+ test |
+| P1-T5 | `manageActivityWatch` 接 `probeIntentDisp.applyStatus`；rename / Stop 路徑也接；test 覆蓋 rename 期間 (oldName stop, newName 重評估) |
+| P1-T6 | `Module.Start` 加 `probeIntentDisp.replayStatus`；daemon-restart recovery integration test（fixture：projection top frame 含 dead pid + status=running → Start 後 detector 啟動立即 emit → broadcast error） |
 
 **驗收**：
 
 - `go test ./...` 全綠
-- stub detector 啟停流程在 lifecycle test 中可觀察（counter 計數）
-- daemon-restart recovery test：mock DB 內 senderPID + status=running → Start 後 dispatcher.activeProbeIntents 含對應 entry
-- ScreenChange 行為 zero regression（既有 probe_orchestrator_test.go / probe_orchestrator_integration_test.go 全綠）
+- stub detector 啟停流程在 lifecycle test 中可觀察（counter 計數 + generation 隔離）
+- daemon-restart recovery test：fixture mock projection top frame + status → Start 後 dispatcher.activeProbeIntents 含對應 entry
+- ScreenChange 行為 zero regression
+- ProbeIntent 路徑 stale-callback guard 用 `activeProbeIntents` re-check（**不**用 `activeWatchers`） — assertion 由 test 強制（per b36pap7jc ATK-1）
 
 ### Phase 2 — codex detector + drift test + mlab live verify
 
@@ -581,31 +748,28 @@ func (d *probeIntentDispatcher) replayStatus() {
 
 | ID | 內容 |
 |---|---|
-| P2-T1 | `internal/agent/codex/probe_intent_process_dead.go` 新檔 + 單元測試（fake prober + IsPidAlive 控制 + emit signal 1 次後退出 + ctx cancel 提早退出） |
-| P2-T2 | codex `Provider.ProbeIntents()` 宣告 + provider_test.go regression（既有不變、新增 ProbeIntent 宣告 assertion） |
-| P2-T3 | dispatcher 路由 `ProbeIntentKindProcessDead` 到 `codex.StartProcessDeadDetector`（生產 wiring） |
-| P2-T4 | drift test：iterate `registry` 找出所有 `ProbeIntentProvider`；逐一驗證 `ProbeIntents()` 宣告的 Kind 都有 dispatcher case；OnSignal 不為 nil；OnEntryStatus 非空 |
-| P2-T5 | trace dev log 補：`[probe-intent]` step kind（chain log 第 6 條），W4 trace pipeline package comment 同步 |
-| P2-T6 | integration test：mock codex 進程 alive→dead；驗 status running → error broadcast |
-| P2-T7 | mlab live verify：手動測試 codex crash → lights 變 error；codex `/exit` （idle exit）→ ProbeIntent 在 idle 已停 → 無誤觸 |
+| P2-T1 | `internal/agent/codex/probe_intent_process_dead.go` 新檔 + 單元測試（fake `tmuxPaneLister` + IsPidAlive 控制 4 種 pidAlive×paneAlive 組合 + emit Signal 1 次後退出 + ctx cancel 提早退出 + multi-pane fixture 驗 paneID 路徑取對 pane） |
+| P2-T2 | `tmux.Executor.HasPane(paneID string) bool` 方法新增 + 單元測試（wraps `tmux list-panes -a -F '#{pane_id}'`） |
+| P2-T3 | codex `Provider.ProbeIntents()` 宣告 + provider_test.go regression（OnSignal 區分 PaneAlive=true→error / =false→clear） |
+| P2-T4 | dispatcher 路由 `ProbeIntentKindProcessDead` 到 `codex.StartProcessDeadDetector`（生產 wiring，傳 `(tmux, paneID, senderPID)` 三參數） |
+| P2-T5 | drift test：iterate `registry` 找出所有 `ProbeIntentProvider`；逐一驗證 `ProbeIntents()` 宣告的 Kind 都有 dispatcher case + OnSignal 不為 nil + OnEntryStatus 非空 + Signal context fields semantics 不被改變（PaneAlive / PaneID / SenderPID 必填） |
+| P2-T6 | trace dev log 補：`[probe-intent]` step kind（chain log 第 6 條），W4 trace pipeline package comment 同步 |
+| P2-T7 | integration test：mock codex 進程 alive→dead，pane 兩種變體（alive→error 路徑、gone→clear 路徑） |
+| P2-T8 | mlab live verify：(a) codex SIGKILL（pane alive） → lights 變 error；(b) codex pane 直接 `tmux kill-pane`（pane gone）→ lights 變 clear；(c) codex `/exit` （走 PdxStop hook → idle）→ ProbeIntent 在 idle 已停 → 無誤觸；(d) daemon restart 後 codex 從 running 變 dead → ≤2s 變色 |
 
 **驗收**：
 
 - `go test ./internal/...` 全綠
 - drift test 失敗時清楚指出哪個 provider / kind 缺實作
-- mlab live：codex SIGKILL → ≤2s lights 變 error；codex `/exit` 正常退場 → lights 維持 idle，無 error 誤觸
+- mlab live 4 個場景都通過
 - 兩輪 codex review：standard + 三平行（攻擊 / 防守 / 體質）
 - 收斂後 squash merge
 
 ### 為何拆兩 phase
 
-- Phase 1 純 plumbing + interface — 改動範圍包到 schema / replay，risk 集中在共用 `applyProbeGuards` 抽取（regression 風險）
-- Phase 2 detector + provider wiring — 改動局限 codex 包 + dispatcher 路由 case
-- 拆兩 phase 兩輪 codex review 可分別聚焦：Phase 1 review plumbing safety；Phase 2 review detector correctness
-
-> **PR 拆分權衡**（spec drift signal #2，待 codex review 決議）
->
-> 也可合併 single PR — Phase 1 / 2 共 14 task，估 ~800 行 diff，仍在 medium PR review 容量內。Trade-off 詳 §9.2。
+- Phase 1 純 plumbing + interface — 改動範圍核心是 `applyProbeGuards` mechanical extraction + dispatcher state machine（regression 風險）
+- Phase 2 detector + provider wiring — 改動局限 codex 包 + tmux helper + dispatcher 路由 case
+- 拆兩 phase 兩輪 codex review 可分別聚焦：Phase 1 review plumbing safety + ScreenChange regression；Phase 2 review detector correctness + multi-pane edge case
 
 ---
 
@@ -613,11 +777,13 @@ func (d *probeIntentDispatcher) replayStatus() {
 
 ### 8.1 功能性
 
-1. ✅ codex 進程被 SIGKILL（running / waiting 狀態下）→ ≤2s 內 lights 變 `error`
-2. ✅ codex `/exit` 正常退場 → 走 idle hook（PdxStop） → ProbeIntent 在 idle 不啟動 → 無 error 誤觸
-3. ✅ codex idle 期間（已 PdxStop）crash → ProbeIntent 不啟動（gating 排除 idle） → status 維持 idle（**接受**：W6-4 follow-up 處理 idle→clear pane gone 場景）
-4. ✅ daemon 重啟前 codex running，重啟後 codex crash → ≤2s 內 lights 變 error（issue #698 修復）
-5. ✅ session rename 期間 ProbeIntent watcher 跟著 oldName 停、newName 啟（若新 status 仍 running/waiting）
+1. ✅ codex 進程被 SIGKILL（running / waiting 狀態下，pane 仍存在）→ ≤2s 內 lights 變 `error`
+2. ✅ codex pane 被 `tmux kill-pane`（running / waiting 狀態下）→ ≤2s 內 lights 變 `clear`（W6-4 場景）
+3. ✅ codex `/exit` 正常退場 → 走 idle hook（PdxStop） → ProbeIntent 在 idle 不啟動 → 無誤觸
+4. ✅ codex idle 期間 pane 被 close → ProbeIntent 不啟動（gating 排除 idle） → status 維持 idle（accept：純 idle 期間 pane 退場仍由 sweep / SessionEnd hook 處理，不在 W6-3+W6-4 scope）
+5. ✅ daemon 重啟前 codex running，重啟後 codex 已死 → ≤2s 內 lights 變 `error` 或 `clear`（依 pane existence）（issue #698 修復）
+6. ✅ session rename 期間 ProbeIntent watcher 跟著 oldName 停、newName 啟（若新 status 仍 running/waiting）
+7. ✅ multi-pane window：detector 對 hook 來源 pane 作判斷，不被同 window 其他 pane（含其他 codex 實例）影響
 
 ### 8.2 不回歸
 
@@ -641,50 +807,33 @@ func (d *probeIntentDispatcher) replayStatus() {
 
 ---
 
-## 9. Spec Drift Signals（待 codex review 決議）
+## 9. Spec Drift Signals（已隨 codex review b36pap7jc 決議）
 
-### 9.1 audit §7 假設修正：「process exit code」不可行
+### 9.1 ✅ 採納 — audit §7 「process exit code」假設修正
 
-**Drift**：audit §7 W6-3 假設 daemon 能取得 codex exit code 並用 0 vs ≠0 區分 error/clear，但 daemon 不是 codex parent，Unix 設計限制不允許。
+**Drift**：audit §7 W6-3 假設 daemon 能取得 codex exit code，但 daemon 非 codex parent → Unix 限制不允許。
 
-**建議**：以 §0.2 的 binary `process_dead` signal 取代 audit 描述，並在後續更新 audit doc（W6-3 ship 後同步修訂 §6/§7 對應條目）。
+**決議**：採 §0.2 的 binary `process_dead` signal + tmux pane existence 區分 error/clear。W6-3 ship 後同步修訂 audit doc §6/§7 對應條目。
 
-**待決議**：codex review 確認此 platform reality 修正是否合理；若 reviewer 發現替代方案（如 codex 是否有 stderr reporting 機制可低成本接），surface 出來。
+### 9.2 ✅ 採選項 B — 合併 W6-3 + W6-4 first PR
 
-### 9.2 W6-3 vs W6-4 拆/合決議
+**決議**：採選項 B（per b36pap7jc ATK-3）。理由詳 §0.2.1：detector 共用 + interface 穩定性 + 避免 user-visible false alarm。
 
-**選項 A（本 spec 預設，遵守 audit §7.2）**：W6-3 first PR 範圍只含 `process_dead → error`；W6-4 follow-up PR 加 pane existence 觀察區分 error/clear。
+### 9.3 ✅ 採拆 Phase — Phase 1 (interface + plumbing) + Phase 2 (detector + verify)
 
-- 優點：first PR scope 最小，interface finalize 風險低
-- 缺點：alpha 階段 user 主動 close pane（codex 在 running/waiting）會誤標 error；W6-4 ship 前 user-visible 體驗折扣
+**決議**：拆兩 phase（詳 §7「為何拆兩 phase」）— 兩輪 codex review 焦點分離（Phase 1 plumbing/regression / Phase 2 detector/edge case）。
 
-**選項 B（合併 first PR）**：W6-3 + W6-4 同 PR，detector 一次到位。
+### 9.4 ✅ 採 polling — 1Hz `IsPidAlive + tmux list-panes`
 
-- 優點：detector 共用、區分機制是 binary signal，拆開的邊際成本不低；user 體驗從第一個 W6 PR 就完整
-- 缺點：first PR scope 略大；interface 需多一個 `Signal.Payload` 欄位（或 dispatcher 多傳一參數）
+**決議**：採 polling 1Hz。1Hz × `syscall.Kill(pid, 0)` + `tmux list-panes` cost 可忽略；不採 kqueue（macOS only / cgo 複雜度 / lib 風險）。codex review 若認可此決議即定案。
 
-**待決議**：codex review 給意見；user 拍板。
+### 9.5 ✅ 採 reuse `agent_frames.pid + pane_id` — **不**新增 schema 欄位
 
-### 9.3 PR 拆 / 合 phase 決議
+**決議**：per b36pap7jc FH-1 + 後續 self-check（既有 frame.pid / pane_id 已涵蓋語意，新增 last_sender_pid 欄位是「把 working code 變 data」徵兆）。修法詳 §4.3 / §6.2。
 
-詳 §7「為何拆兩 phase」末尾 trade-off。預設拆兩 phase；若 codex review 認為合 single PR 更乾淨，採之。
+---
 
-### 9.4 detector mechanism — polling vs event-driven
-
-**本 spec 預設 polling**（1Hz）。
-
-**alternative：macOS kqueue `EVFILT_PROC + NOTE_EXIT`**（不需 NOTE_EXITSTATUS）— 對 non-child PID 也能收 exit 事件（雖然取不到 exit code，但 W6-3 不需要）。
-
-- 優點：event-driven，零 polling 成本；latency 接近即時
-- 缺點：darwin only（linux 需 fallback `pidfd_open` + `poll`，但 mlab 環境 linux daemon 不在當前 scope）；implementation 複雜度高（cgo / syscall.Kevent）
-
-**本 spec 不採 kqueue**：1Hz polling 成本可忽略，complexity-vs-benefit 不划算。codex review 若發現 kqueue 已有現成 lib 包好可直接 import，再評估。
-
-### 9.5 senderPID 持久化決議
-
-§4.3 / §6.2 預設選項 A（`frames.last_sender_pid` 欄位）。Alternative：選項 B（不持久化，daemon-restart 後等下個 hook 補 — 但破 #698 修復目標）。
-
-**建議**：採 A。codex review 確認 schema 改動是否符合 alpha 階段 `feedback_no_alpha_migration`（不寫 migration script，直接 alter）。
+**所有 spec drift signal 已收斂；本 spec 進 plan 前需通過 codex 二輪確認。**
 
 ---
 
@@ -702,20 +851,22 @@ func (d *probeIntentDispatcher) replayStatus() {
   - `internal/agent/codex/probe_intent_process_dead.go` + test
   - `internal/module/agent/probe_intent_dispatcher.go` + test
   - `internal/module/agent/probe_intent_dispatcher_integration_test.go`
-- **修改**：
-  - `internal/agent/provider.go`（新增 `ProbeIntentProvider` interface + types）
-  - `internal/agent/codex/provider.go`（實作 `ProbeIntents()`）
-  - `internal/module/agent/module.go`（`Start` 加 replayStatus / `manageActivityWatch` 接 dispatcher / `Stop` 加 dispatcher.stopAll）
-  - `internal/module/agent/handler.go`（store senderPID）
-  - `internal/module/agent/probe_orchestrator.go`（抽 `applyProbeGuards` free function）
-  - `internal/module/agent/frame_ops.go` / `internal/module/agent/sweep.go`（如有 senderPID 路徑相關）
-  - `internal/module/agent/trace.go`（package comment 加 `[probe-intent]` step kind）
-  - `internal/store/frame.go`（schema：`last_sender_pid INTEGER`）
-- **drift test**：
   - `internal/module/agent/probe_intent_dispatcher_drift_test.go`（registry sweep + Kind exhaustiveness）
+- **修改**：
+  - `internal/agent/provider.go`（新增 `ProbeIntentProvider` interface + `ProbeIntent` / `ProbeIntentKind` / `Signal` types）
+  - `internal/agent/codex/provider.go`（實作 `ProbeIntents()` + `onProcessDead` mapper）
+  - `internal/module/agent/module.go`（`Start` 加 replayStatus / `manageActivityWatch` 接 dispatcher / `Stop` 加 dispatcher.stopAll / `lookupTopFrameForSession` helper）
+  - `internal/module/agent/probe_orchestrator.go`（**mechanical** 抽 `applyProbeGuards` free function + active-set strategy 注入點；行為零變動）
+  - `internal/module/agent/trace.go`（package comment 加 `[probe-intent]` step kind）
+  - `internal/tmux/executor.go`（新增 `HasPane(paneID string) bool` 方法）
+- **不動**：
+  - `internal/store/frames.go` schema（reuse 既有 `pid + pane_id`，不加新欄位）
+  - `internal/agent/codex/{events,status,hooks}.go`（既有 hook 路徑零變動）
+  - 其他 agent provider（cc / opencode 不受影響 — `ProbeIntentProvider` 是 optional）
 
 ### Issue / 文獻 references
 
 - Issue #698 — daemon restart watcher recovery（W6-3 一併處理）
 - Issue #719 — always-on probe residue（W3 已撤；非本 spec 範圍）
-- Memory `feedback_skeleton_convergence` / `feedback_phase_skip_threshold` / `feedback_codex_pr_review_spec_alignment`
+- Memory `feedback_skeleton_convergence` / `feedback_phase_skip_threshold` / `feedback_codex_pr_review_spec_alignment` / `feedback_no_alpha_migration` / `feedback_codex_review_termination`
+- Codex spec review b36pap7jc — 5 finding 全採納修訂

--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
@@ -1,6 +1,6 @@
 # W6-3 codex error ad-hoc ProbeIntent spec
 
-> **Status**：draft v3（codex review by2z79ouc 4 finding 採納精度修訂；progressive precision，非 architectural drift）
+> **Status**：draft v4（codex review round 3 1 P1 finding — active target mismatch lifecycle gap — 採納修訂）
 > **Worktree**：`.claude/worktrees/lights-w6-3-codex-error` / branch `worktree-lights-w6-3-codex-error`
 > **Base**：`origin/main` @ alpha.261（W3+W4 reverted ProbeProfile framework + monitor top processes）
 > **依賴**：W1 audit `docs/specs/2026-04-28-hook-status-audit-spec.md` §6/§7 / lights-rebuild-spec `docs/specs/2026-04-23-lights-rebuild-spec.md` §8.2 / fix-spec `docs/specs/2026-04-28-lights-rebuild-fix-spec.md` §3
@@ -93,6 +93,7 @@ W3 撤回後（alpha.260）的現況：
 | **startDetector compare-and-arm（m.mu 內 re-read currentStatus）** | by2z79ouc ATK-2 | 本 spec §5.4 / §6.4 |
 | **OnSignal mapping callback in applyProbeGuards（guard 後才 invoke）** | by2z79ouc DEF-1 | 本 spec §3.2 / §5.2 / §5.4 |
 | **detector `isPidAliveFn` package var injection** | by2z79ouc FH-1 | 本 spec §4.2 |
+| **單一 lifecycle helper + active target mismatch 第五 case** | round 3 P1 | 本 spec §5.4 |
 
 ---
 
@@ -143,8 +144,9 @@ W3 撤回後（alpha.260）的現況：
 8. ✅ Detector goroutine 不持有 `m.mu`；channel emit 後 dispatcher 內 consume → 走 `applyProbeGuards`；Signal channel buffer = 1（detector emit 一次後退出）；**鎖序：m.mu only**（per by2z79ouc ATK-1：activeProbeIntents 移進 m.mu 保護，dispatcher 不另持 mutex）
 9. ✅ ProbeIntent state 必須含 pane id；detector 觀察 pane existence 用 pane id 為 tmux target（不是 session target）— 防 multi-pane window 取錯 pane PID（per PR #638 教訓 / b36pap7jc ATK-2）
 10. ✅ ProbeIntent contract（per by2z79ouc DEF-1）：dispatcher 在 **guard 通過後**才 invoke OnSignal（mapping callback）；OnSignal 不會看到被 stale guard / graceWindow / ErrorGuard drop 的 signal — provider 即使有 side effect 也安全
-11. ✅ ProbeIntent compare-and-arm（per by2z79ouc ATK-2）：`startDetector` 在 m.mu 內 re-read `currentStatus` + 比對 `OnEntryStatus`，只在 live status 仍 match 才 record active；防 replay 期間 hook race 後 arm stale watcher
+11. ✅ ProbeIntent compare-and-arm（per by2z79ouc ATK-2）：lifecycle 在 m.mu 內 re-read `currentStatus` + 比對 `OnEntryStatus`，只在 live status 仍 match 才 record active；防 replay 期間 hook race 後 arm stale watcher
 12. ✅ Detector pidAlive 注入（per by2z79ouc FH-1）：codex 包用 `isPidAliveFn` package var（沿 module 包既有 `orchNowFn` / `isPidAliveFn` pattern）；test 覆寫後 cleanup
+13. ✅ ProbeIntent active target re-arm（per round 3 P1）：lifecycle helper 在 `wasActive && shouldActive` 時 m.mu 內比對 `(agentType, paneID, senderPID)` 是否與 active entry 一致；不一致 → cancel 舊 detector + 計算 new generation + 寫入新 entry；防同 status 內 codex 換 pid/pane（restart / multi-pane 切換）後舊 detector 蓋掉新狀態
 
 ### 2.2 禁忌
 
@@ -593,14 +595,26 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
         m.probeOrch.stopWatch(session)
     }
 
-    // 2. 新：dispatch ProbeIntent 啟停（per-agent gating）
+    // 2. 新：dispatch ProbeIntent lifecycle（per-agent gating）
     if m.probeIntentDisp != nil {
         m.probeIntentDisp.applyStatus(session, agentType, newStatus)
     }
 }
 ```
 
-`applyStatus` 內部：
+### 5.4 ProbeIntent lifecycle（單一 helper 在 m.mu 內統管 4 case；per round 3 P1 + by2z79ouc ATK-2 + DEF-1）
+
+`applyStatus` 對每個宣告 intent 走 `applyIntentLifecycle`。Lifecycle decision 全在單一 `m.mu` critical section 內完成：read 當前 active state + currentStatus + top frame；計算需要做的 cancel / start work；unlock 後執行（避免在持 lock 時跑 detector goroutine 啟動工作）。
+
+四個 case：
+
+| `wasActive` | `shouldActive` | live target == active target | 動作 |
+|---|---|---|---|
+| ✗ | ✗ | — | noop |
+| ✗ | ✓ | — | record active + start detector |
+| ✓ | ✗ | — | cancel old + delete active |
+| ✓ | ✓ | ✓ | noop（已 armed correctly）|
+| ✓ | ✓ | ✗ | cancel old + record new active + start new detector（**round 3 P1 修法**：active target mismatch 重啟）|
 
 ```go
 func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus agent.Status) {
@@ -608,61 +622,109 @@ func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus
     if !ok { return }
     intents := probeIntentsOf(provider)  // type assert ProbeIntentProvider；ok=false 直接 return
     for _, intent := range intents {
-        wasActive := d.isActive(session, intent.Kind)
-        shouldActive := slices.Contains(intent.OnEntryStatus, newStatus)
-        switch {
-        case !wasActive && shouldActive:
-            d.startDetector(session, agentType, intent)
-        case wasActive && !shouldActive:
-            d.stopDetector(session, intent.Kind)
-        }
+        d.applyIntentLifecycle(session, agentType, newStatus, intent)
     }
 }
-```
 
-### 5.4 startDetector / Signal 處理（per by2z79ouc ATK-2 compare-and-arm + DEF-1 mapping callback）
+type lifecyclePlan struct {
+    cancelOld   context.CancelFunc  // 非 nil → 須 cancel 舊 detector
+    startCtx    context.Context     // 非 nil → 須啟新 detector goroutines
+    paneID      string
+    senderPID   int
+    generation  uint64
+}
 
-```go
-func (d *probeIntentDispatcher) startDetector(session, agentType string, intent agent.ProbeIntent) {
-    paneID, senderPID, ok := d.parent.lookupTopFrameForSession(session)
-    if !ok || paneID == "" || senderPID == 0 {
-        return  // top frame 缺失，下個 hook 重 hydrate 後 applyStatus 再試
-    }
+func (d *probeIntentDispatcher) applyIntentLifecycle(session, agentType string, newStatus agent.Status, intent agent.ProbeIntent) {
+    shouldActive := slices.Contains(intent.OnEntryStatus, newStatus)
 
-    // Compare-and-arm（per by2z79ouc ATK-2）：在 m.mu 內 re-read currentStatus，
-    // 確認 live status 仍 match OnEntryStatus 才 record active。防 replay race —
-    // snapshot 與 startDetector 之間 hook 可能改 status。
+    // 進 m.mu，計算 plan
     d.parent.mu.Lock()
-    curStatus, hasStatus := d.parent.currentStatus[session]
-    if !hasStatus || !slices.Contains(intent.OnEntryStatus, curStatus) {
-        d.parent.mu.Unlock()
-        return  // status 已變，stale arming attempt → skip
-    }
-    // 還在 m.mu 內 record active — 與 hook applyStatus 路徑同 mutex 保證原子
-    generation := d.parent.nextProbeIntentGeneration()
-    ctx, cancel := context.WithCancel(d.parentCtx)
-    if d.parent.activeProbeIntents[session] == nil {
-        d.parent.activeProbeIntents[session] = make(map[agent.ProbeIntentKind]activeIntent)
-    }
-    d.parent.activeProbeIntents[session][intent.Kind] = activeIntent{
-        agentType:  agentType,
-        paneID:     paneID,
-        senderPID:  senderPID,
-        cancel:     cancel,
-        generation: generation,
+    var plan lifecyclePlan
+    perSession := d.parent.activeProbeIntents[session]
+    cur, wasActive := perSession[intent.Kind]
+
+    switch {
+    case !shouldActive && !wasActive:
+        // case 1: noop
+    case !shouldActive && wasActive:
+        // case 3: stop only
+        plan.cancelOld = cur.cancel
+        delete(perSession, intent.Kind)
+        if len(perSession) == 0 {
+            delete(d.parent.activeProbeIntents, session)
+        }
+    case shouldActive:
+        // case 2 / 4 / 5：lookup live currentStatus + top frame，配合 active target 比較
+        curStatus, hasStatus := d.parent.currentStatus[session]
+        if !hasStatus || !slices.Contains(intent.OnEntryStatus, curStatus) {
+            // by2z79ouc ATK-2：snapshot 與 lifecycle 之間 status 已變 → 不 arm
+            // （若舊 entry 還在，視 wasActive 順手清掉）
+            if wasActive {
+                plan.cancelOld = cur.cancel
+                delete(perSession, intent.Kind)
+                if len(perSession) == 0 {
+                    delete(d.parent.activeProbeIntents, session)
+                }
+            }
+            break
+        }
+        paneID, senderPID, hasFrame := d.parent.lookupTopFrameForSessionLocked(session)
+        if !hasFrame || paneID == "" || senderPID == 0 {
+            // top frame 缺失（罕見）：若 wasActive 但 target 已不可確認 → tear down 防舊 detector 對失效目標誤觸
+            if wasActive {
+                plan.cancelOld = cur.cancel
+                delete(perSession, intent.Kind)
+                if len(perSession) == 0 {
+                    delete(d.parent.activeProbeIntents, session)
+                }
+            }
+            break
+        }
+        targetMatches := wasActive && cur.agentType == agentType && cur.paneID == paneID && cur.senderPID == senderPID
+        if wasActive && targetMatches {
+            // case 4: already armed correctly → noop
+            break
+        }
+        // case 2 (!wasActive) 或 case 5 (target mismatch)：(re)arm
+        if wasActive {
+            plan.cancelOld = cur.cancel
+        }
+        generation := d.parent.nextProbeIntentGeneration()
+        ctx, cancel := context.WithCancel(d.parentCtx)
+        if perSession == nil {
+            perSession = make(map[agent.ProbeIntentKind]activeIntent)
+            d.parent.activeProbeIntents[session] = perSession
+        }
+        perSession[intent.Kind] = activeIntent{
+            agentType:  agentType,
+            paneID:     paneID,
+            senderPID:  senderPID,
+            cancel:     cancel,
+            generation: generation,
+        }
+        plan.startCtx = ctx
+        plan.paneID = paneID
+        plan.senderPID = senderPID
+        plan.generation = generation
     }
     d.parent.mu.Unlock()
 
-    out := make(chan agent.Signal, 1)
-    go func() {
-        switch intent.Kind {
-        case agent.ProbeIntentKindProcessDead:
-            codex.StartProcessDeadDetector(ctx, d.parent.tmux, paneID, senderPID, out)
-        // future Kind: 加 case
-        }
-        close(out)
-    }()
-    go d.consumeSignals(ctx, session, agentType, intent, generation, out)
+    // 在 m.mu 外執行 work（cancel / start 都不需 lock）
+    if plan.cancelOld != nil {
+        plan.cancelOld()
+    }
+    if plan.startCtx != nil {
+        out := make(chan agent.Signal, 1)
+        go func() {
+            switch intent.Kind {
+            case agent.ProbeIntentKindProcessDead:
+                codex.StartProcessDeadDetector(plan.startCtx, d.parent.tmux, plan.paneID, plan.senderPID, out)
+            // future Kind: 加 case
+            }
+            close(out)
+        }()
+        go d.consumeSignals(plan.startCtx, session, agentType, intent, plan.generation, out)
+    }
 }
 
 func (d *probeIntentDispatcher) consumeSignals(
@@ -695,7 +757,11 @@ func makeProbeIntentStaleCheck(session string, kind agent.ProbeIntentKind, agent
 }
 ```
 
-`stopDetector`：在 m.mu 內 lookup activeProbeIntents → 取 cancel → call cancel → 從 map 刪除。Cancel 後 detector 收到 ctx.Done()，退出時 close(out)；consumeSignals goroutine 走完 range 後退出。Generation 不重置 — uint64 純遞增，無 reuse 風險。
+**`Module.Stop` 的 cleanup**：直接遍歷 `activeProbeIntents` cancel 全部 entry + clear map。同一鎖（m.mu）保證 cleanup 期間沒有新 detector 啟動。
+
+**Generation 遞增**：`nextProbeIntentGeneration()` 是 m.mu 內遞增（因 caller 已持 m.mu），純 uint64++；無 reuse 風險（uint64 overflow 需 ~5×10¹⁹ 次 cycle，daemon 永不會到）。
+
+**為何 helper 不暴露 `startDetector` / `stopDetector` 為公開 method**：兩者必須與 active-set mutation + lookup 在同一 m.mu critical section 完成（lifecycle 是原子操作）；拆出單獨的 public method 會誘導 caller 跳過 lifecycle 比對 → 重蹈 round 3 P1 教訓。helper 只透過 `applyStatus`（hook + replay 兩 caller 共用）入口。
 
 ### 5.5 Polling 頻率 / grace window
 
@@ -778,7 +844,8 @@ func (d *probeIntentDispatcher) replayStatus() {
 
 - `applyStatus` 已是 dispatcher 公開介面（hook 路徑也走它）— 重用即可
 - replay 順序：先 `replayFromDB` 把 currentStatus + projection 全 hydrate 完，再 `replayStatus()` — 避免 detector 啟動時 `lookupTopFrameForSession` miss
-- **Replay vs hook race（by2z79ouc ATK-2 修法）**：`replayStatus` 內部呼叫 `applyStatus(session, agentType, snapshotStatus)` 走標準路徑；`startDetector` 內部 compare-and-arm（§5.4）— 若 snapshot 取到 `running` 但 hook 已先把 status 改成 `idle`，`startDetector` 在 m.mu 內 re-read `currentStatus` 看到 `idle` 不在 OnEntryStatus 即 skip arming。**Race 完全封閉**
+- **Replay vs hook race（by2z79ouc ATK-2 + round 3 P1 修法）**：`replayStatus` 內部呼叫 `applyStatus(session, agentType, snapshotStatus)` 走標準路徑；`applyIntentLifecycle` 在 m.mu 內 re-read `currentStatus` + `lookupTopFrameForSessionLocked` + 比對 active target — 若 snapshot 取到 `running` 但 hook 已先把 status 改成 `idle`（or 改了 top frame target），lifecycle 在 m.mu 內看到 live state 為基準直接 skip / restart。**Race 完全封閉**
+- **Active target mismatch（round 3 P1）**：同 status 內 codex 換 pid/pane（restart / multi-pane 切換）— `applyIntentLifecycle` 第五 case：cancel 舊 detector + 寫新 entry（含新 generation） + 啟新 detector；舊 detector 在新 entry 寫入後仍可能 emit 舊 generation 的 stale signal，被 `makeProbeIntentStaleCheck` drop（generation mismatch）
 - **Stale frame race**：若 daemon 在 codex 已死的情況下重啟，replay 取到的 top frame.pid 已是 dead → detector 第一次 poll 立即 emit signal → 套 guards → 因 currentStatus 經 replay 仍是 running，transition gate 通過 → broadcast `error`。**這是預期行為**：user-facing 結果是「daemon restart 後正確發現 codex 不見了，立刻變色」，符合 #698 修復目標
 - **Idle session pane gone（accept 限制）**：若 codex 走完 PdxStop hook（status=idle）後 daemon restart，replay snapshot status=idle → ProbeIntent 不在 OnEntryStatus 不啟 detector → pane 後續被 close 不會自動轉 clear。此屬 §8.1 #4 的 accept 限制（idle 期間 pane 退場由 sweep / SessionEnd hook 處理，不在 W6-3+W6-4 scope）
 - ErrorGuard 與 grace window：replay 路徑**沒有**剛收的 hook，故 graceWindow 不啟動；ErrorGuard 視 currentStatus 而定（若已是 error，guard 阻擋無妨）
@@ -798,7 +865,7 @@ func (d *probeIntentDispatcher) replayStatus() {
 |---|---|
 | P1-T1 | `ProbeIntent` / `ProbeIntentKind` / `Signal` / `ProbeIntentProvider` 落 `internal/agent/provider.go` + 單元測試（schema 對齊 §3.2；Signal 4 fields） |
 | P1-T2 | `applyProbeGuards` free function 抽出（mechanical extraction `probe_orchestrator.go interpretScreenEvent` step 1+2+4+5+6） + 新 `staleCheck strategy` 注入點；regression test 確保 ScreenChange 行為零變動（既有 probe_orchestrator_test.go / probe_orchestrator_integration_test.go 全綠） |
-| P1-T3 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `startDetector` / `stopDetector` / `replayStatus` / `consumeSignals` + activeProbeIntents 結構 + generation token；用 stub detector 測 lifecycle（包括 stale-callback re-check / generation 不匹配 drop） |
+| P1-T3 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `applyIntentLifecycle` / `consumeSignals` + activeProbeIntents 結構（在 m.mu 內保護） + generation token；用 stub detector 測 lifecycle 5 case（含 active target mismatch 觸發 cancel-and-rearm） + stale-callback re-check + generation 不匹配 drop |
 | P1-T4 | `Module.lookupTopFrameForSession` helper（讀 projection top frame `(paneID, pid)`）+ test |
 | P1-T5 | `manageActivityWatch` 接 `probeIntentDisp.applyStatus`；rename / Stop 路徑也接；test 覆蓋 rename 期間 (oldName stop, newName 重評估) |
 | P1-T6 | `Module.Start` 加 `probeIntentDisp.replayStatus`；daemon-restart recovery integration test（fixture：projection top frame 含 dead pid + status=running → Start 後 detector 啟動立即 emit → broadcast error） |
@@ -853,6 +920,8 @@ func (d *probeIntentDispatcher) replayStatus() {
 5. ✅ daemon 重啟前 codex running，重啟後 codex 已死 → ≤2s 內 lights 變 `error` 或 `clear`（依 pane existence）（issue #698 修復）
 6. ✅ session rename 期間 ProbeIntent watcher 跟著 oldName 停、newName 啟（若新 status 仍 running/waiting）
 7. ✅ multi-pane window：detector 對 hook 來源 pane 作判斷，不被同 window 其他 pane（含其他 codex 實例）影響
+8. ✅ active target mismatch（round 3 P1 防護）：codex pane 內 `/exit` + 立即重啟新實例（同 session、status 短暫從 idle 經 SessionStart→UserPromptSubmit 變回 running），detector 必須 cancel 舊 (paneID, oldPID) entry 並 arm 新 (paneID, newPID) entry — 舊 detector 對 oldPID 死亡的 emission 不應蓋掉新 codex 的 running status
+9. ✅ status-stable 換 frame：罕見場景下若 hook 在不變 status 的情況下推送新 top frame（例 frame_ops 重 detect），lifecycle 仍正確 re-arm（不沿用舊 detector）
 
 ### 8.2 不回歸
 
@@ -916,9 +985,13 @@ func (d *probeIntentDispatcher) replayStatus() {
 
 **決議**：codex 包加 `isPidAliveFn = probe.IsPidAlive` package var；test 覆寫 + cleanup（同既有 `orchNowFn` / `recordHookAtHook` / `interruptBeforeFinalLockFn` pattern）。修法詳 §4.2。
 
+### 9.10 ✅ 採 unified lifecycle helper + active target mismatch 第五 case — 解 round 3 P1
+
+**決議**：`applyIntentLifecycle` 在單一 m.mu critical section 內處理 5 case（含 active 但 target changed 的 cancel-and-rearm）；不暴露 `startDetector` / `stopDetector` 為公開 method（避免 caller 跳過 lifecycle 比對）。修法詳 §5.4。
+
 ---
 
-**所有 spec drift signal 已收斂；本 spec v3 進 plan 前需通過 codex 第三輪確認。**
+**所有 spec drift signal 已收斂；本 spec v4 進 plan 前需通過 codex 第四輪確認。**
 
 ---
 

--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
@@ -1,0 +1,721 @@
+# W6-3 codex error ad-hoc ProbeIntent spec
+
+> **Status**：draft（待 codex review）
+> **Worktree**：`.claude/worktrees/lights-w6-3-codex-error` / branch `worktree-lights-w6-3-codex-error`
+> **Base**：`origin/main` @ alpha.260（W3+W4 reverted ProbeProfile framework + dev log baseline）
+> **依賴**：W1 audit `docs/specs/2026-04-28-hook-status-audit-spec.md` §6/§7 / lights-rebuild-spec `docs/specs/2026-04-23-lights-rebuild-spec.md` §8.2 / fix-spec `docs/specs/2026-04-28-lights-rebuild-fix-spec.md` §3
+> **後續**：W6-4 codex clear（沿用本 spec finalize 的 interface）/ W6-1/2/6 cc + codex TUI 觀察（新增 ScreenChange detector kind 時 generalize）
+
+---
+
+## 0. 來龍去脈
+
+**直接動因**（W1 audit §6 W5-4 + §7 W6-3）：
+
+codex CLI 0.124.0 不主動發 `StopFailure` hook（catalog FutureOnly = 5 entries 之一，cf. `internal/agent/codex/events.go:11-15`）。當 codex 進程 crash / kill / 異常退出時，user 看到 codex 不在了但 lights 不變紅 — `error` status 物理上不可達。
+
+**lights-rebuild-spec §8.2 既定方向**：probe 出場條件**從寫死擴充為 agent 驅動**。每個 W6 缺口由對應 agent provider 透過 `ProbeIntentProvider` interface 宣告，detector 實作歸 `internal/agent/{cc,codex,opencode}/probe_intent_*.go`，daemon module 只負責 plumbing。
+
+**W6-3 是 W6 系列的第一個 PR**（per audit §7.2 推薦順序）— 藉此 finalize ProbeIntent interface shape，後續 W6-4 / W6-1/2/6 沿用。
+
+### 0.1 Pre-W6-3 baseline
+
+W3 撤回後（alpha.260）的現況：
+
+| 元素 | 現況 |
+|---|---|
+| `internal/agent/provider.go` | `AgentProvider` core + `HookInstaller` / `StatusSupporter` / 等 optional capabilities；**無** `ProbeIntentProvider` |
+| `probeOrchestrator.startWatch(session, agentType, opts)` | 已 ship；caller 提供 `probe.WatchOptions`；目前**無 production caller**（W3 撤掉 always-on） |
+| `manageActivityWatch(session, agentType, newStatus)` | 退化為 stop-only no-op；`agentType` / `newStatus` 參數保留給 W6 用 |
+| `replayFromDB()` | 重建 `currentStatus` / `subagents` / frame projection；**不**重啟 watcher（issue #698） |
+| Hook payload `sender_pid` | 已強制要求（`internal/module/agent/handler.go:145`：`req.SenderPID == 0` 視為 invalid） |
+| `probe.IsPidAlive(pid)` / `probe.Prober.IsAliveFor(agentType, target)` | 已存在；polling-based |
+| `probe.ScreenChangeWatcher` (`probe.Watch / WatchOptions / ScreenChangeEvent`) | 已 ship；**只**支援 tmux pane content 變化觀察 — **不**支援 process-exit 觀察 |
+| Trace dev log（W4） | `[hook] / [derive] / [handler] / [broadcast]` 5 條 chain log；W6-3 將新增 `[probe-intent]` step kind |
+
+### 0.2 重要 spec drift 修正（與 W1 audit §7 假設不符）
+
+**audit §7 W6-3 寫**：
+
+> codex provider 宣告 ProbeIntent；detector 觀察 codex 進程 exit code（非零）；signal `process_error_exit` → status=error。**約束**：…first PR 僅 process-exit + crash detection（**含 exit code**），TUI / stderr 偵測為延伸 PR
+
+**Platform reality**：daemon 不是 codex 子程序（codex 由 user 在 tmux pane 手動啟動）。Unix 設計上：
+
+- `wait4` / `waitpid` 只對 child PID 有效
+- macOS `kqueue EVFILT_PROC + NOTE_EXIT|NOTE_EXITSTATUS` — `NOTE_EXIT` 對 non-child 仍能收事件，但 `NOTE_EXITSTATUS` 取得的 exit code **僅對 child 可信**
+- `/proc/<pid>/stat` exit_state — Linux 才有，macOS daemon 環境不適用
+- 用 `ps` poll exit status — 進程消失後 `ps` 無紀錄
+
+**結論**：daemon 觀察 non-child codex 進程**只能取得 alive/dead binary signal**，無法區分 exit code 0 vs ≠ 0。
+
+**因此 W6-3 first PR signal 從 `process_error_exit (含 exit code)` 修正為 `process_dead (binary)`**。`error` vs `clear` 的區分改用**伴隨觀察**（tmux pane 是否仍存在）：
+
+| 伴隨觀察 | 語意推論 | Status |
+|---|---|---|
+| `process_dead + tmux_pane_alive` | codex 在 pane 內崩潰 / 被 kill / 異常退出，pane 回到 shell prompt | `error` |
+| `process_dead + tmux_pane_gone` | user 主動關閉 pane / window，連帶 codex 退出 | `clear` |
+
+> **W6-3 vs W6-4 拆分權衡**（spec drift signal #1，待 codex review 決議）
+>
+> 由於兩者共用 detector，「合併 first PR」也是合理選項。本 spec 預設**遵守 audit 拆分**：W6-3 first PR 只實作 `process_dead → error`（不觀察 pane existence）；W6-4 follow-up 加入 pane 觀察區分。
+>
+> Trade-off：W6-3 first PR scope 簡單但會誤標（user 主動退 codex 也標 error）。詳 §9.1。
+
+### 0.3 與 fix-spec / W1 audit 對齊
+
+| 設計要點 | 來源 | 落地處 |
+|---|---|---|
+| ProbeIntent 走 `ProbeIntentProvider` interface（signal → status mapping） | lights-rebuild-spec §8.2 / audit §7.1 | 本 spec §3 |
+| 不偽裝為 hook event（probe 與 hook 是兩條獨立 channel） | audit §7.1 | 本 spec §3 / §5 |
+| 不做跨 agent 中央 liveness watcher / 中央規則 | audit §7.1 / fix-spec §3 | 本 spec §3 / §5 |
+| 不做 always-on probe / generic ProbeProfileProvider | audit §7.1 / fix-spec §3 | 本 spec §5（per-agent gating + 條件式 watch） |
+| Detector 歸 `internal/agent/codex/probe_intent_*.go` | audit §7.1 | 本 spec §4 |
+| daemon module 只負責 plumbing | audit §7.1 | 本 spec §5 |
+| ProbeIntent interface lazy 設計（W6-3 finalize） | audit §7.1 | 本 spec §3.4 |
+| 五大 bloat 徵兆 self-check | audit §7.1.3 / `feedback_skeleton_convergence` | 本 spec §2.2 |
+| daemon-restart watcher recovery (issue #698) | audit §7.1.2 | 本 spec §6 |
+
+---
+
+## 1. 範圍與目標
+
+### 1.1 在範圍
+
+1. `ProbeIntentProvider` 新 optional interface 落 `internal/agent/provider.go`
+2. `ProbeIntent` / `ProbeIntentKind` / `Signal` 結構 finalize（lazy；first PR 唯一 Kind = `ProcessDead`）
+3. codex provider 宣告 `ProcessDead` ProbeIntent → `error`
+4. codex `probe_intent_process_dead.go` detector：polling + `IsPidAlive(senderPID)` 雙檢查
+5. 新檔 `internal/module/agent/probe_intent_dispatcher.go`：per-agent ProbeIntent gating + watcher lifecycle plumbing
+6. `manageActivityWatch` 改造：接 ProbeIntent 啟停（per-agent，**不**做跨 agent 規則）
+7. SenderPID 持久化 + daemon-restart 後 ProbeIntent watcher recovery（issue #698）
+8. drift test：每 ProbeIntent 宣告 vs runtime 實際 dispatch 路徑對齊
+9. dev log 補：`[probe-intent]` step kind（W4 trace pipeline 第 6 條 chain log）
+10. mlab live verify：codex 進程被 kill → lights 變 error
+
+### 1.2 不在範圍
+
+- W6-4 codex clear（pane 觀察區分 error/clear；本 spec 預設拆 follow-up PR — 詳 §9.1）
+- W6-1/2/6 cc + codex TUI 觀察（不同 detector kind，需新增 `ScreenChange` Kind 時再 generalize）
+- W6-5 opencode busy/retry（首選 plugin 補 mapping，issue #661）
+- Always-on probe 復辟（W3 已撤；本 spec 嚴禁）
+- ScreenChange watcher 改造（W6-3 純 process_dead detector，與 ScreenChange watcher 平行 lifecycle）
+- TraceStore schema 改動（dev log 走現有 trace pipeline 加 step kind 即可）
+- Inspector UI（W7 範圍）
+
+### 1.3 為何要做
+
+- W5-4 燈號 bug：codex error 物理不可達是 user-visible 缺口（codex 異常退出時 lights 不變紅）
+- 為 W6 系列鋪 interface — W6-3 first PR finalize 讓 W6-4 / W6-1/2/6 直接沿用
+- 為 #698 daemon-restart 場景補 platform plumbing — 否則 W6 ProbeIntent 在 daemon 重啟後直到下個 hook 才重新掛，多數 W5/W6 ship 後 daemon-restart 體驗破功
+
+---
+
+## 2. 設計約束
+
+### 2.1 必守
+
+1. ✅ ProbeIntent 由 codex provider 透過 `ProbeIntentProvider` 宣告；detector 實作歸 `internal/agent/codex/`
+2. ✅ daemon module 只負責 plumbing（dispatcher / watcher lifecycle / hook → status → broadcast）
+3. ✅ ProbeIntent gating 為條件式（status ∈ {running, waiting} 且 senderPID 已知時 watch；否則 unwatch）
+4. ✅ Interface lazy 設計 — W6-3 finalize 唯一 `ProcessDead` Kind；後續 PR 加新 Kind 時 extend struct
+5. ✅ probe channel 與 hook channel 獨立 — probe 推論、hook 權威；`recordHookAt` graceWindow 機制保留
+6. ✅ ErrorGuard 維持：`currentStatus == StatusError` 時 probe 不再覆寫
+7. ✅ Stale-callback guard：watcher callback 收到事件時必須 re-check `activeWatchers[session] == agentType`，防 rename / agent-swap 後的 ghost broadcast
+
+### 2.2 禁忌
+
+1. ❌ probe 偽裝為 hook event（**不要**寫「fire 合成 StopFailure-equivalent」之類的描述）
+2. ❌ 跨 agent 中央 liveness watcher / 中央規則（如 generic `any → process_dead → error`）
+3. ❌ generic `ProbeProfileProvider` / always-on policy（fix-spec §3 已撤；本 spec 不重蹈）
+4. ❌ 把 codex hook handler 既有 working code 改寫成 ProbeIntent 形式（refactor working code without functional reason）
+5. ❌ parallel registry（除 codex provider 已有的 `ProbeIntents()` 之外不另起 registry）
+6. ❌ 為「未來可能有」的 detector kind 預先抽象（lazy；只有 ProcessDead 一個 kind）
+
+### 2.3 五大 bloat 自我檢查（per `feedback_skeleton_convergence`）
+
+每個 PR commit 前 self-check：
+
+| 徵兆 | W6-3 self-check |
+|---|---|
+| 把 working code 變 data | 不動 codex `events.go` / `status.go` / `hooks.go`；ProbeIntent 是新增 capability，不重寫既有 hook 路徑 |
+| parallel registry | 不加新 registry；ProbeIntent 由 provider 宣告 → dispatcher 在 status 變更時讀取 |
+| 統一抽象（generic framework） | `ProbeIntentKind` 只有 `ProcessDead` 一個 const；不預定義 `ScreenChange` / `LogTail` 等 |
+| refactor working code | 不重寫 ScreenChangeWatcher / probeOrchestrator；新增獨立 `probe_intent_dispatcher.go` plumbing |
+| config flag | 不加 `PDX_PROBE_INTENT_ENABLED` 之類的 flag；alpha 階段直接 ship |
+
+任一冒出 → 停手 surface（per fix-spec §7）。
+
+---
+
+## 3. ProbeIntent 模型 finalize
+
+### 3.1 `ProbeIntentProvider` interface（新 optional capability）
+
+```go
+// internal/agent/provider.go (附加；不動既有 capabilities)
+
+// ProbeIntentProvider declares probe-driven status transitions for an agent.
+//
+// Probe is a recovery channel that complements (not replaces) hooks: when an
+// agent's hook catalog has a structural gap (e.g. codex StopFailure being
+// FutureOnly = ✗ 0.124.0 不發), the agent's provider declares one or more
+// ProbeIntents whose detectors infer the missing transition from runtime
+// observation (process liveness, tmux pane content, etc).
+//
+// Implementing this interface is optional. Providers without ProbeIntents
+// behave identically to pre-W6-3 (no probe-driven transitions).
+//
+// Daemon module reads ProbeIntents() on every status change for the session's
+// agent and starts/stops detectors accordingly. Detectors live in the agent's
+// own package (e.g. internal/agent/codex/probe_intent_*.go) — module only
+// owns the dispatcher plumbing.
+type ProbeIntentProvider interface {
+    ProbeIntents() []ProbeIntent
+}
+```
+
+### 3.2 `ProbeIntent` struct（lazy；W6-3 finalize）
+
+```go
+// ProbeIntent is one probe-driven transition declared by an agent provider.
+//
+// Lifecycle (driven by daemon dispatcher):
+//   1. Status changes to a value listed in OnEntryStatus → dispatcher calls
+//      Detector.Start(ctx) on the per-agent detector instance
+//   2. Detector observes runtime state and emits Signal events on a channel
+//   3. Dispatcher converts Signal → Status via OnSignal and broadcasts
+//   4. Status changes to a value NOT in OnEntryStatus → dispatcher stops
+//      detector (cancel ctx) and frees per-session state
+//
+// W6-3 first PR has one Kind: ProbeIntentKindProcessDead.
+type ProbeIntent struct {
+    // Kind classifies the detector. W6-3 finalize: only ProbeIntentKindProcessDead.
+    // Subsequent W6 PRs MAY introduce additional Kind constants; existing Kind
+    // semantics MUST remain stable.
+    Kind ProbeIntentKind
+
+    // OnEntryStatus is the set of currentStatus values that gate this intent
+    // active. Detector starts on entry to any of these and stops on exit to any
+    // status outside the set.
+    //
+    // Example (W6-3): {StatusRunning, StatusWaiting} — codex error inference
+    // only makes sense while codex is supposed to be doing work.
+    OnEntryStatus []Status
+
+    // OnSignal maps a detector signal to the new Status. Empty Status returned
+    // by OnSignal means "drop this signal" (detector observed transient state
+    // that doesn't warrant a transition).
+    //
+    // dispatcher applies the same guards as ScreenChangeWatcher
+    // (interpretScreenEvent in probe_orchestrator.go): graceWindow / ErrorGuard
+    // / transition gate.
+    OnSignal func(Signal) Status
+}
+
+// ProbeIntentKind is the detector category. W6-3 finalize introduces one Kind;
+// future PRs MAY add more. Use a string type so test fixtures can declare
+// expected kinds without import cycles.
+type ProbeIntentKind string
+
+const (
+    // ProbeIntentKindProcessDead — detector polls senderPID via probe.IsPidAlive
+    // and fires when the agent process is no longer in the tmux pane PID tree.
+    ProbeIntentKindProcessDead ProbeIntentKind = "process_dead"
+)
+
+// Signal is the runtime observation emitted by a detector. The struct is
+// intentionally minimal in W6-3 — future Kind additions extend by adding
+// optional fields (existing fields MUST remain backward compatible).
+type Signal struct {
+    Kind ProbeIntentKind
+
+    // Reserved: future Kind variants populate richer payload here. W6-3
+    // ProcessDead carries no extra payload — the signal itself is the
+    // observation.
+}
+```
+
+**Lazy 設計理由**（per audit §7.1 / `feedback_skeleton_convergence`）：
+
+- `ProbeIntent` 只設計 W6-3 + W6-4 都會用的 `OnEntryStatus` / `OnSignal` 兩欄位
+- `Signal` 預留結構但只有 `Kind` 欄位 — 不預先填 `Payload struct { ... }`
+- `ProbeIntentKind` 只有一個 const — 後續 PR extend 時加 const 即可
+- 不抽 `Detector` interface — 每 Kind 一個 detector goroutine，dispatcher 用 switch on Kind 啟停（switch 範圍小，比 interface 抽象更直白）
+
+### 3.3 First PR 範圍：唯一 Kind = `ProcessDead`
+
+W6-3 only：
+
+- `ProbeIntentKindProcessDead`
+- detector：codex 實作 `probe_intent_process_dead.go`
+- 觀察：tmux pane PID tree 是否仍含 codex 進程（透過 `probe.Prober.IsAliveFor("codex", target)`，已有方法）
+- gating：`OnEntryStatus = {StatusRunning, StatusWaiting}`
+- mapping：`OnSignal = func(Signal) { return StatusError }`
+
+W6-4 follow-up（不在 W6-3 PR 範圍）：
+
+- 同 `ProcessDead` Kind，OnSignal 改為依 pane existence 區分 error/clear
+- 需要時 `Signal.Payload` 增 `PaneAlive bool`（**或** dispatcher 直接傳 pane 觀察結果為第二參數；W6-4 設計時決定）
+
+---
+
+## 4. codex provider 實作
+
+### 4.1 ProbeIntent 宣告（`internal/agent/codex/provider.go` 附加）
+
+```go
+func (p *Provider) ProbeIntents() []agent.ProbeIntent {
+    return []agent.ProbeIntent{
+        {
+            Kind:          agent.ProbeIntentKindProcessDead,
+            OnEntryStatus: []agent.Status{agent.StatusRunning, agent.StatusWaiting},
+            OnSignal:      onProcessDead,
+        },
+    }
+}
+
+// onProcessDead maps a ProcessDead signal to the recovery status. W6-3 first
+// PR returns Error unconditionally; W6-4 will refine to (Error | Clear) based
+// on tmux pane existence observation.
+func onProcessDead(sig agent.Signal) agent.Status {
+    if sig.Kind != agent.ProbeIntentKindProcessDead {
+        return ""  // dispatcher should not invoke OnSignal for mismatched Kind
+    }
+    return agent.StatusError
+}
+```
+
+### 4.2 Detector 機制（`internal/agent/codex/probe_intent_process_dead.go`，新檔）
+
+**Polling-based detection**（不用 platform-specific kqueue / pidfd）：
+
+- daemon 持有 codex senderPID（per-session）
+- detector goroutine 每 `processDeadPollInterval` 醒來檢查：
+  1. `probe.IsPidAlive(senderPID)` — false 即視為 dead（基本快檢）
+  2. （補強）`prober.IsAliveFor("codex", target)` — 整個 tmux pane PID tree 都不含 codex 進程才確認 dead（防 senderPID 是 short-lived 子進程的誤判）
+- dead 確認後 emit signal 一次，detector 結束（dispatcher 已停 watcher，不再 poll）
+
+**Polling 頻率**：建議 `1 * time.Second`。理由：
+
+- codex crash 復原需求對 latency 不敏感（user 看到 codex 不在了，等 1s 變紅可接受）
+- 1Hz × pane PID tree 查詢成本（`ps -Ao pid=,ppid=` + descendant cache 250ms TTL）：每秒 1 個 ps 子進程，可忽略
+- 比 ScreenChangeWatcher 預設 200ms tick 慢 5×，符合「probe 是 recovery」精神（不搶 hook）
+
+**Detector signature**（與 dispatcher 約定）：
+
+```go
+// probe_intent_process_dead.go
+package codex
+
+import (
+    "context"
+    "time"
+
+    "github.com/wake/purdex/internal/agent"
+    "github.com/wake/purdex/internal/agent/probe"
+)
+
+// processDeadPollInterval is the polling cadence for IsPidAlive + IsAliveFor.
+// Exported as a package var so tests can override (see *_test.go) — production
+// code never mutates it.
+var processDeadPollInterval = 1 * time.Second
+
+// ProcessDeadDetector is the codex-side detector for ProbeIntentKindProcessDead.
+// It polls the agent module's prober + senderPID; on first dead-confirmed tick
+// it emits one Signal and returns. Cancel ctx to stop early (e.g. on session
+// rename / status exit OnEntryStatus).
+//
+// prober is *probe.Prober (production) or a test fake satisfying probeIntentProber.
+// target is the tmux target with ":" suffix (e.g. "mySession:") matching the
+// ScreenChangeWatcher convention.
+//
+// Caller is expected to dispatch the emitted Signal to OnSignal and apply the
+// usual probe guards (graceWindow / ErrorGuard / transition gate).
+func StartProcessDeadDetector(
+    ctx context.Context,
+    prober probeIntentProber,
+    target string,
+    senderPID int,
+    out chan<- agent.Signal,
+) {
+    ticker := time.NewTicker(processDeadPollInterval)
+    defer ticker.Stop()
+
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case <-ticker.C:
+            if probe.IsPidAlive(senderPID) {
+                continue
+            }
+            // senderPID is gone; double-check the tmux pane tree to avoid
+            // false-positive on senderPID being a short-lived child (e.g.
+            // codex helper script) that exited but parent codex is alive.
+            if prober.IsAliveFor("codex", target) {
+                continue
+            }
+            select {
+            case out <- agent.Signal{Kind: agent.ProbeIntentKindProcessDead}:
+            case <-ctx.Done():
+            }
+            return
+        }
+    }
+}
+
+// probeIntentProber is the minimal contract this detector requires from
+// internal/agent/probe.Prober. Tests inject a recording fake; production wires
+// the real *probe.Prober.
+type probeIntentProber interface {
+    IsAliveFor(agentType, target string) bool
+}
+```
+
+### 4.3 SenderPID 來源
+
+**hook payload SenderPID** 已在 `EventRequest`（`internal/module/agent/handler.go:91`）+ 強制 validation（line 145：`req.SenderPID == 0` → invalid 400）。daemon 處理每筆 hook event 時：
+
+1. 在 handler.go 主路徑 store senderPID 進 module 新欄位 `senderPIDs map[string]int` (session → pid)
+2. **同時**寫入 frame projection（DB 持久化，給 #698 daemon-restart recovery 用）
+3. 後續 codex hook 抵達時 update senderPID（user 重新啟 codex 會給新 PID）
+
+**選項 A（推薦）**：在 `frames` table 加欄位 `last_sender_pid INTEGER`
+**選項 B**：另起 in-memory map + 不持久化（daemon-restart 後 senderPID 缺失，等下個 hook 重 hydrate；不滿足 #698）
+
+預設選 **A** — 詳 §6 daemon-restart recovery。
+
+### 4.4 Detector lifecycle（與 dispatcher 互動）
+
+| 觸發 | 動作 |
+|---|---|
+| status enter `running` 或 `waiting`，且 senderPID 已知 | dispatcher 啟 detector goroutine（context cancel 在手） |
+| status exit OnEntryStatus（變 idle / error / clear） | dispatcher cancel ctx，detector 收到 `<-ctx.Done()` 退出 |
+| session rename | renameSessionLocked 呼叫 dispatcher.stopFor(oldName) + startFor(newName)（若新 status 仍在 OnEntryStatus） |
+| daemon stop | Module.Stop 呼叫 dispatcher.stopAll |
+| senderPID 缺失（罕見：hook 缺欄位被 handler reject 在前；replay 後 DB 無 last_sender_pid） | dispatcher skip 啟 detector；下個 hook 帶來 PID 後重新觸發 |
+
+---
+
+## 5. Module plumbing
+
+### 5.1 新檔 `internal/module/agent/probe_intent_dispatcher.go`
+
+職責：
+
+- 持有 per-session detector goroutine 集合（`map[session]map[ProbeIntentKind]context.CancelFunc`）
+- 在 status 變更時讀取 provider.ProbeIntents()，啟停對應 detector
+- detector 透過 channel emit Signal → dispatcher 走 OnSignal → 套 guards（graceWindow / ErrorGuard / transition gate） → broadcast
+- 不直接 mutate `m.activeWatchers`（保留給 ScreenChangeWatcher）；新增 `m.activeProbeIntents map[session]map[Kind]ctxCancel`
+
+**為何不 reuse `probeOrchestrator`**：
+
+- `probeOrchestrator` 與 `ScreenChangeWatcher` 緊耦合（`startWatch(session, agentType, opts probe.WatchOptions)` 簽名、`makeCallback` 走 `probe.ScreenChangeCallback` 等）
+- ProcessDead detector 與 ScreenChange 是兩種獨立 mechanism — 強行整進 `probeOrchestrator` 會引入「unify abstraction」bloat（§2.3）
+- 共用部分（graceWindow / ErrorGuard / transition gate）抽為 free function `applyProbeGuards(m, session, agentType, status) (Status, bool)`，在兩個 dispatcher 間共用
+
+### 5.2 `manageActivityWatch` 改造
+
+退化為 stop-only no-op 的版本（W3 撤後）改為：
+
+```go
+func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status) {
+    // 1. 既有：停 ScreenChangeWatcher（ScreenChange 在 W6-3 仍無 caller，no-op 保留）
+    m.mu.Lock()
+    _, wasWatching := m.activeWatchers[session]
+    delete(m.activeWatchers, session)
+    m.mu.Unlock()
+    if wasWatching {
+        m.probeOrch.stopWatch(session)
+    }
+
+    // 2. 新：dispatch ProbeIntent 啟停（per-agent gating）
+    if m.probeIntentDisp != nil {
+        m.probeIntentDisp.applyStatus(session, agentType, newStatus)
+    }
+}
+```
+
+`applyStatus` 內部：
+
+```go
+func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus agent.Status) {
+    provider, ok := d.parent.registry.GetByType(agentType)
+    if !ok { return }
+    intents := probeIntentsOf(provider)  // 走 type assert ProbeIntentProvider
+    for _, intent := range intents {
+        wasActive := d.isActive(session, intent.Kind)
+        shouldActive := slices.Contains(intent.OnEntryStatus, newStatus)
+        switch {
+        case !wasActive && shouldActive:
+            d.startDetector(session, agentType, intent)
+        case wasActive && !shouldActive:
+            d.stopDetector(session, intent.Kind)
+        }
+    }
+}
+```
+
+### 5.3 watcher lifecycle / Signal 處理
+
+```go
+func (d *probeIntentDispatcher) startDetector(session, agentType string, intent agent.ProbeIntent) {
+    senderPID, ok := d.parent.lookupSenderPID(session)
+    if !ok || senderPID == 0 {
+        return  // 等下個 hook 帶 PID，applyStatus 會再次嘗試
+    }
+    ctx, cancel := context.WithCancel(d.parentCtx)
+    out := make(chan agent.Signal, 1)
+    d.recordActive(session, intent.Kind, cancel)
+
+    go func() {
+        switch intent.Kind {
+        case agent.ProbeIntentKindProcessDead:
+            codex.StartProcessDeadDetector(ctx, d.parent.prober, session+":", senderPID, out)
+        // future Kind: 加 case
+        }
+        close(out)
+    }()
+    go d.consumeSignals(ctx, session, agentType, intent, out)
+}
+
+func (d *probeIntentDispatcher) consumeSignals(ctx context.Context, session, agentType string, intent agent.ProbeIntent, in <-chan agent.Signal) {
+    for sig := range in {
+        newStatus := intent.OnSignal(sig)
+        if newStatus == "" { continue }
+        // applyProbeGuards: graceWindow / ErrorGuard / transition gate / stale-callback re-check
+        // 與 probeOrchestrator.interpretScreenEvent 同邏輯；抽 free function 共用
+        if d.parent.applyProbeGuards(session, agentType, newStatus, "probe-intent:"+string(intent.Kind)) {
+            // applyProbeGuards 內部已 setProjectionTopStatus + broadcast
+        }
+    }
+}
+```
+
+### 5.4 Polling 頻率 / grace window
+
+- ProcessDead polling：1Hz（4.2 已述）
+- graceWindow：沿用既有 `probeGraceWindow = 2s`（hook 後 2s 內 probe signal 全 drop）
+- `applyProbeGuards` free function 抽 `probe_orchestrator.go interpretScreenEvent` 的 step 1+2+4+5+6（stale guard / graceWindow / ErrorGuard / transition gate / broadcast），讓 ProcessDead 與 ScreenChange 兩條 dispatcher 共用
+
+---
+
+## 6. Daemon-restart watcher recovery (issue #698)
+
+### 6.1 問題
+
+`Module.Start()` (`internal/module/agent/module.go:223`) 呼叫 `replayFromDB` 重建 `currentStatus` / `subagents` / frame projection，但**不**呼叫 `manageActivityWatch` 重啟任何 watcher。所有 W6 ProbeIntent 在 daemon 重啟後**直到下個 hook 才會重新掛**。
+
+對 W6-3 的影響：user 在 daemon 重啟前 codex 是 running 狀態，daemon 重啟後若 codex crash，**沒有 ProbeIntent watcher**會發現，user 看不到 lights 變紅。
+
+### 6.2 SenderPID 持久化
+
+`frames` table 加欄位 `last_sender_pid INTEGER`：
+
+- 每次 hook handler 處理 EventRequest 時 update：
+  ```sql
+  UPDATE frames SET last_sender_pid = ?, ... WHERE tmux_session = ?
+  ```
+- replayFromDB 時 read 出來填回 `m.senderPIDs[session]`
+
+DB schema：alpha 階段直接 alter（per `feedback_no_alpha_migration` — 不用 migration script，直接改 `internal/store/frame.go` schema）。
+
+### 6.3 Replay 後重新啟動 dispatcher
+
+`Module.Start()` 流程加一步：
+
+```go
+func (m *Module) Start(_ context.Context) error {
+    if err := m.sweepOnce(); err != nil { ... }
+    m.replayFromDB()         // 重建 currentStatus + senderPIDs + frame projection
+    m.startSweep()
+    // 新：根據 replay 後的 currentStatus 重新評估 ProbeIntent gating + 啟動 detector
+    m.probeIntentDisp.replayStatus()
+    ...
+}
+
+func (d *probeIntentDispatcher) replayStatus() {
+    snapshot := d.parent.snapshotStatuses()  // session → (agentType, status)
+    for session, entry := range snapshot {
+        d.applyStatus(session, entry.agentType, entry.status)
+    }
+}
+```
+
+### 6.4 Race / 一致性
+
+- `applyStatus` 已是 dispatcher 公開介面（hook 路徑也走它）— 重用即可，不需另起新方法
+- replay 順序：先 `replayFromDB` 把 senderPIDs / currentStatus 都 hydrate 完，再 `replayStatus()`，避免 detector 啟動時 lookupSenderPID miss
+- 若 replay 後某 session 的 senderPID 真的缺失（DB 欄位 NULL，老資料），`startDetector` skip — 等下個 hook 補
+
+---
+
+## 7. Phase 拆分
+
+### Phase 1 — Interface finalize + module dispatcher + #698 recovery
+
+**目標**：建立 `ProbeIntentProvider` interface + module dispatcher plumbing + DB schema 升級 + replay recovery；codex provider **暫**用 stub detector（永不 emit signal，純測 dispatcher lifecycle）。
+
+**Tasks**（每 task 獨立 commit；TDD）：
+
+| ID | 內容 |
+|---|---|
+| P1-T1 | `ProbeIntent` / `ProbeIntentKind` / `Signal` / `ProbeIntentProvider` 落 `internal/agent/provider.go` + 單元測試 |
+| P1-T2 | `frames` 表加 `last_sender_pid INTEGER`；schema migration（alpha：直接改）+ store layer test |
+| P1-T3 | handler.go 路徑 store senderPID 進 `m.senderPIDs` + DB；replayFromDB 補 hydrate；test |
+| P1-T4 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `startDetector` / `stopDetector` / `replayStatus` / `consumeSignals`；用 stub detector 測 lifecycle |
+| P1-T5 | `applyProbeGuards` free function 抽出（`probe_orchestrator.go` 的 stale guard / graceWindow / ErrorGuard / transition gate / broadcast），ScreenChange + ProbeIntent 兩 dispatcher 共用；regression test 確保 ScreenChange 行為不變 |
+| P1-T6 | `manageActivityWatch` 接 `probeIntentDisp.applyStatus`；rename / Stop 路徑也接 |
+| P1-T7 | `Module.Start` 加 `probeIntentDisp.replayStatus`；daemon-restart recovery integration test |
+
+**驗收**：
+
+- `go test ./...` 全綠
+- stub detector 啟停流程在 lifecycle test 中可觀察（counter 計數）
+- daemon-restart recovery test：mock DB 內 senderPID + status=running → Start 後 dispatcher.activeProbeIntents 含對應 entry
+- ScreenChange 行為 zero regression（既有 probe_orchestrator_test.go / probe_orchestrator_integration_test.go 全綠）
+
+### Phase 2 — codex detector + drift test + mlab live verify
+
+**Tasks**：
+
+| ID | 內容 |
+|---|---|
+| P2-T1 | `internal/agent/codex/probe_intent_process_dead.go` 新檔 + 單元測試（fake prober + IsPidAlive 控制 + emit signal 1 次後退出 + ctx cancel 提早退出） |
+| P2-T2 | codex `Provider.ProbeIntents()` 宣告 + provider_test.go regression（既有不變、新增 ProbeIntent 宣告 assertion） |
+| P2-T3 | dispatcher 路由 `ProbeIntentKindProcessDead` 到 `codex.StartProcessDeadDetector`（生產 wiring） |
+| P2-T4 | drift test：iterate `registry` 找出所有 `ProbeIntentProvider`；逐一驗證 `ProbeIntents()` 宣告的 Kind 都有 dispatcher case；OnSignal 不為 nil；OnEntryStatus 非空 |
+| P2-T5 | trace dev log 補：`[probe-intent]` step kind（chain log 第 6 條），W4 trace pipeline package comment 同步 |
+| P2-T6 | integration test：mock codex 進程 alive→dead；驗 status running → error broadcast |
+| P2-T7 | mlab live verify：手動測試 codex crash → lights 變 error；codex `/exit` （idle exit）→ ProbeIntent 在 idle 已停 → 無誤觸 |
+
+**驗收**：
+
+- `go test ./internal/...` 全綠
+- drift test 失敗時清楚指出哪個 provider / kind 缺實作
+- mlab live：codex SIGKILL → ≤2s lights 變 error；codex `/exit` 正常退場 → lights 維持 idle，無 error 誤觸
+- 兩輪 codex review：standard + 三平行（攻擊 / 防守 / 體質）
+- 收斂後 squash merge
+
+### 為何拆兩 phase
+
+- Phase 1 純 plumbing + interface — 改動範圍包到 schema / replay，risk 集中在共用 `applyProbeGuards` 抽取（regression 風險）
+- Phase 2 detector + provider wiring — 改動局限 codex 包 + dispatcher 路由 case
+- 拆兩 phase 兩輪 codex review 可分別聚焦：Phase 1 review plumbing safety；Phase 2 review detector correctness
+
+> **PR 拆分權衡**（spec drift signal #2，待 codex review 決議）
+>
+> 也可合併 single PR — Phase 1 / 2 共 14 task，估 ~800 行 diff，仍在 medium PR review 容量內。Trade-off 詳 §9.2。
+
+---
+
+## 8. 驗收條件
+
+### 8.1 功能性
+
+1. ✅ codex 進程被 SIGKILL（running / waiting 狀態下）→ ≤2s 內 lights 變 `error`
+2. ✅ codex `/exit` 正常退場 → 走 idle hook（PdxStop） → ProbeIntent 在 idle 不啟動 → 無 error 誤觸
+3. ✅ codex idle 期間（已 PdxStop）crash → ProbeIntent 不啟動（gating 排除 idle） → status 維持 idle（**接受**：W6-4 follow-up 處理 idle→clear pane gone 場景）
+4. ✅ daemon 重啟前 codex running，重啟後 codex crash → ≤2s 內 lights 變 error（issue #698 修復）
+5. ✅ session rename 期間 ProbeIntent watcher 跟著 oldName 停、newName 啟（若新 status 仍 running/waiting）
+
+### 8.2 不回歸
+
+1. ✅ ScreenChangeWatcher 行為零變動（既有 probe_orchestrator_test.go / probe_orchestrator_integration_test.go 全綠）
+2. ✅ codex 既有 hook handling 路徑零變動（events.go / status.go / hooks.go 無功能改動）
+3. ✅ recordHookAt graceWindow / ErrorGuard / transition gate 在 ProbeIntent 路徑也生效
+4. ✅ codex provider 既有 capabilities 都不受影響（HookInstaller / StatusSupporter / etc）
+
+### 8.3 結構
+
+1. ✅ `ProbeIntentProvider` 是 optional interface — 未實作的 provider 行為不變（cc / opencode 不受影響）
+2. ✅ `ProbeIntentKind` 只有 `ProcessDead` 一個 const（lazy）
+3. ✅ Detector 實作位於 `internal/agent/codex/probe_intent_*.go`；module 只負責 dispatcher
+4. ✅ drift test 可偵測 provider 宣告 vs dispatcher 實作不一致
+
+### 8.4 觀察
+
+1. ✅ dev log（`PDX_DEV_MODE=1`）：`[probe-intent] start session=X agent=codex kind=process_dead pid=Y` / `[probe-intent] signal session=X kind=process_dead newStatus=error` / `[probe-intent] stop session=X kind=process_dead reason=Y` 三類 log 完整
+2. ✅ TraceStore chain 第 6 條 step：`[probe-intent]`，與既有 `[hook] / [derive] / [handler] / [broadcast] / [verify_passed]` 對齊
+3. ✅ expvar metric：`probe_intent_started` / `probe_intent_signal_emitted` / `probe_intent_dropped_grace` / etc
+
+---
+
+## 9. Spec Drift Signals（待 codex review 決議）
+
+### 9.1 audit §7 假設修正：「process exit code」不可行
+
+**Drift**：audit §7 W6-3 假設 daemon 能取得 codex exit code 並用 0 vs ≠0 區分 error/clear，但 daemon 不是 codex parent，Unix 設計限制不允許。
+
+**建議**：以 §0.2 的 binary `process_dead` signal 取代 audit 描述，並在後續更新 audit doc（W6-3 ship 後同步修訂 §6/§7 對應條目）。
+
+**待決議**：codex review 確認此 platform reality 修正是否合理；若 reviewer 發現替代方案（如 codex 是否有 stderr reporting 機制可低成本接），surface 出來。
+
+### 9.2 W6-3 vs W6-4 拆/合決議
+
+**選項 A（本 spec 預設，遵守 audit §7.2）**：W6-3 first PR 範圍只含 `process_dead → error`；W6-4 follow-up PR 加 pane existence 觀察區分 error/clear。
+
+- 優點：first PR scope 最小，interface finalize 風險低
+- 缺點：alpha 階段 user 主動 close pane（codex 在 running/waiting）會誤標 error；W6-4 ship 前 user-visible 體驗折扣
+
+**選項 B（合併 first PR）**：W6-3 + W6-4 同 PR，detector 一次到位。
+
+- 優點：detector 共用、區分機制是 binary signal，拆開的邊際成本不低；user 體驗從第一個 W6 PR 就完整
+- 缺點：first PR scope 略大；interface 需多一個 `Signal.Payload` 欄位（或 dispatcher 多傳一參數）
+
+**待決議**：codex review 給意見；user 拍板。
+
+### 9.3 PR 拆 / 合 phase 決議
+
+詳 §7「為何拆兩 phase」末尾 trade-off。預設拆兩 phase；若 codex review 認為合 single PR 更乾淨，採之。
+
+### 9.4 detector mechanism — polling vs event-driven
+
+**本 spec 預設 polling**（1Hz）。
+
+**alternative：macOS kqueue `EVFILT_PROC + NOTE_EXIT`**（不需 NOTE_EXITSTATUS）— 對 non-child PID 也能收 exit 事件（雖然取不到 exit code，但 W6-3 不需要）。
+
+- 優點：event-driven，零 polling 成本；latency 接近即時
+- 缺點：darwin only（linux 需 fallback `pidfd_open` + `poll`，但 mlab 環境 linux daemon 不在當前 scope）；implementation 複雜度高（cgo / syscall.Kevent）
+
+**本 spec 不採 kqueue**：1Hz polling 成本可忽略，complexity-vs-benefit 不划算。codex review 若發現 kqueue 已有現成 lib 包好可直接 import，再評估。
+
+### 9.5 senderPID 持久化決議
+
+§4.3 / §6.2 預設選項 A（`frames.last_sender_pid` 欄位）。Alternative：選項 B（不持久化，daemon-restart 後等下個 hook 補 — 但破 #698 修復目標）。
+
+**建議**：採 A。codex review 確認 schema 改動是否符合 alpha 階段 `feedback_no_alpha_migration`（不寫 migration script，直接 alter）。
+
+---
+
+## 10. 文獻與相關檔案
+
+### 設計來源
+
+- `docs/specs/2026-04-23-lights-rebuild-spec.md` §8.2 — `ProbeIntentProvider` 既定方向
+- `docs/specs/2026-04-28-hook-status-audit-spec.md` §6 / §7 / §7.1 / §7.2 — W5/W6 工作池 + 設計約束 + 推薦順序
+- `docs/specs/2026-04-28-lights-rebuild-fix-spec.md` §3 — Framework 撤回範圍
+
+### 改動觸及
+
+- **新檔**：
+  - `internal/agent/codex/probe_intent_process_dead.go` + test
+  - `internal/module/agent/probe_intent_dispatcher.go` + test
+  - `internal/module/agent/probe_intent_dispatcher_integration_test.go`
+- **修改**：
+  - `internal/agent/provider.go`（新增 `ProbeIntentProvider` interface + types）
+  - `internal/agent/codex/provider.go`（實作 `ProbeIntents()`）
+  - `internal/module/agent/module.go`（`Start` 加 replayStatus / `manageActivityWatch` 接 dispatcher / `Stop` 加 dispatcher.stopAll）
+  - `internal/module/agent/handler.go`（store senderPID）
+  - `internal/module/agent/probe_orchestrator.go`（抽 `applyProbeGuards` free function）
+  - `internal/module/agent/frame_ops.go` / `internal/module/agent/sweep.go`（如有 senderPID 路徑相關）
+  - `internal/module/agent/trace.go`（package comment 加 `[probe-intent]` step kind）
+  - `internal/store/frame.go`（schema：`last_sender_pid INTEGER`）
+- **drift test**：
+  - `internal/module/agent/probe_intent_dispatcher_drift_test.go`（registry sweep + Kind exhaustiveness）
+
+### Issue / 文獻 references
+
+- Issue #698 — daemon restart watcher recovery（W6-3 一併處理）
+- Issue #719 — always-on probe residue（W3 已撤；非本 spec 範圍）
+- Memory `feedback_skeleton_convergence` / `feedback_phase_skip_threshold` / `feedback_codex_pr_review_spec_alignment`

--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
@@ -1,6 +1,6 @@
 # W6-3 codex error ad-hoc ProbeIntent spec
 
-> **Status**：draft v5（codex review round 4 1 P1 — cross-provider lifecycle gap — 採納修訂）
+> **Status**：v6 final（codex round 1-5 共 12 P1+P2 採納；user 同意 (D) — round 5 P1 微修 + 不再派 round 6 直接進 plan）
 > **Worktree**：`.claude/worktrees/lights-w6-3-codex-error` / branch `worktree-lights-w6-3-codex-error`
 > **Base**：`origin/main` @ alpha.261（W3+W4 reverted ProbeProfile framework + monitor top processes）
 > **依賴**：W1 audit `docs/specs/2026-04-28-hook-status-audit-spec.md` §6/§7 / lights-rebuild-spec `docs/specs/2026-04-23-lights-rebuild-spec.md` §8.2 / fix-spec `docs/specs/2026-04-28-lights-rebuild-fix-spec.md` §3
@@ -95,6 +95,7 @@ W3 撤回後（alpha.260）的現況：
 | **detector `isPidAliveFn` package var injection** | by2z79ouc FH-1 | 本 spec §4.2 |
 | **單一 lifecycle helper + active target mismatch 第五 case** | round 3 P1 | 本 spec §5.4 |
 | **applyStatus 入口 reconcileSessionActive（cross-provider cleanup）** | round 4 P1 | 本 spec §5.4 |
+| **consumeSignals applied 後 re-run applyStatus（probe-applied teardown）** | round 5 P1 | 本 spec §5.4 |
 
 ---
 
@@ -149,6 +150,7 @@ W3 撤回後（alpha.260）的現況：
 12. ✅ Detector pidAlive 注入（per by2z79ouc FH-1）：codex 包用 `isPidAliveFn` package var（沿 module 包既有 `orchNowFn` / `isPidAliveFn` pattern）；test 覆寫後 cleanup
 13. ✅ ProbeIntent active target re-arm（per round 3 P1）：lifecycle helper 在 `wasActive && shouldActive` 時 m.mu 內比對 `(agentType, paneID, senderPID)` 是否與 active entry 一致；不一致 → cancel 舊 detector + 計算 new generation + 寫入新 entry；防同 status 內 codex 換 pid/pane（restart / multi-pane 切換）後舊 detector 蓋掉新狀態
 14. ✅ Cross-provider reconcile（per round 4 P1）：`applyStatus` 入口先 `reconcileSessionActive`，cancel/delete 任何 `(agentType, kind)` 不再屬於新 provider 宣告集合的 active entry；防 session 切到無 ProbeIntent 的 provider（cc / opencode）後舊 codex detector 仍 emit 蓋掉新狀態
+15. ✅ Probe-applied teardown（per round 5 P1）：`consumeSignals` 在 `applyProbeGuards` 回傳 `applied=true` 後 re-run `applyStatus(session, agentType, newStatus)` — 讓 lifecycle helper 看到 newStatus 不在 OnEntryStatus（error / clear）走 case 3 cancel+delete；防 active entry 與 currentStatus 不一致（detector goroutine 已退出但 activeProbeIntents 仍含舊 entry → map leak / 後續 lifecycle 誤以為已 armed）
 
 ### 2.2 禁忌
 
@@ -791,7 +793,7 @@ func (d *probeIntentDispatcher) consumeSignals(
 ) {
     for sig := range in {
         // OnSignal 由 applyProbeGuards 在 guard 通過後 invoke（per by2z79ouc DEF-1）
-        applyProbeGuards(d.parent, probeGuardArgs{
+        applied := applyProbeGuards(d.parent, probeGuardArgs{
             Session:    session,
             AgentType:  agentType,
             Reason:     "probe-intent:" + string(intent.Kind),
@@ -799,6 +801,17 @@ func (d *probeIntentDispatcher) consumeSignals(
             Mapping:    intent.OnSignal,
             StaleCheck: makeProbeIntentStaleCheck(session, intent.Kind, agentType, generation),
         })
+        if !applied { continue }
+
+        // round 5 P1：probe 把 status 改了 (error/clear) — re-run lifecycle 觸發
+        // case 3 (active && !shouldActive)：cancel + delete active entry。
+        // 否則 detector goroutine 已退出但 activeProbeIntents 仍含舊 entry：
+        //   - map leak（每次 probe-applied 都累積一筆死 entry）
+        //   - 後續 lifecycle 看到 wasActive=true 走 case 4/5 而非 case 2 重 arm
+        d.parent.mu.Lock()
+        appliedStatus := d.parent.currentStatus[session]
+        d.parent.mu.Unlock()
+        d.applyStatus(session, agentType, appliedStatus)
     }
 }
 
@@ -921,7 +934,7 @@ func (d *probeIntentDispatcher) replayStatus() {
 |---|---|
 | P1-T1 | `ProbeIntent` / `ProbeIntentKind` / `Signal` / `ProbeIntentProvider` 落 `internal/agent/provider.go` + 單元測試（schema 對齊 §3.2；Signal 4 fields） |
 | P1-T2 | `applyProbeGuards` free function 抽出（mechanical extraction `probe_orchestrator.go interpretScreenEvent` step 1+2+4+5+6） + 新 `staleCheck strategy` 注入點；regression test 確保 ScreenChange 行為零變動（既有 probe_orchestrator_test.go / probe_orchestrator_integration_test.go 全綠） |
-| P1-T3 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `reconcileSessionActive` / `applyIntentLifecycle` / `consumeSignals` + activeProbeIntents 結構（在 m.mu 內保護） + generation token；用 stub detector 測 lifecycle 5 case（含 active target mismatch 觸發 cancel-and-rearm） + cross-provider reconcile（codex → cc 切換清掉舊 entry） + stale-callback re-check + generation 不匹配 drop |
+| P1-T3 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `reconcileSessionActive` / `applyIntentLifecycle` / `consumeSignals` + activeProbeIntents 結構（在 m.mu 內保護） + generation token；用 stub detector 測 lifecycle 5 case（含 active target mismatch 觸發 cancel-and-rearm） + cross-provider reconcile（codex → cc 切換清掉舊 entry） + stale-callback re-check + generation 不匹配 drop + **probe-applied teardown**（detector emit 把 status 改成 error → activeProbeIntents 該 entry 被清） |
 | P1-T4 | `Module.lookupTopFrameForSession` helper（讀 projection top frame `(paneID, pid)`）+ test |
 | P1-T5 | `manageActivityWatch` 接 `probeIntentDisp.applyStatus`；rename / Stop 路徑也接；test 覆蓋 rename 期間 (oldName stop, newName 重評估) |
 | P1-T6 | `Module.Start` 加 `probeIntentDisp.replayStatus`；daemon-restart recovery integration test（fixture：projection top frame 含 dead pid + status=running → Start 後 detector 啟動立即 emit → broadcast error） |
@@ -1050,9 +1063,24 @@ func (d *probeIntentDispatcher) replayStatus() {
 
 **決議**：`applyStatus` 入口先 reconcile session 既有 active entries，cancel/delete 任何 `(agentType, kind)` 不再屬於新 provider 宣告集合的 entry；防 cross-provider 切換的 stranded detector。修法詳 §5.4 reconcileSessionActive helper。
 
+### 9.12 ✅ 採 probe-applied teardown re-run applyStatus — 解 round 5 P1
+
+**決議**：`consumeSignals` 在 `applied=true` 後 re-run `applyStatus(session, agentType, newStatus)` — 讓 newStatus（error / clear）走 lifecycle case 3 cancel+delete active entry。修法詳 §5.4 consumeSignals。
+
+### 9.13 Spec convergence 與 stopping criterion（user 同意 (D)）
+
+5 輪 codex review finding 趨勢：5 → 4 → 1 → 1 → 1。每輪挖到不同類別 lifecycle corner case，convergence 明顯但非到 0。User 2026-04-29 決議採 (D)：修 v6 採納 round 5 P1 + **不再派 round 6**，直接進 plan。理由：
+
+- 修法 scope 5 行內，不涉及架構
+- spec lifecycle 已大致窮舉（hook → applyStatus → reconcile → applyIntentLifecycle → consumeSignals → re-apply）
+- plan 階段 codex review 仍會驗證實作正確性（test plan 涵蓋全部 5 case + 4 reconcile + probe-applied teardown）
+- 5 輪是 spec 階段合理上限（同 W2 spec 經驗）
+
+**Known issue 追蹤**：若 round 5 之後仍有 lifecycle corner case（unlikely），於 plan / 實作 / PR review 階段以 follow-up issue 追蹤。
+
 ---
 
-**所有 spec drift signal 已收斂；本 spec v5 進 plan 前需通過 codex 第五輪確認。**
+**所有 spec drift signal 已收斂。本 spec v6 為 final draft；直接進 plan 階段。**
 
 ---
 

--- a/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
+++ b/docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md
@@ -934,8 +934,8 @@ func (d *probeIntentDispatcher) replayStatus() {
 |---|---|
 | P1-T1 | `ProbeIntent` / `ProbeIntentKind` / `Signal` / `ProbeIntentProvider` 落 `internal/agent/provider.go` + 單元測試（schema 對齊 §3.2；Signal 4 fields） |
 | P1-T2 | `applyProbeGuards` free function 抽出（mechanical extraction `probe_orchestrator.go interpretScreenEvent` step 1+2+4+5+6） + 新 `staleCheck strategy` 注入點；regression test 確保 ScreenChange 行為零變動（既有 probe_orchestrator_test.go / probe_orchestrator_integration_test.go 全綠） |
-| P1-T3 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `reconcileSessionActive` / `applyIntentLifecycle` / `consumeSignals` + activeProbeIntents 結構（在 m.mu 內保護） + generation token；用 stub detector 測 lifecycle 5 case（含 active target mismatch 觸發 cancel-and-rearm） + cross-provider reconcile（codex → cc 切換清掉舊 entry） + stale-callback re-check + generation 不匹配 drop + **probe-applied teardown**（detector emit 把 status 改成 error → activeProbeIntents 該 entry 被清） |
-| P1-T4 | `Module.lookupTopFrameForSession` helper（讀 projection top frame `(paneID, pid)`）+ test |
+| P1-T3 | `Module.lookupTopFrameForSessionLocked` helper（讀 projection top frame `(paneID, pid)`）+ test — **plan v2 swap 後為 dispatcher core 的前置依賴** |
+| P1-T4 | 新檔 `internal/module/agent/probe_intent_dispatcher.go`：`applyStatus` / `reconcileSessionActive` / `applyIntentLifecycle` / `consumeSignals` + activeProbeIntents 結構（在 m.mu 內保護） + generation token；用 stub detector 測 lifecycle 5 case（含 active target mismatch 觸發 cancel-and-rearm） + cross-provider reconcile（codex → cc 切換清掉舊 entry） + stale-callback re-check + generation 不匹配 drop + **probe-applied teardown**（detector emit 把 status 改成 error → activeProbeIntents 該 entry 被清） |
 | P1-T5 | `manageActivityWatch` 接 `probeIntentDisp.applyStatus`；rename / Stop 路徑也接；test 覆蓋 rename 期間 (oldName stop, newName 重評估) |
 | P1-T6 | `Module.Start` 加 `probeIntentDisp.replayStatus`；daemon-restart recovery integration test（fixture：projection top frame 含 dead pid + status=running → Start 後 detector 啟動立即 emit → broadcast error） |
 

--- a/internal/agent/codex/probe_intent_process_dead.go
+++ b/internal/agent/codex/probe_intent_process_dead.go
@@ -9,6 +9,7 @@ package codex
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/wake/purdex/internal/agent"
@@ -20,16 +21,45 @@ import (
 // deliberately run slower than ScreenChangeWatcher (200ms tick) to honour
 // the "probe is recovery, not authority" principle. Tests override via the
 // withFastPoll helper.
-var processDeadPollInterval = 1 * time.Second
+//
+// Stored in an atomic.Int64 (nanos) so cross-package integration tests
+// running under -race can mutate it concurrently with a polling detector
+// goroutine without tripping the race detector. Production never mutates
+// it after init; the atomic load is a single instruction on amd64/arm64
+// so the cost vs a plain int64 is negligible at the 1Hz cadence.
+var processDeadPollInterval atomic.Int64
+
+func init() {
+	processDeadPollInterval.Store(int64(1 * time.Second))
+}
+
+func currentProcessDeadPollInterval() time.Duration {
+	return time.Duration(processDeadPollInterval.Load())
+}
 
 // isPidAliveFn is the injectable pid-liveness probe. Production points at
-// probe.IsPidAlive (a syscall.Kill(pid, 0) wrapper). Tests override the
-// package var to control the alive/dead state per call rather than spawning
-// real processes (per b36pap7jc / by2z79ouc FH-1 — the
+// probe.IsPidAlive (a syscall.Kill(pid, 0) wrapper). Tests override via
+// SetIsPidAliveFnForTest to control the alive/dead state per call rather
+// than spawning real processes (per b36pap7jc / by2z79ouc FH-1 — the
 // pidAlive×paneAlive matrix needs deterministic injection).
 //
-// Same pattern as internal/module/agent/probe_orchestrator.go's isPidAliveFn.
-var isPidAliveFn = probe.IsPidAlive
+// Held in an atomic.Pointer so cross-package integration tests running
+// under -race can swap the function pointer concurrently with a polling
+// detector goroutine. The fn is loaded once per poll tick so the atomic
+// cost is negligible at the 1Hz cadence (and ≪ the syscall.Kill itself).
+var isPidAliveFn atomic.Pointer[func(int) bool]
+
+func init() {
+	productionFn := probe.IsPidAlive
+	isPidAliveFn.Store(&productionFn)
+}
+
+// loadIsPidAliveFn dereferences the active pid-liveness probe. Returns a
+// non-nil func — init seeds it with probe.IsPidAlive and the test seam
+// always restores via the same atomic store path.
+func loadIsPidAliveFn() func(int) bool {
+	return *isPidAliveFn.Load()
+}
 
 // tmuxPaneLister is the minimal contract this detector requires for pane
 // existence checks. Implementation in production: tmux.Executor.HasPane(paneID)
@@ -71,7 +101,7 @@ func StartProcessDeadDetector(
 	senderPID int,
 	out chan<- agent.Signal,
 ) {
-	ticker := time.NewTicker(processDeadPollInterval)
+	ticker := time.NewTicker(currentProcessDeadPollInterval())
 	defer ticker.Stop()
 
 	for {
@@ -79,7 +109,7 @@ func StartProcessDeadDetector(
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			pidAlive := isPidAliveFn(senderPID)
+			pidAlive := loadIsPidAliveFn()(senderPID)
 			paneAlive := paneLister.HasPane(paneID)
 			if pidAlive && paneAlive {
 				continue // both alive, keep polling

--- a/internal/agent/codex/probe_intent_process_dead.go
+++ b/internal/agent/codex/probe_intent_process_dead.go
@@ -70,7 +70,13 @@ func loadIsPidAliveFn() func(int) bool {
 // session targets to the first pane via PanePID, which is the wrong
 // observation for non-first siblings.
 type tmuxPaneLister interface {
-	HasPane(paneID string) bool
+	// HasPane returns (exists, err). exists=true → confirmed presence;
+	// exists=false && err==nil → confirmed absence; err != nil → transient
+	// query failure (no server, exec error). Round-4 audit: the detector
+	// must NOT collapse query error into "pane gone" — that triggers
+	// false-positive clear emissions during tmux hiccups while the codex
+	// pane is still alive.
+	HasPane(paneID string) (exists bool, err error)
 }
 
 // StartProcessDeadDetector is the codex-side detector for
@@ -110,7 +116,15 @@ func StartProcessDeadDetector(
 			return
 		case <-ticker.C:
 			pidAlive := loadIsPidAliveFn()(senderPID)
-			paneAlive := paneLister.HasPane(paneID)
+			paneAlive, paneErr := paneLister.HasPane(paneID)
+			// Round-4 audit: a transient tmux query failure (no server,
+			// list-panes exec error) reports paneErr != nil; do NOT
+			// interpret as confirmed absence — keep polling so a recovered
+			// tmux server can be observed as alive on the next tick. Only
+			// confirmed (paneErr==nil) presence/absence drives a Signal.
+			if paneErr != nil {
+				continue
+			}
 			if pidAlive && paneAlive {
 				continue // both alive, keep polling
 			}

--- a/internal/agent/codex/probe_intent_process_dead.go
+++ b/internal/agent/codex/probe_intent_process_dead.go
@@ -1,0 +1,102 @@
+// internal/agent/codex/probe_intent_process_dead.go
+//
+// Codex-side detector for ProbeIntentKindProcessDead. Polls senderPID + paneID
+// and emits one Signal when either invariant fails. Used by the daemon
+// ProbeIntent dispatcher to recover the missing StopFailure transition that
+// codex 0.124.0 does not emit (see docs/specs/2026-04-29-w6-3-codex-error-
+// probe-intent-spec.md §4 for the full design).
+package codex
+
+import (
+	"context"
+	"time"
+
+	"github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/probe"
+)
+
+// processDeadPollInterval is the polling cadence for pidAlive + HasPane.
+// 1Hz is intentional — codex crash recovery is latency-tolerant and we
+// deliberately run slower than ScreenChangeWatcher (200ms tick) to honour
+// the "probe is recovery, not authority" principle. Tests override via the
+// withFastPoll helper.
+var processDeadPollInterval = 1 * time.Second
+
+// isPidAliveFn is the injectable pid-liveness probe. Production points at
+// probe.IsPidAlive (a syscall.Kill(pid, 0) wrapper). Tests override the
+// package var to control the alive/dead state per call rather than spawning
+// real processes (per b36pap7jc / by2z79ouc FH-1 — the
+// pidAlive×paneAlive matrix needs deterministic injection).
+//
+// Same pattern as internal/module/agent/probe_orchestrator.go's isPidAliveFn.
+var isPidAliveFn = probe.IsPidAlive
+
+// tmuxPaneLister is the minimal contract this detector requires for pane
+// existence checks. Implementation in production: tmux.Executor.HasPane(paneID)
+// — wraps `tmux list-panes -a -F '#{pane_id}'` and scans for the target id.
+//
+// Per b36pap7jc ATK-2: the detector deliberately checks the global pane list
+// (NOT probe.Prober.IsAliveFor(sessionTarget)). Multi-pane windows resolve
+// session targets to the first pane via PanePID, which is the wrong
+// observation for non-first siblings.
+type tmuxPaneLister interface {
+	HasPane(paneID string) bool
+}
+
+// StartProcessDeadDetector is the codex-side detector for
+// ProbeIntentKindProcessDead. It polls senderPID + paneID; on the first
+// dead-confirmed tick it emits one Signal carrying the PaneAlive observation
+// and returns. Cancel ctx to stop early (e.g. on session rename or status
+// exit from OnEntryStatus).
+//
+// Polling matrix (spec §4.2):
+//
+//	| pidAlive | paneAlive | action                                  |
+//	|----------|-----------|-----------------------------------------|
+//	| true     | true      | both alive — keep polling               |
+//	| true     | false     | re-parented edge case → emit PaneAlive=false |
+//	| false    | true      | process dead, pane alive → emit PaneAlive=true (W6-3 error) |
+//	| false    | false     | process dead, pane gone → emit PaneAlive=false (W6-4 clear) |
+//
+// The detector emits at most one Signal. Caller is expected to consume the
+// emitted Signal via dispatcher.applyProbeGuards (graceWindow / stale-callback
+// / ErrorGuard / transition gate / OnSignal mapping all live there).
+//
+// paneLister is the minimal contract the detector needs (HasPane(paneID)).
+// Production wires *tmux.Executor; tests inject a fake.
+func StartProcessDeadDetector(
+	ctx context.Context,
+	paneLister tmuxPaneLister,
+	paneID string,
+	senderPID int,
+	out chan<- agent.Signal,
+) {
+	ticker := time.NewTicker(processDeadPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pidAlive := isPidAliveFn(senderPID)
+			paneAlive := paneLister.HasPane(paneID)
+			if pidAlive && paneAlive {
+				continue // both alive, keep polling
+			}
+			// pidAlive=true, paneAlive=false: process re-parented but pane
+			// gone; treat as pane-gone path (PaneAlive=false → W6-4 clear).
+			// Already covered by the Signal{PaneAlive: paneAlive} below.
+			select {
+			case out <- agent.Signal{
+				Kind:      agent.ProbeIntentKindProcessDead,
+				PaneAlive: paneAlive,
+				PaneID:    paneID,
+				SenderPID: senderPID,
+			}:
+			case <-ctx.Done():
+			}
+			return
+		}
+	}
+}

--- a/internal/agent/codex/probe_intent_process_dead_test.go
+++ b/internal/agent/codex/probe_intent_process_dead_test.go
@@ -340,3 +340,48 @@ func TestStartProcessDeadDetector_MultiPane_UsesCorrectPaneID(t *testing.T) {
 		}
 	}
 }
+
+// --- P2-T3: onProcessDead mapper tests (internal — tests unexported fn) ---
+
+// TestOnProcessDead_PaneAliveTrue_MapsToError asserts the W6-3 path:
+// PaneAlive=true (process dead, pane still listed) → StatusError.
+func TestOnProcessDead_PaneAliveTrue_MapsToError(t *testing.T) {
+	got := onProcessDead(agent.Signal{
+		Kind:      agent.ProbeIntentKindProcessDead,
+		PaneAlive: true,
+		PaneID:    "%5",
+		SenderPID: 1234,
+	})
+	if got != agent.StatusError {
+		t.Errorf("onProcessDead(PaneAlive=true) = %q, want %q", got, agent.StatusError)
+	}
+}
+
+// TestOnProcessDead_PaneAliveFalse_MapsToClear asserts the W6-4 path:
+// PaneAlive=false (process dead, pane gone) → StatusClear.
+func TestOnProcessDead_PaneAliveFalse_MapsToClear(t *testing.T) {
+	got := onProcessDead(agent.Signal{
+		Kind:      agent.ProbeIntentKindProcessDead,
+		PaneAlive: false,
+		PaneID:    "%5",
+		SenderPID: 1234,
+	})
+	if got != agent.StatusClear {
+		t.Errorf("onProcessDead(PaneAlive=false) = %q, want %q", got, agent.StatusClear)
+	}
+}
+
+// TestOnProcessDead_WrongKind_ReturnsEmpty asserts that a Signal with a
+// non-ProcessDead Kind returns "" — defends against dispatcher misuse if a
+// future Kind ever shares the OnSignal slot.
+func TestOnProcessDead_WrongKind_ReturnsEmpty(t *testing.T) {
+	got := onProcessDead(agent.Signal{
+		Kind:      "screen_change",
+		PaneAlive: true,
+		PaneID:    "%5",
+		SenderPID: 1234,
+	})
+	if got != "" {
+		t.Errorf("onProcessDead(Kind=screen_change) = %q, want empty Status", got)
+	}
+}

--- a/internal/agent/codex/probe_intent_process_dead_test.go
+++ b/internal/agent/codex/probe_intent_process_dead_test.go
@@ -1,0 +1,342 @@
+// internal/agent/codex/probe_intent_process_dead_test.go
+package codex
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/probe"
+)
+
+// fakePaneLister is a deterministic tmuxPaneLister test double. Tests register
+// the panes they want HasPane to recognise and then assert call counts via
+// HasPaneCalls.
+type fakePaneLister struct {
+	mu       sync.Mutex
+	panes    map[string]bool
+	calls    int
+	callLog  []string
+	override func(string) bool
+}
+
+func newFakePaneLister(panes ...string) *fakePaneLister {
+	m := make(map[string]bool, len(panes))
+	for _, p := range panes {
+		m[p] = true
+	}
+	return &fakePaneLister{panes: m}
+}
+
+func (f *fakePaneLister) HasPane(paneID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.callLog = append(f.callLog, paneID)
+	if f.override != nil {
+		return f.override(paneID)
+	}
+	return f.panes[paneID]
+}
+
+func (f *fakePaneLister) Calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakePaneLister) CallLog() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.callLog))
+	copy(out, f.callLog)
+	return out
+}
+
+// withFastPoll temporarily lowers processDeadPollInterval for the duration of
+// a test. Restored via t.Cleanup.
+func withFastPoll(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := processDeadPollInterval
+	processDeadPollInterval = d
+	t.Cleanup(func() { processDeadPollInterval = orig })
+}
+
+// withPidAlive overrides isPidAliveFn for the duration of a test, restoring
+// the production probe.IsPidAlive implementation in cleanup.
+func withPidAlive(t *testing.T, fn func(int) bool) {
+	t.Helper()
+	orig := isPidAliveFn
+	isPidAliveFn = fn
+	t.Cleanup(func() { isPidAliveFn = orig })
+}
+
+// TestStartProcessDeadDetector_BothAlive_KeepsPolling verifies that when both
+// the pid is alive and the pane exists the detector keeps polling without
+// emitting a Signal. After two ticks we cancel ctx and check the channel is
+// empty (within a short grace window).
+func TestStartProcessDeadDetector_BothAlive_KeepsPolling(t *testing.T) {
+	withFastPoll(t, 1*time.Millisecond)
+	withPidAlive(t, func(pid int) bool { return true })
+
+	lister := newFakePaneLister("%5")
+	out := make(chan agent.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		StartProcessDeadDetector(ctx, lister, "%5", 1234, out)
+		close(done)
+	}()
+
+	// Let it tick a few times before cancelling.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+
+	select {
+	case sig := <-out:
+		t.Fatalf("expected no signal, got %+v", sig)
+	default:
+	}
+	if lister.Calls() == 0 {
+		t.Errorf("expected pane lister to be called at least once")
+	}
+}
+
+// TestStartProcessDeadDetector_PidDead_PaneAlive_EmitsErrorPath verifies the
+// W6-3 path: process dead but pane still listed → Signal{PaneAlive: true}.
+func TestStartProcessDeadDetector_PidDead_PaneAlive_EmitsErrorPath(t *testing.T) {
+	withFastPoll(t, 1*time.Millisecond)
+	withPidAlive(t, func(pid int) bool { return false })
+
+	lister := newFakePaneLister("%5")
+	out := make(chan agent.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartProcessDeadDetector(ctx, lister, "%5", 4321, out)
+		close(done)
+	}()
+
+	select {
+	case sig := <-out:
+		if sig.Kind != agent.ProbeIntentKindProcessDead {
+			t.Errorf("Kind = %q, want %q", sig.Kind, agent.ProbeIntentKindProcessDead)
+		}
+		if !sig.PaneAlive {
+			t.Errorf("PaneAlive = false, want true (W6-3 error path)")
+		}
+		if sig.PaneID != "%5" {
+			t.Errorf("PaneID = %q, want %q", sig.PaneID, "%5")
+		}
+		if sig.SenderPID != 4321 {
+			t.Errorf("SenderPID = %d, want 4321", sig.SenderPID)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("detector did not emit a signal in time")
+	}
+	<-done
+}
+
+// TestStartProcessDeadDetector_PidDead_PaneGone_EmitsClearPath verifies the
+// W6-4 path: process dead and pane gone → Signal{PaneAlive: false}.
+func TestStartProcessDeadDetector_PidDead_PaneGone_EmitsClearPath(t *testing.T) {
+	withFastPoll(t, 1*time.Millisecond)
+	withPidAlive(t, func(pid int) bool { return false })
+
+	// pane list does NOT include %5 → HasPane returns false
+	lister := newFakePaneLister("%9")
+	out := make(chan agent.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartProcessDeadDetector(ctx, lister, "%5", 4321, out)
+		close(done)
+	}()
+
+	select {
+	case sig := <-out:
+		if sig.Kind != agent.ProbeIntentKindProcessDead {
+			t.Errorf("Kind = %q, want %q", sig.Kind, agent.ProbeIntentKindProcessDead)
+		}
+		if sig.PaneAlive {
+			t.Errorf("PaneAlive = true, want false (W6-4 clear path)")
+		}
+		if sig.PaneID != "%5" {
+			t.Errorf("PaneID = %q, want %q", sig.PaneID, "%5")
+		}
+		if sig.SenderPID != 4321 {
+			t.Errorf("SenderPID = %d, want 4321", sig.SenderPID)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("detector did not emit a signal in time")
+	}
+	<-done
+}
+
+// TestStartProcessDeadDetector_PidAlive_PaneGone_TreatedAsPaneGone verifies
+// the rare re-parented edge case: pid is still alive (perhaps re-parented to
+// init) but the pane is gone. Spec §4.2 maps this to the pane-gone path
+// (PaneAlive=false) so caller routes it to clear, not error.
+func TestStartProcessDeadDetector_PidAlive_PaneGone_TreatedAsPaneGone(t *testing.T) {
+	withFastPoll(t, 1*time.Millisecond)
+	withPidAlive(t, func(pid int) bool { return true })
+
+	// pane list omits %5
+	lister := newFakePaneLister("%9")
+	out := make(chan agent.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartProcessDeadDetector(ctx, lister, "%5", 4321, out)
+		close(done)
+	}()
+
+	select {
+	case sig := <-out:
+		if sig.PaneAlive {
+			t.Errorf("PaneAlive = true, want false (re-parented edge case treated as pane-gone)")
+		}
+		if sig.PaneID != "%5" {
+			t.Errorf("PaneID = %q, want %q", sig.PaneID, "%5")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("detector did not emit a signal in time")
+	}
+	<-done
+}
+
+// TestStartProcessDeadDetector_CtxCancel_ExitsImmediately verifies that when
+// ctx is cancelled the detector returns without emitting a Signal.
+func TestStartProcessDeadDetector_CtxCancel_ExitsImmediately(t *testing.T) {
+	withFastPoll(t, 50*time.Millisecond) // slow enough that ctx wins the select
+	withPidAlive(t, func(pid int) bool { return true })
+
+	lister := newFakePaneLister("%5")
+	out := make(chan agent.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		StartProcessDeadDetector(ctx, lister, "%5", 1234, out)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatalf("detector did not return after ctx cancel")
+	}
+
+	select {
+	case sig := <-out:
+		t.Fatalf("expected no signal, got %+v", sig)
+	default:
+	}
+}
+
+// TestStartProcessDeadDetector_EmitsOnceThenReturns verifies that after
+// emitting one Signal the detector returns (does not keep polling). Caller
+// asserts only one Signal lands on the channel.
+func TestStartProcessDeadDetector_EmitsOnceThenReturns(t *testing.T) {
+	withFastPoll(t, 1*time.Millisecond)
+	withPidAlive(t, func(pid int) bool { return false })
+
+	lister := newFakePaneLister("%5")
+	out := make(chan agent.Signal, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartProcessDeadDetector(ctx, lister, "%5", 1234, out)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("detector did not return after first emission")
+	}
+
+	if got := len(out); got != 1 {
+		t.Errorf("len(out) = %d after detector return, want 1", got)
+	}
+}
+
+// TestStartProcessDeadDetector_PidAliveFn_OverrideAndCleanup verifies the
+// test override + cleanup pattern: after t.Cleanup runs, isPidAliveFn must
+// be restored to probe.IsPidAlive (so subsequent tests get production
+// behaviour by default).
+func TestStartProcessDeadDetector_PidAliveFn_OverrideAndCleanup(t *testing.T) {
+	// snapshot the production fn pointer for comparison
+	productionFn := probe.IsPidAlive
+
+	t.Run("override", func(t *testing.T) {
+		withPidAlive(t, func(pid int) bool { return false })
+		// detector logic is exercised elsewhere — here we just confirm the
+		// package var IS overridden during the test
+		if isPidAliveFn(99999) != false {
+			t.Errorf("override did not take effect")
+		}
+	})
+
+	// after t.Cleanup, the package var must point at production again.
+	// We can't compare function values directly in Go, but we can check
+	// behaviour (production probe.IsPidAlive on pid 1 — process 0/1 always
+	// either exists or returns EPERM, both → true).
+	if isPidAliveFn(1) != productionFn(1) {
+		t.Errorf("isPidAliveFn was not restored to production probe.IsPidAlive after cleanup")
+	}
+}
+
+// TestStartProcessDeadDetector_MultiPane_UsesCorrectPaneID verifies that
+// when tmux lists multiple panes (e.g. %5 + %7), the detector queries with
+// its own paneID and is unaffected by sibling panes.
+func TestStartProcessDeadDetector_MultiPane_UsesCorrectPaneID(t *testing.T) {
+	withFastPoll(t, 1*time.Millisecond)
+	withPidAlive(t, func(pid int) bool { return false })
+
+	// Pane list contains %5 and %7. We watch for %5; %5 is alive, %7 should
+	// not interfere.
+	lister := newFakePaneLister("%5", "%7")
+	out := make(chan agent.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartProcessDeadDetector(ctx, lister, "%5", 1234, out)
+		close(done)
+	}()
+
+	select {
+	case sig := <-out:
+		if sig.PaneID != "%5" {
+			t.Errorf("PaneID = %q, want %q (must report watched pane, not sibling)", sig.PaneID, "%5")
+		}
+		if !sig.PaneAlive {
+			t.Errorf("PaneAlive = false, want true (%%5 is in the listed panes)")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("detector did not emit a signal")
+	}
+	<-done
+
+	// Confirm the lister was queried with %5 (not %7).
+	for _, q := range lister.CallLog() {
+		if q != "%5" {
+			t.Errorf("lister queried with %q, want only %q", q, "%5")
+		}
+	}
+}

--- a/internal/agent/codex/probe_intent_process_dead_test.go
+++ b/internal/agent/codex/probe_intent_process_dead_test.go
@@ -3,7 +3,9 @@ package codex
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,7 +21,10 @@ type fakePaneLister struct {
 	panes    map[string]bool
 	calls    int
 	callLog  []string
-	override func(string) bool
+	override func(string) (bool, error)
+	// errOnce returns this error on the next call only (then clears),
+	// simulating a transient tmux query failure (round-4 audit).
+	errOnce error
 }
 
 func newFakePaneLister(panes ...string) *fakePaneLister {
@@ -30,15 +35,20 @@ func newFakePaneLister(panes ...string) *fakePaneLister {
 	return &fakePaneLister{panes: m}
 }
 
-func (f *fakePaneLister) HasPane(paneID string) bool {
+func (f *fakePaneLister) HasPane(paneID string) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls++
 	f.callLog = append(f.callLog, paneID)
+	if f.errOnce != nil {
+		err := f.errOnce
+		f.errOnce = nil
+		return false, err
+	}
 	if f.override != nil {
 		return f.override(paneID)
 	}
-	return f.panes[paneID]
+	return f.panes[paneID], nil
 }
 
 func (f *fakePaneLister) Calls() int {
@@ -207,6 +217,52 @@ func TestStartProcessDeadDetector_PidAlive_PaneGone_TreatedAsPaneGone(t *testing
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatalf("detector did not emit a signal in time")
+	}
+	<-done
+}
+
+// TestStartProcessDeadDetector_PaneListerError_KeepsPolling pins the round-4
+// audit semantics: when HasPane returns a transient error (e.g. tmux server
+// transient failure) the detector MUST NOT collapse the error into a
+// confirmed-absent emission. It continues polling until either a clean
+// query confirms presence/absence or ctx is cancelled.
+//
+// Test wires errOnce so the first poll surfaces an error (no signal
+// emitted), then the subsequent ticks observe pidAlive=false +
+// paneAlive=true → emits the error path Signal.
+func TestStartProcessDeadDetector_PaneListerError_KeepsPolling(t *testing.T) {
+	withFastPoll(t, 1*time.Millisecond)
+	// pid is alive on the first tick (so without the fix the error path
+	// would emit clear); becomes dead on subsequent ticks.
+	var pidCalls atomic.Int32
+	withPidAlive(t, func(pid int) bool {
+		// First call returns alive (paired with errOnce on the first poll
+		// → the detector should skip emit). Subsequent calls dead.
+		return pidCalls.Add(1) == 1
+	})
+
+	lister := newFakePaneLister("%5")
+	lister.errOnce = errors.New("tmux server transient")
+
+	out := make(chan agent.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartProcessDeadDetector(ctx, lister, "%5", 4321, out)
+		close(done)
+	}()
+
+	// Expect a single eventual Signal: PaneAlive=true (W6-3 error path,
+	// not a false-positive clear). The error tick was dropped.
+	select {
+	case sig := <-out:
+		if !sig.PaneAlive {
+			t.Fatalf("PaneAlive = false on tmux error tick — round-4 fix regression (must keep polling, not emit clear)")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("detector never emitted; expected pid-dead + pane-alive after error recovery")
 	}
 	<-done
 }

--- a/internal/agent/codex/probe_intent_process_dead_test.go
+++ b/internal/agent/codex/probe_intent_process_dead_test.go
@@ -59,18 +59,14 @@ func (f *fakePaneLister) CallLog() []string {
 // a test. Restored via t.Cleanup.
 func withFastPoll(t *testing.T, d time.Duration) {
 	t.Helper()
-	orig := processDeadPollInterval
-	processDeadPollInterval = d
-	t.Cleanup(func() { processDeadPollInterval = orig })
+	t.Cleanup(SetProcessDeadPollIntervalForTest(d))
 }
 
 // withPidAlive overrides isPidAliveFn for the duration of a test, restoring
 // the production probe.IsPidAlive implementation in cleanup.
 func withPidAlive(t *testing.T, fn func(int) bool) {
 	t.Helper()
-	orig := isPidAliveFn
-	isPidAliveFn = fn
-	t.Cleanup(func() { isPidAliveFn = orig })
+	t.Cleanup(SetIsPidAliveFnForTest(fn))
 }
 
 // TestStartProcessDeadDetector_BothAlive_KeepsPolling verifies that when both
@@ -286,7 +282,7 @@ func TestStartProcessDeadDetector_PidAliveFn_OverrideAndCleanup(t *testing.T) {
 		withPidAlive(t, func(pid int) bool { return false })
 		// detector logic is exercised elsewhere — here we just confirm the
 		// package var IS overridden during the test
-		if isPidAliveFn(99999) != false {
+		if loadIsPidAliveFn()(99999) != false {
 			t.Errorf("override did not take effect")
 		}
 	})
@@ -295,7 +291,7 @@ func TestStartProcessDeadDetector_PidAliveFn_OverrideAndCleanup(t *testing.T) {
 	// We can't compare function values directly in Go, but we can check
 	// behaviour (production probe.IsPidAlive on pid 1 — process 0/1 always
 	// either exists or returns EPERM, both → true).
-	if isPidAliveFn(1) != productionFn(1) {
+	if loadIsPidAliveFn()(1) != productionFn(1) {
 		t.Errorf("isPidAliveFn was not restored to production probe.IsPidAlive after cleanup")
 	}
 }

--- a/internal/agent/codex/provider.go
+++ b/internal/agent/codex/provider.go
@@ -51,3 +51,41 @@ func (p *Provider) SupportedStatuses() []agent.Status {
 func (p *Provider) IsAlive(tmuxTarget string) bool {
 	return false // Deprecated: agent module uses prober.IsAliveFor directly
 }
+
+// ProbeIntents declares the probe-driven status transitions for the codex
+// agent. W6-3 first PR scope: one intent — ProcessDead — that recovers the
+// missing StopFailure transition codex 0.124.0 does not emit. Future W6 PRs
+// MAY append more intents but MUST keep ProcessDead present and stable.
+//
+// Implements agent.ProbeIntentProvider (optional capability — providers
+// without ProbeIntents behave identically to pre-W6-3).
+//
+// Per spec §4.1: gating set {Running, Waiting} mirrors the only states where
+// codex is supposed to be doing work; OnSignal mapping (PaneAlive=true →
+// Error, false → Clear) splits W6-3 (codex died with pane intact) from W6-4
+// (entire pane disappeared) on the runtime observation captured by
+// StartProcessDeadDetector.
+func (p *Provider) ProbeIntents() []agent.ProbeIntent {
+	return []agent.ProbeIntent{
+		{
+			Kind:          agent.ProbeIntentKindProcessDead,
+			OnEntryStatus: []agent.Status{agent.StatusRunning, agent.StatusWaiting},
+			OnSignal:      onProcessDead,
+		},
+	}
+}
+
+// onProcessDead maps a ProcessDead signal to the recovery status, splitting
+// W6-3 (PaneAlive=true → Error) and W6-4 (PaneAlive=false → Clear) on the
+// pane existence observation that the detector captured. Defends against
+// dispatcher misuse: a Signal with a non-ProcessDead Kind returns an empty
+// Status (drop the signal) rather than mapping to Error or Clear.
+func onProcessDead(sig agent.Signal) agent.Status {
+	if sig.Kind != agent.ProbeIntentKindProcessDead {
+		return ""
+	}
+	if sig.PaneAlive {
+		return agent.StatusError
+	}
+	return agent.StatusClear
+}

--- a/internal/agent/codex/provider_test.go
+++ b/internal/agent/codex/provider_test.go
@@ -85,6 +85,54 @@ func TestCodexSupportedStatuses_DerivesFromEvents(t *testing.T) {
 	}
 }
 
+// --- P2-T3: ProbeIntents() declaration tests ---
+
+// TestProvider_ProbeIntents_DeclaresProcessDead asserts the codex provider
+// declares exactly one ProbeIntent and its Kind is ProcessDead. This is the
+// W6-3 + W6-4 first PR scope; subsequent W6 PRs MAY append more intents but
+// MUST keep ProcessDead present and stable.
+func TestProvider_ProbeIntents_DeclaresProcessDead(t *testing.T) {
+	p := codex.NewProvider()
+	pip, ok := any(p).(agent.ProbeIntentProvider)
+	if !ok {
+		t.Fatalf("codex.Provider does not implement agent.ProbeIntentProvider")
+	}
+	intents := pip.ProbeIntents()
+	if len(intents) != 1 {
+		t.Fatalf("ProbeIntents() len = %d, want 1 (W6-3 first PR scope)", len(intents))
+	}
+	if intents[0].Kind != agent.ProbeIntentKindProcessDead {
+		t.Errorf("ProbeIntents()[0].Kind = %q, want %q", intents[0].Kind, agent.ProbeIntentKindProcessDead)
+	}
+	if intents[0].OnSignal == nil {
+		t.Errorf("ProbeIntents()[0].OnSignal = nil, want non-nil mapper")
+	}
+}
+
+// TestProvider_ProbeIntents_OnEntryStatusContainsRunningWaiting verifies the
+// gating set covers both Running and Waiting (codex process_dead inference
+// only makes sense while codex is supposed to be working).
+func TestProvider_ProbeIntents_OnEntryStatusContainsRunningWaiting(t *testing.T) {
+	p := codex.NewProvider()
+	pip, ok := any(p).(agent.ProbeIntentProvider)
+	if !ok {
+		t.Fatalf("codex.Provider does not implement agent.ProbeIntentProvider")
+	}
+	intents := pip.ProbeIntents()
+	if len(intents) == 0 {
+		t.Fatalf("ProbeIntents() returned no intents")
+	}
+	gating := make(map[agent.Status]bool, len(intents[0].OnEntryStatus))
+	for _, s := range intents[0].OnEntryStatus {
+		gating[s] = true
+	}
+	for _, want := range []agent.Status{agent.StatusRunning, agent.StatusWaiting} {
+		if !gating[want] {
+			t.Errorf("OnEntryStatus missing %q (have %v)", want, intents[0].OnEntryStatus)
+		}
+	}
+}
+
 // TestCodexSupportedStatuses asserts codex.Provider implements
 // StatusSupporter and declares the same Phase 1 status set as cc/opencode
 // post-DeriveStatus expansion (Commit 3).

--- a/internal/agent/codex/test_seams.go
+++ b/internal/agent/codex/test_seams.go
@@ -1,0 +1,53 @@
+// internal/agent/codex/test_seams.go
+//
+// Cross-package test seams for the ProcessDead detector. Lives in a
+// non-_test.go production file so external packages (notably
+// internal/module/agent integration tests) can override the detector's
+// private polling cadence + pid-liveness function.
+//
+// Both seams operate on atomic primitives that the detector goroutine
+// reads each tick — so a test mutating them while the goroutine is
+// running does not race with the read. The previous value is captured
+// inside SetXxxForTest and returned via the restore func; callers
+// (tests) defer or t.Cleanup that closure. The `*ForTest` naming + the
+// fact that production code never calls these helpers (grep enforces
+// it) keeps the test contract clear without pulling the testing
+// package into the production import graph.
+package codex
+
+import "time"
+
+// SetIsPidAliveFnForTest swaps the pid-liveness probe and returns a
+// restore func. Production code MUST NOT call this helper.
+//
+// Usage in cross-package tests:
+//
+//	t.Cleanup(codex.SetIsPidAliveFnForTest(func(int) bool { return false }))
+//
+// Used by internal/module/agent dispatcher integration tests (P2-T4 /
+// P2-T7) to drive the alive/dead × pane-alive/pane-gone matrix without
+// spawning real processes.
+func SetIsPidAliveFnForTest(fn func(int) bool) (restore func()) {
+	prev := *isPidAliveFn.Load()
+	isPidAliveFn.Store(&fn)
+	return func() {
+		isPidAliveFn.Store(&prev)
+	}
+}
+
+// SetProcessDeadPollIntervalForTest swaps the polling cadence and
+// returns a restore func. Production code MUST NOT call this helper.
+//
+// Usage in cross-package tests:
+//
+//	t.Cleanup(codex.SetProcessDeadPollIntervalForTest(time.Millisecond))
+//
+// Used by integration tests that need detector emission to land within
+// a test deadline rather than the production 1Hz cadence.
+func SetProcessDeadPollIntervalForTest(d time.Duration) (restore func()) {
+	prev := processDeadPollInterval.Load()
+	processDeadPollInterval.Store(int64(d))
+	return func() {
+		processDeadPollInterval.Store(prev)
+	}
+}

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -119,3 +119,10 @@ var MetricProbeIntentDroppedErrorGuard = expvar.NewInt("purdex_probe_intent_drop
 // mapped status equaled the existing currentStatus (transition gate;
 // suppresses no-op broadcasts).
 var MetricProbeIntentDroppedTransitionGate = expvar.NewInt("purdex_probe_intent_dropped_transition_gate_total")
+
+// MetricProbeIntentUnsupportedKind counts arm attempts for kinds with no
+// production detector wiring. Per audit F6: lifecycle MUST fail-closed so
+// new providers declaring an unwired kind surface a runtime signal rather
+// than silently appearing armed with a noop detector. Drift test exercises
+// production routing rather than just a wiredKinds mirror.
+var MetricProbeIntentUnsupportedKind = expvar.NewInt("purdex_probe_intent_unsupported_kind_total")

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -64,3 +64,58 @@ var MetricProbeScreenEvent = expvar.NewInt("purdex_probe_screen_event_total")
 // suppressed event +1 (no dedup) — the counter measures hook authority
 // over probe.
 var MetricProbeGraceWindowSuppressed = expvar.NewInt("purdex_probe_grace_window_suppressed_total")
+
+// --- W6-3 P2-T6 ProbeIntent dispatcher counters ---------------------------
+// Independent namespace ("purdex_probe_intent_*") so existing probe / phase35
+// dashboards stay separable from the per-Kind ProbeIntent fan-out. Each
+// counter is process-cumulative; daemon restart resets to zero. Tests must
+// compare deltas, never absolute values.
+//
+// Drop counters use caller-aware semantics: ScreenChange path leaves
+// probeGuardArgs.OnDrop nil and only bumps MetricProbeGraceWindowSuppressed
+// (legacy contract); ProbeIntent path supplies OnDrop = probeIntentOnDrop
+// so each drop reason routes to a distinct counter for fault isolation
+// (stale-callback vs grace vs error-guard vs transition-gate).
+
+// MetricProbeIntentStarted counts active ProbeIntent detector arming
+// (applyIntentLifecycle case 2 / 5). Increments after the entry is recorded
+// in m.activeProbeIntents and the goroutine has been scheduled.
+var MetricProbeIntentStarted = expvar.NewInt("purdex_probe_intent_started_total")
+
+// MetricProbeIntentStopped counts every detector cancel from the dispatcher
+// (lifecycle case 3, reconcileSessionActive teardown, stopAll). Each
+// distinct activeIntent.cancel invocation = +1.
+var MetricProbeIntentStopped = expvar.NewInt("purdex_probe_intent_stopped_total")
+
+// MetricProbeIntentSignalEmitted counts every Signal observed by
+// consumeSignals before the guard pipeline runs. Decoupled from
+// MetricProbeIntentApplied so dashboards can show the apply ratio.
+var MetricProbeIntentSignalEmitted = expvar.NewInt("purdex_probe_intent_signal_emitted_total")
+
+// MetricProbeIntentApplied counts signals that successfully traversed the
+// full applyProbeGuards pipeline (StaleCheck + graceWindow + Mapping +
+// ErrorGuard + transition gate) and broadcast a status change. Increments
+// happen inside applyProbeGuards on the ProbeIntent code path.
+var MetricProbeIntentApplied = expvar.NewInt("purdex_probe_intent_applied_total")
+
+// MetricProbeIntentDroppedStale counts signals dropped because StaleCheck
+// returned false — either at the early fast-path lock (active map cleared
+// between detector emit and consumeSignals delivery) or at the final
+// critical-section re-check (race between guard pipeline and cancel/rearm).
+var MetricProbeIntentDroppedStale = expvar.NewInt("purdex_probe_intent_dropped_stale_total")
+
+// MetricProbeIntentDroppedGrace counts signals dropped by the
+// recordHookAt-grace window. Distinct from the legacy
+// MetricProbeGraceWindowSuppressed counter so ProbeIntent path can be
+// reasoned about independently from the ScreenChange path.
+var MetricProbeIntentDroppedGrace = expvar.NewInt("purdex_probe_intent_dropped_grace_total")
+
+// MetricProbeIntentDroppedErrorGuard counts signals dropped because
+// currentStatus was already Error (probe is recovery-only; never overwrite
+// an existing error state).
+var MetricProbeIntentDroppedErrorGuard = expvar.NewInt("purdex_probe_intent_dropped_error_guard_total")
+
+// MetricProbeIntentDroppedTransitionGate counts signals dropped because the
+// mapped status equaled the existing currentStatus (transition gate;
+// suppresses no-op broadcasts).
+var MetricProbeIntentDroppedTransitionGate = expvar.NewInt("purdex_probe_intent_dropped_transition_gate_total")

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -271,3 +271,100 @@ type SessionState struct {
 	SessionID string
 	Cwd       string
 }
+
+// ProbeIntentProvider declares probe-driven status transitions for an agent.
+//
+// Probe is a recovery channel that complements (not replaces) hooks: when an
+// agent's hook catalog has a structural gap (e.g. codex StopFailure being
+// FutureOnly = ✗ 0.124.0 不發), the agent's provider declares one or more
+// ProbeIntents whose detectors infer the missing transition from runtime
+// observation (process liveness, tmux pane content, etc).
+//
+// Implementing this interface is optional. Providers without ProbeIntents
+// behave identically to pre-W6-3 (no probe-driven transitions).
+//
+// Daemon module reads ProbeIntents() on every status change for the session's
+// agent and starts/stops detectors accordingly. Detectors live in the agent's
+// own package (e.g. internal/agent/codex/probe_intent_*.go) — module only
+// owns the dispatcher plumbing.
+type ProbeIntentProvider interface {
+	ProbeIntents() []ProbeIntent
+}
+
+// ProbeIntent is one probe-driven transition declared by an agent provider.
+//
+// Lifecycle (driven by daemon dispatcher):
+//  1. Status changes to a value listed in OnEntryStatus → dispatcher resolves
+//     pane id + senderPID from the active frame, then dispatches to the
+//     per-Kind detector goroutine
+//  2. Detector observes runtime state (per Kind) and emits Signal events
+//  3. Dispatcher applies guards (see probe orchestrator §5.3) then
+//     OnSignal(sig) → Status
+//  4. Status changes to a value NOT in OnEntryStatus → dispatcher stops
+//     detector (cancel ctx) and frees per-(session, kind) state
+//
+// W6-3 first PR finalize: one Kind = ProbeIntentKindProcessDead. Future Kind
+// additions (W6-1/2/6 ScreenChange) MUST keep the existing Signal fields
+// backward compatible (add fields, don't repurpose).
+type ProbeIntent struct {
+	// Kind classifies the detector. W6-3 finalize: only ProbeIntentKindProcessDead.
+	// Subsequent W6 PRs MAY introduce additional Kind constants; existing Kind
+	// semantics and Signal field semantics MUST remain stable.
+	Kind ProbeIntentKind
+
+	// OnEntryStatus is the set of currentStatus values that gate this intent
+	// active. Detector starts on entry to any of these and stops on exit to any
+	// status outside the set.
+	//
+	// Example (W6-3+W6-4): {StatusRunning, StatusWaiting} — codex process_dead
+	// inference only makes sense while codex is supposed to be doing work.
+	OnEntryStatus []Status
+
+	// OnSignal maps a detector signal to the new Status. Empty Status returned
+	// by OnSignal means "drop this signal" (detector observed transient state
+	// that doesn't warrant a transition).
+	//
+	// Contract (per by2z79ouc DEF-1): dispatcher invokes OnSignal as a
+	// mapping callback INSIDE applyProbeGuards, AFTER the stale-callback
+	// guard + graceWindow guard pass. OnSignal therefore never sees signals
+	// that should have been dropped by hook authority. ErrorGuard +
+	// transition gate run AFTER OnSignal returns (they need newStatus to
+	// compare against currentStatus). Provider may safely log / count in
+	// OnSignal because pre-guard-survived signals are guaranteed.
+	OnSignal func(Signal) Status
+}
+
+// ProbeIntentKind is the detector category. W6-3 finalize introduces one Kind;
+// future PRs MAY add more. Use a string type so test fixtures can declare
+// expected kinds without import cycles.
+type ProbeIntentKind string
+
+const (
+	// ProbeIntentKindProcessDead — detector polls senderPID + observes pane
+	// existence; emits one Signal with PaneAlive set when the agent process
+	// is no longer in the pane PID tree (W6-3+W6-4 combined: PaneAlive=true
+	// → caller maps to error; false → caller maps to clear).
+	ProbeIntentKindProcessDead ProbeIntentKind = "process_dead"
+)
+
+// Signal is the runtime observation emitted by a detector. W6-3 finalize
+// includes the minimum context W6-3+W6-4 both need; future Kind additions
+// MAY add fields but MUST keep existing field semantics stable.
+//
+// Field rationale (per b36pap7jc DEF-1 — preventing immediate signature churn
+// on the next W6 PR):
+//   - Kind: required for OnSignal type discrimination
+//   - PaneAlive: W6-3+W6-4 binary distinction; future ScreenChange Kinds may
+//     leave it unconditionally true (they observe pane content, not pane life)
+//   - PaneID: explicit pane id — detector resolves & captures this when the
+//     intent arms; OnSignal receives the same value (used by trace
+//     observability and for downstream future-Kind detectors that act on
+//     pane-scoped state)
+//   - SenderPID: the codex sender pid resolved from frame state; carried on
+//     Signal so OnSignal handlers can log without re-querying
+type Signal struct {
+	Kind      ProbeIntentKind
+	PaneAlive bool
+	PaneID    string
+	SenderPID int
+}

--- a/internal/agent/provider_test.go
+++ b/internal/agent/provider_test.go
@@ -1,0 +1,129 @@
+package agent_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wake/purdex/internal/agent"
+)
+
+// TestProbeIntent_StructFields verifies that the Signal struct exposes all
+// four fields W6-3+W6-4 detectors need (Kind / PaneAlive / PaneID / SenderPID)
+// with the documented types. The test uses reflect so an accidental field
+// rename / removal surfaces here instead of as a downstream compile error
+// in detector / dispatcher code.
+func TestProbeIntent_StructFields(t *testing.T) {
+	sig := agent.Signal{
+		Kind:      agent.ProbeIntentKindProcessDead,
+		PaneAlive: true,
+		PaneID:    "%5",
+		SenderPID: 12345,
+	}
+
+	cases := []struct {
+		name     string
+		wantKind reflect.Kind
+	}{
+		{"Kind", reflect.String},
+		{"PaneAlive", reflect.Bool},
+		{"PaneID", reflect.String},
+		{"SenderPID", reflect.Int},
+	}
+
+	v := reflect.ValueOf(sig)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := v.FieldByName(tc.name)
+			if !f.IsValid() {
+				t.Fatalf("Signal is missing field %q", tc.name)
+			}
+			if f.Kind() != tc.wantKind {
+				t.Fatalf("Signal.%s kind = %v, want %v", tc.name, f.Kind(), tc.wantKind)
+			}
+		})
+	}
+
+	// Verify ProbeIntent struct has the three documented fields with the
+	// expected discriminator / status-set / mapper layout.
+	intent := agent.ProbeIntent{
+		Kind:          agent.ProbeIntentKindProcessDead,
+		OnEntryStatus: []agent.Status{agent.StatusRunning, agent.StatusWaiting},
+		OnSignal:      func(agent.Signal) agent.Status { return agent.StatusError },
+	}
+	if intent.Kind != agent.ProbeIntentKindProcessDead {
+		t.Fatalf("ProbeIntent.Kind = %q, want %q", intent.Kind, agent.ProbeIntentKindProcessDead)
+	}
+	if len(intent.OnEntryStatus) != 2 {
+		t.Fatalf("ProbeIntent.OnEntryStatus len = %d, want 2", len(intent.OnEntryStatus))
+	}
+	if intent.OnSignal == nil {
+		t.Fatal("ProbeIntent.OnSignal must be assignable")
+	}
+	if got := intent.OnSignal(agent.Signal{Kind: agent.ProbeIntentKindProcessDead}); got != agent.StatusError {
+		t.Fatalf("ProbeIntent.OnSignal() = %q, want %q", got, agent.StatusError)
+	}
+}
+
+// TestProbeIntentKind_ProcessDead verifies the lone Kind constant value lands
+// at the documented "process_dead" string. Detector / dispatcher / drift test
+// rely on this exact value; the spec calls it out as a stable identifier.
+func TestProbeIntentKind_ProcessDead(t *testing.T) {
+	if got, want := string(agent.ProbeIntentKindProcessDead), "process_dead"; got != want {
+		t.Fatalf("ProbeIntentKindProcessDead = %q, want %q", got, want)
+	}
+}
+
+// TestProbeIntentProvider_OptionalNil asserts that a provider which does NOT
+// implement ProbeIntentProvider still satisfies AgentProvider. This guards
+// the optional-capability contract documented in §3.1: providers without
+// ProbeIntents stay backward compatible with pre-W6-3 behavior.
+func TestProbeIntentProvider_OptionalNil(t *testing.T) {
+	var p agent.AgentProvider = &fakeProvider{agentType: "cc"}
+
+	// fakeProvider does NOT implement ProbeIntentProvider, so the type
+	// assertion must fail.
+	if _, ok := p.(agent.ProbeIntentProvider); ok {
+		t.Fatal("fakeProvider unexpectedly satisfies ProbeIntentProvider; optional capability contract broken")
+	}
+}
+
+// TestProbeIntentProvider_PositiveImplementation verifies that a fake which
+// DOES implement ProbeIntentProvider type-asserts successfully and returns the
+// declared intents. Companion to TestProbeIntentProvider_OptionalNil.
+func TestProbeIntentProvider_PositiveImplementation(t *testing.T) {
+	intents := []agent.ProbeIntent{
+		{
+			Kind:          agent.ProbeIntentKindProcessDead,
+			OnEntryStatus: []agent.Status{agent.StatusRunning},
+			OnSignal:      func(agent.Signal) agent.Status { return agent.StatusError },
+		},
+	}
+	var p agent.AgentProvider = &fakeProbeIntentProvider{
+		fakeProvider: fakeProvider{agentType: "codex"},
+		intents:      intents,
+	}
+
+	pp, ok := p.(agent.ProbeIntentProvider)
+	if !ok {
+		t.Fatal("fakeProbeIntentProvider does not satisfy ProbeIntentProvider")
+	}
+	got := pp.ProbeIntents()
+	if len(got) != 1 {
+		t.Fatalf("ProbeIntents len = %d, want 1", len(got))
+	}
+	if got[0].Kind != agent.ProbeIntentKindProcessDead {
+		t.Fatalf("ProbeIntents[0].Kind = %q, want %q", got[0].Kind, agent.ProbeIntentKindProcessDead)
+	}
+}
+
+// fakeProbeIntentProvider embeds fakeProvider and additionally implements
+// ProbeIntentProvider, so test cases can verify the optional capability
+// type-assertion path. Defined in this file to keep the test scope local.
+type fakeProbeIntentProvider struct {
+	fakeProvider
+	intents []agent.ProbeIntent
+}
+
+func (f *fakeProbeIntentProvider) ProbeIntents() []agent.ProbeIntent {
+	return f.intents
+}

--- a/internal/module/agent/fakes_test.go
+++ b/internal/module/agent/fakes_test.go
@@ -115,3 +115,16 @@ func (f *fakeAgentProvider) RemoveHooks(string) error         { return nil }
 func (f *fakeAgentProvider) CheckHooks() (agentpkg.HookStatus, error) {
 	return agentpkg.HookStatus{}, nil
 }
+
+// fakeProbeIntentAgentProvider is fakeAgentProvider plus a configurable
+// ProbeIntents list. Used by W6-3 P1-T4 dispatcher tests to drive the
+// declared-kinds reconcile + per-intent lifecycle paths without involving
+// the codex package (whose detector lands in P2-T2).
+type fakeProbeIntentAgentProvider struct {
+	fakeAgentProvider
+	intents []agentpkg.ProbeIntent
+}
+
+func (f *fakeProbeIntentAgentProvider) ProbeIntents() []agentpkg.ProbeIntent {
+	return f.intents
+}

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -405,12 +405,20 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// 2. waiting/running/idle transitions restart the watcher for the top frame.
 	watchAgentType := req.AgentType
 	watchStatus := result.Status
+	var watchHint *probeIntentTargetHint
 	if projection != nil && projection.TopFrame != nil {
 		watchAgentType = projection.TopFrame.AgentType
 		watchStatus = projection.TopFrame.Status
+		// Fast-path target injection (codex #3): caller already has
+		// projection.TopFrame resolved; pass it through so the dispatcher
+		// skips lookupTopFrameForSessionLocked → tmux exec under m.mu.
+		watchHint = &probeIntentTargetHint{
+			paneID:    projection.TopFrame.PaneID,
+			senderPID: projection.TopFrame.PID,
+		}
 	}
 	if req.TmuxSession != "" && m.prober != nil && result.Valid {
-		m.manageActivityWatch(req.TmuxSession, watchAgentType, watchStatus)
+		m.manageActivityWatch(req.TmuxSession, watchAgentType, watchStatus, watchHint)
 	}
 
 	// Clear subagents on non-compact SessionStart

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -405,20 +405,12 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// 2. waiting/running/idle transitions restart the watcher for the top frame.
 	watchAgentType := req.AgentType
 	watchStatus := result.Status
-	var watchHint *probeIntentTargetHint
 	if projection != nil && projection.TopFrame != nil {
 		watchAgentType = projection.TopFrame.AgentType
 		watchStatus = projection.TopFrame.Status
-		// Fast-path target injection (codex #3): caller already has
-		// projection.TopFrame resolved; pass it through so the dispatcher
-		// skips lookupTopFrameForSessionLocked → tmux exec under m.mu.
-		watchHint = &probeIntentTargetHint{
-			paneID:    projection.TopFrame.PaneID,
-			senderPID: projection.TopFrame.PID,
-		}
 	}
 	if req.TmuxSession != "" && m.prober != nil && result.Valid {
-		m.manageActivityWatch(req.TmuxSession, watchAgentType, watchStatus, watchHint)
+		m.manageActivityWatch(req.TmuxSession, watchAgentType, watchStatus)
 	}
 
 	// Clear subagents on non-compact SessionStart

--- a/internal/module/agent/handler_devlog_test.go
+++ b/internal/module/agent/handler_devlog_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
@@ -17,16 +18,48 @@ import (
 	"github.com/wake/purdex/internal/tmux"
 )
 
+// devLogBuffer is a thread-safe wrapper around bytes.Buffer used to capture
+// log.Printf output across goroutines. The race detector flags concurrent
+// Write (from dispatcher goroutines) + String (from test waitFor pollers)
+// against a bare bytes.Buffer; the mutex serialises both sides. Only the
+// methods used by callers (Write / String / Bytes) are surfaced.
+type devLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *devLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *devLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *devLogBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]byte, b.buf.Len())
+	copy(out, b.buf.Bytes())
+	return out
+}
+
 // captureDevLog redirects log output to an in-memory buffer for the duration
 // of the test. The previous output is restored via t.Cleanup so subsequent
-// tests don't leak the redirected destination.
-func captureDevLog(t *testing.T) *bytes.Buffer {
+// tests don't leak the redirected destination. The buffer is mutex-guarded
+// so concurrent Write (dispatcher goroutines) + String (waitFor pollers)
+// don't trip the race detector.
+func captureDevLog(t *testing.T) *devLogBuffer {
 	t.Helper()
-	var buf bytes.Buffer
+	buf := &devLogBuffer{}
 	prev := log.Writer()
-	log.SetOutput(&buf)
+	log.SetOutput(buf)
 	t.Cleanup(func() { log.SetOutput(prev) })
-	return &buf
+	return buf
 }
 
 // devLogPostValid POSTs a valid PdxStop hook event for tmux session "dev",

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -481,6 +481,28 @@ func (m *Module) resolvePaneSession(paneID string) (string, string) {
 	return sessionName, m.resolveSessionCode(sessionName)
 }
 
+// lookupTopFrameForSessionLocked returns the top frame's pane_id + pid for
+// session. CALLER MUST hold m.mu. Returns ok=false when the session has no
+// frame projection or no top frame.
+//
+// W6-3 P1-T3: used by probeIntentDispatcher to capture the (paneID, senderPID)
+// snapshot when arming a ProbeIntent detector. The "Locked" suffix marks the
+// caller-locked contract; the implementation reuses projectionForSession,
+// whose data sources (m.frames sql store + m.tmux pane resolver) acquire
+// their own mutexes that are independent of m.mu, so calling it under m.mu
+// does not introduce a lock cycle.
+//
+// See spec §6.2 — the helper deliberately routes through the existing
+// projection pipeline so daemon-restart hydrate replay (P1-T6) and the live
+// hook path observe identical (paneID, pid) selection logic.
+func (m *Module) lookupTopFrameForSessionLocked(session string) (paneID string, pid int, ok bool) {
+	projection, err := m.projectionForSession(session)
+	if err != nil || projection == nil || projection.TopFrame == nil {
+		return "", 0, false
+	}
+	return projection.TopFrame.PaneID, projection.TopFrame.PID, true
+}
+
 // manageActivityWatch is invoked by hook handlers as a status changes; W3
 // reduces it to a default no-op (stop-only) path. When a watcher is already
 // registered for `session`, it is stopped + evicted from activeWatchers; no

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -155,6 +155,13 @@ func New(events *store.AgentEventStore) (*Module, error) {
 			defaultStartProbeIntentDetector(ctx, mod, kind, paneID, senderPID, out)
 		}
 	}
+	// supportedKinds MUST mirror the switch above. Lifecycle fails closed
+	// for any kind missing here (audit F6). Adding a new kind requires
+	// extending both the switch and this map together; the drift test
+	// `TestStartDetectorSwitchMatchesSupportedKinds` enforces parity.
+	m.probeIntentDisp.supportedKinds = map[agentpkg.ProbeIntentKind]struct{}{
+		agentpkg.ProbeIntentKindProcessDead: {},
+	}
 	return m, nil
 }
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -233,12 +233,22 @@ func (m *Module) RegisterRoutes(mux *http.ServeMux) {
 }
 
 // Start replays DB state and registers OnSubscribe callback.
+//
+// W6-3 P1-T6 (closes #698): after replayFromDB hydrates currentStatus +
+// frame projection and startSweep is running, replayStatus walks every
+// session and re-evaluates ProbeIntent gating so detectors armed before
+// shutdown rearm after restart. Sequence MUST be replayFromDB → startSweep
+// → replayStatus so detectors see fully-hydrated state on first poll
+// (per spec §6.3 / §6.4).
 func (m *Module) Start(_ context.Context) error {
 	if err := m.sweepOnce(); err != nil {
 		log.Printf("[agent] startup sweep: %v", err)
 	}
 	m.replayFromDB()
 	m.startSweep()
+	if m.probeIntentDisp != nil {
+		m.probeIntentDisp.replayStatus()
+	}
 
 	if m.core != nil {
 		m.core.Events.OnSubscribe(func(sub *core.EventSubscriber) {
@@ -595,6 +605,38 @@ func (m *Module) resolvePaneSession(paneID string) (string, string) {
 func (m *Module) nextProbeIntentGeneration() uint64 {
 	m.probeIntentGen++
 	return m.probeIntentGen
+}
+
+// sessionStatusSnapshot pairs a session's top-frame agentType with its
+// current status. Used by probeIntentDispatcher.replayStatus to drive
+// applyStatus per-session after a daemon-restart hydrate.
+type sessionStatusSnapshot struct {
+	agentType string
+	status    agentpkg.Status
+}
+
+// snapshotStatuses returns a session → (agentType, status) snapshot taken
+// under m.mu. Used by probeIntentDispatcher.replayStatus (W6-3 P1-T6 /
+// issue #698) so a daemon restart re-arms ProbeIntent detectors based on
+// post-replay state.
+//
+// agentType is sourced from the top-frame projection (NOT from the legacy
+// agent_events row) so the value matches what live hook handlers would
+// produce. Sessions without a resolvable top frame still appear in the
+// snapshot with agentType="" — applyIntentLifecycle handles that path
+// (frame lookup fails inside m.mu → skip arm).
+func (m *Module) snapshotStatuses() map[string]sessionStatusSnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]sessionStatusSnapshot, len(m.currentStatus))
+	for session, status := range m.currentStatus {
+		entry := sessionStatusSnapshot{status: status}
+		if proj, err := m.projectionForSession(session); err == nil && proj != nil && proj.TopFrame != nil {
+			entry.agentType = proj.TopFrame.AgentType
+		}
+		out[session] = entry
+	}
+	return out
 }
 
 // lookupTopFrameForSessionLocked returns the top frame's pane_id + pid for

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -44,6 +44,13 @@ type Module struct {
 	subagents      map[string][]agentpkg.SubagentRef
 	activeWatchers map[string]string // tmuxSession → agentType
 
+	// W6-3 P1-T4: ProbeIntent dispatcher state. activeProbeIntents and
+	// probeIntentGen are protected by m.mu (same mutex as activeWatchers).
+	// probeIntentDisp is the long-lived dispatcher pointer; created in New().
+	activeProbeIntents map[string]map[agentpkg.ProbeIntentKind]activeIntent
+	probeIntentGen     uint64
+	probeIntentDisp    *probeIntentDispatcher
+
 	// statusSnapshots caches the latest statusline payload per sessionCode.
 	// Display-only, not persisted; guarded by snapshotMu (separate from mu
 	// because hot-path agent.status POSTs shouldn't contend with hook writes).
@@ -104,17 +111,18 @@ func New(events *store.AgentEventStore) (*Module, error) {
 		}
 	}
 	m := &Module{
-		events:          events,
-		frames:          frames,
-		traces:          traces,
-		registry:        agentpkg.NewRegistry(),
-		currentStatus:   make(map[string]agentpkg.Status),
-		subagents:       make(map[string][]agentpkg.SubagentRef),
-		activeWatchers:  make(map[string]string),
-		statusSnapshots: make(map[string]statusSnapshot),
-		testObservers:   make(map[string]*testObserver),
-		pathHintDedup:   NewPathHintDedupCache(5 * time.Second),
-		pathHintBuffer:  NewPathHintRingBuffer(200),
+		events:             events,
+		frames:             frames,
+		traces:             traces,
+		registry:           agentpkg.NewRegistry(),
+		currentStatus:      make(map[string]agentpkg.Status),
+		subagents:          make(map[string][]agentpkg.SubagentRef),
+		activeWatchers:     make(map[string]string),
+		activeProbeIntents: make(map[string]map[agentpkg.ProbeIntentKind]activeIntent),
+		statusSnapshots:    make(map[string]statusSnapshot),
+		testObservers:      make(map[string]*testObserver),
+		pathHintDedup:      NewPathHintDedupCache(5 * time.Second),
+		pathHintBuffer:     NewPathHintRingBuffer(200),
 	}
 	if traces != nil {
 		m.traceSink = newHookTraceSink(traces)
@@ -124,6 +132,11 @@ func New(events *store.AgentEventStore) (*Module, error) {
 	// m.prober directly. The orchestrator resolves m.prober lazily, so
 	// "AFTER prober is set" semantics hold at startWatch call time.
 	m.probeOrch = newProbeOrchestrator(m)
+	// W6-3 P1-T4: ProbeIntent dispatcher. Created here (not in Init) so the
+	// pointer is non-nil throughout module lifetime; tests that bypass Init
+	// can call manageActivityWatch / replay paths without nil-checking.
+	// parentCtx defaults to context.Background; rotated in Stop().
+	m.probeIntentDisp = newProbeIntentDispatcher(m)
 	return m, nil
 }
 
@@ -254,6 +267,13 @@ func (m *Module) Stop(_ context.Context) error {
 	}
 	if m.prober != nil {
 		m.prober.StopAllWatches()
+	}
+	// W6-3 P1-T4: cancel every armed ProbeIntent detector before clearing
+	// activeWatchers. stopAll uses the same m.mu, so a concurrent applyStatus
+	// either observes the pre-Stop active map or runs to completion — never
+	// partial.
+	if m.probeIntentDisp != nil {
+		m.probeIntentDisp.stopAll()
 	}
 	m.mu.Lock()
 	m.activeWatchers = make(map[string]string)
@@ -479,6 +499,18 @@ func (m *Module) resolvePaneSession(paneID string) (string, string) {
 		return "", ""
 	}
 	return sessionName, m.resolveSessionCode(sessionName)
+}
+
+// nextProbeIntentGeneration returns a fresh monotonically increasing
+// generation token for ProbeIntent detectors. CALLER MUST hold m.mu (the
+// counter is m.mu-protected; call sites are inside applyIntentLifecycle
+// which already holds the lock).
+//
+// Per spec §5.4 — uint64 overflow needs ~5×10¹⁹ increments and is therefore
+// not a practical concern for daemon lifetime; no reuse risk.
+func (m *Module) nextProbeIntentGeneration() uint64 {
+	m.probeIntentGen++
+	return m.probeIntentGen
 }
 
 // lookupTopFrameForSessionLocked returns the top frame's pane_id + pid for

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -137,6 +137,24 @@ func New(events *store.AgentEventStore) (*Module, error) {
 	// can call manageActivityWatch / replay paths without nil-checking.
 	// parentCtx defaults to context.Background; rotated in Stop().
 	m.probeIntentDisp = newProbeIntentDispatcher(m)
+	// W6-3 P2-T4: route declared ProbeIntent kinds to their per-agent detectors.
+	// The closure resolves m.tmux lazily so it picks up Init()'s wiring (m.tmux
+	// is nil at New() time and assigned during Init); callers (lifecycle plan)
+	// only invoke startDetector after applyIntentLifecycle has read top-frame
+	// state, by which point Init has long completed in production.
+	//
+	// Per spec §5.4 lines 776-780: dispatcher switches on Kind; future Kinds
+	// add cases here. Unknown Kind falls through to defaultStartProbeIntentDetector
+	// (waits on ctx, never emits) — defensive landing for a Kind that surfaces
+	// in registry before its detector lands.
+	m.probeIntentDisp.startDetector = func(ctx context.Context, mod *Module, kind agentpkg.ProbeIntentKind, paneID string, senderPID int, out chan<- agentpkg.Signal) {
+		switch kind {
+		case agentpkg.ProbeIntentKindProcessDead:
+			codex.StartProcessDeadDetector(ctx, mod.tmux, paneID, senderPID, out)
+		default:
+			defaultStartProbeIntentDetector(ctx, mod, kind, paneID, senderPID, out)
+		}
+	}
 	return m, nil
 }
 

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -285,8 +285,17 @@ func (m *Module) Stop(_ context.Context) error {
 }
 
 // renameSessionLocked transfers in-memory agent state (subagents, currentStatus,
-// activeWatchers) from oldName to newName.  CALLER MUST hold m.mu.
-func (m *Module) renameSessionLocked(oldName, newName string) {
+// activeWatchers, activeProbeIntents) from oldName to newName.  CALLER MUST
+// hold m.mu.
+//
+// Returns a slice of CancelFuncs that the caller MUST invoke AFTER releasing
+// m.mu. This routes the W6-3 P1-T5 ProbeIntent cleanup through the same
+// post-unlock pattern as dispatchProbeIntentReeval: detector goroutines that
+// were keyed under oldName get cancelled outside the lock so any concurrent
+// applyProbeGuards re-acquisition does not deadlock. Caller may pass the
+// returned slice to dispatchProbeIntentRenameCancels (or invoke each cancel
+// directly).
+func (m *Module) renameSessionLocked(oldName, newName string) []context.CancelFunc {
 	if subs, ok := m.subagents[oldName]; ok {
 		m.subagents[newName] = subs
 		delete(m.subagents, oldName)
@@ -314,16 +323,41 @@ func (m *Module) renameSessionLocked(oldName, newName string) {
 		// within probeGraceWindow once W6 wires starts again.
 		m.probeOrch.migrateLastHookAt(oldName, newName)
 	}
+
+	// W6-3 P1-T5: drop ProbeIntent active entries keyed under oldName. The
+	// dispatcher cannot rearm under newName until our caller invokes
+	// dispatcher.applyStatus(newName, ...) post-unlock, so collecting +
+	// returning the cancel list (rather than invoking inside the lock) keeps
+	// the cancel + arm sequence contiguous from the dispatcher's POV.
+	var toCancel []context.CancelFunc
+	if perSession, ok := m.activeProbeIntents[oldName]; ok {
+		for _, cur := range perSession {
+			toCancel = append(toCancel, cur.cancel)
+		}
+		delete(m.activeProbeIntents, oldName)
+	}
+	return toCancel
 }
 
 // RenameSession transfers in-memory agent state from oldName to newName
 // under the module's lock.  Used by callers that don't need to coordinate
 // with other rename steps (e.g. tests).  Production callers should prefer
 // RenameSessionAtomic to make the rename atomic with tmux + DB updates.
+//
+// W6-3 P1-T5: after the in-memory rename completes, the ProbeIntent
+// dispatcher is re-evaluated for newName so any active codex / future
+// per-agent probes stay armed against the renamed session. The lock is
+// released before invoking dispatcher.applyStatus because the dispatcher
+// itself acquires m.mu (deadlock otherwise).
 func (m *Module) RenameSession(oldName, newName string) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.renameSessionLocked(oldName, newName)
+	cancels := m.renameSessionLocked(oldName, newName)
+	plan, hasPlan := m.captureProbeIntentReevalLocked(newName)
+	m.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+	m.dispatchProbeIntentReeval(newName, plan, hasPlan)
 }
 
 // RenameSessionAtomic runs doRename under the module's lock and then
@@ -343,12 +377,62 @@ func (m *Module) RenameSession(oldName, newName string) {
 // call any method that acquires m.mu (would deadlock).
 func (m *Module) RenameSessionAtomic(oldName, newName string, doRename func() error) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if err := doRename(); err != nil {
+		m.mu.Unlock()
 		return err
 	}
-	m.renameSessionLocked(oldName, newName)
+	cancels := m.renameSessionLocked(oldName, newName)
+	plan, hasPlan := m.captureProbeIntentReevalLocked(newName)
+	m.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+	m.dispatchProbeIntentReeval(newName, plan, hasPlan)
 	return nil
+}
+
+// probeIntentReevalPlan records the (agentType, status) pair captured during
+// rename so the post-unlock dispatcher.applyStatus call observes the same
+// state the rename observed under m.mu. Routed through a struct (rather
+// than two return values) so future fields (e.g. paneID overrides) extend
+// without touching every call site.
+type probeIntentReevalPlan struct {
+	agentType string
+	status    agentpkg.Status
+}
+
+// captureProbeIntentReevalLocked snapshots the post-rename ProbeIntent
+// re-evaluation inputs: the new session's currentStatus + the top frame's
+// agentType. Returns hasPlan=false when no currentStatus exists yet (rename
+// of a session before any hook fired).
+//
+// CALLER MUST hold m.mu. lookupTopFrameForSessionLocked + projectionForSession
+// touch their own mutexes (frames store, tmux pane resolver) that are
+// independent of m.mu, so calling them under m.mu is safe.
+func (m *Module) captureProbeIntentReevalLocked(session string) (probeIntentReevalPlan, bool) {
+	status, ok := m.currentStatus[session]
+	if !ok {
+		return probeIntentReevalPlan{}, false
+	}
+	agentType := ""
+	if proj, err := m.projectionForSession(session); err == nil && proj != nil && proj.TopFrame != nil {
+		agentType = proj.TopFrame.AgentType
+	}
+	return probeIntentReevalPlan{agentType: agentType, status: status}, true
+}
+
+// dispatchProbeIntentReeval invokes dispatcher.applyStatus outside m.mu so
+// the dispatcher can take its own lock. No-op when hasPlan=false (no
+// currentStatus to evaluate against) or when dispatcher is nil (defensive;
+// New() always wires it).
+func (m *Module) dispatchProbeIntentReeval(session string, plan probeIntentReevalPlan, hasPlan bool) {
+	if !hasPlan {
+		return
+	}
+	if m.probeIntentDisp == nil {
+		return
+	}
+	m.probeIntentDisp.applyStatus(session, plan.agentType, plan.status)
 }
 
 // replayFromDB rebuilds in-memory state from persisted frame projections and
@@ -535,30 +619,40 @@ func (m *Module) lookupTopFrameForSessionLocked(session string) (paneID string, 
 	return projection.TopFrame.PaneID, projection.TopFrame.PID, true
 }
 
-// manageActivityWatch is invoked by hook handlers as a status changes; W3
-// reduces it to a default no-op (stop-only) path. When a watcher is already
-// registered for `session`, it is stopped + evicted from activeWatchers; no
-// new watcher is ever started here.
+// manageActivityWatch is invoked by hook handlers as a status changes. The
+// W3 撤回 stop-only path (no new ScreenChange watcher is ever started here)
+// is preserved; W6-3 P1-T5 dispatches the ProbeIntent lifecycle to
+// probeIntentDisp.applyStatus afterwards so per-agent probe gating runs on
+// every status change.
 //
 // W3 撤回 rationale: Phase 4a-1 wired this function as the always-on probe
 // start site, which violated the "probe is recovery-only" v2.0 contract by
 // covering every Waiting/Running/Idle transition with a screen watcher. W6
-// will reintroduce starts via an explicit ProbeIntent caller that calls
-// `m.probeOrch.startWatch(session, agentType, opts)` directly with chosen
-// WatchOptions. The newStatus parameter is intentionally retained (reserved
-// for that future caller) but currently unused.
+// reintroduces starts via the ProbeIntent dispatcher (per-agent declared
+// intents + lifecycle gating), NOT via probeOrch.startWatch.
 //
 // R3 fix: m.activeWatchers is owned by this function (and renameSessionLocked);
 // the orchestrator deliberately does not touch it.
+//
+// Locking contract: m.mu is acquired and released INSIDE this function for
+// the activeWatchers eviction step; the dispatcher.applyStatus call MUST
+// happen AFTER m.mu is released because the dispatcher takes m.mu itself
+// (see probe_intent_dispatcher.go reconcileSessionActive +
+// applyIntentLifecycle critical sections).
 func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status) {
-	_ = newStatus // reserved for W6 ProbeIntent wiring
-	_ = agentType // reserved for W6 ProbeIntent wiring (e.g. profile lookup)
-
 	m.mu.Lock()
 	_, wasWatching := m.activeWatchers[session]
 	delete(m.activeWatchers, session)
 	m.mu.Unlock()
 	if wasWatching {
 		m.probeOrch.stopWatch(session)
+	}
+
+	// W6-3 P1-T5: dispatch ProbeIntent lifecycle. dispatcher.applyStatus is
+	// safe to call without m.mu held; it routes through reconcileSessionActive
+	// + applyIntentLifecycle which take m.mu themselves for active-set
+	// mutation, then start / cancel detector goroutines outside the lock.
+	if m.probeIntentDisp != nil {
+		m.probeIntentDisp.applyStatus(session, agentType, newStatus)
 	}
 }

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -460,10 +460,7 @@ func (m *Module) dispatchProbeIntentReeval(session string, plan probeIntentReeva
 	if m.probeIntentDisp == nil {
 		return
 	}
-	// Rename re-eval is low-frequency (user-triggered): pass nil hint and
-	// let the dispatcher's slow lookup run. Avoids smuggling rename-time
-	// frame state through the dispatcher path.
-	m.probeIntentDisp.applyStatus(session, plan.agentType, plan.status, nil)
+	m.probeIntentDisp.applyStatus(session, plan.agentType, plan.status)
 }
 
 // replayFromDB rebuilds in-memory state from persisted frame projections and
@@ -702,12 +699,7 @@ func (m *Module) lookupTopFrameForSessionLocked(session string) (paneID string, 
 // happen AFTER m.mu is released because the dispatcher takes m.mu itself
 // (see probe_intent_dispatcher.go reconcileSessionActive +
 // applyIntentLifecycle critical sections).
-//
-// hint: optional fast-path target injection. Hot-path callers (live hook
-// handlers) supply the projection.TopFrame they already resolved, letting
-// the dispatcher skip lookupTopFrameForSessionLocked under m.mu (codex
-// hook-pipeline-lag analysis #3 lock convoy).
-func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status, hint *probeIntentTargetHint) {
+func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status) {
 	m.mu.Lock()
 	_, wasWatching := m.activeWatchers[session]
 	delete(m.activeWatchers, session)
@@ -721,6 +713,6 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
 	// + applyIntentLifecycle which take m.mu themselves for active-set
 	// mutation, then start / cancel detector goroutines outside the lock.
 	if m.probeIntentDisp != nil {
-		m.probeIntentDisp.applyStatus(session, agentType, newStatus, hint)
+		m.probeIntentDisp.applyStatus(session, agentType, newStatus)
 	}
 }

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -460,7 +460,10 @@ func (m *Module) dispatchProbeIntentReeval(session string, plan probeIntentReeva
 	if m.probeIntentDisp == nil {
 		return
 	}
-	m.probeIntentDisp.applyStatus(session, plan.agentType, plan.status)
+	// Rename re-eval is low-frequency (user-triggered): pass nil hint and
+	// let the dispatcher's slow lookup run. Avoids smuggling rename-time
+	// frame state through the dispatcher path.
+	m.probeIntentDisp.applyStatus(session, plan.agentType, plan.status, nil)
 }
 
 // replayFromDB rebuilds in-memory state from persisted frame projections and
@@ -699,7 +702,12 @@ func (m *Module) lookupTopFrameForSessionLocked(session string) (paneID string, 
 // happen AFTER m.mu is released because the dispatcher takes m.mu itself
 // (see probe_intent_dispatcher.go reconcileSessionActive +
 // applyIntentLifecycle critical sections).
-func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status) {
+//
+// hint: optional fast-path target injection. Hot-path callers (live hook
+// handlers) supply the projection.TopFrame they already resolved, letting
+// the dispatcher skip lookupTopFrameForSessionLocked under m.mu (codex
+// hook-pipeline-lag analysis #3 lock convoy).
+func (m *Module) manageActivityWatch(session, agentType string, newStatus agentpkg.Status, hint *probeIntentTargetHint) {
 	m.mu.Lock()
 	_, wasWatching := m.activeWatchers[session]
 	delete(m.activeWatchers, session)
@@ -713,6 +721,6 @@ func (m *Module) manageActivityWatch(session, agentType string, newStatus agentp
 	// + applyIntentLifecycle which take m.mu themselves for active-set
 	// mutation, then start / cancel detector goroutines outside the lock.
 	if m.probeIntentDisp != nil {
-		m.probeIntentDisp.applyStatus(session, agentType, newStatus)
+		m.probeIntentDisp.applyStatus(session, agentType, newStatus, hint)
 	}
 }

--- a/internal/module/agent/module_test.go
+++ b/internal/module/agent/module_test.go
@@ -107,7 +107,7 @@ func TestManageActivityWatch_DefaultNoOp(t *testing.T) {
 		agentpkg.StatusClear,
 	}
 	for _, s := range statuses {
-		m.manageActivityWatch("sess", "cc", s)
+		m.manageActivityWatch("sess", "cc", s, nil)
 	}
 
 	rec.mu.Lock()
@@ -133,7 +133,7 @@ func TestManageActivityWatch_StopsExistingWatcher(t *testing.T) {
 	m.activeWatchers["sess"] = "cc"
 	m.mu.Unlock()
 
-	m.manageActivityWatch("sess", "cc", agentpkg.StatusIdle)
+	m.manageActivityWatch("sess", "cc", agentpkg.StatusIdle, nil)
 
 	m.mu.Lock()
 	_, present := m.activeWatchers["sess"]
@@ -323,7 +323,7 @@ func TestManageActivityWatch_StatusToRunning_ProbeIntentArmed(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning, nil)
 
 	<-rec.started
 	if rec.startCount() != 1 {
@@ -349,14 +349,14 @@ func TestManageActivityWatch_StatusToIdle_ProbeIntentTornDown(t *testing.T) {
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	// Arm.
-	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 
 	// Flip live status to idle, then call manageActivityWatch with idle.
 	m.mu.Lock()
 	m.currentStatus["work"] = agentpkg.StatusIdle
 	m.mu.Unlock()
-	m.manageActivityWatch("work", "codex", agentpkg.StatusIdle)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusIdle, nil)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("activeProbeIntents present after manageActivityWatch(idle), want absent")
@@ -380,7 +380,7 @@ func TestRenameSession_OldNameProbeIntentMigratesToNew(t *testing.T) {
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	// Arm under oldName.
-	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); !ok {
 		t.Fatalf("active entry missing under oldName before rename")
@@ -419,7 +419,7 @@ func TestModuleStop_ProbeIntentDispatcherStoppedAll(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 
 	if err := m.Stop(context.Background()); err != nil {

--- a/internal/module/agent/module_test.go
+++ b/internal/module/agent/module_test.go
@@ -107,7 +107,7 @@ func TestManageActivityWatch_DefaultNoOp(t *testing.T) {
 		agentpkg.StatusClear,
 	}
 	for _, s := range statuses {
-		m.manageActivityWatch("sess", "cc", s, nil)
+		m.manageActivityWatch("sess", "cc", s)
 	}
 
 	rec.mu.Lock()
@@ -133,7 +133,7 @@ func TestManageActivityWatch_StopsExistingWatcher(t *testing.T) {
 	m.activeWatchers["sess"] = "cc"
 	m.mu.Unlock()
 
-	m.manageActivityWatch("sess", "cc", agentpkg.StatusIdle, nil)
+	m.manageActivityWatch("sess", "cc", agentpkg.StatusIdle)
 
 	m.mu.Lock()
 	_, present := m.activeWatchers["sess"]
@@ -323,7 +323,7 @@ func TestManageActivityWatch_StatusToRunning_ProbeIntentArmed(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning, nil)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
 
 	<-rec.started
 	if rec.startCount() != 1 {
@@ -349,14 +349,14 @@ func TestManageActivityWatch_StatusToIdle_ProbeIntentTornDown(t *testing.T) {
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	// Arm.
-	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning, nil)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 
 	// Flip live status to idle, then call manageActivityWatch with idle.
 	m.mu.Lock()
 	m.currentStatus["work"] = agentpkg.StatusIdle
 	m.mu.Unlock()
-	m.manageActivityWatch("work", "codex", agentpkg.StatusIdle, nil)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusIdle)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("activeProbeIntents present after manageActivityWatch(idle), want absent")
@@ -380,7 +380,7 @@ func TestRenameSession_OldNameProbeIntentMigratesToNew(t *testing.T) {
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	// Arm under oldName.
-	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning, nil)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); !ok {
 		t.Fatalf("active entry missing under oldName before rename")
@@ -419,7 +419,7 @@ func TestModuleStop_ProbeIntentDispatcherStoppedAll(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning, nil)
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 
 	if err := m.Stop(context.Background()); err != nil {

--- a/internal/module/agent/module_test.go
+++ b/internal/module/agent/module_test.go
@@ -7,6 +7,7 @@ import (
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/store"
+	"github.com/wake/purdex/internal/tmux"
 )
 
 // TestNew_FailsOnMalformedFramesStore exercises the daemon startup path.
@@ -202,4 +203,88 @@ func TestRenameSessionLocked_StopOnly(t *testing.T) {
 		t.Fatalf("lastHookAt[newname] missing after rename — graceWindow lost")
 	}
 	m.probeOrch.graceMu.Unlock()
+}
+
+// P1-T3: lookupTopFrameForSessionLocked tests
+// -------------------------------------------
+// helper returns the top-frame's pane_id + pid for a session under m.mu.
+// Used by the W6-3 ProbeIntent dispatcher to capture the (paneID, senderPID)
+// snapshot when arming a detector. Tests run with m.mu held to mirror the
+// production caller contract.
+
+// TestLookupTopFrameForSessionLocked_HappyPath seeds one frame for a session
+// and asserts the helper returns its pane_id + pid.
+func TestLookupTopFrameForSessionLocked_HappyPath(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+
+	if _, err := m.frames.Upsert(store.Frame{
+		FrameID:          "frame-1",
+		PaneID:           "%5",
+		AgentType:        "codex",
+		PID:              4242,
+		PPID:             1,
+		ProcessStartTime: "Sun Apr 20 01:30:00 2026",
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        100,
+		LastSeenAt:       120,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	m.mu.Lock()
+	paneID, pid, ok := m.lookupTopFrameForSessionLocked("work")
+	m.mu.Unlock()
+
+	if !ok {
+		t.Fatalf("lookupTopFrameForSessionLocked: ok=false, want true")
+	}
+	if paneID != "%5" {
+		t.Fatalf("paneID = %q, want %%5", paneID)
+	}
+	if pid != 4242 {
+		t.Fatalf("pid = %d, want 4242", pid)
+	}
+}
+
+// TestLookupTopFrameForSessionLocked_NoSession_NotOk asserts an unknown
+// session returns ok=false (no panic, no stale read).
+func TestLookupTopFrameForSessionLocked_NoSession_NotOk(t *testing.T) {
+	m := newTestModule(t)
+	m.tmux = tmux.NewFakeExecutor()
+
+	m.mu.Lock()
+	paneID, pid, ok := m.lookupTopFrameForSessionLocked("ghost")
+	m.mu.Unlock()
+
+	if ok {
+		t.Fatalf("ok=true for unknown session, want false")
+	}
+	if paneID != "" || pid != 0 {
+		t.Fatalf("paneID=%q pid=%d, want empty/0 for missing session", paneID, pid)
+	}
+}
+
+// TestLookupTopFrameForSessionLocked_NoTopFrame_NotOk seeds tmux pane
+// resolution but no frames row — projection.TopFrame is nil, helper returns
+// ok=false.
+func TestLookupTopFrameForSessionLocked_NoTopFrame_NotOk(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+
+	m.mu.Lock()
+	paneID, pid, ok := m.lookupTopFrameForSessionLocked("work")
+	m.mu.Unlock()
+
+	if ok {
+		t.Fatalf("ok=true with no frames seeded, want false")
+	}
+	if paneID != "" || pid != 0 {
+		t.Fatalf("paneID=%q pid=%d, want empty/0 for missing top frame", paneID, pid)
+	}
 }

--- a/internal/module/agent/module_test.go
+++ b/internal/module/agent/module_test.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/store"
@@ -287,4 +289,148 @@ func TestLookupTopFrameForSessionLocked_NoTopFrame_NotOk(t *testing.T) {
 	if paneID != "" || pid != 0 {
 		t.Fatalf("paneID=%q pid=%d, want empty/0 for missing top frame", paneID, pid)
 	}
+}
+
+// -----------------------------------------------------------------------------
+// W6-3 P1-T5: manageActivityWatch / rename / Stop ProbeIntent wiring
+// -----------------------------------------------------------------------------
+
+// newWiringTestModule builds a module like newDispatcherTestModule but with
+// the recording detector pre-installed. Callers seed frames + currentStatus
+// and then drive manageActivityWatch / RenameSession / Stop.
+func newWiringTestModule(t *testing.T) (*Module, *recordingDetector) {
+	t.Helper()
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	m.tmux = fakeTmux
+	m.registry.Register(&fakeProbeIntentAgentProvider{
+		fakeAgentProvider: fakeAgentProvider{typeName: "codex"},
+		intents:           []agentpkg.ProbeIntent{processDeadIntent()},
+	})
+	rec := installRecordingDetector(t, m)
+	return m, rec
+}
+
+// TestManageActivityWatch_StatusToRunning_ProbeIntentArmed pins the P1-T5
+// wiring contract: when manageActivityWatch is invoked with a Running status
+// for a session whose top frame matches a registered ProbeIntent provider
+// (codex + ProcessDead), the dispatcher arms a detector and records an
+// active entry.
+func TestManageActivityWatch_StatusToRunning_ProbeIntentArmed(t *testing.T) {
+	m, rec := newWiringTestModule(t)
+	if fake, ok := m.tmux.(*tmux.FakeExecutor); ok {
+		fake.SetPaneSessionName("%5", "work")
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
+
+	<-rec.started
+	if rec.startCount() != 1 {
+		t.Fatalf("detector started count = %d, want 1", rec.startCount())
+	}
+	cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if !ok {
+		t.Fatalf("activeProbeIntents missing after manageActivityWatch(running)")
+	}
+	if cur.agentType != "codex" || cur.paneID != "%5" || cur.senderPID != 4242 {
+		t.Fatalf("active entry = %+v, want codex/%%5/4242", cur)
+	}
+}
+
+// TestManageActivityWatch_StatusToIdle_ProbeIntentTornDown pins the teardown
+// wiring: a session that was armed via Running transitions to Idle, and
+// manageActivityWatch dispatches lifecycle case 3 to delete the entry.
+func TestManageActivityWatch_StatusToIdle_ProbeIntentTornDown(t *testing.T) {
+	m, rec := newWiringTestModule(t)
+	if fake, ok := m.tmux.(*tmux.FakeExecutor); ok {
+		fake.SetPaneSessionName("%5", "work")
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	// Arm.
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+
+	// Flip live status to idle, then call manageActivityWatch with idle.
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+	m.manageActivityWatch("work", "codex", agentpkg.StatusIdle)
+
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("activeProbeIntents present after manageActivityWatch(idle), want absent")
+	}
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() == 1 }, "detector cancel after teardown")
+}
+
+// TestRenameSession_OldNameProbeIntentMigratesToNew pins the rename wiring:
+// when a session is renamed while a ProbeIntent is armed under oldName, the
+// rename path tears down the oldName entry and the dispatcher rearms under
+// newName via the post-unlock applyStatus call.
+//
+// Per spec §5.3: dispatcher.applyStatus must NOT be invoked while m.mu is
+// held; rename caller releases the lock before invoking it. The lifecycle
+// helper re-reads currentStatus + top frame inside m.mu independently.
+func TestRenameSession_OldNameProbeIntentMigratesToNew(t *testing.T) {
+	m, rec := newWiringTestModule(t)
+	if fake, ok := m.tmux.(*tmux.FakeExecutor); ok {
+		fake.SetPaneSessionName("%5", "work")
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	// Arm under oldName.
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); !ok {
+		t.Fatalf("active entry missing under oldName before rename")
+	}
+
+	// Re-point the fake tmux pane to the new session name + insert a frame
+	// row keyed under the new session so projection rebuild observes the
+	// renamed pane.
+	if fake, ok := m.tmux.(*tmux.FakeExecutor); ok {
+		fake.SetPaneSessionName("%5", "renamed")
+	}
+
+	m.RenameSession("work", "renamed")
+
+	// Old entry must be gone (either explicitly dropped by rename re-eval or
+	// rearmed under newName which removes the oldName key).
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("active entry still present under oldName after rename")
+	}
+
+	// New entry must exist under newName, armed against the same target.
+	waitFor(t, time.Second, func() bool {
+		cur, ok := readActiveIntent(m, "renamed", agentpkg.ProbeIntentKindProcessDead)
+		return ok && cur.agentType == "codex" && cur.senderPID == 4242
+	}, "active entry rearmed under newName")
+}
+
+// TestModuleStop_ProbeIntentDispatcherStoppedAll pins Module.Stop wiring:
+// every armed ProbeIntent detector is cancelled and activeProbeIntents is
+// cleared before Stop returns. Same contract as TestStopAll_* but exercised
+// through the public Module.Stop entry point.
+func TestModuleStop_ProbeIntentDispatcherStoppedAll(t *testing.T) {
+	m, rec := newWiringTestModule(t)
+	if fake, ok := m.tmux.(*tmux.FakeExecutor); ok {
+		fake.SetPaneSessionName("%5", "work")
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.manageActivityWatch("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+
+	if err := m.Stop(context.Background()); err != nil {
+		t.Fatalf("Module.Stop: %v", err)
+	}
+
+	m.mu.Lock()
+	if len(m.activeProbeIntents) != 0 {
+		m.mu.Unlock()
+		t.Fatalf("activeProbeIntents non-empty after Module.Stop: %d entries", len(m.activeProbeIntents))
+	}
+	m.mu.Unlock()
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() == 1 }, "detector cancel after Module.Stop")
 }

--- a/internal/module/agent/probe_intent_dispatcher.go
+++ b/internal/module/agent/probe_intent_dispatcher.go
@@ -144,33 +144,19 @@ func (d *probeIntentDispatcher) setParentCtx(ctx context.Context) {
 	d.parentCtx = ctx
 }
 
-// probeIntentTargetHint is an optional fast-path target supplied by hot-path
-// callers (live hook handlers) that already have projection.TopFrame in
-// scope. When non-nil, applyIntentLifecycle skips
-// lookupTopFrameForSessionLocked → projectionForSession → tmux exec — the
-// codex Daemon Hook Pipeline Lag analysis (#3) measured the lookup as the
-// primary contributor to D-segment lock convoy in the W6-3 dispatcher
-// path. Replay (daemon restart) and consumeSignals teardown have no caller
-// context and pass nil → slow lookup retained as the source of truth.
-type probeIntentTargetHint struct {
-	paneID    string
-	senderPID int
-}
-
 // applyStatus is the single entry point for ProbeIntent lifecycle
 // transitions. Called from:
 //
 //   - manageActivityWatch (P1-T5): live hook path, when a hook flips
-//     currentStatus. Caller supplies hint from projection.TopFrame.
-//   - replayStatus (P1-T6): daemon-restart hydrate. hint=nil.
+//     currentStatus.
+//   - replayStatus (P1-T6): daemon-restart hydrate.
 //   - consumeSignals teardown (round 5 P1): probe-applied transitions
 //     re-run lifecycle so the active entry teardown path stays unified.
-//     hint=nil (teardown drops the active entry without arming).
 //
 // Per spec §5.4: reconcile session-wide active-set against the new
 // (agentType, declaredKinds) tuple BEFORE running the per-intent
 // lifecycle so cross-provider switches don't leave stranded entries.
-func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus agentpkg.Status, hint *probeIntentTargetHint) {
+func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus agentpkg.Status) {
 	provider, ok := d.parent.registry.Get(agentType)
 	if !ok {
 		// Unknown agent → reconcile clears every active entry for the
@@ -190,7 +176,7 @@ func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus
 	d.reconcileSessionActive(session, agentType, declaredKinds)
 
 	for _, intent := range intents {
-		d.applyIntentLifecycle(session, agentType, newStatus, intent, hint)
+		d.applyIntentLifecycle(session, agentType, newStatus, intent)
 	}
 }
 
@@ -266,17 +252,10 @@ func (d *probeIntentDispatcher) reconcileSessionActive(
 //
 // Per spec §5.4: lifecycle decision runs entirely inside one m.mu
 // critical section; cancel + start work runs after Unlock.
-//
-// hint: optional fast-path target. When non-nil with paneID + senderPID
-// both populated, the lookup-under-lock step is skipped (avoiding the
-// D-segment lock convoy described in the codex hook-pipeline-lag analysis
-// #3). When nil — replay path / consumeSignals teardown — lookup runs as
-// before.
 func (d *probeIntentDispatcher) applyIntentLifecycle(
 	session, agentType string,
 	newStatus agentpkg.Status,
 	intent agentpkg.ProbeIntent,
-	hint *probeIntentTargetHint,
 ) {
 	shouldActive := slices.Contains(intent.OnEntryStatus, newStatus)
 
@@ -311,20 +290,7 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 			}
 			break
 		}
-		var paneID string
-		var senderPID int
-		var hasFrame bool
-		if hint != nil && hint.paneID != "" && hint.senderPID != 0 {
-			// Fast path: caller has projection.TopFrame in scope; trust it
-			// rather than re-computing under m.mu (which routes through
-			// projectionForSession → tmux exec). currentStatus re-validation
-			// above + StaleCheck below still cover concurrency races.
-			paneID = hint.paneID
-			senderPID = hint.senderPID
-			hasFrame = true
-		} else {
-			paneID, senderPID, hasFrame = d.parent.lookupTopFrameForSessionLocked(session)
-		}
+		paneID, senderPID, hasFrame := d.parent.lookupTopFrameForSessionLocked(session)
 		if !hasFrame || paneID == "" || senderPID == 0 {
 			if wasActive {
 				plan.cancelOld = cur.cancel
@@ -478,11 +444,7 @@ func (d *probeIntentDispatcher) consumeSignals(
 				},
 			})
 		}
-		// Teardown re-arm: applied status is error/clear so applyIntentLifecycle
-		// drops the active entry through case 3 (no arm). hint=nil — slow
-		// lookup path is fine because the lifecycle decision short-circuits
-		// before the lookup runs.
-		d.applyStatus(session, agentType, appliedStatus, nil)
+		d.applyStatus(session, agentType, appliedStatus)
 	}
 }
 
@@ -547,9 +509,7 @@ func probeIntentsOf(p agentpkg.AgentProvider) []agentpkg.ProbeIntent {
 func (d *probeIntentDispatcher) replayStatus() {
 	snapshot := d.parent.snapshotStatuses()
 	for session, entry := range snapshot {
-		// Replay has no caller context (daemon restart): hint=nil falls
-		// back to lookupTopFrameForSessionLocked.
-		d.applyStatus(session, entry.agentType, entry.status, nil)
+		d.applyStatus(session, entry.agentType, entry.status)
 	}
 }
 

--- a/internal/module/agent/probe_intent_dispatcher.go
+++ b/internal/module/agent/probe_intent_dispatcher.go
@@ -372,6 +372,32 @@ func probeIntentsOf(p agentpkg.AgentProvider) []agentpkg.ProbeIntent {
 	return nil
 }
 
+// replayStatus walks every session that has a currentStatus entry and
+// re-runs applyStatus so ProbeIntent detectors arm against post-replay
+// state. Called from Module.Start after replayFromDB + startSweep so a
+// daemon restart inherits the same gating behavior as a live status
+// transition.
+//
+// Per spec §6.3 / §6.4: snapshot is taken under m.mu via
+// snapshotStatuses; for each session, applyStatus runs outside m.mu.
+// applyIntentLifecycle re-reads currentStatus + lookupTopFrameForSessionLocked
+// inside its own m.mu critical section, so any hook arriving between
+// snapshot and lifecycle observes consistent state — race fully closed.
+//
+// Per spec §6.4 stale-frame race: if the snapshot says Running but the
+// top frame.pid is already dead (codex crashed before daemon restart),
+// the production codex detector polls and emits a Signal on its first
+// IsPidAlive call → applyProbeGuards broadcasts error → consumeSignals
+// re-runs applyStatus(error) which tears down the entry. This is the
+// canonical issue #698 fix: daemon restart correctly discovers the
+// missing process and flips lights without waiting for the next hook.
+func (d *probeIntentDispatcher) replayStatus() {
+	snapshot := d.parent.snapshotStatuses()
+	for session, entry := range snapshot {
+		d.applyStatus(session, entry.agentType, entry.status)
+	}
+}
+
 // stopAll cancels every active ProbeIntent detector and clears the map.
 // Called from Module.Stop. Locks m.mu so no concurrent applyStatus can
 // observe a partial map.

--- a/internal/module/agent/probe_intent_dispatcher.go
+++ b/internal/module/agent/probe_intent_dispatcher.go
@@ -397,7 +397,7 @@ func (d *probeIntentDispatcher) consumeSignals(
 ) {
 	for sig := range in {
 		agentpkg.MetricProbeIntentSignalEmitted.Add(1)
-		applied := applyProbeGuards(d.parent, probeGuardArgs{
+		applied, appliedStatus := applyProbeGuards(d.parent, probeGuardArgs{
 			Session:    session,
 			AgentType:  agentType,
 			Reason:     "probe-intent:" + string(intent.Kind),
@@ -419,9 +419,10 @@ func (d *probeIntentDispatcher) consumeSignals(
 		// BEFORE applyStatus so test waitFor predicates that key off
 		// active-entry presence see the log/trace as a happens-before
 		// guarantee rather than a race against case 3 teardown.
-		d.parent.mu.Lock()
-		appliedStatus := d.parent.currentStatus[session]
-		d.parent.mu.Unlock()
+		//
+		// appliedStatus comes from applyProbeGuards' return (P2-T6): a
+		// re-read of currentStatus[session] races with concurrent SessionEnd
+		// hooks that may delete the entry before we acquire m.mu.
 		agentpkg.MetricProbeIntentApplied.Add(1)
 		if isDevMode() {
 			log.Printf("[probe-intent] signal session=%s kind=%s PaneAlive=%v newStatus=%s applied=true",

--- a/internal/module/agent/probe_intent_dispatcher.go
+++ b/internal/module/agent/probe_intent_dispatcher.go
@@ -479,19 +479,25 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 			log.Printf("[probe-intent] start session=%s agent=%s kind=%s pane=%s pid=%d generation=%d",
 				session, agentType, intent.Kind, plan.paneID, plan.senderPID, plan.generation)
 		}
-		d.parent.traceSink.AppendProbeIntent(probeIntentTraceArgs{
-			TmuxSession: session,
-			PaneID:      plan.paneID,
-			AgentType:   agentType,
-			Kind:        string(intent.Kind),
-			Decision:    "start",
-			Reason:      "lifecycle-applyStatus",
-			Payload: map[string]any{
-				"pane_id":    plan.paneID,
-				"sender_pid": plan.senderPID,
-				"generation": plan.generation,
-			},
-		})
+		// F9 audit: Module.New treats trace-store init failure as
+		// non-fatal (traceSink left nil). Other paths (unsupported,
+		// stop, signal) guard nil already; start path must do the same
+		// or any arm in degraded-trace mode panics the agent module.
+		if d.parent.traceSink != nil {
+			d.parent.traceSink.AppendProbeIntent(probeIntentTraceArgs{
+				TmuxSession: session,
+				PaneID:      plan.paneID,
+				AgentType:   agentType,
+				Kind:        string(intent.Kind),
+				Decision:    "start",
+				Reason:      "lifecycle-applyStatus",
+				Payload: map[string]any{
+					"pane_id":    plan.paneID,
+					"sender_pid": plan.senderPID,
+					"generation": plan.generation,
+				},
+			})
+		}
 	}
 }
 

--- a/internal/module/agent/probe_intent_dispatcher.go
+++ b/internal/module/agent/probe_intent_dispatcher.go
@@ -2,10 +2,61 @@ package agent
 
 import (
 	"context"
+	"log"
 	"slices"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 )
+
+// probeIntentOnDrop is the OnDrop callback installed on probeGuardArgs by
+// the dispatcher's consumeSignals path. It maps the canonical drop-reason
+// string (per applyProbeGuards contract) to the matching expvar counter
+// + dev log line. ScreenChange callers leave probeGuardArgs.OnDrop nil so
+// the legacy MetricProbeGraceWindowSuppressed semantics stay isolated.
+//
+// reason values are stable strings emitted by applyProbeGuards:
+// "stale-callback" / "grace" / "error-guard" / "transition-gate". Anything
+// else is logged but not counted (defensive landing for future drop
+// branches that may add reasons before this map is updated).
+func probeIntentOnDrop(reason string) {
+	switch reason {
+	case "stale-callback":
+		agentpkg.MetricProbeIntentDroppedStale.Add(1)
+	case "grace":
+		agentpkg.MetricProbeIntentDroppedGrace.Add(1)
+	case "error-guard":
+		agentpkg.MetricProbeIntentDroppedErrorGuard.Add(1)
+	case "transition-gate":
+		agentpkg.MetricProbeIntentDroppedTransitionGate.Add(1)
+	}
+	if isDevMode() {
+		log.Printf("[probe-intent] drop reason=%s", reason)
+	}
+}
+
+// probeIntentOnDropForSession returns an OnDrop callback that prefixes the
+// drop log with session + kind context so dev-mode tail can correlate the
+// drop with the originating dispatcher path. Counter increments mirror
+// probeIntentOnDrop. The closure variant exists because applyProbeGuards
+// invokes OnDrop without re-supplying session/kind context.
+func probeIntentOnDropForSession(session string, kind agentpkg.ProbeIntentKind) func(string) {
+	return func(reason string) {
+		switch reason {
+		case "stale-callback":
+			agentpkg.MetricProbeIntentDroppedStale.Add(1)
+		case "grace":
+			agentpkg.MetricProbeIntentDroppedGrace.Add(1)
+		case "error-guard":
+			agentpkg.MetricProbeIntentDroppedErrorGuard.Add(1)
+		case "transition-gate":
+			agentpkg.MetricProbeIntentDroppedTransitionGate.Add(1)
+		}
+		if isDevMode() {
+			log.Printf("[probe-intent] drop session=%s kind=%s reason=%s",
+				session, kind, reason)
+		}
+	}
+}
 
 // probeIntentDispatcher routes ProbeIntent lifecycle events from
 // manageActivityWatch / replayStatus into per-(session, kind) detector
@@ -285,6 +336,18 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 	// Execute plan outside m.mu.
 	if plan.cancelOld != nil {
 		plan.cancelOld()
+		agentpkg.MetricProbeIntentStopped.Add(1)
+		if isDevMode() {
+			log.Printf("[probe-intent] stop session=%s kind=%s reason=lifecycle-applyStatus",
+				session, intent.Kind)
+		}
+		d.parent.traceSink.AppendProbeIntent(probeIntentTraceArgs{
+			TmuxSession: session,
+			AgentType:   agentType,
+			Kind:        string(intent.Kind),
+			Decision:    "stop",
+			Reason:      "lifecycle-applyStatus",
+		})
 	}
 	if plan.startCtx != nil {
 		out := make(chan agentpkg.Signal, 1)
@@ -293,6 +356,24 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 			close(out)
 		}()
 		go d.consumeSignals(plan.startCtx, session, agentType, intent, plan.generation, out)
+		agentpkg.MetricProbeIntentStarted.Add(1)
+		if isDevMode() {
+			log.Printf("[probe-intent] start session=%s agent=%s kind=%s pane=%s pid=%d generation=%d",
+				session, agentType, intent.Kind, plan.paneID, plan.senderPID, plan.generation)
+		}
+		d.parent.traceSink.AppendProbeIntent(probeIntentTraceArgs{
+			TmuxSession: session,
+			PaneID:      plan.paneID,
+			AgentType:   agentType,
+			Kind:        string(intent.Kind),
+			Decision:    "start",
+			Reason:      "lifecycle-applyStatus",
+			Payload: map[string]any{
+				"pane_id":    plan.paneID,
+				"sender_pid": plan.senderPID,
+				"generation": plan.generation,
+			},
+		})
 	}
 }
 
@@ -315,6 +396,7 @@ func (d *probeIntentDispatcher) consumeSignals(
 	in <-chan agentpkg.Signal,
 ) {
 	for sig := range in {
+		agentpkg.MetricProbeIntentSignalEmitted.Add(1)
 		applied := applyProbeGuards(d.parent, probeGuardArgs{
 			Session:    session,
 			AgentType:  agentType,
@@ -322,13 +404,45 @@ func (d *probeIntentDispatcher) consumeSignals(
 			Signal:     sig,
 			Mapping:    intent.OnSignal,
 			StaleCheck: makeProbeIntentStaleCheck(session, intent.Kind, agentType, generation),
+			OnDrop:     probeIntentOnDropForSession(session, intent.Kind),
 		})
 		if !applied {
 			continue
 		}
+		// Per spec §5.4 round 5 P1: applied=true means OnEntryStatus no
+		// longer holds (currentStatus already flipped to error/clear inside
+		// applyProbeGuards step 4). Re-run applyStatus so lifecycle case 3
+		// (active && !shouldActive) cancels the detector ctx + deletes the
+		// active entry through the single lifecycle entry point.
+		//
+		// Ordering: emit observability surfaces (counter / log / trace)
+		// BEFORE applyStatus so test waitFor predicates that key off
+		// active-entry presence see the log/trace as a happens-before
+		// guarantee rather than a race against case 3 teardown.
 		d.parent.mu.Lock()
 		appliedStatus := d.parent.currentStatus[session]
 		d.parent.mu.Unlock()
+		agentpkg.MetricProbeIntentApplied.Add(1)
+		if isDevMode() {
+			log.Printf("[probe-intent] signal session=%s kind=%s PaneAlive=%v newStatus=%s applied=true",
+				session, intent.Kind, sig.PaneAlive, appliedStatus)
+		}
+		if d.parent.traceSink != nil {
+			d.parent.traceSink.AppendProbeIntent(probeIntentTraceArgs{
+				TmuxSession: session,
+				PaneID:      sig.PaneID,
+				AgentType:   agentType,
+				Kind:        string(intent.Kind),
+				Decision:    "signal",
+				Reason:      "applied",
+				Payload: map[string]any{
+					"pane_alive": sig.PaneAlive,
+					"sender_pid": sig.SenderPID,
+					"new_status": string(appliedStatus),
+					"generation": generation,
+				},
+			})
+		}
 		d.applyStatus(session, agentType, appliedStatus)
 	}
 }

--- a/internal/module/agent/probe_intent_dispatcher.go
+++ b/internal/module/agent/probe_intent_dispatcher.go
@@ -586,13 +586,25 @@ func (d *probeIntentDispatcher) consumeSignals(
 	// match) would short-circuit the next status change → re-arm never
 	// fires → codex stays Running indefinitely after a missed crash.
 	// Generation-scoped so a concurrent rearm survives.
+	//
+	// F1 round-3 follow-up: teardown alone is insufficient — codex that
+	// dies WITHIN graceWindow has no future hook to re-trigger lifecycle.
+	// Re-run applyStatus when live status still gates the intent so a
+	// fresh detector arms. graceWindow may suppress the next emit too;
+	// the next post-loop iteration repeats this teardown+rearm cycle
+	// until graceWindow expires (worst case 2-3 polls at 1Hz vs
+	// permanent miss).
 	if !appliedAny {
 		d.parent.mu.Lock()
 		teardown, ok := d.stopActiveIntentInLock(session, intent.Kind, generation, "detector-exited-no-effect")
+		curStatus, hasStatus := d.parent.currentStatus[session]
 		d.parent.mu.Unlock()
 		if ok {
 			teardown.cancel()
 			d.emitStopObservability(session, teardown)
+			if hasStatus && slices.Contains(intent.OnEntryStatus, curStatus) {
+				d.applyStatus(session, agentType, curStatus)
+			}
 		}
 	}
 }

--- a/internal/module/agent/probe_intent_dispatcher.go
+++ b/internal/module/agent/probe_intent_dispatcher.go
@@ -144,19 +144,33 @@ func (d *probeIntentDispatcher) setParentCtx(ctx context.Context) {
 	d.parentCtx = ctx
 }
 
+// probeIntentTargetHint is an optional fast-path target supplied by hot-path
+// callers (live hook handlers) that already have projection.TopFrame in
+// scope. When non-nil, applyIntentLifecycle skips
+// lookupTopFrameForSessionLocked → projectionForSession → tmux exec — the
+// codex Daemon Hook Pipeline Lag analysis (#3) measured the lookup as the
+// primary contributor to D-segment lock convoy in the W6-3 dispatcher
+// path. Replay (daemon restart) and consumeSignals teardown have no caller
+// context and pass nil → slow lookup retained as the source of truth.
+type probeIntentTargetHint struct {
+	paneID    string
+	senderPID int
+}
+
 // applyStatus is the single entry point for ProbeIntent lifecycle
 // transitions. Called from:
 //
 //   - manageActivityWatch (P1-T5): live hook path, when a hook flips
-//     currentStatus.
-//   - replayStatus (P1-T6): daemon-restart hydrate.
+//     currentStatus. Caller supplies hint from projection.TopFrame.
+//   - replayStatus (P1-T6): daemon-restart hydrate. hint=nil.
 //   - consumeSignals teardown (round 5 P1): probe-applied transitions
 //     re-run lifecycle so the active entry teardown path stays unified.
+//     hint=nil (teardown drops the active entry without arming).
 //
 // Per spec §5.4: reconcile session-wide active-set against the new
 // (agentType, declaredKinds) tuple BEFORE running the per-intent
 // lifecycle so cross-provider switches don't leave stranded entries.
-func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus agentpkg.Status) {
+func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus agentpkg.Status, hint *probeIntentTargetHint) {
 	provider, ok := d.parent.registry.Get(agentType)
 	if !ok {
 		// Unknown agent → reconcile clears every active entry for the
@@ -176,7 +190,7 @@ func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus
 	d.reconcileSessionActive(session, agentType, declaredKinds)
 
 	for _, intent := range intents {
-		d.applyIntentLifecycle(session, agentType, newStatus, intent)
+		d.applyIntentLifecycle(session, agentType, newStatus, intent, hint)
 	}
 }
 
@@ -252,10 +266,17 @@ func (d *probeIntentDispatcher) reconcileSessionActive(
 //
 // Per spec §5.4: lifecycle decision runs entirely inside one m.mu
 // critical section; cancel + start work runs after Unlock.
+//
+// hint: optional fast-path target. When non-nil with paneID + senderPID
+// both populated, the lookup-under-lock step is skipped (avoiding the
+// D-segment lock convoy described in the codex hook-pipeline-lag analysis
+// #3). When nil — replay path / consumeSignals teardown — lookup runs as
+// before.
 func (d *probeIntentDispatcher) applyIntentLifecycle(
 	session, agentType string,
 	newStatus agentpkg.Status,
 	intent agentpkg.ProbeIntent,
+	hint *probeIntentTargetHint,
 ) {
 	shouldActive := slices.Contains(intent.OnEntryStatus, newStatus)
 
@@ -290,7 +311,20 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 			}
 			break
 		}
-		paneID, senderPID, hasFrame := d.parent.lookupTopFrameForSessionLocked(session)
+		var paneID string
+		var senderPID int
+		var hasFrame bool
+		if hint != nil && hint.paneID != "" && hint.senderPID != 0 {
+			// Fast path: caller has projection.TopFrame in scope; trust it
+			// rather than re-computing under m.mu (which routes through
+			// projectionForSession → tmux exec). currentStatus re-validation
+			// above + StaleCheck below still cover concurrency races.
+			paneID = hint.paneID
+			senderPID = hint.senderPID
+			hasFrame = true
+		} else {
+			paneID, senderPID, hasFrame = d.parent.lookupTopFrameForSessionLocked(session)
+		}
 		if !hasFrame || paneID == "" || senderPID == 0 {
 			if wasActive {
 				plan.cancelOld = cur.cancel
@@ -444,7 +478,11 @@ func (d *probeIntentDispatcher) consumeSignals(
 				},
 			})
 		}
-		d.applyStatus(session, agentType, appliedStatus)
+		// Teardown re-arm: applied status is error/clear so applyIntentLifecycle
+		// drops the active entry through case 3 (no arm). hint=nil — slow
+		// lookup path is fine because the lifecycle decision short-circuits
+		// before the lookup runs.
+		d.applyStatus(session, agentType, appliedStatus, nil)
 	}
 }
 
@@ -509,7 +547,9 @@ func probeIntentsOf(p agentpkg.AgentProvider) []agentpkg.ProbeIntent {
 func (d *probeIntentDispatcher) replayStatus() {
 	snapshot := d.parent.snapshotStatuses()
 	for session, entry := range snapshot {
-		d.applyStatus(session, entry.agentType, entry.status)
+		// Replay has no caller context (daemon restart): hint=nil falls
+		// back to lookupTopFrameForSessionLocked.
+		d.applyStatus(session, entry.agentType, entry.status, nil)
 	}
 }
 

--- a/internal/module/agent/probe_intent_dispatcher.go
+++ b/internal/module/agent/probe_intent_dispatcher.go
@@ -84,6 +84,15 @@ type probeIntentDispatcher struct {
 	// Default points to defaultStartProbeIntentDetector; P2-T4 wires a
 	// codex-routed implementation in newProbeIntentDispatcher / Init.
 	startDetector probeIntentDetectorStarter
+
+	// supportedKinds is the registry of ProbeIntent kinds that have
+	// production detector wiring. Lifecycle pre-arm checks membership and
+	// fails closed (skip arm + emit observability) for unwired kinds — per
+	// audit F6: a provider declaring a new kind without a paired Module.New
+	// switch case must surface as a runtime signal rather than silently
+	// appearing armed with a noop default detector. nil map = no kinds
+	// supported (test default for empty Module unless the test populates).
+	supportedKinds map[agentpkg.ProbeIntentKind]struct{}
 }
 
 // probeIntentDetectorStarter is the contract for ProbeIntent detector
@@ -116,12 +125,35 @@ type activeIntent struct {
 // detectors and starting new goroutines is intentionally deferred so
 // applyIntentLifecycle never blocks on goroutine schedule while holding
 // m.mu (avoids long lock holds during detector startup).
+//
+// stopOld carries the full observability context for the case-3 / case-5
+// teardown so emitStopObservability can run after Unlock without
+// re-reading map state.
 type lifecyclePlan struct {
-	cancelOld  context.CancelFunc
-	startCtx   context.Context
+	stopOld         *stopMeta
+	startCtx        context.Context
+	paneID          string
+	senderPID       int
+	generation      uint64
+	unsupportedKind bool
+	kind            agentpkg.ProbeIntentKind
+}
+
+// stopMeta carries the metadata needed to cancel + emit observability for
+// a stopped active intent. Returned by stopActiveIntentInLock so callers
+// can defer the cancel + emit work until after they release m.mu.
+//
+// Per audit F5/F7: every cancel path (lifecycle case 3/5, reconcile,
+// stopAll, consumeSignals teardown) MUST emit metric + dev log + trace.
+// Centralizing the emission contract through stopMeta + emitStopObservability
+// eliminates the previously-distributed observability gaps.
+type stopMeta struct {
+	cancel     context.CancelFunc
+	agentType  string
+	kind       agentpkg.ProbeIntentKind
 	paneID     string
-	senderPID  int
 	generation uint64
+	reason     string
 }
 
 // newProbeIntentDispatcher constructs a dispatcher tied to the given
@@ -180,6 +212,71 @@ func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus
 	}
 }
 
+// stopActiveIntentInLock removes activeProbeIntents[session][kind] when
+// either expectGeneration==0 (caller doesn't care which generation) OR
+// cur.generation matches expectGeneration. Returns ok=true with full
+// stopMeta only when an entry was removed.
+//
+// CALLER MUST hold m.mu. The returned cancel ctx is invoked AFTER Unlock
+// (followed by emitStopObservability) so detector goroutines that
+// re-acquire m.mu during shutdown do not deadlock.
+//
+// Generation guard (audit F2): consumeSignals teardown after applied=true
+// passes its emitting generation; if a concurrent rearm has already
+// installed gen N+1, the mismatch causes ok=false and the newer detector
+// stays intact.
+func (d *probeIntentDispatcher) stopActiveIntentInLock(
+	session string,
+	kind agentpkg.ProbeIntentKind,
+	expectGeneration uint64,
+	reason string,
+) (stopMeta, bool) {
+	perSession := d.parent.activeProbeIntents[session]
+	cur, ok := perSession[kind]
+	if !ok {
+		return stopMeta{}, false
+	}
+	if expectGeneration != 0 && cur.generation != expectGeneration {
+		return stopMeta{}, false
+	}
+	delete(perSession, kind)
+	if len(perSession) == 0 {
+		delete(d.parent.activeProbeIntents, session)
+	}
+	return stopMeta{
+		cancel:     cur.cancel,
+		agentType:  cur.agentType,
+		kind:       kind,
+		paneID:     cur.paneID,
+		generation: cur.generation,
+		reason:     reason,
+	}, true
+}
+
+// emitStopObservability records counter + dev log + trace for an intent
+// teardown. Per audit F5/F7: every stop path must emit these three
+// surfaces — single helper enforces the contract.
+func (d *probeIntentDispatcher) emitStopObservability(session string, meta stopMeta) {
+	agentpkg.MetricProbeIntentStopped.Add(1)
+	if isDevMode() {
+		log.Printf("[probe-intent] stop session=%s agent=%s kind=%s generation=%d reason=%s",
+			session, meta.agentType, meta.kind, meta.generation, meta.reason)
+	}
+	if d.parent.traceSink != nil {
+		d.parent.traceSink.AppendProbeIntent(probeIntentTraceArgs{
+			TmuxSession: session,
+			PaneID:      meta.paneID,
+			AgentType:   meta.agentType,
+			Kind:        string(meta.kind),
+			Decision:    "stop",
+			Reason:      meta.reason,
+			Payload: map[string]any{
+				"generation": meta.generation,
+			},
+		})
+	}
+}
+
 // reconcileSessionActive cancels + deletes active entries that no longer
 // apply to the (newAgentType, declaredKinds) pair. Called from applyStatus
 // before the per-intent lifecycle loop.
@@ -197,11 +294,12 @@ func (d *probeIntentDispatcher) reconcileSessionActive(
 	newAgentType string,
 	declaredKinds map[agentpkg.ProbeIntentKind]struct{},
 ) {
-	var toCancel []context.CancelFunc
+	var stops []stopMeta
 
 	d.parent.mu.Lock()
 	perSession := d.parent.activeProbeIntents[session]
 	if perSession != nil {
+		var staleKinds []agentpkg.ProbeIntentKind
 		for kind, cur := range perSession {
 			stale := declaredKinds == nil ||
 				cur.agentType != newAgentType
@@ -211,18 +309,23 @@ func (d *probeIntentDispatcher) reconcileSessionActive(
 				}
 			}
 			if stale {
-				toCancel = append(toCancel, cur.cancel)
-				delete(perSession, kind)
+				staleKinds = append(staleKinds, kind)
 			}
 		}
-		if len(perSession) == 0 {
-			delete(d.parent.activeProbeIntents, session)
+		// Map mutation outside the iterator to avoid Go's "for range over
+		// map being mutated" undefined ordering on subsequent iterations.
+		for _, kind := range staleKinds {
+			meta, ok := d.stopActiveIntentInLock(session, kind, 0, "reconcile-cross-provider")
+			if ok {
+				stops = append(stops, meta)
+			}
 		}
 	}
 	d.parent.mu.Unlock()
 
-	for _, cancel := range toCancel {
-		cancel()
+	for _, meta := range stops {
+		meta.cancel()
+		d.emitStopObservability(session, meta)
 	}
 }
 
@@ -269,10 +372,8 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 		// case 1: noop
 	case !shouldActive && wasActive:
 		// case 3: stop only
-		plan.cancelOld = cur.cancel
-		delete(perSession, intent.Kind)
-		if len(perSession) == 0 {
-			delete(d.parent.activeProbeIntents, session)
+		if meta, ok := d.stopActiveIntentInLock(session, intent.Kind, 0, "lifecycle-not-shouldActive"); ok {
+			plan.stopOld = &meta
 		}
 	case shouldActive:
 		// case 2 / 4 / 5: lookup live currentStatus + top frame.
@@ -282,10 +383,8 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 		curStatus, hasStatus := d.parent.currentStatus[session]
 		if !hasStatus || !slices.Contains(intent.OnEntryStatus, curStatus) {
 			if wasActive {
-				plan.cancelOld = cur.cancel
-				delete(perSession, intent.Kind)
-				if len(perSession) == 0 {
-					delete(d.parent.activeProbeIntents, session)
+				if meta, ok := d.stopActiveIntentInLock(session, intent.Kind, 0, "lifecycle-status-drift"); ok {
+					plan.stopOld = &meta
 				}
 			}
 			break
@@ -293,10 +392,8 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 		paneID, senderPID, hasFrame := d.parent.lookupTopFrameForSessionLocked(session)
 		if !hasFrame || paneID == "" || senderPID == 0 {
 			if wasActive {
-				plan.cancelOld = cur.cancel
-				delete(perSession, intent.Kind)
-				if len(perSession) == 0 {
-					delete(d.parent.activeProbeIntents, session)
+				if meta, ok := d.stopActiveIntentInLock(session, intent.Kind, 0, "lifecycle-frame-miss"); ok {
+					plan.stopOld = &meta
 				}
 			}
 			break
@@ -309,12 +406,28 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 			// case 4: already armed correctly
 			break
 		}
-		// case 2 (!wasActive) or case 5 (target mismatch)
+		// case 2 (!wasActive) or case 5 (target mismatch).
+		// F6 fail-closed: refuse to arm an unsupported kind. A future
+		// provider might declare a new ProbeIntentKind without the matching
+		// Module.New switch case; emit observability + skip arm rather
+		// than silently parking on the noop default detector.
+		if _, supported := d.supportedKinds[intent.Kind]; !supported {
+			plan.unsupportedKind = true
+			if wasActive {
+				if meta, ok := d.stopActiveIntentInLock(session, intent.Kind, 0, "lifecycle-unsupported-kind"); ok {
+					plan.stopOld = &meta
+				}
+			}
+			break
+		}
 		if wasActive {
-			plan.cancelOld = cur.cancel
+			if meta, ok := d.stopActiveIntentInLock(session, intent.Kind, 0, "lifecycle-target-mismatch"); ok {
+				plan.stopOld = &meta
+			}
 		}
 		generation := d.parent.nextProbeIntentGeneration()
 		ctx, cancel := context.WithCancel(d.parentCtx)
+		perSession = d.parent.activeProbeIntents[session]
 		if perSession == nil {
 			perSession = make(map[agentpkg.ProbeIntentKind]activeIntent)
 			d.parent.activeProbeIntents[session] = perSession
@@ -334,20 +447,25 @@ func (d *probeIntentDispatcher) applyIntentLifecycle(
 	d.parent.mu.Unlock()
 
 	// Execute plan outside m.mu.
-	if plan.cancelOld != nil {
-		plan.cancelOld()
-		agentpkg.MetricProbeIntentStopped.Add(1)
+	if plan.stopOld != nil {
+		plan.stopOld.cancel()
+		d.emitStopObservability(session, *plan.stopOld)
+	}
+	if plan.unsupportedKind {
+		agentpkg.MetricProbeIntentUnsupportedKind.Add(1)
 		if isDevMode() {
-			log.Printf("[probe-intent] stop session=%s kind=%s reason=lifecycle-applyStatus",
-				session, intent.Kind)
+			log.Printf("[probe-intent] unsupported_kind session=%s agent=%s kind=%s reason=skip-arm",
+				session, agentType, intent.Kind)
 		}
-		d.parent.traceSink.AppendProbeIntent(probeIntentTraceArgs{
-			TmuxSession: session,
-			AgentType:   agentType,
-			Kind:        string(intent.Kind),
-			Decision:    "stop",
-			Reason:      "lifecycle-applyStatus",
-		})
+		if d.parent.traceSink != nil {
+			d.parent.traceSink.AppendProbeIntent(probeIntentTraceArgs{
+				TmuxSession: session,
+				AgentType:   agentType,
+				Kind:        string(intent.Kind),
+				Decision:    "drop",
+				Reason:      "unsupported-kind",
+			})
+		}
 	}
 	if plan.startCtx != nil {
 		out := make(chan agentpkg.Signal, 1)
@@ -395,6 +513,7 @@ func (d *probeIntentDispatcher) consumeSignals(
 	generation uint64,
 	in <-chan agentpkg.Signal,
 ) {
+	appliedAny := false
 	for sig := range in {
 		agentpkg.MetricProbeIntentSignalEmitted.Add(1)
 		applied, appliedStatus := applyProbeGuards(d.parent, probeGuardArgs{
@@ -409,16 +528,17 @@ func (d *probeIntentDispatcher) consumeSignals(
 		if !applied {
 			continue
 		}
+		appliedAny = true
 		// Per spec §5.4 round 5 P1: applied=true means OnEntryStatus no
 		// longer holds (currentStatus already flipped to error/clear inside
-		// applyProbeGuards step 4). Re-run applyStatus so lifecycle case 3
-		// (active && !shouldActive) cancels the detector ctx + deletes the
-		// active entry through the single lifecycle entry point.
+		// applyProbeGuards step 4). Tear down the active entry through the
+		// generation-scoped helper so a concurrent rearm (gen N+1 from a
+		// different hook) survives our cleanup — audit F2.
 		//
-		// Ordering: emit observability surfaces (counter / log / trace)
-		// BEFORE applyStatus so test waitFor predicates that key off
-		// active-entry presence see the log/trace as a happens-before
-		// guarantee rather than a race against case 3 teardown.
+		// Ordering: emit signal observability (counter / log / trace) BEFORE
+		// teardown so test waitFor predicates keying off active-entry
+		// presence see the signal log as a happens-before guarantee rather
+		// than a race against the teardown's stop log.
 		//
 		// appliedStatus comes from applyProbeGuards' return (P2-T6): a
 		// re-read of currentStatus[session] races with concurrent SessionEnd
@@ -444,7 +564,36 @@ func (d *probeIntentDispatcher) consumeSignals(
 				},
 			})
 		}
-		d.applyStatus(session, agentType, appliedStatus)
+		// F2 fix: generation-scoped teardown. If a concurrent hook rearmed
+		// gen N+1 between detector emit and now, stopActiveIntentInLock
+		// returns ok=false (cur.generation != generation) and the newer
+		// detector is preserved. Previously we re-ran applyStatus(error)
+		// which routed through case-3 cleanup and cancelled whatever entry
+		// was present — including the newer rearmed gen — leaving the
+		// session running but undetected.
+		d.parent.mu.Lock()
+		teardown, ok := d.stopActiveIntentInLock(session, intent.Kind, generation, "applied:"+string(appliedStatus))
+		d.parent.mu.Unlock()
+		if ok {
+			teardown.cancel()
+			d.emitStopObservability(session, teardown)
+		}
+	}
+	// F1 fix: detector exited (one-shot post-emit) but the loop exited
+	// without an applied signal — graceWindow drop, transition gate, or
+	// other guard rejected the only emission. Without this teardown the
+	// active entry stays around with no live detector; case-4 (target
+	// match) would short-circuit the next status change → re-arm never
+	// fires → codex stays Running indefinitely after a missed crash.
+	// Generation-scoped so a concurrent rearm survives.
+	if !appliedAny {
+		d.parent.mu.Lock()
+		teardown, ok := d.stopActiveIntentInLock(session, intent.Kind, generation, "detector-exited-no-effect")
+		d.parent.mu.Unlock()
+		if ok {
+			teardown.cancel()
+			d.emitStopObservability(session, teardown)
+		}
 	}
 }
 
@@ -521,19 +670,34 @@ func (d *probeIntentDispatcher) replayStatus() {
 // detector goroutines that may briefly attempt re-acquisition through
 // applyProbeGuards do not deadlock.
 func (d *probeIntentDispatcher) stopAll() {
-	var toCancel []context.CancelFunc
+	type stopAllRecord struct {
+		session string
+		meta    stopMeta
+	}
+	var stops []stopAllRecord
 
 	d.parent.mu.Lock()
-	for _, perSession := range d.parent.activeProbeIntents {
-		for _, cur := range perSession {
-			toCancel = append(toCancel, cur.cancel)
+	for session, perSession := range d.parent.activeProbeIntents {
+		for kind, cur := range perSession {
+			stops = append(stops, stopAllRecord{
+				session: session,
+				meta: stopMeta{
+					cancel:     cur.cancel,
+					agentType:  cur.agentType,
+					kind:       kind,
+					paneID:     cur.paneID,
+					generation: cur.generation,
+					reason:     "module-stop",
+				},
+			})
 		}
 	}
 	d.parent.activeProbeIntents = make(map[string]map[agentpkg.ProbeIntentKind]activeIntent)
 	d.parent.mu.Unlock()
 
-	for _, cancel := range toCancel {
-		cancel()
+	for _, rec := range stops {
+		rec.meta.cancel()
+		d.emitStopObservability(rec.session, rec.meta)
 	}
 }
 

--- a/internal/module/agent/probe_intent_dispatcher.go
+++ b/internal/module/agent/probe_intent_dispatcher.go
@@ -1,0 +1,415 @@
+package agent
+
+import (
+	"context"
+	"slices"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+)
+
+// probeIntentDispatcher routes ProbeIntent lifecycle events from
+// manageActivityWatch / replayStatus into per-(session, kind) detector
+// goroutines and then funnels the detector signals back through
+// applyProbeGuards.
+//
+// Lock ownership (per spec §5.1 / by2z79ouc ATK-1): all active-set state
+// (m.activeProbeIntents + m.probeIntentGen) lives under m.mu. The dispatcher
+// holds no mutex of its own — every state mutation routes through m.mu.
+// Detector goroutines + consumeSignals goroutines run lock-free; they
+// re-acquire m.mu through applyProbeGuards' StaleCheck closure when they
+// need to broadcast.
+//
+// Per spec §5.4 / round 5 P1: applyIntentLifecycle is the single helper
+// that decides start / stop / re-arm; callers (applyStatus,
+// reconcileSessionActive, consumeSignals teardown) all funnel through it
+// so the lifecycle decision is atomic with the active-set read under m.mu.
+type probeIntentDispatcher struct {
+	parent    *Module
+	parentCtx context.Context
+
+	// startDetector routes (kind, paneID, senderPID) → detector goroutine.
+	// Per-dispatcher field (not a package var) so concurrent tests using
+	// independent Modules don't race on a global swap during cleanup.
+	// Default points to defaultStartProbeIntentDetector; P2-T4 wires a
+	// codex-routed implementation in newProbeIntentDispatcher / Init.
+	startDetector probeIntentDetectorStarter
+}
+
+// probeIntentDetectorStarter is the contract for ProbeIntent detector
+// goroutines. Implementations MUST honor ctx (return on Done) and MUST
+// NOT close the supplied out channel — the dispatcher owns the channel
+// lifetime. Implementations MAY emit zero or more Signal values before
+// returning.
+type probeIntentDetectorStarter func(
+	ctx context.Context,
+	m *Module,
+	kind agentpkg.ProbeIntentKind,
+	paneID string,
+	senderPID int,
+	out chan<- agentpkg.Signal,
+)
+
+// activeIntent records one (session, kind) detector arming. Stored in
+// m.activeProbeIntents under m.mu. agentType + paneID + senderPID +
+// generation form the dedup tuple checked against fresh hook input.
+type activeIntent struct {
+	agentType  string
+	paneID     string
+	senderPID  int
+	cancel     context.CancelFunc
+	generation uint64
+}
+
+// lifecyclePlan records the work that must happen OUTSIDE m.mu after
+// applyIntentLifecycle finishes its critical section. Cancelling old
+// detectors and starting new goroutines is intentionally deferred so
+// applyIntentLifecycle never blocks on goroutine schedule while holding
+// m.mu (avoids long lock holds during detector startup).
+type lifecyclePlan struct {
+	cancelOld  context.CancelFunc
+	startCtx   context.Context
+	paneID     string
+	senderPID  int
+	generation uint64
+}
+
+// newProbeIntentDispatcher constructs a dispatcher tied to the given
+// Module. parentCtx is initialized to context.Background; callers may
+// rotate it via setParentCtx for tests or future Stop()-driven cancel
+// roots. Per W6-3 P1-T4 contract.
+func newProbeIntentDispatcher(parent *Module) *probeIntentDispatcher {
+	return &probeIntentDispatcher{
+		parent:        parent,
+		parentCtx:     context.Background(),
+		startDetector: defaultStartProbeIntentDetector,
+	}
+}
+
+// setParentCtx swaps the root context that future detector goroutines
+// inherit from. Existing armed detectors keep their original ctx (their
+// cancel() is recorded in activeIntent). Test seam — production call
+// sites do not rotate parentCtx.
+func (d *probeIntentDispatcher) setParentCtx(ctx context.Context) {
+	d.parentCtx = ctx
+}
+
+// applyStatus is the single entry point for ProbeIntent lifecycle
+// transitions. Called from:
+//
+//   - manageActivityWatch (P1-T5): live hook path, when a hook flips
+//     currentStatus.
+//   - replayStatus (P1-T6): daemon-restart hydrate.
+//   - consumeSignals teardown (round 5 P1): probe-applied transitions
+//     re-run lifecycle so the active entry teardown path stays unified.
+//
+// Per spec §5.4: reconcile session-wide active-set against the new
+// (agentType, declaredKinds) tuple BEFORE running the per-intent
+// lifecycle so cross-provider switches don't leave stranded entries.
+func (d *probeIntentDispatcher) applyStatus(session, agentType string, newStatus agentpkg.Status) {
+	provider, ok := d.parent.registry.Get(agentType)
+	if !ok {
+		// Unknown agent → reconcile clears every active entry for the
+		// session (declaredKinds=nil sentinel) and returns. Per round 4 P1:
+		// without this, switching session top agent away from codex would
+		// leave codex active entries stranded with their detectors still
+		// polling.
+		d.reconcileSessionActive(session, agentType, nil)
+		return
+	}
+	intents := probeIntentsOf(provider)
+
+	declaredKinds := make(map[agentpkg.ProbeIntentKind]struct{}, len(intents))
+	for _, intent := range intents {
+		declaredKinds[intent.Kind] = struct{}{}
+	}
+	d.reconcileSessionActive(session, agentType, declaredKinds)
+
+	for _, intent := range intents {
+		d.applyIntentLifecycle(session, agentType, newStatus, intent)
+	}
+}
+
+// reconcileSessionActive cancels + deletes active entries that no longer
+// apply to the (newAgentType, declaredKinds) pair. Called from applyStatus
+// before the per-intent lifecycle loop.
+//
+// declaredKinds=nil is the sentinel for "drop everything" (unknown agent
+// or provider has no ProbeIntents); otherwise an entry survives only when
+// its agentType matches AND its kind is in declaredKinds.
+//
+// Per round 4 P1 (spec §5.4): stranded detectors still pass
+// makeProbeIntentStaleCheck because their entry is still in the active
+// map; this reconcile is the only place that drops the entry on cross-
+// provider transitions.
+func (d *probeIntentDispatcher) reconcileSessionActive(
+	session string,
+	newAgentType string,
+	declaredKinds map[agentpkg.ProbeIntentKind]struct{},
+) {
+	var toCancel []context.CancelFunc
+
+	d.parent.mu.Lock()
+	perSession := d.parent.activeProbeIntents[session]
+	if perSession != nil {
+		for kind, cur := range perSession {
+			stale := declaredKinds == nil ||
+				cur.agentType != newAgentType
+			if !stale {
+				if _, ok := declaredKinds[kind]; !ok {
+					stale = true
+				}
+			}
+			if stale {
+				toCancel = append(toCancel, cur.cancel)
+				delete(perSession, kind)
+			}
+		}
+		if len(perSession) == 0 {
+			delete(d.parent.activeProbeIntents, session)
+		}
+	}
+	d.parent.mu.Unlock()
+
+	for _, cancel := range toCancel {
+		cancel()
+	}
+}
+
+// applyIntentLifecycle decides whether to start / stop / re-arm the
+// detector for (session, intent.Kind) based on:
+//
+//   - shouldActive: newStatus ∈ intent.OnEntryStatus
+//   - wasActive: m.activeProbeIntents[session][intent.Kind] is set
+//   - target match: existing entry's (agentType, paneID, senderPID) ==
+//     fresh top-frame (paneID, senderPID) for this agentType
+//
+// The five cases (per spec §5.4 + round 3 P1):
+//
+//  1. !shouldActive && !wasActive → noop
+//  2. !shouldActive &&  wasActive → cancel + delete
+//  3.  shouldActive && !wasActive (frame ok) → record + arm
+//  4.  shouldActive &&  wasActive (target match) → noop
+//  5.  shouldActive &&  wasActive (target mismatch) → cancel + record + arm
+//
+// Edge cases (per spec §5.4 lines 717-739):
+//
+//   - shouldActive but currentStatus has drifted between snapshot and
+//     this call (by2z79ouc ATK-2 / replay race): if wasActive, tear down;
+//     don't arm.
+//   - shouldActive but lookupTopFrameForSessionLocked misses: if
+//     wasActive, tear down (target unverifiable); don't arm.
+//
+// Per spec §5.4: lifecycle decision runs entirely inside one m.mu
+// critical section; cancel + start work runs after Unlock.
+func (d *probeIntentDispatcher) applyIntentLifecycle(
+	session, agentType string,
+	newStatus agentpkg.Status,
+	intent agentpkg.ProbeIntent,
+) {
+	shouldActive := slices.Contains(intent.OnEntryStatus, newStatus)
+
+	d.parent.mu.Lock()
+	var plan lifecyclePlan
+	perSession := d.parent.activeProbeIntents[session]
+	cur, wasActive := perSession[intent.Kind]
+
+	switch {
+	case !shouldActive && !wasActive:
+		// case 1: noop
+	case !shouldActive && wasActive:
+		// case 3: stop only
+		plan.cancelOld = cur.cancel
+		delete(perSession, intent.Kind)
+		if len(perSession) == 0 {
+			delete(d.parent.activeProbeIntents, session)
+		}
+	case shouldActive:
+		// case 2 / 4 / 5: lookup live currentStatus + top frame.
+		// Per spec §5.4 by2z79ouc ATK-2: status may have changed between
+		// the snapshot taken by caller and this lock; re-validate against
+		// live currentStatus inside m.mu.
+		curStatus, hasStatus := d.parent.currentStatus[session]
+		if !hasStatus || !slices.Contains(intent.OnEntryStatus, curStatus) {
+			if wasActive {
+				plan.cancelOld = cur.cancel
+				delete(perSession, intent.Kind)
+				if len(perSession) == 0 {
+					delete(d.parent.activeProbeIntents, session)
+				}
+			}
+			break
+		}
+		paneID, senderPID, hasFrame := d.parent.lookupTopFrameForSessionLocked(session)
+		if !hasFrame || paneID == "" || senderPID == 0 {
+			if wasActive {
+				plan.cancelOld = cur.cancel
+				delete(perSession, intent.Kind)
+				if len(perSession) == 0 {
+					delete(d.parent.activeProbeIntents, session)
+				}
+			}
+			break
+		}
+		targetMatches := wasActive &&
+			cur.agentType == agentType &&
+			cur.paneID == paneID &&
+			cur.senderPID == senderPID
+		if wasActive && targetMatches {
+			// case 4: already armed correctly
+			break
+		}
+		// case 2 (!wasActive) or case 5 (target mismatch)
+		if wasActive {
+			plan.cancelOld = cur.cancel
+		}
+		generation := d.parent.nextProbeIntentGeneration()
+		ctx, cancel := context.WithCancel(d.parentCtx)
+		if perSession == nil {
+			perSession = make(map[agentpkg.ProbeIntentKind]activeIntent)
+			d.parent.activeProbeIntents[session] = perSession
+		}
+		perSession[intent.Kind] = activeIntent{
+			agentType:  agentType,
+			paneID:     paneID,
+			senderPID:  senderPID,
+			cancel:     cancel,
+			generation: generation,
+		}
+		plan.startCtx = ctx
+		plan.paneID = paneID
+		plan.senderPID = senderPID
+		plan.generation = generation
+	}
+	d.parent.mu.Unlock()
+
+	// Execute plan outside m.mu.
+	if plan.cancelOld != nil {
+		plan.cancelOld()
+	}
+	if plan.startCtx != nil {
+		out := make(chan agentpkg.Signal, 1)
+		go func() {
+			d.startDetector(plan.startCtx, d.parent, intent.Kind, plan.paneID, plan.senderPID, out)
+			close(out)
+		}()
+		go d.consumeSignals(plan.startCtx, session, agentType, intent, plan.generation, out)
+	}
+}
+
+// consumeSignals reads detector emissions, runs them through the shared
+// applyProbeGuards pipeline, and tears down the active entry on a
+// successful probe-applied transition.
+//
+// Per round 5 P1 (spec §5.4 lines 805-815): a probe that successfully
+// flips status to error/clear means OnEntryStatus no longer holds; the
+// detector goroutine has already exited (or is about to via ctx
+// cancel from the upstream re-armed lifecycle), but the active entry
+// would otherwise leak. Re-running applyStatus with the freshly applied
+// status walks lifecycle case 3 (active && !shouldActive) → cancel +
+// delete.
+func (d *probeIntentDispatcher) consumeSignals(
+	_ context.Context,
+	session, agentType string,
+	intent agentpkg.ProbeIntent,
+	generation uint64,
+	in <-chan agentpkg.Signal,
+) {
+	for sig := range in {
+		applied := applyProbeGuards(d.parent, probeGuardArgs{
+			Session:    session,
+			AgentType:  agentType,
+			Reason:     "probe-intent:" + string(intent.Kind),
+			Signal:     sig,
+			Mapping:    intent.OnSignal,
+			StaleCheck: makeProbeIntentStaleCheck(session, intent.Kind, agentType, generation),
+		})
+		if !applied {
+			continue
+		}
+		d.parent.mu.Lock()
+		appliedStatus := d.parent.currentStatus[session]
+		d.parent.mu.Unlock()
+		d.applyStatus(session, agentType, appliedStatus)
+	}
+}
+
+// makeProbeIntentStaleCheck returns the StaleCheck closure used by
+// applyProbeGuards on the ProbeIntent path. Per spec §5.4: re-checks
+// active-entry presence + agentType + generation. Caller (applyProbeGuards)
+// invokes this while holding m.mu, so the read is lock-free.
+//
+// generation guard: detector goroutine that was cancelled then a new
+// detector armed (case 5 / replay race) — old detector's queued signal
+// still in-flight will hit a different generation in the active map and
+// drop. Two-tier dedup with agentType (cross-provider switch) +
+// generation (same provider re-arm).
+func makeProbeIntentStaleCheck(
+	session string,
+	kind agentpkg.ProbeIntentKind,
+	agentType string,
+	generation uint64,
+) func(*Module) bool {
+	return func(m *Module) bool {
+		intents, ok := m.activeProbeIntents[session]
+		if !ok {
+			return false
+		}
+		cur, ok := intents[kind]
+		if !ok {
+			return false
+		}
+		return cur.agentType == agentType && cur.generation == generation
+	}
+}
+
+// probeIntentsOf returns the provider's declared ProbeIntents, or nil
+// when the provider does not implement ProbeIntentProvider. Per spec
+// §3.1: implementing the interface is optional.
+func probeIntentsOf(p agentpkg.AgentProvider) []agentpkg.ProbeIntent {
+	if pip, ok := p.(agentpkg.ProbeIntentProvider); ok {
+		return pip.ProbeIntents()
+	}
+	return nil
+}
+
+// stopAll cancels every active ProbeIntent detector and clears the map.
+// Called from Module.Stop. Locks m.mu so no concurrent applyStatus can
+// observe a partial map.
+//
+// CancelFuncs are collected under m.mu and invoked outside the lock so
+// detector goroutines that may briefly attempt re-acquisition through
+// applyProbeGuards do not deadlock.
+func (d *probeIntentDispatcher) stopAll() {
+	var toCancel []context.CancelFunc
+
+	d.parent.mu.Lock()
+	for _, perSession := range d.parent.activeProbeIntents {
+		for _, cur := range perSession {
+			toCancel = append(toCancel, cur.cancel)
+		}
+	}
+	d.parent.activeProbeIntents = make(map[string]map[agentpkg.ProbeIntentKind]activeIntent)
+	d.parent.mu.Unlock()
+
+	for _, cancel := range toCancel {
+		cancel()
+	}
+}
+
+// defaultStartProbeIntentDetector is the P1-T4 stub: blocks on ctx and
+// never emits. Existence of the goroutine still proves dispatcher
+// lifecycle (ctx cancel triggers exit + close(out) by the caller). P2-T4
+// supplies a codex-routed starter via probeIntentDispatcher.startDetector
+// instead of a package-global swap, so concurrent dispatcher tests stay
+// isolated.
+func defaultStartProbeIntentDetector(
+	ctx context.Context,
+	_ *Module,
+	_ agentpkg.ProbeIntentKind,
+	_ string,
+	_ int,
+	_ chan<- agentpkg.Signal,
+) {
+	<-ctx.Done()
+}
+

--- a/internal/module/agent/probe_intent_dispatcher_codex_wire_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_codex_wire_test.go
@@ -64,7 +64,7 @@ func TestApplyStatus_RealCodexDetector_ArmsAndStops(t *testing.T) {
 		t.Fatalf("dispatcher.startDetector unset — Module.New() did not wire the codex routing closure")
 	}
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	// After detector emits PaneAlive=true → OnSignal returns Error → guards
 	// pass → applied=true → consumeSignals invokes applyStatus(error) →
@@ -98,7 +98,7 @@ func TestApplyStatus_RealCodexDetector_PaneGone_ClearPath(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	waitFor(t, 2*time.Second, func() bool {
 		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
@@ -131,7 +131,7 @@ func TestApplyStatus_RealCodexDetector_BothAlive_NoEmit(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	// Detector polls but never emits. Wait long enough that several ticks
 	// would have happened (poll=1ms × ~50ms gives ≥40 ticks) — entry must

--- a/internal/module/agent/probe_intent_dispatcher_codex_wire_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_codex_wire_test.go
@@ -1,0 +1,173 @@
+// internal/module/agent/probe_intent_dispatcher_codex_wire_test.go
+//
+// W6-3 P2-T4: integration test for the dispatcher → codex ProcessDead
+// detector wiring set up in Module.New(). The other dispatcher_test.go
+// tests swap startDetector to a recording stub; this test deliberately
+// leaves the production wiring in place and drives the codex detector
+// via its public test seams (codex.SetIsPidAliveFnForTest +
+// codex.SetProcessDeadPollIntervalForTest) so the codex package's
+// detector goroutine actually runs end-to-end.
+package agent
+
+import (
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/codex"
+)
+
+// installCodexDetectorSeams installs the codex test seams (fast poll +
+// alive-fn override) and arranges stopAll to cancel any armed detectors
+// at test end. Cleanup ordering is LIFO: stopAll runs first → detector
+// ctx cancel propagates → seam restores run last.
+//
+// The seams use atomic primitives so a still-polling detector reading
+// the active fn concurrently with the cleanup write does not race; the
+// stopAll call here is a leak-prevention belt rather than a race-fix
+// (without it, the goroutine would keep polling until the test process
+// exits).
+func installCodexDetectorSeams(t *testing.T, m *Module, alive func(int) bool) {
+	t.Helper()
+	t.Cleanup(codex.SetProcessDeadPollIntervalForTest(time.Millisecond))
+	t.Cleanup(codex.SetIsPidAliveFnForTest(alive))
+	t.Cleanup(func() { m.probeIntentDisp.stopAll() })
+}
+
+// TestApplyStatus_RealCodexDetector_ArmsAndStops drives the full P2-T4
+// wiring: applyStatus(running) on a session with a ProcessDead-declaring
+// provider arms the dispatcher, the codex detector polls (override:
+// pid=dead, pane=alive → emit Signal{PaneAlive=true}), guards run, status
+// flips to error, and consumeSignals re-runs applyStatus(error) which
+// tears the active entry down (case 3).
+//
+// This test does NOT swap dispatcher.startDetector; it exercises the
+// production closure installed in Module.New(). The codex package's
+// isPidAliveFn is controlled via the cross-package test seam.
+func TestApplyStatus_RealCodexDetector_ArmsAndStops(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+
+	// Force the first poll tick to observe pid=dead. Seam helper orders
+	// stopAll BEFORE seam restoration to keep -race clean.
+	installCodexDetectorSeams(t, m, func(int) bool { return false })
+
+	// Register %5 in the fake tmux pane list so HasPane returns true →
+	// PaneAlive=true → OnSignal returns Error (W6-3 path).
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%5"})
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	// Sanity: the production dispatcher closure (not a stub) is in place.
+	if m.probeIntentDisp.startDetector == nil {
+		t.Fatalf("dispatcher.startDetector unset — Module.New() did not wire the codex routing closure")
+	}
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	// After detector emits PaneAlive=true → OnSignal returns Error → guards
+	// pass → applied=true → consumeSignals invokes applyStatus(error) →
+	// case 3 (active && !shouldActive) tears down the active entry.
+	waitFor(t, 2*time.Second, func() bool {
+		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return !ok
+	}, "active entry torn down after real codex detector emits")
+
+	m.mu.Lock()
+	got := m.currentStatus["work"]
+	m.mu.Unlock()
+	if got != agentpkg.StatusError {
+		t.Fatalf("currentStatus = %q, want error after real codex detector emit", got)
+	}
+}
+
+// TestApplyStatus_RealCodexDetector_PaneGone_ClearPath drives the W6-4
+// path through the same production wiring: pid dead + pane gone →
+// PaneAlive=false → OnSignal returns Clear → status flips to clear,
+// active entry torn down.
+func TestApplyStatus_RealCodexDetector_PaneGone_ClearPath(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+
+	installCodexDetectorSeams(t, m, func(int) bool { return false })
+
+	// Pane list intentionally OMITS %5 — HasPane(%5)=false → PaneAlive=false.
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%9"})
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	waitFor(t, 2*time.Second, func() bool {
+		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return !ok
+	}, "active entry torn down after real codex detector emits clear")
+
+	m.mu.Lock()
+	got := m.currentStatus["work"]
+	m.mu.Unlock()
+	if got != agentpkg.StatusClear {
+		t.Fatalf("currentStatus = %q, want clear after real codex detector emit (pane gone)", got)
+	}
+}
+
+// TestApplyStatus_RealCodexDetector_BothAlive_NoEmit confirms the
+// detector keeps polling without emitting when both pid and pane are
+// alive: the active entry persists, currentStatus stays running.
+//
+// This is the negative case that complements the two emit-path tests
+// above — the codex routing closure is exercised but the inner detector
+// does not produce a signal.
+func TestApplyStatus_RealCodexDetector_BothAlive_NoEmit(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+
+	installCodexDetectorSeams(t, m, func(int) bool { return true })
+
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%5"})
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	// Detector polls but never emits. Wait long enough that several ticks
+	// would have happened (poll=1ms × ~50ms gives ≥40 ticks) — entry must
+	// remain armed and currentStatus untouched.
+	time.Sleep(50 * time.Millisecond)
+
+	cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if !ok {
+		t.Fatalf("active entry torn down despite both alive — should remain armed")
+	}
+	if cur.agentType != "codex" || cur.paneID != "%5" || cur.senderPID != 4242 {
+		t.Fatalf("active entry mutated unexpectedly: %+v", cur)
+	}
+	m.mu.Lock()
+	got := m.currentStatus["work"]
+	m.mu.Unlock()
+	if got != agentpkg.StatusRunning {
+		t.Fatalf("currentStatus = %q, want running (no signal applied)", got)
+	}
+	// stopAll runs in installCodexDetectorSeams' Cleanup before the seam
+	// restorations.
+}
+
+// getFakeTmux returns the FakeExecutor backing m.tmux, or false when the
+// test module didn't install one. Helper extracted so the wire tests
+// don't repeat the type assertion + nil-check pattern.
+func getFakeTmux(t *testing.T, m *Module) (interface {
+	SetPanes(paneIDs []string)
+}, bool) {
+	t.Helper()
+	type setter interface {
+		SetPanes(paneIDs []string)
+	}
+	if m.tmux == nil {
+		return nil, false
+	}
+	s, ok := m.tmux.(setter)
+	return s, ok
+}

--- a/internal/module/agent/probe_intent_dispatcher_codex_wire_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_codex_wire_test.go
@@ -64,7 +64,7 @@ func TestApplyStatus_RealCodexDetector_ArmsAndStops(t *testing.T) {
 		t.Fatalf("dispatcher.startDetector unset — Module.New() did not wire the codex routing closure")
 	}
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	// After detector emits PaneAlive=true → OnSignal returns Error → guards
 	// pass → applied=true → consumeSignals invokes applyStatus(error) →
@@ -98,7 +98,7 @@ func TestApplyStatus_RealCodexDetector_PaneGone_ClearPath(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	waitFor(t, 2*time.Second, func() bool {
 		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
@@ -131,7 +131,7 @@ func TestApplyStatus_RealCodexDetector_BothAlive_NoEmit(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	// Detector polls but never emits. Wait long enough that several ticks
 	// would have happened (poll=1ms × ~50ms gives ≥40 ticks) — entry must

--- a/internal/module/agent/probe_intent_dispatcher_drift_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_drift_test.go
@@ -1,0 +1,179 @@
+// internal/module/agent/probe_intent_dispatcher_drift_test.go
+//
+// W6-3 P2-T5 drift coverage for ProbeIntent providers.
+//
+// Three guards make sure the ProbeIntent surface stays internally
+// consistent as future agent providers add intents (W6-4 / W6-1 / W6-2 /
+// W6-6 will all extend this set):
+//
+//  1. Drift coverage — every registered provider that implements
+//     ProbeIntentProvider declares at least one well-formed intent
+//     (OnEntryStatus non-empty + OnSignal non-nil) and every declared
+//     Kind has a dispatcher case wired.
+//
+//  2. Dispatcher routing — every declared Kind is in the wiredKinds set
+//     this test maintains as a mirror of Module.New()'s startDetector
+//     switch. Missing case = drift signal at PR-review time; reviewers
+//     bump wiredKinds in lockstep with the production switch.
+//
+//  3. ProbeIntent shape — for every provider that implements the
+//     interface, ProbeIntents() returns a contract-shaped slice
+//     (OnSignal non-nil + OnEntryStatus non-empty). Empty slice is
+//     acceptable (a provider may declare zero intents) but a single
+//     malformed entry fails.
+//
+// The wiredKinds set MUST stay in sync with internal/module/agent/module.go
+// New()'s startDetector closure. Adding a new Kind without updating both is
+// the canonical drift bug this test guards against.
+package agent
+
+import (
+	"sync"
+	"testing"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/cc"
+	"github.com/wake/purdex/internal/agent/codex"
+	"github.com/wake/purdex/internal/agent/opencode"
+)
+
+// wiredKinds is the set of ProbeIntentKind values for which Module.New()
+// installs a dispatch case in its startDetector closure. Bump this set in
+// lockstep with the production switch in module.go — drift on either side
+// trips TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase.
+//
+// W6-3 first PR scope: only ProcessDead. W6-4 / W6-1 / W6-2 / W6-6 add
+// more entries here as they land.
+var wiredKinds = map[agentpkg.ProbeIntentKind]struct{}{
+	agentpkg.ProbeIntentKindProcessDead: {},
+}
+
+// productionRegistry constructs a registry mirroring what Module.Init()
+// would register on a real daemon, without depending on core.Core wiring.
+// Used by the drift tests so they walk the production surface (cc + codex
+// + opencode) rather than a tailored fixture.
+func productionRegistry(t *testing.T) *agentpkg.Registry {
+	t.Helper()
+	r := agentpkg.NewRegistry()
+	// cc.NewProvider tolerates nil prober/tmux/cfg/cfgMu for tests where the
+	// hook installer / readiness paths are not exercised — see
+	// cc/provider_test.go for prior art. Same is true for codex.NewProvider
+	// (no args) and opencode.NewProvider (no args).
+	r.Register(cc.NewProvider(nil, nil, nil, &sync.RWMutex{}))
+	r.Register(codex.NewProvider())
+	r.Register(opencode.NewProvider())
+	return r
+}
+
+// TestProbeIntentDriftCoverage walks every production provider and
+// verifies any ProbeIntent it declares is fully wired:
+//   - OnEntryStatus is non-empty (otherwise the lifecycle helper would
+//     never gate active=true and the intent would be dead code)
+//   - OnSignal is non-nil (dispatcher's applyProbeGuards invokes it as
+//     mapping callback; nil would crash production)
+//   - Kind appears in wiredKinds (i.e. Module.New()'s startDetector
+//     switch has a case for it)
+//
+// At least one provider must declare ProbeIntentProvider so the suite
+// proves it is exercising real surface, not a vacuous loop. Today only
+// codex satisfies the interface; cc and opencode return false on the
+// type assertion and are skipped.
+func TestProbeIntentDriftCoverage(t *testing.T) {
+	r := productionRegistry(t)
+	providers := r.All()
+	if len(providers) == 0 {
+		t.Fatalf("productionRegistry returned no providers — registry surface broken")
+	}
+	implementers := 0
+	for _, p := range providers {
+		pip, ok := p.(agentpkg.ProbeIntentProvider)
+		if !ok {
+			continue
+		}
+		implementers++
+		intents := pip.ProbeIntents()
+		// A provider that implements the interface but returns no intents
+		// is allowed — but the case is suspicious enough to flag as info
+		// (no failure). Future PRs that add a new ProbeIntentProvider
+		// stub will surface here until they wire intents.
+		if len(intents) == 0 {
+			t.Logf("provider %q implements ProbeIntentProvider but declares zero intents — verify intentional", p.Type())
+			continue
+		}
+		for _, intent := range intents {
+			if len(intent.OnEntryStatus) == 0 {
+				t.Errorf("provider %q intent Kind=%q: OnEntryStatus is empty — lifecycle would never arm", p.Type(), intent.Kind)
+			}
+			if intent.OnSignal == nil {
+				t.Errorf("provider %q intent Kind=%q: OnSignal is nil — dispatcher would crash on signal mapping", p.Type(), intent.Kind)
+			}
+			if _, ok := wiredKinds[intent.Kind]; !ok {
+				t.Errorf("provider %q declares Kind=%q but Module.New()'s startDetector switch has no case for it (wiredKinds drift) — add the case + bump wiredKinds in this test in lockstep", p.Type(), intent.Kind)
+			}
+		}
+	}
+	if implementers == 0 {
+		t.Fatalf("no production provider implements ProbeIntentProvider — drift suite is vacuous; expected at least codex")
+	}
+}
+
+// TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase is the focused
+// dispatcher-routing guard. It collects every declared Kind across the
+// production registry and asserts the set is a subset of wiredKinds.
+// Failure here means a provider added a Kind constant + ProbeIntent slot
+// without bumping Module.New()'s switch.
+func TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase(t *testing.T) {
+	r := productionRegistry(t)
+	declared := make(map[agentpkg.ProbeIntentKind][]string) // kind → providers declaring it
+	for _, p := range r.All() {
+		pip, ok := p.(agentpkg.ProbeIntentProvider)
+		if !ok {
+			continue
+		}
+		for _, intent := range pip.ProbeIntents() {
+			declared[intent.Kind] = append(declared[intent.Kind], p.Type())
+		}
+	}
+	if len(declared) == 0 {
+		t.Fatalf("no provider declares any ProbeIntent — drift suite is vacuous")
+	}
+	for kind, providers := range declared {
+		if _, ok := wiredKinds[kind]; !ok {
+			t.Errorf("Kind=%q declared by providers=%v but missing from wiredKinds (Module.New() switch); add a case + bump wiredKinds together", kind, providers)
+		}
+	}
+}
+
+// TestProbeIntentDrift_OnSignalNonNil_OnEntryStatusNonEmpty isolates the
+// minimum-shape contract: every declared intent must have a non-nil
+// OnSignal mapping function and a non-empty OnEntryStatus gate. These
+// are independent of dispatcher routing — even a Kind that's wired
+// would still crash the dispatcher / never arm if either invariant
+// breaks.
+//
+// Companion to TestProbeIntentDriftCoverage; this one fails fast on the
+// minimal contract regardless of routing wiring, so a regression that
+// nukes wiredKinds at the same time as a malformed intent surfaces both
+// signals to the reviewer rather than just the routing one.
+func TestProbeIntentDrift_OnSignalNonNil_OnEntryStatusNonEmpty(t *testing.T) {
+	r := productionRegistry(t)
+	any := false
+	for _, p := range r.All() {
+		pip, ok := p.(agentpkg.ProbeIntentProvider)
+		if !ok {
+			continue
+		}
+		for _, intent := range pip.ProbeIntents() {
+			any = true
+			if intent.OnSignal == nil {
+				t.Errorf("provider %q kind=%q has nil OnSignal — dispatcher applyProbeGuards mapping callback would crash", p.Type(), intent.Kind)
+			}
+			if len(intent.OnEntryStatus) == 0 {
+				t.Errorf("provider %q kind=%q has empty OnEntryStatus — lifecycle helper would never gate active=true so intent is dead code", p.Type(), intent.Kind)
+			}
+		}
+	}
+	if !any {
+		t.Fatalf("zero ProbeIntent declarations across the production registry — suite is vacuous")
+	}
+}

--- a/internal/module/agent/probe_intent_dispatcher_drift_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_drift_test.go
@@ -11,10 +11,10 @@
 //     (OnEntryStatus non-empty + OnSignal non-nil) and every declared
 //     Kind has a dispatcher case wired.
 //
-//  2. Dispatcher routing — every declared Kind is in the wiredKinds set
-//     this test maintains as a mirror of Module.New()'s startDetector
-//     switch. Missing case = drift signal at PR-review time; reviewers
-//     bump wiredKinds in lockstep with the production switch.
+//  2. Dispatcher routing — every declared Kind appears in the production
+//     supportedKinds map (Module.New()-populated). Missing case = drift
+//     signal at PR-review time; per audit F6 the lifecycle fail-closes
+//     for unwired kinds, but this test catches the drift earlier.
 //
 //  3. ProbeIntent shape — for every provider that implements the
 //     interface, ProbeIntents() returns a contract-shaped slice
@@ -22,9 +22,9 @@
 //     acceptable (a provider may declare zero intents) but a single
 //     malformed entry fails.
 //
-// The wiredKinds set MUST stay in sync with internal/module/agent/module.go
-// New()'s startDetector closure. Adding a new Kind without updating both is
-// the canonical drift bug this test guards against.
+// supportedKinds is read from a freshly-constructed Module via
+// productionSupportedKinds(t); this exercises the production routing
+// directly rather than maintaining a hand-written mirror in the test.
 package agent
 
 import (
@@ -71,8 +71,8 @@ func productionRegistry(t *testing.T) *agentpkg.Registry {
 //     never gate active=true and the intent would be dead code)
 //   - OnSignal is non-nil (dispatcher's applyProbeGuards invokes it as
 //     mapping callback; nil would crash production)
-//   - Kind appears in wiredKinds (i.e. Module.New()'s startDetector
-//     switch has a case for it)
+//   - Kind appears in production supportedKinds (i.e. Module.New()'s
+//     startDetector switch + supportedKinds map have it wired)
 //
 // At least one provider must declare ProbeIntentProvider so the suite
 // proves it is exercising real surface, not a vacuous loop. Today only
@@ -161,8 +161,8 @@ func TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase(t *testing.T) {
 //
 // Companion to TestProbeIntentDriftCoverage; this one fails fast on the
 // minimal contract regardless of routing wiring, so a regression that
-// nukes wiredKinds at the same time as a malformed intent surfaces both
-// signals to the reviewer rather than just the routing one.
+// nukes a production wiring at the same time as a malformed intent surfaces
+// both signals to the reviewer rather than just the routing one.
 func TestProbeIntentDrift_OnSignalNonNil_OnEntryStatusNonEmpty(t *testing.T) {
 	r := productionRegistry(t)
 	any := false

--- a/internal/module/agent/probe_intent_dispatcher_drift_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_drift_test.go
@@ -37,15 +37,15 @@ import (
 	"github.com/wake/purdex/internal/agent/opencode"
 )
 
-// wiredKinds is the set of ProbeIntentKind values for which Module.New()
-// installs a dispatch case in its startDetector closure. Bump this set in
-// lockstep with the production switch in module.go — drift on either side
-// trips TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase.
-//
-// W6-3 first PR scope: only ProcessDead. W6-4 / W6-1 / W6-2 / W6-6 add
-// more entries here as they land.
-var wiredKinds = map[agentpkg.ProbeIntentKind]struct{}{
-	agentpkg.ProbeIntentKindProcessDead: {},
+// productionSupportedKinds reads the actual supportedKinds map populated
+// by Module.New() — the production routing source of truth. Per audit F6:
+// the drift test must exercise production routing rather than a hand-
+// written mirror, so a missing wire surfaces as a real fail-closed
+// branch in lifecycle, not as a stale test fixture.
+func productionSupportedKinds(t *testing.T) map[agentpkg.ProbeIntentKind]struct{} {
+	t.Helper()
+	m := newTestModule(t) // calls Module.New, populates probeIntentDisp.supportedKinds
+	return m.probeIntentDisp.supportedKinds
 }
 
 // productionRegistry constructs a registry mirroring what Module.Init()
@@ -79,6 +79,7 @@ func productionRegistry(t *testing.T) *agentpkg.Registry {
 // codex satisfies the interface; cc and opencode return false on the
 // type assertion and are skipped.
 func TestProbeIntentDriftCoverage(t *testing.T) {
+	wired := productionSupportedKinds(t)
 	r := productionRegistry(t)
 	providers := r.All()
 	if len(providers) == 0 {
@@ -107,8 +108,8 @@ func TestProbeIntentDriftCoverage(t *testing.T) {
 			if intent.OnSignal == nil {
 				t.Errorf("provider %q intent Kind=%q: OnSignal is nil — dispatcher would crash on signal mapping", p.Type(), intent.Kind)
 			}
-			if _, ok := wiredKinds[intent.Kind]; !ok {
-				t.Errorf("provider %q declares Kind=%q but Module.New()'s startDetector switch has no case for it (wiredKinds drift) — add the case + bump wiredKinds in this test in lockstep", p.Type(), intent.Kind)
+			if _, ok := wired[intent.Kind]; !ok {
+				t.Errorf("provider %q declares Kind=%q but Module.New()'s supportedKinds map (production routing) has no entry for it — add a switch case in startDetector + add the kind to supportedKinds together (audit F6 fail-closed contract)", p.Type(), intent.Kind)
 			}
 		}
 	}
@@ -119,10 +120,17 @@ func TestProbeIntentDriftCoverage(t *testing.T) {
 
 // TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase is the focused
 // dispatcher-routing guard. It collects every declared Kind across the
-// production registry and asserts the set is a subset of wiredKinds.
-// Failure here means a provider added a Kind constant + ProbeIntent slot
-// without bumping Module.New()'s switch.
+// production registry and asserts the set is a subset of the production
+// supportedKinds map (Module.New()-populated). Failure here means a
+// provider added a Kind constant + ProbeIntent slot without extending
+// both the startDetector switch AND supportedKinds in lockstep.
+//
+// Per audit F6: this exercises real production routing rather than a
+// hand-written wiredKinds mirror — a missing wire surfaces as
+// fail-closed in the production lifecycle (TestApplyIntentLifecycle_
+// UnsupportedKind_FailsClosed pins that branch directly).
 func TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase(t *testing.T) {
+	wired := productionSupportedKinds(t)
 	r := productionRegistry(t)
 	declared := make(map[agentpkg.ProbeIntentKind][]string) // kind → providers declaring it
 	for _, p := range r.All() {
@@ -138,8 +146,8 @@ func TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase(t *testing.T) {
 		t.Fatalf("no provider declares any ProbeIntent — drift suite is vacuous")
 	}
 	for kind, providers := range declared {
-		if _, ok := wiredKinds[kind]; !ok {
-			t.Errorf("Kind=%q declared by providers=%v but missing from wiredKinds (Module.New() switch); add a case + bump wiredKinds together", kind, providers)
+		if _, ok := wired[kind]; !ok {
+			t.Errorf("Kind=%q declared by providers=%v but missing from production supportedKinds (Module.New() switch + supportedKinds map); add a case + add to supportedKinds together — audit F6 fail-closed", kind, providers)
 		}
 	}
 }

--- a/internal/module/agent/probe_intent_dispatcher_integration_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_integration_test.go
@@ -112,7 +112,7 @@ func TestIntegration_CodexProcessDead_PaneAlive_BroadcastsError(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
 	if got.Status != string(agentpkg.StatusError) {
@@ -142,7 +142,7 @@ func TestIntegration_CodexProcessDead_PaneGone_BroadcastsClear(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
 	if got.Status != string(agentpkg.StatusClear) {
@@ -179,7 +179,7 @@ func TestIntegration_CodexNormalExit_NoErrorBroadcast(t *testing.T) {
 	m.currentStatus["work"] = agentpkg.StatusIdle
 	m.mu.Unlock()
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle)
 
 	// Active entry must remain absent.
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
@@ -216,7 +216,7 @@ func TestIntegration_CodexRestart_ActiveTargetMismatch_ReArms(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	cur1, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 	if !ok {
@@ -246,7 +246,7 @@ func TestIntegration_CodexRestart_ActiveTargetMismatch_ReArms(t *testing.T) {
 	// Now flip pid=dead so the new detector emits on its first tick.
 	codex.SetIsPidAliveFnForTest(func(int) bool { return false })
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
 	if got.Status != string(agentpkg.StatusError) {
@@ -291,7 +291,7 @@ func TestIntegration_AgentSwitchCodexToCC_OldDetectorTornDown(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); !ok {
 		t.Fatalf("codex detector did not arm")
 	}
@@ -299,7 +299,7 @@ func TestIntegration_AgentSwitchCodexToCC_OldDetectorTornDown(t *testing.T) {
 	// Register a cc provider with no ProbeIntents; switch the session top
 	// agent to it. reconcileSessionActive should drop the codex entry.
 	m.registry.Register(&fakeAgentProvider{typeName: "cc-noprobes"})
-	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning)
 
 	waitFor(t, time.Second, func() bool {
 		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)

--- a/internal/module/agent/probe_intent_dispatcher_integration_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_integration_test.go
@@ -1,0 +1,377 @@
+// internal/module/agent/probe_intent_dispatcher_integration_test.go
+//
+// W6-3 P2-T7: end-to-end integration test for the ProbeIntent pipeline:
+// production codex ProcessDead detector + dispatcher + applyProbeGuards +
+// core.Events broadcast. Each test wires a Module with a real
+// EventsBroadcaster, drives the codex detector via cross-package test
+// seams (codex.SetIsPidAliveFnForTest + codex.SetProcessDeadPollIntervalForTest),
+// and asserts the broadcast envelope SPA clients would observe.
+//
+// Tests in this file are independent — every test owns its own Module +
+// subscriber and uses t.Cleanup for teardown. installCodexDetectorSeams
+// orders stopAll → seam restoration so detector goroutines exit before the
+// test process unwinds the seams (race-clean).
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/codex"
+	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/session"
+	"github.com/wake/purdex/internal/store"
+	"github.com/wake/purdex/internal/tmux"
+)
+
+// wireBroadcastSubscriber installs a core.Core with a fresh EventsBroadcaster
+// on the module and registers a test subscriber whose channel the test will
+// drain. The subscriber is removed via t.Cleanup so concurrent tests don't
+// leak through the package-global Module construction. Returns the
+// subscriber for direct channel reads.
+func wireBroadcastSubscriber(t *testing.T, m *Module) *core.EventSubscriber {
+	t.Helper()
+	fakeTmux, ok := m.tmux.(*tmux.FakeExecutor)
+	if !ok {
+		t.Fatalf("expected fake tmux executor, got %T", m.tmux)
+	}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.sessions = &fakeSessionProvider{
+		sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}},
+	}
+	sub := m.core.Events.AddTestSubscriber()
+	t.Cleanup(func() { m.core.Events.RemoveTestSubscriber(sub) })
+	return sub
+}
+
+// readBroadcastNormalized waits up to dur for one broadcast envelope and
+// decodes the inner NormalizedEvent payload. Fatals on timeout or unmarshal
+// failure. Caller passes the expected session code so the assertion stays
+// near the expectation site.
+func readBroadcastNormalized(t *testing.T, sub *core.EventSubscriber, dur time.Duration, wantSessionCode string) agentpkg.NormalizedEvent {
+	t.Helper()
+	select {
+	case msg := <-sub.SendCh():
+		var env struct {
+			Type    string `json:"type"`
+			Session string `json:"session"`
+			Value   string `json:"value"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			t.Fatalf("unmarshal envelope: %v (raw: %s)", err, string(msg))
+		}
+		if env.Type != "hook" {
+			t.Fatalf("envelope type = %q, want hook", env.Type)
+		}
+		if env.Session != wantSessionCode {
+			t.Fatalf("envelope session = %q, want %q", env.Session, wantSessionCode)
+		}
+		var normalized agentpkg.NormalizedEvent
+		if err := json.Unmarshal([]byte(env.Value), &normalized); err != nil {
+			t.Fatalf("unmarshal normalized: %v (raw: %s)", err, env.Value)
+		}
+		return normalized
+	case <-time.After(dur):
+		t.Fatalf("timed out waiting for broadcast")
+	}
+	return agentpkg.NormalizedEvent{}
+}
+
+// expectNoBroadcast asserts no broadcast envelope arrives within dur. Used by
+// negative-case tests (idle session, dispatcher tear-down) where any
+// emission would indicate a regression.
+func expectNoBroadcast(t *testing.T, sub *core.EventSubscriber, dur time.Duration) {
+	t.Helper()
+	select {
+	case msg := <-sub.SendCh():
+		t.Fatalf("unexpected broadcast within %v: %s", dur, string(msg))
+	case <-time.After(dur):
+		// expected: no broadcast
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 1. ProcessDead, pane alive → broadcast error
+// -----------------------------------------------------------------------------
+
+// TestIntegration_CodexProcessDead_PaneAlive_BroadcastsError covers the W6-3
+// canonical path: codex pid dies while its pane survives. The production
+// detector polls (override pid=dead, fake tmux retains the pane id) → emits
+// Signal{PaneAlive=true} → applyProbeGuards flips status to error and
+// broadcasts a NormalizedEvent on the session WS channel.
+func TestIntegration_CodexProcessDead_PaneAlive_BroadcastsError(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	sub := wireBroadcastSubscriber(t, m)
+
+	// pid dead + pane alive → PaneAlive=true → OnSignal → StatusError.
+	installCodexDetectorSeams(t, m, func(int) bool { return false })
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%5"})
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
+	if got.Status != string(agentpkg.StatusError) {
+		t.Fatalf("normalized.Status = %q, want %q", got.Status, agentpkg.StatusError)
+	}
+	if got.AgentType != "codex" {
+		t.Fatalf("normalized.AgentType = %q, want codex", got.AgentType)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 2. ProcessDead, pane gone → broadcast clear
+// -----------------------------------------------------------------------------
+
+// TestIntegration_CodexProcessDead_PaneGone_BroadcastsClear covers the W6-4
+// path: codex pid dies AND its pane has already been closed. The production
+// detector emits Signal{PaneAlive=false} → OnSignal → StatusClear → broadcast
+// envelope status=clear.
+func TestIntegration_CodexProcessDead_PaneGone_BroadcastsClear(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	sub := wireBroadcastSubscriber(t, m)
+
+	installCodexDetectorSeams(t, m, func(int) bool { return false })
+	// pane list intentionally OMITS %5 → HasPane(%5)=false → PaneAlive=false.
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%9"})
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
+	if got.Status != string(agentpkg.StatusClear) {
+		t.Fatalf("normalized.Status = %q, want %q", got.Status, agentpkg.StatusClear)
+	}
+	if got.AgentType != "codex" {
+		t.Fatalf("normalized.AgentType = %q, want codex", got.AgentType)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 3. Idle session → ProbeIntent not armed → no broadcast
+// -----------------------------------------------------------------------------
+
+// TestIntegration_CodexNormalExit_NoErrorBroadcast pins the gating contract:
+// when applyStatus runs with StatusIdle (not in OnEntryStatus = {Running,
+// Waiting}), the dispatcher does NOT arm a detector even if pid is dead. No
+// broadcast is emitted. Validates the negative case via select+timeout.
+func TestIntegration_CodexNormalExit_NoErrorBroadcast(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	sub := wireBroadcastSubscriber(t, m)
+
+	// Even if a hypothetical detector polled, pid=dead — but lifecycle
+	// gating means the detector never starts because Idle ∉ OnEntryStatus.
+	installCodexDetectorSeams(t, m, func(int) bool { return false })
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%5"})
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+	// Override seedRunningFrame's Running default with Idle: applyStatus
+	// reads currentStatus inside applyIntentLifecycle so this is the single
+	// source of truth for the lifecycle decision.
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle)
+
+	// Active entry must remain absent.
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("active entry present for idle session, want absent")
+	}
+	// And no broadcast within a generous window.
+	expectNoBroadcast(t, sub, 100*time.Millisecond)
+}
+
+// -----------------------------------------------------------------------------
+// 4. Active target mismatch (lifecycle case 5) → cancel + re-arm
+// -----------------------------------------------------------------------------
+
+// TestIntegration_CodexRestart_ActiveTargetMismatch_ReArms exercises lifecycle
+// case 5 with the production codex detector wiring. First arm targets
+// senderPID=4242; replacing the top frame with senderPID=5555 (codex restarted
+// in the same pane) forces a cancel + re-arm with a fresh generation. The new
+// detector then emits PaneAlive=true (pid=dead override) → broadcast carries
+// Status=error.
+func TestIntegration_CodexRestart_ActiveTargetMismatch_ReArms(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	sub := wireBroadcastSubscriber(t, m)
+
+	// First arm window: pid alive so the detector keeps polling without
+	// emitting; then we flip pid=dead via SetIsPidAliveFnForTest before the
+	// re-arm so only the second detector emits.
+	t.Cleanup(codex.SetProcessDeadPollIntervalForTest(time.Millisecond))
+	aliveRestore := codex.SetIsPidAliveFnForTest(func(int) bool { return true })
+	t.Cleanup(aliveRestore)
+	t.Cleanup(func() { m.probeIntentDisp.stopAll() })
+
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%5"})
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	cur1, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if !ok {
+		t.Fatalf("first arm did not record active entry")
+	}
+	if cur1.senderPID != 4242 {
+		t.Fatalf("first arm senderPID = %d, want 4242", cur1.senderPID)
+	}
+
+	// Simulate codex restart: same pane, new sender PID. Insert a later
+	// frame so projection picks it as TopFrame.
+	if _, err := m.frames.Upsert(store.Frame{
+		FrameID:          "frame-work-codex-restart",
+		PaneID:           "%5",
+		AgentType:        "codex",
+		PID:              5555,
+		PPID:             1,
+		ProcessStartTime: "Sun Apr 20 02:30:00 2026",
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        200,
+		LastSeenAt:       220,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert restart frame: %v", err)
+	}
+
+	// Now flip pid=dead so the new detector emits on its first tick.
+	codex.SetIsPidAliveFnForTest(func(int) bool { return false })
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
+	if got.Status != string(agentpkg.StatusError) {
+		t.Fatalf("normalized.Status = %q, want %q after re-arm", got.Status, agentpkg.StatusError)
+	}
+
+	// After the new detector emits + applyProbeGuards applies, consumeSignals
+	// re-runs applyStatus(error) → case 3 tears down the active entry.
+	waitFor(t, 2*time.Second, func() bool {
+		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return !ok
+	}, "active entry torn down after re-armed detector emits")
+
+	// Sanity: the generation changed across the re-arm. We can't read the
+	// post-teardown generation directly (entry is gone), but the broadcast
+	// proves the re-armed (5555) detector — not the stale (4242) one — was
+	// the source.
+}
+
+// -----------------------------------------------------------------------------
+// 5. Cross-provider switch (codex → cc) → reconcile tears down stale entry
+// -----------------------------------------------------------------------------
+
+// TestIntegration_AgentSwitchCodexToCC_OldDetectorTornDown verifies the
+// cross-provider reconcile path: applyStatus("work", "codex") arms the
+// ProcessDead detector; switching to a "cc" provider that declares NO
+// ProbeIntents triggers reconcileSessionActive to drop the stale codex entry,
+// even though the cc lifecycle never starts a new detector. The codex
+// detector ctx is canceled (no broadcast emitted from the abandoned poll).
+func TestIntegration_AgentSwitchCodexToCC_OldDetectorTornDown(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	sub := wireBroadcastSubscriber(t, m)
+
+	// Keep pid alive while codex is armed; the codex detector then has no
+	// reason to emit before reconcile cancels it.
+	t.Cleanup(codex.SetProcessDeadPollIntervalForTest(time.Millisecond))
+	t.Cleanup(codex.SetIsPidAliveFnForTest(func(int) bool { return true }))
+	t.Cleanup(func() { m.probeIntentDisp.stopAll() })
+
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%5"})
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); !ok {
+		t.Fatalf("codex detector did not arm")
+	}
+
+	// Register a cc provider with no ProbeIntents; switch the session top
+	// agent to it. reconcileSessionActive should drop the codex entry.
+	m.registry.Register(&fakeAgentProvider{typeName: "cc-noprobes"})
+	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning)
+
+	waitFor(t, time.Second, func() bool {
+		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return !ok
+	}, "codex active entry torn down after cross-provider switch")
+
+	// No broadcast should arrive — the codex detector was canceled before it
+	// could emit, and cc declares no intents.
+	expectNoBroadcast(t, sub, 100*time.Millisecond)
+}
+
+// -----------------------------------------------------------------------------
+// 6. Replay path, real detector, pane gone → broadcast clear
+// -----------------------------------------------------------------------------
+
+// TestIntegration_ReplayWithRealDetector_PaneGone_BroadcastsClear simulates a
+// daemon-restart recovery (per plan-review P1-2): hydrated state has the codex
+// frame.pid stored, the pane has already been closed, and currentStatus is
+// Running. replayStatus walks the session and arms the production codex
+// detector, which observes pid=dead + pane=gone on its first tick → emits
+// Signal{PaneAlive=false} → broadcast Status=clear.
+func TestIntegration_ReplayWithRealDetector_PaneGone_BroadcastsClear(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	sub := wireBroadcastSubscriber(t, m)
+
+	installCodexDetectorSeams(t, m, func(int) bool { return false })
+	// Pane list OMITS %5 → HasPane(%5)=false → PaneAlive=false.
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%9"})
+	}
+	// Hydrate the way replayFromDB would: frame + currentStatus=Running.
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	// Drive replayStatus directly — equivalent to the Module.Start step
+	// after replayFromDB + startSweep have hydrated state.
+	m.probeIntentDisp.replayStatus()
+
+	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
+	if got.Status != string(agentpkg.StatusClear) {
+		t.Fatalf("normalized.Status = %q, want %q (replay pane-gone path)", got.Status, agentpkg.StatusClear)
+	}
+	if got.AgentType != "codex" {
+		t.Fatalf("normalized.AgentType = %q, want codex", got.AgentType)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 7. Replay path, real detector, pane alive → broadcast error
+// -----------------------------------------------------------------------------
+
+// TestIntegration_ReplayWithRealDetector_PaneAlive_BroadcastsError mirrors #6
+// but the pane survived the daemon restart. Real detector emits
+// Signal{PaneAlive=true} → broadcast Status=error. Together with #6 these
+// two tests pin the canonical issue-#698 fix: a daemon restart correctly
+// re-evaluates ProbeIntent gating against live state, no hook required.
+func TestIntegration_ReplayWithRealDetector_PaneAlive_BroadcastsError(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	sub := wireBroadcastSubscriber(t, m)
+
+	installCodexDetectorSeams(t, m, func(int) bool { return false })
+	if fake, ok := getFakeTmux(t, m); ok {
+		fake.SetPanes([]string{"%5"})
+	}
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.replayStatus()
+
+	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
+	if got.Status != string(agentpkg.StatusError) {
+		t.Fatalf("normalized.Status = %q, want %q (replay pane-alive path)", got.Status, agentpkg.StatusError)
+	}
+	if got.AgentType != "codex" {
+		t.Fatalf("normalized.AgentType = %q, want codex", got.AgentType)
+	}
+}

--- a/internal/module/agent/probe_intent_dispatcher_integration_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_integration_test.go
@@ -112,7 +112,7 @@ func TestIntegration_CodexProcessDead_PaneAlive_BroadcastsError(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
 	if got.Status != string(agentpkg.StatusError) {
@@ -142,7 +142,7 @@ func TestIntegration_CodexProcessDead_PaneGone_BroadcastsClear(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
 	if got.Status != string(agentpkg.StatusClear) {
@@ -179,7 +179,7 @@ func TestIntegration_CodexNormalExit_NoErrorBroadcast(t *testing.T) {
 	m.currentStatus["work"] = agentpkg.StatusIdle
 	m.mu.Unlock()
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle, nil)
 
 	// Active entry must remain absent.
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
@@ -216,7 +216,7 @@ func TestIntegration_CodexRestart_ActiveTargetMismatch_ReArms(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	cur1, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 	if !ok {
@@ -246,7 +246,7 @@ func TestIntegration_CodexRestart_ActiveTargetMismatch_ReArms(t *testing.T) {
 	// Now flip pid=dead so the new detector emits on its first tick.
 	codex.SetIsPidAliveFnForTest(func(int) bool { return false })
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	got := readBroadcastNormalized(t, sub, 2*time.Second, "code-work")
 	if got.Status != string(agentpkg.StatusError) {
@@ -291,7 +291,7 @@ func TestIntegration_AgentSwitchCodexToCC_OldDetectorTornDown(t *testing.T) {
 	}
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); !ok {
 		t.Fatalf("codex detector did not arm")
 	}
@@ -299,7 +299,7 @@ func TestIntegration_AgentSwitchCodexToCC_OldDetectorTornDown(t *testing.T) {
 	// Register a cc provider with no ProbeIntents; switch the session top
 	// agent to it. reconcileSessionActive should drop the codex entry.
 	m.registry.Register(&fakeAgentProvider{typeName: "cc-noprobes"})
-	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning, nil)
 
 	waitFor(t, time.Second, func() bool {
 		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)

--- a/internal/module/agent/probe_intent_dispatcher_observability_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_observability_test.go
@@ -311,7 +311,7 @@ func TestProbeIntent_Expvar_DroppedCounterByReason(t *testing.T) {
 		m.sessions = &fakeSessionProvider{}
 		// active map empty → StaleCheck returns false on first lock.
 		before := snapshotProbeIntentMetrics()
-		applied := applyProbeGuards(m, probeGuardArgs{
+		applied, _ := applyProbeGuards(m, probeGuardArgs{
 			Session:   "work",
 			AgentType: "codex",
 			Reason:    "probe-intent:process_dead",

--- a/internal/module/agent/probe_intent_dispatcher_observability_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_observability_test.go
@@ -271,6 +271,7 @@ type probeIntentMetricSnapshot struct {
 	droppedGrace          int64
 	droppedErrorGuard     int64
 	droppedTransitionGate int64
+	unsupportedKind       int64
 }
 
 func snapshotProbeIntentMetrics() probeIntentMetricSnapshot {
@@ -283,6 +284,7 @@ func snapshotProbeIntentMetrics() probeIntentMetricSnapshot {
 		droppedGrace:          metricInt("purdex_probe_intent_dropped_grace_total"),
 		droppedErrorGuard:     metricInt("purdex_probe_intent_dropped_error_guard_total"),
 		droppedTransitionGate: metricInt("purdex_probe_intent_dropped_transition_gate_total"),
+		unsupportedKind:       metricInt("purdex_probe_intent_unsupported_kind_total"),
 	}
 }
 

--- a/internal/module/agent/probe_intent_dispatcher_observability_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_observability_test.go
@@ -29,7 +29,7 @@ func TestProbeIntent_DevLog_StartLine(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 
 	out := buf.String()
@@ -64,7 +64,7 @@ func TestProbeIntent_DevLog_SignalLine(t *testing.T) {
 	})
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	waitFor(t, time.Second, func() bool {
 		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
@@ -158,7 +158,7 @@ func TestProbeIntent_TraceStore_StartStep(t *testing.T) {
 		t.Skip("traceSink not wired in this fixture")
 	}
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 
 	// Flush before reading.
@@ -221,7 +221,7 @@ func TestProbeIntent_TraceStore_SignalStep(t *testing.T) {
 		t.Skip("traceSink not wired in this fixture")
 	}
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	waitFor(t, time.Second, func() bool {
 		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 		return !ok
@@ -294,7 +294,7 @@ func TestProbeIntent_Expvar_StartedCounterIncrement(t *testing.T) {
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	before := snapshotProbeIntentMetrics()
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 	after := snapshotProbeIntentMetrics()
 

--- a/internal/module/agent/probe_intent_dispatcher_observability_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_observability_test.go
@@ -1,0 +1,457 @@
+// internal/module/agent/probe_intent_dispatcher_observability_test.go
+//
+// W6-3 P2-T6: observability surfaces for the ProbeIntent dispatcher —
+// dev-mode log lines, TraceStore [probe-intent] step persistence, and
+// expvar counters. Tests use the recording / emit-once detector helpers
+// from probe_intent_dispatcher_test.go.
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/store"
+)
+
+// -----------------------------------------------------------------------------
+// (a) dev log
+// -----------------------------------------------------------------------------
+
+// TestProbeIntent_DevLog_StartLine pins the [probe-intent] start log line
+// emitted from applyIntentLifecycle when a fresh detector arms.
+func TestProbeIntent_DevLog_StartLine(t *testing.T) {
+	t.Setenv("PDX_DEV_MODE", "1")
+	buf := captureDevLog(t)
+
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+
+	out := buf.String()
+	line := findProbeIntentLogLine(t, out, "[probe-intent] start")
+	for _, want := range []string{
+		"session=work",
+		"agent=codex",
+		"kind=process_dead",
+		"pane=%5",
+		"pid=4242",
+		"generation=",
+	} {
+		if !strings.Contains(line, want) {
+			t.Errorf("[probe-intent] start missing %q in: %s", want, line)
+		}
+	}
+}
+
+// TestProbeIntent_DevLog_SignalLine pins the [probe-intent] signal log line
+// emitted from consumeSignals after applyProbeGuards returns applied=true.
+func TestProbeIntent_DevLog_SignalLine(t *testing.T) {
+	t.Setenv("PDX_DEV_MODE", "1")
+	buf := captureDevLog(t)
+
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+	installEmitOnceDetector(t, m, agentpkg.Signal{
+		Kind:      agentpkg.ProbeIntentKindProcessDead,
+		PaneAlive: true,
+		PaneID:    "%5",
+		SenderPID: 4242,
+	})
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	waitFor(t, time.Second, func() bool {
+		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return !ok
+	}, "active entry torn down after applied=true")
+
+	out := buf.String()
+	line := findProbeIntentLogLine(t, out, "[probe-intent] signal")
+	for _, want := range []string{
+		"session=work",
+		"kind=process_dead",
+		"PaneAlive=true",
+		"newStatus=error",
+		"applied=true",
+	} {
+		if !strings.Contains(line, want) {
+			t.Errorf("[probe-intent] signal missing %q in: %s", want, line)
+		}
+	}
+}
+
+// TestProbeIntent_DevLog_DropReason_StaleCallback verifies the drop log
+// line shape when applyProbeGuards rejects a signal at the stale-callback
+// guard (active map empty / generation mismatch).
+//
+// Direct-call pattern: we exercise applyProbeGuards with StaleCheck → false
+// while wired with the dispatcher's session-aware OnDrop callback. This
+// pins the log-line + counter contract without needing a second detector
+// emit (which would conflict with the spec §5.4 case-3 ctx-cancel teardown
+// in consumeSignals).
+func TestProbeIntent_DevLog_DropReason_StaleCallback(t *testing.T) {
+	t.Setenv("PDX_DEV_MODE", "1")
+	buf := captureDevLog(t)
+
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+
+	applyProbeGuards(m, probeGuardArgs{
+		Session:   "work",
+		AgentType: "codex",
+		Reason:    "probe-intent:process_dead",
+		Signal: agentpkg.Signal{
+			Kind:      agentpkg.ProbeIntentKindProcessDead,
+			PaneAlive: true,
+			PaneID:    "%5",
+			SenderPID: 4242,
+		},
+		Mapping:    func(agentpkg.Signal) agentpkg.Status { return agentpkg.StatusError },
+		StaleCheck: func(*Module) bool { return false },
+		OnDrop:     probeIntentOnDropForSession("work", agentpkg.ProbeIntentKindProcessDead),
+	})
+
+	out := buf.String()
+	line := findProbeIntentLogLine(t, out, "[probe-intent] drop")
+	for _, want := range []string{
+		"session=work",
+		"kind=process_dead",
+		"reason=stale-callback",
+	} {
+		if !strings.Contains(line, want) {
+			t.Errorf("[probe-intent] drop missing %q in: %s", want, line)
+		}
+	}
+}
+
+// findProbeIntentLogLine is a helper that returns the first log line
+// containing the given pattern, or fails the test if not found.
+func findProbeIntentLogLine(t *testing.T, out, pattern string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, pattern) {
+			return line
+		}
+	}
+	t.Fatalf("missing log line %q in:\n%s", pattern, out)
+	return ""
+}
+
+// -----------------------------------------------------------------------------
+// (b) TraceStore step
+// -----------------------------------------------------------------------------
+
+// TestProbeIntent_TraceStore_StartStep verifies that arming a detector
+// records a [probe-intent] step into the trace sink when traces are wired.
+func TestProbeIntent_TraceStore_StartStep(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	if m.traceSink == nil {
+		t.Skip("traceSink not wired in this fixture")
+	}
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+
+	// Flush before reading.
+	m.traceSink.FlushForTest()
+
+	page, err := m.traces.ListChains(store.TraceListFilter{})
+	if err != nil {
+		t.Fatalf("ListChains: %v", err)
+	}
+	var found bool
+	for _, ch := range page.Chains {
+		if ch.LatestStepKind != TraceStepProbeIntent {
+			continue
+		}
+		rec, err := m.traces.GetChainRecord(ch.ChainID)
+		if err != nil {
+			t.Fatalf("GetChainRecord: %v", err)
+		}
+		if rec == nil || len(rec.Steps) == 0 {
+			t.Fatalf("chain %s has no steps", ch.ChainID)
+		}
+		step := rec.Steps[0]
+		if step.Kind != TraceStepProbeIntent {
+			t.Errorf("step.Kind = %q, want %q", step.Kind, TraceStepProbeIntent)
+			continue
+		}
+		if step.Decision != "start" {
+			continue
+		}
+		found = true
+		if step.TmuxSession != "work" {
+			t.Errorf("step.TmuxSession = %q, want work", step.TmuxSession)
+		}
+		if step.AgentType != "codex" {
+			t.Errorf("step.AgentType = %q, want codex", step.AgentType)
+		}
+		if step.PaneID != "%5" {
+			t.Errorf("step.PaneID = %q, want %%5", step.PaneID)
+		}
+	}
+	if !found {
+		t.Fatalf("no chain found with [probe-intent] start step")
+	}
+}
+
+// TestProbeIntent_TraceStore_SignalStep verifies that an applied signal
+// records a [probe-intent] step with decision=signal.
+func TestProbeIntent_TraceStore_SignalStep(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+	installEmitOnceDetector(t, m, agentpkg.Signal{
+		Kind:      agentpkg.ProbeIntentKindProcessDead,
+		PaneAlive: true,
+		PaneID:    "%5",
+		SenderPID: 4242,
+	})
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	if m.traceSink == nil {
+		t.Skip("traceSink not wired in this fixture")
+	}
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	waitFor(t, time.Second, func() bool {
+		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return !ok
+	}, "active entry torn down")
+
+	m.traceSink.FlushForTest()
+
+	page, err := m.traces.ListChains(store.TraceListFilter{})
+	if err != nil {
+		t.Fatalf("ListChains: %v", err)
+	}
+	var foundSignal bool
+	for _, ch := range page.Chains {
+		rec, err := m.traces.GetChainRecord(ch.ChainID)
+		if err != nil {
+			t.Fatalf("GetChainRecord: %v", err)
+		}
+		if rec == nil {
+			continue
+		}
+		for _, st := range rec.Steps {
+			if st.Kind == TraceStepProbeIntent && st.Decision == "signal" {
+				foundSignal = true
+				if st.TmuxSession != "work" {
+					t.Errorf("signal step session = %q, want work", st.TmuxSession)
+				}
+			}
+		}
+	}
+	if !foundSignal {
+		t.Fatalf("no [probe-intent] step found with decision=signal")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// (c) expvar metrics
+// -----------------------------------------------------------------------------
+
+// probeIntentMetricSnapshot reads the eight ProbeIntent counters for delta
+// assertions. expvar globals persist across tests — only deltas are stable.
+type probeIntentMetricSnapshot struct {
+	started               int64
+	stopped               int64
+	signalEmitted         int64
+	applied               int64
+	droppedStale          int64
+	droppedGrace          int64
+	droppedErrorGuard     int64
+	droppedTransitionGate int64
+}
+
+func snapshotProbeIntentMetrics() probeIntentMetricSnapshot {
+	return probeIntentMetricSnapshot{
+		started:               metricInt("purdex_probe_intent_started_total"),
+		stopped:               metricInt("purdex_probe_intent_stopped_total"),
+		signalEmitted:         metricInt("purdex_probe_intent_signal_emitted_total"),
+		applied:               metricInt("purdex_probe_intent_applied_total"),
+		droppedStale:          metricInt("purdex_probe_intent_dropped_stale_total"),
+		droppedGrace:          metricInt("purdex_probe_intent_dropped_grace_total"),
+		droppedErrorGuard:     metricInt("purdex_probe_intent_dropped_error_guard_total"),
+		droppedTransitionGate: metricInt("purdex_probe_intent_dropped_transition_gate_total"),
+	}
+}
+
+// TestProbeIntent_Expvar_StartedCounterIncrement verifies arming +1's the
+// MetricProbeIntentStarted counter exactly once.
+func TestProbeIntent_Expvar_StartedCounterIncrement(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	before := snapshotProbeIntentMetrics()
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+	after := snapshotProbeIntentMetrics()
+
+	if got := after.started - before.started; got != 1 {
+		t.Errorf("MetricProbeIntentStarted delta = %d, want 1", got)
+	}
+}
+
+// TestProbeIntent_Expvar_DroppedCounterByReason exercises the four drop
+// reason counters by routing each through applyProbeGuards.
+func TestProbeIntent_Expvar_DroppedCounterByReason(t *testing.T) {
+	t.Run("stale", func(t *testing.T) {
+		m := newDispatcherTestModule(t)
+		m.sessions = &fakeSessionProvider{}
+		// active map empty → StaleCheck returns false on first lock.
+		before := snapshotProbeIntentMetrics()
+		applied := applyProbeGuards(m, probeGuardArgs{
+			Session:   "work",
+			AgentType: "codex",
+			Reason:    "probe-intent:process_dead",
+			Signal:    agentpkg.Signal{Kind: agentpkg.ProbeIntentKindProcessDead},
+			Mapping:   func(agentpkg.Signal) agentpkg.Status { return agentpkg.StatusError },
+			StaleCheck: func(*Module) bool { return false },
+			OnDrop:    nil, // dispatcher-only field; pass nil here, set via reason argument below
+		})
+		// We need a way to actually count "stale" → use the dispatcher route.
+		_ = applied
+		// Direct route: emit a signal via consumeSignals with a closure
+		// that returns false. Wrap the dispatcher to confirm counter delta.
+		dispatcherDropStale(t, m)
+		after := snapshotProbeIntentMetrics()
+		if got := after.droppedStale - before.droppedStale; got < 1 {
+			t.Errorf("droppedStale delta = %d, want >= 1", got)
+		}
+	})
+
+	t.Run("grace", func(t *testing.T) {
+		m := newDispatcherTestModule(t)
+		m.sessions = &fakeSessionProvider{}
+		seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+		// Arm so StaleCheck passes.
+		m.mu.Lock()
+		m.activeProbeIntents["work"] = map[agentpkg.ProbeIntentKind]activeIntent{
+			agentpkg.ProbeIntentKindProcessDead: {
+				agentType:  "codex",
+				paneID:     "%5",
+				senderPID:  4242,
+				generation: 1,
+			},
+		}
+		m.probeIntentGen = 1
+		m.mu.Unlock()
+		// Trigger graceWindow: recordHookAt now → next probe within window
+		// is suppressed.
+		m.probeOrch.recordHookAt("work")
+
+		before := snapshotProbeIntentMetrics()
+		applyProbeGuards(m, probeGuardArgs{
+			Session:    "work",
+			AgentType:  "codex",
+			Reason:     "probe-intent:process_dead",
+			Signal:     agentpkg.Signal{Kind: agentpkg.ProbeIntentKindProcessDead},
+			Mapping:    func(agentpkg.Signal) agentpkg.Status { return agentpkg.StatusError },
+			StaleCheck: makeProbeIntentStaleCheck("work", agentpkg.ProbeIntentKindProcessDead, "codex", 1),
+			OnDrop:     probeIntentOnDrop,
+		})
+		after := snapshotProbeIntentMetrics()
+		if got := after.droppedGrace - before.droppedGrace; got != 1 {
+			t.Errorf("droppedGrace delta = %d, want 1", got)
+		}
+	})
+
+	t.Run("error_guard", func(t *testing.T) {
+		m := newDispatcherTestModule(t)
+		m.sessions = &fakeSessionProvider{}
+		seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+		m.mu.Lock()
+		m.activeProbeIntents["work"] = map[agentpkg.ProbeIntentKind]activeIntent{
+			agentpkg.ProbeIntentKindProcessDead: {
+				agentType:  "codex",
+				paneID:     "%5",
+				senderPID:  4242,
+				generation: 1,
+			},
+		}
+		m.probeIntentGen = 1
+		m.currentStatus["work"] = agentpkg.StatusError
+		m.mu.Unlock()
+
+		before := snapshotProbeIntentMetrics()
+		applyProbeGuards(m, probeGuardArgs{
+			Session:    "work",
+			AgentType:  "codex",
+			Reason:     "probe-intent:process_dead",
+			Signal:     agentpkg.Signal{Kind: agentpkg.ProbeIntentKindProcessDead},
+			Mapping:    func(agentpkg.Signal) agentpkg.Status { return agentpkg.StatusError },
+			StaleCheck: makeProbeIntentStaleCheck("work", agentpkg.ProbeIntentKindProcessDead, "codex", 1),
+			OnDrop:     probeIntentOnDrop,
+		})
+		after := snapshotProbeIntentMetrics()
+		if got := after.droppedErrorGuard - before.droppedErrorGuard; got != 1 {
+			t.Errorf("droppedErrorGuard delta = %d, want 1", got)
+		}
+	})
+
+	t.Run("transition_gate", func(t *testing.T) {
+		m := newDispatcherTestModule(t)
+		m.sessions = &fakeSessionProvider{}
+		seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+		m.mu.Lock()
+		m.activeProbeIntents["work"] = map[agentpkg.ProbeIntentKind]activeIntent{
+			agentpkg.ProbeIntentKindProcessDead: {
+				agentType:  "codex",
+				paneID:     "%5",
+				senderPID:  4242,
+				generation: 1,
+			},
+		}
+		m.probeIntentGen = 1
+		// currentStatus already Running; mapping returns Running → gate trips.
+		m.currentStatus["work"] = agentpkg.StatusRunning
+		m.mu.Unlock()
+
+		before := snapshotProbeIntentMetrics()
+		applyProbeGuards(m, probeGuardArgs{
+			Session:    "work",
+			AgentType:  "codex",
+			Reason:     "probe-intent:process_dead",
+			Signal:     agentpkg.Signal{Kind: agentpkg.ProbeIntentKindProcessDead},
+			Mapping:    func(agentpkg.Signal) agentpkg.Status { return agentpkg.StatusRunning },
+			StaleCheck: makeProbeIntentStaleCheck("work", agentpkg.ProbeIntentKindProcessDead, "codex", 1),
+			OnDrop:     probeIntentOnDrop,
+		})
+		after := snapshotProbeIntentMetrics()
+		if got := after.droppedTransitionGate - before.droppedTransitionGate; got != 1 {
+			t.Errorf("droppedTransitionGate delta = %d, want 1", got)
+		}
+	})
+}
+
+// dispatcherDropStale exercises the stale-callback drop counter by
+// invoking applyProbeGuards via the dispatcher's consumeSignals path.
+func dispatcherDropStale(t *testing.T, m *Module) {
+	t.Helper()
+	// Direct path: applyProbeGuards with a StaleCheck that returns false.
+	// The dispatcher uses probeIntentOnDrop callback when wired through
+	// consumeSignals; we mirror that here.
+	applyProbeGuards(m, probeGuardArgs{
+		Session:    "work",
+		AgentType:  "codex",
+		Reason:     "probe-intent:process_dead",
+		Signal:     agentpkg.Signal{Kind: agentpkg.ProbeIntentKindProcessDead},
+		Mapping:    func(agentpkg.Signal) agentpkg.Status { return agentpkg.StatusError },
+		StaleCheck: func(*Module) bool { return false },
+		OnDrop:     probeIntentOnDrop,
+	})
+}

--- a/internal/module/agent/probe_intent_dispatcher_observability_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_observability_test.go
@@ -29,7 +29,7 @@ func TestProbeIntent_DevLog_StartLine(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 
 	out := buf.String()
@@ -64,7 +64,7 @@ func TestProbeIntent_DevLog_SignalLine(t *testing.T) {
 	})
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	waitFor(t, time.Second, func() bool {
 		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
@@ -158,7 +158,7 @@ func TestProbeIntent_TraceStore_StartStep(t *testing.T) {
 		t.Skip("traceSink not wired in this fixture")
 	}
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 
 	// Flush before reading.
@@ -221,7 +221,7 @@ func TestProbeIntent_TraceStore_SignalStep(t *testing.T) {
 		t.Skip("traceSink not wired in this fixture")
 	}
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	waitFor(t, time.Second, func() bool {
 		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 		return !ok
@@ -294,7 +294,7 @@ func TestProbeIntent_Expvar_StartedCounterIncrement(t *testing.T) {
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	before := snapshotProbeIntentMetrics()
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 	after := snapshotProbeIntentMetrics()
 

--- a/internal/module/agent/probe_intent_dispatcher_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_test.go
@@ -729,3 +729,124 @@ func TestReplayStatus_StaleFrame_DetectorEmitsImmediately(t *testing.T) {
 		t.Fatalf("currentStatus = %q, want error after stale-frame replay", got)
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Round-2 audit fixes: F1 graceWindow strand / F2 generation-scoped teardown / F6 fail-closed
+// -----------------------------------------------------------------------------
+
+// TestConsumeSignals_GraceWindowDrop_TearsDownActiveEntry pins F1: when a
+// one-shot detector emits its sole Signal during an active graceWindow,
+// applyProbeGuards drops the signal (applied=false), the channel closes,
+// and consumeSignals' post-loop teardown must remove the active entry —
+// otherwise a future status change observes case-4 (target match) and the
+// detector never re-arms, leaving codex permanently undetected.
+func TestConsumeSignals_GraceWindowDrop_TearsDownActiveEntry(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+	// Emit-once-and-exit detector mirrors production codex (returns after
+	// emit, channel closes via wrapping goroutine).
+	m.probeIntentDisp.startDetector = func(ctx context.Context, _ *Module, _ agentpkg.ProbeIntentKind, _ string, _ int, out chan<- agentpkg.Signal) {
+		select {
+		case out <- agentpkg.Signal{
+			Kind:      agentpkg.ProbeIntentKindProcessDead,
+			PaneAlive: true,
+			PaneID:    "%5",
+			SenderPID: 4242,
+		}:
+		case <-ctx.Done():
+		}
+	}
+	t.Cleanup(func() { m.probeIntentDisp.stopAll() })
+
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+	// Open graceWindow: any probe signal arriving in the next probeGraceWindow
+	// is suppressed. With the F1 fix, the active entry must still be torn
+	// down so a subsequent crash is not missed.
+	m.probeOrch.recordHookAt("work")
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	waitFor(t, 2*time.Second, func() bool {
+		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return !ok
+	}, "active entry torn down post-loop after graceWindow drop (F1)")
+}
+
+// TestStopActiveIntentInLock_GenerationMismatch_PreservesEntry pins F2:
+// the generation guard must reject mismatched expectations so a concurrent
+// rearm (gen N+1) survives the previous detector's applied-true teardown.
+// Direct unit test on stopActiveIntentInLock — the F2 fix's contract is
+// the helper's behavior under generation mismatch.
+func TestStopActiveIntentInLock_GenerationMismatch_PreservesEntry(t *testing.T) {
+	m := newDispatcherTestModule(t)
+
+	cancelCalls := int32(0)
+	cancel := func() { atomic.AddInt32(&cancelCalls, 1) }
+	m.mu.Lock()
+	m.activeProbeIntents["work"] = map[agentpkg.ProbeIntentKind]activeIntent{
+		agentpkg.ProbeIntentKindProcessDead: {
+			agentType:  "codex",
+			paneID:     "%5",
+			senderPID:  4242,
+			generation: 5,
+			cancel:     cancel,
+		},
+	}
+	m.mu.Unlock()
+
+	// Caller observed gen 1 → expectGeneration=1 → cur.generation=5 → mismatch.
+	m.mu.Lock()
+	_, ok := m.probeIntentDisp.stopActiveIntentInLock("work", agentpkg.ProbeIntentKindProcessDead, 1, "test-mismatch")
+	m.mu.Unlock()
+
+	if ok {
+		t.Fatalf("ok=true with mismatched expectGeneration, want false")
+	}
+	if atomic.LoadInt32(&cancelCalls) != 0 {
+		t.Fatalf("cancel invoked %d times despite mismatch, want 0", atomic.LoadInt32(&cancelCalls))
+	}
+	// Entry must still be present.
+	cur, present := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if !present {
+		t.Fatalf("entry torn down despite generation mismatch")
+	}
+	if cur.generation != 5 {
+		t.Fatalf("generation = %d, want 5 (preserved)", cur.generation)
+	}
+}
+
+// TestApplyIntentLifecycle_UnsupportedKind_FailsClosed pins F6: when a
+// provider declares a Kind that has no corresponding entry in
+// supportedKinds, lifecycle must NOT arm a detector — silent default
+// noop would otherwise leave the system "armed" with zero observability.
+// Verifies (1) no detector started, (2) no active entry recorded, (3)
+// MetricProbeIntentUnsupportedKind +1.
+func TestApplyIntentLifecycle_UnsupportedKind_FailsClosed(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	futureKind := agentpkg.ProbeIntentKind("future_kind_unwired")
+	futureIntent := agentpkg.ProbeIntent{
+		Kind:          futureKind,
+		OnEntryStatus: []agentpkg.Status{agentpkg.StatusRunning},
+		OnSignal:      func(agentpkg.Signal) agentpkg.Status { return agentpkg.StatusError },
+	}
+
+	before := snapshotProbeIntentMetrics()
+	m.probeIntentDisp.applyIntentLifecycle("work", "codex", agentpkg.StatusRunning, futureIntent)
+	after := snapshotProbeIntentMetrics()
+
+	if rec.startCount() != 0 {
+		t.Fatalf("detector started %d time(s) for unsupported kind, want 0", rec.startCount())
+	}
+	if _, ok := readActiveIntent(m, "work", futureKind); ok {
+		t.Fatalf("active entry created for unsupported kind, want none")
+	}
+	if got := after.unsupportedKind - before.unsupportedKind; got != 1 {
+		t.Fatalf("unsupportedKind metric delta = %d, want 1", got)
+	}
+	if got := after.started - before.started; got != 0 {
+		t.Fatalf("started metric delta = %d, want 0 (no arm)", got)
+	}
+}

--- a/internal/module/agent/probe_intent_dispatcher_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_test.go
@@ -879,3 +879,29 @@ func TestApplyIntentLifecycle_UnsupportedKind_FailsClosed(t *testing.T) {
 		t.Fatalf("started metric delta = %d, want 0 (no arm)", got)
 	}
 }
+
+// TestApplyIntentLifecycle_NilTraceSink_DoesNotPanic pins F9: Module.New
+// treats trace-store init failure as non-fatal and leaves traceSink nil.
+// All ProbeIntent observability sites (start / stop / signal /
+// unsupported-kind / drop) MUST guard the nil — otherwise any codex
+// running/waiting transition in degraded mode panics the agent module.
+//
+// This test exercises the start path specifically because it was the
+// only site missing the guard before round-5; the others were already
+// covered by the existing observability tests with non-nil traceSink.
+func TestApplyIntentLifecycle_NilTraceSink_DoesNotPanic(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+	// Simulate degraded-trace mode (Module.New non-fatal trace init failure).
+	m.traceSink = nil
+
+	// Arming exercises the start observability emit which previously
+	// dereferenced traceSink unconditionally. Pre-fix: panics here.
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	<-rec.started
+	if rec.startCount() != 1 {
+		t.Fatalf("detector started count = %d, want 1 (arm must succeed under nil traceSink)", rec.startCount())
+	}
+}

--- a/internal/module/agent/probe_intent_dispatcher_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_test.go
@@ -1,0 +1,629 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/store"
+	"github.com/wake/purdex/internal/tmux"
+)
+
+// -----------------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------------
+
+// processDeadIntent is the canonical W6-3 ProbeIntent declaration used in
+// dispatcher tests. OnEntryStatus = {Running, Waiting}; OnSignal mirrors the
+// production codex mapping (PaneAlive=true → error, =false → clear).
+func processDeadIntent() agentpkg.ProbeIntent {
+	return agentpkg.ProbeIntent{
+		Kind:          agentpkg.ProbeIntentKindProcessDead,
+		OnEntryStatus: []agentpkg.Status{agentpkg.StatusRunning, agentpkg.StatusWaiting},
+		OnSignal: func(sig agentpkg.Signal) agentpkg.Status {
+			if sig.PaneAlive {
+				return agentpkg.StatusError
+			}
+			return agentpkg.StatusClear
+		},
+	}
+}
+
+// newDispatcherTestModule wires a Module with a fake codex provider that
+// declares the ProcessDead intent, plus a fake tmux executor that resolves
+// "%5" → "work". Returns a t.Cleanup-bound module ready for dispatcher
+// lifecycle tests. The default detector stub honors ctx and never emits;
+// individual tests swap startProbeIntentDetectorFn when they need control.
+func newDispatcherTestModule(t *testing.T) *Module {
+	t.Helper()
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.registry.Register(&fakeProbeIntentAgentProvider{
+		fakeAgentProvider: fakeAgentProvider{typeName: "codex"},
+		intents:           []agentpkg.ProbeIntent{processDeadIntent()},
+	})
+	return m
+}
+
+// seedRunningFrame inserts a top frame for the (paneID, session, agentType,
+// pid) tuple and writes currentStatus = Running. Used by tests that want a
+// pre-existing armable target.
+func seedRunningFrame(t *testing.T, m *Module, session, paneID, agentType string, pid int) {
+	t.Helper()
+	if _, err := m.frames.Upsert(store.Frame{
+		FrameID:          "frame-" + session + "-" + agentType,
+		PaneID:           paneID,
+		AgentType:        agentType,
+		PID:              pid,
+		PPID:             1,
+		ProcessStartTime: "Sun Apr 20 01:30:00 2026",
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        100,
+		LastSeenAt:       120,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("seed frame: %v", err)
+	}
+	m.mu.Lock()
+	m.currentStatus[session] = agentpkg.StatusRunning
+	m.mu.Unlock()
+}
+
+// readActiveIntent returns the active entry under m.mu, with ok=false if
+// missing. Helper for assertions.
+func readActiveIntent(m *Module, session string, kind agentpkg.ProbeIntentKind) (activeIntent, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	per, ok := m.activeProbeIntents[session]
+	if !ok {
+		return activeIntent{}, false
+	}
+	cur, ok := per[kind]
+	return cur, ok
+}
+
+// installRecordingDetector swaps in a stub that records every (paneID,
+// senderPID) start, increments started counter, and exits when ctx done
+// (incrementing canceled counter). Returns the counters + a started chan
+// that closes after the first start (for synchronizing tests).
+type recordingDetector struct {
+	mu       sync.Mutex
+	starts   []recordingDetectorStart
+	canceled int32
+	started  chan struct{}
+}
+
+type recordingDetectorStart struct {
+	PaneID    string
+	SenderPID int
+	Kind      agentpkg.ProbeIntentKind
+}
+
+// installRecordingDetector swaps the dispatcher's startDetector to a
+// recorder. Per-dispatcher field swap (instead of a package global)
+// keeps tests isolated under -race even when subtests run sequentially
+// in different Modules. Cleanup also stops the dispatcher so any
+// goroutine still reading the field exits before the test returns.
+func installRecordingDetector(t *testing.T, m *Module) *recordingDetector {
+	t.Helper()
+	rec := &recordingDetector{started: make(chan struct{})}
+	m.probeIntentDisp.startDetector = func(ctx context.Context, _ *Module, kind agentpkg.ProbeIntentKind, paneID string, senderPID int, _ chan<- agentpkg.Signal) {
+		rec.mu.Lock()
+		rec.starts = append(rec.starts, recordingDetectorStart{PaneID: paneID, SenderPID: senderPID, Kind: kind})
+		first := len(rec.starts) == 1
+		rec.mu.Unlock()
+		if first {
+			close(rec.started)
+		}
+		<-ctx.Done()
+		atomic.AddInt32(&rec.canceled, 1)
+	}
+	t.Cleanup(func() { m.probeIntentDisp.stopAll() })
+	return rec
+}
+
+func (r *recordingDetector) startCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.starts)
+}
+
+func (r *recordingDetector) cancelCount() int32 {
+	return atomic.LoadInt32(&r.canceled)
+}
+
+// waitFor polls until pred returns true or timeout. Used to synchronize
+// goroutine teardown without sleeps.
+func waitFor(t *testing.T, deadline time.Duration, pred func() bool, msg string) {
+	t.Helper()
+	start := time.Now()
+	for time.Since(start) < deadline {
+		if pred() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("waitFor timeout: %s", msg)
+}
+
+// -----------------------------------------------------------------------------
+// Lifecycle 5 case
+// -----------------------------------------------------------------------------
+
+// case 1: !shouldActive && !wasActive → noop
+func TestApplyIntentLifecycle_Case1_NotActive_NotShouldActive_Noop(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+
+	// Status idle, not in OnEntryStatus
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle)
+
+	if rec.startCount() != 0 {
+		t.Fatalf("detector started count = %d, want 0", rec.startCount())
+	}
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("activeProbeIntents present after idle, want absent")
+	}
+}
+
+// case 2: shouldActive && !wasActive (frame ok) → record + arm
+func TestApplyIntentLifecycle_Case2_NotActive_ShouldActive_Start(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	<-rec.started
+	if rec.startCount() != 1 {
+		t.Fatalf("detector started count = %d, want 1", rec.startCount())
+	}
+	cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if !ok {
+		t.Fatalf("activeProbeIntents missing, want set")
+	}
+	if cur.agentType != "codex" || cur.paneID != "%5" || cur.senderPID != 4242 {
+		t.Fatalf("active entry = %+v, want codex/%%5/4242", cur)
+	}
+	if cur.generation == 0 {
+		t.Fatalf("generation = 0, want >0")
+	}
+
+	// Cleanup: stopAll cancels the goroutine.
+	m.probeIntentDisp.stopAll()
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() == 1 }, "detector cancel after stopAll")
+}
+
+// case 3: !shouldActive && wasActive → cancel + delete
+func TestApplyIntentLifecycle_Case3_Active_NotShouldActive_Stop(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	// Arm
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+
+	// Transition to idle (not in OnEntryStatus)
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle)
+
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("activeProbeIntents present after idle, want absent")
+	}
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() == 1 }, "detector cancel after stop")
+}
+
+// case 4: shouldActive && wasActive && targetMatches → noop (no extra arm)
+func TestApplyIntentLifecycle_Case4_Active_ShouldActive_TargetMatch_Noop(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	// First arm
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+	cur1, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+
+	// Re-apply with same status / same target — should be a noop
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	if rec.startCount() != 1 {
+		t.Fatalf("detector started count = %d, want 1 (case 4 noop)", rec.startCount())
+	}
+	cur2, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if cur1.generation != cur2.generation {
+		t.Fatalf("generation changed across noop apply: %d → %d", cur1.generation, cur2.generation)
+	}
+
+	m.probeIntentDisp.stopAll()
+}
+
+// case 5: shouldActive && wasActive && target mismatch → cancel old + record new + arm
+func TestApplyIntentLifecycle_Case5_Active_ShouldActive_TargetMismatch_CancelAndRearm(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+	cur1, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+
+	// Add a second frame with a different pid (simulates codex restart in the
+	// same pane). The new frame has a later StartedAt so projection selects
+	// it as TopFrame.
+	if _, err := m.frames.Upsert(store.Frame{
+		FrameID:          "frame-work-codex-restart",
+		PaneID:           "%5",
+		AgentType:        "codex",
+		PID:              5555,
+		PPID:             1,
+		ProcessStartTime: "Sun Apr 20 02:30:00 2026",
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        200,
+		LastSeenAt:       220,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	// Wait for second start.
+	waitFor(t, time.Second, func() bool { return rec.startCount() == 2 }, "second detector start")
+	cur2, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if cur2.senderPID != 5555 {
+		t.Fatalf("rearmed senderPID = %d, want 5555", cur2.senderPID)
+	}
+	if cur1.generation == cur2.generation {
+		t.Fatalf("generation did not advance on re-arm: %d == %d", cur1.generation, cur2.generation)
+	}
+	// Old detector goroutine should have been cancelled.
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() >= 1 }, "old detector cancel")
+
+	m.probeIntentDisp.stopAll()
+}
+
+// -----------------------------------------------------------------------------
+// Reconcile 4 case
+// -----------------------------------------------------------------------------
+
+// case A: unknown agent → drop all entries for the session
+func TestReconcileSessionActive_UnknownAgent_DropAll(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+
+	// Pretend agentType swap to an unregistered name.
+	m.probeIntentDisp.applyStatus("work", "ghost-agent", agentpkg.StatusRunning)
+
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("activeProbeIntents present after unknown-agent reconcile")
+	}
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() == 1 }, "old detector cancel after unknown agent")
+}
+
+// case B: provider has no ProbeIntents → drop all
+func TestReconcileSessionActive_ProviderHasNoIntents_DropAll(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+
+	// Register a no-intent provider with a different agent name and switch.
+	m.registry.Register(&fakeAgentProvider{typeName: "cc-noprobes"})
+	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning)
+
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("activeProbeIntents present after switching to no-probe provider")
+	}
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() == 1 }, "detector cancel after no-probe switch")
+}
+
+// case C: agentType changed → drop old kind even if the new provider declares
+// the same Kind. (The new provider's lifecycle then rearms under its own
+// agentType.)
+func TestReconcileSessionActive_AgentTypeChanged_DropOld(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+	cur1, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if cur1.agentType != "codex" {
+		t.Fatalf("initial agentType = %q, want codex", cur1.agentType)
+	}
+
+	// Register an alt provider that also declares ProcessDead and switch.
+	m.registry.Register(&fakeProbeIntentAgentProvider{
+		fakeAgentProvider: fakeAgentProvider{typeName: "alt-codex"},
+		intents:           []agentpkg.ProbeIntent{processDeadIntent()},
+	})
+	// Replace top frame agent type so lifecycle finds (paneID, pid) under the new name.
+	if _, err := m.frames.Upsert(store.Frame{
+		FrameID:          "frame-work-alt-codex",
+		PaneID:           "%5",
+		AgentType:        "alt-codex",
+		PID:              7777,
+		PPID:             1,
+		ProcessStartTime: "Sun Apr 20 02:30:00 2026",
+		Status:           agentpkg.StatusRunning,
+		StartedAt:        300,
+		LastSeenAt:       320,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert alt frame: %v", err)
+	}
+	// Remove the old codex frame to make alt-codex the top frame.
+	if err := m.frames.Delete("frame-work-codex"); err != nil {
+		t.Fatalf("Delete frame: %v", err)
+	}
+
+	m.probeIntentDisp.applyStatus("work", "alt-codex", agentpkg.StatusRunning)
+	waitFor(t, time.Second, func() bool {
+		cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return ok && cur.agentType == "alt-codex"
+	}, "active entry agentType becomes alt-codex")
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() >= 1 }, "old codex detector cancel")
+
+	m.probeIntentDisp.stopAll()
+}
+
+// case D: kind not in declared → drop the old kind only. Implemented by
+// constructing a session with an active ProcessDead entry, then switching to a
+// provider that declares NO ProcessDead (empty intents).
+func TestReconcileSessionActive_KindNotInDeclared_DropOldKind(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+
+	// Register an alt agent that declares NO intents and switch.
+	m.registry.Register(&fakeProbeIntentAgentProvider{
+		fakeAgentProvider: fakeAgentProvider{typeName: "alt-noprobedead"},
+		intents:           nil, // empty declared kinds
+	})
+	m.probeIntentDisp.applyStatus("work", "alt-noprobedead", agentpkg.StatusRunning)
+
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("ProcessDead entry present after switching to provider without it")
+	}
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() == 1 }, "detector cancel after kind drop")
+}
+
+// -----------------------------------------------------------------------------
+// Probe-applied teardown (round 5 P1)
+// -----------------------------------------------------------------------------
+
+// installEmitOnceDetector swaps the dispatcher's startDetector to one that
+// emits a single Signal on start, then waits for ctx.Done. Used to verify
+// consumeSignals re-runs applyStatus after applied=true. Cleanup stops
+// the dispatcher to drain detector goroutines.
+func installEmitOnceDetector(t *testing.T, m *Module, sig agentpkg.Signal) {
+	t.Helper()
+	m.probeIntentDisp.startDetector = func(ctx context.Context, _ *Module, _ agentpkg.ProbeIntentKind, _ string, _ int, out chan<- agentpkg.Signal) {
+		select {
+		case out <- sig:
+		case <-ctx.Done():
+			return
+		}
+		<-ctx.Done()
+	}
+	t.Cleanup(func() { m.probeIntentDisp.stopAll() })
+}
+
+// applied=true → re-runs applyStatus → activeProbeIntents entry deleted via
+// case 3 (active && !shouldActive).
+func TestConsumeSignals_AppliedTrue_ReRunsApplyStatus(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+	installEmitOnceDetector(t, m, agentpkg.Signal{
+		Kind:      agentpkg.ProbeIntentKindProcessDead,
+		PaneAlive: true,
+		PaneID:    "%5",
+		SenderPID: 4242,
+	})
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	// After detector emits PaneAlive=true → OnSignal returns Error → guards
+	// pass → applied=true → consumeSignals invokes applyStatus(error) →
+	// case 3 (active, error not in OnEntryStatus) tears down.
+	waitFor(t, time.Second, func() bool {
+		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return !ok
+	}, "active entry torn down after applied=true")
+
+	m.mu.Lock()
+	got := m.currentStatus["work"]
+	m.mu.Unlock()
+	if got != agentpkg.StatusError {
+		t.Fatalf("currentStatus = %q, want error", got)
+	}
+}
+
+// applied=false (transition gate trips because currentStatus already error)
+// → consumeSignals continues but does NOT tear down. Active entry persists.
+func TestConsumeSignals_AppliedFalse_NoTeardown(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+	installEmitOnceDetector(t, m, agentpkg.Signal{
+		Kind:      agentpkg.ProbeIntentKindProcessDead,
+		PaneAlive: true,
+		PaneID:    "%5",
+		SenderPID: 4242,
+	})
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	// Pre-set currentStatus to Error: applyProbeGuards' ErrorGuard rejects
+	// the signal → applied=false. We still want the detector arm path to
+	// run, so apply with Running first to arm, then flip to Error AFTER arm.
+	//
+	// Easier path: arm with Running, then between detector start and
+	// signal delivery, set Error. But that's racy. Instead: set
+	// OnEntryStatus to include Error so arm path runs even with status=Error;
+	// detector emits PaneAlive=true → OnSignal returns Error; transition
+	// gate (current==new==Error) trips → applied=false.
+	//
+	// Replace registry intent with one whose OnEntryStatus includes Error:
+	m.registry = agentpkg.NewRegistry()
+	m.registry.Register(&fakeProbeIntentAgentProvider{
+		fakeAgentProvider: fakeAgentProvider{typeName: "codex"},
+		intents: []agentpkg.ProbeIntent{
+			{
+				Kind:          agentpkg.ProbeIntentKindProcessDead,
+				OnEntryStatus: []agentpkg.Status{agentpkg.StatusError},
+				OnSignal: func(sig agentpkg.Signal) agentpkg.Status {
+					return agentpkg.StatusError
+				},
+			},
+		},
+	})
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusError
+	m.mu.Unlock()
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusError)
+
+	// Active entry should remain (no probe-applied teardown happened).
+	// Wait a brief moment for the detector to emit + guard to drop.
+	time.Sleep(50 * time.Millisecond)
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); !ok {
+		t.Fatalf("active entry torn down despite applied=false")
+	}
+
+	m.probeIntentDisp.stopAll()
+}
+
+// -----------------------------------------------------------------------------
+// Stale-callback / generation guard
+// -----------------------------------------------------------------------------
+
+func TestMakeStaleCheck_GenerationMismatch_ReturnsFalse(t *testing.T) {
+	m := newTestModule(t)
+	m.mu.Lock()
+	m.activeProbeIntents["work"] = map[agentpkg.ProbeIntentKind]activeIntent{
+		agentpkg.ProbeIntentKindProcessDead: {
+			agentType:  "codex",
+			generation: 5,
+		},
+	}
+	m.mu.Unlock()
+
+	check := makeProbeIntentStaleCheck("work", agentpkg.ProbeIntentKindProcessDead, "codex", 4)
+	m.mu.Lock()
+	got := check(m)
+	m.mu.Unlock()
+	if got {
+		t.Fatalf("staleCheck = true with generation mismatch (expect 5 vs got 4); want false")
+	}
+}
+
+func TestMakeStaleCheck_AgentTypeMismatch_ReturnsFalse(t *testing.T) {
+	m := newTestModule(t)
+	m.mu.Lock()
+	m.activeProbeIntents["work"] = map[agentpkg.ProbeIntentKind]activeIntent{
+		agentpkg.ProbeIntentKindProcessDead: {
+			agentType:  "codex",
+			generation: 5,
+		},
+	}
+	m.mu.Unlock()
+
+	check := makeProbeIntentStaleCheck("work", agentpkg.ProbeIntentKindProcessDead, "alt-codex", 5)
+	m.mu.Lock()
+	got := check(m)
+	m.mu.Unlock()
+	if got {
+		t.Fatalf("staleCheck = true with agentType mismatch; want false")
+	}
+}
+
+func TestMakeStaleCheck_AllMatch_ReturnsTrue(t *testing.T) {
+	m := newTestModule(t)
+	m.mu.Lock()
+	m.activeProbeIntents["work"] = map[agentpkg.ProbeIntentKind]activeIntent{
+		agentpkg.ProbeIntentKindProcessDead: {
+			agentType:  "codex",
+			generation: 5,
+		},
+	}
+	m.mu.Unlock()
+
+	check := makeProbeIntentStaleCheck("work", agentpkg.ProbeIntentKindProcessDead, "codex", 5)
+	m.mu.Lock()
+	got := check(m)
+	m.mu.Unlock()
+	if !got {
+		t.Fatalf("staleCheck = false with all-match; want true")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Replay race (by2z79ouc ATK-2)
+// -----------------------------------------------------------------------------
+
+// applyStatus snapshot says Running, but a concurrent hook flipped
+// currentStatus to Idle before m.mu was acquired. Lifecycle re-reads under
+// lock and refuses to arm.
+func TestApplyIntentLifecycle_StatusChangedBetweenSnapshotAndArm_NoArming(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	// Simulate the race: caller snapshot reads Running, but by the time
+	// applyIntentLifecycle gets the lock, currentStatus[session] has been
+	// flipped to Idle (e.g. a PdxStop hook landed in between).
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+
+	if rec.startCount() != 0 {
+		t.Fatalf("detector started despite live currentStatus = Idle; want zero starts")
+	}
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("activeProbeIntents present despite live status mismatch")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// stopAll
+// -----------------------------------------------------------------------------
+
+func TestStopAll_CancelsAndClearsActiveMap(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	<-rec.started
+
+	m.probeIntentDisp.stopAll()
+
+	m.mu.Lock()
+	if len(m.activeProbeIntents) != 0 {
+		m.mu.Unlock()
+		t.Fatalf("activeProbeIntents non-empty after stopAll: %d entries", len(m.activeProbeIntents))
+	}
+	m.mu.Unlock()
+
+	waitFor(t, time.Second, func() bool { return rec.cancelCount() == 1 }, "detector cancel after stopAll")
+}

--- a/internal/module/agent/probe_intent_dispatcher_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_test.go
@@ -161,7 +161,7 @@ func TestApplyIntentLifecycle_Case1_NotActive_NotShouldActive_Noop(t *testing.T)
 	rec := installRecordingDetector(t, m)
 
 	// Status idle, not in OnEntryStatus
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle, nil)
 
 	if rec.startCount() != 0 {
 		t.Fatalf("detector started count = %d, want 0", rec.startCount())
@@ -177,7 +177,7 @@ func TestApplyIntentLifecycle_Case2_NotActive_ShouldActive_Start(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	<-rec.started
 	if rec.startCount() != 1 {
@@ -206,14 +206,14 @@ func TestApplyIntentLifecycle_Case3_Active_NotShouldActive_Stop(t *testing.T) {
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	// Arm
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 
 	// Transition to idle (not in OnEntryStatus)
 	m.mu.Lock()
 	m.currentStatus["work"] = agentpkg.StatusIdle
 	m.mu.Unlock()
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle, nil)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("activeProbeIntents present after idle, want absent")
@@ -228,12 +228,12 @@ func TestApplyIntentLifecycle_Case4_Active_ShouldActive_TargetMatch_Noop(t *test
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	// First arm
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 	cur1, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 
 	// Re-apply with same status / same target — should be a noop
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	if rec.startCount() != 1 {
 		t.Fatalf("detector started count = %d, want 1 (case 4 noop)", rec.startCount())
@@ -252,7 +252,7 @@ func TestApplyIntentLifecycle_Case5_Active_ShouldActive_TargetMismatch_CancelAnd
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 	cur1, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 
@@ -274,7 +274,7 @@ func TestApplyIntentLifecycle_Case5_Active_ShouldActive_TargetMismatch_CancelAnd
 		t.Fatalf("Upsert frame: %v", err)
 	}
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	// Wait for second start.
 	waitFor(t, time.Second, func() bool { return rec.startCount() == 2 }, "second detector start")
@@ -301,11 +301,11 @@ func TestReconcileSessionActive_UnknownAgent_DropAll(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 
 	// Pretend agentType swap to an unregistered name.
-	m.probeIntentDisp.applyStatus("work", "ghost-agent", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "ghost-agent", agentpkg.StatusRunning, nil)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("activeProbeIntents present after unknown-agent reconcile")
@@ -319,12 +319,12 @@ func TestReconcileSessionActive_ProviderHasNoIntents_DropAll(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 
 	// Register a no-intent provider with a different agent name and switch.
 	m.registry.Register(&fakeAgentProvider{typeName: "cc-noprobes"})
-	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning, nil)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("activeProbeIntents present after switching to no-probe provider")
@@ -340,7 +340,7 @@ func TestReconcileSessionActive_AgentTypeChanged_DropOld(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 	cur1, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 	if cur1.agentType != "codex" {
@@ -372,7 +372,7 @@ func TestReconcileSessionActive_AgentTypeChanged_DropOld(t *testing.T) {
 		t.Fatalf("Delete frame: %v", err)
 	}
 
-	m.probeIntentDisp.applyStatus("work", "alt-codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "alt-codex", agentpkg.StatusRunning, nil)
 	waitFor(t, time.Second, func() bool {
 		cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 		return ok && cur.agentType == "alt-codex"
@@ -390,7 +390,7 @@ func TestReconcileSessionActive_KindNotInDeclared_DropOldKind(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 
 	// Register an alt agent that declares NO intents and switch.
@@ -398,7 +398,7 @@ func TestReconcileSessionActive_KindNotInDeclared_DropOldKind(t *testing.T) {
 		fakeAgentProvider: fakeAgentProvider{typeName: "alt-noprobedead"},
 		intents:           nil, // empty declared kinds
 	})
-	m.probeIntentDisp.applyStatus("work", "alt-noprobedead", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "alt-noprobedead", agentpkg.StatusRunning, nil)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("ProcessDead entry present after switching to provider without it")
@@ -440,7 +440,7 @@ func TestConsumeSignals_AppliedTrue_ReRunsApplyStatus(t *testing.T) {
 	})
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	// After detector emits PaneAlive=true → OnSignal returns Error → guards
 	// pass → applied=true → consumeSignals invokes applyStatus(error) →
@@ -499,7 +499,7 @@ func TestConsumeSignals_AppliedFalse_NoTeardown(t *testing.T) {
 	m.currentStatus["work"] = agentpkg.StatusError
 	m.mu.Unlock()
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusError)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusError, nil)
 
 	// Active entry should remain (no probe-applied teardown happened).
 	// Wait a brief moment for the detector to emit + guard to drop.
@@ -594,7 +594,7 @@ func TestApplyIntentLifecycle_StatusChangedBetweenSnapshotAndArm_NoArming(t *tes
 	m.currentStatus["work"] = agentpkg.StatusIdle
 	m.mu.Unlock()
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 
 	if rec.startCount() != 0 {
 		t.Fatalf("detector started despite live currentStatus = Idle; want zero starts")
@@ -613,7 +613,7 @@ func TestStopAll_CancelsAndClearsActiveMap(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
 	<-rec.started
 
 	m.probeIntentDisp.stopAll()
@@ -727,5 +727,89 @@ func TestReplayStatus_StaleFrame_DetectorEmitsImmediately(t *testing.T) {
 	m.mu.Unlock()
 	if got != agentpkg.StatusError {
 		t.Fatalf("currentStatus = %q, want error after stale-frame replay", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Bundle #3: probeIntentTargetHint fast-path
+// -----------------------------------------------------------------------------
+
+// TestApplyStatus_HintBypassesFrameLookup pins the codex hook-pipeline-lag
+// fix #3 contract: a non-nil hint with paneID + senderPID populated must
+// arm the detector with the hint values without consulting
+// lookupTopFrameForSessionLocked. Sessions whose frame is missing from the
+// store would otherwise miss case-2 arming on the slow path; the hint
+// route lets the live hook-handler caller (handler.go) pass through its
+// projection.TopFrame snapshot directly.
+//
+// Two-call test:
+//
+//  1. nil hint, no frame seeded — slow lookup misses → case "shouldActive
+//     but lookup miss" applies; no arm because nothing was wasActive.
+//  2. hint provided, no frame seeded — hint path arms the detector with
+//     hint.paneID / hint.senderPID even though the slow lookup would have
+//     failed.
+func TestApplyStatus_HintBypassesFrameLookup(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	// Seed currentStatus only — no frame in m.frames store, so
+	// lookupTopFrameForSessionLocked returns hasFrame=false.
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+
+	// (1) nil hint → slow lookup misses → no arm.
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	if rec.startCount() != 0 {
+		t.Fatalf("nil-hint detector started count = %d, want 0 (slow lookup must miss)", rec.startCount())
+	}
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("nil-hint activeProbeIntents present, want absent")
+	}
+
+	// (2) hint provided → arm with hint values (no frame seeded).
+	hint := &probeIntentTargetHint{paneID: "%9", senderPID: 8888}
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, hint)
+	<-rec.started
+	if rec.startCount() != 1 {
+		t.Fatalf("hint detector started count = %d, want 1", rec.startCount())
+	}
+	cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if !ok {
+		t.Fatalf("hint activeProbeIntents missing, want set")
+	}
+	if cur.agentType != "codex" || cur.paneID != "%9" || cur.senderPID != 8888 {
+		t.Fatalf("hint active entry = %+v, want codex/%%9/8888", cur)
+	}
+	rec.mu.Lock()
+	gotPaneID := rec.starts[0].PaneID
+	gotPID := rec.starts[0].SenderPID
+	rec.mu.Unlock()
+	if gotPaneID != "%9" || gotPID != 8888 {
+		t.Fatalf("detector started with paneID=%q senderPID=%d, want %%9/8888", gotPaneID, gotPID)
+	}
+}
+
+// TestApplyStatus_HintIncomplete_FallsBackToLookup verifies the empty-hint
+// guard: a hint struct with paneID="" or senderPID=0 must not be treated
+// as a valid fast-path target — the slow lookup runs as if hint were nil.
+// Production callers always populate both fields when they have
+// projection.TopFrame, but the guard is the contract that test mocks /
+// future callers can rely on.
+func TestApplyStatus_HintIncomplete_FallsBackToLookup(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	// Hint with empty paneID → guard rejects, slow lookup arms with frame.
+	hint := &probeIntentTargetHint{paneID: "", senderPID: 8888}
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, hint)
+	<-rec.started
+	cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if !ok {
+		t.Fatalf("activeProbeIntents missing, want set")
+	}
+	if cur.paneID != "%5" || cur.senderPID != 4242 {
+		t.Fatalf("active entry = paneID=%q senderPID=%d, want %%5/4242 (slow lookup, hint rejected)", cur.paneID, cur.senderPID)
 	}
 }

--- a/internal/module/agent/probe_intent_dispatcher_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_test.go
@@ -734,42 +734,71 @@ func TestReplayStatus_StaleFrame_DetectorEmitsImmediately(t *testing.T) {
 // Round-2 audit fixes: F1 graceWindow strand / F2 generation-scoped teardown / F6 fail-closed
 // -----------------------------------------------------------------------------
 
-// TestConsumeSignals_GraceWindowDrop_TearsDownActiveEntry pins F1: when a
-// one-shot detector emits its sole Signal during an active graceWindow,
-// applyProbeGuards drops the signal (applied=false), the channel closes,
-// and consumeSignals' post-loop teardown must remove the active entry —
-// otherwise a future status change observes case-4 (target match) and the
-// detector never re-arms, leaving codex permanently undetected.
-func TestConsumeSignals_GraceWindowDrop_TearsDownActiveEntry(t *testing.T) {
+// TestConsumeSignals_GraceWindowDrop_RearmsAfterTeardown pins F1 +
+// round-3 follow-up: when a one-shot detector emits its sole Signal
+// during an active graceWindow, applyProbeGuards drops the signal
+// (applied=false), the channel closes, and consumeSignals' post-loop
+// path must (1) remove the stranded active entry (F1) AND (2) re-arm
+// a fresh generation if currentStatus still gates the intent — otherwise
+// a codex that dies within graceWindow is permanently undetected
+// because there's no future hook to trigger lifecycle.
+//
+// The detector emits exactly once; subsequent arms block on ctx so the
+// rearm cycle stays bounded (production graceWindow expiry breaks the
+// cycle within 2-3 detector polls).
+func TestConsumeSignals_GraceWindowDrop_RearmsAfterTeardown(t *testing.T) {
 	m := newDispatcherTestModule(t)
 	m.sessions = &fakeSessionProvider{}
-	// Emit-once-and-exit detector mirrors production codex (returns after
-	// emit, channel closes via wrapping goroutine).
+
+	var emitCount atomic.Int64
 	m.probeIntentDisp.startDetector = func(ctx context.Context, _ *Module, _ agentpkg.ProbeIntentKind, _ string, _ int, out chan<- agentpkg.Signal) {
-		select {
-		case out <- agentpkg.Signal{
-			Kind:      agentpkg.ProbeIntentKindProcessDead,
-			PaneAlive: true,
-			PaneID:    "%5",
-			SenderPID: 4242,
-		}:
-		case <-ctx.Done():
+		// Only the first arm emits — subsequent rearms block so the test
+		// can settle on a single rearm without runaway loops.
+		if emitCount.Add(1) == 1 {
+			select {
+			case out <- agentpkg.Signal{
+				Kind:      agentpkg.ProbeIntentKindProcessDead,
+				PaneAlive: true,
+				PaneID:    "%5",
+				SenderPID: 4242,
+			}:
+			case <-ctx.Done():
+			}
+			return
 		}
+		<-ctx.Done()
 	}
 	t.Cleanup(func() { m.probeIntentDisp.stopAll() })
 
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
-	// Open graceWindow: any probe signal arriving in the next probeGraceWindow
-	// is suppressed. With the F1 fix, the active entry must still be torn
-	// down so a subsequent crash is not missed.
+	// Open graceWindow: probe signal in the next probeGraceWindow is
+	// suppressed. The F1 fix tears down + the round-3 follow-up rearms.
 	m.probeOrch.recordHookAt("work")
 
 	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
+	// Capture gen 1 (first arm) before the teardown+rearm cycle completes.
+	var gen1 uint64
+	waitFor(t, time.Second, func() bool {
+		cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		if !ok {
+			return false
+		}
+		gen1 = cur.generation
+		return gen1 > 0
+	}, "gen 1 active entry observed before teardown")
+
+	// Wait for the rearm: emitCount becomes 2 (second arm) AND active
+	// entry's generation has advanced past gen 1. With the round-3 fix
+	// the post-loop teardown calls applyStatus → applyIntentLifecycle
+	// arms a fresh gen.
 	waitFor(t, 2*time.Second, func() bool {
-		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
-		return !ok
-	}, "active entry torn down post-loop after graceWindow drop (F1)")
+		cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		if !ok {
+			return false
+		}
+		return cur.generation > gen1 && emitCount.Load() >= 2
+	}, "rearm with new generation after graceWindow drop (F1 round-3 follow-up)")
 }
 
 // TestStopActiveIntentInLock_GenerationMismatch_PreservesEntry pins F2:

--- a/internal/module/agent/probe_intent_dispatcher_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_test.go
@@ -627,3 +627,105 @@ func TestStopAll_CancelsAndClearsActiveMap(t *testing.T) {
 
 	waitFor(t, time.Second, func() bool { return rec.cancelCount() == 1 }, "detector cancel after stopAll")
 }
+
+// -----------------------------------------------------------------------------
+// W6-3 P1-T6: replayStatus daemon-restart recovery (closes #698)
+// -----------------------------------------------------------------------------
+
+// TestReplayStatus_RunningSession_DetectorArmed pins the recovery contract:
+// after replayFromDB hydrates currentStatus + frame projection, replayStatus
+// re-runs applyStatus per session so a session whose top frame matches a
+// ProbeIntent provider rearms its detector.
+func TestReplayStatus_RunningSession_DetectorArmed(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	if fake, ok := m.tmux.(*tmux.FakeExecutor); ok {
+		fake.SetPaneSessionName("%5", "work")
+	}
+	// Seed a frame + currentStatus the way replayFromDB would after a
+	// daemon restart with codex still running on session "work".
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.replayStatus()
+
+	<-rec.started
+	if rec.startCount() != 1 {
+		t.Fatalf("detector started count = %d, want 1", rec.startCount())
+	}
+	cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+	if !ok {
+		t.Fatalf("activeProbeIntents missing after replayStatus")
+	}
+	if cur.agentType != "codex" || cur.paneID != "%5" || cur.senderPID != 4242 {
+		t.Fatalf("active entry = %+v, want codex/%%5/4242", cur)
+	}
+}
+
+// TestReplayStatus_IdleSession_DetectorNotArmed pins the gating contract:
+// a session whose replayed status is Idle (not in OnEntryStatus for the
+// ProcessDead intent) does NOT arm a detector.
+func TestReplayStatus_IdleSession_DetectorNotArmed(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	rec := installRecordingDetector(t, m)
+	if fake, ok := m.tmux.(*tmux.FakeExecutor); ok {
+		fake.SetPaneSessionName("%5", "work")
+	}
+	// Seed a frame but flip currentStatus to Idle.
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	m.probeIntentDisp.replayStatus()
+
+	// Give any goroutine that might wrongly start a brief moment to do so.
+	time.Sleep(20 * time.Millisecond)
+	if rec.startCount() != 0 {
+		t.Fatalf("detector started for idle session: count = %d, want 0", rec.startCount())
+	}
+	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
+		t.Fatalf("activeProbeIntents present for idle session, want absent")
+	}
+}
+
+// TestReplayStatus_StaleFrame_DetectorEmitsImmediately exercises the
+// canonical issue-#698 fix path: daemon restart inherits a frame whose
+// process has already died. The detector (here stub-driven via
+// installEmitOnceDetector) emits a Signal on first call; consumeSignals
+// runs it through applyProbeGuards which broadcasts error + tears down
+// the active entry.
+//
+// In production the detector polls IsPidAlive at 1Hz; here we simulate
+// the immediate emit so the test stays deterministic without timing
+// dependencies. Real codex emit path is tested in P2-T7 / mlab.
+func TestReplayStatus_StaleFrame_DetectorEmitsImmediately(t *testing.T) {
+	m := newDispatcherTestModule(t)
+	m.sessions = &fakeSessionProvider{}
+	if fake, ok := m.tmux.(*tmux.FakeExecutor); ok {
+		fake.SetPaneSessionName("%5", "work")
+	}
+	installEmitOnceDetector(t, m, agentpkg.Signal{
+		Kind:      agentpkg.ProbeIntentKindProcessDead,
+		PaneAlive: true,
+		PaneID:    "%5",
+		SenderPID: 4242,
+	})
+	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
+
+	m.probeIntentDisp.replayStatus()
+
+	// After detector emits PaneAlive=true → OnSignal returns Error → guards
+	// pass → applied=true → consumeSignals invokes applyStatus(error) →
+	// case 3 tears down the active entry.
+	waitFor(t, time.Second, func() bool {
+		_, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
+		return !ok
+	}, "active entry torn down after stale-frame emit")
+
+	m.mu.Lock()
+	got := m.currentStatus["work"]
+	m.mu.Unlock()
+	if got != agentpkg.StatusError {
+		t.Fatalf("currentStatus = %q, want error after stale-frame replay", got)
+	}
+}

--- a/internal/module/agent/probe_intent_dispatcher_test.go
+++ b/internal/module/agent/probe_intent_dispatcher_test.go
@@ -161,7 +161,7 @@ func TestApplyIntentLifecycle_Case1_NotActive_NotShouldActive_Noop(t *testing.T)
 	rec := installRecordingDetector(t, m)
 
 	// Status idle, not in OnEntryStatus
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle)
 
 	if rec.startCount() != 0 {
 		t.Fatalf("detector started count = %d, want 0", rec.startCount())
@@ -177,7 +177,7 @@ func TestApplyIntentLifecycle_Case2_NotActive_ShouldActive_Start(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	<-rec.started
 	if rec.startCount() != 1 {
@@ -206,14 +206,14 @@ func TestApplyIntentLifecycle_Case3_Active_NotShouldActive_Stop(t *testing.T) {
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	// Arm
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 
 	// Transition to idle (not in OnEntryStatus)
 	m.mu.Lock()
 	m.currentStatus["work"] = agentpkg.StatusIdle
 	m.mu.Unlock()
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusIdle)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("activeProbeIntents present after idle, want absent")
@@ -228,12 +228,12 @@ func TestApplyIntentLifecycle_Case4_Active_ShouldActive_TargetMatch_Noop(t *test
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
 	// First arm
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 	cur1, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 
 	// Re-apply with same status / same target — should be a noop
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	if rec.startCount() != 1 {
 		t.Fatalf("detector started count = %d, want 1 (case 4 noop)", rec.startCount())
@@ -252,7 +252,7 @@ func TestApplyIntentLifecycle_Case5_Active_ShouldActive_TargetMismatch_CancelAnd
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 	cur1, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 
@@ -274,7 +274,7 @@ func TestApplyIntentLifecycle_Case5_Active_ShouldActive_TargetMismatch_CancelAnd
 		t.Fatalf("Upsert frame: %v", err)
 	}
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	// Wait for second start.
 	waitFor(t, time.Second, func() bool { return rec.startCount() == 2 }, "second detector start")
@@ -301,11 +301,11 @@ func TestReconcileSessionActive_UnknownAgent_DropAll(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 
 	// Pretend agentType swap to an unregistered name.
-	m.probeIntentDisp.applyStatus("work", "ghost-agent", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "ghost-agent", agentpkg.StatusRunning)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("activeProbeIntents present after unknown-agent reconcile")
@@ -319,12 +319,12 @@ func TestReconcileSessionActive_ProviderHasNoIntents_DropAll(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 
 	// Register a no-intent provider with a different agent name and switch.
 	m.registry.Register(&fakeAgentProvider{typeName: "cc-noprobes"})
-	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "cc-noprobes", agentpkg.StatusRunning)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("activeProbeIntents present after switching to no-probe provider")
@@ -340,7 +340,7 @@ func TestReconcileSessionActive_AgentTypeChanged_DropOld(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 	cur1, _ := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 	if cur1.agentType != "codex" {
@@ -372,7 +372,7 @@ func TestReconcileSessionActive_AgentTypeChanged_DropOld(t *testing.T) {
 		t.Fatalf("Delete frame: %v", err)
 	}
 
-	m.probeIntentDisp.applyStatus("work", "alt-codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "alt-codex", agentpkg.StatusRunning)
 	waitFor(t, time.Second, func() bool {
 		cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
 		return ok && cur.agentType == "alt-codex"
@@ -390,7 +390,7 @@ func TestReconcileSessionActive_KindNotInDeclared_DropOldKind(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 
 	// Register an alt agent that declares NO intents and switch.
@@ -398,7 +398,7 @@ func TestReconcileSessionActive_KindNotInDeclared_DropOldKind(t *testing.T) {
 		fakeAgentProvider: fakeAgentProvider{typeName: "alt-noprobedead"},
 		intents:           nil, // empty declared kinds
 	})
-	m.probeIntentDisp.applyStatus("work", "alt-noprobedead", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "alt-noprobedead", agentpkg.StatusRunning)
 
 	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
 		t.Fatalf("ProcessDead entry present after switching to provider without it")
@@ -440,7 +440,7 @@ func TestConsumeSignals_AppliedTrue_ReRunsApplyStatus(t *testing.T) {
 	})
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	// After detector emits PaneAlive=true → OnSignal returns Error → guards
 	// pass → applied=true → consumeSignals invokes applyStatus(error) →
@@ -499,7 +499,7 @@ func TestConsumeSignals_AppliedFalse_NoTeardown(t *testing.T) {
 	m.currentStatus["work"] = agentpkg.StatusError
 	m.mu.Unlock()
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusError, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusError)
 
 	// Active entry should remain (no probe-applied teardown happened).
 	// Wait a brief moment for the detector to emit + guard to drop.
@@ -594,7 +594,7 @@ func TestApplyIntentLifecycle_StatusChangedBetweenSnapshotAndArm_NoArming(t *tes
 	m.currentStatus["work"] = agentpkg.StatusIdle
 	m.mu.Unlock()
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 
 	if rec.startCount() != 0 {
 		t.Fatalf("detector started despite live currentStatus = Idle; want zero starts")
@@ -613,7 +613,7 @@ func TestStopAll_CancelsAndClearsActiveMap(t *testing.T) {
 	rec := installRecordingDetector(t, m)
 	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
 
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
+	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning)
 	<-rec.started
 
 	m.probeIntentDisp.stopAll()
@@ -727,89 +727,5 @@ func TestReplayStatus_StaleFrame_DetectorEmitsImmediately(t *testing.T) {
 	m.mu.Unlock()
 	if got != agentpkg.StatusError {
 		t.Fatalf("currentStatus = %q, want error after stale-frame replay", got)
-	}
-}
-
-// -----------------------------------------------------------------------------
-// Bundle #3: probeIntentTargetHint fast-path
-// -----------------------------------------------------------------------------
-
-// TestApplyStatus_HintBypassesFrameLookup pins the codex hook-pipeline-lag
-// fix #3 contract: a non-nil hint with paneID + senderPID populated must
-// arm the detector with the hint values without consulting
-// lookupTopFrameForSessionLocked. Sessions whose frame is missing from the
-// store would otherwise miss case-2 arming on the slow path; the hint
-// route lets the live hook-handler caller (handler.go) pass through its
-// projection.TopFrame snapshot directly.
-//
-// Two-call test:
-//
-//  1. nil hint, no frame seeded — slow lookup misses → case "shouldActive
-//     but lookup miss" applies; no arm because nothing was wasActive.
-//  2. hint provided, no frame seeded — hint path arms the detector with
-//     hint.paneID / hint.senderPID even though the slow lookup would have
-//     failed.
-func TestApplyStatus_HintBypassesFrameLookup(t *testing.T) {
-	m := newDispatcherTestModule(t)
-	rec := installRecordingDetector(t, m)
-	// Seed currentStatus only — no frame in m.frames store, so
-	// lookupTopFrameForSessionLocked returns hasFrame=false.
-	m.mu.Lock()
-	m.currentStatus["work"] = agentpkg.StatusRunning
-	m.mu.Unlock()
-
-	// (1) nil hint → slow lookup misses → no arm.
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, nil)
-	if rec.startCount() != 0 {
-		t.Fatalf("nil-hint detector started count = %d, want 0 (slow lookup must miss)", rec.startCount())
-	}
-	if _, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead); ok {
-		t.Fatalf("nil-hint activeProbeIntents present, want absent")
-	}
-
-	// (2) hint provided → arm with hint values (no frame seeded).
-	hint := &probeIntentTargetHint{paneID: "%9", senderPID: 8888}
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, hint)
-	<-rec.started
-	if rec.startCount() != 1 {
-		t.Fatalf("hint detector started count = %d, want 1", rec.startCount())
-	}
-	cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
-	if !ok {
-		t.Fatalf("hint activeProbeIntents missing, want set")
-	}
-	if cur.agentType != "codex" || cur.paneID != "%9" || cur.senderPID != 8888 {
-		t.Fatalf("hint active entry = %+v, want codex/%%9/8888", cur)
-	}
-	rec.mu.Lock()
-	gotPaneID := rec.starts[0].PaneID
-	gotPID := rec.starts[0].SenderPID
-	rec.mu.Unlock()
-	if gotPaneID != "%9" || gotPID != 8888 {
-		t.Fatalf("detector started with paneID=%q senderPID=%d, want %%9/8888", gotPaneID, gotPID)
-	}
-}
-
-// TestApplyStatus_HintIncomplete_FallsBackToLookup verifies the empty-hint
-// guard: a hint struct with paneID="" or senderPID=0 must not be treated
-// as a valid fast-path target — the slow lookup runs as if hint were nil.
-// Production callers always populate both fields when they have
-// projection.TopFrame, but the guard is the contract that test mocks /
-// future callers can rely on.
-func TestApplyStatus_HintIncomplete_FallsBackToLookup(t *testing.T) {
-	m := newDispatcherTestModule(t)
-	rec := installRecordingDetector(t, m)
-	seedRunningFrame(t, m, "work", "%5", "codex", 4242)
-
-	// Hint with empty paneID → guard rejects, slow lookup arms with frame.
-	hint := &probeIntentTargetHint{paneID: "", senderPID: 8888}
-	m.probeIntentDisp.applyStatus("work", "codex", agentpkg.StatusRunning, hint)
-	<-rec.started
-	cur, ok := readActiveIntent(m, "work", agentpkg.ProbeIntentKindProcessDead)
-	if !ok {
-		t.Fatalf("activeProbeIntents missing, want set")
-	}
-	if cur.paneID != "%5" || cur.senderPID != 4242 {
-		t.Fatalf("active entry = paneID=%q senderPID=%d, want %%5/4242 (slow lookup, hint rejected)", cur.paneID, cur.senderPID)
 	}
 }

--- a/internal/module/agent/probe_orchestrator.go
+++ b/internal/module/agent/probe_orchestrator.go
@@ -222,6 +222,13 @@ func (o *probeOrchestrator) makeCallback(session, agentType string) probe.Screen
 //     callbacks) and again inside the final critical section (closes the
 //     race window where stop / rename / generation-bump won between the
 //     early unlock and the final lock; codex finding #4 regression).
+//   - OnDrop: optional caller-aware drop callback (W6-3 P2-T6). When non-nil
+//     applyProbeGuards invokes it once with one of the canonical drop
+//     reasons ("stale-callback" / "grace" / "error-guard" / "transition-gate")
+//     before returning applied=false. ScreenChange callers leave this nil so
+//     legacy MetricProbeGraceWindowSuppressed semantics stay intact;
+//     ProbeIntent callers pass probeIntentOnDrop so each drop reason routes
+//     to its own counter + dev log line for fault isolation.
 type probeGuardArgs struct {
 	Session    string
 	AgentType  string
@@ -229,6 +236,7 @@ type probeGuardArgs struct {
 	Signal     agentpkg.Signal
 	Mapping    func(agentpkg.Signal) agentpkg.Status
 	StaleCheck func(*Module) bool
+	OnDrop     func(reason string)
 }
 
 // applyProbeGuards runs the shared probe-status-transition pipeline:
@@ -259,6 +267,9 @@ func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
 	staleOK := args.StaleCheck != nil && args.StaleCheck(m)
 	m.mu.Unlock()
 	if !staleOK {
+		if args.OnDrop != nil {
+			args.OnDrop("stale-callback")
+		}
 		return false
 	}
 
@@ -273,6 +284,9 @@ func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
 			if isDevMode() {
 				log.Printf("[probe] graceWindow suppress session=%s agent=%s reason=%s",
 					args.Session, args.AgentType, args.Reason)
+			}
+			if args.OnDrop != nil {
+				args.OnDrop("grace")
 			}
 			return false
 		}
@@ -299,14 +313,23 @@ func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
 	m.mu.Lock()
 	if args.StaleCheck == nil || !args.StaleCheck(m) {
 		m.mu.Unlock()
+		if args.OnDrop != nil {
+			args.OnDrop("stale-callback")
+		}
 		return false
 	}
 	if m.currentStatus[args.Session] == agentpkg.StatusError {
 		m.mu.Unlock()
+		if args.OnDrop != nil {
+			args.OnDrop("error-guard")
+		}
 		return false
 	}
 	if prev, ok := m.currentStatus[args.Session]; ok && prev == newStatus {
 		m.mu.Unlock()
+		if args.OnDrop != nil {
+			args.OnDrop("transition-gate")
+		}
 		return false
 	}
 	m.currentStatus[args.Session] = newStatus

--- a/internal/module/agent/probe_orchestrator.go
+++ b/internal/module/agent/probe_orchestrator.go
@@ -206,9 +206,143 @@ func (o *probeOrchestrator) makeCallback(session, agentType string) probe.Screen
 	}
 }
 
+// probeGuardArgs is the input contract for applyProbeGuards. Caller fills:
+//   - Session / AgentType: identity used by the dev log + downstream broadcast
+//   - Reason: rawEventName placed on the broadcast NormalizedEvent
+//     (ScreenChange path: "probe:activity"; ProbeIntent path: e.g.
+//     "probe-intent:process_dead")
+//   - Signal: raw detector signal, passed verbatim to Mapping. ScreenChange
+//     callers may leave this zero; ProbeIntent callers fill from the channel
+//   - Mapping: per-route status mapping callback. Invoked AFTER the
+//     stale-callback fast-path + graceWindow guard pass (per by2z79ouc DEF-1
+//     contract). Returning "" drops the signal.
+//   - StaleCheck: per-route active-set checker. Invoked WHILE m.mu is held by
+//     applyProbeGuards (caller therefore reads from m.* maps lock-free).
+//     Run twice — once on the early fast-path (cheap stale-drop for ghost
+//     callbacks) and again inside the final critical section (closes the
+//     race window where stop / rename / generation-bump won between the
+//     early unlock and the final lock; codex finding #4 regression).
+type probeGuardArgs struct {
+	Session    string
+	AgentType  string
+	Reason     string
+	Signal     agentpkg.Signal
+	Mapping    func(agentpkg.Signal) agentpkg.Status
+	StaleCheck func(*Module) bool
+}
+
+// applyProbeGuards runs the shared probe-status-transition pipeline:
+//
+//  1. Stale-callback fast-path: m.mu Lock → StaleCheck(m); reject if false.
+//  2. graceWindow suppression: hook within probeGraceWindow → drop + counter.
+//  3. Mapping callback: caller-provided Signal → Status; "" means drop.
+//  4. Final critical section: m.mu Lock → StaleCheck re-check + ErrorGuard +
+//     transition gate; mutate currentStatus on pass.
+//  5. Broadcast: setProjectionTopStatus + buildProjectionNormalized +
+//     broadcastToSession (with NormalizedEvent fallback when the projection
+//     is unavailable).
+//
+// Returns applied=true iff step 4 mutated currentStatus and step 5 broadcast
+// the transition. Every other branch returns applied=false.
+//
+// W6-3 P1-T2: extracted from interpretScreenEvent so the W6-3 ProbeIntent
+// dispatcher (P1-T4) can reuse the same guard pipeline through different
+// StaleCheck / Mapping strategies. ScreenChange path is a strict mechanical
+// extraction — pre-extraction tests must remain green.
+func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
+	if m == nil {
+		return false
+	}
+
+	// 1. Stale-callback guard (early fast-path; lock-free read inside m.mu).
+	m.mu.Lock()
+	staleOK := args.StaleCheck != nil && args.StaleCheck(m)
+	m.mu.Unlock()
+	if !staleOK {
+		return false
+	}
+
+	// 2. graceWindow suppression (independent graceMu — no nesting w/ m.mu).
+	if m.probeOrch != nil {
+		o := m.probeOrch
+		o.graceMu.Lock()
+		last, hasHook := o.lastHookAt[args.Session]
+		o.graceMu.Unlock()
+		if hasHook && orchNowFn().Sub(last) < probeGraceWindow {
+			agentpkg.MetricProbeGraceWindowSuppressed.Add(1)
+			if isDevMode() {
+				log.Printf("[probe] graceWindow suppress session=%s agent=%s reason=%s",
+					args.Session, args.AgentType, args.Reason)
+			}
+			return false
+		}
+	}
+
+	// 3. Mapping callback (per by2z79ouc DEF-1 — invoked only after stale +
+	//    graceWindow guards pass; OnSignal handlers may safely log/count).
+	if args.Mapping == nil {
+		return false
+	}
+	newStatus := args.Mapping(args.Signal)
+	if newStatus == "" {
+		return false
+	}
+
+	// Test-only seam: simulate a concurrent stop/rename that mutates the
+	// active-set between the early fast-path and the final critical section.
+	// Production leaves interruptBeforeFinalLockFn nil (no-op).
+	if hook := interruptBeforeFinalLockFn; hook != nil {
+		hook(args.Session)
+	}
+
+	// 4. Final critical section: atomic re-check + ErrorGuard + transition gate.
+	m.mu.Lock()
+	if args.StaleCheck == nil || !args.StaleCheck(m) {
+		m.mu.Unlock()
+		return false
+	}
+	if m.currentStatus[args.Session] == agentpkg.StatusError {
+		m.mu.Unlock()
+		return false
+	}
+	if prev, ok := m.currentStatus[args.Session]; ok && prev == newStatus {
+		m.mu.Unlock()
+		return false
+	}
+	m.currentStatus[args.Session] = newStatus
+	m.mu.Unlock()
+
+	// 5. Broadcast.
+	agentpkg.MetricProbeScreenEvent.Add(1)
+	if isDevMode() {
+		log.Printf("[probe] status session=%s agent=%s status=%s reason=%s",
+			args.Session, args.AgentType, newStatus, args.Reason)
+	}
+	if projection, err := m.setProjectionTopStatus(args.Session, newStatus); err == nil && projection != nil {
+		normalized := buildProjectionNormalized(projection, args.AgentType, args.Reason, time.Now().UnixNano(), agentpkg.DeriveResult{})
+		m.broadcastToSession(args.Session, normalized)
+		return true
+	}
+	// Fallback when the projection is unavailable (e.g. frames row removed
+	// concurrently with the event). Broadcast a minimal normalized event so
+	// SPA clients still see the status change.
+	normalized := agentpkg.NormalizedEvent{
+		AgentType:    args.AgentType,
+		Status:       string(newStatus),
+		RawEventName: args.Reason,
+		BroadcastTs:  time.Now().UnixNano(),
+	}
+	m.broadcastToSession(args.Session, normalized)
+	return true
+}
+
 // interpretScreenEvent maps a raw probe.ScreenChangeEvent to a status
-// transition (or drops it). Guards run in this order — each layer encodes
-// a specific invariant:
+// transition via applyProbeGuards. The Kind→Status mapping (including the
+// ScreenStable cheap pre-gate, the independent bottom capture, and the
+// dead-PID + shell-prompt sweep branch) stays in this caller layer because
+// the sweep branch may early-return without invoking the dispatcher.
+//
+// Guard layering — each layer encodes a specific invariant:
 //
 //  1. Stale-callback guard (R4): activeWatchers must contain (session →
 //     agentType). After stopWatch / rename the closure may still be invoked
@@ -237,39 +371,23 @@ func (o *probeOrchestrator) interpretScreenEvent(session, agentType string, ev p
 	}
 	m := o.parent
 
-	// 1. Stale-callback guard (early fast-path).
+	// Read prevStatus for the cheap ScreenStable pre-gate (codex finding #8).
+	// This is an upfront read independent of the guard pipeline; it does not
+	// substitute for the StaleCheck closure (which still runs inside
+	// applyProbeGuards under m.mu in steps 1 and 4).
 	m.mu.Lock()
-	currentAgent, active := m.activeWatchers[session]
 	prevStatus, hasPrev := m.currentStatus[session]
 	m.mu.Unlock()
-	if !active || currentAgent != agentType {
-		return
-	}
 
-	// 2. graceWindow suppression.
-	o.graceMu.Lock()
-	last, hasHook := o.lastHookAt[session]
-	o.graceMu.Unlock()
-	if hasHook && orchNowFn().Sub(last) < probeGraceWindow {
-		agentpkg.MetricProbeGraceWindowSuppressed.Add(1)
-		if isDevMode() {
-			log.Printf("[probe] graceWindow suppress session=%s agent=%s kind=%s", session, agentType, ev.Kind)
-		}
-		return
-	}
-
-	// 3. Kind → status mapping.
+	// Step 3 mapping (Kind → status), kept in the caller layer because the
+	// ScreenStable + dead-PID + shell-prompt branch must early-return on
+	// sweep without entering the dispatcher.
 	var status agentpkg.Status
 	switch ev.Kind {
 	case probe.ScreenChanged:
 		status = agentpkg.StatusRunning
 	case probe.ScreenStable:
-		// Cheap pre-gate (codex finding #8): if already Idle and top-frame
-		// PID is alive, the bottom capture would only feed a transition
-		// gate that's about to drop Idle→Idle. Continuous-stable Idle
-		// panes are common (a session sitting at a shell prompt) — skipping
-		// the tmux subprocess here is a measurable cost win. Dead-PID
-		// branch falls through so the sweep cleanup path keeps working.
+		// Cheap pre-gate: stable-Idle + alive top-frame PID is a no-op.
 		if hasPrev && prevStatus == agentpkg.StatusIdle {
 			projection, _ := m.projectionForSession(session)
 			if projection == nil || projection.TopFrame == nil || isPidAliveFn(projection.TopFrame.PID) {
@@ -278,12 +396,7 @@ func (o *probeOrchestrator) interpretScreenEvent(session, agentType string, ev p
 			// Stable Idle + dead PID: fall through to bottom capture for
 			// shell-prompt classification + sweep cleanup.
 		}
-		// R14 fix #1: ev.Content reflects the watcher's TopLines / BottomLines
-		// configuration. For agents on a TopLines profile the captured content
-		// won't include the bottom shell prompt, so LooksLikeShellPrompt would
-		// false-negative. Take an independent bottom-N capture for the
-		// shell-prompt classifier; treat any tmux error as "not a shell
-		// prompt" (conservative — fall through to Idle, never block).
+		// Independent bottom capture for shell-prompt classification.
 		var bottomContent string
 		if m.tmux != nil {
 			if c, err := m.tmux.CapturePaneContent(session+":", 10); err == nil {
@@ -302,52 +415,19 @@ func (o *probeOrchestrator) interpretScreenEvent(session, agentType string, ev p
 		return
 	}
 
-	// Test-only seam: simulate a concurrent stop/rename that mutates
-	// activeWatchers between the early fast-path and the final critical
-	// section. Production leaves interruptBeforeFinalLockFn nil (no-op).
-	if hook := interruptBeforeFinalLockFn; hook != nil {
-		hook(session)
-	}
-
-	// 1 (re-check) + 4. Error Guard + 5. Transition gate.
-	// Single critical section; the re-check of activeWatchers closes the
-	// race window where stopWatch/rename mutated the map between the early
-	// unlock at step 1 and this lock (codex finding #4 regression).
-	m.mu.Lock()
-	currentAgent, active = m.activeWatchers[session]
-	if !active || currentAgent != agentType {
-		m.mu.Unlock()
-		return
-	}
-	if m.currentStatus[session] == agentpkg.StatusError {
-		m.mu.Unlock()
-		return
-	}
-	if prev, ok := m.currentStatus[session]; ok && prev == status {
-		m.mu.Unlock()
-		return
-	}
-	m.currentStatus[session] = status
-	m.mu.Unlock()
-
-	// 6. Apply transition.
-	agentpkg.MetricProbeScreenEvent.Add(1)
-	if isDevMode() {
-		log.Printf("[probe] status session=%s agent=%s status=%s reason=screen-%s", session, agentType, status, ev.Kind)
-	}
-	if projection, err := m.setProjectionTopStatus(session, status); err == nil && projection != nil {
-		normalized := buildProjectionNormalized(projection, agentType, "probe:activity", time.Now().UnixNano(), agentpkg.DeriveResult{})
-		m.broadcastToSession(session, normalized)
-		return
-	}
-	// Fallback when the projection is unavailable (e.g. frames row removed
-	// concurrently with the screen event). Broadcast a minimal normalized
-	// event so SPA clients still see the status change.
-	normalized := agentpkg.NormalizedEvent{
-		AgentType:    agentType,
-		Status:       string(status),
-		RawEventName: "probe:activity",
-		BroadcastTs:  time.Now().UnixNano(),
-	}
-	m.broadcastToSession(session, normalized)
+	// Steps 1 + 2 + 4 + 5 + 6 — delegate to the shared guard pipeline. The
+	// StaleCheck closure encodes the ScreenChange-path active-set check
+	// (activeWatchers[session] == agentType); the Mapping closure returns
+	// the already-resolved status (mapping happened above so the sweep
+	// branch could short-circuit).
+	applyProbeGuards(m, probeGuardArgs{
+		Session:   session,
+		AgentType: agentType,
+		Reason:    "probe:activity",
+		Mapping:   func(agentpkg.Signal) agentpkg.Status { return status },
+		StaleCheck: func(m *Module) bool {
+			currentAgent, active := m.activeWatchers[session]
+			return active && currentAgent == agentType
+		},
+	})
 }

--- a/internal/module/agent/probe_orchestrator.go
+++ b/internal/module/agent/probe_orchestrator.go
@@ -251,15 +251,20 @@ type probeGuardArgs struct {
 //     is unavailable).
 //
 // Returns applied=true iff step 4 mutated currentStatus and step 5 broadcast
-// the transition. Every other branch returns applied=false.
+// the transition; appliedStatus carries the freshly applied newStatus on the
+// success path (empty on every drop). Returning the locally-known newStatus
+// avoids a follow-up currentStatus re-read race in the ProbeIntent dispatcher
+// (P2-T6 fix) — a concurrent SessionEnd hook between step 4 unlock and a
+// caller's re-read could delete the entry, leaving the dev-log / case-3
+// re-apply path with an empty status.
 //
 // W6-3 P1-T2: extracted from interpretScreenEvent so the W6-3 ProbeIntent
 // dispatcher (P1-T4) can reuse the same guard pipeline through different
 // StaleCheck / Mapping strategies. ScreenChange path is a strict mechanical
 // extraction — pre-extraction tests must remain green.
-func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
+func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool, appliedStatus agentpkg.Status) {
 	if m == nil {
-		return false
+		return false, ""
 	}
 
 	// 1. Stale-callback guard (early fast-path; lock-free read inside m.mu).
@@ -270,7 +275,7 @@ func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
 		if args.OnDrop != nil {
 			args.OnDrop("stale-callback")
 		}
-		return false
+		return false, ""
 	}
 
 	// 2. graceWindow suppression (independent graceMu — no nesting w/ m.mu).
@@ -288,18 +293,18 @@ func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
 			if args.OnDrop != nil {
 				args.OnDrop("grace")
 			}
-			return false
+			return false, ""
 		}
 	}
 
 	// 3. Mapping callback (per by2z79ouc DEF-1 — invoked only after stale +
 	//    graceWindow guards pass; OnSignal handlers may safely log/count).
 	if args.Mapping == nil {
-		return false
+		return false, ""
 	}
 	newStatus := args.Mapping(args.Signal)
 	if newStatus == "" {
-		return false
+		return false, ""
 	}
 
 	// Test-only seam: simulate a concurrent stop/rename that mutates the
@@ -316,21 +321,21 @@ func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
 		if args.OnDrop != nil {
 			args.OnDrop("stale-callback")
 		}
-		return false
+		return false, ""
 	}
 	if m.currentStatus[args.Session] == agentpkg.StatusError {
 		m.mu.Unlock()
 		if args.OnDrop != nil {
 			args.OnDrop("error-guard")
 		}
-		return false
+		return false, ""
 	}
 	if prev, ok := m.currentStatus[args.Session]; ok && prev == newStatus {
 		m.mu.Unlock()
 		if args.OnDrop != nil {
 			args.OnDrop("transition-gate")
 		}
-		return false
+		return false, ""
 	}
 	m.currentStatus[args.Session] = newStatus
 	m.mu.Unlock()
@@ -344,7 +349,7 @@ func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
 	if projection, err := m.setProjectionTopStatus(args.Session, newStatus); err == nil && projection != nil {
 		normalized := buildProjectionNormalized(projection, args.AgentType, args.Reason, time.Now().UnixNano(), agentpkg.DeriveResult{})
 		m.broadcastToSession(args.Session, normalized)
-		return true
+		return true, newStatus
 	}
 	// Fallback when the projection is unavailable (e.g. frames row removed
 	// concurrently with the event). Broadcast a minimal normalized event so
@@ -356,7 +361,7 @@ func applyProbeGuards(m *Module, args probeGuardArgs) (applied bool) {
 		BroadcastTs:  time.Now().UnixNano(),
 	}
 	m.broadcastToSession(args.Session, normalized)
-	return true
+	return true, newStatus
 }
 
 // interpretScreenEvent maps a raw probe.ScreenChangeEvent to a status

--- a/internal/module/agent/probe_orchestrator_apply_guards_test.go
+++ b/internal/module/agent/probe_orchestrator_apply_guards_test.go
@@ -1,0 +1,447 @@
+package agent
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/agent/probe"
+)
+
+// W6-3 P1-T2: direct unit tests for the extracted applyProbeGuards free
+// function. The seven cases cover each layered guard independently
+// (StaleCheck fast-path, graceWindow, Mapping, ErrorGuard, transition gate,
+// final critical-section re-check) plus a happy-path mutate+broadcast
+// assertion. ScreenChange path regression coverage lives in
+// TestScreenChangePath_RegressionMatrix below; existing OR* / FX* / CC*
+// tests still hit the path via the orchestrator callback so behaviour parity
+// is double-checked.
+//
+// Helpers --------------------------------------------------------------
+
+// staleAlways / staleNever are convenience StaleCheck strategies for tests
+// where the fast-path / re-check semantics are independent from module state.
+func staleAlways(*Module) bool { return true }
+func staleNever(*Module) bool  { return false }
+
+// mappingTo returns a Mapping callback that always emits the given status.
+// nil status maps to "" which the dispatcher treats as drop.
+func mappingTo(status agentpkg.Status) func(agentpkg.Signal) agentpkg.Status {
+	return func(agentpkg.Signal) agentpkg.Status { return status }
+}
+
+// applyGuardsTestModule wires a Module ready for direct applyProbeGuards
+// invocation. Mirrors orchTestModule but does not require activeWatchers /
+// the prober fake — the StaleCheck closure provides whatever stale semantics
+// the test wants, decoupling these tests from activeWatchers state.
+func applyGuardsTestModule(t *testing.T) *Module {
+	t.Helper()
+	m, _, _ := orchTestModule(t)
+	return m
+}
+
+// TestApplyProbeGuards_StaleCheckGuard_FastPath — StaleCheck closure returns
+// false on the early fast-path; applyProbeGuards must drop the signal,
+// return applied=false, and not broadcast.
+func TestApplyProbeGuards_StaleCheckGuard_FastPath(t *testing.T) {
+	m := applyGuardsTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusIdle, 700)
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	before := snapshotMetrics()
+	applied := applyProbeGuards(m, probeGuardArgs{
+		Session:    "work",
+		AgentType:  "cc",
+		Reason:     "probe:activity",
+		Mapping:    mappingTo(agentpkg.StatusRunning),
+		StaleCheck: staleNever,
+	})
+	after := snapshotMetrics()
+
+	if applied {
+		t.Fatalf("applied = true, want false (StaleCheck rejected)")
+	}
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusIdle {
+		t.Fatalf("currentStatus[work] = %q, want StatusIdle (untouched)", status)
+	}
+}
+
+// TestApplyProbeGuards_GraceWindow — recordHookAt within probeGraceWindow
+// suppresses the signal; counter increments; applied=false.
+func TestApplyProbeGuards_GraceWindow(t *testing.T) {
+	m := applyGuardsTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusWaiting, 701)
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusWaiting
+	m.mu.Unlock()
+	m.probeOrch.recordHookAt("work")
+
+	before := snapshotMetrics()
+	applied := applyProbeGuards(m, probeGuardArgs{
+		Session:    "work",
+		AgentType:  "cc",
+		Reason:     "probe:activity",
+		Mapping:    mappingTo(agentpkg.StatusRunning),
+		StaleCheck: staleAlways,
+	})
+	after := snapshotMetrics()
+
+	if applied {
+		t.Fatalf("applied = true, want false (graceWindow active)")
+	}
+	if got := after.graceWindowSup - before.graceWindowSup; got != 1 {
+		t.Fatalf("graceWindowSup delta = %d, want 1", got)
+	}
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0 (suppressed)", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusWaiting {
+		t.Fatalf("currentStatus[work] = %q, want StatusWaiting (untouched)", status)
+	}
+}
+
+// TestApplyProbeGuards_Mapping_NewStatusEmpty_Drops — Mapping returns "" →
+// dispatcher treats as drop; no mutate, no broadcast.
+func TestApplyProbeGuards_Mapping_NewStatusEmpty_Drops(t *testing.T) {
+	m := applyGuardsTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusRunning, 702)
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+
+	before := snapshotMetrics()
+	applied := applyProbeGuards(m, probeGuardArgs{
+		Session:    "work",
+		AgentType:  "cc",
+		Reason:     "probe-intent:test_drop",
+		Mapping:    mappingTo(""), // empty → drop signal
+		StaleCheck: staleAlways,
+	})
+	after := snapshotMetrics()
+
+	if applied {
+		t.Fatalf("applied = true, want false (empty mapping → drop)")
+	}
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusRunning {
+		t.Fatalf("currentStatus[work] = %q, want StatusRunning (untouched)", status)
+	}
+}
+
+// TestApplyProbeGuards_ErrorGuard — currentStatus = StatusError; probe must
+// never overwrite (recovery-only contract). applied=false; no broadcast.
+func TestApplyProbeGuards_ErrorGuard(t *testing.T) {
+	m := applyGuardsTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusError, 703)
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusError
+	m.mu.Unlock()
+
+	before := snapshotMetrics()
+	applied := applyProbeGuards(m, probeGuardArgs{
+		Session:    "work",
+		AgentType:  "cc",
+		Reason:     "probe:activity",
+		Mapping:    mappingTo(agentpkg.StatusIdle),
+		StaleCheck: staleAlways,
+	})
+	after := snapshotMetrics()
+
+	if applied {
+		t.Fatalf("applied = true, want false (ErrorGuard blocks)")
+	}
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusError {
+		t.Fatalf("currentStatus[work] = %q, want StatusError preserved", status)
+	}
+}
+
+// TestApplyProbeGuards_TransitionGate — currentStatus already equals new
+// mapped status; transition gate drops the duplicate; applied=false.
+func TestApplyProbeGuards_TransitionGate(t *testing.T) {
+	m := applyGuardsTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusRunning, 704)
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusRunning
+	m.mu.Unlock()
+
+	before := snapshotMetrics()
+	applied := applyProbeGuards(m, probeGuardArgs{
+		Session:    "work",
+		AgentType:  "cc",
+		Reason:     "probe:activity",
+		Mapping:    mappingTo(agentpkg.StatusRunning),
+		StaleCheck: staleAlways,
+	})
+	after := snapshotMetrics()
+
+	if applied {
+		t.Fatalf("applied = true, want false (transition gate dedup)")
+	}
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0", got)
+	}
+}
+
+// TestApplyProbeGuards_HappyPath_MutatesAndBroadcasts — every guard passes;
+// currentStatus mutates, broadcast fires, MetricProbeScreenEvent +1, return
+// applied=true.
+func TestApplyProbeGuards_HappyPath_MutatesAndBroadcasts(t *testing.T) {
+	m := applyGuardsTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusIdle, 705)
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	before := snapshotMetrics()
+	applied := applyProbeGuards(m, probeGuardArgs{
+		Session:    "work",
+		AgentType:  "cc",
+		Reason:     "probe:activity",
+		Mapping:    mappingTo(agentpkg.StatusRunning),
+		StaleCheck: staleAlways,
+	})
+	after := snapshotMetrics()
+
+	if !applied {
+		t.Fatalf("applied = false, want true (happy path)")
+	}
+	if got := after.screenEvent - before.screenEvent; got != 1 {
+		t.Fatalf("screenEvent delta = %d, want 1", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusRunning {
+		t.Fatalf("currentStatus[work] = %q, want StatusRunning", status)
+	}
+	select {
+	case <-sub.SendCh():
+		// ok
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for broadcast")
+	}
+}
+
+// TestApplyProbeGuards_FinalCriticalSectionReCheck — StaleCheck strategy
+// returns true on the early fast-path but flips to false by the time the
+// final critical-section re-check runs (simulated via a side-effecting
+// closure fired by interruptBeforeFinalLockFn-equivalent — here we use the
+// counter inside the StaleCheck closure itself). applied=false; no broadcast.
+func TestApplyProbeGuards_FinalCriticalSectionReCheck(t *testing.T) {
+	m := applyGuardsTestModule(t)
+	seedOrchFrame(t, m, agentpkg.StatusIdle, 706)
+	m.mu.Lock()
+	m.currentStatus["work"] = agentpkg.StatusIdle
+	m.mu.Unlock()
+
+	// First call: pass (early fast-path); subsequent calls: fail (final
+	// critical-section re-check). applyProbeGuards must consult StaleCheck
+	// twice — once in step 1 (early fast-path) and again in step 4 (atomic
+	// re-check), per spec §5.2.
+	var calls int32
+	stale := func(*Module) bool {
+		n := atomic.AddInt32(&calls, 1)
+		return n == 1
+	}
+
+	before := snapshotMetrics()
+	applied := applyProbeGuards(m, probeGuardArgs{
+		Session:    "work",
+		AgentType:  "cc",
+		Reason:     "probe:activity",
+		Mapping:    mappingTo(agentpkg.StatusRunning),
+		StaleCheck: stale,
+	})
+	after := snapshotMetrics()
+
+	if applied {
+		t.Fatalf("applied = true, want false (final re-check failed)")
+	}
+	if got := after.screenEvent - before.screenEvent; got != 0 {
+		t.Fatalf("screenEvent delta = %d, want 0 (no broadcast on re-check fail)", got)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("StaleCheck call count = %d, want 2 (early fast-path + final re-check)", got)
+	}
+	m.mu.Lock()
+	status := m.currentStatus["work"]
+	m.mu.Unlock()
+	if status != agentpkg.StatusIdle {
+		t.Fatalf("currentStatus[work] = %q, want StatusIdle (no transition)", status)
+	}
+}
+
+// TestScreenChangePath_RegressionMatrix — table-driven regression for the
+// ScreenChange caller adaptor (interpretScreenEvent). Each case asserts
+// observable output (broadcast / mutation / metric delta) matches the
+// pre-extraction baseline. Mirrors the existing OR* / FX* test invariants
+// in a single table form per plan P1-T2.
+func TestScreenChangePath_RegressionMatrix(t *testing.T) {
+	type setupFn func(t *testing.T, m *Module, fake *fakeTmuxCapture)
+
+	cases := []struct {
+		name            string
+		setup           setupFn
+		event           probe.ScreenChangeEvent
+		expectMutation  bool
+		expectBroadcast bool
+		// expectScreenEventDelta is the delta on MetricProbeScreenEvent.
+		// expectGraceWindowDelta is the delta on MetricProbeGraceWindowSuppressed.
+		expectScreenEventDelta int64
+		expectGraceWindowDelta int64
+		// finalStatus is the expected currentStatus[work] after the call.
+		finalStatus agentpkg.Status
+	}{
+		{
+			name: "stale_active_watchers_drop",
+			setup: func(t *testing.T, m *Module, _ *fakeTmuxCapture) {
+				seedOrchFrame(t, m, agentpkg.StatusIdle, 800)
+				// activeWatchers absent — stale-callback fast-path drops.
+				m.mu.Lock()
+				m.currentStatus["work"] = agentpkg.StatusIdle
+				m.mu.Unlock()
+			},
+			event:                  probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()},
+			expectMutation:         false,
+			expectBroadcast:        false,
+			expectScreenEventDelta: 0,
+			expectGraceWindowDelta: 0,
+			finalStatus:            agentpkg.StatusIdle,
+		},
+		{
+			name: "grace_window_drop",
+			setup: func(t *testing.T, m *Module, _ *fakeTmuxCapture) {
+				seedOrchFrame(t, m, agentpkg.StatusWaiting, 801)
+				m.mu.Lock()
+				m.activeWatchers["work"] = "cc"
+				m.currentStatus["work"] = agentpkg.StatusWaiting
+				m.mu.Unlock()
+				m.probeOrch.recordHookAt("work")
+			},
+			event:                  probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()},
+			expectMutation:         false,
+			expectBroadcast:        false,
+			expectScreenEventDelta: 0,
+			expectGraceWindowDelta: 1,
+			finalStatus:            agentpkg.StatusWaiting,
+		},
+		{
+			name: "error_guard_drop",
+			setup: func(t *testing.T, m *Module, fake *fakeTmuxCapture) {
+				seedOrchFrame(t, m, agentpkg.StatusError, 802)
+				m.mu.Lock()
+				m.activeWatchers["work"] = "cc"
+				m.currentStatus["work"] = agentpkg.StatusError
+				m.mu.Unlock()
+				// ScreenStable would map to Idle; ErrorGuard blocks.
+				fake.SetPaneContent("work:", "user typed something normal")
+			},
+			event:                  probe.ScreenChangeEvent{Kind: probe.ScreenStable, Target: "work:", OccurredAt: time.Now()},
+			expectMutation:         false,
+			expectBroadcast:        false,
+			expectScreenEventDelta: 0,
+			expectGraceWindowDelta: 0,
+			finalStatus:            agentpkg.StatusError,
+		},
+		{
+			name: "transition_gate_drop",
+			setup: func(t *testing.T, m *Module, _ *fakeTmuxCapture) {
+				// currentStatus already Running, ScreenChanged maps to Running.
+				seedOrchFrame(t, m, agentpkg.StatusRunning, 803)
+				m.mu.Lock()
+				m.activeWatchers["work"] = "cc"
+				m.currentStatus["work"] = agentpkg.StatusRunning
+				m.mu.Unlock()
+			},
+			event:                  probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()},
+			expectMutation:         false,
+			expectBroadcast:        false,
+			expectScreenEventDelta: 0,
+			expectGraceWindowDelta: 0,
+			finalStatus:            agentpkg.StatusRunning,
+		},
+		{
+			name: "happy_path_apply",
+			setup: func(t *testing.T, m *Module, _ *fakeTmuxCapture) {
+				seedOrchFrame(t, m, agentpkg.StatusIdle, 804)
+				m.mu.Lock()
+				m.activeWatchers["work"] = "cc"
+				m.currentStatus["work"] = agentpkg.StatusIdle
+				m.mu.Unlock()
+			},
+			event:                  probe.ScreenChangeEvent{Kind: probe.ScreenChanged, Target: "work:", OccurredAt: time.Now()},
+			expectMutation:         true,
+			expectBroadcast:        true,
+			expectScreenEventDelta: 1,
+			expectGraceWindowDelta: 0,
+			finalStatus:            agentpkg.StatusRunning,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _, fake := orchTestModule(t)
+			tc.setup(t, m, fake)
+
+			sub := m.core.Events.AddTestSubscriber()
+			defer m.core.Events.RemoveTestSubscriber(sub)
+
+			before := snapshotMetrics()
+			cb := m.probeOrch.makeCallback("work", "cc")
+			cb(tc.event)
+			after := snapshotMetrics()
+
+			if got := after.screenEvent - before.screenEvent; got != tc.expectScreenEventDelta {
+				t.Fatalf("screenEvent delta = %d, want %d", got, tc.expectScreenEventDelta)
+			}
+			if got := after.graceWindowSup - before.graceWindowSup; got != tc.expectGraceWindowDelta {
+				t.Fatalf("graceWindowSup delta = %d, want %d", got, tc.expectGraceWindowDelta)
+			}
+
+			m.mu.Lock()
+			status := m.currentStatus["work"]
+			m.mu.Unlock()
+			if status != tc.finalStatus {
+				t.Fatalf("currentStatus[work] = %q, want %q", status, tc.finalStatus)
+			}
+
+			// Broadcast assertion is best-effort: drain any pending message
+			// non-blockingly. Subscriber channel buffer is sized for tests.
+			gotBroadcast := false
+			select {
+			case <-sub.SendCh():
+				gotBroadcast = true
+			case <-time.After(50 * time.Millisecond):
+			}
+			if gotBroadcast != tc.expectBroadcast {
+				t.Fatalf("broadcast observed = %v, want %v", gotBroadcast, tc.expectBroadcast)
+			}
+		})
+	}
+}

--- a/internal/module/agent/probe_orchestrator_apply_guards_test.go
+++ b/internal/module/agent/probe_orchestrator_apply_guards_test.go
@@ -52,7 +52,7 @@ func TestApplyProbeGuards_StaleCheckGuard_FastPath(t *testing.T) {
 	m.mu.Unlock()
 
 	before := snapshotMetrics()
-	applied := applyProbeGuards(m, probeGuardArgs{
+	applied, _ := applyProbeGuards(m, probeGuardArgs{
 		Session:    "work",
 		AgentType:  "cc",
 		Reason:     "probe:activity",
@@ -86,7 +86,7 @@ func TestApplyProbeGuards_GraceWindow(t *testing.T) {
 	m.probeOrch.recordHookAt("work")
 
 	before := snapshotMetrics()
-	applied := applyProbeGuards(m, probeGuardArgs{
+	applied, _ := applyProbeGuards(m, probeGuardArgs{
 		Session:    "work",
 		AgentType:  "cc",
 		Reason:     "probe:activity",
@@ -122,7 +122,7 @@ func TestApplyProbeGuards_Mapping_NewStatusEmpty_Drops(t *testing.T) {
 	m.mu.Unlock()
 
 	before := snapshotMetrics()
-	applied := applyProbeGuards(m, probeGuardArgs{
+	applied, _ := applyProbeGuards(m, probeGuardArgs{
 		Session:    "work",
 		AgentType:  "cc",
 		Reason:     "probe-intent:test_drop",
@@ -155,7 +155,7 @@ func TestApplyProbeGuards_ErrorGuard(t *testing.T) {
 	m.mu.Unlock()
 
 	before := snapshotMetrics()
-	applied := applyProbeGuards(m, probeGuardArgs{
+	applied, _ := applyProbeGuards(m, probeGuardArgs{
 		Session:    "work",
 		AgentType:  "cc",
 		Reason:     "probe:activity",
@@ -188,7 +188,7 @@ func TestApplyProbeGuards_TransitionGate(t *testing.T) {
 	m.mu.Unlock()
 
 	before := snapshotMetrics()
-	applied := applyProbeGuards(m, probeGuardArgs{
+	applied, _ := applyProbeGuards(m, probeGuardArgs{
 		Session:    "work",
 		AgentType:  "cc",
 		Reason:     "probe:activity",
@@ -219,7 +219,7 @@ func TestApplyProbeGuards_HappyPath_MutatesAndBroadcasts(t *testing.T) {
 	defer m.core.Events.RemoveTestSubscriber(sub)
 
 	before := snapshotMetrics()
-	applied := applyProbeGuards(m, probeGuardArgs{
+	applied, appliedStatus := applyProbeGuards(m, probeGuardArgs{
 		Session:    "work",
 		AgentType:  "cc",
 		Reason:     "probe:activity",
@@ -230,6 +230,9 @@ func TestApplyProbeGuards_HappyPath_MutatesAndBroadcasts(t *testing.T) {
 
 	if !applied {
 		t.Fatalf("applied = false, want true (happy path)")
+	}
+	if appliedStatus != agentpkg.StatusRunning {
+		t.Fatalf("appliedStatus = %q, want StatusRunning (P2-T6 race fix: caller must not re-read currentStatus)", appliedStatus)
 	}
 	if got := after.screenEvent - before.screenEvent; got != 1 {
 		t.Fatalf("screenEvent delta = %d, want 1", got)
@@ -271,7 +274,7 @@ func TestApplyProbeGuards_FinalCriticalSectionReCheck(t *testing.T) {
 	}
 
 	before := snapshotMetrics()
-	applied := applyProbeGuards(m, probeGuardArgs{
+	applied, _ := applyProbeGuards(m, probeGuardArgs{
 		Session:    "work",
 		AgentType:  "cc",
 		Reason:     "probe:activity",

--- a/internal/module/agent/trace.go
+++ b/internal/module/agent/trace.go
@@ -1,19 +1,25 @@
-// TraceStore step coverage audit (W4 PR-4 Phase 3)
+// TraceStore step coverage audit (W4 PR-4 Phase 3 + W6-3 P2-T6)
 //
-// Hook chains use five trace step kinds, recorded by the calls in this file:
-// trigger / verify / frame / projection / emit. The matrix below documents
-// which steps appear on each hook path and identifies cases where a step is
-// reasonably absent.
+// Hook chains use five trace step kinds recorded inline during handleEvent
+// (trigger / verify / frame / projection / emit). W6-3 P2-T6 adds a sixth
+// step kind, "probe-intent", emitted from a standalone, single-step chain
+// each time the ProbeIntent dispatcher arms a detector or an emitted
+// signal is applied. The probe-intent chains have no parent hook context;
+// they live alongside hook-driven chains in the trace store and surface
+// in dev tooling under the same ListChains pagination.
 //
-//	Path                                                    | trigger | verify | frame | projection | emit
-//	cc/codex/opencode valid main (UserPromptSubmit/Stop/...) | yes     | yes    | yes   | yes        | yes
-//	any agent invalid catalog miss (BogusEvent)             | yes     | yes(*) | —     | —          | —
-//	cc/codex/opencode subagent updated_frame                | yes     | yes    | yes   | yes        | yes
-//	cc/codex/opencode subagent frame_missing/id_missing     | yes     | yes    | yes   | yes        | —
-//	SessionEnd (status=clear)                               | yes     | yes    | yes   | yes        | yes
-//	error_guard_blocked (StopFailure-stuck error)           | yes     | yes    | —     | —          | yes(*)
-//	verify rejected (pid_dead, identity_mismatch, ...)      | yes     | yes(*) | —     | —          | —
-//	replay-from-DB / sendSnapshot (cold reconnect)          | —       | —      | —     | —          | —
+//	Path                                                    | trigger | verify | frame | projection | emit | probe-intent
+//	cc/codex/opencode valid main (UserPromptSubmit/Stop/...) | yes     | yes    | yes   | yes        | yes  | —
+//	any agent invalid catalog miss (BogusEvent)             | yes     | yes(*) | —     | —          | —    | —
+//	cc/codex/opencode subagent updated_frame                | yes     | yes    | yes   | yes        | yes  | —
+//	cc/codex/opencode subagent frame_missing/id_missing     | yes     | yes    | yes   | yes        | —    | —
+//	SessionEnd (status=clear)                               | yes     | yes    | yes   | yes        | yes  | —
+//	error_guard_blocked (StopFailure-stuck error)           | yes     | yes    | —     | —          | yes(*)| —
+//	verify rejected (pid_dead, identity_mismatch, ...)      | yes     | yes(*) | —     | —          | —    | —
+//	replay-from-DB / sendSnapshot (cold reconnect)          | —       | —      | —     | —          | —    | —
+//	probe-intent: detector arm (case 2 / 5)                 | —       | —      | —     | —          | —    | yes (decision=start)
+//	probe-intent: detector cancel (case 3 / reconcile / stop)| —       | —      | —     | —          | —    | yes (decision=stop)
+//	probe-intent: applied signal (consumeSignals)           | —       | —      | —     | —          | —    | yes (decision=signal)
 //
 // Notes on absences (all reasonable, no follow-up trace step needed):
 //
@@ -52,6 +58,20 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/wake/purdex/internal/store"
+)
+
+// Trace step kinds. The first five are written by the inline hook pipeline
+// in handleEvent. TraceStepProbeIntent is the sixth chain log step (W6-3
+// P2-T6) emitted by the ProbeIntent dispatcher; it lives alongside hook
+// chains in agent_trace_chains so dashboards can correlate detector
+// lifecycle with hook activity over the same session/pane.
+const (
+	TraceStepTrigger     = "trigger"
+	TraceStepVerify      = "verify"
+	TraceStepFrame       = "frame"
+	TraceStepProjection  = "projection"
+	TraceStepEmit        = "emit"
+	TraceStepProbeIntent = "probe-intent"
 )
 
 type hookTraceSink struct {
@@ -112,6 +132,69 @@ func (s *hookTraceSink) Close() {
 		close(s.queue)
 		s.worker.Wait()
 	})
+}
+
+// probeIntentTraceArgs is the input contract for AppendProbeIntent. Decision
+// is "start" / "stop" / "signal" / "drop"; Reason carries the lifecycle
+// trigger (e.g. "lifecycle-applyStatus", "stop-all", "stale-callback").
+// Payload is best-effort marshaled into PayloadJSON for downstream tooling.
+type probeIntentTraceArgs struct {
+	TmuxSession string
+	PaneID      string
+	AgentType   string
+	Kind        string
+	Decision    string
+	Reason      string
+	Payload     any
+}
+
+// AppendProbeIntent enqueues a single-step trace chain whose only step is a
+// [probe-intent] entry. The chain RootEventName is "probe_intent_<kind>" and
+// its terminal status mirrors the step decision so ListChains pagination
+// surfaces the chain without requiring extra plumbing on the read side.
+//
+// W6-3 P2-T6: dispatcher invokes this from applyIntentLifecycle (start /
+// stop), reconcileSessionActive (stop), stopAll (stop), consumeSignals
+// (signal), and drop sites (probeIntentOnDrop wrapper). The hookTraceSink
+// receiver is nil-safe so dispatcher code does not need to nil-check.
+func (s *hookTraceSink) AppendProbeIntent(args probeIntentTraceArgs) {
+	if s == nil {
+		return
+	}
+	now := time.Now().UnixNano()
+	chainID := uuid.NewString()
+	step := store.TraceStep{
+		StepID:      uuid.NewString(),
+		ChainID:     chainID,
+		Seq:         1,
+		Kind:        TraceStepProbeIntent,
+		TmuxSession: args.TmuxSession,
+		PaneID:      args.PaneID,
+		AgentType:   args.AgentType,
+		EventName:   args.Kind,
+		Decision:    args.Decision,
+		Reason:      args.Reason,
+		PayloadJSON: marshalTraceJSON(args.Payload),
+		BeforeJSON:  marshalTraceJSON(nil),
+		AfterJSON:   marshalTraceJSON(nil),
+		CreatedAt:   now,
+	}
+	chain := store.TraceChain{
+		ChainID:          chainID,
+		StartedAt:        now,
+		CompletedAt:      now,
+		TerminalStatus:   args.Decision,
+		TerminalReason:   args.Reason,
+		TmuxSession:      args.TmuxSession,
+		PaneID:           args.PaneID,
+		RootAgentType:    args.AgentType,
+		RootEventName:    "probe_intent_" + args.Kind,
+		RootReason:       args.Reason,
+		LatestStepKind:   TraceStepProbeIntent,
+		LatestDecision:   args.Decision,
+		LatestStepReason: args.Reason,
+	}
+	s.Enqueue(store.TraceRecord{Chain: chain, Steps: []store.TraceStep{step}})
 }
 
 type hookTraceCollector struct {

--- a/internal/tmux/executor.go
+++ b/internal/tmux/executor.go
@@ -37,10 +37,14 @@ type Executor interface {
 	RenameSession(oldName, newName string) error
 	HasSession(name string) bool
 	// HasPane reports whether the given pane id (e.g. "%5") still exists in
-	// the global tmux pane list. Returns false on empty paneID, missing
-	// tmux server, or any command error (conservative — caller treats
-	// false as "pane gone").
-	HasPane(paneID string) bool
+	// the global tmux pane list. Returns (false, nil) on empty paneID or
+	// confirmed absence; (true, nil) on confirmed presence; (_, err) on a
+	// transient tmux command failure (no server, exec error). Per round-4
+	// audit: callers that derive "pane gone" semantics MUST distinguish
+	// confirmed-absence from query-error — collapsing both into false
+	// causes false-positive "pane gone" / clear emissions during tmux
+	// hiccups while the pane is still alive.
+	HasPane(paneID string) (exists bool, err error)
 	SendKeys(target, keys string) error
 	SendKeysRaw(target string, keys ...string) error
 	PasteText(target, text string) error
@@ -213,20 +217,20 @@ func (r *RealExecutor) HasSession(name string) bool {
 //
 // Used by codex ProbeIntent ProcessDead detector — see
 // internal/agent/codex/probe_intent_process_dead.go.
-func (r *RealExecutor) HasPane(paneID string) bool {
+func (r *RealExecutor) HasPane(paneID string) (bool, error) {
 	if paneID == "" {
-		return false
+		return false, nil
 	}
 	out, err := exec.Command("tmux", "list-panes", "-a", "-F", "#{pane_id}").Output()
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, line := range strings.Split(string(out), "\n") {
 		if strings.TrimSpace(line) == paneID {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func (r *RealExecutor) SendKeys(target, keys string) error {

--- a/internal/tmux/executor.go
+++ b/internal/tmux/executor.go
@@ -221,8 +221,19 @@ func (r *RealExecutor) HasPane(paneID string) (bool, error) {
 	if paneID == "" {
 		return false, nil
 	}
-	out, err := exec.Command("tmux", "list-panes", "-a", "-F", "#{pane_id}").Output()
+	cmd := exec.Command("tmux", "list-panes", "-a", "-F", "#{pane_id}")
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
+		// Round-5 audit F10: classify "no server running" as confirmed
+		// global absence (false, nil) rather than a transient query
+		// failure. Without this branch the detector would poll forever
+		// when the user tears down the last tmux session — codex pane
+		// is definitively gone but the lights stay armed.
+		if strings.Contains(stderr.String(), "no server running") {
+			return false, nil
+		}
 		return false, err
 	}
 	for _, line := range strings.Split(string(out), "\n") {

--- a/internal/tmux/executor.go
+++ b/internal/tmux/executor.go
@@ -36,6 +36,11 @@ type Executor interface {
 	KillSession(name string) error
 	RenameSession(oldName, newName string) error
 	HasSession(name string) bool
+	// HasPane reports whether the given pane id (e.g. "%5") still exists in
+	// the global tmux pane list. Returns false on empty paneID, missing
+	// tmux server, or any command error (conservative — caller treats
+	// false as "pane gone").
+	HasPane(paneID string) bool
 	SendKeys(target, keys string) error
 	SendKeysRaw(target string, keys ...string) error
 	PasteText(target, text string) error
@@ -199,6 +204,29 @@ func (r *RealExecutor) HasSession(name string) bool {
 	// Use "=" prefix for exact name matching (tmux 3.2+).
 	// Without it, "has-session -t foo" matches "foobar" via prefix.
 	return exec.Command("tmux", "has-session", "-t", "="+name).Run() == nil
+}
+
+// HasPane reports whether the given pane id is currently listed by
+// `tmux list-panes -a -F '#{pane_id}'`. Conservative on any error: a
+// non-zero exit (no server running, etc) returns false. Empty paneID
+// short-circuits to false without invoking tmux.
+//
+// Used by codex ProbeIntent ProcessDead detector — see
+// internal/agent/codex/probe_intent_process_dead.go.
+func (r *RealExecutor) HasPane(paneID string) bool {
+	if paneID == "" {
+		return false
+	}
+	out, err := exec.Command("tmux", "list-panes", "-a", "-F", "#{pane_id}").Output()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) == paneID {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *RealExecutor) SendKeys(target, keys string) error {

--- a/internal/tmux/executor_test.go
+++ b/internal/tmux/executor_test.go
@@ -451,16 +451,17 @@ printf '%%5\n%%7\n'
 	}
 }
 
-// TestHasPane_TmuxCommandError_ReturnsError verifies that a tmux invocation
-// error (e.g. server not running) surfaces as err != nil rather than being
-// collapsed into a confirmed-absent false. Per round-4 audit: callers
-// distinguish transient query failure from confirmed absence to avoid
-// false-positive "pane gone" emissions during tmux hiccups.
-func TestHasPane_TmuxCommandError_ReturnsError(t *testing.T) {
+// TestHasPane_TransientTmuxError_ReturnsError verifies that a generic
+// tmux invocation error (NOT the documented "no server running" branch
+// — that one is confirmed absence per F10) surfaces as err != nil. Per
+// round-4 audit: callers distinguish transient query failure from
+// confirmed absence to avoid false-positive "pane gone" emissions
+// during tmux hiccups.
+func TestHasPane_TransientTmuxError_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "tmux")
 	if err := os.WriteFile(script, []byte(`#!/bin/sh
-printf 'no server running\n' >&2
+printf 'something else went wrong\n' >&2
 exit 1
 `), 0755); err != nil {
 		t.Fatal(err)
@@ -469,10 +470,34 @@ exit 1
 
 	got, err := (&tmux.RealExecutor{}).HasPane("%5")
 	if err == nil {
-		t.Fatalf("HasPane returned err=nil on tmux error, want non-nil")
+		t.Fatalf("HasPane returned err=nil on transient tmux error, want non-nil")
 	}
 	if got {
 		t.Errorf("HasPane returned true on tmux error, want false")
+	}
+}
+
+// TestHasPane_NoServerRunning_ReturnsConfirmedAbsence verifies the round-5
+// F10 fix: tmux exits with stderr "no server running" when there are no
+// active sessions. That is global confirmed absence (every pane is gone),
+// not a transient query failure — caller should drive the clear path.
+func TestHasPane_NoServerRunning_ReturnsConfirmedAbsence(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+printf 'no server running on /private/tmp/tmux-501/default\n' >&2
+exit 1
+`), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	got, err := (&tmux.RealExecutor{}).HasPane("%5")
+	if err != nil {
+		t.Fatalf("HasPane returned err=%v on no-server, want nil (confirmed absence)", err)
+	}
+	if got {
+		t.Errorf("HasPane returned true on no-server, want false")
 	}
 }
 

--- a/internal/tmux/executor_test.go
+++ b/internal/tmux/executor_test.go
@@ -417,7 +417,11 @@ printf '%%5\n%%7\n'
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if !(&tmux.RealExecutor{}).HasPane("%5") {
+	got, err := (&tmux.RealExecutor{}).HasPane("%5")
+	if err != nil {
+		t.Fatalf("HasPane unexpected err: %v", err)
+	}
+	if !got {
 		t.Errorf("HasPane(%q) = false, want true", "%5")
 	}
 }
@@ -438,14 +442,21 @@ printf '%%5\n%%7\n'
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if (&tmux.RealExecutor{}).HasPane("%9") {
+	got, err := (&tmux.RealExecutor{}).HasPane("%9")
+	if err != nil {
+		t.Fatalf("HasPane unexpected err: %v", err)
+	}
+	if got {
 		t.Errorf("HasPane(%q) = true, want false", "%9")
 	}
 }
 
-// TestHasPane_TmuxCommandError_ReturnsFalse verifies that any tmux invocation
-// error (e.g. server not running) is treated conservatively as not-found.
-func TestHasPane_TmuxCommandError_ReturnsFalse(t *testing.T) {
+// TestHasPane_TmuxCommandError_ReturnsError verifies that a tmux invocation
+// error (e.g. server not running) surfaces as err != nil rather than being
+// collapsed into a confirmed-absent false. Per round-4 audit: callers
+// distinguish transient query failure from confirmed absence to avoid
+// false-positive "pane gone" emissions during tmux hiccups.
+func TestHasPane_TmuxCommandError_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "tmux")
 	if err := os.WriteFile(script, []byte(`#!/bin/sh
@@ -456,14 +467,19 @@ exit 1
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if (&tmux.RealExecutor{}).HasPane("%5") {
+	got, err := (&tmux.RealExecutor{}).HasPane("%5")
+	if err == nil {
+		t.Fatalf("HasPane returned err=nil on tmux error, want non-nil")
+	}
+	if got {
 		t.Errorf("HasPane returned true on tmux error, want false")
 	}
 }
 
 // TestHasPane_EmptyPaneID_ReturnsFalse verifies that an empty paneID short
 // circuits to false without invoking tmux. The script below would fail the
-// test if executed.
+// test if executed. err must be nil — empty paneID is confirmed absent,
+// not a query failure.
 func TestHasPane_EmptyPaneID_ReturnsFalse(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "tmux")
@@ -475,7 +491,11 @@ exit 99
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if (&tmux.RealExecutor{}).HasPane("") {
+	got, err := (&tmux.RealExecutor{}).HasPane("")
+	if err != nil {
+		t.Fatalf("HasPane(\"\") unexpected err: %v", err)
+	}
+	if got {
 		t.Errorf("HasPane(\"\") = true, want false")
 	}
 }

--- a/internal/tmux/executor_test.go
+++ b/internal/tmux/executor_test.go
@@ -397,3 +397,85 @@ func TestFakeExecutor_RangeMethods_Roundtrip(t *testing.T) {
 		t.Errorf("CapturePaneTopLines(3) = %q, want %q", got, want)
 	}
 }
+
+// --- P2-T1: Executor.HasPane(paneID) tests ---
+
+// TestHasPane_PaneExists_ReturnsTrue verifies that HasPane returns true
+// when the requested pane id appears in `tmux list-panes -a -F '#{pane_id}'`.
+func TestHasPane_PaneExists_ReturnsTrue(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "tmux")
+	// Mimic `tmux list-panes -a -F '#{pane_id}'` returning two panes.
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+if [ "$1" != "list-panes" ] || [ "$2" != "-a" ] || [ "$3" != "-F" ] || [ "$4" != "#{pane_id}" ]; then
+  printf 'unexpected args: %s\n' "$*" >&2
+  exit 2
+fi
+printf '%%5\n%%7\n'
+`), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if !(&tmux.RealExecutor{}).HasPane("%5") {
+		t.Errorf("HasPane(%q) = false, want true", "%5")
+	}
+}
+
+// TestHasPane_PaneNotInList_ReturnsFalse verifies that HasPane returns false
+// when the pane id is absent from `tmux list-panes` output.
+func TestHasPane_PaneNotInList_ReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+if [ "$1" != "list-panes" ] || [ "$2" != "-a" ] || [ "$3" != "-F" ] || [ "$4" != "#{pane_id}" ]; then
+  printf 'unexpected args: %s\n' "$*" >&2
+  exit 2
+fi
+printf '%%5\n%%7\n'
+`), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if (&tmux.RealExecutor{}).HasPane("%9") {
+		t.Errorf("HasPane(%q) = true, want false", "%9")
+	}
+}
+
+// TestHasPane_TmuxCommandError_ReturnsFalse verifies that any tmux invocation
+// error (e.g. server not running) is treated conservatively as not-found.
+func TestHasPane_TmuxCommandError_ReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+printf 'no server running\n' >&2
+exit 1
+`), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if (&tmux.RealExecutor{}).HasPane("%5") {
+		t.Errorf("HasPane returned true on tmux error, want false")
+	}
+}
+
+// TestHasPane_EmptyPaneID_ReturnsFalse verifies that an empty paneID short
+// circuits to false without invoking tmux. The script below would fail the
+// test if executed.
+func TestHasPane_EmptyPaneID_ReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+printf 'tmux must not be invoked for empty paneID\n' >&2
+exit 99
+`), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if (&tmux.RealExecutor{}).HasPane("") {
+		t.Errorf("HasPane(\"\") = true, want false")
+	}
+}

--- a/internal/tmux/fake_executor.go
+++ b/internal/tmux/fake_executor.go
@@ -55,6 +55,7 @@ type FakeExecutor struct {
 	setWindowOptionCalls []SetWindowOptionCall // calls to SetWindowOption
 	windowOptions        map[string]string
 	paneIDs              []string // global pane id list for HasPane
+	hasPaneErr           error    // simulated transient tmux error for HasPane
 	listCallCount        int      // how many times ListSessions was called
 	alive                bool   // whether tmux server is "alive"
 	HooksOutput          string // returned by ShowHooksGlobal
@@ -212,18 +213,31 @@ func (f *FakeExecutor) HasSession(name string) bool {
 // HasPane reports whether paneID exists in the fake's recorded pane list.
 // Tests register panes via SetPanes (or the existing per-target maps). Empty
 // paneID returns false without lookup, matching RealExecutor semantics.
-func (f *FakeExecutor) HasPane(paneID string) bool {
+func (f *FakeExecutor) HasPane(paneID string) (bool, error) {
 	if paneID == "" {
-		return false
+		return false, nil
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.hasPaneErr != nil {
+		return false, f.hasPaneErr
+	}
 	for _, id := range f.paneIDs {
 		if id == paneID {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
+}
+
+// SetHasPaneError configures the fake to surface this error from the next
+// HasPane invocations until cleared (passing nil clears). Used by tests
+// that exercise the round-4 transient-tmux-error semantics — pane
+// existence is unknown rather than confirmed-absent.
+func (f *FakeExecutor) SetHasPaneError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.hasPaneErr = err
 }
 
 // SetPanes replaces the fake's known pane id list. Used by tests that rely

--- a/internal/tmux/fake_executor.go
+++ b/internal/tmux/fake_executor.go
@@ -54,7 +54,8 @@ type FakeExecutor struct {
 	autoResizeCalls      []string              // targets passed to ResizeWindowAuto
 	setWindowOptionCalls []SetWindowOptionCall // calls to SetWindowOption
 	windowOptions        map[string]string
-	listCallCount        int    // how many times ListSessions was called
+	paneIDs              []string // global pane id list for HasPane
+	listCallCount        int      // how many times ListSessions was called
 	alive                bool   // whether tmux server is "alive"
 	HooksOutput          string // returned by ShowHooksGlobal
 	FailSendKeys         bool   // if true, SendKeysRaw returns an error
@@ -206,6 +207,31 @@ func (f *FakeExecutor) HasSession(name string) bool {
 	defer f.mu.Unlock()
 	_, ok := f.sessions[name]
 	return ok
+}
+
+// HasPane reports whether paneID exists in the fake's recorded pane list.
+// Tests register panes via SetPanes (or the existing per-target maps). Empty
+// paneID returns false without lookup, matching RealExecutor semantics.
+func (f *FakeExecutor) HasPane(paneID string) bool {
+	if paneID == "" {
+		return false
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, id := range f.paneIDs {
+		if id == paneID {
+			return true
+		}
+	}
+	return false
+}
+
+// SetPanes replaces the fake's known pane id list. Used by tests that rely
+// on HasPane (e.g. ProbeIntent ProcessDead detector integration tests).
+func (f *FakeExecutor) SetPanes(paneIDs []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.paneIDs = append(f.paneIDs[:0:0], paneIDs...)
 }
 
 func (f *FakeExecutor) SendKeys(target, keys string) error {


### PR DESCRIPTION
## Summary

W6-3 + W6-4 合併 first PR — 為 lights system **finalize per-agent ad-hoc ProbeIntent interface**，並交付兩個 codex 燈號修補（error / clear）。

**Why bundled**: W6-3 (error) 與 W6-4 (clear) 共用同一個 `ProcessDead` detector — codex CLI 0.124.0 不主動 fire `StopFailure` (FutureOnly) 與 `SessionEnd` (FutureOnly) hook，但 TUI lifecycle 兩端都需要在 codex 進程消失時被觀察到。

依據：
- Spec: `docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md` (v6 final)
- Plan: `docs/specs/2026-04-29-w6-3-codex-error-probe-intent-plan.md` (v2)
- Origin: lights-rebuild-spec §8.2 + W1 audit §7

## 範圍

| 工作 | 內容 | 修了什麼 |
|---|---|---|
| **W6-3** | codex error light | StopFailure FutureOnly 漏洞 → ProbeIntent ProcessDead detector |
| **W6-4** | codex clear light | SessionEnd FutureOnly 漏洞 → 同一 detector，pane-not-alive 路徑 |
| **#698** | Daemon restart activeWatchers 不恢復 | replayStatus 重建 ProbeIntent 細粒度 active-set |

## Phase 1 — Module plumbing (6 task)

| Commit | Task |
|---|---|
| `72263878` | P1-T1 ProbeIntent / Kind / Signal / Provider types |
| `8147ffc6` | P1-T2 extract `applyProbeGuards` from interpretScreenEvent |
| `243df9ef` | P1-T3 `lookupTopFrameForSessionLocked` helper |
| `b8c57888` | P1-T4 ProbeIntent dispatcher core (5-case lifecycle) |
| `d8c3db5e` | P1-T5 wire dispatcher to manageActivityWatch + rename + Stop |
| `0ff3cd43` | P1-T6 replay recovery (closes #698) |

## Phase 2 — codex provider + observability (7 task)

| Commit | Task |
|---|---|
| `232ada27` | P2-T1 `tmux.Executor.HasPane` |
| `0d725fb9` | P2-T2 codex ProcessDead detector with `isPidAliveFn` injection |
| `584bf82a` | P2-T3 codex `ProbeIntents()` + `onProcessDead` mapper |
| `8b35c535` | P2-T4 wire codex detector to dispatcher |
| `656f0d03` | P2-T5 drift test |
| `8286f878` | P2-T6 observability surfaces (signal log + trace step + 8 expvar) |
| `a3a2b2fa` | P2-T7 integration test suite (7 tests) |

## Round 1 + 2 + 3 review fix bundle

4 輪 codex review 提了 8 個 finding，全部處置：

| ID | 來源 | 嚴重 | 處置 | Commit |
|---|---|---|---|---|
| P2-T6 race | mlab live | medium | applyProbeGuards return appliedStatus（不再 re-read currentStatus） | `95d9cf3f` |
| F1 strand | R1 | P1 | consumeSignals 加 appliedAny tracking + post-loop generation-scoped teardown | `f6d3673d` |
| F1 follow-up | R3 | high | post-loop teardown 後 re-applyStatus rearm（codex within graceWindow 不再永久漏偵測） | `43b40acc` |
| F2 generation race | R2-attack | high | 取代 applyStatus(error) re-call 為 generation-scoped stopActiveIntentInLock | `f6d3673d` |
| F3 PID reuse | R2-attack | medium | **defer issue #777** | — |
| F4 hint validation | R2-defense | high | **revert bundle #3** — codex 分析 #3 dispatcher target injection 的 hint 設計違反 spec §5.4 cross-provider race 邊界，改走 codex 分析 #1 fast path 為更乾淨方案（後續 PR） | `3f573720` |
| F5 reconcile/stopAll obs | R2-defense | medium | extract `emitStopObservability`；4 cancel 路徑（lifecycle case 3+5 / reconcile / stopAll / consumeSignals teardown）統一觀測 | `f6d3673d` |
| F6 unsupported kind silent fail | R2-FH | high | dispatcher 加 `supportedKinds` map；lifecycle case 2/5 fail-closed pre-arm check + drift test 改讀 production routing | `f6d3673d` |
| F7 SRP cancel/stop scattered | R2-FH | medium | `stopActiveIntentInLock` 抽 helper，集中 delete + cancel + meta capture | `f6d3673d` |

## 設計關鍵點

- **per-agent ad-hoc**：detector 歸 agent provider；daemon 只 plumbing；不偽裝為 hook event；不做跨 agent 中央規則；不做 always-on
- **ProbeIntent interface lazy**：W6-3 finalize；W6-4 / W6-1/2/6 沿用同 shape
- **shared `applyProbeGuards`**：ScreenChange path + ProbeIntent path 共用 5 step pipeline；返回 `(applied, appliedStatus)` 避免 re-read race
- **lifecycle 5 case** + **fail-closed unsupported kind**
- **post-loop rearm**：detector 退出無 applied 仍會 re-trigger 直到狀態變化或 graceWindow 過

## Test plan

### Unit + integration（go test ./... + go test -race ./internal/module/agent/... + ./internal/agent/codex/... 全綠）

- 24 packages（含 race detector）全綠
- ~63 unit tests + 7 integration tests + 6 round-2/3 regression tests:
  - `TestApplyProbeGuards_HappyPath_MutatesAndBroadcasts` (P2-T6 contract)
  - `TestConsumeSignals_GraceWindowDrop_RearmsAfterTeardown` (F1 + R3 follow-up)
  - `TestStopActiveIntentInLock_GenerationMismatch_PreservesEntry` (F2)
  - `TestApplyIntentLifecycle_UnsupportedKind_FailsClosed` (F6)
  - `TestProbeIntentDrift_AllDeclaredKindsHaveDispatcherCase` reads `productionSupportedKinds` (F6 audit)

### mlab live verify

整體開發流程後段一同跑 §1-§5；本 PR `§1`/`§3` 已驗 PASS：

| § | 場景 | 結果 |
|---|---|---|
| §1 | codex SIGKILL（pane 仍在）→ ≤2s lights error | ✅ |
| §2 | tmux kill-pane → ≤2s lights clear | ⏳ 整體驗證階段 |
| §3 | codex `/exit` → idle，後續不誤觸 | ✅ |
| §4 | daemon restart 後 §1 重做 → replayStatus + ≤2s error | ⏳ 整體驗證階段 |
| §5 | daemon restart 後 §2 重做 → ≤2s clear | ⏳ 整體驗證階段 |

## Closes

- #698 — Daemon restart 後 activeWatchers 不恢復

## Follow-up issues

- #777 — F3 ProbeIntent ProcessDead PID reuse identity verification

## Status flips（W1 audit §6）

- **W5-4** codex error light：🐛 → ✅ via W6-3 ProcessDead detector
- **W5-5** codex clear light：🐛 → ✅ via W6-4（同 detector 的 pane-not-alive path）