### PR TITLE
feat(spa): poll monitor client metrics

### DIFF
--- a/spa/src/components/MemoryMonitorPage.test.tsx
+++ b/spa/src/components/MemoryMonitorPage.test.tsx
@@ -59,6 +59,7 @@ describe('MemoryMonitorPage', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    delete window.electronAPI
   })
 
   it('loads daemon monitor data for the active host without Electron metrics', async () => {
@@ -483,6 +484,60 @@ describe('MemoryMonitorPage', () => {
     expect(within(sessionRow).getByText('Memory 2 KB')).toBeInTheDocument()
     expect(within(sessionRow).getByText('3 processes')).toBeInTheDocument()
     expect(within(sessionRow).getAllByText('Not wired')).toHaveLength(1)
+  })
+
+  it('pulls Electron client metrics at the monitor interval', async () => {
+    const getProcessMetrics = vi.fn()
+      .mockResolvedValueOnce([{ paneId: 'pane-browser', kind: 'browser', memoryKB: 2048, cpuPercent: 4.5, state: 'active' }])
+      .mockResolvedValue([{ paneId: 'pane-browser', kind: 'browser', memoryKB: 4096, cpuPercent: 8.25, state: 'background' }])
+    const onMetricsUpdate = vi.fn()
+    window.electronAPI = {
+      getProcessMetrics,
+      onMetricsUpdate,
+    } as unknown as typeof window.electronAPI
+    vi.mocked(fetchMonitorConfig).mockResolvedValue({ ...monitorConfig, refresh_interval_ms: 10 })
+    useTabStore.setState({
+      tabs: {
+        'tab-browser': tabWithLeaf('tab-browser', 'pane-browser', { kind: 'browser', url: 'https://example.com' }),
+      },
+      tabOrder: ['tab-browser'],
+      activeTabId: 'tab-browser',
+      visitHistory: [],
+    })
+
+    render(<MemoryMonitorPage />)
+
+    const browserRow = await screen.findByTestId('monitor-row-tab-browser-pane-browser')
+    expect(await within(browserRow).findByText('CPU 4.5%')).toBeInTheDocument()
+    expect(within(browserRow).getByText('Memory 2 MB')).toBeInTheDocument()
+    expect(within(browserRow).getByText('active')).toBeInTheDocument()
+    await waitFor(() => expect(getProcessMetrics.mock.calls.length).toBeGreaterThanOrEqual(2))
+    expect(await within(browserRow).findByText('CPU 8.3%')).toBeInTheDocument()
+    expect(within(browserRow).getByText('Memory 4 MB')).toBeInTheDocument()
+    expect(within(browserRow).getByText('background')).toBeInTheDocument()
+    expect(onMetricsUpdate).not.toHaveBeenCalled()
+  })
+
+  it('does not attach stale browser metrics to a reused non-browser pane id', async () => {
+    window.electronAPI = {
+      getProcessMetrics: vi.fn().mockResolvedValue([{ paneId: 'pane-reused', kind: 'browser', memoryKB: 2048, cpuPercent: 4.5, state: 'background' }]),
+      onMetricsUpdate: vi.fn(),
+    } as unknown as typeof window.electronAPI
+    useTabStore.setState({
+      tabs: {
+        'tab-dashboard': tabWithLeaf('tab-dashboard', 'pane-reused', { kind: 'dashboard' }),
+      },
+      tabOrder: ['tab-dashboard'],
+      activeTabId: 'tab-dashboard',
+      visitHistory: [],
+    })
+
+    render(<MemoryMonitorPage />)
+
+    const row = await screen.findByTestId('monitor-row-tab-dashboard-pane-reused')
+    await waitFor(() => expect(window.electronAPI?.getProcessMetrics).toHaveBeenCalled())
+    expect(within(row).queryByText('CPU 4.5%')).not.toBeInTheDocument()
+    expect(within(row).getAllByText('Not wired')).toHaveLength(2)
   })
 
   it('shows selected session top processes from daemon metrics', async () => {

--- a/spa/src/components/MemoryMonitorPage.tsx
+++ b/spa/src/components/MemoryMonitorPage.tsx
@@ -65,6 +65,7 @@ export function MemoryMonitorPage() {
   const [updatingConfigKeys, setUpdatingConfigKeys] = useState<string[]>([])
   const [configReloadNonce, setConfigReloadNonce] = useState(0)
   const [selectedPaneKey, setSelectedPaneKey] = useState<string | null>(null)
+  const [clientMetrics, setClientMetrics] = useState<ElectronTabMetrics[]>([])
   const draftDirtyRef = useRef(false)
   const retryIntervalMS = useRef(5000)
   const activeWorkspace = activeWorkspaceId ? workspaces.find((workspace) => workspace.id === activeWorkspaceId) : undefined
@@ -163,6 +164,38 @@ export function MemoryMonitorPage() {
     setDraftRefreshSeconds(String(Math.round(config.refresh_interval_ms / 1000)))
     setDraftTopProcessLimit(String(config.top_process_limit))
   }, [activeHostId, activeHostKey, data])
+
+  const clientMetricIntervalMS = data?.hostId === activeHostId && data.activeHostKey === activeHostKey
+    ? data.config.refresh_interval_ms
+    : null
+
+  useEffect(() => {
+    if (!clientMetricIntervalMS || !window.electronAPI?.getProcessMetrics) {
+      setClientMetrics([])
+      return
+    }
+
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const load = async () => {
+      try {
+        const metrics = await window.electronAPI?.getProcessMetrics()
+        if (!cancelled) setClientMetrics(metrics ?? [])
+      } catch {
+        if (!cancelled) setClientMetrics([])
+      } finally {
+        if (!cancelled) timer = setTimeout(load, clientMetricIntervalMS)
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [activeHostKey, activeHostId, clientMetricIntervalMS])
 
   if (!activeHostId || !host) {
     return (
@@ -398,7 +431,7 @@ export function MemoryMonitorPage() {
                     </td>
                     <td className="max-w-48 truncate px-3 py-2 font-mono text-text-primary">{row.paneId}</td>
                     <td className="px-3 py-2 text-text-muted">{row.kind}</td>
-                    <td className="px-3 py-2 text-text-muted">{t('performance_monitor.not_wired')}</td>
+                    <td className="px-3 py-2 text-text-muted"><ClientMetricCell row={row} metrics={clientMetrics} /></td>
                     <td className="px-3 py-2 text-text-muted">
                       <DaemonMetricCell row={row} snapshotsByHostId={rowSnapshotsByHostId} validHostIds={validSnapshotHostIds} />
                     </td>
@@ -508,6 +541,20 @@ function DaemonMetricCell({
       <span>{t('performance_monitor.daemon_cpu', { value: formatDaemonCPU(metrics.cpu_percent, t) })}</span>
       <span>{t('performance_monitor.daemon_memory', { value: formatDaemonMemory(metrics.memory_bytes, t) })}</span>
       <span>{formatProcessCount(metrics.process_count, t)}</span>
+    </div>
+  )
+}
+
+function ClientMetricCell({ row, metrics }: { row: PaneRow; metrics: ElectronTabMetrics[] }) {
+  const t = useI18nStore((s) => s.t)
+  const metric = metrics.find((item) => item.paneId === row.paneId && item.kind === row.kind)
+  if (!metric) return t('performance_monitor.not_wired')
+
+  return (
+    <div className="flex flex-wrap gap-x-3 gap-y-1">
+      <span>{t('performance_monitor.daemon_cpu', { value: formatDaemonCPU(metric.cpuPercent, t) })}</span>
+      <span>{t('performance_monitor.daemon_memory', { value: formatDaemonMemory(metric.memoryKB * 1024, t) })}</span>
+      <span>{metric.state}</span>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Poll Electron client metrics through `getProcessMetrics()` at the effective monitor refresh interval.
- Render matching client CPU, memory, and state in Performance Monitor rows.
- Scope client metrics by both `paneId` and pane kind to avoid stale browser metrics on reused pane ids.

## Verification
- `pnpm --prefix spa exec vitest run src/components/MemoryMonitorPage.test.tsx src/lib/host-api.test.ts src/locales/locale-completeness.test.ts src/lib/pane-tree.test.ts`
- `pnpm --prefix spa run lint`
- `pnpm --prefix spa exec tsc -b`
- `pnpm --prefix electron test`
- `git diff --check`