### PR TITLE
perf(daemon): hook pipeline fast-path + sqlite tail tuning

### DIFF
--- a/cmd/pdx/hook.go
+++ b/cmd/pdx/hook.go
@@ -16,6 +16,7 @@ import (
 
 type hookPayload struct {
 	TmuxSession     string          `json:"tmux_session"`
+	TmuxSessionID   string          `json:"tmux_session_id,omitempty"`
 	TmuxPaneID      string          `json:"tmux_pane_id"`
 	PurdexName      string          `json:"purdex_name"`
 	RawEvent        json.RawMessage `json:"raw_event"`
@@ -33,6 +34,7 @@ type hookProvenance struct {
 }
 
 var queryTmuxSessionFn = queryTmuxSession
+var queryTmuxSessionInfoFn = queryTmuxSessionInfo
 var queryTmuxPaneIDFn = queryTmuxPaneID
 var resolveHookProvenanceFn = resolveHookProvenance
 var postHookEventFn = postHookEvent
@@ -68,9 +70,9 @@ func runHook(args []string) {
 		os.Exit(1)
 	}
 
-	tmuxSession := queryTmuxSessionFn()
+	tmuxSessionID, tmuxSession := queryTmuxSessionInfoFn()
 	provenance := resolveHookProvenanceFn()
-	payload := buildHookPayload(tmuxSession, purdexName, os.Stdin, agentType, provenance)
+	payload := buildHookPayload(tmuxSessionID, tmuxSession, purdexName, os.Stdin, agentType, provenance)
 
 	cfg, err := loadConfigFn("")
 	var url, token string
@@ -85,7 +87,8 @@ func runHook(args []string) {
 }
 
 // queryTmuxSession runs `tmux display-message -p '#{session_name}'` and returns
-// the session name, or "" on any error.
+// the session name, or "" on any error. Retained for non-hook callers
+// (cmd/pdx/statusline_proxy.go) that only need the name.
 func queryTmuxSession() string {
 	out, err := exec.Command("tmux", "display-message", "-p", "#{session_name}").Output()
 	if err != nil {
@@ -94,19 +97,49 @@ func queryTmuxSession() string {
 	return strings.TrimRight(string(out), "\n")
 }
 
+// queryTmuxSessionInfo returns (sessionID, sessionName) from a single
+// `tmux display-message -p '#{session_id}|#{session_name}'` call. Both empty
+// on any error. The sessionID ($N format) is immutable across rename and is
+// the primary key the daemon uses to bypass the name cache rename-race
+// window when resolving session codes for hook events.
+func queryTmuxSessionInfo() (string, string) {
+	out, err := exec.Command("tmux", "display-message", "-p", "#{session_id}|#{session_name}").Output()
+	if err != nil {
+		return "", ""
+	}
+	return parseTmuxSessionInfo(string(out))
+}
+
+// parseTmuxSessionInfo splits "<sessionID>|<sessionName>" output on the FIRST
+// '|'. Names may contain '|' characters (real tmux permits them); the parser
+// preserves them in the name half. When no delimiter is present we treat the
+// whole string as the name and return an empty ID — the daemon falls back to
+// the name path safely.
+func parseTmuxSessionInfo(out string) (string, string) {
+	trimmed := strings.TrimRight(out, "\n")
+	idx := strings.Index(trimmed, "|")
+	if idx < 0 {
+		return "", trimmed
+	}
+	return trimmed[:idx], trimmed[idx+1:]
+}
+
 func queryTmuxPaneID() string {
 	return os.Getenv("TMUX_PANE")
 }
 
 // buildHookPayload constructs a hookPayload from the given parameters.
 // If stdin is empty or cannot be read, raw_event defaults to {}.
-func buildHookPayload(tmuxSession, purdexName string, stdin io.Reader, agentType string, provenance hookProvenance) hookPayload {
+// tmuxSessionID is optional ($N format); when non-empty the daemon prefers
+// it over tmuxSession for code resolution to dodge the rename-race window.
+func buildHookPayload(tmuxSessionID, tmuxSession, purdexName string, stdin io.Reader, agentType string, provenance hookProvenance) hookPayload {
 	raw, err := io.ReadAll(stdin)
 	if err != nil || len(bytes.TrimSpace(raw)) == 0 {
 		raw = []byte("{}")
 	}
 	return hookPayload{
 		TmuxSession:     tmuxSession,
+		TmuxSessionID:   tmuxSessionID,
 		TmuxPaneID:      provenance.TmuxPaneID,
 		PurdexName:      purdexName,
 		RawEvent:        json.RawMessage(raw),

--- a/cmd/pdx/hook_test.go
+++ b/cmd/pdx/hook_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestBuildHookPayload_MarshalsPurdexName(t *testing.T) {
 	stdin := strings.NewReader(`{}`)
-	p := buildHookPayload("sess", "PdxSessionStart", stdin, "cc", hookProvenance{
+	p := buildHookPayload("", "sess", "PdxSessionStart", stdin, "cc", hookProvenance{
 		TmuxPaneID:      "%5",
 		SenderPID:       1,
 		SenderStartTime: "Sun Apr 20 01:30:00 2026",
@@ -33,20 +33,20 @@ func TestBuildHookPayload_MarshalsPurdexName(t *testing.T) {
 }
 
 func TestRunHook_PositionalArgPassedAsPurdexName(t *testing.T) {
-	origSession := queryTmuxSessionFn
+	origInfo := queryTmuxSessionInfoFn
 	origResolve := resolveHookProvenanceFn
 	origPost := postHookEventFn
 	origLoad := loadConfigFn
 	origStdin := os.Stdin
 	t.Cleanup(func() {
-		queryTmuxSessionFn = origSession
+		queryTmuxSessionInfoFn = origInfo
 		resolveHookProvenanceFn = origResolve
 		postHookEventFn = origPost
 		loadConfigFn = origLoad
 		os.Stdin = origStdin
 	})
 
-	queryTmuxSessionFn = func() string { return "work" }
+	queryTmuxSessionInfoFn = func() (string, string) { return "$1", "work" }
 	resolveHookProvenanceFn = func() hookProvenance {
 		return hookProvenance{
 			TmuxPaneID:      "%5",
@@ -78,7 +78,7 @@ func TestRunHook_PositionalArgPassedAsPurdexName(t *testing.T) {
 
 func TestBuildHookPayload(t *testing.T) {
 	stdin := strings.NewReader(`{"type":"Stop","session_id":"abc123"}`)
-	p := buildHookPayload("my-session", "Stop", stdin, "", hookProvenance{
+	p := buildHookPayload("", "my-session", "Stop", stdin, "", hookProvenance{
 		TmuxPaneID:      "%5",
 		SenderPID:       123,
 		SenderStartTime: "Sun Apr 20 01:30:00 2026",
@@ -115,7 +115,7 @@ func TestBuildHookPayload(t *testing.T) {
 
 func TestBuildHookPayload_EmptyStdin(t *testing.T) {
 	stdin := strings.NewReader("")
-	p := buildHookPayload("sess", "Start", stdin, "", hookProvenance{
+	p := buildHookPayload("", "sess", "Start", stdin, "", hookProvenance{
 		TmuxPaneID:      "%7",
 		SenderPID:       456,
 		SenderStartTime: "Sun Apr 20 01:40:00 2026",
@@ -134,7 +134,7 @@ func TestBuildHookPayload_EmptyStdin(t *testing.T) {
 
 func TestBuildHookPayload_WithAgentType(t *testing.T) {
 	stdin := strings.NewReader(`{"hook_event_name":"Stop"}`)
-	p := buildHookPayload("sess", "Stop", stdin, "cc", hookProvenance{})
+	p := buildHookPayload("", "sess", "Stop", stdin, "cc", hookProvenance{})
 
 	if p.AgentType != "cc" {
 		t.Errorf("AgentType = %q, want %q", p.AgentType, "cc")
@@ -143,7 +143,7 @@ func TestBuildHookPayload_WithAgentType(t *testing.T) {
 
 func TestBuildHookPayload_EmptyAgent(t *testing.T) {
 	stdin := strings.NewReader(`{}`)
-	p := buildHookPayload("sess", "Stop", stdin, "", hookProvenance{})
+	p := buildHookPayload("", "sess", "Stop", stdin, "", hookProvenance{})
 
 	if p.AgentType != "" {
 		t.Errorf("AgentType = %q, want empty", p.AgentType)
@@ -248,15 +248,147 @@ func TestPostHookEvent_ServerDown(t *testing.T) {
 	}
 }
 
+// TestQueryTmuxSessionInfo_ParsesIDAndName proves the new helper returns
+// (sessionID, sessionName) from a single tmux call. The hook payload uses the
+// immutable ID to bypass the name cache rename-race window in handler.go.
+func TestQueryTmuxSessionInfo_ParsesIDAndName(t *testing.T) {
+	origInfo := queryTmuxSessionInfoFn
+	t.Cleanup(func() { queryTmuxSessionInfoFn = origInfo })
+
+	queryTmuxSessionInfoFn = func() (string, string) { return "$5", "alpha" }
+
+	id, name := queryTmuxSessionInfoFn()
+	if id != "$5" {
+		t.Errorf("sessionID = %q, want $5", id)
+	}
+	if name != "alpha" {
+		t.Errorf("sessionName = %q, want alpha", name)
+	}
+}
+
+// TestQueryTmuxSessionInfo_HandlesNameWithPipe pins parser behaviour for
+// session names containing the delimiter. We split on the FIRST '|' so the
+// rest of the name (including any further '|') survives intact. Real tmux
+// permits '|' in session names; the parser must not corrupt it.
+func TestQueryTmuxSessionInfo_HandlesNameWithPipe(t *testing.T) {
+	id, name := parseTmuxSessionInfo("$5|name|with|pipes\n")
+	if id != "$5" {
+		t.Errorf("sessionID = %q, want $5", id)
+	}
+	if name != "name|with|pipes" {
+		t.Errorf("sessionName = %q, want name|with|pipes", name)
+	}
+}
+
+// TestQueryTmuxSessionInfo_NoDelimiter covers the malformed/legacy tmux output
+// path. When the delimiter is absent we treat the entire output as the name
+// and return an empty ID — handler.go falls back to the name path safely.
+func TestQueryTmuxSessionInfo_NoDelimiter(t *testing.T) {
+	id, name := parseTmuxSessionInfo("legacy-name\n")
+	if id != "" {
+		t.Errorf("sessionID = %q, want empty", id)
+	}
+	if name != "legacy-name" {
+		t.Errorf("sessionName = %q, want legacy-name", name)
+	}
+}
+
+// TestBuildHookPayload_IncludesSessionID verifies the wire format carries
+// tmux_session_id when populated. The daemon needs the immutable ID to
+// resolve the session code without consulting the name cache.
+func TestBuildHookPayload_IncludesSessionID(t *testing.T) {
+	stdin := strings.NewReader(`{}`)
+	p := buildHookPayload("$7", "alpha", "PdxStop", stdin, "cc", hookProvenance{
+		TmuxPaneID:      "%5",
+		SenderPID:       1,
+		SenderStartTime: "Sun Apr 20 01:30:00 2026",
+	})
+	if p.TmuxSessionID != "$7" {
+		t.Errorf("TmuxSessionID = %q, want $7", p.TmuxSessionID)
+	}
+
+	out, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"tmux_session_id":"$7"`) {
+		t.Errorf("payload missing tmux_session_id: %s", string(out))
+	}
+}
+
+// TestBuildHookPayload_OmitsEmptySessionID guards omitempty: legacy CLIs that
+// don't populate the ID must not emit the field, so handler.go's fallback
+// branch (driven by req.TmuxSessionID == "") triggers correctly.
+func TestBuildHookPayload_OmitsEmptySessionID(t *testing.T) {
+	stdin := strings.NewReader(`{}`)
+	p := buildHookPayload("", "alpha", "PdxStop", stdin, "cc", hookProvenance{
+		TmuxPaneID: "%5", SenderPID: 1,
+		SenderStartTime: "Sun Apr 20 01:30:00 2026",
+	})
+	out, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), `tmux_session_id`) {
+		t.Errorf("empty TmuxSessionID must be omitted via omitempty: %s", string(out))
+	}
+}
+
+// TestRunHook_PopulatesSessionID proves the runHook entry point routes the
+// new info-query helper into the payload. queryTmuxSessionInfoFn returns both
+// fields in a single call — runHook must pass both into buildHookPayload.
+func TestRunHook_PopulatesSessionID(t *testing.T) {
+	origInfo := queryTmuxSessionInfoFn
+	origResolve := resolveHookProvenanceFn
+	origPost := postHookEventFn
+	origLoad := loadConfigFn
+	origStdin := os.Stdin
+	t.Cleanup(func() {
+		queryTmuxSessionInfoFn = origInfo
+		resolveHookProvenanceFn = origResolve
+		postHookEventFn = origPost
+		loadConfigFn = origLoad
+		os.Stdin = origStdin
+	})
+
+	queryTmuxSessionInfoFn = func() (string, string) { return "$11", "work" }
+	resolveHookProvenanceFn = func() hookProvenance {
+		return hookProvenance{TmuxPaneID: "%5", SenderPID: 42, SenderStartTime: "t"}
+	}
+	loadConfigFn = func(string) (config.Config, error) { return config.Config{}, nil }
+
+	var got hookPayload
+	postHookEventFn = func(_ string, _ string, payload hookPayload) error {
+		got = payload
+		return nil
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	_ = w.Close()
+	os.Stdin = r
+
+	runHook([]string{"--agent", "cc", "PdxSessionStart"})
+
+	if got.TmuxSession != "work" {
+		t.Errorf("TmuxSession = %q, want work", got.TmuxSession)
+	}
+	if got.TmuxSessionID != "$11" {
+		t.Errorf("TmuxSessionID = %q, want $11", got.TmuxSessionID)
+	}
+}
+
 func TestRunHook_PopulatesProvenance(t *testing.T) {
-	origSession := queryTmuxSessionFn
+	origInfo := queryTmuxSessionInfoFn
 	origPaneID := queryTmuxPaneIDFn
 	origResolve := resolveHookProvenanceFn
 	origPost := postHookEventFn
 	origLoad := loadConfigFn
 	origStdin := os.Stdin
 	t.Cleanup(func() {
-		queryTmuxSessionFn = origSession
+		queryTmuxSessionInfoFn = origInfo
 		queryTmuxPaneIDFn = origPaneID
 		resolveHookProvenanceFn = origResolve
 		postHookEventFn = origPost
@@ -264,7 +396,7 @@ func TestRunHook_PopulatesProvenance(t *testing.T) {
 		os.Stdin = origStdin
 	})
 
-	queryTmuxSessionFn = func() string { return "work" }
+	queryTmuxSessionInfoFn = func() (string, string) { return "$3", "work" }
 	queryTmuxPaneIDFn = func() string { return "%5" }
 	resolveHookProvenanceFn = func() hookProvenance {
 		return hookProvenance{

--- a/docs/specs/2026-04-30-daemon-hook-pipeline-lag-analysis.md
+++ b/docs/specs/2026-04-30-daemon-hook-pipeline-lag-analysis.md
@@ -1,0 +1,240 @@
+# Daemon Hook Pipeline Lag — Production-Grade Root Cause Analysis
+
+> **Status**: analysis doc (not a spec — feeds into action items below)
+> **Worktree**: `daemon-perf-fastpath` / branch `worktree-daemon-perf-fastpath`
+> **Base**: `origin/main` @ alpha.268
+> **Investigation date**: 2026-04-30
+> **Codex job**: `task-mokpcqt9-f3tolm` (8m 20s, effort=high)
+> **Trigger context**: W6-3+W6-4 ProbeIntent first PR mlab live verify revealed user-perceived "3 second lag" from hook trigger to SPA tab status update; W6-3 ProbeIntent itself stayed within spec ≤2s but the surrounding pipeline added unaccounted-for time.
+
+---
+
+## 1. Observed symptoms
+
+User on mlab (M4 / 16GB / SSD), running codex pane:
+
+- **"按 Enter ping → SPA 看到 codex icon"** ≈ **3 秒**（兩次測試一致）
+- **"`/exit` 或 `^c` → SPA 看到 terminal icon"** ≈ **3-4 秒**
+
+Daemon log slice (one PdxUserPromptSubmit chain, grep `[hook] / [derive] / [handler] / [probe] / [broadcast]`):
+
+```
+07:20:10  [hook] trigger session=purdex-sync agent=codex purdex_name=PdxUserPromptSubmit chain_id=83ab82dc
+07:20:10  [derive] verify_passed status=running
+07:20:10  [handler] frame_apply lifecycle=PdxUserPromptSubmit decision=updated_frame
+07:20:12  [handler] projection_built top_status=running pane_id=%11           ← +2s gap (B 段)
+07:20:12  [probe] recordHookAt
+07:20:14  [probe-intent] start arm pid=16596 generation=3
+07:20:15  [broadcast] decision=broadcasted reason=session_code_resolved        ← +3s from frame_apply (E 段)
+```
+
+Two consistent gaps reproducible across multiple chains:
+- **B**: `frame_apply → projection_built` ≈ 1-2s
+- **E**: `projection_built → broadcast` ≈ 1-2s
+
+W6-3 ProbeIntent detector (`arm → emit signal → status=error`) measured ~1-2s, **within spec ≤2s** — not the source of the user-perceived lag.
+
+---
+
+## 2. Root cause
+
+### 2.1 真正主犯：`resolveSessionCode` in hook hot path
+
+`emitHookToSession` (`internal/module/agent/handler.go:480, 494`) calls `resolveSessionCode(tmuxSession)` on **every hook event**. That function calls `m.sessions.ListSessions()` directly — bypassing the existing `cachedListSessions()` debounce that `/api/sessions` HTTP handler uses.
+
+`ListSessions()` (`internal/module/session/service.go:15-44`) executes:
+1. `tmux list-sessions` × 1 (`internal/tmux/executor.go:81`)
+2. `meta.CleanOrphans()` write × 1 (`internal/module/session/service.go:21`)
+3. `applyActivePaneMetadata()` × S sessions (`internal/module/session/service.go:44`)
+4. Inside each: `ActivePaneMetadata()` runs **7 × `tmux display-message`** (`internal/tmux/executor.go:115`)
+5. Plus S × `meta.GetMeta()` reads
+
+**Total per hook**: `1 + 7×S` tmux subprocess invocations. With S=5 live sessions (typical user setup) = **36 tmux exec calls**. Each tmux subprocess on macOS = 30-80ms (process spawn + tmux client→server roundtrip). Lower bound: 36 × 30ms = **1.08s**. Upper bound under load: 36 × 80ms = **2.88s**. This matches the observed +1-3s gap exactly.
+
+### 2.2 B 段次因：`projectionForSession` 走 per-pane tmux exec
+
+`handler.handleEvent` calls `m.projectionForSession(req.TmuxSession)` (`handler.go:308`) after `applyFrameEvent` already produced a pane-scoped projection. The second call is **necessary** semantically (pane-scope → session-scope upgrade needed for multi-pane sessions) but its implementation walks `frames.ListAll → BuildSessionProjections → per-projection resolvePaneSession`.
+
+`resolvePaneSession` (`internal/module/agent/module.go:605`) issues another `tmux display-message "#{session_name}"` per pane (`internal/tmux/executor.go:268`). With P=5 live panes = 5 more tmux subprocesses ≈ **150-400ms** added to B 段.
+
+### 2.3 D 段：W6-3 dispatcher target lookup 持 `m.mu`
+
+`probeIntentDispatcher.applyIntentLifecycle` (`internal/module/agent/probe_intent_dispatcher.go:262`) calls `lookupTopFrameForSessionLocked` inside the `m.mu` critical section. That helper transitively calls `projectionForSession → resolvePaneSession → tmux exec` — **all under the global lock**. Other goroutines (other hook handlers, probe callbacks, rename) convoy behind it.
+
+This is W6-3 自己引入的 lock convoy；the dispatcher fundamentally needs to know `(paneID, senderPID)` to arm/match detectors, but the hook caller (`manageActivityWatch`) **already has** `projection.TopFrame` in scope — no need to re-query.
+
+### 2.4 E 段次因：sqlite `synchronous=FULL` + 沒 `busy_timeout`
+
+`internal/store/{meta,agent_event,frames,trace}.go` 的 DSN 只開 `journal_mode(wal)`，沒設 `synchronous` (預設 FULL — 每次 commit fsync) 或 `busy_timeout`。File-backed pool 也沒 cap (`SetMaxOpenConns` 只在 `:memory:` test 設 1)。
+
+但這不是主因：`sync=FULL` 在 SSD 是 ms 級不是秒級；`busy_timeout` 沒設只會立即 abort（`SQLITE_BUSY` error），log 沒 abort path 表示沒撞到。Tail 治理價值約 **20-150ms** average，contention/checkpoint 高峰可達 200ms+。
+
+### 2.5 已排除（非主因）
+
+- `pdx hook` CLI cold start：80-250ms 額外 tax 在 hook 進入 daemon **之前**；user log 已從 `[hook] trigger` 對齊，不解釋 daemon 內 3s。
+- HTTP handler sync trace enqueue：`hookTraceSink.Enqueue` 是 channel send，不等 db write (`internal/module/agent/trace.go:106`).
+- SPA WebSocket flow control：broadcaster non-blocking、滿了就 drop (`internal/core/events.go:28, 110`)，不會 block handler.
+- GC / goroutine scheduling：通常 ms 級，不會穩定每 hook 都貢獻 2s 分段。
+- W6-3 detector 1Hz polling：影響 arm 後 recovery latency，不是 hook 主路徑。
+
+---
+
+## 3. Production-grade fix proposals
+
+所有方案都必須在 production 環境（含 Linux daemon、power loss、並發、跨版本 schema）安全。
+
+### 3.1 #1 — `resolveSessionCode` fast path **(highest ROI)**
+
+**Design**:
+- 在 `internal/module/session/` 加 `LookupCodeByName(name string) (code string, ok bool)` — 只做「session name → tmux session ID → code」解析；**不**跑 `CleanOrphans`、`ActivePaneMetadata`、full `SessionInfo` hydration
+- agent module type-assert 新介面，miss 時 fallback 舊路徑
+- rename atomic flow 同步更新 lookup state；create/delete 時 invalidate
+
+**Production safety**:
+- 純讀路徑，不改狀態機
+- code 仍由 tmux session ID 決定（authoritative source 不變）
+- macOS / Linux 都只依賴 tmux 基本命令
+- rename invalidation 走既有 `RenameSessionAtomic` hook
+
+**Risk matrix**: low
+- 主要 regression：rename 後 cache stale → 解法是 rename atomic path 同步 invalidate + miss-refresh 補底
+- 跨版本 schema：無
+- Observability：保留現有 log path
+
+**Effort**: 4-6h / **預期收益**: **1.0-2.5s** / **與 W6-3 dependency**: 可獨立 ship
+
+### 3.2 #2 — `agent_frames` 加 `tmux_session` 欄位 persist
+
+**Design**:
+- `internal/store/frames.go` schema migration：加 `tmux_session TEXT NOT NULL DEFAULT ''`
+- `applyFrameEvent` 寫入 `req.TmuxSession`
+- 加 `frames.ListBySession(session)` 或 `ProjectSession(session)`
+- `handler.handleEvent` 改用 session-scoped 直接 query，不再 `ListAll + per-pane resolvePaneSession`
+
+**Production safety**:
+- 比純 in-memory cache 穩：可重播、可 restart、可在 `RenameSessionAtomic` 內 atomic 更新
+- Migration 採 dual-read：`tmux_session=''` 舊 row fallback 舊路徑，新 hook 寫入後逐步 cover
+- Schema migration 走既有 migrateFramesDB 順序（idempotent）
+
+**Risk matrix**: medium
+- 改 schema：要寫 migration test、historical replay test
+- rename flow：sql update + cache invalidation 須一起做（atomic）
+- Observability：trace store 可考慮加 `tmux_session` 欄位輔助 debug
+
+**Effort**: 8-14h / **預期收益**: **0.5-1.5s** / **與 W6-3 dependency**: 改的 `handler.go` / `module.go` rename 區與 W6-3 #3 high overlap → **應在 W6-3 + #1 ship 後做**
+
+### 3.3 #3 — W6-3 dispatcher target injection（hook path 不再走 lookup）
+
+**Design**:
+- `manageActivityWatch(session, agentType, newStatus)` signature 加 optional `target ProbeIntentTarget{paneID, senderPID}` 參數
+- caller (`handler.handleEvent` line ~413) 從 `projection.TopFrame` 取 target 直接傳
+- `dispatcher.applyStatus` 收 target：若 caller 有提供就直接用；nil 才走慢速 `lookupTopFrameForSessionLocked`（replay path 保留）
+- target 在 m.mu 外讀取，generation/cancel/active-set 仍在 m.mu 內保護
+
+**Production safety**:
+- target value 來自同一次 projection，比重新查更一致（避免 hook 與 lookup 之間 race window）
+- replay path 仍走慢速 lookup（daemon restart 沒 caller context）
+- Lifecycle 5 case + reconcile + replay race + cross-provider 全部不變
+
+**Risk matrix**: medium
+- W6-3 邏輯面修改 → 補 lifecycle / rename / replay race tests
+- 與 W6-3 spec §5.4 對齊（不破壞「lifecycle 單一進入點」原則 — caller 提供 target 是 hint 不是 bypass）
+
+**Effort**: 4-8h / **預期收益**: **0.5-1.5s**（消除 lock convoy） / **與 W6-3 dependency**: **建議與 W6-3 一起 bundle**（避免 W6-3 ship 後自己引入 lock convoy 再修）
+
+### 3.4 #4 — sqlite `busy_timeout + pool cap`
+
+**Design**:
+- 4 個 store DSN 加 `busy_timeout(5000)` pragma
+- File-backed pool: `agent DB SetMaxOpenConns(4) + SetMaxIdleConns(4)`、`meta DB 2/2`
+- 不改 `synchronous`（保 FULL）
+
+**Production safety**:
+- `busy_timeout` 不改 durability，只是讓 SQLITE_BUSY 等而非 abort（避免 transient contention 中斷）
+- Pool cap 對 WAL 多 reader 並發友善；既有 `UpsertIfUnchanged` / `DeleteIfUnchanged` 已用 optimistic concurrency 不依賴單連線序列化 (`internal/store/frames.go:263, 363`)
+- SQLite WAL 多 reader / 單 writer 模型不變
+
+**Risk matrix**: low
+- 無 schema / API 改動
+- 只可能因 pool 放大導致 fd 用量略增（cap=4 不顯著）
+
+**Effort**: 2-4h / **預期收益**: **20-150ms** average / 可壓 200ms+ tail / **與 W6-3 dependency**: 完全獨立
+
+### 3.5 #5 — sqlite `synchronous=NORMAL` **(NOT recommended for now)**
+
+**Design**: DSN 加 `synchronous(NORMAL)` pragma — fsync 從 per-page write 降到 per-transaction commit。
+
+**Trade-off**:
+- **不損壞 DB / 不改一致性**：integrity 保證不變
+- **Power loss 可能丟最後幾筆已回應的 WAL commit**：durability 降級
+- 大多 OLTP service 都用 NORMAL，但 purdex 這類 dev 工具 + 觀測性 store 對 last-commit durability 沒明確要求
+
+**Recommendation**: **暫不做**。User 明確要求 production-grade、不依賴「dev 接受短暫 inconsistency」取捨。即使 codex 確認 NORMAL 是 durability 而非 integrity tradeoff，仍視為 future-consideration。Stability-first 優先 #4 即可。
+
+---
+
+## 4. Out of scope（不修）
+
+- **SPA render path**：lag 發生在 daemon broadcast 之前，SPA 收到 event 後 render 是 ms 級
+- **WebSocket subscriber flow control**：non-blocking drop semantics 已正確 (`internal/core/events.go:28, 110`)
+- **Tailscale / network**：user 與 daemon 同機，無網路 hop
+- **Codex detector 1Hz poll**：影響 arm 後 recovery latency，不是 hook 主路徑
+- **`pdx hook` CLI cold start**：80-250ms 額外 tax 在 daemon 之外
+- **`broadcast async + coalesce`**：codex 明確不建議（會引入 out-of-order / drop-more 風險，對 lag 幾乎沒幫助）
+
+---
+
+## 5. 推薦執行順序
+
+| Order | Item | Effort | Risk | 收益 | Bundle |
+|---|---|---|---|---|---|
+| 1 | **#1** `resolveSessionCode` fast path | 4-6h | low | 1.0-2.5s | 獨立 hotfix PR |
+| 2 | **#3** W6-3 dispatcher target injection | 4-8h | med | 0.5-1.5s | **bundle 進 W6-3 PR** |
+| 3 | **#4** sqlite `busy_timeout + pool cap` | 2-4h | low | 20-150ms tail | 獨立或併 #1 PR |
+| 4 | #2 `tmux_session` persist + session-scoped query | 8-14h | med | 0.5-1.5s | W6-3 + #1 ship 後做 |
+| - | #5 `synchronous=NORMAL` | 1-2h | med (durability) | 30-150ms tail | **不做**（production-grade 約束）|
+
+**Total expected improvement**: 1.5s-4s reduction (hook → broadcast 從 3-4s 降到 ~0.5-1s)。
+
+---
+
+## 6. 並行作業排程
+
+兩個 worktree 並行：
+
+### 6.1 W6-3+W6-4 worktree (`lights-w6-3-codex-error`)
+
+- 主任務：W6-3 收尾（P2-T6 signal log race fix + #3 dispatcher target injection + P2-T8 mlab live verify + PR + 兩輪 review + bump）
+- bundle #3 是**新增 scope**，理由：避免 W6-3 ship 後自己引入 lock convoy 再修；改動 mechanical（manageActivityWatch + dispatcher.applyStatus signature）
+
+### 6.2 daemon-perf worktree (`daemon-perf-fastpath`，本文件所在)
+
+- 主任務：#1 fast-path + #4 sqlite tuning（一個 PR 或拆兩個都可）
+- 與 W6-3 重疊：**`internal/module/agent/handler.go` 同檔不同函式**
+  - W6-3 #3 改 line ~413 (manageActivityWatch caller)
+  - #1 改 line ~480-494 (emitHookToSession + resolveSessionCode)
+  - 兩函式相距 70+ lines，git auto-merge 應 OK，但 review 期間互相 rebase 一次
+
+### 6.3 後續（W6-3 + #1+#4 ship 後）
+
+- W6-LightsUI（issue #762，3 個 SPA 燈號 polish）
+- #2 `tmux_session` persist（需 schema migration，scope 較大）
+- W6-1 cc running spinner / W6-2 cc idle PostCompact / W6-5 / W6-6 等 W6 子項
+- W5 燈號 bug 工作池
+
+---
+
+## 7. 引用
+
+- Codex job `task-mokpcqt9-f3tolm` (8m 20s, effort=high, model=spark)
+- Codex session ID: `019ddba1-a2f7-7813-8cd2-37a40c876e9c`
+- Codex log: `/Users/wake/.claude/plugins/data/codex-openai-codex/state/purdex-4f74e01e473c9395/jobs/task-mokpcqt9-f3tolm.log`
+- 觀察 daemon log: `/tmp/pdx-w6-3.log` (mlab, build commit `a3a2b2fa` from `worktree-lights-w6-3-codex-error`)
+
+---
+
+## 8. 文獻
+
+- W1 audit: `docs/specs/2026-04-28-hook-status-audit-spec.md`（hook → status → 燈號對齊 SOT）
+- W6-3 spec: `docs/specs/2026-04-29-w6-3-codex-error-probe-intent-spec.md`（dispatcher 5-case lifecycle）
+- W6-3 plan: `docs/specs/2026-04-29-w6-3-codex-error-probe-intent-plan.md`（P1+P2 任務拆分）

--- a/internal/module/agent/fast_path_test.go
+++ b/internal/module/agent/fast_path_test.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/wake/purdex/internal/module/session"
+)
+
+// Compile-time guard: the production *session.SessionModule must satisfy the
+// unexported sessionCodeLookuper interface. If Task A's method signature ever
+// drifts (e.g. someone changes the return shape), this fails to compile and
+// surfaces the regression at build time instead of in production hot path.
+var _ sessionCodeLookuper = (*session.SessionModule)(nil)
+
+// fakeFastSessionProvider implements both session.SessionProvider AND
+// LookupCodeByName, mirroring the production *session.SessionModule. Counters
+// let tests assert which code path resolveSessionCode took: the fast-path
+// branch must call LookupCodeByName and skip ListSessions; only a fast-path
+// miss is allowed to fall through to ListSessions.
+type fakeFastSessionProvider struct {
+	sessions       []session.SessionInfo
+	lookup         map[string]string
+	listCalls      int
+	lookupCalls    int
+	lookupHits     int
+}
+
+func (f *fakeFastSessionProvider) ListSessions() ([]session.SessionInfo, error) {
+	f.listCalls++
+	return f.sessions, nil
+}
+
+func (f *fakeFastSessionProvider) GetSession(code string) (*session.SessionInfo, error) {
+	for _, s := range f.sessions {
+		if s.Code == code {
+			return &s, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeFastSessionProvider) UpdateMeta(string, session.MetaUpdate) error { return nil }
+func (f *fakeFastSessionProvider) HandleTerminalWS(http.ResponseWriter, *http.Request, string) {
+}
+
+// LookupCodeByName satisfies the unexported sessionCodeLookuper interface in
+// the agent package. Counts every call so tests can assert hit / miss.
+func (f *fakeFastSessionProvider) LookupCodeByName(name string) (string, bool) {
+	f.lookupCalls++
+	if f.lookup == nil {
+		return "", false
+	}
+	code, ok := f.lookup[name]
+	if ok {
+		f.lookupHits++
+	}
+	return code, ok
+}
+
+// TestResolveSessionCode_UsesFastPathWhenAvailable verifies the entire point of
+// the optimization: when the provider exposes LookupCodeByName, the hot path
+// MUST hit the cache and skip ListSessions (which fans out 1+7×S tmux
+// subprocesses per call).
+func TestResolveSessionCode_UsesFastPathWhenAvailable(t *testing.T) {
+	m := &Module{}
+	fake := &fakeFastSessionProvider{
+		// ListSessions returns data too — this lets us prove via listCalls==0
+		// that the fast path bypassed it, rather than relying on an empty list
+		// that could mask incorrect fall-through.
+		sessions: []session.SessionInfo{{Name: "foo", Code: "slow-foo"}},
+		lookup:   map[string]string{"foo": "code-foo"},
+	}
+	m.sessions = fake
+
+	got := m.resolveSessionCode("foo")
+
+	if got != "code-foo" {
+		t.Errorf("resolveSessionCode = %q; want %q (fast-path code)", got, "code-foo")
+	}
+	if fake.lookupCalls != 1 {
+		t.Errorf("LookupCodeByName calls = %d; want 1", fake.lookupCalls)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListSessions calls = %d; want 0 (fast-path must skip slow path)", fake.listCalls)
+	}
+}
+
+// TestResolveSessionCode_FallsBackOnFastPathMiss covers the safety-net branch:
+// if the cache reports the name as unknown (recently created/renamed session,
+// cache invalidation race), the slow path runs once and returns the canonical
+// answer. Critical for correctness — fast path must never silently drop.
+func TestResolveSessionCode_FallsBackOnFastPathMiss(t *testing.T) {
+	m := &Module{}
+	fake := &fakeFastSessionProvider{
+		sessions: []session.SessionInfo{{Name: "missing", Code: "slow-code"}},
+		lookup:   map[string]string{}, // empty → every lookup misses
+	}
+	m.sessions = fake
+
+	got := m.resolveSessionCode("missing")
+
+	if got != "slow-code" {
+		t.Errorf("resolveSessionCode = %q; want %q (fallback code)", got, "slow-code")
+	}
+	if fake.lookupCalls != 1 {
+		t.Errorf("LookupCodeByName calls = %d; want 1", fake.lookupCalls)
+	}
+	if fake.listCalls != 1 {
+		t.Errorf("ListSessions calls = %d; want 1 (fallback should fire once)", fake.listCalls)
+	}
+}
+
+// TestResolveSessionCode_FallsBackWhenNoFastPathInterface guarantees backward
+// compatibility: providers that don't implement LookupCodeByName (e.g. the
+// existing fakeSessionProvider used by ~20 other tests) keep working through
+// the slow path. If this regressed, the entire suite would break.
+func TestResolveSessionCode_FallsBackWhenNoFastPathInterface(t *testing.T) {
+	m := &Module{}
+	m.sessions = &fakeSessionProvider{
+		sessions: []session.SessionInfo{{Name: "alpha", Code: "alpha-code"}},
+	}
+
+	got := m.resolveSessionCode("alpha")
+
+	if got != "alpha-code" {
+		t.Errorf("resolveSessionCode = %q; want %q", got, "alpha-code")
+	}
+}

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -490,10 +490,28 @@ func (m *Module) emitHookToSession(tmuxSession string, normalized agentpkg.Norma
 	return "broadcasted", "session_code_resolved"
 }
 
-// resolveSessionCode maps a tmux session name to the pdx session code.
+// sessionCodeLookuper is the optional fast-path interface a SessionProvider
+// can implement to avoid the 1+7×S tmux subprocess fan-out of ListSessions on
+// every hook event. The production *session.SessionModule satisfies this
+// implicitly via its 1s TTL name→code cache (see internal/module/session/
+// lookup.go). Kept unexported here because it's a hot-path optimization, not
+// a public contract.
+type sessionCodeLookuper interface {
+	LookupCodeByName(name string) (string, bool)
+}
+
+// resolveSessionCode maps a tmux session name to the pdx session code. Tries
+// the cached fast path first; falls through to ListSessions on a cache miss
+// so a hook fired during a rename/create race window before cache refresh
+// still resolves correctly (safety net per SOT §3.1).
 func (m *Module) resolveSessionCode(tmuxName string) string {
 	if m.sessions == nil {
 		return ""
+	}
+	if lookuper, ok := m.sessions.(sessionCodeLookuper); ok {
+		if code, found := lookuper.LookupCodeByName(tmuxName); found {
+			return code
+		}
 	}
 	sessions, err := m.sessions.ListSessions()
 	if err != nil {

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -83,7 +83,16 @@ func (m *Module) resolveStatuslineInstaller(w http.ResponseWriter, r *http.Reque
 // (P3-T5) removed that alias so standard struct unmarshal with the
 // `purdex_name` tag is the only shape now accepted.
 type EventRequest struct {
-	TmuxSession     string          `json:"tmux_session"`
+	TmuxSession string `json:"tmux_session"`
+	// TmuxSessionID is the immutable tmux session identifier in `$N` format.
+	// When present, the daemon resolves the session code via a pure
+	// EncodeSessionID call, completely bypassing the name→code cache and
+	// closing the rename-race window where an external
+	// `tmux kill-session foo && tmux new-session -s foo` could otherwise
+	// alias the old code via a stale cache entry. Empty string falls
+	// through to the existing name-based path for backward compat with
+	// older pdx hook binaries.
+	TmuxSessionID   string          `json:"tmux_session_id,omitempty"`
 	TmuxPaneID      string          `json:"tmux_pane_id"`
 	PurdexName      string          `json:"purdex_name"`
 	RawEvent        json.RawMessage `json:"raw_event"`
@@ -356,7 +365,7 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		syncProjectionState(m.currentStatus, m.subagents, req.TmuxSession, projection)
 		m.mu.Unlock()
 		normalized := buildProjectionNormalized(projection, req.AgentType, req.PurdexName, broadcastTs, result)
-		emitDecision, emitReason := m.emitHookToSession(req.TmuxSession, normalized)
+		emitDecision, emitReason := m.emitHookToSession(req, normalized)
 		trace.Emit(normalized, normalized.AgentType, normalized.RawEventName, emitDecision, emitReason)
 		if isDevMode() {
 			log.Printf("[broadcast] session=%s has_clients=%t decision=%s reason=%s raw_event_name=%s chain_id=%s",
@@ -425,7 +434,7 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 	m.mu.Lock()
 	syncProjectionState(m.currentStatus, m.subagents, req.TmuxSession, projection)
 	m.mu.Unlock()
-	emitDecision, emitReason := m.emitHookToSession(req.TmuxSession, normalized)
+	emitDecision, emitReason := m.emitHookToSession(req, normalized)
 	trace.Emit(normalized, normalized.AgentType, normalized.RawEventName, emitDecision, emitReason)
 	if isDevMode() {
 		log.Printf("[broadcast] session=%s has_clients=%t decision=%s reason=%s raw_event_name=%s chain_id=%s",
@@ -472,22 +481,61 @@ func (m *Module) buildNormalized(tmuxSession, eventName, agentType string, broad
 	return normalized
 }
 
-// broadcastToSession resolves the tmux session name to a session code and broadcasts.
+// broadcastToSession resolves the tmux session name to a session code and
+// broadcasts. Used by the probe orchestrator (no hook payload available, so
+// no tmux_session_id) — falls through to the name-based resolveSessionCode
+// path, which is still cache-backed. Hook callsites should use
+// emitHookToSession instead so the immutable ID path engages.
 func (m *Module) broadcastToSession(tmuxSession string, normalized agentpkg.NormalizedEvent) {
-	_, _ = m.emitHookToSession(tmuxSession, normalized)
-}
-
-func (m *Module) emitHookToSession(tmuxSession string, normalized agentpkg.NormalizedEvent) (string, string) {
 	if m.core == nil {
-		return "skipped", "core_unavailable"
+		return
 	}
 	code := m.resolveSessionCode(tmuxSession)
 	if code == "" {
+		return
+	}
+	m.emitNormalizedToCode(code, normalized)
+}
+
+// emitHookToSession routes a hook-derived normalized event to its WS code.
+// Prefers req.TmuxSessionID (immutable, pure-function resolution) over
+// req.TmuxSession (cache-backed, racy across kill+recreate). Returns the
+// (decision, reason) tuple the trace pipeline annotates onto the chain.
+func (m *Module) emitHookToSession(req EventRequest, normalized agentpkg.NormalizedEvent) (string, string) {
+	if m.core == nil {
+		return "skipped", "core_unavailable"
+	}
+	code := m.resolveSessionCodeFromHook(req)
+	if code == "" {
 		return "skipped", "session_code_missing"
 	}
+	m.emitNormalizedToCode(code, normalized)
+	return "broadcasted", "session_code_resolved"
+}
+
+// emitNormalizedToCode is the shared bottom half of both broadcast paths:
+// marshals the normalized event JSON and pushes it onto the events bus.
+// Callers MUST resolve the session code first; this helper makes no
+// assumptions about how it was obtained.
+func (m *Module) emitNormalizedToCode(code string, normalized agentpkg.NormalizedEvent) {
 	payload, _ := json.Marshal(normalized)
 	m.core.Events.Broadcast(code, "hook", string(payload))
-	return "broadcasted", "session_code_resolved"
+}
+
+// resolveSessionCodeFromHook prefers the immutable tmux session ID from the
+// hook payload (eliminates the name-reuse race window) and falls back to
+// the cached name-path resolution when the ID is missing (older pdx hook
+// binary) or malformed (unexpected payload corruption). Falling back rather
+// than dropping keeps a partial-rollout daemon-vs-hook version skew safe.
+func (m *Module) resolveSessionCodeFromHook(req EventRequest) string {
+	if req.TmuxSessionID != "" {
+		code, err := session.EncodeSessionID(req.TmuxSessionID)
+		if err == nil {
+			return code
+		}
+		log.Printf("[agent] invalid tmux_session_id %q: %v (falling back to name path)", req.TmuxSessionID, err)
+	}
+	return m.resolveSessionCode(req.TmuxSession)
 }
 
 // sessionCodeLookuper is the optional fast-path interface a SessionProvider

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -500,17 +500,19 @@ func (m *Module) broadcastToSession(tmuxSession string, normalized agentpkg.Norm
 // emitHookToSession routes a hook-derived normalized event to its WS code.
 // Prefers req.TmuxSessionID (immutable, pure-function resolution) over
 // req.TmuxSession (cache-backed, racy across kill+recreate). Returns the
-// (decision, reason) tuple the trace pipeline annotates onto the chain.
+// (decision, reason) tuple the trace pipeline annotates onto the chain;
+// the reason value carries the resolution path label so operators can grep
+// daemon logs and confirm hook clients have migrated to the ID payload.
 func (m *Module) emitHookToSession(req EventRequest, normalized agentpkg.NormalizedEvent) (string, string) {
 	if m.core == nil {
 		return "skipped", "core_unavailable"
 	}
-	code := m.resolveSessionCodeFromHook(req)
+	code, path := m.resolveSessionCodeFromHook(req)
 	if code == "" {
 		return "skipped", "session_code_missing"
 	}
 	m.emitNormalizedToCode(code, normalized)
-	return "broadcasted", "session_code_resolved"
+	return "broadcasted", string(path)
 }
 
 // emitNormalizedToCode is the shared bottom half of both broadcast paths:
@@ -522,20 +524,48 @@ func (m *Module) emitNormalizedToCode(code string, normalized agentpkg.Normalize
 	m.core.Events.Broadcast(code, "hook", string(payload))
 }
 
+// hookSessionCodePath labels which resolution branch produced the session
+// code for a hook event. It is surfaced through emitHookToSession's reason
+// return so the trace pipeline / broadcast log lets operators tell during
+// rollout whether hook clients have migrated to the new tmux_session_id
+// payload (fast path) vs still using the legacy name path (cache lookup).
+type hookSessionCodePath string
+
+const (
+	// hookCodePathID — TmuxSessionID present and valid; the immutable ID
+	// path resolved the code via a pure EncodeSessionID call. Migrated
+	// hook clients hit this branch.
+	hookCodePathID hookSessionCodePath = "id_path"
+	// hookCodePathIDEmpty — TmuxSessionID missing; backward-compat
+	// fallback to the name-cache path. Indicates the hook client is an
+	// older pdx binary not yet updated; an operational signal that
+	// rollout is incomplete.
+	hookCodePathIDEmpty hookSessionCodePath = "id_empty"
+	// hookCodePathMalformedID — TmuxSessionID present but rejected by
+	// EncodeSessionID (corrupt payload / bug). Falls back to the name
+	// path; the inline error log captures the offending value.
+	hookCodePathMalformedID hookSessionCodePath = "malformed_id"
+)
+
 // resolveSessionCodeFromHook prefers the immutable tmux session ID from the
 // hook payload (eliminates the name-reuse race window) and falls back to
 // the cached name-path resolution when the ID is missing (older pdx hook
 // binary) or malformed (unexpected payload corruption). Falling back rather
 // than dropping keeps a partial-rollout daemon-vs-hook version skew safe.
-func (m *Module) resolveSessionCodeFromHook(req EventRequest) string {
-	if req.TmuxSessionID != "" {
-		code, err := session.EncodeSessionID(req.TmuxSessionID)
-		if err == nil {
-			return code
-		}
-		log.Printf("[agent] invalid tmux_session_id %q: %v (falling back to name path)", req.TmuxSessionID, err)
+//
+// The returned hookSessionCodePath labels the branch that produced the
+// code; see the constants for semantics. Callers that don't log the
+// reason can ignore the second return.
+func (m *Module) resolveSessionCodeFromHook(req EventRequest) (string, hookSessionCodePath) {
+	if req.TmuxSessionID == "" {
+		return m.resolveSessionCode(req.TmuxSession), hookCodePathIDEmpty
 	}
-	return m.resolveSessionCode(req.TmuxSession)
+	code, err := session.EncodeSessionID(req.TmuxSessionID)
+	if err != nil {
+		log.Printf("[agent] invalid tmux_session_id %q: %v (falling back to name path)", req.TmuxSessionID, err)
+		return m.resolveSessionCode(req.TmuxSession), hookCodePathMalformedID
+	}
+	return code, hookCodePathID
 }
 
 // sessionCodeLookuper is the optional fast-path interface a SessionProvider

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -191,7 +191,11 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// as a fallback for older / non-conforming senders.
 	if req.AgentType == "cc" && (req.PurdexName == "PdxPreToolUse" || req.PurdexName == "PdxPostToolUse") &&
 		m.core != nil && m.pathHintDedup != nil && m.pathHintBuffer != nil {
-		if code := m.resolveSessionCode(req.TmuxSession); code != "" {
+		// Prefer the immutable tmux session ID (matches the broadcast path
+		// in emitHookToSession). resolveSessionCode (name cache) would
+		// otherwise leak the kill+recreate rename race onto path hints —
+		// stale code → wrong SPA session receives the path hint.
+		if code, _ := m.resolveSessionCodeFromHook(req); code != "" {
 			cwdFallback := ""
 			if m.sessions != nil {
 				if info, err := m.sessions.GetSession(code); err == nil && info != nil {

--- a/internal/module/agent/handler_path_hint_test.go
+++ b/internal/module/agent/handler_path_hint_test.go
@@ -74,6 +74,66 @@ func TestHandleEvent_DoesNotEmitPathHintForBashTool(t *testing.T) {
 	}
 }
 
+// TestHandleEvent_PathHintUsesIDPathWhenPresent pins the round-3 finding-1
+// fix: the cc PreToolUse / PostToolUse path-hint emit branch must resolve
+// its session code via the same immutable-ID path as emitHookToSession.
+//
+// Setup: the fake session provider's name cache is deliberately seeded
+// with a "stale-code" entry for the tmux session "alpha" — simulating the
+// kill-then-recreate name-reuse window where the cache still points at the
+// previous incarnation's code. The hook payload carries the new tmux
+// session ID "$5". A regression that reverts to resolveSessionCode(name)
+// would broadcast the path hint to "stale-code" (wrong SPA session).
+// Asserting we receive it on the EncodeSessionID("$5") code proves the ID
+// path is wired into path-hint emission.
+func TestHandleEvent_PathHintUsesIDPathWhenPresent(t *testing.T) {
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "alpha")
+	m.tmux = fakeTmux
+	// Seed BOTH the cache-style lookup and ListSessions with stale data:
+	// any name-resolution path returns "stale-code". Only the ID path
+	// produces the expected EncodeSessionID("$5") result.
+	m.sessions = &fakeFastSessionProvider{
+		sessions: []session.SessionInfo{{Code: "stale-code", Name: "alpha"}},
+		lookup:   map[string]string{"alpha": "stale-code"},
+	}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive: func(event string, _ json.RawMessage) agentpkg.DeriveResult {
+			return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusRunning}
+		},
+	})
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	wantCode, err := session.EncodeSessionID("$5")
+	if err != nil {
+		t.Fatalf("EncodeSessionID: %v", err)
+	}
+	if wantCode == "stale-code" {
+		t.Fatalf("test setup: ID-derived code collided with stale-code; pick a different ID")
+	}
+
+	body := `{"tmux_session":"alpha","tmux_session_id":"$5","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","purdex_name":"PdxPreToolUse","raw_event":{"cwd":"/x","tool_name":"Read","tool_input":{"file_path":"/x/y/z.go"}},"agent_type":"cc"}`
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	// awaitPathHint will fail the test if it sees the path_hint on a
+	// different session code than wantCode. So a positive return here
+	// directly proves the ID-derived code (not the stale name-cache code)
+	// was used.
+	if !awaitPathHint(t, sub, wantCode, "/x/y", "/x", []string{"z.go", `"path":`, `"basename"`}) {
+		t.Fatal("expected agent.path_hint broadcast on ID-derived session code")
+	}
+}
+
 func TestHandleEvent_DoesNotEmitPathHintForOpenCode(t *testing.T) {
 	m := newTestModule(t)
 	fakeTmux := tmux.NewFakeExecutor()

--- a/internal/module/agent/hook_payload_test.go
+++ b/internal/module/agent/hook_payload_test.go
@@ -125,6 +125,54 @@ func TestResolveSessionCodeFromHook_FallsBackOnMalformedID(t *testing.T) {
 	}
 }
 
+// TestResolveSessionCodeFromHook_TrustsIDOverMismatchedName locks the current
+// trust contract: a valid tmux_session_id is trusted authoritatively. The daemon
+// does NOT cross-validate against tmux_session/tmux_pane_id. This means a
+// payload with mismatched fields (e.g. id=$5 + name=alpha where $5 belongs
+// to beta) produces split-state: broadcast and path hint emit to the
+// ID-derived code (beta-code), while internal projection/trace/events
+// keying still uses the name (alpha). User-visible emit is correct (reaches
+// the actual session via ID). Full system-wide ID-keying is tracked as a
+// follow-up; this test locks the current behavior so future refactors don't
+// silently change semantics.
+func TestResolveSessionCodeFromHook_TrustsIDOverMismatchedName(t *testing.T) {
+	m := &Module{}
+	fake := &fakeFastSessionProvider{
+		// Seed name→code so that if a regression caused the name path to
+		// run, we'd get "alpha-code" — distinct from the ID-derived code
+		// EncodeSessionID("$5") yields. This makes the assertion below
+		// catch any silent semantic flip.
+		sessions: []session.SessionInfo{{Name: "alpha", Code: "alpha-code"}},
+		lookup:   map[string]string{"alpha": "alpha-code"},
+	}
+	m.sessions = fake
+
+	// Mismatched payload: name claims "alpha" but ID is "$5". Per contract,
+	// pdx hook is the trusted producer; daemon must NOT reconcile.
+	req := EventRequest{TmuxSessionID: "$5", TmuxSession: "alpha"}
+	got, path := m.resolveSessionCodeFromHook(req)
+
+	want, err := session.EncodeSessionID("$5")
+	if err != nil {
+		t.Fatalf("EncodeSessionID: %v", err)
+	}
+	if got != want {
+		t.Errorf("resolveSessionCodeFromHook = %q, want %q (ID must win over mismatched name)", got, want)
+	}
+	if got == "alpha-code" {
+		t.Errorf("resolveSessionCodeFromHook returned name-derived code %q; ID path was bypassed", got)
+	}
+	if path != hookCodePathID {
+		t.Errorf("resolution path = %q, want %q (ID path label expected even with mismatched name)", path, hookCodePathID)
+	}
+	if fake.lookupCalls != 0 {
+		t.Errorf("LookupCodeByName calls = %d, want 0 (name path must not be consulted when ID is valid)", fake.lookupCalls)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListSessions calls = %d, want 0 (slow path must not be consulted when ID is valid)", fake.listCalls)
+	}
+}
+
 // TestEmitHookToSession_DirectUsesSessionIDPath is the focused unit-level
 // proof: emitHookToSession with an EventRequest carrying tmux_session_id
 // broadcasts to the ID-derived code WITHOUT touching the name cache. We

--- a/internal/module/agent/hook_payload_test.go
+++ b/internal/module/agent/hook_payload_test.go
@@ -49,7 +49,7 @@ func TestResolveSessionCodeFromHook_BypassesCacheWhenIDPresent(t *testing.T) {
 	m.sessions = fake
 
 	req := EventRequest{TmuxSessionID: "$5", TmuxSession: "alpha"}
-	got := m.resolveSessionCodeFromHook(req)
+	got, path := m.resolveSessionCodeFromHook(req)
 
 	want, err := session.EncodeSessionID("$5")
 	if err != nil {
@@ -57,6 +57,9 @@ func TestResolveSessionCodeFromHook_BypassesCacheWhenIDPresent(t *testing.T) {
 	}
 	if got != want {
 		t.Errorf("resolveSessionCodeFromHook = %q, want %q (pure ID path)", got, want)
+	}
+	if path != hookCodePathID {
+		t.Errorf("resolution path = %q, want %q", path, hookCodePathID)
 	}
 	if fake.lookupCalls != 0 {
 		t.Errorf("LookupCodeByName calls = %d, want 0 (ID path must skip cache)", fake.lookupCalls)
@@ -80,10 +83,13 @@ func TestResolveSessionCodeFromHook_FallsBackToNamePathOnEmptyID(t *testing.T) {
 	m.sessions = fake
 
 	req := EventRequest{TmuxSessionID: "", TmuxSession: "alpha"}
-	got := m.resolveSessionCodeFromHook(req)
+	got, path := m.resolveSessionCodeFromHook(req)
 
 	if got != "alpha-code" {
 		t.Errorf("resolveSessionCodeFromHook = %q, want alpha-code", got)
+	}
+	if path != hookCodePathIDEmpty {
+		t.Errorf("resolution path = %q, want %q", path, hookCodePathIDEmpty)
 	}
 	if fake.lookupCalls != 1 {
 		t.Errorf("LookupCodeByName calls = %d, want 1 (fallback engaged)", fake.lookupCalls)
@@ -106,10 +112,13 @@ func TestResolveSessionCodeFromHook_FallsBackOnMalformedID(t *testing.T) {
 	m.sessions = fake
 
 	req := EventRequest{TmuxSessionID: "not-a-tmux-id", TmuxSession: "beta"}
-	got := m.resolveSessionCodeFromHook(req)
+	got, path := m.resolveSessionCodeFromHook(req)
 
 	if got != "beta-code" {
 		t.Errorf("resolveSessionCodeFromHook = %q, want beta-code", got)
+	}
+	if path != hookCodePathMalformedID {
+		t.Errorf("resolution path = %q, want %q", path, hookCodePathMalformedID)
 	}
 	if fake.lookupCalls != 1 {
 		t.Errorf("LookupCodeByName calls = %d, want 1 (fallback after malformed ID)", fake.lookupCalls)
@@ -153,6 +162,9 @@ func TestEmitHookToSession_DirectUsesSessionIDPath(t *testing.T) {
 	decision, reason := m.emitHookToSession(req, normalized)
 	if decision != "broadcasted" {
 		t.Fatalf("decision = %q (reason=%q), want broadcasted", decision, reason)
+	}
+	if reason != string(hookCodePathID) {
+		t.Errorf("reason = %q, want %q (id_path label exposes fast-path activation)", reason, hookCodePathID)
 	}
 
 	select {
@@ -201,11 +213,42 @@ func TestEmitHookToSession_LegacyPayloadUsesNamePath(t *testing.T) {
 	req := EventRequest{TmuxSession: "work"} // legacy: no TmuxSessionID
 	normalized := agentpkg.NormalizedEvent{AgentType: "cc", RawEventName: "PdxStop"}
 
-	decision, _ := m.emitHookToSession(req, normalized)
+	decision, reason := m.emitHookToSession(req, normalized)
 	if decision != "broadcasted" {
 		t.Fatalf("decision = %q, want broadcasted (legacy fallback)", decision)
 	}
+	if reason != string(hookCodePathIDEmpty) {
+		t.Errorf("reason = %q, want %q (id_empty label flags un-migrated hook clients)", reason, hookCodePathIDEmpty)
+	}
 	if fake.lookupCalls != 1 {
 		t.Errorf("LookupCodeByName calls = %d, want 1 (name path engaged)", fake.lookupCalls)
+	}
+}
+
+// TestEmitHookToSession_MalformedIDReason pins the third path label: when a
+// hook payload reaches us with a corrupt TmuxSessionID, the reason carries
+// the malformed_id label so log greps can spot the pathological case
+// distinct from a benign legacy (id_empty) fallback.
+func TestEmitHookToSession_MalformedIDReason(t *testing.T) {
+	m := newTestModule(t)
+	fake := &fakeFastSessionProvider{
+		sessions: []session.SessionInfo{{Name: "work", Code: "code-work"}},
+		lookup:   map[string]string{"work": "code-work"},
+	}
+	m.sessions = fake
+	m.core = &core.Core{Events: core.NewEventsBroadcaster()}
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	req := EventRequest{TmuxSessionID: "not-a-tmux-id", TmuxSession: "work"}
+	normalized := agentpkg.NormalizedEvent{AgentType: "cc", RawEventName: "PdxStop"}
+
+	decision, reason := m.emitHookToSession(req, normalized)
+	if decision != "broadcasted" {
+		t.Fatalf("decision = %q, want broadcasted (fallback after malformed ID)", decision)
+	}
+	if reason != string(hookCodePathMalformedID) {
+		t.Errorf("reason = %q, want %q (malformed_id label distinguishes corruption from legacy)", reason, hookCodePathMalformedID)
 	}
 }

--- a/internal/module/agent/hook_payload_test.go
+++ b/internal/module/agent/hook_payload_test.go
@@ -1,0 +1,211 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	agentpkg "github.com/wake/purdex/internal/agent"
+	"github.com/wake/purdex/internal/core"
+	"github.com/wake/purdex/internal/module/session"
+)
+
+// TestEventRequest_UnmarshalsTmuxSessionID pins the wire-level contract: the
+// daemon must read `tmux_session_id` off the hook payload. Without this, the
+// fast path can't engage and every hook still racing through the name cache
+// is exposed to the kill-then-recreate name-reuse window.
+func TestEventRequest_UnmarshalsTmuxSessionID(t *testing.T) {
+	var req EventRequest
+	body := `{"tmux_session_id":"$7","tmux_session":"alpha"}`
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.TmuxSessionID != "$7" {
+		t.Errorf("TmuxSessionID = %q, want $7", req.TmuxSessionID)
+	}
+	if req.TmuxSession != "alpha" {
+		t.Errorf("TmuxSession = %q, want alpha", req.TmuxSession)
+	}
+}
+
+// TestResolveSessionCodeFromHook_BypassesCacheWhenIDPresent is the primary
+// acceptance test for option A: when the hook payload carries the immutable
+// tmux session ID, the daemon resolves the session code via a pure O(1)
+// EncodeSessionID call — neither LookupCodeByName nor ListSessions runs.
+//
+// This is the structural fix for the rename-race finding that all three
+// codex round-2 reviewers flagged: the name cache TTL window leaves room
+// for `kill-session foo && new-session -s foo` to alias the old code, and
+// only side-stepping the cache entirely closes that window.
+func TestResolveSessionCodeFromHook_BypassesCacheWhenIDPresent(t *testing.T) {
+	m := &Module{}
+	fake := &fakeFastSessionProvider{
+		// ListSessions/lookup deliberately seeded with NO entry for $5 so a
+		// regression that falls through to either path returns "" and the
+		// counter assertion below catches it.
+		sessions: []session.SessionInfo{{Name: "alpha", Code: "stale-code"}},
+		lookup:   map[string]string{"alpha": "stale-code"},
+	}
+	m.sessions = fake
+
+	req := EventRequest{TmuxSessionID: "$5", TmuxSession: "alpha"}
+	got := m.resolveSessionCodeFromHook(req)
+
+	want, err := session.EncodeSessionID("$5")
+	if err != nil {
+		t.Fatalf("EncodeSessionID: %v", err)
+	}
+	if got != want {
+		t.Errorf("resolveSessionCodeFromHook = %q, want %q (pure ID path)", got, want)
+	}
+	if fake.lookupCalls != 0 {
+		t.Errorf("LookupCodeByName calls = %d, want 0 (ID path must skip cache)", fake.lookupCalls)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListSessions calls = %d, want 0 (ID path must skip slow path)", fake.listCalls)
+	}
+}
+
+// TestResolveSessionCodeFromHook_FallsBackToNamePathOnEmptyID covers
+// backward compat: when the pdx hook binary is older than the daemon and
+// omits tmux_session_id, the daemon falls through to the existing
+// LookupCodeByName fast path. Required so a partial rollout (daemon
+// upgraded before hooks) doesn't break the hot path.
+func TestResolveSessionCodeFromHook_FallsBackToNamePathOnEmptyID(t *testing.T) {
+	m := &Module{}
+	fake := &fakeFastSessionProvider{
+		sessions: []session.SessionInfo{{Name: "alpha", Code: "alpha-code"}},
+		lookup:   map[string]string{"alpha": "alpha-code"},
+	}
+	m.sessions = fake
+
+	req := EventRequest{TmuxSessionID: "", TmuxSession: "alpha"}
+	got := m.resolveSessionCodeFromHook(req)
+
+	if got != "alpha-code" {
+		t.Errorf("resolveSessionCodeFromHook = %q, want alpha-code", got)
+	}
+	if fake.lookupCalls != 1 {
+		t.Errorf("LookupCodeByName calls = %d, want 1 (fallback engaged)", fake.lookupCalls)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListSessions calls = %d, want 0 (cache hit on fallback)", fake.listCalls)
+	}
+}
+
+// TestResolveSessionCodeFromHook_FallsBackOnMalformedID covers the corruption
+// path: a payload reaching us with TmuxSessionID="not-a-tmux-id" must not
+// silently drop. EncodeSessionID errors → we fall through to the name path
+// and the existing LookupCodeByName cache covers the resolution.
+func TestResolveSessionCodeFromHook_FallsBackOnMalformedID(t *testing.T) {
+	m := &Module{}
+	fake := &fakeFastSessionProvider{
+		sessions: []session.SessionInfo{{Name: "beta", Code: "beta-code"}},
+		lookup:   map[string]string{"beta": "beta-code"},
+	}
+	m.sessions = fake
+
+	req := EventRequest{TmuxSessionID: "not-a-tmux-id", TmuxSession: "beta"}
+	got := m.resolveSessionCodeFromHook(req)
+
+	if got != "beta-code" {
+		t.Errorf("resolveSessionCodeFromHook = %q, want beta-code", got)
+	}
+	if fake.lookupCalls != 1 {
+		t.Errorf("LookupCodeByName calls = %d, want 1 (fallback after malformed ID)", fake.lookupCalls)
+	}
+}
+
+// TestEmitHookToSession_DirectUsesSessionIDPath is the focused unit-level
+// proof: emitHookToSession with an EventRequest carrying tmux_session_id
+// broadcasts to the ID-derived code WITHOUT touching the name cache. We
+// drive the helper directly (skipping handleEvent's frame_ops/projection
+// machinery, which has its own name→code lookups for frame storage that
+// are explicitly out of scope per the SOT). This test pins the cache-bypass
+// behaviour where the fix lives.
+func TestEmitHookToSession_DirectUsesSessionIDPath(t *testing.T) {
+	m := newTestModule(t)
+	expectedCode, err := session.EncodeSessionID("$9")
+	if err != nil {
+		t.Fatalf("EncodeSessionID: %v", err)
+	}
+
+	fake := &fakeFastSessionProvider{
+		// Empty stores: any name-keyed call would return "" and skip the
+		// broadcast. Green broadcast → ID path fired. Counter == 0 → ID
+		// path is the ONLY route taken.
+		sessions: []session.SessionInfo{},
+		lookup:   map[string]string{},
+	}
+	m.sessions = fake
+	m.core = &core.Core{Events: core.NewEventsBroadcaster()}
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	req := EventRequest{TmuxSessionID: "$9", TmuxSession: "work"}
+	normalized := agentpkg.NormalizedEvent{
+		AgentType:    "cc",
+		RawEventName: "PdxStop",
+		BroadcastTs:  time.Now().UnixNano(),
+	}
+
+	decision, reason := m.emitHookToSession(req, normalized)
+	if decision != "broadcasted" {
+		t.Fatalf("decision = %q (reason=%q), want broadcasted", decision, reason)
+	}
+
+	select {
+	case msg := <-sub.SendCh():
+		var env struct {
+			Type    string `json:"type"`
+			Session string `json:"session"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if env.Type != "hook" {
+			t.Errorf("type = %q, want hook", env.Type)
+		}
+		if env.Session != expectedCode {
+			t.Errorf("session = %q, want %q (ID-derived code)", env.Session, expectedCode)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for broadcast — ID path likely not engaged")
+	}
+
+	if fake.lookupCalls != 0 {
+		t.Errorf("LookupCodeByName calls = %d, want 0 (ID path must skip name cache)", fake.lookupCalls)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListSessions calls = %d, want 0 (ID path must skip slow path)", fake.listCalls)
+	}
+}
+
+// TestEmitHookToSession_LegacyPayloadUsesNamePath covers the backward-compat
+// branch: when a pre-upgrade pdx hook binary sends a payload without
+// tmux_session_id, emitHookToSession must still resolve via the name cache.
+// Pins that the new ID branch hasn't broken the fallback path.
+func TestEmitHookToSession_LegacyPayloadUsesNamePath(t *testing.T) {
+	m := newTestModule(t)
+	fake := &fakeFastSessionProvider{
+		sessions: []session.SessionInfo{{Name: "work", Code: "code-work"}},
+		lookup:   map[string]string{"work": "code-work"},
+	}
+	m.sessions = fake
+	m.core = &core.Core{Events: core.NewEventsBroadcaster()}
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	req := EventRequest{TmuxSession: "work"} // legacy: no TmuxSessionID
+	normalized := agentpkg.NormalizedEvent{AgentType: "cc", RawEventName: "PdxStop"}
+
+	decision, _ := m.emitHookToSession(req, normalized)
+	if decision != "broadcasted" {
+		t.Fatalf("decision = %q, want broadcasted (legacy fallback)", decision)
+	}
+	if fake.lookupCalls != 1 {
+		t.Errorf("LookupCodeByName calls = %d, want 1 (name path engaged)", fake.lookupCalls)
+	}
+}

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -141,6 +141,16 @@ func (m *Module) Init(c *core.Core) error {
 	}
 	m.sessions = svc.(session.SessionProvider)
 
+	// Surface whether the hook hot path will use the LookupCodeByName fast
+	// path or fall back to the 1+7×S ListSessions fan-out. Anything that
+	// wraps SessionProvider with a decorator that drops LookupCodeByName
+	// will be visible at startup instead of as a silent latency regression.
+	if _, ok := m.sessions.(sessionCodeLookuper); ok {
+		log.Print("[agent] hook fast-path active (LookupCodeByName available)")
+	} else {
+		log.Print("[agent] hook fast-path NOT active — sessions does not implement LookupCodeByName")
+	}
+
 	// Expose event store and module so other modules (e.g. session rename) can update it.
 	c.Registry.Register("agent.events", m.events)
 	c.Registry.Register("agent.module", m)

--- a/internal/module/session/handler.go
+++ b/internal/module/session/handler.go
@@ -153,6 +153,8 @@ func (m *SessionModule) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	m.invalidateNameCache()
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(info)
@@ -197,6 +199,8 @@ func (m *SessionModule) handleRename(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	m.invalidateNameCache()
+
 	// Return updated info with new name
 	info.Name = req.Name
 	w.Header().Set("Content-Type", "application/json")
@@ -224,6 +228,8 @@ func (m *SessionModule) handleDelete(w http.ResponseWriter, r *http.Request) {
 
 	// Delete meta
 	_ = m.meta.DeleteMeta(info.TmuxID)
+
+	m.invalidateNameCache()
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/module/session/lookup.go
+++ b/internal/module/session/lookup.go
@@ -2,13 +2,20 @@ package session
 
 import "time"
 
-const nameCacheTTL = time.Second
+// nameCacheTTL bounds how long a stale name→code mapping can be observed
+// after an external mutation (tmux rename / kill / new outside the daemon's
+// HTTP handlers) before the next refresh. The watcher path invalidates
+// proactively via wait-for, but a hook arriving in the gap between the
+// mutation and the watcher catching up still relies on this TTL as the
+// upper bound. 250ms keeps user-perceived staleness invisible while leaving
+// the cache hot for the 1+7×S avoidance that motivated this fast path.
+const nameCacheTTL = 250 * time.Millisecond
 
 // LookupCodeByName returns the session code for a tmux session name using a
-// 1s TTL cache built from a single `tmux list-sessions` call. It deliberately
-// avoids the meta merge / pane metadata fan-out that ListSessions performs,
-// because the hook hot path only needs name→code resolution and was paying
-// 1+7×S tmux subprocesses per event.
+// short-TTL cache built from a single `tmux list-sessions` call. It
+// deliberately avoids the meta merge / pane metadata fan-out that
+// ListSessions performs, because the hook hot path only needs name→code
+// resolution and was paying 1+7×S tmux subprocesses per event.
 func (m *SessionModule) LookupCodeByName(name string) (string, bool) {
 	m.nameCacheMu.Lock()
 	defer m.nameCacheMu.Unlock()

--- a/internal/module/session/lookup.go
+++ b/internal/module/session/lookup.go
@@ -1,0 +1,48 @@
+package session
+
+import "time"
+
+const nameCacheTTL = time.Second
+
+// LookupCodeByName returns the session code for a tmux session name using a
+// 1s TTL cache built from a single `tmux list-sessions` call. It deliberately
+// avoids the meta merge / pane metadata fan-out that ListSessions performs,
+// because the hook hot path only needs name→code resolution and was paying
+// 1+7×S tmux subprocesses per event.
+func (m *SessionModule) LookupCodeByName(name string) (string, bool) {
+	m.nameCacheMu.Lock()
+	defer m.nameCacheMu.Unlock()
+
+	if time.Since(m.nameCacheAt) < nameCacheTTL && m.nameCacheData != nil {
+		code, ok := m.nameCacheData[name]
+		return code, ok
+	}
+
+	sessions, err := m.tmux.ListSessions()
+	if err != nil {
+		return "", false
+	}
+
+	next := make(map[string]string, len(sessions))
+	for _, s := range sessions {
+		code, err := EncodeSessionID(s.ID)
+		if err != nil {
+			continue
+		}
+		next[s.Name] = code
+	}
+	m.nameCacheData = next
+	m.nameCacheAt = time.Now()
+
+	code, ok := next[name]
+	return code, ok
+}
+
+// invalidateNameCache forces the next LookupCodeByName call to refresh from
+// tmux. Call sites: handleCreate / handleRename / handleDelete success
+// branches — the only mutation paths that change the name→code mapping.
+func (m *SessionModule) invalidateNameCache() {
+	m.nameCacheMu.Lock()
+	m.nameCacheAt = time.Time{}
+	m.nameCacheMu.Unlock()
+}

--- a/internal/module/session/lookup_test.go
+++ b/internal/module/session/lookup_test.go
@@ -75,6 +75,55 @@ func TestLookupCodeByName_RefreshAfterInvalidate(t *testing.T) {
 	assert.Equal(t, 2, fake.ListCallCount(), "invalidate must force the next lookup to refresh")
 }
 
+// TestLookupCodeByName_NameReuseAfterInvalidate documents the cache's
+// staleness contract under the name-reuse scenario: an external actor kills
+// session "alpha" ($1) and immediately recreates a new session also called
+// "alpha" but with a different tmux ID ($2). Until the watcher's wait-for
+// path reaches invalidateNameCache, a hook resolving "alpha" must observe
+// the stale code-of-$1; once invalidated, the next lookup converges on the
+// fresh code-of-$2. The 250ms TTL bounds how long the stale window can
+// last in the absence of explicit invalidation.
+func TestLookupCodeByName_NameReuseAfterInvalidate(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+	fake.AddSession("alpha", "/tmp")
+
+	staleCode, err := EncodeSessionID("$0")
+	require.NoError(t, err)
+
+	freshCode, err := EncodeSessionID("$1")
+	require.NoError(t, err)
+
+	got, ok := mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	require.Equal(t, staleCode, got)
+	require.Equal(t, 1, fake.ListCallCount())
+
+	// External mutation: kill "alpha" and immediately recreate it. The fake's
+	// auto-incrementing ID counter guarantees the recreated session takes a
+	// different tmux ID, mirroring real tmux behavior.
+	require.NoError(t, fake.KillSession("alpha"))
+	fake.AddSession("alpha", "/tmp")
+
+	// Cache is still warm — the lookup observes the stale mapping. This is
+	// the documented race window.
+	stillStale, ok := mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	assert.Equal(t, staleCode, stillStale,
+		"without invalidation, fresh-cache lookup must return the stale code (race window observable)")
+	assert.Equal(t, 1, fake.ListCallCount(),
+		"fresh cache must not re-query tmux even when underlying state diverged")
+
+	// Watcher catches up via wait-for and signals invalidation.
+	mod.invalidateNameCache()
+
+	healed, ok := mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	assert.Equal(t, freshCode, healed,
+		"after invalidate, the next lookup must return the fresh code (self-healing)")
+	assert.NotEqual(t, staleCode, healed)
+	assert.Equal(t, 2, fake.ListCallCount(), "invalidate forces a refresh on the next lookup")
+}
+
 func TestLookupCodeByName_RenameInvalidatesCache(t *testing.T) {
 	mod, _, fake := newTestModule(t)
 	fake.AddSession("oldname", "/tmp")

--- a/internal/module/session/lookup_test.go
+++ b/internal/module/session/lookup_test.go
@@ -1,0 +1,101 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupCodeByName_HitOnFreshCache(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+	fake.AddSession("alpha", "/tmp")
+
+	wantCode, err := EncodeSessionID("$0")
+	require.NoError(t, err)
+
+	code, ok := mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	assert.Equal(t, wantCode, code)
+	assert.Equal(t, 1, fake.ListCallCount())
+
+	code, ok = mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	assert.Equal(t, wantCode, code)
+	assert.Equal(t, 1, fake.ListCallCount(), "second lookup within TTL must not re-query tmux")
+}
+
+func TestLookupCodeByName_RefreshOnStale(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+	fake.AddSession("alpha", "/tmp")
+
+	_, ok := mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	assert.Equal(t, 1, fake.ListCallCount())
+
+	// Force the cache stamp into the past so the next call sees a stale cache.
+	mod.nameCacheMu.Lock()
+	mod.nameCacheAt = time.Now().Add(-2 * nameCacheTTL)
+	mod.nameCacheMu.Unlock()
+
+	_, ok = mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	assert.Equal(t, 2, fake.ListCallCount(), "stale cache must trigger a refresh")
+}
+
+func TestLookupCodeByName_MissReturnsFalse(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+	fake.AddSession("foo", "/tmp")
+
+	code, ok := mod.LookupCodeByName("bar")
+	assert.False(t, ok)
+	assert.Equal(t, "", code)
+	assert.Equal(t, 1, fake.ListCallCount(), "miss must refresh once, not retry")
+
+	// A repeated miss while cache is fresh must not re-query tmux either.
+	code, ok = mod.LookupCodeByName("bar")
+	assert.False(t, ok)
+	assert.Equal(t, "", code)
+	assert.Equal(t, 1, fake.ListCallCount())
+}
+
+func TestLookupCodeByName_RefreshAfterInvalidate(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+	fake.AddSession("alpha", "/tmp")
+
+	_, ok := mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	assert.Equal(t, 1, fake.ListCallCount())
+
+	mod.invalidateNameCache()
+
+	_, ok = mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	assert.Equal(t, 2, fake.ListCallCount(), "invalidate must force the next lookup to refresh")
+}
+
+func TestLookupCodeByName_RenameInvalidatesCache(t *testing.T) {
+	mod, _, fake := newTestModule(t)
+	fake.AddSession("oldname", "/tmp")
+
+	oldCode, ok := mod.LookupCodeByName("oldname")
+	require.True(t, ok)
+	require.NotEmpty(t, oldCode)
+	assert.Equal(t, 1, fake.ListCallCount())
+
+	// Simulate the side effect of a successful rename: the underlying tmux
+	// state changed, and the handler signals invalidation so the next lookup
+	// refreshes against the new ground truth.
+	require.NoError(t, fake.RenameSession("oldname", "newname"))
+	mod.invalidateNameCache()
+
+	newCode, ok := mod.LookupCodeByName("newname")
+	require.True(t, ok)
+	assert.Equal(t, oldCode, newCode, "tmux session ID survives rename, so code is unchanged")
+	assert.Equal(t, 2, fake.ListCallCount(), "lookup after invalidate must re-query tmux")
+
+	missCode, ok := mod.LookupCodeByName("oldname")
+	assert.False(t, ok)
+	assert.Equal(t, "", missCode, "old name must no longer resolve after rename + invalidate")
+}

--- a/internal/module/session/module.go
+++ b/internal/module/session/module.go
@@ -33,6 +33,14 @@ type SessionModule struct {
 	listCacheMu   sync.Mutex
 	listCacheData []SessionInfo
 	listCacheAt   time.Time
+
+	// nameCache backs LookupCodeByName: a name→code map plus a TTL stamp.
+	// Separate from listCache because the lookup fast path runs only one
+	// tmux subprocess (list-sessions) — no meta merge, no per-session
+	// metadata fan-out — and is hit on the hook hot path (#?).
+	nameCacheMu   sync.Mutex
+	nameCacheData map[string]string
+	nameCacheAt   time.Time
 }
 
 // NewSessionModule creates a SessionModule with the given MetaStore.

--- a/internal/module/session/watcher.go
+++ b/internal/module/session/watcher.go
@@ -76,9 +76,16 @@ func (m *SessionModule) tickNormal() {
 	}
 
 	hash := hashSessions(sessions)
-	if m.wstate.updateHash(hash) && m.core.Events.HasSubscribers() {
-		data := mustMarshal(sessions)
-		m.core.Events.Broadcast("", "sessions", data)
+	if m.wstate.updateHash(hash) {
+		// Hash changed = session list mutated (possibly by external tmux
+		// commands that bypass the HTTP handlers' invalidation). Bust the
+		// name cache before broadcasting so the next LookupCodeByName
+		// refreshes from tmux.
+		m.invalidateNameCache()
+		if m.core.Events.HasSubscribers() {
+			data := mustMarshal(sessions)
+			m.core.Events.Broadcast("", "sessions", data)
+		}
 	}
 }
 
@@ -98,6 +105,12 @@ func (m *SessionModule) broadcastTmuxStatus(value string) {
 }
 
 func (m *SessionModule) broadcastSessions() {
+	// Goroutine A's wait-for unblocks here whenever tmux signals a
+	// session/window/pane change — including external `tmux rename-session`
+	// that bypasses the HTTP handlers' explicit invalidation. Bust the name
+	// cache up front so stale name→code mappings can't survive the 1s TTL.
+	m.invalidateNameCache()
+
 	if !m.core.Events.HasSubscribers() {
 		return
 	}

--- a/internal/module/session/watcher_test.go
+++ b/internal/module/session/watcher_test.go
@@ -196,6 +196,87 @@ func TestWatcherNoRepeatBroadcastInTmuxDown(t *testing.T) {
 	}
 }
 
+// TestTickNormal_InvalidatesNameCacheOnHashChange verifies that when the
+// watcher's polling loop detects a session-list change (hash diff), it
+// invalidates the LookupCodeByName cache. This is the safety net for the
+// case where an external `tmux rename-session` mutates state without going
+// through the daemon's HTTP handlers.
+func TestTickNormal_InvalidatesNameCacheOnHashChange(t *testing.T) {
+	mod, fake, _ := newWatcherTestModule(t)
+
+	fake.AddSession("alpha", "/tmp")
+
+	// Prime tickNormal so its lastHash matches the current session list,
+	// otherwise the very first tick we run below would already see a hash
+	// change from "" → some-hash and invalidate, masking the real assertion.
+	mod.tickNormal()
+
+	// Pre-populate the name cache.
+	_, ok := mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	mod.nameCacheMu.Lock()
+	require.False(t, mod.nameCacheAt.IsZero(), "cache must be populated before the test")
+	mod.nameCacheMu.Unlock()
+
+	// Mutate session list externally so the next tickNormal sees a new hash.
+	fake.AddSession("beta", "/tmp")
+
+	mod.tickNormal()
+
+	mod.nameCacheMu.Lock()
+	defer mod.nameCacheMu.Unlock()
+	assert.True(t, mod.nameCacheAt.IsZero(), "tickNormal must invalidate name cache when hash changes")
+}
+
+// TestTickNormal_DoesNotInvalidateOnUnchangedHash verifies that the steady
+// state (no session changes) does not pointlessly bust the cache.
+func TestTickNormal_DoesNotInvalidateOnUnchangedHash(t *testing.T) {
+	mod, fake, _ := newWatcherTestModule(t)
+
+	fake.AddSession("alpha", "/tmp")
+
+	// First tick to register the current hash.
+	mod.tickNormal()
+
+	// Pre-populate the name cache.
+	_, ok := mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	mod.nameCacheMu.Lock()
+	require.False(t, mod.nameCacheAt.IsZero(), "cache must be populated before the test")
+	mod.nameCacheMu.Unlock()
+
+	// No mutation: the next tick must see an identical hash and not invalidate.
+	mod.tickNormal()
+
+	mod.nameCacheMu.Lock()
+	defer mod.nameCacheMu.Unlock()
+	assert.False(t, mod.nameCacheAt.IsZero(), "tickNormal must not invalidate name cache when hash is unchanged")
+}
+
+// TestBroadcastSessions_InvalidatesNameCache verifies that the wait-for path
+// (which lands in broadcastSessions) invalidates the name cache. This is the
+// authoritative signal — tmux just told us "something changed".
+func TestBroadcastSessions_InvalidatesNameCache(t *testing.T) {
+	mod, fake, events := newWatcherTestModule(t)
+	sub := events.AddTestSubscriber()
+	defer events.RemoveTestSubscriber(sub)
+
+	fake.AddSession("alpha", "/tmp")
+
+	// Pre-populate the name cache.
+	_, ok := mod.LookupCodeByName("alpha")
+	require.True(t, ok)
+	mod.nameCacheMu.Lock()
+	require.False(t, mod.nameCacheAt.IsZero(), "cache must be populated before the test")
+	mod.nameCacheMu.Unlock()
+
+	mod.broadcastSessions()
+
+	mod.nameCacheMu.Lock()
+	defer mod.nameCacheMu.Unlock()
+	assert.True(t, mod.nameCacheAt.IsZero(), "broadcastSessions must invalidate name cache")
+}
+
 func TestHashSessionsChangesWhenPaneTitleChanges(t *testing.T) {
 	base := []SessionInfo{{
 		Code:      "aa",

--- a/internal/store/agent_event.go
+++ b/internal/store/agent_event.go
@@ -26,10 +26,12 @@ type AgentEventStore struct{ db *sql.DB }
 func OpenAgentEvent(path string) (*AgentEventStore, error) {
 	dsn := path
 	if path != ":memory:" {
-		// busy_timeout(5000): make transient write contention WAIT instead of
+		// busy_timeout(500): make transient write contention WAIT instead of
 		// returning SQLITE_BUSY immediately — protects tail latency under
 		// concurrent hooks/sweep/checkpoint without changing durability.
-		dsn = path + "?_pragma=journal_mode(wal)&_pragma=busy_timeout(5000)"
+		// 500ms catches typical SSD checkpoint contention (<300ms observed)
+		// without blocking the hot path past user-perceived UI latency.
+		dsn = path + "?_pragma=journal_mode(wal)&_pragma=busy_timeout(500)"
 	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {

--- a/internal/store/agent_event.go
+++ b/internal/store/agent_event.go
@@ -26,7 +26,10 @@ type AgentEventStore struct{ db *sql.DB }
 func OpenAgentEvent(path string) (*AgentEventStore, error) {
 	dsn := path
 	if path != ":memory:" {
-		dsn = path + "?_pragma=journal_mode(wal)"
+		// busy_timeout(5000): make transient write contention WAIT instead of
+		// returning SQLITE_BUSY immediately — protects tail latency under
+		// concurrent hooks/sweep/checkpoint without changing durability.
+		dsn = path + "?_pragma=journal_mode(wal)&_pragma=busy_timeout(5000)"
 	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
@@ -36,6 +39,12 @@ func OpenAgentEvent(path string) (*AgentEventStore, error) {
 		// Keep a single connection so the in-memory schema is shared across
 		// all queries and transactions in tests.
 		db.SetMaxOpenConns(1)
+	} else {
+		// File-backed: bound the pool so concurrent goroutines can't fan out
+		// fds. agent_event DB is shared with FramesStore + TraceStore via
+		// .Frames() / .Traces(), so cap=4 governs all three together.
+		db.SetMaxOpenConns(4)
+		db.SetMaxIdleConns(4)
 	}
 	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
 		db.Close()

--- a/internal/store/agent_event_test.go
+++ b/internal/store/agent_event_test.go
@@ -138,7 +138,7 @@ func TestAgentEventStore_Delete(t *testing.T) {
 }
 
 // TestOpenAgentEvent_BusyTimeoutApplied verifies that a file-backed
-// AgentEventStore opens with PRAGMA busy_timeout=5000 — making transient
+// AgentEventStore opens with PRAGMA busy_timeout=500 — making transient
 // write contention WAIT instead of return SQLITE_BUSY immediately.
 func TestOpenAgentEvent_BusyTimeoutApplied(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "agent.db")
@@ -152,8 +152,8 @@ func TestOpenAgentEvent_BusyTimeoutApplied(t *testing.T) {
 	if err := s.db.QueryRow("PRAGMA busy_timeout").Scan(&ms); err != nil {
 		t.Fatalf("query busy_timeout: %v", err)
 	}
-	if ms != 5000 {
-		t.Errorf("busy_timeout: want 5000, got %d", ms)
+	if ms != 500 {
+		t.Errorf("busy_timeout: want 500, got %d", ms)
 	}
 }
 

--- a/internal/store/agent_event_test.go
+++ b/internal/store/agent_event_test.go
@@ -2,8 +2,13 @@
 package store
 
 import (
+	"context"
 	"encoding/json"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func openTestAgentEventStore(t *testing.T) *AgentEventStore {
@@ -129,6 +134,115 @@ func TestAgentEventStore_Delete(t *testing.T) {
 	ev, _ := s.Get("proj")
 	if ev != nil {
 		t.Error("expected nil after delete")
+	}
+}
+
+// TestOpenAgentEvent_BusyTimeoutApplied verifies that a file-backed
+// AgentEventStore opens with PRAGMA busy_timeout=5000 — making transient
+// write contention WAIT instead of return SQLITE_BUSY immediately.
+func TestOpenAgentEvent_BusyTimeoutApplied(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "agent.db")
+	s, err := OpenAgentEvent(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	var ms int
+	if err := s.db.QueryRow("PRAGMA busy_timeout").Scan(&ms); err != nil {
+		t.Fatalf("query busy_timeout: %v", err)
+	}
+	if ms != 5000 {
+		t.Errorf("busy_timeout: want 5000, got %d", ms)
+	}
+}
+
+// TestOpenAgentEvent_PoolCapApplied verifies the file-backed agent DB pool
+// cap is set to 4. The agent_event DB is shared across FramesStore and
+// TraceStore via OpenAgentEvent's *sql.DB, so cap=4 governs all three.
+func TestOpenAgentEvent_PoolCapApplied(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "agent.db")
+	s, err := OpenAgentEvent(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	got := s.db.Stats().MaxOpenConnections
+	if got != 4 {
+		t.Errorf("MaxOpenConnections: want 4, got %d", got)
+	}
+}
+
+// TestOpenAgentEvent_BusyTimeoutWaitsNotAborts proves that competing writers
+// on a file-backed DB block-wait via busy_timeout instead of returning
+// SQLITE_BUSY. Goroutine A holds a write tx for ~200ms; goroutine B
+// concurrently issues a write that would otherwise abort. Without
+// busy_timeout, B fails fast with SQLITE_BUSY; with it, B waits and succeeds.
+func TestOpenAgentEvent_BusyTimeoutWaitsNotAborts(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "agent.db")
+	s, err := OpenAgentEvent(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	// Seed a row so goroutine A's UPDATE has something to lock.
+	if err := s.Set("locked-key", "Stop", json.RawMessage(`{}`), "cc", 1); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	holdStarted := make(chan struct{})
+
+	// Goroutine A — hold a write tx for 200ms.
+	go func() {
+		defer wg.Done()
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Errorf("A: begin: %v", err)
+			return
+		}
+		// BEGIN IMMEDIATE-equivalent: do an UPDATE to acquire RESERVED lock.
+		if _, err := tx.Exec("UPDATE agent_events SET event_name = ? WHERE tmux_session = ?", "A-write", "locked-key"); err != nil {
+			_ = tx.Rollback()
+			t.Errorf("A: update: %v", err)
+			return
+		}
+		close(holdStarted)
+		time.Sleep(200 * time.Millisecond)
+		if err := tx.Commit(); err != nil {
+			t.Errorf("A: commit: %v", err)
+		}
+	}()
+
+	// Goroutine B — race a competing write while A holds the lock.
+	go func() {
+		defer wg.Done()
+		<-holdStarted
+		// Tiny extra sleep so A is definitely mid-tx.
+		time.Sleep(20 * time.Millisecond)
+		if err := s.Set("locked-key", "B-write", json.RawMessage(`{}`), "cc", 2); err != nil {
+			if strings.Contains(err.Error(), "SQLITE_BUSY") {
+				t.Errorf("B: aborted with SQLITE_BUSY — busy_timeout not effective: %v", err)
+			} else {
+				t.Errorf("B: unexpected error: %v", err)
+			}
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("test timed out waiting for goroutines: %v", ctx.Err())
 	}
 }
 

--- a/internal/store/meta.go
+++ b/internal/store/meta.go
@@ -35,10 +35,12 @@ type MetaStore struct{ db *sql.DB }
 func OpenMeta(path string) (*MetaStore, error) {
 	dsn := path
 	if path != ":memory:" {
-		// busy_timeout(5000): make transient write contention WAIT instead of
+		// busy_timeout(500): make transient write contention WAIT instead of
 		// returning SQLITE_BUSY immediately — protects tail latency under
 		// concurrent hooks/sweep/checkpoint without changing durability.
-		dsn = path + "?_pragma=journal_mode(wal)&_pragma=busy_timeout(5000)"
+		// 500ms catches typical SSD checkpoint contention (<300ms observed)
+		// without blocking the hot path past user-perceived UI latency.
+		dsn = path + "?_pragma=journal_mode(wal)&_pragma=busy_timeout(500)"
 	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {

--- a/internal/store/meta.go
+++ b/internal/store/meta.go
@@ -35,7 +35,10 @@ type MetaStore struct{ db *sql.DB }
 func OpenMeta(path string) (*MetaStore, error) {
 	dsn := path
 	if path != ":memory:" {
-		dsn = path + "?_pragma=journal_mode(wal)"
+		// busy_timeout(5000): make transient write contention WAIT instead of
+		// returning SQLITE_BUSY immediately — protects tail latency under
+		// concurrent hooks/sweep/checkpoint without changing durability.
+		dsn = path + "?_pragma=journal_mode(wal)&_pragma=busy_timeout(5000)"
 	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
@@ -46,9 +49,13 @@ func OpenMeta(path string) (*MetaStore, error) {
 	// the same DSN, and each :memory: connection is an independent database
 	// — so a second pool connection would see an empty schema. Pin the pool
 	// to a single connection so all goroutines share the same in-memory DB.
-	// File-backed DBs are unaffected (WAL mode handles concurrency natively).
+	// File-backed DBs use a small cap to bound fd usage; meta has lower
+	// write volume than agent_event so 2/2 is plenty.
 	if path == ":memory:" {
 		db.SetMaxOpenConns(1)
+	} else {
+		db.SetMaxOpenConns(2)
+		db.SetMaxIdleConns(2)
 	}
 	if err := migrateMetaDB(db); err != nil {
 		db.Close()

--- a/internal/store/pragma_test.go
+++ b/internal/store/pragma_test.go
@@ -1,0 +1,114 @@
+// internal/store/pragma_test.go
+// Internal-package tests covering sqlite tuning pragmas (busy_timeout) and
+// connection pool caps for the meta DB. The agent_event DB has equivalent
+// coverage in agent_event_test.go.
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestOpenMeta_BusyTimeoutApplied verifies that a file-backed MetaStore
+// opens with PRAGMA busy_timeout=5000 — making transient write contention
+// WAIT instead of return SQLITE_BUSY immediately.
+func TestOpenMeta_BusyTimeoutApplied(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "meta.db")
+	m, err := OpenMeta(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { m.Close() })
+
+	var ms int
+	if err := m.db.QueryRow("PRAGMA busy_timeout").Scan(&ms); err != nil {
+		t.Fatalf("query busy_timeout: %v", err)
+	}
+	if ms != 5000 {
+		t.Errorf("busy_timeout: want 5000, got %d", ms)
+	}
+}
+
+// TestOpenMeta_PoolCapApplied verifies the file-backed meta DB pool cap is 2.
+// Meta DB has lower write volume than agent_event so a smaller cap is fine.
+func TestOpenMeta_PoolCapApplied(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "meta.db")
+	m, err := OpenMeta(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { m.Close() })
+
+	got := m.db.Stats().MaxOpenConnections
+	if got != 2 {
+		t.Errorf("MaxOpenConnections: want 2, got %d", got)
+	}
+}
+
+// TestOpenMeta_BusyTimeoutWaitsNotAborts proves competing writers block-wait
+// instead of returning SQLITE_BUSY on the meta DB.
+func TestOpenMeta_BusyTimeoutWaitsNotAborts(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "meta.db")
+	m, err := OpenMeta(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { m.Close() })
+
+	if err := m.SetMeta("$0", SessionMeta{Mode: "terminal"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	holdStarted := make(chan struct{})
+
+	go func() {
+		defer wg.Done()
+		tx, err := m.db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Errorf("A: begin: %v", err)
+			return
+		}
+		if _, err := tx.Exec("UPDATE session_meta SET mode = ? WHERE tmux_id = ?", "stream", "$0"); err != nil {
+			_ = tx.Rollback()
+			t.Errorf("A: update: %v", err)
+			return
+		}
+		close(holdStarted)
+		time.Sleep(200 * time.Millisecond)
+		if err := tx.Commit(); err != nil {
+			t.Errorf("A: commit: %v", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-holdStarted
+		time.Sleep(20 * time.Millisecond)
+		if err := m.SetMeta("$0", SessionMeta{Mode: "jsonl"}); err != nil {
+			if strings.Contains(err.Error(), "SQLITE_BUSY") {
+				t.Errorf("B: aborted with SQLITE_BUSY — busy_timeout not effective: %v", err)
+			} else {
+				t.Errorf("B: unexpected error: %v", err)
+			}
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("test timed out waiting for goroutines: %v", ctx.Err())
+	}
+}

--- a/internal/store/pragma_test.go
+++ b/internal/store/pragma_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // TestOpenMeta_BusyTimeoutApplied verifies that a file-backed MetaStore
-// opens with PRAGMA busy_timeout=5000 — making transient write contention
+// opens with PRAGMA busy_timeout=500 — making transient write contention
 // WAIT instead of return SQLITE_BUSY immediately.
 func TestOpenMeta_BusyTimeoutApplied(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "meta.db")
@@ -28,8 +28,8 @@ func TestOpenMeta_BusyTimeoutApplied(t *testing.T) {
 	if err := m.db.QueryRow("PRAGMA busy_timeout").Scan(&ms); err != nil {
 		t.Fatalf("query busy_timeout: %v", err)
 	}
-	if ms != 5000 {
-		t.Errorf("busy_timeout: want 5000, got %d", ms)
+	if ms != 500 {
+		t.Errorf("busy_timeout: want 500, got %d", ms)
 	}
 }
 


### PR DESCRIPTION
## Summary

修 daemon hook hot path 兩個 production-grade lag 源 + 完整消除 round-2 抓到的 stale name reuse race 根因。

- **#1 `resolveSessionCode` fast path**（主修，預期 1.0-2.5s）— hook 路徑不再跑 `1 + 7×S` tmux subprocess
- **#4 sqlite `busy_timeout` + pool cap**（次修，tail 治理 20-150ms）
- **Option A — hook payload 帶 tmux_session_id**（race 根本修法）— hook broadcast + path hint 走 `EncodeSessionID(req.TmuxSessionID)` 純函式 O(1)，bypass cache

不在這 PR 的：#2 `tmux_session` persist（schema migration）、#3 dispatcher target injection（bundle 進 W6-3）、#5 `synchronous=NORMAL`（durability tradeoff）。

完整 root cause + production-safety 論證：`docs/specs/2026-04-30-daemon-hook-pipeline-lag-analysis.md`

## Live verify (mlab)

W6-3 binary baseline（SOT §1，單一 chain）：`[hook] trigger → [broadcast]` = **5 秒**

Perf binary 6 chains（daemon log 秒精度）：

| Chain | Hook → Broadcast | Δ |
|---|---|---|
| 6fbb219d (PdxStop) | 10:12:11 → 10:12:11 | <1s |
| 8a1834cc (PdxSessionStart) | 10:12:27 → 10:12:27 | <1s |
| a6880889 (PdxUserPromptSubmit) | 10:12:27 → 10:12:27 | <1s |
| c6911bb0 (PdxSessionStart) | 10:12:38 → 10:12:39 | ≤2s (boundary) |
| c639037c (PdxUserPromptSubmit) | 10:12:39 → 10:12:39 | <1s |
| 4d3a0a96 (PdxUserPromptSubmit) | 10:12:53 → 10:12:53 | <1s |

5/6 chains ≤1s window，1/6 跨 1s 邊界。User 體感確認「至少 hook 觸發夠快」。
量測精度限制 → follow-up issue #782（加 `log.Lmicroseconds`）。

## Changes (14 commits)

| Commit | 內容 |
|---|---|
| `7b513146` | docs: 240 行 root cause 分析（codex job `task-mokpcqt9-f3tolm`，effort=high） |
| `73de4606` | feat(session): `LookupCodeByName(name) (code, ok)` + TTL `nameCache` |
| `1d93fa8c` | feat(session): create/rename/delete success path 同步 `invalidateNameCache()` |
| `4b900da9` | chore(store): agent + meta DSN 加 `busy_timeout` + pool cap (4/4 + 2/2) |
| `bde22105` | feat(agent): `resolveSessionCode` type-assert `sessionCodeLookuper`，hit fast path / miss fallback `ListSessions()` 安全網 |
| `8f8f0887` | fix(session): watcher tickNormal hash-change + broadcastSessions 同步 invalidate |
| `6c6cf8ed` | fix(session): tighten name cache TTL 1s → 250ms |
| `487634c1` | fix(store): lower sqlite busy_timeout 5000ms → 500ms |
| `9969703d` | feat(agent): startup log fast-path activation status |
| `08861424` | feat(hook): include tmux session ID in hook payload（option A） |
| `7acc6b3e` | feat(agent): resolve hook session code by tmux ID, bypass name cache |
| `747c2e01` | feat(agent): label hook session code resolution path（id_path / id_empty / malformed_id） |
| `568b985b` | fix(agent): path hint emit uses tmux session ID resolution |
| `1e459d56` | test(agent): lock mismatched-ID-payload contract |

### Hook payload tmux_session_id（option A — race 根因消除）

新增：
- `cmd/pdx/hook.go`: `queryTmuxSessionInfo()` 一次 `tmux display-message -p '#{session_id}|#{session_name}'`（少 1 subprocess）
- `internal/module/agent/handler.go`: `EventRequest.TmuxSessionID` + `resolveSessionCodeFromHook(req) (code, path)` helper

行為：
- ID present + valid → `EncodeSessionID(req.TmuxSessionID)` O(1)，**不碰 cache、不碰 ListSessions**
- ID empty (legacy binary) → fallback `resolveSessionCode(name)`，path label `id_empty`
- ID malformed → fallback + log，path label `malformed_id`
- Path label 寫進 broadcast log reason，operator grep 可看 hook clients 是否已 migrate

Race 根因消除原理：`tmux session_id` (`$N`) 跨 rename immutable；kill+recreate 同名會給新 ID。即使外部 `tmux kill-session foo && tmux new-session -s foo`，新 hook 帶新 ID，daemon 直接出新 code，無 race。

### Cache invalidation 三層（fallback path 仍受保護）

1. HTTP handlers (handleCreate/Rename/Delete) — daemon-internal mutation
2. Watcher tickNormal hash-change — 5s polling reconcile
3. Watcher broadcastSessions 開頭 — wait-for 喚醒（涵蓋外部 tmux 變更 via builtin tmux hooks signal `purdex_sess_evt`）

### sqlite tuning

- `agent_event.go`: `_pragma=journal_mode(wal)&_pragma=busy_timeout(500)` + `SetMaxOpenConns(4) + SetMaxIdleConns(4)`
- `meta.go`: 同 pragma + pool `2/2`
- **不動 `synchronous`**（保 FULL，不引入 durability tradeoff）

## Codex review 四輪

| Round | Verdict | Findings | 處理 |
|---|---|---|---|
| 1 標準 | needs-attention | 1 P2: 外部 tmux 變更繞過 invalidation | `8f8f0887` watcher invalidate |
| 2 三平行 (attack/defense/health) | needs-attention | 3 high (同 finding: name reuse race) + 2 medium | `6c6cf8ed` TTL 1s→250ms / `487634c1` busy_timeout 5000→500 / `9969703d` startup log |
| 3 確認 round-2 | fix-and-ship | 2 medium: PathHint 仍走 name + reason 無分流 | `747c2e01` path label / `568b985b` path hint 走 ID |
| 4 終驗 | fix-and-ship | 1 medium: mismatched ID/name split-state | `1e459d56` lock contract test + follow-up issue |

| 嚴重性信心 | 關聯 | 複雜 | Finding | 動作 |
|---|---|---|---|---|
| 高 | 高 | 中 | Stale name reuse race（round-2） | 完全消除：option A `tmux_session_id` immutable identity |
| 高 | 高 | 低 | 5s busy_timeout 把 contention lag 放大 | `487634c1` 降到 500ms |
| 中 | 高 | 低 | Decorator wrapping 隱藏 fast-path 失效 | `9969703d` startup log |
| 中 | 高 | 低 | PathHint 仍走 name path（round-3） | `568b985b` 改用 `resolveSessionCodeFromHook` |
| 中 | 中 | 低 | Reason log 無分流（round-3） | `747c2e01` `id_path` / `id_empty` / `malformed_id` label |
| 中 | 高 | 低 | Mismatched ID/name split-state（round-4） | `1e459d56` lock contract + follow-up #781 |

## Test plan

- [x] TDD: Tasks A 5 + B 3 + C 6 + round-1 fix 3 + round-2 fix 4 + option A 8 + round-3 fix 6 + round-4 fix 1 = **36 new tests**（all RED→GREEN）
- [x] `go test ./...` 全綠（24 packages）
- [x] `go test -race ./internal/module/agent/... ./internal/module/session/... ./internal/store/... ./cmd/pdx/...` race-clean
- [x] `go build ./...` clean
- [x] compile-time guard 確認 `*session.SessionModule` 滿足 `sessionCodeLookuper`
- [x] mlab live verify：5/6 chains ≤1s（baseline 5s）+ user 體感確認

## Production safety

- 純讀路徑，code 仍由 tmux session ID 決定（authoritative source 不變）
- ID-derived code (`EncodeSessionID`) 是純確定性函式，無外部依賴
- macOS / Linux 都只依賴 tmux 基本命令
- 三層 invalidate（HTTP handler + watcher hash + watcher wait-for）涵蓋 fallback path 的 race
- 250ms TTL：watcher 反應 typically <50ms via wait-for，250ms 留足安全邊際
- name-reuse race self-healing 由 regression test 證明
- `busy_timeout=500` 不改 durability，500ms 對 SSD checkpoint typical latency (<300ms) 留足
- pool cap 對 WAL 多 reader 並發友善
- fallback 路徑保留 + path label 可觀測，hot-path 修改不會 silently 漏 broadcast
- mismatched payload 語義由 `TestResolveSessionCodeFromHook_TrustsIDOverMismatchedName` 鎖定，未來重構不會 silently 改變

## Follow-up issues

- **#781**: 全系統 session_id-keyed identity 改造（消除 internal state 殘留 split-state，需 schema migration）
- **#782**: daemon log 加 `log.Lmicroseconds` 提升 timing 量測精度

## Parallel work note

`worktree-lights-w6-3-codex-error` 同時改 `internal/module/agent/handler.go` 但不同函式（`manageActivityWatch` ~line 413 vs 本 PR 的 `resolveSessionCode` / `emitHookToSession` ~line 480-510），相距 70+ lines，git auto-merge 應 OK；後 merge 者 rebase 一次。