### PR TITLE
feat(spa): add performance monitor settings page

### DIFF
--- a/spa/src/components/NewPanePage.test.tsx
+++ b/spa/src/components/NewPanePage.test.tsx
@@ -45,4 +45,12 @@ describe('NewPanePage', () => {
     expect(screen.queryByText('Browser')).toBeNull()
     expect(screen.getByText('Dashboard')).toBeTruthy()
   })
+
+  it('does not expose Performance Monitor as pane replacement content', () => {
+    registerModule({ id: 'memory-monitor', name: 'Performance Monitor', panes: [{ kind: 'memory-monitor', component: () => null }] })
+
+    render(<NewPanePage onSelect={vi.fn()} />)
+
+    expect(screen.queryByText('Performance Monitor')).toBeNull()
+  })
 })

--- a/spa/src/components/NewPanePage.tsx
+++ b/spa/src/components/NewPanePage.tsx
@@ -5,7 +5,7 @@ interface Props {
   onSelect: (content: PaneContent) => void
 }
 
-const SIMPLE_KINDS = new Set(['dashboard', 'history', 'hosts', 'memory-monitor'])
+const SIMPLE_KINDS = new Set(['dashboard', 'history', 'hosts'])
 
 export function NewPanePage({ onSelect }: Props) {
   const paneKinds = getModules().flatMap((m) =>

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -31,6 +31,7 @@ import { isModuleOwnedContribution } from './settings-contribution-types'
 import { clearHostBuiltinSources } from './host-builtin-sections'
 import enLocale from '../locales/en.json'
 import zhLocale from '../locales/zh-TW.json'
+import { useModuleEnabledStore } from '../stores/useModuleEnabledStore'
 
 const FakeComponent = () => null
 
@@ -46,6 +47,7 @@ function clearAll() {
 describe('registerBuiltinModules', () => {
   beforeEach(() => {
     clearAll()
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
   })
 
   afterEach(() => {
@@ -69,6 +71,21 @@ describe('registerBuiltinModules', () => {
     const monitor = getModules().find((module) => module.id === 'memory-monitor')
     expect(monitor?.name).toBe('Performance Monitor')
     expect(getPaneRenderer('memory-monitor')).toBeDefined()
+  })
+
+  it('registers Performance Monitor as a settings page', () => {
+    registerBuiltinModules()
+
+    const contribution = listContributions('purdex').find((item) => item.id === 'memory-monitor.performance-monitor')
+    expect(contribution?.localId).toBe('performance-monitor')
+    expect(contribution?.labelKey).toBe('performance_monitor.title')
+  })
+
+  it('hides Performance Monitor settings page when the module is disabled', () => {
+    useModuleEnabledStore.getState().setEnabled('memory-monitor', false)
+    registerBuiltinModules()
+
+    expect(listContributions('purdex').some((item) => item.id === 'memory-monitor.performance-monitor')).toBe(false)
   })
 
   it('registers browser provider as disabled when no electronAPI', () => {

--- a/spa/src/lib/register-modules/index.tsx
+++ b/spa/src/lib/register-modules/index.tsx
@@ -85,6 +85,10 @@ function MemoryMonitorPaneWrapper() {
   return <MemoryMonitorPage />
 }
 
+function PerformanceMonitorSettingsSection() {
+  return <MemoryMonitorPage />
+}
+
 function InterfaceSectionHost() {
   const subs = getInterfaceSubsections()
   const [active, setActive] = useState<string>(() => subs[0]?.id ?? '')
@@ -171,6 +175,13 @@ export function registerBuiltinModules(): void {
     disableable: true,
     descriptionKey: 'modules.memory_monitor.description',
     panes: [{ kind: 'memory-monitor', component: MemoryMonitorPaneWrapper }],
+    settings: [{
+      localId: 'performance-monitor',
+      scope: 'purdex',
+      order: 6,
+      labelKey: 'performance_monitor.title',
+      component: PerformanceMonitorSettingsSection,
+    }],
   })
   registerModule({
     id: 'hosts',


### PR DESCRIPTION
## Summary
- Move Performance Monitor discovery into Settings as a module-owned settings page.
- Remove Performance Monitor from the pane replacement content chooser.
- Keep the existing `memory-monitor` module id and pane renderer for restore compatibility; disabled modules hide the settings page.

## Verification
- `pnpm --prefix spa exec vitest run src/lib/register-modules.test.ts src/components/NewPanePage.test.tsx src/components/SettingsPage.test.tsx src/components/MemoryMonitorPage.test.tsx src/components/MemoryMonitorDisabled.test.tsx src/locales/locale-completeness.test.ts`
- `pnpm --prefix spa run lint`
- `pnpm --prefix spa exec tsc -b`
- `git diff --check`