### PR TITLE
fix(spa): W6-LightsUI 4 lights polish

### DIFF
--- a/spa/src/components/SubagentDots.test.tsx
+++ b/spa/src/components/SubagentDots.test.tsx
@@ -26,43 +26,43 @@ describe('SubagentDots', () => {
     expect(container.querySelectorAll('[data-testid="subagent-dot"]').length).toBe(0)
   })
 
-  it('colors dots by ref.type — cc blue / codex yellow / opencode orange', () => {
+  it('colors dots by is_proxy: native (false/undefined) → blue, proxy (true) → orange', () => {
     const refs = [
-      makeRef({ id: 'a', type: 'cc' }),
-      makeRef({ id: 'b', type: 'codex' }),
-      makeRef({ id: 'c', type: 'opencode' }),
+      makeRef({ id: 'a', type: 'cc', is_proxy: false }),
+      makeRef({ id: 'b', type: 'codex', is_proxy: true }),
+      makeRef({ id: 'c', type: 'opencode' }),  // is_proxy undefined → native
     ]
     const { container } = render(<SubagentDots refs={refs} />)
     const dots = Array.from(container.querySelectorAll<HTMLElement>('[data-testid="subagent-dot"]'))
     expect(dots.length).toBe(3)
     // rgb() form — jsdom normalizes hex to rgb.
-    expect(dots[0].style.backgroundColor).toBe('rgb(96, 165, 250)') // #60a5fa
-    expect(dots[1].style.backgroundColor).toBe('rgb(250, 204, 21)') // #facc15
-    expect(dots[2].style.backgroundColor).toBe('rgb(249, 115, 22)') // #f97316
+    expect(dots[0].style.backgroundColor).toBe('rgb(96, 165, 250)')   // native blue #60a5fa
+    expect(dots[1].style.backgroundColor).toBe('rgb(249, 115, 22)')   // proxy orange #f97316
+    expect(dots[2].style.backgroundColor).toBe('rgb(96, 165, 250)')   // native blue (undefined)
   })
 
-  it('unknown type falls back to cc blue', () => {
-    const refs = [makeRef({ id: 'x', type: 'unknown-future-agent' })]
+  it('color is independent of ref.type — codex non-proxy stays native blue', () => {
+    const refs = [makeRef({ id: 'x', type: 'codex', is_proxy: false })]
     const { container } = render(<SubagentDots refs={refs} />)
     const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
     expect(dot.style.backgroundColor).toBe('rgb(96, 165, 250)')
   })
 
-  it('proxy ref renders as hollow outline (transparent bg + 1px border in type color)', () => {
+  it('proxy ref renders as solid orange (no border, no transparent bg)', () => {
     const refs = [makeRef({ id: 'p', type: 'codex', is_proxy: true })]
     const { container } = render(<SubagentDots refs={refs} />)
     const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
     expect(dot.getAttribute('data-is-proxy')).toBe('true')
-    expect(dot.style.backgroundColor).toBe('transparent')
-    expect(dot.style.border).toBe('1px solid rgb(250, 204, 21)')
+    expect(dot.style.backgroundColor).toBe('rgb(249, 115, 22)')
+    expect(dot.style.border).toBe('')
   })
 
-  it('non-proxy (is_proxy=false or undefined) renders solid bg, no border', () => {
+  it('non-proxy ref renders as solid blue (no border)', () => {
     const refs = [makeRef({ id: 'n', type: 'codex', is_proxy: false })]
     const { container } = render(<SubagentDots refs={refs} />)
     const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
     expect(dot.getAttribute('data-is-proxy')).toBe('false')
-    expect(dot.style.backgroundColor).toBe('rgb(250, 204, 21)')
+    expect(dot.style.backgroundColor).toBe('rgb(96, 165, 250)')
     expect(dot.style.border).toBe('')
   })
 })

--- a/spa/src/components/SubagentDots.tsx
+++ b/spa/src/components/SubagentDots.tsx
@@ -9,31 +9,16 @@ interface Props {
   left?: number
 }
 
-// Phase 2 PR-2b: dot color per agent family, derived inline (plan §5 — don't
-// abstract the palette elsewhere until a second consumer needs it).
-// Fallback to the cc blue keeps legacy / unknown types visible.
-const TYPE_COLOR: Record<string, string> = {
-  cc: '#60a5fa',
-  codex: '#facc15',
-  opencode: '#f97316',
-}
-const FALLBACK_COLOR = TYPE_COLOR.cc
-const colorFor = (type: string) => TYPE_COLOR[type] ?? FALLBACK_COLOR
+// Dot color encodes whether the subagent ref is a cross-agent proxy (e.g.
+// codex shelling out to cc and triggering cc's own SubagentStart hook) versus
+// a native sub-task spawned inside the agent's own tool loop. Type family is
+// already conveyed by the agent icon in the parent indicator.
+const NATIVE_COLOR = '#60a5fa'  // blue
+const PROXY_COLOR = '#f97316'   // orange
 
-// Proxy refs (cross-agent hook collapsed onto a parent frame) render as a
-// hollow ring — transparent background + 1px ring in the type color — to
-// distinguish from native subagents (solid fill of the same color).
-const dotStyle = (ref: SubagentRef): CSSProperties => {
-  const color = colorFor(ref.type)
-  if (ref.is_proxy) {
-    return {
-      backgroundColor: 'transparent',
-      border: `1px solid ${color}`,
-      boxSizing: 'border-box',
-    }
-  }
-  return { backgroundColor: color }
-}
+const dotStyle = (ref: SubagentRef): CSSProperties => ({
+  backgroundColor: ref.is_proxy ? PROXY_COLOR : NATIVE_COLOR,
+})
 
 const DOT_SIZES: Record<number, number> = { 1: 4, 2: 3.5, 3: 3 }
 

--- a/spa/src/components/TabStatusIndicator.test.tsx
+++ b/spa/src/components/TabStatusIndicator.test.tsx
@@ -48,6 +48,27 @@ describe('TabStatusIndicator', () => {
     expect(dot.style.backgroundColor).toBe('rgb(239, 68, 68)')
   })
 
+  it('overlay mode: running animates breathe when not unread', () => {
+    cleanup()
+    render(
+      <TabStatusIndicator status="running" mode="overlay" isActive={false} />,
+    )
+    const dot = screen.getByTestId('tab-status-indicator')
+    expect(dot.className).toContain('animate-breathe')
+  })
+
+  it('overlay mode: unread dot stays static (no animate-breathe)', () => {
+    // Component-level invariant: unread tint is informational, not a call-to-
+    // action — it must not pulse. The store layer also clears unread on
+    // running, but the indicator must not breathe even if both flags arrive.
+    cleanup()
+    render(
+      <TabStatusIndicator status="running" mode="overlay" isActive={false} isUnread />,
+    )
+    const dot = screen.getByTestId('tab-status-indicator')
+    expect(dot.className).not.toContain('animate-breathe')
+  })
+
   it('overlay mode: renders warning-diamond instead of dot when status is error', () => {
     cleanup()
     render(

--- a/spa/src/components/TabStatusIndicator.tsx
+++ b/spa/src/components/TabStatusIndicator.tsx
@@ -37,7 +37,7 @@ export function TabStatusIndicator({ status, mode, isActive, isUnread = false }:
         <WarningDiamond
           data-testid="tab-status-error"
           size={10}
-          weight="duotone"
+          weight="fill"
           color={STATUS_COLORS.error}
           style={{
             position: 'absolute',
@@ -53,7 +53,7 @@ export function TabStatusIndicator({ status, mode, isActive, isUnread = false }:
     return (
       <span
         data-testid="tab-status-indicator"
-        className={`rounded-full flex-shrink-0 ${isRunning ? 'animate-breathe' : ''}`}
+        className={`rounded-full flex-shrink-0 ${isRunning && !isUnread ? 'animate-breathe' : ''}`}
         style={{
           width: '6px',
           height: '6px',
@@ -73,7 +73,7 @@ export function TabStatusIndicator({ status, mode, isActive, isUnread = false }:
       <WarningDiamond
         data-testid="tab-status-error"
         size={14}
-        weight="duotone"
+        weight="fill"
         color={STATUS_COLORS.error}
         className="flex-shrink-0"
       />

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -252,6 +252,22 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().unread[`${H}:dev`]).toBeUndefined()
   })
 
+  it('running status → clears existing unread regardless of focus', () => {
+    // Background tab + waiting marks unread, then a UserPromptSubmit fires
+    // while still in background — unread should clear because running is
+    // unambiguous user activity, not an actionable signal to surface.
+    useAgentStore.setState({ unread: { [`${H}:dev`]: true } })
+    const event: NormalizedEvent = {
+      agent_type: 'cc',
+      status: 'running',
+      raw_event_name: 'PdxUserPromptSubmit',
+      broadcast_ts: Date.now(),
+    }
+    useAgentStore.getState().handleNormalizedEvent(H, 'dev', event)
+    expect(useAgentStore.getState().statuses[`${H}:dev`]).toBe('running')
+    expect(useAgentStore.getState().unread[`${H}:dev`]).toBeUndefined()
+  })
+
   it('agent type is stored from event', () => {
     useAgentStore.getState().handleNormalizedEvent(H, 'dev', {
       agent_type: 'codex',

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -156,6 +156,19 @@ export const useAgentStore = create<AgentState>()(
       if (status) {
         set((s) => ({ statuses: { ...s.statuses, [key]: status } }))
 
+        // running is unambiguous user activity — clear any leftover unread
+        // (e.g. raised by a prior waiting/idle while the tab was in background)
+        // regardless of focus.
+        if (status === 'running') {
+          set((s) => {
+            if (!(key in s.unread)) return s
+
+            const { [key]: _, ...rest } = s.unread
+            return { unread: rest }
+          })
+          return
+        }
+
         // Mark unread when not focused. Notification raises status=idle but
         // shouldn't surface as actionable: cc emits PdxNotification post-W2,
         // codex/opencode pre-migration still emit "Notification". Recognise


### PR DESCRIPTION
## Summary

Closes #762 — four self-contained SPA lights fixes after W1 audit + W6-3+W6-4 ship.

- **useAgentStore**: when status flips to `running`, clear any leftover unread. Previously a background tab marked unread by a prior waiting/idle would keep the red dot indefinitely until the user opened the tab.
- **TabStatusIndicator (overlay dot)**: drop `animate-breathe` whenever `isUnread`. Unread tint is informational, not a call-to-action — it must not pulse. Combined with the store fix this makes the running+unread combination unreachable, but the component-level invariant is enforced independently.
- **TabStatusIndicator (error icon)**: `WarningDiamond` weight `duotone` → `fill` (both 10px overlay and 14px replace mode) for crisper rendering at small sizes.
- **SubagentDots**: dot color now encodes `is_proxy` semantics (proxy = orange, native = blue) instead of agent type family. Drops the hollow-ring proxy variant — agent type is already conveyed by the parent icon.

## Test plan

- [x] `npx vitest run` — 3168 pass / 4 baseline fails (TabBar + hosts contributor, pre-existing on alpha.275, unrelated)
- [x] Targeted: `npx vitest run useAgentStore TabStatusIndicator SubagentDots` — 56/56 pass (was 50/56 before fix)
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` — clean (chunk warning pre-existing)
- [ ] mlab live: spawn cc/codex/opencode subagent in non-active tab, verify dot color is by `is_proxy` not type
- [ ] mlab live: switch active tab from background unread → status shifts to running → dot turns green non-pulsing (running re-paints; unread cleared)
- [ ] mlab live: trigger error state → confirm WarningDiamond looks crisper than duotone

## Notes

- Per #762: small PR (~117 lines incl. tests), no spec/plan/codex two-round review needed — single round of cross-model review will suffice.
- No props signature changes; `renderInlineTabIcon.tsx` and `TabIcon.tsx` callers untouched.
- WarningDiamond weight is a build-time SVG variant (Phosphor renders different paths per weight, no runtime attribute) — not asserted in unit tests; verified by inspecting the diff and visual smoke.