### PR TITLE
feat(agent): cc PdxPostToolUse → running status (W6-1a)

### DIFF
--- a/internal/agent/cc/events.go
+++ b/internal/agent/cc/events.go
@@ -118,9 +118,8 @@ var ccEventSpecs = []agent.HookEventSpec{
 		PurdexName:   "PdxPostToolUse",
 		UpstreamKeys: []string{"PostToolUse"},
 		Lifecycle:    agent.LifecycleNone,
-		EmitsStatus:  []agent.Status{},
-		Description:  "Tool call completed successfully",
-		Handling:     agent.HookHandlingIgnored,
+		EmitsStatus:  []agent.Status{agent.StatusRunning},
+		Description:  "Tool call completed successfully (signals running after permission grant)",
 	},
 	{
 		PurdexName:   "PdxPostToolUseFailure",

--- a/internal/agent/cc/events_test.go
+++ b/internal/agent/cc/events_test.go
@@ -20,6 +20,7 @@ var expectedCCInstallableEventNames = []string{
 	"PdxNotification",
 	"PdxPermissionRequest",
 	"PdxSessionEnd",
+	"PdxPostToolUse",
 }
 
 // expectedCCEventNames lists the upstream event-name keys that cc's installer
@@ -37,6 +38,7 @@ var expectedCCEventNames = []string{
 	"Notification",
 	"PermissionRequest",
 	"SessionEnd",
+	"PostToolUse",
 }
 
 // expectedCCCatalogHandling is pinned to the Claude Code hooks reference,
@@ -50,7 +52,7 @@ var expectedCCCatalogHandling = map[string]agent.HookHandling{
 	"PdxPreToolUse":          agent.HookHandlingUnsupported,
 	"PdxPermissionRequest":   agent.HookHandlingStatus,
 	"PdxPermissionDenied":    agent.HookHandlingIgnored,
-	"PdxPostToolUse":         agent.HookHandlingIgnored,
+	"PdxPostToolUse":         agent.HookHandlingStatus,
 	"PdxPostToolUseFailure":  agent.HookHandlingIgnored,
 	"PdxPostToolBatch":       agent.HookHandlingUnsupported,
 	"PdxNotification":        agent.HookHandlingStatus,
@@ -262,7 +264,7 @@ var expectedCCPreservedMetadata = map[string]ccLegacyMetadata{
 	"PdxUserPromptExpansion": {[]agent.Status{}, "User command expanded before model processing", false, agent.HookHandlingUnsupported},
 	"PdxPreToolUse":          {[]agent.Status{}, "Tool call about to execute", false, agent.HookHandlingUnsupported},
 	"PdxPermissionDenied":    {[]agent.Status{}, "Tool permission denied by auto mode classifier", false, agent.HookHandlingIgnored},
-	"PdxPostToolUse":         {[]agent.Status{}, "Tool call completed successfully", false, agent.HookHandlingIgnored},
+	"PdxPostToolUse":         {[]agent.Status{agent.StatusRunning}, "Tool call completed successfully (signals running after permission grant)", false, ""},
 	"PdxPostToolUseFailure":  {[]agent.Status{}, "Tool call failed", false, agent.HookHandlingIgnored},
 	"PdxPostToolBatch":       {[]agent.Status{}, "Parallel tool call batch resolved", false, agent.HookHandlingUnsupported},
 	"PdxTaskCreated":         {[]agent.Status{}, "Task was created", false, agent.HookHandlingIgnored},

--- a/internal/agent/cc/status.go
+++ b/internal/agent/cc/status.go
@@ -27,6 +27,20 @@ func deriveCCStatus(purdexName string, rawEvent json.RawMessage) agent.DeriveRes
 			Status: agent.StatusRunning,
 		}
 
+	case "PdxPostToolUse":
+		// W6-1a: cc fires PostToolUse after a tool completes — including
+		// after the user grants a paused permission prompt. Mapping to
+		// running unblocks the waiting → running transition that has no
+		// other hook between Notification(permission_prompt)/PermissionRequest
+		// and the eventual Stop.
+		return agent.DeriveResult{
+			Valid:  true,
+			Status: agent.StatusRunning,
+			Detail: map[string]any{
+				"tool_name": raw["tool_name"],
+			},
+		}
+
 	case "PdxNotification":
 		nt := strVal(raw, "notification_type")
 		var status agent.Status

--- a/internal/agent/cc/status_test.go
+++ b/internal/agent/cc/status_test.go
@@ -82,6 +82,21 @@ func TestDeriveCCStatus_PdxPermissionRequest_Waiting(t *testing.T) {
 	}
 }
 
+// TestDeriveCCStatus_PdxPostToolUse_Running asserts the W6-1a contract:
+// PostToolUse fires after a tool completes — including after a permission
+// grant — and must flip status to running so the waiting → running transition
+// has an actual hook signal between Notification(permission_prompt) and the
+// eventual Stop.
+func TestDeriveCCStatus_PdxPostToolUse_Running(t *testing.T) {
+	r := deriveViaProvider("PdxPostToolUse", map[string]any{"tool_name": "Bash"})
+	if !r.Valid || r.Status != agent.StatusRunning {
+		t.Fatalf("expected running, got %+v", r)
+	}
+	if r.Detail["tool_name"] != "Bash" {
+		t.Fatalf("expected tool_name Bash in detail")
+	}
+}
+
 func TestDeriveCCStatus_PdxStop_Idle(t *testing.T) {
 	r := deriveViaProvider("PdxStop", map[string]any{"last_assistant_message": "Done"})
 	if !r.Valid || r.Status != agent.StatusIdle {

--- a/internal/agent/drift_test.go
+++ b/internal/agent/drift_test.go
@@ -46,6 +46,7 @@ var providerFixtures = map[string][]driftFixture{
 		{"PdxNotification", `{"notification_type":"idle_prompt"}`, agent.StatusIdle, true},
 		{"PdxNotification", `{"notification_type":"auth_success"}`, agent.StatusIdle, true},
 		{"PdxPermissionRequest", `{"tool_name":"Bash"}`, agent.StatusWaiting, true},
+		{"PdxPostToolUse", `{"tool_name":"Bash"}`, agent.StatusRunning, true},
 		{"PdxStop", `{}`, agent.StatusIdle, true},
 		{"PdxStopFailure", `{"error":"x"}`, agent.StatusError, true},
 		{"PdxSessionEnd", `{}`, agent.StatusClear, true},


### PR DESCRIPTION
## Summary

W6-1a catalog-only fix: promote cc `PdxPostToolUse` from `Handling=Ignored` (non-installable) to a status-emitting hook with `EmitsStatus=[Running]`. Closes the W5-1 gap where, after a permission grant, lights stayed yellow until `PdxStop` flipped to idle — skipping the running phase entirely. Now `PdxPostToolUse` gives `waiting → running` a real hook signal.

W6-2 (cc compact) was also live-verified in this session: `SessionStart(source=compact)` fires reliably on `/compact` end but daemon's `compact_ignored` branch is intentional and trace-only — pre-compact `PdxStop` already settles status to idle in all observed scenarios, so no code change is needed for W6-2 (verified-only, documented in commit body).

## Files changed

- `internal/agent/cc/events.go` — `PdxPostToolUse`: drop `HookHandlingIgnored`, add `EmitsStatus=[StatusRunning]`, sharpen description (1 entry now installable, total cc installable count 9 → 10).
- `internal/agent/cc/status.go` — new `PdxPostToolUse` case returning `Status=Running` with `tool_name` detail.
- `internal/agent/cc/events_test.go` — extend installable / event-name / catalog-handling / preserved-metadata fixtures.
- `internal/agent/cc/status_test.go` — `TestDeriveCCStatus_PdxPostToolUse_Running`.
- `internal/agent/drift_test.go` — fixture `{"PdxPostToolUse", \`{"tool_name":"Bash"}\`, StatusRunning, true}` for cc.

Net: +36 / -5 lines.

## Test plan

- [x] `go test ./...` clean (24 packages)
- [x] `go test -race ./internal/agent/cc/... ./internal/agent/... ./internal/module/agent/...` clean
- [x] `go vet ./...` clean
- [x] mlab live verify (cc 2.1.123, daemon built from this branch + `pdx setup --agent cc`):
  - [x] Auto-allowed `Bash(whoami)` flow: UserPromptSubmit → running, **PdxPostToolUse → running**, PdxStop → idle (3-step chain log clean)
  - [x] Permission-required `Write(/tmp/...)` flow: PdxPermissionRequest → waiting, PdxNotification(permission_prompt) → waiting (dual fire confirmed), user approves, **PdxPostToolUse → running** (the W6-1a fix), PdxStop → idle
  - [x] /compact flow: PdxSubagentStop → idle (carry-over), PdxSessionStart(source=compact) → invalid_skip compact_ignored (no light flip; pre-compact already idle)
- [ ] Codex round 1 standard review

## Notes

- Bonus finding from W6-1a permission verify: cc 2.1.123 fires both `PermissionRequest` and `Notification(permission_prompt)` on a Write permission ask. This confirms the W5-2 dual-fire question that was downgraded to "needs trace evidence" in the audit. No additional fix needed (both map to waiting; idempotent overlap).
- Per W6-LightsUI precedent (alpha.277, PR #783) this is a small catalog-only PR — no spec/plan/codex-review big flow; round-1 standard codex review only, then squash-merge.
- Upgrade note for users post-merge: `~/.claude/settings.json` already has `PostToolUse` after running `pdx setup --agent cc` from this binary; existing alpha.278 installs auto-pick-up the new hook on next install/setup.