### PR TITLE
fix(spa): preserve dot-slash terminal file links

### DIFF
--- a/spa/src/lib/terminal-link/matchers/file-path.test.ts
+++ b/spa/src/lib/terminal-link/matchers/file-path.test.ts
@@ -48,6 +48,10 @@ describe('createFilePathMatcher — absolute', () => {
   it('does NOT pick /foo.ts out of ~/foo.ts', () => {
     expect(make().provide('open ~/foo.ts')).toHaveLength(0)
   })
+
+  it('does NOT pick /CLAUDE.md out of ./CLAUDE.md', () => {
+    expect(make().provide('open ./CLAUDE.md')).toHaveLength(0)
+  })
 })
 
 describe('createFilePathMatcher — relativeSlash', () => {
@@ -59,6 +63,13 @@ describe('createFilePathMatcher — relativeSlash', () => {
     expect(r).toHaveLength(1)
     expect(r[0].text).toBe('src/App.tsx')
     expect(r[0].meta).toEqual({ path: 'src/App.tsx' })
+  })
+
+  it('matches ./CLAUDE.md', () => {
+    const r = make().provide('edit ./CLAUDE.md now')
+    expect(r).toHaveLength(1)
+    expect(r[0].text).toBe('./CLAUDE.md')
+    expect(r[0].meta).toEqual({ path: './CLAUDE.md' })
   })
 
   it('matches internal/agent/cc/extract.go:14', () => {

--- a/spa/src/lib/terminal-link/matchers/file-path.ts
+++ b/spa/src/lib/terminal-link/matchers/file-path.ts
@@ -1,7 +1,7 @@
 import type { LinkMatcher } from '../types'
 
 // 絕對路徑：必須以 `/` 開頭 + 末段 name.ext（支援多重副檔名如 .d.ts / .min.js）
-export const ABS_RE = /(?<![\w/:~])(\/(?:[\w.-]+\/)*[\w-]+(?:\.[A-Za-z0-9]+)+)(?::(\d+)(?::(\d+))?)?/g
+export const ABS_RE = /(?<![\w/:~.])(\/(?:[\w.-]+\/)*[\w-]+(?:\.[A-Za-z0-9]+)+)(?::(\d+)(?::(\d+))?)?/g
 
 // Tilde 路徑：以 ~/ 開頭 + 末段 name.ext（支援 dotdir 與多重副檔名）
 export const TILDE_RE = /(?<![\w/:~])(~\/(?:[\w.-]+\/)*[\w-]+(?:\.[A-Za-z0-9]+)+)(?::(\d+)(?::(\d+))?)?/g


### PR DESCRIPTION
## Summary
- Prevent absolute file-link detection from slicing `/CLAUDE.md` out of `./CLAUDE.md`
- Cover dot-slash relative file links in terminal-link matcher tests

## Tests
- `pnpm --prefix spa exec vitest run src/lib/terminal-link/matchers/file-path.test.ts`
- `pnpm --prefix spa exec vitest run src/lib/terminal-link`