### PR TITLE
fix(spa): clear stale subagent dots

### DIFF
--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -938,7 +938,7 @@ func buildProjectionNormalized(projection *SessionProjection, fallbackAgentType,
 		}
 		return normalized
 	}
-	normalized.Subagents = append([]agentpkg.SubagentRef(nil), projection.Subagents...)
+	normalized.Subagents = append([]agentpkg.SubagentRef{}, projection.Subagents...)
 	if projection.TopFrame == nil {
 		normalized.Status = string(agentpkg.StatusClear)
 		return normalized

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -895,6 +895,26 @@ func TestBuildNormalized_WithSubagents(t *testing.T) {
 	}
 }
 
+func TestBuildProjectionNormalized_NilSubagentsSerializesEmptyArray(t *testing.T) {
+	projection := &SessionProjection{
+		TopFrame: &store.Frame{
+			AgentType: "cc",
+			Status:    agentpkg.StatusRunning,
+		},
+		Subagents: nil,
+	}
+
+	normalized := buildProjectionNormalized(projection, "cc", "PdxPostToolUse", 1, agentpkg.DeriveResult{Valid: true})
+	if normalized.Subagents == nil {
+		t.Fatal("Subagents should be non-nil empty slice, got nil")
+	}
+
+	data, _ := json.Marshal(normalized)
+	if !strings.Contains(string(data), `"subagents":[]`) {
+		t.Errorf("JSON should contain \"subagents\":[], got %s", string(data))
+	}
+}
+
 // --- Bug 0b: RenameSession transfers in-memory state ---
 
 func TestRenameSession(t *testing.T) {

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -156,6 +156,19 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().subagents[`${H}:dev`]).toEqual([a])
   })
 
+  it('event with null subagents clears existing subagents', () => {
+    const a = ref('agent-A')
+    useAgentStore.setState({ subagents: { [`${H}:dev`]: [a] } })
+    useAgentStore.getState().handleNormalizedEvent(H, 'dev', {
+      agent_type: 'cc',
+      status: 'running',
+      subagents: null,
+      raw_event_name: 'PdxUserPromptSubmit',
+      broadcast_ts: Date.now(),
+    })
+    expect(useAgentStore.getState().subagents[`${H}:dev`]).toBeUndefined()
+  })
+
   it('markRead → clears unread', () => {
     useAgentStore.setState({ unread: { [`${H}:dev`]: true } })
     useAgentStore.getState().markRead(H, 'dev')

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -53,7 +53,7 @@ export interface NormalizedEvent {
   agent_type: string
   status: string             // running | waiting | idle | error | clear
   model?: string
-  subagents?: SubagentRef[]
+  subagents?: SubagentRef[] | null
   raw_event_name: string
   broadcast_ts: number
   detail?: Record<string, unknown>
@@ -142,11 +142,11 @@ export const useAgentStore = create<AgentState>()(
       }
 
       // Store subagents
-      if (event.subagents) {
+      if ('subagents' in event) {
+        const subagents = event.subagents ?? []
         set((s) => ({
-          subagents: event.subagents!.length > 0
-            ? { ...s.subagents, [key]: event.subagents! }
-             
+          subagents: subagents.length > 0
+            ? { ...s.subagents, [key]: subagents }
             : (() => { const { [key]: _, ...rest } = s.subagents; return rest })(),
         }))
       }


### PR DESCRIPTION
## Summary
- Treat explicit `subagents: null` as an empty subagent list in the SPA store so stale dots are cleared.
- Keep missing `subagents` as a no-op and ensure projection payloads serialize empty subagents as `[]` instead of `null`.

## Tests
- `pnpm --prefix spa exec vitest run src/stores/useAgentStore.test.ts`
- `pnpm --prefix spa run lint`
- `go test ./internal/module/agent -count=1`