### PR TITLE
refactor(settings): PR-1 — sidebar reorder, puzzle icon style, ModulesSwitchboard padding

### DIFF
--- a/docs/specs/2026-05-02-settings-architecture-fix-plan.md
+++ b/docs/specs/2026-05-02-settings-architecture-fix-plan.md
@@ -1,0 +1,485 @@
+# Plan — Settings 架構修正
+
+**Spec**: [2026-05-02-settings-architecture-fix-spec.md](2026-05-02-settings-architecture-fix-spec.md)
+**Approach**: TDD, two-PR sequential. PR-1 純視覺/順序，PR-2 結構性收編 + Sync 升格。
+
+## 共用前置
+
+- 主環境跑 `pnpm install`（codex sandbox 無法跑）
+- 每個 task 完成後 `cd spa && npx vitest run <pattern>` 跑相關 + `pnpm run lint`
+- Test fixture 慣例：
+  - `register-modules` 相關測試 import `clearAllForHmr` / `resetSettingsContributionsForHmr` 在 `beforeEach` 重置 registry
+  - 既有 `register-modules.test.ts` / `register-modules.quick-commands.test.tsx` 是 task 1.x / 2.x 的主要 anchor
+  - URL alias 測試在 `SettingsPage.test.tsx`（如不存在則新建）使用 wouter `Router` + `memoryLocation`
+
+## PR-1：視覺 / 順序（純視覺，無結構變更）
+
+### Task 1.1 — 新增 `spa/src/lib/settings-order.ts`
+
+新檔案，集中常數 + JSDoc 說明 band 切分（§4.1.1 / §4.1.2）：
+
+```ts
+export const SETTINGS_ORDER = {
+  APPEARANCE: 0,
+  TERMINAL: 1,
+  INTERFACE: 2,
+  ELECTRON: 5,
+  MODULE_CONFIG: 10,
+  MODULE_EDITOR: 11,
+  MODULE_QUICK_COMMANDS: 12,
+  MODULE_PERFORMANCE_MONITOR: 13,
+  MODULE_SYNC: 14,
+  DEV_ENVIRONMENT: 20,
+  TMUX_AGENT_MONITOR: 21,
+} as const
+```
+
+**Tests**: 不需要單獨測試（純常數）。Linter / type check pass 即可。
+
+### Task 1.2 — 寫 sidebar order 測試（先紅）
+
+新增 `spa/src/lib/__tests__/settings-order-pr1.test.ts`：
+
+```ts
+// 1.2.a — listContributions('purdex') after registerBuiltinModules 順序
+//   expected (ASC): appearance(0), terminal(1), interface(2),
+//                   [electron(5)?],  ← caps 條件可 mock 成 true
+//                   performance-monitor(11), open-behavior(12),
+//                   link-detect(13), editor(14), quick-commands(15),
+//                   module-config(10) [插在 interface 與 perf-monitor 之間]
+//   ⚠️ 用 listContributions + registerSettingsSection 兩個 source 合併斷言
+//
+// 1.2.b — module-config 必須出現在所有 module-owned (puzzle) 上方:
+//          rows.findIndex(id='module-config') < rows.findIndex(any module-owned)
+//
+// 1.2.c — 無重複 order：每個 entry 的 order 在 active 集合中唯一
+```
+
+**Expected**: 先紅（current code module-config 還是 8、perf-monitor 6 等）。
+
+### Task 1.3 — 改 register-modules order（讓 1.2 紅 → 綠）
+
+`spa/src/lib/register-modules/index.tsx`：
+
+```diff
+- order: 6,                              // memory-monitor settings
++ order: 11,
+- registerSettingsSection({ id: 'module-config', ..., order: 8, ... })
++ registerSettingsSection({ id: 'module-config', ..., order: SETTINGS_ORDER.MODULE_CONFIG, ... })
+- registerSettingsSection({ id: 'sync', ..., order: 11, ... })
++ registerSettingsSection({ id: 'sync', ..., order: 16, ... })  // PR-1 過渡
+- registerSettingsSection({ id: 'appearance', ..., order: 0, ... })
++ registerSettingsSection({ id: 'appearance', ..., order: SETTINGS_ORDER.APPEARANCE, ... })
+- registerSettingsSection({ id: 'terminal', ..., order: 1, ... })
++ registerSettingsSection({ id: 'terminal', ..., order: SETTINGS_ORDER.TERMINAL, ... })
+- registerSettingsSection({ id: 'interface', ..., order: 2, ... })
++ registerSettingsSection({ id: 'interface', ..., order: SETTINGS_ORDER.INTERFACE, ... })
+- registerSettingsSection({ id: 'electron', ..., order: 5, ... })
++ registerSettingsSection({ id: 'electron', ..., order: SETTINGS_ORDER.ELECTRON, ... })
+- registerSettingsSection({ id: 'dev-environment', ..., order: 20, ... })
++ registerSettingsSection({ id: 'dev-environment', ..., order: SETTINGS_ORDER.DEV_ENVIRONMENT, ... })
+- registerSettingsSection({ id: 'tmux-agent-monitor', ..., order: 21, ... })
++ registerSettingsSection({ id: 'tmux-agent-monitor', ..., order: SETTINGS_ORDER.TMUX_AGENT_MONITOR, ... })
+```
+
+`registerModule` 內 quick-commands `order: 10` → `15`。
+
+`spa/src/lib/register-modules/editor-module.tsx`：
+
+```diff
+  settings: [
+-   { localId: 'editor', scope: 'purdex', order: 9, ... },
++   { localId: 'editor', scope: 'purdex', order: 14, ... },        // PR-1 過渡
+-   { localId: 'link-detect', scope: 'purdex', order: 8, ... },
++   { localId: 'link-detect', scope: 'purdex', order: 13, ... },
+-   { localId: 'open-behavior', scope: 'purdex', order: 7, ... },
++   { localId: 'open-behavior', scope: 'purdex', order: 12, ... },
+    { localId: 'workspace-home-path', scope: 'workspace', order: 0, ... },
+    { localId: 'host-home-path', scope: 'host', order: 100, ... },
+  ]
+```
+
+⚠️ PR-1 的 SETTINGS_ORDER 常數對 module-owned 對應 PR-2 final（11/12/13/14），PR-1 程式碼用 hard-coded 11-16；只有 module-config / 非 module-owned 用常數。Plan acceptance 守住「PR-1 結束時 ASC 排序與 §4.1.4 表完全一致」。
+
+**Run**: `cd spa && npx vitest run lib/__tests__/settings-order-pr1` → 綠。
+
+### Task 1.4 — 改 puzzle icon 三 caller（一次到位）
+
+三個檔案，改法相同：
+
+```diff
+  <PuzzlePiece
+-   size={12}                                         // hosts 是 size={10}
+-   weight="fill"
+-   className="flex-shrink-0 rotate-[30deg] text-text-muted"
++   size={12}
++   weight="bold"
++   className="flex-shrink-0 text-text-muted"
+    aria-hidden
+  />
+```
+
+檔案：
+1. `spa/src/components/settings/SettingsSidebar.tsx:88-93`
+2. `spa/src/features/workspace/components/WorkspaceSettingsPage.tsx:162-167`
+3. `spa/src/components/hosts/HostSidebar.tsx:124-129`（size={10} 不動）
+
+### Task 1.5 — 寫 puzzle icon 測試（守住三 caller）
+
+新增 `spa/src/components/settings/SettingsSidebar.test.tsx`（如已存在則 append）：
+
+```tsx
+// 1.5.a — Sidebar puzzle row className 不含 'rotate-[30deg]'
+// 1.5.b — Sidebar puzzle weight prop = 'bold'
+//   用 rendered DOM SVG 看不到 weight prop，改測 className 是 fill / bold 對應的 svg path
+//   Phosphor Icons 的 bold 與 fill 渲染 stroke-width 不同；最簡單測法是
+//   render PuzzlePiece 直接，比對 outerHTML 含 'stroke-width' (bold) 而非 'fill="currentColor"'
+//   （或更簡單：mock @phosphor-icons/react 接收 weight prop，比對 prop 值）
+// 1.5.c — module-owned row 顯示 puzzle，built-in row 不顯示
+```
+
+**WorkspaceSettingsPage.test.tsx** / **HostSidebar.test.tsx**（如已存在）追加同樣斷言。如不存在不新建（避免 PR-1 範圍膨脹）。
+
+### Task 1.6 — `ModulesSwitchboardSection` 拿掉 `p-6`
+
+`spa/src/components/settings/ModulesSwitchboardSection.tsx:36`：
+
+```diff
+- <div className="p-6 space-y-6">
++ <div className="space-y-6">
+```
+
+`ModulesSwitchboardSection.test.tsx` 既有測試應通過（如果有 className 斷言調整 selector）。
+
+### Task 1.7 — 跑全部 vitest + lint
+
+```bash
+cd spa && npx vitest run && pnpm run lint
+```
+
+預期：所有測試綠 + lint 0。
+
+### PR-1 Acceptance（spec §5.1）
+
+- [ ] A1：vitest `settings-order-pr1` 全綠 → sidebar order = §4.1.4 表
+- [ ] A2：三個 PuzzlePiece caller 都改完（grep `rotate-\[30deg\]` 全 spa = 0 hit）
+- [ ] A3：URL routing 不變（既有 settings paths 全部仍解析）
+- [ ] A4：ModulesSwitchboard outer wrapper 無 `p-6`
+- [ ] A5：vitest 全綠
+
+### PR-1 Commits（建議切分）
+
+1. `feat(settings): introduce SETTINGS_ORDER constants` (Task 1.1)
+2. `test(settings): add PR-1 sidebar order assertions (red)` (Task 1.2)
+3. `refactor(settings): reorder sidebar entries per PR-1 transitional table` (Task 1.3)
+4. `style(settings): puzzle icon → bold weight, no rotation` (Task 1.4 + 1.5)
+5. `refactor(settings): drop double p-6 from ModulesSwitchboardSection` (Task 1.6)
+
+---
+
+## PR-2：Editor 收編 + Sync modularize + Quick Commands 頁首
+
+⚠️ PR-2 必須建立在 PR-1 已 merged main 的 base 上。
+
+### Task 2.1 — 寫 Editor 收編測試（先紅）
+
+新增 `spa/src/components/settings/__tests__/editor-section-consolidation.test.tsx`：
+
+```tsx
+// 2.1.a — listContributions('purdex') 不含 'open-behavior' / 'link-detect' localId
+// 2.1.b — editor section render 後同時包含三段 heading：
+//   - <h2> 文本含 t('settings.section.editor')
+//   - 第一段 SettingItem rows（Monaco prefs, tab_size 等）
+//   - <h3> 含 t('settings.editor.open_behavior.title')
+//   - <h3> 含 t('settings.editor.link_detect.title')
+// 2.1.c — Open Behavior toggle (popupOnMissingFile) 改變 useEditorSettingsStore state
+// 2.1.d — Link Detection toggle (linkDetectAbsolute) 改變 useUISettingsStore state
+//   （用 within(<screen text=link_detect.title 的 section>) 鎖定範圍避免誤點 sidebar）
+// 2.1.e — 父頁無重複 h3（h3 數 = 2）
+// 2.1.f — Editor 段落內無多餘 outer p-6（render 後 outer div 的 className 不含 'p-6'）
+```
+
+### Task 2.2 — 寫 URL alias 測試（先紅）
+
+新增 `spa/src/components/SettingsPage.test.tsx`（如已存在則 append）。Setup：mock `wouter` `useLocation` 起點為 `/settings/link-detect`，再以 `useLocation` setter 觀察 replace 後路徑。
+
+```tsx
+// 2.2.a — start at /settings/link-detect → setLocation called with '/settings/editor', { replace: true }
+// 2.2.b — start at /settings/open-behavior → 同上
+// 2.2.c — start at /settings/editor-buffers → 維持既有 alias 行為（existing test 保留）
+// 2.2.d — start at /settings/editor → 不 replace（identity，避免無限循環）
+// 2.2.e — start at /settings/link-detect 時 Editor module 被 disable（mock useModuleEnabledStore）
+//          → 不 mount Editor，self-heal 走 default 路徑（不要求 hard 404）
+// 2.2.f — alias map identity case: rawUrlSection === canonical 不重複 setLocation
+```
+
+### Task 2.3 — 寫 Sync modularize 測試（先紅）
+
+新增 `spa/src/lib/__tests__/sync-as-module.test.ts`：
+
+```ts
+// 2.3.a — registerBuiltinModules 後 getModules() 含 { id: 'sync', ... }
+// 2.3.b — getModules().filter(m => m.disableable === true) 不含 sync
+//          → ModulesSwitchboard 不列 Sync
+// 2.3.c — listContributions('purdex') 中 sync 的 moduleId === 'sync'
+//          → isModuleOwnedContribution 為 true
+// 2.3.d — sync 的 order === SETTINGS_ORDER.MODULE_SYNC (=14)
+// 2.3.e — stale persisted state useModuleEnabledStore { sync: false } 仍保留 sync contribution
+//          （非 disableable 的 module 不被 enabled-store 過濾）
+// 2.3.f — 重複呼叫 dispatchSettingsContributions（HMR 模擬）後 sync 仍存在且 moduleId 不變
+// 2.3.g — registerSyncContributors 仍在 boot 被呼叫（檢查 syncEngine.getContributors().length === 7）
+```
+
+### Task 2.4 — 寫 Quick Commands 頁首測試（先紅）
+
+`spa/src/components/settings/QuickCommandsSettingsSection.test.tsx` append：
+
+```tsx
+// 2.4.a — outer wrapper className 不含 'p-6'
+// 2.4.b — render 後 DOM 含 <h2> 文字 = t('settings.quick_commands.title')
+// 2.4.c — 緊隨 <h2> 之後是 <p> 文字 = t('settings.quick_commands.desc')
+// 2.4.d — "新建" 按鈕仍存在 + click 後仍開 dialog（既有行為不破）
+// 2.4.e — commands list 既有功能（edit / delete）仍可用（既有測試保留）
+```
+
+### Task 2.5 — Editor 三頁合一實作（讓 2.1 / 2.2 紅 → 綠）
+
+#### 2.5.1 重組 `EditorPurdexSettingsSection`
+
+`spa/src/components/settings/EditorPurdexSettingsSection.tsx`：
+
+```tsx
+import { EditorOpenBehaviorSection } from './editor/EditorOpenBehaviorSection'
+import { EditorLinkDetectionSection } from './editor/EditorLinkDetectionSection'
+
+export function EditorPurdexSettingsSection(_props: Props) {
+  // ... 既有 hooks ...
+
+  return (
+    <div>
+      <h2 className="text-lg text-text-primary">{t('settings.editor.title')}</h2>
+      <p className="text-xs text-text-secondary mb-6">{t('settings.editor.desc')}</p>
+
+      {/* 既有 6 個 Monaco SettingItem rows，原本就在 component 內，不動 */}
+
+      <EditorOpenBehaviorSection />
+      <EditorLinkDetectionSection />
+
+      <p className="text-xs text-text-muted mt-4">
+        {t('settings.editor.tiptap_note')}
+      </p>
+    </div>
+  )
+}
+```
+
+#### 2.5.2 縮減 `editorModuleDefinition.settings`
+
+`spa/src/lib/register-modules/editor-module.tsx`：
+
+```diff
+  settings: [
+    {
+      localId: 'editor',
+      scope: 'purdex',
+-     order: 14,                                         // PR-1 過渡值
++     order: SETTINGS_ORDER.MODULE_EDITOR,               // = 11
+      labelKey: 'settings.section.editor',
+      component: EditorPurdexSettingsSection,
+    },
+-   {
+-     localId: 'link-detect',
+-     scope: 'purdex',
+-     order: 13,
+-     labelKey: 'settings.editor.link_detect.title',
+-     component: EditorLinkDetectionSection,
+-   },
+-   {
+-     localId: 'open-behavior',
+-     scope: 'purdex',
+-     order: 12,
+-     labelKey: 'settings.editor.open_behavior.title',
+-     component: EditorOpenBehaviorSection,
+-   },
+    { localId: 'workspace-home-path', ... },
+    { localId: 'host-home-path', ... },
+  ]
+```
+
+`EditorOpenBehaviorSection` / `EditorLinkDetectionSection` 兩個 component 不刪、不重寫；只是 register-modules 不再單獨註冊，由 `EditorPurdexSettingsSection` import。
+
+#### 2.5.3 URL alias map
+
+`spa/src/components/SettingsPage.tsx`：
+
+```diff
++ const URL_ALIASES: Record<string, string> = {
++   'editor-buffers': 'editor',
++   'link-detect': 'editor',
++   'open-behavior': 'editor',
++ }
+
+  const rawUrlSection = parts[0] || null
+- // Legacy URL alias: pre-HSR the Editor Buffers tab lived at
+- // `/settings/editor-buffers`; the new Editor section id is `editor`.
+- // Bookmarks / browser history entries must keep resolving — map the old
+- // id to the new one before the normal selection logic runs.
+- const urlSection = rawUrlSection === 'editor-buffers' ? 'editor' : rawUrlSection
++ // Legacy URL aliases: keep prior `/settings/<id>` URLs resolving after
++ // sidebar restructure (editor-buffers → editor: HSR; link-detect /
++ // open-behavior → editor: PR-2 collapse).
++ const urlSection = rawUrlSection ? URL_ALIASES[rawUrlSection] ?? rawUrlSection : null
+```
+
+Self-heal 既有的 `setLocation(`/settings/${urlSection}`, { replace: true })` 路徑會自動把 URL replace 為 canonical `/settings/editor`，行為不變。
+
+### Task 2.6 — Sync modularize 實作（讓 2.3 紅 → 綠）
+
+`spa/src/lib/register-modules/index.tsx`：
+
+```diff
++ import { SyncSection } from '../../components/settings/SyncSection'  // 既有 import 不動
+
+  // 移除：
+- registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: 16, component: SyncSection })
+
+  // 新增（registerModule 區段內，最好放 quick-commands 之後）：
++ registerModule({
++   id: 'sync',
++   name: 'Sync',
++   // disableable 留空 — structural module，未來再加 disable 行為時另開 issue
++   settings: [
++     {
++       localId: 'sync',
++       scope: 'purdex',
++       order: SETTINGS_ORDER.MODULE_SYNC,
++       labelKey: 'settings.section.sync',
++       component: SyncSection,
++     },
++   ],
++ })
+```
+
+`registerSyncContributors()` call 維持目前位置不挪。
+
+### Task 2.7 — Quick Commands 頁首 + Performance Monitor / Editor 收尾 order
+
+#### 2.7.1 Quick Commands
+
+`spa/src/components/settings/QuickCommandsSettingsSection.tsx`：
+
+```diff
+  return (
+-   <div className="p-6 space-y-4">
+-     <div className="flex items-center justify-between">
+-       <h2 className="text-lg text-text-primary">{t('settings.quick_commands.title')}</h2>
++   <div>
++     <h2 className="text-lg text-text-primary">{t('settings.quick_commands.title')}</h2>
++     <p className="text-xs text-text-secondary mb-6">{t('settings.quick_commands.desc')}</p>
++     <div className="flex items-center justify-end mb-3">
+        <button ref={triggerRef} ... >
+          <Plus size={12} /> {t('settings.quick_commands.new')}
+        </button>
+      </div>
+      {/* commands list 維持不動 */}
+```
+
+`registerModule({ id: 'quick-commands', ..., order: 15 })` → `SETTINGS_ORDER.MODULE_QUICK_COMMANDS` (=12)。
+
+#### 2.7.2 Performance Monitor
+
+`spa/src/lib/register-modules/index.tsx`：
+
+```diff
+  registerModule({
+    id: 'memory-monitor',
+    ...
+    settings: [{
+      localId: 'performance-monitor',
+      scope: 'purdex',
+-     order: 11,                                          // PR-1 過渡值
++     order: SETTINGS_ORDER.MODULE_PERFORMANCE_MONITOR,   // = 13
+      labelKey: 'performance_monitor.title',
+      component: PerformanceMonitorSettingsSection,
+    }],
+  })
+```
+
+#### 2.7.3 i18n 新增 key
+
+`spa/src/locales/en-US.ts`（或對應 i18n source）：
+
+```ts
+'settings.quick_commands.desc': 'Manage commands and where they appear in the UI.',
+```
+
+`zh-TW.ts`：
+
+```ts
+'settings.quick_commands.desc': '管理快捷指令以及它們在介面中出現的位置。',
+```
+
+其他 locale 比照。
+
+### Task 2.8 — 寫 PR-2 final order 測試
+
+新增 `spa/src/lib/__tests__/settings-order-pr2.test.ts`：
+
+```ts
+// 2.8.a — listContributions('purdex') ASC 順序 = §4.1.3 final 表
+//   appearance(0), terminal(1), interface(2), [electron(5)?],
+//   module-config(10), editor(11), quick-commands(12),
+//   performance-monitor(13), sync(14),
+//   [dev-environment(20)?], [tmux-agent-monitor(21)?]
+// 2.8.b — sidebar 不含 'open-behavior' / 'link-detect' rows
+// 2.8.c — 每個 entry 用的 order 值都來自 SETTINGS_ORDER（grep editorModuleDefinition / register-modules
+//          的 order 值，確認都是 SETTINGS_ORDER.X 而非 hard-coded number）
+//          —— 用測試保證未來 reviewer 看 git diff 直接擋住
+```
+
+刪除 `settings-order-pr1.test.ts`（它的 transitional order 在 PR-2 已不適用）。
+
+### Task 2.9 — 跑全部測試 + lint + 手動驗證
+
+```bash
+cd spa && npx vitest run && pnpm run lint && pnpm run build
+```
+
+手動（mlab dev server + Air `.app`）：
+- `/settings` sidebar 順序與 §4.1.3 一致
+- 直接訪問 `/settings/link-detect` + `/settings/open-behavior` 自動 replace 為 `/settings/editor`
+- Editor 頁三段都顯示且互動正常
+- Sync row 顯示 puzzle icon
+- ModulesSwitchboard 不列 Sync
+- Quick Commands 頁首視覺與 Appearance 一致
+
+### PR-2 Acceptance（spec §5.2）
+
+- [ ] A6：sidebar 不含 open-behavior / link-detect entry
+- [ ] A7：Editor 頁三段 render + 互動 store 改變（test 2.1.c, 2.1.d 綠）
+- [ ] A8：URL alias replace（test 2.2.a-f 綠）
+- [ ] A9：Sync moduleId === 'sync' + puzzle icon（test 2.3.c, 2.3.d 綠）
+- [ ] A10：Sync 不在 switchboard（test 2.3.b 綠）
+- [ ] A11：Quick Commands h2 + p + outer 無 p-6（test 2.4.a-c 綠）
+- [ ] A12：vitest + lint + build 全綠
+
+### PR-2 Commits（建議切分）
+
+1. `test(settings): add PR-2 red tests for editor consolidation / alias / sync` (Task 2.1-2.4)
+2. `refactor(editor): collapse open-behavior + link-detect into Editor settings page` (Task 2.5)
+3. `feat(settings): URL alias map for legacy editor sub-section paths` (Task 2.5.3)
+4. `feat(sync): upgrade Sync to a structural module (non-disableable)` (Task 2.6)
+5. `style(quick-commands): unify settings page header to Appearance pattern` (Task 2.7.1)
+6. `refactor(settings): switch all module-owned orders to SETTINGS_ORDER constants` (Task 2.7.2 + 2.8)
+7. `i18n(settings): add quick_commands.desc` (Task 2.7.3)
+
+---
+
+## 收斂與後續
+
+- PR-1 + PR-2 各自跑兩輪 codex review（標準 + 三平行 adversarial）
+- 預期 review finding：PR-1 收斂快（純視覺）；PR-2 finding 會集中在 alias edge case / Sync stale persisted state — 已在 plan §2.2.e + §2.3.e 預先測過
+- Bump PR：alpha 號碼 +2（PR-1 一個、PR-2 一個），CHANGELOG 兩條
+- 不在 PR scope 但需要開 issue 追蹤：
+  - Performance Monitor 從 settings 拆出
+  - Sync 加 `disableable: true` + engine/contributors disable wiring

--- a/docs/specs/2026-05-02-settings-architecture-fix-plan.md
+++ b/docs/specs/2026-05-02-settings-architecture-fix-plan.md
@@ -103,7 +103,27 @@ export const SETTINGS_ORDER = {
 
 **Run**: `cd spa && npx vitest run lib/__tests__/settings-order-pr1` → 綠。
 
-### Task 1.4 — 改 puzzle icon 三 caller（一次到位）
+### Task 1.4 — 寫 puzzle icon 測試（先紅）
+
+新增 `spa/src/components/settings/SettingsSidebar.test.tsx`（如已存在則 append）。最穩的測法是 mock `@phosphor-icons/react` 攔截 props：
+
+```tsx
+// vi.mock('@phosphor-icons/react', () => ({
+//   PuzzlePiece: ({ weight, className, ...rest }) => (
+//     <i data-testid="puzzle" data-weight={weight} className={className} {...rest} />
+//   ),
+//   /* ...其他在這個檔案會渲染的 icon 也要 mock 成 minimal stub... */
+// }))
+//
+// 1.4.a — render SettingsSidebar 並確認 module-owned row 的 puzzle:
+//          dataset.weight === 'bold'
+//          className 不含 'rotate-[30deg]'
+// 1.4.b — render SettingsSidebar 並確認 built-in row 沒有 [data-testid="puzzle"]
+```
+
+WorkspaceSettingsPage / HostSidebar 採同樣 mock 法在它們既有的 test 檔（如有）追加同樣斷言；如測試檔不存在不新建（避免 PR-1 範圍膨脹）。
+
+### Task 1.5 — 改 puzzle icon 三 caller（讓 1.4 紅 → 綠）
 
 三個檔案，改法相同：
 
@@ -124,21 +144,7 @@ export const SETTINGS_ORDER = {
 2. `spa/src/features/workspace/components/WorkspaceSettingsPage.tsx:162-167`
 3. `spa/src/components/hosts/HostSidebar.tsx:124-129`（size={10} 不動）
 
-### Task 1.5 — 寫 puzzle icon 測試（守住三 caller）
-
-新增 `spa/src/components/settings/SettingsSidebar.test.tsx`（如已存在則 append）：
-
-```tsx
-// 1.5.a — Sidebar puzzle row className 不含 'rotate-[30deg]'
-// 1.5.b — Sidebar puzzle weight prop = 'bold'
-//   用 rendered DOM SVG 看不到 weight prop，改測 className 是 fill / bold 對應的 svg path
-//   Phosphor Icons 的 bold 與 fill 渲染 stroke-width 不同；最簡單測法是
-//   render PuzzlePiece 直接，比對 outerHTML 含 'stroke-width' (bold) 而非 'fill="currentColor"'
-//   （或更簡單：mock @phosphor-icons/react 接收 weight prop，比對 prop 值）
-// 1.5.c — module-owned row 顯示 puzzle，built-in row 不顯示
-```
-
-**WorkspaceSettingsPage.test.tsx** / **HostSidebar.test.tsx**（如已存在）追加同樣斷言。如不存在不新建（避免 PR-1 範圍膨脹）。
+如 WorkspaceSettingsPage / HostSidebar 既有 test 在 1.4 已加斷言，三個檔案要在同一 commit 改完才會全綠。
 
 ### Task 1.6 — `ModulesSwitchboardSection` 拿掉 `p-6`
 
@@ -167,13 +173,14 @@ cd spa && npx vitest run && pnpm run lint
 - [ ] A4：ModulesSwitchboard outer wrapper 無 `p-6`
 - [ ] A5：vitest 全綠
 
-### PR-1 Commits（建議切分）
+### PR-1 Commits（每個 commit 都可獨立通過 CI）
 
-1. `feat(settings): introduce SETTINGS_ORDER constants` (Task 1.1)
-2. `test(settings): add PR-1 sidebar order assertions (red)` (Task 1.2)
-3. `refactor(settings): reorder sidebar entries per PR-1 transitional table` (Task 1.3)
-4. `style(settings): puzzle icon → bold weight, no rotation` (Task 1.4 + 1.5)
-5. `refactor(settings): drop double p-6 from ModulesSwitchboardSection` (Task 1.6)
+每個 commit 內先寫紅測試（local 確認失敗），再加實作讓綠 — 同 commit 提交以維持 CI 綠。
+
+1. `feat(settings): introduce SETTINGS_ORDER constants` (Task 1.1，純常數新增，無測試)
+2. `refactor(settings): reorder sidebar to PR-1 transitional table + add order assertions` (Task 1.2 + 1.3 同 commit：紅測試 + register-modules order 改動同時提交)
+3. `style(settings): puzzle icon bold + no rotation, with three-caller assertions` (Task 1.4 + 1.5 同 commit：mock-prop 紅測試 + 三 caller icon 改動同時提交)
+4. `refactor(settings): drop double p-6 from ModulesSwitchboardSection` (Task 1.6)
 
 ---
 
@@ -197,20 +204,30 @@ cd spa && npx vitest run && pnpm run lint
 //   （用 within(<screen text=link_detect.title 的 section>) 鎖定範圍避免誤點 sidebar）
 // 2.1.e — 父頁無重複 h3（h3 數 = 2）
 // 2.1.f — Editor 段落內無多餘 outer p-6（render 後 outer div 的 className 不含 'p-6'）
+// 2.1.g — workspace / host scope 不回歸：
+//   editorModuleDefinition.settings 仍含 { localId: 'workspace-home-path', scope: 'workspace' }
+//                                      + { localId: 'host-home-path', scope: 'host' }
+//   purdex scope 只剩 { localId: 'editor' }
 ```
 
 ### Task 2.2 — 寫 URL alias 測試（先紅）
 
-新增 `spa/src/components/SettingsPage.test.tsx`（如已存在則 append）。Setup：mock `wouter` `useLocation` 起點為 `/settings/link-detect`，再以 `useLocation` setter 觀察 replace 後路徑。
+新增 `spa/src/components/SettingsPage.test.tsx`（如已存在則 append）。每個 case `beforeEach` 必須：
+- `resetLastSection()`（avoid SettingsPage module-level `lastSection` 跨測試污染）
+- 以 `memoryLocation`（wouter `wouter/memory-location`）注入 wouter Router，初始 path 設為該 case 的起點
+- 用 isolated registry：beforeEach 跑 `resetSettingsContributionsForHmr()` + 重新 register 一份穩定 contribution 集合（至少含 `editor` 與 `appearance`，appearance order=0 為 known first selectable）
 
 ```tsx
-// 2.2.a — start at /settings/link-detect → setLocation called with '/settings/editor', { replace: true }
+// 2.2.a — start at /settings/link-detect → location 在 mount 後 effects 跑完變成 '/settings/editor'
 // 2.2.b — start at /settings/open-behavior → 同上
-// 2.2.c — start at /settings/editor-buffers → 維持既有 alias 行為（existing test 保留）
-// 2.2.d — start at /settings/editor → 不 replace（identity，避免無限循環）
-// 2.2.e — start at /settings/link-detect 時 Editor module 被 disable（mock useModuleEnabledStore）
-//          → 不 mount Editor，self-heal 走 default 路徑（不要求 hard 404）
-// 2.2.f — alias map identity case: rawUrlSection === canonical 不重複 setLocation
+// 2.2.c — start at /settings/editor-buffers → 維持既有 alias 行為（既有測試保留）
+// 2.2.d — start at /settings/editor → location 維持不變（identity，避免無限循環 / 多餘 history entry）
+// 2.2.e — start at /settings/link-detect 時 alias canonical target ('editor') 不 selectable（mock
+//          useModuleEnabledStore 讓 editor module disabled，dispatch 後 listContributions 不含 'editor'）
+//          → location 自我修復到 firstSelectable（在 fixture 下 = 'appearance' = order 0）
+//            而非停在 '/settings/editor' 或 '/settings/link-detect'。
+// 2.2.f — alias map identity case：rawUrlSection === canonical（editor）不重複觸發 setLocation
+//          （spy useLocation setter 確認 mount + 後續 effect 不對同 path 多次 replace）
 ```
 
 ### Task 2.3 — 寫 Sync modularize 測試（先紅）
@@ -242,9 +259,29 @@ cd spa && npx vitest run && pnpm run lint
 // 2.4.e — commands list 既有功能（edit / delete）仍可用（既有測試保留）
 ```
 
-### Task 2.5 — Editor 三頁合一實作（讓 2.1 / 2.2 紅 → 綠）
+### Task 2.5 — 寫 PR-2 final order assertion（先紅）
 
-#### 2.5.1 重組 `EditorPurdexSettingsSection`
+新增 `spa/src/lib/__tests__/settings-order-pr2.test.ts`（取代 PR-1 的 transitional test）：
+
+```ts
+// 2.5.a — listContributions('purdex') ASC 順序 = §4.1.3 final 表
+//   appearance(0), terminal(1), interface(2), [electron(5)?],
+//   module-config(10), editor(11), quick-commands(12),
+//   performance-monitor(13), sync(14),
+//   [dev-environment(20)?], [tmux-agent-monitor(21)?]
+// 2.5.b — sidebar 不含 'open-behavior' / 'link-detect' rows
+// 2.5.c — registerBuiltinModules 後每個 settings entry 的 order 值都來自 SETTINGS_ORDER
+//          —— 範圍限定：只看 register-modules/index.tsx + editor-module.tsx 的 settings declaration
+//             區塊（new-tab provider / interface subsection 等不在這條規則內）。
+//             實作上：對 listContributions('purdex') 的每筆 entry 比對其 order 值落在
+//             Object.values(SETTINGS_ORDER) 集合內，若有 hard-code（不等於任一常數）則 fail。
+```
+
+PR-2 task 2.1-2.5 全部寫完先確認紅。`settings-order-pr1.test.ts` 在 task 2.10 PR-2 final order 全綠之後刪除（先有 final test 綠、再刪 transitional）。
+
+### Task 2.6 — Editor 三頁合一實作（讓 2.1 / 2.2 / 2.5 紅 → 部分綠）
+
+#### 2.6.1 重組 `EditorPurdexSettingsSection`
 
 `spa/src/components/settings/EditorPurdexSettingsSection.tsx`：
 
@@ -273,7 +310,7 @@ export function EditorPurdexSettingsSection(_props: Props) {
 }
 ```
 
-#### 2.5.2 縮減 `editorModuleDefinition.settings`
+#### 2.6.2 縮減 `editorModuleDefinition.settings`
 
 `spa/src/lib/register-modules/editor-module.tsx`：
 
@@ -308,7 +345,7 @@ export function EditorPurdexSettingsSection(_props: Props) {
 
 `EditorOpenBehaviorSection` / `EditorLinkDetectionSection` 兩個 component 不刪、不重寫；只是 register-modules 不再單獨註冊，由 `EditorPurdexSettingsSection` import。
 
-#### 2.5.3 URL alias map
+#### 2.6.3 URL alias map
 
 `spa/src/components/SettingsPage.tsx`：
 
@@ -333,7 +370,7 @@ export function EditorPurdexSettingsSection(_props: Props) {
 
 Self-heal 既有的 `setLocation(`/settings/${urlSection}`, { replace: true })` 路徑會自動把 URL replace 為 canonical `/settings/editor`，行為不變。
 
-### Task 2.6 — Sync modularize 實作（讓 2.3 紅 → 綠）
+### Task 2.7 — Sync modularize 實作（讓 2.3 紅 → 綠）
 
 `spa/src/lib/register-modules/index.tsx`：
 
@@ -362,9 +399,9 @@ Self-heal 既有的 `setLocation(`/settings/${urlSection}`, { replace: true })` 
 
 `registerSyncContributors()` call 維持目前位置不挪。
 
-### Task 2.7 — Quick Commands 頁首 + Performance Monitor / Editor 收尾 order
+### Task 2.8 — Quick Commands 頁首 + Performance Monitor / Editor 收尾 order
 
-#### 2.7.1 Quick Commands
+#### 2.8.1 Quick Commands
 
 `spa/src/components/settings/QuickCommandsSettingsSection.tsx`：
 
@@ -386,7 +423,7 @@ Self-heal 既有的 `setLocation(`/settings/${urlSection}`, { replace: true })` 
 
 `registerModule({ id: 'quick-commands', ..., order: 15 })` → `SETTINGS_ORDER.MODULE_QUICK_COMMANDS` (=12)。
 
-#### 2.7.2 Performance Monitor
+#### 2.8.2 Performance Monitor
 
 `spa/src/lib/register-modules/index.tsx`：
 
@@ -405,7 +442,7 @@ Self-heal 既有的 `setLocation(`/settings/${urlSection}`, { replace: true })` 
   })
 ```
 
-#### 2.7.3 i18n 新增 key
+#### 2.8.3 i18n 新增 key
 
 `spa/src/locales/en-US.ts`（或對應 i18n source）：
 
@@ -421,25 +458,11 @@ Self-heal 既有的 `setLocation(`/settings/${urlSection}`, { replace: true })` 
 
 其他 locale 比照。
 
-### Task 2.8 — 寫 PR-2 final order 測試
+### Task 2.9 — 刪除 PR-1 transitional order 測試
 
-新增 `spa/src/lib/__tests__/settings-order-pr2.test.ts`：
+`settings-order-pr2.test.ts` 已在 task 2.5 寫紅、task 2.6-2.8 實作後綠。確認綠後刪除 `spa/src/lib/__tests__/settings-order-pr1.test.ts`（transitional order 在 PR-2 final 後不再適用）。
 
-```ts
-// 2.8.a — listContributions('purdex') ASC 順序 = §4.1.3 final 表
-//   appearance(0), terminal(1), interface(2), [electron(5)?],
-//   module-config(10), editor(11), quick-commands(12),
-//   performance-monitor(13), sync(14),
-//   [dev-environment(20)?], [tmux-agent-monitor(21)?]
-// 2.8.b — sidebar 不含 'open-behavior' / 'link-detect' rows
-// 2.8.c — 每個 entry 用的 order 值都來自 SETTINGS_ORDER（grep editorModuleDefinition / register-modules
-//          的 order 值，確認都是 SETTINGS_ORDER.X 而非 hard-coded number）
-//          —— 用測試保證未來 reviewer 看 git diff 直接擋住
-```
-
-刪除 `settings-order-pr1.test.ts`（它的 transitional order 在 PR-2 已不適用）。
-
-### Task 2.9 — 跑全部測試 + lint + 手動驗證
+### Task 2.10 — 跑全部測試 + lint + 手動驗證
 
 ```bash
 cd spa && npx vitest run && pnpm run lint && pnpm run build
@@ -448,6 +471,8 @@ cd spa && npx vitest run && pnpm run lint && pnpm run build
 手動（mlab dev server + Air `.app`）：
 - `/settings` sidebar 順序與 §4.1.3 一致
 - 直接訪問 `/settings/link-detect` + `/settings/open-behavior` 自動 replace 為 `/settings/editor`
+- 直接訪問 `/settings/sync`（升格 module 後 deep link 仍可達 SyncSection）
+- Editor module 在 Modules switchboard 改成 disabled → 訪問 `/settings/link-detect` 不 mount Editor、URL self-heal 到第一個 selectable section
 - Editor 頁三段都顯示且互動正常
 - Sync row 顯示 puzzle icon
 - ModulesSwitchboard 不列 Sync
@@ -463,15 +488,15 @@ cd spa && npx vitest run && pnpm run lint && pnpm run build
 - [ ] A11：Quick Commands h2 + p + outer 無 p-6（test 2.4.a-c 綠）
 - [ ] A12：vitest + lint + build 全綠
 
-### PR-2 Commits（建議切分）
+### PR-2 Commits（每個 commit 都可獨立通過 CI — slice 內 red+green 同 commit）
 
-1. `test(settings): add PR-2 red tests for editor consolidation / alias / sync` (Task 2.1-2.4)
-2. `refactor(editor): collapse open-behavior + link-detect into Editor settings page` (Task 2.5)
-3. `feat(settings): URL alias map for legacy editor sub-section paths` (Task 2.5.3)
-4. `feat(sync): upgrade Sync to a structural module (non-disableable)` (Task 2.6)
-5. `style(quick-commands): unify settings page header to Appearance pattern` (Task 2.7.1)
-6. `refactor(settings): switch all module-owned orders to SETTINGS_ORDER constants` (Task 2.7.2 + 2.8)
-7. `i18n(settings): add quick_commands.desc` (Task 2.7.3)
+1. `feat(editor): consolidate open-behavior + link-detect into Editor settings page` (Task 2.1 紅 + Task 2.6.1/2.6.2 實作 + Task 2.9 刪 PR-1 test 同 commit；測試 + 實作不分開)
+2. `feat(settings): URL alias map for legacy editor sub-section paths` (Task 2.2 紅 + Task 2.6.3 實作同 commit)
+3. `feat(sync): upgrade Sync to a structural module (non-disableable)` (Task 2.3 紅 + Task 2.7 實作同 commit)
+4. `style(quick-commands): unify settings page header to Appearance pattern + add desc i18n` (Task 2.4 紅 + Task 2.8.1/2.8.3 實作同 commit)
+5. `refactor(settings): switch all module-owned orders to SETTINGS_ORDER constants` (Task 2.5 紅 + Task 2.8.2 實作同 commit；final order test 在這個 commit 才綠 — 因為要等 perf-monitor / quick-commands / editor / sync 都改完才會 final)
+
+⚠️ 順序很重要：commit 5（final order）必須是最後一個，因為它要等前 4 個 commit 全到位後才會綠。如要更穩，可在 commit 1-4 內把 PR-1 transitional test 暫時排除（skip 或刪）；然後 commit 5 一起恢復正確 final 行為。或乾脆 commit 1 開頭就刪 PR-1 transitional，PR-1 與 PR-2 一起共用 final order test（PR-1 在 PR merge 前已綠，PR-2 開始時 transitional test 即已落主幹）。實作時擇一即可。
 
 ---
 

--- a/docs/specs/2026-05-02-settings-architecture-fix-plan.md
+++ b/docs/specs/2026-05-02-settings-architecture-fix-plan.md
@@ -41,12 +41,11 @@ export const SETTINGS_ORDER = {
 新增 `spa/src/lib/__tests__/settings-order-pr1.test.ts`：
 
 ```ts
-// 1.2.a — listContributions('purdex') after registerBuiltinModules 順序
-//   expected (ASC): appearance(0), terminal(1), interface(2),
-//                   [electron(5)?],  ← caps 條件可 mock 成 true
-//                   performance-monitor(11), open-behavior(12),
-//                   link-detect(13), editor(14), quick-commands(15),
-//                   module-config(10) [插在 interface 與 perf-monitor 之間]
+// 1.2.a — listContributions('purdex') + listSettingsSections() 合併後 ASC：
+//   appearance(0), terminal(1), interface(2), [electron(5)?],
+//   module-config(10), performance-monitor(11), open-behavior(12),
+//   link-detect(13), editor(14), quick-commands(15), sync(16),
+//   [dev-environment(20)?], [tmux-agent-monitor(21)?]
 //   ⚠️ 用 listContributions + registerSettingsSection 兩個 source 合併斷言
 //
 // 1.2.b — module-config 必須出現在所有 module-owned (puzzle) 上方:
@@ -215,7 +214,9 @@ cd spa && npx vitest run && pnpm run lint
 新增 `spa/src/components/SettingsPage.test.tsx`（如已存在則 append）。每個 case `beforeEach` 必須：
 - `resetLastSection()`（avoid SettingsPage module-level `lastSection` 跨測試污染）
 - 以 `memoryLocation`（wouter `wouter/memory-location`）注入 wouter Router，初始 path 設為該 case 的起點
-- 用 isolated registry：beforeEach 跑 `resetSettingsContributionsForHmr()` + 重新 register 一份穩定 contribution 集合（至少含 `editor` 與 `appearance`，appearance order=0 為 known first selectable）
+- 用 isolated registry：beforeEach 跑 `resetSettingsContributionsForHmr()` + 重新 register 一份穩定 fixture：
+  - `appearance` 用 legacy `registerSettingsSection({ id: 'appearance', order: 0, ... })` — 永遠 selectable，當 firstSelectable fallback
+  - `editor` **必須**用 `registerModule({ id: 'editor', disableable: true, settings: [{ localId: 'editor', scope: 'purdex', order: 11, ... }] })` 註冊；否則 2.2.e 的 `useModuleEnabledStore` mock 對 legacy 註冊路徑無效，editor 不會從 listContributions 移除
 
 ```tsx
 // 2.2.a — start at /settings/link-detect → location 在 mount 後 effects 跑完變成 '/settings/editor'
@@ -270,14 +271,18 @@ cd spa && npx vitest run && pnpm run lint
 //   performance-monitor(13), sync(14),
 //   [dev-environment(20)?], [tmux-agent-monitor(21)?]
 // 2.5.b — sidebar 不含 'open-behavior' / 'link-detect' rows
-// 2.5.c — registerBuiltinModules 後每個 settings entry 的 order 值都來自 SETTINGS_ORDER
-//          —— 範圍限定：只看 register-modules/index.tsx + editor-module.tsx 的 settings declaration
-//             區塊（new-tab provider / interface subsection 等不在這條規則內）。
-//             實作上：對 listContributions('purdex') 的每筆 entry 比對其 order 值落在
-//             Object.values(SETTINGS_ORDER) 集合內，若有 hard-code（不等於任一常數）則 fail。
+// 2.5.c — listContributions('purdex') 每筆 entry 的 order 值都落在
+//          `Object.values(SETTINGS_ORDER)` 集合內（防止非法 / 未經規劃的 order）。
+//          ⚠️ 限制：runtime 拿不到「來源是常數還是 hard-code 數字」的資訊，所以這條
+//          只能擋「order 值非法」，擋不到「值碰巧等於常數但來自 hard-code」。後者由
+//          code review + commit 訊息守住，不在 test 範圍。
 ```
 
-PR-2 task 2.1-2.5 全部寫完先確認紅。`settings-order-pr1.test.ts` 在 task 2.10 PR-2 final order 全綠之後刪除（先有 final test 綠、再刪 transitional）。
+PR-2 commit 流程明確一條路徑：
+- commit 1（Editor 收編）的開頭就 `git rm` 掉 `spa/src/lib/__tests__/settings-order-pr1.test.ts`，避免 commit 1-4 過程中 transitional test 因為某些 entry 已改、某些尚未改而紅
+- `settings-order-pr2.test.ts`（Task 2.5）在 commit 5（最後一個 commit）才**新增**並讓綠 — 此時 perf-monitor / quick-commands / editor / sync 都已改完
+- commit 1-4 期間 sidebar order 已經沒有任何專屬 test 守住（因 PR-1 transitional 已刪、PR-2 final 還沒加），這是預期窗口
+- 其他 PR-2 紅測試（Task 2.1 / 2.2 / 2.3 / 2.4）對應的實作落在同一個 commit 內，commit 1-4 個別都綠
 
 ### Task 2.6 — Editor 三頁合一實作（讓 2.1 / 2.2 / 2.5 紅 → 部分綠）
 
@@ -444,23 +449,23 @@ Self-heal 既有的 `setLocation(`/settings/${urlSection}`, { replace: true })` 
 
 #### 2.8.3 i18n 新增 key
 
-`spa/src/locales/en-US.ts`（或對應 i18n source）：
+`spa/src/locales/en.json`：
 
-```ts
-'settings.quick_commands.desc': 'Manage commands and where they appear in the UI.',
+```json
+"settings.quick_commands.desc": "Manage commands and where they appear in the UI."
 ```
 
-`zh-TW.ts`：
+`spa/src/locales/zh-TW.json`：
 
-```ts
-'settings.quick_commands.desc': '管理快捷指令以及它們在介面中出現的位置。',
+```json
+"settings.quick_commands.desc": "管理快捷指令以及它們在介面中出現的位置。"
 ```
 
-其他 locale 比照。
+其他 locale（如有）比照。
 
-### Task 2.9 — 刪除 PR-1 transitional order 測試
+### Task 2.9 — Sanity check（沒有專用實作步驟）
 
-`settings-order-pr2.test.ts` 已在 task 2.5 寫紅、task 2.6-2.8 實作後綠。確認綠後刪除 `spa/src/lib/__tests__/settings-order-pr1.test.ts`（transitional order 在 PR-2 final 後不再適用）。
+刪除動作已在 commit 1 做，final order test 在 commit 5 引入。本 task 只是 commit 流程上的 checkpoint：在開 PR 前確認 `settings-order-pr1.test.ts` 不存在、`settings-order-pr2.test.ts` 綠。
 
 ### Task 2.10 — 跑全部測試 + lint + 手動驗證
 
@@ -494,9 +499,12 @@ cd spa && npx vitest run && pnpm run lint && pnpm run build
 2. `feat(settings): URL alias map for legacy editor sub-section paths` (Task 2.2 紅 + Task 2.6.3 實作同 commit)
 3. `feat(sync): upgrade Sync to a structural module (non-disableable)` (Task 2.3 紅 + Task 2.7 實作同 commit)
 4. `style(quick-commands): unify settings page header to Appearance pattern + add desc i18n` (Task 2.4 紅 + Task 2.8.1/2.8.3 實作同 commit)
-5. `refactor(settings): switch all module-owned orders to SETTINGS_ORDER constants` (Task 2.5 紅 + Task 2.8.2 實作同 commit；final order test 在這個 commit 才綠 — 因為要等 perf-monitor / quick-commands / editor / sync 都改完才會 final)
+5. `refactor(settings): switch all module-owned orders to SETTINGS_ORDER constants + add PR-2 final order test` (Task 2.8.2 實作 + Task 2.5 final order test 在這個 commit 內**新增**並讓綠)
 
-⚠️ 順序很重要：commit 5（final order）必須是最後一個，因為它要等前 4 個 commit 全到位後才會綠。如要更穩，可在 commit 1-4 內把 PR-1 transitional test 暫時排除（skip 或刪）；然後 commit 5 一起恢復正確 final 行為。或乾脆 commit 1 開頭就刪 PR-1 transitional，PR-1 與 PR-2 一起共用 final order test（PR-1 在 PR merge 前已綠，PR-2 開始時 transitional test 即已落主幹）。實作時擇一即可。
+關鍵點：
+- commit 1 開頭就 `git rm spa/src/lib/__tests__/settings-order-pr1.test.ts` — transitional test 在 PR-2 一啟動就刪
+- final order test 直到 commit 5 才**新增**（不是在 commit 1-4 中先以紅狀態存在）
+- commit 1-4 期間沒有 sidebar order 專屬 test 守護是預期窗口；其他 PR-2 紅測試（Task 2.1/2.2/2.3/2.4）對應實作落在同一 commit 內，個別 commit 都綠
 
 ---
 

--- a/docs/specs/2026-05-02-settings-architecture-fix-spec.md
+++ b/docs/specs/2026-05-02-settings-architecture-fix-spec.md
@@ -356,12 +356,12 @@ registerModule({
 範圍（純視覺、無行為改變）：
 
 1. Puzzle icon：rotate-0 + weight=bold（含 spa 內所有 `<PuzzlePiece>` 用法）
-2. Sidebar order 重排：electron 5（不動）、module-config 10、editor 11、quick-commands 12、performance-monitor 13、dev-environment 20（不動）、tmux-agent-monitor 21（不動）。Sync 暫留 11（PR-2 才升格 + 改 14）
+2. Sidebar order 重排為 §4.1.4 PR-1 transitional table（module-config 10、performance-monitor 11、open-behavior 12、link-detect 13、editor 14、quick-commands 15、sync 16；其餘不動）。**注意**：本表是過渡值；PR-2 才會把 Editor 三 entry 收編 + Sync 升格成 module，並切到 §4.1.3 final 表
 3. Padding 一律拿掉 `p-X` outer wrapper：`ModulesSwitchboardSection` / 其他帶 padding 的 module section
 4. **不**碰 Editor 三頁、不碰 Sync 註冊方式、不碰 Quick Commands 頁首
 
 Acceptance：
-- A1：Sidebar visual order = §4.1 表（Sync 仍在 11）
+- A1：Sidebar visual order = §4.1.4 PR-1 transitional 表
 - A2：SettingsSidebar / WorkspaceSettingsPage / HostSidebar 三處 puzzle icon 皆為直立（無 `rotate`）+ bold weight
 - A3：所有 sidebar URL（既有 + new）正常解析
 - A4：Settings 內容不雙 pad（screenshot 比較或 test 斷言 outer 無 `p-6`）

--- a/docs/specs/2026-05-02-settings-architecture-fix-spec.md
+++ b/docs/specs/2026-05-02-settings-architecture-fix-spec.md
@@ -97,7 +97,7 @@
 
 ### 4.1 Sidebar 順序
 
-設定新的 order 區段（保留 0-29 的數字空間）：
+#### 4.1.1 Order band 設計
 
 | 區段 | 範圍 | 用途 |
 |---|---|---|
@@ -105,55 +105,119 @@
 | Top conditional built-in | 5 – 9 | Electron |
 | Modules switchboard | 10 | `module-config` |
 | Module-owned | 11 – 19 | Editor / Quick Commands / Performance Monitor / Sync |
-| Tail built-in | 20 – 29 | Sync 升格後保留：Dev Environment / Tmux Agent Monitor |
+| Tail built-in | 20 – 29 | Dev Environment / Tmux Agent Monitor |
 
-新 order 表：
+#### 4.1.2 集中常數（PR-1 新增）
 
-| id | order | source | label |
+新增 `spa/src/lib/settings-order.ts`：
+
+```ts
+export const SETTINGS_ORDER = {
+  // Top built-in
+  APPEARANCE: 0,
+  TERMINAL: 1,
+  INTERFACE: 2,
+  // Top conditional
+  ELECTRON: 5,
+  // Modules switchboard (single, top of modules group)
+  MODULE_CONFIG: 10,
+  // Module-owned (PR-2 final state — PR-1 uses transitional values per §4.1.4)
+  MODULE_EDITOR: 11,
+  MODULE_QUICK_COMMANDS: 12,
+  MODULE_PERFORMANCE_MONITOR: 13,
+  MODULE_SYNC: 14,
+  // Tail built-in
+  DEV_ENVIRONMENT: 20,
+  TMUX_AGENT_MONITOR: 21,
+} as const
+```
+
+`register-modules/index.tsx` + `editor-module.tsx` + 任何新增 settings 註冊一律從這個檔案 import，禁止 hard-code 數字。Linter / review 守住（spec acceptance A_C1）。
+
+#### 4.1.3 PR-2 final order 表
+
+| id | order（常數） | source | label |
 |---|---|---|---|
-| appearance | 0 | built-in | settings.section.appearance |
-| terminal | 1 | built-in | settings.section.terminal |
-| interface | 2 | built-in | settings.section.interface |
-| electron | 5 | built-in（條件） | settings.section.electron |
-| module-config | 10 | built-in | settings.section.modules |
-| editor | 11 | module-owned | settings.section.editor |
-| quick-commands | 12 | module-owned | settings.section.quick_commands |
-| performance-monitor | 13 | module-owned | performance_monitor.title |
-| sync | 14 | module-owned（升格） | settings.section.sync |
-| dev-environment | 20 | built-in（dev） | settings.section.dev_environment |
-| tmux-agent-monitor | 21 | built-in（dev） | settings.section.tmux_agent_monitor |
+| appearance | 0 (`APPEARANCE`) | built-in | settings.section.appearance |
+| terminal | 1 (`TERMINAL`) | built-in | settings.section.terminal |
+| interface | 2 (`INTERFACE`) | built-in | settings.section.interface |
+| electron | 5 (`ELECTRON`) | built-in（條件） | settings.section.electron |
+| module-config | 10 (`MODULE_CONFIG`) | built-in | settings.section.modules |
+| editor | 11 (`MODULE_EDITOR`) | module-owned | settings.section.editor |
+| quick-commands | 12 (`MODULE_QUICK_COMMANDS`) | module-owned | settings.section.quick_commands |
+| performance-monitor | 13 (`MODULE_PERFORMANCE_MONITOR`) | module-owned | performance_monitor.title |
+| sync | 14 (`MODULE_SYNC`) | module-owned（升格） | settings.section.sync |
+| dev-environment | 20 (`DEV_ENVIRONMENT`) | built-in（dev） | settings.section.dev_environment |
+| tmux-agent-monitor | 21 (`TMUX_AGENT_MONITOR`) | built-in（dev） | settings.section.tmux_agent_monitor |
 
 說明：
-- module-owned 區段內部排序按 alpha：Editor (11) → Quick Commands (12) → Performance Monitor (13) → Sync (14)；任何 listing 沿用 `order ASC`，sidebar 與 switchboard 一致
+- module-owned 內部排序：Editor (11) → Quick Commands (12) → Performance Monitor (13) → Sync (14)
 - `link-detect`、`open-behavior` 兩個 entry 不再出現在 sidebar（從 `editorModuleDefinition.settings` 移除）
+
+#### 4.1.4 PR-1 過渡 order 表
+
+PR-1 不收編 Editor，因此 `open-behavior` / `link-detect` / `editor` 仍是三個獨立 entry。為了讓 `module-config` 在 PR-1 結束時就落在所有 module-owned 之上、避免 final-state 與過渡 state 互相打架，PR-1 對所有 module-owned entry 各加固定 offset（+10）後排：
+
+| id | PR-1 order | 變化 | source |
+|---|---|---|---|
+| appearance | 0 | 不動 | built-in |
+| terminal | 1 | 不動 | built-in |
+| interface | 2 | 不動 | built-in |
+| electron | 5 | 不動 | built-in（條件） |
+| **module-config** | **10** | 8 → 10（解 collision） | built-in |
+| **performance-monitor** | **11** | 6 → 11 | module-owned |
+| **open-behavior** | **12** | 7 → 12 | module-owned |
+| **link-detect** | **13** | 8 → 13 | module-owned |
+| **editor** | **14** | 9 → 14 | module-owned |
+| **quick-commands** | **15** | 10 → 15 | module-owned |
+| **sync** | **16** | 11 → 16（仍 built-in） | built-in（PR-2 才升格） |
+| dev-environment | 20 | 不動 | built-in（dev） |
+| tmux-agent-monitor | 21 | 不動 | built-in（dev） |
+
+PR-1 對應的常數 import 是「過渡值」— 為了避免 PR-1 / PR-2 兩次改 SETTINGS_ORDER 的可讀性混亂，採用以下做法：
+- `SETTINGS_ORDER` 一次定義成 PR-2 final 值（§4.1.2）
+- PR-1 只把 `module-config` 的 `order` 從 8 改成 `SETTINGS_ORDER.MODULE_CONFIG`（=10）
+- PR-1 對其他 module-owned 沿用 6/7/8/9/10/11 的舊值（不挪）
+- 結果 PR-1 sidebar：`appearance(0) → terminal(1) → interface(2) → electron(5) → performance-monitor(6) → open-behavior(7) → link-detect(8) → editor(9) → quick-commands(10) → module-config(10, alphabetically 同數時不保證；改用 11 確保排在後）`
+
+⚠️ **Re-evaluate**: order 8/8 collision 與「module-config 排到 modules 群組頂端」這兩個要求只有 PR-1 動更多 entry 才能同時滿足。下兩個方案二選一：
+
+**方案 A（PR-1 完整重排，PR-2 只動收編）— 推薦**
+- PR-1 直接套 §4.1.4 過渡 order 表（performance-monitor / open-behavior / link-detect / editor / quick-commands / sync 都改 order）
+- PR-2 只改：editor 14 → 11、移除 open-behavior + link-detect、quick-commands 15 → 12、performance-monitor 11 → 13、sync 16 → 14（升格時改 source）
+- 優點：使用者在 PR-1 結束時就看到「modules 群組成形」；PR-2 是純結構變更，不再動順序
+- 缺點：PR-1 改的 order 比較多
+
+**方案 B（PR-1 最小，PR-2 完整重排）**
+- PR-1 只改 `module-config` 8 → 10（解 collision），sidebar 仍混雜
+- PR-2 同時做 Editor 收編 + Sync 升格 + 完整 order 重排
+- 優點：PR-1 純粹 cosmetic
+- 缺點：PR-1 結束時 sidebar 仍亂；PR-2 變動範圍變大
+
+**選方案 A**。PR-1 的「視覺/順序」名字本來就涵蓋順序重排；PR-2 聚焦「結構變更」更乾淨。
 
 ### 4.2 Editor 三頁合一
 
 #### 4.2.1 `EditorPurdexSettingsSection` 重組
 
-新結構（單一 page，三段落）：
+`EditorOpenBehaviorSection` 與 `EditorLinkDetectionSection` 既有實作已自帶 `<h3>` + 段落 desc + `SettingItem` 序列（page 與 embedded 兩種用途都已適用），父頁直接 import 不再外加 heading：
 
 ```tsx
 <div>
-  <h2>{t('settings.section.editor')}</h2>          // sidebar 同名
+  <h2>{t('settings.section.editor')}</h2>
   <p>{t('settings.editor.desc')}</p>
 
-  {/* Section 1：Monaco 偏好 — 既有 SettingItem 序列 */}
+  {/* Monaco 偏好 — 既有 SettingItem 序列，無 h3 */}
   <SettingItem ... />  // tab_size / insert_spaces / word_wrap / line_numbers / minimap / font_size
 
-  {/* Section 2：Open Behavior */}
-  <h3>{t('settings.editor.open_behavior.title')}</h3>
-  <EditorOpenBehaviorSection />
-
-  {/* Section 3：Link Detection */}
-  <h3>{t('settings.editor.link_detect.title')}</h3>
-  <EditorLinkDetectionSection />
+  <EditorOpenBehaviorSection />   {/* 內含 h3 + SettingItems */}
+  <EditorLinkDetectionSection />  {/* 內含 h3 + SettingItems */}
 
   <p>{t('settings.editor.tiptap_note')}</p>
 </div>
 ```
 
-H3 標題樣式：`text-base text-text-primary mt-8 mb-2`（沿用 Appearance / Terminal 內部分隔的視覺節奏）。`<EditorOpenBehaviorSection />` 與 `<EditorLinkDetectionSection />` 內部 outer `<div>` / `<h2>` 由各自 component 拿掉（如有），確保段落 heading 由父頁負責。
+兩個 child component 不重寫；只是從 sidebar 直接 mount 改成 EditorPurdexSettingsSection import。具體 outer wrapper / 重複 heading 風險的細節由 plan 階段處理。
 
 #### 4.2.2 `editorModuleDefinition.settings` 縮減
 
@@ -312,12 +376,12 @@ Acceptance：
 3. `SettingsPage` URL alias map 擴充
 4. Sync `registerSettingsSection` → `registerModule`
 5. Quick Commands 頁首改 `<h2>` + `<p>`
-6. 新增 i18n：`settings.quick_commands.desc`
+6. 新增 i18n：`settings.quick_commands.desc`（既有 `settings.editor.link_detect.title` 與 `settings.editor.open_behavior.title` 兩個 key 不動，從 sidebar label 用途自然轉成 section heading 用途）
 
 Acceptance：
 - A6：`/settings` sidebar 只剩一個 Editor entry（`Open Behavior`、`Link Detection` 不在 sidebar）
 - A7：Editor 頁內可看到三段：Monaco 偏好 / Open Behavior / Link Detection；功能行為與舊頁等價（既有測試 pass）
-- A8：`/settings/link-detect` + `/settings/open-behavior` 開啟後 URL 自動 replace 為 `/settings/editor` 並 mount Editor 頁
+- A8：`/settings/link-detect` + `/settings/open-behavior` 在 Editor module 啟用時自動 replace 為 `/settings/editor` 並 mount Editor 頁；Editor module 被 disable 時走既有 self-heal（不要求 hard 404）
 - A9：`/settings/sync` 開啟後仍 mount SyncSection；sidebar 上 Sync row 顯示 puzzle icon
 - A10：Sync 在 ModulesSwitchboard 中**不**出現（disableable !== true）
 - A11：Quick Commands 頁首結構與 Appearance / Terminal 視覺一致（h2 + p + 主要內容）

--- a/docs/specs/2026-05-02-settings-architecture-fix-spec.md
+++ b/docs/specs/2026-05-02-settings-architecture-fix-spec.md
@@ -1,0 +1,373 @@
+# Settings 架構修正 Spec
+
+- **Date**: 2026-05-02
+- **Worktree**: `.claude/worktrees/settings-architecture-fix`（branch `worktree-settings-architecture-fix`）
+- **Context**: alpha.284 後 Settings sidebar 累積成不一致狀態：（1）Modules switchboard（`module-config`）夾在 `link-detect (8)` 與 `editor (9)` 之間（同 order 8 衝突），語意上應是 modules 群組的標頭；（2）Editor module 把 Monaco 偏好 / Open Behavior / Link Detection 拆成三個獨立 sidebar entry，與「一個 module 對應一頁」的 mental model 不符；（3）Sync 功能自帶 engine + 7 個 contributors + store，自成一個邏輯單元，但仍以 built-in section 註冊，與其他 module（Quick Commands、Editor）的 sidebar 視覺 / 群組分類不一致；（4）puzzle icon 旋轉 30° + fill weight 視覺較雜，要轉正 + bold；（5）module-owned section 之間的 padding 寫法不一（`p-6 space-y-X` vs 無 padding）。
+
+## 1. 背景
+
+### 1.1 alpha.284 sidebar 現況（按實際 order 排序）
+
+| order | id | label | source | 備註 |
+|---|---|---|---|---|
+| 0 | appearance | Appearance | built-in（`registerSettingsSection`） | |
+| 1 | terminal | Terminal | built-in | |
+| 2 | interface | Interface | built-in | 自帶 subsections |
+| 5 | electron | Desktop App | built-in（條件） | `caps.canSystemTray` |
+| 6 | performance-monitor | Performance Monitor | module-owned（`memory-monitor`）🧩 | |
+| 7 | open-behavior | Open Behavior | module-owned（`editor`）🧩 | Editor 子設定 |
+| 8 | link-detect | Link Detection | module-owned（`editor`）🧩 | Editor 子設定 ⚠️ 同 8 衝突 |
+| 8 | module-config | Modules | built-in | switchboard ⚠️ 同 8 衝突 |
+| 9 | editor | Editor | module-owned（`editor`）🧩 | Monaco 偏好 |
+| 10 | quick-commands | Quick Commands | module-owned（`quick-commands`）🧩 | |
+| 11 | sync | Sync | built-in | 功能上自成 module 但未升格 |
+| 20 | dev-environment | Development | built-in（dev only） | |
+| 21 | tmux-agent-monitor | Tmux Agent Monitor | built-in（dev/devUpdate） | |
+
+四個結構性問題：
+
+1. **群組無視覺分隔**：modules 群組（`memory-monitor` / `editor` 三頁 / `quick-commands`）跟非 module section 交錯排列；Modules switchboard 應落在 modules 群組標頭位置
+2. **Editor 一拆三**：`open-behavior` (7) + `link-detect` (8) + `editor` (9) 是同一 module 的設定，但成三個 sidebar entry。使用者 mental model 是「找 Editor 設定 → 點 Editor」，不該分散
+3. **Sync 功能 vs 結構不一致**：Sync 自帶 engine、7 contributors、settings UI、`use-sync-store`，與 Quick Commands / Editor 性質相同，但卻是 built-in section
+4. **Padding/style drift**：`AppearanceSection` 用 `<div>` + `<h2>` + `<SettingItem>`；`QuickCommandsSettingsSection` 用 `<div className="p-6 space-y-4">`；`ModulesSwitchboardSection` 用 `<div className="p-6 space-y-6">`。`GlobalSettingsPage` 的 outer container 已經 `p-6`，這幾個會 double-pad
+
+### 1.2 Puzzle icon 現況
+
+`SettingsSidebar.tsx:88-93`:
+
+```tsx
+<PuzzlePiece
+  size={12}
+  weight="fill"
+  className="flex-shrink-0 rotate-[30deg] text-text-muted"
+  aria-hidden
+/>
+```
+
+需要：`rotate-0`（轉正）+ `weight="bold"`（線框風）。Size 維持 12。
+
+## 2. 範圍 + Non-goals
+
+### 2.1 範圍（in scope）
+
+**PR-1（視覺 / 順序）**
+
+- Puzzle icon：`rotate-[30deg]` → 移除、`weight="fill"` → `weight="bold"`
+- Sidebar 順序重排（見 §4.1）— Modules switchboard 移到所有 module-owned 上方
+- Module-owned section 統一移除 `p-6 space-y-X` outer wrapper（依賴 `GlobalSettingsPage` 的 `p-6`）
+- 不動內部 logic、不動 i18n key、不動 URL routing
+
+**PR-2（Editor 收編 + Sync modularize + 頁首統一）**
+
+- Editor 三 entry 收編成一個 `editor` page，內部以多段（Monaco 偏好 / Open Behavior / Link Detection）排列
+- 移除 `link-detect` (order 8) + `open-behavior` (order 7) sidebar entry（從 `editorModuleDefinition.settings` 拿掉）
+- URL alias：`/settings/link-detect` + `/settings/open-behavior` → `/settings/editor`（沿用 `editor-buffers` → `editor` 模式）
+- Sync 升格為 module（`registerModule({ id: 'sync', name: 'Sync', settings: [{ scope: 'purdex', ... }] })`，**不**加 `disableable: true`），sidebar 自動取得 puzzle icon、自然落在 modules 群組
+- 移除 `registerSettingsSection({ id: 'sync', ... })` 的呼叫（搬到 module def）
+- Quick Commands 頁首樣式統一（`<h2>` + `<p>` + 拿掉 `p-6 space-y-4`），CRUD list 內容不動
+- i18n：補 `settings.editor.{open_behavior,link_detect}.title` → 改成同頁內段落 heading 用，URL 路由 label 不再使用
+
+### 2.2 Non-goals（本 PR 不做、可開 issue）
+
+- Performance Monitor 從 settings 拆出（使用者明確指示「先放，後面要會再拆出來」）
+- Sync 加 `disableable: true` 與對應的 engine / contributors 停用設計（structural module 升格後，未來題）
+- Switchboard 加分隔線 / 視覺群組標題（純 sidebar 視覺，未要求）
+- 其他非 module section（Appearance / Terminal / Interface / Sync 內部 / Electron / Dev / Tmux Agent Monitor）的樣式 refactor
+- Subsection（Interface 的 new-tab / pane / sidebar）結構不動
+- Editor 的 workspace-scope / host-scope contributions 不動
+- 重命名 sidebar id（避免 URL 大規模 break）
+
+## 3. 不變量
+
+- **I1**：Sidebar 視覺順序：`built-in core (Appearance / Terminal / Interface / Electron) → Modules（switchboard）→ module-owned (Editor / Quick Commands / Performance Monitor / Sync) → built-in tail (Dev Environment / Tmux Agent Monitor)`
+- **I2**：Module-owned 判定（`isModuleOwnedContribution`）不變；Sync 升格後自動歸類為 module-owned，自動取得 puzzle icon
+- **I3**：URL stability — 任何在 alpha.284 之前可達的 `/settings/<id>` URL，PR-2 後須仍可達或被 alias 到語意對等的新 URL；不可 hard 404
+  - `/settings/link-detect` → 302/replace 到 `/settings/editor`
+  - `/settings/open-behavior` → 302/replace 到 `/settings/editor`
+  - `/settings/editor-buffers` → `/settings/editor`（既有 alias，不動）
+  - `/settings/sync` → 仍正常解析（id 不變，只是改由 module 註冊）
+- **I4**：Editor 收編後 spa/src/components/settings/editor/ 下的兩個現有 component（`EditorLinkDetectionSection`、`EditorOpenBehaviorSection`）以**段落（subsection block）**形式繼續存在，不重寫成 inline；只是 import 進 `EditorPurdexSettingsSection` 重組
+- **I5**：Sync 升格為 module 不改變 `syncEngine` 的生命週期 — `registerSyncContributors()` 維持目前 boot-time 呼叫；module def 只是設定 entry 的 source 改變
+- **I6**：Padding 一致性 — 所有 module-owned section 的 outer wrapper **不再**自帶 `p-6`，依賴 `GlobalSettingsPage` 的 `<div className="flex-1 overflow-y-auto p-6">`
+- **I7**：i18n key 不刪 —`settings.editor.link_detect.title` / `settings.editor.open_behavior.title` 仍會被 EditorPurdexSettingsSection 用作段落 heading；`settings.section.editor`、`settings.section.modules`、`settings.section.sync`、`settings.section.quick_commands` 維持 sidebar label
+- **I8**：Tests — 既有 settings section 測試（`AppearanceSection.test.tsx`、`TerminalSection.test.tsx`、`ModulesSwitchboardSection.test.tsx`、`InterfaceSection.test.tsx`、`SettingsSidebar.test.tsx` 等）只允許因 padding/icon 變動而調整 selector / class 斷言，不允許因順序 break 而被 skip 或刪除
+- **I9**：Switchboard 的 `disableable: true` 過濾邏輯不動 — Sync 雖是 module，因 `disableable !== true`，**不**出現在 switchboard list；視覺上 module-owned 並非 disableable 的等價
+
+## 4. 設計
+
+### 4.1 Sidebar 順序
+
+設定新的 order 區段（保留 0-29 的數字空間）：
+
+| 區段 | 範圍 | 用途 |
+|---|---|---|
+| Top built-in | 0 – 4 | Appearance / Terminal / Interface |
+| Top conditional built-in | 5 – 9 | Electron |
+| Modules switchboard | 10 | `module-config` |
+| Module-owned | 11 – 19 | Editor / Quick Commands / Performance Monitor / Sync |
+| Tail built-in | 20 – 29 | Sync 升格後保留：Dev Environment / Tmux Agent Monitor |
+
+新 order 表：
+
+| id | order | source | label |
+|---|---|---|---|
+| appearance | 0 | built-in | settings.section.appearance |
+| terminal | 1 | built-in | settings.section.terminal |
+| interface | 2 | built-in | settings.section.interface |
+| electron | 5 | built-in（條件） | settings.section.electron |
+| module-config | 10 | built-in | settings.section.modules |
+| editor | 11 | module-owned | settings.section.editor |
+| quick-commands | 12 | module-owned | settings.section.quick_commands |
+| performance-monitor | 13 | module-owned | performance_monitor.title |
+| sync | 14 | module-owned（升格） | settings.section.sync |
+| dev-environment | 20 | built-in（dev） | settings.section.dev_environment |
+| tmux-agent-monitor | 21 | built-in（dev） | settings.section.tmux_agent_monitor |
+
+說明：
+- module-owned 區段內部排序按 alpha：Editor (11) → Quick Commands (12) → Performance Monitor (13) → Sync (14)；任何 listing 沿用 `order ASC`，sidebar 與 switchboard 一致
+- `link-detect`、`open-behavior` 兩個 entry 不再出現在 sidebar（從 `editorModuleDefinition.settings` 移除）
+
+### 4.2 Editor 三頁合一
+
+#### 4.2.1 `EditorPurdexSettingsSection` 重組
+
+新結構（單一 page，三段落）：
+
+```tsx
+<div>
+  <h2>{t('settings.section.editor')}</h2>          // sidebar 同名
+  <p>{t('settings.editor.desc')}</p>
+
+  {/* Section 1：Monaco 偏好 — 既有 SettingItem 序列 */}
+  <SettingItem ... />  // tab_size / insert_spaces / word_wrap / line_numbers / minimap / font_size
+
+  {/* Section 2：Open Behavior */}
+  <h3>{t('settings.editor.open_behavior.title')}</h3>
+  <EditorOpenBehaviorSection />
+
+  {/* Section 3：Link Detection */}
+  <h3>{t('settings.editor.link_detect.title')}</h3>
+  <EditorLinkDetectionSection />
+
+  <p>{t('settings.editor.tiptap_note')}</p>
+</div>
+```
+
+H3 標題樣式：`text-base text-text-primary mt-8 mb-2`（沿用 Appearance / Terminal 內部分隔的視覺節奏）。`<EditorOpenBehaviorSection />` 與 `<EditorLinkDetectionSection />` 內部 outer `<div>` / `<h2>` 由各自 component 拿掉（如有），確保段落 heading 由父頁負責。
+
+#### 4.2.2 `editorModuleDefinition.settings` 縮減
+
+```ts
+settings: [
+  { localId: 'editor', scope: 'purdex', order: 11, ... },              // 唯一 purdex-scope entry
+  { localId: 'workspace-home-path', scope: 'workspace', order: 0, ... }, // 不動
+  { localId: 'host-home-path',      scope: 'host',      order: 100, ... },// 不動
+]
+```
+
+移除：`{ localId: 'link-detect', ... }`、`{ localId: 'open-behavior', ... }`。
+
+#### 4.2.3 URL alias
+
+`SettingsPage.tsx` 既有 alias 邏輯（`editor-buffers` → `editor`）擴充為 map：
+
+```ts
+const URL_ALIASES: Record<string, string> = {
+  'editor-buffers': 'editor',
+  'link-detect': 'editor',
+  'open-behavior': 'editor',
+}
+const urlSection = rawUrlSection ? URL_ALIASES[rawUrlSection] ?? rawUrlSection : null
+```
+
+Self-heal 既有的 `setLocation(..., { replace: true })` 路徑會自動把 URL 矯正成 `/settings/editor`。
+
+### 4.3 Sync 升格為 module
+
+#### 4.3.1 移除 built-in 註冊
+
+`spa/src/lib/register-modules/index.tsx`：
+
+```diff
+-  registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: 11, component: SyncSection })
+```
+
+#### 4.3.2 新增 module def
+
+```ts
+registerModule({
+  id: 'sync',
+  name: 'Sync',
+  // disableable: 不設定 — structural module，將來再加 disable 時另開 issue
+  settings: [
+    {
+      localId: 'sync',
+      scope: 'purdex',
+      order: 14,
+      labelKey: 'settings.section.sync',
+      component: SyncSection,
+    },
+  ],
+})
+```
+
+`registerSyncContributors()` 維持目前 boot-time 呼叫，不挪到 module def 內。
+
+#### 4.3.3 SyncSection 內部不動
+
+`SyncSection.tsx` 既有實作維持，只在 PR-1 時跟其他 section 一起拿掉 `p-6` outer padding（如有）。
+
+### 4.4 Quick Commands 頁首統一
+
+`QuickCommandsSettingsSection.tsx`：
+
+```diff
+- <div className="p-6 space-y-4">
+-   <div className="flex items-center justify-between">
+-     <h2 className="text-lg text-text-primary">{t('settings.quick_commands.title')}</h2>
++ <div>
++   <h2 className="text-lg text-text-primary">{t('settings.quick_commands.title')}</h2>
++   <p className="text-xs text-text-secondary mb-6">{t('settings.quick_commands.desc')}</p>
++   <div className="flex items-center justify-end mb-3">
+      <button ...>{t('settings.quick_commands.new')}</button>
+    </div>
+    {/* commands list 維持 */}
+```
+
+新增 i18n key `settings.quick_commands.desc`（短說明，跟 Appearance/Terminal 一致）。
+
+### 4.5 Padding 統一
+
+`GlobalSettingsPage` 的 `<div className="flex-1 overflow-y-auto p-6">` 已負責整體 padding。對所有 settings section component 立規則：
+
+- Outer wrapper 一律 `<div>`（無 `p-X`、無 `space-y-X`）
+- 標題：`<h2 className="text-lg text-text-primary">...`
+- 描述：`<p className="text-xs text-text-secondary mb-6">...`
+- 內容：`<SettingItem>` rows 或自訂結構
+
+需修正的檔案（已驗證實際 outer wrapper）：
+
+| 檔案 | 現況 | 改動 |
+|---|---|---|
+| `AppearanceSection.tsx` | `<div>` | 不動 |
+| `TerminalSection.tsx` | `<div>` | 不動 |
+| `EditorPurdexSettingsSection.tsx` | `<div>` | PR-2 重組為三段 |
+| `SyncSection.tsx` | `<div>` | 不動 |
+| `InterfaceSection.tsx` | `<div className="flex h-full">`（自帶 sidebar 結構） | 不動 |
+| `ModulesSwitchboardSection.tsx` | `<div className="p-6 space-y-6">` | PR-1 改為 `<div>`（拿掉 `p-6`，內部已用 `space-y-6` 元素，視需要保留） |
+| `QuickCommandsSettingsSection.tsx` | `<div className="p-6 space-y-4">` | PR-2 改為 `<div>` + 統一頁首 |
+| `ElectronSection.tsx` | `<div className="space-y-6">` | 不動（無 `p-X` 不雙 pad） |
+| `DevEnvironmentSection.tsx` | `<div className="space-y-6">` | 不動 |
+| `TmuxAgentMonitorSection.tsx` | `<div className="space-y-6">` | 不動 |
+
+僅 `ModulesSwitchboardSection` 與 `QuickCommandsSettingsSection` 因含 `p-6` 與 `GlobalSettingsPage` 的 `p-6` 雙 pad，需修。其餘只用 `space-y-6` 不雙 pad，視覺差異是「元素間距不一致」而非「邊距重複」，超出本 PR 範圍。
+
+### 4.6 Puzzle icon
+
+`SettingsSidebar.tsx`：
+
+```diff
+   <PuzzlePiece
+     size={12}
+-    weight="fill"
+-    className="flex-shrink-0 rotate-[30deg] text-text-muted"
++    weight="bold"
++    className="flex-shrink-0 text-text-muted"
+     aria-hidden
+   />
+```
+
+範圍（已 grep 確認三個 caller，全部一致改）：
+
+- `spa/src/components/settings/SettingsSidebar.tsx:88-93`（size 12）
+- `spa/src/features/workspace/components/WorkspaceSettingsPage.tsx:162-167`（size 12）
+- `spa/src/components/hosts/HostSidebar.tsx:124-129`（size 10）
+
+三處都有 `weight="fill"` + `rotate-[30deg]`，PR-1 一次改完。Size 維持各自原值（10 / 12）不統一改。
+
+## 5. PR 切分
+
+### 5.1 PR-1：視覺 / 順序
+
+範圍（純視覺、無行為改變）：
+
+1. Puzzle icon：rotate-0 + weight=bold（含 spa 內所有 `<PuzzlePiece>` 用法）
+2. Sidebar order 重排：electron 5（不動）、module-config 10、editor 11、quick-commands 12、performance-monitor 13、dev-environment 20（不動）、tmux-agent-monitor 21（不動）。Sync 暫留 11（PR-2 才升格 + 改 14）
+3. Padding 一律拿掉 `p-X` outer wrapper：`ModulesSwitchboardSection` / 其他帶 padding 的 module section
+4. **不**碰 Editor 三頁、不碰 Sync 註冊方式、不碰 Quick Commands 頁首
+
+Acceptance：
+- A1：Sidebar visual order = §4.1 表（Sync 仍在 11）
+- A2：SettingsSidebar / WorkspaceSettingsPage / HostSidebar 三處 puzzle icon 皆為直立（無 `rotate`）+ bold weight
+- A3：所有 sidebar URL（既有 + new）正常解析
+- A4：Settings 內容不雙 pad（screenshot 比較或 test 斷言 outer 無 `p-6`）
+- A5：既有 vitest 全綠（含 SettingsSidebar / ModulesSwitchboardSection / 各 section 測試）
+
+### 5.2 PR-2：Editor 收編 + Sync modularize + Quick Commands 頁首
+
+範圍：
+
+1. `EditorPurdexSettingsSection` 重組為單頁三段
+2. `editorModuleDefinition.settings` 移除 `link-detect` / `open-behavior` entry
+3. `SettingsPage` URL alias map 擴充
+4. Sync `registerSettingsSection` → `registerModule`
+5. Quick Commands 頁首改 `<h2>` + `<p>`
+6. 新增 i18n：`settings.quick_commands.desc`
+
+Acceptance：
+- A6：`/settings` sidebar 只剩一個 Editor entry（`Open Behavior`、`Link Detection` 不在 sidebar）
+- A7：Editor 頁內可看到三段：Monaco 偏好 / Open Behavior / Link Detection；功能行為與舊頁等價（既有測試 pass）
+- A8：`/settings/link-detect` + `/settings/open-behavior` 開啟後 URL 自動 replace 為 `/settings/editor` 並 mount Editor 頁
+- A9：`/settings/sync` 開啟後仍 mount SyncSection；sidebar 上 Sync row 顯示 puzzle icon
+- A10：Sync 在 ModulesSwitchboard 中**不**出現（disableable !== true）
+- A11：Quick Commands 頁首結構與 Appearance / Terminal 視覺一致（h2 + p + 主要內容）
+- A12：所有 vitest 全綠（含新增 alias / module-owned 判定測試）
+
+## 6. 風險 + 對策
+
+| Risk | Severity | 對策 |
+|---|---|---|
+| Editor 收編破壞既有 OpenBehavior / LinkDetection 內部行為 | Medium | TDD：先抽 OpenBehavior / LinkDetection 段落 component（不重寫），父頁 import；既有測試 pass = 行為不變 |
+| URL alias map 邏輯擴充誤判 — 例如 `link-detect` 內含 `editor-buffers` 結構衝突 | Low | alias map 是 plain object lookup，無 prefix match；新增 unit test 覆蓋三個 alias |
+| Sync 升格後 `dispatchSettingsContributions` 過濾路徑改變（從 built-in → module-owned） | Medium | Sync `disableable !== true`，過濾邏輯（`disabled module 跳過`）對它無作用；新增 test 確認 Sync contribution 在 dispatch 後仍存在 |
+| Sidebar order 衝撞 — 既有 order 8/8 collision 同時也是 alpha.284 在跑的狀態，重新編號可能讓使用者感覺位置跳動 | Low | order 改變屬於本次重排目的，CHANGELOG 記錄 |
+| Puzzle icon 改動同時影響 HostPage / Workspace settings | Low | grep `PuzzlePiece` 全 spa 確認所有 caller 一致 |
+| Quick Commands 頁首改動破壞既有 dialog 測試 | Low | 改動限於 outer wrapper + h2/p 新增；list 與 dialog 內部不動；既有 vitest 應 pass |
+
+## 7. 測試策略
+
+### 7.1 既有需要 pass
+
+- `SettingsSidebar.test.tsx` — order 改變後 mock contribution 順序需更新
+- `ModulesSwitchboardSection.test.tsx` — Sync 升格後**不**進 switchboard 列表（新增斷言 + 既有不破）
+- `AppearanceSection.test.tsx` / `TerminalSection.test.tsx` — 不動
+- `InterfaceSection.test.tsx` — 不動
+- `EditorPurdexSettingsSection`（如有測試）— 重組為三段後測試需要更新
+
+### 7.2 新增
+
+- **PR-1**
+  - SettingsSidebar：puzzle icon className 不含 `rotate-[30deg]`；weight prop = `bold`
+  - SettingsSidebar：order 排序在 mock fixture 下符合 §4.1
+- **PR-2**
+  - `SettingsPage` URL alias：`/settings/link-detect` 跟 `/settings/open-behavior` 都 mount Editor section + URL 被 replace 為 `/settings/editor`
+  - Editor 頁：三段 heading 都 render（Monaco 偏好 / Open Behavior / Link Detection）
+  - Sync：在 contribution registry 中 `moduleId === 'sync'` 而非 `_builtin.legacy-section`（`isModuleOwnedContribution` 為 true）
+  - Sync：不在 ModulesSwitchboard 列表（`getModules().filter(disableable === true)` 不含 `sync`）
+
+### 7.3 手動驗證（mlab + Air）
+
+- `/settings` 進去 sidebar 視覺順序與 §4.1 一致
+- 所有 module-owned row 顯示直立 puzzle icon
+- 點 Editor → 三段都展示，Monaco 偏好可改、Open Behavior toggle 可動、Link Detection toggle 可動
+- 直接訪問 `/settings/link-detect` 跟 `/settings/open-behavior` URL，自動跳到 `/settings/editor`
+- Sync 在 sidebar 顯示 puzzle icon、點進去 SyncSection 正常運作、Modules switchboard 不列 Sync
+- Quick Commands 頁首是 h2 + 描述 p（跟 Appearance 視覺一致），下方仍是 commands list
+- Performance Monitor 不動（暫不重組）
+
+## 8. Future work（開 issue 追蹤，本 PR 不做）
+
+- Performance Monitor 從 settings 拆出（使用者明確指示，未來題）
+- Sync 加 `disableable: true` + engine / contributors disable wiring
+- Switchboard 加分隔線 / group title 視覺
+- Performance Monitor / Sync / 其他 module-owned section 內部樣式統一

--- a/spa/src/components/hosts/HostSidebar.tsx
+++ b/spa/src/components/hosts/HostSidebar.tsx
@@ -123,8 +123,8 @@ export function HostSidebar({ selectedHostId, selectedSubPage, onSelect, onAddHo
                         {moduleOwned && (
                           <PuzzlePiece
                             size={10}
-                            weight="fill"
-                            className="flex-shrink-0 rotate-[30deg] text-text-muted"
+                            weight="bold"
+                            className="flex-shrink-0 text-text-muted"
                             aria-hidden
                           />
                         )}

--- a/spa/src/components/settings/ModulesSwitchboardSection.tsx
+++ b/spa/src/components/settings/ModulesSwitchboardSection.tsx
@@ -33,7 +33,10 @@ export function ModulesSwitchboardSection({ ctx: _ctx }: Props = {}) {
   const modules = getModules().filter((m) => m.disableable === true)
 
   return (
-    <div className="p-6 space-y-6">
+    // Spec §4.5 — outer wrapper drops `p-6` because GlobalSettingsPage
+    // already pads the section container; doubling up was producing
+    // visible inset drift versus other module-owned sections.
+    <div className="space-y-6">
       {hasPending && <ReloadBanner t={t} />}
       <div className="space-y-4">
         {modules.map((m) => (

--- a/spa/src/components/settings/SettingsSidebar.test.tsx
+++ b/spa/src/components/settings/SettingsSidebar.test.tsx
@@ -1,5 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+// Mock <PuzzlePiece> so we can assert on the `weight` and `className`
+// props SettingsSidebar passes to it. The real Phosphor SVG render
+// is expensive and opaque to weight / className assertions;
+// intercepting the component lets us hold the rotate-bold contract
+// on the prop boundary instead of the rendered output. Spec §4.6.
+vi.mock('@phosphor-icons/react', () => {
+  type StubProps = {
+    weight?: string
+    className?: string
+    'aria-hidden'?: boolean | string
+    children?: ReactNode
+  }
+  const PuzzlePiece = ({ weight, className, ...rest }: StubProps) => (
+    <span
+      data-testid="puzzle"
+      data-weight={weight}
+      className={className}
+      {...rest}
+    />
+  )
+  return { PuzzlePiece }
+})
+
 import { SettingsSidebar } from './SettingsSidebar'
 import { registerSettingsSection, clearSettingsSectionRegistry } from '../../lib/settings-section-registry'
 import {
@@ -129,6 +154,35 @@ describe('SettingsSidebar (F7: disabled-by-ctx)', () => {
     expect(row.getAttribute('data-disabled-ctx')).toBeNull()
     fireEvent.click(screen.getByText('AliveLabel'))
     expect(onSelect).toHaveBeenCalledWith('alive')
+  })
+
+  it('module-owned puzzle icon is bold + not rotated', () => {
+    // Spec §4.6 — Settings sidebar puzzle icon must be `weight="bold"`
+    // and have no `rotate-[30deg]` class. Asserted at the Phosphor prop
+    // boundary via the module-level mock above.
+    registerSettingsContribution({
+      moduleId: 'mod',
+      id: 'mod.alive',
+      localId: 'alive',
+      scope: 'purdex',
+      order: 5,
+      labelKey: 'AliveLabel',
+      component: FakeComp,
+    })
+
+    render(<SettingsSidebar activeSection="appearance" onSelectSection={vi.fn()} />)
+    const puzzles = screen.getAllByTestId('puzzle')
+    // Exactly one module-owned row exists in this fixture (`alive`).
+    expect(puzzles).toHaveLength(1)
+    expect(puzzles[0].getAttribute('data-weight')).toBe('bold')
+    expect(puzzles[0].className).not.toContain('rotate-')
+  })
+
+  it('built-in row does not render a puzzle icon', () => {
+    // Only the dispatched legacy `appearance` row exists here — no
+    // module-owned contribution, so no puzzle icon should render.
+    render(<SettingsSidebar activeSection="appearance" onSelectSection={vi.fn()} />)
+    expect(screen.queryByTestId('puzzle')).toBeNull()
   })
 
   it('omitted `disabled` defaults to enabled', () => {

--- a/spa/src/components/settings/SettingsSidebar.test.tsx
+++ b/spa/src/components/settings/SettingsSidebar.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@phosphor-icons/react', () => {
   type StubProps = {
     weight?: string
     className?: string
-    'aria-hidden'?: boolean | string
+    'aria-hidden'?: boolean | 'true' | 'false'
     children?: ReactNode
   }
   const PuzzlePiece = ({ weight, className, ...rest }: StubProps) => (

--- a/spa/src/components/settings/SettingsSidebar.tsx
+++ b/spa/src/components/settings/SettingsSidebar.tsx
@@ -87,8 +87,8 @@ export function SettingsSidebar({ activeSection, onSelectSection }: Props) {
               {row.moduleOwned && (
                 <PuzzlePiece
                   size={12}
-                  weight="fill"
-                  className="flex-shrink-0 rotate-[30deg] text-text-muted"
+                  weight="bold"
+                  className="flex-shrink-0 text-text-muted"
                   aria-hidden
                 />
               )}

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
@@ -161,8 +161,8 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
                 {moduleOwned && (
                   <PuzzlePiece
                     size={12}
-                    weight="fill"
-                    className="flex-shrink-0 rotate-[30deg] text-text-muted"
+                    weight="bold"
+                    className="flex-shrink-0 text-text-muted"
                     aria-hidden
                   />
                 )}

--- a/spa/src/lib/__tests__/settings-order-pr1.test.ts
+++ b/spa/src/lib/__tests__/settings-order-pr1.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { listContributions } from '../settings-contribution-registry'
+import {
+  clearAllBuiltinModuleRegistries,
+  resetAndRegisterBuiltinModules,
+  resetModuleEnabledStore,
+} from './test-bootstrap-harness'
+import { isModuleOwnedContribution } from '../settings-contribution-types'
+import { SETTINGS_ORDER } from '../settings-order'
+
+// Spec §4.1.4 — PR-1 transitional sidebar order. After PR-1 lands but
+// before PR-2 ships, the sidebar must look like:
+//
+//   appearance(0)
+//   terminal(1)
+//   interface(2)
+//   electron(5)            -- gated by canSystemTray, present in tests' jsdom env? No → may not exist; test guards
+//   module-config(10)      -- moved up to be the modules group header
+//   performance-monitor(11)
+//   open-behavior(12)
+//   link-detect(13)
+//   editor(14)
+//   quick-commands(15)
+//   sync(16)
+//   dev-environment(20)    -- only when caps.devUpdateEnabled
+//   tmux-agent-monitor(21) -- DEV or devUpdateEnabled
+//
+// PR-2 then collapses open-behavior + link-detect into editor and bumps
+// the rest down to the SETTINGS_ORDER MODULE_* values; this PR-1 test is
+// removed at the start of PR-2 (commit 1 in PR-2 `git rm`s it).
+
+beforeEach(() => {
+  resetAndRegisterBuiltinModules()
+})
+
+afterEach(() => {
+  clearAllBuiltinModuleRegistries()
+  resetModuleEnabledStore()
+})
+
+describe('PR-1 transitional sidebar order (spec §4.1.4)', () => {
+  it('purdex-scope contributions are in PR-1 transitional ASC order', () => {
+    const items = listContributions('purdex')
+      .map((c) => ({ id: c.localId, order: c.order }))
+      .sort((a, b) => a.order - b.order)
+    const ids = items.map((x) => x.id)
+
+    // The bootstrap harness registers every built-in module + dispatches the
+    // contributions; in jsdom (no electronAPI, but DEV / devUpdateEnabled are
+    // still effectively true via Vite import.meta.env.DEV), expect the
+    // following always-on transitional set.
+    //
+    // Built-in section IDs visible in `listContributions('purdex')` after
+    // dispatch land under `_builtin.legacy-section.<id>` but expose their
+    // `localId` (= the human-readable id) at the top level.
+    expect(ids).toContain('appearance')
+    expect(ids).toContain('terminal')
+    expect(ids).toContain('interface')
+    expect(ids).toContain('module-config')
+    expect(ids).toContain('performance-monitor')
+    expect(ids).toContain('open-behavior')
+    expect(ids).toContain('link-detect')
+    expect(ids).toContain('editor')
+    expect(ids).toContain('quick-commands')
+    expect(ids).toContain('sync')
+
+    // Order assertions for each entry that is always present.
+    const orderOf = (localId: string) => items.find((i) => i.id === localId)!.order
+    expect(orderOf('appearance')).toBe(0)
+    expect(orderOf('terminal')).toBe(1)
+    expect(orderOf('interface')).toBe(2)
+    expect(orderOf('module-config')).toBe(SETTINGS_ORDER.MODULE_CONFIG) // = 10
+    expect(orderOf('performance-monitor')).toBe(11)
+    expect(orderOf('open-behavior')).toBe(12)
+    expect(orderOf('link-detect')).toBe(13)
+    expect(orderOf('editor')).toBe(14)
+    expect(orderOf('quick-commands')).toBe(15)
+    expect(orderOf('sync')).toBe(16)
+  })
+
+  it('module-config sits above every module-owned contribution', () => {
+    const items = listContributions('purdex')
+      .slice()
+      .sort((a, b) => a.order - b.order)
+    const moduleConfigIdx = items.findIndex((c) => c.localId === 'module-config')
+    expect(moduleConfigIdx).toBeGreaterThanOrEqual(0)
+
+    const firstModuleOwnedIdx = items.findIndex((c) => isModuleOwnedContribution(c))
+    expect(firstModuleOwnedIdx).toBeGreaterThanOrEqual(0)
+
+    expect(moduleConfigIdx).toBeLessThan(firstModuleOwnedIdx)
+  })
+
+  it('every active purdex-scope contribution has a unique order (no collisions)', () => {
+    const orders = listContributions('purdex').map((c) => c.order)
+    const seen = new Set<number>()
+    for (const o of orders) {
+      expect(seen.has(o)).toBe(false)
+      seen.add(o)
+    }
+  })
+})

--- a/spa/src/lib/__tests__/settings-order-pr1.test.ts
+++ b/spa/src/lib/__tests__/settings-order-pr1.test.ts
@@ -39,43 +39,67 @@ afterEach(() => {
 })
 
 describe('PR-1 transitional sidebar order (spec §4.1.4)', () => {
-  it('purdex-scope contributions are in PR-1 transitional ASC order', () => {
+  it('purdex-scope contributions match the exact PR-1 transitional ASC list', () => {
+    // Take only entries we own + control in the PR-1 fixture. Optional
+    // entries gated by env / caps (electron / dev-environment /
+    // tmux-agent-monitor) are filtered out so the assertion is stable
+    // across DEV vs prod-like jsdom runs. The list below is the ENTIRE
+    // expected ordered set under those conditions — toEqual rejects any
+    // unexpected entry that sneaks in between known ids.
+    const KNOWN_ALWAYS_ON = new Set([
+      'appearance',
+      'terminal',
+      'interface',
+      'module-config',
+      'performance-monitor',
+      'open-behavior',
+      'link-detect',
+      'editor',
+      'quick-commands',
+      'sync',
+    ])
+
     const items = listContributions('purdex')
+      .filter((c) => KNOWN_ALWAYS_ON.has(c.localId))
       .map((c) => ({ id: c.localId, order: c.order }))
       .sort((a, b) => a.order - b.order)
-    const ids = items.map((x) => x.id)
 
-    // The bootstrap harness registers every built-in module + dispatches the
-    // contributions; in jsdom (no electronAPI, but DEV / devUpdateEnabled are
-    // still effectively true via Vite import.meta.env.DEV), expect the
-    // following always-on transitional set.
-    //
-    // Built-in section IDs visible in `listContributions('purdex')` after
-    // dispatch land under `_builtin.legacy-section.<id>` but expose their
-    // `localId` (= the human-readable id) at the top level.
-    expect(ids).toContain('appearance')
-    expect(ids).toContain('terminal')
-    expect(ids).toContain('interface')
-    expect(ids).toContain('module-config')
-    expect(ids).toContain('performance-monitor')
-    expect(ids).toContain('open-behavior')
-    expect(ids).toContain('link-detect')
-    expect(ids).toContain('editor')
-    expect(ids).toContain('quick-commands')
-    expect(ids).toContain('sync')
+    expect(items).toEqual([
+      { id: 'appearance',          order: SETTINGS_ORDER.APPEARANCE },           // 0
+      { id: 'terminal',            order: SETTINGS_ORDER.TERMINAL },             // 1
+      { id: 'interface',           order: SETTINGS_ORDER.INTERFACE },            // 2
+      { id: 'module-config',       order: SETTINGS_ORDER.MODULE_CONFIG },        // 10
+      { id: 'performance-monitor', order: SETTINGS_ORDER.MODULE_PERFORMANCE_MONITOR_PR1 }, // 11
+      { id: 'open-behavior',       order: SETTINGS_ORDER.MODULE_EDITOR_OPEN_BEHAVIOR_PR1 }, // 12
+      { id: 'link-detect',         order: SETTINGS_ORDER.MODULE_EDITOR_LINK_DETECT_PR1 },   // 13
+      { id: 'editor',              order: SETTINGS_ORDER.MODULE_EDITOR_PR1 },               // 14
+      { id: 'quick-commands',      order: SETTINGS_ORDER.MODULE_QUICK_COMMANDS_PR1 },       // 15
+      { id: 'sync',                order: SETTINGS_ORDER.SYNC_PR1 },                        // 16
+    ])
+  })
 
-    // Order assertions for each entry that is always present.
-    const orderOf = (localId: string) => items.find((i) => i.id === localId)!.order
-    expect(orderOf('appearance')).toBe(0)
-    expect(orderOf('terminal')).toBe(1)
-    expect(orderOf('interface')).toBe(2)
-    expect(orderOf('module-config')).toBe(SETTINGS_ORDER.MODULE_CONFIG) // = 10
-    expect(orderOf('performance-monitor')).toBe(11)
-    expect(orderOf('open-behavior')).toBe(12)
-    expect(orderOf('link-detect')).toBe(13)
-    expect(orderOf('editor')).toBe(14)
-    expect(orderOf('quick-commands')).toBe(15)
-    expect(orderOf('sync')).toBe(16)
+  it('no contribution sneaks in between module-config and the modules-group tail', () => {
+    // After module-config (=10) there must be ONLY the PR-1 module-owned
+    // entries — performance-monitor through sync — until tail-built-in
+    // (>= 20). This guard catches a hypothetical legacy section
+    // registered with order 10.5 / 12.5 / etc. which would still pass the
+    // unique-order check below but visually break the modules group.
+    const PR1_MODULE_GROUP_IDS = [
+      'performance-monitor',
+      'open-behavior',
+      'link-detect',
+      'editor',
+      'quick-commands',
+      'sync',
+    ]
+    const items = listContributions('purdex')
+      .slice()
+      .sort((a, b) => a.order - b.order)
+
+    const between = items
+      .filter((c) => c.order > SETTINGS_ORDER.MODULE_CONFIG && c.order < 20)
+      .map((c) => c.localId)
+    expect(between).toEqual(PR1_MODULE_GROUP_IDS)
   })
 
   it('module-config sits above every module-owned contribution', () => {

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -378,10 +378,15 @@ describe('registerBuiltinModules → new contribution registry (PR-2)', () => {
     // F3 follow-up restored `module-config` — removing it left
     // `ModuleDefinition.globalConfig` API live-but-unreachable (silent
     // dead-end). Deferred removal to HSR PR-5 tracked by #574.
+    //
+    // Order moved 8 → 10 by settings-architecture-fix PR-1 (spec §4.1.4)
+    // so the Modules Switchboard sits at the top of the modules group
+    // instead of colliding with link-detect. Sourced from SETTINGS_ORDER
+    // constants now.
     const contribs = listContributions('purdex')
     const entry = contribs.find((c) => c.localId === 'module-config')
     expect(entry).toBeDefined()
-    expect(entry?.order).toBe(8)
+    expect(entry?.order).toBe(10)
     expect(getSettingsSections().find((s) => s.id === 'module-config')).toBeDefined()
   })
 

--- a/spa/src/lib/register-modules/editor-module.tsx
+++ b/spa/src/lib/register-modules/editor-module.tsx
@@ -32,24 +32,27 @@ export const editorModuleDefinition: ModuleDefinition = {
     { kind: 'pdf-preview', component: PdfPreviewPane },
   ],
   settings: [
+    // PR-1 transitional values (spec §4.1.4); PR-2 collapses link-detect +
+    // open-behavior into editor and bumps editor order to
+    // SETTINGS_ORDER.MODULE_EDITOR (=11).
     {
       localId: 'editor',
       scope: 'purdex',
-      order: 9,
+      order: 14,
       labelKey: 'settings.section.editor',
       component: EditorPurdexSettingsSection,
     },
     {
       localId: 'link-detect',
       scope: 'purdex',
-      order: 8,
+      order: 13,
       labelKey: 'settings.editor.link_detect.title',
       component: EditorLinkDetectionSection,
     },
     {
       localId: 'open-behavior',
       scope: 'purdex',
-      order: 7,
+      order: 12,
       labelKey: 'settings.editor.open_behavior.title',
       component: EditorOpenBehaviorSection,
     },

--- a/spa/src/lib/register-modules/editor-module.tsx
+++ b/spa/src/lib/register-modules/editor-module.tsx
@@ -1,5 +1,6 @@
 import type { ModuleDefinition } from '../module-registry'
 import type { PaneContent } from '../../types/tab'
+import { SETTINGS_ORDER } from '../settings-order'
 import {
   registerNewTabProvider,
   unregisterNewTabProvidersByModule,
@@ -33,26 +34,26 @@ export const editorModuleDefinition: ModuleDefinition = {
   ],
   settings: [
     // PR-1 transitional values (spec §4.1.4); PR-2 collapses link-detect +
-    // open-behavior into editor and bumps editor order to
-    // SETTINGS_ORDER.MODULE_EDITOR (=11).
+    // open-behavior into editor and switches `editor` to
+    // SETTINGS_ORDER_PR2_FUTURE.MODULE_EDITOR (=11).
     {
       localId: 'editor',
       scope: 'purdex',
-      order: 14,
+      order: SETTINGS_ORDER.MODULE_EDITOR_PR1,
       labelKey: 'settings.section.editor',
       component: EditorPurdexSettingsSection,
     },
     {
       localId: 'link-detect',
       scope: 'purdex',
-      order: 13,
+      order: SETTINGS_ORDER.MODULE_EDITOR_LINK_DETECT_PR1,
       labelKey: 'settings.editor.link_detect.title',
       component: EditorLinkDetectionSection,
     },
     {
       localId: 'open-behavior',
       scope: 'purdex',
-      order: 12,
+      order: SETTINGS_ORDER.MODULE_EDITOR_OPEN_BEHAVIOR_PR1,
       labelKey: 'settings.editor.open_behavior.title',
       component: EditorOpenBehaviorSection,
     },

--- a/spa/src/lib/register-modules/index.tsx
+++ b/spa/src/lib/register-modules/index.tsx
@@ -61,6 +61,7 @@ import {
 import { applyModuleFileOpeners } from './module-file-openers'
 import { clearAllForHmr as clearFileOpenerRegistryForHmr } from '../file-opener-registry'
 import { QuickCommandsSettingsSection } from '../../components/settings/QuickCommandsSettingsSection'
+import { SETTINGS_ORDER } from '../settings-order'
 
 function NewTabPaneWrapper({ pane }: PaneRendererProps) {
   const handleSelect = (content: PaneContent) => {
@@ -178,7 +179,7 @@ export function registerBuiltinModules(): void {
     settings: [{
       localId: 'performance-monitor',
       scope: 'purdex',
-      order: 6,
+      order: 11, // PR-1 transitional value (spec §4.1.4); PR-2 → SETTINGS_ORDER.MODULE_PERFORMANCE_MONITOR
       labelKey: 'performance_monitor.title',
       component: PerformanceMonitorSettingsSection,
     }],
@@ -206,7 +207,7 @@ export function registerBuiltinModules(): void {
       {
         localId: 'quick-commands',
         scope: 'purdex',
-        order: 10, // between editor (9) and sync (11), after module-config (8)
+        order: 15, // PR-1 transitional value (spec §4.1.4); PR-2 → SETTINGS_ORDER.MODULE_QUICK_COMMANDS
         labelKey: 'settings.section.quick_commands',
         component: QuickCommandsSettingsSection,
       },
@@ -246,22 +247,22 @@ export function registerBuiltinModules(): void {
   })
 
   // Settings sections
-  registerSettingsSection({ id: 'appearance', label: 'settings.section.appearance', order: 0, component: AppearanceSection })
-  registerSettingsSection({ id: 'terminal', label: 'settings.section.terminal', order: 1, component: TerminalSection })
+  registerSettingsSection({ id: 'appearance', label: 'settings.section.appearance', order: SETTINGS_ORDER.APPEARANCE, component: AppearanceSection })
+  registerSettingsSection({ id: 'terminal', label: 'settings.section.terminal', order: SETTINGS_ORDER.TERMINAL, component: TerminalSection })
   registerSettingsSection({
     id: 'interface',
     label: 'settings.section.interface',
-    order: 2,
+    order: SETTINGS_ORDER.INTERFACE,
     component: InterfaceSectionHost,
   })
-  registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: 11, component: SyncSection })
+  registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: 16, component: SyncSection }) // PR-1 transitional (spec §4.1.4); PR-2 promotes to module + SETTINGS_ORDER.MODULE_SYNC
   // Modules Switchboard — replaces the long-dormant `globalConfig` UI with a
   // module enable/disable panel. Keeps the id `module-config` for URL
   // stability (`/settings/module-config`).
   registerSettingsSection({
     id: 'module-config',
     label: 'settings.section.modules',
-    order: 8,
+    order: SETTINGS_ORDER.MODULE_CONFIG,
     component: ModulesSwitchboardSection,
   })
 
@@ -314,7 +315,7 @@ export function registerBuiltinModules(): void {
     registerSettingsSection({
       id: 'electron',
       label: 'settings.section.electron',
-      order: 5,
+      order: SETTINGS_ORDER.ELECTRON,
       component: ElectronSection,
     })
   }
@@ -323,7 +324,7 @@ export function registerBuiltinModules(): void {
     registerSettingsSection({
       id: 'dev-environment',
       label: 'settings.section.dev_environment',
-      order: 20,
+      order: SETTINGS_ORDER.DEV_ENVIRONMENT,
       component: DevEnvironmentSection,
     })
   }
@@ -332,7 +333,7 @@ export function registerBuiltinModules(): void {
     registerSettingsSection({
       id: 'tmux-agent-monitor',
       label: 'settings.section.tmux_agent_monitor',
-      order: 21,
+      order: SETTINGS_ORDER.TMUX_AGENT_MONITOR,
       component: TmuxAgentMonitorSection,
     })
   }

--- a/spa/src/lib/register-modules/index.tsx
+++ b/spa/src/lib/register-modules/index.tsx
@@ -179,7 +179,7 @@ export function registerBuiltinModules(): void {
     settings: [{
       localId: 'performance-monitor',
       scope: 'purdex',
-      order: 11, // PR-1 transitional value (spec §4.1.4); PR-2 → SETTINGS_ORDER.MODULE_PERFORMANCE_MONITOR
+      order: SETTINGS_ORDER.MODULE_PERFORMANCE_MONITOR_PR1,
       labelKey: 'performance_monitor.title',
       component: PerformanceMonitorSettingsSection,
     }],
@@ -207,7 +207,7 @@ export function registerBuiltinModules(): void {
       {
         localId: 'quick-commands',
         scope: 'purdex',
-        order: 15, // PR-1 transitional value (spec §4.1.4); PR-2 → SETTINGS_ORDER.MODULE_QUICK_COMMANDS
+        order: SETTINGS_ORDER.MODULE_QUICK_COMMANDS_PR1,
         labelKey: 'settings.section.quick_commands',
         component: QuickCommandsSettingsSection,
       },
@@ -255,7 +255,7 @@ export function registerBuiltinModules(): void {
     order: SETTINGS_ORDER.INTERFACE,
     component: InterfaceSectionHost,
   })
-  registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: 16, component: SyncSection }) // PR-1 transitional (spec §4.1.4); PR-2 promotes to module + SETTINGS_ORDER.MODULE_SYNC
+  registerSettingsSection({ id: 'sync', label: 'settings.section.sync', order: SETTINGS_ORDER.SYNC_PR1, component: SyncSection })
   // Modules Switchboard — replaces the long-dormant `globalConfig` UI with a
   // module enable/disable panel. Keeps the id `module-config` for URL
   // stability (`/settings/module-config`).

--- a/spa/src/lib/settings-order.ts
+++ b/spa/src/lib/settings-order.ts
@@ -1,0 +1,43 @@
+/**
+ * Centralized order constants for the Settings sidebar.
+ *
+ * The sidebar is grouped into bands so visual ordering communicates intent:
+ *
+ *   | Band                        | Range  | Examples                                  |
+ *   |-----------------------------|--------|-------------------------------------------|
+ *   | Top built-in (core)         | 0 – 4  | Appearance / Terminal / Interface         |
+ *   | Top conditional built-in    | 5 – 9  | Electron (gated by canSystemTray)         |
+ *   | Modules switchboard         | 10     | `module-config` (single header row)       |
+ *   | Module-owned                | 11–19  | Editor / Quick Commands / Perf / Sync     |
+ *   | Tail built-in               | 20–29  | Dev Environment / Tmux Agent Monitor      |
+ *
+ * `register-modules/index.tsx`, `editor-module.tsx`, and any future
+ * `registerSettingsSection` / `registerModule({ settings: [...] })` call
+ * MUST import from this file instead of hard-coding numbers. Reviewers
+ * watch for hard-coded `order:` literals during PR review.
+ *
+ * NOTE: PR-1 is a transitional state — `module-config` adopts the constant
+ * (=10) so it lands above the existing module-owned entries, but the
+ * module-owned entries themselves keep transitional hard-coded values
+ * (11/12/13/14/15/16) until PR-2 finishes the Editor consolidation +
+ * Sync upgrade. PR-2 swaps the remaining hard-coded values for the
+ * `MODULE_*` constants below — see spec §4.1.3 / §4.1.4.
+ */
+export const SETTINGS_ORDER = {
+  // Top built-in (core) — always present.
+  APPEARANCE: 0,
+  TERMINAL: 1,
+  INTERFACE: 2,
+  // Top conditional built-in.
+  ELECTRON: 5,
+  // Modules switchboard — single row, header of the modules group.
+  MODULE_CONFIG: 10,
+  // Module-owned (PR-2 final values; PR-1 keeps transitional numbers).
+  MODULE_EDITOR: 11,
+  MODULE_QUICK_COMMANDS: 12,
+  MODULE_PERFORMANCE_MONITOR: 13,
+  MODULE_SYNC: 14,
+  // Tail built-in — dev / debug surfaces.
+  DEV_ENVIRONMENT: 20,
+  TMUX_AGENT_MONITOR: 21,
+} as const

--- a/spa/src/lib/settings-order.ts
+++ b/spa/src/lib/settings-order.ts
@@ -16,12 +16,16 @@
  * MUST import from this file instead of hard-coding numbers. Reviewers
  * watch for hard-coded `order:` literals during PR review.
  *
- * NOTE: PR-1 is a transitional state — `module-config` adopts the constant
- * (=10) so it lands above the existing module-owned entries, but the
- * module-owned entries themselves keep transitional hard-coded values
- * (11/12/13/14/15/16) until PR-2 finishes the Editor consolidation +
- * Sync upgrade. PR-2 swaps the remaining hard-coded values for the
- * `MODULE_*` constants below — see spec §4.1.3 / §4.1.4.
+ * Two surfaces are exposed:
+ *
+ * 1. `SETTINGS_ORDER` — the active order values for the **current** state
+ *    of the codebase (PR-1: includes PR-1 transitional `MODULE_*_PR1`
+ *    constants). All call sites read from this object.
+ *
+ * 2. `SETTINGS_ORDER_PR2_FUTURE` — values that PR-2 will switch to after
+ *    Editor consolidation + Sync upgrade complete. **Not used by any
+ *    call site in PR-1.** Kept here so the eventual PR-2 swap is a
+ *    one-line constant rename rather than a wholesale rewrite.
  */
 export const SETTINGS_ORDER = {
   // Top built-in (core) — always present.
@@ -32,12 +36,30 @@ export const SETTINGS_ORDER = {
   ELECTRON: 5,
   // Modules switchboard — single row, header of the modules group.
   MODULE_CONFIG: 10,
-  // Module-owned (PR-2 final values; PR-1 keeps transitional numbers).
+  // Module-owned (PR-1 transitional). Editor still has three sidebar
+  // entries (open-behavior / link-detect / editor); Sync is still
+  // registered as a built-in section. PR-2 collapses these into a
+  // single Editor entry + upgrades Sync to a module — at that point
+  // the values move to SETTINGS_ORDER_PR2_FUTURE below.
+  MODULE_PERFORMANCE_MONITOR_PR1: 11,
+  MODULE_EDITOR_OPEN_BEHAVIOR_PR1: 12,
+  MODULE_EDITOR_LINK_DETECT_PR1: 13,
+  MODULE_EDITOR_PR1: 14,
+  MODULE_QUICK_COMMANDS_PR1: 15,
+  SYNC_PR1: 16,
+  // Tail built-in — dev / debug surfaces.
+  DEV_ENVIRONMENT: 20,
+  TMUX_AGENT_MONITOR: 21,
+} as const
+
+/**
+ * Order values that PR-2 will adopt once Editor consolidation +
+ * Sync upgrade complete. Do not import these constants in PR-1
+ * call sites — the file-level lint guard / order test rejects use.
+ */
+export const SETTINGS_ORDER_PR2_FUTURE = {
   MODULE_EDITOR: 11,
   MODULE_QUICK_COMMANDS: 12,
   MODULE_PERFORMANCE_MONITOR: 13,
   MODULE_SYNC: 14,
-  // Tail built-in — dev / debug surfaces.
-  DEV_ENVIRONMENT: 20,
-  TMUX_AGENT_MONITOR: 21,
 } as const


### PR DESCRIPTION
## Summary

Settings 架構修正 PR-1（純視覺 / 順序），對應 [spec §5.1](docs/specs/2026-05-02-settings-architecture-fix-spec.md) + [plan PR-1](docs/specs/2026-05-02-settings-architecture-fix-plan.md)。

**4 個 commit，每個 commit CI 獨立綠**

- `d6b7fed5` — 新增 `SETTINGS_ORDER` 常數（集中 sidebar order，避免再撞 8/8 collision）
- `a99ab3cc` — Sidebar 重排到 PR-1 過渡 order 表 + 紅綠測試（`settings-order-pr1.test.ts`）。Modules switchboard 從 8 → 10，落到所有 module-owned 上方；Editor 三 entry / Performance Monitor / Quick Commands / Sync 各 +offset 進入 modules 群組
- `85c9303d` — Puzzle icon 三 caller 改 `weight="bold"` + 移除 `rotate-[30deg]`（SettingsSidebar / WorkspaceSettingsPage / HostSidebar）+ mock-prop test 守住
- `02faafb6` — `ModulesSwitchboardSection` outer wrapper `p-6 space-y-6` → `space-y-6`，避免與 `GlobalSettingsPage` 的 `p-6` 雙 pad

PR-2（Editor 三頁合一 + Sync modularize + Quick Commands 頁首）獨立 PR 接續，本 PR 完全不碰結構變更。

## Test plan

- [x] `cd spa && npx vitest run` — 3175 passed / 4 pre-existing failed（TabBar pinned tooltip + 3 sync hosts contributor，main 上同樣紅，與本 PR 無關）
- [x] `cd spa && pnpm run lint` — 0 error
- [x] grep `rotate-\[30deg\]` 全 spa source 0 hits
- [x] 既有 `register-modules.test.ts` F3 module-config order 斷言更新（8 → 10），是直接副作用
- [ ] 手動：mlab dev server + Air `.app` 開啟 `/settings`，確認 sidebar 順序 = §4.1.4 過渡表、puzzle icon 直立 bold、Modules Switchboard 內距正常