### PR TITLE
fix(spa): silence empty opencode stop notifications

### DIFF
--- a/internal/agent/opencode/status.go
+++ b/internal/agent/opencode/status.go
@@ -20,7 +20,10 @@ func deriveOpenCodeStatus(eventName string, rawEvent json.RawMessage) agent.Deri
 	case "PdxPermissionRequest":
 		return agent.DeriveResult{Valid: true, Status: agent.StatusWaiting, Detail: detailSubset(raw, "request_type", "permission", "patterns", "questions")}
 	case "PdxStop":
-		return agent.DeriveResult{Valid: true, Status: agent.StatusIdle}
+		return agent.DeriveResult{Valid: true, Status: agent.StatusIdle, Detail: map[string]any{
+			"notification_silent": true,
+			"stop_source":          "session.status.idle",
+		}}
 	case "PdxStopFailure":
 		return agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: detailSubset(raw, "error", "error_details")}
 	case "PdxSessionEnd":

--- a/internal/agent/opencode/status_test.go
+++ b/internal/agent/opencode/status_test.go
@@ -72,6 +72,12 @@ func TestOpenCodeDeriveStatus_PdxStop(t *testing.T) {
 	if !r.Valid || r.Status != agent.StatusIdle {
 		t.Fatalf("expected idle, got %+v", r)
 	}
+	if r.Detail["notification_silent"] != true {
+		t.Fatalf("notification_silent = %#v, want true", r.Detail["notification_silent"])
+	}
+	if r.Detail["stop_source"] != "session.status.idle" {
+		t.Fatalf("stop_source = %#v, want session.status.idle", r.Detail["stop_source"])
+	}
 }
 
 func TestOpenCodeDeriveStatus_PdxStopFailure(t *testing.T) {

--- a/spa/src/hooks/useNotificationDispatcher.test.ts
+++ b/spa/src/hooks/useNotificationDispatcher.test.ts
@@ -20,6 +20,9 @@ describe('shouldNotify', () => {
   it('returns true for idle event', () => {
     expect(shouldNotify({ derived: 'idle', eventName: 'Stop', compositeKey: 'host:abc', focusedCompositeKey: '', hasTab: true, settings: defaultSettings })).toBe(true)
   })
+  it('returns false for notification_silent event', () => {
+    expect(shouldNotify({ derived: 'idle', eventName: 'PdxStop', compositeKey: 'host:abc', focusedCompositeKey: '', hasTab: true, settings: defaultSettings, notificationSilent: true })).toBe(false)
+  })
   it('returns false for running event', () => {
     expect(shouldNotify({ derived: 'running', eventName: 'UserPromptSubmit', compositeKey: 'host:abc', focusedCompositeKey: '', hasTab: true, settings: defaultSettings })).toBe(false)
   })

--- a/spa/src/hooks/useNotificationDispatcher.ts
+++ b/spa/src/hooks/useNotificationDispatcher.ts
@@ -55,14 +55,16 @@ interface ShouldNotifyParams {
   focusedCompositeKey: string
   hasTab: boolean
   settings: NotificationSettings
+  notificationSilent?: boolean
 }
 
 export function shouldNotify(params: ShouldNotifyParams): boolean {
-  const { derived, eventName: rawEventName, compositeKey: ck, focusedCompositeKey, hasTab, settings } = params
+  const { derived, eventName: rawEventName, compositeKey: ck, focusedCompositeKey, hasTab, settings, notificationSilent = false } = params
   // W2 transition: cc broadcasts PdxXxx; legacy literal keys live in shouldNotify
   // suppression checks and NotificationSettings.events. Normalize once at entry.
   const eventName = normalizeEventName(rawEventName)
   if (derived !== 'waiting' && derived !== 'idle' && derived !== 'error') return false
+  if (notificationSilent) return false
   // Informational Notification subtypes (idle_prompt, auth_success) derive to 'idle'
   // but should not trigger desktop notifications — consistent with unread marking logic.
   if (derived === 'idle' && eventName === 'Notification') return false
@@ -111,7 +113,15 @@ export function useNotificationDispatcher(): void {
         const activeInfo = getActiveSessionInfo()
         const focusedCompositeKey = activeInfo ? compositeKey(activeInfo.hostId, activeInfo.sessionCode) : ''
 
-        if (!shouldNotify({ derived, eventName: event.raw_event_name, compositeKey: compositeKeyStr, focusedCompositeKey, hasTab, settings })) continue
+        if (!shouldNotify({
+          derived,
+          eventName: event.raw_event_name,
+          compositeKey: compositeKeyStr,
+          focusedCompositeKey,
+          hasTab,
+          settings,
+          notificationSilent: event.detail?.notification_silent === true,
+        })) continue
 
         const sessionsMap = useSessionStore.getState().sessions
         const hostSessions = sessionsMap[hostId] ?? []

--- a/spa/src/stores/useAgentStore.test.ts
+++ b/spa/src/stores/useAgentStore.test.ts
@@ -252,6 +252,19 @@ describe('useAgentStore', () => {
     expect(useAgentStore.getState().unread[`${H}:dev`]).toBe(true)
   })
 
+  it('silent Stop → idle, does NOT mark unread', () => {
+    const event: NormalizedEvent = {
+      agent_type: 'opencode',
+      status: 'idle',
+      raw_event_name: 'PdxStop',
+      broadcast_ts: Date.now(),
+      detail: { notification_silent: true, stop_source: 'session.status.idle' },
+    }
+    useAgentStore.getState().handleNormalizedEvent(H, 'dev', event)
+    expect(useAgentStore.getState().statuses[`${H}:dev`]).toBe('idle')
+    expect(useAgentStore.getState().unread[`${H}:dev`]).toBeUndefined()
+  })
+
   it('Stop → does NOT mark unread when focused', () => {
     const tab = { ...createTab({ kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev', mode: 'terminal', cachedName: '', tmuxInstance: '' }), id: 't1' }
     useTabStore.setState({ tabs: { t1: tab }, activeTabId: 't1' })

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -175,8 +175,9 @@ export const useAgentStore = create<AgentState>()(
         // both literals during the transition.
         const rawName = event.raw_event_name
         const isNotification = rawName === 'Notification' || rawName === 'PdxNotification'
+        const notificationSilent = event.detail?.notification_silent === true
         const isActionable = status === 'waiting' || status === 'error' ||
-          (status === 'idle' && !isNotification)
+          (status === 'idle' && !isNotification && !notificationSilent)
         const activeInfo = getActiveSessionInfo()
         const activeKey = activeInfo ? compositeKey(activeInfo.hostId, activeInfo.sessionCode) : ''
         if (isActionable && activeKey !== key) {


### PR DESCRIPTION
## Summary
- Mark OpenCode `PdxStop` events derived from `session.status.idle` as notification-silent while preserving the idle status transition.
- Respect `detail.notification_silent` in SPA unread and desktop notification policy.

## Tests
- `go test ./internal/agent/opencode ./internal/module/agent -count=1`
- `pnpm --prefix spa exec vitest run src/stores/useAgentStore.test.ts src/hooks/useNotificationDispatcher.test.ts`
- `pnpm --prefix spa run lint`