### PR TITLE
fix(agent): ignore detached frames in pane projection

### DIFF
--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -783,8 +783,55 @@ func (m *Module) projectPane(paneID string) (*SessionProjection, error) {
 	if err != nil {
 		return nil, err
 	}
+	frames = m.filterPaneOwnedProjectionFrames(paneID, frames)
 	projection := buildPaneProjection(paneID, frames)
 	return &projection, nil
+}
+
+func (m *Module) filterProjectionFrames(frames []store.Frame) []store.Frame {
+	if len(frames) == 0 {
+		return frames
+	}
+	byPane := make(map[string][]store.Frame)
+	for _, frame := range frames {
+		byPane[frame.PaneID] = append(byPane[frame.PaneID], frame)
+	}
+	filtered := make([]store.Frame, 0, len(frames))
+	for paneID, paneFrames := range byPane {
+		filtered = append(filtered, m.filterPaneOwnedProjectionFrames(paneID, paneFrames)...)
+	}
+	return filtered
+}
+
+func (m *Module) filterPaneOwnedProjectionFrames(paneID string, frames []store.Frame) []store.Frame {
+	if len(frames) == 0 || m == nil || m.tmux == nil {
+		return frames
+	}
+	panePID, err := resolvePanePIDFn(m.tmux, paneID)
+	if err != nil {
+		return frames
+	}
+	filtered := make([]store.Frame, 0, len(frames))
+	for _, frame := range frames {
+		if projectionFrameEligibleForPane(frame, panePID) {
+			filtered = append(filtered, frame)
+		}
+	}
+	return filtered
+}
+
+func projectionFrameEligibleForPane(frame store.Frame, panePID int) bool {
+	if !isPidAliveFn(frame.PID) {
+		return false
+	}
+	actualStart, err := processStartTimeFn(frame.PID)
+	if err != nil {
+		return true
+	}
+	if actualStart != frame.ProcessStartTime {
+		return false
+	}
+	return pidAncestorIncludesFn(frame.PID, panePID)
 }
 
 func frameID(frame *store.Frame) string {

--- a/internal/module/agent/module.go
+++ b/internal/module/agent/module.go
@@ -637,6 +637,7 @@ func (m *Module) liveFrameProjections() ([]SessionProjection, error) {
 	if len(frames) == 0 {
 		return nil, nil
 	}
+	frames = m.filterProjectionFrames(frames)
 	return BuildSessionProjections(frames), nil
 }
 

--- a/internal/module/agent/projection_test.go
+++ b/internal/module/agent/projection_test.go
@@ -1,10 +1,12 @@
 package agent
 
 import (
+	"encoding/json"
 	"testing"
 
 	agentpkg "github.com/wake/purdex/internal/agent"
 	"github.com/wake/purdex/internal/store"
+	"github.com/wake/purdex/internal/tmux"
 )
 
 func TestProjection_TopFrameWins(t *testing.T) {
@@ -183,11 +185,11 @@ func TestProjection_NoProxyRefsUnchangedBehavior(t *testing.T) {
 // preserves both refs by merging.
 //
 // Race scenario unchanged from Q1 trail:
-//   1. cc + codex SessionStart race → standalone codex created
-//   2. cc reconcile attaches IsProxy ref to cc but the DeleteIfUnchanged
-//      against the codex row fails (concurrent writer)
-//   3. A SubagentStart hook for codex arrives and writes a native ref
-//      into codex.Subagents
+//  1. cc + codex SessionStart race → standalone codex created
+//  2. cc reconcile attaches IsProxy ref to cc but the DeleteIfUnchanged
+//     against the codex row fails (concurrent writer)
+//  3. A SubagentStart hook for codex arrives and writes a native ref
+//     into codex.Subagents
 //
 // Result: TopFrame == cc; Subagents = [cc's IsProxy codex ref,
 // child's native task-codex-1 ref] (both preserved on wire).
@@ -562,6 +564,85 @@ func TestProjection_IT5_PartialStateHiddenByProjectionDedup(t *testing.T) {
 	delta := agentpkg.MetricProjectionDedupHidden.Value() - startMetric
 	if delta != 1 {
 		t.Fatalf("MetricProjectionDedupHidden delta = %d, want +1", delta)
+	}
+}
+
+func TestProjectPane_FiltersDetachedAliveFramesFromTop(t *testing.T) {
+	m := newSweepTestModule(t)
+	m.tmux.(*tmux.FakeExecutor).SetPanePID("%5", "100")
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "codex",
+		PID:              200,
+		PPID:             1,
+		ProcessStartTime: "live",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origAncestor := pidAncestorIncludesFn
+	isPidAliveFn = func(pid int) bool { return pid == 200 }
+	processStartTimeFn = func(pid int) (string, error) { return "live", nil }
+	pidAncestorIncludesFn = func(pid, ancestor int) bool { return false }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		pidAncestorIncludesFn = origAncestor
+	})
+
+	proj, err := m.projectPane("%5")
+	if err != nil {
+		t.Fatalf("projectPane: %v", err)
+	}
+	if proj == nil || proj.TopFrame != nil {
+		t.Fatalf("TopFrame = %+v, want nil for detached frame", proj.TopFrame)
+	}
+	normalized := buildProjectionNormalized(proj, "cc", "PdxSessionEnd", 1, agentpkg.DeriveResult{Valid: true})
+	if normalized.Status != string(agentpkg.StatusClear) {
+		b, _ := json.Marshal(normalized)
+		t.Fatalf("normalized = %s, want status clear", b)
+	}
+}
+
+func TestProjectPane_KeepsPaneOwnedFrameAsTop(t *testing.T) {
+	m := newSweepTestModule(t)
+	m.tmux.(*tmux.FakeExecutor).SetPanePID("%5", "100")
+	if _, err := m.frames.Upsert(store.Frame{
+		PaneID:           "%5",
+		AgentType:        "cc",
+		PID:              200,
+		PPID:             100,
+		ProcessStartTime: "live",
+		Status:           agentpkg.StatusIdle,
+		StartedAt:        10,
+		LastSeenAt:       10,
+		Verified:         true,
+	}); err != nil {
+		t.Fatalf("Upsert frame: %v", err)
+	}
+	origAlive := isPidAliveFn
+	origStart := processStartTimeFn
+	origAncestor := pidAncestorIncludesFn
+	isPidAliveFn = func(pid int) bool { return pid == 200 }
+	processStartTimeFn = func(pid int) (string, error) { return "live", nil }
+	pidAncestorIncludesFn = func(pid, ancestor int) bool { return pid == 200 && ancestor == 100 }
+	t.Cleanup(func() {
+		isPidAliveFn = origAlive
+		processStartTimeFn = origStart
+		pidAncestorIncludesFn = origAncestor
+	})
+
+	proj, err := m.projectPane("%5")
+	if err != nil {
+		t.Fatalf("projectPane: %v", err)
+	}
+	if proj.TopFrame == nil || proj.TopFrame.AgentType != "cc" {
+		t.Fatalf("TopFrame = %+v, want cc", proj.TopFrame)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Filter pane projections to frames whose process still belongs to the current tmux pane tree.
- Preserve fail-open behavior when tmux PID or process start lookup is unavailable.
- Add regression coverage for alive-but-detached codex frames clearing instead of becoming the top frame.

## Tests
- go test ./internal/module/agent -run 'TestProjectPane_FiltersDetachedAliveFramesFromTop|TestProjectPane_KeepsPaneOwnedFrameAsTop|TestLiveFrameProjections_PreservesFrameOnLookupError|TestProjection_IT5_PartialStateHiddenByProjectionDedup' -count=1
- go test ./internal/module/agent -count=1
- git diff --check