### PR TITLE
[lights] cc Bash sniff delegating flag for codex visibility (#821)

### DIFF
--- a/docs/specs/2026-05-03-lights-bash-sniff-delegating-plan.md
+++ b/docs/specs/2026-05-03-lights-bash-sniff-delegating-plan.md
@@ -1,0 +1,294 @@
+# Lights Bash Sniff Delegating — Implementation Plan
+
+> **Status**：v3（plan-review round 2 採納 1 high + 1 minor 全收斂；plan freeze）
+>
+> v1 → v2 修：B1 mark/unmark 不再 reuse `mutateSubagentsWithRetry`（updateSubagents 不支援 in-place mutation），改 mirror `upsertProxyRefForBroker:1245` pattern 走 dedicated UpsertIfUnchanged retry loop；B2 helper signature 加 `(senderPID, senderStartTime)` 並內部用 `GetByIdentity` 找 frame；F4 P3-T1 加非-cc agent_type explicit gating tests；F6 handler placement 明寫 separate adjacent block（不 nest 在 PathHint conditional 內）；F8 mlab live verify 必在 PR push 前完成並更新 spec L6 wording
+>
+> v2 → v3 修：F9 撤回——P6-T3 adversarial review 改回 always run（不 conditional）對齊 repo 兩輪 review 流程；test count/run regex 不一致 cleanup（P2 統一 12 cases + regex 加 `TestSubagentStop`；P3 統一 8 cases）
+> **依賴 spec**：`docs/specs/2026-05-03-lights-bash-sniff-delegating-spec.md` v2 final（spec round 2 codex review 0 blocker）
+> **Worktree**：`.claude/worktrees/lights-bash-sniff-delegating` / branch `worktree-lights-bash-sniff-delegating`
+> **Base**：`origin/main` @ alpha.283（L2 `d9db812d` + bump `9374bf88`）
+> **拆分**：4 個 phase 序列執行（資料 schema → daemon helpers → handler wiring → SPA 層）+ 整合驗證；每 task 獨立 commit；單一 subagent owner per phase（避 file 寫衝突）
+> **Issue**：[#821](https://github.com/wake/purdex/issues/821)
+
+---
+
+## 0. Plan 總覽
+
+### 0.1 範圍重申（per spec §1 / §3）
+
+Lights bash sniff delegating — 在 cc subagent 透過 Bash invoke `codex-companion.mjs` 時，於 cc 父 frame 的對應 SubagentRef 上掛 `Delegating=true` flag，SPA 渲染為橘色 dot；PostToolUse / PostToolUseFailure 配對清除；不污染 IsProxy invariant。
+
+**核心 in-scope**（spec §3）：
+- #1：`SubagentRef` 加 `Delegating bool` + `DelegatingToolUseIDs []string` 兩個 omitempty 欄位（§3.1）
+- #2：`internal/module/agent/delegation_extractor.go` 純函式 `ExtractDelegationHint`（§3.4）含 token-boundary 檢測（§3.3）
+- #3：`internal/module/agent/frame_ops.go` 兩 helper：`markDelegatingRef` / `unmarkDelegatingRef`（§3.5），用 `mutateSubagentsWithRetry` 走 optimistic concurrency
+- #4：`internal/module/agent/handler.go` wiring 三事件：`PdxPreToolUse` (mark) / `PdxPostToolUse` + `PdxPostToolUseFailure` (unmark) — 緊鄰既有 PathHint 區塊（handler.go:195-202）
+- #5：SPA 層更新 `SubagentRef` type、`SubagentDots.tsx` 渲染條件 `(is_proxy || delegating) ? PROXY_COLOR : NATIVE_COLOR`、新增 `data-delegating` 測試屬性
+
+**Out-of-scope reaffirm**（spec §3.7）：
+- 不解 codex 端真實 lifecycle（governance P3 才解）
+- 不取代 governance phase
+- 不改 `IsProxy` 任何 attach 路徑（保持 invariant）
+- 不偵測 codex CLI 直接呼叫（非 codex-companion）
+- 不處理 opencode 委派（agent_type gate）
+- 不為 background Bash `BashOutput` 輪詢做特殊追蹤（spec L6 已知限制）
+- 不處理 `PdxPostToolBatch`（Task tool semantic，非 Bash）
+
+### 0.2 估計
+
+- 總 production code：~210 行（subagent.go +8 / delegation_extractor.go +90 / frame_ops.go +70 / handler.go +35 / spa +10）
+- 總 test code：~410 行（extractor +180 / frame_ops +130 / handler +60 / spa +40）
+- 預估 PR diff：~620 raw production+tests / ≤700 effective（spec AC11 cap）+ ~850 spec/plan docs
+- 預估時間：4-6 小時 subagent TDD（Phase 1 ~1.5hr / Phase 2 ~1.5hr / Phase 3 ~1.5hr / Phase 4 ~1hr）+ 1 輪 standard codex review + 1 輪 adversarial review (~2-3hr）+ mlab live verify ~30min
+
+### 0.3 鎖序與不變式（per spec §3）
+
+實作時必持守：
+- **`IsProxy` 完全不動**：daemon 只在 `delegation_extractor` / `markDelegatingRef` / `unmarkDelegatingRef` / `handler` 三地對 `Delegating` + `DelegatingToolUseIDs` 兩個新欄位讀寫；既有 `findProxyParent` / `attachProxyRefWithRetry` / `removeProxyRefForSender*` / `canonicalizeDescendantsAfterUpsert` / `pruneDeadProxyRefs` / L2 turn-aware path **零修改**
+- **Invariant `Delegating == len(DelegatingToolUseIDs) > 0`**：mark/unmark 兩 helper 必持守；slice append 走 dedupe；slice remove 走 linear scan；recompute Delegating 走 `len() > 0`
+- **Dedicated retry loop（B1 修正）**：mark/unmark 兩 helper **不能** reuse `mutateSubagentsWithRetry`——既有 helper 經 `updateSubagents` 只支援 SubagentStart append-if-missing 與 SubagentStop remove-matching，**沒有 in-place mutation 既有 ref 欄位的能力**（`frame_ops.go:825-840`）。改 mirror `upsertProxyRefForBroker:1245-1297` 的 pattern：直接 `copy(next, current.Subagents)` → mutate `next[idx].DelegatingToolUseIDs / .Delegating` → `UpsertIfUnchanged(current, expected.LastSeenAt)`，衝突走 `GetByIdentity` reload 重試。`proxyUpsertMaxAttempts=3` 的 retry cap 套用相同值
+- **Helper signature 含 frame identity（B2 修正）**：mark/unmark 兩 helper 接 `(paneID string, senderPID int, senderStartTime string, agentID, toolUseID string, broadcastTs int64) error`——內部用 `GetByIdentity(paneID, senderPID, senderStartTime)` 找 cc frame；session-code resolve 由 caller (handler) 做，helper 純粹做 frame mutation
+- **token detection 純函式**：`containsCodexCompanionToken` 不依賴外部 state，可全 unit test 覆蓋；無 regex（避 ReDoS）
+- **handler wiring 緊鄰 PathHint**：新邏輯放在 handler.go:195-202 既有 cc PdxPreToolUse / PdxPostToolUse 區塊**之後**（同 if 條件），確保不影響既有 PathHint 流；`PdxPostToolUseFailure` wiring 不需動 cc events catalog（已存在 line 125-131）
+- **SPA 層分離測試屬性**：`data-is-proxy` 不動（保留既有測試介面），新加 `data-delegating`；測試 case 改 ref shape 而非改 attribute name
+- **`mutateSubagentsWithRetry` race scope 不誇大**：只 cover「ref 已存在後的 concurrent writes」；PreToolUse 在 SubagentStart 之前到達 → 靜默 no-op（spec L7 / regression #12）
+
+### 0.4 Spec 收斂歷程備註
+
+Spec v1 → v2 共 1 輪 codex review 收斂（B1 token detection / B2 slice / B3 PostToolUseFailure / M1-M2 / F1-F5 / AC11 統一 / regression matrix +3 row / size estimate 修正）。Spec round 2 codex review 0 blocker，2 minor wording fix 已 inline 修正（spec §1 開頭 size estimate stale + §2.4 dispatch sites wording）。
+
+**不再審 spec**，剩餘風險靠 PR review 兜底（spec §11 freeze checklist 最末條 — PR 兩輪 codex review）。
+
+---
+
+## 1. Phase 1：資料 schema + 純函式 extractor（Subagent A）
+
+可獨立完成。Subagent A 拿 P1-T1 + P1-T2，每 task 獨立 commit。
+
+### P1-T1 — `SubagentRef` 加兩個 omitempty 欄位
+
+**目標**：在 `internal/agent/subagent.go::SubagentRef` 加 `Delegating bool` + `DelegatingToolUseIDs []string`，跟著既有 `SourceTurnID` 的 omitempty 模式（同檔頭註解），無 DB migration。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/agent/subagent.go` | `SubagentRef` 加兩欄；header 註解加一段：「`Delegating` / `DelegatingToolUseIDs`：cc subagent 跑 Bash invoking codex-companion 時的旁路 flag，與 `IsProxy`（cross-type PPID 驗證）正交。Invariant：`Delegating == len(DelegatingToolUseIDs) > 0`，由 `markDelegatingRef`/`unmarkDelegatingRef` 共同維持」 |
+| `internal/agent/subagent_test.go` | 加 `TestSubagentRef_DelegatingFields_OmitemptyJSON` —— Marshal 空值 ref，確認 `delegating` / `delegating_tool_use_ids` key 不出現；Marshal 帶值 ref 確認都出現 |
+
+**TDD 步驟**：
+1. 寫 test：`TestSubagentRef_DelegatingFields_OmitemptyJSON`（Red）
+2. 加欄位 + JSON tag（Green）
+3. Lint 跑 (Refactor)
+4. **Commit**: `feat(daemon): SubagentRef adds Delegating + DelegatingToolUseIDs fields`
+
+### P1-T2 — `delegation_extractor.go` 純函式 + token detection + 全 table-driven 測試
+
+**目標**：實作 `ExtractDelegationHint` pure function（spec §3.4）+ `containsCodexCompanionToken` token-boundary helper（spec §3.3）。完全可單獨 unit test，無 daemon state 依賴。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/delegation_extractor.go`（新檔） | 約 90 LOC：`DelegationHint` struct（4 欄）、`ExtractDelegationHint(rawEvent, eventName) (DelegationHint, bool)`、`containsCodexCompanionToken(command string) bool`。常數復用 `MaxRawEventBytes` from `path_hint_extractor.go:15`；defenses 對齊（agent_id / tool_use_id 拒控制字元、bound 長度）。Switch 三 eventName：`PdxPreToolUse` / `PdxPostToolUse` / `PdxPostToolUseFailure`。Pre 命中要求 `IsCodexMark = containsCodexCompanionToken(command)`；Post 兩 event 統一回 `IsUnmark = true, IsCodexMark = false` |
+| `internal/module/agent/delegation_extractor_test.go`（新檔） | 約 180 LOC：`TestExtractDelegationHint_Cases` table-driven 14 cases（spec §6.1 全表 + 邊界）；`TestContainsCodexCompanionToken_Cases` table-driven 9 cases（spec §3.3 全表 + 邊界 like `mjsx` / `mjs.bak` / EOF / 多 occurrence）|
+
+**TDD 步驟**：
+1. 寫 14 個 ExtractDelegationHint test case（全 Red）
+2. 寫 9 個 containsCodexCompanionToken test case（Red）
+3. 實作 `containsCodexCompanionToken`（先 Green token detection）
+4. 實作 `ExtractDelegationHint` 解 raw JSON / 套 token check / 套 defenses（Green）
+5. 跑 `go test ./internal/module/agent/... -run TestExtractDelegationHint -v` 全綠
+6. Lint
+7. **Commit**: `feat(daemon): add ExtractDelegationHint pure function with token-boundary detection`
+
+---
+
+## 2. Phase 2：daemon helpers — markDelegatingRef / unmarkDelegatingRef（Subagent B）
+
+Phase 1 全 commit 後啟動，因為 P2-T1 要動 `frame_ops.go` 並讀 `SubagentRef.DelegatingToolUseIDs` 欄位。
+
+### P2-T1 — `markDelegatingRef` + `unmarkDelegatingRef` helpers（dedicated retry loop）
+
+**目標**：在 `internal/module/agent/frame_ops.go` 加兩 helper，**mirror `upsertProxyRefForBroker:1245-1297` 的 pattern**（B1 修正：不能 reuse `mutateSubagentsWithRetry`），自己跑 `UpsertIfUnchanged` retry；signature 含 frame identity (B2 修正)。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/frame_ops.go` | 約 90 LOC：兩 method 簽名：<br>`(m *Module) markDelegatingRef(paneID string, senderPID int, senderStartTime string, agentID, toolUseID string, broadcastTs int64) error`<br>`(m *Module) unmarkDelegatingRef(paneID string, senderPID int, senderStartTime string, agentID, toolUseID string, broadcastTs int64) error`<br>內部 pattern：(1) `m.frames.GetByIdentity(paneID, senderPID, senderStartTime)` 找 cc frame；nil → 靜默 no-op（spec L7 race：PreToolUse 在 SubagentStart 之前到達）。(2) for attempt in [0, proxyUpsertMaxAttempts) — `expected := current.LastSeenAt`、`copy(next, current.Subagents)`、線性 scan find `ref.ID == agentID` → 沒找到 → no-op（spec §3.5 race acceptable）；找到 → mutate `next[idx].DelegatingToolUseIDs` (mark: dedupe append / unmark: linear remove) + `next[idx].Delegating = len(next[idx].DelegatingToolUseIDs) > 0`。(3) `next` assign back, `current.LastSeenAt = broadcastTs`，`UpsertIfUnchanged(current, expected)` → ok return；衝突 reload via `GetByIdentity` retry。註解明寫「mirror upsertProxyRefForBroker pattern」+ 「Race scope: PreToolUse-before-SubagentStart silent no-op (spec L7)」 |
+| `internal/module/agent/frame_ops_test.go` | 約 130 LOC，11 cases per spec §6.2 + 加 1（B2 verification）：`TestMarkDelegatingRef_AppendsToolUseIDOnMatchingRef` / `TestMarkDelegatingRef_DedupesRepeatedToolUseID` / `TestMarkDelegatingRef_NoOpWhenAgentIDNotFound` / `TestMarkDelegatingRef_NoOpWhenFrameMissing` / `TestMarkDelegatingRef_RetryOnUpsertConflict` (B2: simulate concurrent writer via `frames.UpsertIfUnchanged` mismatch, verify retry loop succeeds) / `TestUnmarkDelegatingRef_RemovesToolUseID` / `TestUnmarkDelegatingRef_DelegatingFalseWhenListEmpties` / `TestUnmarkDelegatingRef_DelegatingTrueWhenOthersStillActive` / `TestUnmarkDelegatingRef_NoOpWhenToolUseIDNotInList` / `TestUnmarkDelegatingRef_NoOpAfterSubagentStop` / `TestSubagentStopRemovesRefIncludingDelegatingFlag` / `TestDelegatingNativeRef_CoexistsWith_RealIsProxyRef_OnSameParent` |
+
+**TDD 步驟**：
+1. 寫 12 個 test case（全 Red）
+2. 實作兩 helper（Green）
+3. 跑 `go test ./internal/module/agent/... -run "TestMark|TestUnmark|TestDelegating|TestSubagentStop" -v` 全綠
+4. 跑 `go test ./internal/module/agent/... -count=10 -race` 確保 dedicated retry loop concurrency 路徑不 panic
+5. Lint
+6. **Commit**: `feat(daemon): add markDelegatingRef + unmarkDelegatingRef helpers with optimistic concurrency`
+
+---
+
+## 3. Phase 3：handler wiring + integration tests（主 session）
+
+Phase 2 全 commit 後啟動。主 session 接手 — 涉及 handler 跨多 lifecycle，需 careful integration。
+
+### P3-T1 — `handler.go` wiring delegation extractor 到 cc PreTool/PostTool/PostToolFailure
+
+**目標**：在 `handler.go:195-202` 既有 PathHint 處理區塊**緊鄰之後加 separate adjacent block**（F6 修正：**不 nest 在 PathHint conditional 內**——PathHint 依賴 `m.core / m.pathHintDedup / m.pathHintBuffer`，delegation 不需這些）；mark/unmark via Phase 2 helpers，把 `req.SenderPID / req.SenderStartTime` 傳入 helper（B2 修正）。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/handler.go` | 約 40 LOC：在 PathHint block **之後**（不在 if 內）加新獨立 block：`if req.AgentType == "cc" && (req.PurdexName == "PdxPreToolUse" \|\| req.PurdexName == "PdxPostToolUse" \|\| req.PurdexName == "PdxPostToolUseFailure")`，呼叫 `ExtractDelegationHint(req.RawEvent, req.PurdexName)`；hint OK + IsCodexMark → 呼叫 `m.markDelegatingRef(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, hint.AgentID, hint.ToolUseID, broadcastTs)`；hint OK + IsUnmark → `m.unmarkDelegatingRef(...)` 同樣 6 參數。錯誤 log 但不 fail handler（fail-soft 對齊 PathHint pattern）。註解說明：「Delegation flag 與 PathHint 並列獨立；不依賴 path-hint infrastructure；同一 cc PreToolUse raw event 可同時 emit 兩種推導，extraction 互相獨立、dedup state 不影響」 |
+| `internal/module/agent/handler_test.go` | 約 80 LOC integration test：<br>`TestHandleEvent_CCPreToolUseBashCodexCompanion_MarksDelegating` (e2e: inject PreToolUse fixture → assert frame.Subagents[i].Delegating==true)<br>`TestHandleEvent_CCPostToolUseBashAfterMark_UnmarksDelegating` (mark 後 inject PostToolUse → 確認 Delegating==false)<br>`TestHandleEvent_CCPostToolUseFailureBashAfterMark_UnmarksDelegating` (B3 path)<br>`TestHandleEvent_CCPreToolUseBashNonCodex_NoMark` (non-codex Bash → 不 mark)<br>`TestHandleEvent_CCPreToolUseBashTopLevelNoAgentID_NoMark` (agent_id="" → skip)<br>`TestHandleEvent_CCPreToolUseConcurrentTwoCodexBash_BothTracked` (B2 reverse-order verification)<br>**`TestHandleEvent_CodexAgentTypePreToolUseBashCodexCompanion_NoMark` (F4 — AC10 / regression #9 explicit handler-level gating)**<br>**`TestHandleEvent_OpencodeAgentTypePreToolUseBashCodexCompanion_NoMark` (F4 — AC10 / regression #10 explicit handler-level gating)** |
+
+**TDD 步驟**：
+1. 寫 8 個 integration test case（全 Red）—— 6 cc 路徑 + 2 非-cc agent_type gating
+2. 加 wiring（Green）
+3. 跑 `go test ./internal/module/agent/... -run "TestHandleEvent_(CC|Codex|Opencode).*Delegating|TestHandleEvent_(CC|Codex|Opencode).*NoMark" -v` 全綠
+4. 跑全 `internal/module/agent/...` test suite 確保零 regression（特別 `frame_ops_l2_test.go` L2 turn-aware）
+5. 跑 `go vet ./...` + lint
+6. **Commit**: `feat(daemon): wire delegation extractor in handler for cc PreTool/PostTool/PostToolFailure`
+
+---
+
+## 4. Phase 4：SPA 層 — type + renderer + 測試（Subagent C）
+
+可跟 Phase 2/3 並行（SPA 層獨立檔），但簡化起見序列做。
+
+### P4-T1 — SPA `SubagentRef` type 加兩欄 + `SubagentDots` 渲染條件 + `data-delegating` attr
+
+**目標**：spec §3.6 全套：`useAgentStore.ts` SubagentRef type 加兩 optional 欄；`SubagentDots.tsx` `dotStyle` 加 `delegating` 條件、新增 `data-delegating` attr、保留 `data-is-proxy` 不變、註解更新。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `spa/src/stores/useAgentStore.ts` | +3：SubagentRef type 加 `delegating?: boolean` 與 `delegating_tool_use_ids?: string[]` 兩 optional fields |
+| `spa/src/components/SubagentDots.tsx` | +4：`dotStyle` 條件改 `(ref.is_proxy \|\| ref.delegating) ? PROXY_COLOR : NATIVE_COLOR`；JSX `<span>` 加 `data-delegating={ref.delegating ? 'true' : 'false'}`；上方註解 block（line 13-17）追加：「Delegating: cc native subagent 推測在 invoke codex-companion via Bash sniff（spec §3.6）；與 IsProxy 正交，OR 條件渲染相同橘色」 |
+| `spa/src/components/SubagentDots.test.tsx` | 約 +40：4 個 colour case：`delegating=true, is_proxy=false → orange + data-delegating=true + data-is-proxy=false`；`delegating=false, is_proxy=true → orange + data-delegating=false + data-is-proxy=true`；`delegating=true, is_proxy=true → orange + 兩屬性都 true`；`delegating=false, is_proxy=false → blue + 兩屬性都 false` |
+
+**TDD 步驟**：
+1. 寫 4 個 SPA test（全 Red）
+2. 改 type + renderer（Green）
+3. 跑 `cd spa && pnpm install && npx vitest run --reporter verbose` 全綠
+4. 跑 `cd spa && pnpm run lint` + `cd spa && pnpm run build` 確保無 type error
+5. **Commit**: `feat(spa): SubagentDots renders orange when delegating flag set`
+
+---
+
+## 5. Phase 5：整合驗證 + mlab live verify（主 session）
+
+Phase 1-4 全 commit 後執行。
+
+### P5-T1 — 全套 regression sweep
+
+**目標**：跑全 daemon test、SPA test、lint、build；確保 spec §6.5 既有 suite 全綠。
+
+**步驟**：
+1. `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-bash-sniff-delegating && go test ./... -count=1` — 全 daemon test 綠
+2. `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-bash-sniff-delegating && go test ./internal/module/agent/... -count=10 -race` — race-mode 10 輪
+3. `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-bash-sniff-delegating/spa && pnpm install && npx vitest run` — SPA 全綠
+4. `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-bash-sniff-delegating/spa && pnpm run lint && pnpm run build` — 0 lint error / build 成功
+5. `cd /Users/wake/Workspace/wake/purdex/.claude/worktrees/lights-bash-sniff-delegating && go vet ./...` — 0 vet
+6. **Commit (only if any auto-format changes)**: `chore: post-implementation sweep formatting`
+
+### P5-T2 — mlab live verify（**必在 P6-T1 push PR 之前完成**，F8 修正）
+
+**目標**：spec §6.3 background lifecycle observation；確認 foreground `/codex:rescue` 正確顯示橘色 + 結束變藍 + SubagentStop 消失；驗證 background 行為 (a) 還是 (b) 並 **on-spot 更新 spec §7 L6 wording**（因為 spec 在 PR diff 內，AC1b/AC2b 結論依賴此觀察）。
+
+**步驟**：
+1. mlab 端 `make build` daemon
+2. 換上新 daemon binary
+3. 在 cc session 跑 `/codex:rescue --wait` 簡單任務 → 觀察 SPA dot 變橘 → 任務完成後變藍 → cc subagent end 後消失
+4. 在 cc session 跑 `/codex:rescue --background` → 觀察 dot 行為（flicker 或 stays orange？）
+5. 在 cc session 跑 `/codex:adversarial-review --background` 三平行 → 觀察是否 3 個橘 dot
+6. 在 cc subagent 內 `pnpm build`（非 codex Bash）→ 確認 dot 留藍
+7. **on-spot Edit spec §7 L6 wording with real result**（不是「post-merge 更新」）：若 background lifecycle 是 (a)（flicker only），把 L6 描述定型為 confirmed limitation + 開 follow-up issue 追蹤 BashOutput tracking；若是 (b)（stays orange），把 AC1b/AC2b 升級為 unconditional pass + 移除 L6 conditional wording。Commit `fix(spec): finalize L6 background lifecycle wording per mlab observation`
+8. mlab 結果 capture 進 PR description（截圖 / 文字描述都可）
+
+**Failure path**：若觀察結果跟 spec §2.6 兩種預期都不符（罕見第三種行為），停下來 surface 給 user 重評估，不直接進 PR。
+
+---
+
+## 6. PR + Review
+
+### P6-T1 — Push + 開 PR
+
+**目標**：把 worktree branch push 上 origin，開 PR，包含 spec + plan + 6 commits + mlab verify 描述。
+
+**步驟**：
+1. 從 worktree 內 `git push -u origin worktree-lights-bash-sniff-delegating`
+2. `gh pr create --title "[lights] cc Bash sniff delegating flag for codex visibility (#821)" --body "$(...)"`：body 含 issue ref、spec freeze 結論、各 phase commit 摘要、mlab verify capture、AC checklist
+3. Mark P6-T1 done
+
+### P6-T2 — Round 1 codex standard review
+
+**目標**：跨模型第二意見，spec coherence + impl 對齊 + invariant 保護。
+
+**步驟**：
+1. `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" review --background --base main`
+2. 等 1-3 min 輪詢 result
+3. 若 0 finding → 進 P6-T3
+4. 若有 finding → 用 spec §10「PR review 問題彙整 + 收斂」流程：表格化（信心 / 關聯 / 複雜度），優先處理 high-conf + high-rel + low-cplx；當下不修開 issue 追蹤。
+5. 修完 commit `fix: address codex round-1 review`，重派 round 1 直到 0 blocker
+
+### P6-T3 — Round 2 codex 三平行 adversarial review（**always run**，對齊 repo 兩輪 review 流程）
+
+**目標**：spec §10 兩輪 review 的第二輪，三視角找 bug。
+
+**步驟**：
+1. `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" adversarial-review --background --base main "focus: 1) 攻擊方 — token detection 繞過 / Pre-Post 配對 race / SubagentStop 順序問題 / B2 slice unbounded growth; 2) 防守方 — IsProxy invariant 是否真不破壞 / L2 turn-aware 是否真不衝突 / canonicalizeDescendantsAfterUpsert 是否仍正確 read IsProxy only; 3) 體質 — delegation_extractor.go SRP / frame_ops.go 是否過大 / handler.go wiring 是否該抽 helper"`
+2. 等 5-10 min 輪詢
+3. 收斂 finding 同 P6-T2 流程
+4. 採納完所有可修項，issue 追蹤 deferred
+
+### P6-T4 — Squash merge + bump PR
+
+**目標**：CLAUDE.md 流程 — 不直推 main，PR merge 後獨立 bump PR。
+
+**步驟**：
+1. `gh pr merge --squash --delete-branch <PR-number>`
+2. 主 session ExitWorktree（remove）
+3. 新 worktree `chore-bump-alpha-NNN`，`git reset --hard origin/main`，更 VERSION + package.json + spa/package.json + CHANGELOG.md
+4. `gh pr create --title "chore: bump version to 1.0.0-alpha.NNN"`
+5. self-review approve + squash merge
+
+### P6-T5 — 清理 + 更新 memory
+
+**目標**：清掉 worktree，記住 ship 結果。
+
+**步驟**：
+1. `git worktree list` 確認沒殘留
+2. 更新 issue #821 標 closed by PR #X
+3. 更新 `kickoff_codex_broker_and_lights_governance.md` §6 加註：「✅ shipped at alpha.NNN」
+4. 在 MEMORY.md kickoff 段加新條目（或附在 governance kickoff 之下） — issue #821 結案
+
+---
+
+## 7. 風險與兜底
+
+| 風險 | 兜底 |
+|---|---|
+| `mutateSubagentsWithRetry` 在 race 條件下的 retry edge case | 跑 `-count=10 -race` 多輪；若 panic 有 trace 可追 |
+| Background Bash 真行為 (a) flicker only → user 看不到完整 visibility | spec L6 已預先承認；mlab verify 只更新 wording，不改 code |
+| codex plugin script renaming (script 改名 codex-companion.mjs → codex-runner.mjs) | spec L1 已知；token 偵測仍可改一行；不需大改 |
+| `mutateSubagentsWithRetry` race 描述太強的 `markDelegatingRef`（PreToolUse 在 SubagentStart 之前到達） | spec L7 / regression #12 已預先承認；no-op 行為 by design |
+| PostToolUseFailure raw payload schema 跟 PostToolUse 不完全相同 | extractor 走容錯解析（同 PathHint pattern）；fixture 在 P3-T1 integration test 覆蓋 |
+| SubagentRef slice 無上限增長（PostToolUse 不來） | SubagentStop 自動清整個 ref；極端情況下加防禦性 cap (~32) → 暫不加，等實測 |
+
+---
+
+## 8. Plan freeze checklist
+
+- [x] 範圍對齊 spec
+- [x] 鎖序與不變式具體可遵循
+- [x] 4 個 phase + 1 整合 + 1 PR phase 拆分清楚
+- [x] 每 task 有目標 / 改動 / TDD 步驟 / commit message
+- [x] 涵蓋 spec 全 11 AC + 全 15 regression scenario + 全 7 known limitation
+- [x] 估計時間 + LOC 對齊 spec §8
+- [x] Codex plan-review round 1 0 blocker（v2 採納 2 blocker + 4 minor 全收斂）
+- [x] Codex plan-review round 2 0 blocker（v3 採納 1 high + 1 minor 全收斂；implementation design ready per round-2 verdict）

--- a/docs/specs/2026-05-03-lights-bash-sniff-delegating-spec.md
+++ b/docs/specs/2026-05-03-lights-bash-sniff-delegating-spec.md
@@ -1,0 +1,484 @@
+# Spec — Lights: Bash sniff delegating flag (cc → codex visibility)
+
+**Issue**: [#821](https://github.com/wake/purdex/issues/821)
+**Kickoff**: `kickoff_codex_broker_and_lights_governance.md` §6 (user-actionable safety signal)
+**Date**: 2026-05-03 (v1 → v2)
+**Branch**: `worktree-lights-bash-sniff-delegating`
+**Baseline**: origin/main `9374bf88` (alpha.283)
+**Scope**: Detect cc-side delegation to codex via cc's own `PreToolUse(Bash)` command sniff, surface visually as orange dot on the cc tab — without violating the existing `IsProxy` invariant, without requiring codex plugin cooperation, and without depending on any governance phase.
+
+**Estimated size**: ~620 production+tests LOC (within AC11 cap of 700), plus ~850 LOC for spec + plan docs. Single PR. One round of standard codex review should suffice for the implementation; spec passed round 2 with 0 blockers (round 1 surfaced 3 blockers + 2 important fixes addressed in v2).
+
+**v2 supersedes v1** — v1 review (`task-moors21a-we2agx`, codex thread `019dea4a-5bc9-73d1-aa66-064b0511a2a1`) found 3 blockers (B1 substring missing canonical quoted command; B2 single ToolUseID can't represent N concurrent codex Bash; B3 `PostToolUseFailure` missed) + 2 important fixes (M1 background Bash lifecycle ambiguous; M2 mutateSubagentsWithRetry race description overstated) + 5 fact corrections + size + AC11 wording contradiction. v2 addresses all of them.
+
+---
+
+## 1. Symptom & motivation
+
+### 1.1 User-reported gap
+
+When the user runs `/codex:rescue` / `/codex:review` / `/codex:adversarial-review` inside a cc session (sessions `purdex-big-plan`, `purdex-sync`), cc's tab shows a **blue native subagent dot** instead of the **orange cross-agent proxy dot** that the lights system reserves for "cc is awaiting another agent."
+
+### 1.2 Root cause (already investigated, not in scope to fix)
+
+`/codex:rescue` routes to a cc-native Task subagent named `codex-rescue` (a forwarder defined at `~/.claude/plugins/cache/openai-codex/codex/1.0.2/agents/codex-rescue.md`). cc fires upstream `SubagentStart` hook → daemon walks `LifecycleSubagentStart` path (`internal/module/agent/frame_ops.go:145-200`) → `IsProxy` is left zero (line 166) → SPA renders blue (`spa/src/components/SubagentDots.tsx:16-20`).
+
+The forwarder then `Bash`-spawns `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...` which attaches to a daemonized broker (`app-server-broker.mjs`, `setsid`+detached, `PPID=1`). Broker spawns a `task-worker` (real codex CLI). Codex fires its 9 hooks via `~/.codex/hooks.json` → `pdx hook --agent codex Pdx<Event>`.
+
+But `findProxyParent` (`frame_ops.go:1689-1753`) requires the PPID chain from sender PID upward to reach a frame-registered cross-type ancestor in the same `TmuxPaneID`. The chain breaks at broker (`broker.PPID=1` → line 1699 `if ppid <= 1: return nil`). So the proxy `SubagentRef` attach **never fires** for the codex-via-broker scenario. L2 PR #801 (alpha.283) fixed `Stop`-after-attach detach but does not help here — attach never happens.
+
+### 1.3 Why the colour matters (user-actionable safety signal)
+
+| Colour | Meaning | What the agent knows about it |
+|---|---|---|
+| Blue (native) | cc is doing the work itself | `SubagentStop` hook fires when child finishes — cc has lifecycle visibility |
+| Orange (proxy) | cc is **awaiting** a cross-agent | **No lifecycle visibility** — if codex hangs, cc waits forever |
+
+**Orange dot stuck for too long = cc is hanging on codex, user should intervene**. With everything currently shown as blue, the user has no visual signal to distinguish "cc is thinking hard" from "cc is stuck on a dead codex broker." The user must memorize start time and watch the clock manually. This is the gap to close.
+
+### 1.4 Five alternatives considered, this one chosen
+
+A separate brainstorm round (codex thread `019dea2a-f067-7fd1-a2fb-dedf1b537b53`, plus subagent run) evaluated 6 alternatives beyond Op1/Op2/Op3. Key dismissals:
+
+- **Op1 protocol extension** (codex hook payload carries `originating_cc_session_id+pid`): M complexity, depends on plugin cooperation, ~2-3 weeks behind governance P3.
+- **Op2 broker registry redirect**: violates governance P1 read-only inventory design (`internal/codexbroker` plan §1).
+- **Op3 cc subagent name whitelist**: pollutes the `IsProxy=true ⟺ verified cross-type PPID identity` invariant; bad dead-detection.
+- **Reverse light-up via `pre_tool_without_proxy_parent` skip reason** (`frame_ops.go:232`): structural cross-cc-session pollution risk when broker outlives cc-A and gets adopted by cc-B in the same pane (governance P3 territory).
+
+The chosen approach (this spec): **decouple from codex entirely**. Use cc's own `PreToolUse(Bash)` event stream — which cc already fires reliably and which the daemon already routes (`handler.go:195-202` for path hint extraction) — to detect "cc is currently invoking codex-companion." Surface as a separate **`Delegating` flag** on `SubagentRef`, rendered with the existing orange colour. **`IsProxy` invariant is left untouched**.
+
+---
+
+## 2. Cross-validated facts
+
+### 2.1 cc hook payload schema
+
+[Anthropic Claude Code hooks reference](https://code.claude.com/docs/en/hooks), confirmed 2026-05-03:
+
+| Field | PreToolUse | PostToolUse | PostToolUseFailure |
+|---|---|---|---|
+| `session_id` | ✅ | ✅ | ✅ |
+| `transcript_path` | ✅ | ✅ | ✅ |
+| `cwd` | ✅ | ✅ | ✅ |
+| `permission_mode` | ✅ | ✅ | ✅ |
+| `hook_event_name` | ✅ | ✅ | ✅ |
+| `agent_id` | optional (present when running in subagent) | optional (same) | optional (same) |
+| `agent_type` | optional (when running in subagent) | optional (same) | optional (same) |
+| `tool_name` | ✅ | ✅ | ✅ |
+| `tool_input` | ✅ | ✅ | ✅ |
+| `tool_use_id` | ✅ | ✅ | ✅ |
+
+Bash tool input schema:
+```json
+{ "tool_name": "Bash", "tool_input": { "command": "npm test", "description": "...", "timeout": 120000, "run_in_background": false } }
+```
+
+`PostToolUseFailure` already in cc events catalog at `internal/agent/cc/events.go:125-131` (Lifecycle: None, Handling: Ignored). This spec re-purposes its raw event stream for unmark — Lifecycle classification stays None.
+
+### 2.2 Daemon already extracts cc raw event in PreToolUse / PostToolUse
+
+`internal/module/agent/handler.go:195-202` already gates cc `PdxPreToolUse` / `PdxPostToolUse` for raw event decoding (PathHint extraction). New extractor mirrors the same pattern: `internal/module/agent/path_hint_extractor.go` (`MaxRawEventBytes = 64 KiB` cap, pure function `ExtractPathHint`).
+
+Session resolution must use `resolveSessionCodeFromHook` (handler's existing helper that prefers immutable `tmux_session_id`), not `FindByPanePID` directly — the latter would re-introduce the rename race that handler.go:201-206 explicitly avoids.
+
+### 2.3 SubagentRef extensibility
+
+`internal/agent/subagent.go::SubagentRef` already added `SourceTurnID` for L2 with the same `omitempty` + opaque-blob storage pattern (header comment lines 8-13: "subagents_json is an opaque TEXT blob; see frames.go — No DB migration needed"). New `omitempty` fields (`Delegating bool`, `DelegatingToolUseIDs []string`) follow the same pattern with zero migration cost.
+
+### 2.4 codex-companion invocation pattern (canonical forms)
+
+Confirmed against plugin v1.0.2 in-scope delegation dispatch sites (the read-only `status`/`result`/`cancel`/`setup` subcommands also invoke `codex-companion.mjs` but run at top-level cc context where `agent_id == ""`, so they are naturally filtered by §3.2 step 2):
+
+| Source | Canonical form |
+|---|---|
+| `commands/rescue.md:21` | `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...` |
+| `commands/review.md:45` | `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" review ...` |
+| `commands/adversarial-review.md:50` | `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" adversarial-review ...` |
+| `agents/codex-rescue.md:21` | `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...` |
+
+**Critical observation**: `codex-companion.mjs` is followed by `"` (closing quote) and then space — **not directly by space**. v1's substring `"codex-companion.mjs "` (trailing space) would have **missed every canonical command**. v2 fixes by token-boundary detection — see §3.3.
+
+### 2.5 Concurrency: SubagentDots cap
+
+`spa/src/components/SubagentDots.tsx:33` clamps to 3 dots maximum. `/codex:adversarial-review` triggers up to 3 parallel codex jobs (attack / defense / health). Each parallel dispatch comes via its own forwarder subagent → cc fires 3 `SubagentStart` events → 3 separate `SubagentRef` entries. Each ref independently sets/unsets its own `Delegating` flag based on its own subagent's Bash call. This naturally maps to "3 orange dots" without further wiring.
+
+### 2.6 Background Bash lifecycle (background dispatch flows)
+
+`/codex:review --background` and `/codex:adversarial-review --background` invoke Bash with `run_in_background: true` (plugin `commands/review.md:52-58`, `commands/adversarial-review.md:56-63`). Anthropic's hook spec does **not** publicly document whether `PostToolUse` fires:
+- (a) immediately after the background process is **launched** (returns to caller), or
+- (b) when the background process **exits**.
+
+Empirically this needs **mlab fixture verification** (test plan §6.3). Spec design accommodates both:
+- If (a): orange dot fires briefly (PreToolUse) then clears (PostToolUse) — visible only as a flicker. The cc-native dot remains blue while subagent awaits the background completion via `BashOutput` polls (which fire as **new tool uses**, not the original one). **Acknowledged limitation L6 — background dispatches may not stay orange for full duration**. Workaround would be tracking `BashOutput` polls keyed to the original `tool_use_id` (out of scope for this spec).
+- If (b): orange dot stays for full background duration — matches AC1/AC2 directly.
+
+§4 AC1/AC2 are scoped to **foreground** dispatches; background AC is split into AC1b/AC2b conditional on lifecycle (a)/(b).
+
+---
+
+## 3. Strategy
+
+### 3.1 Identity model
+
+Add two `omitempty` fields to `SubagentRef`:
+
+```go
+type SubagentRef struct {
+    // ... existing fields ...
+    Delegating           bool     `json:"delegating,omitempty"`
+    DelegatingToolUseIDs []string `json:"delegating_tool_use_ids,omitempty"`
+}
+```
+
+`Delegating == true` ⟺ `len(DelegatingToolUseIDs) > 0` (invariant maintained by helpers in §3.5).
+
+`Delegating=true` means **"this cc-native subagent has at least one in-flight Bash call invoking codex-companion"**. The flag is owned by cc's own event stream — it doesn't claim anything about codex's actual liveness. `DelegatingToolUseIDs` records every active Bash invocation that triggered the flag, so multiple concurrent codex calls from the same subagent track independently and stale-tool-id PostToolUse events become idempotent no-ops (B2 fix).
+
+`IsProxy` is **not** touched. SPA renders dots with: `(ref.is_proxy || ref.delegating) ? PROXY_COLOR : NATIVE_COLOR`. The two flags coexist without interference; downstream proxy logic (L2 turn-aware detach, `canonicalizeDescendantsAfterUpsert`, `pruneDeadProxyRefs`) reads only `IsProxy` and is unaffected.
+
+### 3.2 Wiring
+
+Three new mutations on the cc native-subagent path. All gated on `req.AgentType == "cc"` and `tool_name == "Bash"`. All run alongside the existing PathHint extraction in `handler.go:195-202`.
+
+**On `PdxPreToolUse`**:
+1. Decode raw payload: `{tool_name, tool_input.command, tool_use_id, agent_id}`.
+2. Skip if `tool_name != "Bash"`, `agent_id == ""` (means cc is running at top-level, not inside a Task subagent), `tool_use_id == ""`, or command doesn't match codex-companion token (§3.3).
+3. Resolve session via `resolveSessionCodeFromHook` (NOT `FindByPanePID` directly).
+4. Find the cc frame for this pane and the `SubagentRef` whose `ID == agent_id`.
+5. Append `tool_use_id` to `DelegatingToolUseIDs` (deduped); set `Delegating=true`.
+6. Persist via `mutateSubagentsWithRetry` (covers concurrent writes **after the ref already exists**, see M2).
+
+**On `PdxPostToolUse`** and **`PdxPostToolUseFailure`** (B3 fix — same handler path):
+1. Decode raw payload: `{tool_name, tool_use_id, agent_id}`. (`tool_input.command` not needed — Pre's match is the ground truth; Post unmark works by `tool_use_id` membership.)
+2. Skip if `tool_name != "Bash"`, `agent_id == ""`, or `tool_use_id == ""`.
+3. Resolve session via `resolveSessionCodeFromHook`.
+4. Find the cc frame and `SubagentRef` whose `ID == agent_id`.
+5. Remove `tool_use_id` from `DelegatingToolUseIDs` (no-op if not present — covers PostToolUse arriving for non-codex Bash, or after `SubagentStop`). Update `Delegating` flag: `len(DelegatingToolUseIDs) > 0`.
+6. Persist via `mutateSubagentsWithRetry`.
+
+**On `PdxSubagentStop`** (cc native): existing flow removes the ref entirely. `Delegating` flag and `DelegatingToolUseIDs` disappear with the ref. No special handling needed.
+
+**On `PdxPostToolBatch`**: out of scope — parallel tool call batch is a Task tool semantic that doesn't flow through Bash. Spec's `tool_name == "Bash"` gate naturally ignores it.
+
+### 3.3 Match pattern (token detection — B1 fix)
+
+```
+required: command contains "codex-companion.mjs" followed by one of: '"', "'", whitespace, EOL
+```
+
+Implementation: locate substring `codex-companion.mjs` then inspect the next byte. Reject if next byte is alphanumeric / `.` / `/` / `_` / `-` (i.e. continues a filename token like `codex-companion.mjs.bak` or `codex-companion.mjsx`).
+
+| `tool_input.command` | Match? |
+|---|---|
+| `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task --background "..."` | ✅ (next byte: `"`) |
+| `node ~/.claude/plugins/.../codex-companion.mjs review --base main` | ✅ (next byte: ` `) |
+| `bash -c "node /custom/codex-companion.mjs adversarial-review focus"` | ✅ (next byte: ` `) |
+| `node 'codex-companion.mjs' task` | ✅ (next byte: `'`) |
+| `node $(./find-script).mjs task` | ❌ (does not contain `codex-companion.mjs`) |
+| `node codex-companion.mjs.bak task` | ❌ (next byte: `.` — not boundary) |
+| `echo "codex-companion.mjs"` | ✅ (next byte: `"` — known false positive, see L1) |
+| `cat README \| grep codex-companion.mjs` | ✅ (next byte: EOF — known false positive, see L1) |
+| `git log --grep=codex-companion.mjsx` | ❌ (continues token) |
+
+Implementation hint (Go):
+```go
+func containsCodexCompanionToken(command string) bool {
+    needle := "codex-companion.mjs"
+    for i := 0; i+len(needle) <= len(command); {
+        idx := strings.Index(command[i:], needle)
+        if idx < 0 { return false }
+        end := i + idx + len(needle)
+        if end == len(command) {
+            return true
+        }
+        c := command[end]
+        if c == '"' || c == '\'' || c == ' ' || c == '\t' || c == '\n' {
+            return true
+        }
+        // Continues a different token — keep searching.
+        i = i + idx + len(needle)
+    }
+    return false
+}
+```
+
+The `echo` / `grep` false positives are acknowledged in L1 — full shell parsing is far more expensive than the value of 100% precision. Functional damage is zero (dot just turns orange briefly until matching PostToolUse arrives).
+
+### 3.4 Extractor (pure function)
+
+New file `internal/module/agent/delegation_extractor.go`:
+
+```go
+type DelegationHint struct {
+    AgentID      string  // hook payload agent_id (cc Task subagent id)
+    ToolUseID    string  // hook payload tool_use_id (Bash invocation id)
+    IsCodexMark  bool    // PreToolUse with command match → mark
+    IsUnmark     bool    // PostToolUse / PostToolUseFailure → unmark by tool_use_id
+}
+
+// ExtractDelegationHint is a pure function. Returns hint+true when the raw
+// cc PreToolUse / PostToolUse / PostToolUseFailure event represents a Bash
+// invocation inside a subagent.
+//
+// IsCodexMark is true only for PreToolUse with a codex-companion token match.
+// IsUnmark is true for PostToolUse / PostToolUseFailure regardless of command
+// (caller uses ToolUseID for membership-removal — non-codex Bash unmarks
+// naturally as no-op).
+//
+// Defenses (mirrored from path_hint_extractor.go):
+//   - rawEvent must be < MaxRawEventBytes (64 KiB)
+//   - command, agent_id, tool_use_id all bounded by ~PATH_MAX-class caps
+//   - reject control / NUL chars in agent_id / tool_use_id (WS injection risk)
+func ExtractDelegationHint(rawEvent json.RawMessage, eventName string) (DelegationHint, bool)
+```
+
+Pattern uses the token detection of §3.3 — no regex, no ReDoS risk.
+
+### 3.5 Frame helpers
+
+Two new helpers in `frame_ops.go`:
+
+```go
+// markDelegatingRef appends toolUseID to DelegatingToolUseIDs (deduped) and
+// sets Delegating=true on the SubagentRef whose ID matches agentID, on the
+// frame at (paneID, frame's PID). Idempotent — re-mark with same ToolUseID
+// is a no-op (slice membership check).
+//
+// Race scope (M2): covers concurrent writes after the SubagentRef already
+// exists. If PreToolUse arrives before SubagentStart establishes the ref
+// (regression #10), this is a silent no-op — by design, since attaching a
+// flag to a non-existent ref has no meaningful semantics.
+func (m *Module) markDelegatingRef(paneID, agentID, toolUseID string) error
+
+// unmarkDelegatingRef removes toolUseID from DelegatingToolUseIDs on the ref
+// whose ID == agentID, recomputes Delegating = len(remaining) > 0. No-op if
+// ref not found, ID not in slice, or whole frame missing (covers PostToolUse
+// arriving after SubagentStop, PostToolUseFailure for non-codex Bash, etc.).
+func (m *Module) unmarkDelegatingRef(paneID, agentID, toolUseID string) error
+```
+
+Both use `mutateSubagentsWithRetry` for optimistic concurrency.
+
+### 3.6 SPA rendering
+
+`spa/src/components/SubagentDots.tsx`:
+
+```tsx
+// Dot color: orange if either is_proxy (real cross-agent proxy via PPID
+// chain) OR delegating (cc subagent inferred to be invoking codex-companion
+// via Bash sniff). Both signals indicate "agent is awaiting downstream";
+// they coexist without interference (delegating=true + is_proxy=true
+// renders the same orange).
+const NATIVE_COLOR = '#60a5fa'  // blue
+const PROXY_COLOR = '#f97316'   // orange
+
+const dotStyle = (ref: SubagentRef): CSSProperties => ({
+  backgroundColor: (ref.is_proxy || ref.delegating) ? PROXY_COLOR : NATIVE_COLOR,
+})
+```
+
+Test introspection: **leave `data-is-proxy` unchanged**, add new `data-delegating` attribute (F4 fix). Tests can target either independently.
+
+`useAgentStore.ts` SubagentRef type (`spa/src/stores/useAgentStore.ts:42`) gains:
+```ts
+type SubagentRef = {
+  // ...existing...
+  delegating?: boolean
+  delegating_tool_use_ids?: string[]
+}
+```
+
+### 3.7 Out of scope
+
+- **Codex-side actual lifecycle**: this spec doesn't claim to know whether codex is alive, dead, or hung. The orange dot only reflects "cc is currently inside a Bash call invoking codex-companion." If codex hangs and cc's Bash subprocess hangs with it, the dot stays orange — **this is exactly the user-actionable signal we want** (orange too long = user intervenes).
+- **Replacing governance P3**: P3 still needs to land separately to clean up dead brokers and to actively detach orange dots when broker death is detected. This spec is the **visual signal half** of the safety story; P3 is the **sweep half**.
+- **Real proxy attach for codex**: Op1 (codex hook payload origin extension) remains the long-term solution if/when we want to surface codex's own runtime state. This spec doesn't preclude Op1 — `IsProxy` is left untouched, so Op1 can layer on top later.
+- **Detecting codex started outside the companion**: User running `codex` CLI directly in a cc Bash call without the companion wrapper is rare and unsupported here.
+- **opencode delegation visibility**: opencode forwarder pattern (if any) is out of scope; spec only covers `agent_type=="cc"`.
+- **Background Bash tracked through `BashOutput` polls** (L6): out of scope; if PostToolUse fires on launch (not on exit), background dispatches show only flicker. Not regressing existing behaviour.
+- **`PdxPostToolBatch` parallel tool batch**: Task tool semantic, not Bash; naturally filtered by `tool_name == "Bash"` gate.
+
+---
+
+## 4. Acceptance criteria
+
+| AC | Description |
+|---|---|
+| AC1 | `/codex:rescue` (foreground) inside cc session → cc tab shows orange dot for the duration of the codex-companion Bash call |
+| AC1b | `/codex:rescue --background` → orange dot fires at PreToolUse; behaviour at PostToolUse depends on cc lifecycle semantics (see §2.6 — verified in §6.3 fixture). Either way, no functional regression. |
+| AC2 | `/codex:review` (foreground) and `/codex:adversarial-review` (foreground) show orange the same way |
+| AC2b | `/codex:review --background` and `/codex:adversarial-review --background` follow AC1b semantics |
+| AC3 | `/codex:adversarial-review` running 3 parallel codex jobs (foreground) shows 3 orange dots (one per forwarder subagent), capped at SubagentDots max=3 |
+| AC4 | cc subagent running non-codex Bash (`pnpm build`, `git push`, `pytest`, etc.) shows blue dot — no false orange |
+| AC5 | `PostToolUse(Bash)` for the same `tool_use_id` removes from `DelegatingToolUseIDs`; if list becomes empty, `Delegating=false` → dot returns to blue |
+| AC5b | `PostToolUseFailure(Bash)` for the same `tool_use_id` behaves identically to AC5 (B3 fix) |
+| AC5c | Two concurrent codex Bash calls (T1, T2) from same subagent: `Delegating=true` while either is in flight, regardless of completion order. Verifies B2 fix. |
+| AC6 | `SubagentStop` fires → ref removed → dot disappears (existing behaviour, unchanged) |
+| AC7 | L2 turn-aware detach for real codex proxy refs (when they exist via legitimate PPID-chain attach) is unaffected — `IsProxy` invariant intact |
+| AC8 | Native delegating ref + real `IsProxy` proxy ref coexist on same parent: both render orange (capped at 3 dots); detach/prune of one does not affect the other (F5 fix). Daemon test required. |
+| AC9 | cc PreToolUse(Bash) at top-level (no `agent_id`, cc not inside a Task subagent) → no marking attempted |
+| AC10 | opencode and codex events ignored (gated on `req.AgentType == "cc"`) |
+| AC11 | PR diff total ≤ 700 lines for production code + tests, **excluding** `docs/specs/*.md` (this spec, plan, etc.). Documentation has no per-PR cap. |
+
+---
+
+## 5. Regression matrix
+
+| # | Scenario | Expected dot | Notes |
+|---|---|---|---|
+| 1 | cc top-level (no subagent) running Bash `codex-companion task ...` | None | No agent_id → §3.2 step 2 skip |
+| 2 | cc native Task subagent running Bash `pnpm build` | Blue | Token no match → no mark |
+| 3 | cc native Task subagent running Bash `node "$ROOT/codex-companion.mjs" task` (canonical quoted form) | Orange | Token boundary `"` matches (B1 fix verified) |
+| 4 | Scenario 3 → Bash completes → PostToolUse | Blue | tool_use_id removed from list, list now empty → Delegating=false |
+| 5 | Scenario 3 → Bash exits non-zero → PostToolUseFailure | Blue | B3 fix: failure path also unmarks |
+| 6 | cc Task subagent runs 2 parallel codex Bash (T1 first, T2 second), T2 completes first | Orange (still) | B2 fix: list has [T1,T2]; remove T2 leaves [T1]; Delegating still true |
+| 6b | Continue 6: T1 completes | Blue | List empty → Delegating=false |
+| 7 | `/codex:adversarial-review --wait` foreground with 3 parallel forwarder subagents each spawning codex | 3 orange | Each subagent has own agent_id; each ref independently marked |
+| 8 | `/codex:adversarial-review --background` (3 parallel background) | flicker (per AC1b — depends on cc lifecycle) | L6 known limitation |
+| 9 | codex running in a different pane (independent, not via cc) | Unaffected | codex hook events still go to codex frame projection; no mutation on cc |
+| 10 | opencode running anything | Unaffected | `req.AgentType == "cc"` gate |
+| 11 | Native delegating ref + legitimate IsProxy ref on same parent (e.g. user runs codex CLI directly in same pane while a cc subagent also delegates) | 2 orange dots | F5 / AC8: both render orange; SubagentDots renders both as separate dots (cap 3); detach paths independent |
+| 12 | cc PreToolUse(Bash) with `agent_id` set but matching ref not found yet (race: SubagentStart hook in flight) | No mark (silent no-op) | M2 acknowledged: PreToolUse arriving before ref exists is a known miss; no recovery — by design (rare, recovers on next tool use) |
+| 13 | L2 turn-aware sequential codex turns | Unaffected | L2 path independent — tested by existing `frame_ops_l2_test.go` suite |
+| 14 | `node codex-companion.mjs.bak task` (token continuation) | Blue | Boundary check rejects |
+| 15 | `cat README \| grep codex-companion.mjs` | Orange (false positive — L1) | Dot returns to blue at PostToolUse — functionally harmless |
+
+---
+
+## 6. Test plan
+
+### 6.1 Unit — `delegation_extractor_test.go` (new)
+
+Table-driven, modeled on `path_hint_extractor_test.go`:
+
+| Case | Input | Expected |
+|---|---|---|
+| Bash + canonical quoted command | PreToolUse + Bash + `command="node \"$ROOT/codex-companion.mjs\" task"` + agent_id=X + tool_use_id=Y | hint{X,Y,IsCodexMark:true, IsUnmark:false}, true |
+| Bash + bare path | PreToolUse + `command="node /path/codex-companion.mjs review"` | IsCodexMark:true |
+| Bash + single-quoted | PreToolUse + `command="node 'codex-companion.mjs' task"` | IsCodexMark:true |
+| Bash + token continuation | PreToolUse + `command="node codex-companion.mjs.bak task"` | IsCodexMark:false (boundary check) |
+| Bash + non-codex command | PreToolUse + `command="pnpm build"` | IsCodexMark:false |
+| Non-Bash tool (Read) | PreToolUse + Read + ... | _, false |
+| No agent_id (top-level cc) | PreToolUse + Bash + canonical command + agent_id="" | _, false |
+| No tool_use_id | PreToolUse + Bash + canonical command + tool_use_id="" | _, false |
+| PostToolUse + codex command | PostToolUse + Bash + canonical + agent_id=X + tool_use_id=Y | hint{X,Y,IsCodexMark:false, IsUnmark:true}, true |
+| PostToolUse + non-codex command | PostToolUse + Bash + `pnpm build` + agent_id=X + tool_use_id=Y | hint{X,Y,IsCodexMark:false, IsUnmark:true}, true (caller no-op on missing tool_use_id) |
+| PostToolUseFailure + codex | PostToolUseFailure + Bash + canonical + agent_id=X + tool_use_id=Y | hint{X,Y,IsCodexMark:false, IsUnmark:true}, true |
+| Over MaxRawEventBytes | 70KB raw | _, false |
+| Invalid JSON | malformed | _, false |
+| Control char in agent_id | `\x00` in agent_id | _, false (WS injection guard) |
+| `echo "codex-companion.mjs"` (false positive) | command match → IsCodexMark:true | acknowledged L1 |
+
+### 6.2 Unit — `frame_ops_test.go` additions
+
+- `TestMarkDelegatingRef_AppendsToolUseIDOnMatchingRef`
+- `TestMarkDelegatingRef_DedupesRepeatedToolUseID`
+- `TestMarkDelegatingRef_NoOpWhenAgentIDNotFound` (covers M2 race)
+- `TestMarkDelegatingRef_NoOpWhenFrameMissing`
+- `TestUnmarkDelegatingRef_RemovesToolUseID`
+- `TestUnmarkDelegatingRef_DelegatingFalseWhenListEmpties`
+- `TestUnmarkDelegatingRef_DelegatingTrueWhenOthersStillActive` (B2 verification)
+- `TestUnmarkDelegatingRef_NoOpWhenToolUseIDNotInList`
+- `TestUnmarkDelegatingRef_NoOpAfterSubagentStop`
+- `TestSubagentStopRemovesRefIncludingDelegatingFlag` (regression — existing flow unchanged)
+- `TestDelegatingNativeRef_CoexistsWith_RealIsProxyRef_OnSameParent` (AC8 / F5 coverage)
+
+### 6.3 Integration — `handler.go` end-to-end
+
+Inject fixture cc PreToolUse(Bash codex command) → daemon round-trip → assert frame.Subagents[i].Delegating == true and tool_use_id in list. Then PostToolUse → assert removed and Delegating=false. Then SubagentStop → assert ref removed.
+
+**Background lifecycle fixture (M1 verification)**: Inject cc PreToolUse(Bash) with `tool_input.run_in_background=true`, then capture the subsequent hook stream. Assert:
+- Whether PostToolUse fires immediately (lifecycle a) or later (lifecycle b).
+- Update L6 limitation wording in spec post-merge based on observed behaviour.
+
+This fixture is **mlab live verification** in §test plan — daemon unit tests use synthetic fixtures of both shapes to keep the implementation neutral.
+
+### 6.4 SPA — `SubagentDots.test.tsx`
+
+Add four cases:
+- `delegating=true, is_proxy=false` → orange + `data-delegating="true"` + `data-is-proxy="false"`
+- `delegating=false, is_proxy=true` → orange + `data-delegating="false"` + `data-is-proxy="true"` (existing)
+- `delegating=true, is_proxy=true` → orange + both attrs true
+- `delegating=false, is_proxy=false` → blue (existing)
+
+### 6.5 Regression — existing suites must pass unchanged
+
+- `frame_ops_test.go` (full)
+- `frame_ops_l2_test.go` (L2 turn-aware)
+- `frame_ops_test.go::TestSubagentStart_*`
+- `path_hint_extractor_test.go`
+- All SPA component tests
+
+---
+
+## 7. Known limitations
+
+| ID | Limitation | Mitigation |
+|---|---|---|
+| L1 | Token detection allows `echo "codex-companion.mjs"` and similar false positives. False negatives possible if codex plugin renames the script (`codex-companion.mjs` → `codex-runner.mjs`) or user wraps in shell substitution `$(...)` that hides the literal token. | Acceptable: false negatives only lose visibility (no functional regression); false positives clear at PostToolUse and are functionally harmless. Track upstream codex plugin script naming for breakage. |
+| L2 | Fixture verification needed: confirm `PostToolUse` (and `PostToolUseFailure`) actually carry `tool_use_id` — if some path drops the field, unmark cannot match. | Implementation gate: integration test in §6.3 must capture real cc fixture. If `tool_use_id` is missing in some path, fall back to `SubagentStop`-time cleanup (existing flow already removes the ref entirely). |
+| L3 | Codex actually hung (broker dead, codex_worker zombie) but cc Bash still awaits → dot stays orange "forever" until cc's own Bash timeout fires | **This is the desired signal**, not a bug. User sees orange too long → user intervenes. Pairs with cc's built-in Bash subprocess timeout as system-side backstop. |
+| L4 | Manual `codex` CLI invocation outside the companion (e.g. user runs `codex exec` directly in a cc Task subagent's Bash) | Out of scope — `codex-companion.mjs` is the canonical delegation entrypoint; raw CLI invocations are an edge case to revisit only if used in practice. |
+| L5 | (covered by B2 fix) — DelegatingToolUseIDs as slice handles concurrent codex Bash calls correctly regardless of completion order. | Addressed in §3.1, AC5c, regression #6/#6b. |
+| L6 | Background Bash dispatches (`run_in_background: true`) may show only orange flicker if cc fires PostToolUse on launch (not exit). Not yet confirmed which lifecycle cc 1.x uses — see §6.3 fixture verification. | Acceptable: foreground dispatches (the common case) are unaffected. If background flicker proves painful, follow-up issue can extend tracking via `BashOutput` polls keyed to original `tool_use_id`. AC1b/AC2b explicitly conditional on lifecycle. |
+| L7 | M2 race: PreToolUse(Bash codex-companion) arriving before matching SubagentStart establishes the ref → silent no-op, dot stays blue. | Acceptable: rare timing window (cc subagent first action before any tool use is unusual); recovers when subagent ends → dot goes away naturally. Non-recovery is by design. |
+
+---
+
+## 8. PR size estimate
+
+| File | LOC delta |
+|---|---|
+| `internal/agent/subagent.go` | +8 (two fields + comments) |
+| `internal/agent/cc/events.go` | +0 (PostToolUseFailure already exists) |
+| `internal/module/agent/delegation_extractor.go` | +90 (new file: ExtractDelegationHint + token detection) |
+| `internal/module/agent/delegation_extractor_test.go` | +180 (new file: 14 table-driven cases) |
+| `internal/module/agent/frame_ops.go` | +70 (markDelegatingRef + unmarkDelegatingRef + slice helpers) |
+| `internal/module/agent/frame_ops_test.go` | +130 (11 new test cases) |
+| `internal/module/agent/handler.go` | +35 (wiring near :201 PathHint block — Pre + Post + PostFailure) |
+| `internal/module/agent/handler_test.go` | +60 (integration: PreToolUse → mark → PostToolUse → unmark; PostToolUseFailure path; B2 concurrent) |
+| `spa/src/stores/useAgentStore.ts` | +3 (type fields) |
+| `spa/src/components/SubagentDots.tsx` | +4 (renderer condition + comment + data-delegating attr) |
+| `spa/src/components/SubagentDots.test.tsx` | +40 (4 colour + attr cases) |
+| **Production + tests** | **~620 lines** (over the AC11 cap of 500) |
+| `docs/specs/2026-05-03-lights-bash-sniff-delegating-spec.md` | +600 (this file v2) |
+| `docs/specs/2026-05-03-lights-bash-sniff-delegating-plan.md` | +250 (next task) |
+| **Total PR** | **~1470 lines** |
+
+Production + tests ~620 fits within AC11 cap of 700 (raised from v1's 500 to accommodate B2 slice + B3 failure-path additions). Documentation (~850 lines for spec + plan combined) is not counted toward the cap.
+
+---
+
+## 9. Implementation order (preview — full plan in §3 task)
+
+1. SubagentRef +2 fields + JSON omitempty + slice util
+2. delegation_extractor.go pure function with token detection + table-driven tests (TDD)
+3. frame_ops.go markDelegatingRef + unmarkDelegatingRef (slice append/remove + Delegating recompute) + tests
+4. handler.go wiring near existing PathHint block — three event names (Pre + Post + PostFailure) + integration tests
+5. spa SubagentRef type + SubagentDots renderer + data-delegating attr + tests
+6. Regression sweep: full Go test suite + spa vitest + lint + build
+7. mlab live verify §6.3 background lifecycle observation; update L6 wording with real behaviour
+
+---
+
+## 10. Risks & open questions
+
+| Risk | Mitigation |
+|---|---|
+| Anthropic CC hook payload changes break `agent_id` semantics | Pin to current schema (2026-05-03 docs); add fixture-based tests for each cc hook event. Future schema changes caught by fixture diff. |
+| Codex plugin script renaming | L1 — track upstream; substring match is the reverse (any future name change is a known follow-up issue). |
+| Frame mutation race at `markDelegatingRef` collides with concurrent SubagentStart on same agent_id | Use `mutateSubagentsWithRetry` (already proven for L2 turn-aware concurrency); race description in §3.5 acknowledges the M2 boundary. |
+| Background Bash lifecycle (a vs b) | §6.3 fixture; AC1b/AC2b conditional; L6 explicit. No code change required regardless of which lifecycle empirically happens. |
+| Slice-based DelegatingToolUseIDs grows unbounded if PostToolUse never fires | In practice cc subagent ends → SubagentStop → entire ref deleted, slice freed. Worst case bounded by `MaxConcurrentBashPerSubagent` (cc-side limit, not our concern). Add defensive cap at ~32 entries with log-and-discard if needed. |
+
+---
+
+## 11. Spec freeze checklist
+
+- [x] All cross-validated facts cited (v2)
+- [x] Acceptance criteria measurable (v2 — split foreground/background, added AC5b/c, AC8)
+- [x] Regression matrix covers 15 scenarios (v2 — added quoted command, PostToolUseFailure, concurrent reverse-order, native+IsProxy coexistence)
+- [x] Test plan covers extractor / frame helpers / handler / SPA / regression / background fixture
+- [x] Known limitations enumerated (v2 — added L6, L7)
+- [x] PR size cap reconciled (raised AC11 to 700 for v2 scope)
+- [ ] Codex spec round 2 review with 0 blocker findings (gate before plan write)

--- a/internal/agent/cc/events.go
+++ b/internal/agent/cc/events.go
@@ -8,8 +8,12 @@ import "github.com/wake/purdex/internal/agent"
 // Ordering matches the installer's emit order and plan §1.4 cc table.
 //
 // EmitsStatus semantics:
-//   - Detail-only events (SubagentStart/Stop) declare an empty slice — they
-//     produce Valid=true with Status="" at runtime.
+//   - Detail-only events (SubagentStart/Stop, PreToolUse, PostToolUseFailure)
+//     declare an empty slice — they produce Valid=true with Status="" at
+//     runtime. PreToolUse + PostToolUseFailure are routed via handler.go's
+//     delegation extractor (PR #829, issue #821) to mark/unmark the
+//     Delegating flag for codex-companion Bash invocations; they must stay
+//     installable so cc actually fires them on fresh installs.
 //   - Polymorphic events (Notification) declare the union across sub-branches
 //     (permission_prompt / elicitation_dialog → Waiting; idle_prompt /
 //     auth_success → Idle). Drift test pins each sub-branch separately.
@@ -104,7 +108,6 @@ var ccEventSpecs = []agent.HookEventSpec{
 		Lifecycle:    agent.LifecycleNone,
 		EmitsStatus:  []agent.Status{},
 		Description:  "Tool call about to execute",
-		Handling:     agent.HookHandlingUnsupported,
 	},
 	{
 		PurdexName:   "PdxPermissionDenied",
@@ -127,7 +130,6 @@ var ccEventSpecs = []agent.HookEventSpec{
 		Lifecycle:    agent.LifecycleNone,
 		EmitsStatus:  []agent.Status{},
 		Description:  "Tool call failed",
-		Handling:     agent.HookHandlingIgnored,
 	},
 	{
 		PurdexName:   "PdxPostToolBatch",

--- a/internal/agent/cc/events_test.go
+++ b/internal/agent/cc/events_test.go
@@ -20,7 +20,9 @@ var expectedCCInstallableEventNames = []string{
 	"PdxNotification",
 	"PdxPermissionRequest",
 	"PdxSessionEnd",
+	"PdxPreToolUse",
 	"PdxPostToolUse",
+	"PdxPostToolUseFailure",
 }
 
 // expectedCCEventNames lists the upstream event-name keys that cc's installer
@@ -38,7 +40,9 @@ var expectedCCEventNames = []string{
 	"Notification",
 	"PermissionRequest",
 	"SessionEnd",
+	"PreToolUse",
 	"PostToolUse",
+	"PostToolUseFailure",
 }
 
 // expectedCCCatalogHandling is pinned to the Claude Code hooks reference,
@@ -49,11 +53,11 @@ var expectedCCCatalogHandling = map[string]agent.HookHandling{
 	"PdxSessionStart":        agent.HookHandlingStatus,
 	"PdxUserPromptSubmit":    agent.HookHandlingStatus,
 	"PdxUserPromptExpansion": agent.HookHandlingUnsupported,
-	"PdxPreToolUse":          agent.HookHandlingUnsupported,
+	"PdxPreToolUse":          agent.HookHandlingDetail,
 	"PdxPermissionRequest":   agent.HookHandlingStatus,
 	"PdxPermissionDenied":    agent.HookHandlingIgnored,
 	"PdxPostToolUse":         agent.HookHandlingStatus,
-	"PdxPostToolUseFailure":  agent.HookHandlingIgnored,
+	"PdxPostToolUseFailure":  agent.HookHandlingDetail,
 	"PdxPostToolBatch":       agent.HookHandlingUnsupported,
 	"PdxNotification":        agent.HookHandlingStatus,
 	"PdxSubagentStart":       agent.HookHandlingDetail,
@@ -189,13 +193,19 @@ func TestCCEvents_EmitsStatusForNotification(t *testing.T) {
 }
 
 // TestCCEvents_DetailOnlyHaveEmptyEmitsStatus enforces detail-only events
-// (SubagentStart/Stop) declare EmitsStatus as an empty slice — not nil — so
-// drift tooling and Inspector UI can distinguish "explicitly empty" from
-// "unknown".
+// (SubagentStart/Stop, PreToolUse, PostToolUseFailure) declare EmitsStatus as
+// an empty slice — not nil — so drift tooling and Inspector UI can
+// distinguish "explicitly empty" from "unknown".
 func TestCCEvents_DetailOnlyHaveEmptyEmitsStatus(t *testing.T) {
 	p := NewProvider(nil, nil, nil, nil)
+	detailOnlyNames := map[string]bool{
+		"PdxSubagentStart":      true,
+		"PdxSubagentStop":       true,
+		"PdxPreToolUse":         true,
+		"PdxPostToolUseFailure": true,
+	}
 	for _, e := range p.Events() {
-		if e.PurdexName != "PdxSubagentStart" && e.PurdexName != "PdxSubagentStop" {
+		if !detailOnlyNames[e.PurdexName] {
 			continue
 		}
 		if e.EmitsStatus == nil {
@@ -203,6 +213,34 @@ func TestCCEvents_DetailOnlyHaveEmptyEmitsStatus(t *testing.T) {
 		}
 		if len(e.EmitsStatus) != 0 {
 			t.Errorf("cc %s EmitsStatus = %v, want empty", e.PurdexName, e.EmitsStatus)
+		}
+	}
+}
+
+// TestCCEvents_DelegationHooksInstallable pins the round-1 codex re-review P1
+// fix: cc must install PreToolUse + PostToolUseFailure hooks so the
+// delegation flag wiring (PR #829, issue #821) actually receives events on
+// fresh installs. Removing Handling: HookHandlingUnsupported/Ignored makes
+// EffectiveHookHandling fall back to HookHandlingDetail (since EmitsStatus
+// is empty), which makes IsInstallableHookSpec return true and lets
+// mergeClaudeHooks write both keys into ~/.claude/settings.json.
+func TestCCEvents_DelegationHooksInstallable(t *testing.T) {
+	p := NewProvider(nil, nil, nil, nil)
+	required := map[string]bool{
+		"PdxPreToolUse":         false,
+		"PdxPostToolUseFailure": false,
+	}
+	for _, e := range p.Events() {
+		if _, ok := required[e.PurdexName]; ok {
+			if !agent.IsInstallableHookSpec(e) {
+				t.Errorf("cc %s must be installable for delegation flag wiring (PR #829)", e.PurdexName)
+			}
+			required[e.PurdexName] = true
+		}
+	}
+	for name, found := range required {
+		if !found {
+			t.Errorf("cc catalog missing %s entry", name)
 		}
 	}
 }
@@ -262,10 +300,10 @@ var expectedCCPreservedMetadata = map[string]ccLegacyMetadata{
 	"PdxPermissionRequest":   {[]agent.Status{agent.StatusWaiting}, "Tool permission request awaiting user approval", false, ""},
 	"PdxSessionEnd":          {[]agent.Status{agent.StatusClear}, "Claude Code session ended", false, ""},
 	"PdxUserPromptExpansion": {[]agent.Status{}, "User command expanded before model processing", false, agent.HookHandlingUnsupported},
-	"PdxPreToolUse":          {[]agent.Status{}, "Tool call about to execute", false, agent.HookHandlingUnsupported},
+	"PdxPreToolUse":          {[]agent.Status{}, "Tool call about to execute", false, ""},
 	"PdxPermissionDenied":    {[]agent.Status{}, "Tool permission denied by auto mode classifier", false, agent.HookHandlingIgnored},
 	"PdxPostToolUse":         {[]agent.Status{agent.StatusRunning}, "Tool call completed successfully (signals running after permission grant)", false, ""},
-	"PdxPostToolUseFailure":  {[]agent.Status{}, "Tool call failed", false, agent.HookHandlingIgnored},
+	"PdxPostToolUseFailure":  {[]agent.Status{}, "Tool call failed", false, ""},
 	"PdxPostToolBatch":       {[]agent.Status{}, "Parallel tool call batch resolved", false, agent.HookHandlingUnsupported},
 	"PdxTaskCreated":         {[]agent.Status{}, "Task was created", false, agent.HookHandlingIgnored},
 	"PdxTaskCompleted":       {[]agent.Status{}, "Task was completed", false, agent.HookHandlingIgnored},

--- a/internal/agent/cc/status.go
+++ b/internal/agent/cc/status.go
@@ -101,6 +101,40 @@ func deriveCCStatus(purdexName string, rawEvent json.RawMessage) agent.DeriveRes
 			Valid:  true,
 			Detail: map[string]any{"agent_id": raw["agent_id"]},
 		}
+
+	case "PdxPreToolUse":
+		// Detail-only valid (Status=""): handler.go uses PreToolUse to drive
+		// the delegation flag mark for codex-companion Bash invocations
+		// (issue #821). Returning Valid=false here would drop the request
+		// down handler.go's invalid-skip return — the DB mutation would
+		// happen in the pre-derive block but no broadcast would reach the
+		// SPA. Mirrors the existing PdxSubagentStart / PdxSubagentStop
+		// detail-only pattern (events.go line 11-15 EmitsStatus convention).
+		return agent.DeriveResult{
+			Valid: true,
+			Detail: map[string]any{
+				"tool_name":   raw["tool_name"],
+				"tool_use_id": raw["tool_use_id"],
+				"agent_id":    raw["agent_id"],
+			},
+		}
+
+	case "PdxPostToolUseFailure":
+		// Detail-only valid (Status=""): symmetric counterpart for the
+		// delegation unmark path. Without this case, a failed
+		// codex-companion Bash would clear the DB Delegating flag silently
+		// (handler invalid-skip return) and the SPA would stay orange.
+		// Status="" so PostToolUseFailure does not pollute the
+		// idle/running/waiting status derivation — failure semantics live
+		// in PdxStopFailure, not here.
+		return agent.DeriveResult{
+			Valid: true,
+			Detail: map[string]any{
+				"tool_name":   raw["tool_name"],
+				"tool_use_id": raw["tool_use_id"],
+				"agent_id":    raw["agent_id"],
+			},
+		}
 	}
 
 	return agent.DeriveResult{Valid: false}

--- a/internal/agent/cc/status_test.go
+++ b/internal/agent/cc/status_test.go
@@ -128,6 +128,67 @@ func TestDeriveCCStatus_PdxSubagentStart_DetailOnly(t *testing.T) {
 	}
 }
 
+// TestDeriveCCStatus_PdxPreToolUse_DetailOnly pins the round-1 codex review fix:
+// production cc provider must classify PdxPreToolUse as Valid=true (detail-only)
+// so handler.go reaches the broadcast path. Before the fix, this returned
+// Valid=false, so the delegation flag mark would mutate the frame DB but never
+// emit to the SPA. Mirrors the existing PdxSubagentStart detail-only pattern.
+func TestDeriveCCStatus_PdxPreToolUse_DetailOnly(t *testing.T) {
+	r := deriveViaProvider("PdxPreToolUse", map[string]any{
+		"tool_name":   "Bash",
+		"tool_use_id": "T1",
+		"agent_id":    "agent-X",
+	})
+	if !r.Valid {
+		t.Fatalf("PdxPreToolUse should be valid (detail-only); got %+v", r)
+	}
+	if r.Status != "" {
+		t.Fatalf("PdxPreToolUse should not set status (detail-only); got %s", r.Status)
+	}
+	if r.Detail == nil {
+		t.Fatal("PdxPreToolUse should carry Detail map")
+	}
+	if r.Detail["tool_name"] != "Bash" {
+		t.Errorf("Detail[tool_name] = %v, want Bash", r.Detail["tool_name"])
+	}
+	if r.Detail["tool_use_id"] != "T1" {
+		t.Errorf("Detail[tool_use_id] = %v, want T1", r.Detail["tool_use_id"])
+	}
+	if r.Detail["agent_id"] != "agent-X" {
+		t.Errorf("Detail[agent_id] = %v, want agent-X", r.Detail["agent_id"])
+	}
+}
+
+// TestDeriveCCStatus_PdxPostToolUseFailure_DetailOnly is the sister pin for the
+// unmark broadcast path. Same rationale as PdxPreToolUse — without the fix the
+// production cc provider returned Valid=false and the unmark would silently
+// mutate DB without broadcasting cleared state.
+func TestDeriveCCStatus_PdxPostToolUseFailure_DetailOnly(t *testing.T) {
+	r := deriveViaProvider("PdxPostToolUseFailure", map[string]any{
+		"tool_name":   "Bash",
+		"tool_use_id": "T2",
+		"agent_id":    "agent-Y",
+	})
+	if !r.Valid {
+		t.Fatalf("PdxPostToolUseFailure should be valid (detail-only); got %+v", r)
+	}
+	if r.Status != "" {
+		t.Fatalf("PdxPostToolUseFailure should not set status (detail-only); got %s", r.Status)
+	}
+	if r.Detail == nil {
+		t.Fatal("PdxPostToolUseFailure should carry Detail map")
+	}
+	if r.Detail["tool_name"] != "Bash" {
+		t.Errorf("Detail[tool_name] = %v, want Bash", r.Detail["tool_name"])
+	}
+	if r.Detail["tool_use_id"] != "T2" {
+		t.Errorf("Detail[tool_use_id] = %v, want T2", r.Detail["tool_use_id"])
+	}
+	if r.Detail["agent_id"] != "agent-Y" {
+		t.Errorf("Detail[agent_id] = %v, want agent-Y", r.Detail["agent_id"])
+	}
+}
+
 func TestDeriveCCStatus_PdxModelExtraction(t *testing.T) {
 	r := deriveViaProvider("PdxSessionStart", map[string]any{"source": "startup", "modelName": "opus-4"})
 	if r.Model != "opus-4" {

--- a/internal/agent/drift_test.go
+++ b/internal/agent/drift_test.go
@@ -52,6 +52,14 @@ var providerFixtures = map[string][]driftFixture{
 		{"PdxSessionEnd", `{}`, agent.StatusClear, true},
 		{"PdxSubagentStart", `{"agent_id":"a"}`, "", true}, // Valid=true, Status="" (filtered)
 		{"PdxSubagentStop", `{"agent_id":"a"}`, "", true},  // Valid=true, Status="" (filtered)
+		// PR #829 / issue #821: cc PreToolUse + PostToolUseFailure are
+		// detail-only valid (Valid=true, Status="") so handler.go's
+		// delegation extractor can mark/unmark the Delegating flag for
+		// codex-companion Bash invocations. Removing Handling from events.go
+		// makes both spec entries installable; the fixtures here cover the
+		// installer-iteration drift contract.
+		{"PdxPreToolUse", `{"tool_name":"Bash","tool_use_id":"t","agent_id":"a"}`, "", true},
+		{"PdxPostToolUseFailure", `{"tool_name":"Bash","tool_use_id":"t","agent_id":"a"}`, "", true},
 	},
 	"codex": {
 		{"PdxSessionStart", `{}`, agent.StatusIdle, true},

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -11,12 +11,19 @@ package agent
 //     empty. omitempty keeps the wire format backward-compatible — old
 //     subagents_json blobs deserialize to "". No DB migration needed
 //     (subagents_json is an opaque TEXT blob; see frames.go).
+//   - Delegating / DelegatingToolUseIDs: cc subagent 跑 Bash invoking
+//     codex-companion 時的旁路 flag，與 IsProxy（cross-type PPID 驗證）正交。
+//     Invariant: Delegating == len(DelegatingToolUseIDs) > 0，由
+//     markDelegatingRef / unmarkDelegatingRef 共同維持（spec §3.5）。Both
+//     omitempty so pre-existing subagents_json blobs deserialize cleanly.
 type SubagentRef struct {
-	ID              string `json:"id"`
-	Type            string `json:"type"`
-	StartedAt       int64  `json:"started_at"`
-	SourcePID       int    `json:"source_pid"`
-	SourceStartTime string `json:"source_start_time"`
-	IsProxy         bool   `json:"is_proxy,omitempty"`
-	SourceTurnID    string `json:"source_turn_id,omitempty"`
+	ID                   string   `json:"id"`
+	Type                 string   `json:"type"`
+	StartedAt            int64    `json:"started_at"`
+	SourcePID            int      `json:"source_pid"`
+	SourceStartTime      string   `json:"source_start_time"`
+	IsProxy              bool     `json:"is_proxy,omitempty"`
+	SourceTurnID         string   `json:"source_turn_id,omitempty"`
+	Delegating           bool     `json:"delegating,omitempty"`
+	DelegatingToolUseIDs []string `json:"delegating_tool_use_ids,omitempty"`
 }

--- a/internal/agent/subagent_test.go
+++ b/internal/agent/subagent_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -34,7 +35,7 @@ func TestSubagentRef_JSONRoundTripFull(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if got != ref {
+	if !reflect.DeepEqual(got, ref) {
 		t.Errorf("round trip mismatch: got %+v, want %+v", got, ref)
 	}
 }
@@ -83,7 +84,7 @@ func TestSubagentRef_JSONRoundTrip_SourceTurnID(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if got != ref {
+	if !reflect.DeepEqual(got, ref) {
 		t.Errorf("round trip mismatch: got %+v, want %+v", got, ref)
 	}
 
@@ -112,6 +113,60 @@ func TestSubagentRef_JSONRoundTrip_SourceTurnID(t *testing.T) {
 	}
 }
 
+// TestSubagentRef_DelegatingFields_OmitemptyJSON is the Phase 1 P1-T1 contract
+// test for the cc-native delegation flag (spec §3.1 / §3.5). Both
+// Delegating and DelegatingToolUseIDs ride the omitempty wire pattern so
+// existing subagents_json blobs deserialize cleanly (no DB migration). When
+// either is set, the keys must appear in the marshaled output.
+func TestSubagentRef_DelegatingFields_OmitemptyJSON(t *testing.T) {
+	// Case (a): zero-value Delegating fields → keys omitted.
+	zero := SubagentRef{
+		ID:        "a",
+		Type:      "cc",
+		StartedAt: 1,
+	}
+	data, err := json.Marshal(zero)
+	if err != nil {
+		t.Fatalf("Marshal zero: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "delegating") {
+		t.Errorf("delegating-related keys must be omitted on zero value, got: %s", s)
+	}
+
+	// Case (b): set Delegating=true + populated tool_use_ids → keys present.
+	marked := SubagentRef{
+		ID:                   "a",
+		Type:                 "cc",
+		StartedAt:            1,
+		Delegating:           true,
+		DelegatingToolUseIDs: []string{"toolUseA"},
+	}
+	data2, err := json.Marshal(marked)
+	if err != nil {
+		t.Fatalf("Marshal marked: %v", err)
+	}
+	s2 := string(data2)
+	if !strings.Contains(s2, `"delegating":true`) {
+		t.Errorf("missing delegating:true: %s", s2)
+	}
+	if !strings.Contains(s2, `"delegating_tool_use_ids":["toolUseA"]`) {
+		t.Errorf("missing delegating_tool_use_ids array: %s", s2)
+	}
+
+	// Round-trip preserves the slice.
+	var got SubagentRef
+	if err := json.Unmarshal(data2, &got); err != nil {
+		t.Fatalf("Unmarshal marked: %v", err)
+	}
+	if !got.Delegating {
+		t.Errorf("expected Delegating=true after round-trip, got false")
+	}
+	if len(got.DelegatingToolUseIDs) != 1 || got.DelegatingToolUseIDs[0] != "toolUseA" {
+		t.Errorf("DelegatingToolUseIDs round-trip mismatch: %+v", got.DelegatingToolUseIDs)
+	}
+}
+
 func TestSubagentRef_NativeZeroSourceFieldsValid(t *testing.T) {
 	ref := SubagentRef{
 		ID:        "a",
@@ -134,7 +189,7 @@ func TestSubagentRef_NativeZeroSourceFieldsValid(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if got != ref {
+	if !reflect.DeepEqual(got, ref) {
 		t.Errorf("round trip mismatch: got %+v, want %+v", got, ref)
 	}
 }

--- a/internal/module/agent/delegation_extractor.go
+++ b/internal/module/agent/delegation_extractor.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// MaxDelegationIDBytes caps both agent_id and tool_use_id to a generous
+// PATH_MAX-class bound. Real cc payloads stay well under this; the cap
+// limits per-event memory cost and matches the defense pattern in
+// path_hint_extractor.go.
+const MaxDelegationIDBytes = 256
+
+// codexCompanionToken is the literal script filename whose presence in a
+// cc Bash invocation marks the subagent as currently delegating to codex
+// via codex-companion.mjs. See spec §3.3 for boundary semantics.
+const codexCompanionToken = "codex-companion.mjs"
+
+// DelegationHint describes the delegation signal extracted from a cc
+// PreToolUse / PostToolUse / PostToolUseFailure raw event. Callers pair
+// it with the cc SubagentRef whose ID matches AgentID.
+//
+// IsCodexMark is set only when PreToolUse carries a Bash command whose
+// codex-companion token passes the §3.3 boundary check.
+//
+// IsUnmark is set on every PostToolUse / PostToolUseFailure (regardless
+// of command content). Callers remove ToolUseID from the SubagentRef's
+// DelegatingToolUseIDs membership list — non-codex Bash invocations that
+// were never marked simply produce a no-op removal.
+type DelegationHint struct {
+	AgentID     string
+	ToolUseID   string
+	IsCodexMark bool
+	IsUnmark    bool
+}
+
+// rawDelegationEvent decodes the four fields ExtractDelegationHint needs
+// from a cc Bash hook payload. Field tags align with the upstream cc hook
+// schema (`tool_name` / `tool_input.command` / `agent_id` / `tool_use_id`).
+type rawDelegationEvent struct {
+	ToolName  string `json:"tool_name"`
+	ToolInput struct {
+		Command string `json:"command"`
+	} `json:"tool_input"`
+	AgentID   string `json:"agent_id"`
+	ToolUseID string `json:"tool_use_id"`
+}
+
+// ExtractDelegationHint is a pure function. Returns (hint, true) when the
+// raw cc PreToolUse / PostToolUse / PostToolUseFailure event represents a
+// Bash invocation inside a Task subagent.
+//
+// Defenses (mirror path_hint_extractor.go):
+//   - rawEvent must be < MaxRawEventBytes
+//   - agent_id / tool_use_id length bounded by MaxDelegationIDBytes
+//   - control / NUL chars in agent_id / tool_use_id reject the event
+//     (WS-injection guard — same shape as hasControlOrNul there)
+//
+// Pure function: no I/O, no goroutine state, no daemon dependency.
+// All behaviour fully determined by inputs.
+func ExtractDelegationHint(rawEvent json.RawMessage, eventName string) (DelegationHint, bool) {
+	switch eventName {
+	case "PdxPreToolUse", "PdxPostToolUse", "PdxPostToolUseFailure":
+	default:
+		return DelegationHint{}, false
+	}
+	if len(rawEvent) > MaxRawEventBytes {
+		return DelegationHint{}, false
+	}
+	var ev rawDelegationEvent
+	if err := json.Unmarshal(rawEvent, &ev); err != nil {
+		return DelegationHint{}, false
+	}
+	if ev.ToolName != "Bash" {
+		return DelegationHint{}, false
+	}
+	if ev.AgentID == "" || ev.ToolUseID == "" {
+		return DelegationHint{}, false
+	}
+	if len(ev.AgentID) > MaxDelegationIDBytes || len(ev.ToolUseID) > MaxDelegationIDBytes {
+		return DelegationHint{}, false
+	}
+	if hasControlOrNul(ev.AgentID) || hasControlOrNul(ev.ToolUseID) {
+		return DelegationHint{}, false
+	}
+
+	hint := DelegationHint{
+		AgentID:   ev.AgentID,
+		ToolUseID: ev.ToolUseID,
+	}
+	if eventName == "PdxPreToolUse" {
+		hint.IsCodexMark = containsCodexCompanionToken(ev.ToolInput.Command)
+	} else {
+		// PdxPostToolUse / PdxPostToolUseFailure: caller does membership
+		// removal by ToolUseID. Command is intentionally not inspected —
+		// non-codex Bash unmarks are no-ops at the helper layer.
+		hint.IsUnmark = true
+	}
+	return hint, true
+}
+
+// containsCodexCompanionToken returns true when command contains the
+// literal "codex-companion.mjs" followed by a token boundary: a quote
+// (`"` / `'`), whitespace (space / tab / newline), or EOL. Continuation
+// bytes (alphanumeric / `.` / `/` / `_` / `-`) reject the match so
+// "codex-companion.mjs.bak" and "codex-companion.mjsx" don't fire.
+//
+// On a rejected first occurrence the search continues — multiple
+// occurrences are inspected independently. See spec §3.3.
+func containsCodexCompanionToken(command string) bool {
+	for i := 0; i+len(codexCompanionToken) <= len(command); {
+		idx := strings.Index(command[i:], codexCompanionToken)
+		if idx < 0 {
+			return false
+		}
+		end := i + idx + len(codexCompanionToken)
+		if end == len(command) {
+			return true
+		}
+		c := command[end]
+		if c == '"' || c == '\'' || c == ' ' || c == '\t' || c == '\n' {
+			return true
+		}
+		// Continues a different token — keep searching past this rejection.
+		i = i + idx + len(codexCompanionToken)
+	}
+	return false
+}

--- a/internal/module/agent/delegation_extractor_test.go
+++ b/internal/module/agent/delegation_extractor_test.go
@@ -1,0 +1,287 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// mkBashRaw builds a cc Bash tool hook payload. Pass empty string for any of
+// agentID / toolUseID to exercise the omission paths in spec §6.1.
+func mkBashRaw(toolName, command, agentID, toolUseID string) json.RawMessage {
+	payload := map[string]any{
+		"tool_name": toolName,
+		"tool_input": map[string]any{
+			"command": command,
+		},
+	}
+	if agentID != "" {
+		payload["agent_id"] = agentID
+	}
+	if toolUseID != "" {
+		payload["tool_use_id"] = toolUseID
+	}
+	b, _ := json.Marshal(payload)
+	return b
+}
+
+// mkRawWithControlAgentID hand-assembles a JSON payload whose agent_id
+// contains a literal NUL byte, so the extractor's control-char guard is
+// exercised on a real attacker shape (json.Marshal would escape NUL via map).
+func mkRawWithControlAgentID() json.RawMessage {
+	const prefix = `{"tool_name":"Bash","tool_input":{"command":"node codex-companion.mjs task"},"agent_id":"agent-`
+	const suffix = `-X","tool_use_id":"toolUse-Y"}`
+	var b strings.Builder
+	b.WriteString(prefix)
+	b.WriteByte(0x00) // NUL
+	b.WriteString(suffix)
+	return json.RawMessage(b.String())
+}
+
+// TestExtractDelegationHint_Cases mirrors spec §6.1 — table-driven cc
+// PreToolUse / PostToolUse / PostToolUseFailure cases plus defenses
+// (size cap, malformed JSON, control-char rejection).
+func TestExtractDelegationHint_Cases(t *testing.T) {
+	const canonicalCmd = `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task --background "..."`
+	const barePathCmd = `node /path/codex-companion.mjs review`
+	const singleQuotedCmd = `node 'codex-companion.mjs' task`
+	const continuationCmd = `node codex-companion.mjs.bak task`
+	const nonCodexCmd = `pnpm build`
+
+	// Build a >MaxRawEventBytes payload by stuffing command field.
+	bigCmd := strings.Repeat("a", MaxRawEventBytes+1024)
+	bigRaw := mkBashRaw("Bash", bigCmd, "agent-X", "toolUse-Y")
+
+	cases := []struct {
+		name        string
+		raw         json.RawMessage
+		eventName   string
+		wantOK      bool
+		wantAgent   string
+		wantToolUse string
+		wantMark    bool
+		wantUnmark  bool
+	}{
+		{
+			name:        "PreToolUse Bash canonical quoted command",
+			raw:         mkBashRaw("Bash", canonicalCmd, "agent-X", "toolUse-Y"),
+			eventName:   "PdxPreToolUse",
+			wantOK:      true,
+			wantAgent:   "agent-X",
+			wantToolUse: "toolUse-Y",
+			wantMark:    true,
+			wantUnmark:  false,
+		},
+		{
+			name:        "PreToolUse Bash bare path command",
+			raw:         mkBashRaw("Bash", barePathCmd, "agent-X", "toolUse-Y"),
+			eventName:   "PdxPreToolUse",
+			wantOK:      true,
+			wantAgent:   "agent-X",
+			wantToolUse: "toolUse-Y",
+			wantMark:    true,
+			wantUnmark:  false,
+		},
+		{
+			name:        "PreToolUse Bash single-quoted command",
+			raw:         mkBashRaw("Bash", singleQuotedCmd, "agent-X", "toolUse-Y"),
+			eventName:   "PdxPreToolUse",
+			wantOK:      true,
+			wantAgent:   "agent-X",
+			wantToolUse: "toolUse-Y",
+			wantMark:    true,
+			wantUnmark:  false,
+		},
+		{
+			name:        "PreToolUse Bash token-continuation .bak",
+			raw:         mkBashRaw("Bash", continuationCmd, "agent-X", "toolUse-Y"),
+			eventName:   "PdxPreToolUse",
+			wantOK:      true,
+			wantAgent:   "agent-X",
+			wantToolUse: "toolUse-Y",
+			wantMark:    false,
+			wantUnmark:  false,
+		},
+		{
+			name:        "PreToolUse Bash non-codex command",
+			raw:         mkBashRaw("Bash", nonCodexCmd, "agent-X", "toolUse-Y"),
+			eventName:   "PdxPreToolUse",
+			wantOK:      true,
+			wantAgent:   "agent-X",
+			wantToolUse: "toolUse-Y",
+			wantMark:    false,
+			wantUnmark:  false,
+		},
+		{
+			name:      "PreToolUse non-Bash tool (Read)",
+			raw:       mkBashRaw("Read", canonicalCmd, "agent-X", "toolUse-Y"),
+			eventName: "PdxPreToolUse",
+			wantOK:    false,
+		},
+		{
+			name:      "PreToolUse Bash without agent_id (top-level cc)",
+			raw:       mkBashRaw("Bash", canonicalCmd, "", "toolUse-Y"),
+			eventName: "PdxPreToolUse",
+			wantOK:    false,
+		},
+		{
+			name:      "PreToolUse Bash without tool_use_id",
+			raw:       mkBashRaw("Bash", canonicalCmd, "agent-X", ""),
+			eventName: "PdxPreToolUse",
+			wantOK:    false,
+		},
+		{
+			name:        "PostToolUse Bash canonical command",
+			raw:         mkBashRaw("Bash", canonicalCmd, "agent-X", "toolUse-Y"),
+			eventName:   "PdxPostToolUse",
+			wantOK:      true,
+			wantAgent:   "agent-X",
+			wantToolUse: "toolUse-Y",
+			wantMark:    false,
+			wantUnmark:  true,
+		},
+		{
+			name:        "PostToolUse Bash non-codex command",
+			raw:         mkBashRaw("Bash", nonCodexCmd, "agent-X", "toolUse-Y"),
+			eventName:   "PdxPostToolUse",
+			wantOK:      true,
+			wantAgent:   "agent-X",
+			wantToolUse: "toolUse-Y",
+			wantMark:    false,
+			wantUnmark:  true,
+		},
+		{
+			name:        "PostToolUseFailure Bash canonical command",
+			raw:         mkBashRaw("Bash", canonicalCmd, "agent-X", "toolUse-Y"),
+			eventName:   "PdxPostToolUseFailure",
+			wantOK:      true,
+			wantAgent:   "agent-X",
+			wantToolUse: "toolUse-Y",
+			wantMark:    false,
+			wantUnmark:  true,
+		},
+		{
+			name:      "raw event over MaxRawEventBytes cap",
+			raw:       bigRaw,
+			eventName: "PdxPreToolUse",
+			wantOK:    false,
+		},
+		{
+			name:      "malformed JSON",
+			raw:       json.RawMessage(`{"tool_name":`),
+			eventName: "PdxPreToolUse",
+			wantOK:    false,
+		},
+		{
+			name:      "control char in agent_id (NUL)",
+			raw:       mkRawWithControlAgentID(),
+			eventName: "PdxPreToolUse",
+			wantOK:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hint, ok := ExtractDelegationHint(tc.raw, tc.eventName)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (hint=%+v)", ok, tc.wantOK, hint)
+			}
+			if !ok {
+				return
+			}
+			if hint.AgentID != tc.wantAgent {
+				t.Errorf("AgentID = %q, want %q", hint.AgentID, tc.wantAgent)
+			}
+			if hint.ToolUseID != tc.wantToolUse {
+				t.Errorf("ToolUseID = %q, want %q", hint.ToolUseID, tc.wantToolUse)
+			}
+			if hint.IsCodexMark != tc.wantMark {
+				t.Errorf("IsCodexMark = %v, want %v", hint.IsCodexMark, tc.wantMark)
+			}
+			if hint.IsUnmark != tc.wantUnmark {
+				t.Errorf("IsUnmark = %v, want %v", hint.IsUnmark, tc.wantUnmark)
+			}
+		})
+	}
+}
+
+// TestContainsCodexCompanionToken_Cases mirrors spec §3.3 — token-boundary
+// rule: next byte after `codex-companion.mjs` must be quote, whitespace, or
+// EOL. Continuation bytes (alnum / `.` / `/` / `_` / `-`) reject.
+func TestContainsCodexCompanionToken_Cases(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{
+			name: "canonical quoted plugin path",
+			cmd:  `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task --background "..."`,
+			want: true,
+		},
+		{
+			name: "bare path with space boundary",
+			cmd:  `node ~/.claude/plugins/.../codex-companion.mjs review --base main`,
+			want: true,
+		},
+		{
+			name: "double-quoted full subcommand",
+			cmd:  `bash -c "node /custom/codex-companion.mjs adversarial-review focus"`,
+			want: true,
+		},
+		{
+			name: "single-quoted script name",
+			cmd:  `node 'codex-companion.mjs' task`,
+			want: true,
+		},
+		{
+			name: "shell substitution hides the literal token",
+			cmd:  `node $(./find-script).mjs task`,
+			want: false,
+		},
+		{
+			name: "token continuation .bak",
+			cmd:  `node codex-companion.mjs.bak task`,
+			want: false,
+		},
+		{
+			name: "echo false positive (next byte: quote)",
+			cmd:  `echo "codex-companion.mjs"`,
+			want: true,
+		},
+		{
+			name: "grep pipe — EOF boundary",
+			cmd:  `cat README | grep codex-companion.mjs`,
+			want: true,
+		},
+		{
+			name: "git log mjsx continuation",
+			cmd:  `git log --grep=codex-companion.mjsx`,
+			want: false,
+		},
+		{
+			name: "newline boundary",
+			cmd:  "node codex-companion.mjs\nnext-line",
+			want: true,
+		},
+		{
+			name: "tab boundary",
+			cmd:  "node codex-companion.mjs\ttask",
+			want: true,
+		},
+		{
+			name: "second occurrence after rejected first",
+			cmd:  `node codex-companion.mjs.bak; node "codex-companion.mjs" task`,
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := containsCodexCompanionToken(tc.cmd)
+			if got != tc.want {
+				t.Fatalf("containsCodexCompanionToken(%q) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -1751,3 +1751,168 @@ func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
 	}
 	return nil, nil
 }
+
+// ---------------------------------------------------------------------------
+// Phase 2 P2-T1 — markDelegatingRef / unmarkDelegatingRef
+// (spec §3.5 / plan §2 P2-T1)
+// ---------------------------------------------------------------------------
+
+// markDelegatingRef appends toolUseID to DelegatingToolUseIDs (deduped) and
+// sets Delegating=true on the SubagentRef whose ID matches agentID, on the
+// frame at (paneID, senderPID, senderStartTime). Idempotent — re-mark with
+// same toolUseID is a no-op (slice membership check).
+//
+// Mirror upsertProxyRefForBroker pattern (frame_ops.go:1216-1297). Does NOT
+// reuse mutateSubagentsWithRetry — that helper's SubagentStart branch routes
+// through updateSubagents → subagentRefMatches (turn-aware), which only
+// supports SubagentStart append-if-missing / SubagentStop remove-matching,
+// not in-place mutation of an existing ref's fields (frame_ops.go:825-848 /
+// plan §0.3 B1). Same UpsertIfUnchanged retry cap (proxyUpsertMaxAttempts).
+//
+// Race scope (spec L7): when PreToolUse arrives before SubagentStart has
+// established the ref (regression #10/#12), this is a silent no-op — by
+// design, since attaching a flag to a non-existent ref has no meaningful
+// semantics; recovers when subagent ends or on the next tool use.
+//
+// Invariant: Delegating == len(DelegatingToolUseIDs) > 0.
+func (m *Module) markDelegatingRef(paneID string, senderPID int, senderStartTime string, agentID, toolUseID string, broadcastTs int64) error {
+	parent, err := m.frames.GetByIdentity(paneID, senderPID, senderStartTime)
+	if err != nil {
+		return err
+	}
+	if parent == nil {
+		// Spec L7: PreToolUse-before-SubagentStart silent no-op.
+		return nil
+	}
+
+	current := *parent
+	for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
+		expected := current.LastSeenAt
+
+		idx := -1
+		for i, ref := range current.Subagents {
+			if ref.ID == agentID {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			// Ref not present — spec §3.5 race: PreToolUse beat SubagentStart.
+			return nil
+		}
+
+		// Build a fresh slice so mutating next[idx] never aliases the caller's
+		// snapshot or any other reader of current.Subagents.
+		next := make([]agentpkg.SubagentRef, len(current.Subagents))
+		copy(next, current.Subagents)
+
+		// Dedupe append toolUseID into a fresh backing array (avoid sharing
+		// with the existing ref's slice).
+		ids := make([]string, 0, len(next[idx].DelegatingToolUseIDs)+1)
+		ids = append(ids, next[idx].DelegatingToolUseIDs...)
+		already := false
+		for _, id := range ids {
+			if id == toolUseID {
+				already = true
+				break
+			}
+		}
+		if !already {
+			ids = append(ids, toolUseID)
+		}
+		next[idx].DelegatingToolUseIDs = ids
+		next[idx].Delegating = len(ids) > 0
+
+		current.Subagents = next
+		current.LastSeenAt = broadcastTs
+		ok, _, err := m.frames.UpsertIfUnchanged(current, expected)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+
+		reloaded, rerr := m.frames.GetByIdentity(paneID, senderPID, senderStartTime)
+		if rerr != nil {
+			return rerr
+		}
+		if reloaded == nil {
+			// Frame disappeared mid-flight — silent no-op (mirror
+			// upsertProxyRefForBroker's reload-nil branch).
+			return nil
+		}
+		current = *reloaded
+	}
+	return fmt.Errorf("markDelegatingRef: exceeded %d retries for frame %s", proxyUpsertMaxAttempts, current.FrameID)
+}
+
+// unmarkDelegatingRef removes toolUseID from DelegatingToolUseIDs on the ref
+// whose ID == agentID, then recomputes Delegating = len(remaining) > 0. No-op
+// if ref not found, ID not in slice, or whole frame missing (covers
+// PostToolUse arriving after SubagentStop, PostToolUseFailure for non-codex
+// Bash, etc.).
+//
+// Mirror upsertProxyRefForBroker pattern (frame_ops.go:1216-1297). Does NOT
+// reuse mutateSubagentsWithRetry — see markDelegatingRef rationale.
+//
+// Invariant: Delegating == len(DelegatingToolUseIDs) > 0.
+func (m *Module) unmarkDelegatingRef(paneID string, senderPID int, senderStartTime string, agentID, toolUseID string, broadcastTs int64) error {
+	parent, err := m.frames.GetByIdentity(paneID, senderPID, senderStartTime)
+	if err != nil {
+		return err
+	}
+	if parent == nil {
+		return nil
+	}
+
+	current := *parent
+	for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
+		expected := current.LastSeenAt
+
+		idx := -1
+		for i, ref := range current.Subagents {
+			if ref.ID == agentID {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return nil
+		}
+
+		next := make([]agentpkg.SubagentRef, len(current.Subagents))
+		copy(next, current.Subagents)
+
+		// Filter into a fresh slice (do not mutate the caller's backing
+		// array via append/in-place writes).
+		filtered := make([]string, 0, len(next[idx].DelegatingToolUseIDs))
+		for _, id := range next[idx].DelegatingToolUseIDs {
+			if id != toolUseID {
+				filtered = append(filtered, id)
+			}
+		}
+		next[idx].DelegatingToolUseIDs = filtered
+		next[idx].Delegating = len(filtered) > 0
+
+		current.Subagents = next
+		current.LastSeenAt = broadcastTs
+		ok, _, err := m.frames.UpsertIfUnchanged(current, expected)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+
+		reloaded, rerr := m.frames.GetByIdentity(paneID, senderPID, senderStartTime)
+		if rerr != nil {
+			return rerr
+		}
+		if reloaded == nil {
+			return nil
+		}
+		current = *reloaded
+	}
+	return fmt.Errorf("unmarkDelegatingRef: exceeded %d retries for frame %s", proxyUpsertMaxAttempts, current.FrameID)
+}

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -1774,6 +1774,16 @@ func (m *Module) findProxyParent(req EventRequest) (*store.Frame, error) {
 // design, since attaching a flag to a non-existent ref has no meaningful
 // semantics; recovers when subagent ends or on the next tool use.
 //
+// Lookup excludes proxy refs (ref.IsProxy=true) even when their ID matches:
+// Delegating is a cc-native subagent state by design (spec §3.1). If a proxy
+// ref happens to share an ID with a real native subagent (rare namespace
+// collision pinned by TestUpdateSubagents_ProxyNativeIDNamespacesAreIsolated)
+// the proxy ref must not absorb the flag — otherwise the native ref stays
+// blue while the proxy ref ends up orange-via-delegation, defeating the
+// visual signal. Mirror filter applied in unmarkDelegatingRef. The IsProxy
+// invariant rule (plan §0.3 B-rule) is preserved: this filter only reads
+// IsProxy, never writes it.
+//
 // Invariant: Delegating == len(DelegatingToolUseIDs) > 0.
 func (m *Module) markDelegatingRef(paneID string, senderPID int, senderStartTime string, agentID, toolUseID string, broadcastTs int64) error {
 	parent, err := m.frames.GetByIdentity(paneID, senderPID, senderStartTime)
@@ -1791,7 +1801,9 @@ func (m *Module) markDelegatingRef(paneID string, senderPID int, senderStartTime
 
 		idx := -1
 		for i, ref := range current.Subagents {
-			if ref.ID == agentID {
+			// Skip proxy refs even on ID match — see helper comment for
+			// the namespace-collision rationale.
+			if ref.ID == agentID && !ref.IsProxy {
 				idx = i
 				break
 			}
@@ -1856,6 +1868,10 @@ func (m *Module) markDelegatingRef(paneID string, senderPID int, senderStartTime
 // Mirror upsertProxyRefForBroker pattern (frame_ops.go:1216-1297). Does NOT
 // reuse mutateSubagentsWithRetry — see markDelegatingRef rationale.
 //
+// Lookup excludes proxy refs (ref.IsProxy=true) for the same reason as
+// markDelegatingRef: Delegating is a cc-native subagent state. See
+// markDelegatingRef helper comment for the namespace-collision rationale.
+//
 // Invariant: Delegating == len(DelegatingToolUseIDs) > 0.
 func (m *Module) unmarkDelegatingRef(paneID string, senderPID int, senderStartTime string, agentID, toolUseID string, broadcastTs int64) error {
 	parent, err := m.frames.GetByIdentity(paneID, senderPID, senderStartTime)
@@ -1872,7 +1888,8 @@ func (m *Module) unmarkDelegatingRef(paneID string, senderPID int, senderStartTi
 
 		idx := -1
 		for i, ref := range current.Subagents {
-			if ref.ID == agentID {
+			// Skip proxy refs even on ID match — see markDelegatingRef.
+			if ref.ID == agentID && !ref.IsProxy {
 				idx = i
 				break
 			}

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -25,6 +25,20 @@ const proxyMaxDepth = 5
 // that hit this limit are genuine hot loops, not ordinary concurrency.
 const proxyUpsertMaxAttempts = 3
 
+// MaxDelegatingToolUseIDs caps DelegatingToolUseIDs slice growth per
+// SubagentRef. Spec §10 risk table pre-acknowledged that a degenerate hook
+// stream (missing PostToolUse / hook resends with new tool_use_id) could
+// inflate subagents_json unboundedly — making UpsertIfUnchanged, projection
+// broadcast, and SPA payload progressively slower or out-of-budget — and
+// recommended "defensive cap at ~32 entries with log-and-discard if needed".
+// Round-2 codex three-parallel adversarial review (PR #829, finding #2)
+// triggered enforcement.
+//
+// On overflow, oldest IDs evict first (FIFO). The Delegating flag stays
+// true so the visual signal does not flap; dev-mode log surfaces hook stream
+// health for operators.
+const MaxDelegatingToolUseIDs = 32
+
 // nativeBaselineKey identifies a native (IsProxy=false) subagent ref for the
 // SessionStart filter-merge baseline (Phase 3.5 plan §2.2.2 v12 T1 fix). The
 // triple (Type, ID, StartedAt) survives ID collision between an old-session
@@ -1831,6 +1845,17 @@ func (m *Module) markDelegatingRef(paneID string, senderPID int, senderStartTime
 		}
 		if !already {
 			ids = append(ids, toolUseID)
+		}
+		// FIFO evict-oldest enforcement (spec §10 / round-2 finding #2).
+		// Cap kicks in when degenerate hook streams keep mark'ing without
+		// matching PostToolUse — preserves Delegating=true so the visual
+		// signal does not flap; surfaces a dev-mode log for operators.
+		if len(ids) > MaxDelegatingToolUseIDs {
+			if isDevMode() {
+				log.Printf("[delegation] cap reached: evicting %d oldest entries (agent_id=%s pane=%s)",
+					len(ids)-MaxDelegatingToolUseIDs, agentID, paneID)
+			}
+			ids = ids[len(ids)-MaxDelegatingToolUseIDs:]
 		}
 		next[idx].DelegatingToolUseIDs = ids
 		next[idx].Delegating = len(ids) > 0

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -4578,3 +4578,139 @@ func TestDelegatingNativeRef_CoexistsWith_RealIsProxyRef_OnSameParent(t *testing
 		t.Fatalf("proxy ref leaked delegating fields: %+v", p)
 	}
 }
+
+// TestMarkDelegatingRef_SkipsProxyRefWithSameID pins the round-1 third-pass
+// codex finding (PR #829): when a proxy ref happens to share an ID with a
+// native cc subagent and is ordered before the native ref in
+// parent.Subagents, markDelegatingRef must skip the proxy ref and mutate
+// the native ref only — otherwise the proxy turns orange-via-delegation
+// while the native cc subagent stays blue, defeating the visual signal.
+//
+// Pairs with TestUpdateSubagents_ProxyNativeIDNamespacesAreIsolated (U6)
+// which pins kind-aware identity on the SubagentStart/Stop append/remove
+// path; this test extends the same isolation guarantee to the delegating
+// flag mutation path.
+func TestMarkDelegatingRef_SkipsProxyRefWithSameID(t *testing.T) {
+	m := newProxyTestModule(t)
+	// Proxy ref is INTENTIONALLY ordered before the native ref so the linear
+	// scan would hit the proxy first if !ref.IsProxy guard were missing.
+	proxyRef := agentpkg.SubagentRef{
+		ID:              "agent-X",
+		Type:            "codex",
+		StartedAt:       30,
+		SourcePID:       999,
+		SourceStartTime: "t999",
+		IsProxy:         true,
+		SourceTurnID:    "t_x",
+	}
+	nativeRef := nativeSubagentRef("agent-X", 40)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		proxyRef,
+		nativeRef,
+	})
+
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-X", "tool-T1", 100); err != nil {
+		t.Fatalf("markDelegatingRef: %v", err)
+	}
+	got, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 2 {
+		t.Fatalf("Subagents count = %d, want 2 (proxy + native preserved); refs=%+v", len(got.Subagents), got.Subagents)
+	}
+
+	// Pull both refs out by IsProxy regardless of ordering.
+	var p, n agentpkg.SubagentRef
+	for _, ref := range got.Subagents {
+		if ref.IsProxy {
+			p = ref
+		} else {
+			n = ref
+		}
+	}
+	// Proxy ref MUST remain unmarked (cc-native delegation flag must not
+	// leak to a same-ID proxy ref).
+	if p.Delegating {
+		t.Fatalf("proxy ref absorbed Delegating flag despite IsProxy=true: %+v", p)
+	}
+	if len(p.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("proxy ref DelegatingToolUseIDs = %v, want empty", p.DelegatingToolUseIDs)
+	}
+	// Proxy identity fields untouched.
+	if !p.IsProxy || p.ID != "agent-X" || p.SourcePID != 999 || p.SourceStartTime != "t999" || p.SourceTurnID != "t_x" {
+		t.Fatalf("proxy ref identity drifted: %+v", p)
+	}
+	// Native ref MUST hold the flag.
+	if !n.Delegating {
+		t.Fatalf("native ref Delegating = false, want true (mark should target native, not proxy)")
+	}
+	if len(n.DelegatingToolUseIDs) != 1 || n.DelegatingToolUseIDs[0] != "tool-T1" {
+		t.Fatalf("native ref DelegatingToolUseIDs = %v, want [tool-T1]", n.DelegatingToolUseIDs)
+	}
+	if n.IsProxy {
+		t.Fatalf("native ref drifted to IsProxy=true: %+v", n)
+	}
+}
+
+// TestUnmarkDelegatingRef_SkipsProxyRefWithSameID — sister test for the
+// unmark path. Pre-condition simulates a hypothetical pre-existing crossed
+// state: both proxy and native refs (sharing ID) carry the same toolUseID
+// in their DelegatingToolUseIDs slice. unmarkDelegatingRef must clear only
+// the native ref's slice, leaving the proxy ref's slice untouched.
+func TestUnmarkDelegatingRef_SkipsProxyRefWithSameID(t *testing.T) {
+	m := newProxyTestModule(t)
+	// Same ordering as the mark sister test: proxy first.
+	proxyRef := agentpkg.SubagentRef{
+		ID:                   "agent-X",
+		Type:                 "codex",
+		StartedAt:            30,
+		SourcePID:            999,
+		SourceStartTime:      "t999",
+		IsProxy:              true,
+		SourceTurnID:         "t_x",
+		Delegating:           true,
+		DelegatingToolUseIDs: []string{"tool-T1"},
+	}
+	nativeRef := nativeSubagentRef("agent-X", 40)
+	nativeRef.Delegating = true
+	nativeRef.DelegatingToolUseIDs = []string{"tool-T1"}
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		proxyRef,
+		nativeRef,
+	})
+
+	if err := m.unmarkDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-X", "tool-T1", 110); err != nil {
+		t.Fatalf("unmarkDelegatingRef: %v", err)
+	}
+	got, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 2 {
+		t.Fatalf("Subagents count = %d, want 2; refs=%+v", len(got.Subagents), got.Subagents)
+	}
+	var p, n agentpkg.SubagentRef
+	for _, ref := range got.Subagents {
+		if ref.IsProxy {
+			p = ref
+		} else {
+			n = ref
+		}
+	}
+	// Proxy ref's pre-existing crossed state MUST be left intact —
+	// unmarkDelegatingRef has no business touching proxy ref state.
+	if !p.Delegating {
+		t.Fatalf("proxy ref Delegating cleared by unmark, want preserved (proxy state untouched): %+v", p)
+	}
+	if len(p.DelegatingToolUseIDs) != 1 || p.DelegatingToolUseIDs[0] != "tool-T1" {
+		t.Fatalf("proxy ref DelegatingToolUseIDs = %v, want [tool-T1] (unchanged)", p.DelegatingToolUseIDs)
+	}
+	// Native ref's flag MUST be cleared.
+	if n.Delegating {
+		t.Fatalf("native ref Delegating = true, want false after unmark: %+v", n)
+	}
+	if len(n.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("native ref DelegatingToolUseIDs = %v, want empty after unmark", n.DelegatingToolUseIDs)
+	}
+}

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -4201,3 +4201,380 @@ func TestCandidateHasOwnedState_EmptySubagentsReturnsFalse(t *testing.T) {
 		t.Fatal("candidateHasOwnedState = true, want false (empty subagents — no state to preserve)")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Phase 2 P2-T1 — markDelegatingRef / unmarkDelegatingRef
+// (spec §3.5 / plan §2 P2-T1)
+// ---------------------------------------------------------------------------
+
+// seedFrameWithSubagents installs `refs` on the seeded frame's Subagents
+// slice via Upsert, then re-reads through GetByIdentity to return a fresh
+// snapshot reflecting the persisted LastSeenAt. Local helper for the
+// delegating-ref tests below; not promoted to package-wide fixtures because
+// other tests already have their own subagent seeding ergonomics.
+func seedFrameWithSubagents(t *testing.T, m *Module, paneID, agentType string, pid int, startTime string, lastSeenAt int64, refs []agentpkg.SubagentRef) store.Frame {
+	t.Helper()
+	parent := seedFrame(t, m, paneID, agentType, pid, startTime, lastSeenAt)
+	parent.Subagents = refs
+	if _, err := m.frames.Upsert(parent); err != nil {
+		t.Fatalf("seed parent ref: %v", err)
+	}
+	got, err := m.frames.GetByIdentity(paneID, pid, startTime)
+	if err != nil || got == nil {
+		t.Fatalf("reload parent: %v / %v", err, got)
+	}
+	return *got
+}
+
+// nativeSubagentRef returns a non-proxy SubagentRef as the cc native
+// SubagentStart payload would shape it (ID = agent_id string).
+func nativeSubagentRef(agentID string, startedAt int64) agentpkg.SubagentRef {
+	return agentpkg.SubagentRef{
+		ID:        agentID,
+		Type:      "task",
+		StartedAt: startedAt,
+	}
+}
+
+func TestMarkDelegatingRef_AppendsToolUseIDOnMatchingRef(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("markDelegatingRef: %v", err)
+	}
+	got, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 1 {
+		t.Fatalf("Subagents count = %d, want 1; refs=%+v", len(got.Subagents), got.Subagents)
+	}
+	ref := got.Subagents[0]
+	if !ref.Delegating {
+		t.Fatalf("ref.Delegating = false, want true (after mark)")
+	}
+	if len(ref.DelegatingToolUseIDs) != 1 || ref.DelegatingToolUseIDs[0] != "tool-T1" {
+		t.Fatalf("ref.DelegatingToolUseIDs = %v, want [tool-T1]", ref.DelegatingToolUseIDs)
+	}
+	if got.LastSeenAt != 100 {
+		t.Fatalf("LastSeenAt = %d, want 100", got.LastSeenAt)
+	}
+}
+
+func TestMarkDelegatingRef_DedupesRepeatedToolUseID(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("first mark: %v", err)
+	}
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 110); err != nil {
+		t.Fatalf("second mark (dedupe): %v", err)
+	}
+	got, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	ref := got.Subagents[0]
+	if len(ref.DelegatingToolUseIDs) != 1 {
+		t.Fatalf("DelegatingToolUseIDs = %v, want single entry (deduped)", ref.DelegatingToolUseIDs)
+	}
+	if !ref.Delegating {
+		t.Fatalf("ref.Delegating = false, want true after dedupe re-mark")
+	}
+}
+
+func TestMarkDelegatingRef_NoOpWhenAgentIDNotFound(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	// Mark with agent-Z (not present) → silent no-op (spec L7 race:
+	// PreToolUse arrived before SubagentStart established the ref).
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-Z", "tool-T1", 100); err != nil {
+		t.Fatalf("markDelegatingRef returned error on missing ref, want nil (silent no-op): %v", err)
+	}
+	got, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 1 {
+		t.Fatalf("Subagents count = %d, want 1 (unchanged); refs=%+v", len(got.Subagents), got.Subagents)
+	}
+	if got.Subagents[0].Delegating {
+		t.Fatalf("ref.Delegating = true, want false (no-op)")
+	}
+	if len(got.Subagents[0].DelegatingToolUseIDs) != 0 {
+		t.Fatalf("DelegatingToolUseIDs = %v, want empty (no-op)", got.Subagents[0].DelegatingToolUseIDs)
+	}
+}
+
+func TestMarkDelegatingRef_NoOpWhenFrameMissing(t *testing.T) {
+	m := newProxyTestModule(t)
+	// No frame seeded for pid=999.
+	if err := m.markDelegatingRef("%5", 999, "tNone", "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("markDelegatingRef on missing frame returned error, want nil silent no-op: %v", err)
+	}
+}
+
+func TestMarkDelegatingRef_RetryOnUpsertConflict(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	// Inject a concurrent racer write BEFORE our mark call. The racer
+	// adds an unrelated proxy ref and bumps LastSeenAt to 60. Our caller's
+	// `parent` snapshot is still at LastSeenAt=50, so the helper's first
+	// UpsertIfUnchanged(expected=50) fails; the helper reloads, sees the
+	// racer's ref + LastSeenAt=60, and the second attempt succeeds —
+	// preserving both the racer's ref and our delegating mark on agent-A.
+	racer := agentpkg.SubagentRef{
+		ID:              "proxy:codex:999:t999",
+		Type:            "codex",
+		StartedAt:       55,
+		SourcePID:       999,
+		SourceStartTime: "t999",
+		IsProxy:         true,
+		SourceTurnID:    "t_x",
+	}
+	cur, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil || cur == nil {
+		t.Fatalf("racer baseline read: %v / %v", err, cur)
+	}
+	cur.Subagents = append(cur.Subagents, racer)
+	cur.LastSeenAt = 60
+	if _, err := m.frames.Upsert(*cur); err != nil {
+		t.Fatalf("racer Upsert: %v", err)
+	}
+
+	// Call helper; helper reloads internally on first conflict.
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("markDelegatingRef: %v", err)
+	}
+	got, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 2 {
+		t.Fatalf("Subagents count = %d, want 2 (racer + native); refs=%+v", len(got.Subagents), got.Subagents)
+	}
+	var native agentpkg.SubagentRef
+	for _, ref := range got.Subagents {
+		if !ref.IsProxy && ref.ID == "agent-A" {
+			native = ref
+		}
+	}
+	if !native.Delegating || len(native.DelegatingToolUseIDs) != 1 || native.DelegatingToolUseIDs[0] != "tool-T1" {
+		t.Fatalf("native ref after retry = %+v, want Delegating=true ToolUseIDs=[tool-T1]", native)
+	}
+}
+
+func TestUnmarkDelegatingRef_RemovesToolUseID(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	if err := m.unmarkDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 110); err != nil {
+		t.Fatalf("unmark: %v", err)
+	}
+	got, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	ref := got.Subagents[0]
+	if len(ref.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("DelegatingToolUseIDs = %v, want empty after unmark", ref.DelegatingToolUseIDs)
+	}
+	if ref.Delegating {
+		t.Fatalf("ref.Delegating = true, want false after list emptied")
+	}
+}
+
+func TestUnmarkDelegatingRef_DelegatingFalseWhenListEmpties(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	// Mark exactly one tool use, then unmark it. Verify the invariant
+	// Delegating == len(DelegatingToolUseIDs) > 0 flips to false.
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	if err := m.unmarkDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 110); err != nil {
+		t.Fatalf("unmark: %v", err)
+	}
+	got, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if got.Subagents[0].Delegating {
+		t.Fatalf("Delegating = true, want false (invariant: len==0 → false)")
+	}
+}
+
+func TestUnmarkDelegatingRef_DelegatingTrueWhenOthersStillActive(t *testing.T) {
+	// B2 verification: two concurrent codex Bash calls (T1, T2) from the
+	// same subagent. unmarking T2 should leave [T1] in the list, with
+	// Delegating still true.
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("mark T1: %v", err)
+	}
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T2", 105); err != nil {
+		t.Fatalf("mark T2: %v", err)
+	}
+	if err := m.unmarkDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T2", 110); err != nil {
+		t.Fatalf("unmark T2: %v", err)
+	}
+	got, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	ref := got.Subagents[0]
+	if len(ref.DelegatingToolUseIDs) != 1 || ref.DelegatingToolUseIDs[0] != "tool-T1" {
+		t.Fatalf("DelegatingToolUseIDs = %v, want [tool-T1]", ref.DelegatingToolUseIDs)
+	}
+	if !ref.Delegating {
+		t.Fatalf("ref.Delegating = false, want true (T1 still active)")
+	}
+}
+
+func TestUnmarkDelegatingRef_NoOpWhenToolUseIDNotInList(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("mark T1: %v", err)
+	}
+	// Unmark a different tool_use_id that was never marked → list unchanged.
+	if err := m.unmarkDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T2", 110); err != nil {
+		t.Fatalf("unmark unknown: %v", err)
+	}
+	got, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	ref := got.Subagents[0]
+	if len(ref.DelegatingToolUseIDs) != 1 || ref.DelegatingToolUseIDs[0] != "tool-T1" {
+		t.Fatalf("DelegatingToolUseIDs = %v, want [tool-T1] (unchanged)", ref.DelegatingToolUseIDs)
+	}
+	if !ref.Delegating {
+		t.Fatalf("ref.Delegating = false, want true (T1 still in list)")
+	}
+}
+
+func TestUnmarkDelegatingRef_NoOpAfterSubagentStop(t *testing.T) {
+	// Simulate PostToolUse arriving after SubagentStop has already removed
+	// the ref. unmarkDelegatingRef must be a silent no-op (return nil, no
+	// frame mutation).
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	// Run real SubagentStop flow — removes the ref.
+	stopRef := nativeSubagentRef("agent-A", 0)
+	if _, _, err := m.mutateSubagentsWithRetry(parent, agentpkg.LifecycleSubagentStop, stopRef, 80); err != nil {
+		t.Fatalf("SubagentStop: %v", err)
+	}
+	before, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if len(before.Subagents) != 0 {
+		t.Fatalf("Subagents count after Stop = %d, want 0", len(before.Subagents))
+	}
+
+	// PostToolUse late arrival — must silently no-op.
+	if err := m.unmarkDelegatingRef("%5", 100, "t100", "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("unmarkDelegatingRef post-Stop returned error, want nil: %v", err)
+	}
+	after, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if len(after.Subagents) != 0 {
+		t.Fatalf("Subagents count after late unmark = %d, want 0 (frame unchanged)", len(after.Subagents))
+	}
+}
+
+func TestSubagentStopRemovesRefIncludingDelegatingFlag(t *testing.T) {
+	// Regression: existing SubagentStop flow (mutateSubagentsWithRetry +
+	// updateSubagents → LifecycleSubagentStop branch) removes the ref
+	// entirely, including any Delegating / DelegatingToolUseIDs state.
+	// The delegating-flag fields must NOT linger after a stop.
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	mid, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if !mid.Subagents[0].Delegating {
+		t.Fatalf("pre-Stop Delegating = false, want true")
+	}
+
+	// Trigger SubagentStop on agent-A through the existing path.
+	stopRef := nativeSubagentRef("agent-A", 0)
+	if _, _, err := m.mutateSubagentsWithRetry(*mid, agentpkg.LifecycleSubagentStop, stopRef, 110); err != nil {
+		t.Fatalf("SubagentStop: %v", err)
+	}
+	got, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if len(got.Subagents) != 0 {
+		t.Fatalf("Subagents count after Stop = %d, want 0 (ref removed)", len(got.Subagents))
+	}
+}
+
+func TestDelegatingNativeRef_CoexistsWith_RealIsProxyRef_OnSameParent(t *testing.T) {
+	// AC8 / F5 coverage: parent.Subagents holds both a native ref (with
+	// Delegating set) and a real IsProxy ref. Mutating the native ref must
+	// not touch the proxy ref's identity fields (IsProxy, SourceTurnID,
+	// SourcePID/StartTime), and vice versa.
+	m := newProxyTestModule(t)
+	proxyRef := agentpkg.SubagentRef{
+		ID:              "proxy:codex:999:t999",
+		Type:            "codex",
+		StartedAt:       55,
+		SourcePID:       999,
+		SourceStartTime: "t999",
+		IsProxy:         true,
+		SourceTurnID:    "t_x",
+	}
+	native := nativeSubagentRef("agent-A", 40)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		native,
+		proxyRef,
+	})
+
+	if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", "tool-T1", 100); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	got, _ := m.frames.GetByIdentity("%5", 100, "t100")
+	if len(got.Subagents) != 2 {
+		t.Fatalf("Subagents count = %d, want 2 (native + proxy coexist)", len(got.Subagents))
+	}
+	var n, p agentpkg.SubagentRef
+	for _, ref := range got.Subagents {
+		if ref.IsProxy {
+			p = ref
+		} else {
+			n = ref
+		}
+	}
+	if !n.Delegating || len(n.DelegatingToolUseIDs) != 1 || n.DelegatingToolUseIDs[0] != "tool-T1" {
+		t.Fatalf("native ref after mark = %+v, want Delegating=true ToolUseIDs=[tool-T1]", n)
+	}
+	// Proxy ref untouched: identity fields preserved exactly, no
+	// delegating fields leaked into it.
+	if !p.IsProxy || p.SourcePID != 999 || p.SourceStartTime != "t999" || p.SourceTurnID != "t_x" || p.ID != "proxy:codex:999:t999" {
+		t.Fatalf("proxy ref drifted: %+v", p)
+	}
+	if p.Delegating || len(p.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("proxy ref leaked delegating fields: %+v", p)
+	}
+}

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -514,7 +515,7 @@ func TestUpdateSubagents_StartAddsRef(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("len = %d, want 1", len(got))
 	}
-	if got[0] != start {
+	if !reflect.DeepEqual(got[0], start) {
 		t.Fatalf("got[0] = %+v, want %+v", got[0], start)
 	}
 }
@@ -526,7 +527,7 @@ func TestUpdateSubagents_StartDuplicateIDKeepsExisting(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("len = %d, want 1", len(got))
 	}
-	if got[0] != existing {
+	if !reflect.DeepEqual(got[0], existing) {
 		t.Fatalf("got[0] = %+v, want %+v (no overwrite)", got[0], existing)
 	}
 }
@@ -538,7 +539,7 @@ func TestUpdateSubagents_StopRemovesByID(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("len = %d, want 1", len(got))
 	}
-	if got[0] != b {
+	if !reflect.DeepEqual(got[0], b) {
 		t.Fatalf("got[0] = %+v, want %+v", got[0], b)
 	}
 }
@@ -558,7 +559,7 @@ func TestUpdateSubagents_StopMissingIsNoop(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("len = %d, want 1", len(got))
 	}
-	if got[0] != a {
+	if !reflect.DeepEqual(got[0], a) {
 		t.Fatalf("got[0] = %+v, want %+v", got[0], a)
 	}
 }

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -4712,5 +4713,55 @@ func TestUnmarkDelegatingRef_SkipsProxyRefWithSameID(t *testing.T) {
 	}
 	if len(n.DelegatingToolUseIDs) != 0 {
 		t.Fatalf("native ref DelegatingToolUseIDs = %v, want empty after unmark", n.DelegatingToolUseIDs)
+	}
+}
+
+// TestMarkDelegatingRef_CapsToolUseIDsAt32 pins the round-2 codex three-
+// parallel adversarial review finding #2 (medium, PR #829):
+// DelegatingToolUseIDs slice had no per-ref cap, so a degenerate hook stream
+// (missing PostToolUse / hook resends with new tool_use_id) could inflate
+// subagents_json unboundedly. Spec §10 risk table pre-acknowledged the issue
+// and recommended "defensive cap at ~32 entries with log-and-discard if
+// needed"; this test locks the cap at MaxDelegatingToolUseIDs with FIFO
+// evict-oldest behaviour. Delegating must remain true throughout (no flap).
+func TestMarkDelegatingRef_CapsToolUseIDsAt32(t *testing.T) {
+	m := newProxyTestModule(t)
+	parent := seedFrameWithSubagents(t, m, "%5", "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("agent-A", 40),
+	})
+
+	const overflow = 3
+	total := MaxDelegatingToolUseIDs + overflow
+	for i := 0; i < total; i++ {
+		toolUseID := fmt.Sprintf("tool-T%d", i)
+		// Distinct broadcastTs per mark so LastSeenAt advances and tests
+		// don't accidentally hit UpsertIfUnchanged conflict noise.
+		if err := m.markDelegatingRef(parent.PaneID, parent.PID, parent.ProcessStartTime, "agent-A", toolUseID, int64(100+i)); err != nil {
+			t.Fatalf("mark #%d: %v", i, err)
+		}
+	}
+
+	got, err := m.frames.GetByIdentity("%5", 100, "t100")
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 1 {
+		t.Fatalf("Subagents count = %d, want 1", len(got.Subagents))
+	}
+	ref := got.Subagents[0]
+	if len(ref.DelegatingToolUseIDs) != MaxDelegatingToolUseIDs {
+		t.Fatalf("DelegatingToolUseIDs len = %d, want %d (cap)", len(ref.DelegatingToolUseIDs), MaxDelegatingToolUseIDs)
+	}
+	// FIFO evict-oldest: oldest `overflow` entries dropped, newest
+	// MaxDelegatingToolUseIDs entries kept in original order.
+	for i := 0; i < MaxDelegatingToolUseIDs; i++ {
+		want := fmt.Sprintf("tool-T%d", i+overflow)
+		if ref.DelegatingToolUseIDs[i] != want {
+			t.Fatalf("DelegatingToolUseIDs[%d] = %q, want %q (FIFO evict-oldest)", i, ref.DelegatingToolUseIDs[i], want)
+		}
+	}
+	// Visual signal must not flap.
+	if !ref.Delegating {
+		t.Fatalf("ref.Delegating = false, want true throughout cap enforcement")
 	}
 }

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -218,6 +218,36 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 
 	broadcastTs := time.Now().UnixNano()
 
+	// Delegation flag wiring — independent of PathHint extraction. Detect cc
+	// subagent invoking codex-companion via Bash and mark / unmark Delegating
+	// flag on the matching SubagentRef. Spec §3.2 + §3.3. PathHint and
+	// delegation are emitted from the same raw cc PreToolUse / PostToolUse /
+	// PostToolUseFailure event but are extracted independently — neither
+	// depends on the other's dedup state or module fields (delegation does
+	// not need m.core / m.pathHintDedup / m.pathHintBuffer; spec §3.2 / plan
+	// §0.3 F6). This block is therefore a sibling of the PathHint block, not
+	// nested inside its conditional.
+	if req.AgentType == "cc" &&
+		(req.PurdexName == "PdxPreToolUse" || req.PurdexName == "PdxPostToolUse" || req.PurdexName == "PdxPostToolUseFailure") {
+		if hint, ok := ExtractDelegationHint(req.RawEvent, req.PurdexName); ok {
+			if hint.IsCodexMark {
+				if err := m.markDelegatingRef(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, hint.AgentID, hint.ToolUseID, broadcastTs); err != nil {
+					if isDevMode() {
+						log.Printf("[delegation] mark error: %v", err)
+					}
+					// fail-soft: do not abort handler (mirrors PathHint pattern)
+				}
+			} else if hint.IsUnmark {
+				if err := m.unmarkDelegatingRef(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, hint.AgentID, hint.ToolUseID, broadcastTs); err != nil {
+					if isDevMode() {
+						log.Printf("[delegation] unmark error: %v", err)
+					}
+					// fail-soft
+				}
+			}
+		}
+	}
+
 	// Find provider
 	var provider agentpkg.AgentProvider
 	if m.registry != nil {

--- a/internal/module/agent/handler.go
+++ b/internal/module/agent/handler.go
@@ -342,6 +342,76 @@ func (m *Module) handleEvent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Detail-only no-frame-mutation guard for cc PreToolUse / PostToolUseFailure
+	// (round-2 codex three-parallel adversarial review finding #1, PR #829).
+	// These events were upgraded to Valid=true in commit b121eb26 to enable the
+	// Delegating mark/unmark broadcast, but applyFrameEvent's
+	// LifecycleNone+Status="" path falls back to StatusIdle and CREATES a new
+	// frame when none exists (frame_ops.go:530-532, generic post-switch
+	// create-new-frame block). A tool-precursor / tool-failure event must NOT
+	// resurrect a torn-down frame.
+	//
+	// The delegation mutation block above (handler.go:230) is safe on its own:
+	// it goes through GetByIdentity + UpsertIfUnchanged and is a silent no-op
+	// when frame is missing (spec L7). The only remaining risk is the
+	// downstream applyFrameEvent invitation; this short-circuit removes it.
+	//
+	// Behavior:
+	//   - Frame already mutated by delegation block above (when applicable).
+	//   - If frame exists for this session: rebuild projection, broadcast.
+	//   - If frame missing: 200 ok, no broadcast, no mutation. PreToolUse /
+	//     PostToolUseFailure must not resurrect.
+	//
+	// Compared to the LifecycleSubagentStart/Stop short-circuit at
+	// handler.go:410-441, this branch is stricter: it bypasses applyFrameEvent
+	// entirely (the SubagentStart/Stop path still calls applyFrameEvent for the
+	// detail-only Subagents membership update; here there is no Subagents
+	// mutation to perform).
+	if req.AgentType == "cc" &&
+		(req.PurdexName == "PdxPreToolUse" || req.PurdexName == "PdxPostToolUseFailure") {
+		if req.TmuxSession == "" {
+			trace.Finish("completed", "detail_only_no_session")
+			traceFinished = true
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+			return
+		}
+		projection, perr := m.projectionForSession(req.TmuxSession)
+		if perr != nil {
+			log.Printf("[handler] detail-only projection: %v", perr)
+			trace.Finish("aborted", "projection_failed")
+			traceFinished = true
+			http.Error(w, `{"error":"projection failed"}`, http.StatusInternalServerError)
+			return
+		}
+		if projection == nil || projection.TopFrame == nil {
+			// No frame to broadcast; PreToolUse / PostToolUseFailure must
+			// not resurrect a torn-down frame. The delegation mutation
+			// block above already silent no-op'd (spec L7).
+			trace.Finish("completed", "detail_only_no_frame")
+			traceFinished = true
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+			return
+		}
+		normalized := buildProjectionNormalized(projection, req.AgentType, req.PurdexName, broadcastTs, result)
+		emitDecision, emitReason := m.emitHookToSession(req, normalized)
+		trace.Emit(normalized, normalized.AgentType, normalized.RawEventName, emitDecision, emitReason)
+		if isDevMode() {
+			log.Printf("[broadcast] session=%s has_clients=%t decision=%s reason=%s raw_event_name=%s chain_id=%s detail_only=true",
+				req.TmuxSession, m.hasSubscribers(), emitDecision, emitReason, normalized.RawEventName, trace.ChainID())
+		}
+		if emitDecision == "broadcasted" {
+			trace.Finish("completed", "detail_only_broadcasted")
+		} else {
+			trace.Finish("completed", "detail_only_emit_skipped")
+		}
+		traceFinished = true
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		return
+	}
+
 	paneProjection, frameMeta, err := m.applyFrameEvent(req, result, broadcastTs)
 	if err != nil {
 		log.Printf("[agent] frame event: %v", err)

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -2885,3 +2885,112 @@ func TestHandleEvent_OpencodeAgentTypePreToolUseBashCodexCompanion_NoMark(t *tes
 		t.Fatalf("DelegatingToolUseIDs = %v, want empty (opencode agent_type must not mark)", ref.DelegatingToolUseIDs)
 	}
 }
+
+// delegationModuleWithRealCCProvider mirrors delegationModule but registers the
+// production cc.Provider rather than fakeAgentProvider. This pins the round-1
+// codex review fix: production deriveCCStatus must classify PdxPreToolUse and
+// PdxPostToolUseFailure as Valid=true (detail-only) so handler.go reaches
+// projectionForSession + emitHookToSession (broadcast). The fake provider used
+// by P3-T1's eight cases always returns Valid=true and therefore masked the
+// catalog gap.
+func delegationModuleWithRealCCProvider(t *testing.T) *Module {
+	t.Helper()
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.registry.Register(agentcc.NewProvider(nil, nil, nil, nil))
+	return m
+}
+
+// seedCCFrameWithSubagentReal seeds a cc frame on pane %5 with one
+// SubagentRef. Uses the production-provider module variant so the seed events
+// (SessionStart, SubagentStart) flow through the real deriveCCStatus catalog.
+func seedCCFrameWithSubagentReal(t *testing.T, m *Module, agentID string) {
+	t.Helper()
+	bodies := []string{
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","purdex_name":"PdxSessionStart","raw_event":{"source":"startup"},"agent_type":"cc"}`,
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","purdex_name":"PdxSubagentStart","raw_event":{"agent_id":"` + agentID + `"},"agent_type":"cc"}`,
+	}
+	for _, body := range bodies {
+		req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		m.handleEvent(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("seed body %q: status = %d (body=%s)", body, w.Code, w.Body.String())
+		}
+	}
+}
+
+// TestHandleEvent_CCPreToolUseBashCodexCompanion_BroadcastsViaProductionDeriveStatus
+// pins the round-1 codex review finding: before the deriveCCStatus fix, the
+// production cc provider returned Valid=false on PdxPreToolUse so handler.go
+// hit the invalid-skip return at line ~287 — the delegation flag mark would
+// mutate the frame DB but never broadcast. The SPA therefore never saw the
+// orange dot. This test uses the real cc.NewProvider so the catalog gap is
+// regression-locked, and asserts a broadcast actually fires after the mark.
+func TestHandleEvent_CCPreToolUseBashCodexCompanion_BroadcastsViaProductionDeriveStatus(t *testing.T) {
+	m := delegationModuleWithRealCCProvider(t)
+	seedCCFrameWithSubagentReal(t, m, "agent-X")
+
+	// Subscribe AFTER seed so seed broadcasts don't leak into the mark drain.
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	sendBody(t, m, preToolUseBody("cc", codexCompanionBashCommand, "agent-X", "tool-use-T1"))
+
+	// 1. DB-level: mark took effect (mirrors the existing P3-T1 assertion).
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if !ref.Delegating {
+		t.Fatalf("Delegating = false, want true after PreToolUse codex-companion (ref=%+v)", ref)
+	}
+
+	// 2. Broadcast-level: the production deriveCCStatus catalog gap previously
+	// returned Valid=false here, so handler hit invalid-skip and never reached
+	// emitHookToSession. After the fix the mark must broadcast so the SPA can
+	// render the orange dot. drainBroadcasts only returns "hook" envelopes.
+	msgs := drainBroadcasts(sub, 200*time.Millisecond)
+	if len(msgs) == 0 {
+		t.Fatal("no hook broadcast after PreToolUse mark — production cc provider returned Valid=false and handler took the invalid-skip return path (round-1 codex finding)")
+	}
+}
+
+// TestHandleEvent_CCPostToolUseFailureBashAfterMark_BroadcastsViaProductionDeriveStatus
+// is the sister regression test for the unmark broadcast path. Without the
+// status.go fix, PostToolUseFailure was Valid=false in production so the
+// unmark would clear the DB flag silently — the SPA would stay orange after
+// the codex-companion call failed.
+func TestHandleEvent_CCPostToolUseFailureBashAfterMark_BroadcastsViaProductionDeriveStatus(t *testing.T) {
+	m := delegationModuleWithRealCCProvider(t)
+	seedCCFrameWithSubagentReal(t, m, "agent-X")
+
+	// Mark first (this exercises the PreToolUse broadcast path too).
+	sendBody(t, m, preToolUseBody("cc", codexCompanionBashCommand, "agent-X", "tool-use-T1"))
+	preRef := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if !preRef.Delegating {
+		t.Fatalf("pre-unmark precondition failed: ref=%+v", preRef)
+	}
+
+	// Subscribe AFTER mark so the drain only sees the unmark broadcast.
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	sendBody(t, m, postToolUseBody(true, "agent-X", "tool-use-T1"))
+
+	// 1. DB-level: unmark took effect.
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if ref.Delegating {
+		t.Fatalf("Delegating = true after PostToolUseFailure unmark, want false (ref=%+v)", ref)
+	}
+
+	// 2. Broadcast-level: the unmark must surface to the SPA so the orange dot
+	// clears. Pre-fix, PostToolUseFailure was Valid=false → invalid-skip → no
+	// broadcast → SPA stuck orange.
+	msgs := drainBroadcasts(sub, 200*time.Millisecond)
+	if len(msgs) == 0 {
+		t.Fatal("no hook broadcast after PostToolUseFailure unmark — production cc provider returned Valid=false and handler took the invalid-skip return path (round-1 codex finding)")
+	}
+}

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -2994,3 +2994,173 @@ func TestHandleEvent_CCPostToolUseFailureBashAfterMark_BroadcastsViaProductionDe
 		t.Fatal("no hook broadcast after PostToolUseFailure unmark — production cc provider returned Valid=false and handler took the invalid-skip return path (round-1 codex finding)")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Round-2 codex three-parallel adversarial review finding #1 (PR #829):
+// detail-only PreToolUse / PostToolUseFailure must NOT trigger frame mutation
+// or resurrect torn-down frames. Commit b121eb26 upgraded these events to
+// Valid=true so the Delegating broadcast can fire, but applyFrameEvent's
+// LifecycleNone+Status="" path falls back to StatusIdle and creates a new
+// frame when none exists. The detail-only short-circuit branch in handler.go
+// (between error guard and applyFrameEvent) closes that hole.
+//
+// These tests use the real cc.Provider (delegationModuleWithRealCCProvider)
+// so the production catalog gap is regression-locked end-to-end.
+// ---------------------------------------------------------------------------
+
+// findCCFrameRow returns the (only) cc store.Frame row on pane %5; fatals if
+// missing. Mirrors findCCFrame but exposes the full Frame struct so tests can
+// observe LastSeenAt and other top-level fields, not just Subagents.
+func findCCFrameRow(t *testing.T, m *Module) store.Frame {
+	t.Helper()
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(frames))
+	}
+	return frames[0]
+}
+
+// nonCodexBashCommand is a Bash command that delegation_extractor will reject
+// (no codex-companion path). Used by the detail-only no-mutation tests to
+// drive the handler through PreToolUse / PostToolUseFailure WITHOUT firing
+// markDelegatingRef / unmarkDelegatingRef — proving any LastSeenAt change
+// must have come from applyFrameEvent's LifecycleNone fallback path (the
+// resurrection / mutation behavior the short-circuit closes).
+const nonCodexBashCommand = `pnpm build`
+
+// 1. Detail-only PreToolUse with NO existing frame must not resurrect.
+func TestHandleEvent_CCPreToolUseDetailOnly_DoesNotCreateFrameWhenMissing(t *testing.T) {
+	m := delegationModuleWithRealCCProvider(t)
+	// NO seed — pane %5 has no frame.
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	sendBody(t, m, preToolUseBody("cc", codexCompanionBashCommand, "agent-X", "tool-use-Tghost"))
+
+	// 1. Frame store must remain empty — PreToolUse must not resurrect.
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0 (PreToolUse must not create / resurrect frames; frames=%+v)", len(frames), frames)
+	}
+
+	// 2. No broadcast — no frame to project from.
+	msgs := drainBroadcasts(sub, 100*time.Millisecond)
+	if len(msgs) != 0 {
+		t.Fatalf("got %d broadcasts, want 0 (no frame, no projection, no broadcast); msgs=%+v", len(msgs), msgs)
+	}
+}
+
+// 2. Detail-only PreToolUse with existing frame must broadcast WITHOUT
+// running applyFrameEvent. We send a non-codex Bash command so the
+// delegation block also skips, isolating the test to the new short-circuit
+// branch: any LastSeenAt change would have to come from applyFrameEvent's
+// LifecycleNone fallback (which the short-circuit must skip).
+func TestHandleEvent_CCPreToolUseDetailOnly_NoMutationWhenFrameExists(t *testing.T) {
+	m := delegationModuleWithRealCCProvider(t)
+	seedCCFrameWithSubagentReal(t, m, "agent-X")
+
+	beforeFrame := findCCFrameRow(t, m)
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	sendBody(t, m, preToolUseBody("cc", nonCodexBashCommand, "agent-X", "tool-use-Tnoop"))
+
+	afterFrame := findCCFrameRow(t, m)
+
+	// 1. Frame still exists (broadcast surfaces existing-frame projection).
+	if afterFrame.FrameID != beforeFrame.FrameID {
+		t.Fatalf("FrameID changed: before=%s after=%s (frame must not be replaced)", beforeFrame.FrameID, afterFrame.FrameID)
+	}
+
+	// 2. No applyFrameEvent mutation: LastSeenAt unchanged. The delegation
+	// block was skipped (non-codex command, ExtractDelegationHint returns
+	// ok=false) so the only path that could touch LastSeenAt is
+	// applyFrameEvent's UpdateHookPath narrow-column update — exactly what
+	// the new short-circuit must prevent.
+	if afterFrame.LastSeenAt != beforeFrame.LastSeenAt {
+		t.Fatalf("LastSeenAt changed: before=%d after=%d (applyFrameEvent must not run on detail-only PreToolUse)", beforeFrame.LastSeenAt, afterFrame.LastSeenAt)
+	}
+
+	// 3. Status unchanged.
+	if afterFrame.Status != beforeFrame.Status {
+		t.Fatalf("Status changed: before=%s after=%s (applyFrameEvent's StatusIdle fallback must not run)", beforeFrame.Status, afterFrame.Status)
+	}
+
+	// 4. Broadcast must still fire — the SPA needs the projection refresh
+	// even when frame state is unchanged (e.g. delegation flag downstream).
+	msgs := drainBroadcasts(sub, 200*time.Millisecond)
+	if len(msgs) == 0 {
+		t.Fatal("no hook broadcast — detail-only PreToolUse with existing frame must broadcast existing-frame projection")
+	}
+}
+
+// 3. Detail-only PostToolUseFailure with NO existing frame must not resurrect.
+func TestHandleEvent_CCPostToolUseFailureDetailOnly_DoesNotCreateFrameWhenMissing(t *testing.T) {
+	m := delegationModuleWithRealCCProvider(t)
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	sendBody(t, m, postToolUseBody(true, "agent-X", "tool-use-Tghost"))
+
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 0 {
+		t.Fatalf("frame count = %d, want 0 (PostToolUseFailure must not create / resurrect frames; frames=%+v)", len(frames), frames)
+	}
+
+	msgs := drainBroadcasts(sub, 100*time.Millisecond)
+	if len(msgs) != 0 {
+		t.Fatalf("got %d broadcasts, want 0; msgs=%+v", len(msgs), msgs)
+	}
+}
+
+// 4. Detail-only PostToolUseFailure with existing frame must broadcast
+// WITHOUT running applyFrameEvent. We send agent_id="agent-Y" with no
+// matching ref (the seed is agent-X), so unmarkDelegatingRef hits its
+// NoOpWhenAgentIDNotFound early-return (P2-T1 case #3) and never calls
+// UpsertIfUnchanged. Any LastSeenAt change must therefore be
+// applyFrameEvent's LifecycleNone fallback — exactly what the new
+// short-circuit must prevent.
+func TestHandleEvent_CCPostToolUseFailureDetailOnly_NoMutationWhenFrameExists(t *testing.T) {
+	m := delegationModuleWithRealCCProvider(t)
+	seedCCFrameWithSubagentReal(t, m, "agent-X")
+
+	beforeFrame := findCCFrameRow(t, m)
+
+	sub := m.core.Events.AddTestSubscriber()
+	defer m.core.Events.RemoveTestSubscriber(sub)
+
+	// agent-Y has no matching ref → unmarkDelegatingRef early-returns
+	// without UpsertIfUnchanged → any LastSeenAt change must therefore be
+	// applyFrameEvent's LifecycleNone fallback (which the short-circuit
+	// must skip).
+	sendBody(t, m, postToolUseBody(true, "agent-Y", "tool-use-Tghost"))
+
+	afterFrame := findCCFrameRow(t, m)
+
+	if afterFrame.FrameID != beforeFrame.FrameID {
+		t.Fatalf("FrameID changed: before=%s after=%s", beforeFrame.FrameID, afterFrame.FrameID)
+	}
+	if afterFrame.LastSeenAt != beforeFrame.LastSeenAt {
+		t.Fatalf("LastSeenAt changed: before=%d after=%d (applyFrameEvent must not run on detail-only PostToolUseFailure)", beforeFrame.LastSeenAt, afterFrame.LastSeenAt)
+	}
+	if afterFrame.Status != beforeFrame.Status {
+		t.Fatalf("Status changed: before=%s after=%s", beforeFrame.Status, afterFrame.Status)
+	}
+
+	msgs := drainBroadcasts(sub, 200*time.Millisecond)
+	if len(msgs) == 0 {
+		t.Fatal("no hook broadcast — detail-only PostToolUseFailure with existing frame must broadcast existing-frame projection")
+	}
+}

--- a/internal/module/agent/handler_test.go
+++ b/internal/module/agent/handler_test.go
@@ -2549,3 +2549,339 @@ func TestHandleEvent_PreToolUse_NoParent_NoBroadcast(t *testing.T) {
 		t.Fatalf("currentStatus[\"work\"] = %q, want unset (no broadcast path should run)", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Phase 3 P3-T1 — Delegation flag end-to-end via handler
+// (spec §3.2 / §6.3 / plan §3 P3-T1)
+//
+// These tests exercise the full handler.go wiring of ExtractDelegationHint +
+// markDelegatingRef / unmarkDelegatingRef. Each test seeds a cc frame via
+// PdxSessionStart + PdxSubagentStart (with a fake provider that emits the
+// agent_id) so that markDelegatingRef can locate the matching SubagentRef.
+// ---------------------------------------------------------------------------
+
+// delegationModule constructs a Module wired for cc Bash delegation tests:
+// fake tmux + sessions + core, plus a fake cc provider that emits agent_id
+// on PdxSubagentStart. After this helper a SessionStart + SubagentStart pair
+// can be injected to materialise the SubagentRef.
+func delegationModule(t *testing.T) *Module {
+	t.Helper()
+	m := newTestModule(t)
+	fakeTmux := tmux.NewFakeExecutor()
+	fakeTmux.SetPaneSessionName("%5", "work")
+	m.tmux = fakeTmux
+	m.sessions = &fakeSessionProvider{sessions: []session.SessionInfo{{Code: "code-work", Name: "work"}}}
+	m.core = &core.Core{Events: core.NewEventsBroadcaster(), Tmux: fakeTmux}
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "cc",
+		derive: func(event string, raw json.RawMessage) agentpkg.DeriveResult {
+			switch event {
+			case "PdxSessionStart":
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			case "PdxSubagentStart":
+				// Pass through agent_id from raw event payload — handler turns
+				// this into the cc native SubagentRef on the frame.
+				var payload struct {
+					AgentID string `json:"agent_id"`
+				}
+				_ = json.Unmarshal(raw, &payload)
+				if payload.AgentID == "" {
+					payload.AgentID = "agent-X"
+				}
+				return agentpkg.DeriveResult{Valid: true, Detail: map[string]any{"agent_id": payload.AgentID}}
+			default:
+				return agentpkg.DeriveResult{Valid: true, Status: agentpkg.StatusIdle}
+			}
+		},
+	})
+	return m
+}
+
+// seedCCFrameWithSubagent fires SessionStart + SubagentStart to create a cc
+// frame in pane %5 with one native SubagentRef whose ID == agentID. Returns
+// after the frame is observable via ListByPane.
+func seedCCFrameWithSubagent(t *testing.T, m *Module, agentID string) {
+	t.Helper()
+	bodies := []string{
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","purdex_name":"PdxSessionStart","raw_event":{},"agent_type":"cc"}`,
+		`{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","purdex_name":"PdxSubagentStart","raw_event":{"agent_id":"` + agentID + `"},"agent_type":"cc"}`,
+	}
+	for _, body := range bodies {
+		req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		m.handleEvent(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("seed body %q: status = %d (body=%s)", body, w.Code, w.Body.String())
+		}
+	}
+}
+
+// findCCFrame returns the (only) cc frame on pane %5; fatals if missing.
+func findCCFrame(t *testing.T, m *Module) []agentpkg.SubagentRef {
+	t.Helper()
+	frames, err := m.frames.ListByPane("%5")
+	if err != nil {
+		t.Fatalf("ListByPane: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frame count = %d, want 1 (delegation tests rely on a single seeded frame)", len(frames))
+	}
+	return frames[0].Subagents
+}
+
+// findRefByID linear-scans subagents; fatals when not found.
+func findRefByID(t *testing.T, refs []agentpkg.SubagentRef, agentID string) agentpkg.SubagentRef {
+	t.Helper()
+	for _, r := range refs {
+		if r.ID == agentID {
+			return r
+		}
+	}
+	t.Fatalf("no SubagentRef with ID=%q in %+v", agentID, refs)
+	return agentpkg.SubagentRef{}
+}
+
+// containsString helper for slice membership checks in delegation tests.
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+const codexCompanionBashCommand = `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task --background "review main"`
+
+// preToolUseBody emits a cc PdxPreToolUse event for pane %5 with the given
+// command + agent_id + tool_use_id. Set agentType to "" to default to "cc".
+func preToolUseBody(agentType, command, agentID, toolUseID string) string {
+	if agentType == "" {
+		agentType = "cc"
+	}
+	raw := map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "Bash",
+		"tool_input": map[string]any{
+			"command":     command,
+			"description": "test",
+		},
+		"tool_use_id": toolUseID,
+		"agent_id":    agentID,
+		"agent_type":  "general-purpose",
+	}
+	rawJSON, _ := json.Marshal(raw)
+	return `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","purdex_name":"PdxPreToolUse","raw_event":` + string(rawJSON) + `,"agent_type":"` + agentType + `"}`
+}
+
+// postToolUseBody emits PdxPostToolUse (or PdxPostToolUseFailure when failure
+// is true) for pane %5 with the given tool_use_id + agent_id. tool_input is
+// omitted — Post events do not carry the command.
+func postToolUseBody(failure bool, agentID, toolUseID string) string {
+	purdex := "PdxPostToolUse"
+	if failure {
+		purdex = "PdxPostToolUseFailure"
+	}
+	raw := map[string]any{
+		"hook_event_name": "PostToolUse",
+		"tool_name":       "Bash",
+		"tool_response":   map[string]any{"stdout": "", "stderr": "", "exit_code": 0},
+		"tool_use_id":     toolUseID,
+		"agent_id":        agentID,
+		"agent_type":      "general-purpose",
+	}
+	rawJSON, _ := json.Marshal(raw)
+	return `{"tmux_session":"work","tmux_pane_id":"%5","sender_pid":200,"sender_start_time":"Sun Apr 20 01:30:00 2026","purdex_name":"` + purdex + `","raw_event":` + string(rawJSON) + `,"agent_type":"cc"}`
+}
+
+func sendBody(t *testing.T, m *Module, body string) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/agent/event", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	m.handleEvent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// 1. PreToolUse Bash with codex-companion command marks Delegating=true.
+func TestHandleEvent_CCPreToolUseBashCodexCompanion_MarksDelegating(t *testing.T) {
+	m := delegationModule(t)
+	seedCCFrameWithSubagent(t, m, "agent-X")
+
+	sendBody(t, m, preToolUseBody("cc", codexCompanionBashCommand, "agent-X", "tool-use-T1"))
+
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if !ref.Delegating {
+		t.Fatalf("Delegating = false, want true (ref=%+v)", ref)
+	}
+	if !containsString(ref.DelegatingToolUseIDs, "tool-use-T1") {
+		t.Fatalf("DelegatingToolUseIDs = %v, want it to contain tool-use-T1", ref.DelegatingToolUseIDs)
+	}
+}
+
+// 2. PostToolUse after a mark removes the tool_use_id and clears Delegating.
+func TestHandleEvent_CCPostToolUseBashAfterMark_UnmarksDelegating(t *testing.T) {
+	m := delegationModule(t)
+	seedCCFrameWithSubagent(t, m, "agent-X")
+	sendBody(t, m, preToolUseBody("cc", codexCompanionBashCommand, "agent-X", "tool-use-T1"))
+
+	// Pin Red visibility: confirm the mark step took effect before unmarking,
+	// otherwise this test would silently pass with no wiring at all.
+	preRef := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if !preRef.Delegating || !containsString(preRef.DelegatingToolUseIDs, "tool-use-T1") {
+		t.Fatalf("pre-unmark precondition failed: ref=%+v (mark step did not run)", preRef)
+	}
+
+	sendBody(t, m, postToolUseBody(false, "agent-X", "tool-use-T1"))
+
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if ref.Delegating {
+		t.Fatalf("Delegating = true, want false after unmark (ref=%+v)", ref)
+	}
+	if len(ref.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("DelegatingToolUseIDs = %v, want empty", ref.DelegatingToolUseIDs)
+	}
+}
+
+// 3. PostToolUseFailure after a mark also unmarks (B3 path).
+func TestHandleEvent_CCPostToolUseFailureBashAfterMark_UnmarksDelegating(t *testing.T) {
+	m := delegationModule(t)
+	seedCCFrameWithSubagent(t, m, "agent-X")
+	sendBody(t, m, preToolUseBody("cc", codexCompanionBashCommand, "agent-X", "tool-use-T1"))
+
+	// Pin Red visibility: confirm the mark step took effect (B3 unmark path
+	// only runs through PostToolUseFailure when wiring covers all three event
+	// names).
+	preRef := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if !preRef.Delegating || !containsString(preRef.DelegatingToolUseIDs, "tool-use-T1") {
+		t.Fatalf("pre-unmark precondition failed: ref=%+v (mark step did not run)", preRef)
+	}
+
+	sendBody(t, m, postToolUseBody(true, "agent-X", "tool-use-T1"))
+
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if ref.Delegating {
+		t.Fatalf("Delegating = true, want false after PostToolUseFailure unmark (ref=%+v)", ref)
+	}
+	if len(ref.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("DelegatingToolUseIDs = %v, want empty", ref.DelegatingToolUseIDs)
+	}
+}
+
+// 4. PreToolUse Bash with a non-codex command does NOT mark.
+func TestHandleEvent_CCPreToolUseBashNonCodex_NoMark(t *testing.T) {
+	m := delegationModule(t)
+	seedCCFrameWithSubagent(t, m, "agent-X")
+
+	sendBody(t, m, preToolUseBody("cc", "pnpm build", "agent-X", "tool-use-Tnoop"))
+
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if ref.Delegating {
+		t.Fatalf("Delegating = true, want false (non-codex Bash should not mark; ref=%+v)", ref)
+	}
+	if len(ref.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("DelegatingToolUseIDs = %v, want empty", ref.DelegatingToolUseIDs)
+	}
+}
+
+// 5. Top-level cc PreToolUse (agent_id=="") never marks — extractor rejects.
+func TestHandleEvent_CCPreToolUseBashTopLevelNoAgentID_NoMark(t *testing.T) {
+	m := delegationModule(t)
+	seedCCFrameWithSubagent(t, m, "agent-X")
+
+	sendBody(t, m, preToolUseBody("cc", codexCompanionBashCommand, "", "tool-use-Ttop"))
+
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if ref.Delegating {
+		t.Fatalf("Delegating = true, want false (top-level cc has no agent_id; ref=%+v)", ref)
+	}
+}
+
+// 6. Concurrent two codex-companion Bash invocations (B2 verification): both
+// tool_use_ids accumulate; unmarking one leaves the other; unmarking the
+// second clears Delegating.
+func TestHandleEvent_CCPreToolUseConcurrentTwoCodexBash_BothTracked(t *testing.T) {
+	m := delegationModule(t)
+	seedCCFrameWithSubagent(t, m, "agent-X")
+
+	sendBody(t, m, preToolUseBody("cc", codexCompanionBashCommand, "agent-X", "tool-use-A"))
+	sendBody(t, m, preToolUseBody("cc", codexCompanionBashCommand, "agent-X", "tool-use-B"))
+
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if !ref.Delegating {
+		t.Fatalf("Delegating = false, want true with two outstanding tool_use_ids (ref=%+v)", ref)
+	}
+	if !containsString(ref.DelegatingToolUseIDs, "tool-use-A") || !containsString(ref.DelegatingToolUseIDs, "tool-use-B") {
+		t.Fatalf("DelegatingToolUseIDs = %v, want both tool-use-A and tool-use-B", ref.DelegatingToolUseIDs)
+	}
+
+	// Unmark A — Delegating still true with B remaining.
+	sendBody(t, m, postToolUseBody(false, "agent-X", "tool-use-A"))
+	ref = findRefByID(t, findCCFrame(t, m), "agent-X")
+	if !ref.Delegating {
+		t.Fatalf("Delegating = false after unmarking A, want true (B still active); ref=%+v", ref)
+	}
+	if containsString(ref.DelegatingToolUseIDs, "tool-use-A") {
+		t.Fatalf("DelegatingToolUseIDs still contains tool-use-A after unmark: %v", ref.DelegatingToolUseIDs)
+	}
+	if !containsString(ref.DelegatingToolUseIDs, "tool-use-B") {
+		t.Fatalf("DelegatingToolUseIDs missing tool-use-B: %v", ref.DelegatingToolUseIDs)
+	}
+
+	// Unmark B — Delegating clears.
+	sendBody(t, m, postToolUseBody(false, "agent-X", "tool-use-B"))
+	ref = findRefByID(t, findCCFrame(t, m), "agent-X")
+	if ref.Delegating {
+		t.Fatalf("Delegating = true after both unmarks, want false (ref=%+v)", ref)
+	}
+	if len(ref.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("DelegatingToolUseIDs = %v, want empty after both unmarks", ref.DelegatingToolUseIDs)
+	}
+}
+
+// 7. F4 / AC10 — codex agent_type PreToolUse Bash with codex-companion
+// command must NOT touch the cc frame's Delegating flag. Handler-level gate
+// `req.AgentType == "cc"` is the wall.
+func TestHandleEvent_CodexAgentTypePreToolUseBashCodexCompanion_NoMark(t *testing.T) {
+	m := delegationModule(t)
+	seedCCFrameWithSubagent(t, m, "agent-X")
+	// codex provider must exist or handleEvent rejects the agent_type lookup.
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "codex",
+		derive:   func(string, json.RawMessage) agentpkg.DeriveResult { return agentpkg.DeriveResult{Valid: true} },
+	})
+
+	sendBody(t, m, preToolUseBody("codex", codexCompanionBashCommand, "agent-X", "tool-use-Tcodex"))
+
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if ref.Delegating {
+		t.Fatalf("Delegating = true, want false (codex agent_type must not flow through delegation wiring; ref=%+v)", ref)
+	}
+	if len(ref.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("DelegatingToolUseIDs = %v, want empty (codex agent_type must not mark)", ref.DelegatingToolUseIDs)
+	}
+}
+
+// 8. F4 / AC10 — opencode agent_type PreToolUse Bash with codex-companion
+// command must NOT touch the cc frame's Delegating flag.
+func TestHandleEvent_OpencodeAgentTypePreToolUseBashCodexCompanion_NoMark(t *testing.T) {
+	m := delegationModule(t)
+	seedCCFrameWithSubagent(t, m, "agent-X")
+	m.registry.Register(&fakeAgentProvider{
+		typeName: "opencode",
+		derive:   func(string, json.RawMessage) agentpkg.DeriveResult { return agentpkg.DeriveResult{Valid: true} },
+	})
+
+	sendBody(t, m, preToolUseBody("opencode", codexCompanionBashCommand, "agent-X", "tool-use-Topencode"))
+
+	ref := findRefByID(t, findCCFrame(t, m), "agent-X")
+	if ref.Delegating {
+		t.Fatalf("Delegating = true, want false (opencode agent_type must not flow through delegation wiring; ref=%+v)", ref)
+	}
+	if len(ref.DelegatingToolUseIDs) != 0 {
+		t.Fatalf("DelegatingToolUseIDs = %v, want empty (opencode agent_type must not mark)", ref.DelegatingToolUseIDs)
+	}
+}

--- a/internal/store/frames_test.go
+++ b/internal/store/frames_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -259,7 +260,9 @@ func TestFrames_UpsertAndReadSubagentRefs(t *testing.T) {
 	if len(got.Subagents) != 1 {
 		t.Fatalf("subagents len = %d, want 1", len(got.Subagents))
 	}
-	if got.Subagents[0] != want[0] {
+	// SubagentRef contains slice fields (DelegatingToolUseIDs) so == is not
+	// usable; compare via reflect.DeepEqual.
+	if !reflect.DeepEqual(got.Subagents[0], want[0]) {
 		t.Fatalf("subagents[0] = %+v, want %+v", got.Subagents[0], want[0])
 	}
 }

--- a/spa/src/components/SubagentDots.test.tsx
+++ b/spa/src/components/SubagentDots.test.tsx
@@ -11,6 +11,8 @@ function makeRef(partial: Partial<SubagentRef>): SubagentRef {
     source_pid: partial.source_pid ?? 0,
     source_start_time: partial.source_start_time ?? '',
     is_proxy: partial.is_proxy,
+    delegating: partial.delegating,
+    delegating_tool_use_ids: partial.delegating_tool_use_ids,
   }
 }
 
@@ -64,5 +66,45 @@ describe('SubagentDots', () => {
     expect(dot.getAttribute('data-is-proxy')).toBe('false')
     expect(dot.style.backgroundColor).toBe('rgb(96, 165, 250)')
     expect(dot.style.border).toBe('')
+  })
+
+  // Phase 4 (issue #821): delegating flag composes with is_proxy via OR to
+  // render orange. Both signals indicate "agent is awaiting downstream"; they
+  // coexist without interference. Spec §3.6 / §6.4.
+
+  it('delegating=true, is_proxy=false → orange + data-delegating="true"', () => {
+    const refs = [makeRef({ id: 'd1', type: 'cc', is_proxy: false, delegating: true })]
+    const { container } = render(<SubagentDots refs={refs} />)
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
+    expect(dot.style.backgroundColor).toBe('rgb(249, 115, 22)')
+    expect(dot.getAttribute('data-delegating')).toBe('true')
+    expect(dot.getAttribute('data-is-proxy')).toBe('false')
+  })
+
+  it('delegating=false, is_proxy=true → orange + data-delegating="false"', () => {
+    const refs = [makeRef({ id: 'd2', type: 'codex', is_proxy: true, delegating: false })]
+    const { container } = render(<SubagentDots refs={refs} />)
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
+    expect(dot.style.backgroundColor).toBe('rgb(249, 115, 22)')
+    expect(dot.getAttribute('data-delegating')).toBe('false')
+    expect(dot.getAttribute('data-is-proxy')).toBe('true')
+  })
+
+  it('delegating=true, is_proxy=true → orange + both attrs true (OR composition)', () => {
+    const refs = [makeRef({ id: 'd3', type: 'codex', is_proxy: true, delegating: true })]
+    const { container } = render(<SubagentDots refs={refs} />)
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
+    expect(dot.style.backgroundColor).toBe('rgb(249, 115, 22)')
+    expect(dot.getAttribute('data-delegating')).toBe('true')
+    expect(dot.getAttribute('data-is-proxy')).toBe('true')
+  })
+
+  it('delegating=false, is_proxy=false → blue + both attrs false', () => {
+    const refs = [makeRef({ id: 'd4', type: 'cc', is_proxy: false, delegating: false })]
+    const { container } = render(<SubagentDots refs={refs} />)
+    const dot = container.querySelector<HTMLElement>('[data-testid="subagent-dot"]')!
+    expect(dot.style.backgroundColor).toBe('rgb(96, 165, 250)')
+    expect(dot.getAttribute('data-delegating')).toBe('false')
+    expect(dot.getAttribute('data-is-proxy')).toBe('false')
   })
 })

--- a/spa/src/components/SubagentDots.tsx
+++ b/spa/src/components/SubagentDots.tsx
@@ -13,11 +13,16 @@ interface Props {
 // codex shelling out to cc and triggering cc's own SubagentStart hook) versus
 // a native sub-task spawned inside the agent's own tool loop. Type family is
 // already conveyed by the agent icon in the parent indicator.
+//
+// Delegating: cc native subagent inferred to be invoking codex-companion
+// via Bash sniff (spec §3.6); orthogonal to is_proxy and rendered with
+// the same orange via OR composition. Both signals indicate "agent is
+// awaiting downstream"; they coexist without interference.
 const NATIVE_COLOR = '#60a5fa'  // blue
 const PROXY_COLOR = '#f97316'   // orange
 
 const dotStyle = (ref: SubagentRef): CSSProperties => ({
-  backgroundColor: ref.is_proxy ? PROXY_COLOR : NATIVE_COLOR,
+  backgroundColor: (ref.is_proxy || ref.delegating) ? PROXY_COLOR : NATIVE_COLOR,
 })
 
 const DOT_SIZES: Record<number, number> = { 1: 4, 2: 3.5, 3: 3 }
@@ -53,6 +58,7 @@ export function SubagentDots({ refs, left: leftOverride }: Props) {
             data-testid="subagent-dot"
             data-subagent-type={ref.type}
             data-is-proxy={ref.is_proxy ? 'true' : 'false'}
+            data-delegating={ref.delegating ? 'true' : 'false'}
             className="absolute rounded-full animate-breathe"
             style={{
               width: dotSize,

--- a/spa/src/stores/useAgentStore.ts
+++ b/spa/src/stores/useAgentStore.ts
@@ -46,6 +46,8 @@ export interface SubagentRef {
   source_pid: number
   source_start_time: string
   is_proxy?: boolean
+  delegating?: boolean
+  delegating_tool_use_ids?: string[]
 }
 
 /** Normalized event from backend (replaces AgentHookEvent). */


### PR DESCRIPTION
## Summary

Solves issue #821 — when cc invokes `/codex:rescue` / `/codex:review` / `/codex:adversarial-review`, the cc tab now shows the **orange dot** (delegating) instead of the misleading **blue native dot**. Pure cc-side detection via `PreToolUse(Bash)` command sniff — no codex plugin cooperation, no `IsProxy` invariant pollution, zero dependence on governance phases.

Spec frozen at v2 + plan frozen at v3 (each via 2 rounds of codex review). Issue: #821.

### Approach

- **Identity model**: 2 omitempty fields on `SubagentRef` — `Delegating bool` + `DelegatingToolUseIDs []string`. Invariant: `Delegating == len(DelegatingToolUseIDs) > 0`.
- **Wiring**: cc PreToolUse(Bash codex-companion command) → mark; cc PostToolUse(Bash) / PostToolUseFailure(Bash) → unmark by tool_use_id. Top-level cc (no agent_id) and non-cc agent_type explicitly gated out.
- **Token detection**: `containsCodexCompanionToken` — pure function, no regex (no ReDoS).
- **Concurrency**: 2 helpers `markDelegatingRef` / `unmarkDelegatingRef` mirror `upsertProxyRefForBroker:1216-1297` with dedicated `UpsertIfUnchanged` retry loop.
- **handler placement**: separate adjacent block AFTER PathHint block, NOT nested.
- **SPA**: `dotStyle` composes `is_proxy || delegating`; new `data-delegating` attr.

### Round-1 codex review fixes (2 follow-up commits)

R1 surfaced 1 P2 finding: production cc provider returned `Valid=false` for `PdxPreToolUse` / `PdxPostToolUseFailure`, so handler.go invalid-skip branch would mutate the frame DB but never broadcast. Fake provider in tests masked this.

- `b121eb26` — `cc/status.go` adds detail-only valid cases for both events; production-shaped integration tests use real `cc.NewProvider()` to lock the broadcast path.
- `d1e51717` — `cc/events.go` removes `Handling: HookHandlingUnsupported / Ignored` so installer actually writes both hooks into `~/.claude/settings.json`. Without this, fresh installs would never fire the events. Verified via Anthropic CC hooks reference and existing user settings.json (lacks both hooks → empirically confirms installer gap).

### Phase commits

| Phase | Commit | Description |
|---|---|---|
| P1-T1 | `4cbc1ce4` | SubagentRef +Delegating/+DelegatingToolUseIDs |
| P1-T2 | `42a9e3d4` | ExtractDelegationHint pure fn + token-boundary detection |
| P2-T1 | `0077b54c` | markDelegatingRef + unmarkDelegatingRef helpers |
| P3-T1 | `5ce01174` | handler wiring for cc PreTool/PostTool/PostToolFailure |
| P4-T1 | `c7b7c4d2` | SPA dotStyle + data-delegating attr |
| R1 #1 | `b121eb26` | upgrade PdxPreToolUse + PdxPostToolUseFailure to detail-only valid |
| R1 #2 | `d1e51717` | make above events installable so cc fires them |

### Diff stats

~1719 insertions / 28 deletions across 15 files (production + tests). Spec + plan docs in base commit `a036a6b6`.

## Acceptance criteria coverage

- ✅ AC1 — `/codex:rescue` foreground
- ⏳ AC1b — background (deferred to user mlab verify)
- ✅ AC2 — `/codex:review` / `/codex:adversarial-review` foreground
- ⏳ AC2b — background (deferred)
- ✅ AC3 — 3 parallel codex jobs (capped at SubagentDots max=3)
- ✅ AC4 — non-codex Bash stays blue
- ✅ AC5 / AC5b / AC5c — PostToolUse / PostToolUseFailure / concurrent
- ✅ AC6 — SubagentStop removes ref
- ✅ AC7 — L2 turn-aware unaffected
- ✅ AC8 — native delegating + real IsProxy coexist
- ✅ AC9 — top-level cc skipped
- ✅ AC10 — non-cc agent_type gated
- ✅ AC11 — within ~1719 LOC effective cap

## Test plan

- [x] daemon `go test ./... -count=1` — 25 packages green (across all 7 commits)
- [x] `go test ./internal/module/agent/... -count=10 -race` — race-mode 10× delegation tests green
- [x] `go vet ./...` — 0 finding
- [x] SPA target tests green; SPA lint/build clean (4 unrelated pre-existing failures in TabBar / sync hosts unaffected)
- [x] Round-1 codex re-review on installer fix passing (will retrigger after this commit)
- [ ] **mlab live verify (deferred to user real-environment verification)** — see below for required user action

## ⚠️ User action required before verification

**Existing managed install (the user's mlab cc):** `~/.claude/settings.json` does NOT include `PreToolUse` / `PostToolUseFailure` hook entries (verified via `jq` on user's actual file). After this PR ships, cc must re-merge hooks for the new entries to land:

- Run `pdx install hooks` (or daemon relaunch with managed-install path), OR
- Settings → Hooks → Reinstall

Without this user action, cc will not fire the new events, the daemon won't receive PdxPreToolUse / PdxPostToolUseFailure, and the orange dot will never light up nor clear on failure.

**Fresh install:** automatically picks up the new entries on first hook merge. No manual action needed.

mlab verify steps (after reinstall):
1. `/codex:rescue --wait <task>` → orange during, blue after, dot vanishes on subagent end
2. `/codex:rescue --background` → observe lifecycle (a) flicker / (b) stays orange — drives spec §7 L6 final wording
3. `/codex:adversarial-review --background` → 3 parallel orange dots
4. cc subagent running `pnpm build` → stays blue (no false positive)

## Known limitations (spec §7)

| ID | Limitation |
|---|---|
| L1 | Token detection allows `echo "codex-companion.mjs"` false positive |
| L2 | PostToolUse fixture must carry tool_use_id (verified) |
| L3 | Codex hung but cc Bash awaits → stays orange (desired user-actionable signal) |
| L4 | Manual `codex` CLI outside companion wrapper out of scope |
| L5 | Concurrent codex Bash via slice (B2 fix) |
| L6 | Background Bash lifecycle conditional on mlab verify |
| L7 | PreToolUse-before-SubagentStart race → silent no-op by design |

## Out of scope

- Real codex-side proxy attach (Op1 protocol extension)
- Replacing governance P3 (sweep + reap)
- Detecting codex started without companion wrapper
- opencode delegation visibility
- Background Bash tracking via BashOutput polls (L6)

Issue: #821