### PR TITLE
feat(daemon): PdxStopFailure native subagent detach (rate-limit cleanup)

### DIFF
--- a/docs/specs/2026-05-03-rate-limit-subagent-cleanup-plan.md
+++ b/docs/specs/2026-05-03-rate-limit-subagent-cleanup-plan.md
@@ -1,7 +1,19 @@
 # Rate-limit subagent cleanup + notification debounce — Implementation Plan
 
-> **Status**：v1（plan 初稿，待 codex round 1 review）
+> **Status**：v2（plan-review round 1 收 3 P1 + 5 P2 + 4 fact + 2 nit；v2 全採納）
 >
+> v1 → v2 修：
+> - **P1.1 §7 test instrumentation**: `counterFrameStore` 設計不可行（`Module.frames` 是 `*store.FramesStore` concrete type，無 interface 可 wrap）。改用 `applyFrameEvent` 回傳的 `FrameTraceMeta.Reason` 直接驗證 — `Misses_NoMutation` assert `Reason ∈ {"parent_frame_found", "daemon_restart_recovery", "no_parent_fallback"}`（generic post-switch path），`Hits` assert `Reason == "native_subagent_detached_on_stop_failure"`. 完全可從單 unit test 驗證、無需 store-level fake.
+> - **P1.2 §4 P3-T2**: `shouldNotify` signature 必須加 `detail` 或 `errorString` 參數（既有 `ShouldNotifyParams` 沒帶 `detail`）。改動表更新含 caller signature 變更.
+> - **P1.3 Phase 2 backup**: `.mode insert <table>` 不可行（無對應表）。改用 `sqlite3 .backup` 整庫備份；補 restore SQL.
+> - P2: P1-T3 拆兩 commit (case-split-only / native-detach-impl) 降 review surface
+> - P2: P3-T1 + P3-T2 合併（key builder + state 沒行為，與 shouldNotify integration 同 commit 較自然）
+> - P2: P3-T2 明說 `eventName` 用 normalized（與 dispatcher 既有 normalize pattern 對齊；`PdxStopFailure` 與 `StopFailure` 共 bucket — acceptable）
+> - P2: §4 Round 2 adversarial 防守 focus 加具體 spec drift gate（PR-A diff 不 touch SPA / PR-B 不 touch daemon）
+> - P2: Phase 2 重寫 restart 行為描述（不靠 in-memory map reload，靠下次 projection 從 DB 投影）
+> - fact 採納（無修改），nit 修正 case count + `seenAtRef` 描述
+
+
 > **依賴 spec**：`docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md` v3 + follow-ups（spec round 3 codex review approve to enter plan，2 個非阻塞點已 inline 修正）
 > **Worktree**：`.claude/worktrees/rate-limit-cleanup` / branch `worktree-rate-limit-cleanup`
 > **Base**：`origin/main` @ alpha.289 (`401a785c chore: bump 1.0.0-alpha.289`)
@@ -53,7 +65,7 @@
 - **不污染 `unread`**（spec §4.5）— debounce 只走 `shouldNotify` 的 OS notification path；`useAgentStore.handleNormalizedEvent` 內的 `unread[ck]=true` 路徑零修改
 - **不擋非 error**（spec §4.5）— `shouldNotify` 內 `if (derived === 'error')` gate
 - **Key 對稱**（spec §4.4 / §4.6）— 編碼 `buildDebounceKey([ck, eventName, errorString])` 與解碼 `JSON.parse(rawKey)[0/1/2]` 共用同一 helper / 反向操作；測試 `debounce__key_uses_json_array_not_pipe_join` 鎖定
-- **State 為 module-level 不進 zustand**（spec §4.3）— 模仿既有 `seenAtRef` pattern；test 用 `__resetDebounceStateForTests()` 清狀態
+- **State 為 module-level 不進 zustand**（spec §4.3）— dispatcher-private ephemeral state，無 cross-component subscription、無持久化；test 用 `__resetDebounceStateForTests()` 清狀態
 
 ### 0.4 Subagent 切分
 
@@ -107,34 +119,46 @@
 3. 跑 `go test ./internal/module/agent/... -run TestFindNativeRefByID -v` 全綠
 4. **Commit**: `feat(daemon): add findNativeRefByID pure helper for pre-check ref presence`
 
-### P1-T3 — `applyFrameEvent` 拆 `LifecycleStopFailure` 獨立 case + native detach 邏輯
+### P1-T3a — `applyFrameEvent` 拆 `LifecycleStopFailure` 獨立 case（split-only，零行為改動）
 
-**目標**：spec §3.2 全套。把現行 `case agentpkg.LifecycleStop, agentpkg.LifecycleStopFailure:` 拆成：
-- `case agentpkg.LifecycleStopFailure:` — 新增 `frame != nil` 分支：pre-check + mutate + trace reason `native_subagent_detached_on_stop_failure`；mismatched / no agent_id → break；frame == nil → `fallthrough`
-- `case agentpkg.LifecycleStop:` — 既有 body 完整保留（從原本聯合 case 抄出來）
+**目標**：把現行 `case agentpkg.LifecycleStop, agentpkg.LifecycleStopFailure:` 拆成兩個 case，body 完全相同（從聯合 case 完整複製）。**這 commit 不引入新邏輯**，純結構手術，方便 P1-T3b 在乾淨基礎上加 native detach 邏輯。
 
 **改動**：
 
 | 檔案 | 改動 |
 |---|---|
-| `internal/module/agent/frame_ops.go` | line 288 拆 case；新 `LifecycleStopFailure` body ~50 LOC（per spec §3.2 全文）；trace reason 常數 placement: `internal/module/agent/trace.go` 或 `frame_ops.go` 內聯（檢查既有 reason 怎麼放）。原 line 288-424 body 改 placement 到新 `case LifecycleStop:` 下；fallthrough 從 LifecycleStopFailure no-frame branch 進入 |
-| `internal/module/agent/frame_ops_test.go` | + 6 case，per spec §6.1（直接表）：<br>`TestStopFailure_NativeDetach_Hits`<br>`TestStopFailure_NativeDetach_Misses_NoMutation` — 三條 assertion：(a) FrameTraceMeta.Reason ≠ `"native_subagent_detached_on_stop_failure"`; (b) trace pipeline emit legacy `UpdateHookPath` step (透過 spy on `m.frames.UpsertIfUnchanged` call counter — 0 invocation 時等同無 mutate); (c) `frame.Status` post = `error`, `LastSeenAt` 已 refresh<br>`TestStopFailure_NoAgentId_LegacyBehaviour` — payload 缺 `agent_id` field<br>`TestStopFailure_EmptyAgentId_LegacyBehaviour` — payload `agent_id: ""`<br>`TestStopFailure_PreservesProxyRefs` — frame 同時有 native + proxy；只 native 被 detach<br>`TestStopFailure_FrameNil_FallthroughToProxyDetach` — frame==nil，走原 codex turn-aware path<br>`TestStopFailure_FrameDeletedMidFlight` — pre-check pass 但 mutate 回 false (concurrent delete)；trace reason `frame_missing` |
-
-**Test Instrumentation 細節（addresses spec §6.1 codex round-3 P2）**：
-- spy/call-counter 於 `m.frames.UpsertIfUnchanged`：用 fake store wrapping production interface，於 test setup 注入；計 `UpsertIfUnchanged` 被呼叫次數
-- 測試 `Misses_NoMutation` assertion (b) 寫法：`require.Equal(t, 0, fakeStore.UpsertCallCount, "mutateSubagentsWithRetry must not run when ref absent")`
-- 既有 fakes 在 `internal/module/agent/fakes_test.go`，verify call-counter 可加上去；若沒有則 inline test fake
+| `internal/module/agent/frame_ops.go` | line 288 從聯合 case 拆成 `case agentpkg.LifecycleStopFailure:` 與 `case agentpkg.LifecycleStop:` 兩 case，body 各自一份完整副本（duplication 暫時接受 — P1-T3b 馬上會在 StopFailure 分支加新邏輯，並在 frame==nil 走 fallthrough 收回 duplication） |
+| 無 test 改動 | 既有 `frame_ops_l2_test.go` / `handler_test.go` 全套既有 test 做 regression guard |
 
 **TDD 步驟**：
-1. 寫 7 個 test case（全 Red），包含 spy fake 的 call-counter setup
-2. 拆 case 結構（先讓 `case LifecycleStop:` 與 `case LifecycleStopFailure:` 各自編譯通過、body 都 break）
-3. 加 `LifecycleStopFailure` 內的 pre-check + mutate + trace reason 邏輯（Green）
-4. 加 fallthrough（Green）
-5. 跑 `go test ./internal/module/agent/... -run TestStopFailure -v` 全綠
-6. 跑 `go test ./internal/module/agent/... -count=10 -race` race-mode 10 輪確保拆 case 沒引入 race
-7. 跑 `go test ./internal/module/agent/...` 全套確保 `frame_ops_l2_test.go` 既有 L2 test 零 regression（spec AC2）
-8. Lint + vet
-9. **Commit**: `feat(daemon): native subagent detach on PdxStopFailure (closes dthn-class accumulation)`
+1. 拆 case，body 重複
+2. 跑 `go test ./internal/module/agent/...` 全套 — 期望全綠（零行為改動）
+3. 跑 `go test ./internal/module/agent/... -count=10 -race`
+4. Lint + vet
+5. **Commit**: `refactor(daemon): split LifecycleStopFailure case from LifecycleStop (no behaviour change)`
+
+### P1-T3b — `LifecycleStopFailure` 加 native detach 邏輯 + fallthrough
+
+**目標**：spec §3.2 全套。在 P1-T3a 的乾淨基礎上：
+- `case LifecycleStopFailure:` — 新增 `frame != nil` 分支：pre-check + mutate + trace reason `native_subagent_detached_on_stop_failure`；mismatched / no agent_id → break；frame == nil → `fallthrough` 進 `LifecycleStop` body 收回 P1-T3a 的 duplication
+- `case LifecycleStop:` body 不變（已 P1-T3a 拆出）
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/frame_ops.go` | `LifecycleStopFailure` body 重寫成 spec §3.2 完整 snippet：(1) `frame != nil` 分支 pre-check via `findNativeRefByID` (Phase P1-T2 已加) (2) 命中 → `mutateSubagentsWithRetry(LifecycleSubagentStop, ref)` → 報 `Decision="updated_frame"` `Reason="native_subagent_detached_on_stop_failure"` 或 `Reason="frame_missing"`（concurrent delete） (3) 不命中 / 缺 / 空 agent_id → `break`（走 generic post-switch） (4) `frame == nil` → `fallthrough` 進 `LifecycleStop` 既有 codex/proxy detach 路徑（P1-T3a 拆出的副本被 fallthrough 收掉）|
+| `internal/module/agent/frame_ops_test.go` | + 6 case，per spec §6.1（直接表）：<br>`TestStopFailure_NativeDetach_Hits` — assert `meta.Reason == "native_subagent_detached_on_stop_failure"` + DB ref 確實被移除<br>`TestStopFailure_NativeDetach_Misses_NoMutation` — assert `meta.Reason ∈ {"parent_frame_found", "daemon_restart_recovery", "no_parent_fallback"}` + DB Status=error / LastSeenAt 已 refresh（per §7 instrumentation）<br>`TestStopFailure_NoAgentId_LegacyBehaviour` — payload 缺 `agent_id` field；同 Misses behaviour<br>`TestStopFailure_EmptyAgentId_LegacyBehaviour` — payload `agent_id: ""`；同 Misses behaviour<br>`TestStopFailure_PreservesProxyRefs` — frame 同時有 native + proxy；只 native 被 detach<br>`TestStopFailure_FrameNil_FallthroughToProxyDetach` — frame==nil，走原 codex turn-aware proxy detach；assert reason `proxy_subagent_detached_on_stop` (or family)<br>`TestStopFailure_FrameDeletedMidFlight` — pre-check pass 但 mutate 回 `applied=false`；trace reason `frame_missing` |
+
+**TDD 步驟**：
+1. 寫 7 個 test case（紅）
+2. 加 native detach 邏輯（綠）
+3. 加 fallthrough，把 P1-T3a 的副本收掉（綠）
+4. 跑 `go test ./internal/module/agent/... -run TestStopFailure -v` 全綠
+5. 跑 `go test ./internal/module/agent/... -count=10 -race` race-mode 10 輪
+6. 跑 `go test ./internal/module/agent/...` 全套確保 `frame_ops_l2_test.go` 既有 L2 test 零 regression（spec AC2）
+7. Lint + vet
+8. **Commit**: `feat(daemon): native subagent detach on PdxStopFailure (closes dthn-class accumulation)`
 
 ### P1-T4 — Fixture replay regression guard
 
@@ -168,7 +192,7 @@
 
 ## 2. Phase 1 → Phase 2 過渡：PR-A merge + dthn 現場 SQL cleanup（operational）
 
-PR-A merge 後依 spec §5 操作序：
+PR-A merge 後依 spec §5 操作序執行。**這不是 plan task**；主 session 在 PR-A merge 後手動執行。後續 Phase 3 PR-B 不依賴 cleanup 結果（PR-B 是 SPA-only）。
 
 ```bash
 # 1. 確認版本
@@ -180,15 +204,12 @@ pgrep -lf 'pdx serve'   # 只有一個 PID
 # 3. 停 daemon
 brew services stop pdx  # 或 kill <pid>
 
-# 4. 備份
+# 4. 整庫備份（PR-A merge 是不可逆 SQL UPDATE 前的最後保障）
 mkdir -p ~/.config/pdx/backups
-sqlite3 ~/.config/pdx/agent_events.db <<'EOF' > ~/.config/pdx/backups/2026-05-03-pre-cleanup.sql
-.headers on
-.mode insert agent_frames_pre_cleanup_backup
-SELECT pane_id, frame_id, agent_type, subagents_json, last_seen_at
-FROM agent_frames
-WHERE json_array_length(subagents_json) > 100;
-EOF
+TS=$(date +%Y-%m-%d-%H%M%S)
+sqlite3 ~/.config/pdx/agent_events.db ".backup '/Users/wake/.config/pdx/backups/agent_events-pre-cleanup-${TS}.db'"
+# Verify backup readable
+sqlite3 ~/.config/pdx/backups/agent_events-pre-cleanup-${TS}.db "SELECT COUNT(*) FROM agent_frames;"
 
 # 5. 檢查影響面
 sqlite3 ~/.config/pdx/agent_events.db "SELECT pane_id, agent_type, json_array_length(subagents_json) AS n_refs FROM agent_frames WHERE json_array_length(subagents_json) > 100 ORDER BY n_refs DESC;"
@@ -201,59 +222,64 @@ WHERE json_array_length(subagents_json) > 100;
 COMMIT;
 EOF
 
-# 7. 啟 daemon
+# 7. 啟 daemon — 注意：daemon restart 不會「預載」in-memory frame state；
+#    下一次 hook event / projection 查詢觸發 m.frames.ListByPane / GetByIdentity
+#    才會從 DB 投影出當前狀態。SPA 透過下一次 hook broadcast 收到清空後的 subagents。
 brew services start pdx
 
 # 8. 觀察 1 個 cc Task cycle 後再次 query 確認沒再累積
+sqlite3 ~/.config/pdx/agent_events.db "SELECT pane_id, json_array_length(subagents_json) FROM agent_frames WHERE json_array_length(subagents_json) > 0;"
 ```
 
-**不是 plan task，主 session 在 PR-A merge 後手動執行**。後續 Phase 3 PR-B 不依賴 cleanup 結果（PR-B 是 SPA-only）。
+**Restore 步驟**（若 cleanup 後出現問題需回滾）：
+
+```bash
+# 停 daemon
+brew services stop pdx
+# 整庫覆蓋（最後備份的時間戳依 step 4 實際輸出）
+cp ~/.config/pdx/backups/agent_events-pre-cleanup-2026-05-03-XXXXXX.db ~/.config/pdx/agent_events.db
+brew services start pdx
+```
+
+**WAL 檔注意**：`.backup` 已含 WAL 內容。restore 後 daemon 啟動會重建 `.db-shm` 與 `.db-wal`，無需手動處理。
 
 ---
 
 ## 3. Phase 3：PR-B SPA notification debounce（Subagent B）
 
-### P3-T1 — `buildDebounceKey` + module-level state Map + `__resetDebounceStateForTests`
+### P3-T1 — `buildDebounceKey` + state Map + `shouldNotify` 整合 sliding debounce（合併原 v1 P3-T1 + P3-T2）
 
-**目標**：spec §4.2 / §4.3 / §4.6。建立 dispatcher-private 狀態管理 + key builder。test reset helper 必要（避免 module-level Map 跨 test 污染）。
+**目標**：spec §4.1 / §4.2 / §4.3 / §4.6。建立 dispatcher-private 狀態 + key builder + sliding gate 整合到 `shouldNotify`。一個 commit — key builder + state 沒有獨立行為，與 shouldNotify integration 同 commit 較自然。
 
-**改動**：
+**Signature change**：既有 `ShouldNotifyParams`（[useNotificationDispatcher.ts:55](spa/src/hooks/useNotificationDispatcher.ts) 確認）**沒有 `detail`**，只有 `notificationSilent`。本 task 必須加新欄位 — 兩選一：
 
-| 檔案 | 改動 |
-|---|---|
-| `spa/src/hooks/useNotificationDispatcher.ts` | +25 LOC：`const ERROR_NOTIFY_WINDOW_MS = 60_000`；`const errorDebounceState = new Map<string, { silentUntil: number }>()`；`function buildDebounceKey(ck, eventName, detailError)` JSON.stringify 三元 array；`export function __resetDebounceStateForTests()`（測試專用 export，名稱以 `__` 前綴 + `ForTests` 後綴標 deliberate test seam）|
-| `spa/src/hooks/useNotificationDispatcher.test.ts` | + `describe('buildDebounceKey')`：4 case — 正常字串 / 含 `\|` 字元 / detailError undefined→empty / detailError null→empty |
+- **選項 A（推薦）**：`ShouldNotifyParams` 加 `errorString?: string`，由 caller (line 113-128) 從 `event.detail?.error` 抽出、normalize 成 string 後傳入。優點：`shouldNotify` 簽章接收 plain string、好 unit test
+- **選項 B**：傳整個 `event.detail`，`shouldNotify` 內 `String(detail?.error ?? '')`。簽章彈性但 caller 邊界較髒
 
-**TDD 步驟**：
-1. 寫 4 個 buildDebounceKey test（Red）
-2. 加 const + helper + reset export（Green）
-3. 跑 `cd spa && npx vitest run --reporter verbose useNotificationDispatcher` 全綠
-4. **Commit**: `feat(spa): debounce key builder + dispatcher state map for error notifications`
+選項 A，理由：與既有 `notificationSilent` boolean 對齊（caller 抽出後傳 plain primitive），測試 setup 簡潔。
 
-### P3-T2 — `shouldNotify` 整合 sliding debounce
-
-**目標**：spec §4.1 / §4.6。在 `shouldNotify` 既有檢查鏈尾端、`return true` 之前加 error-debounce gate。trailing-edge sliding：window 內 silentUntil 持續延長並 return false；window 過則 notify + reset。
+**Event name 用 normalized 還是 raw**：spec 說 `raw_event_name`，但 dispatcher [既有 normalize pattern](spa/src/hooks/useNotificationDispatcher.ts:65) 在 `shouldNotify` 入口先 normalize。**plan v2 決策**：用 normalized，與既有 dispatcher 行為對齊。語意：`PdxStopFailure` 與 legacy `StopFailure`（W2 transition 期間）共 debounce bucket — 可接受，因為這兩個其實是同一事件的兩個命名 phase。
 
 **改動**：
 
 | 檔案 | 改動 |
 |---|---|
-| `spa/src/hooks/useNotificationDispatcher.ts` | +20 LOC：`shouldNotify` 函式體加段（per spec §4.6 整段 snippet）；signature 不變（既有 args 已含 `derived` / `eventName` / `compositeKey` / `detail`）|
-| `spa/src/hooks/useNotificationDispatcher.test.ts` | + per spec §6.2 quantitative cases：<br>`debounce__first_error_passes`<br>`debounce__second_error_within_window_blocked_and_extends` — 用 `vi.useFakeTimers()` + `vi.setSystemTime()` 控時鐘<br>`debounce__error_after_silence_window_passes`<br>`debounce__storm_100_events_yields_one_notification`（AC5 anchor）<br>`debounce__different_keys_independent`（host / session / eventName / errorString 四個維度）<br>`debounce__key_uses_json_array_not_pipe_join`（spec key collision rebuke test）|
+| `spa/src/hooks/useNotificationDispatcher.ts` | ~50 LOC：<br>(1) `const ERROR_NOTIFY_WINDOW_MS = 60_000`<br>(2) `const errorDebounceState = new Map<string, { silentUntil: number }>()`<br>(3) `function buildDebounceKey(ck: string, eventName: string, errorString: string): string { return JSON.stringify([ck, eventName, errorString]) }`<br>(4) `export function __resetDebounceStateForTests()` 清 Map（測試專用 export，`__` + `ForTests` 命名標 deliberate test seam）<br>(5) `ShouldNotifyParams` 加 `errorString?: string`<br>(6) `useNotificationDispatcher` 主體 caller 從 `event.detail?.error` 抽 → `String(... ?? '')` → 傳入 `shouldNotify`<br>(7) `shouldNotify` 函式體加 sliding gate（per spec §4.6 snippet 但用 `errorString` 參數而非 `args.detail?.error`）|
+| `spa/src/hooks/useNotificationDispatcher.test.ts` | + per spec §6.2 全表 quantitative cases：<br>`debounce__first_error_passes`<br>`debounce__second_error_within_window_blocked_and_extends` — `vi.useFakeTimers()` + `vi.setSystemTime()` 控時鐘<br>`debounce__error_after_silence_window_passes`<br>`debounce__storm_100_events_yields_one_notification`（AC5 anchor）<br>`debounce__different_keys_independent`<br>`debounce__key_uses_json_array_not_pipe_join`（spec key collision rebuke test）<br>+ `describe('buildDebounceKey')` 4 sub-case（正常 / 含 `\|` / undefined / null）|
 
 **Test Instrumentation 細節**：
-- `vi.useFakeTimers()` + `vi.setSystemTime(Date.now() + N_ms)` 控制 `Date.now()`，避免實時 60s flake
-- 100-event storm test：迴圈內 `vi.advanceTimersByTime(600)` 模擬 1.67 Hz；assert 只有第一筆 return true
-- key collision test：`compositeKey="a|b"` + `eventName="c"` + `error="d|e"` vs 同 `JSON.stringify` 輸出，assert 不同 keys
+- `vi.useFakeTimers()` + `vi.setSystemTime()`：避實時 60s 等待 / flake
+- 100-event storm test：迴圈內 `vi.advanceTimersByTime(600)` 模擬 1.67 Hz；assert 只第一筆 `shouldNotify` return true
+- key collision test：`ck="a|b"` + `eventName="c"` + `errorString="d|e"` vs `ck="a"` + `eventName="b|c"` + `errorString="d|e"`，assert 不同 JSON output
 
 **TDD 步驟**：
-1. 寫 6 個 sliding debounce test case（Red）
-2. 改 `shouldNotify` 加 gate（Green）
-3. 跑 `cd spa && npx vitest run useNotificationDispatcher` 全綠
-4. 跑 `cd spa && npx vitest run --reporter verbose --testNamePattern="storm_100"` 確認量化 test 通過
+1. 寫 10 個 test case（含 buildDebounceKey 4 sub-case）（Red）
+2. 加 const + helper + reset export + signature change + caller wiring + shouldNotify gate（Green）
+3. 跑 `cd spa && pnpm install && npx vitest run --reporter verbose useNotificationDispatcher` 全綠
+4. 跑 `cd spa && pnpm run lint && pnpm run build` 確保 type 正確（signature change ripple 不破其他 caller）
 5. **Commit**: `feat(spa): trailing-edge sliding debounce for error notifications`
 
-### P3-T3 — Cleanup 兩 path（per-session / TTL）
+### P3-T2 — Cleanup 兩 path（per-session / TTL）
 
 **目標**：spec §4.4。`clearSession` / `removeHost` 觸發時清相關 entries；`shouldNotify` 熱路徑做 TTL self-cleanup（stale entries `silentUntil < now - 5×WINDOW_MS` 移除）。
 
@@ -276,7 +302,7 @@ brew services start pdx
 4. 跑 vitest 全綠
 5. **Commit**: `feat(spa): debounce cleanup on clearSession/removeHost + TTL self-cleanup`
 
-### P3-T4 — Unread badge / waiting / non-error 隔離測試
+### P3-T3 — Unread badge / waiting / non-error 隔離測試
 
 **目標**：spec AC6 / AC7 / §4.5 — debounce **不能** mask `unread` 寫入、不能擋 `waiting`、不能影響 hook broadcast。
 
@@ -292,7 +318,7 @@ brew services start pdx
 3. 跑 vitest
 4. **Commit**: `test(spa): debounce isolation guards (waiting / unread badge)`
 
-### P3-T5 — PR-B push + Round 1 codex review
+### P3-T4 — PR-B push + Round 1 codex review
 
 **步驟**：
 1. 跑全 SPA test sweep：`cd spa && pnpm install && npx vitest run && pnpm run lint && pnpm run build`
@@ -314,9 +340,9 @@ brew services start pdx
 
 **Round 2 三平行 adversarial review**：
 - 觸發：`/codex:adversarial-review --base main --background <focus>` 三次（攻擊/防守/體質）
-- 攻擊 focus：「race condition、null payload、time-based fake timer flake、Map memory leak、cleanup helper 反向 parse 失敗」
-- 防守 focus：「PR-A 有沒有越界做 PR-B 的事；PR-B 有沒有不該 mask 的事；spec §3 / §4 邊界是否守住；既有 invariant（IsProxy / unread boolean / lifecycle / trace pipeline）零修改」
-- 體質 focus：「frame_ops.go 拆 case 後檔案大小、test instrumentation 是否複雜化過頭、SRP、命名一致性」
+- 攻擊 focus：「race condition、null payload、time-based fake timer flake、Map memory leak、cleanup helper 反向 parse 失敗、空 agent_id / 異常 JSON 字符的 buildDebounceKey 行為、StopFailure trigger 與 SubagentStop 同 ID 同時 race 的 idempotency」
+- 防守 focus：「**diff 邊界守住**：PR-A diff 不應 touch `spa/`；PR-B diff 不應 touch `internal/` 或 `cmd/`。**Invariant 守住**：IsProxy attach/detach 路徑零修改、unread boolean 寫入路徑零修改、L2 turn-aware proxy detach 零 regression、`frame_ops_l2_test.go` 既有測試全綠、既有 trace reason 字面零碰撞、`useNotificationDispatcher` 既有 caller signature 改動 ripple 沒破其他元件。**Spec drift 守住**：spec §3 / §4 邊界、Out-of-scope §9 沒被偷渡」
+- 體質 focus：「frame_ops.go 拆 case 後檔案大小、test instrumentation 是否複雜化過頭、SRP、命名一致性、`__resetDebounceStateForTests` 是否暴露過多測試 hook、PR-A 與 PR-B 各自 LOC 是否真的在 spec AC9 cap 內」
 
 **Finding 處理**：依 `feedback_dev_process.md` — 嚴重性信心 / 關聯 / 複雜度三維表；高關聯 + 高信心 + 低複雜聯集全修；低關聯 + 中高複雜延後（gh issue）；只有 trade-off 不確定時停下找 user。
 
@@ -354,30 +380,61 @@ brew services start pdx
 
 ---
 
-## 7. Test Instrumentation Strategy（spec §6.1 codex round-3 P2）
+## 7. Test Instrumentation Strategy（spec §6.1 codex round-3 P2 + plan round-1 P1.1）
 
-**問題**：spec §6.1 `TestStopFailure_NativeDetach_Misses_NoMutation` 的 assertion (a) 「subagents bit-identical」不夠 — miss-ref 走 mutate 也會寫回相同 slice。
+**問題**：spec §6.1 `TestStopFailure_NativeDetach_Misses_NoMutation` 的 assertion 「subagents bit-identical / no-mutate-call」需要可驗證機制。原 v1 草案 `counterFrameStore` fake **不可行** — `internal/module/agent/module.go:31` 是 `frames *store.FramesStore` concrete type，沒有 `store.FrameStore` interface 可包；`fakes_test.go` 也沒有 frame-store fake 可擴展。
 
-**Plan-level decision**：用 **fake frame store with call counter**：
+**Plan v2 decision**：用 **`applyFrameEvent` 回傳的 `FrameTraceMeta.Reason` 行為差異**驗證。spec §3.2 兩 path 自然 emit 不同 trace reason：
+
+| Path | Decision | Reason | Notes |
+|---|---|---|---|
+| `Hits`（agent_id 命中 native ref） | `updated_frame` | `native_subagent_detached_on_stop_failure` | 新增 reason |
+| `Misses_NoMutation`（agent_id 不命中 / 缺 / 空） | `updated_frame` | `parent_frame_found` 或 `daemon_restart_recovery` 或 `no_parent_fallback` | 既有 reason，由 generic post-switch path 在 `frame_ops.go:771-775` 賦值 |
+| `FrameDeletedMidFlight` | `skipped` | `frame_missing` | 既有 reason |
+| `FrameNil_FallthroughToProxyDetach` | depends on proxy detach inner branch | `proxy_subagent_detached_on_stop` 或 `proxy_subagent_stop_no_match` 等 | 既有 reason，零修改 |
+
+**Test pattern**：直接呼叫 `m.applyFrameEvent(req, result, ts)` → 取回傳 `FrameTraceMeta` → assert `Reason` 值。無需 store-level wrap 或 spy；既有 `frame_ops_test.go` 已用這 pattern（多處）。
 
 ```go
-type counterFrameStore struct {
-    inner store.FrameStore
-    UpsertCallCount int
-    GetCallCount    int
+func TestStopFailure_NativeDetach_Misses_NoMutation(t *testing.T) {
+    m, _ := setupTestModule(t)  // existing helper or build inline
+    paneID, frameID := seedCCFrameWithoutNativeRef(t, m, "no-match-id")  // helpers in fakes_test.go pattern
+    req := buildPdxStopFailureRequest(paneID, "different-id")  // agent_id mismatch
+    result := agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: map[string]any{"agent_id": "different-id", "error": "rate_limit"}}
+
+    _, meta, err := m.applyFrameEvent(req, result, time.Now().UnixNano())
+    require.NoError(t, err)
+    // (a) ref-presence pre-check did NOT match → no native detach trace step:
+    require.NotEqual(t, "native_subagent_detached_on_stop_failure", meta.Reason)
+    // (b) generic post-switch path executed (legacy behaviour preserved):
+    require.Equal(t, "updated_frame", meta.Decision)
+    require.Contains(t, []string{"parent_frame_found", "daemon_restart_recovery", "no_parent_fallback"}, meta.Reason)
+    // (c) frame Status now error, LastSeenAt refreshed (verify via DB read):
+    refreshed := getFrameByID(t, m, frameID)
+    require.Equal(t, agent.StatusError, refreshed.Status)
+    require.Greater(t, refreshed.LastSeenAt, /*pre-event timestamp*/)
 }
-func (c *counterFrameStore) UpsertIfUnchanged(f store.Frame, expected int64) (bool, store.Frame, error) {
-    c.UpsertCallCount++
-    return c.inner.UpsertIfUnchanged(f, expected)
-}
-// ... GetByIdentity / ListByPane 透傳 ...
 ```
 
-於 test setup wrap production store；assertion 寫 `require.Equal(t, 0, fakeStore.UpsertCallCount, "no UpsertIfUnchanged call expected when ref absent")`。
+```go
+func TestStopFailure_NativeDetach_Hits(t *testing.T) {
+    m, _ := setupTestModule(t)
+    paneID, frameID := seedCCFrameWithNativeRef(t, m, "match-id")
+    req := buildPdxStopFailureRequest(paneID, "match-id")
+    result := agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: map[string]any{"agent_id": "match-id", "error": "rate_limit"}}
 
-**Placement**：`internal/module/agent/fakes_test.go`（既有 test fakes 集中地）— 加 `counterFrameStore` type，方便其他 test 復用 call counter pattern。
+    _, meta, err := m.applyFrameEvent(req, result, time.Now().UnixNano())
+    require.NoError(t, err)
+    require.Equal(t, "updated_frame", meta.Decision)
+    require.Equal(t, "native_subagent_detached_on_stop_failure", meta.Reason)
+    refreshed := getFrameByID(t, m, frameID)
+    require.Empty(t, refreshed.Subagents)  // ref actually removed
+}
+```
 
-**驗證**：`TestStopFailure_NativeDetach_Misses_NoMutation` 用此 fake；`TestStopFailure_NativeDetach_Hits` 反向用同 fake assert UpsertCallCount > 0（cross-validate fake 本身正確）。
+**Cross-validation**：兩 test reciprocally guarantee — `Hits` 沒 emit 新 reason 時就是 bug 在於 pre-check 過嚴；`Misses` emit 新 reason 時就是 bug 在於 pre-check 沒擋住誤判。Reason mismatch 是直接、確定的失敗信號。
+
+**Placement**：seed helpers (`seedCCFrameWithNativeRef` / `seedCCFrameWithoutNativeRef` / `getFrameByID` / `buildPdxStopFailureRequest`) 視既有 `fakes_test.go` 內容判斷 — 既有 helper 復用優先，缺則加。
 
 ---
 

--- a/docs/specs/2026-05-03-rate-limit-subagent-cleanup-plan.md
+++ b/docs/specs/2026-05-03-rate-limit-subagent-cleanup-plan.md
@@ -1,6 +1,14 @@
 # Rate-limit subagent cleanup + notification debounce — Implementation Plan
 
-> **Status**：v2（plan-review round 1 收 3 P1 + 5 P2 + 4 fact + 2 nit；v2 全採納）
+> **Status**：v3（plan-review round 2 收 1 P1 + 3 P2 + 1 nit；v3 全採納；待 round 3 final approve）
+>
+> v2 → v3 修：
+> - **P1 Phase 2 restore WAL**：restore 前必先 `rm -f .db-wal .db-shm`，避免新 `.db` 與舊 WAL 不一致；指令補進 §2 流程
+> - **P2 §7 test 命名語意過強**：`TestStopFailure_NativeDetach_Misses_NoNativeDetachTrace` → `TestStopFailure_NativeDetach_Misses_NoNativeDetachTrace`。`FrameTraceMeta.Reason` 比對證明的是「沒走 detach branch」而非嚴格「mutate 沒被 call」；前者已足以鎖住 spec §3.2 行為契約
+> - **P2 AC 表 phase/task 編號 stale**：v2 把 P3-T1+T2 合併、P3-T3→T2、T4→T3、T5→T4；AC table 對應修正（AC5→P3-T1 / AC6→P3-T3 / AC7→P3-T2 / AC8→P3-T4 / AC9→P3-T4）
+> - **nit §7 helper 名稱**：example 改用既有 helper 名稱 `newTestModule` / `seedFrame` / `seedFrameWithSubagents` / `m.frames.GetByIdentity`，避免 subagent 誤找
+
+> **Previous status**：v2（plan-review round 1 收 3 P1 + 5 P2 + 4 fact + 2 nit；v2 全採納）
 >
 > v1 → v2 修：
 > - **P1.1 §7 test instrumentation**: `counterFrameStore` 設計不可行（`Module.frames` 是 `*store.FramesStore` concrete type，無 interface 可 wrap）。改用 `applyFrameEvent` 回傳的 `FrameTraceMeta.Reason` 直接驗證 — `Misses_NoMutation` assert `Reason ∈ {"parent_frame_found", "daemon_restart_recovery", "no_parent_fallback"}`（generic post-switch path），`Hits` assert `Reason == "native_subagent_detached_on_stop_failure"`. 完全可從單 unit test 驗證、無需 store-level fake.
@@ -148,7 +156,7 @@
 | 檔案 | 改動 |
 |---|---|
 | `internal/module/agent/frame_ops.go` | `LifecycleStopFailure` body 重寫成 spec §3.2 完整 snippet：(1) `frame != nil` 分支 pre-check via `findNativeRefByID` (Phase P1-T2 已加) (2) 命中 → `mutateSubagentsWithRetry(LifecycleSubagentStop, ref)` → 報 `Decision="updated_frame"` `Reason="native_subagent_detached_on_stop_failure"` 或 `Reason="frame_missing"`（concurrent delete） (3) 不命中 / 缺 / 空 agent_id → `break`（走 generic post-switch） (4) `frame == nil` → `fallthrough` 進 `LifecycleStop` 既有 codex/proxy detach 路徑（P1-T3a 拆出的副本被 fallthrough 收掉）|
-| `internal/module/agent/frame_ops_test.go` | + 6 case，per spec §6.1（直接表）：<br>`TestStopFailure_NativeDetach_Hits` — assert `meta.Reason == "native_subagent_detached_on_stop_failure"` + DB ref 確實被移除<br>`TestStopFailure_NativeDetach_Misses_NoMutation` — assert `meta.Reason ∈ {"parent_frame_found", "daemon_restart_recovery", "no_parent_fallback"}` + DB Status=error / LastSeenAt 已 refresh（per §7 instrumentation）<br>`TestStopFailure_NoAgentId_LegacyBehaviour` — payload 缺 `agent_id` field；同 Misses behaviour<br>`TestStopFailure_EmptyAgentId_LegacyBehaviour` — payload `agent_id: ""`；同 Misses behaviour<br>`TestStopFailure_PreservesProxyRefs` — frame 同時有 native + proxy；只 native 被 detach<br>`TestStopFailure_FrameNil_FallthroughToProxyDetach` — frame==nil，走原 codex turn-aware proxy detach；assert reason `proxy_subagent_detached_on_stop` (or family)<br>`TestStopFailure_FrameDeletedMidFlight` — pre-check pass 但 mutate 回 `applied=false`；trace reason `frame_missing` |
+| `internal/module/agent/frame_ops_test.go` | + 6 case，per spec §6.1（直接表）：<br>`TestStopFailure_NativeDetach_Hits` — assert `meta.Reason == "native_subagent_detached_on_stop_failure"` + DB ref 確實被移除<br>`TestStopFailure_NativeDetach_Misses_NoNativeDetachTrace` — assert `meta.Reason ∈ {"parent_frame_found", "daemon_restart_recovery", "no_parent_fallback"}` + DB Status=error / LastSeenAt 已 refresh（per §7 instrumentation）<br>`TestStopFailure_NoAgentId_LegacyBehaviour` — payload 缺 `agent_id` field；同 Misses behaviour<br>`TestStopFailure_EmptyAgentId_LegacyBehaviour` — payload `agent_id: ""`；同 Misses behaviour<br>`TestStopFailure_PreservesProxyRefs` — frame 同時有 native + proxy；只 native 被 detach<br>`TestStopFailure_FrameNil_FallthroughToProxyDetach` — frame==nil，走原 codex turn-aware proxy detach；assert reason `proxy_subagent_detached_on_stop` (or family)<br>`TestStopFailure_FrameDeletedMidFlight` — pre-check pass 但 mutate 回 `applied=false`；trace reason `frame_missing` |
 
 **TDD 步驟**：
 1. 寫 7 個 test case（紅）
@@ -236,12 +244,18 @@ sqlite3 ~/.config/pdx/agent_events.db "SELECT pane_id, json_array_length(subagen
 ```bash
 # 停 daemon
 brew services stop pdx
+# 移除舊 WAL/SHM — 否則新 .db 與舊 WAL 不一致，啟動可能讀到 stale state
+rm -f ~/.config/pdx/agent_events.db-wal ~/.config/pdx/agent_events.db-shm
 # 整庫覆蓋（最後備份的時間戳依 step 4 實際輸出）
 cp ~/.config/pdx/backups/agent_events-pre-cleanup-2026-05-03-XXXXXX.db ~/.config/pdx/agent_events.db
+# 啟動 — daemon 第一次寫入時會重建空的 .db-wal / .db-shm
 brew services start pdx
 ```
 
-**WAL 檔注意**：`.backup` 已含 WAL 內容。restore 後 daemon 啟動會重建 `.db-shm` 與 `.db-wal`，無需手動處理。
+**WAL 檔注意**：
+- `.backup` API 產生 source DB 的一致 snapshot（含 WAL 中已提交內容），備份時 daemon 已停所以新寫入也不會發生 — `.backup` 本身正確
+- **Restore 時必須先刪舊 `.db-wal` / `.db-shm`**，因為這兩檔是 persistent state 的一部分；單獨覆蓋 `.db` 會讓新 DB 與舊 WAL 不一致，啟動讀到混合狀態（rare 但 destructive）
+- 不需要在 `.backup` 前強制 `WAL checkpoint`；`.backup` 已是正確 snapshot 路徑（見 [SQLite backup API](https://www.sqlite.org/backup.html) + [WAL doc](https://www.sqlite.org/wal.html)）
 
 ---
 
@@ -355,14 +369,14 @@ brew services start pdx
 | AC | Validated by | Phase |
 |---|---|---|
 | AC1 dthn 不再累積 | Phase 2 SQL cleanup + 1 Task cycle 觀察 + Phase 1 fixture replay test | P1-T4 + Phase 2 |
-| AC2 frame==nil 路徑零 regression | `go test ./internal/module/agent/... -run "L2|Stop"` 既有 L2 test 全綠 | P1-T3 |
-| AC3 no/empty agent_id legacy preserve | `TestStopFailure_NoAgentId_LegacyBehaviour` + `TestStopFailure_EmptyAgentId_LegacyBehaviour` | P1-T3 |
-| AC4 no phantom detach broadcast | `TestStopFailure_NativeDetach_Misses_NoMutation` 三條 assertion | P1-T3 |
-| AC5 ≥98.8% suppression | `debounce__storm_100_events_yields_one_notification` | P3-T2 |
-| AC6 unread badge unaffected | `debounce__unread_badge_unaffected` | P3-T4 |
-| AC7 cleanup 清 state | `debounce__clear_session_resets` + `debounce__remove_host_resets` | P3-T3 |
-| AC8 lint / type clean | `go vet ./...` + `pnpm run lint` + `pnpm run build` | P1-T5, P3-T5 |
-| AC9 LOC cap | PR diff `+/- LOC` ≤ 500 (PR-A) / ≤ 300 (PR-B) | P1-T5, P3-T5 |
+| AC2 frame==nil 路徑零 regression | `go test ./internal/module/agent/... -run "L2|Stop"` 既有 L2 test 全綠 | P1-T3a + P1-T3b |
+| AC3 no/empty agent_id legacy preserve | `TestStopFailure_NoAgentId_LegacyBehaviour` + `TestStopFailure_EmptyAgentId_LegacyBehaviour` | P1-T3b |
+| AC4 no phantom detach broadcast | `TestStopFailure_NativeDetach_Misses_NoNativeDetachTrace` 三條 assertion | P1-T3b |
+| AC5 ≥98.8% suppression | `debounce__storm_100_events_yields_one_notification` | P3-T1 |
+| AC6 unread badge unaffected | `debounce__unread_badge_unaffected` | P3-T3 |
+| AC7 cleanup 清 state | `debounce__clear_session_resets` + `debounce__remove_host_resets` | P3-T2 |
+| AC8 lint / type clean | `go vet ./...` + `pnpm run lint` + `pnpm run build` | P1-T5, P3-T4 |
+| AC9 LOC cap | PR diff `+/- LOC` ≤ 500 (PR-A) / ≤ 300 (PR-B) | P1-T5, P3-T4 |
 
 ---
 
@@ -382,7 +396,7 @@ brew services start pdx
 
 ## 7. Test Instrumentation Strategy（spec §6.1 codex round-3 P2 + plan round-1 P1.1）
 
-**問題**：spec §6.1 `TestStopFailure_NativeDetach_Misses_NoMutation` 的 assertion 「subagents bit-identical / no-mutate-call」需要可驗證機制。原 v1 草案 `counterFrameStore` fake **不可行** — `internal/module/agent/module.go:31` 是 `frames *store.FramesStore` concrete type，沒有 `store.FrameStore` interface 可包；`fakes_test.go` 也沒有 frame-store fake 可擴展。
+**問題**：spec §6.1 `TestStopFailure_NativeDetach_Misses_NoNativeDetachTrace` 的 assertion 「subagents bit-identical / no-mutate-call」需要可驗證機制。原 v1 草案 `counterFrameStore` fake **不可行** — `internal/module/agent/module.go:31` 是 `frames *store.FramesStore` concrete type，沒有 `store.FrameStore` interface 可包；`fakes_test.go` 也沒有 frame-store fake 可擴展。
 
 **Plan v2 decision**：用 **`applyFrameEvent` 回傳的 `FrameTraceMeta.Reason` 行為差異**驗證。spec §3.2 兩 path 自然 emit 不同 trace reason：
 
@@ -396,45 +410,59 @@ brew services start pdx
 **Test pattern**：直接呼叫 `m.applyFrameEvent(req, result, ts)` → 取回傳 `FrameTraceMeta` → assert `Reason` 值。無需 store-level wrap 或 spy；既有 `frame_ops_test.go` 已用這 pattern（多處）。
 
 ```go
-func TestStopFailure_NativeDetach_Misses_NoMutation(t *testing.T) {
-    m, _ := setupTestModule(t)  // existing helper or build inline
-    paneID, frameID := seedCCFrameWithoutNativeRef(t, m, "no-match-id")  // helpers in fakes_test.go pattern
-    req := buildPdxStopFailureRequest(paneID, "different-id")  // agent_id mismatch
-    result := agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: map[string]any{"agent_id": "different-id", "error": "rate_limit"}}
+func TestStopFailure_NativeDetach_Misses_NoNativeDetachTrace(t *testing.T) {
+    m := newTestModule(t)
+    frame := seedFrame(t, m, "cc", agent.StatusRunning)
+    // seed frame with a native ref whose ID will NOT match the StopFailure payload
+    seedFrameWithSubagents(t, m, frame, []agent.SubagentRef{{ID: "no-match-id"}})
 
-    _, meta, err := m.applyFrameEvent(req, result, time.Now().UnixNano())
+    req := buildPdxStopFailureRequest(frame.PaneID, "different-id", frame.PID, frame.ProcessStartTime)
+    result := agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: map[string]any{"agent_id": "different-id", "error": "rate_limit"}}
+    preTs := time.Now().UnixNano()
+    _, meta, err := m.applyFrameEvent(req, result, preTs)
     require.NoError(t, err)
+
     // (a) ref-presence pre-check did NOT match → no native detach trace step:
     require.NotEqual(t, "native_subagent_detached_on_stop_failure", meta.Reason)
     // (b) generic post-switch path executed (legacy behaviour preserved):
     require.Equal(t, "updated_frame", meta.Decision)
     require.Contains(t, []string{"parent_frame_found", "daemon_restart_recovery", "no_parent_fallback"}, meta.Reason)
     // (c) frame Status now error, LastSeenAt refreshed (verify via DB read):
-    refreshed := getFrameByID(t, m, frameID)
+    refreshed, err := m.frames.GetByIdentity(frame.PaneID, frame.PID, frame.ProcessStartTime)
+    require.NoError(t, err)
+    require.NotNil(t, refreshed)
     require.Equal(t, agent.StatusError, refreshed.Status)
-    require.Greater(t, refreshed.LastSeenAt, /*pre-event timestamp*/)
+    require.GreaterOrEqual(t, refreshed.LastSeenAt, preTs)
+    // ref still present (because not matched)
+    require.Len(t, refreshed.Subagents, 1)
+    require.Equal(t, "no-match-id", refreshed.Subagents[0].ID)
 }
 ```
 
 ```go
 func TestStopFailure_NativeDetach_Hits(t *testing.T) {
-    m, _ := setupTestModule(t)
-    paneID, frameID := seedCCFrameWithNativeRef(t, m, "match-id")
-    req := buildPdxStopFailureRequest(paneID, "match-id")
-    result := agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: map[string]any{"agent_id": "match-id", "error": "rate_limit"}}
+    m := newTestModule(t)
+    frame := seedFrame(t, m, "cc", agent.StatusRunning)
+    seedFrameWithSubagents(t, m, frame, []agent.SubagentRef{{ID: "match-id"}})
 
+    req := buildPdxStopFailureRequest(frame.PaneID, "match-id", frame.PID, frame.ProcessStartTime)
+    result := agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: map[string]any{"agent_id": "match-id", "error": "rate_limit"}}
     _, meta, err := m.applyFrameEvent(req, result, time.Now().UnixNano())
     require.NoError(t, err)
     require.Equal(t, "updated_frame", meta.Decision)
     require.Equal(t, "native_subagent_detached_on_stop_failure", meta.Reason)
-    refreshed := getFrameByID(t, m, frameID)
+    refreshed, err := m.frames.GetByIdentity(frame.PaneID, frame.PID, frame.ProcessStartTime)
+    require.NoError(t, err)
+    require.NotNil(t, refreshed)
     require.Empty(t, refreshed.Subagents)  // ref actually removed
 }
 ```
 
 **Cross-validation**：兩 test reciprocally guarantee — `Hits` 沒 emit 新 reason 時就是 bug 在於 pre-check 過嚴；`Misses` emit 新 reason 時就是 bug 在於 pre-check 沒擋住誤判。Reason mismatch 是直接、確定的失敗信號。
 
-**Placement**：seed helpers (`seedCCFrameWithNativeRef` / `seedCCFrameWithoutNativeRef` / `getFrameByID` / `buildPdxStopFailureRequest`) 視既有 `fakes_test.go` 內容判斷 — 既有 helper 復用優先，缺則加。
+**測試保證範圍誠實標示**：`FrameTraceMeta.Reason` 比對證明的是「沒走 detach branch」，**不嚴格**證明「`mutateSubagentsWithRetry` 沒被呼叫」（理論上 miss-ref mutate 也會寫回等價 slice + refresh LastSeenAt，但 spec §3.2 設計 break 路徑就是不 call mutate，所以行為契約已鎖住）。要進一步嚴格驗證 mutate-not-called 需要 instrumentation 級改動（`Module.frames` 抽 interface）— 本 PR 不擴大 scope。
+
+**Placement**：example 中 `newTestModule` / `seedFrame` / `seedFrameWithSubagents` 是既有 helper 名（驗於 `internal/module/agent/fakes_test.go`）；`buildPdxStopFailureRequest` 若不存在則 inline 構造 EventRequest（payload shape per spec §1.2 fixture）。實作時 subagent 應先 grep 既有 helper signature 後再 reuse / 新建。
 
 ---
 

--- a/docs/specs/2026-05-03-rate-limit-subagent-cleanup-plan.md
+++ b/docs/specs/2026-05-03-rate-limit-subagent-cleanup-plan.md
@@ -1,0 +1,406 @@
+# Rate-limit subagent cleanup + notification debounce — Implementation Plan
+
+> **Status**：v1（plan 初稿，待 codex round 1 review）
+>
+> **依賴 spec**：`docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md` v3 + follow-ups（spec round 3 codex review approve to enter plan，2 個非阻塞點已 inline 修正）
+> **Worktree**：`.claude/worktrees/rate-limit-cleanup` / branch `worktree-rate-limit-cleanup`
+> **Base**：`origin/main` @ alpha.289 (`401a785c chore: bump 1.0.0-alpha.289`)
+> **拆分**：兩 PR — PR-A daemon native detach (correctness)；PR-B SPA error notification debounce (UX policy)。每 task 獨立 commit。Phase 1 PR-A 與 Phase 3 PR-B 之間插 Phase 2 operational SQL cleanup（一次性手動，不是 task）
+
+---
+
+## 0. Plan 總覽
+
+### 0.1 範圍重申（per spec §1 / §3 / §4）
+
+兩 PR 解 dthn-class symptom（cc 主 frame `subagents_json` 累積到 3944 native refs，配合 rate-limit 風暴每 1.5 Hz 桌面 notification 騷擾）：
+
+**PR-A daemon correctness**（spec §3）：
+- #1：cc / codex / opencode 三家 `PdxStopFailure` derive 加帶 `agent_id`（`raw["agent_id"]` → `Detail["agent_id"]`，nil-safe）
+- #2：新 helper `findNativeRefByID(refs, id) int` — 純讀，pre-check 「frame.Subagents 是否含此 native ID」
+- #3：`applyFrameEvent` switch 把 `LifecycleStopFailure` 從 `LifecycleStop` 共用 case 拆成獨立 case，frame != nil + agent_id 命中時走 `mutateSubagentsWithRetry(LifecycleSubagentStop, ref)`；agent_id 缺失或不命中 → break；frame == nil → fallthrough to `LifecycleStop` 既有 codex/proxy 路徑
+- #4：新 trace reason `native_subagent_detached_on_stop_failure`；既有 `frame_missing` reuse for concurrent SessionEnd race
+
+**PR-B SPA UX**（spec §4）：
+- #5：`useNotificationDispatcher.ts` 新 module-level Map + `buildDebounceKey([ck, eventName, errorString])` JSON.stringify
+- #6：`shouldNotify` 對 `derived === 'error'` 走 trailing-edge sliding debounce，windowMs=60_000；新事件 within window → `silentUntil = now + WINDOW_MS` 延長 + return false；window 過 → notify + reset
+- #7：cleanup 兩 path：`clearSession` / `removeHost` 用 JSON.parse decode 第一元素比對；TTL self-cleanup `silentUntil < now - 5×WINDOW_MS`
+
+**Out-of-scope reaffirm**（spec §9）：
+- 不擋 `derived='waiting'` notification
+- 不擋 `unread` badge
+- 不動 daemon broadcast suppression
+- 不為 native ref 加 `last_seen_at` schema migration（一次性 SQL cleanup 已足）
+- 不擴 opencode plugin payload 加 `agent_id`（plugin template change，另案）
+
+### 0.2 估計
+
+- **PR-A**：production ~80 LOC（cc/codex/opencode derive +6 / findNativeRefByID +12 / handler switch +50 / trace const +1）+ test ~360 LOC = ~440 LOC，遠低於 spec AC9 的 500 LOC cap
+- **PR-B**：production ~70 LOC（dispatcher state +20 / buildDebounceKey +5 / shouldNotify +20 / cleanup hooks +25）+ test ~190 LOC = ~260 LOC，低於 spec AC9 的 300 LOC cap
+- **時間**：PR-A subagent TDD ~3 hr / 兩輪 codex review ~2 hr / mlab live verify ~30 min；PR-B subagent TDD ~2 hr / 兩輪 codex review ~1.5 hr。總 ~9 hr active work，跨 1-2 個 session
+
+### 0.3 鎖序與不變式（per spec §3 / §4）
+
+**PR-A**：
+- **`mutateSubagentsWithRetry.applied=true` 不代表 ref 移除**（spec §2.3）— pre-check `findNativeRefByID >= 0` 後才呼叫 mutate；mutate 回 `applied=false` 是 race（concurrent SessionEnd），trace reason `frame_missing`
+- **空 agent_id 走 break legacy path**（spec §3.2 / §6.1）— `findNativeRefByID("")` early return -1，與「agent_id 不命中」同 path（preserves v0 status update + LastSeenAt refresh + broadcast）
+- **Native match by ID alone**（spec §2.4）— `subagentRefMatches` 比對 native ref 只看 ID；`Type: frame.AgentType` 是 informational，不影響 match
+- **frame == nil 路徑零修改**（spec §3.2）— fallthrough 進 `LifecycleStop` body 後第一行 `if frame != nil { break }` 永不觸發（因為 fallthrough 條件就是 frame == nil），既有 codex turn-aware proxy detach + cc/opencode wildcard process-level detach 完全保留
+- **`LifecycleStop` 路徑零修改**：當 `LifecycleStop` 直接命中 case body（未從 StopFailure fallthrough）— 因為 spec §3.2 只在 `case LifecycleStopFailure` 加新分支，`case LifecycleStop` 直接 fall through 進 body 用既有邏輯。Go switch 沒 implicit fallthrough，每個 case 是 self-contained body
+- **trace reason 不重命名**：spec §3.5 — `native_subagent_detached_on_stop_failure` 是新；`frame_missing` 是 reuse；其他既有 reason 字面零碰撞
+
+**PR-B**：
+- **不污染 `unread`**（spec §4.5）— debounce 只走 `shouldNotify` 的 OS notification path；`useAgentStore.handleNormalizedEvent` 內的 `unread[ck]=true` 路徑零修改
+- **不擋非 error**（spec §4.5）— `shouldNotify` 內 `if (derived === 'error')` gate
+- **Key 對稱**（spec §4.4 / §4.6）— 編碼 `buildDebounceKey([ck, eventName, errorString])` 與解碼 `JSON.parse(rawKey)[0/1/2]` 共用同一 helper / 反向操作；測試 `debounce__key_uses_json_array_not_pipe_join` 鎖定
+- **State 為 module-level 不進 zustand**（spec §4.3）— 模仿既有 `seenAtRef` pattern；test 用 `__resetDebounceStateForTests()` 清狀態
+
+### 0.4 Subagent 切分
+
+| Phase | Owner | Files | 並行性 |
+|---|---|---|---|
+| Phase 1 PR-A | Subagent A | `internal/agent/{cc,codex,opencode}/status.go` + `internal/module/agent/frame_ops.go` + `internal/module/agent/handler_test.go` | 序列（同 daemon code，避 file 寫衝突） |
+| Phase 2 dthn cleanup | 主 session（手動） | DB SQL only | 在 PR-A merge 後 |
+| Phase 3 PR-B | Subagent B | `spa/src/hooks/useNotificationDispatcher.ts` + `spa/src/hooks/useNotificationDispatcher.test.ts` | 與 Phase 1 互不衝突；可並行；spec § 11 建議序列降風險 |
+
+每 task **獨立 commit**，PR 不 squash 在單一 commit（用 GitHub squash-merge 收尾）。
+
+---
+
+## 1. Phase 1：PR-A daemon native detach（Subagent A）
+
+### P1-T1 — 三家 provider derive 加 `agent_id` 進 Detail
+
+**目標**：`internal/agent/cc/status.go:83`、`internal/agent/codex/status.go:67`、`internal/agent/opencode/status.go:27` 三處 `PdxStopFailure` case 在 Detail map 加 `"agent_id": raw["agent_id"]`。nil-safe（`raw["agent_id"]` 缺鍵回 nil）。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/agent/cc/status.go` | line 87-90 Detail map 加 `"agent_id": raw["agent_id"]` |
+| `internal/agent/codex/status.go` | line 67 PdxStopFailure case 同樣加 |
+| `internal/agent/opencode/status.go` | line 27 PdxStopFailure case 同樣加 |
+| `internal/agent/cc/status_test.go` | + `TestDeriveCC_PdxStopFailure_AgentIdInDetail`：raw `{"agent_id":"x","error":"rate_limit"}` → `Detail["agent_id"]=="x"`；raw 無 agent_id → `Detail["agent_id"]==nil` |
+| `internal/agent/codex/status_test.go` | + 同上 codex 版（fixture 用 `parseRawJSON` helper if exists, else inline `json.RawMessage`） |
+| `internal/agent/opencode/status_test.go` | + 同上 opencode 版 |
+
+**TDD 步驟**：
+1. 寫 6 個 derive test case (3 provider × 2 case: with / without agent_id)（全 Red）
+2. 三檔 derive 加 `"agent_id": raw["agent_id"]`（Green）
+3. 跑 `go test ./internal/agent/... -run "TestDerive.*StopFailure" -v` 全綠
+4. **Commit**: `feat(daemon): cc/codex/opencode derive surface agent_id in PdxStopFailure detail`
+
+### P1-T2 — `findNativeRefByID` 純函式 helper + 測試
+
+**目標**：`internal/module/agent/frame_ops.go` 加新 helper，placement adjacent to existing `findProxyRefByBroker:947`。Pure read, no side effects.
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/frame_ops.go` | +12 LOC：`findNativeRefByID(refs []agentpkg.SubagentRef, id string) int` — `id == ""` early return -1；linear scan 比 `!r.IsProxy && r.ID == id`；首中 return index；無中 return -1。Placement: 緊接 `findProxyRefByBroker:947` 之後。Doc comment 引 spec §2.3 解釋為何不能用 `mutateSubagentsWithRetry` 的「空 mutation」當證據 |
+| `internal/module/agent/frame_ops_test.go` | + 4 case：<br>`TestFindNativeRefByID_HitsNativeRef` — `[{ID:"x", IsProxy:false}]` + id="x" → 0<br>`TestFindNativeRefByID_SkipsProxyRefWithSameID` — `[{ID:"x", IsProxy:true}]` + id="x" → -1<br>`TestFindNativeRefByID_EmptyIdReturnsNotFound` — id="" → -1（任何 refs）<br>`TestFindNativeRefByID_NotFoundReturnsNegativeOne` — `[{ID:"y"}]` + id="x" → -1 |
+
+**TDD 步驟**：
+1. 寫 4 個 test case（全 Red）
+2. 加 helper 實作（Green）
+3. 跑 `go test ./internal/module/agent/... -run TestFindNativeRefByID -v` 全綠
+4. **Commit**: `feat(daemon): add findNativeRefByID pure helper for pre-check ref presence`
+
+### P1-T3 — `applyFrameEvent` 拆 `LifecycleStopFailure` 獨立 case + native detach 邏輯
+
+**目標**：spec §3.2 全套。把現行 `case agentpkg.LifecycleStop, agentpkg.LifecycleStopFailure:` 拆成：
+- `case agentpkg.LifecycleStopFailure:` — 新增 `frame != nil` 分支：pre-check + mutate + trace reason `native_subagent_detached_on_stop_failure`；mismatched / no agent_id → break；frame == nil → `fallthrough`
+- `case agentpkg.LifecycleStop:` — 既有 body 完整保留（從原本聯合 case 抄出來）
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/frame_ops.go` | line 288 拆 case；新 `LifecycleStopFailure` body ~50 LOC（per spec §3.2 全文）；trace reason 常數 placement: `internal/module/agent/trace.go` 或 `frame_ops.go` 內聯（檢查既有 reason 怎麼放）。原 line 288-424 body 改 placement 到新 `case LifecycleStop:` 下；fallthrough 從 LifecycleStopFailure no-frame branch 進入 |
+| `internal/module/agent/frame_ops_test.go` | + 6 case，per spec §6.1（直接表）：<br>`TestStopFailure_NativeDetach_Hits`<br>`TestStopFailure_NativeDetach_Misses_NoMutation` — 三條 assertion：(a) FrameTraceMeta.Reason ≠ `"native_subagent_detached_on_stop_failure"`; (b) trace pipeline emit legacy `UpdateHookPath` step (透過 spy on `m.frames.UpsertIfUnchanged` call counter — 0 invocation 時等同無 mutate); (c) `frame.Status` post = `error`, `LastSeenAt` 已 refresh<br>`TestStopFailure_NoAgentId_LegacyBehaviour` — payload 缺 `agent_id` field<br>`TestStopFailure_EmptyAgentId_LegacyBehaviour` — payload `agent_id: ""`<br>`TestStopFailure_PreservesProxyRefs` — frame 同時有 native + proxy；只 native 被 detach<br>`TestStopFailure_FrameNil_FallthroughToProxyDetach` — frame==nil，走原 codex turn-aware path<br>`TestStopFailure_FrameDeletedMidFlight` — pre-check pass 但 mutate 回 false (concurrent delete)；trace reason `frame_missing` |
+
+**Test Instrumentation 細節（addresses spec §6.1 codex round-3 P2）**：
+- spy/call-counter 於 `m.frames.UpsertIfUnchanged`：用 fake store wrapping production interface，於 test setup 注入；計 `UpsertIfUnchanged` 被呼叫次數
+- 測試 `Misses_NoMutation` assertion (b) 寫法：`require.Equal(t, 0, fakeStore.UpsertCallCount, "mutateSubagentsWithRetry must not run when ref absent")`
+- 既有 fakes 在 `internal/module/agent/fakes_test.go`，verify call-counter 可加上去；若沒有則 inline test fake
+
+**TDD 步驟**：
+1. 寫 7 個 test case（全 Red），包含 spy fake 的 call-counter setup
+2. 拆 case 結構（先讓 `case LifecycleStop:` 與 `case LifecycleStopFailure:` 各自編譯通過、body 都 break）
+3. 加 `LifecycleStopFailure` 內的 pre-check + mutate + trace reason 邏輯（Green）
+4. 加 fallthrough（Green）
+5. 跑 `go test ./internal/module/agent/... -run TestStopFailure -v` 全綠
+6. 跑 `go test ./internal/module/agent/... -count=10 -race` race-mode 10 輪確保拆 case 沒引入 race
+7. 跑 `go test ./internal/module/agent/...` 全套確保 `frame_ops_l2_test.go` 既有 L2 test 零 regression（spec AC2）
+8. Lint + vet
+9. **Commit**: `feat(daemon): native subagent detach on PdxStopFailure (closes dthn-class accumulation)`
+
+### P1-T4 — Fixture replay regression guard
+
+**目標**：spec §6.1 `TestStopFailure_FixtureReplay_DthnPayload` — 把真實 dthn payload 存進 fixture，replay 確認 detach。R1 risk mitigation：版本相依 regression guard，cc 上游 payload shape drift 時 CI 抓得到。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `internal/module/agent/testdata/dthn_stopfailure_2026_05_03.json`（新檔） | 從 dthn `agent_trace_steps` 抄一個真實 PdxStopFailure trigger payload（chain `c02151f0...` 或同等代表性樣本），sanitize 掉 cwd 等 environment-specific 欄位但保留 schema |
+| `internal/module/agent/frame_ops_test.go` | + `TestStopFailure_FixtureReplay_DthnPayload` — load fixture, 構 frame with seeded native ref `{ID: <fixture's agent_id>, IsProxy: false}`, replay; assert ref removed + trace reason `native_subagent_detached_on_stop_failure` |
+
+**TDD 步驟**：
+1. 從 dthn DB 抽一個 representative chain 的 trigger payload；存 testdata
+2. 寫 fixture replay test（Red）
+3. 因為 P1-T3 實作完，應直接 Green（這 test 是 regression guard，不驅動實作）
+4. 跑 `go test ./internal/module/agent/... -run TestStopFailure_FixtureReplay -v`
+5. **Commit**: `test(daemon): fixture replay regression guard for dthn PdxStopFailure shape`
+
+### P1-T5 — PR-A push + Round 1 codex review
+
+**步驟**：
+1. 跑全 daemon test sweep：`go test ./... -count=1` + `go test ./internal/module/agent/... -count=10 -race` + `go vet ./...`
+2. Push branch
+3. `gh pr create` — title `feat(daemon): PdxStopFailure native subagent detach (rate-limit cleanup)`；body 引 spec / dthn data / trace reason / risk mitigation / AC checklist
+4. **委派 codex round 1 standard review**: `/codex:review --base main --background`，focus 含「StopFailure case 拆分後 fallthrough 行為、findNativeRefByID 與既有 helper 一致性、test instrumentation 是否真的擋得住 phantom broadcast」
+5. 收 finding 表 → 處理（高關聯/高信心/低複雜全修；其他開 issue）
+6. 押進 Round 2 三平行 adversarial：攻擊（race/邊界/誤判）+ 防守（spec drift / native detach 是否擴張過頭）+ 體質（檔案大小 / 拆 case 後可讀性）
+
+---
+
+## 2. Phase 1 → Phase 2 過渡：PR-A merge + dthn 現場 SQL cleanup（operational）
+
+PR-A merge 後依 spec §5 操作序：
+
+```bash
+# 1. 確認版本
+pdx --version  # 應 ≥ 下一個 alpha
+
+# 2. 確認沒有第二個 daemon 在跑
+pgrep -lf 'pdx serve'   # 只有一個 PID
+
+# 3. 停 daemon
+brew services stop pdx  # 或 kill <pid>
+
+# 4. 備份
+mkdir -p ~/.config/pdx/backups
+sqlite3 ~/.config/pdx/agent_events.db <<'EOF' > ~/.config/pdx/backups/2026-05-03-pre-cleanup.sql
+.headers on
+.mode insert agent_frames_pre_cleanup_backup
+SELECT pane_id, frame_id, agent_type, subagents_json, last_seen_at
+FROM agent_frames
+WHERE json_array_length(subagents_json) > 100;
+EOF
+
+# 5. 檢查影響面
+sqlite3 ~/.config/pdx/agent_events.db "SELECT pane_id, agent_type, json_array_length(subagents_json) AS n_refs FROM agent_frames WHERE json_array_length(subagents_json) > 100 ORDER BY n_refs DESC;"
+
+# 6. Cleanup（transaction）
+sqlite3 ~/.config/pdx/agent_events.db <<'EOF'
+BEGIN;
+UPDATE agent_frames SET subagents_json='[]'
+WHERE json_array_length(subagents_json) > 100;
+COMMIT;
+EOF
+
+# 7. 啟 daemon
+brew services start pdx
+
+# 8. 觀察 1 個 cc Task cycle 後再次 query 確認沒再累積
+```
+
+**不是 plan task，主 session 在 PR-A merge 後手動執行**。後續 Phase 3 PR-B 不依賴 cleanup 結果（PR-B 是 SPA-only）。
+
+---
+
+## 3. Phase 3：PR-B SPA notification debounce（Subagent B）
+
+### P3-T1 — `buildDebounceKey` + module-level state Map + `__resetDebounceStateForTests`
+
+**目標**：spec §4.2 / §4.3 / §4.6。建立 dispatcher-private 狀態管理 + key builder。test reset helper 必要（避免 module-level Map 跨 test 污染）。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `spa/src/hooks/useNotificationDispatcher.ts` | +25 LOC：`const ERROR_NOTIFY_WINDOW_MS = 60_000`；`const errorDebounceState = new Map<string, { silentUntil: number }>()`；`function buildDebounceKey(ck, eventName, detailError)` JSON.stringify 三元 array；`export function __resetDebounceStateForTests()`（測試專用 export，名稱以 `__` 前綴 + `ForTests` 後綴標 deliberate test seam）|
+| `spa/src/hooks/useNotificationDispatcher.test.ts` | + `describe('buildDebounceKey')`：4 case — 正常字串 / 含 `\|` 字元 / detailError undefined→empty / detailError null→empty |
+
+**TDD 步驟**：
+1. 寫 4 個 buildDebounceKey test（Red）
+2. 加 const + helper + reset export（Green）
+3. 跑 `cd spa && npx vitest run --reporter verbose useNotificationDispatcher` 全綠
+4. **Commit**: `feat(spa): debounce key builder + dispatcher state map for error notifications`
+
+### P3-T2 — `shouldNotify` 整合 sliding debounce
+
+**目標**：spec §4.1 / §4.6。在 `shouldNotify` 既有檢查鏈尾端、`return true` 之前加 error-debounce gate。trailing-edge sliding：window 內 silentUntil 持續延長並 return false；window 過則 notify + reset。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `spa/src/hooks/useNotificationDispatcher.ts` | +20 LOC：`shouldNotify` 函式體加段（per spec §4.6 整段 snippet）；signature 不變（既有 args 已含 `derived` / `eventName` / `compositeKey` / `detail`）|
+| `spa/src/hooks/useNotificationDispatcher.test.ts` | + per spec §6.2 quantitative cases：<br>`debounce__first_error_passes`<br>`debounce__second_error_within_window_blocked_and_extends` — 用 `vi.useFakeTimers()` + `vi.setSystemTime()` 控時鐘<br>`debounce__error_after_silence_window_passes`<br>`debounce__storm_100_events_yields_one_notification`（AC5 anchor）<br>`debounce__different_keys_independent`（host / session / eventName / errorString 四個維度）<br>`debounce__key_uses_json_array_not_pipe_join`（spec key collision rebuke test）|
+
+**Test Instrumentation 細節**：
+- `vi.useFakeTimers()` + `vi.setSystemTime(Date.now() + N_ms)` 控制 `Date.now()`，避免實時 60s flake
+- 100-event storm test：迴圈內 `vi.advanceTimersByTime(600)` 模擬 1.67 Hz；assert 只有第一筆 return true
+- key collision test：`compositeKey="a|b"` + `eventName="c"` + `error="d|e"` vs 同 `JSON.stringify` 輸出，assert 不同 keys
+
+**TDD 步驟**：
+1. 寫 6 個 sliding debounce test case（Red）
+2. 改 `shouldNotify` 加 gate（Green）
+3. 跑 `cd spa && npx vitest run useNotificationDispatcher` 全綠
+4. 跑 `cd spa && npx vitest run --reporter verbose --testNamePattern="storm_100"` 確認量化 test 通過
+5. **Commit**: `feat(spa): trailing-edge sliding debounce for error notifications`
+
+### P3-T3 — Cleanup 兩 path（per-session / TTL）
+
+**目標**：spec §4.4。`clearSession` / `removeHost` 觸發時清相關 entries；`shouldNotify` 熱路徑做 TTL self-cleanup（stale entries `silentUntil < now - 5×WINDOW_MS` 移除）。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `spa/src/hooks/useNotificationDispatcher.ts` | +25 LOC：`function purgeDebounceForCompositeKey(ck: string)` 與 `function purgeDebounceForHost(hostId: string)` — 用 `JSON.parse(rawKey)[0]` 反解第一元素比對；註冊到 useAgentStore 的 `clearSession` / `removeHost` actions（既有 store 在 `useAgentStore.ts:102` / `:196`）。TTL self-cleanup 在 `shouldNotify` 內：第一次進 error gate 時順手 sweep 過期 keys |
+| `spa/src/hooks/useNotificationDispatcher.test.ts` | + 3 case：<br>`debounce__clear_session_resets`<br>`debounce__remove_host_resets`<br>`debounce__ttl_cleanup`（fake timer 推進 5×WINDOW_MS 後檢查 Map.size 縮減） |
+| `spa/src/stores/useAgentStore.ts` | （若必要）on `clearSession` / `removeHost` action 內呼叫 dispatcher 的 purge helper — **但盡量不從 store 反向依賴 dispatcher**；改成 dispatcher 內訂閱 store changes 較乾淨。具體實作走訂閱模式 vs reverse import 由 plan-review 決定（plan 默認訂閱模式） |
+
+**Test Instrumentation 細節**：
+- 訂閱模式：`useEffect`-like 在 dispatcher 初始化時 `useAgentStore.subscribe((state, prevState) => { /* diff sessions/hosts → purge */ })`
+- TTL：`shouldNotify` error gate 開頭加 `for (const [k, v] of errorDebounceState) if (v.silentUntil < now - 5 * WINDOW_MS) errorDebounceState.delete(k)`；amortised cost 可接受（Map 規模封頂於 active sessions × event types）
+
+**TDD 步驟**：
+1. 寫 3 個 cleanup test case（Red）
+2. 加 purge helpers（Green） + dispatcher subscribe wiring
+3. 加 TTL self-cleanup（Green）
+4. 跑 vitest 全綠
+5. **Commit**: `feat(spa): debounce cleanup on clearSession/removeHost + TTL self-cleanup`
+
+### P3-T4 — Unread badge / waiting / non-error 隔離測試
+
+**目標**：spec AC6 / AC7 / §4.5 — debounce **不能** mask `unread` 寫入、不能擋 `waiting`、不能影響 hook broadcast。
+
+**改動**：
+
+| 檔案 | 改動 |
+|---|---|
+| `spa/src/hooks/useNotificationDispatcher.test.ts` | + 2 case：<br>`debounce__waiting_not_debounced` — 同 session 連 5 次 `derived='waiting'` 都 return true<br>`debounce__unread_badge_unaffected` — error 被 debounce 後 `useAgentStore.unread[ck]` 仍 true（assertion 不在 dispatcher，是檢查 store；測試需 inject 經 `handleNormalizedEvent` 路徑） |
+
+**TDD 步驟**：
+1. 寫 2 個 case（Red）
+2. （應該無實作改動 — 既有設計已隔離）（Green 直接）
+3. 跑 vitest
+4. **Commit**: `test(spa): debounce isolation guards (waiting / unread badge)`
+
+### P3-T5 — PR-B push + Round 1 codex review
+
+**步驟**：
+1. 跑全 SPA test sweep：`cd spa && pnpm install && npx vitest run && pnpm run lint && pnpm run build`
+2. Push branch
+3. `gh pr create` — title `feat(spa): trailing-edge sliding debounce for error notifications`；body 引 spec / windowMs rationale / AC checklist
+4. **委派 codex round 1 standard review**: `/codex:review --base main --background`，focus 「sliding 語意 vs 直覺、key collision、cleanup 訂閱模式 vs reverse import、fake timer 是否真避免 flake」
+5. 收 finding → 處理
+6. 押 Round 2 adversarial：攻擊（key edge case / race / TTL 漏網之魚）+ 防守（debounce 是否該擋 unread / 是否該擋 waiting / 設計與 spec drift）+ 體質（dispatcher.ts 是否 SRP）
+
+---
+
+## 4. PR-A / PR-B Review 流程（共用）
+
+兩 PR 各自走兩輪 codex review（per CLAUDE.md）。
+
+**Round 1 standard review**：
+- 觸發：`/codex:review --base main --background`
+- focus：跨模型差異化 — go race、type 一致性、JSON marshal 邊界、test 是否覆蓋實作所有 branch、spec drift 檢查
+
+**Round 2 三平行 adversarial review**：
+- 觸發：`/codex:adversarial-review --base main --background <focus>` 三次（攻擊/防守/體質）
+- 攻擊 focus：「race condition、null payload、time-based fake timer flake、Map memory leak、cleanup helper 反向 parse 失敗」
+- 防守 focus：「PR-A 有沒有越界做 PR-B 的事；PR-B 有沒有不該 mask 的事；spec §3 / §4 邊界是否守住；既有 invariant（IsProxy / unread boolean / lifecycle / trace pipeline）零修改」
+- 體質 focus：「frame_ops.go 拆 case 後檔案大小、test instrumentation 是否複雜化過頭、SRP、命名一致性」
+
+**Finding 處理**：依 `feedback_dev_process.md` — 嚴重性信心 / 關聯 / 複雜度三維表；高關聯 + 高信心 + 低複雜聯集全修；低關聯 + 中高複雜延後（gh issue）；只有 trade-off 不確定時停下找 user。
+
+**Convergence 規範**（per `feedback_codex_review_termination.md`）：no critical / P1 + known issue 已 follow-up issue 即可 ship。
+
+---
+
+## 5. Acceptance gates（map to spec §7）
+
+| AC | Validated by | Phase |
+|---|---|---|
+| AC1 dthn 不再累積 | Phase 2 SQL cleanup + 1 Task cycle 觀察 + Phase 1 fixture replay test | P1-T4 + Phase 2 |
+| AC2 frame==nil 路徑零 regression | `go test ./internal/module/agent/... -run "L2|Stop"` 既有 L2 test 全綠 | P1-T3 |
+| AC3 no/empty agent_id legacy preserve | `TestStopFailure_NoAgentId_LegacyBehaviour` + `TestStopFailure_EmptyAgentId_LegacyBehaviour` | P1-T3 |
+| AC4 no phantom detach broadcast | `TestStopFailure_NativeDetach_Misses_NoMutation` 三條 assertion | P1-T3 |
+| AC5 ≥98.8% suppression | `debounce__storm_100_events_yields_one_notification` | P3-T2 |
+| AC6 unread badge unaffected | `debounce__unread_badge_unaffected` | P3-T4 |
+| AC7 cleanup 清 state | `debounce__clear_session_resets` + `debounce__remove_host_resets` | P3-T3 |
+| AC8 lint / type clean | `go vet ./...` + `pnpm run lint` + `pnpm run build` | P1-T5, P3-T5 |
+| AC9 LOC cap | PR diff `+/- LOC` ≤ 500 (PR-A) / ≤ 300 (PR-B) | P1-T5, P3-T5 |
+
+---
+
+## 6. Risk register（map to spec §8）+ plan-level mitigation
+
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 cc payload shape drift | `TestStopFailure_FixtureReplay_DthnPayload`（P1-T4）+ Round 2 adversarial 攻擊 focus 含「fixture replay 用真實 cc 9.x payload，未來 cc 10.x 改 schema 該 test 會失敗即時告警」 | P1-T4 |
+| R2 false-positive native detach | pre-check 已封；Round 2 adversarial 攻擊 focus 包含「兩 subagent 同 ID」邊界 | P1-T3 |
+| R3 60s window 漏 second wave storm | spec 已接受；PR-B `__resetDebounceStateForTests` + ttl_cleanup test 確保不致永久 mask | P3-T3 |
+| R4 module Map memory leak | TTL test + cleanup test 雙覆蓋 | P3-T3 |
+| R5 同 frame agent_id 碰撞 | cc 上游 invariant；不在我們 scope；spec §8 R5 |  |
+| R6 daemon restart projection replay 大 frame 慢 | Phase 2 SQL cleanup 是 expected primary path；PR-A 阻止 re-accumulate；長期看是否需 schema-level GC 視 issue tracker | Phase 2 + 後續 issue |
+| R7 opencode emission 不 emit agent_id | spec §2.2 / §9 已接受 no-op；derive change 仍 ship 為 future-proof | P1-T1 |
+
+---
+
+## 7. Test Instrumentation Strategy（spec §6.1 codex round-3 P2）
+
+**問題**：spec §6.1 `TestStopFailure_NativeDetach_Misses_NoMutation` 的 assertion (a) 「subagents bit-identical」不夠 — miss-ref 走 mutate 也會寫回相同 slice。
+
+**Plan-level decision**：用 **fake frame store with call counter**：
+
+```go
+type counterFrameStore struct {
+    inner store.FrameStore
+    UpsertCallCount int
+    GetCallCount    int
+}
+func (c *counterFrameStore) UpsertIfUnchanged(f store.Frame, expected int64) (bool, store.Frame, error) {
+    c.UpsertCallCount++
+    return c.inner.UpsertIfUnchanged(f, expected)
+}
+// ... GetByIdentity / ListByPane 透傳 ...
+```
+
+於 test setup wrap production store；assertion 寫 `require.Equal(t, 0, fakeStore.UpsertCallCount, "no UpsertIfUnchanged call expected when ref absent")`。
+
+**Placement**：`internal/module/agent/fakes_test.go`（既有 test fakes 集中地）— 加 `counterFrameStore` type，方便其他 test 復用 call counter pattern。
+
+**驗證**：`TestStopFailure_NativeDetach_Misses_NoMutation` 用此 fake；`TestStopFailure_NativeDetach_Hits` 反向用同 fake assert UpsertCallCount > 0（cross-validate fake 本身正確）。
+
+---
+
+## 8. Convergence checklist（plan freeze）
+
+進實作前必滿足：
+
+- [x] spec v3 + follow-ups 三輪 codex review approve to enter plan
+- [ ] 本 plan v1 → codex round 1 review 收斂（task #4）
+- [ ] 必要時 plan v2 → codex round 2 review 0 blocker（依風險判斷）
+- [ ] 啟 P1-T1 subagent
+
+PR push 前必滿足：
+
+- [ ] PR-A 全套測試綠 + race-mode 10 輪 + lint + vet
+- [ ] PR-B 全套測試綠 + lint + build
+- [ ] 改動 LOC 在 spec AC9 cap 內
+- [ ] commit history 每 task 獨立 commit
+
+PR merge 前必滿足：
+
+- [ ] Round 1 codex standard review 收斂
+- [ ] Round 2 三平行 adversarial review 收斂
+- [ ] 高關聯 / 高信心 / 低複雜 finding 全修
+- [ ] 其他 finding 開 issue 追蹤
+- [ ] AC1-AC9 對應 test 全綠

--- a/docs/specs/2026-05-03-rate-limit-subagent-cleanup-plan.md
+++ b/docs/specs/2026-05-03-rate-limit-subagent-cleanup-plan.md
@@ -462,7 +462,12 @@ func TestStopFailure_NativeDetach_Hits(t *testing.T) {
 
 **測試保證範圍誠實標示**：`FrameTraceMeta.Reason` 比對證明的是「沒走 detach branch」，**不嚴格**證明「`mutateSubagentsWithRetry` 沒被呼叫」（理論上 miss-ref mutate 也會寫回等價 slice + refresh LastSeenAt，但 spec §3.2 設計 break 路徑就是不 call mutate，所以行為契約已鎖住）。要進一步嚴格驗證 mutate-not-called 需要 instrumentation 級改動（`Module.frames` 抽 interface）— 本 PR 不擴大 scope。
 
-**Placement**：example 中 `newTestModule` / `seedFrame` / `seedFrameWithSubagents` 是既有 helper 名（驗於 `internal/module/agent/fakes_test.go`）；`buildPdxStopFailureRequest` 若不存在則 inline 構造 EventRequest（payload shape per spec §1.2 fixture）。實作時 subagent 應先 grep 既有 helper signature 後再 reuse / 新建。
+**Placement / helper 真實位置**：
+- `newTestModule(t)` — `internal/module/agent/handler_test.go`
+- `seedFrame(t, m, agentType, status)` 與 `seedFrameWithSubagents(t, m, frame, refs)` — `internal/module/agent/frame_ops_test.go`
+- `buildPdxStopFailureRequest(...)` 不存在；實作時 inline 構造 `EventRequest`（payload shape per spec §1.2 fixture）或新建 helper
+
+**實作前必跑**：subagent 在 P1-T3b 開頭先 `grep -n "func newTestModule\|func seedFrame" internal/module/agent/`，確認既有 signature；範例 code 是 illustrative，最終 call site 以 grep 結果為準。
 
 ---
 

--- a/docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md
+++ b/docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md
@@ -416,7 +416,7 @@ Not a code change. Captured here so PR-A's verification plan can reference it.
 | Test | Behaviour asserted |
 |---|---|
 | `TestStopFailure_NativeDetach_Hits` | `frame.Subagents` has native ref `{ID: X}`; `PdxStopFailure` payload `{agent_id: X}` arrives; ref removed; trace reason `native_subagent_detached_on_stop_failure` |
-| `TestStopFailure_NativeDetach_Misses_NoMutation` | `frame.Subagents` empty (or contains only refs whose IDs differ from payload `agent_id`); payload `{agent_id: X}` arrives; assertions: (a) **`mutateSubagentsWithRetry` is NOT called** (subagents list bit-identical pre/post); (b) NO `native_subagent_detached_on_stop_failure` trace step recorded; (c) legacy post-switch `UpdateHookPath` path DOES execute — `frame.Status` becomes `error`, `LastSeenAt` refreshes, normalized event broadcast — preserving v0 behaviour bit-exactly for unrecognised payloads. Asserts pre-check correctness without breaking legacy semantics. |
+| `TestStopFailure_NativeDetach_Misses_NoMutation` | `frame.Subagents` empty (or contains only refs whose IDs differ from payload `agent_id`); payload `{agent_id: X}` arrives; assertions: (a) `applyFrameEvent` returned `FrameTraceMeta.Reason != "native_subagent_detached_on_stop_failure"` (the only behaviourally-distinct trace signal of the new code path); (b) `mutateSubagentsWithRetry` not invoked — verified either via a spy/call-counter wrapper around the frame store interface, or by asserting the trace pipeline emits the legacy `UpdateHookPath` step rather than a frame-level mutation step. Plan §test-instrumentation will pick the concrete mechanism; "subagents bit-identical pre/post" alone is **not** sufficient evidence (a miss-ref mutate would also write back the same slice). (c) Legacy post-switch `UpdateHookPath` path DOES execute — `frame.Status` becomes `error`, `LastSeenAt` refreshes, normalized event broadcast — preserving v0 behaviour bit-exactly for unrecognised payloads. Together (a)+(b)+(c) prove pre-check correctness without breaking legacy semantics. |
 | `TestStopFailure_NoAgentId_LegacyBehaviour` | payload omits `agent_id` field entirely; existing `frame != nil` break path preserved; no detach, no trace change |
 | `TestStopFailure_EmptyAgentId_LegacyBehaviour` | payload contains `agent_id: ""` (explicit empty string from upstream); same behaviour as missing field. Locks down the empty-string branch since `findNativeRefByID` returns -1 early when id is empty |
 | `TestStopFailure_PreservesProxyRefs` | `frame.Subagents` has `{ID:X, IsProxy:false}` AND `{ID:Y, IsProxy:true, SourcePID:P}`; payload `{agent_id:X}`; only X removed, Y untouched |
@@ -481,7 +481,7 @@ Optimistic-concurrency retry path (`mutateSubagentsWithRetry`) is already covere
 - Rate-limit retry-throttling for cc itself (upstream concern)
 - daemon-side broadcast suppression / coalescing (would mask trace fidelity)
 - adding a `last_seen_at` timestamp to native refs to enable a TTL sweep (broader schema change; revisit if Phase 1 turns out insufficient)
-- opencode plugin emitting `StopFailure` (currently doesn't; out of scope here)
+- opencode plugin extending `PdxStopFailure` payload with `agent_id` (currently emits the event but without `agent_id`, so opencode native detach is a silent no-op until the plugin template is updated; that template change is out of scope here)
 - Migrating PR-B's debounce state into zustand (architectural divergence, no concrete benefit)
 - SPA-side suppression of `unread` badge during error storms (deliberately preserved)
 

--- a/docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md
+++ b/docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md
@@ -1,0 +1,381 @@
+# Spec — Rate-limit subagent cleanup + notification debounce
+
+**Date**: 2026-05-03
+**Branch**: `worktree-rate-limit-cleanup`
+**Baseline**: origin/main `401a785c` (alpha.289)
+**Scope**: Two-phase fix for the dthn-class symptom "subagent dots never go away":
+- **Phase 1 (PR-A, daemon)**: when an agent fires `StopFailure` carrying a subagent's `agent_id` (the documented hook payload pattern when an in-flight Task subagent terminates abnormally — observed empirically in 98% of dthn's 1573 rate-limit episodes), detach the matching native `SubagentRef` from the parent frame. Today this code path is a no-op (`frame_ops.go:288-300`), so native refs accumulate forever.
+- **Phase 2 (PR-B, SPA)**: trailing-edge sliding debounce for `derived='error'` desktop notifications, keyed by `compositeKey + raw_event_name + detail.error`. Suppresses error-storm notification spam while preserving the unread badge.
+
+Phase 3 is operational (one-shot dthn cleanup), not a code change.
+
+**Estimated size**: ~250 LOC daemon (PR-A) + ~150 LOC SPA (PR-B), plus ~600 LOC tests across both PRs. Two separate PRs (correctness vs UX policy).
+
+---
+
+## 1. Symptom & motivation
+
+### 1.1 User-reported gap
+
+tmux session `dthn` (cc agent) accumulated **3944 native `SubagentRef`** entries in `agent_frames.subagents_json` (pane `%50`). The SPA shows the cc tab as "subagent permanently in flight" because every hook broadcast carries the full ref list. Restarting cc was the only way to clear the lights.
+
+Concurrently, the user receives ~1.5 desktop notifications/sec for `rate_limit` errors during a Claude Code rate-limit storm — every `PdxStopFailure` re-fires `derived='error'` → `shouldNotify` → OS notification. cc already shows the rate-limit error in its own UI, so the SPA's flood adds noise without information.
+
+### 1.2 Root cause — data evidence
+
+Chain-level reconciliation against `agent_trace_chains` / `agent_trace_steps` (trace retention window ~6h):
+
+| Metric | Value |
+|---|---|
+| Distinct `agent_id` in `PdxSubagentStart` (window) | 1573 |
+| → followed by `PdxSubagentStop` (same `agent_id`) | **32 (2.0%)** |
+| → followed by `PdxStopFailure` (same `agent_id`, `error=rate_limit`) | **1541 (97.9%)** |
+| → followed by neither | 0 |
+| → followed by both | 0 (mutually exclusive) |
+
+Outside the trace retention window, `subagents_json` carries 1432 additional "orphan" refs whose original `SubagentStart` predates trace retention. Each of those refs has a corresponding `PdxStopFailure` row inside the window — i.e. the same code path leaks them.
+
+**Hook payload shape** (`agent_trace_steps.payload_json`, dthn chain `c02151f0...`):
+```json
+{
+  "session_id": "f828329e-...",
+  "agent_id": "aac56e6312afceb04",
+  "agent_type": "general-purpose",
+  "hook_event_name": "StopFailure",
+  "error": "rate_limit",
+  "last_assistant_message": "You're out of extra usage · resets 2:30pm (Asia/Taipei)"
+}
+```
+The `agent_id` field uniquely identifies the failing **subagent** (not the cc main session). `agent_type=general-purpose` confirms the same — cc's main agent type is `cc`, not `general-purpose`.
+
+### 1.3 Why the daemon doesn't detach
+
+`internal/module/agent/frame_ops.go:288-300` (alpha.289):
+```go
+case agentpkg.LifecycleStop, agentpkg.LifecycleStopFailure:
+    if frame != nil {
+        break  // ← cc main frame exists → fall through, no native ref handling
+    }
+    // L2 codex turn-aware proxy detach (only fires when frame == nil)
+```
+And `internal/module/agent/sweep.go:398-447` (`pruneDeadProxyRefs`):
+```go
+for _, ref := range frame.Subagents {
+    if !ref.IsProxy { continue }  // ← native refs unreachable
+    ...
+}
+```
+Native refs have no other GC path. `LifecycleSessionEnd` deletes the whole frame and would clean them, but cc keeps the main session alive across rate-limit retries, so SessionEnd never fires.
+
+### 1.4 Why notification noise is decoupled
+
+Even after PR-A lands and `subagents_json` stops accumulating, every `PdxStopFailure` still derives to `Status=error` and triggers `useNotificationDispatcher` with `derived='error'`. The hook firing rate is bounded by cc's retry backoff (~1.5 Hz observed); 1 desktop notification per cc Task error is reasonable, ~90/min is not.
+
+### 1.5 Documented behaviour vs emergent
+
+The cc hook contract is not formally documented for the "subagent fails with rate_limit" branch. The 98% observed pattern in dthn's `agent_trace_chains` is treated here as a **high-confidence empirical observation**, not a guaranteed upstream invariant. Phase 1 is therefore designed to be **idempotent and safe even if the assumption is partially wrong** (see §3.4 risk).
+
+---
+
+## 2. Cross-validated facts
+
+### 2.1 Existing `StopFailure` handling parity
+
+`internal/module/agent/frame_ops_l2_test.go` already exercises `StopFailure` parity with `Stop` for codex turn-aware proxy detach (test names containing "stopfailure parity"). Phase 1 extends the same parity concept from proxy refs to native refs, on the cc/opencode wildcard branch.
+
+### 2.2 cc derive does not surface `agent_id` for `PdxStopFailure`
+
+`internal/agent/cc/status.go:83-91` (current):
+```go
+case "PdxStopFailure":
+    return agent.DeriveResult{
+        Valid:  true,
+        Status: agent.StatusError,
+        Detail: map[string]any{
+            "error_details": raw["error_details"],
+            "error":         raw["error"],
+        },
+    }
+```
+`agent_id` is in `raw_event` but not in `result.Detail`. Phase 1 must either (a) extend the derive to add `agent_id` to `Detail`, or (b) parse `req.RawEvent` directly in the handler. Option (a) keeps the boundary clean (provider owns the raw→Detail mapping); chosen.
+
+`internal/agent/codex/status.go:67` and `internal/agent/opencode/status.go:27` use the same pattern and need the same one-line addition for parity. opencode plugin currently does not emit `StopFailure` (no upstream event source per `events.go`), but the catalog entry exists; codex emits `StopFailure` from agent SDK.
+
+### 2.3 `updateSubagents` is idempotent
+
+`internal/module/agent/frame_ops.go:872-895`:
+```go
+case agentpkg.LifecycleSubagentStop:
+    filtered := make([]agentpkg.SubagentRef, 0, len(current))
+    for _, existing := range current {
+        if !subagentRefMatches(existing, ref) {
+            filtered = append(filtered, existing)
+        }
+    }
+    return filtered
+```
+A `LifecycleSubagentStop` mutation against a ref list that does not contain a matching ref is a no-op (returns equivalent slice). This is the safety net that makes Phase 1 safe even if a `StopFailure` payload's `agent_id` does **not** correspond to a real native subagent.
+
+### 2.4 `subagentRefMatches` for native refs
+
+`frame_ops.go:913-932` — native refs match on `ID` alone (cross-kind never matches). So a `StopFailure` synthesised `SubagentRef{ID: agent_id, Type: frame.AgentType, IsProxy: false}` will only match native refs with the same `ID`. Proxy refs with the same `ID` (impossible by construction — proxy IDs are `proxy:<type>:<pid>:<startTime>`) are not at risk.
+
+### 2.5 SPA notification dispatcher current state
+
+`spa/src/hooks/useNotificationDispatcher.ts`:
+- `shouldNotify` (lines 60-93) gates on `derived in {waiting, idle, error}` plus suppression rules.
+- `derived='error'` always passes when not focused, regardless of how recently the same session had an error.
+- Per-session/event dedup uses `prevEvents → currentEvents` set diff (lines ~82) to detect "new event arrived" — this is **not** a time-window debounce; it just compares two snapshots.
+
+PR-B adds a parallel debounce layer specifically for `derived='error'`.
+
+---
+
+## 3. Design — Phase 1 (PR-A, daemon)
+
+### 3.1 Provider derive change
+
+For all three providers (cc, codex, opencode), `PdxStopFailure` derive adds `agent_id` to `Detail`:
+```go
+case "PdxStopFailure":
+    return agent.DeriveResult{
+        Valid:  true,
+        Status: agent.StatusError,
+        Detail: map[string]any{
+            "error_details": raw["error_details"],
+            "error":         raw["error"],
+            "agent_id":      raw["agent_id"],  // NEW; nil-safe (raw["agent_id"] returns nil if absent)
+        },
+    }
+```
+
+When the upstream payload omits `agent_id` (e.g. main-session `StopFailure`), `raw["agent_id"]` is `nil`, downstream extracts `""` via type assertion and skips the detach branch — preserving today's behaviour for that case.
+
+### 3.2 Handler `LifecycleStopFailure` extension
+
+`frame_ops.go:288` `case agentpkg.LifecycleStop, agentpkg.LifecycleStopFailure:` — split the joint case:
+
+```go
+case agentpkg.LifecycleStopFailure:
+    // Native subagent failure path: payload's agent_id identifies the
+    // failing subagent (not the main session). Empirically this is how
+    // cc reports rate-limit and other subagent terminations (~98% of
+    // observed Task failures in dthn telemetry, 2026-05-03). When the
+    // payload carries an agent_id and the parent frame holds a
+    // matching native ref, detach it idempotently. updateSubagents is
+    // a no-op for non-matching IDs, so a payload that doesn't actually
+    // refer to a subagent (e.g. main-session StopFailure with a stale
+    // agent_id) is naturally safe.
+    if frame != nil {
+        agentID, _ := result.Detail["agent_id"].(string)
+        if agentID != "" {
+            ref := agentpkg.SubagentRef{
+                ID:   agentID,
+                Type: frame.AgentType,  // §2.4 invariant: native match by ID alone
+            }
+            applied, stored, merr := m.mutateSubagentsWithRetry(*frame, agentpkg.LifecycleSubagentStop, ref, broadcastTs)
+            if merr != nil {
+                return nil, FrameTraceMeta{}, merr
+            }
+            if applied {
+                projection, perr := m.projectPane(req.TmuxPaneID)
+                return projection, FrameTraceMeta{
+                    FrameID:       stored.FrameID,
+                    ParentFrameID: stored.ParentFrameID,
+                    Decision:      "updated_frame",
+                    Reason:        "native_subagent_detached_on_stop_failure",
+                    Before:        before,
+                    After:         summarizeFrame(&stored),
+                }, perr
+            }
+        }
+        break  // no agent_id, or no matching ref — preserves legacy behaviour
+    }
+    // frame == nil: fall through to existing codex/proxy detach below.
+    fallthrough
+case agentpkg.LifecycleStop:
+    // ... existing logic at frame_ops.go:288-424 unchanged ...
+```
+
+Trace reason `native_subagent_detached_on_stop_failure` is new; existing `proxy_subagent_detached_on_stop` covers the `frame==nil` branch and is unchanged.
+
+### 3.3 Why `Type: frame.AgentType` (not raw `agent_type` from payload)
+
+The native ref's `Type` field drives SPA `SubagentDots` colour family logic. Existing code stores `frame.AgentType` (e.g. `cc`) at `SubagentStart` time (`frame_ops.go:164`). For the detach match to find the existing ref, the synthesised ref's `Type` must equal the stored ref's `Type`, which is `frame.AgentType` — not the payload's `agent_type` (`general-purpose`, a sub-variant). `subagentRefMatches` actually only compares `ID` for natives (§2.4), so `Type` is informational here, but using `frame.AgentType` keeps the ref-construction pattern consistent with `frame_ops.go:157-169` where `Type` is set the same way.
+
+### 3.4 Risk: false-positive detach
+
+If a `PdxStopFailure` payload carries an `agent_id` that **happens** to collide with a still-live native `SubagentRef.ID` despite not actually referring to that subagent, Phase 1 will detach a ref that should still be lit. Consequence: SPA shows one fewer dot for ~as long as the subagent is genuinely running.
+
+Mitigation:
+- Native `agent_id` is cc-controlled (cc's internal Task ID). Collision requires cc to issue identical IDs to two different subagents in the same frame, which contradicts cc's own Task tool semantics.
+- Even if collision happens, `updateSubagents` removes one ref; if a later `PdxSubagentStop` re-fires with the same ID against an empty list, that's also a no-op (idempotent). No status-leak corruption — the worst observable effect is a transiently-missing dot.
+
+This risk is judged acceptable in exchange for fixing the unbounded accumulation. AC4 enforces the idempotency contract via tests.
+
+### 3.5 Trace observability
+
+Add a new step reason constant `native_subagent_detached_on_stop_failure` in `frame_ops.go` (search for existing `proxy_subagent_detached_on_stop` and place adjacent). Existing trace pipeline propagates it through `applyFrameEvent → handleEvent → trace.Frame()` without other changes.
+
+---
+
+## 4. Design — Phase 2 (PR-B, SPA debounce)
+
+### 4.1 Debounce semantics
+
+**Trailing-edge sliding window**, not fixed-window throttle:
+
+- First `derived='error'` for a given `(compositeKey, eventName, detailError)` triple: notify, set `silentUntil = now + WINDOW_MS`.
+- Subsequent `derived='error'` arrivals while `now < silentUntil`: do not notify, **extend** `silentUntil = now + WINDOW_MS`.
+- Subsequent arrivals after `now ≥ silentUntil`: notify again, reset window.
+
+User-facing semantics: "one notification per error episode, where an episode ends when no error of the same kind arrives for `WINDOW_MS` consecutive ms."
+
+`WINDOW_MS = 60_000`. Rationale: rate-limit storms typically last for the entire reset window (5–10 min) once they begin; 60s of silence is a strong signal the episode is genuinely over. Not the rate-limit reset duration directly, because the user already sees the rate-limit message in cc's own UI (per user input 2026-05-03).
+
+### 4.2 Key composition
+
+```ts
+const debounceKey = `${compositeKey}|${normalizedEventName}|${String(detailError ?? '')}`
+```
+
+Three components:
+1. `compositeKey` (host:sessionCode) — different sessions/hosts notify independently.
+2. `normalizedEventName` — different event names (e.g. `StopFailure` vs `Stop`) notify independently.
+3. `detail.error` — `rate_limit` storm doesn't suppress a different error type (`auth_failed`, etc.) on the same session.
+
+`detailError` defaults to empty string (not undefined) so `error=undefined` events still get a stable key.
+
+### 4.3 State location
+
+Module-level `Map<string, { silentUntil: number }>` in `useNotificationDispatcher.ts`. Not zustand. Rationale: ephemeral dispatcher-private state, no cross-component subscription, no persistence. Aligns with the existing `seenAtRef` pattern (current dedup is also module-level state).
+
+### 4.4 Cleanup
+
+Two cleanup paths:
+1. **Per-session**: on `clearSession(hostId, sessionCode)` (agent store action) and `removeHost(hostId)` — wipe entries whose key prefix matches. Hooks already exist; debounce module subscribes.
+2. **TTL self-cleanup**: in the `shouldNotify` hot path, if an existing entry's `silentUntil < now - 5×WINDOW_MS` it is stale and can be removed in-place. Bounds memory across long-running app.
+
+### 4.5 Scope limits
+
+- Only gates `derived === 'error'`. `waiting` and `idle` notifications stay one-per-event.
+- Does **not** suppress unread badge (`useAgentStore.unread[ck]` mutation in `handleNormalizedEvent`). The badge stays sticky regardless of debounce.
+- Does **not** suppress hook broadcasts at the daemon side. Trace, history, and DB writes are unchanged.
+
+### 4.6 `shouldNotify` integration
+
+```ts
+function shouldNotify(args): boolean {
+  // ... existing checks ...
+  if (derived === 'error') {
+    const key = `${ck}|${eventName}|${String(args.detail?.error ?? '')}`
+    const now = Date.now()
+    const entry = errorDebounceState.get(key)
+    if (entry && now < entry.silentUntil) {
+      entry.silentUntil = now + WINDOW_MS  // extend
+      return false
+    }
+    errorDebounceState.set(key, { silentUntil: now + WINDOW_MS })
+    // fall through, return true at end
+  }
+  // ... existing return logic ...
+}
+```
+
+---
+
+## 5. Design — Phase 3 (operational)
+
+After PR-A merges and a fresh daemon restart picks up the binary:
+
+1. Observe whether `agent_frames.subagents_json` for pane `%50` (dthn) self-heals when cc fires the next `PdxStopFailure` (each one detaches one ref).
+2. If self-heal is too slow (3944 refs × ~0.7s/event ≈ 45 min), one-shot SQL: `UPDATE agent_frames SET subagents_json='[]' WHERE pane_id='%50';` followed by `pdx serve` restart so the in-memory `m.subagents` map reloads from DB. SPA reconciles via the next hook broadcast.
+
+Not a code change. Captured here so PR-A's verification plan can reference it.
+
+---
+
+## 6. TDD test plan
+
+### 6.1 PR-A daemon tests (`internal/module/agent/`)
+
+| Test | Behaviour asserted |
+|---|---|
+| `TestStopFailure_NativeDetach_Hits` | `frame.Subagents` has native ref `{ID: X}`; `PdxStopFailure` payload `{agent_id: X}` arrives; ref removed; trace reason `native_subagent_detached_on_stop_failure` |
+| `TestStopFailure_NativeDetach_Misses_Idempotent` | `frame.Subagents` empty; payload `{agent_id: X}`; no error, no broadcast change, trace reason `proxy_subagent_stop_no_match` (existing) or new `native_subagent_no_match` — choose during plan |
+| `TestStopFailure_NoAgentId_LegacyBehaviour` | payload omits `agent_id`; existing `frame != nil` break path preserved; no detach, no trace change |
+| `TestStopFailure_PreservesProxyRefs` | `frame.Subagents` has `{ID:X, IsProxy:false}` AND `{ID:Y, IsProxy:true, SourcePID:P}`; payload `{agent_id:X}`; only X removed, Y untouched |
+| `TestStopFailure_FrameNil_FallthroughToProxyDetach` | `frame == nil`; payload `{agent_id:X}`; existing codex/proxy detach branch reached unchanged |
+| `TestStopFailureDerive_AgentIdInDetail` (per provider × 3) | cc/codex/opencode `deriveStatus("PdxStopFailure", {agent_id: "x"})` returns `Detail["agent_id"] == "x"` |
+| `TestStopFailureDerive_AgentIdMissing` | derive omits `agent_id` from raw → `Detail["agent_id"] == nil` |
+
+Optimistic-concurrency retry path (`mutateSubagentsWithRetry`) is already covered by existing tests; this PR doesn't change its contract.
+
+### 6.2 PR-B SPA tests (`spa/src/hooks/`)
+
+| Test | Behaviour asserted |
+|---|---|
+| `debounce__first_error_passes` | First `derived=error` for a key returns `shouldNotify=true` |
+| `debounce__second_error_within_window_blocked_and_extends` | Second arrival 30s later: `false`, `silentUntil` extended to `t2 + 60s` |
+| `debounce__error_after_silence_window_passes` | Arrival 70s after last: `true` (window expired) |
+| `debounce__different_keys_independent` | Same session, different `detail.error` → both pass; same error, different sessions → both pass |
+| `debounce__clear_session_resets` | `clearSession` removes key; next arrival passes |
+| `debounce__waiting_not_debounced` | `derived=waiting` for the same session passes every time |
+| `debounce__unread_badge_unaffected` | Even when notification suppressed, `useAgentStore.unread[ck]=true` still set |
+| `debounce__ttl_cleanup` | After 5×WINDOW_MS no activity, `shouldNotify` removes stale entries |
+
+---
+
+## 7. Acceptance criteria
+
+- **AC1**: dthn class symptom gone — after PR-A, `agent_frames.subagents_json` for any cc pane no longer accumulates beyond live subagent count.
+- **AC2**: Existing `Stop`/`StopFailure` proxy-detach behaviour for `frame == nil` path bit-identical (regression guard via existing `frame_ops_l2_test.go`).
+- **AC3**: `PdxStopFailure` with no `agent_id` (main-session failure) preserves legacy behaviour.
+- **AC4**: PR-A is idempotent — replaying any `PdxStopFailure` against an already-detached ref is a no-op.
+- **AC5**: PR-B suppresses ≥99% of redundant `derived=error` notifications during a 1.5 Hz storm (60s window @ 1.5 Hz = 1 notification per 90 events).
+- **AC6**: PR-B preserves unread badge semantics — sticky after first error, doesn't clear on subsequent debounced arrivals.
+- **AC7**: PR-B `clearSession` / `removeHost` clean debounce state for the affected keys.
+- **AC8**: Both PRs ship with no new lint / type errors and full test coverage of the matrix in §6.
+- **AC9**: PR size cap: PR-A ≤ 500 LOC production+tests; PR-B ≤ 300 LOC production+tests. (Spec docs not counted.)
+
+---
+
+## 8. Risks / known limitations
+
+| # | Risk | Mitigation / acceptance |
+|---|---|---|
+| R1 | cc upstream changes how `StopFailure` payload is shaped | Phase 1 idempotent; if `agent_id` no longer appears, code becomes silent no-op. Plan §verification has live-fixture replay step |
+| R2 | False-positive native detach (§3.4) | Bounded blast radius (one missing dot, transient); idempotency ACL covers replay |
+| R3 | PR-B 60s window misses a "second wave" rate-limit storm | User intent (§1.4): cc UI shows error already; missed notification is preferable to flood. Window can be tuned later via env/config if needed |
+| R4 | Module-level Map memory leak | TTL self-cleanup in §4.4 + per-session cleanup hooks bound the working set |
+| R5 | Different cc Task subagent's `agent_id` collides with a live one | cc's Task tool issues unique IDs by design; collision is a cc upstream bug, not ours to defend against |
+
+---
+
+## 9. Out of scope
+
+- Rate-limit retry-throttling for cc itself (upstream concern)
+- daemon-side broadcast suppression / coalescing (would mask trace fidelity)
+- adding a `last_seen_at` timestamp to native refs to enable a TTL sweep (broader schema change; revisit if Phase 1 turns out insufficient)
+- opencode plugin emitting `StopFailure` (currently doesn't; out of scope here)
+- Migrating PR-B's debounce state into zustand (architectural divergence, no concrete benefit)
+- SPA-side suppression of `unread` badge during error storms (deliberately preserved)
+
+---
+
+## 10. Verification plan
+
+1. **PR-A unit tests**: `go test ./internal/module/agent/... ./internal/agent/...` green.
+2. **PR-A live verification (mlab)**: with daemon built from PR-A, simulate dthn-class flow via `pdx hook --agent cc PdxSubagentStart` then `pdx hook --agent cc PdxStopFailure` with the same `agent_id` and confirm `subagents_json` in DB drops by one ref. Replay with mismatched `agent_id` to confirm no-op.
+3. **PR-A dthn cleanup**: after PR-A merges to main and a fresh daemon binary is in place, observe `agent_frames.subagents_json` for pane `%50` over 5 min — should drain at the rate cc fires `PdxStopFailure`. If still not converging fully, run the SQL from §5.
+4. **PR-B unit tests**: `cd spa && npx vitest run` for `useNotificationDispatcher.test.ts` green.
+5. **PR-B manual SPA**: trigger 30 consecutive `derived=error` events for a session in dev; confirm exactly one OS notification fires, unread badge sticks, subsequent same-error events do not re-trigger.
+
+---
+
+## 11. PR sequencing
+
+- **PR-A first**: correctness fix; lands without behavioural change for existing `frame == nil` paths.
+- **dthn cleanup** (operational, ad-hoc): immediately after PR-A merges and daemon restarts.
+- **PR-B second**: UX-only; depends conceptually on PR-A (without it, debounce hides the symptom of unbounded ref accumulation), but does not technically depend on PR-A code changes — could land independently if needed.
+- **One bump PR per merged feature PR**, per CLAUDE.md convention.

--- a/docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md
+++ b/docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md
@@ -1,10 +1,19 @@
 # Spec — Rate-limit subagent cleanup + notification debounce
 
-**Date**: 2026-05-03 (v1 → v2)
+**Date**: 2026-05-03 (v1 → v2 → v3)
 **Branch**: `worktree-rate-limit-cleanup`
 **Baseline**: origin/main `401a785c` (alpha.289)
 
-**v2 supersedes v1**. v1 codex review (`task-mopk1n84-e61c4i`, thread `019ded1e-ca04-7583-bfbf-b28d2eee134f`) found 3 P1 + 5 P2 + 1 nit findings. v2 addresses all of them:
+**v3 supersedes v2**. v2 codex review (`task-mopkf73y-c4bjsx`, thread `019ded28-6dad-7930-9df0-d04a29c72724`) found 2 P1 + 3 P2 + 1 fact + 1 nit (residual matrix from v1 → v2 transition). v3 addresses all of them:
+- P1: §6.1 `TestStopFailure_NativeDetach_Misses_NoMutation` assertion rewritten — break path DOES execute legacy `UpdateHookPath` (Status=error, LastSeenAt refresh, broadcast); test asserts only "no `mutateSubagentsWithRetry`, no `native_subagent_detached_on_stop_failure` trace step", not "no broadcast change".
+- P1: §10 verification plan rewritten — SQL is the immediate cleanup step, not "observe first then SQL if slow". Aligns with §5 / §11.
+- P2: §4.6 snippet updated to `JSON.stringify` (was still pipe-join).
+- P2: §4.4 cleanup description updated — uses key-builder reverse decode (`JSON.parse(key)[0] === ck`), not prefix-match.
+- P2: §5 SQL operational sequence adds `SELECT` backup + `BEGIN/COMMIT` transaction + multi-process check.
+- fact: §2.2 opencode "currently does not emit StopFailure" corrected — opencode `session.error` DOES emit `PdxStopFailure` via plugin_template.go; missing piece is `agent_id` in payload, not the event itself.
+- nit: §3.2 "two new trace reasons" softened to "one new reason; existing `frame_missing` is reused".
+
+**v2 superseded v1**. v1 codex review (`task-mopk1n84-e61c4i`, thread `019ded1e-ca04-7583-bfbf-b28d2eee134f`) found 3 P1 + 5 P2 + 1 nit findings. v2 addressed all of them:
 - P1.1 `mutateSubagentsWithRetry` `applied=true` does **not** mean a ref was actually removed (it only signals `UpsertIfUnchanged` succeeded; `LastSeenAt` always refreshes regardless of ref-list change). v2 adds an explicit pre-check via new helper `findNativeRefByID` so we never broadcast a phantom detach.
 - P1.2 dthn cleanup: SQL is the **expected primary cleanup path**, not a fallback; PR-A only handles future StopFailure events, and historical refs whose terminal `StopFailure` predates trace retention will never be re-emitted.
 - P1.3 AC5 99% number arithmetic mismatch (1/90 = 98.89%, not 99%). v2 reframes as "≥98.8% suppression over a 100-event window".
@@ -106,7 +115,7 @@ case "PdxStopFailure":
 ```
 `agent_id` is in `raw_event` but not in `result.Detail`. Phase 1 must either (a) extend the derive to add `agent_id` to `Detail`, or (b) parse `req.RawEvent` directly in the handler. Option (a) keeps the boundary clean (provider owns the raw→Detail mapping); chosen.
 
-`internal/agent/codex/status.go:67` and `internal/agent/opencode/status.go:27` use the same pattern and need the same one-line addition for parity. cc emits `PdxStopFailure` reliably (3005 observed in dthn telemetry). codex emits `PdxStopFailure` from agent SDK (catalog entry `FutureOnly:true`). opencode catalog has the entry but **the plan must verify** against `internal/agent/opencode/plugin_template.go` whether `tool.execute.after` / `session.error` failure paths actually emit `PdxStopFailure` with `agent_id` — if the upstream source is dead, the derive change remains no-op-safe (tests assert nil → empty string round-trip), but the §6.1 opencode test row should be marked "currently inactive emission, derive contract still pinned".
+`internal/agent/codex/status.go:67` and `internal/agent/opencode/status.go:27` use the same pattern and need the same one-line addition for parity. cc emits `PdxStopFailure` reliably (3005 observed in dthn telemetry). codex emits `PdxStopFailure` from agent SDK (catalog entry `FutureOnly:true`). opencode currently emits `PdxStopFailure` via `internal/agent/opencode/plugin_template.go`'s `session.error` handler, but the payload **does not include `agent_id`** — so even with the derive change applied, opencode's native detach remains a silent no-op until the plugin template is updated to surface the failing subagent's `agent_id`. The derive change is still made for parity (cheap, future-proofs the day opencode adds the field), and the test matrix marks the opencode "currently inactive native-detach behaviour, derive contract pinned" status explicitly.
 
 ### 2.3 `updateSubagents` is data-idempotent but `mutateSubagentsWithRetry` is **not** observation-idempotent
 
@@ -256,9 +265,10 @@ case agentpkg.LifecycleStop:
     // ... existing logic at frame_ops.go:288-424 unchanged ...
 ```
 
-Two new trace reasons:
-- `native_subagent_detached_on_stop_failure` — agent_id matched a native ref, ref removed
-- (no new reason for the no-match path — falling through to legacy `break` reaches the post-switch `UpdateHookPath` path; existing trace pipeline records that branch)
+Trace reasons:
+- **New**: `native_subagent_detached_on_stop_failure` — agent_id matched a native ref, ref removed
+- **Reused (existing)**: `frame_missing` — `findNativeRefByID` ≥0 but `mutateSubagentsWithRetry` returned `applied=false` (concurrent SessionEnd / sweep deleted the frame mid-flight). Same string already used elsewhere in `frame_ops.go` for the same semantic ("frame disappeared between read and write"), so reuse is intentional, not collision.
+- **No-match no-op (no new reason)**: `findNativeRefByID < 0` → `break` → legacy post-switch `UpdateHookPath` path (status/lastSeen update, normalized broadcast). Existing trace pipeline records that branch as it always has.
 
 Existing `proxy_subagent_detached_on_stop` covers the `frame==nil` branch and is unchanged.
 
@@ -319,7 +329,7 @@ Module-level `Map<string, { silentUntil: number }>` in `useNotificationDispatche
 ### 4.4 Cleanup
 
 Two cleanup paths:
-1. **Per-session**: on `clearSession(hostId, sessionCode)` (agent store action) and `removeHost(hostId)` — wipe entries whose key prefix matches. Hooks already exist; debounce module subscribes.
+1. **Per-session / per-host**: on `clearSession(hostId, sessionCode)` and `removeHost(hostId)` — iterate Map keys and decode each via `JSON.parse(key)` (the array form `[compositeKey, eventName, errorString]`). Compare `parsedKey[0]` to the target compositeKey, or compare `parsedKey[0].split(':')[0]` to the target hostId for `removeHost`. Prefix string match does **not** work because keys are JSON-stringified arrays (`"[\"hostA:sX\",\"Stop\",\"\"]"`). Helper `forEachDebounceKey((parsed, rawKey) => ...)` keeps the parse-once-per-iteration pattern in one place.
 2. **TTL self-cleanup**: in the `shouldNotify` hot path, if an existing entry's `silentUntil < now - 5×WINDOW_MS` it is stale and can be removed in-place. Bounds memory across long-running app.
 
 ### 4.5 Scope limits
@@ -331,10 +341,14 @@ Two cleanup paths:
 ### 4.6 `shouldNotify` integration
 
 ```ts
+function buildDebounceKey(ck: string, eventName: string, detailError: unknown): string {
+  return JSON.stringify([ck, eventName, String(detailError ?? '')])
+}
+
 function shouldNotify(args): boolean {
   // ... existing checks ...
   if (derived === 'error') {
-    const key = `${ck}|${eventName}|${String(args.detail?.error ?? '')}`
+    const key = buildDebounceKey(ck, eventName, args.detail?.error)
     const now = Date.now()
     const entry = errorDebounceState.get(key)
     if (entry && now < entry.silentUntil) {
@@ -348,6 +362,8 @@ function shouldNotify(args): boolean {
 }
 ```
 
+Same `buildDebounceKey` helper used by cleanup paths (§4.4) so encode/decode stay symmetric.
+
 ---
 
 ## 5. Design — Phase 3 (operational)
@@ -358,10 +374,34 @@ Reasoning: PR-A only handles `PdxStopFailure` events arriving *after* the fix is
 
 Operational sequence:
 1. Confirm PR-A daemon binary is deployed (`pdx --version` ≥ next alpha).
-2. Stop daemon (`brew services stop pdx` or signal handler).
-3. SQL: `UPDATE agent_frames SET subagents_json='[]' WHERE pane_id='%50';` (and any other pane suffering the same accumulation — query first: `SELECT pane_id, json_array_length(subagents_json) FROM agent_frames WHERE json_array_length(subagents_json) > 100;`).
-4. Start daemon. In-memory `m.subagents` map rebuilds from DB on first projection.
-5. SPA reconciles via the next hook broadcast (or via WS replay on reconnect).
+2. Confirm no second `pdx serve` instance is running (`pgrep -lf 'pdx serve'` should return one PID — the production daemon — and nothing else; abort if a dev instance is also live).
+3. Stop daemon (`brew services stop pdx` or `kill <pid>`).
+4. **Backup** affected rows before destructive UPDATE:
+   ```sql
+   .headers on
+   .mode insert agent_frames_pre_cleanup_backup
+   SELECT pane_id, frame_id, agent_type, subagents_json, last_seen_at
+   FROM agent_frames
+   WHERE json_array_length(subagents_json) > 100;
+   ```
+   Pipe to a `.sql` file (`> ~/.config/pdx/backups/2026-05-03-pre-cleanup.sql`) so a `RESTORE` is a one-liner if the cleanup turns out wrong.
+5. **Inspect** which panes actually need cleanup:
+   ```sql
+   SELECT pane_id, agent_type, json_array_length(subagents_json) AS n_refs
+   FROM agent_frames
+   WHERE json_array_length(subagents_json) > 100
+   ORDER BY n_refs DESC;
+   ```
+6. **Cleanup** in a transaction so a partial failure rolls back:
+   ```sql
+   BEGIN;
+   UPDATE agent_frames SET subagents_json='[]'
+   WHERE json_array_length(subagents_json) > 100;
+   COMMIT;
+   ```
+   Threshold `100` is conservative — well above any plausible live subagent count, well below dthn's 3944. Adjust per inspection output if a different cutoff fits.
+7. Start daemon. In-memory `m.subagents` map rebuilds from DB on first projection.
+8. SPA reconciles via the next hook broadcast (or via WS replay on reconnect).
 
 Self-heal observation is **opportunistic** — useful only if a long-running cc session is still firing live `PdxStopFailure` events whose `agent_id` happens to match an existing ref (rare, since terminated subagents don't fire again).
 
@@ -376,7 +416,7 @@ Not a code change. Captured here so PR-A's verification plan can reference it.
 | Test | Behaviour asserted |
 |---|---|
 | `TestStopFailure_NativeDetach_Hits` | `frame.Subagents` has native ref `{ID: X}`; `PdxStopFailure` payload `{agent_id: X}` arrives; ref removed; trace reason `native_subagent_detached_on_stop_failure` |
-| `TestStopFailure_NativeDetach_Misses_NoMutation` | `frame.Subagents` empty; payload `{agent_id: X}`; **no `mutateSubagentsWithRetry` call**, no `LastSeenAt` refresh, no broadcast change, no trace step claiming detach. Asserts pre-check correctness. |
+| `TestStopFailure_NativeDetach_Misses_NoMutation` | `frame.Subagents` empty (or contains only refs whose IDs differ from payload `agent_id`); payload `{agent_id: X}` arrives; assertions: (a) **`mutateSubagentsWithRetry` is NOT called** (subagents list bit-identical pre/post); (b) NO `native_subagent_detached_on_stop_failure` trace step recorded; (c) legacy post-switch `UpdateHookPath` path DOES execute — `frame.Status` becomes `error`, `LastSeenAt` refreshes, normalized event broadcast — preserving v0 behaviour bit-exactly for unrecognised payloads. Asserts pre-check correctness without breaking legacy semantics. |
 | `TestStopFailure_NoAgentId_LegacyBehaviour` | payload omits `agent_id` field entirely; existing `frame != nil` break path preserved; no detach, no trace change |
 | `TestStopFailure_EmptyAgentId_LegacyBehaviour` | payload contains `agent_id: ""` (explicit empty string from upstream); same behaviour as missing field. Locks down the empty-string branch since `findNativeRefByID` returns -1 early when id is empty |
 | `TestStopFailure_PreservesProxyRefs` | `frame.Subagents` has `{ID:X, IsProxy:false}` AND `{ID:Y, IsProxy:true, SourcePID:P}`; payload `{agent_id:X}`; only X removed, Y untouched |
@@ -450,8 +490,8 @@ Optimistic-concurrency retry path (`mutateSubagentsWithRetry`) is already covere
 ## 10. Verification plan
 
 1. **PR-A unit tests**: `go test ./internal/module/agent/... ./internal/agent/...` green.
-2. **PR-A live verification (mlab)**: with daemon built from PR-A, simulate dthn-class flow via `pdx hook --agent cc PdxSubagentStart` then `pdx hook --agent cc PdxStopFailure` with the same `agent_id` and confirm `subagents_json` in DB drops by one ref. Replay with mismatched `agent_id` to confirm no-op.
-3. **PR-A dthn cleanup**: after PR-A merges to main and a fresh daemon binary is in place, observe `agent_frames.subagents_json` for pane `%50` over 5 min — should drain at the rate cc fires `PdxStopFailure`. If still not converging fully, run the SQL from §5.
+2. **PR-A live verification (mlab)**: with daemon built from PR-A, simulate dthn-class flow via `pdx hook --agent cc PdxSubagentStart` then `pdx hook --agent cc PdxStopFailure` with the same `agent_id` and confirm `subagents_json` in DB drops by one ref. Replay with mismatched `agent_id` and confirm: (a) no `mutateSubagentsWithRetry` invocation in trace; (b) frame `Status` still updates to `error` and `LastSeenAt` still refreshes (legacy behaviour preserved).
+3. **PR-A dthn cleanup**: after PR-A merges to main and a fresh daemon binary is deployed, run §5 SQL operational sequence directly. Self-heal observation is **not** the primary recovery path — historical refs whose terminal `StopFailure` is already in the past will never be re-emitted by cc, so observation alone won't drain the accumulated 3944 refs. After SQL cleanup, watch `SELECT pane_id, json_array_length(subagents_json) FROM agent_frames` for one cc Task cycle to confirm zero re-accumulation under live `PdxStopFailure` traffic.
 4. **PR-B unit tests**: `cd spa && npx vitest run` for `useNotificationDispatcher.test.ts` green.
 5. **PR-B manual SPA**: trigger 30 consecutive `derived=error` events for a session in dev; confirm exactly one OS notification fires, unread badge sticks, subsequent same-error events do not re-trigger.
 

--- a/docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md
+++ b/docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md
@@ -1,8 +1,15 @@
 # Spec — Rate-limit subagent cleanup + notification debounce
 
-**Date**: 2026-05-03
+**Date**: 2026-05-03 (v1 → v2)
 **Branch**: `worktree-rate-limit-cleanup`
 **Baseline**: origin/main `401a785c` (alpha.289)
+
+**v2 supersedes v1**. v1 codex review (`task-mopk1n84-e61c4i`, thread `019ded1e-ca04-7583-bfbf-b28d2eee134f`) found 3 P1 + 5 P2 + 1 nit findings. v2 addresses all of them:
+- P1.1 `mutateSubagentsWithRetry` `applied=true` does **not** mean a ref was actually removed (it only signals `UpsertIfUnchanged` succeeded; `LastSeenAt` always refreshes regardless of ref-list change). v2 adds an explicit pre-check via new helper `findNativeRefByID` so we never broadcast a phantom detach.
+- P1.2 dthn cleanup: SQL is the **expected primary cleanup path**, not a fallback; PR-A only handles future StopFailure events, and historical refs whose terminal `StopFailure` predates trace retention will never be re-emitted.
+- P1.3 AC5 99% number arithmetic mismatch (1/90 = 98.89%, not 99%). v2 reframes as "≥98.8% suppression over a 100-event window".
+- P2 fixes: empty-string agent_id test case, 100-event quantitative test, daemon-restart projection replay risk, fixture-replay regression guard, debounce key collision via JSON-encoded array.
+- nit fix: opencode StopFailure emission language tightened.
 **Scope**: Two-phase fix for the dthn-class symptom "subagent dots never go away":
 - **Phase 1 (PR-A, daemon)**: when an agent fires `StopFailure` carrying a subagent's `agent_id` (the documented hook payload pattern when an in-flight Task subagent terminates abnormally — observed empirically in 98% of dthn's 1573 rate-limit episodes), detach the matching native `SubagentRef` from the parent frame. Today this code path is a no-op (`frame_ops.go:288-300`), so native refs accumulate forever.
 - **Phase 2 (PR-B, SPA)**: trailing-edge sliding debounce for `derived='error'` desktop notifications, keyed by `compositeKey + raw_event_name + detail.error`. Suppresses error-storm notification spam while preserving the unread badge.
@@ -99,9 +106,9 @@ case "PdxStopFailure":
 ```
 `agent_id` is in `raw_event` but not in `result.Detail`. Phase 1 must either (a) extend the derive to add `agent_id` to `Detail`, or (b) parse `req.RawEvent` directly in the handler. Option (a) keeps the boundary clean (provider owns the raw→Detail mapping); chosen.
 
-`internal/agent/codex/status.go:67` and `internal/agent/opencode/status.go:27` use the same pattern and need the same one-line addition for parity. opencode plugin currently does not emit `StopFailure` (no upstream event source per `events.go`), but the catalog entry exists; codex emits `StopFailure` from agent SDK.
+`internal/agent/codex/status.go:67` and `internal/agent/opencode/status.go:27` use the same pattern and need the same one-line addition for parity. cc emits `PdxStopFailure` reliably (3005 observed in dthn telemetry). codex emits `PdxStopFailure` from agent SDK (catalog entry `FutureOnly:true`). opencode catalog has the entry but **the plan must verify** against `internal/agent/opencode/plugin_template.go` whether `tool.execute.after` / `session.error` failure paths actually emit `PdxStopFailure` with `agent_id` — if the upstream source is dead, the derive change remains no-op-safe (tests assert nil → empty string round-trip), but the §6.1 opencode test row should be marked "currently inactive emission, derive contract still pinned".
 
-### 2.3 `updateSubagents` is idempotent
+### 2.3 `updateSubagents` is data-idempotent but `mutateSubagentsWithRetry` is **not** observation-idempotent
 
 `internal/module/agent/frame_ops.go:872-895`:
 ```go
@@ -114,7 +121,20 @@ case agentpkg.LifecycleSubagentStop:
     }
     return filtered
 ```
-A `LifecycleSubagentStop` mutation against a ref list that does not contain a matching ref is a no-op (returns equivalent slice). This is the safety net that makes Phase 1 safe even if a `StopFailure` payload's `agent_id` does **not** correspond to a real native subagent.
+A `LifecycleSubagentStop` mutation against a ref list that does not contain a matching ref returns the equivalent (de-duplicated) slice — **data unchanged**.
+
+However, the persistence wrapper `mutateSubagentsWithRetry` (`frame_ops.go:1244-1267`) does NOT propagate this no-op signal:
+```go
+current.Subagents = updateSubagents(current.Subagents, lifecycle, ref)  // may be unchanged
+current.LastSeenAt = broadcastTs                                        // ALWAYS refreshes
+ok, stored, err := m.frames.UpsertIfUnchanged(current, expected)        // commits the row
+if ok {
+    return true, stored, nil  // ← `applied=true` even when Subagents didn't change
+}
+```
+`applied=true` only signals "DB write succeeded under optimistic-concurrency", not "the target ref was actually present and detached". Any caller that interprets `applied=true` as proof of detach will broadcast a phantom event.
+
+**Implication for Phase 1**: PR-A must pre-check ref presence via a pure read helper (§3.2) before invoking `mutateSubagentsWithRetry`. The mutate helper is still safe to call on a missing ref (writes the same `Subagents` back with refreshed `LastSeenAt`), but the caller must not claim a detach happened.
 
 ### 2.4 `subagentRefMatches` for native refs
 
@@ -155,41 +175,80 @@ When the upstream payload omits `agent_id` (e.g. main-session `StopFailure`), `r
 
 `frame_ops.go:288` `case agentpkg.LifecycleStop, agentpkg.LifecycleStopFailure:` — split the joint case:
 
+New pure helper in `frame_ops.go` (placed adjacent to `findProxyRefByBroker`):
+```go
+// findNativeRefByID returns the index of a native (non-proxy) ref with the
+// given ID, or -1 when no such ref exists. Pure read, no side effects.
+// Callers use this to gate destructive native-ref operations so that a
+// missing ref is never reported as a successful detach.
+func findNativeRefByID(refs []agentpkg.SubagentRef, id string) int {
+    if id == "" {
+        return -1
+    }
+    for i, r := range refs {
+        if !r.IsProxy && r.ID == id {
+            return i
+        }
+    }
+    return -1
+}
+```
+
+`applyFrameEvent` switch:
 ```go
 case agentpkg.LifecycleStopFailure:
     // Native subagent failure path: payload's agent_id identifies the
     // failing subagent (not the main session). Empirically this is how
     // cc reports rate-limit and other subagent terminations (~98% of
-    // observed Task failures in dthn telemetry, 2026-05-03). When the
-    // payload carries an agent_id and the parent frame holds a
-    // matching native ref, detach it idempotently. updateSubagents is
-    // a no-op for non-matching IDs, so a payload that doesn't actually
-    // refer to a subagent (e.g. main-session StopFailure with a stale
-    // agent_id) is naturally safe.
+    // observed Task failures in dthn telemetry, 2026-05-03).
+    //
+    // Two-step gate: pre-check ref presence with the pure helper, then
+    // mutate. mutateSubagentsWithRetry's `applied=true` does NOT mean a
+    // ref was removed — it only means UpsertIfUnchanged committed
+    // (LastSeenAt always refreshes). Without the pre-check we'd
+    // broadcast a phantom "detached" trace step on every mismatched
+    // payload (§2.3).
     if frame != nil {
         agentID, _ := result.Detail["agent_id"].(string)
-        if agentID != "" {
-            ref := agentpkg.SubagentRef{
-                ID:   agentID,
-                Type: frame.AgentType,  // §2.4 invariant: native match by ID alone
-            }
-            applied, stored, merr := m.mutateSubagentsWithRetry(*frame, agentpkg.LifecycleSubagentStop, ref, broadcastTs)
-            if merr != nil {
-                return nil, FrameTraceMeta{}, merr
-            }
-            if applied {
-                projection, perr := m.projectPane(req.TmuxPaneID)
-                return projection, FrameTraceMeta{
-                    FrameID:       stored.FrameID,
-                    ParentFrameID: stored.ParentFrameID,
-                    Decision:      "updated_frame",
-                    Reason:        "native_subagent_detached_on_stop_failure",
-                    Before:        before,
-                    After:         summarizeFrame(&stored),
-                }, perr
-            }
+        if agentID == "" || findNativeRefByID(frame.Subagents, agentID) < 0 {
+            // No payload agent_id, or payload references a ref we don't
+            // hold. Trace as no_match for observability; preserve legacy
+            // post-switch UpdateHookPath / projection refresh by breaking.
+            // Note: we do NOT mutate frame here. Even though
+            // mutateSubagentsWithRetry would be data-safe (returns same
+            // slice), it would refresh LastSeenAt and consume an OCC
+            // attempt for no benefit.
+            break
         }
-        break  // no agent_id, or no matching ref — preserves legacy behaviour
+        ref := agentpkg.SubagentRef{
+            ID:   agentID,
+            Type: frame.AgentType,  // §2.4: native match by ID alone
+        }
+        applied, stored, merr := m.mutateSubagentsWithRetry(*frame, agentpkg.LifecycleSubagentStop, ref, broadcastTs)
+        if merr != nil {
+            return nil, FrameTraceMeta{}, merr
+        }
+        if !applied {
+            // Frame deleted mid-flight (concurrent sweep / SessionEnd).
+            // Trace as frame_missing so handler treats it like the
+            // frame == nil branch.
+            projection, perr := m.projectPane(req.TmuxPaneID)
+            return projection, FrameTraceMeta{
+                Decision: "skipped",
+                Reason:   "frame_missing",
+                Before:   before,
+                After:    map[string]any{},
+            }, perr
+        }
+        projection, perr := m.projectPane(req.TmuxPaneID)
+        return projection, FrameTraceMeta{
+            FrameID:       stored.FrameID,
+            ParentFrameID: stored.ParentFrameID,
+            Decision:      "updated_frame",
+            Reason:        "native_subagent_detached_on_stop_failure",
+            Before:        before,
+            After:         summarizeFrame(&stored),
+        }, perr
     }
     // frame == nil: fall through to existing codex/proxy detach below.
     fallthrough
@@ -197,7 +256,11 @@ case agentpkg.LifecycleStop:
     // ... existing logic at frame_ops.go:288-424 unchanged ...
 ```
 
-Trace reason `native_subagent_detached_on_stop_failure` is new; existing `proxy_subagent_detached_on_stop` covers the `frame==nil` branch and is unchanged.
+Two new trace reasons:
+- `native_subagent_detached_on_stop_failure` — agent_id matched a native ref, ref removed
+- (no new reason for the no-match path — falling through to legacy `break` reaches the post-switch `UpdateHookPath` path; existing trace pipeline records that branch)
+
+Existing `proxy_subagent_detached_on_stop` covers the `frame==nil` branch and is unchanged.
 
 ### 3.3 Why `Type: frame.AgentType` (not raw `agent_type` from payload)
 
@@ -209,9 +272,10 @@ If a `PdxStopFailure` payload carries an `agent_id` that **happens** to collide 
 
 Mitigation:
 - Native `agent_id` is cc-controlled (cc's internal Task ID). Collision requires cc to issue identical IDs to two different subagents in the same frame, which contradicts cc's own Task tool semantics.
-- Even if collision happens, `updateSubagents` removes one ref; if a later `PdxSubagentStop` re-fires with the same ID against an empty list, that's also a no-op (idempotent). No status-leak corruption — the worst observable effect is a transiently-missing dot.
+- Pre-check via `findNativeRefByID` (§3.2) ensures the detach ONLY fires when a matching ref actually exists. A spoofed/stale `agent_id` that doesn't match any held ref is a silent no-op trace step, not a phantom detach broadcast.
+- Even if collision happens and detach fires, the worst observable effect is a transiently-missing dot — the genuinely-running subagent's eventual `SubagentStop` against an empty list is itself a no-op (`updateSubagents` returns equivalent slice). No status corruption.
 
-This risk is judged acceptable in exchange for fixing the unbounded accumulation. AC4 enforces the idempotency contract via tests.
+This risk is judged acceptable in exchange for fixing the unbounded accumulation. AC4 enforces the no-phantom-broadcast contract via tests.
 
 ### 3.5 Trace observability
 
@@ -236,15 +300,17 @@ User-facing semantics: "one notification per error episode, where an episode end
 ### 4.2 Key composition
 
 ```ts
-const debounceKey = `${compositeKey}|${normalizedEventName}|${String(detailError ?? '')}`
+const debounceKey = JSON.stringify([compositeKey, normalizedEventName, String(detailError ?? '')])
 ```
+
+`JSON.stringify` over a 3-element array is collision-free across any string content (separator characters in `compositeKey` / `eventName` / `detailError` are escaped, unlike a `|`-joined string). Stable string output that survives Map key equality.
 
 Three components:
 1. `compositeKey` (host:sessionCode) — different sessions/hosts notify independently.
 2. `normalizedEventName` — different event names (e.g. `StopFailure` vs `Stop`) notify independently.
 3. `detail.error` — `rate_limit` storm doesn't suppress a different error type (`auth_failed`, etc.) on the same session.
 
-`detailError` defaults to empty string (not undefined) so `error=undefined` events still get a stable key.
+`detailError` defaults to empty string (not undefined) so `error=undefined` events still get a stable key. All "missing-error" events on a session collapse to one debounce bucket; this is the conservative choice (under-notify rather than over-notify on unknown error categories).
 
 ### 4.3 State location
 
@@ -286,10 +352,18 @@ function shouldNotify(args): boolean {
 
 ## 5. Design — Phase 3 (operational)
 
-After PR-A merges and a fresh daemon restart picks up the binary:
+After PR-A merges and a fresh daemon binary is in place, **SQL cleanup is the expected primary path**, not a fallback.
 
-1. Observe whether `agent_frames.subagents_json` for pane `%50` (dthn) self-heals when cc fires the next `PdxStopFailure` (each one detaches one ref).
-2. If self-heal is too slow (3944 refs × ~0.7s/event ≈ 45 min), one-shot SQL: `UPDATE agent_frames SET subagents_json='[]' WHERE pane_id='%50';` followed by `pdx serve` restart so the in-memory `m.subagents` map reloads from DB. SPA reconciles via the next hook broadcast.
+Reasoning: PR-A only handles `PdxStopFailure` events arriving *after* the fix is deployed. dthn's 3944 historical refs were terminated by `PdxStopFailure` events that already happened — their corresponding rows are recorded in `agent_trace_chains` (those still inside retention) and gone from the upstream stream. cc's hook contract issues each `agent_id` exactly once across `SubagentStart` / `SubagentStop` / `StopFailure`; a ref that already received its terminal event will never receive another. Therefore self-heal cannot recover historical refs.
+
+Operational sequence:
+1. Confirm PR-A daemon binary is deployed (`pdx --version` ≥ next alpha).
+2. Stop daemon (`brew services stop pdx` or signal handler).
+3. SQL: `UPDATE agent_frames SET subagents_json='[]' WHERE pane_id='%50';` (and any other pane suffering the same accumulation — query first: `SELECT pane_id, json_array_length(subagents_json) FROM agent_frames WHERE json_array_length(subagents_json) > 100;`).
+4. Start daemon. In-memory `m.subagents` map rebuilds from DB on first projection.
+5. SPA reconciles via the next hook broadcast (or via WS replay on reconnect).
+
+Self-heal observation is **opportunistic** — useful only if a long-running cc session is still firing live `PdxStopFailure` events whose `agent_id` happens to match an existing ref (rare, since terminated subagents don't fire again).
 
 Not a code change. Captured here so PR-A's verification plan can reference it.
 
@@ -302,12 +376,16 @@ Not a code change. Captured here so PR-A's verification plan can reference it.
 | Test | Behaviour asserted |
 |---|---|
 | `TestStopFailure_NativeDetach_Hits` | `frame.Subagents` has native ref `{ID: X}`; `PdxStopFailure` payload `{agent_id: X}` arrives; ref removed; trace reason `native_subagent_detached_on_stop_failure` |
-| `TestStopFailure_NativeDetach_Misses_Idempotent` | `frame.Subagents` empty; payload `{agent_id: X}`; no error, no broadcast change, trace reason `proxy_subagent_stop_no_match` (existing) or new `native_subagent_no_match` — choose during plan |
-| `TestStopFailure_NoAgentId_LegacyBehaviour` | payload omits `agent_id`; existing `frame != nil` break path preserved; no detach, no trace change |
+| `TestStopFailure_NativeDetach_Misses_NoMutation` | `frame.Subagents` empty; payload `{agent_id: X}`; **no `mutateSubagentsWithRetry` call**, no `LastSeenAt` refresh, no broadcast change, no trace step claiming detach. Asserts pre-check correctness. |
+| `TestStopFailure_NoAgentId_LegacyBehaviour` | payload omits `agent_id` field entirely; existing `frame != nil` break path preserved; no detach, no trace change |
+| `TestStopFailure_EmptyAgentId_LegacyBehaviour` | payload contains `agent_id: ""` (explicit empty string from upstream); same behaviour as missing field. Locks down the empty-string branch since `findNativeRefByID` returns -1 early when id is empty |
 | `TestStopFailure_PreservesProxyRefs` | `frame.Subagents` has `{ID:X, IsProxy:false}` AND `{ID:Y, IsProxy:true, SourcePID:P}`; payload `{agent_id:X}`; only X removed, Y untouched |
 | `TestStopFailure_FrameNil_FallthroughToProxyDetach` | `frame == nil`; payload `{agent_id:X}`; existing codex/proxy detach branch reached unchanged |
+| `TestStopFailure_FrameDeletedMidFlight` | `findNativeRefByID` returns ≥0 but `mutateSubagentsWithRetry` returns `applied=false` (concurrent SessionEnd / sweep deleted frame); trace reason `frame_missing` |
+| `TestStopFailure_FixtureReplay_DthnPayload` | Replay a recorded production `PdxStopFailure` payload from dthn telemetry against a frame seeded with the corresponding native ref; assert ref removed. Acts as version-pinned regression guard against cc upstream payload-shape drift |
 | `TestStopFailureDerive_AgentIdInDetail` (per provider × 3) | cc/codex/opencode `deriveStatus("PdxStopFailure", {agent_id: "x"})` returns `Detail["agent_id"] == "x"` |
-| `TestStopFailureDerive_AgentIdMissing` | derive omits `agent_id` from raw → `Detail["agent_id"] == nil` |
+| `TestStopFailureDerive_AgentIdMissing` | derive when raw payload omits `agent_id` field → `Detail["agent_id"] == nil` (cc/codex) or absent (opencode `detailSubset`) |
+| `TestFindNativeRefByID_*` | Pure helper unit tests: hits native ref by ID; returns -1 for proxy refs with same ID; returns -1 for empty id; returns -1 for not-found |
 
 Optimistic-concurrency retry path (`mutateSubagentsWithRetry`) is already covered by existing tests; this PR doesn't change its contract.
 
@@ -318,21 +396,25 @@ Optimistic-concurrency retry path (`mutateSubagentsWithRetry`) is already covere
 | `debounce__first_error_passes` | First `derived=error` for a key returns `shouldNotify=true` |
 | `debounce__second_error_within_window_blocked_and_extends` | Second arrival 30s later: `false`, `silentUntil` extended to `t2 + 60s` |
 | `debounce__error_after_silence_window_passes` | Arrival 70s after last: `true` (window expired) |
-| `debounce__different_keys_independent` | Same session, different `detail.error` → both pass; same error, different sessions → both pass |
+| `debounce__storm_100_events_yields_one_notification` | Quantitative AC5 anchor: drive 100 consecutive `derived=error` events on the same key over 60s simulated time; assert exactly **1** call passes through. Also asserts the sliding extension never lets a second notification slip through at the original window boundary |
+| `debounce__different_keys_independent` | Same session, different `detail.error` → both pass; same error, different sessions → both pass; same error, same session, different `eventName` → both pass |
+| `debounce__key_uses_json_array_not_pipe_join` | Key built from `compositeKey` containing `\|` and `detail.error` containing `\|` does NOT collide. Locks down JSON-stringify approach |
 | `debounce__clear_session_resets` | `clearSession` removes key; next arrival passes |
+| `debounce__remove_host_resets` | `removeHost` removes all keys for that host; next arrival on a session under that host passes |
 | `debounce__waiting_not_debounced` | `derived=waiting` for the same session passes every time |
-| `debounce__unread_badge_unaffected` | Even when notification suppressed, `useAgentStore.unread[ck]=true` still set |
-| `debounce__ttl_cleanup` | After 5×WINDOW_MS no activity, `shouldNotify` removes stale entries |
+| `debounce__unread_badge_unaffected` | Even when notification suppressed, `useAgentStore.unread[ck]=true` still set by `handleNormalizedEvent` |
+| `debounce__ttl_cleanup` | After 5×WINDOW_MS no activity for a key, `shouldNotify` removes stale entries (memory bound test) |
+| `debounce__test_reset_helper` | `__resetDebounceStateForTests` clears module-level Map between tests so test order doesn't matter |
 
 ---
 
 ## 7. Acceptance criteria
 
-- **AC1**: dthn class symptom gone — after PR-A, `agent_frames.subagents_json` for any cc pane no longer accumulates beyond live subagent count.
+- **AC1**: dthn class symptom gone — after PR-A + the §5 SQL cleanup, `agent_frames.subagents_json` for any cc pane no longer accumulates beyond live subagent count under sustained `PdxStopFailure` traffic.
 - **AC2**: Existing `Stop`/`StopFailure` proxy-detach behaviour for `frame == nil` path bit-identical (regression guard via existing `frame_ops_l2_test.go`).
-- **AC3**: `PdxStopFailure` with no `agent_id` (main-session failure) preserves legacy behaviour.
-- **AC4**: PR-A is idempotent — replaying any `PdxStopFailure` against an already-detached ref is a no-op.
-- **AC5**: PR-B suppresses ≥99% of redundant `derived=error` notifications during a 1.5 Hz storm (60s window @ 1.5 Hz = 1 notification per 90 events).
+- **AC3**: `PdxStopFailure` with no `agent_id` (or empty-string `agent_id`, or `agent_id` not matching any held native ref) preserves legacy behaviour: no mutation, no phantom trace step.
+- **AC4**: PR-A never broadcasts a phantom "detached" event. The pre-check `findNativeRefByID` ensures the `native_subagent_detached_on_stop_failure` trace reason is only emitted when a ref was actually removed.
+- **AC5**: PR-B suppresses **≥98.8%** of redundant `derived=error` notifications during a sustained storm. Reference scenario: 100 consecutive same-key events within 60s yields exactly 1 notification (99% suppression). Real-world dthn-class storm at 1.5 Hz over 33 min ≈ 3000 events / 1 notification = 99.97%.
 - **AC6**: PR-B preserves unread badge semantics — sticky after first error, doesn't clear on subsequent debounced arrivals.
 - **AC7**: PR-B `clearSession` / `removeHost` clean debounce state for the affected keys.
 - **AC8**: Both PRs ship with no new lint / type errors and full test coverage of the matrix in §6.
@@ -344,11 +426,13 @@ Optimistic-concurrency retry path (`mutateSubagentsWithRetry`) is already covere
 
 | # | Risk | Mitigation / acceptance |
 |---|---|---|
-| R1 | cc upstream changes how `StopFailure` payload is shaped | Phase 1 idempotent; if `agent_id` no longer appears, code becomes silent no-op. Plan §verification has live-fixture replay step |
-| R2 | False-positive native detach (§3.4) | Bounded blast radius (one missing dot, transient); idempotency ACL covers replay |
+| R1 | cc upstream changes how `StopFailure` payload is shaped | If `agent_id` no longer appears, pre-check returns -1 → silent no-op (legacy break path). `TestStopFailure_FixtureReplay_DthnPayload` (§6.1) acts as version-pinned regression guard so silent failure to detach is detected at PR-CI time, not runtime |
+| R2 | False-positive native detach (§3.4) | Pre-check via `findNativeRefByID` ensures detach only fires on a real held ref. Worst case: one missing dot, transient |
 | R3 | PR-B 60s window misses a "second wave" rate-limit storm | User intent (§1.4): cc UI shows error already; missed notification is preferable to flood. Window can be tuned later via env/config if needed |
-| R4 | Module-level Map memory leak | TTL self-cleanup in §4.4 + per-session cleanup hooks bound the working set |
+| R4 | Module-level Map memory leak | TTL self-cleanup in §4.4 + per-session cleanup hooks bound the working set. Test: `debounce__ttl_cleanup` |
 | R5 | Different cc Task subagent's `agent_id` collides with a live one | cc's Task tool issues unique IDs by design; collision is a cc upstream bug, not ours to defend against |
+| R6 | dthn-style accumulated `subagents_json` (3944 refs) bloats projection / replay cost on daemon restart | Phase 3 SQL cleanup is the **expected** primary mitigation (§5 reframed). PR-A alone cannot recover historical refs. Once cleared, ongoing PR-A behaviour prevents re-accumulation. Out of scope: schema-level GC like `last_seen_at` per ref (would require migration; not justified for a one-time cleanup) |
+| R7 | opencode `PdxStopFailure` upstream emission status uncertain | §2.2 / §9 acknowledge the uncertainty. Plan must verify against opencode plugin fixtures before finalizing the opencode derive change. If opencode never emits this event in practice, the derive change is dead-code-safe (no behavioural drift) |
 
 ---
 
@@ -376,6 +460,6 @@ Optimistic-concurrency retry path (`mutateSubagentsWithRetry`) is already covere
 ## 11. PR sequencing
 
 - **PR-A first**: correctness fix; lands without behavioural change for existing `frame == nil` paths.
-- **dthn cleanup** (operational, ad-hoc): immediately after PR-A merges and daemon restarts.
+- **dthn cleanup** (operational, expected primary path per §5): immediately after PR-A merges and daemon restarts. SQL `UPDATE agent_frames SET subagents_json='[]'` for affected panes.
 - **PR-B second**: UX-only; depends conceptually on PR-A (without it, debounce hides the symptom of unbounded ref accumulation), but does not technically depend on PR-A code changes — could land independently if needed.
 - **One bump PR per merged feature PR**, per CLAUDE.md convention.

--- a/internal/agent/cc/status.go
+++ b/internal/agent/cc/status.go
@@ -81,12 +81,19 @@ func deriveCCStatus(purdexName string, rawEvent json.RawMessage) agent.DeriveRes
 		}
 
 	case "PdxStopFailure":
+		// agent_id surfaces the failing subagent's identity (cc emits this
+		// for in-flight Task subagents that terminate abnormally — the
+		// 1573-event dthn telemetry sample carried it on 97.9% of
+		// chains). Pass through nil-safe; downstream applyFrameEvent
+		// pre-checks ref presence before mutating, so a nil agent_id is
+		// harmless.
 		return agent.DeriveResult{
 			Valid:  true,
 			Status: agent.StatusError,
 			Detail: map[string]any{
 				"error_details": raw["error_details"],
 				"error":         raw["error"],
+				"agent_id":      raw["agent_id"],
 			},
 		}
 

--- a/internal/agent/cc/status_test.go
+++ b/internal/agent/cc/status_test.go
@@ -111,6 +111,39 @@ func TestDeriveCCStatus_PdxStopFailure_Error(t *testing.T) {
 	}
 }
 
+// TestDeriveCCStatus_PdxStopFailure_AgentIdInDetail pins the spec §3.1
+// contract: cc PdxStopFailure derive must surface raw["agent_id"] into
+// Detail so downstream applyFrameEvent can pre-check ref presence and
+// detach the matching native SubagentRef on rate-limit storms.
+func TestDeriveCCStatus_PdxStopFailure_AgentIdInDetail(t *testing.T) {
+	r := deriveViaProvider("PdxStopFailure", map[string]any{
+		"agent_id": "aac56e6312afceb04",
+		"error":    "rate_limit",
+	})
+	if !r.Valid {
+		t.Fatalf("expected Valid=true, got %+v", r)
+	}
+	if r.Detail["agent_id"] != "aac56e6312afceb04" {
+		t.Fatalf("Detail[agent_id] = %#v, want aac56e6312afceb04", r.Detail["agent_id"])
+	}
+}
+
+// TestDeriveCCStatus_PdxStopFailure_AgentIdMissing locks down the nil-safe
+// branch: when raw payload omits agent_id, Detail["agent_id"] must be nil
+// (key set, value nil) so handler's type assertion `agentID, _ := ...(string)`
+// yields "" and the legacy break path fires.
+func TestDeriveCCStatus_PdxStopFailure_AgentIdMissing(t *testing.T) {
+	r := deriveViaProvider("PdxStopFailure", map[string]any{
+		"error": "rate_limit",
+	})
+	if !r.Valid {
+		t.Fatalf("expected Valid=true, got %+v", r)
+	}
+	if r.Detail["agent_id"] != nil {
+		t.Fatalf("Detail[agent_id] = %#v, want nil for missing key", r.Detail["agent_id"])
+	}
+}
+
 func TestDeriveCCStatus_PdxSessionEnd_Clear(t *testing.T) {
 	r := deriveViaProvider("PdxSessionEnd", map[string]any{})
 	if !r.Valid || r.Status != agent.StatusClear {

--- a/internal/agent/codex/status.go
+++ b/internal/agent/codex/status.go
@@ -52,12 +52,16 @@ func deriveCodexStatus(eventName string, rawEvent json.RawMessage) agent.DeriveR
 		return agent.DeriveResult{Valid: true, Status: agent.StatusIdle}
 
 	case "PdxStopFailure":
+		// agent_id surfaces the failing subagent's identity for parity
+		// with cc; nil-safe pass-through, downstream pre-checks before
+		// mutating native ref list.
 		return agent.DeriveResult{
 			Valid:  true,
 			Status: agent.StatusError,
 			Detail: map[string]any{
 				"error_details": raw["error_details"],
 				"error":         raw["error"],
+				"agent_id":      raw["agent_id"],
 			},
 		}
 

--- a/internal/agent/codex/status_test.go
+++ b/internal/agent/codex/status_test.go
@@ -181,6 +181,30 @@ func TestCodexDeriveStatus_PdxStopFailure(t *testing.T) {
 	}
 }
 
+// TestCodexDeriveStatus_PdxStopFailure_AgentIdInDetail mirrors cc spec §3.1
+// for codex provider: raw["agent_id"] must surface into Detail so the
+// handler-side native detach branch can read the failing subagent ID.
+func TestCodexDeriveStatus_PdxStopFailure_AgentIdInDetail(t *testing.T) {
+	r := deriveWithRaw("PdxStopFailure", `{"agent_id":"codex-sub-1","error":"rate_limit"}`)
+	if !r.Valid {
+		t.Fatalf("expected Valid, got %+v", r)
+	}
+	if r.Detail["agent_id"] != "codex-sub-1" {
+		t.Fatalf("Detail[agent_id] = %#v, want codex-sub-1", r.Detail["agent_id"])
+	}
+}
+
+// TestCodexDeriveStatus_PdxStopFailure_AgentIdMissing locks down nil-safe.
+func TestCodexDeriveStatus_PdxStopFailure_AgentIdMissing(t *testing.T) {
+	r := deriveWithRaw("PdxStopFailure", `{"error":"rate_limit"}`)
+	if !r.Valid {
+		t.Fatalf("expected Valid, got %+v", r)
+	}
+	if r.Detail["agent_id"] != nil {
+		t.Fatalf("Detail[agent_id] = %#v, want nil for missing key", r.Detail["agent_id"])
+	}
+}
+
 // TestDeriveCodexStatus_PdxPreToolUse asserts PdxPreToolUse returns
 // Valid=true with Status="" so that handler.go does not early-return on the
 // Valid=false branch and the new LifecycleUserPromptSubmit case in

--- a/internal/agent/opencode/status.go
+++ b/internal/agent/opencode/status.go
@@ -25,7 +25,13 @@ func deriveOpenCodeStatus(eventName string, rawEvent json.RawMessage) agent.Deri
 			"stop_source":          "session.status.idle",
 		}}
 	case "PdxStopFailure":
-		return agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: detailSubset(raw, "error", "error_details")}
+		// agent_id surfaces the failing subagent's identity for parity
+		// with cc/codex. opencode plugin_template currently does NOT
+		// emit agent_id on session.error so detailSubset omits the key
+		// in practice — derive contract is pinned for the day the
+		// plugin adds it (no daemon-side change required when that
+		// happens).
+		return agent.DeriveResult{Valid: true, Status: agent.StatusError, Detail: detailSubset(raw, "error", "error_details", "agent_id")}
 	case "PdxSessionEnd":
 		return agent.DeriveResult{Valid: true, Status: agent.StatusClear}
 	default:

--- a/internal/agent/opencode/status_test.go
+++ b/internal/agent/opencode/status_test.go
@@ -90,6 +90,42 @@ func TestOpenCodeDeriveStatus_PdxStopFailure(t *testing.T) {
 	}
 }
 
+// TestOpenCodeDeriveStatus_PdxStopFailure_AgentIdInDetail mirrors spec §3.1
+// for opencode: even though opencode plugin_template currently does not
+// emit agent_id in its session.error payload, the derive contract is pinned
+// for parity so the day the plugin adds it, native detach activates without
+// further daemon code change. detailSubset sets the key only when the raw
+// payload carries it.
+func TestOpenCodeDeriveStatus_PdxStopFailure_AgentIdInDetail(t *testing.T) {
+	r := deriveViaProvider("PdxStopFailure", map[string]any{
+		"agent_id": "opencode-sub-1",
+		"error":    "rate_limit",
+	})
+	if !r.Valid || r.Status != agent.StatusError {
+		t.Fatalf("expected error, got %+v", r)
+	}
+	if r.Detail["agent_id"] != "opencode-sub-1" {
+		t.Fatalf("Detail[agent_id] = %#v, want opencode-sub-1", r.Detail["agent_id"])
+	}
+}
+
+// TestOpenCodeDeriveStatus_PdxStopFailure_AgentIdMissing pins the
+// detailSubset semantics: when raw payload omits agent_id, the key is
+// absent from Detail (not present-with-nil). Handler-side type assertion
+// `Detail["agent_id"].(string)` still yields "" via the zero-value branch
+// so behaviour is identical to cc/codex's nil-key case.
+func TestOpenCodeDeriveStatus_PdxStopFailure_AgentIdMissing(t *testing.T) {
+	r := deriveViaProvider("PdxStopFailure", map[string]any{
+		"error": "rate_limit",
+	})
+	if !r.Valid || r.Status != agent.StatusError {
+		t.Fatalf("expected error, got %+v", r)
+	}
+	if _, present := r.Detail["agent_id"]; present {
+		t.Fatalf("expected Detail[agent_id] absent for missing key (detailSubset omits absent keys), got %#v", r.Detail["agent_id"])
+	}
+}
+
 func TestOpenCodeDeriveStatus_PdxSessionEnd(t *testing.T) {
 	r := deriveViaProvider("PdxSessionEnd", map[string]any{})
 	if !r.Valid || r.Status != agent.StatusClear {

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -325,9 +325,43 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 				// frame's AgentType.
 				Type: frame.AgentType,
 			}
-			applied, stored, merr := m.mutateSubagentsWithRetry(*frame, agentpkg.LifecycleSubagentStop, ref, broadcastTs)
-			if merr != nil {
-				return nil, FrameTraceMeta{}, merr
+			// PR-A round-1 codex review P1 (thread 019ded5d): mutate ref
+			// removal AND Status update in the same UpsertIfUnchanged
+			// transaction. The plain mutateSubagentsWithRetry helper only
+			// touches Subagents+LastSeenAt — using it alone would skip the
+			// post-switch UpdateHookPath path that normally writes
+			// Status=error, leaving the parent frame stuck in its prior
+			// status (e.g. running) after a subagent rate-limit failure.
+			// We mirror mutateSubagentsWithRetry's OCC loop structure but
+			// add a Status field write so detach + status are atomic from
+			// the SPA's viewpoint.
+			current := *frame
+			var stored store.Frame
+			applied := false
+			for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
+				expected := current.LastSeenAt
+				current.Subagents = updateSubagents(current.Subagents, agentpkg.LifecycleSubagentStop, ref)
+				current.Status = result.Status
+				current.LastSeenAt = broadcastTs
+				ok, s, uerr := m.frames.UpsertIfUnchanged(current, expected)
+				if uerr != nil {
+					return nil, FrameTraceMeta{}, uerr
+				}
+				if ok {
+					stored = s
+					applied = true
+					break
+				}
+				reloaded, rerr := m.frames.GetByIdentity(frame.PaneID, frame.PID, frame.ProcessStartTime)
+				if rerr != nil {
+					return nil, FrameTraceMeta{}, rerr
+				}
+				if reloaded == nil {
+					// Frame deleted mid-flight; fall through to
+					// frame_missing trace below.
+					break
+				}
+				current = *reloaded
 			}
 			if !applied {
 				// Frame deleted mid-flight (concurrent SessionEnd or

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -286,160 +286,80 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 			After:         summarizeFrame(&stored),
 		}, err
 	case agentpkg.LifecycleStopFailure:
-		// P1-T3a structural split: case body is a verbatim copy of the
-		// LifecycleStop branch below. P1-T3b will replace this body with
-		// the native subagent detach branch + fallthrough to LifecycleStop
-		// for the frame == nil tail. No behaviour change in this commit.
+		// Native subagent failure path: payload's agent_id identifies
+		// the failing subagent (not the main session). Empirically this
+		// is how cc reports rate_limit and other subagent terminations
+		// (~98% of observed Task failures in dthn telemetry, 2026-05-03,
+		// spec §1.2). Without this branch native SubagentRefs accumulate
+		// forever — the only GC path is LifecycleSessionEnd, which never
+		// fires on a long-running cc session that retries through
+		// rate-limit storms (frame_ops.go old §288-300 was a no-op for
+		// frame != nil).
 		//
-		// L2 codex turn-aware Stop targeted detach (spec §3.3.D + plan
-		// §3 P3-T8a). All detach goes through pane-scan helpers; we never
-		// call findProxyParent on the Stop path because the sender's PPID
-		// chain may have already been torn down by the time the hook
-		// arrives (B1/v2 fix).
-		//
-		// Gate 1 — sender owns its own frame. Standalone agent Stop is
-		// the J3 dispatcher's territory (lights-rebuild ProbeIntent), not
-		// L2 proxy detach (spec §3.3.D + §5 row 12).
+		// Two-step gate: pre-check ref presence with the pure helper,
+		// then mutate. mutateSubagentsWithRetry's `applied=true` does
+		// NOT mean a ref was removed — it only means UpsertIfUnchanged
+		// committed (LastSeenAt always refreshes regardless of whether
+		// the target ref was present, spec §2.3). Without the pre-check
+		// we'd broadcast a phantom "detached" trace step on every
+		// mismatched payload.
 		if frame != nil {
-			break
-		}
-		// Gate 2 — non-codex providers fall back to wildcard process-level
-		// detach (cc/opencode have no per-turn identity). Mirrors the
-		// long-standing PR-2b SessionEnd path.
-		if req.AgentType != "codex" {
-			removed, ownerAfter, ownerBefore, ownerAfterMap, derr := m.removeProxyRefForSender(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, broadcastTs)
-			if derr != nil {
-				return nil, FrameTraceMeta{}, derr
-			}
-			if removed {
-				projection, perr := m.projectPane(req.TmuxPaneID)
-				return projection, FrameTraceMeta{
-					FrameID:       ownerAfter.FrameID,
-					ParentFrameID: ownerAfter.ParentFrameID,
-					Decision:      "updated_frame",
-					Reason:        "proxy_subagent_detached_on_stop",
-					Before:        ownerBefore,
-					After:         ownerAfterMap,
-				}, perr
-			}
-			// No matching ref — fall through to generic post-switch path
-			// so legacy behavior (no frame mutation, projection refresh)
-			// stays observable.
-			break
-		}
-		// Codex three sub-case dispatch (spec §3.3.D table).
-		turnID := parseCodexTurnID(req.RawEvent)
-		if turnID != "" {
-			// (a) Targeted detach by (PID, StartTime, TurnID).
-			removed, ownerAfter, ownerBefore, ownerAfterMap, derr := m.removeProxyRefForSenderTurn(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, turnID, broadcastTs)
-			if derr != nil {
-				return nil, FrameTraceMeta{}, derr
-			}
-			if removed {
-				projection, perr := m.projectPane(req.TmuxPaneID)
-				return projection, FrameTraceMeta{
-					FrameID:       ownerAfter.FrameID,
-					ParentFrameID: ownerAfter.ParentFrameID,
-					Decision:      "updated_frame",
-					Reason:        "proxy_subagent_detached_on_stop_turn",
-					Before:        ownerBefore,
-					After:         ownerAfterMap,
-				}, perr
-			}
-			// Stop's turn doesn't match any live ref. Could be late Stop
-			// after a turn-change upsert overwrote SourceTurnID, or a
-			// stale-tombstone Stop after a previous detach (idempotent
-			// no-op). Trace stop_no_match either way.
-			projection, perr := m.projectPane(req.TmuxPaneID)
-			return projection, FrameTraceMeta{
-				Decision: "skipped",
-				Reason:   "proxy_subagent_stop_no_match",
-				Before:   map[string]any{},
-				After:    map[string]any{},
-			}, perr
-		}
-		// (b)/(c) — codex Stop with empty/parse-failed turn_id. Pane-scan
-		// for the matching broker ref (PID, StartTime) to make the
-		// fallback decision; any non-matching broker's SourceTurnID is
-		// irrelevant (H1/v2 fix).
-		paneFrames, perr := m.frames.ListByPane(req.TmuxPaneID)
-		if perr != nil {
-			return nil, FrameTraceMeta{}, perr
-		}
-		var matched *agentpkg.SubagentRef
-		for i := range paneFrames {
-			idx := findProxyRefByBroker(paneFrames[i].Subagents, req.SenderPID, req.SenderStartTime)
-			if idx >= 0 {
-				ref := paneFrames[i].Subagents[idx]
-				matched = &ref
+			agentID, _ := result.Detail["agent_id"].(string)
+			if agentID == "" || findNativeRefByID(frame.Subagents, agentID) < 0 {
+				// No payload agent_id, or payload references a ref we
+				// don't hold. Trace as no-detach for observability;
+				// preserve legacy post-switch UpdateHookPath +
+				// projection refresh by breaking. We do NOT mutate
+				// frame here — even though mutateSubagentsWithRetry
+				// would be data-safe (returns same slice), it would
+				// refresh LastSeenAt and consume an OCC attempt for
+				// no benefit.
 				break
 			}
-		}
-		if matched == nil {
-			// No broker ref to detach — silently drop the Stop. Trace as
-			// stop_no_match so the chain remains observable; this also
-			// covers idempotent re-Stop after a previous successful
-			// detach (row 14 lower-confidence branch).
-			projection, perr2 := m.projectPane(req.TmuxPaneID)
+			ref := agentpkg.SubagentRef{
+				ID: agentID,
+				// Type: native ref match is by ID alone (spec §2.4 +
+				// subagentRefMatches at frame_ops.go:913); Type is
+				// informational. Mirror the SubagentStart construction
+				// pattern at frame_ops.go:171-184 by using the parent
+				// frame's AgentType.
+				Type: frame.AgentType,
+			}
+			applied, stored, merr := m.mutateSubagentsWithRetry(*frame, agentpkg.LifecycleSubagentStop, ref, broadcastTs)
+			if merr != nil {
+				return nil, FrameTraceMeta{}, merr
+			}
+			if !applied {
+				// Frame deleted mid-flight (concurrent SessionEnd or
+				// sweep deleted the row between our pre-check and the
+				// UpsertIfUnchanged). Trace as frame_missing — the
+				// existing reason already used elsewhere for
+				// "row disappeared between read and write".
+				projection, perr := m.projectPane(req.TmuxPaneID)
+				return projection, FrameTraceMeta{
+					Decision: "skipped",
+					Reason:   "frame_missing",
+					Before:   before,
+					After:    map[string]any{},
+				}, perr
+			}
+			projection, perr := m.projectPane(req.TmuxPaneID)
 			return projection, FrameTraceMeta{
-				Decision: "skipped",
-				Reason:   "proxy_subagent_stop_no_match",
-				Before:   map[string]any{},
-				After:    map[string]any{},
-			}, perr2
-		}
-		if matched.SourceTurnID != "" {
-			// (b) Matching broker has a live SourceTurnID (a previous
-			// upsert recorded a turn_id). Stop with empty turn_id is
-			// almost certainly a malformed payload, NOT a legitimate
-			// "broker is finished" signal — keep the ref so the
-			// conservative behavior preserves the lit dot until either
-			// the next upsert or governance sweep clears it.
-			projection, perr2 := m.projectPane(req.TmuxPaneID)
-			return projection, FrameTraceMeta{
-				Decision: "skipped",
-				Reason:   "proxy_subagent_stop_parse_failed",
-				Before:   map[string]any{},
-				After:    map[string]any{},
-			}, perr2
-		}
-		// (c) Matching broker has empty SourceTurnID (SessionStart
-		// attached but no UserPromptSubmit/PreToolUse upsert ever
-		// recorded a turn) → empty-turn-only detach. Round-2 A1: a
-		// process-level wildcard here would TOCTOU-race a concurrent
-		// UserPromptSubmit that upgrades the ref to turn-aware between
-		// our ListByPane scan above and the detach helper. Re-verify
-		// SourceTurnID == "" inside the optimistic-concurrency loop by
-		// reusing removeProxyRefForSenderTurn with turnID == "" — the
-		// match condition becomes (PID, StartTime, SourceTurnID == "")
-		// and any concurrent upgrade falls into the no-match branch
-		// (proxy_subagent_stop_no_match below).
-		removed, ownerAfter, ownerBefore, ownerAfterMap, derr := m.removeProxyRefForSenderTurn(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, "", broadcastTs)
-		if derr != nil {
-			return nil, FrameTraceMeta{}, derr
-		}
-		if removed {
-			projection, perr2 := m.projectPane(req.TmuxPaneID)
-			return projection, FrameTraceMeta{
-				FrameID:       ownerAfter.FrameID,
-				ParentFrameID: ownerAfter.ParentFrameID,
+				FrameID:       stored.FrameID,
+				ParentFrameID: stored.ParentFrameID,
 				Decision:      "updated_frame",
-				Reason:        "proxy_subagent_detached_on_stop",
-				Before:        ownerBefore,
-				After:         ownerAfterMap,
-			}, perr2
+				Reason:        "native_subagent_detached_on_stop_failure",
+				Before:        before,
+				After:         summarizeFrame(&stored),
+			}, perr
 		}
-		// Pane-scan saw a matching ref but the helper found nothing —
-		// concurrent writer detached between scan and helper. Trace
-		// stop_no_match so the chain accurately reflects "ref already
-		// gone" without claiming to have detached it twice.
-		projection, perr2 := m.projectPane(req.TmuxPaneID)
-		return projection, FrameTraceMeta{
-			Decision: "skipped",
-			Reason:   "proxy_subagent_stop_no_match",
-			Before:   map[string]any{},
-			After:    map[string]any{},
-		}, perr2
+		// frame == nil: collapse onto the existing LifecycleStop body so
+		// codex turn-aware proxy detach + cc/opencode wildcard
+		// process-level detach paths are reused unchanged. The
+		// `if frame != nil { break }` guard at the top of the
+		// LifecycleStop case body is a no-op here because frame is
+		// nil by precondition.
+		fallthrough
 	case agentpkg.LifecycleStop:
 		// L2 codex turn-aware Stop targeted detach (spec §3.3.D + plan
 		// §3 P3-T8a). All detach goes through pane-scan helpers; we never

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -325,50 +325,35 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 				// frame's AgentType.
 				Type: frame.AgentType,
 			}
-			// PR-A round-1 codex review P1 (thread 019ded5d): mutate ref
-			// removal AND Status update in the same UpsertIfUnchanged
-			// transaction. The plain mutateSubagentsWithRetry helper only
-			// touches Subagents+LastSeenAt — using it alone would skip the
-			// post-switch UpdateHookPath path that normally writes
-			// Status=error, leaving the parent frame stuck in its prior
-			// status (e.g. running) after a subagent rate-limit failure.
-			// We mirror mutateSubagentsWithRetry's OCC loop structure but
-			// add a Status field write so detach + status are atomic from
-			// the SPA's viewpoint.
-			current := *frame
-			var stored store.Frame
-			applied := false
-			for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
-				expected := current.LastSeenAt
-				current.Subagents = updateSubagents(current.Subagents, agentpkg.LifecycleSubagentStop, ref)
-				current.Status = result.Status
-				current.LastSeenAt = broadcastTs
-				ok, s, uerr := m.frames.UpsertIfUnchanged(current, expected)
-				if uerr != nil {
-					return nil, FrameTraceMeta{}, uerr
-				}
-				if ok {
-					stored = s
-					applied = true
-					break
-				}
-				reloaded, rerr := m.frames.GetByIdentity(frame.PaneID, frame.PID, frame.ProcessStartTime)
-				if rerr != nil {
-					return nil, FrameTraceMeta{}, rerr
-				}
-				if reloaded == nil {
-					// Frame deleted mid-flight; fall through to
-					// frame_missing trace below.
-					break
-				}
-				current = *reloaded
+			// PR-A round-2 codex review (threads 019ded61/62/63):
+			// mutateSubagentsAndStatusWithRetry handles three concerns:
+			//  1. atomic ref removal + Status=error write (R1 P1 fix)
+			//  2. per-attempt ref-presence re-check (R2 phantom-detach fix)
+			//  3. retry exhaustion vs frame deletion distinguished
+			outcome, stored, merr := m.mutateSubagentsAndStatusWithRetry(*frame, ref, result.Status, broadcastTs)
+			if merr != nil {
+				// Retry exhausted (frame still exists but every
+				// UpsertIfUnchanged conflicted). Surface as handler
+				// error per mutateSubagentsWithRetry contract.
+				return nil, FrameTraceMeta{}, merr
 			}
-			if !applied {
-				// Frame deleted mid-flight (concurrent SessionEnd or
-				// sweep deleted the row between our pre-check and the
-				// UpsertIfUnchanged). Trace as frame_missing — the
-				// existing reason already used elsewhere for
-				// "row disappeared between read and write".
+			switch outcome {
+			case detachOutcomeDetached:
+				projection, perr := m.projectPane(req.TmuxPaneID)
+				return projection, FrameTraceMeta{
+					FrameID:       stored.FrameID,
+					ParentFrameID: stored.ParentFrameID,
+					Decision:      "updated_frame",
+					Reason:        "native_subagent_detached_on_stop_failure",
+					Before:        before,
+					After:         summarizeFrame(&stored),
+				}, perr
+			case detachOutcomeFrameMissing:
+				// Concurrent SessionEnd / sweep deleted the row
+				// between our pre-check and the retry. Use the
+				// existing frame_missing reason already used
+				// elsewhere for "row disappeared between read and
+				// write".
 				projection, perr := m.projectPane(req.TmuxPaneID)
 				return projection, FrameTraceMeta{
 					Decision: "skipped",
@@ -376,16 +361,17 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 					Before:   before,
 					After:    map[string]any{},
 				}, perr
+			case detachOutcomeRefAlreadyAbsent:
+				// Race lost — another writer detached the same ref
+				// between our pre-check and a retry baseline. We
+				// did NOT mutate; fall through to legacy
+				// post-switch UpdateHookPath path so StopFailure
+				// semantics (Status=error, LastSeenAt refresh)
+				// still take effect. The trace step is whatever
+				// the legacy path emits (parent_frame_found etc.),
+				// honestly reflecting "didn't take detach branch".
+				break
 			}
-			projection, perr := m.projectPane(req.TmuxPaneID)
-			return projection, FrameTraceMeta{
-				FrameID:       stored.FrameID,
-				ParentFrameID: stored.ParentFrameID,
-				Decision:      "updated_frame",
-				Reason:        "native_subagent_detached_on_stop_failure",
-				Before:        before,
-				After:         summarizeFrame(&stored),
-			}, perr
 		}
 		// frame == nil: collapse onto the existing LifecycleStop body so
 		// codex turn-aware proxy detach + cc/opencode wildcard
@@ -1400,6 +1386,106 @@ func (m *Module) mutateSubagentsWithRetry(frame store.Frame, lifecycle agentpkg.
 		current = *reloaded
 	}
 	return false, store.Frame{}, fmt.Errorf("subagent mutation %s: exceeded %d retries for frame %s", lifecycle, proxyUpsertMaxAttempts, frame.FrameID)
+}
+
+// detachOutcome categorizes the result of mutateSubagentsAndStatusWithRetry
+// so the caller can pick the right trace reason and broadcast path. The
+// four outcomes are intentionally disjoint: each represents a distinct
+// observable state in the storage layer that must produce a distinct
+// trace step (per PR-A round-2 adversarial review, thread 019ded6{1,2,3}).
+//
+// PR-A round-2 codex review (R2) found that an inline retry loop folding
+// "ref already gone after reload" and "retries exhausted" into a single
+// frame_missing outcome could:
+//
+//  1. emit a phantom native_subagent_detached_on_stop_failure trace
+//     when a concurrent writer detached the same ref between our
+//     pre-check and a retry attempt;
+//  2. silently drop the StopFailure status update under retry exhaustion
+//     without surfacing an error to the caller.
+//
+// This helper fixes both by re-checking ref presence on every retry
+// baseline and reporting the four outcomes separately.
+type detachOutcome int
+
+const (
+	// detachOutcomeDetached: this attempt's UpsertIfUnchanged succeeded and
+	// the target ref was actually present in the baseline that committed.
+	// Caller emits native_subagent_detached_on_stop_failure.
+	detachOutcomeDetached detachOutcome = iota
+	// detachOutcomeRefAlreadyAbsent: a reload showed the target ref no
+	// longer present (concurrent SubagentStop or another StopFailure for
+	// the same agent_id won the race). No mutation issued for this path.
+	// Caller MUST fall back to legacy post-switch status update so
+	// StopFailure semantics still write Status=error / refresh LastSeenAt.
+	detachOutcomeRefAlreadyAbsent
+	// detachOutcomeFrameMissing: a reload returned nil because the row
+	// was deleted concurrently (SessionEnd / sweep). Caller emits
+	// frame_missing trace.
+	detachOutcomeFrameMissing
+)
+
+// mutateSubagentsAndStatusWithRetry atomically removes a native ref AND
+// updates frame Status in a single UpsertIfUnchanged transaction. Mirrors
+// mutateSubagentsWithRetry's OCC retry loop but adds two contracts the
+// plain helper does not provide:
+//
+//  1. Per-attempt ref-presence re-check: if the target ref disappears
+//     between attempts (concurrent writer wins the race), abort with
+//     detachOutcomeRefAlreadyAbsent so caller can avoid emitting a phantom
+//     detach trace.
+//  2. Atomic Status field write: Status persists in the same row update
+//     as the Subagents change, eliminating the race window between
+//     "ref removed" and "status updated to error" that a two-step
+//     (mutate then UpdateHookPath) approach would leak.
+//
+// Retry exhaustion (UpsertIfUnchanged keeps conflicting while the row
+// still exists across all proxyUpsertMaxAttempts iterations) returns an
+// error, mirroring mutateSubagentsWithRetry's contract — the caller
+// surfaces this via the standard handler error path.
+//
+// PR-A round-2 codex review threads 019ded61 / 019ded62 / 019ded63.
+func (m *Module) mutateSubagentsAndStatusWithRetry(
+	frame store.Frame,
+	ref agentpkg.SubagentRef,
+	status agentpkg.Status,
+	broadcastTs int64,
+) (detachOutcome, store.Frame, error) {
+	current := frame
+	for attempt := 0; attempt < proxyUpsertMaxAttempts; attempt++ {
+		// Per-attempt re-check (R2 attacker / defender / health fix).
+		// On the first iteration this re-confirms the caller's
+		// pre-check (cheap, O(n) scan); on later iterations after a
+		// reload it catches the race where another writer already
+		// detached the ref. Without this, updateSubagents would
+		// no-op and we'd commit Status+LastSeenAt under the new
+		// "native_subagent_detached_on_stop_failure" reason despite
+		// not actually removing anything.
+		if findNativeRefByID(current.Subagents, ref.ID) < 0 {
+			return detachOutcomeRefAlreadyAbsent, current, nil
+		}
+		expected := current.LastSeenAt
+		next := current
+		next.Subagents = updateSubagents(current.Subagents, agentpkg.LifecycleSubagentStop, ref)
+		next.Status = status
+		next.LastSeenAt = broadcastTs
+		ok, stored, err := m.frames.UpsertIfUnchanged(next, expected)
+		if err != nil {
+			return 0, store.Frame{}, err
+		}
+		if ok {
+			return detachOutcomeDetached, stored, nil
+		}
+		reloaded, err := m.frames.GetByIdentity(frame.PaneID, frame.PID, frame.ProcessStartTime)
+		if err != nil {
+			return 0, store.Frame{}, err
+		}
+		if reloaded == nil {
+			return detachOutcomeFrameMissing, store.Frame{}, nil
+		}
+		current = *reloaded
+	}
+	return 0, store.Frame{}, fmt.Errorf("subagent+status mutation: exceeded %d retries for frame %s", proxyUpsertMaxAttempts, frame.FrameID)
 }
 
 // attachProxyRefWithRetry is a thin wrapper over mutateSubagentsWithRetry

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -285,7 +285,162 @@ func (m *Module) applyFrameEvent(req EventRequest, result agentpkg.DeriveResult,
 			Before:        parentBefore,
 			After:         summarizeFrame(&stored),
 		}, err
-	case agentpkg.LifecycleStop, agentpkg.LifecycleStopFailure:
+	case agentpkg.LifecycleStopFailure:
+		// P1-T3a structural split: case body is a verbatim copy of the
+		// LifecycleStop branch below. P1-T3b will replace this body with
+		// the native subagent detach branch + fallthrough to LifecycleStop
+		// for the frame == nil tail. No behaviour change in this commit.
+		//
+		// L2 codex turn-aware Stop targeted detach (spec §3.3.D + plan
+		// §3 P3-T8a). All detach goes through pane-scan helpers; we never
+		// call findProxyParent on the Stop path because the sender's PPID
+		// chain may have already been torn down by the time the hook
+		// arrives (B1/v2 fix).
+		//
+		// Gate 1 — sender owns its own frame. Standalone agent Stop is
+		// the J3 dispatcher's territory (lights-rebuild ProbeIntent), not
+		// L2 proxy detach (spec §3.3.D + §5 row 12).
+		if frame != nil {
+			break
+		}
+		// Gate 2 — non-codex providers fall back to wildcard process-level
+		// detach (cc/opencode have no per-turn identity). Mirrors the
+		// long-standing PR-2b SessionEnd path.
+		if req.AgentType != "codex" {
+			removed, ownerAfter, ownerBefore, ownerAfterMap, derr := m.removeProxyRefForSender(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, broadcastTs)
+			if derr != nil {
+				return nil, FrameTraceMeta{}, derr
+			}
+			if removed {
+				projection, perr := m.projectPane(req.TmuxPaneID)
+				return projection, FrameTraceMeta{
+					FrameID:       ownerAfter.FrameID,
+					ParentFrameID: ownerAfter.ParentFrameID,
+					Decision:      "updated_frame",
+					Reason:        "proxy_subagent_detached_on_stop",
+					Before:        ownerBefore,
+					After:         ownerAfterMap,
+				}, perr
+			}
+			// No matching ref — fall through to generic post-switch path
+			// so legacy behavior (no frame mutation, projection refresh)
+			// stays observable.
+			break
+		}
+		// Codex three sub-case dispatch (spec §3.3.D table).
+		turnID := parseCodexTurnID(req.RawEvent)
+		if turnID != "" {
+			// (a) Targeted detach by (PID, StartTime, TurnID).
+			removed, ownerAfter, ownerBefore, ownerAfterMap, derr := m.removeProxyRefForSenderTurn(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, turnID, broadcastTs)
+			if derr != nil {
+				return nil, FrameTraceMeta{}, derr
+			}
+			if removed {
+				projection, perr := m.projectPane(req.TmuxPaneID)
+				return projection, FrameTraceMeta{
+					FrameID:       ownerAfter.FrameID,
+					ParentFrameID: ownerAfter.ParentFrameID,
+					Decision:      "updated_frame",
+					Reason:        "proxy_subagent_detached_on_stop_turn",
+					Before:        ownerBefore,
+					After:         ownerAfterMap,
+				}, perr
+			}
+			// Stop's turn doesn't match any live ref. Could be late Stop
+			// after a turn-change upsert overwrote SourceTurnID, or a
+			// stale-tombstone Stop after a previous detach (idempotent
+			// no-op). Trace stop_no_match either way.
+			projection, perr := m.projectPane(req.TmuxPaneID)
+			return projection, FrameTraceMeta{
+				Decision: "skipped",
+				Reason:   "proxy_subagent_stop_no_match",
+				Before:   map[string]any{},
+				After:    map[string]any{},
+			}, perr
+		}
+		// (b)/(c) — codex Stop with empty/parse-failed turn_id. Pane-scan
+		// for the matching broker ref (PID, StartTime) to make the
+		// fallback decision; any non-matching broker's SourceTurnID is
+		// irrelevant (H1/v2 fix).
+		paneFrames, perr := m.frames.ListByPane(req.TmuxPaneID)
+		if perr != nil {
+			return nil, FrameTraceMeta{}, perr
+		}
+		var matched *agentpkg.SubagentRef
+		for i := range paneFrames {
+			idx := findProxyRefByBroker(paneFrames[i].Subagents, req.SenderPID, req.SenderStartTime)
+			if idx >= 0 {
+				ref := paneFrames[i].Subagents[idx]
+				matched = &ref
+				break
+			}
+		}
+		if matched == nil {
+			// No broker ref to detach — silently drop the Stop. Trace as
+			// stop_no_match so the chain remains observable; this also
+			// covers idempotent re-Stop after a previous successful
+			// detach (row 14 lower-confidence branch).
+			projection, perr2 := m.projectPane(req.TmuxPaneID)
+			return projection, FrameTraceMeta{
+				Decision: "skipped",
+				Reason:   "proxy_subagent_stop_no_match",
+				Before:   map[string]any{},
+				After:    map[string]any{},
+			}, perr2
+		}
+		if matched.SourceTurnID != "" {
+			// (b) Matching broker has a live SourceTurnID (a previous
+			// upsert recorded a turn_id). Stop with empty turn_id is
+			// almost certainly a malformed payload, NOT a legitimate
+			// "broker is finished" signal — keep the ref so the
+			// conservative behavior preserves the lit dot until either
+			// the next upsert or governance sweep clears it.
+			projection, perr2 := m.projectPane(req.TmuxPaneID)
+			return projection, FrameTraceMeta{
+				Decision: "skipped",
+				Reason:   "proxy_subagent_stop_parse_failed",
+				Before:   map[string]any{},
+				After:    map[string]any{},
+			}, perr2
+		}
+		// (c) Matching broker has empty SourceTurnID (SessionStart
+		// attached but no UserPromptSubmit/PreToolUse upsert ever
+		// recorded a turn) → empty-turn-only detach. Round-2 A1: a
+		// process-level wildcard here would TOCTOU-race a concurrent
+		// UserPromptSubmit that upgrades the ref to turn-aware between
+		// our ListByPane scan above and the detach helper. Re-verify
+		// SourceTurnID == "" inside the optimistic-concurrency loop by
+		// reusing removeProxyRefForSenderTurn with turnID == "" — the
+		// match condition becomes (PID, StartTime, SourceTurnID == "")
+		// and any concurrent upgrade falls into the no-match branch
+		// (proxy_subagent_stop_no_match below).
+		removed, ownerAfter, ownerBefore, ownerAfterMap, derr := m.removeProxyRefForSenderTurn(req.TmuxPaneID, req.SenderPID, req.SenderStartTime, "", broadcastTs)
+		if derr != nil {
+			return nil, FrameTraceMeta{}, derr
+		}
+		if removed {
+			projection, perr2 := m.projectPane(req.TmuxPaneID)
+			return projection, FrameTraceMeta{
+				FrameID:       ownerAfter.FrameID,
+				ParentFrameID: ownerAfter.ParentFrameID,
+				Decision:      "updated_frame",
+				Reason:        "proxy_subagent_detached_on_stop",
+				Before:        ownerBefore,
+				After:         ownerAfterMap,
+			}, perr2
+		}
+		// Pane-scan saw a matching ref but the helper found nothing —
+		// concurrent writer detached between scan and helper. Trace
+		// stop_no_match so the chain accurately reflects "ref already
+		// gone" without claiming to have detached it twice.
+		projection, perr2 := m.projectPane(req.TmuxPaneID)
+		return projection, FrameTraceMeta{
+			Decision: "skipped",
+			Reason:   "proxy_subagent_stop_no_match",
+			Before:   map[string]any{},
+			After:    map[string]any{},
+		}, perr2
+	case agentpkg.LifecycleStop:
 		// L2 codex turn-aware Stop targeted detach (spec §3.3.D + plan
 		// §3 P3-T8a). All detach goes through pane-scan helpers; we never
 		// call findProxyParent on the Stop path because the sender's PPID

--- a/internal/module/agent/frame_ops.go
+++ b/internal/module/agent/frame_ops.go
@@ -967,6 +967,33 @@ func findProxyRefByBroker(refs []agentpkg.SubagentRef, pid int, startTime string
 	return -1
 }
 
+// findNativeRefByID returns the index of the native (non-proxy) SubagentRef
+// with the given ID, or -1 when no such ref exists. Pure read, no side
+// effects.
+//
+// Callers use this to gate destructive native-ref operations (PdxStopFailure
+// → LifecycleSubagentStop) so that a missing or non-matching agent_id is
+// never reported as a successful detach. mutateSubagentsWithRetry's
+// `applied=true` only signals UpsertIfUnchanged committed (LastSeenAt always
+// refreshes) — it does NOT prove a ref was actually removed (spec §2.3).
+// Without this pre-check we would broadcast a phantom "detached" trace step
+// on every mismatched payload.
+//
+// Empty id short-circuits to -1 so the legacy break path fires for payloads
+// whose agent_id field is absent (`raw["agent_id"] == nil` → "" via type
+// assertion at the call site) or explicitly empty.
+func findNativeRefByID(refs []agentpkg.SubagentRef, id string) int {
+	if id == "" {
+		return -1
+	}
+	for i, ref := range refs {
+		if !ref.IsProxy && ref.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
 func syncProjectionState(currentStatus map[string]agentpkg.Status, subagents map[string][]agentpkg.SubagentRef, tmuxSession string, projection *SessionProjection) {
 	if projection == nil || projection.TopFrame == nil {
 		delete(currentStatus, tmuxSession)

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -5061,6 +5062,75 @@ func TestStopFailure_FrameNil_FallthroughToProxyDetach(t *testing.T) {
 	}
 	if meta.Reason != "proxy_subagent_detached_on_stop" {
 		t.Fatalf("Reason = %q, want proxy_subagent_detached_on_stop (fallthrough wildcard detach)", meta.Reason)
+	}
+}
+
+// TestStopFailure_FixtureReplay_DthnPayload pins the cc upstream payload
+// shape against a recorded production sample (spec §1.2 chain `c02151f0...`).
+// If cc ever changes the StopFailure payload schema in a way that breaks
+// our agent_id surfacing (rename, nesting under a different parent key,
+// removal entirely) this test fails at PR-CI time rather than silently
+// accumulating refs in production again.
+//
+// The fixture file is sanitised (cwd / transcript / session_id replaced
+// with fixture-friendly tokens) but `agent_id`, `error`, `agent_type`,
+// `hook_event_name` keep their original schema and value shape from
+// dthn pane %50.
+func TestStopFailure_FixtureReplay_DthnPayload(t *testing.T) {
+	raw, err := os.ReadFile("testdata/dthn_stopfailure_2026_05_03.json")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	agentID, _ := payload["agent_id"].(string)
+	if agentID == "" {
+		t.Fatalf("fixture missing agent_id (rate-limit cleanup contract pin); payload=%+v", payload)
+	}
+
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	parent := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef(agentID, 40),
+	})
+
+	// Provider derive (cc) surfaces agent_id into Detail; mirror that
+	// here so the handler-side pre-check works on the same shape it
+	// would see in production.
+	result := agentpkg.DeriveResult{
+		Valid:  true,
+		Status: agentpkg.StatusError,
+		Detail: map[string]any{
+			"error_details": payload["error_details"],
+			"error":         payload["error"],
+			"agent_id":      payload["agent_id"],
+		},
+	}
+	req := EventRequest{
+		TmuxSession:     "work",
+		TmuxPaneID:      pane,
+		PurdexName:      "PdxStopFailure",
+		AgentType:       "cc",
+		SenderPID:       parent.PID,
+		SenderStartTime: parent.ProcessStartTime,
+		RawEvent:        json.RawMessage(raw),
+	}
+
+	_, meta, err := m.applyFrameEvent(req, result, 200)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "native_subagent_detached_on_stop_failure" {
+		t.Fatalf("Reason = %q, want native_subagent_detached_on_stop_failure (cc payload schema drift?); meta=%+v", meta.Reason, meta)
+	}
+	got, gerr := m.frames.GetByIdentity(pane, parent.PID, parent.ProcessStartTime)
+	if gerr != nil || got == nil {
+		t.Fatalf("reload: %v / %v", gerr, got)
+	}
+	if len(got.Subagents) != 0 {
+		t.Fatalf("Subagents = %+v, want empty after fixture replay detach", got.Subagents)
 	}
 }
 

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -4899,6 +4899,17 @@ func TestStopFailure_NativeDetach_Hits(t *testing.T) {
 	if len(got.Subagents) != 0 {
 		t.Fatalf("Subagents = %+v, want empty after native detach", got.Subagents)
 	}
+	// PR-A round-1 codex review P1 (thread 019ded5d): atomic ref+status
+	// write — frame.Status MUST persist as error after detach. Earlier
+	// implementation called mutateSubagentsWithRetry alone, which only
+	// touches Subagents+LastSeenAt and skipped the post-switch
+	// UpdateHookPath status update.
+	if got.Status != agentpkg.StatusError {
+		t.Fatalf("Status = %q, want %q after StopFailure detach (codex round-1 P1)", got.Status, agentpkg.StatusError)
+	}
+	if got.LastSeenAt != 200 {
+		t.Fatalf("LastSeenAt = %d, want 200 (broadcastTs)", got.LastSeenAt)
+	}
 }
 
 func TestStopFailure_NativeDetach_Misses_NoNativeDetachTrace(t *testing.T) {

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -5145,46 +5145,154 @@ func TestStopFailure_FixtureReplay_DthnPayload(t *testing.T) {
 	}
 }
 
-func TestStopFailure_FrameDeletedMidFlight(t *testing.T) {
+// TestStopFailure_FrameAbsentBeforePreCheck verifies the user-visible safety
+// contract: when a frame is gone before applyFrameEvent even sees it, the
+// StopFailure path never emits a successful native detach trace. This is
+// the "post-delete state" sanity check; the actual mid-flight delete
+// (pre-check pass + UpsertIfUnchanged finds row deleted) is exercised
+// directly at the helper level by
+// TestMutateSubagentsAndStatusWithRetry_FrameDeletedMidFlight (R2 defender
+// finding: original test name "FrameDeletedMidFlight" was misleading).
+func TestStopFailure_FrameAbsentBeforePreCheck(t *testing.T) {
 	m := newProxyTestModule(t)
 	pane := newStopFailurePane()
 	parent := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
 		nativeSubagentRef("match-id", 40),
 	})
 
-	// Inject a hook that deletes the frame between findNativeRefByID's
-	// pre-check and mutateSubagentsWithRetry's UpsertIfUnchanged. The
-	// retry loop sees applied=false because the row no longer exists,
-	// then GetByIdentity returns nil → mutate returns (false, _, nil).
-	// applyFrameEvent must trace `frame_missing`.
+	// Delete frame BEFORE applyFrameEvent runs — applyFrameEvent's top
+	// GetByIdentity returns nil, so the StopFailure case fallthroughs to
+	// LifecycleStop body. cc wildcard branch hits removeProxyRefForSender,
+	// finds nothing for senderPID=100, breaks to generic post-switch path.
+	// The new native detach reason MUST NOT be emitted.
 	if err := m.frames.Delete(parent.FrameID); err != nil {
 		t.Fatalf("simulate concurrent delete: %v", err)
 	}
-	// Re-seed parent baseline expectations: now there is no frame for
-	// (pane, pid, startTime) — applyFrameEvent's GetByIdentity at the
-	// top will return frame == nil too. To exercise the
-	// `pre-check pass + mutate applied=false` branch specifically we
-	// need to keep frame != nil at the GetByIdentity call but vanish
-	// before the UpsertIfUnchanged. Simulate this by re-Upserting and
-	// then arranging a parallel-delete via the retry path — but a
-	// simpler equivalent is to assert that even with the frame absent
-	// from the start (the post-delete state), the StopFailure path
-	// emits a non-detach trace and does NOT panic / leak. The
-	// frame_missing branch under pre-check pass + mutate applied=false
-	// is structurally guarded by spec §3.2 break logic; this test
-	// covers the user-visible safety contract: a deleted frame never
-	// reports a successful native detach.
 	req, result := buildStopFailureRequest(pane, parent.PID, parent.ProcessStartTime, "match-id", "cc")
 	_, meta, err := m.applyFrameEvent(req, result, 300)
 	if err != nil {
 		t.Fatalf("applyFrameEvent: %v", err)
 	}
-	// With frame == nil at top of applyFrameEvent, the StopFailure case
-	// fallthroughs to the LifecycleStop body — no native ref exists to
-	// detach (cc wildcard branch hits removeProxyRefForSender, finds
-	// nothing for senderPID=100, breaks to generic post-switch path).
-	// In any case the new native detach reason MUST NOT be emitted.
 	if meta.Reason == "native_subagent_detached_on_stop_failure" {
 		t.Fatalf("Reason = %q, want non-detach for deleted frame", meta.Reason)
 	}
 }
+
+// PR-A round-2 codex review (threads 019ded61/62/63) caught that the
+// retry loop did not re-check ref presence after each reload, allowing
+// a phantom native_subagent_detached_on_stop_failure trace under
+// concurrent SubagentStop / parallel StopFailure races. The four tests
+// below exercise mutateSubagentsAndStatusWithRetry directly to cover
+// each detachOutcome branch precisely.
+
+func TestMutateSubagentsAndStatusWithRetry_DetachedSuccessfully(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	parent := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("match-id", 40),
+	})
+
+	ref := agentpkg.SubagentRef{ID: "match-id", Type: "cc"}
+	outcome, stored, err := m.mutateSubagentsAndStatusWithRetry(parent, ref, agentpkg.StatusError, 200)
+	if err != nil {
+		t.Fatalf("mutate: %v", err)
+	}
+	if outcome != detachOutcomeDetached {
+		t.Fatalf("outcome = %v, want detachOutcomeDetached", outcome)
+	}
+	if len(stored.Subagents) != 0 {
+		t.Fatalf("Subagents = %+v, want empty", stored.Subagents)
+	}
+	if stored.Status != agentpkg.StatusError {
+		t.Fatalf("Status = %q, want %q", stored.Status, agentpkg.StatusError)
+	}
+	if stored.LastSeenAt != 200 {
+		t.Fatalf("LastSeenAt = %d, want 200", stored.LastSeenAt)
+	}
+}
+
+// TestMutateSubagentsAndStatusWithRetry_RefAlreadyAbsentAfterReload covers
+// the R2 phantom-detach race: caller's pre-check passed (ref existed
+// when we built `frame`), but a concurrent writer detached the same ref
+// before our first UpsertIfUnchanged committed. Our reload reveals the
+// ref already gone — helper must NOT report Detached.
+func TestMutateSubagentsAndStatusWithRetry_RefAlreadyAbsentAfterReload(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	// Step 1: seed frame WITH the target ref; remember this stale baseline.
+	stale := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("match-id", 40),
+	})
+	// Step 2: simulate concurrent writer that already removed the ref AND
+	// bumped LastSeenAt. Helper's first UpsertIfUnchanged will fail
+	// (expected stale.LastSeenAt=50 vs current 999); reload returns the
+	// post-race state — ref already gone.
+	racePost := stale
+	racePost.Subagents = []agentpkg.SubagentRef{}
+	racePost.LastSeenAt = 999
+	ok, _, err := m.frames.UpsertIfUnchanged(racePost, stale.LastSeenAt)
+	if err != nil || !ok {
+		t.Fatalf("seed race-post state: ok=%v err=%v", ok, err)
+	}
+	// Step 3: invoke helper with the STALE baseline (caller's view from
+	// before the race). On first UpsertIfUnchanged conflict, helper
+	// reloads → racePost (ref already absent) → returns RefAlreadyAbsent
+	// without committing a phantom detach.
+	ref := agentpkg.SubagentRef{ID: "match-id", Type: "cc"}
+	outcome, _, err := m.mutateSubagentsAndStatusWithRetry(stale, ref, agentpkg.StatusError, 1500)
+	if err != nil {
+		t.Fatalf("mutate: %v", err)
+	}
+	if outcome != detachOutcomeRefAlreadyAbsent {
+		t.Fatalf("outcome = %v, want detachOutcomeRefAlreadyAbsent (phantom-detach race not handled)", outcome)
+	}
+	// DB-level invariant: the post-race state stays untouched (helper did
+	// NOT issue a write since ref was already absent on retry baseline).
+	got, _ := m.frames.GetByIdentity(pane, stale.PID, stale.ProcessStartTime)
+	if got == nil || got.LastSeenAt != 999 {
+		t.Fatalf("got = %+v, want post-race state preserved (LastSeenAt=999)", got)
+	}
+}
+
+// TestMutateSubagentsAndStatusWithRetry_FrameDeletedMidFlight exercises
+// the pre-check-passes-but-row-deleted path that the original
+// FrameDeletedMidFlight test name claimed but did not actually cover
+// (R2 defender finding).
+func TestMutateSubagentsAndStatusWithRetry_FrameDeletedMidFlight(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	stale := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("match-id", 40),
+	})
+	// Simulate concurrent SessionEnd / sweep: delete the row entirely.
+	if err := m.frames.Delete(stale.FrameID); err != nil {
+		t.Fatalf("simulate delete: %v", err)
+	}
+	// Helper sees pre-check pass on stale baseline (ref present), then
+	// UpsertIfUnchanged conflicts, GetByIdentity returns nil → FrameMissing.
+	ref := agentpkg.SubagentRef{ID: "match-id", Type: "cc"}
+	outcome, _, err := m.mutateSubagentsAndStatusWithRetry(stale, ref, agentpkg.StatusError, 200)
+	if err != nil {
+		t.Fatalf("mutate: %v", err)
+	}
+	if outcome != detachOutcomeFrameMissing {
+		t.Fatalf("outcome = %v, want detachOutcomeFrameMissing", outcome)
+	}
+}
+
+// TestMutateSubagentsAndStatusWithRetry_RetryExhaustionContract documents
+// the helper's "exceeded retries" path. The actual triggering of three
+// consecutive UpsertIfUnchanged conflicts is covered at applyFrameEvent
+// level by TestPhase35_IT9_FilterMergeExhaustedRetryAbortsApply (line ~3702),
+// which uses the existing processStartTimeFn module seam to drive
+// row-mutation between attempts. mutateSubagentsAndStatusWithRetry shares
+// the same OCC UpsertIfUnchanged + GetByIdentity reload pattern, so its
+// exhaustion behaviour is structurally inherited; adding a duplicate
+// race-driving test here would require a new module-level seam without
+// new coverage value (R2 health finding tracked as fact rather than
+// blocker per round-2 thread 019ded63).
+//
+// Caller behaviour (applyFrameEvent's LifecycleStopFailure case) propagates
+// the helper's error verbatim via `return nil, FrameTraceMeta{}, merr`,
+// surfacing as a 500 from the HTTP handler — consistent with the
+// pre-existing exhaustion path on the SessionStart filter-merge code.

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -4817,3 +4817,293 @@ func TestFindNativeRefByID_NotFoundReturnsNegativeOne(t *testing.T) {
 		t.Fatalf("findNativeRefByID = %d, want -1", got)
 	}
 }
+
+// LifecycleStopFailure native subagent detach branch (P1-T3b). Spec §3.2 +
+// §6.1 + plan §1 P1-T3b table. Covers seven scenarios:
+//   1. Hits — payload agent_id matches an existing native ref → detach +
+//      trace `native_subagent_detached_on_stop_failure`.
+//   2. Misses_NoNativeDetachTrace — payload agent_id does not match any
+//      held native ref → break path; legacy generic post-switch fires
+//      (status=error, LastSeenAt refreshed); reason is NOT the new detach
+//      reason.
+//   3. NoAgentId_LegacyBehaviour — payload omits agent_id → same as miss.
+//   4. EmptyAgentId_LegacyBehaviour — payload `agent_id: ""` → same as
+//      miss; helper short-circuits at id == "".
+//   5. PreservesProxyRefs — frame holds both native + proxy refs; only
+//      the matching native ref is detached, proxy ref untouched.
+//   6. FrameNil_FallthroughToProxyDetach — frame == nil; fallthrough
+//      reaches the LifecycleStop body's existing codex/proxy branches
+//      unchanged.
+//   7. FrameDeletedMidFlight — pre-check matches but mutate returns
+//      applied=false because a concurrent SessionEnd / sweep deleted the
+//      frame; trace reason `frame_missing`.
+
+func newStopFailurePane() string { return "%50" }
+
+func buildStopFailureRequest(paneID string, senderPID int, senderStartTime, agentID, agentType string) (EventRequest, agentpkg.DeriveResult) {
+	rawJSON, _ := json.Marshal(map[string]any{
+		"agent_id":        agentID,
+		"agent_type":      "general-purpose",
+		"hook_event_name": "StopFailure",
+		"error":           "rate_limit",
+	})
+	req := EventRequest{
+		TmuxSession:     "work",
+		TmuxPaneID:      paneID,
+		PurdexName:      "PdxStopFailure",
+		AgentType:       agentType,
+		SenderPID:       senderPID,
+		SenderStartTime: senderStartTime,
+		RawEvent:        rawJSON,
+	}
+	detail := map[string]any{
+		"error_details": nil,
+		"error":         "rate_limit",
+	}
+	// Spec §3.1: cc/codex carry agent_id even when nil (map literal); we
+	// mirror that here. Empty-string and missing tests override below.
+	if agentID != "<missing>" {
+		detail["agent_id"] = agentID
+	}
+	result := agentpkg.DeriveResult{
+		Valid:  true,
+		Status: agentpkg.StatusError,
+		Detail: detail,
+	}
+	return req, result
+}
+
+func TestStopFailure_NativeDetach_Hits(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	parent := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("match-id", 40),
+	})
+
+	req, result := buildStopFailureRequest(pane, parent.PID, parent.ProcessStartTime, "match-id", "cc")
+	_, meta, err := m.applyFrameEvent(req, result, 200)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Decision != "updated_frame" {
+		t.Fatalf("Decision = %q, want updated_frame (meta=%+v)", meta.Decision, meta)
+	}
+	if meta.Reason != "native_subagent_detached_on_stop_failure" {
+		t.Fatalf("Reason = %q, want native_subagent_detached_on_stop_failure (meta=%+v)", meta.Reason, meta)
+	}
+	got, err := m.frames.GetByIdentity(pane, parent.PID, parent.ProcessStartTime)
+	if err != nil || got == nil {
+		t.Fatalf("reload parent: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 0 {
+		t.Fatalf("Subagents = %+v, want empty after native detach", got.Subagents)
+	}
+}
+
+func TestStopFailure_NativeDetach_Misses_NoNativeDetachTrace(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	// Frame holds a single native ref whose ID does NOT match the
+	// incoming StopFailure payload.
+	parent := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("no-match-id", 40),
+	})
+
+	req, result := buildStopFailureRequest(pane, parent.PID, parent.ProcessStartTime, "different-id", "cc")
+	preTs := int64(200)
+	_, meta, err := m.applyFrameEvent(req, result, preTs)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+
+	// (a) ref-presence pre-check did NOT match → no native detach trace step.
+	if meta.Reason == "native_subagent_detached_on_stop_failure" {
+		t.Fatalf("Reason = %q, want non-detach (legacy break path); meta=%+v", meta.Reason, meta)
+	}
+	// (b) generic post-switch path executed → Decision updated_frame +
+	// Reason ∈ {parent_frame_found, daemon_restart_recovery, no_parent_fallback}.
+	if meta.Decision != "updated_frame" {
+		t.Fatalf("Decision = %q, want updated_frame (meta=%+v)", meta.Decision, meta)
+	}
+	switch meta.Reason {
+	case "parent_frame_found", "daemon_restart_recovery", "no_parent_fallback":
+		// expected legacy reasons
+	default:
+		t.Fatalf("Reason = %q, want one of parent_frame_found/daemon_restart_recovery/no_parent_fallback", meta.Reason)
+	}
+	// (c) Legacy semantics preserved: status=error, LastSeenAt refreshed,
+	// ref still present (because not matched).
+	got, err := m.frames.GetByIdentity(pane, parent.PID, parent.ProcessStartTime)
+	if err != nil || got == nil {
+		t.Fatalf("reload parent: %v / %v", err, got)
+	}
+	if got.Status != agentpkg.StatusError {
+		t.Fatalf("Status = %q, want error", got.Status)
+	}
+	if got.LastSeenAt < preTs {
+		t.Fatalf("LastSeenAt = %d, want >= %d (refresh)", got.LastSeenAt, preTs)
+	}
+	if len(got.Subagents) != 1 || got.Subagents[0].ID != "no-match-id" {
+		t.Fatalf("Subagents = %+v, want unchanged [no-match-id]", got.Subagents)
+	}
+}
+
+func TestStopFailure_NoAgentId_LegacyBehaviour(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	parent := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("no-match-id", 40),
+	})
+
+	// Use the "<missing>" sentinel to omit agent_id from Detail entirely.
+	req, result := buildStopFailureRequest(pane, parent.PID, parent.ProcessStartTime, "<missing>", "cc")
+	if _, present := result.Detail["agent_id"]; present {
+		t.Fatalf("test setup: agent_id should be absent for missing case")
+	}
+
+	_, meta, err := m.applyFrameEvent(req, result, 200)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "native_subagent_detached_on_stop_failure" {
+		t.Fatalf("Reason = %q, want legacy break (no agent_id)", meta.Reason)
+	}
+	if meta.Decision != "updated_frame" {
+		t.Fatalf("Decision = %q, want updated_frame (legacy break)", meta.Decision)
+	}
+	got, err := m.frames.GetByIdentity(pane, parent.PID, parent.ProcessStartTime)
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 1 {
+		t.Fatalf("Subagents = %+v, want unchanged", got.Subagents)
+	}
+}
+
+func TestStopFailure_EmptyAgentId_LegacyBehaviour(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	parent := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("no-match-id", 40),
+	})
+
+	// Explicit empty string — exercises findNativeRefByID's id == "" early
+	// short-circuit.
+	req, result := buildStopFailureRequest(pane, parent.PID, parent.ProcessStartTime, "", "cc")
+	if result.Detail["agent_id"] != "" {
+		t.Fatalf("test setup: expected empty-string agent_id, got %#v", result.Detail["agent_id"])
+	}
+
+	_, meta, err := m.applyFrameEvent(req, result, 200)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason == "native_subagent_detached_on_stop_failure" {
+		t.Fatalf("Reason = %q, want legacy break (empty agent_id)", meta.Reason)
+	}
+	got, err := m.frames.GetByIdentity(pane, parent.PID, parent.ProcessStartTime)
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 1 {
+		t.Fatalf("Subagents = %+v, want unchanged", got.Subagents)
+	}
+}
+
+func TestStopFailure_PreservesProxyRefs(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	// Frame holds one native + one proxy ref. StopFailure agent_id matches
+	// only the native — proxy must survive untouched.
+	parent := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("match-id", 40),
+		{ID: "proxy:codex:42:t1", Type: "codex", StartedAt: 50, SourcePID: 42, SourceStartTime: "t1", IsProxy: true},
+	})
+
+	req, result := buildStopFailureRequest(pane, parent.PID, parent.ProcessStartTime, "match-id", "cc")
+	_, meta, err := m.applyFrameEvent(req, result, 200)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "native_subagent_detached_on_stop_failure" {
+		t.Fatalf("Reason = %q, want native_subagent_detached_on_stop_failure", meta.Reason)
+	}
+	got, err := m.frames.GetByIdentity(pane, parent.PID, parent.ProcessStartTime)
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v / %v", err, got)
+	}
+	if len(got.Subagents) != 1 {
+		t.Fatalf("Subagents = %+v, want exactly one ref (proxy preserved)", got.Subagents)
+	}
+	if !got.Subagents[0].IsProxy || got.Subagents[0].SourcePID != 42 {
+		t.Fatalf("surviving ref = %+v, want the proxy", got.Subagents[0])
+	}
+}
+
+func TestStopFailure_FrameNil_FallthroughToProxyDetach(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	// Parent owns no frame for the senderPID — but a parent frame in the
+	// pane carries a proxy ref for the broker. StopFailure for that broker
+	// should fallthrough to LifecycleStop's wildcard process-level proxy
+	// detach for non-codex / wildcard branch.
+	_ = seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		{ID: "proxy:cc:42:t1", Type: "cc", StartedAt: 50, SourcePID: 42, SourceStartTime: "t1", IsProxy: true},
+	})
+
+	// Sender == proxy broker (PID 42, t1) with no own frame: triggers
+	// the frame == nil path → fallthrough into LifecycleStop body.
+	// AgentType "cc" means non-codex branch → wildcard removeProxyRefForSender.
+	req, result := buildStopFailureRequest(pane, 42, "t1", "anything", "cc")
+	_, meta, err := m.applyFrameEvent(req, result, 200)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	if meta.Reason != "proxy_subagent_detached_on_stop" {
+		t.Fatalf("Reason = %q, want proxy_subagent_detached_on_stop (fallthrough wildcard detach)", meta.Reason)
+	}
+}
+
+func TestStopFailure_FrameDeletedMidFlight(t *testing.T) {
+	m := newProxyTestModule(t)
+	pane := newStopFailurePane()
+	parent := seedFrameWithSubagents(t, m, pane, "cc", 100, "t100", 50, []agentpkg.SubagentRef{
+		nativeSubagentRef("match-id", 40),
+	})
+
+	// Inject a hook that deletes the frame between findNativeRefByID's
+	// pre-check and mutateSubagentsWithRetry's UpsertIfUnchanged. The
+	// retry loop sees applied=false because the row no longer exists,
+	// then GetByIdentity returns nil → mutate returns (false, _, nil).
+	// applyFrameEvent must trace `frame_missing`.
+	if err := m.frames.Delete(parent.FrameID); err != nil {
+		t.Fatalf("simulate concurrent delete: %v", err)
+	}
+	// Re-seed parent baseline expectations: now there is no frame for
+	// (pane, pid, startTime) — applyFrameEvent's GetByIdentity at the
+	// top will return frame == nil too. To exercise the
+	// `pre-check pass + mutate applied=false` branch specifically we
+	// need to keep frame != nil at the GetByIdentity call but vanish
+	// before the UpsertIfUnchanged. Simulate this by re-Upserting and
+	// then arranging a parallel-delete via the retry path — but a
+	// simpler equivalent is to assert that even with the frame absent
+	// from the start (the post-delete state), the StopFailure path
+	// emits a non-detach trace and does NOT panic / leak. The
+	// frame_missing branch under pre-check pass + mutate applied=false
+	// is structurally guarded by spec §3.2 break logic; this test
+	// covers the user-visible safety contract: a deleted frame never
+	// reports a successful native detach.
+	req, result := buildStopFailureRequest(pane, parent.PID, parent.ProcessStartTime, "match-id", "cc")
+	_, meta, err := m.applyFrameEvent(req, result, 300)
+	if err != nil {
+		t.Fatalf("applyFrameEvent: %v", err)
+	}
+	// With frame == nil at top of applyFrameEvent, the StopFailure case
+	// fallthroughs to the LifecycleStop body — no native ref exists to
+	// detach (cc wildcard branch hits removeProxyRefForSender, finds
+	// nothing for senderPID=100, breaks to generic post-switch path).
+	// In any case the new native detach reason MUST NOT be emitted.
+	if meta.Reason == "native_subagent_detached_on_stop_failure" {
+		t.Fatalf("Reason = %q, want non-detach for deleted frame", meta.Reason)
+	}
+}

--- a/internal/module/agent/frame_ops_test.go
+++ b/internal/module/agent/frame_ops_test.go
@@ -4765,3 +4765,55 @@ func TestMarkDelegatingRef_CapsToolUseIDsAt32(t *testing.T) {
 		t.Fatalf("ref.Delegating = false, want true throughout cap enforcement")
 	}
 }
+
+// findNativeRefByID — pure helper unit tests (P1-T2). Spec §3.2 / §6.1 pin
+// the contract: native ref lookup gates the StopFailure detach branch so a
+// non-matching agent_id never triggers a phantom mutation.
+
+func TestFindNativeRefByID_HitsNativeRef(t *testing.T) {
+	refs := []agentpkg.SubagentRef{
+		{ID: "x", IsProxy: false},
+	}
+	if got := findNativeRefByID(refs, "x"); got != 0 {
+		t.Fatalf("findNativeRefByID = %d, want 0", got)
+	}
+}
+
+func TestFindNativeRefByID_SkipsProxyRefWithSameID(t *testing.T) {
+	// Proxy IDs are constructed `proxy:<type>:<pid>:<startTime>` and never
+	// collide with native cc Task IDs in practice — but the helper must
+	// still skip proxy refs even on a synthetic same-ID match, otherwise
+	// StopFailure could detach a proxy ref masquerading as native.
+	refs := []agentpkg.SubagentRef{
+		{ID: "x", IsProxy: true, SourcePID: 100, SourceStartTime: "Sun Apr 20 01:00:00 2026"},
+	}
+	if got := findNativeRefByID(refs, "x"); got != -1 {
+		t.Fatalf("findNativeRefByID = %d, want -1 (proxy ref must be skipped)", got)
+	}
+}
+
+func TestFindNativeRefByID_EmptyIdReturnsNotFound(t *testing.T) {
+	// Empty agent_id in the StopFailure payload must short-circuit to
+	// the legacy break path; helper returns -1 before any scan so the
+	// caller can rely on a single negative-id sentinel.
+	refs := []agentpkg.SubagentRef{
+		{ID: "x", IsProxy: false},
+	}
+	if got := findNativeRefByID(refs, ""); got != -1 {
+		t.Fatalf("findNativeRefByID(_, \"\") = %d, want -1", got)
+	}
+	// Empty refs + empty id → -1 too.
+	if got := findNativeRefByID(nil, ""); got != -1 {
+		t.Fatalf("findNativeRefByID(nil, \"\") = %d, want -1", got)
+	}
+}
+
+func TestFindNativeRefByID_NotFoundReturnsNegativeOne(t *testing.T) {
+	refs := []agentpkg.SubagentRef{
+		{ID: "y", IsProxy: false},
+		{ID: "z", IsProxy: false},
+	}
+	if got := findNativeRefByID(refs, "x"); got != -1 {
+		t.Fatalf("findNativeRefByID = %d, want -1", got)
+	}
+}

--- a/internal/module/agent/testdata/dthn_stopfailure_2026_05_03.json
+++ b/internal/module/agent/testdata/dthn_stopfailure_2026_05_03.json
@@ -1,0 +1,8 @@
+{
+  "session_id": "f828329e-fixture-sanitized-uuid",
+  "agent_id": "aac56e6312afceb04",
+  "agent_type": "general-purpose",
+  "hook_event_name": "StopFailure",
+  "error": "rate_limit",
+  "last_assistant_message": "You're out of extra usage · resets 2:30pm (Asia/Taipei)"
+}


### PR DESCRIPTION
## Summary

Closes the dthn-class accumulation bug where cc subagent failures via rate-limit error path leak native `SubagentRef` entries into `agent_frames.subagents_json`. Empirical observation against dthn (pane `%50`): **3944** native refs accumulated, with **1541/1573 (97.9%)** SubagentStart events terminating via `PdxStopFailure` (carrying the failing subagent's `agent_id`) instead of `PdxSubagentStop`. Today's `frame_ops.go:288` `case LifecycleStopFailure: if frame != nil { break }` is a no-op — payload's `agent_id` is never consumed, so native refs have no GC path.

This PR makes the daemon detach the matching native ref idempotently when `PdxStopFailure` payload carries a known `agent_id`, while preserving v0 behaviour bit-exactly for unrecognised payloads.

## Spec / plan / convergence

- Spec: `docs/specs/2026-05-03-rate-limit-subagent-cleanup-spec.md` v3+followups (3 rounds codex review approved)
- Plan: `docs/specs/2026-05-03-rate-limit-subagent-cleanup-plan.md` v3+fact fix (3 rounds codex review approve to enter implementation)
- Spec / plan threads: `019ded1e` / `019ded28` / `019ded2e` (spec); `019ded37` / `019ded40` / `019ded45` (plan)

## PR-A scope (this PR)

This branch carries both the **production code change** (PR-A daemon native detach) **and** spec/plan docs that drove the implementation. Per repo convention, spec/plan docs live alongside code in `docs/specs/`. They are process artefacts, not production behaviour, and have already gone through their own 3-round codex review prior to implementation. PR-B (SPA notification debounce) is a separate forthcoming PR per spec §11 sequencing.

## Changes — daemon code

7 commits (P1-T1 → P1-T4 + 2 review fixes):

- `edf4bd92` cc/codex/opencode derive surface `agent_id` in `PdxStopFailure` detail
- `45a11e58` add `findNativeRefByID` pure helper (pre-check ref presence)
- `508e0cd6` split `LifecycleStopFailure` case from `LifecycleStop` (no behaviour change)
- `a9858535` native subagent detach on `PdxStopFailure` (closes dthn accumulation)
- `2dd26eed` fixture replay regression guard
- `3dc34dac` R1 P1 fix: atomic ref+status write (codex thread `019ded5d`)
- `e5417f56` R2 fix: per-attempt re-check + 4-outcome retry helper (codex threads `019ded6{1,2,3}`)

New trace reason: `native_subagent_detached_on_stop_failure`. Existing `frame_missing` reused for concurrent SessionEnd race. Existing reasons / IsProxy invariant / L2 turn-aware path all unchanged.

## Codex review track

| Round | Type | Findings | Resolution |
|---|---|---|---|
| R1 | standard | 1 P1 (status persistence skipped after detach) | Fixed in `3dc34dac` — atomic ref+status write |
| R2 attacker | adversarial | 1 high (phantom detach trace on retry race) | Fixed in `e5417f56` — per-attempt re-check |
| R2 defender | adversarial | 1 high (same as attacker) + 1 medium (mid-flight delete test gap) + 1 medium (PR scope drift: docs included) | High+test medium fixed in `e5417f56`; scope-drift medium addressed via this PR description (docs are spec/plan artefacts, separately reviewed) |
| R2 health | adversarial | 1 high (retry exhaustion mislabeled as frame_missing) + 1 medium (same as attacker) | Fixed in `e5417f56` — 4-outcome detachOutcome enum |
| R3 | standard | 0 | Approved |

## LOC vs spec AC9

Spec AC9 caps PR-A at 500 LOC production+tests. Actual after R1+R2 fixes: **production ~225 + tests ~720 = 945 LOC** (well over original cap). Justification:

- Spec §6.1 / plan §1 P1-T3b enumerate 7 mandatory test cases + 1 fixture replay
- R2 review forced extracting `mutateSubagentsAndStatusWithRetry` helper with 4 outcomes (~110 LOC) + 4 helper-level race tests (~150 LOC) for race-safety guarantees
- Each correctness test averages ~50–60 LOC including seed setup, assertion blocks, DB-state verification

Reducing test scope would compromise AC4 (no phantom detach) or R2 race-safety guarantees. Open to discussion on raising AC9 cap (retrospective spec amendment) — current overage reflects review-driven correctness, not bloat.

## Test plan

- [x] `go test ./internal/agent/... ./internal/module/agent/... -count=1` all green (post-R2-fix)
- [x] `go vet ./...` clean
- [x] Targeted race-mode 10 rounds (`-run "TestStopFailure_|TestFindNativeRefByID_|TestMutateSubagentsAndStatus" -race -count=10`) clean
- [x] L2 regression: existing `frame_ops_l2_test.go` `StopFailure parity` cases all green
- [ ] mlab live verify: simulate `pdx hook --agent cc PdxSubagentStart` → `PdxStopFailure` with same `agent_id`; confirm `subagents_json` drops by one ref. Replay with mismatched ID; confirm no detach trace + Status=error + LastSeenAt refresh
- [ ] dthn cleanup post-merge per spec §5 SQL operational sequence (expected primary recovery path; self-heal not viable since historical refs' terminal events predate trace retention)

## Known issues / out of scope

- **Pre-existing race-mode flake**: `TestConsumeSignals_GraceWindowDrop_RearmsAfterTeardown` fails 100% under `-race -count=10`. Memory `kickoff_sweep_drop_idle_timeout` confirms pre-existing. This PR's targeted race tests are clean
- **opencode `PdxStopFailure` no-op**: opencode plugin emits the event but without `agent_id` — derive change is future-proofed but native detach silent until `plugin_template.go` adds the field. Spec §9, R7
- **PR-B (SPA notification debounce)**: separate forthcoming PR per spec §11

## Risk register (spec §8)

R1–R7 mitigations all in tests / fixture replay / pre-check guards / 4-outcome helper. R6 (daemon-restart projection replay cost) addressed by Phase 2 SQL cleanup post-merge (spec §5).