### PR TITLE
fix(files): disableable + close SR-2 (migrate workspaceConfig → settings contribution)

### DIFF
--- a/docs/specs/2026-05-03-files-disableable-sr2-plan.md
+++ b/docs/specs/2026-05-03-files-disableable-sr2-plan.md
@@ -1,0 +1,685 @@
+# Plan — Files module disableable + SR-2 修復
+
+> Date: 2026-05-03  
+> Spec: [`2026-05-03-files-disableable-sr2-spec.md`](./2026-05-03-files-disableable-sr2-spec.md)  
+> Status: Draft (round-2 codex plan review pending — round-1 finding 已修)  
+> Worktree: `.claude/worktrees/files-disableable-sr2` / branch `worktree-files-disableable-sr2`
+
+## 0. 開工前準備
+
+**進 worktree** (已 done — session 已在 `/Users/wake/Workspace/wake/purdex/.claude/worktrees/files-disableable-sr2`)
+
+**確認 staging**:
+```bash
+git status                                # 應該只有 spec 檔 staged
+git diff --cached --stat                  # 確認無 spec 以外檔案 leak
+```
+
+**Subagent task brief**：每個 Bash 都要 `cd <worktree-path> && ...`（feedback_subagent_cwd_enforcement）。
+
+**驗證指令**（每 commit 跑一次）：
+```bash
+pnpm --prefix spa exec vitest run
+pnpm --prefix spa exec tsc -p tsconfig.app.json --noEmit
+pnpm --prefix spa run lint
+pnpm --prefix spa run build
+```
+建議 commit-1 跑完整套；commit 2-4 在開發中先跑 affected `vitest run <path>`，最後一個 commit 完整跑全套。
+
+## 1. Commit 1 — i18n keys + `SETTINGS_ORDER.WORKSPACE_FILES`
+
+### 1.1 觸碰檔案
+- `spa/src/locales/en.json`
+- `spa/src/locales/zh-TW.json`
+- `spa/src/lib/settings-order.ts`
+
+### 1.2 i18n keys 新增（en + zh-TW 對齊）
+
+en.json 三個新 key（依字母 order 插在合適位置）：
+```json
+"modules.files.description": "Workspace and session file tree, with click-to-open into the Editor",
+"settings.files.project_path.label": "Project path",
+"settings.section.files_workspace": "Files",
+```
+
+zh-TW.json 對應（注意 `settings.section.files_workspace` 改用「檔案」對齊既有「終端機」/「外觀」風格）：
+```json
+"modules.files.description": "工作區與 Session 檔案樹，可點擊開啟至 Editor",
+"settings.files.project_path.label": "專案路徑",
+"settings.section.files_workspace": "檔案",
+```
+
+**插入位置（精確 line 對齊既有檔案，subagent 直接照插）**：
+
+en.json：
+- `modules.files.description` → 插在 line 24 後（`modules.quick_commands.description` 之後），形成 editor → browser → memory_monitor → quick_commands → files 群組（依既有非字母順序，append 風格）。
+- `settings.section.files_workspace` → 插在 line 145 後（`settings.section.editor` 之後）。
+- `settings.files.project_path.label` → 插在 line 165 後（`settings.editor` block 起始之前；獨立放在 `settings.editor.title` 之前更乾淨；如環境位置已偏，subagent 取「`settings.editor.*` block 之前」原則處理）。
+
+zh-TW.json：對應 en.json 行號鏡像（zh-TW.json 結構同 en.json）；如 zh-TW.json line offset 與 en.json 不同，subagent 用「相同 key 鄰居」策略找位置。
+
+### 1.3 `SETTINGS_ORDER.WORKSPACE_FILES` 新增
+
+`spa/src/lib/settings-order.ts` diff（**整段 docblock 改寫，明確 order values are scoped per settings scope，避免讀者把 purdex MODULE_CONFIG=10 與 workspace WORKSPACE_FILES=10 誤讀為撞號**）：
+
+```diff
+ /**
+- * Centralized order constants for the Settings sidebar.
+- *
+- * The sidebar is grouped into bands so visual ordering communicates intent:
+- *
+- *   | Band                        | Range  | Examples                                  |
+- *   |-----------------------------|--------|-------------------------------------------|
+- *   | Top built-in (core)         | 0 – 4  | Appearance / Terminal / Interface         |
+- *   | Top conditional built-in    | 5 – 9  | Electron (gated by canSystemTray)         |
+- *   | Modules switchboard         | 10     | `module-config` (single header row)       |
+- *   | Module-owned                | 11–19  | Editor / Quick Commands / Perf / Sync     |
+- *   | Tail built-in               | 20–29  | Dev Environment / Tmux Agent Monitor      |
++ * Centralized order constants for the Settings sidebar.
++ *
++ * Order values are **scoped per settings scope** (`purdex` / `workspace` /
++ * `host`); the sidebar sorts each scope's contributions independently. The
++ * tables below describe the visual bands within each scope. Numbers can
++ * legitimately repeat across scopes (e.g. purdex `MODULE_CONFIG = 10` and
++ * workspace `WORKSPACE_FILES = 10`) — they never compete because contribution
++ * lists are filtered by scope before sorting.
++ *
++ * **purdex scope** — sidebar at `/settings`:
++ *
++ *   | Band                        | Range  | Examples                                  |
++ *   |-----------------------------|--------|-------------------------------------------|
++ *   | Top built-in (core)         | 0 – 4  | Appearance / Terminal / Interface         |
++ *   | Top conditional built-in    | 5 – 9  | Electron (gated by canSystemTray)         |
++ *   | Modules switchboard         | 10     | `module-config` (single header row)       |
++ *   | Module-owned                | 11–19  | Editor / Quick Commands / Perf / Sync     |
++ *   | Tail built-in               | 20–29  | Dev Environment / Tmux Agent Monitor      |
++ *
++ * **workspace scope** — sidebar at `/settings/workspaces/<id>`:
++ *
++ *   | Band                        | Range  | Examples                                  |
++ *   |-----------------------------|--------|-------------------------------------------|
++ *   | Module-owned                | 0 – 19 | Editor home path (inline 0) / Files (10)  |
++ *
++ * **host scope** — sidebar at `/settings/hosts/<id>`:
++ *
++ *   | Band                        | Range   | Examples                                 |
++ *   |-----------------------------|---------|------------------------------------------|
++ *   | Module-owned                | 0 – 199 | Editor home path (inline 100)            |
+  *
+  * `register-modules/index.tsx`, `editor-module.tsx`, and any future
+  * `registerSettingsSection` / `registerModule({ settings: [...] })` call
+  * MUST import from this file instead of hard-coding numbers. Reviewers
+  * watch for hard-coded `order:` literals during PR review.
+  *
+  * Spec §4.1.3 (PR-2 final values). PR-1's transitional `*_PR1` constants
+  * were removed by PR-2 commit 5 once Editor was consolidated and Sync
+  * was promoted to a structural module.
+  */
+ export const SETTINGS_ORDER = {
++  // ---- purdex scope ---------------------------------------------------
+   // Top built-in (core) — always present.
+   APPEARANCE: 0,
+   TERMINAL: 1,
+   INTERFACE: 2,
+   // Top conditional built-in.
+   ELECTRON: 5,
+   // Modules switchboard — single row, header of the modules group.
+   MODULE_CONFIG: 10,
+   // Module-owned (PR-2 final order).
+   MODULE_EDITOR: 11,
+   MODULE_QUICK_COMMANDS: 12,
+   MODULE_PERFORMANCE_MONITOR: 13,
+   MODULE_SYNC: 14,
+   // Tail built-in — dev / debug surfaces.
+   DEV_ENVIRONMENT: 20,
+   TMUX_AGENT_MONITOR: 21,
++  // ---- workspace scope ------------------------------------------------
++  WORKSPACE_FILES: 10,
+ } as const
+```
+
+> 注意：（1）`WORKSPACE_FILES = 10` 放在 workspace section 註解後（檔尾）；（2）數字 `10` 與 purdex `MODULE_CONFIG = 10` 重複是 by-design，docblock 已說明 per-scope 獨立；（3）Editor inline 0 / 100 暫不收編（spec §4.1 註解備案）。
+
+### 1.4 TDD（commit 1）
+- 此 commit 純資料 / 常數，沒有新功能 → 無新測試。
+- 既有測試應 0 影響。
+- 驗證：跑全套 vitest / tsc / lint / build，預期全綠（`SETTINGS_ORDER.WORKSPACE_FILES` 有定義但無消費者）。
+
+### 1.5 Commit message
+```
+chore(settings): seed i18n keys + SETTINGS_ORDER.WORKSPACE_FILES for Files module migration
+
+Setup commit for SR-2 fix (Files module disableable). Adds three i18n keys
+(modules.files.description, settings.section.files_workspace,
+settings.files.project_path.label) and the WORKSPACE_FILES = 10 order
+constant. No functional change; subsequent commits consume them.
+
+Spec: docs/specs/2026-05-03-files-disableable-sr2-spec.md §1.x
+```
+
+## 2. Commit 2 — `FilesWorkspaceSettingsSection` 元件 + 單元測試
+
+### 2.1 觸碰檔案
+- 新檔 `spa/src/components/settings/FilesWorkspaceSettingsSection.tsx`
+- 新檔 `spa/src/components/settings/FilesWorkspaceSettingsSection.test.tsx`
+
+### 2.2 元件實作
+
+```tsx
+// spa/src/components/settings/FilesWorkspaceSettingsSection.tsx
+import { useId } from 'react'
+import { useWorkspaceStore } from '../../features/workspace/store'
+import { useI18nStore } from '../../stores/useI18nStore'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
+
+interface Props {
+  ctx: SettingsContextFor<'workspace'>
+}
+
+export function FilesWorkspaceSettingsSection({ ctx }: Props) {
+  if (ctx.scope !== 'workspace') return null
+  return <Body workspaceId={ctx.workspaceId} />
+}
+
+function Body({ workspaceId }: { workspaceId: string }) {
+  const t = useI18nStore((s) => s.t)
+  const projectPath = useWorkspaceStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.moduleConfig?.['files']?.['projectPath'],
+  )
+  const value = typeof projectPath === 'string' ? projectPath : ''
+  const inputId = useId()
+
+  const handleChange = (next: string) => {
+    useWorkspaceStore.getState().setModuleConfig(workspaceId, 'files', 'projectPath', next)
+  }
+
+  return (
+    <div className="flex items-center justify-between py-1">
+      <label htmlFor={inputId} className="text-xs text-text-secondary">
+        {t('settings.files.project_path.label')}
+      </label>
+      <input
+        id={inputId}
+        className="w-48 px-2 py-0.5 rounded border border-border-default bg-surface-primary text-xs text-text-primary"
+        type="text"
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+      />
+    </div>
+  )
+}
+```
+
+設計筆記：
+- `useId()` for stable input id（與 `ConfigField` 一致）。
+- `useWorkspaceStore` selector 走「找 workspace → 讀 moduleConfig」鏈，nullish chain 保 storage shape 缺失安全（與 `FileTreeView.tsx:24` 完全等價）。
+- onChange-immediate（不對齊 EditorHomePathWorkspaceSection 的 trim/blur）— spec §4.2 已說明。
+- `if (ctx.scope !== 'workspace') return null` 是型別 narrowing 兼運行守則。
+
+### 2.3 TDD — 兩階段紅綠
+
+**階段 A — Stub commit-step**：先建立最小 stub `FilesWorkspaceSettingsSection.tsx` 只 export `() => null`，讓測試 import 不爆但行為紅：
+
+```tsx
+// stub
+export function FilesWorkspaceSettingsSection(_props: { ctx: any }) { return null }
+```
+
+**階段 B — Test-first 行為紅**：寫下方測試，預期：
+- "renders empty value when no projectPath is set" → 紅（找不到 `textbox`）
+- "renders existing projectPath" → 紅（找不到 `textbox`）
+- "writes back to ..." → 紅
+- "label uses i18n key ..." → 紅
+- "returns null when ctx scope is not workspace" → 綠（stub 永遠 null）
+
+**階段 C — 實作補綠**：把元件改寫成 §2.2 完整實作；五個 test 全綠。
+
+> 此三段必須在同一 commit 內完成（commit 2 是「component + tests」單一語意），不分多 commit。階段命名只是 subagent 內部執行步驟說明。
+
+`FilesWorkspaceSettingsSection.test.tsx`：
+
+```tsx
+import { vi } from 'vitest'
+vi.mock('../../stores/useI18nStore', () => ({
+  useI18nStore: Object.assign(vi.fn((sel: any) => sel({ t: (k: string) => k })), {
+    getState: () => ({ t: (k: string) => k }),
+  }),
+}))
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { FilesWorkspaceSettingsSection } from './FilesWorkspaceSettingsSection'
+import { useWorkspaceStore } from '../../features/workspace/store'
+
+describe('FilesWorkspaceSettingsSection', () => {
+  let wsId: string
+
+  beforeEach(() => {
+    cleanup()
+    useWorkspaceStore.getState().reset()
+    const ws = useWorkspaceStore.getState().addWorkspace('Test')
+    wsId = ws.id
+  })
+
+  it('returns null when ctx scope is not workspace', () => {
+    // narrow guard branch
+    // @ts-expect-error — feeding wrong-scope ctx to verify runtime guard
+    const { container } = render(<FilesWorkspaceSettingsSection ctx={{ scope: 'purdex' }} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders empty value when no projectPath is set', () => {
+    render(<FilesWorkspaceSettingsSection ctx={{ scope: 'workspace', workspaceId: wsId }} />)
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('')
+  })
+
+  it('renders existing projectPath', () => {
+    useWorkspaceStore.getState().setModuleConfig(wsId, 'files', 'projectPath', '/home/user/proj')
+    render(<FilesWorkspaceSettingsSection ctx={{ scope: 'workspace', workspaceId: wsId }} />)
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('/home/user/proj')
+  })
+
+  it('writes back to useWorkspaceStore.moduleConfig.files.projectPath on change', () => {
+    render(<FilesWorkspaceSettingsSection ctx={{ scope: 'workspace', workspaceId: wsId }} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '/new/path' } })
+    const stored = useWorkspaceStore
+      .getState()
+      .workspaces.find((w) => w.id === wsId)?.moduleConfig?.['files']?.['projectPath']
+    expect(stored).toBe('/new/path')
+  })
+
+  it('label uses i18n key settings.files.project_path.label', () => {
+    render(<FilesWorkspaceSettingsSection ctx={{ scope: 'workspace', workspaceId: wsId }} />)
+    expect(screen.getByLabelText('settings.files.project_path.label')).toBeInTheDocument()
+  })
+})
+```
+
+> Pattern 對齊 `ModuleConfigSection.test.tsx`（也用 i18n mock + render + fireEvent）。`useWorkspaceStore.reset()` 清狀態。
+
+### 2.4 驗證
+```bash
+pnpm --prefix spa exec vitest run spa/src/components/settings/FilesWorkspaceSettingsSection.test.tsx
+```
+預期：5 tests pass。
+
+### 2.5 Commit message
+```
+feat(settings): add FilesWorkspaceSettingsSection workspace-scope component
+
+New self-contained component for the Files module's projectPath setting.
+Reads/writes useWorkspaceStore.workspaces[wsId].moduleConfig.files.projectPath
+(same path FileTreeView already uses), so the storage shape is unchanged.
+
+Not yet wired into the registry — commit 3 migrates the Files module to
+settings: [{ scope: 'workspace' }] and references this component.
+
+Spec: docs/specs/2026-05-03-files-disableable-sr2-spec.md §4.2
+```
+
+## 3. Commit 3 — Files module 遷移 + SR-2 拔註解
+
+### 3.1 觸碰檔案
+- `spa/src/lib/register-modules/index.tsx`
+- `spa/src/lib/dispatch-settings-contributions.ts`
+- `spa/src/lib/register-modules.test.ts`（修既有測試）
+- `spa/src/features/workspace/components/WorkspaceSettingsPage.tsx`（移除 ModuleConfigSection 渲染掛載點）
+- 不動：`spa/src/components/settings/ModuleConfigSection.tsx`（自然 dead；follow-up issue 拆）
+
+### 3.2 `register-modules/index.tsx` Files 區塊改寫
+
+完整 diff：
+```diff
+   // FS backends
+   registerBuiltinFsBackends(caps)
+
+   registerModule({
+     id: 'files',
+     name: 'Files',
+-    // SR-2 (codex review #617): intentionally NOT flagged disableable yet.
+-    // The module's only settings surface lives in `workspaceConfig`, which
+-    // `WorkspaceSettingsPage` renders through `ModuleConfigSection` — a path
+-    // that does not consult `useModuleEnabledStore`. Toggling would be a lie
+-    // until PR 3 wires workspace-scope legacy contributions into the filter.
+-    workspaceConfig: [
+-      { key: 'projectPath', type: 'string', label: '專案路徑' },
+-    ],
++    disableable: true,
++    descriptionKey: 'modules.files.description',
++    settings: [
++      {
++        localId: 'workspace-files',
++        scope: 'workspace',
++        order: SETTINGS_ORDER.WORKSPACE_FILES,
++        labelKey: 'settings.section.files_workspace',
++        component: FilesWorkspaceSettingsSection,
++      },
++    ],
+     views: [
+       ...
+     ],
+   })
+```
+
+新增 import（檔案頂部）：
+```ts
+import { FilesWorkspaceSettingsSection } from '../../components/settings/FilesWorkspaceSettingsSection'
+```
+
+### 3.3 `dispatch-settings-contributions.ts` 清理
+
+```diff
+-// PR-5 deprecation: module authors using `globalConfig` / `workspaceConfig`
+-// should migrate to `settings: [{ scope, localId }]`. `files` is exempt until
+-// the files owner completes its refactor.
+-const DEPRECATED_LEGACY_CONFIG_EXEMPT: ReadonlySet<string> = new Set(['files'])
++// PR-5 deprecation: module authors using `globalConfig` / `workspaceConfig`
++// should migrate to `settings: [{ scope, localId }]`. Empty exempt set kept
++// as a future-friendly escape hatch — add a moduleId here to silence the
++// deprecation warning while a migration is in flight.
++const DEPRECATED_LEGACY_CONFIG_EXEMPT: ReadonlySet<string> = new Set()
+```
+
+### 3.4 `WorkspaceSettingsPage.tsx` 移除 ModuleConfigSection 掛載點
+
+```diff
+ import { WorkspaceIconPicker } from './WorkspaceIconPicker'
+ import { WorkspaceDeleteDialog } from './WorkspaceDeleteDialog'
+-import { ModuleConfigSection } from '../../../components/settings/ModuleConfigSection'
+
+ ...
+
+         {/* Icon */}
+         <section className="mb-8">
+           ...
+         </section>
+
+-        {/* Module Settings */}
+-        <ModuleConfigSection scope={{ workspaceId }} />
+-
+         {/* Registry-driven workspace-scoped contributions.
+             ... */}
+         {workspaceContributions.map((c) => {
+```
+
+**理由更正（codex round-1 P1）**：Files 拔 `workspaceConfig` 後 `getModulesWithWorkspaceConfig()` 自動回 `[]`，`ModuleConfigSection.tsx:16` 的 `if (modules.length === 0) return null` 會讓元件不渲染任何 DOM。所以「移除 mount」**不是功能上必要**（disable filter 已透過 `settings: [...]` 路徑生效），而是 housekeeping：
+
+- 移除後讀者看 `WorkspaceSettingsPage.tsx` 不會再對「為什麼有個 `<ModuleConfigSection>` 但好像沒輸出」困惑。
+- 與 spec N2「不刪 `ModuleConfigSection.tsx` 檔案 / 欄位 / helper」對齊：本 PR 只拔 mount call，`ModuleConfigSection.tsx` 元件本體仍在。
+
+> 風險評估：若 `ModuleConfigSection.tsx` 被任何**外部**（test / dev tool / story）引用，移除 import 不會影響它們。`rg "ModuleConfigSection" spa/src` 確認過：唯二引用是 `WorkspaceSettingsPage.tsx`（mount 點 — 本 PR 移除）和 `ModuleConfigSection.test.tsx`（自身測試 — 不動）。
+
+### 3.5 修既有測試 `register-modules.test.ts`
+
+刪掉 `does NOT warn for files module (exempted during transition)`（現有 line 479-488）。新增一個更具體的：
+
+```ts
+it('does NOT emit any deprecation warning for the real Files bootstrap', () => {
+  registerBuiltinModules()
+  const msgs = (warnSpy.mock.calls as unknown[][]).map((c) => String(c[0]))
+  expect(msgs.some((m) => m.includes('files') && m.includes('deprecated'))).toBe(false)
+})
+```
+
+> 放在同個 `describe('ModuleDefinition.globalConfig / workspaceConfig deprecation (PR-5)', ...)` 裡。`registerBuiltinModules()` 在既有 `register-modules.test.ts:58-145` 已被大量直接呼叫且不需特別 mock — `getPlatformCapabilities()` 對 vitest 環境下缺 `window.electronAPI` 是 safe fallback，FS backend / sync registry 寫入都是同步 in-memory；不再保留窄 fixture fallback（codex round-1 P1：fallback 會弱化 SR-2 真實驗證，而 real bootstrap 已可用）。
+
+### 3.6 TDD — 紅先（disable filter 接得到的測試）
+
+對應 spec §6.1 #1 / #2 / #3 / #4。**重點：codex round-1 P0 — 「Files disabled → 無 contribution」單獨測試會 false-green（current Files 沒有任何 workspace contribution，所以 disabled 時 list 本來就空），無法證明 SR-2 修好。修法：在同一 test 內先驗 enabled 出現 → reset → disabled 不出現。**（legacy hardcoded `'專案路徑'` label absence 在 §4.2 UI test 另驗，registry test 不覆蓋 DOM path — codex round-2 P2 釐清。）
+
+```ts
+// 在 register-modules.test.ts 新 describe block
+// 補上既有 ./module-registry import 中尚未列入的 getModule（既有檔已 import clearModuleRegistry / getModules / getPaneRenderer / registerModule — codex round-2 P1）
+import { getModule } from './module-registry'
+import { useModuleEnabledStore } from '../stores/useModuleEnabledStore'
+import { SETTINGS_ORDER } from './settings-order'
+
+describe('Files module — SR-2 fix (disable filter via settings contribution)', () => {
+  beforeEach(() => {
+    clearAll()  // 沿用既有 helper（已含 clearModuleRegistry / clearContributions）
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  })
+
+  afterEach(() => {
+    clearAll()
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  })
+
+  it('Files registers with disableable: true + descriptionKey + no workspaceConfig', () => {
+    registerBuiltinModules()
+    const filesMod = getModule('files')!
+    expect(filesMod.disableable).toBe(true)
+    expect(filesMod.descriptionKey).toBe('modules.files.description')
+    expect(filesMod.workspaceConfig).toBeUndefined()
+  })
+
+  it('Files contributes a workspace-scope settings entry with correct localId/order', () => {
+    registerBuiltinModules()
+    const list = listContributions('workspace')
+    const filesEntry = list.find((c) => c.id === 'files.workspace-files')
+    expect(filesEntry).toBeDefined()
+    expect(filesEntry?.scope).toBe('workspace')
+    expect(filesEntry?.order).toBe(SETTINGS_ORDER.WORKSPACE_FILES)
+    expect(filesEntry?.labelKey).toBe('settings.section.files_workspace')
+    expect(filesEntry?.moduleId).toBe('files')
+  })
+
+  // CRITICAL: same-test before/after compare to avoid false-green from
+  // "Files never had a workspace contribution to begin with" (codex R1 P0).
+  it('reload-after-disable: Files contribution present when enabled, absent when disabled before bootstrap', () => {
+    // Step 1 — Files enabled (default) → Files contribution present
+    registerBuiltinModules()
+    const enabledList = listContributions('workspace')
+    expect(enabledList.find((c) => c.id === 'files.workspace-files')).toBeDefined()
+
+    // Step 2 — reset state and bootstrap with Files persisted-disabled
+    clearAll()
+    useModuleEnabledStore.setState({ enabled: { files: false }, baseline: null })
+    registerBuiltinModules()
+    const disabledList = listContributions('workspace')
+    expect(disabledList.find((c) => c.id === 'files.workspace-files')).toBeUndefined()
+  })
+})
+```
+
+> 注意：`registerBuiltinModules()` 在既有 vitest 環境已大量被呼叫（line 58-145），不需額外 mock（codex R1 P1 確認）。新 describe 的 beforeEach + afterEach 都顯式 reset `useModuleEnabledStore` 是必要的 — `enabled` 由 persist middleware 寫到 storage（`useModuleEnabledStore.ts:79, 112-119`），不 reset 會讓 case 順序影響後續 test。
+
+### 3.7 整合測試 `WorkspaceSettingsPage.registry.test.tsx` — 留到 commit 4
+
+### 3.8 驗證
+```bash
+pnpm --prefix spa exec vitest run spa/src/lib/register-modules.test.ts
+pnpm --prefix spa exec vitest run spa/src/lib/dispatch-settings-contributions.test.ts
+pnpm --prefix spa exec tsc -p tsconfig.app.json --noEmit
+pnpm --prefix spa run lint
+```
+
+預期：
+- `register-modules.test.ts` 既有 ~30+ tests + 新增 3-4 tests 全綠（其中刪了 1 個 `does NOT warn for files module (exempted during transition)`）。
+- `dispatch-settings-contributions.test.ts` 全綠（dual-declaration / F1 / etc 不受影響）。
+- tsc / lint clean。
+
+### 3.9 Commit message
+```
+refactor(files): migrate Files module from workspaceConfig to settings contribution (close SR-2)
+
+Files now declares `disableable: true` + `settings: [{ scope: 'workspace' }]`
+instead of the deprecated `workspaceConfig`. This wires the module's
+projectPath setting into `dispatchSettingsContributions`'s disable filter,
+so toggling Files off in the Modules Switchboard actually hides the
+setting (after a reload, matching alpha.288's reload-required UX).
+
+Changes:
+- register-modules/index.tsx: Files block rewritten; SR-2 inline comment removed
+- dispatch-settings-contributions.ts: drop 'files' from DEPRECATED_LEGACY_CONFIG_EXEMPT
+  and update the surrounding comment
+- WorkspaceSettingsPage.tsx: remove now-dead <ModuleConfigSection> mount
+- register-modules.test.ts: drop the "files exempted during transition" test
+  and add coverage for the new disable-filter path
+
+Storage shape unchanged — moduleConfig.files.projectPath still backs the value;
+existing readers (FileTreeView, file-open-bootstrap) unaffected.
+
+Spec: docs/specs/2026-05-03-files-disableable-sr2-spec.md §4.1, §4.3, §6.1
+Closes SR-2 from PR #617.
+```
+
+## 4. Commit 4 — 整合測試（補 UI coverage，非 TDD 紅綠 commit）
+
+**定位調整（codex round-1 P0）**：commit 3 已落地實作 + registry 層測試，commit 4 是「補 UI 渲染層 coverage」而非 TDD 紅綠 commit。Commit message 與 spec §6.3 強調 coverage 性質。下方 test 若在 commit 3 之後寫，本就會直接綠 — 這是預期行為，不違反 TDD 紀律（registry 層的紅綠在 commit 3 §3.6 已完成）。
+
+### 4.1 觸碰檔案
+- `spa/src/features/workspace/components/WorkspaceSettingsPage.registry.test.tsx`
+
+### 4.2 新增測試（spec §6.3 #9 #10）
+
+在既有 `describe('WorkspaceSettingsPage — workspace-scoped registry rendering', ...)` 後新增：
+
+```tsx
+import { registerBuiltinModules } from '../../../lib/register-modules'
+import { clearModuleRegistry } from '../../../lib/module-registry'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
+
+describe('WorkspaceSettingsPage — Files module integration (SR-2)', () => {
+  let wsId: string
+
+  beforeEach(() => {
+    cleanup()
+    clearModuleRegistry()
+    clearContributions()
+    useWorkspaceStore.getState().reset()
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+    const ws = useWorkspaceStore.getState().addWorkspace('Test WS')
+    wsId = ws.id
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearContributions()
+    clearModuleRegistry()
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  })
+
+  // CRITICAL: same-test before/after compare to prove SR-2 fix actually wires
+  // the disable filter (codex R1 P0). Reuse render() output to verify the
+  // legacy hardcoded `'專案路徑'` label is also gone — that string used to
+  // come from ConfigField + ModuleConfigSection's deprecated path; if it
+  // still shows up, the SR-2 mount removal is incomplete.
+  it('reload-after-disable: Files header/input render when enabled, disappear when disabled before bootstrap', () => {
+    // Step 1 — Files enabled (default) → header + input rendered
+    registerBuiltinModules()
+    const { unmount } = render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(screen.getByText('settings.section.files_workspace')).toBeInTheDocument()
+    expect(screen.getByLabelText('settings.files.project_path.label')).toBeInTheDocument()
+    // Legacy hardcoded label from old ConfigField path must be gone
+    expect(screen.queryByText('專案路徑')).toBeNull()
+    unmount()
+
+    // Step 2 — reset registries + state, bootstrap with Files persisted-disabled
+    clearModuleRegistry()
+    clearContributions()
+    useModuleEnabledStore.setState({ enabled: { files: false }, baseline: null })
+    registerBuiltinModules()
+    render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(screen.queryByText('settings.section.files_workspace')).toBeNull()
+    expect(screen.queryByLabelText('settings.files.project_path.label')).toBeNull()
+  })
+})
+```
+
+> 注意 imports: `registerBuiltinModules`、`clearModuleRegistry`、`useModuleEnabledStore` 都要加；既有檔頂部已有 `clearContributions` / `useWorkspaceStore`。
+
+### 4.3 驗證
+```bash
+pnpm --prefix spa exec vitest run spa/src/features/workspace/components/WorkspaceSettingsPage.registry.test.tsx
+pnpm --prefix spa exec vitest run                # 完整跑一次確認沒打到別人
+pnpm --prefix spa exec tsc -p tsconfig.app.json --noEmit
+pnpm --prefix spa run lint
+pnpm --prefix spa run build
+```
+
+預期：~3200 tests + 新增 ≈ 9（commit 2 五個 + commit 3 四個 + commit 4 兩個 - commit 3 刪一個 = 淨增約 8），全綠。
+
+### 4.4 Commit message
+```
+test(settings): add WorkspaceSettingsPage UI coverage for Files module enable/disable (SR-2)
+
+Coverage commit (not TDD red→green — registry layer red→green is in commit 3).
+Adds end-to-end UI verification of the reload-after-disable contract:
+registerBuiltinModules() + render(<WorkspaceSettingsPage>) with Files
+enabled vs disabled-before-bootstrap. Same-test before/after compare proves
+the SR-2 fix actually wires the disable filter; explicit `'專案路徑'`
+absence assertion guards against the legacy ConfigField path leaking back.
+
+Spec: docs/specs/2026-05-03-files-disableable-sr2-spec.md §6.3
+```
+
+## 5. 風險點 / Rollback
+
+| 風險 | 影響 | 偵測 | Rollback |
+|---|---|---|---|
+| `registerBuiltinModules()` 在測試環境噴 capability 缺漏 | commit 3 / 4 紅 | vitest run output | 改用窄 fixture（直接 registerModule + dispatch）替代 `registerBuiltinModules()` |
+| `WorkspaceSettingsPage.tsx` 拿掉 ModuleConfigSection 後，現存 `WorkspaceSettingsPage.registry.test.tsx` 既有 case 撞到（如 baseline 測試 querySelector 路徑） | commit 3 紅 | vitest run | 修既有測試的 selector，不還原刪掉的掛載點 |
+| `useWorkspaceStore.reset()` 清掉測試前 setup 的 workspace | commit 2 / 4 紅 | vitest output `wsId is undefined` | beforeEach 內先 reset 後 addWorkspace（已照此順序） |
+| zustand persist 副作用洩漏（test 跑完 localStorage 殘留 enabled.files=false） | follow-on test 紅（看狀態） | vitest output | beforeEach 強制 `useModuleEnabledStore.setState({ enabled: {}, baseline: null })` |
+| Bundle size 影響（新增 component） | 微（< 1KB gzipped） | `pnpm --prefix spa run build` 看 size 報告 | 不需 rollback |
+
+**Rollback 路徑**：每個 commit 獨立可 revert。若 commit 4 出包，留 commit 1-3（disable filter 已生效）；若 commit 3 出包，留 commit 1-2（純準備 + 元件，無功能變更）。
+
+## 6. PR description 草稿
+
+```markdown
+## Summary
+
+Close SR-2 from codex review of PR #617: migrate Files module from
+deprecated `workspaceConfig` to `settings: [{ scope: 'workspace' }]` so
+the Modules Switchboard's disable filter actually hides the projectPath
+setting. Files is now `disableable: true` and behaves identically to
+Editor / Quick Commands / Performance Monitor (reload-required UX).
+
+Spec: [`2026-05-03-files-disableable-sr2-spec.md`](docs/specs/2026-05-03-files-disableable-sr2-spec.md)
+Plan: [`2026-05-03-files-disableable-sr2-plan.md`](docs/specs/2026-05-03-files-disableable-sr2-plan.md)
+
+## Changes
+
+- `register-modules/index.tsx` — Files: `disableable: true` + `settings: [...]` + drop SR-2 inline comment
+- `dispatch-settings-contributions.ts` — drop `'files'` from `DEPRECATED_LEGACY_CONFIG_EXEMPT` + update surrounding comment
+- `WorkspaceSettingsPage.tsx` — drop now-dead `<ModuleConfigSection>` mount
+- New: `FilesWorkspaceSettingsSection.tsx` — workspace-scope settings UI for projectPath (storage path unchanged)
+- New: `SETTINGS_ORDER.WORKSPACE_FILES = 10` — first workspace-scope constant
+- 3 new i18n keys (en + zh-TW)
+- Tests: ~8 net additions, 1 deletion
+
+## Storage
+
+Storage shape **unchanged**: `useWorkspaceStore.workspaces[wsId].moduleConfig.files.projectPath`.
+All existing readers (`FileTreeView`, `file-open-bootstrap.ts`) untouched.
+
+## Test plan
+
+> Subagent 跑完 PR 開立前驗證後，再把下方 `[ ]` 換成 `[x]`。
+
+- [ ] `pnpm --prefix spa exec vitest run` — full suite green
+- [ ] `pnpm --prefix spa exec tsc -p tsconfig.app.json --noEmit` — 0 errors
+- [ ] `pnpm --prefix spa run lint` — 0 errors
+- [ ] `pnpm --prefix spa run build` — passes
+- [ ] **mlab live verify**:
+  - [ ] `/settings/module-config` lists Files toggle row with description text
+  - [ ] Disable Files (without reload) → workspace settings still shows Files (live toggle does not re-dispatch); ReloadBanner appears
+  - [ ] Reload → workspace settings no longer shows Files header / input
+  - [ ] Re-enable + reload → Files header / input return with prior value
+  - [ ] file-tree workspace/session views still mountable into sidebar even when Files disabled (I4 known limitation)
+  - [ ] Browser console no longer warns `[module] files uses deprecated workspaceConfig`
+
+## Follow-up issues
+
+- F-1 (planned): drop `ModuleConfigSection.tsx` + `getModulesWith*Config()` helpers + `ModuleDefinition.workspaceConfig` / `globalConfig` fields once no module uses them
+- F-2: clean stale comment in `ModulesSwitchboardSection.tsx` lines 64-68 (mentions `editor/files/browser/memory-monitor` having no purdex contribution; no longer accurate)
+- F-3: if "all disableable modules need a settings page" rule is ever adopted, add Files purdex placeholder for symmetry with Browser
+```
+
+## 7. Resolved decisions（codex round-1 review 後收斂）
+
+- Q1（resolved）：commit 3 移除 `<ModuleConfigSection>` mount 不拆獨立 commit。理由更正（codex R1 P1.5）— 移除**不是**功能需要，是 housekeeping；但歸到 commit 3 仍合理，因 commit 3 是「Files 遷移與 SR-2 收尾」單一語意。spec N2 講「不刪 component file」與本 PR 拔 mount 不矛盾（檔案保留、call site 拔）。
+- Q2（resolved）：不收編 Editor 的 inline `workspace-home-path` / `host-home-path` 進 SETTINGS_ORDER。理由：（1）超出本 PR scope；（2）Editor 既有風格穩定；（3）`settings-order.ts` 註解 workspace band 已標明 Editor inline 0 是 known legacy；（4）codex R1 Q2 確認此判斷正確。改用 follow-up issue（已收進 spec §9 F-X 之外的 backlog）。
+- Q3（resolved）：`registerBuiltinModules()` 在測試環境可直接呼叫，不需先補 stub。codex R1 Q3 已確認：`getPlatformCapabilities()` 對缺 `window.electronAPI` 是 safe fallback、FS / sync registry 寫入都是同步 in-memory。窄 fixture fallback 已從 plan 移除（codex R1 P1.4）。

--- a/docs/specs/2026-05-03-files-disableable-sr2-plan.md
+++ b/docs/specs/2026-05-03-files-disableable-sr2-plan.md
@@ -323,8 +323,9 @@ Spec: docs/specs/2026-05-03-files-disableable-sr2-spec.md §4.2
 - `spa/src/lib/register-modules/index.tsx`
 - `spa/src/lib/dispatch-settings-contributions.ts`
 - `spa/src/lib/register-modules.test.ts`（修既有測試）
-- `spa/src/features/workspace/components/WorkspaceSettingsPage.tsx`（移除 ModuleConfigSection 渲染掛載點）
+- ~~`spa/src/features/workspace/components/WorkspaceSettingsPage.tsx`（移除 ModuleConfigSection 渲染掛載點）~~ — **撤銷**，見 §3.4。
 - 不動：`spa/src/components/settings/ModuleConfigSection.tsx`（自然 dead；follow-up issue 拆）
+- 不動：`spa/src/features/workspace/components/WorkspaceSettingsPage.tsx`（mount 點保留作 escape hatch）
 
 ### 3.2 `register-modules/index.tsx` Files 區塊改寫
 
@@ -380,34 +381,18 @@ import { FilesWorkspaceSettingsSection } from '../../components/settings/FilesWo
 +const DEPRECATED_LEGACY_CONFIG_EXEMPT: ReadonlySet<string> = new Set()
 ```
 
-### 3.4 `WorkspaceSettingsPage.tsx` 移除 ModuleConfigSection 掛載點
+### 3.4 `WorkspaceSettingsPage.tsx` mount 處理
 
-```diff
- import { WorkspaceIconPicker } from './WorkspaceIconPicker'
- import { WorkspaceDeleteDialog } from './WorkspaceDeleteDialog'
--import { ModuleConfigSection } from '../../../components/settings/ModuleConfigSection'
+**最終決定（codex PR adversarial round-1 high finding）**：mount call **保留不動**。
 
- ...
+原 plan 是移除 `<ModuleConfigSection>` 的 import + mount（housekeeping 動機）。但 codex PR adversarial review 抓到：移除 mount 會把 deprecated `workspaceConfig` API 的唯一 render 入口拆掉，而 `DEPRECATED_LEGACY_CONFIG_EXEMPT` 仍是 supported escape hatch、`ModuleConfigSection.tsx` 也仍存在 — 這對任何 in-flight migration 或 out-of-tree 仍用 `workspaceConfig` 的 module 是 silent failure。
 
-         {/* Icon */}
-         <section className="mb-8">
-           ...
-         </section>
+修正方案：
+- `WorkspaceSettingsPage.tsx` 不動 — `import { ModuleConfigSection }` 保留、`<ModuleConfigSection scope={{ workspaceId }} />` mount call 保留。
+- 對 Files migration 無功能影響：Files 拔 `workspaceConfig` 後 `getModulesWithWorkspaceConfig()` 回 `[]`，`ModuleConfigSection.tsx:16` 的 early return 讓元件不輸出 DOM。
+- 完整拆（mount + ModuleConfigSection.tsx + helpers + workspaceConfig/globalConfig 欄位）一次清在 F-1 follow-up，**不在本 PR 切兩半**。
 
--        {/* Module Settings */}
--        <ModuleConfigSection scope={{ workspaceId }} />
--
-         {/* Registry-driven workspace-scoped contributions.
-             ... */}
-         {workspaceContributions.map((c) => {
-```
-
-**理由更正（codex round-1 P1）**：Files 拔 `workspaceConfig` 後 `getModulesWithWorkspaceConfig()` 自動回 `[]`，`ModuleConfigSection.tsx:16` 的 `if (modules.length === 0) return null` 會讓元件不渲染任何 DOM。所以「移除 mount」**不是功能上必要**（disable filter 已透過 `settings: [...]` 路徑生效），而是 housekeeping：
-
-- 移除後讀者看 `WorkspaceSettingsPage.tsx` 不會再對「為什麼有個 `<ModuleConfigSection>` 但好像沒輸出」困惑。
-- 與 spec N2「不刪 `ModuleConfigSection.tsx` 檔案 / 欄位 / helper」對齊：本 PR 只拔 mount call，`ModuleConfigSection.tsx` 元件本體仍在。
-
-> 風險評估：若 `ModuleConfigSection.tsx` 被任何**外部**（test / dev tool / story）引用，移除 import 不會影響它們。`rg "ModuleConfigSection" spa/src` 確認過：唯二引用是 `WorkspaceSettingsPage.tsx`（mount 點 — 本 PR 移除）和 `ModuleConfigSection.test.tsx`（自身測試 — 不動）。
+> 風險評估：完全不動 `WorkspaceSettingsPage.tsx`，等於本 PR 對該檔 0 改動。實作上 commit 3 確實執行過「拔 mount」，後續 commit 09bcc61e 把它恢復回來；plan 此處保留歷史脈絡是為了讓 reviewer 看到決策軌跡。
 
 ### 3.5 修既有測試 `register-modules.test.ts`
 
@@ -644,7 +629,7 @@ Plan: [`2026-05-03-files-disableable-sr2-plan.md`](docs/specs/2026-05-03-files-d
 
 - `register-modules/index.tsx` — Files: `disableable: true` + `settings: [...]` + drop SR-2 inline comment
 - `dispatch-settings-contributions.ts` — drop `'files'` from `DEPRECATED_LEGACY_CONFIG_EXEMPT` + update surrounding comment
-- `WorkspaceSettingsPage.tsx` — drop now-dead `<ModuleConfigSection>` mount
+- `WorkspaceSettingsPage.tsx` — **unchanged** (commit 3 originally removed the `<ModuleConfigSection>` mount, but PR adversarial review flagged this as detaching the only escape-hatch render path while the `workspaceConfig` API is still officially deprecated-but-supported; commit 09bcc61e restored it. Full removal deferred to F-1.)
 - New: `FilesWorkspaceSettingsSection.tsx` — workspace-scope settings UI for projectPath (storage path unchanged)
 - New: `SETTINGS_ORDER.WORKSPACE_FILES = 10` — first workspace-scope constant
 - 3 new i18n keys (en + zh-TW)
@@ -680,6 +665,6 @@ All existing readers (`FileTreeView`, `file-open-bootstrap.ts`) untouched.
 
 ## 7. Resolved decisions（codex round-1 review 後收斂）
 
-- Q1（resolved）：commit 3 移除 `<ModuleConfigSection>` mount 不拆獨立 commit。理由更正（codex R1 P1.5）— 移除**不是**功能需要，是 housekeeping；但歸到 commit 3 仍合理，因 commit 3 是「Files 遷移與 SR-2 收尾」單一語意。spec N2 講「不刪 component file」與本 PR 拔 mount 不矛盾（檔案保留、call site 拔）。
+- Q1（re-resolved，PR adversarial round-1）：mount 不移除。原 plan 是 commit 3 housekeeping 拔 mount；PR adversarial review 抓到 escape-hatch 矛盾後，commit 09bcc61e 恢復 mount。完整拆收進 F-1。Spec N2 同步更新明寫「mount 也保留」。
 - Q2（resolved）：不收編 Editor 的 inline `workspace-home-path` / `host-home-path` 進 SETTINGS_ORDER。理由：（1）超出本 PR scope；（2）Editor 既有風格穩定；（3）`settings-order.ts` 註解 workspace band 已標明 Editor inline 0 是 known legacy；（4）codex R1 Q2 確認此判斷正確。改用 follow-up issue（已收進 spec §9 F-X 之外的 backlog）。
 - Q3（resolved）：`registerBuiltinModules()` 在測試環境可直接呼叫，不需先補 stub。codex R1 Q3 已確認：`getPlatformCapabilities()` 對缺 `window.electronAPI` 是 safe fallback、FS / sync registry 寫入都是同步 in-memory。窄 fixture fallback 已從 plan 移除（codex R1 P1.4）。

--- a/docs/specs/2026-05-03-files-disableable-sr2-spec.md
+++ b/docs/specs/2026-05-03-files-disableable-sr2-spec.md
@@ -1,0 +1,363 @@
+# Spec — Files module disableable + SR-2 修復
+
+> Date: 2026-05-03  
+> Status: Draft (round-2 codex review approved, ready for plan)  
+> Repo: purdex / branch: `worktree-files-disableable-sr2`  
+> Related: SR-2 from codex review of PR #617 (modules switchboard)
+
+## 1. Context
+
+`alpha.288` (PR #816 + #825) 落地 Modules Switchboard，把 disableable 模組的 settings 過濾收斂到單一 hook 點 `dispatchSettingsContributions`。當時 codex review 列了 SR-2：Files module 是「disableable lie」候選 — 它唯一的 settings surface 在 deprecated `ModuleDefinition.workspaceConfig`，渲染走 `WorkspaceSettingsPage` → `ModuleConfigSection` → `getModulesWithWorkspaceConfig()`，**完全繞過** `useModuleEnabledStore` 的 disable filter。所以即使把 Files 標 `disableable: true`，使用者 toggle off 後 Workspace settings 內仍可編輯 `projectPath`，是個謊話。SR-2 採取保守策略：暫時不標 disableable，並加一段 inline 註解警示。
+
+`register-modules/index.tsx:243-247`
+
+```ts
+// SR-2 (codex review #617): intentionally NOT flagged disableable yet.
+// The module's only settings surface lives in `workspaceConfig`, which
+// `WorkspaceSettingsPage` renders through `ModuleConfigSection` — a path
+// that does not consult `useModuleEnabledStore`. Toggling would be a lie
+// until PR 3 wires workspace-scope legacy contributions into the filter.
+```
+
+`dispatch-settings-contributions.ts:32` 的 `DEPRECATED_LEGACY_CONFIG_EXEMPT` 也豁免了 Files 的 `workspaceConfig` deprecation warning。
+
+本 spec 結束 SR-2 過渡：把 Files 從 deprecated `workspaceConfig` 遷到 `settings: [{ scope: 'workspace' }]`，讓 disable filter 真的接得到，順便拔 SR-2 註解 + deprecation exempt。
+
+## 2. Goals / Non-Goals
+
+### Goals
+- G1: Files module 標 `disableable: true`，自動出現在 Modules Switchboard。
+- G2: Files 的 workspace `projectPath` 設定走 `settings: [{ scope: 'workspace' }]` contribution path，受 `dispatchSettingsContributions` 的 disable filter 控制。
+- G3: Disable Files **後 reload**（與其他 disableable module 同 UX：ReloadBanner 提示 → 使用者 reload）→ `WorkspaceSettingsPage` 內不再渲染 `projectPath` input。Live toggle **不**即時隱藏；保持與 alpha.288 既有架構（`useModuleEnabledStore.setEnabled` 只寫 store，不重新 dispatch contributions）一致。
+- G4: Storage shape 不動 — `projectPath` 仍存在 `useWorkspaceStore.workspaces[wsId].moduleConfig['files'].projectPath`，所有現有 reader (`FileTreeView`, `file-open-bootstrap`) 不需改。
+- G5: 移除 SR-2 inline 註解 + `DEPRECATED_LEGACY_CONFIG_EXEMPT` 的 `'files'` entry + 對應的 deprecation block 註解（`dispatch-settings-contributions.ts:29-32`）。
+
+### Non-Goals
+- N1: 不擴大 disable 範圍至 `views`（spec I4 不變量：disable 只影響 `dispatchSettingsContributions`，file-tree workspace/session view 仍可被加進 sidebar）。
+- N2: 不刪 `ModuleConfigSection.tsx` / `ModuleDefinition.workspaceConfig` 欄位 / `getModulesWithWorkspaceConfig` helper。Files 遷出後 `getModulesWith*Config()` 自動回 `[]`，`ModuleConfigSection` 自動 `return null`。完整拆 follow-up issue。  
+  **In scope（codex review round-2）**：本 PR 會移除 `WorkspaceSettingsPage.tsx` 對 `<ModuleConfigSection>` 的 mount call（dead-render housekeeping），但 `ModuleConfigSection.tsx` 元件本體與其自身 test 都不動。
+- N3: 不加 Files purdex-scope placeholder / settings page。對齊 Browser 的處理（disableable 但 purdex sidebar 無條目）；Files 設定本就是 workspace 範疇，purdex 沒東西可放，placeholder 是 dead UX。
+- N4: 不調整 PR-2 落地的 purdex sidebar 順序（`MODULE_EDITOR` / `MODULE_QUICK_COMMANDS` / `MODULE_PERFORMANCE_MONITOR` / `MODULE_SYNC` 不動）。本 PR 只新增 workspace-scope 常數 `WORKSPACE_FILES`（§4.1）— Files contribution 是 workspace scope，跟 purdex sidebar 順序無關。
+
+## 3. Invariants
+
+- I1: `projectPath` 的 storage path 不變 — `useWorkspaceStore.workspaces[wsId].moduleConfig['files'].projectPath`。
+- I2: Files disabled state（store 內 `enabled.files === false`）+ 重跑 `dispatchSettingsContributions` → `listContributions('workspace')` 結果不含 `files.workspace-files`（對齊 EC-1b — disable filter 在 `dispatchSettingsContributions` 內套）。實務上重跑只發生在 `registerBuiltinModules()` boot-time 執行；live toggle 後須 reload 才生效（對齊 ReloadBanner UX）。
+- I3: Files enable + dispatch 後 `WorkspaceSettingsPage` 渲染 Files contribution 的 `<h3>` header + body（puzzle icon 因 `isModuleOwnedContribution(c) === true`）。
+- I4: 本 PR 對 disable filter 副作用範圍的承諾（取代舊 spec 的廣義 I4，因 `module-registry.ts:170-188 resolvePaneRenderer` 與 `module-file-openers.ts:29-34 applyModuleFileOpeners` 已實際對 disable 反應）：
+  - **Files 沒有 panes** → 不受 `resolvePaneRenderer` disable→placeholder 行為影響。
+  - **Files 沒有 `fileOpeners`** → 不受 `applyModuleFileOpeners` 跳過行為影響。
+  - **Files 有 views**（`file-tree-workspace` / `file-tree-session`）→ `getAllViews()` / `getViewDefinition()` 不套 disable filter，所以即使 disable Files 後再 reload，views 仍可被加進 sidebar。這是 spec `2026-04-23-modules-switchboard-spec.md` §3 I4 留下的 known limitation（v1 認可），本 PR 不擴大範圍。
+  - **Files 有 settings**（本 PR 新增的 workspace contribution）→ 受 `dispatchSettingsContributions` disable filter 控制。
+- I5: `DEPRECATED_LEGACY_CONFIG_EXEMPT` 移除 `'files'` 後，沒任何 module 用 `globalConfig` / `workspaceConfig`，dispatch 不會噴 deprecation warning（驗證手段：startup log 無 `[module] ...deprecated...` 訊息）。
+
+## 4. Design
+
+### 4.1 Module 定義改動
+
+`register-modules/index.tsx` 內 Files registerModule：
+
+```diff
+ registerModule({
+   id: 'files',
+   name: 'Files',
+-  // SR-2 (codex review #617): intentionally NOT flagged disableable yet.
+-  // The module's only settings surface lives in `workspaceConfig`, which
+-  // `WorkspaceSettingsPage` renders through `ModuleConfigSection` — a path
+-  // that does not consult `useModuleEnabledStore`. Toggling would be a lie
+-  // until PR 3 wires workspace-scope legacy contributions into the filter.
+-  workspaceConfig: [
+-    { key: 'projectPath', type: 'string', label: '專案路徑' },
+-  ],
++  disableable: true,
++  descriptionKey: 'modules.files.description',
++  settings: [
++    {
++      localId: 'workspace-files',
++      scope: 'workspace',
++      order: SETTINGS_ORDER.WORKSPACE_FILES,
++      labelKey: 'settings.section.files_workspace',
++      component: FilesWorkspaceSettingsSection,
++    },
++  ],
+   views: [
+     { id: 'file-tree-workspace', ..., scope: 'workspace', ... },
+     { id: 'file-tree-session',   ..., scope: 'tab', ... },
+   ],
+ })
+```
+
+順序考量：Workspace scope sidebar 既有唯一 entry 是 Editor 的 `workspace-home-path` (`order: 0`)。Files 用 `WORKSPACE_FILES = 10` 排在 Editor 之後（按字母 Editor → Files 順序，與目前 purdex sidebar 順序一致）。
+
+`settings-order.ts` 的 lint 守則（spec PR-2 §4.1.2「禁止 hard-code 數字」）原本只 enforce 到 purdex scope（`editor-module.tsx` 的 workspace-home-path / host-home-path 是 inline 數字）。本 PR 把 Files workspace order 收編進 `SETTINGS_ORDER`，並更新該檔註解明確：所有 scope（purdex / workspace / host）新增 `settings: [...]` 都該從 `SETTINGS_ORDER` import；Editor 的 inline 數字屬 known legacy，未來可順手收編但不在本 PR scope。
+
+新增常數：
+
+```diff
+ export const SETTINGS_ORDER = {
+   ...
+   MODULE_SYNC: 14,
+   ...
++  // Workspace-scope module contributions.
++  WORKSPACE_FILES: 10,
+ } as const
+```
+
+### 4.2 `FilesWorkspaceSettingsSection` 元件
+
+新檔 `spa/src/components/settings/FilesWorkspaceSettingsSection.tsx`，介面參考 `EditorHomePathWorkspaceSection`：
+
+```tsx
+import { useId } from 'react'
+import { useWorkspaceStore } from '../../features/workspace/store'
+import { useI18nStore } from '../../stores/useI18nStore'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
+
+interface Props { ctx: SettingsContextFor<'workspace'> }
+
+export function FilesWorkspaceSettingsSection({ ctx }: Props) {
+  if (ctx.scope !== 'workspace') return null
+  return <Body workspaceId={ctx.workspaceId} />
+}
+
+function Body({ workspaceId }: { workspaceId: string }) {
+  const t = useI18nStore((s) => s.t)
+  const projectPath = useWorkspaceStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.moduleConfig?.['files']?.['projectPath'],
+  )
+  const value = typeof projectPath === 'string' ? projectPath : ''
+  const inputId = useId()
+
+  const handleChange = (next: string) => {
+    useWorkspaceStore.getState().setModuleConfig(workspaceId, 'files', 'projectPath', next)
+  }
+
+  return (
+    <div className="flex items-center justify-between py-1">
+      <label htmlFor={inputId} className="text-xs text-text-secondary">
+        {t('settings.files.project_path.label')}
+      </label>
+      <input
+        id={inputId}
+        className="w-48 px-2 py-0.5 rounded border border-border-default bg-surface-primary text-xs text-text-primary"
+        type="text"
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+      />
+    </div>
+  )
+}
+```
+
+設計重點：
+- **Storage path 不動**：直接讀寫 `useWorkspaceStore` 的 `moduleConfig['files']['projectPath']`，跟 `FileTreeView.tsx:24,79` 用同一個 path（I1）。
+- **無 trim / commit-on-blur**：對齊既有 `ConfigField` 的 onChange-immediate 寫法。`EditorHomePathWorkspaceSection` 的 trim/blur 流程是針對檔案路徑空白敏感性，本 PR 不引入新行為（最小 diff 原則）。如果未來要對齊 Editor 寫法，可開 follow-up。
+- **i18n key**：`settings.files.project_path.label` 取代 hardcoded `'專案路徑'`。`labelKey: 'settings.section.files_workspace'` 是 sidebar header，內部 input label 另開 key。
+
+### 4.3 `dispatch-settings-contributions.ts` 清理
+
+```diff
+-// PR-5 deprecation: module authors using `globalConfig` / `workspaceConfig`
+-// should migrate to `settings: [{ scope, localId }]`. `files` is exempt until
+-// the files owner completes its refactor.
+-const DEPRECATED_LEGACY_CONFIG_EXEMPT: ReadonlySet<string> = new Set(['files'])
++// PR-5 deprecation: module authors using `globalConfig` / `workspaceConfig`
++// should migrate to `settings: [{ scope, localId }]`. Empty exempt set kept
++// as a future-friendly escape hatch — add a moduleId here to silence the
++// deprecation warning while a migration is in flight.
++const DEPRECATED_LEGACY_CONFIG_EXEMPT: ReadonlySet<string> = new Set()
+```
+
+保留 set 結構以便將來新增豁免（同 PR 內不刪變數，避免 churn）；註解同步更新去掉 Files 特例字眼。
+
+### 4.4 i18n
+
+新增 keys（en + zh-TW）：
+
+| key | en | zh-TW |
+|---|---|---|
+| `modules.files.description` | "Workspace and session file tree, with click-to-open into the Editor" | "工作區與 Session 檔案樹，可點擊開啟至 Editor" |
+| `settings.section.files_workspace` | "Files" | "檔案" |
+| `settings.files.project_path.label` | "Project path" | "專案路徑" |
+
+注意：用 `settings.section.files_workspace` 而非 `settings.section.files`，是為了預留將來 purdex-scope `settings.section.files` 的可能（不衝撞）。Sidebar header label 顯示就是 "Files" / "檔案"。
+
+### 4.5 既有 reader 不動
+
+`FileTreeView.tsx:24` `workspace?.moduleConfig?.['files']?.['projectPath']` 不變。  
+`FileTreeView.tsx:79` `setModuleConfig(workspaceId, 'files', 'projectPath', trimmed)` 不變（empty-state inline 設定流程仍可用）。  
+`file-open-bootstrap.ts:184` `cfg?.['files']?.['projectPath']` 不變。
+
+→ G4 達成。
+
+## 5. Edge Cases
+
+| EC | 情境 | 預期行為 |
+|---|---|---|
+| EC-1 | 使用者 disable Files → 切到 Workspace settings（**不 reload**） | Live toggle 後 contribution registry 仍是舊的（`setEnabled` 只寫 store），所以 Files header + input **仍可見**。同時 `ModulesSwitchboardSection` 顯示 ReloadBanner（因 `hasPendingChanges() === true`），提示 reload 後生效。對齊 alpha.288 既有 UX。 |
+| EC-1b | Disable Files → reload | `registerBuiltinModules()` 重跑 → `dispatchSettingsContributions()` 過濾掉 disabled module → Files header + input 不再出現；既存 `projectPath` 值仍在 store（disable 不清資料）。 |
+| EC-2 | Disable Files 期間 file-tree views 是否能加進 sidebar？ | 是。`getAllViews()` / `getViewDefinition()` 不套 disable filter（I4 known limitation 對齊 `2026-04-23-modules-switchboard-spec.md` §3 I4）。`FileTreeWorkspaceView` 仍可渲染（只看 `projectPath` 是否設定，與 disable 無關）。 |
+| EC-3 | 全新 workspace（無 `moduleConfig.files`）+ Files enabled | `FilesWorkspaceSettingsSection` 渲染空 input；輸入後 `setModuleConfig` 建立 `moduleConfig.files.projectPath`。 |
+| EC-4 | Re-enable Files + reload → projectPath 已存在 | Header + input 恢復顯示，input value 自動帶回 store 既有值（zustand 訂閱重連）。 |
+| EC-5 | 升級路徑（既有使用者已有 `moduleConfig.files.projectPath`） | Storage 不動 = 0 migration；新元件直接讀。 |
+| EC-6 | Module enable state 預設 | `useModuleEnabledStore` 預設 enabled（與其他 disableable module 一致）；新使用者體感無變化。 |
+| EC-7 | I1 dual-declaration guard (`assertNoLegacyScopeConflict`) | 本 PR 不會觸發 — Files 移除 `workspaceConfig` 後只剩 `settings: [{ scope: 'workspace' }]`，沒 dual。 |
+
+## 6. Test Plan (TDD)
+
+### 6.1 失敗測試先寫
+
+新增 `spa/src/lib/register-modules.test.ts` 測試（或新檔）：
+
+1. **「Files 在 contribution registry 以 workspace scope 出現」**
+   ```ts
+   // 紅 → 綠
+   registerBuiltinModules()
+   const list = listContributions('workspace')
+   expect(list.find((c) => c.id === 'files.workspace-files')).toBeDefined()
+   ```
+
+2. **「Files disable → reload → Files contribution 從 workspace registry 消失」**
+   ```ts
+   // Simulate persisted disabled state BEFORE registerBuiltinModules() runs,
+   // mirroring how the real reload flow works: persist write happens during
+   // a previous session, then on next boot registerBuiltinModules() runs and
+   // dispatchSettingsContributions() observes enabled.files === false.
+   useModuleEnabledStore.setState({ enabled: { files: false }, baseline: null })
+   registerBuiltinModules()  // calls dispatchSettingsContributions internally
+   const list = listContributions('workspace')
+   expect(list.find((c) => c.id === 'files.workspace-files')).toBeUndefined()
+   ```
+   說明：本測試對應 reload 後的觀察結果。Live toggle 不重 dispatch（與 alpha.288 既有架構一致）；對應的「toggle 後 ReloadBanner 出現」行為由分層測試涵蓋：
+   - `useModuleEnabledStore.test.ts` 的 T1-9 系列覆蓋 `hasPendingChanges()` 純邏輯。
+   - `ModulesSwitchboardSection.test.tsx` 的 T3-7 涵蓋 ReloadBanner UI 渲染條件。
+   本 PR 不複製這兩層的測試。
+
+3. **「Files 標 `disableable: true` + `descriptionKey`」**
+   ```ts
+   registerBuiltinModules()
+   const filesMod = getModule('files')!
+   expect(filesMod.disableable).toBe(true)
+   expect(filesMod.descriptionKey).toBe('modules.files.description')
+   ```
+
+4. **「Files 不再使用 `workspaceConfig`」（拆 SR-2 確認）**
+   ```ts
+   registerBuiltinModules()
+   const filesMod = getModule('files')!
+   expect(filesMod.workspaceConfig).toBeUndefined()
+   ```
+
+5. **既有測試 `register-modules.test.ts:479` `does NOT warn for files module (exempted during transition)`** — **直接刪除**（採 codex round-1 Q 建議）。Files 不再用 `workspaceConfig`，這個豁免測試失去意義；同檔 fakemod / fakews 兩個 case 已完整涵蓋 deprecation 機制本身。改寫為「Files 特例」測試會殘留心智負擔（讀者看到「Files」會以為仍有特殊處理）。
+
+   取而代之，新增兩個更具體的測試在 §6.1 #4（Files 不再聲明 workspaceConfig）+ 新增「Files bootstrap 不噴 deprecation warning」（與 §6.1 #4 互補）：
+
+   ```ts
+   it('does NOT emit any deprecation warning for the real Files bootstrap', () => {
+     registerBuiltinModules()
+     const msgs = (warnSpy.mock.calls as unknown[][]).map((c) => String(c[0]))
+     expect(msgs.some((m) => m.includes('files') && m.includes('deprecated'))).toBe(false)
+   })
+   ```
+
+### 6.2 元件測試
+
+新增 `spa/src/components/settings/FilesWorkspaceSettingsSection.test.tsx`：
+
+6. **「Read：渲染既有 `projectPath`」** — set store → render → expect input.value
+7. **「Write：onChange 寫入 store」** — render → fire input.change → expect store updated
+8. **「Empty state：未設定 projectPath → input value === ''」**
+
+### 6.3 整合測試
+
+新增 / 修改 `spa/src/features/workspace/components/WorkspaceSettingsPage.registry.test.tsx`：
+
+9. **「Files enabled before bootstrap → WorkspaceSettingsPage 渲染 Files header + input」**
+   ```ts
+   // setup
+   clearModuleRegistry()
+   clearContributions()
+   useModuleEnabledStore.setState({ enabled: {}, baseline: null })  // default enabled
+   registerBuiltinModules()
+   render(<WorkspaceSettingsPage workspaceId={wsId} />)
+   expect(screen.getByText(t('settings.section.files_workspace'))).toBeInTheDocument()
+   ```
+
+10. **「Files disabled before bootstrap (i.e. simulating reload-after-disable) → WorkspaceSettingsPage 不渲染 Files section」**
+    ```ts
+    // setup mirrors a session that boots with persisted disabled state —
+    // the only path Files becomes hidden in the registry under alpha.288's
+    // reload-required architecture.
+    clearModuleRegistry()
+    clearContributions()
+    useModuleEnabledStore.setState({ enabled: { files: false }, baseline: null })
+    registerBuiltinModules()
+    render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(screen.queryByText(t('settings.section.files_workspace'))).toBeNull()
+    ```
+    說明：testname 含 "before bootstrap" 是為了避免被誤讀為「live toggle 即時隱藏」。Live toggle 不重 dispatch（與 alpha.288 既有架構一致）。
+
+### 6.4 既有測試影響
+
+- `ModuleConfigSection.test.tsx` — 不動（用 fixtures）。
+- `dispatch-settings-contributions.test.ts` — 不動（dual-declaration guard 仍以 fakeWS / dualws fixtures 測）。
+- `module-registry.test.ts:161-176` — 仍以 fixture 測 `getModulesWithWorkspaceConfig`，不動（helper 還在）。
+- `WorkspaceSettingsPage.registry.test.tsx` 既有 case — 看實際是否依賴 Files；若依賴則調整。
+
+### 6.5 驗證
+
+- `pnpm --prefix spa exec vitest run` — 全綠（既有 ~3200 通過 + 新增 ≈ 8）
+- `pnpm --prefix spa exec tsc -p tsconfig.app.json --noEmit` — 0 errors
+- `pnpm --prefix spa run lint` — 0 errors
+- `pnpm --prefix spa run build` — 通過
+
+### 6.6 手動驗證 checklist
+
+- [ ] `/settings/module-config` 出現 Files toggle row（描述用 `modules.files.description`）。
+- [ ] **Disable Files（不 reload）→ `/settings` 切 workspace → Files header + input 仍可見** + 切回 `/settings/module-config` 看到 ReloadBanner（與其他 disableable module 同 UX）。
+- [ ] **Disable Files → reload page → workspace settings → Files header + input 不出現**（reload-required 行為）。
+- [ ] Enable Files + reload → workspace settings → Files header + input 回來，input 帶回原值。
+- [ ] 在 input 改值 → `FileTreeWorkspaceView` 實時生效（同 store path）。
+- [ ] Disable 期間 file-tree workspace/session views 仍可被加進 sidebar（I4 known limitation）。
+- [ ] Browser console 不再噴 `[module] files uses deprecated workspaceConfig` warning。
+
+## 7. Acceptance Criteria
+
+- A1: Files 在 Modules Switchboard 出現，可被 toggle，state 持久（與其他 disableable module 一致）。
+- A2: 預先 set `useModuleEnabledStore` `enabled.files = false` → `registerBuiltinModules()` → `listContributions('workspace')` 不含 `files.workspace-files`（reload-required 對齊）。
+- A3: Enable Files + bootstrap dispatch 後 `WorkspaceSettingsPage` 渲染 Files contribution（puzzle icon + header + body）。
+- A4: `register-modules/index.tsx` Files 區塊不再含 SR-2 inline 註解；不再含 `workspaceConfig` 欄位；改用 `disableable: true` + `descriptionKey` + `settings: [{ scope: 'workspace', order: SETTINGS_ORDER.WORKSPACE_FILES, ... }]`。
+- A5: `DEPRECATED_LEGACY_CONFIG_EXEMPT` 不再含 `'files'`，註解去 Files 特例字眼；boot-time dispatch 對 Files 不噴 deprecation warning。
+- A6: 所有既有 `projectPath` reader (`FileTreeView`, `file-open-bootstrap.ts`) 不需改動。
+- A7: `SETTINGS_ORDER` 新增 `WORKSPACE_FILES = 10`；註解更新為「all scopes from this constant」。
+- A8: 全測試通過（vitest / tsc / lint / build）。
+
+## 8. Risks & Trade-offs
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `ModuleConfigSection` 留著但無人用會誤導讀者 | Low | Spec / PR 說明 + follow-up issue 追蹤拆除 |
+| 沒對齊 `EditorHomePathWorkspaceSection` 的 trim/blur/race 處理 | Low | 對齊既有 `ConfigField` 的 onChange-immediate 寫法（最小 diff）；trim/blur 是 Editor home path 的特殊需求，Files projectPath 不必同 |
+| Files purdex sidebar 無 entry 可能被未來「所有 disableable 都要 settings page」規則打破 | Low | 對齊 Browser 的處理；新規則沒落地，落地時再統一加 placeholder |
+| Reload-required UX：使用者 toggle 後沒看 banner 直接切到 Workspace settings 會以為 toggle 沒生效 | Low | 對齊 alpha.288 既有 module（Editor / Quick Commands / Performance Monitor）；ReloadBanner 已是 product-wide UX |
+| Disable Files 後 storage 既存 `projectPath` 是否該清？ | None | 不清。disable = 隱藏 UI，不破壞資料。對齊其他 disableable module 行為 |
+| `WORKSPACE_FILES = 10` 與未來其他 workspace contribution 撞號 | Low | 目前 workspace scope 只有 Editor（inline 0）+ Files（10）；未來新增時按需收編進 SETTINGS_ORDER |
+
+## 9. Out of Scope (follow-up issues)
+
+- F-1: 拆 `ModuleConfigSection.tsx` + `getModulesWith*Config()` helpers + `ModuleDefinition.workspaceConfig` / `globalConfig` 欄位（無真實使用者後 dead code）。
+- F-2: `ModulesSwitchboardSection` line 64-68 過時註解清理（提到 `editor/files/browser/memory-monitor` 都無 purdex contribution 已不正確）。
+- F-3: Files purdex placeholder（若未來確立「所有 disableable module 都要 settings page」規則）。
+
+## 10. Implementation Order (PR 不切 phase)
+
+PR 規模 ~250 LOC change，單一 PR 不切 phase。Commit 順序建議：
+
+1. **Commit 1 — i18n keys + `SETTINGS_ORDER.WORKSPACE_FILES`**：新增 3 個 i18n key（en + zh-TW）+ 常數 + 註解更新。無功能變更。
+2. **Commit 2 — `FilesWorkspaceSettingsSection` 元件 + 單元測試**：新檔 + 紅綠測試。
+3. **Commit 3 — Files module 遷移**：`register-modules/index.tsx` Files 改寫 + 拔 SR-2 註解 + `dispatch-settings-contributions.ts` 拔 exempt 與註解 + 對應 test 更新（紅 → 綠：reload-after-disable 過濾、deprecation warning 不噴）。
+4. **Commit 4 — 整合測試 + PR description 手動 checklist**：`WorkspaceSettingsPage.registry.test.tsx` 增 enable / disabled-after-reload 雙測，更新 PR description。
+
+每個 commit 獨立通過 vitest / lint / tsc。
+
+注意：`VERSION` + `CHANGELOG.md` bump 是 PR merge **後**的獨立 bump PR，不在本 PR 內動（對齊 repo 規範 — 詳見 CLAUDE.md「完整開發流程」第 9 步）。

--- a/docs/specs/2026-05-03-files-disableable-sr2-spec.md
+++ b/docs/specs/2026-05-03-files-disableable-sr2-spec.md
@@ -34,8 +34,7 @@
 
 ### Non-Goals
 - N1: 不擴大 disable 範圍至 `views`（spec I4 不變量：disable 只影響 `dispatchSettingsContributions`，file-tree workspace/session view 仍可被加進 sidebar）。
-- N2: 不刪 `ModuleConfigSection.tsx` / `ModuleDefinition.workspaceConfig` 欄位 / `getModulesWithWorkspaceConfig` helper。Files 遷出後 `getModulesWith*Config()` 自動回 `[]`，`ModuleConfigSection` 自動 `return null`。完整拆 follow-up issue。  
-  **In scope（codex review round-2）**：本 PR 會移除 `WorkspaceSettingsPage.tsx` 對 `<ModuleConfigSection>` 的 mount call（dead-render housekeeping），但 `ModuleConfigSection.tsx` 元件本體與其自身 test 都不動。
+- N2: 不刪 `ModuleConfigSection.tsx` / `ModuleDefinition.workspaceConfig` 欄位 / `getModulesWithWorkspaceConfig` helper。Files 遷出後 `getModulesWith*Config()` 自動回 `[]`，`ModuleConfigSection` 自動 `return null`。**Mount call 也保留**（codex PR adversarial round-1 high finding）— `WorkspaceSettingsPage.tsx` 仍 mount `<ModuleConfigSection scope={{ workspaceId }} />`，作為 in-flight migration / out-of-tree module 仍用 `workspaceConfig` 時的 escape hatch render path。完整拆（mount + component + helpers + 欄位）一次清在 follow-up F-1，避免本 PR 把 escape hatch 拆一半。
 - N3: 不加 Files purdex-scope placeholder / settings page。對齊 Browser 的處理（disableable 但 purdex sidebar 無條目）；Files 設定本就是 workspace 範疇，purdex 沒東西可放，placeholder 是 dead UX。
 - N4: 不調整 PR-2 落地的 purdex sidebar 順序（`MODULE_EDITOR` / `MODULE_QUICK_COMMANDS` / `MODULE_PERFORMANCE_MONITOR` / `MODULE_SYNC` 不動）。本 PR 只新增 workspace-scope 常數 `WORKSPACE_FILES`（§4.1）— Files contribution 是 workspace scope，跟 purdex sidebar 順序無關。
 

--- a/spa/src/components/FileTreeView.tsx
+++ b/spa/src/components/FileTreeView.tsx
@@ -21,7 +21,8 @@ export function FileTreeWorkspaceView({ isActive, workspaceId }: ViewProps) {
   const source: FileSource = useMemo(() => ({ type: 'daemon' as const, hostId: activeHostId }), [activeHostId])
 
   const workspace = useWorkspaceStore((s) => s.workspaces.find((ws) => ws.id === workspaceId))
-  const projectPath = workspace?.moduleConfig?.['files']?.['projectPath'] as string | undefined
+  const rawProjectPath = workspace?.moduleConfig?.['files']?.['projectPath']
+  const projectPath = typeof rawProjectPath === 'string' && rawProjectPath !== '' ? rawProjectPath : undefined
   const setModuleConfig = useWorkspaceStore((s) => s.setModuleConfig)
 
   const [inputValue, setInputValue] = useState('')

--- a/spa/src/components/settings/FilesWorkspaceSettingsSection.test.tsx
+++ b/spa/src/components/settings/FilesWorkspaceSettingsSection.test.tsx
@@ -1,0 +1,53 @@
+import { vi } from 'vitest'
+vi.mock('../../stores/useI18nStore', () => ({
+  useI18nStore: Object.assign(vi.fn((sel: (s: { t: (k: string) => string }) => unknown) => sel({ t: (k: string) => k })), {
+    getState: () => ({ t: (k: string) => k }),
+  }),
+}))
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { FilesWorkspaceSettingsSection } from './FilesWorkspaceSettingsSection'
+import { useWorkspaceStore } from '../../features/workspace/store'
+
+describe('FilesWorkspaceSettingsSection', () => {
+  let wsId: string
+
+  beforeEach(() => {
+    cleanup()
+    useWorkspaceStore.getState().reset()
+    const ws = useWorkspaceStore.getState().addWorkspace('Test')
+    wsId = ws.id
+  })
+
+  it('returns null when ctx scope is not workspace', () => {
+    // @ts-expect-error — feeding wrong-scope ctx to verify runtime guard
+    const { container } = render(<FilesWorkspaceSettingsSection ctx={{ scope: 'purdex' }} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders empty value when no projectPath is set', () => {
+    render(<FilesWorkspaceSettingsSection ctx={{ scope: 'workspace', workspaceId: wsId }} />)
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('')
+  })
+
+  it('renders existing projectPath', () => {
+    useWorkspaceStore.getState().setModuleConfig(wsId, 'files', 'projectPath', '/home/user/proj')
+    render(<FilesWorkspaceSettingsSection ctx={{ scope: 'workspace', workspaceId: wsId }} />)
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('/home/user/proj')
+  })
+
+  it('writes back to useWorkspaceStore.moduleConfig.files.projectPath on change', () => {
+    render(<FilesWorkspaceSettingsSection ctx={{ scope: 'workspace', workspaceId: wsId }} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '/new/path' } })
+    const stored = useWorkspaceStore
+      .getState()
+      .workspaces.find((w) => w.id === wsId)?.moduleConfig?.['files']?.['projectPath']
+    expect(stored).toBe('/new/path')
+  })
+
+  it('label uses i18n key settings.files.project_path.label', () => {
+    render(<FilesWorkspaceSettingsSection ctx={{ scope: 'workspace', workspaceId: wsId }} />)
+    expect(screen.getByLabelText('settings.files.project_path.label')).toBeInTheDocument()
+  })
+})

--- a/spa/src/components/settings/FilesWorkspaceSettingsSection.tsx
+++ b/spa/src/components/settings/FilesWorkspaceSettingsSection.tsx
@@ -1,0 +1,41 @@
+import { useId } from 'react'
+import { useWorkspaceStore } from '../../features/workspace/store'
+import { useI18nStore } from '../../stores/useI18nStore'
+import type { SettingsContextFor } from '../../lib/settings-contribution-types'
+
+interface Props {
+  ctx: SettingsContextFor<'workspace'>
+}
+
+export function FilesWorkspaceSettingsSection({ ctx }: Props) {
+  if (ctx.scope !== 'workspace') return null
+  return <Body workspaceId={ctx.workspaceId} />
+}
+
+function Body({ workspaceId }: { workspaceId: string }) {
+  const t = useI18nStore((s) => s.t)
+  const projectPath = useWorkspaceStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.moduleConfig?.['files']?.['projectPath'],
+  )
+  const value = typeof projectPath === 'string' ? projectPath : ''
+  const inputId = useId()
+
+  const handleChange = (next: string) => {
+    useWorkspaceStore.getState().setModuleConfig(workspaceId, 'files', 'projectPath', next)
+  }
+
+  return (
+    <div className="flex items-center justify-between py-1">
+      <label htmlFor={inputId} className="text-xs text-text-secondary">
+        {t('settings.files.project_path.label')}
+      </label>
+      <input
+        id={inputId}
+        className="w-48 px-2 py-0.5 rounded border border-border-default bg-surface-primary text-xs text-text-primary"
+        type="text"
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+      />
+    </div>
+  )
+}

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.registry.test.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.registry.test.tsx
@@ -19,6 +19,9 @@ import type {
   SettingsContext,
   SettingsContextFor,
 } from '../../../lib/settings-contribution-types'
+import { registerBuiltinModules } from '../../../lib/register-modules'
+import { clearModuleRegistry } from '../../../lib/module-registry'
+import { useModuleEnabledStore } from '../../../stores/useModuleEnabledStore'
 
 // --------------------------------------------------------------------------
 // Shared harness
@@ -249,5 +252,55 @@ describe('WorkspaceSettingsPage — workspace-scoped registry rendering', () => 
     expect(screen.queryByText('PURDEX_BODY')).toBeNull()
     expect(screen.queryByText('HOST_LABEL')).toBeNull()
     expect(screen.queryByText('HOST_BODY')).toBeNull()
+  })
+})
+
+describe('WorkspaceSettingsPage — Files module integration (SR-2)', () => {
+  let wsId: string
+
+  beforeEach(() => {
+    cleanup()
+    clearModuleRegistry()
+    clearContributions()
+    useWorkspaceStore.getState().reset()
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+    wsId = makeWorkspace('Test WS')
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearContributions()
+    clearModuleRegistry()
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  })
+
+  // CRITICAL: same-test before/after compare to prove SR-2 fix actually wires
+  // the disable filter (codex R1 P0). Reuse render() output to verify the
+  // legacy hardcoded `'專案路徑'` label is also gone — that string used to
+  // come from ConfigField + ModuleConfigSection's deprecated path; if it
+  // still shows up, the SR-2 mount removal is incomplete.
+  //
+  // Asserted text uses the resolved en values ('Files' / 'Project path')
+  // because test-setup.ts registers built-in locales, so useI18nStore.t()
+  // returns translations rather than the raw keys (matches the user-visible
+  // contract).
+  it('reload-after-disable: Files header/input render when enabled, disappear when disabled before bootstrap', () => {
+    // Step 1 — Files enabled (default) → header + input rendered
+    registerBuiltinModules()
+    const { unmount } = render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(screen.getByRole('heading', { level: 3, name: /Files/i })).toBeInTheDocument()
+    expect(screen.getByLabelText('Project path')).toBeInTheDocument()
+    // Legacy hardcoded label from old ConfigField path must be gone
+    expect(screen.queryByText('專案路徑')).toBeNull()
+    unmount()
+
+    // Step 2 — reset registries + state, bootstrap with Files persisted-disabled
+    clearModuleRegistry()
+    clearContributions()
+    useModuleEnabledStore.setState({ enabled: { files: false }, baseline: null })
+    registerBuiltinModules()
+    render(<WorkspaceSettingsPage workspaceId={wsId} />)
+    expect(screen.queryByRole('heading', { level: 3, name: /Files/i })).toBeNull()
+    expect(screen.queryByLabelText('Project path')).toBeNull()
   })
 })

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
@@ -16,7 +16,6 @@ import { WorkspaceIcon } from './WorkspaceIcon'
 
 import { WorkspaceIconPicker } from './WorkspaceIconPicker'
 import { WorkspaceDeleteDialog } from './WorkspaceDeleteDialog'
-import { ModuleConfigSection } from '../../../components/settings/ModuleConfigSection'
 
 interface Props {
   workspaceId: string
@@ -125,9 +124,6 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
             onWeightChange={(w) => setWorkspaceIconWeight(workspaceId, w)}
           />
         </section>
-
-        {/* Module Settings */}
-        <ModuleConfigSection scope={{ workspaceId }} />
 
         {/* Registry-driven workspace-scoped contributions.
             F2: mirror PR-2's SettingsSidebar disabled-row pattern —

--- a/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
+++ b/spa/src/features/workspace/components/WorkspaceSettingsPage.tsx
@@ -16,6 +16,7 @@ import { WorkspaceIcon } from './WorkspaceIcon'
 
 import { WorkspaceIconPicker } from './WorkspaceIconPicker'
 import { WorkspaceDeleteDialog } from './WorkspaceDeleteDialog'
+import { ModuleConfigSection } from '../../../components/settings/ModuleConfigSection'
 
 interface Props {
   workspaceId: string
@@ -124,6 +125,9 @@ export function WorkspaceSettingsPage({ workspaceId }: Props) {
             onWeightChange={(w) => setWorkspaceIconWeight(workspaceId, w)}
           />
         </section>
+
+        {/* Module Settings */}
+        <ModuleConfigSection scope={{ workspaceId }} />
 
         {/* Registry-driven workspace-scoped contributions.
             F2: mirror PR-2's SettingsSidebar disabled-row pattern —

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -27,9 +27,10 @@ import { useModuleEnabledStore } from '../stores/useModuleEnabledStore'
 const LEGACY_SECTION_MODULE_ID = '_builtin.legacy-section'
 
 // PR-5 deprecation: module authors using `globalConfig` / `workspaceConfig`
-// should migrate to `settings: [{ scope, localId }]`. `files` is exempt until
-// the files owner completes its refactor.
-const DEPRECATED_LEGACY_CONFIG_EXEMPT: ReadonlySet<string> = new Set(['files'])
+// should migrate to `settings: [{ scope, localId }]`. Empty exempt set kept
+// as a future-friendly escape hatch — add a moduleId here to silence the
+// deprecation warning while a migration is in flight.
+const DEPRECATED_LEGACY_CONFIG_EXEMPT: ReadonlySet<string> = new Set()
 const warnedDeprecationKeys = new Set<string>()
 
 function warnLegacyConfigDeprecations(modules: readonly ModuleDefinition[]): void {

--- a/spa/src/lib/dispatch-settings-contributions.ts
+++ b/spa/src/lib/dispatch-settings-contributions.ts
@@ -27,15 +27,11 @@ import { useModuleEnabledStore } from '../stores/useModuleEnabledStore'
 const LEGACY_SECTION_MODULE_ID = '_builtin.legacy-section'
 
 // PR-5 deprecation: module authors using `globalConfig` / `workspaceConfig`
-// should migrate to `settings: [{ scope, localId }]`. Empty exempt set kept
-// as a future-friendly escape hatch — add a moduleId here to silence the
-// deprecation warning while a migration is in flight.
-const DEPRECATED_LEGACY_CONFIG_EXEMPT: ReadonlySet<string> = new Set()
+// should migrate to `settings: [{ scope, localId }]`.
 const warnedDeprecationKeys = new Set<string>()
 
 function warnLegacyConfigDeprecations(modules: readonly ModuleDefinition[]): void {
   for (const m of modules) {
-    if (DEPRECATED_LEGACY_CONFIG_EXEMPT.has(m.id)) continue
     if (m.globalConfig && m.globalConfig.length > 0) {
       const key = `${m.id}:global`
       if (!warnedDeprecationKeys.has(key)) {

--- a/spa/src/lib/register-modules.test.ts
+++ b/spa/src/lib/register-modules.test.ts
@@ -8,11 +8,13 @@ vi.mock('../features/workspace/lib/icon-path-cache', () => ({
 
 import {
   clearModuleRegistry,
+  getModule,
   getModules,
   getPaneRenderer,
   registerModule,
   type ModuleDefinition,
 } from './module-registry'
+import { SETTINGS_ORDER } from './settings-order'
 import { clearNewTabRegistry, getNewTabProviders } from './new-tab-registry'
 import {
   clearSettingsSectionRegistry,
@@ -476,15 +478,10 @@ describe('ModuleDefinition.globalConfig / workspaceConfig deprecation (PR-5)', (
     expect(msgs.some((m: string) => m.includes('fakews') && m.includes('deprecated'))).toBe(true)
   })
 
-  it('does NOT warn for files module (exempted during transition)', () => {
-    registerModule({
-      id: 'files',
-      name: 'Files',
-      workspaceConfig: [{ key: 'projectPath', type: 'string', label: '專案路徑' }],
-    })
-    dispatchSettingsContributions()
+  it('does NOT emit any deprecation warning for the real Files bootstrap', () => {
+    registerBuiltinModules()
     const msgs = (warnSpy.mock.calls as unknown[][]).map((c) => String(c[0]))
-    expect(msgs.some((m: string) => m.includes('files') && m.includes('deprecated'))).toBe(false)
+    expect(msgs.some((m) => m.includes('files') && m.includes('deprecated'))).toBe(false)
   })
 
   it('does NOT warn for modules using new `settings` field', () => {
@@ -570,6 +567,53 @@ describe('ModuleDefinition.globalConfig / workspaceConfig deprecation (PR-5)', (
       (c) => String(c[0]).includes('retrymod') && String(c[0]).includes('deprecated'),
     ).length
     expect(afterHits).toBe(1)
+  })
+})
+
+describe('Files module — SR-2 fix (disable filter via settings contribution)', () => {
+  beforeEach(() => {
+    clearAll()
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  })
+
+  afterEach(() => {
+    clearAll()
+    useModuleEnabledStore.setState({ enabled: {}, baseline: null })
+  })
+
+  it('Files registers with disableable: true + descriptionKey + no workspaceConfig', () => {
+    registerBuiltinModules()
+    const filesMod = getModule('files')!
+    expect(filesMod.disableable).toBe(true)
+    expect(filesMod.descriptionKey).toBe('modules.files.description')
+    expect(filesMod.workspaceConfig).toBeUndefined()
+  })
+
+  it('Files contributes a workspace-scope settings entry with correct localId/order', () => {
+    registerBuiltinModules()
+    const list = listContributions('workspace')
+    const filesEntry = list.find((c) => c.id === 'files.workspace-files')
+    expect(filesEntry).toBeDefined()
+    expect(filesEntry?.scope).toBe('workspace')
+    expect(filesEntry?.order).toBe(SETTINGS_ORDER.WORKSPACE_FILES)
+    expect(filesEntry?.labelKey).toBe('settings.section.files_workspace')
+    expect(filesEntry?.moduleId).toBe('files')
+  })
+
+  // CRITICAL: same-test before/after compare to avoid false-green from
+  // "Files never had a workspace contribution to begin with" (codex R1 P0).
+  it('reload-after-disable: Files contribution present when enabled, absent when disabled before bootstrap', () => {
+    // Step 1 — Files enabled (default) → Files contribution present
+    registerBuiltinModules()
+    const enabledList = listContributions('workspace')
+    expect(enabledList.find((c) => c.id === 'files.workspace-files')).toBeDefined()
+
+    // Step 2 — reset state and bootstrap with Files persisted-disabled
+    clearAll()
+    useModuleEnabledStore.setState({ enabled: { files: false }, baseline: null })
+    registerBuiltinModules()
+    const disabledList = listContributions('workspace')
+    expect(disabledList.find((c) => c.id === 'files.workspace-files')).toBeUndefined()
   })
 })
 

--- a/spa/src/lib/register-modules/index.tsx
+++ b/spa/src/lib/register-modules/index.tsx
@@ -61,6 +61,7 @@ import {
 import { applyModuleFileOpeners } from './module-file-openers'
 import { clearAllForHmr as clearFileOpenerRegistryForHmr } from '../file-opener-registry'
 import { QuickCommandsSettingsSection } from '../../components/settings/QuickCommandsSettingsSection'
+import { FilesWorkspaceSettingsSection } from '../../components/settings/FilesWorkspaceSettingsSection'
 import { SETTINGS_ORDER } from '../settings-order'
 
 function NewTabPaneWrapper({ pane }: PaneRendererProps) {
@@ -240,13 +241,16 @@ export function registerBuiltinModules(): void {
   registerModule({
     id: 'files',
     name: 'Files',
-    // SR-2 (codex review #617): intentionally NOT flagged disableable yet.
-    // The module's only settings surface lives in `workspaceConfig`, which
-    // `WorkspaceSettingsPage` renders through `ModuleConfigSection` — a path
-    // that does not consult `useModuleEnabledStore`. Toggling would be a lie
-    // until PR 3 wires workspace-scope legacy contributions into the filter.
-    workspaceConfig: [
-      { key: 'projectPath', type: 'string', label: '專案路徑' },
+    disableable: true,
+    descriptionKey: 'modules.files.description',
+    settings: [
+      {
+        localId: 'workspace-files',
+        scope: 'workspace',
+        order: SETTINGS_ORDER.WORKSPACE_FILES,
+        labelKey: 'settings.section.files_workspace',
+        component: FilesWorkspaceSettingsSection,
+      },
     ],
     views: [
       {

--- a/spa/src/lib/settings-order.ts
+++ b/spa/src/lib/settings-order.ts
@@ -1,7 +1,14 @@
 /**
  * Centralized order constants for the Settings sidebar.
  *
- * The sidebar is grouped into bands so visual ordering communicates intent:
+ * Order values are **scoped per settings scope** (`purdex` / `workspace` /
+ * `host`); the sidebar sorts each scope's contributions independently. The
+ * tables below describe the visual bands within each scope. Numbers can
+ * legitimately repeat across scopes (e.g. purdex `MODULE_CONFIG = 10` and
+ * workspace `WORKSPACE_FILES = 10`) — they never compete because contribution
+ * lists are filtered by scope before sorting.
+ *
+ * **purdex scope** — sidebar at `/settings`:
  *
  *   | Band                        | Range  | Examples                                  |
  *   |-----------------------------|--------|-------------------------------------------|
@@ -10,6 +17,18 @@
  *   | Modules switchboard         | 10     | `module-config` (single header row)       |
  *   | Module-owned                | 11–19  | Editor / Quick Commands / Perf / Sync     |
  *   | Tail built-in               | 20–29  | Dev Environment / Tmux Agent Monitor      |
+ *
+ * **workspace scope** — sidebar at `/settings/workspaces/<id>`:
+ *
+ *   | Band                        | Range  | Examples                                  |
+ *   |-----------------------------|--------|-------------------------------------------|
+ *   | Module-owned                | 0 – 19 | Editor home path (inline 0) / Files (10)  |
+ *
+ * **host scope** — sidebar at `/settings/hosts/<id>`:
+ *
+ *   | Band                        | Range   | Examples                                 |
+ *   |-----------------------------|---------|------------------------------------------|
+ *   | Module-owned                | 0 – 199 | Editor home path (inline 100)            |
  *
  * `register-modules/index.tsx`, `editor-module.tsx`, and any future
  * `registerSettingsSection` / `registerModule({ settings: [...] })` call
@@ -21,6 +40,7 @@
  * was promoted to a structural module.
  */
 export const SETTINGS_ORDER = {
+  // ---- purdex scope ---------------------------------------------------
   // Top built-in (core) — always present.
   APPEARANCE: 0,
   TERMINAL: 1,
@@ -37,4 +57,6 @@ export const SETTINGS_ORDER = {
   // Tail built-in — dev / debug surfaces.
   DEV_ENVIRONMENT: 20,
   TMUX_AGENT_MONITOR: 21,
+  // ---- workspace scope ------------------------------------------------
+  WORKSPACE_FILES: 10,
 } as const

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -22,6 +22,7 @@
   "modules.browser.description": "Embedded web browser pane (requires desktop app)",
   "modules.memory_monitor.description": "Host, pane, client, and daemon performance metrics",
   "modules.quick_commands.description": "Quickly run frequently-used commands from Workspace and Host entry points",
+  "modules.files.description": "Workspace and session file tree, with click-to-open into the Editor",
   "module.disabled.title": "{{module}} module is disabled",
   "module.disabled.body": "Enable it and reload to restore this {{paneKind}} pane.",
   "module.disabled.enable": "Enable",
@@ -143,6 +144,7 @@
   "settings.interface.canvas_drop_here": "Drop module here",
   "settings.section.agent": "Agent",
   "settings.section.editor": "Editor",
+  "settings.section.files_workspace": "Files",
 
   "settings.agent.title": "Agent",
   "settings.agent.desc": "Agent notification and hook settings",
@@ -162,6 +164,8 @@
   "settings.agent.hook.install": "Install Hook",
   "settings.agent.hook.remove": "Remove Hook",
   "settings.agent.no_agents": "No agents detected yet. Start a Claude Code session to see agent settings.",
+
+  "settings.files.project_path.label": "Project path",
 
   "settings.editor.title": "Editor",
   "settings.editor.desc": "Preferences for the in-app Monaco code editor.",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -22,6 +22,7 @@
   "modules.browser.description": "內嵌網頁瀏覽器面板（需桌面版）",
   "modules.memory_monitor.description": "主機、面板、client 與 daemon 效能指標",
   "modules.quick_commands.description": "讓你在 Workspace 與 Host 入口快速執行常用指令",
+  "modules.files.description": "工作區與 Session 檔案樹，可點擊開啟至 Editor",
   "module.disabled.title": "{{module}} 模組目前已停用",
   "module.disabled.body": "啟用後重載即可恢復這個 {{paneKind}} 分頁。",
   "module.disabled.enable": "啟用",
@@ -143,6 +144,7 @@
   "settings.interface.canvas_drop_here": "拖曳 module 到此",
   "settings.section.agent": "Agent",
   "settings.section.editor": "編輯器",
+  "settings.section.files_workspace": "檔案",
 
   "settings.agent.title": "Agent",
   "settings.agent.desc": "Agent 通知與 Hook 設定",
@@ -162,6 +164,8 @@
   "settings.agent.hook.install": "安裝 Hook",
   "settings.agent.hook.remove": "移除 Hook",
   "settings.agent.no_agents": "尚未偵測到任何 Agent。啟動 Claude Code 後會出現設定。",
+
+  "settings.files.project_path.label": "專案路徑",
 
   "settings.editor.title": "編輯器",
   "settings.editor.desc": "應用程式內建 Monaco 程式碼編輯器的偏好設定。",


### PR DESCRIPTION
## Summary

Close SR-2 from codex review of PR #617: migrate Files module from
deprecated `workspaceConfig` to `settings: [{ scope: 'workspace' }]` so
the Modules Switchboard's disable filter actually hides the projectPath
setting. Files is now `disableable: true` and behaves identically to
Editor / Quick Commands / Performance Monitor (reload-required UX).

- Spec: [`docs/specs/2026-05-03-files-disableable-sr2-spec.md`](https://github.com/wake/purdex/blob/worktree-files-disableable-sr2/docs/specs/2026-05-03-files-disableable-sr2-spec.md)
- Plan: [`docs/specs/2026-05-03-files-disableable-sr2-plan.md`](https://github.com/wake/purdex/blob/worktree-files-disableable-sr2/docs/specs/2026-05-03-files-disableable-sr2-plan.md)
- 2 rounds of spec + 2 rounds of plan codex review before TDD; 1 standard + 1 three-parallel adversarial PR review after.

## Changes

| File | What |
|---|---|
| `register-modules/index.tsx` | Files: `disableable: true` + `settings: [...]` + drop SR-2 inline comment |
| `dispatch-settings-contributions.ts` | drop `'files'` exempt, then drop the entire `DEPRECATED_LEGACY_CONFIG_EXEMPT` set after it became empty |
| `WorkspaceSettingsPage.tsx` | unchanged (mount restore after PR adversarial review) |
| _new_ `FilesWorkspaceSettingsSection.tsx` | workspace-scope settings UI for projectPath (storage path unchanged) |
| `FileTreeView.tsx` | harden `projectPath` cast with `typeof === 'string'` guard (PR adversarial finding) |
| `settings-order.ts` | new `WORKSPACE_FILES = 10`; docblock rewritten to clarify per-scope ordering |
| `en.json` / `zh-TW.json` | 3 new i18n keys |
| Tests | +8 new (registry SR-2 trio, component, integration), -1 deleted (`exempted during transition` no longer applies) |

## Storage

Storage shape **unchanged**: `useWorkspaceStore.workspaces[wsId].moduleConfig.files.projectPath`.
All existing readers (`FileTreeView`, `file-open-bootstrap.ts`) untouched.

## Test plan

- [x] `pnpm --prefix spa exec vitest run` — 3219 passed (4 pre-existing failures unrelated: TabBar pinned tooltip + 3 sync hosts contributor token=null — same on `main`)
- [x] `pnpm --prefix spa exec tsc -p tsconfig.app.json --noEmit` — 0 errors
- [x] `pnpm --prefix spa run lint` — 0 errors
- [x] `pnpm --prefix spa run build` — passes
- [ ] **mlab live verify** (post-merge / pre-bump):
  - [ ] `/settings/module-config` lists Files toggle row with description text
  - [ ] Disable Files (without reload) → workspace settings still shows Files (live toggle does not re-dispatch); ReloadBanner appears
  - [ ] Reload → workspace settings no longer shows Files header / input
  - [ ] Re-enable + reload → Files header / input return with prior value
  - [ ] file-tree workspace/session views still mountable into sidebar even when Files disabled (I4 known limitation)
  - [ ] Browser console no longer warns `[module] files uses deprecated workspaceConfig`

## Commits

8 atomic commits, each independently passing lint/tsc/affected vitest:

1. `541b663c` — chore: i18n keys + `SETTINGS_ORDER.WORKSPACE_FILES` (no functional change)
2. `563198bb` — feat: `FilesWorkspaceSettingsSection` component + 5 unit tests
3. `dd77aee8` — refactor: Files module migration + SR-2 closure + 3 registry tests + 1 deletion
4. `41d1f139` — test: WorkspaceSettingsPage UI coverage (same-test before/after)
5. `329b4549` — docs: spec + plan
6. `09bcc61e` — fix: restore `<ModuleConfigSection>` mount (PR adversarial round-1 high finding)
7. `c627e330` — fix: harden FileTreeView projectPath cast + drop empty exempt set (PR adversarial round-2)
8. `3905d0a1` — docs: align spec/plan with mount-restored decision

## Codex review history

- **Spec round-1** (`task-mopkzl9k-y2dkcb`, 3m19s): 1 P0 + 4 P1 + 1 P2 + 1 Q — all addressed, spec rewritten.
- **Spec round-2** (`task-moplbxeb-5qqyju`, 2m10s): 0 P0, 2 P1 + 2 P2 + 1 Q — all addressed.
- **Plan round-1** (`task-moploewr-5suaud`, 3m1s): 2 P0 + 4 P1 + 3 P2 + 3 Q — all addressed (including the false-green test risk).
- **Plan round-2** (`task-mopm0dvg-t4wqgw`, 2m26s): 0 P0, 1 P1 (missing import) + 1 P2 (wording) + 4 Q (positive) — addressed.
- **PR standard round-1** (`review-mopmvmlu-5ob3i6`, 1m36s): **0 finding, approved**.
- **PR adversarial round-1** (`review-mopmxxd9-4bt78e`, 25s, accidentally triggered): 1 high finding (mount removal breaks escape hatch) — addressed in commit `09bcc61e`.
- **PR adversarial round-2 (3 parallel)**:
  - Attacker (`task-mopn362e-jt03u5`, 3m22s): 0 P0/P1, 2 P3 — 1 fixed in commit `c627e330` (FileTreeView guard), 1 → issue #834 (HMR baseline gap).
  - Defender (`task-mopn36q8-dw67it`, 2m6s): 0 P0/P1, 1 P2 + 3 P3 — P2 doc-drift fixed in commit `3905d0a1`; P3 → issues #838, #839.
  - File-health (`task-mopn381y-o29tj8`, 1m41s): 0 P0/P1, 3 P2 + 3 P3 — 3 P2 → issues #835/#836/#837 (refactor follow-ups); 1 P3 fixed in commit `c627e330` (drop empty exempt set).

## Follow-up issues (out of scope)

- **#834** — HMR baseline gap leaves new disableable modules without ReloadBanner
- **#835** — extract `Files` module into `register-modules/files-module.tsx` (mirror Editor)
- **#836** — split `register-modules.test.ts` (737 lines)
- **#837** — extract Files integration cases out of `WorkspaceSettingsPage.registry.test.tsx`
- **#838** — re-evaluate Modules Switchboard reload-required UX (live re-dispatch?)
- **#839** — `settings-order.ts` docblock 'MUST import' wording vs Editor inline 0/100 legacy

Original spec follow-up tracking carried over (out of scope, may be folded into issues above):
- **F-1** (planned): drop `ModuleConfigSection.tsx` + `getModulesWith*Config()` helpers + `ModuleDefinition.workspaceConfig` / `globalConfig` fields once no module uses them
- **F-2**: clean stale comment in `ModulesSwitchboardSection.tsx` lines 64-68
- **F-3**: if "all disableable modules need a settings page" rule is ever adopted, add Files purdex placeholder

Closes SR-2 (codex review of PR #617).