### PR TITLE
feat(editor): close dirty-guard + image viewer zoom + monaco scroll buffer

### DIFF
--- a/docs/specs/2026-06-09-editor-close-image-viewer-plan.md
+++ b/docs/specs/2026-06-09-editor-close-image-viewer-plan.md
@@ -1,0 +1,88 @@
+# Plan — Editor 開檔/檢視體驗強化（close dirty-guard + image viewer zoom）
+
+> Date: 2026-06-11
+> Spec: `docs/specs/2026-06-09-editor-close-image-viewer-spec.md`（已過 codex round-1 review，4 finding 全修）
+> Branch: `worktree-editor-close-image-viewer`
+> 前提：實作已大致存在於 worktree（uncommitted，無 commit/PR）。本 plan 將既有 code 視為**實作草稿**，補齊 spec round-1 要求的 2 條 acceptance 測試，驗證後切 4 commit 開 PR。
+
+## 0. 現況盤點
+
+- 9 modified + 4 untracked（含本 plan / spec）。既有 4 測試檔 30 測全過、lint clean、build 通過。
+- 完整套件另有 4 個 **pre-existing failures**（`sync/contributors/hosts.test.ts` ×3、`TabBar.test.tsx` ×1）— origin/main `alpha.294` 同樣 fail，**不在本 PR 範圍**（spec §N5）。
+- 待補：AC11b（untitled dirty guard）、AC17b（image 同步量測）兩條測試 → 目標 32 測。
+
+## 1. Task 切分（對齊 spec §6 的 4 commit）
+
+### T1 — bufferKey helper 抽取（refactor / commit 1）
+- 對應 **G1 / AC1-4**。
+- 既有：`spa/src/lib/editor-buffer-key.ts` + `.test.ts`（4 測）已存在；`EditorPane.tsx`、`EditorBuffersPane.tsx` 已改 import 共用版本、刪私有 copy。
+- 驗證：`vitest run editor-buffer-key`（4 綠）；`grep -rn "function bufferKey" spa/src` 確認無殘留私有定義（僅 `editor-buffer-key.ts` 一處）。
+- **caller regression（codex plan-review #1）**：helper 抽取的真正風險在兩個 caller，必須跑既有 targeted 測試確認整合無回歸：
+  - `spa/src/components/editor/__tests__/EditorPane.test.tsx`（untitled 開/掛 buffer、rename three-step sync）
+  - `spa/src/components/editor/EditorBuffersPane.test.tsx`（rename / delete / smart-open 的 dirty 判斷皆依賴同一 key 公式）
+- 無新增 production 工作（純驗證既有 refactor + caller regression）。
+
+### T2 — dirty guard + untitled 測試（feat / commit 2）
+- 對應 **G2 / G5 / AC5-11b**。
+- 既有：`tab-lifecycle.ts` 的 `closeTab` dirty scan + `editor.close_dirty_confirm` i18n（en + zh-TW）+ 7 測。
+- **補（TDD）**：在 `tab-lifecycle.test.ts` 的 `unsaved editor warning` describe 內新增 AC11b：
+  - case A：`seedBuffer('untitled:draft', true)` + `editorContent('untitled:draft')` → `closeTab` → `confirm` ×1 + `closeTabInWorkspace(id, undefined)`。
+  - case B（可併入）：`seedBuffer('untitled:draft', false)` → 不 `confirm` + 正常關閉（對應「空白/無變更不彈」）。
+  - 預期既有實作**直接通過**（untitled 走相同 `bufferKey({type:'inapp'}, 'untitled:...')` → `inapp:untitled:...` 路徑），無 production 改動。
+  - **範圍界定（codex plan-review #2）**：`seedBuffer` 是直接 **stub buffer 的 dirty 狀態**來測 `closeTab` 攔截邏輯，**不**重測「輸入內容會把 buffer 翻 dirty」那條 store 契約——後者已由 `spa/src/stores/useEditorStore.test.ts`（`updateContent` → `isDirty`）覆蓋。
+- 驗證：`vitest run tab-lifecycle`（8 綠）。
+
+### T3 — image fit/actual + 同步量測測試（feat / commit 3）
+- 對應 **G3 / AC12-17b**。
+- 既有：`ImagePreviewPane.tsx`（fit/actual、oversized、ResizeObserver、render-time reset）+ 6 測。
+- **補（TDD）**：在 `ImagePreviewPane.test.tsx` 新增 AC17b 同步量測 case：
+  - `imgComplete=true` + `naturalW/H=2000` + `box=500`；`render(...)` 後**先 `await screen.findByRole('img')` 等 img mount**（`backend.read(filePath)` resolve → `objectUrl` 設入 state → `img` 才 mount，是非同步鏈），**不**呼叫 `fireEvent.load(img)`，再直接 `waitFor` `img.className` 含 `cursor-zoom-in`（僅靠 mount effect 同步 `measureNatural()` 即判定 oversized）。
+  - **風險與分流（codex plan-review #3）**：jsdom 下 effect 同步階段讀 prototype-stubbed `complete/naturalWidth` 是否穩定。既有測試靠 `fireEvent.load` 補觸發，未驗證同步路徑。若紅，**依序排查**：(a) 先確認 `img` 是否已 mount（findByRole 是否拿到）——沒拿到是非同步鏈未完成，非 mount effect 問題；(b) img 在但 cursor 沒出 → 才是「測試對 jsdom 同步時序假設不當」（調整測試，如顯式 `act()` flush effect）或「production 同步量測真有缺陷」（修 `ImagePreviewPane.tsx`，spec I5 要求同步量測必須成立）。
+- 驗證：`vitest run ImagePreviewPane`（7 綠）。
+
+### T4 — Monaco scrollBeyondLastLine（feat / commit 4）
+- 對應 **G4 / AC18**。
+- 既有：`MonacoWrapper.tsx` `scrollBeyondLastLine: false→true` + 1 測（AC18）。
+- 無新增工作（純驗證）。
+
+## 2. 整合驗證（全 task 完成後）
+
+```
+cd spa
+npx vitest run src/lib/editor-buffer-key.test.ts src/lib/tab-lifecycle.test.ts \
+  src/components/editor/ImagePreviewPane.test.tsx src/components/editor/MonacoWrapper.test.tsx \
+  src/components/editor/__tests__/EditorPane.test.tsx src/components/editor/EditorBuffersPane.test.tsx
+pnpm run lint
+pnpm run build
+```
+- 通過標準：本任務 4 檔 **32 測全綠** + 2 個 caller regression 檔（EditorPane / EditorBuffersPane）不回歸 / lint clean / build 通過。
+- 完整套件 4 個 pre-existing failures 維持原狀（不修、不回歸新增）。
+
+## 3. Commit 順序與訊息
+
+1. `refactor(editor): extract shared bufferKey helper`（commit 1，必先於 2）
+2. `feat(editor): warn before closing tab with unsaved changes`（commit 2，含 untitled AC11b）
+3. `feat(editor): fit/actual zoom toggle in image preview`（commit 3，含同步量測 AC17b）
+4. `feat(editor): enable scrollBeyondLastLine in Monaco`（commit 4）
+
+> commit 1 必須在 2 之前（dirty guard 依賴共用 key）；3、4 彼此獨立。**docs 歸屬講死（codex plan-review #4）**：`spec` + `plan` 兩份文件**併入 commit 1（refactor）**一起提交，維持總數**恰 4 commit**。
+
+## 4. 開發方式
+
+- 依 `feedback_subagent_tdd_priority`：T2 / T3 的「寫測試 → 驗證 →（必要時修 production）」派 subagent 跑 TDD；主 session 負責整合、跑全套驗證、切 commit、開 PR。
+- 每個 task 完成即在 worktree 內驗證對應測試綠燈，再進下一個。
+
+## 5. PR 後流程（對齊 CLAUDE.md）
+
+- PR → codex 兩輪 review（R1 標準 + R2 三平行 adversarial）→ 問題彙整表（信心/關聯/複雜度）→ 修 → merge。
+- 獨立 bump PR 更新 `VERSION` + `CHANGELOG.md`。
+- 清理 worktree、對齊 origin/main。
+
+## 6. 風險彙整
+
+| 風險 | 等級 | 緩解 |
+|------|------|------|
+| AC17b 同步量測在 jsdom 時序下不穩定 | 中 | T3 先判定 test-vs-prod，分別處置（見 T3） |
+| untitled AC11b 揭露 bufferKey 路徑不一致 | 低 | 預期直接綠；若紅代表 untitled 走不同 source/key，需對齊 |
+| 既有 4 pre-existing failures 干擾判讀 | 低 | 只跑本任務 4 檔 + 2 caller regression 檔，不跑全套；spec §N5 已界定 |
+| helper 抽取後 caller 整合回歸 | 中 | T1 納入 EditorPane / EditorBuffersPane targeted 測試（codex plan-review #1） |

--- a/docs/specs/2026-06-09-editor-close-image-viewer-spec.md
+++ b/docs/specs/2026-06-09-editor-close-image-viewer-spec.md
@@ -1,0 +1,121 @@
+# Spec — Editor 開檔/檢視體驗強化（close dirty-guard + image viewer zoom）
+
+> Date: 2026-06-09
+> Status: Draft（待 codex round-1 審閱）
+> Repo: purdex / branch: `worktree-editor-close-image-viewer`
+> Note: 本 spec 為 **reverse-engineered** — 實作已存在於 worktree（uncommitted，無 PR），spec 忠實描述既有行為作為 review 對照基準與 acceptance 契約。
+
+## 1. Context
+
+Editor 模組已支援以 editor pane（Monaco/Tiptap）與 image-preview pane 開啟檔案。本次累積了四個彼此耦合度不一的小改進，主題為「開檔 / 關閉 / 圖片檢視」的使用體驗強化：
+
+1. **`bufferKey` DRY 抽取**（refactor）— `EditorPane.tsx` 與 `EditorBuffersPane.tsx` 各自帶一份 **私有** `bufferKey` / `bufferKeyFor` helper，公式相同。`EditorBuffersPane` 的版本上方原本就有註解預告「until a shared util is extracted, keep the formula in lock-step」。本次把公式抽到單一 `spa/src/lib/editor-buffer-key.ts`，兩個 call site 改 import 共用版本。是 §2 dirty-guard 的 enabler（`closeTab` 需以相同公式查 buffer dirty 狀態）。
+2. **Tab 關閉 dirty guard**（feat）— `closeTab` 在執行關閉前掃 tab layout 的 pane tree，若任一 editor pane 對應的 buffer `isDirty`，跳 `window.confirm`；使用者取消則中止關閉。
+3. **ImagePreviewPane fit/actual 縮放**（feat）— 圖片預覽從「永遠 object-contain 縮放至容器」升級為可在 fit ↔ actual（原始像素）間切換，僅當圖片 oversized（natural 尺寸 > 容器）時才可點擊切換並顯示對應 zoom cursor。
+4. **MonacoWrapper `scrollBeyondLastLine`**（UX 微調）— `false → true`，讓編輯器底部保留可捲動緩衝。**使用者明確需求（編輯時捲到最後一行仍有一段緩衝空間）；與 1–3 功能正交，同 PR 一併納入**。
+
+### 現況基準
+- 改動檔（9 modified + 3 new source files；另含本 spec 檔，working tree 共 4 untracked），全 uncommitted
+- 驗證：本任務 4 測試檔 30 測全過 / `pnpm run lint` clean / `pnpm run build` 通過。本 spec round-1 review 後再補 2 條 acceptance 測試（untitled dirty guard、image 同步量測），目標 32 測
+- 完整套件另有 4 個 **pre-existing failures**（`sync/contributors/hosts.test.ts` ×3、`TabBar.test.tsx` ×1），origin/main `alpha.294` 同樣 fail，**非本任務造成**，不在本 spec 範圍
+
+## 2. Goals / Non-Goals
+
+### Goals
+- **G1（bufferKey 抽取）**：新增 `editor-buffer-key.ts` 匯出純函式 `bufferKey(source, filePath)`，公式與原私有版本逐字一致：`daemon` source → `daemon:${hostId}:${filePath}`，其餘 → `${source.type}:${filePath}`。`EditorPane.tsx`、`EditorBuffersPane.tsx` 兩處改 import，刪除各自私有 copy；行為零變化。
+- **G2（dirty guard）**：`closeTab(tabId)` 在實際關閉（`destroyBrowserViewIfNeeded` + `closeTabInWorkspace`）前，掃描該 tab layout 的所有 pane；若存在 `kind==='editor'` 且其 `bufferKey` 對應 buffer `isDirty===true`，跳一次 `window.confirm(t('editor.close_dirty_confirm'))`。confirm 回 true 才繼續關閉；回 false 則整個 `closeTab` 中止（不關、不寫 history）。
+- **G3（image zoom）**：`ImagePreviewPane` 支援 fit / actual 兩種顯示模式：
+  - 量測圖片 natural 尺寸與容器 box 尺寸，`oversized = natural.w > box.w || natural.h > box.h`。
+  - 僅 `oversized` 時：圖片可點擊在 fit ↔ actual 間切換；cursor 顯示 `cursor-zoom-in`（fit 態）/ `cursor-zoom-out`（actual 態）。
+  - 非 oversized：無 zoom cursor、點擊 no-op、維持 fit（`object-contain`）。
+  - 容器永遠 `overflow-auto` + `min-h-0`（actual 態溢出可捲動）。
+  - 切換檔案（`filePath` 變）時 reset 回 fit。
+- **G4（monaco scroll）**：`MonacoWrapper` 傳給 Monaco 的 `options.scrollBeyondLastLine` 設為 `true`。
+- **G5（i18n）**：新增 key `editor.close_dirty_confirm`（en + zh-TW），供 G2 confirm 文案。
+
+### Non-Goals
+- N1：不改 buffer 的 dirty 追蹤機制本身（沿用 `useEditorStore.buffers[key].isDirty`）。
+- N2：dirty guard 不做「逐 pane 分別 confirm」或「列出哪些檔 dirty」；一個 tab 內多 dirty editor 也只 confirm 一次（首個 dirty 命中即足夠）。
+- N3：dirty guard 不接管 `EditorBuffersPane` 既有的 close-all / close-pane dirty 判斷邏輯（那是另一條既有 path，本次只共用 `bufferKey`，不改其行為）。
+- N4：image zoom 不做多級縮放 / 拖曳平移 / 滾輪縮放；只有 fit ↔ actual 二態 toggle。
+- N5：不修 §1 提到的 4 個 pre-existing test failures。
+
+## 3. Invariants
+
+- I1：`bufferKey` 為純函式，無副作用、不讀 store；輸出對 `(source, filePath)` 決定性。抽取後三個 call site（EditorPane / EditorBuffersPane / tab-lifecycle）產生的 key 完全一致 — 同一檔在 editor store 中只有一個 buffer 條目。
+- I2：`closeTab` 對 **locked tab** 維持既有行為：最前面 early return（`!tab || tab.locked`），**不掃 pane、不 confirm、不關閉**。dirty guard 位於 lock 檢查之後、實際關閉之前。
+- I3：dirty guard 只看 `kind==='editor'` 的 pane；`image-preview`、`new-tab`、terminal 等其他 kind 不觸發 confirm。
+- I4：buffer 不存在（editor pane 開著但 store 無對應 key）視為「非 dirty」，不 confirm。
+- I5：image natural 尺寸量測對「已 cached / HMR 已 `complete` 的圖」也必須成立 — 同步量測 + native `load` listener 雙保險（React `onLoad` 對已 complete 的 img 不可靠）。
+
+## 4. 實作要點（對照既有 code）
+
+### 4.1 `spa/src/lib/editor-buffer-key.ts`（新）
+```ts
+import type { FileSource } from '../types/fs'
+export function bufferKey(source: FileSource, filePath: string): string {
+  if (source.type === 'daemon') return `daemon:${source.hostId}:${filePath}`
+  return `${source.type}:${filePath}`
+}
+```
+- `EditorPane.tsx`：刪私有 `bufferKey`，改 `import { bufferKey } from '../../lib/editor-buffer-key'`。
+- `EditorBuffersPane.tsx`：刪私有 `bufferKeyFor` + 上方註解，4 個 call site 改用 `bufferKey`。
+
+### 4.2 `spa/src/lib/tab-lifecycle.ts`（`closeTab`）
+- lock early-return 後，以 `scanPaneTree(tab.layout, ...)` 走訪；命中首個 dirty editor 即設 `dirty` 旗標，**後續 pane 的 callback 早退為 no-op**（`scanPaneTree` 本身無 short-circuit，仍走完整棵樹，但不再做額外判斷）。
+- `if (dirty && !window.confirm(t('editor.close_dirty_confirm'))) return`。
+- 其後沿用既有 `destroyBrowserViewIfNeeded(tab)` + `closeTabInWorkspace(tabId, opts)`。
+
+### 4.3 `spa/src/components/editor/ImagePreviewPane.tsx`
+- state：`zoom: 'fit'|'actual'`、`natural`、`box`；refs：`containerRef`、`imgRef`。
+- `seenFilePath` render-time adjust-state-on-prop-change：`filePath` 變 → reset `zoom='fit'` + `natural=null`（避免 setState-in-effect cascade）。
+- `measureNatural`（useCallback）：img complete 且 naturalWidth>0 才量；值未變則回 prev（穩定 ref）。
+- effect：mount/objectUrl 變時同步 `measureNatural()` + 掛 native `load` listener。
+- `useLayoutEffect` + `ResizeObserver` 量容器 box。
+- `oversized` useMemo；`isActual = zoom==='actual' && oversized`。
+- class：fit → `max-w-full max-h-full object-contain` + 置中；actual → `max-w-none max-h-none` + 左上對齊；cursor 依 oversized/isActual。
+
+### 4.4 `spa/src/components/editor/MonacoWrapper.tsx`
+- `options.scrollBeyondLastLine: true`（原 `false`）。
+
+## 5. Acceptance Criteria（= 測試契約）
+
+### bufferKey（`editor-buffer-key.test.ts`, 4）
+- AC1 `daemon`+hostId → `daemon:h1:/a.md`
+- AC2 `inapp` → `inapp:/a.md`；AC3 `local` → `local:/a.md`
+- AC4 同 path 不同 hostId → 不同 key
+
+### closeTab dirty guard（`tab-lifecycle.test.ts`, +8）
+- AC5 dirty + 接受 → confirm ×1 + `closeTabInWorkspace(id, undefined)`
+- AC6 dirty + 取消 → confirm ×1 + **不**呼叫 closeTabInWorkspace
+- AC7 clean → 不 confirm + 正常關閉
+- AC8 無 buffer → 不 confirm + 正常關閉
+- AC9 非 editor tab → 不 confirm + 正常關閉
+- AC10 split（一 dirty 一 clean）→ confirm **恰一次** + 正常關閉
+- AC11 locked tab → 不 confirm + **不**關閉
+- **AC11b（新建 untitled 文件）** filePath=`untitled:<name>` 的 editor pane，其 buffer（key=`inapp:untitled:<name>`）`isDirty===true` → 關 tab confirm ×1；`isDirty===false`（或無 buffer）→ 不 confirm。涵蓋使用者主訴「新建文件依是否有內容彈警告」的核心場景。
+
+### ImagePreviewPane（`ImagePreviewPane.test.tsx`, 7）
+- AC12 oversized → fit 態 `cursor-zoom-in` + `object-contain` + `max-w-full`
+- AC13 click → actual 態 `cursor-zoom-out` + `max-w-none` + 無 `object-contain`
+- AC14 再 click → 切回 fit（`cursor-zoom-in` + `object-contain`）
+- AC15 small image → 無 zoom cursor + click no-op（維持 `object-contain`）
+- AC16 容器含 `overflow-auto` + `min-h-0`
+- AC17 `filePath` 變 → reset 回 fit
+- **AC17b（cached/HMR 同步量測，對應 I5）** 圖片已 `complete`（`naturalWidth>0`）但**不**派發後續 `load` event 時，僅靠 mount effect 的同步 `measureNatural()` 也必須正確判定 oversized 並顯示 `cursor-zoom-in`。測試 render 後**不**呼叫 `fireEvent.load`，直接 `waitFor` zoom cursor 出現。
+
+### MonacoWrapper（`MonacoWrapper.test.tsx`, +1）
+- AC18 傳入 options 含 `scrollBeyondLastLine: true`
+
+## 6. Commit 切分（單一 PR，4 commit）
+1. `refactor(editor): extract shared bufferKey helper`（G1 / AC1-4）
+2. `feat(editor): warn before closing tab with unsaved changes`（G2/G5 / AC5-11b，含 untitled）
+3. `feat(editor): fit/actual zoom toggle in image preview`（G3 / AC12-17b，含同步量測）
+4. `feat(editor): enable scrollBeyondLastLine in Monaco`（G4 / AC18）
+
+> commit 1 必須在 commit 2 之前（dirty guard 依賴共用 key）。3、4 彼此獨立。
+
+## 7. Out of Scope / Known Limitations
+- pre-existing test failures（§1 / §N5）— 另案；本 PR 不碰。
+- image zoom 僅二態 toggle，無連續縮放 / 平移（§N4）。
+- dirty guard 不列舉 dirty 檔名、不分 pane confirm（§N2）。

--- a/spa/src/components/editor/EditorBuffersPane.tsx
+++ b/spa/src/components/editor/EditorBuffersPane.tsx
@@ -3,6 +3,7 @@ import { FilePlus, PencilSimple, Stack, Trash, FolderOpen } from '@phosphor-icon
 import type { PaneRendererProps } from '../../lib/module-registry'
 import { getFsBackend } from '../../lib/fs-backend'
 import { scanPaneTree } from '../../lib/pane-tree'
+import { bufferKey } from '../../lib/editor-buffer-key'
 import { useEditorStore } from '../../stores/useEditorStore'
 import { useI18nStore } from '../../stores/useI18nStore'
 import { useTabStore } from '../../stores/useTabStore'
@@ -12,14 +13,6 @@ import type { FileSource } from '../../types/fs'
 import type { Pane, PaneContent, Tab } from '../../types/tab'
 import { RenamePopover } from '../RenamePopover'
 import { createMetadata } from '../../lib/editor-language'
-
-// Local copy of EditorPane's private `bufferKey` helper — until a shared
-// util is extracted, keep the formula in lock-step.  inapp sources alone
-// are relevant here, but the helper is kept source-aware for parity.
-function bufferKeyFor(source: FileSource, filePath: string): string {
-  if (source.type === 'daemon') return `daemon:${source.hostId}:${filePath}`
-  return `${source.type}:${filePath}`
-}
 
 // v1.5 G1 fix — mirror EditorPane's rename three-step sync (backend →
 // tab-layout → editor-store). Without this, renaming via the buffers
@@ -38,8 +31,8 @@ async function performBufferRename(fromPath: string, targetPath: string) {
   await backend.rename(fromPath, targetPath)
   const source: FileSource = { type: 'inapp' }
   useTabStore.getState().renameEditorPanes(source, fromPath, targetPath)
-  const oldKey = bufferKeyFor(source, fromPath)
-  const newKey = bufferKeyFor(source, targetPath)
+  const oldKey = bufferKey(source, fromPath)
+  const newKey = bufferKey(source, targetPath)
   const currentBuffer = useEditorStore.getState().buffers[oldKey]
   const nextMetadata = currentBuffer?.languageSource === 'manual'
     ? { language: currentBuffer.language, languageSource: 'manual' as const }
@@ -221,7 +214,7 @@ export function EditorBuffersPane(_: PaneRendererProps) {
     const dirtyHits = openPanes.filter(([, pane]) => {
       const content = pane.content
       if (content.kind !== 'editor') return false
-      const key = bufferKeyFor(content.source, content.filePath)
+      const key = bufferKey(content.source, content.filePath)
       return useEditorStore.getState().buffers[key]?.isDirty === true
     })
 
@@ -256,7 +249,7 @@ export function EditorBuffersPane(_: PaneRendererProps) {
       for (const [tabId, pane] of openPanes) {
         useTabStore.getState().closePane(tabId, pane.id)
         if (pane.content.kind === 'editor') {
-          const key = bufferKeyFor(pane.content.source, pane.content.filePath)
+          const key = bufferKey(pane.content.source, pane.content.filePath)
           useEditorStore.getState().closePane(pane.id, key)
         }
       }
@@ -303,7 +296,7 @@ export function EditorBuffersPane(_: PaneRendererProps) {
         const c = p.content
         if (c.kind !== 'editor') return
         if (c.source.type !== 'inapp') return
-        const key = bufferKeyFor(c.source, c.filePath)
+        const key = bufferKey(c.source, c.filePath)
         if (useEditorStore.getState().buffers[key]?.isDirty === true) return
         found = p.id
       })

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -11,6 +11,7 @@ import { EditorToolbar } from './EditorToolbar'
 import { EditorStatusBar } from './EditorStatusBar'
 import { RenamePopover } from '../RenamePopover'
 import { findPane } from '../../lib/pane-tree'
+import { bufferKey } from '../../lib/editor-buffer-key'
 import type { FileSource } from '../../types/fs'
 import type { UntitledDocumentState } from '../../types/tab'
 import {
@@ -22,11 +23,6 @@ import {
 const TiptapEditor = lazy(() =>
   import('./TiptapEditor').then((m) => ({ default: m.TiptapEditor }))
 )
-
-function bufferKey(source: FileSource, filePath: string): string {
-  if (source.type === 'daemon') return `daemon:${source.hostId}:${filePath}`
-  return `${source.type}:${filePath}`
-}
 
 function isUntitledPath(filePath: string): boolean {
   return filePath.startsWith('untitled:')

--- a/spa/src/components/editor/ImagePreviewPane.test.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.test.tsx
@@ -3,11 +3,12 @@ import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/re
 import { ImagePreviewPane } from './ImagePreviewPane'
 import type { Pane } from '../../types/tab'
 import type { FileSource } from '../../types/fs'
+import { getFsBackend } from '../../lib/fs-backend'
 
 const read = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
 
 vi.mock('../../lib/fs-backend', () => ({
-  getFsBackend: () => ({ read }),
+  getFsBackend: vi.fn(() => ({ read })),
 }))
 
 // Track defineProperty installs so we can restore between tests.
@@ -26,6 +27,7 @@ function makePane(filePath: string, source: FileSource = { type: 'inapp' }): Pan
 
 beforeEach(() => {
   read.mockClear()
+  vi.mocked(getFsBackend).mockReturnValue({ read } as unknown as ReturnType<typeof getFsBackend>)
 
   // Polyfill ResizeObserver (jsdom lacks it).
   globalThis.ResizeObserver = class {
@@ -320,5 +322,31 @@ describe('ImagePreviewPane', () => {
     await screen.findByRole('img')
 
     expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+  })
+
+  // P3: a backend unavailable on first render but available afterwards (same
+  // source/filePath, so identity is unchanged) must still trigger a re-read
+  // rather than sticking on "No FS backend". Guards the read effect's `backend`
+  // dependency (keying off identity alone would miss this).
+  it('re-reads when the backend becomes available after first render (P3)', async () => {
+    imgComplete = true
+    imgNaturalW = 100
+    imgNaturalH = 100
+    boxW = 500
+    boxH = 500
+
+    // First render: backend not yet registered.
+    vi.mocked(getFsBackend).mockReturnValueOnce(undefined)
+    const { rerender } = render(
+      <ImagePreviewPane pane={makePane('/late.png')} isActive={true} />,
+    )
+    expect(screen.getByText('No FS backend')).toBeInTheDocument()
+    expect(read).not.toHaveBeenCalled()
+
+    // Backend becomes available; identity unchanged, only the `backend` dep
+    // flips — which must still drive a re-read.
+    rerender(<ImagePreviewPane pane={makePane('/late.png')} isActive={true} />)
+    await screen.findByRole('img')
+    expect(read).toHaveBeenCalledWith('/late.png')
   })
 })

--- a/spa/src/components/editor/ImagePreviewPane.test.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.test.tsx
@@ -6,9 +6,14 @@ import type { FileSource } from '../../types/fs'
 import { getFsBackend } from '../../lib/fs-backend'
 
 const read = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
+// Stable backend instance — mirrors production getFsBackend, which returns a
+// Map-cached instance (not a fresh object per call). Now that the render-phase
+// reset compares the backend object to detect a session change, a per-call-new
+// mock would falsely read every rerender as a backend change.
+const backendInstance = { read }
 
 vi.mock('../../lib/fs-backend', () => ({
-  getFsBackend: vi.fn(() => ({ read })),
+  getFsBackend: vi.fn(() => backendInstance),
 }))
 
 // Track defineProperty installs so we can restore between tests.
@@ -27,7 +32,7 @@ function makePane(filePath: string, source: FileSource = { type: 'inapp' }): Pan
 
 beforeEach(() => {
   read.mockClear()
-  vi.mocked(getFsBackend).mockReturnValue({ read } as unknown as ReturnType<typeof getFsBackend>)
+  vi.mocked(getFsBackend).mockReturnValue(backendInstance as unknown as ReturnType<typeof getFsBackend>)
 
   // Polyfill ResizeObserver (jsdom lacks it).
   globalThis.ResizeObserver = class {
@@ -348,5 +353,33 @@ describe('ImagePreviewPane', () => {
     rerender(<ImagePreviewPane pane={makePane('/late.png')} isActive={true} />)
     await screen.findByRole('img')
     expect(read).toHaveBeenCalledWith('/late.png')
+  })
+
+  // Method-E: a backend change for the SAME identity invalidates the preview
+  // session — stale error must drop and a successful re-read on the re-registered
+  // backend must clear the prior error banner (the R4 recovery case).
+  it('drops stale preview/error when the backend changes for the same identity (E)', async () => {
+    imgComplete = true
+    imgNaturalW = 100
+    imgNaturalH = 100
+    boxW = 500
+    boxH = 500
+
+    // First read fails → error banner shown.
+    read.mockRejectedValueOnce(new Error('read failed'))
+    const { rerender } = render(
+      <ImagePreviewPane pane={makePane('/x.png')} isActive={true} />,
+    )
+    await waitFor(() => expect(screen.getByText('read failed')).toBeInTheDocument())
+
+    // Same identity, backend re-registered (new instance); next read succeeds.
+    const reregistered = { read }
+    vi.mocked(getFsBackend).mockReturnValue(
+      reregistered as unknown as ReturnType<typeof getFsBackend>,
+    )
+    rerender(<ImagePreviewPane pane={makePane('/x.png')} isActive={true} />)
+
+    await screen.findByRole('img')
+    expect(screen.queryByText('read failed')).toBeNull()
   })
 })

--- a/spa/src/components/editor/ImagePreviewPane.test.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import { ImagePreviewPane } from './ImagePreviewPane'
 import type { Pane } from '../../types/tab'
+import type { FileSource } from '../../types/fs'
 
 const read = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
 
@@ -16,10 +17,10 @@ let imgNaturalH = 0
 let boxW = 0
 let boxH = 0
 
-function makePane(filePath: string): Pane {
+function makePane(filePath: string, source: FileSource = { type: 'inapp' }): Pane {
   return {
     id: 'p1',
-    content: { kind: 'image-preview', source: { type: 'inapp' }, filePath },
+    content: { kind: 'image-preview', source, filePath },
   }
 }
 
@@ -193,5 +194,131 @@ describe('ImagePreviewPane', () => {
     fireEvent.load(img)
     await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
     expect(img.className).not.toContain('cursor-zoom-out')
+  })
+
+  // F5: same filePath but a different source must also reset zoom/natural.
+  it('resets to fit mode when only the source changes for the same filePath (F5)', async () => {
+    imgComplete = true
+    imgNaturalW = 2000
+    imgNaturalH = 2000
+    boxW = 500
+    boxH = 500
+
+    const { rerender } = render(
+      <ImagePreviewPane
+        pane={makePane('/same.png', { type: 'daemon', hostId: 'h1' })}
+        isActive={true}
+      />,
+    )
+    let img = await screen.findByRole('img')
+    fireEvent.load(img)
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
+
+    // Toggle to actual size.
+    fireEvent.click(img)
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-out'))
+
+    // Same filePath, different daemon host → should reset back to fit.
+    rerender(
+      <ImagePreviewPane
+        pane={makePane('/same.png', { type: 'daemon', hostId: 'h2' })}
+        isActive={true}
+      />,
+    )
+    img = await screen.findByRole('img')
+    fireEvent.load(img)
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
+    expect(img.className).not.toContain('cursor-zoom-out')
+  })
+
+  // F4(a): switching files must not leave the previous image's objectUrl on
+  // screen during the new read — it should fall back to Loading immediately.
+  it('clears the previous image during the next read when switching files (F4)', async () => {
+    imgComplete = true
+    imgNaturalW = 2000
+    imgNaturalH = 2000
+    boxW = 500
+    boxH = 500
+
+    // First file loads successfully.
+    const { rerender } = render(
+      <ImagePreviewPane pane={makePane('/a.png')} isActive={true} />,
+    )
+    await screen.findByRole('img')
+
+    // Hold the next read pending so we can observe the transition state.
+    let resolveB: (data: Uint8Array) => void = () => {}
+    read.mockImplementationOnce(
+      () => new Promise<Uint8Array>((resolve) => { resolveB = resolve }),
+    )
+
+    rerender(<ImagePreviewPane pane={makePane('/b.png')} isActive={true} />)
+
+    // While B is still loading, the old image must be gone (Loading shown).
+    await waitFor(() => expect(screen.queryByRole('img')).toBeNull())
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+    // Resolve B → image reappears.
+    resolveB(new Uint8Array([4, 5, 6]))
+    await screen.findByRole('img')
+  })
+
+  // F4(b): a prior read failure shows an error banner; switching to a file that
+  // reads successfully must clear that sticky error.
+  it('clears a prior error banner when switching to a file that loads (F4)', async () => {
+    imgComplete = true
+    imgNaturalW = 100
+    imgNaturalH = 100
+    boxW = 500
+    boxH = 500
+
+    // First read rejects → error banner.
+    read.mockRejectedValueOnce(new Error('read failed'))
+    const { rerender } = render(
+      <ImagePreviewPane pane={makePane('/bad.png')} isActive={true} />,
+    )
+    await waitFor(() => expect(screen.getByText('read failed')).toBeInTheDocument())
+
+    // Switch to a file that reads fine → error cleared, image shown.
+    rerender(<ImagePreviewPane pane={makePane('/good.png')} isActive={true} />)
+    await screen.findByRole('img')
+    expect(screen.queryByText('read failed')).toBeNull()
+  })
+
+  // H1c: revokeObjectURL must be called on unmount (and when switching files)
+  // so blob URLs do not leak.
+  it('revokes the object URL on unmount (H1c)', async () => {
+    imgComplete = true
+    imgNaturalW = 100
+    imgNaturalH = 100
+    boxW = 500
+    boxH = 500
+
+    const { unmount } = render(
+      <ImagePreviewPane pane={makePane('/leak.png')} isActive={true} />,
+    )
+    await screen.findByRole('img')
+
+    unmount()
+
+    expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+  })
+
+  it('revokes the previous object URL when switching files (H1c)', async () => {
+    imgComplete = true
+    imgNaturalW = 100
+    imgNaturalH = 100
+    boxW = 500
+    boxH = 500
+
+    const { rerender } = render(
+      <ImagePreviewPane pane={makePane('/first.png')} isActive={true} />,
+    )
+    await screen.findByRole('img')
+
+    rerender(<ImagePreviewPane pane={makePane('/second.png')} isActive={true} />)
+    await screen.findByRole('img')
+
+    expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
   })
 })

--- a/spa/src/components/editor/ImagePreviewPane.test.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { ImagePreviewPane } from './ImagePreviewPane'
+import type { Pane } from '../../types/tab'
+
+const read = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
+
+vi.mock('../../lib/fs-backend', () => ({
+  getFsBackend: () => ({ read }),
+}))
+
+// Track defineProperty installs so we can restore between tests.
+let imgComplete = true
+let imgNaturalW = 0
+let imgNaturalH = 0
+let boxW = 0
+let boxH = 0
+
+function makePane(filePath: string): Pane {
+  return {
+    id: 'p1',
+    content: { kind: 'image-preview', source: { type: 'inapp' }, filePath },
+  }
+}
+
+beforeEach(() => {
+  read.mockClear()
+
+  // Polyfill ResizeObserver (jsdom lacks it).
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+
+  // Stub object URL APIs.
+  globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock')
+  globalThis.URL.revokeObjectURL = vi.fn()
+
+  // Stub image natural size + complete via prototype.
+  Object.defineProperty(HTMLImageElement.prototype, 'complete', {
+    configurable: true,
+    get: () => imgComplete,
+  })
+  Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', {
+    configurable: true,
+    get: () => imgNaturalW,
+  })
+  Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', {
+    configurable: true,
+    get: () => imgNaturalH,
+  })
+
+  // Stub container box size via prototype.
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get: () => boxW,
+  })
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get: () => boxH,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+async function renderAndMeasure(filePath: string) {
+  render(<ImagePreviewPane pane={makePane(filePath)} isActive={true} />)
+  const img = await screen.findByRole('img')
+  // Trigger the native load listener now that complete/naturalWidth are set.
+  fireEvent.load(img)
+  return img as HTMLImageElement
+}
+
+describe('ImagePreviewPane', () => {
+  it('renders fit mode with zoom-in cursor when image is oversized', async () => {
+    imgComplete = true
+    imgNaturalW = 2000
+    imgNaturalH = 2000
+    boxW = 500
+    boxH = 500
+
+    const img = await renderAndMeasure('/big.png')
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
+    expect(img.className).toContain('object-contain')
+    expect(img.className).toContain('max-w-full')
+  })
+
+  it('toggles to actual size with zoom-out cursor on click', async () => {
+    imgComplete = true
+    imgNaturalW = 2000
+    imgNaturalH = 2000
+    boxW = 500
+    boxH = 500
+
+    const img = await renderAndMeasure('/big.png')
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
+
+    fireEvent.click(img)
+
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-out'))
+    expect(img.className).toContain('max-w-none')
+    expect(img.className).not.toContain('object-contain')
+  })
+
+  it('toggles back to fit on a second click', async () => {
+    imgComplete = true
+    imgNaturalW = 2000
+    imgNaturalH = 2000
+    boxW = 500
+    boxH = 500
+
+    const img = await renderAndMeasure('/big.png')
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
+
+    fireEvent.click(img)
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-out'))
+
+    fireEvent.click(img)
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
+    expect(img.className).toContain('object-contain')
+  })
+
+  it('shows no zoom cursor and click is a no-op for a small image', async () => {
+    imgComplete = true
+    imgNaturalW = 100
+    imgNaturalH = 100
+    boxW = 500
+    boxH = 500
+
+    const img = await renderAndMeasure('/small.png')
+    await waitFor(() => expect(img).toBeTruthy())
+    expect(img.className).not.toContain('cursor-zoom-in')
+    expect(img.className).not.toContain('cursor-zoom-out')
+
+    fireEvent.click(img)
+    expect(img.className).toContain('object-contain')
+    expect(img.className).not.toContain('max-w-none')
+  })
+
+  it('wraps the image in a scrollable container with overflow-auto and min-h-0', async () => {
+    imgComplete = true
+    imgNaturalW = 2000
+    imgNaturalH = 2000
+    boxW = 500
+    boxH = 500
+
+    const img = await renderAndMeasure('/big.png')
+    const container = img.parentElement as HTMLElement
+    expect(container.className).toContain('overflow-auto')
+    expect(container.className).toContain('min-h-0')
+  })
+
+  it('measures oversized synchronously for a cached/HMR-complete image without a load event (AC17b)', async () => {
+    imgComplete = true
+    imgNaturalW = 2000
+    imgNaturalH = 2000
+    boxW = 500
+    boxH = 500
+
+    render(<ImagePreviewPane pane={makePane('/big.png')} isActive={true} />)
+    // Wait for the async backend.read -> objectUrl -> img mount chain.
+    const img = (await screen.findByRole('img')) as HTMLImageElement
+    // Deliberately do NOT fire a load event — only the mount effect's synchronous
+    // measureNatural() should drive the oversized determination.
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
+    expect(img.className).toContain('object-contain')
+    expect(img.className).toContain('max-w-full')
+  })
+
+  it('resets to fit mode when filePath changes', async () => {
+    imgComplete = true
+    imgNaturalW = 2000
+    imgNaturalH = 2000
+    boxW = 500
+    boxH = 500
+
+    const { rerender } = render(
+      <ImagePreviewPane pane={makePane('/big.png')} isActive={true} />,
+    )
+    let img = await screen.findByRole('img')
+    fireEvent.load(img)
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
+
+    fireEvent.click(img)
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-out'))
+
+    // Switch to a different file — should reset to fit.
+    rerender(<ImagePreviewPane pane={makePane('/other.png')} isActive={true} />)
+    img = await screen.findByRole('img')
+    fireEvent.load(img)
+    await waitFor(() => expect(img.className).toContain('cursor-zoom-in'))
+    expect(img.className).not.toContain('cursor-zoom-out')
+  })
+})

--- a/spa/src/components/editor/ImagePreviewPane.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.tsx
@@ -34,21 +34,24 @@ function ImagePreviewPaneInner({ source, filePath }: { source: FileSource; fileP
     setSeenIdentity(identity)
     setZoom('fit')
     setNatural(null)
-  }
-
-  // Key the read effect off the stable composite identity string rather than the
-  // `backend` object's identity: the backend is resolved fresh on every render and
-  // would otherwise re-run this effect each render (and, with the synchronous
-  // reset below, loop forever). `identity` changes exactly when source or filePath
-  // changes — which is precisely when a re-read is needed.
-  useEffect(() => {
-    if (!backend) return
-    // Clear any previously loaded image / error so switching files immediately
-    // falls back to Loading instead of leaving the old image (or a stale error
-    // banner) on screen until the new read resolves. The previous objectUrl is
-    // still revoked by this effect's cleanup, so no blob URL leaks.
+    // Clear the previous preview synchronously *during render* (not in the read
+    // effect below) so switching files never paints the old image or a stale
+    // error banner for a frame before the effect commits. The old objectUrl is
+    // still revoked by the read effect's cleanup, so no blob URL leaks.
     setObjectUrl(null)
     setError(null)
+  }
+
+  // Re-read whenever the identity (composite source+filePath key, which also
+  // captures daemon hostId so a same-path/different-host switch re-reads) OR the
+  // backend changes. Depending ALSO on `backend` is what makes a backend that
+  // becomes available after first render — or is re-registered — trigger a
+  // re-read instead of sticking on "No FS backend"/stale content; in the steady
+  // state getFsBackend returns a stable instance so this does not re-run per
+  // render. The objectUrl/error reset is done synchronously during render above
+  // (not here), so no stale frame is painted. filePath is covered by identity.
+  useEffect(() => {
+    if (!backend) return
     let url: string | null = null
     let stale = false
     backend.read(filePath)
@@ -60,7 +63,7 @@ function ImagePreviewPaneInner({ source, filePath }: { source: FileSource; fileP
       .catch((err: Error) => { if (!stale) setError(err.message) })
     return () => { stale = true; if (url) URL.revokeObjectURL(url) }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [identity])
+  }, [identity, backend])
 
   const measureNatural = useCallback(() => {
     const img = imgRef.current

--- a/spa/src/components/editor/ImagePreviewPane.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.tsx
@@ -22,34 +22,41 @@ function ImagePreviewPaneInner({ source, filePath }: { source: FileSource; fileP
   const containerRef = useRef<HTMLDivElement | null>(null)
   const imgRef = useRef<HTMLImageElement | null>(null)
 
-  // Reset zoom + measured natural size during render when the buffer changes
-  // (the React-recommended "adjust state on prop change" pattern, avoiding a
-  // setState-in-effect reset that would cascade-render and trip the lint rule).
-  // Identity is the composite (source, filePath) key so that switching to the
-  // same path on a different source (e.g. another daemon host, or inapp↔daemon)
-  // still resets zoom/natural rather than carrying over stale measurements.
+  // A preview "session" is identified by the composite (identity, backend): the
+  // identity (source+filePath, capturing daemon hostId) AND the resolved backend
+  // object together decide which preview is showing. Switching files/hosts, or
+  // having the backend become available / re-registered, all invalidate the
+  // current session. We reset on exactly that composite — the same one the read
+  // effect below depends on — so "when to drop stale preview state" and "when to
+  // re-read" are ONE rule rather than two (the earlier split — reset on identity
+  // only, read on [identity, backend] — is what left same-identity backend
+  // changes half-reset and took several review rounds to surface).
+  //
+  // Done synchronously during render (React's "adjust state on prop change"
+  // pattern) so switching never paints the old image / stale error for a frame
+  // before an effect commits. The old objectUrl is still revoked by the read
+  // effect's cleanup, so no blob URL leaks. `box` is container measurement, not
+  // session state, so it is deliberately not reset here. getFsBackend returns a
+  // stable Map-cached instance, so comparing the backend object does not loop.
   const identity = bufferKey(source, filePath)
   const [seenIdentity, setSeenIdentity] = useState(identity)
-  if (seenIdentity !== identity) {
+  const [seenBackend, setSeenBackend] = useState(backend)
+  if (seenIdentity !== identity || seenBackend !== backend) {
     setSeenIdentity(identity)
+    setSeenBackend(backend)
     setZoom('fit')
     setNatural(null)
-    // Clear the previous preview synchronously *during render* (not in the read
-    // effect below) so switching files never paints the old image or a stale
-    // error banner for a frame before the effect commits. The old objectUrl is
-    // still revoked by the read effect's cleanup, so no blob URL leaks.
     setObjectUrl(null)
     setError(null)
   }
 
-  // Re-read whenever the identity (composite source+filePath key, which also
-  // captures daemon hostId so a same-path/different-host switch re-reads) OR the
-  // backend changes. Depending ALSO on `backend` is what makes a backend that
-  // becomes available after first render — or is re-registered — trigger a
-  // re-read instead of sticking on "No FS backend"/stale content; in the steady
-  // state getFsBackend returns a stable instance so this does not re-run per
-  // render. The objectUrl/error reset is done synchronously during render above
-  // (not here), so no stale frame is painted. filePath is covered by identity.
+  // Re-read whenever the session (identity, backend) changes — the same composite
+  // the render-phase reset above keys off. Resetting preview state happens there
+  // (render phase), not here, so no stale frame is painted. On success we also
+  // clear `error` before setting the new objectUrl: this covers a same-session
+  // re-read that recovers from a prior failure (the reset above only fires on a
+  // session *change*, so a success within the same session must clear the stale
+  // error itself or `if (error) return` would keep short-circuiting the render).
   useEffect(() => {
     if (!backend) return
     let url: string | null = null
@@ -58,6 +65,7 @@ function ImagePreviewPaneInner({ source, filePath }: { source: FileSource; fileP
       .then((data) => {
         if (stale) return
         url = URL.createObjectURL(new Blob([new Uint8Array(data)]))
+        setError(null)
         setObjectUrl(url)
       })
       .catch((err: Error) => { if (!stale) setError(err.message) })

--- a/spa/src/components/editor/ImagePreviewPane.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.tsx
@@ -1,10 +1,9 @@
 // spa/src/components/editor/ImagePreviewPane.tsx
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, useMemo, useCallback } from 'react'
 import type { PaneRendererProps } from '../../lib/module-registry'
 import { getFsBackend } from '../../lib/fs-backend'
 import type { FileSource } from '../../types/fs'
 
-// Outer component does kind guard to avoid hooks-after-early-return
 export function ImagePreviewPane({ pane }: PaneRendererProps) {
   const content = pane.content
   if (content.kind !== 'image-preview') return null
@@ -14,41 +13,100 @@ export function ImagePreviewPane({ pane }: PaneRendererProps) {
 function ImagePreviewPaneInner({ source, filePath }: { source: FileSource; filePath: string }) {
   const [objectUrl, setObjectUrl] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [zoom, setZoom] = useState<'fit' | 'actual'>('fit')
+  const [natural, setNatural] = useState<{ w: number; h: number } | null>(null)
+  const [box, setBox] = useState<{ w: number; h: number } | null>(null)
   const backend = getFsBackend(source)
+
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const imgRef = useRef<HTMLImageElement | null>(null)
+
+  // Reset zoom + measured natural size during render when the file changes
+  // (the React-recommended "adjust state on prop change" pattern, avoiding a
+  // setState-in-effect reset that would cascade-render and trip the lint rule).
+  const [seenFilePath, setSeenFilePath] = useState(filePath)
+  if (seenFilePath !== filePath) {
+    setSeenFilePath(filePath)
+    setZoom('fit')
+    setNatural(null)
+  }
 
   useEffect(() => {
     if (!backend) return
-
     let url: string | null = null
     let stale = false
-
     backend.read(filePath)
       .then((data) => {
         if (stale) return
         url = URL.createObjectURL(new Blob([new Uint8Array(data)]))
         setObjectUrl(url)
       })
-      .catch((err: Error) => {
-        if (!stale) setError(err.message)
-      })
-
+      .catch((err: Error) => { if (!stale) setError(err.message) })
     return () => { stale = true; if (url) URL.revokeObjectURL(url) }
   }, [backend, filePath])
 
-  if (!backend) return <div className="flex-1 flex items-center justify-center text-red-400 text-xs">No FS backend</div>
+  const measureNatural = useCallback(() => {
+    const img = imgRef.current
+    if (!img || !img.complete || img.naturalWidth === 0) return
+    setNatural((prev) =>
+      prev && prev.w === img.naturalWidth && prev.h === img.naturalHeight
+        ? prev
+        : { w: img.naturalWidth, h: img.naturalHeight },
+    )
+  }, [])
 
+  // Cached / HMR blobs can be `complete` before any load event fires, so measure
+  // synchronously AND attach a native load listener (React onLoad is unreliable
+  // for already-complete images — that left oversized permanently false).
+  useEffect(() => {
+    const img = imgRef.current
+    if (!img) return
+    measureNatural()
+    img.addEventListener('load', measureNatural)
+    return () => img.removeEventListener('load', measureNatural)
+  }, [objectUrl, measureNatural])
+
+  useLayoutEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const update = () => {
+      const w = el.clientWidth
+      const h = el.clientHeight
+      setBox((prev) => (prev && prev.w === w && prev.h === h ? prev : { w, h }))
+    }
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [objectUrl])
+
+  const oversized = useMemo(() => {
+    if (!natural || !box) return false
+    return natural.w > box.w || natural.h > box.h
+  }, [natural, box])
+
+  if (!backend) return <div className="flex-1 flex items-center justify-center text-red-400 text-xs">No FS backend</div>
   if (error) return <div className="flex-1 flex items-center justify-center text-red-400 text-xs">{error}</div>
   if (!objectUrl) return <div className="flex-1 flex items-center justify-center text-text-muted text-xs">Loading...</div>
 
   const fileName = filePath.split('/').pop() ?? ''
+  const isActual = zoom === 'actual' && oversized
+  const layoutClasses = isActual ? 'items-start justify-start' : 'items-center justify-center'
+  const cursorClass = oversized ? (isActual ? 'cursor-zoom-out' : 'cursor-zoom-in') : ''
+  const imgClasses = isActual ? 'max-w-none max-h-none' : 'max-w-full max-h-full object-contain'
+
+  const handleClick = () => {
+    if (!oversized) return
+    setZoom((z) => (z === 'fit' ? 'actual' : 'fit'))
+  }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="flex-1 flex flex-col overflow-hidden min-h-0">
       <div className="px-3 py-1 border-b border-border-subtle bg-surface-secondary text-xs text-text-secondary truncate">
         {fileName}
       </div>
-      <div className="flex-1 flex items-center justify-center p-4 overflow-auto bg-surface-primary">
-        <img src={objectUrl} alt={fileName} className="max-w-full max-h-full object-contain" />
+      <div ref={containerRef} className={`flex-1 min-h-0 min-w-0 flex ${layoutClasses} p-4 overflow-auto bg-surface-primary`}>
+        <img ref={imgRef} src={objectUrl} alt={fileName} onLoad={measureNatural} onClick={handleClick} className={`${imgClasses} ${cursorClass}`.trim()} />
       </div>
     </div>
   )

--- a/spa/src/components/editor/ImagePreviewPane.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, useMemo, useCallback } from 'react'
 import type { PaneRendererProps } from '../../lib/module-registry'
 import { getFsBackend } from '../../lib/fs-backend'
+import { bufferKey } from '../../lib/editor-buffer-key'
 import type { FileSource } from '../../types/fs'
 
 export function ImagePreviewPane({ pane }: PaneRendererProps) {
@@ -21,18 +22,33 @@ function ImagePreviewPaneInner({ source, filePath }: { source: FileSource; fileP
   const containerRef = useRef<HTMLDivElement | null>(null)
   const imgRef = useRef<HTMLImageElement | null>(null)
 
-  // Reset zoom + measured natural size during render when the file changes
+  // Reset zoom + measured natural size during render when the buffer changes
   // (the React-recommended "adjust state on prop change" pattern, avoiding a
   // setState-in-effect reset that would cascade-render and trip the lint rule).
-  const [seenFilePath, setSeenFilePath] = useState(filePath)
-  if (seenFilePath !== filePath) {
-    setSeenFilePath(filePath)
+  // Identity is the composite (source, filePath) key so that switching to the
+  // same path on a different source (e.g. another daemon host, or inapp↔daemon)
+  // still resets zoom/natural rather than carrying over stale measurements.
+  const identity = bufferKey(source, filePath)
+  const [seenIdentity, setSeenIdentity] = useState(identity)
+  if (seenIdentity !== identity) {
+    setSeenIdentity(identity)
     setZoom('fit')
     setNatural(null)
   }
 
+  // Key the read effect off the stable composite identity string rather than the
+  // `backend` object's identity: the backend is resolved fresh on every render and
+  // would otherwise re-run this effect each render (and, with the synchronous
+  // reset below, loop forever). `identity` changes exactly when source or filePath
+  // changes — which is precisely when a re-read is needed.
   useEffect(() => {
     if (!backend) return
+    // Clear any previously loaded image / error so switching files immediately
+    // falls back to Loading instead of leaving the old image (or a stale error
+    // banner) on screen until the new read resolves. The previous objectUrl is
+    // still revoked by this effect's cleanup, so no blob URL leaks.
+    setObjectUrl(null)
+    setError(null)
     let url: string | null = null
     let stale = false
     backend.read(filePath)
@@ -43,7 +59,8 @@ function ImagePreviewPaneInner({ source, filePath }: { source: FileSource; fileP
       })
       .catch((err: Error) => { if (!stale) setError(err.message) })
     return () => { stale = true; if (url) URL.revokeObjectURL(url) }
-  }, [backend, filePath])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [identity])
 
   const measureNatural = useCallback(() => {
     const img = imgRef.current

--- a/spa/src/components/editor/MonacoWrapper.test.tsx
+++ b/spa/src/components/editor/MonacoWrapper.test.tsx
@@ -227,4 +227,25 @@ describe('MonacoWrapper', () => {
       }),
     )
   })
+
+  it('enables scrollBeyondLastLine so the bottom has a scroll buffer', () => {
+    render(
+      <MonacoWrapper
+        content="hello"
+        language="markdown"
+        modelId="model-1"
+        isActive={true}
+        initialViewState={null}
+        onChange={() => {}}
+        onCursorChange={() => {}}
+        onViewStateChange={() => {}}
+        onSave={() => {}}
+      />,
+    )
+
+    const lastCall = editorPropsSpy.mock.calls.at(-1)?.[0] as { options: Record<string, unknown> }
+    expect(lastCall.options).toEqual(
+      expect.objectContaining({ scrollBeyondLastLine: true }),
+    )
+  })
 })

--- a/spa/src/components/editor/MonacoWrapper.tsx
+++ b/spa/src/components/editor/MonacoWrapper.tsx
@@ -97,7 +97,7 @@ export function MonacoWrapper({ content, language, modelId, isActive, initialVie
         wordWrap,
         tabSize,
         insertSpaces,
-        scrollBeyondLastLine: false,
+        scrollBeyondLastLine: true,
         automaticLayout: true,
       }}
     />

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -5,6 +5,7 @@ import { useEditorStore } from '../../../stores/useEditorStore'
 import { useTabStore } from '../../../stores/useTabStore'
 import type { Pane } from '../../../types/tab'
 import type { FsBackend } from '../../../lib/fs-backend'
+import { bufferKey } from '../../../lib/editor-buffer-key'
 
 const getFsBackendMock = vi.hoisted(() => vi.fn())
 const editorStatusBarMock = vi.hoisted(() => vi.fn())
@@ -103,7 +104,7 @@ function createBackend(): FsBackend & {
 }
 
 function getBufferKey(filePath: string): string {
-  return `inapp:${filePath}`
+  return bufferKey({ type: 'inapp' }, filePath)
 }
 
 function registerTabPane(pane: Pane, tabId = 'tab-1') {

--- a/spa/src/lib/editor-buffer-key.test.ts
+++ b/spa/src/lib/editor-buffer-key.test.ts
@@ -1,0 +1,23 @@
+// spa/src/lib/editor-buffer-key.test.ts
+import { describe, it, expect } from 'vitest'
+import { bufferKey } from './editor-buffer-key'
+
+describe('bufferKey', () => {
+  it('encodes daemon source with hostId', () => {
+    expect(bufferKey({ type: 'daemon', hostId: 'h1' }, '/a.md')).toBe('daemon:h1:/a.md')
+  })
+
+  it('encodes inapp source', () => {
+    expect(bufferKey({ type: 'inapp' }, '/a.md')).toBe('inapp:/a.md')
+  })
+
+  it('encodes local source', () => {
+    expect(bufferKey({ type: 'local' }, '/a.md')).toBe('local:/a.md')
+  })
+
+  it('produces distinct keys for different hostId with same path', () => {
+    const a = bufferKey({ type: 'daemon', hostId: 'h1' }, '/a.md')
+    const b = bufferKey({ type: 'daemon', hostId: 'h2' }, '/a.md')
+    expect(a).not.toBe(b)
+  })
+})

--- a/spa/src/lib/editor-buffer-key.ts
+++ b/spa/src/lib/editor-buffer-key.ts
@@ -1,0 +1,6 @@
+import type { FileSource } from '../types/fs'
+
+export function bufferKey(source: FileSource, filePath: string): string {
+  if (source.type === 'daemon') return `daemon:${source.hostId}:${filePath}`
+  return `${source.type}:${filePath}`
+}

--- a/spa/src/lib/tab-lifecycle.test.ts
+++ b/spa/src/lib/tab-lifecycle.test.ts
@@ -6,6 +6,7 @@ import { useWorkspaceStore } from '../features/workspace/store'
 import { useEditorStore } from '../stores/useEditorStore'
 import { createTab } from '../types/tab'
 import type { PaneContent, PaneLayout } from '../types/tab'
+import type { FileSource } from '../types/fs'
 import { closeTab } from './tab-lifecycle'
 import { bufferKey } from './editor-buffer-key'
 
@@ -91,12 +92,12 @@ describe('closeTab — unsaved editor warning', () => {
   let closeSpy: ReturnType<typeof vi.spyOn>
   let confirmSpy: ReturnType<typeof vi.spyOn>
 
-  function editorContent(filePath: string): PaneContent {
-    return { kind: 'editor', source: { type: 'inapp' }, filePath }
+  function editorContent(filePath: string, source: FileSource = { type: 'inapp' }): PaneContent {
+    return { kind: 'editor', source, filePath }
   }
 
-  function seedBuffer(filePath: string, isDirty: boolean) {
-    const key = bufferKey({ type: 'inapp' }, filePath)
+  function seedBuffer(filePath: string, isDirty: boolean, source: FileSource = { type: 'inapp' }) {
+    const key = bufferKey(source, filePath)
     useEditorStore.setState({
       buffers: {
         ...useEditorStore.getState().buffers,
@@ -154,6 +155,34 @@ describe('closeTab — unsaved editor warning', () => {
   it('does not confirm when editor buffer is clean', () => {
     seedBuffer('/a.md', false)
     const id = addTabWithLayout({ type: 'leaf', pane: { id: 'p1', content: editorContent('/a.md') } })
+
+    closeTab(id)
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(closeSpy).toHaveBeenCalledWith(id, undefined)
+  })
+
+  it('confirms and closes when a daemon-sourced editor is dirty (H1a)', () => {
+    const daemon: FileSource = { type: 'daemon', hostId: 'h1' }
+    seedBuffer('/a.md', true, daemon)
+    const id = addTabWithLayout({
+      type: 'leaf',
+      pane: { id: 'p1', content: editorContent('/a.md', daemon) },
+    })
+
+    closeTab(id)
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(closeSpy).toHaveBeenCalledWith(id, undefined)
+  })
+
+  it('does not confirm when a daemon-sourced editor buffer is clean (H1a)', () => {
+    const daemon: FileSource = { type: 'daemon', hostId: 'h1' }
+    seedBuffer('/a.md', false, daemon)
+    const id = addTabWithLayout({
+      type: 'leaf',
+      pane: { id: 'p1', content: editorContent('/a.md', daemon) },
+    })
 
     closeTab(id)
 

--- a/spa/src/lib/tab-lifecycle.test.ts
+++ b/spa/src/lib/tab-lifecycle.test.ts
@@ -3,8 +3,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { useTabStore } from '../stores/useTabStore'
 import { useHistoryStore } from '../stores/useHistoryStore'
 import { useWorkspaceStore } from '../features/workspace/store'
+import { useEditorStore } from '../stores/useEditorStore'
 import { createTab } from '../types/tab'
+import type { PaneContent, PaneLayout } from '../types/tab'
 import { closeTab } from './tab-lifecycle'
+import { bufferKey } from './editor-buffer-key'
 
 function resetStores() {
   useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
@@ -81,5 +84,155 @@ describe('closeTab', () => {
     closeTab(tab.id)
 
     expect(useHistoryStore.getState().closedTabs).toHaveLength(1)
+  })
+})
+
+describe('closeTab — unsaved editor warning', () => {
+  let closeSpy: ReturnType<typeof vi.spyOn>
+  let confirmSpy: ReturnType<typeof vi.spyOn>
+
+  function editorContent(filePath: string): PaneContent {
+    return { kind: 'editor', source: { type: 'inapp' }, filePath }
+  }
+
+  function seedBuffer(filePath: string, isDirty: boolean) {
+    const key = bufferKey({ type: 'inapp' }, filePath)
+    useEditorStore.setState({
+      buffers: {
+        ...useEditorStore.getState().buffers,
+        [key]: { isDirty } as never,
+      },
+    })
+  }
+
+  function addTabWithLayout(layout: PaneLayout): string {
+    const tab = createTab({ kind: 'new-tab' })
+    const withLayout = { ...tab, layout }
+    useTabStore.getState().addTab(withLayout)
+    return withLayout.id
+  }
+
+  beforeEach(() => {
+    resetStores()
+    useEditorStore.setState({ buffers: {} })
+    Object.defineProperty(window, 'electronAPI', {
+      value: { destroyBrowserView: vi.fn() },
+      configurable: true,
+      writable: true,
+    })
+    closeSpy = vi.spyOn(useWorkspaceStore.getState(), 'closeTabInWorkspace')
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    closeSpy.mockRestore()
+    confirmSpy.mockRestore()
+    delete window.electronAPI
+  })
+
+  it('confirms and closes when editor is dirty and user accepts', () => {
+    seedBuffer('/a.md', true)
+    const id = addTabWithLayout({ type: 'leaf', pane: { id: 'p1', content: editorContent('/a.md') } })
+
+    closeTab(id)
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(closeSpy).toHaveBeenCalledWith(id, undefined)
+  })
+
+  it('aborts close when editor is dirty and user cancels', () => {
+    confirmSpy.mockReturnValue(false)
+    seedBuffer('/a.md', true)
+    const id = addTabWithLayout({ type: 'leaf', pane: { id: 'p1', content: editorContent('/a.md') } })
+
+    closeTab(id)
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(closeSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not confirm when editor buffer is clean', () => {
+    seedBuffer('/a.md', false)
+    const id = addTabWithLayout({ type: 'leaf', pane: { id: 'p1', content: editorContent('/a.md') } })
+
+    closeTab(id)
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(closeSpy).toHaveBeenCalledWith(id, undefined)
+  })
+
+  it('does not confirm when no buffer exists for the editor pane', () => {
+    const id = addTabWithLayout({ type: 'leaf', pane: { id: 'p1', content: editorContent('/missing.md') } })
+
+    closeTab(id)
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(closeSpy).toHaveBeenCalledWith(id, undefined)
+  })
+
+  it('does not confirm for non-editor tabs', () => {
+    const id = addTabWithLayout({ type: 'leaf', pane: { id: 'p1', content: { kind: 'new-tab' } } })
+
+    closeTab(id)
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(closeSpy).toHaveBeenCalledWith(id, undefined)
+  })
+
+  it('confirms exactly once for a split tab with one dirty and one clean editor', () => {
+    seedBuffer('/dirty.md', true)
+    seedBuffer('/clean.md', false)
+    const id = addTabWithLayout({
+      type: 'split',
+      id: 's1',
+      direction: 'h',
+      children: [
+        { type: 'leaf', pane: { id: 'p1', content: editorContent('/dirty.md') } },
+        { type: 'leaf', pane: { id: 'p2', content: editorContent('/clean.md') } },
+      ],
+      sizes: [50, 50],
+    })
+
+    closeTab(id)
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(closeSpy).toHaveBeenCalledWith(id, undefined)
+  })
+
+  it('returns early for a locked tab without confirming', () => {
+    seedBuffer('/a.md', true)
+    const id = addTabWithLayout({ type: 'leaf', pane: { id: 'p1', content: editorContent('/a.md') } })
+    useTabStore.getState().toggleLock(id)
+
+    closeTab(id)
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(closeSpy).not.toHaveBeenCalled()
+  })
+
+  it('confirms and closes for a dirty untitled draft (AC11b)', () => {
+    seedBuffer('untitled:draft', true)
+    const id = addTabWithLayout({
+      type: 'leaf',
+      pane: { id: 'p1', content: editorContent('untitled:draft') },
+    })
+
+    closeTab(id)
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(closeSpy).toHaveBeenCalledWith(id, undefined)
+  })
+
+  it('does not confirm for a clean untitled draft (AC11b)', () => {
+    seedBuffer('untitled:draft', false)
+    const id = addTabWithLayout({
+      type: 'leaf',
+      pane: { id: 'p1', content: editorContent('untitled:draft') },
+    })
+
+    closeTab(id)
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(closeSpy).toHaveBeenCalledWith(id, undefined)
   })
 })

--- a/spa/src/lib/tab-lifecycle.ts
+++ b/spa/src/lib/tab-lifecycle.ts
@@ -1,10 +1,24 @@
 import { useTabStore } from '../stores/useTabStore'
+import { useEditorStore } from '../stores/useEditorStore'
+import { useI18nStore } from '../stores/useI18nStore'
 import { useWorkspaceStore } from '../features/workspace/store'
 import { destroyBrowserViewIfNeeded } from './browser-cleanup'
+import { scanPaneTree } from './pane-tree'
+import { bufferKey } from './editor-buffer-key'
 
 export function closeTab(tabId: string, opts?: { skipHistory?: boolean }): void {
   const tab = useTabStore.getState().tabs[tabId]
   if (!tab || tab.locked) return
+
+  let dirty = false
+  scanPaneTree(tab.layout, (pane) => {
+    if (dirty) return
+    const c = pane.content
+    if (c.kind !== 'editor') return
+    if (useEditorStore.getState().buffers[bufferKey(c.source, c.filePath)]?.isDirty) dirty = true
+  })
+  if (dirty && !window.confirm(useI18nStore.getState().t('editor.close_dirty_confirm'))) return
+
   destroyBrowserViewIfNeeded(tab)
   useWorkspaceStore.getState().closeTabInWorkspace(tabId, opts)
 }

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -469,6 +469,7 @@
   "settings.monitor.loading": "Loading trace data...",
 
   "editor.provider_label": "Editor",
+  "editor.close_dirty_confirm": "This file has unsaved changes. Close anyway?",
   "editor.new_file": "New File",
   "editor.new_markdown": "New Markdown",
   "editor.settings.home_path.workspace": "Home Path (Workspace)",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -469,6 +469,7 @@
   "settings.monitor.loading": "正在載入 trace 資料...",
 
   "editor.provider_label": "編輯器",
+  "editor.close_dirty_confirm": "此檔案有未儲存的變更，仍要關閉嗎？",
   "editor.new_file": "新增檔案",
   "editor.new_markdown": "新增 Markdown",
   "editor.settings.home_path.workspace": "家目錄（Workspace）",


### PR DESCRIPTION
## 概述

Editor 模組三項開檔/檢視體驗強化，回應使用者三點主訴。實作原已存在於 worktree（uncommitted、無 PR），本次補走完整流程（spec → codex review → plan → codex review → TDD 補測 → PR）。

| 使用者需求 | 對應 | Commit |
|---|---|---|
| 1. 新建文件關閉時依「是否有內容」彈警告 | tab 關閉 dirty guard（含 untitled） | 2 |
| 2a. 遠端圖片超過螢幕高度無法捲動 | 容器 `overflow-auto` | 3 |
| 2b. oversized 縮到 fit + 放大鏡，點擊 toggle 原圖 | fit/actual zoom + zoom cursor | 3 |
| 3. editor 捲到最底補緩衝空間 | Monaco `scrollBeyondLastLine: true` | 4 |

## Commits（4，依賴順序）

1. `refactor(editor): extract shared bufferKey helper` — 抽 `EditorPane`/`EditorBuffersPane` 重複的 `bufferKey` 公式到 `editor-buffer-key.ts`（dirty guard 的 enabler）。含 spec + plan docs。
2. `feat(editor): warn before closing tab with unsaved changes` — `closeTab` 掃 pane tree，任一 editor buffer dirty（含 untitled 草稿）跳 `window.confirm`，取消則中止。+ i18n。
3. `feat(editor): fit/actual zoom toggle in image preview` — 圖片 fit↔actual 二態切換，oversized 才可點擊 + zoom cursor，容器可捲，cached/HMR 同步量測。
4. `feat(editor): enable scrollBeyondLastLine in Monaco` — 底部保留捲動緩衝。

> commit 1 必先於 2（dirty guard 依賴共用 key）；3、4 獨立。

## 流程與審查

- **spec**（`docs/specs/2026-06-09-...-spec.md`）過 codex round-1（gpt-5.4）：4 finding 全修 — 補 AC11b（untitled dirty guard）、AC17b（image 同步量測）兩條測試契約 + 措辭/數字。
- **plan**（同目錄 `-plan.md`）過 codex round-1：4 finding 全修 — 整合驗證納入 `EditorPane`/`EditorBuffersPane` caller regression + 範圍界定補述。
- **TDD**：補 2 條 acceptance 測試，**皆一次到綠、未動任何 production code**（既有實作已支援 spec I5 同步量測雙保險與 untitled 相同 bufferKey 路徑）。

## 驗證

- 本任務 4 核心檔達 **32 測** + `EditorPane`/`EditorBuffersPane` caller regression，6 檔合計 **77 測全綠**。
- `pnpm run lint` clean、`pnpm run build` 通過。
- ⚠️ 完整套件另有 **4 個 pre-existing failures**（`sync/contributors/hosts.test.ts` ×3、`TabBar.test.tsx` ×1），origin/main alpha.294 同樣 fail，**不在本 PR 範圍**。

## Review 焦點

- `closeTab` dirty scan：locked-tab early return 位置、split 多 pane 只 confirm 一次、untitled key 路徑。
- `ImagePreviewPane`：cached/HMR 已 `complete` 圖的同步量測（React `onLoad` 對已 complete img 不可靠）、`oversized` 判定、filePath 切換 render-time reset。
- `bufferKey` 抽取後三個 call site（EditorPane / EditorBuffersPane / tab-lifecycle）key 一致性。