### PR TITLE
feat(editor): persist In-App Storage to IndexedDB (fixes #856)

### DIFF
--- a/docs/specs/2026-06-26-inapp-storage-persist-plan.md
+++ b/docs/specs/2026-06-26-inapp-storage-persist-plan.md
@@ -1,0 +1,66 @@
+# Plan — InAppBackend 持久化（#856）
+
+> Date: 2026-06-26
+> Spec: `docs/specs/2026-06-26-inapp-storage-persist-spec.md`（過 codex round-1，4 finding 全修）
+> Branch: `worktree-inapp-persist`
+> 前提：單一邏輯改動（`InAppBackend` 的儲存層 Map → IndexedDB），呼叫端零改動。
+
+## 0. 現況
+- `InAppBackend`（`spa/src/lib/fs-backend-inapp.ts`）7 method 全對 `private store = new Map()` 操作，純記憶體、重啟即失（#856）。
+- 既有基礎設施：`openIDB`（`spa/src/lib/storage/idb.ts`，`idb` 套件 `openDB` + connection cache + `closeAllIDB`）、`snapshot-store.ts` 為使用範例、`fake-indexeddb` 已在 `test-setup.ts`。
+- 既有 `fs-backend-inapp.test.ts`？— 若無則新建；本 plan 以新建/補齊計。
+
+## 1. Task（單一，TDD）
+
+### T1 — InAppBackend 改 IDB-backed
+對應 **G1 / G2 / I1-I7 / AC1-13**。
+
+**IDB schema**
+- DB `pdx-inapp-fs` v1；objectStore `files`，`keyPath: 'path'`；value `StoredFile { path, content: Uint8Array, isDirectory, mtime }`。
+- lazy `private db(): Promise<IDBPDatabase>` → `openIDB('pdx-inapp-fs', 1, (db) => db.createObjectStore('files', { keyPath: 'path' }))`。
+
+**method 改寫（行為等價於現有 Map 版，對照 spec §4.2，參考 `snapshot-store.ts` 的 `idb` 用法）**
+- `read`：`(await db).get('files', path)` → 無 throw / dir throw / 回 content。
+- `write`：`db.transaction('files', 'readwrite')` 單一 tx：逐層 parent `if (!await tx.store.get(dir)) tx.store.put(dirEntry)`，再 `tx.store.put(fileEntry)`，`await tx.done`（I5 原子性）。**不驗 parent 是否 dir（I6）。**
+- `stat`：`get` → 無 throw / 回 FileStat。
+- `list`：`getAll('files')` → 既有 prefix + direct-children filter + dir-first/name 排序。
+- `mkdir`：`put(dirEntry)`（已存在 blind overwrite，I6）。
+- `delete`：`readwrite` tx：`delete(path)` + 以 cursor（`tx.store.openCursor()`）或 `getAllKeys` 找 `prefix='path/'` 子項逐一 delete。
+- `rename`：`readwrite` tx：`get(from)` → 無 throw；`put({ ...entry, path: to })`（target blind overwrite，I6）+ `delete(from)`。**只搬單一 entry，不遞迴（I7）。**
+
+**移除** `private store = new Map()`。
+
+**TDD 順序**
+1. 新建/補 `fs-backend-inapp.test.ts`，先寫 **AC2 persist 紅**（write → `closeAllIDB()` → new instance → read）——確認現行 Map 版無法通過（或新 IDB 未實作前紅）。
+2. 實作 IDB-backed → AC1-13 全綠。
+3. 測試隔離：`beforeEach`/`afterEach` `await closeAllIDB()` + `await indexedDB.deleteDatabase('pdx-inapp-fs')`。
+
+## 2. 整合驗證
+```
+cd spa
+npx vitest run src/lib/fs-backend-inapp.test.ts \
+  src/components/editor/__tests__/EditorPane.test.tsx \
+  src/components/editor/EditorBuffersPane.test.tsx
+pnpm run lint
+pnpm run build
+```
+- 通過標準：`fs-backend-inapp.test.ts` 13 AC 全綠 + **caller regression**（EditorPane / EditorBuffersPane 用 inapp backend，尤其 EditorBuffersPane blind-overwrite 補償 `:140`）不回歸 / lint clean / build 通過。
+- 完整套件既有 pre-existing failures（origin/main alpha.295 同樣 fail）不在範圍。
+
+## 3. Commit
+1. `feat(editor): persist In-App Storage to IndexedDB (fixes #856)` — 實作 + 測試 + spec/plan docs。單一邏輯改動，不拆。
+
+## 4. 風險
+| 風險 | 等級 | 緩解 |
+|------|------|------|
+| AC2 假驗 persist（cache 連線） | 高→已解 | spec/測試強制 `closeAllIDB()` 後重開（codex review #1） |
+| 實作者把 blind overwrite / 不驗 parent「修正」成 throw | 中 | I6 + AC12 釘死契約 |
+| `idb` 套件 transaction API 用錯（多 put 單 tx / cursor 刪 prefix） | 中 | 對照 `snapshot-store.ts` 既有用法；AC1/3/8 覆蓋 |
+| fake-indexeddb 與真 IDB 行為差異 | 低 | 既有 sync 測試已大量用 fake-indexeddb，先例充分 |
+| caller 用 inapp 的 regression | 中 | §2 納入 EditorPane/EditorBuffersPane targeted 測試 |
+
+## 5. 開發方式
+- 依 `feedback_subagent_tdd_priority` 派 subagent 跑 TDD（寫 13 AC + 實作 + 驗證）；主 session 整合驗證 + 切 commit + PR。
+
+## 6. PR 後流程
+- PR → codex 兩輪 review（R1 標準 + R2 三平行）→ 彙整表 → 修 → merge → bump → 清理對齊。

--- a/docs/specs/2026-06-26-inapp-storage-persist-plan.md
+++ b/docs/specs/2026-06-26-inapp-storage-persist-plan.md
@@ -30,10 +30,10 @@
 
 **移除** `private store = new Map()`。
 
-**TDD 順序**
-1. 新建/補 `fs-backend-inapp.test.ts`，先寫 **AC2 persist 紅**（write → `closeAllIDB()` → new instance → read）——確認現行 Map 版無法通過（或新 IDB 未實作前紅）。
-2. 實作 IDB-backed → AC1-13 全綠。
-3. 測試隔離：`beforeEach`/`afterEach` `await closeAllIDB()` + `await indexedDB.deleteDatabase('pdx-inapp-fs')`。
+**TDD 順序（plan-review #1 / #4）**
+1. 改造既有 `fs-backend-inapp.test.ts`（已有 8 基本測試，**無 persist、無 IDB 隔離**）。測試隔離 helper：`beforeEach` `await closeAllIDB()` + `await deleteInappDB()`，其中 **`deleteInappDB` 是 spec §5 的 Promise-wrapped `deleteDatabase`（等 `onsuccess`、`onblocked` 當失敗）—— 絕不可直接 `await indexedDB.deleteDatabase(...)`**（它回 `IDBOpenDBRequest` 非 Promise，await 不會等刪除完成）。
+2. **先寫紅燈（把本輪 review 釘死的風險一起打紅）**：AC2（persist）+ AC12（overwrite 語意）+ AC13（rename non-recursive）+ 至少一個 **persisted delete & rename** case（write → `closeAllIDB()` → 重建 → delete/rename 仍正確），加 AC14（binary/empty persist）。確認現行 Map 版/未實作前皆紅。
+3. 實作 IDB-backed → **AC1-14 全綠**。
 
 ## 2. 整合驗證
 ```
@@ -44,7 +44,8 @@ npx vitest run src/lib/fs-backend-inapp.test.ts \
 pnpm run lint
 pnpm run build
 ```
-- 通過標準：`fs-backend-inapp.test.ts` 13 AC 全綠 + **caller regression**（EditorPane / EditorBuffersPane 用 inapp backend，尤其 EditorBuffersPane blind-overwrite 補償 `:140`）不回歸 / lint clean / build 通過。
+- 通過標準：`fs-backend-inapp.test.ts` **14 AC 全綠** / lint clean / build 通過。
+- **caller regression（plan-review #2）**：跑 `EditorPane.test.tsx` + `EditorBuffersPane.test.tsx` 確認不回歸——但**這兩份測試把 backend mock 掉了**（`EditorPane.test.tsx:13` / `EditorBuffersPane.test.tsx:28`），只驗 caller 對 `FsBackend` 契約的**用法**，**驗不到真 IDB persist / blind-overwrite 整合**。為補此缺，在 `fs-backend-inapp.test.ts` 內加一個**薄 integration case**：用真 `InAppBackend` 經 `getFsBackend({ type: 'inapp' })`（registry 取用）走 `write → closeAllIDB() → 重建 read` 端到端，驗證 registry 路徑下 persist 正常（不另開重元件測試）。
 - 完整套件既有 pre-existing failures（origin/main alpha.295 同樣 fail）不在範圍。
 
 ## 3. Commit
@@ -53,11 +54,13 @@ pnpm run build
 ## 4. 風險
 | 風險 | 等級 | 緩解 |
 |------|------|------|
-| AC2 假驗 persist（cache 連線） | 高→已解 | spec/測試強制 `closeAllIDB()` 後重開（codex review #1） |
-| 實作者把 blind overwrite / 不驗 parent「修正」成 throw | 中 | I6 + AC12 釘死契約 |
+| AC2 假驗 persist（cache 連線） | 高→已解 | spec/測試強制 `closeAllIDB()` 後重開（spec-review #1） |
+| `deleteDatabase` 誤當 Promise → 隔離失真、case 競態 | 高→已解 | spec §5 Promise-wrapped `deleteInappDB` + `onblocked` 當失敗（plan-review #1） |
+| 實作者把 blind overwrite / 不驗 parent「修正」成 throw | 中 | I6 + AC12 釘死契約，TDD 先紅（plan-review #4） |
 | `idb` 套件 transaction API 用錯（多 put 單 tx / cursor 刪 prefix） | 中 | 對照 `snapshot-store.ts` 既有用法；AC1/3/8 覆蓋 |
+| binary / 空 `Uint8Array` 經 IDB structured-clone 失真 | 低 | AC14 覆蓋空 + 非文字 bytes 的 persist round-trip（plan-review #3） |
 | fake-indexeddb 與真 IDB 行為差異 | 低 | 既有 sync 測試已大量用 fake-indexeddb，先例充分 |
-| caller 用 inapp 的 regression | 中 | §2 納入 EditorPane/EditorBuffersPane targeted 測試 |
+| caller mock 掉 backend → 驗不到真整合 | 中 | §2 補薄 integration case（真 InAppBackend 經 registry round-trip，plan-review #2） |
 
 ## 5. 開發方式
 - 依 `feedback_subagent_tdd_priority` 派 subagent 跑 TDD（寫 13 AC + 實作 + 驗證）；主 session 整合驗證 + 切 commit + PR。

--- a/docs/specs/2026-06-26-inapp-storage-persist-spec.md
+++ b/docs/specs/2026-06-26-inapp-storage-persist-spec.md
@@ -59,7 +59,18 @@
 
 ## 5. Acceptance Criteria（= 測試契約，`fs-backend-inapp.test.ts`）
 
-> **測試隔離（codex review #1）**：每個 case 開始前 `await closeAllIDB()` + `await indexedDB.deleteDatabase('pdx-inapp-fs')`（await 刪除完成）確保乾淨——fake-indexeddb 為記憶體實作、跨 case 持久。
+> **測試隔離（codex review #1 + plan-review #1）**：每個 case 開始前 `await closeAllIDB()`，再以 helper 刪庫。**`indexedDB.deleteDatabase` 回傳 `IDBOpenDBRequest`（非 Promise），不可直接 `await`** —— 必須包成 Promise，等 `onsuccess` resolve、`onerror` reject、`onblocked` 視為**測試失敗**（代表有連線沒關乾淨，會與下個 case 競態）：
+> ```ts
+> function deleteInappDB(): Promise<void> {
+>   return new Promise((resolve, reject) => {
+>     const req = indexedDB.deleteDatabase('pdx-inapp-fs')
+>     req.onsuccess = () => resolve()
+>     req.onerror = () => reject(req.error)
+>     req.onblocked = () => reject(new Error('deleteDatabase blocked — connection not closed'))
+>   })
+> }
+> ```
+> 每 case 前 `await closeAllIDB()` + `await deleteInappDB()`。fake-indexeddb 為記憶體實作、跨 case 持久，須顯式清。
 >
 > **persist 驗證的關鍵**：`openIDB` 按 `(name, version)` 共用 cache 連線，所以**單純 `new InAppBackend()` 只會拿到同一個 cached connection，驗到的是 singleton reuse 而非真 persist**。persist 類測試（AC2 / AC11）必須在建立第二個 backend 前 **先 `await closeAllIDB()`** 關閉 cache 連線（模擬 app 進程結束），讓新實例重新 `openIDB` 開啟落地的 DB，才真正驗證資料持久化。
 
@@ -76,6 +87,7 @@
 - **AC11（persist 全面）**：write 多檔 + mkdir → **`await closeAllIDB()`** → 重建 backend → `list` / `stat` / `rename` / `delete` 對 persisted 資料皆正確生效。
 - **AC12（保留 overwrite 語意，對應 I6）**：`rename` 到已存在 target → 覆寫且**不 throw**；`mkdir` 已存在 path → **不 throw**；`write` 到 parent 為既有檔（非 dir）的路徑時不額外 throw（沿用既有寬鬆行為，不向真 FS 靠攏）。
 - **AC13（rename non-recursive，對應 I7）**：`write('/buffer/d/a.txt')` → `rename('/buffer/d', '/buffer/e')` → 只搬 `/buffer/d` entry 本身；子項 `/buffer/d/a.txt` 仍在原 path（驗證 non-recursive，與既有一致）。
+- **AC14（binary / empty payload persist，對應 §4.1 Uint8Array structured-clone，plan-review #3）**：`write` 一個**空** `Uint8Array(0)` 與一個**非文字 bytes**（如 `[0, 255, 128, 1]`）→ `await closeAllIDB()` → 重建 backend → `read` 兩者皆 **byte 級原樣讀回**（不只靠文字內容驗證，確保 binary content 經 IDB structured-clone 無損）。
 
 ## 6. Commit 切分（單一 PR）
 

--- a/docs/specs/2026-06-26-inapp-storage-persist-spec.md
+++ b/docs/specs/2026-06-26-inapp-storage-persist-spec.md
@@ -31,8 +31,10 @@
 - **I1**：`InAppBackend` 仍 `implements FsBackend`，method 簽章與回傳型別不變（皆 async）。
 - **I2**：`read` 找不到路徑仍 `throw`（`InAppBackend: file not found: <path>`）；`stat` / `rename` 找不到仍 throw（保留既有契約，呼叫端如 `EditorPane.tsx:150` 依賴 catch → 開空 buffer）。
 - **I3**：`write` 仍 auto-create parent directories；`delete` 仍遞迴刪 prefix 子項；`list` 仍只回 direct children（無額外 slash）、dir-first + name 排序。
-- **I4**：IDB 為 **per-origin**。Electron bundled（`app://`）與 dev server（`http://100.64.0.2:5174`）是不同 origin → 各自獨立 IDB。此為「本地持久」語義的正常結果（known limitation，記入 §7）。
+- **I4**：IDB 為 **per-origin** —— **任何 origin 變動（protocol / host / port 任一不同）都會切到另一份獨立的 In-App Storage**。包含 Electron bundled（`app://`）vs dev server，以及 dev 時 `localhost` / LAN IP / port 不同的情況。此為「本地持久」語義的正常結果（known limitation，記入 §7）。
 - **I5**：`write`（含 auto-create dirs + 寫檔）在**單一 readwrite transaction** 內完成，確保原子性，避免半寫狀態。
+- **I6（保留既有寬鬆語意，不向真 FS 靠攏）**：本案只換儲存層，既有的寬鬆行為**一律保留、不得改成像真實 FS 的 throw**：`rename(from, to)` 對已存在的 `to` 為 **blind overwrite**（不 throw）；`mkdir(path)` 對已存在 path 直接覆寫為 dir entry（不 throw）；`write` 只確保每層 parent path 有 entry，**不驗證 parent 是否真為 directory**。（呼叫端如 `EditorBuffersPane.tsx:140` 已對 blind overwrite 自行補償。）
+- **I7（rename non-recursive）**：`rename(from, to)` 只搬 `from` 單一 entry，**不遞迴搬子項**（與既有 Map 版一致）。inapp UI 為 flat `/buffer/*`、無資料夾 rename 入口；directory rename 的子項語意維持 non-recursive，本案不擴張。
 
 ## 4. 實作要點
 
@@ -57,10 +59,12 @@
 
 ## 5. Acceptance Criteria（= 測試契約，`fs-backend-inapp.test.ts`）
 
-> 測試隔離：每個 case 前後以 `closeAllIDB()` + 刪除 `pdx-inapp-fs`（或唯一化 db）確保乾淨；fake-indexeddb 為記憶體實作、跨 case 持久，需顯式清。
+> **測試隔離（codex review #1）**：每個 case 開始前 `await closeAllIDB()` + `await indexedDB.deleteDatabase('pdx-inapp-fs')`（await 刪除完成）確保乾淨——fake-indexeddb 為記憶體實作、跨 case 持久。
+>
+> **persist 驗證的關鍵**：`openIDB` 按 `(name, version)` 共用 cache 連線，所以**單純 `new InAppBackend()` 只會拿到同一個 cached connection，驗到的是 singleton reuse 而非真 persist**。persist 類測試（AC2 / AC11）必須在建立第二個 backend 前 **先 `await closeAllIDB()`** 關閉 cache 連線（模擬 app 進程結束），讓新實例重新 `openIDB` 開啟落地的 DB，才真正驗證資料持久化。
 
 - **AC1**：`write('/buffer/a.txt', X)` → `read` 回 X。
-- **AC2（persist 核心）**：`write` 後**建立全新 `InAppBackend` 實例**（模擬重啟，同一 IDB）→ `read('/buffer/a.txt')` 仍回 X。
+- **AC2（persist 核心）**：`write('/buffer/a.txt', X)` → **`await closeAllIDB()`**（關閉 cache 連線，模擬重啟）→ **建立全新 `InAppBackend` 實例**（觸發重新 `openIDB` 開啟同一落地 DB）→ `read('/buffer/a.txt')` 仍回 X。
 - **AC3**：`write('/buffer/sub/a.txt', X)` → `stat('/buffer/sub')` isDirectory=true（auto-create parent）。
 - **AC4**：`stat` 回正確 `size` / `mtime` / `isDirectory` / `isFile`。
 - **AC5**：`list` 回 direct children，dir-first + name 排序；不含孫層。
@@ -69,7 +73,9 @@
 - **AC8**：`delete(dir)` → 遞迴刪：子檔 `read` throw。
 - **AC9**：`rename(from, to)` → `read(to)` 回內容、`read(from)` throw。
 - **AC10**：`read` / `stat` / `rename` 對不存在路徑 throw（契約保留）。
-- **AC11（persist 全面）**：write 多檔 + mkdir → 重建 backend → `list` / `stat` / `rename` / `delete` 對 persisted 資料皆正確生效。
+- **AC11（persist 全面）**：write 多檔 + mkdir → **`await closeAllIDB()`** → 重建 backend → `list` / `stat` / `rename` / `delete` 對 persisted 資料皆正確生效。
+- **AC12（保留 overwrite 語意，對應 I6）**：`rename` 到已存在 target → 覆寫且**不 throw**；`mkdir` 已存在 path → **不 throw**；`write` 到 parent 為既有檔（非 dir）的路徑時不額外 throw（沿用既有寬鬆行為，不向真 FS 靠攏）。
+- **AC13（rename non-recursive，對應 I7）**：`write('/buffer/d/a.txt')` → `rename('/buffer/d', '/buffer/e')` → 只搬 `/buffer/d` entry 本身；子項 `/buffer/d/a.txt` 仍在原 path（驗證 non-recursive，與既有一致）。
 
 ## 6. Commit 切分（單一 PR）
 
@@ -80,5 +86,5 @@
 ## 7. Out of Scope / Known Limitations
 
 - 跨機同步 / daemon 雙寫 / 衝突 diff（§N1）—— 若日後要，屬 sync roadmap P5 content-addressed 範疇。
-- **IDB per-origin（I4）**：dev server 與 bundled `.app` 是不同 origin，各自獨立 In-App Storage；切換 dev/bundled 看不到對方的 inapp 檔。屬本地持久正常語義，不在本次處理。
+- **IDB per-origin（I4）**：**任何 origin 變動（protocol / host / port）都產生獨立的 In-App Storage** —— dev server vs bundled `.app`、以及 dev 時 `localhost` / LAN IP / port 不同皆然；切換時看不到對方的 inapp 檔。屬本地持久正常語義，不在本次處理。
 - 既有記憶體 inapp 檔已遺失，不遷移（§N3）。

--- a/docs/specs/2026-06-26-inapp-storage-persist-spec.md
+++ b/docs/specs/2026-06-26-inapp-storage-persist-spec.md
@@ -1,0 +1,84 @@
+# Spec — InAppBackend 持久化（修 #856 In-App Storage data-loss）
+
+> Date: 2026-06-26
+> Status: Draft（待 codex round-1 審閱）
+> Repo: purdex / branch: `worktree-inapp-persist`
+> Issue: #856
+
+## 1. Context
+
+新建文件（New File）預設 `source = { type: 'inapp' }`（`EditorNewTabSection.tsx:18,55`），對應 `InAppBackend`（`fs-backend-inapp.ts`）。其儲存是 `private store = new Map()` —— **純記憶體、零持久化**。使用者新建文件、按儲存、命名（如 `twkc.txt` → 路徑 `/buffer/twkc.txt`），`write` 對記憶體成功、UI 顯示已存，但 **app upgrade / 重啟 → 記憶體隨進程消滅 → 內容永久遺失**。`useTabStore` 有 persist（記住 filePath），重開時 `read` 在空 Map 找不到 → 開空 buffer → 顯示空白 + dirty dot。
+
+這是 data-loss trap：`InAppBackend` 掛 "In-App Storage" 名稱、提供完整 fs UX，底層卻 ephemeral。
+
+**使用者已確認 scope = 止血（本地持久）**：把 In-App Storage 持久化即可，**不**做跨機同步、不做衝突 diff。
+
+## 2. Goals / Non-Goals
+
+### Goals
+- **G1**：`InAppBackend` 的儲存從記憶體 `Map` 改為 **IndexedDB**（復用既有 `spa/src/lib/storage/idb.ts` 的 `openIDB`）。新建文件 save 後，**app 重啟仍能讀回**（`new InAppBackend()` 對同一 IDB 讀得到）。
+- **G2**：7 個 `FsBackend` method（`read` / `write` / `stat` / `list` / `mkdir` / `delete` / `rename`）行為契約**完全不變**，只換底層儲存。呼叫端（`EditorPane` / `EditorBuffersPane` / file tree）**零改動**。
+- **G3**：測試以既有 `fake-indexeddb`（已在 `test-setup.ts`）覆蓋 persist 行為——尤其「write → 重建 backend → read 仍在」。
+
+### Non-Goals
+- **N1**：不做跨機同步、不雙寫 daemon、不做衝突偵測 / diff（使用者明確 scope 外）。
+- **N2**：不碰 `DaemonBackend` / `LocalBackend`。
+- **N3**：不遷移既有記憶體 inapp 資料 —— 它本來就隨重啟消失、無可遷移（alpha 階段慣例 [[feedback_no_alpha_migration]]）。改版後新檔即 persist；舊 tab 指向的已遺失檔重開仍空白（無法救）。
+- **N4**：不改 `untitledStoragePath`（`/buffer/<name>`）、不改新建文件預設 source。
+
+## 3. Invariants
+
+- **I1**：`InAppBackend` 仍 `implements FsBackend`，method 簽章與回傳型別不變（皆 async）。
+- **I2**：`read` 找不到路徑仍 `throw`（`InAppBackend: file not found: <path>`）；`stat` / `rename` 找不到仍 throw（保留既有契約，呼叫端如 `EditorPane.tsx:150` 依賴 catch → 開空 buffer）。
+- **I3**：`write` 仍 auto-create parent directories；`delete` 仍遞迴刪 prefix 子項；`list` 仍只回 direct children（無額外 slash）、dir-first + name 排序。
+- **I4**：IDB 為 **per-origin**。Electron bundled（`app://`）與 dev server（`http://100.64.0.2:5174`）是不同 origin → 各自獨立 IDB。此為「本地持久」語義的正常結果（known limitation，記入 §7）。
+- **I5**：`write`（含 auto-create dirs + 寫檔）在**單一 readwrite transaction** 內完成，確保原子性，避免半寫狀態。
+
+## 4. 實作要點
+
+### 4.1 IDB schema
+- DB name：`pdx-inapp-fs`，version `1`。
+- objectStore：`files`，`keyPath: 'path'`。value = `StoredFile { path: string; content: Uint8Array; isDirectory: boolean; mtime: number }`（Uint8Array 由 structured clone 原生支援）。
+- 連線：lazy `private dbPromise()` → `openIDB('pdx-inapp-fs', 1, upgrade)`；upgrade 內 `createObjectStore('files', { keyPath: 'path' })`。openIDB cache 確保同 origin 單連線、blocking/terminated 自癒。
+
+### 4.2 method → IDB 對應（行為等價於現有 Map 版）
+- `read(path)`：`db.get('files', path)` → 無 throw / dir throw / 回 `entry.content`。
+- `write(path, content)`：一個 `readwrite` transaction：對每層 parent dir `if (!exists) put(dir entry)`，再 `put(file entry)`（`mtime = Date.now()`）。
+- `stat(path)`：`db.get` → 無 throw / 回 `{ size: content.byteLength, mtime, isDirectory, isFile }`。
+- `list(path)`：`db.getAll('files')` → 沿用既有 prefix + direct-children filter + dir-first/name 排序。（inapp 檔量小，getAll 可接受；不做 key-range 優化。）
+- `mkdir(path)`：`put(dir entry)`。
+- `delete(path)`：`readwrite` transaction：`delete(path)` + 以 cursor / getAllKeys 找 `prefix` 子項逐一 `delete`。
+- `rename(from, to)`：`readwrite` transaction：`get(from)` → 無 throw；`put({ ...entry, path: to })` + `delete(from)`。（沿用既有：僅搬單一 entry，不遞迴搬子項——與現行行為一致，不擴張。）
+
+> `Date.now()` 在 method 內呼叫（非 render path），無 react-hooks/purity 顧慮。
+
+### 4.3 移除
+- 刪 `private store = new Map()`，所有 method 改走 dbPromise。
+
+## 5. Acceptance Criteria（= 測試契約，`fs-backend-inapp.test.ts`）
+
+> 測試隔離：每個 case 前後以 `closeAllIDB()` + 刪除 `pdx-inapp-fs`（或唯一化 db）確保乾淨；fake-indexeddb 為記憶體實作、跨 case 持久，需顯式清。
+
+- **AC1**：`write('/buffer/a.txt', X)` → `read` 回 X。
+- **AC2（persist 核心）**：`write` 後**建立全新 `InAppBackend` 實例**（模擬重啟，同一 IDB）→ `read('/buffer/a.txt')` 仍回 X。
+- **AC3**：`write('/buffer/sub/a.txt', X)` → `stat('/buffer/sub')` isDirectory=true（auto-create parent）。
+- **AC4**：`stat` 回正確 `size` / `mtime` / `isDirectory` / `isFile`。
+- **AC5**：`list` 回 direct children，dir-first + name 排序；不含孫層。
+- **AC6**：`mkdir('/buffer/d')` → `stat` isDirectory=true。
+- **AC7**：`delete(file)` → `read` throw。
+- **AC8**：`delete(dir)` → 遞迴刪：子檔 `read` throw。
+- **AC9**：`rename(from, to)` → `read(to)` 回內容、`read(from)` throw。
+- **AC10**：`read` / `stat` / `rename` 對不存在路徑 throw（契約保留）。
+- **AC11（persist 全面）**：write 多檔 + mkdir → 重建 backend → `list` / `stat` / `rename` / `delete` 對 persisted 資料皆正確生效。
+
+## 6. Commit 切分（單一 PR）
+
+1. `feat(editor): persist In-App Storage to IndexedDB (fixes #856)` — `InAppBackend` 改 IDB-backed（G1/G2/I*）+ `fs-backend-inapp.test.ts` 全 AC（G3）。TDD：先寫 AC2 persist 紅 → 實作 → 綠。
+
+> 單一邏輯改動（換儲存後端），不拆多 commit；測試與實作同 commit。
+
+## 7. Out of Scope / Known Limitations
+
+- 跨機同步 / daemon 雙寫 / 衝突 diff（§N1）—— 若日後要，屬 sync roadmap P5 content-addressed 範疇。
+- **IDB per-origin（I4）**：dev server 與 bundled `.app` 是不同 origin，各自獨立 In-App Storage；切換 dev/bundled 看不到對方的 inapp 檔。屬本地持久正常語義，不在本次處理。
+- 既有記憶體 inapp 檔已遺失，不遷移（§N3）。

--- a/spa/src/lib/fs-backend-inapp.test.ts
+++ b/spa/src/lib/fs-backend-inapp.test.ts
@@ -22,6 +22,14 @@ function deleteInappDB(): Promise<void> {
   })
 }
 
+// Simulate a process restart: close cached IDB connections so a fresh
+// InAppBackend must reopen the landed DB (rather than reuse the openIDB
+// singleton connection, which would only prove cache reuse, not persistence).
+async function reopenBackend(): Promise<InAppBackend> {
+  await closeAllIDB()
+  return new InAppBackend()
+}
+
 const enc = (s: string) => new TextEncoder().encode(s)
 const dec = (b: Uint8Array) => new TextDecoder().decode(b)
 
@@ -44,17 +52,14 @@ describe('InAppBackend (IndexedDB-backed)', () => {
   // AC1
   it('AC1: write then read returns the content', async () => {
     await backend.write('/buffer/a.txt', enc('hello world'))
-    const result = await backend.read('/buffer/a.txt')
-    expect(dec(result)).toBe('hello world')
+    expect(dec(await backend.read('/buffer/a.txt'))).toBe('hello world')
   })
 
-  // AC2 — persist core: write → closeAllIDB (simulate restart) → new backend → read
+  // AC2 — persist core: write → reopen (simulate restart) → read
   it('AC2: content persists across backend re-creation (closeAllIDB)', async () => {
     await backend.write('/buffer/a.txt', enc('persist me'))
-    await closeAllIDB()
-    const fresh = new InAppBackend()
-    const result = await fresh.read('/buffer/a.txt')
-    expect(dec(result)).toBe('persist me')
+    const fresh = await reopenBackend()
+    expect(dec(await fresh.read('/buffer/a.txt'))).toBe('persist me')
   })
 
   // AC3 — auto-create parent directories
@@ -127,45 +132,41 @@ describe('InAppBackend (IndexedDB-backed)', () => {
     ).rejects.toThrow()
   })
 
-  // AC11 — full persist: write multiple + mkdir → closeAllIDB → rebuild →
-  // list / stat / rename / delete on persisted data all work.
-  it('AC11: list/stat/rename/delete all work on persisted data after rebuild', async () => {
+  // AC11 — persisted list + stat after rebuild (split from delete/rename below
+  // so a failure points at one invariant; codex health-review #1).
+  it('AC11: persisted list + stat work after rebuild', async () => {
     await backend.write('/buffer/x.txt', enc('x'))
     await backend.write('/buffer/y.txt', enc('y'))
     await backend.mkdir('/buffer/dir')
-    await closeAllIDB()
+    const fresh = await reopenBackend()
 
-    const fresh = new InAppBackend()
-
-    // list
-    const entries = await fresh.list('/buffer')
-    expect(entries.map((e) => e.name)).toEqual(['dir', 'x.txt', 'y.txt'])
-
-    // stat
+    expect((await fresh.list('/buffer')).map((e) => e.name)).toEqual([
+      'dir',
+      'x.txt',
+      'y.txt',
+    ])
     const xstat = await fresh.stat('/buffer/x.txt')
     expect(xstat.size).toBe(1)
     expect(xstat.isFile).toBe(true)
-
-    // rename
-    await fresh.rename('/buffer/x.txt', '/buffer/z.txt')
-    expect(dec(await fresh.read('/buffer/z.txt'))).toBe('x')
-    await expect(fresh.read('/buffer/x.txt')).rejects.toThrow()
-
-    // delete
-    await fresh.delete('/buffer/y.txt')
-    await expect(fresh.read('/buffer/y.txt')).rejects.toThrow()
   })
 
-  // AC11b — persisted delete (dir) and rename across rebuild
+  // AC11b — persisted recursive delete after rebuild
   it('AC11b: persisted recursive delete works after rebuild', async () => {
     await backend.write('/buffer/d/a.txt', enc('a'))
     await backend.write('/buffer/d/sub/b.txt', enc('b'))
-    await closeAllIDB()
-
-    const fresh = new InAppBackend()
+    const fresh = await reopenBackend()
     await fresh.delete('/buffer/d')
     await expect(fresh.read('/buffer/d/a.txt')).rejects.toThrow()
     await expect(fresh.read('/buffer/d/sub/b.txt')).rejects.toThrow()
+  })
+
+  // AC11c — persisted rename after rebuild
+  it('AC11c: persisted rename works after rebuild', async () => {
+    await backend.write('/buffer/x.txt', enc('x'))
+    const fresh = await reopenBackend()
+    await fresh.rename('/buffer/x.txt', '/buffer/z.txt')
+    expect(dec(await fresh.read('/buffer/z.txt'))).toBe('x')
+    await expect(fresh.read('/buffer/x.txt')).rejects.toThrow()
   })
 
   // AC12 — preserve lenient overwrite semantics (I6): rename to existing target
@@ -213,9 +214,8 @@ describe('InAppBackend (IndexedDB-backed)', () => {
     const binary = new Uint8Array([0, 255, 128, 1])
     await backend.write('/buffer/empty.bin', empty)
     await backend.write('/buffer/bytes.bin', binary)
-    await closeAllIDB()
+    const fresh = await reopenBackend()
 
-    const fresh = new InAppBackend()
     const emptyOut = await fresh.read('/buffer/empty.bin')
     const binaryOut = await fresh.read('/buffer/bytes.bin')
     expect(Array.from(emptyOut)).toEqual([])

--- a/spa/src/lib/fs-backend-inapp.test.ts
+++ b/spa/src/lib/fs-backend-inapp.test.ts
@@ -1,10 +1,39 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { InAppBackend } from './fs-backend-inapp'
+import { closeAllIDB } from './storage/idb'
+import {
+  registerFsBackend,
+  getFsBackend,
+  clearFsBackendRegistry,
+} from './fs-backend'
 
-describe('InAppBackend', () => {
+// Promise-wrapped deleteDatabase. indexedDB.deleteDatabase returns an
+// IDBOpenDBRequest (NOT a Promise), so `await indexedDB.deleteDatabase(...)`
+// does NOT wait for the delete to finish. We must wrap it and wait for
+// onsuccess; onblocked means a connection was not closed and the next case
+// would race against stale data, so we treat it as a failure.
+function deleteInappDB(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase('pdx-inapp-fs')
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () =>
+      reject(new Error('deleteDatabase blocked — connection not closed'))
+  })
+}
+
+const enc = (s: string) => new TextEncoder().encode(s)
+const dec = (b: Uint8Array) => new TextDecoder().decode(b)
+
+describe('InAppBackend (IndexedDB-backed)', () => {
   let backend: InAppBackend
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // fake-indexeddb is an in-memory implementation that persists across
+    // cases, so we must explicitly close all cached connections and drop the
+    // DB before each test for isolation.
+    await closeAllIDB()
+    await deleteInappDB()
     backend = new InAppBackend()
   })
 
@@ -12,53 +41,205 @@ describe('InAppBackend', () => {
     expect(backend.available()).toBe(true)
   })
 
-  it('writes and reads a file', async () => {
-    const content = new TextEncoder().encode('hello world')
-    await backend.write('/test.txt', content)
-    const result = await backend.read('/test.txt')
-    expect(new TextDecoder().decode(result)).toBe('hello world')
+  // AC1
+  it('AC1: write then read returns the content', async () => {
+    await backend.write('/buffer/a.txt', enc('hello world'))
+    const result = await backend.read('/buffer/a.txt')
+    expect(dec(result)).toBe('hello world')
   })
 
-  it('stat returns file info after write', async () => {
-    const content = new TextEncoder().encode('abc')
-    await backend.write('/stat-test.txt', content)
-    const stat = await backend.stat('/stat-test.txt')
+  // AC2 — persist core: write → closeAllIDB (simulate restart) → new backend → read
+  it('AC2: content persists across backend re-creation (closeAllIDB)', async () => {
+    await backend.write('/buffer/a.txt', enc('persist me'))
+    await closeAllIDB()
+    const fresh = new InAppBackend()
+    const result = await fresh.read('/buffer/a.txt')
+    expect(dec(result)).toBe('persist me')
+  })
+
+  // AC3 — auto-create parent directories
+  it('AC3: write auto-creates parent directories', async () => {
+    await backend.write('/buffer/sub/a.txt', enc('x'))
+    const stat = await backend.stat('/buffer/sub')
+    expect(stat.isDirectory).toBe(true)
+  })
+
+  // AC4 — stat shape
+  it('AC4: stat returns correct size/mtime/isDirectory/isFile', async () => {
+    await backend.write('/buffer/stat.txt', enc('abc'))
+    const stat = await backend.stat('/buffer/stat.txt')
     expect(stat.isFile).toBe(true)
     expect(stat.isDirectory).toBe(false)
     expect(stat.size).toBe(3)
     expect(stat.mtime).toBeGreaterThan(0)
   })
 
-  it('stat throws for nonexistent path', async () => {
-    await expect(backend.stat('/no-such-file')).rejects.toThrow()
+  // AC5 — list direct children, dir-first + name sorted, no grandchildren
+  it('AC5: list returns direct children, dir-first + name sorted, no grandchildren', async () => {
+    await backend.write('/buffer/b.txt', enc('b'))
+    await backend.write('/buffer/a.txt', enc('a'))
+    await backend.write('/buffer/sub/deep.txt', enc('d')) // creates dir /buffer/sub
+    const entries = await backend.list('/buffer')
+    // dir-first then name-sorted: sub (dir), a.txt, b.txt
+    expect(entries.map((e) => e.name)).toEqual(['sub', 'a.txt', 'b.txt'])
+    expect(entries[0].isDir).toBe(true)
+    // no grandchildren leaking
+    expect(entries.map((e) => e.name)).not.toContain('deep.txt')
   })
 
-  it('list returns entries in a directory', async () => {
-    await backend.write('/dir/a.txt', new TextEncoder().encode('a'))
-    await backend.write('/dir/b.txt', new TextEncoder().encode('b'))
-    const entries = await backend.list('/dir')
-    const names = entries.map((e) => e.name).sort()
-    expect(names).toEqual(['a.txt', 'b.txt'])
-  })
-
-  it('mkdir creates a directory entry', async () => {
-    await backend.mkdir('/newdir')
-    const stat = await backend.stat('/newdir')
+  // AC6 — mkdir
+  it('AC6: mkdir creates a directory entry', async () => {
+    await backend.mkdir('/buffer/d')
+    const stat = await backend.stat('/buffer/d')
     expect(stat.isDirectory).toBe(true)
   })
 
-  it('delete removes a file', async () => {
-    await backend.write('/del.txt', new TextEncoder().encode('x'))
-    await backend.delete('/del.txt')
-    await expect(backend.stat('/del.txt')).rejects.toThrow()
+  // AC7 — delete file
+  it('AC7: delete a file makes read throw', async () => {
+    await backend.write('/buffer/del.txt', enc('x'))
+    await backend.delete('/buffer/del.txt')
+    await expect(backend.read('/buffer/del.txt')).rejects.toThrow()
   })
 
-  it('rename moves a file', async () => {
-    const content = new TextEncoder().encode('move me')
-    await backend.write('/old.txt', content)
-    await backend.rename('/old.txt', '/new.txt')
-    const result = await backend.read('/new.txt')
-    expect(new TextDecoder().decode(result)).toBe('move me')
-    await expect(backend.stat('/old.txt')).rejects.toThrow()
+  // AC8 — delete dir recursively removes prefix children
+  it('AC8: delete a directory recursively removes children', async () => {
+    await backend.write('/buffer/d/a.txt', enc('a'))
+    await backend.write('/buffer/d/sub/b.txt', enc('b'))
+    await backend.delete('/buffer/d')
+    await expect(backend.read('/buffer/d/a.txt')).rejects.toThrow()
+    await expect(backend.read('/buffer/d/sub/b.txt')).rejects.toThrow()
+  })
+
+  // AC9 — rename moves a file
+  it('AC9: rename moves content, source read throws', async () => {
+    await backend.write('/buffer/old.txt', enc('move me'))
+    await backend.rename('/buffer/old.txt', '/buffer/new.txt')
+    expect(dec(await backend.read('/buffer/new.txt'))).toBe('move me')
+    await expect(backend.read('/buffer/old.txt')).rejects.toThrow()
+  })
+
+  // AC10 — read/stat/rename throw for nonexistent
+  it('AC10: read/stat/rename throw for nonexistent paths', async () => {
+    await expect(backend.read('/buffer/nope')).rejects.toThrow()
+    await expect(backend.stat('/buffer/nope')).rejects.toThrow()
+    await expect(
+      backend.rename('/buffer/nope', '/buffer/whatever'),
+    ).rejects.toThrow()
+  })
+
+  // AC11 — full persist: write multiple + mkdir → closeAllIDB → rebuild →
+  // list / stat / rename / delete on persisted data all work.
+  it('AC11: list/stat/rename/delete all work on persisted data after rebuild', async () => {
+    await backend.write('/buffer/x.txt', enc('x'))
+    await backend.write('/buffer/y.txt', enc('y'))
+    await backend.mkdir('/buffer/dir')
+    await closeAllIDB()
+
+    const fresh = new InAppBackend()
+
+    // list
+    const entries = await fresh.list('/buffer')
+    expect(entries.map((e) => e.name)).toEqual(['dir', 'x.txt', 'y.txt'])
+
+    // stat
+    const xstat = await fresh.stat('/buffer/x.txt')
+    expect(xstat.size).toBe(1)
+    expect(xstat.isFile).toBe(true)
+
+    // rename
+    await fresh.rename('/buffer/x.txt', '/buffer/z.txt')
+    expect(dec(await fresh.read('/buffer/z.txt'))).toBe('x')
+    await expect(fresh.read('/buffer/x.txt')).rejects.toThrow()
+
+    // delete
+    await fresh.delete('/buffer/y.txt')
+    await expect(fresh.read('/buffer/y.txt')).rejects.toThrow()
+  })
+
+  // AC11b — persisted delete (dir) and rename across rebuild
+  it('AC11b: persisted recursive delete works after rebuild', async () => {
+    await backend.write('/buffer/d/a.txt', enc('a'))
+    await backend.write('/buffer/d/sub/b.txt', enc('b'))
+    await closeAllIDB()
+
+    const fresh = new InAppBackend()
+    await fresh.delete('/buffer/d')
+    await expect(fresh.read('/buffer/d/a.txt')).rejects.toThrow()
+    await expect(fresh.read('/buffer/d/sub/b.txt')).rejects.toThrow()
+  })
+
+  // AC12 — preserve lenient overwrite semantics (I6): rename to existing target
+  // overwrites and does NOT throw; mkdir on existing path does NOT throw; write
+  // to a path whose parent is an existing file does NOT throw.
+  it('AC12: rename to existing target blind-overwrites without throwing', async () => {
+    await backend.write('/buffer/a.txt', enc('AAA'))
+    await backend.write('/buffer/b.txt', enc('BBB'))
+    await backend.rename('/buffer/a.txt', '/buffer/b.txt')
+    expect(dec(await backend.read('/buffer/b.txt'))).toBe('AAA')
+    await expect(backend.read('/buffer/a.txt')).rejects.toThrow()
+  })
+
+  it('AC12: mkdir on existing path does not throw', async () => {
+    await backend.mkdir('/buffer/d')
+    await expect(backend.mkdir('/buffer/d')).resolves.toBeUndefined()
+    const stat = await backend.stat('/buffer/d')
+    expect(stat.isDirectory).toBe(true)
+  })
+
+  it('AC12: write where parent is an existing file does not throw (no FS validation)', async () => {
+    await backend.write('/buffer/parent', enc('iamafile'))
+    // parent already exists as a file; lenient semantics must not throw
+    await expect(
+      backend.write('/buffer/parent/child.txt', enc('child')),
+    ).resolves.toBeUndefined()
+    expect(dec(await backend.read('/buffer/parent/child.txt'))).toBe('child')
+  })
+
+  // AC13 — rename is non-recursive (I7): only the single entry moves
+  it('AC13: rename is non-recursive — children stay at original paths', async () => {
+    await backend.write('/buffer/d/a.txt', enc('a'))
+    await backend.mkdir('/buffer/d')
+    await backend.rename('/buffer/d', '/buffer/e')
+    // /buffer/d entry itself moved
+    const eStat = await backend.stat('/buffer/e')
+    expect(eStat.isDirectory).toBe(true)
+    // child stays at original path (non-recursive)
+    expect(dec(await backend.read('/buffer/d/a.txt'))).toBe('a')
+  })
+
+  // AC14 — binary / empty payload persists byte-for-byte across rebuild
+  it('AC14: empty and non-text binary payloads persist byte-for-byte', async () => {
+    const empty = new Uint8Array(0)
+    const binary = new Uint8Array([0, 255, 128, 1])
+    await backend.write('/buffer/empty.bin', empty)
+    await backend.write('/buffer/bytes.bin', binary)
+    await closeAllIDB()
+
+    const fresh = new InAppBackend()
+    const emptyOut = await fresh.read('/buffer/empty.bin')
+    const binaryOut = await fresh.read('/buffer/bytes.bin')
+    expect(Array.from(emptyOut)).toEqual([])
+    expect(emptyOut.byteLength).toBe(0)
+    expect(Array.from(binaryOut)).toEqual([0, 255, 128, 1])
+  })
+
+  // Thin integration case: registry path (getFsBackend) persists end-to-end.
+  it('integration: registry-resolved inapp backend persists across closeAllIDB', async () => {
+    clearFsBackendRegistry()
+    registerFsBackend('inapp', new InAppBackend())
+    const reg = getFsBackend({ type: 'inapp' })
+    expect(reg).toBeDefined()
+    await reg!.write('/buffer/reg.txt', enc('via registry'))
+
+    await closeAllIDB()
+
+    // simulate process restart: fresh registry + fresh backend instance,
+    // reading the landed DB.
+    clearFsBackendRegistry()
+    registerFsBackend('inapp', new InAppBackend())
+    const reg2 = getFsBackend({ type: 'inapp' })
+    expect(dec(await reg2!.read('/buffer/reg.txt'))).toBe('via registry')
+
+    clearFsBackendRegistry()
   })
 })

--- a/spa/src/lib/fs-backend-inapp.ts
+++ b/spa/src/lib/fs-backend-inapp.ts
@@ -1,5 +1,11 @@
+import type { IDBPDatabase } from 'idb'
+import { openIDB } from './storage/idb'
 import type { FsBackend } from './fs-backend'
 import type { FileStat, FileEntry } from '../types/fs'
+
+const DB_NAME = 'pdx-inapp-fs'
+const DB_VERSION = 1
+const STORE = 'files'
 
 interface StoredFile {
   path: string
@@ -12,44 +18,59 @@ export class InAppBackend implements FsBackend {
   id = 'inapp'
   label = 'In-App Storage'
 
-  private store = new Map<string, StoredFile>()
+  // Lazy, cached IDB connection. openIDB shares the connection per (name,
+  // version) so multiple InAppBackend instances reuse a single handle; tests
+  // call closeAllIDB() to drop it and simulate a process restart.
+  private db(): Promise<IDBPDatabase> {
+    return openIDB(DB_NAME, DB_VERSION, (db) => {
+      db.createObjectStore(STORE, { keyPath: 'path' })
+    })
+  }
 
   available(): boolean {
     return true
   }
 
   async read(path: string): Promise<Uint8Array> {
-    const entry = this.store.get(path)
+    const db = await this.db()
+    const entry = (await db.get(STORE, path)) as StoredFile | undefined
     if (!entry) throw new Error(`InAppBackend: file not found: ${path}`)
     if (entry.isDirectory) throw new Error(`InAppBackend: path is a directory: ${path}`)
     return entry.content
   }
 
   async write(path: string, content: Uint8Array): Promise<void> {
-    // auto-create parent directories
+    const db = await this.db()
+    const now = Date.now()
+    // Single readwrite transaction (I5): auto-create each parent dir entry that
+    // is missing, then write the file. Parent type is NOT validated (I6).
+    const tx = db.transaction(STORE, 'readwrite')
+    const store = tx.store
     const parts = path.split('/')
     for (let i = 1; i < parts.length - 1; i++) {
       const dirPath = parts.slice(0, i + 1).join('/')
-      if (!this.store.has(dirPath)) {
-        this.store.set(dirPath, {
+      const existing = (await store.get(dirPath)) as StoredFile | undefined
+      if (!existing) {
+        await store.put({
           path: dirPath,
           content: new Uint8Array(0),
           isDirectory: true,
-          mtime: Date.now(),
-        })
+          mtime: now,
+        } satisfies StoredFile)
       }
     }
-
-    this.store.set(path, {
+    await store.put({
       path,
       content,
       isDirectory: false,
-      mtime: Date.now(),
-    })
+      mtime: now,
+    } satisfies StoredFile)
+    await tx.done
   }
 
   async stat(path: string): Promise<FileStat> {
-    const entry = this.store.get(path)
+    const db = await this.db()
+    const entry = (await db.get(STORE, path)) as StoredFile | undefined
     if (!entry) throw new Error(`InAppBackend: path not found: ${path}`)
     return {
       size: entry.content.byteLength,
@@ -60,10 +81,13 @@ export class InAppBackend implements FsBackend {
   }
 
   async list(path: string): Promise<FileEntry[]> {
+    const db = await this.db()
+    const all = (await db.getAll(STORE)) as StoredFile[]
     const prefix = path.endsWith('/') ? path : path + '/'
     const seen = new Map<string, FileEntry>()
 
-    for (const [key, entry] of this.store) {
+    for (const entry of all) {
+      const key = entry.path
       if (!key.startsWith(prefix)) continue
       const rest = key.slice(prefix.length)
       // only direct children (no additional slash)
@@ -83,29 +107,45 @@ export class InAppBackend implements FsBackend {
     })
   }
 
-  async mkdir(path: string, _recursive?: boolean): Promise<void> {  
-    this.store.set(path, {
+  async mkdir(path: string, _recursive?: boolean): Promise<void> {
+    const db = await this.db()
+    // Blind overwrite if path already exists (I6).
+    await db.put(STORE, {
       path,
       content: new Uint8Array(0),
       isDirectory: true,
       mtime: Date.now(),
-    })
+    } satisfies StoredFile)
   }
 
-  async delete(path: string, _recursive?: boolean): Promise<void> {  
-    this.store.delete(path)
+  async delete(path: string, _recursive?: boolean): Promise<void> {
+    const db = await this.db()
+    const tx = db.transaction(STORE, 'readwrite')
+    const store = tx.store
+    await store.delete(path)
+    // Recursively delete prefix children.
     const prefix = path.endsWith('/') ? path : path + '/'
-    for (const key of this.store.keys()) {
+    const keys = (await store.getAllKeys()) as string[]
+    for (const key of keys) {
       if (key.startsWith(prefix)) {
-        this.store.delete(key)
+        await store.delete(key)
       }
     }
+    await tx.done
   }
 
   async rename(from: string, to: string): Promise<void> {
-    const entry = this.store.get(from)
-    if (!entry) throw new Error(`InAppBackend: path not found: ${from}`)
-    this.store.set(to, { ...entry, path: to })
-    this.store.delete(from)
+    const db = await this.db()
+    const tx = db.transaction(STORE, 'readwrite')
+    const store = tx.store
+    const entry = (await store.get(from)) as StoredFile | undefined
+    if (!entry) {
+      await tx.done
+      throw new Error(`InAppBackend: path not found: ${from}`)
+    }
+    // Blind overwrite of target (I6); only the single entry moves (I7).
+    await store.put({ ...entry, path: to } satisfies StoredFile)
+    await store.delete(from)
+    await tx.done
   }
 }

--- a/spa/src/lib/fs-backend-inapp.ts
+++ b/spa/src/lib/fs-backend-inapp.ts
@@ -23,7 +23,11 @@ export class InAppBackend implements FsBackend {
   // call closeAllIDB() to drop it and simulate a process restart.
   private db(): Promise<IDBPDatabase> {
     return openIDB(DB_NAME, DB_VERSION, (db) => {
-      db.createObjectStore(STORE, { keyPath: 'path' })
+      // Guard with contains() to match the repo's existing IDB upgrade style
+      // (snapshot-store.ts) and stay safe across future schema version bumps.
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'path' })
+      }
     })
   }
 


### PR DESCRIPTION
## 概述

修 **#856 data-loss**：新建文件預設存到 In-App Storage（`inapp` source），但 `InAppBackend` 底層是純記憶體 `Map` —— 存檔對記憶體成功、UI 顯示已存，但 app upgrade/重啟即遺失，重開 tab（persisted）變空白 + dirty。改用 **IndexedDB**（復用既有 `openIDB`）持久化，重啟後讀得回。

使用者經實機撞上（alpha.295 upgrade 後 `twkc.txt` 空白），確認 scope = **止血（本地持久）**，不做跨機同步/衝突 diff。

## 改動

`InAppBackend` 的 `Map` → IndexedDB（DB `pdx-inapp-fs`，store `files` keyPath `path`）。7 個 `FsBackend` method 改 IDB-backed，**契約完全不變**（只換儲存層）：
- `read`/`stat`/`rename` 對缺失路徑仍 throw（`EditorPane` mount catch 依賴）
- `write` 單一 readwrite transaction：auto-create parent dirs，不驗 parent 是否 dir
- `rename`/`mkdir` 保留 blind-overwrite；`rename` 只搬單一 entry（non-recursive）
- 移除記憶體 `Map`

## 流程

- **spec**（`docs/specs/2026-06-26-...-spec.md`）過 codex round-1：4 finding 全修——其中 codex 點破 **AC2 假驗 persist**（`openIDB` 按 (name,version) cache 連線，裸 `new InAppBackend()` 只證 singleton reuse），改為 `closeAllIDB()` 模擬重啟後重開；並把既有寬鬆語意（I6 overwrite / I7 non-recursive）釘成 invariant。
- **plan** 過 codex round-1：4 finding 全修——codex 點破 **`indexedDB.deleteDatabase` 非 Promise**（回 `IDBOpenDBRequest`），測試隔離改 Promise-wrapped helper（onblocked 當失敗）；補 binary/empty AC14；caller 測試 mock backend 故補薄 integration case。

## 驗證

- `fs-backend-inapp.test.ts` **19 測（AC1-14）全綠**——含 persist-across-`closeAllIDB`、空 `Uint8Array` + 非文字 bytes 的 byte 級 round-trip、registry integration case。
- `EditorPane` / `EditorBuffersPane` caller regression 不回歸。
- `pnpm run lint` clean、`pnpm run build` 通過。

## Review 焦點

- IDB transaction 原子性（`write`/`delete`/`rename` 單 tx + `await tx.done`）；`rename` not-found 先 `tx.done` 再 throw（避免懸置 tx → 下個測試 `onblocked`）。
- 既有寬鬆語意是否確實保留（I6/I7），未「順手」改成真 FS 的 throw。
- persist 驗證是否真有效（`closeAllIDB` 後重開 DB，非 cache reuse）。

## Known limitations / out of scope

- IDB per-origin：dev server vs bundled `.app`（及 dev 時 host/port 變動）各自獨立 store。
- 既有記憶體 inapp 檔不遷移（已遺失）。
- 不跨機同步 / 衝突 diff（scope 外）。