### PR TITLE
fix(editor): prevent Loading editor flicker on markdown buffer switch (#863)

### DIFF
--- a/docs/specs/2026-06-26-attachpane-flicker-fix-spec.md
+++ b/docs/specs/2026-06-26-attachpane-flicker-fix-spec.md
@@ -1,0 +1,80 @@
+# Spec — Fix #863: markdown buffer 切換的 transient `Loading editor…` 閃爍
+
+- **Issue**: #863（cosmetic **medium**，來源 PR #862 R4 adversarial review）
+- **Base**: alpha.297（`94478635`）
+- **Scope**: `spa` only（`EditorPane.tsx` render 推導 + 回歸測試）
+- **Status**: draft → codex review
+
+## 1. 問題
+
+同一 pane 從 markdown buffer A（`wysiwyg` 模式）切到另一個 markdown buffer B 時，UI 先 paint 一幀 `Loading editor…` fallback（閃爍 + 一瞬焦點中斷），才落到 B 的 editor。切 buffer 的觸發點包含 `EditorToolbar` 的 `onBufferSwitch` / `onNewBuffer`，以及 breadcrumb popover 切換 —— 它們都呼叫 `setPaneContent` 改 pane 的 `filePath`，並**刻意不**呼叫 `attachPane`（由 EditorPane 自身的 effect rebind）。
+
+## 2. 根因（已查證）
+
+`attachPane`（`EditorPane.tsx:113-115`）是 **post-commit `useEffect`**。切 buffer 後的「第一個 render」同時滿足：
+
+1. `buffer` 已是 B、`isMarkdown === true`；
+2. `paneState`（`paneStates[paneId]`）**仍是 A 的**：`editorMode === 'wysiwyg'`、`bufferKey === A`（attachPane effect 尚未跑）；
+3. 因此 `effectiveEditorMode === 'wysiwyg'`，但 render 的 wysiwyg 分支被 PR #862 的 **gating render**（`paneState?.bufferKey === key` 才 mount Tiptap）擋下，落入 `else` 的 `Loading editor…` fallback（`EditorPane.tsx:445-452`）。
+
+attachPane effect 跑完後 `paneState` 重建為 B（`createPaneState` 一律 `editorMode: 'raw'`）→ 第二個 render 走 raw Monaco。閃爍 = 第一幀用了 **stale A 的 `editorMode`** 卻被 gating 擋成 Loading。
+
+> 非本 PR 引入的正確性回歸（attachPane 時序本就如此；PR #862 之前 transient 改閃 Suspense fallback / 一瞬 Tiptap content）。PR #862 的 gating render 正確修掉了「stale Tiptap mount 污染 `didRestoreRef`」，但把 transient 視窗變成可見的 `Loading editor…`。
+
+### 2.1 stale 露出的不只 editorMode
+
+第一個 render 中**整個 `paneState` 都是 stale A 的**。除 `editorMode` 外，若放任提前 mount editor，`monacoViewState` / `tiptapViewState` / `cursorPosition` / `showDiff` 也都會是 A 的值，套到 B 上。任何「讓 editor 在 stale 視窗提前 mount」的修法都必須一併處理，否則會把閃爍換成 scroll/cursor 錯位的新 bug。
+
+## 3. 方案
+
+### 方案 A — `attachPane` 改 `useLayoutEffect`（記憶原案，**不採用**）
+
+讓 rebind 在 paint 前同步完成，stale 視窗不被瀏覽器 paint。
+
+- 優點：一招覆蓋所有 stale 衍生（mode + 三種 viewState）。
+- 缺點 1（可測性）：jsdom/RTL 下 `act()` 會把 layout effect 與 passive effect **一併同步 flush**，「不閃」無法確定性斷言；只能斷言「attachPane 註冊為 layout effect」這種脆弱的 implementation detail。
+- 缺點 2（時序面）：改動 `attachPane`（它同時負責切走時刪除舊 buffer）的執行時機，碰觸 §對全 EditorPane 的影響面，風險高於必要。
+
+### 方案 B — render 階段同步派生 aligned paneState（**採用**）
+
+不依賴 effect 時序，於 render 推導一個 `alignedPaneState`：**僅當 `paneState.bufferKey === key` 時才信任 `paneState`，否則視為「尚未對齊」並一律採用全新對齊語義**（等同 `createPaneState` 的預設：`editorMode: 'raw'`、所有 viewState `null`、`cursorPosition {1,1}`、`showDiff false`）。
+
+```ts
+const alignedPaneState = paneState?.bufferKey === key ? paneState : undefined
+const editorMode = alignedPaneState?.editorMode ?? 'raw'
+const effectiveEditorMode = isMarkdown ? editorMode : 'raw'
+const showDiff = alignedPaneState?.showDiff ?? false
+// Monaco/Tiptap/StatusBar 皆改讀 alignedPaneState（viewState/cursor 同理）
+```
+
+**為何正確**：attachPane 跑完後 `paneState` 必為 `createPaneState(B)`（raw + null viewState）。`alignedPaneState` 在 stale 視窗回傳的預設值與「對齊後」**完全相同**，因此：
+
+- stale 視窗直接 render **最終態的 raw Monaco**（而非 `Loading editor…`），消除閃爍；
+- Monaco `key={buffer.modelId}`（B 的 modelId 在 stale/aligned 兩幀不變）→ 不 remount，`initialViewState` 兩幀皆 `null` → **無 scroll/cursor 錯位**；
+- 進入 wysiwyg 分支的前提變為「`isMarkdown && alignedPaneState && editorMode==='wysiwyg'`」，亦即 `paneState.bufferKey === key` 恆成立 → §2 的 `Loading editor…` fallback 在 wysiwyg 路徑下不可達。
+
+**與 R3 gating 的關係**：方案 B 提供 *更強* 的保護而非移除 —— stale 視窗根本不進 wysiwyg 分支（連 Tiptap 都不評估），`didRestoreRef` 不可能被 stale paneState 污染。據此移除 `EditorPane.tsx:445-452` 的 `else` fallback 分支，第三分支化簡為直接 mount Tiptap（此時 `alignedPaneState` 必非 undefined）。
+
+> 取捨：方案 B 是純 render 派生，零 effect 時序依賴、可在 render 層確定性斷言、不動 attachPane 的 buffer 刪除時機。記憶原案（A）的可測性與風險面均劣於 B，故偏離原案。
+
+## 4. 驗收條件（AC）
+
+- **AC1**：freeze `attachPane`（mock noop）後，將一個先前處於 `wysiwyg`、`bufferKey=A` 的 pane render 成指向 markdown buffer B —— **不得** mount `TiptapEditor`，**不得**出現 `Loading editor…` fallback，**必須** mount raw Monaco（`monaco-wrapper`）。（回歸 #863）
+- **AC2**：同 AC1 條件下，Monaco 收到的 `initialViewState` 為 `null`（不得是 A 的 `monacoViewState`）。**測試需透過 `monacoPropsSpy`（mock `MonacoWrapper` 時記錄 props）斷言 `initialViewState === null`** —— 否則只驗到「有 mount raw Monaco」，驗不到 viewState 未外洩。（防 §2.1 viewState 錯位；codex spec review F1）
+- **AC3**：正常對齊路徑不回歸 —— pane 對齊 buffer B 且 `editorMode==='wysiwyg'` 時仍 mount Tiptap 並傳入該 pane 的 `tiptapViewState`（既有 AC9 test 續綠）。
+- **AC4**：非 markdown buffer 一律 raw；既有 R3 gating test 改為驗證「stale 時 mount raw Monaco 而非 fallback」後續綠。
+- **AC5**：覆蓋 §2.1 其餘 stale 露出面 —— 同 AC1 條件下，stale paneState 帶 `showDiff:true` 時**不得**先 mount `DiffView`（`diff-view` 不在場），stale `cursorPosition`（如 5,9）**不得**外洩到 status bar（`EditorStatusBar` 收到 `line:1, column:1`）。（codex spec review F2）
+- **AC6**：`cd spa && npx vitest run` 全綠（既有 4 個 pre-existing 失敗 `TabBar` / `sync hosts` 與本變更無關，已單獨追蹤）、`pnpm run lint`、`pnpm run build` 通過。
+
+## 5. 測試計畫
+
+- 新增 AC1/AC2/AC5 回歸 test（單一 #863 test，沿用既有 `freeze attachPane` 手法：`vi.spyOn(store,'attachPane').mockImplementation(()=>{})`）：擴充 `MonacoWrapper` mock 以 `monacoPropsSpy` 記錄 props（AC2）；在 stale paneState 上預設 `showDiff:true` + `cursorPosition 5,9`，斷言 render B 後 `diff-view` 不在場、`EditorStatusBar` 收到 `line:1/column:1`（AC5）。
+- 改寫既有 R3 gating test（`EditorPane.test.tsx:917`）斷言：stale 時 `monaco-wrapper` 在場、`tiptap-editor` 不在場、無 `Loading editor…`。
+- 跑全 `EditorPane` / `TiptapEditor` / `useEditorStore` 套件確認 attachPane 影響面無回歸。
+
+## 6. 非目標
+
+- 不動 `attachPane` 的 effect 本體與 buffer 刪除語義。
+- 不動 Tiptap/Monaco 內部還原邏輯（#857 已處理）。
+- 不處理切 buffer 時 buffer B 尚未 load 的 `Loading...`（資料層 loading，屬正常狀態，非本 bug）。
+```

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -92,10 +92,18 @@ function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { pan
   const currentName = displayName(filePath, untitled)
   const buffer = useEditorStore((s) => s.buffers[key])
   const paneState = useEditorStore((s) => s.paneStates[paneId])
+  // Only trust paneState once attachPane has rebound it to THIS buffer. Right after
+  // a buffer switch, the first render still sees paneState belonging to the previous
+  // buffer (attachPane is a post-commit effect). Deriving the aligned view
+  // synchronously — falling back to fresh-pane defaults (raw + null viewState) when
+  // it hasn't caught up — keeps the stale paneState off-screen. This fixes the #863
+  // `Loading editor…` flicker without leaking the old buffer's mode/viewState/cursor
+  // onto the new one (attachPane rebuilds paneState to these exact defaults anyway).
+  const alignedPaneState = paneState?.bufferKey === key ? paneState : undefined
   const isMarkdown = buffer?.language === 'markdown'
-  const editorMode = paneState?.editorMode ?? 'raw'
+  const editorMode = alignedPaneState?.editorMode ?? 'raw'
   const effectiveEditorMode = isMarkdown ? editorMode : 'raw'
-  const showDiff = paneState?.showDiff ?? false
+  const showDiff = alignedPaneState?.showDiff ?? false
   const canSave = buffer ? (buffer.isDirty || !buffer.lastStat) : false
   const [renameAnchorRect, setRenameAnchorRect] = useState<DOMRect | null>(null)
   const [renameMode, setRenameMode] = useState<'rename' | 'save'>('rename')
@@ -424,38 +432,37 @@ function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { pan
             language={buffer.language}
             modelId={buffer.modelId}
             isActive={isActive}
-            initialViewState={paneState?.monacoViewState ?? null}
+            initialViewState={alignedPaneState?.monacoViewState ?? null}
             onChange={(value) => useEditorStore.getState().updateContent(key, value)}
             onCursorChange={handleCursorChange}
             onViewStateChange={handleViewStateChange}
             onSave={handleSave}
           />
-        ) : paneState?.bufferKey === key ? (
+        ) : (
+          /* wysiwyg path. effectiveEditorMode === 'wysiwyg' requires alignedPaneState
+             (editorMode came from alignedPaneState?.editorMode ?? 'raw'), so paneState
+             is guaranteed already rebound to THIS buffer — the stale-paneState window
+             can never reach here (it derives raw and renders Monaco instead). Mounting
+             TiptapEditor against the aligned paneState is therefore safe: its one-shot
+             restore reads the correct tiptapViewState and didRestoreRef is never locked
+             against a stale state (supersedes PR #862's R3 post-commit gating). */
           <Suspense fallback={<div className="flex-1 flex items-center justify-center text-text-muted text-xs">Loading editor...</div>}>
             <TiptapEditor
               key={buffer.modelId}
               content={buffer.content}
               isActive={isActive}
-              initialViewState={paneState.tiptapViewState ?? null}
+              initialViewState={alignedPaneState?.tiptapViewState ?? null}
               onChange={(md) => useEditorStore.getState().updateContent(key, md)}
               onViewStateChange={(vs) => useEditorStore.getState().saveTiptapViewState(paneId, vs)}
               onSave={handleSave}
             />
           </Suspense>
-        ) : (
-          /* R3: paneState hasn't caught up to this buffer yet (attachPane is a
-             post-commit effect). Do NOT mount TiptapEditor against a stale/empty
-             paneState — once React.lazy is cached, Tiptap mounts synchronously and
-             its one-shot restore would lock didRestoreRef before the real viewState
-             arrives, silently dropping the restore. Render a fallback until
-             paneState.bufferKey === key. */
-          <div className="flex-1 flex items-center justify-center text-text-muted text-xs">Loading editor...</div>
         )}
       </div>
       <EditorStatusBar
         source={source}
-        line={paneState?.cursorPosition.line ?? 1}
-        column={paneState?.cursorPosition.column ?? 1}
+        line={alignedPaneState?.cursorPosition.line ?? 1}
+        column={alignedPaneState?.cursorPosition.column ?? 1}
         language={buffer.language}
         eol={buffer.eol}
         encoding={buffer.encoding}

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -10,13 +10,17 @@ import { bufferKey } from '../../../lib/editor-buffer-key'
 const getFsBackendMock = vi.hoisted(() => vi.fn())
 const editorStatusBarMock = vi.hoisted(() => vi.fn())
 const tiptapPropsSpy = vi.hoisted(() => vi.fn())
+const monacoPropsSpy = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../lib/fs-backend', () => ({
   getFsBackend: getFsBackendMock,
 }))
 
 vi.mock('../MonacoWrapper', () => ({
-  MonacoWrapper: ({ isActive }: { isActive?: boolean }) => <div data-testid="monaco-wrapper" data-active={isActive ? 'true' : 'false'} />,
+  MonacoWrapper: (props: { isActive?: boolean; initialViewState?: unknown }) => {
+    monacoPropsSpy(props)
+    return <div data-testid="monaco-wrapper" data-active={props.isActive ? 'true' : 'false'} />
+  },
 }))
 
 vi.mock('../DiffView', () => ({
@@ -914,7 +918,7 @@ describe('EditorPane', () => {
     expect(useEditorStore.getState().paneStates[pane.id].tiptapViewState).toEqual({ scrollTop: 42, selection: { type: 'text', from: 2, to: 3 } })
   })
 
-  it('does not mount TiptapEditor against stale paneState even when lazy is cached (R3 gating render)', async () => {
+  it('does not mount TiptapEditor against stale paneState even when lazy is cached (stale→raw derivation, supersedes R3 gating)', async () => {
     const backend = createBackend()
     getFsBackendMock.mockReturnValue(backend)
     useEditorStore.getState().openBuffer(getBufferKey('/notes/g-a.md'), '# A', { language: 'markdown', languageSource: 'manual', eol: 'lf', encoding: 'utf8' })
@@ -938,11 +942,59 @@ describe('EditorPane', () => {
     try {
       tiptapPropsSpy.mockClear()
       render(<EditorPane pane={createPane('/notes/g-b.md', 'pane-gate')} isActive />)
-      // lazy is cached now; WITHOUT the gating render TiptapEditor would mount
-      // synchronously against the stale paneState and lock didRestoreRef. The gate
-      // (bufferKey === key) must prevent the mount entirely.
+      // lazy is cached now; WITHOUT the stale→raw derivation TiptapEditor would mount
+      // synchronously against the stale paneState and lock didRestoreRef. Because the
+      // stale paneState (bufferKey=A ≠ key=B) is treated as unaligned, editorMode
+      // falls back to raw and the wysiwyg branch is never reached — raw Monaco mounts
+      // instead, so Tiptap is never instantiated against a stale state.
       expect(tiptapPropsSpy).not.toHaveBeenCalled()
       expect(screen.queryByTestId('tiptap-editor')).toBeNull()
+      expect(screen.getByTestId('monaco-wrapper')).toBeInTheDocument()
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('switching to a new markdown buffer while previous mode was wysiwyg renders raw Monaco, not a Loading editor flicker (#863)', async () => {
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+    useEditorStore.getState().openBuffer(getBufferKey('/notes/f-a.md'), '# A', { language: 'markdown', languageSource: 'manual', eol: 'lf', encoding: 'utf8' })
+    useEditorStore.getState().openBuffer(getBufferKey('/notes/f-b.md'), '# B', { language: 'markdown', languageSource: 'manual', eol: 'lf', encoding: 'utf8' })
+
+    // Pane aligned to buffer A in wysiwyg, carrying stale A-only state across every
+    // paneState-derived field — proves NONE of it leaks onto buffer B's render:
+    // monacoViewState (must not seed B's Monaco), showDiff (must not pre-mount
+    // DiffView), cursorPosition (must not leak to the status bar).
+    useEditorStore.getState().attachPane('pane-flicker', getBufferKey('/notes/f-a.md'))
+    useEditorStore.getState().setEditorMode('pane-flicker', 'wysiwyg')
+    useEditorStore.getState().saveMonacoViewState('pane-flicker', { stale: 'A' } as unknown as import('monaco-editor').editor.ICodeEditorViewState)
+    useEditorStore.getState().setShowDiff('pane-flicker', true)
+    useEditorStore.getState().updateCursor('pane-flicker', 5, 9)
+
+    // Freeze attachPane so paneState stays stale on A (bufferKey=A) while we render
+    // the pane now pointing at buffer B — deterministically reproducing the transient
+    // window that #863 paints as a `Loading editor…` flicker.
+    const spy = vi.spyOn(useEditorStore.getState(), 'attachPane').mockImplementation(() => {})
+    try {
+      tiptapPropsSpy.mockClear()
+      monacoPropsSpy.mockClear()
+      editorStatusBarMock.mockClear()
+      render(<EditorPane pane={createPane('/notes/f-b.md', 'pane-flicker')} isActive />)
+
+      // AC1: raw Monaco shown; no Tiptap; no `Loading editor…` fallback.
+      expect(screen.getByTestId('monaco-wrapper')).toBeInTheDocument()
+      expect(screen.queryByTestId('tiptap-editor')).toBeNull()
+      expect(tiptapPropsSpy).not.toHaveBeenCalled()
+      expect(screen.queryByText(/Loading editor/)).toBeNull()
+
+      // AC2: Monaco receives null initialViewState — stale A viewState must not leak.
+      expect(monacoPropsSpy).toHaveBeenCalled()
+      expect(monacoPropsSpy.mock.calls.every(([p]) => p.initialViewState === null)).toBe(true)
+
+      // AC5: stale showDiff must not pre-mount DiffView; stale cursor must not leak.
+      expect(screen.queryByTestId('diff-view')).toBeNull()
+      expect(editorStatusBarMock).toHaveBeenCalled()
+      expect(editorStatusBarMock.mock.calls.at(-1)?.[0]).toMatchObject({ line: 1, column: 1 })
     } finally {
       spy.mockRestore()
     }


### PR DESCRIPTION
## 問題

修 #863（cosmetic medium，來源 PR #862 R4 adversarial review）。同一 pane 從 markdown buffer A（`wysiwyg` 模式）切到另一個 markdown buffer B 時，UI 先 paint 一幀 `Loading editor…` fallback（閃爍 + 一瞬焦點中斷），才落到 B 的 editor。

## 根因

`attachPane` 是 post-commit `useEffect`。切 buffer 後的第一個 render 同時：`buffer` 已是 B（`isMarkdown`）、`paneState` 仍是 stale A（`editorMode=wysiwyg`、`bufferKey=A`）。stale `editorMode` 驅動 wysiwyg 分支，被 PR #862 的 gating render（`bufferKey===key` 才 mount Tiptap）擋成 `Loading editor…` fallback。

## 修法（方案 B：render 階段同步派生）

`const alignedPaneState = paneState?.bufferKey === key ? paneState : undefined` —— 僅當 paneState 已對齊本 buffer 才信任它，否則一律採全新對齊語義（raw + null viewState）。attachPane 對齊後 paneState 必為這些預設值，故 stale 視窗直接 render 最終態的 raw Monaco（而非閃 Loading），且不外洩舊 buffer 的 mode / viewState / cursor / diff 狀態。

連帶移除 R3 post-commit gating fallback：wysiwyg 分支前提變為 `bufferKey===key`，stale 視窗不可能 mount Tiptap，`didRestoreRef` 不會被 stale paneState 污染（比 R3 更強的保護）。

詳見 `docs/specs/2026-06-26-attachpane-flicker-fix-spec.md`（含方案 A vs B 取捨，已過 codex spec review，F1/F2 兩個 P2 驗收缺口已補）。

## 測試

- 新增 `#863` 回歸 test（freeze attachPane 手法）：AC1 stale→raw Monaco 不閃 Loading / AC2 `monacoPropsSpy` 驗 `initialViewState===null` / AC5 stale `showDiff`/`cursorPosition` 不外洩。
- 改寫既有 R3 gating test 斷言為「stale 時 mount raw Monaco」。
- `EditorPane` 套件 26/26 綠；`pnpm run lint` / `pnpm run build` 通過。

## 注意

全套件另有 **4 個 pre-existing 失敗**（`TabBar` ×1 + `sync/contributors/hosts` ×3），位於本 PR 未觸碰的檔案、存在於 origin/main，與本變更無關。