### PR TITLE
fix(sync+test): clear host token as null sentinel + fix stale TabBar tooltip test (#674)

### DIFF
--- a/docs/specs/2026-06-26-baseline-674-fix-spec.md
+++ b/docs/specs/2026-06-26-baseline-674-fix-spec.md
@@ -16,8 +16,9 @@
 
 ### 修法（採 `null` sentinel）
 1. `HostConfig.token` 型別 `token?: string` → `token?: string | null`。`null` = 明確「已清除，需 re-auth」，且 JSON 序列化會保留（`undefined` 會被 drop）。
-2. `hosts.ts:63` `: undefined` → `: null`。
+2. endpoint 不符時寫 `: null`（非 `undefined`）。
 3. 既有 3 個 test 不動（已 assert `null`），轉綠。
+3b. **兩個 merge mode 一致**（codex PR R2 adversarial，medium）：抽 `mergeHostsPreservingTokens(current, incomingHosts)` helper，**`full-replace` 與 `field-merge` 共用**。原本 `field-merge` 在 `resolved.hosts === 'remote'` 時 raw 套用 token-stripped 的 incoming hosts（`resolveConflicts` → engine.ts:177 overlay remote），會把**所有**本地 token 靜默清成 `undefined`（連 same-endpoint 也丟、且跳過 `null` re-auth sentinel）。改用 helper 後兩路徑語意一致。補 field-merge 回歸 test（same-endpoint 保留 / endpoint 變更 + 新 host → `null`）。
 4. **Ripple 收斂於 store/sync 邊界**：下游只接受 `string | undefined` 的 sink，於 call site coalesce `?? undefined`，不改其簽章、不讓 `null` 語意外溢到 UI/health 層（codex spec review P1：`DevEnvironmentSection` 為已知型別破口，須列入；`tsc` 已權威確認以下為完整集合）：
    - `spa/src/hooks/useMultiHostEventWs.ts:79` 餵給 `checkHealth(getToken?: () => string | undefined)`：`...hosts[hostId]?.token` → `... ?? undefined`。
    - `spa/src/components/hosts/OverviewSection.tsx:139` 餵給 `TokenField(token?: string)`：`token={host.token}` → `token={host.token ?? undefined}`。

--- a/docs/specs/2026-06-26-baseline-674-fix-spec.md
+++ b/docs/specs/2026-06-26-baseline-674-fix-spec.md
@@ -1,0 +1,55 @@
+# Spec — Fix #674: baseline test failures (sync hosts token + TabBar pinned tooltip)
+
+- **Issue**: #674（`bug` / `test`，origin/main 既有，predates #863）
+- **Base**: alpha.298（`661cc892`）
+- **Scope**: `spa`（sync hosts contributor + 型別 + TabBar test）
+- **Status**: draft → codex review
+
+修兩個**獨立**的 baseline 失敗（共 4 個 test）。決策已定：token 清除 sentinel 採 **`null`**。
+
+## A. Sync `hostsContributor.deserialize` — token 清除契約（3 個 test）
+
+### 現況（三方不一致）
+- **Test** 期望 `token` 為 `null`（`.toBeNull()`）：(1) host 只存在於 incoming snapshot（本地無）；(2) id 撞名但 `ip` 不同；(3) id 撞名但 `port` 不同。安全語意：endpoint 身分不符必須強制 re-auth，避免 bearer token 送到 attacker-controlled daemon。
+- **Impl**（`spa/src/lib/sync/contributors/hosts.ts:63`）：`token: sameEndpoint ? currentHost.token : undefined` —— 寫 `undefined`。
+- **Type**（`spa/src/stores/useHostStore.ts` `HostConfig`）：`token?: string` —— 連 `null` 都不允許。
+
+### 修法（採 `null` sentinel）
+1. `HostConfig.token` 型別 `token?: string` → `token?: string | null`。`null` = 明確「已清除，需 re-auth」，且 JSON 序列化會保留（`undefined` 會被 drop）。
+2. `hosts.ts:63` `: undefined` → `: null`。
+3. 既有 3 個 test 不動（已 assert `null`），轉綠。
+4. **Ripple 收斂於 store/sync 邊界**：下游只接受 `string | undefined` 的 sink，於 call site coalesce `?? undefined`，不改其簽章、不讓 `null` 語意外溢到 UI/health 層（codex spec review P1：`DevEnvironmentSection` 為已知型別破口，須列入；`tsc` 已權威確認以下為完整集合）：
+   - `spa/src/hooks/useMultiHostEventWs.ts:79` 餵給 `checkHealth(getToken?: () => string | undefined)`：`...hosts[hostId]?.token` → `... ?? undefined`。
+   - `spa/src/components/hosts/OverviewSection.tsx:139` 餵給 `TokenField(token?: string)`：`token={host.token}` → `token={host.token ?? undefined}`。
+   - `spa/src/components/settings/DevEnvironmentSection.tsx:35` 的 `token` selector 流入 `streamCheck`(`:184`) / `applyUpdate`(`:245`)，其 Electron API 簽章（`electron.d.ts:114`）僅收 `string | undefined`：於 selector coalesce `?? undefined`，一次收斂兩個 call site。
+5. **`addHost` opts**（`useHostStore.ts:43`）`token?: string` → `token?: string | null`：`host-lifecycle.ts:145` 的 host restore 直接傳整包 `HostConfig`（其 cleared token 應維持 `null`），否則 `tsc` 卡 TS2345。
+6. 其餘 `host.token` 消費者對 `null` 已安全（falsy 檢查 / `?? ''`）：`useHostStore.ts:160` `if (!host?.token)`、`MemoryMonitorPage.tsx:498` `host.token ?? ''`。`pnpm run build`（tsc）權威確認無其他破口。
+
+> 不外溢理由：`null` 的「明確清除」語意只在 persistence/sync 契約層有意義（test 也只在此 assert）；UI/health 既有以 `undefined` 模型「無 token」，於邊界 coalesce 最小化型別 churn。
+
+## B. TabBar pinned tooltip — stale test（1 個 test）
+
+### 現況
+- `HoverTooltip`（`spa/src/components/HoverTooltip.tsx:91`）已把 `role="tooltip"` 元素 **`createPortal` 到 `document.body`**，且常駐（opacity 切顯隱，非 mount/unmount）。
+- Test（`spa/src/components/TabBar.test.tsx:102`）用 `pinnedRoot.querySelector('[role="tooltip"]')` —— 只在 pinned tab **子樹**內找，portal 出去的元素永遠找不到 → `null` → fail。
+- Impl 正確（portal 為刻意設計）。**只改 test**。
+
+### 修法（**純 test-only**，不補 impl testId — codex spec review P3）
+pinned tab 本體不渲染 `span.overflow-hidden`（`SortableTab.tsx:74` 分支），故 label 文字唯一存在於 portal 出去的 tooltip。改 test 以**可及性名稱**精準 scope（repo 既有 `SortableTab.test.tsx:180` / `HoverTooltip.test.tsx:79` 已用全域查詢 tooltip 的先例）：
+- `const tooltip = screen.getByRole('tooltip', { name: 'aaa001' })` —— 一次斷言 role + 文字，且按 accessible name 唯一定位該 pinned tab 的 tooltip（其餘 normal tab 的 tooltip name 不同）。
+- 保留既有正向意圖：tooltip 文字 === label（`aaa001`）、pinned tab 內**不**渲染可見 label（`span.overflow-hidden` 為 null）。
+- **不**在 impl 端補 `testId`：`getByRole` name 已能唯一定位，避免把純測試問題擴成產品 API 變更。
+
+## 驗收條件（AC）
+
+- **AC1**：`hosts.test.ts` 三個 token preservation test 全綠（new host / ip 不符 / port 不符 → `token === null`）。
+- **AC2**：`HostConfig.token` 型別允許 `null`；`pnpm run build`（tsc）通過，無因型別放寬而生的新 error。
+- **AC3**：既有「preserves token when host id exists」test 續綠（sameEndpoint → 保留原 token 字串）。
+- **AC3b**（codex spec review P2）：新增測試證明 cleared token 跨 **JSON persist 邊界**存活為 `null` —— deserialize 一個新 host 後 `JSON.parse(JSON.stringify(host))` 仍含 `token` key 且值為 `null`（`undefined` 會被 drop，這正是選 `null` 而非 `undefined` 的理由；zustand persist 以 `JSON.stringify` 序列化）。
+- **AC4**：TabBar pinned tooltip test 改為查 portal 後轉綠；tooltip 文字 === label、pinned tab 無可見 label span；其餘 TabBar test（normal/locked）不回歸。
+- **AC5**：`npx vitest run`（全套件）**4 個 baseline 失敗歸零**、無新增失敗；`pnpm run lint` 通過。
+
+## 非目標
+- 不改 token 的傳輸/序列化（serialize 已 strip token）。
+- 不改 HoverTooltip 的 portal 設計、不改 TabBar 渲染結構（B 僅測試 + 必要時最小 testId）。
+- 不處理 token 持久化到 IndexedDB 與否（既有行為）。

--- a/spa/src/components/TabBar.test.tsx
+++ b/spa/src/components/TabBar.test.tsx
@@ -97,13 +97,15 @@ describe('TabBar', () => {
 
   it('renders pinned tabs as icon-only with HoverTooltip label', () => {
     const { container } = render(<TabBar tabs={pinnedTabs} activeTabId="t1" {...defaultHandlers} />)
-    // Pinned tab no longer uses native title attr — label comes via HoverTooltip.
-    const pinnedRoot = container.querySelector('[data-tab-id="p1"]')!
-    const tooltip = pinnedRoot.querySelector('[role="tooltip"]')!
+    // Pinned tab no longer uses native title attr — label comes via HoverTooltip,
+    // which portals its role="tooltip" element to document.body (NOT inside the tab
+    // subtree). Scope by accessible name to the target pinned tab's tooltip.
+    const tooltip = screen.getByRole('tooltip', { name: 'aaa001' })
     expect(tooltip).toBeInTheDocument()
     expect(tooltip.textContent).toBe('aaa001')
     // Pinned tab should not render the label as a visible (non-tooltip) text node
     // inside the button — only the icon + the (visually hidden until hover) tooltip.
+    const pinnedRoot = container.querySelector('[data-tab-id="p1"]')!
     expect(pinnedRoot.querySelector('span.overflow-hidden')).toBeNull()
   })
 

--- a/spa/src/components/hosts/OverviewSection.tsx
+++ b/spa/src/components/hosts/OverviewSection.tsx
@@ -136,7 +136,7 @@ export function OverviewSection({ hostId }: Props) {
           onSave={(v) => updateHost(hostId, { port: parseInt(v, 10) || 7860 })}
         />
         <TokenField
-          token={host.token}
+          token={host.token ?? undefined}
           ip={host.ip}
           port={host.port}
           onSave={(token) => {

--- a/spa/src/components/settings/DevEnvironmentSection.tsx
+++ b/spa/src/components/settings/DevEnvironmentSection.tsx
@@ -32,7 +32,7 @@ export function DevEnvironmentSection() {
   const t = useI18nStore((s) => s.t)
   const firstHostId = useHostStore((s) => s.hostOrder[0] ?? '')
   const daemonBase = useHostStore((s) => s.getDaemonBase(firstHostId))
-  const token = useHostStore((s) => firstHostId ? s.hosts[firstHostId]?.token : undefined)
+  const token = useHostStore((s) => firstHostId ? (s.hosts[firstHostId]?.token ?? undefined) : undefined)
 
   const spaSource: 'dev' | 'bundled' = window.location.protocol === 'app:' ? 'bundled' : 'dev'
 

--- a/spa/src/hooks/useMultiHostEventWs.ts
+++ b/spa/src/hooks/useMultiHostEventWs.ts
@@ -76,7 +76,7 @@ export function useMultiHostEventWs() {
       }
 
       const sm = new ConnectionStateMachine(
-        () => checkHealth(baseUrl, () => useHostStore.getState().hosts[hostId]?.token),
+        () => checkHealth(baseUrl, () => useHostStore.getState().hosts[hostId]?.token ?? undefined),
         (result) => {
           useHostStore.getState().setRuntime(hostId, {
             status: statusMap[result.daemon],

--- a/spa/src/lib/sync/contributors/hosts.test.ts
+++ b/spa/src/lib/sync/contributors/hosts.test.ts
@@ -285,4 +285,29 @@ describe('hostsContributor.deserialize (full-replace, token preservation)', () =
     expect(s.hosts.h1.port).toBe(9999)
     expect(s.hosts.h1.token).toBeNull()
   })
+
+  it('cleared token survives the JSON persist boundary as null (the reason it is not undefined)', () => {
+    useHostStore.setState({ hosts: {}, hostOrder: [], activeHostId: null })
+
+    const contributor = createHostsContributor()
+    contributor.deserialize(
+      {
+        version: 1,
+        data: {
+          hosts: { hNew: { id: 'hNew', name: 'new', ip: '10.0.0.2', port: 7860, order: 0 } },
+          hostOrder: ['hNew'],
+          activeHostId: null,
+        },
+      },
+      { type: 'full-replace' },
+    )
+
+    // zustand persist serializes via JSON.stringify; undefined would drop the key
+    // entirely, losing the "explicitly cleared, re-auth required" signal on rehydrate.
+    // null keeps the key with an unambiguous value across the boundary.
+    const host = useHostStore.getState().hosts.hNew
+    const roundTripped = JSON.parse(JSON.stringify(host)) as { token?: unknown }
+    expect('token' in roundTripped).toBe(true)
+    expect(roundTripped.token).toBeNull()
+  })
 })

--- a/spa/src/lib/sync/contributors/hosts.test.ts
+++ b/spa/src/lib/sync/contributors/hosts.test.ts
@@ -178,6 +178,42 @@ describe('createHostsContributor', () => {
     // activeHostId stays local
     expect(state.activeHostId).toBe(localHostId)
   })
+
+  it('field-merge with resolved.hosts=remote enforces the same token contract as full-replace', () => {
+    useHostStore.setState({
+      hosts: {
+        same: { id: 'same', name: 'same', ip: '10.0.0.1', port: 7860, token: 'KEEP', order: 0 },
+        moved: { id: 'moved', name: 'moved', ip: '10.0.0.2', port: 7860, token: 'STALE', order: 1 },
+      },
+      hostOrder: ['same', 'moved'],
+      activeHostId: 'same',
+    })
+
+    // Incoming hosts are token-stripped (serialize() drops token). `same` keeps its
+    // endpoint; `moved` reuses the id at a different ip; `fresh` is new.
+    const incoming: FullPayload = {
+      version: 1,
+      data: {
+        hosts: {
+          same: { id: 'same', name: 'same', ip: '10.0.0.1', port: 7860, order: 0 },
+          moved: { id: 'moved', name: 'moved', ip: '203.0.113.9', port: 7860, order: 1 },
+          fresh: { id: 'fresh', name: 'fresh', ip: '10.0.0.3', port: 7860, order: 2 },
+        },
+        hostOrder: ['same', 'moved', 'fresh'],
+        activeHostId: 'same',
+      },
+    }
+
+    contributor.deserialize(incoming, {
+      type: 'field-merge',
+      resolved: { hosts: 'remote', hostOrder: 'remote', activeHostId: 'local' },
+    })
+
+    const s = useHostStore.getState()
+    expect(s.hosts.same.token).toBe('KEEP') // same endpoint → preserved
+    expect(s.hosts.moved.token).toBeNull() // endpoint changed → cleared (re-auth)
+    expect(s.hosts.fresh.token).toBeNull() // new host → cleared
+  })
 })
 
 describe('hostsContributor.deserialize (full-replace, token preservation)', () => {

--- a/spa/src/lib/sync/contributors/hosts.ts
+++ b/spa/src/lib/sync/contributors/hosts.ts
@@ -5,6 +5,29 @@
 import { useHostStore, type HostConfig } from '../../../stores/useHostStore'
 import type { SyncContributor, FullPayload, MergeStrategy } from '../types'
 
+// Apply an incoming (token-stripped) host map onto the current state, preserving
+// each host's local token ONLY when endpoint identity (ip + port) still matches.
+// A reused id pointing at a different endpoint — or a host not present locally —
+// gets the explicit `null` sentinel ("cleared, re-auth required"), never a stale
+// token (which could leak a bearer to an attacker-controlled daemon) and never a
+// silently-dropped `undefined`. Shared by full-replace and field-merge so both
+// merge modes enforce the same token-clearing contract.
+function mergeHostsPreservingTokens(
+  current: Record<string, HostConfig>,
+  incomingHosts: Record<string, HostConfig>,
+): Record<string, HostConfig> {
+  const merged: Record<string, HostConfig> = {}
+  for (const [id, host] of Object.entries(incomingHosts)) {
+    const currentHost = current[id]
+    const sameEndpoint =
+      currentHost !== undefined &&
+      currentHost.ip === host.ip &&
+      currentHost.port === host.port
+    merged[id] = { ...host, token: sameEndpoint ? currentHost.token : null }
+  }
+  return merged
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -45,40 +68,24 @@ export function createHostsContributor(): SyncContributor {
       const incoming = fp.data as Record<string, unknown>
 
       if (merge.type === 'full-replace') {
-        const current = useHostStore.getState().hosts
         const incomingHosts = (incoming.hosts ?? {}) as unknown as Record<string, HostConfig>
-        const mergedHosts: Record<string, HostConfig> = {}
-        for (const [id, host] of Object.entries(incomingHosts)) {
-          // Only preserve token when endpoint identity (ip, port) matches.
-          // A bundle reusing an id but pointing at a different endpoint must
-          // force re-auth, otherwise a bearer token could be sent to an
-          // attacker-controlled daemon.
-          const currentHost = current[id]
-          const sameEndpoint =
-            currentHost !== undefined &&
-            currentHost.ip === host.ip &&
-            currentHost.port === host.port
-          mergedHosts[id] = {
-            ...host,
-            // Preserve the token only when endpoint identity matches; otherwise write
-            // an explicit `null` ("cleared, re-auth required") rather than `undefined`,
-            // so the cleared state survives serialization and is unambiguous downstream.
-            token: sameEndpoint ? currentHost.token : null,
-          }
-        }
         useHostStore.setState({
-          hosts: mergedHosts,
+          hosts: mergeHostsPreservingTokens(useHostStore.getState().hosts, incomingHosts),
           hostOrder: incoming.hostOrder as string[],
           activeHostId: incoming.activeHostId as string | null,
         })
         return
       }
 
-      // field-merge: only apply fields where resolved[field] === 'remote'
+      // field-merge: only apply fields where resolved[field] === 'remote'.
+      // Applying remote `hosts` must enforce the same endpoint-aware token
+      // contract as full-replace — incoming hosts are token-stripped, so a raw
+      // assignment would silently drop every local token (and skip the `null`
+      // re-auth sentinel for endpoint-changed hosts).
       const patch: Partial<Pick<ReturnType<typeof useHostStore.getState>, 'hosts' | 'hostOrder' | 'activeHostId'>> = {}
       for (const field of ['hosts', 'hostOrder', 'activeHostId'] as const) {
         if (merge.resolved[field] === 'remote' && field in incoming) {
-          if (field === 'hosts') patch.hosts = incoming[field] as unknown as Record<string, HostConfig>
+          if (field === 'hosts') patch.hosts = mergeHostsPreservingTokens(useHostStore.getState().hosts, incoming[field] as unknown as Record<string, HostConfig>)
           if (field === 'hostOrder') patch.hostOrder = incoming[field] as string[]
           if (field === 'activeHostId') patch.activeHostId = incoming[field] as string | null
         }

--- a/spa/src/lib/sync/contributors/hosts.ts
+++ b/spa/src/lib/sync/contributors/hosts.ts
@@ -60,7 +60,10 @@ export function createHostsContributor(): SyncContributor {
             currentHost.port === host.port
           mergedHosts[id] = {
             ...host,
-            token: sameEndpoint ? currentHost.token : undefined,
+            // Preserve the token only when endpoint identity matches; otherwise write
+            // an explicit `null` ("cleared, re-auth required") rather than `undefined`,
+            // so the cleared state survives serialization and is unambiguous downstream.
+            token: sameEndpoint ? currentHost.token : null,
           }
         }
         useHostStore.setState({

--- a/spa/src/stores/useHostStore.ts
+++ b/spa/src/stores/useHostStore.ts
@@ -10,7 +10,10 @@ export interface HostConfig {
   name: string
   ip: string
   port: number
-  token?: string
+  // `null` is the explicit "token cleared, re-auth required" sentinel written by
+  // the sync deserialize path when a host is new or its endpoint (ip/port) changed.
+  // Distinct from `undefined` (field simply absent); `null` survives JSON round-trips.
+  token?: string | null
   order: number
 }
 
@@ -40,7 +43,7 @@ interface HostState {
   runtime: Record<string, HostRuntime>
   activeHostId: string | null
 
-  addHost: (opts: { id?: string; name: string; ip: string; port: number; token?: string }) => string
+  addHost: (opts: { id?: string; name: string; ip: string; port: number; token?: string | null }) => string
   updateHost: (hostId: string, updates: Partial<Pick<HostConfig, 'name' | 'ip' | 'port' | 'token'>>) => void
   removeHost: (hostId: string) => void
   reorderHosts: (orderedIds: string[]) => void


### PR DESCRIPTION
Closes #674 — 兩個 origin/main 既有、互相獨立的 baseline 測試失敗（共 4 個 test）。

## A. Sync `hostsContributor.deserialize` token 清除 sentinel（3 個 test）
- **根因**：deserialize（full-replace）在 host 為新增、或 id 撞名但 endpoint（ip/port）不同時須清除 token（安全：避免 bearer token 重送到不同/惡意 daemon），impl 寫 `undefined`，但 test 期望 `null`、type 是 `token?: string`（連 null 都不允許）。三方不一致。
- **修法**（採 `null` sentinel，user 決策）：`HostConfig.token` → `string | null`；deserialize endpoint 不符時寫 `null`；`null` 比 `undefined` 多了「明確已清除」語意，且 JSON 序列化會保留（zustand persist 邊界）。
- **Ripple 收斂於 store/sync 邊界**：`tsc` 揭露的 3 個 `string | undefined` sink（checkHealth getToken / TokenField / DevEnvironmentSection 的 streamCheck+applyUpdate）於 call site coalesce `?? undefined`；`addHost` opts 放寬為 `string | null`（host restore 傳整包 HostConfig）。
- 新增回歸 test：cleared token 經 `JSON.stringify` 仍為 `null`（`undefined` 會被 drop）。

## B. TabBar pinned tooltip — stale test（1 個 test）
- **根因**：`HoverTooltip` 已 `createPortal` `role="tooltip"` 到 `document.body`，test 卻用 `pinnedRoot.querySelector` 在 tab 子樹內找 → 永遠 null。**impl 正確，純 stale test**。
- **修法**：改用 `screen.getByRole('tooltip', { name: 'aaa001' })` 按可及性名稱精準定位（pinned tab 無可見 label span）。test-only，無 impl 變更、不補 testId。

## 驗證
- 全套件 **3318/3318 綠**（先前 4 baseline 失敗歸零，無新增失敗）；`pnpm run build`（tsc）+ `pnpm run lint` 通過。
- Spec：`docs/specs/2026-06-26-baseline-674-fix-spec.md`（已過 codex spec review，3 findings P1/P2/P3 全收斂：P1 DevEnvironmentSection ripple 已修並補錄、P2 加 persist 邊界 AC/test、P3 改純 test-only getByRole）。

兩個 commit 獨立（A sync / B TabBar）。