### PR TITLE
feat(storage): Storage In-App nested CRUD + folder move (subsystem 1, Phase 1b)

### DIFF
--- a/docs/specs/2026-06-27-storage-filemanager-spec.md
+++ b/docs/specs/2026-06-27-storage-filemanager-spec.md
@@ -180,10 +180,18 @@ testable.
   `moveDir` helper) to re-key **every** `from/`-prefixed descendant entry in one transaction.
   Folder rename/move UI MUST NOT ship on the single-entry rename.
 - **New folder (mkdir)** — currently absent; create under the selected dir.
-- **Unified new-file helper** (§#854, codex P2-5): one `createUniqueInAppFile(dir)` used by
-  **all three** entry points (`EditorPane.tsx:408`, `EditorBuffersPane.tsx:115`,
-  `EditorNewTabSection.tsx:17`), name generated against the live tree with collision guard —
-  so the dup-bufferKey race can't return from another entry.
+- **Unified new-file helper** (§#854, codex P2-5): one `createUniqueInAppFile(dir, ext)` used
+  by **all three** entry points (`EditorPane.tsx:408`, `EditorBuffersPane.tsx:115`,
+  `EditorNewTabSection.tsx:17`), with **atomic IDB `add()` reservation** (not scan-then-write)
+  as the single serialization point — so the dup-bufferKey race can't return from another
+  entry.
+  - **Amendment (1b plan, 2026-06-28)**: the three entries were not symmetric —
+    `EditorPane`/`EditorBuffersPane` already eagerly write an empty file, but
+    `EditorNewTabSection` used a **lazy in-memory `untitled:`** buffer (UntitledDocumentState,
+    rename-before-save, `.txt`/`.md`). **Decision: converge all three on eager reservation.**
+    EditorNewTabSection now reserves a real file via `createUniqueInAppFile(dir, ext)`; the
+    `.txt`/`.md` choice is preserved as `ext`. The `untitled:` virtual path is no longer
+    produced by this entry. See `2026-06-28-storage-filemanager-1b-plan.md` §"Spec amendment".
 - File rename (in-place + across dirs); collision pre-check (reuse `stat` guard
   `EditorBuffersPane.tsx:144-153`).
 - Recursive delete; preserve locked-tab refusal + dirty-pane confirm guards

--- a/docs/specs/2026-06-28-storage-filemanager-1b-plan.md
+++ b/docs/specs/2026-06-28-storage-filemanager-1b-plan.md
@@ -6,144 +6,201 @@ Parent plan outline: `2026-06-27-storage-filemanager-plan.md` §"Phase 1b".
 
 T1b-1 (backend recursive rename/move) is **already shipped** in this worktree
 (`402c05ce`, `InAppBackend.rename` re-keys every `from/`-prefixed descendant in one
-IDB tx + full collision scan; 23 backend tests green). This plan covers **T1b-2 … T1b-6**.
+IDB tx + full collision scan; 23 backend tests green). This plan covers **T1b-0, T1b-2 …
+T1b-6b**.
+
+> **Revision history**: v1 (initial) → **v2** after codex plan-review round 1
+> (`task-mqwtpgw5-fl4lau`, NEEDS-REVISION) + main-session independent verification. v2
+> changes: added T1b-0 folder-selection prerequisite (codex P1-1); added bulk descendant
+> pane/buffer re-point helper for folder rename/move (codex P1-2); **EditorNewTabSection
+> converted to eager per user decision** (codex P2-3 — spec amended below); prefix-match on
+> `pane.content.filePath` not `bufferKey` (codex P2-4); folder naming uses `add`-reserve for
+> symmetry (codex P3-5); T1b-6 split into pure helper / DnD wiring (codex P3-6).
+
+## Spec amendment (this plan — supersedes spec §Phase 1b #854 wording)
+
+The spec lists three new-file entry points sharing `createUniqueInAppFile`. Implementation
+reveals they were **not symmetric**: `EditorPane` new buffer (`EditorPane.tsx:424`) and
+`StoragePane` (`storage-actions.ts:58`) already **eagerly write** an empty real file; only
+`EditorNewTabSection` (`EditorNewTabSection.tsx:18-70`) used a **lazy in-memory `untitled:`**
+buffer (UntitledDocumentState, rename-before-save, `.txt`/`.md` choice) that persists on first
+save. **Decision (user): converge all three on the eager reservation model.**
+EditorNewTabSection now creates a real reserved file via `createUniqueInAppFile(dir, ext)`; the
+`.txt`/`.md` buttons are preserved as the `ext` argument (both eager). The `untitled:` virtual
+path is no longer produced by this entry. AC-1b's "rapid double new-file from any of the 3
+entry points → no shared bufferKey" is thereby satisfiable by the single atomic namer.
 
 ## Existing groundwork (from 1a + T1b-1) — reused, not rebuilt
 
 - `InAppBackend` (`spa/src/lib/fs-backend-inapp.ts`): `write` (auto-creates parent dirs in
-  one tx), `mkdir`, `delete(path, recursive)` (prefix-sweep), **`rename(from,to)` recursive
-  re-key** (T1b-1), `list` (direct children), `stat`.
+  one tx, `put`), `mkdir` (blind `put`), `delete(path, recursive)` (prefix-sweep),
+  **`rename(from,to)` recursive re-key** (T1b-1), `list` (direct children), `stat`.
 - `storage-paths.ts`: `STORAGE_ROOT='/buffer'`, `join`, `parentOf`, `basename`,
   `relativeToRoot`, `isUnderRoot`.
 - `storage-tree.ts`: `TreeNode {path,name,isDir,size,children?}`, `listTreeUnder`.
-- `useStorageTree` hook: `{tree,loading,error,expanded,refresh,toggle}` (full-path identity).
+- `useStorageTree` hook: `{tree,loading,error,expanded,refresh,toggle}` — **selection lives in
+  StoragePane, currently leaf-file only** (see T1b-0).
 - `StoragePane.tsx` (271): toolbar + `StorageTree` + Backups placeholder; `handleNew`/
-  `handleRenameConfirm`/`handleDelete`/`handleOpen`.
-- `storage-actions.ts` (183): `createStorageFile`, `renameStorageEntry(from,newName)` (stat
-  collision guard :87-92), `deleteStorageEntries(targets,t)` (locked-tab refusal :139 +
-  dirty-pane confirm :145-154).
-- dnd-kit already a dep (`@dnd-kit/core/sortable/utilities`); pattern in
-  `RegionManager.tsx:63-76` (PointerSensor distance:5, DndContext+SortableContext).
+  `handleRenameConfirm`/`handleDelete`/`handleOpen`; `selected` state targets a **file** path.
+- `storage-actions.ts` (183): `createStorageFile` (`:58` eager write), `renameStorageEntry`
+  (stat collision guard `:87-92`, single-path re-point via `performBufferRename` `:33-48`),
+  `deleteStorageEntries` (open-pane scan **exact-match** `:132`, locked refusal `:139`,
+  dirty confirm `:145`, `backend.delete(path)` **non-recursive** `:180`).
+- `performBufferRename` (`storage-actions.ts:33-48`): single-path pane+buffer re-point —
+  `useTabStore.renameEditorPanes(source, from, to)` (`useTabStore.ts:82` — **exact-match**
+  `content.filePath === oldPath`) + `useEditorStore.renameBuffer(oldKey, newKey, meta)`
+  (`useEditorStore.ts:177` — single key). **No bulk/prefix variant exists** → folder
+  rename/move needs T1b-4's new helper.
+- `editor-buffer-key.ts`: `bufferKey(source, path)` → `inapp:/buffer/...` (NOT the bare path).
+- dnd-kit is a dep (`@dnd-kit/core/sortable/utilities`); flat-reorder patterns in
+  `RegionManager.tsx:63-76`, `TabBar.tsx`. **No nested-tree DnD precedent in repo.**
 
 ## Design decisions (resolve before impl — flag any reversal in review)
 
-1. **#854 reservation is atomic at the IDB layer, not a name scan.** Root cause: EditorPane
-   (`EditorPane.tsx:424`) and StoragePane (`storage-actions.ts:58`) both name via
-   `Untitled-${Date.now()}.md` → same-ms double-click collides; EditorNewTabSection
-   (`EditorNewTabSection.tsx:18-52`) scans only one level. A scan-then-write namer is still
-   racy. **Fix:** add `InAppBackend.createUnique(dir, baseName, ext): Promise<string>` that
-   loops `store.add()` (IDB `add` throws `ConstraintError` if the key exists) incrementing
-   the suffix until the empty file is created, returning the reserved path. `add` (not `put`)
-   is the single serialization point, so two concurrent callers from *any* entry point get
-   two distinct keys. `createUniqueInAppFile(dir)` in a new `inapp-namer.ts` wraps it.
-2. **Consequence: a new untitled file now persists immediately** (empty entry written on
-   create) instead of being purely in-memory until first save. This is intended — the file
-   is what the tree manages, and it makes the bufferKey real at creation. Editor open flow
-   for the 3 entry points opens the reserved path. (Verify no double-write/overwrite of the
-   reserved empty file clobbers an immediately-typed buffer — open must `read` not `write`.)
-3. **In-place rename only in T1b-4** (basename change within the same parent, files + folders).
-   Cross-directory move is exclusively T1b-6 (drag). Keeps rename UI single-axis.
-4. **Folder-aware guards in T1b-5**: a folder delete/rename must evaluate locked/dirty against
-   **every descendant's** open pane, not just the folder path. Compute the affected path set
-   = target + all open panes whose bufferKey is under `target/`.
-5. **One PR** (`feat(storage): Phase 1b nested CRUD + folder move`), task-per-commit, TDD.
+1. **#854 reservation is atomic at the IDB layer.** Add `InAppBackend.createUnique(dir,
+   baseName, ext): Promise<string>` looping `store.add()` (IDB `add` throws `ConstraintError`
+   if the key exists, unlike `put`) incrementing the suffix until the empty file is created;
+   returns the reserved path. `add` is the single serialization point, so concurrent callers
+   from any entry point get distinct keys. Confirmed sound + non-conflicting with existing
+   `write`/`put` by codex review. `createUniqueInAppFile(dir, ext)` in `inapp-namer.ts` wraps
+   it. **`ext` is a required parameter** (preserves `.txt`/`.md`).
+2. **Immediate persist does not clobber typed content** (codex-verified): `EditorPane` opens a
+   real path via `read`→`openBuffer` with no redundant `write` on open. All three new-file
+   entries now reserve eagerly (see Spec amendment).
+3. **Folder selection (NEW — codex P1-1).** The 1a tree selects **leaf files only**; clicking a
+   folder row toggles expand/collapse and does not select it. T1b-3/4/5/6 need a folder as the
+   action target. T1b-0 adds a folder-selectable model: `selectedNode {path, isDir}`; clicking a
+   folder **name** selects it, the caret still toggles expand. `targetDir` = the folder itself
+   if a folder is selected, `parentOf(path)` if a file is selected, else `STORAGE_ROOT`.
+4. **In-place rename only in T1b-4**; cross-directory move is exclusively T1b-6 (drag).
+5. **Folder rename/move re-points every descendant open pane** (codex P1-2 / verified). New
+   bulk helper `remapPanesUnder(source, from, to)`: collect every open pane whose
+   `pane.content.filePath === from || .startsWith(from + '/')` across **editor + image-preview
+   + pdf-preview** kinds, then re-point each to `to + filePath.slice(from.length)` (panes +
+   their editor buffers). Single-file rename keeps using `performBufferRename`.
+6. **Descendant guard matches on `pane.content.filePath`, NOT `bufferKey`** (codex P2-4):
+   `p === target || p.startsWith(target + '/')` (the trailing slash avoids `/buffer/a` matching
+   `/buffer/ab`). Derive `bufferKey` from `filePath` only when looking up a dirty buffer.
+7. **Folder naming uses `add`-reserve too** (codex P3-5): `InAppBackend.mkdirUnique(dir,
+   baseName)` via `store.add()` on the dir key — atomic, symmetric with files, no double-click
+   same-name folder race.
+8. **One PR** (`feat(storage): Phase 1b nested CRUD + folder move`), task-per-commit, TDD.
 
 ## Tasks
 
-Order: T1b-2 (namer, foundation) → T1b-3 (mkdir) → T1b-4 (rename) → T1b-5 (delete) →
-T1b-6 (drag move). Each: failing tests first, then impl, suite+lint+build green.
+Order & deps: **T1b-0** (folder selection, prerequisite) → T1b-2 (namer) → T1b-3 (mkdir) →
+T1b-4 (rename + bulk re-point) → T1b-5 (delete) → **T1b-6a** (pure move helper) → **T1b-6b**
+(DnD wiring). Each: failing tests first, then impl, suite+lint+build green.
 
-### T1b-2 — Unified `createUniqueInAppFile` namer + wire 3 entry points
-- **Backend** `fs-backend-inapp.ts`: add `createUnique(dir, baseName='Untitled', ext='md'):
-  Promise<string>`. Loop: candidate = `Untitled`, `Untitled-1`, `Untitled-2`…; `store.add({
-  path: join(dir, name+'.'+ext), content: empty, mtime })`; on `ConstraintError` increment;
-  on success return the path. Bounded retry (e.g. 10_000) → throw if exhausted.
-- **lib** new `spa/src/lib/inapp-namer.ts`: `createUniqueInAppFile(dir=STORAGE_ROOT):
-  Promise<string>` = `getFsBackend('inapp').createUnique(dir)`. Single namer.
-- **Wire** all 3 entry points to call it (replacing local naming):
-  - `storage-actions.ts:58` `createStorageFile` → `createUniqueInAppFile(targetDir)`.
-  - `EditorPane.tsx:424` new buffer → `createUniqueInAppFile(STORAGE_ROOT)` then open path.
-  - `EditorNewTabSection.tsx:18-52` `nextUntitledName` → replaced by `createUniqueInAppFile`.
-- **Tests** (`fs-backend-inapp.test.ts` + `inapp-namer.test.ts`):
-  - T2-1 `createUnique` returns `/buffer/Untitled.md` on empty dir.
-  - T2-2 collision: pre-seed `/buffer/Untitled.md` → returns `/buffer/Untitled-1.md`.
-  - T2-3 **#854 race**: `await Promise.all([createUniqueInAppFile(), createUniqueInAppFile()])`
-    → two **distinct** paths, two entries in `list`, no shared key.
-  - T2-4 reserved file is empty + appears in `listTreeUnder`.
-  - T2-5 entry-point parity: storage-actions create + EditorNewTabSection both go through the
-    namer (assert no `Date.now()` / local scan remains — grep-level or behavioral).
+### T1b-0 — Folder-selectable tree + target model (prerequisite, codex P1-1)
+- `StoragePane.tsx`: change `selected` from a file path to `selectedNode { path, isDir }`
+  (or keep path + derive isDir from tree). Clicking a folder **name** selects it; the caret /
+  double-click still toggles expand (`StorageRow.tsx:107,115`). Derive `targetDir` per
+  decision 3.
+- `StorageRow`/`StorageTree`: render selected state for folders too; keep open-on-double-click
+  for files.
+- **Tests** (`StoragePane.test.tsx`, `StorageRow.test.tsx`):
+  - T0-1 clicking a folder name selects it (selected style), caret toggles expand independently.
+  - T0-2 `targetDir`: folder selected → folder; file selected → its parent; none → ROOT.
+  - T0-3 selecting a folder does not open a tab (only files open).
+- **Dep:** none. **Blocks:** T1b-3/4/5/6.
+
+### T1b-2 — Unified eager namer `createUnique`(+ext) + wire all 3 entry points
+- **Backend** `fs-backend-inapp.ts`: `createUnique(dir, baseName='Untitled', ext): Promise<
+  string>`. Loop candidate `Untitled`,`Untitled-1`…; `store.add({path: join(dir,
+  name+'.'+ext), content: empty, mtime})`; on `ConstraintError` increment; success → return
+  path; bounded retry (10_000) → throw.
+- **lib** `spa/src/lib/inapp-namer.ts`: `createUniqueInAppFile(dir, ext): Promise<string>`.
+- **Wire** (all eager):
+  - `storage-actions.ts:58` `createStorageFile(targetDir)` → `createUniqueInAppFile(targetDir,
+    'md')`.
+  - `EditorPane.tsx:424` new buffer → `createUniqueInAppFile(STORAGE_ROOT, 'md')` then open.
+  - `EditorNewTabSection.tsx:18-70` → `.txt`/`.md` buttons call `createUniqueInAppFile(
+    STORAGE_ROOT, ext)`, open the **real** path (no `untitled:`). Remove `nextUntitledName`.
+    If `UntitledDocumentState`/`untitled:` handling becomes fully unreferenced after this,
+    note it (de,ad-code removal is a **separate cleanup commit**, not folded here, to keep the
+    diff surgical — verify references first via grep).
+- **Tests** (`fs-backend-inapp.test.ts`, `inapp-namer.test.ts`, `EditorNewTabSection.test.tsx`):
+  - T2-1 `createUnique` → `/buffer/Untitled.md` on empty dir; `.txt` ext honored.
+  - T2-2 collision: seed `/buffer/Untitled.md` → `/buffer/Untitled-1.md`.
+  - T2-3 **#854 race**: `Promise.all([createUniqueInAppFile(d,'md'), …])` → distinct paths,
+    two `list` entries, no shared key.
+  - T2-4 reserved file empty + appears in `listTreeUnder`.
+  - T2-5 EditorNewTabSection `.txt`/`.md` each create a real reserved path (behavioral —
+    pane content `filePath` is `/buffer/…`, **not** `untitled:`), no shared key on rapid click.
 - **Dep:** none.
 
 ### T1b-3 — New Folder (mkdir) UI
-- **storage-actions.ts**: `createStorageFolder(dir, t): Promise<{path}|{error}>` — unique
-  folder name via a small `createUniqueDirName` (scan `list(dir)` for `New Folder`,
-  `New Folder 1`…; mkdir is not an `add`-race surface like files since folders are rarely
-  rapid-doubled — a scan + `mkdir` is acceptable; if review wants symmetry, route through an
-  `add`-based reserve too).
-- **StoragePane.tsx**: toolbar "New Folder" button → `createStorageFolder(selectedDir||ROOT)`
-  → `refresh()` → auto-expand + select the new folder. `selectedDir` = selected node's dir
-  (if a file is selected, its `parentOf`; if a folder, itself; else ROOT).
-- **Tests** (`storage-actions.test.ts` + `StoragePane.test.tsx`):
-  - T3-1 mkdir creates a folder that shows in the tree (`isDir`).
-  - T3-2 new file created **under** the selected folder lands at `folder/Untitled.md`
-    (accepts children — proves dir is real).
-  - T3-3 folder name collision increments (`New Folder 1`).
-- **Dep:** T1b-2 (uses `createUniqueInAppFile(dir)` to prove children land under it).
+- **Backend** `mkdirUnique(dir, baseName='New Folder'): Promise<string>` via `add`-reserve
+  (decision 7).
+- **storage-actions.ts** `createStorageFolder(targetDir)` → `mkdirUnique` → `{path}|{error}`.
+- **StoragePane.tsx** toolbar "New Folder" button → `createStorageFolder(targetDir)` (T1b-0)
+  → `refresh()` → auto-expand + select new folder.
+- **Tests**: T3-1 folder appears in tree (`isDir`); T3-2 a new file created with `targetDir`=new
+  folder lands at `folder/Untitled.md` (folder is real / accepts children); T3-3 name collision
+  increments (`New Folder 1`) — concurrent double-create → two distinct folders.
+- **Dep:** T1b-0, T1b-2.
 
-### T1b-4 — Rename (in-place) for files + folders, collision pre-check
-- **storage-actions.ts** `renameStorageEntry(from, newName)`: already stat-guards file
-  collisions. Extend: (a) compute `to = join(parentOf(from), newName)`; (b) **pre-check before
-  any mutation** — `stat(to)` exists → `{kind:'exists'}` (folders: also reject if `to` has any
-  `to/` descendant, but `rename`'s own scan covers it — keep the early `stat` as the UI-facing
-  guard); (c) call `backend.rename(from, to)` (recursive re-key for folders via T1b-1).
-- **StoragePane.tsx** `handleRenameConfirm`: works for both file and folder selection;
-  surface `exists` as inline error; on ok `refresh()` + re-select renamed node by new path.
+### T1b-4 — In-place rename (file + folder) + bulk descendant re-point
+- **storage-actions.ts** `renameStorageEntry(from, newName)`: compute `to = join(parentOf(
+  from), newName)`; **pre-check `stat(to)` before any mutation** → `{kind:'exists'}`; then
+  `backend.rename(from, to)` (recursive re-key via T1b-1).
+- **New** `remapPanesUnder(source, from, to)` (decision 5/6): for files, equals current
+  `performBufferRename`; for folders, enumerate open panes where `filePath === from ||
+  startsWith(from+'/')` (editor/image/pdf) and re-point each pane + its buffer to the mapped
+  path. `renameStorageEntry` dispatches file→`performBufferRename`, folder→`remapPanesUnder`.
+- **StoragePane.tsx** `handleRenameConfirm`: works for file or folder selection; surface
+  `exists` inline; on ok `refresh()` + re-select by new path.
 - **Tests**:
-  - T4-1 file rename to a free name: old path gone, new present, content intact, mtime kept.
-  - T4-2 file rename to an **existing** path: refused, **no backend mutation** (assert source
-    untouched + target untouched).
-  - T4-3 **folder rename moves ≥2 nested descendants** (AC-1b): `a/` with `a/b.md`, `a/c/d.md`
-    → rename `a`→`z`: `z/b.md`+`z/c/d.md` present, `a/*` gone, contents intact.
-  - T4-4 folder rename onto an existing folder name refused before mutation.
-- **Dep:** T1b-1 (folder recursive rename).
+  - T4-1 file rename: old gone, new present, content + mtime intact.
+  - T4-2 file rename onto existing path: refused, **no mutation** (source + target untouched).
+  - T4-3 **folder rename moves ≥2 nested descendants** (AC-1b): `a/b.md`+`a/c/d.md` → rename
+    `a`→`z`: `z/b.md`+`z/c/d.md` present, `a/*` gone, contents intact.
+  - T4-4 folder rename onto existing folder name refused before mutation.
+  - T4-5 **open descendant pane re-pointed**: `a/b.md` open in an editor pane; rename `a`→`z`
+    → that pane's `filePath` becomes `z/b.md`, buffer key remapped, no stale/orphan buffer.
+    Repeat for an image-preview pane (`a/p.png`).
+- **Dep:** T1b-0, T1b-1.
 
 ### T1b-5 — Recursive delete with folder-aware locked/dirty guards
-- **storage-actions.ts** `deleteStorageEntries(targets, t)`: today checks open panes whose
-  bufferKey == a target. Extend the affected-pane computation to **descendants**: a pane is
-  affected if its bufferKey === target **or** startsWith `target + '/'`. Locked-descendant →
-  refuse; dirty-descendant → confirm (reuse `delete_dirty_confirm`). Then
-  `backend.delete(path, true)` for folders (prefix-sweep) / `delete(path)` for files.
-- **StoragePane.tsx** `handleDelete`: unchanged call site; close any open panes for the
-  deleted path set after success (no resurrection — pair with `useTabStore.closePane` like 1a's
-  guard) + `refresh()`.
+- **storage-actions.ts** `deleteStorageEntries(targets, t)`: extend the affected-pane scan
+  (`:132`) to descendants — a pane is affected if `filePath === t || startsWith(t+'/')` for
+  any target `t` (decision 6). Locked descendant → refuse; dirty descendant → confirm. Close
+  all affected panes + drop buffers BEFORE delete (existing G2 order). `backend.delete(path,
+  true)` for folders / `delete(path)` for files.
 - **Tests**:
   - T5-1 folder delete removes folder + all descendants (`list` empty under it).
-  - T5-2 delete a folder whose descendant is open in a **locked** tab → refused, nothing
-    deleted.
-  - T5-3 delete a folder whose descendant is **dirty** → confirm prompt fires; on confirm
-    deletes, on cancel no-op.
+  - T5-2 folder whose descendant is open in a **locked** tab → refused, nothing deleted.
+  - T5-3 folder whose descendant is **dirty** → confirm fires; confirm deletes, cancel no-ops.
   - T5-4 file delete (1a regression) still guarded + works.
-- **Dep:** none (extends 1a; independent of T1b-2/3/4).
+- **Dep:** T1b-0.
 
-### T1b-6 — Drag-and-drop move across folders
-- **StorageTree/StorageRow**: wrap rows with dnd-kit (`useSortable`/`useDraggable` for source,
-  `useDroppable` for folder rows + the root). `DndContext` in `StoragePane` with
-  `PointerSensor {distance:5}` (mirror `RegionManager`). Drop a node onto a **folder** (or root):
-  `to = join(targetDir, basename(from))`; reject drop onto self / own descendant / same parent
-  (no-op); collision pre-check `stat(to)` → inline error; else `backend.rename(from, to)`
-  (recursive for folders via T1b-1) → `refresh()`.
-- **Move helper** `moveStorageEntry(from, targetDir)` in storage-actions (shares the rename
-  collision + guard path; reuses T1b-5's descendant logic for moving a folder that contains
-  open panes — moving re-keys, so open panes' bufferKeys must be updated like 1a rename did,
-  via `renameEditorPanes`/`renameBuffer`).
-- **Tests**:
-  - T6-1 drag file into a folder: old path gone, new present under folder, content intact.
-  - T6-2 drag folder into another folder: all descendants re-keyed (AC-1b move).
-  - T6-3 drop onto self / own descendant / current parent → no-op (no mutation).
-  - T6-4 drop where target name exists → refused (inline error), no mutation.
-  - T6-5 moving a folder containing an open pane re-points the pane's bufferKey (no stale
-    buffer / no resurrection).
-- **Dep:** T1b-1 (move), T1b-4 (collision pre-check shared), T1b-5 (descendant pane logic).
+### T1b-6a — Pure move helper + guards + tests (codex P3-6, data layer)
+- **storage-actions.ts** `moveStorageEntry(from, targetDir): Promise<MoveOutcome>`:
+  `to = join(targetDir, basename(from))`; reject (no-op) if `targetDir === parentOf(from)`,
+  `to === from`, or `targetDir === from || targetDir.startsWith(from+'/')` (into self/own
+  descendant); `stat(to)` exists → `{kind:'exists'}`; else `backend.rename(from, to)` +
+  `remapPanesUnder` (reuses T1b-4 helper; recursive for folders).
+- **Tests** (no DnD):
+  - T6-1 move file into folder: old gone, new under folder, content intact.
+  - T6-2 move folder into folder: all descendants re-keyed (AC-1b move).
+  - T6-3 move onto self / own descendant / current parent → no-op (no mutation).
+  - T6-4 move where target name exists → `exists`, no mutation.
+  - T6-5 moving a folder containing an open pane re-points it (no stale buffer / resurrection).
+- **Dep:** T1b-1, T1b-4 (shares collision + `remapPanesUnder`).
+
+### T1b-6b — Drag-and-drop wiring + UI (codex P3-6, interaction layer)
+- **StoragePane/StorageTree/StorageRow**: `DndContext` (`PointerSensor {distance:5}`, mirror
+  `RegionManager.tsx:63-76`); rows as drag sources (`useDraggable`/`useSortable`), folder rows
+  + root as drop targets (`useDroppable`). Drag handle / drop-target highlight; preserve
+  click-select + double-click-open coexistence. On drop → `moveStorageEntry(activePath,
+  dropTargetDir)` (T1b-6a) → inline `exists` error / `refresh()`.
+- **Tests** (UI-level, RTL + dnd-kit harness):
+  - T6b-1 drag a file onto a folder → `moveStorageEntry` called with that folder; tree updates.
+  - T6b-2 drop onto root moves to `STORAGE_ROOT`.
+  - T6b-3 drop onto self / own descendant → no move (guard surfaces).
+  - T6b-4 click still selects, double-click still opens (no DnD regression).
+- **Dep:** T1b-6a.
 
 ## Verification per task
 `cd spa && npx vitest run` (full suite green; 1a baseline 3397 + new), `pnpm run lint`,
@@ -153,18 +210,22 @@ build manually (feedback_codex_sandbox_no_install).
 ## AC-1b coverage map
 | AC-1b clause | Task / tests |
 |---|---|
-| Folder rename/move re-keys all descendants (≥2 nested) | T1b-4 T4-3, T1b-6 T6-2 |
+| Folder rename/move re-keys all descendants (≥2 nested) | T1b-4 T4-3, T1b-6a T6-2 |
 | mkdir creates folder that accepts children | T1b-3 T3-1/T3-2 |
 | File rename to existing path refused before mutation | T1b-4 T4-2 |
 | Folder delete removes descendants; locked refused; dirty confirms | T1b-5 T5-1/T5-2/T5-3 |
-| Drag file into folder moves it (old gone/new present/intact) | T1b-6 T6-1 |
+| Drag a file into another folder moves it (old gone/new present/intact) | T1b-6a T6-1 + T1b-6b T6b-1 |
 | Rapid double new-file from any of 3 entry points → no shared bufferKey | T1b-2 T2-3/T2-5 |
+| (enabler) folder is a selectable action target | T1b-0 T0-1/T0-2 |
+| (enabler) folder move re-points open descendant panes | T1b-4 T4-5, T1b-6a T6-5 |
 
 ## Out of scope (Phase 1c)
 Upload (picker + OS-file drag-drop), download/export, binary open-disposition, size cap +
 quota banner. Drag-and-drop in 1b is **intra-tree move only**, not OS-file ingest.
 
-## Follow-ups to watch (from 1a review, may resurface)
-- onBufferSwitch dirty-guard semantics now moot under open-or-focus (1a follow-up a) — if a
-  test touches it during rename/move, prefer removing the redundant confirm over patching.
+## Follow-ups to watch (from 1a review)
+- onBufferSwitch dirty-guard now moot under open-or-focus (1a follow-up a) — if a test touches
+  it during rename/move, prefer removing the redundant confirm over patching.
 - #625 manage-from-secondary-pane duplicate tab (pre-existing, spec §7) — do not regress.
+- If `UntitledDocumentState`/`untitled:` becomes fully dead after T1b-2, open a cleanup
+  commit/issue rather than mixing removal into the namer change.

--- a/docs/specs/2026-06-28-storage-filemanager-1b-plan.md
+++ b/docs/specs/2026-06-28-storage-filemanager-1b-plan.md
@@ -63,7 +63,9 @@ entry points → no shared bufferKey" is thereby satisfiable by the single atomi
    returns the reserved path. `add` is the single serialization point, so concurrent callers
    from any entry point get distinct keys. Confirmed sound + non-conflicting with existing
    `write`/`put` by codex review. `createUniqueInAppFile(dir, ext)` in `inapp-namer.ts` wraps
-   it. **`ext` is a required parameter** (preserves `.txt`/`.md`).
+   it. **`ext` contract: `'md' | 'txt'` (bare, no leading dot)**; backend forms the path as
+   `join(dir, name + '.' + ext)`. UI buttons map label → bare ext in their click handler (never
+   pass `'.md'`) — single normalization point, avoids `Untitled..md`.
 2. **Immediate persist does not clobber typed content** (codex-verified): `EditorPane` opens a
    real path via `read`→`openBuffer` with no redundant `write` on open. All three new-file
    entries now reserve eagerly (see Spec amendment).
@@ -74,10 +76,15 @@ entry points → no shared bufferKey" is thereby satisfiable by the single atomi
    if a folder is selected, `parentOf(path)` if a file is selected, else `STORAGE_ROOT`.
 4. **In-place rename only in T1b-4**; cross-directory move is exclusively T1b-6 (drag).
 5. **Folder rename/move re-points every descendant open pane** (codex P1-2 / verified). New
-   bulk helper `remapPanesUnder(source, from, to)`: collect every open pane whose
-   `pane.content.filePath === from || .startsWith(from + '/')` across **editor + image-preview
-   + pdf-preview** kinds, then re-point each to `to + filePath.slice(from.length)` (panes +
-   their editor buffers). Single-file rename keeps using `performBufferRename`.
+   **pure** helper `remapPanesUnder(source, from, to)` — **does NOT touch the backend**: collect
+   every open pane whose `pane.content.filePath === from || .startsWith(from + '/')` across
+   **editor + image-preview + pdf-preview** kinds, then for each call
+   `renameEditorPanes(source, oldPath, newPath)` + (editor only) `renameBuffer(oldKey, newKey,
+   metadata)`. A single file = one iteration. The lone `backend.rename` lives **only** in the
+   caller (`renameStorageEntry` / `moveStorageEntry`), called **exactly once** before
+   `remapPanesUnder` — so file and folder share one path and there is no double-rename. This
+   replaces the old `performBufferRename` (`storage-actions.ts:33-48`), whose embedded
+   `backend.rename` is hoisted into the caller during the refactor.
 6. **Descendant guard matches on `pane.content.filePath`, NOT `bufferKey`** (codex P2-4):
    `p === target || p.startsWith(target + '/')` (the trailing slash avoids `/buffer/a` matching
    `/buffer/ab`). Derive `bufferKey` from `filePath` only when looking up a dirty buffer.
@@ -115,11 +122,19 @@ T1b-4 (rename + bulk re-point) → T1b-5 (delete) → **T1b-6a** (pure move help
   - `storage-actions.ts:58` `createStorageFile(targetDir)` → `createUniqueInAppFile(targetDir,
     'md')`.
   - `EditorPane.tsx:424` new buffer → `createUniqueInAppFile(STORAGE_ROOT, 'md')` then open.
-  - `EditorNewTabSection.tsx:18-70` → `.txt`/`.md` buttons call `createUniqueInAppFile(
-    STORAGE_ROOT, ext)`, open the **real** path (no `untitled:`). Remove `nextUntitledName`.
-    If `UntitledDocumentState`/`untitled:` handling becomes fully unreferenced after this,
-    note it (de,ad-code removal is a **separate cleanup commit**, not folded here, to keep the
-    diff surgical — verify references first via grep).
+  - `EditorNewTabSection.tsx:18-70` → `.txt`/`.md` buttons map to bare ext and call
+    `createUniqueInAppFile(STORAGE_ROOT, ext)`, open the **real** path (no `untitled:`). Remove
+    only the `nextUntitledName` **producer**.
+    - **MUST NOT touch the `untitled:` runtime contract** (codex R2 P2-3): `EditorPane` still
+      loads/renames/saves existing `untitled:` panes (`EditorPane.tsx:161,236,330`) and
+      `useTabStore` **persists** pane content (`useTabStore.ts:432`), so users may already have
+      persisted `untitled:` tabs. Those must keep working. `UntitledDocumentState` /
+      `renameEditorPanes` `options.untitled` / `renameEditorPanesInLayout`'s untitled branch
+      stay intact. Any dead-code removal is a **separate issue** requiring a persisted-tab
+      migration or explicit compat strategy — out of scope for this PR.
+    - Pre-change grep to scope the producer vs consumers: `rg -n "nextUntitledName|
+      UntitledDocumentState|untitledStoragePath|untitledSuggestedName|hasBeenRenamed|untitled:"
+      spa/src/{components,lib,stores,types}`.
 - **Tests** (`fs-backend-inapp.test.ts`, `inapp-namer.test.ts`, `EditorNewTabSection.test.tsx`):
   - T2-1 `createUnique` → `/buffer/Untitled.md` on empty dir; `.txt` ext honored.
   - T2-2 collision: seed `/buffer/Untitled.md` → `/buffer/Untitled-1.md`.
@@ -142,13 +157,17 @@ T1b-4 (rename + bulk re-point) → T1b-5 (delete) → **T1b-6a** (pure move help
 - **Dep:** T1b-0, T1b-2.
 
 ### T1b-4 — In-place rename (file + folder) + bulk descendant re-point
-- **storage-actions.ts** `renameStorageEntry(from, newName)`: compute `to = join(parentOf(
-  from), newName)`; **pre-check `stat(to)` before any mutation** → `{kind:'exists'}`; then
-  `backend.rename(from, to)` (recursive re-key via T1b-1).
-- **New** `remapPanesUnder(source, from, to)` (decision 5/6): for files, equals current
-  `performBufferRename`; for folders, enumerate open panes where `filePath === from ||
-  startsWith(from+'/')` (editor/image/pdf) and re-point each pane + its buffer to the mapped
-  path. `renameStorageEntry` dispatches file→`performBufferRename`, folder→`remapPanesUnder`.
+- **storage-actions.ts** `renameStorageEntry(from, newName)` — **one uniform path for file and
+  folder** (no branch, no double-rename): (1) `to = join(parentOf(from), newName)`; (2)
+  pre-check `stat(to)` before any mutation → `{kind:'exists'}`; (3) **exactly one**
+  `await backend.rename(from, to)` (recursive re-key via T1b-1); (4) `remapPanesUnder(source,
+  from, to)`.
+- **Refactor** the existing `performBufferRename` (`storage-actions.ts:33-48`) into the **pure**
+  `remapPanesUnder(source, from, to)` of decision 5 — it performs only pane+buffer remap and
+  **no** `backend.rename` (that call is hoisted up into step 3). For a single file this is one
+  iteration carrying the language metadata as before; for a folder it iterates every descendant
+  pane (`filePath === from || startsWith(from+'/')`, editor/image/pdf). This is the **only**
+  remaining caller-side backend mutation point for rename.
 - **StoragePane.tsx** `handleRenameConfirm`: works for file or folder selection; surface
   `exists` inline; on ok `refresh()` + re-select by new path.
 - **Tests**:

--- a/docs/specs/2026-06-28-storage-filemanager-1b-plan.md
+++ b/docs/specs/2026-06-28-storage-filemanager-1b-plan.md
@@ -1,0 +1,170 @@
+# Storage Phase 1b — Detailed Plan (Nested CRUD + recursive folder move)
+
+Base: alpha.300. Worktree `storage-filemanager-1b`. Spec:
+`2026-06-27-storage-filemanager-spec.md` §"Phase 1b" + AC-1b.
+Parent plan outline: `2026-06-27-storage-filemanager-plan.md` §"Phase 1b".
+
+T1b-1 (backend recursive rename/move) is **already shipped** in this worktree
+(`402c05ce`, `InAppBackend.rename` re-keys every `from/`-prefixed descendant in one
+IDB tx + full collision scan; 23 backend tests green). This plan covers **T1b-2 … T1b-6**.
+
+## Existing groundwork (from 1a + T1b-1) — reused, not rebuilt
+
+- `InAppBackend` (`spa/src/lib/fs-backend-inapp.ts`): `write` (auto-creates parent dirs in
+  one tx), `mkdir`, `delete(path, recursive)` (prefix-sweep), **`rename(from,to)` recursive
+  re-key** (T1b-1), `list` (direct children), `stat`.
+- `storage-paths.ts`: `STORAGE_ROOT='/buffer'`, `join`, `parentOf`, `basename`,
+  `relativeToRoot`, `isUnderRoot`.
+- `storage-tree.ts`: `TreeNode {path,name,isDir,size,children?}`, `listTreeUnder`.
+- `useStorageTree` hook: `{tree,loading,error,expanded,refresh,toggle}` (full-path identity).
+- `StoragePane.tsx` (271): toolbar + `StorageTree` + Backups placeholder; `handleNew`/
+  `handleRenameConfirm`/`handleDelete`/`handleOpen`.
+- `storage-actions.ts` (183): `createStorageFile`, `renameStorageEntry(from,newName)` (stat
+  collision guard :87-92), `deleteStorageEntries(targets,t)` (locked-tab refusal :139 +
+  dirty-pane confirm :145-154).
+- dnd-kit already a dep (`@dnd-kit/core/sortable/utilities`); pattern in
+  `RegionManager.tsx:63-76` (PointerSensor distance:5, DndContext+SortableContext).
+
+## Design decisions (resolve before impl — flag any reversal in review)
+
+1. **#854 reservation is atomic at the IDB layer, not a name scan.** Root cause: EditorPane
+   (`EditorPane.tsx:424`) and StoragePane (`storage-actions.ts:58`) both name via
+   `Untitled-${Date.now()}.md` → same-ms double-click collides; EditorNewTabSection
+   (`EditorNewTabSection.tsx:18-52`) scans only one level. A scan-then-write namer is still
+   racy. **Fix:** add `InAppBackend.createUnique(dir, baseName, ext): Promise<string>` that
+   loops `store.add()` (IDB `add` throws `ConstraintError` if the key exists) incrementing
+   the suffix until the empty file is created, returning the reserved path. `add` (not `put`)
+   is the single serialization point, so two concurrent callers from *any* entry point get
+   two distinct keys. `createUniqueInAppFile(dir)` in a new `inapp-namer.ts` wraps it.
+2. **Consequence: a new untitled file now persists immediately** (empty entry written on
+   create) instead of being purely in-memory until first save. This is intended — the file
+   is what the tree manages, and it makes the bufferKey real at creation. Editor open flow
+   for the 3 entry points opens the reserved path. (Verify no double-write/overwrite of the
+   reserved empty file clobbers an immediately-typed buffer — open must `read` not `write`.)
+3. **In-place rename only in T1b-4** (basename change within the same parent, files + folders).
+   Cross-directory move is exclusively T1b-6 (drag). Keeps rename UI single-axis.
+4. **Folder-aware guards in T1b-5**: a folder delete/rename must evaluate locked/dirty against
+   **every descendant's** open pane, not just the folder path. Compute the affected path set
+   = target + all open panes whose bufferKey is under `target/`.
+5. **One PR** (`feat(storage): Phase 1b nested CRUD + folder move`), task-per-commit, TDD.
+
+## Tasks
+
+Order: T1b-2 (namer, foundation) → T1b-3 (mkdir) → T1b-4 (rename) → T1b-5 (delete) →
+T1b-6 (drag move). Each: failing tests first, then impl, suite+lint+build green.
+
+### T1b-2 — Unified `createUniqueInAppFile` namer + wire 3 entry points
+- **Backend** `fs-backend-inapp.ts`: add `createUnique(dir, baseName='Untitled', ext='md'):
+  Promise<string>`. Loop: candidate = `Untitled`, `Untitled-1`, `Untitled-2`…; `store.add({
+  path: join(dir, name+'.'+ext), content: empty, mtime })`; on `ConstraintError` increment;
+  on success return the path. Bounded retry (e.g. 10_000) → throw if exhausted.
+- **lib** new `spa/src/lib/inapp-namer.ts`: `createUniqueInAppFile(dir=STORAGE_ROOT):
+  Promise<string>` = `getFsBackend('inapp').createUnique(dir)`. Single namer.
+- **Wire** all 3 entry points to call it (replacing local naming):
+  - `storage-actions.ts:58` `createStorageFile` → `createUniqueInAppFile(targetDir)`.
+  - `EditorPane.tsx:424` new buffer → `createUniqueInAppFile(STORAGE_ROOT)` then open path.
+  - `EditorNewTabSection.tsx:18-52` `nextUntitledName` → replaced by `createUniqueInAppFile`.
+- **Tests** (`fs-backend-inapp.test.ts` + `inapp-namer.test.ts`):
+  - T2-1 `createUnique` returns `/buffer/Untitled.md` on empty dir.
+  - T2-2 collision: pre-seed `/buffer/Untitled.md` → returns `/buffer/Untitled-1.md`.
+  - T2-3 **#854 race**: `await Promise.all([createUniqueInAppFile(), createUniqueInAppFile()])`
+    → two **distinct** paths, two entries in `list`, no shared key.
+  - T2-4 reserved file is empty + appears in `listTreeUnder`.
+  - T2-5 entry-point parity: storage-actions create + EditorNewTabSection both go through the
+    namer (assert no `Date.now()` / local scan remains — grep-level or behavioral).
+- **Dep:** none.
+
+### T1b-3 — New Folder (mkdir) UI
+- **storage-actions.ts**: `createStorageFolder(dir, t): Promise<{path}|{error}>` — unique
+  folder name via a small `createUniqueDirName` (scan `list(dir)` for `New Folder`,
+  `New Folder 1`…; mkdir is not an `add`-race surface like files since folders are rarely
+  rapid-doubled — a scan + `mkdir` is acceptable; if review wants symmetry, route through an
+  `add`-based reserve too).
+- **StoragePane.tsx**: toolbar "New Folder" button → `createStorageFolder(selectedDir||ROOT)`
+  → `refresh()` → auto-expand + select the new folder. `selectedDir` = selected node's dir
+  (if a file is selected, its `parentOf`; if a folder, itself; else ROOT).
+- **Tests** (`storage-actions.test.ts` + `StoragePane.test.tsx`):
+  - T3-1 mkdir creates a folder that shows in the tree (`isDir`).
+  - T3-2 new file created **under** the selected folder lands at `folder/Untitled.md`
+    (accepts children — proves dir is real).
+  - T3-3 folder name collision increments (`New Folder 1`).
+- **Dep:** T1b-2 (uses `createUniqueInAppFile(dir)` to prove children land under it).
+
+### T1b-4 — Rename (in-place) for files + folders, collision pre-check
+- **storage-actions.ts** `renameStorageEntry(from, newName)`: already stat-guards file
+  collisions. Extend: (a) compute `to = join(parentOf(from), newName)`; (b) **pre-check before
+  any mutation** — `stat(to)` exists → `{kind:'exists'}` (folders: also reject if `to` has any
+  `to/` descendant, but `rename`'s own scan covers it — keep the early `stat` as the UI-facing
+  guard); (c) call `backend.rename(from, to)` (recursive re-key for folders via T1b-1).
+- **StoragePane.tsx** `handleRenameConfirm`: works for both file and folder selection;
+  surface `exists` as inline error; on ok `refresh()` + re-select renamed node by new path.
+- **Tests**:
+  - T4-1 file rename to a free name: old path gone, new present, content intact, mtime kept.
+  - T4-2 file rename to an **existing** path: refused, **no backend mutation** (assert source
+    untouched + target untouched).
+  - T4-3 **folder rename moves ≥2 nested descendants** (AC-1b): `a/` with `a/b.md`, `a/c/d.md`
+    → rename `a`→`z`: `z/b.md`+`z/c/d.md` present, `a/*` gone, contents intact.
+  - T4-4 folder rename onto an existing folder name refused before mutation.
+- **Dep:** T1b-1 (folder recursive rename).
+
+### T1b-5 — Recursive delete with folder-aware locked/dirty guards
+- **storage-actions.ts** `deleteStorageEntries(targets, t)`: today checks open panes whose
+  bufferKey == a target. Extend the affected-pane computation to **descendants**: a pane is
+  affected if its bufferKey === target **or** startsWith `target + '/'`. Locked-descendant →
+  refuse; dirty-descendant → confirm (reuse `delete_dirty_confirm`). Then
+  `backend.delete(path, true)` for folders (prefix-sweep) / `delete(path)` for files.
+- **StoragePane.tsx** `handleDelete`: unchanged call site; close any open panes for the
+  deleted path set after success (no resurrection — pair with `useTabStore.closePane` like 1a's
+  guard) + `refresh()`.
+- **Tests**:
+  - T5-1 folder delete removes folder + all descendants (`list` empty under it).
+  - T5-2 delete a folder whose descendant is open in a **locked** tab → refused, nothing
+    deleted.
+  - T5-3 delete a folder whose descendant is **dirty** → confirm prompt fires; on confirm
+    deletes, on cancel no-op.
+  - T5-4 file delete (1a regression) still guarded + works.
+- **Dep:** none (extends 1a; independent of T1b-2/3/4).
+
+### T1b-6 — Drag-and-drop move across folders
+- **StorageTree/StorageRow**: wrap rows with dnd-kit (`useSortable`/`useDraggable` for source,
+  `useDroppable` for folder rows + the root). `DndContext` in `StoragePane` with
+  `PointerSensor {distance:5}` (mirror `RegionManager`). Drop a node onto a **folder** (or root):
+  `to = join(targetDir, basename(from))`; reject drop onto self / own descendant / same parent
+  (no-op); collision pre-check `stat(to)` → inline error; else `backend.rename(from, to)`
+  (recursive for folders via T1b-1) → `refresh()`.
+- **Move helper** `moveStorageEntry(from, targetDir)` in storage-actions (shares the rename
+  collision + guard path; reuses T1b-5's descendant logic for moving a folder that contains
+  open panes — moving re-keys, so open panes' bufferKeys must be updated like 1a rename did,
+  via `renameEditorPanes`/`renameBuffer`).
+- **Tests**:
+  - T6-1 drag file into a folder: old path gone, new present under folder, content intact.
+  - T6-2 drag folder into another folder: all descendants re-keyed (AC-1b move).
+  - T6-3 drop onto self / own descendant / current parent → no-op (no mutation).
+  - T6-4 drop where target name exists → refused (inline error), no mutation.
+  - T6-5 moving a folder containing an open pane re-points the pane's bufferKey (no stale
+    buffer / no resurrection).
+- **Dep:** T1b-1 (move), T1b-4 (collision pre-check shared), T1b-5 (descendant pane logic).
+
+## Verification per task
+`cd spa && npx vitest run` (full suite green; 1a baseline 3397 + new), `pnpm run lint`,
+`pnpm run build` (tsc). Codex sandbox has no network → main session runs install/test/lint/
+build manually (feedback_codex_sandbox_no_install).
+
+## AC-1b coverage map
+| AC-1b clause | Task / tests |
+|---|---|
+| Folder rename/move re-keys all descendants (≥2 nested) | T1b-4 T4-3, T1b-6 T6-2 |
+| mkdir creates folder that accepts children | T1b-3 T3-1/T3-2 |
+| File rename to existing path refused before mutation | T1b-4 T4-2 |
+| Folder delete removes descendants; locked refused; dirty confirms | T1b-5 T5-1/T5-2/T5-3 |
+| Drag file into folder moves it (old gone/new present/intact) | T1b-6 T6-1 |
+| Rapid double new-file from any of 3 entry points → no shared bufferKey | T1b-2 T2-3/T2-5 |
+
+## Out of scope (Phase 1c)
+Upload (picker + OS-file drag-drop), download/export, binary open-disposition, size cap +
+quota banner. Drag-and-drop in 1b is **intra-tree move only**, not OS-file ingest.
+
+## Follow-ups to watch (from 1a review, may resurface)
+- onBufferSwitch dirty-guard semantics now moot under open-or-focus (1a follow-up a) — if a
+  test touches it during rename/move, prefer removing the redundant confirm over patching.
+- #625 manage-from-secondary-pane duplicate tab (pre-existing, spec §7) — do not regress.

--- a/spa/src/components/FileTreeView.test.tsx
+++ b/spa/src/components/FileTreeView.test.tsx
@@ -28,6 +28,7 @@ const mockBackend = {
   delete: vi.fn(),
   rename: vi.fn(),
   createUnique: vi.fn(),
+  mkdirUnique: vi.fn(),
 }
 
 beforeEach(() => {

--- a/spa/src/components/FileTreeView.test.tsx
+++ b/spa/src/components/FileTreeView.test.tsx
@@ -27,6 +27,7 @@ const mockBackend = {
   mkdir: vi.fn(),
   delete: vi.fn(),
   rename: vi.fn(),
+  createUnique: vi.fn(),
 }
 
 beforeEach(() => {

--- a/spa/src/components/editor/EditorNewTabSection.test.tsx
+++ b/spa/src/components/editor/EditorNewTabSection.test.tsx
@@ -4,99 +4,87 @@ import { EditorNewTabSection } from './EditorNewTabSection'
 import { useEditorStore } from '../../stores/useEditorStore'
 import { useTabStore } from '../../stores/useTabStore'
 
-const getFsBackendMock = vi.hoisted(() => vi.fn())
+const createUniqueInAppFileMock = vi.hoisted(() => vi.fn())
 
-vi.mock('../../lib/fs-backend', () => ({
-  getFsBackend: getFsBackendMock,
+vi.mock('../../lib/inapp-namer', () => ({
+  createUniqueInAppFile: createUniqueInAppFileMock,
 }))
 
-describe('EditorNewTabSection', () => {
+describe('EditorNewTabSection (eager reserved files — T1b-2)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     useEditorStore.getState().clearAllBuffers()
     useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
   })
 
-  it('creates an untitled markdown document without writing to backend', async () => {
-    const backend = {
-      list: vi.fn(async () => []),
-      write: vi.fn(),
-    }
+  // T2-5: New Markdown reserves a REAL path (not an `untitled:` virtual path).
+  it('New Markdown reserves a real /buffer path and opens it (no untitled:)', async () => {
+    createUniqueInAppFileMock.mockResolvedValue('/buffer/Untitled.md')
     const onSelect = vi.fn()
-    getFsBackendMock.mockReturnValue(backend)
 
     render(<EditorNewTabSection onSelect={onSelect} />)
-
     fireEvent.click(screen.getByRole('button', { name: 'New Markdown' }))
 
     await waitFor(() => {
       expect(onSelect).toHaveBeenCalledWith({
         kind: 'editor',
         source: { type: 'inapp' },
-        filePath: 'untitled:Untitled',
-        untitled: {
-          name: 'Untitled',
-          suggestedExtension: '.md',
-          hasBeenRenamed: false,
-        },
+        filePath: '/buffer/Untitled.md',
       })
     })
-
-    expect(backend.write).not.toHaveBeenCalled()
+    expect(createUniqueInAppFileMock).toHaveBeenCalledWith('/buffer', 'md')
+    const content = onSelect.mock.calls[0][0]
+    expect(content.filePath.startsWith('untitled:')).toBe(false)
+    expect(content.untitled).toBeUndefined()
   })
 
-  it('uses the next readable untitled name when a draft with the same template exists', async () => {
-    const backend = {
-      list: vi.fn(async () => []),
-    }
+  // T2-5: New File maps the button label to the bare `txt` ext.
+  it('New File reserves a real .txt path via the bare txt extension', async () => {
+    createUniqueInAppFileMock.mockResolvedValue('/buffer/Untitled.txt')
     const onSelect = vi.fn()
-    getFsBackendMock.mockReturnValue(backend)
-
-    useTabStore.setState({
-      tabs: {
-        'tab-1': {
-          id: 'tab-1',
-          pinned: false,
-          locked: false,
-          createdAt: 1,
-          layout: {
-            type: 'leaf',
-            pane: {
-              id: 'pane-1',
-              content: {
-                kind: 'editor',
-                source: { type: 'inapp' },
-                filePath: 'untitled:Untitled',
-                untitled: {
-                  name: 'Untitled',
-                  suggestedExtension: '.txt',
-                  hasBeenRenamed: false,
-                },
-              },
-            },
-          },
-        },
-      },
-      tabOrder: ['tab-1'],
-      activeTabId: 'tab-1',
-      visitHistory: [],
-    })
 
     render(<EditorNewTabSection onSelect={onSelect} />)
-
     fireEvent.click(screen.getByRole('button', { name: 'New File' }))
 
     await waitFor(() => {
       expect(onSelect).toHaveBeenCalledWith({
         kind: 'editor',
         source: { type: 'inapp' },
-        filePath: 'untitled:Untitled-1',
-        untitled: {
-          name: 'Untitled-1',
-          suggestedExtension: '.txt',
-          hasBeenRenamed: false,
-        },
+        filePath: '/buffer/Untitled.txt',
       })
     })
+    expect(createUniqueInAppFileMock).toHaveBeenCalledWith('/buffer', 'txt')
+  })
+
+  // T2-5: rapid double-click → two distinct reserved paths, never a shared key.
+  it('rapid double new-file gets distinct reserved paths (no shared key)', async () => {
+    createUniqueInAppFileMock
+      .mockResolvedValueOnce('/buffer/Untitled.md')
+      .mockResolvedValueOnce('/buffer/Untitled-1.md')
+    const onSelect = vi.fn()
+
+    render(<EditorNewTabSection onSelect={onSelect} />)
+    const btn = screen.getByRole('button', { name: 'New Markdown' })
+    fireEvent.click(btn)
+    fireEvent.click(btn)
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledTimes(2)
+    })
+    const paths = onSelect.mock.calls.map((c) => c[0].filePath)
+    expect(new Set(paths).size).toBe(2)
+  })
+
+  it('does not call onSelect when the namer fails (backend unavailable)', async () => {
+    createUniqueInAppFileMock.mockRejectedValue(new Error('InApp backend unavailable'))
+    const onSelect = vi.fn()
+
+    render(<EditorNewTabSection onSelect={onSelect} />)
+    fireEvent.click(screen.getByRole('button', { name: 'New Markdown' }))
+
+    await waitFor(() => {
+      expect(createUniqueInAppFileMock).toHaveBeenCalled()
+    })
+    expect(onSelect).not.toHaveBeenCalled()
   })
 })

--- a/spa/src/components/editor/EditorNewTabSection.tsx
+++ b/spa/src/components/editor/EditorNewTabSection.tsx
@@ -1,10 +1,8 @@
 import { useCallback } from 'react'
 import { FilePlus, FileText } from '@phosphor-icons/react'
-import { getFsBackend } from '../../lib/fs-backend'
-import { scanPaneTree } from '../../lib/pane-tree'
 import { useI18nStore } from '../../stores/useI18nStore'
-import { useTabStore } from '../../stores/useTabStore'
-import { STORAGE_ROOT, isUnderRoot, relativeToRoot } from '../../lib/storage-paths'
+import { createUniqueInAppFile } from '../../lib/inapp-namer'
+import { STORAGE_ROOT } from '../../lib/storage-paths'
 import type { PaneContent } from '../../types/tab'
 import type { FileSource } from '../../types/fs'
 
@@ -15,76 +13,36 @@ interface Props {
 export function EditorNewTabSection({ onSelect }: Props) {
   const t = useI18nStore((s) => s.t)
 
-  const nextUntitledName = useCallback(async (suggestedExtension: '.txt' | '.md') => {
+  // T1b-2: eager reservation. Both buttons map their label to a bare extension
+  // (`'txt' | 'md'`, no leading dot — the namer forms the path) and reserve a
+  // real `/buffer/Untitled[-N].<ext>` file via the unified atomic namer, then
+  // open that real path. The old lazy in-memory `untitled:` buffer producer is
+  // gone; `untitled:` is no longer minted here (its runtime load/rename/save
+  // contract in EditorPane stays intact for any already-persisted tabs).
+  const createFile = useCallback(async (ext: 'txt' | 'md') => {
     const source: FileSource = { type: 'inapp' }
-    const backend = getFsBackend(source)
-    if (!backend) return null
-
-    const usedFilenames = new Set<string>()
-
-    for (const tab of Object.values(useTabStore.getState().tabs)) {
-      scanPaneTree(tab.layout, (pane) => {
-        if (pane.content.kind !== 'editor' || pane.content.source.type !== 'inapp') return
-        if (pane.content.untitled) {
-          const suffix = pane.content.untitled.hasBeenRenamed ? '' : pane.content.untitled.suggestedExtension
-          usedFilenames.add(`${pane.content.untitled.name}${suffix}`)
-          return
-        }
-        const path = pane.content.filePath
-        if (isUnderRoot(path)) {
-          usedFilenames.add(relativeToRoot(path))
-        }
-      })
-    }
-
-    const entries = await backend.list(STORAGE_ROOT)
-    for (const entry of entries) {
-      if (!entry.isDir) usedFilenames.add(entry.name)
-    }
-
-    let n = 0
-    let name = 'Untitled'
-    while (usedFilenames.has(`${name}${suggestedExtension}`)) {
-      n += 1
-      name = `Untitled-${n}`
-    }
-
-    return name
-  }, [])
-
-  const createFile = useCallback(async (suggestedExtension: '.txt' | '.md') => {
-    const source: FileSource = { type: 'inapp' }
-
-    const name = await nextUntitledName(suggestedExtension)
-    if (!name) {
-      console.error('[editor] InApp backend not available')
+    let filePath: string
+    try {
+      filePath = await createUniqueInAppFile(STORAGE_ROOT, ext)
+    } catch (err) {
+      console.error('[editor] failed to reserve a new file', err)
       return
     }
-
-    onSelect({
-      kind: 'editor',
-      source,
-      filePath: `untitled:${name}`,
-      untitled: {
-        name,
-        suggestedExtension,
-        hasBeenRenamed: false,
-      },
-    } as PaneContent)
-  }, [nextUntitledName, onSelect])
+    onSelect({ kind: 'editor', source, filePath })
+  }, [onSelect])
 
   return (
     <div className="flex gap-2">
       <button
         className="flex items-center gap-2 px-4 py-2 rounded-lg border border-border-subtle bg-surface-secondary hover:bg-surface-hover text-text-primary text-sm transition-colors"
-        onClick={() => createFile('.txt')}
+        onClick={() => createFile('txt')}
       >
         <FilePlus size={16} />
         {t('editor.new_file')}
       </button>
       <button
         className="flex items-center gap-2 px-4 py-2 rounded-lg border border-border-subtle bg-surface-secondary hover:bg-surface-hover text-text-primary text-sm transition-colors"
-        onClick={() => createFile('.md')}
+        onClick={() => createFile('md')}
       >
         <FileText size={16} />
         {t('editor.new_markdown')}

--- a/spa/src/components/editor/EditorPane.test.tsx
+++ b/spa/src/components/editor/EditorPane.test.tsx
@@ -33,6 +33,12 @@ vi.mock('../../lib/open-in-app-file', () => ({
   openInAppFile: (...args: unknown[]) => openInAppFileMock(...args),
 }))
 
+// D2: the "new buffer" entry point reserves through the unified atomic namer.
+const createUniqueInAppFileMock = vi.hoisted(() => vi.fn())
+vi.mock('../../lib/inapp-namer', () => ({
+  createUniqueInAppFile: createUniqueInAppFileMock,
+}))
+
 // Path-aware backend so the chip click drives `listTreeUnder`.
 const listMock = vi.fn()
 vi.mock('../../lib/fs-backend', () => ({
@@ -125,5 +131,36 @@ describe('EditorPane — breadcrumb quick-switch (T6)', () => {
 
     expect(openInAppFileMock).toHaveBeenCalledTimes(1)
     expect(openInAppFileMock).toHaveBeenCalledWith('/buffer/root.md', WS_ID)
+  })
+
+  // D2 (AC-1b clause 6): the breadcrumb "new buffer" reserves through the atomic
+  // namer; two reservations get distinct real paths — never a shared key.
+  it('D2: new buffer routes through createUniqueInAppFile with distinct paths (no shared key)', async () => {
+    // Empty buffer dir → the popover renders its "new buffer" affordance.
+    listMock.mockResolvedValue([])
+    createUniqueInAppFileMock
+      .mockResolvedValueOnce('/buffer/Untitled.md')
+      .mockResolvedValueOnce('/buffer/Untitled-1.md')
+    const setPaneContentSpy = vi
+      .spyOn(useTabStore.getState(), 'setPaneContent')
+      .mockImplementation(() => {})
+    renderPane()
+
+    // First reservation.
+    fireEvent.click(screen.getByRole('button', { name: /Purdex/ }))
+    const firstBtn = await waitFor(() => screen.getByTestId('breadcrumb-popover-new-buffer'))
+    fireEvent.click(firstBtn)
+    await waitFor(() => expect(setPaneContentSpy).toHaveBeenCalledTimes(1))
+
+    // Second reservation (reopen the popover; the first dismissed it).
+    fireEvent.click(screen.getByRole('button', { name: /Purdex/ }))
+    const secondBtn = await waitFor(() => screen.getByTestId('breadcrumb-popover-new-buffer'))
+    fireEvent.click(secondBtn)
+    await waitFor(() => expect(setPaneContentSpy).toHaveBeenCalledTimes(2))
+
+    expect(createUniqueInAppFileMock).toHaveBeenCalledWith('/buffer', 'md')
+    const filePaths = setPaneContentSpy.mock.calls.map((c) => (c[2] as { filePath: string }).filePath)
+    expect(filePaths).toEqual(['/buffer/Untitled.md', '/buffer/Untitled-1.md'])
+    expect(new Set(filePaths).size).toBe(2)
   })
 })

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -14,7 +14,8 @@ import { EditorStatusBar } from './EditorStatusBar'
 import { RenamePopover } from '../RenamePopover'
 import { findPane } from '../../lib/pane-tree'
 import { bufferKey } from '../../lib/editor-buffer-key'
-import { STORAGE_ROOT, join } from '../../lib/storage-paths'
+import { STORAGE_ROOT } from '../../lib/storage-paths'
+import { createUniqueInAppFile } from '../../lib/inapp-namer'
 import type { FileSource } from '../../types/fs'
 import type { UntitledDocumentState } from '../../types/tab'
 import {
@@ -421,10 +422,14 @@ function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { pan
           const currentBuf = useEditorStore.getState().buffers[currentKey]
           if (currentBuf?.isDirty && !window.confirm(t('editor.buffers.confirm_switch_dirty'))) return
 
-          const path = join(STORAGE_ROOT, `Untitled-${Date.now()}.md`)
-          const backend = getFsBackend({ type: 'inapp' })
-          if (!backend) return
-          await backend.write(path, new Uint8Array(0))
+          // Eager unified namer (#854): atomically reserve a unique empty file
+          // (collision-free even on a rapid double-click) and open its real path.
+          let path: string
+          try {
+            path = await createUniqueInAppFile(STORAGE_ROOT, 'md')
+          } catch {
+            return
+          }
           const tabId = findTabIdForPane(paneId)
           if (!tabId) return
           useTabStore.getState().setPaneContent(tabId, paneId, {

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -109,6 +109,7 @@ function createBackend(): FsBackend & {
     delete: vi.fn(),
     rename: vi.fn(),
     createUnique: vi.fn(),
+    mkdirUnique: vi.fn(),
   } as FsBackend & {
     read: ReturnType<typeof vi.fn>
     write: ReturnType<typeof vi.fn>

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -108,6 +108,7 @@ function createBackend(): FsBackend & {
     mkdir: vi.fn(),
     delete: vi.fn(),
     rename: vi.fn(),
+    createUnique: vi.fn(),
   } as FsBackend & {
     read: ReturnType<typeof vi.fn>
     write: ReturnType<typeof vi.fn>

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -18,6 +18,7 @@ type MockBackend = {
   stat: Mock
   read: Mock
   mkdir: Mock
+  mkdirUnique: Mock
   createUnique: Mock
   id: 'inapp'
   label: string
@@ -294,6 +295,7 @@ beforeEach(() => {
     stat: vi.fn().mockResolvedValue({ size: 0, mtime: 0, isDirectory: false, isFile: true } as FileStat),
     read: vi.fn().mockResolvedValue(new Uint8Array(0)),
     mkdir: vi.fn().mockResolvedValue(undefined),
+    mkdirUnique: vi.fn().mockResolvedValue('/buffer/New Folder'),
     createUnique: vi.fn().mockResolvedValue('/buffer/Untitled.md'),
   }
 
@@ -1244,5 +1246,90 @@ describe('StoragePane', () => {
     fireEvent.doubleClick(folder)
     await screen.findByText('x.md') // expanded
     expect(openInAppFile).not.toHaveBeenCalled()
+  })
+
+  // --- New Folder (mkdir) + New File targetDir wiring (Phase 1b T1b-3) ---
+
+  it('T3-1: New Folder creates a directory (mkdirUnique) that appears in the tree', async () => {
+    const paths = new Map<string, { isDir: boolean; size: number }>()
+    mockBackend.list = pathAwareList(paths)
+    mockBackend.mkdirUnique = vi.fn(async (dir: string) => {
+      const path = `${dir}/New Folder`
+      paths.set(path, { isDir: true, size: 0 })
+      return path
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+    fireEvent.click(screen.getByTestId('toolbar-new-folder'))
+    await waitFor(() => {
+      // No selection → targets the storage root.
+      expect(mockBackend.mkdirUnique).toHaveBeenCalledWith('/buffer')
+    })
+    const row = await screen.findByTestId('buffer-row')
+    expect(row.getAttribute('data-path')).toBe('/buffer/New Folder')
+    expect(row.getAttribute('data-isdir')).toBe('true')
+    // The new folder is auto-selected.
+    expect(row.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('T3-2: a New File created with the new folder selected lands inside it (folder accepts children)', async () => {
+    const paths = new Map<string, { isDir: boolean; size: number }>()
+    mockBackend.list = pathAwareList(paths)
+    mockBackend.mkdirUnique = vi.fn(async (dir: string) => {
+      const path = `${dir}/New Folder`
+      paths.set(path, { isDir: true, size: 0 })
+      return path
+    })
+    mockBackend.createUnique = vi.fn(async (dir: string, base: string, ext: string) => {
+      const path = `${dir}/${base}.${ext}`
+      paths.set(path, { isDir: false, size: 0 })
+      return path
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+    // New Folder → auto-selected + auto-expanded.
+    fireEvent.click(screen.getByTestId('toolbar-new-folder'))
+    await screen.findByTestId('buffer-row') // tree rebuilt → selection resolves to the folder
+    // New File now targets the selected folder (T1b-0 wiring).
+    fireEvent.click(screen.getByTestId('toolbar-new'))
+    await waitFor(() => {
+      expect(mockBackend.createUnique).toHaveBeenCalledWith('/buffer/New Folder', 'Untitled', 'md')
+    })
+    // The child file shows up under the (auto-expanded) folder.
+    await waitFor(() => {
+      const child = screen
+        .getAllByTestId('buffer-row')
+        .find((r) => r.getAttribute('data-path') === '/buffer/New Folder/Untitled.md')
+      expect(child).toBeTruthy()
+    })
+  })
+
+  it('T3-3: New Folder does not overwrite an existing folder — it increments the name', async () => {
+    // A "New Folder" already exists (e.g. from a prior session); creating
+    // another must not clobber it (decision 7 — add-reserve increments).
+    const paths = new Map<string, { isDir: boolean; size: number }>([
+      ['/buffer/New Folder', { isDir: true, size: 0 }],
+    ])
+    mockBackend.list = pathAwareList(paths)
+    mockBackend.mkdirUnique = vi.fn(async (dir: string) => {
+      let n = 0
+      let path = `${dir}/New Folder`
+      while (paths.has(path)) {
+        n += 1
+        path = `${dir}/New Folder ${n}`
+      }
+      paths.set(path, { isDir: true, size: 0 })
+      return path
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByTestId('buffer-row')
+    fireEvent.click(screen.getByTestId('toolbar-new-folder'))
+    await waitFor(() => {
+      const names = screen
+        .getAllByTestId('buffer-row')
+        .map((r) => r.getAttribute('data-path'))
+      expect(names).toContain('/buffer/New Folder')
+      expect(names).toContain('/buffer/New Folder 1')
+    })
   })
 })

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -1,12 +1,39 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { Mock } from 'vitest'
-import { useState } from 'react'
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { useState, type ReactNode } from 'react'
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
 import { StoragePane } from './StoragePane'
+import { computeMoveFromDragEnd } from './storage-actions'
 import { openInAppFile } from '../../../lib/open-in-app-file'
 import type { Pane, Tab } from '../../../types/tab'
 import type { FsBackend } from '../../../lib/fs-backend'
 import type { FileEntry, FileStat, FileSource } from '../../../types/fs'
+import type { DragEndEvent } from '@dnd-kit/core'
+
+// dnd-kit is mocked to a lightweight harness: DndContext captures the
+// `onDragEnd` callback so tests can drive a drop synthetically (real pointer
+// drag is impractical in jsdom — the plan endorses a pure handler +
+// onDragEnd-capture smoke). The draggable/droppable hooks become no-ops so rows
+// still render and the existing click/double-click suite keeps passing.
+let mockDragEnd: ((event: DragEndEvent) => void | Promise<void>) | undefined
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children, onDragEnd }: { children: ReactNode; onDragEnd: (e: DragEndEvent) => void }) => {
+    mockDragEnd = onDragEnd
+    return children
+  },
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => undefined,
+    transform: null,
+    isDragging: false,
+  }),
+  useDroppable: () => ({ setNodeRef: () => undefined, isOver: false }),
+  PointerSensor: class {},
+  useSensor: () => ({}),
+  useSensors: () => [],
+  closestCenter: () => [],
+}))
 
 // Mock fs-backend: list/write/delete/rename/read are per-test spies. The helper
 // below installs a fresh mock into the registry before each test.
@@ -227,6 +254,7 @@ function pathAwareList(paths: Map<string, { isDir: boolean; size: number }>): Mo
 
 beforeEach(() => {
   eventLog.length = 0
+  mockDragEnd = undefined
   setPaneContentSpy.mockReset()
   setActiveTabSpy.mockReset()
   addTabSpy.mockReset()
@@ -1394,6 +1422,144 @@ describe('StoragePane', () => {
         .map((r) => r.getAttribute('data-path'))
       expect(names).toContain('/buffer/New Folder')
       expect(names).toContain('/buffer/New Folder 1')
+    })
+  })
+
+  // --- Drag-and-drop move wiring (Phase 1b T1b-6b) ---
+
+  describe('computeMoveFromDragEnd (pure drop resolver)', () => {
+    it('maps a file dropped on a folder to {from, targetDir=folder}', () => {
+      expect(
+        computeMoveFromDragEnd({ id: '/buffer/a.md' }, { id: '/buffer/dir' }),
+      ).toEqual({ from: '/buffer/a.md', targetDir: '/buffer/dir' })
+    })
+
+    it('maps the root sentinel over-id to a STORAGE_ROOT targetDir', () => {
+      expect(
+        computeMoveFromDragEnd({ id: '/buffer/dir/a.md' }, { id: '/buffer' }),
+      ).toEqual({ from: '/buffer/dir/a.md', targetDir: '/buffer' })
+    })
+
+    it('returns null when there is no drop target (dropped on empty space)', () => {
+      expect(computeMoveFromDragEnd({ id: '/buffer/a.md' }, null)).toBeNull()
+    })
+  })
+
+  it('T6b-1: dragging a file onto a folder moves it into that folder and refreshes', async () => {
+    const paths = new Map<string, { isDir: boolean; size: number }>([
+      ['/buffer/dir', { isDir: true, size: 0 }],
+      ['/buffer/a.md', { isDir: false, size: 3 }],
+    ])
+    mockBackend.list = pathAwareList(paths)
+    mockBackend.stat.mockRejectedValue(new Error('not found')) // no collision
+    mockBackend.rename = vi.fn(async (from: string, to: string) => {
+      const meta = paths.get(from)!
+      paths.delete(from)
+      paths.set(to, meta)
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findAllByTestId('buffer-row')
+    expect(mockDragEnd).toBeTypeOf('function') // DndContext mounted + wired
+    await act(async () => {
+      await mockDragEnd!({
+        active: { id: '/buffer/a.md' },
+        over: { id: '/buffer/dir' },
+      } as unknown as DragEndEvent)
+    })
+    expect(mockBackend.rename).toHaveBeenCalledWith('/buffer/a.md', '/buffer/dir/a.md')
+    // Tree refreshed: the file now lives under the (expandable) folder.
+    await waitFor(() => {
+      const names = screen.getAllByTestId('buffer-row').map((r) => r.getAttribute('data-path'))
+      expect(names).not.toContain('/buffer/a.md')
+    })
+  })
+
+  it('T6b-2: dropping a nested file on the root region moves it to STORAGE_ROOT', async () => {
+    const paths = new Map<string, { isDir: boolean; size: number }>([
+      ['/buffer/dir', { isDir: true, size: 0 }],
+      ['/buffer/dir/a.md', { isDir: false, size: 3 }],
+    ])
+    mockBackend.list = pathAwareList(paths)
+    mockBackend.stat.mockRejectedValue(new Error('not found'))
+    mockBackend.rename = vi.fn(async (from: string, to: string) => {
+      const meta = paths.get(from)!
+      paths.delete(from)
+      paths.set(to, meta)
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findAllByTestId('buffer-row')
+    await act(async () => {
+      await mockDragEnd!({
+        active: { id: '/buffer/dir/a.md' },
+        over: { id: '/buffer' },
+      } as unknown as DragEndEvent)
+    })
+    expect(mockBackend.rename).toHaveBeenCalledWith('/buffer/dir/a.md', '/buffer/a.md')
+  })
+
+  it('T6b-3: dropping onto self or own descendant is a no-op (no backend mutation)', async () => {
+    const paths = new Map<string, { isDir: boolean; size: number }>([
+      ['/buffer/dir', { isDir: true, size: 0 }],
+      ['/buffer/dir/sub', { isDir: true, size: 0 }],
+    ])
+    mockBackend.list = pathAwareList(paths)
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findAllByTestId('buffer-row')
+    // onto self
+    await act(async () => {
+      await mockDragEnd!({
+        active: { id: '/buffer/dir' },
+        over: { id: '/buffer/dir' },
+      } as unknown as DragEndEvent)
+    })
+    // into own descendant
+    await act(async () => {
+      await mockDragEnd!({
+        active: { id: '/buffer/dir' },
+        over: { id: '/buffer/dir/sub' },
+      } as unknown as DragEndEvent)
+    })
+    expect(mockBackend.rename).not.toHaveBeenCalled()
+    expect(mockBackend.stat).not.toHaveBeenCalled()
+  })
+
+  it('T6b-3b: dropping onto an existing same-named entry surfaces the inline exists error', async () => {
+    const paths = new Map<string, { isDir: boolean; size: number }>([
+      ['/buffer/dir', { isDir: true, size: 0 }],
+      ['/buffer/dir/a.md', { isDir: false, size: 3 }],
+      ['/buffer/a.md', { isDir: false, size: 9 }],
+    ])
+    mockBackend.list = pathAwareList(paths)
+    // The target /buffer/dir/a.md already exists.
+    mockBackend.stat.mockImplementation(async (p: string) => {
+      if (paths.has(p)) return { size: 0, mtime: 0, isDirectory: false, isFile: true } as FileStat
+      throw new Error('not found')
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findAllByTestId('buffer-row')
+    await act(async () => {
+      await mockDragEnd!({
+        active: { id: '/buffer/a.md' },
+        over: { id: '/buffer/dir' },
+      } as unknown as DragEndEvent)
+    })
+    expect(mockBackend.rename).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.getByText('editor.buffers.rename_exists_error')).toBeTruthy()
+    })
+  })
+
+  it('T6b-4: click still selects and double-click still opens (no DnD regression)', async () => {
+    mockBackend.list.mockResolvedValue([
+      { name: 'a.md', isDir: false, size: 3 },
+    ] as FileEntry[])
+    render(<StoragePane pane={makePane()} isActive />)
+    const row = await screen.findByTestId('buffer-row')
+    fireEvent.click(row)
+    expect(row.getAttribute('aria-selected')).toBe('true')
+    fireEvent.doubleClick(row)
+    await waitFor(() => {
+      expect(openInAppFile).toHaveBeenCalledWith('/buffer/a.md', 'ws1')
     })
   })
 })

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -3,7 +3,6 @@ import type { Mock } from 'vitest'
 import { useState, type ReactNode } from 'react'
 import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
 import { StoragePane } from './StoragePane'
-import { computeMoveFromDragEnd } from './storage-actions'
 import { openInAppFile } from '../../../lib/open-in-app-file'
 import type { Pane, Tab } from '../../../types/tab'
 import type { FsBackend } from '../../../lib/fs-backend'
@@ -58,6 +57,12 @@ const eventLog: string[] = []
 vi.mock('../../../lib/fs-backend', () => ({
   getFsBackend: () => mockBackend as unknown as FsBackend,
   registerFsBackend: vi.fn(),
+  // The capability guards (codex H1) narrow a resolved backend; mirror the real
+  // typeof check against the mock backend.
+  supportsCreateUnique: (b: { createUnique?: unknown } | undefined) =>
+    typeof b?.createUnique === 'function',
+  supportsMkdirUnique: (b: { mkdirUnique?: unknown } | undefined) =>
+    typeof b?.mkdirUnique === 'function',
 }))
 
 // Open routing is the StoragePane's collaboration boundary: the pane resolves
@@ -671,8 +676,10 @@ describe('StoragePane', () => {
     tabStoreState.activeTabId = 'TA'
     render(<StoragePane pane={makePane()} isActive />)
     const rows = await screen.findAllByTestId('buffer-row')
-    fireEvent.click(rows[0]) // x.md
-    fireEvent.click(rows[1]) // y.md
+    fireEvent.click(rows[0]) // x.md (plain click selects only x.md)
+    // Modifier click adds y.md to the multi-selection (codex B5: plain click no
+    // longer accretes — additive multi-select needs cmd/ctrl/shift).
+    fireEvent.click(rows[1], { ctrlKey: true }) // + y.md
     fireEvent.click(screen.getByTestId('toolbar-delete'))
     await waitFor(() => {
       expect(screen.getByText('editor.buffers.delete_locked_refused')).toBeTruthy()
@@ -1426,24 +1433,10 @@ describe('StoragePane', () => {
   })
 
   // --- Drag-and-drop move wiring (Phase 1b T1b-6b) ---
-
-  describe('computeMoveFromDragEnd (pure drop resolver)', () => {
-    it('maps a file dropped on a folder to {from, targetDir=folder}', () => {
-      expect(
-        computeMoveFromDragEnd({ id: '/buffer/a.md' }, { id: '/buffer/dir' }),
-      ).toEqual({ from: '/buffer/a.md', targetDir: '/buffer/dir' })
-    })
-
-    it('maps the root sentinel over-id to a STORAGE_ROOT targetDir', () => {
-      expect(
-        computeMoveFromDragEnd({ id: '/buffer/dir/a.md' }, { id: '/buffer' }),
-      ).toEqual({ from: '/buffer/dir/a.md', targetDir: '/buffer' })
-    })
-
-    it('returns null when there is no drop target (dropped on empty space)', () => {
-      expect(computeMoveFromDragEnd({ id: '/buffer/a.md' }, null)).toBeNull()
-    })
-  })
+  // The pure resolver `computeMoveFromDragEnd` is unit-tested in
+  // `storage-dnd.test.ts`; the cases below drive the wired `onDragEnd` with a
+  // synthetic drop event whose `over.data.current.targetDir` mirrors what the
+  // row / root droppables publish (codex B1).
 
   it('T6b-1: dragging a file onto a folder moves it into that folder and refreshes', async () => {
     const paths = new Map<string, { isDir: boolean; size: number }>([
@@ -1463,7 +1456,7 @@ describe('StoragePane', () => {
     await act(async () => {
       await mockDragEnd!({
         active: { id: '/buffer/a.md' },
-        over: { id: '/buffer/dir' },
+        over: { id: '/buffer/dir', data: { current: { targetDir: '/buffer/dir' } } },
       } as unknown as DragEndEvent)
     })
     expect(mockBackend.rename).toHaveBeenCalledWith('/buffer/a.md', '/buffer/dir/a.md')
@@ -1491,7 +1484,7 @@ describe('StoragePane', () => {
     await act(async () => {
       await mockDragEnd!({
         active: { id: '/buffer/dir/a.md' },
-        over: { id: '/buffer' },
+        over: { id: '/buffer', data: { current: { targetDir: '/buffer' } } },
       } as unknown as DragEndEvent)
     })
     expect(mockBackend.rename).toHaveBeenCalledWith('/buffer/dir/a.md', '/buffer/a.md')
@@ -1509,14 +1502,14 @@ describe('StoragePane', () => {
     await act(async () => {
       await mockDragEnd!({
         active: { id: '/buffer/dir' },
-        over: { id: '/buffer/dir' },
+        over: { id: '/buffer/dir', data: { current: { targetDir: '/buffer/dir' } } },
       } as unknown as DragEndEvent)
     })
     // into own descendant
     await act(async () => {
       await mockDragEnd!({
         active: { id: '/buffer/dir' },
-        over: { id: '/buffer/dir/sub' },
+        over: { id: '/buffer/dir/sub', data: { current: { targetDir: '/buffer/dir/sub' } } },
       } as unknown as DragEndEvent)
     })
     expect(mockBackend.rename).not.toHaveBeenCalled()
@@ -1540,7 +1533,7 @@ describe('StoragePane', () => {
     await act(async () => {
       await mockDragEnd!({
         active: { id: '/buffer/a.md' },
-        over: { id: '/buffer/dir' },
+        over: { id: '/buffer/dir', data: { current: { targetDir: '/buffer/dir' } } },
       } as unknown as DragEndEvent)
     })
     expect(mockBackend.rename).not.toHaveBeenCalled()
@@ -1561,5 +1554,132 @@ describe('StoragePane', () => {
     await waitFor(() => {
       expect(openInAppFile).toHaveBeenCalledWith('/buffer/a.md', 'ws1')
     })
+  })
+
+  it('B1-UI: dropping a file onto a same-dir sibling is a no-op (targetDir = shared parent)', async () => {
+    // The sibling row publishes /buffer as its targetDir; the move then collapses
+    // to a no-op (targetDir === parentOf(from)) instead of bouncing to root.
+    mockBackend.list.mockResolvedValue([
+      { name: 'a.md', isDir: false, size: 3 },
+      { name: 'b.md', isDir: false, size: 3 },
+    ] as FileEntry[])
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findAllByTestId('buffer-row')
+    await act(async () => {
+      await mockDragEnd!({
+        active: { id: '/buffer/a.md' },
+        over: { id: '/buffer/b.md', data: { current: { targetDir: '/buffer' } } },
+      } as unknown as DragEndEvent)
+    })
+    expect(mockBackend.rename).not.toHaveBeenCalled()
+    expect(mockBackend.stat).not.toHaveBeenCalled()
+  })
+
+  // --- Folder Open guard (codex B3) ---
+
+  it('B3: selecting a folder disables the toolbar Open button (folders are not openable)', async () => {
+    mockBackend.list = pathAwareList(
+      new Map([
+        ['/buffer/dir', { isDir: true, size: 0 }],
+        ['/buffer/note.md', { isDir: false, size: 3 }],
+      ]),
+    )
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findAllByTestId('buffer-row')
+    const rowByPath = (p: string) =>
+      screen.getAllByTestId('buffer-row').find((r) => r.getAttribute('data-path') === p)!
+    const openBtn = screen.getByTestId('toolbar-open') as HTMLButtonElement
+    // Folder selected → Open disabled, and clicking it never routes to open.
+    fireEvent.click(rowByPath('/buffer/dir'))
+    expect(openBtn.disabled).toBe(true)
+    fireEvent.click(openBtn)
+    expect(openInAppFile).not.toHaveBeenCalled()
+    // A file selection re-enables Open.
+    fireEvent.click(rowByPath('/buffer/note.md'))
+    expect(openBtn.disabled).toBe(false)
+  })
+
+  // --- Selection model: plain click never toggles off (codex B5) ---
+
+  it('B5: a second plain click keeps the row selected (no toggle-off)', async () => {
+    mockBackend.list.mockResolvedValue([
+      { name: 'a.md', isDir: false, size: 3 },
+    ] as FileEntry[])
+    render(<StoragePane pane={makePane()} isActive />)
+    const row = await screen.findByTestId('buffer-row')
+    fireEvent.click(row)
+    expect(row.getAttribute('aria-selected')).toBe('true')
+    // Pre-fix this second plain click toggled the row OFF (the click→click→
+    // dblclick sequence stranded the action target); now it stays selected.
+    fireEvent.click(row)
+    expect(row.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('B5b: a modifier click toggles the row out of a multi-selection', async () => {
+    mockBackend.list.mockResolvedValue([
+      { name: 'a.md', isDir: false, size: 3 },
+      { name: 'b.md', isDir: false, size: 3 },
+    ] as FileEntry[])
+    render(<StoragePane pane={makePane()} isActive />)
+    const rows = await screen.findAllByTestId('buffer-row')
+    fireEvent.click(rows[0]) // a.md
+    fireEvent.click(rows[1], { metaKey: true }) // + b.md
+    expect(rows[0].getAttribute('aria-selected')).toBe('true')
+    expect(rows[1].getAttribute('aria-selected')).toBe('true')
+    // Modifier-click b.md again → toggles it back out.
+    fireEvent.click(rows[1], { metaKey: true })
+    expect(rows[1].getAttribute('aria-selected')).toBe('false')
+    expect(rows[0].getAttribute('aria-selected')).toBe('true')
+  })
+
+  // --- Same-name rename closes the popover without a backend rename (codex B4) ---
+
+  it('B4-UI: confirming a rename with the SAME name closes the popover and never calls backend.rename', async () => {
+    mockBackend.list.mockResolvedValue([
+      { name: 'foo.md', isDir: false, size: 10 },
+    ] as FileEntry[])
+    render(<StoragePane pane={makePane()} isActive />)
+    const row = await screen.findByTestId('buffer-row')
+    fireEvent.click(row)
+    fireEvent.click(screen.getByTestId('toolbar-rename'))
+    const input = await screen.findByTestId('rename-input')
+    expect((input as HTMLInputElement).value).toBe('foo.md')
+    // Confirm with the unchanged name.
+    fireEvent.click(screen.getByTestId('rename-confirm'))
+    await waitFor(() => {
+      expect(screen.queryByTestId('rename-popover-harness')).toBeNull()
+    })
+    expect(mockBackend.rename).not.toHaveBeenCalled()
+    expect(mockBackend.stat).not.toHaveBeenCalled()
+  })
+
+  // --- D2: rapid double new-file converges on the atomic namer (no shared key) ---
+
+  it('D2: rapid double New File routes through the atomic createUnique namer with no shared key', async () => {
+    let n = 0
+    mockBackend.list.mockResolvedValue([] as FileEntry[])
+    // Atomic reservation: each call hands back a distinct path (mirrors the IDB
+    // `add` serialization point) — never a Date.now()-style shared key.
+    mockBackend.createUnique = vi.fn(async () => {
+      n += 1
+      return n === 1 ? '/buffer/Untitled.md' : `/buffer/Untitled-${n - 1}.md`
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+    const newBtn = screen.getByTestId('toolbar-new')
+    // Two rapid clicks. The busy-disable guard may serialize them to a single
+    // reservation, but whatever fires goes through the atomic namer — no blind
+    // write, and any reservations are distinct (no shared key, #854).
+    fireEvent.click(newBtn)
+    fireEvent.click(newBtn)
+    await waitFor(() => {
+      expect(mockBackend.createUnique).toHaveBeenCalled()
+    })
+    expect(mockBackend.write).not.toHaveBeenCalled()
+    const reserved = await Promise.all(
+      (mockBackend.createUnique as Mock).mock.results.map((r) => r.value),
+    )
+    // No two reservations collide on the same key.
+    expect(new Set(reserved).size).toBe(reserved.length)
   })
 })

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -335,7 +335,7 @@ describe('StoragePane', () => {
     fireEvent.click(row) // select
     fireEvent.click(screen.getByTestId('toolbar-delete'))
     await waitFor(() => {
-      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/foo.md')
+      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/foo.md', false)
     })
   })
 
@@ -522,7 +522,7 @@ describe('StoragePane', () => {
     fireEvent.click(row)
     fireEvent.click(screen.getByTestId('toolbar-delete'))
     await waitFor(() => {
-      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/x.md')
+      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/x.md', false)
     })
     const firstDeleteIdx = eventLog.findIndex((e) => e.startsWith('delete:'))
     const closeIdxs = eventLog
@@ -570,7 +570,7 @@ describe('StoragePane', () => {
     fireEvent.click(row)
     fireEvent.click(screen.getByTestId('toolbar-delete'))
     await waitFor(() => {
-      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/p.png')
+      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/p.png', false)
     })
     const firstDeleteIdx = eventLog.findIndex((e) => e.startsWith('delete:'))
     const closeIdxs = eventLog
@@ -711,7 +711,7 @@ describe('StoragePane', () => {
       fireEvent.click(screen.getByTestId('toolbar-delete'))
       expect(confirmTrue).toHaveBeenCalledWith('editor.buffers.delete_one_confirm')
       await waitFor(() => {
-        expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/only.md')
+        expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/only.md', false)
       })
     }
   })
@@ -935,7 +935,7 @@ describe('StoragePane', () => {
     fireEvent.click(screen.getByTestId('toolbar-delete'))
 
     await waitFor(() => {
-      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/x.md')
+      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/x.md', false)
     })
     const editorState = editorModule.useEditorStore.getState()
     expect(editorState.buffers['inapp:/buffer/x.md']).toBeUndefined()
@@ -1166,7 +1166,7 @@ describe('StoragePane', () => {
     fireEvent.click(leafRow)
     fireEvent.click(screen.getByTestId('toolbar-delete'))
     await waitFor(() => {
-      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/a/b/x.md')
+      expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/a/b/x.md', false)
     })
   })
 

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -18,6 +18,7 @@ type MockBackend = {
   stat: Mock
   read: Mock
   mkdir: Mock
+  createUnique: Mock
   id: 'inapp'
   label: string
   available: () => boolean
@@ -293,6 +294,7 @@ beforeEach(() => {
     stat: vi.fn().mockResolvedValue({ size: 0, mtime: 0, isDirectory: false, isFile: true } as FileStat),
     read: vi.fn().mockResolvedValue(new Uint8Array(0)),
     mkdir: vi.fn().mockResolvedValue(undefined),
+    createUnique: vi.fn().mockResolvedValue('/buffer/Untitled.md'),
   }
 
   vi.stubGlobal('confirm', vi.fn(() => true))
@@ -335,18 +337,17 @@ describe('StoragePane', () => {
     })
   })
 
-  it('B2-4: New calls backend.write with Untitled-<timestamp>.md and refreshes', async () => {
+  it('B2-4: New calls backend.createUnique(root, Untitled, md) and refreshes', async () => {
     mockBackend.list.mockResolvedValue([] as FileEntry[])
     render(<StoragePane pane={makePane()} isActive />)
     await screen.findByText('editor.buffers.empty')
     fireEvent.click(screen.getByTestId('toolbar-new'))
     await waitFor(() => {
-      expect(mockBackend.write).toHaveBeenCalledTimes(1)
+      expect(mockBackend.createUnique).toHaveBeenCalledTimes(1)
     })
-    const [path, content] = mockBackend.write.mock.calls[0]
-    expect(path).toMatch(/^\/buffer\/Untitled-\d+\.md$/)
-    expect(content).toBeInstanceOf(Uint8Array)
-    expect(content.byteLength).toBe(0)
+    // Eager unified namer (#854): no blind write(), reservation is atomic.
+    expect(mockBackend.createUnique).toHaveBeenCalledWith('/buffer', 'Untitled', 'md')
+    expect(mockBackend.write).not.toHaveBeenCalled()
     // Refresh: list called a second time once the hook re-reads.
     await waitFor(() => {
       expect(mockBackend.list).toHaveBeenCalledTimes(2)

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { Mock } from 'vitest'
 import { useState } from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { StoragePane } from './StoragePane'
 import { openInAppFile } from '../../../lib/open-in-app-file'
 import type { Pane, Tab } from '../../../types/tab'
@@ -967,10 +967,11 @@ describe('StoragePane', () => {
     expect(folderA.getAttribute('data-isdir')).toBe('true')
     expect(screen.queryByText('x.md')).toBeNull()
 
-    // Expand a → b appears; expand b → x.md appears.
-    fireEvent.click(folderA)
+    // Expand a → b appears; expand b → x.md appears. (Double-click toggles
+    // expand now that single-click selects the folder — T0-1.)
+    fireEvent.doubleClick(folderA)
     const folderB = await screen.findByText('b')
-    fireEvent.click(folderB)
+    fireEvent.doubleClick(folderB.closest('[data-testid="buffer-row"]')!)
     const leaf = await screen.findByText('x.md')
     const leafRow = leaf.closest('[data-testid="buffer-row"]')
     expect(leafRow?.getAttribute('data-path')).toBe('/buffer/a/b/x.md')
@@ -990,8 +991,9 @@ describe('StoragePane', () => {
     render(<StoragePane pane={makePane()} isActive />)
     const d1 = await screen.findByText('d1')
     const d2 = await screen.findByText('d2')
-    fireEvent.click(d1.closest('[data-testid="buffer-row"]')!)
-    fireEvent.click(d2.closest('[data-testid="buffer-row"]')!)
+    // Double-click expands the folders (single-click now selects — T0-1).
+    fireEvent.doubleClick(d1.closest('[data-testid="buffer-row"]')!)
+    fireEvent.doubleClick(d2.closest('[data-testid="buffer-row"]')!)
     const leaves = await screen.findAllByText('x.md')
     const row1 = leaves[0].closest('[data-testid="buffer-row"]') as HTMLElement
     const row2 = leaves[1].closest('[data-testid="buffer-row"]') as HTMLElement
@@ -1017,8 +1019,8 @@ describe('StoragePane', () => {
     // Collapsed folder → Folder; png → FilePng.
     expect(byPath('/buffer/dir').getAttribute('data-icon')).toBe('Folder')
     expect(byPath('/buffer/pic.png').getAttribute('data-icon')).toBe('FilePng')
-    // Expand the folder → it switches to FolderOpen, and the md row resolves.
-    fireEvent.click(byPath('/buffer/dir'))
+    // Expand the folder (double-click) → it switches to FolderOpen, and the md row resolves.
+    fireEvent.doubleClick(byPath('/buffer/dir'))
     await waitFor(() => {
       const updated = screen.getAllByTestId('buffer-row')
       const dir = updated.find((r) => r.getAttribute('data-path') === '/buffer/dir')!
@@ -1129,8 +1131,9 @@ describe('StoragePane', () => {
     )
     mockBackend.stat.mockRejectedValue(new Error('not found'))
     render(<StoragePane pane={makePane()} isActive />)
-    fireEvent.click(await screen.findByText('a').then((n) => n.closest('[data-testid="buffer-row"]')!))
-    fireEvent.click((await screen.findByText('b')).closest('[data-testid="buffer-row"]')!)
+    // Double-click expands the folders (single-click now selects — T0-1).
+    fireEvent.doubleClick(await screen.findByText('a').then((n) => n.closest('[data-testid="buffer-row"]')!))
+    fireEvent.doubleClick((await screen.findByText('b')).closest('[data-testid="buffer-row"]')!)
     const leafRow = (await screen.findByText('x.md')).closest('[data-testid="buffer-row"]')!
     fireEvent.click(leafRow) // select
     fireEvent.click(screen.getByTestId('toolbar-rename'))
@@ -1153,13 +1156,92 @@ describe('StoragePane', () => {
       ]),
     )
     render(<StoragePane pane={makePane()} isActive />)
-    fireEvent.click((await screen.findByText('a')).closest('[data-testid="buffer-row"]')!)
-    fireEvent.click((await screen.findByText('b')).closest('[data-testid="buffer-row"]')!)
+    // Double-click expands the folders (single-click now selects — T0-1).
+    fireEvent.doubleClick((await screen.findByText('a')).closest('[data-testid="buffer-row"]')!)
+    fireEvent.doubleClick((await screen.findByText('b')).closest('[data-testid="buffer-row"]')!)
     const leafRow = (await screen.findByText('x.md')).closest('[data-testid="buffer-row"]')!
     fireEvent.click(leafRow)
     fireEvent.click(screen.getByTestId('toolbar-delete'))
     await waitFor(() => {
       expect(mockBackend.delete).toHaveBeenCalledWith('/buffer/a/b/x.md')
     })
+  })
+
+  // --- Folder-selectable tree + target model (Phase 1b T1b-0) ---
+
+  it('T0-1: clicking a folder name selects it (selected style), without expanding or opening', async () => {
+    mockBackend.list = pathAwareList(
+      new Map([
+        ['/buffer/dir', { isDir: true, size: 0 }],
+        ['/buffer/dir/x.md', { isDir: false, size: 3 }],
+      ]),
+    )
+    render(<StoragePane pane={makePane()} isActive />)
+    const folder = await screen.findByTestId('buffer-row')
+    expect(folder.getAttribute('data-path')).toBe('/buffer/dir')
+    fireEvent.click(folder)
+    // Folder shows the selected style and stays collapsed; no tab opened.
+    expect(folder.getAttribute('aria-selected')).toBe('true')
+    expect(screen.queryByText('x.md')).toBeNull()
+    expect(openInAppFile).not.toHaveBeenCalled()
+  })
+
+  it('T0-1b: the caret toggles expand independently of selection', async () => {
+    mockBackend.list = pathAwareList(
+      new Map([
+        ['/buffer/dir', { isDir: true, size: 0 }],
+        ['/buffer/dir/x.md', { isDir: false, size: 3 }],
+      ]),
+    )
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByTestId('buffer-row') // wait for the async tree build
+    const rowByPath = (p: string) =>
+      screen.getAllByTestId('buffer-row').find((r) => r.getAttribute('data-path') === p)!
+    fireEvent.click(rowByPath('/buffer/dir')) // select the folder
+    expect(rowByPath('/buffer/dir').getAttribute('aria-selected')).toBe('true')
+    // Expanding via the caret reveals the child but leaves selection intact.
+    fireEvent.click(within(rowByPath('/buffer/dir')).getByTestId('buffer-caret'))
+    await screen.findByText('x.md')
+    expect(rowByPath('/buffer/dir').getAttribute('aria-selected')).toBe('true')
+    expect(rowByPath('/buffer/dir/x.md').getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('T0-2: targetDir derives from selection (none→root, folder→self, file→parent)', async () => {
+    mockBackend.list = pathAwareList(
+      new Map([
+        ['/buffer/dir', { isDir: true, size: 0 }],
+        ['/buffer/dir/x.md', { isDir: false, size: 3 }],
+      ]),
+    )
+    render(<StoragePane pane={makePane()} isActive />)
+    const region = await screen.findByTestId('storage-tree-region')
+    await screen.findByTestId('buffer-row') // wait for the async tree build
+    const rowByPath = (p: string) =>
+      screen.getAllByTestId('buffer-row').find((r) => r.getAttribute('data-path') === p)!
+    // Nothing selected → storage root.
+    expect(region.getAttribute('data-target-dir')).toBe('/buffer')
+    // Folder selected → the folder itself.
+    fireEvent.click(rowByPath('/buffer/dir'))
+    expect(region.getAttribute('data-target-dir')).toBe('/buffer/dir')
+    // Deselect, expand (caret = no selection), select the nested file → its parent.
+    fireEvent.click(rowByPath('/buffer/dir'))
+    fireEvent.click(within(rowByPath('/buffer/dir')).getByTestId('buffer-caret'))
+    await screen.findByText('x.md')
+    fireEvent.click(rowByPath('/buffer/dir/x.md'))
+    expect(region.getAttribute('data-target-dir')).toBe('/buffer/dir')
+  })
+
+  it('T0-3: double-clicking a folder toggles expand and never opens a tab', async () => {
+    mockBackend.list = pathAwareList(
+      new Map([
+        ['/buffer/dir', { isDir: true, size: 0 }],
+        ['/buffer/dir/x.md', { isDir: false, size: 3 }],
+      ]),
+    )
+    render(<StoragePane pane={makePane()} isActive />)
+    const folder = await screen.findByTestId('buffer-row')
+    fireEvent.doubleClick(folder)
+    await screen.findByText('x.md') // expanded
+    expect(openInAppFile).not.toHaveBeenCalled()
   })
 })

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -1304,6 +1304,70 @@ describe('StoragePane', () => {
     })
   })
 
+  // --- In-place rename of a folder selection (Phase 1b T1b-4) ---
+
+  it('T4-UI-1: renaming a selected folder routes through backend.rename and re-selects the new path', async () => {
+    const paths = new Map<string, { isDir: boolean; size: number }>([
+      ['/buffer/dir', { isDir: true, size: 0 }],
+      ['/buffer/dir/x.md', { isDir: false, size: 3 }],
+    ])
+    mockBackend.list = pathAwareList(paths)
+    mockBackend.stat.mockRejectedValue(new Error('not found'))
+    // Re-key the fixture like the real recursive backend.rename (T1b-1).
+    mockBackend.rename = vi.fn(async (from: string, to: string) => {
+      for (const [p, meta] of Array.from(paths)) {
+        if (p === from || p.startsWith(from + '/')) {
+          paths.delete(p)
+          paths.set(to + p.slice(from.length), meta)
+        }
+      }
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    const folder = await screen.findByTestId('buffer-row')
+    fireEvent.click(folder) // select the folder
+    fireEvent.click(screen.getByTestId('toolbar-rename'))
+    const input = await screen.findByTestId('rename-input')
+    expect((input as HTMLInputElement).value).toBe('dir')
+    fireEvent.change(input, { target: { value: 'docs' } })
+    fireEvent.click(screen.getByTestId('rename-confirm'))
+    await waitFor(() => {
+      expect(mockBackend.rename).toHaveBeenCalledWith('/buffer/dir', '/buffer/docs')
+    })
+    expect(mockBackend.rename).toHaveBeenCalledTimes(1)
+    // Tree rebuilt → the renamed folder is present and re-selected by new path.
+    await waitFor(() => {
+      const row = screen
+        .getAllByTestId('buffer-row')
+        .find((r) => r.getAttribute('data-path') === '/buffer/docs')
+      expect(row).toBeTruthy()
+      expect(row!.getAttribute('aria-selected')).toBe('true')
+    })
+  })
+
+  it('T4-UI-2: folder rename onto an existing name shows the inline exists error (no mutation)', async () => {
+    mockBackend.list = pathAwareList(
+      new Map([
+        ['/buffer/a', { isDir: true, size: 0 }],
+        ['/buffer/z', { isDir: true, size: 0 }],
+      ]),
+    )
+    mockBackend.stat.mockImplementation(async (p: string) => {
+      if (p === '/buffer/z') return { size: 0, mtime: 0, isDirectory: true, isFile: false } as FileStat
+      throw new Error('not found')
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    const rows = await screen.findAllByTestId('buffer-row')
+    fireEvent.click(rows.find((r) => r.getAttribute('data-path') === '/buffer/a')!)
+    fireEvent.click(screen.getByTestId('toolbar-rename'))
+    const input = await screen.findByTestId('rename-input')
+    fireEvent.change(input, { target: { value: 'z' } })
+    fireEvent.click(screen.getByTestId('rename-confirm'))
+    await waitFor(() => {
+      expect(screen.getByTestId('rename-error').textContent).toBe('editor.buffers.rename_exists_error')
+    })
+    expect(mockBackend.rename).not.toHaveBeenCalled()
+  })
+
   it('T3-3: New Folder does not overwrite an existing folder — it increments the name', async () => {
     // A "New Folder" already exists (e.g. from a prior session); creating
     // another must not clobber it (decision 7 — add-reserve increments).

--- a/spa/src/components/editor/storage/StoragePane.tsx
+++ b/spa/src/components/editor/storage/StoragePane.tsx
@@ -21,13 +21,13 @@ import { findNode, targetDirOf } from '../../../lib/storage-tree'
 import { RenamePopover } from '../../RenamePopover'
 import { StorageTree } from './StorageTree'
 import {
-  computeMoveFromDragEnd,
   createStorageFile,
   createStorageFolder,
   deleteStorageEntries,
   moveStorageEntry,
   renameStorageEntry,
 } from './storage-actions'
+import { computeMoveFromDragEnd } from './storage-dnd'
 
 /**
  * Resolve the workspace that hosts this Storage pane, so opened files land in
@@ -64,7 +64,13 @@ function StorageRegionDropZone({
   targetDir: string
   children: ReactNode
 }) {
-  const { setNodeRef, isOver } = useDroppable({ id: STORAGE_ROOT })
+  // Publish `STORAGE_ROOT` as this zone's authoritative drop target dir (codex
+  // B1) so a drop on empty space / between rows resolves to the storage root via
+  // the same `over.data.targetDir` channel the row droppables use.
+  const { setNodeRef, isOver } = useDroppable({
+    id: STORAGE_ROOT,
+    data: { targetDir: STORAGE_ROOT },
+  })
   return (
     <div
       ref={setNodeRef}
@@ -118,8 +124,14 @@ export function StoragePane({ pane }: PaneRendererProps) {
 
   // --- Selection / open ---
 
-  const handleSelect = useCallback((path: string) => {
+  // Plain click → select ONLY this row (replace selection). Modifier click
+  // (cmd/ctrl/shift, surfaced as `additive`) → toggle into a multi-selection
+  // (codex B5). A plain click never deselects, so the click→click→double-click
+  // sequence leaves the row selected instead of toggling it off and stranding a
+  // stale rename/new/move target.
+  const handleSelect = useCallback((path: string, additive: boolean) => {
     setSelected((prev) => {
+      if (!additive) return new Set([path])
       const next = new Set(prev)
       if (next.has(path)) next.delete(path)
       else next.add(path)
@@ -223,8 +235,11 @@ export function StoragePane({ pane }: PaneRendererProps) {
   }, [selectedArray, t, refresh])
 
   const handleOpenSelected = useCallback(() => {
-    if (singleSelected) handleOpen(singleSelected)
-  }, [singleSelected, handleOpen])
+    // Only files open (codex B3): a folder is not openable, so guard here as
+    // well as disabling the toolbar button — a folder must never be handed to
+    // openInAppFile.
+    if (singleSelected && !selectedNode?.isDir) handleOpen(singleSelected)
+  }, [singleSelected, selectedNode, handleOpen])
 
   // --- Drag-and-drop move (T1b-6b) ---
 
@@ -259,7 +274,9 @@ export function StoragePane({ pane }: PaneRendererProps) {
   const hasAny = tree.length > 0
   const canRename = selectedArray.length === 1
   const canDelete = selectedArray.length >= 1
-  const canOpen = selectedArray.length === 1
+  // Open is only valid for a single FILE selection (codex B3): a folder is not
+  // openable, so the toolbar Open button disables when a folder is selected.
+  const canOpen = singleSelected !== null && !selectedNode?.isDir
   const toolbarBusy = busy || loading
 
   return (

--- a/spa/src/components/editor/storage/StoragePane.tsx
+++ b/spa/src/components/editor/storage/StoragePane.tsx
@@ -7,7 +7,7 @@ import { useWorkspaceStore } from '../../../features/workspace/store'
 import { useStorageTree } from '../../../hooks/useStorageTree'
 import { findPane } from '../../../lib/pane-tree'
 import { openInAppFile } from '../../../lib/open-in-app-file'
-import { basename } from '../../../lib/storage-paths'
+import { basename, join, parentOf } from '../../../lib/storage-paths'
 import { findNode, targetDirOf } from '../../../lib/storage-tree'
 import { RenamePopover } from '../../RenamePopover'
 import { StorageTree } from './StorageTree'
@@ -141,9 +141,12 @@ export function StoragePane({ pane }: PaneRendererProps) {
       if (!renameTarget) return
       const res = await renameStorageEntry(renameTarget, newName)
       if ('ok' in res) {
+        // Re-select by the new full path (file or folder) so a follow-up action
+        // keeps targeting the renamed entry once the tree rebuilds.
+        const newPath = join(parentOf(renameTarget), newName)
         setRenameTarget(null)
         setRenameError(null)
-        setSelected(new Set())
+        setSelected(new Set([newPath]))
         refresh()
       } else if (res.kind === 'exists') {
         setRenameError(t('editor.buffers.rename_exists_error'))

--- a/spa/src/components/editor/storage/StoragePane.tsx
+++ b/spa/src/components/editor/storage/StoragePane.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react'
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
 import { FilePlus, FolderPlus, PencilSimple, Stack, Trash, FolderOpen } from '@phosphor-icons/react'
 import type { PaneRendererProps } from '../../../lib/module-registry'
 import { useI18nStore } from '../../../stores/useI18nStore'
@@ -7,14 +16,16 @@ import { useWorkspaceStore } from '../../../features/workspace/store'
 import { useStorageTree } from '../../../hooks/useStorageTree'
 import { findPane } from '../../../lib/pane-tree'
 import { openInAppFile } from '../../../lib/open-in-app-file'
-import { basename, join, parentOf } from '../../../lib/storage-paths'
+import { STORAGE_ROOT, basename, join, parentOf } from '../../../lib/storage-paths'
 import { findNode, targetDirOf } from '../../../lib/storage-tree'
 import { RenamePopover } from '../../RenamePopover'
 import { StorageTree } from './StorageTree'
 import {
+  computeMoveFromDragEnd,
   createStorageFile,
   createStorageFolder,
   deleteStorageEntries,
+  moveStorageEntry,
   renameStorageEntry,
 } from './storage-actions'
 
@@ -36,6 +47,35 @@ function resolveWorkspaceId(paneId: string): string | null {
     }
   }
   return null
+}
+
+/**
+ * The scrollable tree region, made a single `useDroppable` drop target keyed by
+ * `STORAGE_ROOT` (drop here → move to the storage root). It must live in its own
+ * component because `useDroppable` has to run *inside* the `DndContext` that
+ * `StoragePane` renders. `closestCenter` collision detection lets a nested
+ * folder droppable win when the pointer is over it, falling back to this root
+ * zone for empty space / file rows.
+ */
+function StorageRegionDropZone({
+  targetDir,
+  children,
+}: {
+  targetDir: string
+  children: ReactNode
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: STORAGE_ROOT })
+  return (
+    <div
+      ref={setNodeRef}
+      className={'flex-1 overflow-y-auto' + (isOver ? ' bg-surface-hover/50' : '')}
+      data-testid="storage-tree-region"
+      data-target-dir={targetDir}
+      data-root-over={isOver ? 'true' : 'false'}
+    >
+      {children}
+    </div>
+  )
 }
 
 /**
@@ -186,6 +226,34 @@ export function StoragePane({ pane }: PaneRendererProps) {
     if (singleSelected) handleOpen(singleSelected)
   }, [singleSelected, handleOpen])
 
+  // --- Drag-and-drop move (T1b-6b) ---
+
+  // Mirror RegionManager: a 5px activation distance so a stationary
+  // click/double-click never starts a drag — select/open/toggle coexist with
+  // dragging.
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }))
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const move = computeMoveFromDragEnd(event.active, event.over)
+      if (!move) return
+      setActionError(null)
+      const res = await moveStorageEntry(move.from, move.targetDir)
+      if ('ok' in res) {
+        // Keep the moved entry selected at its new home so a follow-up action
+        // still targets it once the tree rebuilds.
+        setSelected(new Set([join(move.targetDir, basename(move.from))]))
+        refresh()
+      } else if (res.kind === 'exists') {
+        setActionError(t('editor.buffers.rename_exists_error'))
+      } else if (res.kind === 'error') {
+        setActionError(res.message)
+      }
+      // 'noop' (inert / self / own-descendant): silent.
+    },
+    [refresh, t],
+  )
+
   // --- Render ---
 
   const hasAny = tree.length > 0
@@ -254,31 +322,31 @@ export function StoragePane({ pane }: PaneRendererProps) {
         </button>
       </div>
 
-      {/* Body: tree (left) + placeholder Backups sidebar (right). */}
+      {/* Body: tree (left) + placeholder Backups sidebar (right). The tree is a
+          DnD surface: rows are drag sources, folder rows + the root region are
+          drop targets, and a drop calls `moveStorageEntry` via `handleDragEnd`. */}
       <div className="flex-1 flex overflow-hidden">
-        <div
-          className="flex-1 overflow-y-auto"
-          data-testid="storage-tree-region"
-          data-target-dir={targetDir}
-        >
-          {error && <div className="p-4 text-xs text-red-400">{error}</div>}
-          {!error && !hasAny && (
-            <div className="p-8 flex flex-col items-center justify-center text-text-muted">
-              <Stack size={32} className="mb-2 opacity-50" />
-              <p className="text-sm">{t('editor.buffers.empty')}</p>
-            </div>
-          )}
-          {!error && hasAny && (
-            <StorageTree
-              tree={tree}
-              expanded={expanded}
-              selected={selected}
-              onToggle={toggle}
-              onSelect={handleSelect}
-              onOpen={handleOpen}
-            />
-          )}
-        </div>
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <StorageRegionDropZone targetDir={targetDir}>
+            {error && <div className="p-4 text-xs text-red-400">{error}</div>}
+            {!error && !hasAny && (
+              <div className="p-8 flex flex-col items-center justify-center text-text-muted">
+                <Stack size={32} className="mb-2 opacity-50" />
+                <p className="text-sm">{t('editor.buffers.empty')}</p>
+              </div>
+            )}
+            {!error && hasAny && (
+              <StorageTree
+                tree={tree}
+                expanded={expanded}
+                selected={selected}
+                onToggle={toggle}
+                onSelect={handleSelect}
+                onOpen={handleOpen}
+              />
+            )}
+          </StorageRegionDropZone>
+        </DndContext>
         <aside
           data-testid="storage-backups-placeholder"
           className="w-48 shrink-0 border-l border-border-subtle p-3 text-xs text-text-muted"

--- a/spa/src/components/editor/storage/StoragePane.tsx
+++ b/spa/src/components/editor/storage/StoragePane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { FilePlus, PencilSimple, Stack, Trash, FolderOpen } from '@phosphor-icons/react'
+import { FilePlus, FolderPlus, PencilSimple, Stack, Trash, FolderOpen } from '@phosphor-icons/react'
 import type { PaneRendererProps } from '../../../lib/module-registry'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { useTabStore } from '../../../stores/useTabStore'
@@ -13,6 +13,7 @@ import { RenamePopover } from '../../RenamePopover'
 import { StorageTree } from './StorageTree'
 import {
   createStorageFile,
+  createStorageFolder,
   deleteStorageEntries,
   renameStorageEntry,
 } from './storage-actions'
@@ -102,11 +103,29 @@ export function StoragePane({ pane }: PaneRendererProps) {
   const handleNew = useCallback(async () => {
     setBusy(true)
     setActionError(null)
-    const res = await createStorageFile()
+    // T1b-0 wiring: the new file lands in the selected folder (or the parent of
+    // a selected file, else the storage root).
+    const res = await createStorageFile(targetDir)
     setBusy(false)
     if (res.error) setActionError(res.error)
     else refresh()
-  }, [refresh])
+  }, [refresh, targetDir])
+
+  const handleNewFolder = useCallback(async () => {
+    setBusy(true)
+    setActionError(null)
+    const res = await createStorageFolder(targetDir)
+    setBusy(false)
+    if ('error' in res) {
+      setActionError(res.error)
+      return
+    }
+    // Auto-expand the (empty) new folder and select it so a follow-up New File
+    // immediately targets it, then refresh to materialize the row.
+    if (!expanded.has(res.path)) toggle(res.path)
+    setSelected(new Set([res.path]))
+    refresh()
+  }, [refresh, targetDir, expanded, toggle])
 
   const handleOpenRename = useCallback(() => {
     if (!singleSelected) return
@@ -188,6 +207,16 @@ export function StoragePane({ pane }: PaneRendererProps) {
         >
           <FilePlus size={14} />
           {t('editor.buffers.new')}
+        </button>
+        <button
+          data-testid="toolbar-new-folder"
+          onClick={handleNewFolder}
+          disabled={toolbarBusy}
+          className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-text-secondary hover:bg-surface-hover disabled:opacity-50"
+          title={t('editor.buffers.new_folder')}
+        >
+          <FolderPlus size={14} />
+          {t('editor.buffers.new_folder')}
         </button>
         <button
           data-testid="toolbar-rename"

--- a/spa/src/components/editor/storage/StoragePane.tsx
+++ b/spa/src/components/editor/storage/StoragePane.tsx
@@ -8,6 +8,7 @@ import { useStorageTree } from '../../../hooks/useStorageTree'
 import { findPane } from '../../../lib/pane-tree'
 import { openInAppFile } from '../../../lib/open-in-app-file'
 import { basename } from '../../../lib/storage-paths'
+import { findNode, targetDirOf } from '../../../lib/storage-tree'
 import { RenamePopover } from '../../RenamePopover'
 import { StorageTree } from './StorageTree'
 import {
@@ -62,6 +63,17 @@ export function StoragePane({ pane }: PaneRendererProps) {
 
   const selectedArray = useMemo(() => Array.from(selected), [selected])
   const singleSelected = selectedArray.length === 1 ? selectedArray[0] : null
+
+  // Resolve the single selection back to its TreeNode so we know whether it is a
+  // folder, then derive the directory that nesting-aware actions (new file / new
+  // folder / drop) should target (T1b-0): folder → itself, file → parent, no
+  // single selection → storage root. Exposed on the tree region below so later
+  // 1b tasks (and tests) can consume it.
+  const selectedNode = useMemo(
+    () => (singleSelected ? findNode(tree, singleSelected) : null),
+    [singleSelected, tree],
+  )
+  const targetDir = useMemo(() => targetDirOf(selectedNode), [selectedNode])
 
   // --- Selection / open ---
 
@@ -212,7 +224,11 @@ export function StoragePane({ pane }: PaneRendererProps) {
 
       {/* Body: tree (left) + placeholder Backups sidebar (right). */}
       <div className="flex-1 flex overflow-hidden">
-        <div className="flex-1 overflow-y-auto">
+        <div
+          className="flex-1 overflow-y-auto"
+          data-testid="storage-tree-region"
+          data-target-dir={targetDir}
+        >
           {error && <div className="p-4 text-xs text-red-400">{error}</div>}
           {!error && !hasAny && (
             <div className="p-8 flex flex-col items-center justify-center text-text-muted">

--- a/spa/src/components/editor/storage/StorageRow.test.tsx
+++ b/spa/src/components/editor/storage/StorageRow.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { StorageRow } from './StorageRow'
+import type { TreeNode } from '../../../lib/storage-tree'
+import type { FsBackend } from '../../../lib/fs-backend'
+
+// StorageRow word-count reads bytes for text files; stub the backend so the
+// effect never throws. Selection/expand behavior is what these tests exercise.
+vi.mock('../../../lib/fs-backend', () => ({
+  getFsBackend: () => ({ read: vi.fn().mockResolvedValue(new Uint8Array(0)) }) as unknown as FsBackend,
+  registerFsBackend: vi.fn(),
+}))
+
+function folder(): TreeNode {
+  return { path: '/buffer/dir', name: 'dir', isDir: true, size: 0, children: [] }
+}
+function file(): TreeNode {
+  return { path: '/buffer/note.md', name: 'note.md', isDir: false, size: 4 }
+}
+
+let onToggle: Mock
+let onSelect: Mock
+let onOpen: Mock
+
+beforeEach(() => {
+  onToggle = vi.fn()
+  onSelect = vi.fn()
+  onOpen = vi.fn()
+})
+
+function renderFolder(expanded = false) {
+  render(
+    <StorageRow
+      node={folder()}
+      depth={0}
+      selected={false}
+      expanded={expanded}
+      onToggle={onToggle}
+      onSelect={onSelect}
+      onOpen={onOpen}
+    />,
+  )
+}
+
+describe('StorageRow folder selection (T0-1)', () => {
+  it('clicking the folder name selects it (does NOT toggle expand)', () => {
+    renderFolder()
+    fireEvent.click(screen.getByTestId('buffer-row'))
+    expect(onSelect).toHaveBeenCalledWith('/buffer/dir')
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it('clicking the caret toggles expand independently (does NOT select)', () => {
+    renderFolder()
+    fireEvent.click(screen.getByTestId('buffer-caret'))
+    expect(onToggle).toHaveBeenCalledWith('/buffer/dir')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('double-clicking a folder toggles expand but never opens a tab', () => {
+    renderFolder()
+    fireEvent.doubleClick(screen.getByTestId('buffer-row'))
+    expect(onToggle).toHaveBeenCalledWith('/buffer/dir')
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+})
+
+describe('StorageRow file behavior (unchanged)', () => {
+  it('single-click selects a file', () => {
+    render(
+      <StorageRow
+        node={file()}
+        depth={0}
+        selected={false}
+        expanded={false}
+        onToggle={onToggle}
+        onSelect={onSelect}
+        onOpen={onOpen}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('buffer-row'))
+    expect(onSelect).toHaveBeenCalledWith('/buffer/note.md')
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('double-click opens a file (no caret rendered)', () => {
+    render(
+      <StorageRow
+        node={file()}
+        depth={0}
+        selected={false}
+        expanded={false}
+        onToggle={onToggle}
+        onSelect={onSelect}
+        onOpen={onOpen}
+      />,
+    )
+    expect(screen.queryByTestId('buffer-caret')).toBeNull()
+    fireEvent.doubleClick(screen.getByTestId('buffer-row'))
+    expect(onOpen).toHaveBeenCalledWith('/buffer/note.md')
+  })
+})

--- a/spa/src/components/editor/storage/StorageRow.test.tsx
+++ b/spa/src/components/editor/storage/StorageRow.test.tsx
@@ -47,7 +47,8 @@ describe('StorageRow folder selection (T0-1)', () => {
   it('clicking the folder name selects it (does NOT toggle expand)', () => {
     renderFolder()
     fireEvent.click(screen.getByTestId('buffer-row'))
-    expect(onSelect).toHaveBeenCalledWith('/buffer/dir')
+    // Plain click → non-additive select (codex B5).
+    expect(onSelect).toHaveBeenCalledWith('/buffer/dir', false)
     expect(onToggle).not.toHaveBeenCalled()
   })
 
@@ -80,8 +81,24 @@ describe('StorageRow file behavior (unchanged)', () => {
       />,
     )
     fireEvent.click(screen.getByTestId('buffer-row'))
-    expect(onSelect).toHaveBeenCalledWith('/buffer/note.md')
+    expect(onSelect).toHaveBeenCalledWith('/buffer/note.md', false)
     expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('a modifier (cmd/ctrl) click selects additively (codex B5)', () => {
+    render(
+      <StorageRow
+        node={file()}
+        depth={0}
+        selected={false}
+        expanded={false}
+        onToggle={onToggle}
+        onSelect={onSelect}
+        onOpen={onOpen}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('buffer-row'), { metaKey: true })
+    expect(onSelect).toHaveBeenCalledWith('/buffer/note.md', true)
   })
 
   it('double-click opens a file (no caret rendered)', () => {
@@ -99,5 +116,64 @@ describe('StorageRow file behavior (unchanged)', () => {
     expect(screen.queryByTestId('buffer-caret')).toBeNull()
     fireEvent.doubleClick(screen.getByTestId('buffer-row'))
     expect(onOpen).toHaveBeenCalledWith('/buffer/note.md')
+  })
+})
+
+describe('StorageRow keyboard parity (codex B6)', () => {
+  it('Enter on a file opens it', () => {
+    render(
+      <StorageRow node={file()} depth={0} selected={false} expanded={false}
+        onToggle={onToggle} onSelect={onSelect} onOpen={onOpen} />,
+    )
+    fireEvent.keyDown(screen.getByTestId('buffer-row'), { key: 'Enter' })
+    expect(onOpen).toHaveBeenCalledWith('/buffer/note.md')
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it('Enter on a folder toggles its expansion (never opens)', () => {
+    renderFolder()
+    fireEvent.keyDown(screen.getByTestId('buffer-row'), { key: 'Enter' })
+    expect(onToggle).toHaveBeenCalledWith('/buffer/dir')
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('Space selects the row (non-additive without a modifier)', () => {
+    render(
+      <StorageRow node={file()} depth={0} selected={false} expanded={false}
+        onToggle={onToggle} onSelect={onSelect} onOpen={onOpen} />,
+    )
+    fireEvent.keyDown(screen.getByTestId('buffer-row'), { key: ' ' })
+    expect(onSelect).toHaveBeenCalledWith('/buffer/note.md', false)
+  })
+
+  it('Space with a modifier selects additively', () => {
+    renderFolder()
+    fireEvent.keyDown(screen.getByTestId('buffer-row'), { key: ' ', ctrlKey: true })
+    expect(onSelect).toHaveBeenCalledWith('/buffer/dir', true)
+  })
+})
+
+describe('StorageRow drop target dir (codex B1)', () => {
+  it('a folder row publishes ITS OWN path as the drop targetDir', () => {
+    renderFolder()
+    expect(screen.getByTestId('buffer-row').getAttribute('data-target-dir')).toBe('/buffer/dir')
+  })
+
+  it('a file row publishes its PARENT dir as the drop targetDir (drop = into its folder, not root)', () => {
+    render(
+      <StorageRow node={file()} depth={0} selected={false} expanded={false}
+        onToggle={onToggle} onSelect={onSelect} onOpen={onOpen} />,
+    )
+    // file is /buffer/note.md → parent /buffer.
+    expect(screen.getByTestId('buffer-row').getAttribute('data-target-dir')).toBe('/buffer')
+  })
+
+  it('a NESTED file row publishes its immediate parent folder, not the root', () => {
+    const nested: TreeNode = { path: '/buffer/dir/sub/x.md', name: 'x.md', isDir: false, size: 2 }
+    render(
+      <StorageRow node={nested} depth={2} selected={false} expanded={false}
+        onToggle={onToggle} onSelect={onSelect} onOpen={onOpen} />,
+    )
+    expect(screen.getByTestId('buffer-row').getAttribute('data-target-dir')).toBe('/buffer/dir/sub')
   })
 })

--- a/spa/src/components/editor/storage/StorageRow.tsx
+++ b/spa/src/components/editor/storage/StorageRow.tsx
@@ -4,6 +4,7 @@ import { CaretRight, CaretDown } from '@phosphor-icons/react'
 import { ICON_MAP } from '../../tab-icon-map'
 import { fileIconForPath } from '../../../lib/file-icon'
 import { getFsBackend } from '../../../lib/fs-backend'
+import { parentOf } from '../../../lib/storage-paths'
 import type { TreeNode } from '../../../lib/storage-tree'
 
 /**
@@ -57,7 +58,12 @@ interface StorageRowProps {
   selected: boolean
   expanded: boolean
   onToggle: (path: string) => void
-  onSelect: (path: string) => void
+  /**
+   * Select this row. `additive` (cmd/ctrl/shift held) toggles the row in a
+   * multi-selection; a plain click (additive=false) replaces the selection with
+   * just this row (codex B5).
+   */
+  onSelect: (path: string, additive: boolean) => void
   onOpen: (path: string) => void
 }
 
@@ -93,14 +99,23 @@ export function StorageRow({
   const text = isTextNode(node)
   const [wordCount, setWordCount] = useState<number | null>(null)
 
-  // Drag source (every row) + drop target (folders only — files disable the
-  // droppable). One DOM node carries both refs via the merge callback below.
+  // The directory a drop onto THIS row targets (codex B1): a folder accepts
+  // children into itself; a file resolves to its parent dir (dropping onto a
+  // file means "into the folder it lives in"). Published on the droppable's
+  // `data.targetDir` so the drop resolver reads an authoritative value instead
+  // of inferring it from the over-id — which previously let a drop onto a file
+  // row (no droppable then) fall through to the root zone and move to root.
+  const targetDir = node.isDir ? node.path : parentOf(node.path)
+
+  // Drag source (every row) + drop target (EVERY row now — files route a drop
+  // to their parent dir via `targetDir`). One DOM node carries both refs via the
+  // merge callback below.
   const { attributes, listeners, setNodeRef: setDragRef, transform, isDragging } = useDraggable({
     id: node.path,
   })
   const { setNodeRef: setDropRef, isOver } = useDroppable({
     id: node.path,
-    disabled: !node.isDir,
+    data: { targetDir },
   })
   const setRowRef = useCallback(
     (el: HTMLDivElement | null) => {
@@ -138,8 +153,14 @@ export function StorageRow({
   const Icon = ICON_MAP[iconName] ?? ICON_MAP.File
 
   // Single click selects (file or folder); double-click opens a file or toggles
-  // a folder's expansion. The caret has its own handler below.
-  const handleClick = () => onSelect(node.path)
+  // a folder's expansion. A plain click selects ONLY this row (replacing the
+  // selection); a modifier click (cmd/ctrl/shift) toggles it into a
+  // multi-selection (codex B5) — so the click→click→double-click sequence no
+  // longer toggles the row off and leaves a stale/empty action target. The
+  // caret has its own handler below.
+  const isAdditive = (e: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean }) =>
+    e.metaKey || e.ctrlKey || e.shiftKey
+  const handleClick = (e: React.MouseEvent) => onSelect(node.path, isAdditive(e))
   const handleDoubleClick = () => {
     if (node.isDir) onToggle(node.path)
     else onOpen(node.path)
@@ -149,6 +170,19 @@ export function StorageRow({
     // selection (and vice versa).
     e.stopPropagation()
     onToggle(node.path)
+  }
+  // Keyboard parity for the `role="button"` row (codex B6): Enter mirrors the
+  // double-click (file → open, folder → toggle); Space selects (additive with a
+  // modifier). preventDefault on Space stops the page from scrolling.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (node.isDir) onToggle(node.path)
+      else onOpen(node.path)
+    } else if (e.key === ' ') {
+      e.preventDefault()
+      onSelect(node.path, isAdditive(e))
+    }
   }
 
   return (
@@ -162,11 +196,13 @@ export function StorageRow({
       data-isdir={node.isDir ? 'true' : 'false'}
       data-icon={iconName}
       data-drop-over={dropActive ? 'true' : 'false'}
+      data-target-dir={targetDir}
       role="button"
       tabIndex={0}
       aria-selected={selected}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
+      onKeyDown={handleKeyDown}
       style={{
         paddingLeft: 8 + depth * 16,
         ...(transform ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` } : {}),

--- a/spa/src/components/editor/storage/StorageRow.tsx
+++ b/spa/src/components/editor/storage/StorageRow.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useDraggable, useDroppable } from '@dnd-kit/core'
 import { CaretRight, CaretDown } from '@phosphor-icons/react'
 import { ICON_MAP } from '../../tab-icon-map'
 import { fileIconForPath } from '../../../lib/file-icon'
@@ -71,6 +72,14 @@ interface StorageRowProps {
  * selection (and selecting never expands). **Double-click** opens a file or
  * toggles a folder's expansion. Text files additionally render a word count
  * (decoded from the backend bytes); binary files show size only.
+ *
+ * Drag-and-drop move (T1b-6b): every row is a `useDraggable` source keyed by its
+ * full path; **folder** rows are additionally `useDroppable` drop targets (files
+ * pass `disabled` so they never accept a drop — the root region in `StoragePane`
+ * is the other target). The `PointerSensor` activation distance (5px, set in
+ * `StoragePane`) keeps a stationary click/double-click from starting a drag, so
+ * select/open/toggle coexist with dragging. `StoragePane.onDragEnd` resolves the
+ * active path + drop target into a `moveStorageEntry` call.
  */
 export function StorageRow({
   node,
@@ -83,6 +92,24 @@ export function StorageRow({
 }: StorageRowProps) {
   const text = isTextNode(node)
   const [wordCount, setWordCount] = useState<number | null>(null)
+
+  // Drag source (every row) + drop target (folders only — files disable the
+  // droppable). One DOM node carries both refs via the merge callback below.
+  const { attributes, listeners, setNodeRef: setDragRef, transform, isDragging } = useDraggable({
+    id: node.path,
+  })
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: node.path,
+    disabled: !node.isDir,
+  })
+  const setRowRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      setDragRef(el)
+      setDropRef(el)
+    },
+    [setDragRef, setDropRef],
+  )
+  const dropActive = node.isDir && isOver
 
   useEffect(() => {
     // Rows are keyed by full path in `StorageTree`, so `text` is constant for a
@@ -126,22 +153,31 @@ export function StorageRow({
 
   return (
     <div
+      ref={setRowRef}
+      {...attributes}
+      {...listeners}
       data-testid="buffer-row"
       data-name={node.name}
       data-path={node.path}
       data-isdir={node.isDir ? 'true' : 'false'}
       data-icon={iconName}
+      data-drop-over={dropActive ? 'true' : 'false'}
       role="button"
       tabIndex={0}
       aria-selected={selected}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
-      style={{ paddingLeft: 8 + depth * 16 }}
+      style={{
+        paddingLeft: 8 + depth * 16,
+        ...(transform ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` } : {}),
+      }}
       className={
         'w-full flex items-center gap-1.5 pr-3 py-1.5 text-left text-xs transition-colors cursor-pointer ' +
         (selected
           ? 'bg-surface-selected text-text-primary'
-          : 'text-text-secondary hover:bg-surface-hover')
+          : 'text-text-secondary hover:bg-surface-hover') +
+        (dropActive ? ' ring-1 ring-inset ring-accent bg-surface-hover' : '') +
+        (isDragging ? ' opacity-50' : '')
       }
     >
       {node.isDir ? (
@@ -149,6 +185,7 @@ export function StorageRow({
           type="button"
           data-testid="buffer-caret"
           onClick={handleCaretClick}
+          onPointerDown={(e) => e.stopPropagation()}
           aria-label={expanded ? 'Collapse' : 'Expand'}
           className="shrink-0 flex items-center justify-center text-text-muted hover:text-text-primary"
         >

--- a/spa/src/components/editor/storage/StorageRow.tsx
+++ b/spa/src/components/editor/storage/StorageRow.tsx
@@ -62,8 +62,14 @@ interface StorageRowProps {
 
 /**
  * A single storage tree row: type icon (`fileIconForPath` → `ICON_MAP`) + name +
- * metadata. Folders show a caret and toggle expand on click; files select on
- * click and open on double-click. Text files additionally render a word count
+ * metadata.
+ *
+ * Selection vs expand are separate gestures (T1b-0): a **single click anywhere
+ * on the row selects** the node (file or folder), so a folder can be the target
+ * of nesting-aware actions. The **caret** is its own button that toggles
+ * expand/collapse and stops propagation, so expanding a folder never changes the
+ * selection (and selecting never expands). **Double-click** opens a file or
+ * toggles a folder's expansion. Text files additionally render a word count
  * (decoded from the backend bytes); binary files show size only.
  */
 export function StorageRow({
@@ -104,38 +110,50 @@ export function StorageRow({
   const iconName = fileIconForPath(node.path, { isDir: node.isDir, expanded })
   const Icon = ICON_MAP[iconName] ?? ICON_MAP.File
 
-  const handleClick = () => {
-    if (node.isDir) onToggle(node.path)
-    else onSelect(node.path)
-  }
+  // Single click selects (file or folder); double-click opens a file or toggles
+  // a folder's expansion. The caret has its own handler below.
+  const handleClick = () => onSelect(node.path)
   const handleDoubleClick = () => {
-    if (!node.isDir) onOpen(node.path)
+    if (node.isDir) onToggle(node.path)
+    else onOpen(node.path)
+  }
+  const handleCaretClick = (e: React.MouseEvent) => {
+    // Stop the row's select handler so expand/collapse is independent of
+    // selection (and vice versa).
+    e.stopPropagation()
+    onToggle(node.path)
   }
 
   return (
-    <button
+    <div
       data-testid="buffer-row"
       data-name={node.name}
       data-path={node.path}
       data-isdir={node.isDir ? 'true' : 'false'}
       data-icon={iconName}
+      role="button"
+      tabIndex={0}
       aria-selected={selected}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       style={{ paddingLeft: 8 + depth * 16 }}
       className={
-        'w-full flex items-center gap-1.5 pr-3 py-1.5 text-left text-xs transition-colors ' +
+        'w-full flex items-center gap-1.5 pr-3 py-1.5 text-left text-xs transition-colors cursor-pointer ' +
         (selected
           ? 'bg-surface-selected text-text-primary'
           : 'text-text-secondary hover:bg-surface-hover')
       }
     >
       {node.isDir ? (
-        expanded ? (
-          <CaretDown size={12} className="shrink-0 text-text-muted" />
-        ) : (
-          <CaretRight size={12} className="shrink-0 text-text-muted" />
-        )
+        <button
+          type="button"
+          data-testid="buffer-caret"
+          onClick={handleCaretClick}
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+          className="shrink-0 flex items-center justify-center text-text-muted hover:text-text-primary"
+        >
+          {expanded ? <CaretDown size={12} /> : <CaretRight size={12} />}
+        </button>
       ) : (
         <span className="w-3 shrink-0" />
       )}
@@ -147,6 +165,6 @@ export function StorageRow({
           {text && wordCount !== null ? ` · ${wordCount} words` : ''}
         </span>
       )}
-    </button>
+    </div>
   )
 }

--- a/spa/src/components/editor/storage/StorageTree.tsx
+++ b/spa/src/components/editor/storage/StorageTree.tsx
@@ -5,7 +5,7 @@ interface StorageTreeProps {
   tree: TreeNode[]
   /** Full paths of currently expanded directories. */
   expanded: Set<string>
-  /** Full paths of currently selected (leaf-file) nodes. */
+  /** Full paths of currently selected nodes (files OR folders — T1b-0). */
   selected: Set<string>
   onToggle: (path: string) => void
   onSelect: (path: string) => void

--- a/spa/src/components/editor/storage/StorageTree.tsx
+++ b/spa/src/components/editor/storage/StorageTree.tsx
@@ -8,7 +8,8 @@ interface StorageTreeProps {
   /** Full paths of currently selected nodes (files OR folders — T1b-0). */
   selected: Set<string>
   onToggle: (path: string) => void
-  onSelect: (path: string) => void
+  /** Select a row; `additive` (modifier held) toggles into a multi-selection. */
+  onSelect: (path: string, additive: boolean) => void
   onOpen: (path: string) => void
 }
 

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -18,6 +18,12 @@ let backend: unknown = null
 vi.mock('../../../lib/fs-backend', () => ({
   getFsBackend: () => backend,
   registerFsBackend: vi.fn(),
+  // Capability guards (codex H1) — narrow via the same typeof check the real
+  // module uses, so the configurable `backend` here flows through unchanged.
+  supportsCreateUnique: (b: { createUnique?: unknown } | undefined | null) =>
+    typeof b?.createUnique === 'function',
+  supportsMkdirUnique: (b: { mkdirUnique?: unknown } | undefined | null) =>
+    typeof b?.mkdirUnique === 'function',
 }))
 
 beforeEach(() => {
@@ -515,5 +521,127 @@ describe('moveStorageEntry — pure recursive move + guards (T1b-6a)', () => {
     const res = await moveStorageEntry('/buffer/x.md', '/buffer/dir')
 
     expect(res).toEqual({ kind: 'error', message: 'boom' })
+  })
+})
+
+// --- codex B2: deleting a folder + one of its descendants together must not
+// half-delete then error on the now-missing descendant -----------------------
+
+describe('deleteStorageEntries — overlapping (folder + descendant) selection is normalized (B2)', () => {
+  let real: InAppBackend
+  const enc = (s: string) => new TextEncoder().encode(s)
+  const t: (key: string, params?: Record<string, string | number>) => string = (k) => k
+  const originalConfirm = window.confirm
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    real = new InAppBackend()
+    backend = real
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useEditorStore.setState({ buffers: {}, paneStates: {} })
+    window.confirm = () => true
+  })
+
+  afterEach(() => {
+    window.confirm = originalConfirm
+  })
+
+  it('B2: selecting a folder AND its descendant deletes cleanly (status deleted, not error)', async () => {
+    await real.write('/buffer/a/b.md', enc('BB'))
+    await real.write('/buffer/a/c/d.md', enc('DD'))
+    // Select the folder AND a nested descendant of it. Pre-fix the loop deleted
+    // the folder recursively, then re-deleted the now-missing descendant →
+    // not-found → status:error after the folder was already (partly) gone.
+    const deleteSpy = vi.spyOn(real, 'delete')
+
+    const res = await deleteStorageEntries(['/buffer/a', '/buffer/a/c/d.md'], t)
+
+    expect(res).toEqual({ status: 'deleted' })
+    // The descendant covered by the folder ancestor is dropped from the set, so
+    // exactly one delete (the folder) runs.
+    expect(deleteSpy).toHaveBeenCalledTimes(1)
+    expect(deleteSpy).toHaveBeenCalledWith('/buffer/a', true)
+    await expect(real.stat('/buffer/a')).rejects.toThrow()
+    await expect(real.stat('/buffer/a/c/d.md')).rejects.toThrow()
+  })
+
+  it('B2: a non-overlapping multi-select still deletes every target', async () => {
+    await real.write('/buffer/x.md', enc('XX'))
+    await real.write('/buffer/y.md', enc('YY'))
+
+    const res = await deleteStorageEntries(['/buffer/x.md', '/buffer/y.md'], t)
+
+    expect(res).toEqual({ status: 'deleted' })
+    await expect(real.stat('/buffer/x.md')).rejects.toThrow()
+    await expect(real.stat('/buffer/y.md')).rejects.toThrow()
+  })
+})
+
+// --- codex B4: renaming to the current name is a no-op success ----------------
+
+describe('renameStorageEntry — same-name rename is a no-op success (B4)', () => {
+  let real: InAppBackend
+  const enc = (s: string) => new TextEncoder().encode(s)
+  const dec = (b: Uint8Array) => new TextDecoder().decode(b)
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    real = new InAppBackend()
+    backend = real
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useEditorStore.setState({ buffers: {}, paneStates: {} })
+  })
+
+  it('B4: rename to the same basename returns ok WITHOUT calling backend.rename', async () => {
+    await real.write('/buffer/foo.md', enc('hello'))
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await renameStorageEntry('/buffer/foo.md', 'foo.md')
+
+    expect(res).toEqual({ ok: true })
+    expect(renameSpy).not.toHaveBeenCalled()
+    // Untouched: the same-name short-circuit never reached the collision scan
+    // (which would have rejected the source as its own target).
+    expect(dec(await real.read('/buffer/foo.md'))).toBe('hello')
+  })
+
+  it('B4: same-name rename of a folder is also a no-op success', async () => {
+    await real.write('/buffer/dir/x.md', enc('X'))
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await renameStorageEntry('/buffer/dir', 'dir')
+
+    expect(res).toEqual({ ok: true })
+    expect(renameSpy).not.toHaveBeenCalled()
+    expect(dec(await real.read('/buffer/dir/x.md'))).toBe('X')
+  })
+})
+
+// --- codex D2 (AC-1b clause 6): rapid/concurrent new-file reservations from the
+// Storage entry point converge on the atomic namer — distinct keys, never shared
+
+describe('createStorageFile — concurrent reservations get distinct keys (D2 / #854)', () => {
+  let real: InAppBackend
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    real = new InAppBackend()
+    backend = real
+  })
+
+  it('D2: two concurrent createStorageFile calls reserve two distinct paths (no shared key)', async () => {
+    const [a, b] = await Promise.all([
+      createStorageFile('/buffer'),
+      createStorageFile('/buffer'),
+    ])
+    expect(a.error).toBeUndefined()
+    expect(b.error).toBeUndefined()
+    // Both reservations materialized as two distinct files under /buffer.
+    const entries = await real.list('/buffer')
+    const names = entries.map((e) => e.name).sort()
+    expect(names).toEqual(['Untitled-1.md', 'Untitled.md'])
   })
 })

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { createStorageFile, renameStorageEntry } from './storage-actions'
+import {
+  createStorageFile,
+  createStorageFolder,
+  renameStorageEntry,
+} from './storage-actions'
 
 // Configurable backend: default null so we exercise the "missing backend" guard.
 let backend: unknown = null
@@ -19,8 +23,37 @@ describe('storage-actions — missing In-App backend is a failure, not silent su
     expect(res.error).toBeTruthy()
   })
 
+  it('createStorageFolder returns an error when the backend is missing', async () => {
+    const res = await createStorageFolder()
+    expect('error' in res && res.error).toBeTruthy()
+  })
+
   it('renameStorageEntry returns a kind:error outcome (so the rename popover is not closed as if it worked)', async () => {
     const res = await renameStorageEntry('/buffer/a.md', 'b.md')
     expect(res).toEqual({ kind: 'error', message: expect.any(String) })
+  })
+})
+
+describe('createStorageFolder — mkdirUnique delegation (T1b-3)', () => {
+  it('calls mkdirUnique with the target dir and returns the reserved path', async () => {
+    const mkdirUnique = vi.fn().mockResolvedValue('/buffer/sub/New Folder')
+    backend = { mkdirUnique }
+    const res = await createStorageFolder('/buffer/sub')
+    expect(mkdirUnique).toHaveBeenCalledWith('/buffer/sub')
+    expect(res).toEqual({ path: '/buffer/sub/New Folder' })
+  })
+
+  it('defaults the target dir to the storage root', async () => {
+    const mkdirUnique = vi.fn().mockResolvedValue('/buffer/New Folder')
+    backend = { mkdirUnique }
+    const res = await createStorageFolder()
+    expect(mkdirUnique).toHaveBeenCalledWith('/buffer')
+    expect(res).toEqual({ path: '/buffer/New Folder' })
+  })
+
+  it('surfaces a backend failure as an error outcome', async () => {
+    backend = { mkdirUnique: vi.fn().mockRejectedValue(new Error('boom')) }
+    const res = await createStorageFolder('/buffer')
+    expect('error' in res && res.error).toBe('boom')
   })
 })

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   createStorageFile,
   createStorageFolder,
+  deleteStorageEntries,
   renameStorageEntry,
 } from './storage-actions'
 import { InAppBackend } from '../../../lib/fs-backend-inapp'
@@ -253,5 +254,129 @@ describe('renameStorageEntry — file + folder via one backend.rename + pure rem
     expect(tab.layout.pane.content).toMatchObject({ kind: 'image-preview', filePath: '/buffer/z/p.png' })
     // A preview pane has no editor buffer — none must be conjured by the remap.
     expect(useEditorStore.getState().buffers['inapp:/buffer/z/p.png']).toBeUndefined()
+  })
+})
+
+// --- T1b-5: recursive delete with folder-aware locked/dirty guards ------------
+//
+// Same real-backend harness: a folder delete must sweep every descendant
+// (recursive), and the locked/dirty guards must fire when ANY affected pane is a
+// descendant of a deleted folder (not just an exact-path match). The window
+// confirm is stubbed per-case.
+
+describe('deleteStorageEntries — recursive folder delete + descendant-aware guards (T1b-5)', () => {
+  let real: InAppBackend
+  const enc = (s: string) => new TextEncoder().encode(s)
+  const t: (key: string, params?: Record<string, string | number>) => string = (k) => k
+  const originalConfirm = window.confirm
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    real = new InAppBackend()
+    backend = real
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useEditorStore.setState({ buffers: {}, paneStates: {} })
+    window.confirm = () => true
+  })
+
+  afterEach(() => {
+    window.confirm = originalConfirm
+  })
+
+  it('T5-1: folder delete removes the folder + ALL descendants (list empty under it)', async () => {
+    await real.write('/buffer/a/b.md', enc('BB'))
+    await real.write('/buffer/a/c/d.md', enc('DD'))
+    await real.write('/buffer/keep.md', enc('K'))
+
+    const res = await deleteStorageEntries(['/buffer/a'], t)
+
+    expect(res).toEqual({ status: 'deleted' })
+    await expect(real.stat('/buffer/a')).rejects.toThrow()
+    await expect(real.stat('/buffer/a/b.md')).rejects.toThrow()
+    await expect(real.stat('/buffer/a/c/d.md')).rejects.toThrow()
+    // Sibling outside the folder is untouched.
+    expect(await real.list('/buffer')).toEqual([
+      expect.objectContaining({ name: 'keep.md', isDir: false }),
+    ])
+  })
+
+  it('T5-2: a descendant open in a LOCKED tab refuses the whole delete (nothing deleted)', async () => {
+    await real.write('/buffer/a/b.md', enc('BB'))
+    useTabStore.setState({
+      tabs: { T1: { ...makeEditorTab('T1', 'P1', '/buffer/a/b.md'), locked: true } },
+      tabOrder: ['T1'],
+      activeTabId: 'T1',
+      visitHistory: [],
+    })
+
+    const res = await deleteStorageEntries(['/buffer/a'], t)
+
+    expect(res.status).toBe('refused')
+    // Refused before any mutation: the folder + descendant are intact.
+    expect((await real.stat('/buffer/a')).isDirectory).toBe(true)
+    expect(new TextDecoder().decode(await real.read('/buffer/a/b.md'))).toBe('BB')
+  })
+
+  it('T5-3: a DIRTY descendant triggers the dirty confirm — confirm deletes, cancel no-ops', async () => {
+    await real.write('/buffer/a/b.md', enc('BB'))
+    useTabStore.setState({
+      tabs: { T1: makeEditorTab('T1', 'P1', '/buffer/a/b.md') },
+      tabOrder: ['T1'],
+      activeTabId: 'T1',
+      visitHistory: [],
+    })
+    seedBuffer('/buffer/a/b.md', 'P1')
+    // Mark the descendant buffer dirty so the dirty-specific confirm wins.
+    useEditorStore.setState((s) => ({
+      buffers: { ...s.buffers, 'inapp:/buffer/a/b.md': { ...s.buffers['inapp:/buffer/a/b.md'], isDirty: true } },
+    }))
+
+    // Case 1: cancel → cancelled, nothing deleted.
+    const cancelSpy = vi.fn(() => false)
+    window.confirm = cancelSpy
+    const cancelled = await deleteStorageEntries(['/buffer/a'], t)
+    expect(cancelled).toEqual({ status: 'cancelled' })
+    expect(cancelSpy).toHaveBeenCalledTimes(1)
+    expect(cancelSpy.mock.calls[0][0]).toContain('delete_dirty_confirm')
+    expect((await real.stat('/buffer/a/b.md')).isDirectory).toBe(false)
+
+    // Case 2: confirm → deleted (folder + descendant gone).
+    const okSpy = vi.fn(() => true)
+    window.confirm = okSpy
+    const deleted = await deleteStorageEntries(['/buffer/a'], t)
+    expect(deleted).toEqual({ status: 'deleted' })
+    expect(okSpy.mock.calls[0][0]).toContain('delete_dirty_confirm')
+    await expect(real.stat('/buffer/a')).rejects.toThrow()
+    await expect(real.stat('/buffer/a/b.md')).rejects.toThrow()
+  })
+
+  it('T5-4: file delete (1a regression) still guarded + works', async () => {
+    await real.write('/buffer/x.md', enc('XX'))
+    const okSpy = vi.fn(() => true)
+    window.confirm = okSpy
+
+    const res = await deleteStorageEntries(['/buffer/x.md'], t)
+
+    expect(res).toEqual({ status: 'deleted' })
+    expect(okSpy).toHaveBeenCalledTimes(1)
+    // A lone file uses the single-file confirm, not the dirty one.
+    expect(okSpy.mock.calls[0][0]).toContain('delete_one_confirm')
+    await expect(real.stat('/buffer/x.md')).rejects.toThrow()
+  })
+
+  it('T5-4b: file delete open in a LOCKED tab is refused (regression)', async () => {
+    await real.write('/buffer/x.md', enc('XX'))
+    useTabStore.setState({
+      tabs: { T1: { ...makeEditorTab('T1', 'P1', '/buffer/x.md'), locked: true } },
+      tabOrder: ['T1'],
+      activeTabId: 'T1',
+      visitHistory: [],
+    })
+
+    const res = await deleteStorageEntries(['/buffer/x.md'], t)
+
+    expect(res.status).toBe('refused')
+    expect(new TextDecoder().decode(await real.read('/buffer/x.md'))).toBe('XX')
   })
 })

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -4,6 +4,11 @@ import {
   createStorageFolder,
   renameStorageEntry,
 } from './storage-actions'
+import { InAppBackend } from '../../../lib/fs-backend-inapp'
+import { closeAllIDB } from '../../../lib/storage/idb'
+import { useTabStore } from '../../../stores/useTabStore'
+import { useEditorStore } from '../../../stores/useEditorStore'
+import type { Tab } from '../../../types/tab'
 
 // Configurable backend: default null so we exercise the "missing backend" guard.
 let backend: unknown = null
@@ -55,5 +60,198 @@ describe('createStorageFolder — mkdirUnique delegation (T1b-3)', () => {
     backend = { mkdirUnique: vi.fn().mockRejectedValue(new Error('boom')) }
     const res = await createStorageFolder('/buffer')
     expect('error' in res && res.error).toBe('boom')
+  })
+})
+
+// --- T1b-4: in-place rename (file + folder) via a SINGLE backend.rename +
+// pure remapPanesUnder -------------------------------------------------------
+//
+// These cases exercise the REAL InAppBackend (fake-indexeddb) + the REAL tab /
+// editor stores, so we verify the full path: one backend re-key (recursive for
+// folders, T1b-1) followed by a pure pane/buffer re-point that touches NO
+// backend. The fs-backend module mock returns whatever `backend` points at, so
+// assigning a real InAppBackend here routes storage-actions through it.
+
+function deleteInappDB(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase('pdx-inapp-fs')
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => reject(new Error('deleteDatabase blocked — connection not closed'))
+  })
+}
+
+function makeEditorTab(tabId: string, paneId: string, filePath: string): Tab {
+  return {
+    id: tabId,
+    pinned: false,
+    locked: false,
+    createdAt: Date.now(),
+    layout: {
+      type: 'leaf',
+      pane: { id: paneId, content: { kind: 'editor', source: { type: 'inapp' }, filePath } },
+    },
+  }
+}
+
+function makePreviewTab(
+  tabId: string,
+  paneId: string,
+  filePath: string,
+  kind: 'image-preview' | 'pdf-preview',
+): Tab {
+  return {
+    id: tabId,
+    pinned: false,
+    locked: false,
+    createdAt: Date.now(),
+    layout: {
+      type: 'leaf',
+      pane: { id: paneId, content: { kind, source: { type: 'inapp' }, filePath } },
+    },
+  }
+}
+
+function seedBuffer(filePath: string, paneId: string, languageSource: 'extension' | 'manual' = 'extension', language = 'markdown') {
+  useEditorStore.setState({
+    buffers: {
+      [`inapp:${filePath}`]: {
+        content: 'X',
+        savedContent: 'X',
+        isDirty: false,
+        lastStat: null,
+        modelId: 'm1',
+        language,
+        languageSource,
+        eol: 'lf',
+        encoding: 'utf8',
+      },
+    },
+    paneStates: {
+      [paneId]: {
+        bufferKey: `inapp:${filePath}`,
+        editorMode: 'raw',
+        showDiff: false,
+        cursorPosition: { line: 1, column: 1 },
+        monacoViewState: null,
+        tiptapViewState: null,
+      },
+    },
+  })
+}
+
+describe('renameStorageEntry — file + folder via one backend.rename + pure remapPanesUnder (T1b-4)', () => {
+  let real: InAppBackend
+  const enc = (s: string) => new TextEncoder().encode(s)
+  const dec = (b: Uint8Array) => new TextDecoder().decode(b)
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    real = new InAppBackend()
+    backend = real // overrides the top-level `backend = null`
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useEditorStore.setState({ buffers: {}, paneStates: {} })
+  })
+
+  it('T4-1: file rename — old gone, new present, content + mtime intact, exactly one backend.rename', async () => {
+    await real.write('/buffer/a.md', enc('hello'))
+    const before = await real.stat('/buffer/a.md')
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await renameStorageEntry('/buffer/a.md', 'b.md')
+
+    expect(res).toEqual({ ok: true })
+    expect(renameSpy).toHaveBeenCalledTimes(1)
+    expect(renameSpy).toHaveBeenCalledWith('/buffer/a.md', '/buffer/b.md')
+    await expect(real.stat('/buffer/a.md')).rejects.toThrow()
+    expect(dec(await real.read('/buffer/b.md'))).toBe('hello')
+    expect((await real.stat('/buffer/b.md')).mtime).toBe(before.mtime)
+  })
+
+  it('T4-2: file rename onto an existing path — refused, NO mutation (source + target untouched)', async () => {
+    await real.write('/buffer/a.md', enc('AAA'))
+    await real.write('/buffer/b.md', enc('BBB'))
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await renameStorageEntry('/buffer/a.md', 'b.md')
+
+    expect(res).toEqual({ kind: 'exists' })
+    expect(renameSpy).not.toHaveBeenCalled()
+    expect(dec(await real.read('/buffer/a.md'))).toBe('AAA')
+    expect(dec(await real.read('/buffer/b.md'))).toBe('BBB')
+  })
+
+  it('T4-3: folder rename moves ≥2 nested descendants (AC-1b), one backend.rename', async () => {
+    await real.write('/buffer/a/b.md', enc('BB'))
+    await real.write('/buffer/a/c/d.md', enc('DD'))
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await renameStorageEntry('/buffer/a', 'z')
+
+    expect(res).toEqual({ ok: true })
+    expect(renameSpy).toHaveBeenCalledTimes(1)
+    expect(renameSpy).toHaveBeenCalledWith('/buffer/a', '/buffer/z')
+    expect(dec(await real.read('/buffer/z/b.md'))).toBe('BB')
+    expect(dec(await real.read('/buffer/z/c/d.md'))).toBe('DD')
+    await expect(real.stat('/buffer/a')).rejects.toThrow()
+    await expect(real.stat('/buffer/a/b.md')).rejects.toThrow()
+    await expect(real.stat('/buffer/a/c/d.md')).rejects.toThrow()
+  })
+
+  it('T4-4: folder rename onto an existing folder name — refused before any mutation', async () => {
+    await real.write('/buffer/a/b.md', enc('BB'))
+    await real.write('/buffer/z/keep.md', enc('K')) // z already exists as a dir
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await renameStorageEntry('/buffer/a', 'z')
+
+    expect(res).toEqual({ kind: 'exists' })
+    expect(renameSpy).not.toHaveBeenCalled()
+    expect(dec(await real.read('/buffer/a/b.md'))).toBe('BB')
+    expect(dec(await real.read('/buffer/z/keep.md'))).toBe('K')
+  })
+
+  it('T4-5: folder rename re-points an open EDITOR descendant pane (no stale/orphan buffer)', async () => {
+    await real.write('/buffer/a/b.md', enc('content'))
+    useTabStore.setState({
+      tabs: { T1: makeEditorTab('T1', 'P1', '/buffer/a/b.md') },
+      tabOrder: ['T1'],
+      activeTabId: 'T1',
+      visitHistory: [],
+    })
+    seedBuffer('/buffer/a/b.md', 'P1')
+
+    const res = await renameStorageEntry('/buffer/a', 'z')
+
+    expect(res).toEqual({ ok: true })
+    const tab = useTabStore.getState().tabs.T1
+    expect(tab.layout.type).toBe('leaf')
+    if (tab.layout.type !== 'leaf') throw new Error('expected leaf')
+    expect(tab.layout.pane.content).toMatchObject({ kind: 'editor', filePath: '/buffer/z/b.md' })
+    const ed = useEditorStore.getState()
+    expect(ed.buffers['inapp:/buffer/z/b.md']).toBeDefined()
+    expect(ed.buffers['inapp:/buffer/a/b.md']).toBeUndefined()
+    expect(ed.paneStates.P1?.bufferKey).toBe('inapp:/buffer/z/b.md')
+  })
+
+  it('T4-5b: folder rename re-points an open IMAGE-PREVIEW descendant pane (no spurious editor buffer)', async () => {
+    await real.write('/buffer/a/p.png', enc('PNG'))
+    useTabStore.setState({
+      tabs: { T2: makePreviewTab('T2', 'P2', '/buffer/a/p.png', 'image-preview') },
+      tabOrder: ['T2'],
+      activeTabId: 'T2',
+      visitHistory: [],
+    })
+    useEditorStore.setState({ buffers: {}, paneStates: {} })
+
+    const res = await renameStorageEntry('/buffer/a', 'z')
+
+    expect(res).toEqual({ ok: true })
+    const tab = useTabStore.getState().tabs.T2
+    if (tab.layout.type !== 'leaf') throw new Error('expected leaf')
+    expect(tab.layout.pane.content).toMatchObject({ kind: 'image-preview', filePath: '/buffer/z/p.png' })
+    // A preview pane has no editor buffer — none must be conjured by the remap.
+    expect(useEditorStore.getState().buffers['inapp:/buffer/z/p.png']).toBeUndefined()
   })
 })

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -334,7 +334,7 @@ describe('deleteStorageEntries — recursive folder delete + descendant-aware gu
     }))
 
     // Case 1: cancel → cancelled, nothing deleted.
-    const cancelSpy = vi.fn(() => false)
+    const cancelSpy = vi.fn((_message?: string) => false)
     window.confirm = cancelSpy
     const cancelled = await deleteStorageEntries(['/buffer/a'], t)
     expect(cancelled).toEqual({ status: 'cancelled' })
@@ -343,7 +343,7 @@ describe('deleteStorageEntries — recursive folder delete + descendant-aware gu
     expect((await real.stat('/buffer/a/b.md')).isDirectory).toBe(false)
 
     // Case 2: confirm → deleted (folder + descendant gone).
-    const okSpy = vi.fn(() => true)
+    const okSpy = vi.fn((_message?: string) => true)
     window.confirm = okSpy
     const deleted = await deleteStorageEntries(['/buffer/a'], t)
     expect(deleted).toEqual({ status: 'deleted' })
@@ -354,7 +354,7 @@ describe('deleteStorageEntries — recursive folder delete + descendant-aware gu
 
   it('T5-4: file delete (1a regression) still guarded + works', async () => {
     await real.write('/buffer/x.md', enc('XX'))
-    const okSpy = vi.fn(() => true)
+    const okSpy = vi.fn((_message?: string) => true)
     window.confirm = okSpy
 
     const res = await deleteStorageEntries(['/buffer/x.md'], t)

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -3,6 +3,7 @@ import {
   createStorageFile,
   createStorageFolder,
   deleteStorageEntries,
+  moveStorageEntry,
   renameStorageEntry,
 } from './storage-actions'
 import { InAppBackend } from '../../../lib/fs-backend-inapp'
@@ -378,5 +379,141 @@ describe('deleteStorageEntries — recursive folder delete + descendant-aware gu
 
     expect(res.status).toBe('refused')
     expect(new TextDecoder().decode(await real.read('/buffer/x.md'))).toBe('XX')
+  })
+})
+
+// --- T1b-6a: pure recursive move (drag target = a directory) via a SINGLE
+// backend.rename + pure remapPanesUnder --------------------------------------
+//
+// Same real-backend + real-store harness as rename: `moveStorageEntry(from,
+// targetDir)` computes `to = targetDir/basename(from)` and re-uses the exact
+// rename machinery — one recursive backend.rename (T1b-1) + the pure
+// remapPanesUnder re-point (T1b-4). The no-op guards (already-there / into self
+// / into own descendant) and the pre-mutation collision check must fire WITHOUT
+// any backend.rename, asserted with a spy.
+
+describe('moveStorageEntry — pure recursive move + guards (T1b-6a)', () => {
+  let real: InAppBackend
+  const enc = (s: string) => new TextEncoder().encode(s)
+  const dec = (b: Uint8Array) => new TextDecoder().decode(b)
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    real = new InAppBackend()
+    backend = real
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useEditorStore.setState({ buffers: {}, paneStates: {} })
+  })
+
+  it('T6-1: move a file into a folder — old gone, new under folder, content intact, one rename', async () => {
+    await real.write('/buffer/x.md', enc('hello'))
+    await real.mkdir('/buffer/dir')
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await moveStorageEntry('/buffer/x.md', '/buffer/dir')
+
+    expect(res).toEqual({ ok: true })
+    expect(renameSpy).toHaveBeenCalledTimes(1)
+    expect(renameSpy).toHaveBeenCalledWith('/buffer/x.md', '/buffer/dir/x.md')
+    await expect(real.stat('/buffer/x.md')).rejects.toThrow()
+    expect(dec(await real.read('/buffer/dir/x.md'))).toBe('hello')
+  })
+
+  it('T6-2: move a folder into another folder — ≥2 nested descendants re-keyed (AC-1b), one rename', async () => {
+    await real.write('/buffer/a/b.md', enc('BB'))
+    await real.write('/buffer/a/c/d.md', enc('DD'))
+    await real.mkdir('/buffer/dest')
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await moveStorageEntry('/buffer/a', '/buffer/dest')
+
+    expect(res).toEqual({ ok: true })
+    expect(renameSpy).toHaveBeenCalledTimes(1)
+    expect(renameSpy).toHaveBeenCalledWith('/buffer/a', '/buffer/dest/a')
+    expect(dec(await real.read('/buffer/dest/a/b.md'))).toBe('BB')
+    expect(dec(await real.read('/buffer/dest/a/c/d.md'))).toBe('DD')
+    await expect(real.stat('/buffer/a')).rejects.toThrow()
+    await expect(real.stat('/buffer/a/b.md')).rejects.toThrow()
+    await expect(real.stat('/buffer/a/c/d.md')).rejects.toThrow()
+  })
+
+  it('T6-3a: move onto the CURRENT parent dir — no-op, no mutation', async () => {
+    await real.write('/buffer/a/b.md', enc('BB'))
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await moveStorageEntry('/buffer/a/b.md', '/buffer/a')
+
+    expect(res).toEqual({ kind: 'noop' })
+    expect(renameSpy).not.toHaveBeenCalled()
+    expect(dec(await real.read('/buffer/a/b.md'))).toBe('BB')
+  })
+
+  it('T6-3b: move a folder onto ITSELF — no-op, no mutation', async () => {
+    await real.write('/buffer/a/b.md', enc('BB'))
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await moveStorageEntry('/buffer/a', '/buffer/a')
+
+    expect(res).toEqual({ kind: 'noop' })
+    expect(renameSpy).not.toHaveBeenCalled()
+    expect((await real.stat('/buffer/a')).isDirectory).toBe(true)
+    expect(dec(await real.read('/buffer/a/b.md'))).toBe('BB')
+  })
+
+  it('T6-3c: move a folder into its OWN descendant — no-op, no mutation', async () => {
+    await real.write('/buffer/a/c/d.md', enc('DD'))
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await moveStorageEntry('/buffer/a', '/buffer/a/c')
+
+    expect(res).toEqual({ kind: 'noop' })
+    expect(renameSpy).not.toHaveBeenCalled()
+    expect(dec(await real.read('/buffer/a/c/d.md'))).toBe('DD')
+  })
+
+  it('T6-4: move where the target name already exists — refused (exists), no mutation', async () => {
+    await real.write('/buffer/x.md', enc('AAA'))
+    await real.write('/buffer/dir/x.md', enc('BBB')) // collision at /buffer/dir/x.md
+    const renameSpy = vi.spyOn(real, 'rename')
+
+    const res = await moveStorageEntry('/buffer/x.md', '/buffer/dir')
+
+    expect(res).toEqual({ kind: 'exists' })
+    expect(renameSpy).not.toHaveBeenCalled()
+    expect(dec(await real.read('/buffer/x.md'))).toBe('AAA')
+    expect(dec(await real.read('/buffer/dir/x.md'))).toBe('BBB')
+  })
+
+  it('T6-5: moving a folder with an OPEN editor descendant re-points the pane (no stale buffer)', async () => {
+    await real.write('/buffer/a/b.md', enc('content'))
+    await real.mkdir('/buffer/dest')
+    useTabStore.setState({
+      tabs: { T1: makeEditorTab('T1', 'P1', '/buffer/a/b.md') },
+      tabOrder: ['T1'],
+      activeTabId: 'T1',
+      visitHistory: [],
+    })
+    seedBuffer('/buffer/a/b.md', 'P1')
+
+    const res = await moveStorageEntry('/buffer/a', '/buffer/dest')
+
+    expect(res).toEqual({ ok: true })
+    const tab = useTabStore.getState().tabs.T1
+    if (tab.layout.type !== 'leaf') throw new Error('expected leaf')
+    expect(tab.layout.pane.content).toMatchObject({ kind: 'editor', filePath: '/buffer/dest/a/b.md' })
+    const ed = useEditorStore.getState()
+    expect(ed.buffers['inapp:/buffer/dest/a/b.md']).toBeDefined()
+    expect(ed.buffers['inapp:/buffer/a/b.md']).toBeUndefined()
+    expect(ed.paneStates.P1?.bufferKey).toBe('inapp:/buffer/dest/a/b.md')
+  })
+
+  it('T6-error: surfaces a backend rename failure as a kind:error outcome', async () => {
+    await real.write('/buffer/x.md', enc('hello'))
+    vi.spyOn(real, 'rename').mockRejectedValueOnce(new Error('boom'))
+
+    const res = await moveStorageEntry('/buffer/x.md', '/buffer/dir')
+
+    expect(res).toEqual({ kind: 'error', message: 'boom' })
   })
 })

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -10,8 +10,10 @@
  * dirty-pane confirm + locked-tab refusal guards are preserved verbatim.
  *
  * Phase 1b: new-file now goes through the unified eager `createUniqueInAppFile`
- * namer (atomic IDB reservation, #854) and accepts a `targetDir`. Folder mkdir /
- * rename / recursive move land in their own 1b tasks.
+ * namer (atomic IDB reservation, #854) and accepts a `targetDir`. Folder mkdir
+ * (`createStorageFolder`) and in-place rename of files AND folders
+ * (`renameStorageEntry` + the pure `remapPanesUnder` re-point) have landed;
+ * recursive move (drag) lands in T1b-6.
  */
 import { getFsBackend } from '../../../lib/fs-backend'
 import { createUniqueInAppFile } from '../../../lib/inapp-namer'
@@ -27,26 +29,59 @@ import type { Pane, Tab } from '../../../types/tab'
 
 export type Translate = (key: string, params?: Record<string, string | number>) => string
 
-// v1.5 G1 fix — mirror EditorPane's rename three-step sync (backend →
-// tab-layout → editor-store). Without this, renaming via the storage pane
-// leaves the editor store keyed by the old path: a subsequent Save would write
-// to the stale filename and a re-open would resurrect a ghost buffer. The
-// `renameBuffer` metadata argument also refreshes language + languageSource
-// when crossing file extensions (preserve a manual override, otherwise
-// recompute from the new path — same contract as `EditorPane.handleRenameSubmit`).
-export async function performBufferRename(fromPath: string, targetPath: string) {
-  const backend = getFsBackend({ type: 'inapp' })
-  if (!backend) throw new Error('InApp backend unavailable')
-  await backend.rename(fromPath, targetPath)
-  const source: FileSource = { type: 'inapp' }
-  useTabStore.getState().renameEditorPanes(source, fromPath, targetPath)
-  const oldKey = bufferKey(source, fromPath)
-  const newKey = bufferKey(source, targetPath)
-  const currentBuffer = useEditorStore.getState().buffers[oldKey]
-  const nextMetadata = currentBuffer?.languageSource === 'manual'
-    ? { language: currentBuffer.language, languageSource: 'manual' as const }
-    : createMetadata(source, targetPath)
-  useEditorStore.getState().renameBuffer(oldKey, newKey, nextMetadata)
+/**
+ * remapPanesUnder — PURE pane + buffer re-point for a rename/move that has
+ * ALREADY happened at the backend layer. It performs NO backend mutation: the
+ * single `backend.rename` lives in the caller (`renameStorageEntry`, and the
+ * future `moveStorageEntry`) and runs exactly once BEFORE this helper, so file
+ * and folder share one code path and there is no double-rename.
+ *
+ * It enumerates every open file pane — editor + image-preview + pdf-preview —
+ * whose `content.filePath` is `from` itself OR a `from/`-prefixed descendant
+ * (the trailing slash stops `/buffer/a` from matching `/buffer/ab`, decision 6),
+ * then for each affected path:
+ *   - re-points the tab layout via `renameEditorPanes(source, oldPath, newPath)`
+ *     (which already rewrites all three file-pane kinds), and
+ *   - for editor panes only, re-keys the editor-store buffer via
+ *     `renameBuffer(oldKey, newKey, metadata)`. The metadata mirrors the old
+ *     single-path `performBufferRename` / `EditorPane.handleRenameSubmit`:
+ *     preserve a manual language override, otherwise recompute from the new
+ *     path so crossing extensions refreshes the language.
+ *
+ * A single-file rename is the one-iteration case (`from === filePath`, so
+ * `newPath = to`); a folder rename iterates every open descendant.
+ */
+export function remapPanesUnder(source: FileSource, from: string, to: string): void {
+  const fromPrefix = from + '/'
+  // Collect each affected open path once, tracking whether any pane on that path
+  // is an editor (→ it also needs an editor-store buffer re-key, not just a
+  // layout re-point).
+  const affected = new Map<string, boolean>()
+  const { tabs } = useTabStore.getState()
+  for (const tab of Object.values(tabs)) {
+    scanPaneTree(tab.layout, (pane) => {
+      const c = pane.content
+      if (!isFilePaneContent(c)) return
+      if (c.source.type !== source.type) return
+      if (c.source.type === 'daemon' && source.type === 'daemon' && c.source.hostId !== source.hostId) return
+      if (c.filePath === from || c.filePath.startsWith(fromPrefix)) {
+        affected.set(c.filePath, (affected.get(c.filePath) ?? false) || c.kind === 'editor')
+      }
+    })
+  }
+
+  for (const [oldPath, hasEditor] of affected) {
+    const newPath = to + oldPath.slice(from.length)
+    useTabStore.getState().renameEditorPanes(source, oldPath, newPath)
+    if (!hasEditor) continue
+    const oldKey = bufferKey(source, oldPath)
+    const newKey = bufferKey(source, newPath)
+    const currentBuffer = useEditorStore.getState().buffers[oldKey]
+    const nextMetadata = currentBuffer?.languageSource === 'manual'
+      ? { language: currentBuffer.language, languageSource: 'manual' as const }
+      : createMetadata(source, newPath)
+    useEditorStore.getState().renameBuffer(oldKey, newKey, nextMetadata)
+  }
 }
 
 /**
@@ -92,10 +127,14 @@ export type RenameOutcome =
   | { kind: 'error'; message: string }
 
 /**
- * Rename a leaf file identified by its **full path**. `newName` is a basename;
- * the file stays in its own directory (`parentOf(fromPath)`). A `stat` pre-check
- * aborts before any backend mutation if the destination already exists (F4 —
- * `InAppBackend.rename` is a blind overwrite).
+ * In-place rename of a **file or folder** identified by its full path —
+ * one uniform path, no branch, no double-rename (T1b-4). `newName` is a
+ * basename; the entry stays in its own directory (`parentOf(fromPath)`). A
+ * `stat` pre-check aborts before any backend mutation if the destination
+ * already exists (F4). The lone backend mutation is a single
+ * `backend.rename` (recursive re-key of folder descendants, T1b-1), followed
+ * by the pure `remapPanesUnder` re-point — so a folder rename moves every
+ * descendant and re-points every open descendant pane in one shot.
  */
 export async function renameStorageEntry(
   fromPath: string,
@@ -114,7 +153,9 @@ export async function renameStorageEntry(
     if (exists) return { kind: 'exists' }
   }
   try {
-    await performBufferRename(fromPath, targetPath)
+    // The ONLY backend mutation for rename — exactly once, file and folder alike.
+    await backend.rename(fromPath, targetPath)
+    remapPanesUnder({ type: 'inapp' }, fromPath, targetPath)
     return { ok: true }
   } catch (err) {
     return { kind: 'error', message: err instanceof Error ? err.message : String(err) }

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -66,6 +66,26 @@ export async function createStorageFile(targetDir: string = STORAGE_ROOT): Promi
   }
 }
 
+/**
+ * Create a new empty folder under `targetDir` (defaults to the storage root)
+ * via the atomic `mkdirUnique` reservation (decision 7), giving a collision-free
+ * `New Folder[ N]` even under a rapid double-click. Returns the reserved path or
+ * an error (a missing backend is a failure, not a silent success — symmetric
+ * with `createStorageFile`).
+ */
+export async function createStorageFolder(
+  targetDir: string = STORAGE_ROOT,
+): Promise<{ path: string } | { error: string }> {
+  const backend = getFsBackend({ type: 'inapp' })
+  if (!backend) return { error: 'InApp backend unavailable' }
+  try {
+    const path = await backend.mkdirUnique(targetDir)
+    return { path }
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
 export type RenameOutcome =
   | { ok: true }
   | { kind: 'exists' }

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -16,7 +16,7 @@
  * The recursive move data layer (`moveStorageEntry`, T1b-6a) reuses that same
  * single-rename + `remapPanesUnder` path; the drag-and-drop wiring is T1b-6b.
  */
-import { getFsBackend } from '../../../lib/fs-backend'
+import { getFsBackend, supportsMkdirUnique } from '../../../lib/fs-backend'
 import { createUniqueInAppFile } from '../../../lib/inapp-namer'
 import { bufferKey } from '../../../lib/editor-buffer-key'
 import { scanPaneTree } from '../../../lib/pane-tree'
@@ -113,7 +113,9 @@ export async function createStorageFolder(
   targetDir: string = STORAGE_ROOT,
 ): Promise<{ path: string } | { error: string }> {
   const backend = getFsBackend({ type: 'inapp' })
-  if (!backend) return { error: 'InApp backend unavailable' }
+  // Narrow to the mkdir-unique capability (codex H1) — it lives on the optional
+  // `SupportsUniqueCreate`, not the base `FsBackend`.
+  if (!supportsMkdirUnique(backend)) return { error: 'InApp backend unavailable' }
   try {
     const path = await backend.mkdirUnique(targetDir)
     return { path }
@@ -146,13 +148,17 @@ export async function renameStorageEntry(
   // the rename popover and clear selection as if the rename happened.
   if (!backend) return { kind: 'error', message: 'InApp backend unavailable' }
   const targetPath = join(parentOf(fromPath), newName)
-  if (targetPath !== fromPath) {
-    const exists = await backend
-      .stat(targetPath)
-      .then(() => true)
-      .catch(() => false)
-    if (exists) return { kind: 'exists' }
-  }
+  // Same-name rename is a no-op success (codex B4): if the new basename equals
+  // the current one, `targetPath === fromPath`. Short-circuit BEFORE the stat /
+  // rename — otherwise `backend.rename(from, from)` runs its collision scan and
+  // sees the source itself as a same-path collision, rejecting a confirmation
+  // the user meant as "keep the name". Returning ok closes the popover cleanly.
+  if (targetPath === fromPath) return { ok: true }
+  const exists = await backend
+    .stat(targetPath)
+    .then(() => true)
+    .catch(() => false)
+  if (exists) return { kind: 'exists' }
   try {
     // The ONLY backend mutation for rename — exactly once, file and folder alike.
     await backend.rename(fromPath, targetPath)
@@ -228,27 +234,6 @@ export async function moveStorageEntry(
   }
 }
 
-/**
- * Pure resolver for a drag-and-drop drop (T1b-6b): maps the dnd-kit `active`
- * (the dragged row, id = full path) and `over` (the drop target, id = a folder
- * path OR the `STORAGE_ROOT` sentinel on the root region) into the
- * `{ from, targetDir }` pair to hand to `moveStorageEntry`. Returns `null` when
- * the drop landed on empty space (`over` is nullish) so the caller no-ops.
- *
- * The over-id IS the target directory in both cases (a folder path, or the root
- * sentinel which equals the real root dir), so no branch is needed. All the
- * inert-move / self / own-descendant / collision guards stay in
- * `moveStorageEntry` — this is a thin, unit-testable mapping kept here (rather
- * than in the pane component) so the `.tsx` only exports components.
- */
-export function computeMoveFromDragEnd(
-  active: { id: string | number } | null | undefined,
-  over: { id: string | number } | null | undefined,
-): { from: string; targetDir: string } | null {
-  if (!active || !over) return null
-  return { from: String(active.id), targetDir: String(over.id) }
-}
-
 export type DeleteOutcome =
   | { status: 'deleted' }
   | { status: 'cancelled' }
@@ -286,6 +271,17 @@ export async function deleteStorageEntries(
   const backend = getFsBackend({ type: 'inapp' })
   if (!backend) return { status: 'cancelled' }
 
+  // Normalize the selection (codex B2): drop any target already covered by an
+  // ancestor target (`t` is under some other `o`). Selecting a folder AND one of
+  // its descendants would otherwise recursively delete the folder first, then
+  // re-delete the now-missing descendant — a not-found error AFTER the panes are
+  // already closed and the folder partially gone (half-deleted state). The
+  // pane-close scan, the confirm count and the delete loop all operate on this
+  // normalized set so each surviving target is deleted exactly once.
+  const normalized = targets.filter(
+    (t) => !targets.some((o) => o !== t && t.startsWith(o + '/')),
+  )
+
   const { tabs } = useTabStore.getState()
   const openPanes: Array<[string, Pane]> = []
   for (const [tabId, tab] of Object.entries(tabs) as Array<[string, Tab]>) {
@@ -295,7 +291,7 @@ export async function deleteStorageEntries(
       // so deleting a png/pdf open in a preview pane — or anything nested under
       // a deleted folder — fires the locked-tab refusal, closes the pane, and
       // leaves no stale tab behind.
-      if (isFilePaneContent(c) && c.source.type === 'inapp' && isAffectedByTargets(c.filePath, targets)) {
+      if (isFilePaneContent(c) && c.source.type === 'inapp' && isAffectedByTargets(c.filePath, normalized)) {
         openPanes.push([tabId, pane])
       }
     })
@@ -319,12 +315,12 @@ export async function deleteStorageEntries(
     if (!window.confirm(t('editor.buffers.delete_dirty_confirm', { count: dirtyHits.length }))) {
       return { status: 'cancelled' }
     }
-  } else if (targets.length === 1) {
+  } else if (normalized.length === 1) {
     if (!window.confirm(t('editor.buffers.delete_one_confirm'))) {
       return { status: 'cancelled' }
     }
   } else {
-    if (!window.confirm(t('editor.buffers.confirm_delete', { count: targets.length }))) {
+    if (!window.confirm(t('editor.buffers.confirm_delete', { count: normalized.length }))) {
       return { status: 'cancelled' }
     }
   }
@@ -338,11 +334,11 @@ export async function deleteStorageEntries(
         useEditorStore.getState().closePane(pane.id, key)
       }
     }
-    // Step 2: delete each target. Folders go through the recursive sweep
-    // (prefix-delete of every descendant); files use the plain non-recursive
-    // delete. A stat failure (e.g. the entry vanished under a concurrent op) is
-    // treated as a non-folder and still attempted.
-    for (const path of targets) {
+    // Step 2: delete each NORMALIZED target. Folders go through the recursive
+    // sweep (prefix-delete of every descendant); files use the plain
+    // non-recursive delete. A stat failure (e.g. the entry vanished under a
+    // concurrent op) is treated as a non-folder and still attempted.
+    for (const path of normalized) {
       const isDir = await backend
         .stat(path)
         .then((s) => s.isDirectory)

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -12,8 +12,9 @@
  * Phase 1b: new-file now goes through the unified eager `createUniqueInAppFile`
  * namer (atomic IDB reservation, #854) and accepts a `targetDir`. Folder mkdir
  * (`createStorageFolder`) and in-place rename of files AND folders
- * (`renameStorageEntry` + the pure `remapPanesUnder` re-point) have landed;
- * recursive move (drag) lands in T1b-6.
+ * (`renameStorageEntry` + the pure `remapPanesUnder` re-point) have landed.
+ * The recursive move data layer (`moveStorageEntry`, T1b-6a) reuses that same
+ * single-rename + `remapPanesUnder` path; the drag-and-drop wiring is T1b-6b.
  */
 import { getFsBackend } from '../../../lib/fs-backend'
 import { createUniqueInAppFile } from '../../../lib/inapp-namer'
@@ -23,7 +24,7 @@ import { isFilePaneContent } from '../../../lib/pane-utils'
 import { useEditorStore } from '../../../stores/useEditorStore'
 import { useTabStore } from '../../../stores/useTabStore'
 import { createMetadata } from '../../../lib/editor-language'
-import { STORAGE_ROOT, join, parentOf } from '../../../lib/storage-paths'
+import { STORAGE_ROOT, basename, join, parentOf } from '../../../lib/storage-paths'
 import type { FileSource } from '../../../types/fs'
 import type { Pane, Tab } from '../../../types/tab'
 
@@ -156,6 +157,71 @@ export async function renameStorageEntry(
     // The ONLY backend mutation for rename — exactly once, file and folder alike.
     await backend.rename(fromPath, targetPath)
     remapPanesUnder({ type: 'inapp' }, fromPath, targetPath)
+    return { ok: true }
+  } catch (err) {
+    return { kind: 'error', message: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+export type MoveOutcome =
+  | { ok: true }
+  | { kind: 'noop' }
+  | { kind: 'exists' }
+  | { kind: 'error'; message: string }
+
+/**
+ * Move a **file or folder** (`from`) into `targetDir`, keeping its basename —
+ * the data layer behind drag-and-drop (T1b-6a; the DnD wiring is T1b-6b). It
+ * shares the exact rename machinery: the destination is `targetDir/basename`,
+ * and a successful move is one recursive `backend.rename` (folder descendants
+ * re-keyed by T1b-1) followed by the pure `remapPanesUnder` re-point (T1b-4) —
+ * so a folder move re-points every open descendant pane in one shot.
+ *
+ * Three branches diverge BEFORE any mutation, so `backend.rename` fires exactly
+ * once on the success path and zero times otherwise:
+ *   - **no-op** (`{kind:'noop'}`, no `stat`, no mutation) when the move is inert:
+ *     dropping onto the current parent (`targetDir === parentOf(from)`, which
+ *     also covers `to === from`), onto the entry itself (`targetDir === from`),
+ *     or into its own descendant (`targetDir` is a `from/`-prefixed path) — the
+ *     last guard stops a folder being moved inside itself (decision 6).
+ *   - **collision** (`{kind:'exists'}`) when `stat(to)` resolves — a same-named
+ *     entry already lives in the target dir; refused before mutation (F4).
+ *   - otherwise the single `backend.rename(from, to)` + `remapPanesUnder`.
+ */
+export async function moveStorageEntry(
+  from: string,
+  targetDir: string,
+): Promise<MoveOutcome> {
+  const backend = getFsBackend({ type: 'inapp' })
+  // Missing backend = failure, not success (codex R3): a fake ok would clear the
+  // drag selection as if the move had happened.
+  if (!backend) return { kind: 'error', message: 'InApp backend unavailable' }
+
+  const to = join(targetDir, basename(from))
+
+  // No-op guards (no stat, no mutation): already there, onto self, or into own
+  // descendant. `targetDir === parentOf(from)` subsumes the `to === from` case.
+  if (
+    targetDir === parentOf(from) ||
+    to === from ||
+    targetDir === from ||
+    targetDir.startsWith(from + '/')
+  ) {
+    return { kind: 'noop' }
+  }
+
+  // Collision pre-check before any backend mutation (F4): a same-named sibling
+  // already in the target dir refuses the move.
+  const exists = await backend
+    .stat(to)
+    .then(() => true)
+    .catch(() => false)
+  if (exists) return { kind: 'exists' }
+
+  try {
+    // The ONLY backend mutation for move — exactly once, file and folder alike.
+    await backend.rename(from, to)
+    remapPanesUnder({ type: 'inapp' }, from, to)
     return { ok: true }
   } catch (err) {
     return { kind: 'error', message: err instanceof Error ? err.message : String(err) }

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -169,7 +169,22 @@ export type DeleteOutcome =
   | { status: 'error'; message: string }
 
 /**
- * Delete the given **full paths**. Preserves the v1.4/v1.5 guards:
+ * True when `filePath` is one of the deleted `targets` OR a descendant of any
+ * target folder. The trailing slash stops `/buffer/a` from matching the sibling
+ * `/buffer/ab` (decision 6); the exact-equality branch keeps a file target
+ * matching its own open pane. A folder delete therefore drags every open
+ * descendant pane through the same locked/dirty guards + close-before-delete
+ * sequence as an exact hit.
+ */
+function isAffectedByTargets(filePath: string, targets: string[]): boolean {
+  return targets.some((target) => filePath === target || filePath.startsWith(target + '/'))
+}
+
+/**
+ * Delete the given **full paths** (files or folders). Preserves the v1.4/v1.5
+ * guards, now folder-aware — a folder target sweeps every descendant
+ * (recursive) and the guards consider any open DESCENDANT pane affected, not
+ * just an exact path match (decision 6, T1b-5):
  *   - F2: refuse outright if any affected editor pane lives in a locked tab.
  *   - F5/F6: dirty-specific confirm wins over single / multi confirm.
  *   - G2: close every affected pane AND drop its editor-store buffer + paneState
@@ -190,9 +205,10 @@ export async function deleteStorageEntries(
     scanPaneTree(tab.layout, (pane) => {
       const c = pane.content
       // Cover editor AND the file-preview kinds (image-preview / pdf-preview)
-      // so deleting a png/pdf open in a preview pane fires the locked-tab
-      // refusal, closes the pane, and leaves no stale tab behind.
-      if (isFilePaneContent(c) && c.source.type === 'inapp' && targets.includes(c.filePath)) {
+      // so deleting a png/pdf open in a preview pane — or anything nested under
+      // a deleted folder — fires the locked-tab refusal, closes the pane, and
+      // leaves no stale tab behind.
+      if (isFilePaneContent(c) && c.source.type === 'inapp' && isAffectedByTargets(c.filePath, targets)) {
         openPanes.push([tabId, pane])
       }
     })
@@ -235,9 +251,16 @@ export async function deleteStorageEntries(
         useEditorStore.getState().closePane(pane.id, key)
       }
     }
-    // Step 2: delete the files.
+    // Step 2: delete each target. Folders go through the recursive sweep
+    // (prefix-delete of every descendant); files use the plain non-recursive
+    // delete. A stat failure (e.g. the entry vanished under a concurrent op) is
+    // treated as a non-folder and still attempted.
     for (const path of targets) {
-      await backend.delete(path)
+      const isDir = await backend
+        .stat(path)
+        .then((s) => s.isDirectory)
+        .catch(() => false)
+      await backend.delete(path, isDir)
     }
     return { status: 'deleted' }
   } catch (err) {

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -228,6 +228,27 @@ export async function moveStorageEntry(
   }
 }
 
+/**
+ * Pure resolver for a drag-and-drop drop (T1b-6b): maps the dnd-kit `active`
+ * (the dragged row, id = full path) and `over` (the drop target, id = a folder
+ * path OR the `STORAGE_ROOT` sentinel on the root region) into the
+ * `{ from, targetDir }` pair to hand to `moveStorageEntry`. Returns `null` when
+ * the drop landed on empty space (`over` is nullish) so the caller no-ops.
+ *
+ * The over-id IS the target directory in both cases (a folder path, or the root
+ * sentinel which equals the real root dir), so no branch is needed. All the
+ * inert-move / self / own-descendant / collision guards stay in
+ * `moveStorageEntry` — this is a thin, unit-testable mapping kept here (rather
+ * than in the pane component) so the `.tsx` only exports components.
+ */
+export function computeMoveFromDragEnd(
+  active: { id: string | number } | null | undefined,
+  over: { id: string | number } | null | undefined,
+): { from: string; targetDir: string } | null {
+  if (!active || !over) return null
+  return { from: String(active.id), targetDir: String(over.id) }
+}
+
 export type DeleteOutcome =
   | { status: 'deleted' }
   | { status: 'cancelled' }

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -9,11 +9,12 @@
  * (`parentOf(fromPath)`), delete removes the exact selected paths. The
  * dirty-pane confirm + locked-tab refusal guards are preserved verbatim.
  *
- * Folder mkdir / rename / recursive move / the unified `createUniqueInAppFile`
- * namer are explicitly deferred to Phase 1b — new-file here still lands flat at
- * the storage root (acceptable until 1b introduces folders).
+ * Phase 1b: new-file now goes through the unified eager `createUniqueInAppFile`
+ * namer (atomic IDB reservation, #854) and accepts a `targetDir`. Folder mkdir /
+ * rename / recursive move land in their own 1b tasks.
  */
 import { getFsBackend } from '../../../lib/fs-backend'
+import { createUniqueInAppFile } from '../../../lib/inapp-namer'
 import { bufferKey } from '../../../lib/editor-buffer-key'
 import { scanPaneTree } from '../../../lib/pane-tree'
 import { isFilePaneContent } from '../../../lib/pane-utils'
@@ -48,16 +49,17 @@ export async function performBufferRename(fromPath: string, targetPath: string) 
   useEditorStore.getState().renameBuffer(oldKey, newKey, nextMetadata)
 }
 
-/** Create a new empty markdown file at the storage root. Flat-only in 1a. */
-export async function createStorageFile(): Promise<{ error?: string }> {
-  const backend = getFsBackend({ type: 'inapp' })
-  // A missing backend is a real failure, not a silent success (codex R3): surface
-  // it like a write error so handleNew shows the banner instead of refreshing as if
-  // a file were created.
-  if (!backend) return { error: 'InApp backend unavailable' }
-  const path = join(STORAGE_ROOT, `Untitled-${Date.now()}.md`)
+/**
+ * Create a new empty markdown file under `targetDir` (defaults to the storage
+ * root). Uses the unified eager `createUniqueInAppFile` namer — the atomic IDB
+ * `add` reservation that gives a collision-free `Untitled[-N].md` even under a
+ * rapid double-click (#854), replacing the old `Date.now()` suffix. A missing
+ * backend surfaces as an error (codex R3) so handleNew shows the banner instead
+ * of refreshing as if a file were created.
+ */
+export async function createStorageFile(targetDir: string = STORAGE_ROOT): Promise<{ error?: string }> {
   try {
-    await backend.write(path, new Uint8Array(0))
+    await createUniqueInAppFile(targetDir, 'md')
     return {}
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) }

--- a/spa/src/components/editor/storage/storage-dnd.test.ts
+++ b/spa/src/components/editor/storage/storage-dnd.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { computeMoveFromDragEnd } from './storage-dnd'
+
+// The resolver reads the drop target's directory from `over.data.current.targetDir`
+// (codex B1) — the authoritative value each droppable publishes — rather than
+// inferring it from the over-id. A folder row publishes its own path; a file row
+// publishes its PARENT dir; the root region publishes STORAGE_ROOT.
+describe('computeMoveFromDragEnd (authoritative over.data.targetDir — B1 / H3)', () => {
+  it('maps a file dropped on a folder to {from, targetDir=folder path}', () => {
+    expect(
+      computeMoveFromDragEnd(
+        { id: '/buffer/a.md' },
+        { id: '/buffer/dir', data: { current: { targetDir: '/buffer/dir' } } },
+      ),
+    ).toEqual({ from: '/buffer/a.md', targetDir: '/buffer/dir' })
+  })
+
+  it('B1: a file dropped on ANOTHER FILE row targets that file\'s PARENT dir (not root)', () => {
+    // The file row at /buffer/dir/b.md publishes its parent /buffer/dir as the
+    // drop target, so dropping a.md onto it moves a.md INTO /buffer/dir — it must
+    // NOT fall through to the storage root.
+    expect(
+      computeMoveFromDragEnd(
+        { id: '/buffer/a.md' },
+        { id: '/buffer/dir/b.md', data: { current: { targetDir: '/buffer/dir' } } },
+      ),
+    ).toEqual({ from: '/buffer/a.md', targetDir: '/buffer/dir' })
+  })
+
+  it('B1: dropping a file onto a SAME-DIR sibling resolves to their shared parent (move is a no-op downstream)', () => {
+    // Both files live in /buffer; the sibling publishes /buffer as targetDir, so
+    // the resolver returns targetDir === the source's own parent — `moveStorageEntry`
+    // then collapses it to a no-op (targetDir === parentOf(from)).
+    expect(
+      computeMoveFromDragEnd(
+        { id: '/buffer/a.md' },
+        { id: '/buffer/b.md', data: { current: { targetDir: '/buffer' } } },
+      ),
+    ).toEqual({ from: '/buffer/a.md', targetDir: '/buffer' })
+  })
+
+  it('maps the root region to a STORAGE_ROOT targetDir', () => {
+    expect(
+      computeMoveFromDragEnd(
+        { id: '/buffer/dir/a.md' },
+        { id: '/buffer', data: { current: { targetDir: '/buffer' } } },
+      ),
+    ).toEqual({ from: '/buffer/dir/a.md', targetDir: '/buffer' })
+  })
+
+  it('returns null when there is no drop target (dropped on empty space)', () => {
+    expect(computeMoveFromDragEnd({ id: '/buffer/a.md' }, null)).toBeNull()
+  })
+
+  it('returns null when the drop target publishes no targetDir', () => {
+    expect(computeMoveFromDragEnd({ id: '/buffer/a.md' }, { id: '/buffer/dir' })).toBeNull()
+  })
+})

--- a/spa/src/components/editor/storage/storage-dnd.ts
+++ b/spa/src/components/editor/storage/storage-dnd.ts
@@ -1,0 +1,38 @@
+/**
+ * storage-dnd — the pure drag-and-drop resolver for the Storage pane, split out
+ * of `storage-actions` (codex H3) so the data-layer CRUD module stays free of
+ * dnd-kit concerns and this thin mapping is unit-testable on its own. The repo
+ * precedent is `features/workspace/lib/computeDragEndAction.ts`.
+ */
+
+/**
+ * Resolve a dnd-kit drop into the `{ from, targetDir }` pair for
+ * `moveStorageEntry`. The drop target's directory is read from
+ * `over.data.current.targetDir` — the **authoritative** value each droppable
+ * publishes (codex B1):
+ *
+ *   - a **folder** row publishes its own path,
+ *   - a **file** row publishes its PARENT directory (dropping onto a file means
+ *     "into the folder that file lives in" — the common file-manager gesture;
+ *     dropping onto a same-directory sibling then collapses to a no-op inside
+ *     `moveStorageEntry` because the target dir equals the source's parent),
+ *   - the root region publishes `STORAGE_ROOT`.
+ *
+ * Reading `targetDir` from the droppable's data (rather than inferring it from
+ * `over.id`) removes the old ambiguity where a drop onto a file row — which had
+ * no droppable — fell through to the root zone and silently moved the entry back
+ * to the storage root. Returns `null` (caller no-ops) when there is no drop
+ * target or the target published no `targetDir`.
+ */
+export function computeMoveFromDragEnd(
+  active: { id: string | number } | null | undefined,
+  over:
+    | { id: string | number; data?: { current?: { targetDir?: unknown } } }
+    | null
+    | undefined,
+): { from: string; targetDir: string } | null {
+  if (!active || !over) return null
+  const targetDir = over.data?.current?.targetDir
+  if (typeof targetDir !== 'string') return null
+  return { from: String(active.id), targetDir }
+}

--- a/spa/src/lib/fs-backend-daemon.ts
+++ b/spa/src/lib/fs-backend-daemon.ts
@@ -69,15 +69,9 @@ export class DaemonBackend implements FsBackend {
     await this.post('/api/fs/rename', { from, to })
   }
 
-  // In-App-only flow (#854); no daemon endpoint / UI entry point uses it.
-  async createUnique(_dir: string, _baseName: string, _ext: 'md' | 'txt'): Promise<string> {
-    throw new Error('DaemonBackend: createUnique is not supported')
-  }
-
-  // In-App-only flow (#854); no daemon endpoint / UI entry point uses it.
-  async mkdirUnique(_dir: string, _baseName?: string): Promise<string> {
-    throw new Error('DaemonBackend: mkdirUnique is not supported')
-  }
+  // The unique-name reservation (#854) is an In-App-only capability
+  // (`SupportsUniqueCreate`); DaemonBackend deliberately does NOT implement it
+  // (codex H1) — no daemon endpoint / UI entry point uses it.
 }
 
 /**
@@ -108,7 +102,5 @@ export function createDaemonBackendForHost(hostId: string): FsBackend {
     mkdir: (path, recursive) => getDaemon().mkdir(path, recursive),
     delete: (path, recursive) => getDaemon().delete(path, recursive),
     rename: (from, to) => getDaemon().rename(from, to),
-    createUnique: (dir, baseName, ext) => getDaemon().createUnique(dir, baseName, ext),
-    mkdirUnique: (dir, baseName) => getDaemon().mkdirUnique(dir, baseName),
   }
 }

--- a/spa/src/lib/fs-backend-daemon.ts
+++ b/spa/src/lib/fs-backend-daemon.ts
@@ -73,6 +73,11 @@ export class DaemonBackend implements FsBackend {
   async createUnique(_dir: string, _baseName: string, _ext: 'md' | 'txt'): Promise<string> {
     throw new Error('DaemonBackend: createUnique is not supported')
   }
+
+  // In-App-only flow (#854); no daemon endpoint / UI entry point uses it.
+  async mkdirUnique(_dir: string, _baseName?: string): Promise<string> {
+    throw new Error('DaemonBackend: mkdirUnique is not supported')
+  }
 }
 
 /**
@@ -104,5 +109,6 @@ export function createDaemonBackendForHost(hostId: string): FsBackend {
     delete: (path, recursive) => getDaemon().delete(path, recursive),
     rename: (from, to) => getDaemon().rename(from, to),
     createUnique: (dir, baseName, ext) => getDaemon().createUnique(dir, baseName, ext),
+    mkdirUnique: (dir, baseName) => getDaemon().mkdirUnique(dir, baseName),
   }
 }

--- a/spa/src/lib/fs-backend-daemon.ts
+++ b/spa/src/lib/fs-backend-daemon.ts
@@ -68,6 +68,11 @@ export class DaemonBackend implements FsBackend {
   async rename(from: string, to: string): Promise<void> {
     await this.post('/api/fs/rename', { from, to })
   }
+
+  // In-App-only flow (#854); no daemon endpoint / UI entry point uses it.
+  async createUnique(_dir: string, _baseName: string, _ext: 'md' | 'txt'): Promise<string> {
+    throw new Error('DaemonBackend: createUnique is not supported')
+  }
 }
 
 /**
@@ -98,5 +103,6 @@ export function createDaemonBackendForHost(hostId: string): FsBackend {
     mkdir: (path, recursive) => getDaemon().mkdir(path, recursive),
     delete: (path, recursive) => getDaemon().delete(path, recursive),
     rename: (from, to) => getDaemon().rename(from, to),
+    createUnique: (dir, baseName, ext) => getDaemon().createUnique(dir, baseName, ext),
   }
 }

--- a/spa/src/lib/fs-backend-inapp.test.ts
+++ b/spa/src/lib/fs-backend-inapp.test.ts
@@ -169,16 +169,11 @@ describe('InAppBackend (IndexedDB-backed)', () => {
     await expect(fresh.read('/buffer/x.txt')).rejects.toThrow()
   })
 
-  // AC12 — preserve lenient overwrite semantics (I6): rename to existing target
-  // overwrites and does NOT throw; mkdir on existing path does NOT throw; write
-  // to a path whose parent is an existing file does NOT throw.
-  it('AC12: rename to existing target blind-overwrites without throwing', async () => {
-    await backend.write('/buffer/a.txt', enc('AAA'))
-    await backend.write('/buffer/b.txt', enc('BBB'))
-    await backend.rename('/buffer/a.txt', '/buffer/b.txt')
-    expect(dec(await backend.read('/buffer/b.txt'))).toBe('AAA')
-    await expect(backend.read('/buffer/a.txt')).rejects.toThrow()
-  })
+  // AC12 — mkdir + write retain lenient overwrite semantics (I6). NOTE: rename
+  // collision is NO LONGER lenient as of Phase 1b T1 — see "1b T1: rename
+  // collision" cases below, which require rename to refuse before any mutation
+  // (spec AC-1b: "File rename to an existing path is refused before any backend
+  // mutation").
 
   it('AC12: mkdir on existing path does not throw', async () => {
     await backend.mkdir('/buffer/d')
@@ -196,16 +191,91 @@ describe('InAppBackend (IndexedDB-backed)', () => {
     expect(dec(await backend.read('/buffer/parent/child.txt'))).toBe('child')
   })
 
-  // AC13 — rename is non-recursive (I7): only the single entry moves
-  it('AC13: rename is non-recursive — children stay at original paths', async () => {
-    await backend.write('/buffer/d/a.txt', enc('a'))
-    await backend.mkdir('/buffer/d')
-    await backend.rename('/buffer/d', '/buffer/e')
-    // /buffer/d entry itself moved
-    const eStat = await backend.stat('/buffer/e')
-    expect(eStat.isDirectory).toBe(true)
-    // child stays at original path (non-recursive)
-    expect(dec(await backend.read('/buffer/d/a.txt'))).toBe('a')
+  // AC13 (Phase 1b T1) — rename is now dir-aware + recursive: moving a folder
+  // re-keys EVERY descendant and removes all old paths (spec §2 gap P2-7 / AC-1b).
+  it('AC13: rename moves a directory recursively — all descendants re-keyed, old paths gone', async () => {
+    // seed a 2-level nested tree with distinct contents
+    await backend.mkdir('/buffer/a')
+    await backend.write('/buffer/a/x.md', enc('X-CONTENT'))
+    await backend.mkdir('/buffer/a/b')
+    await backend.write('/buffer/a/b/y.md', enc('Y-CONTENT'))
+
+    await backend.rename('/buffer/a', '/buffer/z')
+
+    // new tree exists with IDENTICAL content
+    expect((await backend.stat('/buffer/z')).isDirectory).toBe(true)
+    expect(dec(await backend.read('/buffer/z/x.md'))).toBe('X-CONTENT')
+    expect((await backend.stat('/buffer/z/b')).isDirectory).toBe(true)
+    expect(dec(await backend.read('/buffer/z/b/y.md'))).toBe('Y-CONTENT')
+
+    // every old /buffer/a* key is gone
+    await expect(backend.stat('/buffer/a')).rejects.toThrow()
+    await expect(backend.read('/buffer/a/x.md')).rejects.toThrow()
+    await expect(backend.stat('/buffer/a/b')).rejects.toThrow()
+    await expect(backend.read('/buffer/a/b/y.md')).rejects.toThrow()
+    // /buffer parent only contains the moved dir now
+    expect((await backend.list('/buffer')).map((e) => e.name)).toEqual(['z'])
+  })
+
+  // 1b T1 — a move is not a content edit: every moved descendant keeps its mtime
+  it('1b T1: recursive move preserves each descendant mtime (not a content edit)', async () => {
+    await backend.mkdir('/buffer/a')
+    await backend.write('/buffer/a/x.md', enc('X'))
+    await backend.write('/buffer/a/b/y.md', enc('Y')) // auto-creates /buffer/a/b
+
+    // capture original mtimes
+    const m = {
+      a: (await backend.stat('/buffer/a')).mtime,
+      x: (await backend.stat('/buffer/a/x.md')).mtime,
+      b: (await backend.stat('/buffer/a/b')).mtime,
+      y: (await backend.stat('/buffer/a/b/y.md')).mtime,
+    }
+
+    await backend.rename('/buffer/a', '/buffer/z')
+
+    expect((await backend.stat('/buffer/z')).mtime).toBe(m.a)
+    expect((await backend.stat('/buffer/z/x.md')).mtime).toBe(m.x)
+    expect((await backend.stat('/buffer/z/b')).mtime).toBe(m.b)
+    expect((await backend.stat('/buffer/z/b/y.md')).mtime).toBe(m.y)
+  })
+
+  // 1b T1 — collision over the target subtree must throw with NO partial mutation:
+  // reject if `to` exists OR any `${to}/`-prefixed key exists, and leave the
+  // original tree fully intact (spec AC-1b: refused before any backend mutation).
+  it('1b T1: rename throws when `to` exactly exists, original tree intact', async () => {
+    await backend.mkdir('/buffer/a')
+    await backend.write('/buffer/a/x.md', enc('X'))
+    await backend.write('/buffer/z', enc('OCCUPIED')) // exact `to` collision
+
+    await expect(backend.rename('/buffer/a', '/buffer/z')).rejects.toThrow()
+
+    // nothing moved: original tree intact, target untouched
+    expect((await backend.stat('/buffer/a')).isDirectory).toBe(true)
+    expect(dec(await backend.read('/buffer/a/x.md'))).toBe('X')
+    expect(dec(await backend.read('/buffer/z'))).toBe('OCCUPIED')
+  })
+
+  it('1b T1: rename throws when a `${to}/child` key exists, original tree intact', async () => {
+    await backend.mkdir('/buffer/a')
+    await backend.write('/buffer/a/x.md', enc('X'))
+    // no exact /buffer/z, but a descendant of the target already exists
+    await backend.write('/buffer/z/occupied.md', enc('OCCUPIED'))
+
+    await expect(backend.rename('/buffer/a', '/buffer/z')).rejects.toThrow()
+
+    // original tree intact
+    expect((await backend.stat('/buffer/a')).isDirectory).toBe(true)
+    expect(dec(await backend.read('/buffer/a/x.md'))).toBe('X')
+    // target subtree untouched
+    expect(dec(await backend.read('/buffer/z/occupied.md'))).toBe('OCCUPIED')
+  })
+
+  // 1b T1 — file move regression: single-entry re-key still works
+  it('1b T1: rename moves a single file correctly (regression)', async () => {
+    await backend.write('/buffer/a/x.md', enc('FILE'))
+    await backend.rename('/buffer/a/x.md', '/buffer/a/y.md')
+    expect(dec(await backend.read('/buffer/a/y.md'))).toBe('FILE')
+    await expect(backend.read('/buffer/a/x.md')).rejects.toThrow()
   })
 
   // AC14 — binary / empty payload persists byte-for-byte across rebuild

--- a/spa/src/lib/fs-backend-inapp.test.ts
+++ b/spa/src/lib/fs-backend-inapp.test.ts
@@ -375,3 +375,73 @@ describe('InAppBackend.createUnique (atomic eager namer)', () => {
     expect(tree.map((n) => n.path)).toContain('/buffer/Untitled.md')
   })
 })
+
+// T1b-3 — mkdirUnique: atomic eager reservation of a unique DIRECTORY via the
+// same IDB store.add serialization point as createUnique. Folder candidates use
+// a SPACE-separated suffix ("New Folder", "New Folder 1", …), unlike files'
+// hyphen, matching the plan's T3-3 expectation.
+describe('InAppBackend.mkdirUnique (atomic eager folder namer)', () => {
+  let backend: InAppBackend
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    backend = new InAppBackend()
+  })
+
+  // M1: empty dir → first candidate is a real directory entry.
+  it('M1: reserves /buffer/New Folder as a directory on an empty dir', async () => {
+    const path = await backend.mkdirUnique('/buffer')
+    expect(path).toBe('/buffer/New Folder')
+    const stat = await backend.stat(path)
+    expect(stat.isDirectory).toBe(true)
+    expect(stat.isFile).toBe(false)
+  })
+
+  it('M1: honors a custom baseName', async () => {
+    const path = await backend.mkdirUnique('/buffer', 'Docs')
+    expect(path).toBe('/buffer/Docs')
+    expect((await backend.stat(path)).isDirectory).toBe(true)
+  })
+
+  // M2: collision → space-separated increment.
+  it('M2: returns "/buffer/New Folder 1" when "/buffer/New Folder" exists', async () => {
+    await backend.mkdir('/buffer/New Folder')
+    const path = await backend.mkdirUnique('/buffer')
+    expect(path).toBe('/buffer/New Folder 1')
+  })
+
+  it('M2: skips multiple existing candidates', async () => {
+    await backend.mkdir('/buffer/New Folder')
+    await backend.mkdir('/buffer/New Folder 1')
+    await backend.mkdir('/buffer/New Folder 2')
+    const path = await backend.mkdirUnique('/buffer')
+    expect(path).toBe('/buffer/New Folder 3')
+  })
+
+  // M3: concurrent double-create must yield TWO distinct folders (no overwrite),
+  // exercising the add-reserve race fix (decision 7).
+  it('M3: concurrent mkdirUnique calls reserve distinct folders (no overwrite)', async () => {
+    const [a, b] = await Promise.all([
+      backend.mkdirUnique('/buffer'),
+      backend.mkdirUnique('/buffer'),
+    ])
+    expect(a).not.toBe(b)
+    const names = (await backend.list('/buffer')).map((e) => e.name).sort()
+    expect(names).toEqual(['New Folder', 'New Folder 1'])
+    // both are real directories
+    for (const p of [a, b]) {
+      expect((await backend.stat(p)).isDirectory).toBe(true)
+    }
+  })
+
+  // M4: the reserved folder is a real directory that accepts children.
+  it('M4: the reserved folder accepts a child file', async () => {
+    const dir = await backend.mkdirUnique('/buffer')
+    await backend.write(`${dir}/note.md`, enc('hi'))
+    const tree = await listTreeUnder(backend, '/buffer')
+    const folder = tree.find((n) => n.path === dir)
+    expect(folder?.isDir).toBe(true)
+    expect(folder?.children?.map((c) => c.path)).toContain(`${dir}/note.md`)
+  })
+})

--- a/spa/src/lib/fs-backend-inapp.test.ts
+++ b/spa/src/lib/fs-backend-inapp.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { InAppBackend } from './fs-backend-inapp'
+import { listTreeUnder } from './storage-tree'
 import { closeAllIDB } from './storage/idb'
 import {
   registerFsBackend,
@@ -311,5 +312,66 @@ describe('InAppBackend (IndexedDB-backed)', () => {
     expect(dec(await reg2!.read('/buffer/reg.txt'))).toBe('via registry')
 
     clearFsBackendRegistry()
+  })
+})
+
+// T1b-2 — createUnique: atomic eager reservation of a unique empty file via
+// IDB store.add (the single serialization point that fixes #854's double-click
+// shared-key race).
+describe('InAppBackend.createUnique (atomic eager namer)', () => {
+  let backend: InAppBackend
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    backend = new InAppBackend()
+  })
+
+  // T2-1: empty dir → first candidate, ext honored (bare, no leading dot).
+  it('T2-1: reserves /buffer/Untitled.md on an empty dir', async () => {
+    const path = await backend.createUnique('/buffer', 'Untitled', 'md')
+    expect(path).toBe('/buffer/Untitled.md')
+    expect((await backend.read(path)).byteLength).toBe(0)
+  })
+
+  it('T2-1: honors a txt extension', async () => {
+    const path = await backend.createUnique('/buffer', 'Untitled', 'txt')
+    expect(path).toBe('/buffer/Untitled.txt')
+  })
+
+  // T2-2: collision → increment the suffix.
+  it('T2-2: returns /buffer/Untitled-1.md when /buffer/Untitled.md exists', async () => {
+    await backend.write('/buffer/Untitled.md', enc(''))
+    const path = await backend.createUnique('/buffer', 'Untitled', 'md')
+    expect(path).toBe('/buffer/Untitled-1.md')
+  })
+
+  it('T2-2: skips multiple existing candidates', async () => {
+    await backend.write('/buffer/Untitled.md', enc(''))
+    await backend.write('/buffer/Untitled-1.md', enc(''))
+    await backend.write('/buffer/Untitled-2.md', enc(''))
+    const path = await backend.createUnique('/buffer', 'Untitled', 'md')
+    expect(path).toBe('/buffer/Untitled-3.md')
+  })
+
+  // T2-3: #854 race — concurrent callers must get distinct keys, no shared key.
+  it('T2-3: concurrent createUnique calls reserve distinct paths (#854)', async () => {
+    const [a, b] = await Promise.all([
+      backend.createUnique('/buffer', 'Untitled', 'md'),
+      backend.createUnique('/buffer', 'Untitled', 'md'),
+    ])
+    expect(a).not.toBe(b)
+    const names = (await backend.list('/buffer')).map((e) => e.name).sort()
+    expect(names).toEqual(['Untitled-1.md', 'Untitled.md'])
+  })
+
+  // T2-4: reserved file is empty and shows up in a recursive tree enumeration.
+  it('T2-4: reserved file is empty and appears under listTreeUnder', async () => {
+    const path = await backend.createUnique('/buffer', 'Untitled', 'md')
+    const stat = await backend.stat(path)
+    expect(stat.size).toBe(0)
+    expect(stat.isFile).toBe(true)
+    const tree = await listTreeUnder(backend, '/buffer')
+    expect(tree.map((n) => n.path)).toContain('/buffer/Untitled.md')
   })
 })

--- a/spa/src/lib/fs-backend-inapp.ts
+++ b/spa/src/lib/fs-backend-inapp.ts
@@ -214,4 +214,37 @@ export class InAppBackend implements FsBackend {
     }
     throw new Error(`InAppBackend.createUnique: exhausted ${MAX} candidates under ${dir}`)
   }
+
+  async mkdirUnique(dir: string, baseName = 'New Folder'): Promise<string> {
+    const db = await this.db()
+    const now = Date.now()
+    const MAX = 10_000
+    // Symmetric with createUnique (decision 7): store.add() is the single
+    // serialization point, so a rapid double "New Folder" click each wins a
+    // distinct key instead of clobbering. Folder candidates use a SPACE suffix
+    // ("New Folder", "New Folder 1", …) and carry NO extension. A fresh tx per
+    // attempt because a ConstraintError aborts the transaction it occurred in.
+    for (let n = 0; n < MAX; n++) {
+      const name = n === 0 ? baseName : `${baseName} ${n}`
+      const path = join(dir, name)
+      const tx = db.transaction(STORE, 'readwrite')
+      try {
+        await tx.store.add({
+          path,
+          content: new Uint8Array(0),
+          isDirectory: true,
+          mtime: now,
+        } satisfies StoredFile)
+        await tx.done
+        return path
+      } catch (err) {
+        // Observe the aborted tx's rejection to avoid an unhandled rejection
+        // before retrying the next suffix.
+        tx.done.catch(() => {})
+        if ((err as { name?: string } | null)?.name === 'ConstraintError') continue
+        throw err
+      }
+    }
+    throw new Error(`InAppBackend.mkdirUnique: exhausted ${MAX} candidates under ${dir}`)
+  }
 }

--- a/spa/src/lib/fs-backend-inapp.ts
+++ b/spa/src/lib/fs-backend-inapp.ts
@@ -1,6 +1,7 @@
 import type { IDBPDatabase } from 'idb'
 import { openIDB } from './storage/idb'
 import type { FsBackend } from './fs-backend'
+import { join } from './storage-paths'
 import type { FileStat, FileEntry } from '../types/fs'
 
 const DB_NAME = 'pdx-inapp-fs'
@@ -177,5 +178,40 @@ export class InAppBackend implements FsBackend {
       await store.delete(key)
     }
     await tx.done
+  }
+
+  async createUnique(dir: string, baseName = 'Untitled', ext: 'md' | 'txt'): Promise<string> {
+    const db = await this.db()
+    const now = Date.now()
+    const MAX = 10_000
+    // store.add() is the single serialization point: it throws ConstraintError
+    // if the keyPath (path) already exists, unlike put()'s blind overwrite. So
+    // concurrent callers — e.g. a rapid double "New file" click (#854) — each
+    // win exactly one distinct key; the loser retries the next suffix instead
+    // of sharing the key. A fresh tx per attempt because a ConstraintError
+    // aborts the transaction it occurred in.
+    for (let n = 0; n < MAX; n++) {
+      const name = n === 0 ? baseName : `${baseName}-${n}`
+      const path = join(dir, `${name}.${ext}`)
+      const tx = db.transaction(STORE, 'readwrite')
+      try {
+        await tx.store.add({
+          path,
+          content: new Uint8Array(0),
+          isDirectory: false,
+          mtime: now,
+        } satisfies StoredFile)
+        await tx.done
+        return path
+      } catch (err) {
+        // A failed add() aborts its transaction, so tx.done rejects with an
+        // AbortError. We left it un-awaited (we threw out of the try first), so
+        // observe it here to avoid an unhandled rejection before retrying.
+        tx.done.catch(() => {})
+        if ((err as { name?: string } | null)?.name === 'ConstraintError') continue
+        throw err
+      }
+    }
+    throw new Error(`InAppBackend.createUnique: exhausted ${MAX} candidates under ${dir}`)
   }
 }

--- a/spa/src/lib/fs-backend-inapp.ts
+++ b/spa/src/lib/fs-backend-inapp.ts
@@ -142,14 +142,40 @@ export class InAppBackend implements FsBackend {
     const db = await this.db()
     const tx = db.transaction(STORE, 'readwrite')
     const store = tx.store
-    const entry = (await store.get(from)) as StoredFile | undefined
-    if (!entry) {
+
+    // Dir-aware recursive move: select `from` itself plus every descendant
+    // (`from/`-prefixed key). A file move is the single-key case of this.
+    const fromPrefix = from + '/'
+    const allKeys = (await store.getAllKeys()) as string[]
+    const sourceKeys = allKeys.filter(
+      (k) => k === from || k.startsWith(fromPrefix),
+    )
+    if (sourceKeys.length === 0) {
       await tx.done
       throw new Error(`InAppBackend: path not found: ${from}`)
     }
-    // Blind overwrite of target (I6); only the single entry moves (I7).
-    await store.put({ ...entry, path: to } satisfies StoredFile)
-    await store.delete(from)
+
+    // Full collision scan over the WHOLE target subtree BEFORE any mutation:
+    // reject if `to` exists or any `${to}/`-prefixed key exists (spec AC-1b —
+    // refused before any backend mutation). idb auto-aborts the tx on throw.
+    const toPrefix = to + '/'
+    const collision = allKeys.some(
+      (k) => k === to || k.startsWith(toPrefix),
+    )
+    if (collision) {
+      await tx.done
+      throw new Error(`InAppBackend: rename target already exists: ${to}`)
+    }
+
+    // Re-key every entry in one transaction, preserving each entry's mtime
+    // (a move is not a content edit, so we must NOT bump mtime).
+    for (const key of sourceKeys) {
+      const entry = (await store.get(key)) as StoredFile | undefined
+      if (!entry) continue
+      const newKey = to + key.slice(from.length)
+      await store.put({ ...entry, path: newKey } satisfies StoredFile)
+      await store.delete(key)
+    }
     await tx.done
   }
 }

--- a/spa/src/lib/fs-backend-inapp.ts
+++ b/spa/src/lib/fs-backend-inapp.ts
@@ -1,6 +1,6 @@
 import type { IDBPDatabase } from 'idb'
 import { openIDB } from './storage/idb'
-import type { FsBackend } from './fs-backend'
+import type { FsBackend, SupportsUniqueCreate } from './fs-backend'
 import { join } from './storage-paths'
 import type { FileStat, FileEntry } from '../types/fs'
 
@@ -15,7 +15,7 @@ interface StoredFile {
   mtime: number
 }
 
-export class InAppBackend implements FsBackend {
+export class InAppBackend implements FsBackend, SupportsUniqueCreate {
   id = 'inapp'
   label = 'In-App Storage'
 

--- a/spa/src/lib/fs-backend-local.ts
+++ b/spa/src/lib/fs-backend-local.ts
@@ -43,16 +43,7 @@ export class LocalBackend implements FsBackend {
     return this.api.rename(from, to)
   }
 
-  // The eager-unique-name reservation (#854) is an In-App-only flow; the Local
-  // and Daemon backends have no atomic add primitive exposed and no UI entry
-  // point that calls this, so it is intentionally unsupported here.
-  async createUnique(): Promise<string> {
-    throw new Error('LocalBackend: createUnique is not supported')
-  }
-
-  // Like createUnique, the atomic folder reservation (#854) is an In-App-only
-  // flow with no Local atomic-add primitive and no UI entry point.
-  async mkdirUnique(): Promise<string> {
-    throw new Error('LocalBackend: mkdirUnique is not supported')
-  }
+  // The eager-unique-name reservation (#854) is an In-App-only capability
+  // (`SupportsUniqueCreate`); LocalBackend deliberately does NOT implement it
+  // (codex H1) — no atomic add primitive, no UI entry point.
 }

--- a/spa/src/lib/fs-backend-local.ts
+++ b/spa/src/lib/fs-backend-local.ts
@@ -42,4 +42,11 @@ export class LocalBackend implements FsBackend {
   async rename(from: string, to: string): Promise<void> {
     return this.api.rename(from, to)
   }
+
+  // The eager-unique-name reservation (#854) is an In-App-only flow; the Local
+  // and Daemon backends have no atomic add primitive exposed and no UI entry
+  // point that calls this, so it is intentionally unsupported here.
+  async createUnique(): Promise<string> {
+    throw new Error('LocalBackend: createUnique is not supported')
+  }
 }

--- a/spa/src/lib/fs-backend-local.ts
+++ b/spa/src/lib/fs-backend-local.ts
@@ -49,4 +49,10 @@ export class LocalBackend implements FsBackend {
   async createUnique(): Promise<string> {
     throw new Error('LocalBackend: createUnique is not supported')
   }
+
+  // Like createUnique, the atomic folder reservation (#854) is an In-App-only
+  // flow with no Local atomic-add primitive and no UI entry point.
+  async mkdirUnique(): Promise<string> {
+    throw new Error('LocalBackend: mkdirUnique is not supported')
+  }
 }

--- a/spa/src/lib/fs-backend.test.ts
+++ b/spa/src/lib/fs-backend.test.ts
@@ -15,6 +15,7 @@ function createMockBackend(id: string): FsBackend {
     mkdir: async () => {},
     delete: async () => {},
     rename: async () => {},
+    createUnique: async () => '',
   }
 }
 

--- a/spa/src/lib/fs-backend.test.ts
+++ b/spa/src/lib/fs-backend.test.ts
@@ -16,6 +16,7 @@ function createMockBackend(id: string): FsBackend {
     delete: async () => {},
     rename: async () => {},
     createUnique: async () => '',
+    mkdirUnique: async () => '',
   }
 }
 

--- a/spa/src/lib/fs-backend.test.ts
+++ b/spa/src/lib/fs-backend.test.ts
@@ -15,8 +15,6 @@ function createMockBackend(id: string): FsBackend {
     mkdir: async () => {},
     delete: async () => {},
     rename: async () => {},
-    createUnique: async () => '',
-    mkdirUnique: async () => '',
   }
 }
 

--- a/spa/src/lib/fs-backend.ts
+++ b/spa/src/lib/fs-backend.ts
@@ -12,6 +12,18 @@ export interface FsBackend {
   mkdir(path: string, recursive?: boolean): Promise<void>
   delete(path: string, recursive?: boolean): Promise<void>
   rename(from: string, to: string): Promise<void>
+}
+
+/**
+ * Optional capability for the atomic unique-name reservation flow (#854). It is
+ * an In-App-only concern: only `InAppBackend` has an atomic `add` primitive (IDB
+ * `store.add` throws on a duplicate key) and only the In-App storage UI mints
+ * `Untitled[-N]` / `New Folder[ N]` names this way. Keeping it OFF the base
+ * `FsBackend` interface (codex H1) stops the Local/Daemon backends from having
+ * to carry `not-supported` stubs that exist only to satisfy a contract no caller
+ * exercises. Consumers narrow to this capability via `supports*` guards below.
+ */
+export interface SupportsUniqueCreate {
   /**
    * Atomically reserve a unique empty file under `dir`. Loops candidate names
    * `<baseName>`, `<baseName>-1`, … forming each path as `dir/<name>.<ext>`
@@ -29,6 +41,20 @@ export interface FsBackend {
    * existing folder (#854-class race). Returns the reserved path.
    */
   mkdirUnique(dir: string, baseName?: string): Promise<string>
+}
+
+/** Narrow a resolved backend to the unique-file-create capability (codex H1). */
+export function supportsCreateUnique(
+  backend: FsBackend | undefined,
+): backend is FsBackend & Pick<SupportsUniqueCreate, 'createUnique'> {
+  return typeof (backend as Partial<SupportsUniqueCreate> | undefined)?.createUnique === 'function'
+}
+
+/** Narrow a resolved backend to the unique-folder-create capability (codex H1). */
+export function supportsMkdirUnique(
+  backend: FsBackend | undefined,
+): backend is FsBackend & Pick<SupportsUniqueCreate, 'mkdirUnique'> {
+  return typeof (backend as Partial<SupportsUniqueCreate> | undefined)?.mkdirUnique === 'function'
 }
 
 const backends = new Map<string, FsBackend>()

--- a/spa/src/lib/fs-backend.ts
+++ b/spa/src/lib/fs-backend.ts
@@ -21,6 +21,14 @@ export interface FsBackend {
    * path.
    */
   createUnique(dir: string, baseName: string, ext: 'md' | 'txt'): Promise<string>
+  /**
+   * Atomically reserve a unique empty DIRECTORY under `dir`. Loops candidate
+   * names `<baseName>`, `<baseName> 1`, … (space-separated suffix, no extension)
+   * and reserves the first free key via the same single serialization point as
+   * `createUnique` — so a rapid double "New Folder" click cannot clobber an
+   * existing folder (#854-class race). Returns the reserved path.
+   */
+  mkdirUnique(dir: string, baseName?: string): Promise<string>
 }
 
 const backends = new Map<string, FsBackend>()

--- a/spa/src/lib/fs-backend.ts
+++ b/spa/src/lib/fs-backend.ts
@@ -12,6 +12,15 @@ export interface FsBackend {
   mkdir(path: string, recursive?: boolean): Promise<void>
   delete(path: string, recursive?: boolean): Promise<void>
   rename(from: string, to: string): Promise<void>
+  /**
+   * Atomically reserve a unique empty file under `dir`. Loops candidate names
+   * `<baseName>`, `<baseName>-1`, … forming each path as `dir/<name>.<ext>`
+   * (`ext` is bare — no leading dot) and reserves the first free key in a way
+   * that is safe against concurrent callers (the single serialization point
+   * that fixes the double-new-file shared-key race, #854). Returns the reserved
+   * path.
+   */
+  createUnique(dir: string, baseName: string, ext: 'md' | 'txt'): Promise<string>
 }
 
 const backends = new Map<string, FsBackend>()

--- a/spa/src/lib/inapp-namer.test.ts
+++ b/spa/src/lib/inapp-namer.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createUniqueInAppFile } from './inapp-namer'
+
+const getFsBackendMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./fs-backend', () => ({
+  getFsBackend: getFsBackendMock,
+}))
+
+describe('createUniqueInAppFile (single namer over the InApp backend)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('delegates to backend.createUnique(dir, "Untitled", ext) and returns the path', async () => {
+    const createUnique = vi.fn(async (dir: string, _base: string, ext: string) => `${dir}/Untitled.${ext}`)
+    getFsBackendMock.mockReturnValue({ createUnique })
+
+    const path = await createUniqueInAppFile('/buffer', 'md')
+
+    expect(createUnique).toHaveBeenCalledWith('/buffer', 'Untitled', 'md')
+    expect(path).toBe('/buffer/Untitled.md')
+  })
+
+  it('forwards a bare txt extension and a nested target dir', async () => {
+    const createUnique = vi.fn(async (dir: string, _base: string, ext: string) => `${dir}/Untitled.${ext}`)
+    getFsBackendMock.mockReturnValue({ createUnique })
+
+    const path = await createUniqueInAppFile('/buffer/sub', 'txt')
+
+    expect(createUnique).toHaveBeenCalledWith('/buffer/sub', 'Untitled', 'txt')
+    expect(path).toBe('/buffer/sub/Untitled.txt')
+  })
+
+  it('throws when the InApp backend is unavailable (surfaced, not silent)', async () => {
+    getFsBackendMock.mockReturnValue(undefined)
+    await expect(createUniqueInAppFile('/buffer', 'md')).rejects.toThrow()
+  })
+})

--- a/spa/src/lib/inapp-namer.test.ts
+++ b/spa/src/lib/inapp-namer.test.ts
@@ -5,6 +5,10 @@ const getFsBackendMock = vi.hoisted(() => vi.fn())
 
 vi.mock('./fs-backend', () => ({
   getFsBackend: getFsBackendMock,
+  // Capability guard (codex H1): mirror the real typeof narrow so the mocked
+  // backend (or undefined) flows through createUniqueInAppFile unchanged.
+  supportsCreateUnique: (b: { createUnique?: unknown } | undefined) =>
+    typeof b?.createUnique === 'function',
 }))
 
 describe('createUniqueInAppFile (single namer over the InApp backend)', () => {

--- a/spa/src/lib/inapp-namer.ts
+++ b/spa/src/lib/inapp-namer.ts
@@ -1,0 +1,23 @@
+/**
+ * inapp-namer — the single entry point for "create a new uniquely-named file"
+ * in the In-App storage. All three new-file UI affordances (the Storage pane,
+ * the editor "new buffer" popover, and the empty-editor new-tab section)
+ * converge here so the eager-reservation model and the #854 race fix live in
+ * exactly one place.
+ *
+ * The atomic uniqueness guarantee is provided by `InAppBackend.createUnique`
+ * (IDB `store.add`); this wrapper only resolves the backend and forwards the
+ * bare extension (`'md' | 'txt'`, no leading dot — the backend forms the path).
+ */
+import { getFsBackend } from './fs-backend'
+
+/**
+ * Reserve a new unique empty `Untitled[-N].<ext>` file under `dir` and return
+ * its full path. Throws if the In-App backend is unavailable so callers can
+ * surface the failure instead of silently creating nothing.
+ */
+export async function createUniqueInAppFile(dir: string, ext: 'md' | 'txt'): Promise<string> {
+  const backend = getFsBackend({ type: 'inapp' })
+  if (!backend) throw new Error('InApp backend unavailable')
+  return backend.createUnique(dir, 'Untitled', ext)
+}

--- a/spa/src/lib/inapp-namer.ts
+++ b/spa/src/lib/inapp-namer.ts
@@ -9,15 +9,17 @@
  * (IDB `store.add`); this wrapper only resolves the backend and forwards the
  * bare extension (`'md' | 'txt'`, no leading dot — the backend forms the path).
  */
-import { getFsBackend } from './fs-backend'
+import { getFsBackend, supportsCreateUnique } from './fs-backend'
 
 /**
  * Reserve a new unique empty `Untitled[-N].<ext>` file under `dir` and return
- * its full path. Throws if the In-App backend is unavailable so callers can
+ * its full path. Throws if the In-App backend is unavailable OR does not provide
+ * the unique-create capability (codex H1: `createUnique` lives on the optional
+ * `SupportsUniqueCreate` capability, not the base `FsBackend`) so callers can
  * surface the failure instead of silently creating nothing.
  */
 export async function createUniqueInAppFile(dir: string, ext: 'md' | 'txt'): Promise<string> {
   const backend = getFsBackend({ type: 'inapp' })
-  if (!backend) throw new Error('InApp backend unavailable')
+  if (!supportsCreateUnique(backend)) throw new Error('InApp backend unavailable')
   return backend.createUnique(dir, 'Untitled', ext)
 }

--- a/spa/src/lib/register-modules/fs-backends.tsx
+++ b/spa/src/lib/register-modules/fs-backends.tsx
@@ -36,6 +36,7 @@ export function registerBuiltinFsBackends(caps: PlatformCapabilities): void {
       mkdir: (path, recursive) => getDaemon().mkdir(path, recursive),
       delete: (path, recursive) => getDaemon().delete(path, recursive),
       rename: (from, to) => getDaemon().rename(from, to),
+      createUnique: (dir, baseName, ext) => getDaemon().createUnique(dir, baseName, ext),
     })
   }
 

--- a/spa/src/lib/register-modules/fs-backends.tsx
+++ b/spa/src/lib/register-modules/fs-backends.tsx
@@ -36,8 +36,6 @@ export function registerBuiltinFsBackends(caps: PlatformCapabilities): void {
       mkdir: (path, recursive) => getDaemon().mkdir(path, recursive),
       delete: (path, recursive) => getDaemon().delete(path, recursive),
       rename: (from, to) => getDaemon().rename(from, to),
-      createUnique: (dir, baseName, ext) => getDaemon().createUnique(dir, baseName, ext),
-      mkdirUnique: (dir, baseName) => getDaemon().mkdirUnique(dir, baseName),
     })
   }
 

--- a/spa/src/lib/register-modules/fs-backends.tsx
+++ b/spa/src/lib/register-modules/fs-backends.tsx
@@ -37,6 +37,7 @@ export function registerBuiltinFsBackends(caps: PlatformCapabilities): void {
       delete: (path, recursive) => getDaemon().delete(path, recursive),
       rename: (from, to) => getDaemon().rename(from, to),
       createUnique: (dir, baseName, ext) => getDaemon().createUnique(dir, baseName, ext),
+      mkdirUnique: (dir, baseName) => getDaemon().mkdirUnique(dir, baseName),
     })
   }
 

--- a/spa/src/lib/storage-tree.test.ts
+++ b/spa/src/lib/storage-tree.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { listTreeUnder, type TreeNode } from './storage-tree'
+import { listTreeUnder, findNode, targetDirOf, type TreeNode } from './storage-tree'
+import { STORAGE_ROOT } from './storage-paths'
 import type { FsBackend } from './fs-backend'
 import type { FileEntry } from '../types/fs'
 
@@ -118,5 +119,67 @@ describe('listTreeUnder', () => {
     const empty: TreeNode = tree[0]
     expect(empty.isDir).toBe(true)
     expect(empty.children).toEqual([])
+  })
+})
+
+// Fixture tree used by findNode / targetDirOf:
+//   /buffer/dir            (folder)
+//   /buffer/dir/b.md       (file)
+//   /buffer/dir/sub        (folder)
+//   /buffer/dir/sub/c.txt  (file)
+//   /buffer/a.md           (file)
+function sampleTree(): TreeNode[] {
+  return [
+    {
+      path: '/buffer/dir',
+      name: 'dir',
+      isDir: true,
+      size: 0,
+      children: [
+        {
+          path: '/buffer/dir/sub',
+          name: 'sub',
+          isDir: true,
+          size: 0,
+          children: [{ path: '/buffer/dir/sub/c.txt', name: 'c.txt', isDir: false, size: 3 }],
+        },
+        { path: '/buffer/dir/b.md', name: 'b.md', isDir: false, size: 7 },
+      ],
+    },
+    { path: '/buffer/a.md', name: 'a.md', isDir: false, size: 5 },
+  ]
+}
+
+describe('findNode', () => {
+  it('finds a top-level node by full path', () => {
+    expect(findNode(sampleTree(), '/buffer/a.md')?.name).toBe('a.md')
+    expect(findNode(sampleTree(), '/buffer/dir')?.isDir).toBe(true)
+  })
+
+  it('finds a deeply nested node by full path', () => {
+    const node = findNode(sampleTree(), '/buffer/dir/sub/c.txt')
+    expect(node?.path).toBe('/buffer/dir/sub/c.txt')
+    expect(node?.isDir).toBe(false)
+  })
+
+  it('returns null for an unknown path', () => {
+    expect(findNode(sampleTree(), '/buffer/nope.md')).toBeNull()
+    expect(findNode([], '/buffer/a.md')).toBeNull()
+  })
+})
+
+describe('targetDirOf (T0-2)', () => {
+  it('returns the folder itself when a folder is selected', () => {
+    expect(targetDirOf(findNode(sampleTree(), '/buffer/dir'))).toBe('/buffer/dir')
+    expect(targetDirOf(findNode(sampleTree(), '/buffer/dir/sub'))).toBe('/buffer/dir/sub')
+  })
+
+  it('returns the parent directory when a file is selected', () => {
+    expect(targetDirOf(findNode(sampleTree(), '/buffer/a.md'))).toBe(STORAGE_ROOT)
+    expect(targetDirOf(findNode(sampleTree(), '/buffer/dir/sub/c.txt'))).toBe('/buffer/dir/sub')
+  })
+
+  it('returns the storage root when nothing is selected', () => {
+    expect(targetDirOf(null)).toBe(STORAGE_ROOT)
   })
 })

--- a/spa/src/lib/storage-tree.ts
+++ b/spa/src/lib/storage-tree.ts
@@ -10,7 +10,7 @@
  * directories are distinct nodes (`/buffer/d1/x.md` ≠ `/buffer/d2/x.md`).
  */
 import type { FsBackend } from './fs-backend'
-import { join } from './storage-paths'
+import { join, parentOf, STORAGE_ROOT } from './storage-paths'
 
 export interface TreeNode {
   /** Full path under the storage root, e.g. `/buffer/dir/b.md`. The identity. */
@@ -55,4 +55,34 @@ export async function listTreeUnder(backend: FsBackend, root: string): Promise<T
     }
   }
   return sortNodes(nodes)
+}
+
+/**
+ * Depth-first lookup of the node whose full `path` matches, or `null`. Used by
+ * the Storage pane to resolve the current selection (a path) back to its
+ * `TreeNode` so it can read `isDir` for the `targetDir` derivation (T1b-0).
+ */
+export function findNode(nodes: TreeNode[], path: string): TreeNode | null {
+  for (const node of nodes) {
+    if (node.path === path) return node
+    if (node.children) {
+      const found = findNode(node.children, path)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+/**
+ * The directory that nesting-aware actions (new file / new folder / drop-to)
+ * should target given the current single selection (T1b-0, decision 3):
+ *
+ * - a selected **folder** → the folder itself,
+ * - a selected **file** → its parent directory,
+ * - **no** selection (or a non-single selection resolving to `null`) → the
+ *   storage root.
+ */
+export function targetDirOf(node: TreeNode | null): string {
+  if (!node) return STORAGE_ROOT
+  return node.isDir ? node.path : parentOf(node.path)
 }

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -480,6 +480,7 @@
   "editor.buffers.tab_title": "Storage",
   "editor.buffers.empty": "No buffers yet",
   "editor.buffers.new": "New Buffer",
+  "editor.buffers.new_folder": "New Folder",
   "editor.buffers.rename": "Rename",
   "editor.buffers.delete": "Delete",
   "editor.buffers.open": "Open",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -480,6 +480,7 @@
   "editor.buffers.tab_title": "儲存空間",
   "editor.buffers.empty": "尚無暫存檔",
   "editor.buffers.new": "新增暫存檔",
+  "editor.buffers.new_folder": "新增資料夾",
   "editor.buffers.rename": "重新命名",
   "editor.buffers.delete": "刪除",
   "editor.buffers.open": "開啟",


### PR DESCRIPTION
## Storage Phase 1b — Nested CRUD + recursive folder move

子系統 1 第二階段：在 1a 巢狀樹（PR #869）之上，補齊資料夾級的建立 / 改名 / 移動 / 刪除與統一的新檔命名。純前端（IndexedDB `InAppBackend`），無 daemon 改動。

### 任務（每個獨立 commit，TDD）
| Task | 內容 |
|------|------|
| **T1b-1** | 後端遞迴 `rename`/move：一次 tx re-key 所有 `from/` 前綴後代 + 碰撞掃描（先前已 commit）|
| **T1b-0** | **資料夾可選**：tree selection 從「只選 leaf file」擴成可選資料夾（name 選取 / caret 獨立 toggle）+ `targetDir` 衍生（folder→自身 / file→parent / none→root）|
| **T1b-2** | **統一 eager namer**：`InAppBackend.createUnique` 用 IDB `store.add()` 原子保留（修 #854 dup-bufferKey race）；`createUniqueInAppFile(dir, ext)` 單一 namer wire 三入口 |
| **T1b-3** | **New Folder (mkdir)**：`mkdirUnique` add-reserve；toolbar 按鈕 + New File 也 wire 到 `targetDir` |
| **T1b-4** | **rename（檔案+資料夾）**：把 `performBufferRename` 重構為 **pure** `remapPanesUnder`（不碰 backend）；`renameStorageEntry` 統一路徑、**恰好一次** `backend.rename` + 後代 pane re-point |
| **T1b-5** | **遞迴 delete**：open-pane 守衛從 exact-match 擴成 descendant（locked refuse / dirty confirm 含資料夾後代）+ folder `delete(path, true)` |
| **T1b-6a** | **pure `moveStorageEntry`**：no-op（self/descendant/same-parent）+ 碰撞 + 重用 `remapPanesUnder` |
| **T1b-6b** | **dnd-kit 拖曳 wiring**：`DndContext`（PointerSensor 5px）+ draggable row + droppable 資料夾/root；`computeMoveFromDragEnd` pure handler；保留 click-select / double-click-open 共存 |

### 設計重點
- **#854 修法**：IDB `add()`（非 `put`）作單一序列化點，並發呼叫必得不同 key。
- **eager untitled（spec amendment，user 拍板）**：`EditorNewTabSection` 從 lazy `untitled:` 改為三入口統一 eager 立即建檔；`.txt/.md` 以 `ext: 'md'|'txt'`（bare）保留。**`untitled:` runtime contract（EditorPane load/rename/save + useTabStore persist）保留不動**，dead-code 清理另開 issue。
- **單一 backend mutation 點**：rename/move 的 `backend.rename` 只在 `renameStorageEntry`/`moveStorageEntry` 呼叫一次；`remapPanesUnder` 為 pure pane/buffer re-point（spy 斷言 exactly-once）。
- **descendant 前綴比對**對 `pane.content.filePath` 做 `p === t || p.startsWith(t + '/')`（trailing slash 避免 `/buffer/a` 誤含 `/buffer/ab`）。

### Plan / review
- Detailed plan `docs/specs/2026-06-28-storage-filemanager-1b-plan.md`，**codex 3 輪 review 收斂 SHIP-READY**（R1 6 findings → R2 3 self-introduced → R3 clean）。
- Spec `docs/specs/2026-06-27-storage-filemanager-spec.md` §Phase 1b 已加 eager amendment。

### 驗證
- **Full vitest 3468 passed / 0 fail**（309 檔；1a baseline 3397 + 71）
- `pnpm run lint` clean、`pnpm run build`（tsc + vite）green

### 範圍外（Phase 1c）
上傳 / 下載 / binary open-disposition / size cap + quota。1b 的拖曳僅 intra-tree move，非 OS-file ingest。
