### PR TITLE
feat(storage): Storage In-App upload/download/binary-disposition/quota (subsystem 1, Phase 1c)

### DIFF
--- a/docs/specs/2026-06-28-storage-filemanager-1c-plan.md
+++ b/docs/specs/2026-06-28-storage-filemanager-1c-plan.md
@@ -1,0 +1,148 @@
+# Storage Phase 1c — Detailed Plan (Upload / download / binary-disposition / quota)
+
+Base: alpha.301 (1a+1b shipped). Worktree `storage-filemanager-1c`. Spec:
+`2026-06-27-storage-filemanager-spec.md` §"Phase 1c" + AC-1c. Parent plan outline:
+`2026-06-27-storage-filemanager-plan.md` §"Phase 1c".
+
+Pure front-end (IndexedDB `InAppBackend`), no daemon/Electron-IPC changes — OS download uses
+the browser anchor pattern, which works inside the Electron WebContents too.
+
+## Existing groundwork (reused, not rebuilt)
+
+- **Quota detector**: `sync/snapshot-store.ts:19-27` `isQuotaError(err)` (DOMException name
+  `QuotaExceededError` + legacy codes 22/1014). Currently **private → must be exported** (or
+  lifted to a shared util) for reuse.
+- **Backend**: `fs-backend-inapp.ts` `write(path, content: Uint8Array)` (no size check; quota
+  surfaces at `tx.done`), `read(path): Uint8Array` (ready for download), `stat`.
+- **Open routing**: `open-in-app-file.ts:45-82` `openInAppFile(path, wsId)` → `getDefaultOpener`
+  → `createContent` → insert tab. `register-modules/editor-module.tsx:18-90`:
+  `IMAGE_EXTS`/`PDF_EXTS`/`BINARY_EXTS(=IMAGE∪PDF)`; openers `image-preview`, `pdf-viewer`,
+  `monaco-editor` (matches non-dir **and not BINARY_EXTS** → today a `.docx` still matches
+  monaco and mounts as garbled text). `file-opener-registry.ts:55-58` `getDefaultOpener`.
+- **Download pattern**: `settings/SyncSection.tsx:43-50` `triggerDownload(blob, filename)`
+  (`createObjectURL` + `a.download` + `revokeObjectURL`); file-picker pattern (input ref +
+  `.click()` + `file.arrayBuffer()`/`.text()`), `:75,:175-187`.
+- **DnD (1b)**: `StoragePane.tsx` `DndContext` + `PointerSensor{distance:5}`,
+  `StorageRegionDropZone` (root `useDroppable`, `data-testid="storage-tree-region"`),
+  `StorageRow` `useDraggable`+`useDroppable`. dnd-kit is **pointer-event** based.
+- **Inline error banner**: `StoragePane.tsx:102` `actionError` state, `:348` render,
+  `setActionError(msg)` / `setActionError(null)`.
+
+## Design decisions
+
+1. **Native OS-file drop coexists with dnd-kit, distinguished by `dataTransfer.files`.**
+   dnd-kit uses pointer events; OS-file drop uses HTML5 `dragover`/`drop` carrying
+   `DataTransfer.files`. Add native `onDragOver`(`preventDefault` to allow drop)/`onDrop` to the
+   tree region. In `onDrop`, **only act when `e.dataTransfer.files.length > 0`** (an internal
+   node drag has no files) → ingest those files; otherwise ignore (let dnd-kit handle it). No
+   conflict because the two systems never both carry the same payload.
+2. **Binary open-disposition via an explicit `DOWNLOAD_EXTS` set, not a mounted pane.** A
+   download is a side-effect (no tab), so it does **not** fit `FileOpener.createContent`
+   (which returns `PaneContent`). `openInAppFile` gains a pre-dispatch branch: if the extension
+   is in `DOWNLOAD_EXTS` (office/archive/binary: `doc,docx,xls,xlsx,ppt,pptx,zip,rar,7z,tar,gz,
+   bin,exe,dmg,…`), **read bytes → `triggerDownload` → return undefined** (no tab). Images/PDF
+   still preview; text/code still monaco. (This also fixes the current `.docx`→monaco-garbled
+   path.) Keep the set in `editor-module.tsx` next to IMAGE/PDF for one source of truth.
+3. **Download is single-file only.** No folder→zip in 1c. Toolbar `Download` enabled iff
+   `singleSelected && !selectedNode.isDir`. Byte-identical: `read` → `Blob([bytes])` →
+   `triggerDownload(blob, basename)`.
+4. **Upload never overwrites.** On name collision the uploaded basename is suffixed
+   (`name (1).ext`, `name (2).ext`) via a `stat`-loop unique-path helper. (Upload is
+   user-initiated, not the rapid-double-click vector #854 addressed; a `stat`-loop is enough —
+   no atomic `add` reservation required.) **Any file type accepted.**
+5. **Soft size cap ~25 MB checked before write.** `SOFT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024`.
+   A file over the cap is rejected with an inline-banner **warning** before any write. On the
+   write itself, `QuotaExceededError` is caught via the exported `isQuotaError` and surfaced as
+   an inline-banner **error** (never silent).
+6. **Shared `triggerDownload` util.** Lift `triggerDownload` out of `SyncSection.tsx` into
+   `spa/src/lib/download-file.ts` (single impl), consumed by T1c-2 download + T1c-3 disposition;
+   update SyncSection to import it (behavior unchanged).
+7. **One PR** (`feat(storage): Phase 1c upload/download/binary-disposition/quota`),
+   task-per-commit, TDD.
+
+## Tasks
+
+Order & deps: **T1c-2** (download + shared util) → **T1c-3** (open-disposition, reuses util) →
+**T1c-1** (upload) → **T1c-4** (size cap + quota guards on upload). Each: failing tests first,
+then impl, full suite + lint + build green.
+
+### T1c-2 — Download / export a stored file + shared `triggerDownload` util
+- **New** `spa/src/lib/download-file.ts`: `triggerDownload(blob, filename)` (lifted from
+  SyncSection; `createObjectURL`+`a.download`+`revokeObjectURL`). Update `SyncSection.tsx` to
+  import it (no behavior change).
+- **storage-actions.ts** `downloadStorageFile(path): Promise<{ok}|{error}>`: `backend.read(path)`
+  → `new Blob([bytes])` → `triggerDownload(blob, basename(path))`.
+- **StoragePane.tsx**: toolbar `Download` button, enabled `singleSelected && !selectedNode?.isDir`;
+  errors via `setActionError`.
+- **Tests**: T2-1 download yields byte-identical content (assert `triggerDownload` called with a
+  Blob whose bytes equal the stored file; mock the anchor/URL); T2-2 download disabled/guarded
+  for a folder selection; T2-3 SyncSection still exports via the shared util (regression).
+- **Dep:** none.
+
+### T1c-3 — Binary open-disposition (non-previewable → download, not editor)
+- **editor-module.tsx**: add `DOWNLOAD_EXTS` (office/archive/binary set, decision 2) next to
+  IMAGE/PDF.
+- **open-in-app-file.ts**: before opener dispatch, if `extension ∈ DOWNLOAD_EXTS` →
+  `backend.read(path)` → `triggerDownload(Blob, name)` → `return undefined` (no tab). Images/PDF
+  → preview pane (unchanged); text/code → monaco (unchanged).
+- **Tests**: T3-1 opening a `.docx` triggers download + opens **no** tab; T3-2 opening a `.png`
+  still mounts the image-preview pane; T3-3 opening a `.md` still mounts monaco; T3-4 `.zip`
+  triggers download.
+- **Dep:** T1c-2 (shared `triggerDownload`).
+
+### T1c-1 — Upload (file picker + OS-file drag-drop)
+- **storage-actions.ts** `uploadFile(targetDir, file: File): Promise<{path}|{error}|{tooLarge}>`:
+  size-cap check (decision 5; returns `tooLarge` with the cap) → compute a non-colliding path
+  via a `stat`-loop unique-namer on `file.name` (decision 4) → `file.arrayBuffer()` →
+  `new Uint8Array(buf)` → `backend.write(path, bytes)` (quota caught here, decision 5) →
+  `{path}`. **Any type accepted.** Support multiple files (loop, aggregate first error).
+- **StoragePane.tsx**:
+  - Toolbar `Upload` button → hidden `<input type=file multiple>` ref + `.click()` → on change
+    upload each into `targetDir` (T1b-0) → `refresh()`; clear the input value after.
+  - Native OS-file drop on the tree region (decision 1): `onDragOver` preventDefault,
+    `onDrop` guarded by `dataTransfer.files.length > 0` → upload each into `targetDir` →
+    `refresh()`. Must not interfere with dnd-kit node move.
+- **Tests**: T1-1 upload an image stores it and it appears in the tree; opening it renders in the
+  image-preview pane (AC-1c #1); T1-2 upload a `.docx` stores it; opening triggers download
+  (ties to T1c-3) (AC-1c #2); T1-3 name collision → suffixed (`name (1).ext`), original intact;
+  T1-4 native `drop` with `dataTransfer.files` ingests; a `drop` with **no** files is ignored
+  (dnd-kit path untouched); T1-5 multiple-file upload writes all.
+- **Dep:** T1b-0 (`targetDir`), T1c-2 (for the T1-2 open→download assertion path).
+
+### T1c-4 — Soft size cap + quota error banner
+- **lib**: export `isQuotaError` from `sync/snapshot-store.ts` (or lift to
+  `spa/src/lib/quota.ts` and re-import in snapshot-store to avoid a second copy — prefer the
+  lift). Add `SOFT_MAX_UPLOAD_BYTES` constant (storage-paths.ts or storage-actions.ts).
+- **storage-actions.ts** `uploadFile`: enforce the cap before write (→ `{tooLarge, cap}`); wrap
+  `backend.write` so a thrown `QuotaExceededError` (via `isQuotaError`) returns `{error}` with a
+  quota message (never silent).
+- **StoragePane.tsx**: map `tooLarge` → inline-banner **warning** (file name + cap); `error`
+  (quota) → inline-banner **error**. i18n keys (EN + zh-TW).
+- **Tests**: T4-1 a file over the cap is rejected with a visible inline-banner warning, **no
+  write** (AC-1c #4a); T4-2 a simulated `QuotaExceededError` from `write` surfaces an
+  inline-banner error, not a silent no-op (AC-1c #4b); T4-3 `isQuotaError` unit cases
+  (DOMException name + codes 22/1014 + negative).
+- **Dep:** T1c-1 (guards layer onto its upload path).
+
+## Verification per task
+`cd spa && npx vitest run` (full suite green; alpha.301 baseline + new), `pnpm run lint`,
+`pnpm run build` (tsc + vite — run build every task; T1b-5 once shipped a tsc-only break that
+vitest alone missed). Codex sandbox has no network → main session runs install/test/lint/build.
+
+## AC-1c coverage map
+| AC-1c clause | Task / tests |
+|---|---|
+| Upload image/pdf stores it; opening renders in preview pane | T1c-1 T1-1 |
+| Upload `.docx` stores it; opening triggers download (no garbled editor) | T1c-1 T1-2 + T1c-3 T3-1 |
+| Downloading a stored file yields byte-identical content | T1c-2 T2-1 |
+| Over-cap file rejected with visible warning; simulated quota surfaces inline error | T1c-4 T4-1/T4-2 |
+
+## Out of scope
+Folder→zip download, Electron native save dialog (anchor download suffices), content-addressed
+chunking (Sync P5), subsystem 2 (daemon backup/restore). Upload is OS-file ingest; intra-tree
+node move is 1b.
+
+## Follow-ups to watch
+- 1b deferred file-health issues #872-#875 (storage-actions/StoragePane/StorageRow/test splits)
+  will grow with 1c's additions — note in PR if a new method materially worsens them, but do
+  **not** fold the splits into this PR.

--- a/docs/specs/2026-06-28-storage-filemanager-1c-plan.md
+++ b/docs/specs/2026-06-28-storage-filemanager-1c-plan.md
@@ -42,14 +42,28 @@ the browser anchor pattern, which works inside the Electron WebContents too.
    is in `DOWNLOAD_EXTS` (office/archive/binary: `doc,docx,xls,xlsx,ppt,pptx,zip,rar,7z,tar,gz,
    bin,exe,dmg,…`), **read bytes → `triggerDownload` → return undefined** (no tab). Images/PDF
    still preview; text/code still monaco. (This also fixes the current `.docx`→monaco-garbled
-   path.) Keep the set in `editor-module.tsx` next to IMAGE/PDF for one source of truth.
+   path.)
+   - **Layering (codex R1 F2)**: do NOT keep the set in `editor-module.tsx` — that is the
+     module-registration layer, and `lib/open-in-app-file.ts` reading from it creates a
+     `lib → module-registration → StoragePane → lib` cycle / inversion. Instead extract the
+     extension roles to a **shared leaf lib** `spa/src/lib/file-extension-roles.ts` exporting
+     `IMAGE_EXTS` / `PDF_EXTS` / `DOWNLOAD_EXTS` (+ `roleForExtension(ext)` helper). Both
+     `editor-module.tsx` (openers) and `open-in-app-file.ts` (disposition) import from it — one
+     SOT, no cycle.
 3. **Download is single-file only.** No folder→zip in 1c. Toolbar `Download` enabled iff
    `singleSelected && !selectedNode.isDir`. Byte-identical: `read` → `Blob([bytes])` →
    `triggerDownload(blob, basename)`.
-4. **Upload never overwrites.** On name collision the uploaded basename is suffixed
-   (`name (1).ext`, `name (2).ext`) via a `stat`-loop unique-path helper. (Upload is
-   user-initiated, not the rapid-double-click vector #854 addressed; a `stat`-loop is enough —
-   no atomic `add` reservation required.) **Any file type accepted.**
+4. **Upload never overwrites — atomic, not stat-loop (codex R1 F1).** A `stat`-loop is racy:
+   the picker and the native OS-file drop are independent entry points, and the base write is
+   `store.put()` (blind overwrite), so two concurrent uploads could pick the same name and the
+   second clobbers the first. Instead **reuse the #854 atomic `add()` reservation**: generalize
+   `InAppBackend.createUnique(dir, baseName, ext, content?)` to accept optional initial
+   `content` (default empty — 1b callers unaffected, they pass 3 args). Upload parses
+   `file.name` → `(baseName, ext)` and calls `createUnique(targetDir, baseName, ext, bytes)`,
+   so the unique-name reservation **and** the byte write happen on the same atomic `add` (suffix
+   `-N` on collision, matching the existing namer). Ext-less names (`README`) → `ext = ''`;
+   `createUnique` must form the path without a trailing dot in that case. **Any file type
+   accepted.**
 5. **Soft size cap ~25 MB checked before write.** `SOFT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024`.
    A file over the cap is rejected with an inline-banner **warning** before any write. On the
    write itself, `QuotaExceededError` is caught via the exported `isQuotaError` and surfaced as
@@ -80,9 +94,11 @@ then impl, full suite + lint + build green.
 - **Dep:** none.
 
 ### T1c-3 — Binary open-disposition (non-previewable → download, not editor)
-- **editor-module.tsx**: add `DOWNLOAD_EXTS` (office/archive/binary set, decision 2) next to
-  IMAGE/PDF.
-- **open-in-app-file.ts**: before opener dispatch, if `extension ∈ DOWNLOAD_EXTS` →
+- **New** `spa/src/lib/file-extension-roles.ts` (shared leaf lib, decision 2): move
+  `IMAGE_EXTS` / `PDF_EXTS` out of `editor-module.tsx`, add `DOWNLOAD_EXTS`; export +
+  `roleForExtension(ext): 'image'|'pdf'|'download'|'text'`. Update `editor-module.tsx` openers
+  to import from it (no behavior change).
+- **open-in-app-file.ts**: before opener dispatch, if `roleForExtension(ext) === 'download'` →
   `backend.read(path)` → `triggerDownload(Blob, name)` → `return undefined` (no tab). Images/PDF
   → preview pane (unchanged); text/code → monaco (unchanged).
 - **Tests**: T3-1 opening a `.docx` triggers download + opens **no** tab; T3-2 opening a `.png`
@@ -90,39 +106,50 @@ then impl, full suite + lint + build green.
   triggers download.
 - **Dep:** T1c-2 (shared `triggerDownload`).
 
-### T1c-1 — Upload (file picker + OS-file drag-drop)
-- **storage-actions.ts** `uploadFile(targetDir, file: File): Promise<{path}|{error}|{tooLarge}>`:
-  size-cap check (decision 5; returns `tooLarge` with the cap) → compute a non-colliding path
-  via a `stat`-loop unique-namer on `file.name` (decision 4) → `file.arrayBuffer()` →
-  `new Uint8Array(buf)` → `backend.write(path, bytes)` (quota caught here, decision 5) →
-  `{path}`. **Any type accepted.** Support multiple files (loop, aggregate first error).
+### T1c-1 — Upload (file picker + OS-file drag-drop) — happy path, NO cap/quota yet
+- **storage-actions.ts** `uploadFile(targetDir, file: File): Promise<{path}|{error}>`: parse
+  `file.name` → `(baseName, ext)` → `file.arrayBuffer()` → `new Uint8Array(buf)` →
+  `createUnique(targetDir, baseName, ext, bytes)` (decision 4, atomic no-overwrite) → `{path}`.
+  **No size cap, no quota handling here** (codex R1 F3 — those land in T1c-4); the result shape
+  stays `{path}|{error}` and T1c-4 widens it. **Any type accepted.**
+- **storage-actions.ts** `uploadFiles(targetDir, files: File[]): Promise<UploadSummary>` where
+  `UploadSummary = { uploaded: string[]; failed: { name: string; reason: string }[] }`
+  (codex R1 F5 — report partial success, not just the first error).
 - **StoragePane.tsx**:
   - Toolbar `Upload` button → hidden `<input type=file multiple>` ref + `.click()` → on change
-    upload each into `targetDir` (T1b-0) → `refresh()`; clear the input value after.
+    `uploadFiles(targetDir, [...files])` → `refresh()`; clear the input value after.
   - Native OS-file drop on the tree region (decision 1): `onDragOver` preventDefault,
-    `onDrop` guarded by `dataTransfer.files.length > 0` → upload each into `targetDir` →
-    `refresh()`. Must not interfere with dnd-kit node move.
-- **Tests**: T1-1 upload an image stores it and it appears in the tree; opening it renders in the
-  image-preview pane (AC-1c #1); T1-2 upload a `.docx` stores it; opening triggers download
-  (ties to T1c-3) (AC-1c #2); T1-3 name collision → suffixed (`name (1).ext`), original intact;
-  T1-4 native `drop` with `dataTransfer.files` ingests; a `drop` with **no** files is ignored
-  (dnd-kit path untouched); T1-5 multiple-file upload writes all.
-- **Dep:** T1b-0 (`targetDir`), T1c-2 (for the T1-2 open→download assertion path).
+    `onDrop` guarded by `dataTransfer.files.length > 0` → `uploadFiles(targetDir, [...files])`
+    → `refresh()`. Must not interfere with dnd-kit node move.
+  - Surface `summary.failed` as one inline banner that reflects partial success
+    (e.g. "Uploaded N, M failed: <firstFailedName> …").
+- **Tests**: T1-1 upload an **image** stores it + appears in tree; opening renders in the
+  image-preview pane (AC-1c #1); **T1-1b upload a `.pdf`; opening renders in the pdf-preview
+  pane** (AC-1c #1, codex R1 F4); T1-2 upload a `.docx` stores it; opening triggers download
+  (ties to T1c-3) (AC-1c #2); T1-3 name collision → atomic suffix (`name-1.ext`), original
+  intact; T1-4 native `drop` with `dataTransfer.files` ingests; a `drop` with **no** files is
+  ignored (dnd-kit path untouched); T1-5 multi-file upload returns a summary with all uploaded;
+  T1-6 partial failure → summary `uploaded`+`failed` populated, banner reflects both.
+- **Dep:** T1b-0 (`targetDir`), T1c-2 (for the open→download / preview assertion paths).
 
-### T1c-4 — Soft size cap + quota error banner
-- **lib**: export `isQuotaError` from `sync/snapshot-store.ts` (or lift to
-  `spa/src/lib/quota.ts` and re-import in snapshot-store to avoid a second copy — prefer the
-  lift). Add `SOFT_MAX_UPLOAD_BYTES` constant (storage-paths.ts or storage-actions.ts).
-- **storage-actions.ts** `uploadFile`: enforce the cap before write (→ `{tooLarge, cap}`); wrap
-  `backend.write` so a thrown `QuotaExceededError` (via `isQuotaError`) returns `{error}` with a
-  quota message (never silent).
-- **StoragePane.tsx**: map `tooLarge` → inline-banner **warning** (file name + cap); `error`
-  (quota) → inline-banner **error**. i18n keys (EN + zh-TW).
-- **Tests**: T4-1 a file over the cap is rejected with a visible inline-banner warning, **no
-  write** (AC-1c #4a); T4-2 a simulated `QuotaExceededError` from `write` surfaces an
-  inline-banner error, not a silent no-op (AC-1c #4b); T4-3 `isQuotaError` unit cases
-  (DOMException name + codes 22/1014 + negative).
-- **Dep:** T1c-1 (guards layer onto its upload path).
+### T1c-4 — Soft size cap + quota error banner (owns ALL upload guards, codex R1 F3)
+- **lib**: lift `isQuotaError` from `sync/snapshot-store.ts` into `spa/src/lib/quota.ts` and
+  re-import it back in `snapshot-store.ts` (single impl, no second copy; keep snapshot-store
+  tests green). Add `SOFT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024`.
+- **storage-actions.ts**: this task **widens** `uploadFile`'s result to
+  `{path} | {error} | {tooLarge: { name: string; cap: number }}`. (a) **Before** any write,
+  reject `file.size > SOFT_MAX_UPLOAD_BYTES` → `{tooLarge}` (no write at all). (b) Wrap the
+  `createUnique` write so a thrown quota error (via `isQuotaError`) returns `{error}` with a
+  quota message — never silent. `uploadFiles` folds `tooLarge`/`error` into the
+  `UploadSummary.failed` entries with a typed reason.
+- **StoragePane.tsx**: map a `tooLarge` failure → inline-banner **warning** (file name + cap);
+  a quota `error` → inline-banner **error**. i18n keys (EN + zh-TW).
+- **Tests**: T4-1 a file over the cap → inline-banner warning, `createUnique`/write **not
+  called** (AC-1c #4a); T4-2 a simulated `QuotaExceededError` from the write → inline-banner
+  error, not a silent no-op (AC-1c #4b); T4-3 `isQuotaError` unit cases (DOMException name +
+  codes 22/1014 + negative); T4-4 `snapshot-store` still detects quota through the lifted util
+  (regression).
+- **Dep:** T1c-1 (widens its upload path; all cap/quota responsibility lives here).
 
 ## Verification per task
 `cd spa && npx vitest run` (full suite green; alpha.301 baseline + new), `pnpm run lint`,
@@ -132,7 +159,8 @@ vitest alone missed). Codex sandbox has no network → main session runs install
 ## AC-1c coverage map
 | AC-1c clause | Task / tests |
 |---|---|
-| Upload image/pdf stores it; opening renders in preview pane | T1c-1 T1-1 |
+| Upload **image** stores it; opening renders in image-preview pane | T1c-1 T1-1 |
+| Upload **pdf** stores it; opening renders in pdf-preview pane | T1c-1 T1-1b |
 | Upload `.docx` stores it; opening triggers download (no garbled editor) | T1c-1 T1-2 + T1c-3 T3-1 |
 | Downloading a stored file yields byte-identical content | T1c-2 T2-1 |
 | Over-cap file rejected with visible warning; simulated quota surfaces inline error | T1c-4 T4-1/T4-2 |

--- a/docs/specs/2026-06-28-storage-filemanager-1c-plan.md
+++ b/docs/specs/2026-06-28-storage-filemanager-1c-plan.md
@@ -64,6 +64,16 @@ the browser anchor pattern, which works inside the Electron WebContents too.
    `-N` on collision, matching the existing namer). Ext-less names (`README`) → `ext = ''`;
    `createUnique` must form the path without a trailing dot in that case. **Any file type
    accepted.**
+   - **Contract change (codex R2 NEW-P2)**: `createUnique`'s `ext` is today typed `'md' | 'txt'`
+     (`fs-backend.ts` `SupportsUniqueCreate` + `fs-backend-inapp.ts`). Upload needs arbitrary
+     extensions (`png`/`pdf`/`docx`/`zip`/ext-less `''`), so **widen `ext` to `string`** at the
+     interface and impl, and update every touch point in the same commit so it compiles:
+     `fs-backend.ts` (`SupportsUniqueCreate.createUnique` signature), `fs-backend-inapp.ts`
+     (`createUnique` impl + the path-forming line — no trailing dot when `ext === ''`),
+     `inapp-namer.ts` (still passes `'md'`/`'txt'` — fine under `string`), and the
+     `createUnique`-typed mocks/guards in `fs-backend-inapp.test.ts` / `fs-backend.test.ts` /
+     `storage-actions.test.ts`. 1b's 3-arg callers stay valid (4th `content` optional,
+     defaulting to empty).
 5. **Soft size cap ~25 MB checked before write.** `SOFT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024`.
    A file over the cap is rejected with an inline-banner **warning** before any write. On the
    write itself, `QuotaExceededError` is caught via the exported `isQuotaError` and surfaced as

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -4,6 +4,7 @@ import { useState, type ReactNode } from 'react'
 import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
 import { StoragePane } from './StoragePane'
 import { openInAppFile } from '../../../lib/open-in-app-file'
+import { triggerDownload } from '../../../lib/download-file'
 import type { Pane, Tab } from '../../../types/tab'
 import type { FsBackend } from '../../../lib/fs-backend'
 import type { FileEntry, FileStat, FileSource } from '../../../types/fs'
@@ -72,6 +73,14 @@ vi.mock('../../../lib/fs-backend', () => ({
 // `lib/open-in-app-file.test.ts`; here we only assert the pane routes through it.
 vi.mock('../../../lib/open-in-app-file', () => ({
   openInAppFile: vi.fn(() => 'opened-tab'),
+}))
+
+// The Download toolbar button routes through the real `downloadStorageFile`
+// (which reads via the mocked backend) but the final OS download is the shared
+// `triggerDownload` util — stub it so jsdom's missing createObjectURL /
+// navigation never fires, and so we can assert the download was dispatched.
+vi.mock('../../../lib/download-file', () => ({
+  triggerDownload: vi.fn(),
 }))
 
 // Workspace store: StoragePane.resolveWorkspaceId maps the owning tab → its
@@ -267,6 +276,7 @@ beforeEach(() => {
   renameEditorPanesSpy.mockReset()
   ;(openInAppFile as unknown as Mock).mockReset()
   ;(openInAppFile as unknown as Mock).mockReturnValue('opened-tab')
+  ;(triggerDownload as unknown as Mock).mockReset()
 
   setPaneContentSpy.mockImplementation((tabId: string, paneId: string) => {
     eventLog.push(`setPaneContent:${tabId}:${paneId}`)
@@ -1597,6 +1607,58 @@ describe('StoragePane', () => {
     // A file selection re-enables Open.
     fireEvent.click(rowByPath('/buffer/note.md'))
     expect(openBtn.disabled).toBe(false)
+  })
+
+  // --- Download / export a stored file (T1c-2) ---
+
+  it('T2-2a: selecting a file enables Download and clicking dispatches downloadStorageFile', async () => {
+    const bytes = new TextEncoder().encode('hello world')
+    mockBackend.list.mockResolvedValue([
+      { name: 'note.md', isDir: false, size: bytes.byteLength },
+    ] as FileEntry[])
+    mockBackend.read.mockResolvedValue(bytes)
+    render(<StoragePane pane={makePane()} isActive />)
+    const row = await screen.findByTestId('buffer-row')
+    const downloadBtn = screen.getByTestId('toolbar-download') as HTMLButtonElement
+    // No selection → disabled.
+    expect(downloadBtn.disabled).toBe(true)
+    fireEvent.click(row) // select the file
+    expect(downloadBtn.disabled).toBe(false)
+    fireEvent.click(downloadBtn)
+    await waitFor(() => {
+      // downloadStorageFile read the file's bytes …
+      expect(mockBackend.read).toHaveBeenCalledWith('/buffer/note.md')
+    })
+    await waitFor(() => {
+      // … and handed them to the shared download util as a Blob named by basename.
+      expect(triggerDownload).toHaveBeenCalledTimes(1)
+    })
+    const [blob, filename] = (triggerDownload as unknown as Mock).mock.calls[0]
+    expect(blob).toBeInstanceOf(Blob)
+    expect(filename).toBe('note.md')
+  })
+
+  it('T2-2b: selecting a folder disables Download and clicking never downloads', async () => {
+    mockBackend.list = pathAwareList(
+      new Map([
+        ['/buffer/dir', { isDir: true, size: 0 }],
+        ['/buffer/note.md', { isDir: false, size: 3 }],
+      ]),
+    )
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findAllByTestId('buffer-row')
+    const rowByPath = (p: string) =>
+      screen.getAllByTestId('buffer-row').find((r) => r.getAttribute('data-path') === p)!
+    const downloadBtn = screen.getByTestId('toolbar-download') as HTMLButtonElement
+    // Folder selected → Download disabled, and a click never reads / downloads.
+    fireEvent.click(rowByPath('/buffer/dir'))
+    expect(downloadBtn.disabled).toBe(true)
+    fireEvent.click(downloadBtn)
+    expect(triggerDownload).not.toHaveBeenCalled()
+    expect(mockBackend.read).not.toHaveBeenCalledWith('/buffer/dir')
+    // A file selection re-enables Download.
+    fireEvent.click(rowByPath('/buffer/note.md'))
+    expect(downloadBtn.disabled).toBe(false)
   })
 
   // --- Selection model: plain click never toggles off (codex B5) ---

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { Mock } from 'vitest'
 import { useState, type ReactNode } from 'react'
-import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within, act, createEvent } from '@testing-library/react'
 import { StoragePane } from './StoragePane'
 import { SOFT_MAX_UPLOAD_BYTES } from './storage-actions'
 import { openInAppFile } from '../../../lib/open-in-app-file'
@@ -97,14 +97,20 @@ vi.mock('../../../features/workspace/store', () => ({
   },
 }))
 
+// i18n is a hoisted spy so the upload banner tests (C6) can assert the
+// interpolation PARAMS (name / cap / counts), not just the key. The spy still
+// returns the key with any `{{var}}` placeholders substituted, so the existing
+// `getByText('editor.buffers.…')` assertions (keys carry no placeholders) hold.
+const { tSpy } = vi.hoisted(() => ({
+  tSpy: vi.fn((key: string, params?: Record<string, string | number>): string => {
+    if (!params) return key
+    return key.replace(/\{\{(\w+)\}\}/g, (_, k) => String(params[k] ?? ''))
+  }),
+}))
+
 vi.mock('../../../stores/useI18nStore', () => ({
   useI18nStore: (selector: (s: { t: (k: string, p?: Record<string, string | number>) => string }) => unknown) =>
-    selector({
-      t: (key: string, params?: Record<string, string | number>): string => {
-        if (!params) return key
-        return key.replace(/\{\{(\w+)\}\}/g, (_, k) => String(params[k] ?? ''))
-      },
-    }),
+    selector({ t: tSpy }),
 }))
 
 const setPaneContentSpy = vi.fn()
@@ -278,6 +284,7 @@ beforeEach(() => {
   ;(openInAppFile as unknown as Mock).mockReset()
   ;(openInAppFile as unknown as Mock).mockReturnValue('opened-tab')
   ;(triggerDownload as unknown as Mock).mockReset()
+  tSpy.mockClear()
 
   setPaneContentSpy.mockImplementation((tabId: string, paneId: string) => {
     eventLog.push(`setPaneContent:${tabId}:${paneId}`)
@@ -1862,6 +1869,25 @@ describe('StoragePane — upload via picker + native OS-file drop (T1c-1)', () =
     expect(mockBackend.createUnique).not.toHaveBeenCalled()
   })
 
+  it('C3: dropping an OS FOLDER (types:[Files] but files:[]) is preventDefaulted and not ingested', async () => {
+    wireUploadBackend()
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+
+    const region = screen.getByTestId('storage-tree-region')
+    // An OS folder drag reports the `Files` type but yields an EMPTY files list.
+    // The handler must claim it (preventDefault) so it never falls back to the
+    // browser default — yet must NOT try to ingest a zero-file drop.
+    const dropEvent = createEvent.drop(region, {
+      dataTransfer: { files: [], types: ['Files'] },
+    })
+    await act(async () => {
+      fireEvent(region, dropEvent)
+    })
+    expect(dropEvent.defaultPrevented).toBe(true)
+    expect(mockBackend.createUnique).not.toHaveBeenCalled()
+  })
+
   it('T1-6: a partial failure surfaces an inline banner naming the first failed file', async () => {
     const paths = new Map<string, { isDir: boolean; size: number }>()
     mockBackend.list = pathAwareList(paths)
@@ -1880,10 +1906,15 @@ describe('StoragePane — upload via picker + native OS-file drop (T1c-1)', () =
       new File([new Uint8Array([2])], 'bad.bin'),
     ])
 
-    // Banner reflects partial success: the inline error renders the partial key
-    // (the i18n mock returns the key, not the interpolated EN/zh-TW string). The
-    // good file still uploaded, the bad one failed.
+    // Banner reflects partial success. C6: assert the i18n call carries the
+    // right interpolation params (uploaded/failed counts + the first failed
+    // name), not just the key.
     await waitFor(() => expect(screen.getByText('editor.buffers.upload_partial')).toBeTruthy())
+    expect(tSpy).toHaveBeenCalledWith('editor.buffers.upload_partial', {
+      uploaded: 1,
+      failed: 1,
+      name: 'bad.bin',
+    })
     const calls = (mockBackend.createUnique as Mock).mock.calls.map((c) => c[1])
     expect(calls).toEqual(['ok', 'bad'])
   })
@@ -1907,6 +1938,11 @@ describe('StoragePane — upload via picker + native OS-file drop (T1c-1)', () =
     const warning = await screen.findByTestId('storage-warning')
     expect(warning.textContent).toBe('editor.buffers.upload_too_large')
     expect(warning.className).toContain('text-amber-400')
+    // C6: the warning interpolates the file name + the cap in MB (25 = 25 MiB).
+    expect(tSpy).toHaveBeenCalledWith('editor.buffers.upload_too_large', {
+      name: 'huge.bin',
+      cap: 25,
+    })
     expect(mockBackend.createUnique).not.toHaveBeenCalled()
   })
 
@@ -1923,6 +1959,8 @@ describe('StoragePane — upload via picker + native OS-file drop (T1c-1)', () =
 
     const banner = await screen.findByText('editor.buffers.upload_quota')
     expect(banner.className).toContain('text-red-400')
+    // C6: the quota error names the file that could not be saved.
+    expect(tSpy).toHaveBeenCalledWith('editor.buffers.upload_quota', { name: 'x.txt' })
     expect(screen.queryByTestId('storage-warning')).toBeNull()
   })
 })

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -1745,3 +1745,145 @@ describe('StoragePane', () => {
     expect(new Set(reserved).size).toBe(reserved.length)
   })
 })
+
+// --- T1c-1: upload (file picker + native OS-file drop) -----------------------
+//
+// `openInAppFile` is mocked here (its kind dispatch — png→image-preview /
+// pdf→pdf-preview / docx→download — is proven in lib/open-in-app-file.test.ts).
+// These cases assert the StoragePane wiring: the picker / native drop ingests
+// files via the atomic `createUnique(dir, base, ext, bytes)`, the file appears
+// in the tree after refresh, opening routes through `openInAppFile`, and a
+// no-files drop never touches upload (dnd-kit node move untouched).
+
+describe('StoragePane — upload via picker + native OS-file drop (T1c-1)', () => {
+  /** A `createUnique` that records bytes and materializes the path in `paths`. */
+  function wireUploadBackend() {
+    const paths = new Map<string, { isDir: boolean; size: number }>()
+    mockBackend.list = pathAwareList(paths)
+    mockBackend.createUnique = vi.fn(async (dir: string, base: string, ext: string) => {
+      const fileName = ext === '' ? base : `${base}.${ext}`
+      const path = `${dir}/${fileName}`
+      paths.set(path, { isDir: false, size: 1 })
+      return path
+    })
+    return paths
+  }
+
+  async function uploadViaPicker(files: File[]) {
+    const input = screen.getByTestId('upload-input') as HTMLInputElement
+    await act(async () => {
+      fireEvent.change(input, { target: { files } })
+    })
+  }
+
+  it('T1-1: uploading an image via the picker stores its bytes (png ext), shows it in the tree, and opening routes through openInAppFile', async () => {
+    wireUploadBackend()
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+
+    await uploadViaPicker([new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' })])
+
+    await waitFor(() => expect(mockBackend.createUnique).toHaveBeenCalled())
+    const [dir, base, ext, bytes] = (mockBackend.createUnique as Mock).mock.calls[0]
+    expect(dir).toBe('/buffer')
+    expect(base).toBe('photo')
+    expect(ext).toBe('png')
+    expect(Array.from(bytes as Uint8Array)).toEqual([1, 2, 3])
+
+    const row = await screen.findByTestId('buffer-row')
+    expect(row.getAttribute('data-path')).toBe('/buffer/photo.png')
+    fireEvent.doubleClick(row)
+    await waitFor(() => expect(openInAppFile).toHaveBeenCalledWith('/buffer/photo.png', 'ws1'))
+  })
+
+  it('T1-1b: uploading a .pdf stores it and opening routes through openInAppFile (→ pdf-preview)', async () => {
+    wireUploadBackend()
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+
+    await uploadViaPicker([new File([new Uint8Array([8])], 'doc.pdf', { type: 'application/pdf' })])
+
+    await waitFor(() => expect(mockBackend.createUnique).toHaveBeenCalled())
+    expect((mockBackend.createUnique as Mock).mock.calls[0][2]).toBe('pdf')
+    const row = await screen.findByTestId('buffer-row')
+    expect(row.getAttribute('data-path')).toBe('/buffer/doc.pdf')
+    fireEvent.doubleClick(row)
+    await waitFor(() => expect(openInAppFile).toHaveBeenCalledWith('/buffer/doc.pdf', 'ws1'))
+  })
+
+  it('T1-2: uploading a .docx stores it and opening routes through openInAppFile (→ download)', async () => {
+    wireUploadBackend()
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+
+    await uploadViaPicker([new File([new Uint8Array([5])], 'sheet.docx')])
+
+    await waitFor(() => expect(mockBackend.createUnique).toHaveBeenCalled())
+    expect((mockBackend.createUnique as Mock).mock.calls[0][2]).toBe('docx')
+    const row = await screen.findByTestId('buffer-row')
+    expect(row.getAttribute('data-path')).toBe('/buffer/sheet.docx')
+    fireEvent.doubleClick(row)
+    await waitFor(() => expect(openInAppFile).toHaveBeenCalledWith('/buffer/sheet.docx', 'ws1'))
+  })
+
+  it('T1-4: a native drop carrying dataTransfer.files ingests them', async () => {
+    wireUploadBackend()
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+
+    const region = screen.getByTestId('storage-tree-region')
+    await act(async () => {
+      fireEvent.drop(region, {
+        dataTransfer: { files: [new File([new Uint8Array([9])], 'dropped.txt')], types: ['Files'] },
+      })
+    })
+
+    await waitFor(() => expect(mockBackend.createUnique).toHaveBeenCalled())
+    const [dir, base, ext] = (mockBackend.createUnique as Mock).mock.calls[0]
+    expect(dir).toBe('/buffer')
+    expect(base).toBe('dropped')
+    expect(ext).toBe('txt')
+    const row = await screen.findByTestId('buffer-row')
+    expect(row.getAttribute('data-path')).toBe('/buffer/dropped.txt')
+  })
+
+  it('T1-4: a native drop with NO files is ignored (dnd-kit node move untouched)', async () => {
+    wireUploadBackend()
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+
+    const region = screen.getByTestId('storage-tree-region')
+    fireEvent.drop(region, { dataTransfer: { files: [], types: [] } })
+    // Let any stray microtask settle.
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mockBackend.createUnique).not.toHaveBeenCalled()
+  })
+
+  it('T1-6: a partial failure surfaces an inline banner naming the first failed file', async () => {
+    const paths = new Map<string, { isDir: boolean; size: number }>()
+    mockBackend.list = pathAwareList(paths)
+    mockBackend.createUnique = vi.fn(async (dir: string, base: string, ext: string) => {
+      if (base === 'bad') throw new Error('boom')
+      const fileName = ext === '' ? base : `${base}.${ext}`
+      const path = `${dir}/${fileName}`
+      paths.set(path, { isDir: false, size: 1 })
+      return path
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+
+    await uploadViaPicker([
+      new File([new Uint8Array([1])], 'ok.txt'),
+      new File([new Uint8Array([2])], 'bad.bin'),
+    ])
+
+    // Banner reflects partial success: the inline error renders the partial key
+    // (the i18n mock returns the key, not the interpolated EN/zh-TW string). The
+    // good file still uploaded, the bad one failed.
+    await waitFor(() => expect(screen.getByText('editor.buffers.upload_partial')).toBeTruthy())
+    const calls = (mockBackend.createUnique as Mock).mock.calls.map((c) => c[1])
+    expect(calls).toEqual(['ok', 'bad'])
+  })
+})

--- a/spa/src/components/editor/storage/StoragePane.test.tsx
+++ b/spa/src/components/editor/storage/StoragePane.test.tsx
@@ -3,6 +3,7 @@ import type { Mock } from 'vitest'
 import { useState, type ReactNode } from 'react'
 import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
 import { StoragePane } from './StoragePane'
+import { SOFT_MAX_UPLOAD_BYTES } from './storage-actions'
 import { openInAppFile } from '../../../lib/open-in-app-file'
 import { triggerDownload } from '../../../lib/download-file'
 import type { Pane, Tab } from '../../../types/tab'
@@ -1885,5 +1886,43 @@ describe('StoragePane — upload via picker + native OS-file drop (T1c-1)', () =
     await waitFor(() => expect(screen.getByText('editor.buffers.upload_partial')).toBeTruthy())
     const calls = (mockBackend.createUnique as Mock).mock.calls.map((c) => c[1])
     expect(calls).toEqual(['ok', 'bad'])
+  })
+
+  // --- T1c-4: size cap warning + quota error banner -------------------------
+
+  /** A File whose `size` is forced past the cap WITHOUT allocating the bytes. */
+  function oversizedFile(name: string, size: number): File {
+    const file = new File([new Uint8Array([0])], name)
+    Object.defineProperty(file, 'size', { value: size })
+    return file
+  }
+
+  it('T4-1: an over-cap file shows the amber too-large WARNING and never writes', async () => {
+    wireUploadBackend()
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+
+    await uploadViaPicker([oversizedFile('huge.bin', SOFT_MAX_UPLOAD_BYTES + 1)])
+
+    const warning = await screen.findByTestId('storage-warning')
+    expect(warning.textContent).toBe('editor.buffers.upload_too_large')
+    expect(warning.className).toContain('text-amber-400')
+    expect(mockBackend.createUnique).not.toHaveBeenCalled()
+  })
+
+  it('T4-2: a quota write failure shows the red quota ERROR banner (not silent)', async () => {
+    const paths = new Map<string, { isDir: boolean; size: number }>()
+    mockBackend.list = pathAwareList(paths)
+    mockBackend.createUnique = vi.fn(async () => {
+      throw new DOMException('full', 'QuotaExceededError')
+    })
+    render(<StoragePane pane={makePane()} isActive />)
+    await screen.findByText('editor.buffers.empty')
+
+    await uploadViaPicker([new File([new Uint8Array([1])], 'x.txt')])
+
+    const banner = await screen.findByText('editor.buffers.upload_quota')
+    expect(banner.className).toContain('text-red-400')
+    expect(screen.queryByTestId('storage-warning')).toBeNull()
   })
 })

--- a/spa/src/components/editor/storage/StoragePane.tsx
+++ b/spa/src/components/editor/storage/StoragePane.tsx
@@ -8,7 +8,7 @@ import {
   useSensors,
   type DragEndEvent,
 } from '@dnd-kit/core'
-import { DownloadSimple, FilePlus, FolderPlus, PencilSimple, Stack, Trash, FolderOpen } from '@phosphor-icons/react'
+import { DownloadSimple, FilePlus, FolderPlus, PencilSimple, Stack, Trash, FolderOpen, UploadSimple } from '@phosphor-icons/react'
 import type { PaneRendererProps } from '../../../lib/module-registry'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { useTabStore } from '../../../stores/useTabStore'
@@ -27,6 +27,7 @@ import {
   downloadStorageFile,
   moveStorageEntry,
   renameStorageEntry,
+  uploadFiles,
 } from './storage-actions'
 import { computeMoveFromDragEnd } from './storage-dnd'
 
@@ -60,9 +61,13 @@ function resolveWorkspaceId(paneId: string): string | null {
  */
 function StorageRegionDropZone({
   targetDir,
+  onNativeDragOver,
+  onNativeDrop,
   children,
 }: {
   targetDir: string
+  onNativeDragOver: (e: React.DragEvent<HTMLDivElement>) => void
+  onNativeDrop: (e: React.DragEvent<HTMLDivElement>) => void
   children: ReactNode
 }) {
   // Publish `STORAGE_ROOT` as this zone's authoritative drop target dir (codex
@@ -79,6 +84,12 @@ function StorageRegionDropZone({
       data-testid="storage-tree-region"
       data-target-dir={targetDir}
       data-root-over={isOver ? 'true' : 'false'}
+      // Native OS-file drop (Phase 1c decision 1). HTML5 drag events carrying
+      // `DataTransfer.files` are a SEPARATE event stream from dnd-kit's pointer
+      // events, so these handlers only fire for an OS-file drag; an internal
+      // node move (no files) is ignored and left entirely to dnd-kit.
+      onDragOver={onNativeDragOver}
+      onDrop={onNativeDrop}
     >
       {children}
     </div>
@@ -106,6 +117,7 @@ export function StoragePane({ pane }: PaneRendererProps) {
   const [renameError, setRenameError] = useState<string | null>(null)
   const [renameAnchorRect, setRenameAnchorRect] = useState<DOMRect | null>(null)
   const renameAnchorRef = useRef<HTMLButtonElement | null>(null)
+  const uploadInputRef = useRef<HTMLInputElement | null>(null)
 
   const error = actionError ?? treeError
 
@@ -242,6 +254,65 @@ export function StoragePane({ pane }: PaneRendererProps) {
     if (singleSelected && !selectedNode?.isDir) handleOpen(singleSelected)
   }, [singleSelected, selectedNode, handleOpen])
 
+  // --- Upload (file picker + native OS-file drop, T1c-1) ---
+
+  // Ingest OS files into the current `targetDir`. Shared by the picker and the
+  // native drop. Reflects partial success in the inline banner (codex R1 F5):
+  // any failure names the count + first failed file; all-success clears it.
+  const ingestFiles = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) return
+      setBusy(true)
+      setActionError(null)
+      const summary = await uploadFiles(targetDir, files)
+      setBusy(false)
+      if (summary.failed.length > 0) {
+        setActionError(
+          t('editor.buffers.upload_partial', {
+            uploaded: summary.uploaded.length,
+            failed: summary.failed.length,
+            name: summary.failed[0].name,
+          }),
+        )
+      }
+      refresh()
+    },
+    [targetDir, refresh, t],
+  )
+
+  const handleUploadClick = useCallback(() => {
+    uploadInputRef.current?.click()
+  }, [])
+
+  const handleUploadChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files ? Array.from(e.target.files) : []
+      // Clear the value so re-selecting the SAME file fires change again.
+      e.target.value = ''
+      await ingestFiles(files)
+    },
+    [ingestFiles],
+  )
+
+  // Native OS-file drag (decision 1). `preventDefault` on dragover is what makes
+  // the region a valid drop target; only act when the drag actually carries
+  // files so an internal dnd-kit node move passes straight through.
+  const handleNativeDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (e.dataTransfer?.types?.includes('Files')) e.preventDefault()
+  }, [])
+
+  const handleNativeDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      const files = e.dataTransfer?.files
+      // No files → this is a dnd-kit internal node drag; do NOT preventDefault,
+      // do NOT ingest — let dnd-kit's pointer-event flow own it.
+      if (!files || files.length === 0) return
+      e.preventDefault()
+      void ingestFiles(Array.from(files))
+    },
+    [ingestFiles],
+  )
+
   const handleDownload = useCallback(async () => {
     // Single-file only (T1c-2): a folder is not downloadable, so guard here as
     // well as disabling the toolbar button. The byte read + OS download happen
@@ -321,6 +392,24 @@ export function StoragePane({ pane }: PaneRendererProps) {
           {t('editor.buffers.new_folder')}
         </button>
         <button
+          data-testid="toolbar-upload"
+          onClick={handleUploadClick}
+          disabled={toolbarBusy}
+          className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-text-secondary hover:bg-surface-hover disabled:opacity-50"
+          title={t('editor.buffers.upload')}
+        >
+          <UploadSimple size={14} />
+          {t('editor.buffers.upload')}
+        </button>
+        <input
+          ref={uploadInputRef}
+          type="file"
+          multiple
+          data-testid="upload-input"
+          className="hidden"
+          onChange={handleUploadChange}
+        />
+        <button
           data-testid="toolbar-rename"
           ref={renameAnchorRef}
           onClick={handleOpenRename}
@@ -368,7 +457,11 @@ export function StoragePane({ pane }: PaneRendererProps) {
           drop targets, and a drop calls `moveStorageEntry` via `handleDragEnd`. */}
       <div className="flex-1 flex overflow-hidden">
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <StorageRegionDropZone targetDir={targetDir}>
+          <StorageRegionDropZone
+            targetDir={targetDir}
+            onNativeDragOver={handleNativeDragOver}
+            onNativeDrop={handleNativeDrop}
+          >
             {error && <div className="p-4 text-xs text-red-400">{error}</div>}
             {!error && !hasAny && (
               <div className="p-8 flex flex-col items-center justify-center text-text-muted">

--- a/spa/src/components/editor/storage/StoragePane.tsx
+++ b/spa/src/components/editor/storage/StoragePane.tsx
@@ -112,6 +112,10 @@ export function StoragePane({ pane }: PaneRendererProps) {
 
   const [selected, setSelected] = useState<Set<string>>(() => new Set())
   const [actionError, setActionError] = useState<string | null>(null)
+  // Upload-only soft warning (over the size cap) — rendered amber, below errors.
+  // Kept separate from `actionError` (red) so a too-large rejection reads as a
+  // recoverable warning, not a hard failure (T1c-4).
+  const [actionWarning, setActionWarning] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [renameTarget, setRenameTarget] = useState<string | null>(null)
   const [renameError, setRenameError] = useState<string | null>(null)
@@ -168,6 +172,7 @@ export function StoragePane({ pane }: PaneRendererProps) {
   const handleNew = useCallback(async () => {
     setBusy(true)
     setActionError(null)
+    setActionWarning(null)
     // T1b-0 wiring: the new file lands in the selected folder (or the parent of
     // a selected file, else the storage root).
     const res = await createStorageFile(targetDir)
@@ -179,6 +184,7 @@ export function StoragePane({ pane }: PaneRendererProps) {
   const handleNewFolder = useCallback(async () => {
     setBusy(true)
     setActionError(null)
+    setActionWarning(null)
     const res = await createStorageFolder(targetDir)
     setBusy(false)
     if ('error' in res) {
@@ -237,6 +243,7 @@ export function StoragePane({ pane }: PaneRendererProps) {
     if (selectedArray.length === 0) return
     setBusy(true)
     setActionError(null)
+    setActionWarning(null)
     const res = await deleteStorageEntries(selectedArray, t)
     setBusy(false)
     if (res.status === 'deleted') {
@@ -257,23 +264,41 @@ export function StoragePane({ pane }: PaneRendererProps) {
   // --- Upload (file picker + native OS-file drop, T1c-1) ---
 
   // Ingest OS files into the current `targetDir`. Shared by the picker and the
-  // native drop. Reflects partial success in the inline banner (codex R1 F5):
-  // any failure names the count + first failed file; all-success clears it.
+  // native drop. Reflects partial success in the inline banner (codex R1 F5) and
+  // distinguishes the T1c-4 guard outcomes by typed reason:
+  //   - a quota failure (store full) → red error banner (takes precedence);
+  //   - else if EVERY failure is too-large → amber warning naming the first file
+  //     + the cap in MB (a soft, recoverable rejection, not a hard error);
+  //   - else → the generic partial message (count + first failed file).
+  // All-success clears both banners.
   const ingestFiles = useCallback(
     async (files: File[]) => {
       if (files.length === 0) return
       setBusy(true)
       setActionError(null)
+      setActionWarning(null)
       const summary = await uploadFiles(targetDir, files)
       setBusy(false)
-      if (summary.failed.length > 0) {
-        setActionError(
-          t('editor.buffers.upload_partial', {
-            uploaded: summary.uploaded.length,
-            failed: summary.failed.length,
-            name: summary.failed[0].name,
-          }),
-        )
+      const { failed } = summary
+      if (failed.length > 0) {
+        const quota = failed.find((f) => f.kind === 'quota')
+        const tooLarge = failed.filter((f) => f.kind === 'too-large')
+        if (quota) {
+          setActionError(t('editor.buffers.upload_quota', { name: quota.name }))
+        } else if (tooLarge.length === failed.length) {
+          const capMb = Math.round((tooLarge[0].cap ?? 0) / (1024 * 1024))
+          setActionWarning(
+            t('editor.buffers.upload_too_large', { name: tooLarge[0].name, cap: capMb }),
+          )
+        } else {
+          setActionError(
+            t('editor.buffers.upload_partial', {
+              uploaded: summary.uploaded.length,
+              failed: failed.length,
+              name: failed[0].name,
+            }),
+          )
+        }
       }
       refresh()
     },
@@ -319,6 +344,7 @@ export function StoragePane({ pane }: PaneRendererProps) {
     // in downloadStorageFile; surface any failure in the inline banner.
     if (!singleSelected || selectedNode?.isDir) return
     setActionError(null)
+    setActionWarning(null)
     const res = await downloadStorageFile(singleSelected)
     if ('error' in res) setActionError(res.error)
   }, [singleSelected, selectedNode])
@@ -335,6 +361,7 @@ export function StoragePane({ pane }: PaneRendererProps) {
       const move = computeMoveFromDragEnd(event.active, event.over)
       if (!move) return
       setActionError(null)
+      setActionWarning(null)
       const res = await moveStorageEntry(move.from, move.targetDir)
       if ('ok' in res) {
         // Keep the moved entry selected at its new home so a follow-up action
@@ -463,6 +490,11 @@ export function StoragePane({ pane }: PaneRendererProps) {
             onNativeDrop={handleNativeDrop}
           >
             {error && <div className="p-4 text-xs text-red-400">{error}</div>}
+            {!error && actionWarning && (
+              <div data-testid="storage-warning" className="p-4 text-xs text-amber-400">
+                {actionWarning}
+              </div>
+            )}
             {!error && !hasAny && (
               <div className="p-8 flex flex-col items-center justify-center text-text-muted">
                 <Stack size={32} className="mb-2 opacity-50" />

--- a/spa/src/components/editor/storage/StoragePane.tsx
+++ b/spa/src/components/editor/storage/StoragePane.tsx
@@ -328,11 +328,19 @@ export function StoragePane({ pane }: PaneRendererProps) {
 
   const handleNativeDrop = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
-      const files = e.dataTransfer?.files
-      // No files → this is a dnd-kit internal node drag; do NOT preventDefault,
-      // do NOT ingest — let dnd-kit's pointer-event flow own it.
-      if (!files || files.length === 0) return
+      const dt = e.dataTransfer
+      // Not an OS-file drag (no `Files` type) → this is a dnd-kit internal node
+      // move; do NOT preventDefault, do NOT ingest — let dnd-kit's pointer-event
+      // flow own it.
+      if (!dt?.types?.includes('Files')) return
+      // It IS an OS-file drag — claim it so the browser never falls back to its
+      // default drop (navigating to / opening the dropped item). This covers
+      // dropping an OS FOLDER, which reports `types: ['Files']` but an EMPTY
+      // `files` list (codex R2 C3): without preventDefault the folder drop would
+      // leak to the browser default.
       e.preventDefault()
+      const files = dt.files
+      if (!files || files.length === 0) return
       void ingestFiles(Array.from(files))
     },
     [ingestFiles],

--- a/spa/src/components/editor/storage/StoragePane.tsx
+++ b/spa/src/components/editor/storage/StoragePane.tsx
@@ -8,7 +8,7 @@ import {
   useSensors,
   type DragEndEvent,
 } from '@dnd-kit/core'
-import { FilePlus, FolderPlus, PencilSimple, Stack, Trash, FolderOpen } from '@phosphor-icons/react'
+import { DownloadSimple, FilePlus, FolderPlus, PencilSimple, Stack, Trash, FolderOpen } from '@phosphor-icons/react'
 import type { PaneRendererProps } from '../../../lib/module-registry'
 import { useI18nStore } from '../../../stores/useI18nStore'
 import { useTabStore } from '../../../stores/useTabStore'
@@ -24,6 +24,7 @@ import {
   createStorageFile,
   createStorageFolder,
   deleteStorageEntries,
+  downloadStorageFile,
   moveStorageEntry,
   renameStorageEntry,
 } from './storage-actions'
@@ -241,6 +242,16 @@ export function StoragePane({ pane }: PaneRendererProps) {
     if (singleSelected && !selectedNode?.isDir) handleOpen(singleSelected)
   }, [singleSelected, selectedNode, handleOpen])
 
+  const handleDownload = useCallback(async () => {
+    // Single-file only (T1c-2): a folder is not downloadable, so guard here as
+    // well as disabling the toolbar button. The byte read + OS download happen
+    // in downloadStorageFile; surface any failure in the inline banner.
+    if (!singleSelected || selectedNode?.isDir) return
+    setActionError(null)
+    const res = await downloadStorageFile(singleSelected)
+    if ('error' in res) setActionError(res.error)
+  }, [singleSelected, selectedNode])
+
   // --- Drag-and-drop move (T1b-6b) ---
 
   // Mirror RegionManager: a 5px activation distance so a stationary
@@ -277,6 +288,9 @@ export function StoragePane({ pane }: PaneRendererProps) {
   // Open is only valid for a single FILE selection (codex B3): a folder is not
   // openable, so the toolbar Open button disables when a folder is selected.
   const canOpen = singleSelected !== null && !selectedNode?.isDir
+  // Download is single-file only (T1c-2): a folder is not downloadable, same
+  // guard as Open.
+  const canDownload = canOpen
   const toolbarBusy = busy || loading
 
   return (
@@ -336,6 +350,16 @@ export function StoragePane({ pane }: PaneRendererProps) {
         >
           <FolderOpen size={14} />
           {t('editor.buffers.open')}
+        </button>
+        <button
+          data-testid="toolbar-download"
+          onClick={handleDownload}
+          disabled={!canDownload || toolbarBusy}
+          className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-text-secondary hover:bg-surface-hover disabled:opacity-50"
+          title={t('editor.buffers.download')}
+        >
+          <DownloadSimple size={14} />
+          {t('editor.buffers.download')}
         </button>
       </div>
 

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -8,6 +8,8 @@ import {
   renameStorageEntry,
   uploadFile,
   uploadFiles,
+  SOFT_MAX_UPLOAD_BYTES,
+  QUOTA_ERROR_MESSAGE,
 } from './storage-actions'
 import { InAppBackend } from '../../../lib/fs-backend-inapp'
 import { closeAllIDB } from '../../../lib/storage/idb'
@@ -784,12 +786,72 @@ describe('uploadFile / uploadFiles — OS-file ingest via atomic createUnique (T
     const bad = new File([new Uint8Array([2])], 'bad.bin')
     const summary = await uploadFiles('/buffer', [good, bad])
     expect(summary.uploaded).toEqual(['/buffer/ok.txt'])
-    expect(summary.failed).toEqual([{ name: 'bad.bin', reason: 'disk boom' }])
+    expect(summary.failed).toEqual([{ name: 'bad.bin', reason: 'disk boom', kind: 'other' }])
   })
 
   it('missing backend → uploadFile returns an error (no silent no-op)', async () => {
     backend = null
     const res = await uploadFile('/buffer', new File([new Uint8Array([1])], 'x.txt'))
     expect('error' in res && res.error).toBeTruthy()
+  })
+})
+
+// --- T1c-4: soft size cap + quota guard on upload (owns ALL upload guards) -----
+//
+// The cap is checked BEFORE any write (an over-cap file never reaches
+// `createUnique`); a quota throw at write time is caught via the shared
+// `isQuotaError` and surfaced (never silent). `uploadFiles` folds both into the
+// summary's `failed[]` with the right typed reason.
+
+/** A File whose `size` is forced past the cap WITHOUT allocating the bytes. */
+function oversizedFile(name: string, size: number): File {
+  const file = new File([new Uint8Array([0])], name)
+  Object.defineProperty(file, 'size', { value: size })
+  return file
+}
+
+describe('uploadFile / uploadFiles — size cap + quota guards (T1c-4)', () => {
+  it('T4-1: a file over the cap returns { tooLarge } and never calls createUnique', async () => {
+    const createUnique = vi.fn()
+    backend = { createUnique }
+    const file = oversizedFile('huge.bin', SOFT_MAX_UPLOAD_BYTES + 1)
+    const res = await uploadFile('/buffer', file)
+    expect(res).toEqual({ tooLarge: { name: 'huge.bin', cap: SOFT_MAX_UPLOAD_BYTES } })
+    expect(createUnique).not.toHaveBeenCalled()
+  })
+
+  it('a file exactly at the cap is accepted (boundary is strictly-greater)', async () => {
+    const createUnique = vi.fn(async () => '/buffer/edge.bin')
+    backend = { createUnique }
+    const res = await uploadFile('/buffer', oversizedFile('edge.bin', SOFT_MAX_UPLOAD_BYTES))
+    expect(res).toEqual({ path: '/buffer/edge.bin' })
+    expect(createUnique).toHaveBeenCalledTimes(1)
+  })
+
+  it('T4-2: a QuotaExceededError thrown by the write surfaces as { error } (not silent)', async () => {
+    const createUnique = vi.fn(async () => {
+      throw new DOMException('full', 'QuotaExceededError')
+    })
+    backend = { createUnique }
+    const res = await uploadFile('/buffer', new File([new Uint8Array([1])], 'x.txt'))
+    expect(res).toEqual({ error: QUOTA_ERROR_MESSAGE })
+  })
+
+  it('uploadFiles folds tooLarge + quota into failed[] with typed reasons', async () => {
+    const createUnique = vi.fn(async (dir: string, base: string, ext: string) => {
+      if (base === 'boom') throw new DOMException('full', 'QuotaExceededError')
+      return ext === '' ? `${dir}/${base}` : `${dir}/${base}.${ext}`
+    })
+    backend = { createUnique }
+    const summary = await uploadFiles('/buffer', [
+      new File([new Uint8Array([1])], 'ok.txt'),
+      oversizedFile('huge.bin', SOFT_MAX_UPLOAD_BYTES + 1),
+      new File([new Uint8Array([2])], 'boom.bin'),
+    ])
+    expect(summary.uploaded).toEqual(['/buffer/ok.txt'])
+    expect(summary.failed).toEqual([
+      { name: 'huge.bin', reason: 'too-large', kind: 'too-large', cap: SOFT_MAX_UPLOAD_BYTES },
+      { name: 'boom.bin', reason: QUOTA_ERROR_MESSAGE, kind: 'quota' },
+    ])
   })
 })

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -6,6 +6,8 @@ import {
   downloadStorageFile,
   moveStorageEntry,
   renameStorageEntry,
+  uploadFile,
+  uploadFiles,
 } from './storage-actions'
 import { InAppBackend } from '../../../lib/fs-backend-inapp'
 import { closeAllIDB } from '../../../lib/storage/idb'
@@ -709,5 +711,85 @@ describe('downloadStorageFile — byte-identical export via shared triggerDownlo
     const res = await downloadStorageFile('/buffer/nope.md')
     expect('error' in res && res.error).toBeTruthy()
     expect(triggerDownload).not.toHaveBeenCalled()
+  })
+})
+
+// --- T1c-1: upload (OS-file ingest) via the atomic createUnique(+content) ------
+//
+// Real InAppBackend so the byte write + atomic -N suffix collision are genuinely
+// exercised; uploadFiles partial-success is asserted with a stub backend so one
+// file can deterministically fail.
+
+describe('uploadFile / uploadFiles — OS-file ingest via atomic createUnique (T1c-1)', () => {
+  let real: InAppBackend
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    real = new InAppBackend()
+    backend = real
+  })
+
+  it('T1-1: stores a file with its bytes under a parsed (baseName, ext)', async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' })
+    const res = await uploadFile('/buffer', file)
+    expect(res).toEqual({ path: '/buffer/photo.png' })
+    expect(Array.from(await real.read('/buffer/photo.png'))).toEqual([1, 2, 3])
+  })
+
+  it('parses an ext-less name with NO trailing dot', async () => {
+    const file = new File([new Uint8Array([9])], 'README')
+    const res = await uploadFile('/buffer', file)
+    expect(res).toEqual({ path: '/buffer/README' })
+    expect(Array.from(await real.read('/buffer/README'))).toEqual([9])
+  })
+
+  it('splits on the LAST dot (archive.tar.gz → archive.tar + gz)', async () => {
+    const file = new File([new Uint8Array([4])], 'archive.tar.gz')
+    const res = await uploadFile('/buffer', file)
+    expect(res).toEqual({ path: '/buffer/archive.tar.gz' })
+  })
+
+  it('T1-3: a name collision reserves an atomic -N suffix, original intact', async () => {
+    await real.write('/buffer/report.pdf', new Uint8Array([0]))
+    const file = new File([new Uint8Array([7, 7])], 'report.pdf')
+    const res = await uploadFile('/buffer', file)
+    expect(res).toEqual({ path: '/buffer/report-1.pdf' })
+    expect(Array.from(await real.read('/buffer/report.pdf'))).toEqual([0])
+    expect(Array.from(await real.read('/buffer/report-1.pdf'))).toEqual([7, 7])
+  })
+
+  it('T1-5: uploadFiles returns every uploaded path in the summary (no failures)', async () => {
+    const files = [
+      new File([new Uint8Array([1])], 'a.txt'),
+      new File([new Uint8Array([2])], 'b.png'),
+      new File([new Uint8Array([3])], 'c.docx'),
+    ]
+    const summary = await uploadFiles('/buffer', files)
+    expect(summary.failed).toEqual([])
+    expect(summary.uploaded.sort()).toEqual(
+      ['/buffer/a.txt', '/buffer/b.png', '/buffer/c.docx'].sort(),
+    )
+  })
+
+  it('T1-6: a partial failure populates BOTH uploaded and failed (not just the first error)', async () => {
+    // Stub backend so a specific file name throws — one good, one bad.
+    backend = {
+      createUnique: vi.fn(async (dir: string, base: string, ext: string) => {
+        if (base === 'bad') throw new Error('disk boom')
+        return ext === '' ? `${dir}/${base}` : `${dir}/${base}.${ext}`
+      }),
+    }
+    const good = new File([new Uint8Array([1])], 'ok.txt')
+    const bad = new File([new Uint8Array([2])], 'bad.bin')
+    const summary = await uploadFiles('/buffer', [good, bad])
+    expect(summary.uploaded).toEqual(['/buffer/ok.txt'])
+    expect(summary.failed).toEqual([{ name: 'bad.bin', reason: 'disk boom' }])
+  })
+
+  it('missing backend → uploadFile returns an error (no silent no-op)', async () => {
+    backend = null
+    const res = await uploadFile('/buffer', new File([new Uint8Array([1])], 'x.txt'))
+    expect('error' in res && res.error).toBeTruthy()
   })
 })

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -3,11 +3,13 @@ import {
   createStorageFile,
   createStorageFolder,
   deleteStorageEntries,
+  downloadStorageFile,
   moveStorageEntry,
   renameStorageEntry,
 } from './storage-actions'
 import { InAppBackend } from '../../../lib/fs-backend-inapp'
 import { closeAllIDB } from '../../../lib/storage/idb'
+import { triggerDownload } from '../../../lib/download-file'
 import { useTabStore } from '../../../stores/useTabStore'
 import { useEditorStore } from '../../../stores/useEditorStore'
 import type { Tab } from '../../../types/tab'
@@ -24,6 +26,13 @@ vi.mock('../../../lib/fs-backend', () => ({
     typeof b?.createUnique === 'function',
   supportsMkdirUnique: (b: { mkdirUnique?: unknown } | undefined | null) =>
     typeof b?.mkdirUnique === 'function',
+}))
+
+// Stub the shared download util so the OS-file download is observable without
+// jsdom's unimplemented createObjectURL / navigation. We capture the Blob it is
+// handed and assert byte-identity against the stored content.
+vi.mock('../../../lib/download-file', () => ({
+  triggerDownload: vi.fn(),
 }))
 
 beforeEach(() => {
@@ -643,5 +652,62 @@ describe('createStorageFile — concurrent reservations get distinct keys (D2 / 
     const entries = await real.list('/buffer')
     const names = entries.map((e) => e.name).sort()
     expect(names).toEqual(['Untitled-1.md', 'Untitled.md'])
+  })
+})
+
+// --- T1c-2: download / export a stored file via the shared triggerDownload util
+//
+// Real InAppBackend (fake-indexeddb) so the download reads back the exact bytes
+// that were written; triggerDownload is mocked (module-level) so we can capture
+// the Blob and assert byte-identity + filename without jsdom's missing
+// createObjectURL.
+
+describe('downloadStorageFile — byte-identical export via shared triggerDownload (T1c-2)', () => {
+  let real: InAppBackend
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    real = new InAppBackend()
+    backend = real
+    ;(triggerDownload as unknown as ReturnType<typeof vi.fn>).mockReset()
+  })
+
+  it('T2-1: reads the stored bytes and hands triggerDownload a byte-identical Blob named by basename', async () => {
+    // Arbitrary binary content (incl. a zero byte) so any text round-trip bug
+    // would corrupt it.
+    const bytes = new Uint8Array([0x00, 0x01, 0x42, 0xff, 0x10, 0x7a])
+    await real.write('/buffer/sub/report.bin', bytes)
+
+    const res = await downloadStorageFile('/buffer/sub/report.bin')
+
+    expect(res).toEqual({ ok: true })
+    expect(triggerDownload).toHaveBeenCalledTimes(1)
+    const [blob, filename] = (triggerDownload as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(filename).toBe('report.bin')
+    expect(blob).toBeInstanceOf(Blob)
+    // Byte-identical: read the Blob back and compare every byte.
+    const roundTrip = new Uint8Array(await (blob as Blob).arrayBuffer())
+    expect(Array.from(roundTrip)).toEqual(Array.from(bytes))
+  })
+
+  it('T2-1b: missing backend returns an error and never calls triggerDownload', async () => {
+    backend = null
+    const res = await downloadStorageFile('/buffer/x.md')
+    expect('error' in res && res.error).toBeTruthy()
+    expect(triggerDownload).not.toHaveBeenCalled()
+  })
+
+  it('T2-1c: a directory path is a read failure → error, no download', async () => {
+    await real.write('/buffer/dir/f.md', new TextEncoder().encode('x'))
+    const res = await downloadStorageFile('/buffer/dir')
+    expect('error' in res && res.error).toBeTruthy()
+    expect(triggerDownload).not.toHaveBeenCalled()
+  })
+
+  it('T2-1d: a missing file is a read failure → error, no download', async () => {
+    const res = await downloadStorageFile('/buffer/nope.md')
+    expect('error' in res && res.error).toBeTruthy()
+    expect(triggerDownload).not.toHaveBeenCalled()
   })
 })

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -9,7 +9,6 @@ import {
   uploadFile,
   uploadFiles,
   SOFT_MAX_UPLOAD_BYTES,
-  QUOTA_ERROR_MESSAGE,
 } from './storage-actions'
 import { InAppBackend } from '../../../lib/fs-backend-inapp'
 import { closeAllIDB } from '../../../lib/storage/idb'
@@ -789,10 +788,93 @@ describe('uploadFile / uploadFiles — OS-file ingest via atomic createUnique (T
     expect(summary.failed).toEqual([{ name: 'bad.bin', reason: 'disk boom', kind: 'other' }])
   })
 
-  it('missing backend → uploadFile returns an error (no silent no-op)', async () => {
+  it('missing backend → uploadFile returns a typed error (no silent no-op)', async () => {
     backend = null
     const res = await uploadFile('/buffer', new File([new Uint8Array([1])], 'x.txt'))
-    expect('error' in res && res.error).toBeTruthy()
+    expect(res).toEqual({ kind: 'error', name: 'x.txt', message: expect.any(String) })
+  })
+})
+
+// --- codex R2 C1: file.name sanitisation (path-traversal / hidden-data guard)
+//
+// The browser File API hands back whatever the OS reported. A name carrying a
+// path separator or a traversal token must never form a key OUTSIDE the target
+// dir or one the tree cannot surface. uploadFile flattens to a basename, strips
+// control characters, and rejects empty / dot-only names — proven here against
+// a REAL InAppBackend so we can also assert NOTHING escaped the storage root.
+
+describe('uploadFile — file.name sanitisation (C1 security)', () => {
+  let real: InAppBackend
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    real = new InAppBackend()
+    backend = real
+  })
+
+  /** Every key written to the real backend must live under the storage root. */
+  async function assertAllKeysUnderRoot(): Promise<string[]> {
+    const db = await (real as unknown as { db(): Promise<{ getAllKeys(store: string): Promise<string[]> }> }).db()
+    const keys = await db.getAllKeys('files')
+    for (const k of keys) {
+      expect(k === '/buffer' || k.startsWith('/buffer/')).toBe(true)
+    }
+    return keys
+  }
+
+  it('flattens a name carrying a forward slash to its basename (no nested key)', async () => {
+    const res = await uploadFile('/buffer', new File([new Uint8Array([1])], 'sub/evil.txt'))
+    expect(res).toEqual({ path: '/buffer/evil.txt' })
+    // The flattened file is a DIRECT child of /buffer — no stray `sub` dir, and
+    // crucially no invisible `/buffer/sub/evil.txt` the tree could not show.
+    const keys = await assertAllKeysUnderRoot()
+    expect(keys).toEqual(['/buffer/evil.txt'])
+  })
+
+  it('flattens a name carrying a backslash to its basename', async () => {
+    const res = await uploadFile('/buffer', new File([new Uint8Array([2])], 'sub\\evil.txt'))
+    expect(res).toEqual({ path: '/buffer/evil.txt' })
+    await assertAllKeysUnderRoot()
+  })
+
+  it('a `../` traversal name flattens to its basename and never escapes the root', async () => {
+    const res = await uploadFile('/buffer', new File([new Uint8Array([3])], '../evil.txt'))
+    expect(res).toEqual({ path: '/buffer/evil.txt' })
+    const keys = await assertAllKeysUnderRoot()
+    expect(keys).toEqual(['/buffer/evil.txt'])
+  })
+
+  it('rejects a `..` traversal token (no write)', async () => {
+    const res = await uploadFile('/buffer', new File([new Uint8Array([4])], '..'))
+    expect(res).toMatchObject({ kind: 'error' })
+    expect(await assertAllKeysUnderRoot()).toEqual([])
+  })
+
+  it('rejects a lone `.` name (no write)', async () => {
+    const res = await uploadFile('/buffer', new File([new Uint8Array([5])], '.'))
+    expect(res).toMatchObject({ kind: 'error' })
+    expect(await assertAllKeysUnderRoot()).toEqual([])
+  })
+
+  it('rejects a pure-whitespace name (no write)', async () => {
+    const res = await uploadFile('/buffer', new File([new Uint8Array([6])], '   '))
+    expect(res).toMatchObject({ kind: 'error' })
+    expect(await assertAllKeysUnderRoot()).toEqual([])
+  })
+
+  it('strips control characters from the name before reserving the key', async () => {
+    const res = await uploadFile('/buffer', new File([new Uint8Array([7])], 'a\u0000\u0001b.txt'))
+    expect(res).toEqual({ path: '/buffer/ab.txt' })
+    await assertAllKeysUnderRoot()
+  })
+
+  it('does NOT silently rewrite a trailing-dot name (`foo.` stays `foo.`, not `foo`)', async () => {
+    const res = await uploadFile('/buffer', new File([new Uint8Array([8])], 'foo.'))
+    // The trailing dot is preserved as part of the basename — never collapsed to
+    // `/buffer/foo` behind the user's back.
+    expect(res).toEqual({ path: '/buffer/foo.' })
+    expect(await assertAllKeysUnderRoot()).toEqual(['/buffer/foo.'])
   })
 })
 
@@ -811,12 +893,12 @@ function oversizedFile(name: string, size: number): File {
 }
 
 describe('uploadFile / uploadFiles — size cap + quota guards (T1c-4)', () => {
-  it('T4-1: a file over the cap returns { tooLarge } and never calls createUnique', async () => {
+  it('T4-1: a file over the cap returns a typed too-large result and never calls createUnique', async () => {
     const createUnique = vi.fn()
     backend = { createUnique }
     const file = oversizedFile('huge.bin', SOFT_MAX_UPLOAD_BYTES + 1)
     const res = await uploadFile('/buffer', file)
-    expect(res).toEqual({ tooLarge: { name: 'huge.bin', cap: SOFT_MAX_UPLOAD_BYTES } })
+    expect(res).toEqual({ kind: 'too-large', name: 'huge.bin', cap: SOFT_MAX_UPLOAD_BYTES })
     expect(createUnique).not.toHaveBeenCalled()
   })
 
@@ -828,13 +910,13 @@ describe('uploadFile / uploadFiles — size cap + quota guards (T1c-4)', () => {
     expect(createUnique).toHaveBeenCalledTimes(1)
   })
 
-  it('T4-2: a QuotaExceededError thrown by the write surfaces as { error } (not silent)', async () => {
+  it('T4-2: a QuotaExceededError thrown by the write surfaces as a typed quota result (not silent)', async () => {
     const createUnique = vi.fn(async () => {
       throw new DOMException('full', 'QuotaExceededError')
     })
     backend = { createUnique }
     const res = await uploadFile('/buffer', new File([new Uint8Array([1])], 'x.txt'))
-    expect(res).toEqual({ error: QUOTA_ERROR_MESSAGE })
+    expect(res).toEqual({ kind: 'quota', name: 'x.txt' })
   })
 
   it('uploadFiles folds tooLarge + quota into failed[] with typed reasons', async () => {
@@ -851,7 +933,7 @@ describe('uploadFile / uploadFiles — size cap + quota guards (T1c-4)', () => {
     expect(summary.uploaded).toEqual(['/buffer/ok.txt'])
     expect(summary.failed).toEqual([
       { name: 'huge.bin', reason: 'too-large', kind: 'too-large', cap: SOFT_MAX_UPLOAD_BYTES },
-      { name: 'boom.bin', reason: QUOTA_ERROR_MESSAGE, kind: 'quota' },
+      { name: 'boom.bin', reason: 'quota', kind: 'quota' },
     ])
   })
 })

--- a/spa/src/components/editor/storage/storage-actions.test.ts
+++ b/spa/src/components/editor/storage/storage-actions.test.ts
@@ -851,6 +851,15 @@ describe('uploadFile — file.name sanitisation (C1 security)', () => {
     expect(await assertAllKeysUnderRoot()).toEqual([])
   })
 
+  it('rejects an un-normalized traversal in targetDir before any write (C1b defense-in-depth)', async () => {
+    // `isUnderRoot` is a prefix check and `join` keeps `..` literal, so a
+    // targetDir carrying a traversal token must be rejected by the explicit
+    // segment guard, not slip a `/buffer/../evil.txt` candidate past the root.
+    const res = await uploadFile('/buffer/..', new File([new Uint8Array([9])], 'evil.txt'))
+    expect(res).toMatchObject({ kind: 'error' })
+    expect(await assertAllKeysUnderRoot()).toEqual([])
+  })
+
   it('rejects a lone `.` name (no write)', async () => {
     const res = await uploadFile('/buffer', new File([new Uint8Array([5])], '.'))
     expect(res).toMatchObject({ kind: 'error' })

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -18,6 +18,7 @@
  */
 import { getFsBackend, supportsMkdirUnique } from '../../../lib/fs-backend'
 import { createUniqueInAppFile } from '../../../lib/inapp-namer'
+import { triggerDownload } from '../../../lib/download-file'
 import { bufferKey } from '../../../lib/editor-buffer-key'
 import { scanPaneTree } from '../../../lib/pane-tree'
 import { isFilePaneContent } from '../../../lib/pane-utils'
@@ -119,6 +120,32 @@ export async function createStorageFolder(
   try {
     const path = await backend.mkdirUnique(targetDir)
     return { path }
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Download (export) a single stored file to the OS via the shared
+ * `triggerDownload` util (Phase 1c T1c-2). Reads the exact bytes from the
+ * backend and hands them off as a `Blob` named by the file's basename, so the
+ * saved file is byte-identical to what is stored. A missing backend, a
+ * directory path, or a missing file all surface as `{ error }` (never a silent
+ * no-op) and never reach `triggerDownload`. Folder downloads are out of scope in
+ * 1c — the caller disables the button for a folder selection.
+ */
+export async function downloadStorageFile(
+  path: string,
+): Promise<{ ok: true } | { error: string }> {
+  const backend = getFsBackend({ type: 'inapp' })
+  if (!backend) return { error: 'InApp backend unavailable' }
+  try {
+    const bytes = await backend.read(path)
+    // Re-wrap into a fresh ArrayBuffer-backed view so the Blob part is a plain
+    // `Uint8Array<ArrayBuffer>` (the backend's `Uint8Array<ArrayBufferLike>`
+    // does not satisfy `BlobPart` under strict TS) — mirrors Image/PdfPreview.
+    triggerDownload(new Blob([new Uint8Array(bytes)]), basename(path))
+    return { ok: true }
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) }
   }

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -260,9 +260,14 @@ export async function uploadFile(targetDir: string, file: File): Promise<UploadR
   const { baseName, ext } = splitFileName(safeName)
   // Defense-in-depth (C1): every `createUnique` candidate lives directly under
   // `targetDir`, so verifying the un-suffixed path stays under the storage root
-  // catches a non-root `targetDir` before any byte is read or written.
+  // catches a non-root `targetDir` before any byte is read or written. `join`
+  // keeps `..`/`.` as literal segments and `isUnderRoot` is a prefix check, so a
+  // `targetDir` carrying an un-normalized traversal token (e.g. `/buffer/..`)
+  // could otherwise slip a `/buffer/../x` candidate past the root guard — reject
+  // any traversal segment explicitly (codex 1c fix-wave confirm, C1b).
   const candidate = join(targetDir, ext === '' ? baseName : `${baseName}.${ext}`)
-  if (!isUnderRoot(candidate)) {
+  const hasTraversal = candidate.split('/').some((seg) => seg === '..' || seg === '.')
+  if (hasTraversal || !isUnderRoot(candidate)) {
     return { kind: 'error', name: file.name, message: `Invalid file name: ${file.name}` }
   }
   try {

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -26,7 +26,7 @@ import { isFilePaneContent } from '../../../lib/pane-utils'
 import { useEditorStore } from '../../../stores/useEditorStore'
 import { useTabStore } from '../../../stores/useTabStore'
 import { createMetadata } from '../../../lib/editor-language'
-import { STORAGE_ROOT, basename, join, parentOf } from '../../../lib/storage-paths'
+import { STORAGE_ROOT, basename, join, parentOf, isUnderRoot } from '../../../lib/storage-paths'
 import type { FileSource } from '../../../types/fs'
 import type { Pane, Tab } from '../../../types/tab'
 
@@ -158,11 +158,43 @@ export async function downloadStorageFile(
  * everything after the LAST dot; an ext-less name (`README`) and a dotfile
  * (`.env`, a leading dot at index 0) both yield `ext = ''` so the whole name is
  * preserved. `archive.tar.gz` → (`archive.tar`, `gz`).
+ *
+ * A name whose LAST dot is the final character (`foo.`) keeps the trailing dot
+ * as part of the basename (`{ baseName: 'foo.', ext: '' }`) rather than silently
+ * collapsing to `foo` (C1) — the stored name must never be rewritten to a
+ * different one behind the user's back.
  */
 function splitFileName(fileName: string): { baseName: string; ext: string } {
   const dot = fileName.lastIndexOf('.')
-  if (dot <= 0) return { baseName: fileName, ext: '' }
+  if (dot <= 0 || dot === fileName.length - 1) return { baseName: fileName, ext: '' }
   return { baseName: fileName.slice(0, dot), ext: fileName.slice(dot + 1) }
+}
+
+/**
+ * Sanitise an OS-provided `file.name` into a safe single-segment basename, or
+ * `null` when the name cannot yield a valid entry (C1 — path-traversal / hidden
+ * data). The browser File API hands back whatever the OS reported, which for a
+ * dropped folder or a crafted archive entry can contain path separators
+ * (`sub/evil.txt`, `..\\x`), a traversal token (`..`), control characters, or be
+ * blank — any of which, fed straight into `createUnique` + `join`, could write
+ * OUTSIDE the selected dir or to a key the tree never surfaces.
+ *
+ * Steps: take the BASENAME only (drop every `/`- or `\\`-delimited directory
+ * component, so an OS folder structure is flattened into the target dir rather
+ * than recreated), strip control characters, trim surrounding whitespace, then
+ * reject an empty or dot-only result (`''`, `.`, `..`, `...`).
+ */
+function sanitizeUploadName(rawName: string): string | null {
+  // Basename only: a folder structure in the dropped name is flattened, and a
+  // `../` traversal loses its separators so it can never escape `targetDir`.
+  const base = rawName.split(/[/\\]/).pop() ?? ''
+  // Drop NUL + other C0 control characters that have no place in a file name.
+  // eslint-disable-next-line no-control-regex -- intentional C0 control-char strip
+  const stripped = base.replace(/[\u0000-\u001f]/g, '').trim()
+  // Empty (incl. a pure-whitespace or pure-control name) or a dot-only token
+  // (`.` / `..` / `...`) is not a usable file name.
+  if (stripped === '' || /^\.+$/.test(stripped)) return null
+  return stripped
 }
 
 /**
@@ -175,53 +207,73 @@ function splitFileName(fileName: string): { baseName: string; ext: string } {
 export const SOFT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024
 
 /**
- * Sentinel message returned by `uploadFile` when a write fails because the
- * backing store is full (`isQuotaError`). `uploadFiles` matches on it to tag the
- * failure `kind: 'quota'` so the UI can show a distinct "storage full" banner
- * instead of a generic error — keeping `uploadFile`'s public result the plain
- * `{ path } | { error } | { tooLarge }` union (the quota case is an `{ error }`).
+ * Outcome of a single `uploadFile`, a TYPED discriminated union (codex R2 C4):
+ * the failure variants carry their own `kind` so `uploadFiles` and the banner
+ * branch on a tag rather than string-matching a sentinel message. A `too-large`
+ * / `quota` failure already names the (sanitised) file; a generic `error`
+ * carries its raw message.
  */
-export const QUOTA_ERROR_MESSAGE = 'Storage quota exceeded'
-
 export type UploadResult =
   | { path: string }
-  | { error: string }
-  | { tooLarge: { name: string; cap: number } }
+  | { kind: 'too-large'; name: string; cap: number }
+  | { kind: 'quota'; name: string }
+  | { kind: 'error'; name: string; message: string }
 
 /**
  * Ingest a single OS file into `targetDir` (Phase 1c; T1c-1 happy path widened
  * by T1c-4, which owns ALL upload guards). Order of guards:
- *   1. Missing/incapable backend → `{ error }` (never a silent no-op).
- *   2. **Size cap before any write** (decision 5): `file.size > SOFT_MAX_UPLOAD_BYTES`
- *      → `{ tooLarge: { name, cap } }`. `createUnique` is NOT called and the bytes
- *      are NOT read — the over-cap file never touches the store.
- *   3. Otherwise parse `(baseName, ext)`, read bytes, and reserve a unique key
- *      via the atomic `createUnique(dir, base, ext, bytes)` — unique-name
- *      reservation AND byte write on one `add` (no overwrite race; `-N` suffix on
- *      collision, decision 4). A thrown quota exhaustion is caught via the shared
- *      `isQuotaError` and surfaced as `{ error: QUOTA_ERROR_MESSAGE }` (never
- *      silent); any other throw surfaces its message. Any file type is accepted.
+ *   1. Missing/incapable backend → `{ kind: 'error' }` (never a silent no-op).
+ *   2. **Sanitise `file.name`** (C1): flatten to a basename, strip control
+ *      characters, reject empty / dot-only / traversal names — so an OS-provided
+ *      name carrying `/`, `\\`, or `..` can never write outside `targetDir` or to
+ *      an invisible key. A rejected name → `{ kind: 'error' }`.
+ *   3. **Size cap before any write** (decision 5): `file.size > SOFT_MAX_UPLOAD_BYTES`
+ *      → `{ kind: 'too-large' }`. `createUnique` is NOT called and the bytes are
+ *      NOT read — the over-cap file never touches the store.
+ *   4. Otherwise parse `(baseName, ext)`, defensively re-check the candidate path
+ *      stays under the storage root, read bytes, and reserve a unique key via the
+ *      atomic `createUnique(dir, base, ext, bytes)` — unique-name reservation AND
+ *      byte write on one `add` (no overwrite race; `-N` suffix on collision,
+ *      decision 4). A thrown quota exhaustion is caught via the shared
+ *      `isQuotaError` and surfaced as `{ kind: 'quota' }` (never silent); any
+ *      other throw surfaces as `{ kind: 'error' }`. Any file type is accepted.
  */
 export async function uploadFile(targetDir: string, file: File): Promise<UploadResult> {
   const backend = getFsBackend({ type: 'inapp' })
   // Narrow to the unique-create capability (codex H1) — it lives on the optional
   // `SupportsUniqueCreate`, not the base `FsBackend`.
-  if (!supportsCreateUnique(backend)) return { error: 'InApp backend unavailable' }
+  if (!supportsCreateUnique(backend)) {
+    return { kind: 'error', name: file.name, message: 'InApp backend unavailable' }
+  }
+  // C1 (security / data-loss): sanitise the OS-provided name BEFORE it forms a
+  // key — a name with path separators or a traversal token must never escape the
+  // selected dir or land on a key the tree cannot show.
+  const safeName = sanitizeUploadName(file.name)
+  if (safeName == null) {
+    return { kind: 'error', name: file.name, message: `Invalid file name: ${file.name}` }
+  }
   // Size cap is checked BEFORE the read+write (decision 5): an over-cap file is
   // rejected without ever reading its bytes or reserving a name.
   if (file.size > SOFT_MAX_UPLOAD_BYTES) {
-    return { tooLarge: { name: file.name, cap: SOFT_MAX_UPLOAD_BYTES } }
+    return { kind: 'too-large', name: safeName, cap: SOFT_MAX_UPLOAD_BYTES }
+  }
+  const { baseName, ext } = splitFileName(safeName)
+  // Defense-in-depth (C1): every `createUnique` candidate lives directly under
+  // `targetDir`, so verifying the un-suffixed path stays under the storage root
+  // catches a non-root `targetDir` before any byte is read or written.
+  const candidate = join(targetDir, ext === '' ? baseName : `${baseName}.${ext}`)
+  if (!isUnderRoot(candidate)) {
+    return { kind: 'error', name: file.name, message: `Invalid file name: ${file.name}` }
   }
   try {
-    const { baseName, ext } = splitFileName(file.name)
     const bytes = new Uint8Array(await file.arrayBuffer())
     const path = await backend.createUnique(targetDir, baseName, ext, bytes)
     return { path }
   } catch (err) {
-    // A full store throws a quota DOMException at write time; surface it as a
-    // distinct (sentinel) error so the caller can show a "storage full" banner.
-    if (isQuotaError(err)) return { error: QUOTA_ERROR_MESSAGE }
-    return { error: err instanceof Error ? err.message : String(err) }
+    // A full store throws a quota DOMException at write time; tag it `quota` so
+    // the caller can show a distinct "storage full" banner.
+    if (isQuotaError(err)) return { kind: 'quota', name: safeName }
+    return { kind: 'error', name: safeName, message: err instanceof Error ? err.message : String(err) }
   }
 }
 
@@ -256,13 +308,14 @@ export async function uploadFiles(targetDir: string, files: File[]): Promise<Upl
     const res = await uploadFile(targetDir, file)
     if ('path' in res) {
       uploaded.push(res.path)
-    } else if ('tooLarge' in res) {
-      failed.push({ name: res.tooLarge.name, reason: 'too-large', kind: 'too-large', cap: res.tooLarge.cap })
+    } else if (res.kind === 'too-large') {
+      // Read the typed kind straight off the result (codex R2 C4) — no string
+      // sentinel round-trip.
+      failed.push({ name: res.name, reason: 'too-large', kind: 'too-large', cap: res.cap })
+    } else if (res.kind === 'quota') {
+      failed.push({ name: res.name, reason: 'quota', kind: 'quota' })
     } else {
-      // `{ error }`: the quota sentinel becomes `kind: 'quota'`, everything else
-      // is `kind: 'other'` (a generic failure carrying its raw message).
-      const kind: UploadFailureKind = res.error === QUOTA_ERROR_MESSAGE ? 'quota' : 'other'
-      failed.push({ name: file.name, reason: res.error, kind })
+      failed.push({ name: res.name, reason: res.message, kind: 'other' })
     }
   }
   return { uploaded, failed }

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -19,6 +19,7 @@
 import { getFsBackend, supportsCreateUnique, supportsMkdirUnique } from '../../../lib/fs-backend'
 import { createUniqueInAppFile } from '../../../lib/inapp-namer'
 import { triggerDownload } from '../../../lib/download-file'
+import { isQuotaError } from '../../../lib/quota'
 import { bufferKey } from '../../../lib/editor-buffer-key'
 import { scanPaneTree } from '../../../lib/pane-tree'
 import { isFilePaneContent } from '../../../lib/pane-utils'
@@ -165,52 +166,104 @@ function splitFileName(fileName: string): { baseName: string; ext: string } {
 }
 
 /**
- * Ingest a single OS file into `targetDir` (Phase 1c T1c-1, happy path). Parses
- * the name into `(baseName, ext)`, reads the bytes, and reserves a unique key
- * via the atomic `createUnique(dir, base, ext, bytes)` — so the unique-name
- * reservation AND the byte write land on one `add` (no overwrite race; a
- * collision increments the `-N` suffix, decision 4). Any file type is accepted;
- * there is NO size cap or quota handling here — those land in T1c-4, which
- * widens this result shape. A missing/incapable backend or a read/write failure
- * surfaces as `{ error }` (never a silent no-op).
+ * Soft upper bound on a single uploaded file (~25 MB, T1c-4 decision 5). A file
+ * over the cap is rejected BEFORE any write (no `createUnique`, no byte read into
+ * IDB), surfacing as a `tooLarge` result rather than letting a large blob bloat
+ * the In-App store. The cap is "soft": it is enforced per-file at ingest, not a
+ * hard quota — the genuine IDB quota is caught separately at write time.
  */
-export async function uploadFile(
-  targetDir: string,
-  file: File,
-): Promise<{ path: string } | { error: string }> {
+export const SOFT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+
+/**
+ * Sentinel message returned by `uploadFile` when a write fails because the
+ * backing store is full (`isQuotaError`). `uploadFiles` matches on it to tag the
+ * failure `kind: 'quota'` so the UI can show a distinct "storage full" banner
+ * instead of a generic error — keeping `uploadFile`'s public result the plain
+ * `{ path } | { error } | { tooLarge }` union (the quota case is an `{ error }`).
+ */
+export const QUOTA_ERROR_MESSAGE = 'Storage quota exceeded'
+
+export type UploadResult =
+  | { path: string }
+  | { error: string }
+  | { tooLarge: { name: string; cap: number } }
+
+/**
+ * Ingest a single OS file into `targetDir` (Phase 1c; T1c-1 happy path widened
+ * by T1c-4, which owns ALL upload guards). Order of guards:
+ *   1. Missing/incapable backend → `{ error }` (never a silent no-op).
+ *   2. **Size cap before any write** (decision 5): `file.size > SOFT_MAX_UPLOAD_BYTES`
+ *      → `{ tooLarge: { name, cap } }`. `createUnique` is NOT called and the bytes
+ *      are NOT read — the over-cap file never touches the store.
+ *   3. Otherwise parse `(baseName, ext)`, read bytes, and reserve a unique key
+ *      via the atomic `createUnique(dir, base, ext, bytes)` — unique-name
+ *      reservation AND byte write on one `add` (no overwrite race; `-N` suffix on
+ *      collision, decision 4). A thrown quota exhaustion is caught via the shared
+ *      `isQuotaError` and surfaced as `{ error: QUOTA_ERROR_MESSAGE }` (never
+ *      silent); any other throw surfaces its message. Any file type is accepted.
+ */
+export async function uploadFile(targetDir: string, file: File): Promise<UploadResult> {
   const backend = getFsBackend({ type: 'inapp' })
   // Narrow to the unique-create capability (codex H1) — it lives on the optional
   // `SupportsUniqueCreate`, not the base `FsBackend`.
   if (!supportsCreateUnique(backend)) return { error: 'InApp backend unavailable' }
+  // Size cap is checked BEFORE the read+write (decision 5): an over-cap file is
+  // rejected without ever reading its bytes or reserving a name.
+  if (file.size > SOFT_MAX_UPLOAD_BYTES) {
+    return { tooLarge: { name: file.name, cap: SOFT_MAX_UPLOAD_BYTES } }
+  }
   try {
     const { baseName, ext } = splitFileName(file.name)
     const bytes = new Uint8Array(await file.arrayBuffer())
     const path = await backend.createUnique(targetDir, baseName, ext, bytes)
     return { path }
   } catch (err) {
+    // A full store throws a quota DOMException at write time; surface it as a
+    // distinct (sentinel) error so the caller can show a "storage full" banner.
+    if (isQuotaError(err)) return { error: QUOTA_ERROR_MESSAGE }
     return { error: err instanceof Error ? err.message : String(err) }
   }
 }
 
+/** Why a single upload failed — lets the UI pick the right banner (T1c-4). */
+export type UploadFailureKind = 'too-large' | 'quota' | 'other'
+
+export interface UploadFailure {
+  name: string
+  reason: string
+  kind: UploadFailureKind
+  /** The soft cap in bytes — present only for `kind: 'too-large'`. */
+  cap?: number
+}
+
 export interface UploadSummary {
   uploaded: string[]
-  failed: { name: string; reason: string }[]
+  failed: UploadFailure[]
 }
 
 /**
  * Ingest multiple OS files into `targetDir`, reporting PARTIAL success (codex R1
  * F5): every uploaded path lands in `uploaded`, and each failure lands in
- * `failed` with the file name + reason — the caller surfaces both in one banner
+ * `failed` with a TYPED reason (T1c-4) so the caller can render a too-large
+ * warning, a quota error, or a generic partial message — all in one banner
  * rather than aborting on the first error. Files are processed sequentially so
  * the atomic `-N` suffixing stays deterministic for same-named drops.
  */
 export async function uploadFiles(targetDir: string, files: File[]): Promise<UploadSummary> {
   const uploaded: string[] = []
-  const failed: { name: string; reason: string }[] = []
+  const failed: UploadFailure[] = []
   for (const file of files) {
     const res = await uploadFile(targetDir, file)
-    if ('path' in res) uploaded.push(res.path)
-    else failed.push({ name: file.name, reason: res.error })
+    if ('path' in res) {
+      uploaded.push(res.path)
+    } else if ('tooLarge' in res) {
+      failed.push({ name: res.tooLarge.name, reason: 'too-large', kind: 'too-large', cap: res.tooLarge.cap })
+    } else {
+      // `{ error }`: the quota sentinel becomes `kind: 'quota'`, everything else
+      // is `kind: 'other'` (a generic failure carrying its raw message).
+      const kind: UploadFailureKind = res.error === QUOTA_ERROR_MESSAGE ? 'quota' : 'other'
+      failed.push({ name: file.name, reason: res.error, kind })
+    }
   }
   return { uploaded, failed }
 }

--- a/spa/src/components/editor/storage/storage-actions.ts
+++ b/spa/src/components/editor/storage/storage-actions.ts
@@ -16,7 +16,7 @@
  * The recursive move data layer (`moveStorageEntry`, T1b-6a) reuses that same
  * single-rename + `remapPanesUnder` path; the drag-and-drop wiring is T1b-6b.
  */
-import { getFsBackend, supportsMkdirUnique } from '../../../lib/fs-backend'
+import { getFsBackend, supportsCreateUnique, supportsMkdirUnique } from '../../../lib/fs-backend'
 import { createUniqueInAppFile } from '../../../lib/inapp-namer'
 import { triggerDownload } from '../../../lib/download-file'
 import { bufferKey } from '../../../lib/editor-buffer-key'
@@ -149,6 +149,70 @@ export async function downloadStorageFile(
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) }
   }
+}
+
+/**
+ * Split a file's basename into `(baseName, ext)` for `createUnique`, matching
+ * the path-forming rule there (`ext === ''` → no trailing dot). The extension is
+ * everything after the LAST dot; an ext-less name (`README`) and a dotfile
+ * (`.env`, a leading dot at index 0) both yield `ext = ''` so the whole name is
+ * preserved. `archive.tar.gz` → (`archive.tar`, `gz`).
+ */
+function splitFileName(fileName: string): { baseName: string; ext: string } {
+  const dot = fileName.lastIndexOf('.')
+  if (dot <= 0) return { baseName: fileName, ext: '' }
+  return { baseName: fileName.slice(0, dot), ext: fileName.slice(dot + 1) }
+}
+
+/**
+ * Ingest a single OS file into `targetDir` (Phase 1c T1c-1, happy path). Parses
+ * the name into `(baseName, ext)`, reads the bytes, and reserves a unique key
+ * via the atomic `createUnique(dir, base, ext, bytes)` — so the unique-name
+ * reservation AND the byte write land on one `add` (no overwrite race; a
+ * collision increments the `-N` suffix, decision 4). Any file type is accepted;
+ * there is NO size cap or quota handling here — those land in T1c-4, which
+ * widens this result shape. A missing/incapable backend or a read/write failure
+ * surfaces as `{ error }` (never a silent no-op).
+ */
+export async function uploadFile(
+  targetDir: string,
+  file: File,
+): Promise<{ path: string } | { error: string }> {
+  const backend = getFsBackend({ type: 'inapp' })
+  // Narrow to the unique-create capability (codex H1) — it lives on the optional
+  // `SupportsUniqueCreate`, not the base `FsBackend`.
+  if (!supportsCreateUnique(backend)) return { error: 'InApp backend unavailable' }
+  try {
+    const { baseName, ext } = splitFileName(file.name)
+    const bytes = new Uint8Array(await file.arrayBuffer())
+    const path = await backend.createUnique(targetDir, baseName, ext, bytes)
+    return { path }
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+export interface UploadSummary {
+  uploaded: string[]
+  failed: { name: string; reason: string }[]
+}
+
+/**
+ * Ingest multiple OS files into `targetDir`, reporting PARTIAL success (codex R1
+ * F5): every uploaded path lands in `uploaded`, and each failure lands in
+ * `failed` with the file name + reason — the caller surfaces both in one banner
+ * rather than aborting on the first error. Files are processed sequentially so
+ * the atomic `-N` suffixing stays deterministic for same-named drops.
+ */
+export async function uploadFiles(targetDir: string, files: File[]): Promise<UploadSummary> {
+  const uploaded: string[] = []
+  const failed: { name: string; reason: string }[] = []
+  for (const file of files) {
+    const res = await uploadFile(targetDir, file)
+    if ('path' in res) uploaded.push(res.path)
+    else failed.push({ name: file.name, reason: res.error })
+  }
+  return { uploaded, failed }
 }
 
 export type RenameOutcome =

--- a/spa/src/components/settings/SyncSection.test.tsx
+++ b/spa/src/components/settings/SyncSection.test.tsx
@@ -223,6 +223,37 @@ describe('SyncSection subsection routing', () => {
     fireEvent.click(screen.getByRole('button', { name: /history/i }))
     expect(fn).toHaveBeenCalledWith('history')
   })
+
+  // Regression (Phase 1c T2-3): Export All still downloads through the shared
+  // `triggerDownload` util after it was lifted out of this component into
+  // `lib/download-file.ts`. jsdom implements neither createObjectURL nor
+  // revokeObjectURL, so we stub them and assert the anchor-download dance fires
+  // unchanged (object URL → <a download> → click → revoke).
+  it('Export All triggers a download via the shared triggerDownload util', () => {
+    useSyncStore.getState().setActiveProvider('file')
+
+    const createObjectURL = vi.fn(() => 'blob:sync-export')
+    const revokeObjectURL = vi.fn()
+    ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = createObjectURL
+    ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = revokeObjectURL
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {})
+    const createElementSpy = vi.spyOn(document, 'createElement')
+
+    render(<SyncSection />)
+    fireEvent.click(screen.getByRole('button', { name: /Export All|匯出全部/i }))
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    const anchor = createElementSpy.mock.results.find(
+      (r) => r.value instanceof HTMLAnchorElement,
+    )?.value as HTMLAnchorElement
+    expect(anchor).toBeInstanceOf(HTMLAnchorElement)
+    // Sync export keeps its `.purdex-sync` filename suffix.
+    expect(anchor.download).toMatch(/\.purdex-sync$/)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:sync-export')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/spa/src/components/settings/SyncSection.tsx
+++ b/spa/src/components/settings/SyncSection.tsx
@@ -22,6 +22,7 @@ import { useI18nStore } from '../../stores/useI18nStore'
 import { pluralKey } from '../../lib/plural'
 import { useSettingsRoute } from '../SettingsPage'
 import { SnapshotHistoryPage } from '../../features/settings/sections/sync-history/SnapshotHistoryPage'
+import { triggerDownload } from '../../lib/download-file'
 
 type ProviderId = 'off' | 'daemon' | 'file'
 
@@ -38,15 +39,6 @@ function formatRelativeTime(t: ReturnType<typeof useI18nStore.getState>['t'], ms
   if (diffHr < 24) return t('settings.sync.time.hoursAgo', { n: diffHr })
   const diffDay = Math.floor(diffHr / 24)
   return t('settings.sync.time.daysAgo', { n: diffDay })
-}
-
-function triggerDownload(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
 }
 
 export function SyncSection() {

--- a/spa/src/lib/download-file.test.ts
+++ b/spa/src/lib/download-file.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { triggerDownload } from './download-file'
+
+// jsdom implements neither URL.createObjectURL nor revokeObjectURL, so we stub
+// them and assert the full anchor-download dance: create an object URL for the
+// blob, build an <a download> pointing at it, click it, then revoke the URL.
+describe('triggerDownload — anchor object-URL download (lifted from SyncSection)', () => {
+  let createObjectURL: ReturnType<typeof vi.fn>
+  let revokeObjectURL: ReturnType<typeof vi.fn>
+  let clickSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    createObjectURL = vi.fn(() => 'blob:mock-url')
+    revokeObjectURL = vi.fn()
+    // URL is a global; stub the two static methods jsdom lacks.
+    ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = createObjectURL
+    ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = revokeObjectURL
+    // Spy on anchor click so the download never actually navigates in jsdom.
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates an object URL, builds an <a download>, clicks it, then revokes', () => {
+    const createElementSpy = vi.spyOn(document, 'createElement')
+    const blob = new Blob(['hello'], { type: 'text/plain' })
+
+    triggerDownload(blob, 'report.txt')
+
+    // Object URL created for exactly this blob.
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(createObjectURL).toHaveBeenCalledWith(blob)
+
+    // An anchor was created carrying the URL + download filename, then clicked.
+    const anchor = createElementSpy.mock.results.find(
+      (r) => r.value instanceof HTMLAnchorElement,
+    )?.value as HTMLAnchorElement
+    expect(anchor).toBeInstanceOf(HTMLAnchorElement)
+    expect(anchor.href).toContain('blob:mock-url')
+    expect(anchor.download).toBe('report.txt')
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+
+    // The URL is revoked after the click (no leak).
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+})

--- a/spa/src/lib/download-file.ts
+++ b/spa/src/lib/download-file.ts
@@ -1,0 +1,18 @@
+/**
+ * download-file — the single source of truth for triggering a browser "save as"
+ * download from an in-memory `Blob`.
+ *
+ * Lifted verbatim out of `settings/SyncSection.tsx` (Phase 1c decision 6) so the
+ * sync export, the Storage download/export action, and the binary
+ * open-disposition all share one implementation. The anchor + object-URL dance
+ * works inside the Electron WebContents too, so no daemon/IPC save dialog is
+ * needed.
+ */
+export function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/spa/src/lib/file-extension-roles.test.ts
+++ b/spa/src/lib/file-extension-roles.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import {
+  IMAGE_EXTS,
+  PDF_EXTS,
+  DOWNLOAD_EXTS,
+  roleForExtension,
+} from './file-extension-roles'
+
+describe('roleForExtension', () => {
+  it('classifies image extensions as image', () => {
+    for (const ext of ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'ico']) {
+      expect(roleForExtension(ext)).toBe('image')
+    }
+  })
+
+  it('classifies pdf as pdf', () => {
+    expect(roleForExtension('pdf')).toBe('pdf')
+  })
+
+  it('classifies office/archive/binary extensions as download', () => {
+    for (const ext of [
+      'doc',
+      'docx',
+      'xls',
+      'xlsx',
+      'ppt',
+      'pptx',
+      'zip',
+      'rar',
+      '7z',
+      'tar',
+      'gz',
+      'bin',
+      'exe',
+      'dmg',
+    ]) {
+      expect(roleForExtension(ext)).toBe('download')
+    }
+  })
+
+  it('classifies text/code/unknown extensions as text', () => {
+    for (const ext of ['md', 'ts', 'txt', 'js', 'json', 'css', 'html', 'go', 'py', '']) {
+      expect(roleForExtension(ext)).toBe('text')
+    }
+    // unknown extension falls through to text
+    expect(roleForExtension('xyzzy')).toBe('text')
+  })
+
+  it('is case-insensitive', () => {
+    expect(roleForExtension('PNG')).toBe('image')
+    expect(roleForExtension('PDF')).toBe('pdf')
+    expect(roleForExtension('DOCX')).toBe('download')
+    expect(roleForExtension('MD')).toBe('text')
+  })
+
+  it('DOWNLOAD_EXTS does not include any text/code extensions', () => {
+    for (const ext of [
+      'md',
+      'ts',
+      'tsx',
+      'js',
+      'jsx',
+      'txt',
+      'json',
+      'css',
+      'scss',
+      'html',
+      'xml',
+      'yml',
+      'yaml',
+      'go',
+      'py',
+      'rs',
+      'sh',
+      'log',
+      'csv',
+    ]) {
+      expect(DOWNLOAD_EXTS.has(ext)).toBe(false)
+    }
+  })
+
+  it('the three sets are mutually exclusive', () => {
+    for (const ext of IMAGE_EXTS) {
+      expect(PDF_EXTS.has(ext)).toBe(false)
+      expect(DOWNLOAD_EXTS.has(ext)).toBe(false)
+    }
+    for (const ext of PDF_EXTS) {
+      expect(DOWNLOAD_EXTS.has(ext)).toBe(false)
+    }
+  })
+})

--- a/spa/src/lib/file-extension-roles.ts
+++ b/spa/src/lib/file-extension-roles.ts
@@ -1,0 +1,68 @@
+/**
+ * file-extension-roles — the single source of truth for mapping a file
+ * extension to its open "role" (image preview / pdf preview / forced download /
+ * text editor).
+ *
+ * This is a **leaf lib** (Phase 1c decision 2 / codex R1 F2): it imports nothing
+ * from the app. Both the module-registration layer
+ * (`register-modules/editor-module.tsx`, which wires the `image-preview` /
+ * `pdf-viewer` / `monaco-editor` file-openers) and `lib/open-in-app-file.ts`
+ * (which decides binary open-disposition) consume the same sets from here. Were
+ * the sets to live in `editor-module.tsx`, `open-in-app-file.ts` reading them
+ * back would form a `lib → module-registration → StoragePane → lib` cycle, so
+ * the SOT must sit at this leaf level.
+ */
+
+/** Extensions that open in the image-preview pane. */
+export const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'ico'])
+
+/** Extensions that open in the pdf-preview pane. */
+export const PDF_EXTS = new Set(['pdf'])
+
+/**
+ * Non-previewable binary / office / archive extensions that are downloaded
+ * rather than mounted in a pane. Deliberately excludes every text/code
+ * extension — those must fall through to the monaco editor. Mounting e.g. a
+ * `.docx` as text produced garbled output, which this set fixes by routing it
+ * to a download instead.
+ */
+export const DOWNLOAD_EXTS = new Set([
+  // office documents
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx',
+  // archives
+  'zip',
+  'rar',
+  '7z',
+  'tar',
+  'gz',
+  'bz2',
+  'xz',
+  // opaque binaries / installers
+  'bin',
+  'exe',
+  'dmg',
+  'iso',
+  'so',
+  'dll',
+  'wasm',
+])
+
+export type FileRole = 'image' | 'pdf' | 'download' | 'text'
+
+/**
+ * The open role for an extension. Image/pdf hit their dedicated preview panes,
+ * download covers the non-previewable binaries above, and everything else
+ * (text, code, unknown, ext-less) is treated as text → monaco editor.
+ */
+export function roleForExtension(ext: string): FileRole {
+  const e = ext.toLowerCase()
+  if (IMAGE_EXTS.has(e)) return 'image'
+  if (PDF_EXTS.has(e)) return 'pdf'
+  if (DOWNLOAD_EXTS.has(e)) return 'download'
+  return 'text'
+}

--- a/spa/src/lib/fs-backend-inapp.test.ts
+++ b/spa/src/lib/fs-backend-inapp.test.ts
@@ -376,6 +376,54 @@ describe('InAppBackend.createUnique (atomic eager namer)', () => {
   })
 })
 
+// T1c-1 — createUnique generalized: optional initial `content` written on the
+// same atomic add(), arbitrary `ext` (widened from 'md'|'txt'), and ext-less
+// names with NO trailing dot. The 1b 3-arg callers stay unaffected (empty file).
+describe('InAppBackend.createUnique (content + arbitrary extension, Phase 1c T1c-1)', () => {
+  let backend: InAppBackend
+
+  beforeEach(async () => {
+    await closeAllIDB()
+    await deleteInappDB()
+    backend = new InAppBackend()
+  })
+
+  it('writes the supplied bytes into the reserved file (byte-identical)', async () => {
+    const bytes = new Uint8Array([0x00, 0x10, 0xff, 0x42, 0x7a])
+    const path = await backend.createUnique('/buffer', 'photo', 'png', bytes)
+    expect(path).toBe('/buffer/photo.png')
+    expect(Array.from(await backend.read(path))).toEqual(Array.from(bytes))
+  })
+
+  it('accepts arbitrary extensions (pdf / docx)', async () => {
+    const p1 = await backend.createUnique('/buffer', 'doc', 'pdf', new Uint8Array([1]))
+    const p2 = await backend.createUnique('/buffer', 'sheet', 'docx', new Uint8Array([2]))
+    expect(p1).toBe('/buffer/doc.pdf')
+    expect(p2).toBe('/buffer/sheet.docx')
+  })
+
+  it('forms an ext-less name (README) with NO trailing dot', async () => {
+    const path = await backend.createUnique('/buffer', 'README', '', new Uint8Array([5]))
+    expect(path).toBe('/buffer/README')
+    expect((await backend.stat(path)).isFile).toBe(true)
+    expect(Array.from(await backend.read(path))).toEqual([5])
+  })
+
+  it('collision still increments the -N suffix and leaves the original content intact', async () => {
+    await backend.createUnique('/buffer', 'a', 'bin', new Uint8Array([1]))
+    const path = await backend.createUnique('/buffer', 'a', 'bin', new Uint8Array([2, 2]))
+    expect(path).toBe('/buffer/a-1.bin')
+    expect(Array.from(await backend.read('/buffer/a.bin'))).toEqual([1])
+    expect(Array.from(await backend.read('/buffer/a-1.bin'))).toEqual([2, 2])
+  })
+
+  it('a 1b 3-arg call (no content) still reserves an EMPTY file', async () => {
+    const path = await backend.createUnique('/buffer', 'Untitled', 'md')
+    expect(path).toBe('/buffer/Untitled.md')
+    expect((await backend.read(path)).byteLength).toBe(0)
+  })
+})
+
 // T1b-3 — mkdirUnique: atomic eager reservation of a unique DIRECTORY via the
 // same IDB store.add serialization point as createUnique. Folder candidates use
 // a SPACE-separated suffix ("New Folder", "New Folder 1", …), unlike files'

--- a/spa/src/lib/fs-backend-inapp.ts
+++ b/spa/src/lib/fs-backend-inapp.ts
@@ -180,10 +180,20 @@ export class InAppBackend implements FsBackend, SupportsUniqueCreate {
     await tx.done
   }
 
-  async createUnique(dir: string, baseName = 'Untitled', ext: 'md' | 'txt'): Promise<string> {
+  async createUnique(
+    dir: string,
+    baseName = 'Untitled',
+    ext: string,
+    content?: Uint8Array,
+  ): Promise<string> {
     const db = await this.db()
     const now = Date.now()
     const MAX = 10_000
+    // The reserved file's bytes: the caller-supplied `content` (OS-file upload,
+    // Phase 1c) or an empty buffer (1b's new-file namer). Reused across retries —
+    // only the winning add() persists, and idb structured-clones the value, so
+    // sharing the reference is safe.
+    const bytes = content ?? new Uint8Array(0)
     // store.add() is the single serialization point: it throws ConstraintError
     // if the keyPath (path) already exists, unlike put()'s blind overwrite. So
     // concurrent callers — e.g. a rapid double "New file" click (#854) — each
@@ -192,12 +202,14 @@ export class InAppBackend implements FsBackend, SupportsUniqueCreate {
     // aborts the transaction it occurred in.
     for (let n = 0; n < MAX; n++) {
       const name = n === 0 ? baseName : `${baseName}-${n}`
-      const path = join(dir, `${name}.${ext}`)
+      // An ext-less name (`README`, ext === '') must not carry a trailing dot.
+      const fileName = ext === '' ? name : `${name}.${ext}`
+      const path = join(dir, fileName)
       const tx = db.transaction(STORE, 'readwrite')
       try {
         await tx.store.add({
           path,
-          content: new Uint8Array(0),
+          content: bytes,
           isDirectory: false,
           mtime: now,
         } satisfies StoredFile)

--- a/spa/src/lib/fs-backend.ts
+++ b/spa/src/lib/fs-backend.ts
@@ -25,14 +25,27 @@ export interface FsBackend {
  */
 export interface SupportsUniqueCreate {
   /**
-   * Atomically reserve a unique empty file under `dir`. Loops candidate names
+   * Atomically reserve a unique file under `dir`. Loops candidate names
    * `<baseName>`, `<baseName>-1`, … forming each path as `dir/<name>.<ext>`
    * (`ext` is bare — no leading dot) and reserves the first free key in a way
    * that is safe against concurrent callers (the single serialization point
    * that fixes the double-new-file shared-key race, #854). Returns the reserved
    * path.
+   *
+   * `ext` is a plain string (Phase 1c widened it from `'md' | 'txt'`) so OS-file
+   * upload can reserve arbitrary extensions (`png` / `pdf` / `docx` / …). An
+   * empty `ext` (an ext-less name like `README`) forms the path WITHOUT a
+   * trailing dot. The optional `content` seeds the reserved file's bytes on the
+   * same atomic `add` — so upload's unique-name reservation AND its byte write
+   * happen as one operation (no overwrite race). It defaults to empty, so the 1b
+   * 3-arg callers (which mint empty `Untitled[-N]` files) are unaffected.
    */
-  createUnique(dir: string, baseName: string, ext: 'md' | 'txt'): Promise<string>
+  createUnique(
+    dir: string,
+    baseName: string,
+    ext: string,
+    content?: Uint8Array,
+  ): Promise<string>
   /**
    * Atomically reserve a unique empty DIRECTORY under `dir`. Loops candidate
    * names `<baseName>`, `<baseName> 1`, … (space-separated suffix, no extension)

--- a/spa/src/lib/open-in-app-file.test.ts
+++ b/spa/src/lib/open-in-app-file.test.ts
@@ -212,4 +212,16 @@ describe('openInAppFile', () => {
     expect(triggerDownload).not.toHaveBeenCalled()
     expect(readMock).not.toHaveBeenCalled()
   })
+
+  it('C2: a .docx deleted BETWEEN stat and read (read rejects) quietly refuses — no throw, no tab, no download', async () => {
+    // TOCTOU: stat resolves (file existed), but the read fails (the entry was
+    // removed, or the backend errored, in the gap). The download branch must
+    // swallow it and return undefined, matching the stat-gate's silent abort —
+    // never an unhandled rejection.
+    statMock.mockResolvedValue({ size: 4, mtime: 0, isDirectory: false, isFile: true })
+    readMock.mockRejectedValue(new Error('vanished'))
+    await expect(openInAppFile('/buffer/gone.docx', 'w1')).resolves.toBeUndefined()
+    expect(useTabStore.getState().tabOrder).toHaveLength(0)
+    expect(triggerDownload).not.toHaveBeenCalled()
+  })
 })

--- a/spa/src/lib/open-in-app-file.test.ts
+++ b/spa/src/lib/open-in-app-file.test.ts
@@ -9,24 +9,36 @@ import {
 import { registerFsBackend, clearFsBackendRegistry } from './fs-backend'
 import { editorModuleDefinition } from './register-modules/editor-module'
 import { getPrimaryPane } from './pane-tree'
+import { triggerDownload } from './download-file'
 import type { PaneContent } from '../types/tab'
 import type { FsBackend } from './fs-backend'
 import type { FileStat } from '../types/fs'
+
+// T1c-3: the download-disposition branch calls triggerDownload (side-effect,
+// no tab). Mock it so jsdom never performs a real anchor download and we can
+// assert the bytes/filename it was handed.
+vi.mock('./download-file', () => ({ triggerDownload: vi.fn() }))
 
 // stat-gate (R2-1): openInAppFile stats the path before opening. The spy
 // resolves (file exists) by default; individual tests make it reject to
 // simulate a missing/stale entry.
 const statMock = vi.fn<(path: string) => Promise<FileStat>>()
+// T1c-3: download-disposition reads bytes before triggerDownload.
+const readMock = vi.fn<(path: string) => Promise<Uint8Array>>()
 
 function registerStatBackend(): void {
   clearFsBackendRegistry()
   statMock.mockReset()
   statMock.mockResolvedValue({ size: 0, mtime: 0, isDirectory: false, isFile: true })
+  readMock.mockReset()
+  readMock.mockResolvedValue(new Uint8Array([1, 2, 3]))
+  vi.mocked(triggerDownload).mockClear()
   registerFsBackend('inapp', {
     id: 'inapp',
     label: 'In-App',
     available: () => true,
     stat: statMock,
+    read: readMock,
   } as unknown as FsBackend)
 }
 
@@ -155,5 +167,49 @@ describe('openInAppFile', () => {
     expect(useTabStore.getState().tabOrder).toHaveLength(0)
     // Refused before touching the backend.
     expect(statMock).not.toHaveBeenCalled()
+  })
+
+  // --- T1c-3: binary open-disposition (non-previewable → download, no tab) ---
+
+  it('T3-1: opening a .docx triggers a download and opens NO tab', async () => {
+    readMock.mockResolvedValue(new Uint8Array([10, 20, 30]))
+    const tabId = await openInAppFile('/buffer/report.docx', 'w1')
+    // No tab opened — download is a side-effect, not a pane.
+    expect(tabId).toBeUndefined()
+    expect(useTabStore.getState().tabOrder).toHaveLength(0)
+    // Bytes read and handed to triggerDownload with the basename.
+    expect(readMock).toHaveBeenCalledWith('/buffer/report.docx')
+    expect(triggerDownload).toHaveBeenCalledTimes(1)
+    const [blobArg, nameArg] = vi.mocked(triggerDownload).mock.calls[0]
+    expect(blobArg).toBeInstanceOf(Blob)
+    expect(nameArg).toBe('report.docx')
+  })
+
+  it('T3-2: opening a .png still mounts the image-preview pane (no download)', async () => {
+    const tabId = await openInAppFile('/buffer/p.png', 'w1')
+    expect(primaryContent(tabId!)?.kind).toBe('image-preview')
+    expect(triggerDownload).not.toHaveBeenCalled()
+  })
+
+  it('T3-3: opening a .md still mounts the monaco editor (no download)', async () => {
+    const tabId = await openInAppFile('/buffer/x.md', 'w1')
+    expect(primaryContent(tabId!)?.kind).toBe('editor')
+    expect(triggerDownload).not.toHaveBeenCalled()
+  })
+
+  it('T3-4: opening a .zip triggers a download and opens NO tab', async () => {
+    const tabId = await openInAppFile('/buffer/bundle.zip', 'w1')
+    expect(tabId).toBeUndefined()
+    expect(useTabStore.getState().tabOrder).toHaveLength(0)
+    expect(triggerDownload).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(triggerDownload).mock.calls[0][1]).toBe('bundle.zip')
+  })
+
+  it('T3: a missing .docx (stat rejects) does NOT download (stat-gate still applies)', async () => {
+    statMock.mockRejectedValue(new Error('not found'))
+    const tabId = await openInAppFile('/buffer/ghost.docx', 'w1')
+    expect(tabId).toBeUndefined()
+    expect(triggerDownload).not.toHaveBeenCalled()
+    expect(readMock).not.toHaveBeenCalled()
   })
 })

--- a/spa/src/lib/open-in-app-file.ts
+++ b/spa/src/lib/open-in-app-file.ts
@@ -4,6 +4,8 @@ import { getDefaultOpener } from './file-opener-registry'
 import { computeClusterInsertTarget } from './tab-insert/compute-cluster-insert-target'
 import { getFsBackend } from './fs-backend'
 import { basename } from './storage-paths'
+import { roleForExtension } from './file-extension-roles'
+import { triggerDownload } from './download-file'
 import type { FileInfo } from '../types/fs'
 import type { PaneContent } from '../types/tab'
 
@@ -35,12 +37,13 @@ import type { PaneContent } from '../types/tab'
  * first and ABORT when it does not exist. Skipping this lets a deleted/stale
  * path open as an empty editor buffer whose next save would resurrect the file.
  * The tree only offers existing entries, but it can go stale between render and
- * click, so the gate is load-bearing. The Phase 1c download-disposition for
- * non-previewable binaries (docx/xlsx/zip…) is NOT handled here — Phase 1a
- * covers image/pdf/editor only.
+ * click, so the gate is load-bearing. After the gate, a non-previewable binary
+ * (docx/xlsx/zip…) is routed to a download via `roleForExtension` (Phase 1c
+ * T1c-3) instead of opening a (garbled) editor pane.
  *
- * @returns the id of the opened (or focused) tab, or `undefined` when the open
- *   is refused (null workspace), the file is missing, or no opener matches.
+ * @returns the id of the opened (or focused) tab, or `undefined` when the file
+ *   was downloaded (no tab), the open is refused (null workspace), the file is
+ *   missing, or no opener matches.
  */
 export async function openInAppFile(
   path: string,
@@ -63,6 +66,19 @@ export async function openInAppFile(
 
   const name = basename(path)
   const extension = name.includes('.') ? name.split('.').pop()! : ''
+
+  // T1c-3: binary open-disposition. A non-previewable binary (docx/xlsx/zip/…)
+  // is downloaded as a side-effect — it has no pane, so it is handled BEFORE
+  // opener dispatch rather than via `FileOpener.createContent` (which must
+  // return a `PaneContent`). The stat-gate above already proved the path
+  // exists, so the `read` cannot resurrect a stale file. Returns `undefined`:
+  // no tab is opened. (Image/pdf → preview pane; text/code → monaco below.)
+  if (roleForExtension(extension) === 'download') {
+    const bytes = await backend.read(path)
+    triggerDownload(new Blob([new Uint8Array(bytes)]), name)
+    return undefined
+  }
+
   const file: FileInfo = {
     name,
     path,

--- a/spa/src/lib/open-in-app-file.ts
+++ b/spa/src/lib/open-in-app-file.ts
@@ -74,8 +74,17 @@ export async function openInAppFile(
   // exists, so the `read` cannot resurrect a stale file. Returns `undefined`:
   // no tab is opened. (Image/pdf → preview pane; text/code → monaco below.)
   if (roleForExtension(extension) === 'download') {
-    const bytes = await backend.read(path)
-    triggerDownload(new Blob([new Uint8Array(bytes)]), name)
+    // The stat-gate proved the path existed a moment ago, but the entry can be
+    // deleted (or the read otherwise fail) between the stat and this read — a
+    // TOCTOU window. Guard the read+download so a failure quietly refuses (no
+    // tab, no throw), consistent with the stat-gate's silent abort above
+    // (codex R2 C2), rather than escaping as an unhandled rejection.
+    try {
+      const bytes = await backend.read(path)
+      triggerDownload(new Blob([new Uint8Array(bytes)]), name)
+    } catch {
+      return undefined
+    }
     return undefined
   }
 

--- a/spa/src/lib/quota.test.ts
+++ b/spa/src/lib/quota.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { isQuotaError } from './quota'
+
+// isQuotaError is the single quota detector shared by the Sync snapshot store
+// and the Storage upload path (T1c-4). These cases pin every signal it accepts:
+// the standard DOMException name plus the historic numeric codes, and the
+// negatives that must NOT be mistaken for a quota exhaustion.
+describe('isQuotaError', () => {
+  it('true for a DOMException named QuotaExceededError', () => {
+    expect(isQuotaError(new DOMException('full', 'QuotaExceededError'))).toBe(true)
+  })
+
+  it('true for the standard numeric code 22', () => {
+    const err = new DOMException('full', 'SomeOtherName')
+    Object.defineProperty(err, 'code', { value: 22 })
+    expect(isQuotaError(err)).toBe(true)
+  })
+
+  it('true for the Firefox legacy code 1014', () => {
+    const err = new DOMException('full', 'SomeOtherName')
+    Object.defineProperty(err, 'code', { value: 1014 })
+    expect(isQuotaError(err)).toBe(true)
+  })
+
+  it('false for a plain Error', () => {
+    expect(isQuotaError(new Error('QuotaExceededError'))).toBe(false)
+  })
+
+  it('false for a non-DOMException value', () => {
+    expect(isQuotaError({ name: 'QuotaExceededError', code: 22 })).toBe(false)
+    expect(isQuotaError(null)).toBe(false)
+    expect(isQuotaError('QuotaExceededError')).toBe(false)
+  })
+
+  it('false for an unrelated DOMException (wrong name + code)', () => {
+    expect(isQuotaError(new DOMException('nope', 'AbortError'))).toBe(false)
+  })
+})

--- a/spa/src/lib/quota.ts
+++ b/spa/src/lib/quota.ts
@@ -1,0 +1,20 @@
+/**
+ * isQuotaError — true when `err` is a storage-quota exhaustion thrown by
+ * IndexedDB / the Storage API. Lifted out of `sync/snapshot-store.ts` (T1c-4)
+ * into this shared leaf so both the Sync snapshot store and the Storage upload
+ * path detect a full quota through ONE implementation (no second copy).
+ *
+ * Matches the standard `DOMException` name `QuotaExceededError` plus the historic
+ * numeric codes 22 (standard) and 1014 (Firefox). A non-`DOMException` value
+ * (a plain `Error`, a bare object that merely looks like one, etc.) is never a
+ * quota error.
+ */
+export function isQuotaError(err: unknown): boolean {
+  if (err instanceof DOMException) {
+    if (err.name === 'QuotaExceededError') return true
+    // Historic numeric codes: 22 (standard), 1014 (Firefox).
+    const code = (err as DOMException & { code?: number }).code
+    if (code === 22 || code === 1014) return true
+  }
+  return false
+}

--- a/spa/src/lib/register-modules/__tests__/editor-module.test.tsx
+++ b/spa/src/lib/register-modules/__tests__/editor-module.test.tsx
@@ -35,6 +35,17 @@ describe('editorModuleDefinition.fileOpeners', () => {
     expect(opener?.match({ name: 'src', path: '/src', extension: '', size: 0, isDirectory: true })).toBe(false)
   })
 
+  it('C7: monaco-editor opener excludes DOWNLOAD_EXTS so the registry agrees with open-in-app disposition', () => {
+    // A .docx (and other non-previewable binaries) must NOT match monaco — they
+    // are routed to a download by `roleForExtension`, and the registry matcher
+    // now shares that single SOT (`roleForExtension(ext) === 'text'`).
+    const opener = editorModuleDefinition.fileOpeners?.find((o) => o.id === 'monaco-editor')
+    expect(opener?.match({ name: 'a.docx', path: '/a.docx', extension: 'docx', size: 1, isDirectory: false })).toBe(false)
+    expect(opener?.match({ name: 'a.zip', path: '/a.zip', extension: 'zip', size: 1, isDirectory: false })).toBe(false)
+    // An ext-less name is still text → monaco.
+    expect(opener?.match({ name: 'README', path: '/README', extension: '', size: 1, isDirectory: false })).toBe(true)
+  })
+
   describe('registerEditorNewTabProviders', () => {
     beforeEach(() => clearNewTabRegistry())
     afterEach(() => clearNewTabRegistry())

--- a/spa/src/lib/register-modules/editor-module.tsx
+++ b/spa/src/lib/register-modules/editor-module.tsx
@@ -14,9 +14,11 @@ import { ManageBuffersNewTabCard } from '../../components/editor/ManageBuffersNe
 import { EditorHomePathWorkspaceSection } from '../../components/editor/EditorHomePathWorkspaceSection'
 import { EditorHomePathHostSection } from '../../components/editor/EditorHomePathHostSection'
 import { EditorPurdexSettingsSection } from '../../components/settings/EditorPurdexSettingsSection'
+import { IMAGE_EXTS, PDF_EXTS } from '../file-extension-roles'
 
-const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'ico'])
-const PDF_EXTS = new Set(['pdf'])
+// Non-dir files that are NOT image/pdf still match the monaco editor here.
+// Download-disposition for non-previewable binaries (docx/zip/…) is handled
+// upstream in `open-in-app-file.ts` via `roleForExtension`, before dispatch.
 const BINARY_EXTS = new Set([...IMAGE_EXTS, ...PDF_EXTS])
 
 export const editorModuleDefinition: ModuleDefinition = {

--- a/spa/src/lib/register-modules/editor-module.tsx
+++ b/spa/src/lib/register-modules/editor-module.tsx
@@ -14,12 +14,7 @@ import { ManageBuffersNewTabCard } from '../../components/editor/ManageBuffersNe
 import { EditorHomePathWorkspaceSection } from '../../components/editor/EditorHomePathWorkspaceSection'
 import { EditorHomePathHostSection } from '../../components/editor/EditorHomePathHostSection'
 import { EditorPurdexSettingsSection } from '../../components/settings/EditorPurdexSettingsSection'
-import { IMAGE_EXTS, PDF_EXTS } from '../file-extension-roles'
-
-// Non-dir files that are NOT image/pdf still match the monaco editor here.
-// Download-disposition for non-previewable binaries (docx/zip/…) is handled
-// upstream in `open-in-app-file.ts` via `roleForExtension`, before dispatch.
-const BINARY_EXTS = new Set([...IMAGE_EXTS, ...PDF_EXTS])
+import { IMAGE_EXTS, PDF_EXTS, roleForExtension } from '../file-extension-roles'
 
 export const editorModuleDefinition: ModuleDefinition = {
   id: 'editor',
@@ -83,8 +78,13 @@ export const editorModuleDefinition: ModuleDefinition = {
       id: 'monaco-editor',
       label: 'Text Editor',
       icon: 'File',
+      // Monaco owns only the `text` role — the SAME classification
+      // `open-in-app-file.ts` uses for disposition (codex R2 C7), so a registry
+      // caller and `openInAppFile` agree: image/pdf hit their preview panes, the
+      // non-previewable binaries in DOWNLOAD_EXTS (docx/zip/…) are excluded here
+      // and routed to a download, and everything else falls through to monaco.
       match: (file) =>
-        !file.isDirectory && !BINARY_EXTS.has(file.extension.toLowerCase()),
+        !file.isDirectory && roleForExtension(file.extension) === 'text',
       priority: 'default',
       createContent: (source, file) =>
         ({ kind: 'editor', source, filePath: file.path }) as PaneContent,

--- a/spa/src/lib/sync/__tests__/snapshot-store.test.ts
+++ b/spa/src/lib/sync/__tests__/snapshot-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from 'vitest'
 import { createSnapshotStore } from '../snapshot-store'
-import { closeAllIDB } from '../../storage/idb'
+import { closeAllIDB, openIDB } from '../../storage/idb'
 import type { SyncBundle } from '../types'
 
 const bundle = (device = 'dev-a'): SyncBundle => ({
@@ -161,5 +161,68 @@ describe('SnapshotStore.rotateSessionPristine (Adv-1 atomicity)', () => {
     expect(pristine).toHaveLength(1)
     // Whichever rotation committed last is the winner.
     expect([metaA.id, metaB.id]).toContain(pristine[0].id)
+  })
+})
+
+// --- C5 (T4-4): the quota-retry fallback still works through the LIFTED
+// `isQuotaError` (now imported from lib/quota). A first put that throws a quota
+// DOMException must trigger compaction + a successful retry — proving the lift
+// did not break detection.
+describe('SnapshotStore.createSnapshot — quota-retry via the lifted isQuotaError (C5)', () => {
+  beforeEach(async () => {
+    await closeAllIDB()
+    indexedDB.deleteDatabase('purdex-sync-test')
+  })
+
+  it('a quota-failed first put triggers compaction then a successful retry', async () => {
+    const store = createSnapshotStore('purdex-sync-test')
+    await store.init()
+
+    // openIDB caches by (name, version), so this resolves to the SAME connection
+    // the store uses → overriding `db.put` here intercepts the store's writes.
+    const db = await openIDB('purdex-sync-test', 1, () => {})
+    const realPut = db.put.bind(db)
+    let putCalls = 0
+    // Override the idb shorthand `put`: reject the FIRST call with a quota
+    // DOMException (as a full IDB would), pass every later call through.
+    const dbWithPut = db as unknown as { put: typeof db.put }
+    dbWithPut.put = ((storeName: string, value: unknown) => {
+      putCalls += 1
+      if (putCalls === 1) {
+        return Promise.reject(new DOMException('quota exceeded', 'QuotaExceededError'))
+      }
+      return realPut(storeName as never, value as never)
+    }) as typeof db.put
+
+    try {
+      const meta = await store.createSnapshot(bundle(), 'manual')
+      // First put rejected (quota) → compactFn() → retry put succeeded.
+      expect(putCalls).toBeGreaterThanOrEqual(2)
+      // The snapshot persisted despite the initial quota failure.
+      const fetched = await store.getLocal(meta.id)
+      expect(fetched).not.toBeNull()
+    } finally {
+      delete (db as unknown as { put?: unknown }).put
+    }
+  })
+
+  it('a NON-quota put error is NOT retried — it propagates', async () => {
+    const store = createSnapshotStore('purdex-sync-test')
+    await store.init()
+    const db = await openIDB('purdex-sync-test', 1, () => {})
+    let putCalls = 0
+    const dbWithPut = db as unknown as { put: typeof db.put }
+    dbWithPut.put = (() => {
+      putCalls += 1
+      return Promise.reject(new Error('disk on fire'))
+    }) as typeof db.put
+
+    try {
+      await expect(store.createSnapshot(bundle(), 'manual')).rejects.toThrow('disk on fire')
+      // No compaction-retry for a non-quota error: put attempted exactly once.
+      expect(putCalls).toBe(1)
+    } finally {
+      delete (db as unknown as { put?: unknown }).put
+    }
   })
 })

--- a/spa/src/lib/sync/snapshot-store.ts
+++ b/spa/src/lib/sync/snapshot-store.ts
@@ -1,4 +1,5 @@
 import { openIDB } from '../storage/idb'
+import { isQuotaError } from '../quota'
 import type { SyncBundle } from './types'
 import type { SnapshotMetadata, SnapshotTrigger, StoredSnapshot } from './snapshot-types'
 import { computeCompaction } from './snapshot-compaction'
@@ -14,16 +15,6 @@ function genId(): string {
 
 function computeBundleSize(bundle: SyncBundle): number {
   return new TextEncoder().encode(JSON.stringify(bundle)).byteLength
-}
-
-function isQuotaError(err: unknown): boolean {
-  if (err instanceof DOMException) {
-    if (err.name === 'QuotaExceededError') return true
-    // Historic numeric codes: 22 (standard), 1014 (Firefox).
-    const code = (err as DOMException & { code?: number }).code
-    if (code === 22 || code === 1014) return true
-  }
-  return false
 }
 
 export interface SnapshotStore {

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -487,6 +487,8 @@
   "editor.buffers.download": "Download",
   "editor.buffers.upload": "Upload",
   "editor.buffers.upload_partial": "Uploaded {{uploaded}}, {{failed}} failed: {{name}} …",
+  "editor.buffers.upload_too_large": "{{name}} is too large to upload (max {{cap}} MB).",
+  "editor.buffers.upload_quota": "Storage is full — {{name}} could not be saved.",
   "editor.buffers.confirm_delete": "Delete {{count}} buffer(s)?",
   "editor.buffers.confirm_switch_dirty": "Current buffer has unsaved changes. Switch anyway?",
   "editor.buffers.rename_slash_error": "Subfolders not supported",

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -485,6 +485,8 @@
   "editor.buffers.delete": "Delete",
   "editor.buffers.open": "Open",
   "editor.buffers.download": "Download",
+  "editor.buffers.upload": "Upload",
+  "editor.buffers.upload_partial": "Uploaded {{uploaded}}, {{failed}} failed: {{name}} …",
   "editor.buffers.confirm_delete": "Delete {{count}} buffer(s)?",
   "editor.buffers.confirm_switch_dirty": "Current buffer has unsaved changes. Switch anyway?",
   "editor.buffers.rename_slash_error": "Subfolders not supported",

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -484,6 +484,7 @@
   "editor.buffers.rename": "Rename",
   "editor.buffers.delete": "Delete",
   "editor.buffers.open": "Open",
+  "editor.buffers.download": "Download",
   "editor.buffers.confirm_delete": "Delete {{count}} buffer(s)?",
   "editor.buffers.confirm_switch_dirty": "Current buffer has unsaved changes. Switch anyway?",
   "editor.buffers.rename_slash_error": "Subfolders not supported",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -484,6 +484,7 @@
   "editor.buffers.rename": "重新命名",
   "editor.buffers.delete": "刪除",
   "editor.buffers.open": "開啟",
+  "editor.buffers.download": "下載",
   "editor.buffers.confirm_delete": "刪除 {{count}} 個暫存檔？",
   "editor.buffers.confirm_switch_dirty": "目前暫存檔有未儲存的變更，仍要切換嗎？",
   "editor.buffers.rename_slash_error": "不支援子資料夾",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -485,6 +485,8 @@
   "editor.buffers.delete": "刪除",
   "editor.buffers.open": "開啟",
   "editor.buffers.download": "下載",
+  "editor.buffers.upload": "上傳",
+  "editor.buffers.upload_partial": "已上傳 {{uploaded}} 個，{{failed}} 個失敗：{{name}} …",
   "editor.buffers.confirm_delete": "刪除 {{count}} 個暫存檔？",
   "editor.buffers.confirm_switch_dirty": "目前暫存檔有未儲存的變更，仍要切換嗎？",
   "editor.buffers.rename_slash_error": "不支援子資料夾",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -487,6 +487,8 @@
   "editor.buffers.download": "下載",
   "editor.buffers.upload": "上傳",
   "editor.buffers.upload_partial": "已上傳 {{uploaded}} 個，{{failed}} 個失敗：{{name}} …",
+  "editor.buffers.upload_too_large": "{{name}} 太大，無法上傳（上限 {{cap}} MB）。",
+  "editor.buffers.upload_quota": "儲存空間已滿，無法儲存 {{name}}。",
   "editor.buffers.confirm_delete": "刪除 {{count}} 個暫存檔？",
   "editor.buffers.confirm_switch_dirty": "目前暫存檔有未儲存的變更，仍要切換嗎？",
   "editor.buffers.rename_slash_error": "不支援子資料夾",


### PR DESCRIPTION
## Storage Phase 1c — Upload / download / binary-disposition / quota

子系統 1 第三階段：在 1a 巢狀樹 + 1b 巢狀 CRUD 之上補齊檔案進出。純前端（IndexedDB `InAppBackend`），無 daemon/Electron-IPC 改動（OS 下載走瀏覽器 anchor，Electron WebContents 亦適用）。

### 任務（每個獨立 commit，TDD）
| Task | 內容 |
|------|------|
| **T1c-2** | 下載/匯出單檔（`backend.read`→Blob→anchor download）；抽共用 `lib/download-file.ts` `triggerDownload`（SyncSection 改 import，行為不變）|
| **T1c-3** | 非可預覽 binary 開檔→**下載 disposition**（docx/xlsx/zip… 不掛 editor 變亂碼）；抽 leaf lib `lib/file-extension-roles.ts`（IMAGE/PDF/DOWNLOAD + `roleForExtension`，消除 lib→module-registration 反向依賴）|
| **T1c-1** | **上傳**：toolbar picker + OS 檔案拖入（native HTML5 drop，用 `dataTransfer.files.length>0` 與 1b dnd-kit node-move 共存）；泛化 `createUnique(dir, base, ext: string, content?)` 原子保留+寫入；`uploadFiles → UploadSummary{uploaded[],failed[]}` partial 回報 |
| **T1c-4** | **軟上限 ~25MB**（write 前擋）+ **quota 錯誤**（`isQuotaError` lift 到 `lib/quota.ts`，write catch）→ inline banner warning/error 分流 |

### 設計重點
- **OS-file native drop 與 dnd-kit 共存**：dnd-kit 用 pointer events、OS drop 用 HTML5 drag events（獨立事件流）；native handler 僅當 `dataTransfer.files.length>0` 處理，否則放行 → 不干擾樹內節點拖曳（codex plan review 引 dnd-kit/MDN 文件確認方向）。
- **upload 不覆蓋**：reuse #854 的 IDB `store.add()` 原子保留（泛化 `createUnique` 收 `content`），picker + drop 並發都走同一序列化點；suffix `-N`，ext-less 不留 trailing dot。
- **binary disposition**：`openInAppFile` 在 dispatch 前判 `roleForExtension==='download'` → read+triggerDownload+不開 tab；image/pdf 仍 preview、text 仍 monaco。
- **guard 分層**：size cap 在 write 前擋（完全不寫）；quota 在 write catch（never silent）；`UploadSummary.failed` 帶 `kind: too-large|quota|other` 供 banner 分流。

### Plan / review
- Detailed plan `docs/specs/2026-06-28-storage-filemanager-1c-plan.md`，**codex 3 輪 plan review → SHIP-READY**（R1 5 findings → R2 5 resolved+1 new → R3 clean）。

### 驗證
- **Full vitest 3541 passed / 0 fail**（313 檔；alpha.301 baseline 3491 + 50）
- `pnpm run lint` clean、`pnpm run build`（tsc + vite）green

### 範圍外
資料夾→zip 下載、Electron native save dialog（anchor 已足夠）、content-addressed chunking（Sync P5）、子系統 2（daemon 備份還原）。
