### PR TITLE
feat(storage+browser): post-2b UI polish — brighten text, boot backup check, New File rename, hide URL dropdown

### DIFF
--- a/spa/src/components/BrowserNewTabSection.tsx
+++ b/spa/src/components/BrowserNewTabSection.tsx
@@ -4,6 +4,14 @@ import { useI18nStore } from '../stores/useI18nStore'
 import { useBrowserHistoryStore } from '../stores/useBrowserHistoryStore'
 import type { NewTabProviderProps } from '../lib/new-tab-registry'
 
+/**
+ * Hidden-but-retained: the URL-history suggestion dropdown is intentionally not
+ * rendered for now (per UX feedback) while ALL of its logic — history store,
+ * keyboard navigation, outside-click close, scroll-into-view — is kept intact.
+ * Flip to `true` to restore the dropdown with no other change.
+ */
+const SHOW_URL_HISTORY_DROPDOWN = false
+
 export function BrowserNewTabSection({ onSelect }: NewTabProviderProps) {
   const t = useI18nStore((s) => s.t)
   const urls = useBrowserHistoryStore((s) => s.urls)
@@ -124,7 +132,7 @@ export function BrowserNewTabSection({ onSelect }: NewTabProviderProps) {
           className="flex-1 bg-surface-input border border-border-default rounded-md text-text-primary text-xs px-3 py-1.5 focus:border-border-active focus:outline-none"
         />
       </form>
-      {showDropdown && filtered.length > 0 && (
+      {SHOW_URL_HISTORY_DROPDOWN && showDropdown && filtered.length > 0 && (
         <div
           ref={dropdownRef}
           className="absolute right-2 mt-1 bg-surface-elevated border border-border-default rounded-md shadow-lg max-h-48 overflow-y-auto z-10"

--- a/spa/src/components/editor/storage/BackupStatusSidebar.tsx
+++ b/spa/src/components/editor/storage/BackupStatusSidebar.tsx
@@ -46,9 +46,9 @@ export function BackupStatusSidebar() {
   return (
     <aside
       data-testid="storage-backups-panel"
-      className="w-48 shrink-0 border-l border-border-subtle p-3 text-xs text-text-muted"
+      className="w-48 shrink-0 border-l border-border-subtle p-3 text-xs text-text-secondary"
     >
-      <div className="mb-2 font-medium text-text-secondary">
+      <div className="mb-2 font-medium text-text-primary">
         {t('editor.buffers.backup.title')}
       </div>
 

--- a/spa/src/components/editor/storage/StorageRow.tsx
+++ b/spa/src/components/editor/storage/StorageRow.tsx
@@ -178,7 +178,7 @@ export function StorageRow({
         'w-full flex items-center gap-1.5 pr-3 py-1.5 text-left text-xs transition-colors cursor-pointer ' +
         (selected
           ? 'bg-surface-selected text-text-primary'
-          : 'text-text-secondary hover:bg-surface-hover') +
+          : 'text-text-primary hover:bg-surface-hover') +
         (dropActive ? ' ring-1 ring-inset ring-accent bg-surface-hover' : '') +
         (isDragging ? ' opacity-50' : '')
       }
@@ -200,7 +200,7 @@ export function StorageRow({
       <Icon size={14} className="shrink-0 text-text-muted" />
       <span className="truncate flex-1">{node.name}</span>
       {!node.isDir && (
-        <span className="shrink-0 text-text-muted tabular-nums">
+        <span className="shrink-0 text-text-secondary tabular-nums">
           {node.size} B
           {text && wordCount !== null ? ` · ${wordCount} words` : ''}
         </span>

--- a/spa/src/lib/storage-backup/backup-auto-trigger.test.ts
+++ b/spa/src/lib/storage-backup/backup-auto-trigger.test.ts
@@ -148,3 +148,71 @@ describe('createBackupAutoTrigger (T2b-6)', () => {
     expect(host.size()).toBe(0) // host listener removed
   })
 })
+
+describe('createBackupAutoTrigger initial boot check (runInitialCheck)', () => {
+  it('runs one backupNow at creation when a host is already resolvable', () => {
+    const fb = fakeBackend()
+    const host = fakeHostSub()
+    const backupNow = vi.fn()
+    createBackupAutoTrigger({
+      backend: fb.backend,
+      resolveHostId: () => 'A',
+      subscribeHost: host.subscribe,
+      backupNow,
+      runInitialCheck: true,
+    })
+    expect(backupNow).toHaveBeenCalledTimes(1)
+    expect(backupNow).toHaveBeenCalledWith('A')
+  })
+
+  it('defers the check until a host first becomes available, then fires exactly once', () => {
+    const fb = fakeBackend()
+    const host = fakeHostSub()
+    const backupNow = vi.fn()
+    let resolved: string | undefined = undefined
+    createBackupAutoTrigger({
+      backend: fb.backend,
+      resolveHostId: () => resolved,
+      subscribeHost: host.subscribe,
+      backupNow,
+      runInitialCheck: true,
+    })
+    expect(backupNow).not.toHaveBeenCalled() // no host at boot
+    resolved = 'A'
+    host.fire() // host connected
+    expect(backupNow).toHaveBeenCalledTimes(1)
+    expect(backupNow).toHaveBeenCalledWith('A')
+    host.fire() // a later host-store change must NOT re-fire the boot check
+    expect(backupNow).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not run any initial check when runInitialCheck is unset', () => {
+    const fb = fakeBackend()
+    const host = fakeHostSub()
+    const backupNow = vi.fn()
+    createBackupAutoTrigger({
+      backend: fb.backend,
+      resolveHostId: () => 'A',
+      subscribeHost: host.subscribe,
+      backupNow,
+    })
+    expect(backupNow).not.toHaveBeenCalled()
+  })
+
+  it('dispose removes a still-pending initial-check host listener', () => {
+    const fb = fakeBackend()
+    const host = fakeHostSub()
+    const backupNow = vi.fn()
+    const trigger = createBackupAutoTrigger({
+      backend: fb.backend,
+      resolveHostId: () => undefined,
+      subscribeHost: host.subscribe,
+      backupNow,
+      runInitialCheck: true,
+    })
+    trigger.dispose()
+    expect(host.size()).toBe(0) // both cancel + initial listeners removed
+    host.fire()
+    expect(backupNow).not.toHaveBeenCalled()
+  })
+})

--- a/spa/src/lib/storage-backup/backup-auto-trigger.ts
+++ b/spa/src/lib/storage-backup/backup-auto-trigger.ts
@@ -25,6 +25,12 @@ export interface BackupAutoTriggerOptions {
   backupNow: (hostId: string) => void | Promise<void>
   /** Debounce window in ms (default 2000). */
   delayMs?: number
+  /**
+   * Run one backup check at creation (app boot), as soon as a host is
+   * resolvable. Lets a device that launches with un-backed-up `/buffer` content
+   * capture it without waiting for an edit. Fires exactly once.
+   */
+  runInitialCheck?: boolean
 }
 
 export interface BackupAutoTrigger {
@@ -32,7 +38,7 @@ export interface BackupAutoTrigger {
 }
 
 export function createBackupAutoTrigger(opts: BackupAutoTriggerOptions): BackupAutoTrigger {
-  const { backend, resolveHostId, subscribeHost, backupNow, delayMs = 2000 } = opts
+  const { backend, resolveHostId, subscribeHost, backupNow, delayMs = 2000, runInitialCheck = false } = opts
 
   let timer: ReturnType<typeof setTimeout> | null = null
   let pendingHost: string | null = null
@@ -69,10 +75,33 @@ export function createBackupAutoTrigger(opts: BackupAutoTriggerOptions): BackupA
     }
   })
 
+  // Initial boot check (item 2): back up once as soon as a host is resolvable.
+  // backupNow's own no-op suppression + the daemon's content-keyed no-op mean an
+  // unchanged tree is just a cheap round-trip, not a new snapshot. If no host is
+  // resolvable yet (daemon still connecting), defer to the first host-store
+  // change that yields one — then fire exactly once and drop the listener.
+  let initUnsub: (() => void) | null = null
+  if (runInitialCheck) {
+    const host = resolveHostId()
+    if (host) {
+      void backupNow(host)
+    } else {
+      initUnsub = subscribeHost(() => {
+        const h = resolveHostId()
+        if (!h) return
+        initUnsub?.()
+        initUnsub = null
+        void backupNow(h)
+      })
+    }
+  }
+
   return {
     dispose: () => {
       unsubMutation()
       unsubHost()
+      initUnsub?.()
+      initUnsub = null
       clearPending()
     },
   }
@@ -95,5 +124,7 @@ export function startBackupAutoTrigger(): BackupAutoTrigger | null {
     },
     subscribeHost: (cb) => useHostStore.subscribe(cb),
     backupNow: (hostId) => useBackupStore.getState().backupNow(hostId),
+    // Check once on boot whether the In-App tree needs a backup (item 2).
+    runInitialCheck: true,
   })
 }

--- a/spa/src/locales/en.json
+++ b/spa/src/locales/en.json
@@ -479,7 +479,7 @@
   "editor.settings.home_path.clear": "Clear",
   "editor.buffers.tab_title": "Storage",
   "editor.buffers.empty": "No buffers yet",
-  "editor.buffers.new": "New Buffer",
+  "editor.buffers.new": "New File",
   "editor.buffers.new_folder": "New Folder",
   "editor.buffers.rename": "Rename",
   "editor.buffers.delete": "Delete",

--- a/spa/src/locales/zh-TW.json
+++ b/spa/src/locales/zh-TW.json
@@ -479,7 +479,7 @@
   "editor.settings.home_path.clear": "清除",
   "editor.buffers.tab_title": "儲存空間",
   "editor.buffers.empty": "尚無暫存檔",
-  "editor.buffers.new": "新增暫存檔",
+  "editor.buffers.new": "新增檔案",
   "editor.buffers.new_folder": "新增資料夾",
   "editor.buffers.rename": "重新命名",
   "editor.buffers.delete": "刪除",


### PR DESCRIPTION
使用者實測 Phase 2b 後的 4 項 UI/UX polish。輕量 self-review（無 codex,使用者指定）。

## 改動（各自獨立 commit）
1. **`style(storage)` 調亮文字** — 檔名 `text-text-secondary`→`primary`、size/words `muted`→`secondary`；備份側欄面板 `muted`→`secondary`、標題 →`primary`。(`StorageRow.tsx` / `BackupStatusSidebar.tsx`)
2. **`i18n(storage)` New Buffer → New File** — `editor.buffers.new`：`New File` / `新增檔案`,對齊 Editor 區的 New File 措辭。(en + zh-TW)
3. **`feat(browser)` 隱藏 URL 歷史 dropdown** — `SHOW_URL_HISTORY_DROPDOWN = false` flag gate render,history store / 鍵盤導航 / outside-click / scroll-into-view 邏輯**全保留**,翻 flag 即還原。(`BrowserNewTabSection.tsx`)
4. **`feat(storage)` 啟動時檢查一次 backup** — `runInitialCheck`：app boot 時 host 就緒即跑一次 `backupNow`(未就緒則等首個 host 出現時觸發一次,idempotent,dispose 清乾淨)。靠 backupNow no-op 抑制 + daemon content-keyed no-op,內容沒變只是輕量 round-trip。(`backup-auto-trigger.ts` + TDD 4 新測試)

## 驗證
- TDD：item 4 先 red(2 fail)→ 實作 → green
- `npx vitest run` → **322 files / 3616 tests**（+4 boot-check）全綠
- `pnpm run lint` clean
- `pnpm run build` OK

## 已知考量（非阻擋）
- boot 檢查沿用既有 `activeHostId ?? hostOrder[0]` resolver,不檢查連線狀態 — 若 daemon 啟動瞬間尚未連上,可能短暫顯示 backup error（與既有 mutation-trigger 行為一致）。若實測造成困擾,後續可對兩條路徑統一加 connection gating。