### PR TITLE
fix(spa): image/pdf preview fill height via h-full, not flex-1

### DIFF
--- a/spa/src/components/editor/ImagePreviewPane.test.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.test.tsx
@@ -161,6 +161,30 @@ describe('ImagePreviewPane', () => {
     expect(container.className).toContain('min-h-0')
   })
 
+  it('fills its mount with an explicit height (h-full) so the fit-height chain works under a non-flex parent', async () => {
+    // Root cause of the "width fits but height does not, and cannot scroll"
+    // bug: the per-tab mount wrapper in TabContent is position:absolute inset:0
+    // (a plain block, not a flex container), so a `flex-1` root collapses to
+    // content height. Without a definite height, the inner container has no
+    // height for the image's max-height:100% to resolve against (it computes to
+    // `none`), leaving only width constrained → tall images overflow and the
+    // overflow is clipped, unscrollable. The pane must claim height the same way
+    // EditorPane does — `h-full w-full` — which resolves against the block
+    // parent's definite (inset:0) height. Guards against regressing back to
+    // `flex-1`.
+    imgComplete = true
+    imgNaturalW = 2000
+    imgNaturalH = 2000
+    boxW = 500
+    boxH = 500
+
+    const img = await renderAndMeasure('/big.png')
+    const container = img.parentElement as HTMLElement
+    const root = container.parentElement as HTMLElement
+    expect(root.className).toContain('h-full')
+    expect(root.className).not.toContain('flex-1')
+  })
+
   it('measures oversized synchronously for a cached/HMR-complete image without a load event (AC17b)', async () => {
     imgComplete = true
     imgNaturalW = 2000

--- a/spa/src/components/editor/ImagePreviewPane.tsx
+++ b/spa/src/components/editor/ImagePreviewPane.tsx
@@ -129,7 +129,7 @@ function ImagePreviewPaneInner({ source, filePath }: { source: FileSource; fileP
   }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden min-h-0">
+    <div className="h-full w-full flex flex-col overflow-hidden min-h-0">
       <div className="px-3 py-1 border-b border-border-subtle bg-surface-secondary text-xs text-text-secondary truncate">
         {fileName}
       </div>

--- a/spa/src/components/editor/PdfPreviewPane.test.tsx
+++ b/spa/src/components/editor/PdfPreviewPane.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { PdfPreviewPane } from './PdfPreviewPane'
+import type { Pane } from '../../types/tab'
+import type { FileSource } from '../../types/fs'
+import { getFsBackend } from '../../lib/fs-backend'
+
+const read = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
+const backendInstance = { read }
+
+vi.mock('../../lib/fs-backend', () => ({
+  getFsBackend: vi.fn(() => backendInstance),
+}))
+
+function makePane(filePath: string, source: FileSource = { type: 'inapp' }): Pane {
+  return { id: 'p1', content: { kind: 'pdf-preview', source, filePath } }
+}
+
+beforeEach(() => {
+  read.mockClear()
+  vi.mocked(getFsBackend).mockReturnValue(backendInstance as unknown as ReturnType<typeof getFsBackend>)
+  globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock')
+  globalThis.URL.revokeObjectURL = vi.fn()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('PdfPreviewPane', () => {
+  it('fills its mount with an explicit height (h-full) so the iframe height chain works under a non-flex parent', async () => {
+    // Same root cause as ImagePreviewPane: the per-tab mount wrapper in
+    // TabContent is position:absolute (a plain block, not a flex container), so
+    // a `flex-1` root collapses to content height and the iframe's `h-full` has
+    // no definite height to resolve against. The pane must claim height via
+    // `h-full w-full` like EditorPane. Guards against regressing to `flex-1`.
+    render(<PdfPreviewPane pane={makePane('/doc.pdf')} isActive={true} />)
+    const iframe = await screen.findByTitle('doc.pdf')
+    const root = iframe.parentElement?.parentElement as HTMLElement
+    expect(root.className).toContain('h-full')
+    expect(root.className).not.toContain('flex-1')
+  })
+})

--- a/spa/src/components/editor/PdfPreviewPane.tsx
+++ b/spa/src/components/editor/PdfPreviewPane.tsx
@@ -43,7 +43,7 @@ function PdfPreviewPaneInner({ source, filePath }: { source: FileSource; filePat
   const fileName = filePath.split('/').pop() ?? ''
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="h-full w-full flex flex-col overflow-hidden">
       <div className="px-3 py-1 border-b border-border-subtle bg-surface-secondary text-xs text-text-secondary truncate">
         {fileName}
       </div>


### PR DESCRIPTION
## 問題

在 tab 內瀏覽圖片時，圖片**寬度會等比縮到容器寬，但高度不縮**——直幅圖只能看到上半、下半被裁掉且**無法捲動**。PDF 預覽有相同症狀。

## 根因

完整高度鏈：

```
TabContent
  (A) <div flex-1 relative overflow-hidden>      ← 有明確高度、會 clip
    (B) <div class="absolute" inset:0>            ← ⚠️ position:absolute 純 block，非 flex container
       ImagePreviewPane root <div flex-1 ...>     ← flex-1 在 block 父層下失效 → 塌成內容高
         container <div flex-1 min-h-0 overflow-auto>
           <img max-w-full max-h-full object-contain>
```

`flex-1` 只有在 flex 父層下才生效。B 是 `position:absolute` 的純 block，所以 root 的 `flex-1` 失效、塌成內容高 → 內層容器沒有明確高度 → `<img>` 的 `max-height:100%`（PDF 則是 iframe 的 `h-full`）解析成 `none` → 只剩寬度受限。溢出的高度撞上 A 的 `overflow-hidden` 被裁掉、不可捲。

split / 有 header 的情境因父層是 flex 容器，`flex-1` 正常，所以只有「單一整頁圖片/PDF」會中。

**Working reference**：同 codebase 的 `EditorPane` root 用的是 `h-full w-full`（不是 flex-1），所以一直正常。`ImagePreviewPane` / `PdfPreviewPane` 用 `flex-1` 才是偏離慣例的 bug。

## 修法

兩個 pane root：`flex-1` → `h-full w-full`，對齊 `EditorPane`。`h-full`（height:100%）能解析到 block 父層 B 的明確（inset:0）高度。

- 修好「高不縮」：高度鏈接通 → `object-contain` 自然長邊優先等比縮。
- 連帶修好「捲不動」：fit 模式不再溢出；actual 模式本來就 `items-start` 可捲。

## 驗證

- Playwright 還原 A→B→C→D 鏈實證：現況 img 1400px 撐爆 600px 容器；修後等比縮到 543×78 正確 contain。
- 回歸測試：兩 pane root 斷言 `h-full` 且非 `flex-1`（紅→綠）。
- vitest 3694 全綠 / lint 乾淨 / build OK。

## 注意

App 端需更新到含此修正的版本才會生效（HMR 不涵蓋已 bundle 的舊版）。