### PR TITLE
fix(spa): new-tab / history panes fill height via h-full, not flex-1

### DIFF
--- a/spa/src/components/HistoryPage.test.tsx
+++ b/spa/src/components/HistoryPage.test.tsx
@@ -24,6 +24,18 @@ describe('HistoryPage', () => {
     expect(screen.getByText('No browsing history yet')).toBeTruthy()
   })
 
+  it('root fills its mount with h-full (not flex-1) so the overflow-y-auto list is scrollable', () => {
+    // Same root cause as the new-tab start screen: the history pane mounts
+    // under TabContent's position:absolute (block) wrapper, so a `flex-1` root
+    // collapses to content height and its own `overflow-y-auto` never gets a
+    // bounded height to scroll within. Must claim height via `h-full`.
+    const { container } = render(<HistoryPage {...makePaneProps()} />)
+    const root = container.firstChild as HTMLElement
+    expect(root.className).toContain('h-full')
+    expect(root.className).not.toContain('flex-1')
+    expect(root.className).toContain('overflow-y-auto')
+  })
+
   it('renders browse records in reverse chronological order', () => {
     const content1: PaneContent = { kind: 'dashboard' }
     const content2: PaneContent = { kind: 'tmux-session', hostId: 'test-host', sessionCode: 'dev001', mode: 'terminal', cachedName: '', tmuxInstance: '' }

--- a/spa/src/components/HistoryPage.tsx
+++ b/spa/src/components/HistoryPage.tsx
@@ -16,7 +16,7 @@ export function HistoryPage(_props: PaneRendererProps) {
   const sorted = [...browseHistory].reverse()
 
   return (
-    <div className="flex-1 flex flex-col overflow-y-auto p-4">
+    <div className="h-full w-full flex flex-col overflow-y-auto p-4">
       <h2 className="text-sm font-medium text-text-secondary mb-4">{t('page.history.title')}</h2>
       {sorted.length === 0 && (
         <p className="text-sm text-text-muted">{t('page.history.empty')}</p>

--- a/spa/src/components/NewTabPage.test.tsx
+++ b/spa/src/components/NewTabPage.test.tsx
@@ -203,4 +203,28 @@ describe('NewTabPage — module-aware provider filter', () => {
     expect(screen.queryByTestId('card-editor-buffers')).toBeNull()
     expect(screen.queryByTestId('card-sessions')).toBeNull()
   })
+
+  it('grid root fills its mount with h-full (not flex-1) so the scrollable column is bounded', () => {
+    // The new-tab pane mounts under TabContent's position:absolute wrapper (a
+    // plain block, not a flex container), so a `flex-1` root collapses to
+    // content height and the inner `overflow-y-auto` column never gets a
+    // bounded height to scroll within. The root must claim height via `h-full`
+    // (resolves against the block parent's definite inset:0 height), matching
+    // EditorPane. Guards against regressing the start-screen scroll.
+    registerNewTabProvider({
+      id: 'sessions',
+      label: 'session.provider_label',
+      icon: 'List',
+      order: 0,
+      component: FakeSessionsCard,
+    })
+    primeLayout(['sessions'])
+
+    const { container } = render(<NewTabPage onSelect={() => {}} />)
+    const root = container.firstChild as HTMLElement
+    expect(root.className).toContain('h-full')
+    expect(root.className).not.toContain('flex-1')
+    // The scroll column is still present underneath.
+    expect((root.firstChild as HTMLElement).className).toContain('overflow-y-auto')
+  })
 })

--- a/spa/src/components/NewTabPage.tsx
+++ b/spa/src/components/NewTabPage.tsx
@@ -45,12 +45,12 @@ export function NewTabPage({ onSelect }: Props) {
   const byId = useMemo(() => Object.fromEntries(providers.map((p) => [p.id, p])), [providers])
 
   if (!hydrated) {
-    return <div className="flex-1" />
+    return <div className="h-full w-full" />
   }
 
   if (providers.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center" data-testid="newtab-empty-state">
+      <div className="h-full w-full flex items-center justify-center" data-testid="newtab-empty-state">
         <p className="text-sm text-text-secondary">{t('page.newtab.empty')}</p>
       </div>
     )
@@ -66,7 +66,7 @@ export function NewTabPage({ onSelect }: Props) {
   const hasAnyVisibleEntry = profile.columns.some((col) => col.some((id) => byId[id]))
   if (!hasAnyVisibleEntry) {
     return (
-      <div className="flex-1 flex items-center justify-center" data-testid="newtab-empty-state">
+      <div className="h-full w-full flex items-center justify-center" data-testid="newtab-empty-state">
         <p className="text-sm text-text-secondary">{t('page.newtab.empty')}</p>
       </div>
     )
@@ -75,7 +75,7 @@ export function NewTabPage({ onSelect }: Props) {
   const gridCols = colsClass(profile.columns.length)
 
   return (
-    <div className={`flex-1 grid overflow-hidden gap-6 px-6 pt-8 ${gridCols}`}>
+    <div className={`h-full w-full grid overflow-hidden gap-6 px-6 pt-8 ${gridCols}`}>
       {profile.columns.map((col, i) => (
         <div key={`${profileKey}-${i}`} className="flex flex-col gap-6 overflow-y-auto">
           {col.map((id) => {


### PR DESCRIPTION
## 問題

「起始畫面（new-tab）」與「History pane」**無法捲動**。延續 #889 的同一個 bug class。

## 根因

`NewTabPage` / `HistoryPage` 的 root 用 `flex-1` 撐高，但 `TabContent` 的每分頁掛載層是 `position:absolute inset:0` 的純 block（非 flex container），`flex-1` 在其下失效 → root 塌成內容高 → 內層 `overflow-y-auto`（new-tab 欄 / history 列表）拿不到有界高度就不能捲，內容溢出被 `overflow-hidden` 裁掉、無捲軸。

`EditorPane` 與 `TerminalView` 本來就用 `h-full w-full`（解析 block 父層的 inset:0 明確高度），所以正常。

## 修法

`NewTabPage`（grid + empty-state + placeholder 四個 root return）與 `HistoryPage` root：`flex-1` → `h-full w-full`。

## 不受影響（已查證）

`HostPage` / `SettingsPage` 的 root 是 `flex h-full`，其 `flex-1 overflow-y-auto` 是正確 flex child → **本來就會捲、不動**。

## 驗證

- Playwright 還原 grid 鏈：`flex-1` 下 column 不可捲（scrollHeight==clientHeight）；`h-full` 下 scrollable=true（realistic 非壓縮內容，不需額外 grid-rows）。
- 回歸測試：兩 root 斷言 `h-full` 且非 `flex-1`（紅→綠）。
- vitest 3696 全綠 / lint / build OK。

## 注意

純 SPA 改動走 HMR；App 端需更新到含此修正的版本才生效。

關聯 #889（image/pdf preview 同 bug class）。源頭修法（TabContent wrapper 改 flex）因會動到 terminal 掛載契約（分割可能 reflow）暫不採，記為 follow-up。