### PR TITLE
feat(spa): markdown opens in Live Mode + fix Live Mode scroll jump on tab switch

### DIFF
--- a/spa/src/components/editor/EditorPane.test.tsx
+++ b/spa/src/components/editor/EditorPane.test.tsx
@@ -25,7 +25,7 @@ vi.mock('./MonacoWrapper', () => ({ MonacoWrapper: () => <div data-testid="monac
 vi.mock('./DiffView', () => ({ DiffView: () => null }))
 vi.mock('./EditorStatusBar', () => ({ EditorStatusBar: () => null }))
 vi.mock('../RenamePopover', () => ({ RenamePopover: () => null }))
-vi.mock('./TiptapEditor', () => ({ TiptapEditor: () => null }))
+vi.mock('./TiptapEditor', () => ({ TiptapEditor: () => <div data-testid="tiptap" /> }))
 
 // The unit under test: the quick-switch must route through openInAppFile.
 const openInAppFileMock = vi.fn()
@@ -162,5 +162,24 @@ describe('EditorPane — breadcrumb quick-switch (T6)', () => {
     const filePaths = setPaneContentSpy.mock.calls.map((c) => (c[2] as { filePath: string }).filePath)
     expect(filePaths).toEqual(['/buffer/Untitled.md', '/buffer/Untitled-1.md'])
     expect(new Set(filePaths).size).toBe(2)
+  })
+
+  it('opens a markdown file in Live Mode (wysiwyg) by default', async () => {
+    // beforeEach seeds a markdown buffer at FILE. With no explicit user mode
+    // choice (paneState.editorMode null), markdown must resolve to wysiwyg.
+    renderPane()
+    expect(await screen.findByTestId('tiptap')).toBeTruthy()
+    expect(screen.queryByTestId('monaco')).toBeNull()
+  })
+
+  it('opens a non-markdown file in raw (Monaco) by default', async () => {
+    // Same path, but the buffer language is plaintext → default resolves to raw.
+    useEditorStore.setState({ buffers: {}, paneStates: {} })
+    useEditorStore.getState().openBuffer(bufferKey({ type: 'inapp' }, FILE), 'plain', {
+      language: 'plaintext',
+    })
+    renderPane()
+    expect(await screen.findByTestId('monaco')).toBeTruthy()
+    expect(screen.queryByTestId('tiptap')).toBeNull()
   })
 })

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -123,7 +123,19 @@ function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { pan
   // onto the new one (attachPane rebuilds paneState to these exact defaults anyway).
   const alignedPaneState = paneState?.bufferKey === key ? paneState : undefined
   const isMarkdown = buffer?.language === 'markdown'
-  const editorMode = alignedPaneState?.editorMode ?? 'raw'
+  // Mode resolution, in order of precedence:
+  //   1. stale/unaligned paneState → raw. Deriving raw while paneState hasn't
+  //      rebound to THIS buffer keeps the #863 invariant: Tiptap (lazy) never
+  //      mounts against a stale paneState, and no `Loading editor…` Suspense
+  //      flicker paints during a buffer switch. The wysiwyg default only kicks
+  //      in once aligned.
+  //   2. aligned + explicit user choice (concrete editorMode) → that choice; it
+  //      wins and survives remounts.
+  //   3. aligned + no choice (editorMode null) → language default: markdown opens
+  //      in Live Mode (wysiwyg), everything else raw.
+  const editorMode = alignedPaneState
+    ? (alignedPaneState.editorMode ?? (isMarkdown ? 'wysiwyg' : 'raw'))
+    : 'raw'
   const effectiveEditorMode = isMarkdown ? editorMode : 'raw'
   const showDiff = alignedPaneState?.showDiff ?? false
   const canSave = buffer ? (buffer.isDirty || !buffer.lastStat) : false
@@ -460,13 +472,14 @@ function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { pan
             onSave={handleSave}
           />
         ) : (
-          /* wysiwyg path. effectiveEditorMode === 'wysiwyg' requires alignedPaneState
-             (editorMode came from alignedPaneState?.editorMode ?? 'raw'), so paneState
-             is guaranteed already rebound to THIS buffer — the stale-paneState window
-             can never reach here (it derives raw and renders Monaco instead). Mounting
-             TiptapEditor against the aligned paneState is therefore safe: its one-shot
-             restore reads the correct tiptapViewState and didRestoreRef is never locked
-             against a stale state (supersedes PR #862's R3 post-commit gating). */
+          /* wysiwyg path. effectiveEditorMode === 'wysiwyg' requires alignedPaneState:
+             the mode resolution derives raw whenever paneState is stale/unaligned (the
+             markdown → wysiwyg default only applies once aligned), so paneState is
+             guaranteed already rebound to THIS buffer here — the stale-paneState window
+             can never reach this branch (it derives raw and renders Monaco instead).
+             Mounting TiptapEditor against the aligned paneState is therefore safe: its
+             one-shot restore reads the correct tiptapViewState and didRestoreRef is never
+             locked against a stale state (supersedes PR #862's R3 post-commit gating). */
           <Suspense fallback={<div className="flex-1 flex items-center justify-center text-text-muted text-xs">Loading editor...</div>}>
             <TiptapEditor
               key={buffer.modelId}

--- a/spa/src/components/editor/TiptapEditor.test.tsx
+++ b/spa/src/components/editor/TiptapEditor.test.tsx
@@ -85,6 +85,9 @@ describe('TiptapEditor', () => {
     rerender(<TiptapEditor content="# Hello" isActive={true} onChange={() => {}} onSave={() => {}} />)
 
     expect(focusSpy).toHaveBeenCalledTimes(1)
+    // Re-activation focus must not scroll the caret into view — otherwise a
+    // scrolled document jumps to the top on every tab switch back.
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
   })
 
   it('focuses on the null→editor ready transition when active (AC2, M1)', () => {

--- a/spa/src/components/editor/TiptapEditor.tsx
+++ b/spa/src/components/editor/TiptapEditor.tsx
@@ -25,7 +25,11 @@ export function TiptapEditor({ content, isActive, initialViewState, onChange, on
   const hasInitializedRef = useRef(false)
 
   const focusEditable = () => {
-    containerRef.current?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus()
+    // preventScroll: refocusing on tab re-activation (the isActive false→true
+    // effect) must NOT scroll the caret into view — that jumps a scrolled
+    // document back to the top on every tab switch. Scroll position is owned by
+    // the container / restored viewState, never by focus.
+    containerRef.current?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus({ preventScroll: true })
   }
 
   useEffect(() => {

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -205,7 +205,7 @@ describe('EditorPane', () => {
   })
 
   it('passes active state through to the editor content for refocus', async () => {
-    const pane = createPane('/notes/focus.md')
+    const pane = createPane('/notes/focus.txt')
     const backend = createBackend()
     getFsBackendMock.mockReturnValue(backend)
     backend.read.mockResolvedValue(new TextEncoder().encode('hello world'))
@@ -219,7 +219,7 @@ describe('EditorPane', () => {
     const { rerender } = render(<EditorPane pane={pane} isActive={false} />)
 
     await waitFor(() => {
-      expect(useEditorStore.getState().buffers[getBufferKey('/notes/focus.md')]).toBeDefined()
+      expect(useEditorStore.getState().buffers[getBufferKey('/notes/focus.txt')]).toBeDefined()
     })
 
     rerender(<EditorPane pane={pane} isActive />)

--- a/spa/src/stores/useEditorStore.test.ts
+++ b/spa/src/stores/useEditorStore.test.ts
@@ -25,7 +25,9 @@ describe('useEditorStore', () => {
     })
     expect(state.paneStates['pane-b']).toMatchObject({
       bufferKey: 'key1',
-      editorMode: 'raw',
+      // null = no explicit choice yet; the component resolves the language
+      // default (markdown → wysiwyg, else raw) at render time.
+      editorMode: null,
       showDiff: false,
       cursorPosition: { line: 1, column: 1 },
     })
@@ -56,7 +58,9 @@ describe('useEditorStore', () => {
     expect(useEditorStore.getState().buffers['key-a']).toBeUndefined()
     expect(useEditorStore.getState().paneStates['pane-a']).toMatchObject({
       bufferKey: 'key-b',
-      editorMode: 'raw',
+      // switching buffers resets pane-local state to fresh defaults; editorMode
+      // null means "resolve language default at render" (key-b is markdown → wysiwyg).
+      editorMode: null,
       showDiff: false,
       cursorPosition: { line: 1, column: 1 },
     })

--- a/spa/src/stores/useEditorStore.ts
+++ b/spa/src/stores/useEditorStore.ts
@@ -31,7 +31,10 @@ export interface TiptapViewState {
 
 export interface EditorPaneState {
   bufferKey: string
-  editorMode: EditorMode
+  // null = no explicit user choice yet → resolve to the language default at
+  // render time (markdown → 'wysiwyg' Live Mode, everything else → 'raw').
+  // A concrete value means the user picked it; that survives remounts.
+  editorMode: EditorMode | null
   showDiff: boolean
   cursorPosition: { line: number; column: number }
   monacoViewState: editor.ICodeEditorViewState | null
@@ -63,7 +66,7 @@ let nextModelId = 1
 function createPaneState(bufferKey: string): EditorPaneState {
   return {
     bufferKey,
-    editorMode: 'raw',
+    editorMode: null,
     showDiff: false,
     cursorPosition: { line: 1, column: 1 },
     monacoViewState: null,


### PR DESCRIPTION
Batch A 的 editor 線，兩項各自獨立 commit。

## ① feat: markdown 預設開為 Live Mode（wysiwyg）
`.md` 原本開在 raw（Monaco），現在預設進 **Live Mode（Tiptap wysiwyg）**；非 markdown 維持 raw。

- `EditorPaneState.editorMode` 改為 `EditorMode | null`：`null` = 未明確選擇 → render 時解析語言預設（markdown→wysiwyg，其餘→raw）。使用者明確切換存具體值，優先且跨 remount（keep-alive / raw↔wysiwyg toggle）保留。
- 語言預設只在 paneState 對齊 buffer 後才套用；stale/未對齊仍 derive raw → 保住 #863 不變式（Tiptap lazy 不對 stale 掛載、buffer 切換不閃 `Loading editor…`）。

## ② fix: Live Mode 切 tab 回來跳頂
切走 markdown Live Mode tab 再切回會跳到最頂。根因：`isActive` false→true 的 effect 用純 `.focus()` 重聚焦 contenteditable，把游標（頂端）捲進視野。修法：`.focus({ preventScroll: true })`。

## 範圍說明
原本一併探索了「明確 mode 選擇跨 pane 換檔持久化」（per-buffer memory），但 codex 連續多輪抓到同一類 stale-path 問題（rename / delete / move 各是一個 path-reuse vector，且開/關檔覆蓋不一）——meta-drift 訊號。權衡後**撤回該持久化**：使用者在意的「切 tab 保持 mode」在 keep-alive 下本來就 work，不需該機制；只放棄較少見的「pane 換檔再回」持久化，換得零 stale-path class、無散落 invalidation hook。

## 驗證
- 回歸測試：markdown→wysiwyg / 非 md→raw；TiptapEditor 重新 active 的 focus 帶 `preventScroll`。#863 的 3 個守護測試維持綠。
- full vitest 3698 綠 / lint / build 通過。codex round-1 審此 ①② 版本無 finding。

純 SPA 改動走 HMR；App 需更新到含此的版本才生效。③（Typora 樣式）另開 PR。