### PR TITLE
feat: shift+click a URL opens the OS default browser (not a mini window)

### DIFF
--- a/electron/browser-view-ipc.ts
+++ b/electron/browser-view-ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow } from 'electron'
+import { ipcMain, BrowserWindow, shell } from 'electron'
 import { isAllowedUrl } from './browser-view-manager'
 import type { BrowserViewManager } from './browser-view-manager'
 import type { MiniWindowManager } from './mini-browser-window'
@@ -71,6 +71,13 @@ export function registerBrowserViewIpc(
     miniWindowManager.moveToTab(paneId)
   })
 
+  // Open a URL in the OS default browser. Scheme-guarded (http/https only) so a
+  // stray token can never hand file:// or a custom scheme to the OS handler.
+  ipcMain.handle('shell:open-external', (_event, url: string) => {
+    if (!isAllowedUrl(url)) return
+    return shell.openExternal(url)
+  })
+
   // --- State request (SPA loaded after view was created) ---
 
   ipcMain.handle('browser-view:request-state', (_event, paneId: string) => {
@@ -85,7 +92,9 @@ export function registerBrowserViewIpc(
     if (!isAllowedUrl(data.url)) return
 
     if (data.shiftKey) {
-      miniWindowManager.open(entry.window, data.url)
+      // Shift+Click inside a browser pane → OS default browser (consistent with
+      // terminal-link shift+click). Plain click still opens an in-app tab.
+      shell.openExternal(data.url)
     } else {
       // Notify parent window SPA to open new browser tab
       try {

--- a/electron/browser-view-ipc.ts
+++ b/electron/browser-view-ipc.ts
@@ -3,6 +3,19 @@ import { isAllowedUrl } from './browser-view-manager'
 import type { BrowserViewManager } from './browser-view-manager'
 import type { MiniWindowManager } from './mini-browser-window'
 
+// Open a URL in the OS default browser, scheme-guarded and never rejecting.
+// shell.openExternal can reject (no OS handler, platform failure); we catch so
+// neither the fire-and-forget link-click path nor the ipcMain.handle path can
+// surface an unhandled promise rejection in the main process.
+async function openAllowedExternalUrl(url: string): Promise<void> {
+  if (!isAllowedUrl(url)) return
+  try {
+    await shell.openExternal(url)
+  } catch (err) {
+    console.error('[browser-view] shell.openExternal failed:', err)
+  }
+}
+
 export function registerBrowserViewIpc(
   manager: BrowserViewManager,
   miniWindowManager: MiniWindowManager,
@@ -73,10 +86,9 @@ export function registerBrowserViewIpc(
 
   // Open a URL in the OS default browser. Scheme-guarded (http/https only) so a
   // stray token can never hand file:// or a custom scheme to the OS handler.
-  ipcMain.handle('shell:open-external', (_event, url: string) => {
-    if (!isAllowedUrl(url)) return
-    return shell.openExternal(url)
-  })
+  // Always resolves (failures are caught + logged), so the renderer's invoke
+  // never rejects.
+  ipcMain.handle('shell:open-external', (_event, url: string) => openAllowedExternalUrl(url))
 
   // --- State request (SPA loaded after view was created) ---
 
@@ -94,7 +106,8 @@ export function registerBrowserViewIpc(
     if (data.shiftKey) {
       // Shift+Click inside a browser pane → OS default browser (consistent with
       // terminal-link shift+click). Plain click still opens an in-app tab.
-      shell.openExternal(data.url)
+      // Fire-and-forget; the helper catches so there is no unhandled rejection.
+      void openAllowedExternalUrl(data.url)
     } else {
       // Notify parent window SPA to open new browser tab
       try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -53,6 +53,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Browser View — mini window
   browserViewOpenMiniWindow: (url: string) =>
     ipcRenderer.invoke('browser-view:open-mini-window', url),
+  // Open a URL in the OS default browser (main-process shell.openExternal).
+  openExternalUrl: (url: string) =>
+    ipcRenderer.invoke('shell:open-external', url),
   browserViewMoveToTab: (paneId: string) =>
     ipcRenderer.invoke('browser-view:move-to-tab', paneId),
 

--- a/spa/src/lib/register-modules/index.tsx
+++ b/spa/src/lib/register-modules/index.tsx
@@ -396,7 +396,7 @@ export function registerBuiltinModules(): void {
     urlOpener: {
       isElectron: caps.isElectron,
       openBrowserTab,
-      openMiniWindow: (url) => window.electronAPI?.browserViewOpenMiniWindow(url),
+      openExternal: (url) => window.electronAPI?.openExternalUrl(url),
     },
     filePathOpener: {
       // P5: file-path opener now drives the openFile pipeline (stat → cache

--- a/spa/src/lib/terminal-link/openers/url.test.ts
+++ b/spa/src/lib/terminal-link/openers/url.test.ts
@@ -12,49 +12,49 @@ describe('url opener', () => {
   beforeEach(() => { vi.restoreAllMocks() })
 
   it('canOpen true only for type url', () => {
-    const o = createUrlOpener({ isElectron: false, openBrowserTab: vi.fn(), openMiniWindow: vi.fn() })
+    const o = createUrlOpener({ isElectron: false, openBrowserTab: vi.fn(), openExternal: vi.fn() })
     expect(o.canOpen(token)).toBe(true)
     expect(o.canOpen({ ...token, type: 'file' })).toBe(false)
   })
 
   it('web: uses window.open with _blank', () => {
     const spy = vi.spyOn(window, 'open').mockImplementation(() => null)
-    const o = createUrlOpener({ isElectron: false, openBrowserTab: vi.fn(), openMiniWindow: vi.fn() })
+    const o = createUrlOpener({ isElectron: false, openBrowserTab: vi.fn(), openExternal: vi.fn() })
     o.open(token, {}, new MouseEvent('click'))
     expect(spy).toHaveBeenCalledWith('https://example.com', '_blank')
   })
 
   it('electron normal click: openBrowserTab', () => {
     const openBrowserTab = vi.fn()
-    const openMiniWindow = vi.fn()
-    const o = createUrlOpener({ isElectron: true, openBrowserTab, openMiniWindow })
+    const openExternal = vi.fn()
+    const o = createUrlOpener({ isElectron: true, openBrowserTab, openExternal })
     o.open(token, {}, new MouseEvent('click'))
     expect(openBrowserTab).toHaveBeenCalledWith('https://example.com')
-    expect(openMiniWindow).not.toHaveBeenCalled()
+    expect(openExternal).not.toHaveBeenCalled()
   })
 
-  it('electron shift+click: openMiniWindow', () => {
+  it('electron shift+click: openExternal (OS default browser)', () => {
     const openBrowserTab = vi.fn()
-    const openMiniWindow = vi.fn()
-    const o = createUrlOpener({ isElectron: true, openBrowserTab, openMiniWindow })
+    const openExternal = vi.fn()
+    const o = createUrlOpener({ isElectron: true, openBrowserTab, openExternal })
     o.open(token, {}, new MouseEvent('click', { shiftKey: true }))
-    expect(openMiniWindow).toHaveBeenCalledWith('https://example.com')
+    expect(openExternal).toHaveBeenCalledWith('https://example.com')
     expect(openBrowserTab).not.toHaveBeenCalled()
   })
 
   it('rejects non-http(s) schemes regardless of matcher output', () => {
     const openBrowserTab = vi.fn()
-    const openMiniWindow = vi.fn()
+    const openExternal = vi.fn()
     const webSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-    const electron = createUrlOpener({ isElectron: true, openBrowserTab, openMiniWindow })
-    const web = createUrlOpener({ isElectron: false, openBrowserTab, openMiniWindow })
+    const electron = createUrlOpener({ isElectron: true, openBrowserTab, openExternal })
+    const web = createUrlOpener({ isElectron: false, openBrowserTab, openExternal })
 
     for (const uri of ['javascript:alert(1)', 'data:text/html,<script>x</script>', 'file:///etc/passwd']) {
       electron.open({ ...token, text: uri }, {}, new MouseEvent('click'))
       web.open({ ...token, text: uri }, {}, new MouseEvent('click'))
     }
     expect(openBrowserTab).not.toHaveBeenCalled()
-    expect(openMiniWindow).not.toHaveBeenCalled()
+    expect(openExternal).not.toHaveBeenCalled()
     expect(webSpy).not.toHaveBeenCalled()
   })
 })

--- a/spa/src/lib/terminal-link/openers/url.ts
+++ b/spa/src/lib/terminal-link/openers/url.ts
@@ -3,7 +3,8 @@ import type { LinkOpener } from '../types'
 export interface UrlOpenerDeps {
   isElectron: boolean
   openBrowserTab: (url: string) => void
-  openMiniWindow: (url: string) => void
+  // Open in the OS default browser (Electron shell.openExternal).
+  openExternal: (url: string) => void
 }
 
 export function createUrlOpener(deps: UrlOpenerDeps): LinkOpener {
@@ -17,8 +18,8 @@ export function createUrlOpener(deps: UrlOpenerDeps): LinkOpener {
       // 兜底檢查 scheme：即使第三方 matcher 誤產 token，也不會把 `javascript:` / `data:` 傳到 window.open
       if (!uri.startsWith('http://') && !uri.startsWith('https://')) return
       if (deps.isElectron) {
-        // Shift+Click 開在 mini window，普通 click 開在 browser tab
-        if (event.shiftKey) deps.openMiniWindow(uri)
+        // Shift+Click 開在 OS 預設瀏覽器，普通 click 開在 app 內 browser tab
+        if (event.shiftKey) deps.openExternal(uri)
         else deps.openBrowserTab(uri)
       } else {
         window.open(uri, '_blank')

--- a/spa/src/lib/terminal-link/register.test.ts
+++ b/spa/src/lib/terminal-link/register.test.ts
@@ -7,7 +7,7 @@ describe('registerBuiltinTerminalLinks', () => {
 
   it('registers both url and file-path matchers', () => {
     registerBuiltinTerminalLinks({
-      urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
+      urlOpener: { isElectron: false, openBrowserTab: () => {}, openExternal: () => {} },
       filePathOpener: {
         tryOpenFile: async () => {},
         openAsBuffer: () => {},
@@ -24,7 +24,7 @@ describe('registerBuiltinTerminalLinks', () => {
 
   it('is idempotent — double call does not double-register matchers or openers', () => {
     const deps = {
-      urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
+      urlOpener: { isElectron: false, openBrowserTab: () => {}, openExternal: () => {} },
       filePathOpener: {
         tryOpenFile: async () => {},
         openAsBuffer: () => {},
@@ -51,7 +51,7 @@ describe('registerBuiltinTerminalLinks — 4 file-path matchers', () => {
 
   it('registers all 4 file-path matchers', () => {
     registerBuiltinTerminalLinks({
-      urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
+      urlOpener: { isElectron: false, openBrowserTab: () => {}, openExternal: () => {} },
       filePathOpener: {
         tryOpenFile: async () => {},
         openAsBuffer: () => {},
@@ -75,7 +75,7 @@ describe('registerBuiltinTerminalLinks — 4 file-path matchers', () => {
   // independent and always registers.
   it('skips ALL four file-path matchers when fileMatchersEnabled=false', () => {
     registerBuiltinTerminalLinks({
-      urlOpener: { isElectron: false, openBrowserTab: () => {}, openMiniWindow: () => {} },
+      urlOpener: { isElectron: false, openBrowserTab: () => {}, openExternal: () => {} },
       filePathOpener: {
         tryOpenFile: async () => {},
         openAsBuffer: () => {},

--- a/spa/src/types/electron.d.ts
+++ b/spa/src/types/electron.d.ts
@@ -84,6 +84,7 @@ interface Window {
     browserViewPrint: (paneId: string) => Promise<void>
     destroyBrowserView: (paneId: string) => Promise<void>
     browserViewOpenMiniWindow: (url: string) => Promise<void>
+    openExternalUrl: (url: string) => Promise<void>
     browserViewMoveToTab: (paneId: string) => Promise<void>
     requestBrowserViewState: (paneId: string) => Promise<void>
     onBrowserViewStateUpdate: (callback: (paneId: string, state: { url: string; title: string; canGoBack: boolean; canGoForward: boolean; isLoading: boolean }) => void) => () => void


### PR DESCRIPTION
Batch A 第 ④ 項。

## 需求
終端機（及 browser pane 內）點 URL：一般點擊 → app 內 tab（現況已如此）；**shift+click 原本開 Electron 迷你視窗，改為開「OS 預設瀏覽器」**。

## 改動
- **SPA**：url opener 的 `openMiniWindow` dep 改成 `openExternal`，shift 分支呼叫它；接到新的 `window.electronAPI.openExternalUrl` bridge。
- **Electron**：preload 曝 `openExternalUrl` → 新增 `shell:open-external` IPC handler，先用既有 `isAllowedUrl`（僅 http/https）做 scheme 防護再 `shell.openExternal`。browser pane 內連結點擊的 shift 分支也從迷你視窗改為 `shell.openExternal`（一致性）。
- 迷你視窗路徑**保留**給 browser pane 的「pop out」按鈕。非 Electron（純瀏覽器）行為不變。

## 驗證
- 回歸測試：shift+click 呼叫 openExternal（非開 tab）；非 http(s) scheme 仍被拒。
- electron `tsc --noEmit` 乾淨 / full SPA vitest 3696 綠 / lint / build 通過。

## ⚠️ 部署注意
此 PR 改到 **Electron main（IPC）+ preload**，依 CLAUDE.md 這類改動**不走 SPA HMR**——你 Air 端要**重打包 + dev update** 才會生效。