### PR TITLE
fix(spa): keep light (non-terminal) tabs alive across switches (Live Mode scroll)

### DIFF
--- a/spa/src/components/TabContent.tsx
+++ b/spa/src/components/TabContent.tsx
@@ -1,5 +1,6 @@
 import { PaneLayoutRenderer } from './PaneLayoutRenderer'
 import { useTabAlivePool } from '../hooks/useTabAlivePool'
+import { isLightTab } from '../lib/pane-weight'
 import type { Tab } from '../types/tab'
 
 interface Props {
@@ -10,7 +11,7 @@ interface Props {
 export function TabContent({ activeTab, allTabs }: Props) {
   const { aliveIds, poolVersion } = useTabAlivePool(
     activeTab?.id ?? null,
-    allTabs.map((t) => ({ id: t.id, pinned: t.pinned })),
+    allTabs.map((t) => ({ id: t.id, pinned: t.pinned, light: isLightTab(t.layout) })),
   )
 
   const tabMap = new Map(allTabs.map((t) => [t.id, t]))

--- a/spa/src/hooks/useTabAlivePool.test.ts
+++ b/spa/src/hooks/useTabAlivePool.test.ts
@@ -103,6 +103,21 @@ describe('useTabAlivePool', () => {
     }
   })
 
+  it('pinned light tabs are budget-exempt (keepAlivePinned keeps all, even beyond MAX)', () => {
+    resetSettings({ keepAliveCount: 0, keepAlivePinned: true })
+    const n = LIGHT_KEEP_ALIVE_MAX + 2
+    const tabs: MockTab[] = Array.from({ length: n }, (_, i) => ({
+      id: `ed${i}`, pinned: true, light: true,
+    }))
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useTabAlivePool(activeId, tabs),
+      { initialProps: { activeId: 'ed0' as string } },
+    )
+    for (let i = 1; i < n; i++) rerender({ activeId: `ed${i}` })
+    // All pinned light tabs stay alive despite exceeding LIGHT_KEEP_ALIVE_MAX.
+    for (let i = 0; i < n; i++) expect(result.current.aliveIds).toContain(`ed${i}`)
+  })
+
   it('an active LIGHT tab does not shrink the heavy budget (maxNormal = keepAliveCount)', () => {
     resetSettings({ keepAliveCount: 1 })
     const tabs: MockTab[] = [

--- a/spa/src/hooks/useTabAlivePool.test.ts
+++ b/spa/src/hooks/useTabAlivePool.test.ts
@@ -13,10 +13,52 @@ function resetSettings(overrides?: { keepAliveCount?: number; keepAlivePinned?: 
   })
 }
 
-interface MockTab { id: string; pinned: boolean }
+interface MockTab { id: string; pinned: boolean; light?: boolean }
 
 describe('useTabAlivePool', () => {
   beforeEach(() => resetSettings())
+
+  it('light tabs stay alive at keepAliveCount=0 (not just the active tab)', () => {
+    // Editor/preview/settings tabs are light → always kept alive so they never
+    // remount on a tab switch, independent of the terminal-oriented keepAliveCount.
+    const tabs: MockTab[] = [
+      { id: 'ed1', pinned: false, light: true },
+      { id: 'ed2', pinned: false, light: true },
+    ]
+    const { result } = renderHook(() => useTabAlivePool('ed1', tabs))
+    expect(result.current.aliveIds).toContain('ed1')
+    expect(result.current.aliveIds).toContain('ed2')
+  })
+
+  it('heavy tabs remain bounded by keepAliveCount=0 (only the active heavy tab)', () => {
+    const tabs: MockTab[] = [
+      { id: 't1', pinned: false }, // heavy (light omitted)
+      { id: 't2', pinned: false },
+    ]
+    const { result } = renderHook(() => useTabAlivePool('t1', tabs))
+    expect(result.current.aliveIds).toEqual(['t1'])
+  })
+
+  it('mixed pool at keepAliveCount=0: all light alive + only the active heavy', () => {
+    const tabs: MockTab[] = [
+      { id: 'term', pinned: false }, // heavy
+      { id: 'ed1', pinned: false, light: true },
+      { id: 'ed2', pinned: false, light: true },
+    ]
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useTabAlivePool(activeId, tabs),
+      { initialProps: { activeId: 'term' as string } },
+    )
+    // term active heavy → alive; both editors light → alive.
+    expect(result.current.aliveIds).toEqual(expect.arrayContaining(['term', 'ed1', 'ed2']))
+
+    // Switch to a light tab: the heavy terminal is no longer active → evicted
+    // (keepAliveCount=0), but both editors stay alive.
+    rerender({ activeId: 'ed1' })
+    expect(result.current.aliveIds).toContain('ed1')
+    expect(result.current.aliveIds).toContain('ed2')
+    expect(result.current.aliveIds).not.toContain('term')
+  })
 
   it('keepAliveCount=0: pool only contains activeTabId', () => {
     const tabs: MockTab[] = [

--- a/spa/src/hooks/useTabAlivePool.test.ts
+++ b/spa/src/hooks/useTabAlivePool.test.ts
@@ -60,6 +60,26 @@ describe('useTabAlivePool', () => {
     expect(result.current.aliveIds).not.toContain('term')
   })
 
+  it('an active LIGHT tab does not shrink the heavy budget (maxNormal = keepAliveCount)', () => {
+    resetSettings({ keepAliveCount: 1 })
+    const tabs: MockTab[] = [
+      { id: 'term1', pinned: false },
+      { id: 'term2', pinned: false },
+      { id: 'ed', pinned: false, light: true },
+    ]
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useTabAlivePool(activeId, tabs),
+      { initialProps: { activeId: 'term1' as string } },
+    )
+    rerender({ activeId: 'term2' })
+    rerender({ activeId: 'ed' })
+    // active is light → keepAliveCount(1) heavy tabs kept = term2 (most recent
+    // heavy). term1 evicted. ed (light) always alive.
+    expect(result.current.aliveIds).toContain('ed')
+    expect(result.current.aliveIds).toContain('term2')
+    expect(result.current.aliveIds).not.toContain('term1')
+  })
+
   it('keepAliveCount=0: pool only contains activeTabId', () => {
     const tabs: MockTab[] = [
       { id: 'a', pinned: false },

--- a/spa/src/hooks/useTabAlivePool.test.ts
+++ b/spa/src/hooks/useTabAlivePool.test.ts
@@ -82,6 +82,27 @@ describe('useTabAlivePool', () => {
     expect(result.current.aliveIds).not.toContain('term')
   })
 
+  it('keeps light tabs alive after many interleaved heavy-tab visits (history trim invariant)', () => {
+    const lightTabs: MockTab[] = Array.from({ length: LIGHT_KEEP_ALIVE_MAX }, (_, i) => ({
+      id: `ed${i}`, pinned: false, light: true,
+    }))
+    const heavyTabs: MockTab[] = Array.from({ length: 25 }, (_, i) => ({ id: `t${i}`, pinned: false }))
+    const tabs = [...lightTabs, ...heavyTabs]
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useTabAlivePool(activeId, tabs),
+      { initialProps: { activeId: 'ed0' as string } },
+    )
+    // Visit all light tabs, then churn through far more heavy tabs than the old
+    // length-based history cap would retain.
+    for (let i = 1; i < LIGHT_KEEP_ALIVE_MAX; i++) rerender({ activeId: `ed${i}` })
+    for (let i = 0; i < 25; i++) rerender({ activeId: `t${i}` })
+    // Every light tab (none evicted by the light LRU — exactly MAX of them) must
+    // still be alive despite the heavy churn.
+    for (let i = 0; i < LIGHT_KEEP_ALIVE_MAX; i++) {
+      expect(result.current.aliveIds).toContain(`ed${i}`)
+    }
+  })
+
   it('an active LIGHT tab does not shrink the heavy budget (maxNormal = keepAliveCount)', () => {
     resetSettings({ keepAliveCount: 1 })
     const tabs: MockTab[] = [

--- a/spa/src/hooks/useTabAlivePool.test.ts
+++ b/spa/src/hooks/useTabAlivePool.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useTabAlivePool } from './useTabAlivePool'
+import { useTabAlivePool, LIGHT_KEEP_ALIVE_MAX } from './useTabAlivePool'
 import { useUISettingsStore } from '../stores/useUISettingsStore'
 
 function resetSettings(overrides?: { keepAliveCount?: number; keepAlivePinned?: boolean }) {
@@ -18,16 +18,37 @@ interface MockTab { id: string; pinned: boolean; light?: boolean }
 describe('useTabAlivePool', () => {
   beforeEach(() => resetSettings())
 
-  it('light tabs stay alive at keepAliveCount=0 (not just the active tab)', () => {
-    // Editor/preview/settings tabs are light → always kept alive so they never
-    // remount on a tab switch, independent of the terminal-oriented keepAliveCount.
+  it('recently-visited light tabs stay alive at keepAliveCount=0 (not just the active tab)', () => {
+    // Editor/preview tabs are light → kept alive across switches (up to
+    // LIGHT_KEEP_ALIVE_MAX), independent of the terminal-oriented keepAliveCount.
     const tabs: MockTab[] = [
       { id: 'ed1', pinned: false, light: true },
       { id: 'ed2', pinned: false, light: true },
     ]
-    const { result } = renderHook(() => useTabAlivePool('ed1', tabs))
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useTabAlivePool(activeId, tabs),
+      { initialProps: { activeId: 'ed1' as string } },
+    )
+    rerender({ activeId: 'ed2' }) // visit ed2 so it enters history
+    rerender({ activeId: 'ed1' })
     expect(result.current.aliveIds).toContain('ed1')
     expect(result.current.aliveIds).toContain('ed2')
+  })
+
+  it('light tabs are LRU-bounded to LIGHT_KEEP_ALIVE_MAX (oldest evicted)', () => {
+    const n = LIGHT_KEEP_ALIVE_MAX + 1
+    const tabs: MockTab[] = Array.from({ length: n }, (_, i) => ({
+      id: `ed${i}`, pinned: false, light: true,
+    }))
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useTabAlivePool(activeId, tabs),
+      { initialProps: { activeId: 'ed0' as string } },
+    )
+    for (let i = 1; i < n; i++) rerender({ activeId: `ed${i}` })
+    // Visited ed0..ed{n-1}; keep the MAX most recent → ed0 (oldest) evicts.
+    expect(result.current.aliveIds).toHaveLength(LIGHT_KEEP_ALIVE_MAX)
+    expect(result.current.aliveIds).toContain(`ed${n - 1}`)
+    expect(result.current.aliveIds).not.toContain('ed0')
   })
 
   it('heavy tabs remain bounded by keepAliveCount=0 (only the active heavy tab)', () => {
@@ -49,11 +70,12 @@ describe('useTabAlivePool', () => {
       ({ activeId }) => useTabAlivePool(activeId, tabs),
       { initialProps: { activeId: 'term' as string } },
     )
-    // term active heavy → alive; both editors light → alive.
-    expect(result.current.aliveIds).toEqual(expect.arrayContaining(['term', 'ed1', 'ed2']))
+    // Active heavy terminal is alive; editors not visited yet.
+    expect(result.current.aliveIds).toContain('term')
 
-    // Switch to a light tab: the heavy terminal is no longer active → evicted
-    // (keepAliveCount=0), but both editors stay alive.
+    // Visit both editors, then land on ed1: the heavy terminal is no longer
+    // active → evicted (keepAliveCount=0), but both light editors stay alive.
+    rerender({ activeId: 'ed2' })
     rerender({ activeId: 'ed1' })
     expect(result.current.aliveIds).toContain('ed1')
     expect(result.current.aliveIds).toContain('ed2')

--- a/spa/src/hooks/useTabAlivePool.ts
+++ b/spa/src/hooks/useTabAlivePool.ts
@@ -110,13 +110,31 @@ export function useTabAlivePool(activeTabId: string | null, tabs: MinimalTab[]) 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTabId, keepAliveCount, keepAlivePinned, tabMap, settingsVersion])
 
-  // Trim history to prevent unbounded growth
+  // Trim history to prevent unbounded growth WITHOUT dropping any tab that could
+  // still be kept alive. A plain length cap is wrong here: light and heavy tabs
+  // share one history, so after enough heavy visits a still-recent light tab
+  // would slide past the cut and be forgotten (then remount, losing its state).
+  // Instead keep, newest-first, the LIGHT_KEEP_ALIVE_MAX most-recent light tabs,
+  // a generous heavy buffer, and all pinned tabs; drop the rest.
   useEffect(() => {
-    const maxHistory = Math.max(keepAliveCount + 10, 20)
-    if (historyRef.current.length > maxHistory) {
-      historyRef.current = historyRef.current.slice(0, maxHistory)
+    const h = historyRef.current
+    const heavyBudget = Math.max(keepAliveCount + 10, 20)
+    let lightKept = 0
+    let heavyKept = 0
+    const kept: string[] = []
+    for (const id of h) {
+      const tab = tabMap.get(id)
+      if (!tab) continue // closed tab (already filtered at render, defensive)
+      if (keepAlivePinned && tab.pinned) {
+        kept.push(id)
+      } else if (tab.light) {
+        if (lightKept < LIGHT_KEEP_ALIVE_MAX) { kept.push(id); lightKept++ }
+      } else if (heavyKept < heavyBudget) {
+        kept.push(id); heavyKept++
+      }
     }
-  }, [activeTabId, keepAliveCount])
+    if (kept.length !== h.length) historyRef.current = kept
+  }, [activeTabId, keepAliveCount, keepAlivePinned, tabMap])
 
   return { aliveIds, poolVersion: settingsVersion }
 }

--- a/spa/src/hooks/useTabAlivePool.ts
+++ b/spa/src/hooks/useTabAlivePool.ts
@@ -93,17 +93,22 @@ export function useTabAlivePool(activeTabId: string | null, tabs: MinimalTab[]) 
     // Light tabs bypass keepAliveCount but are LRU-bounded to
     // LIGHT_KEEP_ALIVE_MAX (most-recent-first via history) so retention is not
     // unbounded. The active tab is always the head of history, so if it is light
-    // it is always within the budget → always alive.
+    // it is always within the budget → always alive. Pinned light tabs are
+    // budget-exempt (the keepAlivePinned contract), matching pinned heavy tabs.
     const seen = new Set(heavyAlive)
     const result = [...heavyAlive]
     let lightCount = 0
     for (const id of h) {
-      if (lightCount >= LIGHT_KEEP_ALIVE_MAX) break
       const tab = tabMap.get(id)
       if (!tab || !tab.light || seen.has(id)) continue
-      seen.add(id)
-      result.push(id)
-      lightCount++
+      if (keepAlivePinned && tab.pinned) {
+        seen.add(id)
+        result.push(id)
+      } else if (lightCount < LIGHT_KEEP_ALIVE_MAX) {
+        seen.add(id)
+        result.push(id)
+        lightCount++
+      }
     }
     return result
     // historyRef.current is mutated synchronously above, not a reactive dep

--- a/spa/src/hooks/useTabAlivePool.ts
+++ b/spa/src/hooks/useTabAlivePool.ts
@@ -1,13 +1,19 @@
 import { useEffect, useRef, useMemo } from 'react'
 import { useUISettingsStore } from '../stores/useUISettingsStore'
 
+// Light tabs are cheap relative to terminals but NOT free (each keeps a Monaco /
+// Tiptap instance, image/PDF Blob URL, etc.). Keep the most-recently-visited N
+// alive — enough that the working set survives tab switches without a remount —
+// while bounding memory instead of retaining every light tab ever opened.
+export const LIGHT_KEEP_ALIVE_MAX = 8
+
 interface MinimalTab {
   id: string
   pinned: boolean
-  // Light tabs (no terminal/browser pane) are cheap and always kept alive so
-  // their state survives tab switches without a remount. keepAliveCount bounds
-  // only heavy tabs. Absent → treated as heavy (preserves callers/tests that
-  // don't classify their tabs).
+  // Light tabs (no terminal/browser pane) bypass keepAliveCount and are kept
+  // alive up to LIGHT_KEEP_ALIVE_MAX (most-recent-first) so their state survives
+  // tab switches without a remount. Absent → treated as heavy (preserves
+  // callers/tests that don't classify their tabs).
   light?: boolean
 }
 
@@ -84,14 +90,20 @@ export function useTabAlivePool(activeTabId: string | null, tabs: MinimalTab[]) 
       heavyAlive = [...pinnedAlive, ...alive]
     }
 
-    // Light tabs are cheap → always alive, independent of keepAliveCount.
+    // Light tabs bypass keepAliveCount but are LRU-bounded to
+    // LIGHT_KEEP_ALIVE_MAX (most-recent-first via history) so retention is not
+    // unbounded. The active tab is always the head of history, so if it is light
+    // it is always within the budget → always alive.
     const seen = new Set(heavyAlive)
     const result = [...heavyAlive]
-    for (const t of tabMap.values()) {
-      if (t.light && !seen.has(t.id)) {
-        seen.add(t.id)
-        result.push(t.id)
-      }
+    let lightCount = 0
+    for (const id of h) {
+      if (lightCount >= LIGHT_KEEP_ALIVE_MAX) break
+      const tab = tabMap.get(id)
+      if (!tab || !tab.light || seen.has(id)) continue
+      seen.add(id)
+      result.push(id)
+      lightCount++
     }
     return result
     // historyRef.current is mutated synchronously above, not a reactive dep

--- a/spa/src/hooks/useTabAlivePool.ts
+++ b/spa/src/hooks/useTabAlivePool.ts
@@ -4,6 +4,11 @@ import { useUISettingsStore } from '../stores/useUISettingsStore'
 interface MinimalTab {
   id: string
   pinned: boolean
+  // Light tabs (no terminal/browser pane) are cheap and always kept alive so
+  // their state survives tab switches without a remount. keepAliveCount bounds
+  // only heavy tabs. Absent → treated as heavy (preserves callers/tests that
+  // don't classify their tabs).
+  light?: boolean
 }
 
 export function useTabAlivePool(activeTabId: string | null, tabs: MinimalTab[]) {
@@ -46,29 +51,43 @@ export function useTabAlivePool(activeTabId: string | null, tabs: MinimalTab[]) 
 
   const aliveIds = useMemo(() => {
     const h = historyRef.current
+
+    // Heavy tabs (terminal/browser) follow the keepAliveCount LRU exactly as
+    // before. Light tabs are excluded from that bound and appended afterwards,
+    // so with no light tabs the result is byte-identical to the original.
+    let heavyAlive: string[]
     if (keepAliveCount === 0) {
-      return activeTabId ? [activeTabId] : []
-    }
+      heavyAlive = activeTabId && !tabMap.get(activeTabId)?.light ? [activeTabId] : []
+    } else {
+      const alive: string[] = []
+      const pinnedAlive: string[] = []
+      const maxNormal = keepAliveCount + 1 // +1 for active tab
+      let normalCount = 0
 
-    const alive: string[] = []
-    const pinnedAlive: string[] = []
-    const maxNormal = keepAliveCount + 1 // +1 for active tab
-    let normalCount = 0
-
-    for (const id of h) {
-      const tab = tabMap.get(id)
-      if (!tab) continue
-      if (keepAlivePinned && tab.pinned) {
-        // Pinned tabs kept alive separately, don't count toward normal limit
-        pinnedAlive.push(id)
-      } else {
-        if (normalCount < maxNormal) {
+      for (const id of h) {
+        const tab = tabMap.get(id)
+        if (!tab || tab.light) continue
+        if (keepAlivePinned && tab.pinned) {
+          // Pinned tabs kept alive separately, don't count toward normal limit
+          pinnedAlive.push(id)
+        } else if (normalCount < maxNormal) {
           alive.push(id)
           normalCount++
         }
       }
+      heavyAlive = [...pinnedAlive, ...alive]
     }
-    return [...pinnedAlive, ...alive]
+
+    // Light tabs are cheap → always alive, independent of keepAliveCount.
+    const seen = new Set(heavyAlive)
+    const result = [...heavyAlive]
+    for (const t of tabMap.values()) {
+      if (t.light && !seen.has(t.id)) {
+        seen.add(t.id)
+        result.push(t.id)
+      }
+    }
+    return result
     // historyRef.current is mutated synchronously above, not a reactive dep
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTabId, keepAliveCount, keepAlivePinned, tabMap, settingsVersion])

--- a/spa/src/hooks/useTabAlivePool.ts
+++ b/spa/src/hooks/useTabAlivePool.ts
@@ -61,7 +61,13 @@ export function useTabAlivePool(activeTabId: string | null, tabs: MinimalTab[]) 
     } else {
       const alive: string[] = []
       const pinnedAlive: string[] = []
-      const maxNormal = keepAliveCount + 1 // +1 for active tab
+      // keepAliveCount is the number of INACTIVE heavy tabs kept. The active tab
+      // only claims one of those slots when it is itself heavy; when the active
+      // tab is light it is kept alive separately and must not shrink the heavy
+      // budget. (With no light tabs the active tab is heavy → +1 → byte-identical
+      // to the original.)
+      const activeIsHeavy = activeTabId ? !tabMap.get(activeTabId)?.light : false
+      const maxNormal = keepAliveCount + (activeIsHeavy ? 1 : 0)
       let normalCount = 0
 
       for (const id of h) {

--- a/spa/src/lib/pane-weight.test.ts
+++ b/spa/src/lib/pane-weight.test.ts
@@ -26,6 +26,14 @@ describe('isLightTab', () => {
     expect(isLightTab(leaf(browser))).toBe(false)
   })
 
+  it('background-working / unknown kinds are heavy (allowlist: not always-alive)', () => {
+    // memory-monitor polls while mounted → must be bounded, not always alive.
+    expect(isLightTab(leaf({ kind: 'memory-monitor' }))).toBe(false)
+    // editor-buffers (storage pane) + hosts do their own fetching → heavy.
+    expect(isLightTab(leaf({ kind: 'editor-buffers' }))).toBe(false)
+    expect(isLightTab(leaf({ kind: 'hosts' }))).toBe(false)
+  })
+
   it('a split is heavy if ANY leaf is heavy', () => {
     const editorPlusTerminal: PaneLayout = {
       type: 'split', id: 'sp', direction: 'h', sizes: [50, 50],

--- a/spa/src/lib/pane-weight.test.ts
+++ b/spa/src/lib/pane-weight.test.ts
@@ -14,11 +14,11 @@ const browser: PaneContent = { kind: 'browser', url: 'https://x' }
 const image: PaneContent = { kind: 'image-preview', source: { type: 'inapp' }, filePath: '/a.png' }
 
 describe('isLightTab', () => {
-  it('a single editor / preview / settings pane is light', () => {
+  it('self-contained, statically-rendered kinds are light', () => {
     expect(isLightTab(leaf(editor))).toBe(true)
     expect(isLightTab(leaf(image))).toBe(true)
-    expect(isLightTab(leaf({ kind: 'settings', scope: 'global' }))).toBe(true)
-    expect(isLightTab(leaf({ kind: 'new-tab' }))).toBe(true)
+    expect(isLightTab(leaf({ kind: 'dashboard' }))).toBe(true)
+    expect(isLightTab(leaf({ kind: 'history' }))).toBe(true)
   })
 
   it('a terminal or browser pane is heavy (not light)', () => {
@@ -26,12 +26,15 @@ describe('isLightTab', () => {
     expect(isLightTab(leaf(browser))).toBe(false)
   })
 
-  it('background-working / unknown kinds are heavy (allowlist: not always-alive)', () => {
+  it('background-working / extensible-host / unknown kinds are heavy (allowlist)', () => {
     // memory-monitor polls while mounted → must be bounded, not always alive.
     expect(isLightTab(leaf({ kind: 'memory-monitor' }))).toBe(false)
     // editor-buffers (storage pane) + hosts do their own fetching → heavy.
     expect(isLightTab(leaf({ kind: 'editor-buffers' }))).toBe(false)
     expect(isLightTab(leaf({ kind: 'hosts' }))).toBe(false)
+    // settings / new-tab host extensible child components that can fetch/stream.
+    expect(isLightTab(leaf({ kind: 'settings', scope: 'global' }))).toBe(false)
+    expect(isLightTab(leaf({ kind: 'new-tab' }))).toBe(false)
   })
 
   it('a split is heavy if ANY leaf is heavy', () => {

--- a/spa/src/lib/pane-weight.test.ts
+++ b/spa/src/lib/pane-weight.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { isLightTab } from './pane-weight'
+import type { PaneLayout, PaneContent } from '../types/tab'
+
+function leaf(content: PaneContent, id = 'p'): PaneLayout {
+  return { type: 'leaf', pane: { id, content } }
+}
+
+const editor: PaneContent = { kind: 'editor', source: { type: 'inapp' }, filePath: '/a.md' }
+const terminal: PaneContent = {
+  kind: 'tmux-session', hostId: 'h', sessionCode: 's', mode: 'terminal', cachedName: '', tmuxInstance: '',
+}
+const browser: PaneContent = { kind: 'browser', url: 'https://x' }
+const image: PaneContent = { kind: 'image-preview', source: { type: 'inapp' }, filePath: '/a.png' }
+
+describe('isLightTab', () => {
+  it('a single editor / preview / settings pane is light', () => {
+    expect(isLightTab(leaf(editor))).toBe(true)
+    expect(isLightTab(leaf(image))).toBe(true)
+    expect(isLightTab(leaf({ kind: 'settings', scope: 'global' }))).toBe(true)
+    expect(isLightTab(leaf({ kind: 'new-tab' }))).toBe(true)
+  })
+
+  it('a terminal or browser pane is heavy (not light)', () => {
+    expect(isLightTab(leaf(terminal))).toBe(false)
+    expect(isLightTab(leaf(browser))).toBe(false)
+  })
+
+  it('a split is heavy if ANY leaf is heavy', () => {
+    const editorPlusTerminal: PaneLayout = {
+      type: 'split', id: 'sp', direction: 'h', sizes: [50, 50],
+      children: [leaf(editor, 'a'), leaf(terminal, 'b')],
+    }
+    expect(isLightTab(editorPlusTerminal)).toBe(false)
+  })
+
+  it('a split of only light leaves is light', () => {
+    const twoEditors: PaneLayout = {
+      type: 'split', id: 'sp', direction: 'v', sizes: [50, 50],
+      children: [leaf(editor, 'a'), leaf(image, 'b')],
+    }
+    expect(isLightTab(twoEditors)).toBe(true)
+  })
+})

--- a/spa/src/lib/pane-weight.ts
+++ b/spa/src/lib/pane-weight.ts
@@ -1,22 +1,26 @@
 import type { PaneLayout } from '../types/tab'
 import { collectLeaves } from './pane-tree'
 
-// Explicit ALLOWLIST of "light" pane kinds — cheap, static content that does no
-// background work while hidden, so it is safe to keep mounted across tab switches
-// (preserving editor scroll/mode, form inputs, …). Anything NOT listed here is
-// treated as heavy and bound by keepAliveCount — an allowlist so a new/unknown
-// pane kind defaults to the conservative (bounded) side. Deliberately excludes:
-// tmux-session / browser (GPU/WebContents memory) and memory-monitor / hosts /
-// editor-buffers (background polling / fetching that must not run unbounded for
-// hidden tabs).
+// Explicit ALLOWLIST of "light" pane kinds — self-contained renderers that load
+// once and do NO background work (no polling, streams, or fetch loops) while
+// hidden, so they are safe to keep mounted across tab switches (preserving editor
+// scroll/mode, etc.). Anything NOT listed is heavy and bound by keepAliveCount —
+// an allowlist so new/unknown kinds default to the conservative (bounded) side.
+//
+// Deliberately EXCLUDED (all bounded):
+//   - tmux-session / browser: GPU / WebContents memory.
+//   - memory-monitor: polls metrics while mounted.
+//   - hosts / editor-buffers: their own fetching.
+//   - settings / new-tab: host EXTENSIBLE child components (settings sections,
+//     new-tab provider cards) that can run daemon checks / streams / fetches —
+//     unbounded background work if kept alive. Only self-contained, statically
+//     rendered kinds qualify below.
 const LIGHT_PANE_KINDS = new Set<string>([
   'editor',
   'image-preview',
   'pdf-preview',
-  'new-tab',
   'dashboard',
   'history',
-  'settings',
 ])
 
 /**

--- a/spa/src/lib/pane-weight.ts
+++ b/spa/src/lib/pane-weight.ts
@@ -1,18 +1,30 @@
 import type { PaneLayout } from '../types/tab'
 import { collectLeaves } from './pane-tree'
 
-// "Heavy" panes are the memory/GPU-heavy renderers that keepAliveCount is meant
-// to bound: tmux terminals (xterm / WebGL contexts) and browser panes (Electron
-// WebContentsView). Every other pane kind (editor, previews, settings, history,
-// new-tab, dashboard, …) is cheap.
-const HEAVY_PANE_KINDS = new Set<string>(['tmux-session', 'browser'])
+// Explicit ALLOWLIST of "light" pane kinds — cheap, static content that does no
+// background work while hidden, so it is safe to keep mounted across tab switches
+// (preserving editor scroll/mode, form inputs, …). Anything NOT listed here is
+// treated as heavy and bound by keepAliveCount — an allowlist so a new/unknown
+// pane kind defaults to the conservative (bounded) side. Deliberately excludes:
+// tmux-session / browser (GPU/WebContents memory) and memory-monitor / hosts /
+// editor-buffers (background polling / fetching that must not run unbounded for
+// hidden tabs).
+const LIGHT_PANE_KINDS = new Set<string>([
+  'editor',
+  'image-preview',
+  'pdf-preview',
+  'new-tab',
+  'dashboard',
+  'history',
+  'settings',
+])
 
 /**
- * A tab is "light" when it contains NO heavy pane. Light tabs are kept alive
- * across tab switches regardless of keepAliveCount, so their state (editor
- * scroll/mode, form inputs, …) is preserved and they never remount. keepAliveCount
- * only bounds heavy tabs.
+ * A tab is "light" only when EVERY pane is a known-light kind. Light tabs are
+ * kept alive across tab switches regardless of keepAliveCount, so they never
+ * remount and their state is preserved. Any heavy (or unknown) pane makes the
+ * whole tab heavy → bound by keepAliveCount.
  */
 export function isLightTab(layout: PaneLayout): boolean {
-  return !collectLeaves(layout).some((pane) => HEAVY_PANE_KINDS.has(pane.content.kind))
+  return collectLeaves(layout).every((pane) => LIGHT_PANE_KINDS.has(pane.content.kind))
 }

--- a/spa/src/lib/pane-weight.ts
+++ b/spa/src/lib/pane-weight.ts
@@ -1,0 +1,18 @@
+import type { PaneLayout } from '../types/tab'
+import { collectLeaves } from './pane-tree'
+
+// "Heavy" panes are the memory/GPU-heavy renderers that keepAliveCount is meant
+// to bound: tmux terminals (xterm / WebGL contexts) and browser panes (Electron
+// WebContentsView). Every other pane kind (editor, previews, settings, history,
+// new-tab, dashboard, …) is cheap.
+const HEAVY_PANE_KINDS = new Set<string>(['tmux-session', 'browser'])
+
+/**
+ * A tab is "light" when it contains NO heavy pane. Light tabs are kept alive
+ * across tab switches regardless of keepAliveCount, so their state (editor
+ * scroll/mode, form inputs, …) is preserved and they never remount. keepAliveCount
+ * only bounds heavy tabs.
+ */
+export function isLightTab(layout: PaneLayout): boolean {
+  return !collectLeaves(layout).some((pane) => HEAVY_PANE_KINDS.has(pane.content.kind))
+}


### PR DESCRIPTION
承接使用者回報：Live Mode（及任何 editor tab）**切走再切回會「重新載入」→ 回到頂端**。

## 根因
`keepAliveCount` 預設 **0**，`useTabAlivePool` 在 `=== 0` 時**只保留 active tab** → 每次切 tab 都 unmount+remount editor → 依賴的 viewState 還原沒穩定生效 → 回頂 + reload flash。而 `keepAliveCount` 本質是 **terminal renderer 記憶體設定（xterm/WebGL context）**，editor tab 是被它連坐 evict 的。

## 修法（方案 B — 根治，非 targeted 還原）
把 tab 分成 **light vs heavy**：
- **heavy** = 含 `tmux-session`（terminal）或 `browser`（WebContentsView）pane —— keepAliveCount 該管的記憶體大戶。
- **light** = 其餘（editor / preview / settings / history / new-tab…）→ **永遠 alive、不受 keepAliveCount 連坐**，切 tab 不 remount，scroll/mode/輸入由瀏覽器原生保留。
- heavy tab 維持**原本一模一樣的 LRU**（無 light tab 時 alive set 與原本 byte-identical）。

- 新 `isLightTab(layout)`：掃 leaves 是否含 heavy pane kind。
- `useTabAlivePool` 加 optional `light` flag：light tab 繞過 keepAliveCount bound、附加進 alive set。
- `TabContent` 用 isLightTab 分類每個 tab。

## 驗證
- 新測試：light tab 在 keepAliveCount=0 恆 alive / heavy 仍受限 / 混合池保留所有 light + 只留 active heavy / isLightTab 分類；**既有 pool LRU 測試全部不動**（heavy path byte-identical）。
- full vitest 3705 綠（連跑 2 次穩定）/ lint / build 通過。

## 效果 / 注意
- Live Mode 切 tab 回來**維持原捲動位置、無 reload flash**（純 SPA → HMR 即時，你 App 應可直接驗）。
- 取捨：light tab 常駐記憶體（editor/Monaco/Tiptap 等），遠小於 terminal GPU context；terminal 記憶體行為完全不變。