### PR TITLE
feat(editor): Outline-style markdown Live Mode + content-width toggle

### DIFF
--- a/docs/specs/2026-07-02-md-preview-outline-style-plan.md
+++ b/docs/specs/2026-07-02-md-preview-outline-style-plan.md
@@ -1,0 +1,129 @@
+# Plan — Markdown Live Mode Outline 風樣式 + 內容寬度切換
+
+**Spec**: `2026-07-02-md-preview-outline-style-spec.md`
+**Branch**: `worktree-md-preview-outline-style`
+**Date**: 2026-07-02
+
+實作紀律：TDD（先寫失敗測試再實作）、每 task 獨立 commit、subagent 開發、主 session 整合/review。三 phase → 三個 PR-sized 提交群（可同 PR 分 commit）。
+
+---
+
+## Phase 1 — Outline 靜態 prose 樣式（CSS）
+
+**檔案**：`spa/src/index.css`、`spa/src/components/editor/TiptapEditor.tsx`（僅去 `prose-sm`）、`TiptapEditor.test.tsx`（斷言）。
+
+### Task 1.1 — 去 `prose-sm`（TDD）
+- **測試（先）**：`TiptapEditor.test.tsx` 加一條：渲染後 editor 容器 class **不含 `prose-sm`**、仍含 `tiptap-editor prose prose-invert`。
+  - 註：class 設在 `editorProps.attributes`（`TiptapEditor.tsx:62`），測試取 `[contenteditable]` 或 `.tiptap-editor` node 的 className 斷言。
+- **實作**：移除 `TiptapEditor.tsx:62` class 字串中的 `prose-sm`。
+- **commit**：`refactor(editor): drop prose-sm from Tiptap; explicit CSS owns type scale`
+
+### Task 1.2 — Outline `.tiptap-editor` 樣式塊（CSS，無單元測試）
+- **實作**：`index.css` 加樣式塊，全部以 `.tiptap-editor` 前綴限定（scope 已驗證：只有 TiptapEditor 用此 class；MessageBubble 用泛用 prose 不受影響）。依 spec §5 Phase 1 selector 表：
+  - `.tiptap-editor { line-height: 1.7; }`
+  - `.tiptap-editor :is(h1,h2,h3,h4,h5,h6) { font-weight: 600; margin: 1em 0 0.25em; border-bottom: 0; }`
+  - h1 28 / h2 22 / h3 18 / h4 16 / h5,h6 15（px 或 rem 對應）
+  - `.tiptap-editor :is(h1,h2,h3,h4,h5,h6) + p { margin-top: 0.25em; }`
+  - `.tiptap-editor p { font-size: 16px; }`；頂層區塊 `> * { margin: .5em 0 }`、`> :first-child { margin-top: 0 }`
+  - `.tiptap-editor :is(ul,ol)` 縮排 + `li` 間距
+  - `.tiptap-editor pre { border-radius: 6px; overflow-x: auto; }` + mono + 淡底
+  - `.tiptap-editor :not(pre) > code`（inline）mono、`font-size: 90%`、淡底、小圓角
+  - `.tiptap-editor blockquote` 左邊框 + 灰字 + `padding-inline`
+  - `.tiptap-editor table` cell padding/border/隔行底；外層（`.tableWrapper` 或 `table` 容器）`overflow-x: auto`
+  - **顏色沿用深色變數**（不覆寫 prose-invert 的色）。
+  - **不含 padding / max-width**（留 Phase 3）。
+- **驗證**：`pnpm run build` + `pnpm run lint` 綠；手動截圖 7 樣本（spec §5 Phase 1）對照 Outline。
+- **commit**：`feat(editor): Outline-style markdown typography for Live Mode`
+
+**Phase 1 完成準則**：AC1（樣式，除寬度置中留 Phase 3）、AC10 部分（build/lint/vitest 綠）。
+
+---
+
+## Phase 2 — `contentWidth` 全域偏好（store，強 TDD）
+
+**檔案**：`spa/src/stores/useEditorSettingsStore.ts`、`useEditorSettingsStore.test.ts`（既有或新建）。
+
+### Task 2.1 — store 欄位 + setter + sanitize + persist（TDD）
+- **測試（先）**，於 store 測試檔：
+  1. 初始 `contentWidth === 'narrow'`。
+  2. `setContentWidth('full')` → state 為 `'full'`。
+  3. `partialize` 產出含 `contentWidth`；rehydrate（merge）後保留 persisted 值。
+  4. `sanitize`/`merge` 對非法 persisted（`'wide'` / `123` / `null` / 缺欄）→ 落回 `'narrow'`。
+  5. `reset()` → 回 `'narrow'`。
+- **實作**（對照既有 `fontSize` 等欄位模式）：
+  - `export type ContentWidthOption = 'narrow' | 'full'`
+  - interface 加 `contentWidth: ContentWidthOption` + `setContentWidth`
+  - `DEFAULT_EDITOR_SETTINGS.contentWidth = 'narrow'`
+  - `isContentWidth` guard；`sanitize` 加一行；`partialize` 加 `contentWidth`
+  - setter：`setContentWidth: (contentWidth) => set({ contentWidth })`
+  - **改寫檔頭 doc 註解（5-16）** 為 global editor preferences（Monaco + Tiptap）。
+- **commit**：`feat(editor-settings): add global contentWidth preference (narrow/full)`
+
+**Phase 2 完成準則**：AC3（持久化 + 預設 narrow）。
+
+---
+
+## Phase 3 — 寬度套用 + 狀態列 toggle（元件 TDD）
+
+**檔案**：`TiptapEditor.tsx`、`EditorStatusBar.tsx`、`EditorPane.tsx` + 各測試。
+
+### Task 3.1 — TiptapEditor 寬度 wrapper（TDD）
+- **測試（先）**，`TiptapEditor.test.tsx`：
+  1. `contentWidth="narrow"` → 內層 wrapper 帶限寬 class（如 `max-w-[52em] mx-auto` 或 `data-content-width="narrow"`）。
+  2. `contentWidth="full"` → wrapper 無限寬（滿寬）。
+  3. **切 prop `narrow`→`full` 不 remount**：rerender 前後 `[contenteditable]` DOM node 為同一 reference（editor instance 未重建）；scroll root `scrollTop` 不被歸零（設一個 scrollTop 再切 prop，斷言不變）。
+- **實作**：
+  - Props 加 `contentWidth?: ContentWidthOption`（default `'narrow'`）。
+  - 現 `TiptapEditor.tsx:160` 內層 div 依 `contentWidth` 套 class：`narrow` → `max-w-[52em] mx-auto px-4`（`box-sizing: border-box`，padding 在 52em 內）；`full` → `max-w-none px-4`。**水平 padding 從 editorProps class（62 行）移到此 wrapper**；editor class 的 `px-4` 拿掉、`py-4` 保留（垂直）。
+  - scroll 容器（151-154）與 viewState 還原/focus 邏輯**完全不動**。
+- **commit**：`feat(editor): apply content-width wrapper in TiptapEditor`
+
+### Task 3.2 — EditorStatusBar 寬度 toggle（TDD）
+- **測試（先）**，`EditorStatusBar.test.tsx`：
+  1. `editorMode="wysiwyg"` + `onContentWidthChange` → 渲染寬度 toggle 按鈕（by title/role）。
+  2. `editorMode="raw"` → 不渲染 toggle。
+  3. 無 `onContentWidthChange` → 不渲染。
+  4. 點擊：`contentWidth="narrow"` 時呼叫 `onContentWidthChange('full')`；反之。
+  5. icon/title 反映當前值（narrow 顯示 `Narrow width` title、full 顯示 `Full width`）。
+- **實作**：
+  - Props 加 `contentWidth?: ContentWidthOption`、`onContentWidthChange?: (v) => void`。
+  - 在 `ml-auto` 群組、Live Mode 鈕左側加按鈕；顯示條件 `editorMode === 'wysiwyg' && onContentWidthChange`（**唯一條件，不加 isMarkdown 二判**，spec Blocker 定案）。
+  - Phosphor `ArrowsInLineHorizontal`(narrow) / `ArrowsOutLineHorizontal`(full) + `title`（硬字串，不 i18n）。
+- **commit**：`feat(editor): add content-width toggle to status bar`
+
+### Task 3.3 — EditorPane 接線（TDD）
+- **測試（先）**，`EditorPane.test.tsx`（延伸既有）：
+  1. store `contentWidth` 值傳入 `<TiptapEditor>`（wysiwyg 路徑）。
+  2. `<EditorStatusBar>` 收到 `contentWidth` + `onContentWidthChange`。
+  3. **raw ↔ live 往返**：切回 raw 再回 wysiwyg，傳入的 `contentWidth` 仍為 store 值（AC8）。
+- **實作**：
+  - `const contentWidth = useEditorSettingsStore((s) => s.contentWidth)`。
+  - `<TiptapEditor ... contentWidth={contentWidth} />`（`EditorPane.tsx:484`）。
+  - `<EditorStatusBar ... contentWidth={contentWidth} onContentWidthChange={(v) => useEditorSettingsStore.getState().setContentWidth(v)} />`（496）。
+- **commit**：`feat(editor): wire content-width preference through EditorPane`
+
+**Phase 3 完成準則**：AC2、AC4-AC9、AC11。
+
+---
+
+## 整體驗證（PR 前）
+
+- `cd spa && npx vitest run` 全綠。
+- `cd spa && pnpm run lint` 綠。
+- `cd spa && pnpm run build` 綠。
+- 手動（SPA HMR，純前端）：
+  - md 檔開 Live Mode → 預設 narrow 置中、Outline 樣式。
+  - toggle 切 full/narrow 即時生效、不跳頂、不失 selection。
+  - 寬表 / 長 code 橫捲可讀。
+  - reload 後維持選擇。
+  - raw/diff 無 toggle。
+
+## 相依與順序
+
+- Phase 1、Phase 2 互相獨立，可先做任一或並行。
+- Phase 3 依賴 Phase 2（store）與 Phase 1（wrapper 樣式協調）。
+- 建議：subagent A 做 Phase 1、subagent B 做 Phase 2（並行）→ 主 session 整合 → Phase 3（依序 3.1→3.2→3.3，或 3.1/3.2 並行後 3.3）。
+
+## 非目標（重申）
+
+不改配色 / 不動 Monaco / 不做每檔寬度 / 不加 Settings 頁控制項 / 不新增 i18n key / 不動 markdown 解析儲存 handoff。

--- a/docs/specs/2026-07-02-md-preview-outline-style-plan.md
+++ b/docs/specs/2026-07-02-md-preview-outline-style-plan.md
@@ -13,9 +13,10 @@
 **檔案**：`spa/src/index.css`、`spa/src/components/editor/TiptapEditor.tsx`（僅去 `prose-sm`）、`TiptapEditor.test.tsx`（斷言）。
 
 ### Task 1.1 — 去 `prose-sm`（TDD）
-- **測試（先）**：`TiptapEditor.test.tsx` 加一條：渲染後 editor 容器 class **不含 `prose-sm`**、仍含 `tiptap-editor prose prose-invert`。
-  - 註：class 設在 `editorProps.attributes`（`TiptapEditor.tsx:62`），測試取 `[contenteditable]` 或 `.tiptap-editor` node 的 className 斷言。
-- **實作**：移除 `TiptapEditor.tsx:62` class 字串中的 `prose-sm`。
+- **測試（先）**，`TiptapEditor.test.tsx`：
+  - **必須更新既有測試**：現有 `applies typography classes to the editable root`（約 :62-67）斷言 `data-editor-class` 含 `'prose prose-invert prose-sm max-w-none'`——去 `prose-sm` 後**這條會紅**，改斷言 `'prose prose-invert max-w-none'`（去掉 prose-sm 後仍為連續子字串）＋顯式 `expect(...).not.stringContaining('prose-sm')`。
+  - **加便宜 smoke test（回應 codex）**：editable root 的 `data-editor-class` 仍含 `tiptap-editor`——整個 `.tiptap-editor` CSS scope 建立在此 class 上，class 名被改則 CI 現在抓不到。
+- **實作**：移除 `TiptapEditor.tsx:62` class 字串中的 `prose-sm`（其餘保留，含 `max-w-none`；`max-w-none` 由 Task 3.1 才移到 wrapper）。
 - **commit**：`refactor(editor): drop prose-sm from Tiptap; explicit CSS owns type scale`
 
 ### Task 1.2 — Outline `.tiptap-editor` 樣式塊（CSS，無單元測試）
@@ -44,12 +45,13 @@
 **檔案**：`spa/src/stores/useEditorSettingsStore.ts`、`useEditorSettingsStore.test.ts`（既有或新建）。
 
 ### Task 2.1 — store 欄位 + setter + sanitize + persist（TDD）
-- **測試（先）**，於 store 測試檔：
+- **測試（先）**，`useEditorSettingsStore.test.ts`，**併入既有 rehydrate 信任邊界測法（回應 codex；真正該守的是 `persist.rehydrate()` 行為，非 helper-level partialize）**：
   1. 初始 `contentWidth === 'narrow'`。
   2. `setContentWidth('full')` → state 為 `'full'`。
-  3. `partialize` 產出含 `contentWidth`；rehydrate（merge）後保留 persisted 值。
-  4. `sanitize`/`merge` 對非法 persisted（`'wide'` / `123` / `null` / 缺欄）→ 落回 `'narrow'`。
-  5. `reset()` → 回 `'narrow'`。
+  3. `setContentWidth('full')` 後，`localStorage[EDITOR_SETTINGS]` envelope 的 `state.contentWidth === 'full'`（比照 S1-6）。
+  4. **rehydrate happy-path（比照 S1-9）**：直接寫 envelope `state.contentWidth='full'` → `await persist.rehydrate()` → state 為 `'full'`。
+  5. **rehydrate 非法值（比照 S1-7）**：envelope `state.contentWidth='wide'`（或 `123`/`null`/缺欄）→ rehydrate 後落回 `'narrow'`。
+  6. `reset()` → 回 `'narrow'`。
 - **實作**（對照既有 `fontSize` 等欄位模式）：
   - `export type ContentWidthOption = 'narrow' | 'full'`
   - interface 加 `contentWidth: ContentWidthOption` + `setContentWidth`
@@ -69,13 +71,23 @@
 
 ### Task 3.1 — TiptapEditor 寬度 wrapper（TDD）
 - **測試（先）**，`TiptapEditor.test.tsx`：
-  1. `contentWidth="narrow"` → 內層 wrapper 帶限寬 class（如 `max-w-[52em] mx-auto` 或 `data-content-width="narrow"`）。
-  2. `contentWidth="full"` → wrapper 無限寬（滿寬）。
-  3. **切 prop `narrow`→`full` 不 remount**：rerender 前後 `[contenteditable]` DOM node 為同一 reference（editor instance 未重建）；scroll root `scrollTop` 不被歸零（設一個 scrollTop 再切 prop，斷言不變）。
+  1. `contentWidth="narrow"` → 內層 wrapper 帶限寬 class（斷言確切字串 `max-w-[52em] mx-auto box-border px-4`，或 `data-content-width="narrow"`）。
+  2. `contentWidth="full"` → wrapper 為滿寬（`max-w-none`，無 52em）。
+  3. **切 prop `narrow`↔`full` 不重跑 restore/focus/viewState、scrollTop 不歸零（回應 codex Blocker 1，改用行為斷言為主證據）**：既有 harness 已把 `@tiptap/react` 全 mock、且已有 `resolveRestoreSelection`（mock spy）、`editor.view.dispatch`（vi.fn）、`focusSpy`。作法——render `narrow`（觸發一次 restore/focus）記下各 spy call count 與 scroll root `scrollTop`（先設一非零值），`rerender` 成 `full`：
+     - `resolveRestoreSelection` **call count 不變**（restore 不重跑）
+     - `editor.view.dispatch` **不再被呼叫**（selection 不重設）
+     - `focusSpy` **不再被呼叫**（focus 不重打）
+     - `onViewStateChange` **在 rerender 過程未被觸發**（未誤判為 unmount 寫回）
+     - `tiptap-scroll-root.scrollTop` **維持原值**（不歸零）
+     - DOM node reference 相同僅作**輔助**佐證，**不**當「editor instance 未重建」的主要證據（mock 下 instance identity 由 mock 決定，不反映真實生命週期）。
 - **實作**：
   - Props 加 `contentWidth?: ContentWidthOption`（default `'narrow'`）。
-  - 現 `TiptapEditor.tsx:160` 內層 div 依 `contentWidth` 套 class：`narrow` → `max-w-[52em] mx-auto px-4`（`box-sizing: border-box`，padding 在 52em 內）；`full` → `max-w-none px-4`。**水平 padding 從 editorProps class（62 行）移到此 wrapper**；editor class 的 `px-4` 拿掉、`py-4` 保留（垂直）。
+  - 現 `TiptapEditor.tsx:160` 內層 div 依 `contentWidth` 套 class：
+    - `narrow` → **`max-w-[52em] mx-auto box-border px-4`**（`box-border` = `box-sizing: border-box`，**使 padding 計入 52em 之內**，落實 spec §4.1；回應 codex Blocker 2——無 `box-border` 則 padding 加在 52em 外、量測偏掉）
+    - `full` → `max-w-none px-4`
+  - **水平 padding 從 editorProps class（`:62` 的 `px-4`）移到此 wrapper**；editor root class 去 `px-4`、**保留 `max-w-none`**（讓 prose 不自我限縮到 65ch，改由 wrapper 統一控寬）、`py-4` 保留（垂直）。
   - scroll 容器（151-154）與 viewState 還原/focus 邏輯**完全不動**。
+- **已知風險（明寫，回應 codex）**：padding 換位置不影響 scroll root 的 scrollTop 讀寫（仍是同一 container），但 `narrow` 文字 measure 變窄後 reflow，**同一 scrollTop 數值可能對應不同視覺位置**——本 task 只保證「scrollTop 不歸零」，**不保證視覺 anchor 完全不位移**（spec §7 已列為接受風險）。
 - **commit**：`feat(editor): apply content-width wrapper in TiptapEditor`
 
 ### Task 3.2 — EditorStatusBar 寬度 toggle（TDD）
@@ -118,11 +130,12 @@
   - reload 後維持選擇。
   - raw/diff 無 toggle。
 
-## 相依與順序
+## 相依與順序（回應 codex：區分硬依賴 vs 視覺整合依賴）
 
-- Phase 1、Phase 2 互相獨立，可先做任一或並行。
-- Phase 3 依賴 Phase 2（store）與 Phase 1（wrapper 樣式協調）。
-- 建議：subagent A 做 Phase 1、subagent B 做 Phase 2（並行）→ 主 session 整合 → Phase 3（依序 3.1→3.2→3.3，或 3.1/3.2 並行後 3.3）。
+- Phase 1、Phase 2 互相獨立，可並行。
+- **硬依賴**：Phase 3 → Phase 2（`contentWidth` store 需先存在，`3.2`/`3.3` 讀它）。
+- **僅視覺整合依賴**（非技術依賴）：Phase 3 → Phase 1（Task `3.1` 的 wrapper 只要測試不把 typography class 綁死，其實 Phase 2 完成即可先做，不必等 Phase 1）。
+- 建議：subagent A 做 Phase 1、subagent B 做 Phase 2（並行）→ 主 session 整合 → Phase 3（`3.1`/`3.2` 可並行、`3.3` 最後接線）。
 
 ## 非目標（重申）
 

--- a/docs/specs/2026-07-02-md-preview-outline-style-spec.md
+++ b/docs/specs/2026-07-02-md-preview-outline-style-spec.md
@@ -1,0 +1,191 @@
+# Spec — Markdown Live Mode 閱讀樣式（Outline 風）＋ 內容寬度切換
+
+**Date**: 2026-07-02
+**Branch**: `worktree-md-preview-outline-style`
+**Author**: Claude (Opus 4.8) + Wake
+**狀態**: Draft（待 codex 審）
+
+---
+
+## 1. 背景與問題
+
+Purdex 的 markdown「Live Mode」（Tiptap WYSIWYG，`editorMode === 'wysiwyg'`）目前**沒有任何自訂 prose 樣式**：
+
+- `TiptapEditor.tsx:62` 的 editor 容器 class 為
+  `tiptap-editor prose prose-invert prose-sm max-w-none px-4 py-4`。
+- `prose-sm` 使字級偏小；`max-w-none` 讓內容**貼齊面板寬度**——面板一寬，單行字元數暴增到 100+，遠超過舒適閱讀的 50–75（CJK 更宜 ≤40 全形），閱讀體驗差。
+- `spa/src/index.css` 只 `@plugin "@tailwindcss/typography"`，**無任何 `.tiptap-editor` / `.ProseMirror` / prose 覆寫**（grep 確認）。
+
+使用者要求：markdown 預覽套用 **Outline（getoutline.com）** 的閱讀樣式，並提供**內容寬度切換**（限寬置中 ⇄ 滿寬）。
+
+### 為何參考 Outline
+
+Outline 的編輯器與 Purdex 同屬 **ProseMirror** 家族，樣式可近乎 1:1 移植。以下數值直接取自 Outline 原始碼（`outline/outline@main`）：
+
+| 來源檔 | 取用內容 |
+|--------|----------|
+| `shared/editor/styles/EditorStyleHelper.ts` | `documentWidth = "52em"`、`padding = 32`、`blockRadius = "6px"` |
+| `shared/editor/components/Styles.ts` | 字級變數、標題 margin/weight、區塊間距、複雜文字行高 |
+| `shared/styles/theme.ts` | `fontFamily`、`fontWeight*` |
+
+**權威數值表**：
+
+- 內容欄寬 `52em`（≈832px @16px），置中。
+- 字級：p `16px` / h1 `28px` / h2 `22px` / h3 `18px` / h4 `16px` / h5,h6 `15px`。
+- 標題：`font-weight: 600`、**無底線**、`margin: 1em 0 0.25em`；標題緊接的 p `margin-top: 0.25em`。
+- 頂層區塊間距：`margin: .5em 0`，首塊 `margin-top: 0`。
+- 字體：`-apple-system, BlinkMacSystemFont, Inter, 'Segoe UI', Roboto, Oxygen, sans-serif`；等寬 `'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace`。
+- block 圓角 `6px`。
+- **CJK 行高洞察**：Outline 對「複雜文字系統」（泰、南亞、藏、阿拉伯、蒙古…）特別把 `p { line-height: 1.7 }`、段落 margin `0.8em`，因預設 Latin 行高對高字身文字太擠。**Outline 漏列了 CJK，但中文正屬此類**——故我們對正文採 `line-height: 1.7`（有原始碼依據，非臆測）。
+
+---
+
+## 2. 目標與非目標
+
+### 目標
+
+1. Markdown Live Mode 的渲染樣式對齊 Outline：字級階層、行高、標題（無底線、600 粗）、區塊間距、code block、清單、blockquote、表格。
+2. 內容寬度可在 **`narrow`（限寬置中，預設）** 與 **`full`（滿寬，現狀 `max-w-none`）** 間切換。
+3. 切換入口為 `EditorStatusBar` 右下角、Live Mode 鈕旁；**僅在 markdown Live Mode（wysiwyg）顯示**。
+4. 寬度偏好為 **Purdex 全域**、持久化（一次設定，所有 md 檔一致）。
+
+### 非目標
+
+- **不改深色主題配色**：沿用 `prose-invert` / 既有 CSS 變數；只移植 Outline 的尺寸/間距/字重/無底線/欄寬，不套 Outline 的淺色。
+- **不動 Monaco（raw mode）樣式**：寬度切換與 prose 樣式只作用於 Tiptap Live Mode。
+- **不做每檔獨立寬度**（已與使用者確認採全域）。
+- **不新增 Settings 頁面控制項**（狀態列 toggle 即入口；如需可列 follow-up issue）。
+- **不改 markdown 解析、儲存、handoff、viewState 還原**等既有行為。
+- **不引入自訂字型檔**（用系統字體堆疊）。
+
+---
+
+## 3. 現況程式碼盤點（探勘結果，實作免重探）
+
+| 位置 | 現況 | 本次動作 |
+|------|------|----------|
+| `spa/src/index.css` | 只 `@plugin typography`，無 prose 覆寫 | **Phase 1**：加 `.tiptap-editor` 靜態樣式 |
+| `TiptapEditor.tsx:62` | class 含 `prose-sm max-w-none px-4 py-4`（寫死） | **Phase 1/3**：去 `prose-sm`；寬度改由 prop 控制的內層 wrapper |
+| `TiptapEditor.tsx:150-163` | 外層 scroll 容器 + `min-h-full` 內層 div 包 `<EditorContent>` | **Phase 3**：內層改為「置中欄 wrapper」，寬度依 prop |
+| `useEditorSettingsStore.ts` | persist + sanitize + merge 成熟模式；doc 註「僅 Monaco 讀」 | **Phase 2**：加 `contentWidth`，更新 doc 註 |
+| `EditorStatusBar.tsx` | 右下角有 Live Mode / language 下拉 | **Phase 3**：加寬度 toggle |
+| `EditorPane.tsx:484-492` | 渲染 `<TiptapEditor>`；status bar 在 496 | **Phase 3**：讀 store 寬度傳入 + wire toggle |
+
+---
+
+## 4. 設計
+
+### 4.1 樣式套用策略（靜態 vs 動態分離）
+
+- **靜態（Phase 1）**：字級、行高、標題、間距、code、清單、blockquote、表格——這些不隨狀態改變，寫進 `index.css` 針對 `.tiptap-editor`（ProseMirror 容器已帶此 class）。用 `.tiptap-editor` 前綴確保只作用於本編輯器，不污染其他 prose 使用處。
+- **動態（Phase 3）**：只有「內容寬度」隨偏好改變。**不**在 `useEditor` 初始化的 class 上改（那需 `setOptions` 重設、易與 viewState 打架），改在 `<EditorContent>` 外層包一個**置中欄 wrapper**，其 class 依 `contentWidth` prop：
+  - `narrow` → `max-width: 52em; margin-inline: auto;`（＋水平 padding）
+  - `full` → 無 max-width（等同現狀）。
+  - ProseMirror 節點填滿 wrapper；水平 padding 移到 wrapper，垂直 padding 保留。
+
+> 為何不用 `prose` 內建 `max-w-*`：Tailwind prose 的 `max-w-none` 目前寫死在 editor class；用獨立 wrapper 控制寬度可保 `useEditor` 設定不變（避免 remount / viewState 風險），且 `narrow/full` 切換是純 class 替換、可反應式。
+
+### 4.2 寬度偏好狀態
+
+擴充 `useEditorSettingsStore`（既有 persist/sanitize/merge 模式）：
+
+```ts
+export type ContentWidthOption = 'narrow' | 'full'
+
+interface EditorSettingsState {
+  // ...existing
+  contentWidth: ContentWidthOption      // default 'narrow'
+  setContentWidth: (v: ContentWidthOption) => void
+}
+```
+
+- `DEFAULT_EDITOR_SETTINGS.contentWidth = 'narrow'`。
+- `sanitize`：加 `isContentWidth` guard，非法值 → 落回 default。
+- `partialize` / `merge` 一併納入。
+- 更新檔頭 doc 註解：此 store 現同時服務 Monaco 與 **Tiptap 的 `contentWidth`**（原註「Only MonacoWrapper reads」需修正）。
+- **不註冊 syncManager**（與既有 editor 偏好一致，device-local）。
+
+### 4.3 Toggle UI（EditorStatusBar）
+
+- 新增 optional props：`contentWidth?: ContentWidthOption`、`onContentWidthChange?: (v) => void`。
+- **僅當 `editorMode === 'wysiwyg'` 且 `onContentWidthChange` 存在**時渲染（raw mode 不顯示——寬度只對 Live Mode 有意義）。
+- 位置：Live Mode 鈕**左側**（同一 `ml-auto` 群組內）。
+- 型式：與現有 language/mode 鈕一致的小按鈕，點擊在 `narrow ⇄ full` 間切換（兩態直接 toggle，不必下拉選單）。
+- 標籤/圖示：用 Phosphor icon 表達寬窄（如 `ArrowsInLineHorizontal` / `ArrowsOutLineHorizontal`），附 `title`。i18n 走既有 `useI18nStore`（若狀態列其他文字已 i18n；否則沿用現有硬字串風格保持一致）。
+
+### 4.4 EditorPane 接線
+
+- 讀 `const contentWidth = useEditorSettingsStore((s) => s.contentWidth)`。
+- 傳給 `<TiptapEditor contentWidth={contentWidth} />`。
+- `<EditorStatusBar>` 加 `contentWidth={contentWidth}`、`onContentWidthChange={(v) => useEditorSettingsStore.getState().setContentWidth(v)}`。
+
+### 4.5 TiptapEditor 接線
+
+- 新增 prop `contentWidth: ContentWidthOption`（或帶 default `'narrow'` 以相容測試）。
+- 內層 wrapper（現 `TiptapEditor.tsx:160` 的 div）依 `contentWidth` 套寬度 class。
+- 保留既有 scroll 容器、viewState 還原、focus 邏輯**完全不動**。
+
+---
+
+## 5. Phase 切分（依 review 大小）
+
+### Phase 1 — Outline 靜態 prose 樣式（CSS-only）
+
+- **範圍**：`spa/src/index.css` 加 `.tiptap-editor` 樣式塊；移除 editor class 的 `prose-sm`（改由 CSS 明確定字級）。
+- **交付**：字級階層（28/22/18/16/15/16）、`line-height: 1.7`、標題 600＋無底線＋margin、區塊間距、code（mono＋`6px`＋淡底）、行內 code、清單、blockquote、表格；全部深色。
+- **驗證**：`pnpm run build` + lint 綠；手動截圖對照 Outline 參考。純 CSS 難 TDD——測試僅斷言 editor class **不再含 `prose-sm`**（TiptapEditor 既有測試延伸）。
+- **Review 大小**：小（單檔 CSS + 一處 class 字串）。
+
+### Phase 2 — `contentWidth` 全域偏好（store，強 TDD）
+
+- **範圍**：`useEditorSettingsStore.ts` 加 `contentWidth` 全套（type、default、setter、sanitize guard、partialize、merge、doc 註）。
+- **驗證（TDD 先行）**：
+  - default 為 `'narrow'`。
+  - `setContentWidth('full')` 生效。
+  - persist round-trip（rehydrate 保留）。
+  - `sanitize` 對非法值（`'wide'`、數字、null）落回 default。
+  - `reset` 回 default。
+- **Review 大小**：小（單 store + 測試）。
+
+### Phase 3 — 寬度套用 + 狀態列 toggle（元件 TDD）
+
+- **範圍**：`TiptapEditor.tsx`（prop + wrapper class）、`EditorStatusBar.tsx`（toggle）、`EditorPane.tsx`（接線）。
+- **驗證（TDD）**：
+  - `EditorStatusBar`：wysiwyg 時渲染寬度 toggle；raw 時不渲染；點擊呼叫 `onContentWidthChange` 傳另一態；顯示反映當前 `contentWidth`。
+  - `EditorPane`：從 store 讀 `contentWidth` 並傳入 TiptapEditor 與 StatusBar（可用既有 EditorPane 測試延伸 / mock store）。
+  - `TiptapEditor`：`narrow` 套限寬 class、`full` 不套（斷言 wrapper class）。
+- **Review 大小**：中（3 檔，含 UI）。
+
+**Phase 相依**：1 獨立可先；2 獨立；3 依賴 2（需 store）。可 1→2→3 順序，或 1、2 並行後 3。
+
+---
+
+## 6. 驗收準則（整體）
+
+1. Markdown Live Mode 預設呈現：限寬置中 `52em`、行高 1.7、標題無底線、字級階層如上，深色。
+2. 狀態列（Live Mode 時）出現寬度 toggle；切 `full` 立即滿寬、切 `narrow` 立即限寬置中。
+3. 偏好持久化：重載後維持上次選擇；預設 `narrow`。
+4. Raw（Monaco）模式不受影響、無寬度 toggle。
+5. 非 markdown 檔不顯示寬度 toggle。
+6. `cd spa && npx vitest run` 全綠、`pnpm run lint` 綠、`pnpm run build` 綠。
+7. 既有 viewState 還原 / focus / handoff 行為不回歸。
+
+---
+
+## 7. 風險與緩解
+
+| 風險 | 緩解 |
+|------|------|
+| `.tiptap-editor` 樣式外溢到其他 prose 使用處 | 一律以 `.tiptap-editor` 前綴限定；grep 確認無其他元件複用此 class |
+| 去 `prose-sm` 後 Tailwind prose 預設值回大，與自訂衝突 | CSS 明確覆寫關鍵屬性；build 後截圖驗證 |
+| wrapper 改結構影響 scroll/viewState 還原 | 只在既有內層 div 加寬度 class，不動 scroll 容器與還原邏輯；Phase 3 測試守住 |
+| store doc 註「僅 Monaco」失真 | Phase 2 一併修正註解，避免誤導後續開發 |
+| CJK 行高 1.7 對純英文檔略鬆 | 可接受；Outline 亦對多語系統一放鬆；如反彈再 follow-up 分語系 |
+
+---
+
+## 8. 未決 / 待 codex 檢視
+
+1. Toggle 用「兩態直接切」還是「下拉（跟 Live Mode 一致）」？本 spec 採兩態直切（更快）；請 codex 評 UX 一致性。
+2. 寬度只作用 Live Mode，raw/diff 不顯示 toggle——是否有使用者會期待 raw 也限寬？（本 spec 判定否。）
+3. `52em` 是否直接沿用，或因 Purdex 深色 + 中文再微調？（本 spec 先沿用權威值，實測後可調。）

--- a/docs/specs/2026-07-02-md-preview-outline-style-spec.md
+++ b/docs/specs/2026-07-02-md-preview-outline-style-spec.md
@@ -79,9 +79,11 @@ Outline 的編輯器與 Purdex 同屬 **ProseMirror** 家族，樣式可近乎 1
 
 - **靜態（Phase 1）**：字級、行高、標題、間距、code、清單、blockquote、表格——這些不隨狀態改變，寫進 `index.css` 針對 `.tiptap-editor`（ProseMirror 容器已帶此 class）。用 `.tiptap-editor` 前綴確保只作用於本編輯器，不污染其他 prose 使用處。
 - **動態（Phase 3）**：只有「內容寬度」隨偏好改變。**不**在 `useEditor` 初始化的 class 上改（那需 `setOptions` 重設、易與 viewState 打架），改在 `<EditorContent>` 外層包一個**置中欄 wrapper**，其 class 依 `contentWidth` prop：
-  - `narrow` → `max-width: 52em; margin-inline: auto;`（＋水平 padding）
+  - `narrow` → `max-width: 52em; margin-inline: auto;`（＋水平 padding，見下）
   - `full` → 無 max-width（等同現狀）。
-  - ProseMirror 節點填滿 wrapper；水平 padding 移到 wrapper，垂直 padding 保留。
+  - ProseMirror 節點填滿 wrapper；**水平 padding 由 Phase 3 一併移到 wrapper**（Phase 1 不碰 padding），垂直 padding 保留。
+
+**padding 與 52em 的關係（明訂，回應 codex 2b）**：wrapper 採 `box-sizing: border-box`，`max-width: 52em` 為**欄寬含水平 padding**（padding 在 52em 之內）。故實際文字 measure ≈ `52em − 2×水平 padding`（約 48–50em），略窄於 52em、更貼近舒適閱讀甜蜜點；此為刻意取捨，非 bug。Outline 的 `documentWidth` 是純內容欄、gutter 另計，我們以「52em 含 padding」近似之，避免再引入 gutter 常數。
 
 > 為何不用 `prose` 內建 `max-w-*`：Tailwind prose 的 `max-w-none` 目前寫死在 editor class；用獨立 wrapper 控制寬度可保 `useEditor` 設定不變（避免 remount / viewState 風險），且 `narrow/full` 切換是純 class 替換、可反應式。
 
@@ -102,16 +104,17 @@ interface EditorSettingsState {
 - `DEFAULT_EDITOR_SETTINGS.contentWidth = 'narrow'`。
 - `sanitize`：加 `isContentWidth` guard，非法值 → 落回 default。
 - `partialize` / `merge` 一併納入。
-- 更新檔頭 doc 註解：此 store 現同時服務 Monaco 與 **Tiptap 的 `contentWidth`**（原註「Only MonacoWrapper reads」需修正）。
+- **改寫檔頭整段 doc 註解（`useEditorSettingsStore.ts:5-16`，回應 codex 4）**：現註解整段假設「Monaco-only / Only MonacoWrapper reads」已失真（設定頁、file-open 流程、本次 Tiptap `contentWidth` 都會讀）。改為「global editor preferences（Monaco + Tiptap 共用）」，避免誤導後續 reviewer。
 - **不註冊 syncManager**（與既有 editor 偏好一致，device-local）。
 
 ### 4.3 Toggle UI（EditorStatusBar）
 
 - 新增 optional props：`contentWidth?: ContentWidthOption`、`onContentWidthChange?: (v) => void`。
-- **僅當 `editorMode === 'wysiwyg'` 且 `onContentWidthChange` 存在**時渲染（raw mode 不顯示——寬度只對 Live Mode 有意義）。
+- **唯一顯示條件（回應 codex Blocker）**：`editorMode === 'wysiwyg' && onContentWidthChange != null` 時渲染，否則不渲染。此條件已**完整涵蓋**「非 Live Mode 不顯示」；不需要、也不應該再用「isMarkdown」二次判斷——因為進到 wysiwyg 的前提本就是 markdown-capable buffer（`canUseLiveMode = isMarkdown || language === 'markdown'`，見 `EditorStatusBar.tsx:84` / `EditorPane.tsx:506`）。**一個 language 被手動設為 markdown 的非 `.md` 檔進 Live Mode 時，toggle 應照常顯示**（這是預期行為，非例外）。§6 驗收改以「Live Mode」為準，不再用「非 markdown 檔」措辭。
 - 位置：Live Mode 鈕**左側**（同一 `ml-auto` 群組內）。
-- 型式：與現有 language/mode 鈕一致的小按鈕，點擊在 `narrow ⇄ full` 間切換（兩態直接 toggle，不必下拉選單）。
-- 標籤/圖示：用 Phosphor icon 表達寬窄（如 `ArrowsInLineHorizontal` / `ArrowsOutLineHorizontal`），附 `title`。i18n 走既有 `useI18nStore`（若狀態列其他文字已 i18n；否則沿用現有硬字串風格保持一致）。
+- 型式：與現有 language/mode 鈕一致的小按鈕，點擊在 `narrow ⇄ full` 間直接切換（兩態 toggle，不下拉選單）。
+- **標籤（定案，回應 codex 5-Q1）**：icon（Phosphor `ArrowsInLineHorizontal` narrow / `ArrowsOutLineHorizontal` full）**＋ `title` tooltip**（如 `Narrow width` / `Full width`）。**不做 icon-only 無提示**。
+- **i18n 策略（定案，回應 codex 6a）**：狀態列現有文字（`Source`/`Live Mode`/語言名）**皆為硬編碼英文、未走 i18n**。本次 toggle 的 `title` **沿用同一硬字串慣例**，**不新增 i18n key**，保持狀態列一致；全面國際化另案處理（如需可列 follow-up issue）。
 
 ### 4.4 EditorPane 接線
 
@@ -131,9 +134,22 @@ interface EditorSettingsState {
 
 ### Phase 1 — Outline 靜態 prose 樣式（CSS-only）
 
-- **範圍**：`spa/src/index.css` 加 `.tiptap-editor` 樣式塊；移除 editor class 的 `prose-sm`（改由 CSS 明確定字級）。
-- **交付**：字級階層（28/22/18/16/15/16）、`line-height: 1.7`、標題 600＋無底線＋margin、區塊間距、code（mono＋`6px`＋淡底）、行內 code、清單、blockquote、表格；全部深色。
-- **驗證**：`pnpm run build` + lint 綠；手動截圖對照 Outline 參考。純 CSS 難 TDD——測試僅斷言 editor class **不再含 `prose-sm`**（TiptapEditor 既有測試延伸）。
+- **範圍**：`spa/src/index.css` 加 `.tiptap-editor` 樣式塊；移除 editor class 的 `prose-sm`（改由 CSS 明確定字級）。**Phase 1 不碰 padding / 寬度責任**（水平 padding 與置中欄留給 Phase 3，回應 codex 1a），僅處理 typography 與去 `prose-sm`。
+- **明確需覆寫的 selector 清單（回應 codex 3c，避免半數仍吃 typography 預設）**，一律以 `.tiptap-editor` 前綴限定：
+  | selector | 覆寫 |
+  |----------|------|
+  | `.tiptap-editor` | `line-height: 1.7`（CJK 舒適，Outline 複雜文字依據） |
+  | `.tiptap-editor h1..h6` | 字級 28/22/18/16/15/15、`font-weight: 600`、`margin: 1em 0 0.25em`、**無 `border-bottom`** |
+  | `.tiptap-editor h* + p` | `margin-top: 0.25em`（標題黏近內文） |
+  | `.tiptap-editor p` | 字級 16、頂層區塊 `margin: .5em 0` |
+  | `.tiptap-editor ul, ol` | 縮排 + item 間距 |
+  | `.tiptap-editor pre` | mono、`border-radius: 6px`、淡底、`overflow-x: auto`（保留橫捲，見風險 3b） |
+  | `.tiptap-editor code`（inline） | mono、`font-size: 90%`、淡底、小圓角 |
+  | `.tiptap-editor blockquote` | 左邊框、灰字、`padding-inline` |
+  | `.tiptap-editor table` | cell padding、border、隔行淡底、外層 `overflow-x: auto` |
+  | `.tiptap-editor > :first-child` | `margin-top: 0` |
+  - 顏色一律**沿用深色**（既有 CSS 變數 / `prose-invert`），不套 Outline 淺色。
+- **驗證**：`pnpm run build` + lint 綠；測試斷言 editor class **不再含 `prose-sm`**（TiptapEditor 既有測試延伸）。純 CSS 難 TDD，**手動比對樣本清單（回應 codex 6c）**必須逐項截圖對照 Outline：①段落 ②h1/h2/h3 三層標題 ③blockquote ④inline code ⑤code block（含長行橫捲）⑥ul 與 ol ⑦table（含寬表橫捲）。
 - **Review 大小**：小（單檔 CSS + 一處 class 字串）。
 
 ### Phase 2 — `contentWidth` 全域偏好（store，強 TDD）
@@ -149,11 +165,12 @@ interface EditorSettingsState {
 
 ### Phase 3 — 寬度套用 + 狀態列 toggle（元件 TDD）
 
-- **範圍**：`TiptapEditor.tsx`（prop + wrapper class）、`EditorStatusBar.tsx`（toggle）、`EditorPane.tsx`（接線）。
+- **範圍**：`TiptapEditor.tsx`（prop + wrapper class + 水平 padding 移入 wrapper）、`EditorStatusBar.tsx`（toggle）、`EditorPane.tsx`（接線）。
 - **驗證（TDD）**：
-  - `EditorStatusBar`：wysiwyg 時渲染寬度 toggle；raw 時不渲染；點擊呼叫 `onContentWidthChange` 傳另一態；顯示反映當前 `contentWidth`。
+  - `EditorStatusBar`：wysiwyg 時渲染寬度 toggle；raw 時不渲染；點擊呼叫 `onContentWidthChange` 傳另一態；顯示（icon + title）反映當前 `contentWidth`。
   - `EditorPane`：從 store 讀 `contentWidth` 並傳入 TiptapEditor 與 StatusBar（可用既有 EditorPane 測試延伸 / mock store）。
   - `TiptapEditor`：`narrow` 套限寬 class、`full` 不套（斷言 wrapper class）。
+  - **切寬度不 remount / scrollTop 不歸零（回應 codex 1b，本 phase 最易回歸點）**：改變 `contentWidth` prop 後，同一 ProseMirror 節點 / editor instance 不被重建（`key` 不變、`useEditor` 不重跑），且 scroll root 的 `scrollTop` 不因 class 切換被歸零。以 rerender 前後同一 DOM node reference / instance identity 斷言。
 - **Review 大小**：中（3 檔，含 UI）。
 
 **Phase 相依**：1 獨立可先；2 獨立；3 依賴 2（需 store）。可 1→2→3 順序，或 1、2 並行後 3。
@@ -162,13 +179,17 @@ interface EditorSettingsState {
 
 ## 6. 驗收準則（整體）
 
-1. Markdown Live Mode 預設呈現：限寬置中 `52em`、行高 1.7、標題無底線、字級階層如上，深色。
+1. Markdown Live Mode 預設呈現：限寬置中 `52em`（含 padding）、行高 1.7、標題無底線、字級階層如上，深色。
 2. 狀態列（Live Mode 時）出現寬度 toggle；切 `full` 立即滿寬、切 `narrow` 立即限寬置中。
 3. 偏好持久化：重載後維持上次選擇；預設 `narrow`。
-4. Raw（Monaco）模式不受影響、無寬度 toggle。
-5. 非 markdown 檔不顯示寬度 toggle。
-6. `cd spa && npx vitest run` 全綠、`pnpm run lint` 綠、`pnpm run build` 綠。
-7. 既有 viewState 還原 / focus / handoff 行為不回歸。
+4. Raw（Monaco）模式與 Diff 模式不受影響、無寬度 toggle。
+5. **寬度 toggle 僅在 Live Mode（wysiwyg）顯示**（非 Live Mode——即 raw/diff——不顯示；一個 language=markdown 的非 `.md` 檔在 Live Mode 時**照常顯示**）。
+6. **切換寬度不使 editor remount、不丟失 selection、不掉 focus、不把 scrollTop 歸零**（回應 codex 6a/1b）。
+7. **`narrow` 下寬表格與長 code block 仍可讀**：以外層 `overflow-x: auto` 保留橫向捲動，不被 `52em` 裁切（回應 codex 3b）。
+8. **raw ↔ live 往返後**，`contentWidth` 仍沿用 store 值（回應 codex 6b）。
+9. **CJK 長文 + code/table 人工檢查**（回應 codex 5-Q3）：以中文長文（含三層標題、清單、寬表、長 code）實測 `52em` 閱讀觀感，作為是否需微調的依據；本次先忠實沿用 `52em`。
+10. `cd spa && npx vitest run` 全綠、`pnpm run lint` 綠、`pnpm run build` 綠。
+11. 既有 viewState 還原 / focus / handoff 行為不回歸。
 
 ---
 
@@ -179,13 +200,15 @@ interface EditorSettingsState {
 | `.tiptap-editor` 樣式外溢到其他 prose 使用處 | 一律以 `.tiptap-editor` 前綴限定；grep 確認無其他元件複用此 class |
 | 去 `prose-sm` 後 Tailwind prose 預設值回大，與自訂衝突 | CSS 明確覆寫關鍵屬性；build 後截圖驗證 |
 | wrapper 改結構影響 scroll/viewState 還原 | 只在既有內層 div 加寬度 class，不動 scroll 容器與還原邏輯；Phase 3 測試守住 |
-| store doc 註「僅 Monaco」失真 | Phase 2 一併修正註解，避免誤導後續開發 |
+| store doc 註「僅 Monaco」失真 | Phase 2 改寫整段檔頭註解為 global editor preferences |
 | CJK 行高 1.7 對純英文檔略鬆 | 可接受；Outline 亦對多語系統一放鬆；如反彈再 follow-up 分語系 |
+| **切寬度 reflow 後 scroll 體感跳動**（scrollTop 數值不變，但段落高度改變致視角瞬移，回應 codex 3a） | 列為已知風險；驗收 AC6 只保證「不歸零」，體感位移屬 reflow 物理性質，接受；如反彈可 follow-up 記錄切換前錨點段落再校正 |
+| **`narrow` 下寬表格 / 長 code block 橫向溢出被裁**（回應 codex 3b） | `pre` / `table` 外層 `overflow-x: auto`；AC7 守住 |
 
 ---
 
-## 8. 未決 / 待 codex 檢視
+## 8. 未決事項的定案（原待 codex，已採納其判斷）
 
-1. Toggle 用「兩態直接切」還是「下拉（跟 Live Mode 一致）」？本 spec 採兩態直切（更快）；請 codex 評 UX 一致性。
-2. 寬度只作用 Live Mode，raw/diff 不顯示 toggle——是否有使用者會期待 raw 也限寬？（本 spec 判定否。）
-3. `52em` 是否直接沿用，或因 Purdex 深色 + 中文再微調？（本 spec 先沿用權威值，實測後可調。）
+1. **Toggle 型式** → **兩態直接切**（非下拉）。codex 同意：只有 2 值，下拉多一步、收益低。保留 icon + `title` tooltip，不做 icon-only。
+2. **寬度只作用 Live Mode**（raw/diff 不顯示 toggle）→ **維持**。codex 同意：raw 是 Monaco 有自身閱讀語意、diff 更不該混入。
+3. **`52em`** → **先忠實沿用**，不先做 Purdex 微調。codex 同意，但要求驗收補 CJK 長文 + code/table 人工檢查（已納入 AC9），作為日後是否微調的依據。

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -506,7 +506,11 @@ function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { pan
         isMarkdown={isMarkdown}
         editorMode={effectiveEditorMode}
         contentWidth={contentWidth}
-        onContentWidthChange={(value) => useEditorSettingsStore.getState().setContentWidth(value)}
+        // Width toggle is a Live-Mode-only control: while DiffView is mounted the
+        // Tiptap surface is gone, so withhold the handler (EditorStatusBar hides
+        // the toggle when onContentWidthChange is absent) even though editorMode
+        // may still read 'wysiwyg' (AC4: raw/diff show no toggle).
+        onContentWidthChange={showDiff ? undefined : (value) => useEditorSettingsStore.getState().setContentWidth(value)}
         onLanguageChange={(language) => useEditorStore.getState().setBufferLanguage(key, language)}
         onModeChange={(mode) => {
           if (!isMarkdown && mode === 'wysiwyg') return

--- a/spa/src/components/editor/EditorPane.tsx
+++ b/spa/src/components/editor/EditorPane.tsx
@@ -2,6 +2,7 @@
 import { lazy, Suspense, useEffect, useCallback, useState } from 'react'
 import type { PaneRendererProps } from '../../lib/module-registry'
 import { useEditorStore } from '../../stores/useEditorStore'
+import { useEditorSettingsStore } from '../../stores/useEditorSettingsStore'
 import { useTabStore } from '../../stores/useTabStore'
 import { useWorkspaceStore } from '../../features/workspace/store'
 import { useI18nStore } from '../../stores/useI18nStore'
@@ -114,6 +115,7 @@ function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { pan
   const currentName = displayName(filePath, untitled)
   const buffer = useEditorStore((s) => s.buffers[key])
   const paneState = useEditorStore((s) => s.paneStates[paneId])
+  const contentWidth = useEditorSettingsStore((s) => s.contentWidth)
   // Only trust paneState once attachPane has rebound it to THIS buffer. Right after
   // a buffer switch, the first render still sees paneState belonging to the previous
   // buffer (attachPane is a post-commit effect). Deriving the aligned view
@@ -485,6 +487,7 @@ function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { pan
               key={buffer.modelId}
               content={buffer.content}
               isActive={isActive}
+              contentWidth={contentWidth}
               initialViewState={alignedPaneState?.tiptapViewState ?? null}
               onChange={(md) => useEditorStore.getState().updateContent(key, md)}
               onViewStateChange={(vs) => useEditorStore.getState().saveTiptapViewState(paneId, vs)}
@@ -502,6 +505,8 @@ function EditorPaneInner({ paneId, source, filePath, untitled, isActive }: { pan
         encoding={buffer.encoding}
         isMarkdown={isMarkdown}
         editorMode={effectiveEditorMode}
+        contentWidth={contentWidth}
+        onContentWidthChange={(value) => useEditorSettingsStore.getState().setContentWidth(value)}
         onLanguageChange={(language) => useEditorStore.getState().setBufferLanguage(key, language)}
         onModeChange={(mode) => {
           if (!isMarkdown && mode === 'wysiwyg') return

--- a/spa/src/components/editor/EditorStatusBar.test.tsx
+++ b/spa/src/components/editor/EditorStatusBar.test.tsx
@@ -172,6 +172,155 @@ describe('EditorStatusBar', () => {
     expect(controls).toContainElement(screen.getByTitle('Select language'))
   })
 
+  it('renders the content-width toggle in Live Mode when onContentWidthChange is provided', () => {
+    render(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
+        editorMode="wysiwyg"
+        contentWidth="narrow"
+        onContentWidthChange={() => {}}
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByTitle('Narrow width')).toBeInTheDocument()
+  })
+
+  it('does not render the content-width toggle in raw mode', () => {
+    render(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
+        editorMode="raw"
+        contentWidth="narrow"
+        onContentWidthChange={() => {}}
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    expect(screen.queryByTitle('Narrow width')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Full width')).not.toBeInTheDocument()
+  })
+
+  it('does not render the content-width toggle without an onContentWidthChange handler', () => {
+    render(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
+        editorMode="wysiwyg"
+        contentWidth="narrow"
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    expect(screen.queryByTitle('Narrow width')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Full width')).not.toBeInTheDocument()
+  })
+
+  it('toggles between narrow and full on click', () => {
+    const onContentWidthChange = vi.fn()
+    const { rerender } = render(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
+        editorMode="wysiwyg"
+        contentWidth="narrow"
+        onContentWidthChange={onContentWidthChange}
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    fireEvent.click(screen.getByTitle('Narrow width'))
+    expect(onContentWidthChange).toHaveBeenCalledWith('full')
+
+    rerender(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
+        editorMode="wysiwyg"
+        contentWidth="full"
+        onContentWidthChange={onContentWidthChange}
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    fireEvent.click(screen.getByTitle('Full width'))
+    expect(onContentWidthChange).toHaveBeenLastCalledWith('narrow')
+  })
+
+  it('reflects the current contentWidth in the toggle title', () => {
+    const { rerender } = render(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
+        editorMode="wysiwyg"
+        contentWidth="narrow"
+        onContentWidthChange={() => {}}
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByTitle('Narrow width')).toBeInTheDocument()
+    expect(screen.queryByTitle('Full width')).not.toBeInTheDocument()
+
+    rerender(
+      <EditorStatusBar
+        source={{ type: 'inapp' }}
+        line={1}
+        column={1}
+        language="markdown"
+        eol="lf"
+        encoding="utf8"
+        isMarkdown
+        editorMode="wysiwyg"
+        contentWidth="full"
+        onContentWidthChange={() => {}}
+        onModeChange={() => {}}
+        onLanguageChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByTitle('Full width')).toBeInTheDocument()
+    expect(screen.queryByTitle('Narrow width')).not.toBeInTheDocument()
+  })
+
   it('keeps cursor info and hides selectors only when changes are unavailable', () => {
     render(
       <EditorStatusBar

--- a/spa/src/components/editor/EditorStatusBar.tsx
+++ b/spa/src/components/editor/EditorStatusBar.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { CaretUp } from '@phosphor-icons/react'
+import { CaretUp, ArrowsInLineHorizontal, ArrowsOutLineHorizontal } from '@phosphor-icons/react'
 import { useClickOutside } from '../../hooks/useClickOutside'
 import { useHostStore } from '../../stores/useHostStore'
 import type { FileSource } from '../../types/fs'
 import type { EditorEol, EditorEncoding } from '../../stores/useEditorStore'
+import type { ContentWidthOption } from '../../stores/useEditorSettingsStore'
 
 interface Props {
   source: FileSource
@@ -14,6 +15,8 @@ interface Props {
   encoding: EditorEncoding
   isMarkdown: boolean
   editorMode: 'raw' | 'wysiwyg'
+  contentWidth?: ContentWidthOption
+  onContentWidthChange?: (value: ContentWidthOption) => void
   onModeChange?: (mode: 'raw' | 'wysiwyg') => void
   onLanguageChange?: (language: string) => void
 }
@@ -55,7 +58,7 @@ function languageLabel(language: string): string {
   return LANGUAGE_OPTIONS.find((option) => option.value === language)?.label ?? language
 }
 
-export function EditorStatusBar({ source, line, column, language, eol, encoding, isMarkdown, editorMode, onModeChange, onLanguageChange }: Props) {
+export function EditorStatusBar({ source, line, column, language, eol, encoding, isMarkdown, editorMode, contentWidth = 'narrow', onContentWidthChange, onModeChange, onLanguageChange }: Props) {
   const [modeMenuOpen, setModeMenuOpen] = useState(false)
   const [languageMenuOpen, setLanguageMenuOpen] = useState(false)
   const modeMenuRef = useRef<HTMLDivElement>(null)
@@ -119,6 +122,18 @@ export function EditorStatusBar({ source, line, column, language, eol, encoding,
               </div>
             )}
           </div>
+        )}
+        {editorMode === 'wysiwyg' && onContentWidthChange && (
+          <button
+            type="button"
+            title={contentWidth === 'full' ? 'Full width' : 'Narrow width'}
+            onClick={() => onContentWidthChange(contentWidth === 'narrow' ? 'full' : 'narrow')}
+            className="flex items-center gap-1 px-2 py-0.5 rounded border border-border-subtle text-[10px] text-text-secondary hover:bg-surface-hover transition-colors"
+          >
+            {contentWidth === 'full'
+              ? <ArrowsOutLineHorizontal size={12} />
+              : <ArrowsInLineHorizontal size={12} />}
+          </button>
         )}
         {onModeChange && (
           <div className="relative" ref={modeMenuRef}>

--- a/spa/src/components/editor/TiptapEditor.test.tsx
+++ b/spa/src/components/editor/TiptapEditor.test.tsx
@@ -58,9 +58,23 @@ describe('TiptapEditor', () => {
   it('applies typography classes to the editable root', () => {
     render(<TiptapEditor content="# Hello" isActive={false} onChange={() => {}} onSave={() => {}} />)
 
+    // prose-sm dropped: explicit .tiptap-editor CSS now owns the type scale.
     expect(screen.getByTestId('editor-content')).toHaveAttribute(
       'data-editor-class',
-      expect.stringContaining('prose prose-invert prose-sm max-w-none'),
+      expect.stringContaining('prose prose-invert max-w-none'),
+    )
+    expect(screen.getByTestId('editor-content')).toHaveAttribute(
+      'data-editor-class',
+      expect.not.stringContaining('prose-sm'),
+    )
+  })
+
+  it('keeps the tiptap-editor class the CSS scope depends on', () => {
+    render(<TiptapEditor content="# Hello" isActive={false} onChange={() => {}} onSave={() => {}} />)
+
+    expect(screen.getByTestId('editor-content')).toHaveAttribute(
+      'data-editor-class',
+      expect.stringContaining('tiptap-editor'),
     )
   })
 

--- a/spa/src/components/editor/TiptapEditor.test.tsx
+++ b/spa/src/components/editor/TiptapEditor.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TiptapEditor } from './TiptapEditor'
+import { resolveRestoreSelection } from './tiptapSelection'
 
 const useEditorSpy = vi.hoisted(() => vi.fn())
 const editorClassRef = vi.hoisted(() => ({ current: '' }))
@@ -180,6 +181,76 @@ describe('TiptapEditor', () => {
     expect(dispatch.mock.invocationCallOrder[0]).toBeLessThan(focusSpy.mock.invocationCallOrder[0])
     // scroll restored before focus (scrollTop already 50 at focus time)
     expect(scrollAtFocus).toBe(50)
+  })
+
+  it('centers the content wrapper when contentWidth is narrow', () => {
+    render(<TiptapEditor content="# Hello" isActive={false} contentWidth="narrow" onChange={() => {}} onSave={() => {}} />)
+
+    const wrapper = screen.getByTestId('editor-content').parentElement as HTMLElement
+    expect(wrapper.className).toContain('max-w-[52em]')
+    expect(wrapper.className).toContain('mx-auto')
+    expect(wrapper.className).toContain('box-border')
+  })
+
+  it('lets the content wrapper span full width when contentWidth is full', () => {
+    render(<TiptapEditor content="# Hello" isActive={false} contentWidth="full" onChange={() => {}} onSave={() => {}} />)
+
+    const wrapper = screen.getByTestId('editor-content').parentElement as HTMLElement
+    expect(wrapper.className).toContain('max-w-none')
+    expect(wrapper.className).not.toContain('max-w-[52em]')
+  })
+
+  it('defaults to narrow when contentWidth is not provided', () => {
+    render(<TiptapEditor content="# Hello" isActive={false} onChange={() => {}} onSave={() => {}} />)
+
+    const wrapper = screen.getByTestId('editor-content').parentElement as HTMLElement
+    expect(wrapper.className).toContain('max-w-[52em]')
+  })
+
+  it('moves horizontal padding off the editable root onto the wrapper (keeps max-w-none / py-4)', () => {
+    render(<TiptapEditor content="# Hello" isActive={false} contentWidth="narrow" onChange={() => {}} onSave={() => {}} />)
+
+    // Horizontal padding now lives on the width wrapper; the editable root keeps
+    // max-w-none (so prose does not self-limit to 65ch) and its vertical padding.
+    const editorClass = screen.getByTestId('editor-content').getAttribute('data-editor-class') ?? ''
+    expect(editorClass).not.toContain('px-4')
+    expect(editorClass).toContain('max-w-none')
+    expect(editorClass).toContain('py-4')
+  })
+
+  it('does not rerun restore/focus/viewState or reset scroll when contentWidth toggles', () => {
+    const dispatch = vi.fn()
+    const ed = makeMockEditor({
+      state: { selection: { from: 1, to: 1 }, doc: {}, tr: { setSelection: vi.fn().mockReturnThis() } },
+      view: { dispatch },
+    })
+    useEditorSpy.mockReturnValue(ed)
+    const onViewStateChange = vi.fn()
+    const initial = { scrollTop: 30, selection: { type: 'text' as const, from: 2, to: 5 } }
+
+    const { rerender } = render(
+      <TiptapEditor content="hi" isActive={true} initialViewState={initial} contentWidth="narrow"
+        onChange={() => {}} onViewStateChange={onViewStateChange} onSave={() => {}} />,
+    )
+
+    // Snapshot the one-shot restore/focus footprint after the initial (narrow) render.
+    const restoreCalls = vi.mocked(resolveRestoreSelection).mock.calls.length
+    const dispatchCalls = dispatch.mock.calls.length
+    const focusCalls = focusSpy.mock.calls.length
+    const scrollRoot = screen.getByTestId('tiptap-scroll-root')
+    Object.defineProperty(scrollRoot, 'scrollTop', { value: 77, writable: true, configurable: true })
+    onViewStateChange.mockClear()
+
+    rerender(
+      <TiptapEditor content="hi" isActive={true} initialViewState={initial} contentWidth="full"
+        onChange={() => {}} onViewStateChange={onViewStateChange} onSave={() => {}} />,
+    )
+
+    expect(vi.mocked(resolveRestoreSelection).mock.calls.length).toBe(restoreCalls) // restore not re-run
+    expect(dispatch.mock.calls.length).toBe(dispatchCalls) // selection not re-dispatched
+    expect(focusSpy.mock.calls.length).toBe(focusCalls) // focus not re-fired
+    expect(onViewStateChange).not.toHaveBeenCalled() // no phantom unmount write-back
+    expect(scrollRoot.scrollTop).toBe(77) // scroll position preserved
   })
 
   it('does NOT overwrite existing viewState when unmounted before editor is ready (R1 P2)', () => {

--- a/spa/src/components/editor/TiptapEditor.tsx
+++ b/spa/src/components/editor/TiptapEditor.tsx
@@ -5,17 +5,19 @@ import { NodeSelection } from '@tiptap/pm/state'
 import { useEffect, useLayoutEffect, useRef } from 'react'
 import { resolveRestoreSelection } from './tiptapSelection'
 import type { TiptapViewState } from '../../stores/useEditorStore'
+import type { ContentWidthOption } from '../../stores/useEditorSettingsStore'
 
 interface Props {
   content: string // raw markdown
   isActive: boolean
   initialViewState?: TiptapViewState | null
+  contentWidth?: ContentWidthOption
   onChange: (markdown: string) => void
   onViewStateChange?: (viewState: TiptapViewState) => void
   onSave: () => void
 }
 
-export function TiptapEditor({ content, isActive, initialViewState, onChange, onViewStateChange, onSave }: Props) {
+export function TiptapEditor({ content, isActive, initialViewState, contentWidth = 'narrow', onChange, onViewStateChange, onSave }: Props) {
   const onSaveRef = useRef(onSave)
   const containerRef = useRef<HTMLDivElement>(null)
   const isActiveRef = useRef(isActive)
@@ -59,7 +61,7 @@ export function TiptapEditor({ content, isActive, initialViewState, onChange, on
     },
     editorProps: {
       attributes: {
-        class: 'tiptap-editor prose prose-invert max-w-none min-h-full px-4 py-4 focus:outline-none',
+        class: 'tiptap-editor prose prose-invert max-w-none min-h-full py-4 focus:outline-none',
       },
       handleKeyDown: (_view, event) => {
         if ((event.metaKey || event.ctrlKey) && event.key === 's') {
@@ -157,7 +159,11 @@ export function TiptapEditor({ content, isActive, initialViewState, onChange, on
         focusEditable()
       }}
     >
-      <div className="min-h-full [&_.tiptap-editor]:min-h-full [&_.tiptap-editor]:cursor-text">
+      <div
+        className={`min-h-full ${
+          contentWidth === 'full' ? 'max-w-none px-4' : 'max-w-[52em] mx-auto box-border px-4'
+        } [&_.tiptap-editor]:min-h-full [&_.tiptap-editor]:cursor-text`}
+      >
         <EditorContent editor={editor} />
       </div>
     </div>

--- a/spa/src/components/editor/TiptapEditor.tsx
+++ b/spa/src/components/editor/TiptapEditor.tsx
@@ -59,7 +59,7 @@ export function TiptapEditor({ content, isActive, initialViewState, onChange, on
     },
     editorProps: {
       attributes: {
-        class: 'tiptap-editor prose prose-invert prose-sm max-w-none min-h-full px-4 py-4 focus:outline-none',
+        class: 'tiptap-editor prose prose-invert max-w-none min-h-full px-4 py-4 focus:outline-none',
       },
       handleKeyDown: (_view, event) => {
         if ((event.metaKey || event.ctrlKey) && event.key === 's') {

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { EditorPane } from '../EditorPane'
 import { useEditorStore } from '../../../stores/useEditorStore'
 import { useTabStore } from '../../../stores/useTabStore'
+import { useEditorSettingsStore } from '../../../stores/useEditorSettingsStore'
 import type { Pane } from '../../../types/tab'
 import type { FsBackend } from '../../../lib/fs-backend'
 import { bufferKey } from '../../../lib/editor-buffer-key'
@@ -28,7 +29,7 @@ vi.mock('../DiffView', () => ({
 }))
 
 vi.mock('../EditorStatusBar', () => ({
-  EditorStatusBar: (props: { language: string; eol: 'lf' | 'crlf'; encoding: 'utf8'; isMarkdown: boolean; editorMode: 'raw' | 'wysiwyg' }) => {
+  EditorStatusBar: (props: { language: string; eol: 'lf' | 'crlf'; encoding: 'utf8'; isMarkdown: boolean; editorMode: 'raw' | 'wysiwyg'; contentWidth?: 'narrow' | 'full'; onContentWidthChange?: (v: 'narrow' | 'full') => void }) => {
     editorStatusBarMock(props)
     return (
       <div
@@ -144,6 +145,7 @@ describe('EditorPane', () => {
     vi.clearAllMocks()
     useEditorStore.getState().clearAllBuffers()
     useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useEditorSettingsStore.setState({ contentWidth: 'narrow' })
   })
 
   it('preserves pane-local editor state across unmount when the pane still exists in tabs', async () => {
@@ -918,6 +920,71 @@ describe('EditorPane', () => {
     // onViewStateChange 回呼確實寫回 store
     fireEvent.click(screen.getByTestId('tiptap-editor'))
     expect(useEditorStore.getState().paneStates[pane.id].tiptapViewState).toEqual({ scrollTop: 42, selection: { type: 'text', from: 2, to: 3 } })
+  })
+
+  it('passes the store contentWidth into TiptapEditor (wysiwyg path)', async () => {
+    useEditorSettingsStore.setState({ contentWidth: 'full' })
+    const pane = createPane('/notes/cw.md', 'pane-cw')
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+    useEditorStore.getState().openBuffer(getBufferKey('/notes/cw.md'), '# hello', {
+      language: 'markdown', languageSource: 'manual', eol: 'lf', encoding: 'utf8',
+    })
+    useEditorStore.getState().attachPane(pane.id, getBufferKey('/notes/cw.md'))
+    useEditorStore.getState().setEditorMode(pane.id, 'wysiwyg')
+
+    render(<EditorPane pane={pane} isActive />)
+    await waitFor(() => screen.getByTestId('tiptap-editor'))
+
+    expect(tiptapPropsSpy).toHaveBeenLastCalledWith(expect.objectContaining({ contentWidth: 'full' }))
+  })
+
+  it('passes contentWidth + onContentWidthChange into EditorStatusBar and the callback updates the store', async () => {
+    useEditorSettingsStore.setState({ contentWidth: 'narrow' })
+    const pane = createPane('/notes/cw2.md', 'pane-cw2')
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+    useEditorStore.getState().openBuffer(getBufferKey('/notes/cw2.md'), '# hello', {
+      language: 'markdown', languageSource: 'manual', eol: 'lf', encoding: 'utf8',
+    })
+    useEditorStore.getState().attachPane(pane.id, getBufferKey('/notes/cw2.md'))
+    useEditorStore.getState().setEditorMode(pane.id, 'wysiwyg')
+
+    render(<EditorPane pane={pane} isActive />)
+    await waitFor(() => screen.getByTestId('tiptap-editor'))
+
+    expect(editorStatusBarMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ contentWidth: 'narrow', onContentWidthChange: expect.any(Function) }),
+    )
+
+    const onContentWidthChange = editorStatusBarMock.mock.calls.at(-1)?.[0].onContentWidthChange as (v: 'narrow' | 'full') => void
+    act(() => onContentWidthChange('full'))
+    expect(useEditorSettingsStore.getState().contentWidth).toBe('full')
+  })
+
+  it('keeps the store contentWidth after a raw ↔ live round trip (AC8)', async () => {
+    useEditorSettingsStore.setState({ contentWidth: 'full' })
+    const pane = createPane('/notes/cw3.md', 'pane-cw3')
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+    useEditorStore.getState().openBuffer(getBufferKey('/notes/cw3.md'), '# hello', {
+      language: 'markdown', languageSource: 'manual', eol: 'lf', encoding: 'utf8',
+    })
+    useEditorStore.getState().attachPane(pane.id, getBufferKey('/notes/cw3.md'))
+    useEditorStore.getState().setEditorMode(pane.id, 'wysiwyg')
+
+    render(<EditorPane pane={pane} isActive />)
+    await waitFor(() => screen.getByTestId('tiptap-editor'))
+    expect(tiptapPropsSpy).toHaveBeenLastCalledWith(expect.objectContaining({ contentWidth: 'full' }))
+
+    // Switch to raw and back to wysiwyg.
+    act(() => useEditorStore.getState().setEditorMode(pane.id, 'raw'))
+    await waitFor(() => screen.getByTestId('monaco-wrapper'))
+    tiptapPropsSpy.mockClear()
+    act(() => useEditorStore.getState().setEditorMode(pane.id, 'wysiwyg'))
+    await waitFor(() => screen.getByTestId('tiptap-editor'))
+
+    expect(tiptapPropsSpy).toHaveBeenLastCalledWith(expect.objectContaining({ contentWidth: 'full' }))
   })
 
   it('does not mount TiptapEditor against stale paneState even when lazy is cached (stale→raw derivation, supersedes R3 gating)', async () => {

--- a/spa/src/components/editor/__tests__/EditorPane.test.tsx
+++ b/spa/src/components/editor/__tests__/EditorPane.test.tsx
@@ -962,6 +962,30 @@ describe('EditorPane', () => {
     expect(useEditorSettingsStore.getState().contentWidth).toBe('full')
   })
 
+  it('withholds the width-toggle handler while DiffView is active, even entering diff from Live Mode (AC4)', async () => {
+    useEditorSettingsStore.setState({ contentWidth: 'narrow' })
+    const pane = createPane('/notes/cw-diff.md', 'pane-cw-diff')
+    const backend = createBackend()
+    getFsBackendMock.mockReturnValue(backend)
+    useEditorStore.getState().openBuffer(getBufferKey('/notes/cw-diff.md'), '# hello', {
+      language: 'markdown', languageSource: 'manual', eol: 'lf', encoding: 'utf8',
+    })
+    useEditorStore.getState().attachPane(pane.id, getBufferKey('/notes/cw-diff.md'))
+    useEditorStore.getState().setEditorMode(pane.id, 'wysiwyg')
+
+    render(<EditorPane pane={pane} isActive />)
+    await waitFor(() => screen.getByTestId('tiptap-editor'))
+    // Live Mode exposes the handler → toggle visible.
+    expect(editorStatusBarMock.mock.calls.at(-1)?.[0].onContentWidthChange).toEqual(expect.any(Function))
+
+    // Enter diff: DiffView mounts and Tiptap unmounts, but editorMode stays
+    // 'wysiwyg'. The handler must be withheld so EditorStatusBar hides the toggle.
+    act(() => useEditorStore.getState().setShowDiff(pane.id, true))
+    await waitFor(() => {
+      expect(editorStatusBarMock.mock.calls.at(-1)?.[0].onContentWidthChange).toBeUndefined()
+    })
+  })
+
   it('keeps the store contentWidth after a raw ↔ live round trip (AC8)', async () => {
     useEditorSettingsStore.setState({ contentWidth: 'full' })
     const pane = createPane('/notes/cw3.md', 'pane-cw3')

--- a/spa/src/index.css
+++ b/spa/src/index.css
@@ -62,3 +62,114 @@ button:disabled {
 @utility animate-breathe {
   animation: breathe 2s ease-in-out infinite;
 }
+
+/* === Markdown Live Mode (Tiptap) — Outline-style reading typography ===
+   Scoped strictly to `.tiptap-editor` (only TiptapEditor uses this class;
+   MessageBubble uses generic prose and is unaffected). Sizes / weights /
+   spacing are ported from Outline (getoutline.com, ProseMirror family);
+   colours stay on the existing theme variables (never override prose-invert
+   hues). line-height 1.7 follows Outline's complex-script relaxation, which
+   also suits CJK. Width / centering / padding are intentionally NOT set here
+   (owned by a later phase). */
+.tiptap-editor {
+  --tiptap-font-sans: -apple-system, BlinkMacSystemFont, Inter, "Segoe UI", Roboto, Oxygen, sans-serif;
+  --tiptap-font-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-family: var(--tiptap-font-sans);
+  line-height: 1.7;
+}
+
+/* Top-level block rhythm */
+.tiptap-editor > * {
+  margin: 0.5em 0;
+}
+.tiptap-editor > :first-child {
+  margin-top: 0;
+}
+
+/* Headings — 600 weight, no underline, tight bottom margin */
+.tiptap-editor :is(h1, h2, h3, h4, h5, h6) {
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 1em 0 0.25em;
+  border-bottom: 0;
+}
+.tiptap-editor h1 {
+  font-size: 28px;
+}
+.tiptap-editor h2 {
+  font-size: 22px;
+}
+.tiptap-editor h3 {
+  font-size: 18px;
+}
+.tiptap-editor h4 {
+  font-size: 16px;
+}
+.tiptap-editor :is(h5, h6) {
+  font-size: 15px;
+}
+/* A paragraph directly after a heading hugs it */
+.tiptap-editor :is(h1, h2, h3, h4, h5, h6) + p {
+  margin-top: 0.25em;
+}
+
+/* Body copy */
+.tiptap-editor p {
+  font-size: 16px;
+}
+
+/* Lists — reasonable indent + item spacing */
+.tiptap-editor :is(ul, ol) {
+  padding-inline-start: 1.5em;
+}
+.tiptap-editor li {
+  margin: 0.25em 0;
+}
+.tiptap-editor li > :is(ul, ol) {
+  margin: 0.25em 0;
+}
+
+/* Code blocks — mono, faint fill, rounded, horizontally scrollable */
+.tiptap-editor pre {
+  font-family: var(--tiptap-font-mono);
+  background: var(--surface-secondary);
+  border-radius: 6px;
+  padding: 0.75em 1em;
+  overflow-x: auto;
+}
+.tiptap-editor pre code {
+  background: none;
+  padding: 0;
+  font-size: 90%;
+}
+
+/* Inline code — mono, faint fill, small radius */
+.tiptap-editor :not(pre) > code {
+  font-family: var(--tiptap-font-mono);
+  font-size: 90%;
+  background: var(--surface-secondary);
+  padding: 0.15em 0.35em;
+  border-radius: 4px;
+}
+
+/* Blockquote — left rule, muted text */
+.tiptap-editor blockquote {
+  border-inline-start: 3px solid var(--border-default);
+  color: var(--text-secondary);
+  padding-inline: 1em;
+}
+
+/* Tables — cell padding / borders / zebra rows; horizontally scrollable */
+.tiptap-editor .tableWrapper {
+  overflow-x: auto;
+}
+.tiptap-editor table {
+  border-collapse: collapse;
+}
+.tiptap-editor :is(th, td) {
+  border: 1px solid var(--border-default);
+  padding: 0.4em 0.6em;
+}
+.tiptap-editor tbody tr:nth-child(odd) {
+  background: color-mix(in srgb, var(--surface-secondary) 50%, transparent);
+}

--- a/spa/src/index.css
+++ b/spa/src/index.css
@@ -152,11 +152,20 @@ button:disabled {
   border-radius: 4px;
 }
 
-/* Blockquote — left rule, muted text */
+/* Blockquote — left rule, muted text. Also neutralise Tailwind prose's
+   italic + medium weight + inserted curly quote marks (open-quote/close-quote
+   on blockquote p ::before/::after), none of which Outline uses. */
 .tiptap-editor blockquote {
   border-inline-start: 3px solid var(--border-default);
   color: var(--text-secondary);
   padding-inline: 1em;
+  font-style: normal;
+  font-weight: normal;
+  quotes: none;
+}
+.tiptap-editor blockquote p:first-of-type::before,
+.tiptap-editor blockquote p:last-of-type::after {
+  content: none;
 }
 
 /* Tables — cell padding / borders / zebra rows; horizontally scrollable */

--- a/spa/src/index.css
+++ b/spa/src/index.css
@@ -143,13 +143,20 @@ button:disabled {
   font-size: 90%;
 }
 
-/* Inline code — mono, faint fill, small radius */
+/* Inline code — mono, faint fill, small radius. Also neutralise Tailwind
+   prose's injected backticks (code ::before/::after content:"`") and its 600
+   weight, neither of which Outline uses. */
 .tiptap-editor :not(pre) > code {
   font-family: var(--tiptap-font-mono);
   font-size: 90%;
+  font-weight: normal;
   background: var(--surface-secondary);
   padding: 0.15em 0.35em;
   border-radius: 4px;
+}
+.tiptap-editor :not(pre) > code::before,
+.tiptap-editor :not(pre) > code::after {
+  content: none;
 }
 
 /* Blockquote — left rule, muted text. Also neutralise Tailwind prose's

--- a/spa/src/stores/useEditorSettingsStore.test.ts
+++ b/spa/src/stores/useEditorSettingsStore.test.ts
@@ -40,6 +40,13 @@ describe('useEditorSettingsStore', () => {
     // P5: open-behavior toggles default ON — popup + auto layer-1 search.
     expect(s.popupOnMissingFile).toBe(true)
     expect(s.autoSearchLayer1).toBe(true)
+    // Tiptap Live Mode content-width preference defaults to narrow (centered).
+    expect(s.contentWidth).toBe('narrow')
+  })
+
+  it('S1-1c: setContentWidth toggles the store', () => {
+    useEditorSettingsStore.getState().setContentWidth('full')
+    expect(useEditorSettingsStore.getState().contentWidth).toBe('full')
   })
 
   it('S1-1b: setPopupOnMissingFile / setAutoSearchLayer1 toggle the store', () => {
@@ -74,6 +81,7 @@ describe('useEditorSettingsStore', () => {
       setLineNumbers,
       setMinimap,
       setFontSize,
+      setContentWidth,
       reset,
     } = useEditorSettingsStore.getState()
     setTabSize(8)
@@ -82,6 +90,7 @@ describe('useEditorSettingsStore', () => {
     setLineNumbers('off')
     setMinimap(false)
     setFontSize(18)
+    setContentWidth('full')
     reset()
     const s = useEditorSettingsStore.getState()
     expect(s.tabSize).toBe(2)
@@ -90,6 +99,7 @@ describe('useEditorSettingsStore', () => {
     expect(s.lineNumbers).toBe('on')
     expect(s.minimap).toBe(true)
     expect(s.fontSize).toBe(13)
+    expect(s.contentWidth).toBe('narrow')
   })
 
   it('S1-6: setWordWrap("off") persists to localStorage under EDITOR_SETTINGS', () => {
@@ -186,5 +196,57 @@ describe('useEditorSettingsStore', () => {
     expect(s.insertSpaces).toBe(true)
     expect(s.lineNumbers).toBe('on')
     expect(s.minimap).toBe(true)
+  })
+
+  it('S1-10: setContentWidth("full") persists to localStorage under EDITOR_SETTINGS', () => {
+    useEditorSettingsStore.getState().setContentWidth('full')
+    const raw = localStorage.getItem(STORAGE_KEYS.EDITOR_SETTINGS)
+    expect(raw).toBeTruthy()
+    const parsed = JSON.parse(raw!)
+    expect(parsed.state.contentWidth).toBe('full')
+  })
+
+  it('S1-11: happy-path rehydrate restores persisted contentWidth', async () => {
+    // Baseline in-memory state is the default.
+    expect(useEditorSettingsStore.getState().contentWidth).toBe('narrow')
+
+    localStorage.setItem(
+      STORAGE_KEYS.EDITOR_SETTINGS,
+      JSON.stringify({
+        state: {
+          tabSize: 2,
+          insertSpaces: true,
+          wordWrap: 'on',
+          lineNumbers: 'on',
+          minimap: true,
+          fontSize: 13,
+          contentWidth: 'full',
+        },
+        version: 1,
+      }),
+    )
+
+    await useEditorSettingsStore.persist.rehydrate()
+    expect(useEditorSettingsStore.getState().contentWidth).toBe('full')
+  })
+
+  it('S1-12: rehydrate with invalid contentWidth falls back to narrow', async () => {
+    for (const bad of ['wide', 123, null]) {
+      localStorage.setItem(
+        STORAGE_KEYS.EDITOR_SETTINGS,
+        JSON.stringify({ state: { contentWidth: bad }, version: 1 }),
+      )
+      await useEditorSettingsStore.persist.rehydrate()
+      expect(useEditorSettingsStore.getState().contentWidth).toBe('narrow')
+      resetStore()
+    }
+
+    // Missing field also falls back to narrow.
+    localStorage.setItem(
+      STORAGE_KEYS.EDITOR_SETTINGS,
+      JSON.stringify({ state: { wordWrap: 'off' }, version: 1 }),
+    )
+    await useEditorSettingsStore.persist.rehydrate()
+    expect(useEditorSettingsStore.getState().contentWidth).toBe('narrow')
   })
 })

--- a/spa/src/stores/useEditorSettingsStore.ts
+++ b/spa/src/stores/useEditorSettingsStore.ts
@@ -3,20 +3,26 @@ import { persist } from 'zustand/middleware'
 import { purdexStorage, STORAGE_KEYS } from '../lib/storage'
 
 /**
- * User-controlled Monaco code-editor preferences.
+ * User-controlled global editor preferences, shared across both editor
+ * surfaces: the Monaco code editor and the Tiptap Live Mode renderer.
  *
- * Scope: Purdex global. Not per-host / per-workspace; same editor preferences
- * apply across every `/buffer/*` document and any other Monaco instance.
+ * Scope: Purdex global. Not per-host / per-workspace; the same preferences
+ * apply across every `/buffer/*` document and any other editor instance.
  * Not registered with `syncManager` — editor preferences are a device-local
  * choice (the small-screen laptop may want fontSize 11 while the big monitor
  * uses 14) rather than shared config.
  *
- * Tiptap integration is explicitly out of scope for this PR — see spec §2
- * non-goals. Only `MonacoWrapper` reads from this store.
+ * Consumers:
+ * - `MonacoWrapper` reads the code-editor prefs (tabSize / wordWrap /
+ *   lineNumbers / minimap / fontSize / insertSpaces).
+ * - Tiptap Live Mode (`TiptapEditor` via `EditorPane`) reads `contentWidth`,
+ *   the narrow (centered, ~52em) vs full (edge-to-edge) content-width
+ *   preference for rendered markdown.
  */
 export type WordWrapOption = 'on' | 'off'
 export type LineNumbersOption = 'on' | 'off'
 export type TabSizeOption = 2 | 4 | 8
+export type ContentWidthOption = 'narrow' | 'full'
 
 const FONT_SIZE_MIN = 10
 const FONT_SIZE_MAX = 24
@@ -45,6 +51,13 @@ export interface EditorSettingsState {
    */
   autoSearchLayer1: boolean
 
+  /**
+   * Tiptap Live Mode content-width preference. `narrow` centers rendered
+   * markdown within a ~52em column (Outline-style reading measure); `full`
+   * lets content span the editor edge-to-edge. Read by `TiptapEditor`.
+   */
+  contentWidth: ContentWidthOption
+
   setTabSize: (value: TabSizeOption) => void
   setInsertSpaces: (value: boolean) => void
   setWordWrap: (value: WordWrapOption) => void
@@ -53,6 +66,7 @@ export interface EditorSettingsState {
   setFontSize: (value: number) => void
   setPopupOnMissingFile: (value: boolean) => void
   setAutoSearchLayer1: (value: boolean) => void
+  setContentWidth: (value: ContentWidthOption) => void
   reset: () => void
 }
 
@@ -65,6 +79,7 @@ export const DEFAULT_EDITOR_SETTINGS = {
   fontSize: 13,
   popupOnMissingFile: true,
   autoSearchLayer1: true,
+  contentWidth: 'narrow' as ContentWidthOption,
 } as const
 
 function isTabSize(v: unknown): v is TabSizeOption {
@@ -77,6 +92,10 @@ function isWordWrap(v: unknown): v is WordWrapOption {
 
 function isLineNumbers(v: unknown): v is LineNumbersOption {
   return v === 'on' || v === 'off'
+}
+
+function isContentWidth(v: unknown): v is ContentWidthOption {
+  return v === 'narrow' || v === 'full'
 }
 
 function clampFontSize(value: number): number {
@@ -93,7 +112,7 @@ function clampFontSize(value: number): number {
  */
 function sanitize(raw: unknown): Partial<Pick<
   EditorSettingsState,
-  'tabSize' | 'insertSpaces' | 'wordWrap' | 'lineNumbers' | 'minimap' | 'fontSize' | 'popupOnMissingFile' | 'autoSearchLayer1'
+  'tabSize' | 'insertSpaces' | 'wordWrap' | 'lineNumbers' | 'minimap' | 'fontSize' | 'popupOnMissingFile' | 'autoSearchLayer1' | 'contentWidth'
 >> {
   if (raw === null || typeof raw !== 'object') return {}
   const src = raw as Record<string, unknown>
@@ -109,6 +128,7 @@ function sanitize(raw: unknown): Partial<Pick<
   }
   if (typeof src.popupOnMissingFile === 'boolean') out.popupOnMissingFile = src.popupOnMissingFile
   if (typeof src.autoSearchLayer1 === 'boolean') out.autoSearchLayer1 = src.autoSearchLayer1
+  if (isContentWidth(src.contentWidth)) out.contentWidth = src.contentWidth
 
   return out
 }
@@ -126,6 +146,7 @@ export const useEditorSettingsStore = create<EditorSettingsState>()(
       setFontSize: (value) => set({ fontSize: clampFontSize(value) }),
       setPopupOnMissingFile: (popupOnMissingFile) => set({ popupOnMissingFile }),
       setAutoSearchLayer1: (autoSearchLayer1) => set({ autoSearchLayer1 }),
+      setContentWidth: (contentWidth) => set({ contentWidth }),
       reset: () => set({ ...DEFAULT_EDITOR_SETTINGS }),
     }),
     {
@@ -142,6 +163,7 @@ export const useEditorSettingsStore = create<EditorSettingsState>()(
         fontSize: state.fontSize,
         popupOnMissingFile: state.popupOnMissingFile,
         autoSearchLayer1: state.autoSearchLayer1,
+        contentWidth: state.contentWidth,
       }),
       merge: (persisted, current) => {
         const clean = sanitize(persisted)


### PR DESCRIPTION
## 摘要

為 markdown **Live Mode**（Tiptap WYSIWYG 渲染）套用 [Outline](https://github.com/outline/outline)（同屬 ProseMirror 家族）的閱讀排版，並加入**內容寬度切換**（限寬置中 ⇄ 滿寬）。解決先前 `max-w-none` 貼齊面板、寬螢幕單行字元數暴增到 100+、閱讀不適的問題。

樣式數值直接取自 Outline 原始碼（`documentWidth 52em`、h1 28 / h2 22 / h3 18 / h4 16 / h5-6 15、行高 1.7、標題無底線 600 粗、code `6px` 圓角等）。**行高 1.7** 沿用 Outline 對「複雜文字系統」的放鬆處理——中文正屬此類（Outline 漏列 CJK，我們補上）。

## 設計

- **靜態樣式**（`index.css`，scope 於 `.tiptap-editor`）：字級階層、行高、標題、清單、code、blockquote、表格。**顏色一律沿用既有 theme CSS 變數**（跨主題自適應，非硬編深色）——不改配色。
- **動態寬度**（wrapper class by prop）：`narrow` → `max-w-[52em] mx-auto box-border px-4`（padding 計入 52em 內）；`full` → `max-w-none`。不動 `useEditor` 初始化，避免 remount / viewState 風險。
- **全域偏好**：`useEditorSettingsStore.contentWidth`（persist + sanitize + rehydrate 信任邊界），預設 `narrow`，device-local。
- **Toggle 入口**：狀態列右下角、Live Mode 鈕左側，**僅 Live Mode 顯示**；Phosphor 箭頭 icon + tooltip。

## Phases（commit 對應）

| Phase | Commit |
|-------|--------|
| 去 `prose-sm` | `010fab66` |
| Outline typography CSS | `2106ac41` |
| `contentWidth` store | `a990de42` |
| TiptapEditor 寬度 wrapper | `76767819` |
| 狀態列 toggle | `b701f0dd` |
| EditorPane 接線 | `92c8c335` |

## 測試 / 驗證

- **3728 tests passed**（332 檔）；`pnpm run lint` 乾淨；`pnpm run build` 綠。
- 關鍵回歸守護：切寬度**不重跑 restore/dispatch/focus/viewState、scrollTop 不歸零**（行為斷言，非 instance identity）。
- store 併入既有 `rehydrate()` 信任邊界測法（非法值落回 narrow / happy-path 還原）。

## 文件

- Spec：`docs/specs/2026-07-02-md-preview-outline-style-spec.md`
- Plan：`docs/specs/2026-07-02-md-preview-outline-style-plan.md`
- 兩者皆經 codex 跨模型審閱（spec 1 blocker + 12 項；plan 2 blocker + 5 項）全數修正。

## 已知取捨

- `narrow` 下文字 measure 變窄後 reflow，同一 `scrollTop` 數值可能對應不同視覺位置（只保證不歸零，不保證 anchor 完全不位移）——已列接受風險。
- `52em` 先忠實沿用 Outline 值，CJK 長文 + code/table 觀感待實測後可再微調。
- 不改配色 / 不動 Monaco / 不做每檔寬度 / 不新增 i18n key。

🤖 Generated with [Claude Code](https://claude.com/claude-code)