### PR TITLE
feat(snapshot): workspace snapshot capture/storage/restore engine (Phase 1+2, headless)

### DIFF
--- a/docs/specs/2026-07-13-workspace-snapshot-plan.md
+++ b/docs/specs/2026-07-13-workspace-snapshot-plan.md
@@ -157,14 +157,16 @@ export async function ensureSessions(
 - `restorable===false` 的已死筆 → `failed`、`createSession` **未**對它呼叫（不 `createSession('', …)`）。
 - `rebuild:false` → 所有已死一律 `failed`、`createSession` 完全未呼叫；活著仍 `reattached`。
 - `createSession` 對某筆 reject → 該筆 `failed`、其餘照常。
+- **host 離線**（`listSessions` throw）→ 該 host 所有 entry `failed`、`createSession` 未對該 host 呼叫（spec §3.3「session 死但 host 活」vs「host 離線」以 `listSessions` 成敗區分）。
 - **跨 host 同 code**：A、B 同 code，A 活 B 死 → `remap['A'][code].status==='reattached'`、`remap['B'][code].status==='rebuilt'`，不互污。
+- **撞同名 session（§8.1，原 T8 併入，codex plan-review Important）**：`createSession` mock 回傳 `name`/`code` 與請求不同（模擬 daemon 自動改名）→ entry `status==='rebuilt'`、`newCode`=回傳 `session.code`、`session.name`=回傳實際 name（前端一律以 `createSession` **回傳物件**為準，非請求值）。**手動探明**：Phase 2 期間對 daemon 手打一次同名 `POST /api/sessions`，記錄實際行為（拒絕/改名/復用）回填 spec §8.1。
 
 ### T4 — `remapLayoutSessions`（restore.ts）
 
 **Consumes:** `Remap`；`scanPaneTree`/`updatePaneInLayout`。
 **Produces:** `export function remapLayoutSessions(layout: PaneLayout, remap: Remap, opts?: { onlyTerminated?: boolean }): PaneLayout`（純函式）
 
-對每個 `tmux-session` pane 以 `(pane.hostId, pane.sessionCode)` 查 remap：`reattached`/`rebuilt` → 設 `sessionCode=newCode`、`cachedName=session.name`、刪 `terminated`；`failed` → 保留 code、設 `terminated:'tmux-restarted'`；查無 → 原樣。`opts.onlyTerminated===true` → 只處理原本帶 `terminated` 的 pane，活 pane 完全不碰。
+對每個 `tmux-session` pane 以 `(pane.hostId, pane.sessionCode)` 查 remap：`reattached`/`rebuilt` → 設 `sessionCode=newCode`、`cachedName=session.name`、刪 `terminated`；`failed` → 保留 code、設 `terminated:'tmux-restarted'`（**reason 定案，codex plan-review Minor**：restore 情境一律用 `'tmux-restarted'`，語意最貼近「session 因 tmux/host 重啟而失效需重建」；不臆測 `session-closed`/`host-removed`）；查無 → 原樣。`opts.onlyTerminated===true` → 只處理原本帶 `terminated` 的 pane，活 pane 完全不碰。
 
 **Tests:**
 - `rebuilt` entry → pane 的 `sessionCode` 換成 newCode、`cachedName` 更新、`terminated` 清除。
@@ -216,17 +218,15 @@ function syncSessionStore(remap: Remap): void   // 依 remap 的 session 物件 
 > `now` 由 caller（UI）帶入 orchestration（決定性）：三動作簽章實測時可再收一個 `now` 參數或注入 `captureSnapshot`；plan 實作時以 deps 注入 `capture`/`now` 便於測試。
 
 **Tests:**
-- **rebuildAllSessions 範圍（a 點）**：snapshot 有 5 個 restorable 已死 session（其中 2 個當前 tab 未引用）+ 當前 tabs 有對應 terminated pane → `createSession` 呼叫 5 次（含 2 orphan）；當前 tab 結構未變（只 terminated pane 換 code）；未寫 `-prev`。
+- **rebuildAllSessions 範圍（a 點）**：snapshot 有 5 個 restorable 已死 session（其中 2 個當前 tab 未引用）+ 當前 tabs 有對應 terminated pane → `createSession` 呼叫 5 次（含 2 orphan）；當前 tab 結構未變（只 terminated pane 換 code）；**未寫 `-prev`（斷言 `readPrevSnapshot()===null`）**。
 - **restoreTabLayout**：死的 pane 標 terminated（未 createSession）、活的接回；`-prev` 於執行前寫入；tab/workspace = snapshot。
 - **restoreAll**：全重建 + 取代 = snapshot；`-prev` 寫入。
 - **undoLastRestore**：先 restoreAll(A) 產生 `-prev`=舊態 → `undoLastRestore()` 還回舊態；無 `-prev` → 回 `null`。
 - **rebuiltButUnattached（R3 B）**：mock `replaceTabSnapshot` throw（validate 不過）→ `restoreAll` reject、`RestoreReport.rebuiltButUnattached` 含所有 rebuilt 的 `{hostId,name,cwd}`；前端 store 未變（rollback）。
 - **syncSessionStore**：`rebuilt` 後 `useSessionStore.sessions[host]` 含新 session、pane `cachedName`=daemon 回傳 name。
+- **syncSessionStore 聚合不互蓋（codex plan-review Important）**：單一 host 有 2 個 session（1 reattached + 1 rebuilt）→ `replaceHost` 對該 host **只呼叫一次**、`sessions[host]` 含**兩個** session（驗逐筆 replaceHost 互蓋的陷阱已避開）。
 
-### T8 — §8.1 撞同名 session 探明（測試釘住）
-
-**Files:** Test only（`restore.contention.test.ts`）+ plan 註記。
-探明 daemon `createSession` 遇同名 session 行為（Phase 2 期間手動打一次 `POST /api/sessions` 同名，記錄結果於 spec §8.1）。先寫測試：mock `createSession` 回「daemon 自動改名」的 session（`name` 與請求不同）→ 斷言 `ensureSessions` 以**回傳物件**的 code+name 為準（remap.session=回傳物件），前端對接正確。緩解已內建（§3.3），本 task 只釘行為 + 補斷言。
+> **§8.1 撞名探明併入 T3**（codex plan-review Important）：`ensureSessions` 的「以回傳物件為準」語意在 T3 完成時即被測試釘住，不另立晚於 T3 的 task。
 
 **Phase 2 done-criteria:** `npx vitest run` 綠；`pnpm run lint` + `pnpm run build` 綠。§8.1 探明結果回填 spec。PR → codex 兩輪 review（攻擊方重點：rollback / rebuiltButUnattached / 複合鍵不互污）。
 
@@ -234,7 +234,7 @@ function syncSessionStore(remap: Remap): void   // 依 remap 的 session 物件 
 
 ## Phase 3 — Settings「Snapshot」section UI（PR 3）
 
-### T10 — `SnapshotSettingsSection` 骨架 + 健康度對帳
+### T8 — `SnapshotSettingsSection` 骨架 + 健康度對帳
 
 **Files:** Create `spa/src/components/settings/SnapshotSettingsSection.tsx`；Test `SnapshotSettingsSection.test.tsx`。
 **Consumes:** `readSnapshot`；`listSessions`（掛載時對各 host 即時對帳）。範本 `SyncSection.tsx`（status tone toast + `SettingItem` + Phosphor icon 按鈕 + `busy` 並發保護 + `const t = useI18nStore(s=>s.t)`）。
@@ -246,7 +246,7 @@ function syncSessionStore(remap: Remap): void   // 依 remap 的 session 物件 
 - 區塊 2 渲染 workspace→tab→pane（terminal 顯 name、editor 顯 filePath、browser 顯 url）。
 - 無快照 → empty state（只顯「拍下快照」鈕）。
 
-### T11 — 三動作按鈕 wiring + toast
+### T9 — 三動作按鈕 wiring + toast
 
 **Files:** Modify `SnapshotSettingsSection.tsx`；Test 續 `SnapshotSettingsSection.test.tsx`。
 **Consumes:** T7 orchestration（`captureSnapshot`/`rebuildAllSessions`/`restoreTabLayout`/`restoreAll`/`undoLastRestore`）。
@@ -259,7 +259,7 @@ function syncSessionStore(remap: Remap): void   // 依 remap 的 session 物件 
 - `busy` 期間重複點擊只觸發一次。
 - 無 `-prev` → 復原鈕 `disabled`。
 
-### T12 — 註冊 section + i18n
+### T10 — 註冊 section + i18n
 
 **Files:** Modify `spa/src/lib/register-modules/index.tsx`（`registerSettingsSection({ id:'snapshot', label:'settings.section.snapshot', order: SETTINGS_ORDER.SNAPSHOT, component: SnapshotSettingsSection })`）+ `SETTINGS_ORDER` 加 `SNAPSHOT`（置既有之後）；i18n 檔加 `settings.section.snapshot` + 動作/健康度/toast 文案 key（en + zh-TW）。
 
@@ -271,9 +271,9 @@ function syncSessionStore(remap: Remap): void   // 依 remap 的 session 物件 
 
 ## Risks / notes
 
-- **§8.1 撞同名 session**（唯一碰 daemon 點）：Phase 2 T8 探明，緩解已內建（以 `createSession` 回傳實際 code+name 為準）。
+- **§8.1 撞同名 session**（唯一碰 daemon 點）：Phase 2 T3 探明（已併入），緩解已內建（以 `createSession` 回傳實際 code+name 為準）。
 - **§8.3 大量 session 重建**：`ensureSessions` 對已死逐一 `createSession`；量大時的並行/上限 —— Phase 2 T3 實作時傾向「有上限並行（如 `p-limit` 語意，手寫 chunk）+ 逐一失敗隔離」，測試以序列 mock 驗語意即可，並行度為效能優化不改語意。
 - **best-effort 取代跨視窗空窗**：`replaceTabSnapshot` 兩次 `setState` 各自 `syncManager.notify` 廣播，其他視窗短暫見中間態 —— spec §3.5 已明訂 best-effort、非承諾消除；不引入 batched key（超本次範圍）。
 - **daemon 副作用非交易性（R3 B）**：restore 失敗 rollback 只還原前端 store；已建 session 用 `rebuiltButUnattached` 揭露、不自動刪（與「重建所有 session」刻意 orphan 一致，不造成資料遺失）。
 - **`settings.scope.workspaceId`（R3 C）**：`validateSnapshotConsistency` 不驗；若指向已刪 workspace，既有 UI 顯示 `Workspace not found`（非致命）。
-- **`Date.now()` 注入**：`capture`/orchestration 的 `now` 由 UI 帶入以利決定性測試；只有 T11 UI 層實際呼叫 `Date.now()`。
+- **`Date.now()` 注入**：`capture`/orchestration 的 `now` 由 UI 帶入以利決定性測試；只有 T9 UI 層實際呼叫 `Date.now()`。

--- a/docs/specs/2026-07-13-workspace-snapshot-plan.md
+++ b/docs/specs/2026-07-13-workspace-snapshot-plan.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** 依 `superpowers:subagent-driven-development` 每個 Task 派 fresh subagent（TDD：先寫測試→跑紅→實作→跑綠→commit），主 session 只做整合與 task 間 review。Steps 用 checkbox 追蹤。
 
-實作定稿 spec `docs/specs/2026-07-13-workspace-snapshot-spec.md`（`3d9c69b`，codex R1–R3 全過）。純前端 SPA 功能，daemon 大概率零改動（唯一待探明：§8.1 撞同名 session，Phase 2 T9 探）。
+實作定稿 spec `docs/specs/2026-07-13-workspace-snapshot-spec.md`（`3d9c69b`，codex R1–R3 全過）。純前端 SPA 功能，daemon 大概率零改動（唯一待探明：§8.1 撞同名 session，Phase 2 T3 探）。
 
 **Goal:** 拍下當前整個工作區（workspace/tab/pane 結構 + 每個 tmux session 的 name/cwd），讓伺服器重開機 / tmux 重啟後依 name+cwd 一鍵把工作環境重建回來。
 
@@ -96,6 +96,11 @@ export interface EnsureReport { reattached: number; rebuilt: number; failed: num
 export interface RestoreReport extends EnsureReport {
   rebuiltButUnattached: Array<{ hostId: string; name: string; cwd: string }>  // R3 B
 }
+// 失敗契約（codex 複審 B2）：三動作成功 resolve RestoreReport；replaceTabSnapshot throw
+// 時包成 RestoreError（帶已收集含 rebuiltButUnattached 的 report）reject，UI catch 後讀 e.report。
+export class RestoreError extends Error {
+  constructor(public report: RestoreReport, public cause?: unknown) { super('restore failed') }
+}
 // storage.ts (走 browserStorage，自己 JSON.stringify；key 常數見下)
 export const SNAPSHOT_KEY = 'purdex-workspace-snapshot'
 export const SNAPSHOT_PREV_KEY = 'purdex-workspace-snapshot-prev'
@@ -118,10 +123,17 @@ export function writePrevSnapshot(snap: WorkspaceSnapshot): void
 
 **Files:** Create `capture.ts`；Test `capture.test.ts`。
 **Consumes:** T1 型別 + `writeSnapshot`；`useTabStore`/`useWorkspaceStore` getState；`listSessions`；`scanPaneTree`。
-**Produces:** `export async function captureSnapshot(now: number): Promise<CaptureResult>`
+**Produces（拆兩個 API，codex 複審 B1）:**
+```ts
+export async function buildSnapshot(now: number): Promise<WorkspaceSnapshot>  // 純建物件，不寫任何 storage
+export async function captureSnapshot(now: number): Promise<CaptureResult>    // = buildSnapshot + writeSnapshot 正本 + 回統計
+```
 
-邏輯：①`useTabStore.getState()` 取 `tabs/tabOrder/activeTabId`、`useWorkspaceStore.getState()` 取 `workspaces/activeWorkspaceId`。②對每個 tab.layout `scanPaneTree` 收集 `content.kind==='tmux-session'` 的 `{hostId, sessionCode, mode, cachedName}`，依 hostId 分組。③每個 host **呼叫一次** `listSessions(hostId)`：成功 → 對每個 code 在清單找 `s.code===sessionCode`，命中填 `{name:s.name, cwd:s.cwd, currentCommand:s.current_command, restorable:true}`；未命中（拍當下已死）→ `{name:cachedName, cwd:undefined, restorable:false, captureError:'session-dead-at-capture'}`。`listSessions` throw（host 不可達）→ 該 host 全部 code → `{name:cachedName, cwd:undefined, restorable:false, captureError:'host-unreachable'}`。④組 `WorkspaceSnapshot { version:1, capturedAt: now, … , sessionMeta }`，`writeSnapshot`。⑤回 `{ total, resolved(restorable=true 數), unresolved(restorable=false 數) }`。
+**`buildSnapshot(now)` 邏輯：**①`useTabStore.getState()` 取 `tabs/tabOrder/activeTabId`、`useWorkspaceStore.getState()` 取 `workspaces/activeWorkspaceId`。②對每個 tab.layout `scanPaneTree` 收集 `content.kind==='tmux-session'` 的 `{hostId, sessionCode, mode, cachedName}`，依 hostId 分組。③每個 host **呼叫一次** `listSessions(hostId)`：成功 → 對每個 code 在清單找 `s.code===sessionCode`，命中填 `{name:s.name, cwd:s.cwd, currentCommand:s.current_command, restorable:true}`；未命中（拍當下已死）→ `{name:cachedName, cwd:undefined, restorable:false, captureError:'session-dead-at-capture'}`。`listSessions` throw（host 不可達）→ 該 host 全部 code → `{name:cachedName, cwd:undefined, restorable:false, captureError:'host-unreachable'}`。④回 `WorkspaceSnapshot { version:1, capturedAt: now, … , sessionMeta }`（**不寫 storage**）。
 
+**`captureSnapshot(now)` 邏輯：**`const snap = await buildSnapshot(now)` → `writeSnapshot(snap)`（寫正本）→ 回 `{ total, resolved(restorable=true 數), unresolved(restorable=false 數) }`（由 `snap.sessionMeta` 統計）。
+
+> **B1 rationale**：`captureSnapshot` 會覆寫正本 snapshot；restore 前若要拍「當前態」寫 `-prev` 後悔藥（T7），**必須用 `buildSnapshot` 不碰正本**，否則會在還原前把正本覆寫成當前態、毀掉還原來源。
 > `capturedAt` 由入參 `now` 帶入（決定性測試）；不在函式內 `Date.now()`。
 
 **Tests（mock `host-api`：`vi.mock('../host-api', …{ …actual, listSessions: vi.fn() })`；`beforeEach` `setState` 植入兩 store + `localStorage.clear()`）:**
@@ -130,6 +142,7 @@ export function writePrevSnapshot(snap: WorkspaceSnapshot): void
 - host B `listSessions` reject → B 的 pane `restorable=false`+`captureError:'host-unreachable'`、A 照常；`unresolved` 計數正確、**不中斷**。
 - pane code 不在 live 清單 → `captureError:'session-dead-at-capture'`、`cwd===undefined`。
 - 無 tmux pane（純 editor/browser tab） → `total=0`、`sessionMeta` 為 `{}`、仍寫出快照。
+- **`buildSnapshot` 不寫 storage（B1）**：先 `writeSnapshot(舊快照)` → `buildSnapshot(now)` 回新物件但 `readSnapshot()` 仍為**舊快照**（未被覆寫）；改呼叫 `captureSnapshot(now)` 後 `readSnapshot()` 才變新物件。
 
 **Phase 1 done-criteria:** `npx vitest run`（新測試綠）；`pnpm run lint` + `pnpm run build` 綠。PR → codex 兩輪 review。
 
@@ -170,7 +183,7 @@ export async function ensureSessions(
 
 **Tests:**
 - `rebuilt` entry → pane 的 `sessionCode` 換成 newCode、`cachedName` 更新、`terminated` 清除。
-- `failed` → pane 標 `terminated`。
+- `failed` → pane 標 `terminated`，**斷言 `terminated === 'tmux-restarted'`（釘死具體值，防回退，codex 複審 I1）**。
 - **`onlyTerminated:true`**：一活 pane 的 (hostId,code) 恰等於某 remap 舊 code、但該 pane 非 terminated → **不被動到**（正確性防線，spec §3.5）。
 - split 樹（巢狀 SplitLayout）多 tmux pane → 全部依複合鍵改寫。
 
@@ -197,6 +210,7 @@ export function replaceTabSnapshot(snap: WorkspaceSnapshot): void    // 取代 t
 - `replaceTabSnapshot` 後兩 store = 快照內容；`visitHistory` 不含已消失 tab（restore 後立刻 `closeTabInWorkspace` active tab → 選到的下一個 tab 正確）。
 - 壞快照（validate 不過）→ throw、兩 store **完全未變**。
 - mock 第二個 `setState`（workspace）throw → 兩 store 皆 rollback 回舊值。
+- **mock 第一個 `setState`（tab）throw → workspace 完全未被呼叫、tab store rollback 回舊值、不留半套（codex 複審 I2，釘死「任一步 throw 全回滾」的第一分支）**。
 - `replaceTabState` 只動 tab store、不碰 workspace。
 
 ### T7 — 三動作 orchestration + `-prev` + rebuiltButUnattached（restore.ts）

--- a/docs/specs/2026-07-13-workspace-snapshot-plan.md
+++ b/docs/specs/2026-07-13-workspace-snapshot-plan.md
@@ -1,0 +1,279 @@
+# Plan — Workspace Snapshot（工作區快照 / 一鍵重建）
+
+> **For agentic workers:** 依 `superpowers:subagent-driven-development` 每個 Task 派 fresh subagent（TDD：先寫測試→跑紅→實作→跑綠→commit），主 session 只做整合與 task 間 review。Steps 用 checkbox 追蹤。
+
+實作定稿 spec `docs/specs/2026-07-13-workspace-snapshot-spec.md`（`3d9c69b`，codex R1–R3 全過）。純前端 SPA 功能，daemon 大概率零改動（唯一待探明：§8.1 撞同名 session，Phase 2 T9 探）。
+
+**Goal:** 拍下當前整個工作區（workspace/tab/pane 結構 + 每個 tmux session 的 name/cwd），讓伺服器重開機 / tmux 重啟後依 name+cwd 一鍵把工作環境重建回來。
+
+**Architecture:** 三層純邏輯（capture / storage / restore，不依賴 React，Vitest 直測）+ 一個 Settings section UI。restore 建立在兩個 primitive 上：`ensureSessions`（對帳 + 重建，回傳 `(hostId,oldCode)→RemapEntry` 複合鍵表）與 `remapLayoutSessions`（純函式改寫 layout 樹）。三個還原動作（重建所有 session / 還原 tab 佈局 / 全部還原）由這兩個 primitive 組合。
+
+**Tech Stack:** React 19 / Zustand 5（既有 store，直接 `setState` merge-mode 整包取代）/ Vitest + RTL / Phosphor Icons。
+
+## Global Constraints
+
+- **Package manager `pnpm`**；測試 `cd spa && npx vitest run`、lint `pnpm run lint`、build `pnpm run build`。
+- **複合鍵**：`sessionCode` 是 **host-local**，`sessionMeta` / `Remap` 一律 `Record<hostId, Record<sessionCode, …>>` 巢狀索引；禁用裸 code。
+- **`restorable`**：cwd 有值且 host 可達才 `true`；`restorable === false` 者 restore **不呼叫 `createSession`**，直接標 terminated。
+- **重建範圍＝產品決策（a 點，勿翻案）**：「重建所有 session」重建快照裡**所有** `restorable` 且對帳已死的 session，**不限**當前 tab 是否引用；orphan 為預期。`onlyTerminated` 只收窄 **remap 套用範圍**（改當前哪些 pane），與重建範圍獨立。
+- **取代為 best-effort 一致、非跨視窗真原子**；失敗「不留半套」僅指前端 store（daemon 已建 session 是真副作用，揭露不自動刪除）。
+- **每個 Task 獨立 commit**；不直推 main（走 PR）。
+
+---
+
+## What already exists（逐字簽章，do not rebuild）
+
+**`spa/src/lib/host-api.ts`**
+```ts
+export interface Session {                          // :7-18
+  code: string; name: string; cwd: string; mode: string
+  cc_session_id: string; cc_model: string; has_relay: boolean
+  current_command?: string; pane_title?: string; window_name?: string
+}
+export async function listSessions(hostId: string): Promise<Session[]>          // :94 (fail→throw)
+export async function createSession(hostId: string, name: string, cwd: string, mode: string): Promise<Session>  // :100
+export async function fetchSessionCwd(hostId: string, sessionCode: string, signal?: AbortSignal): Promise<string> // :157
+```
+
+**`spa/src/types/tab.ts`** — `Tab { id; pinned; locked; createdAt; layout: PaneLayout }`（:5）；`PaneLayout = { type:'leaf'; pane:Pane } | SplitLayout`（:14）；`Pane { id; content: PaneContent }`（:22）；`PaneContent` tmux-session 分支 = `{ kind:'tmux-session'; hostId; sessionCode; mode:'terminal'|'stream'; cachedName; tmuxInstance; terminated?: TerminatedReason }`（:35）；`TerminatedReason = 'session-closed'|'tmux-restarted'|'host-removed'`（:28）；`Workspace { id; name; icon?; iconWeight?; tabs: string[]; activeTabId: string|null; moduleConfig? }`（:53）；`createTab(content, opts?)`（:64）、`createWorkspace(name, icon?)`（:74）、`isStandaloneTab(tabId, workspaces)`（:85）。
+
+**`spa/src/lib/pane-tree.ts`** — `scanPaneTree(layout, fn:(pane:Pane)=>void): void`（:41）；`collectLeaves(layout): Pane[]`（:136）；`updatePaneInLayout(layout, paneId, content): PaneLayout`（:24）。**注意** `findTabBySessionCode` 只比 primary pane，快照掃全樹一律用 `scanPaneTree`。
+
+**`spa/src/stores/useTabStore.ts`** — `TabState { tabs: Record<string,Tab>; tabOrder: string[]; activeTabId: string|null; visitHistory: string[]; … }`（:127）。persist partialize 只存 `tabs/tabOrder/activeTabId`（**`visitHistory` 不 persist**，:454）。actions：`setTabLayout(tabId, layout)`（:349）、`markTerminated(hostId, sessionCode, reason)`（:426）、`updateSessionCache(hostId, sessionCode, cachedName)`（:408）。**整包取代無專用 action → `useTabStore.setState({ tabs, tabOrder, activeTabId, visitHistory })`**（merge-mode）。
+
+**`spa/src/features/workspace/store.ts`** — `WorkspaceState { workspaces: Workspace[]; activeWorkspaceId: string|null; … }`（:9）。persist partialize `workspaces/activeWorkspaceId`（:292）。`importWorkspace(ws)` 只在 id 不存在時 append（:266）；`reset()` → `{ workspaces:[], activeWorkspaceId:null }`（:290）。整包取代 → `useWorkspaceStore.setState({ workspaces, activeWorkspaceId })`。關 tab 讀 `useTabStore.getState().visitHistory` 選下一個 tab（`closeTabInWorkspace` :186–219）。
+
+**`spa/src/stores/useSessionStore.ts`** — `sessions: Record<string, Session[]>`（hostId→array，**不 persist**）；`replaceHost(hostId, sessions: Session[])`（:29，整包替換單 host）；`fetchHost(hostId)`（:23）。`SessionPaneContent` 以 `sessions[hostId].find(s=>s.code===sessionCode)` 取 live session（:27）。
+
+**`spa/src/lib/composite-key.ts`** — `compositeKey(hostId, sessionCode): string` → `` `${hostId}:${sessionCode}` ``。
+
+**`spa/src/lib/storage/`** — `browserStorage: StateStorage`（`getItem/setItem/removeItem`，`setItem` 有 `prev===value` 短路 + `syncManager.notify(name)`；browser-backend.ts:4）；`STORAGE_KEYS`（keys.ts，`as const`）。
+
+**`spa/src/lib/settings-section-registry.ts`** — `registerSettingsSection({ id, label, order, component: React.ComponentType })`（:66，`label` 是 i18n key，`component===undefined` 會 warn+return）。註冊點 `spa/src/lib/register-modules/index.tsx:307+`（用 `SETTINGS_ORDER.*` 常數）。UI 範本 `spa/src/components/settings/SyncSection.tsx`（status tone toast + `SettingItem` + Phosphor icon 按鈕 + `busy` 並發保護）。
+
+## Decisions（user + codex, this session）
+
+1. **重建範圍 a 點**：見 Global Constraints（override codex R2 orphan 收窄）。
+2. **PR / Phase 切分**：**Phase 1 資料模型+capture+storage** → **Phase 2 restore 引擎+三動作** → **Phase 3 Settings UI**，各獨立 PR + codex 兩輪 review。
+3. **restore 失敗揭露（R3 B）**：orchestration 回傳 `rebuiltButUnattached: Array<{hostId,name,cwd}>`；UI toast + `console.warn` 揭露，不自動刪 daemon session。
+4. **`validateSnapshotConsistency` 範圍界定（R3 C）**：只驗 tab/workspace 導航參照（五條），不驗 pane content 語意參照（`settings.scope.workspaceId`）。
+5. **`ensureSessions` 加 `{ rebuild?: boolean }`**：「還原 tab 佈局」用 `rebuild:false`（死的一律 `failed`→terminated、不 createSession），統一 primitive（實作細化 spec §3.5「還原 tab 佈局：不重建」）。
+
+---
+
+## Phase 1 — 資料模型 + capture + 持久化（PR 1）
+
+新目錄 `spa/src/lib/snapshot/`。純邏輯 TDD，mock 兩 store + `host-api`。
+
+### T1 — 型別 + storage 讀寫（`spa/src/lib/snapshot/types.ts` + `storage.ts`）
+
+**Files:** Create `types.ts`、`storage.ts`；Test `storage.test.ts`。
+
+**Produces:**
+```ts
+// types.ts
+export interface SessionMeta {
+  hostId: string; sessionCode: string; name: string
+  mode: 'terminal' | 'stream'
+  cwd?: string; currentCommand?: string
+  restorable: boolean
+  captureError?: 'host-unreachable' | 'session-dead-at-capture'
+}
+export interface WorkspaceSnapshot {
+  version: 1; capturedAt: number
+  tabs: Record<string, Tab>; tabOrder: string[]; activeTabId: string | null
+  workspaces: Workspace[]; activeWorkspaceId: string | null
+  sessionMeta: Record<string, Record<string, SessionMeta>>   // [hostId][sessionCode]
+}
+export interface CaptureResult { total: number; resolved: number; unresolved: number }
+import type { Session } from '../host-api'
+export type RemapEntry =
+  | { status: 'reattached'; newCode: string; session: Session }
+  | { status: 'rebuilt';    newCode: string; session: Session }
+  | { status: 'failed' }
+export type Remap = Record<string, Record<string, RemapEntry>>  // [hostId][oldCode]
+export interface EnsureReport { reattached: number; rebuilt: number; failed: number }
+export interface RestoreReport extends EnsureReport {
+  rebuiltButUnattached: Array<{ hostId: string; name: string; cwd: string }>  // R3 B
+}
+// storage.ts (走 browserStorage，自己 JSON.stringify；key 常數見下)
+export const SNAPSHOT_KEY = 'purdex-workspace-snapshot'
+export const SNAPSHOT_PREV_KEY = 'purdex-workspace-snapshot-prev'
+export function readSnapshot(): WorkspaceSnapshot | null
+export function writeSnapshot(snap: WorkspaceSnapshot): void
+export function readPrevSnapshot(): WorkspaceSnapshot | null
+export function writePrevSnapshot(snap: WorkspaceSnapshot): void
+```
+`read*` 走 `browserStorage.getItem` + `JSON.parse`，parse 失敗 / `version !== 1` → 回 `null`（不拋）。`write*` 走 `browserStorage.setItem(key, JSON.stringify(snap))`（享 `syncManager.notify` 廣播，無 listener 亦安全）。
+
+**Steps:** 寫 `storage.test.ts` 紅 → 實作 → 綠 → commit。
+**Tests（`storage.test.ts`，`beforeEach` `localStorage.clear()`）:**
+- `writeSnapshot` 後 `readSnapshot` 得等值物件（round-trip）。
+- 空 key → `readSnapshot()` 回 `null`。
+- localStorage 存入壞 JSON → `readSnapshot()` 回 `null`、不拋。
+- `version` 非 1 → `readSnapshot()` 回 `null`。
+- `writePrevSnapshot` / `readPrevSnapshot` 各自獨立 key，互不干擾。
+
+### T2 — capture（`spa/src/lib/snapshot/capture.ts`）
+
+**Files:** Create `capture.ts`；Test `capture.test.ts`。
+**Consumes:** T1 型別 + `writeSnapshot`；`useTabStore`/`useWorkspaceStore` getState；`listSessions`；`scanPaneTree`。
+**Produces:** `export async function captureSnapshot(now: number): Promise<CaptureResult>`
+
+邏輯：①`useTabStore.getState()` 取 `tabs/tabOrder/activeTabId`、`useWorkspaceStore.getState()` 取 `workspaces/activeWorkspaceId`。②對每個 tab.layout `scanPaneTree` 收集 `content.kind==='tmux-session'` 的 `{hostId, sessionCode, mode, cachedName}`，依 hostId 分組。③每個 host **呼叫一次** `listSessions(hostId)`：成功 → 對每個 code 在清單找 `s.code===sessionCode`，命中填 `{name:s.name, cwd:s.cwd, currentCommand:s.current_command, restorable:true}`；未命中（拍當下已死）→ `{name:cachedName, cwd:undefined, restorable:false, captureError:'session-dead-at-capture'}`。`listSessions` throw（host 不可達）→ 該 host 全部 code → `{name:cachedName, cwd:undefined, restorable:false, captureError:'host-unreachable'}`。④組 `WorkspaceSnapshot { version:1, capturedAt: now, … , sessionMeta }`，`writeSnapshot`。⑤回 `{ total, resolved(restorable=true 數), unresolved(restorable=false 數) }`。
+
+> `capturedAt` 由入參 `now` 帶入（決定性測試）；不在函式內 `Date.now()`。
+
+**Tests（mock `host-api`：`vi.mock('../host-api', …{ …actual, listSessions: vi.fn() })`；`beforeEach` `setState` 植入兩 store + `localStorage.clear()`）:**
+- 單 host 兩 tmux pane 都活著 → `sessionMeta[host][code]` 依複合鍵巢狀正確、`restorable=true`、`resolved=2`；`readSnapshot()` 存到、`capturedAt===now`。
+- **跨 host 同 code**：host A、host B 各有相同 `sessionCode` 值 → `sessionMeta['A'][code]` 與 `sessionMeta['B'][code]` 各自獨立、不互蓋。
+- host B `listSessions` reject → B 的 pane `restorable=false`+`captureError:'host-unreachable'`、A 照常；`unresolved` 計數正確、**不中斷**。
+- pane code 不在 live 清單 → `captureError:'session-dead-at-capture'`、`cwd===undefined`。
+- 無 tmux pane（純 editor/browser tab） → `total=0`、`sessionMeta` 為 `{}`、仍寫出快照。
+
+**Phase 1 done-criteria:** `npx vitest run`（新測試綠）；`pnpm run lint` + `pnpm run build` 綠。PR → codex 兩輪 review。
+
+---
+
+## Phase 2 — restore 引擎 + 三動作（PR 2）
+
+`spa/src/lib/snapshot/restore.ts`。純邏輯 TDD。
+
+### T3 — `ensureSessions`（restore.ts）
+
+**Consumes:** `SessionMeta/Remap/EnsureReport`；`listSessions`/`createSession`。
+**Produces:**
+```ts
+export async function ensureSessions(
+  sessionMeta: Record<string, Record<string, SessionMeta>>,
+  opts?: { rebuild?: boolean },        // rebuild default true
+): Promise<{ remap: Remap; report: EnsureReport }>
+```
+每 host **一次** `listSessions`（成功=host 可達）。對 `sessionMeta[host][oldCode]`：live 清單含 oldCode → `reattached`（newCode=oldCode, session=該 live）；已死 且 `opts.rebuild!==false` 且 `restorable` → `createSession(host, name, cwd!, mode)` → `rebuilt`（newCode=回傳 `session.code`, session=回傳物件）；否則（host 離線 / `restorable===false` / `rebuild===false` / `createSession` throw）→ `failed`。逐 session 失敗隔離（單筆 throw 只記 `failed`，不中斷其他）。
+
+**Tests（mock host-api）:**
+- 全活 → 全 `reattached`、`createSession` 未被呼叫、`report.reattached` 正確。
+- **重建範圍（a 點）**：3 筆 restorable 已死（含當前 tab 未引用的 orphan）+ 1 筆活著 → `createSession` 呼叫 **3** 次（= restorable 且已死數，活著走 reattached 不計入），**不因未引用而略過**。
+- `restorable===false` 的已死筆 → `failed`、`createSession` **未**對它呼叫（不 `createSession('', …)`）。
+- `rebuild:false` → 所有已死一律 `failed`、`createSession` 完全未呼叫；活著仍 `reattached`。
+- `createSession` 對某筆 reject → 該筆 `failed`、其餘照常。
+- **跨 host 同 code**：A、B 同 code，A 活 B 死 → `remap['A'][code].status==='reattached'`、`remap['B'][code].status==='rebuilt'`，不互污。
+
+### T4 — `remapLayoutSessions`（restore.ts）
+
+**Consumes:** `Remap`；`scanPaneTree`/`updatePaneInLayout`。
+**Produces:** `export function remapLayoutSessions(layout: PaneLayout, remap: Remap, opts?: { onlyTerminated?: boolean }): PaneLayout`（純函式）
+
+對每個 `tmux-session` pane 以 `(pane.hostId, pane.sessionCode)` 查 remap：`reattached`/`rebuilt` → 設 `sessionCode=newCode`、`cachedName=session.name`、刪 `terminated`；`failed` → 保留 code、設 `terminated:'tmux-restarted'`；查無 → 原樣。`opts.onlyTerminated===true` → 只處理原本帶 `terminated` 的 pane，活 pane 完全不碰。
+
+**Tests:**
+- `rebuilt` entry → pane 的 `sessionCode` 換成 newCode、`cachedName` 更新、`terminated` 清除。
+- `failed` → pane 標 `terminated`。
+- **`onlyTerminated:true`**：一活 pane 的 (hostId,code) 恰等於某 remap 舊 code、但該 pane 非 terminated → **不被動到**（正確性防線，spec §3.5）。
+- split 樹（巢狀 SplitLayout）多 tmux pane → 全部依複合鍵改寫。
+
+### T5 — `validateSnapshotConsistency`（restore.ts）
+
+**Produces:** `export function validateSnapshotConsistency(snap: WorkspaceSnapshot): { ok: true } | { ok: false; reason: string }`
+
+五條（R2 C，全通過才 `ok`）：①`workspace.tabs` 每 id ∈ `tabs`；②`activeTabId` ∈ `tabs` 或 `null`；③各 `workspace.activeTabId` ∈ 該 `workspace.tabs`；④`activeWorkspaceId` ∈ `workspaces` 的 id 集合，或 `null`；⑤`tabOrder` 每 id ∈ `tabs`。**不驗** `settings.scope.workspaceId`（R3 C 範圍界定）。
+
+**Tests:** 合法快照 → `ok:true`；分別造 5 種壞快照（workspace.tabs 幽靈 id / activeTabId 幽靈 / workspace.activeTabId 不在該 ws / activeWorkspaceId 不在 workspaces / tabOrder 幽靈）各回 `ok:false`；`settings` pane scope 指向不存在 workspace → 仍 `ok:true`（明示不驗）。
+
+### T6 — `replaceTabState` + `replaceTabSnapshot`（restore.ts）
+
+**Consumes:** T5；`useTabStore`/`useWorkspaceStore` setState。
+**Produces:**
+```ts
+export function replaceTabState(tabs, tabOrder, activeTabId): void   // 僅 tab store，供「重建所有 session」
+export function replaceTabSnapshot(snap: WorkspaceSnapshot): void    // 取代 tab + workspace（含 rollback）
+```
+`replaceTabState`：`useTabStore.setState({ tabs, tabOrder, activeTabId, visitHistory: <filtered> })`（`visitHistory` filter 成新 `tabOrder` 子集）。
+`replaceTabSnapshot`：①`validateSnapshotConsistency`，不 ok → throw（不動 store）。②存兩 store 舊值（`useTabStore.getState()` / `useWorkspaceStore.getState()` 的相關欄位）。③`useTabStore.setState({ tabs, tabOrder, activeTabId, visitHistory: filtered })` → `useWorkspaceStore.setState({ workspaces, activeWorkspaceId })`。④任一步 throw → 用舊值 `setState` rollback 兩 store、再 rethrow。
+
+**Tests（`setState` merge-mode harness）:**
+- `replaceTabSnapshot` 後兩 store = 快照內容；`visitHistory` 不含已消失 tab（restore 後立刻 `closeTabInWorkspace` active tab → 選到的下一個 tab 正確）。
+- 壞快照（validate 不過）→ throw、兩 store **完全未變**。
+- mock 第二個 `setState`（workspace）throw → 兩 store 皆 rollback 回舊值。
+- `replaceTabState` 只動 tab store、不碰 workspace。
+
+### T7 — 三動作 orchestration + `-prev` + rebuiltButUnattached（restore.ts）
+
+**Consumes:** T3–T6；`readSnapshot`/`writeSnapshot`/`readPrevSnapshot`/`writePrevSnapshot`/`captureSnapshot`；`useSessionStore.replaceHost`。
+**Produces:**
+```ts
+export async function rebuildAllSessions(snap: WorkspaceSnapshot): Promise<RestoreReport>
+export async function restoreTabLayout(snap: WorkspaceSnapshot): Promise<RestoreReport>
+export async function restoreAll(snap: WorkspaceSnapshot): Promise<RestoreReport>
+export async function undoLastRestore(): Promise<RestoreReport | null>   // 讀 -prev 走 restoreAll
+function syncSessionStore(remap: Remap): void   // 依 remap 的 session 物件 replaceHost 各 host
+```
+- **rebuildAllSessions**（a 點）：`ensureSessions(snap.sessionMeta)`（**全部** restorable 已死者重建，含 orphan）→ `remapLayoutSessions(當前每個 tab.layout, remap, { onlyTerminated:true })` → `replaceTabState(當前 tabs 改寫後, 當前 tabOrder, 當前 activeTabId)` → `syncSessionStore`。**不寫 `-prev`**（非破壞性）。
+- **restoreTabLayout**：`ensureSessions(snap.sessionMeta, { rebuild:false })`（只對帳活著、死的 failed→terminated）→ `remapLayoutSessions(snap 每個 tab.layout, remap, {})` → 先 `writePrevSnapshot(await captureSnapshot(now))` → `replaceTabSnapshot(改寫後 snap)` → `syncSessionStore`。
+- **restoreAll**：`ensureSessions(snap.sessionMeta)`（全重建）→ `remapLayoutSessions(snap tabs, remap, {})` → `writePrevSnapshot(capture)` → `replaceTabSnapshot` → `syncSessionStore`。
+- **rebuiltButUnattached（R3 B）**：`replaceTabSnapshot` throw 時，把本次 `remap` 中 `status==='rebuilt'` 的 `{hostId,name,cwd}` 收進 `RestoreReport.rebuiltButUnattached`、rethrow 給 UI 揭露（**不刪 daemon session**）。
+
+> `now` 由 caller（UI）帶入 orchestration（決定性）：三動作簽章實測時可再收一個 `now` 參數或注入 `captureSnapshot`；plan 實作時以 deps 注入 `capture`/`now` 便於測試。
+
+**Tests:**
+- **rebuildAllSessions 範圍（a 點）**：snapshot 有 5 個 restorable 已死 session（其中 2 個當前 tab 未引用）+ 當前 tabs 有對應 terminated pane → `createSession` 呼叫 5 次（含 2 orphan）；當前 tab 結構未變（只 terminated pane 換 code）；未寫 `-prev`。
+- **restoreTabLayout**：死的 pane 標 terminated（未 createSession）、活的接回；`-prev` 於執行前寫入；tab/workspace = snapshot。
+- **restoreAll**：全重建 + 取代 = snapshot；`-prev` 寫入。
+- **undoLastRestore**：先 restoreAll(A) 產生 `-prev`=舊態 → `undoLastRestore()` 還回舊態；無 `-prev` → 回 `null`。
+- **rebuiltButUnattached（R3 B）**：mock `replaceTabSnapshot` throw（validate 不過）→ `restoreAll` reject、`RestoreReport.rebuiltButUnattached` 含所有 rebuilt 的 `{hostId,name,cwd}`；前端 store 未變（rollback）。
+- **syncSessionStore**：`rebuilt` 後 `useSessionStore.sessions[host]` 含新 session、pane `cachedName`=daemon 回傳 name。
+
+### T8 — §8.1 撞同名 session 探明（測試釘住）
+
+**Files:** Test only（`restore.contention.test.ts`）+ plan 註記。
+探明 daemon `createSession` 遇同名 session 行為（Phase 2 期間手動打一次 `POST /api/sessions` 同名，記錄結果於 spec §8.1）。先寫測試：mock `createSession` 回「daemon 自動改名」的 session（`name` 與請求不同）→ 斷言 `ensureSessions` 以**回傳物件**的 code+name 為準（remap.session=回傳物件），前端對接正確。緩解已內建（§3.3），本 task 只釘行為 + 補斷言。
+
+**Phase 2 done-criteria:** `npx vitest run` 綠；`pnpm run lint` + `pnpm run build` 綠。§8.1 探明結果回填 spec。PR → codex 兩輪 review（攻擊方重點：rollback / rebuiltButUnattached / 複合鍵不互污）。
+
+---
+
+## Phase 3 — Settings「Snapshot」section UI（PR 3）
+
+### T10 — `SnapshotSettingsSection` 骨架 + 健康度對帳
+
+**Files:** Create `spa/src/components/settings/SnapshotSettingsSection.tsx`；Test `SnapshotSettingsSection.test.tsx`。
+**Consumes:** `readSnapshot`；`listSessions`（掛載時對各 host 即時對帳）。範本 `SyncSection.tsx`（status tone toast + `SettingItem` + Phosphor icon 按鈕 + `busy` 並發保護 + `const t = useI18nStore(s=>s.t)`）。
+
+結構：頂部列（拍快照鈕顯 `capturedAt` 相對時間、全部還原、復原上次還原）+ 區塊 1 Tmux（對帳表：`host/name/cwd/current_command/健康度`）+ 區塊 2 Tabs（樹狀 workspace→tab→pane）。**健康度四態**（掛載時各 host `listSessions` 對帳）：🟢 活著（live 清單含 code）/ 🔴 已死可重建（`restorable` 且 host 可達、live 無 code）/ ⚠️ 只能保留結構（`restorable===false`）/ ⚪ host 離線（`listSessions` throw）。
+
+**Tests（RTL，mock `snapshot/storage` + `host-api`）:**
+- 有快照 + host live 缺某 code → 該列渲染 🔴；live 含 → 🟢；`restorable:false` → ⚠️；host reject → 該 host 全列 ⚪。
+- 區塊 2 渲染 workspace→tab→pane（terminal 顯 name、editor 顯 filePath、browser 顯 url）。
+- 無快照 → empty state（只顯「拍下快照」鈕）。
+
+### T11 — 三動作按鈕 wiring + toast
+
+**Files:** Modify `SnapshotSettingsSection.tsx`；Test 續 `SnapshotSettingsSection.test.tsx`。
+**Consumes:** T7 orchestration（`captureSnapshot`/`rebuildAllSessions`/`restoreTabLayout`/`restoreAll`/`undoLastRestore`）。
+
+「拍下快照」→ `captureSnapshot(Date.now())` → toast「已拍快照：N 個終端機、其中 M 個無法記錄路徑」。「重建所有 session」（Tmux 區鈕）→ `rebuildAllSessions`。「還原 tab 佈局」（Tabs 區鈕）→ `restoreTabLayout`。「全部還原」→ `restoreAll`。「復原上次還原」→ `undoLastRestore`。`busy` 並發保護（`if(busy)return`→`setBusy(true)`→`finally setBusy(false)`）。toast 依 `RestoreReport` 彙總「X 接回 / Y 重建 / Z 無法重建」；**`rebuiltButUnattached` 非空 → warn tone toast 列 name/cwd/host（R3 B）+ `console.warn`**。無快照 → 還原鈕 disabled；無 `-prev` → 復原鈕 disabled。
+
+**Tests:**
+- 點各鈕呼叫對應 orchestration（mock restore 層）、toast 文案正確。
+- `rebuiltButUnattached` 非空 → warn toast 含 name/cwd/host。
+- `busy` 期間重複點擊只觸發一次。
+- 無 `-prev` → 復原鈕 `disabled`。
+
+### T12 — 註冊 section + i18n
+
+**Files:** Modify `spa/src/lib/register-modules/index.tsx`（`registerSettingsSection({ id:'snapshot', label:'settings.section.snapshot', order: SETTINGS_ORDER.SNAPSHOT, component: SnapshotSettingsSection })`）+ `SETTINGS_ORDER` 加 `SNAPSHOT`（置既有之後）；i18n 檔加 `settings.section.snapshot` + 動作/健康度/toast 文案 key（en + zh-TW）。
+
+**Tests:** `getSettingsSections()` 含 `id:'snapshot'`；i18n key en/zh-TW 皆存在（對齊既有 i18n 測試慣例）。
+
+**Phase 3 done-criteria:** `npx vitest run` 綠；`pnpm run lint` + `pnpm run build` 綠。PR → codex 兩輪 review。
+
+---
+
+## Risks / notes
+
+- **§8.1 撞同名 session**（唯一碰 daemon 點）：Phase 2 T8 探明，緩解已內建（以 `createSession` 回傳實際 code+name 為準）。
+- **§8.3 大量 session 重建**：`ensureSessions` 對已死逐一 `createSession`；量大時的並行/上限 —— Phase 2 T3 實作時傾向「有上限並行（如 `p-limit` 語意，手寫 chunk）+ 逐一失敗隔離」，測試以序列 mock 驗語意即可，並行度為效能優化不改語意。
+- **best-effort 取代跨視窗空窗**：`replaceTabSnapshot` 兩次 `setState` 各自 `syncManager.notify` 廣播，其他視窗短暫見中間態 —— spec §3.5 已明訂 best-effort、非承諾消除；不引入 batched key（超本次範圍）。
+- **daemon 副作用非交易性（R3 B）**：restore 失敗 rollback 只還原前端 store；已建 session 用 `rebuiltButUnattached` 揭露、不自動刪（與「重建所有 session」刻意 orphan 一致，不造成資料遺失）。
+- **`settings.scope.workspaceId`（R3 C）**：`validateSnapshotConsistency` 不驗；若指向已刪 workspace，既有 UI 顯示 `Workspace not found`（非致命）。
+- **`Date.now()` 注入**：`capture`/orchestration 的 `now` 由 UI 帶入以利決定性測試；只有 T11 UI 層實際呼叫 `Date.now()`。

--- a/docs/specs/2026-07-13-workspace-snapshot-spec.md
+++ b/docs/specs/2026-07-13-workspace-snapshot-spec.md
@@ -1,0 +1,231 @@
+# Spec — Workspace Snapshot（工作區快照 / 一鍵重建）
+
+**Date**: 2026-07-13
+**Branch**: `worktree-workspace-snapshot`
+**Author**: Claude (Opus 4.8) + Wake
+**狀態**: Draft（待 codex 審）
+
+---
+
+## 1. 背景與現況
+
+Purdex 的 tab / workspace / pane 結構**本來就會持久化到 localStorage**（`purdex-tabs` / `purdex-workspaces`），重開 app 時 tab 會自動還原。但有一個缺口：terminal（tmux-session）pane 在前端只存 `sessionCode`（daemon 對 tmux session 的編碼參照），**不存 tmux session name，也不存 cwd**。因此：
+
+- 重開機 / tmux server 重啟 / 換機器後，舊 `sessionCode` 一律失效 → 自動還原的 terminal tab 會顯示為「已終止」，**無法自動把工作環境重建回來**。
+- 使用者失去「我當時在哪些目錄開了哪些終端機」的資訊。
+
+本功能新增「工作區快照」：在拍快照的當下，額外記錄每個 tmux session 的 **name + cwd（+ 當時在跑的 current_command，僅供顯示）**，讓還原時能對已死掉的 session **依 name + cwd 用 `tmux new-session` 重建**，達成「一鍵重建工作環境」。
+
+### 引擎盤點（已存在，本次沿用，不改）
+
+| 能力 | 位置 |
+|------|------|
+| Tab / Pane / PaneContent / SplitLayout / Workspace 型別 | `spa/src/types/tab.ts` |
+| `listSessions(hostId)` → 每個 session 帶 `code / name / cwd / mode / current_command` | `spa/src/lib/host-api.ts:94` |
+| `createSession(hostId, name, cwd, mode)` → **已支援指定 name + cwd** | `spa/src/lib/host-api.ts:100` |
+| `fetchSessionCwd(hostId, code)`（單抓，備援） | `spa/src/lib/host-api.ts:157` |
+| daemon cwd SOT = tmux `pane_current_path` | `internal/module/session/cwd_handler.go` / `service.go` |
+| Tab store（persist `purdex-tabs`，partialize `tabs/tabOrder/activeTabId`） | `spa/src/stores/useTabStore.ts:454` |
+| Workspace store（persist `purdex-workspaces`，partialize `workspaces/activeWorkspaceId`） | `spa/src/features/workspace/store.ts:292` |
+| `scanPaneTree(layout, fn)`（唯讀走訪所有 pane）/ `collectLeaves` / `updatePaneInLayout` / `findTabBySessionCode` | `spa/src/lib/pane-tree.ts` |
+| Terminated 標記機制（`TerminatedReason` / `markTerminated` / `markHostTerminated`） | `spa/src/types/tab.ts` / `useTabStore.ts` |
+| 統一 storage backend `purdexStorage` + keys | `spa/src/lib/storage/index.ts` / `keys.ts` |
+| Settings section 註冊 `registerSettingsSection({ id, label, order, component })` | `spa/src/lib/settings-section-registry.ts` |
+| 既有 section 元件範例 | `spa/src/components/settings/*SettingsSection.tsx` |
+
+### 關鍵事實
+
+- **純前端 SPA 功能**：capture 靠 `listSessions`、restore 靠 `createSession(name, cwd, mode)`，daemon **大概率零改動**。唯一待探明：重建時 daemon 遇到「同 name 已存在的 session」的行為（§8 風險）。
+- terminal pane 存的 `sessionCode` 在重建後**必然改變**，任何還原都必須改寫 layout 樹裡的 code（→ §3.3 重映射表）。
+
+---
+
+## 2. 目標與非目標
+
+### 目標
+
+1. 使用者可**拍下**當前整個工作區狀態的快照：所有 workspace / tab / pane 結構 + 每個 tmux session 的 `hostId / name / cwd / current_command`。
+2. **單一份**快照，存 localStorage，再拍即覆蓋；還原前自動存一份 `-prev` 後悔藥。
+3. 還原時對 tmux session：**活著直接接回、已死依 name+cwd 自動重建**、host 離線則標 terminated（隔離失敗，不中斷整體）。
+4. Settings 新增「Snapshot」section 頁，分 **Tmux Sessions / Tabs** 兩區，含**即時健康度對帳**（🟢活著 / 🔴已死 / ⚪離線）。
+5. 三個還原動作（可分別執行）：**重建所有 session**（Tmux 區）、**還原 tab 佈局**（Tab 區）、**全部還原**（頂部）；外加 **復原上次還原**（讀 `-prev`）。
+
+### 非目標
+
+- **不自動重跑** session 內原本在跑的程式（claude / vim…）。`current_command` 僅顯示，供使用者手動判斷。理由：任意命令自動執行有安全風險，且程式內部狀態（vim buffer、claude 對話）無法靠命令名還原。
+- **不記錄** app-frame 側欄/面板佈局（`purdex-layout`）—— 使用者明確排除，只記 tab/workspace。
+- **不做多份具名快照**（單一份覆蓋式）。
+- **不新增跨裝置 sync**：快照存本機 localStorage，不進 `purdex-sync` snapshot-store。
+- **不改** tab/workspace persist 格式與既有 store action 語意。
+
+---
+
+## 3. 設計
+
+### 3.1 資料模型
+
+快照存 localStorage，key = `purdex-workspace-snapshot`（正本）與 `purdex-workspace-snapshot-prev`（還原前自動備份）。
+
+```ts
+interface WorkspaceSnapshot {
+  version: 1
+  capturedAt: number
+  // 沿用兩個 store 既有 partialize 的形狀，避免格式漂移
+  tabs: Record<string, Tab>          // 完整 tab + layout 樹
+  tabOrder: string[]
+  activeTabId: string | null
+  workspaces: Workspace[]
+  activeWorkspaceId: string | null
+  // sidecar：拍快照當下每個 tmux-session pane 的 tmux 側資訊
+  sessionMeta: Record<string, {      // key = 拍快照當下的 sessionCode
+    hostId: string
+    name: string
+    cwd: string
+    mode: 'terminal' | 'stream'
+    currentCommand?: string          // 顯示用；抓不到則省略
+  }>
+}
+```
+
+- `sessionMeta` 的 key 是**拍快照當下**的 `sessionCode`，作為與 layout 樹裡 pane 對接的橋樑。
+- 讀 / 寫透過 `purdexStorage`（與其他 store 一致），非直接 `localStorage`。
+
+### 3.2 拍快照（capture）
+
+`captureSnapshot(): Promise<CaptureResult>`：
+
+1. 從 `useTabStore.getState()` 取 `tabs / tabOrder / activeTabId`；從 `useWorkspaceStore.getState()` 取 `workspaces / activeWorkspaceId`。（用既有 partialize 形狀。）
+2. `scanPaneTree` 走過每個 tab.layout，收集所有 `kind === 'tmux-session'` 的 pane，取得 `{ sessionCode, hostId, mode }`，依 `hostId` 分組。
+3. 每個涉及的 host **呼叫一次** `listSessions(hostId)`（一次拿全部，優於逐一 `fetchSessionCwd`）。用回傳結果比對出每個 pane 的 `name / cwd / current_command`，填入 `sessionMeta`。
+   - host `listSessions` 失敗 → 該 host 的 pane 記為 name 用 `cachedName`、cwd 空字串，並在 `CaptureResult` 累計 `unresolved` 計數（不中斷）。
+   - session 已不在清單（拍快照當下就死了）→ 同上，用 `cachedName`、空 cwd。
+4. 組出 `WorkspaceSnapshot`（`capturedAt` 由呼叫端注入，見下），整包覆蓋寫入 `purdex-workspace-snapshot`。
+5. 回傳 `CaptureResult { total, resolved, unresolved }` 供 UI toast。
+
+> **時間戳**：`capturedAt` 不在純函式內部產生（利於測試決定性）。由 UI 呼叫端以 `Date.now()` 帶入 capture 參數。
+
+### 3.3 sessionCode 重映射（restore 的共同核心）
+
+terminal pane 嵌的是 sessionCode，重建出的 code 必然不同，故任何 restore 都繞不開一張 `oldCode → newCode | null` 表。
+
+`ensureSessions(sessionMeta): Promise<Remap>`：
+
+- 蒐集 `sessionMeta` 涉及的所有 hostId，每個 host **呼叫一次** `listSessions(hostId)` 得「目前活著」的 code 清單（並偵測 host 是否可達）。
+- 對 `sessionMeta` 每筆：
+  - **活著**（oldCode ∈ 活著清單）→ `newCode = oldCode`（直接接回，內容不動）。
+  - **已死** 且 host 可達 → `createSession(hostId, name, cwd, mode)` → `newCode = 新 code`。
+  - **host 離線** 或 `createSession` 失敗 → `newCode = null`（該 pane 之後標 terminated）。
+- 回傳 `Remap = Map<oldCode, string | null>` + `EnsureReport { reattached, rebuilt, failed }`。
+
+### 3.4 套用重映射到 layout 樹
+
+`remapLayoutSessions(layout, remap): PaneLayout`（純函式，基於 `updatePaneInLayout` / `scanPaneTree`）：
+
+- 走過樹，對每個 `tmux-session` pane：
+  - `remap` 有 `newCode`（非 null）→ 設 `sessionCode = newCode`，清除 `terminated`。
+  - `remap` 為 `null` → 保留原 code，設 `terminated`（沿用 `TerminatedReason`）。
+  - `remap` 無此 code（理論上不會，防禦性）→ 原樣不動。
+
+### 3.5 三個還原動作
+
+全部建立在 §3.3 / §3.4 primitive 上，共用同一套邏輯：
+
+| 動作 | 位置 | 步驟 |
+|------|------|------|
+| **重建所有 session** | Tmux 區 | `remap = ensureSessions(snapshot.sessionMeta)` → 對**當前已開**的 `useTabStore.tabs` 各 layout 套 `remapLayoutSessions` → `setState` 更新 tabs。**不動 tab 結構**（不新增/刪除 tab、不碰 workspace）。 |
+| **還原 tab 佈局** | Tab 區 | 只針對「目前還活著」做輕量對帳（`listSessions` 比對；死掉者標 terminated，**不重建**——重建是 Tmux 區職責）→ 以 `snapshot.tabs/tabOrder/activeTabId` + `snapshot.workspaces/activeWorkspaceId` **原子取代** store。 |
+| **全部還原** | 頂部 | `remap = ensureSessions(...)` → 對 `snapshot.tabs` 各 layout 套 `remapLayoutSessions` → 以改寫後結果 + workspaces **原子取代**兩 store。（= §3.2 完整流程） |
+
+**原子取代**：以單次 `useTabStore.setState({ tabs, tabOrder, activeTabId })` + `useWorkspaceStore.setState({ workspaces, activeWorkspaceId })` 整包覆蓋；persist middleware 自動寫回 localStorage。中途失敗不留半套（先算完 remap + 改寫，最後才 setState）。
+
+**還原前自動備份**：任一「取代式」動作（還原 tab 佈局 / 全部還原）執行前，先把**當前** store 狀態 capture 成一份 `WorkspaceSnapshot` 寫入 `purdex-workspace-snapshot-prev`。「復原上次還原」= 讀 `-prev` 走「全部還原」流程。
+
+> 「重建所有 session」不取代 tab 結構、非破壞性，故不寫 `-prev`（僅改 sessionCode，可再拍/再還原）。
+
+### 3.6 錯誤處理
+
+- capture：host 失敗僅該 host 記空 cwd，其餘照拍；toast「已拍快照：N 個終端機、其中 M 個路徑未能記錄」。
+- restore：逐 session 獨立失敗隔離（重建失敗只標該 pane terminated）；toast 彙總「X 直接接回 / Y 依路徑重建 / Z 無法重建」。
+- restore 全程「先算後套」：`ensureSessions` + `remapLayoutSessions` 完成後才 `setState`，避免半套狀態。
+
+### 3.7 UI — Settings「Snapshot」section
+
+透過 `registerSettingsSection({ id: 'snapshot', label: 'Snapshot', order, component: SnapshotSettingsSection })` 註冊（order 置於既有 sections 之後，plan 階段定值）。
+
+`SnapshotSettingsSection`：
+
+- **頂部列**：
+  - 「拍下快照」鈕（顯示 `capturedAt` 相對時間，例如「上次：3 小時前」）。
+  - 「全部還原」鈕（快照不存在時 disabled）。
+  - 「復原上次還原」鈕（`-prev` 不存在時 disabled）。
+- **區塊 1 — Tmux Sessions**（對帳表）：
+  - 每列：`host / name / cwd / current_command（拍當下）/ 健康度`。
+  - 健康度：section 掛載時對各 host `listSessions` 即時對帳 → 🟢 活著（可接回）/ 🔴 已死（將依 cwd 重建）/ ⚪ host 離線（無法重建）。
+  - 區塊動作鈕：「重建所有 session」。
+- **區塊 2 — Tabs / Workspaces**：
+  - 樹狀列出 workspace → tab → pane（kind + 識別資訊：terminal 顯示 name、editor/preview 顯示 filePath、browser 顯示 url）。
+  - 區塊動作鈕：「還原 tab 佈局」。
+- 快照不存在時，兩區顯示 empty state（只給「拍下快照」）。
+
+---
+
+## 4. 元件 / 資料流
+
+| 檔案 | 類型 | 職責 |
+|------|------|------|
+| `spa/src/lib/snapshot/types.ts` | 新增 | `WorkspaceSnapshot` / `SessionMeta` / `Remap` / `CaptureResult` / `EnsureReport` 型別 |
+| `spa/src/lib/snapshot/storage.ts` | 新增 | 讀/寫 `purdex-workspace-snapshot(-prev)`（走 `purdexStorage`） |
+| `spa/src/lib/snapshot/capture.ts` | 新增 | `captureSnapshot`（讀兩 store + `listSessions` 補 meta） |
+| `spa/src/lib/snapshot/restore.ts` | 新增 | `ensureSessions` / `remapLayoutSessions` / 三動作 orchestration + `-prev` 寫入 |
+| `spa/src/components/settings/SnapshotSettingsSection.tsx` | 新增 | Settings section UI（兩區 + 健康度對帳 + 動作鈕 + toast） |
+| section 註冊呼叫點（對齊既有 `*SettingsSection` 註冊處） | 修改 | `registerSettingsSection(...)` |
+
+- **依賴方向**：UI → restore/capture → host-api + pane-tree + stores。純邏輯層（capture/restore/storage）不依賴 React，利於 Vitest 單元測試。
+
+---
+
+## 5. Phase 切分（依 review 大小）
+
+### Phase 1 — 資料模型 + capture + 持久化
+- `types.ts` / `storage.ts` / `capture.ts`。
+- `captureSnapshot` 產出 `WorkspaceSnapshot`（含 sessionMeta 正確對應 code→name/cwd/command）、寫入 localStorage。
+- **驗收**：mock 兩 store + mock `listSessions`，斷言快照內容正確；host 失敗時 `unresolved` 計數正確、不中斷。純邏輯，TDD。
+
+### Phase 2 — restore 引擎 + 三動作
+- `restore.ts`：`ensureSessions`（重映射表）、`remapLayoutSessions`（純函式）、三個 orchestration 動作、`-prev` 寫入。
+- **驗收**：
+  - 「部分活著、部分已死、host 離線」情境 → `oldCode→newCode` 表正確、layout 樹 code 正確改寫、失敗 pane 標 terminated。
+  - 原子取代後兩 store 狀態 = 快照內容。
+  - 三動作語意各自正確（重建 session 不動 tab 結構；還原 tab 佈局不重建 session；全部還原兩者兼具）。
+  - `-prev` 於取代式動作前被寫入；「復原上次還原」能還回去。
+  - **撞名邊界**：先寫一個測試釘住 daemon `createSession` 對同名 session 的行為（§8 探明後補斷言）。
+
+### Phase 3 — Settings Snapshot section UI
+- `SnapshotSettingsSection.tsx` + 註冊。
+- 兩區呈現、掛載時即時健康度對帳、三顆動作鈕、toast 彙總、empty state。
+- **驗收**：React Testing Library — 健康度三態渲染、動作鈕觸發對應 orchestration（mock restore 層）、快照不存在時 empty state。
+
+---
+
+## 6. 測試策略
+
+- 純邏輯層（Phase 1/2）以 Vitest 單元測試為主，mock `host-api` 與兩 store（依 `feedback_zustand_harness_setstate` 的 merge-mode setState 慣例）。
+- UI 層（Phase 3）用 RTL，mock restore/capture 層，聚焦互動與狀態渲染。
+- 每個 Phase 獨立 commit；`cd spa && npx vitest run` + `pnpm run lint` + `pnpm run build` 全綠才進下一 Phase。
+
+---
+
+## 7. 限制（寫進 UI 說明文案）
+
+- 重建的 session 只回到 **cwd**；原本在跑的程式不會自動重跑（僅顯示拍當下的 `current_command` 供參考）。
+- `stream` mode session 重建後為空（Claude `-p` 串流不重播），同樣只還原 cwd。
+- 快照為**單一份**，再拍即覆蓋。跨裝置不同步（本機 localStorage）。
+
+---
+
+## 8. 待探明 / 風險
+
+1. **撞同名 session**（唯一可能碰 daemon 的點）：`createSession(hostId, name, cwd, mode)` 在 daemon 上已存在同 name 的 session 時的行為為何？（拒絕 / 自動改名 / 復用？）Phase 2 先寫一個測試/手動打 API 探明；若行為不利（例如靜默復用到錯的 session），再評估 daemon 端補「name 唯一性 / 回傳實際 name」。**這是 spec 唯一的開放技術問題。**
+2. **host 可達性判定**：`ensureSessions` 需區分「session 死了但 host 活著（可重建）」vs「host 離線（不可重建）」。以 `listSessions` 是否成功回應作為 host 可達訊號。
+3. **大量 session**：`ensureSessions` 對已死 session 逐一 `createSession`；session 很多時為序列/並行？plan 階段定（傾向有上限的並行 + 逐一失敗隔離）。
+4. **capturedAt 決定性**：純函式不呼叫 `Date.now()`，由 UI 帶入，確保單元測試可決定性斷言。

--- a/docs/specs/2026-07-13-workspace-snapshot-spec.md
+++ b/docs/specs/2026-07-13-workspace-snapshot-spec.md
@@ -3,7 +3,7 @@
 **Date**: 2026-07-13
 **Branch**: `worktree-workspace-snapshot`
 **Author**: Claude (Opus 4.8) + Wake
-**狀態**: Draft v2（已納入 codex 第一輪 review 六項修正：#1 複合鍵 Blocker、#2 visitHistory、#3 重建收窄、#4 best-effort 取代、#5 restorable、#6 session store 同步）
+**狀態**: Draft v3。v2 納入 codex R1 六項修正（#1 複合鍵 Blocker、#2 visitHistory、#3 重建 remap 收窄、#4 best-effort 取代、#5 restorable、#6 session store 同步）。v3 納入 codex R2 修正（validateSnapshotConsistency 拆五條、restore 對 daemon 副作用非交易性揭露、sync 檔路徑）**與使用者定案的產品決策**：「重建所有 session」重建快照裡**所有可觀測 session（不收窄、orphan 為預期）**，明確 override codex R2 對 orphan 的收窄建議（§3.5）。
 
 ---
 
@@ -30,7 +30,7 @@ Purdex 的 tab / workspace / pane 結構**本來就會持久化到 localStorage*
 | Workspace store（persist `purdex-workspaces`，partialize `workspaces/activeWorkspaceId`；關 tab 讀 `visitHistory` 選下一個） | `spa/src/features/workspace/store.ts:195/292` |
 | `scanPaneTree` / `collectLeaves` / `updatePaneInLayout` / `findTabBySessionCode` | `spa/src/lib/pane-tree.ts` |
 | Terminated 標記（`TerminatedReason` / `markTerminated`） | `spa/src/types/tab.ts` / `useTabStore.ts` |
-| storage backend `purdexStorage`（**每次 setItem 立即 localStorage + `syncManager.notify` 廣播**） | `spa/src/lib/storage/browser-backend.ts` / `sync.ts:15` |
+| storage backend `purdexStorage`（**每次 setItem 立即 localStorage + `syncManager.notify` 廣播**） | `spa/src/lib/storage/browser-backend.ts` / `spa/src/lib/storage/sync.ts:15` |
 | pane 內容用 `useSessionStore.sessions[hostId]` 查 session；名稱快取只在 WS 事件更新 | `spa/src/components/SessionPaneContent.tsx:27` / `useMultiHostEventWs.ts:103` |
 | Settings section 註冊 `registerSettingsSection({ id, label, order, component })` | `spa/src/lib/settings-section-registry.ts` |
 
@@ -148,15 +148,17 @@ type Remap = Record<string /* hostId */, Record<string /* oldCode */, RemapEntry
 
 | 動作 | 位置 | 步驟 |
 |------|------|------|
-| **重建所有 session** | Tmux 區 | `ensureSessions(snapshot.sessionMeta)` → 對**當前已開** `useTabStore.tabs` 套 `remapLayoutSessions(…, { onlyTerminated: true })`（見「收窄語意」）→ `replaceTabState`（僅 tabs）+ 同步 session store。**不動 tab 結構**、不碰 workspace、不寫 `-prev`。 |
+| **重建所有 session** | Tmux 區 | ①`ensureSessions(snapshot.sessionMeta)` —— **重建快照裡所有 `restorable` 且 host 可達的 session**，不限當前 tab 是否引用（見「重建範圍＝產品決策」）；②對**當前已開** tabs 套 `remapLayoutSessions(…, { onlyTerminated: true })`（只把 terminated pane 接到重建結果，活著的 pane 不碰）→ `replaceTabState`（僅 tabs）+ 同步 session store。**不動 tab 結構**、不碰 workspace、不寫 `-prev`。 |
 | **還原 tab 佈局** | Tab 區 | 對「目前還活著」依 (hostId,code) 輕量對帳（死掉標 terminated，**不重建**）→ `replaceTabSnapshot(snapshot)` 取代 tab/workspace。 |
 | **全部還原** | 頂部 | `ensureSessions(...)` → 對 `snapshot.tabs` 套 `remapLayoutSessions` → `replaceTabSnapshot(改寫後)` + 同步 session store。（= §3.2 完整流程） |
 
-**「重建所有 session」收窄語意（codex #3）**：此動作把 remap 套到**當前已開** tabs；若不限制、當前某 pane 的 (hostId, code) 剛好碰到 snapshot 舊 code，會誤改不屬該快照的 pane。故限制 `onlyTerminated: true` —— 活著的 pane 完全不碰、terminated 的本就壞了重建正是所需。**殘餘風險**（極罕見）：重開機後新 session 恰好複用某舊 code 值且該 pane 剛好 terminated；即便命中，也只是接到一個以正確 cwd 新建的 session，影響有限。此收窄使「還原 tab 佈局 → 重建所有 session」在**核心情境（persist 還原後 session 全死）**下等價於「全部還原」，但**不宣稱普遍等價**。
+**「重建所有 session」重建範圍＝產品決策（使用者定案，勿翻案）**：此動作對**整份** `snapshot.sessionMeta` 做 `ensureSessions`，重建快照裡**所有** `restorable` 且 host 可達的 session —— **刻意不限縮**在「當前已開 tab 仍引用的 session」。核心情境是伺服器重開機後 tmux 全滅，使用者要一次把**整個工作環境的 tmux session** 都拉回來；因此重建出當前畫面尚未接上的 session（orphan）是**預期行為、非缺陷** —— 隨後配合「還原 tab 佈局」/「全部還原」即接上，即使單獨執行，那些 session 也會出現在 daemon `listSessions` / Sessions 清單供手動接回。**codex R2 對 orphan 的收窄建議在此明確不採納。**
+
+**remap 套用範圍仍收窄（避免誤改活 pane，codex R1 #3）**：重建產生的 remap 僅以 `onlyTerminated: true` 套回當前 tabs 的 terminated pane —— 活著的 pane 完全不碰，杜絕「某活 pane 的 (hostId, code) 恰撞 snapshot 舊 code 而被誤改」。此為正確性防線，與上述重建範圍**獨立、互不影響**（重建範圍決定 daemon 上建哪些 session；remap 範圍決定改當前哪些 pane）。**副作用揭露**：本動作在 daemon 上實際建立 session（含 orphan），非唯讀；因僅新增 tmux session、不動 tab/workspace 結構，仍不寫 `-prev`。
 
 **取代語意（best-effort，非真原子）（codex #4）**：兩 store 各自 `setState` **並非真原子** —— `browserStorage.setItem` 每次立即 `localStorage.setItem` + `syncManager.notify`，其他視窗會立刻 rehydrate 單一 key，故中間有可觀察空窗。改用 coordinator：
 
-- `validateSnapshotConsistency(snapshot)`：驗 `workspace.tabs` 每個 id、`activeTabId`、各 `workspace.activeTabId`、`activeWorkspaceId` 都能在 `tabs` 解析；不通過則中止、不動任何 store。
+- `validateSnapshotConsistency(snapshot)`（codex R2 拆明五條，修正「全部驗在 `tabs`」的矛盾）：①`workspace.tabs` 每個 id ∈ `tabs`；②`activeTabId` ∈ `tabs`（或 `null`）；③各 `workspace.activeTabId` ∈ 該 `workspace.tabs`；④`activeWorkspaceId` ∈ `workspaces`（**非** `tabs`）或 `null`；⑤`tabOrder` 每個 id ∈ `tabs`。任一不通過則中止、不動任何 store。
 - `replaceTabSnapshot(snapshot)`：先驗證 → 保存兩 store 舊值 → 依序 setState（tab 先、workspace 後）→ 任一步丟錯則**用舊值 rollback** 兩 store。
 - **visitHistory（codex #2）**：`useTabStore.visitHistory` 非 persist、workspace 關 tab 讀它選下一個（`workspace/store.ts:195`）；取代時把 `visitHistory` filter 成新 `tabOrder` 子集（移除指向已消失 tab 的引用），連同 `tabs/tabOrder/activeTabId` 一起 set。
 - spec 明訂此為 **best-effort 一致，非跨視窗真原子**。
@@ -171,7 +173,7 @@ type Remap = Record<string /* hostId */, Record<string /* oldCode */, RemapEntry
 
 - capture：host 失敗僅該 host 記 `restorable=false`（cwd undefined），其餘照拍；toast「已拍快照：N 個終端機、其中 M 個無法記錄路徑」。
 - restore：逐 session 獨立失敗隔離（重建失敗或 `restorable=false` 只標該 pane terminated，不 `createSession('')`）；toast 彙總「X 直接接回 / Y 依路徑重建 / Z 無法重建」。
-- restore「先算後套」：`ensureSessions` + `remapLayoutSessions` 完成後才進 `replaceTabSnapshot`（含一致性驗證 + rollback），失敗不留半套。
+- restore「先算後套」：`ensureSessions` + `remapLayoutSessions` 完成後才進 `replaceTabSnapshot`（含一致性驗證 + rollback）。**「不留半套」僅指前端 store**（codex R2）：`replaceTabSnapshot` 失敗會用舊值 rollback 兩 store，但 `ensureSessions` 已在 daemon 建立的 session 是**真副作用、不會自動撤銷**；此時彙整「已重建但未接上」session 清單，toast + 日誌揭露（plan 評估是否補償刪除，見 §8.5）。
 
 ### 3.7 UI — Settings「Snapshot」section
 
@@ -183,7 +185,7 @@ type Remap = Record<string /* hostId */, Record<string /* oldCode */, RemapEntry
 - **區塊 1 — Tmux Sessions**（對帳表）：
   - 每列：`host / name / cwd（無值顯示「未記錄」）/ current_command（拍當下）/ 健康度`。
   - 健康度：section 掛載時對各 host（依 hostId）`listSessions` 即時對帳 → 🟢 活著（可接回）/ 🔴 已死可重建（`restorable` 且 host 可達）/ ⚠️ 只能保留結構（`restorable=false`，無 cwd）/ ⚪ host 離線（無法重建）。
-  - 區塊鈕：「重建所有 session」（僅重建 🔴；⚠️/⚪ 維持 terminated）。
+  - 區塊鈕：「重建所有 session」（重建**快照裡所有** 🔴，不限當前 tab 是否引用；⚠️/⚪ 維持 terminated）。
 - **區塊 2 — Tabs / Workspaces**：樹狀列 workspace → tab → pane（terminal 顯示 name、editor/preview 顯示 filePath、browser 顯示 url）。區塊鈕：「還原 tab 佈局」。
 - 無快照時兩區顯示 empty state（只給「拍下快照」）。
 
@@ -215,10 +217,11 @@ type Remap = Record<string /* hostId */, Record<string /* oldCode */, RemapEntry
 - **驗收**：
   - **跨 host 同 code 不撞（#1）**：兩 host 各有相同 `sessionCode` 值，remap 依 (hostId,code) 各自對帳、不互污。
   - 「部分活著 / 已死 / host 離線 / cwd 不明」→ 各 entry status 正確、layout 依複合鍵改寫、`failed` 與 `restorable=false` 標 terminated 且**未呼叫 `createSession('')`（#5）**。
-  - **取代一致性（#4）**：`validateSnapshotConsistency` 擋掉 workspace 指向不存在 tab 的壞快照；第二個 store setState 丟錯時兩 store 皆 rollback。
+  - **取代一致性（#4 + R2 C）**：`validateSnapshotConsistency` 五條參照檢查各自擋掉對應壞快照（含 `activeWorkspaceId` 不在 `workspaces`、`tabOrder` 含幽靈 id、`workspace.activeTabId` 不在該 workspace）；第二個 store setState 丟錯時兩 store 皆 rollback。
   - **visitHistory（#2）**：取代後不含已消失 tab 引用；「restore 後立刻關 active tab」選到的下一個 tab 正確。
   - **session store 同步（#6）**：`rebuilt` 後 `useSessionStore` 有新 session、pane `cachedName` = daemon 回傳實際 name。
-  - **重建收窄（#3）**：「重建所有 session」只改 `terminated` pane；當前有一活著且 code 恰等於某 snapshot 舊 code 的 pane 不被動到。
+  - **重建範圍 + remap 收窄（#3 + a 點產品決策）**：「重建所有 session」對整份 `sessionMeta` 重建（含當前 tab 未引用的 orphan —— 斷言 `createSession` 呼叫筆數 = restorable 總數，**不因當前 tab 未引用而略過**）；但 remap 只改 `terminated` pane —— 當前有一活著且 code 恰等於某 snapshot 舊 code 的 pane 不被動到。
+  - **daemon 副作用揭露（R2 B）**：`replaceTabSnapshot` 驗證失敗 / rollback 時，回傳含「已重建但未接上」session 清單供 UI 揭露。
   - 三動作語意各自正確；`-prev` 於取代式動作前寫入、「復原上次還原」能還回去。
   - **撞名邊界（§8.1）**：先寫測試釘住 daemon `createSession` 對同名 session 的行為（探明後補斷言）。
 
@@ -253,3 +256,4 @@ type Remap = Record<string /* hostId */, Record<string /* oldCode */, RemapEntry
 2. **host 可達性判定**：`ensureSessions` 以 `listSessions` 是否成功回應區分「session 死但 host 活（可重建）」vs「host 離線（`failed`）」。
 3. **大量 session**：`ensureSessions` 對已死 session 逐一 `createSession`；量大時序列/並行？plan 定（傾向有上限並行 + 逐一失敗隔離）。
 4. **`replaceTabSnapshot` rollback 邊界**：第一個 `setState` 已 `syncManager.notify` 廣播後才 rollback，其他視窗仍可能短暫見中間態 —— §3.5 已明訂 best-effort、非承諾消除。plan 評估是否引入單一 batched key（超出本次範圍，先記錄）。
+5. **restore 的 daemon 副作用非交易性（codex R2 B）**：`ensureSessions` 先在 daemon 建立 session，之後 `replaceTabSnapshot` 若一致性驗證失敗 / rollback，已建 session **不會自動刪除**（前端 store 乾淨，daemon 端多出 session）。緩解：restore 失敗時彙整「已重建但未接上」清單 toast + 日誌；plan 評估補償刪除或引導用「重建所有 session」重試接上。此與「重建所有 session」刻意產生的 orphan（§3.5）性質一致 —— daemon 端多出的 session 可被後續動作接回或手動清理，**不造成資料遺失**，故本次採「揭露而不自動刪除」。

--- a/docs/specs/2026-07-13-workspace-snapshot-spec.md
+++ b/docs/specs/2026-07-13-workspace-snapshot-spec.md
@@ -3,7 +3,7 @@
 **Date**: 2026-07-13
 **Branch**: `worktree-workspace-snapshot`
 **Author**: Claude (Opus 4.8) + Wake
-**狀態**: Draft v3。v2 納入 codex R1 六項修正（#1 複合鍵 Blocker、#2 visitHistory、#3 重建 remap 收窄、#4 best-effort 取代、#5 restorable、#6 session store 同步）。v3 納入 codex R2 修正（validateSnapshotConsistency 拆五條、restore 對 daemon 副作用非交易性揭露、sync 檔路徑）**與使用者定案的產品決策**：「重建所有 session」重建快照裡**所有可觀測 session（不收窄、orphan 為預期）**，明確 override codex R2 對 orphan 的收窄建議（§3.5）。
+**狀態**: Draft v3。v2 納入 codex R1 六項修正（#1 複合鍵 Blocker、#2 visitHistory、#3 重建 remap 收窄、#4 best-effort 取代、#5 restorable、#6 session store 同步）。v3 納入 codex R2 修正（validateSnapshotConsistency 拆五條、restore 對 daemon 副作用非交易性揭露、sync 檔路徑）**與使用者定案的產品決策**：「重建所有 session」重建快照裡**所有可觀測 session（不收窄、orphan 為預期）**，明確 override codex R2 對 orphan 的收窄建議（§3.5）。**已通過 codex R3 複審（在接受 orphan 產品決策前提下 approve、可據以寫 plan）**，R3 兩小修已納入：§5 `createSession` 筆數斷言精確化（活著 session 走 reattached 不計入）、§3.5 validateSnapshotConsistency 範圍界定（僅驗導航參照）。
 
 ---
 
@@ -158,7 +158,7 @@ type Remap = Record<string /* hostId */, Record<string /* oldCode */, RemapEntry
 
 **取代語意（best-effort，非真原子）（codex #4）**：兩 store 各自 `setState` **並非真原子** —— `browserStorage.setItem` 每次立即 `localStorage.setItem` + `syncManager.notify`，其他視窗會立刻 rehydrate 單一 key，故中間有可觀察空窗。改用 coordinator：
 
-- `validateSnapshotConsistency(snapshot)`（codex R2 拆明五條，修正「全部驗在 `tabs`」的矛盾）：①`workspace.tabs` 每個 id ∈ `tabs`；②`activeTabId` ∈ `tabs`（或 `null`）；③各 `workspace.activeTabId` ∈ 該 `workspace.tabs`；④`activeWorkspaceId` ∈ `workspaces`（**非** `tabs`）或 `null`；⑤`tabOrder` 每個 id ∈ `tabs`。任一不通過則中止、不動任何 store。
+- `validateSnapshotConsistency(snapshot)`（codex R2 拆明五條，修正「全部驗在 `tabs`」的矛盾）：①`workspace.tabs` 每個 id ∈ `tabs`；②`activeTabId` ∈ `tabs`（或 `null`）；③各 `workspace.activeTabId` ∈ 該 `workspace.tabs`；④`activeWorkspaceId` ∈ `workspaces`（**非** `tabs`）或 `null`；⑤`tabOrder` 每個 id ∈ `tabs`。任一不通過則中止、不動任何 store。**範圍界定（codex R3）**：本檢查僅涵蓋 tab/workspace **導航參照**；**不驗** pane content 內部語意參照 —— 例如 `settings` pane 的 `scope.workspaceId` 指向已刪 workspace，該情況既有 UI 已顯示 `Workspace not found`、非致命，plan 可評估是否補驗（本次不擴張範圍）。
 - `replaceTabSnapshot(snapshot)`：先驗證 → 保存兩 store 舊值 → 依序 setState（tab 先、workspace 後）→ 任一步丟錯則**用舊值 rollback** 兩 store。
 - **visitHistory（codex #2）**：`useTabStore.visitHistory` 非 persist、workspace 關 tab 讀它選下一個（`workspace/store.ts:195`）；取代時把 `visitHistory` filter 成新 `tabOrder` 子集（移除指向已消失 tab 的引用），連同 `tabs/tabOrder/activeTabId` 一起 set。
 - spec 明訂此為 **best-effort 一致，非跨視窗真原子**。
@@ -220,7 +220,7 @@ type Remap = Record<string /* hostId */, Record<string /* oldCode */, RemapEntry
   - **取代一致性（#4 + R2 C）**：`validateSnapshotConsistency` 五條參照檢查各自擋掉對應壞快照（含 `activeWorkspaceId` 不在 `workspaces`、`tabOrder` 含幽靈 id、`workspace.activeTabId` 不在該 workspace）；第二個 store setState 丟錯時兩 store 皆 rollback。
   - **visitHistory（#2）**：取代後不含已消失 tab 引用；「restore 後立刻關 active tab」選到的下一個 tab 正確。
   - **session store 同步（#6）**：`rebuilt` 後 `useSessionStore` 有新 session、pane `cachedName` = daemon 回傳實際 name。
-  - **重建範圍 + remap 收窄（#3 + a 點產品決策）**：「重建所有 session」對整份 `sessionMeta` 重建（含當前 tab 未引用的 orphan —— 斷言 `createSession` 呼叫筆數 = restorable 總數，**不因當前 tab 未引用而略過**）；但 remap 只改 `terminated` pane —— 當前有一活著且 code 恰等於某 snapshot 舊 code 的 pane 不被動到。
+  - **重建範圍 + remap 收窄（#3 + a 點產品決策）**：「重建所有 session」對整份 `sessionMeta` 重建 —— 斷言 `createSession` 呼叫筆數 = 快照中 `restorable` **且** restore 當下對帳為「已死」的 session 數（即 🔴，含當前 tab 未引用的 orphan）；活著的 session 走 `reattached`、**不計入** create 筆數（codex R3）；且不因當前 tab 未引用而略過任何已死 orphan。但 remap 只改 `terminated` pane —— 當前有一活著且 code 恰等於某 snapshot 舊 code 的 pane 不被動到。
   - **daemon 副作用揭露（R2 B）**：`replaceTabSnapshot` 驗證失敗 / rollback 時，回傳含「已重建但未接上」session 清單供 UI 揭露。
   - 三動作語意各自正確；`-prev` 於取代式動作前寫入、「復原上次還原」能還回去。
   - **撞名邊界（§8.1）**：先寫測試釘住 daemon `createSession` 對同名 session 的行為（探明後補斷言）。

--- a/docs/specs/2026-07-13-workspace-snapshot-spec.md
+++ b/docs/specs/2026-07-13-workspace-snapshot-spec.md
@@ -3,40 +3,41 @@
 **Date**: 2026-07-13
 **Branch**: `worktree-workspace-snapshot`
 **Author**: Claude (Opus 4.8) + Wake
-**狀態**: Draft（待 codex 審）
+**狀態**: Draft v2（已納入 codex 第一輪 review 六項修正：#1 複合鍵 Blocker、#2 visitHistory、#3 重建收窄、#4 best-effort 取代、#5 restorable、#6 session store 同步）
 
 ---
 
 ## 1. 背景與現況
 
-Purdex 的 tab / workspace / pane 結構**本來就會持久化到 localStorage**（`purdex-tabs` / `purdex-workspaces`），重開 app 時 tab 會自動還原。但有一個缺口：terminal（tmux-session）pane 在前端只存 `sessionCode`（daemon 對 tmux session 的編碼參照），**不存 tmux session name，也不存 cwd**。因此：
+Purdex 的 tab / workspace / pane 結構**本來就會持久化到 localStorage**（`purdex-tabs` / `purdex-workspaces`），重開 app 時 tab 會自動還原。缺口在於 terminal（tmux-session）pane 在前端只存 `sessionCode`（daemon 對 tmux session 的 host-local 編碼參照），**不存 tmux session name，也不存 cwd**。因此：
 
-- 重開機 / tmux server 重啟 / 換機器後，舊 `sessionCode` 一律失效 → 自動還原的 terminal tab 會顯示為「已終止」，**無法自動把工作環境重建回來**。
-- 使用者失去「我當時在哪些目錄開了哪些終端機」的資訊。
+- **伺服器重開機 / tmux server 重啟 / 換機器**後，舊 `sessionCode` 一律失效 → 自動還原的 terminal tab 顯示為「已終止」，**無法自動把工作環境重建回來**。這正是本功能要解的**唯一核心痛點**（使用者親自定位）。
+- 單純關掉 app 重開、或更新 Electron（不動 daemon）→ session 還活著、code 不變，**現在就會自動接回**，不是本功能目標。
 
-本功能新增「工作區快照」：在拍快照的當下，額外記錄每個 tmux session 的 **name + cwd（+ 當時在跑的 current_command，僅供顯示）**，讓還原時能對已死掉的 session **依 name + cwd 用 `tmux new-session` 重建**，達成「一鍵重建工作環境」。
+本功能新增「工作區快照」：拍快照當下額外記錄每個 tmux session 的 **name + cwd（+ 當時 current_command，僅顯示）**，讓還原時對已死掉的 session **依 name + cwd 用 `tmux new-session` 重建**，達成「一鍵重建工作環境」。
 
 ### 引擎盤點（已存在，本次沿用，不改）
 
 | 能力 | 位置 |
 |------|------|
 | Tab / Pane / PaneContent / SplitLayout / Workspace 型別 | `spa/src/types/tab.ts` |
-| `listSessions(hostId)` → 每個 session 帶 `code / name / cwd / mode / current_command` | `spa/src/lib/host-api.ts:94` |
-| `createSession(hostId, name, cwd, mode)` → **已支援指定 name + cwd** | `spa/src/lib/host-api.ts:100` |
-| `fetchSessionCwd(hostId, code)`（單抓，備援） | `spa/src/lib/host-api.ts:157` |
-| daemon cwd SOT = tmux `pane_current_path` | `internal/module/session/cwd_handler.go` / `service.go` |
-| Tab store（persist `purdex-tabs`，partialize `tabs/tabOrder/activeTabId`） | `spa/src/stores/useTabStore.ts:454` |
-| Workspace store（persist `purdex-workspaces`，partialize `workspaces/activeWorkspaceId`） | `spa/src/features/workspace/store.ts:292` |
-| `scanPaneTree(layout, fn)`（唯讀走訪所有 pane）/ `collectLeaves` / `updatePaneInLayout` / `findTabBySessionCode` | `spa/src/lib/pane-tree.ts` |
-| Terminated 標記機制（`TerminatedReason` / `markTerminated` / `markHostTerminated`） | `spa/src/types/tab.ts` / `useTabStore.ts` |
-| 統一 storage backend `purdexStorage` + keys | `spa/src/lib/storage/index.ts` / `keys.ts` |
+| `listSessions(hostId)` → 每 session 帶 `code / name / cwd / mode / current_command` | `spa/src/lib/host-api.ts:94` |
+| `createSession(hostId, name, cwd, mode)` → **已支援指定 name + cwd**，回傳完整 `Session` | `spa/src/lib/host-api.ts:100` |
+| `fetchSessionCwd(hostId, code)`（單抓備援） | `spa/src/lib/host-api.ts:157` |
+| daemon cwd SOT = tmux `pane_current_path`；建立走 `tmux new-session -c cwd` | `internal/module/session/cwd_handler.go` / `internal/tmux/executor.go:187` |
+| **sessionCode 是 host-local**（`compositeKey(hostId, code)`；「sibling hosts can mint identical codes」；測試釘住跨 host 同 code 不互清） | `spa/src/lib/composite-key.ts` / `useMultiHostEventWs.ts:128` / `stores/path-cache/usePathCacheStore.test.ts:112` |
+| Tab store（persist `purdex-tabs`，partialize `tabs/tabOrder/activeTabId`；另有**非 persist** `visitHistory`） | `spa/src/stores/useTabStore.ts:127/454` |
+| Workspace store（persist `purdex-workspaces`，partialize `workspaces/activeWorkspaceId`；關 tab 讀 `visitHistory` 選下一個） | `spa/src/features/workspace/store.ts:195/292` |
+| `scanPaneTree` / `collectLeaves` / `updatePaneInLayout` / `findTabBySessionCode` | `spa/src/lib/pane-tree.ts` |
+| Terminated 標記（`TerminatedReason` / `markTerminated`） | `spa/src/types/tab.ts` / `useTabStore.ts` |
+| storage backend `purdexStorage`（**每次 setItem 立即 localStorage + `syncManager.notify` 廣播**） | `spa/src/lib/storage/browser-backend.ts` / `sync.ts:15` |
+| pane 內容用 `useSessionStore.sessions[hostId]` 查 session；名稱快取只在 WS 事件更新 | `spa/src/components/SessionPaneContent.tsx:27` / `useMultiHostEventWs.ts:103` |
 | Settings section 註冊 `registerSettingsSection({ id, label, order, component })` | `spa/src/lib/settings-section-registry.ts` |
-| 既有 section 元件範例 | `spa/src/components/settings/*SettingsSection.tsx` |
 
 ### 關鍵事實
 
-- **純前端 SPA 功能**：capture 靠 `listSessions`、restore 靠 `createSession(name, cwd, mode)`，daemon **大概率零改動**。唯一待探明：重建時 daemon 遇到「同 name 已存在的 session」的行為（§8 風險）。
-- terminal pane 存的 `sessionCode` 在重建後**必然改變**，任何還原都必須改寫 layout 樹裡的 code（→ §3.3 重映射表）。
+- **純前端 SPA 功能**：capture 靠 `listSessions`、restore 靠 `createSession(name, cwd, mode)`，daemon **大概率零改動**（唯一待探明：撞同名 session，§8.1）。
+- terminal pane 的 `sessionCode` **host-local**，重建後必變 → 任何還原都必須以 **(hostId, sessionCode) 複合鍵**改寫 layout 樹（§3.3）。
 
 ---
 
@@ -44,18 +45,18 @@ Purdex 的 tab / workspace / pane 結構**本來就會持久化到 localStorage*
 
 ### 目標
 
-1. 使用者可**拍下**當前整個工作區狀態的快照：所有 workspace / tab / pane 結構 + 每個 tmux session 的 `hostId / name / cwd / current_command`。
-2. **單一份**快照，存 localStorage，再拍即覆蓋；還原前自動存一份 `-prev` 後悔藥。
-3. 還原時對 tmux session：**活著直接接回、已死依 name+cwd 自動重建**、host 離線則標 terminated（隔離失敗，不中斷整體）。
-4. Settings 新增「Snapshot」section 頁，分 **Tmux Sessions / Tabs** 兩區，含**即時健康度對帳**（🟢活著 / 🔴已死 / ⚪離線）。
-5. 三個還原動作（可分別執行）：**重建所有 session**（Tmux 區）、**還原 tab 佈局**（Tab 區）、**全部還原**（頂部）；外加 **復原上次還原**（讀 `-prev`）。
+1. **拍下**當前整個工作區狀態：所有 workspace / tab / pane 結構 + 每個 tmux session 的 `hostId / sessionCode / name / cwd / current_command`。
+2. **單一份**快照存 localStorage，再拍即覆蓋；還原前自動存 `-prev` 後悔藥。
+3. 還原 tmux session：**活著直接接回、已死且 cwd 可得則依 name+cwd 自動重建**、否則標 terminated（隔離失敗，不中斷整體）。
+4. Settings 新增「Snapshot」section 頁，分 **Tmux Sessions / Tabs** 兩區 + **即時健康度對帳**。
+5. 三個可分別執行的還原動作：**重建所有 session**、**還原 tab 佈局**、**全部還原**；外加 **復原上次還原**。
 
 ### 非目標
 
-- **不自動重跑** session 內原本在跑的程式（claude / vim…）。`current_command` 僅顯示，供使用者手動判斷。理由：任意命令自動執行有安全風險，且程式內部狀態（vim buffer、claude 對話）無法靠命令名還原。
-- **不記錄** app-frame 側欄/面板佈局（`purdex-layout`）—— 使用者明確排除，只記 tab/workspace。
+- **不自動重跑** session 內原本在跑的程式（claude / vim…）。`current_command` 僅顯示（安全＋內部狀態無法還原）。
+- **不記錄** app-frame 側欄/面板佈局（`purdex-layout`，使用者明確排除）。
 - **不做多份具名快照**（單一份覆蓋式）。
-- **不新增跨裝置 sync**：快照存本機 localStorage，不進 `purdex-sync` snapshot-store。
+- **不進** `purdex-sync` snapshot-store、不做跨裝置 sync（本機 localStorage）。
 - **不改** tab/workspace persist 格式與既有 store action 語意。
 
 ---
@@ -67,105 +68,124 @@ Purdex 的 tab / workspace / pane 結構**本來就會持久化到 localStorage*
 快照存 localStorage，key = `purdex-workspace-snapshot`（正本）與 `purdex-workspace-snapshot-prev`（還原前自動備份）。
 
 ```ts
+interface SessionMeta {
+  hostId: string
+  sessionCode: string              // 拍快照當下的 code（host-local）
+  name: string
+  mode: 'terminal' | 'stream'
+  cwd?: string                     // 抓不到則 undefined（不是空字串）
+  currentCommand?: string          // 顯示用；抓不到則省略
+  restorable: boolean              // cwd 有值且 host 可達才 true
+  captureError?: 'host-unreachable' | 'session-dead-at-capture'
+}
+
 interface WorkspaceSnapshot {
   version: 1
   capturedAt: number
-  // 沿用兩個 store 既有 partialize 的形狀，避免格式漂移
-  tabs: Record<string, Tab>          // 完整 tab + layout 樹
+  // 沿用兩 store 既有 partialize 形狀，避免格式漂移
+  tabs: Record<string, Tab>
   tabOrder: string[]
   activeTabId: string | null
   workspaces: Workspace[]
   activeWorkspaceId: string | null
-  // sidecar：拍快照當下每個 tmux-session pane 的 tmux 側資訊
-  sessionMeta: Record<string, {      // key = 拍快照當下的 sessionCode
-    hostId: string
-    name: string
-    cwd: string
-    mode: 'terminal' | 'stream'
-    currentCommand?: string          // 顯示用；抓不到則省略
-  }>
+  // sidecar：以 (hostId, sessionCode) 複合鍵巢狀索引
+  sessionMeta: Record<string, Record<string, SessionMeta>>  // [hostId][sessionCode]
 }
 ```
 
-- `sessionMeta` 的 key 是**拍快照當下**的 `sessionCode`，作為與 layout 樹裡 pane 對接的橋樑。
-- 讀 / 寫透過 `purdexStorage`（與其他 store 一致），非直接 `localStorage`。
+- **複合鍵（codex Blocker #1）**：`sessionCode` **host-local**（`composite-key.ts`、`useMultiHostEventWs.ts:128` 註解、`usePathCacheStore.test.ts:112` 測試皆釘住）。`sessionMeta` 以 `[hostId][sessionCode]` 巢狀索引；`Remap`（§3.3）與 `remapLayoutSessions`（§3.4）一律以 **(hostId, sessionCode)** 對帳，禁用裸 code。
+- **`restorable`（codex #5）**：僅當 `cwd` 有值（tmux `pane_current_path` 成功）且 host 可達才 `true`。cwd 不明者**不進 `createSession`**（避免 `tmux new-session -c ''` 開在錯目錄），restore 時直接標 terminated。
+- 讀 / 寫透過 `purdexStorage`，非直接 `localStorage`。
 
 ### 3.2 拍快照（capture）
 
-`captureSnapshot(): Promise<CaptureResult>`：
+`captureSnapshot(now: number): Promise<CaptureResult>`：
 
-1. 從 `useTabStore.getState()` 取 `tabs / tabOrder / activeTabId`；從 `useWorkspaceStore.getState()` 取 `workspaces / activeWorkspaceId`。（用既有 partialize 形狀。）
-2. `scanPaneTree` 走過每個 tab.layout，收集所有 `kind === 'tmux-session'` 的 pane，取得 `{ sessionCode, hostId, mode }`，依 `hostId` 分組。
-3. 每個涉及的 host **呼叫一次** `listSessions(hostId)`（一次拿全部，優於逐一 `fetchSessionCwd`）。用回傳結果比對出每個 pane 的 `name / cwd / current_command`，填入 `sessionMeta`。
-   - host `listSessions` 失敗 → 該 host 的 pane 記為 name 用 `cachedName`、cwd 空字串，並在 `CaptureResult` 累計 `unresolved` 計數（不中斷）。
-   - session 已不在清單（拍快照當下就死了）→ 同上，用 `cachedName`、空 cwd。
-4. 組出 `WorkspaceSnapshot`（`capturedAt` 由呼叫端注入，見下），整包覆蓋寫入 `purdex-workspace-snapshot`。
-5. 回傳 `CaptureResult { total, resolved, unresolved }` 供 UI toast。
+1. 從 `useTabStore.getState()` 取 `tabs / tabOrder / activeTabId`；`useWorkspaceStore.getState()` 取 `workspaces / activeWorkspaceId`。
+2. `scanPaneTree` 走每個 tab.layout，收集所有 `kind === 'tmux-session'` 的 pane（`{ sessionCode, hostId, mode }`），依 `hostId` 分組。
+3. 每個涉及 host **呼叫一次** `listSessions(hostId)`，依 `(hostId, sessionCode)` 比對出 `name / cwd / current_command`，填 `sessionMeta[hostId][sessionCode]`，`restorable = true`。
+   - host `listSessions` 失敗 → `name = cachedName`、`cwd = undefined`、`restorable = false`、`captureError = 'host-unreachable'`，累計 `unresolved`（不中斷）。
+   - session 已不在清單（拍當下就死）→ `name = cachedName`、`cwd = undefined`、`restorable = false`、`captureError = 'session-dead-at-capture'`。
+4. 組出 `WorkspaceSnapshot`（`capturedAt = now`），整包覆蓋寫 `purdex-workspace-snapshot`。
+5. 回傳 `CaptureResult { total, resolved, unresolved }` 供 toast。
 
-> **時間戳**：`capturedAt` 不在純函式內部產生（利於測試決定性）。由 UI 呼叫端以 `Date.now()` 帶入 capture 參數。
+> **決定性**：`capturedAt` 不在函式內呼叫 `Date.now()`，由 UI 帶入（`now`），利於單元測試決定性斷言。
 
-### 3.3 sessionCode 重映射（restore 的共同核心）
+### 3.3 sessionCode 重映射（restore 共同核心）
 
-terminal pane 嵌的是 sessionCode，重建出的 code 必然不同，故任何 restore 都繞不開一張 `oldCode → newCode | null` 表。
+terminal pane 嵌 host-local code，重建後必變，故任何 restore 都繞不開以 **(hostId, oldCode)** 為鍵的重映射表。
 
-`ensureSessions(sessionMeta): Promise<Remap>`：
+```ts
+type RemapEntry =
+  | { status: 'reattached'; newCode: string; session: Session }  // 活著，code 不變
+  | { status: 'rebuilt';    newCode: string; session: Session }  // 依 name+cwd 重建
+  | { status: 'failed' }                                         // 無法重建 → 標 terminated
+type Remap = Record<string /* hostId */, Record<string /* oldCode */, RemapEntry>>
+```
 
-- 蒐集 `sessionMeta` 涉及的所有 hostId，每個 host **呼叫一次** `listSessions(hostId)` 得「目前活著」的 code 清單（並偵測 host 是否可達）。
-- 對 `sessionMeta` 每筆：
-  - **活著**（oldCode ∈ 活著清單）→ `newCode = oldCode`（直接接回，內容不動）。
-  - **已死** 且 host 可達 → `createSession(hostId, name, cwd, mode)` → `newCode = 新 code`。
-  - **host 離線** 或 `createSession` 失敗 → `newCode = null`（該 pane 之後標 terminated）。
-- 回傳 `Remap = Map<oldCode, string | null>` + `EnsureReport { reattached, rebuilt, failed }`。
+`ensureSessions(sessionMeta): Promise<{ remap: Remap; report: EnsureReport }>`：
+
+- 蒐集涉及的 hostId，每個 host **呼叫一次** `listSessions(hostId)`（成功回應 = host 可達訊號）。
+- 對 `sessionMeta[hostId][oldCode]` 每筆：
+  - **活著**（oldCode ∈ 該 host 活著清單）→ `reattached`，`newCode = oldCode`，`session` = 該筆。
+  - **已死** 且 `restorable`（host 可達 + cwd 有值）→ `createSession(hostId, name, cwd, mode)` → `rebuilt`，`newCode` = 回傳 session code，`session` = 回傳物件（**含 daemon 實際採用的 name**，§8.1）。
+  - **host 離線** / **`restorable === false`（cwd 不明）** / `createSession` 失敗 → `failed`（後續標 terminated；**不呼叫 `createSession('', …)`**）。
+- **回傳完整 `Session` 物件**（codex #6），供 restore 後同步 `useSessionStore` + `cachedName`。
+- `EnsureReport { reattached, rebuilt, failed }` 供 toast。
 
 ### 3.4 套用重映射到 layout 樹
 
-`remapLayoutSessions(layout, remap): PaneLayout`（純函式，基於 `updatePaneInLayout` / `scanPaneTree`）：
+`remapLayoutSessions(layout, remap, opts?): PaneLayout`（純函式，基於 `updatePaneInLayout` / `scanPaneTree`），對每個 `tmux-session` pane 以 **(pane.hostId, pane.sessionCode)** 查 `remap`：
 
-- 走過樹，對每個 `tmux-session` pane：
-  - `remap` 有 `newCode`（非 null）→ 設 `sessionCode = newCode`，清除 `terminated`。
-  - `remap` 為 `null` → 保留原 code，設 `terminated`（沿用 `TerminatedReason`）。
-  - `remap` 無此 code（理論上不會，防禦性）→ 原樣不動。
+- `reattached` / `rebuilt` → 設 `sessionCode = newCode`、`cachedName = session.name`，清除 `terminated`。
+- `failed` → 保留原 code，設 `terminated`（`TerminatedReason`）。
+- remap 無此 (hostId, code)（防禦性）→ 原樣不動。
+- `opts.onlyTerminated`（供「重建所有 session」，§3.5）為 true 時**只處理原本 `terminated` 的 pane**，活著的 pane 完全不碰。
 
 ### 3.5 三個還原動作
 
-全部建立在 §3.3 / §3.4 primitive 上，共用同一套邏輯：
+全部建立在 §3.3 / §3.4 primitive 上：
 
 | 動作 | 位置 | 步驟 |
 |------|------|------|
-| **重建所有 session** | Tmux 區 | `remap = ensureSessions(snapshot.sessionMeta)` → 對**當前已開**的 `useTabStore.tabs` 各 layout 套 `remapLayoutSessions` → `setState` 更新 tabs。**不動 tab 結構**（不新增/刪除 tab、不碰 workspace）。 |
-| **還原 tab 佈局** | Tab 區 | 只針對「目前還活著」做輕量對帳（`listSessions` 比對；死掉者標 terminated，**不重建**——重建是 Tmux 區職責）→ 以 `snapshot.tabs/tabOrder/activeTabId` + `snapshot.workspaces/activeWorkspaceId` **原子取代** store。 |
-| **全部還原** | 頂部 | `remap = ensureSessions(...)` → 對 `snapshot.tabs` 各 layout 套 `remapLayoutSessions` → 以改寫後結果 + workspaces **原子取代**兩 store。（= §3.2 完整流程） |
+| **重建所有 session** | Tmux 區 | `ensureSessions(snapshot.sessionMeta)` → 對**當前已開** `useTabStore.tabs` 套 `remapLayoutSessions(…, { onlyTerminated: true })`（見「收窄語意」）→ `replaceTabState`（僅 tabs）+ 同步 session store。**不動 tab 結構**、不碰 workspace、不寫 `-prev`。 |
+| **還原 tab 佈局** | Tab 區 | 對「目前還活著」依 (hostId,code) 輕量對帳（死掉標 terminated，**不重建**）→ `replaceTabSnapshot(snapshot)` 取代 tab/workspace。 |
+| **全部還原** | 頂部 | `ensureSessions(...)` → 對 `snapshot.tabs` 套 `remapLayoutSessions` → `replaceTabSnapshot(改寫後)` + 同步 session store。（= §3.2 完整流程） |
 
-**原子取代**：以單次 `useTabStore.setState({ tabs, tabOrder, activeTabId })` + `useWorkspaceStore.setState({ workspaces, activeWorkspaceId })` 整包覆蓋；persist middleware 自動寫回 localStorage。中途失敗不留半套（先算完 remap + 改寫，最後才 setState）。
+**「重建所有 session」收窄語意（codex #3）**：此動作把 remap 套到**當前已開** tabs；若不限制、當前某 pane 的 (hostId, code) 剛好碰到 snapshot 舊 code，會誤改不屬該快照的 pane。故限制 `onlyTerminated: true` —— 活著的 pane 完全不碰、terminated 的本就壞了重建正是所需。**殘餘風險**（極罕見）：重開機後新 session 恰好複用某舊 code 值且該 pane 剛好 terminated；即便命中，也只是接到一個以正確 cwd 新建的 session，影響有限。此收窄使「還原 tab 佈局 → 重建所有 session」在**核心情境（persist 還原後 session 全死）**下等價於「全部還原」，但**不宣稱普遍等價**。
 
-**還原前自動備份**：任一「取代式」動作（還原 tab 佈局 / 全部還原）執行前，先把**當前** store 狀態 capture 成一份 `WorkspaceSnapshot` 寫入 `purdex-workspace-snapshot-prev`。「復原上次還原」= 讀 `-prev` 走「全部還原」流程。
+**取代語意（best-effort，非真原子）（codex #4）**：兩 store 各自 `setState` **並非真原子** —— `browserStorage.setItem` 每次立即 `localStorage.setItem` + `syncManager.notify`，其他視窗會立刻 rehydrate 單一 key，故中間有可觀察空窗。改用 coordinator：
 
-> 「重建所有 session」不取代 tab 結構、非破壞性，故不寫 `-prev`（僅改 sessionCode，可再拍/再還原）。
+- `validateSnapshotConsistency(snapshot)`：驗 `workspace.tabs` 每個 id、`activeTabId`、各 `workspace.activeTabId`、`activeWorkspaceId` 都能在 `tabs` 解析；不通過則中止、不動任何 store。
+- `replaceTabSnapshot(snapshot)`：先驗證 → 保存兩 store 舊值 → 依序 setState（tab 先、workspace 後）→ 任一步丟錯則**用舊值 rollback** 兩 store。
+- **visitHistory（codex #2）**：`useTabStore.visitHistory` 非 persist、workspace 關 tab 讀它選下一個（`workspace/store.ts:195`）；取代時把 `visitHistory` filter 成新 `tabOrder` 子集（移除指向已消失 tab 的引用），連同 `tabs/tabOrder/activeTabId` 一起 set。
+- spec 明訂此為 **best-effort 一致，非跨視窗真原子**。
+
+**同步 session store（codex #6）**：取代/重建後，用 `ensureSessions` 回傳的 `Session` 物件 upsert `useSessionStore`（`replaceHost` / 逐筆），並確保各 pane `cachedName` = daemon 回傳實際 name，避免 restore 後 UI 短暫顯示錯名 / 查不到新 session。
+
+**還原前自動備份**：任一「取代式」動作（還原 tab 佈局 / 全部還原）執行前，先把**當前** store capture 成 `WorkspaceSnapshot` 寫 `purdex-workspace-snapshot-prev`。「復原上次還原」= 讀 `-prev` 走「全部還原」。
+
+> 「重建所有 session」非破壞性（僅改 terminated pane 的 code），故不寫 `-prev`。
 
 ### 3.6 錯誤處理
 
-- capture：host 失敗僅該 host 記空 cwd，其餘照拍；toast「已拍快照：N 個終端機、其中 M 個路徑未能記錄」。
-- restore：逐 session 獨立失敗隔離（重建失敗只標該 pane terminated）；toast 彙總「X 直接接回 / Y 依路徑重建 / Z 無法重建」。
-- restore 全程「先算後套」：`ensureSessions` + `remapLayoutSessions` 完成後才 `setState`，避免半套狀態。
+- capture：host 失敗僅該 host 記 `restorable=false`（cwd undefined），其餘照拍；toast「已拍快照：N 個終端機、其中 M 個無法記錄路徑」。
+- restore：逐 session 獨立失敗隔離（重建失敗或 `restorable=false` 只標該 pane terminated，不 `createSession('')`）；toast 彙總「X 直接接回 / Y 依路徑重建 / Z 無法重建」。
+- restore「先算後套」：`ensureSessions` + `remapLayoutSessions` 完成後才進 `replaceTabSnapshot`（含一致性驗證 + rollback），失敗不留半套。
 
 ### 3.7 UI — Settings「Snapshot」section
 
-透過 `registerSettingsSection({ id: 'snapshot', label: 'Snapshot', order, component: SnapshotSettingsSection })` 註冊（order 置於既有 sections 之後，plan 階段定值）。
+`registerSettingsSection({ id: 'snapshot', label: 'Snapshot', order, component: SnapshotSettingsSection })`（order 置既有 sections 之後，plan 定值）。
 
 `SnapshotSettingsSection`：
 
-- **頂部列**：
-  - 「拍下快照」鈕（顯示 `capturedAt` 相對時間，例如「上次：3 小時前」）。
-  - 「全部還原」鈕（快照不存在時 disabled）。
-  - 「復原上次還原」鈕（`-prev` 不存在時 disabled）。
+- **頂部列**：「拍下快照」（顯示 `capturedAt` 相對時間）、「全部還原」（無快照 disabled）、「復原上次還原」（無 `-prev` disabled）。
 - **區塊 1 — Tmux Sessions**（對帳表）：
-  - 每列：`host / name / cwd / current_command（拍當下）/ 健康度`。
-  - 健康度：section 掛載時對各 host `listSessions` 即時對帳 → 🟢 活著（可接回）/ 🔴 已死（將依 cwd 重建）/ ⚪ host 離線（無法重建）。
-  - 區塊動作鈕：「重建所有 session」。
-- **區塊 2 — Tabs / Workspaces**：
-  - 樹狀列出 workspace → tab → pane（kind + 識別資訊：terminal 顯示 name、editor/preview 顯示 filePath、browser 顯示 url）。
-  - 區塊動作鈕：「還原 tab 佈局」。
-- 快照不存在時，兩區顯示 empty state（只給「拍下快照」）。
+  - 每列：`host / name / cwd（無值顯示「未記錄」）/ current_command（拍當下）/ 健康度`。
+  - 健康度：section 掛載時對各 host（依 hostId）`listSessions` 即時對帳 → 🟢 活著（可接回）/ 🔴 已死可重建（`restorable` 且 host 可達）/ ⚠️ 只能保留結構（`restorable=false`，無 cwd）/ ⚪ host 離線（無法重建）。
+  - 區塊鈕：「重建所有 session」（僅重建 🔴；⚠️/⚪ 維持 terminated）。
+- **區塊 2 — Tabs / Workspaces**：樹狀列 workspace → tab → pane（terminal 顯示 name、editor/preview 顯示 filePath、browser 顯示 url）。區塊鈕：「還原 tab 佈局」。
+- 無快照時兩區顯示 empty state（只給「拍下快照」）。
 
 ---
 
@@ -173,14 +193,14 @@ terminal pane 嵌的是 sessionCode，重建出的 code 必然不同，故任何
 
 | 檔案 | 類型 | 職責 |
 |------|------|------|
-| `spa/src/lib/snapshot/types.ts` | 新增 | `WorkspaceSnapshot` / `SessionMeta` / `Remap` / `CaptureResult` / `EnsureReport` 型別 |
+| `spa/src/lib/snapshot/types.ts` | 新增 | `WorkspaceSnapshot` / `SessionMeta`（含 `restorable`）/ `Remap`（複合鍵）/ `CaptureResult` / `EnsureReport` |
 | `spa/src/lib/snapshot/storage.ts` | 新增 | 讀/寫 `purdex-workspace-snapshot(-prev)`（走 `purdexStorage`） |
-| `spa/src/lib/snapshot/capture.ts` | 新增 | `captureSnapshot`（讀兩 store + `listSessions` 補 meta） |
-| `spa/src/lib/snapshot/restore.ts` | 新增 | `ensureSessions` / `remapLayoutSessions` / 三動作 orchestration + `-prev` 寫入 |
+| `spa/src/lib/snapshot/capture.ts` | 新增 | `captureSnapshot(now)`（讀兩 store + `listSessions` 依 (hostId,code) 補 meta） |
+| `spa/src/lib/snapshot/restore.ts` | 新增 | `ensureSessions`（回傳完整 Session）/ `remapLayoutSessions`（複合鍵、`onlyTerminated`）/ `validateSnapshotConsistency` / `replaceTabState` / `replaceTabSnapshot`（rollback + visitHistory filter + session store 同步）/ 三動作 + `-prev` |
 | `spa/src/components/settings/SnapshotSettingsSection.tsx` | 新增 | Settings section UI（兩區 + 健康度對帳 + 動作鈕 + toast） |
-| section 註冊呼叫點（對齊既有 `*SettingsSection` 註冊處） | 修改 | `registerSettingsSection(...)` |
+| section 註冊呼叫點（對齊既有 `*SettingsSection`） | 修改 | `registerSettingsSection(...)` |
 
-- **依賴方向**：UI → restore/capture → host-api + pane-tree + stores。純邏輯層（capture/restore/storage）不依賴 React，利於 Vitest 單元測試。
+- **依賴方向**：UI → restore/capture → host-api + pane-tree + stores。純邏輯層（capture/restore/storage）不依賴 React，利於 Vitest。
 
 ---
 
@@ -188,44 +208,48 @@ terminal pane 嵌的是 sessionCode，重建出的 code 必然不同，故任何
 
 ### Phase 1 — 資料模型 + capture + 持久化
 - `types.ts` / `storage.ts` / `capture.ts`。
-- `captureSnapshot` 產出 `WorkspaceSnapshot`（含 sessionMeta 正確對應 code→name/cwd/command）、寫入 localStorage。
-- **驗收**：mock 兩 store + mock `listSessions`，斷言快照內容正確；host 失敗時 `unresolved` 計數正確、不中斷。純邏輯，TDD。
+- **驗收**：mock 兩 store + mock `listSessions`，斷言 `sessionMeta` 依 (hostId,code) 巢狀正確、`restorable`/`captureError` 正確；host 失敗 `unresolved` 計數正確、不中斷；`capturedAt` 由入參決定。純邏輯 TDD。
 
 ### Phase 2 — restore 引擎 + 三動作
-- `restore.ts`：`ensureSessions`（重映射表）、`remapLayoutSessions`（純函式）、三個 orchestration 動作、`-prev` 寫入。
+- `restore.ts`：`ensureSessions`（複合鍵、回傳 Session）、`remapLayoutSessions`（複合鍵、`onlyTerminated`）、`validateSnapshotConsistency`、`replaceTabState`/`replaceTabSnapshot`（rollback + visitHistory filter + session store 同步）、三個 orchestration、`-prev`。
 - **驗收**：
-  - 「部分活著、部分已死、host 離線」情境 → `oldCode→newCode` 表正確、layout 樹 code 正確改寫、失敗 pane 標 terminated。
-  - 原子取代後兩 store 狀態 = 快照內容。
-  - 三動作語意各自正確（重建 session 不動 tab 結構；還原 tab 佈局不重建 session；全部還原兩者兼具）。
-  - `-prev` 於取代式動作前被寫入；「復原上次還原」能還回去。
-  - **撞名邊界**：先寫一個測試釘住 daemon `createSession` 對同名 session 的行為（§8 探明後補斷言）。
+  - **跨 host 同 code 不撞（#1）**：兩 host 各有相同 `sessionCode` 值，remap 依 (hostId,code) 各自對帳、不互污。
+  - 「部分活著 / 已死 / host 離線 / cwd 不明」→ 各 entry status 正確、layout 依複合鍵改寫、`failed` 與 `restorable=false` 標 terminated 且**未呼叫 `createSession('')`（#5）**。
+  - **取代一致性（#4）**：`validateSnapshotConsistency` 擋掉 workspace 指向不存在 tab 的壞快照；第二個 store setState 丟錯時兩 store 皆 rollback。
+  - **visitHistory（#2）**：取代後不含已消失 tab 引用；「restore 後立刻關 active tab」選到的下一個 tab 正確。
+  - **session store 同步（#6）**：`rebuilt` 後 `useSessionStore` 有新 session、pane `cachedName` = daemon 回傳實際 name。
+  - **重建收窄（#3）**：「重建所有 session」只改 `terminated` pane；當前有一活著且 code 恰等於某 snapshot 舊 code 的 pane 不被動到。
+  - 三動作語意各自正確；`-prev` 於取代式動作前寫入、「復原上次還原」能還回去。
+  - **撞名邊界（§8.1）**：先寫測試釘住 daemon `createSession` 對同名 session 的行為（探明後補斷言）。
 
 ### Phase 3 — Settings Snapshot section UI
 - `SnapshotSettingsSection.tsx` + 註冊。
-- 兩區呈現、掛載時即時健康度對帳、三顆動作鈕、toast 彙總、empty state。
-- **驗收**：React Testing Library — 健康度三態渲染、動作鈕觸發對應 orchestration（mock restore 層）、快照不存在時 empty state。
+- 兩區呈現、掛載時即時健康度四態對帳、三顆動作鈕、toast 彙總、empty state。
+- **驗收**：RTL — 健康度四態渲染、動作鈕觸發對應 orchestration（mock restore 層）、無快照時 empty state。
 
 ---
 
 ## 6. 測試策略
 
-- 純邏輯層（Phase 1/2）以 Vitest 單元測試為主，mock `host-api` 與兩 store（依 `feedback_zustand_harness_setstate` 的 merge-mode setState 慣例）。
-- UI 層（Phase 3）用 RTL，mock restore/capture 層，聚焦互動與狀態渲染。
-- 每個 Phase 獨立 commit；`cd spa && npx vitest run` + `pnpm run lint` + `pnpm run build` 全綠才進下一 Phase。
+- 純邏輯層（Phase 1/2）以 Vitest 為主，mock `host-api` 與兩 store（依 `feedback_zustand_harness_setstate` 的 merge-mode setState 慣例）。
+- UI 層（Phase 3）用 RTL，mock restore/capture 層。
+- 每 Phase 獨立 commit；`cd spa && npx vitest run` + `pnpm run lint` + `pnpm run build` 全綠才進下一 Phase。
 
 ---
 
 ## 7. 限制（寫進 UI 說明文案）
 
-- 重建的 session 只回到 **cwd**；原本在跑的程式不會自動重跑（僅顯示拍當下的 `current_command` 供參考）。
+- 重建的 session 只回到 **cwd**；原本在跑的程式不會自動重跑（僅顯示拍當下 `current_command`）。
 - `stream` mode session 重建後為空（Claude `-p` 串流不重播），同樣只還原 cwd。
-- 快照為**單一份**，再拍即覆蓋。跨裝置不同步（本機 localStorage）。
+- **cwd 記不到的 session（`restorable=false`）只保留 tab 結構、無法一鍵重建**，UI 明示、restore 標 terminated。
+- 「取代式」還原為 **best-effort 一致，非跨視窗真原子**（§3.5）。
+- 快照為**單一份**，再拍即覆蓋；跨裝置不同步（本機 localStorage）。
 
 ---
 
 ## 8. 待探明 / 風險
 
-1. **撞同名 session**（唯一可能碰 daemon 的點）：`createSession(hostId, name, cwd, mode)` 在 daemon 上已存在同 name 的 session 時的行為為何？（拒絕 / 自動改名 / 復用？）Phase 2 先寫一個測試/手動打 API 探明；若行為不利（例如靜默復用到錯的 session），再評估 daemon 端補「name 唯一性 / 回傳實際 name」。**這是 spec 唯一的開放技術問題。**
-2. **host 可達性判定**：`ensureSessions` 需區分「session 死了但 host 活著（可重建）」vs「host 離線（不可重建）」。以 `listSessions` 是否成功回應作為 host 可達訊號。
-3. **大量 session**：`ensureSessions` 對已死 session 逐一 `createSession`；session 很多時為序列/並行？plan 階段定（傾向有上限的並行 + 逐一失敗隔離）。
-4. **capturedAt 決定性**：純函式不呼叫 `Date.now()`，由 UI 帶入，確保單元測試可決定性斷言。
+1. **撞同名 session**（唯一可能碰 daemon 的點）：`createSession(hostId, name, cwd, mode)` 遇 daemon 上已存在同 name session 的行為？（拒絕 / 自動改名 / 復用？）Phase 2 先寫測試/手動打 API 探明。緩解已內建：`ensureSessions` 一律以 `createSession` **回傳物件的實際 code + name** 為準（§3.3），故即使 daemon 自動改名，前端仍對接正確 session；只有「靜默復用到錯 session」才需 daemon 端補 name 唯一性。**這是 spec 唯一開放技術問題。**
+2. **host 可達性判定**：`ensureSessions` 以 `listSessions` 是否成功回應區分「session 死但 host 活（可重建）」vs「host 離線（`failed`）」。
+3. **大量 session**：`ensureSessions` 對已死 session 逐一 `createSession`；量大時序列/並行？plan 定（傾向有上限並行 + 逐一失敗隔離）。
+4. **`replaceTabSnapshot` rollback 邊界**：第一個 `setState` 已 `syncManager.notify` 廣播後才 rollback，其他視窗仍可能短暫見中間態 —— §3.5 已明訂 best-effort、非承諾消除。plan 評估是否引入單一 batched key（超出本次範圍，先記錄）。

--- a/spa/src/lib/snapshot/capture.test.ts
+++ b/spa/src/lib/snapshot/capture.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTabStore } from '../../stores/useTabStore'
+import { useWorkspaceStore } from '../../features/workspace/store'
+import { listSessions } from '../host-api'
+import type { Session } from '../host-api'
+import type { Tab, PaneLayout, PaneContent } from '../../types/tab'
+import { readSnapshot, writeSnapshot } from './storage'
+import type { WorkspaceSnapshot } from './types'
+import { buildSnapshot, captureSnapshot } from './capture'
+
+vi.mock('../host-api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../host-api')>()),
+  listSessions: vi.fn(),
+}))
+
+function tmuxContent(
+  hostId: string,
+  sessionCode: string,
+  cachedName: string,
+  mode: 'terminal' | 'stream' = 'terminal',
+): PaneContent {
+  return { kind: 'tmux-session', hostId, sessionCode, mode, cachedName, tmuxInstance: '' }
+}
+
+function leaf(paneId: string, content: PaneContent): PaneLayout {
+  return { type: 'leaf', pane: { id: paneId, content } }
+}
+
+function split(id: string, children: PaneLayout[]): PaneLayout {
+  const sizes = children.map(() => 100 / children.length)
+  return { type: 'split', id, direction: 'h', children, sizes }
+}
+
+function tab(id: string, layout: PaneLayout): Tab {
+  return { id, pinned: false, locked: false, createdAt: 0, layout }
+}
+
+function session(overrides: Partial<Session> & { code: string }): Session {
+  return {
+    name: overrides.name ?? overrides.code,
+    cwd: overrides.cwd ?? '/tmp',
+    mode: overrides.mode ?? 'terminal',
+    cc_session_id: '',
+    cc_model: '',
+    has_relay: false,
+    ...overrides,
+  }
+}
+
+function seedStores(tabs: Record<string, Tab>, tabOrder: string[], activeTabId: string | null): void {
+  useTabStore.setState({ tabs, tabOrder, activeTabId })
+  useWorkspaceStore.getState().reset()
+}
+
+describe('buildSnapshot / captureSnapshot', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
+    useWorkspaceStore.getState().reset()
+    vi.mocked(listSessions).mockReset()
+  })
+
+  it('1. single host, two live tmux panes → nested sessionMeta + resolved=2', async () => {
+    const layout = split('s1', [
+      leaf('p1', tmuxContent('hostA', 'code1', 'cached1')),
+      leaf('p2', tmuxContent('hostA', 'code2', 'cached2')),
+    ])
+    seedStores({ t1: tab('t1', layout) }, ['t1'], 't1')
+
+    vi.mocked(listSessions).mockResolvedValue([
+      session({ code: 'code1', name: 'live1', cwd: '/a', current_command: 'vim' }),
+      session({ code: 'code2', name: 'live2', cwd: '/b', current_command: 'top' }),
+    ])
+
+    const result = await captureSnapshot(1000)
+
+    expect(listSessions).toHaveBeenCalledTimes(1)
+    expect(listSessions).toHaveBeenCalledWith('hostA')
+
+    const stored = readSnapshot()
+    expect(stored).not.toBeNull()
+    expect(stored!.capturedAt).toBe(1000)
+    expect(stored!.sessionMeta.hostA.code1).toEqual({
+      hostId: 'hostA', sessionCode: 'code1', name: 'live1', mode: 'terminal',
+      cwd: '/a', currentCommand: 'vim', restorable: true,
+    })
+    expect(stored!.sessionMeta.hostA.code2).toEqual({
+      hostId: 'hostA', sessionCode: 'code2', name: 'live2', mode: 'terminal',
+      cwd: '/b', currentCommand: 'top', restorable: true,
+    })
+    expect(result).toEqual({ total: 2, resolved: 2, unresolved: 0 })
+  })
+
+  it('2. cross-host same sessionCode literal stays independent (composite key)', async () => {
+    const tabs: Record<string, Tab> = {
+      t1: tab('t1', leaf('p1', tmuxContent('hostA', 'shared', 'cachedA'))),
+      t2: tab('t2', leaf('p2', tmuxContent('hostB', 'shared', 'cachedB'))),
+    }
+    seedStores(tabs, ['t1', 't2'], 't1')
+
+    vi.mocked(listSessions).mockImplementation(async (hostId: string) => {
+      if (hostId === 'hostA') return [session({ code: 'shared', name: 'a-name', cwd: '/host-a' })]
+      if (hostId === 'hostB') return [session({ code: 'shared', name: 'b-name', cwd: '/host-b' })]
+      throw new Error(`unexpected host ${hostId}`)
+    })
+
+    const snap = await buildSnapshot(2000)
+
+    expect(listSessions).toHaveBeenCalledTimes(2)
+    expect(snap.sessionMeta.hostA.shared.cwd).toBe('/host-a')
+    expect(snap.sessionMeta.hostB.shared.cwd).toBe('/host-b')
+    expect(snap.sessionMeta.hostA.shared).not.toEqual(snap.sessionMeta.hostB.shared)
+  })
+
+  it('3. one host unreachable does not interrupt the other host', async () => {
+    const tabs: Record<string, Tab> = {
+      t1: tab('t1', leaf('p1', tmuxContent('hostA', 'codeA', 'cachedA'))),
+      t2: tab('t2', leaf('p2', tmuxContent('hostB', 'codeB', 'cachedB'))),
+    }
+    seedStores(tabs, ['t1', 't2'], 't1')
+
+    vi.mocked(listSessions).mockImplementation(async (hostId: string) => {
+      if (hostId === 'hostA') return [session({ code: 'codeA', name: 'live-a', cwd: '/a' })]
+      throw new Error('host B unreachable')
+    })
+
+    const result = await captureSnapshot(3000)
+    const stored = readSnapshot()!
+
+    expect(stored.sessionMeta.hostA.codeA).toMatchObject({ restorable: true, cwd: '/a' })
+    expect(stored.sessionMeta.hostB.codeB).toEqual({
+      hostId: 'hostB', sessionCode: 'codeB', name: 'cachedB', mode: 'terminal',
+      cwd: undefined, restorable: false, captureError: 'host-unreachable',
+    })
+    expect(result).toEqual({ total: 2, resolved: 1, unresolved: 1 })
+  })
+
+  it('4. pane code missing from live list → session-dead-at-capture', async () => {
+    seedStores(
+      { t1: tab('t1', leaf('p1', tmuxContent('hostA', 'deadcode', 'cachedDead'))) },
+      ['t1'],
+      't1',
+    )
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'other-code' })])
+
+    const snap = await buildSnapshot(4000)
+
+    expect(snap.sessionMeta.hostA.deadcode).toEqual({
+      hostId: 'hostA', sessionCode: 'deadcode', name: 'cachedDead', mode: 'terminal',
+      cwd: undefined, restorable: false, captureError: 'session-dead-at-capture',
+    })
+  })
+
+  it('5. no tmux panes → total=0, sessionMeta={}, still writes a snapshot', async () => {
+    seedStores(
+      { t1: tab('t1', leaf('p1', { kind: 'editor', source: { type: 'local' }, filePath: '/tmp/a.md' })) },
+      ['t1'],
+      't1',
+    )
+
+    const result = await captureSnapshot(5000)
+
+    expect(listSessions).not.toHaveBeenCalled()
+    expect(result).toEqual({ total: 0, resolved: 0, unresolved: 0 })
+    const stored = readSnapshot()
+    expect(stored).not.toBeNull()
+    expect(stored!.sessionMeta).toEqual({})
+  })
+
+  it('6. buildSnapshot never writes storage (B1) — only captureSnapshot writes the primary key', async () => {
+    const oldSnap: WorkspaceSnapshot = {
+      version: 1, capturedAt: -1, tabs: {}, tabOrder: [], activeTabId: null,
+      workspaces: [], activeWorkspaceId: null, sessionMeta: {},
+    }
+    writeSnapshot(oldSnap)
+
+    seedStores(
+      { t1: tab('t1', leaf('p1', tmuxContent('hostA', 'code1', 'cached1'))) },
+      ['t1'],
+      't1',
+    )
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'code1', cwd: '/x' })])
+
+    const built = await buildSnapshot(6000)
+    expect(built.capturedAt).toBe(6000)
+    expect(readSnapshot()).toEqual(oldSnap) // still the old snapshot — buildSnapshot did not write
+
+    await captureSnapshot(6000)
+    expect(readSnapshot()!.capturedAt).toBe(6000) // now overwritten by captureSnapshot
+  })
+})

--- a/spa/src/lib/snapshot/capture.test.ts
+++ b/spa/src/lib/snapshot/capture.test.ts
@@ -151,6 +151,27 @@ describe('buildSnapshot / captureSnapshot', () => {
     })
   })
 
+  it('7. live session with empty cwd → not restorable, cwd stays undefined (not "")', async () => {
+    seedStores(
+      { t1: tab('t1', leaf('p1', tmuxContent('hostA', 'code1', 'cached1'))) },
+      ['t1'],
+      't1',
+    )
+    vi.mocked(listSessions).mockResolvedValue([
+      session({ code: 'code1', name: 'live-name', cwd: '', current_command: 'bash' }),
+    ])
+
+    const result = await captureSnapshot(7000)
+    const stored = readSnapshot()!
+
+    expect(stored.sessionMeta.hostA.code1).toEqual({
+      hostId: 'hostA', sessionCode: 'code1', name: 'live-name', mode: 'terminal',
+      cwd: undefined, currentCommand: 'bash', restorable: false,
+    })
+    expect(stored.sessionMeta.hostA.code1.captureError).toBeUndefined()
+    expect(result).toEqual({ total: 1, resolved: 0, unresolved: 1 })
+  })
+
   it('5. no tmux panes → total=0, sessionMeta={}, still writes a snapshot', async () => {
     seedStores(
       { t1: tab('t1', leaf('p1', { kind: 'editor', source: { type: 'local' }, filePath: '/tmp/a.md' })) },

--- a/spa/src/lib/snapshot/capture.ts
+++ b/spa/src/lib/snapshot/capture.ts
@@ -52,25 +52,40 @@ export async function buildSnapshot(now: number): Promise<WorkspaceSnapshot> {
       const sessions = await listSessions(hostId)
       for (const ref of refs) {
         const live = sessions.find((s) => s.code === ref.sessionCode)
-        perHost[ref.sessionCode] = live
-          ? {
-              hostId,
-              sessionCode: ref.sessionCode,
-              name: live.name,
-              mode: ref.mode,
-              cwd: live.cwd,
-              currentCommand: live.current_command,
-              restorable: true,
-            }
-          : {
-              hostId,
-              sessionCode: ref.sessionCode,
-              name: ref.cachedName,
-              mode: ref.mode,
-              cwd: undefined,
-              restorable: false,
-              captureError: 'session-dead-at-capture',
-            }
+        perHost[ref.sessionCode] =
+          live && live.cwd
+            ? {
+                hostId,
+                sessionCode: ref.sessionCode,
+                name: live.name,
+                mode: ref.mode,
+                cwd: live.cwd,
+                currentCommand: live.current_command,
+                restorable: true,
+              }
+            : live
+              ? {
+                  // Live but no usable cwd: keep structure only, not restorable
+                  // (spec line 97 — cwd unknown must not feed createSession).
+                  // cwd stays undefined (spec line 76: not-captured means
+                  // undefined, never empty string); restorable stays false.
+                  hostId,
+                  sessionCode: ref.sessionCode,
+                  name: live.name,
+                  mode: ref.mode,
+                  cwd: undefined,
+                  currentCommand: live.current_command,
+                  restorable: false,
+                }
+              : {
+                  hostId,
+                  sessionCode: ref.sessionCode,
+                  name: ref.cachedName,
+                  mode: ref.mode,
+                  cwd: undefined,
+                  restorable: false,
+                  captureError: 'session-dead-at-capture',
+                }
       }
     } catch {
       for (const ref of refs) {

--- a/spa/src/lib/snapshot/capture.ts
+++ b/spa/src/lib/snapshot/capture.ts
@@ -1,0 +1,119 @@
+import { useTabStore } from '../../stores/useTabStore'
+import { useWorkspaceStore } from '../../features/workspace/store'
+import { listSessions } from '../host-api'
+import { scanPaneTree } from '../pane-tree'
+import { writeSnapshot } from './storage'
+import type { CaptureResult, SessionMeta, WorkspaceSnapshot } from './types'
+import type { Tab } from '../../types/tab'
+
+interface CapturedPaneRef {
+  hostId: string
+  sessionCode: string
+  mode: 'terminal' | 'stream'
+  cachedName: string
+}
+
+function collectTmuxPanesByHost(tabs: Record<string, Tab>): Map<string, CapturedPaneRef[]> {
+  const byHost = new Map<string, CapturedPaneRef[]>()
+  for (const t of Object.values(tabs)) {
+    scanPaneTree(t.layout, (pane) => {
+      if (pane.content.kind !== 'tmux-session') return
+      const { hostId, sessionCode, mode, cachedName } = pane.content
+      const refs = byHost.get(hostId)
+      if (refs) {
+        refs.push({ hostId, sessionCode, mode, cachedName })
+      } else {
+        byHost.set(hostId, [{ hostId, sessionCode, mode, cachedName }])
+      }
+    })
+  }
+  return byHost
+}
+
+/**
+ * Build a WorkspaceSnapshot from the current tab + workspace store state, plus
+ * one `listSessions` call per host to resolve name/cwd/restorable for each
+ * captured tmux-session pane.
+ *
+ * B1: this function MUST NOT write to storage — callers decide when/where to
+ * persist the resulting snapshot (see captureSnapshot below, and T7's
+ * pre-restore `-prev` backup which must build without touching the primary key).
+ */
+export async function buildSnapshot(now: number): Promise<WorkspaceSnapshot> {
+  const { tabs, tabOrder, activeTabId } = useTabStore.getState()
+  const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState()
+
+  const byHost = collectTmuxPanesByHost(tabs)
+  const sessionMeta: Record<string, Record<string, SessionMeta>> = {}
+
+  for (const [hostId, refs] of byHost) {
+    const perHost: Record<string, SessionMeta> = {}
+    try {
+      const sessions = await listSessions(hostId)
+      for (const ref of refs) {
+        const live = sessions.find((s) => s.code === ref.sessionCode)
+        perHost[ref.sessionCode] = live
+          ? {
+              hostId,
+              sessionCode: ref.sessionCode,
+              name: live.name,
+              mode: ref.mode,
+              cwd: live.cwd,
+              currentCommand: live.current_command,
+              restorable: true,
+            }
+          : {
+              hostId,
+              sessionCode: ref.sessionCode,
+              name: ref.cachedName,
+              mode: ref.mode,
+              cwd: undefined,
+              restorable: false,
+              captureError: 'session-dead-at-capture',
+            }
+      }
+    } catch {
+      for (const ref of refs) {
+        perHost[ref.sessionCode] = {
+          hostId,
+          sessionCode: ref.sessionCode,
+          name: ref.cachedName,
+          mode: ref.mode,
+          cwd: undefined,
+          restorable: false,
+          captureError: 'host-unreachable',
+        }
+      }
+    }
+    sessionMeta[hostId] = perHost
+  }
+
+  return {
+    version: 1,
+    capturedAt: now,
+    tabs,
+    tabOrder,
+    activeTabId,
+    workspaces,
+    activeWorkspaceId,
+    sessionMeta,
+  }
+}
+
+/** buildSnapshot + write the primary snapshot key + return capture stats. */
+export async function captureSnapshot(now: number): Promise<CaptureResult> {
+  const snap = await buildSnapshot(now)
+  writeSnapshot(snap)
+
+  let total = 0
+  let resolved = 0
+  let unresolved = 0
+  for (const perHost of Object.values(snap.sessionMeta)) {
+    for (const meta of Object.values(perHost)) {
+      total++
+      if (meta.restorable) resolved++
+      else unresolved++
+    }
+  }
+  return { total, resolved, unresolved }
+}

--- a/spa/src/lib/snapshot/restore.test.ts
+++ b/spa/src/lib/snapshot/restore.test.ts
@@ -59,8 +59,10 @@ describe('ensureSessions', () => {
   it('1. all sessions live → all reattached; createSession never called', async () => {
     const sessionMeta: Record<string, Record<string, SessionMeta>> = {
       hostA: {
-        code1: meta({ hostId: 'hostA', sessionCode: 'code1' }),
-        code2: meta({ hostId: 'hostA', sessionCode: 'code2' }),
+        // Reattach now requires code AND name match, so the meta name must equal
+        // the live session's name (same session survived the daemon restart).
+        code1: meta({ hostId: 'hostA', sessionCode: 'code1', name: 'live1' }),
+        code2: meta({ hostId: 'hostA', sessionCode: 'code2', name: 'live2' }),
       },
     }
     vi.mocked(listSessions).mockResolvedValue([
@@ -181,7 +183,9 @@ describe('ensureSessions', () => {
       B: { shared: meta({ hostId: 'B', sessionCode: 'shared', name: 'b-name', cwd: '/b' }) },
     }
     vi.mocked(listSessions).mockImplementation(async (hostId: string) => {
-      if (hostId === 'A') return [session({ code: 'shared', name: 'a-live' })]
+      // Reattach requires code AND name match: host A's live session shares the
+      // meta's name ('a-name'), so it legitimately reattaches.
+      if (hostId === 'A') return [session({ code: 'shared', name: 'a-name' })]
       if (hostId === 'B') return []
       throw new Error(`unexpected host ${hostId}`)
     })
@@ -220,6 +224,67 @@ describe('ensureSessions', () => {
       expect(entry.session.name).toBe('daemon-renamed')
       expect(entry.session.code).toBe('daemon-assigned-code')
     }
+  })
+
+  it('9. code AND name match → reattached; createSession NOT called', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        code1: meta({ hostId: 'hostA', sessionCode: 'code1', name: 'same-name', cwd: '/w' }),
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'code1', name: 'same-name' })])
+
+    const { remap, report } = await ensureSessions(sessionMeta)
+
+    expect(createSession).not.toHaveBeenCalled()
+    const entry = remap.hostA.code1
+    expect(entry.status).toBe('reattached')
+    if (entry.status === 'reattached') {
+      expect(entry.newCode).toBe('code1')
+      expect(entry.session.name).toBe('same-name')
+    }
+    expect(report).toEqual({ reattached: 1, rebuilt: 0, failed: 0 })
+  })
+
+  it('10. code matches but name differs (code reused for another session), restorable + rebuild default → rebuilt via meta; unrelated live session untouched', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        code1: meta({ hostId: 'hostA', sessionCode: 'code1', name: 'my-name', cwd: '/mine', mode: 'terminal' }),
+      },
+    }
+    // Live list has a DIFFERENT session that reused code1 after the restart.
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'code1', name: 'someone-elses' })])
+    vi.mocked(createSession).mockImplementation(async (_h, name, cwd, mode) =>
+      session({ code: 'rebuilt-code', name, cwd, mode }),
+    )
+
+    const { remap, report } = await ensureSessions(sessionMeta)
+
+    // Rebuild from the snapshot's meta, NOT adoption of the unrelated live session.
+    expect(createSession).toHaveBeenCalledTimes(1)
+    expect(createSession).toHaveBeenCalledWith('hostA', 'my-name', '/mine', 'terminal')
+    const entry = remap.hostA.code1
+    expect(entry.status).toBe('rebuilt')
+    if (entry.status === 'rebuilt') {
+      expect(entry.newCode).toBe('rebuilt-code')
+      expect(entry.session.code).toBe('rebuilt-code')
+    }
+    expect(report).toEqual({ reattached: 0, rebuilt: 1, failed: 0 })
+  })
+
+  it('11. code matches but name differs, rebuild:false → failed; createSession NOT called', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        code1: meta({ hostId: 'hostA', sessionCode: 'code1', name: 'my-name', cwd: '/mine' }),
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'code1', name: 'someone-elses' })])
+
+    const { remap, report } = await ensureSessions(sessionMeta, { rebuild: false })
+
+    expect(createSession).not.toHaveBeenCalled()
+    expect(remap.hostA.code1.status).toBe('failed')
+    expect(report).toEqual({ reattached: 0, rebuilt: 0, failed: 1 })
   })
 })
 

--- a/spa/src/lib/snapshot/restore.test.ts
+++ b/spa/src/lib/snapshot/restore.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSession, listSessions } from '../host-api'
+import type { Session } from '../host-api'
+import type { SessionMeta } from './types'
+import { ensureSessions } from './restore'
+
+vi.mock('../host-api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../host-api')>()),
+  listSessions: vi.fn(),
+  createSession: vi.fn(),
+}))
+
+function session(overrides: Partial<Session> & { code: string }): Session {
+  return {
+    name: overrides.name ?? overrides.code,
+    cwd: overrides.cwd ?? '/tmp',
+    mode: overrides.mode ?? 'terminal',
+    cc_session_id: '',
+    cc_model: '',
+    has_relay: false,
+    ...overrides,
+  }
+}
+
+function meta(overrides: Partial<SessionMeta> & { hostId: string; sessionCode: string }): SessionMeta {
+  return {
+    name: overrides.name ?? overrides.sessionCode,
+    mode: overrides.mode ?? 'terminal',
+    cwd: overrides.cwd ?? '/work',
+    restorable: overrides.restorable ?? true,
+    ...overrides,
+  }
+}
+
+describe('ensureSessions', () => {
+  beforeEach(() => {
+    vi.mocked(listSessions).mockReset()
+    vi.mocked(createSession).mockReset()
+  })
+
+  it('1. all sessions live → all reattached; createSession never called', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        code1: meta({ hostId: 'hostA', sessionCode: 'code1' }),
+        code2: meta({ hostId: 'hostA', sessionCode: 'code2' }),
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([
+      session({ code: 'code1', name: 'live1' }),
+      session({ code: 'code2', name: 'live2' }),
+    ])
+
+    const { remap, report } = await ensureSessions(sessionMeta)
+
+    expect(listSessions).toHaveBeenCalledTimes(1)
+    expect(createSession).not.toHaveBeenCalled()
+    expect(remap.hostA.code1.status).toBe('reattached')
+    expect(remap.hostA.code2.status).toBe('reattached')
+    if (remap.hostA.code1.status === 'reattached') {
+      expect(remap.hostA.code1.newCode).toBe('code1')
+      expect(remap.hostA.code1.session.name).toBe('live1')
+    }
+    expect(report).toEqual({ reattached: 2, rebuilt: 0, failed: 0 })
+  })
+
+  it('2. rebuild scope: 3 restorable dead (incl orphans) + 1 live → createSession exactly 3', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        live1: meta({ hostId: 'hostA', sessionCode: 'live1' }),
+        dead1: meta({ hostId: 'hostA', sessionCode: 'dead1', name: 'd1', cwd: '/a' }),
+        dead2: meta({ hostId: 'hostA', sessionCode: 'dead2', name: 'd2', cwd: '/b' }),
+        orphan: meta({ hostId: 'hostA', sessionCode: 'orphan', name: 'd3', cwd: '/c' }),
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'live1', name: 'live1' })])
+    vi.mocked(createSession).mockImplementation(async (_h, name) =>
+      session({ code: `new-${name}`, name }),
+    )
+
+    const { remap, report } = await ensureSessions(sessionMeta)
+
+    expect(createSession).toHaveBeenCalledTimes(3)
+    expect(remap.hostA.live1.status).toBe('reattached')
+    expect(remap.hostA.dead1.status).toBe('rebuilt')
+    expect(remap.hostA.dead2.status).toBe('rebuilt')
+    expect(remap.hostA.orphan.status).toBe('rebuilt')
+    expect(report).toEqual({ reattached: 1, rebuilt: 3, failed: 0 })
+  })
+
+  it('3. dead entry with restorable=false → failed; createSession not called for it', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        dead: meta({ hostId: 'hostA', sessionCode: 'dead', restorable: false, cwd: undefined }),
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([])
+
+    const { remap, report } = await ensureSessions(sessionMeta)
+
+    expect(createSession).not.toHaveBeenCalled()
+    expect(remap.hostA.dead.status).toBe('failed')
+    expect(report).toEqual({ reattached: 0, rebuilt: 0, failed: 1 })
+  })
+
+  it('4. rebuild:false → dead entries failed, createSession never called; live still reattached', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        live1: meta({ hostId: 'hostA', sessionCode: 'live1' }),
+        dead1: meta({ hostId: 'hostA', sessionCode: 'dead1' }),
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'live1', name: 'live1' })])
+
+    const { remap, report } = await ensureSessions(sessionMeta, { rebuild: false })
+
+    expect(createSession).not.toHaveBeenCalled()
+    expect(remap.hostA.live1.status).toBe('reattached')
+    expect(remap.hostA.dead1.status).toBe('failed')
+    expect(report).toEqual({ reattached: 1, rebuilt: 0, failed: 1 })
+  })
+
+  it('5. createSession rejects for one entry → that entry failed, the rest proceed', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        dead1: meta({ hostId: 'hostA', sessionCode: 'dead1', name: 'd1' }),
+        dead2: meta({ hostId: 'hostA', sessionCode: 'dead2', name: 'd2' }),
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(createSession).mockImplementation(async (_h, name) => {
+      if (name === 'd1') throw new Error('daemon boom')
+      return session({ code: `new-${name}`, name })
+    })
+
+    const { remap, report } = await ensureSessions(sessionMeta)
+
+    expect(createSession).toHaveBeenCalledTimes(2)
+    expect(remap.hostA.dead1.status).toBe('failed')
+    expect(remap.hostA.dead2.status).toBe('rebuilt')
+    expect(report).toEqual({ reattached: 0, rebuilt: 1, failed: 1 })
+  })
+
+  it('6. host offline (listSessions throws) → every entry failed; createSession never called', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        a: meta({ hostId: 'hostA', sessionCode: 'a' }),
+        b: meta({ hostId: 'hostA', sessionCode: 'b' }),
+      },
+    }
+    vi.mocked(listSessions).mockRejectedValue(new Error('host unreachable'))
+
+    const { remap, report } = await ensureSessions(sessionMeta)
+
+    expect(createSession).not.toHaveBeenCalled()
+    expect(remap.hostA.a.status).toBe('failed')
+    expect(remap.hostA.b.status).toBe('failed')
+    expect(report).toEqual({ reattached: 0, rebuilt: 0, failed: 2 })
+  })
+
+  it('7. cross-host same code: A live (reattached), B dead (rebuilt), no contamination', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      A: { shared: meta({ hostId: 'A', sessionCode: 'shared', name: 'a-name' }) },
+      B: { shared: meta({ hostId: 'B', sessionCode: 'shared', name: 'b-name', cwd: '/b' }) },
+    }
+    vi.mocked(listSessions).mockImplementation(async (hostId: string) => {
+      if (hostId === 'A') return [session({ code: 'shared', name: 'a-live' })]
+      if (hostId === 'B') return []
+      throw new Error(`unexpected host ${hostId}`)
+    })
+    vi.mocked(createSession).mockImplementation(async (_h, name) =>
+      session({ code: 'b-new-code', name }),
+    )
+
+    const { remap, report } = await ensureSessions(sessionMeta)
+
+    expect(remap.A.shared.status).toBe('reattached')
+    expect(remap.B.shared.status).toBe('rebuilt')
+    if (remap.B.shared.status === 'rebuilt') {
+      expect(remap.B.shared.newCode).toBe('b-new-code')
+    }
+    expect(remap.A.shared).not.toEqual(remap.B.shared)
+    expect(report).toEqual({ reattached: 1, rebuilt: 1, failed: 0 })
+  })
+
+  it('8. daemon auto-rename (§8.1): trust returned object for newCode + name', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        dead1: meta({ hostId: 'hostA', sessionCode: 'dead1', name: 'requested-name', cwd: '/w' }),
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(createSession).mockResolvedValue(
+      session({ code: 'daemon-assigned-code', name: 'daemon-renamed' }),
+    )
+
+    const { remap } = await ensureSessions(sessionMeta)
+
+    const entry = remap.hostA.dead1
+    expect(entry.status).toBe('rebuilt')
+    if (entry.status === 'rebuilt') {
+      expect(entry.newCode).toBe('daemon-assigned-code')
+      expect(entry.session.name).toBe('daemon-renamed')
+      expect(entry.session.code).toBe('daemon-assigned-code')
+    }
+  })
+})

--- a/spa/src/lib/snapshot/restore.test.ts
+++ b/spa/src/lib/snapshot/restore.test.ts
@@ -4,15 +4,23 @@ import type { Session } from '../host-api'
 import type { PaneContent, PaneLayout, Tab, Workspace } from '../../types/tab'
 import type { Remap } from './types'
 import type { SessionMeta, WorkspaceSnapshot } from './types'
+import { RestoreError } from './types'
 import {
   ensureSessions,
+  rebuildAllSessions,
   remapLayoutSessions,
   replaceTabSnapshot,
   replaceTabState,
+  restoreAll,
+  restoreTabLayout,
+  syncSessionStore,
+  undoLastRestore,
   validateSnapshotConsistency,
 } from './restore'
+import { readPrevSnapshot } from './storage'
 import { useTabStore } from '../../stores/useTabStore'
 import { useWorkspaceStore } from '../../features/workspace/store'
+import { useSessionStore } from '../../stores/useSessionStore'
 
 vi.mock('../host-api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../host-api')>()),
@@ -631,5 +639,255 @@ describe('replaceTabSnapshot / replaceTabState', () => {
     const w = readWs()
     expect(w.workspaces).toEqual(seedWorkspaces())
     expect(w.activeWorkspaceId).toBe('oldws')
+  })
+})
+
+function tmuxTab(
+  id: string,
+  hostId: string,
+  sessionCode: string,
+  overrides?: Partial<Extract<PaneContent, { kind: 'tmux-session' }>>,
+): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: tmuxPane(`pane-${id}`, hostId, sessionCode, overrides),
+  }
+}
+
+function paneOf(t: Tab): Extract<PaneContent, { kind: 'tmux-session' }> {
+  return tmux((t.layout as { pane: { content: PaneContent } }).pane.content)
+}
+
+describe('T7 orchestration', () => {
+  const resetStores = (): void => {
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: null })
+    useSessionStore.setState({ sessions: {}, activeHostId: null, activeCode: null })
+  }
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.mocked(listSessions).mockReset()
+    vi.mocked(createSession).mockReset()
+    resetStores()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    resetStores()
+    localStorage.clear()
+  })
+
+  it('1. rebuildAllSessions rebuilds ALL restorable-dead incl orphans; no -prev written', async () => {
+    const sessionMeta: Record<string, Record<string, SessionMeta>> = {
+      hostA: {
+        s1: meta({ hostId: 'hostA', sessionCode: 's1', cwd: '/a' }),
+        s2: meta({ hostId: 'hostA', sessionCode: 's2', cwd: '/b' }),
+        s3: meta({ hostId: 'hostA', sessionCode: 's3', cwd: '/c' }),
+        s4: meta({ hostId: 'hostA', sessionCode: 's4', cwd: '/d' }), // orphan (no tab)
+        s5: meta({ hostId: 'hostA', sessionCode: 's5', cwd: '/e' }), // orphan (no tab)
+      },
+    }
+    // Current tabs reference s1..s3, each already marked terminated.
+    useTabStore.setState({
+      tabs: {
+        t1: tmuxTab('t1', 'hostA', 's1', { terminated: 'session-closed' }),
+        t2: tmuxTab('t2', 'hostA', 's2', { terminated: 'session-closed' }),
+        t3: tmuxTab('t3', 'hostA', 's3', { terminated: 'session-closed' }),
+      },
+      tabOrder: ['t1', 't2', 't3'],
+      activeTabId: 't1',
+      visitHistory: [],
+    })
+    vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(createSession).mockImplementation(async (_h, name) => session({ code: `new-${name}`, name }))
+
+    const report = await rebuildAllSessions({ ...validSnapshot(), sessionMeta })
+
+    // All 5 restorable-dead sessions rebuilt (including the 2 orphans).
+    expect(createSession).toHaveBeenCalledTimes(5)
+    expect(report.rebuilt).toBe(5)
+    expect(report.rebuiltButUnattached).toEqual([])
+
+    const s = useTabStore.getState()
+    // Structure unchanged; only terminated panes adopt the new codes.
+    expect(s.tabOrder).toEqual(['t1', 't2', 't3'])
+    expect(paneOf(s.tabs.t1).sessionCode).toBe('new-s1')
+    expect(paneOf(s.tabs.t1).terminated).toBeUndefined()
+    expect(paneOf(s.tabs.t3).sessionCode).toBe('new-s3')
+
+    // rebuildAllSessions must NOT write the -prev backup.
+    expect(readPrevSnapshot()).toBeNull()
+  })
+
+  it('2. restoreTabLayout: dead terminated (no createSession), live reattached; -prev pre-mutation; stores = snapshot', async () => {
+    // OLD world uses new-tab panes so the -prev capture makes no listSessions call.
+    useTabStore.setState({ tabs: { oldT: tab('oldT') }, tabOrder: ['oldT'], activeTabId: 'oldT', visitHistory: [] })
+    useWorkspaceStore.setState({
+      workspaces: [workspace({ id: 'oldws', tabs: ['oldT'], activeTabId: 'oldT' })],
+      activeWorkspaceId: 'oldws',
+    })
+
+    const snap: WorkspaceSnapshot = {
+      version: 1,
+      capturedAt: 0,
+      tabs: { tl: tmuxTab('tl', 'hostA', 'live1'), td: tmuxTab('td', 'hostA', 'dead1') },
+      tabOrder: ['tl', 'td'],
+      activeTabId: 'tl',
+      workspaces: [workspace({ id: 'ws1', tabs: ['tl', 'td'], activeTabId: 'tl' })],
+      activeWorkspaceId: 'ws1',
+      sessionMeta: {
+        hostA: {
+          live1: meta({ hostId: 'hostA', sessionCode: 'live1' }),
+          dead1: meta({ hostId: 'hostA', sessionCode: 'dead1' }),
+        },
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'live1', name: 'live1' })])
+
+    await restoreTabLayout(snap, { now: 123 })
+
+    expect(createSession).not.toHaveBeenCalled()
+    const s = useTabStore.getState()
+    expect(s.tabOrder).toEqual(['tl', 'td'])
+    expect(paneOf(s.tabs.tl).sessionCode).toBe('live1')
+    expect(paneOf(s.tabs.tl).terminated).toBeUndefined()
+    expect(paneOf(s.tabs.td).terminated).toBe('tmux-restarted')
+
+    const w = useWorkspaceStore.getState()
+    expect(w.workspaces).toEqual(snap.workspaces)
+    expect(w.activeWorkspaceId).toBe('ws1')
+
+    // -prev captured the OLD world → it was built BEFORE the store mutation.
+    const prev = readPrevSnapshot()
+    expect(prev).not.toBeNull()
+    expect(Object.keys(prev!.tabs)).toEqual(['oldT'])
+  })
+
+  it('3. restoreAll: full rebuild + replace = snapshot; -prev written', async () => {
+    useTabStore.setState({ tabs: { oldT: tab('oldT') }, tabOrder: ['oldT'], activeTabId: 'oldT', visitHistory: [] })
+    useWorkspaceStore.setState({
+      workspaces: [workspace({ id: 'oldws', tabs: ['oldT'], activeTabId: 'oldT' })],
+      activeWorkspaceId: 'oldws',
+    })
+
+    const snap: WorkspaceSnapshot = {
+      version: 1,
+      capturedAt: 0,
+      tabs: { tl: tmuxTab('tl', 'hostA', 'live1'), td: tmuxTab('td', 'hostA', 'dead1') },
+      tabOrder: ['tl', 'td'],
+      activeTabId: 'tl',
+      workspaces: [workspace({ id: 'ws1', tabs: ['tl', 'td'], activeTabId: 'tl' })],
+      activeWorkspaceId: 'ws1',
+      sessionMeta: {
+        hostA: {
+          live1: meta({ hostId: 'hostA', sessionCode: 'live1' }),
+          dead1: meta({ hostId: 'hostA', sessionCode: 'dead1', name: 'd1', cwd: '/w' }),
+        },
+      },
+    }
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'live1', name: 'live1' })])
+    vi.mocked(createSession).mockImplementation(async (_h, name) => session({ code: `new-${name}`, name }))
+
+    await restoreAll(snap, { now: 999 })
+
+    expect(createSession).toHaveBeenCalledTimes(1)
+    const s = useTabStore.getState()
+    expect(paneOf(s.tabs.tl).sessionCode).toBe('live1')
+    expect(paneOf(s.tabs.td).sessionCode).toBe('new-d1')
+    expect(paneOf(s.tabs.td).terminated).toBeUndefined()
+    expect(useWorkspaceStore.getState().workspaces).toEqual(snap.workspaces)
+    expect(readPrevSnapshot()).not.toBeNull()
+  })
+
+  it('4. undoLastRestore restores the pre-restore world captured in -prev', async () => {
+    // pre-A world (new-tab panes → deterministic buildSnapshot, no listSessions).
+    useTabStore.setState({ tabs: { preA: tab('preA') }, tabOrder: ['preA'], activeTabId: 'preA', visitHistory: [] })
+    useWorkspaceStore.setState({
+      workspaces: [workspace({ id: 'wsPre', tabs: ['preA'], activeTabId: 'preA' })],
+      activeWorkspaceId: 'wsPre',
+    })
+    vi.mocked(listSessions).mockResolvedValue([])
+
+    const A = validSnapshot() // t1/t2, ws1, empty sessionMeta
+    await restoreAll(A, { now: 1 })
+    expect(Object.keys(useTabStore.getState().tabs).sort()).toEqual(['t1', 't2'])
+
+    const undone = await undoLastRestore({ now: 2 })
+    expect(undone).not.toBeNull()
+    expect(Object.keys(useTabStore.getState().tabs)).toEqual(['preA'])
+    expect(useTabStore.getState().tabOrder).toEqual(['preA'])
+    expect(useWorkspaceStore.getState().workspaces[0].id).toBe('wsPre')
+  })
+
+  it('4b. undoLastRestore with no -prev present returns null', async () => {
+    expect(readPrevSnapshot()).toBeNull()
+    expect(await undoLastRestore()).toBeNull()
+  })
+
+  it('5. restoreAll rejects with RestoreError listing rebuiltButUnattached when replace fails; stores unchanged', async () => {
+    useTabStore.setState({ tabs: { oldT: tab('oldT') }, tabOrder: ['oldT'], activeTabId: 'oldT', visitHistory: [] })
+    useWorkspaceStore.setState({
+      workspaces: [workspace({ id: 'oldws', tabs: ['oldT'], activeTabId: 'oldT' })],
+      activeWorkspaceId: 'oldws',
+    })
+
+    const snap: WorkspaceSnapshot = {
+      version: 1,
+      capturedAt: 0,
+      tabs: { td: tmuxTab('td', 'hostA', 'dead1') },
+      tabOrder: ['td'],
+      activeTabId: 'ghost', // navigation ref fails validation → replaceTabSnapshot throws
+      workspaces: [workspace({ id: 'ws1', tabs: ['td'], activeTabId: 'td' })],
+      activeWorkspaceId: 'ws1',
+      sessionMeta: { hostA: { dead1: meta({ hostId: 'hostA', sessionCode: 'dead1', name: 'd1', cwd: '/w' }) } },
+    }
+    vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(createSession).mockResolvedValue(session({ code: 'new-d1', name: 'd1', cwd: '/w' }))
+
+    let err: unknown
+    await restoreAll(snap, { now: 5 }).catch((e) => {
+      err = e
+    })
+
+    expect(err).toBeInstanceOf(RestoreError)
+    expect((err as RestoreError).report.rebuiltButUnattached).toEqual([
+      { hostId: 'hostA', name: 'd1', cwd: '/w' },
+    ])
+    // Daemon session was created but the front-end stores are rolled back (T6).
+    expect(useTabStore.getState().tabOrder).toEqual(['oldT'])
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe('oldws')
+  })
+
+  it('6. syncSessionStore places rebuilt/reattached sessions into the session store', () => {
+    const remap: Remap = {
+      hostA: {
+        dead1: { status: 'rebuilt', newCode: 'new1', session: session({ code: 'new1', name: 'N1' }) },
+      },
+    }
+    syncSessionStore(remap)
+    const sessions = useSessionStore.getState().sessions.hostA
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].code).toBe('new1')
+  })
+
+  it('7. syncSessionStore aggregates per host: ONE replaceHost call carrying BOTH sessions (no clobber)', () => {
+    const remap: Remap = {
+      hostA: {
+        a: { status: 'reattached', newCode: 'a', session: session({ code: 'a', name: 'A' }) },
+        b: { status: 'rebuilt', newCode: 'b', session: session({ code: 'b', name: 'B' }) },
+      },
+    }
+    const spy = vi.spyOn(useSessionStore.getState(), 'replaceHost')
+
+    syncSessionStore(remap)
+
+    const callsForHostA = spy.mock.calls.filter((c) => c[0] === 'hostA')
+    expect(callsForHostA).toHaveLength(1)
+    expect(callsForHostA[0][1]).toHaveLength(2)
+    expect(useSessionStore.getState().sessions.hostA).toHaveLength(2)
   })
 })

--- a/spa/src/lib/snapshot/restore.test.ts
+++ b/spa/src/lib/snapshot/restore.test.ts
@@ -909,4 +909,62 @@ describe('T7 orchestration', () => {
     // 'extra' must survive; the rebuilt 'new1' is upserted alongside it.
     expect(codes).toEqual(['extra', 'new1'])
   })
+
+  it('9. syncSessionStore drops the snapshot old code on rebuild (no ghost), keeping unrelated live sessions', () => {
+    // hostA store holds the OLD (now-dead) code plus an unrelated live session.
+    useSessionStore.setState({
+      sessions: {
+        hostA: [session({ code: 'old', name: 'Old' }), session({ code: 'extra', name: 'Extra' })],
+      },
+    })
+    const remap: Remap = {
+      hostA: {
+        old: { status: 'rebuilt', newCode: 'new', session: session({ code: 'new', name: 'New' }) },
+      },
+    }
+
+    syncSessionStore(remap)
+
+    const codes = useSessionStore.getState().sessions.hostA.map((s) => s.code).sort()
+    // 'old' must be gone (dead, replaced by 'new'); 'extra' preserved; 'new' added.
+    expect(codes).toEqual(['extra', 'new'])
+  })
+
+  it('10. restoreAll discloses rebuiltButUnattached when the -prev backup write fails; stores unchanged', async () => {
+    useTabStore.setState({ tabs: { oldT: tab('oldT') }, tabOrder: ['oldT'], activeTabId: 'oldT', visitHistory: [] })
+    useWorkspaceStore.setState({
+      workspaces: [workspace({ id: 'oldws', tabs: ['oldT'], activeTabId: 'oldT' })],
+      activeWorkspaceId: 'oldws',
+    })
+
+    // Snapshot has VALID navigation refs, so only the backup write can fail here.
+    const snap: WorkspaceSnapshot = {
+      version: 1,
+      capturedAt: 0,
+      tabs: { td: tmuxTab('td', 'hostA', 'dead1') },
+      tabOrder: ['td'],
+      activeTabId: 'td',
+      workspaces: [workspace({ id: 'ws1', tabs: ['td'], activeTabId: 'td' })],
+      activeWorkspaceId: 'ws1',
+      sessionMeta: { hostA: { dead1: meta({ hostId: 'hostA', sessionCode: 'dead1', name: 'd1', cwd: '/w' }) } },
+    }
+    vi.mocked(listSessions).mockResolvedValue([])
+    vi.mocked(createSession).mockResolvedValue(session({ code: 'new-d1', name: 'd1', cwd: '/w' }))
+
+    let err: unknown
+    await restoreAll(snap, {
+      now: 5,
+      buildSnapshotFn: () => Promise.reject(new Error('quota exceeded')),
+    }).catch((e) => {
+      err = e
+    })
+
+    expect(err).toBeInstanceOf(RestoreError)
+    expect((err as RestoreError).report.rebuiltButUnattached).toEqual([
+      { hostId: 'hostA', name: 'd1', cwd: '/w' },
+    ])
+    // Backup failed before any store mutation → stores untouched.
+    expect(useTabStore.getState().tabOrder).toEqual(['oldT'])
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe('oldws')
+  })
 })

--- a/spa/src/lib/snapshot/restore.test.ts
+++ b/spa/src/lib/snapshot/restore.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSession, listSessions } from '../host-api'
 import type { Session } from '../host-api'
+import type { PaneContent, PaneLayout } from '../../types/tab'
+import type { Remap } from './types'
 import type { SessionMeta } from './types'
-import { ensureSessions } from './restore'
+import { ensureSessions, remapLayoutSessions } from './restore'
 
 vi.mock('../host-api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../host-api')>()),
@@ -202,5 +204,177 @@ describe('ensureSessions', () => {
       expect(entry.session.name).toBe('daemon-renamed')
       expect(entry.session.code).toBe('daemon-assigned-code')
     }
+  })
+})
+
+function tmuxPane(
+  id: string,
+  hostId: string,
+  sessionCode: string,
+  overrides?: Partial<Extract<PaneContent, { kind: 'tmux-session' }>>,
+): { type: 'leaf'; pane: { id: string; content: PaneContent } } {
+  return {
+    type: 'leaf',
+    pane: {
+      id,
+      content: {
+        kind: 'tmux-session',
+        hostId,
+        sessionCode,
+        mode: 'terminal',
+        cachedName: overrides?.cachedName ?? sessionCode,
+        tmuxInstance: overrides?.tmuxInstance ?? 'default',
+        ...overrides,
+      },
+    },
+  }
+}
+
+function tmux(content: PaneContent): Extract<PaneContent, { kind: 'tmux-session' }> {
+  if (content.kind !== 'tmux-session') throw new Error('expected tmux-session pane')
+  return content
+}
+
+describe('remapLayoutSessions', () => {
+  it('1. rebuilt entry → sessionCode=newCode, cachedName updated, terminated cleared', () => {
+    const layout = tmuxPane('p1', 'hostA', 'old1', {
+      cachedName: 'stale',
+      terminated: 'session-closed',
+    })
+    const remap: Remap = {
+      hostA: {
+        old1: {
+          status: 'rebuilt',
+          newCode: 'new1',
+          session: session({ code: 'new1', name: 'fresh-name' }),
+        },
+      },
+    }
+
+    const result = remapLayoutSessions(layout, remap)
+    const content = tmux((result as { pane: { content: PaneContent } }).pane.content)
+    expect(content.sessionCode).toBe('new1')
+    expect(content.cachedName).toBe('fresh-name')
+    expect(content.terminated).toBeUndefined()
+  })
+
+  it('2. failed entry → terminated set to exactly "tmux-restarted"', () => {
+    const layout = tmuxPane('p1', 'hostA', 'old1')
+    const remap: Remap = { hostA: { old1: { status: 'failed' } } }
+
+    const result = remapLayoutSessions(layout, remap)
+    const content = tmux((result as { pane: { content: PaneContent } }).pane.content)
+    expect(content.sessionCode).toBe('old1')
+    expect(content.terminated).toBe('tmux-restarted')
+  })
+
+  it('3. onlyTerminated:true → live pane matching a remap oldCode is NOT modified', () => {
+    const layout = tmuxPane('p1', 'hostA', 'old1', { cachedName: 'live-name' })
+    const remap: Remap = {
+      hostA: {
+        old1: {
+          status: 'rebuilt',
+          newCode: 'new1',
+          session: session({ code: 'new1', name: 'fresh-name' }),
+        },
+      },
+    }
+
+    const result = remapLayoutSessions(layout, remap, { onlyTerminated: true })
+    const content = tmux((result as { pane: { content: PaneContent } }).pane.content)
+    expect(content.sessionCode).toBe('old1')
+    expect(content.cachedName).toBe('live-name')
+    expect(content.terminated).toBeUndefined()
+  })
+
+  it('4. nested split with multiple tmux panes → all remapped by (hostId, sessionCode)', () => {
+    const layout: PaneLayout = {
+      type: 'split',
+      id: 's1',
+      direction: 'h',
+      sizes: [50, 50],
+      children: [
+        tmuxPane('p1', 'hostA', 'a1', { terminated: 'session-closed' }),
+        {
+          type: 'split',
+          id: 's2',
+          direction: 'v',
+          sizes: [50, 50],
+          children: [
+            tmuxPane('p2', 'hostB', 'b1'),
+            tmuxPane('p3', 'hostA', 'a2', { terminated: 'host-removed' }),
+          ],
+        },
+      ],
+    }
+    const remap: Remap = {
+      hostA: {
+        a1: { status: 'rebuilt', newCode: 'a1-new', session: session({ code: 'a1-new', name: 'A1' }) },
+        a2: { status: 'failed' },
+      },
+      hostB: {
+        b1: { status: 'reattached', newCode: 'b1', session: session({ code: 'b1', name: 'B1' }) },
+      },
+    }
+
+    const result = remapLayoutSessions(layout, remap)
+    const byId: Record<string, Extract<PaneContent, { kind: 'tmux-session' }>> = {}
+    const walk = (l: PaneLayout): void => {
+      if (l.type === 'leaf') {
+        byId[l.pane.id] = tmux(l.pane.content)
+      } else {
+        l.children.forEach(walk)
+      }
+    }
+    walk(result)
+
+    expect(byId.p1.sessionCode).toBe('a1-new')
+    expect(byId.p1.cachedName).toBe('A1')
+    expect(byId.p1.terminated).toBeUndefined()
+
+    expect(byId.p2.sessionCode).toBe('b1')
+    expect(byId.p2.cachedName).toBe('B1')
+    expect(byId.p2.terminated).toBeUndefined()
+
+    expect(byId.p3.sessionCode).toBe('a2')
+    expect(byId.p3.terminated).toBe('tmux-restarted')
+  })
+
+  it('5. no remap entry → pane left unchanged; non-tmux panes preserved', () => {
+    const layout: PaneLayout = {
+      type: 'split',
+      id: 's1',
+      direction: 'h',
+      sizes: [50, 50],
+      children: [
+        tmuxPane('p1', 'hostA', 'unknown'),
+        { type: 'leaf', pane: { id: 'p2', content: { kind: 'new-tab' } } },
+      ],
+    }
+    const remap: Remap = {
+      hostA: {
+        other: { status: 'rebuilt', newCode: 'x', session: session({ code: 'x', name: 'X' }) },
+      },
+    }
+
+    const result = remapLayoutSessions(layout, remap) as Extract<PaneLayout, { type: 'split' }>
+    const first = tmux((result.children[0] as { pane: { content: PaneContent } }).pane.content)
+    expect(first.sessionCode).toBe('unknown')
+    const second = (result.children[1] as { pane: { content: PaneContent } }).pane.content
+    expect(second.kind).toBe('new-tab')
+  })
+
+  it('6. pure: input layout is not mutated', () => {
+    const layout = tmuxPane('p1', 'hostA', 'old1')
+    const remap: Remap = {
+      hostA: {
+        old1: { status: 'rebuilt', newCode: 'new1', session: session({ code: 'new1', name: 'fresh' }) },
+      },
+    }
+
+    const result = remapLayoutSessions(layout, remap)
+    expect(tmux(layout.pane.content).sessionCode).toBe('old1')
+    expect(result).not.toBe(layout)
+    expect(tmux((result as { pane: { content: PaneContent } }).pane.content).sessionCode).toBe('new1')
   })
 })

--- a/spa/src/lib/snapshot/restore.test.ts
+++ b/spa/src/lib/snapshot/restore.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSession, listSessions } from '../host-api'
 import type { Session } from '../host-api'
-import type { PaneContent, PaneLayout } from '../../types/tab'
+import type { PaneContent, PaneLayout, Tab, Workspace } from '../../types/tab'
 import type { Remap } from './types'
-import type { SessionMeta } from './types'
-import { ensureSessions, remapLayoutSessions } from './restore'
+import type { SessionMeta, WorkspaceSnapshot } from './types'
+import { ensureSessions, remapLayoutSessions, validateSnapshotConsistency } from './restore'
 
 vi.mock('../host-api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../host-api')>()),
@@ -376,5 +376,108 @@ describe('remapLayoutSessions', () => {
     expect(tmux(layout.pane.content).sessionCode).toBe('old1')
     expect(result).not.toBe(layout)
     expect(tmux((result as { pane: { content: PaneContent } }).pane.content).sessionCode).toBe('new1')
+  })
+})
+
+function tab(id: string): Tab {
+  return {
+    id,
+    pinned: false,
+    locked: false,
+    createdAt: 0,
+    layout: { type: 'leaf', pane: { id: `pane-${id}`, content: { kind: 'new-tab' } } },
+  }
+}
+
+function workspace(overrides: Partial<Workspace> & { id: string }): Workspace {
+  return {
+    name: overrides.id,
+    tabs: [],
+    activeTabId: null,
+    ...overrides,
+  }
+}
+
+/** Fully-consistent baseline snapshot: two tabs, one workspace holding both. */
+function validSnapshot(): WorkspaceSnapshot {
+  return {
+    version: 1,
+    capturedAt: 0,
+    tabs: { t1: tab('t1'), t2: tab('t2') },
+    tabOrder: ['t1', 't2'],
+    activeTabId: 't1',
+    workspaces: [workspace({ id: 'ws1', tabs: ['t1', 't2'], activeTabId: 't1' })],
+    activeWorkspaceId: 'ws1',
+    sessionMeta: {},
+  }
+}
+
+describe('validateSnapshotConsistency', () => {
+  it('fully-consistent snapshot → ok:true', () => {
+    expect(validateSnapshotConsistency(validSnapshot())).toEqual({ ok: true })
+  })
+
+  it('(i) workspace.tabs references a ghost tab id → ok:false', () => {
+    const snap = validSnapshot()
+    snap.workspaces[0].tabs = ['t1', 'ghost']
+    const result = validateSnapshotConsistency(snap)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.length).toBeGreaterThan(0)
+  })
+
+  it('(ii) activeTabId is a ghost id → ok:false', () => {
+    const snap = validSnapshot()
+    snap.activeTabId = 'ghost'
+    const result = validateSnapshotConsistency(snap)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.length).toBeGreaterThan(0)
+  })
+
+  it('(iii) workspace.activeTabId not in that workspace tabs → ok:false', () => {
+    const snap = validSnapshot()
+    // t2 exists as a tab but is NOT in ws1.tabs below.
+    snap.workspaces[0].tabs = ['t1']
+    snap.workspaces[0].activeTabId = 't2'
+    const result = validateSnapshotConsistency(snap)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.length).toBeGreaterThan(0)
+  })
+
+  it('(iv) activeWorkspaceId is not any workspace id → ok:false', () => {
+    const snap = validSnapshot()
+    snap.activeWorkspaceId = 'ws-ghost'
+    const result = validateSnapshotConsistency(snap)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.length).toBeGreaterThan(0)
+  })
+
+  it('(v) tabOrder references a ghost tab id → ok:false', () => {
+    const snap = validSnapshot()
+    snap.tabOrder = ['t1', 't2', 'ghost']
+    const result = validateSnapshotConsistency(snap)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.length).toBeGreaterThan(0)
+  })
+
+  it('null activeTabId / activeWorkspaceId / workspace.activeTabId are allowed → ok:true', () => {
+    const snap = validSnapshot()
+    snap.activeTabId = null
+    snap.activeWorkspaceId = null
+    snap.workspaces[0].activeTabId = null
+    expect(validateSnapshotConsistency(snap)).toEqual({ ok: true })
+  })
+
+  it('pane settings.scope.workspaceId to a non-existent workspace does NOT fail (R3 C: only navigation refs validated)', () => {
+    // R3 C — scope decision: pane-content semantic refs (settings scope) are
+    // explicitly OUT of scope. A snapshot whose navigation refs are all valid
+    // stays ok:true regardless of any dangling scope reference embedded in a
+    // pane's content. Expressed as a valid snapshot: the point is that a
+    // non-navigation ref never affects the verdict.
+    const snap = validSnapshot()
+    snap.tabs.t1.layout = {
+      type: 'leaf',
+      pane: { id: 'pane-t1', content: { kind: 'settings', scope: { workspaceId: 'ws-does-not-exist' } } },
+    }
+    expect(validateSnapshotConsistency(snap)).toEqual({ ok: true })
   })
 })

--- a/spa/src/lib/snapshot/restore.test.ts
+++ b/spa/src/lib/snapshot/restore.test.ts
@@ -890,4 +890,23 @@ describe('T7 orchestration', () => {
     expect(callsForHostA[0][1]).toHaveLength(2)
     expect(useSessionStore.getState().sessions.hostA).toHaveLength(2)
   })
+
+  it('8. syncSessionStore preserves host live sessions that are NOT in the snapshot remap', () => {
+    // hostA already has an unrelated live session opened outside this snapshot.
+    useSessionStore.setState({
+      sessions: { hostA: [session({ code: 'extra', name: 'Extra' })] },
+    })
+    const remap: Remap = {
+      hostA: {
+        dead1: { status: 'rebuilt', newCode: 'new1', session: session({ code: 'new1', name: 'N1' }) },
+      },
+    }
+
+    syncSessionStore(remap)
+
+    const sessions = useSessionStore.getState().sessions.hostA
+    const codes = sessions.map((s) => s.code).sort()
+    // 'extra' must survive; the rebuilt 'new1' is upserted alongside it.
+    expect(codes).toEqual(['extra', 'new1'])
+  })
 })

--- a/spa/src/lib/snapshot/restore.test.ts
+++ b/spa/src/lib/snapshot/restore.test.ts
@@ -1,10 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSession, listSessions } from '../host-api'
 import type { Session } from '../host-api'
 import type { PaneContent, PaneLayout, Tab, Workspace } from '../../types/tab'
 import type { Remap } from './types'
 import type { SessionMeta, WorkspaceSnapshot } from './types'
-import { ensureSessions, remapLayoutSessions, validateSnapshotConsistency } from './restore'
+import {
+  ensureSessions,
+  remapLayoutSessions,
+  replaceTabSnapshot,
+  replaceTabState,
+  validateSnapshotConsistency,
+} from './restore'
+import { useTabStore } from '../../stores/useTabStore'
+import { useWorkspaceStore } from '../../features/workspace/store'
 
 vi.mock('../host-api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../host-api')>()),
@@ -479,5 +487,149 @@ describe('validateSnapshotConsistency', () => {
       pane: { id: 'pane-t1', content: { kind: 'settings', scope: { workspaceId: 'ws-does-not-exist' } } },
     }
     expect(validateSnapshotConsistency(snap)).toEqual({ ok: true })
+  })
+})
+
+describe('replaceTabSnapshot / replaceTabState', () => {
+  // Seeded "OLD" world, deliberately disjoint from validSnapshot() ("NEW") so
+  // every assertion can tell restored-old apart from applied-new.
+  const seedTabs = (): Record<string, Tab> => ({ old1: tab('old1') })
+  const seedWorkspaces = (): Workspace[] => [
+    workspace({ id: 'oldws', tabs: ['old1'], activeTabId: 'old1' }),
+  ]
+
+  function readTab() {
+    const s = useTabStore.getState()
+    return { tabs: s.tabs, tabOrder: s.tabOrder, activeTabId: s.activeTabId, visitHistory: s.visitHistory }
+  }
+  function readWs() {
+    const s = useWorkspaceStore.getState()
+    return { workspaces: s.workspaces, activeWorkspaceId: s.activeWorkspaceId }
+  }
+
+  beforeEach(() => {
+    // Merge-mode setState, explicitly listing every mutable field we rely on so
+    // state cannot leak across tests.
+    useTabStore.setState({
+      tabs: seedTabs(),
+      tabOrder: ['old1'],
+      activeTabId: 'old1',
+      visitHistory: ['old1'],
+    })
+    useWorkspaceStore.setState({
+      workspaces: seedWorkspaces(),
+      activeWorkspaceId: 'oldws',
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    // Reset to clean defaults so no state bleeds into other suites.
+    useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null, visitHistory: [] })
+    useWorkspaceStore.setState({ workspaces: [], activeWorkspaceId: null })
+  })
+
+  it('1. valid snapshot → both stores equal snapshot; stale visitHistory ids dropped', () => {
+    // Current visitHistory has a live id (t2, in the new tabOrder) and a stale
+    // id (old1, gone from the new tab set). After replace only t2 survives.
+    useTabStore.setState({ visitHistory: ['t2', 'old1'] })
+    const snap = validSnapshot()
+
+    replaceTabSnapshot(snap)
+
+    const t = readTab()
+    expect(t.tabs).toEqual(snap.tabs)
+    expect(t.tabOrder).toEqual(['t1', 't2'])
+    expect(t.activeTabId).toBe('t1')
+    expect(t.visitHistory).toEqual(['t2']) // old1 dropped, t2 kept
+
+    const w = readWs()
+    expect(w.workspaces).toEqual(snap.workspaces)
+    expect(w.activeWorkspaceId).toBe('ws1')
+  })
+
+  it('2. malformed snapshot → throws and BOTH stores completely unchanged', () => {
+    const snap = validSnapshot()
+    snap.activeTabId = 'ghost' // fails validate check 2
+
+    expect(() => replaceTabSnapshot(snap)).toThrow()
+
+    const t = readTab()
+    expect(t.tabs).toEqual(seedTabs())
+    expect(t.tabOrder).toEqual(['old1'])
+    expect(t.activeTabId).toBe('old1')
+    expect(t.visitHistory).toEqual(['old1'])
+
+    const w = readWs()
+    expect(w.workspaces).toEqual(seedWorkspaces())
+    expect(w.activeWorkspaceId).toBe('oldws')
+  })
+
+  it('3. second setState (workspace) throws → BOTH stores roll back to old values', () => {
+    // Throw only on the replace call; the rollback call proceeds via the spy's
+    // call-through default.
+    vi.spyOn(useWorkspaceStore, 'setState').mockImplementationOnce(() => {
+      throw new Error('boom-workspace')
+    })
+
+    expect(() => replaceTabSnapshot(validSnapshot())).toThrow('boom-workspace')
+
+    const t = readTab()
+    expect(t.tabs).toEqual(seedTabs())
+    expect(t.tabOrder).toEqual(['old1'])
+    expect(t.activeTabId).toBe('old1')
+    expect(t.visitHistory).toEqual(['old1'])
+
+    const w = readWs()
+    expect(w.workspaces).toEqual(seedWorkspaces())
+    expect(w.activeWorkspaceId).toBe('oldws')
+  })
+
+  it('4. first setState (tab) throws → workspace never replaced, tab rolled back, no half-apply', () => {
+    const tabSpy = vi
+      .spyOn(useTabStore, 'setState')
+      .mockImplementationOnce(() => {
+        throw new Error('boom-tab')
+      })
+    const wsSpy = vi.spyOn(useWorkspaceStore, 'setState')
+
+    expect(() => replaceTabSnapshot(validSnapshot())).toThrow('boom-tab')
+
+    // Workspace store was never given the NEW values (activeWorkspaceId 'ws1').
+    expect(wsSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ activeWorkspaceId: 'ws1' }),
+    )
+    // Workspace store remains the seeded OLD world.
+    const w = readWs()
+    expect(w.workspaces).toEqual(seedWorkspaces())
+    expect(w.activeWorkspaceId).toBe('oldws')
+
+    // Tab store rolled back to seeded OLD world (rollback setState is the spy's
+    // second call, which calls through).
+    expect(tabSpy).toHaveBeenCalled()
+    const t = readTab()
+    expect(t.tabs).toEqual(seedTabs())
+    expect(t.tabOrder).toEqual(['old1'])
+    expect(t.activeTabId).toBe('old1')
+    expect(t.visitHistory).toEqual(['old1'])
+  })
+
+  it('5. replaceTabState mutates ONLY the tab store; workspace store untouched', () => {
+    // visitHistory keeps ids present in the new tabOrder (n1), drops the rest.
+    useTabStore.setState({ visitHistory: ['n1', 'old1'] })
+
+    const newTabs: Record<string, Tab> = { n1: tab('n1') }
+    replaceTabState(newTabs, ['n1'], 'n1')
+
+    const t = readTab()
+    expect(t.tabs).toEqual(newTabs)
+    expect(t.tabOrder).toEqual(['n1'])
+    expect(t.activeTabId).toBe('n1')
+    expect(t.visitHistory).toEqual(['n1']) // old1 dropped
+
+    // Workspace store completely untouched.
+    const w = readWs()
+    expect(w.workspaces).toEqual(seedWorkspaces())
+    expect(w.activeWorkspaceId).toBe('oldws')
   })
 })

--- a/spa/src/lib/snapshot/restore.ts
+++ b/spa/src/lib/snapshot/restore.ts
@@ -1,5 +1,7 @@
 import { createSession, listSessions } from '../host-api'
 import type { Session } from '../host-api'
+import { scanPaneTree, updatePaneInLayout } from '../pane-tree'
+import type { PaneContent, PaneLayout } from '../../types/tab'
 import type { EnsureReport, Remap, RemapEntry, SessionMeta } from './types'
 
 /**
@@ -69,4 +71,64 @@ export async function ensureSessions(
   }
 
   return { remap, report }
+}
+
+/**
+ * Rewrite every `tmux-session` pane in a layout tree against a {@link Remap}
+ * produced by {@link ensureSessions}, returning a NEW layout (input untouched).
+ *
+ * Per-pane behaviour (keyed by the composite `[hostId][sessionCode]`):
+ * - `reattached` / `rebuilt` → adopt `entry.newCode`, refresh `cachedName` from
+ *   `entry.session.name`, and clear any `terminated` marker (the session is now
+ *   attachable again).
+ * - `failed` → keep the pane's code but mark `terminated: 'tmux-restarted'`.
+ *   The reason is FIXED for the restore path (codex plan-review): restore never
+ *   guesses `'session-closed'` / `'host-removed'`.
+ * - no matching entry → pane left exactly as-is.
+ *
+ * `opts.onlyTerminated` guards the "rebuild all sessions" action (spec §3.5):
+ * when true, only panes that ALREADY carry a `terminated` marker are touched;
+ * live panes are never rewritten even if their key matches a remap entry.
+ */
+export function remapLayoutSessions(
+  layout: PaneLayout,
+  remap: Remap,
+  opts?: { onlyTerminated?: boolean },
+): PaneLayout {
+  const onlyTerminated = opts?.onlyTerminated === true
+
+  // Collect the intended content updates first (scan does not mutate), then fold
+  // them into fresh layouts via updatePaneInLayout so the input is never touched.
+  const updates: Array<{ paneId: string; content: PaneContent }> = []
+
+  scanPaneTree(layout, (pane) => {
+    const content = pane.content
+    if (content.kind !== 'tmux-session') return
+    if (onlyTerminated && content.terminated === undefined) return
+
+    const entry = remap[content.hostId]?.[content.sessionCode]
+    if (!entry) return
+
+    if (entry.status === 'failed') {
+      updates.push({
+        paneId: pane.id,
+        content: { ...content, terminated: 'tmux-restarted' },
+      })
+      return
+    }
+
+    // reattached | rebuilt — adopt new code/name, clear terminated marker.
+    const { terminated: _cleared, ...rest } = content
+    void _cleared
+    updates.push({
+      paneId: pane.id,
+      content: { ...rest, sessionCode: entry.newCode, cachedName: entry.session.name },
+    })
+  })
+
+  let result = layout
+  for (const { paneId, content } of updates) {
+    result = updatePaneInLayout(result, paneId, content)
+  }
+  return result
 }

--- a/spa/src/lib/snapshot/restore.ts
+++ b/spa/src/lib/snapshot/restore.ts
@@ -335,15 +335,22 @@ function collectRebuilt(remap: Remap): RestoreReport['rebuiltButUnattached'] {
  * host. `failed` entries contribute no Session object.
  */
 export function syncSessionStore(remap: Remap): void {
-  const { replaceHost } = useSessionStore.getState()
+  const state = useSessionStore.getState()
+  const { replaceHost } = state
   for (const [hostId, perHost] of Object.entries(remap)) {
-    const sessions: Session[] = []
+    // `replaceHost` overwrites the host's whole session array, so seed from the
+    // host's EXISTING sessions and upsert by code — otherwise any live session
+    // on this host that isn't part of this snapshot (e.g. opened outside it)
+    // would be wiped from the store and vanish from the session-backed UI.
+    const byCode = new Map<string, Session>(
+      (state.sessions[hostId] ?? []).map((s) => [s.code, s]),
+    )
     for (const entry of Object.values(perHost)) {
       if (entry.status === 'reattached' || entry.status === 'rebuilt') {
-        sessions.push(entry.session)
+        byCode.set(entry.session.code, entry.session)
       }
     }
-    replaceHost(hostId, sessions)
+    replaceHost(hostId, Array.from(byCode.values()))
   }
 }
 

--- a/spa/src/lib/snapshot/restore.ts
+++ b/spa/src/lib/snapshot/restore.ts
@@ -4,7 +4,18 @@ import { scanPaneTree, updatePaneInLayout } from '../pane-tree'
 import type { PaneContent, PaneLayout, Tab } from '../../types/tab'
 import { useTabStore } from '../../stores/useTabStore'
 import { useWorkspaceStore } from '../../features/workspace/store'
-import type { EnsureReport, Remap, RemapEntry, SessionMeta, WorkspaceSnapshot } from './types'
+import { useSessionStore } from '../../stores/useSessionStore'
+import { buildSnapshot } from './capture'
+import { readPrevSnapshot, writePrevSnapshot } from './storage'
+import { RestoreError } from './types'
+import type {
+  EnsureReport,
+  Remap,
+  RemapEntry,
+  RestoreReport,
+  SessionMeta,
+  WorkspaceSnapshot,
+} from './types'
 
 /**
  * Reconcile persisted per-host session metadata against each host's live
@@ -278,4 +289,168 @@ export function replaceTabSnapshot(snap: WorkspaceSnapshot): void {
     useWorkspaceStore.setState(oldWs)
     throw err
   }
+}
+
+// ---------------------------------------------------------------------------
+// T7 — restore orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Determinism seam for the orchestrators that snapshot the pre-restore world
+ * into the `-prev` backup. `now` is injected so tests never touch the clock;
+ * `buildSnapshotFn` lets tests substitute the capture path entirely. The UI
+ * layer (a later task) passes a real `Date.now()`; everything defaults here so
+ * production callers can invoke the orchestrators with no second argument.
+ */
+export interface RestoreDeps {
+  now?: number
+  buildSnapshotFn?: typeof buildSnapshot
+}
+
+/**
+ * Collect the daemon sessions that were freshly rebuilt (their tmux processes
+ * now exist) but which the front-end could NOT attach to a pane — reported to
+ * the user via {@link RestoreError} so nothing is silently orphaned. hostId
+ * comes from the outer remap key; name/cwd from the created Session object.
+ */
+function collectRebuilt(remap: Remap): RestoreReport['rebuiltButUnattached'] {
+  const out: RestoreReport['rebuiltButUnattached'] = []
+  for (const [hostId, perHost] of Object.entries(remap)) {
+    for (const entry of Object.values(perHost)) {
+      if (entry.status === 'rebuilt') {
+        out.push({ hostId, name: entry.session.name, cwd: entry.session.cwd })
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Push the reconciled sessions from a {@link Remap} into the session store.
+ *
+ * CRITICAL (codex plan-review): `useSessionStore.replaceHost` replaces the
+ * ENTIRE session array for a host. Calling it per-entry would clobber every
+ * earlier session under that host. So we aggregate ALL `reattached`/`rebuilt`
+ * sessions for a host into ONE array and call `replaceHost` exactly once per
+ * host. `failed` entries contribute no Session object.
+ */
+export function syncSessionStore(remap: Remap): void {
+  const { replaceHost } = useSessionStore.getState()
+  for (const [hostId, perHost] of Object.entries(remap)) {
+    const sessions: Session[] = []
+    for (const entry of Object.values(perHost)) {
+      if (entry.status === 'reattached' || entry.status === 'rebuilt') {
+        sessions.push(entry.session)
+      }
+    }
+    replaceHost(hostId, sessions)
+  }
+}
+
+/** Rewrite every tab's layout in a snapshot against a remap (input untouched). */
+function rewriteSnapshotTabs(
+  snap: WorkspaceSnapshot,
+  remap: Remap,
+  opts: { onlyTerminated?: boolean },
+): WorkspaceSnapshot {
+  const tabs: Record<string, Tab> = {}
+  for (const [id, t] of Object.entries(snap.tabs)) {
+    tabs[id] = { ...t, layout: remapLayoutSessions(t.layout, remap, opts) }
+  }
+  return { ...snap, tabs }
+}
+
+/**
+ * "Rebuild all sessions" action (spec §3.5, product decision "a"):
+ * non-destructive rebuild of every restorable-and-dead session in the snapshot
+ * — including orphans not referenced by any current tab — WITHOUT replacing the
+ * live tab/workspace structure. Only panes ALREADY terminated adopt the new
+ * codes (`onlyTerminated`), so live panes are never disturbed.
+ *
+ * Does NOT write the `-prev` backup (there is nothing to undo — the existing
+ * structure is preserved) and cannot reject on a validation failure because it
+ * uses {@link replaceTabState}, which does not validate navigation refs.
+ */
+export async function rebuildAllSessions(snap: WorkspaceSnapshot): Promise<RestoreReport> {
+  const { remap, report } = await ensureSessions(snap.sessionMeta)
+
+  const { tabs, tabOrder, activeTabId } = useTabStore.getState()
+  const rewritten: Record<string, Tab> = {}
+  for (const [id, t] of Object.entries(tabs)) {
+    rewritten[id] = { ...t, layout: remapLayoutSessions(t.layout, remap, { onlyTerminated: true }) }
+  }
+
+  replaceTabState(rewritten, tabOrder, activeTabId)
+  syncSessionStore(remap)
+  return { ...report, rebuiltButUnattached: [] }
+}
+
+/**
+ * "Restore tab layout" action: adopt the SNAPSHOT's tab/workspace structure but
+ * only reattach still-live sessions — dead sessions are marked terminated
+ * (`rebuild:false`, no `createSession`). The pre-restore world is backed up to
+ * `-prev` (built with {@link buildSnapshot} so the PRIMARY snapshot key is left
+ * intact — plan §T2/B1) BEFORE any store mutation, enabling {@link undoLastRestore}.
+ */
+export async function restoreTabLayout(
+  snap: WorkspaceSnapshot,
+  deps?: RestoreDeps,
+): Promise<RestoreReport> {
+  return applySnapshotRestore(snap, { rebuild: false }, deps)
+}
+
+/**
+ * "Restore everything" action: full rebuild of restorable-dead sessions PLUS
+ * adopting the snapshot's tab/workspace structure. Backs up the pre-restore
+ * world to `-prev` (via {@link buildSnapshot}, B1) before mutating stores.
+ */
+export async function restoreAll(
+  snap: WorkspaceSnapshot,
+  deps?: RestoreDeps,
+): Promise<RestoreReport> {
+  return applySnapshotRestore(snap, { rebuild: true }, deps)
+}
+
+/**
+ * Shared body of {@link restoreTabLayout} / {@link restoreAll}: reconcile
+ * sessions, back up `-prev`, then atomically replace the tab+workspace stores.
+ * If {@link replaceTabSnapshot} throws (bad navigation refs / setState failure),
+ * the daemon sessions we rebuilt stay alive — they are surfaced in
+ * `RestoreError.report.rebuiltButUnattached` (R3 B) and the front-end stores are
+ * rolled back inside {@link replaceTabSnapshot} (T6). We never delete daemon
+ * sessions on this path.
+ */
+async function applySnapshotRestore(
+  snap: WorkspaceSnapshot,
+  ensureOpts: { rebuild: boolean },
+  deps?: RestoreDeps,
+): Promise<RestoreReport> {
+  const now = deps?.now ?? Date.now()
+  const build = deps?.buildSnapshotFn ?? buildSnapshot
+
+  const { remap, report } = await ensureSessions(snap.sessionMeta, ensureOpts)
+  const rewritten = rewriteSnapshotTabs(snap, remap, {})
+
+  // B1: back up the CURRENT world before mutating stores. buildSnapshot MUST be
+  // used (never captureSnapshot) so the primary restore-source key is untouched.
+  writePrevSnapshot(await build(now))
+
+  try {
+    replaceTabSnapshot(rewritten)
+  } catch (cause) {
+    throw new RestoreError({ ...report, rebuiltButUnattached: collectRebuilt(remap) }, cause)
+  }
+
+  syncSessionStore(remap)
+  return { ...report, rebuiltButUnattached: [] }
+}
+
+/**
+ * Undo the most recent restore by replaying the `-prev` backup through
+ * {@link restoreAll}. Returns `null` when there is no backup to undo.
+ */
+export async function undoLastRestore(deps?: RestoreDeps): Promise<RestoreReport | null> {
+  const prev = readPrevSnapshot()
+  if (!prev) return null
+  return restoreAll(prev, deps)
 }

--- a/spa/src/lib/snapshot/restore.ts
+++ b/spa/src/lib/snapshot/restore.ts
@@ -1,7 +1,9 @@
 import { createSession, listSessions } from '../host-api'
 import type { Session } from '../host-api'
 import { scanPaneTree, updatePaneInLayout } from '../pane-tree'
-import type { PaneContent, PaneLayout } from '../../types/tab'
+import type { PaneContent, PaneLayout, Tab } from '../../types/tab'
+import { useTabStore } from '../../stores/useTabStore'
+import { useWorkspaceStore } from '../../features/workspace/store'
 import type { EnsureReport, Remap, RemapEntry, SessionMeta, WorkspaceSnapshot } from './types'
 
 /**
@@ -200,4 +202,80 @@ export function validateSnapshotConsistency(
   }
 
   return { ok: true }
+}
+
+/**
+ * Replace ONLY the tab store's navigation state (does NOT touch the workspace
+ * store). `visitHistory` is NOT persisted, so it is not part of the snapshot;
+ * instead the CURRENT history is filtered to the ids that still exist in the
+ * new `tabOrder` (a subset of the new tab set), so closing the active tab
+ * afterwards still resolves to a live tab rather than a ghost.
+ */
+export function replaceTabState(
+  tabs: Record<string, Tab>,
+  tabOrder: string[],
+  activeTabId: string | null,
+): void {
+  const order = new Set(tabOrder)
+  const visitHistory = useTabStore.getState().visitHistory.filter((id) => order.has(id))
+  useTabStore.setState({ tabs, tabOrder, activeTabId, visitHistory })
+}
+
+/**
+ * Adopt a {@link WorkspaceSnapshot} into BOTH the tab store and the workspace
+ * store with best-effort atomicity.
+ *
+ * Sequence:
+ * 1. `validateSnapshotConsistency` — on failure THROW before touching any
+ *    store (navigation refs must be sound before the UI dereferences them).
+ * 2. Snapshot the OLD values of both stores for rollback.
+ * 3. Replace the tab store, THEN the workspace store.
+ * 4. If ANY setState throws, roll BOTH stores back to the captured old values
+ *    and rethrow — never leave a half-applied state. If the FIRST (tab)
+ *    setState throws, the workspace store was never given new values, so its
+ *    rollback is a no-op restoring the untouched old world.
+ *
+ * `visitHistory` is filtered against `snap.tabOrder` exactly as in
+ * {@link replaceTabState} (it is not carried in the snapshot).
+ */
+export function replaceTabSnapshot(snap: WorkspaceSnapshot): void {
+  const result = validateSnapshotConsistency(snap)
+  if (!result.ok) {
+    throw new Error(`snapshot consistency check failed: ${result.reason}`)
+  }
+
+  const tabState = useTabStore.getState()
+  const oldTab = {
+    tabs: tabState.tabs,
+    tabOrder: tabState.tabOrder,
+    activeTabId: tabState.activeTabId,
+    visitHistory: tabState.visitHistory,
+  }
+  const wsState = useWorkspaceStore.getState()
+  const oldWs = {
+    workspaces: wsState.workspaces,
+    activeWorkspaceId: wsState.activeWorkspaceId,
+  }
+
+  const order = new Set(snap.tabOrder)
+  const visitHistory = tabState.visitHistory.filter((id) => order.has(id))
+
+  try {
+    useTabStore.setState({
+      tabs: snap.tabs,
+      tabOrder: snap.tabOrder,
+      activeTabId: snap.activeTabId,
+      visitHistory,
+    })
+    useWorkspaceStore.setState({
+      workspaces: snap.workspaces,
+      activeWorkspaceId: snap.activeWorkspaceId,
+    })
+  } catch (err) {
+    // Roll BOTH stores back. If the tab setState threw, this restores it; the
+    // workspace rollback restores the (untouched) old world either way.
+    useTabStore.setState(oldTab)
+    useWorkspaceStore.setState(oldWs)
+    throw err
+  }
 }

--- a/spa/src/lib/snapshot/restore.ts
+++ b/spa/src/lib/snapshot/restore.ts
@@ -345,6 +345,11 @@ export function syncSessionStore(remap: Remap): void {
     const byCode = new Map<string, Session>(
       (state.sessions[hostId] ?? []).map((s) => [s.code, s]),
     )
+    // Drop this snapshot's own old codes first: a rebuilt oldCode→newCode (or a
+    // `failed` entry) must not leave the dead oldCode lingering as a ghost
+    // session. Unrelated live sessions on this host (not in the snapshot) are
+    // untouched, so they survive; reattached entries re-add their own code below.
+    for (const oldCode of Object.keys(perHost)) byCode.delete(oldCode)
     for (const entry of Object.values(perHost)) {
       if (entry.status === 'reattached' || entry.status === 'rebuilt') {
         byCode.set(entry.session.code, entry.session)
@@ -438,11 +443,12 @@ async function applySnapshotRestore(
   const { remap, report } = await ensureSessions(snap.sessionMeta, ensureOpts)
   const rewritten = rewriteSnapshotTabs(snap, remap, {})
 
-  // B1: back up the CURRENT world before mutating stores. buildSnapshot MUST be
-  // used (never captureSnapshot) so the primary restore-source key is untouched.
-  writePrevSnapshot(await build(now))
-
   try {
+    // B1: back up the CURRENT world before mutating stores. buildSnapshot MUST be
+    // used (never captureSnapshot) so the primary restore-source key is untouched.
+    // Kept inside the try so a backup-write failure (e.g. localStorage quota)
+    // still discloses the daemon sessions ensureSessions already created.
+    writePrevSnapshot(await build(now))
     replaceTabSnapshot(rewritten)
   } catch (cause) {
     throw new RestoreError({ ...report, rebuiltButUnattached: collectRebuilt(remap) }, cause)

--- a/spa/src/lib/snapshot/restore.ts
+++ b/spa/src/lib/snapshot/restore.ts
@@ -58,7 +58,12 @@ export async function ensureSessions(
         continue
       }
 
-      const alive = live.find((s) => s.code === oldCode)
+      // Reattach ONLY when a live session matches BOTH code AND name. After a
+      // daemon/tmux restart a code can be reused for a DIFFERENT session, so a
+      // code-only match could adopt the wrong session (wrong cwd/process). A
+      // code match with a mismatched name means an unrelated session took the
+      // code → do NOT adopt it; fall through to the dead path (rebuild/fail).
+      const alive = live.find((s) => s.code === oldCode && s.name === meta.name)
       if (alive) {
         perHostRemap[oldCode] = { status: 'reattached', newCode: oldCode, session: alive }
         report.reattached++

--- a/spa/src/lib/snapshot/restore.ts
+++ b/spa/src/lib/snapshot/restore.ts
@@ -1,0 +1,72 @@
+import { createSession, listSessions } from '../host-api'
+import type { Session } from '../host-api'
+import type { EnsureReport, Remap, RemapEntry, SessionMeta } from './types'
+
+/**
+ * Reconcile persisted per-host session metadata against each host's live
+ * session list, reattaching survivors and (optionally) rebuilding restorable
+ * dead sessions.
+ *
+ * Contract highlights (see plan §8.1):
+ * - Exactly one `listSessions` per host. If it throws (host offline), every
+ *   entry for that host is `failed` and `createSession` is never called there.
+ * - Rebuilt entries ALWAYS trust the returned Session object for `newCode` /
+ *   `session` — the daemon may auto-rename or assign a different code.
+ * - Per-session failure isolation: a single `createSession` rejection marks
+ *   only that entry `failed` and never aborts the rest.
+ * - `remap` is nested by hostId then oldCode, so identical code values under
+ *   different hosts never collide.
+ */
+export async function ensureSessions(
+  sessionMeta: Record<string, Record<string, SessionMeta>>,
+  opts?: { rebuild?: boolean },
+): Promise<{ remap: Remap; report: EnsureReport }> {
+  const rebuild = opts?.rebuild !== false
+  const remap: Remap = {}
+  const report: EnsureReport = { reattached: 0, rebuilt: 0, failed: 0 }
+
+  for (const [hostId, perHost] of Object.entries(sessionMeta)) {
+    const perHostRemap: Record<string, RemapEntry> = {}
+    remap[hostId] = perHostRemap
+
+    let live: Session[] | null
+    try {
+      live = await listSessions(hostId)
+    } catch {
+      live = null // host offline — every entry fails, no createSession
+    }
+
+    for (const [oldCode, meta] of Object.entries(perHost)) {
+      if (live === null) {
+        perHostRemap[oldCode] = { status: 'failed' }
+        report.failed++
+        continue
+      }
+
+      const alive = live.find((s) => s.code === oldCode)
+      if (alive) {
+        perHostRemap[oldCode] = { status: 'reattached', newCode: oldCode, session: alive }
+        report.reattached++
+        continue
+      }
+
+      if (!rebuild || !meta.restorable || !meta.cwd) {
+        perHostRemap[oldCode] = { status: 'failed' }
+        report.failed++
+        continue
+      }
+
+      try {
+        const created = await createSession(hostId, meta.name, meta.cwd, meta.mode)
+        // §8.1: trust the returned object, never the request values.
+        perHostRemap[oldCode] = { status: 'rebuilt', newCode: created.code, session: created }
+        report.rebuilt++
+      } catch {
+        perHostRemap[oldCode] = { status: 'failed' }
+        report.failed++
+      }
+    }
+  }
+
+  return { remap, report }
+}

--- a/spa/src/lib/snapshot/restore.ts
+++ b/spa/src/lib/snapshot/restore.ts
@@ -2,7 +2,7 @@ import { createSession, listSessions } from '../host-api'
 import type { Session } from '../host-api'
 import { scanPaneTree, updatePaneInLayout } from '../pane-tree'
 import type { PaneContent, PaneLayout } from '../../types/tab'
-import type { EnsureReport, Remap, RemapEntry, SessionMeta } from './types'
+import type { EnsureReport, Remap, RemapEntry, SessionMeta, WorkspaceSnapshot } from './types'
 
 /**
  * Reconcile persisted per-host session metadata against each host's live
@@ -131,4 +131,73 @@ export function remapLayoutSessions(
     result = updatePaneInLayout(result, paneId, content)
   }
   return result
+}
+
+/**
+ * Structural navigation-integrity guard for a {@link WorkspaceSnapshot}, run
+ * before restore adopts a snapshot. Validates ONLY tab/workspace navigation
+ * references — the ids the UI dereferences to render the tab bar and workspace
+ * switcher. Returns on the FIRST failing check with a short human-readable
+ * reason.
+ *
+ * Five checks (all must pass for `ok:true`):
+ * 1. Every id in each `workspace.tabs` exists as a key in `snap.tabs`.
+ * 2. `snap.activeTabId` is `null` or a key in `snap.tabs`.
+ * 3. Each `workspace.activeTabId` is `null` or belongs to THAT workspace's `tabs`.
+ * 4. `snap.activeWorkspaceId` is `null` or the id of some workspace.
+ * 5. Every id in `snap.tabOrder` exists as a key in `snap.tabs`.
+ *
+ * Deliberately NOT validated (scope decision R3 C): pane-content semantic
+ * references such as `settings.scope.workspaceId`. Those are content, not
+ * navigation, and a dangling one must never block a restore.
+ */
+export function validateSnapshotConsistency(
+  snap: WorkspaceSnapshot,
+): { ok: true } | { ok: false; reason: string } {
+  const tabExists = (id: string): boolean =>
+    Object.prototype.hasOwnProperty.call(snap.tabs, id)
+
+  // 1. Every workspace tab id must resolve to a real tab.
+  for (const ws of snap.workspaces) {
+    for (const tabId of ws.tabs) {
+      if (!tabExists(tabId)) {
+        return { ok: false, reason: `workspace "${ws.id}" references unknown tab "${tabId}"` }
+      }
+    }
+  }
+
+  // 2. activeTabId (nullable) must resolve to a real tab.
+  if (snap.activeTabId !== null && !tabExists(snap.activeTabId)) {
+    return { ok: false, reason: `activeTabId "${snap.activeTabId}" is not a known tab` }
+  }
+
+  // 3. Each workspace.activeTabId (nullable) must belong to that workspace.
+  for (const ws of snap.workspaces) {
+    if (ws.activeTabId !== null && !ws.tabs.includes(ws.activeTabId)) {
+      return {
+        ok: false,
+        reason: `workspace "${ws.id}" activeTabId "${ws.activeTabId}" is not in its tabs`,
+      }
+    }
+  }
+
+  // 4. activeWorkspaceId (nullable) must name an existing workspace.
+  if (
+    snap.activeWorkspaceId !== null &&
+    !snap.workspaces.some((ws) => ws.id === snap.activeWorkspaceId)
+  ) {
+    return {
+      ok: false,
+      reason: `activeWorkspaceId "${snap.activeWorkspaceId}" is not a known workspace`,
+    }
+  }
+
+  // 5. Every tabOrder id must resolve to a real tab.
+  for (const tabId of snap.tabOrder) {
+    if (!tabExists(tabId)) {
+      return { ok: false, reason: `tabOrder references unknown tab "${tabId}"` }
+    }
+  }
+
+  return { ok: true }
 }

--- a/spa/src/lib/snapshot/storage.test.ts
+++ b/spa/src/lib/snapshot/storage.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  SNAPSHOT_KEY,
+  SNAPSHOT_PREV_KEY,
+  readSnapshot,
+  writeSnapshot,
+  readPrevSnapshot,
+  writePrevSnapshot,
+} from './storage'
+import type { WorkspaceSnapshot } from './types'
+
+function makeSnapshot(overrides?: Partial<WorkspaceSnapshot>): WorkspaceSnapshot {
+  return {
+    version: 1,
+    capturedAt: 1000,
+    tabs: {},
+    tabOrder: [],
+    activeTabId: null,
+    workspaces: [],
+    activeWorkspaceId: null,
+    sessionMeta: {},
+    ...overrides,
+  }
+}
+
+describe('snapshot storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips a minimal valid snapshot', () => {
+    const snap = makeSnapshot()
+    writeSnapshot(snap)
+    expect(readSnapshot()).toEqual(snap)
+  })
+
+  it('returns null when key is empty', () => {
+    expect(readSnapshot()).toBeNull()
+  })
+
+  it('returns null (never throws) on malformed JSON', () => {
+    localStorage.setItem(SNAPSHOT_KEY, '{not json')
+    expect(() => readSnapshot()).not.toThrow()
+    expect(readSnapshot()).toBeNull()
+  })
+
+  it('returns null when version is not 1', () => {
+    localStorage.setItem(SNAPSHOT_KEY, JSON.stringify({ version: 2, capturedAt: 1000 }))
+    expect(readSnapshot()).toBeNull()
+  })
+
+  it('keeps prev snapshot independent from current snapshot', () => {
+    const prev = makeSnapshot({ capturedAt: 1000 })
+    const current = makeSnapshot({ capturedAt: 2000 })
+    writePrevSnapshot(prev)
+    writeSnapshot(current)
+    expect(readPrevSnapshot()).toEqual(prev)
+    expect(readSnapshot()).toEqual(current)
+    expect(SNAPSHOT_KEY).not.toBe(SNAPSHOT_PREV_KEY)
+  })
+})

--- a/spa/src/lib/snapshot/storage.test.ts
+++ b/spa/src/lib/snapshot/storage.test.ts
@@ -49,6 +49,44 @@ describe('snapshot storage', () => {
     expect(readSnapshot()).toBeNull()
   })
 
+  describe('shape guard (version:1 but malformed → null, never crash downstream)', () => {
+    // Each blob is version:1 (passes the version check) but corrupt in one basic
+    // top-level field, so the read boundary must reject it rather than let it
+    // flow into restore and crash AFTER daemon side effects.
+    const base = () => makeSnapshot() as unknown as Record<string, unknown>
+
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ['tabs missing', (() => { const b = base(); delete b.tabs; return b })()],
+      ['tabs is an array', { ...base(), tabs: [] }],
+      ['tabOrder not an array', { ...base(), tabOrder: {} }],
+      ['workspaces not an array', { ...base(), workspaces: {} }],
+      ['sessionMeta missing', (() => { const b = base(); delete b.sessionMeta; return b })()],
+      ['activeTabId a number', { ...base(), activeTabId: 42 }],
+      ['activeWorkspaceId a number', { ...base(), activeWorkspaceId: 7 }],
+    ]
+
+    for (const [label, blob] of cases) {
+      it(`returns null when ${label}`, () => {
+        localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(blob))
+        expect(readSnapshot()).toBeNull()
+      })
+
+      it(`readPrevSnapshot returns null when ${label}`, () => {
+        localStorage.setItem(SNAPSHOT_PREV_KEY, JSON.stringify(blob))
+        expect(readPrevSnapshot()).toBeNull()
+      })
+    }
+
+    it('a fully well-formed snapshot still round-trips (guard does not reject valid data)', () => {
+      const snap = makeSnapshot({
+        activeTabId: 't1',
+        activeWorkspaceId: 'ws1',
+      })
+      writeSnapshot(snap)
+      expect(readSnapshot()).toEqual(snap)
+    })
+  })
+
   it('keeps prev snapshot independent from current snapshot', () => {
     const prev = makeSnapshot({ capturedAt: 1000 })
     const current = makeSnapshot({ capturedAt: 2000 })

--- a/spa/src/lib/snapshot/storage.ts
+++ b/spa/src/lib/snapshot/storage.ts
@@ -4,12 +4,36 @@ import type { WorkspaceSnapshot } from './types'
 export const SNAPSHOT_KEY = 'purdex-workspace-snapshot'
 export const SNAPSHOT_PREV_KEY = 'purdex-workspace-snapshot-prev'
 
+/** True for a non-null, non-array plain object. */
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null && !Array.isArray(x)
+}
+
+/**
+ * Lightweight runtime shape guard at the read boundary. A corrupt-but-`version:1`
+ * blob would otherwise flow into restore and crash MID-FLIGHT (after daemon side
+ * effects) instead of being rejected up front. Only basic top-level type/shape is
+ * checked here — deep per-tab/per-session validation is out of scope
+ * (validateSnapshotConsistency covers navigation refs during restore).
+ */
+function isWellFormedSnapshot(x: unknown): x is WorkspaceSnapshot {
+  if (!isPlainObject(x)) return false
+  if (!isPlainObject(x.tabs)) return false
+  if (!Array.isArray(x.tabOrder)) return false
+  if (x.activeTabId !== null && typeof x.activeTabId !== 'string') return false
+  if (!Array.isArray(x.workspaces)) return false
+  if (x.activeWorkspaceId !== null && typeof x.activeWorkspaceId !== 'string') return false
+  if (!isPlainObject(x.sessionMeta)) return false
+  return true
+}
+
 function readSnapshotFromKey(key: string): WorkspaceSnapshot | null {
   const raw = browserStorage.getItem(key) as string | null
   if (raw == null) return null
   try {
-    const parsed = JSON.parse(raw) as WorkspaceSnapshot
-    if (parsed?.version !== 1) return null
+    const parsed = JSON.parse(raw) as unknown
+    if (!isPlainObject(parsed) || parsed.version !== 1) return null
+    if (!isWellFormedSnapshot(parsed)) return null
     return parsed
   } catch {
     return null

--- a/spa/src/lib/snapshot/storage.ts
+++ b/spa/src/lib/snapshot/storage.ts
@@ -5,7 +5,7 @@ export const SNAPSHOT_KEY = 'purdex-workspace-snapshot'
 export const SNAPSHOT_PREV_KEY = 'purdex-workspace-snapshot-prev'
 
 function readSnapshotFromKey(key: string): WorkspaceSnapshot | null {
-  const raw = browserStorage.getItem(key)
+  const raw = browserStorage.getItem(key) as string | null
   if (raw == null) return null
   try {
     const parsed = JSON.parse(raw) as WorkspaceSnapshot

--- a/spa/src/lib/snapshot/storage.ts
+++ b/spa/src/lib/snapshot/storage.ts
@@ -1,0 +1,37 @@
+import { browserStorage } from '../storage/browser-backend'
+import type { WorkspaceSnapshot } from './types'
+
+export const SNAPSHOT_KEY = 'purdex-workspace-snapshot'
+export const SNAPSHOT_PREV_KEY = 'purdex-workspace-snapshot-prev'
+
+function readSnapshotFromKey(key: string): WorkspaceSnapshot | null {
+  const raw = browserStorage.getItem(key)
+  if (raw == null) return null
+  try {
+    const parsed = JSON.parse(raw) as WorkspaceSnapshot
+    if (parsed?.version !== 1) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeSnapshotToKey(key: string, snap: WorkspaceSnapshot): void {
+  browserStorage.setItem(key, JSON.stringify(snap))
+}
+
+export function readSnapshot(): WorkspaceSnapshot | null {
+  return readSnapshotFromKey(SNAPSHOT_KEY)
+}
+
+export function writeSnapshot(snap: WorkspaceSnapshot): void {
+  writeSnapshotToKey(SNAPSHOT_KEY, snap)
+}
+
+export function readPrevSnapshot(): WorkspaceSnapshot | null {
+  return readSnapshotFromKey(SNAPSHOT_PREV_KEY)
+}
+
+export function writePrevSnapshot(snap: WorkspaceSnapshot): void {
+  writeSnapshotToKey(SNAPSHOT_PREV_KEY, snap)
+}

--- a/spa/src/lib/snapshot/types.ts
+++ b/spa/src/lib/snapshot/types.ts
@@ -1,0 +1,32 @@
+import type { Tab, Workspace } from '../../types/tab'
+import type { Session } from '../host-api'
+
+export interface SessionMeta {
+  hostId: string; sessionCode: string; name: string
+  mode: 'terminal' | 'stream'
+  cwd?: string; currentCommand?: string
+  restorable: boolean
+  captureError?: 'host-unreachable' | 'session-dead-at-capture'
+}
+export interface WorkspaceSnapshot {
+  version: 1; capturedAt: number
+  tabs: Record<string, Tab>; tabOrder: string[]; activeTabId: string | null
+  workspaces: Workspace[]; activeWorkspaceId: string | null
+  sessionMeta: Record<string, Record<string, SessionMeta>>   // [hostId][sessionCode]
+}
+export interface CaptureResult { total: number; resolved: number; unresolved: number }
+
+export type RemapEntry =
+  | { status: 'reattached'; newCode: string; session: Session }
+  | { status: 'rebuilt';    newCode: string; session: Session }
+  | { status: 'failed' }
+export type Remap = Record<string, Record<string, RemapEntry>>  // [hostId][oldCode]
+export interface EnsureReport { reattached: number; rebuilt: number; failed: number }
+export interface RestoreReport extends EnsureReport {
+  rebuiltButUnattached: Array<{ hostId: string; name: string; cwd: string }>
+}
+// 失敗契約：三動作成功 resolve RestoreReport；replaceTabSnapshot throw 時包成
+// RestoreError（帶已收集含 rebuiltButUnattached 的 report）reject，UI catch 後讀 e.report。
+export class RestoreError extends Error {
+  constructor(public report: RestoreReport, public cause?: unknown) { super('restore failed') }
+}

--- a/spa/src/lib/snapshot/types.ts
+++ b/spa/src/lib/snapshot/types.ts
@@ -28,5 +28,9 @@ export interface RestoreReport extends EnsureReport {
 // 失敗契約：三動作成功 resolve RestoreReport；replaceTabSnapshot throw 時包成
 // RestoreError（帶已收集含 rebuiltButUnattached 的 report）reject，UI catch 後讀 e.report。
 export class RestoreError extends Error {
-  constructor(public report: RestoreReport, public cause?: unknown) { super('restore failed') }
+  readonly report: RestoreReport
+  constructor(report: RestoreReport, cause?: unknown) {
+    super('restore failed', { cause })
+    this.report = report
+  }
 }


### PR DESCRIPTION
## Workspace Snapshot — Phase 1 + 2（headless capture / storage / restore 引擎）

拍下當前整個工作區（workspace/tab/pane 結構 + 每個 tmux session 的 name/cwd），讓伺服器重開機 / tmux 重啟後依 name+cwd 一鍵把工作環境重建回來。本 PR 為**純前端邏輯層**（不含 UI，UI 是後續 Phase 3）。

Spec `docs/specs/2026-07-13-workspace-snapshot-spec.md`（codex R1–R3 全過）；Plan `...-plan.md`（codex plan-review 修訂）。

### 內容

**Phase 1 — 資料模型 + capture + 持久化**
- `types.ts` — `SessionMeta` / `WorkspaceSnapshot` / `Remap`（複合鍵 `[hostId][code]`）/ `EnsureReport` / `RestoreReport` / `RestoreError`。
- `storage.ts` — `read/write Snapshot` + `-prev` 後悔藥 key，走 `browserStorage`（parse 失敗 / `version!==1` → `null` 不拋）。
- `capture.ts` — `buildSnapshot(now)`（純建物件、**不寫 storage**）與 `captureSnapshot(now)`（寫正本 + 回統計）。每 host 只 `listSessions` 一次；live 無 cwd / 已死 / host 不可達 → `restorable=false`。

**Phase 2 — restore 引擎 + 三動作**（`restore.ts`）
- `ensureSessions` — 對帳 + 重建 primitive；每 host 一次 `listSessions`，restorable 已死者 `createSession`（**一律以回傳物件為準**，防 daemon 改名 §8.1），逐筆失敗隔離，host 離線全 `failed`。
- `remapLayoutSessions` — 純函式依複合鍵改寫 layout 樹；`failed` 標 `terminated:'tmux-restarted'`；`onlyTerminated` 只動已 terminated 的 pane。
- `validateSnapshotConsistency` — 5 條 tab/workspace 導航一致性守衛。
- `replaceTabState` / `replaceTabSnapshot` — 整包取代兩 store，**任一步 throw 全回滾**。
- 三動作 orchestration：`rebuildAllSessions`（重建所有可觀測 restorable 已死 session、含 orphan，不寫 `-prev`）/ `restoreTabLayout`（不重建、死的標 terminated）/ `restoreAll` / `undoLastRestore`；`syncSessionStore` per-host 聚合單次 `replaceHost`（防互蓋）；restore 失敗以 `rebuiltButUnattached` 揭露、不刪 daemon session。

### 設計決策
- **重建範圍（產品定案 a 點）**：「重建所有 session」重建快照裡所有 restorable 且已死者，不限當前 tab 是否引用，orphan 為預期；`onlyTerminated` 只收窄 remap 套用範圍，兩層獨立。
- **best-effort 取代**：非跨視窗真原子；失敗「不留半套」僅指前端 store，daemon 已建 session 為真副作用（揭露不自動刪）。

### 🐞 實作中修正的 plan 矛盾
Plan orchestration 段誤寫「還原前用 `captureSnapshot` 寫 `-prev`」——但 `captureSnapshot` 會覆寫正本、毀掉還原來源。依 plan 自身 B1 設計決策改用 **`buildSnapshot`**（不碰正本）。

### 驗證
- `src/lib/snapshot/` **47 測試綠**；全套 **3868 測試綠**；`pnpm run lint` 乾淨；`pnpm run build` 綠。
- 已 rebase 到最新 `main`，diff 僅本功能檔案。

### 待辦（不在本 PR）
- Phase 3：Settings「Snapshot」section UI（健康度四態 + 三動作按鈕 + i18n）。
- §8.1 撞同名 session daemon 實機探查（緩解已內建）。
