### PR TITLE
fix(panes): split panes can't scroll — split container must claim height via h-full

### DIFF
--- a/spa/src/components/PaneLayoutRenderer.test.tsx
+++ b/spa/src/components/PaneLayoutRenderer.test.tsx
@@ -95,6 +95,33 @@ describe('PaneLayoutRenderer', () => {
     expect(screen.getByTestId('dash-right')).toBeTruthy()
   })
 
+  it('split container claims height via h-full (not flex-1) so panes stay bounded under a block parent', () => {
+    // A top-level split mounts under TabContent's `.absolute inset-0` BLOCK
+    // wrapper, where flex-1 is inert — the container would collapse to content
+    // height and an overflow-y-auto region inside any pane could never scroll
+    // (verified by layout measurement in split-pane-scroll headless repro).
+    // h-full resolves against the absolute wrapper's definite height. Guard the
+    // class so a refactor can't silently regress split-pane scrolling.
+    registerModule({
+      id: 'dashboard-split-root',
+      name: 'Dashboard',
+      panes: [{ kind: 'dashboard', component: ({ pane }) => <div>{pane.id}</div> }],
+    })
+    const layout: PaneLayout = {
+      type: 'split', id: 's1', direction: 'v',
+      children: [
+        { type: 'leaf', pane: { id: 'top', content: { kind: 'dashboard' } } },
+        { type: 'leaf', pane: { id: 'bot', content: { kind: 'dashboard' } } },
+      ],
+      sizes: [50, 50],
+    }
+    const { container } = render(<PaneLayoutRenderer layout={layout} tabId="t1" isActive={true} />)
+    const root = container.firstChild as HTMLElement
+    expect(root.className).toContain('h-full')
+    expect(root.className).toContain('w-full')
+    expect(root.className).not.toContain('flex-1')
+  })
+
   it('renders nested splits', () => {
     registerModule({
       id: 'dashboard-nested',

--- a/spa/src/components/PaneLayoutRenderer.tsx
+++ b/spa/src/components/PaneLayoutRenderer.tsx
@@ -209,7 +209,17 @@ export function PaneLayoutRenderer({ layout, tabId, isActive, showHeader = false
   }
 
   return (
-    <div ref={containerRef} className={`flex-1 flex ${layout.direction === 'h' ? 'flex-row' : 'flex-col'} overflow-hidden`}>
+    // Height MUST come from h-full, not flex-1. A top-level split renders
+    // directly under TabContent's `.absolute inset-0` wrapper, which is a BLOCK
+    // box — `flex-1` (a flex-item property) is inert there, so the container
+    // collapses to CONTENT height and every pane below it becomes unbounded:
+    // an overflow-y-auto region inside a pane then grows to full content height
+    // and can never scroll (the tail is clipped by an ancestor overflow-hidden).
+    // `h-full w-full` resolves against the absolute wrapper's definite height,
+    // cascading a bounded height down through nested splits (whose parent is the
+    // flex child wrapper below, where 100% also resolves). w-full keeps a
+    // horizontal split full-width in that same block context.
+    <div ref={containerRef} className={`h-full w-full flex ${layout.direction === 'h' ? 'flex-row' : 'flex-col'} overflow-hidden`}>
       {layout.children.map((child, i) => (
         <div key={getLayoutKey(child)} className="contents">
           {i > 0 && (


### PR DESCRIPTION
## 問題

分割（pane split）後，pane 內的內容**無法捲動**（如 new-tab 起始畫面在半高分割格搆不到底部）。全頁（單葉）新分頁不受影響。

## 根因

頂層 split 直接掛在 `TabContent` 的 `<div class="absolute" style="inset:0">` **block** 容器下。而 split renderer 的 root 用的是 `flex-1`——這是 **flex-item 屬性，在 block 父層完全失效** → split 容器高度塌陷成 **content height** → 往下每一層 pane 都失去有界高 → pane 內 `overflow-y-auto` 區域撐到全內容高、永遠不需/不能捲動，尾端被上層 `overflow-hidden` 裁掉。

單葉全頁分頁走的是 `h-full w-full`（有界），所以正常——這正是「全頁可捲、分割不可捲」的差異來源。巢狀 split 不受影響（其父層是 flex child wrapper，`flex-1` 有效）。

## 修法

把 split 容器 root 從 `flex-1 flex …` 改為 **`h-full w-full flex …`**。`h-full` 對 absolute wrapper 的有界高解析成功，並向下級聯有界高穿透巢狀 split（其父為 flex wrapper，100% 同樣可解析）；`w-full` 維持橫向分割在 block 語境下的滿寬。

## 驗證

- 3821 vitest 全綠 / lint / build。
- 新增結構守衛測試（split root 必含 `h-full w-full`、不含 `flex-1`）。
- **Headless-chromium 佈局實測**（jsdom 無法量測佈局）：
  | 情境 | 修前 | 修後 |
  |------|------|------|
  | 頂層 split pane | canScroll:false（clientH==scrollH==全內容高） | canScroll:true、last item 可達 |
  | 巢狀 split（TOP/BL/BR 三格） | — | 三格皆 canScroll:true、有界 |

> 註：此修法讓**所有**分割 pane（含 terminal/editor）正確取得有界高——先前它們在頂層分割也處於 content-height 容器。建議在真實 app 對「分割 + terminal」做一次目視確認（tmux 會依新尺寸 reflow，屬預期）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)