### PR TITLE
feat(new-tab): tab-style agent indicator on Sessions list + per-host create & attach

### DIFF
--- a/docs/specs/2026-07-14-newtab-sessions-prefix-create-plan.md
+++ b/docs/specs/2026-07-14-newtab-sessions-prefix-create-plan.md
@@ -1,0 +1,561 @@
+# New-Tab Sessions: tab-style indicator + per-host create — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the New-Tab Sessions list the same agent icon/status prefix a tab shows, and let the user create a session per host that attaches straight into the current pane.
+
+**Architecture:** Extract the agent-layer resolution from `useTabDisplay` into a shared `useSessionAgentIndicator` hook; render each session row via a `SessionRow` that reuses `<TabIcon>`. Restructure the host header into a `<div>` carrying a separate collapse button and a `+` button that toggles an inline create form (`createSession()` → guards → `onSelect` into the current pane).
+
+**Tech Stack:** React 19, Zustand 5, Tailwind 4, Vitest + @testing-library/react, Phosphor Icons.
+
+## Global Constraints
+
+- Package manager **pnpm**; tests `cd spa && npx vitest run`; lint `pnpm run lint`; build `pnpm run build` (all from `spa/`).
+- No new i18n keys — reuse existing `session.*` / `hosts.*` / `common.*` keys.
+- Do not modify the Host page (`components/hosts/SessionsSection.tsx`) or `createSession()` in `lib/host-api.ts`.
+- Existing session-**row** offline gate stays `hostRuntime && status !== 'connected'`; only the new `+`/create uses the stricter Host-page rule.
+- Spec: `docs/specs/2026-07-14-newtab-sessions-prefix-create-spec.md`.
+
+---
+
+## Phase 1 — G1: tab-style indicator
+
+### Task 1: `useSessionAgentIndicator` hook
+
+**Files:**
+- Create: `spa/src/hooks/useSessionAgentIndicator.ts`
+- Test: `spa/src/hooks/useSessionAgentIndicator.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type TabIconComponent = ComponentType<{ size: number; className?: string }>` (moved here from `useTabDisplay.ts`)
+  - `interface SessionAgentIndicator { agentIcon: TabIconComponent | undefined; agentStatus: AgentStatus | undefined; subagentRefs: SubagentRef[]; isUnread: boolean; tabIndicatorStyle: TabIndicatorStyle }`
+  - `function useSessionAgentIndicator(hostId: string, sessionCode: string | undefined, opts?: { isTerminated?: boolean }): SessionAgentIndicator`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// spa/src/hooks/useSessionAgentIndicator.test.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useSessionAgentIndicator } from './useSessionAgentIndicator'
+import { useAgentStore } from '../stores/useAgentStore'
+import { useUISettingsStore } from '../stores/useUISettingsStore'
+import { compositeKey } from '../lib/composite-key'
+
+beforeEach(() => {
+  useAgentStore.setState({ statuses: {}, agentTypes: {}, subagents: {}, unread: {} })
+  useUISettingsStore.setState({ tabIndicatorStyle: 'iconDot', ccIconVariant: 'default', codexIconVariant: 'default' })
+})
+
+describe('useSessionAgentIndicator', () => {
+  it('returns empty indicator when sessionCode is undefined', () => {
+    const { result } = renderHook(() => useSessionAgentIndicator('h1', undefined))
+    expect(result.current.agentIcon).toBeUndefined()
+    expect(result.current.agentStatus).toBeUndefined()
+    expect(result.current.subagentRefs).toEqual([])
+    expect(result.current.isUnread).toBe(false)
+    expect(result.current.tabIndicatorStyle).toBe('iconDot')
+  })
+
+  it('resolves agent icon + status + refs + unread for a live session', () => {
+    const ck = compositeKey('h1', 's1')
+    useAgentStore.setState({
+      statuses: { [ck]: 'running' },
+      agentTypes: { [ck]: 'claude' },
+      subagents: { [ck]: [{ id: 'a', status: 'running' } as never] },
+      unread: { [ck]: true },
+    })
+    const { result } = renderHook(() => useSessionAgentIndicator('h1', 's1'))
+    expect(result.current.agentStatus).toBe('running')
+    expect(result.current.agentIcon).toBeTypeOf('function') // getAgentIcon('claude', ...) resolved a component
+    expect(result.current.subagentRefs).toHaveLength(1)
+    expect(result.current.isUnread).toBe(true)
+  })
+
+  it('suppresses the agent icon when terminated', () => {
+    const ck = compositeKey('h1', 's1')
+    useAgentStore.setState({ agentTypes: { [ck]: 'claude' } })
+    const { result } = renderHook(() => useSessionAgentIndicator('h1', 's1', { isTerminated: true }))
+    expect(result.current.agentIcon).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/hooks/useSessionAgentIndicator.test.ts`
+Expected: FAIL — module `./useSessionAgentIndicator` not found.
+
+- [ ] **Step 3: Write the hook (extract from `useTabDisplay`)**
+
+```ts
+// spa/src/hooks/useSessionAgentIndicator.ts
+import type { ComponentType } from 'react'
+import type { AgentStatus, SubagentRef } from '../stores/useAgentStore'
+import type { TabIndicatorStyle } from '../stores/useUISettingsStore'
+import { useAgentStore } from '../stores/useAgentStore'
+import { useUISettingsStore } from '../stores/useUISettingsStore'
+import { compositeKey } from '../lib/composite-key'
+import { getAgentIcon } from '../lib/agent-icons'
+
+export type TabIconComponent = ComponentType<{ size: number; className?: string }>
+
+const EMPTY_SUBAGENT_REFS: SubagentRef[] = []
+
+export interface SessionAgentIndicator {
+  agentIcon: TabIconComponent | undefined
+  agentStatus: AgentStatus | undefined
+  subagentRefs: SubagentRef[]
+  isUnread: boolean
+  tabIndicatorStyle: TabIndicatorStyle
+}
+
+/**
+ * Resolves the agent-layer indicator (icon/status/subagents/unread + the user's
+ * tabIndicatorStyle) for a single (hostId, sessionCode). Shared by useTabDisplay
+ * (tab bar) and the New-Tab Sessions list so both render an identical prefix.
+ */
+export function useSessionAgentIndicator(
+  hostId: string,
+  sessionCode: string | undefined,
+  opts?: { isTerminated?: boolean },
+): SessionAgentIndicator {
+  const isTerminated = opts?.isTerminated ?? false
+  const ck = sessionCode && hostId ? compositeKey(hostId, sessionCode) : undefined
+
+  const agentStatus = useAgentStore((s) => (ck ? s.statuses[ck] : undefined))
+  const isUnread = useAgentStore((s) => (ck ? !!s.unread[ck] : false))
+  const subagentRefs = useAgentStore((s) => (ck ? (s.subagents[ck] ?? EMPTY_SUBAGENT_REFS) : EMPTY_SUBAGENT_REFS))
+  const agentType = useAgentStore((s) => (ck ? s.agentTypes[ck] : undefined))
+  const tabIndicatorStyle = useUISettingsStore((s) => s.tabIndicatorStyle)
+  const ccIconVariant = useUISettingsStore((s) => s.ccIconVariant)
+  const codexIconVariant = useUISettingsStore((s) => s.codexIconVariant)
+
+  const agentIcon = !isTerminated && agentType
+    ? (getAgentIcon(agentType, { ccVariant: ccIconVariant, codexVariant: codexIconVariant }) as TabIconComponent | undefined)
+    : undefined
+
+  return { agentIcon, agentStatus, subagentRefs, isUnread, tabIndicatorStyle }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd spa && npx vitest run src/hooks/useSessionAgentIndicator.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/hooks/useSessionAgentIndicator.ts spa/src/hooks/useSessionAgentIndicator.test.ts
+git commit -m "feat(new-tab): add useSessionAgentIndicator hook (shared tab/session prefix resolver)"
+```
+
+---
+
+### Task 2: Refactor `useTabDisplay` to consume the hook
+
+**Files:**
+- Modify: `spa/src/hooks/useTabDisplay.ts`
+- Test: `spa/src/hooks/useTabDisplay.test.ts` (existing 14 stay green; add 1 variant test)
+
+**Interfaces:**
+- Consumes: `useSessionAgentIndicator`, `TabIconComponent` (Task 1).
+
+- [ ] **Step 1: Add a variant-update regression test**
+
+Append to `spa/src/hooks/useTabDisplay.test.ts` (adapt store-seed helpers to the file's existing pattern — seed a `tmux-session` tab with `agentTypes[ck]='claude'`):
+
+```ts
+it('re-resolves the agent icon when the cc icon variant changes', () => {
+  // seed a tmux-session tab whose ck has agentType 'claude' (reuse this file's helpers)
+  const first = renderTabDisplay() // -> returns result.current.IconComponent
+  useUISettingsStore.setState({ ccIconVariant: 'mono' })
+  const second = renderTabDisplay()
+  expect(second.IconComponent).not.toBe(first.IconComponent) // variant flows through the extracted hook
+})
+```
+
+(If the existing file already covers variant flow, keep that instead and skip this addition — do not duplicate.)
+
+- [ ] **Step 2: Run the existing suite to confirm baseline green**
+
+Run: `cd spa && npx vitest run src/hooks/useTabDisplay.test.ts`
+Expected: PASS (14 existing; new one FAILS only if variant flow regresses).
+
+- [ ] **Step 3: Refactor `useTabDisplay`**
+
+In `spa/src/hooks/useTabDisplay.ts`:
+- Import `useSessionAgentIndicator` and `TabIconComponent` from `./useSessionAgentIndicator`; remove the local `TabIconComponent` definition and the now-unused imports (`getAgentIcon`, and the agent-store selector lines it replaces — keep the `agentType` read used by `paneTitle`).
+- Replace the inline `agentStatus` / `isUnread` / `subagentRefs` / `tabIndicatorStyle` / `ccIconVariant` / `codexIconVariant` / `agentIcon` computation with:
+
+```ts
+const { agentIcon, agentStatus, subagentRefs, isUnread, tabIndicatorStyle } =
+  useSessionAgentIndicator(hostId, sessionCode, { isTerminated })
+const subagentCount = subagentRefs.length
+```
+
+- Keep: `const agentType = useAgentStore((s) => (ck ? s.agentTypes[ck] : undefined))` (used by the `paneTitle` gate), `dynamicTabName`, `ck`, and `const IconComponent = (agentIcon ?? paneIcon) as TabIconComponent | undefined`.
+- The exported `TabDisplayData` interface and return shape are unchanged.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npx vitest run src/hooks/useTabDisplay.test.ts`
+Expected: PASS (all, incl. the variant test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/hooks/useTabDisplay.ts spa/src/hooks/useTabDisplay.test.ts
+git commit -m "refactor(tabs): useTabDisplay consumes useSessionAgentIndicator (single source of truth)"
+```
+
+---
+
+### Task 3: `SessionRow` with `<TabIcon>` prefix
+
+**Files:**
+- Modify: `spa/src/components/SessionSection.tsx`
+- Test: `spa/src/components/SessionSection.test.tsx`
+
+**Interfaces:**
+- Consumes: `useSessionAgentIndicator` (Task 1), `TabIcon` (`components/TabIcon.tsx`).
+
+- [ ] **Step 1: Write the failing test (prefix DOM under a dot style)**
+
+Add to `SessionSection.test.tsx`. Seed `tabIndicatorStyle: 'dot'` + a running agent, assert the status indicator renders (via `TabStatusIndicator`'s output). Use the agent store + composite key:
+
+```ts
+import { useUISettingsStore } from '../stores/useUISettingsStore'
+import { useAgentStore } from '../stores/useAgentStore'
+import { compositeKey } from '../lib/composite-key'
+
+it('renders the tab-style status indicator for a running-agent session', () => {
+  useUISettingsStore.setState({ tabIndicatorStyle: 'dot' })
+  const ck = compositeKey(HOST_ID, 'abc001')
+  useAgentStore.setState({ statuses: { [ck]: 'running' }, agentTypes: { [ck]: 'claude' }, subagents: {}, unread: {} })
+  useSessionStore.setState({
+    sessions: { [HOST_ID]: [{ code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false }] },
+  })
+  render(<SessionSection onSelect={mockOnSelect} />)
+  // TabStatusIndicator renders a data-testid — assert the running indicator exists.
+  expect(screen.getByTestId('tab-status-indicator')).toBeInTheDocument()
+})
+```
+
+> Before writing, open `components/TabStatusIndicator.tsx` to use its real `data-testid` (or role). If it has none, assert on the rendered agent icon instead: seed no agent and assert the terminal icon is present, then seed an agent and assert an added element. Pick a stable selector that actually exists.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd spa && npx vitest run src/components/SessionSection.test.tsx -t "tab-style status indicator"`
+Expected: FAIL (no status indicator; row still uses `<TerminalWindow>` only).
+
+- [ ] **Step 3: Extract `SessionRow` and render `<TabIcon>`**
+
+In `SessionSection.tsx`, add a `SessionRow` component (hooks can't run in `.map`) and use it inside the sessions `.map`:
+
+```tsx
+import { TabIcon } from './TabIcon'
+import { useSessionAgentIndicator } from '../hooks/useSessionAgentIndicator'
+
+function SessionRow({ hostId, session, disabled, onSelect }: {
+  hostId: string
+  session: Session
+  disabled: boolean
+  onSelect: NewTabProviderProps['onSelect']
+}) {
+  const { agentIcon, agentStatus, subagentRefs, isUnread, tabIndicatorStyle } =
+    useSessionAgentIndicator(hostId, session.code)
+  const IconComponent = agentIcon ?? TerminalWindow
+  return (
+    <button
+      data-session-btn
+      className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-white/10 text-left text-sm text-text-primary cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-1 focus:ring-accent-muted"
+      disabled={disabled}
+      tabIndex={0}
+      onClick={() => onSelect({ kind: 'tmux-session', hostId, sessionCode: session.code, mode: 'terminal', cachedName: session.name, tmuxInstance: '' })}
+      onKeyDown={(e) => { /* keep the existing Arrow/j/k handler verbatim */ }}
+    >
+      <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
+        <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={false} iconSize={14} subagentRefs={subagentRefs} isUnread={isUnread} />
+      </span>
+      <span className="truncate">{session.name}</span>
+      <span className="text-xs text-text-secondary ml-auto">{session.code}</span>
+    </button>
+  )
+}
+```
+
+- Replace the inline `sessions.map((session) => (<button …><TerminalWindow …/>…</button>))` with `sessions.map((session) => <SessionRow key={`${hostId}:${session.code}`} hostId={hostId} session={session} disabled={!!isOffline} onSelect={onSelect} />)`.
+- Import `Session` type; keep `TerminalWindow` import (now the fallback icon). Preserve the exact `onKeyDown` handler by moving it into `SessionRow`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npx vitest run src/components/SessionSection.test.tsx`
+Expected: PASS (new prefix test + all existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/components/SessionSection.tsx spa/src/components/SessionSection.test.tsx
+git commit -m "feat(new-tab): render tab-style agent indicator on Sessions list rows"
+```
+
+---
+
+## Phase 2 — G2: per-host create & attach
+
+### Task 4: Always-render host header (div) with separate collapse + `+` buttons
+
+**Files:**
+- Modify: `spa/src/components/SessionSection.tsx`
+- Test: `spa/src/components/SessionSection.test.tsx`
+
+**Interfaces:**
+- Produces: header container per host in `hostOrder` (single- and multi-host); a `+` button `data-testid={`new-session-${hostId}`}`; the collapse button keeps `data-testid={`host-header-${hostId}`}` + `aria-expanded` (multi-host only).
+- Consumes: Host-page offline rule `!runtime || runtime.status !== 'connected' || runtime.tmuxState === 'unavailable'`.
+
+- [ ] **Step 1: Update existing tests + add new ones**
+
+In `SessionSection.test.tsx`:
+- Replace `shows no sessions message when empty`: with a connected host + zero sessions, the **global** "No sessions available" no longer shows; instead the host's `+` (`new-session-${HOST_ID}`) is present. Keep a separate assertion that with **no hosts at all** (`hostOrder: []`) the global empty message shows.
+- Replace `does not show host header for single host`: now assert the single host shows a create affordance — `screen.getByTestId(`new-session-${HOST_ID}`)` is present — and that NO collapse toggle (`host-header-${HOST_ID}`) exists for a single host.
+- Add:
+
+```ts
+it('renders header + create button for a connected host with zero sessions', () => {
+  useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never } }))
+  render(<SessionSection onSelect={mockOnSelect} />)
+  expect(screen.queryByText('No sessions available')).toBeNull()
+  expect(screen.getByTestId(`new-session-${HOST_ID}`)).toBeInTheDocument()
+})
+
+it('shows the global empty message only when there are no hosts', () => {
+  useHostStore.setState({ hosts: {}, hostOrder: [], activeHostId: null })
+  render(<SessionSection onSelect={mockOnSelect} />)
+  expect(screen.getByText('No sessions available')).toBeInTheDocument()
+})
+
+it('disables the create button when the host tmux is unavailable', () => {
+  useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'unavailable' } as never } }))
+  render(<SessionSection onSelect={mockOnSelect} />)
+  expect(screen.getByTestId(`new-session-${HOST_ID}`)).toBeDisabled()
+})
+
+it('clicking the create button does not toggle collapse', () => {
+  // multi-host so a collapse toggle exists
+  useHostStore.setState({
+    hosts: { [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '1', port: 7860, order: 0 }, [HOST_B]: { id: HOST_B, name: 'air', ip: '2', port: 7860, order: 1 } },
+    hostOrder: [HOST_ID, HOST_B], activeHostId: HOST_ID,
+    runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never },
+  })
+  useSessionStore.setState({ sessions: { [HOST_ID]: [{ code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false }] } })
+  render(<SessionSection onSelect={mockOnSelect} />)
+  fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+  expect(screen.getByTestId(`host-header-${HOST_ID}`)).toHaveAttribute('aria-expanded', 'true') // unchanged
+  expect(screen.getByText('dev')).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `cd spa && npx vitest run src/components/SessionSection.test.tsx`
+Expected: FAIL on the new/updated cases.
+
+- [ ] **Step 3: Restructure the header + iteration**
+
+In `SessionSection.tsx`:
+- Remove the `hasAnySessions` early-return. Instead: if `hostOrder.length === 0` (no hosts) render the global `t('session.no_sessions')`.
+- Iterate `hostOrder` for **every** existing host (drop the "only when sessions exist" implicit gating). For a host with zero sessions, render a subtle empty line `<p className="text-xs text-text-muted px-3 py-1">{t('session.no_sessions')}</p>` under its header (only when expanded).
+- Replace the single-`<button>` header with a `<div className="flex items-center gap-1.5 px-3 py-1 mt-1 w-full">`:
+  - **Collapse control (multi-host only)**: a `<button data-testid={`host-header-${hostId}`} aria-expanded={isExpanded} onClick={toggle} className="flex items-center gap-1.5 flex-1 min-w-0 cursor-pointer">` wrapping caret + status dot + name (move the existing caret/dot/name markup here verbatim). Single-host: render the same caret-less dot + name as a non-interactive `<span>` (no `host-header-` testid, no collapse).
+  - **Create button (always)**: a sibling `<button data-testid={`new-session-${hostId}`} disabled={createDisabled} onClick={() => setCreatingHost((h) => h === hostId ? null : hostId)} className="ml-auto p-1 rounded hover:bg-white/10 text-text-muted hover:text-text-primary cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" title={t('hosts.new_session')}><Plus size={14} /></button>` where `createDisabled = !hostRuntime || hostRuntime.status !== 'connected' || hostRuntime.tmuxState === 'unavailable'`.
+- Add `const [creatingHost, setCreatingHost] = useState<string | null>(null)` (form wiring lands in Task 5; here the button only toggles this state).
+- Import `Plus` from `@phosphor-icons/react`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npx vitest run src/components/SessionSection.test.tsx`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/components/SessionSection.tsx spa/src/components/SessionSection.test.tsx
+git commit -m "feat(new-tab): per-host header with create button; render hosts with zero sessions"
+```
+
+---
+
+### Task 5: `NewTabSessionForm` — create & attach with guards
+
+**Files:**
+- Modify: `spa/src/components/SessionSection.tsx`
+- Test: `spa/src/components/SessionSection.test.tsx`
+
+**Interfaces:**
+- Consumes: `createSession(hostId, name, cwd, mode)` (`lib/host-api`), `useHostStore` (host-live re-check), `onSelect`.
+
+- [ ] **Step 1: Write the failing tests (mock `createSession`)**
+
+Extend the `vi.mock('../lib/host-api', …)` to also expose `createSession: vi.fn()`. Add:
+
+```ts
+import * as hostApi from '../lib/host-api'
+
+it('creates a session and attaches it into the current pane', async () => {
+  useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never } }))
+  vi.mocked(hostApi.createSession).mockResolvedValue({ code: 'new001', name: 'built', cwd: '~', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false })
+  render(<SessionSection onSelect={mockOnSelect} />)
+  fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+  fireEvent.change(screen.getByPlaceholderText('Session name'), { target: { value: 'built' } })
+  fireEvent.click(screen.getByText('Create'))
+  await screen.findByTestId(`new-session-${HOST_ID}`) // let the async create settle
+  expect(hostApi.createSession).toHaveBeenCalledWith(HOST_ID, 'built', '~', 'terminal')
+  expect(mockOnSelect).toHaveBeenCalledWith({ kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'new001', mode: 'terminal', cachedName: 'built', tmuxInstance: '' })
+})
+
+it('does not attach when the created session has a blank code', async () => {
+  useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never } }))
+  vi.mocked(hostApi.createSession).mockResolvedValue({ code: '', name: 'built', cwd: '~', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false })
+  render(<SessionSection onSelect={mockOnSelect} />)
+  fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+  fireEvent.change(screen.getByPlaceholderText('Session name'), { target: { value: 'built' } })
+  fireEvent.click(screen.getByText('Create'))
+  await screen.findByText(/failed|error/i)
+  expect(mockOnSelect).not.toHaveBeenCalled()
+})
+
+it('does not attach when the host is removed while creating', async () => {
+  useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never } }))
+  vi.mocked(hostApi.createSession).mockImplementation(async () => {
+    useHostStore.setState({ hosts: {}, hostOrder: [], activeHostId: null }) // host vanishes mid-flight
+    return { code: 'new001', name: 'built', cwd: '~', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false }
+  })
+  render(<SessionSection onSelect={mockOnSelect} />)
+  fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+  fireEvent.change(screen.getByPlaceholderText('Session name'), { target: { value: 'built' } })
+  fireEvent.click(screen.getByText('Create'))
+  await screen.findByText(/failed|error/i)
+  expect(mockOnSelect).not.toHaveBeenCalled()
+})
+```
+
+> Use the real resolved i18n strings for `Session name` placeholder (`hosts.session_name`) and `Create` (`hosts.create`). Confirm the exact English values in `locales/en.json` before writing; adjust the selectors to match.
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `cd spa && npx vitest run src/components/SessionSection.test.tsx -t "creates a session"`
+Expected: FAIL — no form / `createSession` not wired.
+
+- [ ] **Step 3: Add `NewTabSessionForm` and wire it under the header**
+
+In `SessionSection.tsx`:
+
+```tsx
+import { createSession } from '../lib/host-api'
+
+function NewTabSessionForm({ hostId, onCreated, onCancel }: {
+  hostId: string
+  onCreated: (content: { code: string; name: string; mode: string }) => void
+  onCancel: () => void
+}) {
+  const t = useI18nStore((s) => s.t)
+  const [name, setName] = useState('')
+  const [cwd, setCwd] = useState('~')
+  const [mode, setMode] = useState('terminal')
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState('')
+
+  const disabledSubmit = creating || !name.trim()
+
+  const handleCreate = async () => {
+    if (!name.trim()) return
+    setCreating(true); setError('')
+    try {
+      const created = await createSession(hostId, name.trim(), cwd, mode)
+      // Guard 1 — blank code = failed create.
+      if (!created.code) { setError(t('hosts.create') + ' failed'); return }
+      // Guard 2 — host still live (removed/disconnected during the await must not attach).
+      const rt = useHostStore.getState().runtime[hostId]
+      const live = !!useHostStore.getState().hosts[hostId] && !!rt && rt.status === 'connected' && rt.tmuxState !== 'unavailable'
+      if (!live) { setError(t('hosts.create') + ' failed'); return }
+      onCreated({ code: created.code, name: created.name, mode })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="mx-3 my-1 p-2 bg-surface-secondary border border-border-default rounded-md">
+      <input placeholder={t('hosts.session_name')} value={name} autoFocus
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') handleCreate() }}
+        className="w-full bg-surface-primary border border-border-default rounded px-2 py-1 text-sm text-text-primary mb-1" />
+      <input placeholder={t('hosts.session_cwd')} value={cwd}
+        onChange={(e) => setCwd(e.target.value)}
+        className="w-full bg-surface-primary border border-border-default rounded px-2 py-1 text-sm text-text-muted mb-1" />
+      <select value={mode} onChange={(e) => setMode(e.target.value)}
+        className="bg-surface-primary border border-border-default rounded px-2 py-1 text-sm text-text-primary">
+        <option value="terminal">terminal</option>
+        <option value="stream">stream</option>
+      </select>
+      {error && <p className="text-xs text-red-400 mt-1">{error}</p>}
+      <div className="flex gap-2 mt-2">
+        <button onClick={handleCreate} disabled={disabledSubmit}
+          className="px-2 py-1 rounded text-xs bg-accent text-white cursor-pointer disabled:opacity-50">{t('hosts.create')}</button>
+        <button onClick={onCancel}
+          className="px-2 py-1 rounded text-xs bg-surface-tertiary text-text-secondary cursor-pointer">{t('common.cancel')}</button>
+      </div>
+    </div>
+  )
+}
+```
+
+- Under each host header, when `creatingHost === hostId`, render:
+
+```tsx
+{creatingHost === hostId && (
+  <NewTabSessionForm
+    hostId={hostId}
+    onCancel={() => setCreatingHost(null)}
+    onCreated={({ code, name, mode }) => {
+      setCreatingHost(null)
+      onSelect({ kind: 'tmux-session', hostId, sessionCode: code, mode: mode as 'terminal' | 'stream', cachedName: name, tmuxInstance: '' })
+    }}
+  />
+)}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npx vitest run src/components/SessionSection.test.tsx`
+Expected: PASS (all, incl. blank-code + host-removed guards).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/components/SessionSection.tsx spa/src/components/SessionSection.test.tsx
+git commit -m "feat(new-tab): create a session per host and attach it into the current pane"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `cd spa && npx vitest run` — full suite green.
+- [ ] `cd spa && pnpm run lint` — clean.
+- [ ] `cd spa && pnpm run build` — succeeds.
+- [ ] Manual smoke (HMR): New-Tab Sessions rows show agent icon/status like tabs; per-host `+` opens the form; creating attaches into the current pane (and into a split new-tab pane).
+
+## PR split
+
+Two reviewable PRs off this worktree (recommended): **PR-A = Phase 1 (Tasks 1-3)**, **PR-B = Phase 2 (Tasks 4-5)**. If review size is small, a single PR with the five commits is acceptable. Decide at PR time.

--- a/docs/specs/2026-07-14-newtab-sessions-prefix-create-plan.md
+++ b/docs/specs/2026-07-14-newtab-sessions-prefix-create-plan.md
@@ -42,10 +42,13 @@ import { useSessionAgentIndicator } from './useSessionAgentIndicator'
 import { useAgentStore } from '../stores/useAgentStore'
 import { useUISettingsStore } from '../stores/useUISettingsStore'
 import { compositeKey } from '../lib/composite-key'
+import type { SubagentRef } from '../stores/useAgentStore'
+
+const ref: SubagentRef = { id: 'a', type: 'cc', started_at: 0, source_pid: 0, source_start_time: '' }
 
 beforeEach(() => {
   useAgentStore.setState({ statuses: {}, agentTypes: {}, subagents: {}, unread: {} })
-  useUISettingsStore.setState({ tabIndicatorStyle: 'iconDot', ccIconVariant: 'default', codexIconVariant: 'default' })
+  useUISettingsStore.setState({ tabIndicatorStyle: 'iconDot', ccIconVariant: 'bot', codexIconVariant: 'openai' })
 })
 
 describe('useSessionAgentIndicator', () => {
@@ -62,20 +65,20 @@ describe('useSessionAgentIndicator', () => {
     const ck = compositeKey('h1', 's1')
     useAgentStore.setState({
       statuses: { [ck]: 'running' },
-      agentTypes: { [ck]: 'claude' },
-      subagents: { [ck]: [{ id: 'a', status: 'running' } as never] },
+      agentTypes: { [ck]: 'cc' }, // getAgentIcon only knows 'cc' | 'codex' | 'opencode'
+      subagents: { [ck]: [ref] },
       unread: { [ck]: true },
     })
     const { result } = renderHook(() => useSessionAgentIndicator('h1', 's1'))
     expect(result.current.agentStatus).toBe('running')
-    expect(result.current.agentIcon).toBeTypeOf('function') // getAgentIcon('claude', ...) resolved a component
+    expect(result.current.agentIcon).toBeTypeOf('function') // getAgentIcon('cc', { ccVariant:'bot', ... }) resolved a component
     expect(result.current.subagentRefs).toHaveLength(1)
     expect(result.current.isUnread).toBe(true)
   })
 
   it('suppresses the agent icon when terminated', () => {
     const ck = compositeKey('h1', 's1')
-    useAgentStore.setState({ agentTypes: { [ck]: 'claude' } })
+    useAgentStore.setState({ agentTypes: { [ck]: 'cc' } })
     const { result } = renderHook(() => useSessionAgentIndicator('h1', 's1', { isTerminated: true }))
     expect(result.current.agentIcon).toBeUndefined()
   })
@@ -165,19 +168,28 @@ git commit -m "feat(new-tab): add useSessionAgentIndicator hook (shared tab/sess
 
 - [ ] **Step 1: Add a variant-update regression test**
 
-Append to `spa/src/hooks/useTabDisplay.test.ts` (adapt store-seed helpers to the file's existing pattern — seed a `tmux-session` tab with `agentTypes[ck]='claude'`):
+First read `spa/src/hooks/useTabDisplay.test.ts` to reuse its `makeTab(...)`
+helper and the exact `hostId`/`sessionCode` it bakes into the tab (needed for the
+composite key). Append (adjusting `makeTab`'s host/code into the `compositeKey`):
 
 ```ts
-it('re-resolves the agent icon when the cc icon variant changes', () => {
-  // seed a tmux-session tab whose ck has agentType 'claude' (reuse this file's helpers)
-  const first = renderTabDisplay() // -> returns result.current.IconComponent
-  useUISettingsStore.setState({ ccIconVariant: 'mono' })
-  const second = renderTabDisplay()
-  expect(second.IconComponent).not.toBe(first.IconComponent) // variant flows through the extracted hook
+it('re-resolves the cc agent icon when the cc icon variant changes', () => {
+  const tab = makeTab(/* a tmux-session tab, per this file's helper */)
+  // Seed a 'cc' agent for that tab's composite key (use makeTab's real host/code):
+  const ck = compositeKey(/* host */, /* code */)
+  useAgentStore.setState({ agentTypes: { [ck]: 'cc' } })
+  useUISettingsStore.setState({ tabIndicatorStyle: 'iconDot', ccIconVariant: 'bot', codexIconVariant: 'openai' })
+
+  const { result, rerender } = renderHook(() => useTabDisplay(tab))
+  const first = result.current.IconComponent
+  useUISettingsStore.setState({ ccIconVariant: 'star' }) // valid CcIconVariant
+  rerender()
+  expect(result.current.IconComponent).not.toBe(first) // variant flows through the extracted hook
 })
 ```
 
-(If the existing file already covers variant flow, keep that instead and skip this addition — do not duplicate.)
+(If the existing file already covers cc/codex variant flow through `IconComponent`,
+keep that instead and skip this addition — do not duplicate.)
 
 - [ ] **Step 2: Run the existing suite to confirm baseline green**
 
@@ -234,7 +246,7 @@ import { compositeKey } from '../lib/composite-key'
 it('renders the tab-style status indicator for a running-agent session', () => {
   useUISettingsStore.setState({ tabIndicatorStyle: 'dot' })
   const ck = compositeKey(HOST_ID, 'abc001')
-  useAgentStore.setState({ statuses: { [ck]: 'running' }, agentTypes: { [ck]: 'claude' }, subagents: {}, unread: {} })
+  useAgentStore.setState({ statuses: { [ck]: 'running' }, agentTypes: { [ck]: 'cc' }, subagents: {}, unread: {} })
   useSessionStore.setState({
     sessions: { [HOST_ID]: [{ code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false }] },
   })
@@ -244,7 +256,7 @@ it('renders the tab-style status indicator for a running-agent session', () => {
 })
 ```
 
-> Before writing, open `components/TabStatusIndicator.tsx` to use its real `data-testid` (or role). If it has none, assert on the rendered agent icon instead: seed no agent and assert the terminal icon is present, then seed an agent and assert an added element. Pick a stable selector that actually exists.
+> `TabStatusIndicator` renders `data-testid="tab-status-indicator"` (confirmed) — this test asserts the **status** branch appears in the row. Agent-icon *resolution* itself is covered by Task 1's hook test (asserting `getAgentIcon('cc', …)` returns a component); here we only need the running-agent status indicator to render in a non-`icon` style. Use `agentTypes: { [ck]: 'cc' }` (not a bogus type that would fall back to the terminal icon).
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -323,10 +335,13 @@ In `SessionSection.test.tsx`:
 - Replace `does not show host header for single host`: now assert the single host shows a create affordance — `screen.getByTestId(`new-session-${HOST_ID}`)` is present — and that NO collapse toggle (`host-header-${HOST_ID}`) exists for a single host.
 - Add:
 
+Runtime fixtures use the real `HostRuntime` shape — only `status` is required,
+`tmuxState` is `'ok' | 'unavailable'` (no `as never` casts):
+
 ```ts
 it('renders header + create button for a connected host with zero sessions', () => {
   useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
-  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never } }))
+  useHostStore.setState({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'ok' } } })
   render(<SessionSection onSelect={mockOnSelect} />)
   expect(screen.queryByText('No sessions available')).toBeNull()
   expect(screen.getByTestId(`new-session-${HOST_ID}`)).toBeInTheDocument()
@@ -340,7 +355,14 @@ it('shows the global empty message only when there are no hosts', () => {
 
 it('disables the create button when the host tmux is unavailable', () => {
   useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
-  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'unavailable' } as never } }))
+  useHostStore.setState({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'unavailable' } } })
+  render(<SessionSection onSelect={mockOnSelect} />)
+  expect(screen.getByTestId(`new-session-${HOST_ID}`)).toBeDisabled()
+})
+
+it('disables the create button when the host has no runtime (offline)', () => {
+  useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+  useHostStore.setState({ runtime: {} }) // runtime undefined → Host-page rule treats as offline
   render(<SessionSection onSelect={mockOnSelect} />)
   expect(screen.getByTestId(`new-session-${HOST_ID}`)).toBeDisabled()
 })
@@ -350,7 +372,7 @@ it('clicking the create button does not toggle collapse', () => {
   useHostStore.setState({
     hosts: { [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '1', port: 7860, order: 0 }, [HOST_B]: { id: HOST_B, name: 'air', ip: '2', port: 7860, order: 1 } },
     hostOrder: [HOST_ID, HOST_B], activeHostId: HOST_ID,
-    runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never },
+    runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'ok' } },
   })
   useSessionStore.setState({ sessions: { [HOST_ID]: [{ code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false }] } })
   render(<SessionSection onSelect={mockOnSelect} />)
@@ -401,53 +423,78 @@ git commit -m "feat(new-tab): per-host header with create button; render hosts w
 
 - [ ] **Step 1: Write the failing tests (mock `createSession`)**
 
-Extend the `vi.mock('../lib/host-api', …)` to also expose `createSession: vi.fn()`. Add:
+Extend `vi.mock('../lib/host-api', …)` to also expose `createSession: vi.fn()`,
+and in `beforeEach` add `vi.mocked(hostApi.createSession).mockReset()` so the
+create tests don't cross-contaminate. Use `waitFor` (import from
+`@testing-library/react`) for async assertions — never `findByTestId` on the
+`+` button, which exists before the create resolves. Resolved i18n strings:
+placeholder `Session Name` (`hosts.session_name`), button `Create`
+(`hosts.create`). A live runtime is `{ status: 'connected', tmuxState: 'ok' }`.
 
 ```ts
 import * as hostApi from '../lib/host-api'
+import { waitFor } from '@testing-library/react'
+
+const LIVE = { status: 'connected', tmuxState: 'ok' } as const
+const made = (over: Partial<{ code: string; name: string }> = {}) =>
+  ({ code: 'new001', name: 'built', cwd: '~', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false, ...over })
 
 it('creates a session and attaches it into the current pane', async () => {
   useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
-  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never } }))
-  vi.mocked(hostApi.createSession).mockResolvedValue({ code: 'new001', name: 'built', cwd: '~', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false })
+  useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+  vi.mocked(hostApi.createSession).mockResolvedValue(made())
   render(<SessionSection onSelect={mockOnSelect} />)
   fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
-  fireEvent.change(screen.getByPlaceholderText('Session name'), { target: { value: 'built' } })
+  fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
   fireEvent.click(screen.getByText('Create'))
-  await screen.findByTestId(`new-session-${HOST_ID}`) // let the async create settle
-  expect(hostApi.createSession).toHaveBeenCalledWith(HOST_ID, 'built', '~', 'terminal')
-  expect(mockOnSelect).toHaveBeenCalledWith({ kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'new001', mode: 'terminal', cachedName: 'built', tmuxInstance: '' })
+  await waitFor(() => expect(hostApi.createSession).toHaveBeenCalledWith(HOST_ID, 'built', '~', 'terminal'))
+  await waitFor(() => expect(mockOnSelect).toHaveBeenCalledWith({ kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'new001', mode: 'terminal', cachedName: 'built', tmuxInstance: '' }))
 })
 
 it('does not attach when the created session has a blank code', async () => {
   useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
-  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never } }))
-  vi.mocked(hostApi.createSession).mockResolvedValue({ code: '', name: 'built', cwd: '~', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false })
+  useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+  vi.mocked(hostApi.createSession).mockResolvedValue(made({ code: '' }))
   render(<SessionSection onSelect={mockOnSelect} />)
   fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
-  fireEvent.change(screen.getByPlaceholderText('Session name'), { target: { value: 'built' } })
+  fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
   fireEvent.click(screen.getByText('Create'))
-  await screen.findByText(/failed|error/i)
+  await screen.findByText('Create failed') // inline error, form stays open
+  expect(screen.getByPlaceholderText('Session Name')).toBeInTheDocument()
   expect(mockOnSelect).not.toHaveBeenCalled()
 })
 
 it('does not attach when the host is removed while creating', async () => {
   useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
-  useHostStore.setState((s) => ({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'available' } as never } }))
+  useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
   vi.mocked(hostApi.createSession).mockImplementation(async () => {
-    useHostStore.setState({ hosts: {}, hostOrder: [], activeHostId: null }) // host vanishes mid-flight
-    return { code: 'new001', name: 'built', cwd: '~', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false }
+    useHostStore.setState({ hosts: {}, hostOrder: [], activeHostId: null, runtime: {} }) // host vanishes mid-flight
+    return made()
   })
   render(<SessionSection onSelect={mockOnSelect} />)
   fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
-  fireEvent.change(screen.getByPlaceholderText('Session name'), { target: { value: 'built' } })
+  fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
   fireEvent.click(screen.getByText('Create'))
-  await screen.findByText(/failed|error/i)
-  expect(mockOnSelect).not.toHaveBeenCalled()
+  await waitFor(() => expect(hostApi.createSession).toHaveBeenCalled())
+  await waitFor(() => expect(mockOnSelect).not.toHaveBeenCalled())
+})
+
+it('submits create only once on a double click', async () => {
+  useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+  useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+  let resolve!: (v: ReturnType<typeof made>) => void
+  vi.mocked(hostApi.createSession).mockReturnValue(new Promise((r) => { resolve = r }))
+  render(<SessionSection onSelect={mockOnSelect} />)
+  fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+  fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
+  const createBtn = screen.getByText('Create')
+  fireEvent.click(createBtn)
+  fireEvent.click(createBtn) // second click while in-flight must be a no-op
+  resolve(made())
+  await waitFor(() => expect(mockOnSelect).toHaveBeenCalled())
+  expect(hostApi.createSession).toHaveBeenCalledTimes(1)
 })
 ```
-
-> Use the real resolved i18n strings for `Session name` placeholder (`hosts.session_name`) and `Create` (`hosts.create`). Confirm the exact English values in `locales/en.json` before writing; adjust the selectors to match.
 
 - [ ] **Step 2: Run to verify failures**
 
@@ -456,7 +503,8 @@ Expected: FAIL — no form / `createSession` not wired.
 
 - [ ] **Step 3: Add `NewTabSessionForm` and wire it under the header**
 
-In `SessionSection.tsx`:
+In `SessionSection.tsx` (add `useRef` to the existing `react` import and
+`createSession` from host-api; `useHostStore` is already imported):
 
 ```tsx
 import { createSession } from '../lib/host-api'
@@ -472,11 +520,13 @@ function NewTabSessionForm({ hostId, onCreated, onCancel }: {
   const [mode, setMode] = useState('terminal')
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState('')
+  const creatingRef = useRef(false) // synchronous double-submit guard (fires before `creating` state commits)
 
   const disabledSubmit = creating || !name.trim()
 
   const handleCreate = async () => {
-    if (!name.trim()) return
+    if (creatingRef.current || !name.trim()) return
+    creatingRef.current = true
     setCreating(true); setError('')
     try {
       const created = await createSession(hostId, name.trim(), cwd, mode)
@@ -490,6 +540,7 @@ function NewTabSessionForm({ hostId, onCreated, onCancel }: {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed')
     } finally {
+      creatingRef.current = false
       setCreating(false)
     }
   }

--- a/docs/specs/2026-07-14-newtab-sessions-prefix-create-spec.md
+++ b/docs/specs/2026-07-14-newtab-sessions-prefix-create-spec.md
@@ -31,7 +31,13 @@ relative to the rest of the app:
 
 - No change to the Host page's session table or its create dialog.
 - No "active session" highlighting (matching a list row to an open pane).
-- No new create-session API; reuse `createSession()` from `host-api`.
+- No new create-session API; reuse `createSession()` from `host-api`. We accept
+  its coarse `"<status> <statusText>"` error (not the Host dialog's response-body
+  text) rather than changing `createSession()` — that signature is shared by all
+  callers and widening its behavior is out of scope.
+- No change to the **existing session-row** click/disable semantics (rows keep
+  today's `hostRuntime && status !== 'connected'` gate). Only the new create
+  ("+") affordance adopts the Host-page offline semantics (§5.3).
 - No delete/rename in the New-Tab list (those stay on the Host page).
 
 ## 4. Background (current code)
@@ -79,6 +85,12 @@ function useSessionAgentIndicator(
 ): SessionAgentIndicator
 ```
 
+**Type location (avoid a cycle).** `TabIconComponent` currently lives in
+`useTabDisplay.ts`. Since `useTabDisplay` will import the new hook and the new
+hook needs `TabIconComponent`, move the type into `useSessionAgentIndicator.ts`
+(or a small shared types module) and have `useTabDisplay` import it from there —
+preventing a `useTabDisplay ⇄ useSessionAgentIndicator` import cycle.
+
 Behavior (extracted verbatim from `useTabDisplay`'s agent layer):
 - `ck = sessionCode && hostId ? compositeKey(hostId, sessionCode) : undefined`.
 - Reads `statuses[ck]`, `agentTypes[ck]`, `subagents[ck] ?? []`, `unread[ck]`
@@ -108,23 +120,54 @@ all label/title logic. This is a behavior-preserving extraction; the existing 14
 
 ### 5.3 SessionSection: per-host create & attach (G2)
 
-- **Host header always rendered** (single- and multi-host), carrying: expand
-  caret (multi-host only), host status dot (existing logic), host name, and a
-  `+` new-session button on the right. `+` is disabled when the host is offline.
-  - Single-host case previously rendered no header; it now shows a compact header
-    so the `+` has a home. Expand/collapse stays multi-host-only.
-- **Inline create form** (`NewTabSessionForm`, local to SessionSection): clicking
-  `+` toggles a small form under that host with `name`, `cwd` (default `~`),
-  `mode` (`terminal|stream`) — same fields/labels as the Host page dialog. On
-  submit it calls `createSession(hostId, name.trim(), cwd, mode)`.
-  - **On success** → `onSelect({ kind:'tmux-session', hostId, sessionCode:
+**Always render a host header per host in `hostOrder`** — including hosts with
+**zero** sessions. Today the component early-returns a single global "No
+sessions available" when *no* host has any session, and renders a host header
+only when `hostOrder.length > 1`. Both must change so every host gets a create
+anchor:
+- Iterate `hostOrder`; for each existing host render a header (single- and
+  multi-host). If a host has no sessions, render a subtle per-host empty line
+  (e.g. `session.no_sessions`) under its header instead of hiding it.
+- The global early-return only applies when there are **no hosts at all**.
+
+**Header structure (no nested buttons).** The header is a `<div>` row, not a
+single button:
+- **Left**: in multi-host, a `<button>` wrapping caret + status dot + name that
+  toggles expand/collapse (single-host: same content as a non-interactive span,
+  no collapse). Status-dot logic unchanged.
+- **Right**: a **separate** `+` `<button>` (its own interactive element — never
+  nested in the collapse button) that toggles the inline create form. This
+  avoids illegal nested interactive elements and a `+` click never toggles
+  collapse.
+
+**`+` / create offline gate — Host-page semantics.** The create button and the
+create submit are disabled when the host is offline per the Host page's rule:
+`!runtime || runtime.status !== 'connected' || runtime.tmuxState ===
+'unavailable'` (stricter than the row gate; `tmuxState === 'unavailable'` must
+block create). The existing session-row gate is unchanged (§3).
+
+**Inline create form** (`NewTabSessionForm`, local to SessionSection): clicking
+`+` toggles a small form under that host with `name`, `cwd` (default `~`),
+`mode` (`terminal|stream`) — same fields/labels as the Host page dialog. On
+submit it calls `createSession(hostId, name.trim(), cwd, mode)` with a `creating`
+in-flight guard disabling submit.
+- **On success**, before attaching, apply two guards:
+  1. **Blank code** — if `!created.code`, treat as a failed create (show an
+     error, keep the form open, do **not** attach). Matches the repo's
+     "blank session code = failure" convention.
+  2. **Host still live** — re-read `useHostStore.getState()` and confirm
+     `hosts[hostId]` still exists and is connected (same offline rule as above).
+     A host removed/disconnected while `createSession` was in flight must not
+     attach into a pane pointing at a dead host; show an error instead.
+  - If both guards pass → `onSelect({ kind:'tmux-session', hostId, sessionCode:
     created.code, mode, cachedName: created.name, tmuxInstance:'' })`, then close
-    the form. This attaches the new session into the current pane (via the
-    wrapper's `setPaneContent` + `setActiveTab`). The `created.code` from the
-    response lets us attach immediately, before the WS session-list sync arrives.
-  - **On failure** → show the error text inline; do not attach; keep the form
-    open. A create in-flight guard (`creating`) disables the submit button.
-  - Empty `name` is a no-op (submit disabled), matching the Host dialog.
+    the form. This attaches into the current pane (wrapper's `setPaneContent` +
+    `setActiveTab`). Using `created.code` from the response lets us attach
+    immediately, before the WS session-list sync arrives.
+- **On failure** (network/HTTP throw, blank code, or dead host) → show the error
+  text inline; do not attach; keep the form open. Error text is the coarse
+  `createSession()` message (§3).
+- Empty `name` is a no-op (submit disabled), matching the Host dialog.
 
 ### 5.4 Reuse vs. duplication
 
@@ -151,14 +194,26 @@ SessionRow ─ useSessionAgentIndicator(hostId, code) ─▶ useAgentStore / use
 
 **`SessionSection.test` (extend existing)**
 - Row renders `<TabIcon>` prefix: no-agent → terminal icon; running agent →
-  status indicator present (assert via TabIcon output / testid).
+  status indicator present. Assert the status indicator DOM under a non-`icon`
+  `tabIndicatorStyle` (e.g. `dot` / `iconDot`) so the test exercises the real
+  prefix rather than only the terminal fallback.
 - Host header always present (incl. single host) with a `+` button.
-- `+` disabled when host offline.
+- **Zero sessions**: a connected host with no sessions still renders its header +
+  `+`, and creating works (no global "No sessions" swallow).
+- Clicking `+` toggles the form and does **not** collapse/expand the host.
+- `+` disabled when host offline per Host-page rule — cover `runtime`
+  undefined and `tmuxState === 'unavailable'`, not only `status !== 'connected'`.
 - Submitting the form calls `createSession` and, on success, `onSelect` with the
   correct `tmux-session` content (`created.code` / `created.name` / chosen mode).
-- Create failure surfaces the error and does not call `onSelect`.
+- **Race**: `createSession` resolves after the host is removed/disconnected →
+  no `onSelect`, error surfaced.
+- **Blank code**: `createSession` resolves with empty `code` → no `onSelect`,
+  error surfaced.
+- Create failure (throw) surfaces the error and does not call `onSelect`.
 
 **`useTabDisplay.test`** — unchanged, must stay green (equivalence guard).
+Additionally confirm a cc/codex icon-variant change still updates the resolved
+icon after the refactor (guards against the extraction dropping a variant input).
 
 ## 8. Phases
 
@@ -178,4 +233,8 @@ decided at plan time by review size.
   is intentional; `SessionPaneContent` connects by code, and the store fills in
   shortly after. No dependency on the list containing the new session first.
 - **Offline host** during create: `createSession` will fail → inline error; `+`
-  is already disabled when the host is known-offline.
+  is already disabled when the host is known-offline (Host-page rule).
+- **compositeKey delimiter**: agent state is keyed by `compositeKey(hostId,
+  sessionCode)` = `` `${hostId}:${sessionCode}` ``. Cross-host uniqueness holds as
+  long as `hostId`/`sessionCode` contain no ambiguating colon (existing
+  invariant already relied on by `useTabDisplay`); no design change needed.

--- a/docs/specs/2026-07-14-newtab-sessions-prefix-create-spec.md
+++ b/docs/specs/2026-07-14-newtab-sessions-prefix-create-spec.md
@@ -1,0 +1,181 @@
+# New-Tab Sessions: tab-style indicator + per-host create & attach
+
+Date: 2026-07-14
+Status: Draft
+
+## 1. Problem
+
+The New-Tab start screen's **Sessions** list (`SessionSection.tsx`) renders each
+session with a fixed `<TerminalWindow>` icon, name, and code. It has two gaps
+relative to the rest of the app:
+
+1. **No agent status.** A tab for the same session shows a rich indicator (agent
+   icon such as the Claude Code glyph, a running/error status dot, subagent
+   dots, unread pip) resolved by `useTabDisplay`. The Sessions list shows none of
+   it, so the user can't tell a session's agent state from the start screen.
+2. **No way to create a session.** The Host page can create sessions per host,
+   but from the New-Tab screen the user can only pick an *existing* session.
+   There is no "new session" affordance, and no way to spin one up and land it
+   directly in the pane they're looking at.
+
+## 2. Goals
+
+- **G1** — Each Sessions-list row shows the **same** icon/status prefix a tab
+  shows for that session: agent icon (falling back to the terminal icon), agent
+  status, subagent dots, unread — honoring the user's `tabIndicatorStyle`.
+- **G2** — Per host, the user can **create a new session** (name / cwd / mode)
+  from the New-Tab Sessions list, and on success it **attaches directly into the
+  current pane** (the full-page new tab, or a split new-tab pane).
+
+## 3. Non-Goals
+
+- No change to the Host page's session table or its create dialog.
+- No "active session" highlighting (matching a list row to an open pane).
+- No new create-session API; reuse `createSession()` from `host-api`.
+- No delete/rename in the New-Tab list (those stay on the Host page).
+
+## 4. Background (current code)
+
+- `SessionSection.tsx` — New-Tab provider. Groups sessions by host; a host header
+  row appears **only when `hostOrder.length > 1`**. Each session is a `<button>`
+  calling `onSelect({ kind:'tmux-session', hostId, sessionCode, mode:'terminal',
+  cachedName, tmuxInstance:'' })`. `onSelect` comes from `NewTabPaneWrapper`,
+  which does `setPaneContent(currentTabId, pane.id, content)` + `setActiveTab` —
+  i.e. it replaces **this** pane (works for a full-page new tab and a split
+  new-tab pane alike).
+- `useTabDisplay(tab)` (`hooks/useTabDisplay.ts`) — resolves a tab's display.
+  The **agent layer** it computes: `ck = compositeKey(hostId, sessionCode)`,
+  reads `useAgentStore` `statuses[ck]` / `agentTypes[ck]` / `subagents[ck]` /
+  `unread[ck]`, `getAgentIcon(agentType, { ccVariant, codexVariant })`, and
+  `tabIndicatorStyle` from `useUISettingsStore`. `IconComponent = agentIcon ??
+  paneIcon`, where `paneIcon` is content-kind specific.
+- `TabIcon` (`components/TabIcon.tsx`) — pure presentational; given
+  `{ IconComponent, agentStatus, tabIndicatorStyle, isActive, iconSize,
+  subagentRefs, isUnread }` it renders the exact prefix used in the tab bar.
+- `createSession(hostId, name, cwd, mode)` (`lib/host-api.ts`) — `POST
+  /api/sessions`, returns the new `Session` (has `.code`, `.name`).
+- Host page's `NewSessionDialog` (in `components/hosts/SessionsSection.tsx`) is
+  the reference create form (name / cwd default `~` / mode `terminal|stream`).
+
+## 5. Design
+
+### 5.1 Shared agent-indicator hook (single source of truth)
+
+New `hooks/useSessionAgentIndicator.ts`:
+
+```ts
+interface SessionAgentIndicator {
+  agentIcon: TabIconComponent | undefined   // undefined when no/terminated agent
+  agentStatus: AgentStatus | undefined
+  subagentRefs: SubagentRef[]
+  isUnread: boolean
+  tabIndicatorStyle: TabIndicatorStyle
+}
+
+function useSessionAgentIndicator(
+  hostId: string,
+  sessionCode: string | undefined,
+  opts?: { isTerminated?: boolean },
+): SessionAgentIndicator
+```
+
+Behavior (extracted verbatim from `useTabDisplay`'s agent layer):
+- `ck = sessionCode && hostId ? compositeKey(hostId, sessionCode) : undefined`.
+- Reads `statuses[ck]`, `agentTypes[ck]`, `subagents[ck] ?? []`, `unread[ck]`
+  (all guarded to empty/undefined when `ck` is undefined), plus
+  `tabIndicatorStyle`, `ccIconVariant`, `codexIconVariant`.
+- `agentIcon = !isTerminated && agentType ? getAgentIcon(agentType, { ccVariant,
+  codexVariant }) : undefined` (default `isTerminated=false`).
+- Empty-reference constants reused so identity is stable (no render churn).
+
+`useTabDisplay` is refactored to **consume** this hook for the agent layer,
+keeping its own `paneIcon` fallback (`IconComponent = agentIcon ?? paneIcon`) and
+all label/title logic. This is a behavior-preserving extraction; the existing 14
+`useTabDisplay.test.ts` cases must stay green.
+
+### 5.2 SessionSection: tab-style prefix (G1)
+
+- Extract each session row into a `SessionRow` component (hooks can't run inside
+  `.map()`), which calls `useSessionAgentIndicator(hostId, session.code)` and
+  renders `<TabIcon>` in place of `<TerminalWindow>`:
+  - `IconComponent = agentIcon ?? TerminalWindow` (terminal is the idle/no-agent
+    fallback, matching today's look).
+  - `isActive={false}` (list rows are not "active" tabs).
+  - `iconSize` chosen to sit in TabIcon's `w-4 h-4` box (14, matching the tab
+    bar); final value confirmed during implementation.
+- The row's button, keyboard nav (`data-session-btn`, Arrow/j/k), `onSelect`
+  payload, disabled-when-offline behavior are unchanged.
+
+### 5.3 SessionSection: per-host create & attach (G2)
+
+- **Host header always rendered** (single- and multi-host), carrying: expand
+  caret (multi-host only), host status dot (existing logic), host name, and a
+  `+` new-session button on the right. `+` is disabled when the host is offline.
+  - Single-host case previously rendered no header; it now shows a compact header
+    so the `+` has a home. Expand/collapse stays multi-host-only.
+- **Inline create form** (`NewTabSessionForm`, local to SessionSection): clicking
+  `+` toggles a small form under that host with `name`, `cwd` (default `~`),
+  `mode` (`terminal|stream`) — same fields/labels as the Host page dialog. On
+  submit it calls `createSession(hostId, name.trim(), cwd, mode)`.
+  - **On success** → `onSelect({ kind:'tmux-session', hostId, sessionCode:
+    created.code, mode, cachedName: created.name, tmuxInstance:'' })`, then close
+    the form. This attaches the new session into the current pane (via the
+    wrapper's `setPaneContent` + `setActiveTab`). The `created.code` from the
+    response lets us attach immediately, before the WS session-list sync arrives.
+  - **On failure** → show the error text inline; do not attach; keep the form
+    open. A create in-flight guard (`creating`) disables the submit button.
+  - Empty `name` is a no-op (submit disabled), matching the Host dialog.
+
+### 5.4 Reuse vs. duplication
+
+The Host page's `NewSessionDialog` is not extracted or modified this round
+(keeps blast radius off the Host page's tested behavior). `NewTabSessionForm`
+reuses `createSession()` and the same fields; the two forms are near-duplicates.
+If code review flags the duplication, extracting a shared presentational
+`NewSessionForm` is a follow-up.
+
+## 6. Data flow
+
+```
+SessionRow ─ useSessionAgentIndicator(hostId, code) ─▶ useAgentStore / useUISettingsStore ─▶ <TabIcon>
+  "+"  ─▶ NewTabSessionForm ─ createSession() ─▶ Session ─ onSelect(tmux-session) ─▶ wrapper.setPaneContent(current pane)
+```
+
+## 7. Testing (TDD)
+
+**`useSessionAgentIndicator.test`**
+- No session code → all-empty (undefined status/icon, empty refs, unread false).
+- `agentType` present + not terminated → `agentIcon` from `getAgentIcon`; status
+  / subagents / unread / style passed through.
+- `isTerminated: true` → `agentIcon` undefined even with an agentType.
+
+**`SessionSection.test` (extend existing)**
+- Row renders `<TabIcon>` prefix: no-agent → terminal icon; running agent →
+  status indicator present (assert via TabIcon output / testid).
+- Host header always present (incl. single host) with a `+` button.
+- `+` disabled when host offline.
+- Submitting the form calls `createSession` and, on success, `onSelect` with the
+  correct `tmux-session` content (`created.code` / `created.name` / chosen mode).
+- Create failure surfaces the error and does not call `onSelect`.
+
+**`useTabDisplay.test`** — unchanged, must stay green (equivalence guard).
+
+## 8. Phases
+
+- **Phase 1 (G1)** — `useSessionAgentIndicator` hook + `useTabDisplay` refactor +
+  `SessionRow` with `TabIcon`. Self-contained, visual-only.
+- **Phase 2 (G2)** — always-on host header + `+` + `NewTabSessionForm` + attach.
+
+Both land in one worktree. PR split (one PR / two, or two commits in one PR)
+decided at plan time by review size.
+
+## 9. Risks
+
+- **useTabDisplay refactor** feeds the whole tab bar. Mitigated by pure
+  extraction + the 14 existing tests. If the extraction proves awkward, fall back
+  to a standalone hook with the small agent-layer reads duplicated.
+- **Attach-before-sync**: attaching with `created.code` before the WS list sync
+  is intentional; `SessionPaneContent` connects by code, and the store fills in
+  shortly after. No dependency on the list containing the new session first.
+- **Offline host** during create: `createSession` will fail → inline error; `+`
+  is already disabled when the host is known-offline.

--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -363,6 +363,20 @@ describe('SessionSection', () => {
     expect(mockOnSelect).not.toHaveBeenCalled() // cancelled → no attach
   })
 
+  it('attaches after create under StrictMode (activeRef survives the double-invoke)', async () => {
+    const { StrictMode } = await import('react')
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+    vi.mocked(hostApi.createSession).mockResolvedValue(made())
+    render(<StrictMode><SessionSection onSelect={mockOnSelect} /></StrictMode>)
+    fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+    fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
+    fireEvent.click(screen.getByText('Create'))
+    // StrictMode runs effect setup→cleanup→setup; a still-mounted form must stay
+    // active so the resolved create still attaches.
+    await waitFor(() => expect(mockOnSelect).toHaveBeenCalledWith({ kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'new001', mode: 'terminal', cachedName: 'built', tmuxInstance: '' }))
+  })
+
   it('disables submit and does not POST when the host goes offline after the form opens', () => {
     useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
     useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })

--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -1,6 +1,6 @@
 // spa/src/components/SessionSection.test.tsx
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react'
 import { SessionSection } from './SessionSection'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useHostStore } from '../stores/useHostStore'
@@ -331,5 +331,48 @@ describe('SessionSection', () => {
     resolve(made())
     await waitFor(() => expect(mockOnSelect).toHaveBeenCalled())
     expect(hostApi.createSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('expands a collapsed host when its create button is clicked so the form is visible', () => {
+    useHostStore.setState({
+      hosts: { [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '1', port: 7860, order: 0 }, [HOST_B]: { id: HOST_B, name: 'air', ip: '2', port: 7860, order: 1 } },
+      hostOrder: [HOST_ID, HOST_B], activeHostId: HOST_ID,
+      runtime: { [HOST_ID]: LIVE, [HOST_B]: LIVE },
+    })
+    useSessionStore.setState({ sessions: { [HOST_ID]: [], [HOST_B]: [] } })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    fireEvent.click(screen.getByTestId(`host-header-${HOST_B}`)) // collapse HOST_B
+    expect(screen.getByTestId(`host-header-${HOST_B}`)).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(screen.getByTestId(`new-session-${HOST_B}`)) // + must re-expand and show the form
+    expect(screen.getByPlaceholderText('Session Name')).toBeInTheDocument()
+    expect(screen.getByTestId(`host-header-${HOST_B}`)).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('does not attach when the form is cancelled while a create is in flight', async () => {
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+    let resolve!: (v: ReturnType<typeof made>) => void
+    vi.mocked(hostApi.createSession).mockReturnValue(new Promise((r) => { resolve = r }))
+    render(<SessionSection onSelect={mockOnSelect} />)
+    fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+    fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
+    fireEvent.click(screen.getByText('Create'))
+    fireEvent.click(screen.getByText('Cancel')) // unmounts the form mid-flight
+    await act(async () => { resolve(made()); await Promise.resolve() })
+    await waitFor(() => expect(hostApi.createSession).toHaveBeenCalled())
+    expect(mockOnSelect).not.toHaveBeenCalled() // cancelled → no attach
+  })
+
+  it('disables submit and does not POST when the host goes offline after the form opens', () => {
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+    fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
+    act(() => { useHostStore.setState({ runtime: { [HOST_ID]: { status: 'disconnected' } } }) }) // host drops while form open
+    const createBtn = screen.getByText('Create')
+    expect(createBtn).toBeDisabled()
+    fireEvent.click(createBtn)
+    expect(hostApi.createSession).not.toHaveBeenCalled()
   })
 })

--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -4,6 +4,9 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { SessionSection } from './SessionSection'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useHostStore } from '../stores/useHostStore'
+import { useUISettingsStore } from '../stores/useUISettingsStore'
+import { useAgentStore } from '../stores/useAgentStore'
+import { compositeKey } from '../lib/composite-key'
 
 vi.mock('../hooks/useSessionWatch', () => ({
   useSessionWatch: vi.fn(),
@@ -27,6 +30,8 @@ beforeEach(() => {
     hostOrder: [HOST_ID],
     activeHostId: HOST_ID,
   })
+  useAgentStore.setState({ statuses: {}, agentTypes: {}, subagents: {}, unread: {} })
+  useUISettingsStore.setState({ tabIndicatorStyle: 'badge', ccIconVariant: 'bot', codexIconVariant: 'openai' })
 })
 
 describe('SessionSection', () => {
@@ -214,5 +219,17 @@ describe('SessionSection', () => {
     const sessionButtons = screen.getAllByRole('button').filter((btn) => btn.hasAttribute('data-session-btn'))
     expect(sessionButtons).toHaveLength(1)
     expect(sessionButtons[0]).toHaveTextContent('dev')
+  })
+
+  it('renders the tab-style status indicator for a running-agent session', () => {
+    useUISettingsStore.setState({ tabIndicatorStyle: 'dot' })
+    const ck = compositeKey(HOST_ID, 'abc001')
+    useAgentStore.setState({ statuses: { [ck]: 'running' }, agentTypes: { [ck]: 'cc' }, subagents: {}, unread: {} })
+    useSessionStore.setState({
+      sessions: { [HOST_ID]: [{ code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false }] },
+    })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    // TabStatusIndicator renders a data-testid — assert the running indicator exists.
+    expect(screen.getByTestId('tab-status-indicator')).toBeInTheDocument()
   })
 })

--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -35,9 +35,46 @@ beforeEach(() => {
 })
 
 describe('SessionSection', () => {
-  it('shows no sessions message when empty', () => {
+  it('renders header + create button for a connected host with zero sessions', () => {
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'ok' } } })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    expect(screen.queryByText('No sessions available')).toBeNull()
+    expect(screen.getByTestId(`new-session-${HOST_ID}`)).toBeInTheDocument()
+  })
+
+  it('shows the global empty message only when there are no hosts', () => {
+    useHostStore.setState({ hosts: {}, hostOrder: [], activeHostId: null })
     render(<SessionSection onSelect={mockOnSelect} />)
     expect(screen.getByText('No sessions available')).toBeInTheDocument()
+  })
+
+  it('disables the create button when the host tmux is unavailable', () => {
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'unavailable' } } })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    expect(screen.getByTestId(`new-session-${HOST_ID}`)).toBeDisabled()
+  })
+
+  it('disables the create button when the host has no runtime (offline)', () => {
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: {} }) // runtime undefined → Host-page rule treats as offline
+    render(<SessionSection onSelect={mockOnSelect} />)
+    expect(screen.getByTestId(`new-session-${HOST_ID}`)).toBeDisabled()
+  })
+
+  it('clicking the create button does not toggle collapse', () => {
+    // multi-host so a collapse toggle exists
+    useHostStore.setState({
+      hosts: { [HOST_ID]: { id: HOST_ID, name: 'mlab', ip: '1', port: 7860, order: 0 }, [HOST_B]: { id: HOST_B, name: 'air', ip: '2', port: 7860, order: 1 } },
+      hostOrder: [HOST_ID, HOST_B], activeHostId: HOST_ID,
+      runtime: { [HOST_ID]: { status: 'connected', tmuxState: 'ok' } },
+    })
+    useSessionStore.setState({ sessions: { [HOST_ID]: [{ code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false }] } })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+    expect(screen.getByTestId(`host-header-${HOST_ID}`)).toHaveAttribute('aria-expanded', 'true') // unchanged
+    expect(screen.getByText('dev')).toBeInTheDocument()
   })
 
   it('renders session buttons', () => {
@@ -82,6 +119,7 @@ describe('SessionSection', () => {
     })
     render(<SessionSection onSelect={mockOnSelect} />)
     expect(screen.queryByTestId(`host-header-${HOST_ID}`)).toBeNull()
+    expect(screen.getByTestId(`new-session-${HOST_ID}`)).toBeInTheDocument()
   })
 
   it('shows caret toggle on host header when multiple hosts', () => {

--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -1,12 +1,13 @@
 // spa/src/components/SessionSection.test.tsx
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
 import { SessionSection } from './SessionSection'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useHostStore } from '../stores/useHostStore'
 import { useUISettingsStore } from '../stores/useUISettingsStore'
 import { useAgentStore } from '../stores/useAgentStore'
 import { compositeKey } from '../lib/composite-key'
+import * as hostApi from '../lib/host-api'
 
 vi.mock('../hooks/useSessionWatch', () => ({
   useSessionWatch: vi.fn(),
@@ -14,7 +15,7 @@ vi.mock('../hooks/useSessionWatch', () => ({
 
 vi.mock('../lib/host-api', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
-  return { ...actual, listSessions: vi.fn().mockResolvedValue([]) }
+  return { ...actual, listSessions: vi.fn().mockResolvedValue([]), createSession: vi.fn() }
 })
 
 const HOST_ID = 'test-host'
@@ -32,6 +33,7 @@ beforeEach(() => {
   })
   useAgentStore.setState({ statuses: {}, agentTypes: {}, subagents: {}, unread: {} })
   useUISettingsStore.setState({ tabIndicatorStyle: 'badge', ccIconVariant: 'bot', codexIconVariant: 'openai' })
+  vi.mocked(hostApi.createSession).mockReset()
 })
 
 describe('SessionSection', () => {
@@ -269,5 +271,65 @@ describe('SessionSection', () => {
     render(<SessionSection onSelect={mockOnSelect} />)
     // TabStatusIndicator renders a data-testid — assert the running indicator exists.
     expect(screen.getByTestId('tab-status-indicator')).toBeInTheDocument()
+  })
+
+  const LIVE = { status: 'connected', tmuxState: 'ok' } as const
+  const made = (over: Partial<{ code: string; name: string }> = {}) =>
+    ({ code: 'new001', name: 'built', cwd: '~', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false, ...over })
+
+  it('creates a session and attaches it into the current pane', async () => {
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+    vi.mocked(hostApi.createSession).mockResolvedValue(made())
+    render(<SessionSection onSelect={mockOnSelect} />)
+    fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+    fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
+    fireEvent.click(screen.getByText('Create'))
+    await waitFor(() => expect(hostApi.createSession).toHaveBeenCalledWith(HOST_ID, 'built', '~', 'terminal'))
+    await waitFor(() => expect(mockOnSelect).toHaveBeenCalledWith({ kind: 'tmux-session', hostId: HOST_ID, sessionCode: 'new001', mode: 'terminal', cachedName: 'built', tmuxInstance: '' }))
+  })
+
+  it('does not attach when the created session has a blank code', async () => {
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+    vi.mocked(hostApi.createSession).mockResolvedValue(made({ code: '' }))
+    render(<SessionSection onSelect={mockOnSelect} />)
+    fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+    fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
+    fireEvent.click(screen.getByText('Create'))
+    await screen.findByText('Create failed') // inline error, form stays open
+    expect(screen.getByPlaceholderText('Session Name')).toBeInTheDocument()
+    expect(mockOnSelect).not.toHaveBeenCalled()
+  })
+
+  it('does not attach when the host is removed while creating', async () => {
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+    vi.mocked(hostApi.createSession).mockImplementation(async () => {
+      useHostStore.setState({ hosts: {}, hostOrder: [], activeHostId: null, runtime: {} }) // host vanishes mid-flight
+      return made()
+    })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+    fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
+    fireEvent.click(screen.getByText('Create'))
+    await waitFor(() => expect(hostApi.createSession).toHaveBeenCalled())
+    await waitFor(() => expect(mockOnSelect).not.toHaveBeenCalled())
+  })
+
+  it('submits create only once on a double click', async () => {
+    useSessionStore.setState({ sessions: { [HOST_ID]: [] } })
+    useHostStore.setState({ runtime: { [HOST_ID]: LIVE } })
+    let resolve!: (v: ReturnType<typeof made>) => void
+    vi.mocked(hostApi.createSession).mockReturnValue(new Promise((r) => { resolve = r }))
+    render(<SessionSection onSelect={mockOnSelect} />)
+    fireEvent.click(screen.getByTestId(`new-session-${HOST_ID}`))
+    fireEvent.change(screen.getByPlaceholderText('Session Name'), { target: { value: 'built' } })
+    const createBtn = screen.getByText('Create')
+    fireEvent.click(createBtn)
+    fireEvent.click(createBtn) // second click while in-flight must be a no-op
+    resolve(made())
+    await waitFor(() => expect(mockOnSelect).toHaveBeenCalled())
+    expect(hostApi.createSession).toHaveBeenCalledTimes(1)
   })
 })

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -7,7 +7,7 @@ import { useSessionAgentIndicator } from '../hooks/useSessionAgentIndicator'
 import { TabIcon } from './TabIcon'
 import type { NewTabProviderProps } from '../lib/new-tab-registry'
 import type { Session } from '../lib/host-api'
-import { TerminalWindow, Circle, Spinner, CaretDown, CaretRight } from '@phosphor-icons/react'
+import { TerminalWindow, Circle, Spinner, CaretDown, CaretRight, Plus } from '@phosphor-icons/react'
 
 function SessionRow({ hostId, session, disabled, onSelect }: {
   hostId: string
@@ -64,10 +64,9 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
   const runtime = useHostStore((s) => s.runtime)
   const t = useI18nStore((s) => s.t)
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const [creatingHost, setCreatingHost] = useState<string | null>(null)
 
-  const hasAnySessions = hostOrder.some((hid) => (sessionsMap[hid] ?? []).length > 0)
-
-  if (!hasAnySessions) {
+  if (hostOrder.length === 0) {
     return <p className="text-sm text-text-muted px-2">{t('session.no_sessions')}</p>
   }
 
@@ -80,33 +79,54 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
         const hostRuntime = runtime[hostId]
         const isOffline = hostRuntime && hostRuntime.status !== 'connected'
         const isExpanded = expanded[hostId] !== false
+        const createDisabled = !hostRuntime || hostRuntime.status !== 'connected' || hostRuntime.tmuxState === 'unavailable'
+
+        const statusDot = hostRuntime?.status === 'reconnecting' ? (
+          <Spinner size={8} className="text-yellow-400 animate-spin" />
+        ) : hostRuntime?.status === 'connected' ? (
+          <Circle size={8} weight="fill" className="text-green-400" />
+        ) : hostRuntime ? (
+          <Circle size={8} weight="fill" className="text-red-400" />
+        ) : (
+          <Circle size={8} weight="fill" className="text-text-muted" />
+        )
 
         return (
           <div key={hostId}>
-            {/* Host header — only show when multiple hosts */}
-            {hostOrder.length > 1 && (
+            <div className="flex items-center gap-1.5 px-3 py-1 mt-1 w-full">
+              {hostOrder.length > 1 ? (
+                <button
+                  data-testid={`host-header-${hostId}`}
+                  aria-expanded={isExpanded}
+                  onClick={() => setExpanded((prev) => ({ ...prev, [hostId]: !isExpanded }))}
+                  className="flex items-center gap-1.5 flex-1 min-w-0 cursor-pointer"
+                >
+                  {isExpanded ? <CaretDown size={10} className="text-text-muted" /> : <CaretRight size={10} className="text-text-muted" />}
+                  {statusDot}
+                  <span className="text-xs text-text-muted font-semibold">{host.name}</span>
+                  {isOffline && (
+                    <span className="text-xs text-text-muted ml-auto">{t('session.reconnecting')}</span>
+                  )}
+                </button>
+              ) : (
+                <span className="flex items-center gap-1.5 flex-1 min-w-0">
+                  {statusDot}
+                  <span className="text-xs text-text-muted font-semibold">{host.name}</span>
+                  {isOffline && (
+                    <span className="text-xs text-text-muted ml-auto">{t('session.reconnecting')}</span>
+                  )}
+                </span>
+              )}
               <button
-                data-testid={`host-header-${hostId}`}
-                aria-expanded={isExpanded}
-                onClick={() => setExpanded((prev) => ({ ...prev, [hostId]: !isExpanded }))}
-                className="flex items-center gap-1.5 px-3 py-1 mt-1 w-full cursor-pointer"
+                data-testid={`new-session-${hostId}`}
+                disabled={createDisabled}
+                onClick={() => setCreatingHost((h) => (h === hostId ? null : hostId))}
+                className="ml-auto p-1 rounded hover:bg-white/10 text-text-muted hover:text-text-primary cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                title={t('hosts.new_session')}
               >
-                {isExpanded ? <CaretDown size={10} className="text-text-muted" /> : <CaretRight size={10} className="text-text-muted" />}
-                {hostRuntime?.status === 'reconnecting' ? (
-                  <Spinner size={8} className="text-yellow-400 animate-spin" />
-                ) : hostRuntime?.status === 'connected' ? (
-                  <Circle size={8} weight="fill" className="text-green-400" />
-                ) : hostRuntime ? (
-                  <Circle size={8} weight="fill" className="text-red-400" />
-                ) : (
-                  <Circle size={8} weight="fill" className="text-text-muted" />
-                )}
-                <span className="text-xs text-text-muted font-semibold">{host.name}</span>
-                {isOffline && (
-                  <span className="text-xs text-text-muted ml-auto">{t('session.reconnecting')}</span>
-                )}
+                <Plus size={14} />
               </button>
-            )}
+            </div>
             {isExpanded && sessions.map((session) => (
               <SessionRow
                 key={`${hostId}:${session.code}`}

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -3,8 +3,58 @@ import { useSessionStore } from '../stores/useSessionStore'
 import { useHostStore } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { useSessionWatch } from '../hooks/useSessionWatch'
+import { useSessionAgentIndicator } from '../hooks/useSessionAgentIndicator'
+import { TabIcon } from './TabIcon'
 import type { NewTabProviderProps } from '../lib/new-tab-registry'
+import type { Session } from '../lib/host-api'
 import { TerminalWindow, Circle, Spinner, CaretDown, CaretRight } from '@phosphor-icons/react'
+
+function SessionRow({ hostId, session, disabled, onSelect }: {
+  hostId: string
+  session: Session
+  disabled: boolean
+  onSelect: NewTabProviderProps['onSelect']
+}) {
+  const { agentIcon, agentStatus, subagentRefs, isUnread, tabIndicatorStyle } =
+    useSessionAgentIndicator(hostId, session.code)
+  const IconComponent = agentIcon ?? TerminalWindow
+  return (
+    <button
+      data-session-btn
+      className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-white/10 text-left text-sm text-text-primary cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-1 focus:ring-accent-muted"
+      disabled={disabled}
+      tabIndex={0}
+      onClick={() =>
+        onSelect({ kind: 'tmux-session', hostId, sessionCode: session.code, mode: 'terminal', cachedName: session.name, tmuxInstance: '' })
+      }
+      onKeyDown={(e) => {
+        const container = e.currentTarget.closest('[data-session-list]')
+        if (!container) return
+        const buttons = Array.from(container.querySelectorAll('button[data-session-btn]:not(:disabled)')) as HTMLElement[]
+        const currentIndex = buttons.indexOf(e.currentTarget)
+        if (currentIndex === -1) return
+        switch (e.key) {
+          case 'ArrowDown':
+          case 'j':
+            e.preventDefault()
+            buttons[Math.min(currentIndex + 1, buttons.length - 1)]?.focus()
+            break
+          case 'ArrowUp':
+          case 'k':
+            e.preventDefault()
+            buttons[Math.max(currentIndex - 1, 0)]?.focus()
+            break
+        }
+      }}
+    >
+      <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
+        <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={false} iconSize={14} subagentRefs={subagentRefs} isUnread={isUnread} />
+      </span>
+      <span className="truncate">{session.name}</span>
+      <span className="text-xs text-text-secondary ml-auto">{session.code}</span>
+    </button>
+  )
+}
 
 export function SessionSection({ onSelect }: NewTabProviderProps) {
   useSessionWatch()
@@ -58,39 +108,13 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
               </button>
             )}
             {isExpanded && sessions.map((session) => (
-              <button
+              <SessionRow
                 key={`${hostId}:${session.code}`}
-                data-session-btn
-                className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-white/10 text-left text-sm text-text-primary cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-1 focus:ring-accent-muted"
+                hostId={hostId}
+                session={session}
                 disabled={!!isOffline}
-                tabIndex={0}
-                onClick={() =>
-                  onSelect({ kind: 'tmux-session', hostId, sessionCode: session.code, mode: 'terminal', cachedName: session.name, tmuxInstance: '' })
-                }
-                onKeyDown={(e) => {
-                  const container = e.currentTarget.closest('[data-session-list]')
-                  if (!container) return
-                  const buttons = Array.from(container.querySelectorAll('button[data-session-btn]:not(:disabled)')) as HTMLElement[]
-                  const currentIndex = buttons.indexOf(e.currentTarget)
-                  if (currentIndex === -1) return
-                  switch (e.key) {
-                    case 'ArrowDown':
-                    case 'j':
-                      e.preventDefault()
-                      buttons[Math.min(currentIndex + 1, buttons.length - 1)]?.focus()
-                      break
-                    case 'ArrowUp':
-                    case 'k':
-                      e.preventDefault()
-                      buttons[Math.max(currentIndex - 1, 0)]?.focus()
-                      break
-                  }
-                }}
-              >
-                <TerminalWindow size={16} className="text-text-secondary flex-shrink-0" />
-                <span className="truncate">{session.name}</span>
-                <span className="text-xs text-text-secondary ml-auto">{session.code}</span>
-              </button>
+                onSelect={onSelect}
+              />
             ))}
           </div>
         )

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -82,7 +82,14 @@ function NewTabSessionForm({ hostId, disabled, onCreated, onCancel }: {
   // collapse, host removed, tab switch) so a resolved/rejected request can't
   // setState on a dead component or attach a session the user already dismissed.
   const activeRef = useRef(true)
-  useEffect(() => () => { activeRef.current = false }, [])
+  // Set true on every setup (not just via the ref initialiser) so React 19
+  // StrictMode's dev setup→cleanup→setup double-invoke leaves a still-mounted
+  // form active — otherwise the first cleanup pins it false and no create ever
+  // attaches. Real unmount runs the cleanup last, leaving it false.
+  useEffect(() => {
+    activeRef.current = true
+    return () => { activeRef.current = false }
+  }, [])
 
   const disabledSubmit = creating || !name.trim() || disabled
 

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useHostStore } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
@@ -57,8 +57,17 @@ function SessionRow({ hostId, session, disabled, onSelect }: {
   )
 }
 
-function NewTabSessionForm({ hostId, onCreated, onCancel }: {
+/** Host-page offline semantics: the host still exists and its tmux is usable.
+ *  Read from the live store snapshot so it reflects state at call time. */
+function isHostLive(hostId: string): boolean {
+  const s = useHostStore.getState()
+  const rt = s.runtime[hostId]
+  return !!s.hosts[hostId] && !!rt && rt.status === 'connected' && rt.tmuxState !== 'unavailable'
+}
+
+function NewTabSessionForm({ hostId, disabled, onCreated, onCancel }: {
   hostId: string
+  disabled: boolean
   onCreated: (content: { code: string; name: string; mode: string }) => void
   onCancel: () => void
 }) {
@@ -69,27 +78,33 @@ function NewTabSessionForm({ hostId, onCreated, onCancel }: {
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState('')
   const creatingRef = useRef(false) // synchronous double-submit guard (fires before `creating` state commits)
+  // Liveness guard for the async create: flipped false on unmount (cancel,
+  // collapse, host removed, tab switch) so a resolved/rejected request can't
+  // setState on a dead component or attach a session the user already dismissed.
+  const activeRef = useRef(true)
+  useEffect(() => () => { activeRef.current = false }, [])
 
-  const disabledSubmit = creating || !name.trim()
+  const disabledSubmit = creating || !name.trim() || disabled
 
   const handleCreate = async () => {
-    if (creatingRef.current || !name.trim()) return
+    // Re-check host liveness synchronously at submit time (runtime may have gone
+    // offline since the form opened) — do not fire the POST for a dead host.
+    if (creatingRef.current || !name.trim() || disabled || !isHostLive(hostId)) return
     creatingRef.current = true
     setCreating(true); setError('')
     try {
       const created = await createSession(hostId, name.trim(), cwd, mode)
+      if (!activeRef.current) return // form was cancelled/unmounted during the request
       // Guard 1 — blank code = failed create.
       if (!created.code) { setError(t('hosts.create') + ' failed'); return }
       // Guard 2 — host still live (removed/disconnected during the await must not attach).
-      const rt = useHostStore.getState().runtime[hostId]
-      const live = !!useHostStore.getState().hosts[hostId] && !!rt && rt.status === 'connected' && rt.tmuxState !== 'unavailable'
-      if (!live) { setError(t('hosts.create') + ' failed'); return }
+      if (!isHostLive(hostId)) { setError(t('hosts.create') + ' failed'); return }
       onCreated({ code: created.code, name: created.name, mode })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed')
+      if (activeRef.current) setError(err instanceof Error ? err.message : 'Failed')
     } finally {
       creatingRef.current = false
-      setCreating(false)
+      if (activeRef.current) setCreating(false)
     }
   }
 
@@ -182,7 +197,13 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
               <button
                 data-testid={`new-session-${hostId}`}
                 disabled={createDisabled}
-                onClick={() => setCreatingHost((h) => (h === hostId ? null : hostId))}
+                onClick={() => {
+                  const opening = creatingHost !== hostId
+                  setCreatingHost(opening ? hostId : null)
+                  // Opening on a collapsed host must reveal the form (which is
+                  // gated behind isExpanded) — expand so the "+" isn't a no-op.
+                  if (opening) setExpanded((prev) => ({ ...prev, [hostId]: true }))
+                }}
                 className="ml-auto p-1 rounded hover:bg-white/10 text-text-muted hover:text-text-primary cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                 title={t('hosts.new_session')}
               >
@@ -192,6 +213,7 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
             {isExpanded && creatingHost === hostId && (
               <NewTabSessionForm
                 hostId={hostId}
+                disabled={createDisabled}
                 onCancel={() => setCreatingHost(null)}
                 onCreated={({ code, name, mode }) => {
                   setCreatingHost(null)

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useSessionStore } from '../stores/useSessionStore'
 import { useHostStore } from '../stores/useHostStore'
 import { useI18nStore } from '../stores/useI18nStore'
@@ -6,6 +6,7 @@ import { useSessionWatch } from '../hooks/useSessionWatch'
 import { useSessionAgentIndicator } from '../hooks/useSessionAgentIndicator'
 import { TabIcon } from './TabIcon'
 import type { NewTabProviderProps } from '../lib/new-tab-registry'
+import { createSession } from '../lib/host-api'
 import type { Session } from '../lib/host-api'
 import { TerminalWindow, Circle, Spinner, CaretDown, CaretRight, Plus } from '@phosphor-icons/react'
 
@@ -53,6 +54,67 @@ function SessionRow({ hostId, session, disabled, onSelect }: {
       <span className="truncate">{session.name}</span>
       <span className="text-xs text-text-secondary ml-auto">{session.code}</span>
     </button>
+  )
+}
+
+function NewTabSessionForm({ hostId, onCreated, onCancel }: {
+  hostId: string
+  onCreated: (content: { code: string; name: string; mode: string }) => void
+  onCancel: () => void
+}) {
+  const t = useI18nStore((s) => s.t)
+  const [name, setName] = useState('')
+  const [cwd, setCwd] = useState('~')
+  const [mode, setMode] = useState('terminal')
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState('')
+  const creatingRef = useRef(false) // synchronous double-submit guard (fires before `creating` state commits)
+
+  const disabledSubmit = creating || !name.trim()
+
+  const handleCreate = async () => {
+    if (creatingRef.current || !name.trim()) return
+    creatingRef.current = true
+    setCreating(true); setError('')
+    try {
+      const created = await createSession(hostId, name.trim(), cwd, mode)
+      // Guard 1 — blank code = failed create.
+      if (!created.code) { setError(t('hosts.create') + ' failed'); return }
+      // Guard 2 — host still live (removed/disconnected during the await must not attach).
+      const rt = useHostStore.getState().runtime[hostId]
+      const live = !!useHostStore.getState().hosts[hostId] && !!rt && rt.status === 'connected' && rt.tmuxState !== 'unavailable'
+      if (!live) { setError(t('hosts.create') + ' failed'); return }
+      onCreated({ code: created.code, name: created.name, mode })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed')
+    } finally {
+      creatingRef.current = false
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="mx-3 my-1 p-2 bg-surface-secondary border border-border-default rounded-md">
+      <input placeholder={t('hosts.session_name')} value={name} autoFocus
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') handleCreate() }}
+        className="w-full bg-surface-primary border border-border-default rounded px-2 py-1 text-sm text-text-primary mb-1" />
+      <input placeholder={t('hosts.session_cwd')} value={cwd}
+        onChange={(e) => setCwd(e.target.value)}
+        className="w-full bg-surface-primary border border-border-default rounded px-2 py-1 text-sm text-text-muted mb-1" />
+      <select value={mode} onChange={(e) => setMode(e.target.value)}
+        className="bg-surface-primary border border-border-default rounded px-2 py-1 text-sm text-text-primary">
+        <option value="terminal">terminal</option>
+        <option value="stream">stream</option>
+      </select>
+      {error && <p className="text-xs text-red-400 mt-1">{error}</p>}
+      <div className="flex gap-2 mt-2">
+        <button onClick={handleCreate} disabled={disabledSubmit}
+          className="px-2 py-1 rounded text-xs bg-accent text-white cursor-pointer disabled:opacity-50">{t('hosts.create')}</button>
+        <button onClick={onCancel}
+          className="px-2 py-1 rounded text-xs bg-surface-tertiary text-text-secondary cursor-pointer">{t('common.cancel')}</button>
+      </div>
+    </div>
   )
 }
 
@@ -127,6 +189,16 @@ export function SessionSection({ onSelect }: NewTabProviderProps) {
                 <Plus size={14} />
               </button>
             </div>
+            {isExpanded && creatingHost === hostId && (
+              <NewTabSessionForm
+                hostId={hostId}
+                onCancel={() => setCreatingHost(null)}
+                onCreated={({ code, name, mode }) => {
+                  setCreatingHost(null)
+                  onSelect({ kind: 'tmux-session', hostId, sessionCode: code, mode: mode as 'terminal' | 'stream', cachedName: name, tmuxInstance: '' })
+                }}
+              />
+            )}
             {isExpanded && sessions.map((session) => (
               <SessionRow
                 key={`${hostId}:${session.code}`}

--- a/spa/src/hooks/useSessionAgentIndicator.test.ts
+++ b/spa/src/hooks/useSessionAgentIndicator.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useSessionAgentIndicator } from './useSessionAgentIndicator'
+import { useAgentStore } from '../stores/useAgentStore'
+import { useUISettingsStore } from '../stores/useUISettingsStore'
+import { compositeKey } from '../lib/composite-key'
+import type { SubagentRef } from '../stores/useAgentStore'
+
+const ref: SubagentRef = { id: 'a', type: 'cc', started_at: 0, source_pid: 0, source_start_time: '' }
+
+beforeEach(() => {
+  useAgentStore.setState({ statuses: {}, agentTypes: {}, subagents: {}, unread: {} })
+  useUISettingsStore.setState({ tabIndicatorStyle: 'iconDot', ccIconVariant: 'bot', codexIconVariant: 'openai' })
+})
+
+describe('useSessionAgentIndicator', () => {
+  it('returns empty indicator when sessionCode is undefined', () => {
+    const { result } = renderHook(() => useSessionAgentIndicator('h1', undefined))
+    expect(result.current.agentIcon).toBeUndefined()
+    expect(result.current.agentStatus).toBeUndefined()
+    expect(result.current.subagentRefs).toEqual([])
+    expect(result.current.isUnread).toBe(false)
+    expect(result.current.tabIndicatorStyle).toBe('iconDot')
+  })
+
+  it('resolves agent icon + status + refs + unread for a live session', () => {
+    const ck = compositeKey('h1', 's1')
+    useAgentStore.setState({
+      statuses: { [ck]: 'running' },
+      agentTypes: { [ck]: 'cc' }, // getAgentIcon only knows 'cc' | 'codex' | 'opencode'
+      subagents: { [ck]: [ref] },
+      unread: { [ck]: true },
+    })
+    const { result } = renderHook(() => useSessionAgentIndicator('h1', 's1'))
+    expect(result.current.agentStatus).toBe('running')
+    expect(result.current.agentIcon).toBeTypeOf('function') // getAgentIcon('cc', { ccVariant:'bot', ... }) resolved a component
+    expect(result.current.subagentRefs).toHaveLength(1)
+    expect(result.current.isUnread).toBe(true)
+  })
+
+  it('suppresses the agent icon when terminated', () => {
+    const ck = compositeKey('h1', 's1')
+    useAgentStore.setState({ agentTypes: { [ck]: 'cc' } })
+    const { result } = renderHook(() => useSessionAgentIndicator('h1', 's1', { isTerminated: true }))
+    expect(result.current.agentIcon).toBeUndefined()
+  })
+})

--- a/spa/src/hooks/useSessionAgentIndicator.ts
+++ b/spa/src/hooks/useSessionAgentIndicator.ts
@@ -1,0 +1,47 @@
+import type { ComponentType } from 'react'
+import type { AgentStatus, SubagentRef } from '../stores/useAgentStore'
+import type { TabIndicatorStyle } from '../stores/useUISettingsStore'
+import { useAgentStore } from '../stores/useAgentStore'
+import { useUISettingsStore } from '../stores/useUISettingsStore'
+import { compositeKey } from '../lib/composite-key'
+import { getAgentIcon } from '../lib/agent-icons'
+
+export type TabIconComponent = ComponentType<{ size: number; className?: string }>
+
+const EMPTY_SUBAGENT_REFS: SubagentRef[] = []
+
+export interface SessionAgentIndicator {
+  agentIcon: TabIconComponent | undefined
+  agentStatus: AgentStatus | undefined
+  subagentRefs: SubagentRef[]
+  isUnread: boolean
+  tabIndicatorStyle: TabIndicatorStyle
+}
+
+/**
+ * Resolves the agent-layer indicator (icon/status/subagents/unread + the user's
+ * tabIndicatorStyle) for a single (hostId, sessionCode). Shared by useTabDisplay
+ * (tab bar) and the New-Tab Sessions list so both render an identical prefix.
+ */
+export function useSessionAgentIndicator(
+  hostId: string,
+  sessionCode: string | undefined,
+  opts?: { isTerminated?: boolean },
+): SessionAgentIndicator {
+  const isTerminated = opts?.isTerminated ?? false
+  const ck = sessionCode && hostId ? compositeKey(hostId, sessionCode) : undefined
+
+  const agentStatus = useAgentStore((s) => (ck ? s.statuses[ck] : undefined))
+  const isUnread = useAgentStore((s) => (ck ? !!s.unread[ck] : false))
+  const subagentRefs = useAgentStore((s) => (ck ? (s.subagents[ck] ?? EMPTY_SUBAGENT_REFS) : EMPTY_SUBAGENT_REFS))
+  const agentType = useAgentStore((s) => (ck ? s.agentTypes[ck] : undefined))
+  const tabIndicatorStyle = useUISettingsStore((s) => s.tabIndicatorStyle)
+  const ccIconVariant = useUISettingsStore((s) => s.ccIconVariant)
+  const codexIconVariant = useUISettingsStore((s) => s.codexIconVariant)
+
+  const agentIcon = !isTerminated && agentType
+    ? (getAgentIcon(agentType, { ccVariant: ccIconVariant, codexVariant: codexIconVariant }) as TabIconComponent | undefined)
+    : undefined
+
+  return { agentIcon, agentStatus, subagentRefs, isUnread, tabIndicatorStyle }
+}

--- a/spa/src/hooks/useTabDisplay.test.ts
+++ b/spa/src/hooks/useTabDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { renderHook, act } from '@testing-library/react'
 import { useAgentStore } from '../stores/useAgentStore'
 import type { SubagentRef } from '../stores/useAgentStore'
 import { useUISettingsStore } from '../stores/useUISettingsStore'
@@ -9,6 +9,7 @@ import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { useI18nStore } from '../stores/useI18nStore'
 import { createTab } from '../types/tab'
 import type { Tab } from '../types/tab'
+import { compositeKey } from '../lib/composite-key'
 import { useTabDisplay } from './useTabDisplay'
 
 function makeTab(
@@ -152,6 +153,21 @@ describe('useTabDisplay — icon resolution', () => {
     const { result } = renderHook(() => useTabDisplay(makeTab({ terminated: true })))
     expect(result.current.IconComponent).toBeDefined()
     expect(result.current.isTerminated).toBe(true)
+  })
+
+  it('re-resolves the cc agent icon when the cc icon variant changes', () => {
+    const tab = makeTab()
+    const ck = compositeKey('h1', 'sc1')
+    useAgentStore.setState({ agentTypes: { [ck]: 'cc' } })
+    useUISettingsStore.setState({ tabIndicatorStyle: 'iconDot', ccIconVariant: 'bot', codexIconVariant: 'openai' })
+
+    const { result, rerender } = renderHook(() => useTabDisplay(tab))
+    const first = result.current.IconComponent
+    act(() => {
+      useUISettingsStore.setState({ ccIconVariant: 'star' }) // valid CcIconVariant
+    })
+    rerender()
+    expect(result.current.IconComponent).not.toBe(first) // variant flows through the extracted hook
   })
 })
 

--- a/spa/src/hooks/useTabDisplay.ts
+++ b/spa/src/hooks/useTabDisplay.ts
@@ -1,4 +1,3 @@
-import type { ComponentType } from 'react'
 import type { Tab } from '../types/tab'
 import type { AgentStatus, SubagentRef } from '../stores/useAgentStore'
 import type { TabIndicatorStyle } from '../stores/useUISettingsStore'
@@ -11,14 +10,14 @@ import { useI18nStore } from '../stores/useI18nStore'
 import { getPrimaryPane } from '../lib/pane-tree'
 import { getPaneIcon, getPaneLabel } from '../lib/pane-labels'
 import { compositeKey } from '../lib/composite-key'
-import { getAgentIcon } from '../lib/agent-icons'
 import { ICON_MAP } from '../components/tab-icon-map'
 import type { Session } from '../lib/host-api'
+import { useSessionAgentIndicator } from './useSessionAgentIndicator'
+import type { TabIconComponent } from './useSessionAgentIndicator'
 
 const EMPTY_SESSIONS: Session[] = []
-const EMPTY_SUBAGENT_REFS: SubagentRef[] = []
 
-export type TabIconComponent = ComponentType<{ size: number; className?: string }>
+export type { TabIconComponent }
 
 export interface TabDisplayData {
   displayTitle: string
@@ -49,14 +48,10 @@ export function useTabDisplay(tab: Tab): TabDisplayData {
   const sessions = useSessionStore((s) => (hostId ? s.sessions[hostId] : undefined) ?? EMPTY_SESSIONS)
   const workspaces = useWorkspaceStore((s) => s.workspaces)
 
-  const agentStatus = useAgentStore((s) => (ck ? s.statuses[ck] : undefined))
-  const isUnread = useAgentStore((s) => (ck ? !!s.unread[ck] : false))
-  const subagentRefs = useAgentStore((s) => (ck ? (s.subagents[ck] ?? EMPTY_SUBAGENT_REFS) : EMPTY_SUBAGENT_REFS))
+  const { agentIcon, agentStatus, subagentRefs, isUnread, tabIndicatorStyle } =
+    useSessionAgentIndicator(hostId, sessionCode, { isTerminated })
   const subagentCount = subagentRefs.length
   const agentType = useAgentStore((s) => (ck ? s.agentTypes[ck] : undefined))
-  const tabIndicatorStyle = useUISettingsStore((s) => s.tabIndicatorStyle)
-  const ccIconVariant = useUISettingsStore((s) => s.ccIconVariant)
-  const codexIconVariant = useUISettingsStore((s) => s.codexIconVariant)
   const dynamicTabName = useUISettingsStore((s) => s.dynamicTabName)
 
   const isHostOffline = useHostStore((s) => {
@@ -67,7 +62,6 @@ export function useTabDisplay(tab: Tab): TabDisplayData {
 
   const iconName = getPaneIcon(primaryContent)
   const paneIcon = ICON_MAP[iconName]
-  const agentIcon = !isTerminated && agentType ? getAgentIcon(agentType, { ccVariant: ccIconVariant, codexVariant: codexIconVariant }) : undefined
   const IconComponent = (agentIcon ?? paneIcon) as TabIconComponent | undefined
 
   const sessionLookup = { getByCode: (code: string) => sessions.find((sess) => sess.code === code) }


### PR DESCRIPTION
## 需求（使用者提出）

1. New-Tab 的 **Sessions 列表**每列，加上與 **tab 相同的 agent icon/status prefix**。
2. Sessions 列表**依 host 新增 session**，並在建立成功後**直接 attach 到當前 pane**（全頁 new-tab 或分割格 new-tab）。

## 做法

**① 共用 indicator（單一真相來源）**
- 新增 `hooks/useSessionAgentIndicator.ts`：把原內聯在 `useTabDisplay` 的 agent 層解析（`compositeKey`→`useAgentStore` statuses/agentTypes/subagents/unread + `getAgentIcon` + `tabIndicatorStyle`）抽為共用 hook；`TabIconComponent` type 移入此檔避免循環依賴。
- `useTabDisplay` 重構為消費此 hook（保留其 paneIcon fallback 與 label/title 邏輯，行為等價，14 既有測試全綠）。
- `SessionSection` 每列抽 `SessionRow`，以 `<TabIcon>` 取代固定 `<TerminalWindow>`（無 agent 時 fallback 回 terminal 圖示）。

**② 依 host 新增 session + attach**
- Host header 一律渲染（含單 host、含零 session 的 host）；header 改為 `<div>`，collapse 控制（多 host）與 `+` 新增鈕為**獨立 sibling button**（無 nested button、`+` 不觸發 collapse）。全域「No sessions」只在無任何 host 時顯示。
- `+` 用 host 頁 offline 語意 disable（`!runtime || status!=='connected' || tmuxState==='unavailable'`）。
- `NewTabSessionForm`（name/cwd/mode，沿用 `createSession()`）建立成功後兩道 guard（blank code、host-live re-check）+ `creatingRef` 雙擊防護，通過即 `onSelect` attach 進當前 pane。

## 流程

- spec + plan 各經 **codex 跨模型審一輪**並據以強化（spec：零 session header/nested-button/offline·race·blank-code guard/type cycle；plan：真實 enum/i18n/runtime fixture、waitFor async、double-submit guard）。
- **subagent-driven TDD**（Phase 1 Tasks 1-3 / Phase 2 Tasks 4-5），每 task 獨立 commit。
- 驗證：`vitest 3923 綠 / lint / build` 全過。

## 已知取捨

- Plan 內部矛盾（零 session host 的 per-host 空行 vs 測試斷言「No sessions available」不出現）→ 採測試為準，零 session host 只顯示 header + `+`（`+` 已自解釋）。
- 不改 Host 頁與 `createSession()`；new-tab 端自建精簡表單（與 host 頁近似，如需抽共用為 follow-up）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)