### PR TITLE
feat(new-tab): show session pane title after the code in Sessions list

### DIFF
--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -91,6 +91,35 @@ describe('SessionSection', () => {
     expect(screen.getByText('dev')).toBeInTheDocument()
   })
 
+  it('shows the session pane title after the code', () => {
+    useSessionStore.setState({
+      sessions: {
+        [HOST_ID]: [
+          { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false, pane_title: 'Reading memory' },
+        ],
+      },
+    })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    const row = screen.getByText('dev').closest('button') as HTMLElement
+    expect(row).toHaveTextContent('Reading memory')
+    // title trails the code within the row
+    expect(row.textContent!.indexOf('abc001')).toBeLessThan(row.textContent!.indexOf('Reading memory'))
+  })
+
+  it('omits the title span when the session has no pane title', () => {
+    useSessionStore.setState({
+      sessions: {
+        [HOST_ID]: [
+          { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+        ],
+      },
+    })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    const row = screen.getByText('dev').closest('button') as HTMLElement
+    expect(row).toHaveTextContent('dev')
+    expect(row).toHaveTextContent('abc001')
+  })
+
   it('calls onSelect when session is clicked', () => {
     useSessionStore.setState({
       sessions: {

--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -106,17 +106,31 @@ describe('SessionSection', () => {
     expect(row.textContent!.indexOf('abc001')).toBeLessThan(row.textContent!.indexOf('Reading memory'))
   })
 
-  it('keeps the session name truncatable so a long name cannot overflow the row', () => {
+  it('caps the name at half-width only when a pane title shares the row', () => {
+    const LONG = 'a-very-long-session-name-that-would-overflow'
+    // With a title: name is truncatable AND capped so the title keeps room.
     useSessionStore.setState({
-      sessions: {
-        [HOST_ID]: [
-          { code: 'abc001', name: 'a-very-long-session-name-that-would-overflow', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false, pane_title: 'Reading memory' },
-        ],
-      },
+      sessions: { [HOST_ID]: [
+        { code: 'abc001', name: LONG, cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false, pane_title: 'Reading memory' },
+      ] },
+    })
+    const withTitle = render(<SessionSection onSelect={mockOnSelect} />)
+    const capped = screen.getByText(LONG)
+    expect(capped.className).toContain('truncate')
+    expect(capped.className).toContain('max-w-[50%]')
+    withTitle.unmount()
+
+    // Without a title: name is still truncatable but NOT capped — it may use the
+    // full remaining width instead of being stranded at half a row.
+    useSessionStore.setState({
+      sessions: { [HOST_ID]: [
+        { code: 'abc001', name: LONG, cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false },
+      ] },
     })
     render(<SessionSection onSelect={mockOnSelect} />)
-    const nameSpan = screen.getByText('a-very-long-session-name-that-would-overflow')
-    expect(nameSpan.className).toContain('truncate') // overflow-hidden lets flex shrink+ellipsis it
+    const uncapped = screen.getByText(LONG)
+    expect(uncapped.className).toContain('truncate')
+    expect(uncapped.className).not.toContain('max-w-[50%]')
   })
 
   it('omits the title span when the session has no pane title', () => {

--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -106,6 +106,19 @@ describe('SessionSection', () => {
     expect(row.textContent!.indexOf('abc001')).toBeLessThan(row.textContent!.indexOf('Reading memory'))
   })
 
+  it('keeps the session name truncatable so a long name cannot overflow the row', () => {
+    useSessionStore.setState({
+      sessions: {
+        [HOST_ID]: [
+          { code: 'abc001', name: 'a-very-long-session-name-that-would-overflow', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false, pane_title: 'Reading memory' },
+        ],
+      },
+    })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    const nameSpan = screen.getByText('a-very-long-session-name-that-would-overflow')
+    expect(nameSpan.className).toContain('truncate') // overflow-hidden lets flex shrink+ellipsis it
+  })
+
   it('omits the title span when the session has no pane title', () => {
     useSessionStore.setState({
       sessions: {

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -51,8 +51,11 @@ function SessionRow({ hostId, session, disabled, onSelect }: {
       <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
         <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={false} iconSize={14} subagentRefs={subagentRefs} isUnread={isUnread} />
       </span>
-      <span className="truncate">{session.name}</span>
-      <span className="text-xs text-text-secondary ml-auto">{session.code}</span>
+      <span className="flex-shrink-0">{session.name}</span>
+      <span className="text-xs text-text-secondary flex-shrink-0">{session.code}</span>
+      {session.pane_title && (
+        <span className="text-xs text-text-muted truncate min-w-0">{session.pane_title}</span>
+      )}
     </button>
   )
 }

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -51,7 +51,7 @@ function SessionRow({ hostId, session, disabled, onSelect }: {
       <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
         <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={false} iconSize={14} subagentRefs={subagentRefs} isUnread={isUnread} />
       </span>
-      <span className="truncate">{session.name}</span>
+      <span className="truncate max-w-[50%]">{session.name}</span>
       <span className="text-xs text-text-secondary flex-shrink-0">{session.code}</span>
       {session.pane_title && (
         <span className="text-xs text-text-muted truncate min-w-0 flex-1">{session.pane_title}</span>

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -51,7 +51,9 @@ function SessionRow({ hostId, session, disabled, onSelect }: {
       <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
         <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={false} iconSize={14} subagentRefs={subagentRefs} isUnread={isUnread} />
       </span>
-      <span className="truncate max-w-[50%]">{session.name}</span>
+      {/* Cap the name at half-width ONLY when a pane title shares the row, so
+          the title keeps room; with no title a long name uses the full width. */}
+      <span className={`truncate${session.pane_title ? ' max-w-[50%]' : ''}`}>{session.name}</span>
       <span className="text-xs text-text-secondary flex-shrink-0">{session.code}</span>
       {session.pane_title && (
         <span className="text-xs text-text-muted truncate min-w-0 flex-1">{session.pane_title}</span>

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -51,10 +51,10 @@ function SessionRow({ hostId, session, disabled, onSelect }: {
       <span className="relative inline-flex items-center justify-center w-4 h-4 flex-shrink-0">
         <TabIcon IconComponent={IconComponent} agentStatus={agentStatus} tabIndicatorStyle={tabIndicatorStyle} isActive={false} iconSize={14} subagentRefs={subagentRefs} isUnread={isUnread} />
       </span>
-      <span className="flex-shrink-0">{session.name}</span>
+      <span className="truncate">{session.name}</span>
       <span className="text-xs text-text-secondary flex-shrink-0">{session.code}</span>
       {session.pane_title && (
-        <span className="text-xs text-text-muted truncate min-w-0">{session.pane_title}</span>
+        <span className="text-xs text-text-muted truncate min-w-0 flex-1">{session.pane_title}</span>
       )}
     </button>
   )


### PR DESCRIPTION
## 需求

New-Tab 的 Sessions 列表，每列在 **session id（code）之後**顯示該 session 的動態標題（就是 tab 上顯示的那種 `pane_title`，如「讀取記憶…」），填入原本空白的區域。

## 做法

`SessionRow` 由 `[icon] name  code(ml-auto)` 改為 `[icon] name  code  {pane_title}`：
- code 去掉 `ml-auto`，`pane_title` 接在其後、`text-text-muted`、`truncate min-w-0` 填滿剩餘空間並截斷。
- 僅 `session.pane_title` 存在時渲染（無標題的 session 不變）。
- 不 gate on `dynamicTabName`（此列表明確要顯示標題）。

## 測試

- pane title 存在時渲染且位於 code 之後（斷言 textContent 順序）。
- 無 pane title 時不渲染多餘 span。
- 全套 vitest 3929 綠 / lint / build。純 SPA→HMR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)