### PR TITLE
fix(snapshot): capture cwd from pane_current_path, not session start dir

### DIFF
--- a/spa/src/lib/snapshot/capture.test.ts
+++ b/spa/src/lib/snapshot/capture.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useTabStore } from '../../stores/useTabStore'
 import { useWorkspaceStore } from '../../features/workspace/store'
-import { listSessions } from '../host-api'
+import { listSessions, fetchSessionCwd } from '../host-api'
 import type { Session } from '../host-api'
 import type { Tab, PaneLayout, PaneContent } from '../../types/tab'
 import { readSnapshot, writeSnapshot } from './storage'
@@ -11,6 +11,7 @@ import { buildSnapshot, captureSnapshot } from './capture'
 vi.mock('../host-api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../host-api')>()),
   listSessions: vi.fn(),
+  fetchSessionCwd: vi.fn(),
 }))
 
 function tmuxContent(
@@ -52,43 +53,54 @@ function seedStores(tabs: Record<string, Tab>, tabOrder: string[], activeTabId: 
   useWorkspaceStore.getState().reset()
 }
 
+/**
+ * Configure fetchSessionCwd mock keyed by sessionCode. Value can be a string
+ * (resolves to it) or an Error (rejects with it). Codes absent from the map
+ * reject (they should never be asked — e.g. dead sessions).
+ */
+function mockCwds(map: Record<string, string | Error>): void {
+  vi.mocked(fetchSessionCwd).mockImplementation(async (_hostId: string, code: string) => {
+    const v = map[code]
+    if (v instanceof Error) throw v
+    if (v === undefined) throw new Error(`unexpected fetchSessionCwd for ${code}`)
+    return v
+  })
+}
+
 describe('buildSnapshot / captureSnapshot', () => {
   beforeEach(() => {
     localStorage.clear()
     useTabStore.setState({ tabs: {}, tabOrder: [], activeTabId: null })
     useWorkspaceStore.getState().reset()
     vi.mocked(listSessions).mockReset()
+    vi.mocked(fetchSessionCwd).mockReset()
   })
 
-  it('1. single host, two live tmux panes → nested sessionMeta + resolved=2', async () => {
-    const layout = split('s1', [
-      leaf('p1', tmuxContent('hostA', 'code1', 'cached1')),
-      leaf('p2', tmuxContent('hostA', 'code2', 'cached2')),
-    ])
-    seedStores({ t1: tab('t1', layout) }, ['t1'], 't1')
-
+  it('1. live session cwd comes from fetchSessionCwd (pane_current_path), not session_path', async () => {
+    seedStores(
+      { t1: tab('t1', leaf('p1', tmuxContent('hostA', 'code1', 'cached1'))) },
+      ['t1'],
+      't1',
+    )
+    // listSessions.cwd is the (unexpanded) session_path '~'; the real cwd differs.
     vi.mocked(listSessions).mockResolvedValue([
-      session({ code: 'code1', name: 'live1', cwd: '/a', current_command: 'vim' }),
-      session({ code: 'code2', name: 'live2', cwd: '/b', current_command: 'top' }),
+      session({ code: 'code1', name: 'live1', cwd: '~', current_command: 'vim' }),
     ])
+    mockCwds({ code1: '/Users/wake/Workspace/x' })
 
     const result = await captureSnapshot(1000)
 
     expect(listSessions).toHaveBeenCalledTimes(1)
     expect(listSessions).toHaveBeenCalledWith('hostA')
+    expect(fetchSessionCwd).toHaveBeenCalledWith('hostA', 'code1')
 
-    const stored = readSnapshot()
-    expect(stored).not.toBeNull()
-    expect(stored!.capturedAt).toBe(1000)
-    expect(stored!.sessionMeta.hostA.code1).toEqual({
+    const stored = readSnapshot()!
+    expect(stored.capturedAt).toBe(1000)
+    expect(stored.sessionMeta.hostA.code1).toEqual({
       hostId: 'hostA', sessionCode: 'code1', name: 'live1', mode: 'terminal',
-      cwd: '/a', currentCommand: 'vim', restorable: true,
+      cwd: '/Users/wake/Workspace/x', currentCommand: 'vim', restorable: true,
     })
-    expect(stored!.sessionMeta.hostA.code2).toEqual({
-      hostId: 'hostA', sessionCode: 'code2', name: 'live2', mode: 'terminal',
-      cwd: '/b', currentCommand: 'top', restorable: true,
-    })
-    expect(result).toEqual({ total: 2, resolved: 2, unresolved: 0 })
+    expect(result).toEqual({ total: 1, resolved: 1, unresolved: 0 })
   })
 
   it('2. cross-host same sessionCode literal stays independent (composite key)', async () => {
@@ -99,9 +111,13 @@ describe('buildSnapshot / captureSnapshot', () => {
     seedStores(tabs, ['t1', 't2'], 't1')
 
     vi.mocked(listSessions).mockImplementation(async (hostId: string) => {
-      if (hostId === 'hostA') return [session({ code: 'shared', name: 'a-name', cwd: '/host-a' })]
-      if (hostId === 'hostB') return [session({ code: 'shared', name: 'b-name', cwd: '/host-b' })]
+      if (hostId === 'hostA') return [session({ code: 'shared', name: 'a-name', cwd: '~' })]
+      if (hostId === 'hostB') return [session({ code: 'shared', name: 'b-name', cwd: '~' })]
       throw new Error(`unexpected host ${hostId}`)
+    })
+    vi.mocked(fetchSessionCwd).mockImplementation(async (hostId: string, code: string) => {
+      if (code !== 'shared') throw new Error(`unexpected code ${code}`)
+      return hostId === 'hostA' ? '/host-a' : '/host-b'
     })
 
     const snap = await buildSnapshot(2000)
@@ -112,7 +128,36 @@ describe('buildSnapshot / captureSnapshot', () => {
     expect(snap.sessionMeta.hostA.shared).not.toEqual(snap.sessionMeta.hostB.shared)
   })
 
-  it('3. one host unreachable does not interrupt the other host', async () => {
+  it('3. fetchSessionCwd rejection falls back to session_path; other sessions unaffected', async () => {
+    const layout = split('s1', [
+      leaf('p1', tmuxContent('hostA', 'code1', 'cached1')),
+      leaf('p2', tmuxContent('hostA', 'code2', 'cached2')),
+    ])
+    seedStores({ t1: tab('t1', layout) }, ['t1'], 't1')
+
+    vi.mocked(listSessions).mockResolvedValue([
+      session({ code: 'code1', name: 'live1', cwd: '~', current_command: 'vim' }),
+      session({ code: 'code2', name: 'live2', cwd: '/b', current_command: 'top' }),
+    ])
+    mockCwds({ code1: new Error('cwd probe failed'), code2: '/real/b' })
+
+    const result = await captureSnapshot(3000)
+    const stored = readSnapshot()!
+
+    // code1: fetch rejected → fall back to session_path '~', still restorable.
+    expect(stored.sessionMeta.hostA.code1).toEqual({
+      hostId: 'hostA', sessionCode: 'code1', name: 'live1', mode: 'terminal',
+      cwd: '~', currentCommand: 'vim', restorable: true,
+    })
+    // code2: unaffected by code1's failure — accurate cwd applied.
+    expect(stored.sessionMeta.hostA.code2).toEqual({
+      hostId: 'hostA', sessionCode: 'code2', name: 'live2', mode: 'terminal',
+      cwd: '/real/b', currentCommand: 'top', restorable: true,
+    })
+    expect(result).toEqual({ total: 2, resolved: 2, unresolved: 0 })
+  })
+
+  it('3b. one host unreachable does not interrupt the other host', async () => {
     const tabs: Record<string, Tab> = {
       t1: tab('t1', leaf('p1', tmuxContent('hostA', 'codeA', 'cachedA'))),
       t2: tab('t2', leaf('p2', tmuxContent('hostB', 'codeB', 'cachedB'))),
@@ -120,14 +165,17 @@ describe('buildSnapshot / captureSnapshot', () => {
     seedStores(tabs, ['t1', 't2'], 't1')
 
     vi.mocked(listSessions).mockImplementation(async (hostId: string) => {
-      if (hostId === 'hostA') return [session({ code: 'codeA', name: 'live-a', cwd: '/a' })]
+      if (hostId === 'hostA') return [session({ code: 'codeA', name: 'live-a', cwd: '~' })]
       throw new Error('host B unreachable')
     })
+    mockCwds({ codeA: '/a' })
 
-    const result = await captureSnapshot(3000)
+    const result = await captureSnapshot(3500)
     const stored = readSnapshot()!
 
     expect(stored.sessionMeta.hostA.codeA).toMatchObject({ restorable: true, cwd: '/a' })
+    // Offline host: fetchSessionCwd never asked for its sessions.
+    expect(fetchSessionCwd).not.toHaveBeenCalledWith('hostB', expect.anything())
     expect(stored.sessionMeta.hostB.codeB).toEqual({
       hostId: 'hostB', sessionCode: 'codeB', name: 'cachedB', mode: 'terminal',
       cwd: undefined, restorable: false, captureError: 'host-unreachable',
@@ -135,23 +183,25 @@ describe('buildSnapshot / captureSnapshot', () => {
     expect(result).toEqual({ total: 2, resolved: 1, unresolved: 1 })
   })
 
-  it('4. pane code missing from live list → session-dead-at-capture', async () => {
+  it('4. pane code missing from live list → session-dead-at-capture, cwd never probed', async () => {
     seedStores(
       { t1: tab('t1', leaf('p1', tmuxContent('hostA', 'deadcode', 'cachedDead'))) },
       ['t1'],
       't1',
     )
     vi.mocked(listSessions).mockResolvedValue([session({ code: 'other-code' })])
+    mockCwds({}) // any call is a failure
 
     const snap = await buildSnapshot(4000)
 
+    expect(fetchSessionCwd).not.toHaveBeenCalled()
     expect(snap.sessionMeta.hostA.deadcode).toEqual({
       hostId: 'hostA', sessionCode: 'deadcode', name: 'cachedDead', mode: 'terminal',
       cwd: undefined, restorable: false, captureError: 'session-dead-at-capture',
     })
   })
 
-  it('7. live session with empty cwd → not restorable, cwd stays undefined (not "")', async () => {
+  it('7. fetchSessionCwd resolves "" and session_path also empty → not restorable, cwd undefined', async () => {
     seedStores(
       { t1: tab('t1', leaf('p1', tmuxContent('hostA', 'code1', 'cached1'))) },
       ['t1'],
@@ -160,6 +210,7 @@ describe('buildSnapshot / captureSnapshot', () => {
     vi.mocked(listSessions).mockResolvedValue([
       session({ code: 'code1', name: 'live-name', cwd: '', current_command: 'bash' }),
     ])
+    mockCwds({ code1: '' })
 
     const result = await captureSnapshot(7000)
     const stored = readSnapshot()!
@@ -172,6 +223,47 @@ describe('buildSnapshot / captureSnapshot', () => {
     expect(result).toEqual({ total: 1, resolved: 0, unresolved: 1 })
   })
 
+  it('7b. fetchSessionCwd resolves "" but session_path non-empty → falls back, restorable', async () => {
+    seedStores(
+      { t1: tab('t1', leaf('p1', tmuxContent('hostA', 'code1', 'cached1'))) },
+      ['t1'],
+      't1',
+    )
+    vi.mocked(listSessions).mockResolvedValue([
+      session({ code: 'code1', name: 'live-name', cwd: '/session/start', current_command: 'bash' }),
+    ])
+    mockCwds({ code1: '' })
+
+    const stored = await buildSnapshot(7100)
+
+    expect(stored.sessionMeta.hostA.code1).toEqual({
+      hostId: 'hostA', sessionCode: 'code1', name: 'live-name', mode: 'terminal',
+      cwd: '/session/start', currentCommand: 'bash', restorable: true,
+    })
+  })
+
+  it('6b. two live sessions on one host both resolved independently (Promise.all)', async () => {
+    const layout = split('s1', [
+      leaf('p1', tmuxContent('hostA', 'code1', 'cached1')),
+      leaf('p2', tmuxContent('hostA', 'code2', 'cached2')),
+    ])
+    seedStores({ t1: tab('t1', layout) }, ['t1'], 't1')
+
+    vi.mocked(listSessions).mockResolvedValue([
+      session({ code: 'code1', name: 'live1', cwd: '~' }),
+      session({ code: 'code2', name: 'live2', cwd: '~' }),
+    ])
+    mockCwds({ code1: '/real/one', code2: '/real/two' })
+
+    const snap = await buildSnapshot(6100)
+
+    expect(fetchSessionCwd).toHaveBeenCalledTimes(2)
+    expect(snap.sessionMeta.hostA.code1.cwd).toBe('/real/one')
+    expect(snap.sessionMeta.hostA.code2.cwd).toBe('/real/two')
+    expect(snap.sessionMeta.hostA.code1.restorable).toBe(true)
+    expect(snap.sessionMeta.hostA.code2.restorable).toBe(true)
+  })
+
   it('5. no tmux panes → total=0, sessionMeta={}, still writes a snapshot', async () => {
     seedStores(
       { t1: tab('t1', leaf('p1', { kind: 'editor', source: { type: 'local' }, filePath: '/tmp/a.md' })) },
@@ -182,6 +274,7 @@ describe('buildSnapshot / captureSnapshot', () => {
     const result = await captureSnapshot(5000)
 
     expect(listSessions).not.toHaveBeenCalled()
+    expect(fetchSessionCwd).not.toHaveBeenCalled()
     expect(result).toEqual({ total: 0, resolved: 0, unresolved: 0 })
     const stored = readSnapshot()
     expect(stored).not.toBeNull()
@@ -200,7 +293,8 @@ describe('buildSnapshot / captureSnapshot', () => {
       ['t1'],
       't1',
     )
-    vi.mocked(listSessions).mockResolvedValue([session({ code: 'code1', cwd: '/x' })])
+    vi.mocked(listSessions).mockResolvedValue([session({ code: 'code1', cwd: '~' })])
+    mockCwds({ code1: '/x' })
 
     const built = await buildSnapshot(6000)
     expect(built.capturedAt).toBe(6000)

--- a/spa/src/lib/snapshot/capture.test.ts
+++ b/spa/src/lib/snapshot/capture.test.ts
@@ -144,10 +144,11 @@ describe('buildSnapshot / captureSnapshot', () => {
     const result = await captureSnapshot(3000)
     const stored = readSnapshot()!
 
-    // code1: fetch rejected → fall back to session_path '~', still restorable.
+    // code1: fetch rejected → fall back to session_path '~', still restorable,
+    // but flagged degraded (cwd-probe-failed) so the fallback is observable.
     expect(stored.sessionMeta.hostA.code1).toEqual({
       hostId: 'hostA', sessionCode: 'code1', name: 'live1', mode: 'terminal',
-      cwd: '~', currentCommand: 'vim', restorable: true,
+      cwd: '~', currentCommand: 'vim', restorable: true, captureError: 'cwd-probe-failed',
     })
     // code2: unaffected by code1's failure — accurate cwd applied.
     expect(stored.sessionMeta.hostA.code2).toEqual({
@@ -223,7 +224,7 @@ describe('buildSnapshot / captureSnapshot', () => {
     expect(result).toEqual({ total: 1, resolved: 0, unresolved: 1 })
   })
 
-  it('7b. fetchSessionCwd resolves "" but session_path non-empty → falls back, restorable', async () => {
+  it('7b. fetchSessionCwd resolves "" but session_path non-empty → falls back, restorable, flagged degraded', async () => {
     seedStores(
       { t1: tab('t1', leaf('p1', tmuxContent('hostA', 'code1', 'cached1'))) },
       ['t1'],
@@ -239,6 +240,35 @@ describe('buildSnapshot / captureSnapshot', () => {
     expect(stored.sessionMeta.hostA.code1).toEqual({
       hostId: 'hostA', sessionCode: 'code1', name: 'live-name', mode: 'terminal',
       cwd: '/session/start', currentCommand: 'bash', restorable: true,
+      captureError: 'cwd-probe-failed',
+    })
+  })
+
+  it('G1. same session referenced by two panes probes cwd exactly once, deterministic', async () => {
+    // Same (hostA, code1) shown in two separate tabs → collectTmuxPanesByHost
+    // yields two per-pane refs for the SAME session. Without dedup this fires
+    // two concurrent fetchSessionCwd calls whose completion order is
+    // nondeterministic; here we assert exactly one probe and a stable cwd.
+    const tabs: Record<string, Tab> = {
+      t1: tab('t1', leaf('p1', tmuxContent('hostA', 'code1', 'cached1'))),
+      t2: tab('t2', leaf('p2', tmuxContent('hostA', 'code1', 'cached1'))),
+    }
+    seedStores(tabs, ['t1', 't2'], 't1')
+
+    vi.mocked(listSessions).mockResolvedValue([
+      session({ code: 'code1', name: 'live1', cwd: '~', current_command: 'vim' }),
+    ])
+    mockCwds({ code1: '/real/pane/path' })
+
+    const snap = await buildSnapshot(8000)
+
+    // Deduped to one probe per (host, code).
+    expect(fetchSessionCwd).toHaveBeenCalledTimes(1)
+    expect(fetchSessionCwd).toHaveBeenCalledWith('hostA', 'code1')
+    // Deterministic: the single pane_current_path, never overwritten by a fallback.
+    expect(snap.sessionMeta.hostA.code1).toEqual({
+      hostId: 'hostA', sessionCode: 'code1', name: 'live1', mode: 'terminal',
+      cwd: '/real/pane/path', currentCommand: 'vim', restorable: true,
     })
   })
 

--- a/spa/src/lib/snapshot/capture.ts
+++ b/spa/src/lib/snapshot/capture.ts
@@ -1,6 +1,6 @@
 import { useTabStore } from '../../stores/useTabStore'
 import { useWorkspaceStore } from '../../features/workspace/store'
-import { listSessions } from '../host-api'
+import { listSessions, fetchSessionCwd } from '../host-api'
 import { scanPaneTree } from '../pane-tree'
 import { writeSnapshot } from './storage'
 import type { CaptureResult, SessionMeta, WorkspaceSnapshot } from './types'
@@ -50,43 +50,60 @@ export async function buildSnapshot(now: number): Promise<WorkspaceSnapshot> {
     const perHost: Record<string, SessionMeta> = {}
     try {
       const sessions = await listSessions(hostId)
-      for (const ref of refs) {
-        const live = sessions.find((s) => s.code === ref.sessionCode)
-        perHost[ref.sessionCode] =
-          live && live.cwd
+      // Resolve each live session's accurate cwd (pane_current_path) concurrently.
+      // fetchSessionCwd failures are isolated per-session: a rejection falls back
+      // to the session_path from listSessions rather than aborting the capture.
+      await Promise.all(
+        refs.map(async (ref) => {
+          const live = sessions.find((s) => s.code === ref.sessionCode)
+          if (!live) {
+            perHost[ref.sessionCode] = {
+              hostId,
+              sessionCode: ref.sessionCode,
+              name: ref.cachedName,
+              mode: ref.mode,
+              cwd: undefined,
+              restorable: false,
+              captureError: 'session-dead-at-capture',
+            }
+            return
+          }
+
+          // Prefer the active pane's real current path; fall back to the
+          // session_path (unexpanded start dir) if the probe fails or is empty.
+          let cwd = ''
+          try {
+            cwd = await fetchSessionCwd(hostId, ref.sessionCode)
+          } catch {
+            cwd = ''
+          }
+          if (!cwd) cwd = live.cwd
+
+          perHost[ref.sessionCode] = cwd
             ? {
                 hostId,
                 sessionCode: ref.sessionCode,
                 name: live.name,
                 mode: ref.mode,
-                cwd: live.cwd,
+                cwd,
                 currentCommand: live.current_command,
                 restorable: true,
               }
-            : live
-              ? {
-                  // Live but no usable cwd: keep structure only, not restorable
-                  // (spec line 97 — cwd unknown must not feed createSession).
-                  // cwd stays undefined (spec line 76: not-captured means
-                  // undefined, never empty string); restorable stays false.
-                  hostId,
-                  sessionCode: ref.sessionCode,
-                  name: live.name,
-                  mode: ref.mode,
-                  cwd: undefined,
-                  currentCommand: live.current_command,
-                  restorable: false,
-                }
-              : {
-                  hostId,
-                  sessionCode: ref.sessionCode,
-                  name: ref.cachedName,
-                  mode: ref.mode,
-                  cwd: undefined,
-                  restorable: false,
-                  captureError: 'session-dead-at-capture',
-                }
-      }
+            : {
+                // Live but no usable cwd: keep structure only, not restorable
+                // (spec line 97 — cwd unknown must not feed createSession).
+                // cwd stays undefined (spec line 76: not-captured means
+                // undefined, never empty string); restorable stays false.
+                hostId,
+                sessionCode: ref.sessionCode,
+                name: live.name,
+                mode: ref.mode,
+                cwd: undefined,
+                currentCommand: live.current_command,
+                restorable: false,
+              }
+        }),
+      )
     } catch {
       for (const ref of refs) {
         perHost[ref.sessionCode] = {

--- a/spa/src/lib/snapshot/capture.ts
+++ b/spa/src/lib/snapshot/capture.ts
@@ -50,11 +50,20 @@ export async function buildSnapshot(now: number): Promise<WorkspaceSnapshot> {
     const perHost: Record<string, SessionMeta> = {}
     try {
       const sessions = await listSessions(hostId)
+      // Dedup per-pane refs to one entry per sessionCode BEFORE probing: the same
+      // session can appear in multiple panes/tabs. Mode is per-session and
+      // name/currentCommand come from the live Session, so dropping duplicate
+      // pane refs is safe. This guarantees fetchSessionCwd is called at most once
+      // per unique session — no redundant calls and no race where a later
+      // fallback result overwrites an earlier successful pane_current_path.
+      const uniqueRefs = Array.from(
+        new Map(refs.map((ref) => [ref.sessionCode, ref])).values(),
+      )
       // Resolve each live session's accurate cwd (pane_current_path) concurrently.
       // fetchSessionCwd failures are isolated per-session: a rejection falls back
       // to the session_path from listSessions rather than aborting the capture.
       await Promise.all(
-        refs.map(async (ref) => {
+        uniqueRefs.map(async (ref) => {
           const live = sessions.find((s) => s.code === ref.sessionCode)
           if (!live) {
             perHost[ref.sessionCode] = {
@@ -71,13 +80,17 @@ export async function buildSnapshot(now: number): Promise<WorkspaceSnapshot> {
 
           // Prefer the active pane's real current path; fall back to the
           // session_path (unexpanded start dir) if the probe fails or is empty.
-          let cwd = ''
+          let probed = ''
           try {
-            cwd = await fetchSessionCwd(hostId, ref.sessionCode)
+            probed = await fetchSessionCwd(hostId, ref.sessionCode)
           } catch {
-            cwd = ''
+            probed = ''
           }
-          if (!cwd) cwd = live.cwd
+          // usedFallback: pane_current_path was unavailable and we resorted to
+          // the session_path. Flag it (cwd-probe-failed) so a degraded capture
+          // is observable rather than disguised as a clean pane_current_path.
+          const usedFallback = !probed
+          const cwd = probed || live.cwd
 
           perHost[ref.sessionCode] = cwd
             ? {
@@ -88,6 +101,7 @@ export async function buildSnapshot(now: number): Promise<WorkspaceSnapshot> {
                 cwd,
                 currentCommand: live.current_command,
                 restorable: true,
+                ...(usedFallback ? { captureError: 'cwd-probe-failed' as const } : {}),
               }
             : {
                 // Live but no usable cwd: keep structure only, not restorable

--- a/spa/src/lib/snapshot/types.ts
+++ b/spa/src/lib/snapshot/types.ts
@@ -6,7 +6,7 @@ export interface SessionMeta {
   mode: 'terminal' | 'stream'
   cwd?: string; currentCommand?: string
   restorable: boolean
-  captureError?: 'host-unreachable' | 'session-dead-at-capture'
+  captureError?: 'host-unreachable' | 'session-dead-at-capture' | 'cwd-probe-failed'
 }
 export interface WorkspaceSnapshot {
   version: 1; capturedAt: number


### PR DESCRIPTION
## 問題
Snapshot 擷取的 session cwd 取自 `listSessions().cwd`（tmux `#{session_path}` = session 起始目錄、且不展開 `~`）。實測 UI 的 Directory 欄大多顯示 `~`，且「Rebuild all」會把 session 重建到起始目錄（常是 home）而非實際工作目錄。

## 修法
`capture.ts` 的 live session 改用 `fetchSessionCwd`（daemon `/api/sessions/{code}/cwd` → tmux `#{pane_current_path}`）解析**目前 pane 的實際絕對 cwd**。
- 每 host 仍只 `listSessions` 一次（liveness + name/current_command/mode）；per-session `fetchSessionCwd` 以 `Promise.all` 並發、各自 try/catch 隔離。
- `fetchSessionCwd` throw/空 → fall back 回 `listSessions().cwd`（保留舊行為當退路）；兩者皆空 → `restorable:false`。
- dead / host-offline 分支不變。

## 驗證
- `src/lib/snapshot/` **71 測試綠**（更新既有 capture 測試改斷言 pane_current_path + 新增 fallback/隔離案例）；全套 3930；lint/build 綠。

follow-up 觀察（非本 PR）：capture 未傳 AbortSignal，單一 `/cwd` 探測 hang 會讓該 host 的 Promise.all 卡住——低頻手動 capture 可接受，未來可加 timeout。