### PR TITLE
style(new-tab): match Sessions-list title brightness to the code

### DIFF
--- a/spa/src/components/SessionSection.test.tsx
+++ b/spa/src/components/SessionSection.test.tsx
@@ -133,6 +133,23 @@ describe('SessionSection', () => {
     expect(uncapped.className).not.toContain('max-w-[50%]')
   })
 
+  it('renders the pane title at the same brightness as the code', () => {
+    useSessionStore.setState({
+      sessions: {
+        [HOST_ID]: [
+          { code: 'abc001', name: 'dev', cwd: '/tmp', mode: 'terminal', cc_session_id: '', cc_model: '', has_relay: false, pane_title: 'Reading memory' },
+        ],
+      },
+    })
+    render(<SessionSection onSelect={mockOnSelect} />)
+    const codeCls = screen.getByText('abc001').className
+    const titleCls = screen.getByText('Reading memory').className
+    // The title should use the same text colour token as the code.
+    expect(codeCls).toContain('text-text-secondary')
+    expect(titleCls).toContain('text-text-secondary')
+    expect(titleCls).not.toContain('text-text-muted')
+  })
+
   it('omits the title span when the session has no pane title', () => {
     useSessionStore.setState({
       sessions: {

--- a/spa/src/components/SessionSection.tsx
+++ b/spa/src/components/SessionSection.tsx
@@ -56,7 +56,7 @@ function SessionRow({ hostId, session, disabled, onSelect }: {
       <span className={`truncate${session.pane_title ? ' max-w-[50%]' : ''}`}>{session.name}</span>
       <span className="text-xs text-text-secondary flex-shrink-0">{session.code}</span>
       {session.pane_title && (
-        <span className="text-xs text-text-muted truncate min-w-0 flex-1">{session.pane_title}</span>
+        <span className="text-xs text-text-secondary truncate min-w-0 flex-1">{session.pane_title}</span>
       )}
     </button>
   )


### PR DESCRIPTION
使用者要求：Sessions 列表的 session 標題（pane_title）文字亮度調成和 id（code）一樣。

 span 由 `text-text-muted`（較暗）改為 `text-text-secondary`（同 code）。測試斷言 title 與 code 共用同一 color token。vitest 3931 綠 / lint / build。純 SPA→HMR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)