### PR TITLE
feat(snapshot): manually edit session cwd (rebuild target) in snapshot settings

### DIFF
--- a/docs/specs/2026-07-14-snapshot-cwd-edit-plan.md
+++ b/docs/specs/2026-07-14-snapshot-cwd-edit-plan.md
@@ -1,0 +1,54 @@
+# Plan — Manual cwd edit in Snapshot settings
+
+Implements `docs/specs/2026-07-14-snapshot-cwd-edit-spec.md`. Pure-SPA. Subagent TDD, one commit per task.
+
+## What already exists (verbatim, do not rebuild)
+
+- `spa/src/lib/snapshot/types.ts` — `SessionMeta { hostId; sessionCode; name; mode; cwd?; currentCommand?; restorable; captureError?: 'host-unreachable'|'session-dead-at-capture'|'cwd-probe-failed' }`; `WorkspaceSnapshot { …; sessionMeta: Record<hostId, Record<sessionCode, SessionMeta>> }`.
+- `spa/src/lib/snapshot/storage.ts` — `readSnapshot(): WorkspaceSnapshot | null`, `writeSnapshot(snap): void`.
+- `spa/src/components/settings/SnapshotSettingsSection.tsx`:
+  - `refresh = () => setSnap(readSnapshot())` (:163) — re-reads snapshot + (via the `[snap]`-keyed effect) re-runs health reconciliation.
+  - `TmuxBlock({ snap, liveByHost, busy, onRebuild, t })` (:373) renders the table; the **Directory** `<td>` (:429) is `{meta.cwd ?? '—'}`.
+  - `computeHealth` (:61) already gates 🔴 `dead` on `restorable && cwd` (F2), so a restorable flip re-renders the badge correctly.
+
+## Task 1 — `setSessionMetaCwd` pure function (+ tests)
+
+**File:** `spa/src/lib/snapshot/storage.ts` (near read/write) or a small sibling; **Test:** extend `storage.test.ts` (or a new `edit.test.ts`).
+
+```ts
+export function setSessionMetaCwd(
+  snap: WorkspaceSnapshot, hostId: string, sessionCode: string, rawCwd: string,
+): WorkspaceSnapshot
+```
+- `const cwd = rawCwd.trim()`. Composite key `[hostId][sessionCode]`. Return a NEW snapshot; never mutate input.
+- Missing target entry → return `snap` unchanged.
+- Non-empty → `{ ...meta, cwd, restorable: true, captureError: undefined }`.
+- Empty → `{ ...meta, cwd: undefined, restorable: false, captureError: undefined }`.
+- Only the target entry changes; other hosts / codes untouched.
+
+**Tests:** non-empty sets cwd+restorable+clears captureError; non-empty on a `cwd-probe-failed`/dead entry flips restorable true + clears captureError; empty/whitespace → cwd undefined + restorable false; input not mutated (new object); cross-host same code + other codes isolated; unknown key → unchanged.
+
+**Commit:** `feat(snapshot): setSessionMetaCwd pure snapshot cwd mutation (T1)`
+
+## Task 2 — `EditableCwdCell` + wire into TmuxBlock (+ tests)
+
+**Files:** new `spa/src/components/settings/EditableCwdCell.tsx` + test; modify `SnapshotSettingsSection.tsx`.
+
+- `EditableCwdCell({ cwd, onCommit }: { cwd?: string; onCommit: (value: string) => void })`:
+  - Display mode: `<span>` showing `cwd ?? '—'` (keep the `font-mono` styling), a `title`/cursor affordance, stable `data-testid` (e.g. `snapshot-cwd-cell`), `onDoubleClick` → edit mode.
+  - Edit mode: controlled `<input>` pre-filled with `cwd ?? ''`, auto-focus + select. **Enter** or **blur** → `onCommit(inputValue)` then leave edit; **Esc** → leave edit without committing. Guard against double-commit on Enter-then-blur.
+  - Owns only local draft/editing state.
+- In `SnapshotSettingsSection`, add `handleCommitCwd = (hostId, code, value) => { const cur = readSnapshot(); if (!cur) return; writeSnapshot(setSessionMetaCwd(cur, hostId, code, value)); refresh() }`. Pass `onCommitCwd` down to `TmuxBlock`; replace the Directory `<td>` body (:429) with `<EditableCwdCell cwd={meta.cwd} onCommit={(v) => onCommitCwd(meta.hostId, meta.sessionCode, v)} />`.
+
+**Tests (RTL, mock `snapshot/storage`):** double-click → input pre-filled; Enter → `writeSnapshot` called with updated cwd + cell shows new value; blur → commits; Esc → no `writeSnapshot`, reverts; editing a ⚠️ no-cwd row to a real path → after commit that row's `snapshot-health-*` badge becomes 🔴 (drive restorable flip via real `setSessionMetaCwd` + `refresh`, mocking `listSessions` to keep host reachable + session not live); empty commit → row health ⚠️.
+
+**Commit:** `feat(snapshot): inline-editable cwd cell in snapshot settings (T2)`
+
+## Done criteria
+
+`npx vitest run` full green (no regressions); `pnpm run lint` + `pnpm run build` green. PR → codex review.
+
+## Notes
+
+- No daemon calls; live sessions untouched. Re-capture overwrites edits (by design). No path validation / `~` expansion.
+- `EditableCwdCell` extraction is scoped; the broader hook/subcomponent refactor stays in #921.

--- a/docs/specs/2026-07-14-snapshot-cwd-edit-spec.md
+++ b/docs/specs/2026-07-14-snapshot-cwd-edit-spec.md
@@ -1,0 +1,95 @@
+# Spec — Manually edit Session cwd (rebuild target) in the Snapshot settings
+
+## Goal
+
+Let the user correct or supply the rebuild-target working directory for any session in the Snapshot Sessions reconciliation table by double-clicking the **Directory** cell and editing it inline. This is a purely client-side edit of the persisted snapshot; it does **not** touch the daemon or any live tmux session — it only changes what cwd `Rebuild all` / `Restore everything` will pass to `createSession` for that session.
+
+### Motivation
+
+Captured cwd comes from tmux `#{pane_current_path}` (alpha.321), but it can still be wrong for a user's intent, or fall back to the unexpanded session start dir (`captureError: 'cwd-probe-failed'`), or be absent (`restorable: false`, structure-only). Manual editing gives the user direct control over each session's rebuild location, and — because **all rows are editable** — lets a structure-only (⚠️) session become rebuildable simply by supplying a cwd.
+
+## Decisions (user-approved, do not relitigate)
+
+1. **All rows are editable** (🟢 live / 🔴 dead-rebuildable / ⚠️ structure-only / ⚪ offline). Editing a ⚠️ no-cwd row to a non-empty path makes it rebuildable; editing a 🟢 live row sets the cwd that will be used if it later dies and is rebuilt.
+2. **Re-capture overwrites**: a manual edit applies to the *current* snapshot only. Clicking "Capture snapshot" writes a fresh snapshot and manual edits are lost. No sticky-override layer (YAGNI).
+3. **Empty input clears the cwd** → the session becomes structure-only (`restorable: false`). This is the intentional "make non-rebuildable" capability of an all-rows-editable table.
+4. **No path validation / no `~` expansion / no daemon call**: accept the user's literal trimmed input. The host may be offline or the path created later; respecting the literal input is correct.
+
+## Scope
+
+- **In**: inline edit of the Directory (cwd) cell in the Snapshot settings Tmux reconciliation table; a pure snapshot-mutation function; persistence to snapshot storage; health-badge re-computation via the existing refresh flow.
+- **Out**: name/command/host columns (not editable); the Tabs block; daemon interaction; live-session cwd change; sticky overrides across re-capture; path existence validation.
+
+## Design
+
+### Layer 1 — data mutation (pure, unit-testable)
+
+New function in the snapshot lib (`spa/src/lib/snapshot/storage.ts` or a small sibling — implementer's choice, keep it near `readSnapshot`/`writeSnapshot`):
+
+```ts
+export function setSessionMetaCwd(
+  snap: WorkspaceSnapshot,
+  hostId: string,
+  sessionCode: string,
+  rawCwd: string,
+): WorkspaceSnapshot
+```
+
+Behaviour (returns a NEW snapshot; input never mutated; composite key `[hostId][sessionCode]`):
+- `const cwd = rawCwd.trim()`.
+- If the target `sessionMeta[hostId][sessionCode]` does not exist → return `snap` unchanged (defensive; the UI only edits existing rows).
+- **Non-empty** `cwd` → updated entry: `{ ...meta, cwd, restorable: true, captureError: undefined }` (the manual value is authoritative and supersedes `cwd-probe-failed` / a prior dead capture; the `restorable ⟺ has-usable-cwd` invariant, matching capture.ts and the `computeHealth` 🔴 predicate, is preserved).
+- **Empty** `cwd` → updated entry: `{ ...meta, cwd: undefined, restorable: false, captureError: undefined }` (structure-only).
+- Other hosts / other sessionCodes untouched.
+
+A thin commit helper (either exported or inlined at the call site) reads the current snapshot, applies `setSessionMetaCwd`, and `writeSnapshot`s the result:
+```ts
+// pseudo: read → apply → persist
+const next = setSessionMetaCwd(readSnapshot()!, hostId, code, value)
+writeSnapshot(next)
+```
+Guard: if `readSnapshot()` is null (no snapshot), the cell is not rendered/editable, so this path is unreachable; still, no-op safely if it happens.
+
+### Layer 2 — inline-edit UI
+
+Extract a small `EditableCwdCell` component (nudges the #921 direction without doing the full refactor):
+
+- **Display mode**: renders the current cwd string (or an em-dash / muted placeholder when `cwd` is undefined). A `title`/cursor affordance signals it is editable; `data-testid` stable for tests.
+- **Enter edit**: `onDoubleClick` swaps to a controlled `<input>` pre-filled with the current cwd (empty string when undefined), auto-focused, text selected.
+- **Commit**: **Enter key** or **blur** → trim value → call the commit helper → the parent's existing `refresh()` re-reads the snapshot and re-runs health reconciliation → the row re-renders with the new cwd and updated health badge (e.g. ⚠️ → 🔴 after supplying a path). Then leave edit mode.
+- **Cancel**: **Esc** → discard, leave edit mode, no write.
+- The cell owns only its local editing/draft state; the snapshot is the single source of truth.
+
+Wire `EditableCwdCell` into the Tmux block row's Directory column in `SnapshotSettingsSection.tsx`, passing `hostId`, `sessionCode`, current `cwd`, and an `onCommit(hostId, code, value)` callback (which does read→apply→write→`refresh()`).
+
+### Layer 3 — health re-computation
+
+No new health state. Editing changes `restorable`/`cwd`; the existing `refresh()` (re-read snapshot + re-reconcile via `listSessions`) already re-renders the health badge. Re-running `listSessions` on a cwd edit is redundant (liveness unchanged) but harmless for an infrequent manual action; reuse the existing flow rather than adding a cwd-only fast path.
+
+## Testing
+
+**Pure function (`setSessionMetaCwd`)**
+- Non-empty cwd on an existing entry → `cwd` set, `restorable: true`, `captureError` cleared; input snapshot not mutated (new object).
+- Non-empty cwd on a `cwd-probe-failed` / dead (`restorable:false`) entry → becomes `restorable: true`, `captureError` undefined.
+- Empty / whitespace-only cwd → `cwd: undefined`, `restorable: false`, `captureError: undefined`.
+- Composite-key isolation: same `sessionCode` under a different host, and other codes under the same host, are untouched.
+- Unknown `(hostId, sessionCode)` → snapshot returned unchanged.
+
+**Component (`EditableCwdCell` + section)**
+- Double-click Directory cell → input appears pre-filled with the current cwd.
+- Enter → commits: `writeSnapshot` called with the updated cwd, row shows the new value.
+- Blur → commits (same as Enter).
+- Esc → cancels: no `writeSnapshot`, cell reverts to original display.
+- Editing a ⚠️ (no-cwd) row to a real path → after commit, that row's health badge becomes 🔴 (rebuildable). (Drives the restorable-flip end-to-end through `refresh()`.)
+- Empty input committed → row becomes structure-only (health ⚠️).
+
+## Acceptance criteria
+
+- `setSessionMetaCwd` unit tests + `EditableCwdCell`/section tests green; full `npx vitest run` no regressions; `pnpm run lint` + `pnpm run build` green.
+- Double-clicking a Directory cell edits the cwd; Enter/blur persists to the snapshot and updates the row + health badge; Esc cancels.
+- A structure-only session gains a cwd and becomes rebuildable; a rebuildable session's cwd cleared becomes structure-only.
+- No daemon calls introduced by editing; live sessions untouched.
+
+## Phasing
+
+Single small PR (one review unit): Layer 1 pure function (+ tests) → Layer 2 `EditableCwdCell` + wiring (+ tests) → Layer 3 is emergent (reuses existing `refresh()`). Implemented as separate commits per layer for reviewability.

--- a/spa/src/components/settings/EditableCwdCell.test.tsx
+++ b/spa/src/components/settings/EditableCwdCell.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EditableCwdCell } from './EditableCwdCell'
+
+describe('EditableCwdCell', () => {
+  it('display mode shows the cwd (font-mono) and an em-dash when undefined', () => {
+    const { rerender } = render(<EditableCwdCell cwd="/home/work" onCommit={() => {}} />)
+    const cell = screen.getByTestId('snapshot-cwd-cell')
+    expect(cell.textContent).toBe('/home/work')
+    expect(cell.className).toContain('font-mono')
+
+    rerender(<EditableCwdCell cwd={undefined} onCommit={() => {}} />)
+    expect(screen.getByTestId('snapshot-cwd-cell').textContent).toBe('—')
+  })
+
+  it('double-click → input appears pre-filled with the current cwd', () => {
+    render(<EditableCwdCell cwd="/home/work" onCommit={() => {}} />)
+    expect(screen.queryByTestId('snapshot-cwd-input')).toBeNull()
+
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+    const input = screen.getByTestId('snapshot-cwd-input') as HTMLInputElement
+    expect(input.value).toBe('/home/work')
+  })
+
+  it('double-click on an undefined cwd → input pre-filled with empty string', () => {
+    render(<EditableCwdCell cwd={undefined} onCommit={() => {}} />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+    expect((screen.getByTestId('snapshot-cwd-input') as HTMLInputElement).value).toBe('')
+  })
+
+  it('type + Enter → onCommit called once with the typed value, leaves edit mode', () => {
+    const onCommit = vi.fn()
+    render(<EditableCwdCell cwd="/old" onCommit={onCommit} />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.change(input, { target: { value: '/new/dir' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(onCommit).toHaveBeenCalledWith('/new/dir')
+    expect(screen.queryByTestId('snapshot-cwd-input')).toBeNull()
+    expect(screen.getByTestId('snapshot-cwd-cell')).toBeTruthy()
+  })
+
+  it('blur → commits with the current value', () => {
+    const onCommit = vi.fn()
+    render(<EditableCwdCell cwd="/old" onCommit={onCommit} />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.change(input, { target: { value: '/blurred' } })
+    fireEvent.blur(input)
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(onCommit).toHaveBeenCalledWith('/blurred')
+  })
+
+  it('Enter does not double-commit on the following blur', () => {
+    const onCommit = vi.fn()
+    render(<EditableCwdCell cwd="/old" onCommit={onCommit} />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.change(input, { target: { value: '/once' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    // The Enter already unmounted the input; simulate the trailing blur explicitly.
+    fireEvent.blur(input)
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+  })
+
+  it('Esc → onCommit NOT called, reverts to display showing the original cwd', () => {
+    const onCommit = vi.fn()
+    render(<EditableCwdCell cwd="/original" onCommit={onCommit} />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.change(input, { target: { value: '/discarded' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    // The trailing blur after Esc must not sneak a commit through.
+    fireEvent.blur(input)
+
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('snapshot-cwd-input')).toBeNull()
+    expect(screen.getByTestId('snapshot-cwd-cell').textContent).toBe('/original')
+  })
+})

--- a/spa/src/components/settings/EditableCwdCell.test.tsx
+++ b/spa/src/components/settings/EditableCwdCell.test.tsx
@@ -85,4 +85,75 @@ describe('EditableCwdCell', () => {
     expect(screen.queryByTestId('snapshot-cwd-input')).toBeNull()
     expect(screen.getByTestId('snapshot-cwd-cell').textContent).toBe('/original')
   })
+
+  // ---- H1: disabled blocks entering edit mode --------------------------------
+
+  it('disabled → double-click does NOT enter edit mode (stays in display)', () => {
+    render(<EditableCwdCell cwd="/home/work" onCommit={() => {}} disabled />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+
+    expect(screen.queryByTestId('snapshot-cwd-input')).toBeNull()
+    expect(screen.getByTestId('snapshot-cwd-cell').textContent).toBe('/home/work')
+  })
+
+  // ---- H2: IME composition suppresses Enter/Escape ---------------------------
+
+  it('Enter during IME composition (compositionStart) → onCommit NOT called', () => {
+    const onCommit = vi.fn()
+    render(<EditableCwdCell cwd="/old" onCommit={onCommit} />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: '/半' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onCommit).not.toHaveBeenCalled()
+    // Still editing — the input remains mounted.
+    expect(screen.getByTestId('snapshot-cwd-input')).toBeTruthy()
+  })
+
+  it('Enter with nativeEvent.isComposing → onCommit NOT called', () => {
+    const onCommit = vi.fn()
+    render(<EditableCwdCell cwd="/old" onCommit={onCommit} />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(screen.getByTestId('snapshot-cwd-input')).toBeTruthy()
+  })
+
+  it('compositionEnd then Enter → commits normally', () => {
+    const onCommit = vi.fn()
+    render(<EditableCwdCell cwd="/old" onCommit={onCommit} />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: '/新目錄' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onCommit).not.toHaveBeenCalled()
+
+    fireEvent.compositionEnd(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(onCommit).toHaveBeenCalledWith('/新目錄')
+  })
+
+  it('Esc during IME composition → does NOT cancel (stays editing)', () => {
+    const onCommit = vi.fn()
+    render(<EditableCwdCell cwd="/original" onCommit={onCommit} />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.compositionStart(input)
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    // Composition Escape belongs to the IME — the edit must stay open.
+    expect(screen.getByTestId('snapshot-cwd-input')).toBeTruthy()
+    expect(onCommit).not.toHaveBeenCalled()
+  })
 })

--- a/spa/src/components/settings/EditableCwdCell.tsx
+++ b/spa/src/components/settings/EditableCwdCell.tsx
@@ -12,19 +12,29 @@ import { useEffect, useRef, useState } from 'react'
  *
  * The cell owns only local editing/draft state — the snapshot stays the single
  * source of truth; the parent persists the value and re-reads on `onCommit`.
+ *
+ * `disabled` (set while a capture/restore/rebuild action is in flight) blocks
+ * entering edit mode at all, so a row cannot be edited under a running action
+ * whose result would silently overwrite the edit.
  */
 export function EditableCwdCell({
   cwd,
   onCommit,
+  disabled = false,
 }: {
   cwd?: string
   onCommit: (value: string) => void
+  disabled?: boolean
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState('')
   // Once an edit resolves (commit or cancel) this blocks any trailing blur from
   // firing a second onCommit.
   const committedRef = useRef(false)
+  // True while an IME composition (CJK candidate selection) is active. Enter and
+  // Escape confirm/cancel the candidate, not the edit, so we must let them fall
+  // through to the IME instead of committing/cancelling a half-composed value.
+  const composingRef = useRef(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -35,6 +45,7 @@ export function EditableCwdCell({
   }, [editing])
 
   const startEditing = () => {
+    if (disabled) return
     setDraft(cwd ?? '')
     committedRef.current = false
     setEditing(true)
@@ -54,6 +65,9 @@ export function EditableCwdCell({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Ignore Enter/Escape while an IME composition is active — the keystroke
+    // belongs to the IME (confirm/cancel candidate), not to the edit.
+    if (composingRef.current || e.nativeEvent.isComposing) return
     if (e.key === 'Enter') {
       e.preventDefault()
       commit()
@@ -72,6 +86,8 @@ export function EditableCwdCell({
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={handleKeyDown}
+        onCompositionStart={() => { composingRef.current = true }}
+        onCompositionEnd={() => { composingRef.current = false }}
         onBlur={commit}
         className="w-full min-w-40 rounded border border-border-active bg-bg-input px-1 py-0.5 font-mono text-text-primary outline-none"
       />

--- a/spa/src/components/settings/EditableCwdCell.tsx
+++ b/spa/src/components/settings/EditableCwdCell.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Inline-editable rebuild-target cwd cell for the Snapshot reconciliation table.
+ *
+ * Display mode renders the current cwd (or an em-dash placeholder). Double-click
+ * swaps to a controlled input pre-filled with the cwd, auto-focused with its text
+ * selected. Enter OR blur commits the trimmed-by-the-caller value via `onCommit`;
+ * Esc cancels without committing. A `committedRef` latch guards the two ways an
+ * edit ends from firing `onCommit` twice: Enter commits then unmounts the input,
+ * and Esc's trailing blur would otherwise sneak a commit through.
+ *
+ * The cell owns only local editing/draft state — the snapshot stays the single
+ * source of truth; the parent persists the value and re-reads on `onCommit`.
+ */
+export function EditableCwdCell({
+  cwd,
+  onCommit,
+}: {
+  cwd?: string
+  onCommit: (value: string) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+  // Once an edit resolves (commit or cancel) this blocks any trailing blur from
+  // firing a second onCommit.
+  const committedRef = useRef(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [editing])
+
+  const startEditing = () => {
+    setDraft(cwd ?? '')
+    committedRef.current = false
+    setEditing(true)
+  }
+
+  const commit = () => {
+    if (committedRef.current) return
+    committedRef.current = true
+    setEditing(false)
+    onCommit(draft)
+  }
+
+  const cancel = () => {
+    // Latch so the input's trailing blur (from unmounting) does not commit.
+    committedRef.current = true
+    setEditing(false)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      commit()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      cancel()
+    }
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        data-testid="snapshot-cwd-input"
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={commit}
+        className="w-full min-w-40 rounded border border-border-active bg-bg-input px-1 py-0.5 font-mono text-text-primary outline-none"
+      />
+    )
+  }
+
+  return (
+    <span
+      data-testid="snapshot-cwd-cell"
+      onDoubleClick={startEditing}
+      title="Double-click to edit the rebuild directory"
+      className="font-mono cursor-text hover:text-text-primary"
+    >
+      {cwd ?? '—'}
+    </span>
+  )
+}

--- a/spa/src/components/settings/SnapshotSettingsSection.test.tsx
+++ b/spa/src/components/settings/SnapshotSettingsSection.test.tsx
@@ -10,7 +10,18 @@ import * as hostApiModule from '../../lib/host-api'
 import * as captureModule from '../../lib/snapshot/capture'
 import * as restoreModule from '../../lib/snapshot/restore'
 
-vi.mock('../../lib/snapshot/storage')
+// Partial mock: stub the storage read/write boundary but keep the REAL
+// setSessionMetaCwd so the cwd-edit → restorable-flip drives end-to-end.
+vi.mock('../../lib/snapshot/storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/snapshot/storage')>()
+  return {
+    ...actual,
+    readSnapshot: vi.fn(),
+    writeSnapshot: vi.fn(),
+    readPrevSnapshot: vi.fn(),
+    writePrevSnapshot: vi.fn(),
+  }
+})
 vi.mock('../../lib/host-api')
 vi.mock('../../lib/snapshot/capture')
 vi.mock('../../lib/snapshot/restore')
@@ -67,6 +78,7 @@ function makeSnapshot(over: Partial<WorkspaceSnapshot>): WorkspaceSnapshot {
 }
 
 const mockedReadSnapshot = vi.mocked(storageModule.readSnapshot)
+const mockedWriteSnapshot = vi.mocked(storageModule.writeSnapshot)
 const mockedReadPrev = vi.mocked(storageModule.readPrevSnapshot)
 const mockedListSessions = vi.mocked(hostApiModule.listSessions)
 const mockedCapture = vi.mocked(captureModule.captureSnapshot)
@@ -448,5 +460,127 @@ describe('SnapshotSettingsSection — action wiring (T9)', () => {
       expect(mockedRestoreAll).toHaveBeenCalledTimes(1)
     })
     release(EMPTY_REPORT)
+  })
+})
+
+describe('SnapshotSettingsSection — inline cwd editing (T2)', () => {
+  /**
+   * Wire readSnapshot/writeSnapshot into a single mutable cell so a commit
+   * persists and the subsequent refresh() re-reads the updated snapshot — mirrors
+   * how the real storage boundary behaves so health reconciliation re-runs.
+   */
+  function seedStatefulSnapshot(initial: WorkspaceSnapshot) {
+    let current: WorkspaceSnapshot | null = initial
+    mockedReadSnapshot.mockImplementation(() => current)
+    mockedWriteSnapshot.mockImplementation((s: WorkspaceSnapshot) => {
+      current = s
+    })
+  }
+
+  it('double-click a Directory cell → editable input pre-filled with the cwd', () => {
+    mockedReadSnapshot.mockReturnValue(
+      makeSnapshot({
+        sessionMeta: { h1: { s1: meta({ hostId: 'h1', sessionCode: 's1', name: 'work', cwd: '/x' }) } },
+      }),
+    )
+
+    render(<SnapshotSettingsSection />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+    expect((screen.getByTestId('snapshot-cwd-input') as HTMLInputElement).value).toBe('/x')
+  })
+
+  it('Enter commits → writeSnapshot called with the updated cwd', async () => {
+    seedStatefulSnapshot(
+      makeSnapshot({
+        sessionMeta: { h1: { s1: meta({ hostId: 'h1', sessionCode: 's1', name: 'work', cwd: '/x' }) } },
+      }),
+    )
+
+    render(<SnapshotSettingsSection />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.change(input, { target: { value: '/new/dir' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(mockedWriteSnapshot).toHaveBeenCalledTimes(1)
+    })
+    const persisted = mockedWriteSnapshot.mock.calls[0][0]
+    expect(persisted.sessionMeta.h1.s1.cwd).toBe('/new/dir')
+    expect(persisted.sessionMeta.h1.s1.restorable).toBe(true)
+    // The row now displays the persisted value after refresh().
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-cwd-cell').textContent).toBe('/new/dir')
+    })
+  })
+
+  it('Esc cancels → no writeSnapshot, cell reverts to the original value', () => {
+    mockedReadSnapshot.mockReturnValue(
+      makeSnapshot({
+        sessionMeta: { h1: { s1: meta({ hostId: 'h1', sessionCode: 's1', name: 'work', cwd: '/orig' }) } },
+      }),
+    )
+
+    render(<SnapshotSettingsSection />)
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.change(input, { target: { value: '/discarded' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    fireEvent.blur(input)
+
+    expect(mockedWriteSnapshot).not.toHaveBeenCalled()
+    expect(screen.getByTestId('snapshot-cwd-cell').textContent).toBe('/orig')
+  })
+
+  it('editing a ⚠️ structure-only row to a real path → health flips to 🔴 dead-rebuildable', async () => {
+    seedStatefulSnapshot(
+      makeSnapshot({
+        sessionMeta: {
+          h1: { s1: meta({ hostId: 'h1', sessionCode: 's1', name: 'work', restorable: false, cwd: undefined }) },
+        },
+      }),
+    )
+    // Host reachable, session not in the live list → structure now, dead after cwd.
+    mockedListSessions.mockResolvedValue([session({ code: 'other', name: 'other' })])
+
+    render(<SnapshotSettingsSection />)
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-health-h1-s1').getAttribute('data-health')).toBe('structure')
+    })
+
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.change(input, { target: { value: '/real/dir' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-health-h1-s1').getAttribute('data-health')).toBe('dead')
+    })
+  })
+
+  it('committing an empty cwd → row becomes ⚠️ structure-only', async () => {
+    seedStatefulSnapshot(
+      makeSnapshot({
+        sessionMeta: {
+          h1: { s1: meta({ hostId: 'h1', sessionCode: 's1', name: 'work', restorable: true, cwd: '/x' }) },
+        },
+      }),
+    )
+    mockedListSessions.mockResolvedValue([session({ code: 'other', name: 'other' })])
+
+    render(<SnapshotSettingsSection />)
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-health-h1-s1').getAttribute('data-health')).toBe('dead')
+    })
+
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+    const input = screen.getByTestId('snapshot-cwd-input')
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-health-h1-s1').getAttribute('data-health')).toBe('structure')
+    })
+    expect(mockedWriteSnapshot.mock.calls[0][0].sessionMeta.h1.s1.cwd).toBeUndefined()
   })
 })

--- a/spa/src/components/settings/SnapshotSettingsSection.test.tsx
+++ b/spa/src/components/settings/SnapshotSettingsSection.test.tsx
@@ -558,6 +558,35 @@ describe('SnapshotSettingsSection — inline cwd editing (T2)', () => {
     })
   })
 
+  it('while an action is in flight (busy) → double-click a Directory cell does NOT open the editor, no writeSnapshot', async () => {
+    seedStatefulSnapshot(
+      makeSnapshot({
+        sessionMeta: { h1: { s1: meta({ hostId: 'h1', sessionCode: 's1', name: 'work', cwd: '/x' }) } },
+      }),
+    )
+    // Never-resolving restore keeps `busy` (and busyRef) latched true.
+    let release!: (r: RestoreReport) => void
+    mockedRestoreAll.mockReturnValue(new Promise<RestoreReport>((r) => { release = r }))
+
+    render(<SnapshotSettingsSection />)
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-health-h1-s1')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByTestId('snapshot-restore-all-btn'))
+    // Confirm the section is actually busy (rebuild button disabled).
+    await waitFor(() => {
+      expect((screen.getByTestId('snapshot-rebuild-btn') as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    // The cell is disabled → double-click must not enter edit mode.
+    fireEvent.doubleClick(screen.getByTestId('snapshot-cwd-cell'))
+    expect(screen.queryByTestId('snapshot-cwd-input')).toBeNull()
+    expect(mockedWriteSnapshot).not.toHaveBeenCalled()
+
+    release(EMPTY_REPORT)
+  })
+
   it('committing an empty cwd → row becomes ⚠️ structure-only', async () => {
     seedStatefulSnapshot(
       makeSnapshot({

--- a/spa/src/components/settings/SnapshotSettingsSection.tsx
+++ b/spa/src/components/settings/SnapshotSettingsSection.tsx
@@ -10,8 +10,9 @@ import {
   WarningCircle,
 } from '@phosphor-icons/react'
 import { SettingItem } from './SettingItem'
+import { EditableCwdCell } from './EditableCwdCell'
 import { useI18nStore } from '../../stores/useI18nStore'
-import { readPrevSnapshot, readSnapshot } from '../../lib/snapshot/storage'
+import { readPrevSnapshot, readSnapshot, setSessionMetaCwd, writeSnapshot } from '../../lib/snapshot/storage'
 import { captureSnapshot } from '../../lib/snapshot/capture'
 import {
   rebuildAllSessions,
@@ -161,6 +162,16 @@ export function SnapshotSettingsSection() {
   // object, this bumps the `snap` reference → the reconciliation effect re-fires
   // and the restore handlers close over the latest snapshot on their next click.
   const refresh = () => setSnap(readSnapshot())
+
+  // Persist a manual cwd edit for one session, then re-read + re-reconcile via
+  // `refresh()` so the row's health badge reflects the new restorable state. Pure
+  // client-side: no daemon call, live sessions untouched.
+  const handleCommitCwd = (hostId: string, code: string, value: string) => {
+    const cur = readSnapshot()
+    if (!cur) return
+    writeSnapshot(setSessionMetaCwd(cur, hostId, code, value))
+    refresh()
+  }
 
   const handleCapture = async () => {
     if (busyRef.current) return
@@ -322,7 +333,14 @@ export function SnapshotSettingsSection() {
             </div>
           </SettingItem>
 
-          <TmuxBlock snap={snap} liveByHost={liveByHost} busy={busy} onRebuild={handleRebuild} t={t} />
+          <TmuxBlock
+            snap={snap}
+            liveByHost={liveByHost}
+            busy={busy}
+            onRebuild={handleRebuild}
+            onCommitCwd={handleCommitCwd}
+            t={t}
+          />
           <TabsBlock snap={snap} busy={busy} onRestoreLayout={handleRestoreTab} t={t} />
         </>
       )}
@@ -375,12 +393,14 @@ function TmuxBlock({
   liveByHost,
   busy,
   onRebuild,
+  onCommitCwd,
   t,
 }: {
   snap: WorkspaceSnapshot
   liveByHost: Record<string, HostLive>
   busy: boolean
   onRebuild: () => void
+  onCommitCwd: (hostId: string, code: string, value: string) => void
   t: ReturnType<typeof useI18nStore.getState>['t']
 }) {
   const rows: SessionMeta[] = []
@@ -426,7 +446,12 @@ function TmuxBlock({
                   <tr key={`${meta.hostId}:${meta.sessionCode}`} className="border-t border-border-default">
                     <td className="py-1 pr-3 text-text-primary">{meta.hostId}</td>
                     <td className="py-1 pr-3">{meta.name}</td>
-                    <td className="py-1 pr-3 font-mono">{meta.cwd ?? '—'}</td>
+                    <td className="py-1 pr-3 font-mono">
+                      <EditableCwdCell
+                        cwd={meta.cwd}
+                        onCommit={(v) => onCommitCwd(meta.hostId, meta.sessionCode, v)}
+                      />
+                    </td>
                     <td className="py-1 pr-3 font-mono">{meta.currentCommand ?? '—'}</td>
                     <td className="py-1">
                       <span

--- a/spa/src/components/settings/SnapshotSettingsSection.tsx
+++ b/spa/src/components/settings/SnapshotSettingsSection.tsx
@@ -167,6 +167,11 @@ export function SnapshotSettingsSection() {
   // `refresh()` so the row's health badge reflects the new restorable state. Pure
   // client-side: no daemon call, live sessions untouched.
   const handleCommitCwd = (hostId: string, code: string, value: string) => {
+    // Reject edits landing while a capture/restore/rebuild action is in flight:
+    // that action closed over the pre-edit snapshot and its result would silently
+    // overwrite this write. (The cell is also `disabled` while busy so a row
+    // normally cannot even enter edit mode — this guards the residual window.)
+    if (busyRef.current) return
     const cur = readSnapshot()
     if (!cur) return
     writeSnapshot(setSessionMetaCwd(cur, hostId, code, value))
@@ -450,6 +455,7 @@ function TmuxBlock({
                       <EditableCwdCell
                         cwd={meta.cwd}
                         onCommit={(v) => onCommitCwd(meta.hostId, meta.sessionCode, v)}
+                        disabled={busy}
                       />
                     </td>
                     <td className="py-1 pr-3 font-mono">{meta.currentCommand ?? '—'}</td>

--- a/spa/src/lib/snapshot/storage.test.ts
+++ b/spa/src/lib/snapshot/storage.test.ts
@@ -6,8 +6,9 @@ import {
   writeSnapshot,
   readPrevSnapshot,
   writePrevSnapshot,
+  setSessionMetaCwd,
 } from './storage'
-import type { WorkspaceSnapshot } from './types'
+import type { SessionMeta, WorkspaceSnapshot } from './types'
 
 function makeSnapshot(overrides?: Partial<WorkspaceSnapshot>): WorkspaceSnapshot {
   return {
@@ -95,5 +96,126 @@ describe('snapshot storage', () => {
     expect(readPrevSnapshot()).toEqual(prev)
     expect(readSnapshot()).toEqual(current)
     expect(SNAPSHOT_KEY).not.toBe(SNAPSHOT_PREV_KEY)
+  })
+})
+
+describe('setSessionMetaCwd', () => {
+  function metaEntry(over: Partial<SessionMeta> & Pick<SessionMeta, 'hostId' | 'sessionCode' | 'name'>): SessionMeta {
+    return { mode: 'terminal', restorable: true, ...over }
+  }
+
+  function snapWithMeta(sessionMeta: WorkspaceSnapshot['sessionMeta']): WorkspaceSnapshot {
+    return makeSnapshot({ sessionMeta })
+  }
+
+  it('non-empty cwd sets cwd, restorable:true, clears captureError', () => {
+    const snap = snapWithMeta({
+      h1: { s1: metaEntry({ hostId: 'h1', sessionCode: 's1', name: 'work', cwd: '/old' }) },
+    })
+    const next = setSessionMetaCwd(snap, 'h1', 's1', '/new/path')
+    expect(next.sessionMeta.h1.s1).toMatchObject({
+      cwd: '/new/path',
+      restorable: true,
+    })
+    expect(next.sessionMeta.h1.s1.captureError).toBeUndefined()
+  })
+
+  it('trims surrounding whitespace from a non-empty cwd', () => {
+    const snap = snapWithMeta({
+      h1: { s1: metaEntry({ hostId: 'h1', sessionCode: 's1', name: 'work' }) },
+    })
+    const next = setSessionMetaCwd(snap, 'h1', 's1', '  /trimmed  ')
+    expect(next.sessionMeta.h1.s1.cwd).toBe('/trimmed')
+  })
+
+  it('non-empty cwd on a cwd-probe-failed / dead entry flips restorable true + clears captureError', () => {
+    const snap = snapWithMeta({
+      h1: {
+        s1: metaEntry({
+          hostId: 'h1',
+          sessionCode: 's1',
+          name: 'work',
+          restorable: false,
+          captureError: 'cwd-probe-failed',
+        }),
+      },
+    })
+    const next = setSessionMetaCwd(snap, 'h1', 's1', '/real/dir')
+    expect(next.sessionMeta.h1.s1).toMatchObject({ cwd: '/real/dir', restorable: true })
+    expect(next.sessionMeta.h1.s1.captureError).toBeUndefined()
+  })
+
+  it('empty string clears cwd, restorable:false, captureError undefined', () => {
+    const snap = snapWithMeta({
+      h1: { s1: metaEntry({ hostId: 'h1', sessionCode: 's1', name: 'work', cwd: '/x', restorable: true }) },
+    })
+    const next = setSessionMetaCwd(snap, 'h1', 's1', '')
+    expect(next.sessionMeta.h1.s1.cwd).toBeUndefined()
+    expect(next.sessionMeta.h1.s1.restorable).toBe(false)
+    expect(next.sessionMeta.h1.s1.captureError).toBeUndefined()
+  })
+
+  it('whitespace-only cwd clears cwd, restorable:false', () => {
+    const snap = snapWithMeta({
+      h1: { s1: metaEntry({ hostId: 'h1', sessionCode: 's1', name: 'work', cwd: '/x', restorable: true }) },
+    })
+    const next = setSessionMetaCwd(snap, 'h1', 's1', '   \t  ')
+    expect(next.sessionMeta.h1.s1.cwd).toBeUndefined()
+    expect(next.sessionMeta.h1.s1.restorable).toBe(false)
+    expect(next.sessionMeta.h1.s1.captureError).toBeUndefined()
+  })
+
+  it('does not mutate the input snapshot (new objects, original entry unchanged)', () => {
+    const original = metaEntry({ hostId: 'h1', sessionCode: 's1', name: 'work', cwd: '/old', restorable: true })
+    const snap = snapWithMeta({ h1: { s1: original } })
+    const next = setSessionMetaCwd(snap, 'h1', 's1', '/new')
+
+    expect(next).not.toBe(snap)
+    expect(next.sessionMeta).not.toBe(snap.sessionMeta)
+    expect(next.sessionMeta.h1).not.toBe(snap.sessionMeta.h1)
+    expect(next.sessionMeta.h1.s1).not.toBe(original)
+    // Input entry untouched.
+    expect(original.cwd).toBe('/old')
+    expect(snap.sessionMeta.h1.s1.cwd).toBe('/old')
+  })
+
+  it('composite-key isolation: same code under a different host is untouched', () => {
+    const snap = snapWithMeta({
+      h1: { s1: metaEntry({ hostId: 'h1', sessionCode: 's1', name: 'a', cwd: '/a' }) },
+      h2: { s1: metaEntry({ hostId: 'h2', sessionCode: 's1', name: 'b', cwd: '/b' }) },
+    })
+    const next = setSessionMetaCwd(snap, 'h1', 's1', '/edited')
+    expect(next.sessionMeta.h1.s1.cwd).toBe('/edited')
+    // Different host, same code — reference and value preserved.
+    expect(next.sessionMeta.h2).toBe(snap.sessionMeta.h2)
+    expect(next.sessionMeta.h2.s1.cwd).toBe('/b')
+  })
+
+  it('composite-key isolation: sibling code under the same host is untouched', () => {
+    const snap = snapWithMeta({
+      h1: {
+        s1: metaEntry({ hostId: 'h1', sessionCode: 's1', name: 'a', cwd: '/a' }),
+        s2: metaEntry({ hostId: 'h1', sessionCode: 's2', name: 'b', cwd: '/b' }),
+      },
+    })
+    const before = snap.sessionMeta.h1.s2
+    const next = setSessionMetaCwd(snap, 'h1', 's1', '/edited')
+    expect(next.sessionMeta.h1.s1.cwd).toBe('/edited')
+    expect(next.sessionMeta.h1.s2).toBe(before)
+    expect(next.sessionMeta.h1.s2.cwd).toBe('/b')
+  })
+
+  it('unknown host → snapshot returned unchanged', () => {
+    const snap = snapWithMeta({
+      h1: { s1: metaEntry({ hostId: 'h1', sessionCode: 's1', name: 'a', cwd: '/a' }) },
+    })
+    expect(setSessionMetaCwd(snap, 'nope', 's1', '/x')).toBe(snap)
+  })
+
+  it('unknown code under a known host → snapshot returned unchanged', () => {
+    const snap = snapWithMeta({
+      h1: { s1: metaEntry({ hostId: 'h1', sessionCode: 's1', name: 'a', cwd: '/a' }) },
+    })
+    expect(setSessionMetaCwd(snap, 'h1', 'nope', '/x')).toBe(snap)
   })
 })

--- a/spa/src/lib/snapshot/storage.ts
+++ b/spa/src/lib/snapshot/storage.ts
@@ -59,3 +59,39 @@ export function readPrevSnapshot(): WorkspaceSnapshot | null {
 export function writePrevSnapshot(snap: WorkspaceSnapshot): void {
   writeSnapshotToKey(SNAPSHOT_PREV_KEY, snap)
 }
+
+/**
+ * Return a NEW snapshot with the rebuild-target cwd of one captured session
+ * (composite key `[hostId][sessionCode]`) replaced by the user's trimmed input.
+ * The input snapshot is never mutated — only the changed host map + entry are
+ * spread into fresh objects.
+ *
+ * A non-empty cwd is authoritative: it sets `restorable: true` and clears any
+ * `captureError` (e.g. `cwd-probe-failed`), preserving the `restorable ⟺
+ * has-usable-cwd` invariant that capture.ts and `computeHealth`'s 🔴 predicate
+ * rely on. An empty (or whitespace-only) cwd makes the session structure-only
+ * (`restorable: false`, `cwd: undefined`). A missing target entry is a no-op —
+ * the original snapshot is returned unchanged.
+ */
+export function setSessionMetaCwd(
+  snap: WorkspaceSnapshot,
+  hostId: string,
+  sessionCode: string,
+  rawCwd: string,
+): WorkspaceSnapshot {
+  const meta = snap.sessionMeta[hostId]?.[sessionCode]
+  if (!meta) return snap
+
+  const cwd = rawCwd.trim()
+  const nextEntry = cwd
+    ? { ...meta, cwd, restorable: true, captureError: undefined }
+    : { ...meta, cwd: undefined, restorable: false, captureError: undefined }
+
+  return {
+    ...snap,
+    sessionMeta: {
+      ...snap.sessionMeta,
+      [hostId]: { ...snap.sessionMeta[hostId], [sessionCode]: nextEntry },
+    },
+  }
+}


### PR DESCRIPTION
## 目的
在 Snapshot Sessions 對帳表 double-click **Directory** 欄，手動修正/補上該 session 重建（rebuild）時的目標 cwd。純 client-side 改快照，**不碰 daemon、不動 live session**。承接 alpha.321（cwd 改用 pane_current_path）——即使如此，pane_current_path 未必是使用者要的落點、或 fallback 成 `~`、或根本沒 cwd（structure-only），手動編輯給使用者直接控制。

## 設計（spec/plan 見 docs/specs/2026-07-14-snapshot-cwd-edit-*）
- **所有列可編**：⚠️ 無 cwd 補上路徑 → 變可重建；🟢 live 設將來死掉的落點。
- **T1 純函式** `setSessionMetaCwd(snap, host, code, rawCwd)`：trim；非空 → cwd+restorable:true+清 captureError（手動值權威）；空 → cwd:undefined+restorable:false（清成 structure-only）；複合鍵定點更新、不 mutate。
- **T2 `EditableCwdCell`** inline edit：double-click 進編輯（預填現值）、Enter/blur 存、Esc 取消；committedRef latch 防 Enter-then-blur 雙提交。存檔 → readSnapshot→setSessionMetaCwd→writeSnapshot→既有 refresh() 重讀+重跑健康度 → 該列 badge 即時更新（⚠️→🔴）。
- **重拍整包覆蓋**（手動編輯不 sticky，定案）；無路徑驗證/無 `~` 展開/無 daemon 呼叫。

## 驗證
- `src/lib/snapshot/` + `EditableCwdCell` + `SnapshotSettingsSection` **113 測試綠**；全套 3957；lint/build 綠。base = 最新 main（alpha.323）。