### PR TITLE
fix(opencode): child (subagent) session events no longer hijack the parent light (L1)

### DIFF
--- a/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-plan.md
+++ b/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-plan.md
@@ -13,56 +13,71 @@ All paths relative to repo root; all edits in worktree `opencode-l1-idle-filter`
 
 ## Design invariants (from spec)
 
-`subagentSessions = new Set()`. Child identified by `event.properties.info?.parentID` on `session.created`.
-Gate **all** child lifecycle emits; parent behavior unchanged. `PdxSubagentStart/Stop` untouched.
+`subagentSessions = new Map()` keyed **childSessionID → parentSessionID**. Child identified by
+`event.properties.info?.parentID` on `session.created`. Session id resolved defensively in every
+handler: `sid = event.properties.sessionID || event.properties.info?.id || ''`. Gate **all** child
+lifecycle emits; parent behavior unchanged. `PdxSubagentStart/Stop` untouched.
 
-| Event | Child (in Set / has parentID) | Parent |
+| Event | Child (has parentID / in map) | Parent |
 |---|---|---|
-| `session.created` | add to Set; **no** `PdxSessionStart` | emit `PdxSessionStart` |
+| `session.created` | `set(sid, parentID)`; **no** `PdxSessionStart` | emit `PdxSessionStart` |
 | `session.status` idle | **no** `PdxStop` | existing suppress + `PdxStop` |
 | `session.error` | **no** `PdxStopFailure`; do not arm `suppressIdleForSession` | existing `PdxStopFailure` + arm suppress |
-| `session.deleted` | delete from Set; **no** `PdxSessionEnd` | `subagentSessions.clear()`; emit `PdxSessionEnd` |
+| `session.deleted` | `delete(sid)`; **no** `PdxSessionEnd` | delete entries whose value === `sid` (only this parent's children); emit `PdxSessionEnd` |
 
 Ordering in each handler: **child-check first**, then existing parent logic.
 
 ## Tasks (each its own commit; subagent TDD)
 
 ### T1 — Red: contract cases for child gating
-Add to `plugin_template_contract_test.go` (against `pluginSimState`, which T2 updates):
-- `session.created` with `properties.info.parentID` → mirror returns `ok=false` (no emit) **and** registers child.
-- `session.created` without `parentID` → `PdxSessionStart` (unchanged).
+Add to `plugin_template_contract_test.go` (against `pluginSimState`, which T2 updates). Mirror
+returns `ok=false` where no emit is expected:
+- child `session.created` (`properties.info.parentID`) → `ok=false` **and** registers child.
+- child `session.created` with **no top-level `sessionID`** (only `info.id`+`info.parentID`) → registered under `info.id`.
+- parent `session.created` (no `parentID`) → `PdxSessionStart` (unchanged).
 - registered child `session.status` idle → `ok=false`; unregistered/parent idle → `PdxStop`.
-- registered child `session.error` → `ok=false` **and** `suppressIdleForSession` NOT armed (assert via a following parent-style idle for that id still behaving correctly).
-- registered child `session.deleted` → `ok=false`, removed from Set.
-- parent `session.deleted` → `PdxSessionEnd` **and** Set cleared (assert a previously-registered child id is gone).
-- multi-subagent: register 3 children, 3 child idles suppressed, parent idle → exactly one `PdxStop`.
-- full sequence child created→idle→error→deleted then parent idle → only parent `PdxStop`; both Sets clean.
-Run: tests fail against current mirror (which still emits). Commit red.
+- registered child `session.error` → `ok=false` **and** white-box assert `state.suppressIdleForSession[childID] == false`.
+- registered child `session.deleted` → `ok=false`, removed from map.
+- parent `session.deleted` → `PdxSessionEnd` **and** only that parent's children pruned (previously-registered child id gone).
+- **sibling parents**: children of parent A and B registered; delete A → A's child gone from map, B's child idle still `ok=false` (suppressed).
+- multi-subagent: 3 children registered, 3 child idles `ok=false`, parent idle → exactly one `PdxStop`.
+- full sequence child created→idle→error→deleted then parent idle → only parent `PdxStop`; map + suppress both clean.
+Run: tests fail against current mirror. Commit red.
 
 ### T2 — Green: JS template + mirror in lockstep
-1. `plugin_template.go` `renderManagedPlugin`: add `const subagentSessions = new Set()`; implement the 4-event gating table above (child-check first; parent-delete `subagentSessions.clear()`).
-2. `pluginSimState`: add `subagentSessions map[string]bool`; mirror identical logic in `simulateBusEvent` for `session.created` (read `properties.info.parentID`), `session.status`, `session.error`, `session.deleted`. `newPluginSimState` initializes the map.
+1. `plugin_template.go` `renderManagedPlugin`: add `const subagentSessions = new Map()`; add a
+   `sid = event.properties.sessionID || event.properties.info?.id || ''` resolution in the gated
+   handlers; implement the 4-event gating table (child-check first; parent-delete prunes only
+   entries whose value === sid).
+2. `pluginSimState`: add `subagentSessions map[string]string` (child→parent); mirror identical
+   logic in `simulateBusEvent` for `session.created` (read `properties.info.parentID`, sid fallback
+   to `info.id`), `session.status`, `session.error`, `session.deleted`. `newPluginSimState` inits it.
 3. Keep `emit()`-parity: no new event names → `opencodeEventSpecs` / `validateSpecsCoverEmitted` unaffected.
-Run: T1 cases green; existing contract tests (incl. `ChatMessageClearsStaleErrorSuppression`, `StaleSuppressionWithoutChatMessage`) still green. Commit green.
+Run: T1 green; existing contract tests (incl. `ChatMessageClearsStaleErrorSuppression`,
+`StaleSuppressionWithoutChatMessage`) still green. Commit green.
 
-### T3 — Fixture: subagent session.created
-Add `testdata/opencode-1.14.23-payloads/session.created.subagent.json` (or inline in tests if the
-harness prefers) with `properties.info.parentID` set. Wire into the contract loader if fixture-driven.
+### T3 — Fixtures + rendered-JS static guards
+1. Add `testdata/opencode-1.14.23-payloads/session.created.subagent.json` with `properties.info.parentID`
+   (and a no-top-level-`sessionID` variant for the fallback case, inline in the test if simpler).
+2. Add structural assertions in `plugin_template_test.go`: rendered body contains `subagentSessions`,
+   `event.properties.info?.parentID`, and the child branch precedes the `PdxSessionStart` emit — so
+   a Bun-less CI still catches gate removal.
 Commit.
 
-### T4 — Bun integration: full child lifecycle sequence
-Extend `plugin_template_bun_integration_test.go`: append an IIFE firing, against one stub `pdx` that
-appends every invocation's `(eventName, stdin)` to a capture file, the sequence:
-`session.created(parentID)` → `session.status idle` → `session.error` → `session.deleted` →
-parent `session.created` → parent `session.status idle`. Assert the capture contains **only** the
-parent `PdxSessionStart` and parent `PdxStop` (no child-derived events). Skip if `bun` not in PATH
-(existing guard pattern). Commit.
+### T4 — Bun integration: realistic lifecycle sequence
+Extend `plugin_template_bun_integration_test.go`. Stub `pdx` reads event name from `$4`
+(`[pdxPath,'hook','--agent','opencode',eventName]`) and **appends** `eventName<TAB>stdin` as JSONL
+to the capture file (no `jq`; `emit` awaits `proc.exited` → deterministic order). Fire the sequence:
+`parent created → child created(parentID) → child idle → child error → child deleted → parent idle
+→ parent deleted`. Assert capture contains **only** parent `PdxSessionStart`, `PdxStop`,
+`PdxSessionEnd` (no child-derived events). Skip if `bun` not in PATH (existing guard). Commit.
 
 ### T5 — Verify + docs
 - `go test ./internal/agent/opencode/... -count=1 -race` and `go test ./... -count=1` green.
-- Confirm `plugin_template_test.go` structural assertions still pass.
-- PR body: root-cause table + daemon-log before/after + the live verification steps from spec.
-- Open follow-up issue: SDK-fetch fallback for the plugin-reload miss window (spec §Design decision 4).
+- Confirm `plugin_template_test.go` structural + parity assertions pass.
+- PR body: root-cause table + daemon-log before/after + live verification steps from spec.
+- Open follow-up issue: SDK-fetch fallback for the plugin-reload miss window covering
+  idle/**error**/**deleted** blast radius (spec §Design decision 4).
 
 ## Out of scope (guard against scope creep)
 Daemon/SPA code; `PdxSubagentStart/Stop`; new catalog events; `session.idle` (deprecated); the

--- a/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-plan.md
+++ b/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-plan.md
@@ -1,0 +1,73 @@
+# Plan: OpenCode L1 — child session lifecycle gating
+
+Spec: `2026-07-19-opencode-l1-subagent-idle-filter-spec.md`. Single phase, TDD.
+All paths relative to repo root; all edits in worktree `opencode-l1-idle-filter`.
+
+## Files in scope
+
+- `internal/agent/opencode/plugin_template.go` — `renderManagedPlugin` JS (production).
+- `internal/agent/opencode/plugin_template_contract_test.go` — `pluginSimState` JS-mirror + contract cases.
+- `internal/agent/opencode/plugin_template_bun_integration_test.go` — real-JS Bun sequence test.
+- `internal/agent/opencode/testdata/opencode-1.14.23-payloads/` — add subagent `session.created` fixture.
+- `internal/agent/opencode/plugin_template_test.go` — structural assertions; confirm still green (marker + emit parity; not a byte-golden, so added lines are fine).
+
+## Design invariants (from spec)
+
+`subagentSessions = new Set()`. Child identified by `event.properties.info?.parentID` on `session.created`.
+Gate **all** child lifecycle emits; parent behavior unchanged. `PdxSubagentStart/Stop` untouched.
+
+| Event | Child (in Set / has parentID) | Parent |
+|---|---|---|
+| `session.created` | add to Set; **no** `PdxSessionStart` | emit `PdxSessionStart` |
+| `session.status` idle | **no** `PdxStop` | existing suppress + `PdxStop` |
+| `session.error` | **no** `PdxStopFailure`; do not arm `suppressIdleForSession` | existing `PdxStopFailure` + arm suppress |
+| `session.deleted` | delete from Set; **no** `PdxSessionEnd` | `subagentSessions.clear()`; emit `PdxSessionEnd` |
+
+Ordering in each handler: **child-check first**, then existing parent logic.
+
+## Tasks (each its own commit; subagent TDD)
+
+### T1 — Red: contract cases for child gating
+Add to `plugin_template_contract_test.go` (against `pluginSimState`, which T2 updates):
+- `session.created` with `properties.info.parentID` → mirror returns `ok=false` (no emit) **and** registers child.
+- `session.created` without `parentID` → `PdxSessionStart` (unchanged).
+- registered child `session.status` idle → `ok=false`; unregistered/parent idle → `PdxStop`.
+- registered child `session.error` → `ok=false` **and** `suppressIdleForSession` NOT armed (assert via a following parent-style idle for that id still behaving correctly).
+- registered child `session.deleted` → `ok=false`, removed from Set.
+- parent `session.deleted` → `PdxSessionEnd` **and** Set cleared (assert a previously-registered child id is gone).
+- multi-subagent: register 3 children, 3 child idles suppressed, parent idle → exactly one `PdxStop`.
+- full sequence child created→idle→error→deleted then parent idle → only parent `PdxStop`; both Sets clean.
+Run: tests fail against current mirror (which still emits). Commit red.
+
+### T2 — Green: JS template + mirror in lockstep
+1. `plugin_template.go` `renderManagedPlugin`: add `const subagentSessions = new Set()`; implement the 4-event gating table above (child-check first; parent-delete `subagentSessions.clear()`).
+2. `pluginSimState`: add `subagentSessions map[string]bool`; mirror identical logic in `simulateBusEvent` for `session.created` (read `properties.info.parentID`), `session.status`, `session.error`, `session.deleted`. `newPluginSimState` initializes the map.
+3. Keep `emit()`-parity: no new event names → `opencodeEventSpecs` / `validateSpecsCoverEmitted` unaffected.
+Run: T1 cases green; existing contract tests (incl. `ChatMessageClearsStaleErrorSuppression`, `StaleSuppressionWithoutChatMessage`) still green. Commit green.
+
+### T3 — Fixture: subagent session.created
+Add `testdata/opencode-1.14.23-payloads/session.created.subagent.json` (or inline in tests if the
+harness prefers) with `properties.info.parentID` set. Wire into the contract loader if fixture-driven.
+Commit.
+
+### T4 — Bun integration: full child lifecycle sequence
+Extend `plugin_template_bun_integration_test.go`: append an IIFE firing, against one stub `pdx` that
+appends every invocation's `(eventName, stdin)` to a capture file, the sequence:
+`session.created(parentID)` → `session.status idle` → `session.error` → `session.deleted` →
+parent `session.created` → parent `session.status idle`. Assert the capture contains **only** the
+parent `PdxSessionStart` and parent `PdxStop` (no child-derived events). Skip if `bun` not in PATH
+(existing guard pattern). Commit.
+
+### T5 — Verify + docs
+- `go test ./internal/agent/opencode/... -count=1 -race` and `go test ./... -count=1` green.
+- Confirm `plugin_template_test.go` structural assertions still pass.
+- PR body: root-cause table + daemon-log before/after + the live verification steps from spec.
+- Open follow-up issue: SDK-fetch fallback for the plugin-reload miss window (spec §Design decision 4).
+
+## Out of scope (guard against scope creep)
+Daemon/SPA code; `PdxSubagentStart/Stop`; new catalog events; `session.idle` (deprecated); the
+#30043 upstream patch; SDK-fetch fallback (follow-up issue only).
+
+## Review
+Codex plan review (this doc) → subagent TDD (T1–T5) → PR codex round-1 standard (Go-only, sandbox OK)
+→ adversarial round only if round-1 non-trivial → squash merge → separate bump PR.

--- a/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-spec.md
+++ b/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-spec.md
@@ -57,16 +57,24 @@ must not be emitted.
 
 ## Fix (plugin-only): gate the whole child-session lifecycle
 
-Maintain `subagentSessions = new Set()` of child sessionIDs, learned from `session.created`.
-For any known child session, **suppress every parent-level lifecycle emit**. The child is
-already represented by the subagent dot (`PdxSubagentStart/Stop`).
+Maintain `subagentSessions = new Map()` mapping **childSessionID → parentSessionID**, learned
+from `session.created`. For any known child session, **suppress every parent-level lifecycle
+emit**. The child is already represented by the subagent dot (`PdxSubagentStart/Stop`).
+
+Resolve the session id defensively in every handler (runtime publishes `{ sessionID, info }` but
+the generated SDK type lists only `info` for `session.created`/`session.deleted`, so top-level
+`sessionID` is not guaranteed across versions):
+
+```js
+const sid = event.properties.sessionID || event.properties.info?.id || ''
+```
 
 | Event | New behavior |
 |---|---|
-| `session.created` | if `event.properties.info?.parentID` truthy → `subagentSessions.add(sessionID)` and **return without emitting `PdxSessionStart`**. Parent (no `parentID`) → emit `PdxSessionStart` unchanged. |
-| `session.status` idle | if `subagentSessions.has(sessionID)` → **return** (no `PdxStop`). Else existing `suppressIdleForSession` + `PdxStop` path unchanged. |
-| `session.error` | if `subagentSessions.has(sessionID)` → **return** (no `PdxStopFailure`, and do **not** arm `suppressIdleForSession`). Else existing behavior unchanged. |
-| `session.deleted` | if `subagentSessions.has(sessionID)` → `subagentSessions.delete(sessionID)` and **return** (no `PdxSessionEnd`). Else: if this is a **parent** delete, also `subagentSessions.clear()` (its children are gone — bounds Set growth), then emit `PdxSessionEnd` unchanged. |
+| `session.created` | `parentID = event.properties.info?.parentID`. If truthy → `subagentSessions.set(sid, parentID)` and **return without emitting `PdxSessionStart`**. Parent (no `parentID`) → emit `PdxSessionStart` unchanged. |
+| `session.status` idle | if `subagentSessions.has(sid)` → **return** (no `PdxStop`). Else existing `suppressIdleForSession` + `PdxStop` path unchanged. |
+| `session.error` | if `subagentSessions.has(sid)` → **return** (no `PdxStopFailure`, and do **not** arm `suppressIdleForSession`). Else existing behavior unchanged. |
+| `session.deleted` | if `subagentSessions.has(sid)` → `subagentSessions.delete(sid)` and **return** (no `PdxSessionEnd`). Else (this sid is a **parent**): delete every entry whose value === `sid` (its children only — never a sibling parent's children), then emit `PdxSessionEnd` unchanged. |
 
 `PdxSubagentStart` / `PdxSubagentStop` (from `tool.execute.before/after`) are **unchanged** —
 they remain the sole, correct source of subagent presence.
@@ -78,15 +86,22 @@ they remain the sole, correct source of subagent presence.
    would leave the created/error/deleted holes — deleted being the most severe (frame deletion).
 2. **Child `session.error` is fully skipped**, so `suppressIdleForSession` is never armed for a
    child. This also dissolves the ordering hazard (a child-armed suppression that a child idle
-   would otherwise never clear). Both Sets stay clean for children with no extra bookkeeping.
-3. **Cleanup**: child removed on its own `session.deleted`; the whole Set cleared on the parent's
-   `session.deleted`. If opencode never deletes child sessions mid-process, the Set is bounded by
-   O(child sessions seen in this plugin process) — a few hundred short strings, acceptable for L1.
+   would otherwise never clear). Both structures stay clean for children with no extra bookkeeping.
+3. **`Map`, parent-scoped cleanup.** A single opencode process can host more than one root
+   session over its lifetime (session switcher). A flat `Set` + blanket `clear()` on any parent
+   delete would forget a *sibling* parent's still-live children, re-opening the leak for them.
+   Keying child→parent and deleting only the matching parent's children on parent delete is
+   correct and bounds growth. Per-child `session.deleted` also prunes. Worst case (children never
+   individually deleted) the map is O(child sessions seen in this process) — negligible.
 4. **No SDK fetch fallback in this PR.** The fix assumes the plugin observes a child's
    `session.created` before the child's later events — true for the normal lifecycle. The only
-   miss window is a child already mid-flight when the plugin is (re)loaded (`pdx setup` / reload),
-   where an unknown-child idle would emit one false `PdxStop` — identical to today's behavior, so
-   **not a regression**. Documented limitation; SDK-fetch hardening tracked as a follow-up issue.
+   miss window is a child already mid-flight when the plugin is (re)loaded (`pdx setup` / reload).
+   In that window an unknown child's `session.status` idle emits a false `PdxStop`, its
+   `session.error` a false `PdxStopFailure` (parent turns red), and its `session.deleted` a false
+   `PdxSessionEnd` (**parent frame deleted**) — all identical to today's behavior, so **not a
+   regression**, but the deleted/error blast radius is larger than idle. Documented limitation;
+   SDK-fetch hardening (fetch session parentID for an unknown sid before emitting) tracked as a
+   follow-up issue.
 
 ### Non-goals
 
@@ -101,27 +116,43 @@ Update the Go-side JS-mirror (`pluginSimState`, `plugin_template_contract_test.g
 with the JS template; regenerate the byte-exact template comparison for the added lines.
 
 Contract cases:
-1. subagent `session.created` (`info.parentID` set) → **no** `PdxSessionStart`; sessionID registered.
+1. subagent `session.created` (`info.parentID` set) → **no** `PdxSessionStart`; child registered.
 2. parent `session.created` (no `parentID`) → `PdxSessionStart` emitted; not registered.
-3. registered child `session.status` idle → **no** `PdxStop`. Parent idle → `PdxStop` (unchanged).
-4. registered child `session.error` → **no** `PdxStopFailure`; `suppressIdleForSession` NOT armed.
-5. registered child `session.deleted` → **no** `PdxSessionEnd`; removed from Set.
-6. parent `session.deleted` → `PdxSessionEnd` emitted **and** Set cleared.
-7. multi-subagent: N child idles suppressed; parent's own idle emits exactly one `PdxStop`.
-8. sequence: child created→idle→error→deleted then parent idle → only the parent `PdxStop` survives;
-   both Sets clean afterward.
+3. child `session.created` with **no top-level `sessionID`** (only `info.id` + `info.parentID`) →
+   still registered under `info.id` (proves the `sessionID || info.id` fallback).
+4. registered child `session.status` idle → **no** `PdxStop`. Parent idle → `PdxStop` (unchanged).
+5. registered child `session.error` → **no** `PdxStopFailure`; assert white-box
+   `suppressIdleForSession[childID] == false` (NOT armed).
+6. registered child `session.deleted` → **no** `PdxSessionEnd`; removed from map.
+7. parent `session.deleted` → `PdxSessionEnd` emitted **and** only that parent's children pruned.
+8. **sibling parents**: register children of parent A and parent B; delete A → A's children pruned,
+   B's children still gated (B child idle still suppressed). Guards the Map/scoped-cleanup fix.
+9. multi-subagent: N child idles suppressed; parent's own idle emits exactly one `PdxStop`.
+10. sequence: child created→idle→error→deleted then parent idle → only the parent `PdxStop` survives;
+    both structures clean afterward.
+11. existing `ChatMessageClearsStaleErrorSuppression` / `StaleSuppressionWithoutChatMessage`
+    (parent path) must stay green.
+
+Rendered-JS static guards (`plugin_template_test.go`, run even without Bun): assert the template
+contains `subagentSessions`, reads `event.properties.info?.parentID`, and places the child branch
+before the `PdxSessionStart` emit — so a no-Bun CI still catches removal of the gate.
 
 Fixtures: add a subagent `session.created` variant carrying `info.parentID` under
-`testdata/opencode-1.14.23-payloads/` (schema unchanged across versions).
+`testdata/opencode-1.14.23-payloads/` (schema unchanged across versions); include a variant
+omitting top-level `sessionID` for case 3.
 
 Bun integration (`plugin_template_bun_integration_test.go`): extend beyond the current single
-`session.created` to drive the **full child lifecycle sequence** through the real rendered JS
-against a stub `pdx` recording emitted events — asserting child created/idle/error/deleted emit
-nothing and parent idle emits `PdxStop`. This guards against "mirror and JS drift wrong together".
+`session.created` to drive a realistic sequence through the real rendered JS against a stub `pdx`
+that **appends** every invocation — the stub reads the event name from `$4`
+(`[pdxPath, 'hook', '--agent', 'opencode', eventName]`) and appends `eventName<TAB>stdin` as JSONL
+(no `jq`); `emit()` awaits `proc.exited` so order is deterministic. Sequence:
+`parent created → child created(parentID) → child idle → child error → child deleted → parent idle
+→ parent deleted`. Assert the capture contains **only** parent `PdxSessionStart`, parent `PdxStop`,
+parent `PdxSessionEnd` (no child-derived events). Guards against "mirror and JS drift wrong together".
 
-Optional daemon-level regression (if cheap): feed child lifecycle events under one sender identity
-through the frame handler and assert the parent frame is not idled/errored/deleted. Otherwise the
-Bun sequence + contract cases are the coverage floor.
+Daemon-level regression: skipped — fix is at the emit source, and the Bun sequence + contract cases
+are the coverage floor. (The root-cause daemon derivations were verified by reading `status.go` /
+`frame_ops.go`, not asserted in this PR.)
 
 ## Verification
 

--- a/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-spec.md
+++ b/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-spec.md
@@ -1,0 +1,139 @@
+# Spec: OpenCode L1 — child (subagent) session events no longer hijack the parent light
+
+Date: 2026-07-19
+Scope: `internal/agent/opencode/` (plugin template + test mirror/fixtures). Daemon and SPA untouched.
+Size: small (single phase). Reframed after codex spec review (task-mrrc2hts-ne3zbg).
+
+## Problem (verified live, 2026-07-19)
+
+On `tmux` session `istdb` (opencode running), the parent session's status light collapses
+to **idle** every time a subagent (Task tool) finishes, even though the parent is still
+running. Daemon log smoking gun — subagent completion produces a spurious parent `PdxStop`:
+
+```
+12:45:32 istdb  (opencode) PdxStop status=idle → projection_built top_status=idle   subagents=0   ← parent wrongly idle
+12:45:50 hermes (cc)       PdxSubagentStop     → projection_built top_status=running subagents=0   ← cc parent stays running (correct)
+```
+
+The hook transport is healthy — every opencode event fires and broadcasts. This is a
+pre-existing **semantic** bug (memory L1, never shipped), not a version-update regression.
+
+## Root cause (the general form)
+
+The opencode plugin has **no concept of parent vs child session**. opencode spawns each
+subagent (Task tool) as a **child session** with its own full lifecycle, and the plugin
+re-emits every child lifecycle event as a parent-level `Pdx*` event. The daemon matches a
+frame by **`(tmuxPaneID, senderPID, senderStartTime)`** — NOT by opencode `session_id`
+(`frame_ops.go:86` `GetByIdentity`). Because one opencode process serves parent + all its
+children over one tmux pane with one sender identity, **every child lifecycle event mutates
+the single parent frame**:
+
+| child bus event | plugin emits | daemon derives (`status.go`) | effect on parent frame |
+|---|---|---|---|
+| `session.created` (has `info.parentID`) | `PdxSessionStart` | `StatusIdle` (L15) | parent flaps to idle (masked by following `chat.message` running, but still a wrong projection + broadcast) |
+| `session.status` idle | `PdxStop` | `StatusIdle` (L23) | **parent light collapses to idle** ← the visible bug |
+| `session.error` | `PdxStopFailure` | `StatusError` (L34) | parent light turns **error/red** |
+| `session.deleted` | `PdxSessionEnd` | `StatusClear` (L36) → `deleted_frame` (`frame_ops.go:93`) | **parent frame is deleted** ← worse than idle flap |
+
+The subagent's real, intended representation is already carried by `PdxSubagentStart` /
+`PdxSubagentStop` (emitted from `tool.execute.before/after`), which the daemon treats as
+**detail-only** (`frame_ops.go:80` — they add/remove a subagent dot, they do NOT own the
+frame). So the child session's *own* lifecycle events are pure noise at the parent level and
+must not be emitted.
+
+### Upstream schema (authoritative, checked against current source)
+
+- opencode issue [#30043](https://github.com/anomalyco/opencode/issues/30043) (CLOSED,
+  maintainer: "for now you can fetch the session and see if it has a parent"): `session.status`
+  does **not** carry `parentID`. Filtering on the status event alone is impossible. Same bug the
+  Warp opencode plugin hit.
+- `Session.Info` (`packages/opencode/src/session/session.ts`) has `parentID: optional(SessionID)`,
+  populated only for child sessions.
+- `session.created` publishes the **full info**: `events.publish(Event.Created, { sessionID, info: result })`
+  (`session.ts:537`). So `event.properties.info.parentID` is the authoritative, event-carried
+  signal — no SDK fetch needed. Schema stable 1.14.23 → 1.18.3.
+- Live env: `istdb` runs 1.17.9; PATH `opencode` is 1.18.3 (next restart uses it). Fix must be
+  version-independent — the `session.created` / `info.parentID` path satisfies this.
+
+## Fix (plugin-only): gate the whole child-session lifecycle
+
+Maintain `subagentSessions = new Set()` of child sessionIDs, learned from `session.created`.
+For any known child session, **suppress every parent-level lifecycle emit**. The child is
+already represented by the subagent dot (`PdxSubagentStart/Stop`).
+
+| Event | New behavior |
+|---|---|
+| `session.created` | if `event.properties.info?.parentID` truthy → `subagentSessions.add(sessionID)` and **return without emitting `PdxSessionStart`**. Parent (no `parentID`) → emit `PdxSessionStart` unchanged. |
+| `session.status` idle | if `subagentSessions.has(sessionID)` → **return** (no `PdxStop`). Else existing `suppressIdleForSession` + `PdxStop` path unchanged. |
+| `session.error` | if `subagentSessions.has(sessionID)` → **return** (no `PdxStopFailure`, and do **not** arm `suppressIdleForSession`). Else existing behavior unchanged. |
+| `session.deleted` | if `subagentSessions.has(sessionID)` → `subagentSessions.delete(sessionID)` and **return** (no `PdxSessionEnd`). Else: if this is a **parent** delete, also `subagentSessions.clear()` (its children are gone — bounds Set growth), then emit `PdxSessionEnd` unchanged. |
+
+`PdxSubagentStart` / `PdxSubagentStop` (from `tool.execute.before/after`) are **unchanged** —
+they remain the sole, correct source of subagent presence.
+
+### Design decisions (resolved)
+
+1. **Gate all four child events, not just idle.** Verified against `status.go` + `frame_ops.go`:
+   each child event mutates the parent frame. Gating only `PdxStop` (the original memory plan)
+   would leave the created/error/deleted holes — deleted being the most severe (frame deletion).
+2. **Child `session.error` is fully skipped**, so `suppressIdleForSession` is never armed for a
+   child. This also dissolves the ordering hazard (a child-armed suppression that a child idle
+   would otherwise never clear). Both Sets stay clean for children with no extra bookkeeping.
+3. **Cleanup**: child removed on its own `session.deleted`; the whole Set cleared on the parent's
+   `session.deleted`. If opencode never deletes child sessions mid-process, the Set is bounded by
+   O(child sessions seen in this plugin process) — a few hundred short strings, acceptable for L1.
+4. **No SDK fetch fallback in this PR.** The fix assumes the plugin observes a child's
+   `session.created` before the child's later events — true for the normal lifecycle. The only
+   miss window is a child already mid-flight when the plugin is (re)loaded (`pdx setup` / reload),
+   where an unknown-child idle would emit one false `PdxStop` — identical to today's behavior, so
+   **not a regression**. Documented limitation; SDK-fetch hardening tracked as a follow-up issue.
+
+### Non-goals
+
+- No daemon-side or SPA-side change (fix at the emit source).
+- No change to `PdxSubagentStart` / `PdxSubagentStop`.
+- No new catalog event (`opencodeEventSpecs` unchanged → template/spec parity intact).
+- Not adopting the deprecated `session.idle` event; not implementing the #30043 upstream patch.
+
+## Test strategy (TDD)
+
+Update the Go-side JS-mirror (`pluginSimState`, `plugin_template_contract_test.go`) in lockstep
+with the JS template; regenerate the byte-exact template comparison for the added lines.
+
+Contract cases:
+1. subagent `session.created` (`info.parentID` set) → **no** `PdxSessionStart`; sessionID registered.
+2. parent `session.created` (no `parentID`) → `PdxSessionStart` emitted; not registered.
+3. registered child `session.status` idle → **no** `PdxStop`. Parent idle → `PdxStop` (unchanged).
+4. registered child `session.error` → **no** `PdxStopFailure`; `suppressIdleForSession` NOT armed.
+5. registered child `session.deleted` → **no** `PdxSessionEnd`; removed from Set.
+6. parent `session.deleted` → `PdxSessionEnd` emitted **and** Set cleared.
+7. multi-subagent: N child idles suppressed; parent's own idle emits exactly one `PdxStop`.
+8. sequence: child created→idle→error→deleted then parent idle → only the parent `PdxStop` survives;
+   both Sets clean afterward.
+
+Fixtures: add a subagent `session.created` variant carrying `info.parentID` under
+`testdata/opencode-1.14.23-payloads/` (schema unchanged across versions).
+
+Bun integration (`plugin_template_bun_integration_test.go`): extend beyond the current single
+`session.created` to drive the **full child lifecycle sequence** through the real rendered JS
+against a stub `pdx` recording emitted events — asserting child created/idle/error/deleted emit
+nothing and parent idle emits `PdxStop`. This guards against "mirror and JS drift wrong together".
+
+Optional daemon-level regression (if cheap): feed child lifecycle events under one sender identity
+through the frame handler and assert the parent frame is not idled/errored/deleted. Otherwise the
+Bun sequence + contract cases are the coverage floor.
+
+## Verification
+
+- `go test ./internal/agent/opencode/... -count=1 -race` green; `go test ./... -count=1` green.
+- Live (mlab): rebuild `bin/pdx`, `pdx setup --agent opencode`, run an opencode session that
+  spawns a subagent; confirm daemon log shows no parent `PdxStop` / `PdxStopFailure` /
+  `PdxSessionEnd` at child lifecycle points, parent light stays running, and real parent idle
+  (end of prompt cycle) still emits `PdxStop`.
+
+## Process
+
+Single phase. Codex spec review done (reframe adopted). Next: plan → codex plan review →
+subagent TDD → PR → codex round-1 (Go-only → sandbox OK), adversarial round only if round-1
+surfaces non-trivial findings. Squash merge + separate bump PR. Follow-up issue: SDK-fetch
+fallback for the plugin-reload miss window.

--- a/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-spec.md
+++ b/docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-spec.md
@@ -71,10 +71,10 @@ const sid = event.properties.sessionID || event.properties.info?.id || ''
 
 | Event | New behavior |
 |---|---|
-| `session.created` | `parentID = event.properties.info?.parentID`. If truthy → `subagentSessions.set(sid, parentID)` and **return without emitting `PdxSessionStart`**. Parent (no `parentID`) → emit `PdxSessionStart` unchanged. |
-| `session.status` idle | if `subagentSessions.has(sid)` → **return** (no `PdxStop`). Else existing `suppressIdleForSession` + `PdxStop` path unchanged. |
-| `session.error` | if `subagentSessions.has(sid)` → **return** (no `PdxStopFailure`, and do **not** arm `suppressIdleForSession`). Else existing behavior unchanged. |
-| `session.deleted` | if `subagentSessions.has(sid)` → `subagentSessions.delete(sid)` and **return** (no `PdxSessionEnd`). Else (this sid is a **parent**): delete every entry whose value === `sid` (its children only — never a sibling parent's children), then emit `PdxSessionEnd` unchanged. |
+| `session.created` | `parentID = event.properties.info?.parentID`. If truthy (child) → **return without emitting `PdxSessionStart`**, and `subagentSessions.set(sid, parentID)` **only if `sid` is non-empty** (an empty sid is unkeyable — still suppress its start, but never register `''`). Parent (no `parentID`) → emit `PdxSessionStart` unchanged. |
+| `session.status` idle | if `sid` non-empty and `subagentSessions.has(sid)` → **return** (no `PdxStop`). Else existing `suppressIdleForSession` + `PdxStop` path unchanged. |
+| `session.error` | if `sid` non-empty and `subagentSessions.has(sid)` → **return** (no `PdxStopFailure`, and do **not** arm `suppressIdleForSession`). Else existing behavior unchanged. |
+| `session.deleted` | **`session.deleted` also publishes full `info` (`session.ts:624`), so gate on the event, not the map** — reload-proof. If `event.properties.info?.parentID` truthy (child, even one whose `created` we never saw) → also `subagentSessions.delete(sid)` if keyed, and **return** (no `PdxSessionEnd`). Else (parent): delete every map entry whose value === `sid` (its children only — never a sibling's), then emit `PdxSessionEnd` unchanged. |
 
 `PdxSubagentStart` / `PdxSubagentStop` (from `tool.execute.before/after`) are **unchanged** —
 they remain the sole, correct source of subagent presence.
@@ -93,15 +93,20 @@ they remain the sole, correct source of subagent presence.
    Keying child→parent and deleting only the matching parent's children on parent delete is
    correct and bounds growth. Per-child `session.deleted` also prunes. Worst case (children never
    individually deleted) the map is O(child sessions seen in this process) — negligible.
-4. **No SDK fetch fallback in this PR.** The fix assumes the plugin observes a child's
-   `session.created` before the child's later events — true for the normal lifecycle. The only
-   miss window is a child already mid-flight when the plugin is (re)loaded (`pdx setup` / reload).
-   In that window an unknown child's `session.status` idle emits a false `PdxStop`, its
-   `session.error` a false `PdxStopFailure` (parent turns red), and its `session.deleted` a false
-   `PdxSessionEnd` (**parent frame deleted**) — all identical to today's behavior, so **not a
-   regression**, but the deleted/error blast radius is larger than idle. Documented limitation;
-   SDK-fetch hardening (fetch session parentID for an unknown sid before emitting) tracked as a
-   follow-up issue.
+4. **Reload / out-of-order window (codex adversarial review, `review-mrrdoijw-0ennkw`).** The
+   map is only populated after a child's `session.created`. If the plugin is (re)loaded while a
+   subagent is mid-flight, or an event arrives before that child's `created`, the map is empty for
+   it. Mitigation by event-carried signal:
+   - **`session.deleted` is gated on the event's own `info.parentID`, not the map** — reload-proof.
+     This removes the highest-impact failure (a child delete deleting the **parent frame**), since
+     the child's delete event carries `parentID` even if we never saw its `created` (`session.ts:624`).
+   - **`session.status` idle and `session.error` genuinely lack `parentID`** (#30043; SDK
+     `EventSessionError` = `{sessionID?, error?}`), so they stay map-based. In the narrow reload
+     window an unknown child's idle emits a false `PdxStop` (derived `notification_silent`, so no
+     desktop notification, and self-corrects on the parent's next event) or its error a false
+     `PdxStopFailure` (red until the next event). Both are **recoverable** and strictly narrower
+     than today's always-leak — not a regression. SDK-fetch/startup-hydration hardening for these
+     two is tracked as a follow-up issue.
 
 ### Non-goals
 

--- a/internal/agent/opencode/plugin_template.go
+++ b/internal/agent/opencode/plugin_template.go
@@ -83,10 +83,11 @@ export const PurdexOpenCodeHooks = async () => {
           const sid = event.properties.sessionID || event.properties.info?.id || ''
           const parentID = event.properties.info?.parentID
           if (parentID) {
-            // Child (subagent) session: register and suppress the
-            // parent-level start. The subagent dot is owned by
-            // PdxSubagentStart/Stop instead.
-            subagentSessions.set(sid, parentID)
+            // Child (subagent) session: suppress the parent-level start
+            // (the subagent dot is owned by PdxSubagentStart/Stop) and
+            // register it. Only key a non-empty sid — an empty key would
+            // later swallow an unrelated empty-sid parent delete.
+            if (sid) subagentSessions.set(sid, parentID)
             return
           }
           await emit(PURDEX_EVENT.PdxSessionStart, { session_id: sid })
@@ -110,7 +111,7 @@ export const PurdexOpenCodeHooks = async () => {
           // Child error is pure noise at the parent level; also skip arming
           // suppressIdleForSession so no child-armed entry can leak (a child
           // idle would never clear it since child idles are gated too).
-          if (subagentSessions.has(sid)) return
+          if (sid && subagentSessions.has(sid)) return
           if (sid) suppressIdleForSession.add(sid)
           await emit(PURDEX_EVENT.PdxStopFailure, {
             error: event.properties.error?.name || '',
@@ -121,7 +122,7 @@ export const PurdexOpenCodeHooks = async () => {
         case 'session.status': {
           if (event.properties.status?.type !== 'idle') return
           const sid = event.properties.sessionID || event.properties.info?.id || ''
-          if (subagentSessions.has(sid)) return
+          if (sid && subagentSessions.has(sid)) return
           if (suppressIdleForSession.has(sid)) {
             suppressIdleForSession.delete(sid)
             return
@@ -131,14 +132,19 @@ export const PurdexOpenCodeHooks = async () => {
         }
         case 'session.deleted': {
           const sid = event.properties.sessionID || event.properties.info?.id || ''
-          if (subagentSessions.has(sid)) {
-            subagentSessions.delete(sid)
+          const parentID = event.properties.info?.parentID
+          if (parentID) {
+            // Child delete: gate on the event's own parentID, not the map —
+            // reload-proof (session.deleted carries full info per
+            // session.ts:624), so a child delete never deletes the PARENT
+            // frame even if we never saw this child's created.
+            if (sid) subagentSessions.delete(sid)
             return
           }
           // Parent delete: prune only this parent's children (never a
           // sibling parent's still-live children), then emit end.
-          for (const [childID, parentID] of subagentSessions) {
-            if (parentID === sid) subagentSessions.delete(childID)
+          for (const [childID, pid] of subagentSessions) {
+            if (pid === sid) subagentSessions.delete(childID)
           }
           await emit(PURDEX_EVENT.PdxSessionEnd, { session_id: sid })
           return

--- a/internal/agent/opencode/plugin_template.go
+++ b/internal/agent/opencode/plugin_template.go
@@ -44,6 +44,15 @@ func renderManagedPlugin(pdxPath string) string {
 export const PurdexOpenCodeHooks = async () => {
   const activeSubagents = new Map()
   const suppressIdleForSession = new Set()
+  // childSessionID -> parentSessionID. opencode runs each subagent (Task
+  // tool) as a child session with its own full lifecycle over the same
+  // tmux pane / sender identity as the parent. The daemon matches frames
+  // by (pane, senderPID) not opencode session_id, so re-emitting a child's
+  // lifecycle as a parent-level Pdx* event hijacks the parent frame
+  // (collapses idle / turns error / deletes the frame). Learn child->parent
+  // from session.created and gate every parent-level emit for a known
+  // child. The subagent is already represented by PdxSubagentStart/Stop.
+  const subagentSessions = new Map()
   const pdxPath = %q
   const PURDEX_EVENT = %s
 
@@ -70,9 +79,19 @@ export const PurdexOpenCodeHooks = async () => {
   return {
     event: async ({ event }) => {
       switch (event.type) {
-        case 'session.created':
-          await emit(PURDEX_EVENT.PdxSessionStart, { session_id: event.properties.sessionID })
+        case 'session.created': {
+          const sid = event.properties.sessionID || event.properties.info?.id || ''
+          const parentID = event.properties.info?.parentID
+          if (parentID) {
+            // Child (subagent) session: register and suppress the
+            // parent-level start. The subagent dot is owned by
+            // PdxSubagentStart/Stop instead.
+            subagentSessions.set(sid, parentID)
+            return
+          }
+          await emit(PURDEX_EVENT.PdxSessionStart, { session_id: sid })
           return
+        }
         case 'permission.asked':
           await emit(PURDEX_EVENT.PdxPermissionRequest, {
             request_type: 'permission',
@@ -86,24 +105,44 @@ export const PurdexOpenCodeHooks = async () => {
             questions: event.properties.questions,
           })
           return
-        case 'session.error':
-          if (event.properties.sessionID) suppressIdleForSession.add(event.properties.sessionID)
+        case 'session.error': {
+          const sid = event.properties.sessionID || event.properties.info?.id || ''
+          // Child error is pure noise at the parent level; also skip arming
+          // suppressIdleForSession so no child-armed entry can leak (a child
+          // idle would never clear it since child idles are gated too).
+          if (subagentSessions.has(sid)) return
+          if (sid) suppressIdleForSession.add(sid)
           await emit(PURDEX_EVENT.PdxStopFailure, {
             error: event.properties.error?.name || '',
             error_details: event.properties.error?.data?.message || '',
           })
           return
-        case 'session.status':
+        }
+        case 'session.status': {
           if (event.properties.status?.type !== 'idle') return
-          if (suppressIdleForSession.has(event.properties.sessionID)) {
-            suppressIdleForSession.delete(event.properties.sessionID)
+          const sid = event.properties.sessionID || event.properties.info?.id || ''
+          if (subagentSessions.has(sid)) return
+          if (suppressIdleForSession.has(sid)) {
+            suppressIdleForSession.delete(sid)
             return
           }
-          await emit(PURDEX_EVENT.PdxStop, { session_id: event.properties.sessionID })
+          await emit(PURDEX_EVENT.PdxStop, { session_id: sid })
           return
-        case 'session.deleted':
-          await emit(PURDEX_EVENT.PdxSessionEnd, { session_id: event.properties.sessionID })
+        }
+        case 'session.deleted': {
+          const sid = event.properties.sessionID || event.properties.info?.id || ''
+          if (subagentSessions.has(sid)) {
+            subagentSessions.delete(sid)
+            return
+          }
+          // Parent delete: prune only this parent's children (never a
+          // sibling parent's still-live children), then emit end.
+          for (const [childID, parentID] of subagentSessions) {
+            if (parentID === sid) subagentSessions.delete(childID)
+          }
+          await emit(PURDEX_EVENT.PdxSessionEnd, { session_id: sid })
           return
+        }
       }
     },
     'chat.message': async (input, output) => {

--- a/internal/agent/opencode/plugin_template_bun_integration_test.go
+++ b/internal/agent/opencode/plugin_template_bun_integration_test.go
@@ -150,6 +150,9 @@ func TestRenderManagedPlugin_BunRuntimeGatesChildSessionLifecycle(t *testing.T) 
   await fire({ type: 'session.status', properties: { sessionID: 'child1', status: { type: 'idle' } } })
   await fire({ type: 'session.error', properties: { sessionID: 'child1', error: { name: 'ProviderError', data: { message: 'boom' } } } })
   await fire({ type: 'session.deleted', properties: { sessionID: 'child1' } })
+  // Orphan child delete with NO prior created (reload / out-of-order): its
+  // own info.parentID must gate it reload-proof, never deleting a frame.
+  await fire({ type: 'session.deleted', properties: { sessionID: 'orphan1', info: { id: 'orphan1', parentID: 'parent1' } } })
   await fire({ type: 'session.status', properties: { sessionID: 'parent1', status: { type: 'idle' } } })
   await fire({ type: 'session.deleted', properties: { sessionID: 'parent1' } })
 })()

--- a/internal/agent/opencode/plugin_template_bun_integration_test.go
+++ b/internal/agent/opencode/plugin_template_bun_integration_test.go
@@ -100,3 +100,103 @@ func TestRenderManagedPlugin_BunRuntimeEmitsStdin(t *testing.T) {
 		t.Fatalf("captured stdin session_id = %v, want %q (raw=%q)", got, "test-session", string(captured))
 	}
 }
+
+// TestRenderManagedPlugin_BunRuntimeGatesChildSessionLifecycle drives a
+// realistic parent+subagent lifecycle through the real rendered JS under
+// Bun and proves the child-session gate holds end-to-end (guards against
+// "mirror and JS drift wrong together"). The stub pdx appends every
+// invocation as `eventName<TAB>stdin` JSONL; the event name comes from
+// argv[4] of [pdxPath,'hook','--agent','opencode',eventName]. emit() awaits
+// proc.exited, so appends are ordered and non-interleaved.
+//
+// Sequence: parent created -> child created(parentID) -> child idle ->
+// child error -> child deleted -> parent idle -> parent deleted. Only the
+// three parent-level events (PdxSessionStart, PdxStop, PdxSessionEnd) must
+// reach the stub; every child-derived event must be gated.
+func TestRenderManagedPlugin_BunRuntimeGatesChildSessionLifecycle(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("opencode plugin runtime is POSIX-only; skipping real-Bun integration test")
+	}
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skipf("/bin/sh unavailable (%v); skipping real-Bun integration test", err)
+	}
+	bunPath, err := exec.LookPath("bun")
+	if err != nil {
+		t.Skip("bun not on PATH; skipping real-Bun integration test")
+	}
+	if out, err := exec.Command(bunPath, "--version").Output(); err != nil || strings.TrimSpace(string(out)) == "" {
+		t.Skipf("bun --version failed (%v); skipping real-Bun integration test", err)
+	}
+
+	tmp := t.TempDir()
+	stubPath := filepath.Join(tmp, "pdx-stub")
+	capturePath := filepath.Join(tmp, "events-capture")
+	// argv[4] is the event name; append "<name>\t<stdin>\n" as one JSONL row.
+	stubBody := "#!/bin/sh\nprintf '%s\\t' \"$4\" >> \"$PDX_TEST_EVENT_CAPTURE\"\ncat >> \"$PDX_TEST_EVENT_CAPTURE\"\nprintf '\\n' >> \"$PDX_TEST_EVENT_CAPTURE\"\n"
+	if err := os.WriteFile(stubPath, []byte(stubBody), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	if err := os.Chmod(stubPath, 0o755); err != nil {
+		t.Fatalf("chmod stub: %v", err)
+	}
+
+	body := renderManagedPlugin(stubPath)
+	tail := `
+;(async () => {
+  const hooks = await PurdexOpenCodeHooks()
+  const fire = (ev) => hooks.event({ event: ev })
+  await fire({ type: 'session.created', properties: { sessionID: 'parent1', info: { id: 'parent1' } } })
+  await fire({ type: 'session.created', properties: { sessionID: 'child1', info: { id: 'child1', parentID: 'parent1' } } })
+  await fire({ type: 'session.status', properties: { sessionID: 'child1', status: { type: 'idle' } } })
+  await fire({ type: 'session.error', properties: { sessionID: 'child1', error: { name: 'ProviderError', data: { message: 'boom' } } } })
+  await fire({ type: 'session.deleted', properties: { sessionID: 'child1' } })
+  await fire({ type: 'session.status', properties: { sessionID: 'parent1', status: { type: 'idle' } } })
+  await fire({ type: 'session.deleted', properties: { sessionID: 'parent1' } })
+})()
+`
+	scriptPath := filepath.Join(tmp, "plugin.mjs")
+	if err := os.WriteFile(scriptPath, []byte(body+tail), 0o644); err != nil {
+		t.Fatalf("write plugin.mjs: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bunPath, scriptPath)
+	cmd.Env = append(os.Environ(), "PDX_TEST_EVENT_CAPTURE="+capturePath)
+	if output, runErr := cmd.CombinedOutput(); runErr != nil {
+		t.Fatalf("unexpected bun failure: err=%v output=%s", runErr, string(output))
+	}
+
+	raw, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("read capture: %v", err)
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimRight(string(raw), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		name, payloadJSON, found := strings.Cut(line, "\t")
+		if !found {
+			t.Fatalf("malformed capture row (no tab): %q", line)
+		}
+		names = append(names, name)
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			t.Fatalf("unmarshal payload for %q: %v (raw=%q)", name, err, payloadJSON)
+		}
+		if sid, _ := payload["session_id"].(string); sid != "parent1" {
+			t.Fatalf("event %q session_id = %q, want parent1 (no child event may leak)", name, sid)
+		}
+	}
+
+	want := []string{"PdxSessionStart", "PdxStop", "PdxSessionEnd"}
+	if len(names) != len(want) {
+		t.Fatalf("captured events = %v, want exactly %v (child lifecycle must be gated)", names, want)
+	}
+	for i, n := range names {
+		if n != want[i] {
+			t.Fatalf("captured events = %v, want %v", names, want)
+		}
+	}
+}

--- a/internal/agent/opencode/plugin_template_bun_integration_test.go
+++ b/internal/agent/opencode/plugin_template_bun_integration_test.go
@@ -149,7 +149,7 @@ func TestRenderManagedPlugin_BunRuntimeGatesChildSessionLifecycle(t *testing.T) 
   await fire({ type: 'session.created', properties: { sessionID: 'child1', info: { id: 'child1', parentID: 'parent1' } } })
   await fire({ type: 'session.status', properties: { sessionID: 'child1', status: { type: 'idle' } } })
   await fire({ type: 'session.error', properties: { sessionID: 'child1', error: { name: 'ProviderError', data: { message: 'boom' } } } })
-  await fire({ type: 'session.deleted', properties: { sessionID: 'child1' } })
+  await fire({ type: 'session.deleted', properties: { sessionID: 'child1', info: { id: 'child1', parentID: 'parent1' } } })
   // Orphan child delete with NO prior created (reload / out-of-order): its
   // own info.parentID must gate it reload-proof, never deleting a frame.
   await fire({ type: 'session.deleted', properties: { sessionID: 'orphan1', info: { id: 'orphan1', parentID: 'parent1' } } })

--- a/internal/agent/opencode/plugin_template_contract_test.go
+++ b/internal/agent/opencode/plugin_template_contract_test.go
@@ -74,10 +74,19 @@ func newPluginSimState() *pluginSimState {
 func (s *pluginSimState) simulateBusEvent(eventType string, properties map[string]any) (mappedHookEvent, bool) {
 	switch eventType {
 	case "session.created":
+		sid := resolveSid(properties)
+		parentID := ""
+		if info, ok := properties["info"].(map[string]any); ok {
+			parentID = strMapVal(info, "parentID")
+		}
+		if parentID != "" {
+			s.subagentSessions[sid] = parentID
+			return mappedHookEvent{}, false
+		}
 		return mappedHookEvent{
 			Name: "PdxSessionStart",
 			Payload: map[string]any{
-				"session_id": strMapVal(properties, "sessionID"),
+				"session_id": sid,
 			},
 		}, true
 	case "permission.asked":
@@ -98,9 +107,12 @@ func (s *pluginSimState) simulateBusEvent(eventType string, properties map[strin
 			},
 		}, true
 	case "session.error":
-		sessionID := strMapVal(properties, "sessionID")
-		if sessionID != "" {
-			s.suppressIdleForSession[sessionID] = true
+		sid := resolveSid(properties)
+		if _, isChild := s.subagentSessions[sid]; isChild {
+			return mappedHookEvent{}, false
+		}
+		if sid != "" {
+			s.suppressIdleForSession[sid] = true
 		}
 		var errName, errDetails string
 		if errObj, ok := properties["error"].(map[string]any); ok {
@@ -124,22 +136,35 @@ func (s *pluginSimState) simulateBusEvent(eventType string, properties map[strin
 		if strMapVal(statusObj, "type") != "idle" {
 			return mappedHookEvent{}, false
 		}
-		sessionID := strMapVal(properties, "sessionID")
-		if s.suppressIdleForSession[sessionID] {
-			delete(s.suppressIdleForSession, sessionID)
+		sid := resolveSid(properties)
+		if _, isChild := s.subagentSessions[sid]; isChild {
+			return mappedHookEvent{}, false
+		}
+		if s.suppressIdleForSession[sid] {
+			delete(s.suppressIdleForSession, sid)
 			return mappedHookEvent{}, false
 		}
 		return mappedHookEvent{
 			Name: "PdxStop",
 			Payload: map[string]any{
-				"session_id": sessionID,
+				"session_id": sid,
 			},
 		}, true
 	case "session.deleted":
+		sid := resolveSid(properties)
+		if _, isChild := s.subagentSessions[sid]; isChild {
+			delete(s.subagentSessions, sid)
+			return mappedHookEvent{}, false
+		}
+		for childID, parentID := range s.subagentSessions {
+			if parentID == sid {
+				delete(s.subagentSessions, childID)
+			}
+		}
 		return mappedHookEvent{
 			Name: "PdxSessionEnd",
 			Payload: map[string]any{
-				"session_id": strMapVal(properties, "sessionID"),
+				"session_id": sid,
 			},
 		}, true
 	}
@@ -245,6 +270,20 @@ func (s *pluginSimState) simulateToolExecuteAfter(input, output map[string]any) 
 			"output":     strMapVal(output, "output"),
 		},
 	}, true
+}
+
+// resolveSid mirrors the JS template's defensive session-id resolution:
+// `event.properties.sessionID || event.properties.info?.id || ''`. The
+// generated SDK type lists only `info` for session.created/deleted, so the
+// top-level sessionID is not guaranteed across versions.
+func resolveSid(properties map[string]any) string {
+	if sid := strMapVal(properties, "sessionID"); sid != "" {
+		return sid
+	}
+	if info, ok := properties["info"].(map[string]any); ok {
+		return strMapVal(info, "id")
+	}
+	return ""
 }
 
 func simAgentTypeFromArgs(args map[string]any) string {

--- a/internal/agent/opencode/plugin_template_contract_test.go
+++ b/internal/agent/opencode/plugin_template_contract_test.go
@@ -54,12 +54,18 @@ func loadPayloadFixture(t *testing.T, name string) fixtureEnvelope {
 type pluginSimState struct {
 	activeSubagents        map[string]string
 	suppressIdleForSession map[string]bool
+	// subagentSessions mirrors the JS template's Map keyed
+	// childSessionID → parentSessionID. Learned from session.created
+	// (info.parentID set) and used to gate every parent-level lifecycle
+	// emit for a child (subagent) session. See spec 2026-07-19.
+	subagentSessions map[string]string
 }
 
 func newPluginSimState() *pluginSimState {
 	return &pluginSimState{
 		activeSubagents:        make(map[string]string),
 		suppressIdleForSession: make(map[string]bool),
+		subagentSessions:       make(map[string]string),
 	}
 }
 
@@ -767,6 +773,190 @@ func TestOpenCodePluginTemplate_RenderedTemplateMatchesContracts(t *testing.T) {
 	if !reflect.DeepEqual(gotHooks, expectedHooks) {
 		t.Errorf("rendered strong-hook keys mismatch\n  got:  %v\n  want: %v", gotHooks, expectedHooks)
 	}
+}
+
+// childCreatedProps builds a session.created bus-event `properties` map
+// for a subagent (child) session: top-level sessionID plus info.id and
+// info.parentID (the authoritative child signal).
+func childCreatedProps(childID, parentID string) map[string]any {
+	return map[string]any{
+		"sessionID": childID,
+		"info": map[string]any{
+			"id":       childID,
+			"parentID": parentID,
+		},
+	}
+}
+
+// idleProps builds a session.status idle bus-event `properties` map.
+func idleProps(sessionID string) map[string]any {
+	return map[string]any{
+		"sessionID": sessionID,
+		"status":    map[string]any{"type": "idle"},
+	}
+}
+
+// errorProps builds a session.error bus-event `properties` map.
+func errorProps(sessionID string) map[string]any {
+	return map[string]any{
+		"sessionID": sessionID,
+		"error": map[string]any{
+			"name": "ProviderError",
+			"data": map[string]any{"message": "boom"},
+		},
+	}
+}
+
+// TestOpenCodePluginTemplate_ChildSessionGating covers the L1 fix: a
+// subagent (Task tool) runs as a child opencode session with its own full
+// lifecycle. The plugin must gate every parent-level Pdx* emit for a known
+// child, learning child→parent from session.created's info.parentID. The
+// subagent's real representation is already carried by
+// PdxSubagentStart/Stop (tool.execute.before/after) — unchanged here.
+func TestOpenCodePluginTemplate_ChildSessionGating(t *testing.T) {
+	t.Run("child_created_registers_and_no_emit", func(t *testing.T) {
+		s := newPluginSimState()
+		if _, ok := s.simulateBusEvent("session.created", childCreatedProps("child1", "parent1")); ok {
+			t.Fatal("child session.created must not emit PdxSessionStart")
+		}
+		if s.subagentSessions["child1"] != "parent1" {
+			t.Fatalf("child1 should be registered under parent1; map=%v", s.subagentSessions)
+		}
+	})
+
+	t.Run("parent_created_emits_and_not_registered", func(t *testing.T) {
+		s := newPluginSimState()
+		got, ok := s.simulateBusEvent("session.created", map[string]any{
+			"sessionID": "parent1",
+			"info":      map[string]any{"id": "parent1"},
+		})
+		if !ok || got.Name != "PdxSessionStart" {
+			t.Fatalf("parent session.created must emit PdxSessionStart; ok=%v name=%q", ok, got.Name)
+		}
+		if _, exists := s.subagentSessions["parent1"]; exists {
+			t.Fatal("parent must not be registered as a subagent session")
+		}
+	})
+
+	t.Run("child_created_fallback_to_info_id", func(t *testing.T) {
+		s := newPluginSimState()
+		// No top-level sessionID: only info.id + info.parentID. Proves the
+		// `sessionID || info.id` fallback registers under info.id.
+		if _, ok := s.simulateBusEvent("session.created", map[string]any{
+			"info": map[string]any{"id": "child2", "parentID": "parentX"},
+		}); ok {
+			t.Fatal("child session.created (no top-level sessionID) must not emit")
+		}
+		if s.subagentSessions["child2"] != "parentX" {
+			t.Fatalf("child2 must be registered under info.id fallback; map=%v", s.subagentSessions)
+		}
+	})
+
+	t.Run("child_idle_suppressed_parent_idle_emits", func(t *testing.T) {
+		s := newPluginSimState()
+		s.simulateBusEvent("session.created", childCreatedProps("child1", "parent1"))
+		if _, ok := s.simulateBusEvent("session.status", idleProps("child1")); ok {
+			t.Fatal("registered child idle must not emit PdxStop")
+		}
+		got, ok := s.simulateBusEvent("session.status", idleProps("parent1"))
+		if !ok || got.Name != "PdxStop" {
+			t.Fatalf("parent idle must emit PdxStop; ok=%v name=%q", ok, got.Name)
+		}
+	})
+
+	t.Run("child_error_gated_and_suppress_not_armed", func(t *testing.T) {
+		s := newPluginSimState()
+		s.simulateBusEvent("session.created", childCreatedProps("child1", "parent1"))
+		if _, ok := s.simulateBusEvent("session.error", errorProps("child1")); ok {
+			t.Fatal("registered child error must not emit PdxStopFailure")
+		}
+		// White-box: child error must NOT arm suppressIdleForSession — else a
+		// child-armed entry that no child idle ever clears would leak.
+		if s.suppressIdleForSession["child1"] {
+			t.Fatal("child error must NOT arm suppressIdleForSession[child1]")
+		}
+	})
+
+	t.Run("child_deleted_gated_and_removed", func(t *testing.T) {
+		s := newPluginSimState()
+		s.simulateBusEvent("session.created", childCreatedProps("child1", "parent1"))
+		if _, ok := s.simulateBusEvent("session.deleted", map[string]any{"sessionID": "child1"}); ok {
+			t.Fatal("registered child deleted must not emit PdxSessionEnd")
+		}
+		if _, exists := s.subagentSessions["child1"]; exists {
+			t.Fatal("child must be removed from subagentSessions after session.deleted")
+		}
+	})
+
+	t.Run("parent_deleted_emits_and_prunes_only_its_children", func(t *testing.T) {
+		s := newPluginSimState()
+		s.simulateBusEvent("session.created", childCreatedProps("child1", "parent1"))
+		s.simulateBusEvent("session.created", childCreatedProps("child2", "parent1"))
+		got, ok := s.simulateBusEvent("session.deleted", map[string]any{"sessionID": "parent1"})
+		if !ok || got.Name != "PdxSessionEnd" {
+			t.Fatalf("parent deleted must emit PdxSessionEnd; ok=%v name=%q", ok, got.Name)
+		}
+		if len(s.subagentSessions) != 0 {
+			t.Fatalf("parent1's children must all be pruned; map=%v", s.subagentSessions)
+		}
+	})
+
+	t.Run("sibling_parents_scoped_cleanup", func(t *testing.T) {
+		s := newPluginSimState()
+		s.simulateBusEvent("session.created", childCreatedProps("childA", "parentA"))
+		s.simulateBusEvent("session.created", childCreatedProps("childB", "parentB"))
+		s.simulateBusEvent("session.deleted", map[string]any{"sessionID": "parentA"})
+		if _, exists := s.subagentSessions["childA"]; exists {
+			t.Fatal("childA must be pruned when parentA is deleted")
+		}
+		if s.subagentSessions["childB"] != "parentB" {
+			t.Fatalf("childB must remain registered after parentA delete; map=%v", s.subagentSessions)
+		}
+		if _, ok := s.simulateBusEvent("session.status", idleProps("childB")); ok {
+			t.Fatal("childB idle must still be suppressed after sibling parentA deleted")
+		}
+	})
+
+	t.Run("multi_subagent_idles_suppressed_parent_stops_once", func(t *testing.T) {
+		s := newPluginSimState()
+		children := []string{"c1", "c2", "c3"}
+		for _, c := range children {
+			s.simulateBusEvent("session.created", childCreatedProps(c, "parent1"))
+		}
+		for _, c := range children {
+			if _, ok := s.simulateBusEvent("session.status", idleProps(c)); ok {
+				t.Fatalf("child %s idle must be suppressed", c)
+			}
+		}
+		got, ok := s.simulateBusEvent("session.status", idleProps("parent1"))
+		if !ok || got.Name != "PdxStop" {
+			t.Fatalf("parent idle must emit PdxStop; ok=%v name=%q", ok, got.Name)
+		}
+	})
+
+	t.Run("full_sequence_only_parent_stop_and_structures_clean", func(t *testing.T) {
+		s := newPluginSimState()
+		s.simulateBusEvent("session.created", childCreatedProps("child1", "parent1"))
+		if _, ok := s.simulateBusEvent("session.status", idleProps("child1")); ok {
+			t.Fatal("child idle must be suppressed")
+		}
+		if _, ok := s.simulateBusEvent("session.error", errorProps("child1")); ok {
+			t.Fatal("child error must be gated")
+		}
+		if _, ok := s.simulateBusEvent("session.deleted", map[string]any{"sessionID": "child1"}); ok {
+			t.Fatal("child deleted must be gated")
+		}
+		got, ok := s.simulateBusEvent("session.status", idleProps("parent1"))
+		if !ok || got.Name != "PdxStop" {
+			t.Fatalf("parent idle must emit PdxStop; ok=%v name=%q", ok, got.Name)
+		}
+		if len(s.subagentSessions) != 0 {
+			t.Fatalf("subagentSessions must be clean after sequence; map=%v", s.subagentSessions)
+		}
+		if len(s.suppressIdleForSession) != 0 {
+			t.Fatalf("suppressIdleForSession must be clean after sequence; map=%v", s.suppressIdleForSession)
+		}
+	})
 }
 
 // TestOpenCodePluginTemplate_RenderedTemplateContainsExpectedFilter

--- a/internal/agent/opencode/plugin_template_contract_test.go
+++ b/internal/agent/opencode/plugin_template_contract_test.go
@@ -80,7 +80,11 @@ func (s *pluginSimState) simulateBusEvent(eventType string, properties map[strin
 			parentID = strMapVal(info, "parentID")
 		}
 		if parentID != "" {
-			s.subagentSessions[sid] = parentID
+			// Suppress the child start; only key a non-empty sid so an empty
+			// key can never swallow an unrelated empty-sid parent delete.
+			if sid != "" {
+				s.subagentSessions[sid] = parentID
+			}
 			return mappedHookEvent{}, false
 		}
 		return mappedHookEvent{
@@ -108,10 +112,10 @@ func (s *pluginSimState) simulateBusEvent(eventType string, properties map[strin
 		}, true
 	case "session.error":
 		sid := resolveSid(properties)
-		if _, isChild := s.subagentSessions[sid]; isChild {
-			return mappedHookEvent{}, false
-		}
 		if sid != "" {
+			if _, isChild := s.subagentSessions[sid]; isChild {
+				return mappedHookEvent{}, false
+			}
 			s.suppressIdleForSession[sid] = true
 		}
 		var errName, errDetails string
@@ -137,8 +141,10 @@ func (s *pluginSimState) simulateBusEvent(eventType string, properties map[strin
 			return mappedHookEvent{}, false
 		}
 		sid := resolveSid(properties)
-		if _, isChild := s.subagentSessions[sid]; isChild {
-			return mappedHookEvent{}, false
+		if sid != "" {
+			if _, isChild := s.subagentSessions[sid]; isChild {
+				return mappedHookEvent{}, false
+			}
 		}
 		if s.suppressIdleForSession[sid] {
 			delete(s.suppressIdleForSession, sid)
@@ -152,12 +158,21 @@ func (s *pluginSimState) simulateBusEvent(eventType string, properties map[strin
 		}, true
 	case "session.deleted":
 		sid := resolveSid(properties)
-		if _, isChild := s.subagentSessions[sid]; isChild {
-			delete(s.subagentSessions, sid)
+		parentID := ""
+		if info, ok := properties["info"].(map[string]any); ok {
+			parentID = strMapVal(info, "parentID")
+		}
+		if parentID != "" {
+			// Child delete: gate on the event's own parentID, not the map —
+			// reload-proof, so a child delete never emits PdxSessionEnd
+			// against the parent frame even if we never saw its created.
+			if sid != "" {
+				delete(s.subagentSessions, sid)
+			}
 			return mappedHookEvent{}, false
 		}
-		for childID, parentID := range s.subagentSessions {
-			if parentID == sid {
+		for childID, pid := range s.subagentSessions {
+			if pid == sid {
 				delete(s.subagentSessions, childID)
 			}
 		}
@@ -827,6 +842,20 @@ func childCreatedProps(childID, parentID string) map[string]any {
 	}
 }
 
+// childDeletedProps builds a session.deleted bus-event `properties` map
+// for a subagent (child) session. Real opencode publishes full info on
+// session.deleted (session.ts:624), so the child delete carries its own
+// info.parentID — the authoritative, reload-proof child signal.
+func childDeletedProps(childID, parentID string) map[string]any {
+	return map[string]any{
+		"sessionID": childID,
+		"info": map[string]any{
+			"id":       childID,
+			"parentID": parentID,
+		},
+	}
+}
+
 // idleProps builds a session.status idle bus-event `properties` map.
 func idleProps(sessionID string) map[string]any {
 	return map[string]any{
@@ -919,7 +948,7 @@ func TestOpenCodePluginTemplate_ChildSessionGating(t *testing.T) {
 	t.Run("child_deleted_gated_and_removed", func(t *testing.T) {
 		s := newPluginSimState()
 		s.simulateBusEvent("session.created", childCreatedProps("child1", "parent1"))
-		if _, ok := s.simulateBusEvent("session.deleted", map[string]any{"sessionID": "child1"}); ok {
+		if _, ok := s.simulateBusEvent("session.deleted", childDeletedProps("child1", "parent1")); ok {
 			t.Fatal("registered child deleted must not emit PdxSessionEnd")
 		}
 		if _, exists := s.subagentSessions["child1"]; exists {
@@ -982,7 +1011,7 @@ func TestOpenCodePluginTemplate_ChildSessionGating(t *testing.T) {
 		if _, ok := s.simulateBusEvent("session.error", errorProps("child1")); ok {
 			t.Fatal("child error must be gated")
 		}
-		if _, ok := s.simulateBusEvent("session.deleted", map[string]any{"sessionID": "child1"}); ok {
+		if _, ok := s.simulateBusEvent("session.deleted", childDeletedProps("child1", "parent1")); ok {
 			t.Fatal("child deleted must be gated")
 		}
 		got, ok := s.simulateBusEvent("session.status", idleProps("parent1"))

--- a/internal/agent/opencode/plugin_template_contract_test.go
+++ b/internal/agent/opencode/plugin_template_contract_test.go
@@ -273,8 +273,8 @@ func (s *pluginSimState) simulateToolExecuteAfter(input, output map[string]any) 
 }
 
 // resolveSid mirrors the JS template's defensive session-id resolution:
-// `event.properties.sessionID || event.properties.info?.id || ''`. The
-// generated SDK type lists only `info` for session.created/deleted, so the
+// prefer properties.sessionID, fall back to properties.info.id, else empty.
+// The generated SDK type lists only info for session.created/deleted, so the
 // top-level sessionID is not guaranteed across versions.
 func resolveSid(properties map[string]any) string {
 	if sid := strMapVal(properties, "sessionID"); sid != "" {
@@ -506,7 +506,7 @@ func TestOpenCodePluginTemplate_UsesVerifiedEvents(t *testing.T) {
 			event:       "session.created",
 			fixtureFile: "session.created.json",
 			kind:        "bus-event",
-			expectName: "PdxSessionStart",
+			expectName:  "PdxSessionStart",
 			expectPayload: map[string]any{
 				"session_id": "ses_fixture_session_created_001",
 			},
@@ -515,7 +515,7 @@ func TestOpenCodePluginTemplate_UsesVerifiedEvents(t *testing.T) {
 			event:       "permission.asked",
 			fixtureFile: "permission.asked.json",
 			kind:        "bus-event",
-			expectName: "PdxPermissionRequest",
+			expectName:  "PdxPermissionRequest",
 			expectPayload: map[string]any{
 				"request_type": "permission",
 				"permission":   "edit",
@@ -526,7 +526,7 @@ func TestOpenCodePluginTemplate_UsesVerifiedEvents(t *testing.T) {
 			event:       "question.asked",
 			fixtureFile: "question.asked.json",
 			kind:        "bus-event",
-			expectName: "PdxPermissionRequest",
+			expectName:  "PdxPermissionRequest",
 			expectPayload: map[string]any{
 				"request_type": "question",
 				"questions": []any{
@@ -539,7 +539,7 @@ func TestOpenCodePluginTemplate_UsesVerifiedEvents(t *testing.T) {
 			event:       "session.error",
 			fixtureFile: "session.error.json",
 			kind:        "bus-event",
-			expectName: "PdxStopFailure",
+			expectName:  "PdxStopFailure",
 			expectPayload: map[string]any{
 				"error":         "ProviderError",
 				"error_details": "request timed out",
@@ -549,7 +549,7 @@ func TestOpenCodePluginTemplate_UsesVerifiedEvents(t *testing.T) {
 			event:       "session.status",
 			fixtureFile: "session.status.json",
 			kind:        "bus-event",
-			expectName: "PdxStop",
+			expectName:  "PdxStop",
 			expectPayload: map[string]any{
 				"session_id": "ses_fixture_status_idle_001",
 			},
@@ -558,7 +558,7 @@ func TestOpenCodePluginTemplate_UsesVerifiedEvents(t *testing.T) {
 			event:       "session.deleted",
 			fixtureFile: "session.deleted.json",
 			kind:        "bus-event",
-			expectName: "PdxSessionEnd",
+			expectName:  "PdxSessionEnd",
 			expectPayload: map[string]any{
 				"session_id": "ses_fixture_deleted_001",
 			},
@@ -567,7 +567,7 @@ func TestOpenCodePluginTemplate_UsesVerifiedEvents(t *testing.T) {
 			event:       "chat.message",
 			fixtureFile: "chat.message.json",
 			kind:        "strong-hook",
-			expectName: "PdxUserPromptSubmit",
+			expectName:  "PdxUserPromptSubmit",
 			expectPayload: map[string]any{
 				"session_id": "ses_fixture_chat_001",
 				"message_id": "msg_fixture_chat_001",
@@ -580,7 +580,7 @@ func TestOpenCodePluginTemplate_UsesVerifiedEvents(t *testing.T) {
 			event:       "tool.execute.before",
 			fixtureFile: "tool.execute.before.json",
 			kind:        "strong-hook",
-			expectName: "PdxSubagentStart",
+			expectName:  "PdxSubagentStart",
 			expectPayload: map[string]any{
 				"agent_id":    "call_fixture_task_001",
 				"agent_type":  "Explore",

--- a/internal/agent/opencode/plugin_template_contract_test.go
+++ b/internal/agent/opencode/plugin_template_contract_test.go
@@ -998,6 +998,72 @@ func TestOpenCodePluginTemplate_ChildSessionGating(t *testing.T) {
 	})
 }
 
+// TestOpenCodePluginTemplate_ChildSessionGatingReloadWindow covers the
+// reload / out-of-order window (spec Design decision 4). The map is only
+// populated after a child's session.created; if the plugin reloads while a
+// subagent is mid-flight (or an event arrives before that child's created)
+// the map is empty for it. session.deleted publishes full info
+// (session.ts:624) so it is gated on the event's own info.parentID — NOT
+// the map — which is reload-proof and removes the worst failure (a child
+// delete deleting the PARENT frame). session.status idle / session.error
+// genuinely lack parentID (#30043; SDK EventSessionError = {sessionID?,
+// error?}) so they stay map-based; an unseen child's idle/error still
+// emits — a recoverable, documented limitation asserted here as the
+// current behavior (not a pretend fix). SDK-fetch hardening is follow-up.
+func TestOpenCodePluginTemplate_ChildSessionGatingReloadWindow(t *testing.T) {
+	t.Run("orphan_child_deleted_gated_via_event_parentID", func(t *testing.T) {
+		s := newPluginSimState()
+		// No prior session.created — map is empty for childX. The delete
+		// event carries its own parentID, so it must still be gated.
+		if _, ok := s.simulateBusEvent("session.deleted", map[string]any{
+			"sessionID": "childX",
+			"info":      map[string]any{"id": "childX", "parentID": "parent1"},
+		}); ok {
+			t.Fatal("orphan child session.deleted (event parentID set) must be gated even with empty map")
+		}
+	})
+
+	t.Run("orphan_child_idle_and_error_still_emit_documented_limitation", func(t *testing.T) {
+		// Reload window: idle/error lack parentID, so an unseen child's
+		// idle/error still emits (map-based). This is the recoverable,
+		// documented limitation (idle derives notification_silent and
+		// self-corrects on the parent's next event). Asserted as CURRENT
+		// behavior — not a pretend fix. SDK-fetch hardening is follow-up.
+		s := newPluginSimState()
+		got, ok := s.simulateBusEvent("session.status", idleProps("childOrphan"))
+		if !ok || got.Name != "PdxStop" {
+			t.Fatalf("unseen child idle still emits PdxStop (documented limitation); ok=%v name=%q", ok, got.Name)
+		}
+		s2 := newPluginSimState()
+		got2, ok2 := s2.simulateBusEvent("session.error", errorProps("childOrphan"))
+		if !ok2 || got2.Name != "PdxStopFailure" {
+			t.Fatalf("unseen child error still emits PdxStopFailure (documented limitation); ok=%v name=%q", ok2, got2.Name)
+		}
+	})
+
+	t.Run("empty_sid_never_pollutes_map_and_parent_delete_not_swallowed", func(t *testing.T) {
+		s := newPluginSimState()
+		// Child created with parentID but no resolvable sid (no sessionID,
+		// no info.id). The start is still suppressed, but '' must never be
+		// keyed into the map — an empty key would then swallow the next
+		// empty-sid parent delete.
+		if _, ok := s.simulateBusEvent("session.created", map[string]any{
+			"info": map[string]any{"parentID": "parent1"},
+		}); ok {
+			t.Fatal("child created with empty sid must not emit PdxSessionStart")
+		}
+		if _, exists := s.subagentSessions[""]; exists {
+			t.Fatalf("empty sid must never be keyed into subagentSessions; map=%v", s.subagentSessions)
+		}
+		// A parent session.deleted with no sid and no info.parentID must
+		// still emit PdxSessionEnd — never be swallowed as a child.
+		got, ok := s.simulateBusEvent("session.deleted", map[string]any{})
+		if !ok || got.Name != "PdxSessionEnd" {
+			t.Fatalf("parent delete (empty sid, no parentID) must emit PdxSessionEnd; ok=%v name=%q", ok, got.Name)
+		}
+	})
+}
+
 // TestOpenCodePluginTemplate_RenderedTemplateContainsExpectedFilter
 // guards the Decision 3 / Decision 4 filter line that turns a
 // `session.status` Bus subscription into an idle-only Stop signal. If

--- a/internal/agent/opencode/plugin_template_test.go
+++ b/internal/agent/opencode/plugin_template_test.go
@@ -1,6 +1,7 @@
 package opencode
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,6 +269,80 @@ func TestRenderManagedPlugin_NoLegacyEmitLiteral(t *testing.T) {
 		if strings.Contains(body, lit) {
 			t.Errorf("rendered body still contains legacy literal emit %q (P3-T3 should route via PURDEX_EVENT const)", lit)
 		}
+	}
+}
+
+// TestRenderManagedPlugin_GatesChildSessionLifecycle statically inspects
+// the rendered JS body for the L1 child-session gate so a Bun-less CI
+// still catches removal. It asserts the body (a) declares the
+// subagentSessions map, (b) reads the authoritative child signal
+// event.properties.info?.parentID, and (c) places the child-registration
+// branch before the parent PdxSessionStart emit (child-check first).
+func TestRenderManagedPlugin_GatesChildSessionLifecycle(t *testing.T) {
+	body := renderManagedPlugin("/fake/pdx")
+
+	if !strings.Contains(body, "subagentSessions") {
+		t.Fatal("rendered body missing subagentSessions gate map")
+	}
+	if !strings.Contains(body, "event.properties.info?.parentID") {
+		t.Fatal("rendered body missing child signal event.properties.info?.parentID")
+	}
+
+	setIdx := strings.Index(body, "subagentSessions.set(sid, parentID)")
+	if setIdx < 0 {
+		t.Fatal("rendered body missing child registration subagentSessions.set(sid, parentID)")
+	}
+	emitIdx := strings.Index(body, "emit(PURDEX_EVENT.PdxSessionStart,")
+	if emitIdx < 0 {
+		t.Fatal("rendered body missing PdxSessionStart emit")
+	}
+	if setIdx > emitIdx {
+		t.Fatalf("child registration (idx %d) must precede PdxSessionStart emit (idx %d)", setIdx, emitIdx)
+	}
+}
+
+// TestRenderManagedPlugin_ChildSessionGatesAllLifecycleEmits asserts the
+// gate exists in every parent-level lifecycle branch (created / status /
+// error / deleted), so a partial revert of the fix is caught statically.
+func TestRenderManagedPlugin_ChildSessionGatesAllLifecycleEmits(t *testing.T) {
+	body := renderManagedPlugin("/fake/pdx")
+	for _, want := range []string{
+		"subagentSessions.set(sid, parentID)",
+		"if (subagentSessions.has(sid)) return",
+		"subagentSessions.delete(sid)",
+		"if (parentID === sid) subagentSessions.delete(childID)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered body missing child-gating construct %q", want)
+		}
+	}
+}
+
+// TestSubagentSessionCreatedFixtureCarriesParentID guards the fixture used
+// by the child-gating contract cases: it must be a session.created bus
+// event whose info.parentID is set (the authoritative child signal).
+func TestSubagentSessionCreatedFixtureCarriesParentID(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(payloadFixturesDir, "session.created.subagent.json"))
+	if err != nil {
+		t.Fatalf("read subagent fixture: %v", err)
+	}
+	var env struct {
+		Kind       string                 `json:"kind"`
+		EventType  string                 `json:"eventType"`
+		Properties map[string]interface{} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("parse subagent fixture: %v", err)
+	}
+	if env.Kind != "bus-event" || env.EventType != "session.created" {
+		t.Fatalf("fixture kind/eventType = %q/%q, want bus-event/session.created", env.Kind, env.EventType)
+	}
+	info, ok := env.Properties["info"].(map[string]any)
+	if !ok {
+		t.Fatal("fixture missing properties.info")
+	}
+	if pid, _ := info["parentID"].(string); pid == "" {
+		t.Fatal("fixture properties.info.parentID must be set for a subagent session.created")
 	}
 }
 

--- a/internal/agent/opencode/plugin_template_test.go
+++ b/internal/agent/opencode/plugin_template_test.go
@@ -308,9 +308,9 @@ func TestRenderManagedPlugin_ChildSessionGatesAllLifecycleEmits(t *testing.T) {
 	body := renderManagedPlugin("/fake/pdx")
 	for _, want := range []string{
 		"subagentSessions.set(sid, parentID)",
-		"if (subagentSessions.has(sid)) return",
+		"if (sid && subagentSessions.has(sid)) return",
 		"subagentSessions.delete(sid)",
-		"if (parentID === sid) subagentSessions.delete(childID)",
+		"if (pid === sid) subagentSessions.delete(childID)",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("rendered body missing child-gating construct %q", want)

--- a/internal/agent/opencode/testdata/opencode-1.14.23-payloads/session.created.subagent.json
+++ b/internal/agent/opencode/testdata/opencode-1.14.23-payloads/session.created.subagent.json
@@ -1,0 +1,17 @@
+{
+  "kind": "bus-event",
+  "eventType": "session.created",
+  "properties": {
+    "sessionID": "ses_fixture_subagent_child_001",
+    "info": {
+      "id": "ses_fixture_subagent_child_001",
+      "parentID": "ses_fixture_session_created_001",
+      "version": "1.14.23",
+      "title": "fixture subagent session",
+      "time": {
+        "created": 1730000000000,
+        "updated": 1730000000000
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem (verified live, 2026-07-19)

An opencode session (`tmux istdb`) has its parent status light collapse to **idle** every
time a subagent (Task tool) finishes, even though the parent is still running. Daemon log
smoking gun — subagent completion produces a spurious parent `PdxStop`, and the cc control
group does not:

```
12:45:32 istdb  (opencode) PdxStop status=idle → projection_built top_status=idle   subagents=0   ← parent wrongly idle
12:45:50 hermes (cc)       PdxSubagentStop     → projection_built top_status=running subagents=0   ← cc parent stays running
```

Hook transport is healthy (every event fires + broadcasts). This is a pre-existing **semantic**
bug, not a version regression. (opencode running 1.17.9; PATH 1.18.3 — fix is version-independent.)

## Root cause

The opencode plugin has **no concept of parent vs child session**. opencode runs each subagent
as a **child session** with its own full lifecycle, and the plugin re-emits every child event as
a parent-level `Pdx*`. The daemon matches a frame by `(tmuxPaneID, senderPID, senderStartTime)`
(`frame_ops.go:86 GetByIdentity`) — **not** by opencode `session_id`. One opencode process serves
parent + children over one pane / sender identity, so every child event mutates the single parent
frame:

| child bus event | plugin emits | daemon derives (`status.go`) | effect on parent frame |
|---|---|---|---|
| `session.created` (`info.parentID`) | `PdxSessionStart` | `StatusIdle` | parent flaps to idle |
| `session.status` idle | `PdxStop` | `StatusIdle` | **light collapses to idle** ← visible bug |
| `session.error` | `PdxStopFailure` | `StatusError` | parent turns **red** |
| `session.deleted` | `PdxSessionEnd` | `StatusClear` → `deleted_frame` | **parent frame deleted** |

The subagent's intended representation is already `PdxSubagentStart/Stop` (detail-only,
`frame_ops.go:80` — a dot, not frame ownership). The child's own lifecycle events are noise.

Upstream confirmation: opencode issue [#30043](https://github.com/anomalyco/opencode/issues/30043)
(`session.status` carries no `parentID`); `session.created` publishes full `info` with
`parentID` (`session.ts:537`).

## Fix (plugin-only)

Maintain `subagentSessions = new Map()` (childSessionID → parentSessionID), learned from
`session.created` `info.parentID`. Gate **every** parent-level lifecycle emit for a known child.
Session id resolved defensively (`sessionID || info.id`). Parent delete prunes only its own
children (a single opencode process can host multiple root sessions). `PdxSubagentStart/Stop`
untouched. No daemon/SPA change.

## Tests (TDD)

- Contract cases against the `pluginSimState` JS-mirror: child created/idle/error/deleted all
  gated; parent path unchanged; no-top-level-`sessionID` fallback; **sibling parents** (delete A
  keeps B's children gated); white-box `suppressIdleForSession` not armed for children; existing
  `ChatMessageClearsStaleErrorSuppression` / `StaleSuppressionWithoutChatMessage` stay green.
- Rendered-JS static guards (run without Bun) assert the gate exists in the template.
- Bun end-to-end sequence through the real rendered JS + a recording stub `pdx`:
  `parent created → child created → child idle → child error → child deleted → parent idle →
  parent deleted` emits **only** parent `PdxSessionStart` / `PdxStop` / `PdxSessionEnd`.
- `go test ./internal/agent/opencode/... -race` and `go test ./...` green.

## Verification (post-merge, live on mlab)

Rebuild `bin/pdx`, `pdx setup --agent opencode`, run an opencode session that spawns a subagent;
confirm no parent `PdxStop`/`PdxStopFailure`/`PdxSessionEnd` at child lifecycle points, parent
light stays running, real parent idle still emits `PdxStop`.

## Known limitation (follow-up)

If the plugin is (re)loaded while a child is mid-flight, that unknown child's idle/error/deleted
still leak (same as today — not a regression). SDK-fetch hardening tracked as a follow-up issue.

## Review trail
Spec + plan each got a codex review round (spec reframed PdxStop-only → full child lifecycle;
plan added Map<child,parent> scoped cleanup, sid fallback, sibling-parent + static-guard tests).

Spec: `docs/specs/2026-07-19-opencode-l1-subagent-idle-filter-spec.md`
